### PR TITLE
fix(geometry): partial-overlap opening no longer punches through wall (#832)

### DIFF
--- a/.changeset/fix-832-opening-poke-out-overcuts.md
+++ b/.changeset/fix-832-opening-poke-out-overcuts.md
@@ -1,0 +1,44 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Fix `IfcOpeningElement` punching through the entire wall when the
+authored opening pokes past one wall face (issue #832).
+
+`router/voids.rs::extend_opening_along_direction` is a Revit/ArchiCAD
+heuristic that stretches an opening AABB along its own extrusion axis
+to make sure the AABB clip lands cleanly on both wall faces. It was
+designed for the "opening modelled too short" pattern — opening fully
+inside the wall in extrusion direction. When an opening is *offset*
+so part of it sticks out one face (e.g. a 1 m × 1 m × 0.2 m opening
+positioned so its 0.2 m depth straddles the wall's +X face at exactly
+the wall-thickness boundary), the heuristic over-extended through
+the wall and the AABB clip removed BOTH the touched and untouched
+wall faces — the "punched-through slot" the bug reporter saw on
+wall #222 in `ifc-opening.ifc`.
+
+The fix adds a gate that bails out of the extension when the
+opening's projection on its own extrusion axis pokes past either
+wall projection — comparing projections (not raw coords) so the
+sign of the extrusion direction is irrelevant. The author's bite
+is preserved verbatim and the AABB clip only removes the wall
+material the opening actually intersects.
+
+Regression coverage:
+
+- `rust/geometry/tests/issue_832_opening_representations.rs` — full
+  pipeline test against the reporter's 5-wall fixture, asserting
+  each wall ends up with a bounded hole and the wall faces the
+  opening doesn't reach remain pristine 2-triangle rectangles.
+- `router::voids::reveal_tests::test_extend_opening_skipped_when_opening_pokes_past_wall`
+  — direct unit test pinning the new gate, covering both `+X` and
+  `-X` extrusion-direction polarity.
+- The existing #604 "exact-match coplanarity pad" regression
+  (`test_extend_opening_pads_past_wall_on_exact_match`) still passes
+  unchanged — the new gate intentionally does not fire when the
+  opening fits exactly inside the wall.
+
+Fixture `tests/models/issues/832_opening_representations.ifc` (11 KB,
+SHA-256 `0a81eda40a3b…`) added to the manifest. The bytes need to be
+uploaded to the `fixtures-v1` GitHub Release via `pnpm fixtures:upload`
+once merged.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2423,7 +2423,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-core"
-version = "2.4.1"
+version = "2.4.2"
 dependencies = [
  "fast-float2",
  "futures-core",
@@ -2462,7 +2462,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-engine"
-version = "2.4.1"
+version = "2.4.2"
 dependencies = [
  "ifc-lite-processing",
  "memmap2 0.9.10",
@@ -2471,7 +2471,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-geometry"
-version = "2.4.1"
+version = "2.4.2"
 dependencies = [
  "approx",
  "earcutr",
@@ -2487,7 +2487,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-processing"
-version = "2.4.1"
+version = "2.4.2"
 dependencies = [
  "ifc-lite-core",
  "ifc-lite-geometry",
@@ -2500,7 +2500,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-server"
-version = "2.4.1"
+version = "2.4.2"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2534,7 +2534,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-wasm"
-version = "2.4.1"
+version = "2.4.2"
 dependencies = [
  "console_error_panic_hook",
  "futures-util",

--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -1907,6 +1907,24 @@ impl GeometryRouter {
         if wall_proj_extent > opening_max_dim {
             return (open_min, open_max);
         }
+        // Case (3): the opening was authored to extend past the wall on at
+        // least one side in extrusion direction. This is a partial-overlap
+        // "bite" — issue #832, a 1 × 1 × 0.2 m opening offset so half the
+        // 0.2 m depth pokes out the wall's +X face. The Revit "extend to
+        // reach the opposite wall face" heuristic that follows is only
+        // sound when the opening sits ENTIRELY INSIDE the wall along the
+        // extrusion axis (the "opening too short" pattern); when the
+        // opening already pokes out one side, applying it stretches the
+        // box across the full wall thickness and the AABB clip removes
+        // BOTH faces — the punched-through slot the bug reporter saw.
+        // Compare projections rather than raw coords so the sign of the
+        // extrusion direction is irrelevant.
+        const POKE_TOL: f64 = 1e-6;
+        let opening_pokes_past_wall = open_min_proj < wall_min_proj - POKE_TOL
+            || open_max_proj > wall_max_proj + POKE_TOL;
+        if opening_pokes_past_wall {
+            return (open_min, open_max);
+        }
 
         // Calculate how much to extend in each direction along the extrusion axis
         // If wall extends beyond opening, we need to extend the opening
@@ -3207,6 +3225,46 @@ mod reveal_tests {
         assert_eq!(new_max.x, open_max.x);
         assert_eq!(new_min.z, open_min.z);
         assert_eq!(new_max.z, open_max.z);
+    }
+
+    #[test]
+    fn test_extend_opening_skipped_when_opening_pokes_past_wall() {
+        // Regression for issue #832: a 1×1×0.2 m opening offset so its
+        // 0.2 m extrusion depth pokes 0.1 m past the wall's +X face. The
+        // Revit "extend to reach the opposite wall face" heuristic would
+        // stretch the opening through the wall thickness and the AABB
+        // clip would remove BOTH the +X (touched) and -X (un-touched)
+        // wall faces — the "punched-through slot" the user reported.
+        // The extension must bail out and return the authored bounds.
+        let router = crate::router::GeometryRouter::new();
+
+        // Wall: 0.2 m thick along X, 3 m × 3 m face.
+        let wall_min = Point3::new(7.9, 0.0, 0.0);
+        let wall_max = Point3::new(8.1, 3.0, 3.0);
+        // Opening starts inside the wall (x=8.0) and pokes past +X (x=8.2).
+        let open_min = Point3::new(8.0, 0.5, 1.0);
+        let open_max = Point3::new(8.2, 1.5, 2.0);
+        let dir = Vector3::new(1.0, 0.0, 0.0);
+
+        let (new_min, new_max) =
+            router.extend_opening_along_direction(open_min, open_max, wall_min, wall_max, dir);
+
+        // Authored bounds must come back UNCHANGED — no extension, no pad.
+        assert_eq!(new_min, open_min, "X-poke-out: extension must not change min");
+        assert_eq!(new_max, open_max, "X-poke-out: extension must not change max");
+
+        // Same shape mirrored: opening pokes past -X face, extrusion -X.
+        let wall_min = Point3::new(5.9, 0.0, 0.0);
+        let wall_max = Point3::new(6.1, 3.0, 3.0);
+        let open_min = Point3::new(5.8, 0.5, 1.0);
+        let open_max = Point3::new(6.0, 1.5, 2.0);
+        let dir = Vector3::new(-1.0, 0.0, 0.0);
+
+        let (new_min, new_max) =
+            router.extend_opening_along_direction(open_min, open_max, wall_min, wall_max, dir);
+
+        assert_eq!(new_min, open_min, "-X-poke-out: extension must not change min");
+        assert_eq!(new_max, open_max, "-X-poke-out: extension must not change max");
     }
 
     #[test]

--- a/rust/geometry/tests/issue_832_opening_representations.rs
+++ b/rust/geometry/tests/issue_832_opening_representations.rs
@@ -1,0 +1,322 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Regression test for issue #832 — five walls authored with different
+//! opening representations should all produce a bounded rectangular hole.
+//!
+//! Fixture (`tests/models/issues/832_opening_representations.ifc`) is the
+//! reporter's minimal repro: 5 walls along world +X, 0.2 m thick, 3 m
+//! long, 3 m tall. Each wall has exactly one `IfcRelVoidsElement` →
+//! `IfcOpeningElement` with a 1 m × 1 m × 0.2 m authored bounding box
+//! centred at y ∈ [0.5, 1.5], z ∈ [1, 2] of the wall. Configurations:
+//!
+//! | Wall id | Opening profile / extrude                         | Side overlap |
+//! |---------|---------------------------------------------------|--------------|
+//! | #50     | IfcRectangleProfileDef 1×0.2, vertical 1 m         | full thickness |
+//! | #89     | IfcRectangleProfileDef offset (0.5, 0.1), 1 m     | -X stick-out 0.1 m |
+//! | #128    | IfcArbitraryClosedProfileDef unit-square, +X 0.2 m | full thickness |
+//! | #175    | IfcArbitraryClosedProfileDef, -X extrude 0.2 m     | -X stick-out 0.1 m |
+//! | #222    | IfcArbitraryClosedProfileDef, +X extrude 0.2 m     | +X stick-out 0.1 m |
+//!
+//! User-reported symptom: wall #222 (last) ends up with the cut punching
+//! all the way down to the wall base and out the +X edge — a half-space
+//! cut, not the authored bounded opening.
+
+use ifc_lite_core::{EntityDecoder, IfcType};
+use ifc_lite_geometry::GeometryRouter;
+use rustc_hash::FxHashMap;
+
+const FIXTURE: &str = "../../tests/models/issues/832_opening_representations.ifc";
+
+/// (wall_id, opening_id, label).  Wall #222 is the broken one in the screenshot.
+const WALLS: &[(u32, u32, &str)] = &[
+    (50, 69, "wall1 — rectangle profile, vertical extrude, full thickness"),
+    (89, 108, "wall2 — rectangle profile, vertical extrude, -X stick-out"),
+    (128, 155, "wall3 — arbitrary profile, +X horiz extrude, full thickness"),
+    (175, 202, "wall4 — arbitrary profile, -X horiz extrude, -X stick-out"),
+    (222, 249, "wall5 — arbitrary profile, +X horiz extrude, +X stick-out"),
+];
+
+/// World-space authored opening bounds (taken from the IFC by hand — see
+/// the table at the top of this file). All openings share y ∈ [0.5, 1.5]
+/// and z ∈ [1, 2]; only the x extent differs per wall.
+fn authored_opening_bounds(wall_id: u32) -> ((f32, f32, f32), (f32, f32, f32)) {
+    let x = match wall_id {
+        50 => (-0.1, 0.1),
+        89 => (1.8, 2.0),
+        128 => (3.9, 4.1),
+        175 => (5.8, 6.0),
+        222 => (8.0, 8.2),
+        other => panic!("unexpected wall id #{other}"),
+    };
+    ((x.0, 0.5, 1.0), (x.1, 1.5, 2.0))
+}
+
+fn read_fixture() -> Option<String> {
+    match std::fs::read_to_string(FIXTURE) {
+        Ok(s) => Some(s),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            eprintln!(
+                "skipping issue-832 regression: fixture missing at {FIXTURE} — \
+                 add it from the issue attachment"
+            );
+            None
+        }
+        Err(e) => panic!("failed to read fixture {FIXTURE}: {e}"),
+    }
+}
+
+fn mesh_bounds(mesh: &ifc_lite_geometry::Mesh) -> ([f32; 3], [f32; 3]) {
+    let mut min = [f32::INFINITY; 3];
+    let mut max = [f32::NEG_INFINITY; 3];
+    for p in mesh.positions.chunks_exact(3) {
+        for axis in 0..3 {
+            if p[axis] < min[axis] {
+                min[axis] = p[axis];
+            }
+            if p[axis] > max[axis] {
+                max[axis] = p[axis];
+            }
+        }
+    }
+    (min, max)
+}
+
+/// Z-extent of any wall vertex inside the authored opening footprint
+/// (x, y) — used to detect an opening that has been silently widened in Z
+/// past its authored z ∈ [1, 2].
+fn z_inside_opening_footprint(
+    mesh: &ifc_lite_geometry::Mesh,
+    open_min: (f32, f32, f32),
+    open_max: (f32, f32, f32),
+) -> (f32, f32) {
+    // For every triangle that lies inside the opening's (x, y) rectangle,
+    // collect z values. If the cut went rogue and removed the wall down
+    // to the base, the wall mesh will have no triangle covering the
+    // authored z ∈ [1, 2] strip, and the surviving triangles will give
+    // back a z-range that misses that strip entirely.
+    let mut zs = Vec::new();
+    for tri in mesh.indices.chunks_exact(3) {
+        let mut inside = true;
+        let mut tri_z = [0f32; 3];
+        for (i, vi) in tri.iter().enumerate() {
+            let base = *vi as usize * 3;
+            let x = mesh.positions[base];
+            let y = mesh.positions[base + 1];
+            let z = mesh.positions[base + 2];
+            if x < open_min.0 || x > open_max.0 || y < open_min.1 || y > open_max.1 {
+                inside = false;
+                break;
+            }
+            tri_z[i] = z;
+        }
+        if inside {
+            for z in tri_z {
+                zs.push(z);
+            }
+        }
+    }
+    if zs.is_empty() {
+        return (f32::NAN, f32::NAN);
+    }
+    let zmin = zs.iter().cloned().fold(f32::INFINITY, f32::min);
+    let zmax = zs.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+    (zmin, zmax)
+}
+
+#[test]
+fn all_five_opening_representations_stay_bounded() {
+    let Some(content) = read_fixture() else {
+        return;
+    };
+
+    let entity_index = ifc_lite_core::build_entity_index(&content);
+    let mut decoder = EntityDecoder::with_index(&content, entity_index);
+    let router = GeometryRouter::new();
+
+    // Build the wall→[opening] index. The IfcRelVoidsElement ids in the
+    // fixture are known up-front (it's a 5-wall scratch model), so we
+    // build the index directly from the (wall, opening) pairs above.
+    let mut void_index: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
+    for &(wall_id, opening_id, _) in WALLS {
+        void_index.entry(wall_id).or_default().push(opening_id);
+    }
+
+    let mut failures: Vec<String> = Vec::new();
+
+    for &(wall_id, _opening_id, label) in WALLS {
+        let wall = decoder
+            .decode_by_id(wall_id)
+            .unwrap_or_else(|e| panic!("decode wall #{wall_id} ({e})"));
+        assert_eq!(
+            wall.ifc_type,
+            IfcType::IfcWall,
+            "expected IfcWall at #{wall_id}",
+        );
+
+        let mesh = router
+            .process_element_with_voids(&wall, &mut decoder, &void_index)
+            .unwrap_or_else(|e| panic!("process wall #{wall_id}: {e}"));
+
+        let (wmin, wmax) = mesh_bounds(&mesh);
+
+        // The un-cut wall body spans world z ∈ [0, 3]. Cutting an opening
+        // at z ∈ [1, 2] should NOT shrink the wall's overall z-span —
+        // the wall material above (z > 2) and below (z < 1) the opening
+        // must survive. If the wall mesh suddenly only reaches z = 2 or
+        // starts at z = 1, the cut has eaten material it shouldn't.
+        let span_z = wmax[2] - wmin[2];
+        if !((wmin[2] - 0.0).abs() < 1e-3 && (wmax[2] - 3.0).abs() < 1e-3) {
+            failures.push(format!(
+                "  {label} (#{wall_id}): wall z-span = [{:.4}, {:.4}] (Δ={:.4}) — \
+                 expected [0, 3]; opening eroded the wall outside its z=[1,2] band",
+                wmin[2], wmax[2], span_z,
+            ));
+        }
+
+        // Y-span must also stay [0, 3] — the wall's full length should
+        // survive a y ∈ [0.5, 1.5] opening.
+        if !((wmin[1] - 0.0).abs() < 1e-3 && (wmax[1] - 3.0).abs() < 1e-3) {
+            failures.push(format!(
+                "  {label} (#{wall_id}): wall y-span = [{:.4}, {:.4}] — \
+                 expected [0, 3]; opening eroded the wall outside its y=[0.5,1.5] band",
+                wmin[1], wmax[1],
+            ));
+        }
+
+        // The opening footprint MUST be a genuine hole — there must be
+        // some material immediately above (z just above 2) and below
+        // (z just below 1) the authored opening within its (x, y)
+        // rectangle. If the cut "punches through", the column at the
+        // opening's (x, y) becomes empty everywhere.
+        let (open_min_w, open_max_w) = authored_opening_bounds(wall_id);
+        // Tighten the footprint to the part that actually overlaps the
+        // wall (the partial-overlap walls poke 0.1 m past one face).
+        let opening_in_wall_min = (
+            open_min_w.0.max(wmin[0]),
+            open_min_w.1,
+            open_min_w.2,
+        );
+        let opening_in_wall_max = (
+            open_max_w.0.min(wmax[0]),
+            open_max_w.1,
+            open_max_w.2,
+        );
+        let (z_inside_min, z_inside_max) =
+            z_inside_opening_footprint(&mesh, opening_in_wall_min, opening_in_wall_max);
+
+        // Count vertices below the authored opening (z<0.95), inside the
+        // opening (0.95<z<2.05), and above (z>2.05) — restricted to the
+        // (x,y) column of the opening. A correct cut keeps the below/above
+        // counts unchanged from the un-cut wall (the wall body survives
+        // there) and only removes vertices in the middle band.
+        let mut below_count = 0usize;
+        let mut inside_count = 0usize;
+        let mut above_count = 0usize;
+        for tri in mesh.indices.chunks_exact(3) {
+            let mut centroid = [0.0f32; 3];
+            for &vi in tri {
+                let b = vi as usize * 3;
+                centroid[0] += mesh.positions[b];
+                centroid[1] += mesh.positions[b + 1];
+                centroid[2] += mesh.positions[b + 2];
+            }
+            centroid[0] /= 3.0;
+            centroid[1] /= 3.0;
+            centroid[2] /= 3.0;
+            if centroid[0] < opening_in_wall_min.0
+                || centroid[0] > opening_in_wall_max.0
+                || centroid[1] < opening_in_wall_min.1
+                || centroid[1] > opening_in_wall_max.1
+            {
+                continue;
+            }
+            if centroid[2] < 0.95 {
+                below_count += 1;
+            } else if centroid[2] > 2.05 {
+                above_count += 1;
+            } else {
+                inside_count += 1;
+            }
+        }
+        eprintln!(
+            "[issue-832] {label} (#{wall_id}): wall bbox=[({:.3},{:.3},{:.3})..({:.3},{:.3},{:.3})] \
+             total-tris={} z-inside-footprint=({:.3},{:.3}) \
+             tris-in-footprint below/inside/above = {}/{}/{}",
+            wmin[0], wmin[1], wmin[2], wmax[0], wmax[1], wmax[2],
+            mesh.indices.len() / 3, z_inside_min, z_inside_max,
+            below_count, inside_count, above_count,
+        );
+
+        // The wall body has triangles at its bottom face (z = 0), top face
+        // (z = 3), and the two outer ±0.1 m faces. Inside the opening's
+        // (x, y) column, before the cut, there are triangles below (z<1)
+        // and above (z>2) the authored opening — chunks of the wall's
+        // outer faces. A bounded cut must keep BOTH chunks: removing
+        // either means the opening punched outside its authored z range.
+        if below_count == 0 {
+            failures.push(format!(
+                "  {label} (#{wall_id}): no wall triangles below opening \
+                 (z<0.95) inside its (x,y) footprint — cut extended below \
+                 authored z=[1,2] (most likely the symptom in #832)",
+            ));
+        }
+        if above_count == 0 {
+            failures.push(format!(
+                "  {label} (#{wall_id}): no wall triangles above opening \
+                 (z>2.05) inside its (x,y) footprint — cut extended above \
+                 authored z=[1,2]",
+            ));
+        }
+
+        // Per-face cut signature. The two wall faces of interest are the
+        // -X face at world_x = wall_min, and the +X face at world_x =
+        // wall_max. The opening AABB tells us which face it actually
+        // overlaps; the cut MUST leave the un-overlapped face uncut.
+        // Counting plane-aligned triangles is the simplest invariant: a
+        // pristine wall face is a single rectangle (2 triangles); a cut
+        // face fragments into many.
+        let count_face_tris = |target_x: f32| -> usize {
+            mesh.indices
+                .chunks_exact(3)
+                .filter(|tri| {
+                    tri.iter().all(|&i| {
+                        (mesh.positions[i as usize * 3] - target_x).abs() < 1e-3
+                    })
+                })
+                .count()
+        };
+        let nx_tris = count_face_tris(wmin[0]);
+        let px_tris = count_face_tris(wmax[0]);
+        let opening_touches_minus_x = open_min_w.0 <= wmin[0] + 1e-3;
+        let opening_touches_plus_x = open_max_w.0 >= wmax[0] - 1e-3;
+        eprintln!(
+            "[issue-832]   -X face ({:.3}): {} tris (opening touches: {}); +X face ({:.3}): {} tris (opening touches: {})",
+            wmin[0], nx_tris, opening_touches_minus_x,
+            wmax[0], px_tris, opening_touches_plus_x,
+        );
+        if !opening_touches_minus_x && nx_tris > 2 {
+            failures.push(format!(
+                "  {label} (#{wall_id}): -X face at x={:.3} has {} triangles \
+                 — should be 2 (pristine rectangle), the opening (x ∈ [{:.3}, {:.3}]) \
+                 doesn't reach this face. Cut over-extended through the wall.",
+                wmin[0], nx_tris, open_min_w.0, open_max_w.0,
+            ));
+        }
+        if !opening_touches_plus_x && px_tris > 2 {
+            failures.push(format!(
+                "  {label} (#{wall_id}): +X face at x={:.3} has {} triangles \
+                 — should be 2 (pristine rectangle), the opening (x ∈ [{:.3}, {:.3}]) \
+                 doesn't reach this face. Cut over-extended through the wall.",
+                wmax[0], px_tris, open_min_w.0, open_max_w.0,
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "issue #832 — one or more openings over-cut their host wall:\n{}",
+        failures.join("\n"),
+    );
+}

--- a/tests/models/manifest.json
+++ b/tests/models/manifest.json
@@ -694,6 +694,11 @@
       "size": 56594
     },
     {
+      "path": "issues/832_opening_representations.ifc",
+      "sha256": "0a81eda40a3b575fbcab02db37f1cea7cf9c5dd1d099099a1bb5a5f9f4c64868",
+      "size": 11355
+    },
+    {
       "path": "various/01_BIMcollab_Example_ARC.ifc",
       "sha256": "87392cf24264b023e65d8ca1dab1eb8996643c1aa51b9dff9d518ed8904151fc",
       "size": 18230149


### PR DESCRIPTION
## Summary

`router::voids::extend_opening_along_direction` is a Revit/ArchiCAD heuristic that stretches an opening AABB along its own extrusion axis so the AABB clip lands cleanly on both wall faces. It was designed for the "opening modelled too short to reach both faces" pattern.

When an opening is offset so part of its depth pokes past one wall face — issue #832, a 1 × 1 × 0.2 m opening straddling wall #222's +X face — the heuristic stretched the box across the full wall thickness and the AABB clip removed BOTH the touched and untouched wall faces, producing the "punched-through slot" the reporter saw.

Add a third bail-out gate: if the opening's projection on its own extrusion axis pokes past either wall projection, return the authored bounds. The author's bite is preserved verbatim and the AABB clip only touches wall material the opening actually intersects. Projection-based so the sign of the extrusion direction doesn't matter (the broken case was `+X`; the previously-working `-X` case was getting the right answer by accident — the sign asymmetry was making the union not extend).

## Why prior #821 fix didn't catch this

#821 (PR #834) added a `DifferenceEmptiedHost` fallback inside `boolean.rs::guard_against_full_host_removal` for `IfcBooleanClippingResult` half-spaces. #832 walls use `IfcRelVoidsElement` + `IfcOpeningElement`, which never enter `boolean.rs` — they take the `voids.rs` AABB-clip path. Different mechanism, different code.

## Verification

| wall | opening kind | before fix (-X tris / +X tris) | after fix |
|---|---|---|---|
| #50 | rect, vertical, full thickness | 17 / 19 (both cut, correct) | 17 / 19 |
| #89 | rect, -X stick-out | 17 / 2 (only -X cut, correct) | 17 / 2 |
| #128 | arbitrary, full thickness | 17 / 19 (both cut, correct) | 17 / 19 |
| #175 | arbitrary, -X stick-out | 17 / 2 (only -X cut, correct) | 17 / 2 |
| **#222** | **arbitrary, +X stick-out** | **17 / 19 (both cut → punched-through bug)** | **2 / 19** ← fixed |

## Tests

- `rust/geometry/tests/issue_832_opening_representations.rs` — full pipeline against the reporter's `ifc-opening.ifc` 5-wall fixture, asserting each wall has a bounded hole and any wall face the opening doesn't reach stays a pristine 2-tri rectangle.
- `router::voids::reveal_tests::test_extend_opening_skipped_when_opening_pokes_past_wall` — direct unit test pinning the new gate for both `+X` and `-X` direction polarity.
- Existing #604 coplanarity-pad regression (`test_extend_opening_pads_past_wall_on_exact_match`) untouched — the new gate intentionally does not fire when the opening fits exactly inside the wall.
- Full `cargo test -p ifc-lite-geometry --tests`: green.

Closes #832.

## Fixture upload

Fixture `tests/models/issues/832_opening_representations.ifc` (11 KB, sha256 `0a81eda40a3b…`) is added to `tests/models/manifest.json`. The bytes still need to be uploaded to the `fixtures-v1` GitHub Release — run `pnpm fixtures:upload` after merge.

## Test plan

- [ ] Load `ifc-opening.ifc` in the viewer and confirm wall #222 (rightmost) has a bounded rectangular opening instead of a slot punched to the floor.
- [ ] `pnpm fixtures && cargo test -p ifc-lite-geometry --test issue_832_opening_representations` passes locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed wall openings incorrectly cutting through entire walls when opening boundaries extended past a wall face.

* **Tests**
  * Added comprehensive regression tests including full pipeline and unit tests to prevent recurrence of this issue.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LTplus-AG/ifc-lite/pull/840?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->