### PR TITLE
Bump version to 1.1.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.1.3"
+version = "1.1.4"
 edition = "2021"
 authors = ["IFC-Lite Contributors"]
 license = "MPL-2.0"

--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/viewer",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "IFC-Lite viewer application",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ifc-lite",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "High-performance browser IFC parser & renderer",
   "private": true,
   "type": "module",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/cache",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Binary cache format for IFC-Lite - fast model loading",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/codegen",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "TypeScript code generator from IFC EXPRESS schemas",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/create-ifc-lite/package.json
+++ b/packages/create-ifc-lite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-ifc-lite",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Create IFC-Lite projects with one command",
   "type": "module",
   "bin": {

--- a/packages/create-ifc-lite/src/index.ts
+++ b/packages/create-ifc-lite/src/index.ts
@@ -190,7 +190,7 @@ function createBasicTemplate(targetDir: string, projectName: string) {
   // package.json
   writeFileSync(join(targetDir, 'package.json'), JSON.stringify({
     name: projectName,
-    version: '1.0.0',
+    version: '1.1.4',
     type: 'module',
     scripts: {
       parse: 'npx tsx src/index.ts',

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/data",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Columnar data structures for IFC-Lite",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/export/package.json
+++ b/packages/export/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/export",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Export formats for IFC-Lite",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/geometry/package.json
+++ b/packages/geometry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/geometry",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Geometry processing bridge for IFC-Lite - 1.9x faster than web-ifc",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/parser",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "IFC/STEP parser for IFC-Lite",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/query",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Query system for IFC-Lite",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/renderer",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "WebGPU renderer for IFC-Lite",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/spatial/package.json
+++ b/packages/spatial/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/spatial",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Spatial indexing for IFC-Lite",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -5,7 +5,7 @@
     "IFC-Lite Contributors"
   ],
   "description": "WebAssembly bindings for IFC-Lite",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "license": "MPL-2.0",
   "repository": {
     "type": "git",

--- a/rust/geometry/Cargo.toml
+++ b/rust/geometry/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../../README.md"
 
 [dependencies]
 # Core IFC parsing
-ifc-lite-core = { version = "1.1.3", path = "../core" }
+ifc-lite-core = { version = "1.1.4", path = "../core" }
 
 # Math library
 nalgebra = { version = "0.33", default-features = false, features = ["std"] }

--- a/rust/wasm-bindings/Cargo.toml
+++ b/rust/wasm-bindings/Cargo.toml
@@ -18,8 +18,8 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 # Core packages
-ifc-lite-core = { version = "1.1.3", path = "../core" }
-ifc-lite-geometry = { version = "1.1.3", path = "../geometry" }
+ifc-lite-core = { version = "1.1.4", path = "../core" }
+ifc-lite-geometry = { version = "1.1.4", path = "../geometry" }
 
 # WASM bindings
 wasm-bindgen = "0.2"


### PR DESCRIPTION
- Update all package.json files to 1.1.4
- Update Cargo.toml workspace version and dependencies
- Update hardcoded version strings in create-ifc-lite templates