### PR TITLE
fix(viewer): address surviving PR #588 review feedback

### DIFF
--- a/.changeset/search-feedback-fixes.md
+++ b/.changeset/search-feedback-fixes.md
@@ -1,0 +1,24 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Address PR #588 review feedback that survived the Filter migration:
+
+- Inline-bar Enter now flushes the 80ms debounce by re-scanning against
+  the live `searchQuery`, so committing inside the debounce window
+  selects the entity matching what the input shows (not the prior
+  query) and records the correct recent.
+- The 50ms `frameSelection` timer in the inline bar is tracked via a
+  ref and cleared on rapid selection changes / unmount instead of
+  leaking orphan callbacks.
+- Shift+Enter additive selection in the inline bar and the row-level
+  additive path in the Search modal now TOGGLE via `toggleEntitySelection`,
+  so the same interaction can deselect a previously-added row.
+- New `addEntitiesToSelection` batch action on the selection slice;
+  the Search modal's "Select all" path uses it so a 5K-row select-all
+  dispatches one Zustand `set` instead of N.
+- Tier-0 scoring now keeps the max across name/type/objectType/description
+  fields (matching Tier-1's behaviour). Without this, an entity with a
+  substring name hit and a type-exact hit ranked lower than it should
+  on Tier-0, breaking the comparable-ordering guarantee when results
+  came from a mix of Tier-0 and Tier-1 models.

--- a/apps/viewer/src/components/viewer/SearchInline.tsx
+++ b/apps/viewer/src/components/viewer/SearchInline.tsx
@@ -58,6 +58,12 @@ function isEditableFocused(): boolean {
 export function SearchInline() {
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  // Tracks the latest scheduled `frameSelection` timer so back-to-back
+  // selection changes (or unmount) don't leak orphaned timeouts. Without
+  // this, picking a different result inside the 50ms window — or
+  // unmounting the component — leaves a stale callback queued that fires
+  // on a now-unrelated camera state.
+  const frameTimerRef = useRef<number | null>(null);
 
   const {
     searchQuery,
@@ -76,7 +82,7 @@ export function SearchInline() {
     models,
     setSelectedEntity,
     setSelectedEntityId,
-    addEntityToSelection,
+    toggleEntitySelection,
     cameraCallbacks,
   } = useViewerStore(
     useShallow((s) => ({
@@ -96,7 +102,7 @@ export function SearchInline() {
       models: s.models,
       setSelectedEntity: s.setSelectedEntity,
       setSelectedEntityId: s.setSelectedEntityId,
-      addEntityToSelection: s.addEntityToSelection,
+      toggleEntitySelection: s.toggleEntitySelection,
       cameraCallbacks: s.cameraCallbacks,
     })),
   );
@@ -113,6 +119,15 @@ export function SearchInline() {
     const handle = window.setTimeout(() => setDebouncedQuery(searchQuery), DEBOUNCE_MS);
     return () => window.clearTimeout(handle);
   }, [searchQuery]);
+
+  // Clear any pending frame timer on unmount so a fire-and-forget
+  // callback can't outlive the component.
+  useEffect(() => () => {
+    if (frameTimerRef.current !== null) {
+      window.clearTimeout(frameTimerRef.current);
+      frameTimerRef.current = null;
+    }
+  }, []);
 
   // Split models into two pools: those with a ready Tier-1 index, and
   // those still relying on the Tier-0 linear scan. Recomputed only when
@@ -134,17 +149,26 @@ export function SearchInline() {
     return { tier0Models: t0, tier1Indexes: t1, indexingCount: building };
   }, [models, searchIndexes]);
 
-  const results = useMemo<SearchResult[]>(() => {
-    if (!debouncedQuery.trim()) return [];
+  /**
+   * Run the Tier-0/Tier-1 scan synchronously for an arbitrary query.
+   * Extracted from the debounced `results` memo so the Enter-commit
+   * path can flush against the LIVE `searchQuery` rather than the
+   * debounced snapshot — without it, hitting Enter inside the 80ms
+   * debounce window commits a hit from the previous query and records
+   * the wrong recent-search term, even though the input shows newer
+   * text (Codex P2: "Commit inline search against the current query").
+   */
+  const runScan = useCallback((q: string): SearchResult[] => {
+    if (!q.trim()) return [];
     if (tier0Models.length === 0 && tier1Indexes.length === 0) return [];
 
     const t1Results =
       tier1Indexes.length > 0
-        ? queryTier1Indexes(tier1Indexes, debouncedQuery, { limit: RESULT_LIMIT })
+        ? queryTier1Indexes(tier1Indexes, q, { limit: RESULT_LIMIT })
         : [];
     const t0Results =
       tier0Models.length > 0
-        ? runTier0Scan(tier0Models, debouncedQuery, { limit: RESULT_LIMIT })
+        ? runTier0Scan(tier0Models, q, { limit: RESULT_LIMIT })
         : [];
 
     if (t1Results.length === 0) return t0Results;
@@ -168,7 +192,12 @@ export function SearchInline() {
       if (out.length >= RESULT_LIMIT) break;
     }
     return out;
-  }, [tier0Models, tier1Indexes, debouncedQuery]);
+  }, [tier0Models, tier1Indexes]);
+
+  const results = useMemo<SearchResult[]>(
+    () => runScan(debouncedQuery),
+    [runScan, debouncedQuery],
+  );
 
   // Keep the highlight index in range as results change.
   useEffect(() => {
@@ -189,7 +218,10 @@ export function SearchInline() {
       const globalId = isLegacy ? r.expressId : toGlobalIdFromModels(models, r.modelId, r.expressId);
 
       if (addToSelection) {
-        addEntityToSelection(ref);
+        // Shift+Enter additive — TOGGLES rather than just adds, so a
+        // second Shift+Enter on the same row deselects (was: forced
+        // the user to clear the entire multi-selection to undo).
+        toggleEntitySelection(ref);
         setSelectedEntityId(globalId);
         return;
       }
@@ -197,26 +229,46 @@ export function SearchInline() {
       setSelectedEntityId(globalId);
       setSelectedEntity(ref);
       if (cameraCallbacks.frameSelection) {
-        window.setTimeout(() => cameraCallbacks.frameSelection?.(), 50);
+        if (frameTimerRef.current !== null) window.clearTimeout(frameTimerRef.current);
+        frameTimerRef.current = window.setTimeout(() => {
+          cameraCallbacks.frameSelection?.();
+          frameTimerRef.current = null;
+        }, 50);
       }
     },
     [
-      addEntityToSelection,
       cameraCallbacks,
       models,
       setSelectedEntity,
       setSelectedEntityId,
+      toggleEntitySelection,
     ],
   );
 
-  /** Commit: select + frame + enter vim cycle + record recent. */
+  /**
+   * Commit: select + frame + enter vim cycle + record recent.
+   *
+   * `overrideResults` / `overrideQuery` let the Enter-commit path
+   * pass freshly-scanned results from the LIVE `searchQuery` when
+   * the debounce hasn't settled yet — without that, the user's
+   * `n`/`N` cycle and the recorded recent both reflect the prior
+   * (debounced) query rather than what the input shows.
+   */
   const commitResult = useCallback(
-    (r: SearchResult, index: number, addToSelection: boolean) => {
+    (
+      r: SearchResult,
+      index: number,
+      addToSelection: boolean,
+      overrideResults?: SearchResult[],
+      overrideQuery?: string,
+    ) => {
+      const cycleResults = overrideResults ?? results;
+      const cycleQuery = overrideQuery ?? debouncedQuery;
       applySelection(r, addToSelection);
-      if (!addToSelection && results.length > 0) {
-        enterVimCycle(debouncedQuery, results, index);
+      if (!addToSelection && cycleResults.length > 0) {
+        enterVimCycle(cycleQuery, cycleResults, index);
       }
-      const trimmed = debouncedQuery.trim();
+      const trimmed = cycleQuery.trim();
       if (trimmed) setRecents(pushRecentSearch(trimmed));
       closeSearch();
     },
@@ -348,8 +400,20 @@ export function SearchInline() {
           setSearchModalOpen(true);
           return;
         }
-        const target = results[searchHighlightIndex];
-        if (target) commitResult(target, searchHighlightIndex, e.shiftKey);
+        // Flush the debounce: if the user typed something that hasn't yet
+        // settled into `debouncedQuery`, re-scan synchronously against the
+        // LIVE `searchQuery`. The popover is showing stale results in that
+        // window (debounced still reflects the prior query) so committing
+        // `results[index]` would select the wrong entity. Match the input.
+        const live = searchQuery;
+        const useLive = live.trim() !== debouncedQuery.trim();
+        const liveResults = useLive ? runScan(live) : results;
+        if (liveResults.length === 0) return;
+        const idx = useLive
+          ? Math.min(searchHighlightIndex, liveResults.length - 1)
+          : searchHighlightIndex;
+        const target = liveResults[idx];
+        if (target) commitResult(target, idx, e.shiftKey, liveResults, live);
       }
     },
     [commitResult, results, searchHighlightIndex, searchOpen, setSearchHighlightIndex, setSearchModalOpen, setSearchOpen],

--- a/apps/viewer/src/components/viewer/SearchModal.text.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.text.tsx
@@ -58,7 +58,8 @@ export function SearchModalText({ results, availableModelIds, onClose }: SearchM
     setSearchHighlightIndex,
     setSelectedEntity,
     setSelectedEntityId,
-    addEntityToSelection,
+    addEntitiesToSelection,
+    toggleEntitySelection,
     clearEntitySelection,
     enterVimCycle,
     cameraCallbacks,
@@ -76,7 +77,8 @@ export function SearchModalText({ results, availableModelIds, onClose }: SearchM
       setSearchHighlightIndex: s.setSearchHighlightIndex,
       setSelectedEntity: s.setSelectedEntity,
       setSelectedEntityId: s.setSelectedEntityId,
-      addEntityToSelection: s.addEntityToSelection,
+      addEntitiesToSelection: s.addEntitiesToSelection,
+      toggleEntitySelection: s.toggleEntitySelection,
       clearEntitySelection: s.clearEntitySelection,
       enterVimCycle: s.enterVimCycle,
       cameraCallbacks: s.cameraCallbacks,
@@ -145,20 +147,30 @@ export function SearchModalText({ results, availableModelIds, onClose }: SearchM
     ],
   );
 
-  /** Additive toggle — adds/removes from multi-selection without closing. */
+  /**
+   * Additive toggle — adds OR removes from multi-selection without
+   * closing. Uses `toggleEntitySelection` so a second Shift+Enter (or
+   * a second checkbox click on the same row) deselects, rather than
+   * being a no-op that forces the user to clear the entire selection.
+   */
   const toggleAdditive = useCallback(
     (r: SearchResult) => {
-      addEntityToSelection({ modelId: r.modelId, expressId: r.expressId });
+      toggleEntitySelection({ modelId: r.modelId, expressId: r.expressId });
     },
-    [addEntityToSelection],
+    [toggleEntitySelection],
   );
 
-  /** Batch: add every filtered result to multi-selection. */
+  /**
+   * Batch: add every filtered result to multi-selection in a single
+   * Zustand `set`. The naïve loop over `addEntityToSelection` triggered
+   * one re-render per row — visibly janky on a 5K-row filtered set.
+   */
   const selectAll = useCallback(() => {
-    for (const r of filtered) {
-      addEntityToSelection({ modelId: r.modelId, expressId: r.expressId });
-    }
-  }, [addEntityToSelection, filtered]);
+    if (filtered.length === 0) return;
+    addEntitiesToSelection(
+      filtered.map((r) => ({ modelId: r.modelId, expressId: r.expressId })),
+    );
+  }, [addEntitiesToSelection, filtered]);
 
   /** Batch: frame whatever is the primary selection (if any). */
   const frame = useCallback(() => {

--- a/apps/viewer/src/lib/search/tier0-scan.test.ts
+++ b/apps/viewer/src/lib/search/tier0-scan.test.ts
@@ -122,6 +122,23 @@ describe('runTier0Scan', () => {
     assert.strictEqual(winner!.matchField, 'type');
   });
 
+  it('keeps the MAX score across fields (a substring name hit can be outranked by a type-exact hit)', () => {
+    // The entity's name contains "wall" (NAME_SUBSTR=40) AND its type
+    // is exactly "IfcWall" (TYPE_EXACT=80). The match should win on
+    // type, not be capped at name. Without this, multi-model results
+    // where one model used Tier-1 (max-across-fields) and another
+    // used Tier-0 (short-circuit) would rank the same logical match
+    // differently — breaking the comparable-ordering guarantee.
+    const store = buildStore([
+      { expressId: 10, type: 'IFCWALL', globalId: '1abcdefghijklmnopqrstu', name: 'metal-wall-cladding' },
+    ]);
+    const out = runTier0Scan([modelOf('m', store)], 'ifcwall');
+    assert.strictEqual(out.length, 1);
+    assert.strictEqual(out[0].matchField, 'type', 'type should outrank a substring name hit');
+    // 80 (TYPE_EXACT) ≫ 40 (NAME_SUBSTR).
+    assert.strictEqual(out[0].score, 80);
+  });
+
   it('matches by description and objectType when name/type miss', () => {
     const store = buildStore(baseRows);
 

--- a/apps/viewer/src/lib/search/tier0-scan.ts
+++ b/apps/viewer/src/lib/search/tier0-scan.ts
@@ -169,54 +169,52 @@ function scanModel(
     const name = nIdx !== 0 ? strings.get(nIdx) : '';
     const globalId = gIdx !== 0 ? strings.get(gIdx) : '';
 
+    // Score every applicable field and keep the max — Tier-1's
+    // `scoreEntry` does the same, and the result-merge code in the UI
+    // depends on Tier-0 / Tier-1 producing comparable orderings. The
+    // previous short-circuit (skip type once name produced any score)
+    // ranked an entity that hits NAME_SUBSTR (40) below an entity that
+    // would have hit TYPE_EXACT (80) on its name field, so the same
+    // logical match scored differently across paths.
     let score = 0;
     let matchField: MatchField = 'name';
+    const bump = (s: number, mf: MatchField): void => {
+      if (s > score) {
+        score = s;
+        matchField = mf;
+      }
+    };
 
     if (name) {
       const nameLower = name.toLowerCase();
-      if (nameLower === needle) {
-        score = SCORE.NAME_EXACT;
-        matchField = 'name';
-      } else if (nameLower.startsWith(needle)) {
-        score = SCORE.NAME_PREFIX;
-        matchField = 'name';
-      } else if (nameLower.includes(needle)) {
-        score = SCORE.NAME_SUBSTR;
-        matchField = 'name';
-      }
+      if (nameLower === needle) bump(SCORE.NAME_EXACT, 'name');
+      else if (nameLower.startsWith(needle)) bump(SCORE.NAME_PREFIX, 'name');
+      else if (nameLower.includes(needle)) bump(SCORE.NAME_SUBSTR, 'name');
     }
 
-    if (score === 0) {
-      // Type comparison uses the resolved type-name accessor (handles enum
-      // → PascalCase conversion); cheap but a method call, so we only do
-      // it when nothing else matched.
-      const idForType = expressId[i];
-      const typeName = table.getTypeName(idForType);
+    {
+      // Type lookup uses the resolved type-name accessor (handles enum
+      // → PascalCase conversion). Cheap but a method call, so it stays
+      // inside the per-row loop only because it can outrank NAME_SUBSTR.
+      const typeName = table.getTypeName(expressId[i]);
       const typeLower = typeName.toLowerCase();
-      if (typeLower === needle) {
-        score = SCORE.TYPE_EXACT;
-        matchField = 'type';
-      } else if (typeLower.startsWith(needle)) {
-        score = SCORE.TYPE_PREFIX;
-        matchField = 'type';
-      }
+      if (typeLower === needle) bump(SCORE.TYPE_EXACT, 'type');
+      else if (typeLower.startsWith(needle)) bump(SCORE.TYPE_PREFIX, 'type');
     }
 
     let objectType = '';
-    if (score === 0 && oIdx !== 0) {
+    if (oIdx !== 0) {
       objectType = strings.get(oIdx);
       if (objectType.toLowerCase().includes(needle)) {
-        score = SCORE.OBJECTTYPE_SUBSTR;
-        matchField = 'objectType';
+        bump(SCORE.OBJECTTYPE_SUBSTR, 'objectType');
       }
     }
 
     let description = '';
-    if (score === 0 && dIdx !== 0) {
+    if (dIdx !== 0) {
       description = strings.get(dIdx);
       if (description.toLowerCase().includes(needle)) {
-        score = SCORE.DESCRIPTION_SUBSTR;
-        matchField = 'description';
+        bump(SCORE.DESCRIPTION_SUBSTR, 'description');
       }
     }
 

--- a/apps/viewer/src/store/slices/selectionSlice.test.ts
+++ b/apps/viewer/src/store/slices/selectionSlice.test.ts
@@ -106,6 +106,52 @@ describe('SelectionSlice', () => {
     });
   });
 
+  describe('multi-model selection: addEntitiesToSelection (batch)', () => {
+    it('should add every ref in one set call', () => {
+      const refs: EntityRef[] = [
+        { modelId: 'model-1', expressId: 1 },
+        { modelId: 'model-1', expressId: 2 },
+        { modelId: 'model-2', expressId: 3 },
+      ];
+      state.addEntitiesToSelection(refs);
+      assert.strictEqual(state.selectedEntitiesSet.size, 3);
+    });
+
+    it('should set primary selection to the LAST ref (matches single-add convention)', () => {
+      const refs: EntityRef[] = [
+        { modelId: 'model-1', expressId: 1 },
+        { modelId: 'model-2', expressId: 99 },
+      ];
+      state.addEntitiesToSelection(refs);
+      assert.deepStrictEqual(state.selectedEntity, { modelId: 'model-2', expressId: 99 });
+    });
+
+    it('should be a no-op for empty input', () => {
+      const before = state.selectedEntitiesSet;
+      state.addEntitiesToSelection([]);
+      assert.strictEqual(state.selectedEntitiesSet, before, 'state ref unchanged');
+    });
+
+    it('should compose with prior single-adds without losing entries', () => {
+      const ref0: EntityRef = { modelId: 'model-1', expressId: 0 };
+      state.addEntityToSelection(ref0);
+      state.addEntitiesToSelection([
+        { modelId: 'model-1', expressId: 1 },
+        { modelId: 'model-1', expressId: 2 },
+      ]);
+      assert.strictEqual(state.selectedEntitiesSet.size, 3);
+    });
+
+    it('should dedupe overlapping refs without changing the set size beyond the union', () => {
+      state.addEntityToSelection({ modelId: 'm', expressId: 7 });
+      state.addEntitiesToSelection([
+        { modelId: 'm', expressId: 7 }, // duplicate
+        { modelId: 'm', expressId: 8 },
+      ]);
+      assert.strictEqual(state.selectedEntitiesSet.size, 2);
+    });
+  });
+
   describe('multi-model selection: removeEntityFromSelection', () => {
     it('should remove entity from selection set', () => {
       const ref: EntityRef = { modelId: 'model-1', expressId: 123 };

--- a/apps/viewer/src/store/slices/selectionSlice.ts
+++ b/apps/viewer/src/store/slices/selectionSlice.ts
@@ -46,6 +46,13 @@ export interface SelectionSlice {
   setSelectedEntity: (ref: EntityRef | null) => void;
   /** Add entity to multi-selection */
   addEntityToSelection: (ref: EntityRef) => void;
+  /**
+   * Batch-add multiple entities to multi-selection in a single Zustand
+   * `set`. Use for bulk paths like "Select all visible results" — the
+   * naïve loop over `addEntityToSelection` re-renders every subscriber
+   * O(N) times for an N-row select. Empty input is a no-op.
+   */
+  addEntitiesToSelection: (refs: ReadonlyArray<EntityRef>) => void;
   /** Remove entity from multi-selection */
   removeEntityFromSelection: (ref: EntityRef) => void;
   /** Toggle entity in multi-selection */
@@ -167,6 +174,19 @@ export const createSelectionSlice: StateCreator<SelectionSlice, [], [], Selectio
       selectedEntitiesSet: newSet,
       selectedEntity: ref,
       // NOTE: Don't update selectedEntityId here - caller should use setSelectedEntityId(globalId)
+    };
+  }),
+
+  addEntitiesToSelection: (refs) => set((state) => {
+    if (refs.length === 0) return {};
+    const newSet = new Set(state.selectedEntitiesSet);
+    for (const ref of refs) newSet.add(entityRefToString(ref));
+    // Primary selection becomes the LAST ref in the input — matches the
+    // existing addEntityToSelection convention where the most recent
+    // add is treated as primary.
+    return {
+      selectedEntitiesSet: newSet,
+      selectedEntity: refs[refs.length - 1],
     };
   }),
 


### PR DESCRIPTION
## Summary

Five items from the #588 review survived the Filter migration in #589 because they touched files the migration didn't rewrite. Stacked on \`claude/search-bar-ifc-data-F8m83\` so it lands cleanly together with #588.

| # | Source | Severity | Fix |
|---|---|---|---|
| 1 | Codex bot | P2 | Enter-commit re-scans against live \`searchQuery\` when the 80ms debounce hasn't settled — was committing prior-query hits |
| 2 | CodeRabbit | Minor | \`frameSelection\` 50ms timer tracked + cleared on rapid changes / unmount — was leaking orphan callbacks |
| 3 | Codex bot | P2 | Shift+Enter and row-level additive use \`toggleEntitySelection\` — a second hit now deselects (was forced full-clear) |
| 4 | CodeRabbit | Major | New \`addEntitiesToSelection\` batch action; \`selectAll\` does one Zustand \`set\` instead of N for a 5K-row select-all |
| 5 | CodeRabbit | Minor | Tier-0 scoring keeps the max across fields (matches Tier-1's \`bump\` pattern) — was capping name-substring matches that should rank as type-exact |

## Test plan

- [x] 643/644 full viewer suite (1 skipped, 0 fail)
- [x] 26/26 ESM smoke
- [x] Production build green
- [x] Type-check on every touched file
- [ ] Manual: type \"wall\" → press Enter inside ~50ms → selects the right wall
- [ ] Manual: Shift+Enter on the same row twice → first adds, second removes
- [ ] Manual: open Search modal with 1000+ filtered → Select all → no jank
- [ ] Manual: search a name fragment that's also a partial type match → result ranks by type, not name-substring

🤖 Generated with [Claude Code](https://claude.com/claude-code)