### PR TITLE
chore: fix independent package versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
         id: get-version
         if: steps.changesets.outputs.published == 'true'
         run: |
-          # Read version from root package.json (sync-versions.js keeps this in sync)
+          # Read the root release version (sync-versions.js keeps it aligned to the highest released workspace package version)
           VERSION=$(node -p "require('./package.json').version")
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -91,7 +91,7 @@ pnpm release
 Packages are versioned independently:
 
 - **Independent versioning**: `@ifc-lite/*` packages only bump when they have their own changeset or when Changesets propagates an internal dependency update
-- **Automatic sync**: `scripts/sync-versions.js` syncs `Cargo.toml` workspace version after npm version bumps
+- **Automatic sync**: `scripts/sync-versions.js` syncs the root package version and `Cargo.toml` workspace version to the highest released workspace package version
 - **Dependency propagation**: `updateInternalDependencies: "patch"` keeps dependents aligned when an internal package version changes
 
 ## Secrets Required

--- a/docs/contributing/release.md
+++ b/docs/contributing/release.md
@@ -26,7 +26,7 @@ On each release, the following are published automatically:
 
 ### Version Synchronization
 
-Packages version independently. Changesets still propagates internal dependency bumps, and `scripts/sync-versions.js` keeps npm and Cargo.toml versions aligned.
+Packages version independently. Changesets still propagates internal dependency bumps, and `scripts/sync-versions.js` keeps the root package version and Cargo.toml workspace version aligned with the highest released workspace package version.
 
 ### Workflow
 

--- a/scripts/sync-versions.js
+++ b/scripts/sync-versions.js
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 
 /**
- * Syncs all workspace package versions to the highest version found.
- * Run this after `changeset version` to keep all versions in sync.
+ * Syncs the root release version to the highest workspace version found.
+ * Run this after `changeset version` so the root package.json and Cargo
+ * workspace version track the highest released workspace package.
  *
- * Finds the maximum semver across all non-private workspace packages,
- * then bumps everything (packages, root package.json, Cargo.toml) to that version.
- * Never downgrades — only bumps packages that are behind.
+ * This does not rewrite individual workspace package versions. Changesets
+ * owns those versions directly so packages can version independently.
  */
 
 import { readFileSync, writeFileSync, readdirSync, statSync } from 'fs';
@@ -51,7 +51,7 @@ function getWorkspacePackages() {
 function syncVersions() {
   const packagePaths = getWorkspacePackages();
 
-  // Find the highest version across all non-private workspace packages
+  // Find the highest version across all non-private workspace packages.
   let maxVersion = '0.0.0';
   for (const pkgPath of packagePaths) {
     const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
@@ -69,7 +69,7 @@ function syncVersions() {
   }
 
   const version = maxVersion;
-  console.log(`📦 Syncing all packages to version: ${version}`);
+  console.log(`📦 Syncing root release version to: ${version}`);
 
   // Update workspace Cargo.toml
   const cargoTomlPath = join(rootDir, 'Cargo.toml');
@@ -88,18 +88,6 @@ function syncVersions() {
     rootPackageJson.version = version;
     writeFileSync(rootPackageJsonPath, JSON.stringify(rootPackageJson, null, 2) + '\n');
     console.log(`✅ Updated root package.json version to ${version}`);
-  }
-
-  // Bump any lagging workspace packages (never downgrades)
-  for (const pkgPath of packagePaths) {
-    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
-    if (pkg.private) continue;
-    if (compareSemver(pkg.version, version) >= 0) continue; // already at or above target
-
-    const oldVersion = pkg.version;
-    pkg.version = version;
-    writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
-    console.log(`✅ Updated ${pkg.name} from ${oldVersion} to ${version}`);
   }
 }
 


### PR DESCRIPTION
## Summary
- remove the repo-wide Changesets fixed group
- stop sync-versions.js from rewriting every publishable workspace package to the highest version
- keep the root package version and Cargo workspace version aligned for release tagging

## Why
The current release workflow still promotes nearly every published package to the highest version even after removing the Changesets fixed group. This makes the release PR overstate major bumps. After this change, Changesets controls per-package versions and only true dependents are propagated.

## Verification
- ran the release version flow in a disposable worktree
- confirmed only @ifc-lite/ifcx and @ifc-lite/parser moved to 2.0.0, with a small patch ripple to dependents instead of a repo-wide major bump
