### PR TITLE
Guard worker initialization to prevent errors in Node.js test environments

### DIFF
--- a/packages/wasm/pkg/snippets/wasm-bindgen-rayon-38edf6e439f6d70d/src/workerHelpers.js
+++ b/packages/wasm/pkg/snippets/wasm-bindgen-rayon-38edf6e439f6d70d/src/workerHelpers.js
@@ -28,7 +28,8 @@ function waitForMsgType(target, type) {
   });
 }
 
-waitForMsgType(self, 'wasm_bindgen_worker_init').then(async ({ init, receiver }) => {
+// Guard: only run worker init in a Worker context (skip in Node.js tests)
+if (typeof self !== 'undefined') waitForMsgType(self, 'wasm_bindgen_worker_init').then(async ({ init, receiver }) => {
   // # Note 1
   // Our JS should have been generated in
   // `[out-dir]/snippets/wasm-bindgen-rayon-[hash]/workerHelpers.js`,


### PR DESCRIPTION
## Summary
Added a guard condition to prevent worker initialization code from executing in non-Worker contexts, such as Node.js test environments where the `self` global object is undefined.

## Key Changes
- Wrapped `waitForMsgType(self, 'wasm_bindgen_worker_init')` call with a check for `typeof self !== 'undefined'`
- This prevents runtime errors when the workerHelpers.js module is loaded in Node.js or other non-browser Worker contexts
- Added clarifying comment explaining the guard's purpose

## Implementation Details
The change is minimal and non-breaking: the worker initialization code only executes when `self` is defined (i.e., in actual Web Worker contexts), while gracefully skipping initialization in test environments where `self` is undefined. This allows the module to be safely imported in both Worker and non-Worker contexts without errors.

https://claude.ai/code/session_01RWW75mH8xbtDptJKS6x7dB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime compatibility by preventing worker initialization errors in non-browser environments (Node.js, test runners). The initialization sequence now safely skips in environments where it cannot execute, reducing spurious warnings and failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->