### PR TITLE
fix: update viewer tests to match implementation

### DIFF
--- a/apps/viewer/src/store/slices/selectionSlice.test.ts
+++ b/apps/viewer/src/store/slices/selectionSlice.test.ts
@@ -46,11 +46,15 @@ describe('SelectionSlice', () => {
       assert.deepStrictEqual(state.selectedEntity, ref);
     });
 
-    it('should update legacy selectedEntityId for backward compatibility', () => {
+    it('should NOT update selectedEntityId (caller must use setSelectedEntityId for global ID)', () => {
+      // NOTE: selectedEntityId holds the GLOBAL ID for renderer highlighting,
+      // while selectedEntity.expressId holds the ORIGINAL express ID for property lookup.
+      // The caller should use setSelectedEntityId(globalId) separately.
       const ref: EntityRef = { modelId: 'model-1', expressId: 456 };
       state.setSelectedEntity(ref);
 
-      assert.strictEqual(state.selectedEntityId, 456);
+      // selectedEntityId should remain null - caller must set it separately with globalId
+      assert.strictEqual(state.selectedEntityId, null);
     });
 
     it('should allow clearing selection with null', () => {

--- a/apps/viewer/src/store/types.test.ts
+++ b/apps/viewer/src/store/types.test.ts
@@ -65,8 +65,8 @@ describe('EntityRef utilities', () => {
       const result = stringToEntityRef('model:with:colons:123');
       assert.strictEqual(result.modelId, 'model');
       // The rest including colons becomes part of what's parsed as expressId
-      // "with:colons:123" parsed as Number results in NaN
-      assert.ok(Number.isNaN(result.expressId), 'expressId should be NaN when parsing invalid number');
+      // "with:colons:123" parsed as Number results in NaN, which is converted to -1
+      assert.strictEqual(result.expressId, -1, 'expressId should be -1 when parsing invalid number');
     });
   });
 


### PR DESCRIPTION
- types.test.ts: stringToEntityRef returns -1 for invalid expressIds, not NaN
- selectionSlice.test.ts: setSelectedEntity does not update selectedEntityId (caller must use setSelectedEntityId for global ID separately)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated entity selection behavior validation to reflect refined selection handling
  * Modified identifier validation to consistently represent invalid numeric values as -1

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->