### PR TITLE
ci(docker): raise build timeout 60 -> 120 min

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,8 +40,11 @@ jobs:
     name: Build & Push Docker Image
     runs-on: depot-ubuntu-24.04-4
     # Cap a stuck "Build and push" so it can't run to GitHub's 6h default.
-    # A cold Rust+wasm rebuild (cache miss) is ~30-45 min, so 60 gives headroom.
-    timeout-minutes: 60
+    # A *cold* build — cargo-chef cooking the whole workspace incl. the
+    # manifold-csg-sys C++ kernel after a deps-cache miss — runs >60 min, and a
+    # cold build that gets cancelled never warms the gha cache, so the cap must
+    # let one complete. 120 covers a cold build; warm builds finish in minutes.
+    timeout-minutes: 120
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## What
Raise the Docker Image build `timeout-minutes` from 60 → 120.

## Why
#880 added `timeout-minutes: 60`, but that's too tight for a **cold** build. The Dockerfile uses cargo-chef + GHA layer cache, so warm builds are fast — but when #874's large Rust diff busted the deps cache, cargo-chef has to cook the entire workspace (including the heavy `manifold-csg-sys` C++ kernel). The `e73ac093` run was still going past 80 min, and the post-#880 run on `01b7b392` was **cancelled at exactly 60:00** by the cap.

Worse: a cold build that's cancelled never warms the GHA cache, so every retry would hit the same cold path and cancel again — the image would never rebuild after a big Rust change. 120 min lets one cold build complete and warm the cache; warm builds still finish in minutes, and a genuinely hung build is still capped well under GitHub's 6h default. `cancel-in-progress` (from #880) is unchanged.

CI-only; no changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker build pipeline reliability by extending the build timeout window.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LTplus-AG/ifc-lite/pull/884?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->