### PR TITLE
ci: fix release workflow + skip-when-missing on fixture-loading tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,23 @@ jobs:
       - name: Install Dependencies
         run: pnpm install
 
+      # Cache + fetch fixtures so cross-package tests that load
+      # tests/models/ifc5/*.ifcx (pointcloud, export, ifcx) can run.
+      # Mirrors the Test workflow; key changes only when the manifest does.
+      - name: Cache test fixtures
+        id: fixtures-cache
+        uses: actions/cache@v5
+        with:
+          path: tests/models
+          key: fixtures-${{ hashFiles('tests/models/manifest.json') }}
+
+      - name: Fetch fixtures
+        if: steps.fixtures-cache.outputs.cache-hit != 'true'
+        run: pnpm fixtures
+
+      - name: Verify fixtures
+        run: pnpm fixtures:check
+
       - name: Build Packages
         run: pnpm build
 

--- a/packages/export/src/ifc5-exporter.test.ts
+++ b/packages/export/src/ifc5-exporter.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { resolve } from 'path';
 import { Ifc5Exporter } from './ifc5-exporter.js';
 import { IfcParser, type IfcDataStore } from '@ifc-lite/parser';
@@ -27,6 +27,18 @@ import {
 // ============================================================================
 
 const MODELS_DIR = resolve(__dirname, '../../../tests/models/ifc5');
+
+// Fixtures are fetched on demand via `pnpm fixtures` (AGENTS.md §9). Cross-
+// validation tests that load reference IFCx files skip cleanly when the
+// fixtures aren't on disk so a fresh checkout doesn't crash with ENOENT.
+const FIXTURES = {
+  helloWall: 'Hello_Wall_hello-wall.ifcx',
+  accaBuilding: 'ACCA_Building_esempio_01_edificius.ifcx',
+  ifcHero: 'IFC_Hero_Model_IFC_Hero_Model.ifcx',
+} as const;
+const FIXTURES_AVAILABLE = Object.values(FIXTURES).every((name) =>
+  existsSync(resolve(MODELS_DIR, name)),
+);
 
 function loadReferenceFile(filename: string): any {
   return JSON.parse(readFileSync(resolve(MODELS_DIR, filename), 'utf-8'));
@@ -374,7 +386,7 @@ describe('Ifc5Exporter', () => {
       expect(errors).toEqual([]);
     });
 
-    it('uri pattern matches real IFC5 reference files', () => {
+    it.skipIf(!FIXTURES_AVAILABLE)('uri pattern matches real IFC5 reference files', () => {
       const ref = loadReferenceFile('Hello_Wall_hello-wall.ifcx');
       // Extract the URI pattern from reference
       const refUriPattern = /^https:\/\/identifier\.buildingsmart\.org\/uri\/buildingsmart\/ifc\/\d[.\d]*\/class\/\w+$/;
@@ -452,7 +464,7 @@ describe('Ifc5Exporter', () => {
   });
 
   describe('imports', () => {
-    it('import URIs match those used in real IFC5 files', () => {
+    it.skipIf(!FIXTURES_AVAILABLE)('import URIs match those used in real IFC5 files', () => {
       const ref = loadReferenceFile('Hello_Wall_hello-wall.ifcx');
       const refUris = new Set((ref.imports ?? []).map((i: any) => i.uri));
 
@@ -484,7 +496,7 @@ describe('Ifc5Exporter', () => {
     });
   });
 
-  describe('cross-validation against reference files', () => {
+  describe.skipIf(!FIXTURES_AVAILABLE)('cross-validation against reference files', () => {
     it('reference file Hello_Wall_hello-wall.ifcx passes official schema validation', () => {
       const ref = loadReferenceFile('Hello_Wall_hello-wall.ifcx');
       const errors = validateIfcxFile(ref);

--- a/packages/ifcx/src/hierarchy-builder.test.ts
+++ b/packages/ifcx/src/hierarchy-builder.test.ts
@@ -4,10 +4,13 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { parseIfcx } from './index.js';
 
 const HELLO_WALL_PATH = 'tests/models/ifc5/Hello_Wall_hello-wall.ifcx';
+// Per AGENTS.md §9 fixtures are fetched on demand; skip the suite cleanly
+// when the bytes aren't on disk so a fresh checkout doesn't crash here.
+const FIXTURES_AVAILABLE = existsSync(HELLO_WALL_PATH);
 const STOREY_PATH = '44af358b-3160-4063-8a89-a868335ff3b5';
 const SPACE_PATH = 'e3035b71-bd9f-4cdc-86fd-b56e2f4605b6';
 const WALL_PATH = '93791d5d-5beb-437b-b8ec-2f1f0ba4bf3b';
@@ -18,7 +21,7 @@ function toArrayBuffer(buffer: Buffer): ArrayBuffer {
   return buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
 }
 
-describe('buildHierarchy', () => {
+describe('buildHierarchy', { skip: !FIXTURES_AVAILABLE && 'tests/models/ifc5/Hello_Wall_hello-wall.ifcx missing — run `pnpm fixtures`' }, () => {
   it('maps Hello Wall space boundaries and nested windows into spatial containment', async () => {
     const buffer = readFileSync(HELLO_WALL_PATH);
     const result = await parseIfcx(toArrayBuffer(buffer));

--- a/packages/pointcloud/src/formats/pcd.test.ts
+++ b/packages/pointcloud/src/formats/pcd.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { decodePcd } from './pcd.js';
@@ -13,6 +13,13 @@ import { decodePcd } from './pcd.js';
 // fixture-loading tests don't break when this is run outside vitest.
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(HERE, '../../../..');
+
+// Fixtures live in a GitHub Release (AGENTS.md §9). Skip the IFCx-fixture
+// suite cleanly when they're absent so a fresh checkout — or any CI job
+// that hasn't run `pnpm fixtures` yet — doesn't crash with ENOENT.
+const SMALL_PCD = path.join(REPO_ROOT, 'tests/models/ifc5/Point_Cloud_point-cloud.ifcx');
+const LARGE_PCD = path.join(REPO_ROOT, 'tests/models/ifc5/Point_Cloud_S1-pointcloud.ifcx');
+const FIXTURES_AVAILABLE = existsSync(SMALL_PCD) && existsSync(LARGE_PCD);
 
 function buildAsciiPcd(rows: number[][], rgbColumn = false): Uint8Array {
   const fields = rgbColumn ? 'x y z rgb' : 'x y z';
@@ -97,7 +104,7 @@ describe('decodePcd binary', () => {
   });
 });
 
-describe('decodePcd against IFCx fixtures', () => {
+describe.skipIf(!FIXTURES_AVAILABLE)('decodePcd against IFCx fixtures', () => {
   it('decodes the small Point_Cloud sample (ascii subnode 213 points)', () => {
     const fixturePath = path.join(REPO_ROOT, 'tests/models/ifc5/Point_Cloud_point-cloud.ifcx');
     const ifcx = JSON.parse(readFileSync(fixturePath, 'utf-8')) as {


### PR DESCRIPTION
After #599 merged, the Release workflow on \`main\` failed because \`pnpm test\` loads \`tests/models/ifc5/Point_Cloud_S1-pointcloud.ifcx\` but \`release.yml\` never ran \`pnpm fixtures\`.

## Summary
- \`.github/workflows/release.yml\`: cache + fetch + verify fixtures before \`pnpm test\` (mirrors the Test workflow). Cache key = \`hashFiles('tests/models/manifest.json')\`.
- Three test files violated AGENTS.md §9 (\"tests must skip cleanly when a fixture is absent\") — they hard-crashed with ENOENT. Now they skip:
  - \`packages/pointcloud/src/formats/pcd.test.ts\` — \`describe.skipIf\`
  - \`packages/export/src/ifc5-exporter.test.ts\` — \`it.skipIf\` on 2 tests + \`describe.skipIf\` on the cross-validation block (5 tests total)
  - \`packages/ifcx/src/hierarchy-builder.test.ts\` (node:test) — \`describe(name, { skip: ... }, fn)\`

## Test plan
- [x] With fixtures: every previously-passing test still passes (62/62 in pointcloud).
- [x] Without fixtures: gated tests skip with a clear hint pointing at \`pnpm fixtures\` instead of crashing.
- [ ] CI Release workflow goes green on this PR's merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/louistrue/codesmith/ifc-lite/pr/621"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI workflow with test fixture caching and verification steps.
  * Updated test suites to gracefully skip when optional test fixtures are unavailable, improving test reliability and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->