### PR TITLE
fix(ci): unblock CI after pnpm/action-setup v6 + TS prep regressions

### DIFF
--- a/.github/workflows/desktop-compat.yml
+++ b/.github/workflows/desktop-compat.yml
@@ -43,9 +43,10 @@ jobs:
           persist-credentials: false
 
       - name: Setup pnpm
+        # v6 reads the version from the `packageManager` field in
+        # package.json (`pnpm@10.8.1`); specifying `with.version` here
+        # would conflict and the action errors with ERR_PNPM_BAD_PM_VERSION.
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,9 +47,10 @@ jobs:
           lfs: false
 
       - name: Setup pnpm
+        # v6 reads the version from the `packageManager` field in
+        # package.json (`pnpm@10.8.1`); specifying `with.version` here
+        # would conflict and the action errors with ERR_PNPM_BAD_PM_VERSION.
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -183,9 +184,10 @@ jobs:
           persist-credentials: false
 
       - name: Setup pnpm
+        # v6 reads the version from the `packageManager` field in
+        # package.json (`pnpm@10.8.1`); specifying `with.version` here
+        # would conflict and the action errors with ERR_PNPM_BAD_PM_VERSION.
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/test-templates.yml
+++ b/.github/workflows/test-templates.yml
@@ -49,9 +49,10 @@ jobs:
           persist-credentials: false
 
       - name: Setup pnpm
+        # v6 reads the version from the `packageManager` field in
+        # package.json (`pnpm@10.8.1`); specifying `with.version` here
+        # would conflict and the action errors with ERR_PNPM_BAD_PM_VERSION.
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/packages/lens/tsconfig.json
+++ b/packages/lens/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
## Summary

Two regressions surfaced after merging the dependabot batch:

1. **pnpm/action-setup v6 (from #693) errors out** with \`ERR_PNPM_BAD_PM_VERSION\` because the action now refuses when both \`with.version\` and package.json \`packageManager\` specify a version. test.yml already dropped the \`version:\` arg in #709; this PR replicates that on release.yml (two job blocks), desktop-compat.yml, and test-templates.yml.

2. **@ifc-lite/lens build fails** under stricter typecheck with \`Cannot find name 'performance'\` in \`packages/lens/src/engine.ts\` — same pattern as the encoding fix in #721. Add \`DOM\` to \`packages/lens/tsconfig.json\` \`lib\` so the browser globals are typed.

## Test plan

- [x] \`pnpm --filter @ifc-lite/lens run build\` clean locally
- [x] No \`with: version: 10\` remaining in any workflow (\`grep -rn "version: 10" .github/workflows/\` empty)
- [x] CI on this branch green
- [x] After merge: \`@dependabot rebase\` on #717, #711, #714 once more so they pick up the lens DOM lib

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to use default pnpm version detection from package configuration instead of explicit pinning, improving version consistency across release and testing pipelines.
  * Enhanced TypeScript configuration for the lens package to include DOM type definitions alongside existing library definitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/louistrue/ifc-lite/pull/722?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->