### PR TITLE
Fix: persist selected BYOK model across page reloads

### DIFF
--- a/apps/viewer/src/store/slices/chatSlice.ts
+++ b/apps/viewer/src/store/slices/chatSlice.ts
@@ -13,6 +13,7 @@ import { coerceModelForEntitlement, DEFAULT_FREE_MODEL } from '../../lib/llm/mod
 import { extractCodeBlocks } from '../../lib/llm/code-extractor.js';
 import type { ScriptDiagnostic } from '../../lib/llm/script-diagnostics.js';
 import { formatDiagnosticsForPrompt, getPrimaryRootCause, groupDiagnosticsByRootCause } from '../../lib/llm/script-diagnostics.js';
+import { hasAnyApiKey as hasAnyApiKeyAtInit } from '../../services/api-keys.js';
 
 const MODEL_STORAGE_KEY = 'ifc-lite-chat-model';
 const MESSAGES_STORAGE_KEY = 'ifc-lite-chat-messages';
@@ -269,7 +270,7 @@ export const createChatSlice: StateCreator<ChatSlice, [], [], ChatSlice> = (set,
   chatMessages: loadStoredMessages(null),
   chatStatus: 'idle',
   chatStreamingContent: '',
-  chatActiveModel: loadValidStoredModel(null, false),
+  chatActiveModel: loadValidStoredModel(null, hasAnyApiKeyAtInit()),
   chatAutoExecute: loadStoredAutoExecute(),
   chatError: null,
   chatAbortController: null,


### PR DESCRIPTION
The store init called loadValidStoredModel(null, false), which coerced any stored BYOK model back to the default free model before the component could check localStorage for API keys.

Fix: read hasAnyApiKey() at store creation time so a stored BYOK model is preserved when the user already has keys configured.
