### PR TITLE
Fix context menu positioning and dismiss behavior

### DIFF
--- a/apps/viewer/src/components/viewer/EntityContextMenu.tsx
+++ b/apps/viewer/src/components/viewer/EntityContextMenu.tsx
@@ -6,7 +6,7 @@
  * Context menu for entity interactions
  */
 
-import { useCallback, useEffect, useRef, useMemo } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useMemo, useState } from 'react';
 import {
   Equal,
   Plus,
@@ -73,18 +73,30 @@ export function EntityContextMenu() {
     };
   }, [contextMenu.entityId, models, ifcDataStore]);
 
-  // Close menu when clicking outside
+  // Close menu when clicking/tapping outside.
+  //
+  // Listen on `pointerdown` (with capture) rather than `mousedown`:
+  // the canvas calls `e.preventDefault()` on its own pointerdown
+  // handler, which in some browsers suppresses the compatibility
+  // `mousedown` event — so a plain `mousedown` listener never fires
+  // when the user clicks the 3D viewport to dismiss the menu.
   useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
+    if (!contextMenu.isOpen) return;
+    const handlePointerOutside = (e: PointerEvent) => {
       if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
         closeContextMenu();
       }
     };
-
-    if (contextMenu.isOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
-      return () => document.removeEventListener('mousedown', handleClickOutside);
-    }
+    // Also close on scroll/resize — the anchor coords go stale.
+    const handleDismiss = () => closeContextMenu();
+    document.addEventListener('pointerdown', handlePointerOutside, true);
+    window.addEventListener('resize', handleDismiss);
+    window.addEventListener('wheel', handleDismiss, { passive: true });
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerOutside, true);
+      window.removeEventListener('resize', handleDismiss);
+      window.removeEventListener('wheel', handleDismiss);
+    };
   }, [contextMenu.isOpen, closeContextMenu]);
 
   // Close on escape
@@ -271,6 +283,48 @@ export function EntityContextMenu() {
     closeContextMenu();
   }, [contextEntityRef, canEdit, contextEntityType, contextMenu.entityId, removeEntity, hideEntity, setSelectedEntityId, closeContextMenu]);
 
+  // Viewport-constrained placement (mirrors OS context-menu behaviour):
+  // flip up/left when the menu would overflow the bottom/right edges,
+  // then clamp against the opposite edge so it never crosses any side
+  // of the viewport. Two-pass render: invisible first, then measure and
+  // reposition before the browser paints (useLayoutEffect is sync).
+  const [position, setPosition] = useState<{ left: number; top: number } | null>(null);
+
+  useLayoutEffect(() => {
+    if (!contextMenu.isOpen) {
+      setPosition(null);
+      return;
+    }
+    const node = menuRef.current;
+    if (!node) return;
+    const rect = node.getBoundingClientRect();
+    const margin = 4;
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    const anchorX = contextMenu.screenX;
+    const anchorY = contextMenu.screenY;
+
+    // Horizontal: prefer right of cursor, flip to left if it would
+    // overflow the right edge, then clamp.
+    let left = anchorX;
+    if (left + rect.width + margin > vw) {
+      const flipped = anchorX - rect.width;
+      left = flipped >= margin ? flipped : Math.max(margin, vw - rect.width - margin);
+    }
+    if (left < margin) left = margin;
+
+    // Vertical: prefer below cursor, flip above if it would overflow
+    // the bottom edge, then clamp.
+    let top = anchorY;
+    if (top + rect.height + margin > vh) {
+      const flipped = anchorY - rect.height;
+      top = flipped >= margin ? flipped : Math.max(margin, vh - rect.height - margin);
+    }
+    if (top < margin) top = margin;
+
+    setPosition({ left, top });
+  }, [contextMenu.isOpen, contextMenu.screenX, contextMenu.screenY, contextMenu.entityId]);
+
   if (!contextMenu.isOpen) {
     return null;
   }
@@ -289,8 +343,12 @@ export function EntityContextMenu() {
       ref={menuRef}
       className="fixed z-50 bg-popover border rounded-lg shadow-lg py-1 min-w-48"
       style={{
-        left: contextMenu.screenX,
-        top: contextMenu.screenY,
+        left: position?.left ?? contextMenu.screenX,
+        top: position?.top ?? contextMenu.screenY,
+        // Hide the first render: we need a measured rect to compute the
+        // constrained position. `useLayoutEffect` resolves this before
+        // paint, so the user never sees the unclamped flash.
+        visibility: position ? 'visible' : 'hidden',
       }}
     >
       {contextMenu.entityId && (

--- a/apps/viewer/src/components/viewer/selectionHandlers.ts
+++ b/apps/viewer/src/components/viewer/selectionHandlers.ts
@@ -564,7 +564,13 @@ export function commitAddElementSlabPolygon(): void {
  */
 export async function handleContextMenu(ctx: MouseHandlerContext, e: MouseEvent): Promise<void> {
   e.preventDefault();
-  const { canvas, renderer } = ctx;
+  const { canvas, renderer, mouseState } = ctx;
+  // Right-drag is the pan gesture (see useMouseControls). Some browsers
+  // still fire `contextmenu` after a tiny right-drag — skip when the
+  // user actually moved, so panning never accidentally pops the menu.
+  if (mouseState.didDrag) {
+    return;
+  }
   const rect = canvas.getBoundingClientRect();
   const x = e.clientX - rect.left;
   const y = e.clientY - rect.top;


### PR DESCRIPTION
## Summary
Improves the entity context menu's interaction model and viewport positioning to match standard OS context menu behavior. Fixes issues where the menu could be dismissed by canvas interactions and could overflow viewport edges.

## Key Changes
- **Dismiss behavior**: Changed from `mousedown` to `pointerdown` (with capture phase) to properly detect clicks on the 3D canvas, which calls `preventDefault()` on pointer events. Also added dismissal on window resize and scroll to keep menu anchored to stale coordinates.
- **Viewport-constrained positioning**: Implemented two-pass rendering with `useLayoutEffect` to measure the menu and reposition it before paint. The menu now flips horizontally/vertically when it would overflow viewport edges, then clamps to stay within bounds with a 4px margin.
- **Drag gesture handling**: Added check in `handleContextMenu` to skip opening the menu if the user performed a right-drag (pan gesture), preventing accidental menu opens during canvas panning.
- **Visual polish**: Menu is hidden during the first render (before measurement) to prevent a visible flash of unclamped positioning.

## Implementation Details
- Uses `useState` to track computed position and `useLayoutEffect` to synchronously measure and reposition before browser paint
- Listens to `pointerdown` in capture phase to intercept canvas interactions that suppress `mousedown` events
- Implements standard context menu flip logic: prefer below/right of cursor, flip to above/left if overflow detected, then clamp to viewport edges
- Checks `mouseState.didDrag` to distinguish intentional pans from accidental right-clicks

https://claude.ai/code/session_01Hy12kH2iQNCHyqzsJq9wbt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Context menu now automatically positions itself within viewport boundaries
* Context menu no longer appears after right-click drag pan operations
* Context menu automatically dismisses when window is resized or mouse wheel is used
* Improved event handling for more reliable dismissal when clicking outside the menu

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/louistrue/ifc-lite/pull/685)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->