### PR TITLE
Improve IFC STEP string encoding/decoding compliance

### DIFF
--- a/.changeset/tidy-drinks-unite.md
+++ b/.changeset/tidy-drinks-unite.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/encoding": patch
+---
+
+Improve IFC STEP string handling by implementing robust decode support for `\\S\\`, `\\X\\`, `\\X2\\...\\X0\\`, `\\X4\\...\\X0\\`, and `\\P.\\` directives, and add `encodeIfcString` for producing STEP-safe string escapes.

--- a/packages/encoding/src/ifc-string.test.ts
+++ b/packages/encoding/src/ifc-string.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { describe, it, expect } from 'vitest';
-import { decodeIfcString } from './ifc-string.js';
+import { decodeIfcString, encodeIfcString } from './ifc-string.js';
 
 describe('decodeIfcString', () => {
   it('returns plain strings unchanged', () => {
@@ -17,33 +17,54 @@ describe('decodeIfcString', () => {
   });
 
   it('decodes \\X2\\ unicode hex sequences', () => {
-    // ä = U+00E4
     expect(decodeIfcString('\\X2\\00E4\\X0\\')).toBe('ä');
-    // äü (two chars in one sequence)
     expect(decodeIfcString('\\X2\\00E400FC\\X0\\')).toBe('äü');
   });
 
   it('decodes \\X4\\ 4-byte unicode sequences', () => {
-    // 𝄞 = U+1D11E (Musical Symbol G Clef)
     expect(decodeIfcString('\\X4\\0001D11E\\X0\\')).toBe('𝄞');
   });
 
   it('decodes \\X\\ ISO-8859-1 single byte', () => {
-    // ñ = 0xF1 in ISO-8859-1
     expect(decodeIfcString('\\X\\F1')).toBe('ñ');
   });
 
   it('decodes \\S\\ latin extended', () => {
-    // \\S\\X where X.charCodeAt(0) + 128 = result
-    // 'a' = 97, 97 + 128 = 225 = á
-    expect(decodeIfcString('\\S\\a')).toBe('á');
+    expect(decodeIfcString('\\S\\D')).toBe('Ä');
   });
 
-  it('strips \\P code page switches', () => {
+  it('supports explicit \\PA\\ code page directive before \\S\\', () => {
+    expect(decodeIfcString('\\PA\\\\S\\D')).toBe('Ä');
+  });
+
+  it('strips \\P code page switches in normal text', () => {
     expect(decodeIfcString('\\PA\\Hello')).toBe('Hello');
   });
 
   it('decodes mixed encodings in one string', () => {
     expect(decodeIfcString('Br\\X2\\00FC\\X0\\cke')).toBe('Brücke');
+  });
+});
+
+describe('encodeIfcString', () => {
+  it('keeps printable ASCII unchanged', () => {
+    expect(encodeIfcString('Hello IFC')).toBe('Hello IFC');
+  });
+
+  it('encodes 8-bit latin chars as \\X\\HH', () => {
+    expect(encodeIfcString('Ä')).toBe('\\X\\C4');
+  });
+
+  it('encodes BMP chars as \\X2\\....\\X0\\', () => {
+    expect(encodeIfcString('Ω')).toBe('\\X2\\03A9\\X0\\');
+  });
+
+  it('encodes non-BMP chars as \\X4\\........\\X0\\', () => {
+    expect(encodeIfcString('𝄞')).toBe('\\X4\\0001D11E\\X0\\');
+  });
+
+  it('round-trips with decoder for mixed characters', () => {
+    const value = 'Brücke Ω 𝄞';
+    expect(decodeIfcString(encodeIfcString(value))).toBe(value);
   });
 });

--- a/packages/encoding/src/ifc-string.ts
+++ b/packages/encoding/src/ifc-string.ts
@@ -9,50 +9,117 @@
  * - \X4\XXXXXXXX\X0\ - Unicode 4-byte hex for chars outside BMP
  * - \X\XX\ - ISO-8859-1 hex encoding
  * - \S\X - Extended ASCII with escape
- * - \P..\ - Code page switches (stripped)
+ * - \P..\ - Code page switches (supported as directives and removed)
  */
 export function decodeIfcString(str: string): string {
   if (!str || typeof str !== 'string') return str;
 
-  let result = str;
+  let result = '';
+  let i = 0;
 
-  // Decode \X2\XXXX\X0\ patterns (Unicode 2-byte hex, can have multiple chars)
-  result = result.replace(/\\X2\\([0-9A-Fa-f]+)\\X0\\/g, (_, hex) => {
-    let decoded = '';
-    for (let i = 0; i < hex.length; i += 4) {
-      const charCode = parseInt(hex.substring(i, i + 4), 16);
-      if (!isNaN(charCode)) {
-        decoded += String.fromCharCode(charCode);
+  while (i < str.length) {
+    if (str[i] !== '\\') {
+      result += str[i];
+      i += 1;
+      continue;
+    }
+
+    // Handle code page directives like \PA\, \PB\, ... by consuming them.
+    if (str[i + 1] === 'P' && str[i + 3] === '\\') {
+      i += 4;
+      continue;
+    }
+
+    // Handle \S\X where byte value is ord(X) + 128 in ISO-8859-1.
+    if (str[i + 1] === 'S' && str[i + 2] === '\\' && i + 3 < str.length) {
+      result += String.fromCharCode(str.charCodeAt(i + 3) + 128);
+      i += 4;
+      continue;
+    }
+
+    // Handle \X\HH (8-bit value from ISO 10646 row 0 / ISO-8859-1 overlap).
+    if (str[i + 1] === 'X' && str[i + 2] === '\\' && i + 5 <= str.length) {
+      const hex = str.slice(i + 3, i + 5);
+      if (/^[0-9A-Fa-f]{2}$/.test(hex)) {
+        result += String.fromCharCode(parseInt(hex, 16));
+        i += 5;
+        continue;
       }
     }
-    return decoded;
-  });
 
-  // Decode \X4\XXXXXXXX\X0\ patterns (Unicode 4-byte hex for chars outside BMP)
-  result = result.replace(/\\X4\\([0-9A-Fa-f]+)\\X0\\/g, (_, hex) => {
-    let decoded = '';
-    for (let i = 0; i < hex.length; i += 8) {
-      const codePoint = parseInt(hex.substring(i, i + 8), 16);
-      if (!isNaN(codePoint)) {
-        decoded += String.fromCodePoint(codePoint);
+    // Handle \X2\....\X0\ (UTF-16 hex code units, 4 chars each).
+    if (str.startsWith('\\X2\\', i)) {
+      const end = str.indexOf('\\X0\\', i + 4);
+      if (end !== -1) {
+        const hex = str.slice(i + 4, end);
+        if (hex.length % 4 === 0 && /^[0-9A-Fa-f]+$/.test(hex)) {
+          for (let j = 0; j < hex.length; j += 4) {
+            result += String.fromCharCode(parseInt(hex.slice(j, j + 4), 16));
+          }
+          i = end + 4;
+          continue;
+        }
       }
     }
-    return decoded;
-  });
 
-  // Decode \X\XX\ patterns (ISO-8859-1 single byte)
-  result = result.replace(/\\X\\([0-9A-Fa-f]{2})/g, (_, hex) => {
-    const charCode = parseInt(hex, 16);
-    return !isNaN(charCode) ? String.fromCharCode(charCode) : '';
-  });
+    // Handle \X4\........\X0\ (Unicode scalar values, 8 hex digits each).
+    if (str.startsWith('\\X4\\', i)) {
+      const end = str.indexOf('\\X0\\', i + 4);
+      if (end !== -1) {
+        const hex = str.slice(i + 4, end);
+        if (hex.length % 8 === 0 && /^[0-9A-Fa-f]+$/.test(hex)) {
+          for (let j = 0; j < hex.length; j += 8) {
+            result += String.fromCodePoint(parseInt(hex.slice(j, j + 8), 16));
+          }
+          i = end + 4;
+          continue;
+        }
+      }
+    }
 
-  // Decode \S\X patterns (Latin extended, offset by 128)
-  result = result.replace(/\\S\\(.)/g, (_, char) => {
-    return String.fromCharCode(char.charCodeAt(0) + 128);
-  });
-
-  // Decode \P..\ code page switches (simplified - just remove them)
-  result = result.replace(/\\P[A-Z]?\\/g, '');
+    // Unknown escape sequence: keep the backslash and move on.
+    result += str[i];
+    i += 1;
+  }
 
   return result;
+}
+
+/**
+ * Encode a Unicode string to IFC STEP string escapes.
+ *
+ * - Printable ASCII (32..126) is kept as-is.
+ * - 8-bit values are encoded as \X\HH.
+ * - BMP values are encoded as \X2\HHHH\X0\.
+ * - Non-BMP values are encoded as \X4\HHHHHHHH\X0\.
+ */
+export function encodeIfcString(str: string): string {
+  if (!str || typeof str !== 'string') return str;
+
+  let encoded = '';
+  for (const ch of str) {
+    const codePoint = ch.codePointAt(0);
+    if (codePoint === undefined) {
+      continue;
+    }
+
+    if (codePoint >= 32 && codePoint <= 126 && ch !== '\\') {
+      encoded += ch;
+      continue;
+    }
+
+    if (codePoint <= 0xFF) {
+      encoded += `\\X\\${codePoint.toString(16).toUpperCase().padStart(2, '0')}`;
+      continue;
+    }
+
+    if (codePoint <= 0xFFFF) {
+      encoded += `\\X2\\${codePoint.toString(16).toUpperCase().padStart(4, '0')}\\X0\\`;
+      continue;
+    }
+
+    encoded += `\\X4\\${codePoint.toString(16).toUpperCase().padStart(8, '0')}\\X0\\`;
+  }
+
+  return encoded;
 }

--- a/packages/encoding/src/index.ts
+++ b/packages/encoding/src/index.ts
@@ -2,6 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-export { decodeIfcString } from './ifc-string.js';
+export { decodeIfcString, encodeIfcString } from './ifc-string.js';
 export { parsePropertyValue } from './property-value.js';
 export type { ParsedPropertyValue } from './property-value.js';


### PR DESCRIPTION
### Motivation
- STEP/IFC strings use escape directives (e.g. `\P..\`, `\S\`, `\X\`, `\X2\...\X0\`, `\X4\...\X0\`) that must be parsed in order to correctly decode non-ASCII characters per ISO10303; the previous regex-only approach was brittle for directive ordering and terminators. 
- Provide a safe way to produce STEP-safe string escapes when serializing strings so the project can move toward UTF-8 while remaining compatible with legacy STEP encodings. 

### Description
- Rewrote `decodeIfcString` to a directive-aware single-pass parser that handles `\P` code page directives (consumed/removed), `\S\` (byte + 128), `\X\HH`, `\X2\...\X0\` (UTF-16 code units), and `\X4\...\X0\` (Unicode scalar values). 
- Added `encodeIfcString` which emits STEP-safe escapes for 8-bit, BMP, and non-BMP code points (`\X\HH`, `\X2\HHHH\X0\`, `\X4\HHHHHHHH\X0\`) and preserves printable ASCII. 
- Exported `encodeIfcString` from the package entrypoint and added/updated unit tests in `packages/encoding/src/ifc-string.test.ts` to cover decoding examples, encoder output, and round-trip cases. 
- Added a patch changeset for `@ifc-lite/encoding` to record the public API change. 

### Testing
- Ran the package test suite with `pnpm --filter @ifc-lite/encoding test` and all tests passed (`Test Files 2 passed`, `Tests 25 passed`). 
- Built the package with `pnpm --filter @ifc-lite/encoding build` and TypeScript compilation succeeded. 
- Added unit tests that exercise `decodeIfcString` and `encodeIfcString`, including mixed-encoding round-trips, and they passed in the CI-local run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a73fa4f1b483209fdb3959a3543ba5)