### PR TITLE
fix(embed): retry auto-fit until cameraCallbacks register + diagnostic logs

### DIFF
--- a/apps/viewer-embed/src/components/EmbedViewer.tsx
+++ b/apps/viewer-embed/src/components/EmbedViewer.tsx
@@ -137,21 +137,47 @@ export function EmbedViewer() {
     });
 
     if (autoFittedRef.current) return;
+
+    // Viewport registers cameraCallbacks AFTER renderer.init() resolves (async).
+    // On a fast network + small model, geometry can land before that happens.
+    // Poll for up to ~2 s, checking each frame, then bail out so we never leak.
     autoFittedRef.current = true;
-    // Defer to next frame so the renderer has applied the new meshes and
-    // geometryBoundsRef inside Viewport is up to date before zoomToFit reads it.
-    const id = requestAnimationFrame(() => {
+    const deadline = performance.now() + 2000;
+    let rafId = 0;
+    const tryFit = () => {
       const cbs = useViewerStore.getState().cameraCallbacks;
+      const ready = Boolean(cbs.home || cbs.fitAll || cbs.setPresetView);
+      console.log('[embed] auto-fit tick', {
+        ready,
+        cbs: Object.keys(cbs),
+        view: urlParams.view,
+        camera: urlParams.camera,
+        meshes: meshes.length,
+      });
+      if (!ready) {
+        if (performance.now() < deadline) {
+          rafId = requestAnimationFrame(tryFit);
+        } else {
+          console.warn('[embed] auto-fit gave up — cameraCallbacks never registered');
+        }
+        return;
+      }
       // Honour ?view= / ?camera= URL params first; only auto-fit if neither was set.
       if (urlParams.view) {
+        console.log('[embed] auto-fit: setPresetView', urlParams.view);
         cbs.setPresetView?.(urlParams.view);
       } else if (urlParams.camera) {
-        // Camera URL param is handled elsewhere; skip auto-fit.
-      } else {
-        cbs.home?.();
+        console.log('[embed] auto-fit: skipped (?camera= handled elsewhere)');
+      } else if (cbs.home) {
+        console.log('[embed] auto-fit: home()');
+        cbs.home();
+      } else if (cbs.fitAll) {
+        console.log('[embed] auto-fit: fitAll() fallback');
+        cbs.fitAll();
       }
-    });
-    return () => cancelAnimationFrame(id);
+    };
+    rafId = requestAnimationFrame(tryFit);
+    return () => cancelAnimationFrame(rafId);
   }, [loading, geometryResult, ifcDataStore, urlParams.view, urlParams.camera]);
 
   // Emit selection events to parent


### PR DESCRIPTION
## Summary
PR #775 added auto-fit but it never visibly fires for a small/fast model load.

**Race**: \`Viewport\` registers \`cameraCallbacks\` *after* \`renderer.init()\` resolves (async). On a small file + fast network, \`geometryResult\` becomes truthy before that init resolves, so when the auto-fit effect's single \`requestAnimationFrame\` callback runs, \`cbs.home\` is still undefined and the call silently no-ops.

## Fix
Poll each frame for up to 2 s, checking whether \`home\` / \`fitAll\` / \`setPresetView\` have landed in the store. As soon as one is available, run it. Falls back through \`home\` → \`fitAll\` if \`home\` is missing.

Also logs a \`[embed] auto-fit tick\` line per attempt (with the registered callback keys and url-param state), and a warn if the 2 s deadline passes — so the next bug report has actionable diagnostics instead of silence.

## Test plan after deploy
- [ ] Open \`https://embed.ifclite.com/v1?modelUrl=https://www.ifclite.com/samples/hello-wall.ifc\` — model visible, console shows one or two \`auto-fit tick\` lines followed by \`auto-fit: home()\`.
- [ ] Add \`&view=front\` — first log line shows \`setPresetView\` was called instead of \`home\`.
- [ ] If a future regression breaks \`Viewport\` registration, the warn line surfaces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the initial view auto-fit behavior to properly wait for camera initialization before adjusting the viewer.
  * Enhanced handling of URL parameters for view and camera settings.

* **Chores**
  * Added diagnostic logging for auto-fit operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LTplus-AG/ifc-lite/pull/776?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->