### PR TITLE
Add Add Element tool to toolbar panels menu

### DIFF
--- a/apps/viewer/src/components/viewer/AddElementPanel.tsx
+++ b/apps/viewer/src/components/viewer/AddElementPanel.tsx
@@ -8,8 +8,8 @@
  * (rendered when `activeTool === 'addElement'`); the actual drop
  * happens on a 3D click handled in `selectionHandlers.ts`.
  *
- * Activation only via the command palette — no menubar button. The
- * tool stays active across drops so the user can place several
+ * Activated via the Panels menu in the toolbar or the command palette.
+ * The tool stays active across drops so the user can place several
  * elements in a row; Esc returns to the select tool.
  */
 

--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -33,6 +33,7 @@ import {
   SquareX,
   Building2,
   Plus,
+  PackagePlus,
   MessageSquare,
   ClipboardCheck,
   Palette,
@@ -91,7 +92,7 @@ import {
 } from '@/services/analysis-extensions';
 
 type Tool = 'select' | 'walk' | 'measure' | 'section' | 'annotate';
-type WorkspacePanel = 'script' | 'list' | 'bcf' | 'ids' | 'lens' | string;
+type WorkspacePanel = 'script' | 'list' | 'bcf' | 'ids' | 'lens' | 'addElement' | string;
 
 function isNativeFileHandle(file: File | NativeFileHandle): file is NativeFileHandle {
   return typeof (file as NativeFileHandle).path === 'string';
@@ -570,7 +571,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
     setScriptPanelVisible,
   ]);
 
-  const handleToggleRightPanel = useCallback((panel: 'bcf' | 'ids' | 'lens') => {
+  const handleToggleRightPanel = useCallback((panel: 'bcf' | 'ids' | 'lens' | 'addElement') => {
     if (activeAnalysisExtension?.placement !== 'bottom') {
       closeActiveAnalysisExtension();
     }
@@ -584,20 +585,30 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
     const nextBcfVisible = panel === 'bcf' ? !bcfPanelVisible : false;
     const nextIdsVisible = panel === 'ids' ? !idsPanelVisible : false;
     const nextLensVisible = panel === 'lens' ? !lensPanelVisible : false;
+    const isAddElementActive = activeTool === 'addElement';
+    const nextAddElementActive = panel === 'addElement' ? !isAddElementActive : false;
 
     setBcfPanelVisible(nextBcfVisible);
     setIdsPanelVisible(nextIdsVisible);
     setLensPanelVisible(nextLensVisible);
 
-    if (nextBcfVisible || nextIdsVisible || nextLensVisible) {
+    if (panel === 'addElement') {
+      setActiveTool(nextAddElementActive ? 'addElement' : 'select');
+    } else if (isAddElementActive) {
+      setActiveTool('select');
+    }
+
+    if (nextBcfVisible || nextIdsVisible || nextLensVisible || nextAddElementActive) {
       setRightPanelCollapsed(false);
     }
   }, [
     activeAnalysisExtension?.placement,
+    activeTool,
     bcfPanelVisible,
     idsPanelVisible,
     lensPanelVisible,
     requireDesktopFeature,
+    setActiveTool,
     setBcfPanelVisible,
     setIdsPanelVisible,
     setLensPanelVisible,
@@ -652,9 +663,11 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
     if (bcfPanelVisible) panels.add('bcf');
     if (idsPanelVisible) panels.add('ids');
     if (lensPanelVisible) panels.add('lens');
+    if (activeTool === 'addElement') panels.add('addElement');
     if (analysisExtensionState.activeId) panels.add(analysisExtensionState.activeId);
     return panels;
   }, [
+    activeTool,
     analysisExtensionState.activeId,
     bcfPanelVisible,
     ganttPanelVisible,
@@ -673,6 +686,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
     if (activeWorkspacePanels.has('bcf')) return 'BCF Issues';
     if (activeWorkspacePanels.has('ids')) return 'IDS Validation';
     if (activeWorkspacePanels.has('lens')) return 'Lens Rules';
+    if (activeWorkspacePanels.has('addElement')) return 'Add Element';
     return activeAnalysisExtension?.label ?? 'Analysis';
   }, [activeAnalysisExtension?.label, activeWorkspacePanels]);
 
@@ -1027,6 +1041,13 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
           >
             <Palette className="h-4 w-4 mr-2" />
             Lens Rules
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuCheckboxItem
+            checked={activeWorkspacePanels.has('addElement')}
+            onCheckedChange={() => handleToggleRightPanel('addElement')}
+          >
+            <PackagePlus className="h-4 w-4 mr-2" />
+            Add Element
           </DropdownMenuCheckboxItem>
           {rightAnalysisExtensions.length > 0 && (
             <>


### PR DESCRIPTION
## Summary
Adds the "Add Element" tool to the workspace panels menu in the main toolbar, allowing users to toggle the tool on/off alongside other panels like BCF Issues, IDS Validation, and Lens Rules.

## Key Changes
- Added `PackagePlus` icon import from lucide-react
- Extended `WorkspacePanel` type to include `'addElement'` as a valid panel option
- Updated `handleToggleRightPanel` callback to handle the `'addElement'` panel:
  - Toggles the active tool between `'addElement'` and `'select'`
  - Automatically switches back to `'select'` when opening other panels
  - Expands the right panel when activating the tool
- Updated `activeWorkspacePanels` memo to track when `activeTool === 'addElement'`
- Updated `rightPanelLabel` memo to display "Add Element" when the tool is active
- Added "Add Element" menu item to the panels dropdown with checkbox state binding
- Updated documentation in `AddElementPanel.tsx` to reflect that the tool can now be activated via the toolbar panels menu (in addition to the command palette)

## Implementation Details
The `addElement` tool is now treated as a workspace panel that can be toggled like other right-side panels. When activated, it sets the active tool to `'addElement'`; when deactivated or when another panel is opened, it reverts to the `'select'` tool. This maintains the existing behavior where only one tool/panel is active at a time.

https://claude.ai/code/session_011bcA9GmqcmCnFdqJo4ZEab