### PR TITLE
Add IFC4X3 infrastructure element support for RTC detection

### DIFF
--- a/rust/geometry/src/router/processing.rs
+++ b/rust/geometry/src/router/processing.rs
@@ -79,11 +79,19 @@ impl GeometryRouter {
         const MAX_SAMPLES: usize = 50;
 
         const BUILDING_ELEMENT_TYPES: &[&str] = &[
+            // Building elements
             "IFCWALL", "IFCWALLSTANDARDCASE", "IFCSLAB", "IFCBEAM", "IFCCOLUMN",
             "IFCPLATE", "IFCROOF", "IFCCOVERING", "IFCFOOTING", "IFCRAILING",
             "IFCSTAIR", "IFCSTAIRFLIGHT", "IFCRAMP", "IFCRAMPFLIGHT",
             "IFCDOOR", "IFCWINDOW", "IFCFURNISHINGELEMENT", "IFCBUILDINGELEMENTPROXY",
             "IFCMEMBER", "IFCCURTAINWALL", "IFCPILE", "IFCSHADINGDEVICE",
+            // IFC4X3 infrastructure elements (large real-world coordinates common)
+            "IFCPAVEMENT", "IFCCOURSE", "IFCKERB", "IFCBEARING",
+            "IFCEARTHWORKSELEMENT", "IFCEARTHWORKSCUT", "IFCEARTHWORKSFILL",
+            "IFCRAIL", "IFCSLEEPER", "IFCTRACKELEMENT",
+            "IFCNAVIGATIONELEMENT", "IFCSIGN", "IFCSIGNAL",
+            "IFCDEEPFOUNDATION",
+            "IFCBUILTELEMENT", "IFCCIVILELEMENT", "IFCGEOGRAPHICELEMENT",
         ];
 
         while let Some((_id, type_name, start, end)) = scanner.next_entity() {

--- a/rust/wasm-bindings/src/api/gpu_meshes.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes.rs
@@ -1003,8 +1003,14 @@ impl IfcAPI {
                 let mut router = GeometryRouter::with_scale(unit_scale);
 
                 // DETECT RTC OFFSET from pre-collected building element jobs (no re-scan)
+                // Use both simple AND complex jobs: infrastructure models (IFC4X3) may
+                // only have complex-classified elements (e.g., IfcPavement, IfcCourse).
+                let all_jobs: Vec<_> = pre_pass.simple_jobs.iter()
+                    .chain(pre_pass.complex_jobs.iter())
+                    .copied()
+                    .collect();
                 let rtc_offset =
-                    router.detect_rtc_offset_from_jobs(&pre_pass.simple_jobs, &mut decoder);
+                    router.detect_rtc_offset_from_jobs(&all_jobs, &mut decoder);
                 let needs_shift = rtc_offset.0.abs() > 10000.0
                     || rtc_offset.1.abs() > 10000.0
                     || rtc_offset.2.abs() > 10000.0;

--- a/rust/wasm-bindings/src/api/styling.rs
+++ b/rust/wasm-bindings/src/api/styling.rs
@@ -483,6 +483,7 @@ pub(crate) fn combined_pre_pass(
 fn is_simple_geometry_type(type_name: &str) -> bool {
     matches!(
         type_name,
+        // Building elements
         "IFCWALL"
             | "IFCWALLSTANDARDCASE"
             | "IFCSLAB"
@@ -497,6 +498,13 @@ fn is_simple_geometry_type(type_name: &str) -> bool {
             | "IFCSTAIRFLIGHT"
             | "IFCRAMP"
             | "IFCRAMPFLIGHT"
+            // IFC4X3 infrastructure elements — typically the bulk of infra models
+            | "IFCPAVEMENT"
+            | "IFCCOURSE"
+            | "IFCKERB"
+            | "IFCEARTHWORKSELEMENT"
+            | "IFCEARTHWORKSCUT"
+            | "IFCEARTHWORKSFILL"
     )
 }
 


### PR DESCRIPTION
## Summary
This PR extends geometry processing to support IFC4X3 infrastructure elements (roads, railways, earthworks, etc.) by adding them to element type lists and improving RTC (Real-Time Coordinates) offset detection to work with both simple and complex geometry classifications.

## Key Changes

- **Extended building element types** in `router/processing.rs`:
  - Added IFC4X3 infrastructure elements: pavement, course, kerb, bearing, earthworks, rail, sleeper, track, navigation, sign, signal, deep foundation, and geographic elements
  - Added comments clarifying that these elements commonly have large real-world coordinates

- **Improved RTC offset detection** in `wasm-bindings/src/api/gpu_meshes.rs`:
  - Modified `detect_rtc_offset_from_jobs()` to use both simple and complex geometry jobs instead of only simple jobs
  - This ensures infrastructure models (which may only have complex-classified elements) are properly analyzed for coordinate offset detection

- **Extended simple geometry type classification** in `wasm-bindings/src/api/styling.rs`:
  - Added IFC4X3 infrastructure elements (pavement, course, kerb, earthworks variants) to the `is_simple_geometry_type()` function
  - These are typically the bulk of infrastructure models and benefit from simple geometry classification

## Implementation Details
The changes recognize that IFC4X3 infrastructure models may exclusively use complex-classified element types, so the RTC detection now considers both job classifications to ensure proper coordinate offset calculation for large-scale infrastructure projects.

https://claude.ai/code/session_01A8XumfiVrcyWdUo8Qwdw7C