### PR TITLE
Use on-demand property extraction in lens adapter

### DIFF
--- a/apps/viewer/src/lib/lens/adapter.ts
+++ b/apps/viewer/src/lib/lens/adapter.ts
@@ -14,6 +14,7 @@ import type { LensDataProvider, PropertySetInfo, ClassificationInfo } from '@ifc
 import type { IfcDataStore } from '@ifc-lite/parser';
 import {
   extractEntityAttributesOnDemand,
+  extractPropertiesOnDemand,
   extractQuantitiesOnDemand,
   extractClassificationsOnDemand,
   extractMaterialsOnDemand,
@@ -115,7 +116,17 @@ export function createLensDataProvider(
     getPropertySets(globalId: number): PropertySetInfo[] {
       const resolved = resolveGlobalId(globalId, entries);
       if (!resolved) return [];
-      const psets = resolved.entry.ifcDataStore.properties?.getForEntity?.(resolved.expressId);
+      const store = resolved.entry.ifcDataStore;
+      const id = resolved.expressId;
+
+      // Properties are extracted lazily — the pre-built table is empty unless
+      // server-parsed. Mirror the quantity path and use the on-demand extractor,
+      // which itself falls back to the eager table when no on-demand map exists.
+      if (store.onDemandPropertyMap && store.source?.length > 0) {
+        return extractPropertiesOnDemand(store, id) as PropertySetInfo[];
+      }
+
+      const psets = store.properties?.getForEntity?.(id);
       if (!psets) return [];
       return psets as PropertySetInfo[];
     },

--- a/apps/viewer/src/lib/lens/adapter.ts
+++ b/apps/viewer/src/lib/lens/adapter.ts
@@ -15,6 +15,7 @@ import type { IfcDataStore } from '@ifc-lite/parser';
 import {
   extractEntityAttributesOnDemand,
   extractPropertiesOnDemand,
+  extractTypePropertiesOnDemand,
   extractQuantitiesOnDemand,
   extractClassificationsOnDemand,
   extractMaterialsOnDemand,
@@ -112,11 +113,22 @@ export function createLensDataProvider(
       // On-demand extraction path: pre-built table is empty for client-parsed
       // stores, so iterate the same psets we expose via getPropertySets.
       if (store.onDemandPropertyMap && store.source?.length > 0) {
-        const psets = extractPropertiesOnDemand(store, id);
-        for (const pset of psets) {
+        const instancePsets = extractPropertiesOnDemand(store, id);
+        for (const pset of instancePsets) {
           if (pset.name !== propertySetName) continue;
           for (const prop of pset.properties) {
             if (prop.name === propertyName) return prop.value;
+          }
+        }
+        // Fall through to type-inherited psets (Pset_*Common is typically
+        // attached to IfcSpaceType / IfcWallType, not the instance).
+        const typeProps = extractTypePropertiesOnDemand(store, id);
+        if (typeProps) {
+          for (const pset of typeProps.properties) {
+            if (pset.name !== propertySetName) continue;
+            for (const prop of pset.properties) {
+              if (prop.name === propertyName) return prop.value;
+            }
           }
         }
         return undefined;
@@ -135,7 +147,18 @@ export function createLensDataProvider(
       // server-parsed. Mirror the quantity path and use the on-demand extractor,
       // which itself falls back to the eager table when no on-demand map exists.
       if (store.onDemandPropertyMap && store.source?.length > 0) {
-        return extractPropertiesOnDemand(store, id) as PropertySetInfo[];
+        const instancePsets = extractPropertiesOnDemand(store, id) as PropertySetInfo[];
+        // Merge type-inherited psets (Pset_*Common lives on the type entity
+        // for occurrences). Instance psets take precedence on name conflict.
+        const typeProps = extractTypePropertiesOnDemand(store, id);
+        if (!typeProps || typeProps.properties.length === 0) return instancePsets;
+
+        const seen = new Set(instancePsets.map((p) => p.name));
+        const merged = instancePsets.slice();
+        for (const pset of typeProps.properties) {
+          if (!seen.has(pset.name)) merged.push(pset as PropertySetInfo);
+        }
+        return merged;
       }
 
       const psets = store.properties?.getForEntity?.(id);

--- a/apps/viewer/src/lib/lens/adapter.ts
+++ b/apps/viewer/src/lib/lens/adapter.ts
@@ -106,11 +106,23 @@ export function createLensDataProvider(
     ): unknown {
       const resolved = resolveGlobalId(globalId, entries);
       if (!resolved) return undefined;
-      return resolved.entry.ifcDataStore.properties?.getPropertyValue?.(
-        resolved.expressId,
-        propertySetName,
-        propertyName,
-      );
+      const store = resolved.entry.ifcDataStore;
+      const id = resolved.expressId;
+
+      // On-demand extraction path: pre-built table is empty for client-parsed
+      // stores, so iterate the same psets we expose via getPropertySets.
+      if (store.onDemandPropertyMap && store.source?.length > 0) {
+        const psets = extractPropertiesOnDemand(store, id);
+        for (const pset of psets) {
+          if (pset.name !== propertySetName) continue;
+          for (const prop of pset.properties) {
+            if (prop.name === propertyName) return prop.value;
+          }
+        }
+        return undefined;
+      }
+
+      return store.properties?.getPropertyValue?.(id, propertySetName, propertyName);
     },
 
     getPropertySets(globalId: number): PropertySetInfo[] {


### PR DESCRIPTION
## Summary
Update the lens adapter's `getPropertySets` method to use lazy property extraction, mirroring the approach already used for quantities. This ensures properties are extracted on-demand from the source data when available, rather than relying solely on pre-built tables.

## Changes
- Import `extractPropertiesOnDemand` function from the parser library
- Refactor `getPropertySets` to check for an on-demand property map before falling back to the eager table
- Add explanatory comment documenting the lazy extraction pattern and fallback behavior

## Implementation Details
The change follows the same pattern already established for quantities:
- When `onDemandPropertyMap` exists and source data is available, use `extractPropertiesOnDemand` to lazily extract properties
- Otherwise, fall back to the pre-built properties table
- This ensures properties are available even when the server hasn't pre-parsed them, improving data completeness

https://claude.ai/code/session_01CUSYMc4oh7eSmQJZyPYK5o

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/louistrue/codesmith/ifc-lite/pr/670"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved property data retrieval efficiency by implementing on-demand loading when available, while maintaining backward compatibility with pre-built data sources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/louistrue/ifc-lite/pull/670)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->