### PR TITLE
fix(glb): preserve per-mesh colours when re-importing a .glb

### DIFF
--- a/.changeset/glb-import-preserve-colour.md
+++ b/.changeset/glb-import-preserve-colour.md
@@ -1,0 +1,21 @@
+---
+"@ifc-lite/cache": patch
+"@ifc-lite/export": patch
+---
+
+fix(glb): preserve per-mesh colours when re-importing a `.glb`
+
+Both GLB importers (`parseGLBToMeshData` in `@ifc-lite/cache` and the
+secondary one in `@ifc-lite/export`) hardcoded
+`color: [0.8, 0.8, 0.8, 1.0]` on every mesh and never looked at
+`materials[*].pbrMetallicRoughness.baseColorFactor`. After the
+GLB-export-dialog work (#688) wired colour authoring through the
+exporter end-to-end, a round-trip
+(IFC → GLB → re-import as model) silently lost all colour and the
+viewport went grey.
+
+Fix: resolve each primitive's `material` index against the glTF
+`materials` array and copy `baseColorFactor` into `MeshData.color`,
+keeping the previous grey as the fallback when a primitive has no
+material (e.g. third-party glTFs). Regression tests added in both
+packages cover the round-trip and the no-material fallback.

--- a/packages/cache/src/glb.test.ts
+++ b/packages/cache/src/glb.test.ts
@@ -1,0 +1,213 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { parseGLBToMeshData, loadGLBToMeshData } from './glb.js';
+
+/**
+ * Build a minimal valid GLB (binary glTF) by hand. Mirrors the structure
+ * that `GLTFExporter` in `@ifc-lite/export` produces (one mesh per node,
+ * one material per node, KHR_materials_unlit) without adding a cross-
+ * package test dependency on `@ifc-lite/export`.
+ */
+function buildGLB(materials: Array<[number, number, number, number]>): Uint8Array {
+  // One triangle per material; each lives on its own node referencing its
+  // own material so the material→colour resolution can be checked per node.
+  const triCount = materials.length;
+  const verts = new Float32Array(triCount * 9);    // 3 verts × 3 floats
+  const norms = new Float32Array(triCount * 9);
+  const idx = new Uint32Array(triCount * 3);
+
+  for (let i = 0; i < triCount; i++) {
+    const v = i * 9;
+    verts.set([0, 0, 0, 1, 0, 0, 0, 1, 0], v);
+    norms.set([0, 0, 1, 0, 0, 1, 0, 0, 1], v);
+    idx.set([i * 3, i * 3 + 1, i * 3 + 2], i * 3);
+  }
+
+  const posBytes = new Uint8Array(verts.buffer);
+  const normBytes = new Uint8Array(norms.buffer);
+  const idxBytes = new Uint8Array(idx.buffer);
+
+  const accessors: any[] = [];
+  const primitives: any[] = [];
+  const meshes: any[] = [];
+  const nodes: any[] = [];
+
+  for (let i = 0; i < triCount; i++) {
+    const posIdx = accessors.length;
+    accessors.push({
+      bufferView: 0,
+      byteOffset: i * 9 * 4,
+      componentType: 5126,
+      count: 3,
+      type: 'VEC3',
+      min: [0, 0, 0],
+      max: [1, 1, 0],
+    });
+    const normIdx = accessors.length;
+    accessors.push({
+      bufferView: 1,
+      byteOffset: i * 9 * 4,
+      componentType: 5126,
+      count: 3,
+      type: 'VEC3',
+    });
+    const idxAccIdx = accessors.length;
+    accessors.push({
+      bufferView: 2,
+      byteOffset: i * 3 * 4,
+      componentType: 5125,
+      count: 3,
+      type: 'SCALAR',
+    });
+
+    meshes.push({
+      primitives: [
+        {
+          attributes: { POSITION: posIdx, NORMAL: normIdx },
+          indices: idxAccIdx,
+          material: i,
+        },
+      ],
+    });
+    nodes.push({ mesh: i, extras: { expressId: 100 + i } });
+  }
+
+  const json = {
+    asset: { version: '2.0', generator: 'test' },
+    scene: 0,
+    scenes: [{ nodes: nodes.map((_, i) => i) }],
+    nodes,
+    meshes,
+    materials: materials.map((c) => ({
+      pbrMetallicRoughness: {
+        baseColorFactor: c,
+        metallicFactor: 0,
+        roughnessFactor: 1,
+      },
+      extensions: { KHR_materials_unlit: {} },
+      ...(c[3] < 1 ? { alphaMode: 'BLEND' as const } : {}),
+    })),
+    accessors,
+    bufferViews: [
+      { buffer: 0, byteOffset: 0, byteLength: posBytes.byteLength, byteStride: 12, target: 34962 },
+      {
+        buffer: 0,
+        byteOffset: posBytes.byteLength,
+        byteLength: normBytes.byteLength,
+        byteStride: 12,
+        target: 34962,
+      },
+      {
+        buffer: 0,
+        byteOffset: posBytes.byteLength + normBytes.byteLength,
+        byteLength: idxBytes.byteLength,
+        target: 34963,
+      },
+    ],
+    buffers: [
+      {
+        byteLength: posBytes.byteLength + normBytes.byteLength + idxBytes.byteLength,
+      },
+    ],
+  };
+
+  const jsonStr = JSON.stringify(json);
+  const jsonBuf = new TextEncoder().encode(jsonStr);
+  const jsonPad = (4 - (jsonBuf.byteLength % 4)) % 4;
+  const jsonChunkLen = jsonBuf.byteLength + jsonPad;
+
+  const binLen = posBytes.byteLength + normBytes.byteLength + idxBytes.byteLength;
+  const binPad = (4 - (binLen % 4)) % 4;
+  const binChunkLen = binLen + binPad;
+
+  const total = 12 + 8 + jsonChunkLen + 8 + binChunkLen;
+  const out = new Uint8Array(total);
+  const dv = new DataView(out.buffer);
+  dv.setUint32(0, 0x46546c67, true); // glTF
+  dv.setUint32(4, 2, true);
+  dv.setUint32(8, total, true);
+  dv.setUint32(12, jsonChunkLen, true);
+  dv.setUint32(16, 0x4e4f534a, true); // JSON
+  out.set(jsonBuf, 20);
+  for (let i = 0; i < jsonPad; i++) out[20 + jsonBuf.byteLength + i] = 0x20;
+
+  let off = 20 + jsonChunkLen;
+  dv.setUint32(off, binChunkLen, true);
+  dv.setUint32(off + 4, 0x004e4942, true); // BIN
+  off += 8;
+  out.set(posBytes, off);
+  off += posBytes.byteLength;
+  out.set(normBytes, off);
+  off += normBytes.byteLength;
+  out.set(idxBytes, off);
+  // pad bytes default to 0
+
+  return out;
+}
+
+describe('parseGLBToMeshData / loadGLBToMeshData — material colour round-trip', () => {
+  // Regression for #688: GLB importer hardcoded grey, silently dropping the
+  // exporter's per-mesh material colours on re-import.
+  it('reads pbrMetallicRoughness.baseColorFactor into MeshData.color', () => {
+    const colors: Array<[number, number, number, number]> = [
+      [0.8, 0.2, 0.2, 1.0],
+      [0.1, 0.6, 0.3, 0.5],
+      [0.0, 0.0, 1.0, 1.0],
+    ];
+    const meshes = loadGLBToMeshData(buildGLB(colors));
+    expect(meshes).toHaveLength(3);
+    for (let i = 0; i < colors.length; i++) {
+      const expected = colors[i];
+      const actual = meshes[i].color;
+      expect(actual[0]).toBeCloseTo(expected[0]);
+      expect(actual[1]).toBeCloseTo(expected[1]);
+      expect(actual[2]).toBeCloseTo(expected[2]);
+      expect(actual[3]).toBeCloseTo(expected[3]);
+    }
+  });
+
+  it('falls back to default grey when a primitive has no material', () => {
+    const glb = buildGLB([[0.5, 0.5, 0.5, 1.0]]);
+    // Hand-strip material from the primitive to simulate a 3rd-party GLB.
+    const txt = new TextDecoder().decode(glb.subarray(20, 20 + new DataView(glb.buffer).getUint32(12, true)));
+    expect(txt).toContain('"material":0');
+
+    // Drop just `materials` from the GLB and re-pack. Easier: parse-with-no-
+    // materials by emulating an external file via a fresh buildGLB whose
+    // resolver receives an undefined material index.
+    const meshes = parseGLBToMeshData(
+      {
+        asset: { version: '2.0' },
+        scenes: [{ nodes: [0] }],
+        nodes: [{ mesh: 0 }],
+        meshes: [
+          {
+            primitives: [
+              {
+                attributes: { POSITION: 0, NORMAL: 1 },
+                indices: 2,
+              },
+            ],
+          },
+        ],
+        accessors: [
+          { bufferView: 0, byteOffset: 0, componentType: 5126, count: 3, type: 'VEC3' },
+          { bufferView: 1, byteOffset: 0, componentType: 5126, count: 3, type: 'VEC3' },
+          { bufferView: 2, byteOffset: 0, componentType: 5125, count: 3, type: 'SCALAR' },
+        ],
+        bufferViews: [
+          { buffer: 0, byteOffset: 0, byteLength: 36, byteStride: 12, target: 34962 },
+          { buffer: 0, byteOffset: 36, byteLength: 36, byteStride: 12, target: 34962 },
+          { buffer: 0, byteOffset: 72, byteLength: 12, target: 34963 },
+        ],
+        buffers: [{ byteLength: 84 }],
+      },
+      new Uint8Array(84),
+    );
+    expect(meshes).toHaveLength(1);
+    expect(meshes[0].color).toEqual([0.8, 0.8, 0.8, 1.0]);
+  });
+});

--- a/packages/cache/src/glb.ts
+++ b/packages/cache/src/glb.ts
@@ -45,6 +45,7 @@ interface GLTFDocument {
   scenes?: Array<{ nodes?: number[] }>;
   nodes?: GLTFNode[];
   meshes?: GLTFMesh[];
+  materials?: GLTFMaterial[];
   accessors?: GLTFAccessor[];
   bufferViews?: GLTFBufferView[];
   buffers?: GLTFBuffer[];
@@ -69,6 +70,14 @@ interface GLTFPrimitive {
   };
   indices?: number;
   mode?: number;
+  material?: number;
+}
+
+interface GLTFMaterial {
+  pbrMetallicRoughness?: {
+    baseColorFactor?: [number, number, number, number] | number[];
+  };
+  alphaMode?: 'OPAQUE' | 'MASK' | 'BLEND';
 }
 
 interface GLTFAccessor {
@@ -338,6 +347,23 @@ export function parseGLBToMeshData(gltf: GLTFDocument, bin: Uint8Array): MeshDat
     return meshes;
   }
 
+  const DEFAULT_COLOR: [number, number, number, number] = [0.8, 0.8, 0.8, 1.0];
+
+  const resolveMaterialColor = (
+    materialIdx: number | undefined,
+  ): [number, number, number, number] => {
+    if (materialIdx === undefined) return DEFAULT_COLOR;
+    const material = gltf.materials?.[materialIdx];
+    const factor = material?.pbrMetallicRoughness?.baseColorFactor;
+    if (!factor || factor.length < 3) return DEFAULT_COLOR;
+    return [
+      factor[0],
+      factor[1],
+      factor[2],
+      factor.length >= 4 ? factor[3] : 1.0,
+    ];
+  };
+
   for (let nodeIdx = 0; nodeIdx < gltf.nodes.length; nodeIdx++) {
     const node = gltf.nodes[nodeIdx];
     if (node.mesh === undefined) continue;
@@ -402,7 +428,7 @@ export function parseGLBToMeshData(gltf: GLTFDocument, bin: Uint8Array): MeshDat
         positions,
         normals,
         indices,
-        color: [0.8, 0.8, 0.8, 1.0], // Default grey, can be overridden
+        color: resolveMaterialColor(primitive.material),
       });
     }
   }

--- a/packages/export/src/glb.ts
+++ b/packages/export/src/glb.ts
@@ -81,6 +81,20 @@ export function parseGLBToMeshData(glb: Uint8Array): MeshData[] {
   const meshes: any[] = Array.isArray(json?.meshes) ? json.meshes : [];
   const accessors: any[] = Array.isArray(json?.accessors) ? json.accessors : [];
   const bufferViews: any[] = Array.isArray(json?.bufferViews) ? json.bufferViews : [];
+  const materials: any[] = Array.isArray(json?.materials) ? json.materials : [];
+
+  const DEFAULT_COLOR: [number, number, number, number] = [0.8, 0.8, 0.8, 1];
+  const resolveMaterialColor = (materialIdx: unknown): [number, number, number, number] => {
+    if (typeof materialIdx !== 'number') return DEFAULT_COLOR;
+    const factor = materials[materialIdx]?.pbrMetallicRoughness?.baseColorFactor;
+    if (!Array.isArray(factor) || factor.length < 3) return DEFAULT_COLOR;
+    return [
+      Number(factor[0]),
+      Number(factor[1]),
+      Number(factor[2]),
+      factor.length >= 4 ? Number(factor[3]) : 1,
+    ];
+  };
 
   const readAccessor = (accessorIndex: number): { array: Float32Array | Uint32Array; count: number; components: number } => {
     const acc = accessors[accessorIndex];
@@ -130,7 +144,7 @@ export function parseGLBToMeshData(glb: Uint8Array): MeshData[] {
       positions: new Float32Array(pos),
       normals: new Float32Array(nor),
       indices: new Uint32Array(ind),
-      color: [0.8, 0.8, 0.8, 1],
+      color: resolveMaterialColor(prim.material),
       ifcType: 'IfcElement',
     });
   }

--- a/packages/export/src/gltf-exporter.test.ts
+++ b/packages/export/src/gltf-exporter.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { GLTFExporter } from './gltf-exporter.js';
+import { parseGLBToMeshData } from './glb.js';
 import type { GeometryResult, MeshData } from '@ifc-lite/geometry';
 
 // Helper to create a minimal mesh for testing
@@ -334,6 +335,47 @@ describe('GLTFExporter', () => {
 
       // Should throw with clear error message
       expect(() => exporter.exportGLTF()).toThrow(/no valid geometry/i);
+    });
+  });
+
+  // Regression for the GLB import-loses-colours report. The exporter writes
+  // each mesh colour into materials[*].pbrMetallicRoughness.baseColorFactor,
+  // and parseGLBToMeshData must read those back instead of defaulting to grey.
+  describe('GLB colour round-trip', () => {
+    it('preserves per-mesh colours through export → parseGLBToMeshData', () => {
+      const colours: Array<[number, number, number, number]> = [
+        [0.8, 0.2, 0.2, 1.0],
+        [0.1, 0.6, 0.3, 1.0],
+        [0.0, 0.0, 1.0, 0.5],
+      ];
+      const meshes: MeshData[] = colours.map((c, i) => ({
+        ...createTestMesh(i + 1),
+        color: c,
+      }));
+      const geometryResult: GeometryResult = {
+        meshes,
+        totalVertices: 9,
+        totalTriangles: 3,
+        coordinateInfo: {
+          originShift: { x: 0, y: 0, z: 0 },
+          originalBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 1, y: 1, z: 0 } },
+          shiftedBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 1, y: 1, z: 0 } },
+          hasLargeCoordinates: false,
+        },
+      };
+
+      const glb = new GLTFExporter(geometryResult).exportGLB();
+      const parsed = parseGLBToMeshData(glb);
+
+      expect(parsed).toHaveLength(3);
+      for (let i = 0; i < colours.length; i++) {
+        const expected = colours[i];
+        const actual = parsed[i].color;
+        expect(actual[0]).toBeCloseTo(expected[0]);
+        expect(actual[1]).toBeCloseTo(expected[1]);
+        expect(actual[2]).toBeCloseTo(expected[2]);
+        expect(actual[3]).toBeCloseTo(expected[3]);
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary
- Root cause: both GLB importers (`parseGLBToMeshData` in `@ifc-lite/cache` at `packages/cache/src/glb.ts:405` and the secondary one in `@ifc-lite/export` at `packages/export/src/glb.ts:133`) hardcoded `color: [0.8, 0.8, 0.8, 1.0]` and never read `materials[*].pbrMetallicRoughness.baseColorFactor`.
- Symptom: after #688 wired colour authoring through `GLTFExporter` end-to-end, exporting an IFC to GLB and re-importing it silently dropped every per-mesh colour — the viewport went grey.
- Fix: resolve each primitive's `material` index against the glTF `materials` array and copy `baseColorFactor` into `MeshData.color`; keep grey as the fallback when a primitive has no material (third-party glTFs).

## Changes
- `packages/cache/src/glb.ts` — extend parsed glTF types with `material?: number` on primitives and a `materials?: GLTFMaterial[]` on the document; resolve and copy `baseColorFactor` into `MeshData.color`.
- `packages/export/src/glb.ts` — same fix for the secondary importer.
- `packages/cache/src/glb.test.ts` (new) — hand-built GLB validates colour round-trip and no-material fallback (no cross-package dep).
- `packages/export/src/gltf-exporter.test.ts` — adds an end-to-end test: `GLTFExporter.exportGLB()` → `parseGLBToMeshData()` preserves three input colours including alpha.
- `.changeset/glb-import-preserve-colour.md` — patch bump on both packages.

## Test plan
- [x] `pnpm --filter @ifc-lite/cache test` (15/15 pass, includes 2 new)
- [x] `pnpm --filter @ifc-lite/export test` (102/102 pass, includes 1 new)
- [x] `pnpm --filter @ifc-lite/cache exec tsc --noEmit` clean
- [x] `pnpm --filter @ifc-lite/export exec tsc --noEmit` clean
- [x] `pnpm --filter @ifc-lite/viewer exec tsc --noEmit` clean
- [x] Manual: export an IFC with authored surface styles → GLB → re-import as a model → confirm meshes carry the original colours instead of going grey.

🤖 Generated with [Claude Code](https://claude.com/claude-code)