### PR TITLE
Fix/anchor axis context and body context

### DIFF
--- a/packages/create/src/in-store/anchor.ts
+++ b/packages/create/src/in-store/anchor.ts
@@ -19,6 +19,8 @@ export interface SpatialAnchor {
   ownerHistoryId: number;
   /** IfcGeometricRepresentationSubContext for 'Body' (or its IfcGeometricRepresentationContext fallback). */
   bodyContextId: number;
+  /** IfcGeometricRepresentationSubContext for 'Axis' (or its IfcGeometricRepresentationContext fallback). */
+  axisContextId: number;
   /** The target IfcBuildingStorey expressId. */
   storeyId: number;
   /** The IfcLocalPlacement that the storey itself sits on. New element placements are chained from this. */

--- a/packages/create/src/in-store/resolve-anchor.ts
+++ b/packages/create/src/in-store/resolve-anchor.ts
@@ -25,13 +25,19 @@ export function resolveSpatialAnchor(store: IfcDataStore, storeyExpressId: numbe
     throw new Error('resolveSpatialAnchor: no IfcGeometricRepresentationContext (or Body subcontext) found in store');
   }
 
+  const axisContextId = findAxisContextId(store);
+  if (axisContextId === null) {
+    throw new Error('resolveSpatialAnchor: no IfcGeometricRepresentationContext (or Axis subcontext) found in store');
+  }
+
+
   const storeyPlacementId = findStoreyPlacementId(store, storeyExpressId);
   if (storeyPlacementId === null) {
     throw new Error(`resolveSpatialAnchor: storey #${storeyExpressId} has no resolvable IfcLocalPlacement`);
   }
 
   const schema = (store.schemaVersion ?? 'IFC4') as SpatialAnchorSchema;
-  return { ownerHistoryId, bodyContextId, storeyId: storeyExpressId, storeyPlacementId, schema };
+  return { ownerHistoryId, bodyContextId, axisContextId, storeyId: storeyExpressId, storeyPlacementId, schema };
 }
 
 function findOwnerHistoryId(store: IfcDataStore): number | null {
@@ -46,14 +52,46 @@ function findOwnerHistoryId(store: IfcDataStore): number | null {
 function findBodyContextId(store: IfcDataStore): number | null {
   if (!store.source) return null;
   const extractor = new EntityExtractor(store.source);
+  const subIds = store.entityIndex.byType.get('IFCGEOMETRICREPRESENTATIONSUBCONTEXT') ?? [];
+  for (const id of subIds) {
+    const ref = store.entityIndex.byId.get(id);
+    if (!ref) continue;
+    const entity = extractor.extractEntity(ref);
+    const identifier = entity?.attributes?.[1];
+    if (typeof identifier === 'string' && identifier.toLowerCase() === 'body') {
+      return id;
+    }
+  }
+
+  const ctxIds = store.entityIndex.byType.get('IFCGEOMETRICREPRESENTATIONCONTEXT') ?? [];
+  for (const id of ctxIds) {
+    const ref = store.entityIndex.byId.get(id);
+    if (!ref) continue;
+    const entity = extractor.extractEntity(ref);
+    const dimension = entity?.attributes?.[2];
+    if (typeof dimension === 'number' && dimension === 3) {
+      return id;
+    }
+  }
+
+  return ctxIds[0] ?? null;
+}
+
+/**
+ * Prefer an IfcGeometricRepresentationSubContext with ContextIdentifier='Axis';
+ * otherwise fall back to the first 3D IfcGeometricRepresentationContext.
+ */
+function findAxisContextId(store: IfcDataStore): number | null {
+  if (!store.source) return null;
+  const extractor = new EntityExtractor(store.source);
 
   const subIds = store.entityIndex.byType.get('IFCGEOMETRICREPRESENTATIONSUBCONTEXT') ?? [];
   for (const id of subIds) {
     const ref = store.entityIndex.byId.get(id);
     if (!ref) continue;
     const entity = extractor.extractEntity(ref);
-    const identifier = entity?.attributes?.[0];
-    if (typeof identifier === 'string' && identifier.toLowerCase() === 'body') {
+    const identifier = entity?.attributes?.[1];
+    if (typeof identifier === 'string' && identifier.toLowerCase() === 'axis') {
       return id;
     }
   }
@@ -70,6 +108,7 @@ function findBodyContextId(store: IfcDataStore): number | null {
   }
   return ctxIds[0] ?? null;
 }
+
 
 /**
  * Resolve the target storey's `ObjectPlacement` (an IfcLocalPlacement).


### PR DESCRIPTION
## Summary
Fix anchor context resolution:
- Add `axisContextId` (in addition to `bodyContextId`) in `anchor.ts`
- Fix `findBodyContextId` in `resolve-anchor.ts`:
  - addressed the wrong index previously
  - ensure it returns `IFCGEOMETRICREPRESENTATIONSUBCONTEXT` (not `IFCGEOMETRICREPRESENTATIONCONTEXT`)

## Problem
1) `anchor.ts` only tracked `bodyContextId`, but anchors may also need the axis representation context.
2) `resolve-anchor.ts` `findBodyContextId` was reading the wrong index and could return the parent geometric representation context instead of the subcontext, which leads to incorrect context selection.

## Changes
- `anchor.ts`
  - store/expose `axisContextId` alongside `bodyContextId`
- `resolve-anchor.ts`
  - correct index usage in `findBodyContextId`
  - return `IFCGEOMETRICREPRESENTATIONSUBCONTEXT` for the body context

## Expected impact
- Correct anchor resolution for models where body/axis subcontexts differ
- Avoids selecting the parent context when a subcontext is required


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded spatial anchor resolution to include axis context references alongside existing body context support.
  * Enhanced fallback logic for geometric representation context detection ensures more reliable spatial element anchoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LTplus-AG/ifc-lite/pull/778?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->