### PR TITLE
fix(embed): add repository field so npm provenance publish passes

### DIFF
--- a/packages/embed-protocol/package.json
+++ b/packages/embed-protocol/package.json
@@ -19,6 +19,11 @@
     "typescript": "^6.0.3"
   },
   "license": "MPL-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LTplus-AG/ifc-lite.git",
+    "directory": "packages/embed-protocol"
+  },
   "files": [
     "dist"
   ]

--- a/packages/embed-sdk/package.json
+++ b/packages/embed-sdk/package.json
@@ -22,6 +22,11 @@
     "typescript": "^6.0.3"
   },
   "license": "MPL-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LTplus-AG/ifc-lite.git",
+    "directory": "packages/embed-sdk"
+  },
   "keywords": [
     "ifc",
     "bim",


### PR DESCRIPTION
## Problem

The Release run for `chore: version packages (#764)` published `@ifc-lite/sdk@1.16.0` and `@ifc-lite/export@1.18.1` successfully, but **`@ifc-lite/embed-protocol@1.14.4` and `@ifc-lite/embed-sdk@1.14.4` failed**:

```
npm error code E422
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@ifc-lite%2fembed-sdk
  Error verifying sigstore provenance bundle: Failed to validate repository
  information: package.json: "repository.url" is "", expected to match
  "https://github.com/LTplus-AG/ifc-lite" from provenance
```

## Cause

The Release workflow publishes with `NPM_CONFIG_PROVENANCE=true` (OIDC trusted publishing). npm's provenance verification requires the published `package.json` to carry a `repository.url` that matches the source repo. Both `embed-protocol` and `embed-sdk` had **no `repository` field at all** — an omission carried over when #760 rewrote those package.json files. Every other publishable package in the repo has one.

## Fix

Add the standard `repository` block to both, matching the rest of the monorepo:

```json
"repository": {
  "type": "git",
  "url": "https://github.com/LTplus-AG/ifc-lite.git",
  "directory": "packages/embed-protocol"
}
```

No version bump and no changeset: `1.14.4` of both packages never reached npm (the PUT was rejected), so the next Release run's `changeset publish` retries those exact versions — now with provenance metadata that validates.

## After merge

Merging this pushes to `main` → Release runs with no pending changesets → `changeset publish` finds `embed-protocol@1.14.4` / `embed-sdk@1.14.4` still unpublished → publishes them. `sdk@1.16.0` and `export@1.18.1` are already on npm and will be skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository metadata to package configurations across embed-protocol and embed-sdk packages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LTplus-AG/ifc-lite/pull/765?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->