### PR TITLE
feat: surface-aligned section plane mode (click-to-pick face + slide along normal)

### DIFF
--- a/.changeset/soft-lamps-train.md
+++ b/.changeset/soft-lamps-train.md
@@ -1,0 +1,6 @@
+---
+"@ifc-lite/viewer": minor
+"@ifc-lite/renderer": minor
+---
+
+Add a new surface-aligned section mode that lets users click a model face to orient the cut plane and then move the plane along the picked face normal.

--- a/apps/viewer/src/components/viewer/useMouseControls.ts
+++ b/apps/viewer/src/components/viewer/useMouseControls.ts
@@ -87,6 +87,10 @@ export interface UseMouseControlsParams {
 
   // Callbacks
   handlePickForSelection: (pickResult: PickResult | null) => void;
+  onSectionSurfacePick: (
+    point: { x: number; y: number; z: number },
+    normal: { x: number; y: number; z: number }
+  ) => void;
   setHoverState: (state: { entityId: number; screenX: number; screenY: number }) => void;
   clearHover: () => void;
   openContextMenu: (entityId: number | null, screenX: number, screenY: number) => void;
@@ -201,6 +205,7 @@ export function useMouseControls(params: UseMouseControlsParams): void {
     lastClickPosRef,
     lastCameraStateRef,
     handlePickForSelection,
+    onSectionSurfacePick,
     setHoverState,
     clearHover,
     openContextMenu,
@@ -944,6 +949,22 @@ export function useMouseControls(params: UseMouseControlsParams): void {
       // Measure tool now uses drag interaction (see mousedown/mousemove/mouseup)
       if (tool === 'measure') {
         return; // Skip click handling for measure tool
+      }
+
+      if (tool === 'section' && sectionPlaneRef.current.mode === 'surface') {
+        const result = renderer.raycastScene(x, y, {
+          ...getPickOptions(),
+          snapOptions: {
+            snapToVertices: false,
+            snapToEdges: false,
+            snapToFaces: false,
+          },
+        });
+
+        if (result?.intersection) {
+          onSectionSurfacePick(result.intersection.point, result.intersection.normal);
+        }
+        return;
       }
 
       const now = Date.now();

--- a/apps/viewer/src/components/viewer/useRenderUpdates.ts
+++ b/apps/viewer/src/components/viewer/useRenderUpdates.ts
@@ -103,7 +103,7 @@ export function useRenderUpdates(params: UseRenderUpdatesParams): void {
     if (!renderer || !isInitialized) return;
 
     // Only show overlay when section tool is active, we have a drawing, AND 3D overlay is enabled
-    if (activeTool === 'section' && drawing2D && drawing2D.cutPolygons.length > 0 && show3DOverlay) {
+    if (activeTool === 'section' && sectionPlane.mode === 'axis' && drawing2D && drawing2D.cutPolygons.length > 0 && show3DOverlay) {
       // Convert Drawing2D format to renderer format
       const polygons: CutPolygon2D[] = drawing2D.cutPolygons.map((cp) => ({
         polygon: cp.polygon,

--- a/apps/viewer/src/store.ts
+++ b/apps/viewer/src/store.ts
@@ -29,6 +29,7 @@ export type {
   Measurement,
   ActiveMeasurement,
   EdgeLockState,
+  SectionPlaneMode,
   SectionPlaneAxis,
   SectionPlane,
   HoverState,

--- a/apps/viewer/src/store/constants.ts
+++ b/apps/viewer/src/store/constants.ts
@@ -22,6 +22,8 @@ export const CAMERA_DEFAULTS = {
 // ============================================================================
 
 export const SECTION_PLANE_DEFAULTS = {
+  /** Default section plane mode */
+  MODE: 'axis' as const,
   /** Default section plane axis */
   AXIS: 'down' as const,
   /** Default section plane position (percentage of model bounds) */

--- a/apps/viewer/src/store/slices/sectionSlice.test.ts
+++ b/apps/viewer/src/store/slices/sectionSlice.test.ts
@@ -29,9 +29,26 @@ describe('SectionSlice', () => {
   describe('initial state', () => {
     it('should have default section plane values', () => {
       assert.strictEqual(state.sectionPlane.axis, SECTION_PLANE_DEFAULTS.AXIS);
+      assert.strictEqual(state.sectionPlane.mode, SECTION_PLANE_DEFAULTS.MODE);
       assert.strictEqual(state.sectionPlane.position, SECTION_PLANE_DEFAULTS.POSITION);
       assert.strictEqual(state.sectionPlane.enabled, SECTION_PLANE_DEFAULTS.ENABLED);
       assert.strictEqual(state.sectionPlane.flipped, SECTION_PLANE_DEFAULTS.FLIPPED);
+      assert.strictEqual(state.sectionPlane.customNormal, null);
+    });
+  });
+
+  describe('setSectionPlaneMode', () => {
+    it('should update mode to surface without changing axis', () => {
+      state.setSectionPlaneMode('surface');
+      assert.strictEqual(state.sectionPlane.mode, 'surface');
+      assert.strictEqual(state.sectionPlane.axis, SECTION_PLANE_DEFAULTS.AXIS);
+    });
+
+    it('should clear custom normal when switching back to axis mode', () => {
+      state.setSectionPlaneFromSurface({ x: 1, y: 0, z: 0 }, 25);
+      state.setSectionPlaneMode('axis');
+      assert.strictEqual(state.sectionPlane.mode, 'axis');
+      assert.strictEqual(state.sectionPlane.customNormal, null);
     });
   });
 
@@ -42,10 +59,14 @@ describe('SectionSlice', () => {
     });
 
     it('should preserve other section plane properties', () => {
+      state.sectionPlane.mode = 'surface';
+      state.sectionPlane.customNormal = { x: 0, y: 1, z: 0 };
       state.sectionPlane.position = 75;
       state.setSectionPlaneAxis('side');
+      assert.strictEqual(state.sectionPlane.mode, 'axis');
       assert.strictEqual(state.sectionPlane.axis, 'side');
       assert.strictEqual(state.sectionPlane.position, 75);
+      assert.strictEqual(state.sectionPlane.customNormal, null);
     });
   });
 
@@ -90,6 +111,20 @@ describe('SectionSlice', () => {
     });
   });
 
+  describe('setSectionPlaneFromSurface', () => {
+    it('should set surface mode and normalize normal', () => {
+      state.setSectionPlaneFromSurface({ x: 10, y: 0, z: 0 }, 50);
+      assert.strictEqual(state.sectionPlane.mode, 'surface');
+      assert.strictEqual(state.sectionPlane.position, 50);
+      assert.deepStrictEqual(state.sectionPlane.customNormal, { x: 1, y: 0, z: 0 });
+    });
+
+    it('should clamp position to valid range', () => {
+      state.setSectionPlaneFromSurface({ x: 0, y: 1, z: 0 }, 150);
+      assert.strictEqual(state.sectionPlane.position, 100);
+    });
+  });
+
   describe('flipSectionPlane', () => {
     it('should toggle flipped from false to true', () => {
       assert.strictEqual(state.sectionPlane.flipped, false);
@@ -108,18 +143,22 @@ describe('SectionSlice', () => {
     it('should reset to default values', () => {
       // Modify state
       state.sectionPlane = {
+        mode: 'surface',
         axis: 'side',
         position: 25,
         enabled: false,
         flipped: true,
+        customNormal: { x: 1, y: 0, z: 0 },
       };
 
       state.resetSectionPlane();
 
       assert.strictEqual(state.sectionPlane.axis, SECTION_PLANE_DEFAULTS.AXIS);
+      assert.strictEqual(state.sectionPlane.mode, SECTION_PLANE_DEFAULTS.MODE);
       assert.strictEqual(state.sectionPlane.position, SECTION_PLANE_DEFAULTS.POSITION);
       assert.strictEqual(state.sectionPlane.enabled, SECTION_PLANE_DEFAULTS.ENABLED);
       assert.strictEqual(state.sectionPlane.flipped, SECTION_PLANE_DEFAULTS.FLIPPED);
+      assert.strictEqual(state.sectionPlane.customNormal, null);
     });
   });
 });

--- a/apps/viewer/src/store/slices/sectionSlice.ts
+++ b/apps/viewer/src/store/slices/sectionSlice.ts
@@ -7,7 +7,7 @@
  */
 
 import type { StateCreator } from 'zustand';
-import type { SectionPlane, SectionPlaneAxis } from '../types.js';
+import type { SectionPlane, SectionPlaneAxis, SectionPlaneMode, SectionPlaneNormal } from '../types.js';
 import { SECTION_PLANE_DEFAULTS } from '../constants.js';
 
 export interface SectionSlice {
@@ -15,18 +15,22 @@ export interface SectionSlice {
   sectionPlane: SectionPlane;
 
   // Actions
+  setSectionPlaneMode: (mode: SectionPlaneMode) => void;
   setSectionPlaneAxis: (axis: SectionPlaneAxis) => void;
   setSectionPlanePosition: (position: number) => void;
+  setSectionPlaneFromSurface: (normal: SectionPlaneNormal, position: number) => void;
   toggleSectionPlane: () => void;
   flipSectionPlane: () => void;
   resetSectionPlane: () => void;
 }
 
 const getDefaultSectionPlane = (): SectionPlane => ({
+  mode: SECTION_PLANE_DEFAULTS.MODE,
   axis: SECTION_PLANE_DEFAULTS.AXIS,
   position: SECTION_PLANE_DEFAULTS.POSITION,
   enabled: SECTION_PLANE_DEFAULTS.ENABLED,
   flipped: SECTION_PLANE_DEFAULTS.FLIPPED,
+  customNormal: null,
 });
 
 export const createSectionSlice: StateCreator<SectionSlice, [], [], SectionSlice> = (set) => ({
@@ -34,8 +38,21 @@ export const createSectionSlice: StateCreator<SectionSlice, [], [], SectionSlice
   sectionPlane: getDefaultSectionPlane(),
 
   // Actions
+  setSectionPlaneMode: (mode) => set((state) => ({
+    sectionPlane: {
+      ...state.sectionPlane,
+      mode,
+      customNormal: mode === 'axis' ? null : state.sectionPlane.customNormal,
+    },
+  })),
+
   setSectionPlaneAxis: (axis) => set((state) => ({
-    sectionPlane: { ...state.sectionPlane, axis },
+    sectionPlane: {
+      ...state.sectionPlane,
+      mode: 'axis',
+      axis,
+      customNormal: null,
+    },
   })),
 
   setSectionPlanePosition: (position) => set((state) => {
@@ -43,6 +60,28 @@ export const createSectionSlice: StateCreator<SectionSlice, [], [], SectionSlice
     const clampedPosition = Math.min(100, Math.max(0, Number(position) || 0));
     return {
       sectionPlane: { ...state.sectionPlane, position: clampedPosition },
+    };
+  }),
+
+  setSectionPlaneFromSurface: (normal, position) => set((state) => {
+    const len = Math.sqrt(normal.x * normal.x + normal.y * normal.y + normal.z * normal.z);
+    if (len < 0.000001) {
+      return { sectionPlane: state.sectionPlane };
+    }
+
+    const clampedPosition = Math.min(100, Math.max(0, Number(position) || 0));
+
+    return {
+      sectionPlane: {
+        ...state.sectionPlane,
+        mode: 'surface',
+        position: clampedPosition,
+        customNormal: {
+          x: normal.x / len,
+          y: normal.y / len,
+          z: normal.z / len,
+        },
+      },
     };
   }),
 

--- a/apps/viewer/src/store/types.ts
+++ b/apps/viewer/src/store/types.ts
@@ -85,14 +85,24 @@ export interface EdgeLockState {
 
 /** Semantic axis names: down (Y), front (Z), side (X) for intuitive user experience */
 export type SectionPlaneAxis = 'down' | 'front' | 'side';
+export type SectionPlaneMode = 'axis' | 'surface';
+
+export interface SectionPlaneNormal {
+  x: number;
+  y: number;
+  z: number;
+}
 
 export interface SectionPlane {
+  mode: SectionPlaneMode;
   axis: SectionPlaneAxis;
   /** 0-100 percentage of model bounds */
   position: number;
   enabled: boolean;
   /** If true, show the opposite side of the cut */
   flipped: boolean;
+  /** User-picked surface normal for free-angle section mode */
+  customNormal: SectionPlaneNormal | null;
 }
 
 // ============================================================================

--- a/apps/viewer/src/utils/viewportUtils.ts
+++ b/apps/viewer/src/utils/viewportUtils.ts
@@ -22,6 +22,12 @@ export interface Point3D {
   z: number;
 }
 
+export interface Vector3D {
+  x: number;
+  y: number;
+  z: number;
+}
+
 /**
  * Bounding box in 3D space
  */
@@ -227,6 +233,44 @@ export function calculateGeometryBounds(meshes: MeshData[]): BoundingBox3D {
     min: { x: minX, y: minY, z: minZ },
     max: { x: maxX, y: maxY, z: maxZ },
   };
+}
+
+/**
+ * Project an axis-aligned bounding box onto an arbitrary unit normal.
+ * Returns min/max signed distance values in world coordinates.
+ */
+export function calculateProjectedRangeFromBounds(
+  bounds: BoundingBox3D,
+  normal: Vector3D
+): { min: number; max: number } {
+  const corners: Point3D[] = [
+    { x: bounds.min.x, y: bounds.min.y, z: bounds.min.z },
+    { x: bounds.min.x, y: bounds.min.y, z: bounds.max.z },
+    { x: bounds.min.x, y: bounds.max.y, z: bounds.min.z },
+    { x: bounds.min.x, y: bounds.max.y, z: bounds.max.z },
+    { x: bounds.max.x, y: bounds.min.y, z: bounds.min.z },
+    { x: bounds.max.x, y: bounds.min.y, z: bounds.max.z },
+    { x: bounds.max.x, y: bounds.max.y, z: bounds.min.z },
+    { x: bounds.max.x, y: bounds.max.y, z: bounds.max.z },
+  ];
+
+  let min = Infinity;
+  let max = -Infinity;
+
+  for (const corner of corners) {
+    const projection =
+      corner.x * normal.x +
+      corner.y * normal.y +
+      corner.z * normal.z;
+    min = Math.min(min, projection);
+    max = Math.max(max, projection);
+  }
+
+  if (!Number.isFinite(min) || !Number.isFinite(max)) {
+    return { min: -100, max: 100 };
+  }
+
+  return { min, max };
 }
 
 // ============================================================================

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -93,6 +93,7 @@ export interface SectionPlane {
   position: number; // 0-100 percentage of model bounds
   enabled: boolean;
   flipped?: boolean; // If true, show the opposite side of the cut
+  customNormal?: { x: number; y: number; z: number } | null; // Arbitrary surface-aligned section normal
   min?: number;      // Optional override for min range value
   max?: number;      // Optional override for max range value
 }


### PR DESCRIPTION
### Motivation

- Give users a free-angle section mode where they can click a surface to create a cut plane aligned to that face and then slide the plane along the face normal, instead of only X/Y/Z axis cuts.

### Description

- Add `mode: 'axis' | 'surface'` and `customNormal` to the viewer `SectionPlane` state and defaults, and expose new actions `setSectionPlaneMode` and `setSectionPlaneFromSurface` to set a normalized picked normal and position. (files: `apps/viewer/src/store/types.ts`, `apps/viewer/src/store/constants.ts`, `apps/viewer/src/store/slices/sectionSlice.ts`)
- Wire viewport mouse handling so when the Section tool is in `surface` mode a click raycasts the clicked triangle, extracts the hit point and triangle normal, projects the model bounds onto that normal to compute a min/max distance range, and sets the section position as a percentage along that range via `setSectionPlaneFromSurface`. (files: `apps/viewer/src/components/viewer/useMouseControls.ts`, `apps/viewer/src/components/viewer/Viewport.tsx`, `apps/viewer/src/utils/viewportUtils.ts`)
- Update the Section tool UI to provide an Axis/Surface mode switch, show an instruction when in Surface mode, and disable the axis-only 2D drawing action when Surface mode is active. Also update status text to reflect mode. (file: `apps/viewer/src/components/viewer/tools/SectionPanel.tsx`)
- Extend renderer APIs to accept an arbitrary `customNormal` on the `sectionPlane` options, compute clipping distance by projecting the scene AABB onto that normal when needed, avoid applying building rotation to user-picked normals, and render a preview plane oriented to the arbitrary normal (preview geometry generation implemented for non-axis-aligned planes). (files: `packages/renderer/src/types.ts`, `packages/renderer/src/index.ts`, `packages/renderer/src/section-plane.ts`)
- Add a pure utility to compute projected min/max (AABB projected onto a unit normal) used by viewport and renderer. (file: `apps/viewer/src/utils/viewportUtils.ts`)
- Add unit tests for the section slice (mode transitions and surface-normal behavior) and include a changeset for `@ifc-lite/viewer` and `@ifc-lite/renderer` describing the feature. (files: `apps/viewer/src/store/slices/sectionSlice.test.ts`, `.changeset/soft-lamps-train.md`)

### Testing

- Ran slice unit tests: `cd apps/viewer && pnpm exec tsx --test src/store/slices/sectionSlice.test.ts` — all tests passed for the new `SectionSlice` behavior (mode switch, `setSectionPlaneFromSurface`, normalization, clamping). (passed)
- Attempted full package builds: `pnpm --filter @ifc-lite/viewer build` and `pnpm --filter @ifc-lite/renderer build` — these failed in the workspace environment due to unrelated workspace dependency / resolver issues (missing package entry points / types in this execution environment), not due to the new feature changes. (build failures unrelated)
- Launched dev server and performed a quick UI smoke check; captured a screenshot of the updated Section panel in Surface mode: `artifacts/section-surface-mode.png` (dev server started and UI visible).

If you want I can follow up with: add integration tests that exercise a surface pick with synthetic geometry, or help debug the workspace build issues seen in this environment so we can run full `viewer`/`renderer` builds in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f279151448320982b5f5e35f6d110)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Surface-aligned section mode: click model faces to orient the cutting plane along the picked surface's normal
  * Mode toggle to switch between axis-aligned and surface-aligned section planes
  * Updated UI with mode-specific controls, status messages, and guidance for surface mode
  * 2D drawing feature now available only in axis mode

<!-- end of auto-generated comment: release notes by coderabbit.ai -->