### PR TITLE
test(collab-server): de-flake token bucket refill test with fake timers

### DIFF
--- a/packages/collab-server/test/audit-rate.test.ts
+++ b/packages/collab-server/test/audit-rate.test.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { MemoryPersistence, startCollabServer } from '../src/server.js';
 import { MemoryAuditSink, shortHash } from '../src/audit-log.js';
 import { createRateLimiter } from '../src/rate-limit.js';
@@ -19,13 +19,24 @@ describe('audit log + rate limit', () => {
   });
 
   it('token bucket refills over time', async () => {
-    const limiter = createRateLimiter({ capacity: 3, refillPerSecond: 100 });
-    expect(limiter.tryConsume(1)).toBe(true);
-    expect(limiter.tryConsume(1)).toBe(true);
-    expect(limiter.tryConsume(1)).toBe(true);
-    expect(limiter.tryConsume(1)).toBe(false);
-    await new Promise((r) => setTimeout(r, 50));
-    expect(limiter.tryConsume(1)).toBe(true);
+    // Use fake timers so the test is deterministic on slow CI. The rate
+    // limiter reads Date.now() for refill timing; a few real milliseconds
+    // between consumes used to be enough to refill a token at 100 tokens/s.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+    try {
+      const limiter = createRateLimiter({ capacity: 3, refillPerSecond: 100 });
+      expect(limiter.tryConsume(1)).toBe(true);
+      expect(limiter.tryConsume(1)).toBe(true);
+      expect(limiter.tryConsume(1)).toBe(true);
+      // Bucket empty, no virtual time has passed → must reject.
+      expect(limiter.tryConsume(1)).toBe(false);
+      // 50 ms × 100 tokens/s = 5 tokens, capped at capacity=3.
+      vi.advanceTimersByTime(50);
+      expect(limiter.tryConsume(1)).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('writes to disallowed roles are rejected and logged', async () => {


### PR DESCRIPTION
## Summary

Fixes flaky token-bucket test using vitest fake timers.

The `token bucket refills over time` test in `packages/collab-server/test/audit-rate.test.ts` consumed 3 tokens from a `capacity: 3, refillPerSecond: 100` limiter, then asserted that a 4th `tryConsume(1)` returns `false`. At 0.1 tokens/ms, a slow CI runner spending ~10ms between the four `tryConsume` calls could refill a token in the background and flip the assertion to `true`.

Switch the test to `vi.useFakeTimers()` + `vi.advanceTimersByTime(50)` so wall-clock jitter can no longer affect the bucket. The rate limiter (`packages/collab-server/src/rate-limit.ts`) reads `Date.now()` for refill timing, which vitest fake timers control deterministically — no production code changes needed.

## Test plan

- [x] `pnpm -C packages/collab-server exec vitest run test/audit-rate.test.ts` passes locally
- [x] Re-ran 5 times in a row, 4/4 tests pass deterministically each run

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/louistrue/codesmith/ifc-lite/pr/649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->