### PR TITLE
fix(parser): recognize IFC entity subtypes via inheritance chain

### DIFF
--- a/packages/parser/src/columnar-parser.ts
+++ b/packages/parser/src/columnar-parser.ts
@@ -14,7 +14,7 @@ import { SpatialHierarchyBuilder } from './spatial-hierarchy-builder.js';
 import { EntityExtractor } from './entity-extractor.js';
 import { extractLengthUnitScale } from './unit-extractor.js';
 import { decodeIfcString } from '@ifc-lite/encoding';
-import { getAttributeNames } from './ifc-schema.js';
+import { getAttributeNames, getInheritanceChain } from './ifc-schema.js';
 import { parsePropertyValue } from './on-demand-extractors.js';
 import { CompactEntityIndex, buildCompactEntityIndex } from './compact-entity-index.js';
 import {
@@ -589,14 +589,21 @@ export class ColumnarParser {
               CAT_PROPERTY_REL = 4, CAT_PROPERTY_ENTITY = 5, CAT_ASSOCIATION_REL = 6,
               CAT_TYPE_OBJECT = 7, CAT_RELEVANT = 8;
 
+
+        /** Returns true if `upper` (already uppercased) is a subtype of any type in `set`. */
+        function isSubtypeOfAny(upper: string, set: Set<string>): boolean {
+            const chain = getInheritanceChain(upper);
+            return chain.some(ancestor => set.has(ancestor.toUpperCase()));
+        }
+
         // Cache: type name → category (avoids 4.4M .toUpperCase() calls)
         const typeCategoryCache = new Map<string, number>();
         function getCategory(type: string): number {
             let cat = typeCategoryCache.get(type);
             if (cat !== undefined) return cat;
             const upper = type.toUpperCase();
-            if (SPATIAL_TYPES.has(upper)) cat = CAT_SPATIAL;
-            else if (GEOMETRY_TYPES.has(upper)) cat = CAT_GEOMETRY;
+            if (SPATIAL_TYPES.has(upper) || isSubtypeOfAny(upper, SPATIAL_TYPES)) cat = CAT_SPATIAL;
+            else if (GEOMETRY_TYPES.has(upper) || isSubtypeOfAny(upper, GEOMETRY_TYPES)) cat = CAT_GEOMETRY;        
             else if (HIERARCHY_REL_TYPES.has(upper)) cat = CAT_HIERARCHY_REL;
             else if (PROPERTY_REL_TYPES.has(upper)) cat = CAT_PROPERTY_REL;
             else if (PROPERTY_ENTITY_TYPES.has(upper)) cat = CAT_PROPERTY_ENTITY;

--- a/packages/parser/src/ifc-schema.ts
+++ b/packages/parser/src/ifc-schema.ts
@@ -9,7 +9,7 @@
  * Do NOT hardcode entity types or attributes here; regenerate instead.
  */
 
-import { getAllAttributesForEntity, isKnownEntity } from './generated/schema-registry.js';
+import { getAllAttributesForEntity, isKnownEntity, getInheritanceChainForEntity } from './generated/schema-registry.js';
 
 /**
  * Get all attribute names for an IFC entity type in STEP positional order.
@@ -25,6 +25,14 @@ export function getAttributeNames(type: string): string[] {
  */
 export function isKnownType(type: string): boolean {
     return isKnownEntity(type);
+}
+
+/**
+ * Get the full inheritance chain for an IFC entity type (root → leaf).
+ * Returns PascalCase names, e.g. ['IfcRoot', ..., 'IfcFlowTerminal', 'IfcAirTerminal'].
+ */
+export function getInheritanceChain(type: string): string[] {
+    return getInheritanceChainForEntity(type);
 }
 
 /**

--- a/packages/parser/test/entity-category.test.ts
+++ b/packages/parser/test/entity-category.test.ts
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Tests that concrete IFC entity subtypes are recognized correctly.
+ *
+ * Regression test for: IfcAirTerminal and other MEP subtypes being silently
+ * skipped (CAT_SKIP) because getCategory() only matched exact names in
+ * GEOMETRY_TYPES, without walking the inheritance chain.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getInheritanceChain } from '../src/ifc-schema';
+
+describe('IFC entity inheritance chain', () => {
+    it('IfcAirTerminal has IfcFlowTerminal in its inheritance chain', () => {
+        const chain = getInheritanceChain('IfcAirTerminal');
+        expect(chain.map(c => c.toUpperCase())).toContain('IFCFLOWTERMINAL');
+    });
+
+    it('IfcPump has IfcFlowMovingDevice in its inheritance chain', () => {
+        const chain = getInheritanceChain('IfcPump');
+        expect(chain.map(c => c.toUpperCase())).toContain('IFCFLOWMOVINGDEVICE');
+    });
+
+    it('IfcDuctSegment has IfcFlowSegment in its inheritance chain', () => {
+        const chain = getInheritanceChain('IfcDuctSegment');
+        expect(chain.map(c => c.toUpperCase())).toContain('IFCFLOWSEGMENT');
+    });
+
+    it('IfcValve has IfcFlowController in its inheritance chain', () => {
+        const chain = getInheritanceChain('IfcValve');
+        expect(chain.map(c => c.toUpperCase())).toContain('IFCFLOWCONTROLLER');
+    });
+
+    it('IfcWall still resolves (direct match should still work)', () => {
+        const chain = getInheritanceChain('IfcWall');
+        expect(chain.map(c => c.toUpperCase())).toContain('IFCWALL');
+    });
+
+    it('accepts UPPERCASE input (as passed from getCategory)', () => {
+        const chain = getInheritanceChain('IFCAIRTERMINAL');
+        expect(chain.map(c => c.toUpperCase())).toContain('IFCFLOWTERMINAL');
+    });
+});


### PR DESCRIPTION
IfcAirTerminal and other concrete MEP subtypes were assigned CAT_SKIP because getCategory() matched only exact names in GEOMETRY_TYPES with no inheritance walk. Fix uses getInheritanceChain() to check ancestors, so any subtype of a known geometry base class is recognized automatically.

Also adds regression tests for IfcAirTerminal, IfcPump, IfcDuctSegment, IfcValve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced entity categorization to properly recognize inherited spatial and geometry types.

* **Tests**
  * Added inheritance validation tests for IFC entity types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->