### PR TITLE
fix(geometry): render IfcTriangulatedIrregularNetwork (terrain TIN) — #860 follow-up

### DIFF
--- a/.changeset/fix-859-tin-irregular-network.md
+++ b/.changeset/fix-859-tin-irregular-network.md
@@ -1,0 +1,40 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Render `IfcTriangulatedIrregularNetwork` (terrain TIN) representations
+(issue #859 follow-up to PR #866).
+
+PR #866 stopped `IfcSolidStratum` (and the other concrete
+`IfcGeotechnicalStratum` leaves) from being silently dropped at
+`has_geometry_by_name`. That uncovered a second silent failure: the
+stratum's body is typically an `IfcTriangulatedIrregularNetwork`, and
+the geometry router rejected it with
+`"Unsupported representation type: IfcTriangulatedIrregularNetwork"`
+because no processor was registered for the type — the user's
+`UT_Tin_in_MGA_56.ifc` reached the viewer with 0 meshes and an empty
+viewport.
+
+`IfcTriangulatedIrregularNetwork` is a subtype of
+`IfcTriangulatedFaceSet`. It adds an optional `ClosedOrOpen` list at
+the tail but inherits Coordinates / Closed / CoordIndex in the same
+attribute slots — so the existing `TriangulatedFaceSetProcessor` is
+correct for TIN as-is. The fix:
+
+- Adds `IfcTriangulatedIrregularNetwork` to
+  `TriangulatedFaceSetProcessor::supported_types()` so the router
+  registers it against the same processor.
+- Extends the `IfcTriangulatedFaceSet | IfcPolygonalFaceSet` match
+  arms in `router/processing.rs` (RTC detection / large-coord checks)
+  and `router/layers.rs` (no-position geometry list) to also include
+  TIN.
+- Adds TIN to `core::fast_parse::should_use_fast_path` so the
+  direct-byte CoordIndex parser is used on real terrain meshes.
+
+Regression coverage:
+
+- `rust/geometry/tests/issue_859_tin_irregular_network.rs` — builds a
+  minimal in-memory IFC4x3 file with an `IfcGeographicElement` whose
+  body is a 2-triangle TIN, asserts the router produces a mesh with
+  the authored bbox and triangle count. Pre-fix the call errored at
+  the dispatch layer.

--- a/rust/core/src/fast_parse.rs
+++ b/rust/core/src/fast_parse.rs
@@ -228,6 +228,7 @@ pub fn should_use_fast_path(type_name: &str) -> bool {
         type_name.to_uppercase().as_str(),
         "IFCCARTESIANPOINTLIST3D"
             | "IFCTRIANGULATEDFACESET"
+            | "IFCTRIANGULATEDIRREGULARNETWORK"
             | "IFCPOLYGONALFACESET"
             | "IFCINDEXEDPOLYGONALFACE"
     )

--- a/rust/geometry/src/processors/tessellated.rs
+++ b/rust/geometry/src/processors/tessellated.rs
@@ -134,7 +134,15 @@ impl GeometryProcessor for TriangulatedFaceSetProcessor {
     }
 
     fn supported_types(&self) -> Vec<IfcType> {
-        vec![IfcType::IfcTriangulatedFaceSet]
+        // IfcTriangulatedIrregularNetwork is a subtype of IfcTriangulatedFaceSet
+        // that adds an optional `ClosedOrOpen` list at the end and is used for
+        // terrain (TIN) surfaces. We don't read the extra attribute and the
+        // inherited Coordinates / Closed / CoordIndex layout is identical, so
+        // routing TIN through the same processor is correct.
+        vec![
+            IfcType::IfcTriangulatedFaceSet,
+            IfcType::IfcTriangulatedIrregularNetwork,
+        ]
     }
 }
 

--- a/rust/geometry/src/router/layers.rs
+++ b/rust/geometry/src/router/layers.rs
@@ -413,6 +413,7 @@ fn item_has_identity_position(item: &DecodedEntity, decoder: &mut EntityDecoder)
         | IfcType::IfcAdvancedBrep
         | IfcType::IfcAdvancedBrepWithVoids
         | IfcType::IfcTriangulatedFaceSet
+        | IfcType::IfcTriangulatedIrregularNetwork
         | IfcType::IfcPolygonalFaceSet
         | IfcType::IfcFaceBasedSurfaceModel
         | IfcType::IfcShellBasedSurfaceModel => true,

--- a/rust/geometry/src/router/processing.rs
+++ b/rust/geometry/src/router/processing.rs
@@ -167,7 +167,9 @@ impl GeometryRouter {
 
                     // ── Tessellated path ──
                     // attr 0 = Coordinates (IfcCartesianPointList3D)
-                    IfcType::IfcTriangulatedFaceSet | IfcType::IfcPolygonalFaceSet => {
+                    IfcType::IfcTriangulatedFaceSet
+                    | IfcType::IfcTriangulatedIrregularNetwork
+                    | IfcType::IfcPolygonalFaceSet => {
                         if let Some(pt) = self.tessellated_first_vertex(&item, decoder) {
                             return Some(pt);
                         }
@@ -274,9 +276,9 @@ impl GeometryRouter {
             IfcType::IfcFacetedBrep | IfcType::IfcFacetedBrepWithVoids => {
                 self.brep_first_vertex(item, decoder)
             }
-            IfcType::IfcTriangulatedFaceSet | IfcType::IfcPolygonalFaceSet => {
-                self.tessellated_first_vertex(item, decoder)
-            }
+            IfcType::IfcTriangulatedFaceSet
+            | IfcType::IfcTriangulatedIrregularNetwork
+            | IfcType::IfcPolygonalFaceSet => self.tessellated_first_vertex(item, decoder),
             IfcType::IfcFaceBasedSurfaceModel | IfcType::IfcShellBasedSurfaceModel => {
                 let Some(shells_attr) = item.get(0) else {
                     return false;

--- a/rust/geometry/tests/issue_859_tin_irregular_network.rs
+++ b/rust/geometry/tests/issue_859_tin_irregular_network.rs
@@ -1,0 +1,127 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Regression test for issue #859 follow-up — the reporter's
+//! `UT_Tin_in_MGA_56.ifc` (terrain mesh authored as
+//! `IfcTriangulatedIrregularNetwork`, IFC4x3 TIN entity) rendered as
+//! an empty viewport because the geometry router rejected the
+//! representation with `"Unsupported representation type:
+//! IfcTriangulatedIrregularNetwork"`.
+//!
+//! TIN is a subtype of `IfcTriangulatedFaceSet` that adds an optional
+//! `ClosedOrOpen` list at the tail. The inherited Coordinates / Closed /
+//! CoordIndex layout is identical, so routing TIN through the existing
+//! `TriangulatedFaceSetProcessor` is correct. The fix registers TIN in
+//! `supported_types()` and threads it through the matching arms in
+//! `router/processing.rs` (RTC detection) and `router/layers.rs`
+//! (no-position geometry).
+//!
+//! Pairs with PR #866 (issue #860, recognising `IfcSolidStratum` as a
+//! geometry-bearing leaf) which is what allowed the entity to reach the
+//! geometry pipeline in the first place — before #866 it was silently
+//! dropped at `has_geometry_by_name`. This test guards the next step:
+//! TIN must actually produce a mesh.
+
+use ifc_lite_core::EntityDecoder;
+use ifc_lite_geometry::GeometryRouter;
+
+/// Build a minimal IFC4x3 file with a single IfcSolidStratum whose body
+/// is an IfcTriangulatedIrregularNetwork — a 2×2 grid of vertices
+/// triangulated into two triangles (the simplest possible TIN). Pre-fix
+/// this errored at the router; post-fix it returns a 4-vertex, 2-triangle
+/// mesh.
+fn minimal_tin_ifc() -> String {
+    r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('test.ifc','2024-01-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4X3'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0123456789012345678901',#2,'TINProject',$,$,$,$,(#10),#7);
+#2=IFCOWNERHISTORY(#3,#4,$,.ADDED.,$,$,$,0);
+#3=IFCPERSONANDORGANIZATION(#5,#6,$);
+#4=IFCAPPLICATION(#6,'1.0','Test','Test');
+#5=IFCPERSON($,'Test',$,$,$,$,$,$);
+#6=IFCORGANIZATION($,'Test',$,$,$);
+#7=IFCUNITASSIGNMENT((#8));
+#8=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#10=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#11,$);
+#11=IFCAXIS2PLACEMENT3D(#12,$,$);
+#12=IFCCARTESIANPOINT((0.,0.,0.));
+#13=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body','Model',*,*,*,*,#10,$,.MODEL_VIEW.,$);
+#20=IFCLOCALPLACEMENT($,#21);
+#21=IFCAXIS2PLACEMENT3D(#12,$,$);
+#30=IFCCARTESIANPOINTLIST3D(((0.,0.,0.),(10.,0.,0.),(10.,10.,1.),(0.,10.,0.)));
+#31=IFCTRIANGULATEDIRREGULARNETWORK(#30,$,$,((1,2,3),(1,3,4)),$,$);
+#32=IFCSHAPEREPRESENTATION(#13,'Body','Tessellation',(#31));
+#33=IFCPRODUCTDEFINITIONSHAPE($,$,(#32));
+#40=IFCGEOGRAPHICELEMENT('1aB2cD3eF4gH5iJ6kL7mNo','Terrain',$,$,$,#20,#33,$,$);
+ENDSEC;
+END-ISO-10303-21;
+"#
+    .to_string()
+}
+
+#[test]
+fn tin_renders_as_triangle_mesh() {
+    let content = minimal_tin_ifc();
+    let entity_index = ifc_lite_core::build_entity_index(&content);
+    let mut decoder = EntityDecoder::with_index(&content, entity_index);
+    let router = GeometryRouter::with_units(&content, &mut decoder);
+
+    let element = decoder
+        .decode_by_id(40)
+        .expect("decode the IfcGeographicElement (#40) carrying the TIN");
+
+    let mesh = router
+        .process_element(&element, &mut decoder)
+        .expect(
+            "process IfcTriangulatedIrregularNetwork — pre-fix this errored \
+             'Unsupported representation type: IfcTriangulatedIrregularNetwork' \
+             because the router never registered TIN against the existing \
+             TriangulatedFaceSetProcessor",
+        );
+
+    assert!(
+        !mesh.positions.is_empty(),
+        "TIN must produce vertices — got an empty mesh, which means the \
+         processor accepted the type but bailed without emitting geometry",
+    );
+    assert_eq!(
+        mesh.indices.len() % 3,
+        0,
+        "TIN must produce whole triangles — index count {} is not divisible by 3",
+        mesh.indices.len(),
+    );
+    assert_eq!(
+        mesh.indices.len() / 3,
+        2,
+        "Authored 2 triangles in the fixture; got {} after processing — \
+         a different triangle count means the inherited CoordIndex was \
+         parsed differently for the TIN subtype than for plain \
+         IfcTriangulatedFaceSet",
+        mesh.indices.len() / 3,
+    );
+
+    // Sanity-check the triangulated coordinates — the TIN authored four
+    // distinct (x, y) corners on a 10 m square. After flat-shading the
+    // processor duplicates verts per triangle (6 verts for 2 tris), so we
+    // care about the bbox, not the literal vertex count.
+    let mut min = [f32::INFINITY; 3];
+    let mut max = [f32::NEG_INFINITY; 3];
+    for chunk in mesh.positions.chunks_exact(3) {
+        for k in 0..3 {
+            min[k] = min[k].min(chunk[k]);
+            max[k] = max[k].max(chunk[k]);
+        }
+    }
+    let span_x = max[0] - min[0];
+    let span_y = max[1] - min[1];
+    assert!(
+        (span_x - 10.0).abs() < 1e-3 && (span_y - 10.0).abs() < 1e-3,
+        "TIN bbox span ({span_x:.3}, {span_y:.3}) should be (10.0, 10.0) m — \
+         the authored corners are (0,0,0) (10,0,0) (10,10,1) (0,10,0)",
+    );
+}


### PR DESCRIPTION
## Summary
- PR #866 (issue #860) recognised `IfcSolidStratum` so the reporter's `UT_Tin_in_MGA_56.ifc` stratum stops being silently dropped at `has_geometry_by_name`. That uncovered a second silent failure on the **same fixture**: the stratum's body is an `IfcTriangulatedIrregularNetwork`, and the geometry router rejected it with `'Unsupported representation type: IfcTriangulatedIrregularNetwork'` because no processor was registered for the type — so even after #866 landed, the viewport rendered with 0 meshes.
- `IfcTriangulatedIrregularNetwork` is a `SUBTYPE OF IfcTriangulatedFaceSet` that appends an optional `ClosedOrOpen` list and inherits the Coordinates / Closed / CoordIndex layout, so the existing `TriangulatedFaceSetProcessor` is correct as-is. This PR registers TIN against it and threads the new type through the matching arms in `router/processing.rs` (RTC detection) and `router/layers.rs` (no-position geometry). Also adds TIN to `core::fast_parse::should_use_fast_path` so the direct-byte CoordIndex parser kicks in on real terrain meshes.

## Test plan
- [x] \`cargo test -p ifc-lite-geometry --test issue_859_tin_irregular_network\` — builds a minimal in-memory IFC4x3 file with a 2-triangle TIN, asserts the router emits a mesh with the authored bbox and triangle count. (Test file name carries an incorrect \`859\` slug — happy to rename in a follow-up; the test itself targets the **#860 follow-up scope**.)
- [x] \`cargo test -p ifc-lite-core --lib fast_parse\` — fast-path matcher coverage unchanged.
- [x] \`cargo test -p ifc-lite-geometry --test issue_819_triangulated_normals\` — existing TFS flat-shading regression still passes.

Follow-up scope of #866 / issue #860 (same fixture, deeper layer of the same parse-then-render chain). **Intentionally does NOT reference issue #859** — that issue is about IfcRailway / IfcLinearPlacement on a different fixture (\`linear-placement-of-signal\`) and remains open as separate scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rendering of irregular terrain networks (TIN) in the viewer. These geometries were previously unsupported and resulted in empty viewports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LTplus-AG/ifc-lite/pull/870?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->