### PR TITLE
feat(viewer): three discovery touchpoints to ifclite.dev

### DIFF
--- a/apps/viewer/src/components/viewer/KeyboardShortcutsDialog.tsx
+++ b/apps/viewer/src/components/viewer/KeyboardShortcutsDialog.tsx
@@ -349,6 +349,29 @@ function ShortcutsTab() {
 
   return (
     <div className="space-y-4">
+      {/* Learn-more row: drives discovery to the marketing site and the github.io
+          docs. Sits above the shortcut groups so it's the first thing users hunting
+          for help see, without crowding the keyboard reference itself. */}
+      <div className="rounded border border-border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+        <span className="font-medium text-foreground">Learn more:</span>
+        <a
+          href="https://ifclite.dev"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="ml-2 underline-offset-2 hover:underline hover:text-primary transition-colors"
+        >
+          ifclite.dev
+        </a>
+        <span className="mx-1.5 opacity-40">·</span>
+        <a
+          href="https://ltplus-ag.github.io/ifc-lite/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline-offset-2 hover:underline hover:text-primary transition-colors"
+        >
+          docs
+        </a>
+      </div>
       {Object.entries(grouped).map(([category, shortcuts]) => (
         <div key={category}>
           <h3 className="text-sm font-medium text-muted-foreground mb-2">

--- a/apps/viewer/src/components/viewer/KeyboardShortcutsDialog.tsx
+++ b/apps/viewer/src/components/viewer/KeyboardShortcutsDialog.tsx
@@ -101,7 +101,25 @@ function AboutTab() {
       </div>
 
       {/* Links */}
-      <div className="flex items-center justify-center gap-4 text-xs">
+      <div className="flex items-center justify-center flex-wrap gap-x-4 gap-y-1.5 text-xs">
+        <a
+          href="https://ifclite.dev"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-1.5 text-muted-foreground hover:text-foreground transition-colors"
+        >
+          ifclite.dev
+          <ExternalLink className="h-3 w-3" />
+        </a>
+        <a
+          href="https://ltplus-ag.github.io/ifc-lite/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-1.5 text-muted-foreground hover:text-foreground transition-colors"
+        >
+          Docs
+          <ExternalLink className="h-3 w-3" />
+        </a>
         <a
           href={GITHUB_URL}
           target="_blank"

--- a/apps/viewer/src/components/viewer/StatusBar.tsx
+++ b/apps/viewer/src/components/viewer/StatusBar.tsx
@@ -176,6 +176,18 @@ export function StatusBar() {
         <Separator orientation="vertical" className="h-3.5" />
 
         <span className="opacity-60">v{__APP_VERSION__}</span>
+
+        <Separator orientation="vertical" className="h-3.5" />
+
+        <a
+          href="https://ifclite.dev"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="opacity-60 hover:opacity-100 hover:text-primary transition-opacity"
+          aria-label="Visit ifclite.dev — about, docs, and packages"
+        >
+          ifclite.dev →
+        </a>
       </div>
     </div>
   );

--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -972,7 +972,19 @@ export function ViewportContainer() {
             ))}
           </div>
 
-          {/* Footer */}
+          {/* Footer chips — left: discovery link to the marketing site for first-time
+              visitors, right: shortcuts cue for power users. Both desktop-only. */}
+          <div className="absolute bottom-8 left-8 hidden md:block">
+            <a
+              href="https://ifclite.dev"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group inline-flex items-center gap-2 text-xs font-mono px-3 py-1.5 bg-zinc-100 dark:bg-[#1f2335] border border-zinc-300 dark:border-[#3b4261] text-zinc-500 dark:text-[#565f89] hover:border-primary hover:text-primary transition-colors"
+            >
+              <span>New here?</span>
+              <span className="font-bold text-primary group-hover:translate-x-0.5 transition-transform">ifclite.dev →</span>
+            </a>
+          </div>
           <div className="absolute bottom-8 right-8 hidden md:block">
             <div className="flex items-center gap-2 text-xs font-mono px-3 py-1.5 bg-zinc-100 dark:bg-[#1f2335] border border-zinc-300 dark:border-[#3b4261] text-zinc-500 dark:text-[#565f89]">
               <Command className="h-3 w-3" />


### PR DESCRIPTION
## Summary
Adds three low-friction links from the viewer (ifclite.com) to the new landing site (ifclite.dev) without disrupting the open-and-drop UX existing users rely on.

## Why
ifclite.com is the URL muscle-memory expects for *"open this .ifc fast."* The new landing at ifclite.dev carries the marketing/demos/docs surface. We need users to *find* the landing, but a banner across the viewer would feel like adware to power users. Instead: three small touchpoints sized for first-time discovery while staying invisible to power flows.

## Touchpoints
1. **Empty-state chip** (`ViewportContainer.tsx`) — a desktop-only "New here? ifclite.dev →" chip mirrored opposite the existing SHORTCUTS chip. Only visible *before* a model is loaded; once a file is in the viewport, it's gone.
2. **StatusBar link** (`StatusBar.tsx`) — a tiny mono "ifclite.dev →" pinned next to the version number, same opacity-60 treatment. Always present, never loud.
3. **KeyboardShortcutsDialog row** (`KeyboardShortcutsDialog.tsx`) — a "Learn more" row prepended above the shortcut groups, linking to ifclite.dev *and* the github.io docs. Users who hit `?` for help find both.

All three open in a new tab with `rel="noopener noreferrer"`.

## Test plan
- [ ] Load the viewer with no file — verify the "New here?" chip appears bottom-left and SHORTCUTS still appears bottom-right.
- [ ] Drop an IFC — verify the chip disappears with the rest of the empty state.
- [ ] Confirm StatusBar shows `WebGPU · vX.Y.Z · ifclite.dev →` in that order.
- [ ] Press `?` to open the shortcuts dialog — confirm the "Learn more: ifclite.dev · docs" row sits above the categorised shortcuts.
- [ ] Click each of the three links — opens in a new tab, no console warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Learn more" banner with external resource links to ifclite.dev and documentation in the keyboard shortcuts reference
  * Integrated an ifclite.dev link in the status bar for quick navigation
  * Added a desktop-only discovery chip in the empty state to help new users find additional resources and get started

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LTplus-AG/ifc-lite/pull/774?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->