### PR TITLE
Decode IFC strings in global ID and name extraction

### DIFF
--- a/packages/parser/src/columnar-parser.ts
+++ b/packages/parser/src/columnar-parser.ts
@@ -13,6 +13,7 @@ import type { EntityRef } from './types.js';
 import { SpatialHierarchyBuilder } from './spatial-hierarchy-builder.js';
 import { EntityExtractor } from './entity-extractor.js';
 import { extractLengthUnitScale } from './unit-extractor.js';
+import { decodeIfcString } from '@ifc-lite/encoding';
 import { getAttributeNames } from './ifc-schema.js';
 import { parsePropertyValue } from './on-demand-extractors.js';
 import { CompactEntityIndex, buildCompactEntityIndex } from './compact-entity-index.js';
@@ -349,9 +350,10 @@ function batchExtractGlobalIdAndName(
     // Phase 4: Build result map
     for (let i = 0; i < validIndices.length; i++) {
         const ref = refs[validIndices[i]];
+        const rawName = names[i] || '';
         result.set(ref.expressId, {
             globalId: gids[i] || '',
-            name: names[i] || '',
+            name: rawName ? decodeIfcString(rawName) : '',
         });
     }
 


### PR DESCRIPTION
## Summary
Added IFC string decoding to the `batchExtractGlobalIdAndName` function to properly handle encoded entity names during parsing.

## Key Changes
- Imported `decodeIfcString` from `@ifc-lite/encoding` package
- Modified the name extraction logic to decode IFC-encoded strings before storing them in the result map
- Refactored to store the raw name in a variable first, then conditionally decode it only if the name is non-empty

## Implementation Details
The change ensures that entity names extracted during the batch processing phase are properly decoded from their IFC string representation. This prevents encoded characters from being exposed in the final parsed data structure. The implementation maintains backward compatibility by preserving empty string behavior when no name is present.

https://claude.ai/code/session_01A7A9j4FUeeRGhB9VqBp4Ze

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved entity name decoding to properly handle IFC string formatting, ensuring names are correctly processed and displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->