### PR TITLE
chore: changeset for IfcGridPlacement support (#883)

### DIFF
--- a/.changeset/feat-883-grid-placement.md
+++ b/.changeset/feat-883-grid-placement.md
@@ -1,10 +1,18 @@
 ---
 "@ifc-lite/wasm": minor
+"@ifc-lite/server-bin": minor
 ---
 
 Render IFC4x3 `IfcGridPlacement` so products laid out on a structural grid
 land on their grid-axis intersections instead of stacking at world origin
 (issue #883).
+
+The fix is in the shared `ifc-lite-geometry` Rust crate, so it ships on both
+surfaces that compile it: the WebAssembly build (`@ifc-lite/wasm`) and the
+native server binary downloaded by `@ifc-lite/server-bin` (pinned to its own
+package version, so it needs the bump to pull a rebuilt binary). The desktop
+app (Tauri) and the Docker server image compile the same crate and pick the
+fix up through their own build pipelines.
 
 The placement resolver dispatched only on `IfcLocalPlacement` and
 `IfcLinearPlacement` — every other placement type fell through to identity.

--- a/.changeset/feat-883-grid-placement.md
+++ b/.changeset/feat-883-grid-placement.md
@@ -1,0 +1,39 @@
+---
+"@ifc-lite/wasm": minor
+---
+
+Render IFC4x3 `IfcGridPlacement` so products laid out on a structural grid
+land on their grid-axis intersections instead of stacking at world origin
+(issue #883).
+
+The placement resolver dispatched only on `IfcLocalPlacement` and
+`IfcLinearPlacement` — every other placement type fell through to identity.
+The reporter's `ifcgrid.ifc` placed 25 `IfcColumn`s via
+`IfcGridPlacement → IfcVirtualGridIntersection`, so they all collapsed onto
+the same spot instead of spreading across the grid.
+
+This change:
+
+- Recognises `IfcGridPlacement` in the placement resolver. `PlacementRelTo`
+  (the grid's own placement) composes exactly like `IfcLocalPlacement`;
+  `PlacementLocation (IfcVirtualGridIntersection)` is resolved by reading the
+  two referenced `IfcGridAxis` curves, intersecting them in the grid plane,
+  applying the per-axis lateral `OffsetDistances` (each axis shifted along its
+  left normal) and the optional elevation, then composing `parent * local`.
+- Implements full `IfcGridPlacementDirectionSelect` coverage for
+  `PlacementRefDirection`: an `IfcDirection` sets local +X directly; an
+  `IfcVirtualGridIntersection` points local +X from the placement location to
+  that second intersection; null / unresolved inherits the grid orientation.
+
+Out of scope (documented in code):
+
+- Grid axes are treated as straight lines (chord of the first→last curve
+  sample); curved axes would need arc-length sampling.
+
+Regression coverage:
+
+- `grid_placement_tests` in `rust/geometry/src/router/transforms.rs` — inline
+  unit tests that assert the resolved transform directly: the axis-intersection
+  origin, both `PlacementRefDirection` variants, the `OffsetDistances`
+  perpendicular shift + elevation, and `PlacementRelTo` composition. No
+  committed fixture (per AGENTS.md §9); the unit tests are self-contained.


### PR DESCRIPTION
Adds the changeset that was missing from #886 (`IfcGridPlacement` support, issue #883), which merged without one.

The fix lives in the shared `ifc-lite-geometry` Rust crate, so it reaches **every surface that compiles it**:

| Surface | How it ships | Changeset |
|---|---|---|
| Browser/JS | `@ifc-lite/wasm` (WASM build) | **minor** ✅ |
| Native server (npm) | `@ifc-lite/server-bin` — downloads a binary pinned to *its own* version (`releases/download/v${version}/…`) and doesn't depend on `@ifc-lite/wasm`, so it won't auto-bump | **minor** ✅ |
| Docker server image | `apps/server` (no package.json) | rebuilt by `docker.yml` / `server-binaries.yml` — out of band |
| Desktop (Tauri) | `@ifc-lite/desktop` is `private:true` | rebuilt by its own pipeline — out of band |

Both `minor` bumps match the convention for a new placement type (the #859 `IfcLinearPlacement` fix was a `@ifc-lite/wasm` minor). `@ifc-lite/server-bin` is added explicitly so `npx @ifc-lite/server-bin` re-releases and pulls a **rebuilt native binary** containing the fix, rather than continuing to fetch the pre-fix v-tagged binary.

Dependents of `@ifc-lite/wasm` (parser/viewer/etc.) cascade automatically via `updateInternalDependencies: patch`.

`pnpm changeset status` → `@ifc-lite/wasm` + `@ifc-lite/server-bin` to be bumped at minor. Changeset-only PR; no code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed grid placement rendering accuracy: products positioned on structural grids now correctly resolve to their grid-axis intersection points instead of incorrectly collapsing to the world origin. This improves the visualization and accuracy of grid-based structural layouts across WASM and server-based implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LTplus-AG/ifc-lite/pull/887?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->