### PR TITLE
chore(changesets): add changesets for #789, #792, #793

### DIFF
--- a/.changeset/csg-sequential-subtract-583.md
+++ b/.changeset/csg-sequential-subtract-583.md
@@ -1,0 +1,23 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Fix walls sticking through curved roof slabs on AC20-Institute-Var-2
+(issue #583, PR #789). The chained-polygonal-bounded-half-space code
+path used to mesh-merge every cutter in an `IfcBooleanClippingResult`
+chain into one combined cutter before running a single BSP CSG
+subtract. When the chain contained overlapping or duplicate prisms
+(Wand-010 has four chained cutters including an exact duplicate at
+`x = [17, 25]`), the merge of two closed solids occupying the same
+volume was non-manifold by construction and BSP produced sliver
+artefacts that left ~0.4-2.7 m of wall sticking through the roof.
+
+The fix follows the web-ifc model: drop the batching, let chains fall
+through the standard recursive single-cutter path. Each per-step
+cutter is a single closed manifold prism, structurally eliminating
+the non-manifold-cutter root cause. Two long-standing
+`IfcPolygonalBoundedHalfSpace` issues that the batched path was
+masking were also fixed: the prism now extrudes along the cutter
+Position's `+Z` axis (per the IFC 4.3 spec, not the plane's material-
+side direction), and the polygon winding is reversed against
+`Position.Z` to match the cap reversal in `build_tilted_prism_mesh`.

--- a/.changeset/door-handle-sor-674.md
+++ b/.changeset/door-handle-sor-674.md
@@ -1,0 +1,19 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Fix the broken door-handle silhouette on Revit-exported `IfcDoor`
+fixtures (issue #674, PR #793). `process_surface_of_revolution_face`
+collapsed each profile point's radial vector to
+`radius = sqrt(rx² + ry²)`, discarding the sign of the projection
+onto `axis_x`. Profiles that sat entirely on the `-axis_x` half of
+the axis frame — for example the Revit door-handle bulb, an
+`IfcCircle` arc whose centre is offset 15 mm from the revolution
+axis on the bar side — got mirrored to the `+axis_x` ray and rendered
+180° away from where they should sit, leaving a visible gap between
+the lever bar and the rosette.
+
+The sweep now rotates the profile's actual `(rx, ry)` 2D radial
+vector through the sweep angle, so profiles offset to either side of
+the axis stay on their side. Triangle counts are unchanged
+(repositioning, not re-sampling).

--- a/.changeset/viewer-multi-model-visibility-661.md
+++ b/.changeset/viewer-multi-model-visibility-661.md
@@ -1,0 +1,19 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Fix "Add Model to Scene" hiding the first model when a second is
+loaded (issue #661, PR #792). `useIfcFederation.addModel` always
+called `setIfcDataStore(parsedDataStore)` and
+`setGeometryResult(parsedGeometry)` after `storeAddModel`, with the
+new model's data. `modelSlice.addModel` only flips `activeModelId`
+for the FIRST model, so on subsequent adds those legacy setters
+wrote the new model's data into `models.get(activeModelId)` — i.e.
+into the FIRST model's per-model entry — aliasing both Map entries
+to the second model's mesh and rendering only one element.
+
+The fix drops those two redundant calls from `addModel`. For the
+first model `modelSlice.addModel` already mirrors the data into the
+top-level fields, and for subsequent models the legacy top-level
+fields must stay pointing at the active (first) model's data; the
+existing `setActiveModel` handler updates them on focus change.


### PR DESCRIPTION
## Summary

Three fixes landed on main without changesets, so the next \`changesets/action\` version PR would skip their changelog entries despite the user-visible behavior change:

| PR | Fix | Bump |
|---|---|---|
| #789 | CSG sequential subtraction for chained polygonal half-spaces (#583 walls-through-roof) | \`@ifc-lite/wasm\` patch |
| #793 | Preserve profile sign in IfcSurfaceOfRevolution sweep (#674 / #604 door handle) | \`@ifc-lite/wasm\` patch |
| #792 | Multi-model visibility — first model no longer hidden by Add Model to Scene (#661) | \`@ifc-lite/viewer\` patch |

\`pnpm changeset status\` after applying:

\`\`\`
Packages to be bumped at patch:
  - @ifc-lite/viewer            (1.22.0 → 1.22.1)
Packages to be bumped at minor:
  - @ifc-lite/wasm              (1.16.10 → 1.17.0, dominated by csg-bath-primitives-780)
\`\`\`

## ⚠️ Release workflow still blocked

These changesets line up the changelog but they don't fix the Release workflow itself, which has been failing on every push to main since 2026-05-20 with:

\`\`\`
Error: HttpError: Resource not accessible by integration - https://docs.github.com/rest/pulls/pulls#create-a-pull-request
\`\`\`

The \`changesets/action\` push succeeds (App token has \`contents:write\`) but the PR-creation API call fails because the \`ifc-lite-release-bot-org\` GitHub App lost \`pull_requests:write\` on \`LTplus-AG/ifc-lite\` sometime after the last successful version PR (#768, 2026-05-20).

**Admin action needed** (not in this PR):

1. https://github.com/organizations/LTplus-AG/settings/installations
2. Find the App backing \`RELEASE_APP_ID\`
3. Configure → Repository permissions → **Pull requests: Read and write**
4. Accept any pending permission request banner

After that, the next push to main (or a re-run of the failed Release workflow) will create the version PR and publish v1.17.0 of \`@ifc-lite/wasm\` plus the viewer patch.

## Test plan

- [x] \`pnpm changeset status\` — three new bumps detected
- [ ] After Release workflow App fix: version PR opens, runs CI, can be merged to trigger publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)