### PR TITLE
fix(ci): release workflow needs nightly toolchain after #657 untracked WASM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,14 +33,25 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+      # rust-toolchain.toml pins nightly-2025-11-15 + wasm32-unknown-unknown.
+      # `rustup show` installs that exact toolchain on GHA runners; matches
+      # test.yml + desktop-compat.yml so the published bundle is byte-identical
+      # to what CI tested. Plain @stable would leave the nightly missing and
+      # `wasm-pack build` would fail with "toolchain not installed" — exactly
+      # the regression observed on Release #403 after #657 untracked the wasm.
+      - name: Setup Rust (pinned by rust-toolchain.toml)
+        run: rustup show
+
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: latest
 
       - name: Install Dependencies
         run: pnpm install
@@ -140,7 +151,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
       - name: Verify all packages on npm


### PR DESCRIPTION
## Summary

Hotfix for the Release workflow that broke on main as the first post-merge run of #657. After we stopped committing wasm bundles to git, every workflow calling \`pnpm build\` needs to compile wasm from Rust source. \`release.yml\` was still installing \`dtolnay/rust-toolchain@stable\`, which leaves the \`nightly-2025-11-15\` channel pinned by \`rust-toolchain.toml\` uninstalled — \`wasm-pack build\` then fails with \"toolchain not installed\".

## What changes

- \`Setup Rust\` step: \`dtolnay/rust-toolchain@stable\` → \`rustup show\` (auto-installs the toolchain from \`rust-toolchain.toml\`).
- Add \`Swatinem/rust-cache@v2\` so subsequent release builds reuse cargo's incremental cache (~30 s vs ~3 min cold).
- Replace curl-pipe wasm-pack install with \`jetli/wasm-pack-action@v0.4.0\` (faster + caches the binary).
- Bump both jobs (\`release\` + \`verify-npm-publish\`) from Node 20 → 22 to match \`engines.node\` in \`package.json\` (Release #403 also logged \`WARN  Unsupported engine\`).

Matches the setup pattern in \`test.yml\` and \`desktop-compat.yml\`, both of which passed on PR #657.

## Test plan

- [x] Pattern matches the two workflows that already work post-#657 (Test + Desktop Compatibility).
- [ ] CI on this PR confirms the Test workflow still passes against the head commit. (Release workflow itself only runs on push to main, so the real proof comes after merge.)
- [ ] Post-merge: Release run on main builds cleanly and either publishes (if changesets pending) or finishes with \`published == false\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/louistrue/codesmith/ifc-lite/pr/662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure and tooling versions for improved development and release processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/louistrue/ifc-lite/pull/662)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->