### PR TITLE
Fix mkdocs build: remove invalid normalize_commit_symbols config

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,7 +80,6 @@ markdown_extensions:
       user: louistrue
       repo: ifc-lite
       normalize_issue_symbols: true
-      normalize_commit_symbols: true
   - pymdownx.mark
   - pymdownx.smartsymbols
   - pymdownx.superfences:


### PR DESCRIPTION
- Remove normalize_commit_symbols option from pymdownx.magiclink config
- This option is not supported in pymdown-extensions 10.20
- Build now succeeds with --strict mode