### PR TITLE
Add IFC creation and bSDD lookup capabilities to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Try it at [ifclite.com](https://www.ifclite.com/) to see it in action.
 
 - **View 3D models** in the browser with a fast WebGPU renderer
 - **Extract data** like properties, quantities, spatial structure, and relationships
+- **Create IFC files** programmatically — walls, slabs, columns, beams, stairs, roofs with properties and quantities
+- **Look up bSDD** (buildingSMART Data Dictionary) to discover and add standard properties for any IFC type
 - **Check compliance** against IDS (Information Delivery Specification) rules
 - **Generate 2D drawings** like floor plans, sections, and elevations from 3D
 - **Collaborate** with BCF (BIM Collaboration Format) for issues and viewpoints
@@ -44,7 +46,7 @@ Works with **IFC4 / IFC4X3** and the new **IFC5 (IFCX)** format.
 
 - **Fast.** First triangles on screen in ~200ms. Geometry processing up to 5x faster than the next best option. See [benchmarks](docs/guide/performance.md).
 - **Small.** ~260 KB gzipped. Designed to stay lightweight so your app stays lightweight.
-- **Complete.** Full IFC4X3 schema (876 entities), IFC5, BCF, IDS, 2D drawings, federation, property editing, and export. Parsing is just the start.
+- **Complete.** Full IFC4X3 schema (876 entities), IFC5, BCF, IDS, bSDD, 2D drawings, federation, IFC creation, property editing, and export. Parsing is just the start.
 - **Built for the web.** Rust + WASM core, WebGPU rendering, streaming pipelines, consistent TypeScript API across all packages.
 
 ## Get Started
@@ -114,6 +116,7 @@ You don't need all 25 packages. Here's what to grab for common tasks:
 | Query properties and types | + `@ifc-lite/query` |
 | Validate against IDS rules | + `@ifc-lite/ids` |
 | Generate 2D drawings | + `@ifc-lite/drawing-2d` |
+| Create IFC files from scratch | `@ifc-lite/create` |
 | Export to glTF / IFC / Parquet | + `@ifc-lite/export` |
 | Connect to a server backend | + `@ifc-lite/server-client` |
 
@@ -132,7 +135,7 @@ Ready-to-run projects in the [`examples/`](examples/) folder:
 |---|---|
 | **Start here** | [Quick Start](docs/guide/quickstart.md) · [Installation](docs/guide/installation.md) · [Browser Requirements](docs/guide/browser-requirements.md) |
 | **Guides** | [Parsing](docs/guide/parsing.md) · [Geometry](docs/guide/geometry.md) · [Rendering](docs/guide/rendering.md) · [Querying](docs/guide/querying.md) · [Exporting](docs/guide/exporting.md) |
-| **BIM features** | [Federation](docs/guide/federation.md) · [BCF](docs/guide/bcf.md) · [IDS Validation](docs/guide/ids.md) · [2D Drawings](docs/guide/drawing-2d.md) · [Property Editing](docs/guide/mutations.md) |
+| **BIM features** | [Federation](docs/guide/federation.md) · [BCF](docs/guide/bcf.md) · [IDS Validation](docs/guide/ids.md) · [bSDD](docs/guide/bsdd.md) · [2D Drawings](docs/guide/drawing-2d.md) · [IFC Creation](docs/guide/creation.md) · [Property Editing](docs/guide/mutations.md) |
 | **Tutorials** | [Build a Viewer](docs/tutorials/building-viewer.md) · [Three.js](docs/tutorials/threejs-integration.md) · [Babylon.js](docs/tutorials/babylonjs-integration.md) · [Custom Queries](docs/tutorials/custom-queries.md) |
 | **Deep dives** | [Architecture](docs/architecture/overview.md) · [Data Flow](docs/architecture/data-flow.md) · [Performance](docs/guide/performance.md) |
 | **API** | [TypeScript](docs/api/typescript.md) · [Rust](docs/api/rust.md) · [WASM](docs/api/wasm.md) |


### PR DESCRIPTION
## Summary
Updated README.md to document two new capabilities: programmatic IFC file creation and buildingSMART Data Dictionary (bSDD) integration for discovering and adding standard properties.

## Key Changes
- Added feature highlights for IFC file creation (walls, slabs, columns, beams, stairs, roofs with properties and quantities) and bSDD lookup functionality
- Updated the "Complete" feature description to mention bSDD, IFC creation, and other capabilities
- Added `@ifc-lite/create` package to the common tasks reference table for creating IFC files from scratch
- Expanded the BIM features documentation section with links to new guides:
  - `[bSDD](docs/guide/bsdd.md)` for Data Dictionary integration
  - `[IFC Creation](docs/guide/creation.md)` for programmatic file creation

## Details
These documentation updates reflect the addition of two significant features to the ifc-lite library:
1. **IFC Creation**: Users can now programmatically create IFC files with common building elements and their properties/quantities
2. **bSDD Integration**: Users can look up standard properties from the buildingSMART Data Dictionary to ensure compliance with industry standards

The changes maintain consistency across the README by updating feature lists, capability descriptions, and navigation links to guide users to the new functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Programmatic IFC file creation for walls, slabs, columns, beams, stairs, and roofs with properties and quantities
  * buildingSMART Data Dictionary (bSDD) lookup for standard properties

* **Documentation**
  * Updated guides for IFC creation workflows and bSDD integration
  * Enhanced BIM features documentation with expanded capability references and export options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->