### PR TITLE
feat: merge multilayer wall layers into single solid

### DIFF
--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -285,6 +285,8 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
   const toggleHoverTooltips = useViewerStore((state) => state.toggleHoverTooltips);
   const typeVisibility = useViewerStore((state) => state.typeVisibility);
   const toggleTypeVisibility = useViewerStore((state) => state.toggleTypeVisibility);
+  const mergeWallLayers = useViewerStore((state) => state.mergeWallLayers);
+  const setMergeWallLayers = useViewerStore((state) => state.setMergeWallLayers);
   const resetViewerState = useViewerStore((state) => state.resetViewerState);
   const bcfPanelVisible = useViewerStore((state) => state.bcfPanelVisible);
   const setBcfPanelVisible = useViewerStore((state) => state.setBcfPanelVisible);
@@ -1130,6 +1132,13 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
               Show Site
             </DropdownMenuCheckboxItem>
           )}
+          <DropdownMenuSeparator />
+          <DropdownMenuCheckboxItem
+            checked={mergeWallLayers}
+            onCheckedChange={(checked) => setMergeWallLayers(checked)}
+          >
+            Merge Wall Layers
+          </DropdownMenuCheckboxItem>
         </DropdownMenuContent>
       </DropdownMenu>
 

--- a/apps/viewer/src/hooks/ingest/viewerModelIngest.ts
+++ b/apps/viewer/src/hooks/ingest/viewerModelIngest.ts
@@ -51,6 +51,8 @@ export interface StepBufferIngestOptions {
   onSpatialReady?: (dataStore: IfcDataStore) => void;
   onRtcOffset?: (event: StepRtcOffsetEvent) => void;
   shouldAbort?: () => boolean;
+  /** When true, multilayer wall parts are merged into single solids */
+  mergeLayers?: boolean;
   /** Shared RTC offset from first federated model (IFC Z-up coords).
    *  When set, this model uses the same RTC as the first model instead of
    *  computing its own, ensuring all models share the same coordinate space. */
@@ -183,7 +185,7 @@ export async function parseGlbViewerModel(buffer: ArrayBuffer): Promise<ViewerMo
 }
 
 export async function parseStepBufferViewerModel(options: StepBufferIngestOptions): Promise<StepBufferIngestResult> {
-  const geometryProcessor = new GeometryProcessor({ quality: GeometryQuality.Balanced });
+  const geometryProcessor = new GeometryProcessor({ quality: GeometryQuality.Balanced, mergeLayers: options.mergeLayers });
   await geometryProcessor.init();
 
   const parser = new IfcParser();

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -654,6 +654,7 @@ export function useIfcLoader() {
         const geometryProcessor = new GeometryProcessor({
           quality: GeometryQuality.Balanced,
           preferNative: true,
+          mergeLayers: getViewerStoreApi().getState().mergeWallLayers,
         });
 
         let estimatedTotal = 0;
@@ -1662,9 +1663,11 @@ export function useIfcLoader() {
         && file.size < HUGE_NATIVE_FILE_THRESHOLD;
 
       // Initialize geometry processor first (WASM init is fast if already loaded)
+      const { mergeWallLayers } = getViewerStoreApi().getState();
       const geometryProcessor = new GeometryProcessor({
         quality: GeometryQuality.Balanced,
         preferNative: false,
+        mergeLayers: mergeWallLayers,
       });
       await geometryProcessor.init();
 

--- a/apps/viewer/src/store/constants.ts
+++ b/apps/viewer/src/store/constants.ts
@@ -86,6 +86,8 @@ export const UI_DEFAULTS = {
   SEPARATION_LINES_INTENSITY: 0.38,
   /** Separation-line radius in pixels */
   SEPARATION_LINES_RADIUS: 1.0,
+  /** Merge multilayer wall parts into single solids on import */
+  MERGE_WALL_LAYERS: false,
 } as const;
 
 // ============================================================================

--- a/apps/viewer/src/store/slices/uiSlice.ts
+++ b/apps/viewer/src/store/slices/uiSlice.ts
@@ -30,6 +30,8 @@ export interface UISlice {
   separationLinesQuality: SeparationLinesQuality;
   separationLinesIntensity: number;
   separationLinesRadius: number;
+  /** When true, multilayer wall parts are merged into single solids on import */
+  mergeWallLayers: boolean;
 
   // Actions
   setLeftPanelCollapsed: (collapsed: boolean) => void;
@@ -51,6 +53,7 @@ export interface UISlice {
   setSeparationLinesQuality: (quality: SeparationLinesQuality) => void;
   setSeparationLinesIntensity: (intensity: number) => void;
   setSeparationLinesRadius: (radius: number) => void;
+  setMergeWallLayers: (enabled: boolean) => void;
 }
 
 /** Apply the correct CSS classes on <html> for the given theme */
@@ -78,6 +81,7 @@ export const createUISlice: StateCreator<UISlice, [], [], UISlice> = (set, get) 
   separationLinesQuality: UI_DEFAULTS.SEPARATION_LINES_QUALITY,
   separationLinesIntensity: UI_DEFAULTS.SEPARATION_LINES_INTENSITY,
   separationLinesRadius: UI_DEFAULTS.SEPARATION_LINES_RADIUS,
+  mergeWallLayers: UI_DEFAULTS.MERGE_WALL_LAYERS,
 
   // Actions
   setLeftPanelCollapsed: (leftPanelCollapsed) => set({ leftPanelCollapsed }),
@@ -121,4 +125,5 @@ export const createUISlice: StateCreator<UISlice, [], [], UISlice> = (set, get) 
   setSeparationLinesQuality: (separationLinesQuality) => set({ separationLinesQuality }),
   setSeparationLinesIntensity: (separationLinesIntensity) => set({ separationLinesIntensity }),
   setSeparationLinesRadius: (separationLinesRadius) => set({ separationLinesRadius }),
+  setMergeWallLayers: (mergeWallLayers) => set({ mergeWallLayers }),
 });

--- a/packages/geometry/src/ifc-lite-bridge.ts
+++ b/packages/geometry/src/ifc-lite-bridge.ts
@@ -58,6 +58,8 @@ export interface InstancedStreamingStats {
 
 export interface ParseMeshesAsyncOptions {
   batchSize?: number;
+  /** Merge multilayer wall parts into a single solid per wall. Reduces draw calls for large models. */
+  mergeLayers?: boolean;
   // NOTE: WASM automatically defers style building for faster first frame
   onBatch?: (meshes: MeshDataJs[], progress: StreamingProgress) => void;
   onComplete?: (stats: StreamingStats) => void;
@@ -133,14 +135,18 @@ export class IfcLiteBridge {
   /**
    * Parse IFC content and return mesh collection (blocking)
    * Returns individual meshes with express IDs and colors
+   * @param content Raw IFC file text
+   * @param mergeLayers When true, multilayer wall parts are merged into a single solid per wall
    */
-  parseMeshes(content: string): MeshCollection {
+  parseMeshes(content: string, mergeLayers: boolean = false): MeshCollection {
     if (!this.ifcApi) {
       throw new Error('IFC-Lite not initialized. Call init() first.');
     }
     try {
-      const collection = this.ifcApi.parseMeshes(content);
-      log.debug(`Parsed ${collection.length} meshes`, { operation: 'parseMeshes' });
+      const collection = mergeLayers
+        ? this.ifcApi.parseMeshesMergeLayers(content)
+        : this.ifcApi.parseMeshes(content);
+      log.debug(`Parsed ${collection.length} meshes${mergeLayers ? ' (layers merged)' : ''}`, { operation: 'parseMeshes' });
       return collection;
     } catch (error) {
       log.error('Failed to parse IFC geometry', error, {
@@ -283,14 +289,17 @@ export class IfcLiteBridge {
    * Parse a subset of IFC geometry entities by index range.
    * Performs the full pre-pass but only processes entities in [startIdx, endIdx).
    * Designed for Web Worker parallelization where each worker handles a slice.
+   * @param mergeLayers When true, multilayer wall parts are merged into a single solid per wall
    */
-  parseMeshesSubset(content: string, startIdx: number, endIdx: number, skipExpensive: boolean = false): MeshCollection {
+  parseMeshesSubset(content: string, startIdx: number, endIdx: number, skipExpensive: boolean = false, mergeLayers: boolean = false): MeshCollection {
     if (!this.ifcApi) {
       throw new Error('IFC-Lite not initialized. Call init() first.');
     }
     try {
-      const collection = this.ifcApi.parseMeshesSubset(content, startIdx, endIdx, skipExpensive);
-      log.debug(`Parsed subset [${startIdx}, ${endIdx}) → ${collection.length} meshes`, { operation: 'parseMeshesSubset' });
+      const collection = mergeLayers
+        ? this.ifcApi.parseMeshesSubsetMergeLayers(content, startIdx, endIdx, skipExpensive)
+        : this.ifcApi.parseMeshesSubset(content, startIdx, endIdx, skipExpensive);
+      log.debug(`Parsed subset [${startIdx}, ${endIdx}) → ${collection.length} meshes${mergeLayers ? ' (layers merged)' : ''}`, { operation: 'parseMeshesSubset' });
       return collection;
     } catch (error) {
       log.error('Failed to parse IFC geometry subset', error, {

--- a/packages/geometry/src/ifc-lite-mesh-collector.ts
+++ b/packages/geometry/src/ifc-lite-mesh-collector.ts
@@ -53,10 +53,13 @@ export class IfcLiteMeshCollector {
   private ifcApi: IfcAPI;
   private content: string;
   private _buildingRotation: number | undefined;
+  /** When true, multilayer wall parts are merged into a single solid per wall */
+  private mergeLayers: boolean;
 
-  constructor(ifcApi: IfcAPI, content: string) {
+  constructor(ifcApi: IfcAPI, content: string, mergeLayers: boolean = false) {
     this.ifcApi = ifcApi;
     this.content = content;
+    this.mergeLayers = mergeLayers;
   }
 
   /**
@@ -105,7 +108,9 @@ export class IfcLiteMeshCollector {
   collectMeshes(): MeshData[] {
     let collection: MeshCollection;
     try {
-      collection = this.ifcApi.parseMeshes(this.content);
+      collection = this.mergeLayers
+        ? this.ifcApi.parseMeshesMergeLayers(this.content)
+        : this.ifcApi.parseMeshes(this.content);
     } catch (error) {
       log.error('WASM mesh parsing failed', error, { operation: 'collectMeshes' });
       throw error;
@@ -206,6 +211,7 @@ export class IfcLiteMeshCollector {
     // NOTE: WASM now automatically defers style building for faster first frame
     const processingPromise = this.ifcApi.parseMeshesAsync(this.content, {
       batchSize,
+      mergeLayers: this.mergeLayers,
       onRtcOffset: (rtc: { x: number; y: number; z: number; hasRtc: boolean }) => {
         // Emit RTC offset event so consumer can capture it
         batchQueue.push({

--- a/packages/geometry/src/index.ts
+++ b/packages/geometry/src/index.ts
@@ -85,6 +85,8 @@ interface ByteStreamingPrePassResult {
 export interface GeometryProcessorOptions {
   quality?: GeometryQuality; // Default: Balanced
   preferNative?: boolean; // Default: true in Tauri
+  /** Merge multilayer wall parts into a single solid per wall. Reduces draw calls for large models. */
+  mergeLayers?: boolean; // Default: false
 }
 
 /**
@@ -149,11 +151,14 @@ export class GeometryProcessor {
   private coordinateHandler: CoordinateHandler;
   private isNative: boolean = false;
   private lastNativeStats: PlatformGeometryStats | null = null;
+  /** When true, multilayer wall parts are merged into a single solid per wall */
+  private mergeLayers: boolean = false;
 
   constructor(options: GeometryProcessorOptions = {}) {
     this.bufferBuilder = new BufferBuilder();
     this.coordinateHandler = new CoordinateHandler();
     this.isNative = options.preferNative !== false && isTauri();
+    this.mergeLayers = options.mergeLayers ?? false;
     // Note: options accepted for API compatibility
     void options.quality;
 
@@ -280,7 +285,7 @@ export class GeometryProcessor {
     const decoder = new TextDecoder();
     const content = decoder.decode(buffer);
 
-    const collector = new IfcLiteMeshCollector(this.bridge.getApi(), content);
+    const collector = new IfcLiteMeshCollector(this.bridge.getApi(), content, this.mergeLayers);
     const meshes = collector.collectMeshes();
     const buildingRotation = collector.getBuildingRotation();
 
@@ -612,7 +617,7 @@ export class GeometryProcessor {
 
       yield { type: 'model-open', modelID: 0 };
 
-      const collector = new IfcLiteMeshCollector(this.bridge.getApi(), content);
+      const collector = new IfcLiteMeshCollector(this.bridge.getApi(), content, this.mergeLayers);
       let totalMeshes = 0;
       let extractedBuildingRotation: number | undefined = undefined;
 

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -219,6 +219,12 @@ export class IfcAPI {
    */
   parseMeshes(content: string): MeshCollection;
   /**
+   * Parse IFC file with multilayer wall merging enabled.
+   * Same as `parseMeshes` but merges child `IfcBuildingElementPart` layers
+   * of multilayer walls into a single solid mesh per wall.
+   */
+  parseMeshesMergeLayers(content: string): MeshCollection;
+  /**
    * Parse IFC file with streaming mesh batches for progressive rendering
    * Calls the callback with batches of meshes, yielding to browser between batches
    *
@@ -286,6 +292,11 @@ export class IfcAPI {
    * ```
    */
   parseMeshesSubset(content: string, start_idx: number, end_idx: number, skip_expensive: boolean): MeshCollection;
+  /**
+   * Parse a subset of IFC geometry entities with multilayer wall merging.
+   * Same as `parseMeshesSubset` but merges child wall layers into parent walls.
+   */
+  parseMeshesSubsetMergeLayers(content: string, start_idx: number, end_idx: number, skip_expensive: boolean): MeshCollection;
   /**
    * Parse IFC file and return GPU-ready geometry for zero-copy upload
    *

--- a/rust/wasm-bindings/src/api/gpu_meshes.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes.rs
@@ -348,6 +348,194 @@ impl IfcAPI {
         mesh_collection
     }
 
+    /// Parse IFC file with multilayer wall merging enabled.
+    ///
+    /// Same as `parseMeshes` but merges child `IfcBuildingElementPart` layers
+    /// of multilayer walls into a single solid mesh per wall. This reduces
+    /// draw calls and memory usage for large models with multilayer walls.
+    ///
+    /// Example:
+    /// ```javascript
+    /// const api = new IfcAPI();
+    /// const collection = api.parseMeshesMergeLayers(ifcData);
+    /// // Multilayer walls now produce 1 mesh instead of N meshes per layer
+    /// ```
+    #[wasm_bindgen(js_name = parseMeshesMergeLayers)]
+    pub fn parse_meshes_merge_layers(&self, content: String) -> MeshCollection {
+        use super::styling::combined_pre_pass;
+        use ifc_lite_core::EntityDecoder;
+        use ifc_lite_geometry::{calculate_normals, GeometryRouter};
+
+        // Use combined_pre_pass for aggregate relationship collection
+        let entity_index = ifc_lite_core::build_entity_index(&content);
+        let mut decoder = EntityDecoder::with_index(&content, entity_index);
+        let pre_pass = combined_pre_pass(&content, &mut decoder);
+
+        let total_jobs = pre_pass.simple_jobs.len() + pre_pass.complex_jobs.len();
+        decoder.reserve_cache(total_jobs * 2);
+
+        // Setup router with units and RTC offset
+        let unit_scale = pre_pass
+            .project_id
+            .and_then(|pid| ifc_lite_core::extract_length_unit_scale(&mut decoder, pid).ok())
+            .unwrap_or(1.0);
+        let mut router = GeometryRouter::with_scale(unit_scale);
+
+        let rtc_jobs: Vec<_> = pre_pass
+            .simple_jobs
+            .iter()
+            .take(25)
+            .chain(pre_pass.complex_jobs.iter().take(25))
+            .copied()
+            .collect();
+        let rtc_offset = router
+            .detect_rtc_offset_from_jobs(&rtc_jobs, &mut decoder)
+            .unwrap_or((0.0, 0.0, 0.0));
+        let needs_shift = rtc_offset.0.abs() > 10000.0
+            || rtc_offset.1.abs() > 10000.0
+            || rtc_offset.2.abs() > 10000.0;
+
+        if needs_shift {
+            router.set_rtc_offset(rtc_offset);
+        }
+
+        // Batch preprocess FacetedBreps
+        if !pre_pass.faceted_brep_ids.is_empty() {
+            router.preprocess_faceted_breps(&pre_pass.faceted_brep_ids, &mut decoder);
+        }
+
+        // Build element style map
+        let mut element_styles: rustc_hash::FxHashMap<u32, [f32; 4]> =
+            rustc_hash::FxHashMap::default();
+        if !pre_pass.geometry_styles.is_empty() {
+            for jobs in [&pre_pass.simple_jobs, &pre_pass.complex_jobs] {
+                for &(id, start, end, _ifc_type) in jobs.iter() {
+                    if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
+                        if entity.get(6).map(|a| !a.is_null()).unwrap_or(false) {
+                            if let Some(color) = super::styling::resolve_element_color(
+                                &entity,
+                                &pre_pass.geometry_styles,
+                                &mut decoder,
+                            ) {
+                                element_styles.insert(id, color);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        let building_rotation = pre_pass
+            .site_position
+            .and_then(|pos| {
+                super::styling::extract_building_rotation_from_site(pos, &mut decoder)
+            });
+
+        // Process all elements
+        let all_jobs: Vec<_> = pre_pass
+            .simple_jobs
+            .iter()
+            .chain(pre_pass.complex_jobs.iter())
+            .copied()
+            .collect();
+
+        let mut mesh_collection = MeshCollection::with_capacity(all_jobs.len());
+        if needs_shift {
+            mesh_collection.set_rtc_offset(rtc_offset.0, rtc_offset.1, rtc_offset.2);
+        }
+        mesh_collection.set_building_rotation(building_rotation);
+
+        let mut type_name_cache: rustc_hash::FxHashMap<ifc_lite_core::IfcType, String> =
+            rustc_hash::FxHashMap::default();
+
+        for &(id, job_start, job_end, ifc_type) in &all_jobs {
+            if let Ok(entity) = decoder.decode_at_with_id(id, job_start, job_end) {
+                let has_representation = entity.get(6).map(|a| !a.is_null()).unwrap_or(false);
+                if !has_representation {
+                    continue;
+                }
+
+                let has_openings = pre_pass.void_index.contains_key(&id);
+                let default_color = get_default_color_for_type(&ifc_type);
+                let element_color = element_styles.get(&id).copied();
+                let ifc_type_name = type_name_cache
+                    .entry(ifc_type)
+                    .or_insert_with(|| ifc_type.name().to_string())
+                    .clone();
+
+                let mut push_mesh = |mesh: &mut ifc_lite_geometry::Mesh, color: [f32; 4]| {
+                    if mesh.is_empty() {
+                        return;
+                    }
+                    if mesh.normals.len() != mesh.positions.len() {
+                        calculate_normals(mesh);
+                    }
+                    let mesh_data = MeshDataJs::new(id, ifc_type_name.clone(), mesh.clone(), color);
+                    mesh_collection.add(mesh_data);
+                };
+
+                if has_openings {
+                    if let Ok(mut mesh) = router.process_element_with_voids(
+                        &entity,
+                        &mut decoder,
+                        &pre_pass.void_index,
+                    ) {
+                        let color = element_color.unwrap_or(default_color);
+                        push_mesh(&mut mesh, color);
+                    }
+                } else {
+                    let skip_submesh = matches!(ifc_type, ifc_lite_core::IfcType::IfcSite);
+                    let sub_meshes_result = if skip_submesh {
+                        Err(ifc_lite_geometry::Error::geometry(
+                            "Skip submesh for IfcSite".to_string(),
+                        ))
+                    } else {
+                        router.process_element_with_submeshes(&entity, &mut decoder)
+                    };
+
+                    let has_submeshes = sub_meshes_result
+                        .as_ref()
+                        .map(|s| !s.is_empty())
+                        .unwrap_or(false);
+
+                    if has_submeshes {
+                        let sub_meshes = sub_meshes_result.unwrap();
+                        let mat_colors = pre_pass.element_material_styles.get(&id);
+                        let mut mat_color_idx = 0usize;
+
+                        for sub in sub_meshes.sub_meshes {
+                            let mut mesh = sub.mesh;
+                            let color = resolve_submesh_color(
+                                sub.geometry_id,
+                                &pre_pass.geometry_styles,
+                                &mut decoder,
+                                mat_colors,
+                                &mut mat_color_idx,
+                                element_color,
+                                default_color,
+                            );
+                            push_mesh(&mut mesh, color);
+                        }
+                    } else if let Ok(mut mesh) = router.process_element(&entity, &mut decoder) {
+                        let color = element_color.unwrap_or(default_color);
+                        push_mesh(&mut mesh, color);
+                    }
+                }
+            }
+        }
+
+        // Post-process: merge multilayer wall children into parent walls
+        let default_wall_color = get_default_color_for_type(&ifc_lite_core::IfcType::IfcWall);
+        mesh_collection.merge_wall_layers(
+            &pre_pass.wall_aggregate_index,
+            &pre_pass.child_to_wall_parent,
+            &element_styles,
+            default_wall_color,
+        );
+
+        mesh_collection
+    }
+
     /// Parse a subset of IFC geometry entities by index range.
     ///
     /// Performs the full pre-pass (entity index, combined style/void/brep scan)
@@ -551,6 +739,57 @@ impl IfcAPI {
         }
 
         mesh_collection
+    }
+
+    /// Parse a subset of IFC geometry entities with multilayer wall merging.
+    /// Same as `parseMeshesSubset` but merges child wall layers into parent walls.
+    #[wasm_bindgen(js_name = parseMeshesSubsetMergeLayers)]
+    pub fn parse_meshes_subset_merge_layers(
+        &self,
+        content: String,
+        start_idx: u32,
+        end_idx: u32,
+        skip_expensive: bool,
+    ) -> MeshCollection {
+        let mut collection =
+            self.parse_meshes_subset(content.clone(), start_idx, end_idx, skip_expensive);
+
+        // Build aggregate index from file content for merge
+        let entity_index = ifc_lite_core::build_entity_index(&content);
+        let mut decoder = ifc_lite_core::EntityDecoder::with_index(&content, entity_index);
+        let pre_pass = super::styling::combined_pre_pass(&content, &mut decoder);
+
+        // Build element styles for color lookup
+        let mut element_styles: rustc_hash::FxHashMap<u32, [f32; 4]> =
+            rustc_hash::FxHashMap::default();
+        if !pre_pass.geometry_styles.is_empty() {
+            for jobs in [&pre_pass.simple_jobs, &pre_pass.complex_jobs] {
+                for &(id, start, end, _ifc_type) in jobs.iter() {
+                    if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
+                        if entity.get(6).map(|a| !a.is_null()).unwrap_or(false) {
+                            if let Some(color) = super::styling::resolve_element_color(
+                                &entity,
+                                &pre_pass.geometry_styles,
+                                &mut decoder,
+                            ) {
+                                element_styles.insert(id, color);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        let default_wall_color =
+            get_default_color_for_type(&ifc_lite_core::IfcType::IfcWall);
+        collection.merge_wall_layers(
+            &pre_pass.wall_aggregate_index,
+            &pre_pass.child_to_wall_parent,
+            &element_styles,
+            default_wall_color,
+        );
+
+        collection
     }
 
     /// Parse IFC file and return instanced geometry grouped by geometry hash
@@ -1220,6 +1459,11 @@ impl IfcAPI {
                     .ok()
                     .and_then(|v| v.dyn_into::<Function>().ok());
 
+                let merge_layers: bool = js_sys::Reflect::get(&options, &"mergeLayers".into())
+                    .ok()
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+
                 // ── Phase 1: Build entity index (fast memchr scan, ~200 ms) ──
                 let entity_index = ifc_lite_core::build_entity_index(&content);
                 let mut decoder = EntityDecoder::with_index(&content, entity_index);
@@ -1332,6 +1576,11 @@ impl IfcAPI {
                 let mut type_name_cache: rustc_hash::FxHashMap<ifc_lite_core::IfcType, String> =
                     rustc_hash::FxHashMap::default();
 
+                // When merge_layers is enabled, accumulate child layer meshes
+                // instead of emitting them immediately. They'll be merged and
+                // emitted as a final batch after all processing completes.
+                let mut deferred_layer_meshes: Vec<MeshDataJs> = Vec::new();
+
                 // Process simple geometry first (walls, slabs, etc.) for fast first frame
                 for &(id, start, end, ifc_type) in &pre_pass.simple_jobs {
                     if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
@@ -1363,7 +1612,13 @@ impl IfcAPI {
                                         .or_insert_with(|| ifc_type.name().to_string())
                                         .clone();
                                     let mesh_data = MeshDataJs::new(id, ifc_type_name, mesh, color);
-                                    batch_meshes.push(mesh_data);
+
+                                    // Defer child layer meshes for merging
+                                    if merge_layers && pre_pass.child_to_wall_parent.contains_key(&id) {
+                                        deferred_layer_meshes.push(mesh_data);
+                                    } else {
+                                        batch_meshes.push(mesh_data);
+                                    }
                                     processed += 1;
                                 }
                             }
@@ -1438,6 +1693,9 @@ impl IfcAPI {
                         // O(1) color lookup from pre-built element style map
                         let element_color = element_styles.get(&id).copied();
 
+                        // Helper: push mesh to batch or defer for layer merging
+                        let is_deferred_child = merge_layers && pre_pass.child_to_wall_parent.contains_key(&id);
+
                         if has_openings {
                             // Element has openings - use void subtraction (merged mesh)
                             if let Ok(mut mesh) = router.process_element_with_voids(
@@ -1456,7 +1714,11 @@ impl IfcAPI {
                                     total_triangles += mesh.indices.len() / 3;
 
                                     let mesh_data = MeshDataJs::new(id, ifc_type_name, mesh, color);
-                                    batch_meshes.push(mesh_data);
+                                    if is_deferred_child {
+                                        deferred_layer_meshes.push(mesh_data);
+                                    } else {
+                                        batch_meshes.push(mesh_data);
+                                    }
                                 }
                             }
                         } else {
@@ -1508,7 +1770,11 @@ impl IfcAPI {
 
                                     let mesh_data =
                                         MeshDataJs::new(id, ifc_type_name.clone(), mesh, color);
-                                    batch_meshes.push(mesh_data);
+                                    if is_deferred_child {
+                                        deferred_layer_meshes.push(mesh_data);
+                                    } else {
+                                        batch_meshes.push(mesh_data);
+                                    }
                                 }
                             } else {
                                 // Fallback: use simple single-mesh approach
@@ -1527,7 +1793,11 @@ impl IfcAPI {
 
                                         let mesh_data =
                                             MeshDataJs::new(id, ifc_type_name, mesh, color);
-                                        batch_meshes.push(mesh_data);
+                                        if is_deferred_child {
+                                            deferred_layer_meshes.push(mesh_data);
+                                        } else {
+                                            batch_meshes.push(mesh_data);
+                                        }
                                     }
                                 }
                             }
@@ -1570,6 +1840,40 @@ impl IfcAPI {
                         let progress = js_sys::Object::new();
                         super::set_js_prop(&progress, "percent", &100u32.into());
                         super::set_js_prop(&progress, "phase", &"complete".into());
+
+                        let _ = callback.call2(&JsValue::NULL, &js_meshes, &progress);
+                        total_meshes += js_meshes.length() as usize;
+                    }
+                }
+
+                // Merge deferred layer meshes and emit as final batch
+                if merge_layers && !deferred_layer_meshes.is_empty() {
+                    // Build a temporary MeshCollection to use merge_wall_layers
+                    let mut merge_collection = MeshCollection::from_vec(deferred_layer_meshes);
+                    let default_wall_color = get_default_color_for_type(&ifc_lite_core::IfcType::IfcWall);
+                    merge_collection.merge_wall_layers(
+                        &pre_pass.wall_aggregate_index,
+                        &pre_pass.child_to_wall_parent,
+                        &element_styles,
+                        default_wall_color,
+                    );
+
+                    // Emit merged meshes as a final batch
+                    if let Some(ref callback) = on_batch {
+                        let js_meshes = js_sys::Array::new();
+                        let merged_count = merge_collection.len();
+                        // Move meshes out of collection into JS array
+                        for i in 0..merged_count {
+                            if let Some(mesh) = merge_collection.get(i) {
+                                total_vertices += mesh.vertex_count();
+                                total_triangles += mesh.triangle_count();
+                                js_meshes.push(&mesh.into());
+                            }
+                        }
+
+                        let progress = js_sys::Object::new();
+                        super::set_js_prop(&progress, "percent", &100u32.into());
+                        super::set_js_prop(&progress, "phase", &"merged_layers".into());
 
                         let _ = callback.call2(&JsValue::NULL, &js_meshes, &progress);
                         total_meshes += js_meshes.length() as usize;

--- a/rust/wasm-bindings/src/api/styling.rs
+++ b/rust/wasm-bindings/src/api/styling.rs
@@ -385,6 +385,11 @@ pub(crate) struct PrePassData {
     /// Element ID → list of material-based colors (from IfcRelAssociatesMaterial chain).
     /// Used as fallback when a sub-mesh has no direct IfcStyledItem style.
     pub element_material_styles: rustc_hash::FxHashMap<u32, Vec<[f32; 4]>>,
+    /// Aggregate parent → child IDs (from IfcRelAggregates where parent is IfcWall/IfcWallStandardCase
+    /// and children are IfcBuildingElementPart). Used for multilayer wall merging.
+    pub wall_aggregate_index: rustc_hash::FxHashMap<u32, Vec<u32>>,
+    /// Reverse map: child IfcBuildingElementPart ID → parent IfcWall ID.
+    pub child_to_wall_parent: rustc_hash::FxHashMap<u32, u32>,
 }
 
 /// Single EntityScanner pass that collects everything needed before geometry
@@ -417,6 +422,10 @@ pub(crate) fn combined_pre_pass(
     let mut material_def_reprs: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
     // IfcRelAssociatesMaterial: element_id → material_select_id
     let mut element_to_material: FxHashMap<u32, u32> = FxHashMap::default();
+
+    // Aggregate relationships for multilayer wall merging
+    // Collected raw first, then filtered to wall→part relationships after the scan
+    let mut raw_aggregates: Vec<(u32, Vec<u32>)> = Vec::new();
 
     let mut scanner = EntityScanner::new(content);
 
@@ -465,6 +474,23 @@ pub(crate) fn combined_pre_pass(
                     }
                 }
             }
+            "IFCRELAGGREGATES" => {
+                // Collect aggregate parent→children for multilayer wall merging.
+                // IfcRelAggregates: attr 4 = RelatingObject, attr 5 = RelatedObjects
+                if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
+                    if let Some(parent_id) = entity.get_ref(4) {
+                        if let Some(children_attr) = entity.get(5) {
+                            if let Some(list) = children_attr.as_list() {
+                                let children: Vec<u32> =
+                                    list.iter().filter_map(|item| item.as_entity_ref()).collect();
+                                if !children.is_empty() {
+                                    raw_aggregates.push((parent_id, children));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
             "IFCFACETEDBREP" => {
                 faceted_brep_ids.push(id);
             }
@@ -506,6 +532,38 @@ pub(crate) fn combined_pre_pass(
     // so that multilayer wall parts also get window/door cutouts.
     ifc_lite_geometry::propagate_voids_to_parts(&mut void_index, content, decoder);
 
+    // Build wall aggregate index: filter raw aggregates to only wall→part relationships.
+    // Only keep aggregates where the parent is IfcWall/IfcWallStandardCase and
+    // children are IfcBuildingElementPart with geometry.
+    let mut wall_aggregate_index: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
+    let mut child_to_wall_parent: FxHashMap<u32, u32> = FxHashMap::default();
+    for (parent_id, children) in raw_aggregates {
+        if let Ok(parent) = decoder.decode_by_id(parent_id) {
+            let is_wall = matches!(
+                parent.ifc_type,
+                ifc_lite_core::IfcType::IfcWall | ifc_lite_core::IfcType::IfcWallStandardCase
+            );
+            if !is_wall {
+                continue;
+            }
+            let mut eligible_children = Vec::new();
+            for child_id in children {
+                if let Ok(child) = decoder.decode_by_id(child_id) {
+                    if child.ifc_type == ifc_lite_core::IfcType::IfcBuildingElementPart {
+                        let has_repr = child.get(6).map(|a| !a.is_null()).unwrap_or(false);
+                        if has_repr {
+                            eligible_children.push(child_id);
+                            child_to_wall_parent.insert(child_id, parent_id);
+                        }
+                    }
+                }
+            }
+            if !eligible_children.is_empty() {
+                wall_aggregate_index.insert(parent_id, eligible_children);
+            }
+        }
+    }
+
     PrePassData {
         geometry_styles,
         void_index,
@@ -515,6 +573,8 @@ pub(crate) fn combined_pre_pass(
         simple_jobs,
         complex_jobs,
         element_material_styles,
+        wall_aggregate_index,
+        child_to_wall_parent,
     }
 }
 

--- a/rust/wasm-bindings/src/zero_copy.rs
+++ b/rust/wasm-bindings/src/zero_copy.rs
@@ -269,6 +269,118 @@ impl MeshCollection {
         self.building_rotation = rotation;
     }
 
+    /// Merge multilayer wall children into their parent wall mesh.
+    ///
+    /// When `merge_layers` is enabled, child `IfcBuildingElementPart` meshes that belong
+    /// to a parent `IfcWall` (via `IfcRelAggregates`) are merged into a single mesh using
+    /// the parent wall's express ID and color. This reduces draw calls and memory usage
+    /// for large models with multilayer walls.
+    ///
+    /// # Arguments
+    /// * `wall_aggregate_index` - Parent wall ID → child part IDs
+    /// * `child_to_wall_parent` - Child part ID → parent wall ID
+    /// * `parent_colors` - Optional parent wall colors (from style index)
+    /// * `default_wall_color` - Fallback color for merged walls
+    pub fn merge_wall_layers(
+        &mut self,
+        wall_aggregate_index: &rustc_hash::FxHashMap<u32, Vec<u32>>,
+        child_to_wall_parent: &rustc_hash::FxHashMap<u32, u32>,
+        parent_colors: &rustc_hash::FxHashMap<u32, [f32; 4]>,
+        default_wall_color: [f32; 4],
+    ) {
+        if wall_aggregate_index.is_empty() {
+            return;
+        }
+
+        // Group mesh indices by parent wall ID
+        let mut parent_to_mesh_indices: rustc_hash::FxHashMap<u32, Vec<usize>> =
+            rustc_hash::FxHashMap::default();
+        for (idx, mesh) in self.meshes.iter().enumerate() {
+            if let Some(&parent_id) = child_to_wall_parent.get(&mesh.express_id) {
+                parent_to_mesh_indices
+                    .entry(parent_id)
+                    .or_default()
+                    .push(idx);
+            }
+        }
+
+        if parent_to_mesh_indices.is_empty() {
+            return;
+        }
+
+        // Collect indices of meshes to remove (children that will be merged)
+        let mut indices_to_remove: Vec<usize> = Vec::new();
+        // Collect merged meshes to add
+        let mut merged_meshes: Vec<MeshDataJs> = Vec::new();
+
+        for (parent_id, child_indices) in &parent_to_mesh_indices {
+            if child_indices.len() < 2 {
+                // Single layer — nothing to merge
+                continue;
+            }
+
+            // Calculate total capacity needed
+            let total_positions: usize = child_indices
+                .iter()
+                .map(|&i| self.meshes[i].positions.len())
+                .sum();
+            let total_normals: usize = child_indices
+                .iter()
+                .map(|&i| self.meshes[i].normals.len())
+                .sum();
+            let total_indices: usize = child_indices
+                .iter()
+                .map(|&i| self.meshes[i].indices.len())
+                .sum();
+
+            let mut merged_positions = Vec::with_capacity(total_positions);
+            let mut merged_normals = Vec::with_capacity(total_normals);
+            let mut merged_indices = Vec::with_capacity(total_indices);
+
+            // Merge all child meshes (coordinates are already in Y-up/WebGL space)
+            for &idx in child_indices {
+                let child = &self.meshes[idx];
+                let vertex_offset = (merged_positions.len() / 3) as u32;
+
+                merged_positions.extend_from_slice(&child.positions);
+                merged_normals.extend_from_slice(&child.normals);
+                merged_indices.extend(child.indices.iter().map(|&i| i + vertex_offset));
+            }
+
+            // Use parent wall's color, falling back to first child's color, then default
+            let color = parent_colors
+                .get(parent_id)
+                .copied()
+                .unwrap_or_else(|| self.meshes[child_indices[0]].color);
+            let _ = default_wall_color; // Available if neither parent nor child has color
+
+            merged_meshes.push(MeshDataJs {
+                express_id: *parent_id,
+                ifc_type: "IfcWall".to_string(),
+                positions: merged_positions,
+                normals: merged_normals,
+                indices: merged_indices,
+                color,
+            });
+
+            indices_to_remove.extend(child_indices);
+        }
+
+        if indices_to_remove.is_empty() {
+            return;
+        }
+
+        // Sort in reverse order so we can remove from back to front without invalidating indices
+        indices_to_remove.sort_unstable();
+        indices_to_remove.dedup();
+        for &idx in indices_to_remove.iter().rev() {
+            self.meshes.swap_remove(idx);
+        }
+
+        // Add merged meshes
+        self.meshes.extend(merged_meshes);
+    }
+
     /// Apply RTC offset to all meshes (shift coordinates)
     /// This is used when meshes are collected first and then shifted
     pub fn apply_rtc_offset(&mut self, x: f64, y: f64, z: f64) {
@@ -894,5 +1006,199 @@ mod tests {
         assert!(!mesh.positions_ptr().is_null());
         assert!(!mesh.normals_ptr().is_null());
         assert!(!mesh.indices_ptr().is_null());
+    }
+
+    /// Helper to create a MeshDataJs directly (bypassing coordinate conversion)
+    fn make_test_mesh(express_id: u32, ifc_type: &str, positions: Vec<f32>, color: [f32; 4]) -> MeshDataJs {
+        let vertex_count = positions.len() / 3;
+        let normals = vec![0.0; positions.len()];
+        let indices: Vec<u32> = if vertex_count >= 3 {
+            (0..vertex_count as u32).collect()
+        } else {
+            vec![]
+        };
+        MeshDataJs {
+            express_id,
+            ifc_type: ifc_type.to_string(),
+            positions,
+            normals,
+            indices,
+            color,
+        }
+    }
+
+    #[test]
+    fn test_merge_wall_layers_basic() {
+        use rustc_hash::FxHashMap;
+
+        // Parent wall #100 with two child layers #101, #102
+        let mut wall_aggregate_index: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
+        wall_aggregate_index.insert(100, vec![101, 102]);
+
+        let mut child_to_wall_parent: FxHashMap<u32, u32> = FxHashMap::default();
+        child_to_wall_parent.insert(101, 100);
+        child_to_wall_parent.insert(102, 100);
+
+        let parent_colors: FxHashMap<u32, [f32; 4]> = FxHashMap::default();
+        let default_wall_color = [0.8, 0.8, 0.8, 1.0];
+
+        // Create collection with 3 meshes: 2 child layers + 1 unrelated
+        let child1 = make_test_mesh(101, "IfcBuildingElementPart", vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0], [1.0, 0.0, 0.0, 1.0]);
+        let child2 = make_test_mesh(102, "IfcBuildingElementPart", vec![2.0, 0.0, 0.0, 3.0, 0.0, 0.0, 2.0, 1.0, 0.0], [0.0, 1.0, 0.0, 1.0]);
+        let unrelated = make_test_mesh(200, "IfcSlab", vec![0.0, 0.0, 0.0, 5.0, 0.0, 0.0, 0.0, 5.0, 0.0], [0.5, 0.5, 0.5, 1.0]);
+
+        let mut collection = MeshCollection::new();
+        collection.add(child1);
+        collection.add(child2);
+        collection.add(unrelated);
+
+        assert_eq!(collection.len(), 3);
+
+        collection.merge_wall_layers(
+            &wall_aggregate_index,
+            &child_to_wall_parent,
+            &parent_colors,
+            default_wall_color,
+        );
+
+        // Should have 2 meshes: 1 merged wall + 1 unrelated slab
+        assert_eq!(collection.len(), 2);
+
+        // Find the merged wall mesh
+        let merged = collection.meshes.iter().find(|m| m.express_id == 100);
+        assert!(merged.is_some(), "Merged wall mesh with parent ID 100 should exist");
+        let merged = merged.unwrap();
+
+        // Merged mesh should have all 6 vertices (3 from each child)
+        assert_eq!(merged.positions.len() / 3, 6);
+        assert_eq!(merged.ifc_type, "IfcWall");
+
+        // Unrelated slab should still be there
+        let slab = collection.meshes.iter().find(|m| m.express_id == 200);
+        assert!(slab.is_some(), "Unrelated slab should still exist");
+    }
+
+    #[test]
+    fn test_merge_wall_layers_single_layer_no_merge() {
+        use rustc_hash::FxHashMap;
+
+        // Parent wall #100 with only 1 child layer #101
+        let mut wall_aggregate_index: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
+        wall_aggregate_index.insert(100, vec![101]);
+
+        let mut child_to_wall_parent: FxHashMap<u32, u32> = FxHashMap::default();
+        child_to_wall_parent.insert(101, 100);
+
+        let parent_colors: FxHashMap<u32, [f32; 4]> = FxHashMap::default();
+
+        let child1 = make_test_mesh(101, "IfcBuildingElementPart", vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0], [1.0, 0.0, 0.0, 1.0]);
+
+        let mut collection = MeshCollection::new();
+        collection.add(child1);
+
+        collection.merge_wall_layers(
+            &wall_aggregate_index,
+            &child_to_wall_parent,
+            &parent_colors,
+            [0.8, 0.8, 0.8, 1.0],
+        );
+
+        // Single layer should NOT be merged (nothing to merge with)
+        assert_eq!(collection.len(), 1);
+        assert_eq!(collection.meshes[0].express_id, 101);
+    }
+
+    #[test]
+    fn test_merge_wall_layers_empty_index() {
+        use rustc_hash::FxHashMap;
+
+        let wall_aggregate_index: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
+        let child_to_wall_parent: FxHashMap<u32, u32> = FxHashMap::default();
+        let parent_colors: FxHashMap<u32, [f32; 4]> = FxHashMap::default();
+
+        let mesh = make_test_mesh(200, "IfcSlab", vec![0.0; 9], [0.5, 0.5, 0.5, 1.0]);
+        let mut collection = MeshCollection::new();
+        collection.add(mesh);
+
+        collection.merge_wall_layers(
+            &wall_aggregate_index,
+            &child_to_wall_parent,
+            &parent_colors,
+            [0.8, 0.8, 0.8, 1.0],
+        );
+
+        // No aggregates — nothing should change
+        assert_eq!(collection.len(), 1);
+        assert_eq!(collection.meshes[0].express_id, 200);
+    }
+
+    #[test]
+    fn test_merge_wall_layers_uses_parent_color() {
+        use rustc_hash::FxHashMap;
+
+        let mut wall_aggregate_index: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
+        wall_aggregate_index.insert(100, vec![101, 102]);
+
+        let mut child_to_wall_parent: FxHashMap<u32, u32> = FxHashMap::default();
+        child_to_wall_parent.insert(101, 100);
+        child_to_wall_parent.insert(102, 100);
+
+        let mut parent_colors: FxHashMap<u32, [f32; 4]> = FxHashMap::default();
+        parent_colors.insert(100, [0.2, 0.4, 0.6, 1.0]);
+
+        let child1 = make_test_mesh(101, "IfcBuildingElementPart", vec![0.0; 9], [1.0, 0.0, 0.0, 1.0]);
+        let child2 = make_test_mesh(102, "IfcBuildingElementPart", vec![1.0; 9], [0.0, 1.0, 0.0, 1.0]);
+
+        let mut collection = MeshCollection::new();
+        collection.add(child1);
+        collection.add(child2);
+
+        collection.merge_wall_layers(
+            &wall_aggregate_index,
+            &child_to_wall_parent,
+            &parent_colors,
+            [0.8, 0.8, 0.8, 1.0],
+        );
+
+        let merged = collection.meshes.iter().find(|m| m.express_id == 100).unwrap();
+        // Should use the parent's color
+        assert_eq!(merged.color, [0.2, 0.4, 0.6, 1.0]);
+    }
+
+    #[test]
+    fn test_merge_wall_layers_preserves_indices() {
+        use rustc_hash::FxHashMap;
+
+        let mut wall_aggregate_index: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
+        wall_aggregate_index.insert(100, vec![101, 102]);
+
+        let mut child_to_wall_parent: FxHashMap<u32, u32> = FxHashMap::default();
+        child_to_wall_parent.insert(101, 100);
+        child_to_wall_parent.insert(102, 100);
+
+        let parent_colors: FxHashMap<u32, [f32; 4]> = FxHashMap::default();
+
+        // Child 1: 3 vertices, indices [0, 1, 2]
+        let mut child1 = make_test_mesh(101, "IfcBuildingElementPart", vec![0.0; 9], [1.0, 0.0, 0.0, 1.0]);
+        child1.indices = vec![0, 1, 2];
+
+        // Child 2: 3 vertices, indices [0, 1, 2]
+        let mut child2 = make_test_mesh(102, "IfcBuildingElementPart", vec![1.0; 9], [0.0, 1.0, 0.0, 1.0]);
+        child2.indices = vec![0, 1, 2];
+
+        let mut collection = MeshCollection::new();
+        collection.add(child1);
+        collection.add(child2);
+
+        collection.merge_wall_layers(
+            &wall_aggregate_index,
+            &child_to_wall_parent,
+            &parent_colors,
+            [0.8, 0.8, 0.8, 1.0],
+        );
+
+        let merged = collection.meshes.iter().find(|m| m.express_id == 100).unwrap();
+        // First child: indices 0,1,2. Second child: indices 3,4,5 (offset by 3)
+        assert_eq!(merged.indices, vec![0, 1, 2, 3, 4, 5]);
     }
 }


### PR DESCRIPTION
## Summary
- Adds a **"Merge Wall Layers"** toggle (Class Visibility dropdown) that merges multilayer wall children (`IfcBuildingElementPart` via `IfcRelAggregates`) into a single solid mesh per parent `IfcWall`, reducing draw calls and memory for large models
- Collects aggregate relationships during the pre-pass scan, then post-processes meshes by merging child layers with proper index offsetting, using the parent wall's express ID and color
- Threads the `mergeLayers` option through all three geometry paths: synchronous (`parseMeshesMergeLayers`), subset/worker (`parseMeshesSubsetMergeLayers`), and async streaming (deferred merge batch)

## Test plan
- [x] 5 new Rust unit tests for `merge_wall_layers` (basic merge, single-layer no-op, empty index, parent color, index preservation) — all pass
- [x] Rust `cargo check` — compiles cleanly (only pre-existing warnings)
- [x] TypeScript type-check — no new errors introduced
- [x] All existing `wasm-bindings` tests pass (11/11)
- [ ] Manual: load a multilayer wall IFC model with toggle OFF → verify separate layer meshes
- [ ] Manual: reload with toggle ON → verify merged single-mesh walls, correct void subtraction
- [ ] Manual: verify property panel shows parent wall properties when clicking merged wall

Closes #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Merge Wall Layers" toggle to the Class Visibility menu in the viewer toolbar. When enabled, this feature combines multilayer wall components into single solids for simplified geometry representation and improved rendering performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->