### PR TITLE
ci(docker): add build timeout + cancel-in-progress

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,13 @@ on:
       - 'rust/**'
   workflow_dispatch:
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # A newer push to main supersedes an in-flight image build — cancel the older
+  # run rather than queueing behind it, so a slow/hung build can't jam the
+  # queue (as happened when #874's large Rust diff cache-busted the build and a
+  # later commit's run sat pending behind it).
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -33,6 +39,9 @@ jobs:
   docker:
     name: Build & Push Docker Image
     runs-on: depot-ubuntu-24.04-4
+    # Cap a stuck "Build and push" so it can't run to GitHub's 6h default.
+    # A cold Rust+wasm rebuild (cache miss) is ~30-45 min, so 60 gives headroom.
+    timeout-minutes: 60
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## What
Two hygiene fixes to the Docker Image workflow:
- **`timeout-minutes: 60`** on the build job — caps a stuck "Build and push" instead of letting it run to GitHub's 6h default. A cold Rust+wasm rebuild (cache miss) is ~30–45 min, so 60 is headroom.
- **`concurrency.cancel-in-progress: true`** — a newer push to `main` cancels the older in-flight build rather than queueing behind it.

## Why
On the cleanup merge (#874), the large Rust diff cache-busted the Docker layer cache, so "Build and push" ran ~1h with no cap, and the next commit's run sat `pending` behind it (the workflow serialised on the ref with no cancel). These two settings make a slow/hung build self-limiting and non-jamming.

## Note
docker.yml is in its own `push` path filter, so **merging this to main triggers a fresh Docker run** — and with `cancel-in-progress` now active, that run will supersede the currently-stuck `e73ac093` build, unjamming the queue as a side effect.

No changeset (CI-only, no published `packages/*` source).
