### PR TITLE
Update README and documentation to improve Git LFS handling and benchmark instructions

### DIFF
--- a/.github/workflows/test-templates.yml
+++ b/.github/workflows/test-templates.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          lfs: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2

--- a/README.md
+++ b/README.md
@@ -145,9 +145,15 @@ Ready-to-run projects in the [`examples/`](examples/) folder:
 We welcome contributions! No Rust toolchain needed, WASM comes pre-built.
 
 ```bash
-git clone https://github.com/louistrue/ifc-lite.git
+GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/louistrue/ifc-lite.git
 cd ifc-lite
 pnpm install && pnpm build && pnpm dev   # opens viewer at localhost:5173
+```
+
+If you need large IFC fixtures for benchmarks or stress tests, fetch only the files you need:
+
+```bash
+git lfs pull --include="tests/models/ara3d/AC20-FZK-Haus.ifc"
 ```
 
 See the [Contributing Guide](docs/contributing/setup.md) and [Release Process](RELEASE.md) for details.

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -79,8 +79,14 @@ Guide to setting up a development environment for IFClite.
 ### 1. Clone Repository
 
 ```bash
-git clone https://github.com/louistrue/ifc-lite.git
+GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/louistrue/ifc-lite.git
 cd ifc-lite
+```
+
+This skips automatic Git LFS downloads during clone. For heavy benchmark or stress-test fixtures, fetch only the exact files you need later:
+
+```bash
+git lfs pull --include="tests/models/ara3d/AC20-FZK-Haus.ifc"
 ```
 
 ### 2. Install Dependencies

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -479,10 +479,32 @@ jobs:
 Use a tiered fixture approach so release pipelines stay reliable when Git LFS quota is constrained:
 
 1. Keep release and docs workflows on `actions/checkout` with `lfs: false`.
-2. Keep small smoke-test fixtures in Git (non-LFS) and run them on every PR and release.
+2. Keep smoke-test fixtures small and cheap to access so normal PR and release validation never needs a broad LFS pull.
 3. Run heavy IFC corpus tests (large geometry/benchmark sets) in dedicated manual or scheduled workflows.
 4. For heavy workflows, fetch only required fixtures with `git lfs pull --include="<paths>"` instead of downloading all LFS objects.
 5. Add caching and checksums for downloaded fixture bundles when using external artifact storage.
+
+### Fixture Tiers
+
+- **Smoke fixtures**: Small files required for normal development, package tests, and release verification. These should stay cheap to access and should not require broad LFS pulls.
+- **Benchmark fixtures**: Medium-sized files used for targeted performance checks. Fetch them on demand with `git lfs pull --include="<paths>"`.
+- **Stress fixtures**: Giant files such as full-building streaming tests. Treat these as rare opt-in assets and never assume they are present in a fresh clone.
+
+### Recommended Clone Flow
+
+```bash
+GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/louistrue/ifc-lite.git
+cd ifc-lite
+pnpm install
+```
+
+Then fetch only the fixtures needed for the task at hand:
+
+```bash
+git lfs pull --include="tests/models/ara3d/AC20-FZK-Haus.ifc"
+```
+
+For future giant IFC corpora, prefer external artifact storage plus checksums over adding more always-available Git LFS fixtures to the repo.
 
 ## Next Steps
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -227,7 +227,7 @@ Build and run the native desktop application:
 
 ```bash
 # Clone the repository
-git clone https://github.com/louistrue/ifc-lite.git
+GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/louistrue/ifc-lite.git
 cd ifc-lite
 
 # Install dependencies
@@ -244,6 +244,12 @@ pnpm build
 pnpm build:windows   # Windows (.exe, .msi)
 pnpm build:macos     # macOS (.app, .dmg)
 pnpm build:linux     # Linux (.deb, .AppImage)
+```
+
+If you need large IFC benchmark fixtures, fetch only the specific files you plan to use:
+
+```bash
+git lfs pull --include="tests/models/ara3d/AC20-FZK-Haus.ifc"
 ```
 
 !!! note "Prerequisites for Desktop Build"
@@ -271,7 +277,7 @@ pnpm build:linux     # Linux (.deb, .AppImage)
 
 ```bash
 # Clone the repository
-git clone https://github.com/louistrue/ifc-lite.git
+GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/louistrue/ifc-lite.git
 cd ifc-lite
 
 # Install dependencies

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -16,7 +16,7 @@ Geometry processing is up to 5x faster overall (median 2.18x across test files, 
 
 ### Viewer Benchmark Baseline (2026-02-21)
 
-Measured locally with `pnpm test:benchmark:viewer` on an M1 MacBook Pro:
+Measured locally with the viewer benchmark suite on an M1 MacBook Pro. The two largest fixtures are optional stress tests and should be fetched on demand:
 
 | Model | Size | First Geometry | Total Time | Meshes |
 |-------|------|----------------|------------|--------|
@@ -79,8 +79,12 @@ For large files or team scenarios, the server processes everything in parallel a
 You can run the benchmarks on your own hardware:
 
 ```bash
-pnpm --filter viewer build && pnpm test:benchmark:viewer
+pnpm --filter viewer build
+git lfs pull --include="tests/models/ara3d/AC20-FZK-Haus.ifc"
+VIEWER_BENCHMARK_FILES="tests/models/ara3d/AC20-FZK-Haus.ifc" pnpm test:benchmark:viewer
 ```
+
+For large stress fixtures such as `BWK-BIM` and `Holter Tower`, fetch those files explicitly with `git lfs pull --include=...` before running the benchmark suite.
 
 Results are saved to `tests/benchmark/benchmark-results/` with automatic regression detection. See the [benchmark README](https://github.com/louistrue/ifc-lite/tree/main/tests/benchmark) for details on test models, metrics, and CI integration.
 

--- a/packages/server-bin/README.md
+++ b/packages/server-bin/README.md
@@ -108,10 +108,12 @@ cd my-app
 docker compose up -d
 
 # Or build from source
-git clone https://github.com/louistrue/ifc-lite
+GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/louistrue/ifc-lite
 cd ifc-lite/apps/server
 cargo build --release
 ```
+
+If you later need large IFC benchmark fixtures from the monorepo, fetch only the specific files you plan to use instead of downloading all LFS objects.
 
 ## API Reference
 

--- a/packages/wasm/README.md
+++ b/packages/wasm/README.md
@@ -114,7 +114,7 @@ println!("Parsed {} entities", result.entities.len());
 For contributing or running the full demo app:
 
 ```bash
-git clone https://github.com/louistrue/ifc-lite.git
+GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/louistrue/ifc-lite.git
 cd ifc-lite
 pnpm install && pnpm dev
 ```
@@ -122,6 +122,8 @@ pnpm install && pnpm dev
 Open http://localhost:5173 and load an IFC file.
 
 > **Note:** Requires Node.js 18+ and pnpm 8+. No Rust toolchain needed - WASM is pre-built.
+>
+> **Git LFS:** Large benchmark fixtures are intentionally not downloaded during clone. Pull only the files you need, for example `git lfs pull --include="tests/models/ara3d/AC20-FZK-Haus.ifc"`.
 > 
 > **📖 Full Guide**: See [Installation](docs/guide/installation.md) for detailed setup options including troubleshooting.
 
@@ -262,7 +264,7 @@ ifc-lite/
 For contributing to IFClite itself:
 
 ```bash
-git clone https://github.com/louistrue/ifc-lite.git
+GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/louistrue/ifc-lite.git
 cd ifc-lite
 pnpm install
 
@@ -322,7 +324,7 @@ We welcome contributions!
 
 ```bash
 # Fork and clone
-git clone https://github.com/YOUR_USERNAME/ifc-lite.git
+GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/YOUR_USERNAME/ifc-lite.git
 
 # Create a branch
 git checkout -b feature/my-feature

--- a/packages/wasm/pkg/README.md
+++ b/packages/wasm/pkg/README.md
@@ -145,9 +145,15 @@ Ready-to-run projects in the [`examples/`](examples/) folder:
 We welcome contributions! No Rust toolchain needed, WASM comes pre-built.
 
 ```bash
-git clone https://github.com/louistrue/ifc-lite.git
+GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/louistrue/ifc-lite.git
 cd ifc-lite
 pnpm install && pnpm build && pnpm dev   # opens viewer at localhost:5173
+```
+
+If you need benchmark fixtures, fetch only the files you plan to use:
+
+```bash
+git lfs pull --include="tests/models/ara3d/AC20-FZK-Haus.ifc"
 ```
 
 See the [Contributing Guide](docs/contributing/setup.md) and [Release Process](RELEASE.md) for details.

--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -4,20 +4,34 @@ This directory contains performance benchmarks for IFC-Lite geometry processing 
 
 ## Quick Start
 
-### Run All Benchmarks
+### Run Default Benchmark
 
 ```bash
 # Build viewer first
 pnpm --filter viewer build
 
-# Run benchmarks (headed browser for accurate GPU timing)
-pnpm test:benchmark:viewer
+# Fetch one small fixture on demand
+git lfs pull --include="tests/models/ara3d/AC20-FZK-Haus.ifc"
+
+# Run a single small benchmark (headed browser for accurate GPU timing)
+VIEWER_BENCHMARK_FILES="tests/models/ara3d/AC20-FZK-Haus.ifc" pnpm test:benchmark:viewer
 ```
 
-### Run Specific Model
+### Run Additional Models
 
 ```bash
 VIEWER_BENCHMARK_FILES="tests/models/ara3d/AC20-FZK-Haus.ifc" pnpm test:benchmark:viewer
+```
+
+You can provide a comma-separated list, but only after pulling the exact fixtures you want to test.
+
+### Optional Stress Tests
+
+The largest fixtures are intentionally opt-in because they consume substantial Git LFS bandwidth:
+
+```bash
+git lfs pull --include="tests/models/various/O-S1-BWK-BIM architectural - BIM bouwkundig.ifc,tests/models/ara3d/ISSUE_053_20181220Holter_Tower_10.ifc"
+VIEWER_BENCHMARK_FILES="tests/models/various/O-S1-BWK-BIM architectural - BIM bouwkundig.ifc,tests/models/ara3d/ISSUE_053_20181220Holter_Tower_10.ifc" pnpm test:benchmark:viewer
 ```
 
 ### Check for Regressions
@@ -35,14 +49,17 @@ The benchmark suite includes 4 models covering different scenarios:
 |-------|------|---------|-------------|
 | **FZK-Haus** | 2.4MB | Cutout/boolean testing | Window/door openings must be visible |
 | **Snowdon Towers** | 8.3MB | Structural elements | Fast loading baseline |
-| **BWK-BIM** | 326.8MB | Large architectural | Stress test for streaming |
-| **Holter Tower** | 169.2MB | Complex geometry | Crash prevention (MAX_OPENINGS safeguard) |
+| **BWK-BIM** | 326.8MB | Large architectural | Optional stress test for streaming |
+| **Holter Tower** | 169.2MB | Complex geometry | Optional stress test for crash prevention (MAX_OPENINGS safeguard) |
+
+For day-to-day work, prefer `FZK-Haus` or `Snowdon Towers`. Reserve `BWK-BIM` and `Holter Tower` for intentional stress testing.
 
 ## Establishing Baseline
 
 1. **Run benchmarks on clean branch** (e.g., main):
    ```bash
-   pnpm benchmark:baseline
+   git lfs pull --include="tests/models/ara3d/AC20-FZK-Haus.ifc,tests/models/various/01_Snowdon_Towers_Sample_Structural(1).ifc"
+   VIEWER_BENCHMARK_FILES="tests/models/ara3d/AC20-FZK-Haus.ifc,tests/models/various/01_Snowdon_Towers_Sample_Structural(1).ifc" pnpm test:benchmark:viewer
    ```
 
 2. **Copy results to baseline.json**:
@@ -89,7 +106,8 @@ Baseline updated from local run on 2026-02-21:
 Viewer benchmark CI mode is available via:
 
 ```bash
-pnpm test:benchmark:viewer:ci
+git lfs pull --include="tests/models/ara3d/AC20-FZK-Haus.ifc"
+VIEWER_BENCHMARK_FILES="tests/models/ara3d/AC20-FZK-Haus.ifc" pnpm test:benchmark:viewer:ci
 ```
 
 This runs headless with software rendering (`--use-angle=swiftshader`) and is useful for reproducible CI-style timing checks.
@@ -97,7 +115,7 @@ This runs headless with software rendering (`--use-angle=swiftshader`) and is us
 ## Troubleshooting
 
 **Benchmarks fail with "No baseline available"**:
-- Run `pnpm benchmark:baseline` first to establish baseline
+- Fetch the fixtures you want to baseline, then run `VIEWER_BENCHMARK_FILES="..." pnpm test:benchmark:viewer` and copy the results into `baseline.json`
 
 **Performance regressions detected**:
 - Check if optimizations broke geometry (mesh count validation)


### PR DESCRIPTION
- Added instructions to use `GIT_LFS_SKIP_SMUDGE=1` during repository cloning to avoid automatic LFS downloads.
- Included guidance on fetching specific large IFC benchmark fixtures on demand using `git lfs pull --include`.
- Updated various documentation files to clarify the use of small, medium, and large fixture tiers for testing and development.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated clone instructions to optimize Git LFS usage and reduce initial download size
  * Added guidance for selectively fetching large benchmark fixtures on demand
  * Enhanced setup, testing, and performance documentation with new fixture tier system and workflows
  * Clarified benchmark execution and fixture access strategies

* **Chores**
  * Updated GitHub Actions workflow configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->