### PR TITLE
fix(deps): patch uuid for CVE-2026-41907

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,8 @@
       "@vitest/spy": "^3.2.4",
       "@vitest/utils": "^3.2.4",
       "picomatch@<3": "^2.3.2",
-      "picomatch@>=4": "^4.0.4"
+      "picomatch@>=4": "^4.0.4",
+      "uuid@<11.1.1": "^11.1.1"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,7 @@ overrides:
   '@vitest/utils': ^3.2.4
   picomatch@<3: ^2.3.2
   picomatch@>=4: ^4.0.4
+  uuid@<11.1.1: ^11.1.1
 
 importers:
 
@@ -4339,9 +4340,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   vfile-message@4.0.3:
@@ -7766,7 +7766,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@10.0.0: {}
+  uuid@11.1.1: {}
 
   vfile-message@4.0.3:
     dependencies:
@@ -7812,7 +7812,7 @@ snapshots:
       '@rollup/plugin-virtual': 3.0.2(rollup@4.60.4)
       '@swc/core': 1.15.8(@swc/helpers@0.5.21)
       '@swc/wasm': 1.15.8
-      uuid: 10.0.0
+      uuid: 11.1.1
       vite: 7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)
     transitivePeerDependencies:
       - '@swc/helpers'


### PR DESCRIPTION
## Summary

- Adds a pnpm override pinning `uuid` to `^11.1.1` across the workspace.
- Resolves Dependabot alert [#46](https://github.com/LTplus-AG/ifc-lite/security/dependabot/46) for [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) / CVE-2026-41907 (uuid v3/v5/v6 missing buffer bounds check on caller-supplied `buf`).

## Why an override

`uuid@10.0.0` enters the tree only as a transitive of `vite-plugin-top-level-await@1.6.0`, which hard-pins `"uuid": "10.0.0"` (latest plugin release at time of writing). No newer plugin release is available, so the override is required to lift the transitive to a patched line.

After the override, the lockfile shows `uuid@11.1.1` as the only resolution and `vite-plugin-top-level-await -> uuid: 11.1.1`.

## Exploitability assessment

Not reachable in this repo:

- `uuid` is a **build-time** transitive of a Vite plugin. It does not ship to the runtime bundle delivered to end users.
- The plugin's only caller is `RandomIdentifierGenerator` in `dist/utils/random-identifier.js`, which invokes `v5(seed, namespace)` with two arguments and never passes the optional `buf` argument that the advisory targets.
- The vulnerable code path (`v5(value, namespace, buf, offset)` with an undersized buffer or large offset) is never exercised.

Bumping anyway to clear the alert and stay on a supported uuid release line (uuid@10 is deprecated upstream).

## Test plan

- [x] `pnpm install --lockfile-only` regenerates a clean lockfile with no `uuid@10.0.0` left in the tree.
- [x] `pnpm install --frozen-lockfile` succeeds against the new lockfile.
- [x] Smoke test of `vite-plugin-top-level-await`'s `RandomIdentifierGenerator` against the updated uuid resolves identifiers correctly with no runtime errors.
- [x] CI build / typecheck across the workspace passes.