### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 authors = ["IFC-Lite Contributors"]
 license = "MPL-2.0"

--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/viewer",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "IFC-Lite viewer application",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,33 +1,33 @@
 {
-    "name": "ifc-lite",
-    "version": "1.0.0",
-    "description": "High-performance browser IFC parser & renderer",
-    "private": true,
-    "type": "module",
-    "workspaces": [
-        "packages/*",
-        "apps/*"
-    ],
-    "scripts": {
-        "dev": "pnpm --filter viewer dev",
-        "build": "pnpm -r build",
-        "test": "pnpm -r test",
-        "lint": "pnpm -r lint",
-        "docs:serve": "python3 -m mkdocs serve",
-        "docs:build": "python3 -m mkdocs build",
-        "publish:npm": "pnpm -r publish --access public",
-        "publish:dry": "pnpm -r publish --access public --dry-run",
-        "test:benchmark": "playwright test tests/benchmark/benchmark.spec.ts",
-        "test:benchmark:headed": "playwright test tests/benchmark/benchmark.spec.ts --headed"
-    },
-    "devDependencies": {
-        "@playwright/test": "^1.40.0",
-        "@types/node": "^20.0.0",
-        "tsx": "^4.21.0",
-        "typescript": "^5.3.0"
-    },
-    "engines": {
-        "node": ">=18.0.0",
-        "pnpm": ">=8.0.0"
-    }
+  "name": "ifc-lite",
+  "version": "1.1.0",
+  "description": "High-performance browser IFC parser & renderer",
+  "private": true,
+  "type": "module",
+  "workspaces": [
+    "packages/*",
+    "apps/*"
+  ],
+  "scripts": {
+    "dev": "pnpm --filter viewer dev",
+    "build": "pnpm -r build",
+    "test": "pnpm -r test",
+    "lint": "pnpm -r lint",
+    "docs:serve": "python3 -m mkdocs serve",
+    "docs:build": "python3 -m mkdocs build",
+    "publish:npm": "pnpm -r publish --access public",
+    "publish:dry": "pnpm -r publish --access public --dry-run",
+    "test:benchmark": "playwright test tests/benchmark/benchmark.spec.ts",
+    "test:benchmark:headed": "playwright test tests/benchmark/benchmark.spec.ts --headed"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.40.0",
+    "@types/node": "^20.0.0",
+    "tsx": "^4.21.0",
+    "typescript": "^5.3.0"
+  },
+  "engines": {
+    "node": ">=18.0.0",
+    "pnpm": ">=8.0.0"
+  }
 }

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/cache",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Binary cache format for IFC-Lite - fast model loading",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/codegen",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "TypeScript code generator from IFC EXPRESS schemas",
   "type": "module",
   "main": "dist/index.js",
@@ -13,7 +13,12 @@
     "generate:ifc4": "node dist/cli.js schemas/IFC4.exp -o generated/ifc4",
     "generate:ifc4x3": "node dist/cli.js schemas/IFC4X3.exp -o generated/ifc4x3"
   },
-  "keywords": ["ifc", "express", "codegen", "typescript"],
+  "keywords": [
+    "ifc",
+    "express",
+    "codegen",
+    "typescript"
+  ],
   "author": "",
   "license": "MIT",
   "dependencies": {

--- a/packages/create-ifc-lite/package.json
+++ b/packages/create-ifc-lite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-ifc-lite",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Create IFC-Lite projects with one command",
   "type": "module",
   "bin": {

--- a/packages/create-ifc-lite/src/index.ts
+++ b/packages/create-ifc-lite/src/index.ts
@@ -131,14 +131,14 @@ function createBasicTemplate(targetDir: string, projectName: string) {
   // package.json
   writeFileSync(join(targetDir, 'package.json'), JSON.stringify({
     name: projectName,
-    version: '1.0.0',
+    version: '1.1.0',
     type: 'module',
     scripts: {
       parse: 'npx tsx src/index.ts',
       build: 'tsc',
     },
     dependencies: {
-      '@ifc-lite/parser': '^1.0.0',
+      '@ifc-lite/parser': '^1.1.0',
     },
     devDependencies: {
       typescript: '^5.3.0',
@@ -221,7 +221,7 @@ function createReactTemplate(targetDir: string, projectName: string) {
   // package.json
   writeFileSync(join(targetDir, 'package.json'), JSON.stringify({
     name: projectName,
-    version: '1.0.0',
+    version: '1.1.0',
     type: 'module',
     scripts: {
       dev: 'vite',
@@ -229,9 +229,9 @@ function createReactTemplate(targetDir: string, projectName: string) {
       preview: 'vite preview',
     },
     dependencies: {
-      '@ifc-lite/parser': '^1.0.0',
-      '@ifc-lite/geometry': '^1.0.0',
-      '@ifc-lite/renderer': '^1.0.0',
+      '@ifc-lite/parser': '^1.1.0',
+      '@ifc-lite/geometry': '^1.1.0',
+      '@ifc-lite/renderer': '^1.1.0',
       react: '^18.2.0',
       'react-dom': '^18.2.0',
     },

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/data",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Columnar data structures for IFC-Lite",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/export/package.json
+++ b/packages/export/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/export",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Export formats for IFC-Lite",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/geometry/package.json
+++ b/packages/geometry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/geometry",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Geometry processing bridge for IFC-Lite - 1.9x faster than web-ifc",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/parser",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "IFC/STEP parser for IFC-Lite",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/query",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Query system for IFC-Lite",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/renderer",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "WebGPU renderer for IFC-Lite",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/spatial/package.json
+++ b/packages/spatial/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/spatial",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Spatial indexing for IFC-Lite",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -5,7 +5,7 @@
     "IFC-Lite Contributors"
   ],
   "description": "WebAssembly bindings for IFC-Lite",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "MPL-2.0",
   "repository": {
     "type": "git",

--- a/rust/geometry/Cargo.toml
+++ b/rust/geometry/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../../README.md"
 
 [dependencies]
 # Core IFC parsing
-ifc-lite-core = { version = "1.0.0", path = "../core" }
+ifc-lite-core = { version = "1.1.0", path = "../core" }
 
 # Math library
 nalgebra = { version = "0.33", default-features = false, features = ["std"] }

--- a/rust/wasm-bindings/Cargo.toml
+++ b/rust/wasm-bindings/Cargo.toml
@@ -18,8 +18,8 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 # Core packages
-ifc-lite-core = { version = "1.0.0", path = "../core" }
-ifc-lite-geometry = { version = "1.0.0", path = "../geometry" }
+ifc-lite-core = { version = "1.1.0", path = "../core" }
+ifc-lite-geometry = { version = "1.1.0", path = "../geometry" }
 
 # WASM bindings
 wasm-bindgen = "0.2"

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = join(__dirname, '..');
+
+// Get version from command line argument
+const newVersion = process.argv[2];
+
+if (!newVersion) {
+  console.error('Usage: node scripts/bump-version.mjs <version>');
+  console.error('Example: node scripts/bump-version.mjs 1.1.0');
+  process.exit(1);
+}
+
+// Validate version format (basic check)
+if (!/^\d+\.\d+\.\d+/.test(newVersion)) {
+  console.error(`Invalid version format: ${newVersion}`);
+  console.error('Expected format: MAJOR.MINOR.PATCH (e.g., 1.1.0)');
+  process.exit(1);
+}
+
+console.log(`Bumping version to ${newVersion}...\n`);
+
+// Find current version from root package.json
+const rootPackageJson = JSON.parse(readFileSync(join(ROOT_DIR, 'package.json'), 'utf-8'));
+const oldVersion = rootPackageJson.version;
+console.log(`Current version: ${oldVersion}`);
+console.log(`New version: ${newVersion}\n`);
+
+// Update all package.json files
+function updatePackageJson(filePath) {
+  const content = readFileSync(filePath, 'utf-8');
+  const pkg = JSON.parse(content);
+  
+  if (pkg.version) {
+    pkg.version = newVersion;
+    writeFileSync(filePath, JSON.stringify(pkg, null, 2) + '\n');
+    console.log(`  ✓ Updated ${filePath}`);
+    return true;
+  }
+  return false;
+}
+
+// Update Cargo.toml files
+function updateCargoToml(filePath, isWorkspace = false) {
+  const content = readFileSync(filePath, 'utf-8');
+  let updated = false;
+  let newContent = content;
+  
+  // Update workspace version
+  if (isWorkspace) {
+    const workspaceVersionRegex = /^version\s*=\s*"[^"]+"/m;
+    if (workspaceVersionRegex.test(newContent)) {
+      newContent = newContent.replace(workspaceVersionRegex, `version = "${newVersion}"`);
+      updated = true;
+    }
+  }
+  
+  // Update dependency versions (ifc-lite-core, ifc-lite-geometry)
+  const depVersionRegex = /(ifc-lite-(?:core|geometry)\s*=\s*\{\s*version\s*=\s*)"[^"]+"/g;
+  const matches = newContent.match(depVersionRegex);
+  if (matches) {
+    newContent = newContent.replace(depVersionRegex, `$1"${newVersion}"`);
+    updated = true;
+  }
+  
+  if (updated) {
+    writeFileSync(filePath, newContent);
+    console.log(`  ✓ Updated ${filePath}`);
+  }
+  
+  return updated;
+}
+
+// Update TypeScript file with hardcoded versions
+function updateTypeScriptFile(filePath) {
+  const content = readFileSync(filePath, 'utf-8');
+  let updated = false;
+  let newContent = content;
+  
+  // Replace version strings in template generation
+  // Match: version: '1.0.0' or version: "1.0.0"
+  const versionRegex = /version:\s*['"](\d+\.\d+\.\d+)['"]/g;
+  if (versionRegex.test(newContent)) {
+    newContent = newContent.replace(versionRegex, `version: '${newVersion}'`);
+    updated = true;
+  }
+  
+  // Replace dependency versions like '@ifc-lite/parser': '^1.0.0'
+  const depRegex = /(['"]@ifc-lite\/[^'"]+['"]:\s*['"]\^)\d+\.\d+\.\d+(['"])/g;
+  if (depRegex.test(newContent)) {
+    newContent = newContent.replace(depRegex, `$1${newVersion}$2`);
+    updated = true;
+  }
+  
+  if (updated) {
+    writeFileSync(filePath, newContent);
+    console.log(`  ✓ Updated ${filePath}`);
+  }
+  
+  return updated;
+}
+
+// Find all package.json files recursively
+function findPackageJsonFiles(dir, files = []) {
+  const entries = readdirSync(dir);
+  for (const entry of entries) {
+    const fullPath = join(dir, entry);
+    const stat = statSync(fullPath);
+    
+    if (stat.isDirectory()) {
+      // Skip node_modules, dist, target, and other build directories
+      if (!['node_modules', 'dist', 'target', '.git', 'pkg'].includes(entry)) {
+        findPackageJsonFiles(fullPath, files);
+      }
+    } else if (entry === 'package.json') {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+// Main execution
+try {
+  console.log('Updating package.json files...');
+  const packageJsonFiles = findPackageJsonFiles(ROOT_DIR);
+  let updatedCount = 0;
+  for (const file of packageJsonFiles) {
+    if (updatePackageJson(file)) {
+      updatedCount++;
+    }
+  }
+  console.log(`  Updated ${updatedCount} package.json files\n`);
+  
+  console.log('Updating Cargo.toml files...');
+  // Root workspace Cargo.toml
+  updateCargoToml(join(ROOT_DIR, 'Cargo.toml'), true);
+  
+  // Rust workspace member Cargo.toml files with dependencies
+  updateCargoToml(join(ROOT_DIR, 'rust', 'wasm-bindings', 'Cargo.toml'));
+  updateCargoToml(join(ROOT_DIR, 'rust', 'geometry', 'Cargo.toml'));
+  console.log();
+  
+  console.log('Updating TypeScript files...');
+  updateTypeScriptFile(join(ROOT_DIR, 'packages', 'create-ifc-lite', 'src', 'index.ts'));
+  console.log();
+  
+  console.log(`✅ Version bump complete! All files updated to ${newVersion}`);
+  console.log('\nNext steps:');
+  console.log('  1. Run: pnpm install (to update pnpm-lock.yaml)');
+  console.log('  2. Rebuild WASM if needed: ./build-wasm.sh');
+  console.log('  3. Test the changes');
+  
+} catch (error) {
+  console.error('Error during version bump:', error);
+  process.exit(1);
+}


### PR DESCRIPTION
- Update all package.json files to 1.1.0
- Update Cargo.toml workspace version and dependencies
- Update hardcoded version strings in create-ifc-lite templates
- Add version bump script for future use