### PR TITLE
Fix partial batch cache key collision when multiple batches share a colorKey.

### DIFF
--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -954,7 +954,7 @@ export class Renderer {
                 // Pre-compute visibility for each batch (only when filtering is active)
                 // A batch is visible if ANY of its elements are visible
                 // A batch is fully visible if ALL of its elements are visible
-                const batchVisibility = new Map<string, { visible: boolean; fullyVisible: boolean }>();
+                const batchVisibility = new Map<typeof allBatchedMeshes[number], { visible: boolean; fullyVisible: boolean }>();
 
                 if (hasVisibilityFiltering) {
                     for (const batch of allBatchedMeshes) {
@@ -969,7 +969,7 @@ export class Renderer {
                             }
                         }
 
-                        batchVisibility.set(batch.colorKey, {
+                        batchVisibility.set(batch, {
                             visible: visibleCount > 0,
                             fullyVisible: visibleCount === total,
                         });
@@ -985,6 +985,7 @@ export class Renderer {
                 // PERFORMANCE FIX: Track partially visible batches for sub-batch rendering
                 // Instead of creating 10,000+ individual meshes, we create cached sub-batches
                 const partiallyVisibleBatches: Array<{
+                    sourceBatchKey: string;
                     colorKey: string;
                     visibleIds: Set<number>;
                     color: [number, number, number, number];
@@ -1001,7 +1002,7 @@ export class Renderer {
 
                     // Check visibility
                     if (hasVisibilityFiltering) {
-                        const vis = batchVisibility.get(batch.colorKey);
+                        const vis = batchVisibility.get(batch);
                         if (!vis || !vis.visible) continue; // Skip completely hidden batches
 
                         // Handle partially visible batches - create sub-batches instead of individual meshes
@@ -1017,6 +1018,7 @@ export class Renderer {
                             }
                             if (visibleIds.size > 0) {
                                 partiallyVisibleBatches.push({
+                                    sourceBatchKey: `${batch.colorKey}:${batch.expressIds.join(',')}`,
                                     colorKey: batch.colorKey,
                                     visibleIds,
                                     color: batch.color,
@@ -1102,9 +1104,10 @@ export class Renderer {
                 // This is the key optimization: instead of 10,000+ individual draw calls,
                 // we create cached sub-batches with only visible elements and render them as single draw calls
                 if (partiallyVisibleBatches.length > 0) {
-                    for (const { colorKey, visibleIds, color } of partiallyVisibleBatches) {
+                    for (const { sourceBatchKey, colorKey, visibleIds, color } of partiallyVisibleBatches) {
                         // Get or create a cached sub-batch for this visibility state
                         const subBatch = this.scene.getOrCreatePartialBatch(
+                            sourceBatchKey,
                             colorKey,
                             visibleIds,
                             device,

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -49,7 +49,7 @@ export class Scene {
   // Key = colorKey + ":" + sorted visible expressIds hash
   // This allows rendering partially visible batches as single draw calls instead of 10,000+ individual draws
   private partialBatchCache: Map<string, BatchedMesh> = new Map();
-  private partialBatchCacheKeys: Map<string, string> = new Map(); // colorKey -> current cache key (for invalidation)
+  private partialBatchCacheKeys: Map<string, string> = new Map(); // sourceBatchKey -> current cache key (for invalidation)
 
   // Color overlay system for lens coloring — NEVER modifies original batches.
   // Overlay batches render on top using depthCompare 'equal', so they only
@@ -1080,6 +1080,7 @@ export class Scene {
    * @returns BatchedMesh containing only visible elements, or undefined if no visible elements
    */
   getOrCreatePartialBatch(
+    sourceBatchKey: string,
     colorKey: string,
     visibleIds: Set<number>,
     device: GPUDevice,
@@ -1103,7 +1104,7 @@ export class Scene {
     const cacheKey = `${colorKey}:${idsHash}`;
 
     // Check if we already have this exact partial batch cached
-    const currentCacheKey = this.partialBatchCacheKeys.get(colorKey);
+    const currentCacheKey = this.partialBatchCacheKeys.get(sourceBatchKey);
     if (currentCacheKey === cacheKey) {
       const cached = this.partialBatchCache.get(cacheKey);
       if (cached) return cached;
@@ -1150,7 +1151,7 @@ export class Scene {
 
     // Cache it
     this.partialBatchCache.set(cacheKey, partialBatch);
-    this.partialBatchCacheKeys.set(colorKey, cacheKey);
+    this.partialBatchCacheKeys.set(sourceBatchKey, cacheKey);
 
     return partialBatch;
   }


### PR DESCRIPTION
When multiple batches share the same colorKey (same RGBA color, different elements), the partial batch cache uses colorKey as the invalidation key. Batch B overwrites batch A's cache entry, destroying A's GPU buffers while the render pass still references them. This causes a WebGPU error (Buffer has been destroyed) and visibility filtering (isolate floor, hide elements) silently fails to update the model.

Fix: use the batch object reference for visibility tracking, and a sourceBatchKey (colorKey + expressIds) for cache invalidation, so each batch gets its own cache slot.

Couldn't get stuff like "show only level 3" working without this, patched it a while ago, but better to just merge upstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved batch visibility tracking and caching mechanism for partially visible elements, enhancing rendering efficiency.

* **Refactor**
  * Optimized batch identity tracking to better support cache invalidation and improve rendering pipeline accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->