### PR TITLE
chore(changesets): backfill for #799 + #802

### DIFF
--- a/.changeset/advanced-face-holes-674.md
+++ b/.changeset/advanced-face-holes-674.md
@@ -1,0 +1,37 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Fix the wedge-shaped Z-fight artifact on the door-glass panel
+of Revit-exported `IfcDoor` fixtures (issue #674 true root cause,
+PR #802).
+
+`process_planar_face` in `advanced_face.rs` triangulated each
+`IfcFaceBound` of an `IfcAdvancedFace` as an independent solid
+polygon, ignoring the IFC 4.3 schema's `IfcFaceOuterBound` vs
+inner-bound distinction. For a face with one outer rectangle +
+one inner hole rectangle (the door panel's glass cutout), this
+emitted:
+
+  - outer ring: 2-tri solid quad covering the whole face
+  - inner ring: 2-tri solid quad covering the hole, with the
+    schema-imposed reversed winding → opposite normal
+
+Identical plane, opposite normals, overlapping in the cutout's
+footprint. The WebGPU pipeline runs `cullMode: 'none'`, so the
+canceling pair rendered as the visible wedge.
+
+Fix: identify the outer bound (preferring the typed
+`IfcType::IfcFaceOuterBound`, falling back to the first bound for
+files that emit only `IfcFaceBound`), treat siblings as holes,
+honour the per-bound orientation flag, and call the existing
+`triangulate_polygon_with_holes` helper once — the same pattern
+the FacetedBrep path in `brep.rs` already uses.
+
+Door panel #712 on the issue-604 fixture now emits 32 triangles
+(matching IfcOpenShell's reference), up from 24 pre-fix. The
+same broken code path was the fallback for every other surface
+type in `advanced_face.rs` (B-spline edge cap, cylindrical /
+conical / spherical / toroidal / surface-of-linear-extrusion
+fallbacks); all of those now also produce correct annular
+triangulations on faces with inner bounds.

--- a/.changeset/door-handle-sor-axis-slot-674.md
+++ b/.changeset/door-handle-sor-axis-slot-674.md
@@ -1,0 +1,30 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Fix the door-handle bend rendering with the lever floating
+detached from the rosette on Revit-exported `IfcDoor` fixtures
+(issue #674 redux, PR #799).
+
+`process_surface_of_revolution_face` in `advanced_face.rs` read
+`surface.get(1)` for the axis placement, but per IFC 4.3 the
+`IfcSurfaceOfRevolution` schema is:
+
+  IfcSweptSurface (parent)
+    0 SweptCurve
+    1 Position           (optional IfcAxis2Placement3D)
+  IfcSurfaceOfRevolution (child)
+    2 AxisPosition       (IfcAxis1Placement)
+
+Revit exports `IFCSURFACEOFREVOLUTION(#sc,$,#ap)` — slot 1 is
+null. Reading slot 1 returned None, the fallback
+`(Point3::origin(), +Z)` kicked in, and the angular-extent
+calculation projected boundary points around (0,0,0) instead of
+the true revolution axis. The bend swept ~13° through the wrong
+region of space and the bulb ended up pointing "down and outward"
+from the rosette.
+
+Switched to `surface.get(2)`. AABB on the door fixture lands at
+x=[115, 245] y=[67, 122] vs IfcOpenShell's [120, 250] / [70, 120]
+(5 mm offset from tessellation density). The bulb now rotates
+through the correct quadrant and the handle connects.


### PR DESCRIPTION
## Summary

Two geometry fixes for issue #674 landed on main without changesets and would be silently skipped by the next \`changesets/action\` version PR:

| PR | Fix | Bump |
|---|---|---|
| #799 | door handle SoR reads AxisPosition from the right slot (true #674 handle fix) | \`@ifc-lite/wasm\` patch |
| #802 | IfcFaceOuterBound + holes annular triangulation (true #674 glass artifact fix) | \`@ifc-lite/wasm\` patch |

\`pnpm changeset status\`:

\`\`\`
Packages to be bumped at patch:
  - @ifc-lite/wasm
\`\`\`

Next published \`@ifc-lite/wasm\` will be 1.17.1 with both geometry fixes in its changelog.

(PR #688 also adds a changeset, but on its own branch since it's still open.)

## Test plan

- [x] \`pnpm changeset status\` reports patch bump for @ifc-lite/wasm
- [ ] Once merged: changesets/action opens version PR → @ifc-lite/wasm 1.17.0 → 1.17.1 → publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)