### PR TITLE
Remove debug logs and add build-time version constants

### DIFF
--- a/apps/viewer/src/components/viewer/PropertiesPanel.tsx
+++ b/apps/viewer/src/components/viewer/PropertiesPanel.tsx
@@ -539,26 +539,15 @@ export function PropertiesPanel() {
       modelId = '__legacy__';
     }
 
-    // DEBUG: Log what we're working with
-    console.log('[PropertiesPanel] modelId:', modelId, 'expressId:', expressId, 'mutationVersion:', mutationVersion);
-    console.log('[PropertiesPanel] mutationViews keys:', [...mutationViews.keys()]);
-
     // Try to get properties from mutation view first (handles both base and mutations)
     const mutationView = modelId ? mutationViews.get(modelId) : null;
-    console.log('[PropertiesPanel] mutationView exists:', !!mutationView);
 
     if (mutationView && expressId) {
-      // DEBUG: Log mutation view state
-      const allMutations = mutationView.getMutations();
-      console.log('[PropertiesPanel] All mutations in view:', allMutations.length, allMutations);
-
       // Get merged properties from mutation view (base + mutations applied)
       const mergedProps = mutationView.getForEntity(expressId);
-      console.log('[PropertiesPanel] mergedProps from getForEntity:', mergedProps.length, mergedProps);
 
       // Get list of actual mutations to track which properties changed
       const mutations = mutationView.getMutationsForEntity(expressId);
-      console.log('[PropertiesPanel] mutations for this entity:', mutations.length, mutations);
 
       // Build a set of mutated property keys for quick lookup
       const mutatedKeys = new Set<string>();

--- a/packages/create-ifc-lite/src/index.ts
+++ b/packages/create-ifc-lite/src/index.ts
@@ -168,6 +168,9 @@ function fixViteConfig(targetDir: string) {
   const viteConfig = `import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
+import { readFileSync } from 'fs';
+
+const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
 
 export default defineConfig({
   plugins: [
@@ -184,6 +187,11 @@ export default defineConfig({
       },
     },
   ],
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+    __BUILD_DATE__: JSON.stringify(new Date().toISOString()),
+    __RELEASE_HISTORY__: JSON.stringify([]),
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary
This PR removes debug logging statements from the PropertiesPanel component and adds build-time version and date constants to the Vite configuration for the create-ifc-lite package.

## Key Changes

- **Removed debug console.log statements** from `PropertiesPanel.tsx`:
  - Eliminated 7 debug log statements that were tracking modelId, expressId, mutationVersion, and mutation view state
  - These logs were used during development and are no longer needed in production

- **Added build-time constants** to `create-ifc-lite/src/index.ts`:
  - Imported `readFileSync` from fs module
  - Added logic to read package.json and parse version information
  - Defined three new Vite constants available at build time:
    - `__APP_VERSION__`: Application version from package.json
    - `__BUILD_DATE__`: ISO timestamp of when the build was created
    - `__RELEASE_HISTORY__`: Placeholder array for future release tracking

## Implementation Details
The Vite `define` configuration makes these constants available globally during the build process, allowing them to be used throughout the application for version display and build metadata tracking.

https://claude.ai/code/session_017wS4VGM3oENu9eJWGWgNmV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed debug console output from the properties panel component.
  * Enhanced build configuration to automatically include version, build date, and release history information in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->