### PR TITLE
fix(viewer): persist all class-visibility toggles and always show them

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,13 @@ on:
       - 'rust/**'
   workflow_dispatch:
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # A newer push to main supersedes an in-flight image build — cancel the older
+  # run rather than queueing behind it, so a slow/hung build can't jam the
+  # queue (as happened when #874's large Rust diff cache-busted the build and a
+  # later commit's run sat pending behind it).
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -33,6 +39,9 @@ jobs:
   docker:
     name: Build & Push Docker Image
     runs-on: depot-ubuntu-24.04-4
+    # Cap a stuck "Build and push" so it can't run to GitHub's 6h default.
+    # A cold Rust+wasm rebuild (cache miss) is ~30-45 min, so 60 gives headroom.
+    timeout-minutes: 60
     permissions:
       contents: read
       packages: write

--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -562,107 +562,11 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
   );
   const desktopShell = isTauri();
 
-  // Check which type geometries exist across ALL loaded models (federation-aware).
-  // PERF: Use meshes.length as dep proxy instead of full geometryResult, and
-  // scan incrementally — once a type is found it stays found, so we only scan
-  // NEW meshes since the last check. Per-model cursors ensure federated models
-  // each track their own scan position independently.
-  const typeGeomScanRef = useRef({
-    spaces: false, openings: false, site: false,
-    legacyLastLen: 0,
-    modelLastLen: new Map<string | number, number>(),
-  });
-  const meshLen = geometryResult?.meshes.length ?? 0;
-  const typeGeometryExists = useMemo(() => {
-    const scan = typeGeomScanRef.current;
-
-    // Reset if legacy meshes array shrunk (new file loaded)
-    if (meshLen < scan.legacyLastLen) {
-      scan.spaces = false;
-      scan.openings = false;
-      scan.site = false;
-      scan.legacyLastLen = 0;
-      scan.modelLastLen.clear();
-    }
-
-    // Already found all types — nothing to do
-    if (scan.spaces && scan.openings && scan.site) {
-      return { spaces: scan.spaces, openings: scan.openings, site: scan.site };
-    }
-
-    // Check federated models (scan only new meshes per model)
-    if (models.size > 0) {
-      for (const [modelId, model] of models) {
-        const meshes = model.geometryResult?.meshes;
-        if (!meshes) continue;
-        const modelStart = scan.modelLastLen.get(modelId) ?? 0;
-        // Reset cursor if model was reloaded (mesh array shrunk)
-        const start = meshes.length < modelStart ? 0 : modelStart;
-        for (let i = start; i < meshes.length; i++) {
-          const t = meshes[i].ifcType;
-          if (t === 'IfcSpace') scan.spaces = true;
-          else if (t === 'IfcOpeningElement') scan.openings = true;
-          else if (t === 'IfcSite') scan.site = true;
-          if (scan.spaces && scan.openings && scan.site) break;
-        }
-        scan.modelLastLen.set(modelId, meshes.length);
-        if (scan.spaces && scan.openings && scan.site) break;
-      }
-    }
-
-    // Legacy single-model path (scan only new meshes)
-    if (geometryResult?.meshes) {
-      const meshes = geometryResult.meshes;
-      for (let i = scan.legacyLastLen; i < meshes.length; i++) {
-        const t = meshes[i].ifcType;
-        if (t === 'IfcSpace') scan.spaces = true;
-        else if (t === 'IfcOpeningElement') scan.openings = true;
-        else if (t === 'IfcSite') scan.site = true;
-        if (scan.spaces && scan.openings && scan.site) break;
-      }
-    }
-
-    scan.legacyLastLen = meshLen;
-    return { spaces: scan.spaces, openings: scan.openings, site: scan.site };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- meshLen is a stable proxy for geometryResult
-  }, [models, meshLen]);
-
-  // IfcAnnotation / IfcGrid have no body mesh, so they can't be detected via
-  // the mesh scan. Look up the entity table directly. byType keys are
-  // uppercase STEP names but cache loads sometimes preserve PascalCase.
-  //
-  // Issue #862 split these into separate visibility toggles — files that
-  // ship only one of the two need only that menu entry. Some files ship
-  // only grids (Snowdon Towers Structural — no IfcAnnotation) so probing
-  // each independently is required.
-  const hasIfcEntities = useMemo(() => {
-    const probe = (store: typeof ifcDataStore | undefined) => {
-      const byType = store?.entityIndex?.byType;
-      if (!byType) return { annotations: false, grid: false };
-      return {
-        annotations: (byType.get('IFCANNOTATION')?.length ?? 0) > 0
-          || (byType.get('IfcAnnotation')?.length ?? 0) > 0,
-        grid: (byType.get('IFCGRID')?.length ?? 0) > 0
-          || (byType.get('IfcGrid')?.length ?? 0) > 0,
-      };
-    };
-    let annotations = false;
-    let grid = false;
-    if (models.size > 0) {
-      for (const [, m] of models) {
-        const p = probe(m.ifcDataStore);
-        annotations ||= p.annotations;
-        grid ||= p.grid;
-      }
-    } else {
-      const p = probe(ifcDataStore);
-      annotations = p.annotations;
-      grid = p.grid;
-    }
-    return { annotations, grid };
-  }, [models, ifcDataStore]);
-  const hasIfcAnnotations = hasIfcEntities.annotations;
-  const hasIfcGrid = hasIfcEntities.grid;
+  // NOTE: The Class Visibility dropdown used to gate each toggle on whether
+  // the loaded model actually contained that class (scanning meshes for
+  // Spaces/Openings/Site and probing the entity table for Annotations/Grids).
+  // That gating was removed: the toggles are persisted user preferences, so
+  // they now render unconditionally and stay sticky across models and reloads.
 
   const handleFileSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
@@ -1534,8 +1438,8 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
                 // Stay enabled even with no model loaded — the dropdown
                 // also exposes load-time settings (Merge Multilayer
                 // Walls) that the user should be able to set BEFORE
-                // opening a file. Runtime items inside self-gate via
-                // typeGeometryExists.
+                // opening a file. The class toggles are persisted
+                // preferences, so they always render too.
                 aria-label={mergeLayers ? 'Class Visibility (Merge Multilayer Walls is on)' : 'Class Visibility'}
                 className="relative"
               >
@@ -1557,51 +1461,49 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
           </TooltipContent>
         </Tooltip>
         <DropdownMenuContent className="w-72">
-          {typeGeometryExists.spaces && (
-            <DropdownMenuCheckboxItem
-              checked={typeVisibility.spaces}
-              onCheckedChange={() => toggleTypeVisibility('spaces')}
-            >
-              <Box className="h-4 w-4 mr-2" style={{ color: '#33d9ff' }} />
-              Show Spaces
-            </DropdownMenuCheckboxItem>
-          )}
-          {typeGeometryExists.openings && (
-            <DropdownMenuCheckboxItem
-              checked={typeVisibility.openings}
-              onCheckedChange={() => toggleTypeVisibility('openings')}
-            >
-              <SquareX className="h-4 w-4 mr-2" style={{ color: '#ff6b4a' }} />
-              Show Openings
-            </DropdownMenuCheckboxItem>
-          )}
-          {typeGeometryExists.site && (
-            <DropdownMenuCheckboxItem
-              checked={typeVisibility.site}
-              onCheckedChange={() => toggleTypeVisibility('site')}
-            >
-              <Building2 className="h-4 w-4 mr-2" style={{ color: '#66cc4d' }} />
-              Show Site
-            </DropdownMenuCheckboxItem>
-          )}
-          {hasIfcAnnotations && (
-            <DropdownMenuCheckboxItem
-              checked={typeVisibility.ifcAnnotations}
-              onCheckedChange={() => toggleTypeVisibility('ifcAnnotations')}
-            >
-              <Pencil className="h-4 w-4 mr-2" style={{ color: '#e4b400' }} />
-              Show Annotations
-            </DropdownMenuCheckboxItem>
-          )}
-          {hasIfcGrid && (
-            <DropdownMenuCheckboxItem
-              checked={typeVisibility.ifcGrid}
-              onCheckedChange={() => toggleTypeVisibility('ifcGrid')}
-            >
-              <Pencil className="h-4 w-4 mr-2" style={{ color: '#e4b400' }} />
-              Show Grids
-            </DropdownMenuCheckboxItem>
-          )}
+          {/*
+            Always render all five class toggles, regardless of what the
+            current model contains. They are persisted user preferences
+            (see getPersistedTypeVisibility) — a user who hides Spaces wants
+            that to stick across models and reloads, so the controls must
+            stay visible even when the loaded file has none of that class.
+            Toggling a class absent from the model is simply a no-op.
+          */}
+          <DropdownMenuCheckboxItem
+            checked={typeVisibility.spaces}
+            onCheckedChange={() => toggleTypeVisibility('spaces')}
+          >
+            <Box className="h-4 w-4 mr-2" style={{ color: '#33d9ff' }} />
+            Show Spaces
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuCheckboxItem
+            checked={typeVisibility.openings}
+            onCheckedChange={() => toggleTypeVisibility('openings')}
+          >
+            <SquareX className="h-4 w-4 mr-2" style={{ color: '#ff6b4a' }} />
+            Show Openings
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuCheckboxItem
+            checked={typeVisibility.site}
+            onCheckedChange={() => toggleTypeVisibility('site')}
+          >
+            <Building2 className="h-4 w-4 mr-2" style={{ color: '#66cc4d' }} />
+            Show Site
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuCheckboxItem
+            checked={typeVisibility.ifcAnnotations}
+            onCheckedChange={() => toggleTypeVisibility('ifcAnnotations')}
+          >
+            <Pencil className="h-4 w-4 mr-2" style={{ color: '#e4b400' }} />
+            Show Annotations
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuCheckboxItem
+            checked={typeVisibility.ifcGrid}
+            onCheckedChange={() => toggleTypeVisibility('ifcGrid')}
+          >
+            <Pencil className="h-4 w-4 mr-2" style={{ color: '#e4b400' }} />
+            Show Grids
+          </DropdownMenuCheckboxItem>
 
           {/* Load-time toggles live below the runtime visibility
               switches — they apply on next model open rather than

--- a/apps/viewer/src/store/constants.ts
+++ b/apps/viewer/src/store/constants.ts
@@ -6,6 +6,8 @@
  * Store constants - extracted magic numbers for maintainability
  */
 
+import type { TypeVisibility } from './types.js';
+
 // ============================================================================
 // Camera Defaults
 // ============================================================================
@@ -191,28 +193,33 @@ const SEMANTIC_DEFAULTS = {
   ifcGrid: true,
 } as const;
 
-export const TYPE_VISIBILITY_DEFAULTS = {
-  /** IfcSpace visibility — persisted across reloads. */
-  SPACES:          readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.spaces, SEMANTIC_DEFAULTS.spaces),
-  /** IfcOpeningElement visibility — persisted across reloads. */
-  OPENINGS:        readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.openings, SEMANTIC_DEFAULTS.openings),
-  /** IfcSite visibility — persisted across reloads. */
-  SITE:            readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.site, SEMANTIC_DEFAULTS.site),
-  /** IfcAnnotation visibility (text, dimensions, leaders) — persisted. */
-  IFC_ANNOTATIONS: readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.ifcAnnotations, SEMANTIC_DEFAULTS.ifcAnnotations),
-  /**
-   * IfcGrid visibility (axis lines + bubble tags) — persisted. Issue
-   * #862. Migration: if the new key isn't set yet, fall back to the
-   * legacy combined `ifcAnnotations` preference. That way a user who
-   * previously turned the combined "Annotations & Grids" toggle off
-   * keeps grids hidden after upgrade, instead of grids silently
-   * reappearing (PR #868 review, chatgpt-codex P2).
-   */
-  IFC_GRID:        readPersistedBool(
-    TYPE_VISIBILITY_STORAGE_KEYS.ifcGrid,
-    readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.ifcAnnotations, SEMANTIC_DEFAULTS.ifcGrid),
-  ),
-} as const;
+/**
+ * Resolve the full type-visibility preference set from localStorage.
+ *
+ * Read fresh on EVERY call — not captured once at module load. The store
+ * applies this both at boot (slice init) and on every new-file load
+ * (`resetViewerState`). A module-level constant would snapshot localStorage
+ * at first import and then go stale after the first in-session toggle, so
+ * loading a second model would silently revert the user's choices (e.g.
+ * "Show Annotations" flipping back on). Reading live keeps every toggle
+ * sticky across reloads AND across model swaps within a session.
+ */
+export function getPersistedTypeVisibility(): TypeVisibility {
+  return {
+    spaces:         readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.spaces, SEMANTIC_DEFAULTS.spaces),
+    openings:       readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.openings, SEMANTIC_DEFAULTS.openings),
+    site:           readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.site, SEMANTIC_DEFAULTS.site),
+    ifcAnnotations: readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.ifcAnnotations, SEMANTIC_DEFAULTS.ifcAnnotations),
+    // Issue #862. Migration: if the new grid key isn't set yet, fall back to
+    // the legacy combined `ifcAnnotations` preference so a user who turned
+    // the old "Annotations & Grids" toggle off keeps grids hidden after
+    // upgrade instead of grids silently reappearing (PR #868 review).
+    ifcGrid:        readPersistedBool(
+      TYPE_VISIBILITY_STORAGE_KEYS.ifcGrid,
+      readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.ifcAnnotations, SEMANTIC_DEFAULTS.ifcGrid),
+    ),
+  };
+}
 
 // ============================================================================
 // Data Defaults

--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -49,7 +49,7 @@ import { createPointCloudSlice, type PointCloudSlice, POINT_CLOUD_DEFAULTS } fro
 import { invalidateVisibleBasketCache } from './basketVisibleSet.js';
 
 // Import constants for reset function
-import { CAMERA_DEFAULTS, SECTION_PLANE_DEFAULTS, UI_DEFAULTS, TYPE_VISIBILITY_DEFAULTS } from './constants.js';
+import { CAMERA_DEFAULTS, SECTION_PLANE_DEFAULTS, UI_DEFAULTS, getPersistedTypeVisibility } from './constants.js';
 
 // Re-export types for consumers
 export type * from './types.js';
@@ -203,13 +203,9 @@ const createViewerStore = () => create<ViewerState>()((...args) => ({
       hiddenEntities: new Set(),
       isolatedEntities: null,
       classFilter: null,
-      typeVisibility: {
-        spaces: TYPE_VISIBILITY_DEFAULTS.SPACES,
-        openings: TYPE_VISIBILITY_DEFAULTS.OPENINGS,
-        site: TYPE_VISIBILITY_DEFAULTS.SITE,
-        ifcAnnotations: TYPE_VISIBILITY_DEFAULTS.IFC_ANNOTATIONS,
-        ifcGrid: TYPE_VISIBILITY_DEFAULTS.IFC_GRID,
-      },
+      // Re-read persisted toggles on every file load so a new model never
+      // reverts the user's visibility choices (e.g. "Show Annotations").
+      typeVisibility: getPersistedTypeVisibility(),
 
       // Visibility (multi-model)
       hiddenEntitiesByModel: new Map(),

--- a/apps/viewer/src/store/slices/visibilitySlice.test.ts
+++ b/apps/viewer/src/store/slices/visibilitySlice.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert';
 import { createVisibilitySlice, type VisibilitySlice } from './visibilitySlice.js';
-import { TYPE_VISIBILITY_DEFAULTS } from '../constants.js';
+import { getPersistedTypeVisibility } from '../constants.js';
 
 describe('VisibilitySlice', () => {
   let state: VisibilitySlice;
@@ -33,10 +33,13 @@ describe('VisibilitySlice', () => {
       assert.strictEqual(state.isolatedEntitiesByModel.size, 0);
     });
 
-    it('should have default type visibility', () => {
-      assert.strictEqual(state.typeVisibility.spaces, TYPE_VISIBILITY_DEFAULTS.SPACES);
-      assert.strictEqual(state.typeVisibility.openings, TYPE_VISIBILITY_DEFAULTS.OPENINGS);
-      assert.strictEqual(state.typeVisibility.site, TYPE_VISIBILITY_DEFAULTS.SITE);
+    it('should initialise type visibility from persisted preferences', () => {
+      const persisted = getPersistedTypeVisibility();
+      assert.strictEqual(state.typeVisibility.spaces, persisted.spaces);
+      assert.strictEqual(state.typeVisibility.openings, persisted.openings);
+      assert.strictEqual(state.typeVisibility.site, persisted.site);
+      assert.strictEqual(state.typeVisibility.ifcAnnotations, persisted.ifcAnnotations);
+      assert.strictEqual(state.typeVisibility.ifcGrid, persisted.ifcGrid);
     });
   });
 

--- a/apps/viewer/src/store/slices/visibilitySlice.ts
+++ b/apps/viewer/src/store/slices/visibilitySlice.ts
@@ -11,7 +11,7 @@
 
 import type { StateCreator } from 'zustand';
 import type { TypeVisibility, EntityRef } from '../types.js';
-import { TYPE_VISIBILITY_DEFAULTS, TYPE_VISIBILITY_STORAGE_KEYS } from '../constants.js';
+import { getPersistedTypeVisibility, TYPE_VISIBILITY_STORAGE_KEYS } from '../constants.js';
 
 export interface VisibilitySlice {
   // State (legacy - single model)
@@ -75,13 +75,8 @@ export const createVisibilitySlice: StateCreator<VisibilitySlice, [], [], Visibi
   hiddenEntities: new Set(),
   isolatedEntities: null,
   classFilter: null,
-  typeVisibility: {
-    spaces: TYPE_VISIBILITY_DEFAULTS.SPACES,
-    openings: TYPE_VISIBILITY_DEFAULTS.OPENINGS,
-    site: TYPE_VISIBILITY_DEFAULTS.SITE,
-    ifcAnnotations: TYPE_VISIBILITY_DEFAULTS.IFC_ANNOTATIONS,
-    ifcGrid: TYPE_VISIBILITY_DEFAULTS.IFC_GRID,
-  },
+  // Read persisted toggles fresh so the user's choices survive reloads.
+  typeVisibility: getPersistedTypeVisibility(),
 
   // Initial state (multi-model)
   hiddenEntitiesByModel: new Map(),


### PR DESCRIPTION
## Problem

The **Class Visibility** dropdown (Filter icon, top toolbar) had two issues with its Show Spaces / Openings / Site / Annotations / Grids toggles:

1. **Toggles only appeared when the current model contained that class.** Spaces/Openings/Site were gated on a mesh scan; Annotations/Grids on an entity-table probe. So a control could vanish depending on the loaded file — and a hidden setting then had no visible toggle to confirm it.
2. **Settings didn't reliably persist.** Toggling wrote to `localStorage` and a fresh boot read it back, but `resetViewerState` (runs on **every** file load) reset `typeVisibility` from `TYPE_VISIBILITY_DEFAULTS` — a module-level constant captured **once at import**. After the first in-session toggle, loading another model reverted to that stale snapshot (e.g. *Show Annotations* turning back on), which reads as "doesn't persist on reload".

## Fix

- Replace `TYPE_VISIBILITY_DEFAULTS` with `getPersistedTypeVisibility()` in `store/constants.ts`, which reads `localStorage` **fresh on every call**.
- Use it in both the visibility slice init **and** `resetViewerState`, so all five toggles stay sticky across reloads **and** model swaps within a session. The #862 grid→annotations migration fallback is preserved.
- Remove the `typeGeometryExists` mesh scan and `hasIfcEntities` probe in `MainToolbar.tsx`; all five `Show …` items now render unconditionally. Toggling a class the model lacks is a no-op.

Net **−97 lines** (dead scan/probe code removed).

## Verification

- `visibilitySlice` tests: **35/35 pass** (`npx tsx --test apps/viewer/src/store/slices/visibilitySlice.test.ts`).
- Typecheck clean for touched files. The unrelated `@vercel/analytics/react` error in `App.tsx` is pre-existing (package not installed locally, from the recent analytics-install commit).
- Repo has no ESLint config; typecheck + tests are the gates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Class Visibility toggles (Spaces, Openings, Site, Annotations, Grids) now persist as user preferences across model loads and reloads. Toggles remain consistently available for all loaded models.

* **Improvements**
  * Enhanced Docker build workflow efficiency with concurrent build cancellation for newer pushes and job-level timeout limits to prevent extended build runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LTplus-AG/ifc-lite/pull/881?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->