### PR TITLE
Fix on-demand IfcRoot attribute extraction for type entities

### DIFF
--- a/.changeset/dark-books-grab.md
+++ b/.changeset/dark-books-grab.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/parser": patch
+---
+
+Fix on-demand IfcRoot attribute extraction so `ObjectType` and `Tag` are only read for compatible IFC inheritance chains.

--- a/packages/parser/src/columnar-parser.ts
+++ b/packages/parser/src/columnar-parser.ts
@@ -14,6 +14,7 @@ import { SpatialHierarchyBuilder } from './spatial-hierarchy-builder.js';
 import { EntityExtractor } from './entity-extractor.js';
 import { extractLengthUnitScale } from './unit-extractor.js';
 import { getAttributeNames } from './ifc-schema.js';
+import { getInheritanceChainForEntity } from './generated/schema-registry.js';
 import {
     StringTable,
     EntityTableBuilder,
@@ -736,15 +737,21 @@ export function extractEntityAttributesOnDemand(
     }
 
     const attrs = entity.attributes || [];
+    const typeName = store.entities?.getTypeName?.(entityId) || ref.type;
+    const inheritance = getInheritanceChainForEntity(typeName);
+    const isIfcObject = inheritance.includes('IfcObject');
+    const isIfcElement = inheritance.includes('IfcElement');
+
     // IfcRoot attributes: [GlobalId, OwnerHistory, Name, Description]
     // IfcObject adds: [ObjectType] at index 4
-    // IfcProduct adds: [ObjectPlacement, Representation] at indices 5-6
     // IfcElement adds: [Tag] at index 7
+    // Guard ObjectType/Tag by inheritance to avoid reading unrelated attributes
+    // for entities like IfcTypeObject that don't define those fields.
     const globalId = typeof attrs[0] === 'string' ? attrs[0] : '';
     const name = typeof attrs[2] === 'string' ? attrs[2] : '';
     const description = typeof attrs[3] === 'string' ? attrs[3] : '';
-    const objectType = typeof attrs[4] === 'string' ? attrs[4] : '';
-    const tag = typeof attrs[7] === 'string' ? attrs[7] : '';
+    const objectType = isIfcObject && typeof attrs[4] === 'string' ? attrs[4] : '';
+    const tag = isIfcElement && typeof attrs[7] === 'string' ? attrs[7] : '';
 
     return { globalId, name, description, objectType, tag };
 }

--- a/packages/parser/test/attribute-extractor.test.ts
+++ b/packages/parser/test/attribute-extractor.test.ts
@@ -43,6 +43,40 @@ describe('Entity Attribute Extraction', () => {
     expect(attrs.objectType).toBe('Wall Type');
   });
 
+
+  it('should not treat non-IfcObject attributes as ObjectType', () => {
+    // IfcTypeObject does not define ObjectType; its first extra attr is ApplicableOccurrence
+    const ifcEntity = `#777=IFCWALLTYPE('typeGuid',#1,'Wall Type Name','Type Description','IfcWall/USERDEFINED',$,$,$,.NOTDEFINED.);`;
+    const source = new TextEncoder().encode(ifcEntity);
+
+    const entityRef: EntityRef = {
+      expressId: 777,
+      type: 'IfcWallType',
+      byteOffset: 0,
+      byteLength: source.length,
+      lineNumber: 1,
+    };
+
+    const store = {
+      source,
+      entityIndex: {
+        byId: new Map([[777, entityRef]]),
+        byType: new Map([['IFCWALLTYPE', [777]]]),
+      },
+      entities: {
+        getTypeName: () => 'IfcWallType',
+      },
+    } as unknown as IfcDataStore;
+
+    const attrs = extractEntityAttributesOnDemand(store, 777);
+
+    expect(attrs.globalId).toBe('typeGuid');
+    expect(attrs.name).toBe('Wall Type Name');
+    expect(attrs.description).toBe('Type Description');
+    expect(attrs.objectType).toBe('');
+    expect(attrs.tag).toBe('');
+  });
+
   it('should return empty strings for missing attributes', () => {
     // IFC entity with $  for missing values
     const ifcEntity = `#456=IFCBEAM('abc123',$,$,$,$,$,$,.NOTDEFINED.);`;


### PR DESCRIPTION
### Motivation
- On-demand attribute extraction assumed fixed positional IfcRoot/IfcObject/IfcElement indices and could read unrelated fields (e.g., ApplicableOccurrence on type entities) as `ObjectType`/`Tag` for IfcTypeObject-derived entities.
- This caused incorrect attribute values for type entities and other non-IfcObject/IfcElement descendants when probing STEP buffers on demand.

### Description
- Use schema inheritance to decide which IfcRoot-derived columns are valid: import `getInheritanceChainForEntity` and check for `IfcObject` / `IfcElement` before exposing `ObjectType` and `Tag` in `extractEntityAttributesOnDemand` (file: `packages/parser/src/columnar-parser.ts`).
- Preserve reading of `GlobalId`, `Name`, and `Description` from the IfcRoot positions; only guard optional fields (`ObjectType`, `Tag`) by inheritance membership.
- Add a regression test ensuring `IfcWallType` (a type entity) no longer surfaces its non-`IfcObject` attribute as `objectType` (file: `packages/parser/test/attribute-extractor.test.ts`).
- Add a patch changeset for `@ifc-lite/parser` describing the fix (`.changeset/dark-books-grab.md`).

### Testing
- Built data package: `pnpm --filter @ifc-lite/data build` (succeeded).
- Ran targeted parser tests: `pnpm --filter @ifc-lite/parser test test/attribute-extractor.test.ts` (passed).
- Ran related parser suites: `pnpm --filter @ifc-lite/parser test test/on-demand-type-properties.test.ts` (passed) and `pnpm --filter @ifc-lite/parser test` (all parser tests passed: 7 files, 60 tests).
- All automated tests executed for the modified areas passed after the fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abf213e5e08320915f2d6e8facb842)