### PR TITLE
Performance: Add memoization and indexing to hot paths

### DIFF
--- a/apps/viewer/src/components/viewer/tools/AddElementOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/AddElementOverlay.tsx
@@ -51,14 +51,54 @@ export function AddElementOverlay() {
   // hover points each frame. The tick state is just a number that
   // forces a re-render; the projection itself is read fresh from the
   // store callback.
+  //
+  // Two perf gates:
+  //  1. Skip the loop entirely when there's nothing to project.
+  //     pendingPoints / hoverPoint / autoSpacePreview already trigger
+  //     React re-renders via the store, so the only reason we'd need
+  //     a per-frame tick is to track the camera while content exists.
+  //  2. Only re-render when the camera actually moved since last tick.
+  //     A held tool with a static camera does ~0 work.
+  const getViewpoint = useViewerStore((s) => s.cameraCallbacks.getViewpoint);
+  const hasOverlayContent =
+    pendingPoints.length > 0 ||
+    hoverPoint !== null ||
+    (autoSpacePreview != null && autoSpacePreview.outlines.length > 0);
   const [frameTick, setFrameTick] = useState(0);
   const rafRef = useRef<number | null>(null);
+  const lastViewpointRef = useRef<{
+    px: number; py: number; pz: number;
+    tx: number; ty: number; tz: number;
+    fov: number;
+  } | null>(null);
   useEffect(() => {
     if (activeTool !== 'addElement') return;
+    if (!hasOverlayContent) return;
     let mounted = true;
     const loop = () => {
       if (!mounted) return;
-      setFrameTick((t) => (t + 1) & 0xffff);
+      const vp = getViewpoint?.();
+      if (vp) {
+        const last = lastViewpointRef.current;
+        const moved =
+          !last ||
+          last.px !== vp.position.x || last.py !== vp.position.y || last.pz !== vp.position.z ||
+          last.tx !== vp.target.x  || last.ty !== vp.target.y  || last.tz !== vp.target.z  ||
+          last.fov !== vp.fov;
+        if (moved) {
+          lastViewpointRef.current = {
+            px: vp.position.x, py: vp.position.y, pz: vp.position.z,
+            tx: vp.target.x,   ty: vp.target.y,   tz: vp.target.z,
+            fov: vp.fov,
+          };
+          setFrameTick((t) => (t + 1) & 0xffff);
+        }
+      } else {
+        // Fallback for environments without getViewpoint — preserves the
+        // pre-fix behaviour of an unconditional tick so the projection
+        // can't get stuck stale.
+        setFrameTick((t) => (t + 1) & 0xffff);
+      }
       rafRef.current = requestAnimationFrame(loop);
     };
     rafRef.current = requestAnimationFrame(loop);
@@ -66,8 +106,9 @@ export function AddElementOverlay() {
       mounted = false;
       if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
       rafRef.current = null;
+      lastViewpointRef.current = null;
     };
-  }, [activeTool]);
+  }, [activeTool, hasOverlayContent, getViewpoint]);
 
   const projection = useMemo(
     () => makeProjection(projectToScreen),

--- a/packages/create/src/in-store/auto-space-detect.ts
+++ b/packages/create/src/in-store/auto-space-detect.ts
@@ -130,15 +130,35 @@ export function detectEnclosedAreasWithStats(
   }
 
   // ── 1. Snap endpoints ──
+  // Spatial hash keyed on a snap-sized grid so endpoint resolution stays
+  // O(1) average instead of O(N) linear scans. We probe the cell + its 8
+  // neighbours so a query point near a cell boundary still finds matches
+  // on the other side.
   const vertices: Vertex[] = [];
+  const cellSize = Math.max(snap, EPS);
+  const grid = new Map<string, number[]>();
+  const cellKey = (cx: number, cy: number): string => `${cx},${cy}`;
   const lookup = (pt: Vec2): number => {
-    for (const v of vertices) {
-      const dx = v.pt[0] - pt[0];
-      const dy = v.pt[1] - pt[1];
-      if (dx * dx + dy * dy <= snap * snap) return v.id;
+    const snapSq2 = snap * snap;
+    const cx = Math.floor(pt[0] / cellSize);
+    const cy = Math.floor(pt[1] / cellSize);
+    for (let dx = -1; dx <= 1; dx++) {
+      for (let dy = -1; dy <= 1; dy++) {
+        const bucket = grid.get(cellKey(cx + dx, cy + dy));
+        if (!bucket) continue;
+        for (const id of bucket) {
+          const ddx = vertices[id].pt[0] - pt[0];
+          const ddy = vertices[id].pt[1] - pt[1];
+          if (ddx * ddx + ddy * ddy <= snapSq2) return id;
+        }
+      }
     }
     const id = vertices.length;
     vertices.push({ id, pt: [pt[0], pt[1]] });
+    const key = cellKey(cx, cy);
+    const bucket = grid.get(key);
+    if (bucket) bucket.push(id);
+    else grid.set(key, [id]);
     return id;
   };
 
@@ -203,54 +223,74 @@ export function detectEnclosedAreasWithStats(
   } while (tjunctionsApplied && tjunctionPasses < Math.max(50, indexedSegs.length * 5));
   log(`T-junction snap: ${tjunctionPasses} pass(es)`);
 
-  const maxIterations = Math.max(100, indexedSegs.length * 10);
-  let changed = true;
-  let guard = 0;
-  while (changed && guard < maxIterations) {
-    changed = false;
-    guard++;
-    outer: for (let i = 0; i < splitSegs.length; i++) {
-      for (let j = i + 1; j < splitSegs.length; j++) {
-        const [ai, bi] = splitSegs[i];
-        const [aj, bj] = splitSegs[j];
-        if (ai === aj || ai === bj || bi === aj || bi === bj) continue;
-        const ip = segmentIntersection(
-          vertices[ai].pt, vertices[bi].pt,
-          vertices[aj].pt, vertices[bj].pt,
-        );
-        if (!ip) continue;
-        const newIdx = lookup(ip);
-        if (newIdx === ai || newIdx === bi || newIdx === aj || newIdx === bj) {
-          // Intersection coincides with an existing vertex — split
-          // only the segments that don't already touch it.
-          if (newIdx !== ai && newIdx !== bi) {
-            splitSegs[i] = [ai, newIdx];
-            splitSegs.push([newIdx, bi]);
-            changed = true;
-          }
-          if (newIdx !== aj && newIdx !== bj) {
-            splitSegs[j] = [aj, newIdx];
-            splitSegs.push([newIdx, bj]);
-            changed = true;
-          }
-          if (changed) break outer;
-        } else {
-          // Genuine T or X crossing.
-          splitSegs[i] = [ai, newIdx];
-          splitSegs.push([newIdx, bi]);
-          splitSegs[j] = [aj, newIdx];
-          splitSegs.push([newIdx, bj]);
-          changed = true;
-          break outer;
-        }
-      }
+  // Collect every interior crossing in a single O(N²) pass, recording
+  // the parametric position along each host segment, then split each
+  // segment at all of its collected crossings in one go. Splits don't
+  // alter geometry — they only subdivide — so further passes are
+  // unnecessary. Replaces the previous "split one pair, restart the
+  // whole scan" loop, which was O(N³) on dense wall sets.
+  //
+  // For each original segment we keep a sorted list of (t, vertexId).
+  // Endpoints (t=0 and t=1) are the existing endpoint vertex ids.
+  const seedSegs = splitSegs.slice();
+  const segSplits: Array<Array<{ t: number; v: number }>> = seedSegs.map(([a, b]) => [
+    { t: 0, v: a },
+    { t: 1, v: b },
+  ]);
+
+  // Optional bbox-based pruning: skip pair checks whose AABBs miss.
+  // Keep simple — cost is dominated by segmentIntersection which already
+  // returns null for non-crossings; the bbox pre-check is just to avoid
+  // the math in the easy 90% case.
+  const segBBoxes = seedSegs.map(([a, b]) => {
+    const ax = vertices[a].pt[0], ay = vertices[a].pt[1];
+    const bx = vertices[b].pt[0], by = vertices[b].pt[1];
+    return {
+      minX: Math.min(ax, bx),
+      maxX: Math.max(ax, bx),
+      minY: Math.min(ay, by),
+      maxY: Math.max(ay, by),
+    };
+  });
+
+  for (let i = 0; i < seedSegs.length; i++) {
+    const [ai, bi] = seedSegs[i];
+    const bi_box = segBBoxes[i];
+    for (let j = i + 1; j < seedSegs.length; j++) {
+      const [aj, bj] = seedSegs[j];
+      if (ai === aj || ai === bj || bi === aj || bi === bj) continue;
+      const bj_box = segBBoxes[j];
+      if (
+        bi_box.maxX < bj_box.minX || bj_box.maxX < bi_box.minX ||
+        bi_box.maxY < bj_box.minY || bj_box.maxY < bi_box.minY
+      ) continue;
+
+      const ip = segmentIntersectionParam(
+        vertices[ai].pt, vertices[bi].pt,
+        vertices[aj].pt, vertices[bj].pt,
+      );
+      if (!ip) continue;
+      const newIdx = lookup(ip.point);
+      const isI_endpoint = newIdx === ai || newIdx === bi;
+      const isJ_endpoint = newIdx === aj || newIdx === bj;
+      if (!isI_endpoint) segSplits[i].push({ t: ip.t, v: newIdx });
+      if (!isJ_endpoint) segSplits[j].push({ t: ip.u, v: newIdx });
     }
   }
 
-  if (changed && guard >= maxIterations) {
-    // Iteration cap hit before the splitter converged — detection
-    // results may be incomplete, but emit them rather than failing.
-    log(`intersection splitter hit iteration cap ${maxIterations}; results may be incomplete`);
+  splitSegs.length = 0;
+  for (const splits of segSplits) {
+    if (splits.length <= 2) {
+      // No interior crossings — keep the segment as-is.
+      splitSegs.push([splits[0].v, splits[1].v]);
+      continue;
+    }
+    splits.sort((a, b) => a.t - b.t);
+    for (let k = 0; k < splits.length - 1; k++) {
+      const a = splits[k].v;
+      const b = splits[k + 1].v;
+      if (a !== b) splitSegs.push([a, b]);
+    }
   }
 
   // Deduplicate (a, b) and (b, a) pairs.
@@ -419,14 +459,14 @@ function closestPointOnSegment(
 
 /**
  * Proper-segment intersection test in 2D. Returns the crossing point
- * when the segments cross strictly inside both (excluding shared
- * endpoints at parameter 0 or 1, which produce no new vertex). Uses
- * a small parametric tolerance so two near-coincident endpoints
- * don't register as a fresh interior crossing.
+ * plus the parametric positions on both segments when they cross
+ * inside both (excluding shared endpoints at parameter 0 or 1, which
+ * produce no new vertex). Uses a small parametric tolerance so two
+ * near-coincident endpoints don't register as a fresh interior crossing.
  */
-function segmentIntersection(
+function segmentIntersectionParam(
   p1: Vec2, p2: Vec2, p3: Vec2, p4: Vec2,
-): Vec2 | null {
+): { point: Vec2; t: number; u: number } | null {
   const x1 = p1[0], y1 = p1[1];
   const x2 = p2[0], y2 = p2[1];
   const x3 = p3[0], y3 = p3[1];
@@ -442,5 +482,5 @@ function segmentIntersection(
   if (t < -tol || t > 1 + tol) return null;
   if (u < -tol || u > 1 + tol) return null;
   if ((t < tol || t > 1 - tol) && (u < tol || u > 1 - tol)) return null;
-  return [x1 + t * (x2 - x1), y1 + t * (y2 - y1)];
+  return { point: [x1 + t * (x2 - x1), y1 + t * (y2 - y1)], t, u };
 }

--- a/packages/create/src/in-store/extract-walls.ts
+++ b/packages/create/src/in-store/extract-walls.ts
@@ -155,7 +155,7 @@ export function extractWallSegmentsForStorey(
   }
 
   const extractor = new EntityExtractor(store.source);
-  const dividerIds = collectDividerIdsOnStorey(store, storeyExpressId, dividerTypes, log);
+  const dividerIds = collectDividerIdsOnStorey(store, extractor, storeyExpressId, dividerTypes, log);
   log(`storey #${storeyExpressId}: ${dividerIds.length} contained divider element(s)`);
 
   for (const id of dividerIds) {
@@ -223,6 +223,7 @@ type Logger = (...args: unknown[]) => void;
 
 function collectDividerIdsOnStorey(
   store: IfcDataStore,
+  extractor: EntityExtractor,
   storeyId: number,
   dividerTypes: Set<string>,
   log: Logger,
@@ -230,7 +231,18 @@ function collectDividerIdsOnStorey(
   const ids: number[] = [];
   const seen = new Set<number>();
   if (!store.source) return ids;
-  const extractor = new EntityExtractor(store.source);
+
+  // Build relating → related-children indices ONCE, then walk in O(1) per
+  // parent. Previously each `descendAggregate` / `walkContainmentInto`
+  // call walked every IfcRelAggregates / IfcRelContainedInSpatialStructure
+  // entity in the file looking for one with the right relating id —
+  // O(R·N) total in the number of rels and parents visited.
+  const aggregateChildren = buildRelatingChildrenIndex(
+    store, extractor, 'IFCRELAGGREGATES', 4, 5,
+  );
+  const containmentChildren = buildRelatingChildrenIndex(
+    store, extractor, 'IFCRELCONTAINEDINSPATIALSTRUCTURE', 5, 4,
+  );
 
   const visitMember = (memberId: number) => {
     if (seen.has(memberId)) return;
@@ -252,69 +264,63 @@ function collectDividerIdsOnStorey(
     seen.add(parentId);
     // Anything `IfcRelContainedInSpatialStructure`-anchored to this
     // sub-structure should still be reachable.
-    walkContainmentInto(parentId);
+    const contained = containmentChildren.get(parentId);
+    if (contained) for (const m of contained) visitMember(m);
     // And recurse through aggregation.
-    const aggRels = store.entityIndex.byType.get('IFCRELAGGREGATES') ?? [];
-    for (const relId of aggRels) {
-      const ref = store.entityIndex.byId.get(relId);
-      if (!ref) continue;
-      const rel = extractor.extractEntity(ref);
-      if (!rel) continue;
-      const relating = rel.attributes[4];
-      if (typeof relating !== 'number' || relating !== parentId) continue;
-      const related = rel.attributes[5];
-      if (!Array.isArray(related)) continue;
-      for (const child of related) {
-        if (typeof child !== 'number') continue;
-        visitMember(child);
-      }
-    }
-  };
-
-  const walkContainmentInto = (parentId: number) => {
-    const containedRels = store.entityIndex.byType.get('IFCRELCONTAINEDINSPATIALSTRUCTURE') ?? [];
-    for (const relId of containedRels) {
-      const ref = store.entityIndex.byId.get(relId);
-      if (!ref) continue;
-      const rel = extractor.extractEntity(ref);
-      if (!rel) continue;
-      const relating = rel.attributes[5];
-      if (typeof relating !== 'number' || relating !== parentId) continue;
-      const related = rel.attributes[4];
-      if (!Array.isArray(related)) continue;
-      for (const member of related) {
-        if (typeof member !== 'number') continue;
-        visitMember(member);
-      }
-    }
+    const agg = aggregateChildren.get(parentId);
+    if (agg) for (const c of agg) visitMember(c);
   };
 
   // Mark the storey itself as seen but DON'T push it (we want its
   // children, not the storey id).
   seen.add(storeyId);
-  walkContainmentInto(storeyId);
+  const storeyContained = containmentChildren.get(storeyId);
+  if (storeyContained) for (const m of storeyContained) visitMember(m);
 
   // Some authoring tools attach elements via IfcRelAggregates to the
   // storey instead of containment (or in addition). Walk both
   // unconditionally to keep coverage broad.
-  const aggRels = store.entityIndex.byType.get('IFCRELAGGREGATES') ?? [];
-  for (const relId of aggRels) {
+  const storeyAgg = aggregateChildren.get(storeyId);
+  if (storeyAgg) for (const c of storeyAgg) visitMember(c);
+
+  log(`collected ${ids.length} divider candidate(s) — types: ${[...dividerTypes].join(', ')}`);
+  return ids;
+}
+
+/**
+ * Index every relationship of `relType` by its "relating" attribute, so a
+ * lookup of "what's anchored to id X" becomes O(1) instead of an O(R)
+ * scan of every relationship.
+ */
+function buildRelatingChildrenIndex(
+  store: IfcDataStore,
+  extractor: EntityExtractor,
+  relType: string,
+  relatingIdx: number,
+  relatedIdx: number,
+): Map<number, number[]> {
+  const out = new Map<number, number[]>();
+  const relIds = store.entityIndex.byType.get(relType);
+  if (!relIds) return out;
+  for (const relId of relIds) {
     const ref = store.entityIndex.byId.get(relId);
     if (!ref) continue;
     const rel = extractor.extractEntity(ref);
     if (!rel) continue;
-    const relating = rel.attributes[4];
-    if (typeof relating !== 'number' || relating !== storeyId) continue;
-    const related = rel.attributes[5];
+    const relating = rel.attributes[relatingIdx];
+    if (typeof relating !== 'number') continue;
+    const related = rel.attributes[relatedIdx];
     if (!Array.isArray(related)) continue;
+    let bucket = out.get(relating);
+    if (!bucket) {
+      bucket = [];
+      out.set(relating, bucket);
+    }
     for (const child of related) {
-      if (typeof child !== 'number') continue;
-      visitMember(child);
+      if (typeof child === 'number') bucket.push(child);
     }
   }
-
-  log(`collected ${ids.length} divider candidate(s) — types: ${[...dividerTypes].join(', ')}`);
-  return ids;
+  return out;
 }
 
 interface ExtractAttempt {

--- a/packages/create/src/in-store/wall.ts
+++ b/packages/create/src/in-store/wall.ts
@@ -61,14 +61,16 @@ export function addWallToStore(
   const dx = params.End[0] - params.Start[0];
   const dy = params.End[1] - params.Start[1];
   const dz = params.End[2] - params.Start[2];
-  // Walls are extruded along the placement +Z axis (storey up). Sloped
-  // endpoints would silently emit invalid geometry, so reject them.
-  if (Math.abs(dz) > 1e-9) {
-    throw new Error('addWallToStore: Start and End must lie on the same storey plane (Z must match)');
-  }
   const wallLen = Math.hypot(dx, dy);
   if (wallLen <= 0) {
     throw new Error('addWallToStore: Start and End must be distinct points');
+  }
+  // Walls are extruded along the placement +Z axis (storey up). Sloped
+  // endpoints would silently emit invalid geometry, so reject them.
+  // Use a length-relative epsilon so float-derived noise on nominally
+  // flat coordinates doesn't trip the guard for long walls.
+  if (Math.abs(dz) > Math.max(1e-6 * wallLen, 1e-9)) {
+    throw new Error('addWallToStore: Start and End must lie on the same storey plane (Z must match)');
   }
   const dir: Point3D = vecNorm([dx, dy, 0]);
 

--- a/packages/export/src/step-exporter.ts
+++ b/packages/export/src/step-exporter.ts
@@ -218,6 +218,13 @@ export class StepExporter {
         targetMap.get(mutation.entityId)!.add(mutation.psetName);
       }
 
+      // Build a reverse index of IfcRelDefinesByProperties → (relId, psetId)
+      // pairs keyed on each related entity. The two property/quantity loops
+      // below previously walked every entity in `entityIndex.byId` per
+      // modified entity (O(E·N)); the index keeps the per-entity step
+      // O(K) where K is the number of rels referencing that entity.
+      const relDefinesByEntity = this.buildRelDefinesByPropertiesIndex();
+
       // Collect modified property sets and find original psets to skip
       for (const [entityId, psetNames] of entityPropMutations) {
         modifiedEntities.add(entityId);
@@ -233,29 +240,23 @@ export class StepExporter {
           newPropertySets.push({ entityId, psets: relevantPsets });
         }
 
-        // Find original property set IDs and relationship IDs to skip
-        // Look for IfcRelDefinesByProperties that reference this entity
-        for (const [relId, relRef] of this.dataStore.entityIndex.byId) {
-          const relType = relRef.type.toUpperCase();
-          if (relType === 'IFCRELDEFINESBYPROPERTIES') {
-            // Parse the relationship to check if it references our entity
-            const relatedEntities = this.getRelatedEntities(relId);
-            const relatedPsetId = this.getRelatedPropertySet(relId);
-
-            if (relatedEntities.includes(entityId) && relatedPsetId) {
-              // Check if this pset is one we're modifying
-              const psetName = this.getPropertySetName(relatedPsetId);
-              if (psetName) {
-                relDefinedPsetNames.add(psetName);
-              }
-              if (psetName && psetNames.has(psetName)) {
-                skipRelationshipIds.add(relId);
-                skipPropertySetIds.add(relatedPsetId);
-                // Also skip the individual properties in this pset
-                const propIds = this.getPropertyIdsInSet(relatedPsetId);
-                for (const propId of propIds) {
-                  skipPropertySetIds.add(propId);
-                }
+        // Find original property set IDs and relationship IDs to skip — look
+        // up only the IfcRelDefinesByProperties rels that reference this entity.
+        const rels = relDefinesByEntity.get(entityId);
+        if (rels) {
+          for (const { relId, psetId: relatedPsetId } of rels) {
+            // Check if this pset is one we're modifying
+            const psetName = this.getPropertySetName(relatedPsetId);
+            if (psetName) {
+              relDefinedPsetNames.add(psetName);
+            }
+            if (psetName && psetNames.has(psetName)) {
+              skipRelationshipIds.add(relId);
+              skipPropertySetIds.add(relatedPsetId);
+              // Also skip the individual properties in this pset
+              const propIds = this.getPropertyIdsInSet(relatedPsetId);
+              for (const propId of propIds) {
+                skipPropertySetIds.add(propId);
               }
             }
           }
@@ -303,22 +304,18 @@ export class StepExporter {
           newQuantitySets.push({ entityId, qsets: relevantQsets });
         }
 
-        // Skip original quantity set entities (IfcElementQuantity)
-        for (const [relId, relRef] of this.dataStore.entityIndex.byId) {
-          const relType = relRef.type.toUpperCase();
-          if (relType === 'IFCRELDEFINESBYPROPERTIES') {
-            const relatedEntities = this.getRelatedEntities(relId);
-            const relatedPsetId = this.getRelatedPropertySet(relId);
-
-            if (relatedEntities.includes(entityId) && relatedPsetId) {
-              const qsetName = this.getElementQuantityName(relatedPsetId);
-              if (qsetName && qsetNames.has(qsetName)) {
-                skipRelationshipIds.add(relId);
-                skipPropertySetIds.add(relatedPsetId);
-                const quantIds = this.getPropertyIdsInSet(relatedPsetId);
-                for (const quantId of quantIds) {
-                  skipPropertySetIds.add(quantId);
-                }
+        // Skip original quantity set entities (IfcElementQuantity).
+        // Same per-entity index lookup as the property branch above.
+        const rels = relDefinesByEntity.get(entityId);
+        if (rels) {
+          for (const { relId, psetId: relatedPsetId } of rels) {
+            const qsetName = this.getElementQuantityName(relatedPsetId);
+            if (qsetName && qsetNames.has(qsetName)) {
+              skipRelationshipIds.add(relId);
+              skipPropertySetIds.add(relatedPsetId);
+              const quantIds = this.getPropertyIdsInSet(relatedPsetId);
+              for (const quantId of quantIds) {
+                skipPropertySetIds.add(quantId);
               }
             }
           }
@@ -1047,6 +1044,30 @@ export class StepExporter {
       'IFCCOLOURRGB',
     ]);
     return geometryTypes.has(type);
+  }
+
+  /**
+   * Build a one-shot reverse index of every IfcRelDefinesByProperties in
+   * the source: for each related entity, list the rels and property/quantity
+   * sets that reference it. Used by the export pre-pass so the per-entity
+   * "find owning rels" step is O(K) rather than O(N) per modified entity.
+   */
+  private buildRelDefinesByPropertiesIndex(): Map<number, Array<{ relId: number; psetId: number }>> {
+    const out = new Map<number, Array<{ relId: number; psetId: number }>>();
+    for (const [relId, relRef] of this.dataStore.entityIndex.byId) {
+      if (relRef.type.toUpperCase() !== 'IFCRELDEFINESBYPROPERTIES') continue;
+      const psetId = this.getRelatedPropertySet(relId);
+      if (!psetId) continue;
+      for (const entityId of this.getRelatedEntities(relId)) {
+        let bucket = out.get(entityId);
+        if (!bucket) {
+          bucket = [];
+          out.set(entityId, bucket);
+        }
+        bucket.push({ relId, psetId });
+      }
+    }
+    return out;
   }
 
   /**

--- a/packages/export/src/step-serialization.ts
+++ b/packages/export/src/step-serialization.ts
@@ -215,7 +215,13 @@ export function splitTopLevelArgs(text: string): string[] {
     }
   }
 
-  if (current.trim() || text.endsWith(',')) {
+  // Trailing tokens: only push if there's actual content. The previous
+  // `text.endsWith(',')` check pushed an empty trailing token for inputs
+  // like `"a,"`, producing `['a', '']` — STEP doesn't allow trailing
+  // commas, so the right answer is just `['a']`. Empty interior args
+  // (e.g. `"a,,b"` → `['a', '', 'b']`) are still produced because the
+  // comma branch above handles them.
+  if (current.trim()) {
     parts.push(current.trim());
   }
 

--- a/packages/mutations/src/mutable-property-view.ts
+++ b/packages/mutations/src/mutable-property-view.ts
@@ -38,6 +38,15 @@ export class MutablePropertyView {
   private quantityExtractor: QuantityExtractor | null = null;
   private propertyMutations: Map<string, PropertyMutation> = new Map();
   private quantityMutations: Map<string, QuantityMutation> = new Map();
+  /**
+   * Secondary indices: entityId → mutation keys for that entity.
+   *
+   * `getForEntity` previously iterated the entire `propertyMutations` /
+   * `quantityMutations` map per pset to find newly-added properties — O(M·P)
+   * per call. These indices keep that step O(M_entity) instead.
+   */
+  private propertyKeysByEntity: Map<number, Set<string>> = new Map();
+  private quantityKeysByEntity: Map<number, Set<string>> = new Map();
   private deletedPsets: Set<string> = new Set(); // `${entityId}:${psetName}`
   private deletedQsets: Set<string> = new Set(); // `${entityId}:${qsetName}`
   private newPsets: Map<number, Map<string, PropertySet>> = new Map(); // entityId -> psetName -> PropertySet
@@ -87,6 +96,50 @@ export class MutablePropertyView {
   /** The next expressId that `createEntity` would allocate. */
   peekNextExpressId(): number {
     return this.nextAllocatedId + 1;
+  }
+
+  private setPropertyMutation(entityId: number, key: string, mutation: PropertyMutation): void {
+    this.propertyMutations.set(key, mutation);
+    let bucket = this.propertyKeysByEntity.get(entityId);
+    if (!bucket) {
+      bucket = new Set();
+      this.propertyKeysByEntity.set(entityId, bucket);
+    }
+    bucket.add(key);
+  }
+
+  private deletePropertyMutation(entityId: number, key: string): boolean {
+    const removed = this.propertyMutations.delete(key);
+    if (removed) {
+      const bucket = this.propertyKeysByEntity.get(entityId);
+      if (bucket) {
+        bucket.delete(key);
+        if (bucket.size === 0) this.propertyKeysByEntity.delete(entityId);
+      }
+    }
+    return removed;
+  }
+
+  private setQuantityMutation(entityId: number, key: string, mutation: QuantityMutation): void {
+    this.quantityMutations.set(key, mutation);
+    let bucket = this.quantityKeysByEntity.get(entityId);
+    if (!bucket) {
+      bucket = new Set();
+      this.quantityKeysByEntity.set(entityId, bucket);
+    }
+    bucket.add(key);
+  }
+
+  private deleteQuantityMutation(entityId: number, key: string): boolean {
+    const removed = this.quantityMutations.delete(key);
+    if (removed) {
+      const bucket = this.quantityKeysByEntity.get(entityId);
+      if (bucket) {
+        bucket.delete(key);
+        if (bucket.size === 0) this.quantityKeysByEntity.delete(entityId);
+      }
+    }
+    return removed;
   }
 
   /**
@@ -174,10 +227,17 @@ export class MutablePropertyView {
         }
       }
 
-      // Check for new properties added to this pset
-      for (const [key, mutation] of this.propertyMutations) {
-        if (key.startsWith(`${entityId}:${pset.name}:`) && mutation.operation === 'SET') {
-          const propName = key.split(':')[2];
+      // Check for new properties added to this pset. Iterate the per-entity
+      // key set so this stays O(M_entity) instead of scanning every mutation
+      // in the model.
+      const entityPropKeys = this.propertyKeysByEntity.get(entityId);
+      if (entityPropKeys) {
+        const psetPrefix = `${entityId}:${pset.name}:`;
+        for (const key of entityPropKeys) {
+          if (!key.startsWith(psetPrefix)) continue;
+          const mutation = this.propertyMutations.get(key);
+          if (!mutation || mutation.operation !== 'SET') continue;
+          const propName = key.slice(psetPrefix.length);
           // Only add if not already in the list
           if (!mutatedProperties.some(p => p.name === propName)) {
             mutatedProperties.push({
@@ -318,7 +378,7 @@ export class MutablePropertyView {
     }
 
     // Always store in propertyMutations for tracking
-    this.propertyMutations.set(key, {
+    this.setPropertyMutation(entityId, key, {
       operation: 'SET',
       value,
       valueType,
@@ -356,7 +416,7 @@ export class MutablePropertyView {
       return null; // Property doesn't exist
     }
 
-    this.propertyMutations.set(key, { operation: 'DELETE' });
+    this.setPropertyMutation(entityId, key, { operation: 'DELETE' });
 
     const mutation: Mutation = {
       id: generateMutationId(),
@@ -406,7 +466,7 @@ export class MutablePropertyView {
     // Also add individual property mutations for consistency
     for (const prop of properties) {
       const key = propertyKey(entityId, psetName, prop.name);
-      this.propertyMutations.set(key, {
+      this.setPropertyMutation(entityId, key, {
         operation: 'SET',
         value: prop.value,
         valueType: prop.type ?? PropertyValueType.String,
@@ -446,7 +506,7 @@ export class MutablePropertyView {
     if (pset) {
       for (const prop of pset.properties) {
         const key = propertyKey(entityId, psetName, prop.name);
-        this.propertyMutations.set(key, { operation: 'DELETE' });
+        this.setPropertyMutation(entityId, key, { operation: 'DELETE' });
       }
     }
 
@@ -513,10 +573,16 @@ export class MutablePropertyView {
         }
       }
 
-      // Check for new quantities added to this qset
-      for (const [key, mutation] of this.quantityMutations) {
-        if (key.startsWith(`${entityId}:${qset.name}:`) && mutation.operation === 'SET') {
-          const quantName = key.split(':')[2];
+      // Check for new quantities added to this qset (per-entity index — see
+      // the property-mutations site above for rationale).
+      const entityQtyKeys = this.quantityKeysByEntity.get(entityId);
+      if (entityQtyKeys) {
+        const qsetPrefix = `${entityId}:${qset.name}:`;
+        for (const key of entityQtyKeys) {
+          if (!key.startsWith(qsetPrefix)) continue;
+          const mutation = this.quantityMutations.get(key);
+          if (!mutation || mutation.operation !== 'SET') continue;
+          const quantName = key.slice(qsetPrefix.length);
           if (!mutatedQuantities.some(q => q.name === quantName)) {
             mutatedQuantities.push({
               name: quantName,
@@ -575,7 +641,7 @@ export class MutablePropertyView {
     // Track individual quantity mutations
     for (const q of quantities) {
       const key = quantityKey(entityId, qsetName, q.name);
-      this.quantityMutations.set(key, {
+      this.setQuantityMutation(entityId, key, {
         operation: 'SET',
         value: q.value,
         quantityType: q.quantityType,
@@ -642,7 +708,7 @@ export class MutablePropertyView {
     const oldValue = existingMutation?.value ?? null;
     const isUpdate = existingMutation != null || qsetExistsInBase;
 
-    this.quantityMutations.set(key, {
+    this.setQuantityMutation(entityId, key, {
       operation: 'SET',
       value,
       quantityType: qType,
@@ -932,7 +998,7 @@ export class MutablePropertyView {
   removeQuantityMutation(entityId: number, qsetName: string, quantName?: string): void {
     if (quantName) {
       const key = quantityKey(entityId, qsetName, quantName);
-      this.quantityMutations.delete(key);
+      this.deleteQuantityMutation(entityId, key);
       // Also remove from newQsets if present
       const entityQsets = this.newQsets.get(entityId);
       if (entityQsets) {
@@ -950,10 +1016,16 @@ export class MutablePropertyView {
       if (entityQsets) {
         entityQsets.delete(qsetName);
       }
-      // Remove all quantity mutations for this qset
-      for (const key of [...this.quantityMutations.keys()]) {
-        if (key.startsWith(`${entityId}:${qsetName}:`)) {
-          this.quantityMutations.delete(key);
+      // Remove all quantity mutations for this qset (only those for this entity).
+      const bucket = this.quantityKeysByEntity.get(entityId);
+      if (bucket) {
+        const prefix = `${entityId}:${qsetName}:`;
+        const toRemove: string[] = [];
+        for (const key of bucket) {
+          if (key.startsWith(prefix)) toRemove.push(key);
+        }
+        for (const key of toRemove) {
+          this.deleteQuantityMutation(entityId, key);
         }
       }
     }
@@ -1008,6 +1080,8 @@ export class MutablePropertyView {
   clear(): void {
     this.propertyMutations.clear();
     this.quantityMutations.clear();
+    this.propertyKeysByEntity.clear();
+    this.quantityKeysByEntity.clear();
     this.attributeMutations.clear();
     this.deletedPsets.clear();
     this.deletedQsets.clear();

--- a/packages/mutations/src/store-editor.ts
+++ b/packages/mutations/src/store-editor.ts
@@ -65,6 +65,21 @@ export class StoreEditor {
   }
 
   /**
+   * Re-scan the store and bump the express-id watermark if the store has
+   * grown since construction (e.g. after lazy index hydration or
+   * federating in another model). Cheap to call — `MutablePropertyView`
+   * keeps the high watermark, so re-seeding with a stale value is a
+   * no-op.
+   */
+  refreshWatermark(): void {
+    const fresh = this.computeMaxExistingId();
+    if (fresh > this.maxExistingId) {
+      this.maxExistingId = fresh;
+    }
+    this.view.setExpressIdWatermark(this.maxExistingId);
+  }
+
+  /**
    * Add a new entity to the store overlay. Returns a synthetic `EntityRef`
    * with a freshly-allocated expressId; pass it back to other APIs (other
    * `addEntity` calls, `setPositionalAttribute`, exporters) to reference
@@ -96,9 +111,11 @@ export class StoreEditor {
       throw new Error('StoreEditor.addEntity: type cannot be empty');
     }
     // STEP entity tokens always start with "IFC" / "Ifc". Accept either
-    // PascalCase (`IfcWall`) or the all-caps STEP form (`IFCWALL`); the
-    // exporter handles the case conversion at the file-format boundary.
-    if (!/^[Ii][Ff][Cc][A-Za-z][A-Za-z0-9]*$/.test(trimmed)) {
+    // PascalCase (`IfcWall`) or the all-caps STEP form (`IFCWALL`).
+    // Underscore is allowed in body chars to accommodate vendor-extension
+    // names (e.g. `IfcVendor_Foo`). The exporter handles the case
+    // conversion at the file-format boundary.
+    if (!/^[Ii][Ff][Cc][A-Za-z][A-Za-z0-9_]*$/.test(trimmed)) {
       throw new Error(
         `StoreEditor.addEntity: type "${type}" is not a recognizable IFC entity name (expected e.g. "IfcWall")`,
       );
@@ -120,11 +137,22 @@ export class StoreEditor {
       canonical = resolved;
     }
 
-    // Re-seed every call: cheap (one comparison + at most one write inside the
-    // view), and recovers from `view.clear()`, which resets the allocator to 0
-    // and would otherwise hand out colliding ids on the next addEntity().
+    // Re-seed every call: cheap (one comparison + at most one write inside
+    // the view), and recovers from `view.clear()`, which resets the
+    // allocator to 0 and would otherwise hand out colliding ids on the
+    // next addEntity().
     this.view.setExpressIdWatermark(this.maxExistingId);
-    const created = this.view.createEntity(canonical, attributes);
+    let created = this.view.createEntity(canonical, attributes);
+    // Defence against a stale watermark — the store may have grown after
+    // construction (lazy index hydration, federated merge) without
+    // notifying us. If we just minted an id that's already present in
+    // the source index, drop the entity, refresh the watermark from the
+    // current store, and re-allocate.
+    if (this.store.entityIndex.byId.has(created.expressId)) {
+      this.view.deleteEntity(created.expressId);
+      this.refreshWatermark();
+      created = this.view.createEntity(canonical, attributes);
+    }
     return {
       expressId: created.expressId,
       type: created.type,

--- a/packages/mutations/src/store-editor.ts
+++ b/packages/mutations/src/store-editor.ts
@@ -142,17 +142,16 @@ export class StoreEditor {
     // allocator to 0 and would otherwise hand out colliding ids on the
     // next addEntity().
     this.view.setExpressIdWatermark(this.maxExistingId);
-    let created = this.view.createEntity(canonical, attributes);
     // Defence against a stale watermark — the store may have grown after
     // construction (lazy index hydration, federated merge) without
-    // notifying us. If we just minted an id that's already present in
-    // the source index, drop the entity, refresh the watermark from the
-    // current store, and re-allocate.
-    if (this.store.entityIndex.byId.has(created.expressId)) {
-      this.view.deleteEntity(created.expressId);
+    // notifying us. Check whether the allocator's next id collides with
+    // the current source index BEFORE calling createEntity, so we don't
+    // emit phantom CREATE_ENTITY / DELETE_ENTITY pairs into the mutation
+    // history just to fix our own bookkeeping.
+    if (this.store.entityIndex.byId.has(this.view.peekNextExpressId())) {
       this.refreshWatermark();
-      created = this.view.createEntity(canonical, attributes);
     }
+    const created = this.view.createEntity(canonical, attributes);
     return {
       expressId: created.expressId,
       type: created.type,

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -704,29 +704,64 @@ export class Renderer {
         const hasIsolatedFilter = options.isolatedIds !== null && options.isolatedIds !== undefined;
         const hasVisibilityFiltering = hasHiddenFilter || hasIsolatedFilter;
 
+        // Build the selected-id set once per frame so the X-Ray override paths
+        // can keep highlighted entities at full alpha without per-site checks.
+        const selectedId = options.selectedId;
+        const selectedIds = options.selectedIds;
+        const selectedModelIndex = options.selectedModelIndex;
+        const selectedExpressIds = new Set<number>();
+        if (selectedId !== undefined && selectedId !== null) {
+            selectedExpressIds.add(selectedId);
+        }
+        if (selectedIds) {
+            for (const id of selectedIds) {
+                selectedExpressIds.add(id);
+            }
+        }
+        const hasSelected = selectedExpressIds.size > 0;
+
         // Per-frame alpha overrides for X-Ray mode. See RenderOptions.transparencyOverrides.
-        // Callers supply a fresh Map when contents change (same convention as hiddenIds/isolatedIds).
-        const txOverrides = options.transparencyOverrides;
-        const hasTxOverrides = txOverrides != null && txOverrides.size > 0;
+        // Snapshot the caller's map so mid-frame mutation can't desync classification
+        // and uniform-write decisions for the same batch/mesh.
+        const txOverridesSrc = options.transparencyOverrides;
+        const hasTxOverrides = txOverridesSrc != null && txOverridesSrc.size > 0;
+        const txOverrides = hasTxOverrides ? new Map(txOverridesSrc) : null;
         const alphaForMesh = (expressId: number, fallback: number): number => {
             if (!hasTxOverrides) return fallback;
+            // Selected meshes are exempt — the highlight pass renders them last,
+            // but exempting here also keeps mesh classification + uniform writes
+            // consistent so a selected mesh never enters the transparent pipeline
+            // because of its own override entry.
+            if (hasSelected && selectedExpressIds.has(expressId)) return fallback;
             const a = txOverrides!.get(expressId);
             return a !== undefined ? a : fallback;
         };
-        // alphaForBatch walks batch.expressIds per frame. For typical batch sizes
-        // the cost is well below noise vs. the GPU work, and avoiding a cache
-        // removes the stale-on-mutation bug class entirely.
+        // Cache resolved batch alpha for the frame: classification needs it
+        // (opaque vs transparent routing) and renderBatch needs it for the
+        // uniform write. Without the cache we'd walk batch.expressIds twice
+        // per batch per frame, which becomes the dominant JS cost in X-Ray.
+        const batchAlphaCache = hasTxOverrides
+            ? new WeakMap<{ expressIds: number[]; color: [number, number, number, number] }, number>()
+            : null;
         const alphaForBatch = (
             batch: { expressIds: number[]; color: [number, number, number, number] },
             fallback: number,
         ): number => {
             if (!hasTxOverrides) return fallback;
+            const cached = batchAlphaCache!.get(batch);
+            if (cached !== undefined) return cached;
             let minAlpha = Infinity;
             for (const eid of batch.expressIds) {
+                // Selected ids never drag down a batch's alpha — the highlight
+                // pass redraws them on top, but excluding here also means a
+                // batch made entirely of selected entities stays opaque.
+                if (hasSelected && selectedExpressIds.has(eid)) continue;
                 const a = txOverrides!.get(eid);
                 if (a !== undefined && a < minAlpha) minAlpha = a;
             }
-            return minAlpha === Infinity ? fallback : minAlpha;
+            const resolved = minAlpha === Infinity ? fallback : minAlpha;
+            batchAlphaCache!.set(batch, resolved);
+            return resolved;
         };
 
         // PERFORMANCE FIX: Use batch-level visibility filtering instead of creating individual meshes
@@ -808,9 +843,6 @@ export class Renderer {
             // Write uniform data to each mesh's buffer BEFORE recording commands
             // This ensures each mesh has its own color data
             const allMeshes = [...opaqueMeshes, ...transparentMeshes];
-            const selectedId = options.selectedId;
-            const selectedIds = options.selectedIds;
-            const selectedModelIndex = options.selectedModelIndex;
 
             // Calculate section plane parameters and model bounds
             // Always calculate bounds when sectionPlane is provided (for preview and active mode)
@@ -1155,16 +1187,6 @@ export class Renderer {
                         transparentBatches.push(batch);
                     } else {
                         opaqueBatches.push(batch);
-                    }
-                }
-
-                const selectedExpressIds = new Set<number>();
-                if (selectedId !== undefined && selectedId !== null) {
-                    selectedExpressIds.add(selectedId);
-                }
-                if (selectedIds) {
-                    for (const id of selectedIds) {
-                        selectedExpressIds.add(id);
                     }
                 }
 

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -174,11 +174,22 @@ export interface RenderOptions {
   selectedIds?: Set<number>;      // Multi-selection support
   /**
    * Per-frame alpha overrides — primary use case is X-Ray mode.
+   *
    * Map<expressId, alpha 0..1>. Non-selected meshes/batches whose expressId
-   * appears in this map render at the override alpha through the existing
-   * transparent pipeline. Selected meshes are exempt so highlights stay opaque.
-   * Mixed batches (some entries overridden, some not) take the minimum override
-   * alpha — selected meshes are then re-rendered on top by the highlight pass.
+   * appears in this map render at the override alpha through the transparent
+   * pipeline. Selected meshes (`selectedId` / `selectedIds`) are exempt at
+   * every site, so highlights always paint with their own alpha.
+   *
+   * Mixed batches (some entries overridden, some not) take the minimum
+   * override alpha across non-selected ids; selected meshes in the batch
+   * are then redrawn on top by the highlight pass.
+   *
+   * The renderer snapshots this map at frame start, so callers may freely
+   * mutate or recycle their copy after `render()` returns.
+   *
+   * Note: alphas `>= 0.99` are treated as opaque (the cutoff for switching to
+   * the transparent pipeline). Entries at or above that threshold are no-ops
+   * — keep them out of the map to avoid unnecessary work.
    */
   transparencyOverrides?: Map<number, number> | null;
   // Building rotation in radians (from IfcSite placement) - used to orient section planes

--- a/packages/sandbox/src/bridge-schema.ts
+++ b/packages/sandbox/src/bridge-schema.ts
@@ -292,32 +292,51 @@ function marshalReturn(vm: QuickJSContext, value: unknown, type: ReturnType): Qu
   }
 }
 
+/**
+ * Cycle/depth limits for `marshalValue` — protect the host renderer from a
+ * sandboxed script that hands back a cyclic or pathologically deep object
+ * graph. Values past the depth limit serialise to `null`.
+ */
+const MARSHAL_MAX_DEPTH = 64;
+
 /** Recursively convert a native JS value to a QuickJS handle */
 export function marshalValue(vm: QuickJSContext, value: unknown): QuickJSHandle {
+  return marshalValueWithGuard(vm, value, 0, new WeakSet());
+}
+
+function marshalValueWithGuard(
+  vm: QuickJSContext,
+  value: unknown,
+  depth: number,
+  seen: WeakSet<object>,
+): QuickJSHandle {
   if (value === null || value === undefined) return vm.null;
   if (typeof value === 'string') return vm.newString(value);
   if (typeof value === 'number') return vm.newNumber(value);
   if (typeof value === 'boolean') return value ? vm.true : vm.false;
 
+  if (depth >= MARSHAL_MAX_DEPTH) return vm.null;
+  if (typeof value !== 'object') return vm.null;
+
+  // Cycle guard: a self-referencing object would otherwise blow the stack.
+  if (seen.has(value as object)) return vm.null;
+  seen.add(value as object);
+
   if (Array.isArray(value)) {
     const arr = vm.newArray();
     for (let i = 0; i < value.length; i++) {
-      const item = marshalValue(vm, value[i]);
+      const item = marshalValueWithGuard(vm, value[i], depth + 1, seen);
       vm.setProp(arr, i, item);
       item.dispose();
     }
     return arr;
   }
 
-  if (typeof value === 'object') {
-    const obj = vm.newObject();
-    for (const [k, v] of Object.entries(value)) {
-      const handle = marshalValue(vm, v);
-      vm.setProp(obj, k, handle);
-      handle.dispose();
-    }
-    return obj;
+  const obj = vm.newObject();
+  for (const [k, v] of Object.entries(value as object)) {
+    const handle = marshalValueWithGuard(vm, v, depth + 1, seen);
+    vm.setProp(obj, k, handle);
+    handle.dispose();
   }
-
-  return vm.null;
+  return obj;
 }

--- a/packages/sandbox/src/bridge-schema.ts
+++ b/packages/sandbox/src/bridge-schema.ts
@@ -308,7 +308,7 @@ function marshalValueWithGuard(
   vm: QuickJSContext,
   value: unknown,
   depth: number,
-  seen: WeakSet<object>,
+  stack: WeakSet<object>,
 ): QuickJSHandle {
   if (value === null || value === undefined) return vm.null;
   if (typeof value === 'string') return vm.newString(value);
@@ -318,25 +318,32 @@ function marshalValueWithGuard(
   if (depth >= MARSHAL_MAX_DEPTH) return vm.null;
   if (typeof value !== 'object') return vm.null;
 
-  // Cycle guard: a self-referencing object would otherwise blow the stack.
-  if (seen.has(value as object)) return vm.null;
-  seen.add(value as object);
-
-  if (Array.isArray(value)) {
-    const arr = vm.newArray();
-    for (let i = 0; i < value.length; i++) {
-      const item = marshalValueWithGuard(vm, value[i], depth + 1, seen);
-      vm.setProp(arr, i, item);
-      item.dispose();
+  // Cycle guard: only objects on the *current ancestor chain* count as a
+  // cycle. Removing on exit means an acyclic graph that legitimately
+  // shares a sub-object across siblings (e.g. `{ a: shared, b: shared }`)
+  // still serialises both occurrences fully.
+  const obj = value as object;
+  if (stack.has(obj)) return vm.null;
+  stack.add(obj);
+  try {
+    if (Array.isArray(value)) {
+      const arr = vm.newArray();
+      for (let i = 0; i < value.length; i++) {
+        const item = marshalValueWithGuard(vm, value[i], depth + 1, stack);
+        vm.setProp(arr, i, item);
+        item.dispose();
+      }
+      return arr;
     }
-    return arr;
-  }
 
-  const obj = vm.newObject();
-  for (const [k, v] of Object.entries(value as object)) {
-    const handle = marshalValueWithGuard(vm, v, depth + 1, seen);
-    vm.setProp(obj, k, handle);
-    handle.dispose();
+    const out = vm.newObject();
+    for (const [k, v] of Object.entries(obj)) {
+      const handle = marshalValueWithGuard(vm, v, depth + 1, stack);
+      vm.setProp(out, k, handle);
+      handle.dispose();
+    }
+    return out;
+  } finally {
+    stack.delete(obj);
   }
-  return obj;
 }

--- a/packages/sandbox/src/bridge-store.ts
+++ b/packages/sandbox/src/bridge-store.ts
@@ -89,22 +89,11 @@ export function buildStoreNamespace(): NamespaceSchema {
         tsReturn: '{ modelId: string; expressId: number }',
         call: (sdk, args) => {
           const storeyExpressId = args[1] as number;
-          if (!Number.isInteger(storeyExpressId) || storeyExpressId < 0) {
-            throw new Error(`bim.store.addColumn: storeyExpressId must be a non-negative integer, got ${storeyExpressId}`);
-          }
+          requireStoreyId(storeyExpressId, 'addColumn');
           const params = args[2] as Parameters<typeof sdk.store.addColumn>[2];
-          if (!params || !Array.isArray(params.Position) || params.Position.length !== 3) {
-            throw new Error('bim.store.addColumn: params.Position must be [x, y, z]');
-          }
-          if (!params.Position.every((n) => typeof n === 'number' && Number.isFinite(n))) {
-            throw new Error('bim.store.addColumn: params.Position values must be finite numbers');
-          }
-          for (const key of ['Width', 'Depth', 'Height'] as const) {
-            const v = params[key];
-            if (typeof v !== 'number' || !Number.isFinite(v) || v <= 0) {
-              throw new Error(`bim.store.addColumn: params.${key} must be a finite number > 0, got ${v}`);
-            }
-          }
+          if (!params) throw new Error('bim.store.addColumn: params is required');
+          requirePositionVec3(params.Position, 'addColumn');
+          requirePositiveDims(params, ['Width', 'Depth', 'Height'], 'addColumn');
           return sdk.store.addColumn(args[0] as string, storeyExpressId, params);
         },
         returns: 'value',
@@ -122,27 +111,12 @@ export function buildStoreNamespace(): NamespaceSchema {
         tsReturn: '{ modelId: string; expressId: number }',
         call: (sdk, args) => {
           const storeyExpressId = args[1] as number;
-          if (!Number.isInteger(storeyExpressId) || storeyExpressId < 0) {
-            throw new Error(`bim.store.addWall: storeyExpressId must be a non-negative integer, got ${storeyExpressId}`);
-          }
+          requireStoreyId(storeyExpressId, 'addWall');
           const params = args[2] as Parameters<typeof sdk.store.addWall>[2];
-          if (
-            !params
-            || !Array.isArray(params.Start) || params.Start.length !== 3
-            || !Array.isArray(params.End) || params.End.length !== 3
-          ) {
-            throw new Error('bim.store.addWall: params.Start and params.End must be [x, y, z]');
-          }
-          if (!params.Start.every((n) => typeof n === 'number' && Number.isFinite(n))
-              || !params.End.every((n) => typeof n === 'number' && Number.isFinite(n))) {
-            throw new Error('bim.store.addWall: Start/End values must be finite numbers');
-          }
-          for (const key of ['Thickness', 'Height'] as const) {
-            const v = params[key];
-            if (typeof v !== 'number' || !Number.isFinite(v) || v <= 0) {
-              throw new Error(`bim.store.addWall: params.${key} must be a finite number > 0, got ${v}`);
-            }
-          }
+          if (!params) throw new Error('bim.store.addWall: params is required');
+          requireAxisVec3(params.Start, 'addWall', 'Start');
+          requireAxisVec3(params.End, 'addWall', 'End');
+          requirePositiveDims(params, ['Thickness', 'Height'], 'addWall');
           return sdk.store.addWall(args[0] as string, storeyExpressId, params);
         },
         returns: 'value',
@@ -160,48 +134,13 @@ export function buildStoreNamespace(): NamespaceSchema {
         tsReturn: '{ modelId: string; expressId: number }',
         call: (sdk, args) => {
           const storeyExpressId = args[1] as number;
-          if (!Number.isInteger(storeyExpressId) || storeyExpressId < 0) {
-            throw new Error(`bim.store.addSlab: storeyExpressId must be a non-negative integer, got ${storeyExpressId}`);
-          }
+          requireStoreyId(storeyExpressId, 'addSlab');
           const params = args[2] as Parameters<typeof sdk.store.addSlab>[2];
           if (!params) {
             throw new Error('bim.store.addSlab: params is required');
           }
-          const thickness = (params as { Thickness?: unknown }).Thickness;
-          if (typeof thickness !== 'number' || !Number.isFinite(thickness) || thickness <= 0) {
-            throw new Error(`bim.store.addSlab: params.Thickness must be a finite number > 0, got ${thickness}`);
-          }
-          if ((params as { Profile?: unknown }).Profile === 'polygon') {
-            const polygon = params as { Profile: 'polygon'; OuterCurve: unknown; Position?: unknown };
-            if (!Array.isArray(polygon.OuterCurve) || polygon.OuterCurve.length < 3) {
-              throw new Error('bim.store.addSlab: polygon OuterCurve needs at least 3 points');
-            }
-            for (const pt of polygon.OuterCurve) {
-              if (!Array.isArray(pt) || pt.length !== 2
-                  || typeof pt[0] !== 'number' || !Number.isFinite(pt[0])
-                  || typeof pt[1] !== 'number' || !Number.isFinite(pt[1])) {
-                throw new Error('bim.store.addSlab: each OuterCurve point must be [number, number] of finite values');
-              }
-            }
-            if (polygon.Position !== undefined) {
-              if (!Array.isArray(polygon.Position) || polygon.Position.length !== 3
-                  || !polygon.Position.every((n) => typeof n === 'number' && Number.isFinite(n))) {
-                throw new Error('bim.store.addSlab: params.Position must be [x, y, z] of finite numbers');
-              }
-            }
-          } else {
-            const rect = params as { Position: unknown; Width: unknown; Depth: unknown };
-            if (!Array.isArray(rect.Position) || rect.Position.length !== 3
-                || !rect.Position.every((n) => typeof n === 'number' && Number.isFinite(n))) {
-              throw new Error('bim.store.addSlab: params.Position must be [x, y, z] of finite numbers');
-            }
-            for (const key of ['Width', 'Depth'] as const) {
-              const v = (rect as Record<string, unknown>)[key];
-              if (typeof v !== 'number' || !Number.isFinite(v) || v <= 0) {
-                throw new Error(`bim.store.addSlab: params.${key} must be a finite number > 0, got ${v}`);
-              }
-            }
-          }
+          requirePositiveDims(params, ['Thickness'], 'addSlab');
+          validateProfileParams(params, 'addSlab', ['Width', 'Depth']);
           return sdk.store.addSlab(args[0] as string, storeyExpressId, params);
         },
         returns: 'value',

--- a/packages/sdk/src/namespaces/store.ts
+++ b/packages/sdk/src/namespaces/store.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { normalizeIfcTypeName } from '@ifc-lite/parser';
+import { isKnownType, normalizeIfcTypeName } from '@ifc-lite/parser';
 import type {
   AddBeamInStoreParams,
   AddColumnInStoreParams,
@@ -61,6 +61,18 @@ export class StoreNamespace {
    *   });
    */
   addEntity(modelId: string, def: { type: string; attributes: unknown[] }): EntityRef {
+    if (!def || typeof def.type !== 'string' || def.type.length === 0) {
+      throw new TypeError('addEntity: def.type must be a non-empty IFC type string');
+    }
+    // Normalisation only canonicalises casing for known names — it leaves
+    // unknown strings untouched. The backend's StoreEditor has its own
+    // regex guard, but rejecting typos at the SDK boundary gives a much
+    // more useful error than a generic STEP-emit failure.
+    if (!isKnownType(def.type)) {
+      throw new TypeError(
+        `addEntity: unknown IFC type '${def.type}'. Pass a canonical PascalCase name (e.g. 'IfcWall').`,
+      );
+    }
     return this.backend.store.addEntity(modelId, {
       type: normalizeIfcTypeName(def.type),
       attributes: def.attributes,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -725,17 +725,28 @@ export interface BimBackend {
 /**
  * Route a string-based SdkRequest to the appropriate typed method on a BimBackend.
  * Used by BimHost for wire protocol compatibility.
+ *
+ * Security: namespace/method come straight off the wire. Use `Object.hasOwn`
+ * lookups so an attacker can't reach prototype members (`__proto__`,
+ * `constructor`, `toString`, …) or methods inherited from a host class.
  */
 export function dispatchToBackend(backend: BimBackend, namespace: string, method: string, args: unknown[]): unknown {
-  const ns = (backend as unknown as Record<string, Record<string, (...a: unknown[]) => unknown>>)[namespace];
+  const backendObj = backend as unknown as Record<string, unknown>;
+  if (!Object.prototype.hasOwnProperty.call(backendObj, namespace)) {
+    throw new Error(`Unknown namespace '${namespace}'`);
+  }
+  const ns = backendObj[namespace] as Record<string, unknown> | null | undefined;
   if (!ns || typeof ns !== 'object') {
     throw new Error(`Unknown namespace '${namespace}'`);
+  }
+  if (!Object.prototype.hasOwnProperty.call(ns, method)) {
+    throw new Error(`Unknown method '${namespace}.${method}'`);
   }
   const fn = ns[method];
   if (typeof fn !== 'function') {
     throw new Error(`Unknown method '${namespace}.${method}'`);
   }
-  return fn(...args);
+  return (fn as (...a: unknown[]) => unknown).apply(ns, args);
 }
 
 // ============================================================================

--- a/rust/core/src/legacy_entities.rs
+++ b/rust/core/src/legacy_entities.rs
@@ -99,6 +99,17 @@ pub fn get_legacy_entity_info(entity_name: &str) -> Option<LegacyEntityInfo> {
             has_geometry: false,
         }),
 
+        // IFC2x3 names that have no IFC4x3 enum variant. They map to the
+        // closest modern equivalent; both carry geometry.
+        "IFCEQUIPMENTELEMENT" => Some(LegacyEntityInfo {
+            base_type: IfcType::IfcDistributionElement,
+            has_geometry: true,
+        }),
+        "IFCELECTRICALDISTRIBUTIONPOINT" => Some(LegacyEntityInfo {
+            base_type: IfcType::IfcDistributionElement,
+            has_geometry: true,
+        }),
+
         _ => None,
     }
 }

--- a/rust/core/src/lib.rs
+++ b/rust/core/src/lib.rs
@@ -75,7 +75,7 @@ pub mod legacy_entities;
 pub mod model_bounds;
 pub mod parser;
 pub mod schema_gen;
-pub mod schema_helpers;
+pub(crate) mod schema_helpers;
 pub mod streaming;
 pub mod units;
 
@@ -94,6 +94,6 @@ pub use legacy_entities::{
 pub use model_bounds::{scan_model_bounds, scan_placement_bounds, ModelBounds};
 pub use parser::{parse_entity, EntityScanner, Token};
 pub use schema_gen::{AttributeValue, DecodedEntity, GeometryCategory, IfcSchema, ProfileCategory};
-pub use schema_helpers::has_geometry_by_name;
+pub use schema_helpers::{has_geometry_by_name, is_simple_geometry_type};
 pub use streaming::{parse_stream, ParseEvent, StreamConfig};
 pub use units::{extract_length_unit_scale, get_si_prefix_multiplier};

--- a/rust/core/src/schema_helpers.rs
+++ b/rust/core/src/schema_helpers.rs
@@ -16,9 +16,47 @@
 //! string match).
 //!
 //! Co-authored with Geronimo <gerald.stampfel+geronimo@gmail.com> (PR #585).
+//!
+//! Both helpers are on the hot path during scene construction, where the
+//! same ~50–100 distinct type names are queried thousands of times per file.
+//! We memoise per-name behind a `RwLock<FxHashMap<String, bool>>`: the first
+//! call for a name pays the full `IfcType::from_str` (a ~1300-arm match) +
+//! `is_subtype_of` traversal cost; subsequent calls take a read-lock and a
+//! single hash lookup.
+
+use std::sync::{OnceLock, RwLock};
+
+use rustc_hash::FxHashMap;
 
 use crate::generated::IfcType;
 use crate::legacy_entities::get_legacy_entity_info;
+
+/// Normalise to uppercase ASCII without allocating when the input is already
+/// uppercase (the common case — STEP type tokens are emitted uppercase).
+fn normalise_uppercase(type_name: &str) -> std::borrow::Cow<'_, str> {
+    if type_name.bytes().any(|b| b.is_ascii_lowercase()) {
+        std::borrow::Cow::Owned(type_name.to_ascii_uppercase())
+    } else {
+        std::borrow::Cow::Borrowed(type_name)
+    }
+}
+
+/// Look up a cached bool, or compute via `f` and insert.
+fn cached<F>(cache: &RwLock<FxHashMap<String, bool>>, key: &str, f: F) -> bool
+where
+    F: FnOnce() -> bool,
+{
+    if let Ok(read) = cache.read() {
+        if let Some(&v) = read.get(key) {
+            return v;
+        }
+    }
+    let value = f();
+    if let Ok(mut write) = cache.write() {
+        write.insert(key.to_owned(), value);
+    }
+    value
+}
 
 /// Check if a type name (UPPERCASE STEP string) represents an `IfcProduct`
 /// subtype that can bear geometry (has `ObjectPlacement` + `Representation`).
@@ -28,38 +66,35 @@ use crate::legacy_entities::get_legacy_entity_info;
 ///    inherit from `IfcProduct`, with a small block-list for abstract spatial
 ///    containers (`IfcBuilding`, `IfcBuildingStorey`, `IfcFacility`,
 ///    `IfcFacilityPart`, `IfcSpatialElement`, `IfcSpatialStructureElement`)
-///    that don't carry geometry directly. `IfcSpace` and `IfcSite` are
-///    intentionally kept — they have boundary representations the renderer
-///    consumes.
+///    that don't carry geometry directly. `IfcSpace` and `IfcSite` (and any
+///    concrete subtype of either) are intentionally kept — they have boundary
+///    representations the renderer consumes.
 /// 2. Legacy IFC2x3 / removed-in-IFC4x3 names that aren't in the generated
-///    enum (e.g. `IFCSLABELEMENTEDCASE`, `IFCBUILDINGELEMENT`, `IFCPROXY`)
-///    are resolved through `legacy_entities::get_legacy_entity_info`, which
-///    already carries a `has_geometry` flag.
-/// 3. Reinforcement variants and a couple of legacy names not covered above
-///    fall back to a substring/exact match.
+///    enum (e.g. `IFCSLABELEMENTEDCASE`, `IFCBUILDINGELEMENT`, `IFCPROXY`,
+///    `IFCEQUIPMENTELEMENT`, `IFCELECTRICALDISTRIBUTIONPOINT`) resolve through
+///    `legacy_entities::get_legacy_entity_info`, which carries a
+///    `has_geometry` flag.
+/// 3. Reinforcement variants not covered above fall back to a substring
+///    match (`REINFORCING…` / `REINFORCED…`).
 pub fn has_geometry_by_name(type_name: &str) -> bool {
-    // Avoid an allocation when the input is already uppercase ASCII.
-    let upper_owned;
-    let upper: &str = if type_name.bytes().any(|b| b.is_ascii_lowercase()) {
-        upper_owned = type_name.to_ascii_uppercase();
-        upper_owned.as_str()
-    } else {
-        type_name
-    };
+    static CACHE: OnceLock<RwLock<FxHashMap<String, bool>>> = OnceLock::new();
+    let cache = CACHE.get_or_init(|| RwLock::new(FxHashMap::default()));
 
-    // Legacy / removed entity names not present in the modern enum carry an
-    // explicit `has_geometry` flag in the legacy registry.
+    let upper = normalise_uppercase(type_name);
+    cached(cache, upper.as_ref(), || compute_has_geometry(upper.as_ref()))
+}
+
+fn compute_has_geometry(upper: &str) -> bool {
     if let Some(info) = get_legacy_entity_info(upper) {
         return info.has_geometry;
     }
 
     let t = IfcType::from_str(upper);
     if matches!(t, IfcType::Unknown(_)) {
-        // Reinforcement bars/meshes and a couple of IFC2x3 names not in the
-        // legacy registry. Keep this list minimal — anything new should land
-        // in `legacy_entities.rs` instead.
-        return upper.contains("REINFORC")
-            || matches!(upper, "IFCEQUIPMENTELEMENT" | "IFCELECTRICALDISTRIBUTIONPOINT");
+        // Reinforcement bars/meshes/elements are common in IFC2x3 files. Match
+        // a tighter prefix than `contains("REINFORC")` to avoid catching
+        // unrelated tokens with the substring.
+        return upper.starts_with("IFCREINFORCING") || upper.starts_with("IFCREINFORCED");
     }
 
     if !t.is_subtype_of(IfcType::IfcProduct) {
@@ -70,8 +105,9 @@ pub fn has_geometry_by_name(type_name: &str) -> bool {
 }
 
 /// Subtypes of `IfcProduct` that exist solely as spatial containers and
-/// aren't rendered directly. `IfcSpace` and `IfcSite` are deliberately
-/// exempt — their boundary representations are consumed by the renderer.
+/// aren't rendered directly. `IfcSpace`/`IfcSite` and their concrete
+/// subtypes are deliberately exempt — their boundary representations are
+/// consumed by the renderer.
 ///
 /// We block by inheritance, not by exact match, so IFC4X3 facility
 /// subclasses like `IfcBridge`/`IfcRoad`/`IfcRailway`/`IfcMarineFacility`
@@ -79,10 +115,60 @@ pub fn has_geometry_by_name(type_name: &str) -> bool {
 /// `IfcSpatialZone`, and any future concrete spatial container all collapse
 /// to the same answer without the whitelist needing to enumerate them.
 fn is_non_geometric_spatial(t: IfcType) -> bool {
-    if matches!(t, IfcType::IfcSpace | IfcType::IfcSite) {
+    if t.is_subtype_of(IfcType::IfcSpace) || t.is_subtype_of(IfcType::IfcSite) {
         return false;
     }
     t.is_subtype_of(IfcType::IfcSpatialElement)
+}
+
+/// Check if an IFC entity class is "simple" geometry (processed first for
+/// fast first frame). Driven off the EXPRESS inheritance graph rather than
+/// a leaf-level blacklist, so new IFC4X3 subtypes (e.g. `IfcSolarDevice`
+/// under `IfcEnergyConversionDevice`) are categorised correctly without
+/// code changes — see PR #585.
+///
+/// Returns `true` for "simple" elements (load first), `false` for
+/// "secondary/complex" (openings, doors, windows, furniture, MEP/distribution
+/// elements, spaces, sites, annotations, virtual/proxy entities).
+pub fn is_simple_geometry_type(type_name: &str) -> bool {
+    static CACHE: OnceLock<RwLock<FxHashMap<String, bool>>> = OnceLock::new();
+    let cache = CACHE.get_or_init(|| RwLock::new(FxHashMap::default()));
+
+    let upper = normalise_uppercase(type_name);
+    cached(cache, upper.as_ref(), || compute_is_simple(upper.as_ref()))
+}
+
+fn compute_is_simple(upper: &str) -> bool {
+    let t = match get_legacy_entity_info(upper) {
+        Some(info) => info.base_type,
+        None => IfcType::from_str(upper),
+    };
+
+    // Anything not in the modern schema defaults to "simple" priority,
+    // matching the original blacklist's "anything else is simple" behaviour.
+    if matches!(t, IfcType::Unknown(_)) {
+        return true;
+    }
+
+    let is_secondary = t.is_subtype_of(IfcType::IfcOpeningElement)
+        || t.is_subtype_of(IfcType::IfcWindow)
+        || t.is_subtype_of(IfcType::IfcDoor)
+        || t.is_subtype_of(IfcType::IfcFurnishingElement)
+        // Covers IfcEnergyConversionDevice + IfcSolarDevice + every Flow*
+        // and every MEP terminal — all inherit from IfcDistributionElement.
+        || t.is_subtype_of(IfcType::IfcDistributionElement)
+        || matches!(
+            t,
+            // Spatial elements that have geometry but aren't structural.
+            IfcType::IfcSpace
+                | IfcType::IfcSite
+                // Annotations / virtual / proxy.
+                | IfcType::IfcAnnotation
+                | IfcType::IfcVirtualElement
+                | IfcType::IfcBuildingElementProxy
+        );
+
+    !is_secondary
 }
 
 #[cfg(test)]
@@ -150,8 +236,7 @@ mod tests {
     fn reinforcement_variants_have_geometry() {
         assert!(has_geometry_by_name("IFCREINFORCINGBAR"));
         assert!(has_geometry_by_name("IFCREINFORCINGMESH"));
-        // Substring match for unknown reinforcement variants
-        assert!(has_geometry_by_name("IFCREINFORCEDOBSCURE"));
+        assert!(has_geometry_by_name("IFCREINFORCEDSOIL"));
     }
 
     #[test]
@@ -175,6 +260,13 @@ mod tests {
         assert!(has_geometry_by_name("IFCSPACE"));
         assert!(has_geometry_by_name("IFCSITE"));
         assert!(has_geometry_by_name("IFCOPENINGELEMENT"));
+    }
+
+    #[test]
+    fn legacy_ifc2x3_distribution_names_have_geometry() {
+        // Routed through legacy_entities now (was an inline match arm).
+        assert!(has_geometry_by_name("IFCEQUIPMENTELEMENT"));
+        assert!(has_geometry_by_name("IFCELECTRICALDISTRIBUTIONPOINT"));
     }
 
     #[test]
@@ -234,7 +326,45 @@ mod tests {
 
     #[test]
     fn unknown_garbage_excluded() {
+        // Reinforcement substring tightened to a prefix — unrelated tokens
+        // containing "REINFORC" are no longer accepted.
         assert!(!has_geometry_by_name("IFCNOTAREALTYPE"));
         assert!(!has_geometry_by_name(""));
+        assert!(!has_geometry_by_name("FOOREINFORCEDBAR"));
+    }
+
+    #[test]
+    fn cached_results_are_consistent() {
+        // Hit the cache twice for the same name and confirm both return the
+        // same value (regression for any race in the cache layer).
+        for _ in 0..3 {
+            assert!(has_geometry_by_name("IFCWALL"));
+            assert!(!has_geometry_by_name("IFCPROJECT"));
+            assert!(is_simple_geometry_type("IFCWALL"));
+            assert!(!is_simple_geometry_type("IFCWINDOW"));
+        }
+    }
+
+    #[test]
+    fn is_simple_geometry_type_routes_correctly() {
+        // Structural / structural-adjacent: simple.
+        assert!(is_simple_geometry_type("IFCWALL"));
+        assert!(is_simple_geometry_type("IFCSLAB"));
+        assert!(is_simple_geometry_type("IFCBEAM"));
+        assert!(is_simple_geometry_type("IFCCOLUMN"));
+
+        // Secondary categories.
+        assert!(!is_simple_geometry_type("IFCWINDOW"));
+        assert!(!is_simple_geometry_type("IFCDOOR"));
+        assert!(!is_simple_geometry_type("IFCOPENINGELEMENT"));
+        assert!(!is_simple_geometry_type("IFCFLOWSEGMENT"));
+        assert!(!is_simple_geometry_type("IFCSOLARDEVICE"));
+        assert!(!is_simple_geometry_type("IFCSPACE"));
+        assert!(!is_simple_geometry_type("IFCANNOTATION"));
+        assert!(!is_simple_geometry_type("IFCBUILDINGELEMENTPROXY"));
+
+        // Mixed-case input — exercises the `to_ascii_uppercase` branch.
+        assert!(is_simple_geometry_type("IfcWall"));
+        assert!(!is_simple_geometry_type("IfcDoor"));
     }
 }

--- a/rust/wasm-bindings/src/api/gpu_meshes.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes.rs
@@ -2535,8 +2535,8 @@ impl IfcAPI {
     /// A parallel style worker can run buildPrePassOnce for correct colors later.
     #[wasm_bindgen(js_name = buildPrePassFast)]
     pub fn build_pre_pass_fast(&self, data: &[u8]) -> JsValue {
-        use super::styling::{extract_building_rotation_from_site, is_simple_geometry_type};
-        use ifc_lite_core::{EntityDecoder, EntityScanner, IfcType};
+        use super::styling::extract_building_rotation_from_site;
+        use ifc_lite_core::{is_simple_geometry_type, EntityDecoder, EntityScanner, IfcType};
         use ifc_lite_geometry::GeometryRouter;
 
         let content = decode_ifc_bytes(data);

--- a/rust/wasm-bindings/src/api/styling.rs
+++ b/rust/wasm-bindings/src/api/styling.rs
@@ -488,7 +488,7 @@ pub(crate) fn combined_pre_pass(
             _ => {
                 if ifc_lite_core::has_geometry_by_name(type_name) {
                     let ifc_type = ifc_lite_core::IfcType::from_str(type_name);
-                    if is_simple_geometry_type(type_name) {
+                    if ifc_lite_core::is_simple_geometry_type(type_name) {
                         simple_jobs.push((id, start, end, ifc_type));
                     } else {
                         complex_jobs.push((id, start, end, ifc_type));
@@ -943,57 +943,6 @@ pub(crate) fn pick_material_style_for_submesh(
 
     // Fallback: first available color
     Some(material_colors[0])
-}
-
-/// Check if an IFC entity class is "simple" geometry (processed first for
-/// fast first frame). Driven off the EXPRESS inheritance graph rather than a
-/// leaf-level blacklist, so new IFC4X3 subtypes (e.g. `IfcSolarDevice` under
-/// `IfcEnergyConversionDevice`) are categorised correctly without code
-/// changes — see PR #585.
-pub(crate) fn is_simple_geometry_type(type_name: &str) -> bool {
-    use ifc_lite_core::{get_legacy_entity_info, IfcType};
-
-    let upper_owned;
-    let upper: &str = if type_name.bytes().any(|b| b.is_ascii_lowercase()) {
-        upper_owned = type_name.to_ascii_uppercase();
-        upper_owned.as_str()
-    } else {
-        type_name
-    };
-
-    // Resolve legacy IFC2x3 / removed-in-IFC4x3 names to their modern enum.
-    let t = match get_legacy_entity_info(upper) {
-        Some(info) => info.base_type,
-        None => IfcType::from_str(upper),
-    };
-
-    // Anything not in the modern schema defaults to "simple" priority,
-    // matching the original blacklist's "anything else is simple" behaviour.
-    if matches!(t, IfcType::Unknown(_)) {
-        return true;
-    }
-
-    // Categories that are "secondary/complex" — processed after simple
-    // elements so the first frame paints faster.
-    let is_secondary = t.is_subtype_of(IfcType::IfcOpeningElement)
-        || t.is_subtype_of(IfcType::IfcWindow)
-        || t.is_subtype_of(IfcType::IfcDoor)
-        || t.is_subtype_of(IfcType::IfcFurnishingElement)
-        // Covers IfcEnergyConversionDevice + IfcSolarDevice + every Flow*
-        // and every MEP terminal, all of which inherit from IfcDistributionElement.
-        || t.is_subtype_of(IfcType::IfcDistributionElement)
-        || matches!(
-            t,
-            // Spatial elements that have geometry but aren't structural.
-            IfcType::IfcSpace
-                | IfcType::IfcSite
-                // Annotations / virtual / proxy.
-                | IfcType::IfcAnnotation
-                | IfcType::IfcVirtualElement
-                | IfcType::IfcBuildingElementProxy
-        );
-
-    !is_secondary
 }
 
 /// Resolve element color inline during processing by following its


### PR DESCRIPTION
This PR optimizes several hot paths in the codebase through strategic caching and indexing, reducing algorithmic complexity from O(N²) or O(N³) to O(1) or O(log N) lookups.

## Key Changes

**Rust Core (`schema_helpers.rs`)**
- Added memoization for `has_geometry_by_name()` and new `is_simple_geometry_type()` function using `RwLock<FxHashMap>` behind `OnceLock`
- During scene construction, ~50–100 distinct type names are queried thousands of times; memoization eliminates repeated `IfcType::from_str()` (1300-arm match) and `is_subtype_of()` traversal costs
- Extracted `normalise_uppercase()` helper to avoid allocations when input is already uppercase (common case for STEP tokens)
- Improved reinforcement type detection: changed from `contains("REINFORC")` substring match to `starts_with("IFCREINFORCING" | "IFCREINFORCED")` for precision
- Moved `is_simple_geometry_type()` from wasm-bindings into core and added caching

**TypeScript Spatial Detection (`auto-space-detect.ts`)**
- Replaced O(N) linear vertex lookup with spatial hash grid keyed on snap-sized cells
- Grid probes cell + 8 neighbors for boundary-safe lookups, keeping average case O(1)
- Replaced O(N³) iterative segment-splitting loop with single O(N²) pass that collects all crossings, then splits each segment once
- Added bounding-box pre-checks to skip non-overlapping segment pairs
- Renamed `segmentIntersection()` to `segmentIntersectionParam()` to return parametric positions (t, u) for precise split points

**Property Mutations (`mutable-property-view.ts`)**
- Added secondary indices: `propertyKeysByEntity` and `quantityKeysByEntity` maps
- Changed `getForEntity()` from O(M·P) (scanning all mutations per pset) to O(M_entity) (per-entity key set lookup)
- Extracted `setPropertyMutation()`, `deletePropertyMutation()`, `setQuantityMutation()`, `deleteQuantityMutation()` helpers to maintain index consistency

**Wall Extraction (`extract-walls.ts`)**
- Added `buildRelatingChildrenIndex()` to pre-compute relationship indices by "relating" entity
- Changed from O(R·N) (scanning all rels per parent) to O(1) lookups via indexed maps
- Passed `extractor` parameter to avoid redundant instantiation

**STEP Export (`step-exporter.ts`)**
- Added `buildRelDefinesByPropertiesIndex()` to index IfcRelDefinesByProperties by related entity
- Changed property/quantity mutation loops from O(E·N) (scanning all entities per mutation) to O(K) (per-entity rel count)

**Renderer (`index.ts`)**
- Pre-computed `selectedExpressIds` set once per frame instead of checking multiple times
- Snapshot `transparencyOverrides` map to prevent mid-frame mutation desync
- Added batch alpha cache to avoid walking `batch.expressIds` twice per batch per frame
- Exempted selected meshes from transparency overrides to keep classification consistent

**UI/Sandbox**
- Added perf gates in `AddElementOverlay.tsx`: skip animation loop when no content exists, only re-render on actual camera movement
- Extracted validation helpers in `bridge-store.ts` to reduce duplication
- Added cycle/depth guards in `bridge-schema.ts` `marshalValue()` to protect against pathological object graphs
- Added `refreshWatermark()` to `StoreEditor` for lazy index hydration scenarios
- Relaxed entity name validation to allow underscores for vendor extensions

## Implementation Details

- Memoization uses `OnceLock` for thread-safe lazy initialization with zero runtime cost after first access
- Spatial hash uses `Math.floor(coord / cellSize)` for O(1) cell lookup
- Segment splitting collects all (t, vertexId) pairs per segment,

https://claude.ai/code/session_01LQ5fPCATnKPHnKRau6zTWE