### PR TITLE
fix(embed): auto-fit camera on first load + CSP-safe theme bootstrap

### DIFF
--- a/apps/viewer-embed/index.html
+++ b/apps/viewer-embed/index.html
@@ -18,25 +18,10 @@
     /* Ensure the 3D canvas fills the viewport (Tailwind utilities may not be generated for embed build) */
     #root canvas { width: 100% !important; height: 100% !important; display: block !important; }
   </style>
-  <script>
-    // Apply ?theme= before React boots so there's no dark flash. Default: light.
-    // Wrapped in try/catch because this runs before any error boundary exists and
-    // we must never block React mount. On failure we log to console and fall back
-    // to the .light class already on <html> (set in markup above).
-    (function () {
-      try {
-        var p = new URLSearchParams(location.search);
-        var t = p.get('theme');
-        var root = document.documentElement;
-        root.classList.remove('dark', 'light');
-        root.classList.add(t === 'dark' ? 'dark' : 'light');
-      } catch (e) {
-        if (typeof console !== 'undefined' && console.warn) {
-          console.warn('[ifc-lite-embed] theme bootstrap failed; falling back to light:', e);
-        }
-      }
-    })();
-  </script>
+  <!-- Pre-React theme bootstrap. External script so the deployed CSP
+       (script-src 'self' 'wasm-unsafe-eval' blob:) allows it — inline scripts
+       would need 'unsafe-inline' or a nonce. -->
+  <script src="/theme-bootstrap.js"></script>
 </head>
 <body>
   <div id="root"></div>

--- a/apps/viewer-embed/public/theme-bootstrap.js
+++ b/apps/viewer-embed/public/theme-bootstrap.js
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Pre-React theme bootstrap. Lives at /theme-bootstrap.js (same origin) so the
+ * deployed CSP `script-src 'self' 'wasm-unsafe-eval' blob:` allows it — an inline
+ * <script> would need 'unsafe-inline' or a nonce, neither of which the embed
+ * deploy currently grants. Runs synchronously in <head> before React mounts so
+ * there's no flash on `?theme=dark`. The .light class is already on <html> in
+ * the static markup, so a complete failure here still ships a light embed.
+ */
+(function () {
+  try {
+    var p = new URLSearchParams(location.search);
+    var t = p.get('theme');
+    var root = document.documentElement;
+    root.classList.remove('dark', 'light');
+    root.classList.add(t === 'dark' ? 'dark' : 'light');
+  } catch (e) {
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn('[ifc-lite-embed] theme bootstrap failed; falling back to light:', e);
+    }
+  }
+})();

--- a/apps/viewer-embed/src/components/EmbedViewer.tsx
+++ b/apps/viewer-embed/src/components/EmbedViewer.tsx
@@ -118,16 +118,41 @@ export function EmbedViewer() {
     }
   }, [progress]);
 
-  // Emit model loaded event
+  // Emit model loaded event + auto-fit camera on the first model that lands.
+  // Unlike the full viewer (which has toolbar buttons for fit-all and a default
+  // load flow that fits), the embed has no chrome — so without an explicit fit
+  // call the camera stays at its initial position and the model renders off-frame.
+  // We only fit on the *first* successful load so host-driven SET_CAMERA / view
+  // params via the bridge aren't immediately overridden.
+  const autoFittedRef = useRef(false);
   useEffect(() => {
-    if (!loading && geometryResult?.meshes?.length) {
-      emitEvent('MODEL_LOADED', {
-        entities: ifcDataStore?.entities?.count ?? 0,
-        triangles: geometryResult.totalTriangles,
-        vertices: geometryResult.totalVertices,
-      });
-    }
-  }, [loading, geometryResult, ifcDataStore]);
+    if (loading) return;
+    const meshes = geometryResult?.meshes;
+    if (!meshes || meshes.length === 0) return;
+
+    emitEvent('MODEL_LOADED', {
+      entities: ifcDataStore?.entities?.count ?? 0,
+      triangles: geometryResult.totalTriangles,
+      vertices: geometryResult.totalVertices,
+    });
+
+    if (autoFittedRef.current) return;
+    autoFittedRef.current = true;
+    // Defer to next frame so the renderer has applied the new meshes and
+    // geometryBoundsRef inside Viewport is up to date before zoomToFit reads it.
+    const id = requestAnimationFrame(() => {
+      const cbs = useViewerStore.getState().cameraCallbacks;
+      // Honour ?view= / ?camera= URL params first; only auto-fit if neither was set.
+      if (urlParams.view) {
+        cbs.setPresetView?.(urlParams.view);
+      } else if (urlParams.camera) {
+        // Camera URL param is handled elsewhere; skip auto-fit.
+      } else {
+        cbs.home?.();
+      }
+    });
+    return () => cancelAnimationFrame(id);
+  }, [loading, geometryResult, ifcDataStore, urlParams.view, urlParams.camera]);
 
   // Emit selection events to parent
   const selectedEntityId = useViewerStore((s) => s.selectedEntityId);


### PR DESCRIPTION
## Summary
Two issues surfaced testing the landing iframe against the just-deployed embed.

### Auto-fit on first model load
With the WebGPU dimension clamp from #773 live, the canvas no longer fails — but the model still rendered off-frame. \`EmbedViewer\` was emitting \`MODEL_LOADED\` and not calling fit-all. The full viewer has toolbar buttons and a load flow that triggers the fit; the embed has no chrome so the camera stayed at its initial position.

Added a one-shot effect that calls \`cameraCallbacks.home()\` on the next animation frame after the first successful load. \`?view=\` / \`?camera=\` URL params take precedence so host-driven framing isn't immediately overridden. \`autoFittedRef\` guards re-firing on later content updates (e.g. \`realignFederation\`); hosts can use \`FIT_VIEW\` via the bridge to re-fit on demand.

### CSP-safe theme bootstrap
The deployed embed serves \`Content-Security-Policy: script-src 'self' 'wasm-unsafe-eval' blob:\`, which blocks the inline pre-React theme script that #773 added — causing a console warning and a brief flash to the default \`.light\` class on every \`?theme=dark\` load.

Moved the bootstrap to \`/theme-bootstrap.js\` (in \`apps/viewer-embed/public/\`) so \`'self'\` allows it. Markup still ships \`<html class=\"light\">\` as the no-script fallback.

## Test plan
- [ ] After deploy, open \`https://embed.ifclite.com/v1?modelUrl=https://www.ifclite.com/samples/hello-wall.ifc\` — model should render *in frame* on a white background.
- [ ] Add \`&theme=dark\` — page paints dark immediately (no flash), no CSP-blocked console warning.
- [ ] Add \`&view=front\` — first frame uses the front preset instead of home auto-fit.
- [ ] Use the bridge's \`FIT_VIEW\` command from a host page after first load — still works (autoFittedRef only blocks the *automatic* fire, not bridge calls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Camera now automatically fits to loaded 3D models.
  * View presets can be configured via URL parameters.

* **Refactor**
  * Theme initialization moved to external bootstrap script for improved loading behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LTplus-AG/ifc-lite/pull/775?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->