### PR TITLE
Fix ray casting, resource cleanup, and data structure mutations

### DIFF
--- a/packages/parser/src/columnar-parser.ts
+++ b/packages/parser/src/columnar-parser.ts
@@ -232,7 +232,6 @@ export class ColumnarParser {
 
         // Build compact entity index (typed arrays instead of Map for ~3x memory reduction)
         const compactByIdIndex = buildCompactEntityIndex(entityRefs);
-        // entityRefs is now sorted by expressId (side effect of buildCompactEntityIndex)
 
         // Also build byType index (Map<string, number[]>)
         const byType = new Map<string, number[]>();

--- a/packages/parser/src/compact-entity-index.ts
+++ b/packages/parser/src/compact-entity-index.ts
@@ -89,7 +89,12 @@ export class CompactEntityIndex {
   get(expressId: number): EntityRef | undefined {
     // Check LRU cache first
     const cached = this.lruCache.get(expressId);
-    if (cached !== undefined) return cached;
+    if (cached !== undefined) {
+      // Refresh recency: delete + re-insert moves to end of insertion order
+      this.lruCache.delete(expressId);
+      this.lruCache.set(expressId, cached);
+      return cached;
+    }
 
     const idx = this.binarySearch(expressId);
     if (idx < 0) return undefined;
@@ -239,10 +244,12 @@ export function buildCompactEntityIndex(
   entityRefs: EntityRef[],
   lruMaxSize?: number
 ): CompactEntityIndex {
-  const count = entityRefs.length;
+  // Copy to avoid mutating the caller's array
+  const sorted = entityRefs.slice();
+  const count = sorted.length;
 
   // Sort by expressId for binary search
-  entityRefs.sort((a, b) => a.expressId - b.expressId);
+  sorted.sort((a, b) => a.expressId - b.expressId);
 
   // Deduplicate type strings
   const typeStringMap = new Map<string, number>();
@@ -255,7 +262,7 @@ export function buildCompactEntityIndex(
   const typeIndices = new Uint16Array(count);
 
   for (let i = 0; i < count; i++) {
-    const ref = entityRefs[i];
+    const ref = sorted[i];
     expressIds[i] = ref.expressId;
     byteOffsets[i] = ref.byteOffset;
     byteLengths[i] = ref.byteLength;

--- a/packages/parser/src/opfs-source-buffer.ts
+++ b/packages/parser/src/opfs-source-buffer.ts
@@ -75,13 +75,16 @@ export class OpfsSourceBuffer {
       return new OpfsSourceBuffer(buffer, buffer.byteLength, false);
     }
 
+    let fileName: string | null = null;
+    let syncHandle: OpfsSyncAccessHandle | null = null;
+
     try {
-      const fileName = `ifc-source-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      fileName = `ifc-source-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
       const root = await navigator.storage.getDirectory();
       const fileHandle = await root.getFileHandle(fileName, { create: true }) as unknown as OpfsFileHandle;
 
       // Write buffer to OPFS using sync access handle (fastest path)
-      const syncHandle = await fileHandle.createSyncAccessHandle();
+      syncHandle = await fileHandle.createSyncAccessHandle();
       syncHandle.write(buffer, { at: 0 });
       syncHandle.flush();
 
@@ -92,7 +95,16 @@ export class OpfsSourceBuffer {
 
       return instance;
     } catch {
-      // OPFS failed — fall back to in-memory
+      // OPFS failed — clean up partial resources and fall back to in-memory
+      if (syncHandle) {
+        try { syncHandle.close(); } catch { /* ignore */ }
+      }
+      if (fileName) {
+        try {
+          const root = await navigator.storage.getDirectory();
+          await root.removeEntry(fileName);
+        } catch { /* ignore */ }
+      }
       return new OpfsSourceBuffer(buffer, buffer.byteLength, false);
     }
   }
@@ -103,8 +115,7 @@ export class OpfsSourceBuffer {
   static isOpfsAvailable(): boolean {
     return (
       typeof globalThis !== 'undefined' &&
-      'storage' in globalThis.navigator &&
-      typeof globalThis.navigator.storage.getDirectory === 'function'
+      typeof globalThis.navigator?.storage?.getDirectory === 'function'
     );
   }
 
@@ -113,6 +124,12 @@ export class OpfsSourceBuffer {
    * Works for both in-memory and OPFS-backed buffers.
    */
   readRange(byteOffset: number, byteLength: number): Uint8Array {
+    if (byteOffset < 0 || byteLength < 0 || byteOffset + byteLength > this.byteLength) {
+      throw new RangeError(
+        `OpfsSourceBuffer.readRange: offset=${byteOffset} length=${byteLength} exceeds buffer size=${this.byteLength}`
+      );
+    }
+
     if (this.memoryBuffer) {
       // In-memory: zero-copy subarray view
       return this.memoryBuffer.subarray(byteOffset, byteOffset + byteLength);
@@ -121,7 +138,12 @@ export class OpfsSourceBuffer {
     if (this.fileHandle) {
       // OPFS sync access: read into a new buffer
       const dest = new Uint8Array(byteLength);
-      this.fileHandle.read(dest, { at: byteOffset });
+      const bytesRead = this.fileHandle.read(dest, { at: byteOffset });
+      if (bytesRead < byteLength) {
+        throw new Error(
+          `OpfsSourceBuffer.readRange: short read (${bytesRead}/${byteLength} bytes at offset ${byteOffset})`
+        );
+      }
       return dest;
     }
 

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -1149,6 +1149,7 @@ export class Scene {
     this.pendingBatchKeys.clear();
     this.partialBatchCache.clear();
     this.partialBatchCacheKeys.clear();
+    this.geometryReleased = false;
   }
 
   /**
@@ -1295,6 +1296,40 @@ export class Scene {
   }
 
   /**
+   * Ray-box intersection returning entry distance (tNear).
+   * Returns null if no intersection, otherwise the distance along the ray
+   * to the entry point (clamped to 0 if the ray originates inside the box).
+   */
+  private rayBoxDistance(
+    rayOrigin: Vec3,
+    rayDirInv: Vec3,
+    rayDirSign: [number, number, number],
+    box: BoundingBox
+  ): number | null {
+    const bounds = [box.min, box.max];
+
+    let tmin = (bounds[rayDirSign[0]].x - rayOrigin.x) * rayDirInv.x;
+    let tmax = (bounds[1 - rayDirSign[0]].x - rayOrigin.x) * rayDirInv.x;
+    const tymin = (bounds[rayDirSign[1]].y - rayOrigin.y) * rayDirInv.y;
+    const tymax = (bounds[1 - rayDirSign[1]].y - rayOrigin.y) * rayDirInv.y;
+
+    if (tmin > tymax || tymin > tmax) return null;
+    if (tymin > tmin) tmin = tymin;
+    if (tymax < tmax) tmax = tymax;
+
+    const tzmin = (bounds[rayDirSign[2]].z - rayOrigin.z) * rayDirInv.z;
+    const tzmax = (bounds[1 - rayDirSign[2]].z - rayOrigin.z) * rayDirInv.z;
+
+    if (tmin > tzmax || tzmin > tmax) return null;
+    if (tzmin > tmin) tmin = tzmin;
+    if (tzmax < tmax) tmax = tzmax;
+
+    if (tmax < 0) return null;
+    // If tmin < 0, ray starts inside the box; use 0 as entry distance
+    return tmin < 0 ? 0 : tmin;
+  }
+
+  /**
    * Möller–Trumbore ray-triangle intersection
    * Returns distance to intersection or null if no hit
    */
@@ -1365,19 +1400,10 @@ export class Scene {
         if (hiddenIds?.has(expressId)) continue;
         if (isolatedIds !== null && isolatedIds !== undefined && !isolatedIds.has(expressId)) continue;
 
-        if (this.rayIntersectsBox(rayOrigin, rayDirInv, rayDirSign, bbox)) {
-          // Estimate distance to bbox center as approximate hit distance
-          const cx = (bbox.min.x + bbox.max.x) * 0.5;
-          const cy = (bbox.min.y + bbox.max.y) * 0.5;
-          const cz = (bbox.min.z + bbox.max.z) * 0.5;
-          const dx = cx - rayOrigin.x;
-          const dy = cy - rayOrigin.y;
-          const dz = cz - rayOrigin.z;
-          const dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
-          if (dist < closestDistance) {
-            closestDistance = dist;
-            closestHit = { expressId, distance: dist };
-          }
+        const tNear = this.rayBoxDistance(rayOrigin, rayDirInv, rayDirSign, bbox);
+        if (tNear !== null && tNear < closestDistance) {
+          closestDistance = tNear;
+          closestHit = { expressId, distance: tNear };
         }
       }
       return closestHit;


### PR DESCRIPTION
## Summary
This PR addresses several bugs and improvements across the renderer and parser packages:
1. Fixes ray casting distance calculation to use actual ray-box intersection distance instead of bbox center estimation
2. Improves resource cleanup in OPFS buffer initialization with proper error handling
3. Adds input validation and error handling for buffer read operations
4. Fixes LRU cache behavior to properly track access recency
5. Prevents unintended mutation of caller's data in entity index building

## Key Changes

**Renderer (scene.ts):**
- Added `rayBoxDistance()` method implementing proper ray-box intersection using the slab method, returning the entry distance (tNear) along the ray
- Updated ray casting logic to use actual intersection distance instead of estimating distance to bbox center, improving hit detection accuracy
- Fixed `reset()` method to properly reset `geometryReleased` flag

**Parser (opfs-source-buffer.ts):**
- Improved error handling in `fromBuffer()` to properly clean up partial OPFS resources (sync handle and file) when initialization fails
- Simplified `isOpfsAvailable()` check using optional chaining for better readability
- Added input validation in `readRange()` to check bounds before reading
- Added verification that all requested bytes were actually read from OPFS, throwing error on short reads

**Parser (compact-entity-index.ts):**
- Fixed LRU cache `get()` method to refresh recency by re-inserting accessed items (delete + re-insert moves to end of insertion order)
- Fixed `buildCompactEntityIndex()` to create a copy of the input array before sorting, preventing unintended mutation of caller's data
- Removed misleading comment about side effects

**Parser (columnar-parser.ts):**
- Removed outdated comment about `buildCompactEntityIndex()` side effects

## Implementation Details
- Ray-box intersection now correctly handles rays originating inside the box (returns 0) and rays missing the box (returns null)
- OPFS cleanup uses try-catch blocks to ensure cleanup attempts don't prevent fallback to in-memory buffers
- LRU cache refresh maintains proper insertion-order semantics for eviction

https://claude.ai/code/session_01WPxWaEUfns8YE4ugkW54hb