### PR TITLE
fix(geometry): tessellate SoR bulb on the correct side of the axis so door Hardware aspect renders (#674)

### DIFF
--- a/rust/geometry/src/processors/advanced_face.rs
+++ b/rust/geometry/src/processors/advanced_face.rs
@@ -1378,22 +1378,28 @@ fn process_surface_of_revolution_face(
     let n_angle = ((span / (TAU / 36.0)).ceil() as usize).clamp(4, 48);
     let n_v = profile_pts.len();
 
-    // Generate vertices using cylindrical (r, axial) coordinates of each
-    // profile point — the profile's own angular position around the axis is
-    // irrelevant for the swept surface, only its (radius, axial) matters.
+    // Preserve the profile's (rx, ry) — issue #674: collapsing to radius
+    // mirrored profiles on the −axis_x half to the +axis_x side, drifting
+    // door-handle SoR bulbs 180° away from their bar.
+    let local_profile: Vec<(f64, f64, f64)> = profile_pts
+        .iter()
+        .map(|p| {
+            let r = p - axis_origin;
+            (r.dot(&axis_x), r.dot(&axis_y), r.dot(&axis_dir))
+        })
+        .collect();
+
+    let _ = a_min; // profile is already at a_min in its natural position; only span drives the sweep.
+
     let mut positions = Vec::with_capacity((n_angle + 1) * n_v * 3);
     for i in 0..=n_angle {
-        let theta = a_min + span * (i as f64) / (n_angle as f64);
-        let cos_t = theta.cos();
-        let sin_t = theta.sin();
-        for p in &profile_pts {
-            let r = p - axis_origin;
-            let rx = r.dot(&axis_x);
-            let ry = r.dot(&axis_y);
-            let z = r.dot(&axis_dir);
-            let radius = (rx * rx + ry * ry).sqrt();
-            let world =
-                axis_origin + axis_x * (radius * cos_t) + axis_y * (radius * sin_t) + axis_dir * z;
+        let dtheta = span * (i as f64) / (n_angle as f64);
+        let cos_t = dtheta.cos();
+        let sin_t = dtheta.sin();
+        for &(rx, ry, z) in &local_profile {
+            let nrx = rx * cos_t - ry * sin_t;
+            let nry = rx * sin_t + ry * cos_t;
+            let world = axis_origin + axis_x * nrx + axis_y * nry + axis_dir * z;
             positions.push(world.x as f32);
             positions.push(world.y as f32);
             positions.push(world.z as f32);

--- a/rust/geometry/tests/issue_604_door_regression.rs
+++ b/rust/geometry/tests/issue_604_door_regression.rs
@@ -113,6 +113,51 @@ fn door_handle_and_glass_meshes_are_non_empty() {
     }
 }
 
+/// Regression for issue #674 — the door handle's `IfcSurfaceOfRevolution`
+/// bulb is mirrored to the +axis_x half when the profile sits entirely on
+/// the −axis_x half (Revit-exported door handles), leaving a visible gap
+/// between the lever and the rosette. Pre-fix the lever AABB started at
+/// x≈115 (bulb collapsed onto the bar); post-fix it extends to x≈91,
+/// reaching across to the rosette centred at x≈122.5.
+#[test]
+fn door_handle_bulb_connects_to_rosette() {
+    let Some(content) = read_fixture() else {
+        return;
+    };
+
+    let entity_index = ifc_lite_core::build_entity_index(&content);
+    let mut decoder = EntityDecoder::with_index(&content, entity_index);
+    let router = ifc_lite_geometry::GeometryRouter::new();
+
+    for id in [232u32, 440] {
+        let entity = decoder.decode_by_id(id).expect("decode handle brep");
+        let mesh = router
+            .process_representation_item(&entity, &mut decoder)
+            .expect("handle tessellation must not error");
+
+        let mut x_min = f32::INFINITY;
+        let mut x_max = f32::NEG_INFINITY;
+        for c in mesh.positions.chunks_exact(3) {
+            if c[0] < x_min {
+                x_min = c[0];
+            }
+            if c[0] > x_max {
+                x_max = c[0];
+            }
+        }
+
+        // Lever bar tip is at x=245 (raw mm), so x_max is invariant.
+        assert!(x_max > 240.0, "lever #{id} x_max regressed: {x_max:.2}");
+        // Pre-fix: x_min ≈ 115 (bulb on wrong side of axis). The bulb's true
+        // sweep brings it within ~30 mm of the rosette outer face (x=92).
+        assert!(
+            x_min < 100.0,
+            "lever #{id} bulb mirrored: x_min={x_min:.2} — \
+             SoR profile sign-loss regression of issue #674",
+        );
+    }
+}
+
 /// Half (a) of #604 — wall opening cut must be clean when the opening's
 /// extrusion depth exactly equals the host wall's depth (200 mm == 200 mm
 /// in `door.ifc`). Verifies the PR #605 padding fix on a real Revit IFC,


### PR DESCRIPTION
## Summary

- `process_surface_of_revolution_face` in `rust/geometry/src/processors/advanced_face.rs` used to collapse each profile point's radial vector to `radius = sqrt(rx² + ry²)`, dropping the sign and pinning every profile point onto the `+axis_x` ray. Profiles that lived entirely on the `−axis_x` half of the axis frame — exactly the configuration Revit emits for door-handle bulbs (`IfcCircle` arc revolved around an axis offset by 15 mm) — were mirrored across the axis. The bulb that should bridge the lever bar and the rosette ended up generated 180° away, leaving a visible gap.
- Keep `(rx, ry)` of each profile point and rotate the pair directly through `[0, span]`. The profile already sits at its natural starting angle around the axis, so only `span` is needed for the sweep.
- Pins a regression test on `tests/models/various/issue-604-door.ifc` (lever sub-shells `#232`, `#440`) — pre-fix `x_min ≈ 115` mm, post-fix `x_min ≈ 91` mm, reaching across to the rosette centred at `x = 122.5` mm.

## Root cause

`IfcSurfaceOfRevolution` defines the profile curve in 3D — the profile already lives at its natural angular position around the revolution axis. The sweep is a rotation from that natural position through `span` radians. Using `radius·cos(θ)` instead of rotating `(rx, ry)` works only when the profile starts on the `+axis_x` ray. Door-handle bulbs whose arc center sits on the opposite side of the axis from the bar end up generated on the wrong side of the axis.

## Before / after triangle counts

The fix is a re-tessellation, not a re-sampling, so the triangle count is unchanged (issue is about position, not count). Per-brep AABBs on `issue-604-door.ifc`:

| brep | pre-fix x_min | post-fix x_min | IOS x_min |
|---|---|---|---|
| `#232` lever (near side) | 115.0 | 91.2 | 115.0 (IOS leaves a flat end) |
| `#440` lever (far side)  | 119.0 | 96.0 | 115.0 |

(IOS via pip 0.8.2 produces an open-shell tessellation that doesn't include the bulb meridians the same way — IOS reaches `x_min = 115` because it stops at the bulb base; ours sweeps the full revolution and reaches across to the rosette at `x ≈ 91`.)

## Other fixtures touched

Zero per-element triangle / vertex diff vs `main` on:
- `tests/models/ara3d/AC20-FZK-Haus.ifc` (83 elements)
- `tests/models/ara3d/C20-Institute-Var-2.ifc` (702 elements)

The change only affects faces whose profile sits off the `+axis_x` half of the axis frame — a rare configuration that the FZK and Institute fixtures don't hit. Recent CSG work (PR #789) is untouched.

## Test plan

- [x] `cargo test -p ifc-lite-geometry` — 173 tests pass, including the new `door_handle_bulb_connects_to_rosette`.
- [x] `cargo test -p ifc-lite-geometry --test issue_604_door_regression` — 3 tests pass.
- [x] FZK + Institute correctness sweep: 0 changed elements vs `main`.
- [ ] Visual confirmation in `apps/viewer` against `issue-604-door.ifc`.

Closes #674. Originally surfaced via #604, which was closed after the cylindrical-surface and circle-edge fixes landed — the SoR sign-loss path was separate and survived that pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)