### PR TITLE
fix: recognise IfcSolidStratum + add IfcFacility/stratum icons (#860)

### DIFF
--- a/apps/viewer/src/components/viewer/hierarchy/ifc-icons.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/ifc-icons.ts
@@ -17,6 +17,20 @@ export const IFC_ICON_CODEPOINTS: Record<string, string> = {
   IfcBuilding: '\uea40',
   IfcBuildingStorey: '\ue8fe',
   IfcSpace: '\ueff4',
+  // IFC4.3 facility containers \u2014 same family as IfcBuilding (multi-storey
+  // spatial root) but `domain` carries the "campus / infrastructure
+  // facility" reading; IfcFacilityPart follows the storey-line icon for
+  // consistency. (Issue #860 \u2014 user reported no icon on IfcFacility.)
+  IfcFacility: '\ue7ee', // "domain"
+  IfcFacilityPart: '\ue8fe', // "layers" \u2014 mirrors IfcBuildingStorey
+  IfcBridge: '\uebbf', // "directions_railway" \u2014 civil bridge icon
+  IfcBridgePart: '\ue8fe',
+  IfcRoad: '\uebbe', // "route"
+  IfcRoadPart: '\ue8fe',
+  IfcRailway: '\ue570', // "train"
+  IfcRailwayPart: '\ue8fe',
+  IfcMarineFacility: '\ue532', // "directions_boat"
+  IfcMarineFacilityPart: '\ue8fe',
 
   // Structural
   IfcBeam: '\uf108',
@@ -79,6 +93,19 @@ export const IFC_ICON_CODEPOINTS: Record<string, string> = {
   IfcCivilElement: '\uea99',
   IfcGeographicElement: '\uea99',
   IfcLinearElement: '\uebaa',
+
+  // Geotechnical strata (IFC4.3) \u2014 issue #860. The abstract base plus the
+  // three concrete leaves (IfcSolidStratum / IfcVoidStratum / IfcWaterStratum)
+  // all share the `terrain` glyph. The geometry pipeline routes the leaves
+  // through IfcGeotechnicalStratum via legacy_entities.rs, so the icon map
+  // covers both the leaf names (when entries land in the spatial tree with
+  // their original type string) and the base.
+  IfcGeotechnicalAssembly: '\ue564',
+  IfcGeotechnicalElement: '\ue564',
+  IfcGeotechnicalStratum: '\ue564',
+  IfcSolidStratum: '\ue564',
+  IfcVoidStratum: '\ue564',
+  IfcWaterStratum: '\ue564',
 
   // Proxy / generic fallback
   IfcProduct: '\ue047',

--- a/rust/core/src/legacy_entities.rs
+++ b/rust/core/src/legacy_entities.rs
@@ -110,6 +110,30 @@ pub fn get_legacy_entity_info(entity_name: &str) -> Option<LegacyEntityInfo> {
             has_geometry: true,
         }),
 
+        // === IFC4.3 stratum subtypes (issue #860) ===
+        //
+        // The schema enum exposes the abstract base `IfcGeotechnicalStratum`
+        // but not the three concrete leaves (`IfcSolidStratum`,
+        // `IfcVoidStratum`, `IfcWaterStratum`). Without these, infrastructure
+        // models with terrain / soil layers (e.g. the user's UT_Tin_in_MGA_56
+        // fixture) come back as `IfcType::Unknown(...)` and
+        // `has_geometry_by_name` returns false — the geometry pipeline skips
+        // them silently. Map each subtype to the base so its `Body`
+        // representation (typically `IfcTriangulatedFaceSet`) is processed by
+        // the same code path as any other geotechnical product.
+        "IFCSOLIDSTRATUM" => Some(LegacyEntityInfo {
+            base_type: IfcType::IfcGeotechnicalStratum,
+            has_geometry: true,
+        }),
+        "IFCVOIDSTRATUM" => Some(LegacyEntityInfo {
+            base_type: IfcType::IfcGeotechnicalStratum,
+            has_geometry: true,
+        }),
+        "IFCWATERSTRATUM" => Some(LegacyEntityInfo {
+            base_type: IfcType::IfcGeotechnicalStratum,
+            has_geometry: true,
+        }),
+
         _ => None,
     }
 }

--- a/rust/core/tests/issue_860_stratum_subtypes.rs
+++ b/rust/core/tests/issue_860_stratum_subtypes.rs
@@ -1,0 +1,55 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Regression test for issue #860 — IFC4.3's concrete stratum subtypes
+//! must be recognised as geometry-bearing IfcGeotechnicalStratum even
+//! though the auto-generated schema enum only exposes the abstract base.
+//!
+//! Pre-fix: `has_geometry_by_name("IFCSOLIDSTRATUM")` returned `false`,
+//! and the wasm geometry pipeline silently skipped every stratum element
+//! in the user's UT_Tin_in_MGA_56 terrain fixture.
+
+use ifc_lite_core::{
+    has_geometry_by_name,
+    legacy_entities::{get_legacy_entity_info, map_legacy_to_base_type},
+    IfcType,
+};
+
+#[test]
+fn solid_stratum_recognised_as_geotechnical_stratum() {
+    let info = get_legacy_entity_info("IFCSOLIDSTRATUM")
+        .expect("IFCSOLIDSTRATUM must be in the legacy registry");
+    assert_eq!(info.base_type, IfcType::IfcGeotechnicalStratum);
+    assert!(info.has_geometry, "stratum elements carry Body geometry");
+}
+
+#[test]
+fn void_and_water_strata_are_also_geotechnical_stratum() {
+    for name in &["IFCVOIDSTRATUM", "IFCWATERSTRATUM"] {
+        let info = get_legacy_entity_info(name)
+            .unwrap_or_else(|| panic!("{name} must be in the legacy registry"));
+        assert_eq!(info.base_type, IfcType::IfcGeotechnicalStratum);
+        assert!(info.has_geometry);
+    }
+}
+
+#[test]
+fn has_geometry_by_name_passes_for_all_stratum_subtypes() {
+    for name in &["IFCSOLIDSTRATUM", "IFCVOIDSTRATUM", "IFCWATERSTRATUM"] {
+        assert!(
+            has_geometry_by_name(name),
+            "{name} must report has_geometry=true; pre-fix it returned false \
+             and the wasm pipeline silently dropped every stratum element \
+             from the spatial tree (issue #860)."
+        );
+    }
+}
+
+#[test]
+fn map_legacy_to_base_type_returns_geotechnical_stratum() {
+    assert_eq!(
+        map_legacy_to_base_type("IFCSOLIDSTRATUM"),
+        Some(IfcType::IfcGeotechnicalStratum),
+    );
+}


### PR DESCRIPTION
## Summary
- The auto-generated `IfcType` enum exposes the abstract `IfcGeotechnicalStratum` base but none of its three concrete leaves. The user's `UT_Tin_in_MGA_56.ifc` has the terrain as `IfcSolidStratum`, which fell into `IfcType::Unknown(...)` → `has_geometry_by_name` returned false → wasm pipeline silently dropped the element. Add `IfcSolidStratum`, `IfcVoidStratum`, `IfcWaterStratum` to `legacy_entities.rs`, mapping each to `IfcGeotechnicalStratum` with `has_geometry: true`.
- The spatial-tree icon map covered `IfcSite` / `IfcBuilding` / `IfcBuildingStorey` but had no row for `IfcFacility`, `IfcFacilityPart`, or any IFC4.3 facility subclass (Bridge / Road / Railway / Marine), and no row for any stratum type. All those nodes rendered with the generic widget glyph — the reporter's "no IfcFacility icon" complaint. Added Material Symbols code points for the full set.

## Test plan
- [x] `cargo test -p ifc-lite-core --test issue_860_stratum_subtypes` — 4 tests covering the registry + `has_geometry_by_name` flow.
- [x] `cargo test -p ifc-lite-core -p ifc-lite-geometry` — full suites, 0 failures.
- [x] `tsc --noEmit` on `apps/viewer` clean.

Closes #860.

🤖 Generated with [Claude Code](https://claude.com/claude-code)