### PR TITLE
fix: remove ignored viewer package from changeset

### DIFF
--- a/.changeset/ifc5-federated-loading.md
+++ b/.changeset/ifc5-federated-loading.md
@@ -1,5 +1,4 @@
 ---
-"@ifc-lite/viewer": minor
 "@ifc-lite/ifcx": minor
 "@ifc-lite/parser": minor
 "@ifc-lite/renderer": patch


### PR DESCRIPTION
The @ifc-lite/viewer package is in the changeset ignore list, so it cannot be included in changesets alongside non-ignored packages. This was causing a "mixed changeset" error in CI.