### PR TITLE
Add site_local coordinate space for IfcSite placement translations

### DIFF
--- a/apps/server/src/services/streaming.rs
+++ b/apps/server/src/services/streaming.rs
@@ -43,6 +43,8 @@ struct PreparedData {
     unit_scale: f64,
     /// RTC offset for large-coordinate models (preserves precision in f32 output)
     rtc_offset: (f64, f64, f64),
+    /// Coordinate space of serialized mesh vertices: `site_local`, `model_rtc`, or `raw_ifc`.
+    mesh_coordinate_space: &'static str,
     /// IfcSite ObjectPlacement as a column-major 4×4 matrix (metres).
     site_transform: Option<Vec<f64>>,
     /// IfcBuilding ObjectPlacement as a column-major 4×4 matrix (metres).
@@ -150,11 +152,30 @@ fn prepare_streaming_data(content: String) -> PreparedData {
         }
     };
 
-    let rtc_offset = if let Some(ref st) = site_transform {
-        (st[12], st[13], st[14])
-    } else {
-        detected_rtc_offset
-    };
+    // Three-tier coordinate-space selection, mirroring the non-streaming path:
+    //   1. site_local: IfcSite placement has a non-identity translation.
+    //   2. model_rtc:  fall back to the detected anchor for large-coordinate files.
+    //   3. raw_ifc:    neither anchor applies.
+    const PLACEMENT_IDENTITY_EPSILON: f64 = 1e-9;
+    let site_rtc = site_transform
+        .as_ref()
+        .map(|st| (st[12], st[13], st[14]))
+        .filter(|t| {
+            t.0.abs() > PLACEMENT_IDENTITY_EPSILON
+                || t.1.abs() > PLACEMENT_IDENTITY_EPSILON
+                || t.2.abs() > PLACEMENT_IDENTITY_EPSILON
+        });
+    let detected_has_offset = detected_rtc_offset.0.abs() > PLACEMENT_IDENTITY_EPSILON
+        || detected_rtc_offset.1.abs() > PLACEMENT_IDENTITY_EPSILON
+        || detected_rtc_offset.2.abs() > PLACEMENT_IDENTITY_EPSILON;
+    let (rtc_offset, mesh_coordinate_space): ((f64, f64, f64), &'static str) =
+        if let Some(site) = site_rtc {
+            (site, "site_local")
+        } else if detected_has_offset {
+            (detected_rtc_offset, "model_rtc")
+        } else {
+            ((0.0, 0.0, 0.0), "raw_ifc")
+        };
     router.set_rtc_offset(rtc_offset);
     if !faceted_brep_ids.is_empty() {
         router.preprocess_faceted_breps(&faceted_brep_ids, &mut decoder);
@@ -178,6 +199,7 @@ fn prepare_streaming_data(content: String) -> PreparedData {
         parse_time_ms,
         unit_scale,
         rtc_offset,
+        mesh_coordinate_space,
         site_transform,
         building_transform,
     }
@@ -451,17 +473,7 @@ pub fn process_streaming(
                 },
             },
             cache_key,
-            mesh_coordinate_space: Some(
-                if prepared.rtc_offset.0 != 0.0
-                    || prepared.rtc_offset.1 != 0.0
-                    || prepared.rtc_offset.2 != 0.0
-                {
-                    "model_rtc"
-                } else {
-                    "raw_ifc"
-                }
-                .to_string(),
-            ),
+            mesh_coordinate_space: Some(prepared.mesh_coordinate_space.to_string()),
             site_transform: prepared.site_transform,
             building_transform: prepared.building_transform,
         };

--- a/apps/server/src/types/response.rs
+++ b/apps/server/src/types/response.rs
@@ -62,7 +62,7 @@ pub enum StreamEvent {
         metadata: ModelMetadata,
         /// Cache key for the result.
         cache_key: String,
-        /// Coordinate space of the mesh vertices (e.g. "model_rtc" or "raw_ifc").
+        /// Coordinate space of the mesh vertices: `"site_local"`, `"model_rtc"`, or `"raw_ifc"`.
         #[serde(skip_serializing_if = "Option::is_none")]
         mesh_coordinate_space: Option<String>,
         /// IfcSite ObjectPlacement as a column-major 4×4 matrix (metres).

--- a/rust/geometry/src/router/transforms.rs
+++ b/rust/geometry/src/router/transforms.rs
@@ -383,6 +383,7 @@ impl GeometryRouter {
                 chunk[1] = (t.y - rtc.1) as f32;
                 chunk[2] = (t.z - rtc.2) as f32;
             });
+            mesh.rtc_applied = true;
         } else {
             mesh.positions.chunks_exact_mut(3).for_each(|chunk| {
                 let point = Point3::new(chunk[0] as f64, chunk[1] as f64, chunk[2] as f64);

--- a/rust/processing/src/processor.rs
+++ b/rust/processing/src/processor.rs
@@ -92,8 +92,21 @@ impl Default for StreamingOptions {
     }
 }
 
+const SITE_LOCAL_MESH_COORDINATE_SPACE: &str = "site_local";
 const MODEL_RTC_MESH_COORDINATE_SPACE: &str = "model_rtc";
 const RAW_IFC_MESH_COORDINATE_SPACE: &str = "raw_ifc";
+
+/// Epsilon (metres) below which a placement translation is treated as identity.
+/// Avoids overriding a detected RTC anchor when `IfcSite` sits at the origin
+/// while the geometry itself carries large world coordinates.
+const PLACEMENT_IDENTITY_EPSILON: f64 = 1e-9;
+
+#[inline]
+fn translation_is_nonidentity(t: (f64, f64, f64)) -> bool {
+    t.0.abs() > PLACEMENT_IDENTITY_EPSILON
+        || t.1.abs() > PLACEMENT_IDENTITY_EPSILON
+        || t.2.abs() > PLACEMENT_IDENTITY_EPSILON
+}
 
 /// Job for processing a single entity.
 struct EntityJob {
@@ -1041,15 +1054,27 @@ pub fn process_geometry_streaming_filtered_with_options(
         None => scan_placement_bounds(content).rtc_offset(),
     };
 
-    // Prefer the IfcSite placement translation when it exists. Otherwise use
-    // the model-level detected RTC anchor so all meshes share one coordinate
-    // space instead of receiving independent per-object shifts.
-    let rtc_offset = if let Some(ref st) = site_transform {
-        (st[12], st[13], st[14]) // column-major: translation at indices 12,13,14
+    // Three-tier coordinate-space selection:
+    //   1. `site_local`: IfcSite placement has a non-identity translation.
+    //      Vertices are expressed relative to the site origin — small floats
+    //      AND a meaningful, relatable frame (useful for coordination).
+    //   2. `model_rtc`:  IfcSite is identity (or missing) but geometry still
+    //      lives at large world coordinates. Subtract a detected anchor so
+    //      f32 precision is preserved.
+    //   3. `raw_ifc`:    neither anchor applies; geometry is already small.
+    let site_rtc = site_transform
+        .as_ref()
+        .map(|st| (st[12], st[13], st[14])) // column-major: translation at 12,13,14
+        .filter(|t| translation_is_nonidentity(*t));
+    let detected_has_offset = translation_is_nonidentity(detected_rtc_offset);
+    let (rtc_offset, coord_space) = if let Some(site) = site_rtc {
+        (site, SITE_LOCAL_MESH_COORDINATE_SPACE)
+    } else if detected_has_offset {
+        (detected_rtc_offset, MODEL_RTC_MESH_COORDINATE_SPACE)
     } else {
-        detected_rtc_offset
+        ((0.0, 0.0, 0.0), RAW_IFC_MESH_COORDINATE_SPACE)
     };
-    let has_rtc_offset = rtc_offset.0 != 0.0 || rtc_offset.1 != 0.0 || rtc_offset.2 != 0.0;
+    let has_rtc_offset = coord_space != RAW_IFC_MESH_COORDINATE_SPACE;
     router.set_rtc_offset(rtc_offset);
     let should_preprocess_faceted_breps = !faceted_brep_ids.is_empty()
         && !(options.fast_first_batch && options.initial_batch_size < usize::MAX);
@@ -1244,14 +1269,7 @@ pub fn process_geometry_streaming_filtered_with_options(
 
     ProcessingResult {
         meshes,
-        mesh_coordinate_space: Some(
-            if has_rtc_offset {
-                MODEL_RTC_MESH_COORDINATE_SPACE
-            } else {
-                RAW_IFC_MESH_COORDINATE_SPACE
-            }
-            .to_string(),
-        ),
+        mesh_coordinate_space: Some(coord_space.to_string()),
         site_transform,
         building_transform,
         metadata: ModelMetadata {

--- a/rust/processing/src/types/response.rs
+++ b/rust/processing/src/types/response.rs
@@ -14,9 +14,11 @@ pub struct ParseResponse {
     pub cache_key: String,
     /// All meshes extracted from the IFC file.
     pub meshes: Vec<MeshData>,
-    /// Declares the coordinate space used by serialized mesh vertices.
-    /// `model_rtc` means a model-level RTC anchor was subtracted.
-    /// `raw_ifc` means no RTC anchor was applied.
+    /// Declares the coordinate space used by serialized mesh vertices:
+    /// * `site_local` — vertices are relative to the IfcSite placement
+    ///   translation (small floats in a meaningful, relatable frame).
+    /// * `model_rtc`  — a model-level detected RTC anchor was subtracted.
+    /// * `raw_ifc`    — no RTC anchor was applied; vertices are in raw IFC space.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mesh_coordinate_space: Option<String>,
     /// IfcSite ObjectPlacement as a column-major 4x4 matrix (16 f64 values, in meters).


### PR DESCRIPTION
## Summary
This PR introduces a three-tier coordinate space selection system that prioritizes the IfcSite placement translation when it represents a meaningful, non-identity offset. This provides better coordinate frames for model coordination while preserving precision for large-coordinate geometries.

## Key Changes

- **New coordinate space tier**: Added `site_local` as the preferred coordinate space when IfcSite has a non-identity translation, allowing vertices to be expressed relative to the site origin in a meaningful, relatable frame.

- **Epsilon-based identity detection**: Introduced `PLACEMENT_IDENTITY_EPSILON` (1e-9 metres) and `translation_is_nonidentity()` helper to distinguish meaningful translations from floating-point noise, preventing spurious coordinate space selection.

- **Three-tier selection logic**: Implemented consistent coordinate space selection across both streaming and non-streaming paths:
  1. `site_local` — IfcSite placement has a non-identity translation
  2. `model_rtc` — fall back to detected RTC anchor for large-coordinate files
  3. `raw_ifc` — neither anchor applies; use raw IFC coordinates

- **Unified implementation**: Applied the same logic in both `rust/processing/src/processor.rs` (non-streaming) and `apps/server/src/services/streaming.rs` (streaming path) to ensure consistent behavior.

- **Updated documentation**: Enhanced comments in response types to clarify the three coordinate space options and their use cases.

- **RTC tracking**: Added `mesh.rtc_applied` flag in geometry router to track when RTC offset has been applied to mesh positions.

## Implementation Details

- The epsilon threshold (1e-9 m) is small enough to ignore floating-point rounding errors while catching intentional placements.
- The coordinate space is now determined during data preparation and stored for consistent use throughout processing.
- Both streaming and non-streaming paths now use identical logic for coordinate space selection, reducing maintenance burden and ensuring consistent output.

https://claude.ai/code/session_019RoQHigDdZqvQdySLQqTAB