### PR TITLE
Fix WebGPU pipeline error in 2D section line overlay

### DIFF
--- a/.changeset/section-2d-line-pipeline-webgpu-fix.md
+++ b/.changeset/section-2d-line-pipeline-webgpu-fix.md
@@ -1,0 +1,15 @@
+---
+"@ifc-lite/renderer": patch
+---
+
+Fix invalid WebGPU pipeline error on the 2D section overlay line pipeline.
+After #812 the line pipeline carried `depthBias` / `depthBiasSlopeScale` /
+`depthBiasClamp` alongside `topology: 'line-list'`, which the WebGPU spec
+rejects ("Depth bias is not compatible with non-triangle topology
+LineList"). The invalid pipeline then surfaced a second error on every
+`set_pipeline` for section cut outlines and 3D annotation lines.
+
+The depth-bias fields are removed from the pipeline and the equivalent
+reverse-Z decal nudge is now applied directly in the line vertex shader
+(`clip.z + 5e-5 * clip.w`), preserving the #812 coplanar-line fix while
+producing a valid WebGPU pipeline.

--- a/packages/renderer/src/section-2d-overlay.ts
+++ b/packages/renderer/src/section-2d-overlay.ts
@@ -279,7 +279,15 @@ export class Section2DOverlayRenderer {
         fn vs_main(input: VertexInput) -> VertexOutput {
           var output: VertexOutput;
           let offsetPos = input.position + uniforms.planeOffset.xyz;
-          output.position = uniforms.viewProj * vec4<f32>(offsetPos, 1.0);
+          let clip = uniforms.viewProj * vec4<f32>(offsetPos, 1.0);
+          // Reverse-Z decal nudge for lines coplanar with model faces
+          // (issue #812). WebGPU forbids depthStencil.depthBias on non-
+          // triangle topologies, so we do the equivalent in clip space:
+          // adding a small positive multiple of clip.w raises NDC z by a
+          // constant after the w-divide, which under reverse-Z means
+          // "slightly closer" — enough to beat MSAA jitter on annotation
+          // lines that ride exactly on a wall/floor.
+          output.position = vec4<f32>(clip.x, clip.y, clip.z + 5e-5 * clip.w, clip.w);
           return output;
         }
 
@@ -394,16 +402,11 @@ export class Section2DOverlayRenderer {
         depthWriteEnabled: false,
         // Same z-respect logic as the fill pipeline above — outline lines
         // are drawn on the cut plane, so closer model geometry should hide
-        // them when the camera looks through it.
+        // them when the camera looks through it. The decal nudge for the
+        // #812 coplanar case is applied in the line vertex shader (clip-z
+        // offset) — WebGPU forbids depthStencil.depthBias on non-triangle
+        // topologies.
         depthCompare: 'greater-equal' as const,
-        // Decal bias: nudge annotation/cap lines slightly closer to camera
-        // so they don't z-fight when sitting exactly on a wall/floor face
-        // (issue #812). Reverse-Z means larger depth = closer, so the
-        // bias is negative. Conservative values — large enough to beat
-        // MSAA jitter, small enough to not visibly float on grazing views.
-        depthBias: -4,
-        depthBiasSlopeScale: -0.5,
-        depthBiasClamp: 0,
       },
       multisample: {
         count: this.sampleCount,


### PR DESCRIPTION
## Summary
Fixes an invalid WebGPU pipeline configuration in the 2D section overlay line renderer. The pipeline was carrying depth bias settings (`depthBias`, `depthBiasSlopeScale`, `depthBiasClamp`) alongside `topology: 'line-list'`, which violates the WebGPU spec that forbids depth bias on non-triangle topologies.

## Changes
- **Removed invalid depth bias fields** from the line pipeline's depthStencil configuration
- **Moved depth bias logic to vertex shader**: The reverse-Z decal nudge (from #812) is now applied directly in clip space via `clip.z + 5e-5 * clip.w`, which achieves the same z-fighting prevention without requiring pipeline-level depth bias
- **Updated comments** to explain the new approach and why it was necessary

## Implementation Details
The depth bias was originally added to prevent z-fighting on annotation and cap lines that sit exactly on wall/floor faces. Since WebGPU forbids `depthBias` on line topologies, the equivalent effect is achieved by nudging the clip-space z-coordinate in the vertex shader. Adding a small positive multiple of `clip.w` raises the NDC z-value after the perspective divide, which under reverse-Z semantics means "slightly closer to camera" — sufficient to beat MSAA jitter while remaining invisible on grazing views.

This preserves the fix from #812 while producing a valid WebGPU pipeline.

https://claude.ai/code/session_01BKuN3uDzEkUh3DrPKagnRN