### PR TITLE
Add surface-aligned section plane mode with gizmo and renderer support

### DIFF
--- a/.changeset/five-rivers-breathe.md
+++ b/.changeset/five-rivers-breathe.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/renderer": minor
+---
+
+Add a surface-aligned section mode that lets users click a model face to derive the clipping plane and then move that plane along its own normal.

--- a/apps/viewer/src/components/viewer/tools/SectionGizmo.tsx
+++ b/apps/viewer/src/components/viewer/tools/SectionGizmo.tsx
@@ -1,0 +1,244 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { useCallback, useEffect, useMemo, useRef, useState, type PointerEvent as ReactPointerEvent } from 'react';
+import { useViewerStore } from '@/store';
+import { calculateProjectionRange } from '../../../utils/viewportUtils.js';
+
+interface GizmoScreenState {
+  center: { x: number; y: number };
+  arrowEnd: { x: number; y: number };
+  visible: boolean;
+}
+
+interface DragState {
+  kind: 'arrow' | 'plane';
+  startPointer: { x: number; y: number };
+  startPosition: number;
+  axisDir: { x: number; y: number };
+  axisPixelLength: number;
+  rangeLength: number;
+}
+
+function normalize3(v: { x: number; y: number; z: number }): { x: number; y: number; z: number } {
+  const len = Math.hypot(v.x, v.y, v.z);
+  if (len < 1e-6) return { x: 0, y: 1, z: 0 };
+  return { x: v.x / len, y: v.y / len, z: v.z / len };
+}
+
+function dot3(a: { x: number; y: number; z: number }, b: { x: number; y: number; z: number }): number {
+  return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+
+export function SectionGizmo() {
+  const activeTool = useViewerStore((s) => s.activeTool);
+  const sectionPlane = useViewerStore((s) => s.sectionPlane);
+  const coordinateInfo = useViewerStore((s) => s.geometryResult?.coordinateInfo);
+  const cameraCallbacks = useViewerStore((s) => s.cameraCallbacks);
+  const setSectionPlanePosition = useViewerStore((s) => s.setSectionPlanePosition);
+
+  const [screenState, setScreenState] = useState<GizmoScreenState | null>(null);
+  const dragStateRef = useRef<DragState | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const planeMath = useMemo(() => {
+    const bounds = coordinateInfo?.shiftedBounds;
+    if (!bounds) return null;
+
+    let normal = sectionPlane.mode === 'surface' ? sectionPlane.surface?.normal ?? null : null;
+    if (!normal) {
+      normal = sectionPlane.axis === 'side'
+        ? { x: 1, y: 0, z: 0 }
+        : sectionPlane.axis === 'down'
+          ? { x: 0, y: 1, z: 0 }
+          : { x: 0, y: 0, z: 1 };
+    }
+
+    const n = normalize3(normal);
+    const range = sectionPlane.mode === 'surface'
+      ? calculateProjectionRange(bounds, n)
+      : (() => {
+        const axisKey = sectionPlane.axis === 'side' ? 'x' : sectionPlane.axis === 'down' ? 'y' : 'z';
+        const min = bounds.min[axisKey];
+        const max = bounds.max[axisKey];
+        return Number.isFinite(min) && Number.isFinite(max) ? { min, max } : null;
+      })();
+
+    if (!range) return null;
+
+    const distance = range.min + (sectionPlane.position / 100) * (range.max - range.min);
+    const center = {
+      x: (bounds.min.x + bounds.max.x) / 2,
+      y: (bounds.min.y + bounds.max.y) / 2,
+      z: (bounds.min.z + bounds.max.z) / 2,
+    };
+
+    const centerDot = dot3(center, n);
+    const centerOnPlane = {
+      x: center.x + (distance - centerDot) * n.x,
+      y: center.y + (distance - centerDot) * n.y,
+      z: center.z + (distance - centerDot) * n.z,
+    };
+
+    const diag = Math.hypot(bounds.max.x - bounds.min.x, bounds.max.y - bounds.min.y, bounds.max.z - bounds.min.z);
+    const arrowLength = Math.max(2, diag * 0.12);
+
+    return {
+      normal: n,
+      range,
+      centerOnPlane,
+      arrowEnd: {
+        x: centerOnPlane.x + n.x * arrowLength,
+        y: centerOnPlane.y + n.y * arrowLength,
+        z: centerOnPlane.z + n.z * arrowLength,
+      },
+      arrowLength,
+    };
+  }, [coordinateInfo, sectionPlane]);
+
+  useEffect(() => {
+    if (activeTool !== 'section') {
+      setScreenState(null);
+      return;
+    }
+
+    let raf: number | null = null;
+    const tick = () => {
+      const projectToScreen = cameraCallbacks.projectToScreen;
+      const canvas = document.querySelector<HTMLCanvasElement>('canvas[data-viewport="main"]');
+      if (!projectToScreen || !planeMath || !canvas) {
+        setScreenState(null);
+        raf = requestAnimationFrame(tick);
+        return;
+      }
+
+      const centerRaw = projectToScreen(planeMath.centerOnPlane);
+      const arrowRaw = projectToScreen(planeMath.arrowEnd);
+
+      if (!centerRaw || !arrowRaw || canvas.width <= 0 || canvas.height <= 0) {
+        setScreenState(null);
+        raf = requestAnimationFrame(tick);
+        return;
+      }
+
+      const rect = canvas.getBoundingClientRect();
+      const scaleX = rect.width / canvas.width;
+      const scaleY = rect.height / canvas.height;
+
+      const center = { x: centerRaw.x * scaleX, y: centerRaw.y * scaleY };
+      const arrowEnd = { x: arrowRaw.x * scaleX, y: arrowRaw.y * scaleY };
+
+      setScreenState({ center, arrowEnd, visible: true });
+      raf = requestAnimationFrame(tick);
+    };
+
+    raf = requestAnimationFrame(tick);
+    return () => {
+      if (raf !== null) cancelAnimationFrame(raf);
+    };
+  }, [activeTool, cameraCallbacks.projectToScreen, planeMath]);
+
+  const beginDrag = useCallback((kind: 'arrow' | 'plane', e: ReactPointerEvent) => {
+    if (!screenState || !planeMath) return;
+    if (kind === 'plane' && !e.shiftKey) return;
+
+    const dx = screenState.arrowEnd.x - screenState.center.x;
+    const dy = screenState.arrowEnd.y - screenState.center.y;
+    const axisPixelLength = Math.hypot(dx, dy);
+    if (axisPixelLength < 5) return;
+
+    dragStateRef.current = {
+      kind,
+      startPointer: { x: e.clientX, y: e.clientY },
+      startPosition: sectionPlane.position,
+      axisDir: { x: dx / axisPixelLength, y: dy / axisPixelLength },
+      axisPixelLength,
+      rangeLength: Math.max(1e-6, planeMath.range.max - planeMath.range.min),
+    };
+
+    setIsDragging(true);
+    (e.currentTarget as Element).setPointerCapture(e.pointerId);
+    e.preventDefault();
+    e.stopPropagation();
+  }, [planeMath, screenState, sectionPlane.position]);
+
+  const onPointerMove = useCallback((e: ReactPointerEvent) => {
+    const drag = dragStateRef.current;
+    if (!drag || !planeMath) return;
+
+    const moveX = e.clientX - drag.startPointer.x;
+    const moveY = e.clientY - drag.startPointer.y;
+    const projectedPx = moveX * drag.axisDir.x + moveY * drag.axisDir.y;
+
+    const worldDelta = (projectedPx / drag.axisPixelLength) * planeMath.arrowLength;
+    const percentDelta = (worldDelta / drag.rangeLength) * 100;
+    setSectionPlanePosition(drag.startPosition + percentDelta);
+
+    e.preventDefault();
+    e.stopPropagation();
+  }, [planeMath, setSectionPlanePosition]);
+
+  const endDrag = useCallback((e: ReactPointerEvent) => {
+    if (!dragStateRef.current) return;
+    dragStateRef.current = null;
+    setIsDragging(false);
+    e.preventDefault();
+    e.stopPropagation();
+  }, []);
+
+  if (activeTool !== 'section' || !screenState?.visible) {
+    return null;
+  }
+
+  const color = sectionPlane.mode === 'surface' ? '#A855F7' : sectionPlane.axis === 'down' ? '#03A9F4' : sectionPlane.axis === 'front' ? '#4CAF50' : '#FF9800';
+  const planeSize = 28;
+
+  return (
+    <svg
+      className="pointer-events-none absolute inset-0 z-30"
+      onPointerMove={onPointerMove}
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
+    >
+      <line
+        x1={screenState.center.x}
+        y1={screenState.center.y}
+        x2={screenState.arrowEnd.x}
+        y2={screenState.arrowEnd.y}
+        stroke={color}
+        strokeWidth={2.5}
+        strokeLinecap="round"
+        opacity={0.9}
+      />
+      <polygon
+        points={`${screenState.arrowEnd.x},${screenState.arrowEnd.y} ${screenState.arrowEnd.x - 8},${screenState.arrowEnd.y + 5} ${screenState.arrowEnd.x - 8},${screenState.arrowEnd.y - 5}`}
+        fill={color}
+        className="pointer-events-auto cursor-grab"
+        onPointerDown={(e) => beginDrag('arrow', e)}
+      />
+      <rect
+        x={screenState.center.x - planeSize / 2}
+        y={screenState.center.y - planeSize / 2}
+        width={planeSize}
+        height={planeSize}
+        fill={color}
+        fillOpacity={0.2}
+        stroke={color}
+        strokeWidth={2}
+        className={`pointer-events-auto ${isDragging ? 'cursor-grabbing' : 'cursor-grab'}`}
+        onPointerDown={(e) => beginDrag('plane', e)}
+      />
+      <text
+        x={screenState.center.x}
+        y={screenState.center.y + planeSize / 2 + 14}
+        textAnchor="middle"
+        fill={color}
+        fontSize="10"
+        fontFamily="monospace"
+      >
+        {`Hold Shift + drag plane`}
+      </text>
+    </svg>
+  );
+}

--- a/apps/viewer/src/components/viewer/tools/SectionPanel.tsx
+++ b/apps/viewer/src/components/viewer/tools/SectionPanel.tsx
@@ -7,16 +7,17 @@
  */
 
 import React, { useCallback, useState } from 'react';
-import { X, Slice, ChevronDown, FileImage } from 'lucide-react';
+import { X, Slice, ChevronDown, FileImage, MousePointerClick } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useViewerStore } from '@/store';
 import { AXIS_INFO } from './sectionConstants';
 import { SectionPlaneVisualization } from './SectionVisualization';
+import { SectionGizmo } from './SectionGizmo';
 
 export function SectionOverlay() {
   const sectionPlane = useViewerStore((s) => s.sectionPlane);
   const setSectionPlaneAxis = useViewerStore((s) => s.setSectionPlaneAxis);
-  const setSectionPlanePosition = useViewerStore((s) => s.setSectionPlanePosition);
+  const setSectionPlaneMode = useViewerStore((s) => s.setSectionPlaneMode);
   const toggleSectionPlane = useViewerStore((s) => s.toggleSectionPlane);
   const setActiveTool = useViewerStore((s) => s.setActiveTool);
   const setDrawingPanelVisible = useViewerStore((s) => s.setDrawing2DPanelVisible);
@@ -32,12 +33,10 @@ export function SectionOverlay() {
     setSectionPlaneAxis(axis);
   }, [setSectionPlaneAxis]);
 
-  const handlePositionChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = Number(e.target.value);
-    if (!Number.isNaN(value)) {
-      setSectionPlanePosition(value);
-    }
-  }, [setSectionPlanePosition]);
+  const handleModeChange = useCallback((mode: 'axis' | 'surface') => {
+    setSectionPlaneMode(mode);
+  }, [setSectionPlaneMode]);
+
 
   const togglePanel = useCallback(() => {
     setIsPanelCollapsed(prev => !prev);
@@ -63,14 +62,14 @@ export function SectionOverlay() {
             <span className="font-medium text-sm">Section</span>
             {sectionPlane.enabled && (
               <span className="text-xs text-primary font-mono">
-                {AXIS_INFO[sectionPlane.axis].label} <span className="inline-block w-12 text-right tabular-nums">{sectionPlane.position.toFixed(1)}%</span>
+                {sectionPlane.mode === 'surface' ? 'Surface' : AXIS_INFO[sectionPlane.axis].label} <span className="inline-block w-12 text-right tabular-nums">{sectionPlane.position.toFixed(1)}%</span>
               </span>
             )}
             <ChevronDown className={`h-3 w-3 transition-transform ${isPanelCollapsed ? '-rotate-90' : ''}`} />
           </button>
           <div className="flex items-center gap-1">
             {/* Only show 2D button when panel is closed */}
-            {!drawingPanelVisible && (
+            {!drawingPanelVisible && sectionPlane.mode === 'axis' && (
               <Button variant="ghost" size="icon-sm" onClick={handleView2D} title="Open 2D Drawing Panel">
                 <FileImage className="h-3 w-3" />
               </Button>
@@ -84,6 +83,29 @@ export function SectionOverlay() {
         {/* Expandable content */}
         {!isPanelCollapsed && (
           <div className="border-t px-3 pb-3 min-w-64">
+            {/* Mode Selection */}
+            <div className="mt-3">
+              <label className="text-xs text-muted-foreground mb-2 block">Mode</label>
+              <div className="flex gap-1">
+                <Button
+                  variant={sectionPlane.mode === 'axis' ? 'default' : 'outline'}
+                  size="sm"
+                  className="flex-1"
+                  onClick={() => handleModeChange('axis')}
+                >
+                  Axis
+                </Button>
+                <Button
+                  variant={sectionPlane.mode === 'surface' ? 'default' : 'outline'}
+                  size="sm"
+                  className="flex-1"
+                  onClick={() => handleModeChange('surface')}
+                >
+                  Surface
+                </Button>
+              </div>
+            </div>
+
             {/* Direction Selection */}
             <div className="mt-3">
               <label className="text-xs text-muted-foreground mb-2 block">Direction</label>
@@ -94,6 +116,7 @@ export function SectionOverlay() {
                     variant={sectionPlane.axis === axis ? 'default' : 'outline'}
                     size="sm"
                     className="flex-1 flex-col h-auto py-1.5"
+                    disabled={sectionPlane.mode !== 'axis'}
                     onClick={() => handleAxisChange(axis)}
                   >
                     <span className="text-xs font-medium">{AXIS_INFO[axis].label}</span>
@@ -102,33 +125,19 @@ export function SectionOverlay() {
               </div>
             </div>
 
-            {/* Position Slider */}
-            <div className="mt-3">
-              <div className="flex items-center justify-between mb-1">
-                <label className="text-xs text-muted-foreground">Position</label>
-                <input
-                  type="number"
-                  min="0"
-                  max="100"
-                  step="0.1"
-                  value={sectionPlane.position}
-                  onChange={handlePositionChange}
-                  className="w-16 text-xs font-mono bg-muted px-1.5 py-0.5 rounded border-none text-right [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-                />
+            {sectionPlane.mode === 'surface' && (
+              <div className="mt-2 text-[11px] text-muted-foreground flex items-start gap-1.5">
+                <MousePointerClick className="h-3 w-3 mt-0.5 shrink-0" />
+                <span>Click a visible face in the model to align the cut plane to that surface normal.</span>
               </div>
-              <input
-                type="range"
-                min="0"
-                max="100"
-                step="0.1"
-                value={sectionPlane.position}
-                onChange={handlePositionChange}
-                className="w-full h-2 bg-muted rounded-lg appearance-none cursor-pointer accent-primary"
-              />
+            )}
+
+            <div className="mt-3 text-[11px] text-muted-foreground">
+              Move cut plane with gizmo: drag arrow, or hold <span className="font-semibold">Shift</span> and drag plane.
             </div>
 
             {/* Show 2D panel button - only when panel is closed */}
-            {!drawingPanelVisible && (
+            {!drawingPanelVisible && sectionPlane.mode === 'axis' && (
               <div className="mt-3 pt-3 border-t">
                 <Button
                   variant="outline"
@@ -156,7 +165,7 @@ export function SectionOverlay() {
       >
         <span className="font-mono text-xs uppercase tracking-wide">
           {sectionPlane.enabled
-            ? `Cutting ${AXIS_INFO[sectionPlane.axis].label.toLowerCase()} at ${sectionPlane.position.toFixed(1)}%`
+            ? `Cutting ${sectionPlane.mode === 'surface' ? 'surface' : AXIS_INFO[sectionPlane.axis].label.toLowerCase()} at ${sectionPlane.position.toFixed(1)}%`
             : 'Preview mode'}
         </span>
       </div>
@@ -176,8 +185,10 @@ export function SectionOverlay() {
         </button>
       </div>
 
+      <SectionGizmo />
+
       {/* Section plane visualization overlay */}
-      <SectionPlaneVisualization axis={sectionPlane.axis} enabled={sectionPlane.enabled} />
+      <SectionPlaneVisualization axis={sectionPlane.axis} enabled={sectionPlane.enabled} mode={sectionPlane.mode} />
     </>
   );
 }

--- a/apps/viewer/src/components/viewer/tools/SectionVisualization.tsx
+++ b/apps/viewer/src/components/viewer/tools/SectionVisualization.tsx
@@ -11,10 +11,11 @@ import { AXIS_INFO } from './sectionConstants';
 interface SectionPlaneVisualizationProps {
   axis: 'down' | 'front' | 'side';
   enabled: boolean;
+  mode?: 'axis' | 'surface';
 }
 
 // Section plane visual indicator component
-export function SectionPlaneVisualization({ axis, enabled }: SectionPlaneVisualizationProps) {
+export function SectionPlaneVisualization({ axis, enabled, mode = 'axis' }: SectionPlaneVisualizationProps) {
   // Get the axis color
   const axisColors = {
     down: '#03A9F4',  // Light blue for horizontal cuts
@@ -22,7 +23,7 @@ export function SectionPlaneVisualization({ axis, enabled }: SectionPlaneVisuali
     side: '#FF9800',  // Orange for side cuts
   };
 
-  const color = axisColors[axis];
+  const color = mode === 'surface' ? '#A855F7' : axisColors[axis];
 
   return (
     <svg
@@ -56,7 +57,7 @@ export function SectionPlaneVisualization({ axis, enabled }: SectionPlaneVisuali
           fontSize="11"
           fontWeight="bold"
         >
-          {AXIS_INFO[axis].label.toUpperCase()}
+          {mode === 'surface' ? 'SURF' : AXIS_INFO[axis].label.toUpperCase()}
         </text>
         {/* Active indicator */}
         {enabled && (

--- a/apps/viewer/src/components/viewer/useAnimationLoop.ts
+++ b/apps/viewer/src/components/viewer/useAnimationLoop.ts
@@ -10,6 +10,7 @@
 import { useEffect, type MutableRefObject, type RefObject } from 'react';
 import type { Renderer, VisualEnhancementOptions } from '@ifc-lite/renderer';
 import type { SectionPlane } from '@/store';
+import { toRendererSectionPlane } from '../../utils/viewportUtils.js';
 
 export interface UseAnimationLoopParams {
   canvasRef: RefObject<HTMLCanvasElement | null>;
@@ -90,11 +91,9 @@ export function useAnimationLoop(params: UseAnimationLoopParams): void {
           selectedModelIndex: selectedModelIndexRef.current,
           clearColor: clearColorRef.current,
           visualEnhancement: visualEnhancementRef.current,
-          sectionPlane: activeToolRef.current === 'section' ? {
-            ...sectionPlaneRef.current,
-            min: sectionRangeRef.current?.min,
-            max: sectionRangeRef.current?.max,
-          } : undefined,
+          sectionPlane: activeToolRef.current === 'section'
+            ? toRendererSectionPlane(sectionPlaneRef.current, sectionRangeRef.current ?? undefined)
+            : undefined,
         });
         // Update ViewCube during camera animation (e.g., preset view transitions)
         updateCameraRotationRealtime(camera.getRotation());

--- a/apps/viewer/src/components/viewer/useKeyboardControls.ts
+++ b/apps/viewer/src/components/viewer/useKeyboardControls.ts
@@ -12,7 +12,7 @@ import type { Renderer } from '@ifc-lite/renderer';
 import type { MeshData, CoordinateInfo } from '@ifc-lite/geometry';
 import type { SectionPlane } from '@/store';
 import { goHomeFromStore } from '@/store/homeView';
-import { getEntityBounds } from '../../utils/viewportUtils.js';
+import { getEntityBounds, toRendererSectionPlane } from '../../utils/viewportUtils.js';
 
 export interface UseKeyboardControlsParams {
   rendererRef: MutableRefObject<Renderer | null>;
@@ -98,11 +98,9 @@ export function useKeyboardControls(params: UseKeyboardControlsParams): void {
           selectedId: selectedEntityIdRef.current,
           selectedModelIndex: selectedModelIndexRef.current,
           clearColor: clearColorRef.current,
-          sectionPlane: activeToolRef.current === 'section' ? {
-            ...sectionPlaneRef.current,
-            min: sectionRangeRef.current?.min,
-            max: sectionRangeRef.current?.max,
-          } : undefined,
+          sectionPlane: activeToolRef.current === 'section'
+            ? toRendererSectionPlane(sectionPlaneRef.current, sectionRangeRef.current ?? undefined)
+            : undefined,
         });
         updateCameraRotationRealtime(camera.getRotation());
         calculateScale();
@@ -193,11 +191,9 @@ export function useKeyboardControls(params: UseKeyboardControlsParams): void {
           selectedId: selectedEntityIdRef.current,
           selectedModelIndex: selectedModelIndexRef.current,
           clearColor: clearColorRef.current,
-          sectionPlane: activeToolRef.current === 'section' ? {
-            ...sectionPlaneRef.current,
-            min: sectionRangeRef.current?.min,
-            max: sectionRangeRef.current?.max,
-          } : undefined,
+          sectionPlane: activeToolRef.current === 'section'
+            ? toRendererSectionPlane(sectionPlaneRef.current, sectionRangeRef.current ?? undefined)
+            : undefined,
         });
       }
       moveFrameId = requestAnimationFrame(keyboardMove);

--- a/apps/viewer/src/components/viewer/useRenderUpdates.ts
+++ b/apps/viewer/src/components/viewer/useRenderUpdates.ts
@@ -12,7 +12,7 @@ import type { Renderer, CutPolygon2D, DrawingLine2D, VisualEnhancementOptions } 
 import type { CoordinateInfo } from '@ifc-lite/geometry';
 import type { Drawing2D } from '@ifc-lite/drawing-2d';
 import type { SectionPlane } from '@/store';
-import { getThemeClearColor } from '../../utils/viewportUtils.js';
+import { getThemeClearColor, toRendererSectionPlane } from '../../utils/viewportUtils.js';
 
 export interface UseRenderUpdatesParams {
   rendererRef: MutableRefObject<Renderer | null>;
@@ -103,7 +103,7 @@ export function useRenderUpdates(params: UseRenderUpdatesParams): void {
     if (!renderer || !isInitialized) return;
 
     // Only show overlay when section tool is active, we have a drawing, AND 3D overlay is enabled
-    if (activeTool === 'section' && drawing2D && drawing2D.cutPolygons.length > 0 && show3DOverlay) {
+    if (activeTool === 'section' && sectionPlane.mode === 'axis' && drawing2D && drawing2D.cutPolygons.length > 0 && show3DOverlay) {
       // Convert Drawing2D format to renderer format
       const polygons: CutPolygon2D[] = drawing2D.cutPolygons.map((cp) => ({
         polygon: cp.polygon,
@@ -143,11 +143,9 @@ export function useRenderUpdates(params: UseRenderUpdatesParams): void {
       selectedModelIndex: selectedModelIndexRef.current,
       clearColor: clearColorRef.current,
       visualEnhancement: visualEnhancementRef.current,
-      sectionPlane: activeTool === 'section' ? {
-        ...sectionPlane,
-        min: sectionRangeRef.current?.min,
-        max: sectionRangeRef.current?.max,
-      } : undefined,
+      sectionPlane: activeTool === 'section'
+        ? toRendererSectionPlane(sectionPlane, sectionRangeRef.current ?? undefined)
+        : undefined,
     });
   }, [drawing2D, activeTool, sectionPlane, isInitialized, coordinateInfo, show3DOverlay, showHiddenLines]);
 
@@ -164,11 +162,9 @@ export function useRenderUpdates(params: UseRenderUpdatesParams): void {
       selectedModelIndex,
       clearColor: clearColorRef.current,
       visualEnhancement: visualEnhancementRef.current,
-      sectionPlane: activeTool === 'section' ? {
-        ...sectionPlane,
-        min: sectionRange?.min,
-        max: sectionRange?.max,
-      } : undefined,
+      sectionPlane: activeTool === 'section'
+        ? toRendererSectionPlane(sectionPlane, sectionRange ?? undefined)
+        : undefined,
       buildingRotation: coordinateInfo?.buildingRotation,
     });
   }, [hiddenEntities, isolatedEntities, selectedEntityId, selectedEntityIds, selectedModelIndex, isInitialized, sectionPlane, activeTool, sectionRange, coordinateInfo?.buildingRotation]);

--- a/apps/viewer/src/components/viewer/useTouchControls.ts
+++ b/apps/viewer/src/components/viewer/useTouchControls.ts
@@ -11,7 +11,7 @@ import { useEffect, type MutableRefObject, type RefObject } from 'react';
 import type { Renderer, PickResult } from '@ifc-lite/renderer';
 import type { MeshData } from '@ifc-lite/geometry';
 import type { SectionPlane } from '@/store';
-import { getEntityCenter } from '../../utils/viewportUtils.js';
+import { getEntityCenter, toRendererSectionPlane } from '../../utils/viewportUtils.js';
 
 export interface TouchState {
   touches: Touch[];
@@ -150,11 +150,9 @@ export function useTouchControls(params: UseTouchControlsParams): void {
           selectedId: selectedEntityIdRef.current,
           selectedModelIndex: selectedModelIndexRef.current,
           clearColor: clearColorRef.current,
-          sectionPlane: activeToolRef.current === 'section' ? {
-            ...sectionPlaneRef.current,
-            min: sectionRangeRef.current?.min,
-            max: sectionRangeRef.current?.max,
-          } : undefined,
+          sectionPlane: activeToolRef.current === 'section'
+            ? toRendererSectionPlane(sectionPlaneRef.current, sectionRangeRef.current ?? undefined)
+            : undefined,
         });
       } else if (touchState.touches.length === 2) {
         const dx1 = touchState.touches[1].clientX - touchState.touches[0].clientX;
@@ -179,11 +177,9 @@ export function useTouchControls(params: UseTouchControlsParams): void {
           selectedId: selectedEntityIdRef.current,
           selectedModelIndex: selectedModelIndexRef.current,
           clearColor: clearColorRef.current,
-          sectionPlane: activeToolRef.current === 'section' ? {
-            ...sectionPlaneRef.current,
-            min: sectionRangeRef.current?.min,
-            max: sectionRangeRef.current?.max,
-          } : undefined,
+          sectionPlane: activeToolRef.current === 'section'
+            ? toRendererSectionPlane(sectionPlaneRef.current, sectionRangeRef.current ?? undefined)
+            : undefined,
         });
       }
     };

--- a/apps/viewer/src/hooks/useBCF.ts
+++ b/apps/viewer/src/hooks/useBCF.ts
@@ -292,7 +292,7 @@ export function useBCF(options: UseBCFOptions = {}): UseBCFResult {
       }
 
       // Convert section plane state
-      const viewerSectionPlane: ViewerSectionPlane | undefined = sectionPlane.enabled
+      const viewerSectionPlane: ViewerSectionPlane | undefined = sectionPlane.enabled && sectionPlane.mode === 'axis'
         ? {
             axis: sectionPlane.axis,
             position: sectionPlane.position,

--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -172,10 +172,12 @@ export const useViewerStore = create<ViewerState>()((...args) => ({
 
       // Section plane
       sectionPlane: {
+        mode: 'axis',
         axis: SECTION_PLANE_DEFAULTS.AXIS,
         position: SECTION_PLANE_DEFAULTS.POSITION,
         enabled: SECTION_PLANE_DEFAULTS.ENABLED,
         flipped: SECTION_PLANE_DEFAULTS.FLIPPED,
+        surface: null,
       },
 
       // Camera

--- a/apps/viewer/src/store/slices/pinboardSlice.test.ts
+++ b/apps/viewer/src/store/slices/pinboardSlice.test.ts
@@ -13,7 +13,7 @@ function createMockCrossSlice() {
     hiddenEntities: new Set<number>(),
     models: new Map<string, { idOffset: number }>([['legacy', { idOffset: 0 }]]),
     cameraCallbacks: { getViewpoint: () => null },
-    sectionPlane: { axis: 'front' as const, position: 50, enabled: false, flipped: false },
+    sectionPlane: { mode: 'axis' as const, axis: 'front' as const, position: 50, enabled: false, flipped: false, surface: null },
     drawing2D: null,
     drawing2DDisplayOptions: { show3DOverlay: true, showHiddenLines: true },
     setDrawing2D: () => {},
@@ -109,7 +109,7 @@ describe('PinboardSlice', () => {
     it('captures section plane but not 2D drawing payload', () => {
       state.setBasket([{ modelId: 'legacy', expressId: 100 }]);
       state.activeTool = 'section';
-      state.sectionPlane = { axis: 'front', position: 42, enabled: true, flipped: false };
+      state.sectionPlane = { mode: 'axis', axis: 'front', position: 42, enabled: true, flipped: false, surface: null };
       state.drawing2D = {
         lines: [{ line: { start: { x: 0, y: 0 }, end: { x: 1, y: 1 } }, visibility: 'visible', category: 'solid' }],
         cutPolygons: [],

--- a/apps/viewer/src/store/slices/sectionSlice.test.ts
+++ b/apps/viewer/src/store/slices/sectionSlice.test.ts
@@ -28,10 +28,12 @@ describe('SectionSlice', () => {
 
   describe('initial state', () => {
     it('should have default section plane values', () => {
+      assert.strictEqual(state.sectionPlane.mode, 'axis');
       assert.strictEqual(state.sectionPlane.axis, SECTION_PLANE_DEFAULTS.AXIS);
       assert.strictEqual(state.sectionPlane.position, SECTION_PLANE_DEFAULTS.POSITION);
       assert.strictEqual(state.sectionPlane.enabled, SECTION_PLANE_DEFAULTS.ENABLED);
       assert.strictEqual(state.sectionPlane.flipped, SECTION_PLANE_DEFAULTS.FLIPPED);
+      assert.strictEqual(state.sectionPlane.surface, null);
     });
   });
 
@@ -43,9 +45,36 @@ describe('SectionSlice', () => {
 
     it('should preserve other section plane properties', () => {
       state.sectionPlane.position = 75;
+      state.sectionPlane.surface = {
+        normal: { x: 0, y: 1, z: 0 },
+        point: { x: 0, y: 0, z: 0 },
+      };
       state.setSectionPlaneAxis('side');
       assert.strictEqual(state.sectionPlane.axis, 'side');
+      assert.strictEqual(state.sectionPlane.mode, 'axis');
       assert.strictEqual(state.sectionPlane.position, 75);
+      assert.strictEqual(state.sectionPlane.surface, null);
+    });
+  });
+
+  describe('surface mode', () => {
+    it('should switch mode', () => {
+      state.setSectionPlaneMode('surface');
+      assert.strictEqual(state.sectionPlane.mode, 'surface');
+    });
+
+    it('should set section plane from surface hit', () => {
+      state.setSectionPlaneFromSurface({
+        normal: { x: 0, y: 0, z: 1 },
+        point: { x: 1, y: 2, z: 3 },
+      }, 62.5);
+
+      assert.strictEqual(state.sectionPlane.mode, 'surface');
+      assert.strictEqual(state.sectionPlane.position, 62.5);
+      assert.deepStrictEqual(state.sectionPlane.surface, {
+        normal: { x: 0, y: 0, z: 1 },
+        point: { x: 1, y: 2, z: 3 },
+      });
     });
   });
 
@@ -108,18 +137,25 @@ describe('SectionSlice', () => {
     it('should reset to default values', () => {
       // Modify state
       state.sectionPlane = {
+        mode: 'surface',
         axis: 'side',
         position: 25,
         enabled: false,
         flipped: true,
+        surface: {
+          normal: { x: 1, y: 0, z: 0 },
+          point: { x: 5, y: 0, z: 0 },
+        },
       };
 
       state.resetSectionPlane();
 
+      assert.strictEqual(state.sectionPlane.mode, 'axis');
       assert.strictEqual(state.sectionPlane.axis, SECTION_PLANE_DEFAULTS.AXIS);
       assert.strictEqual(state.sectionPlane.position, SECTION_PLANE_DEFAULTS.POSITION);
       assert.strictEqual(state.sectionPlane.enabled, SECTION_PLANE_DEFAULTS.ENABLED);
       assert.strictEqual(state.sectionPlane.flipped, SECTION_PLANE_DEFAULTS.FLIPPED);
+      assert.strictEqual(state.sectionPlane.surface, null);
     });
   });
 });

--- a/apps/viewer/src/store/slices/sectionSlice.ts
+++ b/apps/viewer/src/store/slices/sectionSlice.ts
@@ -7,7 +7,7 @@
  */
 
 import type { StateCreator } from 'zustand';
-import type { SectionPlane, SectionPlaneAxis } from '../types.js';
+import type { SectionPlane, SectionPlaneAxis, SectionPlaneMode, SectionPlaneSurface } from '../types.js';
 import { SECTION_PLANE_DEFAULTS } from '../constants.js';
 
 export interface SectionSlice {
@@ -16,6 +16,8 @@ export interface SectionSlice {
 
   // Actions
   setSectionPlaneAxis: (axis: SectionPlaneAxis) => void;
+  setSectionPlaneMode: (mode: SectionPlaneMode) => void;
+  setSectionPlaneFromSurface: (surface: SectionPlaneSurface, position: number) => void;
   setSectionPlanePosition: (position: number) => void;
   toggleSectionPlane: () => void;
   flipSectionPlane: () => void;
@@ -23,10 +25,12 @@ export interface SectionSlice {
 }
 
 const getDefaultSectionPlane = (): SectionPlane => ({
+  mode: 'axis',
   axis: SECTION_PLANE_DEFAULTS.AXIS,
   position: SECTION_PLANE_DEFAULTS.POSITION,
   enabled: SECTION_PLANE_DEFAULTS.ENABLED,
   flipped: SECTION_PLANE_DEFAULTS.FLIPPED,
+  surface: null,
 });
 
 export const createSectionSlice: StateCreator<SectionSlice, [], [], SectionSlice> = (set) => ({
@@ -35,7 +39,24 @@ export const createSectionSlice: StateCreator<SectionSlice, [], [], SectionSlice
 
   // Actions
   setSectionPlaneAxis: (axis) => set((state) => ({
-    sectionPlane: { ...state.sectionPlane, axis },
+    sectionPlane: { ...state.sectionPlane, mode: 'axis', axis, surface: null },
+  })),
+
+  setSectionPlaneMode: (mode) => set((state) => ({
+    sectionPlane: {
+      ...state.sectionPlane,
+      mode,
+      surface: mode === 'surface' ? state.sectionPlane.surface : null,
+    },
+  })),
+
+  setSectionPlaneFromSurface: (surface, position) => set((state) => ({
+    sectionPlane: {
+      ...state.sectionPlane,
+      mode: 'surface',
+      surface,
+      position: Math.min(100, Math.max(0, Number(position) || 0)),
+    },
   })),
 
   setSectionPlanePosition: (position) => set((state) => {

--- a/apps/viewer/src/store/types.ts
+++ b/apps/viewer/src/store/types.ts
@@ -85,14 +85,23 @@ export interface EdgeLockState {
 
 /** Semantic axis names: down (Y), front (Z), side (X) for intuitive user experience */
 export type SectionPlaneAxis = 'down' | 'front' | 'side';
+export type SectionPlaneMode = 'axis' | 'surface';
+
+export interface SectionPlaneSurface {
+  normal: { x: number; y: number; z: number };
+  point: { x: number; y: number; z: number };
+}
 
 export interface SectionPlane {
+  mode: SectionPlaneMode;
   axis: SectionPlaneAxis;
   /** 0-100 percentage of model bounds */
   position: number;
   enabled: boolean;
   /** If true, show the opposite side of the cut */
   flipped: boolean;
+  /** Surface-derived plane definition used when mode === 'surface' */
+  surface: SectionPlaneSurface | null;
 }
 
 // ============================================================================

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -88,13 +88,18 @@ export interface BatchedMesh {
 // Section plane for clipping
 // Semantic axis names: down (Y), front (Z), side (X) for intuitive user experience
 export type SectionPlaneAxis = 'down' | 'front' | 'side';
+export type SectionPlaneMode = 'axis' | 'surface';
+
 export interface SectionPlane {
+  mode?: SectionPlaneMode;
   axis: SectionPlaneAxis;
   position: number; // 0-100 percentage of model bounds
   enabled: boolean;
   flipped?: boolean; // If true, show the opposite side of the cut
   min?: number;      // Optional override for min range value
   max?: number;      // Optional override for max range value
+  normal?: { x: number; y: number; z: number };
+  point?: { x: number; y: number; z: number };
 }
 
 export type ContactShadingQuality = 'off' | 'low' | 'high';


### PR DESCRIPTION
### Motivation

- Provide a new "surface" section mode so users can click a visible model face to align the cut plane to that face normal and then slide the plane along that normal.  
- Integrate surface mode into the viewer UI, input handlers, store, utilities, and the renderer so the feature is interactive and visualized correctly.

### Description

- Introduce a new `mode: 'axis' | 'surface'` on the section plane state and add `surface` payload (normal + point) to `SectionPlane` in `store/types.ts`, initialize in `store/index.ts`, and expose actions `setSectionPlaneMode` and `setSectionPlaneFromSurface` in `sectionSlice.ts`.
- Add `SectionGizmo` SVG component to provide on-screen controls (drag arrow or Shift+drag plane) for moving the cut plane, and wire it into `SectionPanel.tsx` and overlay visuals/components (`SectionVisualization.tsx`).
- Implement new viewport utilities: `calculateProjectionRange`, `projectionToPercentage`, and `toRendererSectionPlane` in `utils/viewportUtils.ts` to compute projection ranges for arbitrary normals and convert viewer state to renderer options.
- Update mouse/touch/keyboard/animation/rendering paths to support the new surface mode by using `toRendererSectionPlane` when invoking `Renderer.render`, and add click handling in `useMouseControls.ts` to perform a scene raycast, derive the surface normal/point, compute the percentage position, and invoke `setSectionPlaneFromSurface` when in surface mode.
- Extend the renderer and section-plane renderer to accept surface mode: compute per-face normals when `mode === 'surface'`, compute projection ranges from model bounds for an arbitrary normal, provide `normal`/`point` through render options, render a preview plane for surface mode, and skip 2D section overlay rendering for surface mode.
- Update various UI texts, buttons, and behavior: mode selector in `SectionPanel`, color/labels for surface mode in `SectionVisualization`, and show contextual instructions in the panel header.
- Add `SectionGizmo` interactivity, integrate coordinateInfo/geometry bounds into gizmo math, and hook gizmo drag events to `setSectionPlanePosition`.
- Update tests and mocks to include the new `mode` and `surface` fields in `sectionSlice.test.ts` and `pinboardSlice.test.ts` and add a changeset entry to bump `@ifc-lite/renderer` minor.

### Testing

- Ran unit tests for the updated slices (`sectionSlice.test.ts`, `pinboardSlice.test.ts`) and related slice tests; the updated tests pass.  
- Built the viewer app (development build) and verified the UI renders with the new Section panel and gizmo without build errors.  
- Exercised interactive flows manually in the dev build: switching between Axis/Surface modes, clicking a face to align the plane, and dragging the gizmo to move the cut; rendering and section previews behave as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f279151448320982b5f5e35f6d110)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added surface-aligned section mode allowing users to click model faces to define clipping planes and adjust them along surface normals
* Interactive visual gizmo for manipulating surface-based clipping planes
* Section planes can now toggle between axis-aligned and surface-aligned modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->