### PR TITLE
ci: add Docker image publish workflow for GHCR

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,76 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+name: Docker Image
+
+on:
+  release:
+    types:
+      - published
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/docker.yml'
+      - '.cargo/**'
+      - 'Cargo.lock'
+      - 'Cargo.toml'
+      - 'apps/server/**'
+      - 'rust/**'
+  workflow_dispatch:
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/ifc-lite-server
+
+jobs:
+  docker:
+    name: Build & Push Docker Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          lfs: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # tag release as version (e.g. 0.5.0)
+            type=match,pattern=v(.*),group=1,event=tag
+            # tag release also as latest
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,event=tag
+            # sha for push-to-main builds
+            type=sha,prefix=,event=branch
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/server/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow to build and push the `ghcr.io/louistrue/ifc-lite-server` Docker image to GHCR
- Fixes "not found" error users hit when following Docker installation docs, since no CI workflow existed to publish the image
- Triggers on release (versioned tag + `latest`), push to main (SHA tag), and manual dispatch

## Details

The docs (`installation.md`, `server.md`) and `create-ifc-lite` server template all reference `ghcr.io/louistrue/ifc-lite-server`, but no workflow ever built or pushed this image. Users following the documented `docker run` command got:

```
docker: Error response from daemon: failed to resolve reference "ghcr.io/louistrue/ifc-lite-server:latest": not found
```

The workflow uses:
- `docker/build-push-action@v6` with Buildx
- `docker/metadata-action@v5` for automatic tag/label generation
- GHA layer caching for fast rebuilds (works well with cargo-chef in the Dockerfile)
- `GITHUB_TOKEN` with `packages: write` — no extra secrets needed
- Path filtering matching `server-binaries.yml` patterns

## Test plan

- [ ] Verify workflow syntax is valid (Actions tab shows no parse errors)
- [ ] Trigger via `workflow_dispatch` and confirm image appears at `ghcr.io/louistrue/ifc-lite-server`
- [ ] Confirm `docker run -p 3001:8080 ghcr.io/louistrue/ifc-lite-server:latest` starts successfully
- [ ] Verify health check passes: `curl http://localhost:3001/api/v1/health`

https://claude.ai/code/session_01DpzXztAsdXjzCYmX4BjiyU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated Docker image building and publishing to GitHub Container Registry. Images are automatically built and pushed on release events, main branch updates, and manual triggers, with tagged versions for releases and latest builds for the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->