### PR TITLE
feat(viewer): IfcGrid section-clipping + separate visibility toggle (#862)

### DIFF
--- a/apps/viewer/src/components/viewer/CommandPalette.tsx
+++ b/apps/viewer/src/components/viewer/CommandPalette.tsx
@@ -410,8 +410,12 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
         action: () => { useViewerStore.getState().toggleTypeVisibility('openings'); } },
       { id: 'vis:site', label: 'Site', keywords: 'IfcSite terrain show hide', category: 'Visibility', icon: Building2,
         action: () => { useViewerStore.getState().toggleTypeVisibility('site'); } },
-      { id: 'vis:ifcAnnotations', label: 'Annotations & Grids', keywords: 'IfcAnnotation IfcGrid IfcGridAxis 2d drawing symbols text dimension grid axis bubble tag show hide', category: 'Visibility', icon: Pencil,
+      { id: 'vis:ifcAnnotations', label: 'Annotations', keywords: 'IfcAnnotation 2d drawing symbols text dimension leader label show hide', category: 'Visibility', icon: Pencil,
         action: () => { useViewerStore.getState().toggleTypeVisibility('ifcAnnotations'); } },
+      // Issue #862: IfcGrid split off from IfcAnnotation so dense-grid
+      // models can hide axes/bubbles without losing dimensions.
+      { id: 'vis:ifcGrid', label: 'Grids', keywords: 'IfcGrid IfcGridAxis grid axis bubble tag show hide section clip', category: 'Visibility', icon: Pencil,
+        action: () => { useViewerStore.getState().toggleTypeVisibility('ifcGrid'); } },
       { id: 'vis:reset-colors', label: 'Reset Colors', keywords: 'clear color override', category: 'Visibility', icon: Palette,
         action: () => { execute('bim.viewer.resetColors()\nconsole.log("Colors reset")'); } },
     );

--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -627,29 +627,42 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
     // eslint-disable-next-line react-hooks/exhaustive-deps -- meshLen is a stable proxy for geometryResult
   }, [models, meshLen]);
 
-  // IfcAnnotation has no body mesh, so it can't be detected via the mesh scan.
-  // Look up the entity table directly. byType keys are uppercase STEP names
-  // ('IFCANNOTATION') but cache loads sometimes preserve PascalCase too.
-  // Symbolic 2D overlays cover BOTH IfcAnnotation (text, dimensions, leader
-  // lines, filled regions) AND IfcGrid (axis lines + synthesized bubble +
-  // tag). Some files ship only grids (Snowdon Towers Structural is the
-  // canonical example — no IfcAnnotation at all), so the toggle must
-  // surface for either entity type or grid-only models get no way to hide
-  // the overlay.
-  const hasIfcAnnotations = useMemo(() => {
-    const has = (store: typeof ifcDataStore | undefined) => {
+  // IfcAnnotation / IfcGrid have no body mesh, so they can't be detected via
+  // the mesh scan. Look up the entity table directly. byType keys are
+  // uppercase STEP names but cache loads sometimes preserve PascalCase.
+  //
+  // Issue #862 split these into separate visibility toggles — files that
+  // ship only one of the two need only that menu entry. Some files ship
+  // only grids (Snowdon Towers Structural — no IfcAnnotation) so probing
+  // each independently is required.
+  const hasIfcEntities = useMemo(() => {
+    const probe = (store: typeof ifcDataStore | undefined) => {
       const byType = store?.entityIndex?.byType;
-      if (!byType) return false;
-      return (byType.get('IFCANNOTATION')?.length ?? 0) > 0
-        || (byType.get('IfcAnnotation')?.length ?? 0) > 0
-        || (byType.get('IFCGRID')?.length ?? 0) > 0
-        || (byType.get('IfcGrid')?.length ?? 0) > 0;
+      if (!byType) return { annotations: false, grid: false };
+      return {
+        annotations: (byType.get('IFCANNOTATION')?.length ?? 0) > 0
+          || (byType.get('IfcAnnotation')?.length ?? 0) > 0,
+        grid: (byType.get('IFCGRID')?.length ?? 0) > 0
+          || (byType.get('IfcGrid')?.length ?? 0) > 0,
+      };
     };
+    let annotations = false;
+    let grid = false;
     if (models.size > 0) {
-      for (const [, m] of models) if (has(m.ifcDataStore)) return true;
+      for (const [, m] of models) {
+        const p = probe(m.ifcDataStore);
+        annotations ||= p.annotations;
+        grid ||= p.grid;
+      }
+    } else {
+      const p = probe(ifcDataStore);
+      annotations = p.annotations;
+      grid = p.grid;
     }
-    return has(ifcDataStore);
+    return { annotations, grid };
   }, [models, ifcDataStore]);
+  const hasIfcAnnotations = hasIfcEntities.annotations;
+  const hasIfcGrid = hasIfcEntities.grid;
 
   const handleFileSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
@@ -1577,7 +1590,16 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
               onCheckedChange={() => toggleTypeVisibility('ifcAnnotations')}
             >
               <Pencil className="h-4 w-4 mr-2" style={{ color: '#e4b400' }} />
-              Show Annotations & Grids
+              Show Annotations
+            </DropdownMenuCheckboxItem>
+          )}
+          {hasIfcGrid && (
+            <DropdownMenuCheckboxItem
+              checked={typeVisibility.ifcGrid}
+              onCheckedChange={() => toggleTypeVisibility('ifcGrid')}
+            >
+              <Pencil className="h-4 w-4 mr-2" style={{ color: '#e4b400' }} />
+              Show Grids
             </DropdownMenuCheckboxItem>
           )}
 

--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -40,7 +40,11 @@ import { useGeometryStreaming } from './useGeometryStreaming.js';
 import { usePointCloudSync } from './usePointCloudSync.js';
 import { usePointCloudLifecycle } from './usePointCloudLifecycle.js';
 import { useRenderUpdates } from './useRenderUpdates.js';
-import { useSymbolicAnnotations, useSymbolicAnnotationsRichData } from '../../hooks/useSymbolicAnnotations.js';
+import {
+  useSymbolicAnnotations,
+  useSymbolicAnnotationsRichData,
+  type SectionClipForGrid,
+} from '../../hooks/useSymbolicAnnotations.js';
 
 interface ViewportProps {
   geometry: MeshData[] | null;
@@ -787,6 +791,11 @@ export function Viewport({
   // storey model shows all storeys' annotations layered correctly in 3D
   // (issue #653). Parsing is lazy and only runs while the toggle is on.
   const ifcAnnotationsVisible = useViewerStore((s) => s.typeVisibility.ifcAnnotations);
+  // Issue #862: IfcGrid is a separate toggle from IfcAnnotation. Default
+  // is on so existing users see no change; when the user disables it the
+  // grid axes + bubble tags drop out without affecting dimension/leader
+  // annotation rendering.
+  const ifcGridVisible = useViewerStore((s) => s.typeVisibility.ifcGrid);
   // For annotations whose storey can't be resolved (or whose authored
   // elevation is 0 because the storey Z lives on the placement instead),
   // lift to the middle of the model's vertical span so they don't end up
@@ -799,12 +808,37 @@ export function Viewport({
     if (!Number.isFinite(min) || !Number.isFinite(max) || max <= min) return 0;
     return (min + max) * 0.5;
   }, [coordinateInfo]);
+
+  // Issue #862: section-clip grid lines so dense-grid models stay
+  // readable when a horizontal cut is active. Use a 1.5 m band on each
+  // side of the cut so the cut storey's grids are visible but storeys
+  // 1.5 m+ away are hidden (matches typical residential floor heights).
+  // Only applies to the floor-plan axis (`'down'`) — vertical cuts
+  // don't clip grids since grid lines are inherently vertical.
+  const gridSectionClip = useMemo<SectionClipForGrid | undefined>(() => {
+    if (!sectionPlane.enabled || sectionPlane.axis !== 'down' || !sectionRange) {
+      return undefined;
+    }
+    const posWorld = sectionRange.min + (sectionPlane.position / 100) * (sectionRange.max - sectionRange.min);
+    const GRID_CLIP_HALF_BAND_M = 1.5;
+    return {
+      enabled: true,
+      posWorld,
+      viewDepth: GRID_CLIP_HALF_BAND_M,
+      axis: sectionPlane.axis,
+    };
+  }, [sectionPlane.enabled, sectionPlane.axis, sectionPlane.position, sectionRange]);
+
   const annotationVertices3D = useSymbolicAnnotations({
     enabled: ifcAnnotationsVisible,
+    gridEnabled: ifcGridVisible,
+    gridSectionClip,
     fallbackY: annotationFallbackY,
   });
   const { texts: annotationTexts3D, fills: annotationFills3D } = useSymbolicAnnotationsRichData({
     enabled: ifcAnnotationsVisible,
+    gridEnabled: ifcGridVisible,
+    gridSectionClip,
     fallbackY: annotationFallbackY,
   });
   useEffect(() => {

--- a/apps/viewer/src/hooks/useSymbolicAnnotations.ts
+++ b/apps/viewer/src/hooks/useSymbolicAnnotations.ts
@@ -91,13 +91,31 @@ export interface AnnotationFill2D {
   };
 }
 
-/** Cached parse result keyed by source identity. */
+/** Cached parse result keyed by source identity.
+ *
+ * IfcAnnotation and IfcGridAxis primitives are stored in PARALLEL bucket
+ * collections (issue #862). They share the same parse pass and the same
+ * storey-resolution logic, but the renderer treats them differently:
+ *
+ *   - Annotation buckets always lift every storey (memory
+ *     `feedback_3d_annotation_overlay_no_section_filter.md`: the user
+ *     expects every storey's dimensions to be visible in 3D).
+ *   - Grid buckets get optional section-plane filtering and an
+ *     independent visibility toggle, so dense-grid models can hide
+ *     grids per storey without losing dimensions.
+ */
 interface ParseResult {
+  // IfcAnnotation buckets
   byStorey: Map<number, AnnotationsForStorey>;
-  /** Annotations with no resolvable storey — shown on every floor as a fallback. */
   loose: DrawingLine2D[];
   looseTexts: AnnotationText2D[];
   looseFills: AnnotationFill2D[];
+
+  // IfcGridAxis buckets (issue #862)
+  gridByStorey: Map<number, AnnotationsForStorey>;
+  gridLoose: DrawingLine2D[];
+  gridLooseTexts: AnnotationText2D[];
+  gridLooseFills: AnnotationFill2D[];
 }
 
 const CIRCLE_SEGMENTS_FULL = 32;
@@ -212,6 +230,10 @@ async function parseAnnotations(
     loose: [],
     looseTexts: [],
     looseFills: [],
+    gridByStorey: new Map(),
+    gridLoose: [],
+    gridLooseTexts: [],
+    gridLooseFills: [],
   };
   const source = store.source;
   if (!source || source.byteLength === 0) {
@@ -256,6 +278,7 @@ async function parseAnnotations(
     const ensureBucket = (
       expressId: number,
       primitiveWorldY: number,
+      ifcType: string,
     ): AnnotationsForStorey | null => {
       let effectiveY: number | null = null;
       if (Number.isFinite(primitiveWorldY) && primitiveWorldY !== 0) {
@@ -269,7 +292,11 @@ async function parseAnnotations(
       }
       if (effectiveY === null) return null;
       const key = Math.round(effectiveY * 1000);
-      let bucket = result.byStorey.get(key);
+      // Issue #862: IfcGridAxis primitives land in a parallel bucket
+      // collection so the renderer can section-clip + visibility-toggle
+      // them independently of IfcAnnotation (text/dimension symbols).
+      const storeyMap = ifcType === 'IfcGridAxis' ? result.gridByStorey : result.byStorey;
+      let bucket = storeyMap.get(key);
       if (!bucket) {
         bucket = {
           storeyId: key,
@@ -278,7 +305,7 @@ async function parseAnnotations(
           texts: [],
           fills: [],
         };
-        result.byStorey.set(key, bucket);
+        storeyMap.set(key, bucket);
       }
       return bucket;
     };
@@ -287,8 +314,9 @@ async function parseAnnotations(
       const poly = collection.getPolyline(i);
       if (!poly) continue;
       if (poly.ifcType !== 'IfcAnnotation' && poly.ifcType !== 'IfcGridAxis') continue;
-      const bucket = ensureBucket(poly.expressId, poly.worldY);
-      const out = bucket ? bucket.lines : result.loose;
+      const bucket = ensureBucket(poly.expressId, poly.worldY, poly.ifcType);
+      const looseTarget = poly.ifcType === 'IfcGridAxis' ? result.gridLoose : result.loose;
+      const out = bucket ? bucket.lines : looseTarget;
       polylineToSegments(poly.points, poly.pointCount, poly.isClosed, out);
     }
 
@@ -296,8 +324,9 @@ async function parseAnnotations(
       const circle = collection.getCircle(i);
       if (!circle) continue;
       if (circle.ifcType !== 'IfcAnnotation' && circle.ifcType !== 'IfcGridAxis') continue;
-      const bucket = ensureBucket(circle.expressId, circle.worldY);
-      const out = bucket ? bucket.lines : result.loose;
+      const bucket = ensureBucket(circle.expressId, circle.worldY, circle.ifcType);
+      const looseTarget = circle.ifcType === 'IfcGridAxis' ? result.gridLoose : result.loose;
+      const out = bucket ? bucket.lines : looseTarget;
       circleToSegments(
         circle.centerX,
         circle.centerY,
@@ -335,7 +364,8 @@ async function parseAnnotations(
       // Industry-standard line-spacing (CSS line-height ≈ 1.2). Picks up
       // a little air between rows so descenders don't kiss the next cap.
       const lineSpacing = perLineHeight * 1.2;
-      const bucket = ensureBucket(text.expressId, text.worldY);
+      const bucket = ensureBucket(text.expressId, text.worldY, text.ifcType);
+      const looseTextTarget = text.ifcType === 'IfcGridAxis' ? result.gridLooseTexts : result.looseTexts;
       // All annotation text — grid bubbles, dimension callouts, leader labels —
       // billboards to the camera so it stays legible in any view orientation
       // (top-down, eye-level, oblique). The shader rebuilds the quad in the
@@ -366,7 +396,7 @@ async function parseAnnotations(
           color: textColor,
           targetPx,
         };
-        (bucket ? bucket.texts : result.looseTexts).push(t2d);
+        (bucket ? bucket.texts : looseTextTarget).push(t2d);
       }
     }
 
@@ -389,8 +419,9 @@ async function parseAnnotations(
             }
           : undefined,
       };
-      const bucket = ensureBucket(fill.expressId, fill.worldY);
-      (bucket ? bucket.fills : result.looseFills).push(f2d);
+      const bucket = ensureBucket(fill.expressId, fill.worldY, fill.ifcType);
+      const looseFillTarget = fill.ifcType === 'IfcGridAxis' ? result.gridLooseFills : result.looseFills;
+      (bucket ? bucket.fills : looseFillTarget).push(f2d);
     }
   } finally {
     processor.dispose();
@@ -521,17 +552,48 @@ function resolveBucketY(elevation: number | null, fallbackY: number): number {
   return elevation === null ? fallbackY : elevation;
 }
 
-export function useSymbolicAnnotations(params: {
+/** Section-clip parameters for grid lines (issue #862). Grids ARE clipped
+ *  by the active section plane; IfcAnnotation overlays are NOT (per the
+ *  feedback_3d_annotation_overlay_no_section_filter memory). When
+ *  `enabled === false` no clipping happens — grids lift to every storey
+ *  same as annotations.
+ */
+export interface SectionClipForGrid {
   enabled: boolean;
+  /** World coord on the cut axis (e.g. world-Y for axis='down'). */
+  posWorld: number;
+  /** Half-thickness of the visible band around the cut, world units. */
+  viewDepth: number;
+  /** Cut axis. Only `'down'` performs vertical clipping; other axes pass through unfiltered (grid lines are vertical and don't project meaningfully onto elevation cuts). */
+  axis: 'down' | 'front' | 'side';
+}
+
+export function useSymbolicAnnotations(params: {
+  /** Enable IfcAnnotation lift (the existing default behaviour). */
+  enabled: boolean;
+  /**
+   * Enable IfcGrid lift. Independent of `enabled` so a user can hide
+   * annotations while keeping grids, or vice versa (issue #862).
+   * Defaults to `enabled` so existing call sites that don't set it
+   * keep the legacy combined behaviour.
+   */
+  gridEnabled?: boolean;
+  /** Section clipping for grids only — see [`SectionClipForGrid`]. */
+  gridSectionClip?: SectionClipForGrid;
   /** World Y to use for annotations with no resolvable storey. Defaults to 0. */
   fallbackY?: number;
 }): Float32Array {
-  const { enabled, fallbackY = 0 } = params;
+  const { enabled, gridEnabled, gridSectionClip, fallbackY = 0 } = params;
+  const effectiveGridEnabled = gridEnabled ?? enabled;
   const stores = useActiveStores();
-  const version = useAnnotationParseTrigger(enabled, stores);
+  // Trigger parse if EITHER subset is enabled — the parse pass is shared.
+  const version = useAnnotationParseTrigger(enabled || effectiveGridEnabled, stores);
+  const clipEnabled = !!gridSectionClip && gridSectionClip.enabled && gridSectionClip.axis === 'down';
+  const clipPos = clipEnabled ? gridSectionClip!.posWorld : 0;
+  const clipDepth = clipEnabled ? gridSectionClip!.viewDepth : 0;
 
   return useMemo(() => {
-    if (!enabled) return EMPTY_F32;
+    if (!enabled && !effectiveGridEnabled) return EMPTY_F32;
     void version; // depend on parse-completion ticks
 
     const verts: number[] = [];
@@ -546,22 +608,49 @@ export function useSymbolicAnnotations(params: {
         continue;
       }
       if (debugEnabled()) {
-        const buckets = cached.byStorey.size;
-        const looseLines = cached.loose.length;
-        console.log(`[annotations] store ${storeIdx}: lifting ${buckets} storey buckets + ${looseLines} loose lines (key=${key}, fallbackY=${fallbackY})`);
+        console.log(
+          `[annotations] store ${storeIdx}: annotation buckets=${cached.byStorey.size}+${cached.loose.length}loose, grid buckets=${cached.gridByStorey.size}+${cached.gridLoose.length}loose (annot=${enabled}, grid=${effectiveGridEnabled}, clip=${clipEnabled})`,
+        );
       }
 
-      for (const bucket of cached.byStorey.values()) {
-        liftTo3DLineList(bucket.lines, resolveBucketY(bucket.storeyElevation, fallbackY), verts);
+      if (enabled) {
+        for (const bucket of cached.byStorey.values()) {
+          liftTo3DLineList(bucket.lines, resolveBucketY(bucket.storeyElevation, fallbackY), verts);
+        }
+        liftTo3DLineList(cached.loose, fallbackY, verts);
       }
-      liftTo3DLineList(cached.loose, fallbackY, verts);
+
+      if (effectiveGridEnabled) {
+        // Issue #862: section-clip grid buckets only — IfcAnnotation
+        // intentionally bypasses this per the feedback memory ("the
+        // user expects every storey's dimensions/grid bubbles to lift
+        // into the viewport when [the annotation toggle is] on, even
+        // while a section cut is active").
+        if (clipEnabled) {
+          const lo = clipPos - clipDepth;
+          const hi = clipPos + clipDepth;
+          for (const bucket of cached.gridByStorey.values()) {
+            const y = resolveBucketY(bucket.storeyElevation, fallbackY);
+            if (y < lo || y > hi) continue;
+            liftTo3DLineList(bucket.lines, y, verts);
+          }
+          if (fallbackY >= lo && fallbackY <= hi) {
+            liftTo3DLineList(cached.gridLoose, fallbackY, verts);
+          }
+        } else {
+          for (const bucket of cached.gridByStorey.values()) {
+            liftTo3DLineList(bucket.lines, resolveBucketY(bucket.storeyElevation, fallbackY), verts);
+          }
+          liftTo3DLineList(cached.gridLoose, fallbackY, verts);
+        }
+      }
       storeIdx++;
     }
 
     if (debugEnabled()) console.log(`[annotations] total 3D line vertices: ${verts.length / 3} from ${stores.length} stores`);
     if (verts.length === 0) return EMPTY_F32;
     return new Float32Array(verts);
-  }, [enabled, stores, version, fallbackY]);
+  }, [enabled, effectiveGridEnabled, clipEnabled, clipPos, clipDepth, stores, version, fallbackY]);
 }
 
 /**
@@ -723,13 +812,19 @@ export function useSymbolicAnnotationsForDrawing(params: {
       const cached = PARSE_CACHE.get(key);
       if (!cached) continue;
 
-      for (const bucket of cached.byStorey.values()) {
+      // Drawing-2D pulls BOTH annotation and grid buckets (issue #862
+      // split them at parse time so the 3D viewport can clip them
+      // separately — the 2D Section panel still wants the combined
+      // overlay).
+      const collectBucket = (bucket: AnnotationsForStorey) => {
         const bucketY = resolveBucketY(bucket.storeyElevation, fallbackY);
-        if (bucketY < rangeMin || bucketY > rangeMax) continue;
+        if (bucketY < rangeMin || bucketY > rangeMax) return;
         for (const ln of bucket.lines) pushLine(ln);
         for (const t of bucket.texts) pushText(t);
         for (const f of bucket.fills) pushFill(f);
-      }
+      };
+      for (const bucket of cached.byStorey.values()) collectBucket(bucket);
+      for (const bucket of cached.gridByStorey.values()) collectBucket(bucket);
 
       // Loose annotations have no resolvable storey — include them if the
       // fallback Y lands in the view range. That keeps malformed exports
@@ -739,6 +834,9 @@ export function useSymbolicAnnotationsForDrawing(params: {
         for (const ln of cached.loose) pushLine(ln);
         for (const t of cached.looseTexts) pushText(t);
         for (const f of cached.looseFills) pushFill(f);
+        for (const ln of cached.gridLoose) pushLine(ln);
+        for (const t of cached.gridLooseTexts) pushText(t);
+        for (const f of cached.gridLooseFills) pushFill(f);
       }
     }
 
@@ -757,14 +855,24 @@ export function useSymbolicAnnotationsForDrawing(params: {
  */
 export function useSymbolicAnnotationsRichData(params: {
   enabled: boolean;
+  /** Lift grid-bubble texts + fills. Independent of `enabled` (issue #862).
+   *  Defaults to `enabled` for legacy callers. */
+  gridEnabled?: boolean;
+  /** Section clipping for grid texts/fills only — same semantics as
+   *  [`useSymbolicAnnotations`]. */
+  gridSectionClip?: SectionClipForGrid;
   fallbackY?: number;
 }): { texts: readonly AnnotationText3D[]; fills: readonly AnnotationFill3D[] } {
-  const { enabled, fallbackY = 0 } = params;
+  const { enabled, gridEnabled, gridSectionClip, fallbackY = 0 } = params;
+  const effectiveGridEnabled = gridEnabled ?? enabled;
   const stores = useActiveStores();
-  const version = useAnnotationParseTrigger(enabled, stores);
+  const version = useAnnotationParseTrigger(enabled || effectiveGridEnabled, stores);
+  const clipEnabled = !!gridSectionClip && gridSectionClip.enabled && gridSectionClip.axis === 'down';
+  const clipPos = clipEnabled ? gridSectionClip!.posWorld : 0;
+  const clipDepth = clipEnabled ? gridSectionClip!.viewDepth : 0;
 
   return useMemo(() => {
-    if (!enabled) return { texts: EMPTY_TEXTS, fills: EMPTY_FILLS };
+    if (!enabled && !effectiveGridEnabled) return { texts: EMPTY_TEXTS, fills: EMPTY_FILLS };
     void version;
 
     const texts: AnnotationText3D[] = [];
@@ -803,18 +911,45 @@ export function useSymbolicAnnotationsRichData(params: {
         });
       };
 
-      for (const bucket of cached.byStorey.values()) {
-        const y = resolveBucketY(bucket.storeyElevation, fallbackY);
-        for (const t of bucket.texts) pushText(t, y);
-        for (const f of bucket.fills) pushFill(f, y);
+      if (enabled) {
+        for (const bucket of cached.byStorey.values()) {
+          const y = resolveBucketY(bucket.storeyElevation, fallbackY);
+          for (const t of bucket.texts) pushText(t, y);
+          for (const f of bucket.fills) pushFill(f, y);
+        }
+        for (const t of cached.looseTexts) pushText(t, fallbackY);
+        for (const f of cached.looseFills) pushFill(f, fallbackY);
       }
-      for (const t of cached.looseTexts) pushText(t, fallbackY);
-      for (const f of cached.looseFills) pushFill(f, fallbackY);
+
+      if (effectiveGridEnabled) {
+        if (clipEnabled) {
+          const lo = clipPos - clipDepth;
+          const hi = clipPos + clipDepth;
+          for (const bucket of cached.gridByStorey.values()) {
+            const y = resolveBucketY(bucket.storeyElevation, fallbackY);
+            if (y < lo || y > hi) continue;
+            for (const t of bucket.texts) pushText(t, y);
+            for (const f of bucket.fills) pushFill(f, y);
+          }
+          if (fallbackY >= lo && fallbackY <= hi) {
+            for (const t of cached.gridLooseTexts) pushText(t, fallbackY);
+            for (const f of cached.gridLooseFills) pushFill(f, fallbackY);
+          }
+        } else {
+          for (const bucket of cached.gridByStorey.values()) {
+            const y = resolveBucketY(bucket.storeyElevation, fallbackY);
+            for (const t of bucket.texts) pushText(t, y);
+            for (const f of bucket.fills) pushFill(f, y);
+          }
+          for (const t of cached.gridLooseTexts) pushText(t, fallbackY);
+          for (const f of cached.gridLooseFills) pushFill(f, fallbackY);
+        }
+      }
     }
 
     return {
       texts: texts.length ? texts : EMPTY_TEXTS,
       fills: fills.length ? fills : EMPTY_FILLS,
     };
-  }, [enabled, stores, version, fallbackY]);
+  }, [enabled, effectiveGridEnabled, clipEnabled, clipPos, clipDepth, stores, version, fallbackY]);
 }

--- a/apps/viewer/src/store/constants.ts
+++ b/apps/viewer/src/store/constants.ts
@@ -159,6 +159,7 @@ export const TYPE_VISIBILITY_STORAGE_KEYS = {
   openings:       'ifc-lite-ifc-openings-visible',
   site:           'ifc-lite-ifc-site-visible',
   ifcAnnotations: 'ifc-lite-ifc-annotations-visible',
+  ifcGrid:        'ifc-lite-ifc-grid-visible',
 } as const;
 
 /** Legacy alias — kept until external callers migrate. */
@@ -178,13 +179,16 @@ function readPersistedBool(key: string, fallback: boolean): boolean {
 
 // Semantic defaults applied when no localStorage preference is set.
 // IfcSpace / IfcOpeningElement off — they cover walls and confuse novices
-// on first load. IfcSite + IfcAnnotation/IfcGrid on — both convey
-// design intent users expect to see by default.
+// on first load. IfcSite + IfcAnnotation + IfcGrid on — all three convey
+// design intent users expect to see by default. (Issue #862 split grid
+// into its own toggle so dense-grid models can hide grids without losing
+// dimensions/labels.)
 const SEMANTIC_DEFAULTS = {
   spaces: false,
   openings: false,
   site: true,
   ifcAnnotations: true,
+  ifcGrid: true,
 } as const;
 
 export const TYPE_VISIBILITY_DEFAULTS = {
@@ -194,8 +198,10 @@ export const TYPE_VISIBILITY_DEFAULTS = {
   OPENINGS:        readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.openings, SEMANTIC_DEFAULTS.openings),
   /** IfcSite visibility — persisted across reloads. */
   SITE:            readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.site, SEMANTIC_DEFAULTS.site),
-  /** IfcAnnotation + IfcGrid visibility — persisted across reloads. */
+  /** IfcAnnotation visibility (text, dimensions, leaders) — persisted. */
   IFC_ANNOTATIONS: readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.ifcAnnotations, SEMANTIC_DEFAULTS.ifcAnnotations),
+  /** IfcGrid visibility (axis lines + bubble tags) — persisted. Issue #862. */
+  IFC_GRID:        readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.ifcGrid, SEMANTIC_DEFAULTS.ifcGrid),
 } as const;
 
 // ============================================================================

--- a/apps/viewer/src/store/constants.ts
+++ b/apps/viewer/src/store/constants.ts
@@ -200,8 +200,18 @@ export const TYPE_VISIBILITY_DEFAULTS = {
   SITE:            readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.site, SEMANTIC_DEFAULTS.site),
   /** IfcAnnotation visibility (text, dimensions, leaders) — persisted. */
   IFC_ANNOTATIONS: readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.ifcAnnotations, SEMANTIC_DEFAULTS.ifcAnnotations),
-  /** IfcGrid visibility (axis lines + bubble tags) — persisted. Issue #862. */
-  IFC_GRID:        readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.ifcGrid, SEMANTIC_DEFAULTS.ifcGrid),
+  /**
+   * IfcGrid visibility (axis lines + bubble tags) — persisted. Issue
+   * #862. Migration: if the new key isn't set yet, fall back to the
+   * legacy combined `ifcAnnotations` preference. That way a user who
+   * previously turned the combined "Annotations & Grids" toggle off
+   * keeps grids hidden after upgrade, instead of grids silently
+   * reappearing (PR #868 review, chatgpt-codex P2).
+   */
+  IFC_GRID:        readPersistedBool(
+    TYPE_VISIBILITY_STORAGE_KEYS.ifcGrid,
+    readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.ifcAnnotations, SEMANTIC_DEFAULTS.ifcGrid),
+  ),
 } as const;
 
 // ============================================================================

--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -208,6 +208,7 @@ const createViewerStore = () => create<ViewerState>()((...args) => ({
         openings: TYPE_VISIBILITY_DEFAULTS.OPENINGS,
         site: TYPE_VISIBILITY_DEFAULTS.SITE,
         ifcAnnotations: TYPE_VISIBILITY_DEFAULTS.IFC_ANNOTATIONS,
+        ifcGrid: TYPE_VISIBILITY_DEFAULTS.IFC_GRID,
       },
 
       // Visibility (multi-model)

--- a/apps/viewer/src/store/slices/visibilitySlice.ts
+++ b/apps/viewer/src/store/slices/visibilitySlice.ts
@@ -43,7 +43,7 @@ export interface VisibilitySlice {
   clearAllFilters: () => void;
   showAll: () => void;
   isEntityVisible: (id: number) => boolean;
-  toggleTypeVisibility: (type: 'spaces' | 'openings' | 'site' | 'ifcAnnotations') => void;
+  toggleTypeVisibility: (type: 'spaces' | 'openings' | 'site' | 'ifcAnnotations' | 'ifcGrid') => void;
   /** Set all hidden entities at once (for BCF viewpoint application) */
   setHiddenEntities: (ids: Set<number>) => void;
   /** Set all isolated entities at once (for BCF viewpoint with defaultVisibility=false) */
@@ -80,6 +80,7 @@ export const createVisibilitySlice: StateCreator<VisibilitySlice, [], [], Visibi
     openings: TYPE_VISIBILITY_DEFAULTS.OPENINGS,
     site: TYPE_VISIBILITY_DEFAULTS.SITE,
     ifcAnnotations: TYPE_VISIBILITY_DEFAULTS.IFC_ANNOTATIONS,
+    ifcGrid: TYPE_VISIBILITY_DEFAULTS.IFC_GRID,
   },
 
   // Initial state (multi-model)

--- a/apps/viewer/src/store/types.ts
+++ b/apps/viewer/src/store/types.ts
@@ -199,6 +199,15 @@ export interface TypeVisibility {
   site: boolean;
   /** IfcAnnotation (2D symbolic curves) - on by default when present */
   ifcAnnotations: boolean;
+  /**
+   * IfcGrid axis lines + bubble tags — split from `ifcAnnotations`
+   * (issue #862). Default true to match the legacy combined behaviour;
+   * users with dense grids that obscure components can hide grids while
+   * keeping annotations on. Unlike `ifcAnnotations`, grids are also
+   * section-clipped when a 3D section plane is active so each storey's
+   * grid lines only show for storeys near the cut.
+   */
+  ifcGrid: boolean;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Split `typeVisibility.ifcAnnotations` into two toggles — `ifcAnnotations` (text/dimensions/leaders) and `ifcGrid` (axis lines + bubble tags). Dense-grid models can now hide grids without losing dimensions.
- Added section-plane clipping for grid lines on horizontal cuts (`axis='down'`). Grid buckets outside a ±1.5 m band around the cut are dropped, so the cut storey's grids show in 3D while adjacent storeys' grids don't pile up. **IfcAnnotation is intentionally NOT clipped** — the existing memory (`feedback_3d_annotation_overlay_no_section_filter.md`) protects that behaviour.
- Parse cache (`useSymbolicAnnotations.ts`) gains parallel `gridByStorey` / `gridLoose*` collections; the 2D drawing path pulls both bucket sets so the Section panel surface is unchanged.

## Test plan
- [x] `pnpm --filter @ifc-lite/viewer test` — full viewer suite, 928 tests, 927 pass + 1 skipped, 0 fail.
- [x] `tsc --noEmit` clean.
- [ ] Manual verification on the reporter's HVAC Building model — toggle each visibility entry independently; activate horizontal section and confirm grids clip to the cut storey while dimensions still lift to every storey.

Closes #862.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Separated grid and annotation visibility controls, allowing independent toggling of each in the Class Visibility dropdown and Command Palette.
  * Added section clipping support for grid overlays when horizontal section cuts are active.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LTplus-AG/ifc-lite/pull/868?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->