### PR TITLE
chore: add changeset for visibility filter default

### DIFF
--- a/.changeset/enable-visibility-filter-default.md
+++ b/.changeset/enable-visibility-filter-default.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Enable visibility filter by default in list results table so rows are filtered by 3D visibility state out of the box


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The visibility filter is now enabled by default in list results table rows, automatically filtering them based on the 3D visibility state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->