### PR TITLE
docs: fix incorrect parseStreaming() reference in performance tips

### DIFF
--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -383,7 +383,7 @@ try {
 
 1. **Use columnar parsing** - `parseColumnar()` is faster than `parse()`
 2. **Use Web Workers** - Import from `@ifc-lite/parser/browser` for non-blocking parsing
-3. **Stream large files** - Use `parseStreaming()` for progressive geometry
+3. **Track progress** - Use `onProgress` callback with `parseColumnar()` for loading feedback
 
 ### Server-Side
 


### PR DESCRIPTION
Replace non-existent parseStreaming() with guidance to use parseColumnar() with onProgress callback for loading feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated performance tips in the quickstart guide with revised guidance on data loading optimization techniques.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->