### PR TITLE
Skip artifact upload in PR builds to save Actions storage

### DIFF
--- a/.github/workflows/server-binaries.yml
+++ b/.github/workflows/server-binaries.yml
@@ -96,38 +96,11 @@ jobs:
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
 
-      - name: Prepare Binary (Unix)
-        if: runner.os != 'Windows'
-        run: |
-          mkdir -p dist
-          cp target/${{ matrix.rust-target }}/release/ifc-lite-server dist/
-          chmod +x dist/ifc-lite-server
-
-      - name: Prepare Binary (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          New-Item -ItemType Directory -Force -Path dist
-          Copy-Item "target/${{ matrix.rust-target }}/release/ifc-lite-server.exe" -Destination "dist/"
-
-      - name: Create Archive (tar.gz)
-        if: matrix.archive == 'tar.gz'
-        run: |
-          cd dist
-          tar -czf ../ifc-lite-server-${{ matrix.target }}.tar.gz ifc-lite-server
-
-      - name: Create Archive (zip)
-        if: matrix.archive == 'zip'
-        shell: pwsh
-        run: |
-          Compress-Archive -Path "dist/ifc-lite-server.exe" -DestinationPath "ifc-lite-server-${{ matrix.target }}.zip"
-
-      - name: Upload Build Artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ifc-lite-server-${{ matrix.target }}
-          path: ifc-lite-server-${{ matrix.target }}.${{ matrix.archive }}
-          if-no-files-found: error
+      # The `cargo build` step above is the validation — it fails the job
+      # if the binary doesn't compile. We deliberately don't archive or
+      # upload the binary here: nothing downloads a PR-run server binary,
+      # and 90-day-retained artifacts on every Rust PR were burning Actions
+      # storage credits for no benefit.
 
   release-server-binaries:
     name: Release Server Binary (${{ matrix.target }})
@@ -246,6 +219,9 @@ jobs:
           name: ifc-lite-server-${{ matrix.target }}
           path: ifc-lite-server-${{ matrix.target }}.${{ matrix.archive }}
           if-no-files-found: error
+          # Ad-hoc rebuild artifacts only — keep them briefly so they
+          # don't accumulate against Actions storage.
+          retention-days: 1
 
       - name: Upload to GitHub Release
         if: github.event_name == 'release'


### PR DESCRIPTION
## Summary
Remove binary archiving and artifact upload steps from PR builds in the server-binaries workflow, while keeping them for release builds. This reduces unnecessary consumption of GitHub Actions storage quota.

## Changes
- **PR builds**: Removed steps that prepare, archive, and upload server binaries. The `cargo build` step itself serves as sufficient validation that the binary compiles correctly.
- **Release builds**: Kept all archiving and upload steps, but added a 1-day retention policy to prevent ad-hoc rebuild artifacts from accumulating indefinitely.
- **Documentation**: Added clarifying comments explaining that PR-run binaries are not downloaded by anything and were unnecessarily consuming storage credits.

## Rationale
PR builds don't need to produce downloadable artifacts since:
1. No external process downloads PR-run server binaries
2. The compilation itself validates the build works
3. Removing artifact retention saves GitHub Actions storage quota for the project

https://claude.ai/code/session_017D4Jhad7zWV3MSYJuPrPrN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized pull request validation to focus on compilation verification, reducing build overhead and storage usage.
  * Implemented one-day retention policy for temporary rebuild artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LTplus-AG/ifc-lite/pull/767?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->