### PR TITLE
Bump version to 1.1.7 and fix workspace dependencies

### DIFF
--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/viewer",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "IFC-Lite viewer application",
   "type": "module",
   "scripts": {
@@ -9,14 +9,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ifc-lite/cache": "workspace:*",
-    "@ifc-lite/data": "workspace:*",
-    "@ifc-lite/export": "workspace:*",
-    "@ifc-lite/geometry": "workspace:*",
-    "@ifc-lite/parser": "workspace:*",
-    "@ifc-lite/query": "workspace:*",
-    "@ifc-lite/renderer": "workspace:*",
-    "@ifc-lite/spatial": "workspace:*",
+    "@ifc-lite/cache": "^1.1.7",
+    "@ifc-lite/data": "^1.1.7",
+    "@ifc-lite/export": "^1.1.7",
+    "@ifc-lite/geometry": "^1.1.7",
+    "@ifc-lite/parser": "^1.1.7",
+    "@ifc-lite/query": "^1.1.7",
+    "@ifc-lite/renderer": "^1.1.7",
+    "@ifc-lite/spatial": "^1.1.7",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/cache",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Binary cache format for IFC-Lite - fast model loading",
   "type": "module",
   "main": "./dist/index.js",
@@ -17,8 +17,8 @@
     "test": "tsx --test src/**/*.test.ts"
   },
   "dependencies": {
-    "@ifc-lite/data": "workspace:*",
-    "@ifc-lite/geometry": "workspace:*"
+    "@ifc-lite/data": "^1.1.7",
+    "@ifc-lite/geometry": "^1.1.7"
   },
   "devDependencies": {
     "typescript": "^5.3.0"

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/codegen",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "TypeScript code generator from IFC EXPRESS schemas",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/create-ifc-lite/package.json
+++ b/packages/create-ifc-lite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-ifc-lite",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Create IFC-Lite projects with one command",
   "type": "module",
   "bin": {

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/data",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Columnar data structures for IFC-Lite",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/export/package.json
+++ b/packages/export/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/export",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Export formats for IFC-Lite",
   "type": "module",
   "main": "./dist/index.js",
@@ -16,9 +16,9 @@
     "dev": "tsc --watch"
   },
   "dependencies": {
-    "@ifc-lite/geometry": "workspace:*",
-    "@ifc-lite/data": "workspace:*",
-    "@ifc-lite/parser": "workspace:*",
+    "@ifc-lite/geometry": "^1.1.7",
+    "@ifc-lite/data": "^1.1.7",
+    "@ifc-lite/parser": "^1.1.7",
     "parquet-wasm": "^0.5.0",
     "apache-arrow": "^14.0.0",
     "jszip": "^3.10.0"

--- a/packages/geometry/package.json
+++ b/packages/geometry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/geometry",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Geometry processing bridge for IFC-Lite - 1.9x faster than web-ifc",
   "type": "module",
   "main": "./dist/index.js",
@@ -16,7 +16,7 @@
     "dev": "tsc --watch"
   },
   "dependencies": {
-    "@ifc-lite/wasm": "workspace:*"
+    "@ifc-lite/wasm": "^1.1.7"
   },
   "devDependencies": {
     "typescript": "^5.3.0"

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/parser",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "IFC/STEP parser for IFC-Lite",
   "type": "module",
   "main": "./dist/index.js",
@@ -16,7 +16,7 @@
     "dev": "tsc --watch"
   },
   "dependencies": {
-    "@ifc-lite/data": "workspace:*"
+    "@ifc-lite/data": "^1.1.7"
   },
   "devDependencies": {
     "typescript": "^5.3.0"

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/query",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Query system for IFC-Lite",
   "type": "module",
   "main": "./dist/index.js",
@@ -16,10 +16,10 @@
     "dev": "tsc --watch"
   },
   "dependencies": {
-    "@ifc-lite/parser": "workspace:*",
-    "@ifc-lite/data": "workspace:*",
-    "@ifc-lite/spatial": "workspace:*",
-    "@ifc-lite/geometry": "workspace:*"
+    "@ifc-lite/parser": "^1.1.7",
+    "@ifc-lite/data": "^1.1.7",
+    "@ifc-lite/spatial": "^1.1.7",
+    "@ifc-lite/geometry": "^1.1.7"
   },
   "devDependencies": {
     "typescript": "^5.3.0"

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/renderer",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "WebGPU renderer for IFC-Lite",
   "type": "module",
   "main": "./dist/index.js",
@@ -16,9 +16,9 @@
     "dev": "tsc --watch"
   },
   "dependencies": {
-    "@ifc-lite/spatial": "workspace:*",
-    "@ifc-lite/geometry": "workspace:*",
-    "@ifc-lite/wasm": "workspace:*"
+    "@ifc-lite/spatial": "^1.1.7",
+    "@ifc-lite/geometry": "^1.1.7",
+    "@ifc-lite/wasm": "^1.1.7"
   },
   "devDependencies": {
     "typescript": "^5.3.0"

--- a/packages/spatial/package.json
+++ b/packages/spatial/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/spatial",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Spatial indexing for IFC-Lite",
   "type": "module",
   "main": "./dist/index.js",
@@ -16,7 +16,7 @@
     "dev": "tsc --watch"
   },
   "dependencies": {
-    "@ifc-lite/geometry": "workspace:*"
+    "@ifc-lite/geometry": "^1.1.7"
   },
   "devDependencies": {
     "typescript": "^5.3.0"

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -5,7 +5,7 @@
     "IFC-Lite Contributors"
   ],
   "description": "WebAssembly bindings for IFC-Lite",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "license": "MPL-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Replace all workspace:* with ^1.1.7 in package dependencies
- Add WASM middleware to create-ifc-lite vite template
- Bump all packages to version 1.1.7

This fixes npm install errors caused by workspace: protocol

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 1.1.7 across all packages
  * Updated internal dependencies to stable 1.1.7 versions

* **Improvements**
  * Enhanced WebAssembly module handling with improved server configuration for better file serving and access control
  * Optimized dependency resolution for WebAssembly packages

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->