### PR TITLE
fix: correct wasm changeset package name

### DIFF
--- a/.changeset/advanced-face-improvements.md
+++ b/.changeset/advanced-face-improvements.md
@@ -1,5 +1,5 @@
 ---
-"ifc-lite-wasm": patch
+"@ifc-lite/wasm": patch
 ---
 
 Fix advanced face tessellation: add rational B-spline (NURBS) weight support, SameSense winding correction, and knot vector validation


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package naming from `ifc-lite-wasm` to `@ifc-lite/wasm` for improved organization and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->