### PR TITLE
ci(release): publish v<server-bin-version> release so the native binary download resolves

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,6 +192,62 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # @ifc-lite/server-bin downloads its native archive from a GitHub
+      # release tagged `v<its-own-version>` (packages/server-bin/src/binary.ts).
+      # The root `v<version>` release above is keyed to the *highest* workspace
+      # package version, which is usually NOT server-bin's — so without a
+      # matching tag `npx @ifc-lite/server-bin` 404s on download, and native
+      # binaries never carry geometry fixes that bump only server-bin/wasm.
+      # Create a release at server-bin's own version: that `release: published`
+      # event triggers server-binaries.yml to build + upload the per-platform
+      # archives to this tag, so the download URL resolves with fresh binaries.
+      - name: Create server-bin binary release
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          SB_VERSION=$(node -p "require('./packages/server-bin/package.json').version")
+          TAG="v${SB_VERSION}"
+          # Skip when the tag already exists (server-bin unchanged this cycle,
+          # or it happens to equal the root release already created above).
+          if gh release view "$TAG" > /dev/null 2>&1; then
+            echo "Release $TAG already exists, skipping (server binaries already published)"
+          else
+            git tag "$TAG" || true
+            git push origin "$TAG" || true
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --notes "Native server binary for @ifc-lite/server-bin v${SB_VERSION}. See CHANGELOG.md."
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # @ifc-lite/server-bin downloads its native archive from a GitHub
+      # release tagged `v<its-own-version>` (packages/server-bin/src/binary.ts).
+      # The root `v<version>` release above is keyed to the *highest* workspace
+      # package version, which is usually NOT server-bin's — so without a
+      # matching tag `npx @ifc-lite/server-bin` 404s on download, and native
+      # binaries never carry geometry fixes that bump only server-bin/wasm.
+      # Create a release at server-bin's own version: that `release: published`
+      # event triggers server-binaries.yml to build + upload the per-platform
+      # archives to this tag, so the download URL resolves with fresh binaries.
+      - name: Create server-bin binary release
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          SB_VERSION=$(node -p "require('./packages/server-bin/package.json').version")
+          TAG="v${SB_VERSION}"
+          # Skip when the tag already exists (server-bin unchanged this cycle,
+          # or it happens to equal the root release already created above).
+          if gh release view "$TAG" > /dev/null 2>&1; then
+            echo "Release $TAG already exists, skipping (server binaries already published)"
+          else
+            git tag "$TAG" || true
+            git push origin "$TAG" || true
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --notes "Native server binary for @ifc-lite/server-bin v${SB_VERSION}. See CHANGELOG.md."
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   # Verify every published package is actually reachable on npm.
   # Catches packages accidentally skipped during release before users hit them.
   verify-npm-publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,35 +218,13 @@ jobs:
               --notes "Native server binary for @ifc-lite/server-bin v${SB_VERSION}. See CHANGELOG.md."
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # @ifc-lite/server-bin downloads its native archive from a GitHub
-      # release tagged `v<its-own-version>` (packages/server-bin/src/binary.ts).
-      # The root `v<version>` release above is keyed to the *highest* workspace
-      # package version, which is usually NOT server-bin's — so without a
-      # matching tag `npx @ifc-lite/server-bin` 404s on download, and native
-      # binaries never carry geometry fixes that bump only server-bin/wasm.
-      # Create a release at server-bin's own version: that `release: published`
-      # event triggers server-binaries.yml to build + upload the per-platform
-      # archives to this tag, so the download URL resolves with fresh binaries.
-      - name: Create server-bin binary release
-        if: steps.changesets.outputs.published == 'true'
-        run: |
-          SB_VERSION=$(node -p "require('./packages/server-bin/package.json').version")
-          TAG="v${SB_VERSION}"
-          # Skip when the tag already exists (server-bin unchanged this cycle,
-          # or it happens to equal the root release already created above).
-          if gh release view "$TAG" > /dev/null 2>&1; then
-            echo "Release $TAG already exists, skipping (server binaries already published)"
-          else
-            git tag "$TAG" || true
-            git push origin "$TAG" || true
-            gh release create "$TAG" \
-              --title "$TAG" \
-              --notes "Native server binary for @ifc-lite/server-bin v${SB_VERSION}. See CHANGELOG.md."
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use the fine-grained PAT, NOT GITHUB_TOKEN: a release created with
+          # GITHUB_TOKEN does NOT emit a `release: published` event that starts new
+          # workflow runs (GitHub recursion guard). server-binaries.yml uploads
+          # binaries only on `release: published`, so a GITHUB_TOKEN-created release
+          # would sit empty and downloads would still 404. The PAT is a real
+          # identity, so the event fires and binaries build + upload to this tag.
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
 
   # Verify every published package is actually reachable on npm.
   # Catches packages accidentally skipped during release before users hit them.


### PR DESCRIPTION
Fixes the Codex P1 on the version-packages PR (#888): bumping `@ifc-lite/server-bin` (e.g. → 1.15.0) would publish a **broken** package because it downloads its native binary from `releases/download/v<its-own-version>/…` (`packages/server-bin/src/binary.ts`), but the release job only ever creates **`v<root>`** (root = highest workspace package version via `sync-versions.js`, currently `3.0.0`). No `v1.15.0` assets → `npx @ifc-lite/server-bin` 404s. Same reason native binaries never pick up geometry fixes that bump only `server-bin`/`wasm` (#886 grid placement, #889 alignment).

## Fix
A new `release.yml` step (after "Create GitHub Release") creates a release at **server-bin's own version** when it publishes:
- `SB_VERSION` read from `packages/server-bin/package.json`; tag `v$SB_VERSION`.
- That `release: published` event triggers `server-binaries.yml` (`release-server-binaries`, which fires on `v*` releases) to build + upload the per-platform archives to that tag.
- → `binary.ts`'s download URL resolves, with **freshly-built** binaries carrying the latest fixes.
- Guarded by a `gh release view` exists-check, so unchanged cycles (and the case where root == server-bin) are no-ops.

No code/package changes → no changeset.

## Verification
- `python3 -c "import yaml; yaml.safe_load(...)"` → **YAML OK**.
- Pure insertion: file went 210 → 238 lines (+28, no deletions; the `git diff --stat` 28/28 is CRLF rendering noise — this workflow file uses CRLF).
- Cannot exercise the actual release in CI from here; the step mirrors the existing "Create GitHub Release" step's tag/create pattern and is additive + guarded, so it can't break the existing publish flow.

## Follow-up / heads-up
- **#888 already merged**, so `@ifc-lite/server-bin@1.15.0` may already be published to npm **without** a `v1.15.0` release → currently broken for that exact version. This PR fixes it **going forward**; to remediate 1.15.0 specifically, either run `server-binaries.yml` via `workflow_dispatch` against a manually-created `v1.15.0`, or let the next server-bin bump (with this merged) create a fresh `v<next>` that `@latest` resolves to.
- Reviewer note: the `git push origin "$TAG"` mirrors the existing release step; confirm the `RELEASE_PAT`/checkout credentials in that job allow tag pushes (the existing step relies on the same).
