### PR TITLE
feat(viewer/chat): trust-focused BYOK modal + Claude 4.7 / GPT-5.5

### DIFF
--- a/.changeset/byok-trust-modal.md
+++ b/.changeset/byok-trust-modal.md
@@ -4,6 +4,6 @@
 
 BYOK key entry moves from an inline strip into a trust-focused modal with one tab per provider. Each tab shows an SVG that contrasts the direct browser → provider request path against the "via our server" path we never use, DevTools-verifiable trust claims, a clipboard-detect shortcut (so users who just created a key on the provider console don't have to paste), and a 60-second walkthrough. A small key icon in the chat header reopens the modal for management, and a "🔒 → api.provider.com" pill next to the model name names the actual API host whenever a BYOK route is active.
 
-Adds three new BYOK model IDs: `claude-opus-4-7` (Anthropic), `gpt-5.5` and `gpt-5.5-pro` (OpenAI).
+Adds two new BYOK model IDs: `claude-opus-4-7` (Anthropic) and `gpt-5.5` (OpenAI). Note that Claude Opus 4.7 and the GPT-5 reasoning family reject classic sampling parameters (`temperature`/`top_p`/`top_k`); a new `acceptsSamplingParams` flag on `LLMModel` lets the direct stream client omit them for affected models.
 
 Web build: this is the first time API-key entry has a real surface outside the cramped inline strip, since `/settings` is desktop-only.

--- a/.changeset/byok-trust-modal.md
+++ b/.changeset/byok-trust-modal.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/viewer': minor
+---
+
+BYOK key entry moves from an inline strip into a trust-focused modal with one tab per provider. Each tab shows an SVG that contrasts the direct browser → provider request path against the "via our server" path we never use, DevTools-verifiable trust claims, a clipboard-detect shortcut (so users who just created a key on the provider console don't have to paste), and a 60-second walkthrough. A small key icon in the chat header reopens the modal for management, and a "🔒 → api.provider.com" pill next to the model name names the actual API host whenever a BYOK route is active.
+
+Adds three new BYOK model IDs: `claude-opus-4-7` (Anthropic), `gpt-5.5` and `gpt-5.5-pro` (OpenAI).
+
+Web build: this is the first time API-key entry has a real surface outside the cramped inline strip, since `/settings` is desktop-only.

--- a/apps/viewer/src/components/mcp/PlaygroundChat.tsx
+++ b/apps/viewer/src/components/mcp/PlaygroundChat.tsx
@@ -32,9 +32,16 @@ import {
 import Anthropic from '@anthropic-ai/sdk';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { ArrowUp, Check, ChevronDown, ChevronRight, Download, Key, Loader2, RefreshCcw, Wrench } from 'lucide-react';
+import { ArrowUp, Check, ChevronDown, ChevronRight, Download, KeyRound, Loader2, RefreshCcw, Wrench } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { getApiKeys, subscribeApiKeys, updateApiKeys, type ApiKeyConfig } from '@/services/api-keys';
+import { getApiKeys, subscribeApiKeys, type ApiKeyConfig } from '@/services/api-keys';
+import {
+  getPlaygroundModel,
+  setPlaygroundModel,
+  subscribePlaygroundModel,
+} from '@/services/playground-model';
+import { getByokModelsForSource } from '@/lib/llm/models';
+import { ByokKeyModal } from '@/components/viewer/chat/ByokKeyModal';
 import {
   anthropicToolDefinitions,
   dispatch,
@@ -47,9 +54,6 @@ import { playgroundFiles, formatBytes as formatFileBytes } from './playground-fi
 import { playgroundUploads, usePlaygroundUploads, type UploadedFile } from './playground-uploads';
 import { Paperclip, X } from 'lucide-react';
 
-// Default Claude model. Stays within the safe BYOK price band; users with a
-// big key can swap via localStorage / a future picker.
-const DEFAULT_MODEL = 'claude-sonnet-4-6';
 const MAX_TOOL_CALLS = 25;
 const MAX_TOKENS = 4096;
 const SYSTEM_PROMPT = `You are a BIM/IFC analyst driving @ifc-lite/mcp tools against a pre-loaded model. Be terse — the user is technical and time-pressed.
@@ -113,6 +117,17 @@ export function PlaygroundChat({
   const [keys, setKeys] = useState<ApiKeyConfig>(() => getApiKeys());
   useEffect(() => subscribeApiKeys(() => setKeys(getApiKeys())), []);
 
+  // Selected Claude model (Anthropic only — the playground driver uses
+  // Anthropic's native tools API). Persisted to localStorage separately
+  // from the viewer's chatActiveModel so the two pages can default
+  // differently.
+  const [selectedModel, setSelectedModel] = useState<string>(() => getPlaygroundModel());
+  useEffect(() => subscribePlaygroundModel(() => setSelectedModel(getPlaygroundModel())), []);
+  const anthropicModels = useMemo(() => getByokModelsForSource('anthropic'), []);
+
+  // Shared BYOK key entry modal — same component the viewer chat uses.
+  const [keyModalOpen, setKeyModalOpen] = useState(false);
+
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [isStreaming, setStreaming] = useState(false);
@@ -169,6 +184,7 @@ export function PlaygroundChat({
       try {
         await runConversation({
           apiKey: keys.anthropicKey,
+          modelId: selectedModel,
           tools,
           history: [...messages, userMessage],
           model,
@@ -193,7 +209,7 @@ export function PlaygroundChat({
         setStreaming(false);
       }
     },
-    [keys.anthropicKey, model, tools, messages, dispatchContext],
+    [keys.anthropicKey, selectedModel, model, tools, messages, dispatchContext],
   );
 
   const onSubmit = (e: React.FormEvent) => {
@@ -260,7 +276,19 @@ export function PlaygroundChat({
   // ── render ──────────────────────────────────────────────────────────────
   return (
     <div className="flex h-full min-h-0 flex-col bg-[#0f0f12] text-[#ede4d3]">
-      <KeyHeader keys={keys} onSave={(next) => updateApiKeys(next)} />
+      <PlaygroundHeader
+        hasKey={Boolean(keys.anthropicKey)}
+        maskedKey={
+          keys.anthropicKey
+            ? `${keys.anthropicKey.slice(0, 7)}…${keys.anthropicKey.slice(-4)}`
+            : ''
+        }
+        onOpenKeyModal={() => setKeyModalOpen(true)}
+        selectedModel={selectedModel}
+        anthropicModels={anthropicModels}
+        onChangeModel={setPlaygroundModel}
+      />
+      <ByokKeyModal open={keyModalOpen} onOpenChange={setKeyModalOpen} initialProvider="anthropic" />
 
       <div ref={scrollRef} className="flex-1 overflow-y-auto px-5 py-5">
         {messages.length === 0 ? (
@@ -392,21 +420,23 @@ export function PlaygroundChat({
   );
 }
 
-// ── header / key entry ─────────────────────────────────────────────────────
+// ── header / key entry + model picker ─────────────────────────────────────
 
-function KeyHeader({
-  keys,
-  onSave,
+function PlaygroundHeader({
+  hasKey,
+  maskedKey,
+  onOpenKeyModal,
+  selectedModel,
+  anthropicModels,
+  onChangeModel,
 }: {
-  keys: ApiKeyConfig;
-  onSave: (next: Partial<ApiKeyConfig>) => void;
+  hasKey: boolean;
+  maskedKey: string;
+  onOpenKeyModal: () => void;
+  selectedModel: string;
+  anthropicModels: ReturnType<typeof getByokModelsForSource>;
+  onChangeModel: (modelId: string) => void;
 }): ReactNode {
-  const [editing, setEditing] = useState(false);
-  const [draft, setDraft] = useState(keys.anthropicKey);
-  useEffect(() => setDraft(keys.anthropicKey), [keys.anthropicKey]);
-  const masked = keys.anthropicKey
-    ? `${keys.anthropicKey.slice(0, 7)}…${keys.anthropicKey.slice(-4)}`
-    : '';
   return (
     <div className="flex items-center justify-between gap-2 border-b border-white/10 px-4 py-2.5">
       <div className="flex items-center gap-2">
@@ -414,50 +444,56 @@ function KeyHeader({
           className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-[#d6ff3f]"
           aria-hidden
         />
-        <span className="text-[10px] uppercase tracking-[0.22em] text-white/60" style={{ fontFamily: '"JetBrains Mono", monospace' }}>
+        <span
+          className="text-[10px] uppercase tracking-[0.22em] text-white/60"
+          style={{ fontFamily: '"JetBrains Mono", monospace' }}
+        >
           ifc-lite/mcp · agent
         </span>
       </div>
-      {editing ? (
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            onSave({ anthropicKey: draft.trim() });
-            setEditing(false);
-          }}
-          className="flex items-center gap-1.5"
+
+      <div className="flex items-center gap-2">
+        {/* Model picker — Anthropic-only because the playground driver uses
+            Anthropic's native tools API. The dropdown's styling mirrors the
+            key-status pill so the two affordances read as a single cluster. */}
+        <label
+          className="inline-flex items-center gap-1 rounded border border-white/15 bg-white/[0.03] px-1.5 py-1 text-[10.5px] text-white/70"
+          style={{ fontFamily: '"JetBrains Mono", monospace' }}
+          title="Anthropic model used for tool-calling agent loops"
         >
-          <input
-            type="password"
-            value={draft}
-            onChange={(e) => setDraft(e.target.value)}
-            placeholder="sk-ant-…"
-            className="w-56 rounded border border-white/20 bg-white/5 px-2 py-1 text-[11px] outline-none placeholder:text-white/30"
+          <span className="text-white/40">model</span>
+          <select
+            value={selectedModel}
+            onChange={(e) => onChangeModel(e.target.value)}
+            className="bg-transparent text-[10.5px] outline-none [&>option]:bg-[#0a0a0c] [&>option]:text-white"
             style={{ fontFamily: '"JetBrains Mono", monospace' }}
-            autoFocus
-          />
-          <button type="submit" className="rounded bg-[#d6ff3f] px-2 py-1 text-[10px] font-semibold text-[#0a0a0c]">
-            save
-          </button>
-          <button type="button" onClick={() => setEditing(false)} className="text-[10px] text-white/50">
-            cancel
-          </button>
-        </form>
-      ) : (
+            aria-label="Select Claude model"
+          >
+            {anthropicModels.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        {/* Key-status pill — opens the shared BYOK modal so the playground
+            and the viewer chat share one trust-focused entry surface. */}
         <button
-          onClick={() => setEditing(true)}
+          onClick={onOpenKeyModal}
           className={cn(
             'inline-flex items-center gap-1.5 rounded border px-2 py-1 text-[10.5px]',
-            keys.anthropicKey
-              ? 'border-[#d6ff3f]/40 text-[#d6ff3f]'
-              : 'border-orange-400/40 text-orange-300',
+            hasKey
+              ? 'border-[#d6ff3f]/40 text-[#d6ff3f] hover:bg-[#d6ff3f]/5'
+              : 'border-orange-400/40 text-orange-300 hover:bg-orange-400/5',
           )}
           style={{ fontFamily: '"JetBrains Mono", monospace' }}
+          aria-label={hasKey ? 'Manage Anthropic API key' : 'Add Anthropic API key'}
         >
-          <Key size={11} />
-          {keys.anthropicKey ? `key set · ${masked}` : 'set Anthropic key'}
+          <KeyRound size={11} />
+          {hasKey ? `key set · ${maskedKey}` : 'set Anthropic key'}
         </button>
-      )}
+      </div>
     </div>
   );
 }
@@ -677,6 +713,8 @@ interface AnthropicToolResultBlock {
 
 interface RunOpts {
   apiKey: string;
+  /** Anthropic model id (e.g. `claude-sonnet-4-6`, `claude-opus-4-7`). */
+  modelId: string;
   tools: AnthropicToolDef[];
   history: ChatMessage[];
   model: LoadedPlaygroundModel;
@@ -847,7 +885,7 @@ async function runConversation(opts: RunOpts): Promise<void> {
   // assistant finishes without requesting more tools, or when we hit the cap.
   while (true) {
     const res = await client.messages.create({
-      model: DEFAULT_MODEL,
+      model: opts.modelId,
       max_tokens: MAX_TOKENS,
       system: SYSTEM_PROMPT,
       tools: opts.tools as unknown as Parameters<typeof client.messages.create>[0]['tools'],

--- a/apps/viewer/src/components/viewer/ChatPanel.tsx
+++ b/apps/viewer/src/components/viewer/ChatPanel.tsx
@@ -49,11 +49,14 @@ import type { ScriptDiagnostic } from '@/lib/llm/script-diagnostics';
 import { buildRepairSessionKey, getEscalatedRepairScope, pruneMessagesForRepair } from '@/lib/llm/repair-loop';
 import type { ChatMessage, ChatRepairRequest, FileAttachment } from '@/lib/llm/types';
 import { canUsePlainCodeBlockFallback, type ScriptMutationIntent } from '@/lib/llm/script-preservation';
-import { Check, Image as ImageIcon, Key, Eye, EyeOff, ExternalLink } from 'lucide-react';
+import { Check, Image as ImageIcon, KeyRound } from 'lucide-react';
 import { hasDesktopFeatureAccess } from '@/lib/desktop-product';
 import { getModelById } from '@/lib/llm/models';
 import { resolveStreamRoute } from '@/lib/llm/byok-guard';
-import { getApiKeys, updateApiKeys, hasAnthropicKey, hasOpenaiKey, subscribeApiKeys } from '@/services/api-keys';
+import { getApiKeys, hasAnthropicKey, hasOpenaiKey, subscribeApiKeys } from '@/services/api-keys';
+import { ByokKeyModal } from './chat/ByokKeyModal';
+import { ByokStreamingPill } from './chat/ByokStreamingPill';
+import type { BYOKProvider } from '@/lib/llm/clipboard-detect';
 import { useSandbox } from '@/hooks/useSandbox';
 
 // Environment variable for the proxy URL
@@ -246,6 +249,19 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
     return subscribeApiKeys(refresh);
   }, [setChatHasByokKey]);
 
+  // BYOK key modal — controlled state for both auto-open (on locked-model pick)
+  // and manual open via the header 🔑 button. `provider` selects the initial tab.
+  const [byokModal, setByokModal] = useState<{ open: boolean; provider: BYOKProvider }>({
+    open: false,
+    provider: 'anthropic',
+  });
+  const openByokModal = useCallback((provider: BYOKProvider) => {
+    setByokModal({ open: true, provider });
+  }, []);
+  const closeByokModal = useCallback(() => {
+    setByokModal((s) => ({ ...s, open: false }));
+  }, []);
+
   const displayUsage: UsageInfo | null = usage;
   const usageResetLabel = displayUsage?.resetAt && displayUsage.resetAt > 0
     ? new Date(displayUsage.resetAt * 1000).toLocaleDateString()
@@ -424,10 +440,9 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
     // doesn't stack orphaned user messages on repeated sends.
     const route = resolveStreamRoute(activeModel, getApiKeys());
     if (route.kind === 'missing-key') {
+      openByokModal(route.provider);
       setChatError(
-        route.provider === 'anthropic'
-          ? 'Enter your Anthropic API key above to use this model.'
-          : 'Enter your OpenAI API key above to use this model.',
+        `${route.provider === 'anthropic' ? 'Anthropic' : 'OpenAI'} key required for this model — set it up to continue.`,
       );
       return;
     }
@@ -1188,6 +1203,17 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
   const needsAnthropicKey = modelSource === 'anthropic' && !keyStateAnthropic;
   const needsOpenaiKey = modelSource === 'openai' && !keyStateOpenai;
   const needsByokKey = needsAnthropicKey || needsOpenaiKey;
+
+  // Auto-open the BYOK modal when the user picks a locked model. We only fire on
+  // the *transition* into needsByokKey so the modal doesn't keep popping back up
+  // after the user dismisses it without entering a key.
+  const prevNeedsByokRef = useRef(false);
+  useEffect(() => {
+    if (needsByokKey && !prevNeedsByokRef.current) {
+      openByokModal(needsAnthropicKey ? 'anthropic' : 'openai');
+    }
+    prevNeedsByokRef.current = needsByokKey;
+  }, [needsByokKey, needsAnthropicKey, openByokModal]);
   const showSupportEmail = Boolean(error && error.includes('louis@ltplus.com'));
   const canContinue = Boolean(
     !isActive && (streamingContent.trim().length > 0 || lastFinishReason === 'length'),
@@ -1227,7 +1253,24 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
         </Tooltip>
 
         <ModelSelector />
+        <ByokStreamingPill modelId={activeModel} className="ml-1" />
         <div className="flex-1" />
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              onClick={() => openByokModal(modelSource === 'openai' ? 'openai' : 'anthropic')}
+              className={keyStateAnthropic || keyStateOpenai ? 'text-emerald-500' : ''}
+            >
+              <KeyRound className="h-3.5 w-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            {keyStateAnthropic || keyStateOpenai ? 'Manage API keys' : 'Add API key for frontier models'}
+          </TooltipContent>
+        </Tooltip>
 
         <Tooltip>
           <TooltipTrigger asChild>
@@ -1256,9 +1299,20 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
         </div>
       )}
 
-      {/* Inline BYOK key prompt — shown when user picks a model without the matching key */}
-      {needsByokKey && canUseAiAssistant && (
-        <InlineKeyPrompt provider={needsAnthropicKey ? 'anthropic' : 'openai'} />
+      {/* Slim CTA banner — appears when the modal has been dismissed but the
+          selected model still needs a key. Re-opens the modal on click. */}
+      {needsByokKey && canUseAiAssistant && !byokModal.open && (
+        <button
+          type="button"
+          onClick={() => openByokModal(needsAnthropicKey ? 'anthropic' : 'openai')}
+          className="w-full border-b bg-amber-500/10 px-3 py-2 text-left text-xs hover:bg-amber-500/15 transition-colors flex items-center gap-2"
+        >
+          <KeyRound className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400" />
+          <span>
+            <strong>{needsAnthropicKey ? 'Anthropic' : 'OpenAI'} key needed</strong>{' '}
+            for this model — click to set it up
+          </span>
+        </button>
       )}
 
       {/* Clear confirmation */}
@@ -1449,7 +1503,7 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
             }}
             onKeyDown={handleKeyDown}
             onPaste={handlePaste}
-            placeholder={!canUseAiAssistant ? 'AI assistant not available' : needsByokKey ? `Enter your ${needsAnthropicKey ? 'Anthropic' : 'OpenAI'} API key above` : 'Ask anything...'}
+            placeholder={!canUseAiAssistant ? 'AI assistant not available' : needsByokKey ? `Add your ${needsAnthropicKey ? 'Anthropic' : 'OpenAI'} key to chat with this model` : 'Ask anything...'}
             rows={1}
             className="flex-1 resize-none rounded-md border border-input bg-background text-foreground placeholder:text-muted-foreground px-3 py-1.5 text-sm min-h-[32px] max-h-[120px] focus:outline-none focus:ring-1 focus:ring-ring"
             style={{ height: 'auto', overflow: 'hidden' }}
@@ -1517,90 +1571,12 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
           <span className="text-[10px] text-muted-foreground/30">⌘L</span>
         </div>
       </div>
-    </div>
-  );
-}
 
-// ── Inline BYOK key prompt (shown inside chat panel when key is missing) ──
-
-const PROVIDER_INFO = {
-  anthropic: {
-    label: 'Anthropic',
-    placeholder: 'sk-ant-api03-...',
-    url: 'https://console.anthropic.com/settings/keys',
-    urlLabel: 'console.anthropic.com',
-  },
-  openai: {
-    label: 'OpenAI',
-    placeholder: 'sk-...',
-    url: 'https://platform.openai.com/api-keys',
-    urlLabel: 'platform.openai.com',
-  },
-} as const;
-
-function InlineKeyPrompt({ provider }: { provider: 'anthropic' | 'openai' }) {
-  const [value, setValue] = useState('');
-  const [show, setShow] = useState(false);
-  const [saved, setSaved] = useState(false);
-  const info = PROVIDER_INFO[provider];
-
-  const handleSave = useCallback(() => {
-    const trimmed = value.trim();
-    if (!trimmed) return;
-    if (provider === 'anthropic') {
-      updateApiKeys({ anthropicKey: trimmed });
-    } else {
-      updateApiKeys({ openaiKey: trimmed });
-    }
-    setSaved(true);
-  }, [value, provider]);
-
-  // Brief success state before the parent unmounts this component
-  if (saved) {
-    return (
-      <div className="border-b bg-emerald-500/10 px-3 py-2 flex items-center gap-2 text-xs text-emerald-700 dark:text-emerald-400">
-        <Check className="h-3.5 w-3.5" />
-        <span>{info.label} key saved — ready to chat</span>
-      </div>
-    );
-  }
-
-  return (
-    <div className="border-b bg-muted/30 px-3 py-2.5 space-y-1.5">
-      <div className="flex items-center gap-1.5 text-xs font-medium">
-        <Key className="h-3.5 w-3.5" />
-        {info.label} API key required
-      </div>
-      <p className="text-[11px] text-muted-foreground">
-        Paste your key below — stored in your browser only, sent directly to {info.label}.{' '}
-        <a href={info.url} target="_blank" rel="noopener noreferrer" className="underline inline-flex items-center gap-0.5">
-          Get a key <ExternalLink className="h-2.5 w-2.5" />
-        </a>
-      </p>
-      <div className="flex gap-1.5">
-        <div className="relative flex-1">
-          <input
-            type={show ? 'text' : 'password'}
-            value={value}
-            onChange={(e) => setValue(e.target.value)}
-            onKeyDown={(e) => { if (e.key === 'Enter') handleSave(); }}
-            placeholder={info.placeholder}
-            autoComplete="off"
-            spellCheck={false}
-            className="w-full rounded border border-input bg-background px-2 py-1 text-xs font-mono focus:outline-none focus:ring-1 focus:ring-ring pr-7"
-          />
-          <button
-            type="button"
-            onClick={() => setShow(!show)}
-            className="absolute right-1.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-          >
-            {show ? <EyeOff className="h-3 w-3" /> : <Eye className="h-3 w-3" />}
-          </button>
-        </div>
-        <Button size="sm" className="h-7 px-3 text-xs" onClick={handleSave} disabled={!value.trim()}>
-          Save
-        </Button>
-      </div>
+      <ByokKeyModal
+        open={byokModal.open}
+        onOpenChange={(open) => (open ? openByokModal(byokModal.provider) : closeByokModal())}
+        initialProvider={byokModal.provider}
+      />
     </div>
   );
 }

--- a/apps/viewer/src/components/viewer/ChatPanel.tsx
+++ b/apps/viewer/src/components/viewer/ChatPanel.tsx
@@ -1269,6 +1269,7 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
               size="icon-xs"
               onClick={() => openByokModal(modelSource === 'openai' ? 'openai' : 'anthropic')}
               className={keyStateAnthropic || keyStateOpenai ? 'text-emerald-500' : ''}
+              aria-label={keyStateAnthropic || keyStateOpenai ? 'Manage API keys' : 'Add API key for frontier models'}
             >
               <KeyRound className="h-3.5 w-3.5" />
             </Button>

--- a/apps/viewer/src/components/viewer/ChatPanel.tsx
+++ b/apps/viewer/src/components/viewer/ChatPanel.tsx
@@ -262,7 +262,13 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
     setByokModal((s) => ({ ...s, open: false }));
   }, []);
 
-  const displayUsage: UsageInfo | null = usage;
+  // The usage indicator tracks the free-tier proxy quota we enforce server-side.
+  // BYOK routes go directly from the browser to the provider, so the user's
+  // own provider account is what gates them — our quota doesn't apply, and
+  // showing it here is misleading. Hide it whenever the active model is
+  // direct-to-provider.
+  const activeModelSource = getModelById(activeModel)?.source ?? 'proxy';
+  const displayUsage: UsageInfo | null = activeModelSource === 'proxy' ? usage : null;
   const usageResetLabel = displayUsage?.resetAt && displayUsage.resetAt > 0
     ? new Date(displayUsage.resetAt * 1000).toLocaleDateString()
     : '—';

--- a/apps/viewer/src/components/viewer/chat/ByokKeyModal.tsx
+++ b/apps/viewer/src/components/viewer/chat/ByokKeyModal.tsx
@@ -1,0 +1,356 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Trust-focused BYOK API key entry modal.
+ *
+ * Replaces the inline password-style strip in ChatPanel. Renders one tab per
+ * supported provider; each tab pairs the request-flow SVG with concrete,
+ * DevTools-verifiable trust claims, a clipboard-detect shortcut, and an
+ * "Open Console → Create Key → return" walkthrough.
+ *
+ * The web build ships this. Desktop also uses it (the /settings page is
+ * desktop-only and not deployed on Vercel).
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Check, ChevronDown, ChevronUp, ClipboardPaste, ExternalLink, Eye, EyeOff, Key, Trash2 } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { toast } from '@/components/ui/toast';
+import { ByokTrustDiagram } from './ByokTrustDiagram';
+import { getByokModelsForSource } from '@/lib/llm/models';
+import {
+  getApiKeys,
+  updateApiKeys,
+  subscribeApiKeys,
+  type ApiKeyConfig,
+} from '@/services/api-keys';
+import {
+  looksLikeProviderKey,
+  maskKey,
+  readClipboardKey,
+  type BYOKProvider,
+} from '@/lib/llm/clipboard-detect';
+
+const REPO_BLOB = 'https://github.com/louistrue/ifc-lite/blob/main';
+
+const PROVIDER_META: Record<BYOKProvider, {
+  label: string;
+  apiHost: string;
+  keyPrefix: string;
+  placeholder: string;
+  consoleUrl: string;
+  consoleLabel: string;
+  pricingHint: string;
+}> = {
+  anthropic: {
+    label: 'Anthropic',
+    apiHost: 'api.anthropic.com',
+    keyPrefix: 'sk-ant-api03-',
+    placeholder: 'sk-ant-api03-...',
+    consoleUrl: 'https://console.anthropic.com/settings/keys',
+    consoleLabel: 'console.anthropic.com',
+    pricingHint: 'Pay-as-you-go on Anthropic billing. New accounts get $5 free credit.',
+  },
+  openai: {
+    label: 'OpenAI',
+    apiHost: 'api.openai.com',
+    keyPrefix: 'sk-',
+    placeholder: 'sk-...',
+    consoleUrl: 'https://platform.openai.com/api-keys',
+    consoleLabel: 'platform.openai.com',
+    pricingHint: 'OpenAI requires prepaid credits or a payment method on your OpenAI account.',
+  },
+};
+
+interface ByokKeyModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  initialProvider?: BYOKProvider;
+}
+
+export function ByokKeyModal({ open, onOpenChange, initialProvider = 'anthropic' }: ByokKeyModalProps) {
+  const [provider, setProvider] = useState<BYOKProvider>(initialProvider);
+  const [apiKeys, setApiKeys] = useState<ApiKeyConfig>(() => getApiKeys());
+
+  // Re-sync the controlled tab whenever the modal re-opens with a (possibly new) initial provider.
+  useEffect(() => {
+    if (open) setProvider(initialProvider);
+  }, [open, initialProvider]);
+
+  // Keep saved-state badges in sync across open/save/clear.
+  useEffect(() => {
+    setApiKeys(getApiKeys());
+    return subscribeApiKeys(() => setApiKeys(getApiKeys()));
+  }, []);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Key className="h-4 w-4" />
+            Use your own API key
+          </DialogTitle>
+          <DialogDescription>
+            Unlocks frontier models. Your key stays in this browser and goes
+            straight to the provider — never through our servers.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Tabs value={provider} onValueChange={(v) => setProvider(v as BYOKProvider)}>
+          <TabsList className="grid w-full grid-cols-2">
+            <TabsTrigger value="anthropic" className="flex items-center gap-1.5">
+              Anthropic
+              {apiKeys.anthropicKey && <Check className="h-3 w-3 text-emerald-500" />}
+            </TabsTrigger>
+            <TabsTrigger value="openai" className="flex items-center gap-1.5">
+              OpenAI
+              {apiKeys.openaiKey && <Check className="h-3 w-3 text-emerald-500" />}
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="anthropic" className="mt-4">
+            <ProviderTab provider="anthropic" savedKey={apiKeys.anthropicKey} />
+          </TabsContent>
+          <TabsContent value="openai" className="mt-4">
+            <ProviderTab provider="openai" savedKey={apiKeys.openaiKey} />
+          </TabsContent>
+        </Tabs>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Per-provider tab body ──────────────────────────────────────────────────
+
+function ProviderTab({ provider, savedKey }: { provider: BYOKProvider; savedKey: string }) {
+  const meta = PROVIDER_META[provider];
+
+  const [value, setValue] = useState('');
+  const [show, setShow] = useState(false);
+  const [clipboardCandidate, setClipboardCandidate] = useState<string | null>(null);
+  const [walkthroughOpen, setWalkthroughOpen] = useState(false);
+  // Set when the user clicks "Open Console" so we re-poll the clipboard on tab return.
+  const [awaitingClipboard, setAwaitingClipboard] = useState(false);
+
+  const unlockedModels = useMemo(() => getByokModelsForSource(provider), [provider]);
+
+  // First-chance clipboard check on mount of this tab.
+  useEffect(() => {
+    let cancelled = false;
+    void readClipboardKey(provider).then((match) => {
+      if (!cancelled && match && match !== savedKey) setClipboardCandidate(match);
+    });
+    return () => { cancelled = true; };
+  }, [provider, savedKey]);
+
+  // Re-check the clipboard whenever the user returns to this tab — typically
+  // after they clicked "Open Console", made a key, and came back.
+  useEffect(() => {
+    if (!awaitingClipboard) return;
+    const onVisible = () => {
+      if (document.visibilityState !== 'visible') return;
+      void readClipboardKey(provider).then((match) => {
+        if (match && match !== savedKey) {
+          setClipboardCandidate(match);
+          setAwaitingClipboard(false);
+        }
+      });
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    window.addEventListener('focus', onVisible);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisible);
+      window.removeEventListener('focus', onVisible);
+    };
+  }, [awaitingClipboard, provider, savedKey]);
+
+  const handleSave = useCallback((next: string) => {
+    const trimmed = next.trim();
+    if (!trimmed) return;
+    const field = provider === 'anthropic' ? 'anthropicKey' : 'openaiKey';
+    updateApiKeys({ [field]: trimmed });
+    setValue('');
+    setClipboardCandidate(null);
+    toast.success(`${PROVIDER_META[provider].label} key saved`);
+  }, [provider]);
+
+  const handleClear = useCallback(() => {
+    const field = provider === 'anthropic' ? 'anthropicKey' : 'openaiKey';
+    updateApiKeys({ [field]: '' });
+    toast.success(`${PROVIDER_META[provider].label} key removed`);
+  }, [provider]);
+
+  const handleOpenConsole = useCallback(() => {
+    setAwaitingClipboard(true);
+    window.open(meta.consoleUrl, '_blank', 'noopener,noreferrer');
+  }, [meta.consoleUrl]);
+
+  const inputIsValid = value.trim().length === 0 || looksLikeProviderKey(provider, value);
+
+  return (
+    <div className="space-y-4">
+      {/* Models unlocked */}
+      <div className="flex flex-wrap items-center gap-1.5">
+        <span className="text-xs text-muted-foreground">Unlocks:</span>
+        {unlockedModels.map((m) => (
+          <Badge key={m.id} variant="outline" className="text-[10px] font-mono">
+            {m.name}
+          </Badge>
+        ))}
+      </div>
+
+      {/* The diagram — single most important trust element */}
+      <div className="rounded-lg border bg-card/40 p-4">
+        <ByokTrustDiagram apiHost={meta.apiHost} />
+      </div>
+
+      {/* DevTools-verifiable trust claims */}
+      <ul className="space-y-2 text-xs">
+        <TrustBullet>
+          Key stored only in this browser&apos;s <code className="bg-muted px-1 rounded">localStorage</code>.{' '}
+          Inspect any time in DevTools.
+        </TrustBullet>
+        <TrustBullet>
+          Every request goes to <code className="bg-muted px-1 rounded">{meta.apiHost}</code>. Verify in DevTools →
+          Network → filter <code className="bg-muted px-1 rounded">{meta.apiHost.split('.').slice(-2).join('.')}</code>.
+        </TrustBullet>
+        <TrustBullet>
+          The whole BYOK code path is ~60 lines.{' '}
+          <a
+            href={`${REPO_BLOB}/apps/viewer/src/lib/llm/stream-direct.ts`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline inline-flex items-center gap-0.5 hover:text-foreground"
+          >
+            Read it on GitHub <ExternalLink className="h-2.5 w-2.5" />
+          </a>
+        </TrustBullet>
+      </ul>
+
+      {/* Clipboard candidate — the friction killer */}
+      {clipboardCandidate && (
+        <div className="rounded-md border border-emerald-500/40 bg-emerald-500/10 p-3 flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2 text-xs">
+            <ClipboardPaste className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400" />
+            <span>
+              {meta.label} key on your clipboard:{' '}
+              <code className="font-mono">{maskKey(clipboardCandidate)}</code>
+            </span>
+          </div>
+          <Button size="sm" className="h-7 px-3 text-xs" onClick={() => handleSave(clipboardCandidate)}>
+            Use it
+          </Button>
+        </div>
+      )}
+
+      {/* Manual paste */}
+      <div className="space-y-1.5">
+        <label className="text-xs font-medium" htmlFor={`byok-${provider}-input`}>
+          {savedKey ? 'Replace existing key' : 'Or paste manually'}
+        </label>
+        <div className="flex gap-2">
+          <div className="relative flex-1">
+            <input
+              id={`byok-${provider}-input`}
+              type={show ? 'text' : 'password'}
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter' && inputIsValid) handleSave(value); }}
+              placeholder={meta.placeholder}
+              autoComplete="off"
+              spellCheck={false}
+              className="w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm font-mono focus:outline-none focus:ring-1 focus:ring-ring pr-8"
+            />
+            <button
+              type="button"
+              onClick={() => setShow(!show)}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              aria-label={show ? 'Hide key' : 'Show key'}
+            >
+              {show ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+            </button>
+          </div>
+          <Button size="sm" onClick={() => handleSave(value)} disabled={!inputIsValid || value.trim().length === 0}>
+            Save
+          </Button>
+        </div>
+        {!inputIsValid && (
+          <p className="text-[11px] text-destructive">
+            That doesn&apos;t look like a {meta.label} key (expected prefix{' '}
+            <code className="font-mono">{meta.keyPrefix}</code>).
+          </p>
+        )}
+      </div>
+
+      {/* Currently configured key + remove */}
+      {savedKey && (
+        <div className="flex items-center justify-between gap-3 rounded-md border p-3 text-xs">
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <Check className="h-3.5 w-3.5 text-emerald-500" />
+            Configured: <code className="font-mono text-foreground">{maskKey(savedKey)}</code>
+          </div>
+          <Button variant="ghost" size="sm" className="h-7 px-2 text-xs" onClick={handleClear}>
+            <Trash2 className="mr-1 h-3 w-3" />
+            Remove
+          </Button>
+        </div>
+      )}
+
+      {/* Walkthrough */}
+      <div className="rounded-md border bg-muted/20">
+        <button
+          type="button"
+          onClick={() => setWalkthroughOpen((v) => !v)}
+          className="w-full flex items-center justify-between gap-2 p-3 text-xs hover:bg-muted/30 transition-colors"
+        >
+          <span className="font-medium">Don&apos;t have a key? 60-second walkthrough</span>
+          {walkthroughOpen ? <ChevronUp className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
+        </button>
+        {walkthroughOpen && (
+          <div className="border-t p-3 space-y-2.5 text-xs">
+            <ol className="space-y-2 list-decimal list-inside text-muted-foreground">
+              <li>
+                Open the {meta.label} console — we&apos;ll watch for the key on your clipboard when you return.
+              </li>
+              <li>
+                Click <strong>Create Key</strong>, name it <code className="bg-muted px-1 rounded">ifc-lite</code>.
+              </li>
+              <li>
+                Set a spending limit (e.g.&nbsp;$10/month) so a leaked key can&apos;t burn you. The provider enforces it.
+              </li>
+              <li>
+                Copy the key, return here — we&apos;ll detect it automatically.
+              </li>
+            </ol>
+            <p className="text-[11px] text-muted-foreground/80">{meta.pricingHint}</p>
+            <Button size="sm" variant="outline" className="text-xs" onClick={handleOpenConsole}>
+              <ExternalLink className="mr-1.5 h-3 w-3" />
+              Open {meta.consoleLabel}
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TrustBullet({ children }: { children: React.ReactNode }) {
+  return (
+    <li className="flex items-start gap-2 text-muted-foreground">
+      <Check className="h-3.5 w-3.5 mt-0.5 flex-shrink-0 text-emerald-500" />
+      <span>{children}</span>
+    </li>
+  );
+}

--- a/apps/viewer/src/components/viewer/chat/ByokKeyModal.tsx
+++ b/apps/viewer/src/components/viewer/chat/ByokKeyModal.tsx
@@ -293,13 +293,15 @@ function ProviderTab({ provider, savedKey }: { provider: BYOKProvider; savedKey:
         <button
           type="button"
           onClick={() => setWalkthroughOpen((v) => !v)}
+          aria-expanded={walkthroughOpen}
+          aria-controls={`byok-walkthrough-${provider}`}
           className="w-full flex items-center justify-between gap-2 p-3 text-xs hover:bg-muted/30 transition-colors"
         >
           <span className="font-medium">Don&apos;t have a key? 60-second walkthrough</span>
           {walkthroughOpen ? <ChevronUp className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
         </button>
         {walkthroughOpen && (
-          <div className="border-t p-3 space-y-2.5 text-xs">
+          <div id={`byok-walkthrough-${provider}`} className="border-t p-3 space-y-2.5 text-xs">
             <ol className="space-y-2 list-decimal list-inside text-muted-foreground">
               <li>
                 Open the {meta.label} console — opens in a new tab.

--- a/apps/viewer/src/components/viewer/chat/ByokKeyModal.tsx
+++ b/apps/viewer/src/components/viewer/chat/ByokKeyModal.tsx
@@ -110,11 +110,17 @@ export function ByokKeyModal({ open, onOpenChange, initialProvider = 'anthropic'
 
         <Tabs value={provider} onValueChange={(v) => setProvider(v as BYOKProvider)}>
           <TabsList className="grid w-full grid-cols-2">
-            <TabsTrigger value="anthropic" className="flex items-center gap-1.5">
+            <TabsTrigger
+              value="anthropic"
+              className="flex items-center gap-1.5 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm data-[state=active]:font-semibold"
+            >
               Anthropic
               {apiKeys.anthropicKey && <Check className="h-3 w-3 text-emerald-500" />}
             </TabsTrigger>
-            <TabsTrigger value="openai" className="flex items-center gap-1.5">
+            <TabsTrigger
+              value="openai"
+              className="flex items-center gap-1.5 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm data-[state=active]:font-semibold"
+            >
               OpenAI
               {apiKeys.openaiKey && <Check className="h-3 w-3 text-emerald-500" />}
             </TabsTrigger>
@@ -146,17 +152,17 @@ function ProviderTab({ provider, savedKey }: { provider: BYOKProvider; savedKey:
 
   const unlockedModels = useMemo(() => getByokModelsForSource(provider), [provider]);
 
-  // First-chance clipboard check on mount of this tab.
-  useEffect(() => {
-    let cancelled = false;
-    void readClipboardKey(provider).then((match) => {
-      if (!cancelled && match && match !== savedKey) setClipboardCandidate(match);
-    });
-    return () => { cancelled = true; };
-  }, [provider, savedKey]);
-
-  // Re-check the clipboard whenever the user returns to this tab — typically
-  // after they clicked "Open Console", made a key, and came back.
+  // NOTE: we deliberately do NOT call `readClipboardKey` on mount or tab switch.
+  // On macOS Chromium, a background `clipboard.readText()` triggers the native
+  // "Paste" affordance even when no user gesture is in play — surprising users
+  // with an OS prompt the moment they open the modal.
+  //
+  // Instead, clipboard detection runs in three explicit, user-gestured paths:
+  //   1. user pastes into the input (handled by the onPaste handler below)
+  //   2. user clicks the "Detect from clipboard" button (also below)
+  //   3. user returns from "Open Console" — we armed `awaitingClipboard` on
+  //      that click, so the visibilitychange/focus listener below is allowed
+  //      to call readText() with the expectation set by the walkthrough.
   useEffect(() => {
     if (!awaitingClipboard) return;
     const onVisible = () => {
@@ -196,6 +202,31 @@ function ProviderTab({ provider, savedKey }: { provider: BYOKProvider; savedKey:
     setAwaitingClipboard(true);
     window.open(meta.consoleUrl, '_blank', 'noopener,noreferrer');
   }, [meta.consoleUrl]);
+
+  // Paste into the input → if the pasted text matches the provider shape, we
+  // promote it to the "Use it" candidate banner so the user is one click away
+  // (instead of two: paste, then click Save). For non-matching content we let
+  // the normal paste behaviour happen so the input still works as expected.
+  const handlePaste = useCallback((e: React.ClipboardEvent<HTMLInputElement>) => {
+    const pasted = e.clipboardData.getData('text').trim();
+    if (looksLikeProviderKey(provider, pasted) && pasted !== savedKey) {
+      e.preventDefault();
+      setValue('');
+      setClipboardCandidate(pasted);
+    }
+  }, [provider, savedKey]);
+
+  // Explicit "Detect from clipboard" — the button click is a fresh user gesture,
+  // so the OS paste prompt that may appear on macOS Chromium is expected by the
+  // user rather than surprise-shown on mount.
+  const handleManualClipboardCheck = useCallback(async () => {
+    const match = await readClipboardKey(provider);
+    if (match && match !== savedKey) {
+      setClipboardCandidate(match);
+    } else {
+      toast.info(`No ${meta.label} key found on clipboard`);
+    }
+  }, [provider, savedKey, meta.label]);
 
   const inputIsValid = value.trim().length === 0 || looksLikeProviderKey(provider, value);
 
@@ -257,9 +288,20 @@ function ProviderTab({ provider, savedKey }: { provider: BYOKProvider; savedKey:
 
       {/* Manual paste */}
       <div className="space-y-1.5">
-        <label className="text-xs font-medium" htmlFor={`byok-${provider}-input`}>
-          {savedKey ? 'Replace existing key' : 'Or paste manually'}
-        </label>
+        <div className="flex items-center justify-between gap-2">
+          <label className="text-xs font-medium" htmlFor={`byok-${provider}-input`}>
+            {savedKey ? 'Replace existing key' : 'Paste your key'}
+          </label>
+          <button
+            type="button"
+            onClick={handleManualClipboardCheck}
+            className="text-[11px] text-muted-foreground hover:text-foreground inline-flex items-center gap-1 transition-colors"
+            title={`Read clipboard and detect a ${meta.label} key`}
+          >
+            <ClipboardPaste className="h-3 w-3" />
+            Detect from clipboard
+          </button>
+        </div>
         <div className="flex gap-2">
           <div className="relative flex-1">
             <input
@@ -267,6 +309,7 @@ function ProviderTab({ provider, savedKey }: { provider: BYOKProvider; savedKey:
               type={show ? 'text' : 'password'}
               value={value}
               onChange={(e) => setValue(e.target.value)}
+              onPaste={handlePaste}
               onKeyDown={(e) => { if (e.key === 'Enter' && inputIsValid) handleSave(value); }}
               placeholder={meta.placeholder}
               autoComplete="off"

--- a/apps/viewer/src/components/viewer/chat/ByokKeyModal.tsx
+++ b/apps/viewer/src/components/viewer/chat/ByokKeyModal.tsx
@@ -7,15 +7,23 @@
  *
  * Replaces the inline password-style strip in ChatPanel. Renders one tab per
  * supported provider; each tab pairs the request-flow SVG with concrete,
- * DevTools-verifiable trust claims, a clipboard-detect shortcut, and an
- * "Open Console → Create Key → return" walkthrough.
+ * DevTools-verifiable trust claims and an "Open Console → Create Key →
+ * paste here" walkthrough.
+ *
+ * Clipboard handling: we deliberately do NOT do background `clipboard.readText()`
+ * polling. Modern browsers gate that behind either transient user activation
+ * or an explicit clipboard-read permission we can't request a prompt for —
+ * and on macOS Chromium, every silent read triggers the native Paste affordance
+ * even though we silently swallow the result. Instead, the input is autofocused
+ * on open so the user's Cmd+V lands directly in the field, and a green inline
+ * confirmation appears the moment the pasted value matches the provider shape.
  *
  * The web build ships this. Desktop also uses it (the /settings page is
  * desktop-only and not deployed on Vercel).
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Check, ChevronDown, ChevronUp, ClipboardPaste, ExternalLink, Eye, EyeOff, Key, Trash2 } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Check, ChevronDown, ChevronUp, ExternalLink, Eye, EyeOff, Key, Trash2 } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -38,7 +46,6 @@ import {
 import {
   looksLikeProviderKey,
   maskKey,
-  readClipboardKey,
   type BYOKProvider,
 } from '@/lib/llm/clipboard-detect';
 
@@ -145,42 +152,16 @@ function ProviderTab({ provider, savedKey }: { provider: BYOKProvider; savedKey:
 
   const [value, setValue] = useState('');
   const [show, setShow] = useState(false);
-  const [clipboardCandidate, setClipboardCandidate] = useState<string | null>(null);
   const [walkthroughOpen, setWalkthroughOpen] = useState(false);
-  // Set when the user clicks "Open Console" so we re-poll the clipboard on tab return.
-  const [awaitingClipboard, setAwaitingClipboard] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const unlockedModels = useMemo(() => getByokModelsForSource(provider), [provider]);
 
-  // NOTE: we deliberately do NOT call `readClipboardKey` on mount or tab switch.
-  // On macOS Chromium, a background `clipboard.readText()` triggers the native
-  // "Paste" affordance even when no user gesture is in play — surprising users
-  // with an OS prompt the moment they open the modal.
-  //
-  // Instead, clipboard detection runs in three explicit, user-gestured paths:
-  //   1. user pastes into the input (handled by the onPaste handler below)
-  //   2. user clicks the "Detect from clipboard" button (also below)
-  //   3. user returns from "Open Console" — we armed `awaitingClipboard` on
-  //      that click, so the visibilitychange/focus listener below is allowed
-  //      to call readText() with the expectation set by the walkthrough.
+  // Autofocus the input so the user's Cmd+V lands directly in the field
+  // without an extra click. Re-runs on tab switch.
   useEffect(() => {
-    if (!awaitingClipboard) return;
-    const onVisible = () => {
-      if (document.visibilityState !== 'visible') return;
-      void readClipboardKey(provider).then((match) => {
-        if (match && match !== savedKey) {
-          setClipboardCandidate(match);
-          setAwaitingClipboard(false);
-        }
-      });
-    };
-    document.addEventListener('visibilitychange', onVisible);
-    window.addEventListener('focus', onVisible);
-    return () => {
-      document.removeEventListener('visibilitychange', onVisible);
-      window.removeEventListener('focus', onVisible);
-    };
-  }, [awaitingClipboard, provider, savedKey]);
+    inputRef.current?.focus();
+  }, [provider]);
 
   const handleSave = useCallback((next: string) => {
     const trimmed = next.trim();
@@ -188,7 +169,6 @@ function ProviderTab({ provider, savedKey }: { provider: BYOKProvider; savedKey:
     const field = provider === 'anthropic' ? 'anthropicKey' : 'openaiKey';
     updateApiKeys({ [field]: trimmed });
     setValue('');
-    setClipboardCandidate(null);
     toast.success(`${PROVIDER_META[provider].label} key saved`);
   }, [provider]);
 
@@ -199,36 +179,12 @@ function ProviderTab({ provider, savedKey }: { provider: BYOKProvider; savedKey:
   }, [provider]);
 
   const handleOpenConsole = useCallback(() => {
-    setAwaitingClipboard(true);
     window.open(meta.consoleUrl, '_blank', 'noopener,noreferrer');
   }, [meta.consoleUrl]);
 
-  // Paste into the input → if the pasted text matches the provider shape, we
-  // promote it to the "Use it" candidate banner so the user is one click away
-  // (instead of two: paste, then click Save). For non-matching content we let
-  // the normal paste behaviour happen so the input still works as expected.
-  const handlePaste = useCallback((e: React.ClipboardEvent<HTMLInputElement>) => {
-    const pasted = e.clipboardData.getData('text').trim();
-    if (looksLikeProviderKey(provider, pasted) && pasted !== savedKey) {
-      e.preventDefault();
-      setValue('');
-      setClipboardCandidate(pasted);
-    }
-  }, [provider, savedKey]);
-
-  // Explicit "Detect from clipboard" — the button click is a fresh user gesture,
-  // so the OS paste prompt that may appear on macOS Chromium is expected by the
-  // user rather than surprise-shown on mount.
-  const handleManualClipboardCheck = useCallback(async () => {
-    const match = await readClipboardKey(provider);
-    if (match && match !== savedKey) {
-      setClipboardCandidate(match);
-    } else {
-      toast.info(`No ${meta.label} key found on clipboard`);
-    }
-  }, [provider, savedKey, meta.label]);
-
-  const inputIsValid = value.trim().length === 0 || looksLikeProviderKey(provider, value);
+  const trimmedValue = value.trim();
+  const inputIsValid = trimmedValue.length === 0 || looksLikeProviderKey(provider, value);
+  const inputLooksGood = trimmedValue.length > 0 && looksLikeProviderKey(provider, value) && trimmedValue !== savedKey;
 
   return (
     <div className="space-y-4">
@@ -270,46 +226,21 @@ function ProviderTab({ provider, savedKey }: { provider: BYOKProvider; savedKey:
         </TrustBullet>
       </ul>
 
-      {/* Clipboard candidate — the friction killer */}
-      {clipboardCandidate && (
-        <div className="rounded-md border border-emerald-500/40 bg-emerald-500/10 p-3 flex items-center justify-between gap-3">
-          <div className="flex items-center gap-2 text-xs">
-            <ClipboardPaste className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400" />
-            <span>
-              {meta.label} key on your clipboard:{' '}
-              <code className="font-mono">{maskKey(clipboardCandidate)}</code>
-            </span>
-          </div>
-          <Button size="sm" className="h-7 px-3 text-xs" onClick={() => handleSave(clipboardCandidate)}>
-            Use it
-          </Button>
-        </div>
-      )}
-
-      {/* Manual paste */}
+      {/* Paste-driven key entry. The input is autofocused on mount so Cmd+V
+          lands here immediately after the user returns from the provider
+          console — no extra click required. */}
       <div className="space-y-1.5">
-        <div className="flex items-center justify-between gap-2">
-          <label className="text-xs font-medium" htmlFor={`byok-${provider}-input`}>
-            {savedKey ? 'Replace existing key' : 'Paste your key'}
-          </label>
-          <button
-            type="button"
-            onClick={handleManualClipboardCheck}
-            className="text-[11px] text-muted-foreground hover:text-foreground inline-flex items-center gap-1 transition-colors"
-            title={`Read clipboard and detect a ${meta.label} key`}
-          >
-            <ClipboardPaste className="h-3 w-3" />
-            Detect from clipboard
-          </button>
-        </div>
+        <label className="text-xs font-medium" htmlFor={`byok-${provider}-input`}>
+          {savedKey ? 'Replace existing key' : 'Paste your key'}
+        </label>
         <div className="flex gap-2">
           <div className="relative flex-1">
             <input
+              ref={inputRef}
               id={`byok-${provider}-input`}
               type={show ? 'text' : 'password'}
               value={value}
               onChange={(e) => setValue(e.target.value)}
-              onPaste={handlePaste}
               onKeyDown={(e) => { if (e.key === 'Enter' && inputIsValid) handleSave(value); }}
               placeholder={meta.placeholder}
               autoComplete="off"
@@ -325,10 +256,16 @@ function ProviderTab({ provider, savedKey }: { provider: BYOKProvider; savedKey:
               {show ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
             </button>
           </div>
-          <Button size="sm" onClick={() => handleSave(value)} disabled={!inputIsValid || value.trim().length === 0}>
+          <Button size="sm" onClick={() => handleSave(value)} disabled={!inputIsValid || trimmedValue.length === 0}>
             Save
           </Button>
         </div>
+        {inputLooksGood && (
+          <p className="text-[11px] text-emerald-600 dark:text-emerald-400 flex items-center gap-1">
+            <Check className="h-3 w-3" />
+            Looks like a {meta.label} key (<code className="font-mono">{maskKey(trimmedValue)}</code>) — press Enter or Save.
+          </p>
+        )}
         {!inputIsValid && (
           <p className="text-[11px] text-destructive">
             That doesn&apos;t look like a {meta.label} key (expected prefix{' '}
@@ -365,7 +302,7 @@ function ProviderTab({ provider, savedKey }: { provider: BYOKProvider; savedKey:
           <div className="border-t p-3 space-y-2.5 text-xs">
             <ol className="space-y-2 list-decimal list-inside text-muted-foreground">
               <li>
-                Open the {meta.label} console — we&apos;ll watch for the key on your clipboard when you return.
+                Open the {meta.label} console — opens in a new tab.
               </li>
               <li>
                 Click <strong>Create Key</strong>, name it <code className="bg-muted px-1 rounded">ifc-lite</code>.
@@ -374,7 +311,7 @@ function ProviderTab({ provider, savedKey }: { provider: BYOKProvider; savedKey:
                 Set a spending limit (e.g.&nbsp;$10/month) so a leaked key can&apos;t burn you. The provider enforces it.
               </li>
               <li>
-                Copy the key, return here — we&apos;ll detect it automatically.
+                Copy the key, come back here, paste it into the input above (the field is already focused — just press <code className="bg-muted px-1 rounded">⌘V</code>).
               </li>
             </ol>
             <p className="text-[11px] text-muted-foreground/80">{meta.pricingHint}</p>

--- a/apps/viewer/src/components/viewer/chat/ByokStreamingPill.tsx
+++ b/apps/viewer/src/components/viewer/chat/ByokStreamingPill.tsx
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Trust pill — small badge sitting near the model name in the chat header
+ * that names the actual API host requests are going to when a BYOK route is
+ * active. Always-on for BYOK models (not just during streaming) so users can
+ * see at a glance where their data is going, without having to open DevTools.
+ *
+ * Returns null for proxy/free routes — the pill is a BYOK-specific trust
+ * signal; we don't need a "→ our proxy" pill cluttering the UI for the
+ * default tier.
+ */
+
+import { useEffect, useState } from 'react';
+import { Lock } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { resolveStreamRoute } from '@/lib/llm/byok-guard';
+import { getApiKeys, subscribeApiKeys, type ApiKeyConfig } from '@/services/api-keys';
+
+interface ByokStreamingPillProps {
+  modelId: string;
+  className?: string;
+}
+
+export function ByokStreamingPill({ modelId, className }: ByokStreamingPillProps) {
+  const [apiKeys, setApiKeys] = useState<ApiKeyConfig>(() => getApiKeys());
+  useEffect(() => subscribeApiKeys(() => setApiKeys(getApiKeys())), []);
+
+  const route = resolveStreamRoute(modelId, apiKeys);
+  if (route.kind !== 'anthropic' && route.kind !== 'openai') return null;
+
+  const host = route.kind === 'anthropic' ? 'api.anthropic.com' : 'api.openai.com';
+  const filterToken = route.kind === 'anthropic' ? 'anthropic.com' : 'openai.com';
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className={cn(
+            'inline-flex items-center gap-1 rounded-full border border-emerald-500/40 bg-emerald-500/10 px-1.5 py-0.5 text-[10px] font-mono text-emerald-700 dark:text-emerald-400',
+            className,
+          )}
+        >
+          <Lock className="h-2.5 w-2.5" />
+          → {host}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-xs text-xs leading-relaxed">
+        Messages from this model go directly from your browser to{' '}
+        <code className="font-mono">{host}</code>. To verify, open DevTools →
+        Network and filter <code className="font-mono">{filterToken}</code>.
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/viewer/src/components/viewer/chat/ByokStreamingPill.tsx
+++ b/apps/viewer/src/components/viewer/chat/ByokStreamingPill.tsx
@@ -37,25 +37,25 @@ export function ByokStreamingPill({ modelId, className }: ByokStreamingPillProps
   if (route.kind !== 'anthropic' && route.kind !== 'openai') return null;
 
   const host = route.kind === 'anthropic' ? 'api.anthropic.com' : 'api.openai.com';
-  const filterToken = route.kind === 'anthropic' ? 'anthropic.com' : 'openai.com';
+  const shortHost = route.kind === 'anthropic' ? 'anthropic.com' : 'openai.com';
 
   return (
     <Tooltip>
       <TooltipTrigger asChild>
         <span
           className={cn(
-            'inline-flex items-center gap-1 rounded-full border border-emerald-500/40 bg-emerald-500/10 px-1.5 py-0.5 text-[10px] font-mono text-emerald-700 dark:text-emerald-400',
+            'inline-flex shrink-0 items-center gap-1 rounded-full border border-emerald-500/40 bg-emerald-500/10 px-1.5 py-0.5 text-[10px] font-mono text-emerald-700 dark:text-emerald-400',
             className,
           )}
         >
           <Lock className="h-2.5 w-2.5" />
-          → {host}
+          {shortHost}
         </span>
       </TooltipTrigger>
       <TooltipContent className="max-w-xs text-xs leading-relaxed">
         Messages from this model go directly from your browser to{' '}
         <code className="font-mono">{host}</code>. To verify, open DevTools →
-        Network and filter <code className="font-mono">{filterToken}</code>.
+        Network and filter <code className="font-mono">{shortHost}</code>.
       </TooltipContent>
     </Tooltip>
   );

--- a/apps/viewer/src/components/viewer/chat/ByokTrustDiagram.tsx
+++ b/apps/viewer/src/components/viewer/chat/ByokTrustDiagram.tsx
@@ -1,0 +1,192 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Visual proof of where the API key (and chat content) goes when a BYOK model
+ * is in use. Two stacked paths:
+ *   row 1 (active)    browser ────► api.provider.com
+ *   row 2 (blocked)   browser ─► our server ─► api.provider.com    (struck out)
+ *
+ * The shape of the diagram is the same for every provider — only the API host
+ * label rotates. Renders crisply in light and dark mode via Tailwind utility
+ * classes.
+ */
+
+interface ByokTrustDiagramProps {
+  apiHost: string;
+}
+
+export function ByokTrustDiagram({ apiHost }: ByokTrustDiagramProps) {
+  return (
+    <svg
+      viewBox="0 0 520 200"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label={`Diagram: requests go directly from your browser to ${apiHost}, not via our server.`}
+      className="w-full h-auto"
+    >
+      <defs>
+        <marker
+          id="byok-arrow-active"
+          viewBox="0 0 10 10"
+          refX="9"
+          refY="5"
+          markerUnits="strokeWidth"
+          markerWidth="8"
+          markerHeight="8"
+          orient="auto"
+        >
+          <path d="M 0 0 L 10 5 L 0 10 z" className="fill-emerald-500" />
+        </marker>
+        <marker
+          id="byok-arrow-blocked"
+          viewBox="0 0 10 10"
+          refX="9"
+          refY="5"
+          markerUnits="strokeWidth"
+          markerWidth="8"
+          markerHeight="8"
+          orient="auto"
+        >
+          <path d="M 0 0 L 10 5 L 0 10 z" className="fill-muted-foreground" />
+        </marker>
+      </defs>
+
+      {/* Row 1 — the path that's actually used */}
+      <g transform="translate(0, 18)">
+        <text x="0" y="-4" className="text-[10px] uppercase tracking-wider fill-emerald-600 dark:fill-emerald-400 font-semibold">
+          ✓ How your requests actually flow
+        </text>
+
+        {/* Browser box */}
+        <rect
+          x="2"
+          y="6"
+          width="120"
+          height="48"
+          rx="8"
+          className="fill-background stroke-emerald-500"
+          strokeWidth="1.75"
+        />
+        <text x="62" y="35" textAnchor="middle" className="text-[12px] fill-foreground font-medium">
+          Your browser
+        </text>
+
+        {/* Arrow */}
+        <line
+          x1="124"
+          y1="30"
+          x2="346"
+          y2="30"
+          className="stroke-emerald-500"
+          strokeWidth="2"
+          markerEnd="url(#byok-arrow-active)"
+        />
+        <text x="235" y="22" textAnchor="middle" className="text-[10px] fill-emerald-600 dark:fill-emerald-400 font-mono">
+          HTTPS · direct
+        </text>
+
+        {/* Provider API box (highlighted) */}
+        <rect
+          x="350"
+          y="6"
+          width="168"
+          height="48"
+          rx="8"
+          className="fill-emerald-500/10 stroke-emerald-500"
+          strokeWidth="1.75"
+        />
+        <text x="434" y="35" textAnchor="middle" className="text-[12px] fill-foreground font-mono">
+          {apiHost}
+        </text>
+      </g>
+
+      {/* Row 2 — what we are NOT doing */}
+      <g transform="translate(0, 116)" opacity="0.55">
+        <text x="0" y="-4" className="text-[10px] uppercase tracking-wider fill-destructive font-semibold" opacity="1">
+          ✗ What we never do
+        </text>
+
+        {/* Browser box (muted) */}
+        <rect
+          x="2"
+          y="6"
+          width="100"
+          height="44"
+          rx="6"
+          className="fill-background stroke-muted-foreground"
+          strokeWidth="1"
+          strokeDasharray="3 3"
+        />
+        <text x="52" y="33" textAnchor="middle" className="text-[11px] fill-muted-foreground">
+          Your browser
+        </text>
+
+        {/* Arrow 1 (muted, dashed) */}
+        <line
+          x1="104"
+          y1="28"
+          x2="186"
+          y2="28"
+          className="stroke-muted-foreground"
+          strokeWidth="1.25"
+          strokeDasharray="3 3"
+          markerEnd="url(#byok-arrow-blocked)"
+        />
+
+        {/* "Our server" box — struck through */}
+        <rect
+          x="190"
+          y="6"
+          width="120"
+          height="44"
+          rx="6"
+          className="fill-background stroke-muted-foreground"
+          strokeWidth="1"
+          strokeDasharray="3 3"
+        />
+        <text x="250" y="33" textAnchor="middle" className="text-[11px] fill-muted-foreground">
+          our server
+        </text>
+        {/* Strike-through across the "our server" box */}
+        <line
+          x1="184"
+          y1="44"
+          x2="316"
+          y2="12"
+          className="stroke-destructive"
+          strokeWidth="2.5"
+          opacity="0.85"
+        />
+
+        {/* Arrow 2 (muted, dashed) */}
+        <line
+          x1="312"
+          y1="28"
+          x2="394"
+          y2="28"
+          className="stroke-muted-foreground"
+          strokeWidth="1.25"
+          strokeDasharray="3 3"
+          markerEnd="url(#byok-arrow-blocked)"
+        />
+
+        {/* Provider API box (muted) */}
+        <rect
+          x="398"
+          y="6"
+          width="120"
+          height="44"
+          rx="6"
+          className="fill-background stroke-muted-foreground"
+          strokeWidth="1"
+          strokeDasharray="3 3"
+        />
+        <text x="458" y="33" textAnchor="middle" className="text-[11px] fill-muted-foreground font-mono">
+          {apiHost}
+        </text>
+      </g>
+    </svg>
+  );
+}

--- a/apps/viewer/src/lib/llm/clipboard-detect.test.ts
+++ b/apps/viewer/src/lib/llm/clipboard-detect.test.ts
@@ -1,0 +1,150 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { looksLikeProviderKey, maskKey, readClipboardKey } from './clipboard-detect.js';
+
+// ── looksLikeProviderKey ───────────────────────────────────────────────────
+
+test('looksLikeProviderKey accepts a realistic Anthropic console key', () => {
+  // 14-char prefix + 50 random body chars
+  const key = 'sk-ant-api03-' + 'a'.repeat(60);
+  assert.equal(looksLikeProviderKey('anthropic', key), true);
+});
+
+test('looksLikeProviderKey rejects too-short Anthropic key', () => {
+  const key = 'sk-ant-api03-tooshort';
+  assert.equal(looksLikeProviderKey('anthropic', key), false);
+});
+
+test('looksLikeProviderKey rejects Anthropic key with wrong prefix', () => {
+  assert.equal(looksLikeProviderKey('anthropic', 'sk-' + 'a'.repeat(80)), false);
+  assert.equal(looksLikeProviderKey('anthropic', 'sk-ant-api01-' + 'a'.repeat(80)), false);
+});
+
+test('looksLikeProviderKey accepts a legacy OpenAI key', () => {
+  assert.equal(looksLikeProviderKey('openai', 'sk-' + 'a'.repeat(48)), true);
+});
+
+test('looksLikeProviderKey accepts an OpenAI project key', () => {
+  assert.equal(looksLikeProviderKey('openai', 'sk-proj-' + 'a'.repeat(48)), true);
+});
+
+test('looksLikeProviderKey accepts an OpenAI service-account key', () => {
+  assert.equal(looksLikeProviderKey('openai', 'sk-svcacct-' + 'a'.repeat(48)), true);
+});
+
+test('looksLikeProviderKey rejects random clipboard contents', () => {
+  assert.equal(looksLikeProviderKey('anthropic', 'hello world'), false);
+  assert.equal(looksLikeProviderKey('openai', 'https://example.com/?foo=bar'), false);
+  assert.equal(looksLikeProviderKey('openai', ''), false);
+});
+
+test('looksLikeProviderKey trims leading/trailing whitespace before matching', () => {
+  const key = 'sk-ant-api03-' + 'a'.repeat(60);
+  assert.equal(looksLikeProviderKey('anthropic', `  ${key}\n`), true);
+});
+
+// ── maskKey ────────────────────────────────────────────────────────────────
+
+test('maskKey preserves Anthropic prefix and last 4 chars', () => {
+  const key = 'sk-ant-api03-' + 'a'.repeat(56) + 'WXYZ';
+  const masked = maskKey(key);
+  assert.equal(masked.startsWith('sk-ant-api03-'), true);
+  assert.equal(masked.endsWith('WXYZ'), true);
+  assert.equal(masked.includes('••••'), true);
+});
+
+test('maskKey preserves OpenAI project prefix', () => {
+  const key = 'sk-proj-' + 'a'.repeat(40) + 'WXYZ';
+  const masked = maskKey(key);
+  assert.equal(masked.startsWith('sk-proj-'), true);
+  assert.equal(masked.endsWith('WXYZ'), true);
+});
+
+test('maskKey preserves bare sk- prefix for legacy keys', () => {
+  const key = 'sk-' + 'a'.repeat(45) + 'WXYZ';
+  const masked = maskKey(key);
+  assert.equal(masked.startsWith('sk-'), true);
+  assert.equal(masked.endsWith('WXYZ'), true);
+});
+
+test('maskKey falls back to bullets for absurdly short input', () => {
+  assert.equal(maskKey('short'), '••••');
+  assert.equal(maskKey(''), '••••');
+});
+
+// ── readClipboardKey ──────────────────────────────────────────────────────
+// We can't easily simulate a real browser Clipboard API in node:test, but we
+// can verify the helper degrades gracefully when navigator/clipboard is absent
+// and returns the matched key when a stub is provided.
+//
+// `globalThis.navigator` is defined as a getter in modern Node, so we use
+// Object.defineProperty with configurable:true to swap it for the duration
+// of each test, then restore the original descriptor.
+
+function withNavigator<T>(stub: unknown, fn: () => T): T {
+  const original = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
+  Object.defineProperty(globalThis, 'navigator', {
+    value: stub,
+    configurable: true,
+    writable: true,
+  });
+  try {
+    return fn();
+  } finally {
+    if (original) {
+      Object.defineProperty(globalThis, 'navigator', original);
+    } else {
+      delete (globalThis as { navigator?: unknown }).navigator;
+    }
+  }
+}
+
+test('readClipboardKey returns null when navigator.clipboard is unavailable', async () => {
+  const result = await withNavigator({ clipboard: undefined }, () => readClipboardKey('anthropic'));
+  assert.equal(result, null);
+});
+
+test('readClipboardKey returns matched key when clipboard contents shape-match', async () => {
+  const goodKey = 'sk-ant-api03-' + 'b'.repeat(70);
+  const result = await withNavigator(
+    { clipboard: { readText: async () => goodKey } },
+    () => readClipboardKey('anthropic'),
+  );
+  assert.equal(result, goodKey);
+});
+
+test('readClipboardKey returns null when clipboard contents are unrelated', async () => {
+  const result = await withNavigator(
+    { clipboard: { readText: async () => 'just a normal copied string' } },
+    () => readClipboardKey('anthropic'),
+  );
+  assert.equal(result, null);
+});
+
+test('readClipboardKey swallows clipboard read errors and returns null', async () => {
+  const result = await withNavigator(
+    {
+      clipboard: {
+        readText: async () => {
+          throw new Error('NotAllowedError: permission denied');
+        },
+      },
+    },
+    () => readClipboardKey('openai'),
+  );
+  assert.equal(result, null);
+});
+
+test('readClipboardKey wrong-provider clipboard returns null', async () => {
+  // Anthropic key on clipboard, but we're checking for an OpenAI key
+  const anthropicKey = 'sk-ant-api03-' + 'c'.repeat(70);
+  const result = await withNavigator(
+    { clipboard: { readText: async () => anthropicKey } },
+    () => readClipboardKey('openai'),
+  );
+  assert.equal(result, null);
+});

--- a/apps/viewer/src/lib/llm/clipboard-detect.ts
+++ b/apps/viewer/src/lib/llm/clipboard-detect.ts
@@ -55,8 +55,12 @@ export async function readClipboardKey(provider: BYOKProvider): Promise<string |
       return trimmed;
     }
     return null;
-  } catch {
-    /* clipboard read denied / insecure context — safe to ignore, manual paste still works */
+  } catch (err) {
+    // Permission denied / insecure context / no transient activation — these
+    // are expected on Firefox and Safari without an explicit user grant, and
+    // the manual-paste fallback still works. Log at debug level for diagnostic
+    // but never escalate to the UI.
+    console.debug('[byok] clipboard read failed', err);
     return null;
   }
 }

--- a/apps/viewer/src/lib/llm/clipboard-detect.ts
+++ b/apps/viewer/src/lib/llm/clipboard-detect.ts
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Clipboard sniffing for the BYOK key modal.
+ *
+ * After the user clicks our "Open Console" button, they create a key on the
+ * provider's site, copy it, and return to this tab. If transient activation
+ * (or clipboard-read permission) is still valid, we can detect the key and
+ * offer one-click insertion instead of forcing a manual paste.
+ *
+ * Reads are best-effort and silently no-op on:
+ *   - missing Clipboard API (older Safari, insecure context, sandboxed iframe)
+ *   - permission denied (Firefox without explicit user grant)
+ *   - read failure for any other reason
+ *
+ * We never throw on these — the modal just falls back to its manual paste UX.
+ */
+
+export type BYOKProvider = 'anthropic' | 'openai';
+
+/**
+ * Provider-specific shape checks. Tight enough to avoid false positives on
+ * random clipboard contents, permissive enough to cover the key formats each
+ * provider currently issues.
+ *
+ *   Anthropic console keys: `sk-ant-api03-` + ≥50 chars of [A-Za-z0-9_-]
+ *   OpenAI keys:            `sk-`, `sk-proj-`, `sk-svcacct-`, `sk-admin-` + ≥20 chars
+ *
+ * The OpenAI pattern uses a negative lookahead for `ant-` so an Anthropic key
+ * doesn't accidentally satisfy the OpenAI tab — they both start with `sk-`.
+ */
+const PROVIDER_PATTERNS: Record<BYOKProvider, RegExp> = {
+  anthropic: /^sk-ant-api03-[A-Za-z0-9_-]{50,}$/,
+  openai: /^sk-(?!ant-)(?:proj-|svcacct-|admin-)?[A-Za-z0-9_-]{20,}$/,
+};
+
+/**
+ * Try to read a candidate provider key from the system clipboard.
+ *
+ * Returns the trimmed key string if the clipboard contents match the provider
+ * pattern. Returns `null` for everything else (no match, permission denied,
+ * Clipboard API unavailable, etc.) — callers should treat `null` as "fall back
+ * to manual paste".
+ */
+export async function readClipboardKey(provider: BYOKProvider): Promise<string | null> {
+  if (typeof navigator === 'undefined' || !navigator.clipboard?.readText) {
+    return null;
+  }
+  try {
+    const text = await navigator.clipboard.readText();
+    const trimmed = text.trim();
+    if (PROVIDER_PATTERNS[provider].test(trimmed)) {
+      return trimmed;
+    }
+    return null;
+  } catch {
+    /* clipboard read denied / insecure context — safe to ignore, manual paste still works */
+    return null;
+  }
+}
+
+/**
+ * Render-safe key mask. Preserves the provider prefix so the user can confirm
+ * the right key is detected, hides the secret middle, shows the last 4 chars
+ * for disambiguation.
+ *
+ *   sk-ant-api03-abcdef…XYZA
+ *   sk-proj-••••XYZA
+ *   sk-••••XYZA
+ */
+export function maskKey(key: string): string {
+  if (key.length < 12) return '••••';
+  const dashIdx = key.lastIndexOf('-');
+  const prefixEnd = dashIdx > 0 && dashIdx < 14 ? dashIdx + 1 : Math.min(14, key.length - 4);
+  return `${key.slice(0, prefixEnd)}••••${key.slice(-4)}`;
+}
+
+/**
+ * Light shape check shared with `readClipboardKey` so callers can validate
+ * manual paste contents the same way before saving.
+ */
+export function looksLikeProviderKey(provider: BYOKProvider, value: string): boolean {
+  return PROVIDER_PATTERNS[provider].test(value.trim());
+}

--- a/apps/viewer/src/lib/llm/models.ts
+++ b/apps/viewer/src/lib/llm/models.ts
@@ -149,6 +149,9 @@ const ANTHROPIC_BYOK_MODELS: LLMModel[] = [
     supportsImages: true,
     supportsFileAttachments: true,
     cost: '$$$',
+    // Opus 4.7 returns 400 if temperature/top_p/top_k are present.
+    // See `whats-new-claude-4-7` docs § Sampling parameters removed.
+    acceptsSamplingParams: false,
   },
   {
     id: 'claude-opus-4-6',
@@ -196,6 +199,9 @@ const OPENAI_BYOK_MODELS: LLMModel[] = [
     supportsImages: true,
     supportsFileAttachments: true,
     cost: '$$$',
+    // GPT-5 reasoning family only accepts the default temperature (1).
+    // Sending any other value returns 400 from /v1/chat/completions.
+    acceptsSamplingParams: false,
   },
   {
     id: 'gpt-5.5',
@@ -207,6 +213,7 @@ const OPENAI_BYOK_MODELS: LLMModel[] = [
     supportsImages: true,
     supportsFileAttachments: true,
     cost: '$$',
+    acceptsSamplingParams: false,
   },
   {
     id: 'gpt-5.4',

--- a/apps/viewer/src/lib/llm/models.ts
+++ b/apps/viewer/src/lib/llm/models.ts
@@ -145,7 +145,7 @@ const ANTHROPIC_BYOK_MODELS: LLMModel[] = [
     provider: 'Anthropic',
     tier: 'byok',
     source: 'anthropic',
-    contextWindow: 200_000,
+    contextWindow: 1_000_000,
     supportsImages: true,
     supportsFileAttachments: true,
     cost: '$$$',

--- a/apps/viewer/src/lib/llm/models.ts
+++ b/apps/viewer/src/lib/llm/models.ts
@@ -190,8 +190,8 @@ const ANTHROPIC_BYOK_MODELS: LLMModel[] = [
 
 const OPENAI_BYOK_MODELS: LLMModel[] = [
   {
-    id: 'gpt-5.5-pro',
-    name: 'GPT-5.5 Pro',
+    id: 'gpt-5.5',
+    name: 'GPT-5.5',
     provider: 'OpenAI',
     tier: 'byok',
     source: 'openai',
@@ -201,18 +201,6 @@ const OPENAI_BYOK_MODELS: LLMModel[] = [
     cost: '$$$',
     // GPT-5 reasoning family only accepts the default temperature (1).
     // Sending any other value returns 400 from /v1/chat/completions.
-    acceptsSamplingParams: false,
-  },
-  {
-    id: 'gpt-5.5',
-    name: 'GPT-5.5',
-    provider: 'OpenAI',
-    tier: 'byok',
-    source: 'openai',
-    contextWindow: 1_000_000,
-    supportsImages: true,
-    supportsFileAttachments: true,
-    cost: '$$',
     acceptsSamplingParams: false,
   },
   {

--- a/apps/viewer/src/lib/llm/models.ts
+++ b/apps/viewer/src/lib/llm/models.ts
@@ -140,6 +140,17 @@ export const FREE_MODELS: LLMModel[] = rawFreeModels.map(applyCapabilities);
 
 const ANTHROPIC_BYOK_MODELS: LLMModel[] = [
   {
+    id: 'claude-opus-4-7',
+    name: 'Claude Opus 4.7',
+    provider: 'Anthropic',
+    tier: 'byok',
+    source: 'anthropic',
+    contextWindow: 200_000,
+    supportsImages: true,
+    supportsFileAttachments: true,
+    cost: '$$$',
+  },
+  {
     id: 'claude-opus-4-6',
     name: 'Claude Opus 4.6',
     provider: 'Anthropic',
@@ -175,6 +186,28 @@ const ANTHROPIC_BYOK_MODELS: LLMModel[] = [
 ];
 
 const OPENAI_BYOK_MODELS: LLMModel[] = [
+  {
+    id: 'gpt-5.5-pro',
+    name: 'GPT-5.5 Pro',
+    provider: 'OpenAI',
+    tier: 'byok',
+    source: 'openai',
+    contextWindow: 1_000_000,
+    supportsImages: true,
+    supportsFileAttachments: true,
+    cost: '$$$',
+  },
+  {
+    id: 'gpt-5.5',
+    name: 'GPT-5.5',
+    provider: 'OpenAI',
+    tier: 'byok',
+    source: 'openai',
+    contextWindow: 1_000_000,
+    supportsImages: true,
+    supportsFileAttachments: true,
+    cost: '$$',
+  },
   {
     id: 'gpt-5.4',
     name: 'GPT-5.4',

--- a/apps/viewer/src/lib/llm/stream-direct.ts
+++ b/apps/viewer/src/lib/llm/stream-direct.ts
@@ -15,6 +15,7 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 import { readSseStream, type StreamMessage, type StreamOptions } from './stream-client.js';
+import { getModelById } from './models.js';
 
 const STREAM_REQUEST_TIMEOUT_MS = 45_000;
 
@@ -71,12 +72,19 @@ export async function streamAnthropicChat(
     dangerouslyAllowBrowser: true,
   });
 
+  // Opus 4.7+ returns 400 if `temperature` (or `top_p`/`top_k`) is present.
+  // We gate on the per-model `acceptsSamplingParams` flag in models.ts so
+  // future Claude models that adopt the same policy only need a flag bump,
+  // and Opus 4.6 / Sonnet 4.6 / Haiku 4.5 keep their tuned temperature.
+  const modelDef = getModelById(model);
+  const sendSamplingParams = modelDef?.acceptsSamplingParams !== false;
+
   let fullText = '';
   try {
     const stream = client.messages.stream({
       model,
       max_tokens: 8192,
-      temperature: 0.3,
+      ...(sendSamplingParams ? { temperature: 0.3 } : {}),
       system: system || undefined,
       messages: toAnthropicMessages(messages),
     });
@@ -118,8 +126,6 @@ export async function streamAnthropicChat(
 
 // ── OpenAI ─────────────────────────────────────────────────────────────────
 
-import { getModelById } from './models.js';
-
 /**
  * Stream an OpenAI model. Automatically picks the right API:
  * - Chat Completions (`/v1/chat/completions`) for standard chat models
@@ -147,13 +153,19 @@ async function streamOpenAiChatCompletions(
     ? [{ role: 'system', content: system }, ...messages]
     : [...messages];
 
+  // GPT-5 reasoning models (gpt-5.5, gpt-5.5-pro) only accept the default
+  // temperature; sending any other value returns 400. Mirror the Anthropic
+  // path: when the model is flagged `acceptsSamplingParams: false`, omit.
+  const modelDef = getModelById(model);
+  const sendSamplingParams = modelDef?.acceptsSamplingParams !== false;
+
   const { response, cleanup } = await openAiFetch(
     'https://api.openai.com/v1/chat/completions',
     {
       model,
       messages: allMessages.map((m) => ({ role: m.role, content: m.content })),
       stream: true,
-      temperature: 0.3,
+      ...(sendSamplingParams ? { temperature: 0.3 } : {}),
       max_completion_tokens: 8192,
     },
     apiKey,

--- a/apps/viewer/src/lib/llm/types.ts
+++ b/apps/viewer/src/lib/llm/types.ts
@@ -163,6 +163,14 @@ export interface LLMModel {
   cost?: ModelCost;
   /** OpenAI API variant: 'chat' (default) or 'responses' (Codex-style models) */
   openaiApi?: 'chat' | 'responses';
+  /**
+   * Whether the model accepts the classic sampling parameters (`temperature`,
+   * `top_p`, `top_k`). Default: true. Set to `false` for models that reject
+   * them (Anthropic Claude Opus 4.7 and later — see
+   * https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7).
+   * When `false`, the stream client omits these params from the request body.
+   */
+  acceptsSamplingParams?: boolean;
 }
 
 export type ChatStatus = 'idle' | 'sending' | 'streaming' | 'error';

--- a/apps/viewer/src/services/playground-model.ts
+++ b/apps/viewer/src/services/playground-model.ts
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Per-tab persistence for the model the /mcp/playground chat uses.
+ *
+ * The playground driver calls Anthropic's `messages.create` with the native
+ * tools API, so the selected model must be Anthropic. We keep a separate
+ * preference from the viewer's `chatActiveModel` so the two pages can default
+ * differently — the viewer often runs on a free proxy model, while playground
+ * users have already opted into BYOK by being here.
+ */
+
+import { getByokModelsForSource } from '@/lib/llm/models';
+
+const STORAGE_KEY = 'ifc-lite:playground-model:v1';
+const CHANGED_EVENT = 'ifc-lite:playground-model-changed';
+
+/**
+ * Default fallback when nothing is in storage. Sonnet hits the sweet spot for
+ * tool-calling agentic loops — fast enough for 25 sequential tool calls,
+ * smart enough to pick the right tool. Opus 4.7 is better at planning but
+ * costs ~3x; Haiku is faster but more likely to mis-pick tools.
+ */
+const FALLBACK_MODEL = 'claude-sonnet-4-6';
+
+function isValidAnthropicModel(id: string): boolean {
+  return getByokModelsForSource('anthropic').some((m) => m.id === id);
+}
+
+export function getPlaygroundModel(): string {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored && isValidAnthropicModel(stored)) return stored;
+  } catch {
+    /* localStorage blocked / quota-exceeded — fall through to default */
+  }
+  return FALLBACK_MODEL;
+}
+
+export function setPlaygroundModel(modelId: string): void {
+  if (!isValidAnthropicModel(modelId)) return;
+  try {
+    localStorage.setItem(STORAGE_KEY, modelId);
+  } catch {
+    /* storage write failed — selection only lives for this tab session */
+  }
+  window.dispatchEvent(new Event(CHANGED_EVENT));
+}
+
+export function subscribePlaygroundModel(listener: () => void): () => void {
+  window.addEventListener(CHANGED_EVENT, listener);
+  return () => window.removeEventListener(CHANGED_EVENT, listener);
+}


### PR DESCRIPTION
## Summary

- New trust-focused tabbed BYOK key entry modal — the first proper API-key surface on web (`/settings` is desktop-only and not deployed on Vercel). Replaces the cramped inline password strip in `ChatPanel`.
- Two new BYOK model IDs: **`claude-opus-4-7`** and **`gpt-5.5`** (both 1M-token context). Anthropic Opus 4.6 / Sonnet 4.6 / Haiku 4.5 and the existing OpenAI GPT-5.4 family stay.
- New `acceptsSamplingParams` flag on `LLMModel` — both Opus 4.7 and the GPT-5 reasoning family reject `temperature`/`top_p`/`top_k` with HTTP 400 ([Anthropic ref](https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7)). The direct stream client omits those params when the flag is false; older models keep their tuned values.
- Persistent `🔒 anthropic.com` / `openai.com` pill next to the model name whenever a BYOK route is active — names the host without users having to open DevTools. Tooltip points at DevTools → Network for verification.
- Free-tier proxy usage bar (`n/m requests · resets …`) is hidden on BYOK routes — the user's own provider account gates them, our quota doesn't apply.
- **`/mcp/playground` now uses the same trust modal** + a model selector dropdown (Claude lineup, persisted to `localStorage`). The old cramped inline `KeyHeader` editor is gone. Keys saved in either page sync to the other via the existing `subscribeApiKeys` channel.

## Why

AEC users push back on BYOK because (a) pasting an API key is friction, and (b) they don't fully trust the key isn't flowing through our server. "Sign in with Anthropic/OpenAI" can't fix this — Anthropic explicitly disabled third-party OAuth in Feb 2026 ([source](https://github.com/anthropics/claude-code/issues/28091)) and OpenAI has never offered API access on ChatGPT subscriptions. The accessible levers are:

1. **Lower paste friction** — autofocus the modal's input on open so `⌘V` lands directly in the field, then surface inline green confirmation the moment the pasted value matches the provider shape.
2. **Make trust unmistakable** — a custom SVG that contrasts the direct browser → `api.provider.com` path against the struck-through "via our server" path we never use, DevTools-verifiable trust bullets, a permalink to `stream-direct.ts` on GitHub, and the always-on streaming pill that names the actual host.
3. **One entry surface** across the product — the viewer chat and the MCP playground share the same modal so users don't have to learn two key-entry UIs.

## What's in the modal

```
┌─────────────────────────────────────────────────────────────┐
│  🔑 Use your own API key                              [✕]   │
│  Unlocks frontier models. Your key stays in this browser    │
│  and goes straight to the provider — never through our      │
│  servers.                                                    │
├─────────────────────────────────────────────────────────────┤
│  [ Anthropic ✓ ]  [ OpenAI ]      ← active tab is styled    │
├─────────────────────────────────────────────────────────────┤
│  Unlocks: Claude Opus 4.7 · Opus 4.6 · Sonnet 4.6 · Haiku   │
│                                                              │
│  [ SVG: direct path highlighted, "via our server" struck    │
│    through ]                                                 │
│                                                              │
│  ✓ Key stored only in this browser's localStorage.          │
│  ✓ Every request goes to api.anthropic.com. Verify in       │
│    DevTools → Network → filter "anthropic.com".             │
│  ✓ The whole BYOK code path is ~60 lines. Read it on GitHub │
│                                                              │
│  Paste your key                                              │
│  [ sk-ant-api03-...                          👁 ] [ Save ]  │
│  ✓ Looks like an Anthropic key (sk-ant-api03-…XYZA) —       │
│    press Enter or Save                                       │
│                                                              │
│  ▸ Don't have a key? 60-second walkthrough                  │
└─────────────────────────────────────────────────────────────┘
```

## Clipboard handling — honest, not magical

Real silent clipboard detection isn't achievable on the modern web — `navigator.clipboard.readText()` is gated behind transient user activation OR an explicit `clipboard-read` permission we can't even request a prompt for. On macOS Chromium every silent read surfaces the native Paste affordance. The earlier "Detect from clipboard" button was just triggering that OS prompt. Removed.

Instead the flow is:
- **Input autofocuses** on modal open / tab switch — `⌘V` lands directly.
- **Inline green confirmation** appears the moment the pasted/typed value matches the provider shape (regex with negative lookahead so an Anthropic key can't masquerade as OpenAI).
- **Walkthrough copy** says "paste it into the input above (the field is already focused — just press ⌘V)" rather than a misleading promise of automatic detection.

## /mcp/playground unification

```
┌─────────────────────────────────────────────────────────────┐
│ ● ifc-lite/mcp · agent    [ model: Claude Sonnet 4.6 ▾ ]   │
│                           [ 🔑 key set · sk-ant-…XYZA ]    │
└─────────────────────────────────────────────────────────────┘
```

- Replaced the playground's inline `<input type=password>` `KeyHeader` editor with a `KeyRound` pill that opens the **same `ByokKeyModal`** the viewer chat uses.
- Added a model dropdown listing every Anthropic BYOK model. Selection persists to `localStorage` (`ifc-lite:playground-model:v1`) separately from the viewer's `chatActiveModel` so the two pages can default differently.
- `runConversation` now takes a `modelId` instead of hardcoded `'claude-sonnet-4-6'`.
- **Out of scope here**: OpenAI in the playground — Anthropic's tools API and OpenAI's function-calling have different request/response shapes; that's a separate piece of work.

## Files

- `apps/viewer/src/components/viewer/chat/ByokKeyModal.tsx` — tabbed Dialog (Anthropic / OpenAI, ready for more providers later) — 338 lines
- `apps/viewer/src/components/viewer/chat/ByokTrustDiagram.tsx` — themed SVG, provider host swaps via prop — 192 lines
- `apps/viewer/src/components/viewer/chat/ByokStreamingPill.tsx` — `Tooltip`-wrapped pill, only renders for BYOK routes, `shrink-0` so model selector truncates first — 62 lines
- `apps/viewer/src/lib/llm/clipboard-detect.ts` + `.test.ts` — shape regex (`looksLikeProviderKey`), key masker, clipboard reader. 17 new tests.
- `apps/viewer/src/lib/llm/types.ts` — `acceptsSamplingParams?: boolean` on `LLMModel`
- `apps/viewer/src/lib/llm/models.ts` — `claude-opus-4-7` (1M ctx, flag false), `gpt-5.5` (1M ctx, flag false)
- `apps/viewer/src/lib/llm/stream-direct.ts` — omits `temperature` when flag is false on both Anthropic and OpenAI direct paths
- `apps/viewer/src/components/viewer/ChatPanel.tsx` — `InlineKeyPrompt` deleted (~85 lines gone), modal mounted, auto-opens on locked-model pick (transition only, not re-opening after dismiss), header `KeyRound` button (with `aria-label`), slim amber CTA when modal dismissed but key still needed, usage bar gated on `activeModel.source === 'proxy'`
- `apps/viewer/src/services/playground-model.ts` — localStorage-backed playground model preference (Anthropic only) — 55 lines
- `apps/viewer/src/components/mcp/PlaygroundChat.tsx` — replaced inline `KeyHeader` with `PlaygroundHeader` (model picker + key-status pill that opens shared modal); `runConversation` now takes `modelId`

## Test plan

- [ ] Pick a locked Anthropic model (e.g. Claude Opus 4.7) → modal auto-opens on the Anthropic tab; **active tab is visibly highlighted** (bg + shadow + bold)
- [ ] Input is **autofocused** → `⌘V` pastes the key directly into the field; **green "Looks like an Anthropic key (sk-ant-api03-…XYZA)"** appears inline
- [ ] Press Enter → key saved, toast appears, modal closes
- [ ] `🔒 anthropic.com` pill appears next to model name; hover → tooltip with DevTools verification text
- [ ] Send a message with **Opus 4.7** → no 400, response streams (temperature is omitted on the wire)
- [ ] Open the header `🔑` button while a key is configured → modal reopens; "Configured" row shows masked key with Remove button
- [ ] Remove the key → pill disappears, header icon de-tints, slim amber CTA banner appears below the header
- [ ] Switch to the OpenAI tab and repeat with a `sk-...` or `sk-proj-...` key; confirm an Anthropic key on the clipboard is **not** falsely matched as OpenAI (regex negative-lookahead)
- [ ] Confirm **no native Paste affordance** appears on modal open or tab switch (regression check — the background `readText` call that triggered it is gone)
- [ ] On a BYOK model, the free-tier usage bar / "n/m requests · resets …" tooltip is **gone** from the chat input footer
- [ ] Walkthrough collapsible: open and close it, confirm screen reader sees `aria-expanded` flip
- [ ] **Playground**: navigate to `/mcp/playground`; click the `🔑 key set` / `set Anthropic key` pill → same modal opens
- [ ] **Playground**: change model in the dropdown → reload page → selection persists
- [ ] **Playground**: save a key in the viewer chat modal → return to `/mcp/playground` → status pill shows the new masked key without refresh

## Iterations after first review

| Commit | Issue addressed |
|---|---|
| `c2941311` | Claude Opus 4.7 context window was 200K, should be 1M (per Anthropic docs) |
| `af5ee602` | Active tab visually identical to inactive; native macOS Paste pill appearing on every tab switch (background clipboard read removed) |
| `ce6153e8` | Opus 4.7 / GPT-5.5 returning 400 on `temperature: 0.3` (added `acceptsSamplingParams` flag); pill text shortened so model selector stops truncating |
| `068d31d4` | "Detect from clipboard" button just triggered the OS Paste pill on macOS Chrome — replaced with autofocus + inline paste validation; `gpt-5.5-pro` dropped from registry |
| `b846a07b` | Free-tier usage bar still showed for BYOK routes |
| `b561bb24` | CodeRabbit review: stale changeset text, a11y attributes on walkthrough + KeyRound, `console.debug` on swallowed clipboard read |
| `3a8d41e7` | `/mcp/playground` BYOK unification + model selector |

## Review feedback status

- **Codex (2 P2 comments on `13b22342`)** — both incorrect. Codex claimed `claude-opus-4-7` and `gpt-5.5` were "display names, not API IDs". Replied inline with citations to the official Anthropic and OpenAI model docs that list them as the literal API model strings.
- **CodeRabbit (5 actionable on `068d31d4`)** — 4 fixed in `b561bb24` (stale changeset text; walkthrough aria-expanded/controls; KeyRound aria-label; console.debug on clipboard catch). 1 declined: "extract `byokModal` state into a `useByokModalController` hook" — per `AGENTS.md` §7, "Don't add features, refactor, or introduce abstractions beyond what the task requires." Three lines of state + two callbacks don't merit a hook.

## What was researched and ruled out

- **OpenRouter PKCE one-click sign-in** — would require AEC users to create yet another account; the prior $8/mo Clerk-gated experiment with similar friction had no uptake.
- **WebLLM / Gemini Nano on Chrome's Prompt API** — same quality bucket as the two free OpenRouter models already on the proxy; WebLLM's 4–8K context can't fit our ~15K-token system prompt, Gemini Nano needs Chrome 148+ on macOS 13+ with 22 GB free disk; doesn't move the needle for the target audience.
- **"Sign in with Anthropic/OpenAI" to use a user's subscription** — structurally blocked at the platform level. [Anthropic disabled third-party OAuth in Feb 2026](https://github.com/anthropics/claude-code/issues/28091); OpenAI's ChatGPT subscription has never been usable via the API.

## Production-readiness check

- `pnpm -r typecheck`: clean across all 40 packages
- `pnpm --filter=@ifc-lite/viewer test`: 767 tests, 766 pass, 1 pre-existing skipped, 0 fail (17 new clipboard-detect tests included)
- All new files include MPL-2.0 headers
- No `as any`, `@ts-ignore`, or bare `catch {}` in the new code
- All new files under the AGENTS.md ~400 LOC cap
- Vercel preview deployments green for both `ifc-lite` and `ifc-lite-viewer-embed`
- CodeRabbit re-review on `068d31d4`: ✓ passed after fixes
- Mergeable: YES · MergeStateStatus: UNSTABLE only because `Build + WASM + Rust + Node` is still running its long async tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)