### PR TITLE
Add PolygonalFaceSetProcessor and new geometry processors for enhanced IFC support

### DIFF
--- a/.changeset/add-polygonal-face-set-processor.md
+++ b/.changeset/add-polygonal-face-set-processor.md
@@ -1,0 +1,19 @@
+---
+"@ifc-lite/wasm": minor
+"@ifc-lite/geometry": minor
+---
+
+Add PolygonalFaceSetProcessor and surface model processors for improved geometry support
+
+### New Geometry Processors
+- **PolygonalFaceSetProcessor**: Handle IfcPolygonalFaceSet with triangulation of arbitrary polygons
+- **FaceBasedSurfaceModelProcessor**: Process IfcFaceBasedSurfaceModel geometry
+- **SurfaceOfLinearExtrusionProcessor**: Handle IfcSurfaceOfLinearExtrusion surfaces
+- **ShellBasedSurfaceModelProcessor**: Process IfcShellBasedSurfaceModel geometry
+
+### Performance Optimizations
+- Add fast-path decoder functions with point caching for BREP-heavy files (~2x faster)
+- Add `get_first_entity_ref_fast`, `get_polyloop_coords_fast`, `get_polyloop_coords_cached`
+- Add `has_non_null_attribute()` for fast attribute filtering
+- Optimize FacetedBrep with fast-path using `get_face_bound_fast`
+- Add WASM-specific sequential iteration to avoid threading overhead


### PR DESCRIPTION
This commit introduces the PolygonalFaceSetProcessor to handle IfcPolygonalFaceSet with triangulation of arbitrary polygons, along with several new surface model processors: FaceBasedSurfaceModelProcessor, SurfaceOfLinearExtrusionProcessor, and ShellBasedSurfaceModelProcessor.

Additionally, performance optimizations have been implemented, including fast-path decoder functions with point caching for BREP-heavy files, resulting in approximately 2x faster processing. New functions such as get_first_entity_ref_fast and has_non_null_attribute() have been added to improve efficiency in geometry handling.

These changes significantly enhance the geometry processing capabilities of the IFC-Lite project, improving both functionality and performance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added advanced geometry processors for handling polygonal face sets and surface models with improved geometry recognition.

* **Performance**
  * Optimized geometry processing with enhanced caching strategies for dense BREP models and heavy geometry files.
  * Reduced computational overhead in WebAssembly environments through sequential iteration optimization.

* **Chores**
  * Minor version updates to @ifc-lite/wasm and @ifc-lite/geometry packages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->