### PR TITLE
ci: single-source the wasm build toolchain via a composite action

### DIFF
--- a/.github/actions/setup-wasm-build/action.yml
+++ b/.github/actions/setup-wasm-build/action.yml
@@ -1,0 +1,53 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Single source of truth for the toolchain that scripts/build-wasm.sh needs.
+# The wasm bundle pulls in manifold-csg-sys via the `manifold-csg-wasm-uu`
+# feature (PR #861); its build script (wasm-cxx-shim) needs the pinned Rust
+# nightly + wasm-pack + a wasm32-capable clang-20 with libc++ headers
+# (libc++-18 doesn't cross-compile to wasm32-unknown-unknown — see the git
+# history for the full diagnostic). Ubuntu Noble's main repo tops out at
+# clang-18, so add apt.llvm.org for clang-20.
+#
+# Used by test.yml, release.yml, desktop-compat.yml and sdk-canary.yml so the
+# four stay in lock-step — a toolchain change here updates all of them at once,
+# instead of one drifting (which is how sdk-canary once shipped without LLVM-20
+# and went red on an unrelated PR).
+name: 'Setup WASM build toolchain'
+description: 'Rust (rust-toolchain.toml) + wasm-pack + LLVM-20 for the manifold-csg-sys wasm32 build'
+
+inputs:
+  cache-prefix:
+    description: 'Swatinem/rust-cache prefix-key, to namespace the cargo cache per workflow'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # rust-toolchain.toml pins the nightly + wasm32-unknown-unknown + rust-src;
+    # `rustup show` triggers install of exactly that toolchain.
+    - name: Setup Rust (pinned by rust-toolchain.toml)
+      shell: bash
+      run: rustup show
+
+    - name: Cargo cache
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      with:
+        prefix-key: ${{ inputs.cache-prefix }}
+
+    - name: Install wasm-pack
+      uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa # v0.4.0
+      with:
+        version: latest
+
+    - name: Install LLVM 20 (for manifold-csg-sys wasm build)
+      shell: bash
+      run: |
+        wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+          | sudo gpg --dearmor -o /usr/share/keyrings/llvm-snapshot-keyring.gpg
+        echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot-keyring.gpg] http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" \
+          | sudo tee /etc/apt/sources.list.d/llvm.list
+        sudo apt-get update -qq
+        sudo apt-get install -y -qq \
+          clang-20 lld-20 libc++-20-dev libc++abi-20-dev

--- a/.github/workflows/desktop-compat.yml
+++ b/.github/workflows/desktop-compat.yml
@@ -57,35 +57,10 @@ jobs:
       # WASM bundles are no longer committed (see #654); turbo's wasm
       # packages rebuild from source via scripts/build-wasm.sh, which
       # needs a Rust toolchain matching rust-toolchain.toml + wasm-pack.
-      - name: Setup Rust (pinned by rust-toolchain.toml)
-        run: rustup show
-
-      - name: Cargo cache
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Setup WASM build toolchain
+        uses: ./.github/actions/setup-wasm-build
         with:
-          prefix-key: ci
-
-      - name: Install wasm-pack
-        uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa # v0.4.0
-        with:
-          version: latest
-
-      # PR #861 enables `manifold-csg-wasm-uu` on the wasm bundle;
-      # `manifold-csg-sys`'s build script needs a wasm32-capable
-      # clang + libc++ headers. clang-20 specifically — libc++-18's
-      # ABI/availability config doesn't cross-compile to
-      # wasm32-unknown-unknown (see test.yml's note for the full
-      # diagnostic). Add apt.llvm.org for clang-20 since Ubuntu
-      # Noble's main repo tops out at clang-18.
-      - name: Install LLVM 20 (for manifold-csg-sys wasm build)
-        run: |
-          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
-            | sudo gpg --dearmor -o /usr/share/keyrings/llvm-snapshot-keyring.gpg
-          echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot-keyring.gpg] http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" \
-            | sudo tee /etc/apt/sources.list.d/llvm.list
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq \
-            clang-20 lld-20 libc++-20-dev libc++abi-20-dev
+          cache-prefix: ci
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,31 +97,13 @@ jobs:
       # to what CI tested. Plain @stable would leave the nightly missing and
       # `wasm-pack build` would fail with "toolchain not installed" — exactly
       # the regression observed on Release #403 after #657 untracked the wasm.
-      - name: Setup Rust (pinned by rust-toolchain.toml)
-        run: rustup show
-
-      - name: Cargo cache
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      # Rust + wasm-pack + LLVM-20 for the manifold-csg-sys wasm build.
+      # Single-sourced in .github/actions/setup-wasm-build (shared with
+      # test.yml / desktop-compat.yml / sdk-canary.yml).
+      - name: Setup WASM build toolchain
+        uses: ./.github/actions/setup-wasm-build
         with:
-          prefix-key: release
-
-      - name: Install wasm-pack
-        uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa # v0.4.0
-        with:
-          version: latest
-
-      # PR #861 enables `manifold-csg-wasm-uu` on the wasm bundle;
-      # `manifold-csg-sys`'s build script needs clang-20+ for wasm32
-      # cross-compile. Same install as `test.yml` and `desktop-compat.yml`.
-      - name: Install LLVM 20 (for manifold-csg-sys wasm build)
-        run: |
-          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
-            | sudo gpg --dearmor -o /usr/share/keyrings/llvm-snapshot-keyring.gpg
-          echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot-keyring.gpg] http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" \
-            | sudo tee /etc/apt/sources.list.d/llvm.list
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq \
-            clang-20 lld-20 libc++-20-dev libc++abi-20-dev
+          cache-prefix: release
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/sdk-canary.yml
+++ b/.github/workflows/sdk-canary.yml
@@ -56,34 +56,12 @@ jobs:
           cache: pnpm
 
       # @ifc-lite/cli transitively type-depends on @ifc-lite/wasm (its deps'
-      # .d.ts files reference it), and @ifc-lite/wasm's build is wasm-pack.
-      # Mirror test.yml's toolchain so the dependency-ordered build below
-      # can produce every .d.ts the cli tsc build needs.
-      - name: Setup Rust (pinned by rust-toolchain.toml)
-        run: rustup show
-
-      - name: Cargo cache
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      # .d.ts files reference it), and @ifc-lite/wasm's build is wasm-pack —
+      # so this job needs the full wasm toolchain too.
+      - name: Setup WASM build toolchain
+        uses: ./.github/actions/setup-wasm-build
         with:
-          prefix-key: sdk-canary
-
-      - name: Install wasm-pack
-        uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa # v0.4.0
-        with:
-          version: latest
-
-      # PR #861 enables `manifold-csg-wasm-uu` on the wasm bundle;
-      # `manifold-csg-sys`'s build script needs clang-20+ for the wasm32
-      # cross-compile. Same install as test.yml / release.yml / desktop-compat.yml.
-      - name: Install LLVM 20 (for manifold-csg-sys wasm build)
-        run: |
-          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
-            | sudo gpg --dearmor -o /usr/share/keyrings/llvm-snapshot-keyring.gpg
-          echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot-keyring.gpg] http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" \
-            | sudo tee /etc/apt/sources.list.d/llvm.list
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq \
-            clang-20 lld-20 libc++-20-dev libc++abi-20-dev
+          cache-prefix: sdk-canary
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,44 +103,13 @@ jobs:
           node-version: 22
           cache: pnpm
 
-      # rust-toolchain.toml pins nightly-2025-11-15 with wasm32-unknown-unknown
-      # + rust-src. `rustup show` triggers install of exactly that toolchain.
-      - name: Setup Rust (pinned by rust-toolchain.toml)
-        run: rustup show
-
-      - name: Cargo cache
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      # Rust + wasm-pack + LLVM-20 for the manifold-csg-sys wasm build.
+      # Single-sourced in .github/actions/setup-wasm-build so the four
+      # wasm-building workflows stay in lock-step.
+      - name: Setup WASM build toolchain
+        uses: ./.github/actions/setup-wasm-build
         with:
-          prefix-key: ci-build
-
-      - name: Install wasm-pack
-        uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa # v0.4.0
-        with:
-          version: latest
-
-      # The wasm bundle pulls in `manifold-csg-sys` via the
-      # `manifold-csg-wasm-uu` feature (PR #861). Its build script
-      # (wasm-cxx-shim) needs a wasm32-capable clang + lld + libc++
-      # headers — and specifically clang-20+, because libc++-18's
-      # headers ship ABI/availability config that doesn't compile
-      # cleanly for the wasm32-unknown-unknown target (observed on
-      # the first attempt at this CI fix: `_LIBCPP_ABI_FORCE_ITANIUM`
-      # + `_LIBCPP_AVAILABILITY_VERBOSE_ABORT` errors). Ubuntu Noble's
-      # main repo only has clang-18, so add apt.llvm.org's signed
-      # repo for clang-20.
-      #
-      # Vercel uses emsdk for the same purpose (see
-      # `scripts/vercel-install.sh`); GHA's depot images don't have
-      # any clang preinstalled.
-      - name: Install LLVM 20 (for manifold-csg-sys wasm build)
-        run: |
-          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
-            | sudo gpg --dearmor -o /usr/share/keyrings/llvm-snapshot-keyring.gpg
-          echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot-keyring.gpg] http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" \
-            | sudo tee /etc/apt/sources.list.d/llvm.list
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq \
-            clang-20 lld-20 libc++-20-dev libc++abi-20-dev
+          cache-prefix: ci-build
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## What
Single-sources the WASM build toolchain (Rust + wasm-pack + LLVM-20 for the `manifold-csg-sys` wasm32 cross-compile) into a reusable composite action, `.github/actions/setup-wasm-build`, and adopts it in all four workflows that run `scripts/build-wasm.sh`: `test`, `release`, `desktop-compat`, `sdk-canary`.

## Why
That 4-step block was copy-pasted inline in each workflow. When #861 added the LLVM-20 requirement, three workflows got it and `sdk-canary` was missed — so it shipped without LLVM-20 and went red on an unrelated PR (the path filter only triggered it later). A composite action makes a toolchain change a one-file edit, so the four can't drift again.

This is the follow-up flagged in `AGENTS.md` §3 ("CI toolchain consistency").

## Scope
- Native-only jobs (`Rust tests`, `Manifold CSG tests`) keep their lightweight `rust-cache` setup — they don't build wasm, so they don't need wasm-pack/LLVM.
- Per-workflow cargo cache namespacing is preserved via the `cache-prefix` input (`ci-build` / `release` / `ci` / `sdk-canary`).
- Net −116/+73 lines.

## Validation
`test.yml` and `sdk-canary.yml` run on this PR (sdk-canary's path filter includes its own file), so the composite action is exercised by this PR's own CI before merge. `release.yml`/`desktop-compat.yml` use the identical invocation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized WASM build toolchain setup across CI workflows by introducing a reusable build configuration action. This consolidates duplicate build environment steps (Rust toolchain, dependencies, caching) into a single, maintainable source, improving consistency and reducing configuration drift across continuous integration jobs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LTplus-AG/ifc-lite/pull/878?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->