### PR TITLE
Make PropertiesPanel tabs responsive with compact icon mode

### DIFF
--- a/apps/viewer/src/components/viewer/PropertiesPanel.tsx
+++ b/apps/viewer/src/components/viewer/PropertiesPanel.tsx
@@ -125,16 +125,21 @@ export function PropertiesPanel() {
 
     const updateTabDensity = () => {
       const tabWidth = tabsElement.clientWidth / 3;
-      setCompactTabs(tabWidth < 88);
+      // Switch to icon-only mode early enough to avoid cramped labels.
+      setCompactTabs(tabWidth < 120);
     };
 
     updateTabDensity();
 
-    const resizeObserver = new ResizeObserver(updateTabDensity);
+    const resizeObserver = new ResizeObserver(() => {
+      requestAnimationFrame(updateTabDensity);
+    });
     resizeObserver.observe(tabsElement);
+    window.addEventListener('resize', updateTabDensity);
 
     return () => {
       resizeObserver.disconnect();
+      window.removeEventListener('resize', updateTabDensity);
     };
   }, []);
 


### PR DESCRIPTION
### Motivation
- Improve tab usability on narrow side panels by switching to compact icons when tab labels would be cramped.
- Provide accessible labels and smoother visual transitions for the tabs to enhance UX.

### Description
- Added a `tabsListRef` and `compactTabs` state to `PropertiesPanel` and used a `ResizeObserver` to toggle compact mode based on available tab width.
- Render icons (`FileText`, `Calculator`, `BookOpen`) instead of text when `compactTabs` is true, and added `aria-label`s and a `transition-all` class on tab triggers.
- Imported the `BookOpen` icon and added the `ref` to the `TabsList` element to measure its size.

### Testing
- Ran the project test suite with `yarn test` and all tests passed.
- Performed a TypeScript type check with `tsc --noEmit` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a741ee1aa88320ba81c484f7229876)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Properties panel tabs are now density-aware and responsive: labels switch to compact icons when space is limited and revert to full text when ample space is available.
  * Tab transitions and improved ARIA labels enhance accessibility and visual clarity during resizing and layout changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->