### PR TITLE
docs: add comprehensive 3D viewer and analysis documentation

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -52,6 +52,70 @@ ifc-lite eval model.ifc "bim.query().byType('IfcWall').count()"
 
 ## Commands
 
+### `view` — 3D Viewer
+
+Launch an interactive WebGL 2 viewer in the browser. Control it from the terminal, scripts, or AI assistants via REST API.
+
+```bash
+ifc-lite view model.ifc                          # Open in browser
+ifc-lite view model.ifc --port 3456 --no-open    # Fixed port, no auto-open
+ifc-lite view --empty --port 3456                 # Empty scene for live creation
+```
+
+While running, type interactive commands (`colorize IfcWall red`, `isolate IfcSlab`, `view top`, `reset`) or send commands from another terminal:
+
+```bash
+ifc-lite view --port 3456 --send '{"action":"colorize","type":"IfcWall","color":[1,0,0,1]}'
+```
+
+The viewer exposes a REST API for external tool integration (`/api/command`, `/api/create`, `/api/export`, `/api/status`). See the full [3D Viewer & Analysis](viewer-api.md) guide for details.
+
+**Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--port <N>` | Listen on a specific port (default: random) |
+| `--no-open` | Don't auto-open the browser |
+| `--empty` | Start with an empty scene |
+| `--send <json>` | Send a command to an already-running viewer |
+
+---
+
+### `analyze` — Visual Analysis
+
+Query entities and push color overlays to a running viewer. Requires a viewer to be running first.
+
+```bash
+# Start viewer, then analyze
+ifc-lite view model.ifc --port 3456 --no-open &
+
+ifc-lite analyze model.ifc --viewer 3456 --type IfcWall --color red
+ifc-lite analyze model.ifc --viewer 3456 --type IfcWall --missing "Pset_WallCommon.FireRating" --color red
+ifc-lite analyze model.ifc --viewer 3456 --type IfcSlab --heatmap "Qto_SlabBaseQuantities.GrossArea"
+ifc-lite analyze model.ifc --viewer 3456 --type IfcDoor --isolate --color green --flyto
+ifc-lite analyze model.ifc --viewer 3456 --rules rules.json --json
+```
+
+Supports property filters (`--where`), missing-property checks (`--missing`), heatmaps (`--heatmap`), and batch rules from a JSON file (`--rules`). See the full [3D Viewer & Analysis](viewer-api.md#analyze--visual-analysis-overlay) guide.
+
+**Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--viewer <port>` | Port of running viewer (**required**) |
+| `--type <T>` | IFC type to analyze |
+| `--missing <Pset.Prop>` | Find entities missing a property |
+| `--where <expr>` | Property filter (e.g. `GrossArea>100`) |
+| `--color <name>` | Color matched entities |
+| `--heatmap <Pset.Prop>` | Gradient color by numeric value |
+| `--palette <name>` | Heatmap palette: `blue-red`, `green-red`, `rainbow` |
+| `--isolate` | Hide non-matching entities |
+| `--flyto` | Fly camera to results |
+| `--rules <file>` | Batch rules from JSON |
+| `--json` | Machine-readable output |
+
+---
+
 ### `info` — Model Summary
 
 Print schema version, entity counts, storeys, and top entity types.
@@ -625,6 +689,8 @@ Use `ifc-lite` CLI for BIM/IFC file operations:
 - `ifc-lite diff <file1> <file2>` — compare IFC files
 - `ifc-lite validate <file>` — structural validation
 - `ifc-lite bsdd class <IfcType>` — bSDD class info
+- `ifc-lite view <file> --port <N>` — launch 3D viewer with REST API
+- `ifc-lite analyze <file> --viewer <port> --type <T>` — visual analysis overlay
 - `ifc-lite eval <file> "<expr>"` — evaluate SDK expressions
 - `ifc-lite schema` — discover all SDK methods
 
@@ -646,6 +712,8 @@ Run `ifc-lite schema` to see the full API before writing eval expressions.
 
 | Command | Description |
 |---------|-------------|
+| `view` | Launch interactive 3D viewer with REST API |
+| `analyze` | Visual analysis overlay on running viewer |
 | `info` | Model summary (schema, entities, storeys) |
 | `query` | Query entities by type/properties with full data access |
 | `props` | All properties for a single entity |

--- a/docs/guide/viewer-api.md
+++ b/docs/guide/viewer-api.md
@@ -1,18 +1,74 @@
-# 3D Viewer API (`@ifc-lite/viewer`)
+# 3D Viewer & Analysis
 
-The viewer is a separate package (`packages/viewer`) that provides browser-based 3D visualization. It complements the headless CLI — all standard commands work without it.
+The `view` and `analyze` commands turn the CLI into a visual BIM analysis tool. Launch an interactive WebGL 2 viewer in the browser, then drive it from the terminal, scripts, or AI assistants via a REST API.
 
-## Launching
+!!! info "Optional feature"
+    The viewer is provided by `@ifc-lite/viewer-core`. All other CLI commands work without it — it only activates when you run `view` or `analyze`.
+
+## `view` — Launch 3D Viewer
 
 ```bash
-ifc-lite view model.ifc                              # Opens browser with 3D view
-ifc-lite view model.ifc --port 3456                  # Use specific port
-ifc-lite view --empty --port 3456                    # Empty scene, await commands
+# Open a model in the browser
+ifc-lite view model.ifc
+
+# Fixed port (useful for scripting)
+ifc-lite view model.ifc --port 3456
+
+# Don't auto-open the browser
+ifc-lite view model.ifc --port 3456 --no-open
+
+# Empty scene — build geometry via API
+ifc-lite view --empty --port 3456
 ```
+
+**Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--port <N>` | Listen on a specific port (default: random) |
+| `--no-open` | Don't open the browser automatically |
+| `--empty` | Start with an empty scene (no IFC file) |
+| `--send <json>` | Send a command to an already-running viewer (requires `--port`) |
+
+### Interactive Console
+
+While the viewer is running, type commands directly in the terminal:
+
+```
+colorize IfcWall red        # Color all walls red
+isolate IfcWall IfcSlab     # Show only walls and slabs
+xray IfcWall 0.15           # Make walls transparent
+highlight 42 43             # Highlight entities by express ID
+flyto IfcDoor               # Fly camera to doors
+view front                  # Switch to front view
+storey                      # Color by building storey
+section y center            # Add horizontal section plane
+clearSection                # Remove section plane
+clear                       # Remove live-created geometry
+showall                     # Show all entities
+reset                       # Reset colors and visibility
+quit                        # Stop the viewer
+```
+
+Named colors: `red`, `green`, `blue`, `yellow`, `orange`, `purple`, `cyan`, `white`, `pink`.
+
+### Send Commands from Another Terminal
+
+Use `--send` to control a running viewer without opening a new one:
+
+```bash
+ifc-lite view --port 3456 --send '{"action":"colorize","type":"IfcWall","color":[1,0,0,1]}'
+ifc-lite view --port 3456 --send '{"action":"setView","view":"top"}'
+ifc-lite view --port 3456 --send '{"action":"isolate","types":["IfcWall","IfcSlab"]}'
+```
+
+---
 
 ## REST API
 
-Send live commands to the viewer:
+The viewer exposes a REST API on the same port. Use it from `curl`, scripts, or AI tools.
+
+### `POST /api/command` — Send Viewer Commands
 
 ```bash
 curl -X POST http://localhost:3456/api/command \
@@ -20,13 +76,46 @@ curl -X POST http://localhost:3456/api/command \
   -d '{"action":"colorize","type":"IfcWall","color":[1,0,0,1]}'
 ```
 
-**Type-level actions:** `colorize`, `isolate`, `xray`, `flyto`, `highlight`, `colorByStorey`, `setView`, `showall`, `reset`.
+Returns `{"ok": true, "action": "colorize", "clients": 1}` on success.
 
-**Entity-level actions** (take `ids` array): `colorizeEntities`, `isolateEntities`, `hideEntities`, `showEntities`, `resetColorEntities`.
+#### Type-Level Actions
 
-**Internal/advanced:** `section`, `clearSection`, `addGeometry`, `removeCreated`, `camera`, `picked`.
+These operate on all entities of a given IFC type:
 
-## Live Element Creation
+| Action | Payload | Description |
+|--------|---------|-------------|
+| `colorize` | `{type, color}` | Color all entities of a type |
+| `isolate` | `{types: [...]}` | Show only listed types |
+| `xray` | `{type, opacity?}` | Make a type semi-transparent |
+| `flyto` | `{type}` | Fly camera to a type |
+| `highlight` | `{ids: [...]}` | Highlight express IDs |
+| `colorByStorey` | `{}` | Auto-color by building storey |
+| `setView` | `{view}` | Set camera: `front`, `back`, `left`, `right`, `top`, `bottom`, `iso` |
+| `showall` | `{}` | Reset visibility |
+| `reset` | `{}` | Reset all colors and visibility |
+
+#### Entity-Level Actions
+
+These operate on specific express IDs:
+
+| Action | Payload | Description |
+|--------|---------|-------------|
+| `colorizeEntities` | `{ids, color}` | Color specific entities |
+| `isolateEntities` | `{ids}` | Show only specific entities |
+| `hideEntities` | `{ids}` | Hide specific entities |
+| `showEntities` | `{ids}` | Show previously hidden entities |
+| `resetColorEntities` | `{ids}` | Reset colors on specific entities |
+
+#### Section Planes
+
+| Action | Payload | Description |
+|--------|---------|-------------|
+| `section` | `{axis, position}` | Add section plane. Axis: `x`, `y`, or `z`. Position: number, `"center"`, or `"50%"` |
+| `clearSection` | `{}` | Remove section plane |
+
+### `POST /api/create` — Live Element Creation
+
+Create IFC elements and inject them into the viewer in real time. Accepts a single object or an array for batch creation.
 
 ```bash
 # Single element
@@ -34,28 +123,184 @@ curl -X POST http://localhost:3456/api/create \
   -H 'Content-Type: application/json' \
   -d '{"type":"wall","params":{"Height":3,"Start":[0,0,0],"End":[5,0,0]}}'
 
-# Batch create
+# Batch create (single HTTP call)
 curl -X POST http://localhost:3456/api/create \
   -H 'Content-Type: application/json' \
-  -d '[{"type":"wall","params":{"Height":3,"Start":[0,0,0],"End":[5,0,0]}},{"type":"column","params":{"Height":3,"Position":[5,0,0]}}]'
+  -d '[
+    {"type":"wall","params":{"Height":3,"Start":[0,0,0],"End":[5,0,0]}},
+    {"type":"wall","params":{"Height":3,"Start":[5,0,0],"End":[5,5,0]}},
+    {"type":"slab","params":{"Width":5,"Depth":5}}
+  ]'
+```
 
-# Clear created geometry
+Returns entity list and IFC size:
+
+```json
+{"ok":true,"count":3,"entities":[...],"ifcSize":3646}
+```
+
+All 30+ element types from the [`create` command](cli.md#create--create-ifc-files) are supported. Coordinates use IFC Z-up convention.
+
+### `POST /api/clear-created` — Remove Live Geometry
+
+```bash
 curl -X POST http://localhost:3456/api/clear-created
+```
 
-# Export created geometry
+Removes all geometry added via `/api/create` from the viewer and server state.
+
+### `GET /api/export` — Download Created Geometry
+
+```bash
 curl http://localhost:3456/api/export > created.ifc
 ```
 
-## Analysis Overlay
+Downloads all live-created geometry as a valid IFC STEP file.
+
+### `GET /api/status` — Server Status
 
 ```bash
+curl http://localhost:3456/api/status
+```
+
+```json
+{"ok":true,"model":"Building.ifc","clients":1,"createdSegments":2}
+```
+
+---
+
+## `analyze` — Visual Analysis Overlay
+
+Query entities by type and properties, then push the results as color overlays to a running viewer. Requires a viewer to be running first.
+
+```bash
+# Start the viewer
+ifc-lite view model.ifc --port 3456 --no-open &
+
+# Find walls missing fire rating — color them red
 ifc-lite analyze model.ifc --viewer 3456 \
   --type IfcWall --missing "Pset_WallCommon.FireRating" --color red
 
+# Heatmap by slab area
 ifc-lite analyze model.ifc --viewer 3456 \
-  --type IfcWall --heatmap "Qto_WallBaseQuantities.GrossSideArea" --palette blue-red
+  --type IfcSlab --heatmap "Qto_SlabBaseQuantities.GrossArea" --palette blue-red
+
+# Filter by property value
+ifc-lite analyze model.ifc --viewer 3456 \
+  --type IfcWall --where "Qto_WallBaseQuantities.GrossSideArea>50" --color orange
+
+# Isolate + color + fly to
+ifc-lite analyze model.ifc --viewer 3456 \
+  --type IfcDoor --isolate --color green --flyto
 ```
+
+**Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--viewer <port>` | Port of the running viewer (**required**) |
+| `--type <T>` | IFC type to analyze (e.g. `IfcWall`) |
+| `--missing <Pset.Prop>` | Find entities missing a property |
+| `--where <expr>` | Property filter: `Pset.Prop>100`, `Pset.Prop=true` |
+| `--color <name>` | Color matched entities (named or `r,g,b,a`) |
+| `--heatmap <Pset.Prop>` | Color by numeric value (gradient) |
+| `--palette <name>` | Heatmap palette: `blue-red`, `green-red`, `rainbow` |
+| `--isolate` | Hide non-matching entities |
+| `--flyto` | Fly camera to matched entities |
+| `--rules <file.json>` | Run multiple rules from a JSON file |
+| `--json` | Machine-readable output |
+
+### Rules File
+
+Run multiple analysis rules in one pass using a JSON file:
+
+```json
+[
+  {
+    "name": "Missing fire rating",
+    "type": "IfcWall",
+    "missing": "Pset_WallCommon.FireRating",
+    "color": "red",
+    "isolate": true
+  },
+  {
+    "name": "Large slabs",
+    "type": "IfcSlab",
+    "where": "Qto_SlabBaseQuantities.GrossArea>100",
+    "color": "orange"
+  },
+  {
+    "name": "Wall area heatmap",
+    "type": "IfcWall",
+    "heatmap": "Qto_WallBaseQuantities.GrossSideArea",
+    "palette": "blue-red"
+  }
+]
+```
+
+```bash
+ifc-lite analyze model.ifc --viewer 3456 --rules rules.json --json
+```
+
+---
 
 ## Coordinate Convention
 
-IFC uses Z-up; the 3D viewer uses Y-up internally. The geometry layer handles the conversion automatically during mesh parsing. When using `/api/create`, pass coordinates in IFC Z-up convention (`[x, y, z]` where Z is up).
+IFC uses **Z-up**; the WebGL viewer uses **Y-up** internally. The WASM geometry engine handles the conversion automatically during mesh parsing. When using `/api/create`, pass coordinates in IFC Z-up convention (`[x, y, z]` where Z is vertical).
+
+## Architecture
+
+```mermaid
+graph LR
+  CLI["CLI / curl / AI"] -->|REST API| Server["@ifc-lite/viewer-core<br/>Node.js HTTP"]
+  Server -->|SSE push| Browser["WebGL 2 Viewer<br/>Browser"]
+  Server -->|Stream IFC| Browser
+  Browser -->|WASM parse| Render["GPU Render"]
+```
+
+The viewer is a self-contained WebGL 2 application served as a single HTML page. Commands flow from external tools through the REST API, get broadcast to connected browsers via Server-Sent Events (SSE), and execute in the WebGL renderer.
+
+Key design decisions:
+
+- **IFC streamed from disk** — large models aren't buffered in Node.js memory
+- **WASM geometry engine** — parsing and mesh generation happen in the browser
+- **GPU color-ID picking** — click any entity to see its express ID and type
+- **Per-vertex color buffer** — real-time colorization without re-uploading geometry
+- **SSE with exponential backoff** — reconnects automatically if the connection drops
+- **CORS restricted to localhost** — the API only accepts requests from local origins
+
+## Programmatic Usage (`@ifc-lite/viewer-core`)
+
+The viewer server can be used as a library in your own Node.js tools:
+
+```typescript
+import { startViewerServer } from '@ifc-lite/viewer-core';
+
+const viewer = await startViewerServer({
+  filePath: 'model.ifc',
+  fileName: 'My Model',
+  port: 3456,
+  onReady: (port, url) => console.log(`Viewer at ${url}`),
+});
+
+// Send commands programmatically
+viewer.broadcast({ action: 'colorize', type: 'IfcWall', color: [1, 0, 0, 1] });
+viewer.broadcast({ action: 'setView', view: 'iso' });
+
+// Check connected clients
+console.log(`${viewer.clientCount()} browsers connected`);
+
+// Clean up
+viewer.close();
+```
+
+**Exports:**
+
+| Export | Description |
+|--------|-------------|
+| `startViewerServer(opts)` | Start the HTTP + SSE server |
+| `VALID_ACTIONS` | `Set<string>` of accepted command actions |
+| `getViewerHtml(title)` | Get the self-contained viewer HTML |
+| `createStreamingViewerAdapter(port)` | SDK adapter for `bim.viewer.*` calls |
+| `ViewerServer` | Server instance type |
+| `CreateHandler` | Handler type for `/api/create` |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,6 +114,7 @@ nav:
     - Installation: guide/installation.md
     - Quick Start: guide/quickstart.md
     - CLI Toolkit: guide/cli.md
+    - 3D Viewer & Analysis: guide/viewer-api.md
     - Server Guide: guide/server.md
     - Desktop App: guide/desktop.md
     - Browser Requirements: guide/browser-requirements.md


### PR DESCRIPTION
- Rewrite viewer-api.md with full REST API reference, interactive console commands, analyze overlay guide, rules file format, architecture diagram, and programmatic usage of @ifc-lite/viewer-core
- Add view and analyze command sections to cli.md with flags tables
- Add viewer-api.md to mkdocs.yml navigation under Getting Started

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive CLI guide documentation for `view` and `analyze` commands with usage examples and API details
  * Expanded 3D Viewer & Analysis documentation including REST API endpoints, interactive examples, and programmatic integration patterns
  * Updated documentation navigation structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->