### PR TITLE
docs: add AGENT.md with agent guidelines and LICENSE_HEADER.md

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,27 @@
+# Agent Guidelines: ifc-lite
+
+## 1. Mandatory Schema Compliance
+- **Strict Nomenclature:** Use exact IFC EXPRESS names in user-facing APIs, scripting, and exports. Never invent simplified aliases.
+- **Attributes:** Use IFC PascalCase (`GlobalId`, `Name`, `Description`, `ObjectType`, `Type`) as the default user-facing shape.
+- **Relationships:** Use full IFC relationship entity names (e.g., `IfcRelAggregates`, **not** `Aggregates`).
+- **Type Casing:** STEP entity names are stored as `UPPERCASE`. For display/API output, use `store.entities.getTypeName(id)` to return proper `IfcPascalCase`.
+
+## 2. Critical Performance Patterns
+- **On-Demand Extraction:** `extractEntityAttributesOnDemand` parses the source buffer and is expensive. **Never** call it in large loops; use cached `EntityNode` getters or the list adapter provider.
+- **Zustand Subscriptions:** Use fine-grained selectors (`useViewerStore((s) => s.item)`) to avoid unnecessary re-renders.
+- **Federation-Aware IDs:** Always distinguish `localExpressId` from federated `globalId`; convert via federation helpers/offsets, never ad-hoc math in UI code.
+
+## 3. Mandatory Workflows
+- **License Headers:** Every new source file must include the MPL-2.0 header documented in [`./LICENSE_HEADER.md`](./LICENSE_HEADER.md).
+- **Changesets:** If changes affect published `packages/*`, add a changeset with `pnpm changeset`. Never manually edit package versions or `CHANGELOG.md`.
+- **Generated Artifacts:** Do not edit generated WASM JS/TS declaration outputs in `packages/wasm/`; make source changes in Rust crates and regenerate.
+
+## 4. Single-Model vs Federated-Model Correctness (Common Failure Mode)
+- **Treat both modes as first-class:** Code must work when there is exactly one legacy model *and* when multiple federated models are loaded.
+- **Use canonical resolution path:** Resolve selections/IDs through store-based helpers (`resolveGlobalIdFromModels` and `resolveEntityRef`) rather than assuming federation map state.
+- **Honor fallback behavior:** If federation lookup misses, support single-model fallback (`globalId === expressId`) and legacy sentinel behavior (`modelId: 'legacy'`) where required.
+- **Do not hardcode multi-model assumptions:** Avoid logic that only works when `models.size > 1`; verify behavior for `models.size === 0` (legacy), `1`, and `N`.
+
+## 5. Feedback Loop
+- If a pattern is confusing or repeatedly error-prone, call it out explicitly in your PR notes.
+- Prefer refactors that make the correct path the easiest path (single source of truth helpers, stricter types, fewer implicit fallbacks).

--- a/LICENSE_HEADER.md
+++ b/LICENSE_HEADER.md
@@ -1,0 +1,17 @@
+# License Headers for ifc-lite
+
+All new source files must include the Mozilla Public License 2.0 header at the top.
+
+### TypeScript / JavaScript / CSS (`.ts`, `.tsx`, `.js`, `.css`)
+```text
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+```
+
+### Rust (`.rs`)
+```text
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+```


### PR DESCRIPTION
### Motivation
- Reduce recurring agent mistakes by clarifying IFC schema compliance, performance-safe patterns, and federation vs single-model behavior.
- Provide a single discoverable source for the required Mozilla Public License 2.0 header to ensure consistent licensing in new files.

### Description
- Add `AGENT.md` with concise agent guidelines covering strict IFC EXPRESS nomenclature, on-demand extraction performance rules, Zustand subscription best practices, federation-aware ID handling, mandatory workflows, and a dedicated section on single-model vs federated-model correctness.
- Add `LICENSE_HEADER.md` containing the canonical MPL-2.0 header text blocks for TypeScript/JavaScript/CSS and Rust files and link it from `AGENT.md`.
- Commit the two documentation files to the repository to make the rules and header text easily referenceable by agents and contributors.

### Testing
- This is a documentation-only change so no automated unit or integration tests were run and no test changes were required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f29fb08d48320acbbe6445213c20c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive development and technical standards guidelines.
  * Added Mozilla Public License 2.0 header templates for source files.

* **Chores**
  * Established standardized development practices and licensing conventions for the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->