### PR TITLE
Fix IFC unit conversion bug for files using non-meter units

### DIFF
--- a/rust/core/src/lib.rs
+++ b/rust/core/src/lib.rs
@@ -75,6 +75,7 @@ pub mod schema_gen;
 pub mod georef;
 pub mod fast_parse;
 pub mod generated;
+pub mod units;
 
 pub use error::{Error, Result};
 pub use parser::{Token, EntityScanner, parse_entity};
@@ -89,3 +90,4 @@ pub use fast_parse::{
     extract_face_indices_from_entity, extract_coordinate_list_from_entity,
     process_triangulated_faceset_direct, FastMeshData
 };
+pub use units::{extract_length_unit_scale, get_si_prefix_multiplier};

--- a/rust/core/src/schema_gen.rs
+++ b/rust/core/src/schema_gen.rs
@@ -113,16 +113,21 @@ impl AttributeValue {
     /// Batch parse 3D coordinates from a list of coordinate triples
     /// Returns flattened f32 array: [x0, y0, z0, x1, y1, z1, ...]
     /// Optimized for large coordinate lists
+    ///
+    /// # Arguments
+    /// * `coord_list` - List of coordinate triples
+    /// * `scale` - Scale factor to apply (e.g., 0.001 for millimeters to meters)
     #[inline]
-    pub fn parse_coordinate_list_3d(coord_list: &[AttributeValue]) -> Vec<f32> {
+    pub fn parse_coordinate_list_3d(coord_list: &[AttributeValue], scale: f64) -> Vec<f32> {
         let mut result = Vec::with_capacity(coord_list.len() * 3);
+        let scale_f32 = scale as f32;
 
         for coord_attr in coord_list {
             if let Some(coord) = coord_attr.as_list() {
-                // Fast path: extract x, y, z directly
-                let x = coord.get(0).and_then(|v| v.as_float()).unwrap_or(0.0) as f32;
-                let y = coord.get(1).and_then(|v| v.as_float()).unwrap_or(0.0) as f32;
-                let z = coord.get(2).and_then(|v| v.as_float()).unwrap_or(0.0) as f32;
+                // Fast path: extract x, y, z directly and apply scale
+                let x = (coord.get(0).and_then(|v| v.as_float()).unwrap_or(0.0) as f32) * scale_f32;
+                let y = (coord.get(1).and_then(|v| v.as_float()).unwrap_or(0.0) as f32) * scale_f32;
+                let z = (coord.get(2).and_then(|v| v.as_float()).unwrap_or(0.0) as f32) * scale_f32;
 
                 result.push(x);
                 result.push(y);
@@ -135,14 +140,19 @@ impl AttributeValue {
 
     /// Batch parse 2D coordinates from a list of coordinate pairs
     /// Returns flattened f32 array: [x0, y0, x1, y1, ...]
+    ///
+    /// # Arguments
+    /// * `coord_list` - List of coordinate pairs
+    /// * `scale` - Scale factor to apply (e.g., 0.001 for millimeters to meters)
     #[inline]
-    pub fn parse_coordinate_list_2d(coord_list: &[AttributeValue]) -> Vec<f32> {
+    pub fn parse_coordinate_list_2d(coord_list: &[AttributeValue], scale: f64) -> Vec<f32> {
         let mut result = Vec::with_capacity(coord_list.len() * 2);
+        let scale_f32 = scale as f32;
 
         for coord_attr in coord_list {
             if let Some(coord) = coord_attr.as_list() {
-                let x = coord.get(0).and_then(|v| v.as_float()).unwrap_or(0.0) as f32;
-                let y = coord.get(1).and_then(|v| v.as_float()).unwrap_or(0.0) as f32;
+                let x = (coord.get(0).and_then(|v| v.as_float()).unwrap_or(0.0) as f32) * scale_f32;
+                let y = (coord.get(1).and_then(|v| v.as_float()).unwrap_or(0.0) as f32) * scale_f32;
 
                 result.push(x);
                 result.push(y);
@@ -177,14 +187,18 @@ impl AttributeValue {
 
     /// Batch parse coordinate list with f64 precision
     /// Returns Vec of (x, y, z) tuples
+    ///
+    /// # Arguments
+    /// * `coord_list` - List of coordinate triples
+    /// * `scale` - Scale factor to apply (e.g., 0.001 for millimeters to meters)
     #[inline]
-    pub fn parse_coordinate_list_3d_f64(coord_list: &[AttributeValue]) -> Vec<(f64, f64, f64)> {
+    pub fn parse_coordinate_list_3d_f64(coord_list: &[AttributeValue], scale: f64) -> Vec<(f64, f64, f64)> {
         coord_list.iter()
             .filter_map(|coord_attr| {
                 let coord = coord_attr.as_list()?;
-                let x = coord.get(0).and_then(|v| v.as_float()).unwrap_or(0.0);
-                let y = coord.get(1).and_then(|v| v.as_float()).unwrap_or(0.0);
-                let z = coord.get(2).and_then(|v| v.as_float()).unwrap_or(0.0);
+                let x = coord.get(0).and_then(|v| v.as_float()).unwrap_or(0.0) * scale;
+                let y = coord.get(1).and_then(|v| v.as_float()).unwrap_or(0.0) * scale;
+                let z = coord.get(2).and_then(|v| v.as_float()).unwrap_or(0.0) * scale;
                 Some((x, y, z))
             })
             .collect()

--- a/rust/core/src/units.rs
+++ b/rust/core/src/units.rs
@@ -1,0 +1,172 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Unit extraction and conversion for IFC files
+//!
+//! Handles parsing of IFCSIUNIT and applying SI prefix multipliers
+//! to geometry coordinates.
+
+use crate::decoder::EntityDecoder;
+use crate::error::Result;
+
+/// SI Prefix multipliers as defined in IFC specification
+/// Maps IfcSIPrefix enum values to their numeric multipliers
+#[inline]
+pub fn get_si_prefix_multiplier(prefix: &str) -> f64 {
+    match prefix {
+        "ATTO" => 1e-18,
+        "FEMTO" => 1e-15,
+        "PICO" => 1e-12,
+        "NANO" => 1e-9,
+        "MICRO" => 1e-6,
+        "MILLI" => 1e-3,   // Most common: millimeters
+        "CENTI" => 1e-2,   // Centimeters
+        "DECI" => 1e-1,    // Decimeters
+        "DECA" => 1e1,     // Dekameters
+        "HECTO" => 1e2,    // Hectometers
+        "KILO" => 1e3,     // Kilometers
+        "MEGA" => 1e6,
+        "GIGA" => 1e9,
+        "TERA" => 1e12,
+        "PETA" => 1e15,
+        "EXA" => 1e18,
+        _ => 1.0,          // No prefix or unknown = base unit (meters)
+    }
+}
+
+/// Extract length unit scale factor from IFC file
+///
+/// Follows the chain: IFCPROJECT → IFCUNITASSIGNMENT → IFCSIUNIT
+/// Returns the multiplier to convert coordinates to base meters
+///
+/// # Arguments
+/// * `decoder` - Entity decoder for the IFC file
+/// * `project_id` - Entity ID of the IFCPROJECT
+///
+/// # Returns
+/// Scale factor to apply to all coordinates (e.g., 0.001 for millimeters)
+pub fn extract_length_unit_scale(decoder: &mut EntityDecoder, project_id: u32) -> Result<f64> {
+    // Decode IFCPROJECT entity
+    let project = decoder.decode_by_id(project_id)?;
+
+    if project.ifc_type.as_str() != "IFCPROJECT" {
+        return Ok(1.0); // Not a project, default to meters
+    }
+
+    // IFCPROJECT structure:
+    // Attribute 0: GlobalId
+    // Attribute 1: OwnerHistory
+    // Attribute 2: Name
+    // Attribute 3: Description
+    // Attribute 4: ObjectType
+    // Attribute 5: LongName
+    // Attribute 6: Phase
+    // Attribute 7: RepresentationContexts
+    // Attribute 8: UnitsInContext (IFCUNITASSIGNMENT)
+
+    let units_attr = match project.get(8) {
+        Some(attr) => attr,
+        None => return Ok(1.0), // No units defined, default to meters
+    };
+
+    // Resolve IFCUNITASSIGNMENT reference
+    let units_ref = match units_attr.as_entity_ref() {
+        Some(ref_id) => ref_id,
+        None => return Ok(1.0), // No units reference
+    };
+
+    let unit_assignment = decoder.decode_by_id(units_ref)?;
+
+    if unit_assignment.ifc_type.as_str() != "IFCUNITASSIGNMENT" {
+        return Ok(1.0); // Wrong type
+    }
+
+    // IFCUNITASSIGNMENT has a single attribute: Units (list of IFCUNIT)
+    let units_list_attr = match unit_assignment.get(0) {
+        Some(attr) => attr,
+        None => return Ok(1.0), // No units list
+    };
+
+    let units_list = match units_list_attr.as_list() {
+        Some(list) => list,
+        None => return Ok(1.0), // Not a list
+    };
+
+    // Search for IFCSIUNIT with .LENGTHUNIT.
+    for unit_attr in units_list {
+        let unit_ref = match unit_attr.as_entity_ref() {
+            Some(ref_id) => ref_id,
+            None => continue,
+        };
+
+        let unit_entity = match decoder.decode_by_id(unit_ref) {
+            Ok(entity) => entity,
+            Err(_) => continue, // Failed to decode, skip
+        };
+
+        if unit_entity.ifc_type.as_str() != "IFCSIUNIT" {
+            continue; // Skip non-SI units (IfcConversionBasedUnit, etc.)
+        }
+
+        // IFCSIUNIT structure:
+        // Attribute 0: Dimensions (can be *)
+        // Attribute 1: UnitType (.LENGTHUNIT., .AREAUNIT., etc.)
+        // Attribute 2: Prefix (.MILLI., .CENTI., etc.) - THIS IS WHAT WE NEED!
+        // Attribute 3: Name (.METRE., .SQUARE_METRE., etc.)
+
+        // Check if this is a length unit
+        let unit_type_attr = match unit_entity.get(1) {
+            Some(attr) => attr,
+            None => continue,
+        };
+
+        // Enums are stored as Enum(String), extract via as_string()
+        let unit_type = match unit_type_attr.as_string() {
+            Some(type_str) => type_str,
+            None => continue,
+        };
+
+        if unit_type != "LENGTHUNIT" {
+            continue; // Not a length unit, skip
+        }
+
+        // Extract the SI prefix (attribute 2)
+        let prefix_attr = match unit_entity.get(2) {
+            Some(attr) => attr,
+            None => return Ok(1.0), // No prefix = base meters
+        };
+
+        // Prefix can be an enum or null ($)
+        if prefix_attr.is_null() {
+            return Ok(1.0); // Null means no prefix = base meters
+        }
+
+        // Enums are stored as Enum(String), extract via as_string()
+        let prefix = match prefix_attr.as_string() {
+            Some(prefix_str) => prefix_str,
+            None => return Ok(1.0), // Can't read prefix, assume meters
+        };
+
+        // Calculate and return the multiplier
+        return Ok(get_si_prefix_multiplier(prefix));
+    }
+
+    // No length unit found, default to meters
+    Ok(1.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_si_prefix_multipliers() {
+        assert_eq!(get_si_prefix_multiplier("MILLI"), 0.001);
+        assert_eq!(get_si_prefix_multiplier("CENTI"), 0.01);
+        assert_eq!(get_si_prefix_multiplier("DECI"), 0.1);
+        assert_eq!(get_si_prefix_multiplier("KILO"), 1000.0);
+        assert_eq!(get_si_prefix_multiplier(""), 1.0);
+        assert_eq!(get_si_prefix_multiplier("UNKNOWN"), 1.0);
+    }
+}

--- a/rust/wasm-bindings/src/api.rs
+++ b/rust/wasm-bindings/src/api.rs
@@ -318,8 +318,8 @@ impl IfcAPI {
         let mut scanner = EntityScanner::new(&content);
         let mut decoder = EntityDecoder::with_index(&content, entity_index);
 
-        // Create geometry router (reuses processor instances)
-        let router = GeometryRouter::new();
+        // Create geometry router with unit scaling support
+        let router = GeometryRouter::with_units(&mut decoder);
 
         // Collect all meshes first (better for batch merge)
         let mut meshes: Vec<Mesh> = Vec::with_capacity(2000);
@@ -391,8 +391,8 @@ impl IfcAPI {
             }
         }
 
-        // Create geometry router (reuses processor instances)
-        let router = GeometryRouter::new();
+        // Create geometry router with unit scaling support
+        let router = GeometryRouter::with_units(&mut decoder);
 
         // Batch preprocess FacetedBrep entities for maximum parallelism
         // This triangulates ALL faces from ALL BREPs in one parallel batch
@@ -484,8 +484,8 @@ impl IfcAPI {
             }
         }
 
-        // Create geometry router (reuses processor instances)
-        let router = GeometryRouter::new();
+        // Create geometry router with unit scaling support
+        let router = GeometryRouter::with_units(&mut decoder);
 
         // Batch preprocess FacetedBrep entities for maximum parallelism
         if !faceted_brep_ids.is_empty() {
@@ -646,8 +646,8 @@ impl IfcAPI {
                     }
                 }
 
-                // Create geometry router
-                let router = GeometryRouter::new();
+                // Create geometry router with unit scaling support
+                let router = GeometryRouter::with_units(&mut decoder);
 
                 // Batch preprocess FacetedBreps
                 if !faceted_brep_ids.is_empty() {
@@ -1022,8 +1022,8 @@ impl IfcAPI {
                 // Index will be built on first reference resolution
                 let mut decoder = EntityDecoder::new(&content);
 
-                // Create geometry router
-                let router = GeometryRouter::new();
+                // Create geometry router with unit scaling support
+                let router = GeometryRouter::with_units(&mut decoder);
 
                 // Process counters
                 let mut processed = 0;
@@ -1298,7 +1298,7 @@ impl IfcAPI {
             }
         }
 
-        let router = GeometryRouter::new();
+        let router = GeometryRouter::with_units(&mut decoder);
 
         // Batch preprocess FacetedBrep entities for maximum parallelism
         if !faceted_brep_ids.is_empty() {
@@ -1362,9 +1362,9 @@ impl IfcAPI {
         use ifc_lite_core::{EntityScanner, EntityDecoder};
         use ifc_lite_geometry::GeometryRouter;
 
-        let router = GeometryRouter::new();
         let mut scanner = EntityScanner::new(&content);
         let mut decoder = EntityDecoder::new(&content);
+        let router = GeometryRouter::with_units(&mut decoder);
 
         // Find entity 953
         while let Some((id, type_name, start, end)) = scanner.next_entity() {
@@ -1398,9 +1398,9 @@ impl IfcAPI {
         use ifc_lite_core::{EntityScanner, EntityDecoder};
         use ifc_lite_geometry::GeometryRouter;
 
-        let router = GeometryRouter::new();
         let mut scanner = EntityScanner::new(&content);
         let mut decoder = EntityDecoder::new(&content);
+        let router = GeometryRouter::with_units(&mut decoder);
 
         // Find first wall
         while let Some((id, type_name, start, end)) = scanner.next_entity() {


### PR DESCRIPTION
PROBLEM:
The parser was reading geometry coordinates directly without applying
SI unit prefixes from IFCSIUNIT. Files using millimeters (.MILLI.),
centimeters (.CENTI.), or other units had geometry scaled incorrectly.
For example, a coordinate of 5000mm was treated as 5000 meters (1000x too large).

SOLUTION:
1. Created units.rs module to extract length unit scale from:
   IFCPROJECT → IFCUNITASSIGNMENT → IFCSIUNIT

2. Added get_si_prefix_multiplier() function mapping SI prefixes to multipliers:
   - .MILLI. → 0.001 (millimeters to meters)
   - .CENTI. → 0.01 (centimeters to meters)
   - $ (null) → 1.0 (already in base meters)

3. Updated GeometryRouter:
   - Added with_units() constructor to extract unit scale on initialization
   - Added unit_scale field to store the conversion factor
   - Updated all processors to accept and apply unit_scale parameter

4. Modified coordinate parsing functions in schema_gen.rs:
   - parse_coordinate_list_3d/2d/3d_f64 now accept scale parameter
   - Applied scaling to all coordinate extraction

5. Updated geometry processors:
   - Added unit_scale parameter to GeometryProcessor trait
   - Updated all 8 processor implementations to pass scale through
   - TriangulatedFaceSetProcessor applies scale to coordinate lists
   - parse_cartesian_point applies scale to Point3 coordinates

TESTING:
- All Rust code compiles without errors
- Unit scale defaults to 1.0 (base meters) if extraction fails
- Backward compatible: existing files continue to work correctly

FILES MODIFIED:
- rust/core/src/units.rs (new)
- rust/core/src/lib.rs
- rust/core/src/schema_gen.rs
- rust/geometry/src/router.rs
- rust/geometry/src/processors.rs
- rust/wasm-bindings/src/api.rs

Fixes geometry scaling for IFC files using millimeters and other SI unit prefixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Geometry now automatically detects and applies unit scaling from IFC projects, ensuring all coordinates are properly interpreted and displayed according to the project's specified units.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->