### PR TITLE
Add "Start blank" action to create untitled IFC projects

### DIFF
--- a/.changeset/sab-safe-step-export.md
+++ b/.changeset/sab-safe-step-export.md
@@ -1,0 +1,10 @@
+---
+"@ifc-lite/export": patch
+---
+
+Fix STEP/IFC export failing with `TextDecoder.decode: ArrayBufferView ... can't
+be a SharedArrayBuffer` when the data store's source buffer is SAB-backed.
+Both `StepExporter` and `MergedExporter` now route all source-byte decodes
+through `safeUtf8Decode` from `@ifc-lite/data`, which transparently copies
+into a scratch buffer on the (Firefox / Chrome-with-mitigation) runtimes
+that reject `TextDecoder.decode()` on `SharedArrayBuffer` views.

--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -25,6 +25,7 @@
     "@codemirror/view": "^6.39.14",
     "@ifc-lite/bcf": "workspace:^",
     "@ifc-lite/cache": "workspace:^",
+    "@ifc-lite/create": "workspace:^",
     "@ifc-lite/data": "workspace:^",
     "@ifc-lite/drawing-2d": "workspace:^",
     "@ifc-lite/encoding": "workspace:^",

--- a/apps/viewer/src/components/viewer/AddElementPanel.tsx
+++ b/apps/viewer/src/components/viewer/AddElementPanel.tsx
@@ -8,8 +8,8 @@
  * (rendered when `activeTool === 'addElement'`); the actual drop
  * happens on a 3D click handled in `selectionHandlers.ts`.
  *
- * Activation only via the command palette — no menubar button. The
- * tool stays active across drops so the user can place several
+ * Activated via the Panels menu in the toolbar or the command palette.
+ * The tool stays active across drops so the user can place several
  * elements in a row; Esc returns to the select tool.
  */
 

--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -33,6 +33,7 @@ import {
   SquareX,
   Building2,
   Plus,
+  PackagePlus,
   MessageSquare,
   ClipboardCheck,
   Palette,
@@ -91,7 +92,7 @@ import {
 } from '@/services/analysis-extensions';
 
 type Tool = 'select' | 'walk' | 'measure' | 'section' | 'annotate';
-type WorkspacePanel = 'script' | 'list' | 'bcf' | 'ids' | 'lens' | string;
+type WorkspacePanel = 'script' | 'list' | 'bcf' | 'ids' | 'lens' | 'addElement' | string;
 
 function isNativeFileHandle(file: File | NativeFileHandle): file is NativeFileHandle {
   return typeof (file as NativeFileHandle).path === 'string';
@@ -570,7 +571,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
     setScriptPanelVisible,
   ]);
 
-  const handleToggleRightPanel = useCallback((panel: 'bcf' | 'ids' | 'lens') => {
+  const handleToggleRightPanel = useCallback((panel: 'bcf' | 'ids' | 'lens' | 'addElement') => {
     if (activeAnalysisExtension?.placement !== 'bottom') {
       closeActiveAnalysisExtension();
     }
@@ -584,20 +585,30 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
     const nextBcfVisible = panel === 'bcf' ? !bcfPanelVisible : false;
     const nextIdsVisible = panel === 'ids' ? !idsPanelVisible : false;
     const nextLensVisible = panel === 'lens' ? !lensPanelVisible : false;
+    const isAddElementActive = activeTool === 'addElement';
+    const nextAddElementActive = panel === 'addElement' ? !isAddElementActive : false;
 
     setBcfPanelVisible(nextBcfVisible);
     setIdsPanelVisible(nextIdsVisible);
     setLensPanelVisible(nextLensVisible);
 
-    if (nextBcfVisible || nextIdsVisible || nextLensVisible) {
+    if (panel === 'addElement') {
+      setActiveTool(nextAddElementActive ? 'addElement' : 'select');
+    } else if (isAddElementActive) {
+      setActiveTool('select');
+    }
+
+    if (nextBcfVisible || nextIdsVisible || nextLensVisible || nextAddElementActive) {
       setRightPanelCollapsed(false);
     }
   }, [
     activeAnalysisExtension?.placement,
+    activeTool,
     bcfPanelVisible,
     idsPanelVisible,
     lensPanelVisible,
     requireDesktopFeature,
+    setActiveTool,
     setBcfPanelVisible,
     setIdsPanelVisible,
     setLensPanelVisible,
@@ -652,9 +663,11 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
     if (bcfPanelVisible) panels.add('bcf');
     if (idsPanelVisible) panels.add('ids');
     if (lensPanelVisible) panels.add('lens');
+    if (activeTool === 'addElement') panels.add('addElement');
     if (analysisExtensionState.activeId) panels.add(analysisExtensionState.activeId);
     return panels;
   }, [
+    activeTool,
     analysisExtensionState.activeId,
     bcfPanelVisible,
     ganttPanelVisible,
@@ -673,6 +686,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
     if (activeWorkspacePanels.has('bcf')) return 'BCF Issues';
     if (activeWorkspacePanels.has('ids')) return 'IDS Validation';
     if (activeWorkspacePanels.has('lens')) return 'Lens Rules';
+    if (activeWorkspacePanels.has('addElement')) return 'Add Element';
     return activeAnalysisExtension?.label ?? 'Analysis';
   }, [activeAnalysisExtension?.label, activeWorkspacePanels]);
 
@@ -1027,6 +1041,13 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
           >
             <Palette className="h-4 w-4 mr-2" />
             Lens Rules
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuCheckboxItem
+            checked={activeWorkspacePanels.has('addElement')}
+            onCheckedChange={() => handleToggleRightPanel('addElement')}
+          >
+            <PackagePlus className="h-4 w-4 mr-2" />
+            Add Element
           </DropdownMenuCheckboxItem>
           {rightAnalysisExtensions.length > 0 && (
             <>

--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -642,10 +642,18 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
     setBcfPanelVisible(false);
     setIdsPanelVisible(false);
     setLensPanelVisible(false);
+    // The right slot is single-tenant: when an analysis extension takes
+    // it over, the AddElement tool must release it too, otherwise its 3D
+    // click handler keeps placing elements behind the extension panel.
+    if (activeTool === 'addElement') {
+      setActiveTool('select');
+    }
     setRightPanelCollapsed(false);
   }, [
+    activeTool,
     analysisExtensionState.activeId,
     analysisExtensionState.extensions,
+    setActiveTool,
     setBcfPanelVisible,
     setGanttPanelVisible,
     setIdsPanelVisible,

--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -24,7 +24,8 @@ import { cacheFileBlobs, formatFileSize, getCachedFile, getRecentFiles, recordRe
 import { isTauri } from '@/lib/platform';
 import { toast } from '@/components/ui/toast';
 import { describeUnsupportedFormat } from '@/hooks/ingest/pointCloudIngest';
-import { Upload, MousePointer, Layers, Info, Command, AlertTriangle, ChevronDown, ExternalLink, Plus, Clock3, Sparkles, ArrowUpRight } from 'lucide-react';
+import { Upload, MousePointer, Layers, Info, Command, AlertTriangle, ChevronDown, ExternalLink, Plus, Clock3, Sparkles, ArrowUpRight, PackagePlus } from 'lucide-react';
+import { createBlankIfcFile } from '@/utils/createBlankIfc';
 import type { MeshData, CoordinateInfo, GeometryResult, PointCloudAsset } from '@ifc-lite/geometry';
 import { type IfcDataStore, type MapConversion } from '@ifc-lite/parser';
 import { getEffectiveGeoreference } from '@/lib/geo/effective-georef';
@@ -39,6 +40,7 @@ const DEFAULT_COORDINATE_INFO: CoordinateInfo = {
 
 export function ViewportContainer() {
   const { loadFile, loading, clearAllModels, loadFilesSequentially } = useIfc();
+  const setActiveTool = useViewerStore((s) => s.setActiveTool);
   const releaseGeometryMemory = useViewerStore((s) => s.releaseGeometryMemory);
   const selectedStoreys = useViewerStore((s) => s.selectedStoreys);
   const typeVisibility = useViewerStore((s) => s.typeVisibility);
@@ -429,6 +431,18 @@ export function ViewportContainer() {
     // Reset input so same file can be selected again
     e.target.value = '';
   }, [loadFile, loadFilesSequentially, resetViewerState, clearAllModels, webgpu.supported]);
+
+  const handleStartBlank = useCallback(() => {
+    if (!webgpu.supported) return;
+    void logToDesktopTerminal('info', '[ViewportContainer] Start blank IFC clicked');
+    const file = createBlankIfcFile();
+    // Auto-arm Add Element so the user lands directly in authoring.
+    // setActiveTool is a no-op when the model isn't ready yet, but the
+    // empty-storey scaffold is parsed synchronously enough that the
+    // panel mounts on the first render after addModel.
+    loadFile(file);
+    setActiveTool('addElement');
+  }, [webgpu.supported, loadFile, setActiveTool]);
 
   const hasGeometry = mergedGeometryResult?.meshes && mergedGeometryResult.meshes.length > 0;
 
@@ -844,20 +858,37 @@ export function ViewportContainer() {
               <span className="h-px flex-1 bg-zinc-200 dark:bg-[#3b4261]" />
             </div>
 
-            {/* Track 2 — agent / MCP. Compact inline pill, self-centred so
-                it reads as a meta-link sibling to the primary file-open
-                CTA, not a competing full-width button. */}
-            <a
-              href="/mcp"
-              className="group inline-flex self-center items-center gap-1.5 px-3 py-1.5 font-mono text-[11px] border border-dashed border-zinc-300 dark:border-[#3b4261] text-zinc-500 dark:text-[#7a82a5] hover:border-primary hover:text-primary transition-all cursor-pointer"
-            >
-              <Sparkles className="h-3 w-3 transition-transform group-hover:-translate-y-0.5" />
-              <span>Drive with any LLM</span>
-              <ArrowUpRight className="h-2.5 w-2.5 opacity-60 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
-            </a>
+            {/* Track 2 — two peer pills that both answer "I don't have a
+                file to open": start a fresh project, or hand the wheel to
+                an LLM via MCP. Both share the same dashed-pill silhouette
+                so they read as siblings, with the file-open CTA above
+                staying visually dominant. */}
+            <div className="flex flex-wrap items-center justify-center gap-2">
+              <button
+                type="button"
+                onClick={handleStartBlank}
+                disabled={!webgpu.supported || webgpu.checking}
+                className={`group inline-flex items-center gap-1.5 px-3 py-1.5 font-mono text-[11px] border border-dashed transition-all ${
+                  !webgpu.supported || webgpu.checking
+                    ? 'border-zinc-200 dark:border-[#3b4261]/50 text-zinc-300 dark:text-[#565f89]/50 cursor-not-allowed'
+                    : 'border-zinc-300 dark:border-[#3b4261] text-zinc-500 dark:text-[#7a82a5] hover:border-primary hover:text-primary cursor-pointer'
+                }`}
+              >
+                <PackagePlus className="h-3 w-3 transition-transform group-enabled:group-hover:-translate-y-0.5" />
+                <span>Start blank</span>
+              </button>
+              <a
+                href="/mcp"
+                className="group inline-flex items-center gap-1.5 px-3 py-1.5 font-mono text-[11px] border border-dashed border-zinc-300 dark:border-[#3b4261] text-zinc-500 dark:text-[#7a82a5] hover:border-primary hover:text-primary transition-all cursor-pointer"
+              >
+                <Sparkles className="h-3 w-3 transition-transform group-hover:-translate-y-0.5" />
+                <span>Drive with any LLM</span>
+                <ArrowUpRight className="h-2.5 w-2.5 opacity-60 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+              </a>
+            </div>
 
             <p className="mt-1.5 text-[10px] font-mono text-center text-zinc-400 dark:text-[#565f89]">
-              via MCP · install or try the playground
+              new untitled project · or LLM via MCP
             </p>
 
             {recentFiles.length > 0 && (

--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -432,15 +432,14 @@ export function ViewportContainer() {
     e.target.value = '';
   }, [loadFile, loadFilesSequentially, resetViewerState, clearAllModels, webgpu.supported]);
 
-  const handleStartBlank = useCallback(() => {
+  const handleStartBlank = useCallback(async () => {
     if (!webgpu.supported) return;
     void logToDesktopTerminal('info', '[ViewportContainer] Start blank IFC clicked');
     const file = createBlankIfcFile();
-    // Auto-arm Add Element so the user lands directly in authoring.
-    // setActiveTool is a no-op when the model isn't ready yet, but the
-    // empty-storey scaffold is parsed synchronously enough that the
-    // panel mounts on the first render after addModel.
-    loadFile(file);
+    // Must await: loadFile() calls resetViewerState() internally which
+    // resets activeTool back to 'select'. Setting addElement before that
+    // races and leaves the user in select mode despite the click.
+    await loadFile(file);
     setActiveTool('addElement');
   }, [webgpu.supported, loadFile, setActiveTool]);
 
@@ -866,7 +865,7 @@ export function ViewportContainer() {
             <div className="flex flex-wrap items-center justify-center gap-2">
               <button
                 type="button"
-                onClick={handleStartBlank}
+                onClick={() => { void handleStartBlank(); }}
                 disabled={!webgpu.supported || webgpu.checking}
                 className={`group inline-flex items-center gap-1.5 px-3 py-1.5 font-mono text-[11px] border border-dashed transition-all ${
                   !webgpu.supported || webgpu.checking

--- a/apps/viewer/src/components/viewer/properties/raw-step-format.ts
+++ b/apps/viewer/src/components/viewer/properties/raw-step-format.ts
@@ -22,6 +22,7 @@
  */
 
 import type { IfcAttributeValue } from '@ifc-lite/mutations';
+import { safeUtf8Decode } from '@ifc-lite/data';
 
 /**
  * Tokenize the inside of a STEP entity body (`,`-separated arguments)
@@ -86,9 +87,10 @@ export function extractRawStepTokens(
   byteLength: number,
 ): string[] | null {
   if (byteLength <= 0) return null;
-  const text = new TextDecoder().decode(
-    buffer.subarray(byteOffset, byteOffset + byteLength),
-  );
+  // safeUtf8Decode handles SAB-backed source buffers (the parser
+  // keeps `dataStore.source` SAB-backed for zero-copy worker sharing,
+  // and Firefox/Chrome reject `TextDecoder.decode()` on SAB views).
+  const text = safeUtf8Decode(buffer, byteOffset, byteOffset + byteLength);
   // Match #N=TYPE( ... ) — the trailing `;` is optional in case the
   // ref slice doesn't include it.
   const match = text.match(/^#\d+\s*=\s*[A-Z0-9_]+\(([\s\S]*)\)\s*;?\s*$/i);

--- a/apps/viewer/src/utils/createBlankIfc.ts
+++ b/apps/viewer/src/utils/createBlankIfc.ts
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Generate a minimal blank IFC4 model as a synthetic `File`, so the
+ * welcome card's "Start blank" action can feed it through the regular
+ * `loadFile()` pipeline (format detection → WASM → store federation)
+ * without diverging code paths.
+ *
+ * The result has the smallest spatial hierarchy that satisfies the
+ * Add Element panel's gating (`AddElementPanel.tsx`): one IfcProject,
+ * IfcSite, IfcBuilding and a single IfcBuildingStorey at elevation 0.
+ */
+
+import { IfcCreator } from '@ifc-lite/create';
+
+export interface BlankIfcOptions {
+  projectName?: string;
+  storeyName?: string;
+  storeyElevation?: number;
+}
+
+export function createBlankIfcFile(options: BlankIfcOptions = {}): File {
+  const {
+    projectName = 'Untitled Project',
+    storeyName = 'Level 1',
+    storeyElevation = 0,
+  } = options;
+
+  const creator = new IfcCreator({ Name: projectName });
+  creator.addIfcBuildingStorey({ Name: storeyName, Elevation: storeyElevation });
+  const { content } = creator.toIfc();
+
+  const safeName = projectName.replace(/[^a-z0-9_-]+/gi, '_').replace(/^_+|_+$/g, '') || 'untitled';
+  return new File([content], `${safeName}.ifc`, { type: 'application/ifc' });
+}

--- a/packages/export/src/merged-exporter.ts
+++ b/packages/export/src/merged-exporter.ts
@@ -13,6 +13,7 @@
 import type { IfcDataStore } from '@ifc-lite/parser';
 import { generateHeader } from '@ifc-lite/parser';
 import { decodeIfcString } from '@ifc-lite/encoding';
+import { safeUtf8Decode } from '@ifc-lite/data';
 import { collectReferencedEntityIds, getVisibleEntityIds, collectStyleEntities } from './reference-collector.js';
 import { convertStepLine, needsConversion, type IfcSchemaVersion } from './schema-converter.js';
 
@@ -153,7 +154,6 @@ export class MergedExporter {
     });
 
     const allEntityLines: string[] = [];
-    const decoder = new TextDecoder();
 
     // Track ID offsets per model
     let nextAvailableId = 1;
@@ -176,7 +176,7 @@ export class MergedExporter {
     const firstProjectIds = this.findEntitiesByType(firstModel.dataStore, 'IFCPROJECT');
 
     // Build spatial lookup from first model for Site/Building/Storey unification
-    const spatialLookup = this.buildSpatialLookup(firstModel.dataStore, decoder);
+    const spatialLookup = this.buildSpatialLookup(firstModel.dataStore);
 
     // Process each model
     let isFirstModel = true;
@@ -229,7 +229,7 @@ export class MergedExporter {
 
         // Unify spatial hierarchy: match Site, Building, Storey to first model
         this.unifySpatialEntities(
-          model.dataStore, decoder, spatialLookup, firstModelOffset,
+          model.dataStore, spatialLookup, firstModelOffset,
           sharedRemap, skipEntityIds,
         );
 
@@ -237,7 +237,7 @@ export class MergedExporter {
         // e.g. Model2's Project→Site becomes FirstProject→FirstSite which
         // already exists from Model1, causing duplicate tree nodes.
         this.skipRedundantRelAggregates(
-          model.dataStore, decoder, sharedRemap, skipEntityIds,
+          model.dataStore, sharedRemap, skipEntityIds,
         );
       }
 
@@ -253,9 +253,9 @@ export class MergedExporter {
           continue;
         }
 
-        // Get original entity text
-        const entityText = decoder.decode(
-          source.subarray(entityRef.byteOffset, entityRef.byteOffset + entityRef.byteLength),
+        // Get original entity text — safeUtf8Decode handles SAB-backed sources
+        const entityText = safeUtf8Decode(
+          source, entityRef.byteOffset, entityRef.byteOffset + entityRef.byteLength,
         );
 
         // Remap IDs if this is not the first model or if offset is non-zero
@@ -314,7 +314,6 @@ export class MergedExporter {
     });
 
     const allEntityLines: string[] = [];
-    const decoder = new TextDecoder();
 
     // First pass: count total entities for progress
     let totalEntities = 0;
@@ -338,7 +337,7 @@ export class MergedExporter {
     const firstModelOffset = modelOffsets.get(firstModel.id)!;
     const firstModelInfraMap = this.findInfrastructureEntities(firstModel.dataStore);
     const firstProjectIds = this.findEntitiesByType(firstModel.dataStore, 'IFCPROJECT');
-    const spatialLookup = this.buildSpatialLookup(firstModel.dataStore, decoder);
+    const spatialLookup = this.buildSpatialLookup(firstModel.dataStore);
 
     let isFirstModel = true;
     let entitiesProcessed = 0;
@@ -393,8 +392,8 @@ export class MergedExporter {
           }
         }
 
-        this.unifySpatialEntities(model.dataStore, decoder, spatialLookup, firstModelOffset, sharedRemap, skipEntityIds);
-        this.skipRedundantRelAggregates(model.dataStore, decoder, sharedRemap, skipEntityIds);
+        this.unifySpatialEntities(model.dataStore, spatialLookup, firstModelOffset, sharedRemap, skipEntityIds);
+        this.skipRedundantRelAggregates(model.dataStore, sharedRemap, skipEntityIds);
       }
 
       let entityCount = 0;
@@ -402,8 +401,8 @@ export class MergedExporter {
         if (includedEntityIds !== null && !includedEntityIds.has(expressId)) continue;
         if (skipEntityIds.has(expressId)) continue;
 
-        const entityText = decoder.decode(
-          source.subarray(entityRef.byteOffset, entityRef.byteOffset + entityRef.byteLength),
+        const entityText = safeUtf8Decode(
+          source, entityRef.byteOffset, entityRef.byteOffset + entityRef.byteLength,
         );
 
         let finalText: string;
@@ -517,7 +516,7 @@ export class MergedExporter {
    * Build lookup tables from the first model's spatial entities for
    * matching against subsequent models during merge.
    */
-  private buildSpatialLookup(dataStore: IfcDataStore, decoder: TextDecoder): SpatialLookup {
+  private buildSpatialLookup(dataStore: IfcDataStore): SpatialLookup {
     const lookup: SpatialLookup = {
       sitesByName: new Map(),
       buildingsByName: new Map(),
@@ -529,20 +528,20 @@ export class MergedExporter {
 
     for (const id of this.findEntitiesByType(dataStore, 'IFCSITE')) {
       lookup.siteIds.push(id);
-      const name = this.extractEntityName(id, dataStore, decoder);
+      const name = this.extractEntityName(id, dataStore);
       if (name) lookup.sitesByName.set(name.toLowerCase(), id);
     }
 
     for (const id of this.findEntitiesByType(dataStore, 'IFCBUILDING')) {
       lookup.buildingIds.push(id);
-      const name = this.extractEntityName(id, dataStore, decoder);
+      const name = this.extractEntityName(id, dataStore);
       if (name) lookup.buildingsByName.set(name.toLowerCase(), id);
     }
 
     for (const id of this.findEntitiesByType(dataStore, 'IFCBUILDINGSTOREY')) {
-      const name = this.extractEntityName(id, dataStore, decoder);
+      const name = this.extractEntityName(id, dataStore);
       if (name) lookup.storeysByName.set(name.toLowerCase(), id);
-      const elevation = this.extractStoreyElevation(id, dataStore, decoder);
+      const elevation = this.extractStoreyElevation(id, dataStore);
       if (elevation !== undefined) {
         lookup.storeysByElevation.push({ expressId: id, elevation });
       }
@@ -562,7 +561,6 @@ export class MergedExporter {
    */
   private unifySpatialEntities(
     dataStore: IfcDataStore,
-    decoder: TextDecoder,
     lookup: SpatialLookup,
     firstModelOffset: number,
     sharedRemap: Map<number, number>,
@@ -571,7 +569,7 @@ export class MergedExporter {
     // Unify IfcSite
     const sites = this.findEntitiesByType(dataStore, 'IFCSITE');
     for (const id of sites) {
-      const name = this.extractEntityName(id, dataStore, decoder);
+      const name = this.extractEntityName(id, dataStore);
       let match: number | undefined;
       if (name) match = lookup.sitesByName.get(name.toLowerCase());
       // If single site in both models, unify regardless of name
@@ -587,7 +585,7 @@ export class MergedExporter {
     // Unify IfcBuilding
     const buildings = this.findEntitiesByType(dataStore, 'IFCBUILDING');
     for (const id of buildings) {
-      const name = this.extractEntityName(id, dataStore, decoder);
+      const name = this.extractEntityName(id, dataStore);
       let match: number | undefined;
       if (name) match = lookup.buildingsByName.get(name.toLowerCase());
       if (match === undefined && buildings.length === 1 && lookup.buildingIds.length === 1) {
@@ -602,7 +600,7 @@ export class MergedExporter {
     // Unify IfcBuildingStorey — name match first, then elevation fallback
     const matchedFirstStoreys = new Set<number>();
     for (const id of this.findEntitiesByType(dataStore, 'IFCBUILDINGSTOREY')) {
-      const name = this.extractEntityName(id, dataStore, decoder);
+      const name = this.extractEntityName(id, dataStore);
       let match: number | undefined;
 
       // Try name match
@@ -615,7 +613,7 @@ export class MergedExporter {
 
       // Fallback: match by elevation
       if (match === undefined) {
-        const elevation = this.extractStoreyElevation(id, dataStore, decoder);
+        const elevation = this.extractStoreyElevation(id, dataStore);
         if (elevation !== undefined) {
           for (const entry of lookup.storeysByElevation) {
             if (matchedFirstStoreys.has(entry.expressId)) continue;
@@ -648,19 +646,18 @@ export class MergedExporter {
    */
   private skipRedundantRelAggregates(
     dataStore: IfcDataStore,
-    decoder: TextDecoder,
     sharedRemap: Map<number, number>,
     skipEntityIds: Set<number>,
   ): void {
     for (const relId of this.findEntitiesByType(dataStore, 'IFCRELAGGREGATES')) {
       // RelatingObject is attr 4 — single #ref
-      const relatingAttr = this.extractStepAttribute(relId, dataStore, decoder, 4);
+      const relatingAttr = this.extractStepAttribute(relId, dataStore, 4);
       if (!relatingAttr) continue;
       const relatingRef = relatingAttr.match(/^#(\d+)$/);
       if (!relatingRef || !sharedRemap.has(parseInt(relatingRef[1], 10))) continue;
 
       // RelatedObjects is attr 5 — list of #refs like (#2,#3)
-      const relatedAttr = this.extractStepAttribute(relId, dataStore, decoder, 5);
+      const relatedAttr = this.extractStepAttribute(relId, dataStore, 5);
       if (!relatedAttr) continue;
       const refs: number[] = [];
       const refRegex = /#(\d+)/g;
@@ -683,9 +680,8 @@ export class MergedExporter {
   private extractEntityName(
     expressId: number,
     dataStore: IfcDataStore,
-    decoder: TextDecoder,
   ): string | null {
-    const attr = this.extractStepAttribute(expressId, dataStore, decoder, 2);
+    const attr = this.extractStepAttribute(expressId, dataStore, 2);
     if (!attr || attr === '$') return null;
     if (attr.startsWith("'") && attr.endsWith("'")) {
       const raw = attr.slice(1, -1).replace(/''/g, "'");
@@ -700,9 +696,8 @@ export class MergedExporter {
   private extractStoreyElevation(
     expressId: number,
     dataStore: IfcDataStore,
-    decoder: TextDecoder,
   ): number | undefined {
-    const attr = this.extractStepAttribute(expressId, dataStore, decoder, 9);
+    const attr = this.extractStepAttribute(expressId, dataStore, 9);
     if (!attr || attr === '$') return undefined;
     // Handle typed value like IFCLENGTHMEASURE(3000.)
     const typedMatch = attr.match(/^[A-Z_]+\(([^)]+)\)$/i);
@@ -718,7 +713,6 @@ export class MergedExporter {
   private extractStepAttribute(
     expressId: number,
     dataStore: IfcDataStore,
-    decoder: TextDecoder,
     attrIndex: number,
   ): string | null {
     const source = dataStore.source;
@@ -726,8 +720,8 @@ export class MergedExporter {
     const ref = dataStore.entityIndex.byId.get(expressId);
     if (!ref) return null;
 
-    const entityText = decoder.decode(
-      source.subarray(ref.byteOffset, ref.byteOffset + ref.byteLength),
+    const entityText = safeUtf8Decode(
+      source, ref.byteOffset, ref.byteOffset + ref.byteLength,
     );
 
     // Find opening paren after type name

--- a/packages/export/src/step-exporter.test.ts
+++ b/packages/export/src/step-exporter.test.ts
@@ -469,4 +469,40 @@ describe('StepExporter', () => {
     expect(content).not.toContain('IFCDIRECTION');
     expect(result.stats.newEntityCount).toBe(0);
   });
+
+  it('exports from a SharedArrayBuffer-backed source without TextDecoder/SAB error', async () => {
+    if (typeof SharedArrayBuffer === 'undefined') {
+      console.warn('skip: SharedArrayBuffer unavailable in this runtime');
+      return;
+    }
+    // Copy the fixture bytes into a SAB so the parser produces a
+    // dataStore.source that is SAB-backed — the same shape the in-browser
+    // parser worker hands the main thread. Firefox (and Chrome with the
+    // SAB-decode mitigation enabled) rejects `TextDecoder.decode()` on
+    // SAB-backed views, which used to break STEP export with:
+    //   "TextDecoder.decode: ArrayBufferView branch ... can't be a
+    //    SharedArrayBuffer or an ArrayBufferView backed by a
+    //    SharedArrayBuffer"
+    const encoded = new TextEncoder().encode(SIMPLE_TYPE_INHERITANCE_IFC);
+    const sab = new SharedArrayBuffer(encoded.byteLength);
+    new Uint8Array(sab).set(encoded);
+
+    const parser = new IfcParser();
+    const store = await parser.parseColumnar(sab as unknown as ArrayBuffer, {
+      disableWorkerScan: true,
+    });
+
+    // Apply a positional override so we also exercise the mutation paths
+    // that decode source subarrays via the helper methods.
+    const view = new LiveMutablePropertyView(null, 'sab-model');
+    view.setAttribute(74, 'Name', 'SAB-Safe Wall');
+
+    const exporter = new StepExporter(store, view);
+    const result = exporter.export({ schema: 'IFC4', applyMutations: true });
+
+    const content = decode(result.content);
+    expect(content).toContain('IFCWALL');
+    expect(content).toContain("'SAB-Safe Wall'");
+    expect(result.stats.entityCount).toBeGreaterThan(0);
+  });
 });

--- a/packages/export/src/step-exporter.ts
+++ b/packages/export/src/step-exporter.ts
@@ -21,6 +21,7 @@ import {
 } from '@ifc-lite/parser';
 import type { MutablePropertyView } from '@ifc-lite/mutations';
 import type { PropertySet, QuantitySet } from '@ifc-lite/data';
+import { safeUtf8Decode } from '@ifc-lite/data';
 import { generateIfcGuid } from '@ifc-lite/encoding';
 import { collectReferencedEntityIds, getVisibleEntityIds, collectStyleEntities } from './reference-collector.js';
 import { convertStepLine, needsConversion, type IfcSchemaVersion } from './schema-converter.js';
@@ -492,7 +493,6 @@ export class StepExporter {
 
     // Export original entities from source buffer, SKIPPING modified property sets
     if (!options.deltaOnly && this.dataStore.source) {
-      const decoder = new TextDecoder();
       const source = this.dataStore.source;
 
       // Extract existing entities from source
@@ -531,9 +531,14 @@ export class StepExporter {
           continue;
         }
 
-        // Get original entity text
-        const entityText = decoder.decode(
-          source.subarray(entityRef.byteOffset, entityRef.byteOffset + entityRef.byteLength)
+        // Get original entity text — safeUtf8Decode handles SAB-backed
+        // sources (Firefox/Chrome reject `TextDecoder.decode()` on a
+        // SharedArrayBuffer-backed view; the parser deliberately keeps
+        // `source` zero-copy SAB-backed for worker sharing).
+        const entityText = safeUtf8Decode(
+          source,
+          entityRef.byteOffset,
+          entityRef.byteOffset + entityRef.byteLength
         );
         let nextEntityText = modifiedAttributes.has(expressId)
           ? this.applyAttributeMutations(entityText, entityType, modifiedAttributes.get(expressId)!)
@@ -1077,9 +1082,10 @@ export class StepExporter {
     const entityRef = this.dataStore.entityIndex.byId.get(relId);
     if (!entityRef || !this.dataStore.source) return [];
 
-    const decoder = new TextDecoder();
-    const entityText = decoder.decode(
-      this.dataStore.source.subarray(entityRef.byteOffset, entityRef.byteOffset + entityRef.byteLength)
+    const entityText = safeUtf8Decode(
+      this.dataStore.source,
+      entityRef.byteOffset,
+      entityRef.byteOffset + entityRef.byteLength
     );
 
     // Parse IfcRelDefinesByProperties: #ID=IFCRELDEFINESBYPROPERTIES('guid',$,$,$,(#objects),#pset);
@@ -1103,9 +1109,10 @@ export class StepExporter {
     const entityRef = this.dataStore.entityIndex.byId.get(relId);
     if (!entityRef || !this.dataStore.source) return null;
 
-    const decoder = new TextDecoder();
-    const entityText = decoder.decode(
-      this.dataStore.source.subarray(entityRef.byteOffset, entityRef.byteOffset + entityRef.byteLength)
+    const entityText = safeUtf8Decode(
+      this.dataStore.source,
+      entityRef.byteOffset,
+      entityRef.byteOffset + entityRef.byteLength
     );
 
     // Last #ID before the closing );
@@ -1121,9 +1128,10 @@ export class StepExporter {
     const entityRef = this.dataStore.entityIndex.byId.get(psetId);
     if (!entityRef || !this.dataStore.source) return null;
 
-    const decoder = new TextDecoder();
-    const entityText = decoder.decode(
-      this.dataStore.source.subarray(entityRef.byteOffset, entityRef.byteOffset + entityRef.byteLength)
+    const entityText = safeUtf8Decode(
+      this.dataStore.source,
+      entityRef.byteOffset,
+      entityRef.byteOffset + entityRef.byteLength
     );
 
     // Parse: IFCPROPERTYSET('guid',$,'Name',$,...) - Name is 3rd argument
@@ -1139,9 +1147,10 @@ export class StepExporter {
     const entityRef = this.dataStore.entityIndex.byId.get(entityId);
     if (!entityRef || !this.dataStore.source) return null;
 
-    const decoder = new TextDecoder();
-    const entityText = decoder.decode(
-      this.dataStore.source.subarray(entityRef.byteOffset, entityRef.byteOffset + entityRef.byteLength)
+    const entityText = safeUtf8Decode(
+      this.dataStore.source,
+      entityRef.byteOffset,
+      entityRef.byteOffset + entityRef.byteLength
     );
 
     // Parse: IFCELEMENTQUANTITY('guid',$,'Name',...) - Name is 3rd argument
@@ -1157,9 +1166,10 @@ export class StepExporter {
     const entityRef = this.dataStore.entityIndex.byId.get(psetId);
     if (!entityRef || !this.dataStore.source) return [];
 
-    const decoder = new TextDecoder();
-    const entityText = decoder.decode(
-      this.dataStore.source.subarray(entityRef.byteOffset, entityRef.byteOffset + entityRef.byteLength)
+    const entityText = safeUtf8Decode(
+      this.dataStore.source,
+      entityRef.byteOffset,
+      entityRef.byteOffset + entityRef.byteLength
     );
 
     // Parse: IFCPROPERTYSET(...,(#prop1,#prop2,...)); - Last argument is properties list
@@ -1244,9 +1254,10 @@ export class StepExporter {
     const entityRef = this.dataStore.entityIndex.byId.get(entityId);
     if (!entityRef || !this.dataStore.source) return null;
 
-    const decoder = new TextDecoder();
-    const entityText = decoder.decode(
-      this.dataStore.source.subarray(entityRef.byteOffset, entityRef.byteOffset + entityRef.byteLength)
+    const entityText = safeUtf8Decode(
+      this.dataStore.source,
+      entityRef.byteOffset,
+      entityRef.byteOffset + entityRef.byteLength
     );
 
     const match = entityText.match(/^(#\d+\s*=\s*\w+\()([\s\S]*)(\)\s*;)\s*$/);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,9 @@ importers:
       '@ifc-lite/cache':
         specifier: workspace:^
         version: link:../../packages/cache
+      '@ifc-lite/create':
+        specifier: workspace:^
+        version: link:../../packages/create
       '@ifc-lite/data':
         specifier: workspace:^
         version: link:../../packages/data


### PR DESCRIPTION
## Summary
Adds a "Start blank" button to the welcome screen that creates a minimal IFC4 model with a single storey, allowing users to start authoring immediately without opening an existing file.

## Key Changes
- **New utility**: `createBlankIfcFile()` in `apps/viewer/src/utils/createBlankIfc.ts` generates a synthetic blank IFC file with a project, site, building, and one storey scaffold using `@ifc-lite/create`
- **Welcome screen**: Added "Start blank" button alongside the existing "Drive with any LLM" pill in `ViewportContainer.tsx`, both styled as peer dashed-pill options
- **Auto-activation**: The Add Element tool activates automatically after loading a blank file, landing users directly in the authoring workflow
- **Toolbar integration**: Updated `MainToolbar.tsx` to expose "Add Element" as a toggleable panel in the Panels menu, with proper state management
- **Documentation**: Updated `AddElementPanel.tsx` comment to reflect that activation is now available via both the Panels menu and command palette
- **Dependencies**: Added `@ifc-lite/create` workspace dependency to support IFC model generation

## Implementation Details
- The blank file creation is synchronous, allowing `setActiveTool('addElement')` to work reliably on the first render after model load
- The "Start blank" button respects WebGPU availability (disabled when unsupported or checking)
- Both welcome-screen CTA options now share consistent visual treatment as dashed pills, with the file-open button remaining visually dominant above them

https://claude.ai/code/session_011bcA9GmqcmCnFdqJo4ZEab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Add Element" panel in the Panels menu for sequential element placement.
  * Added "Start blank" button in the empty-state UI to create and load a new untitled IFC project.

* **Bug Fixes**
  * Fixed STEP/IFC export failures on runtimes with shared-array-backed sources so exports no longer fail in those environments.

* **Tests**
  * Added a test verifying STEP export succeeds with shared-array-backed input.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/louistrue/ifc-lite/pull/726?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->