### PR TITLE
Fix create-ifc-lite for standalone usage

### DIFF
--- a/packages/create-ifc-lite/package.json
+++ b/packages/create-ifc-lite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-ifc-lite",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Create IFC-Lite projects with one command",
   "type": "module",
   "bin": {


### PR DESCRIPTION
- Generate standalone tsconfig.json without monorepo extends/paths
- Generate standalone vite.config.ts without @ifc-lite/* aliases (packages now resolve from node_modules)
- Bump version to 1.1.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 1.1.5

* **New Features**
  * Enhanced template setup process for viewer projects with improved configuration generation
  * Added standalone configuration file generation, removing monorepo dependencies

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->