### PR TITLE
feat(viewer): render IfcAlignment as thin centerline lines, not a ribbon

### DIFF
--- a/.changeset/fix-alignment-batch-render.md
+++ b/.changeset/fix-alignment-batch-render.md
@@ -1,0 +1,35 @@
+---
+"@ifc-lite/wasm": minor
+"@ifc-lite/geometry": minor
+"@ifc-lite/renderer": minor
+---
+
+Render `IfcAlignment` as a thin centerline **line** instead of a triangulated
+ribbon, matching how IfcGrid axes and IfcAnnotation curves draw.
+
+`IfcAlignment` carries its geometry in the `Axis` curve (`IfcAlignmentCurve` or
+`IfcPolyline`), not a `Representation`. Previously the streaming batch mesher
+routed it through the whole-element `IfcAlignmentProcessor`, which sampled the
+directrix into a thin solid ribbon strip — visually wrong for what is a
+centerline. Now the alignment is sampled straight into a line-list overlay:
+
+- **`@ifc-lite/wasm`** gains `IfcAPI.parseAlignmentLines(content)`, which walks
+  every `IfcAlignment`, resolves its `Axis` directrix, samples the centerline
+  (1 file-unit station spacing, adaptive cap at 5000 samples) and returns a flat
+  `Float32Array` of 3D line-list vertices `[x0,y0,z0, x1,y1,z1, …]` in the
+  renderer's Y-up, RTC-subtracted, metres world space — the same frame the mesh
+  pipeline produces, so the line lands on the same ground as the terrain.
+- **`@ifc-lite/geometry`** surfaces it as `GeometryProcessor.parseAlignmentLines`.
+- **`@ifc-lite/renderer`** gains `uploadAlignmentLines3D` / `clearAlignmentLines3D`,
+  drawing the centerline through the existing line pipeline (separate buffer).
+
+The batch mesher no longer special-cases `IfcAlignment` into the ribbon
+processor (reverted to the prior skip), so alignments are lines-only — never
+both. In the viewer the centerline renders whenever a model carries an
+alignment (no toggle).
+
+Regression coverage: `alignment_lines` unit tests in
+`rust/wasm-bindings/src/api/alignment_lines.rs` pin the contract — a planar
+polyline alignment emits an even-count line-list whose start maps to the
+renderer origin and whose extent matches the directrix, and a file with no
+alignment emits an empty array.

--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -45,6 +45,7 @@ import {
   useSymbolicAnnotationsRichData,
   type SectionClipForGrid,
 } from '../../hooks/useSymbolicAnnotations.js';
+import { useAlignmentLines3D } from '../../hooks/useAlignmentLines3D.js';
 
 interface ViewportProps {
   geometry: MeshData[] | null;
@@ -861,6 +862,20 @@ export function Viewport({
       renderer.uploadAnnotationLines3D(annotationVertices3D);
     }
   }, [annotationVertices3D, isInitialized]);
+
+  // IfcAlignment centerlines render as thin lines (not a ribbon mesh), always
+  // on — see useAlignmentLines3D. Upload/clear mirrors the annotation overlay;
+  // a separate renderer buffer keeps alignment visibility independent.
+  const alignmentVertices3D = useAlignmentLines3D();
+  useEffect(() => {
+    const renderer = rendererRef.current;
+    if (!renderer || !isInitialized) return;
+    if (alignmentVertices3D.length === 0) {
+      renderer.clearAlignmentLines3D();
+    } else {
+      renderer.uploadAlignmentLines3D(alignmentVertices3D);
+    }
+  }, [alignmentVertices3D, isInitialized]);
 
   // Upload IfcAnnotation text + fill data for the WebGPU symbolic overlay
   // pipelines. Map the hook's per-annotation records into the SymbolicFillInput

--- a/apps/viewer/src/hooks/useAlignmentLines3D.ts
+++ b/apps/viewer/src/hooks/useAlignmentLines3D.ts
@@ -1,0 +1,164 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Always-on extraction of IfcAlignment centerlines for the 3D viewport.
+ *
+ * IfcAlignment carries its geometry in the `Axis` curve (an IfcAlignmentCurve
+ * or IfcPolyline), not a `Representation`, so it never produces a mesh in the
+ * streaming batch mesher. Instead of rendering it as a triangulated ribbon —
+ * which reads as a thin solid strip — the WASM `parseAlignmentLines` API
+ * samples the directrix into a flat 3D line-list in renderer Y-up world space,
+ * which we feed to `renderer.uploadAlignmentLines3D`. This matches how IfcGrid
+ * axes and IfcAnnotation curves render as thin lines.
+ *
+ * Unlike annotations there is no visibility toggle: alignment lines render
+ * whenever a loaded model has alignments. The parse runs once per model source
+ * and is cached module-globally, so federated views share one parse per source.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { GeometryProcessor } from '@ifc-lite/geometry';
+import { useViewerStore } from '@/store';
+import { useShallow } from 'zustand/react/shallow';
+import type { IfcDataStore } from '@ifc-lite/parser';
+
+const EMPTY_F32 = new Float32Array(0);
+
+/**
+ * Stable per-source cache key — FNV-1a over head/mid/tail byte windows folded
+ * with the length, so two structurally distinct sources can't alias even when
+ * they share an exact byte length (a real risk in federated views). Identical
+ * scheme to `useSymbolicAnnotations`' `sourceKey`.
+ */
+function sourceKey(store: IfcDataStore | null | undefined): string | null {
+  const source = store?.source;
+  if (!source || source.byteLength === 0) return null;
+  const len = source.byteLength;
+  const sampleLen = Math.min(32, len);
+  const head = source.subarray(0, sampleLen);
+  const tail = source.subarray(len - sampleLen, len);
+  const midOffset = Math.max(0, Math.floor(len / 2) - Math.floor(sampleLen / 2));
+  const mid = source.subarray(midOffset, Math.min(midOffset + sampleLen, len));
+  const hashOne = (bytes: Uint8Array): string => {
+    let h = 0x811c9dc5;
+    for (let i = 0; i < bytes.length; i++) {
+      h ^= bytes[i];
+      h = Math.imul(h, 0x01000193);
+    }
+    return (h >>> 0).toString(16);
+  };
+  return `b${len}-${hashOne(head)}-${hashOne(mid)}-${hashOne(tail)}`;
+}
+
+// ─── Shared parse cache ──────────────────────────────────────────────────────
+// One WASM walk per model source; cached so re-renders (and federated views
+// that share a source) don't re-parse.
+const PARSE_CACHE = new Map<string, Float32Array>();
+const PARSE_INFLIGHT = new Map<string, Promise<void>>();
+
+type CacheListener = () => void;
+const CACHE_LISTENERS = new Set<CacheListener>();
+function notifyCacheChange(): void {
+  for (const fn of CACHE_LISTENERS) fn();
+}
+
+async function parseAlignmentLinesFor(store: IfcDataStore): Promise<Float32Array> {
+  const source = store.source;
+  if (!source || source.byteLength === 0) return EMPTY_F32;
+  const processor = new GeometryProcessor();
+  try {
+    await processor.init();
+    const verts = processor.parseAlignmentLines(source);
+    return verts && verts.length > 0 ? verts : EMPTY_F32;
+  } finally {
+    processor.dispose();
+  }
+}
+
+function ensureParseFor(stores: IfcDataStore[]): void {
+  for (const store of stores) {
+    const key = sourceKey(store);
+    if (!key) continue;
+    if (PARSE_CACHE.has(key)) continue;
+    if (PARSE_INFLIGHT.has(key)) continue;
+
+    const promise = (async () => {
+      try {
+        const verts = await parseAlignmentLinesFor(store);
+        PARSE_CACHE.set(key, verts);
+        notifyCacheChange();
+      } catch (error) {
+        // Cache empty on failure so we don't retry a doomed parse every tick.
+        // eslint-disable-next-line no-console
+        console.warn('[useAlignmentLines3D] parse failed:', error);
+        PARSE_CACHE.set(key, EMPTY_F32);
+        notifyCacheChange();
+      } finally {
+        PARSE_INFLIGHT.delete(key);
+      }
+    })();
+    PARSE_INFLIGHT.set(key, promise);
+  }
+}
+
+/** Read the active store set from the viewer store. Federation-aware. */
+function useActiveStores(): IfcDataStore[] {
+  const { models, ifcDataStore } = useViewerStore(
+    useShallow((s) => ({ models: s.models, ifcDataStore: s.ifcDataStore })),
+  );
+  return useMemo(() => {
+    const out: IfcDataStore[] = [];
+    if (models.size > 0) {
+      for (const [, m] of models) if (m.ifcDataStore) out.push(m.ifcDataStore);
+    } else if (ifcDataStore) {
+      out.push(ifcDataStore);
+    }
+    return out;
+  }, [models, ifcDataStore]);
+}
+
+/**
+ * Sample every loaded model's IfcAlignment centerlines into a single flat
+ * `[x0,y0,z0, x1,y1,z1, …]` line-list in renderer world space (Y-up,
+ * RTC-subtracted, metres). Returns a stable empty array when no model carries
+ * an alignment. Always parses (no toggle) — see the file header.
+ */
+export function useAlignmentLines3D(): Float32Array {
+  const stores = useActiveStores();
+  const [version, setVersion] = useState(0);
+
+  useEffect(() => {
+    ensureParseFor(stores);
+    const listener: CacheListener = () => setVersion((v) => v + 1);
+    CACHE_LISTENERS.add(listener);
+    return () => {
+      CACHE_LISTENERS.delete(listener);
+    };
+  }, [stores]);
+
+  return useMemo(() => {
+    void version; // depend on parse-completion ticks
+    const arrays: Float32Array[] = [];
+    let total = 0;
+    for (const store of stores) {
+      const key = sourceKey(store);
+      if (!key) continue;
+      const cached = PARSE_CACHE.get(key);
+      if (cached && cached.length > 0) {
+        arrays.push(cached);
+        total += cached.length;
+      }
+    }
+    if (total === 0) return EMPTY_F32;
+    if (arrays.length === 1) return arrays[0];
+    const merged = new Float32Array(total);
+    let offset = 0;
+    for (const a of arrays) {
+      merged.set(a, offset);
+      offset += a.length;
+    }
+    return merged;
+  }, [stores, version]);
+}

--- a/packages/geometry/src/ifc-lite-bridge.ts
+++ b/packages/geometry/src/ifc-lite-bridge.ts
@@ -135,6 +135,32 @@ export class IfcLiteBridge {
   }
 
   /**
+   * Parse IfcAlignment directrix curves into a flat Float32Array of 3D
+   * line-list vertices `[x0,y0,z0, x1,y1,z1, …]` in renderer Y-up world space
+   * (RTC-subtracted, metres). Feed straight to `renderer.uploadAlignmentLines3D`.
+   * Empty when the file has no alignments.
+   */
+  parseAlignmentLines(content: string): Float32Array {
+    if (!this.ifcApi) {
+      throw new Error('IFC-Lite not initialized. Call init() first.');
+    }
+    try {
+      const vertices = this.ifcApi.parseAlignmentLines(content);
+      log.debug(`Parsed ${vertices.length / 3} alignment line vertices`, { operation: 'parseAlignmentLines' });
+      return vertices;
+    } catch (error) {
+      log.error('Failed to parse alignment lines', error, {
+        operation: 'parseAlignmentLines',
+        data: { contentLength: content.length },
+      });
+      if (this.isWasmRuntimeError(error)) {
+        this.markFatalWasmRuntimeError();
+      }
+      throw error;
+    }
+  }
+
+  /**
    * Extract raw profile polygons from all IfcExtrudedAreaSolid building elements.
    *
    * Returns profile outlines + placement transforms for clean 2D projection

--- a/packages/geometry/src/index.ts
+++ b/packages/geometry/src/index.ts
@@ -816,6 +816,24 @@ export class GeometryProcessor {
   }
 
   /**
+   * Parse IfcAlignment directrix curves into a flat Float32Array of 3D
+   * line-list vertices `[x0,y0,z0, x1,y1,z1, …]` in renderer Y-up world space
+   * (RTC-subtracted, metres). Rendered as thin lines (not a ribbon mesh) to
+   * match IfcGrid / IfcAnnotation. Feed straight to `renderer.uploadAlignmentLines3D`.
+   * @param buffer IFC file buffer
+   * @returns Flat line-list vertices, or null if not initialized
+   */
+  parseAlignmentLines(buffer: Uint8Array): Float32Array | null {
+    if (!this.bridge || !this.bridge.isInitialized()) {
+      return null;
+    }
+    // SAB-safe: caller may pass a SharedArrayBuffer-backed view, which
+    // both Firefox and Chromium reject in raw `TextDecoder.decode`.
+    const content = safeUtf8Decode(buffer);
+    return this.bridge.parseAlignmentLines(content);
+  }
+
+  /**
    * Extract raw profile polygons from IfcExtrudedAreaSolid building elements.
    * Returns clean per-element profile outlines + 3D placement transforms.
    * Used by Drawing2DGenerator for artifact-free 2D projection.

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -2026,6 +2026,9 @@ export class Renderer {
             if (this.section2DOverlayRenderer?.hasAnnotationLines3D()) {
                 this.section2DOverlayRenderer.drawAnnotationLines3D(pass, viewProj);
             }
+            if (this.section2DOverlayRenderer?.hasAlignmentLines3D()) {
+                this.section2DOverlayRenderer.drawAlignmentLines3D(pass, viewProj);
+            }
             if (this.symbolicTextPipeline?.hasGeometry()) {
                 // Pass viewport pixel dimensions so the shader can scale glyphs
                 // to a constant on-screen size (BIMvision-style annotations)
@@ -2425,6 +2428,29 @@ export class Renderer {
     clearAnnotationLines3D(): void {
         if (this.section2DOverlayRenderer) {
             this.section2DOverlayRenderer.clearAnnotationLines3D();
+            this.requestRender();
+        }
+    }
+
+    /**
+     * Upload IfcAlignment centerline segments as a flat [x,y,z,x,y,z,...]
+     * line-list in world space. Rendered as thin lines (not a ribbon mesh)
+     * to match IfcGrid / IfcAnnotation. Pass an empty Float32Array to clear.
+     */
+    uploadAlignmentLines3D(vertices: Float32Array): void {
+        if (!this.section2DOverlayRenderer) return;
+        this.section2DOverlayRenderer.uploadAlignmentLines3D(vertices);
+        // Frame alignment-only files the same way annotation overlays are
+        // framed (see uploadAnnotationLines3D).
+        this.expandModelBoundsWithFlatVertices(vertices, 3);
+        if (this.modelBounds) this.camera.setSceneBounds(this.modelBounds);
+        this.requestRender();
+    }
+
+    /** Clear the alignment centerline overlay. */
+    clearAlignmentLines3D(): void {
+        if (this.section2DOverlayRenderer) {
+            this.section2DOverlayRenderer.clearAlignmentLines3D();
             this.requestRender();
         }
     }

--- a/packages/renderer/src/section-2d-overlay.ts
+++ b/packages/renderer/src/section-2d-overlay.ts
@@ -117,6 +117,13 @@ export class Section2DOverlayRenderer {
   private annotationLineVertexBuffer: GPUBuffer | null = null;
   private annotationLineVertexCount = 0;
 
+  // Standalone 3D alignment centerline overlay. Independent buffer from the
+  // annotation lines (separate visibility toggle) but reuses the same line
+  // pipeline. IfcAlignment renders as a thin line here — not a ribbon mesh —
+  // to match IfcGrid axes / IfcAnnotation curves.
+  private alignmentLineVertexBuffer: GPUBuffer | null = null;
+  private alignmentLineVertexCount = 0;
+
   constructor(device: GPUDevice, format: GPUTextureFormat, sampleCount: number = 4) {
     this.device = device;
     this.format = format;
@@ -696,6 +703,43 @@ export class Section2DOverlayRenderer {
   }
 
   /**
+   * Upload a flat Float32Array of 3D line-list vertices for the alignment
+   * centerline overlay. Same format/pipeline as the annotation lines, kept in
+   * a separate buffer so alignment visibility is independent.
+   * Pass an empty array (or omit) to clear.
+   */
+  uploadAlignmentLines3D(vertices: Float32Array): void {
+    this.init();
+
+    if (this.alignmentLineVertexBuffer) {
+      this.alignmentLineVertexBuffer.destroy();
+      this.alignmentLineVertexBuffer = null;
+    }
+    this.alignmentLineVertexCount = 0;
+
+    if (vertices.length < 6) return;
+
+    this.alignmentLineVertexBuffer = this.device.createBuffer({
+      size: vertices.byteLength,
+      usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+    });
+    this.device.queue.writeBuffer(this.alignmentLineVertexBuffer, 0, vertices);
+    this.alignmentLineVertexCount = vertices.length / 3;
+  }
+
+  clearAlignmentLines3D(): void {
+    if (this.alignmentLineVertexBuffer) {
+      this.alignmentLineVertexBuffer.destroy();
+      this.alignmentLineVertexBuffer = null;
+    }
+    this.alignmentLineVertexCount = 0;
+  }
+
+  hasAlignmentLines3D(): boolean {
+    return this.alignmentLineVertexCount > 0;
+  }
+
+  /**
    * Draw the standalone annotation line overlay. Uses the same line pipeline
    * as the section cut outlines (vertex format: 3 floats per vertex, line-list
    * topology) but reads from a separate vertex buffer. The pipeline's
@@ -719,6 +763,26 @@ export class Section2DOverlayRenderer {
     pass.setBindGroup(0, this.bindGroup);
     pass.setVertexBuffer(0, this.annotationLineVertexBuffer);
     pass.draw(this.annotationLineVertexCount);
+  }
+
+  /**
+   * Draw the alignment centerline overlay. Identical pipeline/uniform setup as
+   * `drawAnnotationLines3D`, reading from the separate alignment buffer.
+   */
+  drawAlignmentLines3D(pass: GPURenderPassEncoder, viewProj: Float32Array): void {
+    this.init();
+    if (!this.linePipeline || !this.uniformBuffer || !this.bindGroup) return;
+    if (!this.alignmentLineVertexBuffer || this.alignmentLineVertexCount === 0) return;
+
+    const uniforms = new Float32Array(20);
+    uniforms.set(viewProj, 0);
+    // planeOffset = 0 — vertices are already in world space.
+    this.device.queue.writeBuffer(this.uniformBuffer, 0, uniforms);
+
+    pass.setPipeline(this.linePipeline);
+    pass.setBindGroup(0, this.bindGroup);
+    pass.setVertexBuffer(0, this.alignmentLineVertexBuffer);
+    pass.draw(this.alignmentLineVertexCount);
   }
 
   /**

--- a/rust/wasm-bindings/src/api/alignment_lines.rs
+++ b/rust/wasm-bindings/src/api/alignment_lines.rs
@@ -1,0 +1,214 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! IfcAlignment centerline extraction for the 3D viewport.
+//!
+//! IfcAlignment carries its geometry in the `Axis` curve (an
+//! `IfcAlignmentCurve` or an `IfcPolyline`), not a `Representation`. Rather
+//! than render it as a triangulated ribbon mesh — which reads as a thin solid
+//! strip and not the thin LINE users expect (matching IfcGrid axes and
+//! IfcAnnotation curves) — we sample the alignment directrix into a flat
+//! line-list vertex buffer and feed it through the renderer's existing
+//! `uploadAnnotationLines3D` line pipeline.
+//!
+//! The output is `[x0,y0,z0, x1,y1,z1, …]` line-list pairs in the renderer's
+//! **Y-up, RTC-subtracted, metres** world space — the exact frame the mesh
+//! pipeline produces after its IFC Z-up → WebGL Y-up swap (see
+//! `MeshDataJs::new` in `zero_copy.rs`), so alignment lines land on the same
+//! ground as the terrain meshes.
+
+use super::IfcAPI;
+use ifc_lite_core::{
+    build_entity_index, extract_length_unit_scale, EntityDecoder, EntityScanner, IfcType,
+};
+use ifc_lite_geometry::{AlignmentCurve, GeometryRouter};
+use wasm_bindgen::prelude::*;
+
+/// Station spacing for centerline sampling, in file length units. Mirrors the
+/// (now-removed) ribbon processor: 1 unit ≈ 1 m for metre files, with a hard
+/// sample cap so sub-metre-unit files on long alignments fall back to a
+/// coarser, length-proportional step instead of emitting millions of points.
+const SAMPLE_STEP_FILE_UNITS: f64 = 1.0;
+const MAX_SAMPLES: usize = 5_000;
+
+#[wasm_bindgen]
+impl IfcAPI {
+    /// Parse the file and return every `IfcAlignment` directrix as a flat
+    /// `Float32Array` of 3D line-list vertices `[x0,y0,z0, x1,y1,z1, …]` in
+    /// the renderer's Y-up world space (RTC-subtracted, metres). Consecutive
+    /// samples form line segments. Feed straight to
+    /// `renderer.uploadAnnotationLines3D(...)`.
+    ///
+    /// Returns an empty array when the file has no alignments (or none with a
+    /// resolvable Axis curve), so the caller can clear the overlay cheaply.
+    #[wasm_bindgen(js_name = parseAlignmentLines)]
+    pub fn parse_alignment_lines(&self, content: String) -> js_sys::Float32Array {
+        let verts = extract_alignment_line_vertices(&content);
+        js_sys::Float32Array::from(&verts[..])
+    }
+}
+
+/// Pure-Rust core (unit-testable without wasm-bindgen).
+pub(crate) fn extract_alignment_line_vertices(content: &str) -> Vec<f32> {
+    let entity_index = build_entity_index(content);
+    let mut decoder = EntityDecoder::with_index(content, entity_index);
+
+    // Unit scale (file units → metres) resolved the same way the mesh
+    // pipeline does, so the alignment shares the model's scale.
+    let mut project_scanner = EntityScanner::new(content);
+    let mut unit_scale = 1.0_f64;
+    while let Some((id, type_name, _, _)) = project_scanner.next_entity() {
+        if type_name == "IFCPROJECT" {
+            if let Ok(s) = extract_length_unit_scale(&mut decoder, id) {
+                unit_scale = s;
+            }
+            break;
+        }
+    }
+
+    // RTC offset (metres) — `detect_rtc_offset_from_first_element` returns
+    // (0,0,0) for models within 10 km of the origin, so this is a no-op for
+    // local files and a true shift for georeferenced infrastructure.
+    let router = GeometryRouter::with_scale(unit_scale);
+    let rtc = router.detect_rtc_offset_from_first_element(content, &mut decoder);
+
+    let mut out: Vec<f32> = Vec::new();
+    let mut scanner = EntityScanner::new(content);
+    while let Some((id, type_name, start, end)) = scanner.next_entity() {
+        if type_name != "IFCALIGNMENT" {
+            continue;
+        }
+        let Ok(entity) = decoder.decode_at_with_id(id, start, end) else {
+            continue;
+        };
+        let Some(axis) = locate_axis_curve(&entity, &mut decoder) else {
+            continue;
+        };
+        let Ok(Some(alignment)) = AlignmentCurve::parse(&axis, &mut decoder) else {
+            continue;
+        };
+        append_alignment_segments(&alignment, unit_scale, rtc, &mut out);
+    }
+    out
+}
+
+/// Sample one alignment's centerline and append its line-list segments to
+/// `out`, in renderer Y-up / RTC-subtracted / metres space.
+fn append_alignment_segments(
+    alignment: &AlignmentCurve,
+    unit_scale: f64,
+    rtc: (f64, f64, f64),
+    out: &mut Vec<f32>,
+) {
+    let length = alignment.horizontal_length();
+    if !(length.is_finite() && length > 0.0) {
+        return;
+    }
+
+    let raw_count = ((length / SAMPLE_STEP_FILE_UNITS).ceil() as usize).max(1);
+    let (step, count) = if raw_count > MAX_SAMPLES {
+        (length / MAX_SAMPLES as f64, MAX_SAMPLES + 1)
+    } else {
+        (SAMPLE_STEP_FILE_UNITS, raw_count + 1)
+    };
+
+    // Collect sampled vertices in renderer space.
+    let mut pts: Vec<[f32; 3]> = Vec::with_capacity(count);
+    for i in 0..count {
+        let station = (i as f64 * step).min(length);
+        let o = alignment.evaluate(station).origin;
+        // file units → metres
+        let mx = o.x * unit_scale - rtc.0;
+        let my = o.y * unit_scale - rtc.1;
+        let mz = o.z * unit_scale - rtc.2;
+        // IFC Z-up → WebGL Y-up: (x, z, -y). Matches MeshDataJs::new so the
+        // line lands on the same ground as the terrain meshes.
+        pts.push([mx as f32, mz as f32, -my as f32]);
+    }
+
+    // Emit as a line-list: each adjacent pair is one segment.
+    for w in pts.windows(2) {
+        out.extend_from_slice(&w[0]);
+        out.extend_from_slice(&w[1]);
+    }
+}
+
+/// Resolve an `IfcAlignment`'s directrix curve. IFC4X1 puts `Axis` at
+/// attribute 7; some publishers reuse `Representation` (6) or hang it at 8.
+/// Accept the first ref that resolves to an `IfcAlignmentCurve` or
+/// `IfcPolyline` (the two `AlignmentCurve::parse` understands).
+fn locate_axis_curve(
+    entity: &ifc_lite_core::DecodedEntity,
+    decoder: &mut EntityDecoder,
+) -> Option<ifc_lite_core::DecodedEntity> {
+    let alignment_curve = IfcType::from_str("IFCALIGNMENTCURVE");
+    for idx in [7usize, 8, 6] {
+        let Some(attr) = entity.get(idx) else { continue };
+        if attr.is_null() {
+            continue;
+        }
+        if let Ok(Some(resolved)) = decoder.resolve_ref(attr) {
+            if resolved.ifc_type == alignment_curve || resolved.ifc_type == IfcType::IfcPolyline {
+                return Some(resolved);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Minimal IFC4X1 alignment: IfcAlignment whose Axis (attr 7) is a
+    // 3-point IfcPolyline directrix (0,0,0)->(10,0,0)->(10,10,0), metres.
+    const CONTENT: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('','',(''),(''),'','','');
+FILE_SCHEMA(('IFC4X1'));
+ENDSEC;
+DATA;
+#1=IFCCARTESIANPOINT((0.,0.,0.));
+#2=IFCCARTESIANPOINT((10.,0.,0.));
+#3=IFCCARTESIANPOINT((10.,10.,0.));
+#4=IFCPOLYLINE((#1,#2,#3));
+#10=IFCALIGNMENT('0aBcDeFgHiJkLmNoPqRsT0',$,'Test Alignment',$,$,$,$,#4,$);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+    #[test]
+    fn emits_line_list_for_polyline_alignment() {
+        let verts = extract_alignment_line_vertices(CONTENT);
+        assert!(!verts.is_empty(), "alignment must emit centerline vertices");
+        // Flat [x,y,z] triples, even count of vertices (line-list pairs).
+        assert_eq!(verts.len() % 3, 0, "vertices must be xyz triples");
+        assert_eq!((verts.len() / 3) % 2, 0, "line-list = even vertex count");
+
+        // First sample is the directrix start (0,0,0) → renderer (0,0,-0).
+        assert!(verts[0].abs() < 1e-4, "start x≈0, got {}", verts[0]);
+        assert!(verts[1].abs() < 1e-4, "start y(elev)≈0, got {}", verts[1]);
+        assert!(verts[2].abs() < 1e-4, "start z≈0, got {}", verts[2]);
+
+        // The 20 m polyline lies in the plan (z_ifc = 0) so every renderer-Y
+        // (elevation) must stay 0, and the path must span ~10 m in renderer X
+        // and ~10 m in renderer Z (plan Y, negated).
+        let mut max_x = f32::MIN;
+        let mut max_abs_z = 0.0_f32;
+        for v in verts.chunks_exact(3) {
+            assert!(v[1].abs() < 1e-3, "planar alignment elevation must be ~0");
+            max_x = max_x.max(v[0]);
+            max_abs_z = max_abs_z.max(v[2].abs());
+        }
+        assert!((max_x - 10.0).abs() < 0.5, "max renderer-x ≈10, got {max_x}");
+        assert!((max_abs_z - 10.0).abs() < 0.5, "max |renderer-z| ≈10, got {max_abs_z}");
+    }
+
+    #[test]
+    fn empty_for_no_alignment() {
+        let none = "ISO-10303-21;\nHEADER;\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\nENDSEC;\nEND-ISO-10303-21;\n";
+        assert!(extract_alignment_line_vertices(none).is_empty());
+    }
+}

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -6,6 +6,7 @@
 //!
 //! Modern async/await API for parsing IFC files.
 
+mod alignment_lines;
 mod extract_profiles;
 mod gpu_meshes;
 mod parsing;


### PR DESCRIPTION
## What

Render `IfcAlignment` as a thin **centerline line**, exactly like IfcGrid axes and IfcAnnotation curves — instead of the triangulated **ribbon** strip this PR originally shipped.

> This replaces the earlier ribbon approach (the batch-mesher route + RTC ribbon fix have been reverted; the branch is now a clean lines-only diff vs `main`).

## Why

`IfcAlignment` carries its geometry in the `Axis` curve (`IfcAlignmentCurve` / `IfcPolyline`), not a `Representation`, so it never meshes in the streaming batch path. Rendering it as a swept ribbon read as a thin solid band rather than the centerline users expect.

## How

The directrix is sampled into a flat Y-up line-list and drawn through the renderer's existing line pipeline:

- **`@ifc-lite/wasm`** — new `IfcAPI.parseAlignmentLines(content)` → `Float32Array` of `[x,y,z,…]` line-list vertices in renderer world space (Y-up, RTC-subtracted, metres — the same frame the mesh pipeline produces, so the line lands on the same ground as terrain).
- **`@ifc-lite/geometry`** — `GeometryProcessor.parseAlignmentLines` wrapper.
- **`@ifc-lite/renderer`** — `uploadAlignmentLines3D` / `clearAlignmentLines3D` (separate vertex buffer, reuses the line pipeline).
- **viewer** — `useAlignmentLines3D` hook, always-on (no toggle); `Viewport` uploads/clears alongside the annotation overlay.

The batch mesher no longer special-cases `IfcAlignment` into the ribbon processor, so alignment is **lines-only** — never both.

## Testing

- `alignment_lines` Rust unit tests (planar polyline → even-count line-list mapped to renderer origin/extent; empty file → empty array).
- `cargo test` (wasm `alignment_lines`, geometry) green; `cargo check -p ifc-lite-wasm` clean.
- WASM bundle rebuilt; viewer `tsc --noEmit` passes.

## Changeset

`@ifc-lite/wasm` + `@ifc-lite/geometry` + `@ifc-lite/renderer` (minor). The shared `ifc-lite-geometry` crate is untouched, so `@ifc-lite/server-bin` is no longer bumped.