### PR TITLE
fix: use macos-14 runner for darwin-x64 binary builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,9 +150,9 @@ jobs:
             rust-target: x86_64-unknown-linux-musl
             archive: tar.gz
 
-          # macOS x64 (Intel)
+          # macOS x64 (Intel) — cross-compile from arm64 runner (macos-13 Intel runners are deprecated)
           - target: darwin-x64
-            os: macos-13
+            os: macos-14
             rust-target: x86_64-apple-darwin
             archive: tar.gz
 


### PR DESCRIPTION
## Summary
- The `macos-13-us-default` regional runner used by our `darwin-x64` server binary build is deprecated on GitHub Actions
- Switched to `macos-14` (Apple Silicon) runner and cross-compile `x86_64-apple-darwin` — Rust + Xcode handle this natively, no extra tooling needed

## Test plan
- [ ] Merge and verify the `darwin-x64` Build Server Binary job passes in the next release run

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS Intel build configuration to target macOS 14, improving compatibility with current build infrastructure and addressing deprecation of older build runners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->