### PR TITLE
fix: non-null DOM assertions in Three.js template

### DIFF
--- a/.changeset/fix-template-dom-types.md
+++ b/.changeset/fix-template-dom-types.md
@@ -1,0 +1,5 @@
+---
+"create-ifc-lite": patch
+---
+
+Fix TypeScript error in generated Three.js template: use non-null assertions on DOM element declarations so type narrowing works across function boundaries.

--- a/packages/create-ifc-lite/src/templates/threejs.ts
+++ b/packages/create-ifc-lite/src/templates/threejs.ts
@@ -137,9 +137,9 @@ import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { GeometryProcessor } from '@ifc-lite/geometry';
 import { meshDataToThree } from './ifc-to-threejs.js';
 
-const canvas = document.getElementById('viewer') as HTMLCanvasElement | null;
-const fileInput = document.getElementById('file-input') as HTMLInputElement | null;
-const status = document.getElementById('status');
+const canvas = document.getElementById('viewer') as HTMLCanvasElement;
+const fileInput = document.getElementById('file-input') as HTMLInputElement;
+const status = document.getElementById('status')!;
 if (!canvas || !fileInput || !status) {
   throw new Error('Required DOM elements not found: viewer, file-input, or status');
 }


### PR DESCRIPTION
## Summary
- The generated `main.ts` had `canvas` typed as `HTMLCanvasElement | null`, which caused `tsc --noEmit` to fail with `TS18047: 'canvas' is possibly 'null'` inside `resize()` — TypeScript can't narrow across function boundaries
- Fixed by asserting non-null at declaration (`as HTMLCanvasElement` / `!`) which is the standard pattern for known DOM elements
- Verified: `npm install && tsc --noEmit && vite build` all pass cleanly on a fresh scaffold

## Test
```
npx create-ifc-lite@latest my-app --template threejs
cd my-app && npm install && npx tsc --noEmit  # must exit 0
```

Made with [Cursor](https://cursor.com)