### PR TITLE
fix: add --passWithNoTests for packages without test files

### DIFF
--- a/packages/drawing-2d/package.json
+++ b/packages/drawing-2d/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "test": "vitest run"
+    "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
     "@ifc-lite/geometry": "workspace:^"

--- a/packages/mutations/package.json
+++ b/packages/mutations/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "test": "vitest run"
+    "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
     "@ifc-lite/data": "workspace:^",


### PR DESCRIPTION
drawing-2d and mutations have no test files yet, causing vitest to exit with code 1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test configuration scripts to support successful test execution when no tests are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->