### PR TITLE
fix: restore 60fps by using batch-level visibility filtering

### DIFF
--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -13,9 +13,12 @@ export function ViewportContainer() {
   const { geometryResult, ifcDataStore } = useIfc();
   const selectedStorey = useViewerStore((s) => s.selectedStorey);
   const typeVisibility = useViewerStore((s) => s.typeVisibility);
-  const hiddenEntities = useViewerStore((s) => s.hiddenEntities);
+  const isolatedEntities = useViewerStore((s) => s.isolatedEntities);
 
-  // Filter geometry based on selected storey and type visibility
+  // Filter geometry based on type visibility only
+  // PERFORMANCE FIX: Don't filter by storey or hiddenEntities here
+  // Instead, let the renderer handle visibility filtering at the batch level
+  // This avoids expensive batch rebuilding when visibility changes
   const filteredGeometry = useMemo(() => {
     if (!geometryResult?.meshes) {
       return null;
@@ -61,32 +64,37 @@ export function ViewportContainer() {
       return mesh;
     });
 
-    // Filter by selected storey (if applicable)
+    return meshes;
+  }, [geometryResult, typeVisibility]);
+
+  // Compute combined isolation set (storey + manual isolation)
+  // This is passed to the renderer for batch-level visibility filtering
+  const computedIsolatedIds = useMemo(() => {
+    // If manual isolation is active, use that
+    if (isolatedEntities !== null) {
+      return isolatedEntities;
+    }
+
+    // If storey is selected, compute storey element IDs
     if (ifcDataStore?.spatialHierarchy && selectedStorey !== null) {
       const hierarchy = ifcDataStore.spatialHierarchy;
       const storeyElementIds = hierarchy.byStorey.get(selectedStorey);
 
       if (storeyElementIds && storeyElementIds.length > 0) {
-        const storeyElementIdSet = new Set(storeyElementIds);
-        meshes = meshes.filter(mesh =>
-          storeyElementIdSet.has(mesh.expressId)
-        );
+        return new Set(storeyElementIds);
       }
     }
 
-    // Filter out hidden entities
-    if (hiddenEntities.size > 0) {
-      meshes = meshes.filter(mesh => !hiddenEntities.has(mesh.expressId));
-    }
-
-    return meshes;
-  }, [geometryResult, ifcDataStore, selectedStorey, typeVisibility, hiddenEntities]);
+    // No isolation active
+    return null;
+  }, [ifcDataStore, selectedStorey, isolatedEntities]);
 
   return (
     <div className="relative h-full w-full bg-gradient-to-br from-slate-100 to-slate-200 dark:from-slate-900 dark:to-slate-800">
       <Viewport
         geometry={filteredGeometry}
         coordinateInfo={geometryResult?.coordinateInfo}
+        computedIsolatedIds={computedIsolatedIds}
       />
       <ViewportOverlays />
       <ToolOverlays />


### PR DESCRIPTION
The performance regression was caused by visibility filtering completely disabling batch rendering and creating 60K+ individual meshes instead of ~100-200 batched draw calls.

Key fixes:
- Use batch-level visibility filtering: render batches that are fully visible, skip completely hidden batches
- Remove geometry-level filtering from ViewportContainer for hiddenEntities (renderer handles via batch filtering)
- Add streaming-optimized batch rebuilding: throttle expensive buffer recreation during streaming to reduce O(N²) cost
- Pass computedIsolatedIds from ViewportContainer to Viewport to properly handle storey selection via batch filtering
- Rebuild pending batches when streaming completes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured rendering engine to apply visibility filtering at the batch level instead of per-element processing.
  * Enhanced streaming state management with throttled batch rebuilds.
  * Refactored isolation and selection state handling to use parent-provided configuration instead of relying exclusively on store-level state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->