### PR TITLE
fix(renderer): copy entire depth subresource for GPU picker readback

### DIFF
--- a/.changeset/picker-depth32float-copy.md
+++ b/.changeset/picker-depth32float-copy.md
@@ -1,0 +1,12 @@
+---
+"@ifc-lite/renderer": patch
+---
+
+Fix GPU picker silently failing on small models. `Picker.pick()` was
+reading back a 1×1 `depth-only` texel for click-to-world unprojection,
+which WebGPU rejects — depth/stencil-format copies must cover the full
+subresource. Clicks on files small enough to take the GPU picker path
+(≤500 mesh pieces; larger models hit the CPU-raycast fallback) silently
+resolved to `null`, leaving no 3D highlight and no property panel. The
+depth readback now copies the full depth image and indexes the mapped
+buffer client-side; no shader, pipeline, or point-picker changes.

--- a/packages/renderer/src/picker.ts
+++ b/packages/renderer/src/picker.ts
@@ -226,28 +226,37 @@ export class Picker {
       { width: 1, height: 1 },
     );
 
-    // Parallel depth-texel readback so the host can unproject the click
-    // to a world-space hit point. depth32float = 4 bytes per texel; we
-    // pad the row to 256 like the color readback.
+    // Depth readback for click-to-world unprojection. WebGPU forbids
+    // partial copies from depth/stencil-format textures — the copy must
+    // cover the entire subresource. So we copy the whole depth image
+    // and index into the buffer client-side after mapping. depth32float
+    // = 4 bytes per texel; bytesPerRow must still be a multiple of 256.
+    const depthBytesPerRow = Math.ceil((width * 4) / 256) * 256;
     const depthBuffer = this.device.createBuffer({
-      size: BYTES_PER_ROW,
+      size: depthBytesPerRow * height,
       usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
     });
     encoder.copyTextureToBuffer(
       {
         texture: this.depthTexture,
-        origin: { x: sampleX, y: sampleY, z: 0 },
+        origin: { x: 0, y: 0, z: 0 },
         aspect: 'depth-only',
       },
-      { buffer: depthBuffer, bytesPerRow: BYTES_PER_ROW, rowsPerImage: 1 },
-      { width: 1, height: 1 },
+      { buffer: depthBuffer, bytesPerRow: depthBytesPerRow, rowsPerImage: height },
+      { width, height },
     );
 
     this.device.queue.submit([encoder.finish()]);
     // GPUMapMode.READ = 1 (WebGPU spec)
     await Promise.all([readBuffer.mapAsync(1), depthBuffer.mapAsync(1)]);
     const sample = new Uint32Array(readBuffer.getMappedRange())[0];
-    const depth = new Float32Array(depthBuffer.getMappedRange())[0];
+    const depthBytes = new Uint8Array(depthBuffer.getMappedRange());
+    const depthOffset = sampleY * depthBytesPerRow + sampleX * 4;
+    const depth = new Float32Array(
+      depthBytes.buffer,
+      depthBytes.byteOffset + depthOffset,
+      1,
+    )[0];
     readBuffer.unmap();
     depthBuffer.unmap();
     readBuffer.destroy();


### PR DESCRIPTION
## Summary

- WebGPU forbids partial `copyTextureToBuffer` from a depth/stencil-format texture — the copy must cover the entire subresource. `Picker.pick()` was reading back a 1×1 `depth-only` texel for click-to-world unprojection, and Chrome rejects the submit (`"Copy origin ... does not cover the entire subresource ... Depth32Float"`).
- Symptom: on small models that take the GPU picker path (≤500 mesh pieces; see `picking-manager.ts:152`), clicks silently resolve to `null`. No 3D highlight, no property panel, no selection state. Larger files hit the CPU-raycast fallback and work normally — which is why the bug is file-specific.
- Fix copies the full depth subresource and indexes the mapped buffer at `(sampleY * bytesPerRow + sampleX * 4)`. Per-pick cost goes from 256 B to ~1.6 MB at 576×708 (~33 MB at 4K), bounded by click/hover frequency and reclaimed by `destroy()` after `unmap()`. No shader, pipeline, or point-picker changes.
- Repro: any small IFC; e.g. `BIM-Testfiles/4_DT.ifc` (Revit IFC4, 3 multilayer walls → ~20 mesh pieces after #644's slicer). Not a regression from #644 — that PR just shrank this file enough to expose a latent issue. The recurring `Invalid CommandBuffer` console spam disappears with the fix.

## Test plan

- [ ] Load a small IFC (e.g. `4_DT.ifc`) in the viewer; click a wall — verify 3D highlight + property panel populate, and the inspector shows the wall's GlobalId / attributes / Psets.
- [ ] Click empty canvas space; verify selection clears.
- [ ] Click a wall on a larger file (CPU-raycast path) and confirm no regression.
- [ ] Confirm no `Depth32Float` / `Invalid CommandBuffer` errors appear in DevTools console during picking.
- [ ] Confirm `worldXYZ` in the pick result is finite (it's used by hover tooltips / annotate / addElement placement).
- [ ] Sanity-check rect-pick (Shift+drag) still works — it doesn't read depth, so should be unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/louistrue/codesmith/ifc-lite/pr/645"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->