### PR TITLE
Fix release: skip source-only .ts packages in ESM smoke test

### DIFF
--- a/scripts/verify-esm-entrypoints.mjs
+++ b/scripts/verify-esm-entrypoints.mjs
@@ -102,6 +102,13 @@ function discoverPublishablePackages() {
       });
       continue;
     }
+    // Source-only packages that publish raw .ts (no build step) can't be
+    // loaded by Node's native ESM resolver. They are consumed by bundlers
+    // only, so skip them.
+    if (entry.endsWith('.ts') || entry.endsWith('.tsx')) {
+      out.push({ name: pkg.name, dir, skip: `source-only .ts entry (bundler-consumed): ${entry}` });
+      continue;
+    }
     out.push({ name: pkg.name, dir, entryAbs });
   }
   return out;


### PR DESCRIPTION
The ESM entrypoint verifier loaded every publishable package via Node's native import(). @ifc-lite/embed-protocol and @ifc-lite/embed-sdk publish raw .ts source (no build step, no dist/) — they are consumed by bundlers only. Node can't load .ts files and fails with ERR_UNKNOWN_FILE_EXTENSION, which blocked every release since #552.

Fix: detect entries ending in .ts/.tsx and skip them with a clear message ("source-only .ts entry (bundler-consumed)"). The smoke test continues to verify all packages that produce compiled dist/ output.