### PR TITLE
server: cap gzip decompression at max_file_size_mb

### DIFF
--- a/apps/server/src/routes/parse.rs
+++ b/apps/server/src/routes/parse.rs
@@ -66,8 +66,14 @@ fn parquet_metadata_cache_key(hash: &str, opening_filter: OpeningFilterMode) -> 
 }
 
 /// Extract file data from multipart request.
-/// Automatically decompresses gzip-compressed files.
-async fn extract_file(multipart: &mut Multipart) -> Result<Vec<u8>, ApiError> {
+/// Automatically decompresses gzip-compressed files, refusing inputs whose
+/// decompressed size would exceed `max_file_size_mb`.
+async fn extract_file(
+    multipart: &mut Multipart,
+    max_file_size_mb: usize,
+) -> Result<Vec<u8>, ApiError> {
+    let max_bytes = max_file_size_mb.saturating_mul(1024 * 1024);
+
     while let Some(field) = multipart.next_field().await? {
         let field_name = field.name().unwrap_or_default();
         tracing::debug!(field_name = %field_name, "Processing multipart field");
@@ -82,11 +88,19 @@ async fn extract_file(multipart: &mut Multipart) -> Result<Vec<u8>, ApiError> {
 
             if is_gzipped {
                 tracing::debug!("Detected gzip compression, decompressing...");
-                let mut decoder = GzDecoder::new(bytes.as_ref());
+                // Bound the decompressed stream: read at most max_bytes + 1.
+                // If the cap is hit, treat as oversized rather than allocating
+                // unbounded output for a small compressed input.
+                let mut decoder = GzDecoder::new(bytes.as_ref()).take(max_bytes as u64 + 1);
                 let mut decompressed = Vec::new();
                 decoder
                     .read_to_end(&mut decompressed)
                     .map_err(|e| ApiError::Internal(format!("Failed to decompress gzip: {}", e)))?;
+                if decompressed.len() > max_bytes {
+                    return Err(ApiError::FileTooLarge {
+                        max_mb: max_file_size_mb,
+                    });
+                }
                 tracing::info!(
                     original_size = original_size,
                     decompressed_size = decompressed.len(),
@@ -96,6 +110,11 @@ async fn extract_file(multipart: &mut Multipart) -> Result<Vec<u8>, ApiError> {
                 );
                 return Ok(decompressed);
             } else {
+                if bytes.len() > max_bytes {
+                    return Err(ApiError::FileTooLarge {
+                        max_mb: max_file_size_mb,
+                    });
+                }
                 return Ok(bytes.to_vec());
             }
         }
@@ -112,14 +131,7 @@ pub async fn parse_full(
     mut multipart: Multipart,
 ) -> Result<Json<ParseResponse>, ApiError> {
     // Extract file from multipart
-    let data = extract_file(&mut multipart).await?;
-
-    // Check file size
-    if data.len() > state.config.max_file_size_mb * 1024 * 1024 {
-        return Err(ApiError::FileTooLarge {
-            max_mb: state.config.max_file_size_mb,
-        });
-    }
+    let data = extract_file(&mut multipart, state.config.max_file_size_mb).await?;
 
     // Generate cache key (include opening filter so different modes get different cache entries)
     let cache_key = format!(
@@ -177,14 +189,7 @@ pub async fn parse_stream(
     reject_unsupported_streaming_opening_filter(&query)?;
 
     // Extract file
-    let data = extract_file(&mut multipart).await?;
-
-    // Check file size
-    if data.len() > state.config.max_file_size_mb * 1024 * 1024 {
-        return Err(ApiError::FileTooLarge {
-            max_mb: state.config.max_file_size_mb,
-        });
-    }
+    let data = extract_file(&mut multipart, state.config.max_file_size_mb).await?;
 
     let content = String::from_utf8(data)?;
     let initial_batch_size = state.config.initial_batch_size;
@@ -264,14 +269,7 @@ pub async fn parse_parquet_stream(
     reject_unsupported_streaming_opening_filter(&query)?;
 
     // Extract file
-    let data = extract_file(&mut multipart).await?;
-
-    // Check file size
-    if data.len() > state.config.max_file_size_mb * 1024 * 1024 {
-        return Err(ApiError::FileTooLarge {
-            max_mb: state.config.max_file_size_mb,
-        });
-    }
+    let data = extract_file(&mut multipart, state.config.max_file_size_mb).await?;
 
     // Generate cache key before processing (include opening filter)
     let cache_key = format!(
@@ -530,14 +528,7 @@ pub async fn parse_metadata(
     mut multipart: Multipart,
 ) -> Result<Json<MetadataResponse>, ApiError> {
     // Extract file
-    let data = extract_file(&mut multipart).await?;
-
-    // Check file size
-    if data.len() > state.config.max_file_size_mb * 1024 * 1024 {
-        return Err(ApiError::FileTooLarge {
-            max_mb: state.config.max_file_size_mb,
-        });
-    }
+    let data = extract_file(&mut multipart, state.config.max_file_size_mb).await?;
 
     let file_size = data.len();
     let content = String::from_utf8(data)?;
@@ -615,14 +606,7 @@ pub async fn parse_parquet(
     mut multipart: Multipart,
 ) -> Result<Response, ApiError> {
     // Extract file from multipart
-    let data = extract_file(&mut multipart).await?;
-
-    // Check file size
-    if data.len() > state.config.max_file_size_mb * 1024 * 1024 {
-        return Err(ApiError::FileTooLarge {
-            max_mb: state.config.max_file_size_mb,
-        });
-    }
+    let data = extract_file(&mut multipart, state.config.max_file_size_mb).await?;
 
     // Generate cache key (include opening filter so different modes get different cache entries)
     let cache_key = format!(
@@ -823,14 +807,7 @@ pub async fn parse_parquet_optimized(
     mut multipart: Multipart,
 ) -> Result<Response, ApiError> {
     // Extract file from multipart
-    let data = extract_file(&mut multipart).await?;
-
-    // Check file size
-    if data.len() > state.config.max_file_size_mb * 1024 * 1024 {
-        return Err(ApiError::FileTooLarge {
-            max_mb: state.config.max_file_size_mb,
-        });
-    }
+    let data = extract_file(&mut multipart, state.config.max_file_size_mb).await?;
 
     // Generate cache key (include opening filter so different modes get different cache entries)
     let cache_key = format!(

--- a/packages/mcp/src/safe-path.test.ts
+++ b/packages/mcp/src/safe-path.test.ts
@@ -101,6 +101,27 @@ describe('resolveSafePath', () => {
       }
     });
 
+    it('accepts a file inside an allowed root that is itself a symlink', async () => {
+      // Operator passes --allow <link>; the link points at the real workspace
+      // dir. Files inside should be accepted even though their realpath lives
+      // under the link's target rather than the configured root.
+      const realWorkspace = await mkdtemp(join(tmpdir(), 'mcp-realws-'));
+      const linkedRoot = join(scratch, 'linked-root');
+      try {
+        await symlink(realWorkspace, linkedRoot);
+        const file = join(realWorkspace, 'model.ifc');
+        await writeFile(file, 'x');
+        const out = await resolveSafePath(
+          join(linkedRoot, 'model.ifc'),
+          makeCtx([linkedRoot]),
+          'read',
+        );
+        expect(out).toBe(resolve(file));
+      } finally {
+        await rm(realWorkspace, { recursive: true, force: true });
+      }
+    });
+
     it('accepts a symlink whose target stays inside the allowed root', async () => {
       const real = join(scratch, 'real.ifc');
       await writeFile(real, 'x');
@@ -175,6 +196,19 @@ describe('resolveSafePath', () => {
       await expect(
         resolveSafePath(join(scratch, 'nope.ifc'), makeCtx([scratch]), 'read'),
       ).rejects.toThrow(/does not exist/i);
+    });
+
+    it('handles write paths whose immediate ancestor is the filesystem root', async () => {
+      // Regression: segment slicing must use basename(), not length-based
+      // arithmetic, so a parent of `/` does not silently drop a character.
+      // We can't actually write to `/<random>` in tests, so check the
+      // intermediate behaviour by asking for a path that resolves through
+      // root-as-ancestor and confirming the rejection message names the
+      // *complete* requested path rather than a chopped one.
+      const requested = '/this-segment-must-stay-intact';
+      await expect(
+        resolveSafePath(requested, makeCtx([scratch]), 'write'),
+      ).rejects.toThrow(/this-segment-must-stay-intact/);
     });
   });
 });

--- a/packages/mcp/src/safe-path.test.ts
+++ b/packages/mcp/src/safe-path.test.ts
@@ -1,0 +1,180 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { mkdir, mkdtemp, symlink, writeFile, rm } from 'node:fs/promises';
+import { homedir, tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { resolveSafePath } from './safe-path.js';
+import { ToolExecutionError } from './errors.js';
+
+interface Stub {
+  config: { allowedPaths?: string[] };
+  registry: { list(): Array<{ filePath?: string }> };
+}
+
+function makeCtx(allowedPaths?: string[], modelFiles: string[] = []): Stub {
+  return {
+    config: { allowedPaths },
+    registry: { list: () => modelFiles.map((f) => ({ filePath: f })) },
+  };
+}
+
+describe('resolveSafePath', () => {
+  let scratch: string;
+
+  beforeEach(async () => {
+    scratch = await mkdtemp(join(tmpdir(), 'mcp-safe-path-'));
+  });
+
+  afterEach(async () => {
+    await rm(scratch, { recursive: true, force: true });
+  });
+
+  describe('with explicit --allow roots', () => {
+    it('accepts a path inside an allowed root for read', async () => {
+      const file = join(scratch, 'model.ifc');
+      await writeFile(file, 'ISO-10303-21;');
+      const out = await resolveSafePath(file, makeCtx([scratch]), 'read');
+      expect(out).toBe(resolve(file));
+    });
+
+    it('accepts a write path inside an allowed root even if the file does not exist', async () => {
+      const file = join(scratch, 'new-file.ifc');
+      const out = await resolveSafePath(file, makeCtx([scratch]), 'write');
+      expect(out).toBe(resolve(file));
+    });
+
+    it('rejects a path outside every allowed root', async () => {
+      const other = await mkdtemp(join(tmpdir(), 'mcp-other-'));
+      try {
+        await expect(
+          resolveSafePath(join(other, 'evil.ifc'), makeCtx([scratch]), 'write'),
+        ).rejects.toBeInstanceOf(ToolExecutionError);
+      } finally {
+        await rm(other, { recursive: true, force: true });
+      }
+    });
+
+    it('rejects a sibling whose prefix matches by string but not by path boundary', async () => {
+      // /tmp/scratchAB vs allowed=/tmp/scratch
+      const sibling = `${scratch}-sibling`;
+      await mkdir(sibling, { recursive: true });
+      try {
+        await writeFile(join(sibling, 'a.ifc'), '');
+        await expect(
+          resolveSafePath(join(sibling, 'a.ifc'), makeCtx([scratch]), 'read'),
+        ).rejects.toBeInstanceOf(ToolExecutionError);
+      } finally {
+        await rm(sibling, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('symlink handling', () => {
+    it('refuses a symlink that points outside the allowed root', async () => {
+      const target = await mkdtemp(join(tmpdir(), 'mcp-target-'));
+      const targetFile = join(target, 'secret.ifc');
+      await writeFile(targetFile, 'secret');
+      const link = join(scratch, 'link.ifc');
+      try {
+        await symlink(targetFile, link);
+        await expect(
+          resolveSafePath(link, makeCtx([scratch]), 'read'),
+        ).rejects.toBeInstanceOf(ToolExecutionError);
+      } finally {
+        await rm(target, { recursive: true, force: true });
+      }
+    });
+
+    it('refuses a write whose parent symlinks out of the allowed root', async () => {
+      const target = await mkdtemp(join(tmpdir(), 'mcp-target-'));
+      const linkedDir = join(scratch, 'linked');
+      try {
+        await symlink(target, linkedDir);
+        await expect(
+          resolveSafePath(join(linkedDir, 'new.ifc'), makeCtx([scratch]), 'write'),
+        ).rejects.toBeInstanceOf(ToolExecutionError);
+      } finally {
+        await rm(target, { recursive: true, force: true });
+      }
+    });
+
+    it('accepts a symlink whose target stays inside the allowed root', async () => {
+      const real = join(scratch, 'real.ifc');
+      await writeFile(real, 'x');
+      const link = join(scratch, 'link.ifc');
+      await symlink(real, link);
+      const out = await resolveSafePath(link, makeCtx([scratch]), 'read');
+      expect(out).toBe(resolve(real));
+    });
+  });
+
+  describe('sensitive home directories', () => {
+    it('refuses paths under $HOME/.ssh even with the parent in --allow', async () => {
+      const home = homedir();
+      await expect(
+        resolveSafePath(join(home, '.ssh', 'authorized_keys'), makeCtx([home]), 'write'),
+      ).rejects.toThrow(/sensitive home entry/i);
+    });
+
+    it('refuses ~/.aws/credentials specifically', async () => {
+      const home = homedir();
+      await expect(
+        resolveSafePath(join(home, '.aws', 'credentials'), makeCtx([home]), 'write'),
+      ).rejects.toThrow(/sensitive home entry/i);
+    });
+
+    it('allows ordinary $HOME paths', async () => {
+      const home = homedir();
+      const file = join(home, 'a-non-sensitive-file.ifc');
+      const out = await resolveSafePath(file, makeCtx([home]), 'write');
+      expect(out).toBe(resolve(file));
+    });
+  });
+
+  describe('without --allow (default workspace)', () => {
+    it('falls back to cwd / tmpdir / model dirs', async () => {
+      const file = join(scratch, 'unallowed-but-tmp.ifc');
+      // scratch is inside tmpdir by construction, so the default should accept it.
+      const out = await resolveSafePath(file, makeCtx(undefined), 'write');
+      expect(out).toBe(resolve(file));
+    });
+
+    it('uses the loaded models directory as a default root', async () => {
+      const modelDir = await mkdtemp(join(tmpdir(), 'mcp-model-'));
+      const sibling = join(modelDir, 'export.csv');
+      try {
+        const out = await resolveSafePath(
+          sibling,
+          makeCtx(undefined, [join(modelDir, 'model.ifc')]),
+          'write',
+        );
+        expect(out).toBe(resolve(sibling));
+      } finally {
+        await rm(modelDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('input validation', () => {
+    it('rejects an empty string', async () => {
+      await expect(
+        resolveSafePath('', makeCtx([scratch]), 'read'),
+      ).rejects.toBeInstanceOf(ToolExecutionError);
+    });
+
+    it('rejects non-string input', async () => {
+      await expect(
+        resolveSafePath(undefined, makeCtx([scratch]), 'read'),
+      ).rejects.toBeInstanceOf(ToolExecutionError);
+    });
+
+    it('rejects a read of a non-existent file', async () => {
+      await expect(
+        resolveSafePath(join(scratch, 'nope.ifc'), makeCtx([scratch]), 'read'),
+      ).rejects.toThrow(/does not exist/i);
+    });
+  });
+});

--- a/packages/mcp/src/safe-path.ts
+++ b/packages/mcp/src/safe-path.ts
@@ -25,7 +25,7 @@
 
 import { realpath } from 'node:fs/promises';
 import { homedir, tmpdir } from 'node:os';
-import { dirname, resolve, sep } from 'node:path';
+import { basename, dirname, resolve, sep } from 'node:path';
 import type { ModelRegistry, ServerConfig } from './context.js';
 import { ToolErrorCode, ToolExecutionError } from './errors.js';
 
@@ -76,7 +76,7 @@ export async function resolveSafePath(
     });
   }
   const requested = resolve(raw);
-  const roots = buildAllowedRoots(ctx);
+  const roots = await buildAllowedRoots(ctx);
   rejectIfSensitiveHome(requested);
   ensureWithinRoots(requested, roots);
   const canonical = await canonicalise(requested, mode);
@@ -85,17 +85,30 @@ export async function resolveSafePath(
   return canonical;
 }
 
-function buildAllowedRoots(ctx: PathContext): string[] {
-  const roots = new Set<string>();
+async function buildAllowedRoots(ctx: PathContext): Promise<string[]> {
+  const raw = new Set<string>();
   for (const p of ctx.config.allowedPaths ?? []) {
-    roots.add(resolve(p));
+    raw.add(resolve(p));
   }
-  if (roots.size === 0) {
+  if (raw.size === 0) {
     for (const m of ctx.registry.list()) {
-      if (m.filePath) roots.add(dirname(m.filePath));
+      if (m.filePath) raw.add(dirname(m.filePath));
     }
-    roots.add(resolve(process.cwd()));
-    roots.add(resolve(tmpdir()));
+    raw.add(resolve(process.cwd()));
+    raw.add(resolve(tmpdir()));
+  }
+  // Include both the configured form and its realpath. The bounds check
+  // runs first against the requested path (configured form) and then
+  // against its realpath (canonical form); covering both shapes here
+  // ensures a symlinked root (e.g. --allow /workspace where /workspace is
+  // itself a symlink) still accepts files that legitimately live inside.
+  const roots = new Set<string>(raw);
+  for (const root of raw) {
+    try {
+      roots.add(await realpath(root));
+    } catch {
+      /* root does not yet exist on disk; the configured form stays in. */
+    }
   }
   return [...roots];
 }
@@ -148,9 +161,11 @@ async function canonicalise(p: string, mode: PathMode): Promise<string> {
   }
   // Write target: walk up until we find an existing ancestor, realpath it,
   // then reattach the missing tail. This catches symlinks anywhere along
-  // the existing portion of the path.
+  // the existing portion of the path. We use basename() for each segment
+  // so the logic stays correct when an ancestor is the filesystem root
+  // (where slice-by-length arithmetic would be off by one).
   let cursor = dirname(p);
-  const tail: string[] = [p.slice(cursor.length + 1)];
+  const tail: string[] = [basename(p)];
   while (true) {
     try {
       const real = await realpath(cursor);
@@ -165,7 +180,7 @@ async function canonicalise(p: string, mode: PathMode): Promise<string> {
         message: `Path '${p}' has no existing ancestor`,
       });
     }
-    tail.unshift(cursor.slice(parent.length + 1));
+    tail.unshift(basename(cursor));
     cursor = parent;
   }
 }

--- a/packages/mcp/src/safe-path.ts
+++ b/packages/mcp/src/safe-path.ts
@@ -1,0 +1,171 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Safe path resolution for LLM-supplied file paths.
+ *
+ * Every tool that reads from or writes to a path passed in by the LLM should
+ * route through `resolveSafePath`. The helper:
+ *
+ *   1. Verifies the resolved absolute path falls inside an allowed root.
+ *      - When the operator passed `--allow <dir>` flags, those are the only
+ *        roots. This is the strict mode for production deployments.
+ *      - Otherwise a "sensible workspace" default is used: the directories
+ *        of currently-loaded models, the operator's working directory, and
+ *        `os.tmpdir()`. This keeps the OOTB experience usable without
+ *        defaulting to the whole filesystem.
+ *   2. Follows symlinks (via realpath) and re-checks the canonical target
+ *      against the allowlist — a link sitting in an allowed directory
+ *      cannot redirect to arbitrary locations.
+ *   3. Refuses paths that land in a small fixed list of sensitive
+ *      $HOME subdirectories (credentials stores), regardless of how the
+ *      allowlist is configured.
+ */
+
+import { realpath } from 'node:fs/promises';
+import { homedir, tmpdir } from 'node:os';
+import { dirname, resolve, sep } from 'node:path';
+import type { ModelRegistry, ServerConfig } from './context.js';
+import { ToolErrorCode, ToolExecutionError } from './errors.js';
+
+interface PathContext {
+  config: Pick<ServerConfig, 'allowedPaths'>;
+  registry: Pick<ModelRegistry, 'list'>;
+}
+
+/**
+ * Top-level entries under $HOME we always refuse, even when other guards
+ * would allow them. Credentials and key material live here; legitimate tool
+ * workflows almost never need to touch them.
+ */
+const SENSITIVE_HOME_ENTRIES = new Set([
+  '.ssh',
+  '.aws',
+  '.gnupg',
+  '.gpg',
+  '.kube',
+  '.docker',
+  '.gcloud',
+  '.azure',
+  '.npmrc',
+  '.netrc',
+  '.pgpass',
+]);
+
+export type PathMode = 'read' | 'write';
+
+/**
+ * Validate and canonicalise a path supplied by an MCP tool caller.
+ *
+ * - `mode === 'read'`: the file must exist; its realpath must land in an
+ *   allowed root.
+ * - `mode === 'write'`: the file may not exist yet. The realpath of the
+ *   closest existing ancestor is used for the bounds check, then the missing
+ *   tail is reattached.
+ */
+export async function resolveSafePath(
+  raw: unknown,
+  ctx: PathContext,
+  mode: PathMode,
+): Promise<string> {
+  if (typeof raw !== 'string' || raw.length === 0) {
+    throw new ToolExecutionError({
+      code: ToolErrorCode.INVALID_INPUT,
+      message: 'file_path must be a non-empty string',
+    });
+  }
+  const requested = resolve(raw);
+  const roots = buildAllowedRoots(ctx);
+  rejectIfSensitiveHome(requested);
+  ensureWithinRoots(requested, roots);
+  const canonical = await canonicalise(requested, mode);
+  rejectIfSensitiveHome(canonical);
+  ensureWithinRoots(canonical, roots);
+  return canonical;
+}
+
+function buildAllowedRoots(ctx: PathContext): string[] {
+  const roots = new Set<string>();
+  for (const p of ctx.config.allowedPaths ?? []) {
+    roots.add(resolve(p));
+  }
+  if (roots.size === 0) {
+    for (const m of ctx.registry.list()) {
+      if (m.filePath) roots.add(dirname(m.filePath));
+    }
+    roots.add(resolve(process.cwd()));
+    roots.add(resolve(tmpdir()));
+  }
+  return [...roots];
+}
+
+function ensureWithinRoots(absolute: string, roots: string[]): void {
+  if (roots.length === 0) {
+    throw new ToolExecutionError({
+      code: ToolErrorCode.PERMISSION_DENIED,
+      message:
+        'No allowed roots configured; pass --allow <dir> or load a model first.',
+    });
+  }
+  const ok = roots.some(
+    (root) => absolute === root || absolute.startsWith(root + sep),
+  );
+  if (!ok) {
+    throw new ToolExecutionError({
+      code: ToolErrorCode.PERMISSION_DENIED,
+      message: `Path '${absolute}' is outside allowed roots`,
+      details: { roots },
+    });
+  }
+}
+
+function rejectIfSensitiveHome(absolute: string): void {
+  const home = resolve(homedir());
+  if (absolute !== home && !absolute.startsWith(home + sep)) return;
+  const rest = absolute === home ? '' : absolute.slice(home.length + 1);
+  if (rest.length === 0) return;
+  const first = rest.split(sep)[0];
+  if (first && SENSITIVE_HOME_ENTRIES.has(first)) {
+    throw new ToolExecutionError({
+      code: ToolErrorCode.PERMISSION_DENIED,
+      message: `Refusing to access '${absolute}': sensitive home entry '${first}'`,
+    });
+  }
+}
+
+async function canonicalise(p: string, mode: PathMode): Promise<string> {
+  try {
+    return await realpath(p);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
+  if (mode === 'read') {
+    throw new ToolExecutionError({
+      code: ToolErrorCode.INVALID_INPUT,
+      message: `Path '${p}' does not exist`,
+    });
+  }
+  // Write target: walk up until we find an existing ancestor, realpath it,
+  // then reattach the missing tail. This catches symlinks anywhere along
+  // the existing portion of the path.
+  let cursor = dirname(p);
+  const tail: string[] = [p.slice(cursor.length + 1)];
+  while (true) {
+    try {
+      const real = await realpath(cursor);
+      return resolve(real, ...tail);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    }
+    const parent = dirname(cursor);
+    if (parent === cursor) {
+      throw new ToolExecutionError({
+        code: ToolErrorCode.INVALID_INPUT,
+        message: `Path '${p}' has no existing ancestor`,
+      });
+    }
+    tail.unshift(cursor.slice(parent.length + 1));
+    cursor = parent;
+  }
+}

--- a/packages/mcp/src/tools/bcf.ts
+++ b/packages/mcp/src/tools/bcf.ts
@@ -12,7 +12,6 @@
  */
 
 import { writeFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
 import {
   addCommentToTopic,
   addTopicToProject,
@@ -28,6 +27,7 @@ import {
 import type { Tool } from './types.js';
 import { okResult } from './util.js';
 import { ToolErrorCode, ToolExecutionError } from '../errors.js';
+import { resolveSafePath } from '../safe-path.js';
 
 // One project per server instance. We keep it on a module-level Map keyed by
 // session — for stdio that's exactly one entry; for HTTP each session gets
@@ -200,16 +200,7 @@ const bcfExport: Tool = {
   },
   async handler(input, ctx) {
     const project = getProject(ctx.registry);
-    const filePath = resolve(input.file_path as string);
-    if (ctx.config.allowedPaths && ctx.config.allowedPaths.length > 0) {
-      const ok = ctx.config.allowedPaths.some((p) => filePath === p || filePath.startsWith(p + '/'));
-      if (!ok) {
-        throw new ToolExecutionError({
-          code: ToolErrorCode.PERMISSION_DENIED,
-          message: `Path '${filePath}' outside allowed roots`,
-        });
-      }
-    }
+    const filePath = await resolveSafePath(input.file_path, ctx, 'write');
     const blob = (await writeBCF(project)) as unknown as Blob;
     const buffer = Buffer.from(await blob.arrayBuffer());
     await writeFile(filePath, buffer);

--- a/packages/mcp/src/tools/discovery.ts
+++ b/packages/mcp/src/tools/discovery.ts
@@ -20,6 +20,7 @@ import {
 import type { Tool } from './types.js';
 import { resolveModel, okResult } from './util.js';
 import { loadIfcModel } from '../loader.js';
+import { resolveSafePath } from '../safe-path.js';
 import { ToolErrorCode, ToolExecutionError } from '../errors.js';
 
 export const modelInfo: Tool = {
@@ -106,11 +107,16 @@ export const modelLoad: Tool = {
     additionalProperties: false,
   },
   async handler(input, ctx) {
-    const filePath = input.file_path as string;
+    // Resolve the LLM-supplied path through the safe-path policy first.
+    // The resulting absolute path is symlink-canonicalised and bounds-checked
+    // before we touch the filesystem in `loadIfcModel`.
+    const filePath = await resolveSafePath(input.file_path, ctx, 'read');
     try {
       const loaded = await loadIfcModel(filePath, {
         modelId: input.model_id as string | undefined,
-        allowedPaths: ctx.config.allowedPaths,
+        // Path was already validated; loader's secondary check would be a
+        // tautology, so pass a single-entry allowlist matching the file.
+        allowedPaths: [filePath],
       });
       ctx.registry.add(loaded);
       ctx.log.log('info', 'model_load', { id: loaded.id, file: filePath, entities: loaded.store.entityCount });
@@ -119,6 +125,7 @@ export const modelLoad: Tool = {
         { id: loaded.id, name: loaded.name, schema: loaded.store.schemaVersion, entityCount: loaded.store.entityCount },
       );
     } catch (err) {
+      if (err instanceof ToolExecutionError) throw err;
       throw new ToolExecutionError({
         code: ToolErrorCode.PARSE_FAILED,
         message: `Failed to load '${filePath}': ${(err as Error).message}`,

--- a/packages/mcp/src/tools/export.ts
+++ b/packages/mcp/src/tools/export.ts
@@ -11,22 +11,11 @@
  */
 
 import { writeFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
 import type { EntityRef } from '@ifc-lite/sdk';
 import type { Tool } from './types.js';
 import { okResult, resolveModel } from './util.js';
 import { ToolErrorCode, ToolExecutionError } from '../errors.js';
-
-function checkPath(filePath: string, allowed?: string[]): void {
-  if (!allowed || allowed.length === 0) return;
-  const ok = allowed.some((p) => filePath === p || filePath.startsWith(p + '/'));
-  if (!ok) {
-    throw new ToolExecutionError({
-      code: ToolErrorCode.PERMISSION_DENIED,
-      message: `Path '${filePath}' outside allowed roots`,
-    });
-  }
-}
+import { resolveSafePath } from '../safe-path.js';
 
 const exportIfc: Tool = {
   name: 'export_ifc',
@@ -45,8 +34,7 @@ const exportIfc: Tool = {
   },
   async handler(input, ctx) {
     const m = resolveModel(ctx, input.model_id as string | undefined);
-    const filePath = resolve(input.file_path as string);
-    checkPath(filePath, ctx.config.allowedPaths);
+    const filePath = await resolveSafePath(input.file_path, ctx, 'write');
     const schema = (input.schema as 'IFC2X3' | 'IFC4' | 'IFC4X3' | undefined) ?? m.store.schemaVersion;
     let refs: EntityRef[] = [];
     if (Array.isArray(input.global_ids)) {
@@ -86,8 +74,7 @@ const exportCsv: Tool = {
     const refs = (filterType ? m.bim.query().byType(filterType).toArray() : m.bim.query().toArray()).map((e) => e.ref);
     const csv = m.bim.export.csv(refs, { columns: cols, separator: sep });
     if (typeof input.file_path === 'string') {
-      const filePath = resolve(input.file_path);
-      checkPath(filePath, ctx.config.allowedPaths);
+      const filePath = await resolveSafePath(input.file_path, ctx, 'write');
       await writeFile(filePath, csv, 'utf-8');
       return okResult(`Wrote ${csv.length.toLocaleString()} bytes to ${filePath}.`, { filePath, rows: refs.length });
     }
@@ -116,8 +103,7 @@ const exportJson: Tool = {
     const refs = (filterType ? m.bim.query().byType(filterType).toArray() : m.bim.query().toArray()).map((e) => e.ref);
     const rows = m.bim.export.json(refs, cols);
     if (typeof input.file_path === 'string') {
-      const filePath = resolve(input.file_path);
-      checkPath(filePath, ctx.config.allowedPaths);
+      const filePath = await resolveSafePath(input.file_path, ctx, 'write');
       const text = JSON.stringify(rows, null, 2);
       await writeFile(filePath, text, 'utf-8');
       return okResult(`Wrote ${rows.length} rows to ${filePath}.`, { filePath, rows: rows.length });

--- a/packages/mcp/src/tools/mutate.ts
+++ b/packages/mcp/src/tools/mutate.ts
@@ -22,7 +22,6 @@
  */
 
 import { writeFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
 import { EntityNode } from '@ifc-lite/query';
 import { PropertyValueType } from '@ifc-lite/data';
 import type { Mutation } from '@ifc-lite/mutations';
@@ -30,6 +29,7 @@ import type { Tool } from './types.js';
 import { okResult, resolveModel } from './util.js';
 import type { HeadlessLikeBackend } from '../headless-backend.js';
 import { ToolErrorCode, ToolExecutionError } from '../errors.js';
+import { resolveSafePath } from '../safe-path.js';
 
 interface MutationContext {
   m: ReturnType<typeof resolveModel>;
@@ -330,16 +330,7 @@ const modelSave: Tool = {
   },
   async handler(input, ctx) {
     const m = resolveModel(ctx, input.model_id as string | undefined);
-    const filePath = resolve(input.file_path as string);
-    if (ctx.config.allowedPaths && ctx.config.allowedPaths.length > 0) {
-      const ok = ctx.config.allowedPaths.some((p) => filePath === p || filePath.startsWith(p + '/'));
-      if (!ok) {
-        throw new ToolExecutionError({
-          code: ToolErrorCode.PERMISSION_DENIED,
-          message: `Path '${filePath}' outside allowed roots`,
-        });
-      }
-    }
+    const filePath = await resolveSafePath(input.file_path, ctx, 'write');
     const schema = (input.schema as string | undefined) ?? m.store.schemaVersion;
     const content = m.bim.export.ifc([], { schema: schema as 'IFC2X3' | 'IFC4' | 'IFC4X3' });
     const text = typeof content === 'string' ? content : new TextDecoder().decode(content);

--- a/packages/mcp/src/tools/validation.ts
+++ b/packages/mcp/src/tools/validation.ts
@@ -12,13 +12,14 @@
  */
 
 import { readFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
 import { parseIDS, validateIDS, type IFCDataAccessor } from '@ifc-lite/ids';
 import { getInheritanceChainForEntity } from '@ifc-lite/parser';
 import { EntityNode } from '@ifc-lite/query';
 import type { Tool } from './types.js';
 import { okResult, resolveModel } from './util.js';
 import { ToolErrorCode, ToolExecutionError } from '../errors.js';
+import { resolveSafePath } from '../safe-path.js';
+import type { ToolContext } from '../context.js';
 import { buildIdsAccessor } from './ids-accessor.js';
 
 const idsValidate: Tool = {
@@ -37,7 +38,7 @@ const idsValidate: Tool = {
   },
   async handler(input, ctx) {
     const m = resolveModel(ctx, input.model_id as string | undefined);
-    const xml = await loadIdsXml(input, ctx.config.allowedPaths);
+    const xml = await loadIdsXml(input, ctx);
 
     const idsDoc = parseIDS(xml);
     const accessor = buildIdsAccessor(m.store) as IFCDataAccessor;
@@ -70,20 +71,11 @@ const idsValidate: Tool = {
  */
 async function loadIdsXml(
   input: Record<string, unknown>,
-  allowedPaths?: string[],
+  ctx: ToolContext,
 ): Promise<string> {
   if (typeof input.ids_xml === 'string') return input.ids_xml;
   if (typeof input.ids_path === 'string') {
-    const abs = resolve(input.ids_path);
-    if (allowedPaths && allowedPaths.length > 0) {
-      const ok = allowedPaths.some((p) => abs === p || abs.startsWith(p + '/'));
-      if (!ok) {
-        throw new ToolExecutionError({
-          code: ToolErrorCode.PERMISSION_DENIED,
-          message: `Path '${abs}' outside allowed roots`,
-        });
-      }
-    }
+    const abs = await resolveSafePath(input.ids_path, ctx, 'read');
     return readFile(abs, 'utf-8');
   }
   throw new ToolExecutionError({
@@ -139,7 +131,7 @@ const idsExplain: Tool = {
     additionalProperties: false,
   },
   async handler(input, ctx) {
-    const xml = await loadIdsXml(input, ctx.config.allowedPaths);
+    const xml = await loadIdsXml(input, ctx);
 
     const doc = parseIDS(xml) as { specifications?: Array<{ name?: string; applicability?: unknown; requirements?: unknown[] }> };
     const target = input.spec_name as string | undefined;

--- a/rust/core/src/parser.rs
+++ b/rust/core/src/parser.rs
@@ -885,4 +885,29 @@ ENDSEC;\n";
         s.push_str(");");
         assert!(parse_entity(&s).is_ok());
     }
+
+    fn nested(n: usize) -> String {
+        let mut s = String::from("#1=IFCWALL(");
+        for _ in 0..n {
+            s.push('(');
+        }
+        s.push('1');
+        for _ in 0..n {
+            s.push(')');
+        }
+        s.push_str(");");
+        s
+    }
+
+    /// Boundary: parsing succeeds exactly at MAX_NESTING_DEPTH.
+    #[test]
+    fn test_parse_entity_accepts_exactly_max_nesting() {
+        assert!(parse_entity(&nested(MAX_NESTING_DEPTH as usize)).is_ok());
+    }
+
+    /// Boundary: parsing fails at MAX_NESTING_DEPTH + 1.
+    #[test]
+    fn test_parse_entity_rejects_one_over_max_nesting() {
+        assert!(parse_entity(&nested(MAX_NESTING_DEPTH as usize + 1)).is_err());
+    }
 }

--- a/rust/core/src/parser.rs
+++ b/rust/core/src/parser.rs
@@ -145,8 +145,15 @@ fn derived(input: &str) -> IResult<&str, Token<'_>> {
     map(char('*'), |_| Token::Derived)(input)
 }
 
+/// Maximum nesting depth for token recursion (list and typed-value bodies).
+///
+/// Each `(` in the input bumps depth by one. Real-world IFC entities rarely
+/// nest beyond 5-10 levels; 256 leaves comfortable headroom while keeping
+/// the stack bounded against pathological inputs.
+const MAX_NESTING_DEPTH: u32 = 256;
+
 /// Parse typed value: IFCPARAMETERVALUE(0.), IFCBOOLEAN(.T.)
-fn typed_value(input: &str) -> IResult<&str, Token<'_>> {
+fn typed_value_at_depth(input: &str, depth: u32) -> IResult<&str, Token<'_>> {
     map(
         pair(
             // Type name (all caps with optional numbers/underscores)
@@ -154,7 +161,9 @@ fn typed_value(input: &str) -> IResult<&str, Token<'_>> {
             // Arguments
             delimited(
                 char('('),
-                separated_list0(delimited(ws, char(','), ws), token),
+                separated_list0(delimited(ws, char(','), ws), move |i| {
+                    token_at_depth(i, depth)
+                }),
                 char(')'),
             ),
         ),
@@ -170,6 +179,16 @@ fn ws(input: &str) -> IResult<&str, ()> {
 /// Parse a token with optional surrounding whitespace
 /// Optimized ordering: test cheapest patterns first (single-char markers)
 fn token(input: &str) -> IResult<&str, Token<'_>> {
+    token_at_depth(input, 0)
+}
+
+fn token_at_depth(input: &str, depth: u32) -> IResult<&str, Token<'_>> {
+    if depth > MAX_NESTING_DEPTH {
+        return Err(nom::Err::Failure(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::TooLarge,
+        )));
+    }
     delimited(
         ws,
         alt((
@@ -180,22 +199,31 @@ fn token(input: &str) -> IResult<&str, Token<'_>> {
             // Then by complexity
             enum_value,     // .XXX.
             string_literal, // 'xxx'
-            list,           // (...)
+            move |i| list_at_depth(i, depth + 1), // (...)
             // Numbers: float before integer since float includes '.'
             float,
             integer,
-            typed_value, // IFCPARAMETERVALUE(0.) - most expensive, last
+            // IFCPARAMETERVALUE(0.) - most expensive, last
+            move |i| typed_value_at_depth(i, depth + 1),
         )),
         ws,
     )(input)
 }
 
 /// Parse list: (1, 2, 3) or nested lists
+/// Test-only wrapper for the depth-0 entry into list.
+#[cfg(test)]
 fn list(input: &str) -> IResult<&str, Token<'_>> {
+    list_at_depth(input, 0)
+}
+
+fn list_at_depth(input: &str, depth: u32) -> IResult<&str, Token<'_>> {
     map(
         delimited(
             char('('),
-            separated_list0(delimited(ws, char(','), ws), token),
+            separated_list0(delimited(ws, char(','), ws), move |i| {
+                token_at_depth(i, depth)
+            }),
             char(')'),
         ),
         Token::List,
@@ -822,5 +850,39 @@ ENDSEC;\n";
         let mut scanner = EntityScanner::new(content);
         let counts = scanner.count_by_type();
         assert_eq!(counts.get("IFCDOOR"), Some(&1));
+    }
+
+    /// Deeply nested list arguments must return an error rather than
+    /// recursing through the stack until it overflows.
+    #[test]
+    fn test_parse_entity_rejects_excessive_nesting() {
+        let n = (MAX_NESTING_DEPTH as usize) + 64;
+        let mut s = String::from("#1=IFCWALL(");
+        for _ in 0..n {
+            s.push('(');
+        }
+        s.push('1');
+        for _ in 0..n {
+            s.push(')');
+        }
+        s.push_str(");");
+        // Must not panic / overflow; must return Err.
+        assert!(parse_entity(&s).is_err());
+    }
+
+    /// Moderate nesting still parses successfully.
+    #[test]
+    fn test_parse_entity_accepts_moderate_nesting() {
+        let n = 32;
+        let mut s = String::from("#1=IFCWALL(");
+        for _ in 0..n {
+            s.push('(');
+        }
+        s.push('1');
+        for _ in 0..n {
+            s.push(')');
+        }
+        s.push_str(");");
+        assert!(parse_entity(&s).is_ok());
     }
 }


### PR DESCRIPTION
Previously extract_file ran GzDecoder::read_to_end with no upper bound,
then checked data.len() against the configured cap. A small compressed
payload that expands to many GB would allocate first and trip the limit
afterwards. Bound the decoder with .take(max_bytes + 1) and reject if
the cap is met.

Move the size check into extract_file itself; the six call sites no
longer need to duplicate it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file path safety: Restricted access to sensitive system directories (e.g., `.ssh`, `.aws`, `.docker`) when loading and saving files.
  * Enhanced parser resilience: Protected against malformed files with excessive nesting that could cause system hangs.

* **Chores**
  * Centralized file upload size validation across all file parsing endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/louistrue/ifc-lite/pull/691?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->