### PR TITLE
test(mcp): fix safe-path test failing on macOS (symlinked tmpdir)

### DIFF
--- a/packages/mcp/src/safe-path.test.ts
+++ b/packages/mcp/src/safe-path.test.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { mkdir, mkdtemp, symlink, writeFile, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, realpath, symlink, writeFile, rm } from 'node:fs/promises';
 import { homedir, tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -25,7 +25,11 @@ describe('resolveSafePath', () => {
   let scratch: string;
 
   beforeEach(async () => {
-    scratch = await mkdtemp(join(tmpdir(), 'mcp-safe-path-'));
+    // realpath() so the root is canonical: on macOS tmpdir() lives under
+    // /var, a symlink to /private/var. resolveSafePath always returns
+    // realpath-canonicalized paths, so the test's expected values must be
+    // canonical too — otherwise every `toBe(resolve(...))` assertion fails.
+    scratch = await realpath(await mkdtemp(join(tmpdir(), 'mcp-safe-path-')));
   });
 
   afterEach(async () => {
@@ -105,7 +109,7 @@ describe('resolveSafePath', () => {
       // Operator passes --allow <link>; the link points at the real workspace
       // dir. Files inside should be accepted even though their realpath lives
       // under the link's target rather than the configured root.
-      const realWorkspace = await mkdtemp(join(tmpdir(), 'mcp-realws-'));
+      const realWorkspace = await realpath(await mkdtemp(join(tmpdir(), 'mcp-realws-')));
       const linkedRoot = join(scratch, 'linked-root');
       try {
         await symlink(realWorkspace, linkedRoot);
@@ -164,7 +168,7 @@ describe('resolveSafePath', () => {
     });
 
     it('uses the loaded models directory as a default root', async () => {
-      const modelDir = await mkdtemp(join(tmpdir(), 'mcp-model-'));
+      const modelDir = await realpath(await mkdtemp(join(tmpdir(), 'mcp-model-')));
       const sibling = join(modelDir, 'export.csv');
       try {
         const out = await resolveSafePath(


### PR DESCRIPTION
## Problem

`pnpm test` fails for any contributor on macOS — `@ifc-lite/mcp`'s `src/safe-path.test.ts` has 6 failing assertions:

```
× resolveSafePath > accepts a path inside an allowed root for read
  Expected: "/var/folders/.../mcp-safe-path-XXXX/model.ifc"
  Received: "/private/var/folders/.../mcp-safe-path-XXXX/model.ifc"
```

CI stays green because Linux `/tmp` is a real directory.

## Root cause

`resolveSafePath` deliberately follows symlinks via `realpath` — that canonicalization is its security purpose (re-checking the real target against the allowed roots). It therefore always returns a realpath-resolved path.

The test asserted `expect(out).toBe(resolve(file))`, and `path.resolve()` does **not** resolve symlinks. On macOS `os.tmpdir()` returns `/var/folders/...`, and `/var` is a symlink to `/private/var`, so the two diverge. The implementation is correct; the test's expected value was not canonical.

## Fix

`realpath()` the three `mkdtemp` roots whose paths are later compared (`scratch`, `realWorkspace`, `modelDir`) so the test's expectations are canonical, matching what `resolveSafePath` guarantees. Pure test change — `resolveSafePath` is untouched.

## Verified

`pnpm --filter @ifc-lite/mcp test` → **50/50 pass** (was 44/50 on macOS). Full `pnpm test` → **59/59 task suites pass**.

Found during a full typecheck/build/test sweep of `main` (typecheck 28/28, build 34/34, tests 59/59 — this was the only code-level failure; the rest of the run just needed `pnpm fixtures`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced path handling in test setup to use canonicalized directory paths, improving test reliability across different operating systems. This ensures tests properly account for symlinked paths, particularly on macOS where temporary directories may be symlinked.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LTplus-AG/ifc-lite/pull/761?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->