### PR TITLE
chore(vercel): skip the threaded wasm-pack compile on deploys

### DIFF
--- a/packages/wasm-threaded/package.json
+++ b/packages/wasm-threaded/package.json
@@ -11,6 +11,9 @@
   "scripts": {
     "build": "node ../../scripts/run-build-wasm.mjs --threaded"
   },
+  "devDependencies": {
+    "@ifc-lite/wasm": "workspace:^"
+  },
   "license": "MPL-2.0",
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1358,7 +1358,11 @@ importers:
 
   packages/wasm: {}
 
-  packages/wasm-threaded: {}
+  packages/wasm-threaded:
+    devDependencies:
+      '@ifc-lite/wasm':
+        specifier: workspace:^
+        version: link:../wasm
 
 packages:
 

--- a/scripts/run-build-wasm.mjs
+++ b/scripts/run-build-wasm.mjs
@@ -10,8 +10,8 @@
  * without Unix-style inline env assignment.
  */
 
+import { cpSync, existsSync, mkdirSync, rmSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { patchThreadedDevStub } from './lib/patch-threaded-stub.mjs';
@@ -22,6 +22,42 @@ const script = resolve(rootDir, 'scripts/build-wasm.sh');
 
 const threaded =
   process.argv.includes('--threaded') || process.env.THREADED === '1';
+
+// Vercel cost-cutter: when IFC_LITE_THREADED_STUB=1 is set AND we're
+// building the threaded bundle, skip the second 2m+ wasm-pack compile.
+// The published threaded path is gated behind
+// `localStorage['ifc-lite:single-controller']==='1'` and the controller
+// worker already falls back to per-task serial execution when
+// `initThreadPool` is a no-op (see apps/viewer/src/hooks/useIfcLoader.ts).
+// So we copy the already-built single-thread pkg into the threaded
+// destination and use `patchThreadedDevStub` to add the no-op
+// `initThreadPool` re-export. Same trick `scripts/fetch-prebuilt-wasm.mjs`
+// uses for offline-from-npm dev installs.
+if (threaded && process.env.IFC_LITE_THREADED_STUB === '1') {
+  const sourcePkg = resolve(rootDir, 'packages/wasm/pkg');
+  const destPkg = resolve(rootDir, 'packages/wasm-threaded/pkg');
+
+  if (!existsSync(sourcePkg)) {
+    console.error(
+      `❌ IFC_LITE_THREADED_STUB=1 set but source pkg ${sourcePkg} is missing.\n` +
+        '   The single-thread @ifc-lite/wasm build must run first. Check that\n' +
+        '   turbo sequences `@ifc-lite/wasm:build` before `@ifc-lite/wasm-threaded:build`.',
+    );
+    process.exit(1);
+  }
+
+  rmSync(destPkg, { recursive: true, force: true });
+  mkdirSync(destPkg, { recursive: true });
+  cpSync(sourcePkg, destPkg, { recursive: true, force: true });
+
+  patchThreadedDevStub(destPkg);
+  console.log(
+    `🧵 IFC_LITE_THREADED_STUB=1 → copied ${sourcePkg} → ${destPkg}\n` +
+      '   (threaded bundle stubbed; opt-in single-controller path falls back\n' +
+      '   to per-task serial execution per useIfcLoader.ts).',
+  );
+  process.exit(0);
+}
 
 function findBash() {
   if (process.platform === 'win32') {

--- a/scripts/vercel-build.sh
+++ b/scripts/vercel-build.sh
@@ -59,6 +59,17 @@ else
   echo "   Set TURBO_TEAM + TURBO_TOKEN in the Vercel project env to enable."
 fi
 
+# Skip the second wasm-pack compile for @ifc-lite/wasm-threaded.
+# scripts/run-build-wasm.mjs honours this env var by copying the
+# single-thread pkg/ output into the threaded destination and stubbing
+# `initThreadPool` to a no-op. The published threaded path is gated
+# behind a localStorage flag; opt-in users on Vercel previews get the
+# documented per-task serial fallback (no perf regression in default
+# traffic). Override locally with IFC_LITE_THREADED_STUB=0 to rebuild
+# the real threaded bundle.
+export IFC_LITE_THREADED_STUB="${IFC_LITE_THREADED_STUB:-1}"
+echo "🧵 IFC_LITE_THREADED_STUB=$IFC_LITE_THREADED_STUB (stub threaded bundle from single-thread pkg)"
+
 echo "🏗️  Vercel build phase"
 echo "   HOME=$HOME  PWD=$PWD"
 RUSTUP_BIN=$(command -v rustup 2>/dev/null || true)


### PR DESCRIPTION
## Summary

Halves Vercel's Rust compile cost by stubbing the second wasm-pack invocation. Default traffic doesn't load the threaded bundle anyway — it's gated behind `localStorage['ifc-lite:single-controller']==='1'` and `useIfcLoader.ts:2050` already documents the per-task serial fallback for when `initThreadPool` isn't real.

Mechanism: when `IFC_LITE_THREADED_STUB=1`, `scripts/run-build-wasm.mjs --threaded` copies the already-built `packages/wasm/pkg/` into `packages/wasm-threaded/pkg/` and runs `patchThreadedDevStub` to inject a no-op `initThreadPool` export. Same trick `scripts/fetch-prebuilt-wasm.mjs` uses for offline dev installs.

`scripts/vercel-build.sh` sets `IFC_LITE_THREADED_STUB=1` by default. Override locally (e.g. for a manual single-controller QA preview) with `IFC_LITE_THREADED_STUB=0`.

To make the copy actually find a source, `@ifc-lite/wasm-threaded` now declares `@ifc-lite/wasm` as a workspace devDependency. Turbo's `dependsOn: ["^build"]` picks up the new edge and sequences `@ifc-lite/wasm:build` before `@ifc-lite/wasm-threaded:build`. Without the dep the two tasks ran in parallel and the stub path would have no source.

## Test plan

- [x] `IFC_LITE_THREADED_STUB=1 node scripts/run-build-wasm.mjs --threaded` copies + stubs in <1s instead of running cargo.
- [x] `pnpm --filter @ifc-lite/viewer build` resolves `@ifc-lite/wasm-threaded` against the stubbed pkg and finishes vite build successfully.
- [x] `npx turbo build --filter=@ifc-lite/wasm-threaded --dry=json` shows `@ifc-lite/wasm-threaded` depends on `@ifc-lite/wasm#build`.
- [x] Omitting `IFC_LITE_THREADED_STUB` (or setting it to `0`) keeps the existing wasm-pack threaded build behaviour.
- [ ] Verify on the next Vercel deploy: only the single-thread compile runs (the `@ifc-lite/wasm-threaded:build` task should print `🧵 IFC_LITE_THREADED_STUB=1 → copied …` instead of the cargo lines).

## Trade-offs

Opt-in single-controller users hitting a Vercel preview will not get rayon parallelism in their threaded bundle — they get the same per-task serial fallback that already covers Safari and non-COOP environments. No regression for the 99.9% of users who never flip that localStorage key.

If we ever need a real threaded preview, push with `IFC_LITE_THREADED_STUB=0` in the Vercel project env temporarily.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced WASM build infrastructure with improved cross-platform compatibility in build scripts
  * Streamlined threaded WASM module build workflow with optimized configuration logic
  * Updated deployment build process with refined environment variable settings for consistent package generation across environments

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LTplus-AG/ifc-lite/pull/857?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->