### PR TITLE
Fix camera pan direction and simplify keyboard controls

### DIFF
--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -1409,17 +1409,17 @@ export function Viewport({ geometry, coordinateInfo, computedIsolatedIds, modelI
         const zoomSpeed = 0.1;
 
         if (firstPersonModeRef.current) {
-          // Arrow keys only for first-person navigation
-          if (keyState['arrowup']) { camera.moveFirstPerson(1, 0, 0); moved = true; }
-          if (keyState['arrowdown']) { camera.moveFirstPerson(-1, 0, 0); moved = true; }
-          if (keyState['arrowleft']) { camera.moveFirstPerson(0, -1, 0); moved = true; }
-          if (keyState['arrowright']) { camera.moveFirstPerson(0, 1, 0); moved = true; }
+          // Arrow keys for first-person navigation (camera-relative)
+          if (keyState['arrowup']) { camera.moveFirstPerson(-1, 0, 0); moved = true; }
+          if (keyState['arrowdown']) { camera.moveFirstPerson(1, 0, 0); moved = true; }
+          if (keyState['arrowleft']) { camera.moveFirstPerson(0, 1, 0); moved = true; }
+          if (keyState['arrowright']) { camera.moveFirstPerson(0, -1, 0); moved = true; }
         } else {
-          // Arrow keys only for panning
-          if (keyState['arrowup']) { camera.pan(0, panSpeed, false); moved = true; }
-          if (keyState['arrowdown']) { camera.pan(0, -panSpeed, false); moved = true; }
-          if (keyState['arrowleft']) { camera.pan(-panSpeed, 0, false); moved = true; }
-          if (keyState['arrowright']) { camera.pan(panSpeed, 0, false); moved = true; }
+          // Arrow keys for panning (camera-relative: arrow direction = camera movement)
+          if (keyState['arrowup']) { camera.pan(0, -panSpeed, false); moved = true; }
+          if (keyState['arrowdown']) { camera.pan(0, panSpeed, false); moved = true; }
+          if (keyState['arrowleft']) { camera.pan(panSpeed, 0, false); moved = true; }
+          if (keyState['arrowright']) { camera.pan(-panSpeed, 0, false); moved = true; }
         }
 
         if (moved) {


### PR DESCRIPTION
## Summary
This PR fixes the camera pan direction to match user expectations and simplifies keyboard controls by removing WASD key bindings in favor of arrow keys only.

## Key Changes
- **Fixed pan direction**: Negated the `dy` parameter in mouse pan operations so that upward mouse movement pans the camera upward (previously inverted)
- **Simplified keyboard controls**: Removed WASD key bindings (`w`, `a`, `s`, `d`, `q`, `e`) from both first-person and pan modes, keeping only arrow key navigation
  - First-person mode now uses only arrow keys for movement
  - Pan mode now uses only arrow keys for camera panning
  - Removed zoom controls (`q`/`e` keys) in pan mode

## Implementation Details
- The pan direction fix addresses the unintuitive behavior where dragging the mouse upward would pan the camera downward
- The keyboard control simplification reduces complexity and potential key binding conflicts while maintaining core navigation functionality through arrow keys
- First-person mode retains its directional movement with arrow keys
- Pan mode retains its directional panning with arrow keys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed panning to correctly handle vertical drag direction.
  * First-person navigation now uses arrow keys exclusively for movement.
  * Non-first-person modes now use arrow keys for camera-relative panning; previous WASD/QE bindings removed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->