### PR TITLE
fix(lists): enable visibility filter by default

### DIFF
--- a/apps/viewer/src/components/viewer/lists/ListResultsTable.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListResultsTable.tsx
@@ -33,7 +33,7 @@ export function ListResultsTable({ result }: ListResultsTableProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const [sortCol, setSortCol] = useState<number | null>(null);
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
-  const [filterByVisibility, setFilterByVisibility] = useState(false);
+  const [filterByVisibility, setFilterByVisibility] = useState(true);
 
   const setSelectedEntityId = useViewerStore((s) => s.setSelectedEntityId);
   const setSelectedEntity = useViewerStore((s) => s.setSelectedEntity);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * List now correctly displays only visible items by default, aligning with expected filtering behavior. Row count now shows filtered versus total item counts by default for better visibility clarity. The filter toggle remains fully functional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->