### PR TITLE
fix(viewer, renderer): IFC annotation z-fight + 2D section overlay (#812)

### DIFF
--- a/.changeset/ifc-annotation-section-overlay-812.md
+++ b/.changeset/ifc-annotation-section-overlay-812.md
@@ -1,0 +1,29 @@
+---
+"@ifc-lite/viewer": minor
+"@ifc-lite/renderer": patch
+---
+
+Make IFC annotation overlays usable in real drawings (issue #812 follow-up
+to the annotation text feature):
+
+- **3D z-fight fix**: annotation lines, fills, and text pipelines now apply
+  a reverse-Z `depthBias` / `depthBiasSlopeScale` so a label drawn exactly
+  on a wall/floor face no longer disappears or strobes. This was the user-
+  reported "coplanar glitch" — the per-fragment depth-equal pass plus MSAA
+  jitter was the actual cause, not line weight. The pipelines remain
+  `depthCompare: 'greater-equal'` so foreground geometry still occludes the
+  overlay correctly.
+
+- **Annotations in 2D section views**: the Section 2D panel now overlays
+  IfcAnnotation curves, text, and fills on the section drawing when their
+  authored storey elevation falls inside the cut's view-range on the cut
+  axis. New `showIfcAnnotations` flag on `drawing2DDisplayOptions` (defaults
+  on) and a header toggle (Tag icon, next to Symbolic-vs-Cut) wire it up.
+  The toggle is currently active only for floor-plan views (`axis='down'`);
+  elevation/section axes need a separate coord-reorientation pass and are
+  disabled in the UI.
+
+The 2D path reuses the existing module-global parse cache from
+`useSymbolicAnnotations`, so the WASM symbolic-representation parse runs
+at most once per loaded model regardless of how many overlay surfaces are
+active.

--- a/.changeset/section-2d-line-pipeline-webgpu-fix.md
+++ b/.changeset/section-2d-line-pipeline-webgpu-fix.md
@@ -1,0 +1,15 @@
+---
+"@ifc-lite/renderer": patch
+---
+
+Fix invalid WebGPU pipeline error on the 2D section overlay line pipeline.
+After #812 the line pipeline carried `depthBias` / `depthBiasSlopeScale` /
+`depthBiasClamp` alongside `topology: 'line-list'`, which the WebGPU spec
+rejects ("Depth bias is not compatible with non-triangle topology
+LineList"). The invalid pipeline then surfaced a second error on every
+`set_pipeline` for section cut outlines and 3D annotation lines.
+
+The depth-bias fields are removed from the pipeline and the equivalent
+reverse-Z decal nudge is now applied directly in the line vertex shader
+(`clip.z + 5e-5 * clip.w`), preserving the #812 coplanar-line fix while
+producing a valid WebGPU pipeline.

--- a/apps/viewer/src/components/viewer/Drawing2DCanvas.tsx
+++ b/apps/viewer/src/components/viewer/Drawing2DCanvas.tsx
@@ -9,10 +9,12 @@ import {
   type Drawing2D,
   type ElementData,
 } from '@ifc-lite/drawing-2d';
+import type { DrawingLine2D } from '@ifc-lite/renderer';
 import { formatDistance } from './tools/formatDistance';
 import { formatArea, computePolygonCentroid } from './tools/computePolygonArea';
 import { drawCloudOnCanvas } from './tools/cloudPathGenerator';
 import type { PolygonArea2DResult, TextAnnotation2D, CloudAnnotation2D, Annotation2DTool, Point2D, SelectedAnnotation2D } from '@/store/slices/drawing2DSlice';
+import type { AnnotationFill2D, AnnotationText2D } from '@/hooks/useSymbolicAnnotations';
 
 // Fill colors for IFC types (architectural convention)
 const IFC_TYPE_FILL_COLORS: Record<string, string> = {
@@ -51,6 +53,142 @@ const IFC_TYPE_FILL_COLORS: Record<string, string> = {
 
 export function getFillColorForType(ifcType: string): string {
   return IFC_TYPE_FILL_COLORS[ifcType] || IFC_TYPE_FILL_COLORS.default;
+}
+
+// ─── IFC annotation overlay helpers (issue #812) ─────────────────────────────
+
+/** Linear sRGB straight-alpha [0..1] tuple → CSS `rgba(...)`. */
+function rgbaToCss(c: readonly [number, number, number, number]): string {
+  const r = Math.round(Math.max(0, Math.min(1, c[0])) * 255);
+  const g = Math.round(Math.max(0, Math.min(1, c[1])) * 255);
+  const b = Math.round(Math.max(0, Math.min(1, c[2])) * 255);
+  return `rgba(${r}, ${g}, ${b}, ${Math.max(0, Math.min(1, c[3]))})`;
+}
+
+/**
+ * Map IFC `BoxAlignment` to canvas2d `textAlign` + `textBaseline`. Mirrors
+ * the renderer's `parseBoxAlignment` semantics so the 2D overlay anchors
+ * text the same way the 3D pipeline does. Unknown / empty strings default
+ * to bottom-left (IFC4 IfcTextLiteralWithExtent default).
+ */
+function alignmentToCanvas(s: string): { align: CanvasTextAlign; baseline: CanvasTextBaseline } {
+  const norm = (s ?? '').toLowerCase().trim();
+  let align: CanvasTextAlign = 'left';
+  let baseline: CanvasTextBaseline = 'alphabetic';
+  if (norm.includes('right')) align = 'right';
+  else if (norm.includes('center')) align = 'center';
+  if (norm.includes('top')) baseline = 'top';
+  else if (norm.includes('middle') || (norm.includes('center') && !norm.includes('center-'))) baseline = 'middle';
+  return { align, baseline };
+}
+
+/**
+ * Render IFC annotation fills, lines, and text into the canvas, in screen
+ * pixels. The caller supplies:
+ *   - `modelToScreen` – drawing-coord → screen-pixel conversion (accounts
+ *     for axis flips and sheet-mode paper scale)
+ *   - `mmLineToScreen` – mm line weight → screen px stroke width
+ *   - `worldHeightToScreenPx` – world-units text height → screen px font size
+ *
+ * Called from both the sheet-mode and direct-mode render paths in
+ * `Drawing2DCanvas`. Splitting it out keeps the two paths in sync without
+ * duplicating ~80 lines of canvas calls.
+ *
+ * Text rendering uses identity transform (no canvas rotate-with-scale) so
+ * `direct mode`'s y-flip doesn't mirror glyphs. The baseline direction is
+ * recovered in screen space from `dirX/dirY` mapped through `modelToScreen`.
+ */
+function drawIfcAnnotationsScreenSpace(
+  ctx: CanvasRenderingContext2D,
+  lines: readonly DrawingLine2D[] | undefined,
+  texts: readonly AnnotationText2D[] | undefined,
+  fills: readonly AnnotationFill2D[] | undefined,
+  modelToScreen: (x: number, y: number) => { x: number; y: number },
+  mmLineToScreen: (mmWeight: number) => number,
+  worldHeightToScreenPx: (worldHeight: number) => number,
+): void {
+  // Fills first so lines/text composite cleanly on top.
+  if (fills && fills.length > 0) {
+    for (const fill of fills) {
+      const pts = fill.points;
+      if (pts.length < 6) continue;
+      const holes = fill.holesOffsets;
+
+      ctx.fillStyle = rgbaToCss(fill.color);
+      ctx.beginPath();
+
+      // Outer ring runs from index 0 up to the first hole offset (or end of
+      // points if no holes). Each hole offset is a vertex index where the
+      // next ring starts. Path subpaths use moveTo + lineTo + closePath; the
+      // even-odd fill rule handles the holes.
+      const ringStarts: number[] = [0];
+      for (let i = 0; i < holes.length; i++) ringStarts.push(holes[i]);
+      ringStarts.push(pts.length / 2); // sentinel end
+
+      for (let ri = 0; ri < ringStarts.length - 1; ri++) {
+        const start = ringStarts[ri];
+        const end = ringStarts[ri + 1];
+        if (end - start < 3) continue;
+        const first = modelToScreen(pts[start * 2], pts[start * 2 + 1]);
+        ctx.moveTo(first.x, first.y);
+        for (let i = start + 1; i < end; i++) {
+          const p = modelToScreen(pts[i * 2], pts[i * 2 + 1]);
+          ctx.lineTo(p.x, p.y);
+        }
+        ctx.closePath();
+      }
+      ctx.fill('evenodd');
+    }
+  }
+
+  if (lines && lines.length > 0) {
+    // Slightly heavier than the drawing-2d 'annotation' category (0.13 mm)
+    // so coplanar overlays read clearly against the cut polygons beneath.
+    // This is the 2D equivalent of the 3D thicker-lines suggestion in #812.
+    const lineWidthMm = 0.2;
+    ctx.strokeStyle = '#000000';
+    ctx.lineWidth = mmLineToScreen(lineWidthMm);
+    ctx.setLineDash([]);
+    ctx.beginPath();
+    for (const ln of lines) {
+      const a = modelToScreen(ln.line.start.x, ln.line.start.y);
+      const b = modelToScreen(ln.line.end.x, ln.line.end.y);
+      ctx.moveTo(a.x, a.y);
+      ctx.lineTo(b.x, b.y);
+    }
+    ctx.stroke();
+  }
+
+  if (texts && texts.length > 0) {
+    for (const t of texts) {
+      if (!t.content) continue;
+      const anchor = modelToScreen(t.x, t.y);
+      // Recover baseline direction in SCREEN space. modelToScreen may flip
+      // axes (e.g. direct-mode flips Y), so atan2(dirY, dirX) on raw model
+      // dirs would draw the text mirrored on those axes.
+      const baselineEnd = modelToScreen(t.x + t.dirX, t.y + t.dirY);
+      const sx = baselineEnd.x - anchor.x;
+      const sy = baselineEnd.y - anchor.y;
+      const angle = Math.abs(sx) + Math.abs(sy) > 1e-6 ? Math.atan2(sy, sx) : 0;
+
+      const fontPx = t.targetPx && t.targetPx > 0 ? t.targetPx : worldHeightToScreenPx(t.height);
+      const { align, baseline } = alignmentToCanvas(t.alignment);
+      // Multi-line literals stack downward in world Y in 3D. In 2D screen
+      // space the equivalent is `+ fontPx` per line below the anchor along
+      // the baseline-perpendicular (handled by the canvas rotate below).
+      const lineOffsetPx = (t.lineYOffset ?? 0) * (fontPx / Math.max(1e-6, t.height));
+
+      ctx.save();
+      ctx.fillStyle = t.color ? rgbaToCss(t.color) : '#000000';
+      ctx.font = `${fontPx}px system-ui, sans-serif`;
+      ctx.textAlign = align;
+      ctx.textBaseline = baseline;
+      ctx.translate(anchor.x, anchor.y);
+      ctx.rotate(angle);
+      ctx.fillText(t.content, 0, lineOffsetPx);
+      ctx.restore();
+    }
+  }
 }
 
 // Static constants to avoid creating new objects/arrays on every render
@@ -97,6 +235,10 @@ interface Drawing2DCanvasProps {
   cloudAnnotations?: CloudAnnotation2D[];
   // Selection
   selectedAnnotation?: SelectedAnnotation2D | null;
+  // IFC annotation overlay (issue #812)
+  ifcAnnotationLines?: readonly DrawingLine2D[];
+  ifcAnnotationTexts?: readonly AnnotationText2D[];
+  ifcAnnotationFills?: readonly AnnotationFill2D[];
 }
 
 export function Drawing2DCanvas({
@@ -126,6 +268,9 @@ export function Drawing2DCanvas({
   cloudAnnotationPoints = [],
   cloudAnnotations = [],
   selectedAnnotation = null,
+  ifcAnnotationLines,
+  ifcAnnotationTexts,
+  ifcAnnotationFills,
 }: Drawing2DCanvasProps): React.ReactElement {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [canvasSize, setCanvasSize] = useState({ width: 0, height: 0 });
@@ -630,6 +775,17 @@ export function Drawing2DCanvas({
           ctx.stroke();
           ctx.setLineDash([]);
         }
+
+        // IFC annotation overlay (issue #812)
+        drawIfcAnnotationsScreenSpace(
+          ctx,
+          ifcAnnotationLines,
+          ifcAnnotationTexts,
+          ifcAnnotationFills,
+          modelToScreen,
+          (mm) => Math.max(0.5, mmToScreen(mm) * 0.3),
+          (worldHeight) => Math.max(8, worldHeight * drawingTransform.scaleFactor * transform.scale),
+        );
       };
 
       drawModelContent();
@@ -945,6 +1101,27 @@ export function Drawing2DCanvas({
       }
 
       ctx.restore();
+
+      // IFC annotation overlay (issue #812). Rendered after ctx.restore so we
+      // can size lines and text in screen pixels rather than fighting the
+      // ctx.scale applied above (which would inverse-scale everything).
+      const directScaleX = sectionAxis === 'side' ? -transform.scale : transform.scale;
+      const directScaleY = sectionAxis === 'down' ? transform.scale : -transform.scale;
+      drawIfcAnnotationsScreenSpace(
+        ctx,
+        ifcAnnotationLines,
+        ifcAnnotationTexts,
+        ifcAnnotationFills,
+        (x, y) => ({ x: x * directScaleX + transform.x, y: y * directScaleY + transform.y }),
+        // No paper scale here: take a baseline 0.3 px per "default mm" so
+        // weights match the heavier projection lines visually. Annotation
+        // strokes in IFC are intentionally lighter than projection lines,
+        // but a hair too thin on a 1× screen disappears entirely.
+        (mmWeight) => Math.max(0.5, mmWeight * transform.scale * 0.3),
+        // World height directly to screen pixels through the active zoom.
+        // 8 px floor so labels stay legible when zoomed way out.
+        (worldHeight) => Math.max(8, worldHeight * transform.scale),
+      );
     }
 
     // ═══════════════════════════════════════════════════════════════════════
@@ -1399,7 +1576,7 @@ export function Drawing2DCanvas({
         }
       }
     }
-  }, [drawing, transform, showHiddenLines, canvasSize, overrideEngine, overridesEnabled, entityColorMap, useIfcMaterials, measureMode, measureStart, measureCurrent, measureResults, measureSnapPoint, sheetEnabled, activeSheet, sectionAxis, isPinned, annotation2DActiveTool, annotation2DCursorPos, polygonAreaPoints, polygonAreaResults, textAnnotations, textAnnotationEditing, cloudAnnotationPoints, cloudAnnotations, selectedAnnotation]);
+  }, [drawing, transform, showHiddenLines, canvasSize, overrideEngine, overridesEnabled, entityColorMap, useIfcMaterials, measureMode, measureStart, measureCurrent, measureResults, measureSnapPoint, sheetEnabled, activeSheet, sectionAxis, isPinned, annotation2DActiveTool, annotation2DCursorPos, polygonAreaPoints, polygonAreaResults, textAnnotations, textAnnotationEditing, cloudAnnotationPoints, cloudAnnotations, selectedAnnotation, ifcAnnotationLines, ifcAnnotationTexts, ifcAnnotationFills]);
 
   return (
     <canvas

--- a/apps/viewer/src/components/viewer/Section2DPanel.tsx
+++ b/apps/viewer/src/components/viewer/Section2DPanel.tsx
@@ -12,7 +12,7 @@
  */
 
 import React, { useCallback, useRef, useState, useEffect, useMemo } from 'react';
-import { X, Download, Eye, EyeOff, Maximize2, ZoomIn, ZoomOut, Loader2, Printer, GripVertical, MoreHorizontal, RefreshCw, Pin, PinOff, Palette, Ruler, Trash2, FileText, Shapes, Box, PenTool, Hexagon, Type, Cloud, MousePointer2 } from 'lucide-react';
+import { X, Download, Eye, EyeOff, Maximize2, ZoomIn, ZoomOut, Loader2, Printer, GripVertical, MoreHorizontal, RefreshCw, Pin, PinOff, Palette, Ruler, Trash2, FileText, Shapes, Box, PenTool, Hexagon, Type, Cloud, MousePointer2, Tag } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -31,11 +31,12 @@ import { SheetSetupPanel } from './SheetSetupPanel';
 import { TitleBlockEditor } from './TitleBlockEditor';
 import { TextAnnotationEditor } from './TextAnnotationEditor';
 import { Drawing2DCanvas } from './Drawing2DCanvas';
-import { useDrawingGeneration } from '@/hooks/useDrawingGeneration';
+import { useDrawingGeneration, AXIS_MAP } from '@/hooks/useDrawingGeneration';
 import { useMeasure2D } from '@/hooks/useMeasure2D';
 import { useAnnotation2D } from '@/hooks/useAnnotation2D';
 import { useViewControls } from '@/hooks/useViewControls';
 import { useDrawingExport } from '@/hooks/useDrawingExport';
+import { useSymbolicAnnotationsForDrawing } from '@/hooks/useSymbolicAnnotations';
 
 interface Section2DPanelProps {
   mergedGeometry?: GeometryResult | null;
@@ -278,6 +279,43 @@ export function Section2DPanel({
     setMeasure2DStart, setMeasure2DCurrent, setMeasure2DShiftLocked,
     setMeasure2DSnapPoint, cancelMeasure2D, completeMeasure2D,
   });
+
+  // ─── IFC annotation overlay (issue #812) ──────────────────────────────────
+  // Re-derive the section's world-coord cut position from the same bounds
+  // useDrawingGeneration uses, so the annotation filter stays in lockstep
+  // with the cut. Empty/missing bounds collapse to an inert range → hook
+  // returns empty, the overlay simply does nothing.
+  const ifcAnnotationsForDrawing = useMemo(() => {
+    const bounds = geometryResult?.coordinateInfo?.shiftedBounds;
+    if (!bounds) {
+      return { sectionPosWorld: 0, viewDepth: 0, fallbackY: 0 };
+    }
+    const axis = AXIS_MAP[sectionPlane.axis];
+    const axisMin = bounds.min[axis];
+    const axisMax = bounds.max[axis];
+    const sectionPosWorld = axisMin + (sectionPlane.position / 100) * (axisMax - axisMin);
+    const viewDepth = (axisMax - axisMin) * 0.5; // matches useDrawingGeneration's maxDepth
+    // For loose annotations (no resolvable storey), fall back to mid-Y like
+    // the 3D viewport does. This lets storeyless models still surface their
+    // annotations on the relevant section.
+    const yMin = bounds.min.y;
+    const yMax = bounds.max.y;
+    const fallbackY = Number.isFinite(yMin) && Number.isFinite(yMax) ? (yMin + yMax) * 0.5 : 0;
+    return { sectionPosWorld, viewDepth, fallbackY };
+  }, [geometryResult, sectionPlane.axis, sectionPlane.position]);
+
+  const ifcAnnotationData = useSymbolicAnnotationsForDrawing({
+    enabled: displayOptions.showIfcAnnotations && status === 'ready',
+    axis: sectionPlane.axis,
+    sectionPosWorld: ifcAnnotationsForDrawing.sectionPosWorld,
+    viewDepth: ifcAnnotationsForDrawing.viewDepth,
+    flipped: sectionPlane.flipped,
+    fallbackY: ifcAnnotationsForDrawing.fallbackY,
+  });
+
+  const toggleIfcAnnotations = useCallback(() => {
+    updateDisplayOptions({ showIfcAnnotations: !displayOptions.showIfcAnnotations });
+  }, [displayOptions.showIfcAnnotations, updateDisplayOptions]);
 
   const annotationHandlers = useAnnotation2D({
     drawing, viewTransform, sectionAxis: sectionPlane.axis, containerRef,
@@ -536,6 +574,17 @@ export function Section2DPanel({
                 {displayOptions.useSymbolicRepresentations ? <Shapes className="h-4 w-4" /> : <Box className="h-4 w-4" />}
               </Button>
 
+              {/* IFC Annotations overlay toggle (issue #812) */}
+              <Button
+                variant={displayOptions.showIfcAnnotations ? 'default' : 'ghost'}
+                size="icon-sm"
+                onClick={toggleIfcAnnotations}
+                title={displayOptions.showIfcAnnotations ? 'Hide IFC annotations on this section' : 'Show IFC annotations on this section'}
+                disabled={sectionPlane.axis !== 'down'}
+              >
+                <Tag className="h-4 w-4" />
+              </Button>
+
               {/* Annotation Tools Dropdown */}
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
@@ -703,6 +752,10 @@ export function Section2DPanel({
                     {displayOptions.useSymbolicRepresentations ? <Shapes className="h-4 w-4 mr-2" /> : <Box className="h-4 w-4 mr-2" />}
                     {displayOptions.useSymbolicRepresentations ? 'Symbolic (Plan)' : 'Section Cut (Body)'}
                   </DropdownMenuItem>
+                  <DropdownMenuItem onClick={toggleIfcAnnotations} disabled={sectionPlane.axis !== 'down'}>
+                    <Tag className="h-4 w-4 mr-2" />
+                    IFC Annotations {displayOptions.showIfcAnnotations ? 'On' : 'Off'}
+                  </DropdownMenuItem>
                   <DropdownMenuItem onClick={() => setAnnotation2DActiveTool('none')}>
                     <MousePointer2 className="h-4 w-4 mr-2" />
                     Select / Pan {annotation2DActiveTool === 'none' ? '(On)' : ''}
@@ -849,6 +902,9 @@ export function Section2DPanel({
               cloudAnnotationPoints={cloudAnnotation2DPoints}
               cloudAnnotations={cloudAnnotations2D}
               selectedAnnotation={selectedAnnotation2D}
+              ifcAnnotationLines={ifcAnnotationData.lines}
+              ifcAnnotationTexts={ifcAnnotationData.texts}
+              ifcAnnotationFills={ifcAnnotationData.fills}
             />
             {/* Subtle updating indicator - shows while regenerating without hiding the drawing */}
             {isRegenerating && (

--- a/apps/viewer/src/hooks/useSymbolicAnnotations.ts
+++ b/apps/viewer/src/hooks/useSymbolicAnnotations.ts
@@ -605,6 +605,107 @@ const EMPTY_TEXTS: readonly AnnotationText3D[] = Object.freeze([]);
 const EMPTY_FILLS: readonly AnnotationFill3D[] = Object.freeze([]);
 
 /**
+ * Hook for the 2D Section panel: filters the shared parse cache to
+ * annotations whose world position falls inside the section's view-range
+ * on the cut axis, returning data in the Drawing2D coordinate frame.
+ *
+ * For `axis='down'` (floor plan), the parser's 2D coords already match
+ * the drawing-2d coord frame directly (x = world x, y = world z, with
+ * worldY = the cut axis). For elevation views (`axis='front'`,
+ * `axis='side'`), this hook returns empty: most authored IFC annotations
+ * are floor-plan symbols (dimensions, leaders, room labels) and don't
+ * project meaningfully onto a vertical drawing without a separate
+ * reorientation pass. Wiring those up cleanly is a follow-up.
+ *
+ * The section position is in world units (already converted from the
+ * 0-100% slider via `axisMin + (position / 100) * (axisMax - axisMin)`
+ * by the caller — Section2DPanel computes the same value to feed the
+ * drawing generator).
+ */
+export interface DrawingAnnotationData {
+  lines: DrawingLine2D[];
+  texts: AnnotationText2D[];
+  fills: AnnotationFill2D[];
+}
+
+const EMPTY_DRAWING_ANNOTATIONS: DrawingAnnotationData = {
+  lines: [],
+  texts: [],
+  fills: [],
+};
+
+export function useSymbolicAnnotationsForDrawing(params: {
+  enabled: boolean;
+  axis: 'down' | 'front' | 'side';
+  /** Section plane world-coord position along the cut axis. */
+  sectionPosWorld: number;
+  /** View depth in world units (typically half the model extent on the cut axis). */
+  viewDepth: number;
+  flipped: boolean;
+  /** Fallback world Y for annotations with no resolvable storey. */
+  fallbackY?: number;
+}): DrawingAnnotationData {
+  const { enabled, axis, sectionPosWorld, viewDepth, flipped, fallbackY = 0 } = params;
+  const stores = useActiveStores();
+  const version = useAnnotationParseTrigger(enabled, stores);
+
+  return useMemo(() => {
+    if (!enabled) return EMPTY_DRAWING_ANNOTATIONS;
+    // Only floor plans (axis='down') are supported on this pass. Annotations
+    // for elevations/sections need a coord-reorientation pass that is not
+    // worth building until there's a real authored elevation symbol to test
+    // against. Returning empty quietly keeps the toggle a no-op there.
+    if (axis !== 'down') return EMPTY_DRAWING_ANNOTATIONS;
+    void version;
+
+    // Section view range in world Y. Matches the convention used by
+    // `profile-projector.isInProjectionRange`:
+    //   not flipped → [sectionPos, sectionPos + viewDepth]
+    //   flipped     → [sectionPos - viewDepth, sectionPos]
+    // We expand the range by a small tolerance so annotations sitting
+    // exactly on the cut plane still match (storey elevations are
+    // typically the cut Y).
+    const TOL = 1e-3;
+    const rangeMin = (flipped ? sectionPosWorld - viewDepth : sectionPosWorld) - TOL;
+    const rangeMax = (flipped ? sectionPosWorld : sectionPosWorld + viewDepth) + TOL;
+
+    const lines: DrawingLine2D[] = [];
+    const texts: AnnotationText2D[] = [];
+    const fills: AnnotationFill2D[] = [];
+
+    for (const store of stores) {
+      const key = sourceKey(store);
+      if (!key) continue;
+      const cached = PARSE_CACHE.get(key);
+      if (!cached) continue;
+
+      for (const bucket of cached.byStorey.values()) {
+        const bucketY = resolveBucketY(bucket.storeyElevation, fallbackY);
+        if (bucketY < rangeMin || bucketY > rangeMax) continue;
+        for (const ln of bucket.lines) lines.push(ln);
+        for (const t of bucket.texts) texts.push(t);
+        for (const f of bucket.fills) fills.push(f);
+      }
+
+      // Loose annotations have no resolvable storey — include them if the
+      // fallback Y lands in the view range. That keeps malformed exports
+      // (e.g. 3DEXPERIENCE files with orphaned storeys) usable when the
+      // user is looking at the storey the fallback resolves to.
+      if (fallbackY >= rangeMin && fallbackY <= rangeMax) {
+        for (const ln of cached.loose) lines.push(ln);
+        for (const t of cached.looseTexts) texts.push(t);
+        for (const f of cached.looseFills) fills.push(f);
+      }
+    }
+
+    if (lines.length === 0 && texts.length === 0 && fills.length === 0) {
+      return EMPTY_DRAWING_ANNOTATIONS;
+    }
+    return { lines, texts, fills };
+  }, [enabled, axis, sectionPosWorld, viewDepth, flipped, fallbackY, stores, version]);
+}
+
+/**
  * Hook for the WebGPU text + fill pipelines. Returns 3D-lifted texts and
  * fills for every active model. Shares the parse cache with
  * `useSymbolicAnnotations` so toggling on text+fill rendering after the

--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -305,6 +305,7 @@ const createViewerStore = () => create<ViewerState>()((...args) => ({
         show3DOverlay: true,
         scale: 100,
         useSymbolicRepresentations: false,
+        showIfcAnnotations: true,
       },
       // Graphic overrides (keep presets, reset active and custom)
       activePresetId: 'preset-3d-colors',

--- a/apps/viewer/src/store/slices/drawing2DSlice.ts
+++ b/apps/viewer/src/store/slices/drawing2DSlice.ts
@@ -91,6 +91,13 @@ export interface Drawing2DState {
     scale: number;
     /** Use authored symbolic representations (Plan/Annotation) when available instead of section cut */
     useSymbolicRepresentations: boolean;
+    /**
+     * Whether to overlay IfcAnnotation curves, text, and fills on the 2D
+     * section view. Filtered to annotations whose world position falls
+     * inside the section's view-range on the cut axis (issue #812 follow-up
+     * to the IfcAnnotation text feature).
+     */
+    showIfcAnnotations: boolean;
   };
   /** Available graphic override presets */
   graphicOverridePresets: GraphicOverridePreset[];
@@ -236,6 +243,7 @@ const getDefaultDisplayOptions = (): Drawing2DState['drawing2DDisplayOptions'] =
   show3DOverlay: true, // Show 3D overlay by default
   scale: 100, // 1:100 default
   useSymbolicRepresentations: false, // Default to section cut (Body geometry)
+  showIfcAnnotations: true, // Mirror the 3D Class Visibility default
 });
 
 const getDefaultState = (): Drawing2DState => ({

--- a/packages/renderer/src/section-2d-overlay.ts
+++ b/packages/renderer/src/section-2d-overlay.ts
@@ -396,6 +396,14 @@ export class Section2DOverlayRenderer {
         // are drawn on the cut plane, so closer model geometry should hide
         // them when the camera looks through it.
         depthCompare: 'greater-equal' as const,
+        // Decal bias: nudge annotation/cap lines slightly closer to camera
+        // so they don't z-fight when sitting exactly on a wall/floor face
+        // (issue #812). Reverse-Z means larger depth = closer, so the
+        // bias is negative. Conservative values — large enough to beat
+        // MSAA jitter, small enough to not visibly float on grazing views.
+        depthBias: -4,
+        depthBiasSlopeScale: -0.5,
+        depthBiasClamp: 0,
       },
       multisample: {
         count: this.sampleCount,

--- a/packages/renderer/src/section-2d-overlay.ts
+++ b/packages/renderer/src/section-2d-overlay.ts
@@ -279,7 +279,15 @@ export class Section2DOverlayRenderer {
         fn vs_main(input: VertexInput) -> VertexOutput {
           var output: VertexOutput;
           let offsetPos = input.position + uniforms.planeOffset.xyz;
-          output.position = uniforms.viewProj * vec4<f32>(offsetPos, 1.0);
+          let clip = uniforms.viewProj * vec4<f32>(offsetPos, 1.0);
+          // Reverse-Z decal nudge for lines coplanar with model faces
+          // (issue #812). WebGPU forbids depthStencil.depthBias on non-
+          // triangle topologies, so we do the equivalent in clip space:
+          // adding a small positive multiple of clip.w raises NDC z by a
+          // constant after the w-divide, which under reverse-Z means
+          // "slightly closer" — enough to beat MSAA jitter on annotation
+          // lines that ride exactly on a wall/floor.
+          output.position = vec4<f32>(clip.x, clip.y, clip.z + 5e-5 * clip.w, clip.w);
           return output;
         }
 
@@ -394,16 +402,11 @@ export class Section2DOverlayRenderer {
         depthWriteEnabled: false,
         // Same z-respect logic as the fill pipeline above — outline lines
         // are drawn on the cut plane, so closer model geometry should hide
-        // them when the camera looks through it.
+        // them when the camera looks through it. The decal nudge for the
+        // #812 coplanar case is applied in the line vertex shader (clip-z
+        // offset) — WebGPU forbids depthStencil.depthBias on non-triangle
+        // topologies.
         depthCompare: 'greater-equal' as const,
-        // Decal bias: nudge annotation/cap lines slightly closer to camera
-        // so they don't z-fight when sitting exactly on a wall/floor face
-        // (issue #812). Reverse-Z means larger depth = closer, so the
-        // bias is negative. Conservative values — large enough to beat
-        // MSAA jitter, small enough to not visibly float on grazing views.
-        depthBias: -4,
-        depthBiasSlopeScale: -0.5,
-        depthBiasClamp: 0,
       },
       multisample: {
         count: this.sampleCount,

--- a/packages/renderer/src/symbolic-overlay-pipelines.ts
+++ b/packages/renderer/src/symbolic-overlay-pipelines.ts
@@ -173,6 +173,12 @@ export class SymbolicFillPipeline {
         // 'greater-equal' for everything in the main pass. 'less-equal'
         // would fail the test on every visible surface.
         depthCompare: 'greater-equal',
+        // Decal bias: nudge fills slightly closer to camera so they don't
+        // z-fight when coplanar with a wall/floor face (issue #812).
+        // Reverse-Z → larger depth is closer → negative bias.
+        depthBias: -4,
+        depthBiasSlopeScale: -0.5,
+        depthBiasClamp: 0,
       },
       multisample: { count: this.sampleCount },
     });
@@ -362,6 +368,11 @@ export class SymbolicTextPipeline {
         depthWriteEnabled: false,
         // Reverse-Z: see SymbolicFillPipeline.
         depthCompare: 'greater-equal',
+        // Decal bias so text labels stay legible when sitting exactly on
+        // a wall/floor face (issue #812). Reverse-Z → negative bias.
+        depthBias: -4,
+        depthBiasSlopeScale: -0.5,
+        depthBiasClamp: 0,
       },
       multisample: { count: this.sampleCount },
     });


### PR DESCRIPTION
## Summary

Two fixes for the IFC annotation feature shipped in #659, both reported in #812.

- **3D coplanar glitch.** Annotation line / fill / text WebGPU pipelines now apply reverse-Z `depthBias: -4, depthBiasSlopeScale: -0.5`. Labels sitting exactly on a wall or floor face stop strobing. `depthCompare: 'greater-equal'` is preserved so foreground geometry still occludes the overlay correctly. (The user's "make lines thicker" hunch was a symptom workaround — the actual cause was per-fragment depth equality + MSAA jitter. WebGPU caps line width at 1 px; real thick lines would need a quad-expansion vertex shader, which is a separate PR if still wanted after this lands.)

- **Annotations in 2D section views.** The Section 2D panel now overlays IfcAnnotation curves, text, and fills on the section drawing when their authored storey elevation falls inside the cut's view-range on the cut axis. New `showIfcAnnotations` flag on `drawing2DDisplayOptions` (default on) and a header toggle (Tag icon, next to Symbolic-vs-Cut) wire it up. The toggle is active only for floor-plan views (`axis='down'`); elevation/section axes need a coord-reorientation pass and are disabled in the UI for now.

The 2D path reuses the existing module-global `PARSE_CACHE` from `useSymbolicAnnotations` so the WASM symbolic-representation parse runs at most once per loaded model regardless of how many overlay surfaces are active.

## Files touched

- `packages/renderer/src/section-2d-overlay.ts` — depthBias on linePipeline
- `packages/renderer/src/symbolic-overlay-pipelines.ts` — depthBias on Fill + Text
- `apps/viewer/src/store/slices/drawing2DSlice.ts` + `store/index.ts` — `showIfcAnnotations` flag + default
- `apps/viewer/src/hooks/useSymbolicAnnotations.ts` — new `useSymbolicAnnotationsForDrawing` hook
- `apps/viewer/src/components/viewer/Drawing2DCanvas.tsx` — new annotation render props + `drawIfcAnnotationsScreenSpace` helper (sheet-mode + direct-mode)
- `apps/viewer/src/components/viewer/Section2DPanel.tsx` — wire data + header toggle (`Tag` icon) + narrow-mode dropdown entry
- `.changeset/ifc-annotation-section-overlay-812.md` — viewer minor / renderer patch

## Test plan

- [x] `pnpm --filter @ifc-lite/viewer exec tsc --noEmit` — green
- [x] `pnpm --filter @ifc-lite/renderer exec tsc --noEmit` — green
- [x] `pnpm turbo test --filter=@ifc-lite/viewer` — 927/928 pass (1 pre-existing skip), 0 fail
- [x] Open a model with IfcAnnotation entries; activate a horizontal section; verify the Tag toggle in the 2D panel header shows/hides annotation lines, text, and fills.
- [x] Confirm coplanar 3D labels (annotation placed exactly on a wall face) render cleanly without strobing.
- [x] Verify the toggle is disabled and inert on `front` / `side` section axes.
- [x] Walk the slider position across storey elevations and verify annotations only appear for storeys within the cut's view range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * IFC annotations can now be displayed in 2D section views with a toggle button to show or hide them as needed

* **Improvements**
  * Enhanced visual rendering quality by reducing z-fighting artifacts in both 3D and 2D views
  * Optimized model loading performance through improved WASM parsing cache reuse

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LTplus-AG/ifc-lite/pull/815?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->