### PR TITLE
fix(query): surface on-demand properties/quantities in QueryResultEntity

### DIFF
--- a/.changeset/query-on-demand-fallback.md
+++ b/.changeset/query-on-demand-fallback.md
@@ -1,0 +1,12 @@
+---
+"@ifc-lite/query": patch
+"@ifc-lite/parser": patch
+---
+
+Surface on-demand properties and quantities through the query API.
+
+`parseColumnar` intentionally leaves the pre-parsed `store.properties` / `store.quantities` tables empty and populates `onDemandPropertyMap` / `onDemandQuantityMap` instead, but `QueryResultEntity` only read from the empty pre-parsed tables. As a result `query.ofType(...).includeProperties().includeQuantities().execute()` always returned elements with empty `properties` / `quantities`, even when the IFC file contained them (issue #577).
+
+`loadPropertiesFromStore` / `loadQuantitiesFromStore` in `query-result-entity.ts` now fall back to `extractPropertiesOnDemand` / `extractQuantitiesOnDemand` when the pre-parsed tables are empty and the on-demand maps are present. This applies to the `properties` / `quantities` getters, the `loadProperties` / `loadQuantities` eager loaders, and the `getProperty()` accessor.
+
+Also normalizes untagged STEP enumeration tokens (`.T.` / `.F.` / `.U.` / `.X.`) emitted by some authoring tools in the `NominalValue` slot of `IfcPropertySingleValue`: `.T.` / `.F.` now decode to real JS booleans and `.U.` / `.X.` to a Logical `null`, matching the behavior of the conformant `IFCBOOLEAN(...)` / `IFCLOGICAL(...)` typed form.

--- a/packages/parser/src/on-demand-extractors.ts
+++ b/packages/parser/src/on-demand-extractors.ts
@@ -182,7 +182,21 @@ export function parsePropertyValue(propEntity: IfcEntity): { type: number; value
             } else if (typeof nominalValue === 'boolean') {
                 type = PropertyValueType.Boolean;
             } else if (nominalValue !== null && nominalValue !== undefined) {
-                value = String(nominalValue);
+                // Normalize untagged STEP enumeration tokens. Conformant IFC wraps
+                // booleans as IFCBOOLEAN(.T.) (handled above), but some authoring
+                // tools emit the bare tokens directly in the NominalValue slot.
+                if (nominalValue === '.T.') {
+                    type = PropertyValueType.Boolean;
+                    value = true;
+                } else if (nominalValue === '.F.') {
+                    type = PropertyValueType.Boolean;
+                    value = false;
+                } else if (nominalValue === '.U.' || nominalValue === '.X.') {
+                    type = PropertyValueType.Logical;
+                    value = null;
+                } else {
+                    value = String(nominalValue);
+                }
             }
 
             return { type, value };

--- a/packages/parser/test/on-demand-properties-regression.test.ts
+++ b/packages/parser/test/on-demand-properties-regression.test.ts
@@ -44,4 +44,49 @@ describe('parseLite on-demand property extraction', () => {
     expect(psets[0].properties).toHaveLength(2);
     expect(psets[0].properties.map((prop) => prop.name)).toEqual(['FireRating', 'IsExternal']);
   });
+
+  it('normalizes untagged STEP boolean/logical tokens in NominalValue', async () => {
+    const ifc = `#1=IFCOWNERHISTORY($,$,$,$,$,$,$,0);
+#10=IFCWALLSTANDARDCASE('wall-guid',#1,'Wall A',$,$,$,$,$);
+#20=IFCPROPERTYSINGLEVALUE('IsExternal',$,.T.,$);
+#21=IFCPROPERTYSINGLEVALUE('LoadBearing',$,.F.,$);
+#22=IFCPROPERTYSINGLEVALUE('Combustible',$,.U.,$);
+#23=IFCPROPERTYSINGLEVALUE('FireRating',$,'REI60',$);
+#24=IFCPROPERTYSINGLEVALUE('Height',$,IFCREAL(3000.0),$);
+#30=IFCPROPERTYSET('pset-guid',#1,'Pset_WallCommon',$,(#20,#21,#22,#23,#24));
+#40=IFCRELDEFINESBYPROPERTIES('rel-guid',#1,$,$,(#10),#30);`;
+
+    const source = new TextEncoder().encode(ifc);
+    const tokenizer = new StepTokenizer(source);
+    const entityRefs: Array<{
+      expressId: number;
+      type: string;
+      byteOffset: number;
+      byteLength: number;
+      lineNumber: number;
+    }> = [];
+    for (const ref of tokenizer.scanEntitiesFast()) {
+      entityRefs.push({
+        expressId: ref.expressId,
+        type: ref.type,
+        byteOffset: ref.offset,
+        byteLength: ref.length,
+        lineNumber: ref.line,
+      });
+    }
+
+    const parser = new ColumnarParser();
+    const store = await parser.parseLite(source.buffer.slice(0), entityRefs, {});
+    const psets = extractPropertiesOnDemand(store, 10);
+
+    const byName = Object.fromEntries(
+      psets[0].properties.map((p) => [p.name, { type: p.type, value: p.value }]),
+    );
+
+    expect(byName.IsExternal).toEqual({ type: 3, value: true }); // Boolean
+    expect(byName.LoadBearing).toEqual({ type: 3, value: false });
+    expect(byName.Combustible).toEqual({ type: 4, value: null }); // Logical (.U.)
+    expect(byName.FireRating.value).toBe('REI60');
+    expect(byName.Height.value).toBe(3000.0);
+  });
 });

--- a/packages/query/src/query-result-entity.ts
+++ b/packages/query/src/query-result-entity.ts
@@ -7,54 +7,93 @@
  */
 
 import type { IfcDataStore } from '@ifc-lite/parser';
-import type { PropertySet } from '@ifc-lite/data';
-import type { QuantitySet } from '@ifc-lite/data';
+import { extractPropertiesOnDemand, extractQuantitiesOnDemand } from '@ifc-lite/parser';
+import type { PropertySet, QuantitySet, Property, Quantity, PropertyValue } from '@ifc-lite/data';
+import { PropertyValueType, QuantityType } from '@ifc-lite/data';
 import type { MeshData } from '@ifc-lite/geometry';
 import { EntityNode } from './entity-node.js';
+
+function hasOnDemandProperties(store: IfcDataStore): boolean {
+  return !!store.onDemandPropertyMap && !!store.source && store.source.length > 0;
+}
+
+function hasOnDemandQuantities(store: IfcDataStore): boolean {
+  return !!store.onDemandQuantityMap && !!store.source && store.source.length > 0;
+}
+
+function loadPropertiesFromStore(store: IfcDataStore, expressId: number): PropertySet[] {
+  const preParsed = store.properties.getForEntity(expressId);
+  if (preParsed.length > 0 || !hasOnDemandProperties(store)) {
+    return preParsed;
+  }
+  const raw = extractPropertiesOnDemand(store, expressId);
+  return raw.map((pset): PropertySet => ({
+    name: pset.name,
+    globalId: pset.globalId ?? '',
+    properties: pset.properties.map((p): Property => ({
+      name: p.name,
+      type: p.type as PropertyValueType,
+      value: p.value as PropertyValue,
+    })),
+  }));
+}
+
+function loadQuantitiesFromStore(store: IfcDataStore, expressId: number): QuantitySet[] {
+  const preParsed = store.quantities ? store.quantities.getForEntity(expressId) : [];
+  if (preParsed.length > 0 || !hasOnDemandQuantities(store)) {
+    return preParsed;
+  }
+  const raw = extractQuantitiesOnDemand(store, expressId);
+  return raw.map((qset): QuantitySet => ({
+    name: qset.name,
+    quantities: qset.quantities.map((q): Quantity => ({
+      name: q.name,
+      type: q.type as QuantityType,
+      value: q.value,
+    })),
+  }));
+}
 
 export class QueryResultEntity {
   private store: IfcDataStore;
   readonly expressId: number;
-  
+
   // Cached data (loaded eagerly when includeFlags are set)
   private _properties?: PropertySet[];
   private _quantities?: QuantitySet[];
   private _geometry?: MeshData | null;
-  
+
   constructor(store: IfcDataStore, expressId: number, _includeFlags?: { geometry?: boolean; properties?: boolean; quantities?: boolean }) {
     this.store = store;
     this.expressId = expressId;
   }
-  
+
   get globalId(): string {
     return this.store.entities.getGlobalId(this.expressId);
   }
-  
+
   get name(): string {
     return this.store.entities.getName(this.expressId);
   }
-  
+
   get type(): string {
     return this.store.entities.getTypeName(this.expressId);
   }
-  
+
   get properties(): PropertySet[] {
     if (this._properties !== undefined) {
       return this._properties;
     }
-    return this.store.properties.getForEntity(this.expressId);
+    return loadPropertiesFromStore(this.store, this.expressId);
   }
-  
+
   get quantities(): QuantitySet[] {
     if (this._quantities !== undefined) {
       return this._quantities;
     }
-    if (this.store.quantities) {
-      return this.store.quantities.getForEntity(this.expressId);
-    }
-    return [];
+    return loadQuantitiesFromStore(this.store, this.expressId);
   }
-  
+
   get geometry(): MeshData | null {
     if (this._geometry !== undefined) {
       return this._geometry;
@@ -62,22 +101,29 @@ export class QueryResultEntity {
     // Geometry is not stored in IfcDataStore yet, return null for now
     return null;
   }
-  
-  getProperty(psetName: string, propName: string) {
-    return this.store.properties.getPropertyValue(this.expressId, psetName, propName);
+
+  getProperty(psetName: string, propName: string): PropertyValue | null {
+    const direct = this.store.properties.getPropertyValue(this.expressId, psetName, propName);
+    if (direct !== null) return direct;
+    if (!hasOnDemandProperties(this.store)) return null;
+    for (const pset of loadPropertiesFromStore(this.store, this.expressId)) {
+      if (pset.name !== psetName) continue;
+      for (const p of pset.properties) {
+        if (p.name === propName) return p.value;
+      }
+    }
+    return null;
   }
-  
+
   loadProperties(): void {
     if (this._properties === undefined) {
-      this._properties = this.store.properties.getForEntity(this.expressId);
+      this._properties = loadPropertiesFromStore(this.store, this.expressId);
     }
   }
-  
+
   loadQuantities(): void {
-    if (this._quantities === undefined && this.store.quantities) {
-      this._quantities = this.store.quantities.getForEntity(this.expressId);
-    } else if (this._quantities === undefined) {
-      this._quantities = [];
+    if (this._quantities === undefined) {
+      this._quantities = loadQuantitiesFromStore(this.store, this.expressId);
     }
   }
   

--- a/packages/query/test/on-demand-fallback.test.ts
+++ b/packages/query/test/on-demand-fallback.test.ts
@@ -111,10 +111,7 @@ describe('QueryResultEntity on-demand fallback (issue #577)', () => {
     const [wall] = query.ofType('IfcWallStandardCase').execute();
 
     expect(wall.getProperty('Pset_WallCommon', 'FireRating')).toBe('REI60');
-    // NOTE: on-demand extractor currently returns raw STEP tokens for booleans
-    // (".T." / ".F." rather than true/false). That normalization lives outside
-    // this fix; assert presence here.
-    expect(wall.getProperty('Pset_WallCommon', 'IsExternal')).not.toBeNull();
+    expect(wall.getProperty('Pset_WallCommon', 'IsExternal')).toBe(true);
     expect(wall.getProperty('Pset_WallCommon', 'NoSuchProp')).toBeNull();
   });
 });

--- a/packages/query/test/on-demand-fallback.test.ts
+++ b/packages/query/test/on-demand-fallback.test.ts
@@ -1,0 +1,120 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression test for issue #577.
+ *
+ * `parseColumnar` populates `onDemandPropertyMap` / `onDemandQuantityMap`
+ * and intentionally leaves the pre-parsed property/quantity tables empty.
+ * The query layer must fall back to the on-demand extractors so users get
+ * real data back from `includeProperties()` / `includeQuantities()`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { StepTokenizer, ColumnarParser } from '@ifc-lite/parser';
+import { IfcQuery } from '../src/ifc-query.js';
+
+async function parseFixture(ifc: string) {
+  const source = new TextEncoder().encode(ifc);
+  const tokenizer = new StepTokenizer(source);
+  const entityRefs: Array<{
+    expressId: number;
+    type: string;
+    byteOffset: number;
+    byteLength: number;
+    lineNumber: number;
+  }> = [];
+  for (const ref of tokenizer.scanEntitiesFast()) {
+    entityRefs.push({
+      expressId: ref.expressId,
+      type: ref.type,
+      byteOffset: ref.offset,
+      byteLength: ref.length,
+      lineNumber: ref.line,
+    });
+  }
+  const parser = new ColumnarParser();
+  return parser.parseLite(source.buffer.slice(0), entityRefs, {});
+}
+
+describe('QueryResultEntity on-demand fallback (issue #577)', () => {
+  const ifc = `#1=IFCOWNERHISTORY($,$,$,$,$,$,$,0);
+#10=IFCWALLSTANDARDCASE('wall-guid',#1,'Wall A',$,$,$,$,$);
+#20=IFCPROPERTYSINGLEVALUE('FireRating',$,'REI60',$);
+#21=IFCPROPERTYSINGLEVALUE('IsExternal',$,.T.,$);
+#30=IFCPROPERTYSET('pset-guid',#1,'Pset_WallCommon',$,(#20,#21));
+#40=IFCRELDEFINESBYPROPERTIES('rel-guid',#1,$,$,(#10),#30);
+#50=IFCQUANTITYLENGTH('Length',$,$,5.0);
+#51=IFCQUANTITYAREA('NetSideArea',$,$,12.5);
+#60=IFCELEMENTQUANTITY('qto-guid',#1,'Qto_WallBaseQuantities',$,$,(#50,#51));
+#70=IFCRELDEFINESBYPROPERTIES('qto-rel-guid',#1,$,$,(#10),#60);`;
+
+  it('pre-parsed property/quantity tables are empty after parseLite', async () => {
+    const store = await parseFixture(ifc);
+    expect(store.properties.count).toBe(0);
+    expect(store.quantities?.count ?? 0).toBe(0);
+    expect(store.onDemandPropertyMap?.get(10)).toBeDefined();
+    expect(store.onDemandQuantityMap?.get(10)).toBeDefined();
+  });
+
+  it('QueryResultEntity.properties falls back to the on-demand map', async () => {
+    const store = await parseFixture(ifc);
+    const query = new IfcQuery(store);
+    const [wall] = query.ofType('IfcWallStandardCase').execute();
+    expect(wall).toBeDefined();
+
+    const psets = wall.properties;
+    expect(psets).toHaveLength(1);
+    expect(psets[0].name).toBe('Pset_WallCommon');
+    expect(psets[0].properties.map((p) => p.name).sort()).toEqual(['FireRating', 'IsExternal']);
+  });
+
+  it('QueryResultEntity.quantities falls back to the on-demand map', async () => {
+    const store = await parseFixture(ifc);
+    const query = new IfcQuery(store);
+    const [wall] = query.ofType('IfcWallStandardCase').execute();
+
+    const qsets = wall.quantities;
+    expect(qsets).toHaveLength(1);
+    expect(qsets[0].name).toBe('Qto_WallBaseQuantities');
+    const byName = Object.fromEntries(qsets[0].quantities.map((q) => [q.name, q.value]));
+    expect(byName.Length).toBe(5.0);
+    expect(byName.NetSideArea).toBe(12.5);
+  });
+
+  it('includeProperties() / includeQuantities() eagerly populate results', async () => {
+    const store = await parseFixture(ifc);
+    const query = new IfcQuery(store);
+    const results = query
+      .ofType('IfcWallStandardCase')
+      .includeProperties()
+      .includeQuantities()
+      .execute();
+
+    expect(results).toHaveLength(1);
+    const [wall] = results;
+    expect(wall.properties.length).toBe(1);
+    expect(wall.quantities.length).toBe(1);
+
+    const json = wall.toJSON() as {
+      properties: { name: string }[];
+      quantities?: { name: string }[];
+    };
+    expect(json.properties[0].name).toBe('Pset_WallCommon');
+    expect(json.quantities?.[0].name).toBe('Qto_WallBaseQuantities');
+  });
+
+  it('getProperty() reads values from the on-demand map', async () => {
+    const store = await parseFixture(ifc);
+    const query = new IfcQuery(store);
+    const [wall] = query.ofType('IfcWallStandardCase').execute();
+
+    expect(wall.getProperty('Pset_WallCommon', 'FireRating')).toBe('REI60');
+    // NOTE: on-demand extractor currently returns raw STEP tokens for booleans
+    // (".T." / ".F." rather than true/false). That normalization lives outside
+    // this fix; assert presence here.
+    expect(wall.getProperty('Pset_WallCommon', 'IsExternal')).not.toBeNull();
+    expect(wall.getProperty('Pset_WallCommon', 'NoSuchProp')).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #577.

## Summary

`parseColumnar` was refactored to use on-demand extraction — it populates `store.onDemandPropertyMap` / `store.onDemandQuantityMap` and intentionally leaves `store.properties` / `store.quantities` empty (`packages/parser/src/columnar-parser.ts:450-452`, `:510-551`, `:612-622`). The query layer was never updated to match: `QueryResultEntity` only read from the empty pre-parsed tables, so `query.ofType('IFCWALL').includeProperties().includeQuantities().execute()` always returned elements with empty `properties` / `quantities`.

## Fix

`packages/query/src/query-result-entity.ts` now falls back to `extractPropertiesOnDemand` / `extractQuantitiesOnDemand` (already exported from `@ifc-lite/parser`) when the pre-parsed tables are empty and the on-demand maps are present. Applied to:

- `get properties()` / `get quantities()` (lazy read path)
- `loadProperties()` / `loadQuantities()` (eager path hit by `includeProperties()` / `includeQuantities()`)
- `getProperty(pset, name)` convenience accessor

A small adapter normalizes the on-demand extractor's return shape (`globalId?`, `type: number`) into `PropertySet` / `QuantitySet`.

## Test

Added `packages/query/test/on-demand-fallback.test.ts` — parses an inline IFC fixture with one `IfcWallStandardCase`, one `IfcPropertySet`, and one `IfcElementQuantity`, then asserts:

- `store.properties.count` / `store.quantities.count` are `0` while the on-demand maps are populated (the `parseColumnar` shape).
- `QueryResultEntity.properties` returns `Pset_WallCommon` with both properties.
- `QueryResultEntity.quantities` returns `Qto_WallBaseQuantities` with Length=5.0 and NetSideArea=12.5.
- `.includeProperties().includeQuantities().execute()` eagerly populates the cache (covered via `toJSON()`).
- `getProperty('Pset_WallCommon', 'FireRating')` returns `'REI60'`.

All 109 tests pass in the `@ifc-lite/query` suite.

## Known follow-ups (not in this PR)

1. **Boolean normalization in the on-demand extractor.** `extractPropertiesOnDemand` returns raw STEP tokens like `.T.` / `.F.` instead of `true` / `false`. The test asserts presence rather than the boolean value with a comment explaining why. This lives in the parser, not the query layer — separate fix.
2. **`whereProperty` / `findByProperty` still go through `store.properties`** (`packages/query/src/entity-query.ts:152`), so property-based filtering won't match anything with a `parseColumnar` store until a similar fallback is added there. Wanted to keep this PR tight to the reported symptom; happy to do it as a follow-up.
3. `_includeFlags` is still discarded by the `QueryResultEntity` constructor (prefixed underscore at `:24`). No behavioural impact now that the eager loaders work, but worth removing or actually storing later.

## Test plan

- [x] `pnpm --filter @ifc-lite/query test` — 109/109 pass
- [x] `pnpm --filter @ifc-lite/query build` — typechecks clean
- [ ] Manually verify against `tests/models/buildingsmart/Building-Architecture.ifc` with the snippet from #577

https://claude.ai/code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved property and quantity retrieval with fallback mechanisms for cases where pre-parsed data is unavailable.
  * Enhanced `getProperty()` method with proper type safety and on-demand data extraction capabilities.

* **Tests**
  * Added regression tests for property and quantity loading scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->