### PR TITLE
Fix multi-selection highlight behavior in HierarchyPanel

### DIFF
--- a/apps/viewer/src/components/viewer/HierarchyPanel.tsx
+++ b/apps/viewer/src/components/viewer/HierarchyPanel.tsx
@@ -200,7 +200,9 @@ export function HierarchyPanel() {
     if (node.type === 'type-group') {
       const elements = getNodeElements(node);
       if (elements.length > 0) {
-        setSelectedEntityIds(elements);
+        // Clear multi-selection highlight — isolate shows the class members,
+        // but we don't want every element highlighted/selected
+        setSelectedEntityIds([]);
         setSelectedEntity(resolveEntityRef(elements[0]));
         isolateEntities(elements);
       }
@@ -287,6 +289,10 @@ export function HierarchyPanel() {
       // Element click - select it
       const elementId = node.expressIds[0];  // Original expressId
       const modelId = node.modelIds[0];
+
+      // Clear multi-selection (e.g. from a prior type-group click) so only
+      // this single element is highlighted, matching Viewport pick behavior
+      setSelectedEntityIds([]);
 
       if (modelId !== 'legacy') {
         // Multi-model: need to convert to globalId for renderer


### PR DESCRIPTION
## Summary
This PR fixes the multi-selection highlight behavior in the HierarchyPanel to ensure that only the intended element(s) are highlighted when navigating the hierarchy, matching the behavior of direct viewport picks.

## Key Changes
- **Type-group selection**: When selecting a type-group node, clear the multi-selection highlight before isolating the class members. This prevents all elements from being highlighted while still showing the isolated view.
- **Single element selection**: When selecting an individual element from the hierarchy, clear any prior multi-selection state so only that single element is highlighted, matching the behavior when picking directly in the viewport.

## Implementation Details
Both changes use `setSelectedEntityIds([])` to clear the multi-selection state at the appropriate points in the selection flow:
1. In the type-group handler (line 203-205): Clears selection before isolating group members
2. In the single element handler (line 293-295): Clears any prior multi-selection before selecting the new element

This ensures consistent highlight behavior across different selection methods and prevents visual confusion from multiple highlighted elements.

https://claude.ai/code/session_01PXAYTz8jYrKx73AfYd1C8B

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed multi-selection behavior in the hierarchy panel when isolating members or selecting individual elements. Previously selected items are now properly cleared to prevent unintended multi-selection states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->