### PR TITLE
fix(geometry): render IfcAlignment curves and confirm IfcGeographicElement (#844)

### DIFF
--- a/.changeset/fix-844-alignment-and-geographic-element.md
+++ b/.changeset/fix-844-alignment-and-geographic-element.md
@@ -1,0 +1,32 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Render `IfcAlignment` directrix curves and confirm `IfcGeographicElement`
+terrain meshes load (issue #844).
+
+`IfcGeographicElement` already routes through the standard pipeline —
+its `'Body','Tessellation'` representation hits the existing
+`TriangulatedFaceSetProcessor`. The issue was only ever the
+`IfcAlignment` side: in IFC4X1 the alignment carries its curve in a
+dedicated `Axis` (`IfcAlignmentCurve`) attribute and the file's
+`Representation` is typically `$`, so `process_element` bailed before
+reaching any geometry.
+
+Add `IfcAlignmentProcessor` that consumes the Axis curve via the
+existing `AlignmentCurve` evaluator (full IFC4X1 horizontal + vertical
+parser already used by `SectionedSolidHorizontalProcessor`) and
+samples it at 1 m intervals into a thin triangulated ribbon centred on
+the directrix. Short-circuit `process_element` for `IfcAlignment` so
+the missing-representation path falls through to the ribbon processor.
+
+Regression coverage:
+
+- `rust/geometry/tests/issue_844_terrain_and_alignment.rs` — drives the
+  reporter's IFC4X1 fixture. Verifies both `IfcGeographicElement` #30
+  (Terrain) tessellates and `IfcAlignment` #59 (the 'A1' alignment,
+  8 horizontal + 24 vertical segments) renders as a ribbon spanning
+  more than 2 m on its longest axis.
+
+Fixture `tests/models/issues/844_terrain_and_alignment.ifc` (530 KB)
+added to the manifest.

--- a/rust/geometry/src/processors/alignment.rs
+++ b/rust/geometry/src/processors/alignment.rs
@@ -1,0 +1,144 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! IfcAlignment processor — renders an alignment's directrix curve as a
+//! thin triangulated ribbon so it shows up in the 3D viewer.
+//!
+//! The actual curve evaluation lives in [`crate::alignment::AlignmentCurve`]
+//! (used today by the sectioned-solid processor). Here we just take the
+//! Axis curve referenced by `IfcAlignment` (or any other entity that
+//! `AlignmentCurve::parse` understands), sample it at a fixed station
+//! interval, and emit a flat ribbon two triangles wide per segment along
+//! the alignment's "right" direction.
+
+use crate::alignment::AlignmentCurve;
+use crate::router::GeometryProcessor;
+use crate::{Mesh, Result};
+use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcSchema, IfcType};
+use nalgebra::{Point3, Vector3};
+use std::sync::OnceLock;
+
+fn t_alignment_curve() -> IfcType {
+    // IfcAlignmentCurve is an IFC4X1-only entity; the codegen targets
+    // IFC4X3 so it's not in the enum. Resolve by name and cache.
+    static T: OnceLock<IfcType> = OnceLock::new();
+    *T.get_or_init(|| IfcType::from_str("IFCALIGNMENTCURVE"))
+}
+
+/// IfcAlignment processor — emits a ribbon polyline mesh.
+pub struct IfcAlignmentProcessor;
+
+impl IfcAlignmentProcessor {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for IfcAlignmentProcessor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Station spacing for ribbon sampling, in file length units. The
+/// alignment evaluator returns extrapolated points past either end, so we
+/// stop at exactly the horizontal length to avoid drawing trailing
+/// segments past the authored curve.
+const SAMPLE_STEP_FILE_UNITS: f64 = 1.0;
+/// Width of the rendered ribbon (along the alignment's right-of-travel),
+/// also in file length units. 0.5 m at the alignment's authored scale —
+/// thin enough to read as a curve but wide enough to survive distant
+/// camera angles.
+const RIBBON_HALF_WIDTH_FILE_UNITS: f64 = 0.25;
+
+impl GeometryProcessor for IfcAlignmentProcessor {
+    fn process(
+        &self,
+        entity: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+        _schema: &IfcSchema,
+    ) -> Result<Mesh> {
+        // The Axis curve attribute index depends on the IFC version. Try
+        // the IFC4X1 layout (attribute 7) first, then a small fallback
+        // window — any IfcRef that resolves to a curve we can parse via
+        // AlignmentCurve::parse wins.
+        let curve = locate_axis_curve(entity, decoder)?;
+
+        let alignment = match AlignmentCurve::parse(&curve, decoder)? {
+            Some(a) => a,
+            None => return Ok(Mesh::new()),
+        };
+
+        let length = alignment.horizontal_length();
+        if !(length.is_finite() && length > 0.0) {
+            return Ok(Mesh::new());
+        }
+
+        let sample_count = ((length / SAMPLE_STEP_FILE_UNITS).ceil() as usize).max(1) + 1;
+        let mut left_pts: Vec<Point3<f64>> = Vec::with_capacity(sample_count);
+        let mut right_pts: Vec<Point3<f64>> = Vec::with_capacity(sample_count);
+
+        for i in 0..sample_count {
+            let station = (i as f64 * SAMPLE_STEP_FILE_UNITS).min(length);
+            let frame = alignment.evaluate(station);
+            let offset = frame.right * RIBBON_HALF_WIDTH_FILE_UNITS;
+            left_pts.push(frame.origin - offset);
+            right_pts.push(frame.origin + offset);
+        }
+
+        let n = left_pts.len();
+        let mut mesh = Mesh::with_capacity(n * 2, (n - 1) * 6);
+
+        // Pack vertices: alternating left/right for cache-friendly triangle
+        // indexing — pair (2i, 2i+1) is the cross-section at sample i.
+        let up = Vector3::new(0.0, 0.0, 1.0);
+        for i in 0..n {
+            mesh.add_vertex(left_pts[i], up);
+            mesh.add_vertex(right_pts[i], up);
+        }
+
+        for i in 0..(n - 1) {
+            let a = (i * 2) as u32; // left @ i
+            let b = a + 1; // right @ i
+            let c = a + 2; // left @ i+1
+            let d = a + 3; // right @ i+1
+            // Two triangles per quad, CCW when viewed from +Z.
+            mesh.add_triangle(a, b, d);
+            mesh.add_triangle(a, d, c);
+        }
+
+        Ok(mesh)
+    }
+
+    fn supported_types(&self) -> Vec<IfcType> {
+        vec![IfcType::IfcAlignment]
+    }
+}
+
+/// Resolve the alignment's directrix curve. Tries each plausible attribute
+/// index in turn — IFC4X1 puts Axis at 7, some IFC4X3 publishers reuse
+/// Representation (6), and a few experimental variants hang it at 8.
+fn locate_axis_curve(
+    entity: &DecodedEntity,
+    decoder: &mut EntityDecoder,
+) -> Result<DecodedEntity> {
+    for idx in [7usize, 8, 6] {
+        let Some(attr) = entity.get(idx) else { continue };
+        if attr.is_null() {
+            continue;
+        }
+        let Some(resolved) = decoder.resolve_ref(attr)? else {
+            continue;
+        };
+        if resolved.ifc_type == t_alignment_curve()
+            || resolved.ifc_type == IfcType::IfcPolyline
+        {
+            return Ok(resolved);
+        }
+    }
+    Err(crate::Error::geometry(
+        "IfcAlignment missing recognisable Axis curve (expected IfcAlignmentCurve or IfcPolyline)"
+            .to_string(),
+    ))
+}

--- a/rust/geometry/src/processors/alignment.rs
+++ b/rust/geometry/src/processors/alignment.rs
@@ -45,7 +45,20 @@ impl Default for IfcAlignmentProcessor {
 /// alignment evaluator returns extrapolated points past either end, so we
 /// stop at exactly the horizontal length to avoid drawing trailing
 /// segments past the authored curve.
+///
+/// Assumes the file unit ≈ 1 metre. For non-metre files (millimetre
+/// authoring is common on infrastructure models) a 1 km alignment in
+/// mm would emit 1,000,001 samples and OOM/hang the geometry pass
+/// (PR #849 chatgpt-codex P1 review). [`MAX_SAMPLES`] caps the count
+/// and falls back to a coarser, length-proportional step when this
+/// constant would generate too many — robust against any unit choice
+/// without needing a routing/unit-scale plumbing change.
 const SAMPLE_STEP_FILE_UNITS: f64 = 1.0;
+/// Hard cap on samples per alignment — prevents pathological
+/// unit/length combinations from exploding the mesh. A 5 km alignment
+/// at 1 m steps is well under this; mm-unit files trigger the
+/// length-proportional fallback step below.
+const MAX_SAMPLES: usize = 5_000;
 /// Width of the rendered ribbon (along the alignment's right-of-travel),
 /// also in file length units. 0.5 m at the alignment's authored scale —
 /// thin enough to read as a curve but wide enough to survive distant
@@ -75,12 +88,21 @@ impl GeometryProcessor for IfcAlignmentProcessor {
             return Ok(Mesh::new());
         }
 
-        let sample_count = ((length / SAMPLE_STEP_FILE_UNITS).ceil() as usize).max(1) + 1;
+        // Adaptive sample step: prefer the 1-file-unit default, but fall
+        // back to a length-proportional step when that would exceed
+        // [`MAX_SAMPLES`] (the case for sub-metre file units on long
+        // alignments — issue raised in PR #849 review).
+        let raw_count = ((length / SAMPLE_STEP_FILE_UNITS).ceil() as usize).max(1);
+        let (sample_step, sample_count) = if raw_count > MAX_SAMPLES {
+            (length / MAX_SAMPLES as f64, MAX_SAMPLES + 1)
+        } else {
+            (SAMPLE_STEP_FILE_UNITS, raw_count + 1)
+        };
         let mut left_pts: Vec<Point3<f64>> = Vec::with_capacity(sample_count);
         let mut right_pts: Vec<Point3<f64>> = Vec::with_capacity(sample_count);
 
         for i in 0..sample_count {
-            let station = (i as f64 * SAMPLE_STEP_FILE_UNITS).min(length);
+            let station = (i as f64 * sample_step).min(length);
             let frame = alignment.evaluate(station);
             let offset = frame.right * RIBBON_HALF_WIDTH_FILE_UNITS;
             left_pts.push(frame.origin - offset);

--- a/rust/geometry/src/processors/mod.rs
+++ b/rust/geometry/src/processors/mod.rs
@@ -20,6 +20,7 @@
 
 mod advanced;
 mod advanced_face;
+mod alignment;
 mod boolean;
 mod brep;
 mod csg_primitive;
@@ -37,6 +38,7 @@ mod tests;
 
 // Re-export all processor types
 pub use advanced::{AdvancedBrepProcessor, BSplineSurfaceProcessor};
+pub use alignment::IfcAlignmentProcessor;
 pub use boolean::BooleanClippingProcessor;
 pub use brep::{
     FaceBasedSurfaceModelProcessor, FacetedBrepProcessor, ShellBasedSurfaceModelProcessor,

--- a/rust/geometry/src/router/mod.rs
+++ b/rust/geometry/src/router/mod.rs
@@ -21,10 +21,10 @@ use crate::material_layer_index::MaterialLayerIndex;
 use crate::processors::{
     AdvancedBrepProcessor, BSplineSurfaceProcessor, BlockProcessor, BooleanClippingProcessor,
     CsgSolidProcessor, ExtrudedAreaSolidProcessor, ExtrudedAreaSolidTaperedProcessor,
-    FaceBasedSurfaceModelProcessor, FacetedBrepProcessor, MappedItemProcessor,
-    PolygonalFaceSetProcessor, RevolvedAreaSolidProcessor, SectionedSolidHorizontalProcessor,
-    ShellBasedSurfaceModelProcessor, SphereProcessor, SweptDiskSolidProcessor,
-    TriangulatedFaceSetProcessor,
+    FaceBasedSurfaceModelProcessor, FacetedBrepProcessor, IfcAlignmentProcessor,
+    MappedItemProcessor, PolygonalFaceSetProcessor, RevolvedAreaSolidProcessor,
+    SectionedSolidHorizontalProcessor, ShellBasedSurfaceModelProcessor, SphereProcessor,
+    SweptDiskSolidProcessor, TriangulatedFaceSetProcessor,
 };
 use crate::{BoolFailure, Mesh, Result};
 use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcSchema, IfcType};
@@ -230,6 +230,7 @@ impl GeometryRouter {
         router.register(Box::new(BlockProcessor::new()));
         router.register(Box::new(SphereProcessor::new()));
         router.register(Box::new(CsgSolidProcessor::new()));
+        router.register(Box::new(IfcAlignmentProcessor::new()));
 
         router
     }

--- a/rust/geometry/src/router/processing.rs
+++ b/rust/geometry/src/router/processing.rs
@@ -369,6 +369,17 @@ impl GeometryRouter {
         element: &DecodedEntity,
         decoder: &mut EntityDecoder,
     ) -> Result<Mesh> {
+        // IfcAlignment carries its directrix curve in a dedicated `Axis`
+        // attribute (IFC4X1) instead of (or in addition to) a normal
+        // IfcShapeRepresentation. Route those through the alignment
+        // processor before the standard representation walk, since the
+        // Representation is often `$` in practice.
+        if element.ifc_type == IfcType::IfcAlignment {
+            if let Some(mesh) = self.try_alignment_mesh(element, decoder)? {
+                return Ok(mesh);
+            }
+        }
+
         // Get representation (attribute 6 for most building elements)
         // IfcProduct: GlobalId, OwnerHistory, Name, Description, ObjectType, ObjectPlacement, Representation, Tag
         let representation_attr = element.get(6).ok_or_else(|| {
@@ -1094,5 +1105,33 @@ impl GeometryRouter {
         }
 
         Ok(mesh)
+    }
+
+    /// Run an `IfcAlignment` through the dedicated alignment processor, then
+    /// apply the standard unit scale + placement transform. Returns `None`
+    /// when the alignment has no recognisable directrix curve (the caller
+    /// falls back to normal representation processing).
+    fn try_alignment_mesh(
+        &self,
+        element: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+    ) -> Result<Option<Mesh>> {
+        let processor = match self.processors.get(&IfcType::IfcAlignment) {
+            Some(p) => Arc::clone(p),
+            None => return Ok(None),
+        };
+        let mut mesh = match processor.process(element, decoder, &self.schema) {
+            Ok(m) => m,
+            // Missing Axis or unparseable curve isn't fatal — fall back so
+            // the caller can still walk a normal representation if present.
+            Err(_) => return Ok(None),
+        };
+        if mesh.positions.is_empty() {
+            return Ok(None);
+        }
+        mesh.validate_indices();
+        self.scale_mesh(&mut mesh);
+        self.apply_placement(element, decoder, &mut mesh)?;
+        Ok(Some(mesh))
     }
 }

--- a/rust/geometry/tests/issue_844_terrain_and_alignment.rs
+++ b/rust/geometry/tests/issue_844_terrain_and_alignment.rs
@@ -1,0 +1,116 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Regression test for issue #844 — IfcGeographicElement (terrain) and
+//! IfcAlignment (alignment curves) failed to render.
+//!
+//! `IfcGeographicElement` carries a normal 'Body','Tessellation'
+//! representation with an `IfcTriangulatedFaceSet`, which the existing
+//! dispatcher handles. The new ground IS recognised as a renderable
+//! `IfcProduct` (`is_subtype_of(IfcElement)`); we just need to make sure
+//! the existing pipeline reaches it.
+//!
+//! `IfcAlignment` carries its directrix in a dedicated `Axis`
+//! (`IfcAlignmentCurve`) attribute instead of `Representation`. The new
+//! `IfcAlignmentProcessor` samples that curve into a thin triangulated
+//! ribbon. This test covers both paths against the reporter's fixture.
+
+use ifc_lite_core::{has_geometry_by_name, EntityDecoder, IfcType};
+use ifc_lite_geometry::GeometryRouter;
+
+const FIXTURE: &str = "../../tests/models/issues/844_terrain_and_alignment.ifc";
+
+fn read_fixture() -> Option<String> {
+    match std::fs::read_to_string(FIXTURE) {
+        Ok(s) => Some(s),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            eprintln!(
+                "skipping issue-844 regression: fixture missing at {FIXTURE} — \
+                 run `pnpm fixtures` to fetch it"
+            );
+            None
+        }
+        Err(e) => panic!("failed to read fixture {FIXTURE}: {e}"),
+    }
+}
+
+#[test]
+fn geographic_element_terrain_mesh_renders() {
+    let Some(content) = read_fixture() else {
+        return;
+    };
+
+    let entity_index = ifc_lite_core::build_entity_index(&content);
+    let mut decoder = EntityDecoder::with_index(&content, entity_index);
+    let router = GeometryRouter::with_units(&content, &mut decoder);
+
+    // IfcGeographicElement must be recognised as a renderable product.
+    assert!(
+        has_geometry_by_name("IFCGEOGRAPHICELEMENT"),
+        "IFCGEOGRAPHICELEMENT should be classified as a geometry-bearing IfcProduct",
+    );
+
+    // #30 = first IfcGeographicElement (Terrain) — Body / Tessellation.
+    let terrain = decoder
+        .decode_by_id(30)
+        .expect("decode IfcGeographicElement #30");
+    assert_eq!(terrain.ifc_type, IfcType::IfcGeographicElement);
+
+    let mesh = router
+        .process_element(&terrain, &mut decoder)
+        .expect("process terrain element");
+
+    assert!(
+        mesh.indices.len() / 3 > 10,
+        "expected the terrain mesh to tessellate to >10 triangles, got {}",
+        mesh.indices.len() / 3,
+    );
+}
+
+#[test]
+fn alignment_curve_renders_as_ribbon() {
+    let Some(content) = read_fixture() else {
+        return;
+    };
+
+    let entity_index = ifc_lite_core::build_entity_index(&content);
+    let mut decoder = EntityDecoder::with_index(&content, entity_index);
+    let router = GeometryRouter::with_units(&content, &mut decoder);
+
+    // IfcAlignment passes the renderable-product classifier.
+    assert!(
+        has_geometry_by_name("IFCALIGNMENT"),
+        "IFCALIGNMENT should be classified as a geometry-bearing IfcProduct",
+    );
+
+    // #59 = 'A1' — the longest alignment (8 horizontal + 24 vertical
+    // segments), good for exercising the ribbon sampler.
+    let alignment = decoder.decode_by_id(59).expect("decode IfcAlignment #59");
+    assert_eq!(alignment.ifc_type, IfcType::IfcAlignment);
+
+    let mesh = router
+        .process_element(&alignment, &mut decoder)
+        .expect("process alignment");
+
+    let tri_count = mesh.indices.len() / 3;
+    assert!(
+        tri_count > 50,
+        "expected the alignment ribbon to span many segments, got {tri_count} triangles",
+    );
+
+    // Ribbon must form a contiguous span — at least 2 m on its longest axis.
+    let mut min = [f32::INFINITY; 3];
+    let mut max = [f32::NEG_INFINITY; 3];
+    for chunk in mesh.positions.chunks_exact(3) {
+        for axis in 0..3 {
+            min[axis] = min[axis].min(chunk[axis]);
+            max[axis] = max[axis].max(chunk[axis]);
+        }
+    }
+    let longest = (max[0] - min[0]).max(max[1] - min[1]).max(max[2] - min[2]);
+    assert!(
+        longest > 2.0,
+        "alignment ribbon collapsed (longest axis span = {longest} m)",
+    );
+}

--- a/rust/wasm-bindings/src/api/gpu_meshes.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes.rs
@@ -187,9 +187,17 @@ impl IfcAPI {
 
             // Decode and process the entity
             if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
-                // Check if entity actually has representation (attribute index 6 for IfcProduct)
+                // Check if entity actually has representation (attribute index 6 for IfcProduct).
+                // IfcAlignment is the documented exception: its Axis curve is on
+                // attr 7, and `Representation` (attr 6) is conventionally `$`.
+                // The geometry router has a dedicated early branch for that
+                // case (see `processing.rs::process_element` → `try_alignment_mesh`),
+                // so let alignments through regardless of attr 6 (PR #849 fix —
+                // pre-fix, the user reported the terrain rendered but the
+                // alignment curves did not because this guard short-circuited).
                 let has_representation = entity.get(6).map(|a| !a.is_null()).unwrap_or(false);
-                if !has_representation {
+                let is_alignment = entity.ifc_type == ifc_lite_core::IfcType::IfcAlignment;
+                if !has_representation && !is_alignment {
                     web_sys::console::debug_1(
                         &format!(
                             "[IFC-LITE] #{} ({}) has no representation — skipping geometry",
@@ -597,8 +605,12 @@ impl IfcAPI {
             }
 
             if let Ok(entity) = decoder.decode_at_with_id(id, job_start, job_end) {
+                // IfcAlignment exception — see the equivalent guard in
+                // `parse_meshes`; Axis curve lives on attr 7 and the router
+                // routes through `try_alignment_mesh`.
                 let has_representation = entity.get(6).map(|a| !a.is_null()).unwrap_or(false);
-                if !has_representation {
+                let is_alignment = entity.ifc_type == ifc_lite_core::IfcType::IfcAlignment;
+                if !has_representation && !is_alignment {
                     continue;
                 }
 
@@ -2090,9 +2102,11 @@ impl IfcAPI {
             }
 
             if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
-                // Check if entity has representation
+                // Check if entity has representation. IfcAlignment exception
+                // — see the equivalent guard in `parse_meshes`.
                 let has_representation = entity.get(6).map(|a| !a.is_null()).unwrap_or(false);
-                if !has_representation {
+                let is_alignment = entity.ifc_type == ifc_lite_core::IfcType::IfcAlignment;
+                if !has_representation && !is_alignment {
                     continue;
                 }
 
@@ -3601,8 +3615,10 @@ impl IfcAPI {
             }
 
             if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
+                // IfcAlignment exception — see `parse_meshes`.
                 let has_representation = entity.get(6).map(|a| !a.is_null()).unwrap_or(false);
-                if !has_representation {
+                let is_alignment = entity.ifc_type == ifc_lite_core::IfcType::IfcAlignment;
+                if !has_representation && !is_alignment {
                     continue;
                 }
 
@@ -4248,8 +4264,10 @@ impl IfcAPI {
             let end = chunk[2] as usize;
 
             if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
+                // IfcAlignment exception — see `parse_meshes`.
                 let has_representation = entity.get(6).map(|a| !a.is_null()).unwrap_or(false);
-                if !has_representation {
+                let is_alignment = entity.ifc_type == ifc_lite_core::IfcType::IfcAlignment;
+                if !has_representation && !is_alignment {
                     continue;
                 }
 

--- a/tests/models/manifest.json
+++ b/tests/models/manifest.json
@@ -704,6 +704,16 @@
       "size": 5852
     },
     {
+      "path": "issues/844_terrain_and_alignment.ifc",
+      "sha256": "f6124170e390ed865120985dbd0e6fd38d5c9caae97dd41082031d3246e6a096",
+      "size": 543228
+    },
+    {
+      "path": "issues/846_revolved_beam.ifc",
+      "sha256": "69c2ddfa79087eb24ccd7ba8b8be7fff9135b09251934022959723da5e88c578",
+      "size": 4394
+    },
+    {
       "path": "issues/854_air_terminal_hollow_fillet.ifc",
       "sha256": "0ae00c7883d10a5df32646efba3e4ce70886746e17ac507e649801e11ca3161a",
       "size": 14476


### PR DESCRIPTION
## Summary

- `IfcGeographicElement` already routes cleanly through the standard pipeline — its `'Body','Tessellation'` representation hits the existing `TriangulatedFaceSetProcessor`. The issue was only the `IfcAlignment` side.
- In IFC4X1 the alignment carries its curve in a dedicated `Axis` (`IfcAlignmentCurve`) attribute and the file's `Representation` is typically `\$`, so `process_element` bailed before reaching any geometry.
- Add `IfcAlignmentProcessor` that consumes the Axis curve via the existing `AlignmentCurve` evaluator (full IFC4X1 horizontal + vertical parser already used by `SectionedSolidHorizontalProcessor`) and samples it at 1 m intervals into a thin triangulated ribbon centred on the directrix.
- Short-circuit `process_element` for `IfcAlignment` so the missing-representation path falls through to the ribbon processor.

Fixes #844.

## Test plan

- [x] `cargo test -p ifc-lite-geometry --test issue_844_terrain_and_alignment` — verifies `IfcGeographicElement` #30 (Terrain) tessellates and `IfcAlignment` #59 (the 'A1' alignment with 8 horizontal + 24 vertical segments) renders as a ribbon spanning more than 2 m on its longest axis.
- [x] `cargo test -p ifc-lite-geometry` (full suite) — no regressions.
- [ ] Upload fixture `tests/models/issues/844_terrain_and_alignment.ifc` (530 KB) to the `fixtures-v1` GitHub Release via `pnpm fixtures:upload` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * IFC alignment directrix curves now render as ribbon meshes.
  * IFC geographic element terrain meshes confirmed to load properly.

* **Tests**
  * Added regression tests for alignment and geographic element rendering.

* **Chores**
  * Updated fixture manifest with new test models.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LTplus-AG/ifc-lite/pull/849?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->