### PR TITLE
Add Privacy & Security section to Info dialog

### DIFF
--- a/apps/viewer/src/components/viewer/KeyboardShortcutsDialog.tsx
+++ b/apps/viewer/src/components/viewer/KeyboardShortcutsDialog.tsx
@@ -33,6 +33,46 @@ const TYPE_CONFIG = {
   perf: { icon: Zap, className: 'text-blue-500' },
 } as const;
 
+function PrivacyBanner() {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="pt-2 border-t">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="flex items-center gap-2 w-full rounded-md bg-emerald-500/10 px-2.5 py-1.5 text-left transition-colors hover:bg-emerald-500/15"
+      >
+        <ShieldCheck className="h-3.5 w-3.5 text-emerald-500 shrink-0" />
+        <span className="text-xs font-medium">Your IFC data never leaves your device.</span>
+        {expanded ? (
+          <ChevronDown className="h-3 w-3 ml-auto shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="h-3 w-3 ml-auto shrink-0 text-muted-foreground" />
+        )}
+      </button>
+      {expanded && (
+        <div className="mt-1.5 ml-1 space-y-1 text-xs text-muted-foreground">
+          <p>
+            All files are processed locally in the browser with{' '}
+            <a
+              href="https://webassembly.org/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:text-foreground transition-colors"
+            >
+              WebAssembly (WASM)
+            </a>
+            {' '}&ndash; no server upload, near-native speed.
+          </p>
+          <p className="text-[11px] italic">
+            Verify: press <kbd className="px-1 py-0.5 bg-muted rounded border font-mono text-[10px]">F12</kbd> &rarr; Network tab &rarr; no IFC data transmitted.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
 function AboutTab() {
   const [showPackages, setShowPackages] = useState(false);
   const packageVersions = __PACKAGE_VERSIONS__;
@@ -89,32 +129,7 @@ function AboutTab() {
       </div>
 
       {/* Privacy & Security */}
-      <div className="pt-2 border-t space-y-1.5">
-        <div className="flex items-center gap-1.5 text-sm font-medium">
-          <ShieldCheck className="h-3.5 w-3.5 text-emerald-500" />
-          Privacy &amp; Security
-        </div>
-        <p className="text-xs text-muted-foreground">
-          <span className="font-medium text-foreground">Your IFC data never leaves your device.</span>{' '}
-          All files are processed locally in the browser with{' '}
-          <a
-            href="https://webassembly.org/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline hover:text-foreground transition-colors"
-          >
-            WebAssembly
-          </a>.
-        </p>
-        <ul className="text-xs text-muted-foreground space-y-0.5 ml-3.5 list-disc">
-          <li>No server upload &ndash; everything stays on your device</li>
-          <li>WebAssembly (WASM) enables near-native performance in the browser</li>
-          <li>Your models and data remain private and secure</li>
-        </ul>
-        <p className="text-[11px] text-muted-foreground italic">
-          Verify it yourself: open DevTools (<kbd className="px-1 py-0.5 bg-muted rounded border font-mono text-[10px]">F12</kbd>), check the Network tab, and see that no IFC data is transmitted.
-        </p>
-      </div>
+      <PrivacyBanner />
 
       {/* Package Versions */}
       {packageVersions.length > 0 && (


### PR DESCRIPTION
Added a section to the About tab explaining that all processing happens locally in the browser via WebAssembly with no server uploads, including a tip to verify via DevTools Network tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a collapsible Privacy & Security banner in the About area and feature section explaining local data processing and WebAssembly usage with resource links.
  * Exposed a control for the keyboard shortcuts dialog so other parts of the app can open/close it programmatically.

* **UI Changes**
  * Minor layout and separator adjustments to accommodate the new banner without altering tab content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->