### PR TITLE
Enhance documentation for IFC data exporting and CDN usage

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -289,13 +289,35 @@ For quick prototyping without a build step:
 
 ```html
 <script type="module">
-  import { IfcParser } from 'https://esm.sh/@ifc-lite/parser';
-  import { Renderer } from 'https://esm.sh/@ifc-lite/renderer';
+  import { IfcParser } from 'https://cdn.jsdelivr.net/npm/@ifc-lite/parser@1.2.1/+esm';
 
   const parser = new IfcParser();
-  // ... your code
+  const response = await fetch('model.ifc');
+  const buffer = await response.arrayBuffer();
+  const store = await parser.parseColumnar(buffer);
+  console.log('Entities:', store.entityCount);
 </script>
 ```
+
+For geometry processing with WASM, you must initialize the WASM module explicitly:
+
+```html
+<script type="module">
+  import { GeometryProcessor } from 'https://cdn.jsdelivr.net/npm/@ifc-lite/geometry@1.2.1/+esm';
+  import initWasm from 'https://cdn.jsdelivr.net/npm/@ifc-lite/wasm@1.2.1/+esm';
+
+  // Initialize WASM with explicit path (required for CDN)
+  const wasmUrl = 'https://cdn.jsdelivr.net/npm/@ifc-lite/wasm@1.2.1/pkg/ifc-lite_bg.wasm';
+  await initWasm({ module_or_path: wasmUrl });
+
+  const processor = new GeometryProcessor();
+  await processor.init();
+  // ... process geometry
+</script>
+```
+
+!!! note "HTTP Server Required"
+    CDN examples must be served from an HTTP server (not `file://`). Use `npx serve .` or `python -m http.server`.
 
 !!! warning "Production Usage"
     For production applications, install packages locally rather than using CDN links.

--- a/packages/geometry/src/ifc-lite-bridge.ts
+++ b/packages/geometry/src/ifc-lite-bridge.ts
@@ -50,7 +50,7 @@ export class IfcLiteBridge {
    * Initialize IFC-Lite WASM
    * The WASM binary is automatically resolved from the same location as the JS module
    */
-  async init(_wasmPath?: string): Promise<void> {
+  async init(): Promise<void> {
     if (this.initialized) return;
 
     // Initialize WASM module - wasm-bindgen automatically resolves the WASM URL

--- a/packages/geometry/src/index.ts
+++ b/packages/geometry/src/index.ts
@@ -139,7 +139,7 @@ export class GeometryProcessor {
    * In Tauri: Creates platform bridge for native Rust processing
    * In browser: Loads WASM
    */
-  async init(_wasmPath?: string): Promise<void> {
+  async init(): Promise<void> {
     if (this.isNative) {
       // Create platform bridge for native processing
       this.platformBridge = await createPlatformBridge();


### PR DESCRIPTION
- Added a new section for quick start CDN export, providing a complete HTML example for exporting IFC to GLB directly in the browser without a build step.
- Updated installation guide to include explicit WASM initialization for geometry processing with CDN links.
- Emphasized the requirement of serving examples from an HTTP server for proper functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added quick-start guide for CDN-based IFC to GLB export with code examples
  * Updated CDN integration examples with explicit WASM initialization
  * Added HTTP server requirement note for CDN usage

* **Refactor**
  * Simplified geometry processing initialization

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->