### PR TITLE
Optimize database schema bootstrap and increase timeout thresholds

### DIFF
--- a/server/chat/chat-handler.ts
+++ b/server/chat/chat-handler.ts
@@ -37,6 +37,8 @@ export interface ChatHandlerDeps {
   fetchImpl: typeof fetch;
   usageStore: ChatUsageStore;
   now: () => number;
+  usageStoreTimeoutMs?: number;
+  providerFetchTimeoutMs?: number;
 }
 
 export type HeaderBag = Headers | Record<string, string | string[] | undefined> | undefined;
@@ -49,7 +51,7 @@ export type HandlerRequest = Request | {
   body?: unknown;
 };
 
-const USAGE_STORE_TIMEOUT_MS = 8_000;
+const USAGE_STORE_TIMEOUT_MS = 15_000;
 const PROVIDER_FETCH_TIMEOUT_MS = 20_000;
 
 class ChatHandlerTimeoutError extends Error {
@@ -299,6 +301,8 @@ export async function getAnonymousUserId(req: HandlerRequest): Promise<string> {
 }
 
 export function createChatHandler(config: ChatConfig, deps: ChatHandlerDeps) {
+  const usageStoreTimeoutMs = deps.usageStoreTimeoutMs ?? USAGE_STORE_TIMEOUT_MS;
+  const providerFetchTimeoutMs = deps.providerFetchTimeoutMs ?? PROVIDER_FETCH_TIMEOUT_MS;
   return async function handler(req: HandlerRequest): Promise<Response> {
     const supportEmail = 'louis@ltplus.com';
     const url = getRequestUrl(req, config);
@@ -329,7 +333,7 @@ export function createChatHandler(config: ChatConfig, deps: ChatHandlerDeps) {
       try {
         const snapshot = await withTimeout(
           deps.usageStore.getUsageSnapshot(userId, 'free'),
-          USAGE_STORE_TIMEOUT_MS,
+          usageStoreTimeoutMs,
           'Usage store timed out while loading usage.',
         );
         return corsResponse(
@@ -383,13 +387,13 @@ export function createChatHandler(config: ChatConfig, deps: ChatHandlerDeps) {
     try {
       usageSnapshot = await withTimeout(
         deps.usageStore.getUsageSnapshot(userId, 'free'),
-        USAGE_STORE_TIMEOUT_MS,
+        usageStoreTimeoutMs,
         'Usage store timed out while loading usage.',
       );
 
       const consumed = await withTimeout(
         deps.usageStore.consumeFreeRequest(userId),
-        USAGE_STORE_TIMEOUT_MS,
+        usageStoreTimeoutMs,
         'Usage store timed out while reserving a free request.',
       );
       usageSnapshot = consumed.snapshot;
@@ -448,7 +452,7 @@ export function createChatHandler(config: ChatConfig, deps: ChatHandlerDeps) {
           }),
           signal: controller.signal,
         }),
-        PROVIDER_FETCH_TIMEOUT_MS,
+        providerFetchTimeoutMs,
         'Provider request timed out before a response was received.',
         () => controller.abort(),
       );

--- a/server/chat/sql-chat-usage-store.ts
+++ b/server/chat/sql-chat-usage-store.ts
@@ -21,7 +21,7 @@ interface UsageRow {
 }
 
 const DAY_MS = 24 * 60 * 60 * 1000;
-const DB_TIMEOUT_MS = 8_000;
+const DB_TIMEOUT_MS = 15_000;
 
 class UsageStoreTimeoutError extends Error {
   constructor(operation: string) {
@@ -116,29 +116,25 @@ export class SqlChatUsageStore implements ChatUsageStore {
   }
 
   private async bootstrapSchema(): Promise<void> {
+    // Single round-trip schema bootstrap. Combining the CREATE + ALTERs into one
+    // DO block keeps cold starts within the per-query timeout budget on Neon.
     await withTimeout(this.sql`
-      CREATE TABLE IF NOT EXISTS llm_chat_usage (
-        user_id TEXT PRIMARY KEY,
-        credits_used DOUBLE PRECISION NOT NULL DEFAULT 0,
-        billing_anchor_at BIGINT NOT NULL DEFAULT 0,
-        reset_at BIGINT NOT NULL DEFAULT 0,
-        free_requests_used INTEGER NOT NULL DEFAULT 0,
-        free_reset_at BIGINT NOT NULL DEFAULT 0,
-        updated_at BIGINT NOT NULL DEFAULT 0
-      )
-    ` as Promise<unknown>, 'bootstrap create table');
-    await withTimeout(this.sql`
-      ALTER TABLE llm_chat_usage
-      ADD COLUMN IF NOT EXISTS billing_anchor_at BIGINT
-    ` as Promise<unknown>, 'bootstrap billing_anchor_at');
-    await withTimeout(this.sql`
-      ALTER TABLE llm_chat_usage
-      ADD COLUMN IF NOT EXISTS free_requests_used INTEGER NOT NULL DEFAULT 0
-    ` as Promise<unknown>, 'bootstrap free_requests_used');
-    await withTimeout(this.sql`
-      ALTER TABLE llm_chat_usage
-      ADD COLUMN IF NOT EXISTS free_reset_at BIGINT NOT NULL DEFAULT 0
-    ` as Promise<unknown>, 'bootstrap free_reset_at');
+      DO $$
+      BEGIN
+        CREATE TABLE IF NOT EXISTS llm_chat_usage (
+          user_id TEXT PRIMARY KEY,
+          credits_used DOUBLE PRECISION NOT NULL DEFAULT 0,
+          billing_anchor_at BIGINT NOT NULL DEFAULT 0,
+          reset_at BIGINT NOT NULL DEFAULT 0,
+          free_requests_used INTEGER NOT NULL DEFAULT 0,
+          free_reset_at BIGINT NOT NULL DEFAULT 0,
+          updated_at BIGINT NOT NULL DEFAULT 0
+        );
+        ALTER TABLE llm_chat_usage ADD COLUMN IF NOT EXISTS billing_anchor_at BIGINT;
+        ALTER TABLE llm_chat_usage ADD COLUMN IF NOT EXISTS free_requests_used INTEGER NOT NULL DEFAULT 0;
+        ALTER TABLE llm_chat_usage ADD COLUMN IF NOT EXISTS free_reset_at BIGINT NOT NULL DEFAULT 0;
+      END $$;
+    ` as Promise<unknown>, 'bootstrap schema');
   }
 
   private async ensureReady(): Promise<void> {
@@ -152,7 +148,9 @@ export class SqlChatUsageStore implements ChatUsageStore {
     const initialResetAt = getNextCycleResetFromAnchor(initialAnchorAt, now);
     const initialFreeResetAt = now + DAY_MS;
 
-    await withTimeout(this.sql`
+    // Single round-trip upsert: insert the default row if missing, otherwise
+    // no-op update so RETURNING always yields the current row.
+    const rows = await withTimeout(this.sql`
       INSERT INTO llm_chat_usage (
         user_id,
         credits_used,
@@ -171,15 +169,9 @@ export class SqlChatUsageStore implements ChatUsageStore {
         ${initialFreeResetAt},
         ${now}
       )
-      ON CONFLICT (user_id) DO NOTHING
-    ` as Promise<unknown>, 'loadNormalizedRow insert');
-
-    const rows = await withTimeout(this.sql`
-      SELECT user_id, credits_used, billing_anchor_at, reset_at, free_requests_used, free_reset_at
-      FROM llm_chat_usage
-      WHERE user_id = ${userId}
-      LIMIT 1
-    ` as unknown as Promise<UsageRow[]>, 'loadNormalizedRow select');
+      ON CONFLICT (user_id) DO UPDATE SET user_id = EXCLUDED.user_id
+      RETURNING user_id, credits_used, billing_anchor_at, reset_at, free_requests_used, free_reset_at
+    ` as unknown as Promise<UsageRow[]>, 'loadNormalizedRow upsert');
     const row = rows[0];
     if (!row) {
       throw new Error('Failed to load llm_chat_usage row');

--- a/tests/api/chat.test.ts
+++ b/tests/api/chat.test.ts
@@ -262,6 +262,7 @@ test('chat handler returns a timeout when usage snapshot loading hangs', async (
     fetchImpl: async () => createSseResponse(),
     usageStore: new HangingUsageStore(),
     now: () => Date.now(),
+    usageStoreTimeoutMs: 50,
   });
 
   const response = await handler({
@@ -280,6 +281,7 @@ test('chat handler returns a timeout when the provider never responds', async ()
     fetchImpl: async () => await new Promise<Response>(() => {}),
     usageStore: new MemoryUsageStore(),
     now: () => Date.now(),
+    providerFetchTimeoutMs: 50,
   });
 
   const response = await handler(new Request('https://app.example/api/chat', {


### PR DESCRIPTION
## Summary
This PR optimizes database initialization performance and increases timeout thresholds to accommodate slower database operations, particularly on Neon's serverless platform.

## Key Changes

- **Increased timeout thresholds**: Raised `DB_TIMEOUT_MS` from 8s to 15s in the usage store and `USAGE_STORE_TIMEOUT_MS` from 8s to 15s in the chat handler to provide more headroom for database operations during cold starts
- **Consolidated schema bootstrap**: Refactored `bootstrapSchema()` to combine CREATE TABLE and ALTER TABLE statements into a single PostgreSQL DO block, reducing the number of round-trips from 4 to 1 and keeping cold starts within per-query timeout budgets
- **Optimized row loading**: Changed `loadNormalizedRow()` to use a single UPSERT with RETURNING clause instead of separate INSERT and SELECT queries, reducing database round-trips from 2 to 1
- **Made timeouts configurable**: Added optional `usageStoreTimeoutMs` and `providerFetchTimeoutMs` parameters to `ChatHandlerDeps` to allow tests and deployments to override default timeout values
- **Updated tests**: Modified timeout tests to use the new configurable timeout parameters for more precise testing

## Implementation Details

The schema bootstrap optimization uses PostgreSQL's DO block syntax to execute multiple DDL statements atomically in a single query. This is particularly beneficial for serverless databases like Neon where connection overhead and cold starts can be significant.

The UPSERT optimization uses `ON CONFLICT ... DO UPDATE SET ... RETURNING` to both insert new rows and fetch the current state in a single round-trip, eliminating the need for a follow-up SELECT query.

https://claude.ai/code/session_01UcgepwQvjqjVpUUWw9ymYd