### PR TITLE
fix: default to client-side WASM for IFC loading, require opt-in for server

### DIFF
--- a/apps/viewer/src/utils/ifcConfig.ts
+++ b/apps/viewer/src/utils/ifcConfig.ts
@@ -13,11 +13,24 @@ import type { DynamicBatchConfig } from '@ifc-lite/geometry';
 // Server Configuration
 // ============================================================================
 
-/** IFC server URL - only set via environment variable, no default (pure client-side by default) */
+/** IFC server URL - set via environment variable for server-side IFC processing */
 export const SERVER_URL = import.meta.env.VITE_IFC_SERVER_URL || import.meta.env.VITE_SERVER_URL || '';
 
-/** Enable server parsing - only if server URL is explicitly configured */
-export const USE_SERVER = SERVER_URL !== '' && import.meta.env.VITE_USE_SERVER !== 'false';
+/**
+ * Enable server-side IFC parsing (disabled by default — uses client-side WASM).
+ *
+ * The server URL may be present for other features (e.g. superset integration)
+ * without intending to route normal IFC loading through it.
+ *
+ * To enable server-side IFC processing for development:
+ *   1. Set VITE_IFC_SERVER_URL (or VITE_SERVER_URL) to the server endpoint
+ *   2. Set VITE_USE_SERVER=true
+ *
+ * Example .env:
+ *   VITE_IFC_SERVER_URL=https://ifc-server.example.com
+ *   VITE_USE_SERVER=true
+ */
+export const USE_SERVER = SERVER_URL !== '' && import.meta.env.VITE_USE_SERVER === 'true';
 
 // ============================================================================
 // File Size Thresholds (in bytes unless noted)

--- a/apps/viewer/src/vite-env.d.ts
+++ b/apps/viewer/src/vite-env.d.ts
@@ -5,8 +5,11 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
+  /** Server URL for IFC processing (also used by superset integration) */
   readonly VITE_IFC_SERVER_URL?: string;
+  /** Alternative server URL env var */
   readonly VITE_SERVER_URL?: string;
+  /** Set to 'true' to route IFC loading through server instead of client-side WASM */
   readonly VITE_USE_SERVER?: string;
 }
 


### PR DESCRIPTION
The demo viewer had VITE_IFC_SERVER_URL set for superset integration,
which caused normal IFC loading to route through the server instead of
client-side WASM processing. Flip USE_SERVER to opt-in (requires
VITE_USE_SERVER=true) so the server URL can coexist without affecting
the default WASM processing path.

https://claude.ai/code/session_01StjyfVxUSUbDcVmqyr477T

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated server-side processing activation to require explicit opt-in rather than default enablement.
  * Enhanced configuration documentation with JSDoc comments for environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->