### PR TITLE
Fix glob pattern matching in test script for bash

### DIFF
--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "NODE_OPTIONS='--max-old-space-size=4096' bash -c '(tsc || true) && vite build'",
     "preview": "vite preview",
-    "test": "tsx --test src/**/*.test.ts"
+    "test": "bash -c 'shopt -s globstar && tsx --test src/**/*.test.ts'"
   },
   "dependencies": {
     "@ifc-lite/cache": "workspace:^",


### PR DESCRIPTION
## Summary
Updated the test script in the viewer package to properly handle glob patterns across different bash environments by explicitly enabling the `globstar` option.

## Changes
- Modified the `test` script in `apps/viewer/package.json` to wrap the tsx command in a bash shell with `globstar` option enabled
- This ensures the `**` glob pattern in `src/**/*.test.ts` is correctly expanded to match test files in nested directories

## Details
The previous command relied on the shell's default glob expansion behavior, which may not work consistently across different bash configurations or environments. By explicitly running `bash -c 'shopt -s globstar && ...'`, we ensure that:
- The `**` pattern correctly matches files in all subdirectories recursively
- The behavior is consistent regardless of the user's shell configuration
- Test discovery works reliably in CI/CD environments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test runner configuration to improve recursive test file discovery.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->