### PR TITLE
Add IFC STEP string encoder and broaden decoding support

### DIFF
--- a/.changeset/late-readers-speak.md
+++ b/.changeset/late-readers-speak.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/encoding': patch
+---
+
+Improve IFC STEP string codec behavior by adding standards-aligned encoding support and broader decoding compatibility for documented escaped string forms (`\S\`, `\X\`, `\X2\`, `\X4\`, and code page directives).

--- a/packages/encoding/src/ifc-string.test.ts
+++ b/packages/encoding/src/ifc-string.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { describe, it, expect } from 'vitest';
-import { decodeIfcString } from './ifc-string.js';
+import { decodeIfcString, encodeIfcString } from './ifc-string.js';
 
 describe('decodeIfcString', () => {
   it('returns plain strings unchanged', () => {
@@ -28,15 +28,15 @@ describe('decodeIfcString', () => {
     expect(decodeIfcString('\\X4\\0001D11E\\X0\\')).toBe('𝄞');
   });
 
-  it('decodes \\X\\ ISO-8859-1 single byte', () => {
-    // ñ = 0xF1 in ISO-8859-1
+  it('decodes \\X\\ 8-bit hex sequences with and without trailing slash', () => {
+    // ñ = 0xF1 in ISO 10646 row 0
     expect(decodeIfcString('\\X\\F1')).toBe('ñ');
+    expect(decodeIfcString('\\X\\F1\\')).toBe('ñ');
   });
 
   it('decodes \\S\\ latin extended', () => {
-    // \\S\\X where X.charCodeAt(0) + 128 = result
-    // 'a' = 97, 97 + 128 = 225 = á
-    expect(decodeIfcString('\\S\\a')).toBe('á');
+    // \S\D = 68 + 128 = 196 = Ä
+    expect(decodeIfcString('\\S\\D')).toBe('Ä');
   });
 
   it('strips \\P code page switches', () => {
@@ -45,5 +45,39 @@ describe('decodeIfcString', () => {
 
   it('decodes mixed encodings in one string', () => {
     expect(decodeIfcString('Br\\X2\\00FC\\X0\\cke')).toBe('Brücke');
+  });
+
+  it('handles documented IFC umlaut examples', () => {
+    expect(decodeIfcString('\\S\\D')).toBe('Ä');
+    expect(decodeIfcString('\\PA\\\\S\\D')).toBe('Ä');
+    expect(decodeIfcString('\\X\\C4')).toBe('Ä');
+    expect(decodeIfcString('\\X2\\00C4\\X0\\')).toBe('Ä');
+  });
+});
+
+describe('encodeIfcString', () => {
+  it('returns plain strings unchanged', () => {
+    expect(encodeIfcString('Hello World')).toBe('Hello World');
+  });
+
+  it('encodes apostrophes as doubled quotes', () => {
+    expect(encodeIfcString("O'Brien")).toBe("O''Brien");
+  });
+
+  it('encodes latin-1 extension with compact \\S\\ form', () => {
+    expect(encodeIfcString('Ä')).toBe('\\S\\D');
+  });
+
+  it('encodes BMP unicode with \\X2\\', () => {
+    expect(encodeIfcString('Ω')).toBe('\\X2\\03A9\\X0\\');
+  });
+
+  it('encodes astral unicode with \\X4\\', () => {
+    expect(encodeIfcString('𝄞')).toBe('\\X4\\0001D11E\\X0\\');
+  });
+
+  it('round-trips mixed strings', () => {
+    const value = "Brücke Ω 𝄞 O'Brien";
+    expect(decodeIfcString(encodeIfcString(value))).toBe(value);
   });
 });

--- a/packages/encoding/src/ifc-string.ts
+++ b/packages/encoding/src/ifc-string.ts
@@ -7,7 +7,7 @@
  * Handles:
  * - \X2\XXXX\X0\ - Unicode hex encoding (e.g., \X2\00E4\X0\ -> a with umlaut)
  * - \X4\XXXXXXXX\X0\ - Unicode 4-byte hex for chars outside BMP
- * - \X\XX\ - ISO-8859-1 hex encoding
+ * - \X\XX\ - 8-bit ISO 10646 row 0 hex encoding
  * - \S\X - Extended ASCII with escape
  * - \P..\ - Code page switches (stripped)
  */
@@ -40,8 +40,8 @@ export function decodeIfcString(str: string): string {
     return decoded;
   });
 
-  // Decode \X\XX\ patterns (ISO-8859-1 single byte)
-  result = result.replace(/\\X\\([0-9A-Fa-f]{2})/g, (_, hex) => {
+  // Decode \X\XX\ patterns (8-bit hex in ISO 10646 row 0)
+  result = result.replace(/\\X\\([0-9A-Fa-f]{2})\\?/g, (_, hex) => {
     const charCode = parseInt(hex, 16);
     return !isNaN(charCode) ? String.fromCharCode(charCode) : '';
   });
@@ -53,6 +53,58 @@ export function decodeIfcString(str: string): string {
 
   // Decode \P..\ code page switches (simplified - just remove them)
   result = result.replace(/\\P[A-Z]?\\/g, '');
+
+  // STEP doubles apostrophes inside string literals.
+  result = result.replace(/''/g, "'");
+
+  return result;
+}
+
+/**
+ * Encode plain text for IFC STEP string literals (IFC2x3/IFC4.x conventions).
+ *
+ * Strategy:
+ * - Printable ISO-8859-1 range (32..126) is emitted as-is.
+ * - Apostrophes are doubled per STEP string escaping rules.
+ * - ISO-8859-1 extended characters (160..255) use short-form \S\X where possible.
+ * - Remaining BMP characters use \X2\hhhh\X0\.
+ * - Astral characters use \X4\hhhhhhhh\X0\.
+ */
+export function encodeIfcString(str: string): string {
+  if (!str || typeof str !== 'string') return str;
+
+  let result = '';
+
+  for (const char of str) {
+    if (char === "'") {
+      result += "''";
+      continue;
+    }
+
+    const codePoint = char.codePointAt(0);
+    if (codePoint === undefined) continue;
+
+    if (codePoint >= 32 && codePoint <= 126) {
+      result += char;
+      continue;
+    }
+
+    // ISO-8859-1 extended area can use the compact \S\X form
+    if (codePoint >= 160 && codePoint <= 255) {
+      const shifted = codePoint - 128;
+      if (shifted >= 32 && shifted <= 126) {
+        result += `\\S\\${String.fromCharCode(shifted)}`;
+        continue;
+      }
+    }
+
+    if (codePoint <= 0xffff) {
+      result += `\\X2\\${codePoint.toString(16).toUpperCase().padStart(4, '0')}\\X0\\`;
+      continue;
+    }
+
+    result += `\\X4\\${codePoint.toString(16).toUpperCase().padStart(8, '0')}\\X0\\`;
+  }
 
   return result;
 }

--- a/packages/encoding/src/index.ts
+++ b/packages/encoding/src/index.ts
@@ -2,6 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-export { decodeIfcString } from './ifc-string.js';
+export { decodeIfcString, encodeIfcString } from './ifc-string.js';
 export { parsePropertyValue } from './property-value.js';
 export type { ParsedPropertyValue } from './property-value.js';


### PR DESCRIPTION
### Motivation
- Improve handling of IFC STEP encoded string forms so encoding/decoding round-trips reliably for documented escape variants and real-world files.
- Support both legacy ISO-8859-1/ISO 10646 row-0 forms and full Unicode escapes used in IFC STEP (`\S\`, `\X\`, `\X2\`, `\X4\`).

### Description
- Add `encodeIfcString` to `@ifc-lite/encoding` which emits STEP-safe string escapes including doubled apostrophes, compact `\S\` for Latin-1 extensions, `\X2\hhhh\X0\` for BMP, and `\X4\hhhhhhhh\X0\` for astral characters.
- Harden `decodeIfcString` by accepting `\X\XX` with an optional trailing slash, treating `\X\` as 8-bit ISO 10646 row-0 hex, and unescaping doubled apostrophes (`'' -> '`) so encoder/decoder round-trips match STEP literal semantics.
- Export `encodeIfcString` from the package index and add unit tests that cover documented umlaut examples, optional trailing slash variants, encoding behavior, and mixed round-trip scenarios.
- Add a patch changeset for `@ifc-lite/encoding` describing the behaviour improvements.

### Testing
- Ran unit tests for the package with `pnpm --filter @ifc-lite/encoding test` and all tests passed (`26 passed`).
- New/updated tests live in `packages/encoding/src/ifc-string.test.ts` and exercises both `decodeIfcString` and `encodeIfcString` round-trips.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a73fa4f1b483209fdb3959a3543ba5)