### PR TITLE
fix(viewer): polyfill browser globals for Node.js test runner

### DIFF
--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",
-    "test": "tsx --test --test-concurrency=1 $(find src -type f \\( -name '*.test.ts' -o -name '*.test.tsx' \\) | sort)",
+    "test": "tsx --import ./test-setup.mjs --test --test-concurrency=1 $(find src -type f \\( -name '*.test.ts' -o -name '*.test.tsx' \\) | sort)",
     "check:templates": "tsc -p src/lib/scripts/templates/tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/apps/viewer/test-setup.mjs
+++ b/apps/viewer/test-setup.mjs
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// Polyfill browser globals required by @ifc-lite/wasm worker helpers
+// which execute `waitForMsgType(self, ...)` at import time.
+// In Node.js `self` is undefined and `globalThis` lacks `addEventListener`,
+// so we provide a no-op stub that satisfies the worker bootstrap code.
+if (typeof globalThis.self === 'undefined') {
+  globalThis.self = /** @type {any} */ ({
+    addEventListener() {},
+    removeEventListener() {},
+    postMessage() {},
+  });
+}


### PR DESCRIPTION
The WASM worker helpers call `self.addEventListener()` at import time, which fails in Node.js. Add a test-setup script that stubs `self` with no-op event methods so the 4 affected tests can import store modules that transitively pull in the WASM package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test script configuration to properly initialize the test environment.
  * Added test environment setup module to ensure test execution compatibility with required dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->