### PR TITLE
ci(release): author the version PR via a GitHub App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,11 +40,29 @@ jobs:
       published: ${{ steps.changesets.outputs.published }}
       version: ${{ steps.get-version.outputs.version }}
     steps:
+      # Mint a short-lived installation token for the `ifc-lite-release-bot-org`
+      # GitHub App. The changesets PR (`chore: version packages`) must be
+      # authored by a real identity, NOT the default GITHUB_TOKEN: GitHub
+      # suppresses pull_request/push workflow triggers for GITHUB_TOKEN-authored
+      # events (recursion guard), so the required `Build + WASM + Rust + Node`
+      # check never ran on a version PR and sat permanently "Expected" (#766).
+      # App ID + private key live as `release-publish` environment secrets.
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           lfs: false
+          # Persist the App token so the version-packages branch push made by
+          # changesets/action is App-authored too — not just the PR API call.
+          # Both must be App-authored for the pull_request event to fire.
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup pnpm
         # v6 reads the version from the `packageManager` field in
@@ -135,7 +153,9 @@ jobs:
           commit: 'chore: version packages'
           title: 'chore: version packages'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # App token (not GITHUB_TOKEN) so the version PR + its commits are
+          # authored by ifc-lite-release-bot-org and CI triggers on them.
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           # npm publishes use OIDC trusted publishing — no NPM_TOKEN.
           # `id-token: write` (set at job level) + npm CLI ≥ 11.5.1 +
           # NPM_CONFIG_PROVENANCE complete the handshake automatically


### PR DESCRIPTION
## Problem

The changesets `chore: version packages` PR (#766) is permanently
unmergeable. The `main` ruleset requires the `Build + WASM + Rust + Node`
status check, but it sits at **"Expected — Waiting for status to be
reported"** forever.

**Root cause:** `changesets/action` ran with the default `GITHUB_TOKEN`.
GitHub's recursion guard suppresses `pull_request`/`push` workflow
triggers for `GITHUB_TOKEN`-authored events, so the `Test` workflow
never runs on the version PR — its aggregate gate is never reported.

## Fix

Mint a short-lived installation token for the **`ifc-lite-release-bot-org`**
GitHub App and use it for:

- **`actions/checkout`** — so the version-packages branch push is App-authored
- **`changesets/action`** — so the PR + commits are App-authored

A real App identity is not subject to the recursion guard, so the version
PR gets CI like any normal PR and the required gate reports.

The publish/tag path (`Create GitHub Release`) is deliberately left on
`GITHUB_TOKEN` — out of scope.

## ⚠️ Merge prerequisites

Do **not** merge until both are true, or the release job will fail at the
token-mint step:

- [x] `RELEASE_APP_ID` + `RELEASE_APP_PRIVATE_KEY` set on the `release-publish` environment
- [ ] `ifc-lite-release-bot-org` App **installed** on `LTplus-AG/ifc-lite`

## Effect on #766

Once this lands on `main`, the resulting `Release` run re-pushes
`changeset-release/main` as the App → `Test` triggers → #766's stuck
check finally reports. No manual close/reopen needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release workflow infrastructure by implementing a dedicated GitHub App installation token for version updates and publishing operations. Version pull requests and their commits are now properly attributed to the release automation system, providing clearer attribution, enhanced transparency, and better overall governance of the release process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LTplus-AG/ifc-lite/pull/769?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->