### PR TITLE
fix(changeset): use workspace package name for viewer (unbreaks Release workflow)

### DIFF
--- a/.changeset/3d-section-cap.md
+++ b/.changeset/3d-section-cap.md
@@ -1,7 +1,7 @@
 ---
 '@ifc-lite/renderer': minor
 '@ifc-lite/drawing-2d': patch
-'viewer': patch
+'@ifc-lite/viewer': patch
 ---
 
 3D section cap with screen-space hatches, driven by exact cut polygons.


### PR DESCRIPTION
## Summary
The Release workflow is blocked on `c217c47` (and every commit since) with:

```
🦋 error Error: Found changeset 3d-section-cap for package viewer which is not in the workspace
```

`.changeset/3d-section-cap.md` lists `'viewer': patch`, but the workspace package is `@ifc-lite/viewer` (per `apps/viewer/package.json`). One-character fix.

## Change
`.changeset/3d-section-cap.md`: `'viewer'` → `'@ifc-lite/viewer'`.

## Context
Merged via #561 / follow-up; the broken changeset is still sitting in `.changeset/` because no successful release has consumed it yet. Fixing unblocks the changesets action so it can open the release PR again.

https://claude.ai/code/session_019RoQHigDdZqvQdySLQqTAB