### PR TITLE
fix: add Tauri stub aliases to apps/desktop vite config

### DIFF
--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -45,6 +45,13 @@ export default defineConfig({
       '@ifc-lite/create': path.resolve(__dirname, '../../packages/create/src'),
       '@ifc-lite/embed-protocol': path.resolve(__dirname, '../../packages/embed-protocol/src'),
       '@ifc-lite/embed-sdk': path.resolve(__dirname, '../../packages/embed-sdk/src'),
+      // Tauri API stubs: the shared viewer uses dynamic imports for native file
+      // dialogs. In the real Tauri shell these resolve to @tauri-apps packages;
+      // in the monorepo CI build (where those packages are absent) we point to
+      // lightweight stubs that return null / throw at runtime.
+      '@tauri-apps/api/core': path.resolve(__dirname, '../viewer/src/services/tauri-core-stub.ts'),
+      '@tauri-apps/plugin-dialog': path.resolve(__dirname, '../viewer/src/services/tauri-dialog-stub.ts'),
+      '@tauri-apps/plugin-fs': path.resolve(__dirname, '../viewer/src/services/tauri-fs-stub.ts'),
     },
   },
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`


### PR DESCRIPTION
## Summary
- Add `@tauri-apps/api/core`, `@tauri-apps/plugin-dialog`, and `@tauri-apps/plugin-fs` stub aliases to `apps/desktop/vite.config.ts`
- Fixes CI build failure where Rollup's `handleInvalidResolvedId` rejects the dynamic Tauri imports in `file-dialog.ts`
- The viewer app already has these stubs; `apps/desktop` was the only app missing them after the desktop merge

## Root cause
The desktop merge (#503) added `apps/viewer/src/services/file-dialog.ts` which uses `await import('@tauri-apps/...')`. The viewer's vite config aliases these to stub files. The `apps/desktop` vite config had no such aliases, and in CI (where `@tauri-apps` packages aren't installed), Rollup fails to resolve them.

## Test plan
- [ ] CI Release workflow passes
- [ ] `pnpm build` succeeds for all apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)