### PR TITLE
fix(extensions): align repository URLs with LTplus-AG/ifc-lite

### DIFF
--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -46,11 +46,11 @@
   "author": "Louis True",
   "repository": {
     "type": "git",
-    "url": "https://github.com/louistrue/ifc-lite.git",
+    "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/extensions"
   },
-  "homepage": "https://louistrue.github.io/ifc-lite/",
-  "bugs": "https://github.com/louistrue/ifc-lite/issues",
+  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",
     "bim",


### PR DESCRIPTION
## Summary

- `@ifc-lite/extensions@0.2.0` fails to publish on Release with `E422 Unprocessable Entity — Error verifying sigstore provenance bundle`.
- Root cause: `packages/extensions/package.json` still points at the pre-move owner (`louistrue/ifc-lite`), while the OIDC provenance bundle records the current repo (`LTplus-AG/ifc-lite`). npm rejects the mismatch.
- This package was added in #690 and never had its URLs refreshed after the org move; every other `@ifc-lite/*` package already uses the LTplus-AG URLs.

Updates `repository.url`, `homepage`, and `bugs` to match siblings (e.g. `packages/cache/package.json`).

## Test plan

- [x] CI green on this PR.
- [x] After merge, re-run the failed Release workflow (run [26419921342](https://github.com/LTplus-AG/ifc-lite/actions/runs/26419921342)) — `changesets/publish` should accept `@ifc-lite/extensions@0.2.0` and `verify-npm-publish` should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package repository metadata and associated URLs to reflect organizational changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LTplus-AG/ifc-lite/pull/814?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->