### PR TITLE
fix(viewer): keep UCS axis helper synced with camera orbit

### DIFF
--- a/apps/viewer/src/components/viewer/AxisHelper.tsx
+++ b/apps/viewer/src/components/viewer/AxisHelper.tsx
@@ -8,15 +8,36 @@
  * the axes with Z pointing upward to match what users expect in IFC/BIM context.
  */
 
+import { forwardRef, useImperativeHandle, useRef } from 'react';
+
 interface AxisHelperProps {
   rotationX?: number;
   rotationY?: number;
 }
 
-export function AxisHelper({ rotationX = -25, rotationY = 45 }: AxisHelperProps) {
+export interface AxisHelperRef {
+  updateRotation: (rotationX: number, rotationY: number) => void;
+}
+
+export const AxisHelper = forwardRef<AxisHelperRef, AxisHelperProps>(function AxisHelper(
+  { rotationX = -25, rotationY = 45 }: AxisHelperProps,
+  ref,
+) {
   const size = 50;
   const axisLength = 20;
   const labelOffset = 26;
+  const axisContainerRef = useRef<HTMLDivElement | null>(null);
+
+  const rotationTransform = (nextRotationX: number, nextRotationY: number) =>
+    `rotateX(${nextRotationX}deg) rotateY(${nextRotationY}deg)`;
+
+  useImperativeHandle(ref, () => ({
+    updateRotation(nextRotationX, nextRotationY) {
+      if (axisContainerRef.current) {
+        axisContainerRef.current.style.transform = rotationTransform(nextRotationX, nextRotationY);
+      }
+    },
+  }), []);
 
   // Convert from WebGL convention (Y-up) to IFC display convention (Z-up)
   // In the viewer, Y is up in 3D space, but we relabel:
@@ -34,10 +55,11 @@ export function AxisHelper({ rotationX = -25, rotationY = 45 }: AxisHelperProps)
       }}
     >
       <div
+        ref={axisContainerRef}
         className="relative w-full h-full"
         style={{
           transformStyle: 'preserve-3d',
-          transform: `rotateX(${rotationX}deg) rotateY(${rotationY}deg)`,
+          transform: rotationTransform(rotationX, rotationY),
         }}
       >
         {/* X Axis - Red (pointing right) */}
@@ -122,4 +144,4 @@ export function AxisHelper({ rotationX = -25, rotationY = 45 }: AxisHelperProps)
       </div>
     </div>
   );
-}
+});

--- a/apps/viewer/src/components/viewer/ViewportOverlays.tsx
+++ b/apps/viewer/src/components/viewer/ViewportOverlays.tsx
@@ -16,7 +16,7 @@ import { goHomeFromStore } from '@/store/homeView';
 import { useIfc } from '@/hooks/useIfc';
 import { cn } from '@/lib/utils';
 import { ViewCube, type ViewCubeRef } from './ViewCube';
-import { AxisHelper } from './AxisHelper';
+import { AxisHelper, type AxisHelperRef } from './AxisHelper';
 
 export function ViewportOverlays() {
   const selectedStoreys = useViewerStore((s) => s.selectedStoreys);
@@ -31,6 +31,7 @@ export function ViewportOverlays() {
   // Use refs for rotation to avoid re-renders - ViewCube updates itself directly
   const cameraRotationRef = useRef({ azimuth: 45, elevation: 25 });
   const viewCubeRef = useRef<ViewCubeRef | null>(null);
+  const axisHelperRef = useRef<AxisHelperRef | null>(null);
 
   // Local state for scale - updated via callback, no global re-renders
   const [scale, setScale] = useState(10);
@@ -41,11 +42,11 @@ export function ViewportOverlays() {
     const handleRotationChange = (rotation: { azimuth: number; elevation: number }) => {
       cameraRotationRef.current = rotation;
       // Update ViewCube directly via ref (no React re-render)
-      if (viewCubeRef.current) {
-        const viewCubeRotationX = -rotation.elevation;
-        const viewCubeRotationY = -rotation.azimuth;
-        viewCubeRef.current.updateRotation(viewCubeRotationX, viewCubeRotationY);
-      }
+      const viewCubeRotationX = -rotation.elevation;
+      const viewCubeRotationY = -rotation.azimuth;
+
+      viewCubeRef.current?.updateRotation(viewCubeRotationX, viewCubeRotationY);
+      axisHelperRef.current?.updateRotation(viewCubeRotationX, viewCubeRotationY);
     };
     setOnCameraRotationChange(handleRotationChange);
     return () => setOnCameraRotationChange(null);
@@ -193,6 +194,7 @@ export function ViewportOverlays() {
       {/* Axis Helper (bottom-left, above scale bar) - IFC Z-up convention */}
       <div className="absolute bottom-16 left-4">
         <AxisHelper
+          ref={axisHelperRef}
           rotationX={initialRotationX}
           rotationY={initialRotationY}
         />


### PR DESCRIPTION
### Motivation
- The UCS/gizmo (AxisHelper) only updated when the overlay re-rendered, causing it to "stick" for half an orbit and only refresh on zoom or other state changes.
- Root cause: split update paths where `ViewCube` used an imperative ref update but `AxisHelper` relied on render-time props, producing stale transforms between camera callbacks.

### Description
- Convert `AxisHelper` to a ref-driven component using `forwardRef` and `useImperativeHandle` and expose `updateRotation(rotationX, rotationY)` to update the internal transform directly.
- Add an `axisHelperRef` in `ViewportOverlays` and call `axisHelperRef.current?.updateRotation(...)` alongside the existing `viewCubeRef.current?.updateRotation(...)` on every camera rotation callback.
- Replace the previous conditional coupling with independent optional-chaining updates so each overlay widget receives camera updates immediately without forcing parent re-renders.

### Testing
- Ran the viewer unit test suite with `pnpm -C /workspace/ifc-lite --filter @ifc-lite/viewer test` and all tests passed (`# pass 229`, `# fail 0`).
- Performed a TypeScript check with `pnpm -C /workspace/ifc-lite --filter @ifc-lite/viewer exec tsc --noEmit` which completed without errors.
- Started the dev server and exercised a smoke test that captured a screenshot of the viewer to validate the AxisHelper visually (Playwright script executed and saved an artifact).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a710c44b58832082de8457e986d639)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Axis helper rotation now updates synchronously with viewport rotation changes for enhanced responsiveness during camera interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->