### PR TITLE
Fix mesh batching to handle in-place color mutations during streaming

### DIFF
--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -435,6 +435,16 @@ export class Scene {
     this.activeBucketKey.clear();
     this.bucketVertexBytes.clear();
     this.pendingBatchKeys.clear();
+    // Destroy cached partial batches — their colorKeys are now stale
+    for (const batch of this.partialBatchCache.values()) {
+      batch.vertexBuffer.destroy();
+      batch.indexBuffer.destroy();
+      if (batch.uniformBuffer) {
+        batch.uniformBuffer.destroy();
+      }
+    }
+    this.partialBatchCache.clear();
+    this.partialBatchCacheKeys.clear();
 
     // 5. Re-group ALL meshData by their CURRENT color.
     //    meshData.color may have been mutated in-place since the mesh was


### PR DESCRIPTION
## Summary
This PR fixes a critical bug in the mesh batching system where meshes with in-place color mutations (applied by external code during streaming) were being rendered with incorrect colors. The issue occurred because bucket keys were computed at insertion time based on original colors, but those colors could be mutated later, causing a mismatch between bucket keys and actual mesh colors.

## Key Changes
- **Finalize streaming rebuild**: Changed `finalizeStreaming()` to perform a complete re-grouping of all accumulated meshData by their current colors instead of just filtering out fragments. This ensures bucket keys match the actual colors of meshes after any in-place mutations.

- **Proper resource cleanup**: Added explicit GPU buffer destruction for pre-existing proper batches (non-fragments) during finalization, preventing resource leaks.

- **Complete state reset**: Clear all bucket/batch tracking structures (`batchedMeshes`, `batchedMeshMap`, `batchedMeshIndex`, `batchedMeshData`, `meshDataBatchKey`, `activeBucketKey`, `bucketVertexBytes`, `pendingBatchKeys`) before rebuilding to ensure a clean state.

- **Improved color change detection**: Modified `rebuildPendingBatches()` to derive the old base color from the bucket key rather than from `meshData.color`, since the latter may have been mutated in-place by external code (`applyColorUpdatesToMeshes`). This makes color change detection reliable even when colors are mutated after initial bucketing.

## Implementation Details
- The fix recognizes that during streaming, external code may call `applyColorUpdatesToMeshes()` which mutates `meshData.color` in-place for deferred style/material colors.
- By re-grouping all meshData by their current color during finalization, we ensure the final batches have correct bucket keys that match the actual rendered colors.
- The bucket key is now treated as the source of truth for the original color, not the potentially-mutated `meshData.color` field.

https://claude.ai/code/session_01PXi2CuVMpogZjP2dr2UimB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed batch organization during streaming so items correctly group and render when colors are changed in-place.
  * Improved color state tracking to ensure accurate rendering of items whose colors are modified during streaming.
  * Enhanced batch rebuilding to reflect current color values and prevent rendering inconsistencies from stale color references.

* **Documentation**
  * Clarified internal notes that colors may be mutated in-place during streaming and grouping must use current color values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->