### PR TITLE
Expand spatial structure elements in visibility adapter

### DIFF
--- a/apps/viewer/src/sdk/adapters/visibility-adapter.ts
+++ b/apps/viewer/src/sdk/adapters/visibility-adapter.ts
@@ -6,6 +6,7 @@ import type { EntityRef, VisibilityBackendMethods } from '@ifc-lite/sdk';
 import type { StoreApi } from './types.js';
 import { getModelForRef, type ModelLike } from './model-compat.js';
 import { collectIfcBuildingStoreyElementsWithIfcSpace } from '../../store/basketVisibleSet.js';
+import { IfcTypeEnum, type SpatialNode } from '@ifc-lite/data';
 
 const SPATIAL_TYPES = new Set([
   'IfcBuildingStorey',
@@ -13,6 +14,33 @@ const SPATIAL_TYPES = new Set([
   'IfcSite',
   'IfcProject',
 ]);
+
+function findDescendantNode(root: SpatialNode, expressId: number): SpatialNode | null {
+  const stack: SpatialNode[] = [root];
+  while (stack.length > 0) {
+    const node = stack.pop()!;
+    if (node.expressId === expressId) return node;
+    for (const child of node.children) {
+      stack.push(child);
+    }
+  }
+  return null;
+}
+
+function collectDescendantStoreyIds(node: SpatialNode): number[] {
+  const storeyIds: number[] = [];
+  const stack: SpatialNode[] = [node];
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    if (current.type === IfcTypeEnum.IfcBuildingStorey) {
+      storeyIds.push(current.expressId);
+    }
+    for (const child of current.children) {
+      stack.push(child);
+    }
+  }
+  return storeyIds;
+}
 
 /**
  * If `ref` points to a spatial structure element (storey, building, etc.),
@@ -33,10 +61,15 @@ function expandSpatialRef(ref: EntityRef, model: ModelLike): number[] {
   }
 
   // For higher-level containers (IfcBuilding, IfcSite, IfcProject),
-  // collect elements from all descendant storeys
+  // walk the spatial tree from ref.expressId to find descendant storeys only
+  const startNode = findDescendantNode(hierarchy.project, ref.expressId);
+  if (!startNode) return [ref.expressId];
+
+  const descendantStoreyIds = collectDescendantStoreyIds(startNode);
+
   const allIds: number[] = [];
   const seen = new Set<number>();
-  for (const [storeyId] of hierarchy.byStorey) {
+  for (const storeyId of descendantStoreyIds) {
     const storeyIds = collectIfcBuildingStoreyElementsWithIfcSpace(hierarchy, storeyId);
     if (storeyIds) {
       for (const id of storeyIds) {


### PR DESCRIPTION
## Summary
Enhanced the visibility adapter to automatically expand spatial structure elements (buildings, storeys, sites, projects) to their contained elements when setting visibility. This ensures that toggling visibility on a storey or building affects all contained elements rather than just the container itself.

## Key Changes
- Added `expandSpatialRef()` function that detects spatial structure elements and expands them to their constituent element IDs
- Imported `collectIfcBuildingStoreyElementsWithIfcSpace` utility to retrieve elements within spatial containers
- Updated visibility setting logic to expand spatial references before applying visibility changes
- Defined `SPATIAL_TYPES` set to identify spatial structure element types (IfcBuildingStorey, IfcBuilding, IfcSite, IfcProject)

## Implementation Details
- For `IfcBuildingStorey` elements, directly collects all contained elements using the spatial hierarchy
- For higher-level containers (IfcBuilding, IfcSite, IfcProject), recursively collects elements from all descendant storeys
- Uses a `Set` to deduplicate element IDs when collecting from multiple storeys
- Falls back to the original expressId if expansion yields no results or if the element is not a spatial type
- Properly applies the model's `idOffset` to all expanded IDs before returning

https://claude.ai/code/session_01A15EMyF46Qiw2UreiHDQkS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved visibility isolation for spatial hierarchies: isolating storeys, buildings, sites, or projects now automatically expands selections to include all descendant storeys and contained elements, yielding more complete and predictable isolation results.
  * Isolation behavior updated to apply expanded element sets correctly; hide/show behavior is unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->