### PR TITLE
Fix UCS gizmo rotation updates in viewer overlays

### DIFF
--- a/apps/viewer/src/components/viewer/AxisHelper.tsx
+++ b/apps/viewer/src/components/viewer/AxisHelper.tsx
@@ -8,15 +8,64 @@
  * the axes with Z pointing upward to match what users expect in IFC/BIM context.
  */
 
+import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
+
 interface AxisHelperProps {
   rotationX?: number;
   rotationY?: number;
 }
 
-export function AxisHelper({ rotationX = -25, rotationY = 45 }: AxisHelperProps) {
+export interface AxisHelperRef {
+  updateRotation: (x: number, y: number) => void;
+}
+
+export const AxisHelper = forwardRef<AxisHelperRef, AxisHelperProps>(({ rotationX = -25, rotationY = 45 }, ref) => {
   const size = 50;
   const axisLength = 20;
   const labelOffset = 26;
+  const rotationContainerRef = useRef<HTMLDivElement | null>(null);
+  const xLabelRef = useRef<HTMLDivElement | null>(null);
+  const yLabelRef = useRef<HTMLDivElement | null>(null);
+  const zLabelRef = useRef<HTMLDivElement | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const pendingRotationRef = useRef<{ x: number; y: number } | null>(null);
+
+  const applyRotation = (x: number, y: number) => {
+    if (!rotationContainerRef.current) return;
+
+    rotationContainerRef.current.style.transform = `rotateX(${x}deg) rotateY(${y}deg)`;
+
+    const inverseRotation = `rotateY(${-y}deg) rotateX(${-x}deg)`;
+    if (xLabelRef.current) xLabelRef.current.style.transform = inverseRotation;
+    if (zLabelRef.current) zLabelRef.current.style.transform = inverseRotation;
+    if (yLabelRef.current) yLabelRef.current.style.transform = `translateZ(${labelOffset}px) ${inverseRotation}`;
+  };
+
+  useImperativeHandle(ref, () => ({
+    updateRotation: (x: number, y: number) => {
+      pendingRotationRef.current = { x, y };
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+      }
+
+      rafRef.current = requestAnimationFrame(() => {
+        if (pendingRotationRef.current) {
+          applyRotation(pendingRotationRef.current.x, pendingRotationRef.current.y);
+          pendingRotationRef.current = null;
+        }
+        rafRef.current = null;
+      });
+    },
+  }), []);
+
+  useEffect(() => {
+    applyRotation(rotationX, rotationY);
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+      }
+    };
+  }, []);
 
   // Convert from WebGL convention (Y-up) to IFC display convention (Z-up)
   // In the viewer, Y is up in 3D space, but we relabel:
@@ -34,6 +83,7 @@ export function AxisHelper({ rotationX = -25, rotationY = 45 }: AxisHelperProps)
       }}
     >
       <div
+        ref={rotationContainerRef}
         className="relative w-full h-full"
         style={{
           transformStyle: 'preserve-3d',
@@ -53,6 +103,7 @@ export function AxisHelper({ rotationX = -25, rotationY = 45 }: AxisHelperProps)
           }}
         />
         <div
+          ref={xLabelRef}
           className="absolute text-red-500 font-bold text-xs"
           style={{
             left: size / 2 + labelOffset,
@@ -76,6 +127,7 @@ export function AxisHelper({ rotationX = -25, rotationY = 45 }: AxisHelperProps)
           }}
         />
         <div
+          ref={zLabelRef}
           className="absolute text-blue-500 font-bold text-xs"
           style={{
             left: size / 2 - 4,
@@ -100,6 +152,7 @@ export function AxisHelper({ rotationX = -25, rotationY = 45 }: AxisHelperProps)
           }}
         />
         <div
+          ref={yLabelRef}
           className="absolute text-green-500 font-bold text-xs"
           style={{
             left: size / 2 - 4,
@@ -122,4 +175,6 @@ export function AxisHelper({ rotationX = -25, rotationY = 45 }: AxisHelperProps)
       </div>
     </div>
   );
-}
+});
+
+AxisHelper.displayName = 'AxisHelper';

--- a/apps/viewer/src/components/viewer/ViewportOverlays.tsx
+++ b/apps/viewer/src/components/viewer/ViewportOverlays.tsx
@@ -16,7 +16,7 @@ import { goHomeFromStore } from '@/store/homeView';
 import { useIfc } from '@/hooks/useIfc';
 import { cn } from '@/lib/utils';
 import { ViewCube, type ViewCubeRef } from './ViewCube';
-import { AxisHelper } from './AxisHelper';
+import { AxisHelper, type AxisHelperRef } from './AxisHelper';
 
 export function ViewportOverlays() {
   const selectedStoreys = useViewerStore((s) => s.selectedStoreys);
@@ -31,6 +31,7 @@ export function ViewportOverlays() {
   // Use refs for rotation to avoid re-renders - ViewCube updates itself directly
   const cameraRotationRef = useRef({ azimuth: 45, elevation: 25 });
   const viewCubeRef = useRef<ViewCubeRef | null>(null);
+  const axisHelperRef = useRef<AxisHelperRef | null>(null);
 
   // Local state for scale - updated via callback, no global re-renders
   const [scale, setScale] = useState(10);
@@ -41,11 +42,10 @@ export function ViewportOverlays() {
     const handleRotationChange = (rotation: { azimuth: number; elevation: number }) => {
       cameraRotationRef.current = rotation;
       // Update ViewCube directly via ref (no React re-render)
-      if (viewCubeRef.current) {
-        const viewCubeRotationX = -rotation.elevation;
-        const viewCubeRotationY = -rotation.azimuth;
-        viewCubeRef.current.updateRotation(viewCubeRotationX, viewCubeRotationY);
-      }
+      const viewCubeRotationX = -rotation.elevation;
+      const viewCubeRotationY = -rotation.azimuth;
+      viewCubeRef.current?.updateRotation(viewCubeRotationX, viewCubeRotationY);
+      axisHelperRef.current?.updateRotation(viewCubeRotationX, viewCubeRotationY);
     };
     setOnCameraRotationChange(handleRotationChange);
     return () => setOnCameraRotationChange(null);
@@ -193,6 +193,7 @@ export function ViewportOverlays() {
       {/* Axis Helper (bottom-left, above scale bar) - IFC Z-up convention */}
       <div className="absolute bottom-16 left-4">
         <AxisHelper
+          ref={axisHelperRef}
           rotationX={initialRotationX}
           rotationY={initialRotationY}
         />


### PR DESCRIPTION
### Motivation
- The Axis/UCS helper remained static during camera orbit because it only received initial props and had no live update path; the `ViewCube` already received ref-driven updates, causing inconsistent behavior.
- Make the axis helper respond smoothly and continuously to camera orbit events without forcing React re-renders.

### Description
- Convert `AxisHelper` to an imperative `forwardRef` component that exposes `updateRotation(x, y)` so rotation can be driven via a ref instead of React props (`apps/viewer/src/components/viewer/AxisHelper.tsx`).
- Batch DOM updates for the axis container and label transforms with `requestAnimationFrame` to ensure smooth 60fps updates and keep labels billboarded correctly (`applyRotation` updates container + X/Y/Z label transforms together).
- Wire `ViewportOverlays` to update both the `ViewCube` and the new `AxisHelper` ref on every camera rotation callback, using optional chaining for safe ref calls (`apps/viewer/src/components/viewer/ViewportOverlays.tsx`).

### Testing
- Ran unit tests with `pnpm -C apps/viewer test` and all tests passed (229 tests, 0 failures). ✅
- Attempted production build with `pnpm -C apps/viewer build`; it failed due to existing unresolved workspace imports (`@ifc-lite/sandbox/schema`, `@ifc-lite/create`) unrelated to this change, so build failure is not caused by the UCS fix. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a710c44b58832082de8457e986d639)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AxisHelper component now features a new imperative rotation control API for direct programmatic manipulation of rotation values without component re-renders.
  * Enhanced rotation synchronization: AxisHelper and ViewCube components now update together seamlessly whenever camera orientation changes, delivering consistent visual feedback and smoother user interactions across all viewport controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->