### PR TITLE
fix: use optimizeDeps.exclude for WASM (revert vite-plugin-wasm)

### DIFF
--- a/.changeset/fix-template-wasm-config.md
+++ b/.changeset/fix-template-wasm-config.md
@@ -1,0 +1,5 @@
+---
+"create-ifc-lite": patch
+---
+
+Fix WASM loading in threejs template: revert to `optimizeDeps.exclude: ['@ifc-lite/wasm']` (matching the working example). `vite-plugin-wasm` was incorrect — the wasm-bindgen `new URL('ifc-lite_bg.wasm', import.meta.url)` pattern works correctly when the package is excluded from Vite pre-bundling.

--- a/packages/create-ifc-lite/src/templates/threejs.ts
+++ b/packages/create-ifc-lite/src/templates/threejs.ts
@@ -32,8 +32,6 @@ export function createThreejsTemplate(targetDir: string, projectName: string) {
       '@types/three': '^0.183.0',
       typescript: '^5.3.0',
       vite: '^7.0.0',
-      'vite-plugin-wasm': '^3.0.0',
-      'vite-plugin-top-level-await': '^1.0.0',
     },
   }, null, 2));
 
@@ -53,19 +51,16 @@ export function createThreejsTemplate(targetDir: string, projectName: string) {
 
   // vite.config.ts
   writeFileSync(join(targetDir, 'vite.config.ts'), `import { defineConfig } from 'vite';
-import wasm from 'vite-plugin-wasm';
-import topLevelAwait from 'vite-plugin-top-level-await';
 
 export default defineConfig({
-  plugins: [wasm(), topLevelAwait()],
+  optimizeDeps: {
+    exclude: ['@ifc-lite/wasm'],
+  },
   server: {
     headers: {
       'Cross-Origin-Opener-Policy': 'same-origin',
       'Cross-Origin-Embedder-Policy': 'require-corp',
     },
-  },
-  build: {
-    target: 'esnext',
   },
 });
 `);


### PR DESCRIPTION
## Problem
`create-ifc-lite@1.11.4` introduced `vite-plugin-wasm` + `vite-plugin-top-level-await` to fix WASM loading, but it still fails at runtime. The plugin approach was wrong.

## Root cause
`@ifc-lite/wasm` is a wasm-bindgen package that uses `new URL('ifc-lite_bg.wasm', import.meta.url)` to locate the `.wasm` file. When Vite **excludes** the package from pre-bundling (`optimizeDeps.exclude`), the module is served directly from `node_modules`, `import.meta.url` resolves to the correct package path, and the `.wasm` file is found. This is exactly what `examples/threejs-viewer` does and it works.

## Fix
Revert `vite.config.ts` to the same config as the working example:
```ts
optimizeDeps: { exclude: ['@ifc-lite/wasm'] }
```
Remove `vite-plugin-wasm` and `vite-plugin-top-level-await` from devDependencies.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved WebAssembly loading configuration in the Three.js template to ensure correct module initialization and improved build optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->