### PR TITLE
Fix client-side color parsing mismatch

### DIFF
--- a/packages/parser/src/entity-extractor.ts
+++ b/packages/parser/src/entity-extractor.ts
@@ -104,6 +104,16 @@ export class EntityExtractor {
       return null;
     }
 
+    // TypedValue: IFCTYPENAME(value) - must check before list check
+    // Pattern: identifier followed by parentheses (e.g., IFCNORMALISEDRATIOMEASURE(0.5))
+    const typedValueMatch = value.match(/^([A-Z][A-Z0-9_]*)\((.+)\)$/i);
+    if (typedValueMatch) {
+      const typeName = typedValueMatch[1];
+      const innerValue = typedValueMatch[2].trim();
+      // Return as array [typeName, parsedValue] to match Rust structure
+      return [typeName, this.parseAttributeValue(innerValue)];
+    }
+
     // List/Array: (#123) or (#123, #456) or ()
     if (value.startsWith('(') && value.endsWith(')')) {
       const listContent = value.slice(1, -1).trim();

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -351,6 +351,16 @@ function parseAttributeValue(value: string): any {
     return null;
   }
 
+  // TypedValue: IFCTYPENAME(value) - must check before list check
+  // Pattern: identifier followed by parentheses (e.g., IFCNORMALISEDRATIOMEASURE(0.5))
+  const typedValueMatch = value.match(/^([A-Z][A-Z0-9_]*)\((.+)\)$/i);
+  if (typedValueMatch) {
+    const typeName = typedValueMatch[1];
+    const innerValue = typedValueMatch[2].trim();
+    // Return as array [typeName, parsedValue] to match Rust structure
+    return [typeName, parseAttributeValue(innerValue)];
+  }
+
   // List/Array
   if (value.startsWith('(') && value.endsWith(')')) {
     const listContent = value.slice(1, -1).trim();

--- a/packages/parser/src/style-extractor.ts
+++ b/packages/parser/src/style-extractor.ts
@@ -395,6 +395,7 @@ export class StyleExtractor {
 
     /**
      * Get numeric value from entity attribute
+     * Also handles TypedValue wrappers like [typeName, numericValue]
      */
     private getNumericValue(entity: IfcEntity, index: number): number | null {
         const value = this.getAttributeValue(entity, index);
@@ -404,6 +405,23 @@ export class StyleExtractor {
         if (typeof value === 'string') {
             const parsed = parseFloat(value);
             return isNaN(parsed) ? null : parsed;
+        }
+        // Handle TypedValue wrappers: [typeName, numericValue]
+        // e.g., ["IFCNORMALISEDRATIOMEASURE", 0.5]
+        if (Array.isArray(value) && value.length >= 2) {
+            if (typeof value[0] === 'string' && typeof value[1] === 'number') {
+                return value[1];
+            }
+            // Nested case: recursively try to extract numeric from second element
+            if (typeof value[0] === 'string') {
+                if (typeof value[1] === 'number') {
+                    return value[1];
+                }
+                if (typeof value[1] === 'string') {
+                    const parsed = parseFloat(value[1]);
+                    return isNaN(parsed) ? null : parsed;
+                }
+            }
         }
         return null;
     }


### PR DESCRIPTION
IFC color values can be stored as plain floats (0.5) or wrapped in typed values like IFCNORMALISEDRATIOMEASURE(0.5). The color parsing was failing because:

1. Rust's as_float() only handled Float and Integer types, returning None for TypedValue wrappers (stored as List with type name + value)
2. TypeScript's parseAttributeValue() didn't parse TypedValue patterns
3. TypeScript's getNumericValue() didn't extract values from arrays

This caused colors to fall back to defaults (0.8 gray) when IFC files used typed values for RGB components, resulting in wrong colors being displayed.

Changes:
- Rust: as_float() now extracts numeric values from TypedValue lists
- TypeScript: parseAttributeValue() parses TYPENAME(value) patterns
- TypeScript: getNumericValue() extracts numbers from [type, value] arrays
- Added tests for TypedValue handling in Rust