### PR TITLE
feat: use Material Symbols IFC class icons in hierarchy panel

### DIFF
--- a/apps/viewer/index.html
+++ b/apps/viewer/index.html
@@ -40,6 +40,11 @@
   <!-- Web App Manifest (PWA support) -->
   <link rel="manifest" href="/manifest.json">
   
+  <!-- Material Symbols font for IFC class icons -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap">
+
   <!-- Theme colors -->
   <meta name="theme-color" content="#7aa2f7">
   <meta name="msapplication-TileColor" content="#1a1b26">

--- a/apps/viewer/src/components/viewer/hierarchy/HierarchyNode.tsx
+++ b/apps/viewer/src/components/viewer/hierarchy/HierarchyNode.tsx
@@ -4,13 +4,7 @@
 
 import {
   ChevronRight,
-  Building2,
   Layers,
-  MapPin,
-  FolderKanban,
-  Square,
-  Box,
-  DoorOpen,
   Eye,
   EyeOff,
   FileBox,
@@ -20,21 +14,21 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { cn } from '@/lib/utils';
 import type { TreeNode } from './types';
 import { isSpatialContainer } from './types';
+import { IFC_ICON_CODEPOINTS, IFC_ICON_DEFAULT } from './ifc-icons';
 
-const TYPE_ICONS: Record<string, React.ElementType> = {
+/**
+ * Resolve the Material Symbols code point for a given IFC type string.
+ * Falls back to the generic product icon for unmapped classes.
+ */
+function getIfcIconCodepoint(ifcType: string | undefined): string {
+  if (!ifcType) return IFC_ICON_DEFAULT;
+  return IFC_ICON_CODEPOINTS[ifcType] ?? IFC_ICON_DEFAULT;
+}
+
+/** Lucide fallback icons for non-IFC node types */
+const NODE_TYPE_ICONS: Record<string, React.ElementType> = {
   'unified-storey': Layers,
   'model-header': FileBox,
-  'ifc-type': Building2,
-  IfcProject: FolderKanban,
-  IfcSite: MapPin,
-  IfcBuilding: Building2,
-  IfcBuildingStorey: Layers,
-  IfcSpace: Box,
-  IfcWall: Square,
-  IfcWallStandardCase: Square,
-  IfcDoor: DoorOpen,
-  element: Box,
-  default: Box,
 };
 
 export interface HierarchyNodeProps {
@@ -69,7 +63,9 @@ export function HierarchyNode({
   onModelHeaderClick,
 }: HierarchyNodeProps) {
   const resolvedType = node.ifcType || node.type;
-  const Icon = TYPE_ICONS[resolvedType] || TYPE_ICONS[node.type] || TYPE_ICONS.default;
+  // Use Lucide icon for non-IFC structural nodes, Material Symbols for IFC classes
+  const LucideIcon = NODE_TYPE_ICONS[node.type];
+  const iconCodepoint = getIfcIconCodepoint(resolvedType);
 
   // Model header nodes (for visibility control and expansion)
   if (node.type === 'model-header' && node.id.startsWith('model-')) {
@@ -259,7 +255,17 @@ export function HierarchyNode({
         {/* Type Icon */}
         <Tooltip>
           <TooltipTrigger asChild>
-            <Icon className="h-3.5 w-3.5 shrink-0 text-zinc-500 dark:text-zinc-400" />
+            {LucideIcon ? (
+              <LucideIcon className="h-3.5 w-3.5 shrink-0 text-zinc-500 dark:text-zinc-400" />
+            ) : (
+              <span
+                className="material-symbols-outlined shrink-0 leading-none text-zinc-500 dark:text-zinc-400"
+                style={{ fontSize: '14px' }}
+                aria-hidden="true"
+              >
+                {iconCodepoint}
+              </span>
+            )}
           </TooltipTrigger>
           <TooltipContent>
             <p className="text-xs">{resolvedType}</p>

--- a/apps/viewer/src/components/viewer/hierarchy/ifc-icons.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/ifc-icons.ts
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * IFC class to Material Symbols icon code point mapping.
+ * Based on https://github.com/AECgeeks/ifc-icons (MIT license).
+ *
+ * Values are Unicode code points for the Material Symbols Outlined font.
+ */
+export const IFC_ICON_CODEPOINTS: Record<string, string> = {
+  // Spatial / context
+  IfcContext: '\uf1c4',
+  IfcProject: '\uf1c4',
+  IfcProjectLibrary: '\uf1c4',
+  IfcSite: '\ue80b',
+  IfcBuilding: '\uea40',
+  IfcBuildingStorey: '\ue8fe',
+  IfcSpace: '\ueff4',
+
+  // Structural
+  IfcBeam: '\uf108',
+  IfcBeamStandardCase: '\uf108',
+  IfcColumn: '\ue233',
+  IfcColumnStandardCase: '\ue233',
+  IfcWall: '\ue3c0',
+  IfcWallStandardCase: '\ue3c0',
+  IfcWallElementedCase: '\ue3c0',
+  IfcSlab: '\ue229',
+  IfcSlabStandardCase: '\ue229',
+  IfcSlabElementedCase: '\ue229',
+  IfcRoof: '\uf201',
+  IfcFooting: '\uf200',
+  IfcPile: '\ue047',
+  IfcPlate: '\ue047',
+  IfcPlateStandardCase: '\ue047',
+  IfcMember: '\ue047',
+  IfcMemberStandardCase: '\ue047',
+
+  // Openings & access
+  IfcDoor: '\ueb4f',
+  IfcDoorStandardCase: '\ueb4f',
+  IfcWindow: '\uf088',
+  IfcWindowStandardCase: '\uf088',
+  IfcOpeningElement: '\ue3c6',
+  IfcOpeningStandardCase: '\ue3c6',
+  IfcCurtainWall: '\ue047',
+
+  // Vertical circulation
+  IfcStair: '\uf1a9',
+  IfcStairFlight: '\uf1a9',
+  IfcRamp: '\ue86b',
+  IfcRampFlight: '\ue86b',
+  IfcRailing: '\ue58f',
+
+  // Furnishing
+  IfcFurnishingElement: '\uea45',
+  IfcFurniture: '\uea45',
+  IfcSystemFurnitureElement: '\uea45',
+
+  // MEP terminals
+  IfcAirTerminal: '\uefd8',
+  IfcLamp: '\uf02a',
+  IfcLightFixture: '\uf02a',
+  IfcSanitaryTerminal: '\uea41',
+  IfcSpaceHeater: '\uf076',
+  IfcAudioVisualAppliance: '\ue333',
+  IfcSensor: '\ue51e',
+
+  // Assemblies & misc
+  IfcElementAssembly: '\ue9b0',
+  IfcTransportElement: '\uf1a0',
+  IfcGrid: '\uf015',
+  IfcPort: '\ue8c0',
+  IfcDistributionPort: '\ue8c0',
+  IfcAnnotation: '\ue3c9',
+
+  // Civil / geographic
+  IfcCivilElement: '\uea99',
+  IfcGeographicElement: '\uea99',
+  IfcLinearElement: '\uebaa',
+
+  // Proxy / generic fallback
+  IfcProduct: '\ue047',
+  IfcBuildingElementProxy: '\ue047',
+  IfcProxy: '\ue047',
+};
+
+/** Default code point for unmapped IFC classes (Material Symbols "widgets" / generic product) */
+export const IFC_ICON_DEFAULT = '\ue047';


### PR DESCRIPTION
Replace generic Lucide box/square icons with context-aware Material Symbols icons based on the AECgeeks/ifc-icons mapping. Each IFC class (IfcWall, IfcBeam, IfcDoor, IfcWindow, etc.) now displays a distinct, recognizable icon in the spatial/class/type hierarchy tree.

- Add Material Symbols Outlined font via Google Fonts CDN
- Create ifc-icons.ts mapping ~60 IFC classes to Material Symbol codepoints
- Update HierarchyNode to render Material Symbols for IFC nodes while keeping Lucide icons for structural UI nodes (unified-storey, model-header)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added IFC class icons to the hierarchy view, providing visual representations for building components such as spatial elements, structural components, openings, and MEP systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->