### PR TITLE
test(renderer): cover pole-safe preset orbit behavior

### DIFF
--- a/packages/renderer/src/camera-controls.test.ts
+++ b/packages/renderer/src/camera-controls.test.ts
@@ -21,6 +21,10 @@ function len(v: Vec3): number {
   return Math.sqrt(v.x * v.x + v.y * v.y + v.z * v.z);
 }
 
+function clampUnit(value: number): number {
+  return Math.max(-1, Math.min(1, value));
+}
+
 function sub(a: Vec3, b: Vec3): Vec3 {
   return vec3(a.x - b.x, a.y - b.y, a.z - b.z);
 }
@@ -238,7 +242,7 @@ describe('CameraControls – external pivot orbit', () => {
     for (let i = 0; i < 80; i++) controls.orbit(0, -100);
     const pivot = vec3(5, 5, 15);
     const dir = sub(state.camera.position, pivot);
-    const phi = Math.acos(dir.y / len(dir));
+    const phi = Math.acos(clampUnit(dir.y / len(dir)));
     assert.ok(
       phi >= CC.MIN_PHI - 1e-4 && phi <= CC.MAX_PHI + 1e-4,
       `phi must stay clamped (got ${phi}, range [${CC.MIN_PHI}, ${CC.MAX_PHI}])`,
@@ -342,12 +346,12 @@ describe('CameraControls – orbit from preset top view', () => {
 
   it('drag-up at top view tilts camera smoothly toward the horizon', () => {
     const { state, controls } = setupTopPreset();
-    const phiBefore = Math.acos(state.camera.position.y / len(state.camera.position));
+    const phiBefore = Math.acos(clampUnit(state.camera.position.y / len(state.camera.position)));
 
     // Drag-up: deltaY < 0 → dy > 0 → phi increases toward MAX_PHI.
     controls.orbit(0, -50);
 
-    const phiAfter = Math.acos(state.camera.position.y / len(state.camera.position));
+    const phiAfter = Math.acos(clampUnit(state.camera.position.y / len(state.camera.position)));
     assert.ok(
       phiAfter > phiBefore,
       `phi should increase on drag-up (before=${phiBefore}, after=${phiAfter})`,
@@ -359,7 +363,7 @@ describe('CameraControls – orbit from preset top view', () => {
   it('repeated drag-up stops at the lower pole clamp (does not flip)', () => {
     const { state, controls } = setupTopPreset();
     for (let i = 0; i < 80; i++) controls.orbit(0, -100);
-    const phi = Math.acos(state.camera.position.y / len(state.camera.position));
+    const phi = Math.acos(clampUnit(state.camera.position.y / len(state.camera.position)));
     assert.ok(
       phi <= CC.MAX_PHI + 1e-4,
       `phi must be clamped at MAX_PHI (got ${phi}, max ${CC.MAX_PHI})`,

--- a/packages/renderer/src/camera-preset-orbit.test.ts
+++ b/packages/renderer/src/camera-preset-orbit.test.ts
@@ -1,0 +1,115 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { Camera } from './camera.ts';
+import { CAMERA_CONSTANTS as CC } from './constants.ts';
+import type { Vec3 } from './types.ts';
+
+type PresetView = 'top' | 'bottom' | 'front' | 'back' | 'left' | 'right';
+
+function len(v: Vec3): number {
+  return Math.sqrt(v.x * v.x + v.y * v.y + v.z * v.z);
+}
+
+function clampUnit(value: number): number {
+  return Math.max(-1, Math.min(1, value));
+}
+
+function phiFromCamera(camera: Camera): number {
+  const position = camera.getPosition();
+  const target = camera.getTarget();
+  const dir = {
+    x: position.x - target.x,
+    y: position.y - target.y,
+    z: position.z - target.z,
+  };
+  return Math.acos(clampUnit(dir.y / len(dir)));
+}
+
+function approxEqual(actual: number, expected: number, epsilon = 1e-6): void {
+  assert.ok(
+    Math.abs(actual - expected) <= epsilon,
+    `expected ${actual} ~= ${expected} (diff ${Math.abs(actual - expected)})`,
+  );
+}
+
+function finishPreset(camera: Camera, view: PresetView): void {
+  const originalNow = Date.now;
+  const hadRequestAnimationFrame = Object.prototype.hasOwnProperty.call(globalThis, 'requestAnimationFrame');
+  const originalRequestAnimationFrame = Reflect.get(globalThis, 'requestAnimationFrame');
+  let now = 1_000;
+
+  Date.now = () => now;
+  Reflect.set(globalThis, 'requestAnimationFrame', () => 0);
+
+  try {
+    camera.setPresetView(view);
+    now += 400;
+    camera.update(0);
+  } finally {
+    Date.now = originalNow;
+    if (hadRequestAnimationFrame) {
+      Reflect.set(globalThis, 'requestAnimationFrame', originalRequestAnimationFrame);
+    } else {
+      Reflect.deleteProperty(globalThis, 'requestAnimationFrame');
+    }
+  }
+}
+
+describe('Camera preset orbit behavior', () => {
+  it('top preset starts on MIN_PHI with world Y-up and no first-orbit phi snap', () => {
+    const camera = new Camera();
+    finishPreset(camera, 'top');
+
+    approxEqual(phiFromCamera(camera), CC.MIN_PHI, 1e-6);
+    approxEqual(camera.getUp().x, 0);
+    approxEqual(camera.getUp().y, 1);
+    approxEqual(camera.getUp().z, 0);
+
+    const beforePhi = phiFromCamera(camera);
+    camera.orbit(100, 0);
+    approxEqual(phiFromCamera(camera), beforePhi, 1e-6);
+  });
+
+  it('top preset ignores off-axis click pivot while near pole to prevent sideways drift', () => {
+    const camera = new Camera();
+    finishPreset(camera, 'top');
+    camera.setOrbitCenter({ x: 25, y: 0, z: -15 });
+
+    camera.orbit(0, -50);
+
+    approxEqual(camera.getPosition().x, 0, 1e-6);
+  });
+
+  it('bottom preset starts on MAX_PHI and does not snap on first horizontal orbit', () => {
+    const camera = new Camera();
+    finishPreset(camera, 'bottom');
+
+    approxEqual(phiFromCamera(camera), CC.MAX_PHI, 1e-6);
+    approxEqual(camera.getUp().x, 0);
+    approxEqual(camera.getUp().y, 1);
+    approxEqual(camera.getUp().z, 0);
+
+    const beforePhi = phiFromCamera(camera);
+    camera.orbit(100, 0);
+    approxEqual(phiFromCamera(camera), beforePhi, 1e-6);
+  });
+
+  it('side presets start at the horizon and do not lift on first horizontal orbit', () => {
+    const sideViews: Array<'front' | 'back' | 'left' | 'right'> = ['front', 'back', 'left', 'right'];
+
+    for (const view of sideViews) {
+      const camera = new Camera();
+      finishPreset(camera, view);
+      const beforePhi = phiFromCamera(camera);
+      approxEqual(beforePhi, Math.PI / 2, 1e-6);
+
+      camera.orbit(100, 0);
+      approxEqual(phiFromCamera(camera), beforePhi, 1e-6);
+    }
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add preset-level renderer tests for top, bottom, and side camera views to verify the pole-safe orbit goals from #813.
- Assert top-view off-axis orbit pivots do not cause sideways drift while near the pole.
- Clamp `Math.acos` test inputs in existing orbit assertions to avoid NaN from tiny floating-point overshoot.

### Testing
- `pnpm install`
- `pnpm exec tsx --test packages/renderer/src/camera-controls.test.ts packages/renderer/src/camera-preset-orbit.test.ts`
- `pnpm --filter @ifc-lite/data build && pnpm --filter @ifc-lite/wasm build && pnpm --filter @ifc-lite/wasm-threaded build && pnpm --filter @ifc-lite/geometry build && pnpm --filter @ifc-lite/spatial build && pnpm --filter @ifc-lite/renderer exec tsc --noEmit`
- `pnpm --filter @ifc-lite/renderer build`

### Notes
- Root viewer manual testing on the PR preview could not run in this VM because Chrome reported WebGPU unavailable. The `/mcp/playground` fallback rendered, but it uses separate Three.js controls, so it was not used as evidence for the renderer camera implementation.
- Generated WASM/package metadata created during validation was discarded before commit.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abbef8c7-61c2-4f24-9397-2e35e16ead56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abbef8c7-61c2-4f24-9397-2e35e16ead56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

