### PR TITLE
Add MPL 2.0 license headers and improve code quality

### DIFF
--- a/docs/superset-native-plugin-research.md
+++ b/docs/superset-native-plugin-research.md
@@ -70,7 +70,7 @@ const fd = formData as unknown as IFCViewerFormData;
 
 ## Current Architecture
 
-```
+```text
 ┌─────────────────────────────────────────────────────────┐
 │                    Superset Frontend                     │
 ├─────────────────────────────────────────────────────────┤
@@ -114,7 +114,7 @@ Transform IFC file loading from a technical process into a seamless user experie
 
 ### Phase 1: Hosted Model Storage + Auto-Dataset Creation
 
-```
+```text
 ┌──────────────┐     ┌──────────────────┐     ┌─────────────────┐
 │  IFC File    │────▶│  Upload Service  │────▶│  Object Storage │
 │  (User)      │     │  (Parse + Store) │     │  (S3/GCS/R2)    │
@@ -158,7 +158,7 @@ Transform IFC file loading from a technical process into a seamless user experie
 
 ### Phase 3: SaaS Multi-Tenant Platform
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────┐
 │                      IFC-Lite Cloud                              │
 ├─────────────────────────────────────────────────────────────────┤

--- a/packages/superset-plugin/README.md
+++ b/packages/superset-plugin/README.md
@@ -162,7 +162,7 @@ pnpm test
 
 ## Architecture
 
-```
+```text
 IFC File URL
     → fetch() ArrayBuffer
     → @ifc-lite/geometry GeometryProcessor (WASM)

--- a/packages/superset-plugin/src/bootstrap.ts
+++ b/packages/superset-plugin/src/bootstrap.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 /**
  * Async boundary for Module Federation.
  *

--- a/packages/superset-plugin/src/buildQuery.ts
+++ b/packages/superset-plugin/src/buildQuery.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 import {
   buildQueryContext,
   type QueryFormData,
@@ -39,11 +43,7 @@ export default function buildQuery(
 
     // Color-by metric (numeric, aggregated per entity)
     if (formData.colorMetric && !formData.colorByCategory) {
-      const metricValue =
-        typeof formData.colorMetric === 'object'
-          ? formData.colorMetric
-          : formData.colorMetric;
-      metrics.push(metricValue);
+      metrics.push(formData.colorMetric);
     }
 
     // Category column for categorical coloring

--- a/packages/superset-plugin/src/controlPanel.ts
+++ b/packages/superset-plugin/src/controlPanel.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 import type {
   ControlPanelConfig,
   ControlPanelState,

--- a/packages/superset-plugin/src/hooks/useEntityColorMap.ts
+++ b/packages/superset-plugin/src/hooks/useEntityColorMap.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 import { useMemo } from 'react';
 import type { RGBA } from '../utils/colorScale.js';
 
@@ -18,11 +22,19 @@ export function useEntityColorMap(
     if (entityColorMap.size === 0) return new Map<number, RGBA>();
 
     const numericMap = new Map<number, RGBA>();
+    let hasNonNumeric = false;
     for (const [key, rgba] of entityColorMap) {
       const id = Number(key);
       if (!isNaN(id) && isFinite(id)) {
         numericMap.set(id, rgba);
+      } else if (key) {
+        hasNonNumeric = true;
       }
+    }
+    if (hasNonNumeric) {
+      console.warn(
+        'IFC Viewer: entity_id_column must be numeric ExpressID; non-numeric IDs were ignored.',
+      );
     }
     return numericMap;
   }, [entityColorMap]);

--- a/packages/superset-plugin/src/hooks/useIFCRenderer.ts
+++ b/packages/superset-plugin/src/hooks/useIFCRenderer.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 import { useRef, useEffect, useState, useCallback } from 'react';
 import { Renderer } from '@ifc-lite/renderer';
 

--- a/packages/superset-plugin/src/index.ts
+++ b/packages/superset-plugin/src/index.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 /**
  * @ifc-lite/superset-plugin-chart-ifc-viewer
  *

--- a/packages/superset-plugin/src/metadata.ts
+++ b/packages/superset-plugin/src/metadata.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 import { ChartMetadata, Behavior } from './vendor/superset-types.js';
 import { PLUGIN_NAME } from './types.js';
 

--- a/packages/superset-plugin/src/transformProps.ts
+++ b/packages/superset-plugin/src/transformProps.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 import type { ChartProps } from './vendor/superset-types.js';
 import type { IFCViewerFormData, IFCViewerProps } from './types.js';
 import { DEFAULT_BACKGROUND } from './types.js';
@@ -96,17 +100,12 @@ export default function transformProps(chartProps: ChartProps): IFCViewerProps {
   const bgRaw: unknown = fd.backgroundColor;
   if (typeof bgRaw === 'string' && bgRaw.startsWith('#')) {
     backgroundColor = parseHexToNormalized(bgRaw);
-  } else if (
-    bgRaw &&
-    typeof bgRaw === 'object' &&
-    'r' in bgRaw
-  ) {
-    const bg = bgRaw as { r: number; g: number; b: number; a?: number };
+  } else if (isRgbaInput(bgRaw)) {
     backgroundColor = [
-      bg.r / 255,
-      bg.g / 255,
-      bg.b / 255,
-      bg.a ?? 1,
+      bgRaw.r / 255,
+      bgRaw.g / 255,
+      bgRaw.b / 255,
+      bgRaw.a ?? 1,
     ];
   }
 
@@ -154,4 +153,16 @@ function resolveMetricKey(
   if (!metric) return '';
   if (typeof metric === 'string') return metric;
   return metric.label ?? '';
+}
+
+function isRgbaInput(
+  value: unknown,
+): value is { r: number; g: number; b: number; a?: number } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'r' in value &&
+    'g' in value &&
+    'b' in value
+  );
 }

--- a/packages/superset-plugin/src/types.ts
+++ b/packages/superset-plugin/src/types.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 /**
  * TypeScript interfaces for the IFC Viewer Superset plugin.
  */

--- a/packages/superset-plugin/src/utils/colorScale.ts
+++ b/packages/superset-plugin/src/utils/colorScale.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 /**
  * Color scale utilities for mapping entity metrics/categories to RGBA colors.
  *

--- a/packages/superset-plugin/src/vendor/superset-types.ts
+++ b/packages/superset-plugin/src/vendor/superset-types.ts
@@ -1,3 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type React from 'react';
+
 /**
  * Type declarations for @superset-ui/core and @superset-ui/chart-controls.
  *

--- a/packages/superset-plugin/test/buildQuery.test.ts
+++ b/packages/superset-plugin/test/buildQuery.test.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 import { describe, it, expect } from 'vitest';
 import buildQuery from '../src/buildQuery.js';
 
@@ -13,11 +17,11 @@ describe('buildQuery', () => {
     expect(result.queries).toHaveLength(1);
   });
 
-  it('includes entity_id_column in columns and groupby', () => {
+  it('includes entityIdColumn in columns and groupby', () => {
     const result = buildQuery({
       datasource: '1__table',
       viz_type: 'ifc_viewer',
-      entity_id_column: 'global_id',
+      entityIdColumn: 'global_id',
     });
 
     const query = result.queries[0];
@@ -25,37 +29,37 @@ describe('buildQuery', () => {
     expect(query.groupby).toContain('global_id');
   });
 
-  it('includes model_url_column in columns', () => {
+  it('includes modelUrlColumn in columns', () => {
     const result = buildQuery({
       datasource: '1__table',
       viz_type: 'ifc_viewer',
-      model_url_column: 'model_url',
+      modelUrlColumn: 'model_url',
     });
 
     const query = result.queries[0];
     expect(query.columns).toContain('model_url');
   });
 
-  it('includes color_metric in metrics', () => {
+  it('includes colorMetric in metrics', () => {
     const result = buildQuery({
       datasource: '1__table',
       viz_type: 'ifc_viewer',
-      entity_id_column: 'global_id',
-      color_metric: 'total_cost',
+      entityIdColumn: 'global_id',
+      colorMetric: 'total_cost',
     });
 
     const query = result.queries[0];
     expect(query.metrics).toContain('total_cost');
   });
 
-  it('excludes color_metric when color_by_category is true', () => {
+  it('excludes colorMetric when colorByCategory is true', () => {
     const result = buildQuery({
       datasource: '1__table',
       viz_type: 'ifc_viewer',
-      entity_id_column: 'global_id',
-      color_metric: 'total_cost',
-      color_by_category: true,
-      category_column: 'element_type',
+      entityIdColumn: 'global_id',
+      colorMetric: 'total_cost',
+      colorByCategory: true,
+      categoryColumn: 'element_type',
     });
 
     const query = result.queries[0];
@@ -68,6 +72,7 @@ describe('buildQuery', () => {
     const result = buildQuery({
       datasource: '1__table',
       viz_type: 'ifc_viewer',
+      entityIdColumn: 'global_id',
     });
 
     const query = result.queries[0];
@@ -78,6 +83,7 @@ describe('buildQuery', () => {
     const result = buildQuery({
       datasource: '1__table',
       viz_type: 'ifc_viewer',
+      entityIdColumn: 'global_id',
       row_limit: 1000,
     });
 
@@ -85,11 +91,12 @@ describe('buildQuery', () => {
     expect(query.row_limit).toBe(1000);
   });
 
-  it('includes orderby when color_metric is set', () => {
+  it('includes orderby when colorMetric is set', () => {
     const result = buildQuery({
       datasource: '1__table',
       viz_type: 'ifc_viewer',
-      color_metric: 'cost',
+      entityIdColumn: 'global_id',
+      colorMetric: 'cost',
     });
 
     const query = result.queries[0];

--- a/packages/superset-plugin/test/colorScale.test.ts
+++ b/packages/superset-plugin/test/colorScale.test.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 import { describe, it, expect } from 'vitest';
 import {
   buildSequentialColorMap,

--- a/packages/superset-plugin/test/transformProps.test.ts
+++ b/packages/superset-plugin/test/transformProps.test.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 import { describe, it, expect } from 'vitest';
 import transformProps from '../src/transformProps.js';
 import type { ChartProps } from '../src/vendor/superset-types.js';
@@ -32,7 +36,7 @@ describe('transformProps', () => {
   it('resolves static model URL', () => {
     const result = transformProps(
       makeChartProps({
-        formData: { static_model_url: 'https://example.com/model.ifc' },
+        formData: { staticModelUrl: 'https://example.com/model.ifc' },
       }),
     );
 
@@ -43,8 +47,8 @@ describe('transformProps', () => {
     const result = transformProps(
       makeChartProps({
         formData: {
-          static_model_url: 'https://example.com/static.ifc',
-          model_url_column: 'url',
+          staticModelUrl: 'https://example.com/static.ifc',
+          modelUrlColumn: 'url',
         },
         queriesData: [
           {
@@ -63,8 +67,8 @@ describe('transformProps', () => {
     const result = transformProps(
       makeChartProps({
         formData: {
-          entity_id_column: 'global_id',
-          color_metric: 'cost',
+          entityIdColumn: 'global_id',
+          colorMetric: 'cost',
         },
         queriesData: [
           {
@@ -88,9 +92,9 @@ describe('transformProps', () => {
     const result = transformProps(
       makeChartProps({
         formData: {
-          entity_id_column: 'id',
-          color_metric: 'value',
-          color_scheme: 'reds',
+          entityIdColumn: 'id',
+          colorMetric: 'value',
+          colorScheme: 'reds',
         },
         queriesData: [
           {
@@ -114,13 +118,13 @@ describe('transformProps', () => {
     expect(color1).not.toEqual(color3);
   });
 
-  it('builds categorical color map when color_by_category is true', () => {
+  it('builds categorical color map when colorByCategory is true', () => {
     const result = transformProps(
       makeChartProps({
         formData: {
-          entity_id_column: 'id',
-          color_by_category: true,
-          category_column: 'type',
+          entityIdColumn: 'id',
+          colorByCategory: true,
+          categoryColumn: 'type',
         },
         queriesData: [
           {
@@ -145,7 +149,7 @@ describe('transformProps', () => {
   it('parses hex background color', () => {
     const result = transformProps(
       makeChartProps({
-        formData: { background_color: '#ff0000' },
+        formData: { backgroundColor: '#ff0000' },
       }),
     );
 
@@ -194,8 +198,8 @@ describe('transformProps', () => {
     const result = transformProps(
       makeChartProps({
         formData: {
-          entity_id_column: 'id',
-          color_metric: 'value',
+          entityIdColumn: 'id',
+          colorMetric: 'value',
         },
         queriesData: [
           {

--- a/packages/superset-plugin/webpack.config.js
+++ b/packages/superset-plugin/webpack.config.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 /**
  * Webpack configuration for .supx (Module Federation) distribution.
  *


### PR DESCRIPTION
## Summary
This PR adds Mozilla Public License 2.0 (MPL 2.0) headers to all source files in the superset-plugin package, fixes code quality issues, and improves type safety and error handling.

## Key Changes

### License Headers
- Added MPL 2.0 license headers to all TypeScript/JavaScript source files and webpack config
- Updated documentation code blocks to specify `text` language for proper rendering

### Code Quality & Type Safety
- **IFCViewerChart.tsx**: 
  - Removed `numericColorMap` from dependency array with explanatory comment (not yet supported by renderer)
  - Wrapped click handler in try-catch to gracefully handle GPU context loss
  - Memoized container style object to prevent unnecessary re-renders
  
- **useIFCLoader.ts**:
  - Added `processorReadyRef` to track WASM initialization state
  - Moved `LoaderState` interface to types.ts for better organization
  - Added `totalMeshes` field to LoaderState
  - Improved processor initialization error handling with proper state tracking
  
- **useEntityColorMap.ts**:
  - Added validation for numeric entity IDs with console warning for non-numeric IDs
  - Improved type safety in color map conversion
  
- **buildQuery.ts**:
  - Removed redundant type checking for colorMetric
  
- **transformProps.ts**:
  - Extracted `isRgbaInput()` type guard function for cleaner background color parsing
  - Improved type safety for RGBA color handling

### Test Updates
- Updated test descriptions and variable names to use camelCase (e.g., `entity_id_column` → `entityIdColumn`)
- Added missing `entityIdColumn` to test cases for proper query building
- Ensured consistent test coverage across refactored code

### Documentation
- Fixed markdown code block syntax in architecture diagrams (added `text` language specifier)

https://claude.ai/code/session_01Hp9e2i345vT7PQtFPpxxXA