### PR TITLE
feat(viewer/chat): in-browser WebLLM provider (no API key needed)

### DIFF
--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
+    "@mlc-ai/web-llm": "^0.2.83",
     "react-markdown": "^9.0.1",
     "remark-gfm": "^4.0.0",
     "three": "^0.183.1",

--- a/apps/viewer/src/components/viewer/ChatPanel.tsx
+++ b/apps/viewer/src/components/viewer/ChatPanel.tsx
@@ -36,8 +36,10 @@ import { useViewerStore } from '@/store';
 import { buildErrorFeedbackContent } from '@/store/slices/chatSlice';
 import { ChatMessageComponent } from './chat/ChatMessage';
 import { ModelSelector } from './chat/ModelSelector';
+import { ModelDownloadCard } from './chat/ModelDownloadCard';
 import { fetchUsageSnapshot, streamChat, type StreamMessage, type TextContentPart, type ImageContentPart, type UsageInfo } from '@/lib/llm/stream-client';
 import { streamAnthropicChat, streamOpenAiChat } from '@/lib/llm/stream-direct';
+import { streamWebLLMChat, WebLLMConsentRequiredError } from '@/lib/llm/stream-webllm';
 import { buildStreamMessagesForModel, filterAttachmentsForModel } from '@/lib/llm/message-capabilities';
 import { buildSystemPrompt } from '@/lib/llm/system-prompt';
 import { getModelContext, parseCSV } from '@/lib/llm/context-builder';
@@ -806,7 +808,11 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
         }
     };
     const handleError = (err: Error) => {
-        setChatError(err.message);
+        if (err instanceof WebLLMConsentRequiredError) {
+          setChatError('Click "Download" above to fetch the local model before sending.');
+        } else {
+          setChatError(err.message);
+        }
         setChatAbortController(null);
         commitAssistantTurn();
     };
@@ -827,6 +833,17 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
       });
     } else if (route.kind === 'openai') {
       await streamOpenAiChat(route.apiKey, {
+        model: activeModel,
+        messages: streamMessages,
+        system: systemPrompt,
+        signal: abortController.signal,
+        onChunk: handleChunk,
+        onComplete: handleComplete,
+        onFinishReason: handleFinishReason,
+        onError: handleError,
+      });
+    } else if (route.kind === 'webllm') {
+      await streamWebLLMChat({
         model: activeModel,
         messages: streamMessages,
         system: systemPrompt,
@@ -1260,6 +1277,9 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
       {needsByokKey && canUseAiAssistant && (
         <InlineKeyPrompt provider={needsAnthropicKey ? 'anthropic' : 'openai'} />
       )}
+
+      {/* Local-model download / consent card — shown when user picks a WebLLM model */}
+      {canUseAiAssistant && <ModelDownloadCard modelId={activeModel} />}
 
       {/* Clear confirmation */}
       {showClearConfirm && (

--- a/apps/viewer/src/components/viewer/SettingsPage.tsx
+++ b/apps/viewer/src/components/viewer/SettingsPage.tsx
@@ -10,6 +10,7 @@ import {
   ChevronUp,
   Clock3,
   Cloud,
+  Cpu,
   CreditCard,
   ExternalLink,
   Eye,
@@ -51,6 +52,9 @@ import {
   subscribeApiKeys,
   type ApiKeyConfig,
 } from '@/services/api-keys';
+import { LOCAL_WEBLLM_MODELS, getLocalModelMeta } from '@/lib/llm/models';
+import { detectWebLLMSupport, type WebLLMCapability } from '@/lib/llm/webgpu-capability';
+import { hasWebLLMConsent } from '@/lib/llm/webllm-consent';
 
 export function SettingsPage() {
   const desktopEntitlement = useViewerStore((s) => s.desktopEntitlement);
@@ -98,7 +102,10 @@ export function SettingsPage() {
         </div>
 
         <div className="space-y-6">
-          {/* API Keys Section */}
+          {/* Local model (WebLLM) — primary, no setup */}
+          <LocalModelSection />
+
+          {/* API Keys Section — advanced, collapsed by default */}
           <ApiKeysSection apiKeys={apiKeys} />
 
           <section className="rounded-lg border bg-card p-6 shadow-sm">
@@ -331,6 +338,81 @@ function ApiKeyInput({
   );
 }
 
+function LocalModelSection() {
+  const [support, setSupport] = useState<WebLLMCapability | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    detectWebLLMSupport().then((cap) => { if (!cancelled) setSupport(cap); });
+    return () => { cancelled = true; };
+  }, []);
+
+  return (
+    <section className="rounded-lg border bg-card p-6 shadow-sm">
+      <div className="mb-5 flex items-center gap-3">
+        <Cpu className="h-5 w-5" />
+        <div>
+          <h1 className="text-2xl font-semibold">Local Model</h1>
+          <p className="text-sm text-muted-foreground">
+            Run a coding model entirely in your browser via WebGPU — free, private, offline-capable.
+            No API key required, no data leaves your device.
+          </p>
+        </div>
+      </div>
+
+      {support === null && (
+        <p className="text-sm text-muted-foreground">Checking WebGPU support…</p>
+      )}
+
+      {support?.supported === false && (
+        <div className="rounded-md border border-dashed p-4 text-xs space-y-2">
+          <p className="font-medium text-foreground">Not available in this browser.</p>
+          <p className="text-muted-foreground">
+            {support.reason === 'no-webgpu' && 'WebGPU is required. Try Chrome, Edge, or Safari 18+.'}
+            {support.reason === 'no-adapter' && 'No WebGPU adapter — your GPU driver may not be supported.'}
+            {support.reason === 'not-cross-origin-isolated' && 'Your hosting environment is missing cross-origin isolation headers. The main viewer at ifc-lite.com is fine; this only affects custom embeds.'}
+          </p>
+          <p className="text-muted-foreground">
+            Use a BYOK API key below, or our hosted free tier in the chat panel.
+          </p>
+        </div>
+      )}
+
+      {support?.supported && (
+        <div className="space-y-3">
+          {LOCAL_WEBLLM_MODELS.map((m) => {
+            const meta = getLocalModelMeta(m.id);
+            return (
+              <div key={m.id} className="rounded-md border p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="font-medium">{m.name}</div>
+                    <p className="mt-0.5 text-xs text-muted-foreground">{m.notes}</p>
+                  </div>
+                  {meta && (
+                    <Badge variant="outline" className="text-[10px] shrink-0">
+                      {meta.approxSizeMB >= 1000 ? `${(meta.approxSizeMB / 1000).toFixed(1)} GB` : `${meta.approxSizeMB} MB`}
+                    </Badge>
+                  )}
+                </div>
+                {meta && (
+                  <p className="mt-2 text-[11px] text-muted-foreground">
+                    {meta.blurb} · {meta.vramRequirementGB} GB VRAM recommended ·
+                    {hasWebLLMConsent(m.id) ? ' downloaded' : ' not yet downloaded'}
+                  </p>
+                )}
+              </div>
+            );
+          })}
+          <div className="rounded-md border border-dashed p-3 text-[11px] text-muted-foreground">
+            Pick a local model in the chat panel&apos;s model selector to download it on first use.
+            Models are cached in your browser&apos;s storage and reused across sessions.
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
 function ApiKeysSection({ apiKeys }: { apiKeys: ApiKeyConfig }) {
   const [anthropicKey, setAnthropicKey] = useState(apiKeys.anthropicKey);
   const [openaiKey, setOpenaiKey] = useState(apiKeys.openaiKey);
@@ -365,10 +447,13 @@ function ApiKeysSection({ apiKeys }: { apiKeys: ApiKeyConfig }) {
       <div className="mb-5 flex items-center gap-3">
         <Key className="h-5 w-5" />
         <div>
-          <h1 className="text-2xl font-semibold">API Keys</h1>
+          <h1 className="text-2xl font-semibold">
+            Advanced: API Keys <span className="text-sm font-normal text-muted-foreground">(optional)</span>
+          </h1>
           <p className="text-sm text-muted-foreground">
-            Bring your own Anthropic or OpenAI API key to unlock additional models.
-            You can configure one or both providers independently.
+            Bring your own Anthropic or OpenAI API key for frontier-model access.
+            Most users won&apos;t need this — the local model above and the hosted free tier
+            cover the common cases. Keys are stored only in this browser.
           </p>
         </div>
       </div>

--- a/apps/viewer/src/components/viewer/chat/ModelDownloadCard.tsx
+++ b/apps/viewer/src/components/viewer/chat/ModelDownloadCard.tsx
@@ -1,0 +1,145 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Inline progress card shown in the chat panel while a local (WebLLM) model
+ * is downloading on first use. Subscribes to {@link onWebLLMProgress} and
+ * unmounts itself once the active model id matches the engine's loaded id.
+ *
+ * The actual download is kicked off by {@link streamWebLLMChat} on the first
+ * send; this card just renders the side-effect.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Cpu, Loader2, Download } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
+import {
+  ensureWebLLMEngine,
+  getActiveWebLLMModelId,
+  onWebLLMProgress,
+  type WebLLMProgress,
+} from '@/lib/llm/webllm-engine';
+import { getLocalModelMeta, getModelById } from '@/lib/llm/models';
+import {
+  grantWebLLMConsent,
+  hasWebLLMConsent,
+  subscribeWebLLMConsent,
+} from '@/lib/llm/webllm-consent';
+
+interface Props {
+  /** The model the user has selected. Card hides if this isn't a local model. */
+  modelId: string;
+}
+
+function formatSize(approxMB: number): string {
+  return approxMB >= 1000 ? `${(approxMB / 1000).toFixed(1)} GB` : `${approxMB} MB`;
+}
+
+export function ModelDownloadCard({ modelId }: Props) {
+  const model = getModelById(modelId);
+  const meta = getLocalModelMeta(modelId);
+  const [progress, setProgress] = useState<WebLLMProgress | null>(null);
+  const [loaded, setLoaded] = useState<boolean>(getActiveWebLLMModelId() === modelId);
+  const [consented, setConsented] = useState<boolean>(() => hasWebLLMConsent(modelId));
+  const [starting, setStarting] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoaded(getActiveWebLLMModelId() === modelId);
+    setProgress(null);
+    setConsented(hasWebLLMConsent(modelId));
+    setErrorMsg(null);
+    const offProgress = onWebLLMProgress((event) => {
+      if (event.modelId !== modelId) return;
+      setProgress(event);
+      if ((event.progress ?? 0) >= 1) setLoaded(true);
+    });
+    const offConsent = subscribeWebLLMConsent(() => {
+      setConsented(hasWebLLMConsent(modelId));
+    });
+    return () => { offProgress(); offConsent(); };
+  }, [modelId]);
+
+  const startDownload = useCallback(async () => {
+    if (starting) return;
+    setStarting(true);
+    setErrorMsg(null);
+    grantWebLLMConsent(modelId);
+    try {
+      await ensureWebLLMEngine(modelId);
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : String(err));
+    } finally {
+      setStarting(false);
+    }
+  }, [modelId, starting]);
+
+  if (!model || model.source !== 'webllm') return null;
+
+  const downloading = progress != null && (progress.progress ?? 0) < 1;
+  const finished = loaded || (progress?.progress ?? 0) >= 1;
+
+  if (finished && consented && !errorMsg) return null;
+
+  const sizeLabel = meta ? formatSize(meta.approxSizeMB) : null;
+  const pct = Math.round((progress?.progress ?? 0) * 100);
+
+  // ── Consent state: user picked a local model but hasn't agreed to the download yet
+  if (!consented && !downloading) {
+    return (
+      <div className="mx-2 my-1 rounded-md border border-emerald-500/30 bg-emerald-500/5 px-3 py-2 text-xs">
+        <div className="flex items-start gap-2">
+          <Cpu className="h-3.5 w-3.5 mt-0.5 text-emerald-500 shrink-0" />
+          <div className="min-w-0 flex-1">
+            <div className="font-medium">{model.name}</div>
+            {meta && (
+              <p className="mt-0.5 text-[11px] text-muted-foreground leading-snug">
+                Download <strong>{sizeLabel}</strong> once. Then runs entirely in your browser —
+                free, private, works offline. Your IFC data never leaves your device.
+              </p>
+            )}
+            <div className="mt-2 flex items-center gap-2">
+              <Button size="sm" className="h-6 text-[11px]" onClick={startDownload} disabled={starting}>
+                <Download className="h-3 w-3 mr-1" />
+                Download {sizeLabel}
+              </Button>
+              {meta && (
+                <span className="text-[10px] text-muted-foreground">
+                  Cached for next time · {meta.vramRequirementGB} GB VRAM
+                </span>
+              )}
+            </div>
+            {errorMsg && (
+              <p className="mt-1.5 text-[11px] text-destructive">{errorMsg}</p>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Downloading or loading-into-memory
+  return (
+    <div className="mx-2 my-1 rounded-md border border-emerald-500/30 bg-emerald-500/5 px-3 py-2 text-xs">
+      <div className="flex items-center gap-2">
+        {!finished ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin text-emerald-500" />
+        ) : (
+          <Cpu className="h-3.5 w-3.5 text-emerald-500" />
+        )}
+        <span className="font-medium">{model.name}</span>
+        {sizeLabel && <span className="text-muted-foreground">· {sizeLabel}</span>}
+        {progress?.progress != null && (
+          <span className="ml-auto font-mono text-muted-foreground">{pct}%</span>
+        )}
+      </div>
+      <Progress value={pct} className="mt-1.5 h-1" />
+      <p className="mt-1.5 text-[11px] text-muted-foreground">
+        {progress?.text ?? 'Preparing model — runs entirely in your browser, no data leaves your device.'}
+      </p>
+      {errorMsg && <p className="mt-1.5 text-[11px] text-destructive">{errorMsg}</p>}
+    </div>
+  );
+}

--- a/apps/viewer/src/components/viewer/chat/ModelSelector.tsx
+++ b/apps/viewer/src/components/viewer/chat/ModelSelector.tsx
@@ -11,7 +11,7 @@
  */
 
 import { useCallback, useEffect, useState } from 'react';
-import { Check, Key } from 'lucide-react';
+import { Check, Cpu, Key } from 'lucide-react';
 import {
   Select,
   SelectContent,
@@ -20,9 +20,16 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { useViewerStore } from '@/store';
-import { FREE_MODELS, getModelById, getByokModelsForSource } from '@/lib/llm/models';
+import {
+  FREE_MODELS,
+  getModelById,
+  getByokModelsForSource,
+  getLocalModelMeta,
+  LOCAL_WEBLLM_MODELS,
+} from '@/lib/llm/models';
 import type { LLMModel } from '@/lib/llm/types';
 import { hasAnthropicKey, hasOpenaiKey, subscribeApiKeys } from '@/services/api-keys';
+import { detectWebLLMSupport, type WebLLMCapability } from '@/lib/llm/webgpu-capability';
 
 function formatContextWindow(tokens: number): string {
   if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(0)}M`;
@@ -41,6 +48,7 @@ export function ModelSelector() {
 
   const [hasAnthropic, setHasAnthropic] = useState(hasAnthropicKey);
   const [hasOpenai, setHasOpenai] = useState(hasOpenaiKey);
+  const [webLLMSupport, setWebLLMSupport] = useState<WebLLMCapability | null>(null);
 
   useEffect(() => {
     const refresh = () => {
@@ -48,6 +56,12 @@ export function ModelSelector() {
       setHasOpenai(hasOpenaiKey());
     };
     return subscribeApiKeys(refresh);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    detectWebLLMSupport().then((cap) => { if (!cancelled) setWebLLMSupport(cap); });
+    return () => { cancelled = true; };
   }, []);
 
   const handleChange = useCallback((value: string) => {
@@ -107,6 +121,34 @@ export function ModelSelector() {
                 </span>
               </SelectItem>
             ))}
+          </>
+        )}
+
+        {/* Local (WebLLM) — only shown when WebGPU + COI available */}
+        {webLLMSupport?.supported && LOCAL_WEBLLM_MODELS.length > 0 && (
+          <>
+            <div className="px-2 py-1 mt-1 text-[10px] font-semibold text-muted-foreground uppercase tracking-wider flex items-center gap-1">
+              Local (browser, free)
+              <Cpu className="h-2.5 w-2.5 text-emerald-500" />
+            </div>
+            {LOCAL_WEBLLM_MODELS.map((m) => {
+              const meta = getLocalModelMeta(m.id);
+              return (
+                <SelectItem key={m.id} value={m.id} className="text-xs">
+                  <span className="flex items-center gap-1.5">
+                    <span>{m.name}</span>
+                    <span className="text-muted-foreground text-[10px]">{m.provider}</span>
+                    {meta && (
+                      <span className="text-muted-foreground/50 text-[10px]">
+                        {meta.approxSizeMB >= 1000
+                          ? `${(meta.approxSizeMB / 1000).toFixed(1)} GB`
+                          : `${meta.approxSizeMB} MB`}
+                      </span>
+                    )}
+                  </span>
+                </SelectItem>
+              );
+            })}
           </>
         )}
 

--- a/apps/viewer/src/lib/llm/byok-guard.ts
+++ b/apps/viewer/src/lib/llm/byok-guard.ts
@@ -19,6 +19,7 @@ export type StreamRoute =
   | { kind: 'proxy'; model: string }
   | { kind: 'anthropic'; model: string; apiKey: string }
   | { kind: 'openai'; model: string; apiKey: string }
+  | { kind: 'webllm'; model: string }
   | { kind: 'missing-key'; provider: 'anthropic' | 'openai' };
 
 export function resolveStreamRoute(modelId: string, keys: ApiKeyConfig): StreamRoute {
@@ -34,6 +35,9 @@ export function resolveStreamRoute(modelId: string, keys: ApiKeyConfig): StreamR
     const apiKey = keys.openaiKey.trim();
     if (!apiKey) return { kind: 'missing-key', provider: 'openai' };
     return { kind: 'openai', model: modelId, apiKey };
+  }
+  if (source === 'webllm') {
+    return { kind: 'webllm', model: modelId };
   }
   return { kind: 'proxy', model: modelId };
 }

--- a/apps/viewer/src/lib/llm/models.ts
+++ b/apps/viewer/src/lib/llm/models.ts
@@ -212,7 +212,72 @@ const OPENAI_BYOK_MODELS: LLMModel[] = [
 ];
 
 export const BYOK_MODELS: LLMModel[] = [...ANTHROPIC_BYOK_MODELS, ...OPENAI_BYOK_MODELS];
-export const ALL_MODELS = [...FREE_MODELS, ...BYOK_MODELS];
+
+// ── Local (WebLLM, in-browser) models ──────────────────────────────────────
+// Model ids are MLC catalog ids — passed verbatim to CreateMLCEngine.
+// Assets are fetched from huggingface.co/mlc-ai/<id> on first chat open.
+
+export interface LocalModelMeta {
+  /** Approximate on-disk size after download, in MB. Used for the consent banner. */
+  approxSizeMB: number;
+  /** Approximate VRAM/working-set requirement, in GB. Lets us pick a default. */
+  vramRequirementGB: number;
+  /** Friendly subtitle for the picker, e.g. "Best balance" or "Mobile-friendly". */
+  blurb: string;
+}
+
+const LOCAL_MODELS: Array<LLMModel & { local: LocalModelMeta }> = [
+  {
+    id: 'Qwen2.5-Coder-7B-Instruct-q4f16_1-MLC',
+    name: 'Qwen2.5 Coder 7B',
+    provider: 'Local (browser)',
+    tier: 'local',
+    source: 'webllm',
+    contextWindow: 32_768,
+    supportsImages: false,
+    supportsFileAttachments: true,
+    notes: 'Recommended local model. Runs in your browser via WebGPU. Free, private, offline after first load. 32K-token context fits the full BIM toolkit.',
+    local: { approxSizeMB: 4200, vramRequirementGB: 6, blurb: 'Recommended — full BIM context · desktops & M-series Macs' },
+  },
+  {
+    id: 'Qwen2.5-Coder-1.5B-Instruct-q4f16_1-MLC',
+    name: 'Qwen2.5 Coder 1.5B',
+    provider: 'Local (browser)',
+    tier: 'local',
+    source: 'webllm',
+    // MLC's q4f16 1.5B build is compiled with a 4096-token window — much
+    // smaller than the model's nominal 32K — to keep KV-cache memory bounded.
+    contextWindow: 4_096,
+    supportsImages: false,
+    supportsFileAttachments: true,
+    notes: 'Lightweight — works on most laptops and iPad Safari. 4K-token context is too small for the full BIM toolkit; intended for general chat, not script-assistant tasks.',
+    local: { approxSizeMB: 900, vramRequirementGB: 2, blurb: 'Mobile-friendly · 4K context — general chat only' },
+  },
+  {
+    id: 'Hermes-3-Llama-3.2-3B-q4f16_1-MLC',
+    name: 'Hermes 3 (Llama 3.2 3B)',
+    provider: 'Local (browser)',
+    tier: 'local',
+    source: 'webllm',
+    contextWindow: 8_192,
+    supportsImages: false,
+    supportsFileAttachments: true,
+    notes: 'Tuned for instruction-following and tool use. 8K context fits short BIM tasks but truncates aggressively — Qwen 7B preferred when you can spare the disk space.',
+    local: { approxSizeMB: 1800, vramRequirementGB: 3, blurb: 'Better explanations · 8K context' },
+  },
+];
+
+export const LOCAL_WEBLLM_MODELS: LLMModel[] = LOCAL_MODELS.map(({ local: _local, ...m }) => m);
+
+const LOCAL_MODEL_META: Record<string, LocalModelMeta> = Object.fromEntries(
+  LOCAL_MODELS.map((m) => [m.id, m.local]),
+);
+
+export function getLocalModelMeta(id: string): LocalModelMeta | undefined {
+  return LOCAL_MODEL_META[id];
+}
+
+export const ALL_MODELS = [...FREE_MODELS, ...BYOK_MODELS, ...LOCAL_WEBLLM_MODELS];
 
 const FALLBACK_MODEL: LLMModel = {
   id: 'llm-model-missing',

--- a/apps/viewer/src/lib/llm/stream-webllm.ts
+++ b/apps/viewer/src/lib/llm/stream-webllm.ts
@@ -1,0 +1,211 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Stream a chat completion from an in-browser WebLLM model.
+ *
+ * The engine is OpenAI-shape (`engine.chat.completions.create`), so this
+ * file mirrors {@link streamOpenAiChatCompletions} but skips the network
+ * fetch — inference runs entirely on the user's machine via WebGPU.
+ *
+ * Multimodal content is flattened to text for v1 — the default models
+ * (Qwen2.5-Coder, Llama-3.2) don't accept images, and the chat panel
+ * already gates image attachments on the model's `supportsImages` flag.
+ */
+
+import type { ChatCompletionMessageParam } from '@mlc-ai/web-llm';
+import type { StreamMessage, StreamOptions } from './stream-client.js';
+import { ensureWebLLMEngine } from './webllm-engine.js';
+import { hasWebLLMConsent } from './webllm-consent.js';
+import { getModelById } from './models.js';
+
+export class WebLLMConsentRequiredError extends Error {
+  readonly code = 'webllm-consent-required';
+  constructor(public readonly modelId: string) {
+    super(`Local model "${modelId}" needs to be downloaded before first use.`);
+  }
+}
+
+/** Tokens we reserve for the model's reply. */
+const OUTPUT_BUDGET_TOKENS = 1024;
+
+/**
+ * Coarse estimator — averaging across English code+prose, BPE tokens land
+ * around 3.5–4 characters each. Slight overestimate on the safe side.
+ */
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 3.6);
+}
+
+function messageTokens(m: { content: string }): number {
+  // +4 covers role markers / chat-template overhead per message.
+  return estimateTokens(m.content) + 4;
+}
+
+interface TrimmedConversation {
+  system: string | null;
+  messages: StreamMessage[];
+  systemTokens: number;
+  totalTokens: number;
+  truncated: boolean;
+}
+
+/**
+ * Drop oldest non-system turns until the conversation fits within
+ * `contextWindow - OUTPUT_BUDGET_TOKENS`. The newest user message and the
+ * system prompt are kept verbatim — if even those two don't fit, we surface
+ * the error to the caller.
+ */
+function trimToContextWindow(
+  messages: StreamMessage[],
+  system: string | undefined,
+  contextWindow: number,
+): TrimmedConversation {
+  const budget = Math.max(256, contextWindow - OUTPUT_BUDGET_TOKENS);
+  const systemContent = system ?? null;
+  const systemTokens = systemContent ? estimateTokens(systemContent) + 4 : 0;
+
+  // Flatten content first so token estimates match what's actually sent.
+  const flattened = messages.map((m) => ({
+    role: m.role,
+    content: typeof m.content === 'string'
+      ? m.content
+      : m.content.map((p) => p.type === 'text' ? p.text : '').join('\n'),
+  }));
+
+  // Find the index of the most-recent user message — it must survive trimming.
+  const lastUserIdx = (() => {
+    for (let i = flattened.length - 1; i >= 0; i--) {
+      if (flattened[i].role === 'user') return i;
+    }
+    return flattened.length - 1;
+  })();
+
+  const kept: Array<typeof flattened[number]> = [flattened[lastUserIdx]];
+  let runningTokens = systemTokens + messageTokens(kept[0]);
+
+  // Walk backwards from just before lastUserIdx, adding history while budget allows.
+  for (let i = lastUserIdx - 1; i >= 0; i--) {
+    const candidate = flattened[i];
+    const cost = messageTokens(candidate);
+    if (runningTokens + cost > budget) break;
+    kept.unshift(candidate);
+    runningTokens += cost;
+  }
+
+  // Re-cast kept entries to StreamMessage shape (content stays as string).
+  const trimmedMessages: StreamMessage[] = kept.map((m) => ({
+    role: m.role,
+    content: m.content,
+  }));
+
+  return {
+    system: systemContent,
+    messages: trimmedMessages,
+    systemTokens,
+    totalTokens: runningTokens,
+    truncated: trimmedMessages.length < messages.length,
+  };
+}
+
+function flattenContent(content: StreamMessage['content']): string {
+  if (typeof content === 'string') return content;
+  const parts: string[] = [];
+  for (const part of content) {
+    if (part.type === 'text') {
+      parts.push(part.text);
+    } else {
+      parts.push(`[Image attachment skipped — current local model does not accept images]`);
+    }
+  }
+  return parts.join('\n');
+}
+
+function toWebLLMMessages(messages: StreamMessage[], system?: string): ChatCompletionMessageParam[] {
+  const out: ChatCompletionMessageParam[] = [];
+  if (system) out.push({ role: 'system', content: system });
+  for (const m of messages) {
+    const content = flattenContent(m.content);
+    if (m.role === 'user') {
+      out.push({ role: 'user', content });
+    } else if (m.role === 'assistant') {
+      out.push({ role: 'assistant', content });
+    } else {
+      out.push({ role: 'system', content });
+    }
+  }
+  return out;
+}
+
+export async function streamWebLLMChat(
+  options: Omit<StreamOptions, 'proxyUrl' | 'authToken' | 'onUsageInfo'>,
+): Promise<void> {
+  const { model, messages, system, signal, onChunk, onComplete, onError, onFinishReason } = options;
+
+  if (!hasWebLLMConsent(model)) {
+    onError(new WebLLMConsentRequiredError(model));
+    return;
+  }
+
+  // Trim history to fit the local model's compiled context window. Smaller
+  // MLC builds (e.g. Qwen2.5-Coder-1.5B at 4096) overflow easily on the
+  // viewer's full IFC system prompt — we shed older turns rather than crash.
+  const modelDef = getModelById(model);
+  const contextWindow = modelDef?.contextWindow ?? 4096;
+  const trimmed = trimToContextWindow(messages, system, contextWindow);
+  if (trimmed.totalTokens > contextWindow - OUTPUT_BUDGET_TOKENS) {
+    onError(new Error(
+      `Local model "${modelDef?.name ?? model}" has a ${contextWindow.toLocaleString()}-token context window. ` +
+      `Your current message plus the system prompt is too large (≈${trimmed.totalTokens.toLocaleString()} tokens). ` +
+      `Pick the Qwen 7B model (32K context) or shorten your message.`,
+    ));
+    return;
+  }
+
+  let engine;
+  try {
+    engine = await ensureWebLLMEngine(model);
+  } catch (err) {
+    onError(err instanceof Error ? err : new Error(String(err)));
+    return;
+  }
+
+  if (signal?.aborted) return;
+
+  let fullText = '';
+  let finishReason: string | null = null;
+
+  try {
+    const stream = await engine.chat.completions.create({
+      messages: toWebLLMMessages(trimmed.messages, trimmed.system ?? undefined),
+      stream: true,
+      temperature: 0.3,
+      max_tokens: OUTPUT_BUDGET_TOKENS,
+    });
+
+    for await (const chunk of stream) {
+      if (signal?.aborted) {
+        try { await engine.interruptGenerate(); } catch { /* ignore */ }
+        return;
+      }
+      const choice = chunk.choices?.[0];
+      const delta = choice?.delta?.content;
+      if (delta) {
+        fullText += delta;
+        onChunk(delta);
+      }
+      if (choice?.finish_reason) {
+        finishReason = choice.finish_reason;
+      }
+    }
+  } catch (err) {
+    if (signal?.aborted) return;
+    onError(err instanceof Error ? err : new Error(String(err)));
+    return;
+  }
+
+  if (signal?.aborted) return;
+  onFinishReason?.(finishReason);
+  onComplete(fullText);
+}

--- a/apps/viewer/src/lib/llm/types.ts
+++ b/apps/viewer/src/lib/llm/types.ts
@@ -132,15 +132,16 @@ export interface FileAttachment {
   isSpreadsheetBinary?: boolean;
 }
 
-export type ModelTier = 'free' | 'byok';
+export type ModelTier = 'free' | 'byok' | 'local';
 
 /**
  * Where requests for this model are routed.
  * - 'proxy': through the server-side proxy (free models)
  * - 'anthropic': direct browser-to-Anthropic API (user's own key)
  * - 'openai': direct browser-to-OpenAI API (user's own key)
+ * - 'webllm': in-browser inference via WebGPU (no network, no key)
  */
-export type ModelSource = 'proxy' | 'anthropic' | 'openai';
+export type ModelSource = 'proxy' | 'anthropic' | 'openai' | 'webllm';
 
 /** Relative cost indicator for paid models */
 export type ModelCost = '$' | '$$' | '$$$';

--- a/apps/viewer/src/lib/llm/webgpu-capability.ts
+++ b/apps/viewer/src/lib/llm/webgpu-capability.ts
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * WebGPU + cross-origin-isolation capability detection for the in-browser
+ * (WebLLM) chat backend.
+ *
+ * The Local-LLM tier in the model picker is gated on these checks. If any
+ * fails, we hide the tier rather than letting the user pick a model that
+ * will then fail to load.
+ */
+
+export type WebLLMBlockReason =
+  | 'no-webgpu'
+  | 'no-adapter'
+  | 'not-cross-origin-isolated';
+
+export interface WebLLMCapabilityOk {
+  supported: true;
+  /** Estimated single-buffer cap, in GB — used to pick a default model tier. */
+  vramGB: number;
+  /** Suggested model tier given the heuristic VRAM/RAM check. */
+  recommendedTier: 'lite' | 'default' | 'reasoning';
+}
+
+export interface WebLLMCapabilityBlocked {
+  supported: false;
+  reason: WebLLMBlockReason;
+}
+
+export type WebLLMCapability = WebLLMCapabilityOk | WebLLMCapabilityBlocked;
+
+let cached: Promise<WebLLMCapability> | null = null;
+
+interface NavigatorWithGPU {
+  gpu?: {
+    requestAdapter(): Promise<{ limits?: { maxBufferSize?: number } } | null>;
+  };
+  deviceMemory?: number;
+}
+
+export function detectWebLLMSupport(): Promise<WebLLMCapability> {
+  if (cached) return cached;
+  cached = (async (): Promise<WebLLMCapability> => {
+    if (typeof window === 'undefined') return { supported: false, reason: 'no-webgpu' };
+    if (window.isSecureContext === false) return { supported: false, reason: 'no-webgpu' };
+    if (window.crossOriginIsolated === false) {
+      return { supported: false, reason: 'not-cross-origin-isolated' };
+    }
+    const nav = navigator as unknown as NavigatorWithGPU;
+    if (!nav.gpu) return { supported: false, reason: 'no-webgpu' };
+    let adapter: { limits?: { maxBufferSize?: number } } | null = null;
+    try {
+      adapter = await nav.gpu.requestAdapter();
+    } catch {
+      return { supported: false, reason: 'no-adapter' };
+    }
+    if (!adapter) return { supported: false, reason: 'no-adapter' };
+    const maxBufferBytes = adapter.limits?.maxBufferSize ?? 0;
+    // maxBufferSize roughly tracks usable VRAM tier — 4 GB on integrated, 8+ on discrete.
+    const vramGB = maxBufferBytes / 1e9;
+    // Combine with deviceMemory (system RAM) for the recommendation.
+    const ramGB = nav.deviceMemory ?? 4;
+    const recommendedTier: WebLLMCapabilityOk['recommendedTier'] =
+      vramGB >= 6 && ramGB >= 8 ? 'default' : ramGB >= 6 ? 'reasoning' : 'lite';
+    return { supported: true, vramGB, recommendedTier };
+  })();
+  return cached;
+}
+
+/** Test-only: clear the memoized detection. */
+export function __resetWebLLMCapabilityCache(): void {
+  cached = null;
+}

--- a/apps/viewer/src/lib/llm/webllm-consent.ts
+++ b/apps/viewer/src/lib/llm/webllm-consent.ts
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Persistent "yes, download this model" consent per local-model id.
+ *
+ * Stored in localStorage because the consent set is small (one entry per
+ * model the user has ever agreed to download), and we want this to be a
+ * synchronous read from the chat send path.
+ */
+
+const STORAGE_KEY = 'ifc-lite:webllm-consent:v1';
+
+type ConsentRecord = Record<string, true>;
+
+const listeners = new Set<() => void>();
+
+function read(): ConsentRecord {
+  try {
+    if (typeof localStorage === 'undefined') return {};
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as ConsentRecord) : {};
+  } catch {
+    return {};
+  }
+}
+
+function write(next: ConsentRecord): void {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // best-effort — quota exhaustion just means we re-prompt next session
+  }
+  for (const l of listeners) {
+    try { l(); } catch { /* swallow listener errors */ }
+  }
+}
+
+export function hasWebLLMConsent(modelId: string): boolean {
+  return read()[modelId] === true;
+}
+
+export function grantWebLLMConsent(modelId: string): void {
+  const next = read();
+  if (next[modelId] === true) return;
+  next[modelId] = true;
+  write(next);
+}
+
+export function revokeWebLLMConsent(modelId: string): void {
+  const next = read();
+  if (next[modelId] !== true) return;
+  delete next[modelId];
+  write(next);
+}
+
+export function subscribeWebLLMConsent(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}

--- a/apps/viewer/src/lib/llm/webllm-engine.ts
+++ b/apps/viewer/src/lib/llm/webllm-engine.ts
@@ -1,0 +1,88 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Singleton wrapper around the MLC WebLLM engine.
+ *
+ * Holds at most one loaded model in memory. Switching to a different model
+ * unloads the previous one to free VRAM. Download progress is fanned out
+ * to any subscribers (the ModelDownloadCard listens during first-load).
+ */
+
+import type { MLCEngineInterface, InitProgressReport } from '@mlc-ai/web-llm';
+
+export interface WebLLMProgress {
+  modelId: string;
+  /** Progress fraction in [0, 1], or null when MLC hasn't reported one yet. */
+  progress: number | null;
+  /** Human-readable status text from MLC (e.g. "Loading model from cache"). */
+  text: string;
+}
+
+type ProgressListener = (event: WebLLMProgress) => void;
+
+let engine: MLCEngineInterface | null = null;
+let engineModelId: string | null = null;
+let loading: Promise<MLCEngineInterface> | null = null;
+const listeners = new Set<ProgressListener>();
+
+export function onWebLLMProgress(listener: ProgressListener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function emit(event: WebLLMProgress): void {
+  for (const l of listeners) {
+    try { l(event); } catch { /* swallow listener errors */ }
+  }
+}
+
+export function getActiveWebLLMModelId(): string | null {
+  return engineModelId;
+}
+
+/**
+ * Load (or reuse) the engine for the given MLC model id. If a different
+ * model is currently loaded, unload it first.
+ */
+export async function ensureWebLLMEngine(modelId: string): Promise<MLCEngineInterface> {
+  if (engine && engineModelId === modelId) return engine;
+  if (loading && engineModelId === modelId) return loading;
+
+  // Switching models — unload the previous engine before loading the new one.
+  if (engine && engineModelId !== modelId) {
+    const previous = engine;
+    engine = null;
+    engineModelId = null;
+    try { await previous.unload(); } catch { /* best-effort */ }
+  }
+
+  engineModelId = modelId;
+  loading = (async () => {
+    const { CreateMLCEngine } = await import('@mlc-ai/web-llm');
+    const created = await CreateMLCEngine(modelId, {
+      initProgressCallback: (report: InitProgressReport) => {
+        emit({ modelId, progress: report.progress ?? null, text: report.text });
+      },
+    });
+    engine = created;
+    return created;
+  })();
+
+  try {
+    return await loading;
+  } finally {
+    loading = null;
+  }
+}
+
+/** Unload the currently active engine, if any. */
+export async function unloadWebLLMEngine(): Promise<void> {
+  const previous = engine;
+  engine = null;
+  engineModelId = null;
+  if (previous) {
+    try { await previous.unload(); } catch { /* best-effort */ }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -276,6 +276,9 @@ importers:
       '@ifc-lite/wasm':
         specifier: workspace:^
         version: link:../../packages/wasm
+      '@mlc-ai/web-llm':
+        specifier: ^0.2.83
+        version: 0.2.83
       '@radix-ui/react-alert-dialog':
         specifier: ^1.1.6
         version: 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1776,6 +1779,9 @@ packages:
 
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
+
+  '@mlc-ai/web-llm@0.2.83':
+    resolution: {integrity: sha512-Ynuses0TM9CcSIs9PfX5+xwGOVFssQTXQaAwKFggfEw++shBbEr8fOjI7yJlY96wv0dwVFE+C2KGcO287+FuHw==}
 
   '@neondatabase/serverless@1.0.2':
     resolution: {integrity: sha512-I5sbpSIAHiB+b6UttofhrN/UJXII+4tZPAq1qugzwCwLIL8EZLV7F/JyHUrEIiGgQpEXzpnjlJ+zwcEhheGvCw==}
@@ -3688,6 +3694,10 @@ packages:
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
+  loglevel@1.9.2:
+    resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
+    engines: {node: '>= 0.6.0'}
+
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
@@ -5357,6 +5367,10 @@ snapshots:
       supercluster: 8.0.1
 
   '@marijn/find-cluster-break@1.0.2': {}
+
+  '@mlc-ai/web-llm@0.2.83':
+    dependencies:
+      loglevel: 1.9.2
 
   '@neondatabase/serverless@1.0.2':
     dependencies:
@@ -7146,6 +7160,8 @@ snapshots:
   lodash.startcase@4.4.0: {}
 
   lodash@4.18.1: {}
+
+  loglevel@1.9.2: {}
 
   long@5.3.2: {}
 


### PR DESCRIPTION
## Summary

- Replaces the "paste your OpenAI/Anthropic key" UX with a **Local Model** tier that runs Qwen/Hermes coding models inside the browser via WebGPU. No auth, no network, no per-call cost — the model is downloaded once and cached.
- Demotes BYOK API-key paste to an *Advanced* section. Free hosted proxy remains as before for first-time users without WebGPU.
- All-new code is additive; existing chat routes (Anthropic / OpenAI / proxy) keep working.

## Verification

Verified in browser via Chrome DevTools MCP on \`localhost:3000\`:

1. **WebGPU capability gate** — Local group hides on no-COI or no-WebGPU, shows otherwise.
2. **Model picker** — three Local options listed (Qwen 7B / 1.5B / Hermes 3B) with sizes (4.2 GB / 900 MB / 1.8 GB).
3. **Cold start** — selecting a Local model shows the consent card with "Download 900 MB" button. Nothing downloads silently.
4. **Click Download** — engine load begins; memory rises from 92 MB → ~500 MB while MLC fetches shards into IndexedDB.
5. **Trim guard** — sending a chat with the 1.5B (4K context) triggers the friendly:
   > *Local model "Qwen2.5 Coder 1.5B" has a 4,096-token context window. Your current message plus the system prompt is too large (≈15,309 tokens). Pick the Qwen 7B model (32K context) or shorten your message.*
6. **Settings page** — "Local Model" section is the first card, API Keys demoted to "Advanced: API Keys (optional)" beneath.

## What's in this PR

| Area | Files |
|---|---|
| New engine wiring | \`webllm-engine.ts\`, \`stream-webllm.ts\`, \`webllm-consent.ts\`, \`webgpu-capability.ts\` |
| Routing | \`byok-guard.ts\` (\`kind: 'webllm'\`), \`types.ts\` (\`'local'\` tier, \`'webllm'\` source) |
| Models | \`models.ts\` — three tiers w/ accurate per-model context windows |
| UI | \`ModelSelector.tsx\`, \`ModelDownloadCard.tsx\`, \`SettingsPage.tsx\`, \`ChatPanel.tsx\` |
| Deps | \`@mlc-ai/web-llm@^0.2.83\` |

COOP/COEP already configured in \`apps/viewer/vite.config.ts\` and \`vercel.json\` — no infra changes.

## Real-world note from verification

The viewer's existing chat system prompt is **~15K tokens** (full BIM toolkit context). That means in practice only the **Qwen 7B (32K)** Local model is usable for script-assistant work. The 1.5B (4K) and Hermes 3B (8K) are kept as options but labeled "general chat only / aggressive truncation" in the picker. A follow-up could ship a compact system-prompt mode for the smaller models — out of scope here.

## Test plan

- [x] \`pnpm --filter @ifc-lite/viewer typecheck\` — clean
- [x] Browser smoke test (Chrome / WebGPU): consent → download → trim error path
- [ ] CI green (this PR)
- [ ] Manual: open the dev server in a non-COI iframe (e.g. embed) and confirm the Local tier hides

🤖 Generated with [Claude Code](https://claude.com/claude-code)