### PR TITLE
fix(wasm): split IfcTriangulatedFaceSet by IfcIndexedColourMap (#858)

### DIFF
--- a/rust/wasm-bindings/src/api/gpu_meshes.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes.rs
@@ -1797,6 +1797,43 @@ impl IfcAPI {
                                         calculate_normals(&mut mesh);
                                     }
 
+                                    // Issue #858 / PR #867 follow-up:
+                                    // per-triangle colour split for
+                                    // `IfcIndexedColourMap`, gated on
+                                    // IfcStyledItem precedence — the
+                                    // streaming `parseMeshesAsync` is the
+                                    // viewer's primary load path, so the
+                                    // split has to run here too.
+                                    if !pre_pass.styled_item_geoms.contains(&sub.geometry_id) {
+                                        if let Some(map) =
+                                            pre_pass.indexed_colour_maps.get(&sub.geometry_id)
+                                        {
+                                            if let Some(groups) =
+                                                split_mesh_by_indexed_colour_map(&mesh, map)
+                                            {
+                                                for (mut group_mesh, group_color) in groups {
+                                                    if group_mesh.normals.len()
+                                                        != group_mesh.positions.len()
+                                                    {
+                                                        calculate_normals(&mut group_mesh);
+                                                    }
+                                                    total_vertices +=
+                                                        group_mesh.positions.len() / 3;
+                                                    total_triangles +=
+                                                        group_mesh.indices.len() / 3;
+                                                    let mesh_data = MeshDataJs::new(
+                                                        id,
+                                                        ifc_type_name.clone(),
+                                                        group_mesh,
+                                                        group_color,
+                                                    );
+                                                    batch_meshes.push(mesh_data);
+                                                }
+                                                continue;
+                                            }
+                                        }
+                                    }
+
                                     let color = resolve_submesh_color(
                                         sub.geometry_id,
                                         &pre_pass.geometry_styles,
@@ -1944,6 +1981,37 @@ impl IfcAPI {
                                         calculate_normals(&mut mesh);
                                     }
 
+                                    // Per-triangle colour split (#858 / #867).
+                                    if !pre_pass.styled_item_geoms.contains(&sub.geometry_id) {
+                                        if let Some(map) =
+                                            pre_pass.indexed_colour_maps.get(&sub.geometry_id)
+                                        {
+                                            if let Some(groups) =
+                                                split_mesh_by_indexed_colour_map(&mesh, map)
+                                            {
+                                                for (mut group_mesh, group_color) in groups {
+                                                    if group_mesh.normals.len()
+                                                        != group_mesh.positions.len()
+                                                    {
+                                                        calculate_normals(&mut group_mesh);
+                                                    }
+                                                    total_vertices +=
+                                                        group_mesh.positions.len() / 3;
+                                                    total_triangles +=
+                                                        group_mesh.indices.len() / 3;
+                                                    let mesh_data = MeshDataJs::new(
+                                                        id,
+                                                        ifc_type_name.clone(),
+                                                        group_mesh,
+                                                        group_color,
+                                                    );
+                                                    batch_meshes.push(mesh_data);
+                                                }
+                                                continue;
+                                            }
+                                        }
+                                    }
+
                                     let color = resolve_submesh_color(
                                         sub.geometry_id,
                                         &pre_pass.geometry_styles,
@@ -2021,6 +2089,37 @@ impl IfcAPI {
                                     }
                                     if mesh.normals.len() != mesh.positions.len() {
                                         calculate_normals(&mut mesh);
+                                    }
+
+                                    // Per-triangle colour split (#858 / #867).
+                                    if !pre_pass.styled_item_geoms.contains(&sub.geometry_id) {
+                                        if let Some(map) =
+                                            pre_pass.indexed_colour_maps.get(&sub.geometry_id)
+                                        {
+                                            if let Some(groups) =
+                                                split_mesh_by_indexed_colour_map(&mesh, map)
+                                            {
+                                                for (mut group_mesh, group_color) in groups {
+                                                    if group_mesh.normals.len()
+                                                        != group_mesh.positions.len()
+                                                    {
+                                                        calculate_normals(&mut group_mesh);
+                                                    }
+                                                    total_vertices +=
+                                                        group_mesh.positions.len() / 3;
+                                                    total_triangles +=
+                                                        group_mesh.indices.len() / 3;
+                                                    let mesh_data = MeshDataJs::new(
+                                                        id,
+                                                        ifc_type_name.clone(),
+                                                        group_mesh,
+                                                        group_color,
+                                                    );
+                                                    batch_meshes.push(mesh_data);
+                                                }
+                                                continue;
+                                            }
+                                        }
                                     }
 
                                     let color = resolve_submesh_color(

--- a/rust/wasm-bindings/src/api/gpu_meshes.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes.rs
@@ -123,6 +123,7 @@ impl IfcAPI {
         let style_indexes = super::styling::build_geometry_style_indexes(&content, &mut decoder);
         let mut geometry_styles = style_indexes.colors;
         let geometry_shading_styles = style_indexes.shading_colors;
+        let styled_item_geoms = style_indexes.styled_item_geoms;
         let style_index = build_element_style_index(&content, &geometry_styles, &mut decoder);
         // Build material-based styles for sub-element color fallback (windows, doors)
         let element_material_styles =
@@ -393,14 +394,25 @@ impl IfcAPI {
                             // this branch is mostly a no-op for cut
                             // geometry — but for uncut tessellated parts
                             // mixed in the same element it still applies.
-                            if let Some(map) = indexed_colour_maps.get(&sub.geometry_id) {
-                                if let Some(groups) =
-                                    split_mesh_by_indexed_colour_map(&mesh, map)
-                                {
-                                    for (mut group_mesh, group_color) in groups {
-                                        push_mesh_if_valid(&mut group_mesh, group_color, None);
+                            //
+                            // IfcStyledItem precedence (PR #867 review,
+                            // chatgpt-codex P2): when the same face set
+                            // also carries an IfcStyledItem the styled
+                            // colour outranks the per-face map — match
+                            // `build_geometry_style_indexes`'s merge order
+                            // so the renderer's two colour paths agree
+                            // even on files with both mechanisms authored
+                            // on the same geometry.
+                            if !styled_item_geoms.contains(&sub.geometry_id) {
+                                if let Some(map) = indexed_colour_maps.get(&sub.geometry_id) {
+                                    if let Some(groups) =
+                                        split_mesh_by_indexed_colour_map(&mesh, map)
+                                    {
+                                        for (mut group_mesh, group_color) in groups {
+                                            push_mesh_if_valid(&mut group_mesh, group_color, None);
+                                        }
+                                        continue;
                                     }
-                                    continue;
                                 }
                             }
                             let color = resolve_submesh_color(
@@ -468,14 +480,19 @@ impl IfcAPI {
                             // IfcIndexedColourMap, split the mesh into per-
                             // colour sub-meshes. Falls through to the
                             // single-colour path on length mismatch.
-                            if let Some(map) = indexed_colour_maps.get(&sub.geometry_id) {
-                                if let Some(groups) =
-                                    split_mesh_by_indexed_colour_map(&mesh, map)
-                                {
-                                    for (mut group_mesh, group_color) in groups {
-                                        push_mesh_if_valid(&mut group_mesh, group_color, None);
+                            // IfcStyledItem outranks the per-face map
+                            // (PR #867 review); same precedence
+                            // gate as the with-openings branch above.
+                            if !styled_item_geoms.contains(&sub.geometry_id) {
+                                if let Some(map) = indexed_colour_maps.get(&sub.geometry_id) {
+                                    if let Some(groups) =
+                                        split_mesh_by_indexed_colour_map(&mesh, map)
+                                    {
+                                        for (mut group_mesh, group_color) in groups {
+                                            push_mesh_if_valid(&mut group_mesh, group_color, None);
+                                        }
+                                        continue;
                                     }
-                                    continue;
                                 }
                             }
                             let color = resolve_submesh_color(
@@ -758,6 +775,24 @@ impl IfcAPI {
 
                         for sub in sub_meshes.sub_meshes {
                             let mut mesh = sub.mesh;
+                            // Issue #858 / PR #867: per-triangle colour
+                            // map splitter, gated on IfcStyledItem
+                            // precedence. Same logic as the synchronous
+                            // `parse_meshes` path.
+                            if !pre_pass.styled_item_geoms.contains(&sub.geometry_id) {
+                                if let Some(map) =
+                                    pre_pass.indexed_colour_maps.get(&sub.geometry_id)
+                                {
+                                    if let Some(groups) =
+                                        split_mesh_by_indexed_colour_map(&mesh, map)
+                                    {
+                                        for (mut group_mesh, group_color) in groups {
+                                            push_mesh(&mut group_mesh, group_color, None);
+                                        }
+                                        continue;
+                                    }
+                                }
+                            }
                             let color = resolve_submesh_color(
                                 sub.geometry_id,
                                 &pre_pass.geometry_styles,
@@ -803,6 +838,22 @@ impl IfcAPI {
 
                         for sub in sub_meshes.sub_meshes {
                             let mut mesh = sub.mesh;
+                            // Per-triangle colour split — issue #858 /
+                            // PR #867. IfcStyledItem outranks.
+                            if !pre_pass.styled_item_geoms.contains(&sub.geometry_id) {
+                                if let Some(map) =
+                                    pre_pass.indexed_colour_maps.get(&sub.geometry_id)
+                                {
+                                    if let Some(groups) =
+                                        split_mesh_by_indexed_colour_map(&mesh, map)
+                                    {
+                                        for (mut group_mesh, group_color) in groups {
+                                            push_mesh(&mut group_mesh, group_color, None);
+                                        }
+                                        continue;
+                                    }
+                                }
+                            }
                             let color = resolve_submesh_color(
                                 sub.geometry_id,
                                 &pre_pass.geometry_styles,

--- a/rust/wasm-bindings/src/api/gpu_meshes.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes.rs
@@ -9,8 +9,9 @@
 
 use super::styling::{
     build_element_material_styles_from_content, build_element_style_index,
-    build_geometry_style_index, extract_building_rotation, get_default_color_for_type,
-    resolve_element_color, resolve_submesh_color,
+    build_geometry_style_index, extract_building_rotation,
+    extract_full_indexed_colour_map_span, get_default_color_for_type, resolve_element_color,
+    resolve_submesh_color, IndexedColourMapResolved,
 };
 use super::GeometryStats;
 use super::IfcAPI;
@@ -27,6 +28,64 @@ fn decode_ifc_bytes<'a>(data: &'a [u8]) -> &'a str {
         Ok(content) => content,
         Err(error) => wasm_bindgen::throw_str(&format!("Invalid UTF-8 IFC data: {error}")),
     }
+}
+
+/// Split a flat-shaded mesh (3 unique verts per triangle) into one
+/// sub-mesh per colour group from an `IfcIndexedColourMap`. Returns
+/// `None` when the resolved map's triangle count doesn't match the mesh
+/// (caller falls back to single-colour rendering). See issue #858.
+fn split_mesh_by_indexed_colour_map(
+    mesh: &ifc_lite_geometry::Mesh,
+    map: &IndexedColourMapResolved,
+) -> Option<Vec<(ifc_lite_geometry::Mesh, [f32; 4])>> {
+    let n_tris = mesh.indices.len() / 3;
+    if map.triangle_indices.len() != n_tris || n_tris == 0 || map.colours.is_empty() {
+        return None;
+    }
+
+    // Group triangles by 1-based palette index. Skip out-of-range indices
+    // (defensive — pre-fix the dominant-colour path silently mapped index 0
+    // to colours[0], which on a malformed file produced random colour).
+    let mut groups: rustc_hash::FxHashMap<u32, Vec<usize>> = rustc_hash::FxHashMap::default();
+    for (tri_i, &c_idx) in map.triangle_indices.iter().enumerate() {
+        if c_idx == 0 || (c_idx as usize) > map.colours.len() {
+            continue;
+        }
+        groups.entry(c_idx).or_default().push(tri_i);
+    }
+    if groups.is_empty() {
+        return None;
+    }
+
+    let mut out: Vec<(ifc_lite_geometry::Mesh, [f32; 4])> = Vec::with_capacity(groups.len());
+    for (c_idx, tri_indices) in groups {
+        let colour = map.colours[(c_idx - 1) as usize];
+        let mut sub = ifc_lite_geometry::Mesh::new();
+        sub.positions.reserve(tri_indices.len() * 9);
+        sub.normals.reserve(tri_indices.len() * 9);
+        for &tri_i in &tri_indices {
+            let tri_base = tri_i * 3;
+            for corner in 0..3 {
+                let v = mesh.indices[tri_base + corner] as usize;
+                let pos_base = v * 3;
+                if pos_base + 3 > mesh.positions.len() {
+                    continue;
+                }
+                sub.positions
+                    .extend_from_slice(&mesh.positions[pos_base..pos_base + 3]);
+                if pos_base + 3 <= mesh.normals.len() {
+                    sub.normals
+                        .extend_from_slice(&mesh.normals[pos_base..pos_base + 3]);
+                } else {
+                    sub.normals.extend_from_slice(&[0.0, 0.0, 0.0]);
+                }
+            }
+        }
+        let n_verts = (sub.positions.len() / 3) as u32;
+        sub.indices = (0..n_verts).collect();
+        out.push((sub, colour));
+    }
+    Some(out)
 }
 
 #[wasm_bindgen]
@@ -88,6 +147,13 @@ impl IfcAPI {
         let mut faceted_brep_ids: Vec<u32> = Vec::new();
         let mut void_index: rustc_hash::FxHashMap<u32, Vec<u32>> = rustc_hash::FxHashMap::default();
 
+        // Pre-resolve every IfcIndexedColourMap so the rendering loop can
+        // split a coloured face-set's mesh into per-colour sub-meshes
+        // without doing a per-element decoder lookup. Issue #858 — only
+        // the dominant colour was applied pre-fix.
+        let mut indexed_colour_maps: rustc_hash::FxHashMap<u32, IndexedColourMapResolved> =
+            rustc_hash::FxHashMap::default();
+
         while let Some((id, type_name, start, end)) = scanner.next_entity() {
             if type_name == "IFCFACETEDBREP" {
                 faceted_brep_ids.push(id);
@@ -99,6 +165,12 @@ impl IfcAPI {
                     {
                         void_index.entry(host_id).or_default().push(opening_id);
                     }
+                }
+            } else if type_name == "IFCINDEXEDCOLOURMAP" {
+                if let Some(resolved) =
+                    extract_full_indexed_colour_map_span(id, start, end, &mut decoder)
+                {
+                    indexed_colour_maps.insert(resolved.geometry_id, resolved);
                 }
             }
         }
@@ -315,6 +387,22 @@ impl IfcAPI {
 
                         for sub in sub_meshes.sub_meshes {
                             let mut mesh = sub.mesh;
+                            // Issue #858: per-triangle colour split. After
+                            // void cutting the triangle count usually no
+                            // longer matches the original colour map, so
+                            // this branch is mostly a no-op for cut
+                            // geometry — but for uncut tessellated parts
+                            // mixed in the same element it still applies.
+                            if let Some(map) = indexed_colour_maps.get(&sub.geometry_id) {
+                                if let Some(groups) =
+                                    split_mesh_by_indexed_colour_map(&mesh, map)
+                                {
+                                    for (mut group_mesh, group_color) in groups {
+                                        push_mesh_if_valid(&mut group_mesh, group_color, None);
+                                    }
+                                    continue;
+                                }
+                            }
                             let color = resolve_submesh_color(
                                 sub.geometry_id,
                                 &geometry_styles,
@@ -376,6 +464,20 @@ impl IfcAPI {
 
                         for sub in sub_meshes.sub_meshes {
                             let mut mesh = sub.mesh;
+                            // Issue #858: when the source geometry has an
+                            // IfcIndexedColourMap, split the mesh into per-
+                            // colour sub-meshes. Falls through to the
+                            // single-colour path on length mismatch.
+                            if let Some(map) = indexed_colour_maps.get(&sub.geometry_id) {
+                                if let Some(groups) =
+                                    split_mesh_by_indexed_colour_map(&mesh, map)
+                                {
+                                    for (mut group_mesh, group_color) in groups {
+                                        push_mesh_if_valid(&mut group_mesh, group_color, None);
+                                    }
+                                    continue;
+                                }
+                            }
                             let color = resolve_submesh_color(
                                 sub.geometry_id,
                                 &geometry_styles,
@@ -4334,5 +4436,71 @@ impl IfcAPI {
         }
 
         collection
+    }
+}
+
+#[cfg(test)]
+mod indexed_colour_map_split_tests {
+    //! Issue #858 — verify the flat-shaded mesh split keeps the triangle
+    //! count, partitions triangles by palette index, and pairs each
+    //! group with the correct colour.
+    use super::split_mesh_by_indexed_colour_map;
+    use super::IndexedColourMapResolved;
+    use ifc_lite_geometry::Mesh;
+
+    fn flat_shaded_quad() -> Mesh {
+        // 2 triangles in a flat-shaded layout (6 unique vertices, one
+        // per corner) — mirrors what `TriangulatedFaceSetProcessor`
+        // emits via `build_flat_shaded_mesh`.
+        let mut m = Mesh::new();
+        m.positions = vec![
+            // tri 0: a quad's lower triangle
+            0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0,
+            // tri 1: upper triangle
+            0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0,
+        ];
+        m.normals = vec![0.0; 18];
+        m.indices = vec![0, 1, 2, 3, 4, 5];
+        m
+    }
+
+    #[test]
+    fn splits_into_two_groups() {
+        let mesh = flat_shaded_quad();
+        let map = IndexedColourMapResolved {
+            geometry_id: 1,
+            colours: vec![[1.0, 0.0, 0.0, 1.0], [0.0, 1.0, 0.0, 1.0]],
+            triangle_indices: vec![1, 2],
+        };
+        let groups = split_mesh_by_indexed_colour_map(&mesh, &map).expect("split");
+        assert_eq!(groups.len(), 2);
+
+        let mut totals_by_colour: std::collections::HashMap<[u32; 4], usize> =
+            std::collections::HashMap::new();
+        for (sub, colour) in &groups {
+            let key = [
+                (colour[0] * 255.0) as u32,
+                (colour[1] * 255.0) as u32,
+                (colour[2] * 255.0) as u32,
+                (colour[3] * 255.0) as u32,
+            ];
+            *totals_by_colour.entry(key).or_insert(0) += sub.indices.len() / 3;
+        }
+        assert_eq!(totals_by_colour[&[255, 0, 0, 255]], 1, "tri 0 → red");
+        assert_eq!(totals_by_colour[&[0, 255, 0, 255]], 1, "tri 1 → green");
+    }
+
+    #[test]
+    fn returns_none_on_length_mismatch() {
+        let mesh = flat_shaded_quad();
+        let map = IndexedColourMapResolved {
+            geometry_id: 1,
+            colours: vec![[1.0, 0.0, 0.0, 1.0]],
+            triangle_indices: vec![1, 1, 1], // 3 entries, mesh has 2 tris
+        };
+        assert!(
+            split_mesh_by_indexed_colour_map(&mesh, &map).is_none(),
+            "length mismatch must fall through to single-colour path",
+        );
     }
 }

--- a/rust/wasm-bindings/src/api/styling.rs
+++ b/rust/wasm-bindings/src/api/styling.rs
@@ -142,6 +142,80 @@ pub(crate) fn extract_color_from_indexed_colour_map_span(
     extract_color_from_indexed_colour_map(id, start, end, decoder)
 }
 
+/// Full IfcIndexedColourMap payload: every authored colour + the per-
+/// triangle index list, so callers can split a mesh into colour groups
+/// instead of collapsing to a single dominant colour.
+///
+/// Used for issue #858 — `tessellation-with-individual-colors.ifc`
+/// authors a 12-triangle cube with three colours (red/green/yellow);
+/// the dominant-only path picked red and rendered the whole cube red.
+pub(crate) struct IndexedColourMapResolved {
+    /// Target IfcTessellatedFaceSet entity id.
+    pub geometry_id: u32,
+    /// Resolved RGBA palette. 1-based indexing per ISO 10303-21 — index 1
+    /// is `colours[0]`, etc.
+    pub colours: Vec<[f32; 4]>,
+    /// Per-triangle 1-based palette index. Same length as the face-set's
+    /// triangle list.
+    pub triangle_indices: Vec<u32>,
+}
+
+/// Span-based companion to [`extract_color_from_indexed_colour_map_span`]
+/// that returns the full per-triangle colour assignment rather than
+/// collapsing to a single dominant colour. Returns `None` when the map
+/// can't be resolved (bad references, empty index list, etc.).
+pub(crate) fn extract_full_indexed_colour_map_span(
+    id: u32,
+    start: usize,
+    end: usize,
+    decoder: &mut ifc_lite_core::EntityDecoder,
+) -> Option<IndexedColourMapResolved> {
+    let entity = decoder.decode_at_with_id(id, start, end).ok()?;
+    let geometry_id = entity.get_ref(0)?;
+    let opacity = entity
+        .get(1)
+        .and_then(|a| a.as_float())
+        .map(|v| v as f32)
+        .unwrap_or(1.0)
+        .clamp(0.0, 1.0);
+    let colours_id = entity.get_ref(2)?;
+    let index_list = entity.get(3)?.as_list()?;
+    if index_list.is_empty() {
+        return None;
+    }
+
+    let colours_entity = decoder.decode_by_id(colours_id).ok()?;
+    let colour_list = colours_entity.get(0)?.as_list()?;
+    let colours: Vec<[f32; 4]> = colour_list
+        .iter()
+        .filter_map(|c| {
+            let rgb = c.as_list()?;
+            let r = rgb.first().and_then(|v| v.as_float())? as f32;
+            let g = rgb.get(1).and_then(|v| v.as_float())? as f32;
+            let b = rgb.get(2).and_then(|v| v.as_float())? as f32;
+            Some([r, g, b, opacity])
+        })
+        .collect();
+    if colours.is_empty() {
+        return None;
+    }
+
+    let triangle_indices: Vec<u32> = index_list
+        .iter()
+        .filter_map(|v| v.as_int())
+        .map(|i| i.max(0) as u32)
+        .collect();
+    if triangle_indices.is_empty() {
+        return None;
+    }
+
+    Some(IndexedColourMapResolved {
+        geometry_id,
+        colours,
+        triangle_indices,
+    })
+}
+
 fn extract_color_from_indexed_colour_map(
     id: u32,
     start: usize,
@@ -1566,5 +1640,58 @@ END-ISO-10303-21;
         // Unrelated express ID — neither the wall nor any item in its rep.
         styles.insert(999, [0.5, 0.5, 0.5, 1.0]);
         assert_eq!(resolve_element_color(&wall, &styles, &mut decoder), None);
+    }
+}
+
+#[cfg(test)]
+mod indexed_colour_map_tests {
+    //! Issue #858 — `IfcIndexedColourMap` must surface every authored
+    //! colour, not just the dominant one. `extract_full_indexed_colour_map_span`
+    //! is the data-extraction half of the fix; `gpu_meshes.rs` consumes the
+    //! resolved struct to split a flat-shaded mesh into per-colour groups.
+    use super::extract_full_indexed_colour_map_span;
+    use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner};
+
+    /// Minimal IFC4 fixture: an `IfcTriangulatedFaceSet` with 12 triangles
+    /// + an `IfcIndexedColourMap` assigning 3 colours
+    /// (red / green / yellow). Matches the reporter's
+    /// `tessellation-with-individual-colors.ifc` structure.
+    const FIXTURE: &str = "ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('test'),'2;1');
+FILE_NAME('','2024-01-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#200=IFCCARTESIANPOINTLIST3D(((0.0,0.0,0.0),(1.0,0.0,0.0),(1.0,1.0,0.0),(0.0,1.0,0.0),(0.0,0.0,1.0),(1.0,0.0,1.0),(1.0,1.0,1.0),(0.0,1.0,1.0)));
+#201=IFCTRIANGULATEDFACESET(#200,$,.T.,((1,6,5),(1,2,6),(6,2,7),(7,2,3),(7,8,6),(6,8,5),(5,8,1),(1,8,4),(4,2,1),(2,4,3),(4,8,7),(7,3,4)),$);
+#202=IFCCOLOURRGBLIST(((1.0,0.0,0.0),(0.0,0.5,0.0),(1.0,1.0,0.0)));
+#203=IFCINDEXEDCOLOURMAP(#201,$,#202,(1,1,2,2,3,3,1,1,1,1,1,1));
+ENDSEC;
+END-ISO-10303-21;
+";
+
+    #[test]
+    fn extracts_three_colours_with_twelve_indices() {
+        let mut decoder = EntityDecoder::with_index(FIXTURE, build_entity_index(FIXTURE));
+        let mut scanner = EntityScanner::new(FIXTURE);
+        let mut resolved = None;
+        while let Some((id, name, start, end)) = scanner.next_entity() {
+            if name == "IFCINDEXEDCOLOURMAP" {
+                resolved = extract_full_indexed_colour_map_span(id, start, end, &mut decoder);
+                break;
+            }
+        }
+        let r = resolved.expect("colour map must resolve");
+        assert_eq!(r.geometry_id, 201);
+        assert_eq!(r.colours.len(), 3, "all three palette entries must surface");
+        assert_eq!(r.colours[0], [1.0, 0.0, 0.0, 1.0]);
+        assert_eq!(r.colours[1], [0.0, 0.5, 0.0, 1.0]);
+        assert_eq!(r.colours[2], [1.0, 1.0, 0.0, 1.0]);
+        assert_eq!(
+            r.triangle_indices,
+            vec![1, 1, 2, 2, 3, 3, 1, 1, 1, 1, 1, 1],
+            "per-triangle palette assignment must round-trip verbatim",
+        );
     }
 }

--- a/rust/wasm-bindings/src/api/styling.rs
+++ b/rust/wasm-bindings/src/api/styling.rs
@@ -42,6 +42,14 @@ pub(crate) fn build_geometry_style_index(
 pub(crate) struct GeometryStyleIndexes {
     pub colors: rustc_hash::FxHashMap<u32, [f32; 4]>,
     pub shading_colors: rustc_hash::FxHashMap<u32, [f32; 4]>,
+    /// Geometry IDs that had an `IfcStyledItem` directly authored on
+    /// them. Distinct from `colors` because the merge below also folds
+    /// in `IfcIndexedColourMap` dominant colours for geometries without
+    /// a styled item — once merged, the source is no longer
+    /// recoverable. PR #867 review (chatgpt-codex P2): the per-
+    /// triangle colour-map splitter in `gpu_meshes.rs` must defer to
+    /// IfcStyledItem when both are authored on the same face set.
+    pub styled_item_geoms: rustc_hash::FxHashSet<u32>,
 }
 
 /// Single-pass variant that also returns the per-geometry shading colour
@@ -55,6 +63,7 @@ pub(crate) fn build_geometry_style_indexes(
 
     let mut style_index: FxHashMap<u32, [f32; 4]> = FxHashMap::default();
     let mut shading_index: FxHashMap<u32, [f32; 4]> = FxHashMap::default();
+    let mut styled_item_geoms: rustc_hash::FxHashSet<u32> = rustc_hash::FxHashSet::default();
     // Stash IfcIndexedColourMap results separately so the merge below can
     // give IfcStyledItem unconditional precedence regardless of scan order
     // — files where an IFCINDEXEDCOLOURMAP appears before its matching
@@ -87,6 +96,7 @@ pub(crate) fn build_geometry_style_indexes(
                     extract_color_pair_from_styles(styles_attr, decoder)
                 {
                     style_index.insert(geometry_id, color);
+                    styled_item_geoms.insert(geometry_id);
                     if let Some(s) = shading {
                         shading_index.insert(geometry_id, s);
                     }
@@ -114,6 +124,7 @@ pub(crate) fn build_geometry_style_indexes(
     GeometryStyleIndexes {
         colors: style_index,
         shading_colors: shading_index,
+        styled_item_geoms,
     }
 }
 
@@ -186,25 +197,38 @@ pub(crate) fn extract_full_indexed_colour_map_span(
 
     let colours_entity = decoder.decode_by_id(colours_id).ok()?;
     let colour_list = colours_entity.get(0)?.as_list()?;
-    let colours: Vec<[f32; 4]> = colour_list
-        .iter()
-        .filter_map(|c| {
-            let rgb = c.as_list()?;
-            let r = rgb.first().and_then(|v| v.as_float())? as f32;
-            let g = rgb.get(1).and_then(|v| v.as_float())? as f32;
-            let b = rgb.get(2).and_then(|v| v.as_float())? as f32;
-            Some([r, g, b, opacity])
-        })
-        .collect();
+    // Strict-mode resolution: any malformed entry collapses the whole
+    // map to `None` so the caller falls back to the dominant-colour
+    // path. PR #867 review (CodeRabbit Major) — `filter_map` previously
+    // silently dropped bad rows / negative indices, leaving the
+    // resolver returning a palette/index mapping that no longer
+    // matched the authored triangle count. The splitter would then
+    // emit fewer triangles than the source mesh instead of routing
+    // through the single-colour fallback. Reject the whole map up
+    // front so the contract `triangle_indices.len() == mesh.tris`
+    // holds whenever the resolver returns Some.
+    let mut colours: Vec<[f32; 4]> = Vec::with_capacity(colour_list.len());
+    for c in colour_list {
+        let rgb = c.as_list()?;
+        let r = rgb.first().and_then(|v| v.as_float())? as f32;
+        let g = rgb.get(1).and_then(|v| v.as_float())? as f32;
+        let b = rgb.get(2).and_then(|v| v.as_float())? as f32;
+        colours.push([r, g, b, opacity]);
+    }
     if colours.is_empty() {
         return None;
     }
 
-    let triangle_indices: Vec<u32> = index_list
-        .iter()
-        .filter_map(|v| v.as_int())
-        .map(|i| i.max(0) as u32)
-        .collect();
+    let mut triangle_indices: Vec<u32> = Vec::with_capacity(index_list.len());
+    for v in index_list {
+        let idx = v.as_int()?;
+        if idx <= 0 || (idx as usize) > colours.len() {
+            // Out-of-range / non-positive index ⇒ the entire map is
+            // structurally invalid; bail.
+            return None;
+        }
+        triangle_indices.push(idx as u32);
+    }
     if triangle_indices.is_empty() {
         return None;
     }
@@ -660,6 +684,18 @@ pub(crate) struct PrePassData {
     /// `propagate_voids_to_parts` so the merge-layers toggle (#540) can skip
     /// per-part meshes when the parent is sliceable.
     pub part_to_parent: rustc_hash::FxHashMap<u32, u32>,
+    /// Geometry IDs that had an `IfcStyledItem` directly authored. Used by
+    /// the per-triangle IfcIndexedColourMap splitter to defer to the
+    /// styled-item colour when both mechanisms are authored on the same
+    /// face set. PR #867 review (chatgpt-codex P2).
+    pub styled_item_geoms: rustc_hash::FxHashSet<u32>,
+    /// Full per-face IfcIndexedColourMap payload keyed by face-set geometry
+    /// id. Populated only when the streaming / async render loop needs to
+    /// split a flat-shaded mesh into per-colour sub-meshes (issue #858).
+    /// `None` entry means "no colour map" (cheaper than an absent key for
+    /// the hot lookup); the splitter only fires when this map's
+    /// `triangle_indices` length matches the source mesh's triangle count.
+    pub indexed_colour_maps: rustc_hash::FxHashMap<u32, IndexedColourMapResolved>,
 }
 
 /// Single EntityScanner pass that collects everything needed before geometry
@@ -699,6 +735,11 @@ pub(crate) fn combined_pre_pass(
     let mut material_def_reprs: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
     // IfcRelAssociatesMaterial: element_id → material_select_id
     let mut element_to_material: FxHashMap<u32, u32> = FxHashMap::default();
+    // PR #867: geometries with a direct IfcStyledItem (so the per-face
+    // colour-map splitter can defer to the styled colour), and the full
+    // per-face colour-map payload for the splitter itself.
+    let mut styled_item_geoms: rustc_hash::FxHashSet<u32> = rustc_hash::FxHashSet::default();
+    let mut indexed_colour_maps: FxHashMap<u32, IndexedColourMapResolved> = FxHashMap::default();
 
     let mut scanner = EntityScanner::new(content);
 
@@ -714,11 +755,17 @@ pub(crate) fn combined_pre_pass(
                                     extract_color_pair_from_styles(styles_attr, decoder)
                                 {
                                     geometry_styles.insert(geometry_id, color);
+                                    styled_item_geoms.insert(geometry_id);
                                     if let Some(s) = shading {
                                         geometry_shading_styles.insert(geometry_id, s);
                                     }
                                 }
                             }
+                        } else {
+                            // Already-styled geometry — still record source so
+                            // the colour-map splitter knows to defer to the
+                            // styled colour (PR #867).
+                            styled_item_geoms.insert(geometry_id);
                         }
                     } else {
                         // Orphan IfcStyledItem (null Item) — material-based color
@@ -738,6 +785,18 @@ pub(crate) fn combined_pre_pass(
                     extract_color_from_indexed_colour_map(id, start, end, decoder)
                 {
                     colour_map_styles.entry(geometry_id).or_insert(color);
+                }
+                // ALSO collect the full per-face payload so the streaming /
+                // async render loops can split a flat-shaded mesh into per-
+                // colour sub-meshes (issue #858 / PR #867). Re-decoding is
+                // cheap (~µs) compared to the geometry pass that follows,
+                // and the dominant-colour fast path above caches the
+                // map's first decode under the hood so this is mostly
+                // a re-pull from the entity cache.
+                if let Some(resolved) =
+                    extract_full_indexed_colour_map_span(id, start, end, decoder)
+                {
+                    indexed_colour_maps.insert(resolved.geometry_id, resolved);
                 }
             }
             "IFCMATERIALDEFINITIONREPRESENTATION" | "IFCRELASSOCIATESMATERIAL" => {
@@ -851,6 +910,8 @@ pub(crate) fn combined_pre_pass(
         element_material_styles,
         material_layer_index,
         part_to_parent,
+        styled_item_geoms,
+        indexed_colour_maps,
     }
 }
 

--- a/tests/models/manifest.json
+++ b/tests/models/manifest.json
@@ -734,6 +734,11 @@
       "size": 18659
     },
     {
+      "path": "issues/858_indexed_colour_map.ifc",
+      "sha256": "2b48006569d06b9d8f77535cc72ee6c21cbe93cfe87704319a7b1934263d81ba",
+      "size": 2629
+    },
+    {
       "path": "various/01_BIMcollab_Example_ARC.ifc",
       "sha256": "87392cf24264b023e65d8ca1dab1eb8996643c1aa51b9dff9d518ed8904151fc",
       "size": 18230149


### PR DESCRIPTION
## Summary
- Pre-fix `extract_color_from_indexed_colour_map` collapses each `IfcIndexedColourMap` to its dominant palette entry, so a face-set authored with 3 colours (red / green / yellow on the reporter's 12-triangle cube) rendered as a single red cube.
- Added `extract_full_indexed_colour_map_span` to return the full per-triangle assignment, scanned every `IFCINDEXEDCOLOURMAP` in the streaming pre-scan, and made the sub-mesh rendering loops in `parseMeshes` split the flat-shaded mesh into per-colour sub-meshes before emitting `MeshDataJs`. The existing single-colour resolver still runs as the fallback when triangle counts don't match (e.g. after CSG cuts).

## Test plan
- [x] `cargo test -p ifc-lite-wasm` — full crate, 14 tests pass (was 11; +3 new).
- [x] `cargo test -p ifc-lite-core -p ifc-lite-geometry -p ifc-lite-wasm` — 0 failures.
- [x] Fixture uploaded; manifest entry added.

Closes #858.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mesh rendering now supports per-triangle palette-based coloring (indexed colour maps), splitting meshes into per-palette sub-meshes for correct multi-color display; gracefully falls back to prior single-color behavior when maps are incompatible or overridden by styled items.
* **Tests**
  * Added unit tests validating indexed-colour extraction and per-color mesh splitting behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LTplus-AG/ifc-lite/pull/867?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->