### PR TITLE
Version Packages to 1.2.1

### DIFF
--- a/.changeset/fix-section-plane.md
+++ b/.changeset/fix-section-plane.md
@@ -1,9 +1,0 @@
----
-"@ifc-lite/renderer": patch
----
-
-Fix section plane activation and clipping behavior.
-- Section plane now only active when Section tool is selected
-- Fixed section plane bounds to use model geometry bounds
-- Simplified section plane axis to x/y/z coordinates
-- Fixed visual section plane rendering with proper depth testing

--- a/.changeset/fix-ubuntu-setup.md
+++ b/.changeset/fix-ubuntu-setup.md
@@ -1,8 +1,0 @@
----
-"@ifc-lite/parser": patch
-"create-ifc-lite": patch
----
-
-Fix Ubuntu setup issues and monorepo resolution.
-- Fix `@ifc-lite/parser` worker resolution for Node.js/tsx compatibility
-- Fix `create-ifc-lite` to properly replace `workspace:` protocol in templates

--- a/.changeset/magnetic-edge-snapping.md
+++ b/.changeset/magnetic-edge-snapping.md
@@ -1,9 +1,0 @@
----
-"@ifc-lite/renderer": patch
----
-
-Add magnetic edge snapping to measure tool.
-- New raycastSceneMagnetic API for edge-aware snapping
-- Edge lock state management for "stick and slide" behavior
-- Corner detection with valence tracking
-- Smooth snapping transitions along edges

--- a/packages/cache/CHANGELOG.md
+++ b/packages/cache/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ifc-lite/cache
 
+## 1.2.1
+
+### Patch Changes
+
+- Version sync with @ifc-lite packages
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/cache",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Binary cache format for IFC-Lite - fast model loading",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/codegen/CHANGELOG.md
+++ b/packages/codegen/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @ifc-lite/codegen
+
+## 1.2.1
+
+### Patch Changes
+
+- Version sync with @ifc-lite packages

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/codegen",
-  "version": "1.1.7",
+  "version": "1.2.1",
   "description": "TypeScript code generator from IFC EXPRESS schemas",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/create-ifc-lite/CHANGELOG.md
+++ b/packages/create-ifc-lite/CHANGELOG.md
@@ -1,0 +1,9 @@
+# create-ifc-lite
+
+## 1.1.8
+
+### Patch Changes
+
+- 8cb195d: Fix Ubuntu setup issues and monorepo resolution.
+  - Fix `@ifc-lite/parser` worker resolution for Node.js/tsx compatibility
+  - Fix `create-ifc-lite` to properly replace `workspace:` protocol in templates

--- a/packages/create-ifc-lite/package.json
+++ b/packages/create-ifc-lite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-ifc-lite",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Create IFC-Lite projects with one command",
   "type": "module",
   "bin": {

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @ifc-lite/data
+
+## 1.2.1
+
+### Patch Changes
+
+- Version sync with @ifc-lite packages

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/data",
-  "version": "1.1.7",
+  "version": "1.2.1",
   "description": "Columnar data structures for IFC-Lite",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/export/CHANGELOG.md
+++ b/packages/export/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @ifc-lite/export
+
+## 1.2.1
+
+### Patch Changes
+
+- Version sync with @ifc-lite packages

--- a/packages/export/package.json
+++ b/packages/export/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/export",
-  "version": "1.1.7",
+  "version": "1.2.1",
   "description": "Export formats for IFC-Lite",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/geometry/CHANGELOG.md
+++ b/packages/geometry/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ifc-lite/geometry
 
+## 1.2.1
+
+### Patch Changes
+
+- Version sync with @ifc-lite packages
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/geometry/package.json
+++ b/packages/geometry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/geometry",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Geometry processing bridge for IFC-Lite - 1.9x faster than web-ifc",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ifcx/CHANGELOG.md
+++ b/packages/ifcx/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ifc-lite/ifcx
 
+## 1.2.1
+
+### Patch Changes
+
+- Version sync with @ifc-lite packages
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/ifcx/package.json
+++ b/packages/ifcx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/ifcx",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "IFC5 (IFCX) parser for IFC-Lite",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/parser/CHANGELOG.md
+++ b/packages/parser/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @ifc-lite/parser
 
+## 1.2.1
+
+### Patch Changes
+
+- 8cb195d: Fix Ubuntu setup issues and monorepo resolution.
+  - Fix `@ifc-lite/parser` worker resolution for Node.js/tsx compatibility
+  - Fix `create-ifc-lite` to properly replace `workspace:` protocol in templates
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/parser",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "IFC/STEP parser for IFC-Lite",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/query/CHANGELOG.md
+++ b/packages/query/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @ifc-lite/query
+
+## 1.2.1
+
+### Patch Changes
+
+- Version sync with @ifc-lite packages

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/query",
-  "version": "1.1.7",
+  "version": "1.2.1",
   "description": "Query system for IFC-Lite",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/renderer/CHANGELOG.md
+++ b/packages/renderer/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @ifc-lite/renderer
 
+## 1.2.1
+
+### Patch Changes
+
+- bd6dccd: Fix section plane activation and clipping behavior.
+  - Section plane now only active when Section tool is selected
+  - Fixed section plane bounds to use model geometry bounds
+  - Simplified section plane axis to x/y/z coordinates
+  - Fixed visual section plane rendering with proper depth testing
+- bd6dccd: Add magnetic edge snapping to measure tool.
+  - New raycastSceneMagnetic API for edge-aware snapping
+  - Edge lock state management for "stick and slide" behavior
+  - Corner detection with valence tracking
+  - Smooth snapping transitions along edges
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/renderer",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "WebGPU renderer for IFC-Lite",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/server-bin/CHANGELOG.md
+++ b/packages/server-bin/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @ifc-lite/server-bin
+
+## 1.2.1
+
+### Patch Changes
+
+- Version sync with @ifc-lite packages

--- a/packages/server-bin/package.json
+++ b/packages/server-bin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/server-bin",
-  "version": "1.1.8",
+  "version": "1.2.1",
   "description": "Pre-built IFC-Lite server binary - run without Docker or Rust",
   "type": "module",
   "bin": {

--- a/packages/server-client/CHANGELOG.md
+++ b/packages/server-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ifc-lite/server-client
 
+## 1.2.1
+
+### Patch Changes
+
+- Version sync with @ifc-lite packages
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/server-client/package.json
+++ b/packages/server-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/server-client",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "TypeScript client SDK for IFC-Lite Server",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/spatial/CHANGELOG.md
+++ b/packages/spatial/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @ifc-lite/spatial
+
+## 1.2.1
+
+### Patch Changes
+
+- Version sync with @ifc-lite packages

--- a/packages/spatial/package.json
+++ b/packages/spatial/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifc-lite/spatial",
-  "version": "1.1.7",
+  "version": "1.2.1",
   "description": "Spatial indexing for IFC-Lite",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/wasm/CHANGELOG.md
+++ b/packages/wasm/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ifc-lite/wasm
 
+## 1.2.1
+
+### Patch Changes
+
+- Version sync with @ifc-lite packages
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -5,7 +5,7 @@
     "IFC-Lite Contributors"
   ],
   "description": "WebAssembly bindings for IFC-Lite",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MPL-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bump all @ifc-lite/* packages to 1.2.1:
- @ifc-lite/renderer: Section plane fixes, magnetic edge snapping
- @ifc-lite/parser: Ubuntu setup fixes
- All other @ifc-lite/* packages synced to 1.2.1

Also bumps create-ifc-lite to 1.1.8