### PR TITLE
fix(embed): ship Tailwind utility fallbacks used by Viewport tree

### DIFF
--- a/apps/viewer-embed/index.html
+++ b/apps/viewer-embed/index.html
@@ -17,6 +17,24 @@
     html.dark body { background: #1a1b26; color: #a9b1d6; }
     /* Ensure the 3D canvas fills the viewport (Tailwind utilities may not be generated for embed build) */
     #root canvas { width: 100% !important; height: 100% !important; display: block !important; }
+
+    /* Tailwind utility fallbacks — the embed bundle doesn't include Tailwind, so
+     * the shared Viewport's `className="relative w-full h-full"` wrapper resolves
+     * to NO styling. Without these, the wrapper has no height constraint, the
+     * canvas's intrinsic size (driven by its attribute pixels) blows the layout
+     * out to ~8000+ px tall, and the model lands off-frame. These rules cover
+     * exactly the utilities the Viewport DOM tree uses — keep narrow. */
+    .relative { position: relative; }
+    .absolute { position: absolute; }
+    .inset-0 { top: 0; right: 0; bottom: 0; left: 0; }
+    .w-full { width: 100%; }
+    .h-full { height: 100%; }
+    .block { display: block; }
+    .hidden { display: none; }
+    .flex { display: flex; }
+    .items-center { align-items: center; }
+    .justify-center { justify-content: center; }
+    .overflow-hidden { overflow: hidden; }
   </style>
   <!-- Pre-React theme bootstrap. External script so the deployed CSP
        (script-src 'self' 'wasm-unsafe-eval' blob:) allows it — inline scripts


### PR DESCRIPTION
## Root cause
The embed app doesn't bundle Tailwind, but it renders the shared \`Viewport\` from \`apps/viewer/src\`. Viewport's outer wrapper is:

\`\`\`jsx
<div className=\"relative w-full h-full\">
  <canvas ... />
</div>
\`\`\`

Without Tailwind, those classes resolve to **no styling**. The wrapper has no height constraint. The canvas inside is forced to \`width:100%/height:100%\` via the inline rule already in \`index.html\`, but with no parent height that \"100%\" resolves against the canvas's *intrinsic* size — which is its \`width\`/\`height\` attributes (8192 after PR #773's GPU clamp). Result: the wrapper grows to 8192-ish px tall, the canvas fills it, the model gets rendered far below the viewport.

Confirmed with DOM inspection on \`embed.ifclite.com/v1\` post-#775+#776: \`div.relative.w-full\` had computed \`position: static\` and \`height: 8378px\` despite the className claiming \`relative h-full\`.

## Patch
Inline the exact subset of Tailwind utilities the Viewport DOM tree uses:

\`relative\`, \`absolute\`, \`inset-0\`, \`w-full\`, \`h-full\`, \`flex\`, \`items-center\`, \`justify-center\`, \`overflow-hidden\`, \`block\`, \`hidden\`.

Narrow on purpose — anything broader risks colliding with future class usage if Tailwind ever ships in this bundle.

## Test plan
- [ ] After deploy, open \`https://embed.ifclite.com/v1?modelUrl=https://www.ifclite.com/samples/hello-wall.ifc\` — canvas's CSS height matches viewport height, model is visibly rendered and framed (auto-fit from #775+#776 now has a sane canvas to work against).
- [ ] Toggle \`&theme=dark\` — background changes, layout still correct.
- [ ] Inspect the \`<div class=\"relative w-full h-full\">\` wrapper in DevTools: computed \`position: relative\`, height matches viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)