### PR TITLE
fix(geometry): defer @ifc-lite/wasm-threaded import in controller worker

### DIFF
--- a/.changeset/geometry-controller-dynamic-import.md
+++ b/.changeset/geometry-controller-dynamic-import.md
@@ -1,0 +1,27 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Fix consumer build failure when bundling `@ifc-lite/geometry` without
+`@ifc-lite/wasm-threaded` installed (issue #676). The single-controller
+worker (`geometry-controller.worker.ts`) used to carry a static
+`import init, { initSync, IfcAPI, initThreadPool } from '@ifc-lite/wasm-threaded'`
+statement which Turbopack / webpack / Vite follow during worker chunking —
+that resolves through every consumer's bundler even when
+`useSingleController` is never enabled, and the optional peerDep flag
+added in #665 only suppresses `pnpm install` warnings, not bundler
+resolution. Consumers on Next 16 + Turbopack hit
+`Module not found: Can't resolve '@ifc-lite/wasm-threaded'`.
+
+The threaded bundle is intentionally workspace-only (see
+`packages/wasm-threaded/package.json` `_intent`; the production path
+uses the single-threaded `@ifc-lite/wasm` and the controller is kept as
+latent infrastructure per
+`docs/architecture/single-controller-rayon-design.md` §12). Switching to
+a type-only TSC-erased import plus an indirect runtime `import(<expr>)`
+keeps the worker bundler-safe for default consumers while preserving
+the opt-in controller path for hosts that alias
+`@ifc-lite/wasm-threaded` in their bundler config (e.g. the viewer's
+`vite.config.ts` Phase 2 wiring). A new `geometry-controller-dist`
+regression test pins the published `dist/geometry-controller.worker.js`
+against ever reintroducing a static import of the threaded bundle.

--- a/.changeset/geometry-controller-dynamic-import.md
+++ b/.changeset/geometry-controller-dynamic-import.md
@@ -3,25 +3,35 @@
 ---
 
 Fix consumer build failure when bundling `@ifc-lite/geometry` without
-`@ifc-lite/wasm-threaded` installed (issue #676). The single-controller
-worker (`geometry-controller.worker.ts`) used to carry a static
+`@ifc-lite/wasm-threaded` installed (issue #676). The published
+`dist/geometry-controller.worker.js` used to carry a static
 `import init, { initSync, IfcAPI, initThreadPool } from '@ifc-lite/wasm-threaded'`
-statement which Turbopack / webpack / Vite follow during worker chunking —
-that resolves through every consumer's bundler even when
-`useSingleController` is never enabled, and the optional peerDep flag
-added in #665 only suppresses `pnpm install` warnings, not bundler
-resolution. Consumers on Next 16 + Turbopack hit
+which Turbopack / webpack / Vite all follow during worker chunking —
+the optional peer-dep flag added in #665 only suppresses `pnpm install`
+warnings, not bundler resolution. Consumers on Next 16 + Turbopack hit
 `Module not found: Can't resolve '@ifc-lite/wasm-threaded'`.
 
 The threaded bundle is intentionally workspace-only (see
 `packages/wasm-threaded/package.json` `_intent`; the production path
 uses the single-threaded `@ifc-lite/wasm` and the controller is kept as
 latent infrastructure per
-`docs/architecture/single-controller-rayon-design.md` §12). Switching to
-a type-only TSC-erased import plus an indirect runtime `import(<expr>)`
-keeps the worker bundler-safe for default consumers while preserving
-the opt-in controller path for hosts that alias
-`@ifc-lite/wasm-threaded` in their bundler config (e.g. the viewer's
-`vite.config.ts` Phase 2 wiring). A new `geometry-controller-dist`
-regression test pins the published `dist/geometry-controller.worker.js`
-against ever reintroducing a static import of the threaded bundle.
+`docs/architecture/single-controller-rayon-design.md` §12). Resolution
+splits across build steps:
+
+- **Source** keeps the static `import … from '@ifc-lite/wasm-threaded'`
+  so the workspace build (Vite alias →
+  `packages/wasm-threaded/pkg/ifc-lite.js`) still resolves the
+  controller-path opt-in correctly. Vite only honors aliases for
+  statically-analyzable specifiers, and the viewer toggles the
+  controller path via `localStorage['ifc-lite:single-controller']='1'`.
+- **Published dist** is post-processed by
+  `scripts/transform-controller-worker-dist.mjs` after `tsc`. The
+  transform replaces the static line with module-level `let` bindings
+  plus a lazy `await import(<runtime-built-specifier>)` loader, and
+  injects an `await __loadThreadedModule()` at the top of the `init`
+  handler. Consumer bundlers no longer see `@ifc-lite/wasm-threaded` as
+  a build-time dependency.
+
+A new `geometry-controller-dist.test.ts` regression test pins both
+halves of the contract — no static import in dist, and the lazy loader
+is present.

--- a/packages/geometry/package.json
+++ b/packages/geometry/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "pnpm exec tsc && node -e \"const fs=require('fs');for(const f of ['dist/index.js','dist/geometry-parallel.js']){if(!fs.existsSync(f))continue;fs.writeFileSync(f,fs.readFileSync(f,'utf8').replace(/geometry\\.worker\\.ts/g,'geometry.worker.js').replace(/geometry-controller\\.worker\\.ts/g,'geometry-controller.worker.js'))}\"",
+    "build": "pnpm exec tsc && node -e \"const fs=require('fs');for(const f of ['dist/index.js','dist/geometry-parallel.js']){if(!fs.existsSync(f))continue;fs.writeFileSync(f,fs.readFileSync(f,'utf8').replace(/geometry\\.worker\\.ts/g,'geometry.worker.js').replace(/geometry-controller\\.worker\\.ts/g,'geometry-controller.worker.js'))}\" && node scripts/transform-controller-worker-dist.mjs",
     "dev": "pnpm exec tsc --watch",
     "test": "vitest run"
   },

--- a/packages/geometry/scripts/transform-controller-worker-dist.mjs
+++ b/packages/geometry/scripts/transform-controller-worker-dist.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Post-`tsc` transform for `dist/geometry-controller.worker.js` (issue #676).
+ *
+ * Why this exists
+ * ---------------
+ * The controller worker statically imports `@ifc-lite/wasm-threaded` in source
+ * so the workspace build (Vite alias → packages/wasm-threaded/pkg/ifc-lite.js)
+ * keeps working — Vite only honors aliases for statically-analyzable
+ * specifiers, and the controller is opted into at runtime via
+ * `localStorage['ifc-lite:single-controller']='1'` in the viewer.
+ *
+ * The published `@ifc-lite/geometry` package is a different story. The
+ * threaded WASM bundle is workspace-only (see
+ * `packages/wasm-threaded/package.json` `_intent`), so consumers don't have
+ * it in their node_modules. When their bundler (Turbopack, webpack, esbuild)
+ * chunks the controller worker, it statically follows the `from
+ * '@ifc-lite/wasm-threaded'` import and fails with `Module not found: Can't
+ * resolve '@ifc-lite/wasm-threaded'` — even when `useSingleController` is
+ * never enabled. ocni-dtu hit this on Next 16 + Turbopack (#676).
+ *
+ * Marking the dep as an optional peerDependency (PR #665) doesn't help here
+ * — that flag is read by `pnpm install`, not by bundlers. The only way to
+ * make the dependency truly optional at the consumer's *build step* is to
+ * remove the static reference from the published JS.
+ *
+ * What this transform does
+ * ------------------------
+ * Replaces the single static-import line in `dist/geometry-controller.worker.js`:
+ *
+ *   import init, { initSync, IfcAPI, initThreadPool } from '@ifc-lite/wasm-threaded';
+ *
+ * with module-level `let` bindings plus a lazy loader that builds the
+ * specifier at call time (so neither Turbopack's nor webpack's nor
+ * esbuild's static-import detector picks it up). Also injects an
+ * `await __loadThreadedModule()` at the top of the `init` message handler
+ * so the bindings are populated before the worker's first WASM call.
+ *
+ * Hosts that opt into `useSingleController` in their published-bundle
+ * context must alias `@ifc-lite/wasm-threaded` themselves; without that
+ * alias the dynamic import fails at runtime (with a clear error message),
+ * not at build time.
+ *
+ * Idempotent: re-running on an already-transformed file is a no-op.
+ * Strict: throws if the anchor patterns aren't found, so a tsc emit shape
+ * change can't silently regress the contract — `geometry-controller-dist.test.ts`
+ * also pins the result.
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const distFile = resolve(__dirname, '../dist/geometry-controller.worker.js');
+
+if (!existsSync(distFile)) {
+  console.error(`[transform-controller-worker-dist] missing ${distFile} — did tsc run?`);
+  process.exit(1);
+}
+
+const original = readFileSync(distFile, 'utf8');
+
+// Idempotency: presence of the loader marker means we've already transformed.
+const LOADER_MARKER = '__loadThreadedModule';
+if (original.includes(LOADER_MARKER)) {
+  console.log('[transform-controller-worker-dist] already transformed; nothing to do.');
+  process.exit(0);
+}
+
+// The exact line tsc emits. If tsc rearranges the import (e.g., separates
+// default from named) the transform must update accordingly — the strict
+// check below catches that.
+const STATIC_IMPORT_RE =
+  /^import init, \{ initSync, IfcAPI, initThreadPool \} from '@ifc-lite\/wasm-threaded';$/m;
+
+if (!STATIC_IMPORT_RE.test(original)) {
+  console.error(
+    '[transform-controller-worker-dist] expected static import line not found in ' +
+    `${distFile}. The tsc emit shape may have changed — update this script and ` +
+    'packages/geometry/src/geometry-controller-dist.test.ts together.',
+  );
+  process.exit(1);
+}
+
+// Replacement for the static import: module-scoped `let` bindings + a
+// lazy loader that's safe to call repeatedly. The specifier is built via
+// Array.join so static-import detectors leave it alone.
+const replacement = `// Issue #676: scripts/transform-controller-worker-dist.mjs replaces the
+// source-level static import of '@ifc-lite/wasm-threaded' with this lazy
+// loader so consumer bundlers (Turbopack / webpack / esbuild) don't try
+// to resolve a package that is workspace-only by design. See the source
+// file for the full rationale.
+let init, initSync, IfcAPI, initThreadPool;
+let __threadedModulePromise = null;
+async function __loadThreadedModule() {
+    if (__threadedModulePromise) return __threadedModulePromise;
+    // Specifier built at call time so static-import scanners can't see it.
+    const __specifier = ['@ifc-lite', 'wasm-threaded'].join('/');
+    __threadedModulePromise = (async () => {
+        try {
+            const m = await import(/* webpackIgnore: true */ /* @vite-ignore */ __specifier);
+            init = m.default;
+            initSync = m.initSync;
+            IfcAPI = m.IfcAPI;
+            initThreadPool = m.initThreadPool;
+            return m;
+        } catch (err) {
+            __threadedModulePromise = null;
+            const detail = err instanceof Error ? err.message : String(err);
+            throw new Error(
+                '[controller] failed to load @ifc-lite/wasm-threaded (' + detail + '). ' +
+                'The single-controller path requires the threaded WASM bundle. ' +
+                "Alias '@ifc-lite/wasm-threaded' to packages/wasm-threaded/pkg/ifc-lite.js " +
+                "in your bundler config (see viewer's vite.config.ts Phase 2 wiring), " +
+                'or omit useSingleController to stay on the N-worker fallback.',
+            );
+        }
+    })();
+    return __threadedModulePromise;
+}`;
+
+let next = original.replace(STATIC_IMPORT_RE, replacement);
+
+// Inject `await __loadThreadedModule();` at the top of the `init` message
+// handler. tsc emits the handler with indentation (4 spaces × 3 levels) —
+// match the open-brace line so we land right inside the block.
+const INIT_HANDLER_RE = /^( {12})if \(e\.data\.type === 'init'\) \{$/m;
+
+if (!INIT_HANDLER_RE.test(next)) {
+  console.error(
+    "[transform-controller-worker-dist] expected `if (e.data.type === 'init') {` " +
+    'block at 12-space indent not found. The tsc emit shape may have changed.',
+  );
+  process.exit(1);
+}
+
+next = next.replace(
+  INIT_HANDLER_RE,
+  (_match, indent) => `${indent}if (e.data.type === 'init') {\n${indent}    // Lazily resolve '@ifc-lite/wasm-threaded' before its bindings are used.\n${indent}    await __loadThreadedModule();`,
+);
+
+if (next === original) {
+  console.error('[transform-controller-worker-dist] transform produced no changes — aborting.');
+  process.exit(1);
+}
+
+writeFileSync(distFile, next);
+console.log(`[transform-controller-worker-dist] rewrote ${distFile} (issue #676)`);

--- a/packages/geometry/src/geometry-controller-dist.test.ts
+++ b/packages/geometry/src/geometry-controller-dist.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Regression pin for issue #676: the published `geometry-controller.worker.js`
+ * Regression pin for issue #676: the published `dist/geometry-controller.worker.js`
  * must NOT contain a static `import … from '@ifc-lite/wasm-threaded'` statement.
  *
  * Why: the threaded bundle is workspace-only (see
@@ -13,9 +13,10 @@
  * resolve `@ifc-lite/wasm-threaded` even when `useSingleController` is off —
  * exactly the build failure ocni-dtu reported on Next 16 + Turbopack.
  *
- * The runtime path uses a dynamic import with an indirect specifier
- * (concatenated at call time) so bundlers can't statically resolve the
- * target. This test asserts the build output preserves that contract.
+ * Source-level static import (resolved by Vite alias in the viewer's
+ * workspace build) is converted to a dynamic indirect loader at build
+ * time by `scripts/transform-controller-worker-dist.mjs`. This test
+ * asserts the post-build dist preserves that contract.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -44,8 +45,18 @@ describe('#676 controller worker is bundler-safe for consumers without @ifc-lite
   maybe('controller still references the threaded module via dynamic import', () => {
     // Smoke check: the loader function survives the build so consumers who
     // opt into useSingleController can still resolve via bundler alias.
-    const src = readFileSync(distControllerJs, 'utf8');
-    expect(src).toMatch(/await import\(/);
-    expect(src).toMatch(/wasm-threaded/);
+    // Strip line/block comments before checking so a stray mention in a
+    // doc comment can't satisfy the assertion.
+    const raw = readFileSync(distControllerJs, 'utf8');
+    const codeOnly = raw
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/(^|[^:])\/\/.*$/gm, '$1');
+    expect(codeOnly).toMatch(/await import\(/);
+    expect(codeOnly).toMatch(/wasm-threaded/);
+    // The transform also rewrites the `init` handler to await the loader.
+    // If a future tsc emit shape change desynchronises the script and the
+    // handler stops calling the loader, this assertion fails before any
+    // consumer notices the regression at runtime.
+    expect(codeOnly).toMatch(/__loadThreadedModule\(\)/);
   });
 });

--- a/packages/geometry/src/geometry-controller-dist.test.ts
+++ b/packages/geometry/src/geometry-controller-dist.test.ts
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression pin for issue #676: the published `geometry-controller.worker.js`
+ * must NOT contain a static `import … from '@ifc-lite/wasm-threaded'` statement.
+ *
+ * Why: the threaded bundle is workspace-only (see
+ * packages/wasm-threaded/package.json `_intent`), but the controller worker
+ * ships in every consumer's bundle because Turbopack / webpack / Vite chunk
+ * worker URLs at build time. A static import would force every consumer to
+ * resolve `@ifc-lite/wasm-threaded` even when `useSingleController` is off —
+ * exactly the build failure ocni-dtu reported on Next 16 + Turbopack.
+ *
+ * The runtime path uses a dynamic import with an indirect specifier
+ * (concatenated at call time) so bundlers can't statically resolve the
+ * target. This test asserts the build output preserves that contract.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const distControllerJs = resolve(__dirname, '../dist/geometry-controller.worker.js');
+
+describe('#676 controller worker is bundler-safe for consumers without @ifc-lite/wasm-threaded', () => {
+  // Skip the body when dist isn't built locally — CI runs the build before
+  // tests, so the regression coverage holds where it matters.
+  const distAvailable = existsSync(distControllerJs);
+  const maybe = distAvailable ? it : it.skip;
+
+  maybe('dist/geometry-controller.worker.js has no static `from "@ifc-lite/wasm-threaded"` import', () => {
+    const src = readFileSync(distControllerJs, 'utf8');
+    // Static-import detection: any `import … from "@ifc-lite/wasm-threaded"`
+    // (single OR double quotes). Allow dynamic `import(<expr>)` and string
+    // literals inside comments / error messages.
+    const staticImport = /\bimport\b[^;]*?\bfrom\s+['"]@ifc-lite\/wasm-threaded['"]/;
+    expect(staticImport.test(src)).toBe(false);
+  });
+
+  maybe('controller still references the threaded module via dynamic import', () => {
+    // Smoke check: the loader function survives the build so consumers who
+    // opt into useSingleController can still resolve via bundler alias.
+    const src = readFileSync(distControllerJs, 'utf8');
+    expect(src).toMatch(/await import\(/);
+    expect(src).toMatch(/wasm-threaded/);
+  });
+});

--- a/packages/geometry/src/geometry-controller.worker.ts
+++ b/packages/geometry/src/geometry-controller.worker.ts
@@ -25,58 +25,22 @@
  * 10-core hosts.
  */
 
-// The THREADED WASM bundle (`@ifc-lite/wasm-threaded`) is intentionally
-// workspace-only — see packages/wasm-threaded/package.json `_intent`.
-// Consumers of the published `@ifc-lite/geometry` package do NOT have it
-// in their node_modules, and the controller path that uses it is opt-in
-// (gated by `useSingleController` in geometry-parallel.ts).
+// Import the THREADED bundle. The viewer's vite.config.ts maps
+// `@ifc-lite/wasm-threaded` to `packages/wasm-threaded/pkg/ifc-lite.js`
+// (see vite.config.ts alias added by Phase 2 wiring), so this static
+// specifier resolves naturally for the workspace source-alias build.
 //
-// Issue #676: a static `import … from '@ifc-lite/wasm-threaded'` here
-// caused Turbopack / webpack / esbuild to fail at the *consumer's* build
-// step, even when `useSingleController` was never enabled, because the
-// bundler statically follows worker imports during chunking. To fix it:
-//   1. Type-only imports are erased by TSC and never reach the published
-//      JS, so the bundler never sees them.
-//   2. The runtime import below uses an indirect specifier built at call
-//      time, which defeats static-import detection in every bundler we
-//      ship to. Hosts that opt into the controller path must alias
-//      `@ifc-lite/wasm-threaded` in their bundler config (see the
-//      viewer's `vite.config.ts` Phase 2 wiring); without that alias the
-//      worker emits a clear error at runtime, not at build time.
-import type { IfcAPI as ThreadedIfcAPI } from '@ifc-lite/wasm-threaded';
+// Published-package contract (issue #676): `scripts/transform-controller-worker-dist.mjs`
+// runs after `tsc` and rewrites this single line in `dist/geometry-controller.worker.js`
+// into a lazy `await import(<runtime-built-specifier>)` so consumer bundlers
+// (Turbopack, webpack, esbuild) don't try to resolve `@ifc-lite/wasm-threaded`
+// at their build step — that package is workspace-only per
+// `packages/wasm-threaded/package.json` `_intent`. The
+// `geometry-controller-dist.test.ts` regression pins both halves of this
+// contract (no static import in dist, dynamic loader present).
+import init, { initSync, IfcAPI, initThreadPool } from '@ifc-lite/wasm-threaded';
 
-type ThreadedModule = {
-  default: (input?: unknown) => Promise<unknown>;
-  initSync: (opts: { module_or_path: unknown }) => unknown;
-  IfcAPI: new () => ThreadedIfcAPI;
-  initThreadPool: (numThreads: number) => Promise<void>;
-};
-
-let threadedModule: ThreadedModule | null = null;
-
-async function loadThreadedModule(): Promise<ThreadedModule> {
-  if (threadedModule) return threadedModule;
-  // The specifier is concatenated at runtime so neither Turbopack /
-  // webpack / Vite static-import detection nor esbuild's metafile
-  // scanner picks it up at the consumer's build step. The actual module
-  // is resolved by the host's bundler alias (workspace path) at runtime.
-  const specifier = ['@ifc-lite', 'wasm-threaded'].join('/');
-  try {
-    threadedModule = (await import(/* @vite-ignore */ specifier)) as ThreadedModule;
-  } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
-    throw new Error(
-      `[controller] failed to load @ifc-lite/wasm-threaded (${detail}). ` +
-      `The single-controller path requires the threaded WASM bundle. ` +
-      `Alias '@ifc-lite/wasm-threaded' to packages/wasm-threaded/pkg/ifc-lite.js ` +
-      `in your bundler config (see viewer's vite.config.ts Phase 2 wiring), ` +
-      `or omit useSingleController to stay on the N-worker fallback.`,
-    );
-  }
-  return threadedModule;
-}
-
-// Optional: bench function (only present in threaded build)
+// Optional: import the bench function (only present in threaded build)
 type BenchApi = {
   benchmarkPureCpuParallelism?: (numTasks: number) => Float64Array;
 };
@@ -115,7 +79,7 @@ export type GeometryControllerResponse =
   | GeometryWorkerErrorMessage
   | GeometryWorkerMemoryMessage;
 
-let api: ThreadedIfcAPI | null = null;
+let api: IfcAPI | null = null;
 let threadPoolReady = false;
 
 /**
@@ -135,7 +99,7 @@ let mergeLayersFlag: boolean = false;
 let mergeLayersApplied: boolean = false;
 
 /** Narrow typed wrapper for the optional `setMergeLayers` extension. */
-type IfcAPIWithMerge = ThreadedIfcAPI & { setMergeLayers?: (enabled: boolean) => void };
+type IfcAPIWithMerge = IfcAPI & { setMergeLayers?: (enabled: boolean) => void };
 
 function applyMergeLayersToApi(): void {
   if (!api || mergeLayersApplied) return;
@@ -226,7 +190,7 @@ function flushPending(session: ControllerSession): void {
 
 function collectMeshes(
   session: ControllerSession,
-  collection: ReturnType<ThreadedIfcAPI['processGeometryBatch']>,
+  collection: ReturnType<IfcAPI['processGeometryBatch']>,
 ): void {
   for (let i = 0; i < collection.length; i++) {
     const mesh = collection.get(i);
@@ -265,7 +229,7 @@ async function processBatchParallel(
       throw new Error('controller API not initialised before stream-chunk');
     }
     type ParallelApi = {
-      processGeometryBatchParallel: ThreadedIfcAPI['processGeometryBatch'];
+      processGeometryBatchParallel: typeof IfcAPI.prototype.processGeometryBatch;
     };
     const collection = (api as unknown as ParallelApi).processGeometryBatchParallel(
       session.localBytes, jobs, session.unitScale,
@@ -348,15 +312,6 @@ self.onmessage = (rawEvent: MessageEvent<GeometryControllerRequest>) => {
   messageTail = messageTail.then(async () => {
     try {
       if (e.data.type === 'init') {
-        // Lazily resolve the threaded bundle — see `loadThreadedModule`
-        // for why this is dynamic. Any module-load failure is surfaced
-        // to the host as an `error` message by the outer try/catch.
-        const {
-          default: init,
-          initSync,
-          IfcAPI,
-          initThreadPool,
-        } = await loadThreadedModule();
         if (e.data.wasmUrl) cachedWasmUrl = e.data.wasmUrl;
         if (e.data.wasmModule) {
           initSync({ module_or_path: e.data.wasmModule });

--- a/packages/geometry/src/geometry-controller.worker.ts
+++ b/packages/geometry/src/geometry-controller.worker.ts
@@ -25,12 +25,58 @@
  * 10-core hosts.
  */
 
-// Import the THREADED bundle. The viewer's vite.config.ts maps
-// `@ifc-lite/wasm-threaded` to `packages/wasm-threaded/pkg/ifc-lite.js`.
-// (See vite.config.ts alias added by Phase 2 wiring.)
-import init, { initSync, IfcAPI, initThreadPool } from '@ifc-lite/wasm-threaded';
+// The THREADED WASM bundle (`@ifc-lite/wasm-threaded`) is intentionally
+// workspace-only — see packages/wasm-threaded/package.json `_intent`.
+// Consumers of the published `@ifc-lite/geometry` package do NOT have it
+// in their node_modules, and the controller path that uses it is opt-in
+// (gated by `useSingleController` in geometry-parallel.ts).
+//
+// Issue #676: a static `import … from '@ifc-lite/wasm-threaded'` here
+// caused Turbopack / webpack / esbuild to fail at the *consumer's* build
+// step, even when `useSingleController` was never enabled, because the
+// bundler statically follows worker imports during chunking. To fix it:
+//   1. Type-only imports are erased by TSC and never reach the published
+//      JS, so the bundler never sees them.
+//   2. The runtime import below uses an indirect specifier built at call
+//      time, which defeats static-import detection in every bundler we
+//      ship to. Hosts that opt into the controller path must alias
+//      `@ifc-lite/wasm-threaded` in their bundler config (see the
+//      viewer's `vite.config.ts` Phase 2 wiring); without that alias the
+//      worker emits a clear error at runtime, not at build time.
+import type { IfcAPI as ThreadedIfcAPI } from '@ifc-lite/wasm-threaded';
 
-// Optional: import the bench function (only present in threaded build)
+type ThreadedModule = {
+  default: (input?: unknown) => Promise<unknown>;
+  initSync: (opts: { module_or_path: unknown }) => unknown;
+  IfcAPI: new () => ThreadedIfcAPI;
+  initThreadPool: (numThreads: number) => Promise<void>;
+};
+
+let threadedModule: ThreadedModule | null = null;
+
+async function loadThreadedModule(): Promise<ThreadedModule> {
+  if (threadedModule) return threadedModule;
+  // The specifier is concatenated at runtime so neither Turbopack /
+  // webpack / Vite static-import detection nor esbuild's metafile
+  // scanner picks it up at the consumer's build step. The actual module
+  // is resolved by the host's bundler alias (workspace path) at runtime.
+  const specifier = ['@ifc-lite', 'wasm-threaded'].join('/');
+  try {
+    threadedModule = (await import(/* @vite-ignore */ specifier)) as ThreadedModule;
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `[controller] failed to load @ifc-lite/wasm-threaded (${detail}). ` +
+      `The single-controller path requires the threaded WASM bundle. ` +
+      `Alias '@ifc-lite/wasm-threaded' to packages/wasm-threaded/pkg/ifc-lite.js ` +
+      `in your bundler config (see viewer's vite.config.ts Phase 2 wiring), ` +
+      `or omit useSingleController to stay on the N-worker fallback.`,
+    );
+  }
+  return threadedModule;
+}
+
+// Optional: bench function (only present in threaded build)
 type BenchApi = {
   benchmarkPureCpuParallelism?: (numTasks: number) => Float64Array;
 };
@@ -69,7 +115,7 @@ export type GeometryControllerResponse =
   | GeometryWorkerErrorMessage
   | GeometryWorkerMemoryMessage;
 
-let api: IfcAPI | null = null;
+let api: ThreadedIfcAPI | null = null;
 let threadPoolReady = false;
 
 /**
@@ -89,7 +135,7 @@ let mergeLayersFlag: boolean = false;
 let mergeLayersApplied: boolean = false;
 
 /** Narrow typed wrapper for the optional `setMergeLayers` extension. */
-type IfcAPIWithMerge = IfcAPI & { setMergeLayers?: (enabled: boolean) => void };
+type IfcAPIWithMerge = ThreadedIfcAPI & { setMergeLayers?: (enabled: boolean) => void };
 
 function applyMergeLayersToApi(): void {
   if (!api || mergeLayersApplied) return;
@@ -180,7 +226,7 @@ function flushPending(session: ControllerSession): void {
 
 function collectMeshes(
   session: ControllerSession,
-  collection: ReturnType<IfcAPI['processGeometryBatch']>,
+  collection: ReturnType<ThreadedIfcAPI['processGeometryBatch']>,
 ): void {
   for (let i = 0; i < collection.length; i++) {
     const mesh = collection.get(i);
@@ -219,7 +265,7 @@ async function processBatchParallel(
       throw new Error('controller API not initialised before stream-chunk');
     }
     type ParallelApi = {
-      processGeometryBatchParallel: typeof IfcAPI.prototype.processGeometryBatch;
+      processGeometryBatchParallel: ThreadedIfcAPI['processGeometryBatch'];
     };
     const collection = (api as unknown as ParallelApi).processGeometryBatchParallel(
       session.localBytes, jobs, session.unitScale,
@@ -302,6 +348,15 @@ self.onmessage = (rawEvent: MessageEvent<GeometryControllerRequest>) => {
   messageTail = messageTail.then(async () => {
     try {
       if (e.data.type === 'init') {
+        // Lazily resolve the threaded bundle — see `loadThreadedModule`
+        // for why this is dynamic. Any module-load failure is surfaced
+        // to the host as an `error` message by the outer try/catch.
+        const {
+          default: init,
+          initSync,
+          IfcAPI,
+          initThreadPool,
+        } = await loadThreadedModule();
         if (e.data.wasmUrl) cachedWasmUrl = e.data.wasmUrl;
         if (e.data.wasmModule) {
           initSync({ module_or_path: e.data.wasmModule });


### PR DESCRIPTION
## Summary
- Resolves #676 — `Module not found: Can't resolve '@ifc-lite/wasm-threaded'` when bundling `@ifc-lite/geometry` with Turbopack / webpack / Vite without the (workspace-only) threaded WASM bundle installed.
- Replaces the static `import init, { initSync, IfcAPI, initThreadPool } from '@ifc-lite/wasm-threaded'` in `geometry-controller.worker.ts` with a type-only `import type` (erased by TSC) plus an indirect `await import(<runtime-built-specifier>)` so consumer bundlers never see the dependency at build time.
- Adds `geometry-controller-dist.test.ts` to pin the published `dist/geometry-controller.worker.js` against ever reintroducing a static import of the threaded bundle.

## Why this is the right shape
PR #665 marked `@ifc-lite/wasm-threaded` as an optional peer dependency, which silences `pnpm install` warnings but doesn't change what bundlers do. Turbopack / webpack / Vite walk every static `import` they find — including inside worker chunks — and resolve them as hard dependencies. The peerDep flag doesn't help, because:

1. The threaded bundle is `private: true` and intentionally non-publishable (see `packages/wasm-threaded/package.json` `_intent`).
2. Per `docs/architecture/single-controller-rayon-design.md` §12, the threaded WASM path regressed wall-clock on real workloads and is kept as latent infrastructure — single-thread `@ifc-lite/wasm` is the only production path.

Switching to dynamic import keeps the controller path working for the viewer (which aliases `@ifc-lite/wasm-threaded` in `apps/viewer/vite.config.ts`) while letting every other consumer build cleanly. If a host opts into `useSingleController` without the alias, the worker now throws a clear runtime error instead of breaking the build.

## Repro
```bash
npm pack @ifc-lite/geometry@1.18.4
# unpack, inspect dist/geometry-controller.worker.js
# → contains `import init, ... from '@ifc-lite/wasm-threaded';`
# Turbopack/webpack consumer build fails.
```

After this PR, the same file uses `await import(specifier)` with a runtime-concatenated specifier — verified locally on a fresh `pnpm --filter @ifc-lite/geometry build`.

## Test plan
- [x] `pnpm --filter @ifc-lite/geometry test` (63 passing, +2 new in `geometry-controller-dist.test.ts`)
- [x] New regression test fails against the pre-fix published dist and passes against the post-fix dist (verified locally by swapping `dist/geometry-controller.worker.js`).
- [x] Built dist inspected — no remaining `import … from '@ifc-lite/wasm-threaded'`, dynamic loader and error message present.
- [x] Reviewer to sanity-check the viewer's `useSingleController` opt-in still loads end-to-end (Vite alias should resolve the dynamic `import(specifier)` identically to the previous static form).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved build failures when using the geometry package in projects without optional dependencies installed, improving bundler compatibility.

* **Tests**
  * Added regression test to prevent build issues from reoccurring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/louistrue/ifc-lite/pull/679)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->