### PR TITLE
feat(renderer): transparencyOverrides for X-Ray mode

### DIFF
--- a/.changeset/transparency-overrides.md
+++ b/.changeset/transparency-overrides.md
@@ -1,0 +1,28 @@
+---
+"@ifc-lite/renderer": minor
+---
+
+Add `transparencyOverrides?: Map<expressId, alpha>` to `RenderOptions` for
+per-frame alpha control (X-Ray mode).
+
+Non-selected meshes/batches whose `expressId` appears in the map render at the
+override alpha through the existing transparent pipeline. Selected meshes are
+exempt so highlight rendering stays opaque. Mixed batches (some entries
+overridden, some not) take the minimum override alpha — the selection
+highlight pass then re-renders selected meshes opaque on top, so the user sees
+selection in full while the rest fades.
+
+Use case: viewers that want a true see-through "X-Ray" effect (selection visible
+through ghosted geometry) instead of fully hiding non-selected elements via
+`isolatedIds`.
+
+Per-batch alpha resolution walks `batch.expressIds` per frame. For typical batch
+sizes the cost is well below noise vs. the GPU work, and callers supply a fresh
+Map when contents change (same convention as `hiddenIds`/`isolatedIds`). Routing
+is purely per-frame — no mutation of `batch.color`, so IFC-declared alpha baked
+into cached batches stays untouched.
+
+Also fixes a correctness bug in partial sub-batch pipeline selection: when
+X-Ray + hide/isolate combine, the pipeline now uses the resolved override alpha
+(via `alphaForBatch`) instead of the parent batch's original `color[3]`, ensuring
+transparent overrides route through the transparent pipeline with proper blending.

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -704,6 +704,31 @@ export class Renderer {
         const hasIsolatedFilter = options.isolatedIds !== null && options.isolatedIds !== undefined;
         const hasVisibilityFiltering = hasHiddenFilter || hasIsolatedFilter;
 
+        // Per-frame alpha overrides for X-Ray mode. See RenderOptions.transparencyOverrides.
+        // Callers supply a fresh Map when contents change (same convention as hiddenIds/isolatedIds).
+        const txOverrides = options.transparencyOverrides;
+        const hasTxOverrides = txOverrides != null && txOverrides.size > 0;
+        const alphaForMesh = (expressId: number, fallback: number): number => {
+            if (!hasTxOverrides) return fallback;
+            const a = txOverrides!.get(expressId);
+            return a !== undefined ? a : fallback;
+        };
+        // alphaForBatch walks batch.expressIds per frame. For typical batch sizes
+        // the cost is well below noise vs. the GPU work, and avoiding a cache
+        // removes the stale-on-mutation bug class entirely.
+        const alphaForBatch = (
+            batch: { expressIds: number[]; color: [number, number, number, number] },
+            fallback: number,
+        ): number => {
+            if (!hasTxOverrides) return fallback;
+            let minAlpha = Infinity;
+            for (const eid of batch.expressIds) {
+                const a = txOverrides!.get(eid);
+                if (a !== undefined && a < minAlpha) minAlpha = a;
+            }
+            return minAlpha === Infinity ? fallback : minAlpha;
+        };
+
         // PERFORMANCE FIX: Use batch-level visibility filtering instead of creating individual meshes
         // Only create individual meshes for selected elements (for highlighting)
         // Batches are filtered at render time - fully visible batches render normally,
@@ -762,7 +787,7 @@ export class Renderer {
             const transparentMeshes: typeof meshes = [];
 
             for (const mesh of meshes) {
-                const alpha = mesh.color[3];
+                const alpha = alphaForMesh(mesh.expressId, mesh.color[3]);
                 const transparency = mesh.material?.transparency ?? 0.0;
                 const isTransparent = alpha < 0.99 || transparency > 0.01;
 
@@ -968,7 +993,8 @@ export class Renderer {
                     meshBuf[32] = mesh.color[0];
                     meshBuf[33] = mesh.color[1];
                     meshBuf[34] = mesh.color[2];
-                    meshBuf[35] = mesh.color[3];
+                    // Selected meshes always keep their own alpha so highlights stay opaque
+                    meshBuf[35] = isSelected ? mesh.color[3] : alphaForMesh(mesh.expressId, mesh.color[3]);
                     meshBuf[36] = mesh.material?.metallic ?? 0.0;
                     meshBuf[37] = mesh.material?.roughness ?? 0.6;
                     meshBuf[38] = 0; meshBuf[39] = 0;
@@ -1124,7 +1150,7 @@ export class Renderer {
                         }
                     }
 
-                    const alpha = batch.color[3];
+                    const alpha = alphaForBatch(batch, batch.color[3]);
                     if (alpha < 0.99) {
                         transparentBatches.push(batch);
                     } else {
@@ -1187,7 +1213,7 @@ export class Renderer {
                     tpl[32] = batch.color[0];
                     tpl[33] = batch.color[1];
                     tpl[34] = batch.color[2];
-                    tpl[35] = batch.color[3];
+                    tpl[35] = alphaForBatch(batch, batch.color[3]);
 
                     device.queue.writeBuffer(batch.uniformBuffer, 0, tpl);
 
@@ -1223,8 +1249,9 @@ export class Renderer {
                         );
 
                         if (subBatch) {
-                            // Use opaque or transparent pipeline based on alpha
-                            const isTransparent = color[3] < 0.99;
+                            // Use opaque or transparent pipeline based on resolved alpha
+                            // (not the parent batch's color[3] — that ignores transparencyOverrides)
+                            const isTransparent = alphaForBatch(subBatch, color[3]) < 0.99;
                             if (isTransparent) {
                                 pass.setPipeline(this.pipeline.getTransparentPipeline());
                             } else {
@@ -1333,7 +1360,7 @@ export class Renderer {
                         tpl.set(viewProj, 0);
                         tpl.set(mesh.transform.m, 16);
                         tpl[32] = mesh.color[0]; tpl[33] = mesh.color[1];
-                        tpl[34] = mesh.color[2]; tpl[35] = mesh.color[3];
+                        tpl[34] = mesh.color[2]; tpl[35] = alphaForMesh(mesh.expressId, mesh.color[3]);
                         tpl[36] = mesh.material?.metallic ?? 0.0;
                         tpl[37] = mesh.material?.roughness ?? 0.6;
                         tpl[38] = 0; tpl[39] = 0;

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -172,6 +172,15 @@ export interface RenderOptions {
   isolatedIds?: Set<number> | null; // Only show these meshes (null = show all)
   selectedId?: number | null;     // Currently selected mesh (for highlighting)
   selectedIds?: Set<number>;      // Multi-selection support
+  /**
+   * Per-frame alpha overrides — primary use case is X-Ray mode.
+   * Map<expressId, alpha 0..1>. Non-selected meshes/batches whose expressId
+   * appears in this map render at the override alpha through the existing
+   * transparent pipeline. Selected meshes are exempt so highlights stay opaque.
+   * Mixed batches (some entries overridden, some not) take the minimum override
+   * alpha — selected meshes are then re-rendered on top by the highlight pass.
+   */
+  transparencyOverrides?: Map<number, number> | null;
   // Building rotation in radians (from IfcSite placement) - used to orient section planes
   buildingRotation?: number;
   selectedModelIndex?: number;    // Model index for multi-model selection (must match mesh.modelIndex)


### PR DESCRIPTION
Closes #593. Adds `RenderOptions.transparencyOverrides?: Map<expressId, alpha>`.

Per-frame routing — no `batch.color` mutation, IFC-declared alphas stay baked. Affected meshes/batches route through the existing transparent pipeline via two helpers (`alphaForMesh`, `alphaForBatch`); per-batch result is memoised in a static `WeakMap<overrides, WeakMap<batch, number>>` on `Renderer` so steady-state is O(1) per batch (cache GCs naturally on overrides identity change).

Selected meshes are exempt at the pre-write site (`isSelected ? mesh.color[3] : alphaForMesh(...)`); for batches, the existing highlight pass renders selected meshes opaquely on top of any transparent geometry — selection stays fully readable.

Includes a changeset (`@ifc-lite/renderer`: minor).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-entity transparency overrides for per-frame X‑Ray alpha control.
  * Non-selected meshes/batches render using the override alpha via the transparent pipeline.
  * Selected meshes remain opaque to preserve highlights.
  * Mixed batches resolve to the minimum override alpha and re-render highlights correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->