### PR TITLE
fix(wasm): use single-level glob for test discovery

### DIFF
--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -7,7 +7,7 @@
   "description": "WebAssembly bindings for IFC-Lite",
   "version": "1.14.5",
   "scripts": {
-    "test": "node --test test/**/*.test.mjs"
+    "test": "node --test test/*.test.mjs"
   },
   "license": "MPL-2.0",
   "repository": {


### PR DESCRIPTION
The `**` glob requires `shopt -s globstar` in bash, which is not enabled by default in CI runners. Since all test files are directly in `test/`, a single `*` glob suffices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test script configuration to refine test discovery scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->