### PR TITLE
fix(core): IFC scanner skips '#N' tokens inside STEP comments (#856)

### DIFF
--- a/rust/core/src/parser.rs
+++ b/rust/core/src/parser.rs
@@ -318,25 +318,42 @@ impl<'a> EntityScanner<'a> {
     /// Returns (entity_id, type_name, line_start, line_end)
     #[inline]
     pub fn next_entity(&mut self) -> Option<(u32, &'a str, usize, usize)> {
-        // Find a '#' that actually starts an entity. A `#` is legal inside
+        // Find a '#' that actually starts an entity. A '#' is legal inside
         // STEP-encoded quoted strings (e.g. CATIA writes filenames like
-        // `'…\X0\2#.ifc'` into the HEADER's FILE_NAME), so we validate that
-        // the `#` is followed by at least one ASCII digit before treating it
-        // as an entity anchor. Without this check, an in-string `#` would
-        // misalign `find_entity_end`'s quote parity and silently drop every
-        // remaining entity in the file. See issue #654.
+        // `'…\X0\2#.ifc'` into the HEADER's FILE_NAME) AND inside STEP
+        // `/* … */` comments (template-generated IFC commonly has phrases
+        // like `/* Standard case walls #1 with axis … */`; issue #856).
+        // Validate that the '#' starts a real `#<digits>[ws]*=` pattern
+        // before locking it in — same shape as `build_entity_index`'s
+        // existing check, so the scanner and index stay in agreement.
         let bytes = self.bytes;
         let len = bytes.len();
-        let line_start = loop {
+        let (line_start, id_end_validated) = loop {
             let remaining = &bytes[self.position..];
             let start_offset = memchr::memchr(b'#', remaining)?;
             let candidate = self.position + start_offset;
             let after = candidate + 1;
-            if after < len && bytes[after].is_ascii_digit() {
-                break candidate;
+            if after >= len || !bytes[after].is_ascii_digit() {
+                self.position = after;
+                continue;
             }
-            // Not a valid entity start — advance past this '#' and retry.
-            self.position = after;
+            // Walk the digit run.
+            let mut digit_end = after;
+            while digit_end < len && bytes[digit_end].is_ascii_digit() {
+                digit_end += 1;
+            }
+            // Skip optional whitespace and verify the next byte is '='.
+            let mut probe = digit_end;
+            while probe < len && bytes[probe].is_ascii_whitespace() {
+                probe += 1;
+            }
+            if probe < len && bytes[probe] == b'=' {
+                break (candidate, digit_end);
+            }
+            // '#<digits>' not followed by '=' — this is a comment or string
+            // reference, not an entity definition. Skip past the digits and
+            // keep searching.
+            self.position = digit_end;
         };
 
         // Find the end of the entity (semicolon) while respecting quoted strings
@@ -345,14 +362,9 @@ impl<'a> EntityScanner<'a> {
         let end_offset = self.find_entity_end(line_content)?;
         let line_end = line_start + end_offset + 1;
 
-        // Parse entity ID (inline for speed)
+        // Parse entity ID — digit range already validated in the candidate loop.
         let id_start = line_start + 1;
-        let mut id_end = id_start;
-        while id_end < line_end && self.bytes[id_end].is_ascii_digit() {
-            id_end += 1;
-        }
-
-        // Fast integer parsing without allocation
+        let id_end = id_end_validated;
         let id = self.parse_u32_fast(id_start, id_end)?;
 
         // Find '=' after ID using SIMD

--- a/rust/core/src/parser.rs
+++ b/rust/core/src/parser.rs
@@ -321,17 +321,65 @@ impl<'a> EntityScanner<'a> {
         // Find a '#' that actually starts an entity. A '#' is legal inside
         // STEP-encoded quoted strings (e.g. CATIA writes filenames like
         // `'…\X0\2#.ifc'` into the HEADER's FILE_NAME) AND inside STEP
-        // `/* … */` comments (template-generated IFC commonly has phrases
-        // like `/* Standard case walls #1 with axis … */`; issue #856).
-        // Validate that the '#' starts a real `#<digits>[ws]*=` pattern
-        // before locking it in — same shape as `build_entity_index`'s
-        // existing check, so the scanner and index stay in agreement.
+        // `/* … */` comments. Two layered guards:
+        //
+        //   1. Skip past `/* … */` comment regions entirely so an inner
+        //      `#N=…` token can't be mistaken for an entity (PR #865 follow-
+        //      up — `/* previous #12= IFCWALL */` was the canonical example
+        //      where the original `#N=` shape check still false-positived).
+        //   2. After comment-skipping locates a candidate '#', validate it
+        //      starts a real `#<digits>[ws]*=` pattern. Catches embedded
+        //      references inside STEP strings (CATIA `'…\X0\2#.ifc'`) AND
+        //      any comment-shaped tokens the comment skipper missed (mostly
+        //      a fallback now — true `/* */` regions never reach this check).
+        //
+        // Both checks together keep `next_entity` aligned with
+        // `build_entity_index` which is comment-blind today; if a stray
+        // comment-bound entity slips past the scanner, the index also
+        // ignores it, so the entity decoder + scanner stay consistent.
         let bytes = self.bytes;
         let len = bytes.len();
         let (line_start, id_end_validated) = loop {
+            // Step (1): jump past any `/* … */` comment that starts at or
+            // before the next candidate '#'. Use memchr2 so we look for
+            // '#' and '/' in one SIMD pass — whichever comes first
+            // decides the next move.
             let remaining = &bytes[self.position..];
-            let start_offset = memchr::memchr(b'#', remaining)?;
-            let candidate = self.position + start_offset;
+            let next = memchr::memchr2(b'#', b'/', remaining)?;
+            let candidate = self.position + next;
+            let candidate_byte = bytes[candidate];
+
+            if candidate_byte == b'/' {
+                // '/' might begin a STEP `/* … */` comment. If yes, jump
+                // past `*/`; if not, it's a STEP arithmetic '/' inside a
+                // value list (rare; just step past it).
+                if candidate + 1 < len && bytes[candidate + 1] == b'*' {
+                    let mut p = candidate + 2;
+                    while p + 1 < len {
+                        // Find next '*'; check if followed by '/'.
+                        let from = p;
+                        let star = match memchr::memchr(b'*', &bytes[from..]) {
+                            Some(off) => from + off,
+                            None => return None, // unterminated comment
+                        };
+                        if star + 1 < len && bytes[star + 1] == b'/' {
+                            self.position = star + 2;
+                            break;
+                        }
+                        p = star + 1;
+                    }
+                    if self.position <= candidate {
+                        // Comment never closed — refuse to scan further.
+                        return None;
+                    }
+                    continue;
+                }
+                // Lone '/' — not a comment. Skip past.
+                self.position = candidate + 1;
+                continue;
+            }
+
+            // candidate_byte == b'#'. Step (2): validate `#<digits>[ws]*=`.
             let after = candidate + 1;
             if after >= len || !bytes[after].is_ascii_digit() {
                 self.position = after;

--- a/rust/core/tests/issue_856_scanner_skips_comment_hashes.rs
+++ b/rust/core/tests/issue_856_scanner_skips_comment_hashes.rs
@@ -1,0 +1,78 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Regression test for issue #856 — `EntityScanner::next_entity` must
+//! not lock onto a `#<digits>` token unless it's followed by an `=`
+//! (with optional whitespace).
+//!
+//! Reproduction: the user's fixture `construction-scheduling-task.ifc`
+//! has section banners like
+//!
+//!   /* Standard case walls #1 with axis and body geometry … */
+//!   #356= IFCWALL('26tmERtwL8G8UQn5BoglEh',…);
+//!
+//! Pre-fix the scanner found `#1` inside the comment, walked forward
+//! to the next `=` (the one on `#356= IFCWALL`), and returned a line
+//! range starting at `#1` and ending after `IFCWALL(…)`. The decoder
+//! tried to parse `#1 with axis … */ … #356= IFCWALL(…)` as a single
+//! entity and aborted with a Parse error — `stats.decode_failed += 1`
+//! per affected wall, so the user saw "decode failed: 4" in console
+//! and all four walls were silently dropped from the viewer.
+
+use ifc_lite_core::{EntityDecoder, EntityScanner};
+
+const FIXTURE_WITH_COMMENTS: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [DesignTransferView_V1.0]'),'2;1');
+FILE_NAME('test.ifc','2024-06-11T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1= IFCPROJECT('xxxxxxxxxxxxxxxxxxxxx1',$,'Project',$,$,$,$,$,$);
+/* Standard case walls #1 with axis and body geometry */
+#2= IFCWALL('xxxxxxxxxxxxxxxxxxxxx2',$,'Wall #1',$,$,$,$,$,.NOTDEFINED.);
+/* Another comment with #5 and #99 inside */
+#3= IFCWALL('xxxxxxxxxxxxxxxxxxxxx3',$,'Wall #2',$,$,$,$,$,.NOTDEFINED.);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+#[test]
+fn scanner_skips_in_comment_hashes() {
+    let mut scanner = EntityScanner::new(FIXTURE_WITH_COMMENTS);
+    let mut seen_ids = Vec::new();
+    while let Some((id, name, _start, _end)) = scanner.next_entity() {
+        seen_ids.push((id, name.to_string()));
+    }
+    assert_eq!(
+        seen_ids,
+        vec![
+            (1, "IFCPROJECT".to_string()),
+            (2, "IFCWALL".to_string()),
+            (3, "IFCWALL".to_string()),
+        ],
+        "scanner picked up bogus entities from inside `/* … */` comments",
+    );
+}
+
+#[test]
+fn decoder_can_parse_all_walls_after_scanner_fix() {
+    let mut scanner = EntityScanner::new(FIXTURE_WITH_COMMENTS);
+    let mut decoder = EntityDecoder::new(FIXTURE_WITH_COMMENTS);
+    let mut decoded_walls = 0;
+    while let Some((id, name, start, end)) = scanner.next_entity() {
+        if name != "IFCWALL" {
+            continue;
+        }
+        let entity = decoder
+            .decode_at_with_id(id, start, end)
+            .unwrap_or_else(|e| panic!("decode #{id} failed: {e}"));
+        assert_eq!(entity.ifc_type.name(), "IfcWall");
+        decoded_walls += 1;
+    }
+    assert_eq!(
+        decoded_walls, 2,
+        "expected to decode both walls; pre-fix every wall failed with a parse error",
+    );
+}

--- a/rust/core/tests/issue_856_scanner_skips_comment_hashes.rs
+++ b/rust/core/tests/issue_856_scanner_skips_comment_hashes.rs
@@ -57,6 +57,44 @@ fn scanner_skips_in_comment_hashes() {
 }
 
 #[test]
+fn scanner_skips_definition_shaped_tokens_in_comments() {
+    // PR #865 follow-up review (chatgpt-codex P2): the original
+    // `#N=` shape check still false-positived on `/* #12= IFCWALL */`
+    // because the comment body genuinely contains the `#N=` pattern.
+    // The full fix has to skip `/* … */` regions, not just shape-
+    // check the candidate.
+    const FIXTURE: &str = "ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('test'),'2;1');
+FILE_NAME('','2024-01-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+/* previous version had a typo: #12= IFCWALL('bad',$,'Bad',$,$,$,$,$,.NOTDEFINED.); */
+#1= IFCPROJECT('xxxxxxxxxxxxxxxxxxxxx1',$,'Project',$,$,$,$,$,$);
+/* #99 = IFCSLAB('also-bad',$,'Bad Slab',$,$,$,$,$,$); */
+#2= IFCWALL('xxxxxxxxxxxxxxxxxxxxx2',$,'Wall A',$,$,$,$,$,.NOTDEFINED.);
+ENDSEC;
+END-ISO-10303-21;
+";
+    let mut scanner = EntityScanner::new(FIXTURE);
+    let mut seen_ids = Vec::new();
+    while let Some((id, name, _start, _end)) = scanner.next_entity() {
+        seen_ids.push((id, name.to_string()));
+    }
+    assert_eq!(
+        seen_ids,
+        vec![
+            (1, "IFCPROJECT".to_string()),
+            (2, "IFCWALL".to_string()),
+        ],
+        "scanner picked up bogus #N= entities from inside a /* … */ \
+         comment despite the shape-check guard — the comment-skipping \
+         layer is required to fully fix this class of bug",
+    );
+}
+
+#[test]
 fn decoder_can_parse_all_walls_after_scanner_fix() {
     let mut scanner = EntityScanner::new(FIXTURE_WITH_COMMENTS);
     let mut decoder = EntityDecoder::new(FIXTURE_WITH_COMMENTS);

--- a/tests/models/manifest.json
+++ b/tests/models/manifest.json
@@ -704,6 +704,11 @@
       "size": 5852
     },
     {
+      "path": "issues/856_wall_decode_failed.ifc",
+      "sha256": "5f8a7eda3e63b0e3d4c5f0c986aeb4e8bbfeb9c84f6ccc42845bc5c704ef4849",
+      "size": 18659
+    },
+    {
       "path": "various/01_BIMcollab_Example_ARC.ifc",
       "sha256": "87392cf24264b023e65d8ca1dab1eb8996643c1aa51b9dff9d518ed8904151fc",
       "size": 18230149


### PR DESCRIPTION
## Summary
- `EntityScanner::next_entity` accepted any `#<digits>` byte sequence as an entity start, including ones inside `/* … */` STEP comments. The reporter's `construction-scheduling-task.ifc` has banner comments like `/* Standard case walls #1 with axis … */` — pre-fix the scanner locked onto `#1` in the comment, used `memchr(=)` to skip ahead to the `=` of the REAL `#356= IFCWALL(…);` line, and returned a corrupted line range that the decoder couldn't parse. Result: "decode failed: 4" in the wasm console + all four walls silently dropped from the viewer.
- Mirror `build_entity_index`'s stricter check: after the candidate `#<digits>` run, require the next non-whitespace byte to be `=` before locking the candidate in. Skips embedded `#N` references inside both STEP comments AND property/description strings.

## Test plan
- [x] `cargo test -p ifc-lite-core --test issue_856_scanner_skips_comment_hashes` — new regression on a 2-wall synthetic + 2 comment patterns from the user's fixture.
- [x] `cargo test -p ifc-lite-core -p ifc-lite-geometry` — full suites, 0 failures.

Closes #856.

🤖 Generated with [Claude Code](https://claude.com/claude-code)