### PR TITLE
chore(dependabot): ignore vite semver-major (narrow scope after codex review)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,24 +24,20 @@ updates:
         update-types:
           - minor
           - patch
-    # Ecosystems with known runtime breakage on recent majors.
-    # Lift each entry once we've validated the next major locally.
+    # NOTE: `ignore` blocks BOTH version-update PRs and Dependabot
+    # security-update PRs for the matched scope. Only ignore here when
+    # the CVE-coverage cost is worth the noise reduction.
+    # Runtime deps (apache-arrow, @anthropic-ai/sdk) intentionally stay
+    # unignored so security PRs continue to flow; we'll close noisy
+    # major bumps manually if they reappear.
     ignore:
-      # vite 8 switched the prod build to Rolldown and shipped a broken
-      # `selectionHandlers` chunk to ifc-lite-ltplus.vercel.app (see #741, #746).
+      # vite is devDependency-only — CVE risk is mostly build-time.
+      # Vite 8 switched the prod build to Rolldown and shipped a broken
+      # `selectionHandlers` chunk to ifc-lite-ltplus.vercel.app
+      # (see #741 / #746). Block the next semver-major until Rolldown
+      # output is verified stable for this repo.
       - dependency-name: "vite"
         update-types: ["version-update:semver-major"]
-      # arrow + parquet must bump in lockstep on the Rust side; the npm
-      # apache-arrow major jumps tend to land at the same time and need
-      # coordinated review (see #738, #745).
-      - dependency-name: "apache-arrow"
-        update-types: ["version-update:semver-major"]
-      # Pre-1.0 SDK — Dependabot's "minor-and-patch" group treated a
-      # 0.39 → 0.96 jump as minor. Hold all non-patch bumps for manual review.
-      - dependency-name: "@anthropic-ai/sdk"
-        update-types:
-          - "version-update:semver-major"
-          - "version-update:semver-minor"
 
   - package-ecosystem: cargo
     directory: /

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,24 @@ updates:
         update-types:
           - minor
           - patch
+    # Ecosystems with known runtime breakage on recent majors.
+    # Lift each entry once we've validated the next major locally.
+    ignore:
+      # vite 8 switched the prod build to Rolldown and shipped a broken
+      # `selectionHandlers` chunk to ifc-lite-ltplus.vercel.app (see #741, #746).
+      - dependency-name: "vite"
+        update-types: ["version-update:semver-major"]
+      # arrow + parquet must bump in lockstep on the Rust side; the npm
+      # apache-arrow major jumps tend to land at the same time and need
+      # coordinated review (see #738, #745).
+      - dependency-name: "apache-arrow"
+        update-types: ["version-update:semver-major"]
+      # Pre-1.0 SDK — Dependabot's "minor-and-patch" group treated a
+      # 0.39 → 0.96 jump as minor. Hold all non-patch bumps for manual review.
+      - dependency-name: "@anthropic-ai/sdk"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
 
   - package-ecosystem: cargo
     directory: /


### PR DESCRIPTION
## Summary
Prevents Dependabot from reopening **vite** `^7.x` → `^8.x` weekly. Vite 8 switched the prod build to Rolldown and shipped a broken \`selectionHandlers-*.js\` chunk to ifc-lite-ltplus.vercel.app (\`undefined is not a function\`, blank screen) — reverted in #746.

## Scope (narrowed after codex feedback)
Per GitHub's [Dependabot docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/controlling-dependencies-updated), \`ignore\` blocks **both** version-update PRs and security-update PRs for the matched scope. The original draft also ignored \`apache-arrow\` and \`@anthropic-ai/sdk\` — those are runtime deps where CVE coverage matters more than noise reduction, so they've been removed. We'll close noisy majors manually if they reappear.

Only \`vite\` remains in the ignore list because it's a devDependency: build-time CVEs are rarely critical, and the Rolldown breakage is a known runtime hazard.

## Test plan
- [ ] After merge, no new Dependabot PR for vite ≥ 8 on the next weekly run.
- [ ] apache-arrow and @anthropic-ai/sdk version + security PRs still flow.
- [ ] When ready to re-attempt vite 8: delete the \`vite\` entry and validate the Rolldown prod build locally first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to stabilize the build environment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/louistrue/ifc-lite/pull/747?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->