### PR TITLE
fix: IFC4X3 RTC offset detection (merge PR #359)

### DIFF
--- a/rust/geometry/src/router/processing.rs
+++ b/rust/geometry/src/router/processing.rs
@@ -6,7 +6,7 @@
 
 use super::GeometryRouter;
 use crate::{Error, Mesh, Result, SubMeshCollection};
-use ifc_lite_core::{DecodedEntity, EntityDecoder, GeometryCategory, IfcType};
+use ifc_lite_core::{has_geometry_by_name, DecodedEntity, EntityDecoder, GeometryCategory, IfcType};
 use nalgebra::Matrix4;
 use std::sync::Arc;
 
@@ -78,19 +78,14 @@ impl GeometryRouter {
         let mut translations: Vec<(f64, f64, f64)> = Vec::new();
         const MAX_SAMPLES: usize = 50;
 
-        const BUILDING_ELEMENT_TYPES: &[&str] = &[
-            "IFCWALL", "IFCWALLSTANDARDCASE", "IFCSLAB", "IFCBEAM", "IFCCOLUMN",
-            "IFCPLATE", "IFCROOF", "IFCCOVERING", "IFCFOOTING", "IFCRAILING",
-            "IFCSTAIR", "IFCSTAIRFLIGHT", "IFCRAMP", "IFCRAMPFLIGHT",
-            "IFCDOOR", "IFCWINDOW", "IFCFURNISHINGELEMENT", "IFCBUILDINGELEMENTPROXY",
-            "IFCMEMBER", "IFCCURTAINWALL", "IFCPILE", "IFCSHADINGDEVICE",
-        ];
-
         while let Some((_id, type_name, start, end)) = scanner.next_entity() {
             if translations.len() >= MAX_SAMPLES {
                 break;
             }
-            if !BUILDING_ELEMENT_TYPES.iter().any(|&t| t == type_name) {
+            // Use the canonical has_geometry_by_name check from the schema
+            // instead of a hardcoded list — any entity class with geometry
+            // is a valid candidate for RTC offset sampling.
+            if !has_geometry_by_name(type_name) {
                 continue;
             }
             if let Ok(entity) = decoder.decode_at(start, end) {

--- a/rust/wasm-bindings/src/api/gpu_meshes.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes.rs
@@ -1208,8 +1208,14 @@ impl IfcAPI {
                 let mut router = GeometryRouter::with_scale(unit_scale);
 
                 // DETECT RTC OFFSET from pre-collected building element jobs (no re-scan)
+                // Use both simple AND complex jobs: infrastructure models (IFC4X3) may
+                // only have complex-classified elements (e.g., IfcPavement, IfcCourse).
+                let all_jobs: Vec<_> = pre_pass.simple_jobs.iter()
+                    .chain(pre_pass.complex_jobs.iter())
+                    .copied()
+                    .collect();
                 let rtc_offset =
-                    router.detect_rtc_offset_from_jobs(&pre_pass.simple_jobs, &mut decoder);
+                    router.detect_rtc_offset_from_jobs(&all_jobs, &mut decoder);
                 let needs_shift = rtc_offset.0.abs() > 10000.0
                     || rtc_offset.1.abs() > 10000.0
                     || rtc_offset.2.abs() > 10000.0;

--- a/rust/wasm-bindings/src/api/styling.rs
+++ b/rust/wasm-bindings/src/api/styling.rs
@@ -889,24 +889,30 @@ pub(crate) fn pick_material_style_for_submesh(
     Some(material_colors[0])
 }
 
-/// Check if a type name is "simple" geometry (processed first for fast first frame).
+/// Check if an IFC entity class is "simple" geometry (processed first for fast
+/// first frame).  Instead of whitelisting known simple classes — which breaks
+/// whenever new IFC entity classes appear (e.g. IFC4X3 infrastructure) — we
+/// blacklist the classes that are known to be secondary/complex.  Everything
+/// else with geometry defaults to "simple" priority.
 pub(crate) fn is_simple_geometry_type(type_name: &str) -> bool {
-    matches!(
+    !matches!(
         type_name,
-        "IFCWALL"
-            | "IFCWALLSTANDARDCASE"
-            | "IFCSLAB"
-            | "IFCBEAM"
-            | "IFCCOLUMN"
-            | "IFCPLATE"
-            | "IFCROOF"
-            | "IFCCOVERING"
-            | "IFCFOOTING"
-            | "IFCRAILING"
-            | "IFCSTAIR"
-            | "IFCSTAIRFLIGHT"
-            | "IFCRAMP"
-            | "IFCRAMPFLIGHT"
+        // Openings / voids — subtracted, not rendered directly
+        "IFCOPENINGELEMENT" | "IFCOPENINGSTANDARDCASE"
+        // Windows & doors — detailed geometry, lower priority
+        | "IFCWINDOW" | "IFCWINDOWSTANDARDCASE"
+        | "IFCDOOR" | "IFCDOORSTANDARDCASE"
+        // Furnishing — typically high-poly, secondary
+        | "IFCFURNISHINGELEMENT" | "IFCFURNITURE" | "IFCSYSTEMFURNITUREELEMENT"
+        // MEP / distribution — dense small elements
+        | "IFCDISTRIBUTIONELEMENT" | "IFCDISTRIBUTIONFLOWELEMENT" | "IFCDISTRIBUTIONCONTROLELEMENT"
+        | "IFCFLOWSEGMENT" | "IFCFLOWFITTING" | "IFCFLOWTERMINAL"
+        | "IFCFLOWCONTROLLER" | "IFCFLOWMOVINGDEVICE" | "IFCFLOWSTORAGEDEVICE"
+        | "IFCFLOWTREATMENTDEVICE" | "IFCENERGYCONVERSIONDEVICE"
+        // Spatial elements — not structural
+        | "IFCSPACE" | "IFCSITE"
+        // Annotations & virtual
+        | "IFCANNOTATION" | "IFCVIRTUALELEMENT" | "IFCPROXY"
     )
 }
 


### PR DESCRIPTION
## Summary

Rebases the changes from #359 onto main, resolving the merge conflict in `styling.rs`.

- **Replace hardcoded entity list with `has_geometry_by_name()`** in RTC offset sampling (`processing.rs`) — any entity class with geometry is now a valid candidate, supporting IFC4X3 infrastructure types
- **Use both simple and complex jobs for RTC offset detection** (`gpu_meshes.rs`) — infrastructure models (IFC4X3) that only have complex-classified elements (e.g. IfcPavement, IfcCourse) are now included
- **Invert `is_simple_geometry_type` to blacklist-based** (`styling.rs`) — instead of whitelisting known simple classes (which breaks for new IFC4X3 types), blacklist known secondary/complex classes; preserves `pub(crate)` visibility from main (the conflict)

## Test plan

- [ ] Verify IFC4X3 infrastructure models render correctly with proper RTC offset
- [ ] Verify standard IFC2x3/IFC4 models still render correctly (no regression)
- [ ] Confirm geometry priority ordering (simple vs complex) works as expected

Closes #359

https://claude.ai/code/session_01Qk839TBUvN8y5VCcZwJ4Yk