### PR TITLE
ci(release): use fine-grained PAT instead of GitHub App for version PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,7 @@ name: Release
 
 # PUBLISH AUTHENTICATION — Phase B trusted publishing
 #
-# This workflow does NOT use long-lived publish tokens. It mints
-# short-lived credentials via OIDC at runtime:
+# Package registries — short-lived credentials minted via OIDC at runtime:
 #
 #   npm        — Trusted Publisher configured per `@ifc-lite/*` package on
 #                npmjs.com. `id-token: write` + npm CLI ≥ 11.5.1 +
@@ -12,6 +11,10 @@ name: Release
 #   crates.io  — Trusted Publisher configured per crate on crates.io.
 #                rust-lang/crates-io-auth-action exchanges the OIDC token
 #                for a 30-minute CARGO_REGISTRY_TOKEN.
+#
+# Git side (push of `changeset-release/main` + opening the version PR) uses
+# a fine-grained PAT (`secrets.RELEASE_PAT`) — see the inline comment on
+# the Checkout step for why a PAT and not GITHUB_TOKEN or a GitHub App.
 #
 # The release job runs in the `release-publish` GitHub Environment so any
 # residual repo-scoped secrets are unreachable from other jobs. See
@@ -40,29 +43,33 @@ jobs:
       published: ${{ steps.changesets.outputs.published }}
       version: ${{ steps.get-version.outputs.version }}
     steps:
-      # Mint a short-lived installation token for the `ifc-lite-release-bot-org`
-      # GitHub App. The changesets PR (`chore: version packages`) must be
-      # authored by a real identity, NOT the default GITHUB_TOKEN: GitHub
-      # suppresses pull_request/push workflow triggers for GITHUB_TOKEN-authored
-      # events (recursion guard), so the required `Build + WASM + Rust + Node`
-      # check never ran on a version PR and sat permanently "Expected" (#766).
-      # App ID + private key live as `release-publish` environment secrets.
-      - name: Mint GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-
+      # AUTH for the changesets version PR (`chore: version packages`):
+      # we use a fine-grained PAT (`secrets.RELEASE_PAT`), NOT the default
+      # GITHUB_TOKEN, because GitHub suppresses pull_request/push workflow
+      # triggers on GITHUB_TOKEN-authored events (recursion guard) so the
+      # required `Build + WASM + Rust + Node` check would never run on a
+      # version PR and it would sit permanently "Expected" (issue #766).
+      #
+      # Previously this used an installation token from a GitHub App
+      # (`ifc-lite-release-bot-org`) but the install didn't carry over when
+      # the repo moved from `louistrue/ifc-lite` to `LTplus-AG/ifc-lite`,
+      # and the App's installation token on the new owner lost
+      # `pull_requests:write` — every Release run after that failed with
+      # "Resource not accessible by integration" on the create-PR API call.
+      #
+      # A fine-grained PAT scoped to this repo with `contents: read+write`
+      # and `pull_requests: read+write` survives org/repo moves and removes
+      # the App-management surface entirely. Rotate the PAT in the repo
+      # secrets when it expires; no workflow change needed for rotation.
       - name: Checkout Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           lfs: false
-          # Persist the App token so the version-packages branch push made by
-          # changesets/action is App-authored too — not just the PR API call.
-          # Both must be App-authored for the pull_request event to fire.
-          token: ${{ steps.app-token.outputs.token }}
+          # Persist the PAT so the version-packages branch push made by
+          # changesets/action is PAT-authored too — not just the PR API call.
+          # Both must be PAT-authored for the pull_request event to fire.
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Setup pnpm
         # v6 reads the version from the `packageManager` field in
@@ -153,9 +160,10 @@ jobs:
           commit: 'chore: version packages'
           title: 'chore: version packages'
         env:
-          # App token (not GITHUB_TOKEN) so the version PR + its commits are
-          # authored by ifc-lite-release-bot-org and CI triggers on them.
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          # PAT (not GITHUB_TOKEN) so the version PR + its commits are
+          # authored by a real user identity and CI triggers on them — see
+          # the comment on the Checkout step for the full rationale.
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
           # npm publishes use OIDC trusted publishing — no NPM_TOKEN.
           # `id-token: write` (set at job level) + npm CLI ≥ 11.5.1 +
           # NPM_CONFIG_PROVENANCE complete the handshake automatically


### PR DESCRIPTION
## Summary

Fix the Release workflow that has failed on every push to main since 2026-05-20.

**Root cause:** the `ifc-lite-release-bot-org` GitHub App was installed on `louistrue/ifc-lite` before the repo moved to the `LTplus-AG` org. The move didn't carry the installation across with original scopes — installation token can still push to branches (\`contents:write\` retained) but lost \`pull_requests:write\`. Every release run since then 403s at the create-PR step:

\`\`\`
Error: HttpError: Resource not accessible by integration
\`\`\`

**Fix:** Switch to a fine-grained PAT (\`secrets.RELEASE_PAT\`) scoped to this repo with \`contents: read+write\` + \`pull_requests: read+write\`. PATs:

- Survive org/repo moves
- Dodge the GITHUB_TOKEN recursion guard (workflows trigger on PAT-authored push/pull_request events — same property we relied on the App for, originally #769)
- Don't require App-installation management
- Rotate by regenerating + updating one repo secret; no workflow edits

The \`RELEASE_APP_ID\` / \`RELEASE_APP_PRIVATE_KEY\` secrets in the \`release-publish\` environment are now unused — can be revoked at leisure.

## What this PR doesn't do

Doesn't itself publish anything. Once merged, the **next** push to main (or a manual re-run of the failed Release run) will succeed at create-PR and open the queued \`@ifc-lite/wasm\` 1.16.10 → 1.17.0 version PR.

If you want to publish the queued bump immediately after merging this, push any commit to main (e.g., merging PR #795 which adds the changesets for #789 / #792 / #793) and Release will fire fresh.

## Test plan

- [x] yaml lint: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`
- [x] No leftover \`RELEASE_APP_ID\` / \`RELEASE_APP_PRIVATE_KEY\` / \`create-github-app-token\` references
- [ ] On merge: Release workflow runs, opens \`chore: version packages\` PR successfully (will visually confirm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal release automation infrastructure.

---

**Note:** This release contains no user-facing changes. Updates are limited to internal deployment processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LTplus-AG/ifc-lite/pull/796?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->