### PR TITLE
fix: restore model metadata and georeferencing in properties panel

### DIFF
--- a/apps/viewer/src/components/viewer/PropertiesPanel.tsx
+++ b/apps/viewer/src/components/viewer/PropertiesPanel.tsx
@@ -904,7 +904,12 @@ export function PropertiesPanel() {
   }
 
   if (!selectedEntityId || (!isNativeLazySelection && (!modelQuery || !entityNode))) {
-    // Show model metadata when a single legacy model is loaded and nothing selected
+    // Show model metadata when a single model is loaded and nothing selected.
+    // Handles both federated models (models.size >= 1) and legacy single-model path (models.size === 0).
+    if (models.size === 1) {
+      const singleModel = models.values().next().value as FederatedModel;
+      return <ModelMetadataPanel model={singleModel} />;
+    }
     if (ifcDataStore && models.size === 0 && geometryResult) {
       const legacyModel: FederatedModel = {
         id: '__legacy__',
@@ -921,6 +926,7 @@ export function PropertiesPanel() {
       };
       return <ModelMetadataPanel model={legacyModel} />;
     }
+    // Multi-model or no model loaded: show empty state
     return (
       <div className="h-full flex flex-col border-l-2 border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-black">
         <div className="p-3 border-b-2 border-zinc-200 dark:border-zinc-800 bg-white dark:bg-black">


### PR DESCRIPTION
## Summary
- After the desktop merge (`3cd8a2cb`), loading a single model goes through `addModel()` into the federated `models` Map (`models.size === 1`), but the empty-state logic only showed `ModelMetadataPanel` for the legacy path (`models.size === 0`)
- Added a `models.size === 1` check that renders `ModelMetadataPanel` with the actual `FederatedModel` data — restoring file info, schema version, entity stats, length units, georeferencing, and project information
- Legacy fallback (`models.size === 0`) and multi-model empty state (`models.size > 1`) are preserved

## Test plan
- [x] Load a single IFC file — properties panel should show model metadata (stats, georeferencing, units, project info) when nothing is selected
- [x] Load multiple IFC files — properties panel should show "Select a model or element" when nothing is selected
- [x] Click a model in the hierarchy — should still show that model's metadata
- [x] Select an element — should show element properties as before
- [x] Verify on desktop (native metadata path) — same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)