### PR TITLE
Extract viewer API documentation to dedicated guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,66 +30,9 @@
 - **HeadlessBackend:** `packages/cli/src/headless-backend.ts` implements `BimBackend` without a renderer. Viewer-specific operations are no-ops; query, export, create, IDS, and BCF work fully.
 
 ## 6. 3D Viewer (`@ifc-lite/viewer`)
-
-The viewer is a separate package (`packages/viewer`) that provides browser-based 3D visualization. It complements the headless CLI — all standard commands work without it.
-
-### Launching
-
-```bash
-ifc-lite view model.ifc                              # Opens browser with 3D view
-ifc-lite view model.ifc --port 3456                  # Use specific port
-ifc-lite view --empty --port 3456                    # Empty scene, await commands
-```
-
-### REST API
-
-Send live commands to the viewer:
-
-```bash
-curl -X POST http://localhost:3456/api/command \
-  -H 'Content-Type: application/json' \
-  -d '{"action":"colorize","type":"IfcWall","color":[1,0,0,1]}'
-```
-
-**Type-level actions:** `colorize`, `isolate`, `xray`, `flyto`, `highlight`, `colorByStorey`, `setView`, `showall`, `reset`.
-
-**Entity-level actions** (take `ids` array): `colorizeEntities`, `isolateEntities`, `hideEntities`, `showEntities`, `resetColorEntities`.
-
-**Internal/advanced:** `section`, `clearSection`, `addGeometry`, `removeCreated`, `camera`, `picked`.
-
-### Live Element Creation
-
-```bash
-# Single element
-curl -X POST http://localhost:3456/api/create \
-  -H 'Content-Type: application/json' \
-  -d '{"type":"wall","params":{"Height":3,"Start":[0,0,0],"End":[5,0,0]}}'
-
-# Batch create
-curl -X POST http://localhost:3456/api/create \
-  -H 'Content-Type: application/json' \
-  -d '[{"type":"wall","params":{"Height":3,"Start":[0,0,0],"End":[5,0,0]}},{"type":"column","params":{"Height":3,"Position":[5,0,0]}}]'
-
-# Clear created geometry
-curl -X POST http://localhost:3456/api/clear-created
-
-# Export created geometry
-curl http://localhost:3456/api/export > created.ifc
-```
-
-### Analysis Overlay
-
-```bash
-ifc-lite analyze model.ifc --viewer 3456 \
-  --type IfcWall --missing "Pset_WallCommon.FireRating" --color red
-
-ifc-lite analyze model.ifc --viewer 3456 \
-  --type IfcWall --heatmap "Qto_WallBaseQuantities.GrossSideArea" --palette blue-red
-```
-
-### Coordinate Convention
-
-IFC uses Z-up; the 3D viewer uses Y-up internally. The geometry layer handles the conversion automatically during mesh parsing. When using `/api/create`, pass coordinates in IFC Z-up convention (`[x, y, z]` where Z is up).
+- **Separate package** (`packages/viewer`) — browser-based 3D visualization. All headless CLI commands work without it.
+- **Full API reference:** See [`docs/guide/viewer-api.md`](./docs/guide/viewer-api.md) for launch options, REST API, element creation, and analysis overlays.
+- **Coordinate convention (coding-relevant):** IFC uses Z-up; the viewer uses Y-up internally. The geometry layer converts automatically during mesh parsing. When using `/api/create`, pass coordinates in IFC Z-up convention (`[x, y, z]` where Z is up).
 
 ## 7. Feedback Loop
 - If a pattern is confusing or repeatedly error-prone, call it out explicitly in your PR notes.

--- a/docs/guide/viewer-api.md
+++ b/docs/guide/viewer-api.md
@@ -1,0 +1,61 @@
+# 3D Viewer API (`@ifc-lite/viewer`)
+
+The viewer is a separate package (`packages/viewer`) that provides browser-based 3D visualization. It complements the headless CLI — all standard commands work without it.
+
+## Launching
+
+```bash
+ifc-lite view model.ifc                              # Opens browser with 3D view
+ifc-lite view model.ifc --port 3456                  # Use specific port
+ifc-lite view --empty --port 3456                    # Empty scene, await commands
+```
+
+## REST API
+
+Send live commands to the viewer:
+
+```bash
+curl -X POST http://localhost:3456/api/command \
+  -H 'Content-Type: application/json' \
+  -d '{"action":"colorize","type":"IfcWall","color":[1,0,0,1]}'
+```
+
+**Type-level actions:** `colorize`, `isolate`, `xray`, `flyto`, `highlight`, `colorByStorey`, `setView`, `showall`, `reset`.
+
+**Entity-level actions** (take `ids` array): `colorizeEntities`, `isolateEntities`, `hideEntities`, `showEntities`, `resetColorEntities`.
+
+**Internal/advanced:** `section`, `clearSection`, `addGeometry`, `removeCreated`, `camera`, `picked`.
+
+## Live Element Creation
+
+```bash
+# Single element
+curl -X POST http://localhost:3456/api/create \
+  -H 'Content-Type: application/json' \
+  -d '{"type":"wall","params":{"Height":3,"Start":[0,0,0],"End":[5,0,0]}}'
+
+# Batch create
+curl -X POST http://localhost:3456/api/create \
+  -H 'Content-Type: application/json' \
+  -d '[{"type":"wall","params":{"Height":3,"Start":[0,0,0],"End":[5,0,0]}},{"type":"column","params":{"Height":3,"Position":[5,0,0]}}]'
+
+# Clear created geometry
+curl -X POST http://localhost:3456/api/clear-created
+
+# Export created geometry
+curl http://localhost:3456/api/export > created.ifc
+```
+
+## Analysis Overlay
+
+```bash
+ifc-lite analyze model.ifc --viewer 3456 \
+  --type IfcWall --missing "Pset_WallCommon.FireRating" --color red
+
+ifc-lite analyze model.ifc --viewer 3456 \
+  --type IfcWall --heatmap "Qto_WallBaseQuantities.GrossSideArea" --palette blue-red
+```
+
+## Coordinate Convention
+
+IFC uses Z-up; the 3D viewer uses Y-up internally. The geometry layer handles the conversion automatically during mesh parsing. When using `/api/create`, pass coordinates in IFC Z-up convention (`[x, y, z]` where Z is up).


### PR DESCRIPTION
## Summary
Refactored viewer documentation by extracting detailed API reference from `AGENTS.md` into a dedicated guide file. This improves documentation organization and makes the viewer API more discoverable while keeping the architecture overview concise.

## Changes
- **Created `docs/guide/viewer-api.md`**: New comprehensive guide containing all viewer-specific documentation including:
  - Launch options and command examples
  - Complete REST API reference (type-level and entity-level actions)
  - Live element creation examples (single, batch, and export)
  - Analysis overlay usage
  - Coordinate convention details

- **Updated `AGENTS.md`**: Condensed Section 6 (3D Viewer) to:
  - Brief description of the viewer package
  - Reference link to the new dedicated guide
  - Retained only the coordinate convention note relevant to developers (Z-up vs Y-up conversion)

## Rationale
This change improves documentation maintainability by:
- Separating architectural overview (AGENTS.md) from API reference (viewer-api.md)
- Making the viewer API easier to find and update independently
- Keeping AGENTS.md focused on high-level architecture and design patterns
- Reducing cognitive load when reviewing architecture documentation

https://claude.ai/code/session_01VihfeN7Hard3Lu93gxxAV1