### PR TITLE
fix: bump Dockerfile Rust to 1.88

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -2,7 +2,7 @@
 # Optimized multi-stage build for Railway deployment
 
 # Stage 1: Chef - prepare recipe for dependency caching
-FROM lukemathwalker/cargo-chef:latest-rust-1.87 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.88 AS chef
 WORKDIR /app
 
 # Stage 2: Planner - create dependency recipe


### PR DESCRIPTION
## Summary

- Bumps Dockerfile Rust from 1.83 → 1.88 to fix Docker image build
- Dependencies `darling`, `serde_with`, and `time` all require rustc 1.88+

## Test plan

- [ ] Docker workflow passes in CI

https://claude.ai/code/session_01DpzXztAsdXjzCYmX4BjiyU