### PR TITLE
chore(sdk): republish @ifc-lite/sdk with bSDD exports (fixes broken npx @ifc-lite/cli)

### DIFF
--- a/.changeset/republish-sdk-bsdd.md
+++ b/.changeset/republish-sdk-bsdd.md
@@ -1,0 +1,19 @@
+---
+"@ifc-lite/sdk": minor
+---
+
+Publish the bSDD namespace and the IDS/performance work that landed in the SDK
+since 1.15.0 but was never released.
+
+The published `@ifc-lite/sdk@1.15.0` build predates three source changes
+(#607 hot-path memoization, #615 the bSDD namespace, #623 IDS document auditing
+and schema validation) because none of those PRs included a changeset bumping
+`@ifc-lite/sdk`. As a result the registry build is missing the `BsddNamespace`
+and `BsddHttpError` exports.
+
+`@ifc-lite/mcp` imports `BsddHttpError` from `@ifc-lite/sdk`, so a fresh
+`npx @ifc-lite/cli` (which depends on `@ifc-lite/mcp`) crashed at module load
+with `does not provide an export named 'BsddHttpError'`. Releasing `@ifc-lite/sdk@1.16.0`
+makes the existing `^1.15.0` ranges in the already-published `@ifc-lite/mcp` and
+`@ifc-lite/cli` resolve to a build that has the export — no republish of those
+two packages is required.


### PR DESCRIPTION
## Problem

A fresh `npx @ifc-lite/cli` crashes immediately:

```
import { BsddHttpError } from '@ifc-lite/sdk';
SyntaxError: The requested module '@ifc-lite/sdk' does not provide an export named 'BsddHttpError'
  at .../@ifc-lite/mcp/dist/tools/bsdd.js
```

Reproduced in a clean install of `@ifc-lite/cli@0.8.0`.

## Root cause

The published `@ifc-lite/sdk@1.15.0` build is **stale by three feature PRs**. Its `package.json` version was never bumped after these landed:

| PR | Change to `packages/sdk/src` |
|----|----|
| #607 | hot-path memoization / indexing |
| #615 | **added `BsddHttpError` / `BsddNamespace` exports** |
| #623 | IDS document auditing + schema validation |

None of those PRs included a changeset for `@ifc-lite/sdk`, so Changesets never released a new build. Confirmed against the registry tarball — `dist/index.js` of the published `1.15.0` has zero matches for `BsddHttpError`.

Meanwhile `@ifc-lite/mcp@0.2.0` was published with `"@ifc-lite/sdk": "^1.15.0"` and compiled code that imports `BsddHttpError`. `@ifc-lite/cli` depends on `@ifc-lite/mcp`, so the CLI dies before running any command — even `--version`.

## Fix

A changeset bumping `@ifc-lite/sdk` **minor** (new exports → minor). On release this publishes `@ifc-lite/sdk@1.16.0`.

The already-published `@ifc-lite/mcp@0.2.0` and `@ifc-lite/cli@0.8.0` carry `^1.15.0` ranges, which resolve to `1.16.0` once it is on the registry — **no republish of mcp/cli is required** to unbreak users.

`pnpm changeset version` dry-run verified: bumps `@ifc-lite/sdk` 1.15.0 → 1.16.0 only.

## Follow-up (not in this PR)

Three sdk-modifying PRs shipped without a changeset. A CI guard that fails when `packages/*/src` changes without a matching changeset would prevent recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* **`@ifc-lite/sdk`** republished (v1.16.0) with restored namespace and error exports that were missing in the previous release, resolving stability issues in related packages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LTplus-AG/ifc-lite/pull/759?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->