### PR TITLE
ci(docker): bump chef base image to rust-1.95 for nalgebra 0.35 MSRV

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -1,8 +1,11 @@
 # IFC-Lite Server Dockerfile
 # Optimized multi-stage build for Railway deployment
 
-# Stage 1: Chef - prepare recipe for dependency caching
-FROM lukemathwalker/cargo-chef:latest-rust-1.88 AS chef
+# Stage 1: Chef - prepare recipe for dependency caching.
+# Bumped from rust-1.88 → rust-1.95 because nalgebra 0.35.0 (PR #786) raised
+# its MSRV to 1.89.0. Pinning the bookworm variant so the build glibc lines
+# up with the bookworm-slim runtime stage below.
+FROM lukemathwalker/cargo-chef:latest-rust-1.95-bookworm AS chef
 WORKDIR /app
 
 # Stage 2: Planner - create dependency recipe


### PR DESCRIPTION
## Summary

The Docker Image workflow has been failing on every push to main since PR #786 merged the nalgebra 0.34 → 0.35 bump. nalgebra 0.35 raised its MSRV to 1.89.0; the Dockerfile pinned `lukemathwalker/cargo-chef:latest-rust-1.88`, so `cargo chef cook` aborts in the planner stage:

\`\`\`
error: rustc 1.88.0 is not supported by the following packages:
  nalgebra@0.35.0 requires rustc 1.89.0
  safe_arch@1.0.0 requires rustc 1.89
  wide@1.4.0 requires rustc 1.89
\`\`\`

(Run [#78](https://github.com/LTplus-AG/ifc-lite/actions) on commit \`967dc10d\` is the most recent example.)

## Fix

Bump the chef base image to `latest-rust-1.95-bookworm` — current stable train, verified to exist on Docker Hub. Pinning the bookworm variant keeps the build-stage glibc lined up with the `debian:bookworm-slim` runtime stage we COPY the binary into.

## Test plan

- [x] Docker Hub HEAD on `lukemathwalker/cargo-chef:latest-rust-1.95-bookworm` returns 200
- [ ] Docker Image workflow on this PR builds + pushes successfully (will run on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated server build toolchain to use the latest Rust version for improved compatibility and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LTplus-AG/ifc-lite/pull/794?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->