### PR TITLE
Fix test glob pattern in wasm package

### DIFF
--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -7,7 +7,7 @@
   "description": "WebAssembly bindings for IFC-Lite",
   "version": "1.14.5",
   "scripts": {
-    "test": "node --test test/**/*.test.mjs"
+    "test": "node --test test/*.test.mjs"
   },
   "license": "MPL-2.0",
   "repository": {


### PR DESCRIPTION
## Summary
Updated the test script glob pattern in the wasm package to match test files in the root test directory only, rather than recursively searching subdirectories.

## Changes
- Modified the test script glob pattern from `test/**/*.test.mjs` to `test/*.test.mjs` in `packages/wasm/package.json`

## Details
This change adjusts the test discovery pattern to only include test files directly in the `test/` directory, excluding any nested subdirectories. This may be intentional to avoid running tests from nested test folders or to align with the actual test file structure in the project.

https://claude.ai/code/session_01K8Kr4tkp4AycFMktNB9uYB