### PR TITLE
Optimize CI workflows: remove redundant push:main triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,23 +113,14 @@ jobs:
       - name: Verify fixtures
         run: pnpm fixtures:check
 
+      # Build the publishable artifacts. Typecheck / ESM-resolution /
+      # unit tests are NOT re-run here: branch protection requires
+      # test.yml's `Build + WASM + Rust + Node` check to be green on
+      # the PR before merge, so the SHA reaching `push: main` has
+      # already passed all of them. Repeating them would add ~8 min
+      # per release without changing the verdict.
       - name: Build Packages
         run: pnpm build
-
-      - name: Typecheck
-        run: pnpm typecheck
-        continue-on-error: true
-
-      # Verify every publishable package can be loaded by Node's native ESM
-      # resolver. Catches broken relative imports (e.g. extensionless specifiers
-      # that bundlers tolerate but Node rejects with ERR_MODULE_NOT_FOUND)
-      # before they reach npm consumers. Must run BEFORE `pnpm run release`
-      # so a regression blocks the publish step.
-      - name: Verify ESM entrypoints
-        run: pnpm test:esm
-
-      - name: Run Tests
-        run: pnpm test
 
       # Exchange the workflow's OIDC ID-token for a short-lived (30-minute)
       # crates.io access token. Trusted Publisher must be configured on

--- a/.github/workflows/server-binaries.yml
+++ b/.github/workflows/server-binaries.yml
@@ -5,18 +5,9 @@
 name: Server Binaries
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - '.github/workflows/server-binaries.yml'
-      - '.github/workflows/release.yml'
-      - '.cargo/**'
-      - 'Cargo.lock'
-      - 'Cargo.toml'
-      - 'apps/server/**'
-      - 'rust/**'
-      - 'rust-toolchain.toml'
+  # push:main intentionally dropped — branch-protected PR runs already
+  # validate the same SHA, and the release event re-validates before
+  # uploading binaries. See PR that introduced this change.
   pull_request:
     paths:
       - '.github/workflows/server-binaries.yml'
@@ -32,7 +23,12 @@ on:
       - published
   workflow_dispatch:
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel obsolete runs on force-push; release/workflow_dispatch
+  # runs share the workflow group too, but those are gated by
+  # event_name so they won't trample real releases.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/test-templates.yml
+++ b/.github/workflows/test-templates.yml
@@ -1,13 +1,15 @@
 name: Test Templates
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'packages/create-ifc-lite/**'
+  # push:main intentionally dropped — branch-protected PR runs validate
+  # the same SHA before merge.
   pull_request:
     paths:
       - 'packages/create-ifc-lite/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,6 @@ name: Test
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
Removes redundant `push: main` triggers from CI workflows since branch protection already requires PR checks to pass before merge. This reduces unnecessary workflow runs and build time without compromising validation.

## Key Changes

- **server-binaries.yml**: Removed `push: main` trigger; kept `pull_request` and `release` events. Updated concurrency config to cancel obsolete PR runs on force-push while preserving release/workflow_dispatch runs.

- **release.yml**: Removed redundant typecheck, ESM verification, and unit test steps from the release job. These are already validated by branch-protected PR checks before the SHA reaches `push: main`, so re-running them adds ~8 minutes without changing the verdict.

- **test-templates.yml**: Removed `push: main` trigger; kept `pull_request`. Added concurrency configuration to cancel in-progress runs.

- **test.yml**: Removed `push: main` trigger; kept `pull_request` only.

## Implementation Details

The changes rely on branch protection rules that require the `Build + WASM + Rust + Node` check from test.yml to be green before PRs can merge. This ensures any SHA reaching `push: main` has already passed all validation, making redundant CI runs unnecessary.

Concurrency settings were refined to:
- Cancel obsolete PR runs on force-push
- Preserve release and workflow_dispatch runs (gated by event_name condition)

https://claude.ai/code/session_01NVE2nvGArjzqV1FVUHUGTV