### PR TITLE
viewer: use icons when property panel tabs become narrow

### DIFF
--- a/apps/viewer/src/components/viewer/PropertiesPanel.tsx
+++ b/apps/viewer/src/components/viewer/PropertiesPanel.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { useMemo, useState, useCallback, useEffect } from 'react';
+import { useMemo, useState, useCallback, useEffect, useRef } from 'react';
 import {
   Copy,
   Check,
@@ -19,6 +19,7 @@ import {
   FileBox,
   PenLine,
   Crosshair,
+  BookOpen,
 } from 'lucide-react';
 import { EditToolbar } from './PropertyEditor';
 import { Button } from '@/components/ui/button';
@@ -45,6 +46,7 @@ import type { PropertySet, QuantitySet } from './properties/encodingUtils';
 import { BsddCard } from './properties/BsddCard';
 
 export function PropertiesPanel() {
+  const tabsListRef = useRef<HTMLDivElement | null>(null);
   const selectedEntityId = useViewerStore((s) => s.selectedEntityId);
   const selectedEntity = useViewerStore((s) => s.selectedEntity);
   const selectedEntities = useViewerStore((s) => s.selectedEntities);
@@ -112,9 +114,29 @@ export function PropertiesPanel() {
   const [copied, setCopied] = useState(false);
   const [coordCopied, setCoordCopied] = useState<string | null>(null);
   const [coordOpen, setCoordOpen] = useState(false);
+  const [compactTabs, setCompactTabs] = useState(false);
 
   // Edit mode toggle - allows inline property editing
   const [editMode, setEditMode] = useState(false);
+
+  useEffect(() => {
+    const tabsElement = tabsListRef.current;
+    if (!tabsElement) return;
+
+    const updateTabDensity = () => {
+      const tabWidth = tabsElement.clientWidth / 3;
+      setCompactTabs(tabWidth < 88);
+    };
+
+    updateTabDensity();
+
+    const resizeObserver = new ResizeObserver(updateTabDensity);
+    resizeObserver.observe(tabsElement);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, []);
 
   const copyToClipboard = useCallback((text: string) => {
     navigator.clipboard.writeText(text);
@@ -925,24 +947,37 @@ export function PropertiesPanel() {
 
       {/* Tabs */}
       <Tabs defaultValue="properties" className="flex-1 flex flex-col overflow-hidden">
-        <TabsList className="tabs-list w-full justify-start rounded-none h-9 p-0 shrink-0 flex" style={{ backgroundColor: 'var(--tabs-bg)', borderBottom: '1px solid var(--tabs-border)' }}>
+        <TabsList
+          ref={tabsListRef}
+          className="tabs-list w-full justify-start rounded-none h-9 p-0 shrink-0 flex"
+          style={{ backgroundColor: 'var(--tabs-bg)', borderBottom: '1px solid var(--tabs-border)' }}
+        >
           <TabsTrigger
             value="properties"
             className="tab-trigger flex-1 min-w-0 rounded-none border-b-2 border-transparent data-[state=active]:border-primary uppercase text-[11px] tracking-wide h-full px-2"
           >
-            Properties
+            <span className="flex items-center justify-center gap-1.5 w-full">
+              <FileText className="h-3.5 w-3.5 shrink-0" aria-hidden />
+              {!compactTabs && <span className="truncate">Properties</span>}
+            </span>
           </TabsTrigger>
           <TabsTrigger
             value="quantities"
             className="tab-trigger flex-1 min-w-0 rounded-none border-b-2 border-transparent data-[state=active]:border-primary uppercase text-[11px] tracking-wide h-full px-2"
           >
-            Quantities
+            <span className="flex items-center justify-center gap-1.5 w-full">
+              <Calculator className="h-3.5 w-3.5 shrink-0" aria-hidden />
+              {!compactTabs && <span className="truncate">Quantities</span>}
+            </span>
           </TabsTrigger>
           <TabsTrigger
             value="bsdd"
             className="tab-trigger flex-1 min-w-0 rounded-none border-b-2 border-transparent data-[state=active]:border-primary uppercase text-[11px] tracking-wide h-full px-2"
           >
-            bSDD
+            <span className="flex items-center justify-center gap-1.5 w-full">
+              <BookOpen className="h-3.5 w-3.5 shrink-0" aria-hidden />
+              {!compactTabs && <span className="truncate">bSDD</span>}
+            </span>
           </TabsTrigger>
         </TabsList>
 


### PR DESCRIPTION
### Motivation
- Improve usability on narrow property panel layouts by showing compact, recognizable icons for the Properties / Quantities / bSDD tabs so the UI remains readable.
- Preserve full text labels on wider panels while switching automatically to an icon-first compact mode at small widths.

### Description
- Added a `tabsListRef` and `compactTabs` state to `apps/viewer/src/components/viewer/PropertiesPanel.tsx` and hooked a `ResizeObserver` to detect when per-tab width drops below a threshold and toggle compact mode.
- Replaced the plain text tab triggers with icon-first spans that render `FileText` for Properties, `Calculator` for Quantities, and `BookOpen` for bSDD and hide the labels when `compactTabs` is true.
- Kept existing styling and tab structure; the changes are contained to `PropertiesPanel.tsx` and do not alter property/quantity extraction logic.

### Testing
- Ran a TypeScript type check: `pnpm -C apps/viewer exec tsc --noEmit`, which completed successfully.
- Attempted to start the dev server with `pnpm -C apps/viewer dev --host 0.0.0.0 --port 4173` but Vite dependency scanning failed in this environment due to unresolved local package entry points for `@ifc-lite/create` and `@ifc-lite/sandbox`, so a live UI check was not captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a741ee1aa88320ba81c484f7229876)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Properties Panel tabs now dynamically adapt to available horizontal space, automatically switching to a compact icon-only display when width is constrained.
  * Added visual icons alongside text labels to improve tab identification.
  * Tab labels intelligently collapse to show icons only in compact mode, optimizing screen space usage on smaller displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->