### PR TITLE
revert(deps-dev): pin vite to ^7.3.3 (revert #741) — fix prod blank screen

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -59,6 +59,6 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^4.2.0",
     "typescript": "^6.0.3",
-    "vite": "^8.0.13"
+    "vite": "^7.3.3"
   }
 }

--- a/apps/viewer-embed/package.json
+++ b/apps/viewer-embed/package.json
@@ -42,7 +42,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^4.2.0",
     "typescript": "^6.0.3",
-    "vite": "^8.0.13",
+    "vite": "^7.3.3",
     "vite-plugin-top-level-await": "^1.6.0",
     "vite-plugin-wasm": "^3.6.0"
   }

--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -90,7 +90,7 @@
     "jszip": "^3.10.0",
     "tsx": "^4.22.1",
     "typescript": "^6.0.3",
-    "vite": "^8.0.13",
+    "vite": "^7.3.3",
     "vite-plugin-static-copy": "^4.1.0",
     "vite-plugin-top-level-await": "^1.6.0",
     "vite-plugin-wasm": "^3.6.0"

--- a/examples/babylonjs-viewer/package.json
+++ b/examples/babylonjs-viewer/package.json
@@ -17,6 +17,6 @@
   },
   "devDependencies": {
     "typescript": "^6.0.3",
-    "vite": "^8.0.13"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/collab-demo/package.json
+++ b/examples/collab-demo/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "typescript": "^6.0.3",
-    "vite": "^8.0.13",
+    "vite": "^7.3.3",
     "vite-plugin-top-level-await": "^1.6.0",
     "vite-plugin-wasm": "^3.6.0"
   }

--- a/examples/threejs-collab/package.json
+++ b/examples/threejs-collab/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@types/three": "^0.184.1",
     "typescript": "^6.0.3",
-    "vite": "^8.0.13",
+    "vite": "^7.3.3",
     "vite-plugin-top-level-await": "^1.5.0",
     "vite-plugin-wasm": "^3.6.0"
   }

--- a/examples/threejs-viewer/package.json
+++ b/examples/threejs-viewer/package.json
@@ -18,6 +18,6 @@
   "devDependencies": {
     "@types/three": "^0.184.1",
     "typescript": "^6.0.3",
-    "vite": "^8.0.13"
+    "vite": "^7.3.3"
   }
 }


### PR DESCRIPTION
## Summary
Production deploy `ifc-lite-4sasmdrsp-ltplus.vercel.app` (commit fc56039, from #741) renders a blank screen with:
> Uncaught TypeError: undefined is not a function — selectionHandlers-DKXTIA92.js:1

### Root cause
Vite 8 used Rolldown for the prod build. The deployed bundle imports from \`./rolldown-runtime-*.js\` (Rollup builds have no such helper). The \`selectionHandlers-*.js\` chunk imports \`n\` (aliased from \`it\`) out of \`store-*.js\` and calls \`n(a.models, ...)\`, but \`it\` resolves to \`undefined\` — Rolldown's tree-shaking/export-mangling drops/renames the symbol differently than Rollup.

Local builds via \`pnpm build\` did **not** reproduce this (no \`rolldown-runtime-*.js\` produced, all viewer code lands in \`index-*.js\`), suggesting Vercel's environment activated Rolldown but local did not.

Additionally, the rebase of #743 (@types/node) on top of #741 already clobbered \`pnpm-lock.yaml\` back to vite\@7.3.3 — leaving \`apps/viewer/package.json\` at \`^8.0.13\` but the lockfile at \`7.3.3\`. So even a redeploy from HEAD would have been inconsistent.

### Fix
Pin \`vite\` back to \`^7.3.3\` in all 7 affected \`package.json\` files (the same set #741 touched). Lockfile already says 7.3.3, so this commit has zero lockfile diff and the build is internally consistent again.

### Follow-up
- Re-attempt vite 8 once Rolldown's export handling stabilises. Open a tracking issue rather than letting Dependabot re-open #741 immediately.
- Add \`vite\` to a \`dependabot.yml\` ignore (or pin upper bound) until then.

## Test plan
- [ ] Vercel preview for this PR loads without the \`undefined is not a function\` runtime error.
- [ ] After merge, production deploy of \`main\` no longer ships \`rolldown-runtime-*.js\` chunks.
- [ ] \`pnpm install --frozen-lockfile\` succeeds on a clean clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)