### PR TITLE
fix: add missing CHANGELOG.md for @ifc-lite/ids

### DIFF
--- a/packages/ids/CHANGELOG.md
+++ b/packages/ids/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @ifc-lite/ids
+
+## 1.6.0
+
+### Minor Changes
+
+- Initial tracked version


### PR DESCRIPTION
The changesets action crashes with ENOENT when a package is versioned but has no CHANGELOG.md. This was blocking the 1.6.1 release.