### PR TITLE
fix(embed): publish compiled JS for embed-protocol & embed-sdk (not raw TypeScript)

### DIFF
--- a/.changeset/fix-embed-packages-build.md
+++ b/.changeset/fix-embed-packages-build.md
@@ -1,0 +1,16 @@
+---
+"@ifc-lite/embed-protocol": patch
+"@ifc-lite/embed-sdk": patch
+---
+
+Ship compiled JavaScript instead of raw TypeScript source.
+
+Both packages previously published with `main`/`types`/`exports` pointing at
+`./src/index.ts` and no build step, so the tarball contained only
+`src/index.ts`. A plain `npm install` + `import` failed with
+`Unknown file extension ".ts"` in Node, and the packages were fragile under
+`tsc`, Jest, ts-node, and non-esbuild bundlers — despite `@ifc-lite/embed-sdk`
+being intended for external embedding (Power BI, Superset, Grafana).
+
+They now build with `tsc` to `dist/` and export `./dist/index.js` +
+`./dist/index.d.ts`, matching every other publishable package in the repo.

--- a/packages/embed-protocol/package.json
+++ b/packages/embed-protocol/package.json
@@ -3,13 +3,23 @@
   "version": "1.14.3",
   "description": "Shared postMessage protocol types for ifc-lite embed viewer and SDK",
   "type": "module",
-  "main": "src/index.ts",
-  "types": "src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
   },
+  "scripts": {
+    "build": "pnpm exec tsc",
+    "dev": "pnpm exec tsc --watch"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  },
+  "license": "MPL-2.0",
   "files": [
-    "src"
-  ],
-  "license": "MPL-2.0"
+    "dist"
+  ]
 }

--- a/packages/embed-sdk/package.json
+++ b/packages/embed-sdk/package.json
@@ -3,16 +3,23 @@
   "version": "1.14.3",
   "description": "SDK for embedding the IFC-Lite 3D viewer in any web page via iframe",
   "type": "module",
-  "main": "src/index.ts",
-  "types": "src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
   },
-  "files": [
-    "src"
-  ],
+  "scripts": {
+    "build": "pnpm exec tsc",
+    "dev": "pnpm exec tsc --watch"
+  },
   "dependencies": {
     "@ifc-lite/embed-protocol": "workspace:^"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
   },
   "license": "MPL-2.0",
   "keywords": [
@@ -24,5 +31,8 @@
     "power-bi",
     "superset",
     "grafana"
+  ],
+  "files": [
+    "dist"
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -864,13 +864,21 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.13)(@types/node@25.8.0)(happy-dom@20.9.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.1)
 
-  packages/embed-protocol: {}
+  packages/embed-protocol:
+    devDependencies:
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
 
   packages/embed-sdk:
     dependencies:
       '@ifc-lite/embed-protocol':
         specifier: workspace:^
         version: link:../embed-protocol
+    devDependencies:
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
 
   packages/encoding:
     devDependencies:


### PR DESCRIPTION
## Problem

`@ifc-lite/embed-protocol@1.14.3` and `@ifc-lite/embed-sdk@1.14.3` publish **uncompiled TypeScript**. Their `main`, `types`, and `exports` all point at `./src/index.ts`, there is no `build` script, and the tarball contains only `src/index.ts` + `LICENSE`.

A clean install fails in plain Node:

```
$ npm i @ifc-lite/embed-sdk
$ node -e "import('@ifc-lite/embed-sdk')"
TypeError: Unknown file extension ".ts" for .../node_modules/@ifc-lite/embed-sdk/src/index.ts
```

It only "works" under esbuild/Vite (which strip types); it is fragile under `tsc`, Jest, ts-node, and webpack/ts-loader. `@ifc-lite/embed-sdk` is explicitly meant for external embedding (`keywords: power-bi, superset, grafana`), so shipping raw TS is a real defect, and these are the only two of 32 published packages that do it.

Found while smoke-testing every published package the way a user would (`npm install` + `import`) after the `@ifc-lite/sdk` / `BsddHttpError` regression (#759).

## Fix

Both packages now build with `tsc` to `dist/` and export `./dist/index.js` + `./dist/index.d.ts`, matching every other publishable package:

- add `build` (`pnpm exec tsc`) and `dev` scripts
- repoint `main`/`types`/`exports` at `dist`
- `files: ["dist"]`
- add the `typescript` devDependency

Their `tsconfig.json` already had `outDir: ./dist` / `rootDir: ./src`, so no tsconfig change was needed.

## Verified

- `pnpm --filter @ifc-lite/embed-protocol --filter @ifc-lite/embed-sdk build` → emits `index.js` + `index.d.ts` (+ maps)
- `pnpm pack` → install the tarballs in a clean Node project → `import` of both succeeds:
  - `embed-protocol`: `EMBED_SOURCE, PROTOCOL_VERSION, createCommand, createEvent, createResponse, isEmbedMessage`
  - `embed-sdk`: `IFCLiteEmbed`
- packed `embed-sdk` has its `workspace:^` rewritten to `^1.14.3` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed distribution package configuration for `@ifc-lite/embed-protocol` and `@ifc-lite/embed-sdk` to ship compiled JavaScript and TypeScript type definitions from the build directory. Previously publishing raw source files caused compatibility issues with runtime environments and bundlers. Package entrypoints are now properly aligned with built artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LTplus-AG/ifc-lite/pull/760?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->