### PR TITLE
Add cesiumAvailable state to control Cesium button visibility

### DIFF
--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -306,6 +306,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
   const scriptPanelVisible = useViewerStore((state) => state.scriptPanelVisible);
   const setScriptPanelVisible = useViewerStore((state) => state.setScriptPanelVisible);
   // Cesium 3D overlay state
+  const cesiumAvailable = useViewerStore((state) => state.cesiumAvailable);
   const cesiumEnabled = useViewerStore((state) => state.cesiumEnabled);
   const toggleCesium = useViewerStore((state) => state.toggleCesium);
   const storeModels = useViewerStore((state) => state.models);
@@ -1157,8 +1158,8 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
         </TooltipContent>
       </Tooltip>
 
-      {/* Cesium 3D Context toggle + settings */}
-      {hasModelsLoaded && (
+      {/* Cesium 3D Context toggle + settings — only when model has georeferencing */}
+      {cesiumAvailable && (
         <div className="flex items-center">
           <Tooltip>
             <TooltipTrigger asChild>

--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -43,6 +43,7 @@ export function ViewportContainer() {
   const cesiumEnabled = useViewerStore((s) => s.cesiumEnabled);
   const georefMutations = useViewerStore((s) => s.georefMutations);
   const setCesiumSourceModelId = useViewerStore((s) => s.setCesiumSourceModelId);
+  const setCesiumAvailable = useViewerStore((s) => s.setCesiumAvailable);
   // Subscribe to mutationVersion so Cesium reacts to georef edits
   const mutationVersion = useViewerStore((s) => s.mutationVersion);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -251,6 +252,31 @@ export function ViewportContainer() {
 
     return null;
   }, [cesiumEnabled, storeModels, ifcDataStore, georefMutations, mutationVersion, mergedGeometryResult]);
+
+  // Determine whether Cesium button should be visible (model has georef or user added it via mutations).
+  // Runs independently of cesiumEnabled so the button appears/disappears reactively.
+  useEffect(() => {
+    function hasGeoref(): boolean {
+      // Check federated models
+      for (const [modelId, model] of storeModels) {
+        const ds = model.ifcDataStore;
+        if (!ds) continue;
+        const original = extractGeoreferencingOnDemand(ds as IfcDataStore);
+        const mutCRS = georefMutations.get(modelId)?.projectedCRS;
+        const crsName = mutCRS?.name ?? original?.projectedCRS?.name;
+        if (crsName) return true;
+      }
+      // Fallback to legacy single-model
+      if (ifcDataStore) {
+        const original = extractGeoreferencingOnDemand(ifcDataStore as IfcDataStore);
+        const mutCRS = georefMutations.get('__legacy__')?.projectedCRS;
+        const crsName = mutCRS?.name ?? original?.projectedCRS?.name;
+        if (crsName) return true;
+      }
+      return false;
+    }
+    setCesiumAvailable(hasGeoref());
+  }, [storeModels, ifcDataStore, georefMutations, mutationVersion, setCesiumAvailable]);
 
   // Sync the active Cesium source model ID so terrain actions are scoped correctly
   useEffect(() => {

--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -224,6 +224,7 @@ const createViewerStore = () => create<ViewerState>()((...args) => ({
       separationLinesRadius: UI_DEFAULTS.SEPARATION_LINES_RADIUS,
 
       // Cesium
+      cesiumAvailable: false,
       cesiumEnabled: false,
       cesiumTerrainHeight: null,
       cesiumTerrainClamp: false,

--- a/apps/viewer/src/store/slices/cesiumSlice.ts
+++ b/apps/viewer/src/store/slices/cesiumSlice.ts
@@ -23,6 +23,8 @@ export type CesiumDataSource =
 
 export interface CesiumSlice {
   // State
+  /** Whether a loaded model (or user mutations) provide enough georeferencing to place in Cesium. */
+  cesiumAvailable: boolean;
   cesiumEnabled: boolean;
   cesiumDataSource: CesiumDataSource;
   /** Resolved Cesium ion access token (user override or build-time default). */
@@ -41,6 +43,7 @@ export interface CesiumSlice {
   cesiumGlbLoaded: boolean;
 
   // Actions
+  setCesiumAvailable: (available: boolean) => void;
   setCesiumEnabled: (enabled: boolean) => void;
   toggleCesium: () => void;
   setCesiumDataSource: (source: CesiumDataSource) => void;
@@ -93,6 +96,7 @@ function resolveIonToken(): string {
 }
 
 export const createCesiumSlice: StateCreator<CesiumSlice, [], [], CesiumSlice> = (set) => ({
+  cesiumAvailable: false,
   cesiumEnabled: false,
   cesiumDataSource: loadDataSource(),
   cesiumIonToken: resolveIonToken(),
@@ -103,6 +107,7 @@ export const createCesiumSlice: StateCreator<CesiumSlice, [], [], CesiumSlice> =
   cesiumTerrainClipY: null,
   cesiumGlbLoaded: false,
 
+  setCesiumAvailable: (available) => set({ cesiumAvailable: available }),
   setCesiumEnabled: (enabled) => set({ cesiumEnabled: enabled }),
   toggleCesium: () => set((s) => ({ cesiumEnabled: !s.cesiumEnabled })),
   setCesiumDataSource: (source) => {


### PR DESCRIPTION
## Summary
This PR adds a new `cesiumAvailable` state to track whether a loaded model has sufficient georeferencing data to be displayed in Cesium. The Cesium 3D Context button now only appears when this condition is met, rather than whenever any model is loaded.

## Key Changes
- **New state property**: Added `cesiumAvailable` boolean to the Cesium slice to track georeferencing availability
- **Georeferencing detection**: Implemented `hasGeoref()` logic in `ViewportContainer` that checks both federated and legacy models for georeferencing data (either original or via user mutations)
- **Reactive button visibility**: Updated `MainToolbar` to conditionally render the Cesium button based on `cesiumAvailable` instead of `hasModelsLoaded`
- **Store integration**: Added `setCesiumAvailable` action and initialized the state across both the Cesium slice and main store

## Implementation Details
- The `hasGeoref()` function iterates through all federated models and checks for projected CRS data from either the original IFC data or user-applied georeferencing mutations
- The effect runs independently of `cesiumEnabled`, ensuring the button appears/disappears reactively as models are loaded or georeferencing is added
- The check supports both the federated model approach and legacy single-model fallback using the `'__legacy__'` key
- Dependencies include `storeModels`, `ifcDataStore`, `georefMutations`, and `mutationVersion` to ensure updates when any relevant data changes

https://claude.ai/code/session_013KtUsL8m5do1oWfcnrq4Pz