### PR TITLE
Fix map conversion scaling for metre-converted geometry (issue #595)

### DIFF
--- a/.changeset/cesium-placement-and-navigation.md
+++ b/.changeset/cesium-placement-and-navigation.md
@@ -37,7 +37,7 @@ the same world position as toggling the clamp.
 **UX behaviours**
 
 - `cesiumTerrainClamp` defaults to `true` (slice + reset path).
-- Clamp toggle now actually un-uncheckable — dropped the auto-toggle
+- Clamp toggle is now actually uncheckable — dropped the auto-toggle
   branch that fought the user's setting.
 - Editing OrthogonalHeight directly auto-releases the clamp so the
   edit takes effect (with clamp on, placement is intentionally

--- a/.changeset/cesium-placement-and-navigation.md
+++ b/.changeset/cesium-placement-and-navigation.md
@@ -1,0 +1,68 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Cesium overlay: precomputed terrain placement, ground-floor clamping,
+and a refactored camera path.
+
+**Placement is now resolved before the bridge is built** (no more
+"model loads at IFC OrthogonalHeight, then jumps to terrain"):
+
+- `terrain-elevation.ts` (new module) tries sources in fast-first
+  order — sync `globe.getHeight`, sync `scene.sampleHeight`, async
+  `scene.sampleHeightMostDetailed` with a 3.5 s timeout, then
+  Open-Meteo as a bare-earth fallback. Implausible elevations
+  (e.g. depth-buffer noise from Google Photorealistic 3D Tiles
+  returning `-69184 m`) are range-checked against terrestrial bounds.
+  Results are cached per-session via `clearTerrainElevationCache()`.
+- `sampleHeightMostDetailed` runs *before* Open-Meteo so the model
+  lands on the same surface the user actually sees in 3D Tiles
+  (street decks, podiums) rather than the bare-earth DEM.
+- `createCesiumBridge` accepts a `placementHeightOverride` so the
+  computed placement is baked into the `enuToEcef` origin altitude
+  for both camera frame and model matrix from creation.
+
+**`findClampAnchorY` (new helper, 9 unit tests)** picks the anchor
+viewer-Y that auto-clamp pins to terrain. Primary: the
+`IfcBuildingStorey` whose elevation is closest to 0 (ground floor),
+within the model AABB. Fallback: `bounds.min.y`. Without this,
+basements and foundations dragged the model deep below the terrain
+surface.
+
+**`oHeightForBaseAltitude`** in the Georeferencing panel now mirrors
+the auto-clamp formula (anchor-aware, shift- and RTC-aware), so the
+"Set OrthogonalHeight to Cesium terrain elevation" button produces
+the same world position as toggling the clamp.
+
+**UX behaviours**
+
+- `cesiumTerrainClamp` defaults to `true` (slice + reset path).
+- Clamp toggle now actually un-uncheckable — dropped the auto-toggle
+  branch that fought the user's setting.
+- Editing OrthogonalHeight directly auto-releases the clamp so the
+  edit takes effect (with clamp on, placement is intentionally
+  terrain-anchored regardless of OrthogonalHeight).
+- Stale `terrainHeight` / `terrainClipY` are cleared when a re-query
+  fails so the clip plane doesn't drift relative to the new bridge.
+- Effect 2d depends on `bridgeVersion` so the model matrix refreshes
+  after an async bridge rebuild.
+
+**Camera navigation refactor.** Reported symptom: orbit/zoom
+restricted to the terrain plane. Two coupled root causes:
+
+1. `screenSpaceCameraController.enableInputs` was still default-true.
+   Any input slipping past the overlay's `pointer-events: none`
+   reached Cesium and got processed in the locked frame, fighting
+   our externally-driven pose. Now flipped to `false` (master kill-
+   switch) on top of the per-mode flags.
+2. `syncCamera` used `lookAtTransform(viewerToEcef)` to write
+   position/direction/up in viewer-space. `lookAtTransform` *locks*
+   Cesium's reference frame; rotate/tilt/zoom operations are then
+   constrained to that local frame — the "stuck to terrain plane"
+   behaviour. Refactored to clear `lookAtTransform` with
+   `Matrix4.IDENTITY` and write position/direction/up directly in
+   ECEF (Cesium's RTC handles shader precision for primitives).
+
+**Network hygiene.** `queryTerrainElevation` (Open-Meteo) gets a 5 s
+`AbortController` timeout and a `console.warn` so failures are
+visible instead of silently swallowed.

--- a/.changeset/fix-ifc-map-conversion-scale.md
+++ b/.changeset/fix-ifc-map-conversion-scale.md
@@ -1,0 +1,29 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Apply IfcMapConversion.Scale per IFC schema (issue #595).
+
+Scale converts local engineering coordinates (in the project length unit)
+to map CRS units (e.g. `0.001` for a millimetre project with a metre map).
+ifc-lite's geometry pipeline already converts vertices to metres during
+extraction, so applying the raw Scale to viewer-space coordinates double-
+scaled the model — making the Cesium 3D world context unusable for files
+authored per spec.
+
+Introduces `getEffectiveHorizontalScale(scale, mapUnitScale, lengthUnitScale)`
+which returns `(scale × mapUnitScale) / lengthUnitScale` — the correct
+multiplier for metre-converted geometry. For files where Scale is set
+consistently with the unit difference this evaluates to 1.0 and the
+geometry passes through unchanged. Wired through:
+
+- `cesium-bridge.ts` — 3D model origin and the viewer→ENU rotation.
+- `CesiumOverlay.tsx::buildModelMatrix` — GLB placement.
+- `reproject.ts` — 2D map centre, footprint, and reverse-pick.
+- `useIfcFederation.ts` — multi-model alignment transform.
+
+Adds a visible amber warning in the Georeferencing panel when
+`Scale × mapUnitScale ≠ lengthUnitScale` (the IFC schema invariant) so
+authoring errors are discoverable. The warning surfaces both inline (in
+the expanded Coordinate Operation section) and as a small indicator on
+the collapsed section header.

--- a/apps/viewer/src/components/viewer/CesiumOverlay.tsx
+++ b/apps/viewer/src/components/viewer/CesiumOverlay.tsx
@@ -432,34 +432,14 @@ export function CesiumOverlay({
         );
 
         if (isFirstPosition) {
-          // First time: place the camera ABOVE ground/terrain regardless of
-          // where the model itself sits. Without this, models authored at
-          // low elevations (or sites in alpine regions where the terrain is
-          // higher than the model origin) leave the camera buried under the
-          // globe — Cesium's near-surface controls become awkward and the
-          // user has to fight their way out. Try a synchronous terrain
-          // height first (fast path: any loaded tile answers); fall back to
-          // the async retry-aware query, then to 0 (WGS84 ellipsoid).
-          let groundH: number | null = null;
-          try {
-            const cart = Cesium.Cartographic.fromDegrees(
-              modelOrigin.longitude, modelOrigin.latitude,
-            );
-            const sync = viewer.scene.globe.getHeight(cart);
-            if (sync !== undefined && Number.isFinite(sync)) groundH = sync;
-          } catch { /* not available yet */ }
-          if (groundH === null) {
-            try { groundH = await bridge.queryTerrainHeight(Cesium, viewer); }
-            catch { /* keep null */ }
-            if (cancelled) return;
-          }
-
-          const ALTITUDE_ABOVE_GROUND = 500;
-          const placementBase = Math.max(modelOrigin.height, groundH ?? 0);
+          // First time: fly to the model location.
+          // On first load terrain tiles may not be ready, so globe.getHeight
+          // can return undefined. Use flyTo which handles terrain automatically,
+          // targeting a safe altitude above the model origin.
+          const safeHeight = Math.max(modelOrigin.height, 100);
           viewer.camera.flyTo({
             destination: Cesium.Cartesian3.fromDegrees(
-              modelOrigin.longitude, modelOrigin.latitude,
-              placementBase + ALTITUDE_ABOVE_GROUND,
+              modelOrigin.longitude, modelOrigin.latitude, safeHeight + 500,
             ),
             orientation: {
               heading: 0,

--- a/apps/viewer/src/components/viewer/CesiumOverlay.tsx
+++ b/apps/viewer/src/components/viewer/CesiumOverlay.tsx
@@ -480,6 +480,11 @@ export function CesiumOverlay({
         // matches the terrain surface.
         const terrainClipY = minY + (terrainH - ifcOHeight);
         setCesiumTerrainClipY(terrainClipY);
+      } else {
+        // Failed re-query (offline, API down) — clear stale store fields so
+        // the clip plane doesn't drift relative to the new bridge.
+        setCesiumTerrainHeight(null);
+        setCesiumTerrainClipY(null);
       }
 
       // World-camera stability: when this rebuild changes the placement
@@ -492,7 +497,10 @@ export function CesiumOverlay({
       prevPlacementRef.current = placementHeight;
       if (prevPlacement !== null) {
         const dh = placementHeight - prevPlacement;
-        if (Math.abs(dh) > 1e-6) {
+        // 5 cm threshold — rejects float jitter from cached terrain reads
+        // re-flowing through the same effect, while a real placement edit
+        // (clamp toggle, OrthogonalHeight change) is always far larger.
+        if (Math.abs(dh) > 0.05) {
           const renderer = getGlobalRenderer();
           if (renderer) {
             const cam = renderer.getCamera();
@@ -510,10 +518,11 @@ export function CesiumOverlay({
     })();
 
     return () => { cancelled = true; };
-  }, [
-    status, mapConversion, projectedCRS, coordinateInfo, lengthUnitScale,
-    terrainClamp, terrainEnabled, ionToken,
-  ]);
+    // terrainEnabled and ionToken intentionally omitted — Effect 1 already
+    // owns those (it destroys/recreates the viewer when they change), and
+    // listing them here would cause a redundant bridge rebuild while the
+    // viewer is being torn down.
+  }, [status, mapConversion, projectedCRS, coordinateInfo, lengthUnitScale, terrainClamp]);
 
   // ─── Effect 2c: Load GLB into Cesium (only when geometry changes) ───────
   // This is the heavy operation — only re-runs when geometry actually changes.

--- a/apps/viewer/src/components/viewer/CesiumOverlay.tsx
+++ b/apps/viewer/src/components/viewer/CesiumOverlay.tsx
@@ -562,15 +562,10 @@ export function CesiumOverlay({
     const pos = cam.getPosition();
     const tgt = cam.getTarget();
     let newY = pos.y;
-    let newTgtX = tgt.x;
     let newTgtY = tgt.y;
-    let newTgtZ = tgt.z;
 
     // 1. Stability — compensate placement delta on every change after the
     //    first observation so the user's world camera position stays fixed.
-    //    Both position AND target shift by the same amount so the world
-    //    look-at point is preserved (otherwise editing OrthogonalHeight
-    //    rotates the camera as well as translating it).
     if (prev !== null) {
       const dh = placement - prev;
       if (Math.abs(dh) > 1e-6) {
@@ -604,27 +599,13 @@ export function CesiumOverlay({
         const buffer = Math.max(100, modelH * 2);
         const lift = (groundFloor + buffer) - currentWorldAlt;
         newY += lift;
-
-        // Aim the camera at the model BASE so the lifted view actually
-        // shows the model centred on screen — without this the camera
-        // looks past the model and the building ends up at the bottom of
-        // the viewport (or off-screen for shorter buildings).
-        if (bounds) {
-          newTgtX = (bounds.min.x + bounds.max.x) / 2;
-          newTgtY = bounds.min.y;
-          newTgtZ = (bounds.min.z + bounds.max.z) / 2;
-        }
+        newTgtY += lift;
       }
     }
 
-    if (
-      newY !== pos.y ||
-      newTgtX !== tgt.x ||
-      newTgtY !== tgt.y ||
-      newTgtZ !== tgt.z
-    ) {
+    if (newY !== pos.y || newTgtY !== tgt.y) {
       cam.setPosition(pos.x, newY, pos.z);
-      cam.setTarget(newTgtX, newTgtY, newTgtZ);
+      cam.setTarget(tgt.x, newTgtY, tgt.z);
     }
   }, [status, bridgeVersion, terrainClamp, terrainHeight, coordinateInfo]);
 

--- a/apps/viewer/src/components/viewer/CesiumOverlay.tsx
+++ b/apps/viewer/src/components/viewer/CesiumOverlay.tsx
@@ -252,11 +252,26 @@ export function CesiumOverlay({
   // Use refs so the camera sync loop always reads the latest values
   const terrainClampRef = useRef(terrainClamp);
   const terrainHeightRef = useRef(terrainHeight);
+  const coordinateInfoRef = useRef(coordinateInfo);
   terrainClampRef.current = terrainClamp;
   terrainHeightRef.current = terrainHeight;
+  coordinateInfoRef.current = coordinateInfo;
 
   // Track whether we've auto-clamped to terrain (only once, so user can still uncheck)
   const autoClampedRef = useRef(false);
+
+  // The world altitude where the model frame currently sits (in metres). When
+  // this changes — user edits OrthogonalHeight, terrain clamp toggles, terrain
+  // tile loads with a new height — we shift the IFC viewer's camera Y by the
+  // inverse so the user's world camera position stays put. Without this, every
+  // model-placement edit also translates the camera (because viewerToEcef and
+  // modelMatrix share the same origin altitude), which is what makes editing
+  // OrthogonalHeight feel like it's "moving the camera, not the model."
+  const prevPlacementRef = useRef<number | null>(null);
+  // Track that we've performed the initial above-ground lift so we don't fight
+  // the user's camera once they're navigating.
+  const initialLiftDoneRef = useRef(false);
+  const terrainLiftDoneRef = useRef(false);
 
   // Track the Cesium model (IFC geometry loaded as glTF for correct world positioning)
   const cesiumModelRef = useRef<{ modelMatrix: any; destroy?: () => void } | null>(null);
@@ -400,6 +415,9 @@ export function CesiumOverlay({
   useEffect(() => {
     if (status !== 'ready' || !mapConversion || !projectedCRS) {
       bridgeRef.current = null;
+      prevPlacementRef.current = null;
+      initialLiftDoneRef.current = false;
+      terrainLiftDoneRef.current = false;
       return;
     }
 
@@ -510,6 +528,86 @@ export function CesiumOverlay({
 
     return () => { cancelled = true; clearTimeout(retryTimer); };
   }, [status, terrainEnabled, terrainClamp, bridgeVersion]);
+
+  // ─── Effect 2bb: Anchor the IFC camera to the world ───────────────────
+  // Two responsibilities, both rooted in the fact that viewerToEcef and
+  // modelMatrix share the same enuToEcef origin altitude:
+  //
+  // 1. STABILITY — when the model placement altitude changes (user edits
+  //    OrthogonalHeight, terrain clamp toggles, etc.) we shift the IFC
+  //    camera Y by the inverse delta. Without this, editing the model feels
+  //    like it's moving the camera because the entire frame translates.
+  //
+  // 2. ABOVE-GROUND — on first activation (and once when terrain becomes
+  //    known) lift the camera if its world altitude lands at or below the
+  //    surface. Models authored at low elevations or sites in alpine regions
+  //    otherwise leave the user buried, fighting Cesium's near-surface
+  //    controls to climb back out.
+  useEffect(() => {
+    if (status !== 'ready') return;
+    const bridge = bridgeRef.current;
+    const renderer = getGlobalRenderer();
+    if (!bridge || !renderer) return;
+
+    const bounds = coordinateInfo?.originalBounds;
+    const mvy = bounds ? (bounds.min.y + bounds.max.y) / 2 : 0;
+    const minY = bounds?.min.y ?? 0;
+    const placement = (terrainClamp && terrainHeight !== null)
+      ? terrainHeight + (mvy - minY)
+      : bridge.modelOrigin.height;
+
+    const prev = prevPlacementRef.current;
+    prevPlacementRef.current = placement;
+    const cam = renderer.getCamera();
+    const pos = cam.getPosition();
+    const tgt = cam.getTarget();
+    let newY = pos.y;
+    let newTgtY = tgt.y;
+
+    // 1. Stability — compensate placement delta on every change after the
+    //    first observation so the user's world camera position stays fixed.
+    if (prev !== null) {
+      const dh = placement - prev;
+      if (Math.abs(dh) > 1e-6) {
+        newY -= dh;
+        newTgtY -= dh;
+      }
+    }
+
+    // 2. Above-ground lift — at most twice: once on first bridge
+    //    (no terrain yet → guarantee above the model frame), once when
+    //    terrain first becomes known (lift above terrain if still below).
+    //    Only triggers when the user is actually at or below the surface;
+    //    a normal "above ground" view is left alone so we don't fight a
+    //    user who deliberately zoomed close.
+    const isFirstBridge = !initialLiftDoneRef.current;
+    const terrainJustKnown = terrainHeight !== null && !terrainLiftDoneRef.current;
+    if (isFirstBridge || terrainJustKnown) {
+      if (isFirstBridge) initialLiftDoneRef.current = true;
+      if (terrainHeight !== null) terrainLiftDoneRef.current = true;
+
+      const groundFloor = (terrainHeight !== null)
+        ? Math.max(terrainHeight, placement)
+        : placement;
+      const currentWorldAlt = placement + (newY - mvy);
+      if (currentWorldAlt <= groundFloor) {
+        // Lift to a sensible viewing altitude above ground — at least 100 m
+        // or twice the model height, whichever is larger, so the user can
+        // see the model without immediately fighting Cesium's slow
+        // near-surface controls.
+        const modelH = bounds ? bounds.max.y - bounds.min.y : 0;
+        const buffer = Math.max(100, modelH * 2);
+        const lift = (groundFloor + buffer) - currentWorldAlt;
+        newY += lift;
+        newTgtY += lift;
+      }
+    }
+
+    if (newY !== pos.y || newTgtY !== tgt.y) {
+      cam.setPosition(pos.x, newY, pos.z);
+      cam.setTarget(tgt.x, newTgtY, tgt.z);
+    }
+  }, [status, bridgeVersion, terrainClamp, terrainHeight, coordinateInfo]);
 
   // ─── Effect 2c: Load GLB into Cesium (only when geometry changes) ───────
   // This is the heavy operation — only re-runs when geometry actually changes.
@@ -640,8 +738,19 @@ export function CesiumOverlay({
       const camUp = camera.getUp();
       const fov = camera.getFOV();
 
-      // Sync Cesium camera (no terrain offset — model matrix handles clamping)
-      bridge.syncCamera(Cesium, viewer, camPos, camTarget, camUp, fov);
+      // Camera frame must share the model's enuToEcef origin altitude or the
+      // GLB and the camera diverge (model rendered above/below where the IFC
+      // viewer thinks the camera is looking). When terrain clamping moves the
+      // model up to the terrain surface, lift the camera frame the same way.
+      const bounds = coordinateInfoRef.current?.originalBounds;
+      const mvyForClamp = bounds ? (bounds.min.y + bounds.max.y) / 2 : 0;
+      const minYForClamp = bounds?.min.y ?? 0;
+      let clampOffset = 0;
+      if (terrainClampRef.current && terrainHeightRef.current !== null) {
+        const placement = terrainHeightRef.current + (mvyForClamp - minYForClamp);
+        clampOffset = placement - bridge.modelOrigin.height;
+      }
+      bridge.syncCamera(Cesium, viewer, camPos, camTarget, camUp, fov, clampOffset);
 
       rafRef.current = requestAnimationFrame(syncCamera);
     }

--- a/apps/viewer/src/components/viewer/CesiumOverlay.tsx
+++ b/apps/viewer/src/components/viewer/CesiumOverlay.tsx
@@ -302,10 +302,14 @@ export function CesiumOverlay({
 
         if (cancelled) { viewer.destroy(); return; }
 
-        // Disable Cesium's user input — the IFC viewer controls the camera.
-        // Keep collision detection off since we set the camera programmatically.
+        // Disable Cesium's user input — the IFC viewer drives the camera,
+        // and any input Cesium intercepts (even a stray wheel/touch event
+        // past pointer-events:none) interferes with our orbit/zoom and
+        // produces "stuck to terrain" symptoms. enableInputs is the
+        // master kill-switch; the per-mode flags below are belt-and-braces.
         const scene = viewer.scene;
         const sscc = scene.screenSpaceCameraController;
+        sscc.enableInputs = false;
         sscc.enableRotate = false;
         sscc.enableTranslate = false;
         sscc.enableZoom = false;

--- a/apps/viewer/src/components/viewer/CesiumOverlay.tsx
+++ b/apps/viewer/src/components/viewer/CesiumOverlay.tsx
@@ -562,10 +562,15 @@ export function CesiumOverlay({
     const pos = cam.getPosition();
     const tgt = cam.getTarget();
     let newY = pos.y;
+    let newTgtX = tgt.x;
     let newTgtY = tgt.y;
+    let newTgtZ = tgt.z;
 
     // 1. Stability — compensate placement delta on every change after the
     //    first observation so the user's world camera position stays fixed.
+    //    Both position AND target shift by the same amount so the world
+    //    look-at point is preserved (otherwise editing OrthogonalHeight
+    //    rotates the camera as well as translating it).
     if (prev !== null) {
       const dh = placement - prev;
       if (Math.abs(dh) > 1e-6) {
@@ -599,13 +604,27 @@ export function CesiumOverlay({
         const buffer = Math.max(100, modelH * 2);
         const lift = (groundFloor + buffer) - currentWorldAlt;
         newY += lift;
-        newTgtY += lift;
+
+        // Aim the camera at the model BASE so the lifted view actually
+        // shows the model centred on screen — without this the camera
+        // looks past the model and the building ends up at the bottom of
+        // the viewport (or off-screen for shorter buildings).
+        if (bounds) {
+          newTgtX = (bounds.min.x + bounds.max.x) / 2;
+          newTgtY = bounds.min.y;
+          newTgtZ = (bounds.min.z + bounds.max.z) / 2;
+        }
       }
     }
 
-    if (newY !== pos.y || newTgtY !== tgt.y) {
+    if (
+      newY !== pos.y ||
+      newTgtX !== tgt.x ||
+      newTgtY !== tgt.y ||
+      newTgtZ !== tgt.z
+    ) {
       cam.setPosition(pos.x, newY, pos.z);
-      cam.setTarget(tgt.x, newTgtY, tgt.z);
+      cam.setTarget(newTgtX, newTgtY, newTgtZ);
     }
   }, [status, bridgeVersion, terrainClamp, terrainHeight, coordinateInfo]);
 

--- a/apps/viewer/src/components/viewer/CesiumOverlay.tsx
+++ b/apps/viewer/src/components/viewer/CesiumOverlay.tsx
@@ -560,17 +560,17 @@ export function CesiumOverlay({
     prevPlacementRef.current = placement;
     const cam = renderer.getCamera();
     const pos = cam.getPosition();
-    const tgt = cam.getTarget();
     let newY = pos.y;
-    let newTgtY = tgt.y;
 
-    // 1. Stability — compensate placement delta on every change after the
-    //    first observation so the user's world camera position stays fixed.
+    // 1. Stability — compensate placement delta so the world camera position
+    //    stays fixed across edits. Only the camera POSITION is shifted; the
+    //    target stays put in viewer-space so its world altitude (placement +
+    //    target.y − mvy) tracks the model. That way the camera keeps looking
+    //    AT the model, not at the empty space the model used to occupy.
     if (prev !== null) {
       const dh = placement - prev;
       if (Math.abs(dh) > 1e-6) {
         newY -= dh;
-        newTgtY -= dh;
       }
     }
 
@@ -592,20 +592,20 @@ export function CesiumOverlay({
       const currentWorldAlt = placement + (newY - mvy);
       if (currentWorldAlt <= groundFloor) {
         // Lift to a sensible viewing altitude above ground — at least 100 m
-        // or twice the model height, whichever is larger, so the user can
-        // see the model without immediately fighting Cesium's slow
-        // near-surface controls.
+        // or the model height, whichever is larger, so the user can see the
+        // model without immediately fighting Cesium's slow near-surface
+        // controls. Only POSITION lifts; target stays anchored to the model
+        // so the building sits roughly centred (rather than pinned to the
+        // bottom of the viewport).
         const modelH = bounds ? bounds.max.y - bounds.min.y : 0;
-        const buffer = Math.max(100, modelH * 2);
+        const buffer = Math.max(100, modelH);
         const lift = (groundFloor + buffer) - currentWorldAlt;
         newY += lift;
-        newTgtY += lift;
       }
     }
 
-    if (newY !== pos.y || newTgtY !== tgt.y) {
+    if (newY !== pos.y) {
       cam.setPosition(pos.x, newY, pos.z);
-      cam.setTarget(tgt.x, newTgtY, tgt.z);
     }
   }, [status, bridgeVersion, terrainClamp, terrainHeight, coordinateInfo]);
 

--- a/apps/viewer/src/components/viewer/CesiumOverlay.tsx
+++ b/apps/viewer/src/components/viewer/CesiumOverlay.tsx
@@ -26,6 +26,7 @@ import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
 import type { CoordinateInfo, GeometryResult } from '@ifc-lite/geometry';
 import { getGlobalRenderer } from '@/hooks/useBCF';
 import { createCesiumBridge, type CesiumBridge } from '@/lib/geo/cesium-bridge';
+import { findClampAnchorY } from '@/lib/geo/clamp-anchor';
 import { getEffectiveHorizontalScale } from '@/lib/geo/effective-georef';
 
 // Lazy-loaded Cesium module and CSS
@@ -214,6 +215,10 @@ export interface CesiumOverlayProps {
   geometryResult?: GeometryResult | null;
   /** IFC project length unit → metres (e.g. 0.001 for mm models). Default 1. */
   lengthUnitScale?: number;
+  /** IfcBuildingStorey elevations (express id → metres, viewer-Y aligned).
+   *  Used to clamp the model's ground-floor storey to terrain instead of
+   *  the lowest geometry vertex (which can be a basement or foundation). */
+  storeyElevations?: Map<number, number>;
 }
 
 export function CesiumOverlay({
@@ -222,6 +227,7 @@ export function CesiumOverlay({
   coordinateInfo,
   geometryResult,
   lengthUnitScale = 1,
+  storeyElevations,
 }: CesiumOverlayProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const viewerRef = useRef<InstanceType<typeof import('cesium').Viewer> | null>(null);
@@ -438,7 +444,11 @@ export function CesiumOverlay({
       const bounds = coordinateInfo?.originalBounds;
       const mvy = bounds ? (bounds.min.y + bounds.max.y) / 2 : 0;
       const minY = bounds?.min.y ?? 0;
-      const bottomOffset = mvy - minY;
+      // Clamp anchor: viewer-Y of the storey nearest elevation 0 (typical
+      // ground floor), falling back to bounds.min.y. Without this, basements
+      // and foundations drag the model deep below terrain.
+      const clampAnchorY = findClampAnchorY(bounds, storeyElevations);
+      const anchorOffset = mvy - clampAnchorY;
       const ifcOHeight = tentative.modelOrigin.height;
       // Clamp is purely the user's choice. We do NOT auto-clamp on top of
       // the user's setting — that would reactivate the toggle the moment
@@ -447,12 +457,13 @@ export function CesiumOverlay({
       // checkbox becomes un-uncheckable).
       const placementHeight =
         terrainClamp && terrainH !== null
-          ? terrainH + bottomOffset
+          ? terrainH + anchorOffset
           : ifcOHeight;
 
       console.debug(
         `[CesiumOverlay] placement decision: terrain=${terrainH?.toFixed(2) ?? 'null'}m`
-        + ` ifcOHeight=${ifcOHeight.toFixed(2)}m bottomOffset=${bottomOffset.toFixed(2)}m`
+        + ` ifcOHeight=${ifcOHeight.toFixed(2)}m anchorY=${clampAnchorY.toFixed(2)}m`
+        + ` (minY=${minY.toFixed(2)}m, ${storeyElevations?.size ?? 0} storeys)`
         + ` clamp=${terrainClamp} placement=${placementHeight.toFixed(2)}m`
         + ` (terrain query: ${terrainMs.toFixed(0)}ms)`
       );
@@ -477,8 +488,10 @@ export function CesiumOverlay({
         setCesiumTerrainHeight(terrainH);
         // terrainClipY stays in viewer-space; it represents the world terrain
         // altitude expressed in the bridge's frame so a clip plane at that Y
-        // matches the terrain surface.
-        const terrainClipY = minY + (terrainH - ifcOHeight);
+        // matches the terrain surface. Use the clamp anchor (ground floor)
+        // rather than minY so the clip plane matches the user's ground level
+        // rather than the basement floor.
+        const terrainClipY = clampAnchorY + (terrainH - ifcOHeight);
         setCesiumTerrainClipY(terrainClipY);
       } else {
         // Failed re-query (offline, API down) — clear stale store fields so
@@ -522,7 +535,7 @@ export function CesiumOverlay({
     // owns those (it destroys/recreates the viewer when they change), and
     // listing them here would cause a redundant bridge rebuild while the
     // viewer is being torn down.
-  }, [status, mapConversion, projectedCRS, coordinateInfo, lengthUnitScale, terrainClamp]);
+  }, [status, mapConversion, projectedCRS, coordinateInfo, lengthUnitScale, terrainClamp, storeyElevations]);
 
   // ─── Effect 2c: Load GLB into Cesium (only when geometry changes) ───────
   // This is the heavy operation — only re-runs when geometry actually changes.

--- a/apps/viewer/src/components/viewer/CesiumOverlay.tsx
+++ b/apps/viewer/src/components/viewer/CesiumOverlay.tsx
@@ -432,14 +432,34 @@ export function CesiumOverlay({
         );
 
         if (isFirstPosition) {
-          // First time: fly to the model location.
-          // On first load terrain tiles may not be ready, so globe.getHeight
-          // can return undefined. Use flyTo which handles terrain automatically,
-          // targeting a safe altitude above the model origin.
-          const safeHeight = Math.max(modelOrigin.height, 100);
+          // First time: place the camera ABOVE ground/terrain regardless of
+          // where the model itself sits. Without this, models authored at
+          // low elevations (or sites in alpine regions where the terrain is
+          // higher than the model origin) leave the camera buried under the
+          // globe — Cesium's near-surface controls become awkward and the
+          // user has to fight their way out. Try a synchronous terrain
+          // height first (fast path: any loaded tile answers); fall back to
+          // the async retry-aware query, then to 0 (WGS84 ellipsoid).
+          let groundH: number | null = null;
+          try {
+            const cart = Cesium.Cartographic.fromDegrees(
+              modelOrigin.longitude, modelOrigin.latitude,
+            );
+            const sync = viewer.scene.globe.getHeight(cart);
+            if (sync !== undefined && Number.isFinite(sync)) groundH = sync;
+          } catch { /* not available yet */ }
+          if (groundH === null) {
+            try { groundH = await bridge.queryTerrainHeight(Cesium, viewer); }
+            catch { /* keep null */ }
+            if (cancelled) return;
+          }
+
+          const ALTITUDE_ABOVE_GROUND = 500;
+          const placementBase = Math.max(modelOrigin.height, groundH ?? 0);
           viewer.camera.flyTo({
             destination: Cesium.Cartesian3.fromDegrees(
-              modelOrigin.longitude, modelOrigin.latitude, safeHeight + 500,
+              modelOrigin.longitude, modelOrigin.latitude,
+              placementBase + ALTITUDE_ABOVE_GROUND,
             ),
             orientation: {
               heading: 0,

--- a/apps/viewer/src/components/viewer/CesiumOverlay.tsx
+++ b/apps/viewer/src/components/viewer/CesiumOverlay.tsx
@@ -170,8 +170,6 @@ function buildModelMatrix(
   mapConversion: MapConversion | undefined,
   projectedCRS: ProjectedCRS | undefined,
   coordinateInfo: CoordinateInfo | undefined,
-  clamp: boolean,
-  terrainH: number | null,
   lengthUnitScale: number,
 ) {
   // GLB vertices are in viewer-space metres (geometry engine converts during
@@ -188,15 +186,11 @@ function buildModelMatrix(
   const mvy = bounds ? (bounds.min.y + bounds.max.y) / 2 : 0;
   const mvz = bounds ? (bounds.min.z + bounds.max.z) / 2 : 0;
 
-  let placementHeight = bridge.modelOrigin.height;
-  if (clamp && terrainH !== null) {
-    const minY = bounds?.min.y ?? 0;
-    const bottomOffset = mvy - minY; // already in metres
-    placementHeight = terrainH + bottomOffset;
-  }
-
+  // bridge.modelOrigin.height is the placement altitude — Effect 2 already
+  // baked terrain clamping (when applicable) into it before constructing the
+  // bridge, so there's no per-frame clamp adjustment to make here.
   const origin = Cesium.Cartesian3.fromDegrees(
-    bridge.modelOrigin.longitude, bridge.modelOrigin.latitude, placementHeight,
+    bridge.modelOrigin.longitude, bridge.modelOrigin.latitude, bridge.modelOrigin.height,
   );
   const enuToEcef = Cesium.Transforms.eastNorthUpToFixedFrame(origin);
   // No lengthUnitScale here — viewer-space GLB vertices are already in metres.
@@ -248,30 +242,6 @@ export function CesiumOverlay({
   const setCesiumTerrainHeight = useViewerStore((s) => s.setCesiumTerrainHeight);
   const setCesiumTerrainClipY = useViewerStore((s) => s.setCesiumTerrainClipY);
   const setCesiumGlbLoaded = useViewerStore((s) => s.setCesiumGlbLoaded);
-
-  // Use refs so the camera sync loop always reads the latest values
-  const terrainClampRef = useRef(terrainClamp);
-  const terrainHeightRef = useRef(terrainHeight);
-  const coordinateInfoRef = useRef(coordinateInfo);
-  terrainClampRef.current = terrainClamp;
-  terrainHeightRef.current = terrainHeight;
-  coordinateInfoRef.current = coordinateInfo;
-
-  // Track whether we've auto-clamped to terrain (only once, so user can still uncheck)
-  const autoClampedRef = useRef(false);
-
-  // The world altitude where the model frame currently sits (in metres). When
-  // this changes — user edits OrthogonalHeight, terrain clamp toggles, terrain
-  // tile loads with a new height — we shift the IFC viewer's camera Y by the
-  // inverse so the user's world camera position stays put. Without this, every
-  // model-placement edit also translates the camera (because viewerToEcef and
-  // modelMatrix share the same origin altitude), which is what makes editing
-  // OrthogonalHeight feel like it's "moving the camera, not the model."
-  const prevPlacementRef = useRef<number | null>(null);
-  // Track that we've performed the initial above-ground lift so we don't fight
-  // the user's camera once they're navigating.
-  const initialLiftDoneRef = useRef(false);
-  const terrainLiftDoneRef = useRef(false);
 
   // Track the Cesium model (IFC geometry loaded as glTF for correct world positioning)
   const cesiumModelRef = useRef<{ modelMatrix: any; destroy?: () => void } | null>(null);
@@ -409,205 +379,102 @@ export function CesiumOverlay({
     };
   }, [cesiumEnabled, ionToken, terrainEnabled, dataSource]);
 
-  // ─── Effect 2: Rebuild coordinate bridge when georef changes (fast) ─────
-  // This is the live-edit handler. When the user changes EPSG, eastings,
-  // northings, rotation, etc., we rebuild the bridge and fly to the new spot.
+  // ─── Effect 2: Build the coordinate bridge with terrain-aware placement ─
+  // Precomputes the model placement (terrain-clamped if applicable) BEFORE
+  // building the bridge that the GLB and camera will share. This way the
+  // model loads into Cesium at its final altitude — no post-load shifting,
+  // no camera/model frame divergence, no compensation gymnastics.
+  //
+  // Sequence:
+  //   1. Build a tentative bridge to recover the model's WGS84 lat/lon.
+  //   2. Query terrain at that lat/lon (sync first, async with retry next).
+  //   3. Decide whether to clamp (user toggle OR model authored below terrain).
+  //   4. Rebuild the bridge with placementHeight baked into its enuToEcef
+  //      origin so model matrix and camera frame share a single altitude.
+  //   5. Push terrain-derived state (height, clip Y, clamp toggle) and
+  //      install the bridge.
   useEffect(() => {
     if (status !== 'ready' || !mapConversion || !projectedCRS) {
       bridgeRef.current = null;
-      prevPlacementRef.current = null;
-      initialLiftDoneRef.current = false;
-      terrainLiftDoneRef.current = false;
       return;
     }
 
     let cancelled = false;
 
     (async () => {
-      const bridge = await createCesiumBridge(mapConversion, projectedCRS, coordinateInfo, lengthUnitScale);
-      if (cancelled) return;
+      const Cesium = cesiumModule;
+      const viewer = viewerRef.current;
+      if (!Cesium || !viewer) return;
 
-      if (!bridge) {
+      const tentative = await createCesiumBridge(
+        mapConversion, projectedCRS, coordinateInfo, lengthUnitScale,
+      );
+      if (cancelled) return;
+      if (!tentative) {
         bridgeRef.current = null;
         return;
       }
 
-      const prevBridge = bridgeRef.current;
-      bridgeRef.current = bridge;
-      autoClampedRef.current = false; // reset for new bridge
-      // Bump version so terrain query effect re-runs now that bridge is ready
-      setBridgeVersion((v) => v + 1);
-
-      // Fly to the new model location (smooth animation)
-      const viewer = viewerRef.current;
-      const Cesium = cesiumModule;
-      if (viewer && Cesium) {
-        const { modelOrigin } = bridge;
-
-        const isFirstPosition = !prevBridge;
-        const target = Cesium.Cartesian3.fromDegrees(
-          modelOrigin.longitude, modelOrigin.latitude, modelOrigin.height,
-        );
-
-        if (isFirstPosition) {
-          // First time: fly to the model location.
-          // On first load terrain tiles may not be ready, so globe.getHeight
-          // can return undefined. Use flyTo which handles terrain automatically,
-          // targeting a safe altitude above the model origin.
-          const safeHeight = Math.max(modelOrigin.height, 100);
-          viewer.camera.flyTo({
-            destination: Cesium.Cartesian3.fromDegrees(
-              modelOrigin.longitude, modelOrigin.latitude, safeHeight + 500,
-            ),
-            orientation: {
-              heading: 0,
-              pitch: Cesium.Math.toRadians(-45),
-              roll: 0,
-            },
-            duration: 0, // instant
-          });
-        } else if (prevBridge) {
-          // Georef edit: just re-render, the camera sync loop will pick
-          // up the new bridge on the next frame. No dramatic fly animation.
-          viewer.scene.requestRender();
-        }
+      // Query terrain at the model's location. queryTerrainHeight tries
+      // sync globe.getHeight first, then async sampleTerrainMostDetailed,
+      // then a 3 s retry — bounded delay, no jump on success.
+      let terrainH: number | null = null;
+      if (terrainEnabled && ionToken) {
+        try { terrainH = await tentative.queryTerrainHeight(Cesium, viewer); }
+        catch (err) { console.warn('[CesiumOverlay] terrain query failed:', err); }
+        if (cancelled) return;
       }
+
+      const bounds = coordinateInfo?.originalBounds;
+      const mvy = bounds ? (bounds.min.y + bounds.max.y) / 2 : 0;
+      const minY = bounds?.min.y ?? 0;
+      const bottomOffset = mvy - minY;
+      const ifcOHeight = tentative.modelOrigin.height;
+      // Auto-clamp when the user has it on, OR when the model is authored
+      // meaningfully below terrain (matching the previous auto-toggle).
+      const wantClamp =
+        terrainClamp ||
+        (terrainH !== null && terrainH > ifcOHeight + 5);
+      const placementHeight =
+        wantClamp && terrainH !== null
+          ? terrainH + bottomOffset
+          : ifcOHeight;
+
+      // Build the final bridge with the placement baked in (or reuse the
+      // tentative one when the placement matches its IFC-derived origin).
+      let bridge = tentative;
+      if (Math.abs(placementHeight - ifcOHeight) > 1e-6) {
+        const final = await createCesiumBridge(
+          mapConversion, projectedCRS, coordinateInfo, lengthUnitScale,
+          placementHeight,
+        );
+        if (cancelled) return;
+        if (!final) {
+          bridgeRef.current = null;
+          return;
+        }
+        bridge = final;
+      }
+
+      if (terrainH !== null) {
+        setCesiumTerrainHeight(terrainH);
+        // terrainClipY stays in viewer-space; it represents the world terrain
+        // altitude expressed in the bridge's frame so a clip plane at that Y
+        // matches the terrain surface.
+        const terrainClipY = minY + (terrainH - ifcOHeight);
+        setCesiumTerrainClipY(terrainClipY);
+        if (!terrainClamp && wantClamp) setCesiumTerrainClamp(true);
+      }
+
+      bridgeRef.current = bridge;
+      setBridgeVersion((v) => v + 1);
     })();
 
     return () => { cancelled = true; };
-  }, [status, mapConversion, projectedCRS, coordinateInfo, lengthUnitScale]);
-
-  // ─── Effect 2b: Query terrain height when bridge is ready ───────────────
-  // Also re-queries when terrainClamp is toggled on (in case first query failed)
-  useEffect(() => {
-    if (status !== 'ready') return;
-    const bridge = bridgeRef.current;
-    const viewer = viewerRef.current;
-    const Cesium = cesiumModule;
-    if (!bridge || !viewer || !Cesium) return;
-
-    let cancelled = false;
-
-    // Query immediately, then retry after a delay if terrain tiles weren't loaded yet
-    // Compute model center Y in viewer space for terrain clip offset
-    const bounds = coordinateInfo?.originalBounds;
-    const modelVY = bounds ? (bounds.min.y + bounds.max.y) / 2 : 0;
-    const modelMinY = bounds ? bounds.min.y : 0;
-
-    const doQuery = () => {
-      bridge.queryTerrainHeight(Cesium, viewer).then((h) => {
-        if (!cancelled && h !== null) {
-          setCesiumTerrainHeight(h);
-          // Compute terrain clip Y in viewer space (both h and modelOrigin.height are metres,
-          // bounds are also in metres since the geometry engine converts during extraction)
-          const terrainClipY = modelMinY + (h - bridge.modelOrigin.height);
-          setCesiumTerrainClipY(terrainClipY);
-
-          // Auto-enable terrain clamping if the model is significantly below terrain
-          // (only once — don't override if the user has manually toggled)
-          if (!autoClampedRef.current && h > bridge.modelOrigin.height + 5) {
-            autoClampedRef.current = true;
-            setCesiumTerrainClamp(true);
-            // Fly camera to the clamped position so the model is visible
-            viewer.camera.flyTo({
-              destination: Cesium.Cartesian3.fromDegrees(
-                bridge.modelOrigin.longitude, bridge.modelOrigin.latitude, h + 500,
-              ),
-              orientation: { heading: 0, pitch: Cesium.Math.toRadians(-45), roll: 0 },
-              duration: 0,
-            });
-          }
-        }
-      });
-    };
-
-    // First attempt
-    doQuery();
-    // Retry after 5s in case terrain tiles were still loading
-    const retryTimer = setTimeout(doQuery, 5000);
-
-    return () => { cancelled = true; clearTimeout(retryTimer); };
-  }, [status, terrainEnabled, terrainClamp, bridgeVersion]);
-
-  // ─── Effect 2bb: Anchor the IFC camera to the world ───────────────────
-  // Two responsibilities, both rooted in the fact that viewerToEcef and
-  // modelMatrix share the same enuToEcef origin altitude:
-  //
-  // 1. STABILITY — when the model placement altitude changes (user edits
-  //    OrthogonalHeight, terrain clamp toggles, etc.) we shift the IFC
-  //    camera Y by the inverse delta. Without this, editing the model feels
-  //    like it's moving the camera because the entire frame translates.
-  //
-  // 2. ABOVE-GROUND — on first activation (and once when terrain becomes
-  //    known) lift the camera if its world altitude lands at or below the
-  //    surface. Models authored at low elevations or sites in alpine regions
-  //    otherwise leave the user buried, fighting Cesium's near-surface
-  //    controls to climb back out.
-  useEffect(() => {
-    if (status !== 'ready') return;
-    const bridge = bridgeRef.current;
-    const renderer = getGlobalRenderer();
-    if (!bridge || !renderer) return;
-
-    const bounds = coordinateInfo?.originalBounds;
-    const mvy = bounds ? (bounds.min.y + bounds.max.y) / 2 : 0;
-    const minY = bounds?.min.y ?? 0;
-    const placement = (terrainClamp && terrainHeight !== null)
-      ? terrainHeight + (mvy - minY)
-      : bridge.modelOrigin.height;
-
-    const prev = prevPlacementRef.current;
-    prevPlacementRef.current = placement;
-    const cam = renderer.getCamera();
-    const pos = cam.getPosition();
-    let newY = pos.y;
-
-    // 1. Stability — compensate placement delta so the world camera position
-    //    stays fixed across edits. Only the camera POSITION is shifted; the
-    //    target stays put in viewer-space so its world altitude (placement +
-    //    target.y − mvy) tracks the model. That way the camera keeps looking
-    //    AT the model, not at the empty space the model used to occupy.
-    if (prev !== null) {
-      const dh = placement - prev;
-      if (Math.abs(dh) > 1e-6) {
-        newY -= dh;
-      }
-    }
-
-    // 2. Above-ground lift — at most twice: once on first bridge
-    //    (no terrain yet → guarantee above the model frame), once when
-    //    terrain first becomes known (lift above terrain if still below).
-    //    Only triggers when the user is actually at or below the surface;
-    //    a normal "above ground" view is left alone so we don't fight a
-    //    user who deliberately zoomed close.
-    const isFirstBridge = !initialLiftDoneRef.current;
-    const terrainJustKnown = terrainHeight !== null && !terrainLiftDoneRef.current;
-    if (isFirstBridge || terrainJustKnown) {
-      if (isFirstBridge) initialLiftDoneRef.current = true;
-      if (terrainHeight !== null) terrainLiftDoneRef.current = true;
-
-      const groundFloor = (terrainHeight !== null)
-        ? Math.max(terrainHeight, placement)
-        : placement;
-      const currentWorldAlt = placement + (newY - mvy);
-      if (currentWorldAlt <= groundFloor) {
-        // Lift to a sensible viewing altitude above ground — at least 100 m
-        // or the model height, whichever is larger, so the user can see the
-        // model without immediately fighting Cesium's slow near-surface
-        // controls. Only POSITION lifts; target stays anchored to the model
-        // so the building sits roughly centred (rather than pinned to the
-        // bottom of the viewport).
-        const modelH = bounds ? bounds.max.y - bounds.min.y : 0;
-        const buffer = Math.max(100, modelH);
-        const lift = (groundFloor + buffer) - currentWorldAlt;
-        newY += lift;
-      }
-    }
-
-    if (newY !== pos.y) {
-      cam.setPosition(pos.x, newY, pos.z);
-    }
-  }, [status, bridgeVersion, terrainClamp, terrainHeight, coordinateInfo]);
+  }, [
+    status, mapConversion, projectedCRS, coordinateInfo, lengthUnitScale,
+    terrainClamp, terrainEnabled, ionToken,
+  ]);
 
   // ─── Effect 2c: Load GLB into Cesium (only when geometry changes) ───────
   // This is the heavy operation — only re-runs when geometry actually changes.
@@ -651,7 +518,7 @@ export function CesiumOverlay({
         if (cancelled) return;
 
         // Build initial model matrix
-        const modelMatrix = buildModelMatrix(Cesium, bridge, mapConversion, projectedCRS, coordinateInfo, terrainClampRef.current, terrainHeightRef.current, lengthUnitScale);
+        const modelMatrix = buildModelMatrix(Cesium, bridge, mapConversion, projectedCRS, coordinateInfo, lengthUnitScale);
 
         const blob = new Blob([glbBytes as BlobPart], { type: 'model/gltf-binary' });
         const glbUrl = URL.createObjectURL(blob);
@@ -707,14 +574,15 @@ export function CesiumOverlay({
     const Cesium = cesiumModule;
     if (!model || !bridge || !viewer || !Cesium) return;
 
-    const newMatrix = buildModelMatrix(Cesium, bridge, mapConversion, projectedCRS, coordinateInfo, terrainClamp, terrainHeight, lengthUnitScale);
+    const newMatrix = buildModelMatrix(Cesium, bridge, mapConversion, projectedCRS, coordinateInfo, lengthUnitScale);
     model.modelMatrix = newMatrix;
     viewer.scene.requestRender();
     // Depend on bridgeVersion so the matrix is rebuilt with the *new* bridge
-    // after an async createCesiumBridge replaces it. Without this, a georef
-    // edit synchronously fires this effect with the OLD bridge (giving a
-    // mixed matrix) and never re-runs once the new bridge resolves.
-  }, [terrainClamp, terrainHeight, mapConversion, projectedCRS, coordinateInfo, lengthUnitScale, bridgeVersion]);
+    // after async createCesiumBridge replaces it. Placement (terrain clamp)
+    // is now baked into bridge.modelOrigin.height by Effect 2, so terrain
+    // clamp/height changes drive a bridge rebuild instead of a per-frame
+    // matrix recomputation here.
+  }, [mapConversion, projectedCRS, coordinateInfo, lengthUnitScale, bridgeVersion]);
 
   // ─── Effect 3: Camera sync loop ─────────────────────────────────────────
   useEffect(() => {
@@ -742,19 +610,10 @@ export function CesiumOverlay({
       const camUp = camera.getUp();
       const fov = camera.getFOV();
 
-      // Camera frame must share the model's enuToEcef origin altitude or the
-      // GLB and the camera diverge (model rendered above/below where the IFC
-      // viewer thinks the camera is looking). When terrain clamping moves the
-      // model up to the terrain surface, lift the camera frame the same way.
-      const bounds = coordinateInfoRef.current?.originalBounds;
-      const mvyForClamp = bounds ? (bounds.min.y + bounds.max.y) / 2 : 0;
-      const minYForClamp = bounds?.min.y ?? 0;
-      let clampOffset = 0;
-      if (terrainClampRef.current && terrainHeightRef.current !== null) {
-        const placement = terrainHeightRef.current + (mvyForClamp - minYForClamp);
-        clampOffset = placement - bridge.modelOrigin.height;
-      }
-      bridge.syncCamera(Cesium, viewer, camPos, camTarget, camUp, fov, clampOffset);
+      // bridge.modelOrigin.height already has the placement baked in (terrain
+      // clamp resolved at bridge creation by Effect 2), so the camera frame
+      // and the model matrix share the same enuToEcef origin altitude.
+      bridge.syncCamera(Cesium, viewer, camPos, camTarget, camUp, fov);
 
       rafRef.current = requestAnimationFrame(syncCamera);
     }

--- a/apps/viewer/src/components/viewer/CesiumOverlay.tsx
+++ b/apps/viewer/src/components/viewer/CesiumOverlay.tsx
@@ -416,22 +416,24 @@ export function CesiumOverlay({
       }
 
       // Query terrain at the model's location. queryTerrainHeight tries
-      // sync globe.getHeight first, then async sampleTerrainMostDetailed,
-      // then a 3 s retry — bounded delay, no jump on success.
+      // Cesium's sync sources first (globe.getHeight, scene.sampleHeight),
+      // then Open-Meteo as a fast network fallback that works even with
+      // Google Photorealistic 3D Tiles (where there's no Cesium terrain
+      // provider for getHeight to read). Cached per-session.
+      const t0 = performance.now();
       let terrainH: number | null = null;
-      if (terrainEnabled && ionToken) {
-        try { terrainH = await tentative.queryTerrainHeight(Cesium, viewer); }
-        catch (err) { console.warn('[CesiumOverlay] terrain query failed:', err); }
-        if (cancelled) return;
-      }
+      try { terrainH = await tentative.queryTerrainHeight(Cesium, viewer); }
+      catch (err) { console.warn('[CesiumOverlay] terrain query failed:', err); }
+      if (cancelled) return;
+      const terrainMs = performance.now() - t0;
 
       const bounds = coordinateInfo?.originalBounds;
       const mvy = bounds ? (bounds.min.y + bounds.max.y) / 2 : 0;
       const minY = bounds?.min.y ?? 0;
       const bottomOffset = mvy - minY;
       const ifcOHeight = tentative.modelOrigin.height;
-      // Auto-clamp when the user has it on, OR when the model is authored
-      // meaningfully below terrain (matching the previous auto-toggle).
+      // Auto-clamp when the user has it on (default true), OR when the model
+      // is authored meaningfully below terrain (the previous auto-toggle).
       const wantClamp =
         terrainClamp ||
         (terrainH !== null && terrainH > ifcOHeight + 5);
@@ -439,6 +441,13 @@ export function CesiumOverlay({
         wantClamp && terrainH !== null
           ? terrainH + bottomOffset
           : ifcOHeight;
+
+      console.debug(
+        `[CesiumOverlay] placement decision: terrain=${terrainH?.toFixed(2) ?? 'null'}m`
+        + ` ifcOHeight=${ifcOHeight.toFixed(2)}m bottomOffset=${bottomOffset.toFixed(2)}m`
+        + ` wantClamp=${wantClamp} placement=${placementHeight.toFixed(2)}m`
+        + ` (terrain query: ${terrainMs.toFixed(0)}ms)`
+      );
 
       // Build the final bridge with the placement baked in (or reuse the
       // tentative one when the placement matches its IFC-derived origin).

--- a/apps/viewer/src/components/viewer/CesiumOverlay.tsx
+++ b/apps/viewer/src/components/viewer/CesiumOverlay.tsx
@@ -237,7 +237,6 @@ export function CesiumOverlay({
   const ionToken = useViewerStore((s) => s.cesiumIonToken);
   const terrainEnabled = useViewerStore((s) => s.cesiumTerrainEnabled);
   const terrainClamp = useViewerStore((s) => s.cesiumTerrainClamp);
-  const setCesiumTerrainClamp = useViewerStore((s) => s.setCesiumTerrainClamp);
   const terrainHeight = useViewerStore((s) => s.cesiumTerrainHeight);
   const setCesiumTerrainHeight = useViewerStore((s) => s.setCesiumTerrainHeight);
   const setCesiumTerrainClipY = useViewerStore((s) => s.setCesiumTerrainClipY);
@@ -246,6 +245,14 @@ export function CesiumOverlay({
   // Track the Cesium model (IFC geometry loaded as glTF for correct world positioning)
   const cesiumModelRef = useRef<{ modelMatrix: any; destroy?: () => void } | null>(null);
   const glbCacheRef = useRef<{ meshCount: number; glb: Uint8Array } | null>(null);
+
+  // Last-known placement altitude (in metres) used to keep the user's WORLD
+  // camera position stable across bridge rebuilds. When the user toggles the
+  // clamp or edits OrthogonalHeight, the model placement changes and the
+  // entire viewer→ECEF frame translates with it; we offset the IFC viewer's
+  // camera Y by the inverse so the user perceives the model moving instead
+  // of the camera being dragged along.
+  const prevPlacementRef = useRef<number | null>(null);
 
   // ─── Effect 1: Create/destroy the Cesium viewer (heavy, rare) ───────────
   // Only depends on cesiumEnabled, ionToken, terrainEnabled, dataSource.
@@ -396,6 +403,7 @@ export function CesiumOverlay({
   useEffect(() => {
     if (status !== 'ready' || !mapConversion || !projectedCRS) {
       bridgeRef.current = null;
+      prevPlacementRef.current = null;
       return;
     }
 
@@ -432,20 +440,20 @@ export function CesiumOverlay({
       const minY = bounds?.min.y ?? 0;
       const bottomOffset = mvy - minY;
       const ifcOHeight = tentative.modelOrigin.height;
-      // Auto-clamp when the user has it on (default true), OR when the model
-      // is authored meaningfully below terrain (the previous auto-toggle).
-      const wantClamp =
-        terrainClamp ||
-        (terrainH !== null && terrainH > ifcOHeight + 5);
+      // Clamp is purely the user's choice. We do NOT auto-clamp on top of
+      // the user's setting — that would reactivate the toggle the moment
+      // the user disables it (since terrain is almost always above sea-level
+      // OrthogonalHeights, the auto condition would re-fire forever and the
+      // checkbox becomes un-uncheckable).
       const placementHeight =
-        wantClamp && terrainH !== null
+        terrainClamp && terrainH !== null
           ? terrainH + bottomOffset
           : ifcOHeight;
 
       console.debug(
         `[CesiumOverlay] placement decision: terrain=${terrainH?.toFixed(2) ?? 'null'}m`
         + ` ifcOHeight=${ifcOHeight.toFixed(2)}m bottomOffset=${bottomOffset.toFixed(2)}m`
-        + ` wantClamp=${wantClamp} placement=${placementHeight.toFixed(2)}m`
+        + ` clamp=${terrainClamp} placement=${placementHeight.toFixed(2)}m`
         + ` (terrain query: ${terrainMs.toFixed(0)}ms)`
       );
 
@@ -472,7 +480,29 @@ export function CesiumOverlay({
         // matches the terrain surface.
         const terrainClipY = minY + (terrainH - ifcOHeight);
         setCesiumTerrainClipY(terrainClipY);
-        if (!terrainClamp && wantClamp) setCesiumTerrainClamp(true);
+      }
+
+      // World-camera stability: when this rebuild changes the placement
+      // altitude (clamp toggled, OrthogonalHeight edited), shift the IFC
+      // viewer-space camera Y by the inverse delta so the user's WORLD
+      // camera ECEF position stays put. Without this, the entire frame
+      // translates with the model and edits feel like the camera is
+      // moving instead of the model — exactly what the user reported.
+      const prevPlacement = prevPlacementRef.current;
+      prevPlacementRef.current = placementHeight;
+      if (prevPlacement !== null) {
+        const dh = placementHeight - prevPlacement;
+        if (Math.abs(dh) > 1e-6) {
+          const renderer = getGlobalRenderer();
+          if (renderer) {
+            const cam = renderer.getCamera();
+            const pos = cam.getPosition();
+            cam.setPosition(pos.x, pos.y - dh, pos.z);
+            console.debug(
+              `[CesiumOverlay] placement Δh=${dh.toFixed(2)}m → shifted IFC camera Y by ${(-dh).toFixed(2)}m to hold world camera`,
+            );
+          }
+        }
       }
 
       bridgeRef.current = bridge;

--- a/apps/viewer/src/components/viewer/CesiumOverlay.tsx
+++ b/apps/viewer/src/components/viewer/CesiumOverlay.tsx
@@ -26,6 +26,7 @@ import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
 import type { CoordinateInfo, GeometryResult } from '@ifc-lite/geometry';
 import { getGlobalRenderer } from '@/hooks/useBCF';
 import { createCesiumBridge, type CesiumBridge } from '@/lib/geo/cesium-bridge';
+import { getEffectiveHorizontalScale } from '@/lib/geo/effective-georef';
 
 // Lazy-loaded Cesium module and CSS
 let cesiumPromise: Promise<typeof import('cesium')> | null = null;
@@ -167,11 +168,18 @@ function buildModelMatrix(
   Cesium: typeof import('cesium'),
   bridge: CesiumBridge,
   mapConversion: MapConversion | undefined,
+  projectedCRS: ProjectedCRS | undefined,
   coordinateInfo: CoordinateInfo | undefined,
   clamp: boolean,
   terrainH: number | null,
+  lengthUnitScale: number,
 ) {
-  const hScale = mapConversion?.scale ?? 1.0;
+  // GLB vertices are in viewer-space metres (geometry engine converts during
+  // extraction). IfcMapConversion.Scale is defined per IFC spec relative to
+  // the project length unit, so applying it raw to metre-converted geometry
+  // double-scales the model — see issue #595. Use the effective scale.
+  const mapUnitScale = projectedCRS?.mapUnitScale ?? lengthUnitScale;
+  const hScale = getEffectiveHorizontalScale(mapConversion?.scale, mapUnitScale, lengthUnitScale);
   const absc = mapConversion?.xAxisAbscissa ?? 1.0;
   const ordi = mapConversion?.xAxisOrdinate ?? 0.0;
   const bounds = coordinateInfo?.originalBounds;
@@ -545,7 +553,7 @@ export function CesiumOverlay({
         if (cancelled) return;
 
         // Build initial model matrix
-        const modelMatrix = buildModelMatrix(Cesium, bridge, mapConversion, coordinateInfo, terrainClampRef.current, terrainHeightRef.current);
+        const modelMatrix = buildModelMatrix(Cesium, bridge, mapConversion, projectedCRS, coordinateInfo, terrainClampRef.current, terrainHeightRef.current, lengthUnitScale);
 
         const blob = new Blob([glbBytes as BlobPart], { type: 'model/gltf-binary' });
         const glbUrl = URL.createObjectURL(blob);
@@ -601,10 +609,10 @@ export function CesiumOverlay({
     const Cesium = cesiumModule;
     if (!model || !bridge || !viewer || !Cesium) return;
 
-    const newMatrix = buildModelMatrix(Cesium, bridge, mapConversion, coordinateInfo, terrainClamp, terrainHeight);
+    const newMatrix = buildModelMatrix(Cesium, bridge, mapConversion, projectedCRS, coordinateInfo, terrainClamp, terrainHeight, lengthUnitScale);
     model.modelMatrix = newMatrix;
     viewer.scene.requestRender();
-  }, [terrainClamp, terrainHeight, mapConversion, coordinateInfo, lengthUnitScale]);
+  }, [terrainClamp, terrainHeight, mapConversion, projectedCRS, coordinateInfo, lengthUnitScale]);
 
   // ─── Effect 3: Camera sync loop ─────────────────────────────────────────
   useEffect(() => {

--- a/apps/viewer/src/components/viewer/CesiumOverlay.tsx
+++ b/apps/viewer/src/components/viewer/CesiumOverlay.tsx
@@ -710,7 +710,11 @@ export function CesiumOverlay({
     const newMatrix = buildModelMatrix(Cesium, bridge, mapConversion, projectedCRS, coordinateInfo, terrainClamp, terrainHeight, lengthUnitScale);
     model.modelMatrix = newMatrix;
     viewer.scene.requestRender();
-  }, [terrainClamp, terrainHeight, mapConversion, projectedCRS, coordinateInfo, lengthUnitScale]);
+    // Depend on bridgeVersion so the matrix is rebuilt with the *new* bridge
+    // after an async createCesiumBridge replaces it. Without this, a georef
+    // edit synchronously fires this effect with the OLD bridge (giving a
+    // mixed matrix) and never re-runs once the new bridge resolves.
+  }, [terrainClamp, terrainHeight, mapConversion, projectedCRS, coordinateInfo, lengthUnitScale, bridgeVersion]);
 
   // ─── Effect 3: Camera sync loop ─────────────────────────────────────────
   useEffect(() => {

--- a/apps/viewer/src/components/viewer/PropertiesPanel.tsx
+++ b/apps/viewer/src/components/viewer/PropertiesPanel.tsx
@@ -1309,6 +1309,7 @@ export function PropertiesPanel() {
                 coordinateInfo={(model?.geometryResult ?? geometryResult)?.coordinateInfo}
                 geometryResult={model?.geometryResult ?? geometryResult}
                 lengthUnitScale={lengthUnitScale}
+                storeyElevations={activeDataStore?.spatialHierarchy?.storeyElevations}
               />
             </CollapsibleContent>
           </Collapsible>

--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -215,7 +215,11 @@ export function ViewportContainer() {
         georefMutations.get(modelId),
       );
       if (effective?.projectedCRS?.name && effective.mapConversion) {
-        return { ...effective, sourceModelId: modelId };
+        return {
+          ...effective,
+          sourceModelId: modelId,
+          storeyElevations: ds.spatialHierarchy?.storeyElevations,
+        };
       }
     }
 
@@ -227,7 +231,11 @@ export function ViewportContainer() {
         georefMutations.get('__legacy__'),
       );
       if (effective?.projectedCRS?.name && effective.mapConversion) {
-        return { ...effective, sourceModelId: '__legacy__' };
+        return {
+          ...effective,
+          sourceModelId: '__legacy__',
+          storeyElevations: ifcDataStore.spatialHierarchy?.storeyElevations,
+        };
       }
     }
 
@@ -908,6 +916,7 @@ export function ViewportContainer() {
           coordinateInfo={georef.coordinateInfo}
           geometryResult={mergedGeometryResult}
           lengthUnitScale={georef.lengthUnitScale}
+          storeyElevations={georef.storeyElevations}
         />
       )}
       <Viewport

--- a/apps/viewer/src/components/viewer/properties/GeoreferencingPanel.tsx
+++ b/apps/viewer/src/components/viewer/properties/GeoreferencingPanel.tsx
@@ -688,6 +688,19 @@ export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVers
             <ChevronRight className={`h-3 w-3 text-teal-500 shrink-0 transition-transform ${conversionOpen ? 'rotate-90' : ''}`} />
             <MapPin className="h-3 w-3 text-teal-500 shrink-0" />
             <span className="font-bold text-[11px] text-zinc-700 dark:text-zinc-300 uppercase tracking-wide flex-1 text-left">Coordinate Operation</span>
+            {scaleMismatch && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <AlertTriangle
+                    className="h-3 w-3 text-amber-500 shrink-0"
+                    aria-label="Scale inconsistent with project/map units"
+                  />
+                </TooltipTrigger>
+                <TooltipContent>
+                  Scale inconsistent with project/map units — expand to view details
+                </TooltipContent>
+              </Tooltip>
+            )}
             {!conversionOpen && (
               <span className="text-[10px] font-mono text-teal-600/70 dark:text-teal-500/60">
                 E {mergedConversion.eastings.toFixed(0)} N {mergedConversion.northings.toFixed(0)}

--- a/apps/viewer/src/components/viewer/properties/GeoreferencingPanel.tsx
+++ b/apps/viewer/src/components/viewer/properties/GeoreferencingPanel.tsx
@@ -385,6 +385,25 @@ export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVers
     return meters; // already meters
   }, [mapUnitSuffix]);
 
+  /**
+   * Given a target world altitude (metres) for the model BASE, return the
+   * IfcMapConversion.OrthogonalHeight value (in map units, rounded to 0.01)
+   * that would put the base there — accounting for the bounds offset and
+   * any RTC / origin shifts the geometry pipeline applied. This mirrors
+   * the auto-clamp formula `placement = terrain + bottomOffset` so the
+   * "Set OrthogonalHeight to Cesium terrain elevation" button produces
+   * the same world position as toggling the clamp.
+   */
+  const oHeightForBaseAltitude = useCallback((targetBaseAltitude: number): number => {
+    const bounds = coordinateInfo?.originalBounds;
+    const minY = bounds?.min.y ?? 0;
+    const shiftY = coordinateInfo?.originShift?.y ?? 0;
+    // RTC offset is in IFC Z-up; viewer Y-up takes its Z component.
+    const rtcYupY = coordinateInfo?.wasmRtcOffset?.z ?? 0;
+    const targetOHeightMeters = targetBaseAltitude - shiftY - rtcYupY - minY;
+    return Math.round(metersToMapUnit(targetOHeightMeters) * 100) / 100;
+  }, [coordinateInfo, metersToMapUnit]);
+
   const isMutated = useCallback((entity: 'projectedCRS' | 'mapConversion', field: string): boolean => {
     if (!mutations) return false;
     const entityMuts = mutations[entity];
@@ -470,16 +489,19 @@ export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVers
       { field: 'northings', value: position.northing, oldValue: mergedConversion?.northings },
     ];
     if (position.terrainHeight !== null) {
+      // position.terrainHeight is the world altitude where the user wants the
+      // base of the model — translate to OrthogonalHeight using the same
+      // bounds/shift accounting as the auto-clamp path.
       fields.push({
         field: 'orthogonalHeight',
-        value: Math.round(position.terrainHeight * 10) / 10,
+        value: oHeightForBaseAltitude(position.terrainHeight),
         oldValue: mergedConversion?.orthogonalHeight,
       });
     }
     setGeorefFields(modelId, 'mapConversion', fields);
     setConversionOpen(true);
     requestAlignmentReload();
-  }, [modelId, setGeorefFields, mergedConversion, requestAlignmentReload]);
+  }, [modelId, setGeorefFields, mergedConversion, requestAlignmentReload, oHeightForBaseAltitude]);
 
   const initializeMapConversionDefaults = useCallback(() => {
     if (!modelId || !setGeorefFields) return;
@@ -673,7 +695,7 @@ export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVers
               <GeorefRow label="Eastings" value={mergedConversion.eastings} suffix={mapUnitSuffix} isNumber editable={editable} isMutated={isMutated('mapConversion', 'eastings')} fieldEntity="mapConversion" fieldName="eastings" onSave={v => handleSave('mapConversion', 'eastings', v)} />
               <GeorefRow label="Northings" value={mergedConversion.northings} suffix={mapUnitSuffix} isNumber editable={editable} isMutated={isMutated('mapConversion', 'northings')} fieldEntity="mapConversion" fieldName="northings" onSave={v => handleSave('mapConversion', 'northings', v)} />
               <GeorefRow label="OrthogonalHeight" value={mergedConversion.orthogonalHeight} suffix={mapUnitSuffix} isNumber editable={editable} isMutated={isMutated('mapConversion', 'orthogonalHeight')} fieldEntity="mapConversion" fieldName="orthogonalHeight" onSave={v => handleSave('mapConversion', 'orthogonalHeight', v)}>
-                <TerrainHeightButton modelId={modelId} editable={editable} onApply={(h) => handleSave('mapConversion', 'orthogonalHeight', Math.round(metersToMapUnit(h) * 100) / 100)} />
+                <TerrainHeightButton modelId={modelId} editable={editable} onApply={(h) => handleSave('mapConversion', 'orthogonalHeight', oHeightForBaseAltitude(h))} />
               </GeorefRow>
               <GeorefRow label="XAxisAbscissa" value={mergedConversion.xAxisAbscissa} isNumber editable={editable} isMutated={isMutated('mapConversion', 'xAxisAbscissa')} fieldEntity="mapConversion" fieldName="xAxisAbscissa" onSave={v => handleSave('mapConversion', 'xAxisAbscissa', v)} />
               <GeorefRow label="XAxisOrdinate" value={mergedConversion.xAxisOrdinate} isNumber editable={editable} isMutated={isMutated('mapConversion', 'xAxisOrdinate')} fieldEntity="mapConversion" fieldName="xAxisOrdinate" onSave={v => handleSave('mapConversion', 'xAxisOrdinate', v)} />
@@ -736,7 +758,7 @@ export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVers
           {cesiumTerrainHeight !== null && editable && modelId && (
             <div className="flex items-center gap-1 ml-5">
               <button
-                onClick={() => handleSave('mapConversion', 'orthogonalHeight', Math.round(metersToMapUnit(cesiumTerrainHeight) * 100) / 100)}
+                onClick={() => handleSave('mapConversion', 'orthogonalHeight', oHeightForBaseAltitude(cesiumTerrainHeight))}
                 className="text-[9px] text-teal-500 hover:text-teal-700 dark:hover:text-teal-300 transition-colors flex items-center gap-0.5"
               >
                 <Mountain className="h-2.5 w-2.5" />

--- a/apps/viewer/src/components/viewer/properties/GeoreferencingPanel.tsx
+++ b/apps/viewer/src/components/viewer/properties/GeoreferencingPanel.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useState, useCallback, useMemo } from 'react';
-import { Globe, MapPin, PenLine, Check, X, Search, ChevronRight, Mountain } from 'lucide-react';
+import { Globe, MapPin, PenLine, Check, X, Search, ChevronRight, Mountain, AlertTriangle } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Badge } from '@/components/ui/badge';
 import { computeAngleToGridNorth, type GeoreferenceInfo, type MapConversion, type ProjectedCRS } from '@ifc-lite/parser';
@@ -16,7 +16,7 @@ import { useViewerStore } from '@/store';
 import type { CoordinateInfo, GeometryResult } from '@ifc-lite/geometry';
 import { EpsgLookupDialog, type EpsgResult } from './EpsgLookupDialog';
 import { LocationMap, type PickedPosition } from './LocationMap';
-import { mergeMapConversion, mergeProjectedCRS } from '@/lib/geo/effective-georef';
+import { detectScaleUnitMismatch, mergeMapConversion, mergeProjectedCRS } from '@/lib/geo/effective-georef';
 import { useIfc } from '@/hooks/useIfc';
 import { toast } from '@/components/ui/toast';
 
@@ -361,6 +361,15 @@ export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVers
     return computeAngleToGridNorth(mergedConversion?.xAxisAbscissa, mergedConversion?.xAxisOrdinate);
   }, [mergedConversion]);
 
+  const scaleMismatch = useMemo(() => {
+    if (!mergedConversion) return null;
+    return detectScaleUnitMismatch(
+      mergedConversion.scale,
+      mergedCRS?.mapUnitScale,
+      lengthUnitScale,
+    );
+  }, [mergedConversion, mergedCRS?.mapUnitScale, lengthUnitScale]);
+
   const mapUnitSuffix = useMemo(() => {
     const mapUnit = mergedCRS?.mapUnit?.toUpperCase();
     if (!mapUnit) return 'm';
@@ -664,6 +673,20 @@ export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVers
               <GeorefRow label="XAxisOrdinate" value={mergedConversion.xAxisOrdinate} isNumber editable={editable} isMutated={isMutated('mapConversion', 'xAxisOrdinate')} fieldEntity="mapConversion" fieldName="xAxisOrdinate" onSave={v => handleSave('mapConversion', 'xAxisOrdinate', v)} />
               <AngleRow angle={angleToGridNorth} editable={editable} onAngleChange={handleAngleChange} />
               <GeorefRow label="Scale" value={mergedConversion.scale} isNumber editable={editable} isMutated={isMutated('mapConversion', 'scale')} fieldEntity="mapConversion" fieldName="scale" onSave={v => handleSave('mapConversion', 'scale', v)} />
+              {scaleMismatch && (
+                <div className="px-3 py-2 flex items-start gap-1.5 text-[10px] text-amber-600 dark:text-amber-400 bg-amber-50/50 dark:bg-amber-950/20">
+                  <AlertTriangle className="h-3 w-3 mt-0.5 shrink-0" />
+                  <span className="leading-snug">
+                    <strong>Scale inconsistent with project/map units.</strong>{' '}
+                    Per IFC schema, IfcMapConversion.Scale should bridge the unit
+                    difference between the project length unit and map CRS unit.
+                    Current Scale = {scaleMismatch.rawScale}; expected ≈{' '}
+                    {scaleMismatch.expectedScale.toPrecision(4)}. Geometry is
+                    being placed at {scaleMismatch.effectiveScale.toPrecision(4)}×
+                    its physical size — adjust Scale (or MapUnit) to fix.
+                  </span>
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/apps/viewer/src/components/viewer/properties/GeoreferencingPanel.tsx
+++ b/apps/viewer/src/components/viewer/properties/GeoreferencingPanel.tsx
@@ -443,8 +443,14 @@ export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVers
       ? mergedCRS?.[field as keyof ProjectedCRS]
       : mergedConversion?.[field as keyof MapConversion];
     setGeorefField(modelId, entity, field, value, oldValue as string | number | undefined);
+    // Editing OrthogonalHeight implies "I want this exact altitude" — auto
+    // -release the terrain clamp so the new value actually takes effect
+    // (with clamp on, placement is locked to terrain regardless of oHeight).
+    if (entity === 'mapConversion' && field === 'orthogonalHeight' && terrainClamp) {
+      setCesiumTerrainClamp(false);
+    }
     requestAlignmentReload();
-  }, [modelId, setGeorefField, mergedCRS, mergedConversion, requestAlignmentReload]);
+  }, [modelId, setGeorefField, mergedCRS, mergedConversion, requestAlignmentReload, terrainClamp, setCesiumTerrainClamp]);
 
   // Handle angle edit: compute and set both XAxisAbscissa and XAxisOrdinate
   const handleAngleChange = useCallback((abscissa: number, ordinate: number) => {

--- a/apps/viewer/src/components/viewer/properties/GeoreferencingPanel.tsx
+++ b/apps/viewer/src/components/viewer/properties/GeoreferencingPanel.tsx
@@ -16,6 +16,7 @@ import { useViewerStore } from '@/store';
 import type { CoordinateInfo, GeometryResult } from '@ifc-lite/geometry';
 import { EpsgLookupDialog, type EpsgResult } from './EpsgLookupDialog';
 import { LocationMap, type PickedPosition } from './LocationMap';
+import { findClampAnchorY } from '@/lib/geo/clamp-anchor';
 import { detectScaleUnitMismatch, mergeMapConversion, mergeProjectedCRS } from '@/lib/geo/effective-georef';
 import { useIfc } from '@/hooks/useIfc';
 import { toast } from '@/components/ui/toast';
@@ -324,9 +325,12 @@ export interface GeoreferencingPanelProps {
   geometryResult?: GeometryResult | null;
   /** IFC project length unit → metres (e.g. 0.001 for mm models). Default 1. */
   lengthUnitScale?: number;
+  /** IfcBuildingStorey elevations (express id → metres, viewer-Y aligned).
+   *  Used to anchor the model's ground floor to terrain. */
+  storeyElevations?: Map<number, number>;
 }
 
-export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVersion, coordinateInfo, geometryResult, lengthUnitScale }: GeoreferencingPanelProps) {
+export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVersion, coordinateInfo, geometryResult, lengthUnitScale, storeyElevations }: GeoreferencingPanelProps) {
   const georefMutations = useViewerStore(s => s.georefMutations);
   const setGeorefField = useViewerStore(s => s.setGeorefField);
   const setGeorefFields = useViewerStore(s => s.setGeorefFields);
@@ -386,23 +390,24 @@ export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVers
   }, [mapUnitSuffix]);
 
   /**
-   * Given a target world altitude (metres) for the model BASE, return the
-   * IfcMapConversion.OrthogonalHeight value (in map units, rounded to 0.01)
-   * that would put the base there — accounting for the bounds offset and
-   * any RTC / origin shifts the geometry pipeline applied. This mirrors
-   * the auto-clamp formula `placement = terrain + bottomOffset` so the
-   * "Set OrthogonalHeight to Cesium terrain elevation" button produces
-   * the same world position as toggling the clamp.
+   * Given a target world altitude (metres) for the model's ground floor
+   * (the storey nearest elevation 0, falling back to bounds.min.y when
+   * no storeys are present), return the IfcMapConversion.OrthogonalHeight
+   * value (in map units, rounded to 0.01) that would put the ground floor
+   * there — accounting for any RTC / origin shifts the geometry pipeline
+   * applied. This mirrors the auto-clamp formula so the "Set
+   * OrthogonalHeight to Cesium terrain elevation" button produces the same
+   * world position as toggling the clamp.
    */
   const oHeightForBaseAltitude = useCallback((targetBaseAltitude: number): number => {
     const bounds = coordinateInfo?.originalBounds;
-    const minY = bounds?.min.y ?? 0;
+    const anchorY = findClampAnchorY(bounds, storeyElevations);
     const shiftY = coordinateInfo?.originShift?.y ?? 0;
     // RTC offset is in IFC Z-up; viewer Y-up takes its Z component.
     const rtcYupY = coordinateInfo?.wasmRtcOffset?.z ?? 0;
-    const targetOHeightMeters = targetBaseAltitude - shiftY - rtcYupY - minY;
+    const targetOHeightMeters = targetBaseAltitude - shiftY - rtcYupY - anchorY;
     return Math.round(metersToMapUnit(targetOHeightMeters) * 100) / 100;
-  }, [coordinateInfo, metersToMapUnit]);
+  }, [coordinateInfo, storeyElevations, metersToMapUnit]);
 
   const isMutated = useCallback((entity: 'projectedCRS' | 'mapConversion', field: string): boolean => {
     if (!mutations) return false;

--- a/apps/viewer/src/hooks/useIfcFederation.ts
+++ b/apps/viewer/src/hooks/useIfcFederation.ts
@@ -40,7 +40,7 @@ import {
 } from './ingest/pointCloudIngest.js';
 import { getGlobalRenderer } from './useBCF.js';
 import { readNativeFile, type NativeFileHandle } from '../services/file-dialog.js';
-import { getEffectiveGeoreference, type GeorefMutationDataLike } from '../lib/geo/effective-georef.js';
+import { getEffectiveGeoreference, getEffectiveHorizontalScale, type GeorefMutationDataLike } from '../lib/geo/effective-georef.js';
 
 function isNativeFileHandle(file: File | NativeFileHandle): file is NativeFileHandle {
   return typeof (file as NativeFileHandle).path === 'string';
@@ -81,10 +81,14 @@ function getMapUnitScale(georef: ModelGeoref): number {
   return georef.projectedCRS.mapUnitScale ?? georef.lengthUnitScale ?? 1;
 }
 
-function getAxis(conversion: MapConversion): { a: number; o: number; scale: number; denom: number } {
+function getAxis(georef: ModelGeoref): { a: number; o: number; scale: number; denom: number } {
+  const conversion = georef.mapConversion;
   const a = conversion.xAxisAbscissa ?? 1;
   const o = conversion.xAxisOrdinate ?? 0;
-  const scale = conversion.scale ?? 1;
+  // Use the effective horizontal scale: viewer geometry is already in metres,
+  // so applying IfcMapConversion.Scale raw would double-scale — see issue #595.
+  const mapUnitScale = georef.projectedCRS.mapUnitScale ?? georef.lengthUnitScale ?? 1;
+  const scale = getEffectiveHorizontalScale(conversion.scale, mapUnitScale, georef.lengthUnitScale ?? 1);
   const denom = Math.max(a * a + o * o, 1e-12);
   return { a, o, scale, denom };
 }
@@ -151,8 +155,8 @@ function updateBounds(bounds: ReturnType<typeof emptyBounds>, x: number, y: numb
 function buildGeorefAlignmentTransform(source: ModelGeoref, reference: ModelGeoref): AffineTransform3D | null {
   const sourceConv = source.mapConversion;
   const refConv = reference.mapConversion;
-  const sourceAxis = getAxis(sourceConv);
-  const refAxis = getAxis(refConv);
+  const sourceAxis = getAxis(source);
+  const refAxis = getAxis(reference);
   const refDenom = refAxis.scale * refAxis.denom;
   if (Math.abs(refDenom) < 1e-12) return null;
 

--- a/apps/viewer/src/lib/geo/cesium-bridge.ts
+++ b/apps/viewer/src/lib/geo/cesium-bridge.ts
@@ -28,19 +28,9 @@
 import proj4 from 'proj4';
 import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
 import type { CoordinateInfo } from '@ifc-lite/geometry';
-import { queryTerrainElevation, resolveProjection } from './reproject';
+import { resolveProjection } from './reproject';
+import { resolveTerrainElevation } from './terrain-elevation';
 import { getEffectiveHorizontalScale } from './effective-georef';
-
-/**
- * Module-level cache for terrain elevation lookups so that bridge rebuilds
- * (georef edits, clamp toggles) re-use the value within the session instead
- * of re-hitting the Open-Meteo API or re-loading 3D-tile depth buffers.
- */
-const terrainElevationCache = new Map<string, number>();
-function terrainCacheKey(lat: number, lon: number): string {
-  // 5 decimal places ≈ 1.1m precision — plenty for site-level elevation.
-  return `${lat.toFixed(5)},${lon.toFixed(5)}`;
-}
 
 export interface GeodesicPosition {
   longitude: number;
@@ -280,127 +270,12 @@ export async function createCesiumBridge(
     viewer.scene.requestRender();
   }
 
-  /**
-   * Query terrain elevation at the model's location, trying fast Cesium
-   * sources first then falling back to Open-Meteo for environments that
-   * have 3D Tiles or Photorealistic tiles instead of a Cesium terrain
-   * provider (where globe.getHeight returns 0 and sampleTerrainMostDetailed
-   * has nothing to query).
-   *
-   * Cesium's sync probes occasionally return absurd values (we observed
-   * globe.getHeight returning -69184 m on Google Photorealistic 3D Tiles
-   * with no Cesium ion terrain — depth-buffer noise from an unrendered
-   * area). Every candidate is range-checked against terrestrial bounds
-   * before being accepted.
-   *
-   * Order:
-   *   1. Cache (instant — re-bridge after georef edit).
-   *   2. globe.getHeight (sync, only useful with a non-ellipsoid terrain
-   *      provider AND tiles already loaded for the location).
-   *   3. scene.sampleHeight (sync, queries all primitives including 3D
-   *      Tiles, only works if tiles for the location are already rendered).
-   *   4. Open-Meteo elevation API (~200-500ms, always works online).
-   *   5. scene.sampleHeightMostDetailed (async, loads tiles — slow last
-   *      resort if Open-Meteo fails).
-   */
-  async function queryTerrainHeight(
+  /** Resolve terrain elevation at the model origin via the shared pipeline. */
+  function queryTerrainHeight(
     Cesium: typeof import('cesium'),
     viewer: InstanceType<typeof import('cesium').Viewer>,
   ): Promise<number | null> {
-    // Earth's plausible terrestrial elevation range. Mariana Trench is ~−11 km
-    // (no buildings there) and Everest summit is ~8.85 km. Anything outside
-    // this band is depth-buffer / uninitialised garbage from Cesium and must
-    // be discarded so we don't bury the model 70 km underground.
-    const ELEV_MIN = -1000;
-    const ELEV_MAX = 9000;
-    const isPlausibleElevation = (h: number): boolean =>
-      Number.isFinite(h) && h > ELEV_MIN && h < ELEV_MAX && Math.abs(h) > 1e-3;
-
-    const cacheKey = terrainCacheKey(originLat, originLon);
-    const cached = terrainElevationCache.get(cacheKey);
-    if (cached !== undefined) {
-      console.debug(`[CesiumBridge] terrain (cached) at ${cacheKey}: ${cached.toFixed(2)}m`);
-      return cached;
-    }
-
-    const position = Cesium.Cartographic.fromDegrees(originLon, originLat);
-    const finish = (h: number, source: string, ms?: number) => {
-      terrainElevationCache.set(cacheKey, h);
-      const t = ms !== undefined ? ` (${ms.toFixed(0)}ms)` : '';
-      console.debug(`[CesiumBridge] terrain via ${source}: ${h.toFixed(2)}m at ${cacheKey}${t}`);
-      return h;
-    };
-    const reject = (h: unknown, source: string) => {
-      console.debug(`[CesiumBridge] ${source} returned implausible value ${h}; skipping`);
-    };
-
-    // 1. Sync globe.getHeight — useful when a Cesium terrain provider is set
-    //    AND its tile for this location is loaded. Often noisy garbage with
-    //    Google Photorealistic 3D Tiles + no ion terrain; the range filter
-    //    below catches that.
-    try {
-      const h = viewer.scene.globe.getHeight(position);
-      if (h !== undefined && isPlausibleElevation(h)) {
-        return finish(h, 'globe.getHeight');
-      }
-      if (h !== undefined) reject(h, 'globe.getHeight');
-    } catch (err) {
-      console.warn('[CesiumBridge] globe.getHeight threw:', err);
-    }
-
-    // 2. Sync scene.sampleHeight — works with 3D Tiles (Google
-    //    Photorealistic, Cesium OSM Buildings) when their tiles are already
-    //    rendered. Returns undefined if the area isn't in the depth buffer.
-    const sampleHeightSupported = (viewer.scene as { sampleHeightSupported?: boolean }).sampleHeightSupported;
-    if (sampleHeightSupported) {
-      try {
-        const h = (viewer.scene as { sampleHeight: (p: unknown) => number | undefined }).sampleHeight(position);
-        if (h !== undefined && isPlausibleElevation(h)) {
-          return finish(h, 'scene.sampleHeight');
-        }
-        if (h !== undefined) reject(h, 'scene.sampleHeight');
-      } catch (err) {
-        console.warn('[CesiumBridge] scene.sampleHeight threw:', err);
-      }
-    }
-
-    // 3. Open-Meteo elevation API — reliable network fallback (~300ms with
-    //    the 5s timeout we added). Doesn't need any tiles loaded; works for
-    //    Google 3D Tiles environments where Cesium has no tile depth yet.
-    try {
-      const t0 = performance.now();
-      const elev = await queryTerrainElevation({ lat: originLat, lon: originLon });
-      const ms = performance.now() - t0;
-      if (elev !== null && isPlausibleElevation(elev)) {
-        return finish(elev, 'Open-Meteo', ms);
-      }
-      if (elev !== null) reject(elev, 'Open-Meteo');
-    } catch (err) {
-      console.warn('[CesiumBridge] Open-Meteo elevation threw:', err);
-    }
-
-    // 4. Last-resort: force Cesium to load tiles for this location and
-    //    sample. Slow (seconds) but the most accurate when 3D Tiles are
-    //    the only elevation source and Open-Meteo is unavailable.
-    if (sampleHeightSupported) {
-      try {
-        const t0 = performance.now();
-        type SampleHeightDetailed = (positions: unknown[]) => Promise<unknown[]>;
-        const fn = (viewer.scene as { sampleHeightMostDetailed: SampleHeightDetailed }).sampleHeightMostDetailed;
-        const results = await fn([position]);
-        const ms = performance.now() - t0;
-        const r0 = (results?.[0] as { height?: number } | undefined);
-        if (r0 && r0.height !== undefined && isPlausibleElevation(r0.height)) {
-          return finish(r0.height, 'scene.sampleHeightMostDetailed', ms);
-        }
-        if (r0?.height !== undefined) reject(r0.height, 'scene.sampleHeightMostDetailed');
-      } catch (err) {
-        console.warn('[CesiumBridge] sampleHeightMostDetailed threw:', err);
-      }
-    }
-
-    console.warn(`[CesiumBridge] terrain query: no source returned a plausible value at ${cacheKey}`);
-    return null;
+    return resolveTerrainElevation(Cesium, viewer, originLat, originLon);
   }
 
   function viewerToGeodetic(vx: number, vy: number, vz: number): GeodesicPosition | null {

--- a/apps/viewer/src/lib/geo/cesium-bridge.ts
+++ b/apps/viewer/src/lib/geo/cesium-bridge.ts
@@ -72,6 +72,14 @@ export async function createCesiumBridge(
   projectedCRS: ProjectedCRS,
   coordinateInfo?: CoordinateInfo,
   lengthUnitScale = 1,
+  /**
+   * If provided, replaces the IFC-derived origin altitude (mapConversion's
+   * OrthogonalHeight + viewer-space Z) for the enuToEcef origin used by both
+   * the camera frame and the model matrix. Pass the terrain-clamped placement
+   * here to bake "model on terrain" into the bridge from creation, so the
+   * model never has to be moved after loading into Cesium.
+   */
+  placementHeightOverride?: number,
 ): Promise<CesiumBridge | null> {
   const projDef = await resolveProjection(projectedCRS);
   if (!projDef) return null;
@@ -109,7 +117,12 @@ export async function createCesiumBridge(
   const hScale = getEffectiveHorizontalScale(mapConversion.scale, mapScale, lengthUnitScale);
   const oEasting = mapConversion.eastings * mapScale + hScale * (absc * oIfcX - ordi * oIfcY);
   const oNorthing = mapConversion.northings * mapScale + hScale * (ordi * oIfcX + absc * oIfcY);
-  const oHeight = mapConversion.orthogonalHeight * mapScale + oIfcZ;
+  const ifcOHeight = mapConversion.orthogonalHeight * mapScale + oIfcZ;
+  // The actual altitude used for the enuToEcef origin. When the caller
+  // pre-computes a terrain-clamped placement, we honour it so the bridge,
+  // model matrix, and camera frame are all built around the SAME altitude
+  // from the start — no post-load shifting required.
+  const oHeight = placementHeightOverride ?? ifcOHeight;
 
   let originLon: number, originLat: number;
   try {

--- a/apps/viewer/src/lib/geo/cesium-bridge.ts
+++ b/apps/viewer/src/lib/geo/cesium-bridge.ts
@@ -287,6 +287,12 @@ export async function createCesiumBridge(
    * provider (where globe.getHeight returns 0 and sampleTerrainMostDetailed
    * has nothing to query).
    *
+   * Cesium's sync probes occasionally return absurd values (we observed
+   * globe.getHeight returning -69184 m on Google Photorealistic 3D Tiles
+   * with no Cesium ion terrain — depth-buffer noise from an unrendered
+   * area). Every candidate is range-checked against terrestrial bounds
+   * before being accepted.
+   *
    * Order:
    *   1. Cache (instant — re-bridge after georef edit).
    *   2. globe.getHeight (sync, only useful with a non-ellipsoid terrain
@@ -301,6 +307,15 @@ export async function createCesiumBridge(
     Cesium: typeof import('cesium'),
     viewer: InstanceType<typeof import('cesium').Viewer>,
   ): Promise<number | null> {
+    // Earth's plausible terrestrial elevation range. Mariana Trench is ~−11 km
+    // (no buildings there) and Everest summit is ~8.85 km. Anything outside
+    // this band is depth-buffer / uninitialised garbage from Cesium and must
+    // be discarded so we don't bury the model 70 km underground.
+    const ELEV_MIN = -1000;
+    const ELEV_MAX = 9000;
+    const isPlausibleElevation = (h: number): boolean =>
+      Number.isFinite(h) && h > ELEV_MIN && h < ELEV_MAX && Math.abs(h) > 1e-3;
+
     const cacheKey = terrainCacheKey(originLat, originLon);
     const cached = terrainElevationCache.get(cacheKey);
     if (cached !== undefined) {
@@ -315,16 +330,20 @@ export async function createCesiumBridge(
       console.debug(`[CesiumBridge] terrain via ${source}: ${h.toFixed(2)}m at ${cacheKey}${t}`);
       return h;
     };
+    const reject = (h: unknown, source: string) => {
+      console.debug(`[CesiumBridge] ${source} returned implausible value ${h}; skipping`);
+    };
 
     // 1. Sync globe.getHeight — useful when a Cesium terrain provider is set
-    //    AND its tile for this location is loaded. The default ellipsoid
-    //    provider returns 0 everywhere, so we ignore exact-zero results to
-    //    avoid mistaking "no data" for "sea level".
+    //    AND its tile for this location is loaded. Often noisy garbage with
+    //    Google Photorealistic 3D Tiles + no ion terrain; the range filter
+    //    below catches that.
     try {
       const h = viewer.scene.globe.getHeight(position);
-      if (h !== undefined && Number.isFinite(h) && Math.abs(h) > 1e-3) {
+      if (h !== undefined && isPlausibleElevation(h)) {
         return finish(h, 'globe.getHeight');
       }
+      if (h !== undefined) reject(h, 'globe.getHeight');
     } catch (err) {
       console.warn('[CesiumBridge] globe.getHeight threw:', err);
     }
@@ -336,9 +355,10 @@ export async function createCesiumBridge(
     if (sampleHeightSupported) {
       try {
         const h = (viewer.scene as { sampleHeight: (p: unknown) => number | undefined }).sampleHeight(position);
-        if (h !== undefined && Number.isFinite(h) && Math.abs(h) > 1e-3) {
+        if (h !== undefined && isPlausibleElevation(h)) {
           return finish(h, 'scene.sampleHeight');
         }
+        if (h !== undefined) reject(h, 'scene.sampleHeight');
       } catch (err) {
         console.warn('[CesiumBridge] scene.sampleHeight threw:', err);
       }
@@ -351,9 +371,10 @@ export async function createCesiumBridge(
       const t0 = performance.now();
       const elev = await queryTerrainElevation({ lat: originLat, lon: originLon });
       const ms = performance.now() - t0;
-      if (elev !== null && Number.isFinite(elev)) {
+      if (elev !== null && isPlausibleElevation(elev)) {
         return finish(elev, 'Open-Meteo', ms);
       }
+      if (elev !== null) reject(elev, 'Open-Meteo');
     } catch (err) {
       console.warn('[CesiumBridge] Open-Meteo elevation threw:', err);
     }
@@ -369,15 +390,16 @@ export async function createCesiumBridge(
         const results = await fn([position]);
         const ms = performance.now() - t0;
         const r0 = (results?.[0] as { height?: number } | undefined);
-        if (r0 && Number.isFinite(r0.height)) {
-          return finish(r0.height!, 'scene.sampleHeightMostDetailed', ms);
+        if (r0 && r0.height !== undefined && isPlausibleElevation(r0.height)) {
+          return finish(r0.height, 'scene.sampleHeightMostDetailed', ms);
         }
+        if (r0?.height !== undefined) reject(r0.height, 'scene.sampleHeightMostDetailed');
       } catch (err) {
         console.warn('[CesiumBridge] sampleHeightMostDetailed threw:', err);
       }
     }
 
-    console.warn(`[CesiumBridge] terrain query: no source returned a value at ${cacheKey}`);
+    console.warn(`[CesiumBridge] terrain query: no source returned a plausible value at ${cacheKey}`);
     return null;
   }
 

--- a/apps/viewer/src/lib/geo/cesium-bridge.ts
+++ b/apps/viewer/src/lib/geo/cesium-bridge.ts
@@ -29,6 +29,7 @@ import proj4 from 'proj4';
 import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
 import type { CoordinateInfo } from '@ifc-lite/geometry';
 import { resolveProjection } from './reproject';
+import { getEffectiveHorizontalScale } from './effective-georef';
 
 export interface GeodesicPosition {
   longitude: number;
@@ -75,7 +76,6 @@ export async function createCesiumBridge(
   const projDef = await resolveProjection(projectedCRS);
   if (!projDef) return null;
 
-  const hScale = mapConversion.scale ?? 1.0;
   const absc = mapConversion.xAxisAbscissa ?? 1.0;
   const ordi = mapConversion.xAxisOrdinate ?? 0.0;
   const rotAngle = Math.atan2(ordi, absc);
@@ -103,6 +103,10 @@ export async function createCesiumBridge(
   // converts from the IFC file's native unit during extraction). MapConversion
   // values use the unit from IfcProjectedCRS.MapUnit; fall back to project unit.
   const mapScale = projectedCRS.mapUnitScale ?? lengthUnitScale;
+  // IfcMapConversion.Scale bridges project length unit → map unit (e.g. 0.001
+  // for mm→m). Geometry is already in metres, so the effective horizontal
+  // scale is (Scale * mapUnitScale) / lengthUnitScale — see issue #595.
+  const hScale = getEffectiveHorizontalScale(mapConversion.scale, mapScale, lengthUnitScale);
   const oEasting = mapConversion.eastings * mapScale + hScale * (absc * oIfcX - ordi * oIfcY);
   const oNorthing = mapConversion.northings * mapScale + hScale * (ordi * oIfcX + absc * oIfcY);
   const oHeight = mapConversion.orthogonalHeight * mapScale + oIfcZ;

--- a/apps/viewer/src/lib/geo/cesium-bridge.ts
+++ b/apps/viewer/src/lib/geo/cesium-bridge.ts
@@ -208,6 +208,21 @@ export async function createCesiumBridge(
     );
   }
 
+  /**
+   * Sync the Cesium camera from the IFC viewer's camera state.
+   *
+   * Best practice for an externally-driven camera: keep Cesium's screen-space
+   * controller fully disabled (Effect 1) and write camera state directly in
+   * ECEF coordinates. We previously called `lookAtTransform` so we could set
+   * position/direction/up in viewer-space, but that locks Cesium's reference
+   * frame and constrains certain operations (rotate, tilt, zoom) to the local
+   * frame — which manifested as "can't orbit upward, camera stuck to terrain"
+   * even though our overlay is supposed to be input-passive.
+   *
+   * Instead, transform the IFC camera's viewer-space pose to ECEF here and
+   * write it. Cesium handles RTC for primitives (Models, 3D Tilesets, terrain)
+   * internally so we don't need a local-frame trick for shader precision.
+   */
   function syncCamera(
     Cesium: typeof import('cesium'),
     viewer: InstanceType<typeof import('cesium').Viewer>,
@@ -221,48 +236,60 @@ export async function createCesiumBridge(
     ensureEcefCache(Cesium, clampUp);
     if (!viewerToEcefMatrix) return;
 
-    // Set the camera's reference frame to our viewer→ECEF transform.
-    // After this call, all camera properties (position, direction, up)
-    // are interpreted in IFC VIEWER coordinates, not ECEF.
-    viewer.camera.lookAtTransform(viewerToEcefMatrix);
+    // Make sure no prior lookAtTransform is still in effect — if the
+    // overlay was activated from a previous bridge that called it, the
+    // camera could still be locked to that frame.
+    viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
 
-    // Now set camera in VIEWER coordinates — Cesium applies the transform
-    viewer.camera.position = new Cesium.Cartesian3(camPos.x, camPos.y, camPos.z);
-
-    const dirX = camTarget.x - camPos.x;
-    const dirY = camTarget.y - camPos.y;
-    const dirZ = camTarget.z - camPos.z;
-    const dirLen = Math.sqrt(dirX * dirX + dirY * dirY + dirZ * dirZ);
-    if (dirLen > 1e-8) {
-      viewer.camera.direction = new Cesium.Cartesian3(
-        dirX / dirLen, dirY / dirLen, dirZ / dirLen,
-      );
-    }
-
-    viewer.camera.up = new Cesium.Cartesian3(camUp.x, camUp.y, camUp.z);
-
-    // Recompute right = direction × up (maintain orthonormality)
-    const right = Cesium.Cartesian3.cross(
-      viewer.camera.direction, viewer.camera.up, new Cesium.Cartesian3(),
+    // Transform IFC viewer-space pose → ECEF.
+    // Position uses full matrix (rotation + translation).
+    const posECEF = Cesium.Matrix4.multiplyByPoint(
+      viewerToEcefMatrix,
+      new Cesium.Cartesian3(camPos.x, camPos.y, camPos.z),
+      new Cesium.Cartesian3(),
     );
-    Cesium.Cartesian3.normalize(right, right);
-    viewer.camera.right = right;
+    const targetECEF = Cesium.Matrix4.multiplyByPoint(
+      viewerToEcefMatrix,
+      new Cesium.Cartesian3(camTarget.x, camTarget.y, camTarget.z),
+      new Cesium.Cartesian3(),
+    );
 
-    // Sync FOV — CRITICAL for preventing model drift.
-    // IFC renderer uses `fov` as VERTICAL FOV always.
-    // Cesium's PerspectiveFrustum.fov is HORIZONTAL when aspect > 1 (landscape).
-    // If we set Cesium's fov = IFC's vertical fov, Cesium treats it as horizontal,
-    // producing a completely different projection — the model slides during orbit.
-    // Fix: convert vertical FOV → horizontal FOV.
+    // Direction = (target − position) normalised, in ECEF.
+    const dirECEF = Cesium.Cartesian3.subtract(targetECEF, posECEF, new Cesium.Cartesian3());
+    const dirLen = Cesium.Cartesian3.magnitude(dirECEF);
+    if (dirLen < 1e-8) return; // degenerate: target ≡ position
+    Cesium.Cartesian3.normalize(dirECEF, dirECEF);
+
+    // Up: rotate the viewer-space up vector to ECEF (rotation only, no
+    // translation — multiplyByPointAsVector ignores the translation column).
+    const upECEF = Cesium.Matrix4.multiplyByPointAsVector(
+      viewerToEcefMatrix,
+      new Cesium.Cartesian3(camUp.x, camUp.y, camUp.z),
+      new Cesium.Cartesian3(),
+    );
+    Cesium.Cartesian3.normalize(upECEF, upECEF);
+
+    // Right = direction × up — recompute fresh each frame so the orthonormal
+    // basis stays clean. (The "drift" the previous implementation worried
+    // about only matters if we read Cesium's camera state back into our
+    // calculations; we always recompute from the IFC source of truth.)
+    const rightECEF = Cesium.Cartesian3.cross(dirECEF, upECEF, new Cesium.Cartesian3());
+    Cesium.Cartesian3.normalize(rightECEF, rightECEF);
+
+    viewer.camera.position = posECEF;
+    viewer.camera.direction = dirECEF;
+    viewer.camera.up = upECEF;
+    viewer.camera.right = rightECEF;
+
+    // Sync FOV — IFC renderer reports VERTICAL FOV; Cesium's
+    // PerspectiveFrustum.fov is HORIZONTAL when aspect > 1 (landscape).
+    // Convert vertical → horizontal so the projection matches.
     const frustum = viewer.camera.frustum;
     if (frustum instanceof Cesium.PerspectiveFrustum) {
       const aspect = frustum.aspectRatio || (viewer.canvas.width / viewer.canvas.height);
       if (aspect > 1) {
-        // Landscape: Cesium expects horizontal FOV
-        // horizontal_fov = 2 * atan(aspect * tan(vertical_fov / 2))
         frustum.fov = 2 * Math.atan(aspect * Math.tan(fov / 2));
       } else {
-        // Portrait: Cesium uses fov as vertical — pass through
         frustum.fov = fov;
       }
     }

--- a/apps/viewer/src/lib/geo/cesium-bridge.ts
+++ b/apps/viewer/src/lib/geo/cesium-bridge.ts
@@ -28,8 +28,19 @@
 import proj4 from 'proj4';
 import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
 import type { CoordinateInfo } from '@ifc-lite/geometry';
-import { resolveProjection } from './reproject';
+import { queryTerrainElevation, resolveProjection } from './reproject';
 import { getEffectiveHorizontalScale } from './effective-georef';
+
+/**
+ * Module-level cache for terrain elevation lookups so that bridge rebuilds
+ * (georef edits, clamp toggles) re-use the value within the session instead
+ * of re-hitting the Open-Meteo API or re-loading 3D-tile depth buffers.
+ */
+const terrainElevationCache = new Map<string, number>();
+function terrainCacheKey(lat: number, lon: number): string {
+  // 5 decimal places ≈ 1.1m precision — plenty for site-level elevation.
+  return `${lat.toFixed(5)},${lon.toFixed(5)}`;
+}
 
 export interface GeodesicPosition {
   longitude: number;
@@ -64,8 +75,6 @@ export interface CesiumBridge {
 
   viewerToGeodetic(vx: number, vy: number, vz: number): GeodesicPosition | null;
 }
-
-const TERRAIN_QUERY_RETRY_DELAY_MS = 3000;
 
 export async function createCesiumBridge(
   mapConversion: MapConversion,
@@ -271,37 +280,104 @@ export async function createCesiumBridge(
     viewer.scene.requestRender();
   }
 
+  /**
+   * Query terrain elevation at the model's location, trying fast Cesium
+   * sources first then falling back to Open-Meteo for environments that
+   * have 3D Tiles or Photorealistic tiles instead of a Cesium terrain
+   * provider (where globe.getHeight returns 0 and sampleTerrainMostDetailed
+   * has nothing to query).
+   *
+   * Order:
+   *   1. Cache (instant — re-bridge after georef edit).
+   *   2. globe.getHeight (sync, only useful with a non-ellipsoid terrain
+   *      provider AND tiles already loaded for the location).
+   *   3. scene.sampleHeight (sync, queries all primitives including 3D
+   *      Tiles, only works if tiles for the location are already rendered).
+   *   4. Open-Meteo elevation API (~200-500ms, always works online).
+   *   5. scene.sampleHeightMostDetailed (async, loads tiles — slow last
+   *      resort if Open-Meteo fails).
+   */
   async function queryTerrainHeight(
     Cesium: typeof import('cesium'),
     viewer: InstanceType<typeof import('cesium').Viewer>,
   ): Promise<number | null> {
+    const cacheKey = terrainCacheKey(originLat, originLon);
+    const cached = terrainElevationCache.get(cacheKey);
+    if (cached !== undefined) {
+      console.debug(`[CesiumBridge] terrain (cached) at ${cacheKey}: ${cached.toFixed(2)}m`);
+      return cached;
+    }
+
     const position = Cesium.Cartographic.fromDegrees(originLon, originLat);
+    const finish = (h: number, source: string, ms?: number) => {
+      terrainElevationCache.set(cacheKey, h);
+      const t = ms !== undefined ? ` (${ms.toFixed(0)}ms)` : '';
+      console.debug(`[CesiumBridge] terrain via ${source}: ${h.toFixed(2)}m at ${cacheKey}${t}`);
+      return h;
+    };
 
+    // 1. Sync globe.getHeight — useful when a Cesium terrain provider is set
+    //    AND its tile for this location is loaded. The default ellipsoid
+    //    provider returns 0 everywhere, so we ignore exact-zero results to
+    //    avoid mistaking "no data" for "sea level".
     try {
-      const globeHeight = viewer.scene.globe.getHeight(position);
-      if (globeHeight !== undefined && Number.isFinite(globeHeight)) {
-        return globeHeight;
+      const h = viewer.scene.globe.getHeight(position);
+      if (h !== undefined && Number.isFinite(h) && Math.abs(h) > 1e-3) {
+        return finish(h, 'globe.getHeight');
       }
-    } catch { /* not available yet */ }
+    } catch (err) {
+      console.warn('[CesiumBridge] globe.getHeight threw:', err);
+    }
 
-    try {
-      const terrainProvider = viewer.terrainProvider;
-      if (terrainProvider) {
-        const results = await Cesium.sampleTerrainMostDetailed(terrainProvider, [position]);
-        if (results && results.length > 0 && Number.isFinite(results[0].height)) {
-          return results[0].height;
+    // 2. Sync scene.sampleHeight — works with 3D Tiles (Google
+    //    Photorealistic, Cesium OSM Buildings) when their tiles are already
+    //    rendered. Returns undefined if the area isn't in the depth buffer.
+    const sampleHeightSupported = (viewer.scene as { sampleHeightSupported?: boolean }).sampleHeightSupported;
+    if (sampleHeightSupported) {
+      try {
+        const h = (viewer.scene as { sampleHeight: (p: unknown) => number | undefined }).sampleHeight(position);
+        if (h !== undefined && Number.isFinite(h) && Math.abs(h) > 1e-3) {
+          return finish(h, 'scene.sampleHeight');
         }
+      } catch (err) {
+        console.warn('[CesiumBridge] scene.sampleHeight threw:', err);
       }
-    } catch { /* terrain sampling failed */ }
+    }
 
-    await new Promise(r => setTimeout(r, TERRAIN_QUERY_RETRY_DELAY_MS));
+    // 3. Open-Meteo elevation API — reliable network fallback (~300ms with
+    //    the 5s timeout we added). Doesn't need any tiles loaded; works for
+    //    Google 3D Tiles environments where Cesium has no tile depth yet.
     try {
-      const globeHeight = viewer.scene.globe.getHeight(position);
-      if (globeHeight !== undefined && Number.isFinite(globeHeight)) {
-        return globeHeight;
+      const t0 = performance.now();
+      const elev = await queryTerrainElevation({ lat: originLat, lon: originLon });
+      const ms = performance.now() - t0;
+      if (elev !== null && Number.isFinite(elev)) {
+        return finish(elev, 'Open-Meteo', ms);
       }
-    } catch { /* still not available */ }
+    } catch (err) {
+      console.warn('[CesiumBridge] Open-Meteo elevation threw:', err);
+    }
 
+    // 4. Last-resort: force Cesium to load tiles for this location and
+    //    sample. Slow (seconds) but the most accurate when 3D Tiles are
+    //    the only elevation source and Open-Meteo is unavailable.
+    if (sampleHeightSupported) {
+      try {
+        const t0 = performance.now();
+        type SampleHeightDetailed = (positions: unknown[]) => Promise<unknown[]>;
+        const fn = (viewer.scene as { sampleHeightMostDetailed: SampleHeightDetailed }).sampleHeightMostDetailed;
+        const results = await fn([position]);
+        const ms = performance.now() - t0;
+        const r0 = (results?.[0] as { height?: number } | undefined);
+        if (r0 && Number.isFinite(r0.height)) {
+          return finish(r0.height!, 'scene.sampleHeightMostDetailed', ms);
+        }
+      } catch (err) {
+        console.warn('[CesiumBridge] sampleHeightMostDetailed threw:', err);
+      }
+    }
+
+    console.warn(`[CesiumBridge] terrain query: no source returned a value at ${cacheKey}`);
     return null;
   }
 

--- a/apps/viewer/src/lib/geo/clamp-anchor.test.ts
+++ b/apps/viewer/src/lib/geo/clamp-anchor.test.ts
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { findClampAnchorY } from './clamp-anchor.js';
+
+describe('findClampAnchorY', () => {
+  const buildingBounds = { min: { y: -3.5 }, max: { y: 50 } }; // basement at -3.5m, top at 50m
+
+  it('falls back to bounds.min.y when no storeys are present', () => {
+    assert.strictEqual(findClampAnchorY(buildingBounds, undefined), -3.5);
+    assert.strictEqual(findClampAnchorY(buildingBounds, new Map()), -3.5);
+  });
+
+  it('falls back to bounds.min.y when bounds are missing', () => {
+    const storeys = new Map([[1, 0], [2, 3]]);
+    assert.strictEqual(findClampAnchorY(undefined, storeys), 0);
+  });
+
+  it('picks the storey closest to elevation 0 (ground floor)', () => {
+    const storeys = new Map([
+      [1, -3.0],   // basement
+      [2, 0.0],    // ground floor — closest to 0
+      [3, 3.5],    // 1st floor
+      [4, 7.0],    // 2nd floor
+    ]);
+    assert.strictEqual(findClampAnchorY(buildingBounds, storeys), 0.0);
+  });
+
+  it('handles a model authored with a non-zero ground (e.g. 0.15m above origin)', () => {
+    const storeys = new Map([
+      [1, -3.0],
+      [2, 0.15],   // ground floor — closest to 0
+      [3, 3.65],
+    ]);
+    assert.strictEqual(findClampAnchorY(buildingBounds, storeys), 0.15);
+  });
+
+  it('ignores storeys outside the model bounds (avoid stray site-only markers)', () => {
+    // A "Site" or "External" storey with elevation way outside the actual
+    // building extents shouldn't lift the clamp out into mid-air.
+    const storeys = new Map([
+      [1, -3.0],
+      [2, 200],    // out of bounds — site marker, must be skipped
+      [3, 5.0],
+    ]);
+    // Within bounds: -3.0 (|3|) and 5.0 (|5|). −3.0 is closer to 0.
+    assert.strictEqual(findClampAnchorY(buildingBounds, storeys), -3.0);
+  });
+
+  it('uses the lowest storey if all are below 0 (basement-level model)', () => {
+    const bounds = { min: { y: -10 }, max: { y: -1 } };
+    const storeys = new Map([[1, -8], [2, -3]]);
+    // -3 is closer to 0 than -8
+    assert.strictEqual(findClampAnchorY(bounds, storeys), -3);
+  });
+
+  it('handles negative-only storeys without crashing', () => {
+    const bounds = { min: { y: -100 }, max: { y: 0 } };
+    const storeys = new Map([[1, -50], [2, -20]]);
+    assert.strictEqual(findClampAnchorY(bounds, storeys), -20);
+  });
+
+  it('skips non-finite elevations defensively', () => {
+    const storeys = new Map([
+      [1, NaN],
+      [2, Infinity],
+      [3, 2.0],
+    ]);
+    assert.strictEqual(findClampAnchorY(buildingBounds, storeys), 2.0);
+  });
+
+  it('falls back to bounds.min.y when every storey is out of range', () => {
+    const storeys = new Map([[1, 1000], [2, -1000]]);
+    assert.strictEqual(findClampAnchorY(buildingBounds, storeys), -3.5);
+  });
+});

--- a/apps/viewer/src/lib/geo/clamp-anchor.ts
+++ b/apps/viewer/src/lib/geo/clamp-anchor.ts
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Clamp anchor selection.
+ *
+ * "Auto-clamp to terrain" needs to decide WHICH viewer-Y of the model
+ * should be pinned to the terrain surface. The naïve choice — `bounds.min.y`
+ * — anchors the lowest geometry vertex (typically the bottom of the
+ * basement / foundation) to terrain, which buries the building's
+ * actual ground floor below the surface.
+ *
+ * Better: pick the IfcBuildingStorey whose elevation is closest to 0
+ * (the conventional "ground floor"). Fall back to `bounds.min.y` when
+ * no storeys are present or none lie within the model's vertical
+ * extent — that preserves the previous behaviour for non-architectural
+ * IFCs (structural-only models, civil works, point clouds, etc.).
+ */
+
+interface BoundsLike {
+  min: { y: number };
+  max: { y: number };
+}
+
+/**
+ * @param bounds            Model bounds in viewer-space (Y-up, metres).
+ * @param storeyElevations  IFC storey elevations (metres, viewer-Y aligned).
+ *                          The geometry pipeline already converts IFC Z-up
+ *                          values to viewer-Y, so values here can be
+ *                          compared against `bounds.min.y` / `max.y`.
+ *
+ * @returns viewer-Y altitude that should land at terrain when clamping.
+ */
+export function findClampAnchorY(
+  bounds: BoundsLike | undefined,
+  storeyElevations: Map<number, number> | undefined,
+): number {
+  const minY = bounds?.min.y ?? 0;
+  if (!storeyElevations || storeyElevations.size === 0) return minY;
+
+  const maxY = bounds?.max.y ?? minY;
+  const slack = 1; // metre — tolerate storey markers slightly outside the AABB
+  let bestElevation: number | null = null;
+  let bestDistanceFromZero = Infinity;
+  for (const elevation of storeyElevations.values()) {
+    if (!Number.isFinite(elevation)) continue;
+    if (elevation < minY - slack || elevation > maxY + slack) continue;
+    const distance = Math.abs(elevation);
+    if (distance < bestDistanceFromZero) {
+      bestDistanceFromZero = distance;
+      bestElevation = elevation;
+    }
+  }
+
+  return bestElevation ?? minY;
+}

--- a/apps/viewer/src/lib/geo/effective-georef.test.ts
+++ b/apps/viewer/src/lib/geo/effective-georef.test.ts
@@ -5,7 +5,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 
-import { inferMapUnitScale, mergeMapConversion, mergeProjectedCRS } from './effective-georef.js';
+import { getEffectiveHorizontalScale, inferMapUnitScale, mergeMapConversion, mergeProjectedCRS } from './effective-georef.js';
 import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
 
 describe('effective georeferencing', () => {
@@ -69,5 +69,43 @@ describe('effective georeferencing', () => {
     assert.strictEqual(inferMapUnitScale('FOOT'), 0.3048);
     assert.strictEqual(inferMapUnitScale('METRE'), 1);
     assert.strictEqual(inferMapUnitScale('MILLIMETRE'), 0.001);
+  });
+
+  describe('getEffectiveHorizontalScale (issue #595)', () => {
+    it('returns 1 when project mm and map m, with Scale=0.001 (Bonsai-style)', () => {
+      // mm project (lengthUnitScale=0.001), m map (mapUnitScale=1), Scale=0.001
+      assert.strictEqual(getEffectiveHorizontalScale(0.001, 1, 0.001), 1);
+    });
+
+    it('returns 1 when project m and map m, with Scale=1', () => {
+      assert.strictEqual(getEffectiveHorizontalScale(1, 1, 1), 1);
+    });
+
+    it('returns 1 when project ft and map m, with Scale=0.3048', () => {
+      assert.strictEqual(getEffectiveHorizontalScale(0.3048, 1, 0.3048), 1);
+    });
+
+    it('returns 1 when project mm and map mm, with Scale=1 (consistent units)', () => {
+      assert.strictEqual(getEffectiveHorizontalScale(1, 0.001, 0.001), 1);
+    });
+
+    it('preserves a deliberate non-unit scaling (Scale=2 with metres throughout)', () => {
+      assert.strictEqual(getEffectiveHorizontalScale(2, 1, 1), 2);
+    });
+
+    it('defaults Scale to 1 when undefined', () => {
+      // Project mm, map m, Scale undefined (treated as 1):
+      //   effective = 1 * 1 / 0.001 = 1000 → model would appear 1000x too large.
+      // This matches the IFC spec; users who omit Scale in such files have an
+      // inconsistent file. Issue #595 reports that this happens to "work"
+      // because the workaround offsets a different bug — fixed here.
+      assert.strictEqual(getEffectiveHorizontalScale(undefined, 1, 0.001), 1000);
+    });
+
+    it('falls back to 1 for non-positive lengthUnitScale or mapUnitScale', () => {
+      assert.strictEqual(getEffectiveHorizontalScale(1, 0, 1), 1);
+      assert.strictEqual(getEffectiveHorizontalScale(1, 1, 0), 1);
+      assert.strictEqual(getEffectiveHorizontalScale(1, -1, 1), 1);
+    });
   });
 });

--- a/apps/viewer/src/lib/geo/effective-georef.test.ts
+++ b/apps/viewer/src/lib/geo/effective-georef.test.ts
@@ -5,7 +5,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 
-import { getEffectiveHorizontalScale, inferMapUnitScale, mergeMapConversion, mergeProjectedCRS } from './effective-georef.js';
+import { detectScaleUnitMismatch, getEffectiveHorizontalScale, inferMapUnitScale, mergeMapConversion, mergeProjectedCRS } from './effective-georef.js';
 import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
 
 describe('effective georeferencing', () => {
@@ -106,6 +106,46 @@ describe('effective georeferencing', () => {
       assert.strictEqual(getEffectiveHorizontalScale(1, 0, 1), 1);
       assert.strictEqual(getEffectiveHorizontalScale(1, 1, 0), 1);
       assert.strictEqual(getEffectiveHorizontalScale(1, -1, 1), 1);
+    });
+  });
+
+  describe('detectScaleUnitMismatch', () => {
+    it('returns null for spec-compliant Scale (mm/m with Scale=0.001)', () => {
+      assert.strictEqual(detectScaleUnitMismatch(0.001, 1, 0.001), null);
+    });
+
+    it('returns null when project=map=metres and Scale=1', () => {
+      assert.strictEqual(detectScaleUnitMismatch(1, 1, 1), null);
+    });
+
+    it('returns null when project=map=metres and Scale is undefined', () => {
+      assert.strictEqual(detectScaleUnitMismatch(undefined, 1, 1), null);
+    });
+
+    it('flags the common Scale=1 + mm-project + m-map error', () => {
+      const m = detectScaleUnitMismatch(1, 1, 0.001);
+      assert.ok(m, 'expected a mismatch report');
+      assert.strictEqual(m!.rawScale, 1);
+      assert.strictEqual(m!.effectiveScale, 1000);
+      assert.strictEqual(m!.expectedScale, 0.001);
+    });
+
+    it('flags Scale omitted when units differ', () => {
+      const m = detectScaleUnitMismatch(undefined, 1, 0.001);
+      assert.ok(m);
+      assert.strictEqual(m!.effectiveScale, 1000);
+    });
+
+    it('tolerates tiny floating-point noise around 1.0', () => {
+      // Scale = 1.0 ± 0.4% should still be considered consistent.
+      assert.strictEqual(detectScaleUnitMismatch(1.004, 1, 1), null);
+      assert.strictEqual(detectScaleUnitMismatch(0.996, 1, 1), null);
+    });
+
+    it('flags a deliberate non-unit scaling (Scale=2 with metres)', () => {
+      const m = detectScaleUnitMismatch(2, 1, 1);
+      assert.ok(m);
+      assert.strictEqual(m!.effectiveScale, 2);
     });
   });
 });

--- a/apps/viewer/src/lib/geo/effective-georef.ts
+++ b/apps/viewer/src/lib/geo/effective-georef.ts
@@ -23,6 +23,43 @@ export interface EffectiveGeoreference extends GeoreferenceInfo {
   lengthUnitScale: number;
 }
 
+/**
+ * Compute the effective horizontal scale to apply to viewer-space coordinates
+ * (which are already in metres) when transforming through IfcMapConversion.
+ *
+ * Per the IFC schema, IfcMapConversion.Scale converts LOCAL ENGINEERING
+ * coordinates (in the project's length unit) to MAP coordinates (in the map
+ * CRS unit). For a typical file with mm project units and m map units, the
+ * Scale attribute is 0.001.
+ *
+ * The IFC formula is:
+ *   E_map_units = Eastings + (X_local * absc - Y_local * ordi) * Scale
+ *
+ * To produce metres for proj4, we multiply by mapUnitScale; and X_local can be
+ * recovered from the metre-converted geometry as X_metres / lengthUnitScale.
+ * Substituting:
+ *   E_metres = mapUnitScale * Eastings
+ *            + (mapUnitScale * Scale / lengthUnitScale)
+ *              * (X_metres * absc - Y_metres * ordi)
+ *
+ * So when geometry has already been converted to metres (as ifc-lite does),
+ * the effective horizontal scale is (Scale * mapUnitScale) / lengthUnitScale.
+ * For files where Scale is set per IFC spec to bridge the unit difference
+ * (Scale = lengthUnitScale / mapUnitScale), this evaluates to 1.0 and the
+ * geometry passes through unchanged. Applying the raw Scale would otherwise
+ * double-scale and shrink/expand the model — see issue #595.
+ */
+export function getEffectiveHorizontalScale(
+  ifcMapConversionScale: number | undefined,
+  mapUnitScale: number,
+  lengthUnitScale: number,
+): number {
+  const scale = ifcMapConversionScale ?? 1.0;
+  const lus = lengthUnitScale > 0 ? lengthUnitScale : 1;
+  const mus = mapUnitScale > 0 ? mapUnitScale : 1;
+  return (scale * mus) / lus;
+}
+
 export function inferMapUnitScale(mapUnit: string | undefined, fallback?: number): number | undefined {
   if (!mapUnit) return fallback;
   const normalized = mapUnit.toUpperCase();

--- a/apps/viewer/src/lib/geo/effective-georef.ts
+++ b/apps/viewer/src/lib/geo/effective-georef.ts
@@ -60,6 +60,52 @@ export function getEffectiveHorizontalScale(
   return (scale * mus) / lus;
 }
 
+export interface ScaleUnitMismatch {
+  /** Effective horizontal scale applied to viewer-space (metre) geometry. */
+  effectiveScale: number;
+  /** Raw IfcMapConversion.Scale (or 1 if absent). */
+  rawScale: number;
+  /** Map unit → metres factor (e.g. 1 for METRE, 0.001 for MILLIMETRE). */
+  mapUnitScale: number;
+  /** Project length unit → metres factor. */
+  lengthUnitScale: number;
+  /**
+   * Scale value the file would need for the IFC formula to map local→map
+   * coordinates without any extra scaling (i.e. lengthUnitScale / mapUnitScale).
+   */
+  expectedScale: number;
+}
+
+/**
+ * Detect when IfcMapConversion.Scale is inconsistent with the project and map
+ * units. Per the IFC schema, Scale × mapUnitScale should equal lengthUnitScale
+ * (i.e. effectiveScale = 1.0). A deviation usually means the authoring tool
+ * forgot to set Scale to bridge a unit difference (e.g. mm project + m map
+ * with Scale=1.0). Files like this render at the wrong size in any tool that
+ * follows the schema strictly — see issue #595.
+ *
+ * Returns null when the values are consistent (within 0.5% of 1.0); otherwise
+ * returns the diagnostic data so callers can surface a warning.
+ */
+export function detectScaleUnitMismatch(
+  ifcMapConversionScale: number | undefined,
+  mapUnitScale: number | undefined,
+  lengthUnitScale: number | undefined,
+): ScaleUnitMismatch | null {
+  const lus = lengthUnitScale && lengthUnitScale > 0 ? lengthUnitScale : 1;
+  const mus = mapUnitScale && mapUnitScale > 0 ? mapUnitScale : 1;
+  const rawScale = ifcMapConversionScale ?? 1.0;
+  const effectiveScale = (rawScale * mus) / lus;
+  if (Math.abs(effectiveScale - 1) <= 0.005) return null;
+  return {
+    effectiveScale,
+    rawScale,
+    mapUnitScale: mus,
+    lengthUnitScale: lus,
+    expectedScale: lus / mus,
+  };
+}
+
 export function inferMapUnitScale(mapUnit: string | undefined, fallback?: number): number | undefined {
   if (!mapUnit) return fallback;
   const normalized = mapUnit.toUpperCase();

--- a/apps/viewer/src/lib/geo/reproject.ts
+++ b/apps/viewer/src/lib/geo/reproject.ts
@@ -19,6 +19,7 @@ import proj4 from 'proj4';
 import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
 import type { CoordinateInfo } from '@ifc-lite/geometry';
 import { lookupProj4 } from '@ifc-lite/data';
+import { getEffectiveHorizontalScale } from './effective-georef';
 
 export interface LatLon {
   lat: number;
@@ -230,20 +231,24 @@ export async function resolveProjection(crs: ProjectedCRS): Promise<string | nul
  */
 function computeProjectedCenter(
   conversion: MapConversion,
-  coordinateInfo?: CoordinateInfo,
-  lengthUnitScale = 1,
+  coordinateInfo: CoordinateInfo | undefined,
+  mapUnitScale: number,
+  lengthUnitScale: number,
 ): { easting: number; northing: number } {
   const { ifcX, ifcY } = computeLocalIfcCenter(coordinateInfo);
 
   // Geometry coordinates (ifcX, ifcY) are already in metres — the geometry engine
   // converts from the IFC file's native unit during extraction. Only MapConversion
   // values (eastings, northings) are in the file's native unit and need scaling.
-  const scale = conversion.scale ?? 1.0;
+  // IfcMapConversion.Scale converts project length unit → map unit (e.g. 0.001
+  // for mm→m); since geometry is already in metres, use the effective scale —
+  // see issue #595.
+  const scale = getEffectiveHorizontalScale(conversion.scale, mapUnitScale, lengthUnitScale);
   const abscissa = conversion.xAxisAbscissa ?? 1.0;
   const ordinate = conversion.xAxisOrdinate ?? 0.0;
 
-  const easting = conversion.eastings * lengthUnitScale + scale * (abscissa * ifcX - ordinate * ifcY);
-  const northing = conversion.northings * lengthUnitScale + scale * (ordinate * ifcX + abscissa * ifcY);
+  const easting = conversion.eastings * mapUnitScale + scale * (abscissa * ifcX - ordinate * ifcY);
+  const northing = conversion.northings * mapUnitScale + scale * (ordinate * ifcX + abscissa * ifcY);
 
   return { easting, northing };
 }
@@ -281,7 +286,7 @@ export async function reprojectToLatLon(
   // MapConversion values use the unit from IfcProjectedCRS.MapUnit. If MapUnit
   // is not specified, the IFC spec defaults to the project's length unit.
   const mapScale = crs.mapUnitScale ?? lengthUnitScale;
-  const { easting, northing } = computeProjectedCenter(conversion, coordinateInfo, mapScale);
+  const { easting, northing } = computeProjectedCenter(conversion, coordinateInfo, mapScale, lengthUnitScale);
 
   try {
     const [lon, lat] = proj4(projDef, 'WGS84', [easting, northing]);
@@ -349,11 +354,12 @@ export async function reprojectFromLatLon(
     const mapScale = crs.mapUnitScale ?? lengthUnitScale;
     const invScale = mapScale !== 0 ? 1 / mapScale : 1;
     const { ifcX, ifcY } = computeLocalIfcCenter(coordinateInfo);
-    const scale = conversion?.scale ?? 1.0;
+    // Effective horizontal scale for metre-converted geometry — see issue #595.
+    const scale = getEffectiveHorizontalScale(conversion?.scale, mapScale, lengthUnitScale);
     const abscissa = conversion?.xAxisAbscissa ?? 1.0;
     const ordinate = conversion?.xAxisOrdinate ?? 0.0;
 
-    // Result is in IFC native units (the reverse of: E_native * LUS + geom_offset = E_metres)
+    // Result is in IFC native units (the reverse of: E_native * mapScale + geom_offset = E_metres)
     const easting = (projE - scale * (abscissa * ifcX - ordinate * ifcY)) * invScale;
     const northing = (projN - scale * (ordinate * ifcX + abscissa * ifcY)) * invScale;
 
@@ -387,7 +393,9 @@ export async function computeFootprintGeoJSON(
     return null;
   }
 
-  const scale = conversion.scale ?? 1.0;
+  // Effective horizontal scale for metre-converted geometry — see issue #595.
+  const mapScale = crs.mapUnitScale ?? lengthUnitScale;
+  const scale = getEffectiveHorizontalScale(conversion.scale, mapScale, lengthUnitScale);
   const abscissa = conversion.xAxisAbscissa ?? 1.0;
   const ordinate = conversion.xAxisOrdinate ?? 0.0;
 
@@ -418,8 +426,8 @@ export async function computeFootprintGeoJSON(
     const ifcX = worldX;
     const ifcY = -worldZ;
 
-    // Geometry coords (ifcX/Y) are already in metres; only MapConversion needs scaling
-    const mapScale = crs.mapUnitScale ?? lengthUnitScale;
+    // Geometry coords (ifcX/Y) are already in metres; MapConversion values
+    // are converted to metres via mapScale.
     const easting = conversion.eastings * mapScale + scale * (abscissa * ifcX - ordinate * ifcY);
     const northing = conversion.northings * mapScale + scale * (ordinate * ifcX + abscissa * ifcY);
 

--- a/apps/viewer/src/lib/geo/reproject.ts
+++ b/apps/viewer/src/lib/geo/reproject.ts
@@ -451,14 +451,19 @@ export async function computeFootprintGeoJSON(
  * Returns height in metres above sea level, or null on failure.
  */
 export async function queryTerrainElevation(latLon: LatLon): Promise<number | null> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 5000);
   try {
     const url = `https://api.open-meteo.com/v1/elevation?latitude=${latLon.lat}&longitude=${latLon.lon}`;
-    const resp = await fetch(url);
+    const resp = await fetch(url, { signal: controller.signal });
     if (!resp.ok) return null;
     const data = await resp.json();
     const elev = data?.elevation?.[0];
     return typeof elev === 'number' && Number.isFinite(elev) ? elev : null;
-  } catch {
+  } catch (err) {
+    console.warn(`[reproject] queryTerrainElevation failed for ${latLon.lat},${latLon.lon}:`, err);
     return null;
+  } finally {
+    clearTimeout(timeoutId);
   }
 }

--- a/apps/viewer/src/lib/geo/terrain-elevation.ts
+++ b/apps/viewer/src/lib/geo/terrain-elevation.ts
@@ -120,16 +120,14 @@ export async function resolveTerrainElevation(
   //    DEM. Bounded by a timeout so a slow tile fetch doesn't keep the
   //    bridge waiting forever; Open-Meteo runs after as a backstop.
   if (viewer.scene.sampleHeightSupported) {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
     try {
       const t0 = performance.now();
       const detailed = viewer.scene.sampleHeightMostDetailed([position]);
-      const timeout = new Promise<null>((resolve) =>
-        setTimeout(() => resolve(null), SAMPLE_DETAILED_TIMEOUT_MS),
-      );
-      const winner = await Promise.race([
-        detailed.then((results) => results),
-        timeout,
-      ]);
+      const timeout = new Promise<null>((resolve) => {
+        timeoutId = setTimeout(() => resolve(null), SAMPLE_DETAILED_TIMEOUT_MS);
+      });
+      const winner = await Promise.race([detailed, timeout]);
       const ms = performance.now() - t0;
       if (winner !== null) {
         const r0 = winner[0] as { height?: number } | undefined;
@@ -142,6 +140,10 @@ export async function resolveTerrainElevation(
       }
     } catch (err) {
       console.warn('[TerrainElevation] sampleHeightMostDetailed threw:', err);
+    } finally {
+      // Cancel the timeout if the detailed sample resolved first, so the
+      // timer doesn't dangle and resolve to null after we've moved on.
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
     }
   }
 

--- a/apps/viewer/src/lib/geo/terrain-elevation.ts
+++ b/apps/viewer/src/lib/geo/terrain-elevation.ts
@@ -50,10 +50,16 @@ export function clearTerrainElevationCache(): void {
  *      lat/lon).
  *   3. scene.sampleHeight (sync, queries 3D Tiles + terrain — only works
  *      if tiles for the location are already rendered).
- *   4. Open-Meteo elevation API (~200-500 ms, always works online).
- *   5. scene.sampleHeightMostDetailed (async, forces tile load — slow last
- *      resort if Open-Meteo fails).
+ *   4. scene.sampleHeightMostDetailed with a bounded timeout — forces tile
+ *      load and returns the height of the actually-rendered surface (what
+ *      the user SEES in Google Photorealistic 3D Tiles). Tried before
+ *      Open-Meteo because the visible-tile elevation is what models need
+ *      to sit on; Open-Meteo's DEM ignores buildings/road surfaces.
+ *   5. Open-Meteo elevation API — bare-earth fallback when tiles can't be
+ *      sampled (offline, no 3D tileset, timeout, etc.).
  */
+const SAMPLE_DETAILED_TIMEOUT_MS = 3500;
+
 export async function resolveTerrainElevation(
   Cesium: typeof import('cesium'),
   viewer: InstanceType<typeof import('cesium').Viewer>,
@@ -107,9 +113,40 @@ export async function resolveTerrainElevation(
     }
   }
 
-  // 3. Open-Meteo elevation API — reliable network fallback. Doesn't need
-  //    any tiles loaded; works for Google 3D Tiles environments where
-  //    Cesium has no tile depth yet. True sea-level (0) is allowed here.
+  // 3. Force-load the 3D-Tile tile at this location and sample the
+  //    rendered surface. This is what Google Photorealistic 3D Tiles
+  //    show on screen, so the model lands on the SAME surface the user
+  //    sees — no "below the visible ground" mismatch with Open-Meteo's
+  //    DEM. Bounded by a timeout so a slow tile fetch doesn't keep the
+  //    bridge waiting forever; Open-Meteo runs after as a backstop.
+  if (viewer.scene.sampleHeightSupported) {
+    try {
+      const t0 = performance.now();
+      const detailed = viewer.scene.sampleHeightMostDetailed([position]);
+      const timeout = new Promise<null>((resolve) =>
+        setTimeout(() => resolve(null), SAMPLE_DETAILED_TIMEOUT_MS),
+      );
+      const winner = await Promise.race([
+        detailed.then((results) => results),
+        timeout,
+      ]);
+      const ms = performance.now() - t0;
+      if (winner !== null) {
+        const r0 = winner[0] as { height?: number } | undefined;
+        if (r0?.height !== undefined && isPlausibleElevation(r0.height)) {
+          return accept(r0.height, 'scene.sampleHeightMostDetailed', ms);
+        }
+        if (r0?.height !== undefined) skip(r0.height, 'scene.sampleHeightMostDetailed');
+      } else {
+        console.debug(`[TerrainElevation] sampleHeightMostDetailed timed out after ${ms.toFixed(0)}ms`);
+      }
+    } catch (err) {
+      console.warn('[TerrainElevation] sampleHeightMostDetailed threw:', err);
+    }
+  }
+
+  // 4. Open-Meteo bare-earth elevation. Used as a network fallback when
+  //    the visible-tile sample didn't resolve in time.
   try {
     const t0 = performance.now();
     const elev = await queryTerrainElevation({ lat, lon });
@@ -120,23 +157,6 @@ export async function resolveTerrainElevation(
     if (elev !== null) skip(elev, 'Open-Meteo');
   } catch (err) {
     console.warn('[TerrainElevation] Open-Meteo threw:', err);
-  }
-
-  // 4. Last resort: force Cesium to load tiles for this location. Slow
-  //    (seconds) but the most accurate when 3D Tiles are the only source.
-  if (viewer.scene.sampleHeightSupported) {
-    try {
-      const t0 = performance.now();
-      const results = await viewer.scene.sampleHeightMostDetailed([position]);
-      const ms = performance.now() - t0;
-      const r0 = results?.[0] as { height?: number } | undefined;
-      if (r0?.height !== undefined && isPlausibleElevation(r0.height)) {
-        return accept(r0.height, 'scene.sampleHeightMostDetailed', ms);
-      }
-      if (r0?.height !== undefined) skip(r0.height, 'scene.sampleHeightMostDetailed');
-    } catch (err) {
-      console.warn('[TerrainElevation] sampleHeightMostDetailed threw:', err);
-    }
   }
 
   console.warn(`[TerrainElevation] no source returned a plausible value at ${cacheKey}`);

--- a/apps/viewer/src/lib/geo/terrain-elevation.ts
+++ b/apps/viewer/src/lib/geo/terrain-elevation.ts
@@ -1,0 +1,144 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Terrain elevation lookup pipeline.
+ *
+ * Multiple sources are tried fast-first with diagnostic logging and a
+ * sanity range check, so callers get a usable elevation regardless of
+ * whether the user has Cesium-ion terrain, Google Photorealistic 3D
+ * Tiles, or no Cesium-side terrain at all (Open-Meteo handles that).
+ */
+
+import { queryTerrainElevation } from './reproject';
+
+// Module-level cache so bridge rebuilds (georef edits, clamp toggles)
+// re-use values within the session instead of re-hitting the network.
+const terrainElevationCache = new Map<string, number>();
+
+function terrainCacheKey(lat: number, lon: number): string {
+  // 5 decimal places ≈ 1.1m precision — plenty for site-level elevation.
+  return `${lat.toFixed(5)},${lon.toFixed(5)}`;
+}
+
+// Earth's plausible terrestrial elevation range. Mariana Trench ≈ −11 km
+// (no buildings there) and Everest summit ≈ 8.85 km. Anything outside this
+// band is depth-buffer / uninitialised garbage and must be discarded.
+const ELEV_MIN = -1000;
+const ELEV_MAX = 9000;
+
+function isPlausibleElevation(h: number): boolean {
+  return Number.isFinite(h) && h > ELEV_MIN && h < ELEV_MAX;
+}
+
+/**
+ * Clear the session terrain cache. Call when switching terrain providers,
+ * data sources, or whenever a stale cached value would be misleading.
+ */
+export function clearTerrainElevationCache(): void {
+  terrainElevationCache.clear();
+}
+
+/**
+ * Resolve terrain elevation at a WGS84 lat/lon.
+ *
+ * Order:
+ *   1. Cache (instant — re-bridge after georef edit).
+ *   2. globe.getHeight (sync, terrain provider — exact-zero treated as
+ *      "no data" since the default ellipsoid provider returns 0 for every
+ *      lat/lon).
+ *   3. scene.sampleHeight (sync, queries 3D Tiles + terrain — only works
+ *      if tiles for the location are already rendered).
+ *   4. Open-Meteo elevation API (~200-500 ms, always works online).
+ *   5. scene.sampleHeightMostDetailed (async, forces tile load — slow last
+ *      resort if Open-Meteo fails).
+ */
+export async function resolveTerrainElevation(
+  Cesium: typeof import('cesium'),
+  viewer: InstanceType<typeof import('cesium').Viewer>,
+  lat: number,
+  lon: number,
+): Promise<number | null> {
+  const cacheKey = terrainCacheKey(lat, lon);
+  const cached = terrainElevationCache.get(cacheKey);
+  if (cached !== undefined) {
+    console.debug(`[TerrainElevation] cached at ${cacheKey}: ${cached.toFixed(2)}m`);
+    return cached;
+  }
+
+  const position = Cesium.Cartographic.fromDegrees(lon, lat);
+  const accept = (h: number, source: string, ms?: number): number => {
+    terrainElevationCache.set(cacheKey, h);
+    const t = ms !== undefined ? ` (${ms.toFixed(0)}ms)` : '';
+    console.debug(`[TerrainElevation] via ${source}: ${h.toFixed(2)}m at ${cacheKey}${t}`);
+    return h;
+  };
+  const skip = (h: unknown, source: string) => {
+    console.debug(`[TerrainElevation] ${source} returned implausible value ${h}; skipping`);
+  };
+
+  // 1. Sync globe.getHeight. The default ellipsoid provider returns 0 for
+  //    every lat/lon, so when no real terrain provider is wired we'd lock
+  //    in 0 and never reach the network fallbacks. Treat exact-zero from
+  //    this source specifically as "no data" — Open-Meteo can still return
+  //    a true 0 elsewhere in the chain for legitimate sea-level sites.
+  try {
+    const h = viewer.scene.globe.getHeight(position);
+    if (h !== undefined && isPlausibleElevation(h) && Math.abs(h) > 1e-3) {
+      return accept(h, 'globe.getHeight');
+    }
+    if (h !== undefined && !isPlausibleElevation(h)) skip(h, 'globe.getHeight');
+  } catch (err) {
+    console.warn('[TerrainElevation] globe.getHeight threw:', err);
+  }
+
+  // 2. Sync scene.sampleHeight — works with 3D Tiles when tiles for this
+  //    location are already rendered.
+  if (viewer.scene.sampleHeightSupported) {
+    try {
+      const h = viewer.scene.sampleHeight(position);
+      if (h !== undefined && isPlausibleElevation(h)) {
+        return accept(h, 'scene.sampleHeight');
+      }
+      if (h !== undefined) skip(h, 'scene.sampleHeight');
+    } catch (err) {
+      console.warn('[TerrainElevation] scene.sampleHeight threw:', err);
+    }
+  }
+
+  // 3. Open-Meteo elevation API — reliable network fallback. Doesn't need
+  //    any tiles loaded; works for Google 3D Tiles environments where
+  //    Cesium has no tile depth yet. True sea-level (0) is allowed here.
+  try {
+    const t0 = performance.now();
+    const elev = await queryTerrainElevation({ lat, lon });
+    const ms = performance.now() - t0;
+    if (elev !== null && isPlausibleElevation(elev)) {
+      return accept(elev, 'Open-Meteo', ms);
+    }
+    if (elev !== null) skip(elev, 'Open-Meteo');
+  } catch (err) {
+    console.warn('[TerrainElevation] Open-Meteo threw:', err);
+  }
+
+  // 4. Last resort: force Cesium to load tiles for this location. Slow
+  //    (seconds) but the most accurate when 3D Tiles are the only source.
+  if (viewer.scene.sampleHeightSupported) {
+    try {
+      const t0 = performance.now();
+      const results = await viewer.scene.sampleHeightMostDetailed([position]);
+      const ms = performance.now() - t0;
+      const r0 = results?.[0] as { height?: number } | undefined;
+      if (r0?.height !== undefined && isPlausibleElevation(r0.height)) {
+        return accept(r0.height, 'scene.sampleHeightMostDetailed', ms);
+      }
+      if (r0?.height !== undefined) skip(r0.height, 'scene.sampleHeightMostDetailed');
+    } catch (err) {
+      console.warn('[TerrainElevation] sampleHeightMostDetailed threw:', err);
+    }
+  }
+
+  console.warn(`[TerrainElevation] no source returned a plausible value at ${cacheKey}`);
+  return null;
+}

--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -269,7 +269,10 @@ const createViewerStore = () => create<ViewerState>()((...args) => ({
       cesiumAvailable: false,
       cesiumEnabled: false,
       cesiumTerrainHeight: null,
-      cesiumTerrainClamp: false,
+      // Default the clamp toggle ON so models authored at sea-level
+      // OrthogonalHeight don't load buried below the 3D-tiles terrain on
+      // first activation. Users can still uncheck it manually.
+      cesiumTerrainClamp: true,
       cesiumSourceModelId: null,
       cesiumTerrainClipY: null,
       cesiumGlbLoaded: false,

--- a/apps/viewer/src/store/slices/cesiumSlice.ts
+++ b/apps/viewer/src/store/slices/cesiumSlice.ts
@@ -101,7 +101,7 @@ export const createCesiumSlice: StateCreator<CesiumSlice, [], [], CesiumSlice> =
   cesiumDataSource: loadDataSource(),
   cesiumIonToken: resolveIonToken(),
   cesiumTerrainEnabled: true,
-  cesiumTerrainClamp: false,
+  cesiumTerrainClamp: true,
   cesiumTerrainHeight: null,
   cesiumSourceModelId: null,
   cesiumTerrainClipY: null,


### PR DESCRIPTION
## Summary
Fixes incorrect scaling of IFC models during map conversion when geometry has been converted to metres. The issue occurred because `IfcMapConversion.Scale` is defined relative to the project's native length unit, but was being applied directly to geometry that had already been converted to metres, causing double-scaling.

## Key Changes

- **New function `getEffectiveHorizontalScale()`**: Implements the correct formula for scaling metre-converted geometry:
  - Formula: `(Scale * mapUnitScale) / lengthUnitScale`
  - When `Scale` is set per IFC spec to bridge unit differences (e.g., 0.001 for mm→m), this evaluates to 1.0 and geometry passes through unchanged
  - Includes comprehensive documentation explaining the IFC schema and the scaling derivation

- **Updated `reproject.ts`**: 
  - Replaced raw `conversion.scale` usage with `getEffectiveHorizontalScale()` in three functions: `computeProjectedCenter()`, `reprojectFromLatLon()`, and `computeFootprintGeoJSON()`
  - Fixed `computeProjectedCenter()` to use `mapUnitScale` for MapConversion values (which are in map unit, not project unit)
  - Added proper parameter passing for `mapUnitScale` and `lengthUnitScale`

- **Updated `CesiumOverlay.tsx`**:
  - Modified `buildModelMatrix()` to accept `projectedCRS` and `lengthUnitScale` parameters
  - Uses `getEffectiveHorizontalScale()` instead of raw scale value
  - Updated dependency array to include `projectedCRS`

- **Updated `useIfcFederation.ts`**:
  - Modified `getAxis()` to accept full `ModelGeoref` object and compute effective horizontal scale
  - Ensures georeferencing alignment transforms use correct scaling

- **Updated `cesium-bridge.ts`**:
  - Uses `getEffectiveHorizontalScale()` when creating the Cesium bridge
  - Properly scales MapConversion values using `mapUnitScale`

## Implementation Details

The fix addresses a fundamental issue in how the IFC specification's `IfcMapConversion.Scale` attribute is applied. Per the IFC schema, `Scale` converts LOCAL ENGINEERING coordinates (in the project's length unit) to MAP coordinates (in the map CRS unit). Since ifc-lite converts geometry to metres during extraction, the effective scale must account for both the unit conversion and the map unit scale.

All affected code paths now consistently use the effective horizontal scale formula, ensuring models are positioned and scaled correctly regardless of the project's native unit or map unit configuration.

https://claude.ai/code/session_01Tzmf5nDYWhZ4Mne2oc1J5B

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/louistrue/codesmith/ifc-lite/pr/622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline warning for scale/unit mismatches and effective horizontal scaling.
  * Multi-source terrain elevation lookup with session cache and network fallback.
  * Storey-aware clamp anchor selection and “set orthogonal height” alignment.

* **Behavior Changes**
  * Terrain placement resolved before model creation and baked into origin; clamp enabled by default.
  * Camera inputs hardened (screen-space camera inputs disabled) for stable navigation.
  * Model matrix refreshes after async placement updates.

* **Tests**
  * Added tests for scaling logic and clamp-anchor selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->