### PR TITLE
fix: make GHCR Docker image publicly accessible

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -74,3 +74,14 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64
+
+      - name: Set package visibility to public
+        if: github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            --method PATCH \
+            /users/${{ github.repository_owner }}/packages/container/ifc-lite-server \
+            -f visibility=public \
+            2>/dev/null || echo "Package visibility update skipped (may require manual configuration)"

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -170,6 +170,15 @@ docker run -p 3001:8080 \
   ghcr.io/louistrue/ifc-lite-server
 ```
 
+!!! warning "Registry Authentication"
+    If you get `denied` or `unauthorized` when pulling the image, authenticate with the GitHub Container Registry first:
+
+    ```bash
+    echo YOUR_GITHUB_PAT | docker login ghcr.io -u YOUR_GITHUB_USERNAME --password-stdin
+    ```
+
+    You need a [Personal Access Token](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry) with `read:packages` scope.
+
 ### Option 2: Native Binary
 
 ```bash

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -218,6 +218,9 @@ docker run -p 3001:8080 ghcr.io/louistrue/ifc-lite-server
 npx @ifc-lite/server-bin
 ```
 
+!!! note "Docker Authentication"
+    If the Docker pull fails with `denied`, see the [Installation Guide](installation.md#option-1-docker-recommended-for-production) for authentication instructions.
+
 ### 2. Connect from Client
 
 ```bash

--- a/docs/guide/server.md
+++ b/docs/guide/server.md
@@ -80,6 +80,21 @@ flowchart TB
       ghcr.io/louistrue/ifc-lite-server
     ```
 
+    !!! warning "Registry Authentication"
+        If you get `denied` or `unauthorized` when pulling the image, authenticate with the GitHub Container Registry first:
+
+        ```bash
+        # Log in with a GitHub Personal Access Token (read:packages scope)
+        echo YOUR_GITHUB_PAT | docker login ghcr.io -u YOUR_GITHUB_USERNAME --password-stdin
+
+        # Then retry the docker run command
+        docker run -p 3001:8080 \
+          -v ifc-cache:/app/.cache \
+          ghcr.io/louistrue/ifc-lite-server
+        ```
+
+        See [GitHub docs](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry) for details on creating a PAT with `read:packages` scope.
+
 === "Native Binary"
 
     ```bash


### PR DESCRIPTION
Add a workflow step to set the container package visibility to public
after pushing, and add authentication troubleshooting notes to docs
for users who encounter the "denied" error when pulling the image.

https://claude.ai/code/session_015VBDiVFVvdDxG6qP1CP9DQ