### PR TITLE
feat: add version, build date, and release history to viewer UI

### DIFF
--- a/apps/viewer/src/components/viewer/StatusBar.tsx
+++ b/apps/viewer/src/components/viewer/StatusBar.tsx
@@ -142,6 +142,10 @@ export function StatusBar() {
             {webgpu.checking ? 'Checking...' : webgpu.supported ? 'WebGPU' : 'No WebGPU'}
           </span>
         </div>
+
+        <Separator orientation="vertical" className="h-3.5" />
+
+        <span className="opacity-60">v{__APP_VERSION__}</span>
       </div>
     </div>
   );

--- a/apps/viewer/src/vite-env.d.ts
+++ b/apps/viewer/src/vite-env.d.ts
@@ -8,9 +8,16 @@ interface ImportMetaEnv {
   readonly VITE_IFC_SERVER_URL?: string;
   readonly VITE_SERVER_URL?: string;
   readonly VITE_USE_SERVER?: string;
-  // Add more env variables as needed
 }
 
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+// Build-time constants injected by Vite define
+declare const __APP_VERSION__: string;
+declare const __BUILD_DATE__: string;
+declare const __RELEASE_HISTORY__: Array<{
+  version: string;
+  highlights: Array<{ type: 'feature' | 'fix' | 'perf'; text: string }>;
+}>;

--- a/apps/viewer/vite.config.ts
+++ b/apps/viewer/vite.config.ts
@@ -3,6 +3,159 @@ import react from '@vitejs/plugin-react';
 import wasm from 'vite-plugin-wasm';
 import topLevelAwait from 'vite-plugin-top-level-await';
 import path from 'path';
+import fs from 'fs';
+
+// --- Build-time changelog parser ---
+
+interface ReleaseHighlight {
+  type: 'feature' | 'fix' | 'perf';
+  text: string;
+}
+
+interface Release {
+  version: string;
+  highlights: ReleaseHighlight[];
+}
+
+const SKIP_BOLD_LOWER = new Set([
+  'bug fixes', 'new features', 'performance improvements', 'technical details',
+  'renderer fixes', 'parser fixes', 'viewer integration', 'fixes', 'features',
+  'breaking', 'minor changes', 'patch changes', 'dependencies',
+]);
+
+function isInternalName(text: string): boolean {
+  // Skip PascalCase single-word class names like "PolygonalFaceSetProcessor"
+  return /^[A-Z][a-zA-Z]+$/.test(text) && !text.includes(' ');
+}
+
+function categorizeHighlight(text: string): 'feature' | 'fix' | 'perf' {
+  const lower = text.toLowerCase();
+  if (lower.startsWith('fixed ') || lower.startsWith('fix ')) return 'fix';
+  if (
+    lower.includes('performance') || lower.includes('optimiz') ||
+    lower.includes('zero-copy') || lower.includes('faster') ||
+    lower.includes('batch siz')
+  ) return 'perf';
+  return 'feature';
+}
+
+function extractBulletDescription(line: string): string | null {
+  let text = line.replace(/^-\s+/, '');
+
+  // Pattern: "HASH: ### Header" -> skip inline section headers
+  if (/^[a-f0-9]{7,}:\s*###/.test(text)) return null;
+
+  // Pattern: "HASH: feat/fix/perf: DESCRIPTION"
+  const hashPrefixed = text.match(/^[a-f0-9]{7,}:\s*(?:feat|fix|perf|refactor|chore):\s*(.+)$/i);
+  if (hashPrefixed) return hashPrefixed[1].trim();
+
+  // Pattern: "HASH: DESCRIPTION" (without conventional commit prefix)
+  const hashOnly = text.match(/^[a-f0-9]{7,}:\s*(.+)$/);
+  if (hashOnly) return hashOnly[1].trim();
+
+  // Pattern: "[#PR](url) [`hash`](url) Thanks @user! - DESCRIPTION"
+  const prPattern = text.match(/Thanks\s+\[@[^\]]+\]\([^)]+\)!\s*-\s*(.+)$/);
+  if (prPattern) return prPattern[1].trim();
+
+  return null;
+}
+
+function compareSemver(a: string, b: string): number {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] - pb[i];
+  }
+  return 0;
+}
+
+function parseChangelogs(): Release[] {
+  const packagesDir = path.resolve(__dirname, '../../packages');
+  let dirs: string[];
+  try {
+    dirs = fs.readdirSync(packagesDir);
+  } catch {
+    return [];
+  }
+
+  const versionMap = new Map<string, Map<string, ReleaseHighlight>>();
+  const seenVersionsPerFile = new Map<string, Set<string>>();
+
+  for (const dir of dirs) {
+    const changelogPath = path.join(packagesDir, dir, 'CHANGELOG.md');
+    if (!fs.existsSync(changelogPath)) continue;
+
+    const content = fs.readFileSync(changelogPath, 'utf-8');
+    const fileKey = dir;
+    seenVersionsPerFile.set(fileKey, new Set());
+
+    // Split into version blocks
+    const versionBlocks = content.split(/^## /m).slice(1);
+
+    for (const block of versionBlocks) {
+      const versionMatch = block.match(/^(\d+\.\d+\.\d+)/);
+      if (!versionMatch) continue;
+      const version = versionMatch[1];
+
+      // Skip duplicate version sections within same file
+      if (seenVersionsPerFile.get(fileKey)!.has(version)) continue;
+      seenVersionsPerFile.get(fileKey)!.add(version);
+
+      if (!versionMap.has(version)) {
+        versionMap.set(version, new Map());
+      }
+      const highlights = versionMap.get(version)!;
+
+      const lines = block.split('\n');
+
+      // 1) Extract top-level bullet descriptions (lines starting with "- " at root indent)
+      for (const line of lines) {
+        if (!line.startsWith('- ')) continue;
+        if (line.startsWith('- Updated dependencies')) continue;
+
+        const desc = extractBulletDescription(line);
+        if (desc && desc.length >= 10) {
+          const key = desc.toLowerCase().substring(0, 60);
+          if (!highlights.has(key)) {
+            highlights.set(key, { type: categorizeHighlight(desc), text: desc });
+          }
+        }
+      }
+
+      // 2) Extract bold items as highlights (nested feature names)
+      const boldRegex = /\*\*([^*]+)\*\*/g;
+      let match;
+      while ((match = boldRegex.exec(block)) !== null) {
+        let text = match[1].trim();
+        if (text.endsWith(':')) text = text.slice(0, -1);
+        if (text.includes('@ifc-lite/')) continue;
+        if (SKIP_BOLD_LOWER.has(text.toLowerCase())) continue;
+        if (text.length < 10) continue;
+        if (isInternalName(text)) continue;
+
+        const key = text.toLowerCase().substring(0, 60);
+        if (!highlights.has(key)) {
+          highlights.set(key, { type: categorizeHighlight(text), text });
+        }
+      }
+    }
+  }
+
+  const MAX_HIGHLIGHTS_PER_VERSION = 12;
+
+  return Array.from(versionMap.entries())
+    .sort((a, b) => compareSemver(b[0], a[0]))
+    .map(([version, highlights]) => ({
+      version,
+      highlights: Array.from(highlights.values()).slice(0, MAX_HIGHLIGHTS_PER_VERSION),
+    }))
+    .filter((r) => r.highlights.length > 0);
+}
+
+// Read version from root package.json
+const rootPkg = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, '../../package.json'), 'utf-8')
+);
 
 export default defineConfig({
   plugins: [
@@ -10,6 +163,11 @@ export default defineConfig({
     wasm(),
     topLevelAwait(),
   ],
+  define: {
+    __APP_VERSION__: JSON.stringify(rootPkg.version),
+    __BUILD_DATE__: JSON.stringify(new Date().toISOString()),
+    __RELEASE_HISTORY__: JSON.stringify(parseChangelogs()),
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
- Replace hardcoded version with build-time injection from root package.json
- Add build date display in About tab
- Add "What's New" tab with auto-parsed changelog highlights from all packages
- Show version in StatusBar (bottom right, subtle)
- Changelog parser runs at build time via Vite define, extracts and deduplicates highlights across all package CHANGELOG.md files (capped at 12 per release)
- Shows 5 most recent releases by default with "Show all" expand button
- Color-coded icons: green=feature, amber=fix, blue=perf

fixes #164 
<img width="625" height="650" alt="image" src="https://github.com/user-attachments/assets/5558aa7d-279b-4d0f-9711-6df19e41e744" />
