### PR TITLE
fix(processing): convert param doc-comments to regular comments

### DIFF
--- a/rust/processing/src/processor.rs
+++ b/rust/processing/src/processor.rs
@@ -1369,8 +1369,8 @@ fn process_entity_job(
     void_index: &FxHashMap<u32, Vec<u32>>,
     skipped_entity_ids: &HashSet<u32>,
     geometry_style_index: &FxHashMap<u32, GeometryStyleInfo>,
-    /// Present only when the selected coordinate space is `site_local`;
-    /// rotates mesh vertices into the site's axis frame.
+    // Present only when the selected coordinate space is `site_local`; rotates
+    // mesh vertices into the site's axis frame.
     site_local_rotation: Option<&Vec<f64>>,
 ) -> Vec<MeshData> {
     if skipped_entity_ids.contains(&job.id) {


### PR DESCRIPTION
## Summary
Hotfix for a compile error that shipped with #565. `process_entity_job` had `///` doc-comments on a function parameter, which Rust rejects. Server binary validation CI flagged it on linux-x64, linux-arm64, and linux-x64-musl; `main` is currently broken for anyone running `cargo build -p ifc-lite-server`.

## Change
Two lines in `rust/processing/src/processor.rs` — convert the `///` block above `site_local_rotation` to plain `//` comments.

## Verified locally
`cargo build --release -p ifc-lite-server` now finishes cleanly (1m40s on my box).

## Pre-existing Codex review comments on #565 — NOT addressed here
These are legitimate but pre-existing bugs carried in from #549, not regressions from the merge. Worth their own focused PR:

- **P1** `apps/viewer/src/hooks/useIfcFederation.ts:478` — `addModel` alignment ignores `georefMutations` for the model being reloaded, so georeferencing edits don't change 3D placement on reload.
- **P2** `apps/viewer/src/hooks/useIfcFederation.ts:238` — georef alignment transforms positions but not normals; non-identity rotations leave lighting incorrect.

https://claude.ai/code/session_019RoQHigDdZqvQdySLQqTAB