### PR TITLE
Add embeddable IFC viewer with postMessage protocol

### DIFF
--- a/apps/viewer-embed/index.html
+++ b/apps/viewer-embed/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>IFC-Lite Embed</title>
+  <style>
+    /* Minimal inline styles - no Tailwind dependency for the shell */
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body, #root { width: 100%; height: 100%; overflow: hidden; }
+    body { font-family: system-ui, -apple-system, sans-serif; }
+    html.dark body { background: #1a1b26; color: #a9b1d6; }
+    html.light body, html:not(.dark) body { background: #ffffff; color: #1a1b26; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+</html>

--- a/apps/viewer-embed/package.json
+++ b/apps/viewer-embed/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@ifc-lite/viewer-embed",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Embeddable IFC-Lite 3D viewer for iframes (Power BI, Superset, etc.)",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "NODE_OPTIONS='--max-old-space-size=4096' bash -c '(tsc || true) && vite build'",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@ifc-lite/bcf": "workspace:^",
+    "@ifc-lite/cache": "workspace:^",
+    "@ifc-lite/data": "workspace:^",
+    "@ifc-lite/drawing-2d": "workspace:^",
+    "@ifc-lite/embed-protocol": "workspace:^",
+    "@ifc-lite/export": "workspace:^",
+    "@ifc-lite/geometry": "workspace:^",
+    "@ifc-lite/ids": "workspace:^",
+    "@ifc-lite/ifcx": "workspace:^",
+    "@ifc-lite/mutations": "workspace:^",
+    "@ifc-lite/parser": "workspace:^",
+    "@ifc-lite/query": "workspace:^",
+    "@ifc-lite/renderer": "workspace:^",
+    "@ifc-lite/server-client": "workspace:^",
+    "@ifc-lite/spatial": "workspace:^",
+    "@ifc-lite/wasm": "workspace:^",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "zustand": "^4.4.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.2.0",
+    "typescript": "^5.3.0",
+    "vite": "^5.0.0",
+    "vite-plugin-top-level-await": "^1.6.0",
+    "vite-plugin-wasm": "^3.5.0"
+  }
+}

--- a/apps/viewer-embed/src/bridge/handler.ts
+++ b/apps/viewer-embed/src/bridge/handler.ts
@@ -1,0 +1,351 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Inbound postMessage command handler.
+ *
+ * Receives commands from the parent SDK and dispatches them to the store
+ * and renderer. Also handles the READY → INIT → INIT_ACK handshake.
+ */
+
+import {
+  isEmbedMessage,
+  createResponse,
+  createEvent,
+  EMBED_SOURCE,
+  PROTOCOL_VERSION,
+  type EmbedMessageEnvelope,
+  type InboundCommandType,
+  type InboundPayloads,
+  type ModelInfo,
+  type ViewPreset,
+  type SectionAxis,
+} from '@ifc-lite/embed-protocol';
+import type { ViewerState } from '@/store/index.js';
+
+/** Reference to the store's getState / setState for imperative access */
+interface BridgeContext {
+  getState: () => ViewerState;
+  /** Callback to load a model from URL (async) */
+  loadModelFromUrl: (url: string) => Promise<{ entities: number; triangles: number; vertices: number }>;
+  /** Callback to load a model from ArrayBuffer */
+  loadModelFromBuffer: (buffer: ArrayBuffer, name?: string) => Promise<{ entities: number; triangles: number; vertices: number }>;
+}
+
+let ctx: BridgeContext | null = null;
+let parentOrigin: string = '*';
+
+/** Initialize the bridge with store and callback references */
+export function initBridge(context: BridgeContext) {
+  ctx = context;
+  window.addEventListener('message', onMessage);
+
+  // Send READY event to parent
+  emitToParent(createEvent('READY', { version: PROTOCOL_VERSION }));
+}
+
+/** Clean up the bridge */
+export function destroyBridge() {
+  window.removeEventListener('message', onMessage);
+  ctx = null;
+}
+
+/** Emit an event to the parent window */
+export function emitToParent(msg: EmbedMessageEnvelope, transfer?: Transferable[]) {
+  if (window.parent === window) return; // Not in an iframe
+  window.parent.postMessage(msg, parentOrigin, transfer ?? []);
+}
+
+/** Emit a typed event to the parent */
+export function emitEvent(type: string, data?: unknown) {
+  emitToParent({
+    source: EMBED_SOURCE,
+    version: PROTOCOL_VERSION,
+    type,
+    data,
+  });
+}
+
+// ---- Internal message handler ----
+
+function onMessage(event: MessageEvent) {
+  if (!isEmbedMessage(event.data)) return;
+  if (!ctx) return;
+
+  const msg = event.data as EmbedMessageEnvelope;
+
+  // Track parent origin for responses (but accept * initially for handshake)
+  if (event.origin && event.origin !== 'null') {
+    parentOrigin = event.origin;
+  }
+
+  const { type, requestId, data } = msg;
+
+  // Handle commands with request/response pattern
+  if (requestId) {
+    handleCommand(type as InboundCommandType, data, requestId).catch((err) => {
+      emitToParent(createResponse(requestId, undefined, {
+        code: 'COMMAND_FAILED',
+        message: err instanceof Error ? err.message : String(err),
+      }));
+    });
+    return;
+  }
+
+  // Handle fire-and-forget commands (no requestId)
+  handleCommand(type as InboundCommandType, data).catch(() => {
+    // Silently ignore errors on fire-and-forget commands
+  });
+}
+
+async function handleCommand(type: InboundCommandType, data: unknown, requestId?: string) {
+  if (!ctx) throw new Error('Bridge not initialized');
+  const state = ctx.getState();
+
+  switch (type) {
+    case 'INIT': {
+      const payload = data as InboundPayloads['INIT'];
+      // Apply initial config if provided
+      if (payload?.config?.theme) state.setTheme(payload.config.theme);
+      // ACK the init
+      if (requestId) {
+        emitToParent(createResponse(requestId));
+      }
+      emitEvent('INIT_ACK');
+      return;
+    }
+
+    case 'LOAD_MODEL': {
+      const payload = data as InboundPayloads['LOAD_MODEL'];
+      const stats = await ctx.loadModelFromUrl(payload.url);
+      if (requestId) emitToParent(createResponse(requestId, stats));
+      return;
+    }
+
+    case 'LOAD_MODEL_BUFFER': {
+      const buffer = data as ArrayBuffer;
+      const stats = await ctx.loadModelFromBuffer(buffer);
+      if (requestId) emitToParent(createResponse(requestId, stats));
+      return;
+    }
+
+    case 'ADD_MODEL': {
+      const payload = data as InboundPayloads['ADD_MODEL'];
+      const stats = await ctx.loadModelFromUrl(payload.url);
+      if (requestId) emitToParent(createResponse(requestId, { modelId: 'latest', ...stats }));
+      return;
+    }
+
+    case 'REMOVE_MODEL': {
+      const payload = data as InboundPayloads['REMOVE_MODEL'];
+      state.removeModel(payload.modelId);
+      if (requestId) emitToParent(createResponse(requestId));
+      return;
+    }
+
+    case 'SELECT': {
+      const payload = data as InboundPayloads['SELECT'];
+      if (payload.ids.length === 0) {
+        state.clearEntitySelection();
+      } else {
+        state.setSelectedEntityId(payload.ids[0]);
+        state.setSelectedEntityIds(payload.ids);
+      }
+      if (requestId) emitToParent(createResponse(requestId));
+      return;
+    }
+
+    case 'SELECT_BY_GUID': {
+      const payload = data as InboundPayloads['SELECT_BY_GUID'];
+      // Search all models for matching GlobalId attributes
+      const resolved: number[] = [];
+      for (const [, model] of state.models) {
+        const ds = model.ifcDataStore;
+        if (!ds?.entities) continue;
+        for (let i = 0; i < ds.entities.count; i++) {
+          const attrs = ds.entities.getAttributes?.(i);
+          if (attrs && payload.guids.includes(String(attrs.GlobalId))) {
+            resolved.push(i + model.idOffset);
+          }
+        }
+      }
+      if (resolved.length > 0) {
+        state.setSelectedEntityId(resolved[0]);
+        state.setSelectedEntityIds(resolved);
+      }
+      if (requestId) emitToParent(createResponse(requestId, { resolved }));
+      return;
+    }
+
+    case 'CLEAR_SELECTION': {
+      state.clearEntitySelection();
+      if (requestId) emitToParent(createResponse(requestId));
+      return;
+    }
+
+    case 'ISOLATE': {
+      const payload = data as InboundPayloads['ISOLATE'];
+      state.isolateEntities(payload.ids);
+      if (requestId) emitToParent(createResponse(requestId));
+      return;
+    }
+
+    case 'HIDE': {
+      const payload = data as InboundPayloads['HIDE'];
+      state.hideEntities(payload.ids);
+      if (requestId) emitToParent(createResponse(requestId));
+      return;
+    }
+
+    case 'SHOW': {
+      const payload = data as InboundPayloads['SHOW'];
+      state.showEntities(payload.ids);
+      if (requestId) emitToParent(createResponse(requestId));
+      return;
+    }
+
+    case 'SHOW_ALL': {
+      state.showAllInAllModels();
+      if (requestId) emitToParent(createResponse(requestId));
+      return;
+    }
+
+    case 'SET_COLORS': {
+      const payload = data as InboundPayloads['SET_COLORS'];
+      const updates = new Map<number, [number, number, number, number]>();
+      for (const [key, color] of Object.entries(payload.colorMap)) {
+        updates.set(Number(key), color);
+      }
+      state.updateMeshColors(updates);
+      if (requestId) emitToParent(createResponse(requestId));
+      return;
+    }
+
+    case 'RESET_COLORS': {
+      state.clearPendingColorUpdates();
+      if (requestId) emitToParent(createResponse(requestId));
+      return;
+    }
+
+    case 'FIT_TO_VIEW': {
+      const payload = data as InboundPayloads['FIT_TO_VIEW'];
+      if (payload?.ids && payload.ids.length > 0) {
+        state.setSelectedEntityIds(payload.ids);
+        state.cameraCallbacks.frameSelection?.();
+      } else {
+        state.cameraCallbacks.fitAll?.();
+      }
+      if (requestId) emitToParent(createResponse(requestId));
+      return;
+    }
+
+    case 'SET_CAMERA': {
+      const payload = data as InboundPayloads['SET_CAMERA'];
+      state.setCameraRotation({ azimuth: payload.azimuth, elevation: payload.elevation });
+      if (requestId) emitToParent(createResponse(requestId));
+      return;
+    }
+
+    case 'SET_VIEW': {
+      const payload = data as InboundPayloads['SET_VIEW'];
+      state.cameraCallbacks.setPresetView?.(payload.preset as ViewPreset);
+      if (requestId) emitToParent(createResponse(requestId));
+      return;
+    }
+
+    case 'SET_SECTION': {
+      const payload = data as InboundPayloads['SET_SECTION'];
+      if (payload.axis !== undefined) state.setSectionPlaneAxis(payload.axis as SectionAxis);
+      if (payload.position !== undefined) state.setSectionPlanePosition(payload.position);
+      if (payload.enabled !== undefined) {
+        const current = state.sectionPlane.enabled;
+        if (current !== payload.enabled) state.toggleSectionPlane();
+      }
+      if (payload.flipped !== undefined) {
+        const current = state.sectionPlane.flipped;
+        if (current !== payload.flipped) state.flipSectionPlane();
+      }
+      if (requestId) emitToParent(createResponse(requestId));
+      return;
+    }
+
+    case 'SET_THEME': {
+      const payload = data as InboundPayloads['SET_THEME'];
+      state.setTheme(payload.theme);
+      if (requestId) emitToParent(createResponse(requestId));
+      return;
+    }
+
+    case 'SET_TYPE_VISIBILITY': {
+      const payload = data as InboundPayloads['SET_TYPE_VISIBILITY'];
+      const tv = state.typeVisibility;
+      if (payload.spaces !== undefined && tv.spaces !== payload.spaces) state.toggleTypeVisibility('spaces');
+      if (payload.openings !== undefined && tv.openings !== payload.openings) state.toggleTypeVisibility('openings');
+      if (payload.site !== undefined && tv.site !== payload.site) state.toggleTypeVisibility('site');
+      if (requestId) emitToParent(createResponse(requestId));
+      return;
+    }
+
+    case 'GET_PROPERTIES': {
+      const payload = data as InboundPayloads['GET_PROPERTIES'];
+      // Find entity across all models
+      const lookup = state.resolveGlobalIdFromModels(payload.id);
+      if (!lookup) {
+        if (requestId) emitToParent(createResponse(requestId, undefined, { code: 'NOT_FOUND', message: `Entity ${payload.id} not found` }));
+        return;
+      }
+      const model = state.models.get(lookup.modelId);
+      const ds = model?.ifcDataStore;
+      const attrs = ds?.entities?.getAttributes?.(lookup.expressId);
+      if (requestId) {
+        emitToParent(createResponse(requestId, {
+          expressId: lookup.expressId,
+          ifcType: attrs?.type,
+          name: attrs?.Name,
+          globalId: attrs?.GlobalId,
+          attributes: attrs || {},
+          propertySets: [],
+          quantitySets: [],
+        }));
+      }
+      return;
+    }
+
+    case 'GET_SCREENSHOT': {
+      // Screenshot requires canvas access - return placeholder for now
+      if (requestId) {
+        emitToParent(createResponse(requestId, undefined, {
+          code: 'NOT_IMPLEMENTED',
+          message: 'GET_SCREENSHOT not yet implemented',
+        }));
+      }
+      return;
+    }
+
+    case 'GET_MODEL_INFO': {
+      const models = Array.from(state.models.values());
+      const info: ModelInfo = {
+        models: models.map(m => ({
+          modelId: m.id,
+          name: m.name,
+          entityCount: m.ifcDataStore?.entities?.count ?? 0,
+          triangleCount: m.geometryResult?.totalTriangles ?? 0,
+          visible: m.visible,
+        })),
+        totalEntities: models.reduce((sum, m) => sum + (m.ifcDataStore?.entities?.count ?? 0), 0),
+        totalTriangles: models.reduce((sum, m) => sum + (m.geometryResult?.totalTriangles ?? 0), 0),
+      };
+      if (requestId) emitToParent(createResponse(requestId, info));
+      return;
+    }
+
+    default:
+      if (requestId) {
+        emitToParent(createResponse(requestId, undefined, {
+          code: 'UNKNOWN_COMMAND',
+          message: `Unknown command: ${type}`,
+        }));
+      }
+  }
+}

--- a/apps/viewer-embed/src/bridge/urlParams.ts
+++ b/apps/viewer-embed/src/bridge/urlParams.ts
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Parse URL parameters for the embed viewer.
+ *
+ * URL format:
+ *   /v1?modelUrl=https://...&theme=dark&select=42,43&view=front
+ */
+
+import type { EmbedUrlParams, ViewPreset } from '@ifc-lite/embed-protocol';
+
+const VALID_VIEWS: ViewPreset[] = ['top', 'bottom', 'front', 'back', 'left', 'right'];
+
+export function parseUrlParams(): EmbedUrlParams {
+  const params = new URLSearchParams(window.location.search);
+  const result: EmbedUrlParams = {};
+
+  const modelUrl = params.get('modelUrl');
+  if (modelUrl) result.modelUrl = modelUrl;
+
+  const theme = params.get('theme');
+  if (theme === 'light' || theme === 'dark') result.theme = theme;
+
+  const bg = params.get('bg');
+  if (bg) result.bg = bg;
+
+  const controls = params.get('controls');
+  if (controls === 'orbit' || controls === 'pan' || controls === 'all' || controls === 'none') {
+    result.controls = controls;
+  }
+
+  const autoLoad = params.get('autoLoad');
+  if (autoLoad !== null) result.autoLoad = autoLoad !== 'false';
+
+  const hideAxis = params.get('hideAxis');
+  if (hideAxis === 'true') result.hideAxis = true;
+
+  const hideScale = params.get('hideScale');
+  if (hideScale === 'true') result.hideScale = true;
+
+  const select = params.get('select');
+  if (select) {
+    const ids = select.split(',').map(Number).filter(n => !isNaN(n));
+    if (ids.length > 0) result.select = ids;
+  }
+
+  const isolate = params.get('isolate');
+  if (isolate) {
+    const ids = isolate.split(',').map(Number).filter(n => !isNaN(n));
+    if (ids.length > 0) result.isolate = ids;
+  }
+
+  const hideTypes = params.get('hideTypes');
+  if (hideTypes) result.hideTypes = hideTypes.split(',').map(s => s.trim());
+
+  const camera = params.get('camera');
+  if (camera) {
+    const parts = camera.split(',').map(Number);
+    if (parts.length >= 2 && parts.every(n => !isNaN(n))) {
+      result.camera = { azimuth: parts[0], elevation: parts[1], zoom: parts[2] };
+    }
+  }
+
+  const view = params.get('view') as ViewPreset;
+  if (VALID_VIEWS.includes(view)) result.view = view;
+
+  return result;
+}

--- a/apps/viewer-embed/src/components/EmbedViewer.tsx
+++ b/apps/viewer-embed/src/components/EmbedViewer.tsx
@@ -1,0 +1,289 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Embed viewer: Viewport-only layout with no panels, toolbar, or chrome.
+ *
+ * Reuses the main viewer's Viewport component via the @ alias (which points
+ * to apps/viewer/src/). The embed app shares the same Zustand store instance
+ * as the viewer -- it just doesn't render panels, toolbars, or measurement UI.
+ *
+ * Communication with the host page happens via postMessage (the bridge) and URL params.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Viewport } from '@/components/viewer/Viewport';
+import { ViewportOverlays } from '@/components/viewer/ViewportOverlays';
+import { useIfc } from '@/hooks/useIfc';
+import { useWebGPU } from '@/hooks/useWebGPU';
+import { useViewerStore } from '@/store';
+import { parseUrlParams } from '../bridge/urlParams.js';
+import { initBridge, destroyBridge, emitEvent } from '../bridge/handler.js';
+import type { MeshData, CoordinateInfo } from '@ifc-lite/geometry';
+
+export function EmbedViewer() {
+  const webgpu = useWebGPU();
+  const { geometryResult, ifcDataStore, loadFile, loading, models, clearAllModels } = useIfc();
+  const storeModels = useViewerStore((s) => s.models);
+  const typeVisibility = useViewerStore((s) => s.typeVisibility);
+  const isolatedEntities = useViewerStore((s) => s.isolatedEntities);
+  const selectedStoreys = useViewerStore((s) => s.selectedStoreys);
+  const theme = useViewerStore((s) => s.theme);
+  const setTheme = useViewerStore((s) => s.setTheme);
+  const progress = useViewerStore((s) => s.progress);
+  const error = useViewerStore((s) => s.error);
+  const [urlParams] = useState(() => parseUrlParams());
+  const bridgeInitialized = useRef(false);
+  const autoLoadAttempted = useRef(false);
+
+  // Apply URL params on mount
+  useEffect(() => {
+    if (urlParams.theme) setTheme(urlParams.theme);
+  }, [urlParams.theme, setTheme]);
+
+  // Initialize the postMessage bridge
+  useEffect(() => {
+    if (bridgeInitialized.current) return;
+    bridgeInitialized.current = true;
+
+    initBridge({
+      getState: () => useViewerStore.getState(),
+      loadModelFromUrl: async (url: string) => {
+        const response = await fetch(url);
+        if (!response.ok) throw new Error(`Failed to fetch model: ${response.statusText}`);
+        const buffer = await response.arrayBuffer();
+        const filename = url.split('/').pop() || 'model.ifc';
+        const file = new File([buffer], filename);
+        await loadFile(file);
+        const state = useViewerStore.getState();
+        const gr = state.geometryResult;
+        return {
+          entities: state.ifcDataStore?.entities?.count ?? 0,
+          triangles: gr?.totalTriangles ?? 0,
+          vertices: gr?.totalVertices ?? 0,
+        };
+      },
+      loadModelFromBuffer: async (buffer: ArrayBuffer, name?: string) => {
+        const file = new File([buffer], name || 'model.ifc');
+        await loadFile(file);
+        const state = useViewerStore.getState();
+        const gr = state.geometryResult;
+        return {
+          entities: state.ifcDataStore?.entities?.count ?? 0,
+          triangles: gr?.totalTriangles ?? 0,
+          vertices: gr?.totalVertices ?? 0,
+        };
+      },
+    });
+
+    return () => destroyBridge();
+  }, [loadFile]);
+
+  // Auto-load model from URL param
+  useEffect(() => {
+    if (autoLoadAttempted.current) return;
+    if (!urlParams.modelUrl || !webgpu.supported || loading) return;
+    if (storeModels.size > 0 || geometryResult?.meshes?.length) return;
+
+    autoLoadAttempted.current = true;
+
+    (async () => {
+      try {
+        emitEvent('MODEL_LOADING', { progress: 0, phase: 'Fetching model...' });
+        const response = await fetch(urlParams.modelUrl!);
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const buffer = await response.arrayBuffer();
+        const filename = urlParams.modelUrl!.split('/').pop() || 'model.ifc';
+        const file = new File([buffer], filename);
+        await loadFile(file);
+      } catch (err) {
+        emitEvent('MODEL_ERROR', {
+          error: {
+            code: 'LOAD_FAILED',
+            message: err instanceof Error ? err.message : String(err),
+          },
+        });
+      }
+    })();
+  }, [urlParams.modelUrl, webgpu.supported, loading, loadFile, storeModels.size, geometryResult?.meshes?.length]);
+
+  // Emit progress events to parent
+  useEffect(() => {
+    if (progress) {
+      emitEvent('MODEL_LOADING', { progress: progress.percent, phase: progress.phase });
+    }
+  }, [progress]);
+
+  // Emit model loaded event
+  useEffect(() => {
+    if (!loading && geometryResult?.meshes?.length) {
+      emitEvent('MODEL_LOADED', {
+        entities: ifcDataStore?.entities?.count ?? 0,
+        triangles: geometryResult.totalTriangles,
+        vertices: geometryResult.totalVertices,
+      });
+    }
+  }, [loading, geometryResult, ifcDataStore]);
+
+  // Multi-model: create mapping from modelId to modelIndex
+  const modelIdToIndex = useMemo(() => {
+    const map = new Map<string, number>();
+    let index = 0;
+    for (const modelId of storeModels.keys()) {
+      map.set(modelId, index++);
+    }
+    return map;
+  }, [storeModels]);
+
+  // Merge geometries from all visible models
+  const mergedGeometryResult = useMemo(() => {
+    if (storeModels.size > 0) {
+      const allMeshes: MeshData[] = [];
+      let totalVertices = 0;
+      let totalTriangles = 0;
+      let mergedCoordinateInfo: CoordinateInfo | undefined;
+
+      for (const [modelId, model] of storeModels) {
+        if (!model.visible) continue;
+        const mg = model.geometryResult;
+        const mi = modelIdToIndex.get(modelId) ?? 0;
+        if (mg?.meshes) {
+          for (const mesh of mg.meshes) {
+            allMeshes.push({ ...mesh, modelIndex: mi });
+          }
+          totalVertices += mg.totalVertices || 0;
+          totalTriangles += mg.totalTriangles || 0;
+          if (!mergedCoordinateInfo && mg.coordinateInfo) mergedCoordinateInfo = mg.coordinateInfo;
+        }
+      }
+
+      return { meshes: allMeshes, totalVertices, totalTriangles, coordinateInfo: mergedCoordinateInfo };
+    }
+    return geometryResult;
+  }, [storeModels, geometryResult, modelIdToIndex]);
+
+  // Filter by type visibility
+  const filteredGeometry = useMemo(() => {
+    if (!mergedGeometryResult?.meshes) return null;
+    let meshes = mergedGeometryResult.meshes;
+
+    meshes = meshes.filter(mesh => {
+      if (mesh.ifcType === 'IfcSpace' && !typeVisibility.spaces) return false;
+      if (mesh.ifcType === 'IfcOpeningElement' && !typeVisibility.openings) return false;
+      if (mesh.ifcType === 'IfcSite' && !typeVisibility.site) return false;
+      return true;
+    });
+
+    meshes = meshes.map(mesh => {
+      if (mesh.ifcType === 'IfcSpace' || mesh.ifcType === 'IfcOpeningElement') {
+        return { ...mesh, color: [mesh.color[0], mesh.color[1], mesh.color[2], Math.min(mesh.color[3] * 0.3, 0.3)] as [number, number, number, number] };
+      }
+      return mesh;
+    });
+
+    return meshes;
+  }, [mergedGeometryResult, typeVisibility]);
+
+  // Compute isolation set
+  const computedIsolatedIds = useMemo(() => {
+    if (isolatedEntities !== null) return isolatedEntities;
+    if (selectedStoreys.size > 0) {
+      const combinedGlobalIds = new Set<number>();
+      for (const [, model] of storeModels) {
+        const hierarchy = model.ifcDataStore?.spatialHierarchy;
+        if (!hierarchy) continue;
+        const offset = model.idOffset ?? 0;
+        for (const storeyId of selectedStoreys) {
+          const elements = hierarchy.byStorey.get(storeyId) || hierarchy.byStorey.get(storeyId - offset);
+          if (elements) for (const id of elements) combinedGlobalIds.add(id + offset);
+        }
+      }
+      if (combinedGlobalIds.size > 0) return combinedGlobalIds;
+    }
+    return null;
+  }, [storeModels, selectedStoreys, isolatedEntities]);
+
+  // Background color
+  const bgColor = theme === 'dark' ? '#1a1b26' : '#ffffff';
+  const customBg = urlParams.bg ? `#${urlParams.bg}` : undefined;
+
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        position: 'relative',
+        overflow: 'hidden',
+        background: customBg || bgColor,
+      }}
+    >
+      {/* WebGPU check */}
+      {!webgpu.checking && !webgpu.supported && (
+        <div style={{
+          position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center',
+          fontFamily: 'system-ui', color: theme === 'dark' ? '#a9b1d6' : '#333',
+        }}>
+          <div style={{ textAlign: 'center', padding: '2rem' }}>
+            <p style={{ fontSize: '1.2rem', fontWeight: 700 }}>WebGPU Not Available</p>
+            <p style={{ fontSize: '0.85rem', opacity: 0.7, marginTop: '0.5rem' }}>
+              {webgpu.reason || 'This viewer requires WebGPU support.'}
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Loading indicator */}
+      {loading && (
+        <div style={{
+          position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center',
+          fontFamily: 'system-ui', color: theme === 'dark' ? '#a9b1d6' : '#333', zIndex: 10,
+          background: theme === 'dark' ? 'rgba(26,27,38,0.8)' : 'rgba(255,255,255,0.8)',
+        }}>
+          <div style={{ textAlign: 'center' }}>
+            <p style={{ fontSize: '0.9rem', fontWeight: 600 }}>
+              {progress?.phase || 'Loading...'}
+            </p>
+            {progress && (
+              <div style={{
+                width: '200px', height: '4px', background: theme === 'dark' ? '#3b4261' : '#e5e7eb',
+                borderRadius: '2px', marginTop: '0.75rem', overflow: 'hidden',
+              }}>
+                <div style={{
+                  width: `${progress.percent}%`, height: '100%',
+                  background: '#7aa2f7', transition: 'width 0.3s',
+                }} />
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Error indicator */}
+      {error && !loading && (
+        <div style={{
+          position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center',
+          fontFamily: 'system-ui', color: '#f7768e', zIndex: 10,
+        }}>
+          <div style={{ textAlign: 'center', padding: '2rem' }}>
+            <p style={{ fontSize: '0.9rem', fontWeight: 600 }}>Error</p>
+            <p style={{ fontSize: '0.8rem', opacity: 0.8, marginTop: '0.5rem' }}>{error}</p>
+          </div>
+        </div>
+      )}
+
+      {/* 3D Viewport */}
+      {webgpu.supported && (
+        <>
+          <Viewport
+            geometry={filteredGeometry}
+            coordinateInfo={mergedGeometryResult?.coordinateInfo}
+            computedIsolatedIds={computedIsolatedIds}
+            modelIdToIndex={modelIdToIndex}
+          />
+          <ViewportOverlays />
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/viewer-embed/src/main.tsx
+++ b/apps/viewer-embed/src/main.tsx
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Embed viewer entry point.
+ *
+ * Minimal entry that mounts the EmbedViewer component with no additional chrome.
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { EmbedViewer } from './components/EmbedViewer';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <EmbedViewer />
+  </React.StrictMode>
+);

--- a/apps/viewer-embed/src/vite-env.d.ts
+++ b/apps/viewer-embed/src/vite-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string;
+declare const __BUILD_DATE__: string;

--- a/apps/viewer-embed/tsconfig.json
+++ b/apps/viewer-embed/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "outDir": "./dist",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["../viewer/src/*"],
+      "@ifc-lite/parser": ["../../packages/parser/src"],
+      "@ifc-lite/geometry": ["../../packages/geometry/src"],
+      "@ifc-lite/renderer": ["../../packages/renderer/src"],
+      "@ifc-lite/query": ["../../packages/query/src"],
+      "@ifc-lite/spatial": ["../../packages/spatial/src"],
+      "@ifc-lite/data": ["../../packages/data/src"],
+      "@ifc-lite/bcf": ["../../packages/bcf/src"],
+      "@ifc-lite/cache": ["../../packages/cache/src"],
+      "@ifc-lite/drawing-2d": ["../../packages/drawing-2d/src"],
+      "@ifc-lite/export": ["../../packages/export/src"],
+      "@ifc-lite/ids": ["../../packages/ids/src"],
+      "@ifc-lite/ifcx": ["../../packages/ifcx/src"],
+      "@ifc-lite/mutations": ["../../packages/mutations/src"],
+      "@ifc-lite/embed-protocol": ["../../packages/embed-protocol/src"]
+    }
+  },
+  "include": [
+    "src/**/*",
+    "../viewer/src/**/*",
+    "../../packages/renderer/src/webgpu-types.d.ts"
+  ]
+}

--- a/apps/viewer-embed/vercel.json
+++ b/apps/viewer-embed/vercel.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "cd ../.. && pnpm install && pnpm --filter @ifc-lite/viewer-embed build",
+  "installCommand": "echo 'handled by buildCommand'",
+  "outputDirectory": "dist",
+  "framework": "vite",
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "*"
+        },
+        {
+          "key": "Cross-Origin-Resource-Policy",
+          "value": "cross-origin"
+        },
+        {
+          "key": "Cross-Origin-Embedder-Policy",
+          "value": "credentialless"
+        },
+        {
+          "key": "Cross-Origin-Opener-Policy",
+          "value": "same-origin"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' blob:; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https: blob:; frame-ancestors *;"
+        }
+      ]
+    },
+    {
+      "source": "/(.*)\\.wasm",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "application/wasm"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    }
+  ],
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}

--- a/apps/viewer-embed/vite.config.ts
+++ b/apps/viewer-embed/vite.config.ts
@@ -1,0 +1,67 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import wasm from 'vite-plugin-wasm';
+import topLevelAwait from 'vite-plugin-top-level-await';
+import path from 'path';
+import fs from 'fs';
+
+// Read version from root package.json
+const rootPkg = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, '../../package.json'), 'utf-8')
+);
+
+export default defineConfig({
+  plugins: [
+    react(),
+    wasm(),
+    topLevelAwait(),
+  ],
+  define: {
+    __APP_VERSION__: JSON.stringify(rootPkg.version),
+    __BUILD_DATE__: JSON.stringify(new Date().toISOString()),
+    __RELEASE_HISTORY__: JSON.stringify([]),
+  },
+  resolve: {
+    alias: {
+      // Point @ to the main viewer's src so Viewport, hooks, and store resolve correctly
+      '@': path.resolve(__dirname, '../viewer/src'),
+      '@ifc-lite/parser': path.resolve(__dirname, '../../packages/parser/src'),
+      '@ifc-lite/geometry': path.resolve(__dirname, '../../packages/geometry/src'),
+      '@ifc-lite/renderer': path.resolve(__dirname, '../../packages/renderer/src'),
+      '@ifc-lite/query': path.resolve(__dirname, '../../packages/query/src'),
+      '@ifc-lite/server-client': path.resolve(__dirname, '../../packages/server-client/src'),
+      '@ifc-lite/spatial': path.resolve(__dirname, '../../packages/spatial/src'),
+      '@ifc-lite/data': path.resolve(__dirname, '../../packages/data/src'),
+      '@ifc-lite/bcf': path.resolve(__dirname, '../../packages/bcf/src'),
+      '@ifc-lite/cache': path.resolve(__dirname, '../../packages/cache/src'),
+      '@ifc-lite/drawing-2d': path.resolve(__dirname, '../../packages/drawing-2d/src'),
+      '@ifc-lite/export': path.resolve(__dirname, '../../packages/export/src'),
+      '@ifc-lite/ids': path.resolve(__dirname, '../../packages/ids/src'),
+      '@ifc-lite/ifcx': path.resolve(__dirname, '../../packages/ifcx/src'),
+      '@ifc-lite/mutations': path.resolve(__dirname, '../../packages/mutations/src'),
+      '@ifc-lite/embed-protocol': path.resolve(__dirname, '../../packages/embed-protocol/src'),
+      '@ifc-lite/wasm': path.resolve(__dirname, '../../packages/wasm/pkg/ifc-lite.js'),
+    },
+  },
+  server: {
+    port: 3001,
+    headers: {
+      // Use credentialless instead of require-corp for iframe compatibility
+      'Cross-Origin-Opener-Policy': 'same-origin',
+      'Cross-Origin-Embedder-Policy': 'credentialless',
+    },
+    fs: {
+      allow: ['../..'],
+    },
+  },
+  build: {
+    target: 'esnext',
+  },
+  optimizeDeps: {
+    exclude: ['@duckdb/duckdb-wasm', '@ifc-lite/wasm', 'parquet-wasm'],
+  },
+  worker: {
+    format: 'es',
+    plugins: () => [wasm(), topLevelAwait()],
+  },
+});

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
   ],
   "scripts": {
     "dev": "pnpm build && pnpm --filter viewer dev",
+    "dev:embed": "pnpm build && pnpm --filter @ifc-lite/viewer-embed dev",
     "dev:desktop": "pnpm --filter @ifc-lite/desktop dev",
     "build": "pnpm -r build",
+    "build:embed": "pnpm --filter @ifc-lite/viewer-embed build",
     "build:desktop": "pnpm --filter @ifc-lite/desktop build",
     "build:desktop:windows": "pnpm --filter @ifc-lite/desktop build:windows",
     "build:desktop:macos": "pnpm --filter @ifc-lite/desktop build:macos",

--- a/packages/embed-protocol/package.json
+++ b/packages/embed-protocol/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@ifc-lite/embed-protocol",
+  "version": "0.1.0",
+  "description": "Shared postMessage protocol types for ifc-lite embed viewer and SDK",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "src"
+  ],
+  "license": "MPL-2.0"
+}

--- a/packages/embed-protocol/src/index.ts
+++ b/packages/embed-protocol/src/index.ts
@@ -1,0 +1,279 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Shared postMessage protocol types for ifc-lite embed viewer and SDK.
+ *
+ * Both the embed viewer (inside the iframe) and the embed SDK (in the host page)
+ * import from this package to ensure type safety across the postMessage boundary.
+ */
+
+// ============================================================================
+// Protocol Constants
+// ============================================================================
+
+/** Message discriminator to ignore unrelated postMessage traffic */
+export const EMBED_SOURCE = 'ifc-lite-embed' as const;
+
+/** Current protocol version */
+export const PROTOCOL_VERSION = '1.0' as const;
+
+// ============================================================================
+// Message Envelope
+// ============================================================================
+
+/** Base envelope for all messages crossing the iframe boundary */
+export interface EmbedMessageEnvelope {
+  /** Always 'ifc-lite-embed' - used to filter out unrelated messages */
+  source: typeof EMBED_SOURCE;
+  /** Protocol version for forward compatibility */
+  version: typeof PROTOCOL_VERSION;
+  /** Command or event name */
+  type: string;
+  /** Present on requests, echoed in responses for correlation */
+  requestId?: string;
+  /** Present on responses, matches the original requestId */
+  responseId?: string;
+  /** Payload data */
+  data?: unknown;
+  /** Present on error responses */
+  error?: EmbedError;
+}
+
+export interface EmbedError {
+  code: string;
+  message: string;
+}
+
+// ============================================================================
+// Inbound Commands (parent -> embed viewer)
+// ============================================================================
+
+/** All command types the host can send to the embedded viewer */
+export type InboundCommandType =
+  | 'INIT'
+  | 'LOAD_MODEL'
+  | 'LOAD_MODEL_BUFFER'
+  | 'ADD_MODEL'
+  | 'REMOVE_MODEL'
+  | 'SELECT'
+  | 'SELECT_BY_GUID'
+  | 'CLEAR_SELECTION'
+  | 'ISOLATE'
+  | 'HIDE'
+  | 'SHOW'
+  | 'SHOW_ALL'
+  | 'SET_COLORS'
+  | 'RESET_COLORS'
+  | 'FIT_TO_VIEW'
+  | 'SET_CAMERA'
+  | 'SET_VIEW'
+  | 'SET_SECTION'
+  | 'SET_THEME'
+  | 'SET_TYPE_VISIBILITY'
+  | 'GET_PROPERTIES'
+  | 'GET_SCREENSHOT'
+  | 'GET_MODEL_INFO';
+
+/** Payload types for each inbound command */
+export interface InboundPayloads {
+  INIT: { token?: string; config?: EmbedConfig };
+  LOAD_MODEL: { url: string };
+  LOAD_MODEL_BUFFER: ArrayBuffer;
+  ADD_MODEL: { url: string; name?: string };
+  REMOVE_MODEL: { modelId: string };
+  SELECT: { ids: number[] };
+  SELECT_BY_GUID: { guids: string[] };
+  CLEAR_SELECTION: void;
+  ISOLATE: { ids: number[] };
+  HIDE: { ids: number[] };
+  SHOW: { ids: number[] };
+  SHOW_ALL: void;
+  SET_COLORS: { colorMap: Record<string, [number, number, number, number]> };
+  RESET_COLORS: void;
+  FIT_TO_VIEW: { ids?: number[] };
+  SET_CAMERA: { azimuth: number; elevation: number; zoom?: number };
+  SET_VIEW: { preset: ViewPreset };
+  SET_SECTION: { axis?: SectionAxis; position?: number; enabled?: boolean; flipped?: boolean };
+  SET_THEME: { theme: 'light' | 'dark'; bg?: string };
+  SET_TYPE_VISIBILITY: { spaces?: boolean; openings?: boolean; site?: boolean };
+  GET_PROPERTIES: { id: number };
+  GET_SCREENSHOT: { width?: number; height?: number };
+  GET_MODEL_INFO: void;
+}
+
+/** Response types for commands that return data */
+export interface CommandResponses {
+  LOAD_MODEL: ModelStats;
+  LOAD_MODEL_BUFFER: ModelStats;
+  ADD_MODEL: { modelId: string } & ModelStats;
+  SELECT_BY_GUID: { resolved: number[] };
+  GET_PROPERTIES: EntityProperties;
+  GET_SCREENSHOT: { dataUrl: string };
+  GET_MODEL_INFO: ModelInfo;
+}
+
+// ============================================================================
+// Outbound Events (embed viewer -> parent)
+// ============================================================================
+
+/** All event types the embedded viewer can emit to the host */
+export type OutboundEventType =
+  | 'READY'
+  | 'INIT_ACK'
+  | 'MODEL_LOADING'
+  | 'MODEL_LOADED'
+  | 'MODEL_ERROR'
+  | 'ENTITY_SELECTED'
+  | 'ENTITY_DESELECTED'
+  | 'ENTITY_HOVERED'
+  | 'CAMERA_CHANGED'
+  | 'SECTION_CHANGED';
+
+/** Payload types for each outbound event */
+export interface OutboundPayloads {
+  READY: { version: string };
+  INIT_ACK: void;
+  MODEL_LOADING: { progress: number; phase: string };
+  MODEL_LOADED: { modelId?: string } & ModelStats;
+  MODEL_ERROR: { error: EmbedError };
+  ENTITY_SELECTED: { id: number; globalId?: string; modelId?: string; ifcType?: string };
+  ENTITY_DESELECTED: void;
+  ENTITY_HOVERED: { id: number; globalId?: string; ifcType?: string };
+  CAMERA_CHANGED: { azimuth: number; elevation: number; zoom?: number };
+  SECTION_CHANGED: { axis: SectionAxis; position: number; enabled: boolean };
+}
+
+// ============================================================================
+// Shared Data Types
+// ============================================================================
+
+export type ViewPreset = 'top' | 'bottom' | 'front' | 'back' | 'left' | 'right';
+
+export type SectionAxis = 'down' | 'front' | 'side';
+
+export interface EmbedConfig {
+  theme?: 'light' | 'dark';
+  bg?: string;
+  controls?: 'orbit' | 'pan' | 'all' | 'none';
+  hideAxis?: boolean;
+  hideScale?: boolean;
+  hideTypes?: string[];
+}
+
+export interface ModelStats {
+  entities: number;
+  triangles: number;
+  vertices: number;
+}
+
+export interface EntityProperties {
+  expressId: number;
+  ifcType?: string;
+  name?: string;
+  globalId?: string;
+  attributes: Record<string, unknown>;
+  propertySets: PropertySet[];
+  quantitySets: QuantitySet[];
+}
+
+export interface PropertySet {
+  name: string;
+  properties: Record<string, unknown>;
+}
+
+export interface QuantitySet {
+  name: string;
+  quantities: Record<string, number>;
+}
+
+export interface ModelInfo {
+  models: Array<{
+    modelId: string;
+    name: string;
+    entityCount: number;
+    triangleCount: number;
+    visible: boolean;
+  }>;
+  totalEntities: number;
+  totalTriangles: number;
+}
+
+// ============================================================================
+// URL Parameter Types
+// ============================================================================
+
+/** Parameters that can be passed via URL to the embed viewer */
+export interface EmbedUrlParams {
+  modelUrl?: string;
+  theme?: 'light' | 'dark';
+  bg?: string;
+  controls?: 'orbit' | 'pan' | 'all' | 'none';
+  autoLoad?: boolean;
+  hideAxis?: boolean;
+  hideScale?: boolean;
+  select?: number[];
+  isolate?: number[];
+  hideTypes?: string[];
+  camera?: { azimuth: number; elevation: number; zoom?: number };
+  view?: ViewPreset;
+}
+
+// ============================================================================
+// Helper: Type-safe message creation
+// ============================================================================
+
+/** Create a properly typed outbound event message */
+export function createEvent<T extends OutboundEventType>(
+  type: T,
+  data?: OutboundPayloads[T],
+): EmbedMessageEnvelope {
+  return {
+    source: EMBED_SOURCE,
+    version: PROTOCOL_VERSION,
+    type,
+    data,
+  };
+}
+
+/** Create a properly typed response message */
+export function createResponse(
+  responseId: string,
+  data?: unknown,
+  error?: EmbedError,
+): EmbedMessageEnvelope {
+  return {
+    source: EMBED_SOURCE,
+    version: PROTOCOL_VERSION,
+    type: 'RESPONSE',
+    responseId,
+    data,
+    error,
+  };
+}
+
+/** Create a properly typed command message */
+export function createCommand<T extends InboundCommandType>(
+  type: T,
+  data?: InboundPayloads[T],
+  requestId?: string,
+): EmbedMessageEnvelope {
+  return {
+    source: EMBED_SOURCE,
+    version: PROTOCOL_VERSION,
+    type,
+    requestId,
+    data,
+  };
+}
+
+/** Type guard: is this message from ifc-lite embed? */
+export function isEmbedMessage(data: unknown): data is EmbedMessageEnvelope {
+  return (
+    data !== null &&
+    typeof data === 'object' &&
+    'source' in data &&
+    (data as EmbedMessageEnvelope).source === EMBED_SOURCE
+  );
+}

--- a/packages/embed-protocol/tsconfig.json
+++ b/packages/embed-protocol/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/embed-sdk/package.json
+++ b/packages/embed-sdk/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@ifc-lite/embed-sdk",
+  "version": "0.1.0",
+  "description": "SDK for embedding the IFC-Lite 3D viewer in any web page via iframe",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "src"
+  ],
+  "dependencies": {
+    "@ifc-lite/embed-protocol": "workspace:^"
+  },
+  "license": "MPL-2.0",
+  "keywords": [
+    "ifc",
+    "bim",
+    "3d-viewer",
+    "embed",
+    "iframe",
+    "power-bi",
+    "superset",
+    "grafana"
+  ]
+}

--- a/packages/embed-sdk/src/index.ts
+++ b/packages/embed-sdk/src/index.ts
@@ -1,0 +1,385 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * @ifc-lite/embed-sdk
+ *
+ * A lightweight SDK (~3-5 KB) for embedding the IFC-Lite 3D viewer in any web page.
+ * Creates an iframe pointed at the hosted embed viewer and provides a promise-based
+ * API for controlling it via postMessage.
+ *
+ * @example
+ * ```typescript
+ * import { IFCLiteEmbed } from '@ifc-lite/embed-sdk';
+ *
+ * const viewer = await IFCLiteEmbed.create({
+ *   container: '#viewer',
+ *   modelUrl: 'https://example.com/model.ifc',
+ *   theme: 'dark',
+ * });
+ *
+ * await viewer.select([42, 43]);
+ * viewer.on('entity-selected', (data) => console.log(data));
+ * ```
+ */
+
+import {
+  EMBED_SOURCE,
+  PROTOCOL_VERSION,
+  isEmbedMessage,
+  type EmbedMessageEnvelope,
+  type ViewPreset,
+  type SectionAxis,
+  type ModelStats,
+  type EntityProperties,
+  type ModelInfo,
+} from '@ifc-lite/embed-protocol';
+
+// ============================================================================
+// Public types
+// ============================================================================
+
+export interface EmbedOptions {
+  /** CSS selector or DOM element to mount the iframe into */
+  container: string | HTMLElement;
+  /** URL of the model to load on initialization */
+  modelUrl?: string;
+  /** Color theme */
+  theme?: 'light' | 'dark';
+  /** Custom background color (hex without #) */
+  bg?: string;
+  /** Camera controls mode */
+  controls?: 'orbit' | 'pan' | 'all' | 'none';
+  /** Hide the axis helper */
+  hideAxis?: boolean;
+  /** Hide the scale bar */
+  hideScale?: boolean;
+  /** IFC types to hide by default */
+  hideTypes?: string[];
+  /** Preset camera view */
+  view?: ViewPreset;
+  /** Initial camera position */
+  camera?: { azimuth: number; elevation: number; zoom?: number };
+  /** Origin of the hosted embed viewer (defaults to production) */
+  origin?: string;
+  /** Auth token (sent via postMessage, not URL) */
+  token?: string;
+  /** Handshake timeout in ms (default: 15000) */
+  timeout?: number;
+}
+
+export interface EventMap {
+  'ready': { version: string };
+  'model-loading': { progress: number; phase: string };
+  'model-loaded': ModelStats & { modelId?: string };
+  'model-error': { error: { code: string; message: string } };
+  'entity-selected': { id: number; globalId?: string; modelId?: string; ifcType?: string };
+  'entity-deselected': void;
+  'entity-hovered': { id: number; globalId?: string; ifcType?: string };
+  'camera-changed': { azimuth: number; elevation: number; zoom?: number };
+  'section-changed': { axis: SectionAxis; position: number; enabled: boolean };
+}
+
+type EventCallback<T> = (data: T) => void;
+
+// Re-export types consumers might need
+export type { ViewPreset, SectionAxis, ModelStats, EntityProperties, ModelInfo };
+
+// ============================================================================
+// Default embed origin
+// ============================================================================
+
+const DEFAULT_ORIGIN = 'https://embed.ifc-lite.com';
+
+// ============================================================================
+// IFCLiteEmbed class
+// ============================================================================
+
+export class IFCLiteEmbed {
+  private iframe: HTMLIFrameElement;
+  private origin: string;
+  private pending = new Map<string, {
+    resolve: (data: unknown) => void;
+    reject: (err: Error) => void;
+    timeout: ReturnType<typeof setTimeout>;
+  }>();
+  private listeners = new Map<string, Set<EventCallback<unknown>>>();
+  private readyPromise: Promise<void>;
+  private destroyed = false;
+
+  // --- Factory ---
+
+  /** Create an embed viewer instance. Returns a promise that resolves after the handshake. */
+  static async create(opts: EmbedOptions): Promise<IFCLiteEmbed> {
+    const instance = new IFCLiteEmbed(opts);
+    await instance.readyPromise;
+    return instance;
+  }
+
+  private constructor(opts: EmbedOptions) {
+    this.origin = opts.origin ?? DEFAULT_ORIGIN;
+
+    // Build URL with non-sensitive params
+    const params = new URLSearchParams();
+    if (opts.modelUrl) params.set('modelUrl', opts.modelUrl);
+    if (opts.theme) params.set('theme', opts.theme);
+    if (opts.bg) params.set('bg', opts.bg);
+    if (opts.controls) params.set('controls', opts.controls);
+    if (opts.hideAxis) params.set('hideAxis', 'true');
+    if (opts.hideScale) params.set('hideScale', 'true');
+    if (opts.hideTypes?.length) params.set('hideTypes', opts.hideTypes.join(','));
+    if (opts.view) params.set('view', opts.view);
+    if (opts.camera) {
+      const parts = [opts.camera.azimuth, opts.camera.elevation];
+      if (opts.camera.zoom !== undefined) parts.push(opts.camera.zoom);
+      params.set('camera', parts.join(','));
+    }
+
+    // Create iframe
+    this.iframe = document.createElement('iframe');
+    this.iframe.src = `${this.origin}/v1?${params}`;
+    this.iframe.style.cssText = 'width:100%;height:100%;border:none;display:block;';
+    this.iframe.setAttribute('allow', 'cross-origin-isolated');
+    this.iframe.setAttribute('loading', 'eager');
+
+    // Mount
+    const container = typeof opts.container === 'string'
+      ? document.querySelector(opts.container)
+      : opts.container;
+    if (!container) throw new Error(`Container not found: ${opts.container}`);
+    container.appendChild(this.iframe);
+
+    // Listen for messages
+    window.addEventListener('message', this.onMessage);
+
+    // Handshake: READY -> INIT -> INIT_ACK
+    const handshakeTimeout = opts.timeout ?? 15_000;
+    this.readyPromise = new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('Embed viewer handshake timed out')), handshakeTimeout);
+
+      const waitForReady = (msg: EmbedMessageEnvelope) => {
+        if (msg.type === 'READY') {
+          // Send INIT
+          this.send({ type: 'INIT', data: { token: opts.token } });
+        }
+        if (msg.type === 'INIT_ACK') {
+          clearTimeout(timer);
+          resolve();
+        }
+      };
+
+      // Temporary internal listener for handshake
+      this.onceInternal('READY', waitForReady);
+      this.onceInternal('INIT_ACK', waitForReady);
+    });
+  }
+
+  // --- Commands (promise-based) ---
+
+  /** Load a model from a URL */
+  loadModel(url: string): Promise<ModelStats> {
+    return this.request('LOAD_MODEL', { url }) as Promise<ModelStats>;
+  }
+
+  /** Load a model from an ArrayBuffer (zero-copy transfer) */
+  loadModelBuffer(buffer: ArrayBuffer): Promise<ModelStats> {
+    return this.request('LOAD_MODEL_BUFFER', buffer, [buffer]) as Promise<ModelStats>;
+  }
+
+  /** Add a model to the federation */
+  addModel(url: string, name?: string): Promise<ModelStats & { modelId: string }> {
+    return this.request('ADD_MODEL', { url, name }) as Promise<ModelStats & { modelId: string }>;
+  }
+
+  /** Remove a model from the federation */
+  removeModel(modelId: string): Promise<void> {
+    return this.request('REMOVE_MODEL', { modelId }) as Promise<void>;
+  }
+
+  /** Select entities by global IDs */
+  select(ids: number[]): Promise<void> {
+    return this.request('SELECT', { ids }) as Promise<void>;
+  }
+
+  /** Select entities by IFC GlobalId GUIDs */
+  selectByGuid(guids: string[]): Promise<{ resolved: number[] }> {
+    return this.request('SELECT_BY_GUID', { guids }) as Promise<{ resolved: number[] }>;
+  }
+
+  /** Clear selection */
+  clearSelection(): Promise<void> {
+    return this.request('CLEAR_SELECTION') as Promise<void>;
+  }
+
+  /** Isolate (show only) specific entities */
+  isolate(ids: number[]): Promise<void> {
+    return this.request('ISOLATE', { ids }) as Promise<void>;
+  }
+
+  /** Hide specific entities */
+  hide(ids: number[]): Promise<void> {
+    return this.request('HIDE', { ids }) as Promise<void>;
+  }
+
+  /** Show specific entities */
+  show(ids: number[]): Promise<void> {
+    return this.request('SHOW', { ids }) as Promise<void>;
+  }
+
+  /** Show all entities (reset visibility) */
+  showAll(): Promise<void> {
+    return this.request('SHOW_ALL') as Promise<void>;
+  }
+
+  /** Set color overrides for entities. Keys are entity IDs, values are [r,g,b,a]. */
+  setColors(colorMap: Record<number, [number, number, number, number]>): Promise<void> {
+    // Convert numeric keys to string for JSON serialization
+    const stringKeyed: Record<string, [number, number, number, number]> = {};
+    for (const [k, v] of Object.entries(colorMap)) stringKeyed[k] = v;
+    return this.request('SET_COLORS', { colorMap: stringKeyed }) as Promise<void>;
+  }
+
+  /** Reset all color overrides */
+  resetColors(): Promise<void> {
+    return this.request('RESET_COLORS') as Promise<void>;
+  }
+
+  /** Zoom the camera to fit specific entities (or all if no IDs given) */
+  fitToView(ids?: number[]): Promise<void> {
+    return this.request('FIT_TO_VIEW', { ids }) as Promise<void>;
+  }
+
+  /** Set camera orientation */
+  setCamera(azimuth: number, elevation: number, zoom?: number): Promise<void> {
+    return this.request('SET_CAMERA', { azimuth, elevation, zoom }) as Promise<void>;
+  }
+
+  /** Set a preset camera view */
+  setView(preset: ViewPreset): Promise<void> {
+    return this.request('SET_VIEW', { preset }) as Promise<void>;
+  }
+
+  /** Control the section plane */
+  setSection(opts: { axis?: SectionAxis; position?: number; enabled?: boolean; flipped?: boolean }): Promise<void> {
+    return this.request('SET_SECTION', opts) as Promise<void>;
+  }
+
+  /** Change the color theme */
+  setTheme(theme: 'light' | 'dark', bg?: string): Promise<void> {
+    return this.request('SET_THEME', { theme, bg }) as Promise<void>;
+  }
+
+  /** Toggle IFC type visibility */
+  setTypeVisibility(opts: { spaces?: boolean; openings?: boolean; site?: boolean }): Promise<void> {
+    return this.request('SET_TYPE_VISIBILITY', opts) as Promise<void>;
+  }
+
+  /** Get properties for a specific entity */
+  getProperties(id: number): Promise<EntityProperties> {
+    return this.request('GET_PROPERTIES', { id }) as Promise<EntityProperties>;
+  }
+
+  /** Capture a screenshot of the viewport */
+  getScreenshot(width?: number, height?: number): Promise<{ dataUrl: string }> {
+    return this.request('GET_SCREENSHOT', { width, height }) as Promise<{ dataUrl: string }>;
+  }
+
+  /** Get info about all loaded models */
+  getModelInfo(): Promise<ModelInfo> {
+    return this.request('GET_MODEL_INFO') as Promise<ModelInfo>;
+  }
+
+  // --- Events ---
+
+  /** Subscribe to an event. Returns an unsubscribe function. */
+  on<K extends keyof EventMap>(event: K, callback: EventCallback<EventMap[K]>): () => void {
+    if (!this.listeners.has(event)) this.listeners.set(event, new Set());
+    this.listeners.get(event)!.add(callback as EventCallback<unknown>);
+    return () => this.listeners.get(event)?.delete(callback as EventCallback<unknown>);
+  }
+
+  // --- Lifecycle ---
+
+  /** Destroy the embed viewer and clean up resources */
+  destroy() {
+    this.destroyed = true;
+    window.removeEventListener('message', this.onMessage);
+    for (const p of this.pending.values()) {
+      clearTimeout(p.timeout);
+      p.reject(new Error('Embed destroyed'));
+    }
+    this.pending.clear();
+    this.listeners.clear();
+    this.iframe.remove();
+  }
+
+  // --- Internals ---
+
+  private onMessage = (event: MessageEvent) => {
+    // Filter: must be from our iframe, at our origin
+    if (event.source !== this.iframe.contentWindow) return;
+    if (!isEmbedMessage(event.data)) return;
+
+    const msg = event.data as EmbedMessageEnvelope;
+
+    // Handle response to a pending request
+    if (msg.responseId && this.pending.has(msg.responseId)) {
+      const req = this.pending.get(msg.responseId)!;
+      clearTimeout(req.timeout);
+      this.pending.delete(msg.responseId);
+      if (msg.error) {
+        req.reject(new Error(`${msg.error.code}: ${msg.error.message}`));
+      } else {
+        req.resolve(msg.data);
+      }
+      return;
+    }
+
+    // Broadcast event to external listeners
+    const kebab = msg.type.toLowerCase().replace(/_/g, '-');
+    this.listeners.get(kebab)?.forEach(fn => {
+      try { fn(msg.data); } catch { /* consumer error */ }
+    });
+
+    // Also broadcast to internal listeners (for handshake)
+    this.internalListeners.get(msg.type)?.forEach(fn => {
+      try { fn(msg); } catch { /* ignore */ }
+    });
+  };
+
+  private send(msg: Partial<EmbedMessageEnvelope>, transfer?: Transferable[]) {
+    if (this.destroyed) return;
+    this.iframe.contentWindow?.postMessage(
+      { source: EMBED_SOURCE, version: PROTOCOL_VERSION, ...msg },
+      this.origin,
+      transfer ?? [],
+    );
+  }
+
+  private request(type: string, data?: unknown, transfer?: Transferable[]): Promise<unknown> {
+    if (this.destroyed) return Promise.reject(new Error('Embed destroyed'));
+
+    const requestId = crypto.randomUUID();
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(requestId);
+        reject(new Error(`${type} timed out (30s)`));
+      }, 30_000);
+      this.pending.set(requestId, { resolve, reject, timeout });
+      this.send({ type, requestId, data }, transfer);
+    });
+  }
+
+  // Internal listener system for handshake (separate from public events)
+  private internalListeners = new Map<string, Set<(msg: EmbedMessageEnvelope) => void>>();
+
+  private onceInternal(type: string, fn: (msg: EmbedMessageEnvelope) => void) {
+    if (!this.internalListeners.has(type)) this.internalListeners.set(type, new Set());
+    const wrapped = (msg: EmbedMessageEnvelope) => {
+      fn(msg);
+      this.internalListeners.get(type)?.delete(wrapped);
+    };
+    this.internalListeners.get(type)!.add(wrapped);
+  }
+}

--- a/packages/embed-sdk/tsconfig.json
+++ b/packages/embed-sdk/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,6 +323,88 @@ importers:
         specifier: ^3.5.0
         version: 3.5.0(vite@5.4.21(@types/node@20.19.28)(lightningcss@1.30.2))
 
+  apps/viewer-embed:
+    dependencies:
+      '@ifc-lite/bcf':
+        specifier: workspace:^
+        version: link:../../packages/bcf
+      '@ifc-lite/cache':
+        specifier: workspace:^
+        version: link:../../packages/cache
+      '@ifc-lite/data':
+        specifier: workspace:^
+        version: link:../../packages/data
+      '@ifc-lite/drawing-2d':
+        specifier: workspace:^
+        version: link:../../packages/drawing-2d
+      '@ifc-lite/embed-protocol':
+        specifier: workspace:^
+        version: link:../../packages/embed-protocol
+      '@ifc-lite/export':
+        specifier: workspace:^
+        version: link:../../packages/export
+      '@ifc-lite/geometry':
+        specifier: workspace:^
+        version: link:../../packages/geometry
+      '@ifc-lite/ids':
+        specifier: workspace:^
+        version: link:../../packages/ids
+      '@ifc-lite/ifcx':
+        specifier: workspace:^
+        version: link:../../packages/ifcx
+      '@ifc-lite/mutations':
+        specifier: workspace:^
+        version: link:../../packages/mutations
+      '@ifc-lite/parser':
+        specifier: workspace:^
+        version: link:../../packages/parser
+      '@ifc-lite/query':
+        specifier: workspace:^
+        version: link:../../packages/query
+      '@ifc-lite/renderer':
+        specifier: workspace:^
+        version: link:../../packages/renderer
+      '@ifc-lite/server-client':
+        specifier: workspace:^
+        version: link:../../packages/server-client
+      '@ifc-lite/spatial':
+        specifier: workspace:^
+        version: link:../../packages/spatial
+      '@ifc-lite/wasm':
+        specifier: workspace:^
+        version: link:../../packages/wasm
+      react:
+        specifier: ^18.2.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.3.1(react@18.3.1)
+      zustand:
+        specifier: ^4.4.0
+        version: 4.5.7(@types/react@18.3.27)(react@18.3.1)
+    devDependencies:
+      '@types/react':
+        specifier: ^18.2.0
+        version: 18.3.27
+      '@types/react-dom':
+        specifier: ^18.2.0
+        version: 18.3.7(@types/react@18.3.27)
+      '@vitejs/plugin-react':
+        specifier: ^4.2.0
+        version: 4.7.0(vite@5.4.21(@types/node@20.19.28)(lightningcss@1.30.2))
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.21(@types/node@20.19.28)(lightningcss@1.30.2)
+      vite-plugin-top-level-await:
+        specifier: ^1.6.0
+        version: 1.6.0(rollup@4.55.1)(vite@5.4.21(@types/node@20.19.28)(lightningcss@1.30.2))
+      vite-plugin-wasm:
+        specifier: ^3.5.0
+        version: 3.5.0(vite@5.4.21(@types/node@20.19.28)(lightningcss@1.30.2))
+
   packages/bcf:
     dependencies:
       jszip:
@@ -394,6 +476,14 @@ importers:
       vitest:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@20.19.28)(lightningcss@1.30.2)
+
+  packages/embed-protocol: {}
+
+  packages/embed-sdk:
+    dependencies:
+      '@ifc-lite/embed-protocol':
+        specifier: workspace:^
+        version: link:../embed-protocol
 
   packages/export:
     dependencies:


### PR DESCRIPTION
## Summary

This PR introduces a new embeddable IFC-Lite 3D viewer application designed to be deployed in iframes for integration with BI tools (Power BI, Superset, Grafana, etc.). It includes a complete postMessage-based communication protocol for controlling the viewer from host pages.

## Key Changes

### New Applications & Packages

- **`apps/viewer-embed`**: Minimal embed viewer app that reuses the main viewer's Viewport component and Zustand store, but without panels, toolbars, or UI chrome
- **`packages/embed-protocol`**: Shared TypeScript types and helpers for the postMessage protocol, ensuring type safety across the iframe boundary
- **`packages/embed-sdk`**: SDK package for host pages to control the embedded viewer (implementation in follow-up)

### Embed Viewer Features

- **URL parameter support**: Load models and configure viewer via query params (`?modelUrl=...&theme=dark&select=42,43&view=front`)
- **postMessage bridge**: Full command/response and event system for host-to-viewer communication
- **Multi-model support**: Load and manage multiple IFC models simultaneously
- **Rich controls**: Selection, isolation, visibility, colors, camera, sections, and more
- **Progress events**: Real-time loading feedback to host page
- **WebGPU detection**: Graceful fallback messaging when WebGPU unavailable

### Protocol Design

The embed protocol defines:
- **Inbound commands** (21 types): LOAD_MODEL, SELECT, ISOLATE, SET_CAMERA, SET_SECTION, GET_PROPERTIES, etc.
- **Outbound events** (10 types): READY, MODEL_LOADED, ENTITY_SELECTED, CAMERA_CHANGED, etc.
- **Request/response pattern** with requestId correlation for async operations
- **Type-safe helpers**: `createCommand()`, `createEvent()`, `createResponse()` for both sides

### Implementation Details

- **Bridge initialization**: READY → INIT → INIT_ACK handshake with parent origin tracking
- **Geometry merging**: Multi-model geometries merged with per-model indexing for isolation/selection
- **Type visibility filtering**: Spaces, openings, and site elements can be toggled with transparency
- **Storey-based isolation**: Selection of storeys automatically isolates related entities
- **CORS headers**: Vercel config includes credentialless COEP for iframe compatibility
- **Vite aliases**: `@` points to main viewer's src for component/hook/store reuse

### Build & Deployment

- Added `dev:embed` and `build:embed` scripts to root package.json
- Vercel deployment config with proper CORS, CSP, and COEP headers
- Vite config with WASM and top-level await plugins
- TypeScript paths configured for monorepo package resolution

## Notes

- The embed viewer shares the same Zustand store instance as the main viewer, allowing seamless state management
- URL parameters provide a simple way to pre-configure the viewer without postMessage
- The protocol is versioned (1.0) for forward compatibility
- Error handling includes both request/response errors and fire-and-forget commands

https://claude.ai/code/session_01P5MDhbpLYLYEAWWG2mQ12h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added viewer embed functionality, enabling integration of the 3D IFC viewer into external applications
  * New SDK for embedding with comprehensive API for model loading, visual controls (colors, camera, visibility), and event listening
  * Support for URL parameter configuration (theme, controls, initial view, background color)
  * Iframe-based deployment with cross-origin messaging for secure parent-child communication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->