### PR TITLE
feat(viewer): add Zoom to button for BCF issue detail

### DIFF
--- a/apps/viewer/src/components/viewer/BCFPanel.tsx
+++ b/apps/viewer/src/components/viewer/BCFPanel.tsx
@@ -90,7 +90,7 @@ export function BCFPanel({ onClose }: BCFPanelProps) {
   const models = useViewerStore((s) => s.models);
 
   // BCF hook for camera/snapshot integration
-  const { createViewpointFromState, applyViewpoint } = useBCF();
+  const { createViewpointFromState, applyViewpoint, zoomToTopic, canZoomToTopic } = useBCF();
 
   // Local state
   const [statusFilter, setStatusFilter] = useState('all');
@@ -260,6 +260,11 @@ export function BCFPanel({ onClose }: BCFPanelProps) {
     applyViewpoint(viewpoint, true); // Animate to viewpoint
   }, [applyViewpoint]);
 
+  const handleZoomToTopic = useCallback(() => {
+    if (!activeTopic) return;
+    zoomToTopic(activeTopic);
+  }, [activeTopic, zoomToTopic]);
+
   // Delete viewpoint
   const handleDeleteViewpoint = useCallback(
     (viewpointGuid: string) => {
@@ -391,6 +396,8 @@ export function BCFPanel({ onClose }: BCFPanelProps) {
             onActivateViewpoint={handleActivateViewpoint}
             onDeleteViewpoint={handleDeleteViewpoint}
             onUpdateStatus={handleUpdateStatus}
+            onZoomToTopic={handleZoomToTopic}
+            canZoomToTopic={activeTopic ? canZoomToTopic(activeTopic) : false}
             onDeleteTopic={handleDeleteTopic}
             selectionCount={selectionCount}
             hasIsolation={hasIsolation}

--- a/apps/viewer/src/components/viewer/bcf/BCFTopicDetail.tsx
+++ b/apps/viewer/src/components/viewer/bcf/BCFTopicDetail.tsx
@@ -124,8 +124,9 @@ export function BCFTopicDetail({
               size="sm"
               onClick={onZoomToTopic}
               disabled={!canZoomToTopic}
+              aria-label="Zoom to topic"
             >
-              <Crosshair className="h-4 w-4" />
+              <Crosshair className="h-4 w-4" aria-hidden />
             </Button>
           </TooltipTrigger>
           <TooltipContent>Zoom to</TooltipContent>

--- a/apps/viewer/src/components/viewer/bcf/BCFTopicDetail.tsx
+++ b/apps/viewer/src/components/viewer/bcf/BCFTopicDetail.tsx
@@ -18,8 +18,14 @@ import {
   MousePointer2,
   Focus,
   EyeOff,
+  Crosshair,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import {
@@ -46,6 +52,8 @@ export interface BCFTopicDetailProps {
   onActivateViewpoint: (viewpoint: BCFViewpoint) => void;
   onDeleteViewpoint: (viewpointGuid: string) => void;
   onUpdateStatus: (status: string) => void;
+  onZoomToTopic: () => void;
+  canZoomToTopic: boolean;
   onDeleteTopic: () => void;
   // Viewer state info for capture feedback
   selectionCount: number;
@@ -65,6 +73,8 @@ export function BCFTopicDetail({
   onActivateViewpoint,
   onDeleteViewpoint,
   onUpdateStatus,
+  onZoomToTopic,
+  canZoomToTopic,
   onDeleteTopic,
   selectionCount,
   hasIsolation,
@@ -107,6 +117,19 @@ export function BCFTopicDetail({
           <ChevronLeft className="h-4 w-4" />
         </Button>
         <h3 className="font-medium text-sm flex-1 truncate">{topic.title}</h3>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onZoomToTopic}
+              disabled={!canZoomToTopic}
+            >
+              <Crosshair className="h-4 w-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Zoom to</TooltipContent>
+        </Tooltip>
         <Button
           variant="ghost"
           size="sm"

--- a/apps/viewer/src/hooks/useBCF.ts
+++ b/apps/viewer/src/hooks/useBCF.ts
@@ -13,13 +13,15 @@
 
 import { useCallback, useRef } from 'react';
 import { useViewerStore } from '@/store';
-import type { BCFViewpoint } from '@ifc-lite/bcf';
+import type { BCFTopic, BCFViewpoint } from '@ifc-lite/bcf';
 import {
   createViewpoint,
   extractViewpointState,
+  computeMarkerPositions,
   type ViewerCameraState,
   type ViewerSectionPlane,
   type ViewerBounds,
+  type OverlayBBox,
 } from '@ifc-lite/bcf';
 import type { Renderer } from '@ifc-lite/renderer';
 import {
@@ -52,6 +54,10 @@ interface UseBCFResult {
   createViewpointFromState: (options?: CreateViewpointOptions) => Promise<BCFViewpoint | null>;
   /** Apply a viewpoint to the viewer */
   applyViewpoint: (viewpoint: BCFViewpoint, animate?: boolean) => void;
+  /** Animate the camera to a BCF topic's 3D location (without changing selection/visibility) */
+  zoomToTopic: (topic: BCFTopic) => void;
+  /** Whether a topic has enough data to zoom to */
+  canZoomToTopic: (topic: BCFTopic) => boolean;
   /** Capture a snapshot from the canvas */
   captureSnapshot: () => Promise<string | null>;
   /** Set the canvas ref for snapshot capture */
@@ -482,9 +488,62 @@ export function useBCF(options: UseBCFOptions = {}): UseBCFResult {
     ]
   );
 
+  const canZoomToTopic = useCallback((topic: BCFTopic): boolean => {
+    return topic.viewpoints.length > 0;
+  }, []);
+
+  const zoomToTopic = useCallback(
+    (topic: BCFTopic) => {
+      const renderer = getRenderer();
+      if (!renderer || topic.viewpoints.length === 0) return;
+
+      const boundsLookup = (ifcGuid: string): OverlayBBox | null => {
+        const result = globalIdToExpressId(ifcGuid);
+        if (!result) return null;
+        return renderer.getScene().getEntityBoundingBox(result.expressId);
+      };
+
+      const markers = computeMarkerPositions([topic], boundsLookup, {
+        targetDistance: renderer.getCamera().getDistance(),
+      });
+
+      if (markers.length > 0) {
+        const marker = markers[0];
+
+        if (marker.positionSource === 'component') {
+          for (let i = topic.viewpoints.length - 1; i >= 0; i--) {
+            const vp = topic.viewpoints[i];
+            const guids = [
+              ...(vp.components?.selection ?? []),
+              ...(vp.components?.visibility?.exceptions ?? []),
+            ];
+            for (const comp of guids) {
+              if (!comp.ifcGuid) continue;
+              const bbox = boundsLookup(comp.ifcGuid);
+              if (bbox) {
+                void renderer.getCamera().frameBounds(bbox.min, bbox.max);
+                return;
+              }
+            }
+          }
+        }
+
+        const point = marker.connectorAnchor ?? marker.position;
+        void renderer.getCamera().framePoint(point);
+        return;
+      }
+
+      // Fallback: restore camera from the latest viewpoint only
+      applyViewpoint(topic.viewpoints[topic.viewpoints.length - 1], true);
+    },
+    [applyViewpoint, getRenderer, globalIdToExpressId],
+  );
+
   return {
     createViewpointFromState,
     applyViewpoint,
+    zoomToTopic,
+    canZoomToTopic,
     captureSnapshot,
     setCanvasRef,
     setRendererRef,

--- a/apps/viewer/src/hooks/useBCF.ts
+++ b/apps/viewer/src/hooks/useBCF.ts
@@ -102,6 +102,21 @@ export function clearGlobalRefs(): void {
   globalRendererRef = null;
 }
 
+/** Apply extracted BCF camera state without touching selection, visibility, or section plane. */
+function applyCameraState(
+  renderer: Renderer,
+  camera: NonNullable<ReturnType<typeof extractViewpointState>['camera']>,
+  animate: boolean,
+): void {
+  const rendererCamera = renderer.getCamera();
+  if (animate) {
+    rendererCamera.animateTo(camera.position, camera.target, 300);
+  } else {
+    rendererCamera.setPosition(camera.position.x, camera.position.y, camera.position.z);
+    rendererCamera.setTarget(camera.target.x, camera.target.y, camera.target.z);
+  }
+}
+
 // ============================================================================
 // Hook
 // ============================================================================
@@ -357,6 +372,28 @@ export function useBCF(options: UseBCFOptions = {}): UseBCFResult {
     ]
   );
 
+  /** Restore only the viewpoint camera (used by zoom-to-topic fallback). */
+  const applyViewpointCamera = useCallback(
+    (viewpoint: BCFViewpoint, animate = true) => {
+      const renderer = getRenderer();
+      if (!renderer) {
+        console.warn('[useBCF] Cannot apply viewpoint camera: no renderer');
+        return;
+      }
+
+      const bounds = getBounds() ?? undefined;
+      const state = extractViewpointState(
+        viewpoint,
+        bounds,
+        renderer.getCamera().getDistance(),
+      );
+      if (state.camera) {
+        applyCameraState(renderer, state.camera, animate);
+      }
+    },
+    [getRenderer, getBounds],
+  );
+
   /**
    * Apply a viewpoint to the viewer
    */
@@ -378,22 +415,8 @@ export function useBCF(options: UseBCFOptions = {}): UseBCFResult {
       );
       const { camera, sectionPlane: viewpointSectionPlane } = state;
 
-      // Apply camera
       if (camera) {
-        const rendererCamera = renderer.getCamera();
-
-        if (animate) {
-          // Animate to new position
-          rendererCamera.animateTo(
-            camera.position,
-            camera.target,
-            300 // 300ms animation
-          );
-        } else {
-          // Set immediately
-          rendererCamera.setPosition(camera.position.x, camera.position.y, camera.position.z);
-          rendererCamera.setTarget(camera.target.x, camera.target.y, camera.target.z);
-        }
+        applyCameraState(renderer, camera, animate);
       }
 
       // Apply section plane
@@ -533,10 +556,10 @@ export function useBCF(options: UseBCFOptions = {}): UseBCFResult {
         return;
       }
 
-      // Fallback: restore camera from the latest viewpoint only
-      applyViewpoint(topic.viewpoints[topic.viewpoints.length - 1], true);
+      // Fallback: camera from latest viewpoint only — preserve selection/visibility
+      applyViewpointCamera(topic.viewpoints[topic.viewpoints.length - 1], true);
     },
-    [applyViewpoint, getRenderer, globalIdToExpressId],
+    [applyViewpointCamera, getRenderer, globalIdToExpressId],
   );
 
   return {


### PR DESCRIPTION
## Summary
- Add a **Zoom to** (crosshair) button in the BCF issue detail header, placed left of the delete action
- Introduce `zoomToTopic` / `canZoomToTopic` in `useBCF` to frame the camera on a topic's 3D location using existing marker position logic
- Camera-only framing keeps current selection and visibility unchanged (distinct from per-viewpoint **Go to view**, which applies the full BCF viewpoint state)

## Test plan
- [x] Open a model with BCF topics that have captured viewpoints
- [x] Open a BCF issue in the panel and click **Zoom to** — camera should animate to the issue location
- [x] Confirm selection and hidden/isolated entities are unchanged after zoom
- [x] Confirm **Zoom to** is disabled for topics with no viewpoints
- [ ] Verify **Go to view** on individual viewpoints still applies full viewpoint state (camera + selection + visibility)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Zoom to topic" button in the BCF topic details panel to frame the viewer to the selected topic.
  * Button auto-enables/disables based on whether the topic can be focused.
  * Improved framing logic: will focus components or markers when available, otherwise fall back to the topic viewpoint; camera apply preserves current selection/visibility/section planes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LTplus-AG/ifc-lite/pull/830?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->