### PR TITLE
Fix desktop build: Add default export to App.tsx

### DIFF
--- a/apps/viewer/src/App.tsx
+++ b/apps/viewer/src/App.tsx
@@ -11,3 +11,5 @@ import { ViewerLayout } from './components/viewer/ViewerLayout';
 export function App() {
   return <ViewerLayout />;
 }
+
+export default App;


### PR DESCRIPTION
The desktop app imports App from '@/App' expecting a default export, but App.tsx only had a named export. This caused the build to fail with: "default" is not exported by "../viewer/src/App.tsx"

Added `export default App` to support both named and default imports.