### PR TITLE
Use Node 24 in release workflow to support npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,21 +54,16 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 22
+          # Node 24 ships npm ≥ 11.5.1 out of the box, which is what npm
+          # trusted publishing (OIDC handshake) needs. We tried staying on
+          # Node 22 and self-upgrading npm at runtime in Release #426/#427,
+          # but `npm install -g npm@latest` (with and without --force)
+          # leaves the live npm process unable to resolve its own bundled
+          # deps mid-install — `Cannot find module 'promise-retry'` from
+          # @npmcli/arborist/lib/arborist/rebuild.js. Node 24 sidesteps
+          # the self-upgrade entirely.
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
-
-      # npm trusted publishing needs CLI ≥ 11.5.1; Node 22 still ships
-      # npm 10.x. Upgrade explicitly so `changeset publish` (which
-      # invokes pnpm/npm under the hood) can complete the OIDC handshake.
-      #
-      # `--force` is required because npm 10.x rewrites its own files
-      # mid-install when upgrading itself and ends up unable to resolve
-      # its bundled deps (MODULE_NOT_FOUND: promise-retry). See npm/cli#1633.
-      # Verify the version landed so a silent regression to 10.x fails loud.
-      - name: Upgrade npm to a trusted-publishing-capable version
-        run: |
-          npm install -g npm@latest --force
-          npm --version
 
       # rust-toolchain.toml pins nightly-2025-11-15 + wasm32-unknown-unknown.
       # `rustup show` installs that exact toolchain on GHA runners; matches


### PR DESCRIPTION
## Summary
Upgrade the Node.js version in the release workflow from 22 to 24 to natively support npm trusted publishing (OIDC handshake) without requiring manual npm upgrades.

## Changes
- Updated `setup-node` action to use Node 24 instead of Node 22
- Removed the explicit npm upgrade step that was previously required to get npm ≥ 11.5.1
- Replaced the npm upgrade logic with a detailed explanation of why Node 24 is necessary

## Details
Node 24 ships with npm ≥ 11.5.1 out of the box, which is required for npm trusted publishing. Previously, Node 22 shipped with npm 10.x, requiring a manual upgrade via `npm install -g npm@latest --force`. However, this upgrade process had a critical issue: npm 10.x would rewrite its own files mid-install when upgrading itself, leaving the live npm process unable to resolve bundled dependencies (specifically `promise-retry` from `@npmcli/arborist`).

By upgrading to Node 24, we sidestep this self-upgrade problem entirely, making the release workflow more reliable and eliminating the workaround that was attempted in Release #426/#427.

https://claude.ai/code/session_01NVE2nvGArjzqV1FVUHUGTV