### PR TITLE
fix(viewer): distinct grid icon and flatten class-visibility menu

### DIFF
--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -1501,32 +1501,22 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
             checked={typeVisibility.ifcGrid}
             onCheckedChange={() => toggleTypeVisibility('ifcGrid')}
           >
-            <Pencil className="h-4 w-4 mr-2" style={{ color: '#e4b400' }} />
+            {/* Distinct grid glyph — annotations already use the pencil. */}
+            <Grid3x3 className="h-4 w-4 mr-2" style={{ color: '#e4b400' }} />
             Show Grids
           </DropdownMenuCheckboxItem>
-
-          {/* Load-time toggles live below the runtime visibility
-              switches — they apply on next model open rather than
-              affecting the current scene. The subheader makes that
-              boundary visible at a glance. */}
-          <DropdownMenuSeparator />
-          <DropdownMenuLabel className="px-2 pt-1 pb-0.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-            Load Settings
-          </DropdownMenuLabel>
+          {/* Merge Multilayer Walls sits in the same flat list: every
+              toggle here persists, so there's no longer a "runtime vs
+              load-time" split worth a subheader. It applies on the next
+              model open (the only behavioural difference), surfaced via
+              the hover title rather than a space-eating second line. */}
           <DropdownMenuCheckboxItem
             checked={mergeLayers}
             onCheckedChange={(next) => setMergeLayers(next === true)}
-            // Use items-start so the checkmark and icon line up with
-            // the primary label while the description wraps below.
-            className="items-start gap-2 py-2"
+            title="Render walls as one solid · applies on next model load"
           >
-            <Layers2 className="h-4 w-4 mr-2 mt-0.5 shrink-0 text-primary" />
-            <div className="flex flex-col gap-0.5 min-w-0">
-              <span className="text-sm font-medium leading-tight">Merge Multilayer Walls</span>
-              <span className="text-[11px] leading-tight text-muted-foreground">
-                Render walls as 1 solid · Applies on reload
-              </span>
-            </div>
+            <Layers2 className="h-4 w-4 mr-2 shrink-0 text-primary" />
+            Merge Multilayer Walls
           </DropdownMenuCheckboxItem>
         </DropdownMenuContent>
       </DropdownMenu>


### PR DESCRIPTION
Follow-up to #881, addressing two polish issues in the top-toolbar Class Visibility dropdown.

## Changes

1. **Distinct icon for Show Grids.** It previously shared the exact pencil glyph used by Show Annotations, so the two rows looked identical. Grids now use a `Grid3x3` icon.

2. **Flattened the menu — no more "Load Settings" section.** Now that every toggle here persists across reloads, the runtime-vs-load-time split no longer warrants its own subheader/separator. Merge Multilayer Walls becomes a single-line item in the same flat list. Its one behavioural difference — it applies on the next model load — moves to a hover `title` instead of a wrapped two-line description, which reclaims the vertical space and the empty left gutter that the second line created.

## Verification

- Typecheck clean for the touched file (the unrelated `@vercel/analytics/react` error in `App.tsx` is pre-existing — package not installed locally).
- No orphaned icon imports; `DropdownMenuLabel`/`DropdownMenuSeparator` are still used by other menus.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the Class Visibility dropdown with updated icon display for the "Show Grids" option
  * Reorganized the "Merge Multilayer Walls" setting into the main checkbox list with a descriptive tooltip indicating when changes take effect

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LTplus-AG/ifc-lite/pull/882?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->