### PR TITLE
fix: harden geometry stack usage for WASM

### DIFF
--- a/rust/geometry/src/csg.rs
+++ b/rust/geometry/src/csg.rs
@@ -109,11 +109,14 @@ impl Triangle {
     }
 }
 
+/// Maximum polygon count for either operand in a csgrs boolean operation.
+///
+/// Rectangular solids are 12 triangles, so this still allows the simple box-like
+/// boolean cases we expect while avoiding the complex BSP trees that can overflow
+/// the browser's native call stack in WASM.
+const MAX_CSG_POLYGONS_PER_MESH: usize = 24;
 /// Maximum combined polygon count for CSG operations.
-/// The csgrs BSP tree can infinite-recurse on certain polygon configurations
-/// (coplanar/near-coplanar faces cause repeated splitting with exponential growth).
-/// This limit prevents stack overflow in both native and WASM builds.
-const MAX_CSG_POLYGONS: usize = 2000;
+const MAX_CSG_POLYGONS: usize = MAX_CSG_POLYGONS_PER_MESH * 2;
 
 /// CSG Clipping Processor
 pub struct ClippingProcessor {
@@ -165,6 +168,25 @@ fn aabb_to_mesh(min: Point3<f64>, max: Point3<f64>) -> Mesh {
 }
 
 impl ClippingProcessor {
+    #[inline]
+    fn can_run_csgrs_operation(
+        csg_a: &csgrs::mesh::Mesh<()>,
+        csg_b: &csgrs::mesh::Mesh<()>,
+    ) -> bool {
+        let polygons_a = csg_a.polygons.len();
+        let polygons_b = csg_b.polygons.len();
+
+        if polygons_a < 4 || polygons_b < 4 {
+            return false;
+        }
+
+        if polygons_a > MAX_CSG_POLYGONS_PER_MESH || polygons_b > MAX_CSG_POLYGONS_PER_MESH {
+            return false;
+        }
+
+        polygons_a + polygons_b <= MAX_CSG_POLYGONS
+    }
+
     /// Create a new clipping processor
     pub fn new() -> Self {
         Self { epsilon: 1e-6 }
@@ -411,11 +433,7 @@ impl ClippingProcessor {
             let q2 = quantize(v2);
 
             // Three edges per triangle
-            for (qa, qb, pa, pb) in [
-                (q0, q1, *v0, *v1),
-                (q1, q2, *v1, *v2),
-                (q2, q0, *v2, *v0),
-            ] {
+            for (qa, qb, pa, pb) in [(q0, q1, *v0, *v1), (q1, q2, *v1, *v2), (q2, q0, *v2, *v0)] {
                 let key = make_edge_key(qa, qb);
                 edge_count
                     .entry(key)
@@ -443,8 +461,14 @@ impl ClippingProcessor {
         for (pa, pb) in &boundary_edges {
             let qa = quantize(pa);
             let qb = quantize(pb);
-            adjacency.entry(qa).or_default().push((qb.0, qb.1, qb.2, *pb));
-            adjacency.entry(qb).or_default().push((qa.0, qa.1, qa.2, *pa));
+            adjacency
+                .entry(qa)
+                .or_default()
+                .push((qb.0, qb.1, qb.2, *pb));
+            adjacency
+                .entry(qb)
+                .or_default()
+                .push((qa.0, qa.1, qa.2, *pa));
         }
 
         // Build ordered contour by walking the boundary
@@ -729,14 +753,9 @@ impl ClippingProcessor {
             return Ok(host_mesh.clone());
         }
 
-        // Additional validation: check for degenerate polygons that could cause panics
-        // Skip CSG if either mesh has suspicious polygon counts (too few for a solid)
-        if host_csg.polygons.len() < 4 || opening_csg.polygons.len() < 4 {
-            return Ok(host_mesh.clone());
-        }
-
-        // Safety: skip CSG if combined polygon count risks BSP infinite recursion
-        if host_csg.polygons.len() + opening_csg.polygons.len() > MAX_CSG_POLYGONS {
+        // Safety: only allow simple low-polygon CSG cases. Complex operands are
+        // left uncut rather than risking runaway BSP recursion in csgrs.
+        if !Self::can_run_csgrs_operation(&host_csg, &opening_csg) {
             return Ok(host_mesh.clone());
         }
 
@@ -758,19 +777,19 @@ impl ClippingProcessor {
                 let cleaned = Self::remove_degenerate_triangles(&result, host_mesh);
                 Ok(cleaned)
             }
-            Err(_) => Ok(host_mesh.clone())
+            Err(_) => Ok(host_mesh.clone()),
         }
     }
-    
+
     /// Remove degenerate triangles from CSG result
-    /// 
+    ///
     /// CSG operations can create thin "sliver" triangles at intersection boundaries
     /// due to numerical precision issues. This function removes triangles that:
     /// 1. Have very small area (thin slivers)
     /// 2. Are located inside the original host mesh bounds (not on the surface)
     fn remove_degenerate_triangles(mesh: &Mesh, host_mesh: &Mesh) -> Mesh {
         let (host_min, host_max) = host_mesh.bounds();
-        
+
         // Convert host bounds to f64 for calculations
         let host_min_x = host_min.x as f64;
         let host_min_y = host_min.y as f64;
@@ -778,17 +797,17 @@ impl ClippingProcessor {
         let host_max_x = host_max.x as f64;
         let host_max_y = host_max.y as f64;
         let host_max_z = host_max.z as f64;
-        
+
         // Calculate host dimensions to determine appropriate thresholds
         let host_size_x = (host_max_x - host_min_x).abs();
         let host_size_y = (host_max_y - host_min_y).abs();
         let host_size_z = (host_max_z - host_min_z).abs();
         let min_dim = host_size_x.min(host_size_y).min(host_size_z);
-        
+
         // Minimum area threshold - triangles smaller than this are likely artifacts
         // Use 0.1% of the smallest host dimension squared
         let min_area = (min_dim * 0.001).powi(2);
-        
+
         // Distance threshold for "inside" detection
         let epsilon = min_dim * 0.01;
 
@@ -825,36 +844,44 @@ impl ClippingProcessor {
                 mesh.positions[i2 * 3 + 1] as f64,
                 mesh.positions[i2 * 3 + 2] as f64,
             );
-            
+
             // Calculate triangle area using cross product
             let edge1 = v1 - v0;
             let edge2 = v2 - v0;
             let cross = edge1.cross(&edge2);
             let area = cross.norm() / 2.0;
-            
+
             // Check if triangle is degenerate (very small area)
             if area < min_area {
                 continue;
             }
-            
+
             // Check if any vertex is significantly OUTSIDE the host bounds
             // This catches CSG artifacts that create long thin triangles extending far from the model
             let expansion = min_dim.max(1.0); // At least 1 meter expansion allowed
-            let far_outside = 
-                v0.x < (host_min_x - expansion) || v0.x > (host_max_x + expansion) ||
-                v0.y < (host_min_y - expansion) || v0.y > (host_max_y + expansion) ||
-                v0.z < (host_min_z - expansion) || v0.z > (host_max_z + expansion) ||
-                v1.x < (host_min_x - expansion) || v1.x > (host_max_x + expansion) ||
-                v1.y < (host_min_y - expansion) || v1.y > (host_max_y + expansion) ||
-                v1.z < (host_min_z - expansion) || v1.z > (host_max_z + expansion) ||
-                v2.x < (host_min_x - expansion) || v2.x > (host_max_x + expansion) ||
-                v2.y < (host_min_y - expansion) || v2.y > (host_max_y + expansion) ||
-                v2.z < (host_min_z - expansion) || v2.z > (host_max_z + expansion);
-            
+            let far_outside = v0.x < (host_min_x - expansion)
+                || v0.x > (host_max_x + expansion)
+                || v0.y < (host_min_y - expansion)
+                || v0.y > (host_max_y + expansion)
+                || v0.z < (host_min_z - expansion)
+                || v0.z > (host_max_z + expansion)
+                || v1.x < (host_min_x - expansion)
+                || v1.x > (host_max_x + expansion)
+                || v1.y < (host_min_y - expansion)
+                || v1.y > (host_max_y + expansion)
+                || v1.z < (host_min_z - expansion)
+                || v1.z > (host_max_z + expansion)
+                || v2.x < (host_min_x - expansion)
+                || v2.x > (host_max_x + expansion)
+                || v2.y < (host_min_y - expansion)
+                || v2.y > (host_max_y + expansion)
+                || v2.z < (host_min_z - expansion)
+                || v2.z > (host_max_z + expansion);
+
             if far_outside {
                 continue;
             }
-            
+
             // Check if triangle center is strictly inside the host bounds
             // (not on the surface) - these are likely CSG artifacts
             let center = Point3::new(
@@ -862,19 +889,19 @@ impl ClippingProcessor {
                 (v0.y + v1.y + v2.y) / 3.0,
                 (v0.z + v1.z + v2.z) / 3.0,
             );
-            
+
             // Check if center is inside host bounds (with epsilon margin)
             let inside_x = center.x > (host_min_x + epsilon) && center.x < (host_max_x - epsilon);
             let inside_y = center.y > (host_min_y + epsilon) && center.y < (host_max_y - epsilon);
             let inside_z = center.z > (host_min_z + epsilon) && center.z < (host_max_z - epsilon);
-            
+
             // If triangle is strictly inside the host in ALL dimensions, it's likely an artifact
             // Only remove if it's also relatively small
             let max_area = min_dim * min_dim * 0.1; // 10% of smallest dimension squared
             if inside_x && inside_y && inside_z && area < max_area {
                 continue;
             }
-            
+
             // Get normals
             let n0 = Vector3::new(
                 mesh.normals[i0 * 3] as f64,
@@ -891,7 +918,7 @@ impl ClippingProcessor {
                 mesh.normals[i2 * 3 + 1] as f64,
                 mesh.normals[i2 * 3 + 2] as f64,
             );
-            
+
             // Add valid triangle to cleaned mesh
             let base_idx = cleaned.vertex_count() as u32;
             cleaned.add_vertex(v0, n0);
@@ -899,7 +926,7 @@ impl ClippingProcessor {
             cleaned.add_vertex(v2, n2);
             cleaned.add_triangle(base_idx, base_idx + 1, base_idx + 2);
         }
-        
+
         cleaned
     }
 
@@ -955,15 +982,19 @@ impl ClippingProcessor {
             let tri_max_y = v0.y.max(v1.y).max(v2.y);
             let tri_min_z = v0.z.min(v1.z).min(v2.z);
             let tri_max_z = v0.z.max(v1.z).max(v2.z);
-            
+
             // Check if triangle is completely inside opening bounds (remove it)
-            if tri_min_x >= open_min.x && tri_max_x <= open_max.x &&
-               tri_min_y >= open_min.y && tri_max_y <= open_max.y &&
-               tri_min_z >= open_min.z && tri_max_z <= open_max.z {
+            if tri_min_x >= open_min.x
+                && tri_max_x <= open_max.x
+                && tri_min_y >= open_min.y
+                && tri_max_y <= open_max.y
+                && tri_min_z >= open_min.z
+                && tri_max_z <= open_max.z
+            {
                 // Triangle is inside opening - remove it
                 continue;
             }
-            
+
             // Triangle is not completely inside - keep it
             let n0 = Vector3::new(
                 mesh.normals[i0 * 3] as f64,
@@ -980,14 +1011,14 @@ impl ClippingProcessor {
                 mesh.normals[i2 * 3 + 1] as f64,
                 mesh.normals[i2 * 3 + 2] as f64,
             );
-            
+
             let base_idx = cleaned.vertex_count() as u32;
             cleaned.add_vertex(v0, n0);
             cleaned.add_vertex(v1, n1);
             cleaned.add_vertex(v2, n2);
             cleaned.add_triangle(base_idx, base_idx + 1, base_idx + 2);
         }
-        
+
         cleaned
     }
 
@@ -1014,15 +1045,7 @@ impl ClippingProcessor {
             return Ok(merged);
         }
 
-        // Skip CSG if either mesh has too few polygons for a valid solid
-        if csg_a.polygons.len() < 4 || csg_b.polygons.len() < 4 {
-            let mut merged = mesh_a.clone();
-            merged.merge(mesh_b);
-            return Ok(merged);
-        }
-
-        // Safety: skip CSG if combined polygon count risks BSP infinite recursion
-        if csg_a.polygons.len() + csg_b.polygons.len() > MAX_CSG_POLYGONS {
+        if !Self::can_run_csgrs_operation(&csg_a, &csg_b) {
             let mut merged = mesh_a.clone();
             merged.merge(mesh_b);
             return Ok(merged);
@@ -1055,14 +1078,8 @@ impl ClippingProcessor {
             return Ok(Mesh::new());
         }
 
-        // Skip CSG if either mesh has too few polygons for a valid solid
-        if csg_a.polygons.len() < 4 || csg_b.polygons.len() < 4 {
+        if !Self::can_run_csgrs_operation(&csg_a, &csg_b) {
             return Ok(Mesh::new());
-        }
-
-        // Safety: skip CSG if combined polygon count risks BSP infinite recursion
-        if csg_a.polygons.len() + csg_b.polygons.len() > MAX_CSG_POLYGONS {
-            return Ok(mesh_a.clone());
         }
 
         // Perform CSG intersection
@@ -1354,7 +1371,9 @@ pub fn calculate_normals(mesh: &mut Mesh) {
     mesh.normals.reserve(vertex_count * 3);
 
     for normal in normals {
-        let normalized = normal.try_normalize(1e-6).unwrap_or_else(|| Vector3::new(0.0, 0.0, 1.0));
+        let normalized = normal
+            .try_normalize(1e-6)
+            .unwrap_or_else(|| Vector3::new(0.0, 0.0, 1.0));
         mesh.normals.push(normalized.x as f32);
         mesh.normals.push(normalized.y as f32);
         mesh.normals.push(normalized.z as f32);
@@ -1464,5 +1483,30 @@ mod tests {
 
         let area = triangle.area();
         assert!((area - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_csgrs_operation_guard_allows_simple_boxes() {
+        let box_a = aabb_to_mesh(Point3::new(0.0, 0.0, 0.0), Point3::new(1.0, 1.0, 1.0));
+        let box_b = aabb_to_mesh(Point3::new(0.25, 0.25, 0.25), Point3::new(0.75, 0.75, 0.75));
+
+        let csg_a = ClippingProcessor::mesh_to_csgrs(&box_a).unwrap();
+        let csg_b = ClippingProcessor::mesh_to_csgrs(&box_b).unwrap();
+
+        assert!(ClippingProcessor::can_run_csgrs_operation(&csg_a, &csg_b));
+    }
+
+    #[test]
+    fn test_csgrs_operation_guard_rejects_complex_operands() {
+        let box_mesh = aabb_to_mesh(Point3::new(0.0, 0.0, 0.0), Point3::new(1.0, 1.0, 1.0));
+        let mut complex_mesh = Mesh::new();
+        complex_mesh.merge(&box_mesh);
+        complex_mesh.merge(&box_mesh);
+        complex_mesh.merge(&box_mesh);
+
+        let csg_a = ClippingProcessor::mesh_to_csgrs(&complex_mesh).unwrap();
+        let csg_b = ClippingProcessor::mesh_to_csgrs(&box_mesh).unwrap();
+
+        assert!(!ClippingProcessor::can_run_csgrs_operation(&csg_a, &csg_b));
     }
 }

--- a/rust/geometry/src/router/clipping.rs
+++ b/rust/geometry/src/router/clipping.rs
@@ -8,6 +8,10 @@ use super::GeometryRouter;
 use crate::{Error, Mesh, Point3, Result, Vector3};
 use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcType};
 use nalgebra::Matrix4;
+use rustc_hash::FxHashSet;
+
+/// Maximum IfcBooleanClippingResult chain depth we will follow when extracting a base profile.
+const MAX_CLIPPING_DEPTH: usize = 32;
 
 impl GeometryRouter {
     /// Quick check if an element has clipping planes (IfcBooleanClippingResult in representation)
@@ -89,19 +93,24 @@ impl GeometryRouter {
         let mut clipping_planes: Vec<(Point3<f64>, Vector3<f64>, bool)> = Vec::new();
 
         // Get representation
-        let representation_attr = element.get(6)
+        let representation_attr = element
+            .get(6)
             .ok_or_else(|| Error::geometry("Element missing representation".to_string()))?;
 
-        let representation = decoder.resolve_ref(representation_attr)?
+        let representation = decoder
+            .resolve_ref(representation_attr)?
             .ok_or_else(|| Error::geometry("Failed to resolve representation".to_string()))?;
 
         if representation.ifc_type != IfcType::IfcProductDefinitionShape {
             // Fallback: can't extract profile, return error
-            return Err(Error::geometry("Element representation is not ProductDefinitionShape".to_string()));
+            return Err(Error::geometry(
+                "Element representation is not ProductDefinitionShape".to_string(),
+            ));
         }
 
         // Get representations list
-        let representations_attr = representation.get(2)
+        let representations_attr = representation
+            .get(2)
             .ok_or_else(|| Error::geometry("Missing representations".to_string()))?;
 
         let representations = decoder.resolve_ref_list(representations_attr)?;
@@ -139,7 +148,9 @@ impl GeometryRouter {
         }
 
         // Fallback: couldn't find extruded solid
-        Err(Error::geometry("Could not find IfcExtrudedAreaSolid in representation".to_string()))
+        Err(Error::geometry(
+            "Could not find IfcExtrudedAreaSolid in representation".to_string(),
+        ))
     }
 
     /// Extract profile from IfcBooleanClippingResult recursively
@@ -158,42 +169,56 @@ impl GeometryRouter {
         use nalgebra::Vector3;
 
         let mut clipping_planes: Vec<(Point3<f64>, Vector3<f64>, bool)> = Vec::new();
+        let mut current = boolean_result.clone();
+        let mut visited = FxHashSet::default();
 
-        // Get FirstOperand (the base geometry or another boolean result)
-        let first_operand_attr = boolean_result.get(1)
-            .ok_or_else(|| Error::geometry("BooleanResult missing FirstOperand".to_string()))?;
+        for _depth in 0..MAX_CLIPPING_DEPTH {
+            if !visited.insert(current.id) {
+                return Err(Error::geometry(format!(
+                    "Detected cyclic IfcBooleanClippingResult reference at #{}",
+                    current.id
+                )));
+            }
 
-        let first_operand = decoder.resolve_ref(first_operand_attr)?
-            .ok_or_else(|| Error::geometry("Failed to resolve FirstOperand".to_string()))?;
-
-        // Get SecondOperand (the clipping solid - usually IfcHalfSpaceSolid)
-        if let Some(second_operand_attr) = boolean_result.get(2) {
-            if let Ok(Some(second_operand)) = decoder.resolve_ref(second_operand_attr) {
-                if let Some(clip) = self.extract_half_space_plane(&second_operand, decoder) {
-                    clipping_planes.push(clip);
+            // Get SecondOperand (the clipping solid - usually IfcHalfSpaceSolid)
+            if let Some(second_operand_attr) = current.get(2) {
+                if let Ok(Some(second_operand)) = decoder.resolve_ref(second_operand_attr) {
+                    if let Some(clip) = self.extract_half_space_plane(&second_operand, decoder) {
+                        clipping_planes.push(clip);
+                    }
                 }
             }
-        }
 
-        // Process FirstOperand
-        if first_operand.ifc_type == IfcType::IfcBooleanClippingResult {
-            // Recursively process nested boolean results
-            let (profile, depth, axis, origin, transform, nested_clips) =
-                self.extract_profile_from_boolean_result(&first_operand, decoder)?;
-            clipping_planes.extend(nested_clips);
-            return Ok((profile, depth, axis, origin, transform, clipping_planes));
-        }
+            // Get FirstOperand (the base geometry or another boolean result)
+            let first_operand_attr = current
+                .get(1)
+                .ok_or_else(|| Error::geometry("BooleanResult missing FirstOperand".to_string()))?;
 
-        // FirstOperand should be IfcExtrudedAreaSolid
-        if first_operand.ifc_type == IfcType::IfcExtrudedAreaSolid {
-            let (profile, depth, axis, origin, transform) =
-                self.extract_profile_from_extruded_solid(&first_operand, decoder)?;
-            return Ok((profile, depth, axis, origin, transform, clipping_planes));
+            let first_operand = decoder
+                .resolve_ref(first_operand_attr)?
+                .ok_or_else(|| Error::geometry("Failed to resolve FirstOperand".to_string()))?;
+
+            if first_operand.ifc_type == IfcType::IfcBooleanClippingResult {
+                current = first_operand;
+                continue;
+            }
+
+            // FirstOperand should be IfcExtrudedAreaSolid
+            if first_operand.ifc_type == IfcType::IfcExtrudedAreaSolid {
+                let (profile, depth, axis, origin, transform) =
+                    self.extract_profile_from_extruded_solid(&first_operand, decoder)?;
+                return Ok((profile, depth, axis, origin, transform, clipping_planes));
+            }
+
+            return Err(Error::geometry(format!(
+                "Unsupported base solid type in boolean result: {:?}",
+                first_operand.ifc_type
+            )));
         }
 
         Err(Error::geometry(format!(
-            "Unsupported base solid type in boolean result: {:?}",
-            first_operand.ifc_type
+            "IfcBooleanClippingResult nesting exceeded maximum depth of {} at #{}",
+            MAX_CLIPPING_DEPTH, current.id
         )))
     }
 
@@ -202,34 +227,47 @@ impl GeometryRouter {
         &self,
         extruded_solid: &DecodedEntity,
         decoder: &mut EntityDecoder,
-    ) -> Result<(crate::profile::Profile2D, f64, u8, f64, Option<Matrix4<f64>>)> {
+    ) -> Result<(
+        crate::profile::Profile2D,
+        f64,
+        u8,
+        f64,
+        Option<Matrix4<f64>>,
+    )> {
         // Get SweptArea (attribute 0: IfcProfileDef)
-        let swept_area_attr = extruded_solid.get(0)
+        let swept_area_attr = extruded_solid
+            .get(0)
             .ok_or_else(|| Error::geometry("ExtrudedAreaSolid missing SweptArea".to_string()))?;
 
-        let profile_entity = decoder.resolve_ref(swept_area_attr)?
+        let profile_entity = decoder
+            .resolve_ref(swept_area_attr)?
             .ok_or_else(|| Error::geometry("Failed to resolve SweptArea".to_string()))?;
 
         // Extract the actual 2D profile (preserves chamfered corners!)
         let profile = self.extract_profile_2d(&profile_entity, decoder)?;
 
         // Get depth (attribute 3: Depth)
-        let depth = extruded_solid.get_float(3)
+        let depth = extruded_solid
+            .get_float(3)
             .ok_or_else(|| Error::geometry("ExtrudedAreaSolid missing Depth".to_string()))?;
 
         // Get ExtrudedDirection (attribute 2: IfcDirection)
         // This tells us which axis is the thickness axis
-        let direction_attr = extruded_solid.get(2)
-            .ok_or_else(|| Error::geometry("ExtrudedAreaSolid missing ExtrudedDirection".to_string()))?;
+        let direction_attr = extruded_solid.get(2).ok_or_else(|| {
+            Error::geometry("ExtrudedAreaSolid missing ExtrudedDirection".to_string())
+        })?;
 
-        let direction_entity = decoder.resolve_ref(direction_attr)?
+        let direction_entity = decoder
+            .resolve_ref(direction_attr)?
             .ok_or_else(|| Error::geometry("Failed to resolve ExtrudedDirection".to_string()))?;
 
         // Get direction coordinates (attribute 0: DirectionRatios)
-        let ratios_attr = direction_entity.get(0)
+        let ratios_attr = direction_entity
+            .get(0)
             .ok_or_else(|| Error::geometry("Direction missing DirectionRatios".to_string()))?;
 
-        let ratios = ratios_attr.as_list()
+        let ratios = ratios_attr
+            .as_list()
             .ok_or_else(|| Error::geometry("DirectionRatios is not a list".to_string()))?;
 
         let dx = ratios.get(0).and_then(|v| v.as_float()).unwrap_or(0.0);
@@ -271,7 +309,13 @@ impl GeometryRouter {
             None
         };
 
-        Ok((profile, depth, thickness_axis, wall_origin, position_transform))
+        Ok((
+            profile,
+            depth,
+            thickness_axis,
+            wall_origin,
+            position_transform,
+        ))
     }
 
     /// Extract base mesh from IfcBooleanClippingResult and collect clipping planes
@@ -286,10 +330,12 @@ impl GeometryRouter {
         let mut clipping_planes: Vec<(Point3<f64>, Vector3<f64>, bool)> = Vec::new();
 
         // Get FirstOperand (the base geometry or another boolean result)
-        let first_operand_attr = boolean_result.get(1)
+        let first_operand_attr = boolean_result
+            .get(1)
             .ok_or_else(|| Error::geometry("BooleanResult missing FirstOperand".to_string()))?;
 
-        let first_operand = decoder.resolve_ref(first_operand_attr)?
+        let first_operand = decoder
+            .resolve_ref(first_operand_attr)?
             .ok_or_else(|| Error::geometry("Failed to resolve FirstOperand".to_string()))?;
 
         // Get SecondOperand (the clipping solid - usually IfcHalfSpaceSolid)
@@ -304,7 +350,8 @@ impl GeometryRouter {
         // Process FirstOperand
         if first_operand.ifc_type == IfcType::IfcBooleanClippingResult {
             // Recursively process nested boolean results
-            let (base_mesh, nested_clips) = self.extract_base_from_boolean_result(&first_operand, decoder)?;
+            let (base_mesh, nested_clips) =
+                self.extract_base_from_boolean_result(&first_operand, decoder)?;
             clipping_planes.extend(nested_clips);
             return Ok((base_mesh, clipping_planes));
         }
@@ -332,7 +379,8 @@ impl GeometryRouter {
         use nalgebra::Vector3;
 
         if half_space.ifc_type != IfcType::IfcHalfSpaceSolid
-            && half_space.ifc_type != IfcType::IfcPolygonalBoundedHalfSpace {
+            && half_space.ifc_type != IfcType::IfcPolygonalBoundedHalfSpace
+        {
             return None;
         }
 
@@ -386,7 +434,8 @@ impl GeometryRouter {
         };
 
         // Get AgreementFlag - stored as Enum "T" or "F"
-        let agreement = half_space.get(1)
+        let agreement = half_space
+            .get(1)
             .map(|v| match v {
                 ifc_lite_core::AttributeValue::Enum(e) => e != "F" && e != ".F.",
                 _ => true,

--- a/rust/geometry/src/router/processing.rs
+++ b/rust/geometry/src/router/processing.rs
@@ -8,7 +8,11 @@ use super::GeometryRouter;
 use crate::{Error, Mesh, Result, SubMeshCollection};
 use ifc_lite_core::{has_geometry_by_name, DecodedEntity, EntityDecoder, GeometryCategory, IfcType};
 use nalgebra::Matrix4;
+use rustc_hash::FxHashSet;
 use std::sync::Arc;
+
+/// Maximum nested IfcMappedItem depth we will traverse for a single geometry item.
+const MAX_MAPPED_ITEM_DEPTH: usize = 32;
 
 impl GeometryRouter {
     /// Compute median-based RTC offset from sampled translations.
@@ -27,7 +31,11 @@ impl GeometryRouter {
         z.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
 
         let mid = x.len() / 2;
-        let centroid = (*x.get(mid).unwrap_or(&0.0), *y.get(mid).unwrap_or(&0.0), *z.get(mid).unwrap_or(&0.0));
+        let centroid = (
+            *x.get(mid).unwrap_or(&0.0),
+            *y.get(mid).unwrap_or(&0.0),
+            *z.get(mid).unwrap_or(&0.0),
+        );
 
         const THRESHOLD: f64 = 10000.0;
         if centroid.0.abs() > THRESHOLD
@@ -390,8 +398,34 @@ impl GeometryRouter {
         decoder: &mut EntityDecoder,
         sub_meshes: &mut SubMeshCollection,
     ) -> Result<()> {
+        let mut visited = FxHashSet::default();
+        self.collect_submeshes_from_item_inner(item, decoder, sub_meshes, 0, &mut visited)
+    }
+
+    fn collect_submeshes_from_item_inner(
+        &self,
+        item: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+        sub_meshes: &mut SubMeshCollection,
+        depth: usize,
+        visited: &mut FxHashSet<u32>,
+    ) -> Result<()> {
+        if depth >= MAX_MAPPED_ITEM_DEPTH {
+            return Err(Error::geometry(format!(
+                "MappedItem nesting exceeded maximum depth of {} at #{}",
+                MAX_MAPPED_ITEM_DEPTH, item.id
+            )));
+        }
+
         // For MappedItem, recurse into the mapped representation
         if item.ifc_type == IfcType::IfcMappedItem {
+            if !visited.insert(item.id) {
+                return Err(Error::geometry(format!(
+                    "Detected cyclic IfcMappedItem reference at #{}",
+                    item.id
+                )));
+            }
+
             // Get MappingSource (RepresentationMap)
             let source_attr = item
                 .get(0)
@@ -402,13 +436,13 @@ impl GeometryRouter {
                 .ok_or_else(|| Error::geometry("Failed to resolve MappingSource".to_string()))?;
 
             // Get MappedRepresentation from RepresentationMap (attribute 1)
-            let mapped_repr_attr = source_entity
-                .get(1)
-                .ok_or_else(|| Error::geometry("RepresentationMap missing MappedRepresentation".to_string()))?;
+            let mapped_repr_attr = source_entity.get(1).ok_or_else(|| {
+                Error::geometry("RepresentationMap missing MappedRepresentation".to_string())
+            })?;
 
-            let mapped_repr = decoder
-                .resolve_ref(mapped_repr_attr)?
-                .ok_or_else(|| Error::geometry("Failed to resolve MappedRepresentation".to_string()))?;
+            let mapped_repr = decoder.resolve_ref(mapped_repr_attr)?.ok_or_else(|| {
+                Error::geometry("Failed to resolve MappedRepresentation".to_string())
+            })?;
 
             // Get MappingTarget transformation
             let mapping_transform = if let Some(target_attr) = item.get(1) {
@@ -431,9 +465,13 @@ impl GeometryRouter {
                 for nested_item in items {
                     // Recursively collect sub-meshes (skip unsupported geometry types)
                     let count_before = sub_meshes.len();
-                    if let Err(_e) = self
-                        .collect_submeshes_from_item(&nested_item, decoder, sub_meshes)
-                    {
+                    if let Err(_e) = self.collect_submeshes_from_item_inner(
+                        &nested_item,
+                        decoder,
+                        sub_meshes,
+                        depth + 1,
+                        visited,
+                    ) {
                         #[cfg(debug_assertions)]
                         eprintln!(
                             "[ifc-lite] Skipping unsupported nested geometry #{} ({:?}): {}",
@@ -451,6 +489,8 @@ impl GeometryRouter {
                     }
                 }
             }
+
+            visited.remove(&item.id);
         } else {
             // Regular geometry item - process and record with its ID
             // Skip unsupported geometry types (e.g. IfcGeometricSet) instead of failing

--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -9,7 +9,7 @@ use crate::csg::{ClippingProcessor, Plane, Triangle, TriangleVec};
 use crate::{Error, Mesh, Point3, Result, Vector3};
 use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcType};
 use nalgebra::Matrix4;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 /// Epsilon for normalizing direction vectors (guards against zero-length).
 const NORMALIZE_EPSILON: f64 = 1e-12;
@@ -22,6 +22,8 @@ const MIN_OPENING_VOLUME: f64 = 0.0001;
 const CSG_TRIANGLE_RETENTION_DIVISOR: usize = 4;
 /// Minimum triangle count for a valid CSG result.
 const MIN_VALID_TRIANGLES: usize = 4;
+/// Maximum wrapper depth when drilling through mapped/boolean items to find an extrusion.
+const MAX_EXTRUSION_EXTRACT_DEPTH: usize = 32;
 
 /// Extract rotation columns from a 4x4 transform matrix.
 fn extract_rotation_columns(m: &Matrix4<f64>) -> (Vector3<f64>, Vector3<f64>, Vector3<f64>) {
@@ -46,9 +48,17 @@ fn rotate_and_normalize(
 fn is_body_representation(rep_type: &str) -> bool {
     matches!(
         rep_type,
-        "Body" | "SweptSolid" | "Brep" | "CSG" | "Clipping" | "Tessellation"
-            | "MappedRepresentation" | "SolidModel" | "SurfaceModel"
-            | "AdvancedSweptSolid" | "AdvancedBrep"
+        "Body"
+            | "SweptSolid"
+            | "Brep"
+            | "CSG"
+            | "Clipping"
+            | "Tessellation"
+            | "MappedRepresentation"
+            | "SolidModel"
+            | "SurfaceModel"
+            | "AdvancedSweptSolid"
+            | "AdvancedBrep"
     )
 }
 
@@ -145,58 +155,66 @@ impl GeometryRouter {
         item: &DecodedEntity,
         decoder: &mut EntityDecoder,
     ) -> Option<(Vector3<f64>, Option<Matrix4<f64>>)> {
-        match item.ifc_type {
-            IfcType::IfcExtrudedAreaSolid => {
-                // Direct extraction from ExtrudedDirection (attribute 2) and Position (attribute 1)
-                self.extract_extrusion_direction_from_solid(item, decoder)
-            }
-            IfcType::IfcBooleanClippingResult | IfcType::IfcBooleanResult => {
-                // FirstOperand (attribute 1) contains base geometry
-                let first_attr = item.get(1)?;
-                let first_operand = decoder.resolve_ref(first_attr).ok()??;
-                self.extract_extrusion_direction_recursive(&first_operand, decoder)
-            }
-            IfcType::IfcMappedItem => {
-                // MappingSource (attribute 0) -> MappedRepresentation -> Items
-                let source_attr = item.get(0)?;
-                let source = decoder.resolve_ref(source_attr).ok()??;
-                // RepresentationMap.MappedRepresentation is attribute 1
-                let rep_attr = source.get(1)?;
-                let rep = decoder.resolve_ref(rep_attr).ok()??;
+        let mut current = item.clone();
+        let mut visited = FxHashSet::default();
+        let mut mapping_chain: Option<Matrix4<f64>> = None;
 
-                // MappingTarget (attribute 1) -> instance transform
-                let mapping_transform = if let Some(target_attr) = item.get(1) {
-                    if !target_attr.is_null() {
-                        if let Ok(Some(target)) = decoder.resolve_ref(target_attr) {
-                            self.parse_cartesian_transformation_operator(&target, decoder).ok()
-                        } else {
-                            None
+        for _depth in 0..MAX_EXTRUSION_EXTRACT_DEPTH {
+            if !visited.insert(current.id) {
+                return None;
+            }
+
+            match current.ifc_type {
+                IfcType::IfcExtrudedAreaSolid => {
+                    let (dir, position_transform) =
+                        self.extract_extrusion_direction_from_solid(&current, decoder)?;
+                    let combined = match (mapping_chain.as_ref(), position_transform) {
+                        (Some(chain), Some(pos)) => Some(chain * pos),
+                        (Some(chain), None) => Some(chain.clone()),
+                        (None, Some(pos)) => Some(pos),
+                        (None, None) => None,
+                    };
+                    return Some((dir, combined));
+                }
+                IfcType::IfcBooleanClippingResult | IfcType::IfcBooleanResult => {
+                    // FirstOperand (attribute 1) contains base geometry
+                    let first_attr = current.get(1)?;
+                    current = decoder.resolve_ref(first_attr).ok()??;
+                }
+                IfcType::IfcMappedItem => {
+                    // MappingSource (attribute 0) -> MappedRepresentation -> Items
+                    let source_attr = current.get(0)?;
+                    let source = decoder.resolve_ref(source_attr).ok()??;
+                    // RepresentationMap.MappedRepresentation is attribute 1
+                    let rep_attr = source.get(1)?;
+                    let rep = decoder.resolve_ref(rep_attr).ok()??;
+
+                    // MappingTarget (attribute 1) -> instance transform
+                    if let Some(target_attr) = current.get(1) {
+                        if !target_attr.is_null() {
+                            if let Ok(Some(target)) = decoder.resolve_ref(target_attr) {
+                                if let Ok(map) =
+                                    self.parse_cartesian_transformation_operator(&target, decoder)
+                                {
+                                    mapping_chain = Some(match mapping_chain.take() {
+                                        Some(chain) => chain * map,
+                                        None => map,
+                                    });
+                                }
+                            }
                         }
-                    } else {
-                        None
                     }
-                } else {
-                    None
-                };
 
-                // Get first item from representation
-                let items_attr = rep.get(3)?;
-                let items = decoder.resolve_ref_list(items_attr).ok()?;
-                items.first().and_then(|first| {
-                    self.extract_extrusion_direction_recursive(first, decoder).map(|(dir, pos)| {
-                        // Combine MappingTarget transform with position transform
-                        let combined = match (mapping_transform.as_ref(), pos) {
-                            (Some(map), Some(pos)) => Some(map * pos),
-                            (Some(map), None) => Some(map.clone()),
-                            (None, Some(pos)) => Some(pos),
-                            (None, None) => None,
-                        };
-                        (dir, combined)
-                    })
-                })
+                    // Get first item from representation
+                    let items_attr = rep.get(3)?;
+                    let items = decoder.resolve_ref_list(items_attr).ok()?;
+                    current = items.first()?.clone();
+                }
+                _ => return None,
             }
-            _ => None,
         }
+
+        None
     }
 
     /// Get per-item meshes for an opening element, transformed to world coordinates.
@@ -214,7 +232,8 @@ impl GeometryRouter {
             return Ok(vec![]);
         }
 
-        let representation = decoder.resolve_ref(representation_attr)?
+        let representation = decoder
+            .resolve_ref(representation_attr)?
             .ok_or_else(|| Error::geometry("Failed to resolve representation".to_string()))?;
         let representations_attr = representation.get(2).ok_or_else(|| {
             Error::geometry("ProductDefinitionShape missing Representations".to_string())
@@ -222,7 +241,8 @@ impl GeometryRouter {
         let representations = decoder.resolve_ref_list(representations_attr)?;
 
         // Get the same placement transform that apply_placement uses
-        let mut placement_transform = self.get_placement_transform_from_element(element, decoder)
+        let mut placement_transform = self
+            .get_placement_transform_from_element(element, decoder)
             .unwrap_or_else(|_| Matrix4::identity());
         self.scale_transform(&mut placement_transform);
 
@@ -293,7 +313,8 @@ impl GeometryRouter {
         let representations = decoder.resolve_ref_list(representations_attr)?;
 
         // Get placement transform
-        let mut placement_transform = self.get_placement_transform_from_element(element, decoder)
+        let mut placement_transform = self
+            .get_placement_transform_from_element(element, decoder)
             .unwrap_or_else(|_| Matrix4::identity());
         self.scale_transform(&mut placement_transform);
 
@@ -371,19 +392,38 @@ impl GeometryRouter {
                 ];
 
                 // Transform all corners and compute new AABB
-                let transformed: Vec<Point3<f64>> = corners.iter()
+                let transformed: Vec<Point3<f64>> = corners
+                    .iter()
                     .map(|p| placement_transform.transform_point(p))
                     .collect();
 
                 let world_min = Point3::new(
-                    transformed.iter().map(|p| p.x).fold(f64::INFINITY, f64::min),
-                    transformed.iter().map(|p| p.y).fold(f64::INFINITY, f64::min),
-                    transformed.iter().map(|p| p.z).fold(f64::INFINITY, f64::min),
+                    transformed
+                        .iter()
+                        .map(|p| p.x)
+                        .fold(f64::INFINITY, f64::min),
+                    transformed
+                        .iter()
+                        .map(|p| p.y)
+                        .fold(f64::INFINITY, f64::min),
+                    transformed
+                        .iter()
+                        .map(|p| p.z)
+                        .fold(f64::INFINITY, f64::min),
                 );
                 let world_max = Point3::new(
-                    transformed.iter().map(|p| p.x).fold(f64::NEG_INFINITY, f64::max),
-                    transformed.iter().map(|p| p.y).fold(f64::NEG_INFINITY, f64::max),
-                    transformed.iter().map(|p| p.z).fold(f64::NEG_INFINITY, f64::max),
+                    transformed
+                        .iter()
+                        .map(|p| p.x)
+                        .fold(f64::NEG_INFINITY, f64::max),
+                    transformed
+                        .iter()
+                        .map(|p| p.y)
+                        .fold(f64::NEG_INFINITY, f64::max),
+                    transformed
+                        .iter()
+                        .map(|p| p.z)
+                        .fold(f64::NEG_INFINITY, f64::max),
                 );
 
                 // Apply RTC offset to opening bounds so they match wall mesh coordinate system
@@ -437,7 +477,6 @@ impl GeometryRouter {
         decoder: &mut EntityDecoder,
         void_index: &FxHashMap<u32, Vec<u32>>,
     ) -> Result<Mesh> {
-
         let opening_ids = match void_index.get(&element.id) {
             Some(ids) if !ids.is_empty() => ids,
             _ => {
@@ -455,10 +494,11 @@ impl GeometryRouter {
         let world_clipping_planes: Vec<(Point3<f64>, Vector3<f64>, bool)> =
             if self.has_clipping_planes(element, decoder) {
                 // Get element's ObjectPlacement transform (for clipping planes)
-                let mut object_placement_transform = match self.get_placement_transform_from_element(element, decoder) {
-                    Ok(t) => t,
-                    Err(_) => Matrix4::identity(),
-                };
+                let mut object_placement_transform =
+                    match self.get_placement_transform_from_element(element, decoder) {
+                        Ok(t) => t,
+                        Err(_) => Matrix4::identity(),
+                    };
                 self.scale_transform(&mut object_placement_transform);
 
                 // Extract clipping planes (for roof clips)
@@ -536,7 +576,9 @@ impl GeometryRouter {
             match opening {
                 OpeningType::Rectangular(open_min, open_max, extrusion_dir) => {
                     let (final_min, final_max) = if let Some(dir) = extrusion_dir {
-                        self.extend_opening_along_direction(*open_min, *open_max, wall_min, wall_max, *dir)
+                        self.extend_opening_along_direction(
+                            *open_min, *open_max, wall_min, wall_max, *dir,
+                        )
                     } else {
                         (*open_min, *open_max)
                     };
@@ -552,8 +594,6 @@ impl GeometryRouter {
         if !rect_boxes.is_empty() {
             result = self.cut_multiple_rectangular_openings(&result, &rect_boxes);
         }
-
-        let mut rect_operation_count = 0usize;
 
         // Process remaining non-rectangular openings only
         for opening in &non_rect_openings {
@@ -592,10 +632,12 @@ impl GeometryRouter {
                     // 3. Result validation — reject CSG output that loses > 75 % of triangles
                     let (result_min, result_max) = result.bounds();
                     let (open_min_f32, open_max_f32) = opening_mesh.bounds();
-                    let no_overlap =
-                        open_max_f32.x < result_min.x || open_min_f32.x > result_max.x ||
-                        open_max_f32.y < result_min.y || open_min_f32.y > result_max.y ||
-                        open_max_f32.z < result_min.z || open_min_f32.z > result_max.z;
+                    let no_overlap = open_max_f32.x < result_min.x
+                        || open_min_f32.x > result_max.x
+                        || open_max_f32.y < result_min.y
+                        || open_min_f32.y > result_max.y
+                        || open_max_f32.z < result_min.z
+                        || open_min_f32.z > result_max.z;
                     if no_overlap {
                         continue;
                     }
@@ -615,7 +657,8 @@ impl GeometryRouter {
                         Ok(csg_result) => {
                             // Validate result is not degenerate — must retain a reasonable
                             // fraction of the pre-CSG triangles to catch BSP blowups
-                            let min_tris = (tri_before / CSG_TRIANGLE_RETENTION_DIVISOR).max(MIN_VALID_TRIANGLES);
+                            let min_tris = (tri_before / CSG_TRIANGLE_RETENTION_DIVISOR)
+                                .max(MIN_VALID_TRIANGLES);
                             if !csg_result.is_empty() && csg_result.triangle_count() >= min_tris {
                                 result = csg_result;
                             }
@@ -635,7 +678,9 @@ impl GeometryRouter {
             use crate::csg::{ClippingProcessor, Plane};
             let clipper = ClippingProcessor::new();
 
-            for (_clip_idx, (plane_point, plane_normal, agreement)) in world_clipping_planes.iter().enumerate() {
+            for (_clip_idx, (plane_point, plane_normal, agreement)) in
+                world_clipping_planes.iter().enumerate()
+            {
                 let clip_normal = if *agreement {
                     *plane_normal
                 } else {
@@ -676,13 +721,14 @@ impl GeometryRouter {
             if vertex_count > 100 {
                 openings.push(OpeningType::NonRectangular(opening_mesh));
             } else {
-                let item_bounds_with_dir = self.get_opening_item_bounds_with_direction(&opening_entity, decoder)
+                let item_bounds_with_dir = self
+                    .get_opening_item_bounds_with_direction(&opening_entity, decoder)
                     .unwrap_or_default();
 
                 if !item_bounds_with_dir.is_empty() {
-                    let is_floor_opening = item_bounds_with_dir.iter().any(|(_, _, dir)| {
-                        dir.map(|d| d.z.abs() > 0.95).unwrap_or(false)
-                    });
+                    let is_floor_opening = item_bounds_with_dir
+                        .iter()
+                        .any(|(_, _, dir)| dir.map(|d| d.z.abs() > 0.95).unwrap_or(false));
 
                     if is_floor_opening && vertex_count > 0 {
                         openings.push(OpeningType::NonRectangular(opening_mesh.clone()));
@@ -693,21 +739,30 @@ impl GeometryRouter {
                                 let abs_x = d.x.abs();
                                 let abs_y = d.y.abs();
                                 let abs_z = d.z.abs();
-                                !(abs_x > AXIS_THRESHOLD || abs_y > AXIS_THRESHOLD || abs_z > AXIS_THRESHOLD)
-                            }).unwrap_or(false)
+                                !(abs_x > AXIS_THRESHOLD
+                                    || abs_y > AXIS_THRESHOLD
+                                    || abs_z > AXIS_THRESHOLD)
+                            })
+                            .unwrap_or(false)
                         });
 
                         if any_diagonal {
                             // Only use the diagonal path if we have an actual extrusion direction;
                             // without one the rotation would be arbitrary and produce wrong cuts.
-                            if let Some(dir) = item_bounds_with_dir.iter().find_map(|(_, _, d)| *d) {
-                                let item_meshes = self.get_opening_item_meshes_world(&opening_entity, decoder)
+                            if let Some(dir) = item_bounds_with_dir.iter().find_map(|(_, _, d)| *d)
+                            {
+                                let item_meshes = self
+                                    .get_opening_item_meshes_world(&opening_entity, decoder)
                                     .unwrap_or_default();
                                 if item_meshes.is_empty() {
-                                    openings.push(OpeningType::DiagonalRectangular(opening_mesh.clone(), dir));
+                                    openings.push(OpeningType::DiagonalRectangular(
+                                        opening_mesh.clone(),
+                                        dir,
+                                    ));
                                 } else {
                                     for item_mesh in item_meshes {
-                                        openings.push(OpeningType::DiagonalRectangular(item_mesh, dir));
+                                        openings
+                                            .push(OpeningType::DiagonalRectangular(item_mesh, dir));
                                     }
                                 }
                             } else {
@@ -716,14 +771,20 @@ impl GeometryRouter {
                             }
                         } else {
                             for (min_pt, max_pt, extrusion_dir) in item_bounds_with_dir {
-                                openings.push(OpeningType::Rectangular(min_pt, max_pt, extrusion_dir));
+                                openings.push(OpeningType::Rectangular(
+                                    min_pt,
+                                    max_pt,
+                                    extrusion_dir,
+                                ));
                             }
                         }
                     }
                 } else {
                     let (open_min, open_max) = opening_mesh.bounds();
-                    let min_f64 = Point3::new(open_min.x as f64, open_min.y as f64, open_min.z as f64);
-                    let max_f64 = Point3::new(open_max.x as f64, open_max.y as f64, open_max.z as f64);
+                    let min_f64 =
+                        Point3::new(open_min.x as f64, open_min.y as f64, open_min.z as f64);
+                    let max_f64 =
+                        Point3::new(open_max.x as f64, open_max.y as f64, open_max.z as f64);
 
                     openings.push(OpeningType::Rectangular(min_f64, max_f64, None));
                 }
@@ -764,9 +825,12 @@ impl GeometryRouter {
                     let (b_min, b_max, _) = &rects[j];
 
                     // Check if boxes overlap or are adjacent (within tolerance)
-                    let overlaps_x = a_min.x <= b_max.x + MERGE_TOLERANCE && a_max.x >= b_min.x - MERGE_TOLERANCE;
-                    let overlaps_y = a_min.y <= b_max.y + MERGE_TOLERANCE && a_max.y >= b_min.y - MERGE_TOLERANCE;
-                    let overlaps_z = a_min.z <= b_max.z + MERGE_TOLERANCE && a_max.z >= b_min.z - MERGE_TOLERANCE;
+                    let overlaps_x = a_min.x <= b_max.x + MERGE_TOLERANCE
+                        && a_max.x >= b_min.x - MERGE_TOLERANCE;
+                    let overlaps_y = a_min.y <= b_max.y + MERGE_TOLERANCE
+                        && a_max.y >= b_min.y - MERGE_TOLERANCE;
+                    let overlaps_z = a_min.z <= b_max.z + MERGE_TOLERANCE
+                        && a_max.z >= b_min.z - MERGE_TOLERANCE;
 
                     if overlaps_x && overlaps_y && overlaps_z {
                         // Merge into box i
@@ -812,7 +876,8 @@ impl GeometryRouter {
     ) {
         use nalgebra::Rotation3;
 
-        let diagonal_openings: Vec<(&Mesh, &Vector3<f64>)> = openings.iter()
+        let diagonal_openings: Vec<(&Mesh, &Vector3<f64>)> = openings
+            .iter()
             .filter_map(|o| match o {
                 OpeningType::DiagonalRectangular(mesh, dir) => Some((mesh, dir)),
                 _ => None,
@@ -830,7 +895,10 @@ impl GeometryRouter {
         let mut groups: Vec<(Vector3<f64>, Vec<&Mesh>)> = Vec::new();
         for (mesh, dir) in &diagonal_openings {
             let d = *dir;
-            if let Some(group) = groups.iter_mut().find(|(g, _)| d.dot(g).abs() > DIR_DOT_THRESHOLD) {
+            if let Some(group) = groups
+                .iter_mut()
+                .find(|(g, _)| d.dot(g).abs() > DIR_DOT_THRESHOLD)
+            {
                 group.1.push(mesh);
             } else {
                 groups.push((*d, vec![mesh]));
@@ -878,9 +946,11 @@ impl GeometryRouter {
 
             for opening_mesh in group_meshes {
                 let mut rot_min = Point3::new(f64::INFINITY, f64::INFINITY, f64::INFINITY);
-                let mut rot_max = Point3::new(f64::NEG_INFINITY, f64::NEG_INFINITY, f64::NEG_INFINITY);
+                let mut rot_max =
+                    Point3::new(f64::NEG_INFINITY, f64::NEG_INFINITY, f64::NEG_INFINITY);
                 for chunk in opening_mesh.positions.chunks_exact(3) {
-                    let p = rotation * Point3::new(chunk[0] as f64, chunk[1] as f64, chunk[2] as f64);
+                    let p =
+                        rotation * Point3::new(chunk[0] as f64, chunk[1] as f64, chunk[2] as f64);
                     rot_min.x = rot_min.x.min(p.x);
                     rot_min.y = rot_min.y.min(p.y);
                     rot_min.z = rot_min.z.min(p.z);
@@ -896,13 +966,15 @@ impl GeometryRouter {
 
             // Rotate positions and normals back to world frame
             for chunk in result.positions.chunks_exact_mut(3) {
-                let p = inv_rotation * Point3::new(chunk[0] as f64, chunk[1] as f64, chunk[2] as f64);
+                let p =
+                    inv_rotation * Point3::new(chunk[0] as f64, chunk[1] as f64, chunk[2] as f64);
                 chunk[0] = p.x as f32;
                 chunk[1] = p.y as f32;
                 chunk[2] = p.z as f32;
             }
             for chunk in result.normals.chunks_exact_mut(3) {
-                let n = inv_rotation * Vector3::new(chunk[0] as f64, chunk[1] as f64, chunk[2] as f64);
+                let n =
+                    inv_rotation * Vector3::new(chunk[0] as f64, chunk[1] as f64, chunk[2] as f64);
                 chunk[0] = n.x as f32;
                 chunk[1] = n.y as f32;
                 chunk[2] = n.z as f32;
@@ -926,7 +998,7 @@ impl GeometryRouter {
         open_max: Point3<f64>,
         wall_min: Point3<f64>,
         wall_max: Point3<f64>,
-        extrusion_direction: Vector3<f64>,  // World-space, normalized
+        extrusion_direction: Vector3<f64>, // World-space, normalized
     ) -> (Point3<f64>, Point3<f64>) {
         // Use opening center as reference point for projection
         let open_center = Point3::new(
@@ -981,8 +1053,8 @@ impl GeometryRouter {
 
         // Calculate how much to extend in each direction along the extrusion axis
         // If wall extends beyond opening, we need to extend the opening
-        let extend_backward = (open_min_proj - wall_min_proj).max(0.0);  // How much wall extends before opening
-        let extend_forward = (wall_max_proj - open_max_proj).max(0.0);   // How much wall extends after opening
+        let extend_backward = (open_min_proj - wall_min_proj).max(0.0); // How much wall extends before opening
+        let extend_forward = (wall_max_proj - open_max_proj).max(0.0); // How much wall extends after opening
 
         // Extend opening bounds along the extrusion direction
         let extended_min = open_min - extrusion_direction * extend_backward;
@@ -990,10 +1062,7 @@ impl GeometryRouter {
 
         // Create new AABB that encompasses both original opening and extended points
         // This ensures we don't shrink the opening in other dimensions
-        let all_points = [
-            open_min, open_max,
-            extended_min, extended_max,
-        ];
+        let all_points = [open_min, open_max, extended_min, extended_max];
 
         let new_min = Point3::new(
             all_points.iter().map(|p| p.x).fold(f64::INFINITY, f64::min),
@@ -1001,9 +1070,18 @@ impl GeometryRouter {
             all_points.iter().map(|p| p.z).fold(f64::INFINITY, f64::min),
         );
         let new_max = Point3::new(
-            all_points.iter().map(|p| p.x).fold(f64::NEG_INFINITY, f64::max),
-            all_points.iter().map(|p| p.y).fold(f64::NEG_INFINITY, f64::max),
-            all_points.iter().map(|p| p.z).fold(f64::NEG_INFINITY, f64::max),
+            all_points
+                .iter()
+                .map(|p| p.x)
+                .fold(f64::NEG_INFINITY, f64::max),
+            all_points
+                .iter()
+                .map(|p| p.y)
+                .fold(f64::NEG_INFINITY, f64::max),
+            all_points
+                .iter()
+                .map(|p| p.z)
+                .fold(f64::NEG_INFINITY, f64::max),
         );
 
         (new_min, new_max)
@@ -1070,10 +1148,7 @@ impl GeometryRouter {
 
         const EPSILON: f64 = 1e-6;
 
-        let mut result = Mesh::with_capacity(
-            mesh.positions.len() / 3,
-            mesh.indices.len() / 3,
-        );
+        let mut result = Mesh::with_capacity(mesh.positions.len() / 3, mesh.indices.len() / 3);
 
         let mut clip_buffers = ClipBuffers::new();
 
@@ -1113,7 +1188,10 @@ impl GeometryRouter {
             } else {
                 let edge1 = v1 - v0;
                 let edge2 = v2 - v0;
-                edge1.cross(&edge2).try_normalize(1e-10).unwrap_or(Vector3::new(0.0, 0.0, 1.0))
+                edge1
+                    .cross(&edge2)
+                    .try_normalize(1e-10)
+                    .unwrap_or(Vector3::new(0.0, 0.0, 1.0))
             };
 
             let tri_min_x = v0.x.min(v1.x).min(v2.x);
@@ -1124,9 +1202,13 @@ impl GeometryRouter {
             let tri_max_z = v0.z.max(v1.z).max(v2.z);
 
             // If triangle is completely outside opening, keep it as-is
-            if tri_max_x <= open_min.x - EPSILON || tri_min_x >= open_max.x + EPSILON ||
-               tri_max_y <= open_min.y - EPSILON || tri_min_y >= open_max.y + EPSILON ||
-               tri_max_z <= open_min.z - EPSILON || tri_min_z >= open_max.z + EPSILON {
+            if tri_max_x <= open_min.x - EPSILON
+                || tri_min_x >= open_max.x + EPSILON
+                || tri_max_y <= open_min.y - EPSILON
+                || tri_min_y >= open_max.y + EPSILON
+                || tri_max_z <= open_min.z - EPSILON
+                || tri_min_z >= open_max.z + EPSILON
+            {
                 let base = result.vertex_count() as u32;
                 result.add_vertex(v0, n0);
                 result.add_vertex(v1, n0);
@@ -1136,15 +1218,28 @@ impl GeometryRouter {
             }
 
             // Check if triangle is completely inside opening (remove it)
-            if tri_min_x >= open_min.x + EPSILON && tri_max_x <= open_max.x - EPSILON &&
-               tri_min_y >= open_min.y + EPSILON && tri_max_y <= open_max.y - EPSILON &&
-               tri_min_z >= open_min.z + EPSILON && tri_max_z <= open_max.z - EPSILON {
+            if tri_min_x >= open_min.x + EPSILON
+                && tri_max_x <= open_max.x - EPSILON
+                && tri_min_y >= open_min.y + EPSILON
+                && tri_max_y <= open_max.y - EPSILON
+                && tri_min_z >= open_min.z + EPSILON
+                && tri_max_z <= open_max.z - EPSILON
+            {
                 continue;
             }
 
             // Triangle may intersect opening - clip it
             if self.triangle_intersects_box(&v0, &v1, &v2, &open_min, &open_max) {
-                self.clip_triangle_against_box(&mut result, &mut clip_buffers, &v0, &v1, &v2, &n0, &open_min, &open_max);
+                self.clip_triangle_against_box(
+                    &mut result,
+                    &mut clip_buffers,
+                    &v0,
+                    &v1,
+                    &v2,
+                    &n0,
+                    &open_min,
+                    &open_max,
+                );
             } else {
                 let base = result.vertex_count() as u32;
                 result.add_vertex(v0, n0);
@@ -1157,7 +1252,6 @@ impl GeometryRouter {
         // No internal face generation for diagonal openings
         result
     }
-
 
     /// Test if a triangle intersects an axis-aligned bounding box using Separating Axis Theorem (SAT)
     /// Returns true if triangle and box intersect, false if they are separated
@@ -1266,7 +1360,8 @@ impl GeometryRouter {
                 let mut box_projection = 0.0;
                 for i in 0..3 {
                     let box_axis_vec = box_axes[i];
-                    box_projection += box_half_extents[i] * axis_normalized.dot(&box_axis_vec).abs();
+                    box_projection +=
+                        box_half_extents[i] * axis_normalized.dot(&box_axis_vec).abs();
                 }
 
                 if tri_max < -box_projection || tri_min > box_projection {
@@ -1316,23 +1411,47 @@ impl GeometryRouter {
         // We clip to keep geometry OUTSIDE the box (behind these planes)
         let planes = [
             // +X inward: inside box where x >= open_min.x
-            Plane::new(Point3::new(open_min.x, 0.0, 0.0), Vector3::new(1.0, 0.0, 0.0)),
+            Plane::new(
+                Point3::new(open_min.x, 0.0, 0.0),
+                Vector3::new(1.0, 0.0, 0.0),
+            ),
             // -X inward: inside box where x <= open_max.x
-            Plane::new(Point3::new(open_max.x, 0.0, 0.0), Vector3::new(-1.0, 0.0, 0.0)),
+            Plane::new(
+                Point3::new(open_max.x, 0.0, 0.0),
+                Vector3::new(-1.0, 0.0, 0.0),
+            ),
             // +Y inward: inside box where y >= open_min.y
-            Plane::new(Point3::new(0.0, open_min.y, 0.0), Vector3::new(0.0, 1.0, 0.0)),
+            Plane::new(
+                Point3::new(0.0, open_min.y, 0.0),
+                Vector3::new(0.0, 1.0, 0.0),
+            ),
             // -Y inward: inside box where y <= open_max.y
-            Plane::new(Point3::new(0.0, open_max.y, 0.0), Vector3::new(0.0, -1.0, 0.0)),
+            Plane::new(
+                Point3::new(0.0, open_max.y, 0.0),
+                Vector3::new(0.0, -1.0, 0.0),
+            ),
             // +Z inward: inside box where z >= open_min.z
-            Plane::new(Point3::new(0.0, 0.0, open_min.z), Vector3::new(0.0, 0.0, 1.0)),
+            Plane::new(
+                Point3::new(0.0, 0.0, open_min.z),
+                Vector3::new(0.0, 0.0, 1.0),
+            ),
             // -Z inward: inside box where z <= open_max.z
-            Plane::new(Point3::new(0.0, 0.0, open_max.z), Vector3::new(0.0, 0.0, -1.0)),
+            Plane::new(
+                Point3::new(0.0, 0.0, open_max.z),
+                Vector3::new(0.0, 0.0, -1.0),
+            ),
         ];
 
         // Guard: skip if input vertices contain NaN (from degenerate prior clips)
-        if !v0.x.is_finite() || !v0.y.is_finite() || !v0.z.is_finite()
-            || !v1.x.is_finite() || !v1.y.is_finite() || !v1.z.is_finite()
-            || !v2.x.is_finite() || !v2.y.is_finite() || !v2.z.is_finite()
+        if !v0.x.is_finite()
+            || !v0.y.is_finite()
+            || !v0.z.is_finite()
+            || !v1.x.is_finite()
+            || !v1.y.is_finite()
+            || !v1.z.is_finite()
+            || !v2.x.is_finite()
+            || !v2.y.is_finite()
+            || !v2.z.is_finite()
         {
             // Keep the triangle as-is (don't clip degenerate geometry)
             let base = result.vertex_count() as u32;
@@ -1394,8 +1513,12 @@ impl GeometryRouter {
                         let p2 = front + (back2 - front) * t2;
 
                         // Validate interpolated points
-                        if !p1.x.is_finite() || !p1.y.is_finite() || !p1.z.is_finite()
-                            || !p2.x.is_finite() || !p2.y.is_finite() || !p2.z.is_finite()
+                        if !p1.x.is_finite()
+                            || !p1.y.is_finite()
+                            || !p1.z.is_finite()
+                            || !p2.x.is_finite()
+                            || !p2.y.is_finite()
+                            || !p2.z.is_finite()
                         {
                             buffers.next_remaining.push(tri.clone());
                             continue;
@@ -1426,14 +1549,20 @@ impl GeometryRouter {
                         let p2 = front2 + (back - front2) * t2;
 
                         // Validate interpolated points
-                        if !p1.x.is_finite() || !p1.y.is_finite() || !p1.z.is_finite()
-                            || !p2.x.is_finite() || !p2.y.is_finite() || !p2.z.is_finite()
+                        if !p1.x.is_finite()
+                            || !p1.y.is_finite()
+                            || !p1.z.is_finite()
+                            || !p2.x.is_finite()
+                            || !p2.y.is_finite()
+                            || !p2.z.is_finite()
                         {
                             buffers.next_remaining.push(tri.clone());
                             continue;
                         }
 
-                        buffers.next_remaining.push(Triangle::new(front1, front2, p1));
+                        buffers
+                            .next_remaining
+                            .push(Triangle::new(front1, front2, p1));
                         buffers.next_remaining.push(Triangle::new(front2, p2, p1));
                         buffers.result.push(Triangle::new(p1, p2, back));
                     }
@@ -1458,5 +1587,4 @@ impl GeometryRouter {
             result.add_triangle(base, base + 1, base + 2);
         }
     }
-
 }


### PR DESCRIPTION
## Summary
- bound and de-cycle nested IfcMappedItem, boolean clipping, and extrusion wrapper traversal
- restrict csgrs boolean operations to simple low-polygon operands so complex openings degrade safely instead of risking WASM stack overflow
- add regression tests for the CSG admission gate

## Testing
- cargo test -p ifc-lite-geometry --lib
- cargo check -p ifc-lite-geometry --target wasm32-unknown-unknown

Closes #460