### PR TITLE
feat: respect system color-scheme preference on initial load

### DIFF
--- a/apps/viewer/index.html
+++ b/apps/viewer/index.html
@@ -1,9 +1,18 @@
 <!DOCTYPE html>
-<html lang="en" class="dark">
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>IFClite Viewer</title>
+  <script>
+    // Apply theme before first paint to prevent flash of wrong theme.
+    // Priority: localStorage override > system preference > dark fallback.
+    (function() {
+      var saved = localStorage.getItem('ifc-lite-theme');
+      var theme = saved || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+      if (theme === 'dark') document.documentElement.classList.add('dark');
+    })();
+  </script>
   
   <!-- Legacy ICO favicon (for older browsers) -->
   <link rel="icon" type="image/x-icon" href="/favicon.ico">

--- a/apps/viewer/src/components/viewer/ViewerLayout.tsx
+++ b/apps/viewer/src/components/viewer/ViewerLayout.tsx
@@ -113,12 +113,7 @@ export function ViewerLayout() {
     return () => window.removeEventListener('resize', checkMobile);
   }, [setIsMobile, setLeftPanelCollapsed, setRightPanelCollapsed]);
 
-  // Initialize theme on mount and sync with store
-  useEffect(() => {
-    const currentTheme = useViewerStore.getState().theme;
-    document.documentElement.classList.toggle('dark', currentTheme === 'dark');
-  }, []);
-
+  // Keep DOM class in sync when theme changes (initial class is set by inline script in index.html)
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
   }, [theme]);

--- a/apps/viewer/src/store/constants.ts
+++ b/apps/viewer/src/store/constants.ts
@@ -51,11 +51,19 @@ export const EDGE_LOCK_DEFAULTS = {
 // UI Defaults
 // ============================================================================
 
+/** Resolve the initial theme: localStorage override > system preference > dark fallback */
+function getInitialTheme(): 'light' | 'dark' {
+  if (typeof window === 'undefined') return 'dark';
+  const saved = localStorage.getItem('ifc-lite-theme');
+  if (saved === 'light' || saved === 'dark') return saved;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
 export const UI_DEFAULTS = {
   /** Default active tool */
   ACTIVE_TOOL: 'select',
-  /** Default theme */
-  THEME: 'dark' as const,
+  /** Default theme – respects user's OS colour-scheme preference */
+  THEME: getInitialTheme(),
   /** Default hover tooltips state */
   HOVER_TOOLTIPS_ENABLED: false,
 } as const;

--- a/apps/viewer/src/store/slices/uiSlice.ts
+++ b/apps/viewer/src/store/slices/uiSlice.ts
@@ -44,12 +44,14 @@ export const createUISlice: StateCreator<UISlice, [], [], UISlice> = (set, get) 
 
   setTheme: (theme) => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
+    localStorage.setItem('ifc-lite-theme', theme);
     set({ theme });
   },
 
   toggleTheme: () => {
     const newTheme = get().theme === 'dark' ? 'light' : 'dark';
     document.documentElement.classList.toggle('dark', newTheme === 'dark');
+    localStorage.setItem('ifc-lite-theme', newTheme);
     set({ theme: newTheme });
   },
 


### PR DESCRIPTION
The app previously hardcoded dark mode. Now:
- An inline script in index.html applies the correct class before first paint (no flash of wrong theme)
- The Zustand store default reads from localStorage, then falls back to the browser's prefers-color-scheme media query
- Toggling the theme persists the choice to localStorage so it survives page reloads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Your theme preference is now saved and persists across sessions for a consistent experience
  * App automatically respects your operating system's color-scheme preference when no saved preference is found

* **Bug Fixes**
  * Eliminated the flash of incorrect theme that appeared briefly on page load

<!-- end of auto-generated comment: release notes by coderabbit.ai -->