### PR TITLE
Emit IFCX schemas for all exported attributes in Ifc5Exporter and IfcxWriter

### DIFF
--- a/.changeset/curvy-tigers-attend.md
+++ b/.changeset/curvy-tigers-attend.md
@@ -1,0 +1,6 @@
+---
+"@ifc-lite/export": patch
+"@ifc-lite/ifcx": patch
+---
+
+Fix IFCX export to emit schemas for all written attributes to avoid missing schema errors.

--- a/packages/export/src/ifc5-exporter.ts
+++ b/packages/export/src/ifc5-exporter.ts
@@ -75,8 +75,25 @@ interface IfcxFileOutput {
     timestamp: string;
   };
   imports: string[];
-  schemas: Record<string, unknown>;
+  schemas: Record<string, IfcxSchemaOutput>;
   data: IfcxNodeOutput[];
+}
+
+interface IfcxSchemaOutput {
+  value: IfcxValueDescriptionOutput;
+}
+
+interface IfcxValueDescriptionOutput {
+  dataType: 'Real' | 'Boolean' | 'Integer' | 'String' | 'DateTime' | 'Enum' | 'Array' | 'Object' | 'Reference' | 'Blob';
+  optional?: boolean;
+  arrayRestrictions?: {
+    min?: number;
+    max?: number;
+    value: IfcxValueDescriptionOutput;
+  };
+  objectRestrictions?: {
+    values: Record<string, IfcxValueDescriptionOutput>;
+  };
 }
 
 /** IFCX node in output */
@@ -135,6 +152,7 @@ export class Ifc5Exporter {
 
     // Collect nodes
     const nodes: IfcxNodeOutput[] = [];
+    const schemas: Record<string, IfcxSchemaOutput> = {};
     let propertyCount = 0;
     let meshCount = 0;
 
@@ -222,6 +240,7 @@ export class Ifc5Exporter {
       }
 
       if (Object.keys(attributes).length > 0) {
+        this.registerSchemasForAttributes(schemas, attributes);
         node.attributes = attributes;
       }
 
@@ -238,7 +257,7 @@ export class Ifc5Exporter {
         timestamp: new Date().toISOString(),
       },
       imports: [],
-      schemas: {},
+      schemas,
       data: nodes,
     };
 
@@ -255,6 +274,57 @@ export class Ifc5Exporter {
         fileSize: new TextEncoder().encode(content).length,
       },
     };
+  }
+
+  private registerSchemasForAttributes(
+    schemas: Record<string, IfcxSchemaOutput>,
+    attributes: Record<string, unknown>,
+  ): void {
+    for (const [key, value] of Object.entries(attributes)) {
+      if (!schemas[key]) {
+        schemas[key] = { value: this.inferSchemaForValue(value) };
+      }
+    }
+  }
+
+  private inferSchemaForValue(value: unknown): IfcxValueDescriptionOutput {
+    if (typeof value === 'string') {
+      return { dataType: 'String' };
+    }
+
+    if (typeof value === 'number') {
+      return { dataType: Number.isInteger(value) ? 'Integer' : 'Real' };
+    }
+
+    if (typeof value === 'boolean') {
+      return { dataType: 'Boolean' };
+    }
+
+    if (Array.isArray(value)) {
+      const firstNonNull = value.find((entry) => entry !== null && entry !== undefined);
+      return {
+        dataType: 'Array',
+        arrayRestrictions: {
+          min: value.length,
+          max: value.length,
+          value: this.inferSchemaForValue(firstNonNull),
+        },
+      };
+    }
+
+    if (value && typeof value === 'object') {
+      const values: Record<string, IfcxValueDescriptionOutput> = {};
+      for (const [childKey, childValue] of Object.entries(value)) {
+        values[childKey] = this.inferSchemaForValue(childValue);
+      }
+
+      return {
+        dataType: 'Object',
+        objectRestrictions: { values },
+      };
+    }
+
+    return { dataType: 'String', optional: true };
   }
 
   // --------------------------------------------------------------------------

--- a/packages/ifcx/src/writer.ts
+++ b/packages/ifcx/src/writer.ts
@@ -78,11 +78,12 @@ export class IfcxWriter {
   export(options: IfcxExportOptions = {}): IfcxExportResult {
     const header = this.createHeader(options);
     const nodes = this.collectNodes(options);
+    const schemas = this.buildSchemas(nodes);
 
     const file: IfcxFile = {
       header,
       imports: [],
-      schemas: {},
+      schemas,
       data: nodes,
     };
 
@@ -105,6 +106,61 @@ export class IfcxWriter {
         fileSize: new TextEncoder().encode(content).length,
       },
     };
+  }
+
+  private buildSchemas(nodes: IfcxNode[]): IfcxFile['schemas'] {
+    const schemas: IfcxFile['schemas'] = {};
+
+    for (const node of nodes) {
+      if (!node.attributes) continue;
+      for (const [key, value] of Object.entries(node.attributes)) {
+        if (!schemas[key]) {
+          schemas[key] = { value: this.inferSchemaForValue(value) };
+        }
+      }
+    }
+
+    return schemas;
+  }
+
+  private inferSchemaForValue(value: unknown): IfcxFile['schemas'][string]['value'] {
+    if (typeof value === 'string') {
+      return { dataType: 'String' };
+    }
+
+    if (typeof value === 'number') {
+      return { dataType: Number.isInteger(value) ? 'Integer' : 'Real' };
+    }
+
+    if (typeof value === 'boolean') {
+      return { dataType: 'Boolean' };
+    }
+
+    if (Array.isArray(value)) {
+      const firstNonNull = value.find((entry) => entry !== null && entry !== undefined);
+      return {
+        dataType: 'Array',
+        arrayRestrictions: {
+          min: value.length,
+          max: value.length,
+          value: this.inferSchemaForValue(firstNonNull),
+        },
+      };
+    }
+
+    if (value && typeof value === 'object') {
+      const values: Record<string, IfcxFile['schemas'][string]['value']> = {};
+      for (const [childKey, childValue] of Object.entries(value)) {
+        values[childKey] = this.inferSchemaForValue(childValue);
+      }
+
+      return {
+        dataType: 'Object',
+        objectRestrictions: { values },
+      };
+    }
+
+    return { dataType: 'String', optional: true };
   }
 
   /**


### PR DESCRIPTION
### Motivation
- Avoid runtime consumer errors like `Missing schema "bsi::ifc::class"` by ensuring exported IFCX files declare schemas for every attribute they write.
- The exporters previously populated node `attributes` but left `schemas: {}` empty, producing incomplete IFCX output that breaks strict consumers.

### Description
- Populate the top-level `schemas` map in `Ifc5Exporter` (`packages/export/src/ifc5-exporter.ts`) and `IfcxWriter` (`packages/ifcx/src/writer.ts`) based on all emitted node attributes instead of leaving it empty.
- Add schema shape/type inference for primitives, arrays, and nested objects via `inferSchemaForValue` (and a helper `registerSchemasForAttributes`) so attribute keys (e.g., `bsi::ifc::class`, `usd::usdgeom::mesh`) receive appropriate `dataType` metadata and restrictions.
- Introduce local TypeScript interfaces for IFCX schema/value descriptions and wire the inferred `schemas` into the exported file object.
- Add a changeset file `.changeset/curvy-tigers-attend.md` to patch-bump `@ifc-lite/export` and `@ifc-lite/ifcx`.

### Testing
- Ran a runtime smoke check with `tsx` that constructed a minimal `IfcxWriter` and called `writer.export()` and confirmed `json.schemas` contains `bsi::ifc::class` and the inferred schema (observed as `Object`).
- Attempted package tests with `pnpm --filter @ifc-lite/export test` which executed some suites but failed due to workspace package resolution (`@ifc-lite/parser`) unrelated to the exporter logic in this environment.
- Attempted building packages (`pnpm --filter @ifc-lite/export build`, `pnpm --filter @ifc-lite/ifcx build`) which failed because workspace type/module resolution is not available in this run, and those failures are orthogonal to the schema-emission change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abf1bde27c8320b89e1a3a50aee388)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * IFCX export now correctly emits schemas for all written attributes, preventing missing schema errors during file export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->