### PR TITLE
fix(geometry): IfcRevolvedAreaSolid honors Position and offset axis (#846)

### DIFF
--- a/.changeset/fix-846-revolved-area-solid-position-axis.md
+++ b/.changeset/fix-846-revolved-area-solid-position-axis.md
@@ -1,0 +1,36 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Fix `IfcRevolvedAreaSolid` rendering when the solid's `Position` is not
+identity or the revolution axis is offset from the profile origin
+(issue #846).
+
+The old `RevolvedAreaSolidProcessor` had two bugs:
+
+1. It ignored the `Position` (`IfcAxis2Placement3D`) attribute that
+   places the swept solid's coordinate system in the enclosing
+   representation. The profile and axis values were used as-if in the
+   final object coord system.
+2. It misused the 2D profile vertex `(x, y)` as `(radius, height)`
+   along the axis — only correct when the axis runs through the
+   profile origin along the profile's Y axis. For the reporter's beam
+   the axis sits 1.3 m offset from the profile and points along −Y,
+   so the old code produced a tiny ring near the axis line instead of
+   the authored 45° I-beam sweep.
+
+The fix applies `parse_axis2_placement_3d` to lift the swept-solid
+local coords into the surrounding object frame and rotates each
+profile vertex around the axis line using a proper Rodrigues
+decomposition into parallel and perpendicular components relative to
+the axis direction.
+
+Regression coverage:
+
+- `rust/geometry/tests/issue_846_revolved_beam.rs` — drives the reporter's
+  beam-varying-extrusion-paths fixture. Asserts beam #227 sweeps an arc
+  ≥ 0.9 m long with a ≥ 0.15 m perpendicular profile extent, and that
+  beam #210 (plain extrusion) is unaffected.
+
+Fixture `tests/models/issues/846_revolved_beam.ifc` (4.4 KB) added to
+the manifest.

--- a/.changeset/fix-846-revolved-area-solid-position-axis.md
+++ b/.changeset/fix-846-revolved-area-solid-position-axis.md
@@ -34,3 +34,10 @@ Regression coverage:
 
 Fixture `tests/models/issues/846_revolved_beam.ifc` (4.4 KB) added to
 the manifest.
+
+This PR was branched on top of PR #847 (issue #842 — IfcRationalBSplineSurfaceWithKnots),
+so the manifest update here also carries an `issues/842_rational_bspline_surface.ifc`
+entry inherited from that base. Once #847 lands on `main` and this PR
+rebases, the 842 entry will already be on main and the diff collapses to
+just the 846 entry. Documented per PR #848 review (coderabbit Minor) so
+the scope of the manifest delta is clear.

--- a/.changeset/fix-846-revolved-area-solid-position-axis.md
+++ b/.changeset/fix-846-revolved-area-solid-position-axis.md
@@ -25,12 +25,22 @@ profile vertex around the axis line using a proper Rodrigues
 decomposition into parallel and perpendicular components relative to
 the axis direction.
 
+Second follow-up: after the cap topology was fixed by earcut, the rendered
+I-beam profile still came out as a smooth blob because the side quads and
+caps shared profile-ring vertices — the viewer's vertex-normal averaging
+blended the flange face normal with the perpendicular web face normal at
+every sharp 90° crease in the IPE200 cross-section. Flat-shade the whole
+revolved solid (per-triangle vertex duplication, each triangle carries its
+own face normal) so creases stay crisp.
+
 Regression coverage:
 
 - `rust/geometry/tests/issue_846_revolved_beam.rs` — drives the reporter's
   beam-varying-extrusion-paths fixture. Asserts beam #227 sweeps an arc
-  ≥ 0.9 m long with a ≥ 0.15 m perpendicular profile extent, and that
-  beam #210 (plain extrusion) is unaffected.
+  ≥ 0.9 m long with a ≥ 0.15 m perpendicular profile extent, that beam
+  #210 (plain extrusion) is unaffected, that the cap triangulation is
+  manifold (no edge shared by 3+ triangles), and that the mesh ships
+  per-triangle normals so the renderer can't re-smooth the creases.
 
 Fixture `tests/models/issues/846_revolved_beam.ifc` (4.4 KB) added to
 the manifest.

--- a/rust/geometry/src/processors/swept.rs
+++ b/rust/geometry/src/processors/swept.rs
@@ -11,6 +11,7 @@ use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcSchema, IfcType};
 use nalgebra::Matrix4;
 
 use super::helpers::parse_axis2_placement_3d;
+use super::tessellated::PolygonalFaceSetProcessor;
 use crate::router::GeometryProcessor;
 
 /// Build a rotation-minimising frame (RMF) for sweeping a circular cross-section
@@ -498,6 +499,19 @@ impl GeometryProcessor for RevolvedAreaSolidProcessor {
 
         // Apply Position to lift Position-local coords into object coords.
         apply_transform(&mut mesh, &position_transform);
+
+        // Profile-boundary creases (e.g. flange-to-web on an I-beam) are
+        // all sharp 90° edges, but the swept mesh shares vertices between
+        // adjacent side quads — so per-vertex normal averaging smooths the
+        // shading across every crease and the cross-section reads as a
+        // smooth blob. Flat-shade the whole revolved solid (each triangle
+        // gets its own three vertices with the face normal) so the
+        // shading matches the actual geometry.
+        let flat =
+            PolygonalFaceSetProcessor::build_flat_shaded_mesh(&mesh.positions, &mesh.indices);
+        mesh.positions = flat.positions;
+        mesh.normals = flat.normals;
+        mesh.indices = flat.indices;
 
         Ok(mesh)
     }

--- a/rust/geometry/src/processors/swept.rs
+++ b/rust/geometry/src/processors/swept.rs
@@ -443,52 +443,47 @@ impl GeometryProcessor for RevolvedAreaSolidProcessor {
             }
         }
 
-        // End caps for a partial revolution. Build fan triangles from the
-        // profile centroid for each end ring. Cheap and good enough for the
-        // structural-beam case the IFC spec targets here.
+        // End caps for a partial revolution.
+        //
+        // Originally a fan from the profile centroid to consecutive
+        // boundary points. That assumption only holds for CONVEX
+        // profiles — for a concave profile (I-beam, L-beam, hollow
+        // rectangle …) the centroid lies outside the polygon in some
+        // regions, the fan triangles cross each other, and the cap
+        // renders as a bow-tie/X artifact (issue #846 follow-up: PR
+        // #848 sweep landed correctly but the I-beam cross-section came
+        // out as a zigzag because of this fan path).
+        //
+        // Use earcut on the 2D profile boundary instead. The resulting
+        // triangle indices are in [0..num_profile_points) — they map
+        // 1:1 onto the ring vertices we already emitted, so the cap
+        // just reuses those positions (no new vertices except the side-
+        // wall winding requires flipping one of the two caps so its
+        // outward normal points away from the swept volume).
         if !full_circle && num_profile_points >= 3 {
-            let centroid_2d = {
-                let (sx, sy) = profile_points
-                    .iter()
-                    .fold((0.0, 0.0), |(sx, sy), p| (sx + p.x, sy + p.y));
-                let n = num_profile_points as f64;
-                Point3::new(sx / n, sy / n, 0.0)
-            };
+            let profile_flat: Vec<f64> = profile_points
+                .iter()
+                .flat_map(|p| [p.x, p.y])
+                .collect();
+            let cap_indices = earcutr::earcut(&profile_flat, &[], 2)
+                .map_err(|e| Error::geometry(format!(
+                    "Revolved profile cap triangulation failed: {e:?}"
+                )))?;
 
             for (ring_idx, flip) in [(0usize, true), (segments, false)] {
-                let t = if ring_idx == 0 {
-                    0.0
-                } else {
-                    angle
-                };
-                let cos_t = t.cos();
-                let sin_t = t.sin();
-                let k = axis_direction;
-
-                let v = centroid_2d - axis_location;
-                let v_par = k * v.dot(&k);
-                let v_perp = v - v_par;
-                let v_perp_rot = v_perp * cos_t + k.cross(&v_perp) * sin_t;
-                let center = axis_location + v_par + v_perp_rot;
-
-                let center_idx = (positions.len() / 3) as u32;
-                positions.push(center.x as f32);
-                positions.push(center.y as f32);
-                positions.push(center.z as f32);
-
                 let base = (ring_idx * num_profile_points) as u32;
-                for j in 0..num_profile_points {
-                    let j_next = (j + 1) % num_profile_points;
-                    let a = base + j as u32;
-                    let b = base + j_next as u32;
+                for tri in cap_indices.chunks_exact(3) {
+                    let a = base + tri[0] as u32;
+                    let b = base + tri[1] as u32;
+                    let c = base + tri[2] as u32;
                     if flip {
-                        indices.push(center_idx);
-                        indices.push(b);
                         indices.push(a);
+                        indices.push(c);
+                        indices.push(b);
                     } else {
-                        indices.push(center_idx);
                         indices.push(a);
                         indices.push(b);
+                        indices.push(c);
                     }
                 }
             }

--- a/rust/geometry/src/processors/swept.rs
+++ b/rust/geometry/src/processors/swept.rs
@@ -4,9 +4,13 @@
 
 //! Swept geometry processors - SweptDiskSolid and RevolvedAreaSolid.
 
-use crate::{profiles::ProfileProcessor, Error, Mesh, Point3, Result, Vector3};
+use crate::{
+    extrusion::apply_transform, profiles::ProfileProcessor, Error, Mesh, Point3, Result, Vector3,
+};
 use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcSchema, IfcType};
+use nalgebra::Matrix4;
 
+use super::helpers::parse_axis2_placement_3d;
 use crate::router::GeometryProcessor;
 
 /// Build a rotation-minimising frame (RMF) for sweeping a circular cross-section
@@ -281,42 +285,52 @@ impl GeometryProcessor for RevolvedAreaSolidProcessor {
         decoder: &mut EntityDecoder,
         _schema: &IfcSchema,
     ) -> Result<Mesh> {
-        // IfcRevolvedAreaSolid attributes:
-        // 0: SweptArea (IfcProfileDef) - the 2D profile to revolve
-        // 1: Position (IfcAxis2Placement3D) - placement of the solid
-        // 2: Axis (IfcAxis1Placement) - the axis of revolution
+        // IfcRevolvedAreaSolid attributes (inherits IfcSweptAreaSolid):
+        // 0: SweptArea (IfcProfileDef) - 2D profile in xy plane of Position
+        // 1: Position (IfcAxis2Placement3D) - solid's local coord system
+        // 2: Axis (IfcAxis1Placement) - revolution axis in xy plane of Position
         // 3: Angle (IfcPlaneAngleMeasure) - revolution angle in radians
 
         let profile_attr = entity
             .get(0)
             .ok_or_else(|| Error::geometry("RevolvedAreaSolid missing SweptArea".to_string()))?;
-
         let profile = decoder
             .resolve_ref(profile_attr)?
             .ok_or_else(|| Error::geometry("Failed to resolve SweptArea".to_string()))?;
 
-        // Get axis placement (attribute 2)
+        // Position transform: maps Position-local coords -> object coords.
+        // Optional in some files; default to identity.
+        let position_transform = if let Some(pos_attr) = entity.get(1) {
+            if !pos_attr.is_null() {
+                if let Some(pos_entity) = decoder.resolve_ref(pos_attr)? {
+                    parse_axis2_placement_3d(&pos_entity, decoder)?
+                } else {
+                    Matrix4::identity()
+                }
+            } else {
+                Matrix4::identity()
+            }
+        } else {
+            Matrix4::identity()
+        };
+
         let axis_attr = entity
             .get(2)
             .ok_or_else(|| Error::geometry("RevolvedAreaSolid missing Axis".to_string()))?;
-
         let axis_placement = decoder
             .resolve_ref(axis_attr)?
             .ok_or_else(|| Error::geometry("Failed to resolve Axis".to_string()))?;
 
-        // Get angle (attribute 3)
         let angle = entity
             .get_float(3)
             .ok_or_else(|| Error::geometry("RevolvedAreaSolid missing Angle".to_string()))?;
 
-        // Get the 2D profile points
         let profile_2d = self.profile_processor.process(&profile, decoder)?;
         if profile_2d.outer.is_empty() {
             return Ok(Mesh::new());
         }
 
-        // Parse axis placement to get axis point and direction
-        // IfcAxis1Placement: Location, Axis (optional)
+        // IfcAxis1Placement: 0=Location (IfcCartesianPoint), 1=Axis (IfcDirection, optional)
         let axis_location = {
             let loc_attr = axis_placement
                 .get(0)
@@ -344,138 +358,153 @@ impl GeometryProcessor for RevolvedAreaSolidProcessor {
                     let coords = dir.get(0).and_then(|v| v.as_list()).ok_or_else(|| {
                         Error::geometry("Axis direction missing coordinates".to_string())
                     })?;
-                    Vector3::new(
+                    let raw = Vector3::new(
                         coords.first().and_then(|v| v.as_float()).unwrap_or(0.0),
                         coords.get(1).and_then(|v| v.as_float()).unwrap_or(1.0),
                         coords.get(2).and_then(|v| v.as_float()).unwrap_or(0.0),
-                    )
-                    .normalize()
+                    );
+                    if raw.norm() < 1e-12 {
+                        Vector3::new(0.0, 1.0, 0.0)
+                    } else {
+                        raw.normalize()
+                    }
                 } else {
-                    Vector3::new(0.0, 1.0, 0.0) // Default Y axis
+                    Vector3::new(0.0, 1.0, 0.0)
                 }
             } else {
-                Vector3::new(0.0, 1.0, 0.0) // Default Y axis
+                Vector3::new(0.0, 1.0, 0.0)
             }
         };
 
-        // Generate revolved mesh
-        // Number of segments depends on angle
         let full_circle = angle.abs() >= std::f64::consts::PI * 1.99;
         let segments = if full_circle {
-            24 // Full revolution
+            24
         } else {
-            ((angle.abs() / std::f64::consts::PI * 12.0).ceil() as usize).max(4)
+            ((angle.abs() / std::f64::consts::PI * 12.0).ceil() as usize).max(8)
         };
 
         let profile_points = &profile_2d.outer;
         let num_profile_points = profile_points.len();
 
-        let mut positions = Vec::new();
+        let ring_count = if full_circle { segments } else { segments + 1 };
+        let mut positions = Vec::with_capacity(ring_count * num_profile_points * 3);
         let mut indices = Vec::new();
 
-        // For each segment around the revolution
-        for i in 0..=segments {
-            let t = if full_circle && i == segments {
-                0.0 // Close the loop exactly
+        // Rotate each profile vertex around the axis line in Position-local coords.
+        for i in 0..ring_count {
+            let t = if full_circle {
+                std::f64::consts::TAU * i as f64 / segments as f64
             } else {
                 angle * i as f64 / segments as f64
             };
 
-            // Rotation matrix around axis
             let cos_t = t.cos();
             let sin_t = t.sin();
-            let (ax, ay, az) = (axis_direction.x, axis_direction.y, axis_direction.z);
+            let k = axis_direction;
 
-            // Rodrigues' rotation formula components
-            let k_matrix = |v: Vector3<f64>| -> Vector3<f64> {
-                Vector3::new(
-                    ay * v.z - az * v.y,
-                    az * v.x - ax * v.z,
-                    ax * v.y - ay * v.x,
-                )
+            for p2d in profile_points {
+                // Lift profile vertex into Position-local 3D (xy plane, z=0)
+                let p_local = Point3::new(p2d.x, p2d.y, 0.0);
+
+                // Decompose v = (p_local - axis_location) into parallel + perpendicular
+                // to the axis, then rotate only the perpendicular component by t.
+                let v = p_local - axis_location;
+                let v_par_len = v.dot(&k);
+                let v_par = k * v_par_len;
+                let v_perp = v - v_par;
+                let v_perp_rot = v_perp * cos_t + k.cross(&v_perp) * sin_t;
+
+                let pos_local = axis_location + v_par + v_perp_rot;
+
+                positions.push(pos_local.x as f32);
+                positions.push(pos_local.y as f32);
+                positions.push(pos_local.z as f32);
+            }
+        }
+
+        // Side quads. The last ring connects back to the first only when the
+        // sweep closes the loop (full revolution).
+        let segment_quads = segments;
+        for i in 0..segment_quads {
+            let ring_a = i;
+            let ring_b = (i + 1) % ring_count;
+            for j in 0..num_profile_points {
+                let j_next = (j + 1) % num_profile_points;
+                let a = (ring_a * num_profile_points + j) as u32;
+                let b = (ring_b * num_profile_points + j) as u32;
+                let c = (ring_b * num_profile_points + j_next) as u32;
+                let d = (ring_a * num_profile_points + j_next) as u32;
+                indices.push(a);
+                indices.push(b);
+                indices.push(c);
+                indices.push(a);
+                indices.push(c);
+                indices.push(d);
+            }
+        }
+
+        // End caps for a partial revolution. Build fan triangles from the
+        // profile centroid for each end ring. Cheap and good enough for the
+        // structural-beam case the IFC spec targets here.
+        if !full_circle && num_profile_points >= 3 {
+            let centroid_2d = {
+                let (sx, sy) = profile_points
+                    .iter()
+                    .fold((0.0, 0.0), |(sx, sy), p| (sx + p.x, sy + p.y));
+                let n = num_profile_points as f64;
+                Point3::new(sx / n, sy / n, 0.0)
             };
 
-            // For each point in the profile
-            for (j, p2d) in profile_points.iter().enumerate() {
-                // Profile point in 3D (assume profile is in XY plane, rotated around Y axis)
-                // The 2D profile X becomes distance from axis, Y becomes height along axis
-                let radius = p2d.x;
-                let height = p2d.y;
+            for (ring_idx, flip) in [(0usize, true), (segments, false)] {
+                let t = if ring_idx == 0 {
+                    0.0
+                } else {
+                    angle
+                };
+                let cos_t = t.cos();
+                let sin_t = t.sin();
+                let k = axis_direction;
 
-                // Initial position before rotation (in the plane containing the axis)
-                let v = Vector3::new(radius, 0.0, 0.0);
+                let v = centroid_2d - axis_location;
+                let v_par = k * v.dot(&k);
+                let v_perp = v - v_par;
+                let v_perp_rot = v_perp * cos_t + k.cross(&v_perp) * sin_t;
+                let center = axis_location + v_par + v_perp_rot;
 
-                // Rodrigues' rotation: v_rot = v*cos(t) + (k x v)*sin(t) + k*(k.v)*(1-cos(t))
-                let k_cross_v = k_matrix(v);
-                let k_dot_v = ax * v.x + ay * v.y + az * v.z;
+                let center_idx = (positions.len() / 3) as u32;
+                positions.push(center.x as f32);
+                positions.push(center.y as f32);
+                positions.push(center.z as f32);
 
-                let v_rot =
-                    v * cos_t + k_cross_v * sin_t + axis_direction * k_dot_v * (1.0 - cos_t);
-
-                // Final position = axis_location + height along axis + rotated radius
-                let pos = axis_location + axis_direction * height + v_rot;
-
-                positions.push(pos.x as f32);
-                positions.push(pos.y as f32);
-                positions.push(pos.z as f32);
-
-                // Create triangles (except for the last segment if it connects back)
-                if i < segments && j < num_profile_points - 1 {
-                    let current = (i * num_profile_points + j) as u32;
-                    let next_seg = ((i + 1) * num_profile_points + j) as u32;
-                    let current_next = current + 1;
-                    let next_seg_next = next_seg + 1;
-
-                    // Two triangles per quad
-                    indices.push(current);
-                    indices.push(next_seg);
-                    indices.push(next_seg_next);
-
-                    indices.push(current);
-                    indices.push(next_seg_next);
-                    indices.push(current_next);
+                let base = (ring_idx * num_profile_points) as u32;
+                for j in 0..num_profile_points {
+                    let j_next = (j + 1) % num_profile_points;
+                    let a = base + j as u32;
+                    let b = base + j_next as u32;
+                    if flip {
+                        indices.push(center_idx);
+                        indices.push(b);
+                        indices.push(a);
+                    } else {
+                        indices.push(center_idx);
+                        indices.push(a);
+                        indices.push(b);
+                    }
                 }
             }
         }
 
-        // Add end caps if not a full revolution
-        if !full_circle {
-            // Start cap
-            let start_center_idx = (positions.len() / 3) as u32;
-            let start_center = axis_location
-                + axis_direction
-                    * (profile_points.iter().map(|p| p.y).sum::<f64>()
-                        / profile_points.len() as f64);
-            positions.push(start_center.x as f32);
-            positions.push(start_center.y as f32);
-            positions.push(start_center.z as f32);
-
-            for j in 0..num_profile_points - 1 {
-                indices.push(start_center_idx);
-                indices.push(j as u32 + 1);
-                indices.push(j as u32);
-            }
-
-            // End cap
-            let end_center_idx = (positions.len() / 3) as u32;
-            let end_base = (segments * num_profile_points) as u32;
-            positions.push(start_center.x as f32);
-            positions.push(start_center.y as f32);
-            positions.push(start_center.z as f32);
-
-            for j in 0..num_profile_points - 1 {
-                indices.push(end_center_idx);
-                indices.push(end_base + j as u32);
-                indices.push(end_base + j as u32 + 1);
-            }
-        }
-
-        Ok(Mesh {
+        let mut mesh = Mesh {
             positions,
             normals: Vec::new(),
             indices,
             rtc_applied: false,
-        })
+        };
+
+        // Apply Position to lift Position-local coords into object coords.
+        apply_transform(&mut mesh, &position_transform);
+
+        Ok(mesh)
     }
 
     fn supported_types(&self) -> Vec<IfcType> {

--- a/rust/geometry/src/processors/tessellated.rs
+++ b/rust/geometry/src/processors/tessellated.rs
@@ -494,7 +494,7 @@ impl PolygonalFaceSetProcessor {
     }
 
     #[inline]
-    fn build_flat_shaded_mesh(positions: &[f32], indices: &[u32]) -> Mesh {
+    pub(crate) fn build_flat_shaded_mesh(positions: &[f32], indices: &[u32]) -> Mesh {
         let mut flat_positions: Vec<f32> = Vec::with_capacity(indices.len() * 3);
         let mut flat_normals: Vec<f32> = Vec::with_capacity(indices.len() * 3);
         let mut flat_indices: Vec<u32> = Vec::with_capacity(indices.len());

--- a/rust/geometry/tests/issue_846_revolved_beam.rs
+++ b/rust/geometry/tests/issue_846_revolved_beam.rs
@@ -174,3 +174,66 @@ fn revolved_beam_has_manifold_cap_triangulation() {
         non_manifold_edges.iter().take(5).collect::<Vec<_>>(),
     );
 }
+
+#[test]
+fn revolved_beam_is_flat_shaded_so_creases_stay_sharp() {
+    // Issue #846 second follow-up: after the cap topology was fixed by
+    // earcut, the rendered I-beam profile still looked like a smooth blob.
+    // The cause: side quads + caps shared profile-ring vertices, so the
+    // viewer's vertex-normal averaging blended the flange-face normal with
+    // the perpendicular web-face normal at every crease — every sharp
+    // 90° edge in the IPE200 cross-section came out smoothed.
+    //
+    // Fix: flat-shade the whole revolved solid (per-triangle vertex
+    // duplication, each triangle carries its own face normal). Assert
+    // both invariants the renderer relies on:
+    //   1) positions and normals are parallel arrays (normals populated)
+    //   2) every triangle's three vertex normals are identical → no
+    //      averaging across creases is possible
+    let Some(content) = read_fixture() else { return };
+    let entity_index = ifc_lite_core::build_entity_index(&content);
+    let mut decoder = EntityDecoder::with_index(&content, entity_index);
+    let router = GeometryRouter::with_units(&content, &mut decoder);
+    let beam = decoder
+        .decode_by_id(227)
+        .expect("decode IfcBeam #227 (Revolution)");
+    let mesh = router
+        .process_element(&beam, &mut decoder)
+        .expect("process revolution beam");
+
+    assert_eq!(
+        mesh.normals.len(),
+        mesh.positions.len(),
+        "revolved-solid mesh must ship per-vertex normals; got \
+         {} normal floats for {} position floats — the viewer would \
+         fall back to averaged normals and re-smooth every crease",
+        mesh.normals.len(),
+        mesh.positions.len(),
+    );
+
+    let mut mismatched_triangles = 0usize;
+    for tri in mesh.indices.chunks_exact(3) {
+        let (i0, i1, i2) = (tri[0] as usize, tri[1] as usize, tri[2] as usize);
+        let n0 = &mesh.normals[i0 * 3..i0 * 3 + 3];
+        let n1 = &mesh.normals[i1 * 3..i1 * 3 + 3];
+        let n2 = &mesh.normals[i2 * 3..i2 * 3 + 3];
+        let eq = |a: &[f32], b: &[f32]| {
+            (a[0] - b[0]).abs() < 1e-5
+                && (a[1] - b[1]).abs() < 1e-5
+                && (a[2] - b[2]).abs() < 1e-5
+        };
+        if !(eq(n0, n1) && eq(n1, n2)) {
+            mismatched_triangles += 1;
+        }
+    }
+    assert_eq!(
+        mismatched_triangles, 0,
+        "{} triangles have non-identical vertex normals — the revolved \
+         I-beam is being smooth-shaded again, so creases between the \
+         flange faces and the web will render as a rounded blob \
+         (see swept.rs::process — should call \
+         PolygonalFaceSetProcessor::build_flat_shaded_mesh on the \
+         finished mesh)",
+        mismatched_triangles,
+    );
+}

--- a/rust/geometry/tests/issue_846_revolved_beam.rs
+++ b/rust/geometry/tests/issue_846_revolved_beam.rs
@@ -124,3 +124,53 @@ fn extrusion_beam_unchanged_under_revolved_fix() {
         "expected extrusion beam to span ≈1 m on its long axis, got {max_span}",
     );
 }
+
+#[test]
+fn revolved_beam_has_manifold_cap_triangulation() {
+    // Issue #846 follow-up: the FIRST fix (PR #848) made the sweep curve
+    // land correctly but the end caps were built as a centroid fan — fine
+    // for convex profiles, broken for the I-beam's concave outline.
+    // Visible symptom: the revolved beam's cross-section rendered as a
+    // bowtie/X where adjacent fan triangles crossed each other through
+    // the concave web region of the IPE200 profile.
+    //
+    // Robust catch: an edge that's shared by > 2 triangles is non-manifold,
+    // which is exactly what a bowtie-fan produces (crossed fan triangles
+    // share edges with their neighbours in degenerate ways). Earcut on the
+    // same polygon yields a manifold cap; no edge has more than 2
+    // incidences.
+    let Some(content) = read_fixture() else { return };
+    let entity_index = ifc_lite_core::build_entity_index(&content);
+    let mut decoder = EntityDecoder::with_index(&content, entity_index);
+    let router = GeometryRouter::with_units(&content, &mut decoder);
+    let beam = decoder
+        .decode_by_id(227)
+        .expect("decode IfcBeam #227 (Revolution)");
+    let mesh = router
+        .process_element(&beam, &mut decoder)
+        .expect("process revolution beam");
+
+    let mut edge_count: std::collections::HashMap<(u32, u32), u32> =
+        std::collections::HashMap::new();
+    for tri in mesh.indices.chunks_exact(3) {
+        for k in 0..3 {
+            let a = tri[k];
+            let b = tri[(k + 1) % 3];
+            let key = if a < b { (a, b) } else { (b, a) };
+            *edge_count.entry(key).or_insert(0) += 1;
+        }
+    }
+    let non_manifold_edges: Vec<_> = edge_count
+        .iter()
+        .filter(|(_, &count)| count > 2)
+        .collect();
+    assert!(
+        non_manifold_edges.is_empty(),
+        "{} edges shared by 3+ triangles — cap triangulation is self-\
+         intersecting (the centroid-fan bow-tie that PR #848 follow-up \
+         was supposed to fix; see swept.rs::process for IfcRevolvedAreaSolid).\n\
+         First few: {:?}",
+        non_manifold_edges.len(),
+        non_manifold_edges.iter().take(5).collect::<Vec<_>>(),
+    );
+}

--- a/rust/geometry/tests/issue_846_revolved_beam.rs
+++ b/rust/geometry/tests/issue_846_revolved_beam.rs
@@ -1,0 +1,126 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Regression test for issue #846 — IfcBeam #227 in the
+//! beam-varying-extrusion-paths fixture uses an IfcRevolvedAreaSolid that
+//! references a non-trivial Position offset (0, -100, 0) and a revolution
+//! axis at (-1300, 100, 0) with direction (0,-1,0). The old processor
+//! (a) ignored the IfcSweptAreaSolid Position transform and (b) misused the
+//! 2D profile (x,y) coords as (radius, height) along the axis. The result
+//! was a tiny ring near the axis location instead of the expected 45° arc
+//! sweep of an IPE200 profile around the axis line.
+
+use ifc_lite_core::{EntityDecoder, IfcType};
+use ifc_lite_geometry::GeometryRouter;
+
+const FIXTURE: &str = "../../tests/models/issues/846_revolved_beam.ifc";
+
+fn read_fixture() -> Option<String> {
+    match std::fs::read_to_string(FIXTURE) {
+        Ok(s) => Some(s),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            eprintln!(
+                "skipping issue-846 regression: fixture missing at {FIXTURE} — \
+                 run `pnpm fixtures` to fetch it"
+            );
+            None
+        }
+        Err(e) => panic!("failed to read fixture {FIXTURE}: {e}"),
+    }
+}
+
+fn bounds(mesh: &ifc_lite_geometry::Mesh) -> ([f32; 3], [f32; 3]) {
+    let mut min = [f32::INFINITY; 3];
+    let mut max = [f32::NEG_INFINITY; 3];
+    for chunk in mesh.positions.chunks_exact(3) {
+        for axis in 0..3 {
+            min[axis] = min[axis].min(chunk[axis]);
+            max[axis] = max[axis].max(chunk[axis]);
+        }
+    }
+    (min, max)
+}
+
+#[test]
+fn revolved_beam_sweeps_authored_arc_not_a_degenerate_ring() {
+    let Some(content) = read_fixture() else {
+        return;
+    };
+
+    let entity_index = ifc_lite_core::build_entity_index(&content);
+    let mut decoder = EntityDecoder::with_index(&content, entity_index);
+    let router = GeometryRouter::with_units(&content, &mut decoder);
+
+    let beam = decoder
+        .decode_by_id(227)
+        .expect("decode IfcBeam #227 (Revolution)");
+    assert_eq!(beam.ifc_type, IfcType::IfcBeam);
+
+    let mesh = router
+        .process_element(&beam, &mut decoder)
+        .expect("process revolution beam");
+
+    let tri_count = mesh.indices.len() / 3;
+    assert!(
+        tri_count > 100,
+        "expected non-trivial swept mesh, got {tri_count} triangles",
+    );
+
+    let (min, max) = bounds(&mesh);
+    let span = [max[0] - min[0], max[1] - min[1], max[2] - min[2]];
+
+    // Authored sweep is a 1300 mm-radius IPE200 (200 mm deep flanges) revolved
+    // by 0.79 rad ≈ 45° around an axis offset from the profile origin. The
+    // arc length 1300 mm × 0.79 ≈ 1.03 m must appear in the mesh extents,
+    // and the profile depth (≈ 0.2 m) must show up on a perpendicular axis.
+    // The pre-fix bug produced a tiny ring of order 0.1 m on every axis,
+    // located ≈ 1.3 m from the placement origin (the misused axis location).
+    assert!(
+        span[1] > 0.90,
+        "expected long-axis extent ≥0.90 m (arc length ≈1.03 m), got {} \
+         (full span {span:?}, bounds {min:?}..{max:?})",
+        span[1],
+    );
+    let cross_axis_max = span[0].max(span[2]);
+    assert!(
+        cross_axis_max > 0.15,
+        "expected perpendicular profile extent ≥0.15 m (IPE200 depth ≈0.2 m), \
+         got {cross_axis_max} (full span {span:?})",
+    );
+}
+
+#[test]
+fn extrusion_beam_unchanged_under_revolved_fix() {
+    let Some(content) = read_fixture() else {
+        return;
+    };
+
+    let entity_index = ifc_lite_core::build_entity_index(&content);
+    let mut decoder = EntityDecoder::with_index(&content, entity_index);
+    let router = GeometryRouter::with_units(&content, &mut decoder);
+
+    // Beam #210 is a plain IfcExtrudedAreaSolid — touching the
+    // RevolvedAreaSolidProcessor must not affect the extrusion path.
+    let beam = decoder
+        .decode_by_id(210)
+        .expect("decode IfcBeam #210 (Extrusion)");
+    let mesh = router
+        .process_element(&beam, &mut decoder)
+        .expect("process extrusion beam");
+
+    let tri_count = mesh.indices.len() / 3;
+    assert!(tri_count > 0, "extrusion beam produced no triangles");
+
+    let (min, max) = bounds(&mesh);
+    // The extrusion is a 1 m long IPE200 along world +Z (with local
+    // placement rotation). At minimum the mesh must span ≈ 1 m on its
+    // long axis.
+    let max_span = (max[0] - min[0])
+        .max(max[1] - min[1])
+        .max(max[2] - min[2]);
+    assert!(
+        max_span > 0.9,
+        "expected extrusion beam to span ≈1 m on its long axis, got {max_span}",
+    );
+}


### PR DESCRIPTION
## Summary

`RevolvedAreaSolidProcessor` had two correctness bugs that broke any revolved beam with non-trivial Position or an axis offset from the profile origin:

1. The `IfcSweptAreaSolid.Position` attribute was never applied — profile and axis values were used as-if they were already in the enclosing object frame.
2. The 2D profile vertex `(x, y)` was misused as `(radius, height)` along the axis — only correct when the axis runs through the profile origin in the profile's Y direction.

For the reporter's beam the axis sits 1.3 m offset from the profile pointing along −Y, so the old code produced a tiny ring near the axis line instead of the authored 45° I-beam sweep. The fix lifts swept-solid local coords into the surrounding object frame via `parse_axis2_placement_3d` and rotates each profile vertex around the axis line using a Rodrigues decomposition into components parallel and perpendicular to the axis direction.

Fixes #846.

## Test plan

- [x] `cargo test -p ifc-lite-geometry --test issue_846_revolved_beam` — beam #227 must sweep an arc ≥0.9 m long with a ≥0.15 m perpendicular profile extent; beam #210 (plain extrusion) is unaffected.
- [x] `cargo test -p ifc-lite-geometry` (full suite) — no regressions.
- [ ] Upload fixture `tests/models/issues/846_revolved_beam.ifc` (4.4 KB) to the `fixtures-v1` GitHub Release via `pnpm fixtures:upload` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed incorrect rendering of revolved area solids when the solid's position or revolution axis configuration was non-standard, ensuring accurate geometry computation.

* **Tests**
  * Added regression test coverage for revolved beam geometry to prevent future regressions in swept-solid processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LTplus-AG/ifc-lite/pull/848?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->