### PR TITLE
Add orthographic zoom animation support to camera animator

### DIFF
--- a/packages/renderer/src/camera-animation.ts
+++ b/packages/renderer/src/camera-animation.ts
@@ -210,8 +210,9 @@ export class CameraAnimator {
     };
 
     // Calculate orthoSize for orthographic mode so zoom level resets properly
+    const aspect = this.state.camera.aspect || 1;
     const endOrthoSize = this.state.projectionMode === 'orthographic'
-      ? Math.max(maxSize / 2, maxSize / 2 / this.state.camera.aspect) * 1.5
+      ? Math.max(0.01, maxSize / 2, maxSize / 2 / aspect) * 1.5
       : undefined;
 
     return this.animateTo(endPos, endTarget, duration, endOrthoSize);
@@ -313,8 +314,9 @@ export class CameraAnimator {
     };
 
     // Calculate orthoSize for orthographic mode so zoom level resets properly
+    const aspect = this.state.camera.aspect || 1;
     const endOrthoSize = this.state.projectionMode === 'orthographic'
-      ? Math.max(maxSize / 2, maxSize / 2 / this.state.camera.aspect) * 1.2
+      ? Math.max(0.01, maxSize / 2, maxSize / 2 / aspect) * 1.2
       : undefined;
 
     return this.animateTo(endPos, center, duration, endOrthoSize);
@@ -372,8 +374,9 @@ export class CameraAnimator {
     };
 
     // Calculate orthoSize for orthographic mode so zoom level resets properly
+    const aspect = this.state.camera.aspect || 1;
     const endOrthoSize = this.state.projectionMode === 'orthographic'
-      ? Math.max(maxSize / 2, maxSize / 2 / this.state.camera.aspect) * 1.5
+      ? Math.max(0.01, maxSize / 2, maxSize / 2 / aspect) * 1.5
       : undefined;
 
     return this.animateTo(endPos, center, duration, endOrthoSize);
@@ -430,6 +433,8 @@ export class CameraAnimator {
     this.animationEndPos = endPos;
     this.animationEndTarget = endTarget;
     this.animationEndUp = endUp;
+    this.animationStartOrthoSize = null;
+    this.animationEndOrthoSize = null;
     this.animationDuration = duration;
     this.animationStartTime = Date.now();
     this.animationEasing = this.easeOutCubic;


### PR DESCRIPTION
## Summary
This PR adds support for animating the orthographic zoom level (`orthoSize`) during camera animations. Previously, when animating camera position and target in orthographic projection mode, the zoom level would not be adjusted, resulting in inconsistent framing. This change ensures that orthographic zoom is properly interpolated during camera animations.

## Key Changes
- Added `animationStartOrthoSize` and `animationEndOrthoSize` private properties to track orthographic zoom animation state
- Implemented orthoSize interpolation in the animation loop using linear interpolation (matching the position/target interpolation approach)
- Updated `animateTo()` method signature to accept an optional `endOrthoSize` parameter
- Modified `fitView()`, `viewFit()`, and `zoomExtent()` methods to calculate and pass appropriate orthoSize values when in orthographic projection mode
- Added proper cleanup of orthoSize animation state when animations complete or are cancelled
- OrthoSize calculations use aspect ratio-aware sizing with multipliers (1.5x for fitView/zoomExtent, 1.2x for viewFit) to maintain consistent framing

## Implementation Details
- OrthoSize is only animated when explicitly provided to `animateTo()`, maintaining backward compatibility
- The orthoSize calculation formula: `Math.max(maxSize / 2, maxSize / 2 / aspect) * multiplier` ensures proper scaling in both landscape and portrait orientations
- Animation state is properly reset in both the completion path and the `resetAnimation()` cleanup method

https://claude.ai/code/session_01CFoR5Bdb2FtexxDsD3hS1M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added orthographic zoom interpolation during camera animations for seamless zoom transitions alongside position and orientation changes.
  * Camera animation methods now return Promises that resolve when the animation completes.
  * Animation API accepts an optional orthographic zoom level, and framing/zoom-to-fit operations now respect and apply that zoom.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->