### PR TITLE
Fix cache key generation and handle meshes without normals

### DIFF
--- a/apps/server/src/routes/parse.rs
+++ b/apps/server/src/routes/parse.rs
@@ -48,6 +48,23 @@ fn reject_unsupported_streaming_opening_filter(query: &ParseQuery) -> Result<(),
     ))
 }
 
+/// Build the parquet geometry cache key for a given file hash and opening filter.
+///
+/// Must stay in sync with the writer in `parse_parquet` / `parse_parquet_stream`,
+/// which derives the same suffix from `OpeningFilterMode::cache_key_suffix()`.
+fn parquet_cache_key(hash: &str, opening_filter: OpeningFilterMode) -> String {
+    format!("{}-{}-parquet-v2", hash, opening_filter.cache_key_suffix())
+}
+
+/// Build the parquet metadata cache key for a given file hash and opening filter.
+fn parquet_metadata_cache_key(hash: &str, opening_filter: OpeningFilterMode) -> String {
+    format!(
+        "{}-{}-parquet-metadata-v2",
+        hash,
+        opening_filter.cache_key_suffix()
+    )
+}
+
 /// Extract file data from multipart request.
 /// Automatically decompresses gzip-compressed files.
 async fn extract_file(multipart: &mut Multipart) -> Result<Vec<u8>, ApiError> {
@@ -932,18 +949,22 @@ pub async fn get_data_model(
 /// Check if a file hash is already cached.
 /// Allows client to skip upload if file is already processed.
 ///
+/// The optional `opening_filter` query parameter must match the value used when
+/// the file was uploaded — different filter modes produce distinct cache entries.
+///
 /// Response:
 /// - 200: File is cached (geometry available)
 /// - 404: File not cached (needs upload)
 pub async fn check_cache(
     State(state): State<AppState>,
+    Query(query): Query<ParseQuery>,
     axum::extract::Path(hash): axum::extract::Path<String>,
 ) -> Result<Response, ApiError> {
-    let parquet_cache_key = format!("{}-parquet-v2", hash);
+    let parquet_cache_key = parquet_cache_key(&hash, query.opening_filter);
 
     match state.cache.get_bytes(&parquet_cache_key).await? {
         Some(_) => {
-            tracing::debug!(hash = %hash, "Cache check HIT");
+            tracing::debug!(hash = %hash, cache_key = %parquet_cache_key, "Cache check HIT");
             let response = Response::builder()
                 .status(StatusCode::OK)
                 .body(Body::empty())
@@ -951,7 +972,7 @@ pub async fn check_cache(
             Ok(response)
         }
         None => {
-            tracing::debug!(hash = %hash, "Cache check MISS");
+            tracing::debug!(hash = %hash, cache_key = %parquet_cache_key, "Cache check MISS");
             let response = Response::builder()
                 .status(StatusCode::NOT_FOUND)
                 .body(Body::empty())
@@ -966,15 +987,19 @@ pub async fn check_cache(
 /// Fetch cached Parquet geometry directly without uploading the file.
 /// Used when client-side hash check confirms file is already cached.
 ///
+/// The optional `opening_filter` query parameter must match the value used when
+/// the file was uploaded — different filter modes produce distinct cache entries.
+///
 /// Response:
 /// - 200: Cached Parquet geometry with metadata header
 /// - 404: Cache entry not found
 pub async fn get_cached_geometry(
     State(state): State<AppState>,
+    Query(query): Query<ParseQuery>,
     axum::extract::Path(hash): axum::extract::Path<String>,
 ) -> Result<Response, ApiError> {
-    let parquet_cache_key = format!("{}-parquet-v2", hash);
-    let metadata_cache_key = format!("{}-parquet-metadata-v2", hash);
+    let parquet_cache_key = parquet_cache_key(&hash, query.opening_filter);
+    let metadata_cache_key = parquet_metadata_cache_key(&hash, query.opening_filter);
 
     match (
         state.cache.get_bytes(&parquet_cache_key).await?,
@@ -1004,5 +1029,40 @@ pub async fn get_cached_geometry(
                 hash
             )))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression test for #587: the reader (`check_cache`) used to look up
+    /// `{hash}-parquet-v2`, while the writer (`parse_parquet`) stored
+    /// `{hash}-{opening_filter}-parquet-v2`, so the check always returned 404.
+    /// The shared helper must produce the same key the writer stores under.
+    #[test]
+    fn parquet_cache_key_matches_writer_format() {
+        let hash = "0ab20f4e4014";
+
+        // The writer composes `cache_key = format!("{hash}-{suffix}")` and then
+        // `format!("{cache_key}-parquet-v2")`. The helper must produce the same string.
+        for mode in [
+            OpeningFilterMode::Default,
+            OpeningFilterMode::IgnoreAll,
+            OpeningFilterMode::IgnoreOpaque,
+        ] {
+            let writer_cache_key = format!("{}-{}", hash, mode.cache_key_suffix());
+            let writer_parquet_key = format!("{}-parquet-v2", writer_cache_key);
+            let writer_metadata_key = format!("{}-parquet-metadata-v2", writer_cache_key);
+
+            assert_eq!(parquet_cache_key(hash, mode), writer_parquet_key);
+            assert_eq!(parquet_metadata_cache_key(hash, mode), writer_metadata_key);
+        }
+    }
+
+    #[test]
+    fn parquet_cache_key_default_filter_uses_default_suffix() {
+        let key = parquet_cache_key("abc", OpeningFilterMode::Default);
+        assert_eq!(key, "abc-default-parquet-v2");
     }
 }

--- a/apps/server/src/services/parquet.rs
+++ b/apps/server/src/services/parquet.rs
@@ -122,15 +122,36 @@ pub fn serialize_to_parquet(meshes: &[MeshData]) -> Result<Bytes, ParquetError> 
             let mut ny = Vec::with_capacity(vert_count);
             let mut nz = Vec::with_capacity(vert_count);
 
+            // Some IFC pipelines (e.g. advanced_brep) yield meshes with positions
+            // but no normals. The schema below requires non-null normal columns,
+            // so pad with zeros and let the client recompute them from positions.
+            let has_normals = mesh.normals.len() == mesh.positions.len();
+            if !has_normals && !mesh.normals.is_empty() {
+                tracing::warn!(
+                    express_id = mesh.express_id,
+                    ifc_type = %mesh.ifc_type,
+                    positions = mesh.positions.len(),
+                    normals = mesh.normals.len(),
+                    "Mesh normals length mismatch; emitting zero normals"
+                );
+            }
+
             for i in 0..vert_count {
                 // Position: Z-up to Y-up transform
                 px.push(mesh.positions[i * 3]); // X stays the same
                 py.push(mesh.positions[i * 3 + 2]); // New Y = old Z (vertical)
                 pz.push(-mesh.positions[i * 3 + 1]); // New Z = -old Y (depth)
-                                                     // Normal: Same transform
-                nx.push(mesh.normals[i * 3]); // X stays the same
-                ny.push(mesh.normals[i * 3 + 2]); // New Y = old Z
-                nz.push(-mesh.normals[i * 3 + 1]); // New Z = -old Y
+
+                if has_normals {
+                    // Normal: Same transform as position
+                    nx.push(mesh.normals[i * 3]); // X stays the same
+                    ny.push(mesh.normals[i * 3 + 2]); // New Y = old Z
+                    nz.push(-mesh.normals[i * 3 + 1]); // New Z = -old Y
+                } else {
+                    nx.push(0.0);
+                    ny.push(0.0);
+                    nz.push(0.0);
+                }
             }
             (px, py, pz, nx, ny, nz)
         })
@@ -347,6 +368,28 @@ mod tests {
             data.len() < 10000,
             "Expected compact output, got {} bytes",
             data.len()
+        );
+    }
+
+    /// Regression test for #586: meshes with positions but no normals
+    /// (e.g. `advanced_brep.ifc`) used to panic with "index out of bounds"
+    /// inside the rayon worker, taking down the server process.
+    #[test]
+    fn test_serialize_mesh_without_normals() {
+        let meshes = vec![MeshData::new(
+            42,
+            "IfcAdvancedBrep".to_string(),
+            vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0],
+            Vec::new(), // no normals — must not panic
+            vec![0, 1, 2],
+            [0.8, 0.8, 0.8, 1.0],
+        )];
+
+        let result = serialize_to_parquet(&meshes);
+        assert!(
+            result.is_ok(),
+            "serialize_to_parquet should not panic on empty normals: {:?}",
+            result.err()
         );
     }
 }

--- a/apps/server/src/services/parquet_optimized.rs
+++ b/apps/server/src/services/parquet_optimized.rs
@@ -206,6 +206,19 @@ pub fn serialize_to_parquet_optimized(
         mesh_index_offsets.push(index_offset);
         mesh_index_counts.push(mesh.indices.len() as u32);
 
+        // Some IFC pipelines (e.g. advanced_brep) yield meshes with positions
+        // but no normals; pad with zeros so the schema's non-null columns stay valid.
+        let mesh_has_normals = mesh.normals.len() == mesh.positions.len();
+        if include_normals && !mesh_has_normals && !mesh.normals.is_empty() {
+            tracing::warn!(
+                express_id = mesh.express_id,
+                ifc_type = %mesh.ifc_type,
+                positions = mesh.positions.len(),
+                normals = mesh.normals.len(),
+                "Mesh normals length mismatch; emitting zero normals"
+            );
+        }
+
         // Quantize and store vertices with Z-up to Y-up transform
         // OPTIMIZATION: Apply coordinate transform server-side to eliminate client per-vertex loops
         // IFC uses Z-up, WebGL uses Y-up. Transform: X stays same, new Y = old Z, new Z = -old Y
@@ -215,9 +228,15 @@ pub fn serialize_to_parquet_optimized(
             vertex_z.push(quantize_position(-mesh.positions[i * 3 + 1])); // New Z = -old Y (depth)
 
             if include_normals {
-                normal_x.push(mesh.normals[i * 3]); // X stays the same
-                normal_y.push(mesh.normals[i * 3 + 2]); // New Y = old Z
-                normal_z.push(-mesh.normals[i * 3 + 1]); // New Z = -old Y
+                if mesh_has_normals {
+                    normal_x.push(mesh.normals[i * 3]); // X stays the same
+                    normal_y.push(mesh.normals[i * 3 + 2]); // New Y = old Z
+                    normal_z.push(-mesh.normals[i * 3 + 1]); // New Z = -old Y
+                } else {
+                    normal_x.push(0.0);
+                    normal_y.push(0.0);
+                    normal_z.push(0.0);
+                }
             }
         }
 
@@ -540,5 +559,23 @@ mod tests {
         assert_eq!(color_to_byte(0.0), 0);
         assert_eq!(color_to_byte(1.0), 255);
         assert_eq!(color_to_byte(0.5), 128);
+    }
+
+    /// Regression test for #586: meshes with positions but no normals
+    /// (e.g. `advanced_brep.ifc`) used to panic when `include_normals = true`.
+    #[test]
+    fn test_optimized_serialize_mesh_without_normals() {
+        let meshes = vec![MeshData::new(
+            42,
+            "IfcAdvancedBrep".to_string(),
+            vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0],
+            Vec::new(),
+            vec![0, 1, 2],
+            [0.8, 0.8, 0.8, 1.0],
+        )];
+
+        // Both code paths must survive empty normals.
+        assert!(serialize_to_parquet_optimized_with_stats(&meshes, false).is_ok());
+        assert!(serialize_to_parquet_optimized_with_stats(&meshes, true).is_ok());
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes two critical issues: (1) cache key mismatches between readers and writers causing cache lookups to always fail, and (2) server crashes when processing IFC files with meshes that have positions but no normals (e.g., `advanced_brep.ifc`).

## Key Changes

- **Cache key generation** (`parse.rs`):
  - Extracted `parquet_cache_key()` and `parquet_metadata_cache_key()` helper functions to ensure readers and writers use identical key formats
  - Updated `check_cache()` and `get_cached_geometry()` to accept `opening_filter` query parameter and include it in cache keys
  - Added regression tests verifying cache keys match the writer's format (fixes #587)

- **Mesh normal handling** (`parquet.rs` and `parquet_optimized.rs`):
  - Added validation to detect when mesh normals length doesn't match positions length
  - Pad missing normals with zeros instead of panicking on out-of-bounds access
  - Added warning logs when normals are missing to aid debugging
  - Added regression tests for both serialization paths (fixes #586)

## Implementation Details

The cache key issue occurred because `check_cache()` was generating keys like `{hash}-parquet-v2` while the writer was storing them as `{hash}-{opening_filter}-parquet-v2`. The shared helper functions now ensure both code paths produce identical keys.

For the normals issue, some IFC pipelines (like `advanced_brep`) produce valid meshes with vertex positions but empty normal arrays. Rather than crashing, the code now detects this mismatch and emits zero normals, allowing clients to recompute them from positions if needed.

https://claude.ai/code/session_01Lo4hCEpMhRVXbBMeCSG4yh