### PR TITLE
Fix geometry processing error handling and WGSL shader compliance

### DIFF
--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -1991,7 +1991,11 @@ export function useIfcLoader() {
         await closeGeometryIterator();
       } catch (err) {
         // Close the geometry iterator to release WASM resources on failure.
-        await closeGeometryIterator();
+        // Guard: closeGeometryIterator may not be defined if the error occurred
+        // before the iterator was created (e.g. processAdaptive/processStreaming threw).
+        if (typeof closeGeometryIterator === 'function') {
+          await closeGeometryIterator();
+        }
         if (loadSessionRef.current !== currentSession) return;
         console.error('[useIfc] Error in processing:', err);
         setError(err instanceof Error ? err.message : 'Unknown error during geometry processing');

--- a/packages/renderer/src/shaders/main.wgsl.ts
+++ b/packages/renderer/src/shaders/main.wgsl.ts
@@ -107,11 +107,13 @@ export const mainShaderSource = `
           }
 
           // Compute normal — with fallback for zero normals
+          // dpdx/dpdy must be called outside non-uniform control flow (WGSL spec),
+          // so we compute the flat normal unconditionally and select below.
+          let faceN = cross(dpdx(input.worldPos), dpdy(input.worldPos));
           var N = input.normal;
           let nLen2 = dot(N, N);
           if (nLen2 < 0.0001) {
-            // Fallback: compute flat normal from screen-space derivatives
-            let faceN = cross(dpdx(input.worldPos), dpdy(input.worldPos));
+            // Fallback: use flat normal from screen-space derivatives
             let fLen2 = dot(faceN, faceN);
             N = select(vec3<f32>(0.0, 1.0, 0.0), faceN * inverseSqrt(fLen2), fLen2 > 1e-10);
           } else {


### PR DESCRIPTION
## Summary
This PR fixes two issues: (1) a potential runtime error in IFC geometry processing when cleanup is attempted after early failures, and (2) a WGSL shader specification violation where derivative functions were called within non-uniform control flow.

## Key Changes

- **useIfcLoader.ts**: Added a guard check before calling `closeGeometryIterator()` in the error handler. The iterator may not be defined if an error occurs before it's created (e.g., during `processAdaptive` or `processStreaming`), which would cause a secondary error during cleanup.

- **main.wgsl.ts**: Moved the `faceN` computation (using `dpdx`/`dpdy` derivatives) outside the conditional block. WGSL specification requires derivative functions to be called unconditionally outside non-uniform control flow. The flat normal is now computed unconditionally and selected via `select()` when needed.

## Implementation Details

The shader change maintains the same fallback logic (using flat normals when vertex normals are near-zero) while ensuring WGSL compliance. The computation is slightly more expensive unconditionally, but this is necessary for valid shader code and prevents potential compilation errors on strict WGSL implementations.

https://claude.ai/code/session_016tsHacVAMUKtFwnY47T47M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed a potential crash during IFC file loading when geometry processing encounters errors early in the initialization phase before resources are fully set up.
- Improved fragment shader normal calculation to ensure optimal GPU compatibility and prevent potential rendering artifacts across different graphics hardware configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->