### PR TITLE
fix(geometry): rewrite worker URLs in every published dist file

### DIFF
--- a/.changeset/fix-geometry-worker-url-rewrite.md
+++ b/.changeset/fix-geometry-worker-url-rewrite.md
@@ -1,0 +1,17 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Fix `Could not resolve entry module "geometry.worker.ts"` when bundling the
+published `@ifc-lite/geometry` package with Vite/Rollup.
+
+`src/geometry-parallel.ts` constructs module workers via
+`new Worker(new URL('./geometry.worker.ts', import.meta.url), ...)`. The post-
+build step in `package.json` rewrites those `.ts` URLs to `.js` so the npm
+tarball ships URLs that point at the emitted file — but the rewrite was only
+applied to `dist/index.js`, and the worker URLs live in `dist/geometry-parallel.js`.
+Consumers like the `create-ifc-lite` Vite templates therefore tried to load a
+`.ts` worker entry that is not present in the tarball and the build failed.
+
+Apply the rewrite to every `.js` file in `dist/`, leaving the source TypeScript
+URL unchanged so in-repo Vite builds keep resolving the worker from source.

--- a/packages/geometry/package.json
+++ b/packages/geometry/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "pnpm exec tsc && node -e \"const f='dist/index.js';require('fs').writeFileSync(f,require('fs').readFileSync(f,'utf8').replace(/geometry\\.worker\\.ts/g,'geometry.worker.js'))\"",
+    "build": "pnpm exec tsc && node -e \"const fs=require('fs');for(const f of fs.readdirSync('dist'))if(f.endsWith('.js')){const p='dist/'+f;fs.writeFileSync(p,fs.readFileSync(p,'utf8').replace(/\\.worker\\.ts/g,'.worker.js'))}\"",
     "dev": "pnpm exec tsc --watch",
     "test": "vitest run"
   },


### PR DESCRIPTION
## Summary
Fix the published `@ifc-lite/geometry` package so consumers (`create-ifc-lite` templates, any external Vite/Rollup user) can actually bundle it. Companion to #633 — same root cause, but keeps the workspace Vite build working too.

## Root cause
`src/geometry-parallel.ts` constructs module workers via
```ts
new Worker(new URL('./geometry.worker.ts', import.meta.url), { type: 'module' })
```
The build script in `packages/geometry/package.json` rewrites those `.ts` URLs to `.js` after tsc emits, so the published tarball points at the file that actually exists in `dist/`. But the rewrite only touched `dist/index.js`, while the worker URL lives in `dist/geometry-parallel.js`. So 1.17.0 shipped unpatched `.ts` references and bundlers fail:

```
[commonjs--resolver] Could not resolve entry module
  "node_modules/@ifc-lite/geometry/dist/geometry.worker.ts"
```

This is what was breaking the `test-templates` CI matrix (react / threejs / babylonjs) on PRs that touch `packages/create-ifc-lite/**`, including the unrelated #632.

## Fix
Walk every `.js` in `dist/` and apply the same `.worker.ts` → `.worker.js` substitution. Keep the source TypeScript URL unchanged so workspace consumers (`apps/viewer-embed`, etc.) keep resolving the worker from `src/` — this avoids the regression that surfaced on #633 (`Could not resolve entry module .../src/geometry.worker.js`).

The regex deliberately has no `$N` backreferences in the replacement so the one-liner survives npm/sh shell expansion on every platform.

## Test plan
- [x] `pnpm --filter @ifc-lite/geometry build` — clean rebuild
- [x] `grep -n 'new Worker' dist/geometry-parallel.js` — both URLs now reference `./geometry.worker.js`
- [x] `pnpm pack` + inspect tarball — `package/dist/geometry-parallel.js` references `geometry.worker.js`
- [x] `pnpm --filter @ifc-lite/viewer-embed build` — workspace Vite path still resolves the `.ts` worker from `src/` cleanly
- [ ] CI `test-templates` matrix (react / threejs / babylonjs) — pending

## Notes
- #632 already merged; this PR addresses the CI failure that surfaced there.
- #633 had the right diagnosis but the inverse fix (editing source `.ts` → `.js`) broke the in-repo Vite build. This PR keeps the source untouched and only changes the publish-time rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/louistrue/codesmith/ifc-lite/pr/637"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->