### PR TITLE
fix: override Tailwind v4 dark variant to use .dark class instead of …

### DIFF
--- a/apps/viewer/src/index.css
+++ b/apps/viewer/src/index.css
@@ -4,6 +4,12 @@
 
 @import "tailwindcss";
 
+/* Override Tailwind v4's default media-query dark variant so all dark: utilities
+   respond to the .dark class on <html> instead of prefers-color-scheme.
+   Without this, toggling light mode while the OS is in dark mode leaves all
+   dark: Tailwind utilities active, creating a mixed dark/light UI. */
+@custom-variant dark (&:where(.dark, .dark *));
+
 /* ═══════════════════════════════════════════════════════════════════════════
    TOKYO NIGHT THEME - Dark Stormy Cyberpunk Vibes
    ═══════════════════════════════════════════════════════════════════════════ */


### PR DESCRIPTION
…prefers-color-scheme

Tailwind v4 defaults its dark: variant to @media (prefers-color-scheme: dark), ignoring the v3-era darkMode: ['class'] option in tailwind.config.js. This meant that when a user with an OS-level dark mode switched the app to light theme, the .dark class was correctly removed (fixing CSS custom properties) but all 361 dark: utility applications across 25 component files still fired via the media query, producing a broken mixed dark/light UI.

Adding @custom-variant dark (&:where(.dark, .dark *)) at the top of index.css redirects the entire dark: variant to class-based detection, consistent with how the theme toggle and CSS variable overrides already work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced dark mode behavior to properly respond to user-toggled dark mode preferences, improving the experience when switching between light and dark themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->