### PR TITLE
fix(deploy): SPA-fallback rewrite for /mcp on Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -12,6 +12,14 @@
     {
       "source": "/api/bsdd/:path*",
       "destination": "https://api.bsdd.buildingsmart.org/:path*"
+    },
+    {
+      "source": "/mcp",
+      "destination": "/index.html"
+    },
+    {
+      "source": "/mcp/:path*",
+      "destination": "/index.html"
     }
   ],
   "headers": [


### PR DESCRIPTION
## Summary

- Adds Vercel rewrites so `/mcp` and `/mcp/playground` hit the SPA shell (`/index.html`) instead of returning 404 on direct navigation / refresh / shared link.

## Why

`https://www.ifclite.com/mcp` was 404'ing in production after #615 merged. `vercel.json` had no SPA fallback — the build serves the static dist verbatim, and there is no `mcp/index.html` file, so the request never reached the React router. Internal navigation worked because `pushState` + `popstate` are pure-client.

The old `App.tsx` even documented the same condition for `/settings`: *"vercel.json does not rewrite it"*. That was intentional for `/settings` (no link points there on the web), but `/mcp` is a real public surface — linked from the viewer empty-state card, the toolbar, and the README.

## What

Two narrow rewrites instead of a catch-all `/(.*)`, so we don't accidentally reactivate `/settings` (or any other internal-only route):

```json
{ "source": "/mcp",         "destination": "/index.html" },
{ "source": "/mcp/:path*",  "destination": "/index.html" }
```

## Test plan

- [ ] After merge: `curl -I https://www.ifclite.com/mcp` returns 200 (not 404)
- [ ] `https://www.ifclite.com/mcp/playground` loads the playground page directly
- [ ] `/settings` still does not resolve on the web (we didn't broaden the catch-all)
- [ ] `/api/epsg/*` and `/api/bsdd/*` proxies still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment routing configuration to improve application navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->