### PR TITLE
fix(geometry): document Vite worker.format + add wasmUrls escape hatch (#666)

### DIFF
--- a/.changeset/geometry-wasm-url-plumbing.md
+++ b/.changeset/geometry-wasm-url-plumbing.md
@@ -1,0 +1,14 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Document the Vite `worker.format: 'es'` config requirement (the actual
+root cause of #666 for geometry consumers — ESM workers are not Vite's
+default and the package can't ship around that) and add an optional
+`ProcessParallelOptions.wasmUrls` escape hatch so consumers whose
+bundler doesn't transform `new URL('ifc-lite_bg.wasm', import.meta.url)`
+inside the worker — or who serve the wasm from a different origin
+(CDN, Tauri custom protocol, etc.) — can pass an explicit URL. The
+workers forward it to wasm-bindgen's documented `init(url)` parameter.
+Default behaviour is unchanged: Vite + webpack 5 consumers who already
+worked continue to work without setting `wasmUrls`.

--- a/packages/geometry/README.md
+++ b/packages/geometry/README.md
@@ -76,19 +76,27 @@ standard and the pattern wasm-bindgen produces by default.
 If your bundler can't transform
 `new URL('ifc-lite_bg.wasm', import.meta.url)` inside the worker bundle
 (or you serve the wasm from a CDN at a separate origin), pass explicit
-wasm URLs through `ProcessParallelOptions.wasmUrls`:
+wasm URLs through the `processAdaptive` / `processParallel` `wasmUrls`
+option:
 
 ```ts
+// Vite's `?url` suffix yields a fully-resolved URL string at build time.
+// `@ifc-lite/wasm` and `@ifc-lite/wasm-threaded` both expose the binary
+// at the `./ifc-lite_bg.wasm` subpath so this resolves cleanly through
+// the package's `exports` map.
 import wasmUrl from '@ifc-lite/wasm/ifc-lite_bg.wasm?url';
 
-for await (const event of processor.processStreaming(buffer, {
+for await (const event of processor.processAdaptive(buffer, {
   wasmUrls: { wasm: wasmUrl },
-})) { ... }
+})) { /* ... */ }
 ```
 
-Vite's `?url` suffix yields a fully-resolved URL the worker can pass
-directly to wasm-bindgen's `init(url)` — no `import.meta.url` resolution
-needed inside the worker.
+The worker forwards the URL to wasm-bindgen's documented `init(url)`
+parameter, bypassing the default `new URL(..., import.meta.url)`
+resolution inside the worker entirely. For webpack 5 use
+`new URL('@ifc-lite/wasm/ifc-lite_bg.wasm', import.meta.url).href`;
+for other bundlers, any string the runtime can resolve to the binary
+works.
 
 ## Performance
 

--- a/packages/geometry/README.md
+++ b/packages/geometry/README.md
@@ -53,6 +53,43 @@ if (result.coordinateInfo?.hasLargeCoordinates) {
 }
 ```
 
+## Vite setup
+
+The geometry workers ship as ESM and use the standard
+`new Worker(new URL('./geometry.worker.js', import.meta.url), { type: 'module' })`
+spawn pattern. Vite's default `worker.format: 'iife'` setting can't host
+ESM workers, so consumers need one config line:
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  worker: { format: 'es' },
+});
+```
+
+This is the same contract that Mapbox-GL, Three.js, Cesium, and Monaco
+require — ESM workers are not the Vite default, but they are the modern
+standard and the pattern wasm-bindgen produces by default.
+
+If your bundler can't transform
+`new URL('ifc-lite_bg.wasm', import.meta.url)` inside the worker bundle
+(or you serve the wasm from a CDN at a separate origin), pass explicit
+wasm URLs through `ProcessParallelOptions.wasmUrls`:
+
+```ts
+import wasmUrl from '@ifc-lite/wasm/ifc-lite_bg.wasm?url';
+
+for await (const event of processor.processStreaming(buffer, {
+  wasmUrls: { wasm: wasmUrl },
+})) { ... }
+```
+
+Vite's `?url` suffix yields a fully-resolved URL the worker can pass
+directly to wasm-bindgen's `init(url)` — no `import.meta.url` resolution
+needed inside the worker.
+
 ## Performance
 
 - **First triangles:** 300–500ms (streaming path)

--- a/packages/geometry/src/geometry-controller.worker.ts
+++ b/packages/geometry/src/geometry-controller.worker.ts
@@ -73,6 +73,14 @@ let api: IfcAPI | null = null;
 let threadPoolReady = false;
 
 /**
+ * Captured at the explicit `init` message and forwarded to wasm-bindgen's
+ * `init(url)` call. Mirrors `geometry.worker.ts`'s `cachedWasmUrl` — see
+ * that file for the rationale. Defaults to undefined so wasm-bindgen
+ * falls back to its `import.meta.url`-relative default resolution.
+ */
+let cachedWasmUrl: string | undefined = undefined;
+
+/**
  * Cached merge-layers flag (issue #540). The host may post
  * `set-merge-layers` BEFORE `init`, so we remember the latest value
  * and re-apply once the threaded IfcAPI is constructed.
@@ -294,10 +302,11 @@ self.onmessage = (rawEvent: MessageEvent<GeometryControllerRequest>) => {
   messageTail = messageTail.then(async () => {
     try {
       if (e.data.type === 'init') {
+        if (e.data.wasmUrl) cachedWasmUrl = e.data.wasmUrl;
         if (e.data.wasmModule) {
           initSync({ module_or_path: e.data.wasmModule });
         } else {
-          await init();
+          await init(cachedWasmUrl);
         }
         api = new IfcAPI();
         mergeLayersApplied = false;

--- a/packages/geometry/src/geometry-parallel.ts
+++ b/packages/geometry/src/geometry-parallel.ts
@@ -73,6 +73,28 @@ export interface ProcessParallelOptions {
    * Rust layer. Default `false` keeps existing behaviour.
    */
   mergeLayers?: boolean;
+  /**
+   * Explicit URLs for the wasm-bindgen `.wasm` binaries. When provided,
+   * forwarded to the geometry workers' init messages so they call
+   * `init(wasmUrl)` instead of relying on wasm-bindgen's default
+   * `import.meta.url`-based resolution.
+   *
+   * Vite + webpack 5 consumers don't need to set these — the bundler
+   * rewrites the `new URL('ifc-lite_bg.wasm', import.meta.url)` literal
+   * inside the wasm-bindgen glue at build time. These options exist
+   * for consumers whose bundler doesn't transform that pattern, or who
+   * serve the wasm from a CDN at a different origin (e.g., self-hosted
+   * deployments, Tauri custom protocols, embedded usage).
+   *
+   * `wasm` covers the legacy single-thread worker bundle
+   * (`@ifc-lite/wasm`); `wasmThreaded` covers the rayon controller
+   * bundle (`@ifc-lite/wasm-threaded`). Pass both if both code paths
+   * may run.
+   */
+  wasmUrls?: {
+    wasm?: string;
+    wasmThreaded?: string;
+  };
 }
 
 export async function* processParallel(
@@ -281,7 +303,18 @@ export async function* processParallel(
     // Kick off WASM compile concurrently with the pre-pass scan. The
     // worker's tail-promise serialiser guarantees this `init` completes
     // before any subsequent `stream-start`/`stream-chunk` runs.
-    worker.postMessage({ type: 'init' });
+    //
+    // `wasmUrl` is forwarded only when the consumer explicitly provided
+    // one — undefined leaves the worker on wasm-bindgen's default
+    // `import.meta.url`-based resolution, which is what Vite + webpack
+    // already handle.
+    const wasmUrlForWorker = useController
+      ? options?.wasmUrls?.wasmThreaded
+      : options?.wasmUrls?.wasm;
+    worker.postMessage({
+      type: 'init',
+      ...(wasmUrlForWorker ? { wasmUrl: wasmUrlForWorker } : {}),
+    });
     // Issue #540: forward the user's "Merge Multilayer Walls" toggle
     // BEFORE any stream-start so the worker's IfcAPI has the flag set
     // before its first parse call. The tail-promise serialiser inside
@@ -400,6 +433,15 @@ export async function* processParallel(
   console.log(`[stream] processParallel start, fileSizeMB=${fileSizeMB.toFixed(1)} workerCount=${workerCount}`);
 
   const prepassWorker = makePrepassWorker();
+  // Forward the consumer-supplied wasm URL to the pre-pass worker so it
+  // doesn't fall back to wasm-bindgen's `import.meta.url` default. The
+  // pre-pass worker uses the same `geometry.worker.ts` bundle and the
+  // legacy (non-threaded) wasm, so `wasmUrls.wasm` is the right key.
+  // Skipped entirely when no URL was provided — keeps Vite/webpack
+  // consumers on the bundler-native resolution path.
+  if (options?.wasmUrls?.wasm) {
+    prepassWorker.postMessage({ type: 'init', wasmUrl: options.wasmUrls.wasm });
+  }
   let chunkArrivals = 0;
   let totalDispatchedJobs = 0;
   let firstChunkAt = -1;

--- a/packages/geometry/src/geometry.worker.ts
+++ b/packages/geometry/src/geometry.worker.ts
@@ -7,6 +7,19 @@ import init, { initSync, IfcAPI } from '@ifc-lite/wasm';
 export interface GeometryWorkerInitMessage {
   type: 'init';
   wasmModule?: WebAssembly.Module;
+  /**
+   * Explicit URL to the wasm-bindgen `.wasm` binary. When provided,
+   * `init(wasmUrl)` is called instead of relying on wasm-bindgen's
+   * default `import.meta.url`-based resolution.
+   *
+   * Why: consumers whose bundler doesn't transform
+   * `new URL('ifc-lite_bg.wasm', import.meta.url)` inside the worker's
+   * dist (or who serve the wasm from a CDN at a different origin than
+   * the worker) need to resolve the URL on the main thread and pass it
+   * in. Default-undefined preserves the wasm-bindgen built-in path so
+   * Vite/webpack/Rollup consumers that already work keep working.
+   */
+  wasmUrl?: string;
 }
 
 export interface GeometryWorkerProcessMessage {
@@ -159,6 +172,33 @@ export type GeometryWorkerResponse =
   | GeometryWorkerMemoryMessage;
 
 let api: IfcAPI | null = null;
+
+/**
+ * Captured at the explicit `init` message and used for every subsequent
+ * lazy `await init(...)` call in this worker. When undefined, wasm-bindgen
+ * falls back to its built-in `new URL('ifc-lite_bg.wasm', import.meta.url)`
+ * resolution — which works in Vite + webpack 5 today but breaks for
+ * consumers shipping the worker from a separate origin / Blob URL.
+ * See `GeometryWorkerInitMessage.wasmUrl` for the rationale.
+ */
+let cachedWasmUrl: string | undefined = undefined;
+
+/**
+ * Idempotent wasm + IfcAPI initializer. Centralises the
+ * `if (!api) { await init(); api = new IfcAPI(); ... }` boilerplate that
+ * every message handler used to repeat. Honours `cachedWasmUrl` so the
+ * explicit-URL plumbing only has to set state in one place. Returns the
+ * `IfcAPI` so call sites can use the value directly without a non-null
+ * assertion on the module-level `api`.
+ */
+async function ensureInit(): Promise<IfcAPI> {
+  if (api) return api;
+  await init(cachedWasmUrl);
+  api = new IfcAPI();
+  mergeLayersApplied = false;
+  applyMergeLayersToApi();
+  return api;
+}
 
 /**
  * Cached merge-layers flag for this worker. The host may post
@@ -325,13 +365,8 @@ async function processBatch(session: ProcessingSession, jobs: Uint32Array): Prom
   if (numJobs === 0) return;
 
   try {
-    if (!api) {
-      await init();
-      api = new IfcAPI();
-      mergeLayersApplied = false;
-      applyMergeLayersToApi();
-    }
-    const collection = api.processGeometryBatch(
+    const ifcApi = await ensureInit();
+    const collection = ifcApi.processGeometryBatch(
       session.localBytes, jobs, session.unitScale,
       session.rtcX, session.rtcY, session.rtcZ, session.needsShift,
       session.voidKeys, session.voidCounts, session.voidValues,
@@ -411,12 +446,7 @@ self.onmessage = (rawEvent: MessageEvent<GeometryWorkerRequest>) => {
 async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<void> {
   try {
     if (e.data.type === 'prepass-streaming') {
-      if (!api) {
-        await init();
-        api = new IfcAPI();
-        mergeLayersApplied = false;
-        applyMergeLayersToApi();
-      }
+      const ifcApi = await ensureInit();
       // Heartbeat: lets the host watchdog know the worker is alive even
       // before the first chunk lands.
       (self as unknown as Worker).postMessage({ type: 'prepass-progress', phase: 'parsing' });
@@ -433,14 +463,14 @@ async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<vo
         (self as unknown as Worker).postMessage({ type: 'prepass-stream', event });
       };
       try {
-        api.buildPrePassStreaming(view, onEvent, chunkSize);
+        ifcApi.buildPrePassStreaming(view, onEvent, chunkSize);
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         if (!triedFallback) {
           triedFallback = true;
           console.warn(`[Worker] Streaming prepass with SAB view failed (${msg}), retrying with copy`);
           view = materialiseSharedBytes(sharedBuffer);
-          api.buildPrePassStreaming(view, onEvent, chunkSize);
+          ifcApi.buildPrePassStreaming(view, onEvent, chunkSize);
         } else {
           throw err;
         }
@@ -449,12 +479,7 @@ async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<vo
     }
 
     if (e.data.type === 'prepass' || e.data.type === 'prepass-fast') {
-      if (!api) {
-        await init();
-        api = new IfcAPI();
-        mergeLayersApplied = false;
-        applyMergeLayersToApi();
-      }
+      const ifcApi = await ensureInit();
       // Heartbeat: signals "worker alive, parser running" so the host watchdog
       // can distinguish a stuck pre-pass from one that's still working on a
       // multi-GB file.
@@ -466,7 +491,7 @@ async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<vo
       let result: ReturnType<IfcAPI['buildPrePassOnce']>;
       try {
         const view = viewSharedBytes(sharedBuffer);
-        result = isFast ? api.buildPrePassFast(view) : api.buildPrePassOnce(view);
+        result = isFast ? ifcApi.buildPrePassFast(view) : ifcApi.buildPrePassOnce(view);
       } catch (err) {
         // wasm-bindgen on some runtimes rejects SAB-backed views with a
         // TypeError. Retry once with a materialised copy so we never regress
@@ -474,32 +499,28 @@ async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<vo
         const msg = err instanceof Error ? err.message : String(err);
         console.warn(`[Worker] Prepass with SAB view failed (${msg}), retrying with copy`);
         const copy = materialiseSharedBytes(sharedBuffer);
-        result = isFast ? api.buildPrePassFast(copy) : api.buildPrePassOnce(copy);
+        result = isFast ? ifcApi.buildPrePassFast(copy) : ifcApi.buildPrePassOnce(copy);
       }
       (self as unknown as Worker).postMessage({ type: 'prepass-result', result });
       return;
     }
 
     if (e.data.type === 'init') {
+      if (e.data.wasmUrl) cachedWasmUrl = e.data.wasmUrl;
       if (e.data.wasmModule) {
         initSync({ module_or_path: e.data.wasmModule });
+        api = new IfcAPI();
+        mergeLayersApplied = false;
+        applyMergeLayersToApi();
       } else {
-        await init();
+        await ensureInit();
       }
-      api = new IfcAPI();
-      mergeLayersApplied = false;
-      applyMergeLayersToApi();
       (self as unknown as Worker).postMessage({ type: 'ready' });
       return;
     }
 
     if (e.data.type === 'process') {
-      if (!api) {
-        await init();
-        api = new IfcAPI();
-        mergeLayersApplied = false;
-        applyMergeLayersToApi();
-      }
+      await ensureInit();
       const { sharedBuffer, jobsFlat, unitScale, rtcX, rtcY, rtcZ, needsShift,
               voidKeys, voidCounts, voidValues, styleIds, styleColors } = e.data;
       const session = startSession({
@@ -514,12 +535,7 @@ async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<vo
     }
 
     if (e.data.type === 'stream-start') {
-      if (!api) {
-        await init();
-        api = new IfcAPI();
-        mergeLayersApplied = false;
-        applyMergeLayersToApi();
-      }
+      await ensureInit();
       activeSession = startSession({
         sharedBuffer: e.data.sharedBuffer,
         unitScale: e.data.unitScale,
@@ -564,13 +580,8 @@ async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<vo
       // (~5 s on a 1 GB IFC) — the dominant TTFG bottleneck before this
       // change. Now the only cost is FxHashMap construction from the
       // input slices (~1 s for 14 M entries).
-      if (!api) {
-        await init();
-        api = new IfcAPI();
-        mergeLayersApplied = false;
-        applyMergeLayersToApi();
-      }
-      api.setEntityIndex(e.data.ids, e.data.starts, e.data.lengths);
+      const ifcApi = await ensureInit();
+      ifcApi.setEntityIndex(e.data.ids, e.data.starts, e.data.lengths);
       return;
     }
 

--- a/packages/geometry/src/index.ts
+++ b/packages/geometry/src/index.ts
@@ -919,6 +919,15 @@ export class GeometryProcessor {
     ) => void,
     /** Phase 2 flag — use the single-controller worker (rayon-internal). */
     useSingleController?: boolean,
+    /**
+     * Explicit wasm asset URLs forwarded to the worker pool. See
+     * `ProcessParallelOptions.wasmUrls` in `geometry-parallel.ts` for
+     * the full rationale — needed only for bundlers that can't transform
+     * `new URL('ifc-lite_bg.wasm', import.meta.url)` inside the worker
+     * dist (or deployments that serve wasm from a separate origin).
+     * Vite + webpack 5 consumers leave this undefined.
+     */
+    wasmUrls?: { wasm?: string; wasmThreaded?: string },
   ): AsyncGenerator<StreamingGeometryEvent> {
     // Initialize if needed
     if (!this.bridge?.isInitialized()) {
@@ -932,6 +941,7 @@ export class GeometryProcessor {
       // at construction time. processParallel posts `set-merge-layers`
       // to every spawned worker right after `init`.
       mergeLayers: this.mergeLayers,
+      wasmUrls,
     });
   }
 
@@ -968,6 +978,11 @@ export class GeometryProcessor {
       ) => void;
       /** Phase 2 — opt-in to the single-controller (rayon) worker. */
       useSingleController?: boolean;
+      /**
+       * Explicit wasm asset URLs forwarded to the worker pool.
+       * See `processParallel(...).wasmUrls` for rationale.
+       */
+      wasmUrls?: { wasm?: string; wasmThreaded?: string };
     } = {}
   ): AsyncGenerator<StreamingGeometryEvent> {
     const sizeThreshold = options.sizeThreshold ?? 2 * 1024 * 1024; // Default 2MB
@@ -1037,6 +1052,7 @@ export class GeometryProcessor {
           options.existingSab,
           options.onEntityIndex,
           options.useSingleController,
+          options.wasmUrls,
         );
       } else {
         yield* this.processStreaming(buffer, options.entityIndex, batchConfig, options.sharedRtcOffset);

--- a/packages/geometry/src/wasm-url-plumbing.test.ts
+++ b/packages/geometry/src/wasm-url-plumbing.test.ts
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Asserts the wasm-URL plumbing surface for #666 follow-up: consumers
+ * whose bundler can't transform `new URL('ifc-lite_bg.wasm', import.meta.url)`
+ * inside the worker (or who serve the wasm from a different origin) must
+ * be able to override it via `ProcessParallelOptions.wasmUrls`.
+ *
+ * These are surface-level type/shape checks; the integration path is
+ * verified via the geometry-processor-streaming tests (which exercise
+ * the worker codepath end-to-end against the actual wasm bundle).
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { ProcessParallelOptions } from './geometry-parallel.js';
+import type { GeometryWorkerInitMessage } from './geometry.worker.js';
+
+describe('#666 wasm-url plumbing', () => {
+  it('GeometryWorkerInitMessage accepts an optional wasmUrl', () => {
+    // The type assertion below is the actual test: if `wasmUrl` is
+    // dropped from the message contract, this file fails to typecheck.
+    const msg: GeometryWorkerInitMessage = {
+      type: 'init',
+      wasmUrl: 'https://cdn.example.com/ifc-lite_bg.wasm',
+    };
+    expect(msg.type).toBe('init');
+    expect(msg.wasmUrl).toBe('https://cdn.example.com/ifc-lite_bg.wasm');
+  });
+
+  it('ProcessParallelOptions exposes wasmUrls for both bundles', () => {
+    // Same idea: if either key is renamed or dropped, the file fails
+    // to typecheck. Both legacy + threaded bundles must be configurable
+    // because `processParallel` picks one based on `useSingleController`.
+    const opts: ProcessParallelOptions = {
+      wasmUrls: {
+        wasm: '/assets/ifc-lite_bg.wasm',
+        wasmThreaded: '/assets/ifc-lite-threaded_bg.wasm',
+      },
+    };
+    expect(opts.wasmUrls?.wasm).toBe('/assets/ifc-lite_bg.wasm');
+    expect(opts.wasmUrls?.wasmThreaded).toBe('/assets/ifc-lite-threaded_bg.wasm');
+  });
+
+  it('wasmUrls is optional — default Vite/webpack consumers omit it', () => {
+    // Critical: passing no wasmUrls must remain valid. Vite/webpack
+    // consumers rely on wasm-bindgen's `import.meta.url`-based default
+    // resolution; forcing them to provide URLs would break the
+    // existing zero-config experience.
+    const opts: ProcessParallelOptions = {};
+    expect(opts.wasmUrls).toBeUndefined();
+  });
+});

--- a/packages/geometry/src/wasm-url-plumbing.test.ts
+++ b/packages/geometry/src/wasm-url-plumbing.test.ts
@@ -14,8 +14,14 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
 import type { ProcessParallelOptions } from './geometry-parallel.js';
 import type { GeometryWorkerInitMessage } from './geometry.worker.js';
+import type { GeometryProcessor } from './index.js';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 describe('#666 wasm-url plumbing', () => {
   it('GeometryWorkerInitMessage accepts an optional wasmUrl', () => {
@@ -50,5 +56,53 @@ describe('#666 wasm-url plumbing', () => {
     // existing zero-config experience.
     const opts: ProcessParallelOptions = {};
     expect(opts.wasmUrls).toBeUndefined();
+  });
+
+  it('GeometryProcessor.processParallel accepts wasmUrls in its public signature', () => {
+    // Codex P2 #672: the wasmUrls escape hatch was originally only on
+    // the internal `processParallel()` helper, unreachable from the
+    // public `GeometryProcessor.processParallel(...)` entry point. This
+    // type-level check ensures the public signature accepts it — if
+    // someone drops the param, this file fails to typecheck.
+    type ProcessParallelMethod = GeometryProcessor['processParallel'];
+    type Args = Parameters<ProcessParallelMethod>;
+    // 6th positional parameter is wasmUrls (after buffer, sharedRtcOffset,
+    // existingSab, onEntityIndex, useSingleController).
+    const wasmUrlsArg: Args[5] = { wasm: '/x.wasm' };
+    expect(wasmUrlsArg).toBeDefined();
+  });
+
+  it('GeometryProcessor.processAdaptive accepts wasmUrls in its options object', () => {
+    type ProcessAdaptiveMethod = GeometryProcessor['processAdaptive'];
+    type Options = Parameters<ProcessAdaptiveMethod>[1];
+    // The options bag must include wasmUrls so the adaptive entry point —
+    // which is what consumers actually call from the published package —
+    // can thread the escape hatch through to processParallel.
+    const opts: Options = { wasmUrls: { wasm: '/x.wasm' } };
+    expect(opts.wasmUrls?.wasm).toBe('/x.wasm');
+  });
+});
+
+describe('#666 wasm package exports the binary at a resolvable subpath', () => {
+  // Codex P2 #672: the README documented `@ifc-lite/wasm/ifc-lite_bg.wasm?url`
+  // but the package's `exports` map only exposed `.`, so bundlers honoring
+  // exports would reject the subpath import. This test fails if anyone
+  // re-collapses the exports to just `.` again.
+  const repoRoot = resolve(__dirname, '../../..');
+
+  it('@ifc-lite/wasm exports ./ifc-lite_bg.wasm', () => {
+    const pkgPath = resolve(repoRoot, 'packages/wasm/package.json');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as {
+      exports?: Record<string, unknown>;
+    };
+    expect(pkg.exports?.['./ifc-lite_bg.wasm']).toBe('./pkg/ifc-lite_bg.wasm');
+  });
+
+  it('@ifc-lite/wasm-threaded exports ./ifc-lite_bg.wasm', () => {
+    const pkgPath = resolve(repoRoot, 'packages/wasm-threaded/package.json');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as {
+      exports?: Record<string, unknown>;
+    };
+    expect(pkg.exports?.['./ifc-lite_bg.wasm']).toBe('./pkg/ifc-lite_bg.wasm');
   });
 });

--- a/packages/wasm-threaded/package.json
+++ b/packages/wasm-threaded/package.json
@@ -29,7 +29,8 @@
     ".": {
       "import": "./pkg/ifc-lite.js",
       "types": "./pkg/ifc-lite.d.ts"
-    }
+    },
+    "./ifc-lite_bg.wasm": "./pkg/ifc-lite_bg.wasm"
   },
   "sideEffects": [
     "./pkg/snippets/*"

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -27,7 +27,8 @@
     ".": {
       "import": "./pkg/ifc-lite.js",
       "types": "./pkg/ifc-lite.d.ts"
-    }
+    },
+    "./ifc-lite_bg.wasm": "./pkg/ifc-lite_bg.wasm"
   },
   "sideEffects": false,
   "keywords": [


### PR DESCRIPTION
## Summary

Companion to #671 — follows the **best-practice** approach for the geometry workers (which depend on wasm and so can't reuse pointcloud's Blob-URL inline pattern).

The actual root cause of #666 for geometry is that the geometry workers ship as ESM (`new Worker(url, { type: 'module' })`) and Vite's default `worker.format: 'iife'` can't host them. This is the same constraint Mapbox-GL, Three.js, Cesium, and Monaco have — and they all document the same one-line consumer config (`worker.format: 'es'`) instead of trying to ship around it.

This PR:
1. **Documents `worker.format: 'es'`** in the geometry README as a setup prerequisite (the actual fix for #666's user-visible complaint).
2. **Adds an optional `wasmUrls` escape hatch** for consumers whose bundler doesn't transform `new URL('ifc-lite_bg.wasm', import.meta.url)` inside the worker dist or who serve wasm from a CDN at a separate origin.

## What changed

**Worker side** (`geometry.worker.ts`, `geometry-controller.worker.ts`)
- `GeometryWorkerInitMessage` gains optional `wasmUrl?: string`.
- New `cachedWasmUrl` module state, captured at the explicit `init` message and forwarded to wasm-bindgen's documented `init(url)` parameter on every subsequent lazy init.
- The six duplicated `if (!api) { await init(); api = new IfcAPI(); ...; applyMergeLayersToApi(); }` blocks collapse into a single `ensureInit()` helper that returns the `IfcAPI`. Call sites use the return value so the module-level `api` doesn't need non-null assertions after each `await`.
- Default-undefined `wasmUrl` preserves wasm-bindgen's built-in `import.meta.url`-relative resolution that Vite + webpack 5 already transform — **existing zero-config consumers see no behaviour change**.

**Main-thread side** (`geometry-parallel.ts`)
- New `ProcessParallelOptions.wasmUrls?: { wasm?, wasmThreaded? }` so consumers can pass resolved URLs.
- Picks `wasm` vs `wasmThreaded` per `useSingleController`, posts it in each worker's init message, and forwards `wasmUrls.wasm` to the pre-pass worker (which uses the legacy bundle).
- When `wasmUrls` is omitted, no `wasmUrl` field is sent — worker falls back to its built-in default.

**README**
- New "Vite setup" section explaining the `worker.format: 'es'` requirement and the explicit-URL escape hatch with Vite's `?url` suffix.

## Why this is best practice (not Blob URL inline like pointcloud)

The pointcloud fix in #671 inlines the worker as a Blob URL because pointcloud workers are self-contained — no wasm, no nested workers, small enough that the inline cost is acceptable. **Best practice for workers that depend on wasm is the opposite**: let the bundler handle worker + wasm URL resolution via the standard `new URL(..., import.meta.url)` idiom; document the one-line Vite config; provide an explicit-init escape hatch for non-Vite consumers. This is what every major library shipping workers + wasm does (Mapbox-GL, Cesium, swc-wasm, oxc).

## Test plan

- [x] `pnpm --filter @ifc-lite/geometry test` — 57 tests pass (54 existing + 3 new `wasm-url-plumbing.test.ts` surface checks)
- [x] `pnpm --filter @ifc-lite/geometry exec tsc --noEmit` — clean
- [x] `pnpm --filter @ifc-lite/geometry build` — produces dist
- [ ] Verify a consumer app with `worker: { format: 'es' }` in vite.config.ts loads the geometry worker successfully in a production build
- [ ] Verify the explicit `wasmUrls` path works against a CDN-served wasm binary

Closes #666 (with #671)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/louistrue/codesmith/ifc-lite/pr/672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->