### PR TITLE
fix(2d-section): cull IFC annotations behind the section cut plane

### DIFF
--- a/apps/viewer/src/components/viewer/Section2DPanel.tsx
+++ b/apps/viewer/src/components/viewer/Section2DPanel.tsx
@@ -31,7 +31,7 @@ import { SheetSetupPanel } from './SheetSetupPanel';
 import { TitleBlockEditor } from './TitleBlockEditor';
 import { TextAnnotationEditor } from './TextAnnotationEditor';
 import { Drawing2DCanvas } from './Drawing2DCanvas';
-import { useDrawingGeneration, AXIS_MAP } from '@/hooks/useDrawingGeneration';
+import { useDrawingGeneration, AXIS_MAP, ANNOTATION_VIEW_DEPTH } from '@/hooks/useDrawingGeneration';
 import { useMeasure2D } from '@/hooks/useMeasure2D';
 import { useAnnotation2D } from '@/hooks/useAnnotation2D';
 import { useViewControls } from '@/hooks/useViewControls';
@@ -294,7 +294,11 @@ export function Section2DPanel({
     const axisMin = bounds.min[axis];
     const axisMax = bounds.max[axis];
     const sectionPosWorld = axisMin + (sectionPlane.position / 100) * (axisMax - axisMin);
-    const viewDepth = (axisMax - axisMin) * 0.5; // matches useDrawingGeneration's maxDepth
+    // IFC annotations get a tight 1.2 m view-depth slab — typical plan-view
+    // convention so dimension chains from the next storey don't stack onto
+    // the cut floor. The body cutter still uses half-extent for its own
+    // projection edges; the slab is annotation-specific.
+    const viewDepth = ANNOTATION_VIEW_DEPTH;
     // For loose annotations (no resolvable storey), fall back to mid-Y like
     // the 3D viewport does. This lets storeyless models still surface their
     // annotations on the relevant section.

--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -41,7 +41,6 @@ import { usePointCloudSync } from './usePointCloudSync.js';
 import { usePointCloudLifecycle } from './usePointCloudLifecycle.js';
 import { useRenderUpdates } from './useRenderUpdates.js';
 import { useSymbolicAnnotations, useSymbolicAnnotationsRichData } from '../../hooks/useSymbolicAnnotations.js';
-import { ANNOTATION_VIEW_DEPTH } from '@/hooks/useDrawingGeneration';
 
 interface ViewportProps {
   geometry: MeshData[] | null;
@@ -800,35 +799,13 @@ export function Viewport({
     if (!Number.isFinite(min) || !Number.isFinite(max) || max <= min) return 0;
     return (min + max) * 0.5;
   }, [coordinateInfo]);
-  // When the section tool is active on a horizontal cut, restrict the 3D
-  // annotation overlay to the same 1.2 m slab the 2D Section panel uses
-  // (see `ANNOTATION_VIEW_DEPTH`). Without this, dimensions from every
-  // storey float through the viewport regardless of where the cut sits,
-  // which is what the user reported as "still showing them from ABOVE
-  // camera". The filter no-ops for non-`down` axes and when the cut is
-  // disabled, preserving the toggle's existing "show all" behaviour.
-  const annotation3DSectionFilter = useMemo(() => {
-    if (!sectionPlane.enabled) return undefined;
-    if (sectionPlane.axis !== 'down') return undefined;
-    if (!sectionRange) return undefined;
-    const sectionPosWorld = sectionRange.min + (sectionPlane.position / 100) * (sectionRange.max - sectionRange.min);
-    return {
-      axis: sectionPlane.axis,
-      sectionPosWorld,
-      viewDepth: ANNOTATION_VIEW_DEPTH,
-      flipped: sectionPlane.flipped,
-    } as const;
-  }, [sectionPlane.enabled, sectionPlane.axis, sectionPlane.position, sectionPlane.flipped, sectionRange]);
-
   const annotationVertices3D = useSymbolicAnnotations({
     enabled: ifcAnnotationsVisible,
     fallbackY: annotationFallbackY,
-    sectionFilter: annotation3DSectionFilter,
   });
   const { texts: annotationTexts3D, fills: annotationFills3D } = useSymbolicAnnotationsRichData({
     enabled: ifcAnnotationsVisible,
     fallbackY: annotationFallbackY,
-    sectionFilter: annotation3DSectionFilter,
   });
   useEffect(() => {
     const renderer = rendererRef.current;

--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -41,6 +41,7 @@ import { usePointCloudSync } from './usePointCloudSync.js';
 import { usePointCloudLifecycle } from './usePointCloudLifecycle.js';
 import { useRenderUpdates } from './useRenderUpdates.js';
 import { useSymbolicAnnotations, useSymbolicAnnotationsRichData } from '../../hooks/useSymbolicAnnotations.js';
+import { ANNOTATION_VIEW_DEPTH } from '@/hooks/useDrawingGeneration';
 
 interface ViewportProps {
   geometry: MeshData[] | null;
@@ -799,13 +800,35 @@ export function Viewport({
     if (!Number.isFinite(min) || !Number.isFinite(max) || max <= min) return 0;
     return (min + max) * 0.5;
   }, [coordinateInfo]);
+  // When the section tool is active on a horizontal cut, restrict the 3D
+  // annotation overlay to the same 1.2 m slab the 2D Section panel uses
+  // (see `ANNOTATION_VIEW_DEPTH`). Without this, dimensions from every
+  // storey float through the viewport regardless of where the cut sits,
+  // which is what the user reported as "still showing them from ABOVE
+  // camera". The filter no-ops for non-`down` axes and when the cut is
+  // disabled, preserving the toggle's existing "show all" behaviour.
+  const annotation3DSectionFilter = useMemo(() => {
+    if (!sectionPlane.enabled) return undefined;
+    if (sectionPlane.axis !== 'down') return undefined;
+    if (!sectionRange) return undefined;
+    const sectionPosWorld = sectionRange.min + (sectionPlane.position / 100) * (sectionRange.max - sectionRange.min);
+    return {
+      axis: sectionPlane.axis,
+      sectionPosWorld,
+      viewDepth: ANNOTATION_VIEW_DEPTH,
+      flipped: sectionPlane.flipped,
+    } as const;
+  }, [sectionPlane.enabled, sectionPlane.axis, sectionPlane.position, sectionPlane.flipped, sectionRange]);
+
   const annotationVertices3D = useSymbolicAnnotations({
     enabled: ifcAnnotationsVisible,
     fallbackY: annotationFallbackY,
+    sectionFilter: annotation3DSectionFilter,
   });
   const { texts: annotationTexts3D, fills: annotationFills3D } = useSymbolicAnnotationsRichData({
     enabled: ifcAnnotationsVisible,
     fallbackY: annotationFallbackY,
+    sectionFilter: annotation3DSectionFilter,
   });
   useEffect(() => {
     const renderer = rendererRef.current;

--- a/apps/viewer/src/hooks/useDrawingGeneration.ts
+++ b/apps/viewer/src/hooks/useDrawingGeneration.ts
@@ -92,14 +92,23 @@ export function useDrawingGeneration({
   // Track if this is a regeneration (vs initial generation)
   const isRegeneratingRef = useRef(false);
 
-  // Symbolic lines carry an optional `worldY` (the parent primitive's
-  // elevation in world Y, captured from the WASM extractor). The drawing-2d
-  // package's DrawingLine type has no per-line elevation slot, but we need
-  // it here to cull annotations that sit on the wrong side of the section
-  // cut plane (see filter below `cutEntityIds`). Attaching it as an extra
-  // field keeps the change local — the canvas draws DrawingLine fields and
-  // ignores anything extra.
-  type SymbolicDrawingLine = DrawingLine & { worldY?: number };
+  // Symbolic lines carry the parent primitive's world-space centroid so the
+  // 2D Section filter below can cull them against the active cut plane —
+  // cardinal axis OR a face-picked custom plane. The drawing-2d package's
+  // DrawingLine has no per-line position slot; attaching the centroid as
+  // extra fields keeps the change local since the canvas ignores anything
+  // beyond DrawingLine's declared fields.
+  //
+  // Coordinate space matches the section cutter's input (shifted bounds):
+  // - worldX: read from the polyline's 2D x (already RTC-shifted by WASM)
+  // - worldZ: -(polyline 2D y) — WASM negates Z into the 2D y axis to
+  //   match section-cut output handedness, so flip back here
+  // - worldY: from the WASM `worldY` accessor (vertical elevation)
+  type SymbolicDrawingLine = DrawingLine & {
+    worldX?: number;
+    worldY?: number;
+    worldZ?: number;
+  };
 
   // Cache for symbolic representations - these don't change with section position
   // Only re-parse when model or display options change
@@ -182,6 +191,20 @@ export function useDrawingGeneration({
                 // behind the Rust source; read defensively so a stale build
                 // returns undefined instead of throwing.
                 const polyWorldY = (poly as unknown as { worldY?: number }).worldY;
+                // Centroid in shifted world coords — derived from the 2D
+                // points the WASM extractor already emits in section-cut
+                // space. point.x = world X (RTC-shifted); point.y =
+                // -world Z (negated to match cut-output handedness), so
+                // flip the sign back to recover world Z. Computed once
+                // per source polyline and shared across its segments.
+                let sumX = 0;
+                let sumY = 0;
+                for (let p = 0; p < pointCount; p++) {
+                  sumX += points[p * 2];
+                  sumY += points[p * 2 + 1];
+                }
+                const polyWorldX = pointCount > 0 ? sumX / pointCount : undefined;
+                const polyWorldZ = pointCount > 0 ? -sumY / pointCount : undefined;
 
                 for (let j = 0; j < pointCount - 1; j++) {
                   symbolicLines.push({
@@ -195,7 +218,9 @@ export function useDrawingGeneration({
                     ifcType: poly.ifcType,
                     modelIndex: symbolicModelIndex,
                     depth: 0,
+                    worldX: polyWorldX,
                     worldY: polyWorldY,
+                    worldZ: polyWorldZ,
                   });
                 }
 
@@ -211,7 +236,9 @@ export function useDrawingGeneration({
                     ifcType: poly.ifcType,
                     modelIndex: symbolicModelIndex,
                     depth: 0,
+                    worldX: polyWorldX,
                     worldY: polyWorldY,
+                    worldZ: polyWorldZ,
                   });
                 }
               }
@@ -224,6 +251,11 @@ export function useDrawingGeneration({
                 entitiesWithSymbols.add(circle.expressId);
                 const numSegments = circle.isFullCircle ? 32 : 16;
                 const circleWorldY = (circle as unknown as { worldY?: number }).worldY;
+                // Centre in shifted world coords. circle.centerX is
+                // already RTC-shifted X; circle.centerY carries the
+                // negated Z (see polyline note above) — flip to recover.
+                const circleWorldX = circle.centerX;
+                const circleWorldZ = -circle.centerY;
 
                 for (let j = 0; j < numSegments; j++) {
                   const t1 = j / numSegments;
@@ -248,7 +280,9 @@ export function useDrawingGeneration({
                     ifcType: circle.ifcType,
                     modelIndex: symbolicModelIndex,
                     depth: 0,
+                    worldX: circleWorldX,
                     worldY: circleWorldY,
+                    worldZ: circleWorldZ,
                   });
                 }
               }
@@ -397,34 +431,47 @@ export function useDrawingGeneration({
         // Cull annotations on the far side of the section cut plane.
         //
         // IfcAnnotation / IfcGridAxis polylines (dimensions, room tags, grid
-        // bubbles) live at a single elevation but have no body geometry — the
-        // `cutEntityIds.has(line.entityId)` filter below never sees them, so
-        // they leaked through and rendered regardless of where the section
-        // sat. For a down-section ('y' axis) the WASM extractor gives us
-        // `worldY` per primitive, so apply the same half-space convention the
-        // edge extractor uses for projection lines (see
-        // `EdgeExtractor.filterEdgesByDepth`): when the section is not
-        // flipped, the plane normal points up so we keep annotations whose
-        // worldY ≥ cutY; when flipped, we keep annotations below the cut.
+        // bubbles) live at a single elevation but have no body geometry —
+        // the `cutEntityIds.has(line.entityId)` filter below never matches
+        // them, so without this they render regardless of where the
+        // section sits.
         //
-        // Annotations without a recoverable worldY (older WASM build) are
-        // kept — better to over-render than to silently drop authored
-        // dimensions when the runtime can't classify them.
+        // Reduce every cut mode (cardinal X/Y/Z + face-pick custom plane)
+        // to a single half-space test against a unit normal + signed
+        // distance. For cardinal axes the normal is the basis vector and
+        // distance is `position` (already in shifted-bounds coords, the
+        // same space the symbolic centroids land in). For custom planes
+        // the WASM cutter already uses `normal`/`distance` verbatim, so
+        // re-use both here for consistency with the cap.
         //
-        // Limited to 'y' (down) sections: symbolic primitives are authored
-        // in floor-plan space and only carry worldY; for vertical
-        // ('x' side / 'z' front) sections we'd need per-primitive worldX /
-        // worldZ from the WASM extractor, which isn't exposed yet.
-        const annotationCulled = axis === 'y'
-          ? symbolicLines.filter((line) => {
-              const wy = line.worldY;
-              if (wy === undefined) return true;
-              const isAnnotationLike = line.ifcType === 'IfcAnnotation' || line.ifcType === 'IfcGridAxis';
-              if (!isAnnotationLike) return true;
-              const d = wy - position;
-              return sectionPlane.flipped ? d <= 0 : d >= 0;
-            })
-          : symbolicLines;
+        // The half-space sign matches what `EdgeExtractor.filterEdgesByDepth`
+        // does for projection edges: keep `signedDist ≥ 0` on the +normal
+        // side when not flipped, flip when the user has flipped the section.
+        //
+        // Annotations missing a recoverable centroid (older WASM build, or
+        // a degenerate polyline) are kept — over-rendering is preferable
+        // to silently dropping authored dimensions when the runtime can't
+        // classify them.
+        const cullNormal: [number, number, number] = sectionPlane.custom
+          ? sectionPlane.custom.normal
+          : axis === 'x' ? [1, 0, 0]
+          : axis === 'y' ? [0, 1, 0]
+          : [0, 0, 1];
+        const cullDistance = sectionPlane.custom ? sectionPlane.custom.distance : position;
+        const annotationCulled = symbolicLines.filter((line) => {
+          const isAnnotationLike = line.ifcType === 'IfcAnnotation' || line.ifcType === 'IfcGridAxis';
+          if (!isAnnotationLike) return true;
+          const wx = line.worldX;
+          const wy = line.worldY;
+          const wz = line.worldZ;
+          if (wx === undefined || wy === undefined || wz === undefined) return true;
+          const signedDist =
+            wx * cullNormal[0] +
+            wy * cullNormal[1] +
+            wz * cullNormal[2] -
+            cullDistance;
+          return sectionPlane.flipped ? signedDist <= 0 : signedDist >= 0;
+        });
 
         // Only include symbolic lines for entities that are ACTUALLY being cut
         // This filters out symbols from other floors/levels not intersected by the section plane

--- a/apps/viewer/src/hooks/useDrawingGeneration.ts
+++ b/apps/viewer/src/hooks/useDrawingGeneration.ts
@@ -92,10 +92,19 @@ export function useDrawingGeneration({
   // Track if this is a regeneration (vs initial generation)
   const isRegeneratingRef = useRef(false);
 
+  // Symbolic lines carry an optional `worldY` (the parent primitive's
+  // elevation in world Y, captured from the WASM extractor). The drawing-2d
+  // package's DrawingLine type has no per-line elevation slot, but we need
+  // it here to cull annotations that sit on the wrong side of the section
+  // cut plane (see filter below `cutEntityIds`). Attaching it as an extra
+  // field keeps the change local — the canvas draws DrawingLine fields and
+  // ignores anything extra.
+  type SymbolicDrawingLine = DrawingLine & { worldY?: number };
+
   // Cache for symbolic representations - these don't change with section position
   // Only re-parse when model or display options change
   const symbolicCacheRef = useRef<{
-    lines: DrawingLine[];
+    lines: SymbolicDrawingLine[];
     entities: Set<number>;
     sourceId: string | null;
     useSymbolic: boolean;
@@ -120,7 +129,7 @@ export function useDrawingGeneration({
 
     // Parse symbolic representations if enabled (for hybrid mode)
     // OPTIMIZATION: Cache symbolic data - it doesn't change with section position
-    let symbolicLines: DrawingLine[] = [];
+    let symbolicLines: SymbolicDrawingLine[] = [];
     let entitiesWithSymbols = new Set<number>();
 
     // For multi-model: create cache key from model count and visible model IDs
@@ -167,6 +176,12 @@ export function useDrawingGeneration({
                 entitiesWithSymbols.add(poly.expressId);
                 const points = poly.points;
                 const pointCount = poly.pointCount;
+                // WASM exposes `worldY` on every symbolic primitive — the
+                // elevation of its parent placement (Z-up IFC, world-Y here).
+                // The .d.ts shipped with the @ifc-lite/wasm package lags
+                // behind the Rust source; read defensively so a stale build
+                // returns undefined instead of throwing.
+                const polyWorldY = (poly as unknown as { worldY?: number }).worldY;
 
                 for (let j = 0; j < pointCount - 1; j++) {
                   symbolicLines.push({
@@ -180,6 +195,7 @@ export function useDrawingGeneration({
                     ifcType: poly.ifcType,
                     modelIndex: symbolicModelIndex,
                     depth: 0,
+                    worldY: polyWorldY,
                   });
                 }
 
@@ -195,6 +211,7 @@ export function useDrawingGeneration({
                     ifcType: poly.ifcType,
                     modelIndex: symbolicModelIndex,
                     depth: 0,
+                    worldY: polyWorldY,
                   });
                 }
               }
@@ -206,6 +223,7 @@ export function useDrawingGeneration({
 
                 entitiesWithSymbols.add(circle.expressId);
                 const numSegments = circle.isFullCircle ? 32 : 16;
+                const circleWorldY = (circle as unknown as { worldY?: number }).worldY;
 
                 for (let j = 0; j < numSegments; j++) {
                   const t1 = j / numSegments;
@@ -230,6 +248,7 @@ export function useDrawingGeneration({
                     ifcType: circle.ifcType,
                     modelIndex: symbolicModelIndex,
                     depth: 0,
+                    worldY: circleWorldY,
                   });
                 }
               }
@@ -375,9 +394,41 @@ export function useDrawingGeneration({
           }
         }
 
+        // Cull annotations on the far side of the section cut plane.
+        //
+        // IfcAnnotation / IfcGridAxis polylines (dimensions, room tags, grid
+        // bubbles) live at a single elevation but have no body geometry — the
+        // `cutEntityIds.has(line.entityId)` filter below never sees them, so
+        // they leaked through and rendered regardless of where the section
+        // sat. For a down-section ('y' axis) the WASM extractor gives us
+        // `worldY` per primitive, so apply the same half-space convention the
+        // edge extractor uses for projection lines (see
+        // `EdgeExtractor.filterEdgesByDepth`): when the section is not
+        // flipped, the plane normal points up so we keep annotations whose
+        // worldY ≥ cutY; when flipped, we keep annotations below the cut.
+        //
+        // Annotations without a recoverable worldY (older WASM build) are
+        // kept — better to over-render than to silently drop authored
+        // dimensions when the runtime can't classify them.
+        //
+        // Limited to 'y' (down) sections: symbolic primitives are authored
+        // in floor-plan space and only carry worldY; for vertical
+        // ('x' side / 'z' front) sections we'd need per-primitive worldX /
+        // worldZ from the WASM extractor, which isn't exposed yet.
+        const annotationCulled = axis === 'y'
+          ? symbolicLines.filter((line) => {
+              const wy = line.worldY;
+              if (wy === undefined) return true;
+              const isAnnotationLike = line.ifcType === 'IfcAnnotation' || line.ifcType === 'IfcGridAxis';
+              if (!isAnnotationLike) return true;
+              const d = wy - position;
+              return sectionPlane.flipped ? d <= 0 : d >= 0;
+            })
+          : symbolicLines;
+
         // Only include symbolic lines for entities that are ACTUALLY being cut
         // This filters out symbols from other floors/levels not intersected by the section plane
-        const relevantSymbolicLines = symbolicLines.filter(line =>
+        const relevantSymbolicLines = annotationCulled.filter(line =>
           line.entityId !== undefined && cutEntityIds.has(line.entityId)
         );
 

--- a/apps/viewer/src/hooks/useDrawingGeneration.ts
+++ b/apps/viewer/src/hooks/useDrawingGeneration.ts
@@ -477,15 +477,21 @@ export function useDrawingGeneration({
         // the WASM cutter already uses `normal`/`distance` verbatim, so
         // re-use both here for consistency with the cap.
         //
-        // The kept window is `0 ≤ signedDist ≤ ANNOTATION_VIEW_DEPTH` on
-        // the +normal side (the camera-facing half-space, matching what
-        // `EdgeExtractor.filterEdgesByDepth` does for projection edges).
-        // Flipped sections see the same world from the −normal side, so
-        // the slab mirrors to `−ANNOTATION_VIEW_DEPTH ≤ signedDist ≤ 0`.
-        // Anything BEHIND the camera (wrong sign) or FARTHER than the
-        // view depth is dropped — without the upper bound, dimensions
-        // from every storey beyond the cut stacked on top of each other
-        // because the half-space alone is unbounded along the camera axis.
+        // The kept window is `−ANNOTATION_VIEW_DEPTH ≤ signedDist ≤ 0` on
+        // the −normal side — the side BELOW a down-looking camera, where
+        // IFC dimensions live (authored at the storey's floor elevation,
+        // not at the cut height). This DIVERGES from
+        // `EdgeExtractor.filterEdgesByDepth`, which projects above the
+        // cut: annotations and projection edges are naturally on opposite
+        // sides of the cut plane. Flipped sections look at the same world
+        // from the opposite side, so the slab mirrors to
+        // `0 ≤ signedDist ≤ ANNOTATION_VIEW_DEPTH`.
+        //
+        // Anything on the wrong side of the cut, or farther than the view
+        // depth on the right side, is dropped — without the upper bound,
+        // dimensions from every storey beyond the cut stacked on top of
+        // each other because the half-space alone is unbounded along the
+        // camera axis.
         //
         // Annotations missing a recoverable centroid (older WASM build,
         // or a degenerate polyline) are kept — over-rendering is preferable
@@ -510,9 +516,9 @@ export function useDrawingGeneration({
             wz * cullNormal[2] -
             cullDistance;
           if (sectionPlane.flipped) {
-            return signedDist <= 0 && signedDist >= -ANNOTATION_VIEW_DEPTH;
+            return signedDist >= 0 && signedDist <= ANNOTATION_VIEW_DEPTH;
           }
-          return signedDist >= 0 && signedDist <= ANNOTATION_VIEW_DEPTH;
+          return signedDist <= 0 && signedDist >= -ANNOTATION_VIEW_DEPTH;
         });
 
         // Only include symbolic lines for entities that are ACTUALLY being cut

--- a/apps/viewer/src/hooks/useDrawingGeneration.ts
+++ b/apps/viewer/src/hooks/useDrawingGeneration.ts
@@ -32,6 +32,14 @@ export const AXIS_MAP: Record<'down' | 'front' | 'side', 'x' | 'y' | 'z'> = {
   side: 'x',
 };
 
+// Depth of the slab IN FRONT of the section plane (in shifted-world
+// metres) within which IFC annotation/grid primitives are kept. Beyond
+// the slab they're culled — matches a typical plan-view "view depth"
+// where dimensions for the next storey shouldn't bleed through. The
+// shifted-bounds coordinate system the centroids and `position` both
+// live in is already in metres (WASM applies `unit_scale` upstream).
+export const ANNOTATION_VIEW_DEPTH = 1.2;
+
 interface UseDrawingGenerationParams {
   geometryResult: GeometryResult | null | undefined;
   ifcDataStore: { source: Uint8Array } | null;
@@ -428,7 +436,32 @@ export function useDrawingGeneration({
           }
         }
 
-        // Cull annotations on the far side of the section cut plane.
+        // When the user toggles `sectionPlane.flipped` on a cardinal axis,
+        // the cutter negates the 2D U axis (see `projectTo2D` in
+        // @ifc-lite/drawing-2d/math.ts and `data[6] = flipU` in the GPU
+        // cutter). Symbolic primitives come out of WASM in the cutter's
+        // UNFLIPPED basis — for the plan ('y') case `(line.x = worldX − rtc,
+        // line.y = −worldY + rtc)` — so on a flipped section the cut
+        // polygons land at −X while the symbolic lines stay at +X. The
+        // result the user reported: annotations sitting NEXT TO the model
+        // as if they were mirrored across the model's centre, instead of
+        // staying with the cut. Mirror symbolic X here to match the cutter
+        // for cardinal flipped sections. Custom face-pick planes use
+        // `projectTo2DBasis` (no U flip), so leave them untouched —
+        // symbolic alignment on an arbitrary basis is a separate problem
+        // and out of scope for this fix.
+        const mirrorSymbolicX = sectionPlane.flipped && !sectionPlane.custom;
+        const orientedSymbolicLines: SymbolicDrawingLine[] = mirrorSymbolicX
+          ? symbolicLines.map((line) => ({
+              ...line,
+              line: {
+                start: { x: -line.line.start.x, y: line.line.start.y },
+                end:   { x: -line.line.end.x,   y: line.line.end.y   },
+              },
+            }))
+          : symbolicLines;
+
+        // Cull annotations to a thin view-depth slab IN FRONT of the cut.
         //
         // IfcAnnotation / IfcGridAxis polylines (dimensions, room tags, grid
         // bubbles) live at a single elevation but have no body geometry —
@@ -444,12 +477,18 @@ export function useDrawingGeneration({
         // the WASM cutter already uses `normal`/`distance` verbatim, so
         // re-use both here for consistency with the cap.
         //
-        // The half-space sign matches what `EdgeExtractor.filterEdgesByDepth`
-        // does for projection edges: keep `signedDist ≥ 0` on the +normal
-        // side when not flipped, flip when the user has flipped the section.
+        // The kept window is `0 ≤ signedDist ≤ ANNOTATION_VIEW_DEPTH` on
+        // the +normal side (the camera-facing half-space, matching what
+        // `EdgeExtractor.filterEdgesByDepth` does for projection edges).
+        // Flipped sections see the same world from the −normal side, so
+        // the slab mirrors to `−ANNOTATION_VIEW_DEPTH ≤ signedDist ≤ 0`.
+        // Anything BEHIND the camera (wrong sign) or FARTHER than the
+        // view depth is dropped — without the upper bound, dimensions
+        // from every storey beyond the cut stacked on top of each other
+        // because the half-space alone is unbounded along the camera axis.
         //
-        // Annotations missing a recoverable centroid (older WASM build, or
-        // a degenerate polyline) are kept — over-rendering is preferable
+        // Annotations missing a recoverable centroid (older WASM build,
+        // or a degenerate polyline) are kept — over-rendering is preferable
         // to silently dropping authored dimensions when the runtime can't
         // classify them.
         const cullNormal: [number, number, number] = sectionPlane.custom
@@ -458,7 +497,7 @@ export function useDrawingGeneration({
           : axis === 'y' ? [0, 1, 0]
           : [0, 0, 1];
         const cullDistance = sectionPlane.custom ? sectionPlane.custom.distance : position;
-        const annotationCulled = symbolicLines.filter((line) => {
+        const annotationCulled = orientedSymbolicLines.filter((line) => {
           const isAnnotationLike = line.ifcType === 'IfcAnnotation' || line.ifcType === 'IfcGridAxis';
           if (!isAnnotationLike) return true;
           const wx = line.worldX;
@@ -470,7 +509,10 @@ export function useDrawingGeneration({
             wy * cullNormal[1] +
             wz * cullNormal[2] -
             cullDistance;
-          return sectionPlane.flipped ? signedDist <= 0 : signedDist >= 0;
+          if (sectionPlane.flipped) {
+            return signedDist <= 0 && signedDist >= -ANNOTATION_VIEW_DEPTH;
+          }
+          return signedDist >= 0 && signedDist <= ANNOTATION_VIEW_DEPTH;
         });
 
         // Only include symbolic lines for entities that are ACTUALLY being cut

--- a/apps/viewer/src/hooks/useSymbolicAnnotations.ts
+++ b/apps/viewer/src/hooks/useSymbolicAnnotations.ts
@@ -521,18 +521,52 @@ function resolveBucketY(elevation: number | null, fallbackY: number): number {
   return elevation === null ? fallbackY : elevation;
 }
 
+/** Optional section-plane filter for the 3D annotation overlays. When active,
+ *  only annotation buckets whose elevation falls inside a 1.2 m slab IN FRONT
+ *  of the cut are emitted, so dimensions from storeys above/below the cut
+ *  don't float through the model in the 3D viewport. Only the cardinal
+ *  down-axis is meaningful — annotations are floor-plan symbols and don't
+ *  project sensibly onto vertical sections — so the filter no-ops for
+ *  `axis='front'` / `axis='side'` and lets the toggle behave as before.
+ */
+export interface AnnotationSectionFilter {
+  axis: 'down' | 'front' | 'side';
+  /** Section plane world-coord position along the cut axis. */
+  sectionPosWorld: number;
+  /** Slab depth in world units — typically `ANNOTATION_VIEW_DEPTH`. */
+  viewDepth: number;
+  flipped: boolean;
+}
+
+/** Build the bucket-elevation predicate for an optional section filter.
+ *  Returns `null` when the filter is unset or non-down (filter passes all).
+ */
+function makeSectionBucketPredicate(
+  filter: AnnotationSectionFilter | undefined,
+): ((bucketY: number) => boolean) | null {
+  if (!filter || filter.axis !== 'down') return null;
+  const TOL = 1e-3;
+  const rangeMin = (filter.flipped ? filter.sectionPosWorld - filter.viewDepth : filter.sectionPosWorld) - TOL;
+  const rangeMax = (filter.flipped ? filter.sectionPosWorld : filter.sectionPosWorld + filter.viewDepth) + TOL;
+  return (bucketY: number) => bucketY >= rangeMin && bucketY <= rangeMax;
+}
+
 export function useSymbolicAnnotations(params: {
   enabled: boolean;
   /** World Y to use for annotations with no resolvable storey. Defaults to 0. */
   fallbackY?: number;
+  /** Optional cut-plane slab filter — see `AnnotationSectionFilter`. */
+  sectionFilter?: AnnotationSectionFilter;
 }): Float32Array {
-  const { enabled, fallbackY = 0 } = params;
+  const { enabled, fallbackY = 0, sectionFilter } = params;
   const stores = useActiveStores();
   const version = useAnnotationParseTrigger(enabled, stores);
 
   return useMemo(() => {
     if (!enabled) return EMPTY_F32;
     void version; // depend on parse-completion ticks
+
+    const inRange = makeSectionBucketPredicate(sectionFilter);
 
     const verts: number[] = [];
     let storeIdx = 0;
@@ -552,16 +586,23 @@ export function useSymbolicAnnotations(params: {
       }
 
       for (const bucket of cached.byStorey.values()) {
-        liftTo3DLineList(bucket.lines, resolveBucketY(bucket.storeyElevation, fallbackY), verts);
+        const bucketY = resolveBucketY(bucket.storeyElevation, fallbackY);
+        if (inRange && !inRange(bucketY)) continue;
+        liftTo3DLineList(bucket.lines, bucketY, verts);
       }
-      liftTo3DLineList(cached.loose, fallbackY, verts);
+      // Loose: include only if the fallback Y also falls inside the slab
+      // (or the filter is off). Otherwise orphan dimensions from storeys
+      // outside the slab would still bleed through the 3D overlay.
+      if (!inRange || inRange(fallbackY)) {
+        liftTo3DLineList(cached.loose, fallbackY, verts);
+      }
       storeIdx++;
     }
 
     if (debugEnabled()) console.log(`[annotations] total 3D line vertices: ${verts.length / 3} from ${stores.length} stores`);
     if (verts.length === 0) return EMPTY_F32;
     return new Float32Array(verts);
-  }, [enabled, stores, version, fallbackY]);
+  }, [enabled, stores, version, fallbackY, sectionFilter]);
 }
 
 /**
@@ -673,6 +714,38 @@ export function useSymbolicAnnotationsForDrawing(params: {
     const texts: AnnotationText2D[] = [];
     const fills: AnnotationFill2D[] = [];
 
+    // The drawing-2d cutter negates the 2D U axis on flipped cardinal cuts
+    // (see `projectTo2D` in @ifc-lite/drawing-2d/math.ts and `flipU` in the
+    // GPU cutter). Annotation primitives come out of WASM in the cutter's
+    // UNFLIPPED basis, so on a flipped section they'd sit beside the model
+    // (mirrored across X=0) instead of on top of it — exactly the
+    // "dimensions floating to the right of the floor plan" symptom. Mirror
+    // X for lines/texts/fills here so they line up with the section cut
+    // output drawn underneath. Y stays put (the cutter only flips U).
+    const pushLine = flipped
+      ? (ln: DrawingLine2D) => lines.push({
+          line: {
+            start: { x: -ln.line.start.x, y: ln.line.start.y },
+            end:   { x: -ln.line.end.x,   y: ln.line.end.y   },
+          },
+          category: ln.category,
+        })
+      : (ln: DrawingLine2D) => lines.push(ln);
+    const pushText = flipped
+      ? (t: AnnotationText2D) => texts.push({ ...t, x: -t.x, dirX: -t.dirX })
+      : (t: AnnotationText2D) => texts.push(t);
+    const pushFill = flipped
+      ? (f: AnnotationFill2D) => {
+          const src = f.points;
+          const dst = new Float32Array(src.length);
+          for (let i = 0; i < src.length; i += 2) {
+            dst[i]     = -src[i];
+            dst[i + 1] =  src[i + 1];
+          }
+          fills.push({ ...f, points: dst });
+        }
+      : (f: AnnotationFill2D) => fills.push(f);
+
     for (const store of stores) {
       const key = sourceKey(store);
       if (!key) continue;
@@ -682,9 +755,9 @@ export function useSymbolicAnnotationsForDrawing(params: {
       for (const bucket of cached.byStorey.values()) {
         const bucketY = resolveBucketY(bucket.storeyElevation, fallbackY);
         if (bucketY < rangeMin || bucketY > rangeMax) continue;
-        for (const ln of bucket.lines) lines.push(ln);
-        for (const t of bucket.texts) texts.push(t);
-        for (const f of bucket.fills) fills.push(f);
+        for (const ln of bucket.lines) pushLine(ln);
+        for (const t of bucket.texts) pushText(t);
+        for (const f of bucket.fills) pushFill(f);
       }
 
       // Loose annotations have no resolvable storey — include them if the
@@ -692,9 +765,9 @@ export function useSymbolicAnnotationsForDrawing(params: {
       // (e.g. 3DEXPERIENCE files with orphaned storeys) usable when the
       // user is looking at the storey the fallback resolves to.
       if (fallbackY >= rangeMin && fallbackY <= rangeMax) {
-        for (const ln of cached.loose) lines.push(ln);
-        for (const t of cached.looseTexts) texts.push(t);
-        for (const f of cached.looseFills) fills.push(f);
+        for (const ln of cached.loose) pushLine(ln);
+        for (const t of cached.looseTexts) pushText(t);
+        for (const f of cached.looseFills) pushFill(f);
       }
     }
 
@@ -714,14 +787,18 @@ export function useSymbolicAnnotationsForDrawing(params: {
 export function useSymbolicAnnotationsRichData(params: {
   enabled: boolean;
   fallbackY?: number;
+  /** Optional cut-plane slab filter — see `AnnotationSectionFilter`. */
+  sectionFilter?: AnnotationSectionFilter;
 }): { texts: readonly AnnotationText3D[]; fills: readonly AnnotationFill3D[] } {
-  const { enabled, fallbackY = 0 } = params;
+  const { enabled, fallbackY = 0, sectionFilter } = params;
   const stores = useActiveStores();
   const version = useAnnotationParseTrigger(enabled, stores);
 
   return useMemo(() => {
     if (!enabled) return { texts: EMPTY_TEXTS, fills: EMPTY_FILLS };
     void version;
+
+    const inRange = makeSectionBucketPredicate(sectionFilter);
 
     const texts: AnnotationText3D[] = [];
     const fills: AnnotationFill3D[] = [];
@@ -761,16 +838,19 @@ export function useSymbolicAnnotationsRichData(params: {
 
       for (const bucket of cached.byStorey.values()) {
         const y = resolveBucketY(bucket.storeyElevation, fallbackY);
+        if (inRange && !inRange(y)) continue;
         for (const t of bucket.texts) pushText(t, y);
         for (const f of bucket.fills) pushFill(f, y);
       }
-      for (const t of cached.looseTexts) pushText(t, fallbackY);
-      for (const f of cached.looseFills) pushFill(f, fallbackY);
+      if (!inRange || inRange(fallbackY)) {
+        for (const t of cached.looseTexts) pushText(t, fallbackY);
+        for (const f of cached.looseFills) pushFill(f, fallbackY);
+      }
     }
 
     return {
       texts: texts.length ? texts : EMPTY_TEXTS,
       fills: fills.length ? fills : EMPTY_FILLS,
     };
-  }, [enabled, stores, version, fallbackY]);
+  }, [enabled, stores, version, fallbackY, sectionFilter]);
 }

--- a/apps/viewer/src/hooks/useSymbolicAnnotations.ts
+++ b/apps/viewer/src/hooks/useSymbolicAnnotations.ts
@@ -658,16 +658,28 @@ export function useSymbolicAnnotationsForDrawing(params: {
     if (axis !== 'down') return EMPTY_DRAWING_ANNOTATIONS;
     void version;
 
-    // Section view range in world Y. Matches the convention used by
-    // `profile-projector.isInProjectionRange`:
-    //   not flipped → [sectionPos, sectionPos + viewDepth]
-    //   flipped     → [sectionPos - viewDepth, sectionPos]
-    // We expand the range by a small tolerance so annotations sitting
-    // exactly on the cut plane still match (storey elevations are
-    // typically the cut Y).
+    // Section view range in world Y.
+    //
+    // For a floor-plan cut at axis='down' the camera looks DOWN through the
+    // cut. "In front of the camera" is therefore the side BELOW the cut —
+    // where the floor and authored dimensions sit (IFC convention places
+    // dimension annotations at the storey's floor elevation, not at the
+    // cut height). The user's complaint: with the slab on the +normal
+    // side, you had to scrub the section DOWN into the floor before
+    // anything showed, and then the dimensions appeared one storey BELOW
+    // the cut. Mirror that — keep the slab on the −normal side for the
+    // unflipped down section, and flip it for the reflected-ceiling case.
+    //
+    // Note this DIVERGES from `profile-projector.isInProjectionRange`,
+    // which projects above the cut by default. Annotations live with the
+    // storey floor, the projection lives with the upper-storey volume —
+    // they're naturally on opposite sides of the cut plane.
+    //
+    // Tolerance lets annotations authored exactly on the cut plane (e.g.
+    // a storey at Z=0 with a section right at the storey datum) survive.
     const TOL = 1e-3;
-    const rangeMin = (flipped ? sectionPosWorld - viewDepth : sectionPosWorld) - TOL;
-    const rangeMax = (flipped ? sectionPosWorld : sectionPosWorld + viewDepth) + TOL;
+    const rangeMin = (flipped ? sectionPosWorld : sectionPosWorld - viewDepth) - TOL;
+    const rangeMax = (flipped ? sectionPosWorld + viewDepth : sectionPosWorld) + TOL;
 
     const lines: DrawingLine2D[] = [];
     const texts: AnnotationText2D[] = [];

--- a/apps/viewer/src/hooks/useSymbolicAnnotations.ts
+++ b/apps/viewer/src/hooks/useSymbolicAnnotations.ts
@@ -521,52 +521,18 @@ function resolveBucketY(elevation: number | null, fallbackY: number): number {
   return elevation === null ? fallbackY : elevation;
 }
 
-/** Optional section-plane filter for the 3D annotation overlays. When active,
- *  only annotation buckets whose elevation falls inside a 1.2 m slab IN FRONT
- *  of the cut are emitted, so dimensions from storeys above/below the cut
- *  don't float through the model in the 3D viewport. Only the cardinal
- *  down-axis is meaningful — annotations are floor-plan symbols and don't
- *  project sensibly onto vertical sections — so the filter no-ops for
- *  `axis='front'` / `axis='side'` and lets the toggle behave as before.
- */
-export interface AnnotationSectionFilter {
-  axis: 'down' | 'front' | 'side';
-  /** Section plane world-coord position along the cut axis. */
-  sectionPosWorld: number;
-  /** Slab depth in world units — typically `ANNOTATION_VIEW_DEPTH`. */
-  viewDepth: number;
-  flipped: boolean;
-}
-
-/** Build the bucket-elevation predicate for an optional section filter.
- *  Returns `null` when the filter is unset or non-down (filter passes all).
- */
-function makeSectionBucketPredicate(
-  filter: AnnotationSectionFilter | undefined,
-): ((bucketY: number) => boolean) | null {
-  if (!filter || filter.axis !== 'down') return null;
-  const TOL = 1e-3;
-  const rangeMin = (filter.flipped ? filter.sectionPosWorld - filter.viewDepth : filter.sectionPosWorld) - TOL;
-  const rangeMax = (filter.flipped ? filter.sectionPosWorld : filter.sectionPosWorld + filter.viewDepth) + TOL;
-  return (bucketY: number) => bucketY >= rangeMin && bucketY <= rangeMax;
-}
-
 export function useSymbolicAnnotations(params: {
   enabled: boolean;
   /** World Y to use for annotations with no resolvable storey. Defaults to 0. */
   fallbackY?: number;
-  /** Optional cut-plane slab filter — see `AnnotationSectionFilter`. */
-  sectionFilter?: AnnotationSectionFilter;
 }): Float32Array {
-  const { enabled, fallbackY = 0, sectionFilter } = params;
+  const { enabled, fallbackY = 0 } = params;
   const stores = useActiveStores();
   const version = useAnnotationParseTrigger(enabled, stores);
 
   return useMemo(() => {
     if (!enabled) return EMPTY_F32;
     void version; // depend on parse-completion ticks
-
-    const inRange = makeSectionBucketPredicate(sectionFilter);
 
     const verts: number[] = [];
     let storeIdx = 0;
@@ -586,23 +552,16 @@ export function useSymbolicAnnotations(params: {
       }
 
       for (const bucket of cached.byStorey.values()) {
-        const bucketY = resolveBucketY(bucket.storeyElevation, fallbackY);
-        if (inRange && !inRange(bucketY)) continue;
-        liftTo3DLineList(bucket.lines, bucketY, verts);
+        liftTo3DLineList(bucket.lines, resolveBucketY(bucket.storeyElevation, fallbackY), verts);
       }
-      // Loose: include only if the fallback Y also falls inside the slab
-      // (or the filter is off). Otherwise orphan dimensions from storeys
-      // outside the slab would still bleed through the 3D overlay.
-      if (!inRange || inRange(fallbackY)) {
-        liftTo3DLineList(cached.loose, fallbackY, verts);
-      }
+      liftTo3DLineList(cached.loose, fallbackY, verts);
       storeIdx++;
     }
 
     if (debugEnabled()) console.log(`[annotations] total 3D line vertices: ${verts.length / 3} from ${stores.length} stores`);
     if (verts.length === 0) return EMPTY_F32;
     return new Float32Array(verts);
-  }, [enabled, stores, version, fallbackY, sectionFilter]);
+  }, [enabled, stores, version, fallbackY]);
 }
 
 /**
@@ -787,18 +746,14 @@ export function useSymbolicAnnotationsForDrawing(params: {
 export function useSymbolicAnnotationsRichData(params: {
   enabled: boolean;
   fallbackY?: number;
-  /** Optional cut-plane slab filter — see `AnnotationSectionFilter`. */
-  sectionFilter?: AnnotationSectionFilter;
 }): { texts: readonly AnnotationText3D[]; fills: readonly AnnotationFill3D[] } {
-  const { enabled, fallbackY = 0, sectionFilter } = params;
+  const { enabled, fallbackY = 0 } = params;
   const stores = useActiveStores();
   const version = useAnnotationParseTrigger(enabled, stores);
 
   return useMemo(() => {
     if (!enabled) return { texts: EMPTY_TEXTS, fills: EMPTY_FILLS };
     void version;
-
-    const inRange = makeSectionBucketPredicate(sectionFilter);
 
     const texts: AnnotationText3D[] = [];
     const fills: AnnotationFill3D[] = [];
@@ -838,19 +793,16 @@ export function useSymbolicAnnotationsRichData(params: {
 
       for (const bucket of cached.byStorey.values()) {
         const y = resolveBucketY(bucket.storeyElevation, fallbackY);
-        if (inRange && !inRange(y)) continue;
         for (const t of bucket.texts) pushText(t, y);
         for (const f of bucket.fills) pushFill(f, y);
       }
-      if (!inRange || inRange(fallbackY)) {
-        for (const t of cached.looseTexts) pushText(t, fallbackY);
-        for (const f of cached.looseFills) pushFill(f, fallbackY);
-      }
+      for (const t of cached.looseTexts) pushText(t, fallbackY);
+      for (const f of cached.looseFills) pushFill(f, fallbackY);
     }
 
     return {
       texts: texts.length ? texts : EMPTY_TEXTS,
       fills: fills.length ? fills : EMPTY_FILLS,
     };
-  }, [enabled, stores, version, fallbackY, sectionFilter]);
+  }, [enabled, stores, version, fallbackY]);
 }

--- a/packages/extensions/src/flavor/packer.ts
+++ b/packages/extensions/src/flavor/packer.ts
@@ -77,7 +77,11 @@ export function packFlavor(flavor: Flavor, opts: FlavorPackOptions = {}): Uint8A
     ...(opts.summary ? { summary: opts.summary } : {}),
   };
   const json = JSON.stringify(envelope);
-  return gzipSync(new TextEncoder().encode(json));
+  // Pin mtime to 0 so the gzip header doesn't embed wall-clock time —
+  // two `packFlavor(sameInput)` calls straddling a second boundary
+  // would otherwise differ by a few bytes in the MTIME field and the
+  // `is deterministic for the same input` test would flake on CI.
+  return gzipSync(new TextEncoder().encode(json), { mtime: 0 });
 }
 
 export function unpackFlavor(bytes: Uint8Array): ValidationResult<UnpackedFlavor> {


### PR DESCRIPTION
IfcAnnotation / IfcGridAxis polylines have no body geometry, so the existing `cutEntityIds.has(line.entityId)` filter in the symbolic-hybrid path lets them render regardless of where the section sits when an annotation's express id also lands in the cut set (files that ship a small body alongside the symbolic representation). With the cut plane moved above the building, dimension lines from every floor stacked on top of each other in the 2D Section panel.

Apply the same half-space rule the edge extractor uses for projection lines (EdgeExtractor.filterEdgesByDepth): for a down-section, keep annotations whose worldY is on the kept side of the plane, flipping direction with the section's `flipped` flag. Other ifcTypes are unaffected — their visibility is already controlled by cutEntityIds, and broadening the cull would drop cut walls/slabs whose Plan representation sits at a base elevation below the cut.

Limited to the 'y' (down) axis; vertical sections would need per-primitive worldX / worldZ which the WASM extractor doesn't expose yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More consistent annotation placement and visibility in 2D section views, using a fixed annotation view depth for typical plan views.
  * Better handling of flipped section planes: mirrored coordinates and improved filtering keep annotations aligned and correctly culled.
  * Symbolic annotation positioning refined for more accurate overlay placement.

* **Chores**
  * Packaging made deterministic so identical builds produce identical output files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LTplus-AG/ifc-lite/pull/829?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->