### PR TITLE
feat(geometry): honor IfcSweptDiskSolid StartParam/EndParam

### DIFF
--- a/.changeset/swept-disk-trim-params.md
+++ b/.changeset/swept-disk-trim-params.md
@@ -1,0 +1,14 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Honor `IfcSweptDiskSolid.StartParam` / `EndParam` for `IfcCompositeCurve` and `IfcPolyline` directrices. Previously these were silently ignored, so a swept disk solid like `IFCSWEPTDISKSOLID(#dir, 0.0095, $, 0., 1.)` with a 3-segment composite-curve directrix swept the entire curve instead of just segment `[0,1]` — most visible in rebar models authored by Revit/Tekla, where bars rendered 3-5× their real length with end hooks unfolded into the bar geometry.
+
+The dispatch now honors trim parameters for the two directrix types whose IFC parameterisation is unambiguous from the entity:
+
+- `IfcCompositeCurve` (and subtypes via `is_subtype_of`): segment-index based, each segment contributes 1.0 to the parameter.
+- `IfcPolyline`: point-index based, each segment between consecutive points contributes 1.0.
+
+Boundary segments are truncated by linear interpolation along the sampled polyline (exact for piecewise-linear input). Out-of-range params clamp; inverted ranges (`StartParam ≥ EndParam`) produce empty geometry. Other directrix types (`IfcLine`, `IfcCircle`, `IfcTrimmedCurve`, `IfcBSplineCurve`) still ignore trim — their parameterisations are length / angle / knot-based and need separate handling — flagged as a known limitation.
+
+Adds 11 unit tests in `profiles::tests` covering: full-range identity, exact-half boundaries, strict-interior comparisons, two-point partial trim, fractional multi-segment trim with dedup, out-of-range clamping, inverted ranges, `SameSense=F` reverse-then-trim semantics, and direct-polyline-directrix paths.

--- a/rust/geometry/src/processors/swept.rs
+++ b/rust/geometry/src/processors/swept.rs
@@ -48,15 +48,46 @@ impl GeometryProcessor for SweptDiskSolidProcessor {
         // Get inner radius if hollow
         let _inner_radius = entity.get_float(2);
 
+        // StartParam / EndParam (optional IfcParameterValue). Per IFC spec, when the
+        // directrix is an IfcCompositeCurve the curve is parameterised so that segment
+        // index `i` covers parameter range [i, i+1]. Without honoring these, files that
+        // intend e.g. only the first segment to be swept render every segment — the
+        // common rebar case where a 2 m bar reads as 12 m with hooks unfolded.
+        let start_param = entity.get_float(3);
+        let end_param = entity.get_float(4);
+
         // Resolve the directrix curve
         let directrix = decoder
             .resolve_ref(directrix_attr)?
             .ok_or_else(|| Error::geometry("Failed to resolve Directrix".to_string()))?;
 
-        // Get points along the curve
-        let curve_points = self
-            .profile_processor
-            .get_curve_points(&directrix, decoder)?;
+        // Get points along the curve, honoring trim parameters where the directrix's
+        // parameterisation is well-defined and obvious from the entity:
+        //   - IfcCompositeCurve (and IfcCompositeCurveOnSurface): segment-index based,
+        //     each segment contributes 1.0 to the parameter.
+        //   - IfcPolyline: point-index based, each segment between consecutive points
+        //     contributes 1.0 to the parameter.
+        // Other directrix types (IfcLine, IfcCircle, IfcTrimmedCurve, IfcBSplineCurve)
+        // have length-, angle-, or knot-based parameterisations and fall back to the
+        // full sampler. Files using those with explicit StartParam/EndParam will still
+        // render the full curve — flagged as a known limitation.
+        let has_trim = start_param.is_some() || end_param.is_some();
+        let curve_points = if has_trim
+            && directrix.ifc_type.is_subtype_of(IfcType::IfcCompositeCurve)
+        {
+            self.profile_processor
+                .get_composite_curve_points_trimmed(
+                    &directrix,
+                    decoder,
+                    start_param,
+                    end_param,
+                )?
+        } else if has_trim && directrix.ifc_type == IfcType::IfcPolyline {
+            self.profile_processor
+                .get_polyline_points_trimmed(&directrix, decoder, start_param, end_param)?
+        } else {
+            self.profile_processor.get_curve_points(&directrix, decoder)?
+        };
 
         if curve_points.len() < 2 {
             return Ok(Mesh::new()); // Not enough points

--- a/rust/geometry/src/profiles.rs
+++ b/rust/geometry/src/profiles.rs
@@ -21,6 +21,47 @@ const MAX_CURVE_DEPTH: u32 = 50;
 /// Prevents stack overflow in WASM from Revit exports with deep profile nesting.
 const MAX_PROFILE_DEPTH: u32 = 16;
 
+/// Trim a sampled polyline (>=2 points) to its local parameter range
+/// `[start, end]` where each segment between consecutive points contributes
+/// `1/(n-1)` to the parameter. Returns the start interpolated point, all
+/// intermediate sampled points strictly inside the range, and the end
+/// interpolated point.
+fn trim_polyline(points: &[Point3<f64>], start: f64, end: f64) -> Vec<Point3<f64>> {
+    let n = points.len();
+    if n < 2 || end <= start {
+        return Vec::new();
+    }
+    let s = start.clamp(0.0, 1.0);
+    let e = end.clamp(0.0, 1.0);
+    let denom = (n - 1) as f64;
+    let lerp = |t: f64| -> Point3<f64> {
+        let scaled = t * denom;
+        let mut idx = scaled.floor() as usize;
+        if idx >= n - 1 {
+            return points[n - 1];
+        }
+        let frac = scaled - idx as f64;
+        let a = points[idx];
+        idx += 1;
+        let b = points[idx];
+        Point3::new(
+            a.x + (b.x - a.x) * frac,
+            a.y + (b.y - a.y) * frac,
+            a.z + (b.z - a.z) * frac,
+        )
+    };
+    let mut out = Vec::new();
+    out.push(lerp(s));
+    for (i, p) in points.iter().enumerate() {
+        let t = i as f64 / denom;
+        if t > s && t < e {
+            out.push(*p);
+        }
+    }
+    out.push(lerp(e));
+    out
+}
+
 /// Profile processor - processes IFC profiles into 2D contours
 pub struct ProfileProcessor {
     schema: IfcSchema,
@@ -1025,6 +1066,118 @@ impl ProfileProcessor {
         Ok(result)
     }
 
+    /// Process composite curve into 3D points, honoring `IfcSweptDiskSolid`'s
+    /// `StartParam`/`EndParam`. Per IFC, a composite curve is parameterised so
+    /// segment `i` covers `[i, i+1]`. Segments fully outside `[start, end]` are
+    /// dropped; boundary segments are truncated by linearly interpolating along
+    /// their sampled point list (a per-segment normalised parameter).
+    pub fn get_composite_curve_points_trimmed(
+        &self,
+        curve: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+        start_param: Option<f64>,
+        end_param: Option<f64>,
+    ) -> Result<Vec<Point3<f64>>> {
+        let segments_attr = curve
+            .get(0)
+            .ok_or_else(|| Error::geometry("CompositeCurve missing Segments".to_string()))?;
+        let segments = decoder.resolve_ref_list(segments_attr)?;
+        let num_segments = segments.len();
+        if num_segments == 0 {
+            return Ok(Vec::new());
+        }
+
+        let start = start_param.unwrap_or(0.0).max(0.0);
+        let end = end_param.unwrap_or(num_segments as f64).min(num_segments as f64);
+        if end <= start {
+            return Ok(Vec::new());
+        }
+
+        let mut result: Vec<Point3<f64>> = Vec::new();
+        for (idx, segment) in segments.into_iter().enumerate() {
+            let seg_start = idx as f64;
+            let seg_end = seg_start + 1.0;
+            // Skip segments fully outside the trim window
+            if seg_end <= start || seg_start >= end {
+                continue;
+            }
+
+            let parent_curve_attr = segment.get(2).ok_or_else(|| {
+                Error::geometry("CompositeCurveSegment missing ParentCurve".to_string())
+            })?;
+            let parent_curve = decoder
+                .resolve_ref(parent_curve_attr)?
+                .ok_or_else(|| Error::geometry("Failed to resolve ParentCurve".to_string()))?;
+            let same_sense = segment
+                .get(1)
+                .and_then(|v| match v {
+                    ifc_lite_core::AttributeValue::Enum(e) => Some(e.as_str()),
+                    _ => None,
+                })
+                .map(|e| e == "T" || e == "TRUE")
+                .unwrap_or(true);
+
+            let mut seg_points = self.get_curve_points_with_depth(&parent_curve, decoder, 1)?;
+            if !same_sense {
+                seg_points.reverse();
+            }
+            if seg_points.len() < 2 {
+                continue;
+            }
+
+            // Map global trim window to this segment's local [0,1] domain
+            let local_start = (start - seg_start).clamp(0.0, 1.0);
+            let local_end = (end - seg_start).clamp(0.0, 1.0);
+            if local_end <= local_start {
+                continue;
+            }
+
+            let trimmed = if local_start == 0.0 && local_end == 1.0 {
+                seg_points
+            } else {
+                trim_polyline(&seg_points, local_start, local_end)
+            };
+
+            if trimmed.is_empty() {
+                continue;
+            }
+            if !result.is_empty() {
+                result.extend(trimmed.into_iter().skip(1));
+            } else {
+                result.extend(trimmed);
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Sample an `IfcPolyline` directrix and trim by parameter range.
+    /// IFC parameterises a polyline as `[0, N-1]` where `N` is the number of points
+    /// and each segment between consecutive points contributes 1.0 to the parameter.
+    /// `StartParam` / `EndParam` are converted to a fraction of the polyline and
+    /// `trim_polyline` does the actual cutting (linear interpolation between sampled
+    /// vertices, which is exact for piecewise-linear input).
+    pub fn get_polyline_points_trimmed(
+        &self,
+        curve: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+        start_param: Option<f64>,
+        end_param: Option<f64>,
+    ) -> Result<Vec<Point3<f64>>> {
+        let points = self.process_polyline_3d(curve, decoder)?;
+        if points.len() < 2 {
+            return Ok(points);
+        }
+        let max_param = (points.len() - 1) as f64;
+        let s = start_param.unwrap_or(0.0).clamp(0.0, max_param);
+        let e = end_param.unwrap_or(max_param).clamp(0.0, max_param);
+        if e <= s {
+            return Ok(Vec::new());
+        }
+        // Convert IFC parameter (0..N-1) to trim_polyline's local [0,1] domain
+        Ok(trim_polyline(&points, s / max_param, e / max_param))
+    }
+
     /// Process trimmed curve
     /// IfcTrimmedCurve: BasisCurve, Trim1, Trim2, SenseAgreement, MasterRepresentation
     fn process_trimmed_curve_with_depth(
@@ -1749,5 +1902,297 @@ mod tests {
         assert!(profile.outer.contains(&Point2::new(-1.0, -2.0)));
         assert!(profile.outer.contains(&Point2::new(-1.0, 2.0)));
         assert!(profile.outer.contains(&Point2::new(1.0, 2.0)));
+    }
+
+    // ── trim_polyline / SweptDiskSolid trim-param coverage ────────────────────
+    fn approx_eq_p3(a: Point3<f64>, b: Point3<f64>, tol: f64) -> bool {
+        (a.x - b.x).abs() < tol && (a.y - b.y).abs() < tol && (a.z - b.z).abs() < tol
+    }
+
+    #[test]
+    fn test_trim_polyline_full_range() {
+        let pts = vec![
+            Point3::new(0.0, 0.0, 0.0),
+            Point3::new(1.0, 0.0, 0.0),
+            Point3::new(2.0, 0.0, 0.0),
+        ];
+        let out = trim_polyline(&pts, 0.0, 1.0);
+        assert_eq!(out.len(), 3);
+        assert!(approx_eq_p3(out[0], pts[0], 1e-9));
+        assert!(approx_eq_p3(out[1], pts[1], 1e-9));
+        assert!(approx_eq_p3(out[2], pts[2], 1e-9));
+    }
+
+    #[test]
+    fn test_trim_polyline_halves() {
+        // 3 points evenly spaced from x=0 to x=2; trim to [0, 0.5] should give x ∈ [0, 1]
+        let pts = vec![
+            Point3::new(0.0, 0.0, 0.0),
+            Point3::new(1.0, 0.0, 0.0),
+            Point3::new(2.0, 0.0, 0.0),
+        ];
+        let first_half = trim_polyline(&pts, 0.0, 0.5);
+        assert_eq!(first_half.len(), 2);
+        assert!(approx_eq_p3(first_half[0], Point3::new(0.0, 0.0, 0.0), 1e-9));
+        assert!(approx_eq_p3(first_half[1], Point3::new(1.0, 0.0, 0.0), 1e-9));
+
+        let second_half = trim_polyline(&pts, 0.5, 1.0);
+        assert_eq!(second_half.len(), 2);
+        assert!(approx_eq_p3(second_half[0], Point3::new(1.0, 0.0, 0.0), 1e-9));
+        assert!(approx_eq_p3(second_half[1], Point3::new(2.0, 0.0, 0.0), 1e-9));
+    }
+
+    #[test]
+    fn test_trim_polyline_strict_interior() {
+        // Trim [0.25, 0.75] over 5 evenly-spaced points (params 0, 0.25, 0.5, 0.75, 1)
+        // Strict interior: only points at param 0.5 are added; boundaries are lerp'd.
+        let pts: Vec<Point3<f64>> = (0..5)
+            .map(|i| Point3::new(i as f64, 0.0, 0.0))
+            .collect();
+        let out = trim_polyline(&pts, 0.25, 0.75);
+        // Expected: lerp(0.25)=x=1.0, mid=x=2.0, lerp(0.75)=x=3.0
+        assert_eq!(out.len(), 3);
+        assert!(approx_eq_p3(out[0], Point3::new(1.0, 0.0, 0.0), 1e-9));
+        assert!(approx_eq_p3(out[1], Point3::new(2.0, 0.0, 0.0), 1e-9));
+        assert!(approx_eq_p3(out[2], Point3::new(3.0, 0.0, 0.0), 1e-9));
+    }
+
+    #[test]
+    fn test_trim_polyline_invalid_range() {
+        let pts = vec![Point3::new(0.0, 0.0, 0.0), Point3::new(1.0, 0.0, 0.0)];
+        // start >= end
+        assert!(trim_polyline(&pts, 0.5, 0.5).is_empty());
+        assert!(trim_polyline(&pts, 0.6, 0.4).is_empty());
+        // too few points
+        assert!(trim_polyline(&pts[..1], 0.0, 1.0).is_empty());
+    }
+
+    #[test]
+    fn test_trim_polyline_two_points_partial() {
+        let pts = vec![Point3::new(0.0, 0.0, 0.0), Point3::new(10.0, 0.0, 0.0)];
+        let out = trim_polyline(&pts, 0.3, 0.7);
+        assert_eq!(out.len(), 2);
+        assert!(approx_eq_p3(out[0], Point3::new(3.0, 0.0, 0.0), 1e-9));
+        assert!(approx_eq_p3(out[1], Point3::new(7.0, 0.0, 0.0), 1e-9));
+    }
+
+    #[test]
+    fn test_composite_curve_trim_first_segment_only() {
+        // 3-segment composite curve along +Y, each segment 2.0 long
+        let content = r#"
+#1=IFCCARTESIANPOINT((0.0,0.0,0.0));
+#2=IFCCARTESIANPOINT((0.0,2.0,0.0));
+#3=IFCCARTESIANPOINT((0.0,4.0,0.0));
+#4=IFCCARTESIANPOINT((0.0,6.0,0.0));
+#5=IFCPOLYLINE((#1,#2));
+#6=IFCPOLYLINE((#2,#3));
+#7=IFCPOLYLINE((#3,#4));
+#8=IFCCOMPOSITECURVESEGMENT(.CONTINUOUS.,.T.,#5);
+#9=IFCCOMPOSITECURVESEGMENT(.CONTINUOUS.,.T.,#6);
+#10=IFCCOMPOSITECURVESEGMENT(.CONTINUOUS.,.T.,#7);
+#11=IFCCOMPOSITECURVE((#8,#9,#10),.F.);
+"#;
+        let mut decoder = EntityDecoder::new(content);
+        let schema = IfcSchema::new();
+        let processor = ProfileProcessor::new(schema);
+        let curve = decoder.decode_by_id(11).unwrap();
+
+        // [0,1] → first segment only → points (0,0,0) and (0,2,0)
+        let pts = processor
+            .get_composite_curve_points_trimmed(&curve, &mut decoder, Some(0.0), Some(1.0))
+            .unwrap();
+        assert_eq!(pts.len(), 2);
+        assert!(approx_eq_p3(pts[0], Point3::new(0.0, 0.0, 0.0), 1e-9));
+        assert!(approx_eq_p3(pts[1], Point3::new(0.0, 2.0, 0.0), 1e-9));
+
+        // [1,2] → middle segment only
+        let pts = processor
+            .get_composite_curve_points_trimmed(&curve, &mut decoder, Some(1.0), Some(2.0))
+            .unwrap();
+        assert_eq!(pts.len(), 2);
+        assert!(approx_eq_p3(pts[0], Point3::new(0.0, 2.0, 0.0), 1e-9));
+        assert!(approx_eq_p3(pts[1], Point3::new(0.0, 4.0, 0.0), 1e-9));
+
+        // [0,3] → all three segments concatenated (4 points after de-dup)
+        let pts = processor
+            .get_composite_curve_points_trimmed(&curve, &mut decoder, Some(0.0), Some(3.0))
+            .unwrap();
+        assert_eq!(pts.len(), 4);
+        assert!(approx_eq_p3(pts[0], Point3::new(0.0, 0.0, 0.0), 1e-9));
+        assert!(approx_eq_p3(pts[3], Point3::new(0.0, 6.0, 0.0), 1e-9));
+    }
+
+    #[test]
+    fn test_composite_curve_trim_clamps_out_of_range() {
+        let content = r#"
+#1=IFCCARTESIANPOINT((0.0,0.0,0.0));
+#2=IFCCARTESIANPOINT((0.0,2.0,0.0));
+#3=IFCPOLYLINE((#1,#2));
+#4=IFCCOMPOSITECURVESEGMENT(.CONTINUOUS.,.T.,#3);
+#5=IFCCOMPOSITECURVE((#4),.F.);
+"#;
+        let mut decoder = EntityDecoder::new(content);
+        let schema = IfcSchema::new();
+        let processor = ProfileProcessor::new(schema);
+        let curve = decoder.decode_by_id(5).unwrap();
+
+        // Negative start clamps to 0
+        let pts = processor
+            .get_composite_curve_points_trimmed(&curve, &mut decoder, Some(-5.0), Some(1.0))
+            .unwrap();
+        assert_eq!(pts.len(), 2);
+
+        // End beyond num_segments clamps to num_segments
+        let pts = processor
+            .get_composite_curve_points_trimmed(&curve, &mut decoder, Some(0.0), Some(99.0))
+            .unwrap();
+        assert_eq!(pts.len(), 2);
+
+        // start == end → empty
+        let pts = processor
+            .get_composite_curve_points_trimmed(&curve, &mut decoder, Some(0.5), Some(0.5))
+            .unwrap();
+        assert!(pts.is_empty());
+
+        // start > end → empty
+        let pts = processor
+            .get_composite_curve_points_trimmed(&curve, &mut decoder, Some(0.8), Some(0.2))
+            .unwrap();
+        assert!(pts.is_empty());
+    }
+
+    #[test]
+    fn test_composite_curve_trim_fractional_multi_segment() {
+        // 3-seg polyline along Y at 2.0 each; trim [0.5, 2.5] should yield
+        // 2nd half of seg 0 + all of seg 1 + 1st half of seg 2:
+        //   y = 1.0, 2.0, 4.0, 5.0
+        let content = r#"
+#1=IFCCARTESIANPOINT((0.0,0.0,0.0));
+#2=IFCCARTESIANPOINT((0.0,2.0,0.0));
+#3=IFCCARTESIANPOINT((0.0,4.0,0.0));
+#4=IFCCARTESIANPOINT((0.0,6.0,0.0));
+#5=IFCPOLYLINE((#1,#2));
+#6=IFCPOLYLINE((#2,#3));
+#7=IFCPOLYLINE((#3,#4));
+#8=IFCCOMPOSITECURVESEGMENT(.CONTINUOUS.,.T.,#5);
+#9=IFCCOMPOSITECURVESEGMENT(.CONTINUOUS.,.T.,#6);
+#10=IFCCOMPOSITECURVESEGMENT(.CONTINUOUS.,.T.,#7);
+#11=IFCCOMPOSITECURVE((#8,#9,#10),.F.);
+"#;
+        let mut decoder = EntityDecoder::new(content);
+        let schema = IfcSchema::new();
+        let processor = ProfileProcessor::new(schema);
+        let curve = decoder.decode_by_id(11).unwrap();
+
+        let pts = processor
+            .get_composite_curve_points_trimmed(&curve, &mut decoder, Some(0.5), Some(2.5))
+            .unwrap();
+        // Expected: lerp into seg0 at 0.5 → y=1, end of seg0/start of seg1 → y=2 (kept once),
+        // end of seg1/start of seg2 → y=4 (kept once), lerp into seg2 at 0.5 → y=5
+        let ys: Vec<f64> = pts.iter().map(|p| p.y).collect();
+        assert_eq!(ys.len(), 4, "got points: {:?}", pts);
+        assert!((ys[0] - 1.0).abs() < 1e-9);
+        assert!((ys[1] - 2.0).abs() < 1e-9);
+        assert!((ys[2] - 4.0).abs() < 1e-9);
+        assert!((ys[3] - 5.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_polyline_trim_first_segment() {
+        // 4-point polyline along Y: (0,0,0)→(0,2,0)→(0,4,0)→(0,6,0)
+        // Parameter range is [0, 3]. Trim [0,1] = first segment only.
+        let content = r#"
+#1=IFCCARTESIANPOINT((0.0,0.0,0.0));
+#2=IFCCARTESIANPOINT((0.0,2.0,0.0));
+#3=IFCCARTESIANPOINT((0.0,4.0,0.0));
+#4=IFCCARTESIANPOINT((0.0,6.0,0.0));
+#5=IFCPOLYLINE((#1,#2,#3,#4));
+"#;
+        let mut decoder = EntityDecoder::new(content);
+        let schema = IfcSchema::new();
+        let processor = ProfileProcessor::new(schema);
+        let curve = decoder.decode_by_id(5).unwrap();
+
+        let pts = processor
+            .get_polyline_points_trimmed(&curve, &mut decoder, Some(0.0), Some(1.0))
+            .unwrap();
+        assert_eq!(pts.len(), 2);
+        assert!(approx_eq_p3(pts[0], Point3::new(0.0, 0.0, 0.0), 1e-9));
+        assert!(approx_eq_p3(pts[1], Point3::new(0.0, 2.0, 0.0), 1e-9));
+
+        // Trim [1, 2] = middle segment
+        let pts = processor
+            .get_polyline_points_trimmed(&curve, &mut decoder, Some(1.0), Some(2.0))
+            .unwrap();
+        assert_eq!(pts.len(), 2);
+        assert!(approx_eq_p3(pts[0], Point3::new(0.0, 2.0, 0.0), 1e-9));
+        assert!(approx_eq_p3(pts[1], Point3::new(0.0, 4.0, 0.0), 1e-9));
+
+        // Trim [0.5, 2.5] = half + full + half across 3 segments
+        let pts = processor
+            .get_polyline_points_trimmed(&curve, &mut decoder, Some(0.5), Some(2.5))
+            .unwrap();
+        let ys: Vec<f64> = pts.iter().map(|p| p.y).collect();
+        assert_eq!(ys.len(), 4, "got points: {:?}", pts);
+        assert!((ys[0] - 1.0).abs() < 1e-9);
+        assert!((ys[1] - 2.0).abs() < 1e-9);
+        assert!((ys[2] - 4.0).abs() < 1e-9);
+        assert!((ys[3] - 5.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_polyline_trim_clamps_and_inverts() {
+        let content = r#"
+#1=IFCCARTESIANPOINT((0.0,0.0,0.0));
+#2=IFCCARTESIANPOINT((0.0,2.0,0.0));
+#3=IFCPOLYLINE((#1,#2));
+"#;
+        let mut decoder = EntityDecoder::new(content);
+        let schema = IfcSchema::new();
+        let processor = ProfileProcessor::new(schema);
+        let curve = decoder.decode_by_id(3).unwrap();
+
+        // No params → full polyline
+        let pts = processor
+            .get_polyline_points_trimmed(&curve, &mut decoder, None, None)
+            .unwrap();
+        assert_eq!(pts.len(), 2);
+
+        // Inverted → empty
+        let pts = processor
+            .get_polyline_points_trimmed(&curve, &mut decoder, Some(0.8), Some(0.2))
+            .unwrap();
+        assert!(pts.is_empty());
+
+        // Out-of-range clamps
+        let pts = processor
+            .get_polyline_points_trimmed(&curve, &mut decoder, Some(-5.0), Some(99.0))
+            .unwrap();
+        assert_eq!(pts.len(), 2);
+    }
+
+    #[test]
+    fn test_composite_curve_trim_same_sense_false() {
+        // Single segment with SameSense=F should reverse before trim.
+        // Polyline (0,0,0)→(0,10,0) reversed = (0,10,0)→(0,0,0).
+        // Trim [0, 0.3] of reversed → first 30% of reversed → from y=10 to y=7.
+        let content = r#"
+#1=IFCCARTESIANPOINT((0.0,0.0,0.0));
+#2=IFCCARTESIANPOINT((0.0,10.0,0.0));
+#3=IFCPOLYLINE((#1,#2));
+#4=IFCCOMPOSITECURVESEGMENT(.CONTINUOUS.,.F.,#3);
+#5=IFCCOMPOSITECURVE((#4),.F.);
+"#;
+        let mut decoder = EntityDecoder::new(content);
+        let schema = IfcSchema::new();
+        let processor = ProfileProcessor::new(schema);
+        let curve = decoder.decode_by_id(5).unwrap();
+
+        let pts = processor
+            .get_composite_curve_points_trimmed(&curve, &mut decoder, Some(0.0), Some(0.3))
+            .unwrap();
+        assert_eq!(pts.len(), 2);
+        assert!(approx_eq_p3(pts[0], Point3::new(0.0, 10.0, 0.0), 1e-9));
+        assert!(approx_eq_p3(pts[1], Point3::new(0.0, 7.0, 0.0), 1e-9));
     }
 }


### PR DESCRIPTION
The swept-disk solid processor reads `Radius` but ignores `StartParam` and `EndParam`. Files where the directrix is an `IfcCompositeCurve` or `IfcPolyline` and the trim params restrict the sweep render the entire curve instead — most visible in rebar models from Revit/Tekla, where a 2 m bar declared as `IFCSWEPTDISKSOLID(#dir, r, $, 0., 1.)` over a 3-segment composite curve renders as 12 m with all the end-hooks unfolded into the bar geometry.

## What changes

Dispatch in `SweptDiskSolidProcessor::process` now honors trim parameters for the two directrix types whose IFC parameterisation is unambiguous from the entity:

- `IfcCompositeCurve` (and subtypes via `is_subtype_of`) — segment-index based, each segment contributes 1.0 to the parameter. New `ProfileProcessor::get_composite_curve_points_trimmed` walks segments, drops those fully outside `[start, end]`, and lerps boundary segments.
- `IfcPolyline` — point-index based, each segment between consecutive points contributes 1.0. New `ProfileProcessor::get_polyline_points_trimmed` converts to a `[0, 1]` fraction and reuses `trim_polyline`.

Boundary segments are truncated by linear interpolation along the sampled polyline — exact for piecewise-linear input. Out-of-range params clamp; inverted (\`start ≥ end\`) ranges return an empty mesh.

## Tests

11 new unit tests in \`profiles::tests\` (\`test_trim_polyline_*\`, \`test_composite_curve_trim_*\`, \`test_polyline_trim_*\`) cover full-range identity, exact-half boundaries, strict-interior comparisons, two-point partial trim, fractional multi-segment trim with dedup, out-of-range clamping, inverted ranges, \`SameSense=F\` reverse-then-trim semantics, and direct-polyline-directrix paths.

End-to-end validated against a 22-bar IFC fixture covering each branch (happy to share if helpful).

## Known limitations

- **Other directrix types still ignore trim.** \`IfcLine\`, \`IfcCircle\`, \`IfcEllipse\`, \`IfcTrimmedCurve\`, \`IfcBSplineCurve\` parameterisations are length / angle / knot-based and need their own handling. Rare in practice for swept-disk-solid directrices but worth flagging.
- **Fractional lerp uses uniform-vertex parameter, not arc-length.** Accurate for piecewise-linear segments (the rebar case). For curved parents (e.g. partial-arc \`IfcCircle\` in a composite curve), it's an approximation.
- **\`SweptDiskSolid.InnerRadius\` is still ignored** — pre-existing, separate concern.

## Unrelated bug spotted while testing

The cross-section frame in \`SweptDiskSolidProcessor::process\` re-picks \`up\` per cross-section based on \`tangent.x.abs() < 0.9\`, which causes the perpendicular frame to flip at sharp bends (visible as a twisted / flat-ribbon tube where two cross-sections cross the threshold). Out of scope here — happy to follow up with a parallel-transport / rotation-minimising-frame fix in a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed trim parameter handling in swept disk solid geometry for composite curves and polylines; parameters are now properly applied with linear interpolation and correct boundary clamping.

* **Tests**
  * Added 11 comprehensive unit tests covering trim parameter edge cases, boundary conditions, interior trimming, clamping behavior, and various directrix types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->