### PR TITLE
Make wasm-threaded an optional peer dependency

### DIFF
--- a/packages/geometry/package.json
+++ b/packages/geometry/package.json
@@ -18,16 +18,24 @@
   },
   "dependencies": {
     "@ifc-lite/data": "workspace:^",
-    "@ifc-lite/wasm": "workspace:^",
-    "@ifc-lite/wasm-threaded": "workspace:*"
+    "@ifc-lite/wasm": "workspace:^"
   },
   "optionalDependencies": {
     "@tauri-apps/api": "^2.0.0"
   },
   "devDependencies": {
+    "@ifc-lite/wasm-threaded": "workspace:*",
     "@tauri-apps/api": "^2.0.0",
     "typescript": "^5.3.0",
     "vitest": "^1.6.0"
+  },
+  "peerDependencies": {
+    "@ifc-lite/wasm-threaded": "*"
+  },
+  "peerDependenciesMeta": {
+    "@ifc-lite/wasm-threaded": {
+      "optional": true
+    }
   },
   "license": "MPL-2.0",
   "author": "Louis True",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -893,10 +893,10 @@ importers:
       '@ifc-lite/wasm':
         specifier: workspace:^
         version: link:../wasm
+    devDependencies:
       '@ifc-lite/wasm-threaded':
         specifier: workspace:*
         version: link:../wasm-threaded
-    devDependencies:
       typescript:
         specifier: ^5.3.0
         version: 5.9.3


### PR DESCRIPTION
## Summary
Refactored the dependency structure for `@ifc-lite/wasm-threaded` to make it an optional peer dependency rather than a required dependency. This allows consumers of the geometry package to opt-in to threaded WASM support without forcing it as a hard requirement.

## Changes
- Moved `@ifc-lite/wasm-threaded` from `dependencies` to `devDependencies`
- Added `@ifc-lite/wasm-threaded` as an optional `peerDependencies` entry
- Marked the peer dependency as optional via `peerDependenciesMeta`
- Kept `@ifc-lite/wasm` as a required dependency

## Details
This change improves the package's flexibility by allowing downstream consumers to decide whether they need the threaded WASM variant. The package can still be developed and tested with the threaded version (via devDependencies), but consumers won't be forced to install it unless they explicitly need it.

https://claude.ai/code/session_016V9sTE3VQpm2MqwNgdmxmM

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/louistrue/codesmith/ifc-lite/pr/665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->