### PR TITLE
feat(viewer): redesign visibility menu as a switch-based settings panel

### DIFF
--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -1501,32 +1501,22 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
             checked={typeVisibility.ifcGrid}
             onCheckedChange={() => toggleTypeVisibility('ifcGrid')}
           >
-            <Pencil className="h-4 w-4 mr-2" style={{ color: '#e4b400' }} />
+            {/* Distinct grid glyph — annotations already use the pencil. */}
+            <Grid3x3 className="h-4 w-4 mr-2" style={{ color: '#e4b400' }} />
             Show Grids
           </DropdownMenuCheckboxItem>
-
-          {/* Load-time toggles live below the runtime visibility
-              switches — they apply on next model open rather than
-              affecting the current scene. The subheader makes that
-              boundary visible at a glance. */}
-          <DropdownMenuSeparator />
-          <DropdownMenuLabel className="px-2 pt-1 pb-0.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-            Load Settings
-          </DropdownMenuLabel>
+          {/* Merge Multilayer Walls sits in the same flat list: every
+              toggle here persists, so there's no longer a "runtime vs
+              load-time" split worth a subheader. It applies on the next
+              model open (the only behavioural difference), surfaced via
+              the hover title rather than a space-eating second line. */}
           <DropdownMenuCheckboxItem
             checked={mergeLayers}
             onCheckedChange={(next) => setMergeLayers(next === true)}
-            // Use items-start so the checkmark and icon line up with
-            // the primary label while the description wraps below.
-            className="items-start gap-2 py-2"
+            title="Render walls as one solid · applies on next model load"
           >
-            <Layers2 className="h-4 w-4 mr-2 mt-0.5 shrink-0 text-primary" />
-            <div className="flex flex-col gap-0.5 min-w-0">
-              <span className="text-sm font-medium leading-tight">Merge Multilayer Walls</span>
-              <span className="text-[11px] leading-tight text-muted-foreground">
-                Render walls as 1 solid · Applies on reload
-              </span>
-            </div>
+            <Layers2 className="h-4 w-4 mr-2 shrink-0 text-primary" />
+            Merge Multilayer Walls
           </DropdownMenuCheckboxItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -52,6 +52,7 @@ import {
   Redo2,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
 import { Separator } from '@/components/ui/separator';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import {
@@ -155,6 +156,39 @@ function ToolButton({
         {label} {shortcut && <span className="ml-2 text-xs opacity-60">({shortcut})</span>}
       </TooltipContent>
     </Tooltip>
+  );
+}
+
+interface ClassVisibilityRowProps {
+  /** Colored class glyph (caller sets the tint). */
+  icon: React.ReactNode;
+  label: string;
+  /** One-line plain-language hint about what the IFC class covers. */
+  description: string;
+  checked: boolean;
+  onChange: (next: boolean) => void;
+}
+
+/**
+ * One row of the Visibility panel: colored class icon + label/description
+ * on the left, a Switch on the right. The whole row is a <label>, so a
+ * click anywhere toggles the switch and — because it isn't a menu item —
+ * the dropdown stays open for flipping several classes in a row. The left
+ * cluster dims when off so on/off reads from saturation as well as the
+ * switch position.
+ */
+function ClassVisibilityRow({ icon, label, description, checked, onChange }: ClassVisibilityRowProps) {
+  return (
+    <label className="group flex items-center justify-between gap-3 rounded-md px-2 py-1.5 cursor-pointer hover:bg-muted/50 transition-colors">
+      <span className={cn('flex items-center gap-2.5 min-w-0 transition-opacity', !checked && 'opacity-50')}>
+        {icon}
+        <span className="grid gap-0.5 min-w-0">
+          <span className="text-sm leading-tight truncate">{label}</span>
+          <span className="text-[10px] leading-tight text-muted-foreground truncate">{description}</span>
+        </span>
+      </span>
+      <Switch checked={checked} onCheckedChange={onChange} />
+    </label>
   );
 }
 
@@ -505,6 +539,16 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
   const toggleHoverTooltips = useViewerStore((state) => state.toggleHoverTooltips);
   const typeVisibility = useViewerStore((state) => state.typeVisibility);
   const toggleTypeVisibility = useViewerStore((state) => state.toggleTypeVisibility);
+  const resetTypeVisibility = useViewerStore((state) => state.resetTypeVisibility);
+  // How many of the five class toggles are on — surfaced in the menu
+  // header so the user sees scene state at a glance.
+  const visibleClassCount = [
+    typeVisibility.spaces,
+    typeVisibility.openings,
+    typeVisibility.site,
+    typeVisibility.ifcAnnotations,
+    typeVisibility.ifcGrid,
+  ].filter(Boolean).length;
   // Issue #540: load-time toggle that asks the WASM bridge to merge
   // Revit-style multilayer walls. We surface this in the Class
   // Visibility dropdown so users discover it next to the other
@@ -1440,7 +1484,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
                 // Walls) that the user should be able to set BEFORE
                 // opening a file. The class toggles are persisted
                 // preferences, so they always render too.
-                aria-label={mergeLayers ? 'Class Visibility (Merge Multilayer Walls is on)' : 'Class Visibility'}
+                aria-label={mergeLayers ? 'Visibility (Merge Multilayer Walls is on)' : 'Visibility'}
                 className="relative"
               >
                 <Filter className="h-4 w-4" />
@@ -1457,67 +1501,93 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
             </DropdownMenuTrigger>
           </TooltipTrigger>
           <TooltipContent>
-            {mergeLayers ? 'Class Visibility · Merge Multilayer Walls is on' : 'Class Visibility'}
+            {mergeLayers ? 'Visibility · Merge Multilayer Walls is on' : 'Visibility'}
           </TooltipContent>
         </Tooltip>
-        <DropdownMenuContent className="w-72">
-          {/*
-            Always render all five class toggles, regardless of what the
-            current model contains. They are persisted user preferences
-            (see getPersistedTypeVisibility) — a user who hides Spaces wants
-            that to stick across models and reloads, so the controls must
-            stay visible even when the loaded file has none of that class.
-            Toggling a class absent from the model is simply a no-op.
-          */}
-          <DropdownMenuCheckboxItem
+        {/*
+          Settings-style panel (not a list of menu-items): each row is a
+          plain <label> wrapping a right-aligned Switch, so toggling does
+          NOT close the menu — users routinely flip several classes in one
+          pass. State reads two ways: the switch position and the row
+          dimming when off. All five render unconditionally (persisted
+          preferences, sticky across models/reloads); toggling a class the
+          model lacks is a no-op.
+        */}
+        <DropdownMenuContent align="start" className="w-[300px] p-1.5">
+          <div className="flex items-center justify-between gap-2 px-1.5 pb-1 pt-0.5">
+            <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Visibility
+            </span>
+            <div className="flex items-center gap-1">
+              <span className="text-[11px] tabular-nums text-muted-foreground/80">
+                {visibleClassCount}/5
+              </span>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 px-1.5 text-[11px] font-medium text-muted-foreground hover:text-foreground"
+                onClick={resetTypeVisibility}
+              >
+                Reset
+              </Button>
+            </div>
+          </div>
+
+          <ClassVisibilityRow
+            icon={<Box className="h-4 w-4 shrink-0" style={{ color: '#33d9ff' }} />}
+            label="Spaces"
+            description="Room & zone volumes"
             checked={typeVisibility.spaces}
-            onCheckedChange={() => toggleTypeVisibility('spaces')}
-          >
-            <Box className="h-4 w-4 mr-2" style={{ color: '#33d9ff' }} />
-            Show Spaces
-          </DropdownMenuCheckboxItem>
-          <DropdownMenuCheckboxItem
+            onChange={() => toggleTypeVisibility('spaces')}
+          />
+          <ClassVisibilityRow
+            icon={<SquareX className="h-4 w-4 shrink-0" style={{ color: '#ff6b4a' }} />}
+            label="Openings"
+            description="Door & window voids"
             checked={typeVisibility.openings}
-            onCheckedChange={() => toggleTypeVisibility('openings')}
-          >
-            <SquareX className="h-4 w-4 mr-2" style={{ color: '#ff6b4a' }} />
-            Show Openings
-          </DropdownMenuCheckboxItem>
-          <DropdownMenuCheckboxItem
+            onChange={() => toggleTypeVisibility('openings')}
+          />
+          <ClassVisibilityRow
+            icon={<Building2 className="h-4 w-4 shrink-0" style={{ color: '#66cc4d' }} />}
+            label="Site"
+            description="Terrain & context"
             checked={typeVisibility.site}
-            onCheckedChange={() => toggleTypeVisibility('site')}
-          >
-            <Building2 className="h-4 w-4 mr-2" style={{ color: '#66cc4d' }} />
-            Show Site
-          </DropdownMenuCheckboxItem>
-          <DropdownMenuCheckboxItem
+            onChange={() => toggleTypeVisibility('site')}
+          />
+          <ClassVisibilityRow
+            icon={<Pencil className="h-4 w-4 shrink-0" style={{ color: '#e4b400' }} />}
+            label="Annotations"
+            description="Text, dimensions, leaders"
             checked={typeVisibility.ifcAnnotations}
-            onCheckedChange={() => toggleTypeVisibility('ifcAnnotations')}
-          >
-            <Pencil className="h-4 w-4 mr-2" style={{ color: '#e4b400' }} />
-            Show Annotations
-          </DropdownMenuCheckboxItem>
-          <DropdownMenuCheckboxItem
+            onChange={() => toggleTypeVisibility('ifcAnnotations')}
+          />
+          <ClassVisibilityRow
+            icon={<Grid3x3 className="h-4 w-4 shrink-0" style={{ color: '#e4b400' }} />}
+            label="Grids"
+            description="Structural axes"
             checked={typeVisibility.ifcGrid}
-            onCheckedChange={() => toggleTypeVisibility('ifcGrid')}
-          >
-            {/* Distinct grid glyph — annotations already use the pencil. */}
-            <Grid3x3 className="h-4 w-4 mr-2" style={{ color: '#e4b400' }} />
-            Show Grids
-          </DropdownMenuCheckboxItem>
-          {/* Merge Multilayer Walls sits in the same flat list: every
-              toggle here persists, so there's no longer a "runtime vs
-              load-time" split worth a subheader. It applies on the next
-              model open (the only behavioural difference), surfaced via
-              the hover title rather than a space-eating second line. */}
-          <DropdownMenuCheckboxItem
-            checked={mergeLayers}
-            onCheckedChange={(next) => setMergeLayers(next === true)}
-            title="Render walls as one solid · applies on next model load"
-          >
-            <Layers2 className="h-4 w-4 mr-2 shrink-0 text-primary" />
-            Merge Multilayer Walls
-          </DropdownMenuCheckboxItem>
+            onChange={() => toggleTypeVisibility('ifcGrid')}
+          />
+
+          <DropdownMenuSeparator className="my-1" />
+
+          {/* Merge multilayer walls rebuilds geometry, so unlike the live
+              toggles above it only takes effect on the next model load.
+              The "· on reload" suffix carries that nuance inline — keeps
+              the row identical in shape to the others (no header, no chip
+              crowding the long label). */}
+          <label className="group flex items-center justify-between gap-3 rounded-md px-2 py-1.5 cursor-pointer hover:bg-muted/50 transition-colors">
+            <span className={cn('flex items-center gap-2.5 min-w-0 transition-opacity', !mergeLayers && 'opacity-50')}>
+              <Layers2 className="h-4 w-4 shrink-0 text-primary" />
+              <span className="grid gap-0.5 min-w-0">
+                <span className="text-sm leading-tight truncate">Merge multilayer walls</span>
+                <span className="text-[10px] leading-tight text-muted-foreground truncate">
+                  Render walls as one solid · on reload
+                </span>
+              </span>
+            </span>
+            <Switch checked={mergeLayers} onCheckedChange={(next) => setMergeLayers(next === true)} />
+          </label>
         </DropdownMenuContent>
       </DropdownMenu>
 

--- a/apps/viewer/src/store/constants.ts
+++ b/apps/viewer/src/store/constants.ts
@@ -184,14 +184,15 @@ function readPersistedBool(key: string, fallback: boolean): boolean {
 // on first load. IfcSite + IfcAnnotation + IfcGrid on — all three convey
 // design intent users expect to see by default. (Issue #862 split grid
 // into its own toggle so dense-grid models can hide grids without losing
-// dimensions/labels.)
-const SEMANTIC_DEFAULTS = {
+// dimensions/labels.) Exported so the "Reset" action in the visibility
+// menu can restore these without re-deriving them.
+export const TYPE_VISIBILITY_SEMANTIC_DEFAULTS: TypeVisibility = {
   spaces: false,
   openings: false,
   site: true,
   ifcAnnotations: true,
   ifcGrid: true,
-} as const;
+};
 
 /**
  * Resolve the full type-visibility preference set from localStorage.
@@ -206,17 +207,17 @@ const SEMANTIC_DEFAULTS = {
  */
 export function getPersistedTypeVisibility(): TypeVisibility {
   return {
-    spaces:         readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.spaces, SEMANTIC_DEFAULTS.spaces),
-    openings:       readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.openings, SEMANTIC_DEFAULTS.openings),
-    site:           readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.site, SEMANTIC_DEFAULTS.site),
-    ifcAnnotations: readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.ifcAnnotations, SEMANTIC_DEFAULTS.ifcAnnotations),
+    spaces:         readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.spaces, TYPE_VISIBILITY_SEMANTIC_DEFAULTS.spaces),
+    openings:       readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.openings, TYPE_VISIBILITY_SEMANTIC_DEFAULTS.openings),
+    site:           readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.site, TYPE_VISIBILITY_SEMANTIC_DEFAULTS.site),
+    ifcAnnotations: readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.ifcAnnotations, TYPE_VISIBILITY_SEMANTIC_DEFAULTS.ifcAnnotations),
     // Issue #862. Migration: if the new grid key isn't set yet, fall back to
     // the legacy combined `ifcAnnotations` preference so a user who turned
     // the old "Annotations & Grids" toggle off keeps grids hidden after
     // upgrade instead of grids silently reappearing (PR #868 review).
     ifcGrid:        readPersistedBool(
       TYPE_VISIBILITY_STORAGE_KEYS.ifcGrid,
-      readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.ifcAnnotations, SEMANTIC_DEFAULTS.ifcGrid),
+      readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.ifcAnnotations, TYPE_VISIBILITY_SEMANTIC_DEFAULTS.ifcGrid),
     ),
   };
 }

--- a/apps/viewer/src/store/slices/visibilitySlice.test.ts
+++ b/apps/viewer/src/store/slices/visibilitySlice.test.ts
@@ -309,5 +309,20 @@ describe('VisibilitySlice', () => {
       state.toggleTypeVisibility('ifcAnnotations');
       assert.strictEqual(state.typeVisibility.ifcAnnotations, !initial);
     });
+
+    it('resetTypeVisibility restores semantic defaults', () => {
+      // Flip everything away from defaults first.
+      state.toggleTypeVisibility('spaces');   // false -> true
+      state.toggleTypeVisibility('site');     // true  -> false
+      state.toggleTypeVisibility('ifcGrid');  // true  -> false
+      state.resetTypeVisibility();
+      assert.deepStrictEqual(state.typeVisibility, {
+        spaces: false,
+        openings: false,
+        site: true,
+        ifcAnnotations: true,
+        ifcGrid: true,
+      });
+    });
   });
 });

--- a/apps/viewer/src/store/slices/visibilitySlice.ts
+++ b/apps/viewer/src/store/slices/visibilitySlice.ts
@@ -11,7 +11,7 @@
 
 import type { StateCreator } from 'zustand';
 import type { TypeVisibility, EntityRef } from '../types.js';
-import { getPersistedTypeVisibility, TYPE_VISIBILITY_STORAGE_KEYS } from '../constants.js';
+import { getPersistedTypeVisibility, TYPE_VISIBILITY_STORAGE_KEYS, TYPE_VISIBILITY_SEMANTIC_DEFAULTS } from '../constants.js';
 
 export interface VisibilitySlice {
   // State (legacy - single model)
@@ -44,6 +44,8 @@ export interface VisibilitySlice {
   showAll: () => void;
   isEntityVisible: (id: number) => boolean;
   toggleTypeVisibility: (type: 'spaces' | 'openings' | 'site' | 'ifcAnnotations' | 'ifcGrid') => void;
+  /** Restore every type-visibility toggle to its semantic default (and persist). */
+  resetTypeVisibility: () => void;
   /** Set all hidden entities at once (for BCF viewpoint application) */
   setHiddenEntities: (ids: Set<number>) => void;
   /** Set all isolated entities at once (for BCF viewpoint with defaultVisibility=false) */
@@ -204,6 +206,19 @@ export const createVisibilitySlice: StateCreator<VisibilitySlice, [], [], Visibi
     return {
       typeVisibility: { ...state.typeVisibility, [type]: next },
     };
+  }),
+
+  resetTypeVisibility: () => set(() => {
+    // Restore semantic defaults and persist them per-key (same storage
+    // pattern as toggleTypeVisibility) so the reset survives reloads.
+    if (typeof window !== 'undefined') {
+      (Object.keys(TYPE_VISIBILITY_STORAGE_KEYS) as (keyof typeof TYPE_VISIBILITY_STORAGE_KEYS)[])
+        .forEach((key) => {
+          try { localStorage.setItem(TYPE_VISIBILITY_STORAGE_KEYS[key], String(TYPE_VISIBILITY_SEMANTIC_DEFAULTS[key])); }
+          catch { /* private-mode storage rejection — non-fatal */ }
+        });
+    }
+    return { typeVisibility: { ...TYPE_VISIBILITY_SEMANTIC_DEFAULTS } };
   }),
 
   // Actions (multi-model)


### PR DESCRIPTION
Follow-up to #881/#882 — a UX pass on the top-toolbar visibility menu (frontend-design skill).

## Before

A generic checkbox list: left-aligned checkmarks competed with the colored type icons, on/off was hard to scan, the menu closed after each toggle, and rows gave no hint what each IFC class actually is.

## After

Reworked into a **switch-based settings panel**, matching the existing house pattern (4D `AnimationSettingsPopover`):

- **Right-aligned toggle switches.** Clean left edge (icon + label), a scannable right rail of states. Off rows **dim**, so on/off reads from both switch position and saturation.
- **Menu stays open** while toggling — rows are `<label>`s, not menu items — so users can flip several classes in one pass.
- **Plain-language description per class** (Spaces = "Room & zone volumes", Openings = "Door & window voids", Site = "Terrain & context", Annotations = "Text, dimensions, leaders", Grids = "Structural axes").
- **Header** with a live `N/5` count and a **Reset** that restores semantic defaults (new `resetTypeVisibility` store action; persists like the toggles).
- **Merge multilayer walls** stays in the same flat list under a hairline; its load-time nature is carried inline (`Render walls as one solid · on reload`) — no chip crowding the long label.
- Trigger relabeled "Class Visibility" → "Visibility".

All five toggles still render unconditionally and persist across reloads and model swaps (from #881).

## Preview

Token-accurate mockup (light theme) of the result:

| state | |
|---|---|
| 2/5 shown — Site & Annotations on, rest off (dimmed) | switches right, descriptions, hairline before Merge |

## Verification

- `visibilitySlice` tests: **36/36 pass** (added a `resetTypeVisibility` case).
- Typecheck clean for touched files (the `@vercel/analytics/react` error in `App.tsx` is pre-existing — package not installed locally).
- No new deps; uses the existing `Switch` primitive. No tests/e2e referenced the old menu labels.
