### PR TITLE
fix(embed,renderer): clamp canvas to GPU max + default embed to light

### DIFF
--- a/apps/viewer-embed/index.html
+++ b/apps/viewer-embed/index.html
@@ -20,6 +20,9 @@
   </style>
   <script>
     // Apply ?theme= before React boots so there's no dark flash. Default: light.
+    // Wrapped in try/catch because this runs before any error boundary exists and
+    // we must never block React mount. On failure we log to console and fall back
+    // to the .light class already on <html> (set in markup above).
     (function () {
       try {
         var p = new URLSearchParams(location.search);
@@ -27,7 +30,11 @@
         var root = document.documentElement;
         root.classList.remove('dark', 'light');
         root.classList.add(t === 'dark' ? 'dark' : 'light');
-      } catch (e) {}
+      } catch (e) {
+        if (typeof console !== 'undefined' && console.warn) {
+          console.warn('[ifc-lite-embed] theme bootstrap failed; falling back to light:', e);
+        }
+      }
     })();
   </script>
 </head>

--- a/apps/viewer-embed/index.html
+++ b/apps/viewer-embed/index.html
@@ -1,22 +1,35 @@
 <!DOCTYPE html>
-<html lang="en" class="dark">
+<html lang="en" class="light">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
   <meta name="robots" content="noindex, nofollow">
   <meta name="description" content="Embeddable IFC 3D model viewer">
-  <meta name="color-scheme" content="dark light">
+  <meta name="color-scheme" content="light dark">
   <title>IFC-Lite Embed</title>
   <style>
     /* Minimal inline styles - no Tailwind dependency for the shell */
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
     html, body, #root { width: 100%; height: 100%; overflow: hidden; }
     body { font-family: system-ui, -apple-system, sans-serif; }
-    html.dark body { background: #1a1b26; color: #a9b1d6; }
+    /* Light is the default for embeds; dark is opt-in via ?theme=dark. */
     html.light body, html:not(.dark) body { background: #ffffff; color: #1a1b26; }
+    html.dark body { background: #1a1b26; color: #a9b1d6; }
     /* Ensure the 3D canvas fills the viewport (Tailwind utilities may not be generated for embed build) */
     #root canvas { width: 100% !important; height: 100% !important; display: block !important; }
   </style>
+  <script>
+    // Apply ?theme= before React boots so there's no dark flash. Default: light.
+    (function () {
+      try {
+        var p = new URLSearchParams(location.search);
+        var t = p.get('theme');
+        var root = document.documentElement;
+        root.classList.remove('dark', 'light');
+        root.classList.add(t === 'dark' ? 'dark' : 'light');
+      } catch (e) {}
+    })();
+  </script>
 </head>
 <body>
   <div id="root"></div>

--- a/apps/viewer-embed/src/components/EmbedViewer.tsx
+++ b/apps/viewer-embed/src/components/EmbedViewer.tsx
@@ -38,9 +38,11 @@ export function EmbedViewer() {
   const bridgeInitialized = useRef(false);
   const autoLoadAttempted = useRef(false);
 
-  // Apply URL params on mount
+  // Apply URL params on mount. Embeds default to light unless ?theme=dark
+  // (the surrounding viewer-core store may bootstrap to dark based on system
+  // preference, which is wrong for a third-party iframe with no chrome).
   useEffect(() => {
-    if (urlParams.theme) setTheme(urlParams.theme);
+    setTheme(urlParams.theme === 'dark' ? 'dark' : 'light');
   }, [urlParams.theme, setTheme]);
 
   // Initialize the postMessage bridge

--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -575,12 +575,17 @@ export function Viewport({
       return Math.max(64, Math.floor(size / 64) * 64);
     };
 
+    // Cap at the conservative WebGPU floor; the renderer re-clamps using the actual
+    // adapter limit once the device is initialized. Without this, tall iframe layouts
+    // can ask for canvas dimensions that exceed 8192 and every texture creation fails.
+    const MAX_CANVAS_DIM = 8192;
+
     // Use CSS pixel dimensions for canvas. The Renderer.render() method manages
     // its own dimension alignment via getBoundingClientRect() — do NOT apply DPR
     // here as it creates a mismatch that causes constant context reconfiguration.
     const rect = canvas.getBoundingClientRect();
-    const width = alignToWebGPU(Math.max(1, Math.floor(rect.width)));
-    const height = Math.max(1, Math.floor(rect.height));
+    const width = Math.min(MAX_CANVAS_DIM, alignToWebGPU(Math.max(1, Math.floor(rect.width))));
+    const height = Math.min(MAX_CANVAS_DIM, Math.max(1, Math.floor(rect.height)));
     canvas.width = width;
     canvas.height = height;
 
@@ -735,8 +740,8 @@ export function Viewport({
       resizeObserver = new ResizeObserver(() => {
         if (aborted) return;
         const rect = canvas.getBoundingClientRect();
-        const w = alignToWebGPU(Math.max(1, Math.floor(rect.width)));
-        const h = Math.max(1, Math.floor(rect.height));
+        const w = Math.min(MAX_CANVAS_DIM, alignToWebGPU(Math.max(1, Math.floor(rect.width))));
+        const h = Math.min(MAX_CANVAS_DIM, Math.max(1, Math.floor(rect.height)));
         renderer.resize(w, h);
         renderCurrent();
       });

--- a/packages/renderer/src/device.ts
+++ b/packages/renderer/src/device.ts
@@ -145,6 +145,15 @@ export class WebGPUDevice {
     return this.device;
   }
 
+  /**
+   * Max 2D texture dimension reported by the GPU adapter. WebGPU's spec floor is 8192;
+   * iGPUs and most desktop GPUs report 8192 or 16384. Render targets / depth textures
+   * must not exceed this in either axis or the device fails validation.
+   */
+  getMaxTextureDimension(): number {
+    return this.device?.limits?.maxTextureDimension2D ?? 8192;
+  }
+
   getContext(): GPUCanvasContext {
     if (!this.context) {
       throw new Error('Context not initialized');

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -232,12 +232,17 @@ export class Renderer {
         await this.device.init(this.canvas);
 
         // Get canvas dimensions (use pixel dimensions if set, otherwise use CSS dimensions)
+        // and clamp to the GPU's max 2D texture dimension so the initial pipeline allocations
+        // can't overflow on tall/wide layouts (see render() for the per-frame clamp).
         const rect = this.canvas.getBoundingClientRect();
-        const width = this.canvas.width || Math.max(1, Math.floor(rect.width));
-        const height = this.canvas.height || Math.max(1, Math.floor(rect.height));
+        const maxDim = this.device.getMaxTextureDimension();
+        const rawWidth = this.canvas.width || Math.max(1, Math.floor(rect.width));
+        const rawHeight = this.canvas.height || Math.max(1, Math.floor(rect.height));
+        const width = Math.min(rawWidth, maxDim);
+        const height = Math.min(rawHeight, maxDim);
 
-        // Set pixel dimensions if not already set
-        if (!this.canvas.width || !this.canvas.height) {
+        // Set pixel dimensions if not already set, or if we clamped them down
+        if (!this.canvas.width || !this.canvas.height || this.canvas.width !== width || this.canvas.height !== height) {
             this.canvas.width = width;
             this.canvas.height = height;
         }
@@ -1102,10 +1107,16 @@ export class Renderer {
 
         // Validate canvas dimensions
         // Align width to 64 pixels for WebGPU texture row alignment (256 bytes / 4 bytes per pixel)
+        // and clamp both axes to the GPU's max 2D texture dimension. Some hosts (e.g. tall iframes
+        // on high-DPR displays) can produce canvas dimensions that exceed 8192 and would otherwise
+        // make every depth/colour texture allocation a validation error.
         const rect = this.canvas.getBoundingClientRect();
+        const maxDim = this.device.getMaxTextureDimension();
         const rawWidth = Math.max(1, Math.floor(rect.width));
-        const width = Math.max(64, Math.floor(rawWidth / 64) * 64);
-        const height = Math.max(1, Math.floor(rect.height));
+        const widthAligned = Math.max(64, Math.floor(rawWidth / 64) * 64);
+        const width = Math.min(widthAligned, Math.floor(maxDim / 64) * 64);
+        const rawHeight = Math.max(1, Math.floor(rect.height));
+        const height = Math.min(rawHeight, maxDim);
 
         // Skip rendering if canvas is too small
         if (width < 64 || height < 10) { this._renderSkipCount++; return; }

--- a/packages/renderer/src/pipeline.ts
+++ b/packages/renderer/src/pipeline.ts
@@ -390,6 +390,12 @@ export class RenderPipeline {
     resize(width: number, height: number): void {
         if (width <= 0 || height <= 0) return;
 
+        // Belt-and-suspenders clamp: callers are expected to clamp upstream, but
+        // texture creation must never exceed maxTextureDimension2D or every frame fails.
+        const maxDim = this.device.limits.maxTextureDimension2D;
+        width = Math.min(width, maxDim);
+        height = Math.min(height, maxDim);
+
         this.currentWidth = width;
         this.currentHeight = height;
 
@@ -834,6 +840,12 @@ export class InstancedRenderPipeline {
      * Resize depth texture
      */
     resize(width: number, height: number): void {
+        // Match the primary RenderPipeline.resize() clamp so the InstancedRenderPipeline
+        // can't blow past maxTextureDimension2D either.
+        const maxDim = this.device.limits.maxTextureDimension2D;
+        width = Math.min(width, maxDim);
+        height = Math.min(height, maxDim);
+
         if (this.currentHeight === height && this.depthTexture.width === width) {
             return;
         }


### PR DESCRIPTION
## Summary
- Clamp render-target dimensions to `maxTextureDimension2D` so tall iframe layouts on high-DPR displays no longer trip WebGPU validation (`Dimension Y value 8269 exceeds the limit of 8192`).
- Default `apps/viewer-embed` to a light background and only switch to dark when `?theme=dark` is passed. A pre-React inline script applies the class so there's no dark flash.

## Why
Surfaced by the new landing page iframing `embed.ifclite.com/v1?modelUrl=…`. Parsing and geometry streaming worked (1045 entities, 8 meshes in the host logs), but every frame failed because the canvas was sized past the GPU texture limit. The dark-by-default look was also wrong for a neutral third-party iframe with no surrounding chrome.

## What changed
**Renderer (canvas overflow):**
- `WebGPUDevice.getMaxTextureDimension()` exposes the adapter limit.
- `Renderer.init()` + `Renderer.render()` clamp width/height to it before any texture creation.
- `RenderPipeline.resize()` and `InstancedRenderPipeline.resize()` clamp at texture-creation time (belt-and-suspenders if a stale caller slips through).
- `Viewport.tsx` caps the canvas attribute at the 8192 WebGPU floor on init + resize, so the first frame is safe even before the adapter is queried.

**Embed (theme default):**
- `apps/viewer-embed/index.html` starts in `.light`. Pre-React inline script reads `?theme=` and applies the right class on `<html>` before paint.
- `EmbedViewer` forces `setTheme(urlParams.theme === 'dark' ? 'dark' : 'light')`, ignoring the viewer-core store's prefers-color-scheme bootstrap.

## Test plan
- [ ] Open `https://embed.ifclite.com/v1?modelUrl=https://www.ifclite.com/samples/hello-wall.ifc` after deploy: model renders, no WebGPU errors in console, white background.
- [ ] Append `&theme=dark`: same model renders against the dark background.
- [ ] Open `https://www.ifclite.com/` directly with a model: no regressions (clamp is no-op when dimensions are well under the limit).
- [ ] Pick / Picking still works (`getBoundingClientRect()` path is unchanged; clamps only narrow dimensions, never widen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Light theme is now the default; use `?theme=dark` query parameter to switch themes dynamically.

* **Bug Fixes**
  * Fixed renderer failures on displays with extreme dimensions by clamping canvas sizes to GPU limits.
  * Added safeguards to prevent texture allocation failures in high-resolution scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LTplus-AG/ifc-lite/pull/773?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->