### PR TITLE
Extract stream routing logic and fix Codex truncation handling

### DIFF
--- a/apps/viewer/src/components/viewer/ChatPanel.tsx
+++ b/apps/viewer/src/components/viewer/ChatPanel.tsx
@@ -53,7 +53,7 @@ import { Check, Image as ImageIcon, Key, Eye, EyeOff, ExternalLink } from 'lucid
 import { hasDesktopFeatureAccess } from '@/lib/desktop-product';
 import { getModelById } from '@/lib/llm/models';
 import { resolveStreamRoute } from '@/lib/llm/byok-guard';
-import { getApiKeys, updateApiKeys, hasAnyApiKey, hasAnthropicKey, hasOpenaiKey, subscribeApiKeys } from '@/services/api-keys';
+import { getApiKeys, updateApiKeys, hasAnthropicKey, hasOpenaiKey, subscribeApiKeys } from '@/services/api-keys';
 import { useSandbox } from '@/hooks/useSandbox';
 
 // Environment variable for the proxy URL

--- a/apps/viewer/src/components/viewer/ChatPanel.tsx
+++ b/apps/viewer/src/components/viewer/ChatPanel.tsx
@@ -52,6 +52,7 @@ import { canUsePlainCodeBlockFallback, type ScriptMutationIntent } from '@/lib/l
 import { Check, Image as ImageIcon, Key, Eye, EyeOff, ExternalLink } from 'lucide-react';
 import { hasDesktopFeatureAccess } from '@/lib/desktop-product';
 import { getModelById } from '@/lib/llm/models';
+import { resolveStreamRoute } from '@/lib/llm/byok-guard';
 import { getApiKeys, updateApiKeys, hasAnyApiKey, hasAnthropicKey, hasOpenaiKey, subscribeApiKeys } from '@/services/api-keys';
 import { useSandbox } from '@/hooks/useSandbox';
 
@@ -401,6 +402,20 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
     if (!text.trim() || status === 'streaming' || status === 'sending') return;
     if (!canUseAiAssistant) {
       setChatError('AI assistant is available with Desktop Pro.');
+      return;
+    }
+
+    // Resolve the stream route BEFORE any user-visible side effects (adding
+    // the user message, clearing attachments, setting sending state). If the
+    // selected BYOK model has no key, bail out now so the chat transcript
+    // doesn't stack orphaned user messages on repeated sends.
+    const route = resolveStreamRoute(activeModel, getApiKeys());
+    if (route.kind === 'missing-key') {
+      setChatError(
+        route.provider === 'anthropic'
+          ? 'Enter your Anthropic API key above to use this model.'
+          : 'Enter your OpenAI API key above to use this model.',
+      );
       return;
     }
 
@@ -783,28 +798,11 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
         commitAssistantTurn();
     };
 
-    // Route to direct provider streaming for BYOK models, or through the proxy for free models
-    const resolvedModelInfo = getModelById(activeModel);
-    const modelSource = resolvedModelInfo?.source ?? 'proxy';
-    const currentApiKeys = getApiKeys();
-
-    if (modelSource === 'anthropic' && !currentApiKeys.anthropicKey) {
-      setChatError('Enter your Anthropic API key above to use this model.');
-      setChatStatus('idle');
-      setChatAbortController(null);
-      commitAssistantTurn();
-      return;
-    }
-    if (modelSource === 'openai' && !currentApiKeys.openaiKey) {
-      setChatError('Enter your OpenAI API key above to use this model.');
-      setChatStatus('idle');
-      setChatAbortController(null);
-      commitAssistantTurn();
-      return;
-    }
-
-    if (modelSource === 'anthropic' && currentApiKeys.anthropicKey) {
-      await streamAnthropicChat(currentApiKeys.anthropicKey, {
+    // Route to direct provider streaming for BYOK models, or through the proxy
+    // for free models. The route was already resolved (and the missing-key
+    // case handled) at the top of doSend, so this dispatch is total.
+    if (route.kind === 'anthropic') {
+      await streamAnthropicChat(route.apiKey, {
         model: activeModel,
         messages: streamMessages,
         system: systemPrompt,
@@ -814,8 +812,8 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
         onFinishReason: handleFinishReason,
         onError: handleError,
       });
-    } else if (modelSource === 'openai' && currentApiKeys.openaiKey) {
-      await streamOpenAiChat(currentApiKeys.openaiKey, {
+    } else if (route.kind === 'openai') {
+      await streamOpenAiChat(route.apiKey, {
         model: activeModel,
         messages: streamMessages,
         system: systemPrompt,

--- a/apps/viewer/src/components/viewer/SettingsPage.tsx
+++ b/apps/viewer/src/components/viewer/SettingsPage.tsx
@@ -18,7 +18,6 @@ import {
   Key,
   LayoutPanelTop,
   Lock,
-  RefreshCw,
   Settings2,
   ShieldCheck,
   Trash2,
@@ -40,7 +39,6 @@ import {
   type DesktopEntitlement,
 } from '@/lib/desktop-product';
 import { navigateToPath } from '@/services/app-navigation';
-import { requestDesktopEntitlementRefresh } from '@/lib/desktop/desktopEntitlementEvents';
 import {
   getDesktopPreferences,
   subscribeDesktopPreferences,
@@ -59,7 +57,6 @@ export function SettingsPage() {
   const chatUsage = useViewerStore((s) => s.chatUsage);
   const [preferences, setPreferences] = useState(() => getDesktopPreferences());
   const [apiKeys, setApiKeys] = useState(() => getApiKeys());
-  const [isRefreshingAccount, setIsRefreshingAccount] = useState(false);
   const returnTo = (() => {
     const params = new URLSearchParams(window.location.search);
     const candidate = params.get('returnTo');
@@ -89,19 +86,6 @@ export function SettingsPage() {
     const unit = chatUsage.type === 'credits' ? 'credits' : 'requests';
     return `${chatUsage.used}/${chatUsage.limit} ${unit} used. Resets ${resetLabel}.`;
   }, [chatUsage]);
-
-  const handleRefreshAccount = async () => {
-    setIsRefreshingAccount(true);
-    try {
-      await requestDesktopEntitlementRefresh();
-      toast.success('Account status refreshed');
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Could not refresh account status';
-      toast.error(message);
-    } finally {
-      setIsRefreshingAccount(false);
-    }
-  };
 
   return (
     <div className="min-h-screen bg-background text-foreground">

--- a/apps/viewer/src/lib/llm/byok-guard.test.ts
+++ b/apps/viewer/src/lib/llm/byok-guard.test.ts
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveStreamRoute } from './byok-guard.js';
+import { DEFAULT_BYOK_MODEL, BYOK_MODELS } from './models.js';
+
+const ANTHROPIC_MODEL = BYOK_MODELS.find((m) => m.source === 'anthropic')!;
+const OPENAI_MODEL = BYOK_MODELS.find((m) => m.source === 'openai')!;
+
+test('resolveStreamRoute returns proxy route for free models', () => {
+  const route = resolveStreamRoute('openai/gpt-free', { anthropicKey: '', openaiKey: '' });
+  assert.equal(route.kind, 'proxy');
+  if (route.kind === 'proxy') {
+    assert.equal(route.model, 'openai/gpt-free');
+  }
+});
+
+test('resolveStreamRoute returns proxy route for unknown model ids', () => {
+  const route = resolveStreamRoute('made-up-model', { anthropicKey: 'sk-ant-...', openaiKey: '' });
+  assert.equal(route.kind, 'proxy');
+});
+
+test('resolveStreamRoute returns anthropic route when key present', () => {
+  const route = resolveStreamRoute(ANTHROPIC_MODEL.id, {
+    anthropicKey: 'sk-ant-abc',
+    openaiKey: '',
+  });
+  assert.equal(route.kind, 'anthropic');
+  if (route.kind === 'anthropic') {
+    assert.equal(route.apiKey, 'sk-ant-abc');
+    assert.equal(route.model, ANTHROPIC_MODEL.id);
+  }
+});
+
+test('resolveStreamRoute returns missing-key when anthropic model selected without key', () => {
+  const route = resolveStreamRoute(ANTHROPIC_MODEL.id, {
+    anthropicKey: '',
+    openaiKey: 'sk-openai-xyz',
+  });
+  assert.equal(route.kind, 'missing-key');
+  if (route.kind === 'missing-key') {
+    assert.equal(route.provider, 'anthropic');
+  }
+});
+
+test('resolveStreamRoute returns openai route when key present', () => {
+  const route = resolveStreamRoute(OPENAI_MODEL.id, {
+    anthropicKey: '',
+    openaiKey: 'sk-openai-xyz',
+  });
+  assert.equal(route.kind, 'openai');
+  if (route.kind === 'openai') {
+    assert.equal(route.apiKey, 'sk-openai-xyz');
+  }
+});
+
+test('resolveStreamRoute returns missing-key when openai model selected without key', () => {
+  const route = resolveStreamRoute(OPENAI_MODEL.id, {
+    anthropicKey: 'sk-ant-abc',
+    openaiKey: '',
+  });
+  assert.equal(route.kind, 'missing-key');
+  if (route.kind === 'missing-key') {
+    assert.equal(route.provider, 'openai');
+  }
+});
+
+test('resolveStreamRoute treats whitespace-only keys as missing', () => {
+  const route = resolveStreamRoute(DEFAULT_BYOK_MODEL.id, {
+    anthropicKey: '   ',
+    openaiKey: '   ',
+  });
+  assert.equal(route.kind, 'missing-key');
+});

--- a/apps/viewer/src/lib/llm/byok-guard.ts
+++ b/apps/viewer/src/lib/llm/byok-guard.ts
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Pure routing guard for chat streams.
+ *
+ * Given a model id and the current BYOK key bag, decide whether the send
+ * should go through the proxy, direct to a provider, or be blocked because
+ * a required key is missing. Pulled out of ChatPanel so we can unit-test
+ * the guard without spinning up React — and so the "missing key" check
+ * happens BEFORE the user message is appended to the chat history.
+ */
+
+import { getModelById } from './models.js';
+import type { ApiKeyConfig } from '../../services/api-keys.js';
+
+export type StreamRoute =
+  | { kind: 'proxy'; model: string }
+  | { kind: 'anthropic'; model: string; apiKey: string }
+  | { kind: 'openai'; model: string; apiKey: string }
+  | { kind: 'missing-key'; provider: 'anthropic' | 'openai' };
+
+export function resolveStreamRoute(modelId: string, keys: ApiKeyConfig): StreamRoute {
+  const model = getModelById(modelId);
+  const source = model?.source ?? 'proxy';
+
+  if (source === 'anthropic') {
+    const apiKey = keys.anthropicKey.trim();
+    if (!apiKey) return { kind: 'missing-key', provider: 'anthropic' };
+    return { kind: 'anthropic', model: modelId, apiKey };
+  }
+  if (source === 'openai') {
+    const apiKey = keys.openaiKey.trim();
+    if (!apiKey) return { kind: 'missing-key', provider: 'openai' };
+    return { kind: 'openai', model: modelId, apiKey };
+  }
+  return { kind: 'proxy', model: modelId };
+}

--- a/apps/viewer/src/lib/llm/stream-client.ts
+++ b/apps/viewer/src/lib/llm/stream-client.ts
@@ -116,6 +116,52 @@ export function drainSseBuffer(buffer: string, flush: boolean = false): { events
 }
 
 /**
+ * Read an SSE stream, invoking onEvent for each `data:` payload.
+ * Skips `[DONE]` sentinels and malformed lines. Returns true if the stream
+ * completed normally; false on abort or error (errors are forwarded via
+ * onError, aborts are silent).
+ */
+export async function readSseStream(
+  body: ReadableStream<Uint8Array>,
+  signal: AbortSignal | undefined,
+  onEvent: (data: string) => void,
+  onError: (err: Error) => void,
+): Promise<boolean> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  const dispatchDrained = (events: string[]) => {
+    for (const evt of events) {
+      for (const line of evt.split('\n')) {
+        if (!line.startsWith('data: ')) continue;
+        const data = line.slice(6);
+        if (data === '[DONE]') continue;
+        try { onEvent(data); } catch { /* skip malformed */ }
+      }
+    }
+  };
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const drained = drainSseBuffer(buffer);
+      buffer = drained.remainder;
+      dispatchDrained(drained.events);
+    }
+    buffer += decoder.decode();
+    dispatchDrained(drainSseBuffer(buffer, true).events);
+    return true;
+  } catch (err) {
+    if (signal?.aborted) return false;
+    onError(err instanceof Error ? err : new Error(String(err)));
+    return false;
+  }
+}
+
+/**
  * Fetch current usage snapshot without sending a chat message.
  * Used for instant UI hydration and periodic refresh.
  */
@@ -292,102 +338,36 @@ export async function streamChat(options: StreamOptions): Promise<void> {
     return;
   }
 
-  // Parse SSE stream
-  const reader = response.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = '';
   let fullText = '';
   let finishReason: string | null = null;
 
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
+  const ok = await readSseStream(response.body, signal, (data) => {
+    const parsed = JSON.parse(data) as {
+      __ifcLiteUsage?: UsageInfo;
+      choices?: Array<{
+        delta?: { content?: string };
+        finish_reason?: string | null;
+      }>;
+    };
 
-      buffer += decoder.decode(value, { stream: true });
-
-      const drained = drainSseBuffer(buffer);
-      buffer = drained.remainder;
-
-      for (const event of drained.events) {
-        for (const line of event.split('\n')) {
-          if (!line.startsWith('data: ')) continue;
-          const data = line.slice(6);
-
-          if (data === '[DONE]') continue;
-
-          try {
-            const parsed = JSON.parse(data) as {
-              __ifcLiteUsage?: UsageInfo;
-              choices?: Array<{
-                delta?: { content?: string };
-                finish_reason?: string | null;
-              }>;
-            };
-
-            // Final usage update emitted by proxy after stream-end reconciliation.
-            if (parsed.__ifcLiteUsage && onUsageInfo) {
-              onUsageInfo(parsed.__ifcLiteUsage);
-              continue;
-            }
-
-            const content = parsed.choices?.[0]?.delta?.content;
-            if (content) {
-              fullText += content;
-              onChunk(content);
-            }
-            const chunkFinishReason = parsed.choices?.[0]?.finish_reason;
-            if (chunkFinishReason) {
-              finishReason = chunkFinishReason;
-            }
-          } catch {
-            // Skip malformed SSE lines
-          }
-        }
-      }
+    // Final usage update emitted by proxy after stream-end reconciliation.
+    if (parsed.__ifcLiteUsage && onUsageInfo) {
+      onUsageInfo(parsed.__ifcLiteUsage);
+      return;
     }
-    buffer += decoder.decode();
-    const drained = drainSseBuffer(buffer, true);
-    for (const event of drained.events) {
-      for (const line of event.split('\n')) {
-        if (!line.startsWith('data: ')) continue;
-        const data = line.slice(6);
 
-        if (data === '[DONE]') continue;
-
-        try {
-          const parsed = JSON.parse(data) as {
-            __ifcLiteUsage?: UsageInfo;
-            choices?: Array<{
-              delta?: { content?: string };
-              finish_reason?: string | null;
-            }>;
-          };
-
-          if (parsed.__ifcLiteUsage && onUsageInfo) {
-            onUsageInfo(parsed.__ifcLiteUsage);
-            continue;
-          }
-
-          const content = parsed.choices?.[0]?.delta?.content;
-          if (content) {
-            fullText += content;
-            onChunk(content);
-          }
-          const chunkFinishReason = parsed.choices?.[0]?.finish_reason;
-          if (chunkFinishReason) {
-            finishReason = chunkFinishReason;
-          }
-        } catch {
-          // Skip malformed SSE lines
-        }
-      }
+    const content = parsed.choices?.[0]?.delta?.content;
+    if (content) {
+      fullText += content;
+      onChunk(content);
     }
-  } catch (err) {
-    if (signal?.aborted) return;
-    onError(err instanceof Error ? err : new Error(String(err)));
-    return;
-  }
+    const chunkFinishReason = parsed.choices?.[0]?.finish_reason;
+    if (chunkFinishReason) {
+      finishReason = chunkFinishReason;
+    }
+  }, onError);
+
+  if (!ok) return;
 
   onFinishReason?.(finishReason);
   onComplete(fullText);

--- a/apps/viewer/src/lib/llm/stream-direct.test.ts
+++ b/apps/viewer/src/lib/llm/stream-direct.test.ts
@@ -1,0 +1,106 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { streamOpenAiChat } from './stream-direct.js';
+
+const CODEX_MODEL_ID = 'gpt-5.3-codex';
+
+type FetchImpl = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+function withMockFetch<T>(impl: FetchImpl, fn: () => Promise<T>): Promise<T> {
+  const original = globalThis.fetch;
+  globalThis.fetch = impl as typeof globalThis.fetch;
+  return fn().finally(() => {
+    globalThis.fetch = original;
+  });
+}
+
+function sseResponse(events: string[]): Response {
+  return new Response(new ReadableStream({
+    start(controller) {
+      for (const evt of events) {
+        controller.enqueue(new TextEncoder().encode(`data: ${evt}\n\n`));
+      }
+      controller.close();
+    },
+  }), {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+}
+
+test('streamOpenAiChat (Responses API) reports finish_reason=length when output is truncated', async () => {
+  await withMockFetch(
+    async () => sseResponse([
+      JSON.stringify({ type: 'response.output_text.delta', delta: 'partial' }),
+      JSON.stringify({
+        type: 'response.incomplete',
+        response: { status: 'incomplete', incomplete_details: { reason: 'max_output_tokens' } },
+      }),
+    ]),
+    async () => {
+      let fullText = '';
+      let finishReason: string | null = null;
+      await streamOpenAiChat('sk-test', {
+        model: CODEX_MODEL_ID,
+        messages: [{ role: 'user', content: 'hi' }],
+        onChunk: (text) => { fullText += text; },
+        onComplete: (text) => { fullText = text; },
+        onFinishReason: (reason) => { finishReason = reason; },
+        onError: (err) => { throw err; },
+      });
+      assert.equal(fullText, 'partial');
+      assert.equal(finishReason, 'length');
+    },
+  );
+});
+
+test('streamOpenAiChat (Responses API) reports finish_reason=stop on normal completion', async () => {
+  await withMockFetch(
+    async () => sseResponse([
+      JSON.stringify({ type: 'response.output_text.delta', delta: 'ok' }),
+      JSON.stringify({
+        type: 'response.completed',
+        response: { status: 'completed' },
+      }),
+    ]),
+    async () => {
+      let finishReason: string | null = null;
+      await streamOpenAiChat('sk-test', {
+        model: CODEX_MODEL_ID,
+        messages: [{ role: 'user', content: 'hi' }],
+        onChunk: () => undefined,
+        onComplete: () => undefined,
+        onFinishReason: (reason) => { finishReason = reason; },
+        onError: (err) => { throw err; },
+      });
+      assert.equal(finishReason, 'stop');
+    },
+  );
+});
+
+test('streamOpenAiChat (Responses API) hits the /v1/responses endpoint for codex models', async () => {
+  let capturedUrl: string | null = null;
+  await withMockFetch(
+    async (input) => {
+      capturedUrl = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      return sseResponse([
+        JSON.stringify({ type: 'response.output_text.delta', delta: 'x' }),
+        JSON.stringify({ type: 'response.completed', response: { status: 'completed' } }),
+      ]);
+    },
+    async () => {
+      await streamOpenAiChat('sk-test', {
+        model: CODEX_MODEL_ID,
+        messages: [{ role: 'user', content: 'hi' }],
+        onChunk: () => undefined,
+        onComplete: () => undefined,
+        onError: (err) => { throw err; },
+      });
+    },
+  );
+  assert.equal(capturedUrl, 'https://api.openai.com/v1/responses');
+});

--- a/apps/viewer/src/lib/llm/stream-direct.test.ts
+++ b/apps/viewer/src/lib/llm/stream-direct.test.ts
@@ -58,6 +58,30 @@ test('streamOpenAiChat (Responses API) reports finish_reason=length when output 
   );
 });
 
+test('streamOpenAiChat (Responses API) reports finish_reason=length when incomplete has no reason', async () => {
+  await withMockFetch(
+    async () => sseResponse([
+      JSON.stringify({ type: 'response.output_text.delta', delta: 'partial' }),
+      JSON.stringify({
+        type: 'response.incomplete',
+        response: { status: 'incomplete' },
+      }),
+    ]),
+    async () => {
+      let finishReason: string | null = null;
+      await streamOpenAiChat('sk-test', {
+        model: CODEX_MODEL_ID,
+        messages: [{ role: 'user', content: 'hi' }],
+        onChunk: () => undefined,
+        onComplete: () => undefined,
+        onFinishReason: (reason) => { finishReason = reason; },
+        onError: (err) => { throw err; },
+      });
+      assert.equal(finishReason, 'length');
+    },
+  );
+});
+
 test('streamOpenAiChat (Responses API) reports finish_reason=stop on normal completion', async () => {
   await withMockFetch(
     async () => sseResponse([

--- a/apps/viewer/src/lib/llm/stream-direct.ts
+++ b/apps/viewer/src/lib/llm/stream-direct.ts
@@ -214,21 +214,33 @@ async function streamOpenAiResponses(
   if (!response.body) { cleanup(); onError(new Error('No response body')); return; }
 
   let fullText = '';
+  // Map Responses API terminal events → chat-style finish_reason.
+  // `response.incomplete` with reason `max_output_tokens` → 'length', so the
+  // ChatPanel "Continue" UX can resume a truncated Codex reply.
+  let finishReason: string | null = 'stop';
 
   const ok = await readSseStream(response.body, signal, (data) => {
     const event = JSON.parse(data) as {
       type?: string;
       delta?: string;
-      response?: { status?: string };
+      response?: {
+        status?: string;
+        incomplete_details?: { reason?: string } | null;
+      };
     };
     if (event.type === 'response.output_text.delta' && event.delta) {
       fullText += event.delta;
       onChunk(event.delta);
+    } else if (event.type === 'response.incomplete') {
+      const reason = event.response?.incomplete_details?.reason;
+      finishReason = reason === 'max_output_tokens' ? 'length' : reason ?? 'stop';
+    } else if (event.type === 'response.completed') {
+      finishReason = 'stop';
     }
   }, onError);
 
   cleanup();
-  if (ok) { onFinishReason?.('stop'); onComplete(fullText); }
+  if (ok) { onFinishReason?.(finishReason); onComplete(fullText); }
 }
 
 // ── Shared helpers ─────────────────────────────────────────────────────────

--- a/apps/viewer/src/lib/llm/stream-direct.ts
+++ b/apps/viewer/src/lib/llm/stream-direct.ts
@@ -14,7 +14,7 @@
  */
 
 import Anthropic from '@anthropic-ai/sdk';
-import { drainSseBuffer, type StreamMessage, type StreamOptions } from './stream-client.js';
+import { readSseStream, type StreamMessage, type StreamOptions } from './stream-client.js';
 
 const STREAM_REQUEST_TIMEOUT_MS = 45_000;
 
@@ -311,49 +311,4 @@ async function openAiFetch(
   }
 
   return { response, cleanup };
-}
-
-/** Read an SSE stream, calling onEvent for each `data:` line. Returns true if completed normally. */
-async function readSseStream(
-  body: ReadableStream<Uint8Array>,
-  signal: AbortSignal | undefined,
-  onEvent: (data: string) => void,
-  onError: (err: Error) => void,
-): Promise<boolean> {
-  const reader = body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = '';
-
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      buffer += decoder.decode(value, { stream: true });
-      const drained = drainSseBuffer(buffer);
-      buffer = drained.remainder;
-      for (const evt of drained.events) {
-        for (const line of evt.split('\n')) {
-          if (!line.startsWith('data: ')) continue;
-          const data = line.slice(6);
-          if (data === '[DONE]') continue;
-          try { onEvent(data); } catch { /* skip malformed */ }
-        }
-      }
-    }
-    buffer += decoder.decode();
-    const drained = drainSseBuffer(buffer, true);
-    for (const evt of drained.events) {
-      for (const line of evt.split('\n')) {
-        if (!line.startsWith('data: ')) continue;
-        const data = line.slice(6);
-        if (data === '[DONE]') continue;
-        try { onEvent(data); } catch { /* skip malformed */ }
-      }
-    }
-    return true;
-  } catch (err) {
-    if (signal?.aborted) return false;
-    onError(err instanceof Error ? err : new Error(String(err)));
-    return false;
-  }
 }

--- a/apps/viewer/src/lib/llm/stream-direct.ts
+++ b/apps/viewer/src/lib/llm/stream-direct.ts
@@ -215,8 +215,10 @@ async function streamOpenAiResponses(
 
   let fullText = '';
   // Map Responses API terminal events → chat-style finish_reason.
-  // `response.incomplete` with reason `max_output_tokens` → 'length', so the
-  // ChatPanel "Continue" UX can resume a truncated Codex reply.
+  // `response.incomplete` is any non-completed terminal state: when the
+  // reason is `max_output_tokens` — or simply absent — map to 'length' so
+  // the ChatPanel "Continue" UX can resume a truncated Codex reply. Other
+  // explicit reasons (e.g. `content_filter`) pass through unchanged.
   let finishReason: string | null = 'stop';
 
   const ok = await readSseStream(response.body, signal, (data) => {
@@ -233,7 +235,7 @@ async function streamOpenAiResponses(
       onChunk(event.delta);
     } else if (event.type === 'response.incomplete') {
       const reason = event.response?.incomplete_details?.reason;
-      finishReason = reason === 'max_output_tokens' ? 'length' : reason ?? 'stop';
+      finishReason = reason == null || reason === 'max_output_tokens' ? 'length' : reason;
     } else if (event.type === 'response.completed') {
       finishReason = 'stop';
     }


### PR DESCRIPTION
## Summary
This PR refactors the chat stream routing logic into a testable pure function and fixes handling of truncated responses from OpenAI's Responses API (used by Codex models).

## Key Changes

- **Extract `resolveStreamRoute` function** (`byok-guard.ts`): Moved the logic that determines whether to route a chat request through the proxy, directly to Anthropic, or directly to OpenAI into a pure, testable function. This function also validates that required BYOK API keys are present before any user-visible side effects occur.

- **Fix Codex truncation detection** (`stream-direct.ts`): Updated `streamOpenAiResponses` to properly map the Responses API's `response.incomplete` event with `max_output_tokens` reason to the standard `finish_reason: 'length'`. This enables the ChatPanel's "Continue" UX to correctly resume truncated Codex replies.

- **Improve error handling in ChatPanel** (`ChatPanel.tsx`): Moved the missing API key check to the beginning of `doSend`, before appending the user message to chat history. This prevents orphaned user messages from accumulating when users repeatedly attempt to send with a missing key.

- **Add comprehensive unit tests**: Created test suites for both `resolveStreamRoute` (covering all routing scenarios and edge cases like whitespace-only keys) and `streamOpenAiChat` (verifying finish_reason mapping and endpoint selection for Codex models).

- **Clean up unused code** (`SettingsPage.tsx`): Removed unused account refresh functionality and related imports.

## Implementation Details

The `resolveStreamRoute` function returns a discriminated union type (`StreamRoute`) that clearly represents all possible routing outcomes: proxy routing, direct provider routing with API key, or a missing-key error state. This design allows ChatPanel to handle the missing-key case early and dispatch to the correct streaming function with confidence.

The Responses API finish_reason mapping now correctly distinguishes between normal completion (`'stop'`) and truncation due to token limits (`'length'`), enabling proper continuation semantics for long-running Codex generations.

https://claude.ai/code/session_01FmZLJBDcUy1T1Q1AiyuapZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API key validation for custom models with earlier error detection and more specific error messages when API keys are missing or invalid.
  * Fixed detection of stream completion reasons to accurately report whether output was truncated due to token limits or completed naturally.

* **Refactor**
  * Removed unused account refresh functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->