### PR TITLE
fix: sync npm and rust crate versions correctly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,16 +68,20 @@ jobs:
         id: get-version
         if: steps.changesets.outputs.published == 'true'
         run: |
-          VERSION=$(node -p "require('./package.json').version")
+          # Read version from @ifc-lite/wasm since that's the authoritative source
+          # (changesets updates individual packages but not the private workspace root)
+          VERSION=$(node -p "require('./packages/wasm/package.json').version")
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
         if: steps.changesets.outputs.published == 'true'
         run: |
+          # Create the v* tag (changesets creates @scope/package@version tags, not v* tags)
+          git tag "v${{ steps.get-version.outputs.version }}" || true
+          git push origin "v${{ steps.get-version.outputs.version }}" || true
           gh release create "v${{ steps.get-version.outputs.version }}" \
             --title "v${{ steps.get-version.outputs.version }}" \
-            --notes "See CHANGELOG.md for details" \
-            --verify-tag
+            --notes "See CHANGELOG.md for details"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["rust/core", "rust/geometry", "rust/wasm-bindings", "apps/server", "a
 resolver = "2"
 
 [workspace.package]
-version = "1.2.1"
+version = "1.3.0"
 edition = "2021"
 authors = ["IFC-Lite Contributors"]
 license = "MPL-2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ifc-lite",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "High-performance browser IFC parser & renderer",
   "private": true,
   "type": "module",


### PR DESCRIPTION
- Fix sync-versions.js to read from packages/wasm/package.json instead of root (changesets updates individual packages but not private workspace root)
- Fix release.yml to read version from wasm package and create v* tags (changesets creates @scope/package@version tags, not v* tags)
- Sync root package.json and Cargo.toml to 1.3.0 to match npm packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 1.3.0 across all packages and build configurations.
  * Release process enhanced with improved version synchronization and automation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->