### PR TITLE
fix(viewer): rotate normals and honor georef mutations during federation alignment

### DIFF
--- a/apps/viewer/src/hooks/useIfcFederation.ts
+++ b/apps/viewer/src/hooks/useIfcFederation.ts
@@ -238,6 +238,32 @@ function applyAlignmentTransformAndUpdateBounds(
       positions[i + 2] = alignedZ;
       found = updateBounds(bounds, alignedX, alignedY, alignedZ) || found;
     }
+
+    // Rotate normals by the transform's 3×3 linear part (translation omitted)
+    // and renormalize. CRS alignment is a rigid rotation, so the linear part
+    // itself is the correct transform for normals; degenerate results from
+    // zero-length or non-finite inputs are left in place.
+    const normals = mesh.normals;
+    if (normals && normals.length >= 3) {
+      for (let i = 0; i < normals.length; i += 3) {
+        const nx = normals[i];
+        const ny = normals[i + 1];
+        const nz = normals[i + 2];
+        if (!Number.isFinite(nx) || !Number.isFinite(ny) || !Number.isFinite(nz)) {
+          continue;
+        }
+        const rx = transform.m00 * nx + transform.m01 * ny + transform.m02 * nz;
+        const ry = transform.m10 * nx + transform.m11 * ny + transform.m12 * nz;
+        const rz = transform.m20 * nx + transform.m21 * ny + transform.m22 * nz;
+        const len = Math.sqrt(rx * rx + ry * ry + rz * rz);
+        if (!Number.isFinite(len) || len < 1e-12) {
+          continue;
+        }
+        normals[i] = rx / len;
+        normals[i + 1] = ry / len;
+        normals[i + 2] = rz / len;
+      }
+    }
   }
 
   geometry.coordinateInfo = {
@@ -475,7 +501,16 @@ export function useIfcFederation() {
       }
 
       const referenceGeoref = findReferenceGeorefModel();
-      const parsedGeoref = extractModelGeoref(parsedDataStore, parsedGeometry.coordinateInfo);
+      // Include any georef edits the user has already saved for this model so
+      // that a reload after editing reflects the new placement. Without this,
+      // extractModelGeoref reads only the raw parsed metadata and mutations
+      // are silently ignored.
+      const parsedGeorefMutations = useViewerStore.getState().georefMutations.get(modelId);
+      const parsedGeoref = extractModelGeoref(
+        parsedDataStore,
+        parsedGeometry.coordinateInfo,
+        parsedGeorefMutations,
+      );
       if (referenceGeoref && parsedGeoref) {
         setProgress({ phase: 'Aligning georeferenced model', percent: 90 });
         const aligned = alignGeometryToReferenceGeoref(parsedGeometry, parsedGeoref, referenceGeoref);


### PR DESCRIPTION
## Summary
Two isolated fixes in `apps/viewer/src/hooks/useIfcFederation.ts`, both flagged by Codex on #565 and both pre-existing (originated in #549, carried through the merge).

### P1 — georef mutations ignored on reload (`addModel`, ~line 478)
When a user edits a model's CRS / `IfcMapConversion` via the UI, those edits live in `state.georefMutations` as a side layer on top of the parsed file. `findReferenceGeorefModel` already merged them before computing the reference georef. But the parsed model's own georef in `addModel` was extracted straight from the data store with no mutation argument, so a reload of an edited non-reference model silently dropped the edits — UI claimed the edit was saved but 3D placement didn't change.

Fix: look up the current model's mutation set and pass it into `extractModelGeoref` for `parsedGeoref` as well.

### P2 — normals not rotated during alignment (`applyAlignmentTransformAndUpdateBounds`, ~line 238)
The alignment pass rewrote `mesh.positions` with the full 4×4 affine but never touched `mesh.normals`. Any non-identity alignment (federated models with differing grid-north axes) therefore left lighting incorrect.

Fix: after the positions loop, rotate each normal by the transform's 3×3 linear part and renormalize. CRS alignments are rigid rotations so the linear part itself is the correct normal transform; zero-length or non-finite results are skipped.

## Verified
- Typecheck: no new errors introduced in `useIfcFederation.ts` (pre-existing "can't find react" comes from the sandbox not having `node_modules`; not from these edits).
- Diff is 36 lines, scoped to one file.

https://claude.ai/code/session_019RoQHigDdZqvQdySLQqTAB