### PR TITLE
fix(viewer,wasm): billboard annotation text + transparent grid bubbles (#812)

### DIFF
--- a/.changeset/annotation-billboard-grid-bubble-812.md
+++ b/.changeset/annotation-billboard-grid-bubble-812.md
@@ -1,5 +1,6 @@
 ---
 "@ifc-lite/viewer": patch
+"@ifc-lite/renderer": patch
 "@ifc-lite/wasm": patch
 ---
 
@@ -19,3 +20,15 @@ Improve IFC annotation legibility in 3D (issue #812 follow-up):
   reads through the bubble in 3D. The black outline ring (◯) and tag
   glyph are unchanged — the white ● fill instance has been removed
   from `emit_bubble`, which also drops one text instance per bubble.
+
+- **Annotation text no longer z-fights coplanar surfaces.** Now that
+  every glyph billboards, the quad faces the camera with zero depth
+  slope across its screen extent — which means the text pipeline's
+  `depthBiasSlopeScale: -0.5` contributes ~0 and only the small `-4`
+  constant survives, not enough to beat MSAA jitter on a label drawn
+  exactly on a wall/floor face (visible as dimension digits strobing
+  against terrain in 3D). The symbolic-overlay text shader now applies
+  the same `clip.z + 5e-5 * clip.w` reverse-Z nudge the section-2D
+  line pipeline already uses — depth-format-independent, slope-
+  independent, and large enough to clear coplanar jitter without
+  pulling the label visibly off the surface.

--- a/.changeset/annotation-billboard-grid-bubble-812.md
+++ b/.changeset/annotation-billboard-grid-bubble-812.md
@@ -1,0 +1,21 @@
+---
+"@ifc-lite/viewer": patch
+"@ifc-lite/wasm": patch
+---
+
+Improve IFC annotation legibility in 3D (issue #812 follow-up):
+
+- **All annotation text now billboards to the camera.** Previously only
+  IfcGridAxis tags rebuilt in the screen-aligned basis; IfcAnnotation
+  text (dimensions, leader labels, room tags) kept its authored
+  in-plane orientation. In oblique views that text collapsed to a
+  smeared sliver of pixels — the "distorted dimension labels in
+  FZK-Haus" symptom from the issue. The shader path was already
+  per-instance billboard-aware, so the change is just a flag flip at
+  upload time; anchor and alignment are unchanged.
+
+- **Grid bubbles no longer paint a white disc behind the tag.** The
+  bubble interior is now transparent, so geometry behind a grid line
+  reads through the bubble in 3D. The black outline ring (◯) and tag
+  glyph are unchanged — the white ● fill instance has been removed
+  from `emit_bubble`, which also drops one text instance per bubble.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2423,7 +2423,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-core"
-version = "2.4.1"
+version = "2.4.2"
 dependencies = [
  "fast-float2",
  "futures-core",
@@ -2462,7 +2462,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-engine"
-version = "2.4.1"
+version = "2.4.2"
 dependencies = [
  "ifc-lite-processing",
  "memmap2 0.9.10",
@@ -2471,7 +2471,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-geometry"
-version = "2.4.1"
+version = "2.4.2"
 dependencies = [
  "approx",
  "earcutr",
@@ -2487,7 +2487,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-processing"
-version = "2.4.1"
+version = "2.4.2"
 dependencies = [
  "ifc-lite-core",
  "ifc-lite-geometry",
@@ -2500,7 +2500,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-server"
-version = "2.4.1"
+version = "2.4.2"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2534,7 +2534,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-wasm"
-version = "2.4.1"
+version = "2.4.2"
 dependencies = [
  "console_error_panic_hook",
  "futures-util",

--- a/apps/viewer/src/hooks/useSymbolicAnnotations.ts
+++ b/apps/viewer/src/hooks/useSymbolicAnnotations.ts
@@ -60,10 +60,9 @@ export interface AnnotationText2D {
   /**
    * When true, the renderer rebuilds the glyph quad in screen-aligned
    * (cameraRight, cameraUp) basis so the text always faces the camera.
-   * Set for IfcGridAxis tags — they must stay readable in top-down/ground
-   * views where the authored world-Y up axis collapses to zero on-screen.
-   * Defaults to false (authored, in-plane text — matches BIMvision for
-   * dimension/leader annotations that lie flat on the floor).
+   * Set for every annotation literal (grid bubbles, dimension callouts,
+   * leader labels) so they stay legible in any view — flat-in-plane text
+   * collapses to a sliver at oblique angles (issue #812). Defaults to false.
    */
   billboard?: boolean;
   /** sRGB straight-alpha tint (0..1). Defaults to renderer near-black. */
@@ -337,12 +336,13 @@ async function parseAnnotations(
       // a little air between rows so descenders don't kiss the next cap.
       const lineSpacing = perLineHeight * 1.2;
       const bucket = ensureBucket(text.expressId, text.worldY);
-      // IfcGridAxis bubble tags must stay readable in any view orientation
-      // (top-down, eye-level, oblique). Tag them as billboard so the text
-      // shader rebuilds the quad in screen-aligned basis at render time.
-      // Other annotation text (dimensions, leader labels) keeps authored
-      // orientation — those are meant to lie flat in the floor plane.
-      const isGridTag = text.ifcType === 'IfcGridAxis';
+      // All annotation text — grid bubbles, dimension callouts, leader labels —
+      // billboards to the camera so it stays legible in any view orientation
+      // (top-down, eye-level, oblique). The shader rebuilds the quad in the
+      // screen-aligned basis at render time. Authored orientation is intentionally
+      // dropped: at oblique viewing angles, flat-in-plane text becomes a smeared
+      // sliver of pixels (issue #812). Anchor + alignment are preserved, so each
+      // label still sits at its authored insertion point.
       // Read per-instance style metadata. WASM emits these for grid
       // bubble parts (● fill / ○ outline / tag) and reserves them for
       // future IfcTextStyle resolution on regular annotation text.
@@ -362,7 +362,7 @@ async function parseAnnotations(
           content: lines[li],
           alignment: text.alignment,
           lineYOffset: -li * lineSpacing,
-          billboard: isGridTag,
+          billboard: true,
           color: textColor,
           targetPx,
         };

--- a/packages/renderer/src/shaders/symbolic-overlay.wgsl.ts
+++ b/packages/renderer/src/shaders/symbolic-overlay.wgsl.ts
@@ -176,7 +176,16 @@ fn vs_main(in: VsIn, inst: InstIn) -> VsOut {
   let vMix = mix(inst.uvBounds.w, inst.uvBounds.y, v);
 
   var out: VsOut;
-  out.clipPos = camera.viewProj * vec4<f32>(worldPos, 1.0);
+  let clip = camera.viewProj * vec4<f32>(worldPos, 1.0);
+  // Reverse-Z decal nudge for text coplanar with model faces (issue #812
+  // follow-up: "30", "1.49" etc. flickering against the terrain). The
+  // pipeline-level depthBiasSlopeScale collapses to ~0 for billboard
+  // glyphs — the quad faces the camera, so depth slope across the quad
+  // is zero — leaving only a tiny -4 constant that MSAA jitter beats.
+  // Adding a small positive multiple of clip.w raises NDC z by a
+  // constant after the w-divide, which under reverse-Z reads as
+  // "slightly closer" — same trick the line pipeline uses.
+  out.clipPos = vec4<f32>(clip.x, clip.y, clip.z + 5e-5 * clip.w, clip.w);
   out.uv      = vec2<f32>(uMix, vMix);
   out.color   = inst.color;
   return out;

--- a/rust/wasm-bindings/src/api/symbolic.rs
+++ b/rust/wasm-bindings/src/api/symbolic.rs
@@ -1809,8 +1809,8 @@ fn extract_grid(
     let _ = grid_id;
 }
 
-/// Emit a bubble (white fill ● + black outline ○ + black tag) as three
-/// stacked text instances at (cx, cy, world_y). All three share the same
+/// Emit a bubble (transparent interior + black outline ○ + black tag) as
+/// two stacked text instances at (cx, cy, world_y). Both share the same
 /// anchor + `IfcGridAxis` ifc-type + Axis representation identifier; the
 /// shader's per-instance `targetPx` and `colour` make them render at the
 /// right relative size and tint without needing dedicated pipelines.
@@ -1828,20 +1828,10 @@ fn emit_bubble(
     tag_target_px: f32,
 ) {
     use crate::zero_copy::SymbolicText;
-    // 1) White fill — `●` (U+2B24 BLACK LARGE CIRCLE) tinted white.
-    collection.add_text(SymbolicText::new_styled(
-        axis_id, "IfcGridAxis".to_string(),
-        cx, cy, 1.0, 0.0, bubble_cap_m,
-        "\u{2B24}".to_string(),
-        "center".to_string(),
-        world_y,
-        [1.0, 1.0, 1.0, 1.0],
-        bubble_target_px,
-        "Axis".to_string(),
-    ));
-    // 2) Black outline — `◯` (U+25EF LARGE CIRCLE) at the same size; its
-    //    stroke renders just outside the fill, giving the canonical
-    //    white-fill-black-stroke bubble look from CAD conventions.
+    // 1) Black outline — `◯` (U+25EF LARGE CIRCLE). The interior is left
+    //    transparent so the model behind reads through (issue #812 follow-up).
+    //    A previous revision stacked a white `●` (U+2B24) underneath for the
+    //    classic CAD-sheet look, but it obscured geometry in 3D views.
     collection.add_text(SymbolicText::new_styled(
         axis_id, "IfcGridAxis".to_string(),
         cx, cy, 1.0, 0.0, bubble_cap_m,
@@ -1852,7 +1842,7 @@ fn emit_bubble(
         bubble_target_px,
         "Axis".to_string(),
     ));
-    // 3) Tag text — actual axis label (alphanumeric).
+    // 2) Tag text — actual axis label (alphanumeric).
     collection.add_text(SymbolicText::new_styled(
         axis_id, "IfcGridAxis".to_string(),
         cx, cy, 1.0, 0.0, tag_cap_m,


### PR DESCRIPTION
## Summary
- All IFC annotation text (dimensions, leader labels, room tags) now billboards to the camera, matching the existing `IfcGridAxis` behaviour. Authored in-plane orientation collapsed to a smeared sliver at oblique angles — the "distorted FZK-Haus dimension labels" symptom in #812.
- `emit_bubble` no longer paints the white `●` disc behind the tag. Only the black `◯` outline ring + tag remain, so geometry behind a grid line reads through the bubble in 3D. Drops one text instance per bubble.

## Notes
- Shader path was already per-instance billboard-aware — the annotation change is just `billboard: true` at upload time. Anchor + alignment are unchanged.
- The bubble change removes a draw item; no callers index into the per-bubble text range.

Closes #812.

## Test plan
- [x] Load the ARQ-PSA-2020 grid model from #812 — confirm grid bubbles are transparent and tag/outline still legible.
- [x] Load FZK-Haus — confirm dimension/room-tag text stays legible in oblique 3D view (no smear).
- [x] Top-down view: annotation text still anchors at the authored insertion point with correct alignment.
- [x] 2D section overlay (added in #815) still renders annotations correctly.