### PR TITLE
chore: disable LFS in workflows and document fixture strategy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          lfs: true
+          lfs: false
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          lfs: true
+          lfs: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
@@ -101,7 +101,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          lfs: true
+          lfs: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
@@ -171,7 +171,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          lfs: true
+          lfs: false
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -474,6 +474,16 @@ jobs:
         uses: codecov/codecov-action@v3
 ```
 
+### IFC Fixture Strategy
+
+Use a tiered fixture approach so release pipelines stay reliable when Git LFS quota is constrained:
+
+1. Keep release and docs workflows on `actions/checkout` with `lfs: false`.
+2. Keep small smoke-test fixtures in Git (non-LFS) and run them on every PR and release.
+3. Run heavy IFC corpus tests (large geometry/benchmark sets) in dedicated manual or scheduled workflows.
+4. For heavy workflows, fetch only required fixtures with `git lfs pull --include="<paths>"` instead of downloading all LFS objects.
+5. Add caching and checksums for downloaded fixture bundles when using external artifact storage.
+
 ## Next Steps
 
 - [Setup](setup.md) - Development setup


### PR DESCRIPTION
- Updated GitHub Actions workflows to set `lfs: false` for the checkout action, ensuring that large file storage is not used during the release and documentation processes.
- Added a new section in the testing documentation outlining a tiered fixture strategy to maintain reliability in release pipelines when Git LFS quota is constrained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on fixture strategy and Git LFS quota management for testing workflows.

* **Chores**
  * Optimized CI/CD workflows for improved efficiency in release and documentation pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->