### PR TITLE
fix(geometry): IfcRectangleHollowProfileDef honours fillet radii (#854)

### DIFF
--- a/rust/geometry/src/profiles.rs
+++ b/rust/geometry/src/profiles.rs
@@ -400,6 +400,63 @@ fn same_point_3d(prev: Option<&Point3<f64>>, next: &Point3<f64>) -> bool {
     }
 }
 
+/// Build a rectangle outline with quarter-circle fillets at the four
+/// corners. Used by `IfcRectangleHollowProfileDef` (outer + inner loops)
+/// — see issue #854 for the case where the inner fillet equals the inner
+/// half-dim and the loop degenerates to a full circle.
+///
+/// * `half_x` / `half_y` — half-extents of the rectangle, centred on origin.
+/// * `radius` — fillet radius. `0` (or below 1 µm) emits sharp corners.
+///   Caller must clamp to ≤ `min(half_x, half_y)`.
+/// * `ccw` — output orientation. Profile outer loops are CCW; hole loops
+///   are CW (per `Profile2D::add_hole`'s contract).
+fn rounded_rectangle_outline(
+    half_x: f64,
+    half_y: f64,
+    radius: f64,
+    ccw: bool,
+) -> Vec<Point2<f64>> {
+    if radius <= 1.0e-9 {
+        let pts = vec![
+            Point2::new(-half_x, -half_y),
+            Point2::new(half_x, -half_y),
+            Point2::new(half_x, half_y),
+            Point2::new(-half_x, half_y),
+        ];
+        return if ccw {
+            pts
+        } else {
+            pts.into_iter().rev().collect()
+        };
+    }
+
+    // 6 segments per corner matches `process_rounded_rectangle` — keeps
+    // the outline cheap and the surface-of-revolution-style extrusions
+    // these profiles drive (HVAC diffuser shells, hollow tubular sections)
+    // under the legacy BSP 128-poly cap.
+    const SEGMENTS_PER_CORNER: usize = 6;
+    let half_pi = PI / 2.0;
+    let corners = [
+        (half_x - radius, -half_y + radius, -half_pi, 0.0),
+        (half_x - radius, half_y - radius, 0.0, half_pi),
+        (-half_x + radius, half_y - radius, half_pi, PI),
+        (-half_x + radius, -half_y + radius, PI, PI + half_pi),
+    ];
+
+    let mut points = Vec::with_capacity((SEGMENTS_PER_CORNER + 1) * 4);
+    for (cx, cy, a0, a1) in corners {
+        for i in 0..=SEGMENTS_PER_CORNER {
+            let t = i as f64 / SEGMENTS_PER_CORNER as f64;
+            let a = a0 + (a1 - a0) * t;
+            points.push(Point2::new(cx + radius * a.cos(), cy + radius * a.sin()));
+        }
+    }
+    if !ccw {
+        points.reverse();
+    }
+    points
+}
+
 /// Profile processor - processes IFC profiles into 2D contours
 pub struct ProfileProcessor {
     schema: IfcSchema,
@@ -1017,6 +1074,19 @@ impl ProfileProcessor {
 
     /// Process rectangle hollow profile (rectangular tube)
     /// IfcRectangleHollowProfileDef: ProfileType, ProfileName, Position, XDim, YDim, WallThickness, InnerFilletRadius, OuterFilletRadius
+    ///
+    /// Both fillet radii are optional in the schema. When set, they replace the
+    /// sharp 90° corners with quarter-circle arcs:
+    ///
+    /// * `OuterFilletRadius = R_o` rounds each outer corner with radius R_o.
+    /// * `InnerFilletRadius = R_i` rounds the corresponding inner corner. When
+    ///   `R_i == min(inner_half_x, inner_half_y)` the four inner arcs meet and
+    ///   the inner hole degenerates to a circle (issue #854 — RHS with a thin
+    ///   wall and circular bore, common for HVAC diffusers).
+    ///
+    /// The standard requires `R_o >= R_i + WallThickness` for a uniform-thickness
+    /// shell, but BIM authoring tools sometimes violate that; we tessellate
+    /// whatever radii were authored and let the renderer show the result.
     fn process_rectangle_hollow(&self, profile: &DecodedEntity) -> Result<Profile2D> {
         let x_dim = profile
             .get_float(3)
@@ -1042,21 +1112,27 @@ impl ProfileProcessor {
         let inner_half_x = half_x - wall_thickness;
         let inner_half_y = half_y - wall_thickness;
 
-        // Outer rectangle (counter-clockwise)
-        let outer_points = vec![
-            Point2::new(-half_x, -half_y),
-            Point2::new(half_x, -half_y),
-            Point2::new(half_x, half_y),
-            Point2::new(-half_x, half_y),
-        ];
+        // InnerFilletRadius is attr 6, OuterFilletRadius is attr 7. Both
+        // optional; `None` (or a value below 1 µm) collapses to sharp
+        // corners. Clamp to the half-extent so an authored value larger
+        // than the inner half-dim doesn't fold the polygon inside-out.
+        let inner_fillet = profile
+            .get_float(6)
+            .unwrap_or(0.0)
+            .max(0.0)
+            .min(inner_half_x)
+            .min(inner_half_y);
+        let outer_fillet = profile
+            .get_float(7)
+            .unwrap_or(0.0)
+            .max(0.0)
+            .min(half_x)
+            .min(half_y);
 
-        // Inner rectangle (clockwise for hole - reversed order)
-        let inner_points = vec![
-            Point2::new(-inner_half_x, -inner_half_y),
-            Point2::new(-inner_half_x, inner_half_y),
-            Point2::new(inner_half_x, inner_half_y),
-            Point2::new(inner_half_x, -inner_half_y),
-        ];
+        let outer_points =
+            rounded_rectangle_outline(half_x, half_y, outer_fillet, /*ccw=*/ true);
+        let inner_points =
+            rounded_rectangle_outline(inner_half_x, inner_half_y, inner_fillet, /*ccw=*/ false);
 
         let mut result = Profile2D::new(outer_points);
         result.add_hole(inner_points);

--- a/rust/geometry/src/profiles.rs
+++ b/rust/geometry/src/profiles.rs
@@ -443,12 +443,37 @@ fn rounded_rectangle_outline(
         (-half_x + radius, -half_y + radius, PI, PI + half_pi),
     ];
 
-    let mut points = Vec::with_capacity((SEGMENTS_PER_CORNER + 1) * 4);
+    // Drop duplicate seam vertices when adjacent corners' arc endpoints
+    // coincide. This happens when `radius == half_x` or `radius == half_y`
+    // (the degenerate circle path that motivated issue #854 — the inner
+    // fillet at 10/10 collapses to a single circle whose adjacent corner
+    // arcs share their tangent point). Without dedup the contour
+    // contains zero-length edges that earcutr handles but downstream
+    // analytics / 2D drawing pipelines may not (PR #863 review). 1 µm
+    // tolerance in profile units matches the welding precision used
+    // throughout `manifold_kernel.rs`.
+    let mut points: Vec<Point2<f64>> = Vec::with_capacity((SEGMENTS_PER_CORNER + 1) * 4);
+    const SEAM_TOL: f64 = 1.0e-6;
     for (cx, cy, a0, a1) in corners {
         for i in 0..=SEGMENTS_PER_CORNER {
             let t = i as f64 / SEGMENTS_PER_CORNER as f64;
             let a = a0 + (a1 - a0) * t;
-            points.push(Point2::new(cx + radius * a.cos(), cy + radius * a.sin()));
+            let pt = Point2::new(cx + radius * a.cos(), cy + radius * a.sin());
+            if let Some(prev) = points.last() {
+                if (prev.x - pt.x).abs() < SEAM_TOL && (prev.y - pt.y).abs() < SEAM_TOL {
+                    continue;
+                }
+            }
+            points.push(pt);
+        }
+    }
+    // For the exact-circle case the final vertex also coincides with
+    // the first — same dedup logic, wrapping around.
+    if points.len() >= 2 {
+        let first = points[0];
+        let last = points[points.len() - 1];
+        if (first.x - last.x).abs() < SEAM_TOL && (first.y - last.y).abs() < SEAM_TOL {
+            points.pop();
         }
     }
     if !ccw {

--- a/rust/geometry/tests/issue_854_rect_hollow_fillet.rs
+++ b/rust/geometry/tests/issue_854_rect_hollow_fillet.rs
@@ -1,0 +1,149 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Regression test for issue #854 — `IfcRectangleHollowProfileDef`
+//! must honour `InnerFilletRadius` (attr 6) and `OuterFilletRadius`
+//! (attr 7), not just the wall thickness.
+//!
+//! Fixture is the reporter's air-terminal model:
+//!   #275= IFCRECTANGLEHOLLOWPROFILEDEF(.AREA.,$,$,
+//!         24., 24., 2., 10., 0.);
+//!
+//! XDim=24, YDim=24, WallThickness=2 → inner half-extent = 10.
+//! InnerFilletRadius = 10 == inner_half_x == inner_half_y, so the
+//! inner hole MUST be a perfect circle (the four inner quarter arcs
+//! meet at the cardinal axes). OuterFilletRadius = 0 keeps the outer
+//! corners sharp.
+//!
+//! Pre-fix `process_rectangle_hollow` ignored both fillet attributes
+//! and emitted a 4-corner inner rectangle. Symptom in the viewer:
+//! square inner hole where the user authored a round one.
+
+use ifc_lite_core::{build_entity_index, EntityDecoder};
+use ifc_lite_geometry::GeometryRouter;
+
+const FIXTURE: &str = "../../tests/models/issues/854_air_terminal_hollow_fillet.ifc";
+const AIR_TERMINAL_ID: u32 = 331;
+
+fn read_fixture() -> Option<String> {
+    match std::fs::read_to_string(FIXTURE) {
+        Ok(s) => Some(s),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            eprintln!("issue-854 fixture missing — skipping (run `pnpm fixtures`)");
+            None
+        }
+        Err(e) => panic!("failed to read fixture: {e}"),
+    }
+}
+
+#[test]
+fn issue_854_inner_hole_is_round_when_inner_fillet_equals_half() {
+    let Some(content) = read_fixture() else { return };
+    let ei = build_entity_index(&content);
+    let mut decoder = EntityDecoder::with_index(&content, ei);
+    let entity = decoder
+        .decode_by_id(AIR_TERMINAL_ID)
+        .expect("air terminal #331");
+    let router = GeometryRouter::with_units(&content, &mut decoder);
+    let mesh = router
+        .process_element(&entity, &mut decoder)
+        .expect("air terminal must mesh");
+
+    // The diffuser body is a hollow rectangular prism: square outer
+    // shell + cylindrical inner bore. Pre-fix the inner bore was a
+    // 4-side rectangular tube (8 vertices around the inner). Post-fix
+    // the inner has the fillet's 24 outer vertices per cap (6 segments
+    // × 4 corners), which collapse to a circle when the fillet radius
+    // equals the inner half-dim.
+    //
+    // We don't expose the per-loop vertex breakdown post-triangulation,
+    // so check the proxy: the total vertex count must be well above the
+    // pre-fix 16 (8 outer + 8 inner ×2 caps, plus side walls). A round
+    // inner bore tessellated at 6 segments/corner yields 24+ inner cap
+    // vertices, pushing the mesh past ~80 verts.
+    let n_verts = mesh.positions.len() / 3;
+    assert!(
+        n_verts > 60,
+        "expected rounded inner bore (>= ~80 verts after sharing); got {} \
+         (was the InnerFilletRadius silently ignored?)",
+        n_verts,
+    );
+
+    // And the bore must actually be round on average — sample inner
+    // vertices and verify their distance from the profile centre is
+    // close to the authored fillet radius (10).
+    //
+    // "Inner" vertices are those whose XY distance from the profile
+    // centroid is between 8 and 12 in the local frame (XYDim = 24,
+    // wall = 2 → inner half = 10). The bore axis is along Z (the
+    // extruded-area solid's extrude direction in this fixture); we
+    // discard Z and check that all such vertices sit on a circle of
+    // radius ≈ 10 with ≤ 1 % deviation.
+    //
+    // The local-to-world transform on this fixture is identity (no
+    // rotation, no translation on the air terminal type's Position),
+    // so the world XY matches the profile XY.
+    // The fixture's IfcUnitAssignment overrides the SI metre with an
+    // inch conversion (#31). The geometry pipeline applies the
+    // 0.0254 m/in factor before we see the mesh, so the 24×24 inch
+    // profile lands as a 0.6096×0.6096 m box and the inner fillet
+    // radius = 10 inches = 0.254 m.
+    const M_PER_IN: f64 = 0.0254;
+    let inner_r_expected = 10.0 * M_PER_IN;
+
+    let (mut xmin, mut xmax, mut ymin, mut ymax) =
+        (f64::INFINITY, f64::NEG_INFINITY, f64::INFINITY, f64::NEG_INFINITY);
+    for i in 0..n_verts {
+        let x = mesh.positions[i * 3] as f64;
+        let y = mesh.positions[i * 3 + 1] as f64;
+        if x < xmin { xmin = x; }
+        if x > xmax { xmax = x; }
+        if y < ymin { ymin = y; }
+        if y > ymax { ymax = y; }
+    }
+    let cx = 0.5 * (xmin + xmax);
+    let cy = 0.5 * (ymin + ymax);
+    // The fixture's solid is an IfcExtrudedAreaSolidTapered with a 0.5
+    // scale on the end profile — so the body has TWO inner bores:
+    //   * bottom cap @ z=0:   inner radius = 10" = 0.2540 m
+    //   * top cap @ z=4":     inner radius =  5" = 0.1270 m  (50 % scale)
+    // Only the bottom cap exercises the fillet code path we're testing;
+    // the top cap's inner bore inherits via IfcDerivedProfileDef's
+    // operator, which is a separate concern. Sample a tight ±2 % window
+    // around the start-profile bore so we don't catch the smaller top
+    // bore OR the top cap's outer corner at r = 0.2156.
+    let mut inner_radii = Vec::new();
+    for i in 0..n_verts {
+        let x = mesh.positions[i * 3] as f64 - cx;
+        let y = mesh.positions[i * 3 + 1] as f64 - cy;
+        let r = (x * x + y * y).sqrt();
+        if (0.98 * inner_r_expected..1.02 * inner_r_expected).contains(&r) {
+            inner_radii.push(r);
+        }
+    }
+    assert!(
+        inner_radii.len() >= 24,
+        "expected >= 24 inner-bore vertices (rounded inner), got {} — \
+         InnerFilletRadius probably ignored. bounds=({:.3},{:.3})..({:.3},{:.3})",
+        inner_radii.len(),
+        xmin, ymin, xmax, ymax,
+    );
+    let mean: f64 = inner_radii.iter().sum::<f64>() / inner_radii.len() as f64;
+    let max_dev = inner_radii
+        .iter()
+        .map(|r| (r - mean).abs())
+        .fold(0.0_f64, f64::max);
+    assert!(
+        (mean - inner_r_expected).abs() < 0.005,
+        "inner-bore mean radius = {:.4} m, expected ≈ {:.4} m",
+        mean, inner_r_expected,
+    );
+    assert!(
+        max_dev / mean < 0.01,
+        "inner-bore not circular: max deviation {:.5} / mean {:.4} = {:.2}%",
+        max_dev,
+        mean,
+        100.0 * max_dev / mean,
+    );
+}

--- a/tests/models/manifest.json
+++ b/tests/models/manifest.json
@@ -704,6 +704,11 @@
       "size": 5852
     },
     {
+      "path": "issues/854_air_terminal_hollow_fillet.ifc",
+      "sha256": "0ae00c7883d10a5df32646efba3e4ce70886746e17ac507e649801e11ca3161a",
+      "size": 14476
+    },
+    {
       "path": "issues/856_wall_decode_failed.ifc",
       "sha256": "5f8a7eda3e63b0e3d4c5f0c986aeb4e8bbfeb9c84f6ccc42845bc5c704ef4849",
       "size": 18659


### PR DESCRIPTION
## Summary
- Read `InnerFilletRadius` (attr 6) + `OuterFilletRadius` (attr 7) on `IfcRectangleHollowProfileDef`, emit quarter-circle arcs at each corner. Pre-fix both were silently dropped, so the inner bore always rendered as a sharp rectangle.
- Issue #854's air-terminal fixture has `InnerFilletRadius == inner_half_x == inner_half_y`, the degenerate case where the four inner arcs meet and the inner loop becomes a circle. Symptom in the viewer was a square inner hole.

## Test plan
- [x] `cargo test -p ifc-lite-geometry --test issue_854_rect_hollow_fillet` — new regression test on the reporter's air-terminal fixture; asserts >= 24 inner-bore vertices within ±2 % of the authored fillet radius.
- [x] `cargo test -p ifc-lite-geometry` — full geometry suite, 0 failures.
- [x] Fixture uploaded to fixtures release; manifest entry added.

Closes #854.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for filleted (rounded) corners on hollow rectangular profiles with configurable inner and outer radius control.

* **Bug Fixes**
  * Fixed handling of fillet radii on hollow rectangular profiles to ensure proper geometry generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LTplus-AG/ifc-lite/pull/863?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->