### PR TITLE
viewer: add icon-first fallback for narrow property panel tabs

### DIFF
--- a/apps/viewer/src/components/viewer/PropertiesPanel.tsx
+++ b/apps/viewer/src/components/viewer/PropertiesPanel.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { useMemo, useState, useCallback, useEffect } from 'react';
+import { useMemo, useState, useCallback, useEffect, useRef } from 'react';
 import {
   Copy,
   Check,
@@ -19,6 +19,7 @@ import {
   FileBox,
   PenLine,
   Crosshair,
+  BookOpen,
 } from 'lucide-react';
 import { EditToolbar } from './PropertyEditor';
 import { Button } from '@/components/ui/button';
@@ -112,9 +113,35 @@ export function PropertiesPanel() {
   const [copied, setCopied] = useState(false);
   const [coordCopied, setCoordCopied] = useState<string | null>(null);
   const [coordOpen, setCoordOpen] = useState(false);
+  const tabsListRef = useRef<HTMLDivElement | null>(null);
+  const [compactTabs, setCompactTabs] = useState(false);
 
   // Edit mode toggle - allows inline property editing
   const [editMode, setEditMode] = useState(false);
+
+  useEffect(() => {
+    const tabsElement = tabsListRef.current;
+    if (!tabsElement) return;
+
+    const updateTabsLayout = (width: number) => {
+      // Switch to icon-first tabs when the panel gets too narrow for three labels.
+      setCompactTabs(width < 320);
+    };
+
+    updateTabsLayout(tabsElement.getBoundingClientRect().width);
+
+    const resizeObserver = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      updateTabsLayout(entry.contentRect.width);
+    });
+
+    resizeObserver.observe(tabsElement);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, []);
 
   const copyToClipboard = useCallback((text: string) => {
     navigator.clipboard.writeText(text);
@@ -925,24 +952,36 @@ export function PropertiesPanel() {
 
       {/* Tabs */}
       <Tabs defaultValue="properties" className="flex-1 flex flex-col overflow-hidden">
-        <TabsList className="tabs-list w-full justify-start rounded-none h-9 p-0 shrink-0 flex" style={{ backgroundColor: 'var(--tabs-bg)', borderBottom: '1px solid var(--tabs-border)' }}>
+        <TabsList ref={tabsListRef} className="tabs-list w-full justify-start rounded-none h-9 p-0 shrink-0 flex" style={{ backgroundColor: 'var(--tabs-bg)', borderBottom: '1px solid var(--tabs-border)' }}>
           <TabsTrigger
             value="properties"
+            aria-label="Properties"
             className="tab-trigger flex-1 min-w-0 rounded-none border-b-2 border-transparent data-[state=active]:border-primary uppercase text-[11px] tracking-wide h-full px-2"
           >
-            Properties
+            <span className="flex items-center justify-center gap-1.5 min-w-0">
+              <FileText className="h-3.5 w-3.5 shrink-0" />
+              {!compactTabs && <span className="truncate">Properties</span>}
+            </span>
           </TabsTrigger>
           <TabsTrigger
             value="quantities"
+            aria-label="Quantities"
             className="tab-trigger flex-1 min-w-0 rounded-none border-b-2 border-transparent data-[state=active]:border-primary uppercase text-[11px] tracking-wide h-full px-2"
           >
-            Quantities
+            <span className="flex items-center justify-center gap-1.5 min-w-0">
+              <Calculator className="h-3.5 w-3.5 shrink-0" />
+              {!compactTabs && <span className="truncate">Quantities</span>}
+            </span>
           </TabsTrigger>
           <TabsTrigger
             value="bsdd"
+            aria-label="bSDD"
             className="tab-trigger flex-1 min-w-0 rounded-none border-b-2 border-transparent data-[state=active]:border-primary uppercase text-[11px] tracking-wide h-full px-2"
           >
-            bSDD
+            <span className="flex items-center justify-center gap-1.5 min-w-0">
+              <BookOpen className="h-3.5 w-3.5 shrink-0" />
+              {!compactTabs && <span className="truncate">bSDD</span>}
+            </span>
           </TabsTrigger>
         </TabsList>
 


### PR DESCRIPTION
### Motivation
- Improve usability of the Properties panel on narrow viewports by showing compact, icon-first tabs for Properties, Quantities and bSDD so tab labels don't overflow or wrap.

### Description
- Add `tabsListRef`, `compactTabs` state and a `ResizeObserver` in `PropertiesPanel` to detect narrow tab-strip widths and toggle compact mode. 
- Add icon affordances to the three tab triggers (`FileText`, `Calculator`, `BookOpen`) and render the text labels only when not in compact mode, while preserving `aria-label` for accessibility. 
- Add necessary imports (`useRef`, `BookOpen`) and wire the `TabsList` `ref` to the observer; changes live in `apps/viewer/src/components/viewer/PropertiesPanel.tsx`.

### Testing
- Typecheck: ran `pnpm -C apps/viewer exec tsc --noEmit`, which succeeded. 
- Visual smoke: ran an automated Playwright script to capture wide and narrow screenshots of the viewer; screenshots were produced for verification. 
- Dev server attempt: `pnpm -C apps/viewer dev` encountered workspace package resolution errors (unrelated to this UI change) preventing full runtime hot-reload verification in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a741ee1aa88320ba81c484f7229876)