### PR TITLE
fix: correct server Docker cache path in docs

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -160,7 +160,7 @@ The fastest way to get started is using the `create-ifc-lite` CLI:
 docker run -p 3001:8080 ghcr.io/louistrue/ifc-lite-server
 
 # With persistent cache
-docker run -p 3001:8080 -v ifc-cache:/app/.cache ghcr.io/louistrue/ifc-lite-server
+docker run -p 3001:8080 -v ifc-cache:/app/cache ghcr.io/louistrue/ifc-lite-server
 
 # With environment configuration
 docker run -p 3001:8080 \

--- a/docs/guide/server.md
+++ b/docs/guide/server.md
@@ -76,7 +76,7 @@ flowchart TB
 
     ```bash
     docker run -p 3001:8080 \
-      -v ifc-cache:/app/.cache \
+      -v ifc-cache:/app/cache \
       ghcr.io/louistrue/ifc-lite-server
     ```
 
@@ -485,7 +485,7 @@ services:
       - WORKER_THREADS=8
       - CACHE_MAX_AGE_DAYS=30
     volumes:
-      - ifc-cache:/app/.cache
+      - ifc-cache:/app/cache
 
 volumes:
   ifc-cache:


### PR DESCRIPTION
Update the Docker examples to mount the server cache volume at /app/cache so the published docs match the image configuration and preserve cached results correctly.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker installation guide and server configuration documentation to reflect the correct cache volume mount path specifications for containerized deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->