### PR TITLE
feat(viewer): arbitrary-normal section planes with face-pick (#243)

### DIFF
--- a/.changeset/section-plane-arbitrary-normal.md
+++ b/.changeset/section-plane-arbitrary-normal.md
@@ -1,0 +1,24 @@
+---
+"@ifc-lite/renderer": minor
+"@ifc-lite/viewer": minor
+---
+
+Section plane now accepts an arbitrary world-space normal in addition to the
+three cardinal axes. `SectionPlane` (renderer types + viewer store) gains an
+optional `normal: [x, y, z]`; when set the renderer projects the model bounds
+onto that normal and uses `position` (0–100%) to interpolate the plane
+distance, so the slider keeps offsetting the plane along its own normal. The
+WGSL shader already accepted `vec3 normal + f32 distance` — only the JS layer
+was hardcoding axes.
+
+Viewer surfaces this as a new "Pick face" tool that arms the next click to set
+the section plane through any visible face (the Bonsai-style pick from #243).
+The section panel is now draggable, clamped to the 3D canvas area. The
+nearest-cardinal `axis` plus a derived `flipped` are still populated for
+downstream consumers (BCF snapshots, drawings export, view controls) so they
+get an equivalent cardinal cut for free.
+
+The 2D drawing pipeline still requires a cardinal axis: when a custom plane
+is active the 2D cap overlay is suppressed and the 2D drawing panel reports
+"2D drawing is not available for custom face-picked planes" until the
+generator grows arbitrary-normal support.

--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -195,7 +195,7 @@ export function Viewport({
   const isolatedEntities = computedIsolatedIds ?? storeIsolatedEntities ?? null;
 
   // Tool state
-  const { activeTool, sectionPlane } = useToolState();
+  const { activeTool, sectionPlane, sectionPickMode, setSectionPlaneFromFace, setSectionPickMode } = useToolState();
 
   // Camera state
   const { updateCameraRotationRealtime, updateScaleRealtime, setCameraCallbacks } = useCameraState();
@@ -381,6 +381,7 @@ export function Viewport({
   const measurementConstraintEdgeRef = useLatestRef(measurementConstraintEdge);
   const sectionPlaneRef = useLatestRef(sectionPlane);
   const sectionRangeRef = useLatestRef(sectionRange);
+  const sectionPickModeRef = useLatestRef(sectionPickMode);
   const visualEnhancementRef = useLatestRef(visualEnhancement);
 
   // Terrain clip Y from Cesium store (read as ref for animation loop)
@@ -455,13 +456,21 @@ export function Viewport({
       }
     }
 
+    // Leaving the section tool disarms face-pick so it doesn't surprise
+    // the user on re-entry to a different tool.
+    if (activeTool !== 'section' && sectionPickMode) {
+      setSectionPickMode(false);
+    }
+
     // Set cursor based on active tool
     if (activeTool === 'measure') {
+      canvas.style.cursor = 'crosshair';
+    } else if (activeTool === 'section' && sectionPickMode) {
       canvas.style.cursor = 'crosshair';
     } else {
       canvas.style.cursor = 'default';
     }
-  }, [activeTool, activeMeasurement, cancelMeasurement]);
+  }, [activeTool, activeMeasurement, cancelMeasurement, sectionPickMode, setSectionPickMode]);
 
   // Helper: calculate scale bar value (world-space size for 96px scale bar)
   const calculateScale = () => {
@@ -713,6 +722,7 @@ export function Viewport({
     snapEnabledRef,
     edgeLockStateRef,
     measurementConstraintEdgeRef,
+    sectionPickModeRef,
     hiddenEntitiesRef,
     isolatedEntitiesRef,
     selectedEntityIdRef,
@@ -737,6 +747,8 @@ export function Viewport({
     setHoverState,
     clearHover,
     openContextMenu,
+    setSectionPlaneFromFace,
+    setSectionPickMode,
     startMeasurement,
     updateMeasurement,
     finalizeMeasurement,

--- a/apps/viewer/src/components/viewer/mouseHandlerTypes.ts
+++ b/apps/viewer/src/components/viewer/mouseHandlerTypes.ts
@@ -56,6 +56,17 @@ export interface MouseHandlerContext {
   snapEnabledRef: MutableRefObject<boolean>;
   edgeLockStateRef: MutableRefObject<EdgeLockState>;
   measurementConstraintEdgeRef: MutableRefObject<MeasurementConstraintEdge | null>;
+  /** Latest value of `sectionPickMode` from the section slice. Optional so
+   * existing callers that don't care about section face-pick don't have to
+   * thread it through. */
+  sectionPickModeRef?: MutableRefObject<boolean>;
+  /** Action: set plane through a world-space face. */
+  setSectionPlaneFromFace?: (
+    normal: [number, number, number],
+    point: [number, number, number],
+  ) => void;
+  /** Action: arm/disarm face-pick mode. */
+  setSectionPickMode?: (enabled: boolean) => void;
 
   // Visibility refs
   hiddenEntitiesRef: MutableRefObject<Set<number>>;

--- a/apps/viewer/src/components/viewer/mouseHandlerTypes.ts
+++ b/apps/viewer/src/components/viewer/mouseHandlerTypes.ts
@@ -60,10 +60,11 @@ export interface MouseHandlerContext {
    * existing callers that don't care about section face-pick don't have to
    * thread it through. */
   sectionPickModeRef?: MutableRefObject<boolean>;
-  /** Action: set plane through a world-space face. */
+  /** Action: set plane through a world-space face. `position` is already
+   * projected into 0-100% along the model bounds along the normal. */
   setSectionPlaneFromFace?: (
     normal: [number, number, number],
-    point: [number, number, number],
+    position: number,
   ) => void;
   /** Action: arm/disarm face-pick mode. */
   setSectionPickMode?: (enabled: boolean) => void;

--- a/apps/viewer/src/components/viewer/mouseHandlerTypes.ts
+++ b/apps/viewer/src/components/viewer/mouseHandlerTypes.ts
@@ -56,18 +56,16 @@ export interface MouseHandlerContext {
   snapEnabledRef: MutableRefObject<boolean>;
   edgeLockStateRef: MutableRefObject<EdgeLockState>;
   measurementConstraintEdgeRef: MutableRefObject<MeasurementConstraintEdge | null>;
-  /** Latest value of `sectionPickMode` from the section slice. Optional so
-   * existing callers that don't care about section face-pick don't have to
-   * thread it through. */
-  sectionPickModeRef?: MutableRefObject<boolean>;
+  /** Latest value of `sectionPickMode` from the section slice. */
+  sectionPickModeRef: MutableRefObject<boolean>;
   /** Action: set plane through a world-space face. `position` is already
    * projected into 0-100% along the model bounds along the normal. */
-  setSectionPlaneFromFace?: (
+  setSectionPlaneFromFace: (
     normal: [number, number, number],
     position: number,
   ) => void;
   /** Action: arm/disarm face-pick mode. */
-  setSectionPickMode?: (enabled: boolean) => void;
+  setSectionPickMode: (enabled: boolean) => void;
 
   // Visibility refs
   hiddenEntitiesRef: MutableRefObject<Set<number>>;

--- a/apps/viewer/src/components/viewer/selectionHandlers.ts
+++ b/apps/viewer/src/components/viewer/selectionHandlers.ts
@@ -37,10 +37,39 @@ export async function handleSelectionClick(ctx: MouseHandlerContext, e: MouseEve
     if (hit?.intersection) {
       const n = hit.intersection.normal;
       const p = hit.intersection.point;
-      ctx.setSectionPlaneFromFace?.(
-        [n.x, n.y, n.z],
-        [p.x, p.y, p.z],
-      );
+      // Normalise and project the pick point into 0-100% along the
+      // model's bounds projected onto the plane normal — this is what
+      // the position slider drives, so after the pick dragging the
+      // slider offsets the plane along its normal continuously.
+      const nlen = Math.sqrt(n.x * n.x + n.y * n.y + n.z * n.z);
+      if (nlen > 1e-6) {
+        const nx = n.x / nlen;
+        const ny = n.y / nlen;
+        const nz = n.z / nlen;
+        const bounds = renderer.getModelBounds();
+        let position = 50;
+        if (bounds) {
+          let minP = Infinity;
+          let maxP = -Infinity;
+          for (const cx of [bounds.min.x, bounds.max.x]) {
+            for (const cy of [bounds.min.y, bounds.max.y]) {
+              for (const cz of [bounds.min.z, bounds.max.z]) {
+                const proj = cx * nx + cy * ny + cz * nz;
+                if (proj < minP) minP = proj;
+                if (proj > maxP) maxP = proj;
+              }
+            }
+          }
+          const pickProj = p.x * nx + p.y * ny + p.z * nz;
+          const range = maxP - minP;
+          if (range > 1e-6) {
+            position = Math.min(100, Math.max(0, ((pickProj - minP) / range) * 100));
+          }
+        }
+        ctx.setSectionPlaneFromFace?.([nx, ny, nz], position);
+      } else {
+        ctx.setSectionPickMode?.(false);
+      }
     } else {
       // Missed geometry — cancel the arm so the user isn't stuck in pick
       // mode after an errant background click.

--- a/apps/viewer/src/components/viewer/selectionHandlers.ts
+++ b/apps/viewer/src/components/viewer/selectionHandlers.ts
@@ -26,6 +26,29 @@ export async function handleSelectionClick(ctx: MouseHandlerContext, e: MouseEve
     return;
   }
 
+  // Section-tool face-pick: click any visible face and the plane is set
+  // through it. Intercept before the generic select path so the click
+  // doesn't also flip selection.
+  if (tool === 'section' && ctx.sectionPickModeRef?.current) {
+    const hit = renderer.raycastScene(x, y, {
+      hiddenIds: ctx.hiddenEntitiesRef.current,
+      isolatedIds: ctx.isolatedEntitiesRef.current,
+    });
+    if (hit?.intersection) {
+      const n = hit.intersection.normal;
+      const p = hit.intersection.point;
+      ctx.setSectionPlaneFromFace?.(
+        [n.x, n.y, n.z],
+        [p.x, p.y, p.z],
+      );
+    } else {
+      // Missed geometry — cancel the arm so the user isn't stuck in pick
+      // mode after an errant background click.
+      ctx.setSectionPickMode?.(false);
+    }
+    return;
+  }
+
   // Skip selection for pan/walk tools - they don't select
   if (tool === 'pan' || tool === 'walk') {
     return;

--- a/apps/viewer/src/components/viewer/selectionHandlers.ts
+++ b/apps/viewer/src/components/viewer/selectionHandlers.ts
@@ -9,6 +9,7 @@
  */
 
 import type { MouseHandlerContext } from './mouseHandlerTypes.js';
+import { positionFromPoint } from '@ifc-lite/renderer';
 
 /**
  * Handle click event for selection (single click and double click).
@@ -29,7 +30,7 @@ export async function handleSelectionClick(ctx: MouseHandlerContext, e: MouseEve
   // Section-tool face-pick: click any visible face and the plane is set
   // through it. Intercept before the generic select path so the click
   // doesn't also flip selection.
-  if (tool === 'section' && ctx.sectionPickModeRef?.current) {
+  if (tool === 'section' && ctx.sectionPickModeRef.current) {
     const hit = renderer.raycastScene(x, y, {
       hiddenIds: ctx.hiddenEntitiesRef.current,
       isolatedIds: ctx.isolatedEntitiesRef.current,
@@ -37,43 +38,26 @@ export async function handleSelectionClick(ctx: MouseHandlerContext, e: MouseEve
     if (hit?.intersection) {
       const n = hit.intersection.normal;
       const p = hit.intersection.point;
-      // Normalise and project the pick point into 0-100% along the
-      // model's bounds projected onto the plane normal — this is what
-      // the position slider drives, so after the pick dragging the
-      // slider offsets the plane along its normal continuously.
+      // Normalise and map the pick point into 0-100% along the model's
+      // bounds projected onto the plane normal — this is what the
+      // position slider drives, so after the pick dragging the slider
+      // offsets the plane along its normal continuously. Shared helper
+      // so the mapping stays in lockstep with the renderer's clip.
       const nlen = Math.sqrt(n.x * n.x + n.y * n.y + n.z * n.z);
       if (nlen > 1e-6) {
-        const nx = n.x / nlen;
-        const ny = n.y / nlen;
-        const nz = n.z / nlen;
+        const unit: [number, number, number] = [n.x / nlen, n.y / nlen, n.z / nlen];
         const bounds = renderer.getModelBounds();
-        let position = 50;
-        if (bounds) {
-          let minP = Infinity;
-          let maxP = -Infinity;
-          for (const cx of [bounds.min.x, bounds.max.x]) {
-            for (const cy of [bounds.min.y, bounds.max.y]) {
-              for (const cz of [bounds.min.z, bounds.max.z]) {
-                const proj = cx * nx + cy * ny + cz * nz;
-                if (proj < minP) minP = proj;
-                if (proj > maxP) maxP = proj;
-              }
-            }
-          }
-          const pickProj = p.x * nx + p.y * ny + p.z * nz;
-          const range = maxP - minP;
-          if (range > 1e-6) {
-            position = Math.min(100, Math.max(0, ((pickProj - minP) / range) * 100));
-          }
-        }
-        ctx.setSectionPlaneFromFace?.([nx, ny, nz], position);
+        const position = bounds
+          ? positionFromPoint(bounds, unit, [p.x, p.y, p.z])
+          : 50;
+        ctx.setSectionPlaneFromFace(unit, position);
       } else {
-        ctx.setSectionPickMode?.(false);
+        ctx.setSectionPickMode(false);
       }
     } else {
       // Missed geometry — cancel the arm so the user isn't stuck in pick
       // mode after an errant background click.
-      ctx.setSectionPickMode?.(false);
+      ctx.setSectionPickMode(false);
     }
     return;
   }

--- a/apps/viewer/src/components/viewer/tools/SectionPanel.tsx
+++ b/apps/viewer/src/components/viewer/tools/SectionPanel.tsx
@@ -7,7 +7,7 @@
  */
 
 import React, { useCallback, useState } from 'react';
-import { X, Slice, ChevronDown, FileImage, FlipHorizontal2 } from 'lucide-react';
+import { X, Slice, ChevronDown, FileImage, FlipHorizontal2, MousePointerClick } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useViewerStore } from '@/store';
 import { AXIS_INFO } from './sectionConstants';
@@ -16,8 +16,10 @@ import { SectionCapControls } from './SectionCapControls';
 
 export function SectionOverlay() {
   const sectionPlane = useViewerStore((s) => s.sectionPlane);
+  const sectionPickMode = useViewerStore((s) => s.sectionPickMode);
   const setSectionPlaneAxis = useViewerStore((s) => s.setSectionPlaneAxis);
   const setSectionPlanePosition = useViewerStore((s) => s.setSectionPlanePosition);
+  const setSectionPickMode = useViewerStore((s) => s.setSectionPickMode);
   const toggleSectionPlane = useViewerStore((s) => s.toggleSectionPlane);
   const flipSectionPlane = useViewerStore((s) => s.flipSectionPlane);
   const setActiveTool = useViewerStore((s) => s.setActiveTool);
@@ -25,14 +27,22 @@ export function SectionOverlay() {
   const drawingPanelVisible = useViewerStore((s) => s.drawing2DPanelVisible);
   const clearDrawing = useViewerStore((s) => s.clearDrawing2D);
   const [isPanelCollapsed, setIsPanelCollapsed] = useState(true);
+  const isCustomPlane = sectionPlane.normal !== undefined && sectionPlane.distance !== undefined;
 
   const handleClose = useCallback(() => {
     setActiveTool('select');
   }, [setActiveTool]);
 
   const handleAxisChange = useCallback((axis: 'down' | 'front' | 'side') => {
+    // Re-selecting a preset also cancels any pending face-pick so the UI
+    // doesn't stay in a half-armed state.
+    setSectionPickMode(false);
     setSectionPlaneAxis(axis);
-  }, [setSectionPlaneAxis]);
+  }, [setSectionPlaneAxis, setSectionPickMode]);
+
+  const handlePickFaceToggle = useCallback(() => {
+    setSectionPickMode(!sectionPickMode);
+  }, [sectionPickMode, setSectionPickMode]);
 
   const handlePositionChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const value = Number(e.target.value);
@@ -93,7 +103,7 @@ export function SectionOverlay() {
                 {(['down', 'front', 'side'] as const).map((axis) => (
                   <Button
                     key={axis}
-                    variant={sectionPlane.axis === axis ? 'default' : 'outline'}
+                    variant={!isCustomPlane && sectionPlane.axis === axis ? 'default' : 'outline'}
                     size="sm"
                     className="flex-1 flex-col h-auto py-1.5"
                     onClick={() => handleAxisChange(axis)}
@@ -102,6 +112,21 @@ export function SectionOverlay() {
                   </Button>
                 ))}
               </div>
+              <Button
+                variant={sectionPickMode ? 'default' : isCustomPlane ? 'secondary' : 'outline'}
+                size="sm"
+                className="mt-1.5 w-full h-auto py-1.5"
+                onClick={handlePickFaceToggle}
+                aria-pressed={sectionPickMode}
+                title={sectionPickMode
+                  ? 'Click any face to cut through it'
+                  : 'Pick any face in the model to cut through'}
+              >
+                <MousePointerClick className="h-3 w-3 mr-1.5" />
+                <span className="text-xs font-medium">
+                  {sectionPickMode ? 'Click a face…' : isCustomPlane ? 'Custom plane — pick again' : 'Pick face'}
+                </span>
+              </Button>
             </div>
 
             {/* Position Slider */}

--- a/apps/viewer/src/components/viewer/tools/SectionPanel.tsx
+++ b/apps/viewer/src/components/viewer/tools/SectionPanel.tsx
@@ -6,13 +6,16 @@
  * Section plane controls panel
  */
 
-import React, { useCallback, useState } from 'react';
-import { X, Slice, ChevronDown, FileImage, FlipHorizontal2, MousePointerClick } from 'lucide-react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { X, Slice, ChevronDown, FileImage, FlipHorizontal2, MousePointerClick, GripVertical } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useViewerStore } from '@/store';
 import { AXIS_INFO } from './sectionConstants';
 import { SectionPlaneVisualization } from './SectionVisualization';
 import { SectionCapControls } from './SectionCapControls';
+
+// Visible margin so the panel can't be dragged fully off the 3D canvas.
+const PANEL_DRAG_MARGIN_PX = 8;
 
 export function SectionOverlay() {
   const sectionPlane = useViewerStore((s) => s.sectionPlane);
@@ -27,7 +30,95 @@ export function SectionOverlay() {
   const drawingPanelVisible = useViewerStore((s) => s.drawing2DPanelVisible);
   const clearDrawing = useViewerStore((s) => s.clearDrawing2D);
   const [isPanelCollapsed, setIsPanelCollapsed] = useState(true);
-  const isCustomPlane = sectionPlane.normal !== undefined && sectionPlane.distance !== undefined;
+  const isCustomPlane = sectionPlane.normal !== undefined;
+
+  // Draggable panel state. `panelPos` is null until the user drags, at which
+  // point we switch from the CSS-centred default to explicit pixel offsets
+  // inside the 3D-area parent element.
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const [panelPos, setPanelPos] = useState<{ x: number; y: number } | null>(null);
+  const dragStateRef = useRef<{
+    pointerId: number;
+    startPx: { x: number; y: number };
+    startPy: { x: number; y: number };
+    rectW: number;
+    rectH: number;
+  } | null>(null);
+
+  // Clamp the stored position back inside the parent rect on resize so a
+  // panel dragged near the edge doesn't float off-screen when the viewport
+  // shrinks (window resize, drawing panel opening, etc.).
+  useEffect(() => {
+    if (!panelPos) return;
+    const el = panelRef.current;
+    const parent = el?.parentElement;
+    if (!el || !parent) return;
+    const parentRect = parent.getBoundingClientRect();
+    const panelRect = el.getBoundingClientRect();
+    const maxX = Math.max(PANEL_DRAG_MARGIN_PX, parentRect.width - panelRect.width - PANEL_DRAG_MARGIN_PX);
+    const maxY = Math.max(PANEL_DRAG_MARGIN_PX, parentRect.height - panelRect.height - PANEL_DRAG_MARGIN_PX);
+    const clamped = {
+      x: Math.min(maxX, Math.max(PANEL_DRAG_MARGIN_PX, panelPos.x)),
+      y: Math.min(maxY, Math.max(PANEL_DRAG_MARGIN_PX, panelPos.y)),
+    };
+    if (clamped.x !== panelPos.x || clamped.y !== panelPos.y) {
+      setPanelPos(clamped);
+    }
+    // We intentionally do NOT depend on panelPos here to avoid a feedback loop;
+    // this runs whenever panelPos changes (React's normal effect schedule) and
+    // the clamp is idempotent.
+
+  }, [panelPos]);
+
+  const handleDragPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    // Only left-button drags; ignore right-click, touch pan, etc.
+    if (e.button !== 0) return;
+    const el = panelRef.current;
+    const parent = el?.parentElement;
+    if (!el || !parent) return;
+    const parentRect = parent.getBoundingClientRect();
+    const panelRect = el.getBoundingClientRect();
+    const startPy = {
+      x: panelRect.left - parentRect.left,
+      y: panelRect.top - parentRect.top,
+    };
+    dragStateRef.current = {
+      pointerId: e.pointerId,
+      startPx: { x: e.clientX, y: e.clientY },
+      startPy,
+      rectW: parentRect.width,
+      rectH: parentRect.height,
+    };
+    (e.currentTarget as HTMLDivElement).setPointerCapture(e.pointerId);
+    // Seed explicit position so subsequent pointermove updates are absolute,
+    // not relative to the CSS-centred default.
+    setPanelPos(startPy);
+    e.preventDefault();
+    e.stopPropagation();
+  }, []);
+
+  const handleDragPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragStateRef.current;
+    if (!drag || drag.pointerId !== e.pointerId) return;
+    const el = panelRef.current;
+    if (!el) return;
+    const dx = e.clientX - drag.startPx.x;
+    const dy = e.clientY - drag.startPx.y;
+    const panelRect = el.getBoundingClientRect();
+    const maxX = Math.max(PANEL_DRAG_MARGIN_PX, drag.rectW - panelRect.width - PANEL_DRAG_MARGIN_PX);
+    const maxY = Math.max(PANEL_DRAG_MARGIN_PX, drag.rectH - panelRect.height - PANEL_DRAG_MARGIN_PX);
+    setPanelPos({
+      x: Math.min(maxX, Math.max(PANEL_DRAG_MARGIN_PX, drag.startPy.x + dx)),
+      y: Math.min(maxY, Math.max(PANEL_DRAG_MARGIN_PX, drag.startPy.y + dy)),
+    });
+  }, []);
+
+  const handleDragPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragStateRef.current;
+    if (!drag || drag.pointerId !== e.pointerId) return;
+    (e.currentTarget as HTMLDivElement).releasePointerCapture(e.pointerId);
+    dragStateRef.current = null;
+  }, []);
 
   const handleClose = useCallback(() => {
     setActiveTool('select');
@@ -63,10 +154,32 @@ export function SectionOverlay() {
 
   return (
     <>
-      {/* Compact Section Tool Panel - matches Measure tool style */}
-      <div className="pointer-events-auto absolute top-4 left-1/2 -translate-x-1/2 bg-background/95 backdrop-blur-sm rounded-lg border shadow-lg z-30">
+      {/* Compact Section Tool Panel - matches Measure tool style.
+          Draggable within its parent (the 3D canvas area) via the grip on
+          the header. Until first dragged the panel sits in the default
+          centred position; `panelPos` flips it to explicit pixel offsets
+          after the first drag. */}
+      <div
+        ref={panelRef}
+        className={
+          panelPos === null
+            ? "pointer-events-auto absolute top-4 left-1/2 -translate-x-1/2 bg-background/95 backdrop-blur-sm rounded-lg border shadow-lg z-30"
+            : "pointer-events-auto absolute bg-background/95 backdrop-blur-sm rounded-lg border shadow-lg z-30"
+        }
+        style={panelPos === null ? undefined : { top: `${panelPos.y}px`, left: `${panelPos.x}px` }}
+      >
         {/* Header - always visible */}
         <div className="flex items-center justify-between gap-2 p-2">
+          <div
+            className="flex items-center text-muted-foreground hover:text-foreground cursor-grab active:cursor-grabbing select-none touch-none"
+            title="Drag to move panel"
+            onPointerDown={handleDragPointerDown}
+            onPointerMove={handleDragPointerMove}
+            onPointerUp={handleDragPointerUp}
+            onPointerCancel={handleDragPointerUp}
+          >
+            <GripVertical className="h-4 w-4" />
+          </div>
           <button
             onClick={togglePanel}
             className="flex items-center gap-2 hover:bg-accent/50 rounded px-2 py-1 transition-colors"
@@ -75,7 +188,8 @@ export function SectionOverlay() {
             <span className="font-medium text-sm">Section</span>
             {sectionPlane.enabled && (
               <span className="text-xs text-primary font-mono">
-                {AXIS_INFO[sectionPlane.axis].label} <span className="inline-block w-12 text-right tabular-nums">{sectionPlane.position.toFixed(1)}%</span>
+                {isCustomPlane ? 'Custom' : AXIS_INFO[sectionPlane.axis].label}{' '}
+                <span className="inline-block w-12 text-right tabular-nums">{sectionPlane.position.toFixed(1)}%</span>
               </span>
             )}
             <ChevronDown className={`h-3 w-3 transition-transform ${isPanelCollapsed ? '-rotate-90' : ''}`} />
@@ -200,7 +314,7 @@ export function SectionOverlay() {
       >
         <span className="font-mono text-xs uppercase tracking-wide">
           {sectionPlane.enabled
-            ? `Cut ${AXIS_INFO[sectionPlane.axis].label.toLowerCase()} at ${sectionPlane.position.toFixed(1)}%${sectionPlane.flipped ? ' (flipped)' : ''}`
+            ? `Cut ${isCustomPlane ? 'custom' : AXIS_INFO[sectionPlane.axis].label.toLowerCase()} at ${sectionPlane.position.toFixed(1)}%${sectionPlane.flipped ? ' (flipped)' : ''}`
             : 'Clip off — drag slider to cut'}
         </span>
       </div>

--- a/apps/viewer/src/components/viewer/tools/SectionPanel.tsx
+++ b/apps/viewer/src/components/viewer/tools/SectionPanel.tsx
@@ -195,8 +195,9 @@ export function SectionOverlay() {
             <ChevronDown className={`h-3 w-3 transition-transform ${isPanelCollapsed ? '-rotate-90' : ''}`} />
           </button>
           <div className="flex items-center gap-1">
-            {/* Only show 2D button when panel is closed */}
-            {!drawingPanelVisible && (
+            {/* Only show 2D button when panel is closed — and never for custom
+                planes, where the drawing pipeline can't project correctly yet. */}
+            {!drawingPanelVisible && !isCustomPlane && (
               <Button variant="ghost" size="icon-sm" onClick={handleView2D} title="Open 2D Drawing Panel">
                 <FileImage className="h-3 w-3" />
               </Button>
@@ -285,8 +286,10 @@ export function SectionOverlay() {
             {/* Cap surface controls (hatch, colour, spacing) */}
             <SectionCapControls />
 
-            {/* Show 2D panel button - only when panel is closed */}
-            {!drawingPanelVisible && (
+            {/* Show 2D panel button - only when panel is closed and the
+                plane is a cardinal axis (the drawing pipeline doesn't yet
+                support arbitrary normals). */}
+            {!drawingPanelVisible && !isCustomPlane && (
               <div className="mt-3 pt-3 border-t">
                 <Button
                   variant="outline"
@@ -297,6 +300,11 @@ export function SectionOverlay() {
                   <FileImage className="h-4 w-4 mr-2" />
                   Open 2D Drawing
                 </Button>
+              </div>
+            )}
+            {isCustomPlane && (
+              <div className="mt-3 pt-3 border-t text-[10px] text-muted-foreground leading-snug">
+                2D drawing export is only available for the Down / Front / Side presets. Pick a preset to generate a plan/section.
               </div>
             )}
           </div>
@@ -337,7 +345,7 @@ export function SectionOverlay() {
       </div>
 
       {/* Section plane visualization overlay */}
-      <SectionPlaneVisualization axis={sectionPlane.axis} enabled={sectionPlane.enabled} />
+      <SectionPlaneVisualization axis={sectionPlane.axis} enabled={sectionPlane.enabled} isCustom={isCustomPlane} />
     </>
   );
 }

--- a/apps/viewer/src/components/viewer/tools/SectionPanel.tsx
+++ b/apps/viewer/src/components/viewer/tools/SectionPanel.tsx
@@ -45,30 +45,46 @@ export function SectionOverlay() {
     rectH: number;
   } | null>(null);
 
-  // Clamp the stored position back inside the parent rect on resize so a
-  // panel dragged near the edge doesn't float off-screen when the viewport
-  // shrinks (window resize, drawing panel opening, etc.).
+  // Re-clamp the stored position whenever either the position OR the parent
+  // element changes size — so a panel dragged near the edge doesn't float
+  // off-screen when the viewport shrinks (2D drawing panel opens, window
+  // resize, etc.). Uses a ResizeObserver on the parent and a window resize
+  // listener; the clamp itself is idempotent (uses the functional setState
+  // form and returns `prev` unchanged when already inside bounds), so re-
+  // running it on `panelPos` change doesn't loop.
   useEffect(() => {
     if (!panelPos) return;
     const el = panelRef.current;
     const parent = el?.parentElement;
     if (!el || !parent) return;
-    const parentRect = parent.getBoundingClientRect();
-    const panelRect = el.getBoundingClientRect();
-    const maxX = Math.max(PANEL_DRAG_MARGIN_PX, parentRect.width - panelRect.width - PANEL_DRAG_MARGIN_PX);
-    const maxY = Math.max(PANEL_DRAG_MARGIN_PX, parentRect.height - panelRect.height - PANEL_DRAG_MARGIN_PX);
-    const clamped = {
-      x: Math.min(maxX, Math.max(PANEL_DRAG_MARGIN_PX, panelPos.x)),
-      y: Math.min(maxY, Math.max(PANEL_DRAG_MARGIN_PX, panelPos.y)),
-    };
-    if (clamped.x !== panelPos.x || clamped.y !== panelPos.y) {
-      setPanelPos(clamped);
-    }
-    // We intentionally do NOT depend on panelPos here to avoid a feedback loop;
-    // this runs whenever panelPos changes (React's normal effect schedule) and
-    // the clamp is idempotent.
 
-  }, [panelPos]);
+    const clampNow = () => {
+      const parentRect = parent.getBoundingClientRect();
+      const panelRect = el.getBoundingClientRect();
+      const maxX = Math.max(PANEL_DRAG_MARGIN_PX, parentRect.width - panelRect.width - PANEL_DRAG_MARGIN_PX);
+      const maxY = Math.max(PANEL_DRAG_MARGIN_PX, parentRect.height - panelRect.height - PANEL_DRAG_MARGIN_PX);
+      setPanelPos((prev) => {
+        if (!prev) return prev;
+        const clamped = {
+          x: Math.min(maxX, Math.max(PANEL_DRAG_MARGIN_PX, prev.x)),
+          y: Math.min(maxY, Math.max(PANEL_DRAG_MARGIN_PX, prev.y)),
+        };
+        return clamped.x === prev.x && clamped.y === prev.y ? prev : clamped;
+      });
+    };
+
+    clampNow();
+    const ro = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(clampNow) : null;
+    ro?.observe(parent);
+    window.addEventListener('resize', clampNow);
+    return () => {
+      ro?.disconnect();
+      window.removeEventListener('resize', clampNow);
+    };
+    // Depend on a boolean so we set up / tear down the observer only on the
+    // null↔non-null edge — further updates are handled inside clampNow via
+    // the functional setPanelPos.
+  }, [panelPos !== null]);
 
   const handleDragPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     // Only left-button drags; ignore right-click, touch pan, etc.

--- a/apps/viewer/src/components/viewer/tools/SectionVisualization.tsx
+++ b/apps/viewer/src/components/viewer/tools/SectionVisualization.tsx
@@ -11,10 +11,15 @@ import { AXIS_INFO } from './sectionConstants';
 interface SectionPlaneVisualizationProps {
   axis: 'down' | 'front' | 'side';
   enabled: boolean;
+  /** True when the plane has been set via face-pick (arbitrary normal).
+   * Changes the badge colour + label so the user isn't misled by the
+   * nearest-cardinal `axis` value that's still populated for downstream
+   * compatibility (drawings/BCF). */
+  isCustom?: boolean;
 }
 
 // Section plane visual indicator component
-export function SectionPlaneVisualization({ axis, enabled }: SectionPlaneVisualizationProps) {
+export function SectionPlaneVisualization({ axis, enabled, isCustom = false }: SectionPlaneVisualizationProps) {
   // Get the axis color
   const axisColors = {
     down: '#03A9F4',  // Light blue for horizontal cuts
@@ -22,7 +27,8 @@ export function SectionPlaneVisualization({ axis, enabled }: SectionPlaneVisuali
     side: '#FF9800',  // Orange for side cuts
   };
 
-  const color = axisColors[axis];
+  const color = isCustom ? '#9C6BDE' : axisColors[axis];
+  const label = isCustom ? 'CUSTOM' : AXIS_INFO[axis].label.toUpperCase();
 
   return (
     <svg
@@ -53,10 +59,10 @@ export function SectionPlaneVisualization({ axis, enabled }: SectionPlaneVisuali
           dominantBaseline="central"
           fill={color}
           fontFamily="monospace"
-          fontSize="11"
+          fontSize={isCustom ? 8 : 11}
           fontWeight="bold"
         >
-          {AXIS_INFO[axis].label.toUpperCase()}
+          {label}
         </text>
         {/* Active indicator */}
         {enabled && (

--- a/apps/viewer/src/components/viewer/useAnimationLoop.ts
+++ b/apps/viewer/src/components/viewer/useAnimationLoop.ts
@@ -181,6 +181,10 @@ export function useAnimationLoop(params: UseAnimationLoopParams): void {
             capStyle: sectionPlaneRef.current.capStyle,
             min: sectionRangeRef.current?.min,
             max: sectionRangeRef.current?.max,
+            // Face-pick overrides — when set, the renderer uses these
+            // verbatim and ignores axis/position/min/max.
+            normal: sectionPlaneRef.current.normal,
+            distance: sectionPlaneRef.current.distance,
           } : undefined,
           terrainClipY: terrainClipYRef.current ?? undefined,
         });

--- a/apps/viewer/src/components/viewer/useAnimationLoop.ts
+++ b/apps/viewer/src/components/viewer/useAnimationLoop.ts
@@ -181,10 +181,11 @@ export function useAnimationLoop(params: UseAnimationLoopParams): void {
             capStyle: sectionPlaneRef.current.capStyle,
             min: sectionRangeRef.current?.min,
             max: sectionRangeRef.current?.max,
-            // Face-pick overrides — when set, the renderer uses these
-            // verbatim and ignores axis/position/min/max.
+            // Face-pick: when `normal` is set the renderer projects the
+            // model bounds onto it and uses `position` (above) to interpolate
+            // the plane distance along that range, so the slider still
+            // drives the offset.
             normal: sectionPlaneRef.current.normal,
-            distance: sectionPlaneRef.current.distance,
           } : undefined,
           terrainClipY: terrainClipYRef.current ?? undefined,
         });

--- a/apps/viewer/src/components/viewer/useMouseControls.ts
+++ b/apps/viewer/src/components/viewer/useMouseControls.ts
@@ -56,6 +56,8 @@ export interface UseMouseControlsParams {
   snapEnabledRef: MutableRefObject<boolean>;
   edgeLockStateRef: MutableRefObject<EdgeLockState>;
   measurementConstraintEdgeRef: MutableRefObject<MeasurementConstraintEdge | null>;
+  /** Section tool: when true, next click arms a face-pick for the clip plane. */
+  sectionPickModeRef: MutableRefObject<boolean>;
 
   // Visibility/selection refs
   hiddenEntitiesRef: MutableRefObject<Set<number>>;
@@ -121,6 +123,13 @@ export interface UseMouseControlsParams {
   calculateScale: () => void;
   getPickOptions: () => { isStreaming: boolean; hiddenIds: Set<number>; isolatedIds: Set<number> | null };
   hasPendingMeasurements: () => boolean;
+  /** Section face-pick: set the clip plane through a world-space face. */
+  setSectionPlaneFromFace: (
+    normal: [number, number, number],
+    point: [number, number, number],
+  ) => void;
+  /** Section face-pick: arm/disarm the "next click picks a face" mode. */
+  setSectionPickMode: (enabled: boolean) => void;
 
   // Constants
   HOVER_SNAP_THROTTLE_MS: number;
@@ -144,6 +153,7 @@ export function useMouseControls(params: UseMouseControlsParams): void {
     snapEnabledRef,
     edgeLockStateRef,
     measurementConstraintEdgeRef,
+    sectionPickModeRef,
     hiddenEntitiesRef,
     isolatedEntitiesRef,
     selectedEntityIdRef,
@@ -168,6 +178,8 @@ export function useMouseControls(params: UseMouseControlsParams): void {
     setHoverState,
     clearHover,
     openContextMenu,
+    setSectionPlaneFromFace,
+    setSectionPickMode,
     startMeasurement,
     updateMeasurement,
     finalizeMeasurement,
@@ -212,6 +224,9 @@ export function useMouseControls(params: UseMouseControlsParams): void {
       snapEnabledRef,
       edgeLockStateRef,
       measurementConstraintEdgeRef,
+      sectionPickModeRef,
+      setSectionPlaneFromFace,
+      setSectionPickMode,
       hiddenEntitiesRef,
       isolatedEntitiesRef,
       geometryRef,

--- a/apps/viewer/src/components/viewer/useMouseControls.ts
+++ b/apps/viewer/src/components/viewer/useMouseControls.ts
@@ -126,7 +126,7 @@ export interface UseMouseControlsParams {
   /** Section face-pick: set the clip plane through a world-space face. */
   setSectionPlaneFromFace: (
     normal: [number, number, number],
-    point: [number, number, number],
+    position: number,
   ) => void;
   /** Section face-pick: arm/disarm the "next click picks a face" mode. */
   setSectionPickMode: (enabled: boolean) => void;

--- a/apps/viewer/src/components/viewer/useRenderUpdates.ts
+++ b/apps/viewer/src/components/viewer/useRenderUpdates.ts
@@ -86,7 +86,16 @@ export function useRenderUpdates(params: UseRenderUpdatesParams): void {
     const renderer = rendererRef.current;
     if (!renderer || !isInitialized) return;
 
-    if (activeTool === 'section' && drawing2D && drawing2D.cutPolygons.length > 0 && show3DOverlay) {
+    // Skip the 3D cap overlay for custom-normal planes. `uploadSection2DOverlay`
+    // takes a cardinal axis and projects the 2D polygons back to 3D using an
+    // axis-aligned mapping, so for a tilted plane the cap would land on the
+    // nearest cardinal cut — not on the actual shader clip — and appear at
+    // the wrong location and orientation. The gizmo quad still renders the
+    // plane position; the 2D cap stays empty until the drawing pipeline
+    // supports arbitrary normals.
+    const customPlane = sectionPlane.normal !== undefined;
+
+    if (activeTool === 'section' && drawing2D && drawing2D.cutPolygons.length > 0 && show3DOverlay && !customPlane) {
       const polygons: CutPolygon2D[] = drawing2D.cutPolygons.map((cp) => ({
         polygon: cp.polygon,
         ifcType: cp.ifcType,

--- a/apps/viewer/src/hooks/useDrawingGeneration.ts
+++ b/apps/viewer/src/hooks/useDrawingGeneration.ts
@@ -34,7 +34,15 @@ export const AXIS_MAP: Record<'down' | 'front' | 'side', 'x' | 'y' | 'z'> = {
 interface UseDrawingGenerationParams {
   geometryResult: GeometryResult | null | undefined;
   ifcDataStore: { source: Uint8Array } | null;
-  sectionPlane: { axis: 'down' | 'front' | 'side'; position: number; flipped: boolean };
+  sectionPlane: {
+    axis: 'down' | 'front' | 'side';
+    position: number;
+    flipped: boolean;
+    /** When set, the plane is an arbitrary world-space normal (face-pick). The
+     * drawing pipeline currently only understands cardinal-axis cuts; the
+     * generator short-circuits with an informative error in that case. */
+    normal?: [number, number, number];
+  };
   displayOptions: { showHiddenLines: boolean; useSymbolicRepresentations: boolean; show3DOverlay: boolean; scale: number };
   combinedHiddenIds: Set<number>;
   combinedIsolatedIds: Set<number> | null;
@@ -90,6 +98,17 @@ export function useDrawingGeneration({
       setDrawing(null);
       setDrawingStatus('idle');
       setDrawingError('No visible geometry');
+      return;
+    }
+
+    // Custom-normal planes (face-pick) bypass the 2D drawing pipeline until
+    // the generator supports arbitrary plane normals. Without this guard the
+    // generator would cut the model along the nearest cardinal axis and the
+    // resulting drawing would not match the actual shader clip.
+    if (sectionPlane.normal !== undefined) {
+      setDrawing(null);
+      setDrawingStatus('idle');
+      setDrawingError('2D drawing is not available for custom face-picked planes. Switch to Down/Front/Side to generate.');
       return;
     }
 
@@ -553,7 +572,12 @@ export function useDrawingGeneration({
   // Auto-regenerate when section plane changes
   // Strategy: INSTANT - no debounce, but prevent overlapping computations
   // The generation time itself acts as natural batching for fast slider movements
-  const sectionRef = useRef({ axis: sectionPlane.axis, position: sectionPlane.position, flipped: sectionPlane.flipped });
+  const sectionRef = useRef<{ axis: 'down' | 'front' | 'side'; position: number; flipped: boolean; normalKey: string }>({
+    axis: sectionPlane.axis,
+    position: sectionPlane.position,
+    flipped: sectionPlane.flipped,
+    normalKey: sectionPlane.normal ? sectionPlane.normal.join(',') : '',
+  });
   const isGeneratingRef = useRef(false);
   const latestSectionRef = useRef({ axis: sectionPlane.axis, position: sectionPlane.position, flipped: sectionPlane.flipped });
   const [isRegenerating, setIsRegenerating] = useState(false);
@@ -592,6 +616,12 @@ export function useDrawingGeneration({
     }
   }, [generateDrawing]);
 
+  // Stable key representing the presence/direction of a custom plane —
+  // stringified normal tuple or '' for preset. Lets the effect below notice
+  // transitions into/out of custom mode even if the nearest cardinal axis
+  // happens to match.
+  const normalKey = sectionPlane.normal ? sectionPlane.normal.join(',') : '';
+
   useEffect(() => {
     // Always update latest section ref (even if generating)
     latestSectionRef.current = { axis: sectionPlane.axis, position: sectionPlane.position, flipped: sectionPlane.flipped };
@@ -601,13 +631,19 @@ export function useDrawingGeneration({
     if (
       prev.axis === sectionPlane.axis &&
       prev.position === sectionPlane.position &&
-      prev.flipped === sectionPlane.flipped
+      prev.flipped === sectionPlane.flipped &&
+      prev.normalKey === normalKey
     ) {
       return;
     }
 
     // Update processed ref
-    sectionRef.current = { axis: sectionPlane.axis, position: sectionPlane.position, flipped: sectionPlane.flipped };
+    sectionRef.current = {
+      axis: sectionPlane.axis,
+      position: sectionPlane.position,
+      flipped: sectionPlane.flipped,
+      normalKey,
+    };
 
     // If panel is visible OR 3D overlay is enabled, and we have geometry, regenerate INSTANTLY
     if ((panelVisible || displayOptions.show3DOverlay) && geometryResult?.meshes) {
@@ -615,7 +651,7 @@ export function useDrawingGeneration({
       // doRegenerate handles preventing overlaps and will auto-regenerate with latest when done
       doRegenerate();
     }
-  }, [panelVisible, displayOptions.show3DOverlay, sectionPlane.axis, sectionPlane.position, sectionPlane.flipped, geometryResult, combinedHiddenIds, combinedIsolatedIds, computedIsolatedIds, doRegenerate]);
+  }, [panelVisible, displayOptions.show3DOverlay, sectionPlane.axis, sectionPlane.position, sectionPlane.flipped, normalKey, geometryResult, combinedHiddenIds, combinedIsolatedIds, computedIsolatedIds, doRegenerate]);
 
   return {
     generateDrawing,

--- a/apps/viewer/src/hooks/useDrawingGeneration.ts
+++ b/apps/viewer/src/hooks/useDrawingGeneration.ts
@@ -104,10 +104,12 @@ export function useDrawingGeneration({
     // Custom-normal planes (face-pick) bypass the 2D drawing pipeline until
     // the generator supports arbitrary plane normals. Without this guard the
     // generator would cut the model along the nearest cardinal axis and the
-    // resulting drawing would not match the actual shader clip.
+    // resulting drawing would not match the actual shader clip. Using
+    // status='error' (not 'idle') so the Section2DPanel surfaces the reason
+    // to the user instead of looking like "nothing happened".
     if (sectionPlane.normal !== undefined) {
       setDrawing(null);
-      setDrawingStatus('idle');
+      setDrawingStatus('error');
       setDrawingError('2D drawing is not available for custom face-picked planes. Switch to Down/Front/Side to generate.');
       return;
     }
@@ -579,7 +581,12 @@ export function useDrawingGeneration({
     normalKey: sectionPlane.normal ? sectionPlane.normal.join(',') : '',
   });
   const isGeneratingRef = useRef(false);
-  const latestSectionRef = useRef({ axis: sectionPlane.axis, position: sectionPlane.position, flipped: sectionPlane.flipped });
+  const latestSectionRef = useRef<{ axis: 'down' | 'front' | 'side'; position: number; flipped: boolean; normalKey: string }>({
+    axis: sectionPlane.axis,
+    position: sectionPlane.position,
+    flipped: sectionPlane.flipped,
+    normalKey: sectionPlane.normal ? sectionPlane.normal.join(',') : '',
+  });
   const [isRegenerating, setIsRegenerating] = useState(false);
 
   // Stable regenerate function that handles overlapping calls
@@ -602,12 +609,15 @@ export function useDrawingGeneration({
       isGeneratingRef.current = false;
       setIsRegenerating(false);
 
-      // Check if section changed while we were generating
+      // Check if section changed while we were generating — including
+      // transitions into/out of custom-normal mode (face-pick), which
+      // axis/position/flipped alone can't express.
       const current = latestSectionRef.current;
       if (
         current.axis !== targetSection.axis ||
         current.position !== targetSection.position ||
-        current.flipped !== targetSection.flipped
+        current.flipped !== targetSection.flipped ||
+        current.normalKey !== targetSection.normalKey
       ) {
         // Position changed during generation - regenerate immediately with latest
         // Use microtask to avoid blocking
@@ -623,8 +633,15 @@ export function useDrawingGeneration({
   const normalKey = sectionPlane.normal ? sectionPlane.normal.join(',') : '';
 
   useEffect(() => {
-    // Always update latest section ref (even if generating)
-    latestSectionRef.current = { axis: sectionPlane.axis, position: sectionPlane.position, flipped: sectionPlane.flipped };
+    // Always update latest section ref (even if generating) — include the
+    // normal so the in-flight completion check can notice custom-plane
+    // transitions.
+    latestSectionRef.current = {
+      axis: sectionPlane.axis,
+      position: sectionPlane.position,
+      flipped: sectionPlane.flipped,
+      normalKey,
+    };
 
     // Check if section plane actually changed from last processed
     const prev = sectionRef.current;

--- a/apps/viewer/src/hooks/useViewerSelectors.ts
+++ b/apps/viewer/src/hooks/useViewerSelectors.ts
@@ -50,10 +50,16 @@ export function useVisibilityState() {
 export function useToolState() {
   const activeTool = useViewerStore((state) => state.activeTool);
   const sectionPlane = useViewerStore((state) => state.sectionPlane);
+  const sectionPickMode = useViewerStore((state) => state.sectionPickMode);
+  const setSectionPlaneFromFace = useViewerStore((state) => state.setSectionPlaneFromFace);
+  const setSectionPickMode = useViewerStore((state) => state.setSectionPickMode);
 
   return {
     activeTool,
     sectionPlane,
+    sectionPickMode,
+    setSectionPlaneFromFace,
+    setSectionPickMode,
   };
 }
 

--- a/apps/viewer/src/store/slices/sectionSlice.test.ts
+++ b/apps/viewer/src/store/slices/sectionSlice.test.ts
@@ -181,68 +181,75 @@ describe('SectionSlice', () => {
   });
 
   describe('setSectionPlaneFromFace', () => {
-    it('should set a unit normal and derive distance from dot(point, normal)', () => {
-      state.setSectionPlaneFromFace([0, 1, 0], [10, 5, 20]);
+    it('should set a unit normal and adopt the caller-supplied position', () => {
+      state.setSectionPlaneFromFace([0, 1, 0], 37);
       assert.deepStrictEqual(state.sectionPlane.normal, [0, 1, 0]);
-      assert.strictEqual(state.sectionPlane.distance, 5);
+      assert.strictEqual(state.sectionPlane.position, 37);
       assert.strictEqual(state.sectionPlane.enabled, true);
     });
 
-    it('should normalise a non-unit normal and scale distance accordingly', () => {
-      // Normal [3, 0, 0] (length 3) plus point (3,0,0) means the plane goes
-      // through (3,0,0) with unit normal [1,0,0], so distance = 3.
-      state.setSectionPlaneFromFace([3, 0, 0], [3, 0, 0]);
+    it('should normalise a non-unit normal', () => {
+      // Normal [3, 0, 0] (length 3) should become [1, 0, 0].
+      state.setSectionPlaneFromFace([3, 0, 0], 50);
       const n = state.sectionPlane.normal!;
       assert.ok(Math.abs(n[0] - 1) < 1e-9);
       assert.ok(Math.abs(n[1]) < 1e-9);
       assert.ok(Math.abs(n[2]) < 1e-9);
-      assert.ok(Math.abs(state.sectionPlane.distance! - 3) < 1e-9);
+    });
+
+    it('should clamp position to [0, 100]', () => {
+      state.setSectionPlaneFromFace([0, 1, 0], 150);
+      assert.strictEqual(state.sectionPlane.position, 100);
+      state.setSectionPlaneFromFace([0, 1, 0], -10);
+      assert.strictEqual(state.sectionPlane.position, 0);
     });
 
     it('should pick the nearest cardinal axis for downstream readers', () => {
       // Mostly-Y with a touch of X should map to 'down' (Y axis preset).
-      state.setSectionPlaneFromFace([0.1, 0.99, 0.0], [0, 0, 0]);
+      state.setSectionPlaneFromFace([0.1, 0.99, 0.0], 50);
       assert.strictEqual(state.sectionPlane.axis, 'down');
 
-      state.setSectionPlaneFromFace([0.99, 0.1, 0.0], [0, 0, 0]);
+      state.setSectionPlaneFromFace([0.99, 0.1, 0.0], 50);
       assert.strictEqual(state.sectionPlane.axis, 'side');
 
-      state.setSectionPlaneFromFace([0.0, 0.1, 0.99], [0, 0, 0]);
+      state.setSectionPlaneFromFace([0.0, 0.1, 0.99], 50);
       assert.strictEqual(state.sectionPlane.axis, 'front');
     });
 
     it('should disarm pick mode after a successful pick', () => {
       state.setSectionPickMode(true);
-      state.setSectionPlaneFromFace([0, 1, 0], [0, 0, 0]);
+      state.setSectionPlaneFromFace([0, 1, 0], 50);
       assert.strictEqual(state.sectionPickMode, false);
     });
 
     it('should ignore a degenerate normal and not poison the plane state', () => {
       state.setSectionPlaneAxis('down'); // clears any prior custom plane
       state.setSectionPickMode(true);
-      state.setSectionPlaneFromFace([0, 0, 0], [1, 2, 3]);
+      state.setSectionPlaneFromFace([0, 0, 0], 50);
       // Plane unchanged...
       assert.strictEqual(state.sectionPlane.normal, undefined);
-      assert.strictEqual(state.sectionPlane.distance, undefined);
       // ...and pick mode still cleared so the UI doesn't stay armed.
       assert.strictEqual(state.sectionPickMode, false);
     });
   });
 
   describe('setSectionPlaneAxis clears custom plane', () => {
-    it('should drop normal/distance set by face-pick when a preset is chosen', () => {
-      state.setSectionPlaneFromFace([0, 0, 1], [0, 0, 7]);
+    it('should drop the custom normal when a preset is chosen', () => {
+      state.setSectionPlaneFromFace([0, 0, 1], 50);
       assert.ok(state.sectionPlane.normal !== undefined);
       state.setSectionPlaneAxis('down');
       assert.strictEqual(state.sectionPlane.normal, undefined);
-      assert.strictEqual(state.sectionPlane.distance, undefined);
     });
 
-    it('should drop normal/distance when the position slider moves', () => {
-      state.setSectionPlaneFromFace([0, 0, 1], [0, 0, 7]);
+    it('should keep the custom normal when the slider moves so slider offsets the plane', () => {
+      // After face-pick the slider drags the plane along its normal (does NOT
+      // revert to an axis cut). That was the whole point of issue #243:
+      // "slider only works for front/side/down" bug — the custom normal must
+      // survive slider interaction.
+      state.setSectionPlaneFromFace([0, 0, 1], 50);
       state.setSectionPlanePosition(42);
-      assert.strictEqual(state.sectionPlane.normal, undefined);
-      assert.strictEqual(state.sectionPlane.distance, undefined);
+      assert.deepStrictEqual(state.sectionPlane.normal, [0, 0, 1]);
+      assert.strictEqual(state.sectionPlane.position, 42);
     });
   });
 

--- a/apps/viewer/src/store/slices/sectionSlice.test.ts
+++ b/apps/viewer/src/store/slices/sectionSlice.test.ts
@@ -180,6 +180,82 @@ describe('SectionSlice', () => {
     });
   });
 
+  describe('setSectionPlaneFromFace', () => {
+    it('should set a unit normal and derive distance from dot(point, normal)', () => {
+      state.setSectionPlaneFromFace([0, 1, 0], [10, 5, 20]);
+      assert.deepStrictEqual(state.sectionPlane.normal, [0, 1, 0]);
+      assert.strictEqual(state.sectionPlane.distance, 5);
+      assert.strictEqual(state.sectionPlane.enabled, true);
+    });
+
+    it('should normalise a non-unit normal and scale distance accordingly', () => {
+      // Normal [3, 0, 0] (length 3) plus point (3,0,0) means the plane goes
+      // through (3,0,0) with unit normal [1,0,0], so distance = 3.
+      state.setSectionPlaneFromFace([3, 0, 0], [3, 0, 0]);
+      const n = state.sectionPlane.normal!;
+      assert.ok(Math.abs(n[0] - 1) < 1e-9);
+      assert.ok(Math.abs(n[1]) < 1e-9);
+      assert.ok(Math.abs(n[2]) < 1e-9);
+      assert.ok(Math.abs(state.sectionPlane.distance! - 3) < 1e-9);
+    });
+
+    it('should pick the nearest cardinal axis for downstream readers', () => {
+      // Mostly-Y with a touch of X should map to 'down' (Y axis preset).
+      state.setSectionPlaneFromFace([0.1, 0.99, 0.0], [0, 0, 0]);
+      assert.strictEqual(state.sectionPlane.axis, 'down');
+
+      state.setSectionPlaneFromFace([0.99, 0.1, 0.0], [0, 0, 0]);
+      assert.strictEqual(state.sectionPlane.axis, 'side');
+
+      state.setSectionPlaneFromFace([0.0, 0.1, 0.99], [0, 0, 0]);
+      assert.strictEqual(state.sectionPlane.axis, 'front');
+    });
+
+    it('should disarm pick mode after a successful pick', () => {
+      state.setSectionPickMode(true);
+      state.setSectionPlaneFromFace([0, 1, 0], [0, 0, 0]);
+      assert.strictEqual(state.sectionPickMode, false);
+    });
+
+    it('should ignore a degenerate normal and not poison the plane state', () => {
+      state.setSectionPlaneAxis('down'); // clears any prior custom plane
+      state.setSectionPickMode(true);
+      state.setSectionPlaneFromFace([0, 0, 0], [1, 2, 3]);
+      // Plane unchanged...
+      assert.strictEqual(state.sectionPlane.normal, undefined);
+      assert.strictEqual(state.sectionPlane.distance, undefined);
+      // ...and pick mode still cleared so the UI doesn't stay armed.
+      assert.strictEqual(state.sectionPickMode, false);
+    });
+  });
+
+  describe('setSectionPlaneAxis clears custom plane', () => {
+    it('should drop normal/distance set by face-pick when a preset is chosen', () => {
+      state.setSectionPlaneFromFace([0, 0, 1], [0, 0, 7]);
+      assert.ok(state.sectionPlane.normal !== undefined);
+      state.setSectionPlaneAxis('down');
+      assert.strictEqual(state.sectionPlane.normal, undefined);
+      assert.strictEqual(state.sectionPlane.distance, undefined);
+    });
+
+    it('should drop normal/distance when the position slider moves', () => {
+      state.setSectionPlaneFromFace([0, 0, 1], [0, 0, 7]);
+      state.setSectionPlanePosition(42);
+      assert.strictEqual(state.sectionPlane.normal, undefined);
+      assert.strictEqual(state.sectionPlane.distance, undefined);
+    });
+  });
+
+  describe('setSectionPickMode', () => {
+    it('should arm and disarm face-pick mode', () => {
+      assert.strictEqual(state.sectionPickMode, false);
+      state.setSectionPickMode(true);
+      assert.strictEqual(state.sectionPickMode, true);
+      state.setSectionPickMode(false);
+      assert.strictEqual(state.sectionPickMode, false);
+    });
+  });
+
   describe('resetSectionPlane', () => {
     it('should reset to default values', () => {
       state.setSectionPlaneAxis('side');

--- a/apps/viewer/src/store/slices/sectionSlice.test.ts
+++ b/apps/viewer/src/store/slices/sectionSlice.test.ts
@@ -216,6 +216,26 @@ describe('SectionSlice', () => {
       assert.strictEqual(state.sectionPlane.axis, 'front');
     });
 
+    it('should set flipped when the picked normal points along the negative side of the dominant axis', () => {
+      // Picking the underside of a slab: outward normal points -Y. The
+      // cardinal fallback collapses to 'down' (+Y), so `flipped` must be
+      // true so axis+flipped describes the same cut direction as the
+      // actual custom plane.
+      state.setSectionPlaneFromFace([0, -1, 0], 50);
+      assert.strictEqual(state.sectionPlane.axis, 'down');
+      assert.strictEqual(state.sectionPlane.flipped, true);
+
+      // And +Y should leave flipped clear.
+      state.setSectionPlaneFromFace([0, 1, 0], 50);
+      assert.strictEqual(state.sectionPlane.axis, 'down');
+      assert.strictEqual(state.sectionPlane.flipped, false);
+
+      // West-facing wall (outward normal -X) should map to side+flipped.
+      state.setSectionPlaneFromFace([-0.99, 0.05, 0.0], 50);
+      assert.strictEqual(state.sectionPlane.axis, 'side');
+      assert.strictEqual(state.sectionPlane.flipped, true);
+    });
+
     it('should disarm pick mode after a successful pick', () => {
       state.setSectionPickMode(true);
       state.setSectionPlaneFromFace([0, 1, 0], 50);

--- a/apps/viewer/src/store/slices/sectionSlice.ts
+++ b/apps/viewer/src/store/slices/sectionSlice.ts
@@ -108,6 +108,12 @@ const saveShowOutlines = (v: boolean) => saveBoolean(OUTLINES_SHOW_STORAGE_KEY, 
 export interface SectionSlice {
   // State
   sectionPlane: SectionPlane;
+  /**
+   * When true, the next click on the canvas picks a face and sets the
+   * section plane through it (world-space normal + point). Cleared after
+   * one pick or when the tool changes.
+   */
+  sectionPickMode: boolean;
 
   // Actions
   setSectionPlaneAxis: (axis: SectionPlaneAxis) => void;
@@ -119,6 +125,17 @@ export interface SectionSlice {
   setSectionShowOutlines: (show: boolean) => void;
   setSectionCapStyle: (style: Partial<SectionCapStyle>) => void;
   resetSectionPlane: () => void;
+  /**
+   * Set the section plane from a face pick. `normal` is the face's
+   * world-space unit normal; `point` is any point on the face (typically
+   * the raycast intersection). The derived plane equation is
+   * `dot(worldPos, normal) = dot(point, normal)`.
+   */
+  setSectionPlaneFromFace: (
+    normal: [number, number, number],
+    point: [number, number, number],
+  ) => void;
+  setSectionPickMode: (enabled: boolean) => void;
 }
 
 const getDefaultCapStyle = (): SectionCapStyle => loadCapStyle();
@@ -137,15 +154,42 @@ const getDefaultSectionPlane = (): SectionPlane => ({
   capStyle:     getDefaultCapStyle(),
 });
 
+/**
+ * Map an arbitrary world-space unit normal to the closest cardinal axis
+ * ('down' = Y, 'front' = Z, 'side' = X). Used so downstream code that still
+ * reads `sectionPlane.axis` (drawings export, BCF snapshots) continues to
+ * work with face-picked planes — it gets the nearest axis approximation
+ * rather than a runtime crash.
+ */
+function nearestCardinalAxis(
+  normal: [number, number, number],
+): SectionPlaneAxis {
+  const ax = Math.abs(normal[0]);
+  const ay = Math.abs(normal[1]);
+  const az = Math.abs(normal[2]);
+  if (ay >= ax && ay >= az) return 'down';
+  if (ax >= az) return 'side';
+  return 'front';
+}
+
 export const createSectionSlice: StateCreator<SectionSlice, [], [], SectionSlice> = (set) => ({
   // Initial state
   sectionPlane: getDefaultSectionPlane(),
+  sectionPickMode: false,
 
   // Actions
   setSectionPlaneAxis: (axis) => set((state) => ({
     // Changing the axis implicitly means "I want to cut now" — enable the clip
     // so users don't get stuck in a confusing no-op preview.
-    sectionPlane: { ...state.sectionPlane, axis, enabled: true },
+    // Also drop any custom normal/distance left over from face-pick so the
+    // preset takes over cleanly.
+    sectionPlane: {
+      ...state.sectionPlane,
+      axis,
+      enabled: true,
+      normal: undefined,
+      distance: undefined,
+    },
   })),
 
   setSectionPlanePosition: (position) => set((state) => {
@@ -154,8 +198,15 @@ export const createSectionSlice: StateCreator<SectionSlice, [], [], SectionSlice
     return {
       // Moving the slider also enables the cut — previously you had to press
       // "Cutting" separately, which led to the "it just jitters, doesn't cut"
-      // feedback from users.
-      sectionPlane: { ...state.sectionPlane, position: clampedPosition, enabled: true },
+      // feedback from users. Also drop any custom normal/distance so the
+      // slider returns to controlling the axis-aligned preset.
+      sectionPlane: {
+        ...state.sectionPlane,
+        position: clampedPosition,
+        enabled: true,
+        normal: undefined,
+        distance: undefined,
+      },
     };
   }),
 
@@ -199,6 +250,31 @@ export const createSectionSlice: StateCreator<SectionSlice, [], [], SectionSlice
     } catch (error) {
       console.warn('[section] failed to clear persisted cap preferences', error);
     }
-    return { sectionPlane: getDefaultSectionPlane() };
+    return { sectionPlane: getDefaultSectionPlane(), sectionPickMode: false };
   }),
+
+  setSectionPlaneFromFace: (normal, point) => set((state) => {
+    const nx = normal[0];
+    const ny = normal[1];
+    const nz = normal[2];
+    const len = Math.sqrt(nx * nx + ny * ny + nz * nz);
+    // Degenerate normal: no-op rather than poisoning the renderer with NaNs.
+    if (!Number.isFinite(len) || len < 1e-6) {
+      return { sectionPickMode: false };
+    }
+    const unit: [number, number, number] = [nx / len, ny / len, nz / len];
+    const distance = point[0] * unit[0] + point[1] * unit[1] + point[2] * unit[2];
+    return {
+      sectionPlane: {
+        ...state.sectionPlane,
+        axis: nearestCardinalAxis(unit),
+        normal: unit,
+        distance,
+        enabled: true,
+      },
+      sectionPickMode: false,
+    };
+  }),
+
+  setSectionPickMode: (enabled) => set(() => ({ sectionPickMode: enabled })),
 });

--- a/apps/viewer/src/store/slices/sectionSlice.ts
+++ b/apps/viewer/src/store/slices/sectionSlice.ts
@@ -127,13 +127,15 @@ export interface SectionSlice {
   resetSectionPlane: () => void;
   /**
    * Set the section plane from a face pick. `normal` is the face's
-   * world-space unit normal; `point` is any point on the face (typically
-   * the raycast intersection). The derived plane equation is
-   * `dot(worldPos, normal) = dot(point, normal)`.
+   * world-space unit normal; `position` is the pre-computed 0-100%
+   * position along the model bounds projected onto `normal` (the caller
+   * is responsible for the projection because the store doesn't know the
+   * current bounds). After the pick the slider offsets the plane along
+   * `normal`.
    */
   setSectionPlaneFromFace: (
     normal: [number, number, number],
-    point: [number, number, number],
+    position: number,
   ) => void;
   setSectionPickMode: (enabled: boolean) => void;
 }
@@ -181,14 +183,13 @@ export const createSectionSlice: StateCreator<SectionSlice, [], [], SectionSlice
   setSectionPlaneAxis: (axis) => set((state) => ({
     // Changing the axis implicitly means "I want to cut now" — enable the clip
     // so users don't get stuck in a confusing no-op preview.
-    // Also drop any custom normal/distance left over from face-pick so the
+    // Also drop any custom normal left over from face-pick so the
     // preset takes over cleanly.
     sectionPlane: {
       ...state.sectionPlane,
       axis,
       enabled: true,
       normal: undefined,
-      distance: undefined,
     },
   })),
 
@@ -198,14 +199,14 @@ export const createSectionSlice: StateCreator<SectionSlice, [], [], SectionSlice
     return {
       // Moving the slider also enables the cut — previously you had to press
       // "Cutting" separately, which led to the "it just jitters, doesn't cut"
-      // feedback from users. Also drop any custom normal/distance so the
-      // slider returns to controlling the axis-aligned preset.
+      // feedback from users. `normal` is preserved: when a custom plane is
+      // active the slider offsets it along its normal (the bounds-projection
+      // range is computed by the renderer), so the slider is the single
+      // source of truth for position regardless of axis-vs-custom.
       sectionPlane: {
         ...state.sectionPlane,
         position: clampedPosition,
         enabled: true,
-        normal: undefined,
-        distance: undefined,
       },
     };
   }),
@@ -253,7 +254,7 @@ export const createSectionSlice: StateCreator<SectionSlice, [], [], SectionSlice
     return { sectionPlane: getDefaultSectionPlane(), sectionPickMode: false };
   }),
 
-  setSectionPlaneFromFace: (normal, point) => set((state) => {
+  setSectionPlaneFromFace: (normal, position) => set((state) => {
     const nx = normal[0];
     const ny = normal[1];
     const nz = normal[2];
@@ -263,13 +264,13 @@ export const createSectionSlice: StateCreator<SectionSlice, [], [], SectionSlice
       return { sectionPickMode: false };
     }
     const unit: [number, number, number] = [nx / len, ny / len, nz / len];
-    const distance = point[0] * unit[0] + point[1] * unit[1] + point[2] * unit[2];
+    const clampedPosition = Math.min(100, Math.max(0, Number(position) || 0));
     return {
       sectionPlane: {
         ...state.sectionPlane,
         axis: nearestCardinalAxis(unit),
         normal: unit,
-        distance,
+        position: clampedPosition,
         enabled: true,
       },
       sectionPickMode: false,

--- a/apps/viewer/src/store/slices/sectionSlice.ts
+++ b/apps/viewer/src/store/slices/sectionSlice.ts
@@ -158,20 +158,23 @@ const getDefaultSectionPlane = (): SectionPlane => ({
 
 /**
  * Map an arbitrary world-space unit normal to the closest cardinal axis
- * ('down' = Y, 'front' = Z, 'side' = X). Used so downstream code that still
- * reads `sectionPlane.axis` (drawings export, BCF snapshots) continues to
- * work with face-picked planes — it gets the nearest axis approximation
- * rather than a runtime crash.
+ * ('down' = +Y, 'front' = +Z, 'side' = +X) **and** indicate whether the
+ * picked normal points along the negative side of that cardinal. Used so
+ * downstream code that still reads `sectionPlane.axis + flipped` (drawings
+ * export, BCF snapshots, view controls) continues to describe the same cut
+ * direction as the active custom plane — without this, picking a face whose
+ * outward normal points -X (e.g. the west exterior wall) would degrade to
+ * `axis: 'side'` (+X) without `flipped`, inverting the snapshot.
  */
-function nearestCardinalAxis(
+function nearestCardinalAxisWithSign(
   normal: [number, number, number],
-): SectionPlaneAxis {
+): { axis: SectionPlaneAxis; flipped: boolean } {
   const ax = Math.abs(normal[0]);
   const ay = Math.abs(normal[1]);
   const az = Math.abs(normal[2]);
-  if (ay >= ax && ay >= az) return 'down';
-  if (ax >= az) return 'side';
-  return 'front';
+  if (ay >= ax && ay >= az) return { axis: 'down',  flipped: normal[1] < 0 };
+  if (ax >= az)             return { axis: 'side',  flipped: normal[0] < 0 };
+  return                          { axis: 'front', flipped: normal[2] < 0 };
 }
 
 export const createSectionSlice: StateCreator<SectionSlice, [], [], SectionSlice> = (set) => ({
@@ -265,10 +268,15 @@ export const createSectionSlice: StateCreator<SectionSlice, [], [], SectionSlice
     }
     const unit: [number, number, number] = [nx / len, ny / len, nz / len];
     const clampedPosition = Math.min(100, Math.max(0, Number(position) || 0));
+    const cardinal = nearestCardinalAxisWithSign(unit);
     return {
       sectionPlane: {
         ...state.sectionPlane,
-        axis: nearestCardinalAxis(unit),
+        axis: cardinal.axis,
+        // Preserve the picked half-space for any downstream consumer that
+        // still reads axis + flipped instead of `normal`. Custom-normal
+        // renderer path is unaffected — the shader uses `normal` directly.
+        flipped: cardinal.flipped,
         normal: unit,
         position: clampedPosition,
         enabled: true,

--- a/apps/viewer/src/store/types.ts
+++ b/apps/viewer/src/store/types.ts
@@ -94,20 +94,21 @@ import type { SectionCapStyle } from '@ifc-lite/renderer';
 
 export interface SectionPlane {
   axis: SectionPlaneAxis;
-  /** 0-100 percentage of model bounds */
+  /** 0-100 percentage of the active range. For axis presets this is the range
+   * along the cardinal axis; for custom planes (face-pick) it is the range of
+   * the model bounds projected onto the plane normal, so the slider continues
+   * to translate the plane naturally. */
   position: number;
   enabled: boolean;
   /** If true, show the opposite side of the cut */
   flipped: boolean;
   /**
-   * Optional world-space plane normal. When set (together with `distance`) the
-   * renderer uses it verbatim and ignores `axis` + `position`. Used by
-   * face-pick to support arbitrary planes while keeping `axis` populated with
-   * the nearest cardinal so downstream readers (drawings, BCF) still work.
+   * Optional world-space plane normal. When set, the renderer uses it and the
+   * `position` slider maps to the bounds-projection range along this normal,
+   * ignoring `axis`. `axis` is still populated with the nearest cardinal so
+   * downstream readers (drawings, BCF) keep working.
    */
   normal?: [number, number, number];
-  /** Signed plane offset in world units: `dot(pointOnPlane, normal)`. */
-  distance?: number;
   /** Whether to render the filled, hatched cap surface at the plane. Defaults to true. */
   showCap: boolean;
   /**

--- a/apps/viewer/src/store/types.ts
+++ b/apps/viewer/src/store/types.ts
@@ -99,6 +99,15 @@ export interface SectionPlane {
   enabled: boolean;
   /** If true, show the opposite side of the cut */
   flipped: boolean;
+  /**
+   * Optional world-space plane normal. When set (together with `distance`) the
+   * renderer uses it verbatim and ignores `axis` + `position`. Used by
+   * face-pick to support arbitrary planes while keeping `axis` populated with
+   * the nearest cardinal so downstream readers (drawings, BCF) still work.
+   */
+  normal?: [number, number, number];
+  /** Signed plane offset in world units: `dot(pointOnPlane, normal)`. */
+  distance?: number;
   /** Whether to render the filled, hatched cap surface at the plane. Defaults to true. */
   showCap: boolean;
   /**

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -864,16 +864,14 @@ export class Renderer {
                 }
 
                 if (options.sectionPlane.enabled) {
-                    // Explicit normal + distance override (face-pick / arbitrary
-                    // plane). Used verbatim: no axis mapping, no position slider,
-                    // no building rotation — the caller already has the plane in
-                    // world space.
+                    // Custom-plane path (face-pick): caller supplies a
+                    // world-space normal; `position` (0-100%) maps onto the
+                    // range of the model bounds projected onto that normal,
+                    // so the slider translates the plane along its own normal
+                    // continuously. No axis mapping, no building rotation —
+                    // the caller already chose the plane in world space.
                     const explicitNormal = options.sectionPlane.normal;
-                    const explicitDistance = options.sectionPlane.distance;
-                    const hasExplicitPlane =
-                        explicitNormal !== undefined &&
-                        explicitDistance !== undefined &&
-                        Number.isFinite(explicitDistance);
+                    const hasExplicitPlane = explicitNormal !== undefined;
 
                     let normal: [number, number, number];
                     let distance: number;
@@ -886,11 +884,27 @@ export class Renderer {
                         const len = Math.sqrt(nx * nx + ny * ny + nz * nz);
                         if (len > 1e-6) {
                             normal = [nx / len, ny / len, nz / len];
-                            distance = explicitDistance! / len;
                         } else {
                             normal = [0, 1, 0];
-                            distance = explicitDistance!;
                         }
+                        // Project the 8 AABB corners onto the (unit) normal
+                        // to get the valid distance range, then interpolate
+                        // via `position`.
+                        let minP = Infinity;
+                        let maxP = -Infinity;
+                        for (const cx of [boundsMin.x, boundsMax.x]) {
+                            for (const cy of [boundsMin.y, boundsMax.y]) {
+                                for (const cz of [boundsMin.z, boundsMax.z]) {
+                                    const pr = cx * normal[0] + cy * normal[1] + cz * normal[2];
+                                    if (pr < minP) minP = pr;
+                                    if (pr > maxP) maxP = pr;
+                                }
+                            }
+                        }
+                        const range = maxP - minP;
+                        distance = range > 1e-6
+                            ? minP + (options.sectionPlane.position / 100) * range
+                            : minP;
                     } else {
                         // Axis-aligned preset path (unchanged behaviour).
                         // down = Y axis (horizontal cut), front = Z axis, side = X axis.
@@ -1518,7 +1532,6 @@ export class Renderer {
                         min: options.sectionPlane.min,
                         max: options.sectionPlane.max,
                         normal: options.sectionPlane.normal,
-                        distance: options.sectionPlane.distance,
                     }
                 );
 

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -864,66 +864,95 @@ export class Renderer {
                 }
 
                 if (options.sectionPlane.enabled) {
-                    // Calculate plane normal based on semantic axis
-                    // down = Y axis (horizontal cut), front = Z axis, side = X axis
-                    let normal: [number, number, number] = [0, 0, 0];
-                    if (options.sectionPlane.axis === 'side') normal[0] = 1;        // X axis
-                    else if (options.sectionPlane.axis === 'down') normal[1] = 1;   // Y axis (horizontal)
-                    else normal[2] = 1;                                              // Z axis (front)
+                    // Explicit normal + distance override (face-pick / arbitrary
+                    // plane). Used verbatim: no axis mapping, no position slider,
+                    // no building rotation — the caller already has the plane in
+                    // world space.
+                    const explicitNormal = options.sectionPlane.normal;
+                    const explicitDistance = options.sectionPlane.distance;
+                    const hasExplicitPlane =
+                        explicitNormal !== undefined &&
+                        explicitDistance !== undefined &&
+                        Number.isFinite(explicitDistance);
 
-                    // Apply building rotation if present (rotate normal around Y axis)
-                    // Building rotation is in X-Y plane (Z is up in IFC, Y is up in WebGL)
-                    if (options.buildingRotation !== undefined && options.buildingRotation !== 0) {
-                        const cosR = Math.cos(options.buildingRotation);
-                        const sinR = Math.sin(options.buildingRotation);
-                        // Rotate normal vector around Y axis (vertical)
-                        // For X-Z plane rotation: x' = x*cos - z*sin, z' = x*sin + z*cos, y' = y
-                        const x = normal[0];
-                        const z = normal[2];
-                        normal[0] = x * cosR - z * sinR;
-                        normal[2] = x * sinR + z * cosR;
-                        // Normalize to maintain unit length
-                        const len = Math.sqrt(normal[0] * normal[0] + normal[1] * normal[1] + normal[2] * normal[2]);
-                        if (len > 0.0001) {
-                            normal[0] /= len;
-                            normal[1] /= len;
-                            normal[2] /= len;
+                    let normal: [number, number, number];
+                    let distance: number;
+
+                    if (hasExplicitPlane) {
+                        // Normalise defensively in case caller passes a non-unit vector.
+                        const nx = explicitNormal![0];
+                        const ny = explicitNormal![1];
+                        const nz = explicitNormal![2];
+                        const len = Math.sqrt(nx * nx + ny * ny + nz * nz);
+                        if (len > 1e-6) {
+                            normal = [nx / len, ny / len, nz / len];
+                            distance = explicitDistance! / len;
+                        } else {
+                            normal = [0, 1, 0];
+                            distance = explicitDistance!;
                         }
-                    }
+                    } else {
+                        // Axis-aligned preset path (unchanged behaviour).
+                        // down = Y axis (horizontal cut), front = Z axis, side = X axis.
+                        normal = [0, 0, 0];
+                        if (options.sectionPlane.axis === 'side') normal[0] = 1;        // X axis
+                        else if (options.sectionPlane.axis === 'down') normal[1] = 1;   // Y axis (horizontal)
+                        else normal[2] = 1;                                              // Z axis (front)
 
-                    // Get axis-specific range. The renderer's own `boundsMin/Max`
-                    // are computed from the GPU vertex buffers this frame, so
-                    // they are guaranteed to be in the same Y-up world space as
-                    // `input.worldPos` in the shader. `options.sectionPlane.min/max`
-                    // comes from the UI via `coordinateInfo.shiftedBounds` and can
-                    // be stale during streaming or outright wrong during model
-                    // load (initialised to {0,0,0} before the first bounds update)
-                    // — using those directly was the cause of the "slider moves
-                    // 1% and the whole model disappears" bug.
-                    //
-                    // Policy: always use the renderer's own bounds for the Y-up
-                    // range. Only honour the UI override when it is a valid,
-                    // non-degenerate range that lies INSIDE the actual mesh
-                    // bounds (e.g. storey filtering from the level picker).
-                    const axisIdx = options.sectionPlane.axis === 'side' ? 'x' : options.sectionPlane.axis === 'down' ? 'y' : 'z';
-                    let minVal = boundsMin[axisIdx];
-                    let maxVal = boundsMax[axisIdx];
-                    const uiMin = options.sectionPlane.min;
-                    const uiMax = options.sectionPlane.max;
-                    if (
-                        Number.isFinite(uiMin) &&
-                        Number.isFinite(uiMax) &&
-                        (uiMax as number) - (uiMin as number) > 1e-6 &&
-                        (uiMin as number) >= minVal - 1e-3 &&
-                        (uiMax as number) <= maxVal + 1e-3
-                    ) {
-                        minVal = uiMin as number;
-                        maxVal = uiMax as number;
-                    }
+                        // Apply building rotation if present (rotate normal around Y axis)
+                        // Building rotation is in X-Y plane (Z is up in IFC, Y is up in WebGL)
+                        if (options.buildingRotation !== undefined && options.buildingRotation !== 0) {
+                            const cosR = Math.cos(options.buildingRotation);
+                            const sinR = Math.sin(options.buildingRotation);
+                            // Rotate normal vector around Y axis (vertical)
+                            // For X-Z plane rotation: x' = x*cos - z*sin, z' = x*sin + z*cos, y' = y
+                            const x = normal[0];
+                            const z = normal[2];
+                            normal[0] = x * cosR - z * sinR;
+                            normal[2] = x * sinR + z * cosR;
+                            // Normalize to maintain unit length
+                            const rlen = Math.sqrt(normal[0] * normal[0] + normal[1] * normal[1] + normal[2] * normal[2]);
+                            if (rlen > 0.0001) {
+                                normal[0] /= rlen;
+                                normal[1] /= rlen;
+                                normal[2] /= rlen;
+                            }
+                        }
 
-                    // Calculate plane distance from position percentage
-                    const range = maxVal - minVal;
-                    const distance = minVal + (options.sectionPlane.position / 100) * range;
+                        // Get axis-specific range. The renderer's own `boundsMin/Max`
+                        // are computed from the GPU vertex buffers this frame, so
+                        // they are guaranteed to be in the same Y-up world space as
+                        // `input.worldPos` in the shader. `options.sectionPlane.min/max`
+                        // comes from the UI via `coordinateInfo.shiftedBounds` and can
+                        // be stale during streaming or outright wrong during model
+                        // load (initialised to {0,0,0} before the first bounds update)
+                        // — using those directly was the cause of the "slider moves
+                        // 1% and the whole model disappears" bug.
+                        //
+                        // Policy: always use the renderer's own bounds for the Y-up
+                        // range. Only honour the UI override when it is a valid,
+                        // non-degenerate range that lies INSIDE the actual mesh
+                        // bounds (e.g. storey filtering from the level picker).
+                        const axisIdx = options.sectionPlane.axis === 'side' ? 'x' : options.sectionPlane.axis === 'down' ? 'y' : 'z';
+                        let minVal = boundsMin[axisIdx];
+                        let maxVal = boundsMax[axisIdx];
+                        const uiMin = options.sectionPlane.min;
+                        const uiMax = options.sectionPlane.max;
+                        if (
+                            Number.isFinite(uiMin) &&
+                            Number.isFinite(uiMax) &&
+                            (uiMax as number) - (uiMin as number) > 1e-6 &&
+                            (uiMin as number) >= minVal - 1e-3 &&
+                            (uiMax as number) <= maxVal + 1e-3
+                        ) {
+                            minVal = uiMin as number;
+                            maxVal = uiMax as number;
+                        }
+
+                        // Calculate plane distance from position percentage
+                        const range = maxVal - minVal;
+                        distance = minVal + (options.sectionPlane.position / 100) * range;
+                    }
 
                     sectionPlaneData = { normal, distance, enabled: true };
 
@@ -934,14 +963,13 @@ export class Renderer {
                     if (!this._loggedSectionBounds) {
                         this._loggedSectionBounds = true;
                         console.info('[Section] Y-up bounds used for clip:', {
+                            mode: hasExplicitPlane ? 'explicit' : 'axis-aligned',
                             axis: options.sectionPlane.axis,
-                            axisIdx,
                             bounds: {
                                 min: { x: boundsMin.x, y: boundsMin.y, z: boundsMin.z },
                                 max: { x: boundsMax.x, y: boundsMax.y, z: boundsMax.z },
                             },
-                            uiOverride: { min: uiMin, max: uiMax },
-                            used: { min: minVal, max: maxVal },
+                            normal,
                             position: options.sectionPlane.position,
                             distance,
                             batchedMeshCount: this.scene.getBatchedMeshes().length,
@@ -1489,6 +1517,8 @@ export class Renderer {
                         isPreview: !options.sectionPlane.enabled, // Preview mode when not enabled
                         min: options.sectionPlane.min,
                         max: options.sectionPlane.max,
+                        normal: options.sectionPlane.normal,
+                        distance: options.sectionPlane.distance,
                     }
                 );
 

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -14,6 +14,12 @@ export { Scene } from './scene.js';
 export { Picker } from './picker.js';
 export { MathUtils } from './math.js';
 export { SectionPlaneRenderer } from './section-plane.js';
+export {
+  projectBoundsOntoNormal,
+  planeDistanceForPosition,
+  positionFromPoint,
+  type SectionBounds,
+} from './section-math.js';
 export { Section2DOverlayRenderer } from './section-2d-overlay.js';
 // Section cap styling (hatch pattern ids + default colours). The cap itself
 // is now rendered by Section2DOverlayRenderer's fill pass; this module just
@@ -67,6 +73,7 @@ import type {
 } from './types.js';
 import { SectionPlaneRenderer } from './section-plane.js';
 import { Section2DOverlayRenderer, type CutPolygon2D, type DrawingLine2D } from './section-2d-overlay.js';
+import { planeDistanceForPosition } from './section-math.js';
 import { DEFAULT_CAP_STYLE, HATCH_PATTERN_IDS } from './section-cap-style.js';
 import type { InstancedGeometry } from '@ifc-lite/wasm';
 import { Raycaster, type Intersection } from './raycaster.js';
@@ -887,24 +894,15 @@ export class Renderer {
                         } else {
                             normal = [0, 1, 0];
                         }
-                        // Project the 8 AABB corners onto the (unit) normal
-                        // to get the valid distance range, then interpolate
-                        // via `position`.
-                        let minP = Infinity;
-                        let maxP = -Infinity;
-                        for (const cx of [boundsMin.x, boundsMax.x]) {
-                            for (const cy of [boundsMin.y, boundsMax.y]) {
-                                for (const cz of [boundsMin.z, boundsMax.z]) {
-                                    const pr = cx * normal[0] + cy * normal[1] + cz * normal[2];
-                                    if (pr < minP) minP = pr;
-                                    if (pr > maxP) maxP = pr;
-                                }
-                            }
-                        }
-                        const range = maxP - minP;
-                        distance = range > 1e-6
-                            ? minP + (options.sectionPlane.position / 100) * range
-                            : minP;
+                        // Project the model AABB onto the unit normal and
+                        // interpolate via `position` — shared helper so the
+                        // gizmo quad, the shader clip, and the face-pick
+                        // handler all agree on the mapping.
+                        distance = planeDistanceForPosition(
+                            { min: boundsMin, max: boundsMax },
+                            normal,
+                            options.sectionPlane.position,
+                        );
                     } else {
                         // Axis-aligned preset path (unchanged behaviour).
                         // down = Y axis (horizontal cut), front = Z axis, side = X axis.

--- a/packages/renderer/src/section-math.test.ts
+++ b/packages/renderer/src/section-math.test.ts
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  projectBoundsOntoNormal,
+  planeDistanceForPosition,
+  positionFromPoint,
+} from './section-math.js';
+
+const UNIT_CUBE = {
+  min: { x: 0, y: 0, z: 0 },
+  max: { x: 10, y: 20, z: 30 },
+};
+
+describe('section-math', () => {
+  describe('projectBoundsOntoNormal', () => {
+    it('collapses to the cardinal axis range for cardinal normals', () => {
+      assert.deepStrictEqual(projectBoundsOntoNormal(UNIT_CUBE, [1, 0, 0]), { min: 0, max: 10, range: 10 });
+      assert.deepStrictEqual(projectBoundsOntoNormal(UNIT_CUBE, [0, 1, 0]), { min: 0, max: 20, range: 20 });
+      assert.deepStrictEqual(projectBoundsOntoNormal(UNIT_CUBE, [0, 0, 1]), { min: 0, max: 30, range: 30 });
+    });
+
+    it('returns a larger range for a tilted normal (diagonal of the box)', () => {
+      // Diagonal [1,1,1]/sqrt(3) projects the cube diagonal (10+20+30)/sqrt(3) ≈ 34.64.
+      const n: [number, number, number] = [1 / Math.sqrt(3), 1 / Math.sqrt(3), 1 / Math.sqrt(3)];
+      const { range } = projectBoundsOntoNormal(UNIT_CUBE, n);
+      assert.ok(Math.abs(range - 60 / Math.sqrt(3)) < 1e-9, `expected ${60 / Math.sqrt(3)}, got ${range}`);
+    });
+
+    it('handles negative normals (min/max swap signs)', () => {
+      const { min, max, range } = projectBoundsOntoNormal(UNIT_CUBE, [-1, 0, 0]);
+      assert.strictEqual(min, -10);
+      assert.strictEqual(max, 0);
+      assert.strictEqual(range, 10);
+    });
+  });
+
+  describe('planeDistanceForPosition', () => {
+    it('maps 0 → min and 100 → max along the cardinal axis', () => {
+      assert.strictEqual(planeDistanceForPosition(UNIT_CUBE, [0, 1, 0], 0), 0);
+      assert.strictEqual(planeDistanceForPosition(UNIT_CUBE, [0, 1, 0], 100), 20);
+      assert.strictEqual(planeDistanceForPosition(UNIT_CUBE, [0, 1, 0], 50), 10);
+    });
+
+    it('clamps out-of-range positions to [0, 100]', () => {
+      assert.strictEqual(planeDistanceForPosition(UNIT_CUBE, [0, 1, 0], -50), 0);
+      assert.strictEqual(planeDistanceForPosition(UNIT_CUBE, [0, 1, 0], 150), 20);
+    });
+
+    it('falls back to min for degenerate bounds', () => {
+      const degenerate = { min: { x: 5, y: 5, z: 5 }, max: { x: 5, y: 5, z: 5 } };
+      assert.strictEqual(planeDistanceForPosition(degenerate, [0, 1, 0], 50), 5);
+    });
+  });
+
+  describe('positionFromPoint', () => {
+    it('is the inverse of planeDistanceForPosition on the cardinal axis', () => {
+      // dist at 37% along Y should map back to 37%.
+      const d = planeDistanceForPosition(UNIT_CUBE, [0, 1, 0], 37);
+      const p = positionFromPoint(UNIT_CUBE, [0, 1, 0], [0, d, 0]);
+      assert.ok(Math.abs(p - 37) < 1e-9, `round-trip failed: ${p}`);
+    });
+
+    it('maps the AABB corners to the expected ends', () => {
+      // Point at min corner → 0%; point at max corner → 100%.
+      assert.strictEqual(positionFromPoint(UNIT_CUBE, [0, 1, 0], [5, 0, 15]),  0);
+      assert.strictEqual(positionFromPoint(UNIT_CUBE, [0, 1, 0], [5, 20, 15]), 100);
+    });
+
+    it('clamps a point outside the bounds-projection range', () => {
+      assert.strictEqual(positionFromPoint(UNIT_CUBE, [0, 1, 0], [0, -100, 0]), 0);
+      assert.strictEqual(positionFromPoint(UNIT_CUBE, [0, 1, 0], [0,  100, 0]), 100);
+    });
+
+    it('degenerate bounds return the canonical midpoint', () => {
+      const degenerate = { min: { x: 5, y: 5, z: 5 }, max: { x: 5, y: 5, z: 5 } };
+      assert.strictEqual(positionFromPoint(degenerate, [0, 1, 0], [5, 5, 5]), 50);
+    });
+  });
+});

--- a/packages/renderer/src/section-math.ts
+++ b/packages/renderer/src/section-math.ts
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Shared math for the arbitrary-normal section plane.
+ *
+ * Both the viewer's face-pick handler and the renderer (shader clip +
+ * gizmo quad) need the same mapping from a world-space plane normal + a
+ * 0-100% slider to a world-space plane distance. Duplicating the math in
+ * three places drifted the last time it changed — this module is the
+ * single source of truth.
+ *
+ * The mapping is:
+ *   1. Project the 8 AABB corners of the model bounds onto the unit
+ *      normal. The min/max of those projections define the range of
+ *      plane distances that touch the model.
+ *   2. The slider's `position` (0-100%) interpolates inside that range.
+ *
+ * For a cardinal normal (e.g. `[0, 1, 0]` = down) this reduces to the
+ * classic "slider from min Y to max Y" behaviour, so the axis-preset
+ * path can use the same helper if it wants — but doesn't have to, since
+ * the axis presets precede this work and have their own logic that also
+ * honours an optional UI-supplied storey range.
+ */
+
+export interface SectionBounds {
+  min: { x: number; y: number; z: number };
+  max: { x: number; y: number; z: number };
+}
+
+/**
+ * Project a model AABB onto a unit normal and return the min/max/range
+ * of signed plane distances (`dot(corner, normal)`) across all 8 corners.
+ *
+ * `normal` must be approximately unit length; the callers in this codebase
+ * normalise before calling. For `range < 1e-6` (degenerate bounds, e.g.
+ * an empty scene) consumers should treat the plane as sitting at `min`.
+ */
+export function projectBoundsOntoNormal(
+  bounds: SectionBounds,
+  normal: readonly [number, number, number],
+): { min: number; max: number; range: number } {
+  const { min, max } = bounds;
+  let minP = Infinity;
+  let maxP = -Infinity;
+  for (const cx of [min.x, max.x]) {
+    for (const cy of [min.y, max.y]) {
+      for (const cz of [min.z, max.z]) {
+        const pr = cx * normal[0] + cy * normal[1] + cz * normal[2];
+        if (pr < minP) minP = pr;
+        if (pr > maxP) maxP = pr;
+      }
+    }
+  }
+  return { min: minP, max: maxP, range: maxP - minP };
+}
+
+/**
+ * Convert a slider position (0-100%) to a world-space plane distance
+ * along `normal`, mapped against the model AABB's projected range.
+ * Degenerate bounds (range ≈ 0) collapse to `min`.
+ */
+export function planeDistanceForPosition(
+  bounds: SectionBounds,
+  normal: readonly [number, number, number],
+  position: number,
+): number {
+  const { min, range } = projectBoundsOntoNormal(bounds, normal);
+  if (range < 1e-6) return min;
+  const t = Math.min(100, Math.max(0, position)) / 100;
+  return min + t * range;
+}
+
+/**
+ * Inverse mapping: given a world-space point on the plane (typically a
+ * raycast hit), return the slider position (0-100%) that would place the
+ * plane through it. Used by face-pick so the slider immediately reflects
+ * where the user clicked.
+ */
+export function positionFromPoint(
+  bounds: SectionBounds,
+  normal: readonly [number, number, number],
+  point: readonly [number, number, number],
+): number {
+  const { min, range } = projectBoundsOntoNormal(bounds, normal);
+  if (range < 1e-6) return 50;
+  const proj = point[0] * normal[0] + point[1] * normal[1] + point[2] * normal[2];
+  return Math.min(100, Math.max(0, ((proj - min) / range) * 100));
+}

--- a/packages/renderer/src/section-plane.ts
+++ b/packages/renderer/src/section-plane.ts
@@ -21,13 +21,14 @@ export interface SectionPlaneRenderOptions {
   min?: number;      // Optional override for min range value
   max?: number;      // Optional override for max range value
   /**
-   * Optional explicit plane normal (unit vector) and signed distance from
-   * origin. When both are provided, the gizmo is placed on that world-space
-   * plane and its quad is built from an orthonormal basis derived from the
-   * normal — `axis`/`position`/`min`/`max` are ignored.
+   * Optional world-space plane normal (unit vector). When provided, the
+   * gizmo is placed on the plane whose distance from origin is derived
+   * from the model bounds projected onto `normal`, interpolated by
+   * `position` (0-100%). `axis`/`min`/`max` are ignored for this path.
+   * This mirrors the computation the main renderer does for its shader
+   * clip so the gizmo and the cut stay in lockstep.
    */
   normal?: [number, number, number];
-  distance?: number;
 }
 
 export class SectionPlaneRenderer {
@@ -265,20 +266,17 @@ export class SectionPlaneRenderer {
       return;
     }
 
-    const { axis, position, bounds, viewProj, isPreview, min: minOverride, max: maxOverride, normal, distance } = options;
+    const { axis, position, bounds, viewProj, isPreview, min: minOverride, max: maxOverride, normal } = options;
 
     // Only draw section plane in preview mode - hide it during active cutting
     if (!isPreview) {
       return;
     }
 
-    const hasExplicitPlane =
-      normal !== undefined &&
-      distance !== undefined &&
-      Number.isFinite(distance);
+    const hasExplicitPlane = normal !== undefined;
 
     const vertices = hasExplicitPlane
-      ? this.calculatePlaneVerticesFromNormal(normal!, distance!, bounds)
+      ? this.calculatePlaneVerticesFromNormal(normal!, position, bounds)
       : this.calculatePlaneVertices(axis, position, bounds, 0, minOverride, maxOverride);
     this.device.queue.writeBuffer(this.vertexBuffer, 0, vertices);
 
@@ -401,15 +399,17 @@ export class SectionPlaneRenderer {
 
   /**
    * Compute 6 vertices (two triangles) for the visualization quad of an
-   * arbitrary plane defined by a world-space unit normal and signed distance
-   * from origin (plane equation: `dot(p, n) = d`). The quad is centred on the
-   * foot of the perpendicular from the bounds centre, oriented via an
-   * orthonormal basis derived from the normal, and sized from the bounds'
-   * diagonal so it visibly covers the model no matter how the plane is tilted.
+   * arbitrary plane defined by a world-space unit normal, where `position`
+   * (0-100%) picks the distance along the range of the bounds projected
+   * onto `normal` — this is the same mapping the main renderer does for
+   * its shader clip, so the gizmo and the cut stay in lockstep while the
+   * slider is dragged. The quad is centred on the foot of the perpendicular
+   * from the bounds centre and oriented via an orthonormal basis derived
+   * from the normal so it stays visible at any tilt.
    */
   private calculatePlaneVerticesFromNormal(
     normal: [number, number, number],
-    distance: number,
+    position: number,
     bounds: { min: { x: number; y: number; z: number }; max: { x: number; y: number; z: number } }
   ): Float32Array {
     const { min, max } = bounds;
@@ -425,7 +425,25 @@ export class SectionPlaneRenderer {
       return new Float32Array(30); // degenerate; draw nothing
     }
     nx /= nlen; ny /= nlen; nz /= nlen;
-    const d = distance / nlen;
+
+    // Project the 8 AABB corners onto the unit normal to get the valid
+    // distance range, then interpolate via `position` (0-100%). Matches
+    // the main renderer's mapping so the gizmo sits exactly on the clip.
+    let minP = Infinity;
+    let maxP = -Infinity;
+    for (const cx of [min.x, max.x]) {
+      for (const cy of [min.y, max.y]) {
+        for (const cz of [min.z, max.z]) {
+          const pr = cx * nx + cy * ny + cz * nz;
+          if (pr < minP) minP = pr;
+          if (pr > maxP) maxP = pr;
+        }
+      }
+    }
+    const rng = maxP - minP;
+    const d = rng > 1e-6
+      ? minP + (Math.min(100, Math.max(0, position)) / 100) * rng
+      : minP;
 
     // Foot of the perpendicular from the bounds centre projected onto the
     // plane — keeps the gizmo anchored near the model even when the plane

--- a/packages/renderer/src/section-plane.ts
+++ b/packages/renderer/src/section-plane.ts
@@ -20,6 +20,14 @@ export interface SectionPlaneRenderOptions {
   isPreview?: boolean; // If true, render as preview (less opacity)
   min?: number;      // Optional override for min range value
   max?: number;      // Optional override for max range value
+  /**
+   * Optional explicit plane normal (unit vector) and signed distance from
+   * origin. When both are provided, the gizmo is placed on that world-space
+   * plane and its quad is built from an orthonormal basis derived from the
+   * normal — `axis`/`position`/`min`/`max` are ignored.
+   */
+  normal?: [number, number, number];
+  distance?: number;
 }
 
 export class SectionPlaneRenderer {
@@ -257,15 +265,21 @@ export class SectionPlaneRenderer {
       return;
     }
 
-    const { axis, position, bounds, viewProj, isPreview, min: minOverride, max: maxOverride } = options;
+    const { axis, position, bounds, viewProj, isPreview, min: minOverride, max: maxOverride, normal, distance } = options;
 
     // Only draw section plane in preview mode - hide it during active cutting
     if (!isPreview) {
       return;
     }
 
-    // Calculate plane vertices based on axis and bounds
-    const vertices = this.calculatePlaneVertices(axis, position, bounds, 0, minOverride, maxOverride);
+    const hasExplicitPlane =
+      normal !== undefined &&
+      distance !== undefined &&
+      Number.isFinite(distance);
+
+    const vertices = hasExplicitPlane
+      ? this.calculatePlaneVerticesFromNormal(normal!, distance!, bounds)
+      : this.calculatePlaneVertices(axis, position, bounds, 0, minOverride, maxOverride);
     this.device.queue.writeBuffer(this.vertexBuffer, 0, vertices);
 
     // Update uniforms
@@ -273,8 +287,14 @@ export class SectionPlaneRenderer {
     uniforms.set(viewProj, 0);
 
     // Axis-specific colors for better identification
-    // down (Y) = light blue, front (Z) = green, side (X) = orange
-    if (axis === 'down') {
+    // down (Y) = light blue, front (Z) = green, side (X) = orange.
+    // Custom planes (face-pick) pick up a neutral violet that won't be
+    // confused with any cardinal axis.
+    if (hasExplicitPlane) {
+      uniforms[16] = 0.612; // R - #9C6BDE (violet)
+      uniforms[17] = 0.420; // G
+      uniforms[18] = 0.871; // B
+    } else if (axis === 'down') {
       uniforms[16] = 0.012; // R - #03A9F4
       uniforms[17] = 0.663; // G
       uniforms[18] = 0.957; // B
@@ -377,6 +397,92 @@ export class SectionPlaneRenderer {
     }
 
     return new Float32Array(vertices);
+  }
+
+  /**
+   * Compute 6 vertices (two triangles) for the visualization quad of an
+   * arbitrary plane defined by a world-space unit normal and signed distance
+   * from origin (plane equation: `dot(p, n) = d`). The quad is centred on the
+   * foot of the perpendicular from the bounds centre, oriented via an
+   * orthonormal basis derived from the normal, and sized from the bounds'
+   * diagonal so it visibly covers the model no matter how the plane is tilted.
+   */
+  private calculatePlaneVerticesFromNormal(
+    normal: [number, number, number],
+    distance: number,
+    bounds: { min: { x: number; y: number; z: number }; max: { x: number; y: number; z: number } }
+  ): Float32Array {
+    const { min, max } = bounds;
+
+    // Defensive renormalisation so callers passing e.g. mesh face normals
+    // (which can drift from unit length by quantisation) still get a valid
+    // quad — matches the same defence applied in the main renderer.
+    let nx = normal[0];
+    let ny = normal[1];
+    let nz = normal[2];
+    const nlen = Math.sqrt(nx * nx + ny * ny + nz * nz);
+    if (nlen < 1e-6) {
+      return new Float32Array(30); // degenerate; draw nothing
+    }
+    nx /= nlen; ny /= nlen; nz /= nlen;
+    const d = distance / nlen;
+
+    // Foot of the perpendicular from the bounds centre projected onto the
+    // plane — keeps the gizmo anchored near the model even when the plane
+    // would otherwise sit far from the origin.
+    const cx = (min.x + max.x) / 2;
+    const cy = (min.y + max.y) / 2;
+    const cz = (min.z + max.z) / 2;
+    const s = d - (cx * nx + cy * ny + cz * nz);
+    const px = cx + nx * s;
+    const py = cy + ny * s;
+    const pz = cz + nz * s;
+
+    // Orthonormal basis {u, v} in the plane. Pick a reference axis that is
+    // not parallel to the normal, cross-product to get `u`, then cross again
+    // for `v`. This is the classic "arbitrary perpendicular" trick.
+    const refX = Math.abs(nx) < 0.9 ? 1 : 0;
+    const refY = Math.abs(nx) < 0.9 ? 0 : 1;
+    const refZ = 0;
+    let ux = ny * refZ - nz * refY;
+    let uy = nz * refX - nx * refZ;
+    let uz = nx * refY - ny * refX;
+    const ulen = Math.sqrt(ux * ux + uy * uy + uz * uz) || 1;
+    ux /= ulen; uy /= ulen; uz /= ulen;
+    const vx = ny * uz - nz * uy;
+    const vy = nz * ux - nx * uz;
+    const vz = nx * uy - ny * ux;
+
+    // Size the quad from the bounds' diagonal with 10% padding, matching the
+    // axis-aligned path's visual scale.
+    const dx = max.x - min.x;
+    const dy = max.y - min.y;
+    const dz = max.z - min.z;
+    const half = 0.55 * Math.sqrt(dx * dx + dy * dy + dz * dz);
+
+    const p0x = px - ux * half - vx * half;
+    const p0y = py - uy * half - vy * half;
+    const p0z = pz - uz * half - vz * half;
+    const p1x = px + ux * half - vx * half;
+    const p1y = py + uy * half - vy * half;
+    const p1z = pz + uz * half - vz * half;
+    const p2x = px + ux * half + vx * half;
+    const p2y = py + uy * half + vy * half;
+    const p2z = pz + uz * half + vz * half;
+    const p3x = px - ux * half + vx * half;
+    const p3y = py - uy * half + vy * half;
+    const p3z = pz - uz * half + vz * half;
+
+    return new Float32Array([
+      // Triangle 1
+      p0x, p0y, p0z, 0, 0,
+      p1x, p1y, p1z, 1, 0,
+      p2x, p2y, p2z, 1, 1,
+      // Triangle 2
+      p0x, p0y, p0z, 0, 0,
+      p2x, p2y, p2z, 1, 1,
+      p3x, p3y, p3z, 0, 1,
+    ]);
   }
 
   /**

--- a/packages/renderer/src/section-plane.ts
+++ b/packages/renderer/src/section-plane.ts
@@ -7,6 +7,7 @@
  */
 
 import { PIPELINE_CONSTANTS } from './constants.js';
+import { planeDistanceForPosition } from './section-math.js';
 
 export interface SectionPlaneRenderOptions {
   axis: 'down' | 'front' | 'side';  // Semantic axis names: down (Y), front (Z), side (X)
@@ -314,7 +315,13 @@ export class SectionPlaneRenderer {
     uniforms[19] = 0.25;
     this.device.queue.writeBuffer(this.uniformBuffer, 0, uniforms);
 
-    // Draw section plane with preview pipeline (respects depth)
+    // Draw section plane with preview pipeline (respects depth). Even for
+    // custom-normal planes with clipping enabled we intentionally stay on
+    // this pipeline — the shader has already discarded the +normal
+    // half-space, so the quad is visible through the "hole" left by the
+    // cut, anchored on the actual clip boundary. Switching to the
+    // always-on-top cutPipeline would paint the quad over the kept
+    // geometry and hide whatever the user is trying to see.
     pass.setPipeline(this.previewPipeline!);
     pass.setBindGroup(0, this.bindGroup);
     pass.setVertexBuffer(0, this.vertexBuffer);
@@ -431,24 +438,10 @@ export class SectionPlaneRenderer {
     }
     nx /= nlen; ny /= nlen; nz /= nlen;
 
-    // Project the 8 AABB corners onto the unit normal to get the valid
-    // distance range, then interpolate via `position` (0-100%). Matches
-    // the main renderer's mapping so the gizmo sits exactly on the clip.
-    let minP = Infinity;
-    let maxP = -Infinity;
-    for (const cx of [min.x, max.x]) {
-      for (const cy of [min.y, max.y]) {
-        for (const cz of [min.z, max.z]) {
-          const pr = cx * nx + cy * ny + cz * nz;
-          if (pr < minP) minP = pr;
-          if (pr > maxP) maxP = pr;
-        }
-      }
-    }
-    const rng = maxP - minP;
-    const d = rng > 1e-6
-      ? minP + (Math.min(100, Math.max(0, position)) / 100) * rng
-      : minP;
+    // Shared helper: matches the main renderer's bounds-projection mapping
+    // exactly, so the gizmo quad sits on the shader clip for every slider
+    // position.
+    const d = planeDistanceForPosition(bounds, [nx, ny, nz], position);
 
     // Foot of the perpendicular from the bounds centre projected onto the
     // plane — keeps the gizmo anchored near the model even when the plane

--- a/packages/renderer/src/section-plane.ts
+++ b/packages/renderer/src/section-plane.ts
@@ -268,12 +268,17 @@ export class SectionPlaneRenderer {
 
     const { axis, position, bounds, viewProj, isPreview, min: minOverride, max: maxOverride, normal } = options;
 
-    // Only draw section plane in preview mode - hide it during active cutting
-    if (!isPreview) {
+    const hasExplicitPlane = normal !== undefined;
+
+    // Axis-preset gizmo is preview-only: once clipping is enabled the hatched
+    // 3D cap surfaces take over as the "here is the cut" visual. Custom-normal
+    // planes have no 3D cap yet (the cap pipeline still assumes cardinal axes),
+    // so we keep the gizmo quad visible when clipping is enabled for custom
+    // planes — otherwise the user has no feedback on where the cut actually
+    // sits in world space.
+    if (!isPreview && !hasExplicitPlane) {
       return;
     }
-
-    const hasExplicitPlane = normal !== undefined;
 
     const vertices = hasExplicitPlane
       ? this.calculatePlaneVerticesFromNormal(normal!, position, bounds)

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -129,6 +129,15 @@ export interface SectionPlane {
   flipped?: boolean; // If true, show the opposite side of the cut
   min?: number;      // Optional override for min range value
   max?: number;      // Optional override for max range value
+  /**
+   * Optional world-space plane normal (unit vector). When provided together
+   * with `distance`, the renderer uses them verbatim and ignores `axis`,
+   * `position`, `min`, `max`, and any `buildingRotation`. Used for face-pick
+   * / arbitrary slice planes.
+   */
+  normal?: [number, number, number];
+  /** Signed plane offset: `dot(pointOnPlane, normal)`. Paired with `normal`. */
+  distance?: number;
   /** If true (default), render filled cap surfaces with a screen-space hatch. */
   showCap?: boolean;
   /**

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -130,14 +130,12 @@ export interface SectionPlane {
   min?: number;      // Optional override for min range value
   max?: number;      // Optional override for max range value
   /**
-   * Optional world-space plane normal (unit vector). When provided together
-   * with `distance`, the renderer uses them verbatim and ignores `axis`,
-   * `position`, `min`, `max`, and any `buildingRotation`. Used for face-pick
-   * / arbitrary slice planes.
+   * Optional world-space plane normal (unit vector). When provided, the
+   * renderer projects the model bounds onto `normal` and uses `position`
+   * (0-100%) to interpolate the plane along that range. `axis`, `min`,
+   * `max`, and `buildingRotation` are ignored for this path.
    */
   normal?: [number, number, number];
-  /** Signed plane offset: `dot(pointOnPlane, normal)`. Paired with `normal`. */
-  distance?: number;
   /** If true (default), render filled cap surfaces with a screen-space hatch. */
   showCap?: boolean;
   /**


### PR DESCRIPTION
## Summary

Closes #243. Generalises the section clip from three hard-coded cardinal axes (`down` / `front` / `side`) to any world-space plane, and adds a face-pick mode so users can click any surface to cut through it — the Bonsai-style UX @MensonLF asked for.

The refactor is deliberately minimal: the WGSL shader already accepted `vec3 normal + f32 distance`, so only the JS/TS layer was hardcoding axes. Downstream readers (drawings export, BCF snapshots, view controls) still read `sectionPlane.axis` and keep working — face-pick writes the **nearest cardinal** to `axis` alongside the explicit `normal`/`distance`, so those code paths get a safe approximation instead of a crash.

### State (`apps/viewer/src/store/types.ts`, `sectionSlice.ts`)
- `SectionPlane` gains optional `normal: [x,y,z]` + `distance`. When set, the renderer uses them verbatim and skips axis/position derivation.
- `setSectionPlaneFromFace(normal, point)` normalises the normal, derives `distance = dot(point, normal)`, sets the nearest-cardinal axis for downstream readers, and enables the clip.
- `sectionPickMode` arms the next canvas click; cleared on a successful pick, a miss, or a tool change.
- The existing preset axis/position actions drop any custom normal/distance so clicking a preset reverts to the slider flow cleanly.

### Renderer (`packages/renderer/src/{types,index,section-plane}.ts`)
- `SectionPlane` mirrors the new optional fields.
- Renderer: when an explicit plane is provided, skip the axis → normal mapping, the `buildingRotation` correction, and the position → distance computation. Defensive renormalisation for non-unit normals.
- Gizmo quad is now built from an orthonormal basis derived from the normal (cross-product against a non-parallel reference), sized from the bounds diagonal so it stays visible for any tilt. Custom planes paint violet so they can't be confused with the blue/green/orange cardinal presets.

### UI / input
- `SectionPanel` adds a "Pick face" toggle. Arming it shows "Click a face…"; after a pick, the button becomes "Custom plane — pick again", and the preset buttons deselect to signal you're off the cardinal grid.
- `selectionHandlers` intercepts the click when `tool === 'section' && sectionPickMode`, raycasts the scene, and calls `setSectionPlaneFromFace` with the intersection's face normal + point. Missed clicks disarm pick mode so the user isn't stuck.
- Leaving the section tool disarms pick mode and resets the cursor.

### Behaviour kept intact

- The `down` / `front` / `side` preset buttons behave exactly as before (same normal, same position slider, same building-rotation handling).
- `useViewControls`, `useDrawingGeneration`, `useBCF`, `useFloorplanView`, drawings export, BCF snapshots all continue to read `sectionPlane.axis` and work. Custom planes surface as the nearest cardinal in those paths.
- `SectionPlaneAxis` type is unchanged → no cascading type breakage across the 11 files that consume it.

## Test plan

- [x] 5 new `sectionSlice` tests (normalisation, cardinal mapping, disarm, degenerate normal, preset-clears-custom). All 30 section slice tests pass.
- [x] `pnpm turbo typecheck` — no new errors in any touched file (existing `main` has unrelated Tauri/apache-arrow errors, identical before + after).
- [ ] Manual UI: load any IFC, switch to Section tool, click **Pick face** → click a wall → plane cuts through it at the face's world-space normal; toggle presets → reverts cleanly; slider works again.
- [ ] Regression: confirm the three preset axes still cut identically to `main` (bounds, building rotation).
- [ ] Regression: drawings export + BCF still produce a cardinal-axis snapshot when a custom plane is set.

https://claude.ai/code/session_01QkELkwDNmGiMc52Pi4hDmD

---
_Generated by [Claude Code](https://claude.ai/code/session_01QkELkwDNmGiMc52Pi4hDmD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Face-pick mode: "Pick face" lets you click a visible surface to create a custom, arbitrarily oriented section plane; slider maps to that plane.
  * Draggable section panel: panel can be dragged and stays clamped to the 3D canvas area.
  * Visual cues: custom planes show a distinct "CUSTOM" badge color.

* **Behavior**
  * 2D export/drawing disabled for custom face-picked planes with an explanatory message.
  * Cursor and tool switching reliably enable/disable face-pick mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->