### PR TITLE
Fix snippets not being published in the wasm package

### DIFF
--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -14,7 +14,8 @@
   "files": [
     "pkg/ifc-lite_bg.wasm",
     "pkg/ifc-lite.js",
-    "pkg/ifc-lite.d.ts"
+    "pkg/ifc-lite.d.ts",
+    "pkg/snippets"
   ],
   "main": "./pkg/ifc-lite.js",
   "module": "./pkg/ifc-lite.js",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended package distribution to include additional snippet resources alongside existing WebAssembly and type declaration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->