### PR TITLE
Show all type properties in inherited section regardless of overrides

### DIFF
--- a/apps/viewer/src/components/viewer/PropertiesPanel.tsx
+++ b/apps/viewer/src/components/viewer/PropertiesPanel.tsx
@@ -644,8 +644,8 @@ export function PropertiesPanel() {
 
   // Separate occurrence (instance) and inherited type properties.
   // Occurrence properties are displayed first, type properties in a separate section.
-  // When a pset exists at both levels, occurrence takes precedence; the type-only
-  // properties (not overridden at instance level) are shown in the inherited section.
+  // All type property sets are always shown in the inherited section so users can see
+  // what the type defines, even when the same pset exists at occurrence level.
   const { occurrenceProperties, inheritedTypeProperties } = useMemo(() => {
     const occ: PropertySet[] = properties.map(p => ({ ...p, source: 'instance' as const }));
 
@@ -653,23 +653,10 @@ export function PropertiesPanel() {
       return { occurrenceProperties: occ, inheritedTypeProperties: [] as PropertySet[] };
     }
 
-    const instanceByName = new Set(properties.map(p => p.name));
-    const inherited: PropertySet[] = [];
-
-    for (const typePset of typeProperties.psets) {
-      if (instanceByName.has(typePset.name)) {
-        // Pset exists at instance level - add type-only props that aren't overridden
-        const instancePset = properties.find(p => p.name === typePset.name)!;
-        const instancePropNames = new Set(instancePset.properties.map(p => p.name));
-        const extraProps = typePset.properties.filter(p => !instancePropNames.has(p.name));
-        if (extraProps.length > 0) {
-          inherited.push({ ...typePset, properties: extraProps, source: 'type' });
-        }
-      } else {
-        // Type-only pset - show fully in inherited section
-        inherited.push({ ...typePset, source: 'type' });
-      }
-    }
+    const inherited: PropertySet[] = typeProperties.psets.map(typePset => ({
+      ...typePset,
+      source: 'type' as const,
+    }));
 
     return { occurrenceProperties: occ, inheritedTypeProperties: inherited };
   }, [properties, typeProperties]);
@@ -808,6 +795,13 @@ export function PropertiesPanel() {
               {entityName || `${entityType}`}
             </h3>
             <p className="text-xs font-mono text-zinc-500 dark:text-zinc-400">{entityType}</p>
+            {/* Show associated type entity for occurrences */}
+            {!isTypeEntity && typeProperties && (
+              <p className="text-[11px] font-mono text-indigo-500 dark:text-indigo-400 truncate" title={`${activeDataStore?.entities.getTypeName(typeProperties.typeId) || 'Type'}: ${typeProperties.typeName}`}>
+                <Building2 className="inline h-3 w-3 mr-1 -mt-0.5" />
+                {activeDataStore?.entities.getTypeName(typeProperties.typeId) || 'Type'}: {typeProperties.typeName}
+              </p>
+            )}
           </div>
           <div className="flex gap-1 shrink-0">
             <Tooltip>
@@ -1131,7 +1125,7 @@ export function PropertiesPanel() {
                     )}
                     <div className="flex items-center gap-2 px-1 pb-0.5 text-[11px] text-indigo-600/70 dark:text-indigo-400/60 uppercase tracking-wider font-semibold">
                       <Building2 className="h-3 w-3 shrink-0" />
-                      <span className="truncate">Inherited Type Properties</span>
+                      <span className="truncate">Type Properties ({typeProperties.typeName})</span>
                     </div>
                     {inheritedTypeProperties.map((pset: PropertySet) => (
                       <PropertySetCard


### PR DESCRIPTION
## Summary
Changed the Properties Panel to always display all type property sets in the inherited section, even when the same property set exists at the occurrence (instance) level. Previously, only type-only properties that weren't overridden at the instance level were shown.

## Key Changes
- **Simplified property filtering logic**: Removed the complex logic that filtered out type properties when they were overridden at the instance level. Now all type property sets are always included in the inherited section.
- **Enhanced type entity visibility**: Added a new UI element that displays the associated type entity name and ID for occurrence entities, helping users understand which type defines the properties.
- **Updated section label**: Changed "Inherited Type Properties" to "Type Properties ({typeName})" to better reflect that all type properties are shown and to indicate which type they come from.

## Implementation Details
- The `inheritedTypeProperties` memo now simply maps all type property sets with a 'type' source, without any filtering based on instance-level overrides.
- Added a conditional display of the type entity information below the entity name/type, visible only for non-type entities when type properties exist.
- The Building2 icon is reused to maintain visual consistency with the type properties section header.

https://claude.ai/code/session_011xMK5HJf4GwmaZBvnzbXjG