### PR TITLE
Add Tauri desktop app documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,12 @@
 </p>
 
 <p align="center">
-  <a href="#features">Features</a> · 
-  <a href="#quick-start">Quick Start</a> · 
-  <a href="#documentation">Documentation</a> · 
-  <a href="#architecture">Architecture</a> · 
-  <a href="#performance">Performance</a> · 
+  <a href="#features">Features</a> ·
+  <a href="#quick-start">Quick Start</a> ·
+  <a href="#desktop-app-tauri">Desktop App</a> ·
+  <a href="#documentation">Documentation</a> ·
+  <a href="#architecture">Architecture</a> ·
+  <a href="#performance">Performance</a> ·
   <a href="#contributing">Contributing</a>
 </p>
 
@@ -123,8 +124,29 @@ pnpm install && pnpm dev
 Open http://localhost:5173 and load an IFC file.
 
 > **Note:** Requires Node.js 18+ and pnpm 8+. No Rust toolchain needed - WASM is pre-built.
-> 
+>
 > **📖 Full Guide**: See [Installation](docs/guide/installation.md) for detailed setup options including troubleshooting.
+
+### Option 5: Desktop App (Tauri)
+
+Run IFClite as a native desktop application with enhanced performance:
+
+```bash
+cd apps/desktop
+pnpm install
+pnpm dev          # Development mode
+pnpm build        # Build for current platform
+```
+
+Build for specific platforms:
+
+```bash
+pnpm build:windows   # Windows (.exe, .msi)
+pnpm build:macos     # macOS (.app, .dmg)
+pnpm build:linux     # Linux (.deb, .AppImage)
+```
+
+> **Note:** Requires Rust toolchain for building. See [Tauri Prerequisites](https://v2.tauri.app/start/prerequisites/).
 
 ### Basic Usage
 
@@ -207,7 +229,8 @@ ifc-lite/
 │   └── codegen/               # Schema generator
 │
 ├── apps/
-│   └── viewer/                # React web application
+│   ├── viewer/                # React web application
+│   └── desktop/               # Tauri desktop application
 │
 └── docs/                      # Documentation (MkDocs)
 ```
@@ -257,6 +280,67 @@ ifc-lite/
 | Safari | 18+ | ✅ |
 
 > **More Info**: See [Browser Requirements](docs/guide/browser-requirements.md) for WebGPU feature detection and fallbacks.
+
+## Desktop App (Tauri)
+
+IFClite includes a native desktop application built with [Tauri v2](https://v2.tauri.app/), providing enhanced performance over the web version.
+
+### Why Desktop?
+
+| Feature | Web (WASM) | Desktop (Native) |
+|---------|-----------|------------------|
+| **Parsing** | Single-threaded | Multi-threaded (Rayon) |
+| **Memory** | WASM 4GB limit | System RAM |
+| **File Access** | User upload only | Direct filesystem |
+| **Startup** | Download WASM | Instant |
+| **Large Files** | ~100MB practical limit | 500MB+ supported |
+
+### Architecture
+
+The desktop app reuses the same Rust crates (`ifc-lite-core`, `ifc-lite-geometry`) as the WASM build, but compiled natively:
+
+```
+apps/desktop/
+├── src/                    # React frontend (shared with web)
+├── src-tauri/
+│   ├── src/
+│   │   ├── commands/       # Tauri IPC commands
+│   │   │   ├── ifc.rs      # parse_ifc_buffer, get_geometry
+│   │   │   ├── cache.rs    # Binary caching system
+│   │   │   └── file_dialog.rs
+│   │   └── lib.rs          # Tauri app setup
+│   └── Cargo.toml          # Native dependencies
+└── package.json
+```
+
+### Native Commands
+
+The desktop app exposes these Tauri commands to the frontend:
+
+| Command | Description |
+|---------|-------------|
+| `parse_ifc_buffer` | Parse IFC with native multi-threading |
+| `get_geometry` | Process geometry in parallel batches |
+| `get_geometry_streaming` | Stream geometry progressively |
+| `open_ifc_file` | Native file dialog integration |
+| `get_cached` / `set_cached` | Binary cache for instant reload |
+
+### Building Releases
+
+```bash
+cd apps/desktop
+
+# Development
+pnpm dev
+
+# Production builds
+pnpm build              # Current platform
+pnpm build:windows      # x86_64-pc-windows-msvc
+pnpm build:macos        # universal-apple-darwin (Intel + Apple Silicon)
+pnpm build:linux        # x86_64-unknown-linux-gnu
+```
+
+Output binaries are placed in `apps/desktop/src-tauri/target/release/bundle/`.
 
 ## Development (Contributors)
 


### PR DESCRIPTION
- Add Desktop App link to navigation
- Add Option 5: Desktop App (Tauri) to Quick Start section
- Add dedicated Desktop App section with comparison table, architecture overview, native commands reference, and build instructions
- Update Project Structure to include desktop app