### PR TITLE
feat(clash): grouping + sensible BCF export + lifecycle + IFCx adapter (Phases 2/5/6)

### DIFF
--- a/packages/clash/package.json
+++ b/packages/clash/package.json
@@ -14,6 +14,14 @@
     "./step": {
       "import": "./dist/adapters/step.js",
       "types": "./dist/adapters/step.d.ts"
+    },
+    "./ifcx": {
+      "import": "./dist/adapters/ifcx.js",
+      "types": "./dist/adapters/ifcx.d.ts"
+    },
+    "./bcf": {
+      "import": "./dist/bcf-bridge.js",
+      "types": "./dist/bcf-bridge.d.ts"
     }
   },
   "scripts": {
@@ -25,7 +33,9 @@
     "@ifc-lite/spatial": "workspace:^",
     "@ifc-lite/geometry": "workspace:^",
     "@ifc-lite/parser": "workspace:^",
-    "@ifc-lite/query": "workspace:^"
+    "@ifc-lite/query": "workspace:^",
+    "@ifc-lite/bcf": "workspace:^",
+    "@ifc-lite/ifcx": "workspace:^"
   },
   "devDependencies": {
     "typescript": "^6.0.3",

--- a/packages/clash/src/adapters/ifcx.test.ts
+++ b/packages/clash/src/adapters/ifcx.test.ts
@@ -1,0 +1,196 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+import { elementsFromIfcx } from './ifcx.js';
+import { createClashEngine } from '../engine.js';
+import type { ClashRule } from '../types.js';
+
+/**
+ * Build a closed axis-aligned cube as a USD-style mesh (Z-up `points` +
+ * triangle `faceVertexIndices`), the genuine IFCX geometry encoding consumed
+ * by `@ifc-lite/ifcx`'s geometry extractor.
+ */
+function cubeMesh(ox: number, oy: number, oz: number, size: number) {
+  const s = size;
+  const points: number[][] = [
+    [ox, oy, oz],
+    [ox + s, oy, oz],
+    [ox + s, oy + s, oz],
+    [ox, oy + s, oz],
+    [ox, oy, oz + s],
+    [ox + s, oy, oz + s],
+    [ox + s, oy + s, oz + s],
+    [ox, oy + s, oz + s],
+  ];
+  // 12 triangles (2 per face), wound for a closed solid.
+  const faceVertexIndices = [
+    0, 2, 1, 0, 3, 2, // bottom (-z)
+    4, 5, 6, 4, 6, 7, // top (+z)
+    0, 1, 5, 0, 5, 4, // -y
+    1, 2, 6, 1, 6, 5, // +x
+    2, 3, 7, 2, 7, 6, // +y
+    3, 0, 4, 3, 4, 7, // -x
+  ];
+  return { points, faceVertexIndices };
+}
+
+const SCHEMA_VALUE = { dataType: 'Object' as const };
+
+/**
+ * A minimal but genuine IFCX (IFC5 JSON) file: a project root that contains
+ * two overlapping walls, each with a `Body` child carrying USD mesh geometry.
+ * This is the real wire format `parseIfcx` consumes (header + USD `data`
+ * nodes with `bsi::ifc::class` + `usd::usdgeom::mesh` + `children`), so the
+ * test exercises the real composition / entity / geometry extraction path.
+ */
+function buildIfcxFile() {
+  const ifcClass = (code: string) => ({
+    code,
+    uri: `https://identifier.buildingsmart.org/uri/buildingsmart/ifc/5/class/${code}`,
+  });
+
+  return {
+    header: {
+      id: 'clash-ifcx-fixture',
+      ifcxVersion: 'ifcx_alpha',
+      dataVersion: '1.0.0',
+      author: 'ifc-lite clash adapter test',
+      timestamp: '2025-01-01T00:00:00Z',
+    },
+    imports: [],
+    schemas: {
+      'bsi::ifc::class': { value: SCHEMA_VALUE },
+      'bsi::ifc::name': { value: { dataType: 'String' as const } },
+      'usd::usdgeom::mesh': { value: SCHEMA_VALUE },
+    },
+    data: [
+      {
+        path: 'Project',
+        attributes: { 'bsi::ifc::class': ifcClass('IfcProject') },
+        children: { WallA: 'Project/WallA', WallB: 'Project/WallB' },
+      },
+      {
+        path: 'Project/WallA',
+        attributes: {
+          'bsi::ifc::class': ifcClass('IfcWall'),
+          'bsi::ifc::name': 'Wall A',
+        },
+        children: { Body: 'Project/WallA/Body' },
+      },
+      {
+        path: 'Project/WallA/Body',
+        attributes: { 'usd::usdgeom::mesh': cubeMesh(0, 0, 0, 1) },
+      },
+      {
+        path: 'Project/WallB',
+        attributes: {
+          'bsi::ifc::class': ifcClass('IfcWall'),
+          'bsi::ifc::name': 'Wall B',
+        },
+        children: { Body: 'Project/WallB/Body' },
+      },
+      {
+        path: 'Project/WallB/Body',
+        // Offset by 0.5 so WallB genuinely interpenetrates WallA.
+        attributes: { 'usd::usdgeom::mesh': cubeMesh(0.5, 0, 0, 1) },
+      },
+    ],
+  };
+}
+
+function ifcxBuffer(): ArrayBuffer {
+  const json = JSON.stringify(buildIfcxFile());
+  return new TextEncoder().encode(json).buffer as ArrayBuffer;
+}
+
+function isDegenerate(bounds: { min: number[]; max: number[] }): boolean {
+  return (
+    bounds.max[0] <= bounds.min[0] &&
+    bounds.max[1] <= bounds.min[1] &&
+    bounds.max[2] <= bounds.min[2]
+  );
+}
+
+describe('elementsFromIfcx', () => {
+  it('maps IFCX prims into ClashElements with prim-path keys, tags and bounds', async () => {
+    const { elements } = await elementsFromIfcx({
+      buffer: ifcxBuffer(),
+      modelId: 'ifcx-model',
+    });
+
+    expect(elements).toHaveLength(2);
+
+    const keys = elements.map((e) => e.key).sort();
+    expect(keys).toEqual(['Project/WallA', 'Project/WallB']);
+
+    for (const el of elements) {
+      // key is the durable USD prim path
+      expect(el.key.startsWith('Project/Wall')).toBe(true);
+      // tag carries the IFC class from bsi::ifc::class
+      expect(el.tag).toBe('IfcWall');
+      expect(el.model).toBe('ifcx-model');
+      // ref is a deterministic non-negative integer derived from the path
+      expect(el.ref).toBeGreaterThanOrEqual(0);
+      expect(Number.isInteger(el.ref)).toBe(true);
+      // non-degenerate, world-space bounds from real tessellated geometry
+      expect(isDegenerate(el.bounds)).toBe(false);
+      expect(el.positions.length).toBeGreaterThan(0);
+      expect(el.indices.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('derives a deterministic ref purely from the prim path', async () => {
+    const a = await elementsFromIfcx({ buffer: ifcxBuffer(), modelId: 'm' });
+    const b = await elementsFromIfcx({ buffer: ifcxBuffer(), modelId: 'm' });
+    const refsA = a.elements.map((e) => `${e.key}=${e.ref}`).sort();
+    const refsB = b.elements.map((e) => `${e.key}=${e.ref}`).sort();
+    expect(refsA).toEqual(refsB);
+    // distinct paths => distinct refs in this fixture
+    const refs = new Set(a.elements.map((e) => e.ref));
+    expect(refs.size).toBe(a.elements.length);
+  });
+
+  it('runs the SAME clash core end-to-end on IFCX-sourced elements', async () => {
+    const { elements, exclusions } = await elementsFromIfcx({
+      buffer: ifcxBuffer(),
+      modelId: 'ifcx-model',
+    });
+
+    // Permissive self-clash: every IfcWall vs every other IfcWall.
+    const rule: ClashRule = {
+      id: 'wall-vs-wall',
+      name: 'Wall self-clash',
+      a: 'IfcWall',
+      mode: 'hard',
+    };
+
+    const engine = createClashEngine({ backend: 'ts' });
+    // First prove the geometry overlaps (no exclusions applied).
+    const open = await engine.run(elements, [rule], { excludeVoidsAndHosts: false });
+    expect(open.clashes.length).toBe(1);
+    const clash = open.clashes[0];
+    expect(clash.status).toBe('hard');
+    expect(clash.distance).toBeLessThan(0); // interpenetration
+    expect([clash.a.tag, clash.b.tag]).toEqual(['IfcWall', 'IfcWall']);
+    expect(open.summary.total).toBe(1);
+
+    // The two sibling walls are NOT in a parent/child composition relation,
+    // so the adapter exclusions must not suppress this real clash.
+    const withExclusions = await engine.run(elements, [rule], { exclusions });
+    expect(withExclusions.clashes.length).toBe(1);
+  });
+
+  it('excludes composition parent/child pairs but keeps the set otherwise', async () => {
+    const { elements, exclusions } = await elementsFromIfcx({
+      buffer: ifcxBuffer(),
+      modelId: 'ifcx-model',
+    });
+    // Only the two leaf walls carry geometry; the IfcProject parent has no mesh
+    // and thus no element, so no parent/child pair survives among meshed
+    // elements. The sibling walls are correctly NOT excluded.
+    expect(exclusions.size).toBe(0);
+    expect(elements.every((e) => e.tag === 'IfcWall')).toBe(true);
+  });
+});

--- a/packages/clash/src/adapters/ifcx.ts
+++ b/packages/clash/src/adapters/ifcx.ts
@@ -1,0 +1,192 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * IFCX / USD source adapter: turn a parsed IFCX (IFC5) file into
+ * representation-agnostic `ClashElement`s, proving the clash core is
+ * representation-agnostic (it runs equally on STEP and on USD/IFCX).
+ *
+ * Unlike the STEP adapter, IFCX geometry is pre-tessellated: `parseIfcx`
+ * already returns world-space, Y-up triangle `meshes` (see ifcx's
+ * `geometry-extractor`), so this adapter does no geometry math of its own.
+ *
+ * Identity mapping:
+ * - `key`   = the USD prim PATH (the durable identity in IFCX; the parser
+ *             stores it as the entity GlobalId and exposes it via `idToPath`).
+ * - `ref`   = a deterministic, non-negative 31-bit FNV-1a hash of the prim
+ *             path. We hash the PATH (not the synthetic auto-incrementing
+ *             expressId) so the runtime ref is stable across re-parses and
+ *             across federated layer reorderings, which is the whole point of
+ *             a durable id. Collisions are astronomically unlikely for the
+ *             path counts in a model and never affect correctness (clash
+ *             identity is derived from `key`, not `ref`).
+ * - `model` = `options.modelId`.
+ * - `tag`   = the IFC class code when present (USD `bsi::ifc::class`),
+ *             otherwise `'IfcProduct'`.
+ *
+ * Exclusions are derived purely from the file's own composition hierarchy
+ * (parent/child `ContainsElements` + `Aggregates` edges that `parseIfcx`
+ * builds from the USD `children` structure). This is the IFCX analogue of the
+ * STEP void/host/assembly exclusions; it fabricates no relationships.
+ *
+ * This module is reached via the `@ifc-lite/clash/ifcx` subpath so the core
+ * stays representation- and parser-neutral.
+ */
+
+import { parseIfcx, type MeshData } from '@ifc-lite/ifcx';
+import { makeExclusionSet } from '../exclude.js';
+import { fromPositions } from '../math/aabb.js';
+import type { ClashElement, ExclusionSet } from '../types.js';
+
+/**
+ * Minimal structural view of `@ifc-lite/data`'s `RelationshipGraph`. We type it
+ * locally (rather than importing `@ifc-lite/data`, which is not a direct
+ * dependency of this package) and only touch the two directional halves. The
+ * IFCX parser emits exclusively parent->child composition edges
+ * (`ContainsElements` + `Aggregates`), so reading every edge — with no type
+ * filter — is precisely the set of composition parent/child links.
+ */
+interface CompositionEdges {
+  getTargets(entityId: number): number[];
+}
+interface CompositionGraph {
+  forward: CompositionEdges;
+  inverse: CompositionEdges;
+}
+
+export interface IfcxAdapterOptions {
+  /** Raw IFCX (IFC5 JSON) bytes. */
+  buffer: ArrayBuffer;
+  /** Model/file id (federation). */
+  modelId: string;
+  /** Precompute parent/child composition exclusions. Default true. */
+  buildExclusions?: boolean;
+}
+
+export interface IfcxAdapterResult {
+  elements: ClashElement[];
+  exclusions: ExclusionSet;
+}
+
+/**
+ * Parse an IFCX buffer and project its pre-tessellated meshes into
+ * `ClashElement`s. Async because `parseIfcx` is async.
+ */
+export async function elementsFromIfcx(options: IfcxAdapterOptions): Promise<IfcxAdapterResult> {
+  const { buffer, modelId, buildExclusions = true } = options;
+
+  const parsed = await parseIfcx(buffer);
+  const { meshes, idToPath, entities, relationships } = parsed;
+
+  const elements: ClashElement[] = [];
+  const byExpressId = new Map<number, ClashElement>();
+
+  for (const mesh of meshes) {
+    if (!mesh.positions || mesh.positions.length === 0) continue;
+    if (!mesh.indices || mesh.indices.length === 0) continue;
+
+    const expressId = mesh.expressId;
+    // The prim path is the durable USD identity; skip meshes we cannot key.
+    const key = idToPath.get(expressId);
+    if (!key) continue;
+
+    const element: ClashElement = {
+      key,
+      ref: refFromPath(key),
+      model: modelId,
+      tag: resolveTag(mesh, entities, expressId),
+      name: resolveName(entities, expressId),
+      bounds: fromPositions(mesh.positions),
+      positions: mesh.positions,
+      indices: mesh.indices,
+    };
+
+    elements.push(element);
+    byExpressId.set(expressId, element);
+  }
+
+  const exclusions = buildExclusions
+    ? buildIfcxExclusions(relationships, byExpressId)
+    : makeExclusionSet();
+
+  return { elements, exclusions };
+}
+
+/**
+ * Pair-exclusions from the IFCX composition hierarchy. For every meshed
+ * entity we exclude its composition parents and children (the
+ * `ContainsElements` spatial-containment and `Aggregates` decomposition edges
+ * the parser derives from USD `children`). These are exactly the
+ * host/assembly relationships the STEP adapter excludes, expressed in IFCX
+ * terms; no relationship is invented.
+ */
+export function buildIfcxExclusions(
+  relationships: CompositionGraph,
+  byExpressId: Map<number, ClashElement>,
+): ExclusionSet {
+  const pairs: Array<[string, string]> = [];
+
+  for (const [expressId, element] of byExpressId) {
+    // Children (this entity contains/aggregates them) and parents (inverse).
+    // All IFCX edges are composition edges, so no type filter is needed.
+    const children = relationships.forward.getTargets(expressId);
+    const parents = relationships.inverse.getTargets(expressId);
+    for (const relatedId of children) {
+      const related = byExpressId.get(relatedId);
+      if (related) pairs.push([element.key, related.key]);
+    }
+    for (const relatedId of parents) {
+      const related = byExpressId.get(relatedId);
+      if (related) pairs.push([element.key, related.key]);
+    }
+  }
+
+  return makeExclusionSet(pairs);
+}
+
+/**
+ * IFC class for the element's `tag`. The IFCX geometry extractor stores the
+ * `bsi::ifc::class.code` on `mesh.ifcType`; we fall back to the entity table's
+ * resolved type name, then to a neutral `IfcProduct`.
+ */
+function resolveTag(
+  mesh: MeshData,
+  entities: { getTypeName(id: number): string },
+  expressId: number,
+): string {
+  if (mesh.ifcType && mesh.ifcType.length > 0) return mesh.ifcType;
+  const typeName = entities.getTypeName(expressId);
+  if (typeName && typeName.length > 0 && typeName !== 'Unknown') return typeName;
+  return 'IfcProduct';
+}
+
+function resolveName(
+  entities: { getName(id: number): string },
+  expressId: number,
+): string | undefined {
+  const name = entities.getName(expressId);
+  return name && name.length > 0 ? name : undefined;
+}
+
+/**
+ * Deterministic non-negative 31-bit ref derived purely from the prim path via
+ * FNV-1a over the UTF-16 code units. No clock, no randomness: the same path
+ * always yields the same ref.
+ */
+function refFromPath(path: string): number {
+  let hash = 0x811c9dc5; // FNV-1a 32-bit offset basis
+  for (let i = 0; i < path.length; i++) {
+    hash ^= path.charCodeAt(i) & 0xff;
+    // 32-bit FNV prime multiply via shifts, kept in unsigned 32-bit space.
+    hash = (hash + ((hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24))) >>> 0;
+    // Mix the high byte of multi-byte code units so non-ASCII paths differ.
+    const high = (path.charCodeAt(i) >> 8) & 0xff;
+    if (high !== 0) {
+      hash ^= high;
+      hash = (hash + ((hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24))) >>> 0;
+    }
+  }
+  // Mask to 31 bits so the result is always a non-negative safe integer.
+  return hash & 0x7fffffff;
+}

--- a/packages/clash/src/bcf-bridge.test.ts
+++ b/packages/clash/src/bcf-bridge.test.ts
@@ -1,0 +1,316 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { readBCF } from '@ifc-lite/bcf';
+import type {
+  AABB,
+  Clash,
+  ClashElementRef,
+  ClashGroup,
+  ClashResult,
+  ClashSeverity,
+  ClashStatus,
+} from './types.js';
+import { createBCFFromClashResult, mapBcfToClashes } from './bcf-bridge.js';
+import { uuidFromSeed } from './deterministic-uuid.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+function ref(key: string, tag: string, name?: string): ClashElementRef {
+  return { key, ref: key.length, model: 'm', tag, name };
+}
+
+function bounds(min: [number, number, number], max: [number, number, number]): AABB {
+  return { min, max };
+}
+
+function clash(
+  id: string,
+  a: ClashElementRef,
+  b: ClashElementRef,
+  status: ClashStatus,
+  severity: ClashSeverity,
+  rule: string,
+): Clash {
+  return {
+    id,
+    a,
+    b,
+    rule,
+    status,
+    distance: status === 'hard' ? -0.01 : 0.02,
+    point: [1, 2, 3],
+    bounds: bounds([0, 0, 0], [1, 1, 1]),
+    severity,
+  };
+}
+
+function makeGroup(
+  id: string,
+  severity: ClashSeverity,
+  members: Clash[],
+  discipline?: string,
+  storey?: string,
+): ClashGroup {
+  return {
+    id,
+    title: `Group ${id}`,
+    members,
+    bounds: bounds([0, 0, 0], [4, 3, 2]),
+    representativePoint: [2, 1.5, 1],
+    severity,
+    discipline,
+    storey,
+  };
+}
+
+function makeFixture(): { result: ClashResult; groups: ClashGroup[] } {
+  const c1 = clash(
+    'clash-1',
+    ref('GUID_A1', 'IfcPipeSegment', 'Pipe-1'),
+    ref('GUID_B1', 'IfcBeam', 'Beam-1'),
+    'hard',
+    'critical',
+    'MEPxSTR',
+  );
+  const c2 = clash(
+    'clash-2',
+    ref('GUID_A1', 'IfcPipeSegment', 'Pipe-1'),
+    ref('GUID_B2', 'IfcColumn'),
+    'hard',
+    'critical',
+    'MEPxSTR',
+  );
+  const c3 = clash(
+    'clash-3',
+    ref('GUID_C1', 'IfcDuctSegment'),
+    ref('GUID_D1', 'IfcWall'),
+    'clearance',
+    'major',
+    'HVACxARCH',
+  );
+  const c4 = clash(
+    'clash-4',
+    ref('GUID_E1', 'IfcCableSegment'),
+    ref('GUID_F1', 'IfcPipeSegment'),
+    'clearance',
+    'minor',
+    'ELECxMEP',
+  );
+
+  const g1 = makeGroup('group-critical', 'critical', [c1, c2], 'MEP', 'Level 1');
+  const g2 = makeGroup('group-major', 'major', [c3], 'HVAC', 'Level 2');
+  const g3 = makeGroup('group-minor', 'minor', [c4], 'ELEC');
+
+  const clashes = [c1, c2, c3, c4];
+  const result: ClashResult = {
+    clashes,
+    summary: {
+      total: clashes.length,
+      byRule: { MEPxSTR: 2, HVACxARCH: 1, ELECxMEP: 1 },
+      byTypePair: {},
+      bySeverity: { critical: 2, major: 1, minor: 1, info: 0 },
+    },
+    rulesRun: [],
+    settings: { tolerance: 0.002, excludeVoidsAndHosts: true },
+  };
+
+  return { result, groups: [g1, g2, g3] };
+}
+
+describe('createBCFFromClashResult', () => {
+  it('creates one topic per group with deterministic guids', async () => {
+    const { result, groups } = makeFixture();
+    const project = await createBCFFromClashResult(result, groups, { author: 'tester' });
+
+    expect(project.version).toBe('2.1');
+    expect(project.topics.size).toBe(groups.length);
+
+    for (const group of groups) {
+      const expectedGuid = uuidFromSeed(group.id);
+      expect(project.topics.has(expectedGuid)).toBe(true);
+      const topic = project.topics.get(expectedGuid);
+      expect(topic).toBeDefined();
+      expect(topic?.guid).toBe(expectedGuid);
+      expect(topic?.guid).toMatch(UUID_RE);
+    }
+  });
+
+  it('sorts critical groups first and maps severity to priority', async () => {
+    const { result, groups } = makeFixture();
+    const project = await createBCFFromClashResult(result, groups, { author: 'tester' });
+
+    const critical = project.topics.get(uuidFromSeed('group-critical'));
+    const major = project.topics.get(uuidFromSeed('group-major'));
+    const minor = project.topics.get(uuidFromSeed('group-minor'));
+
+    expect(critical?.priority).toBe('High');
+    expect(major?.priority).toBe('Normal');
+    expect(minor?.priority).toBe('Low');
+
+    // Discipline + 'Clash' labels.
+    expect(critical?.labels).toEqual(['MEP', 'Clash']);
+    // Minor group carries its discipline plus 'Clash'.
+    expect(minor?.labels).toEqual(['ELEC', 'Clash']);
+  });
+
+  it('omits a missing discipline from the labels', async () => {
+    const { result } = makeFixture();
+    const lone = clash(
+      'clash-lone',
+      ref('GUID_X1', 'IfcSlab'),
+      ref('GUID_Y1', 'IfcDuctSegment'),
+      'hard',
+      'info',
+      'rule',
+    );
+    const noDiscipline = makeGroup('group-no-discipline', 'info', [lone]);
+    const project = await createBCFFromClashResult(result, [noDiscipline], { author: 'tester' });
+    const topic = project.topics.get(uuidFromSeed('group-no-discipline'));
+    // No discipline -> just 'Clash'.
+    expect(topic?.labels).toEqual(['Clash']);
+  });
+
+  it('embeds an uncapped clash-ids line plus a capped member table', async () => {
+    const { result, groups } = makeFixture();
+    const project = await createBCFFromClashResult(result, groups, {
+      author: 'tester',
+      maxMembersPerTopic: 1,
+    });
+
+    const critical = project.topics.get(uuidFromSeed('group-critical'));
+    expect(critical?.description).toContain('clash-ids: clash-1,clash-2');
+    // Member table is capped at 1 -> "and 1 more".
+    expect(critical?.description).toContain('and 1 more');
+  });
+
+  it('produces identical guids on repeated calls (determinism)', async () => {
+    const { result, groups } = makeFixture();
+    const a = await createBCFFromClashResult(result, groups, { author: 'tester' });
+    const b = await createBCFFromClashResult(result, groups, { author: 'tester' });
+    expect([...a.topics.keys()].sort()).toEqual([...b.topics.keys()].sort());
+  });
+
+  it('attaches a framing viewpoint with selection and coloring', async () => {
+    const { result, groups } = makeFixture();
+    const project = await createBCFFromClashResult(result, groups, { author: 'tester' });
+    const critical = project.topics.get(uuidFromSeed('group-critical'));
+    expect(critical?.viewpoints.length).toBe(1);
+    const vp = critical?.viewpoints[0];
+    expect(vp?.components?.selection?.length).toBeGreaterThan(0);
+    expect(vp?.components?.coloring?.length).toBe(2);
+    expect(vp?.perspectiveCamera).toBeDefined();
+  });
+
+  it('invokes the snapshot provider per group', async () => {
+    const { result, groups } = makeFixture();
+    const seen: string[] = [];
+    const snapshotProvider = async (g: ClashGroup): Promise<Uint8Array> => {
+      seen.push(g.id);
+      return new Uint8Array([1, 2, 3, 4]);
+    };
+    const project = await createBCFFromClashResult(result, groups, {
+      author: 'tester',
+      snapshotProvider,
+    });
+    expect(seen.sort()).toEqual(['group-critical', 'group-major', 'group-minor']);
+    const critical = project.topics.get(uuidFromSeed('group-critical'));
+    expect(critical?.viewpoints[0]?.snapshotData).toBeInstanceOf(Uint8Array);
+  });
+
+  it('caps topics at maxTopics and adds a transparency overflow topic', async () => {
+    const { result, groups } = makeFixture();
+    const maxTopics = 2;
+    const project = await createBCFFromClashResult(result, groups, {
+      author: 'tester',
+      maxTopics,
+    });
+
+    // 2 exported + 1 overflow marker.
+    expect(project.topics.size).toBe(maxTopics + 1);
+
+    const overflow = [...project.topics.values()].find((t) =>
+      t.title.includes('more clash groups not exported'),
+    );
+    expect(overflow).toBeDefined();
+    expect(overflow?.title).toContain('1 more clash groups not exported');
+    expect(overflow?.description).toContain('exceeded the maxTopics cap of 2');
+
+    // The two exported topics are the two most severe groups.
+    expect(project.topics.has(uuidFromSeed('group-critical'))).toBe(true);
+    expect(project.topics.has(uuidFromSeed('group-major'))).toBe(true);
+    expect(project.topics.has(uuidFromSeed('group-minor'))).toBe(false);
+  });
+});
+
+describe('mapBcfToClashes', () => {
+  it('recovers every clash id -> status from an in-memory project', async () => {
+    const { result, groups } = makeFixture();
+    const project = await createBCFFromClashResult(result, groups, {
+      author: 'tester',
+      status: 'In Progress',
+    });
+    const map = mapBcfToClashes(project);
+
+    expect(map.size).toBe(4);
+    expect(map.get('clash-1')?.status).toBe('In Progress');
+    expect(map.get('clash-1')?.topicGuid).toBe(uuidFromSeed('group-critical'));
+    expect(map.get('clash-2')?.topicGuid).toBe(uuidFromSeed('group-critical'));
+    expect(map.get('clash-3')?.topicGuid).toBe(uuidFromSeed('group-major'));
+    expect(map.get('clash-4')?.topicGuid).toBe(uuidFromSeed('group-minor'));
+  });
+});
+
+describe('BCF round-trip', () => {
+  it('writes a Blob, reads it back, and recovers every clash id', async () => {
+    const { result, groups } = makeFixture();
+    const { writeBCF } = await import('@ifc-lite/bcf');
+    const project = await createBCFFromClashResult(result, groups, {
+      author: 'tester',
+      status: 'Open',
+    });
+
+    const blob = await writeBCF(project);
+    expect(blob).toBeInstanceOf(Blob);
+
+    const buffer = await blob.arrayBuffer();
+    const reloaded = await readBCF(buffer);
+
+    const map = mapBcfToClashes(reloaded);
+    expect(map.size).toBe(4);
+    for (const id of ['clash-1', 'clash-2', 'clash-3', 'clash-4']) {
+      expect(map.has(id)).toBe(true);
+      expect(map.get(id)?.status).toBe('Open');
+    }
+
+    // Topic guids survive the round-trip and remain the deterministic ones.
+    expect(map.get('clash-1')?.topicGuid).toBe(uuidFromSeed('group-critical'));
+    expect(map.get('clash-3')?.topicGuid).toBe(uuidFromSeed('group-major'));
+  });
+});
+
+describe('uuidFromSeed', () => {
+  it('is deterministic and RFC-4122-shaped', () => {
+    const a = uuidFromSeed('group-critical');
+    const b = uuidFromSeed('group-critical');
+    expect(a).toBe(b);
+    expect(a).toMatch(UUID_RE);
+  });
+
+  it('forces the version nibble to 4 and a valid variant nibble', () => {
+    for (const seed of ['a', 'b', 'group-1', 'group-2', '', 'x'.repeat(200)]) {
+      const uuid = uuidFromSeed(seed);
+      expect(uuid).toMatch(UUID_RE);
+      expect(uuid[14]).toBe('4');
+      expect('89ab').toContain(uuid[19]);
+    }
+  });
+
+  it('diffuses similar seeds into different uuids', () => {
+    const u1 = uuidFromSeed('group-1');
+    const u2 = uuidFromSeed('group-2');
+    expect(u1).not.toBe(u2);
+  });
+});

--- a/packages/clash/src/bcf-bridge.ts
+++ b/packages/clash/src/bcf-bridge.ts
@@ -1,0 +1,346 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Clash <-> BCF bridge.
+ *
+ * Turns grouped clash results into a BCF 2.1 project (one topic per clash
+ * group, with a framing viewpoint, selection and coloring) and reads such a
+ * project back into a map of clash-id -> { topicGuid, status } for status
+ * round-tripping. Topic GUIDs are a deterministic function of the group id, so
+ * topic identity is stable across re-exports (timestamps and viewpoint guids
+ * come from @ifc-lite/bcf and are not deterministic, so the archive bytes are
+ * not identical — but the clash<->topic anchoring is).
+ *
+ * Transparency is a first-class concern: when the group count exceeds the cap,
+ * we never silently drop the overflow. We emit the top topics and one extra
+ * marker topic that records exactly how many groups were not exported.
+ */
+
+import {
+  createBCFProject,
+  createBCFTopic,
+  createViewpoint,
+  addViewpointToTopic,
+  addTopicToProject,
+  toARGBColor,
+  type BCFProject,
+  type BCFTopic,
+  type ViewerCameraState,
+  type ViewerBounds,
+} from '@ifc-lite/bcf';
+import type { AABB, Clash, ClashGroup, ClashResult, ClashSeverity, Vec3 } from './types.js';
+import { uuidFromSeed } from './deterministic-uuid.js';
+
+export interface ClashBcfOptions {
+  author: string;
+  status?: string;
+  projectName?: string;
+  maxTopics?: number;
+  maxMembersPerTopic?: number;
+  cameraDistanceFactor?: number;
+  snapshotProvider?: (group: ClashGroup) => Promise<Uint8Array | undefined>;
+}
+
+const DEFAULT_MAX_TOPICS = 1000;
+const DEFAULT_MAX_MEMBERS = 50;
+const DEFAULT_CAMERA_DISTANCE_FACTOR = 2.5;
+/** Minimum eye-to-target standoff (m) so the camera is never coincident with the target. */
+const STANDOFF_FLOOR = 1e-3;
+const CLASH_IDS_PREFIX = 'clash-ids: ';
+
+const SEVERITY_RANK: Record<ClashSeverity, number> = {
+  critical: 0,
+  major: 1,
+  minor: 2,
+  info: 3,
+};
+
+const SEVERITY_PRIORITY: Record<ClashSeverity, string> = {
+  critical: 'High',
+  major: 'Normal',
+  minor: 'Low',
+  info: 'Low',
+};
+
+/** Deterministic sort: severity (critical first), then member count desc, then id. */
+function sortGroups(groups: ClashGroup[]): ClashGroup[] {
+  return [...groups].sort((a, b) => {
+    const sevDiff = SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity];
+    if (sevDiff !== 0) return sevDiff;
+    const countDiff = b.members.length - a.members.length;
+    if (countDiff !== 0) return countDiff;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+}
+
+/** Unique, insertion-ordered list of values. */
+function unique(values: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const v of values) {
+    if (!seen.has(v)) {
+      seen.add(v);
+      out.push(v);
+    }
+  }
+  return out;
+}
+
+function midpoint(b: AABB): Vec3 {
+  return [
+    (b.min[0] + b.max[0]) / 2,
+    (b.min[1] + b.max[1]) / 2,
+    (b.min[2] + b.max[2]) / 2,
+  ];
+}
+
+function diagonalLength(b: AABB): number {
+  const dx = b.max[0] - b.min[0];
+  const dy = b.max[1] - b.min[1];
+  const dz = b.max[2] - b.min[2];
+  return Math.sqrt(dx * dx + dy * dy + dz * dz);
+}
+
+function toViewerBounds(b: AABB): ViewerBounds {
+  return {
+    min: { x: b.min[0], y: b.min[1], z: b.min[2] },
+    max: { x: b.max[0], y: b.max[1], z: b.max[2] },
+  };
+}
+
+/** Frame `bounds` from a fixed oblique direction so the group is fully in view. */
+function cameraForBounds(bounds: AABB, distanceFactor: number): ViewerCameraState {
+  const centerPt = midpoint(bounds);
+  const radius = 0.5 * diagonalLength(bounds);
+
+  // normalize([1, 0.7, 1])
+  const dirLen = Math.sqrt(1 * 1 + 0.7 * 0.7 + 1 * 1);
+  const dir: Vec3 = [1 / dirLen, 0.7 / dirLen, 1 / dirLen];
+
+  // Degenerate bounds (single point) -> use a fixed standoff so the camera is
+  // never coincident with the target.
+  const standoff = Math.max(radius > 0 ? radius * distanceFactor : distanceFactor, STANDOFF_FLOOR);
+
+  const position: Vec3 = [
+    centerPt[0] + dir[0] * standoff,
+    centerPt[1] + dir[1] * standoff,
+    centerPt[2] + dir[2] * standoff,
+  ];
+
+  return {
+    position: { x: position[0], y: position[1], z: position[2] },
+    target: { x: centerPt[0], y: centerPt[1], z: centerPt[2] },
+    up: { x: 0, y: 1, z: 0 },
+    fov: 0.9,
+  };
+}
+
+/** Count members by a string-valued key. */
+function tally(members: Clash[], pick: (c: Clash) => string): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const m of members) {
+    const k = pick(m);
+    out[k] = (out[k] ?? 0) + 1;
+  }
+  return out;
+}
+
+function formatCounts(counts: Record<string, number>): string {
+  const keys = Object.keys(counts).sort();
+  return keys.map((k) => `${k}: ${counts[k]}`).join(', ');
+}
+
+/** A readable, human-facing summary plus the machine-readable clash-ids line. */
+function buildDescription(group: ClashGroup, maxMembers: number): string {
+  const lines: string[] = [];
+  lines.push(`Clash group "${group.title}" with ${group.members.length} member(s).`);
+  if (group.discipline) lines.push(`Discipline: ${group.discipline}`);
+  if (group.storey) lines.push(`Storey: ${group.storey}`);
+  lines.push(`Severity: ${group.severity}`);
+
+  lines.push(`By status: ${formatCounts(tally(group.members, (c) => c.status))}`);
+  lines.push(`By severity: ${formatCounts(tally(group.members, (c) => c.severity))}`);
+
+  const typePairs = tally(group.members, (c) => {
+    const ta = c.a.tag;
+    const tb = c.b.tag;
+    return ta < tb ? `${ta} x ${tb}` : `${tb} x ${ta}`;
+  });
+  lines.push(`Type pairs: ${formatCounts(typePairs)}`);
+
+  lines.push('');
+  lines.push('Members:');
+  const shown = group.members.slice(0, maxMembers);
+  for (const m of shown) {
+    const nameA = m.a.name ? ` (${m.a.name})` : '';
+    const nameB = m.b.name ? ` (${m.b.name})` : '';
+    lines.push(
+      `- [${m.rule}/${m.status}] ${m.a.tag}${nameA} ${m.a.key} <-> ${m.b.tag}${nameB} ${m.b.key} | gap ${m.distance.toFixed(4)}`,
+    );
+  }
+  const remaining = group.members.length - shown.length;
+  if (remaining > 0) {
+    lines.push(`...and ${remaining} more`);
+  }
+
+  lines.push('');
+  // Machine-readable, uncapped: every member id so the round-trip recovers all.
+  // Ids are percent-encoded so commas inside a model name / rule id cannot break
+  // the comma-delimited list (clash ids are otherwise free-form strings).
+  lines.push(`${CLASH_IDS_PREFIX}${group.members.map((m) => encodeURIComponent(m.id)).join(',')}`);
+
+  return lines.join('\n');
+}
+
+/** Build the topic + framing viewpoint for one group. */
+async function buildTopicForGroup(
+  project: BCFProject,
+  group: ClashGroup,
+  opts: ClashBcfOptions,
+  maxMembers: number,
+  cameraDistanceFactor: number,
+): Promise<void> {
+  const description = buildDescription(group, maxMembers);
+  const priority = SEVERITY_PRIORITY[group.severity];
+  const labels = [group.discipline, 'Clash'].filter((l): l is string => Boolean(l));
+
+  const topic = createBCFTopic({
+    title: group.title,
+    description,
+    author: opts.author,
+    topicType: 'Clash',
+    topicStatus: opts.status ?? 'Open',
+    priority,
+    labels,
+  });
+  // Deterministic guid: stable function of the group id (input-only).
+  topic.guid = uuidFromSeed(group.id);
+
+  const selectedGuids = unique(group.members.flatMap((m) => [m.a.key, m.b.key]));
+  const coloredGuids = [
+    { color: toARGBColor(255, 51, 51), guids: unique(group.members.map((m) => m.a.key)) },
+    { color: toARGBColor(255, 165, 0), guids: unique(group.members.map((m) => m.b.key)) },
+  ];
+
+  const camera = cameraForBounds(group.bounds, cameraDistanceFactor);
+  const bounds = toViewerBounds(group.bounds);
+  const snapshotData = opts.snapshotProvider ? await opts.snapshotProvider(group) : undefined;
+
+  const viewpoint = createViewpoint({
+    camera,
+    bounds,
+    selectedGuids,
+    coloredGuids,
+    snapshotData,
+  });
+
+  addViewpointToTopic(topic, viewpoint);
+  addTopicToProject(project, topic);
+}
+
+/**
+ * Build a BCF 2.1 project from a clash result and its precomputed groups.
+ *
+ * Groups are sorted (critical first, then larger groups), capped at
+ * `maxTopics`, and any overflow is recorded in one transparency topic.
+ */
+export async function createBCFFromClashResult(
+  result: ClashResult,
+  groups: ClashGroup[],
+  opts: ClashBcfOptions,
+): Promise<BCFProject> {
+  // `result` carries run-level settings; reference it so the summary in the
+  // overflow topic can quote the real total even when groups are partial.
+  const totalClashes = result.summary.total;
+
+  const project = createBCFProject({
+    name: opts.projectName ?? 'Clash report',
+    version: '2.1',
+  });
+
+  const maxTopics = opts.maxTopics ?? DEFAULT_MAX_TOPICS;
+  const maxMembers = opts.maxMembersPerTopic ?? DEFAULT_MAX_MEMBERS;
+  const cameraDistanceFactor = opts.cameraDistanceFactor ?? DEFAULT_CAMERA_DISTANCE_FACTOR;
+
+  const sorted = sortGroups(groups);
+  const exported = sorted.slice(0, maxTopics);
+  const droppedCount = sorted.length - exported.length;
+
+  for (const group of exported) {
+    await buildTopicForGroup(project, group, opts, maxMembers, cameraDistanceFactor);
+  }
+
+  if (droppedCount > 0) {
+    // Transparency: never silently drop. One marker topic records the overflow.
+    const overflowTitle = `... ${droppedCount} more clash groups not exported`;
+    const overflowDescription = [
+      `${droppedCount} clash group(s) exceeded the maxTopics cap of ${maxTopics} and were not exported.`,
+      `Total clash groups: ${sorted.length}. Exported: ${exported.length}.`,
+      `Total clashes in result: ${totalClashes}.`,
+      'Increase maxTopics to export the remaining groups.',
+    ].join('\n');
+
+    const overflowTopic = createBCFTopic({
+      title: overflowTitle,
+      description: overflowDescription,
+      author: opts.author,
+      topicType: 'Clash',
+      topicStatus: opts.status ?? 'Open',
+      priority: 'Low',
+      labels: ['Clash'],
+    });
+    // Stable guid for the overflow marker too, keyed off the project name and
+    // count so a re-run with the same overflow is idempotent.
+    overflowTopic.guid = uuidFromSeed(
+      `overflow:${opts.projectName ?? 'Clash report'}:${maxTopics}:${droppedCount}`,
+    );
+    addTopicToProject(project, overflowTopic);
+  }
+
+  return project;
+}
+
+/**
+ * Read a BCF project back into a map of clash-id -> { topicGuid, status }.
+ *
+ * Parses the machine-readable `clash-ids:` line that `createBCFFromClashResult`
+ * embeds in each topic description. Topics without that line (e.g. the overflow
+ * marker, or unrelated topics) are skipped.
+ */
+export function mapBcfToClashes(
+  project: BCFProject,
+): Map<string, { topicGuid: string; status: string }> {
+  const map = new Map<string, { topicGuid: string; status: string }>();
+
+  for (const topic of project.topics.values()) {
+    const ids = extractClashIds(topic);
+    if (ids.length === 0) continue;
+    const status = topic.topicStatus ?? 'Open';
+    for (const id of ids) {
+      map.set(id, { topicGuid: topic.guid, status });
+    }
+  }
+
+  return map;
+}
+
+/** Pull the comma-separated ids out of a topic's `clash-ids:` line. */
+function extractClashIds(topic: BCFTopic): string[] {
+  const description = topic.description;
+  if (!description) return [];
+  for (const line of description.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith(CLASH_IDS_PREFIX.trim())) {
+      const payload = trimmed.slice(CLASH_IDS_PREFIX.trim().length).trim();
+      if (payload.length === 0) return [];
+      return payload
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0)
+        .map((s) => decodeURIComponent(s));
+    }
+  }
+  return [];
+}

--- a/packages/clash/src/deterministic-uuid.ts
+++ b/packages/clash/src/deterministic-uuid.ts
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Deterministic, input-only UUID generation.
+ *
+ * Produces an RFC-4122-shaped identifier (8-4-4-4-12 lowercase hex) whose 128
+ * bits are derived purely from a seed string. The same seed always yields the
+ * same UUID, with no dependence on the system clock or any random source. This
+ * is what lets a BCF topic guid be a stable function of a clash-group id, so a
+ * re-run of the same coordination produces byte-identical topic guids and the
+ * round-trip back to clashes stays anchored.
+ *
+ * The 128 bits are filled from four 32-bit words. Each word starts from an
+ * FNV-1a hash of the seed mixed with a distinct salt, then is run through a
+ * short xorshift cascade so adjacent seeds (e.g. "g1" vs "g2") diffuse into
+ * fully different words rather than differing in only a few low bits.
+ */
+
+const FNV_OFFSET_BASIS = 0x811c9dc5;
+const FNV_PRIME = 0x01000193;
+
+/** 32-bit FNV-1a over the UTF-8-ish code units of `input`, seeded with `salt`. */
+function fnv1a(input: string, salt: number): number {
+  let hash = (FNV_OFFSET_BASIS ^ salt) >>> 0;
+  for (let i = 0; i < input.length; i += 1) {
+    const code = input.charCodeAt(i);
+    // Fold the full 16-bit code unit in two byte-sized steps so non-ASCII
+    // comment-free seeds still contribute every bit.
+    hash = (hash ^ (code & 0xff)) >>> 0;
+    hash = Math.imul(hash, FNV_PRIME) >>> 0;
+    hash = (hash ^ ((code >>> 8) & 0xff)) >>> 0;
+    hash = Math.imul(hash, FNV_PRIME) >>> 0;
+  }
+  return hash >>> 0;
+}
+
+/** A short xorshift cascade to diffuse a 32-bit word. */
+function xorshift32(value: number): number {
+  let x = value >>> 0;
+  x ^= x << 13;
+  x >>>= 0;
+  x ^= x >>> 17;
+  x ^= x << 5;
+  return x >>> 0;
+}
+
+/** Left-pad a non-negative 32-bit word to 8 lowercase hex chars. */
+function hex32(value: number): string {
+  return (value >>> 0).toString(16).padStart(8, '0');
+}
+
+/**
+ * Stable RFC-4122-shaped UUID derived purely from `seed`.
+ *
+ * - 8-4-4-4-12 lowercase hex
+ * - version nibble fixed to '4'
+ * - variant nibble in {8, 9, a, b}
+ */
+export function uuidFromSeed(seed: string): string {
+  // Four independent 32-bit words, each its own salt then xorshift-mixed.
+  const w0 = xorshift32(fnv1a(seed, 0x9e3779b1));
+  const w1 = xorshift32(fnv1a(seed, 0x85ebca77));
+  const w2 = xorshift32(fnv1a(seed, 0xc2b2ae3d));
+  const w3 = xorshift32(fnv1a(seed, 0x27d4eb2f));
+
+  // Cross-mix so each output nibble depends on the whole seed, not one word.
+  const a = xorshift32(w0 ^ Math.imul(w3, FNV_PRIME)) >>> 0;
+  const b = xorshift32(w1 ^ Math.imul(w0, FNV_PRIME)) >>> 0;
+  const c = xorshift32(w2 ^ Math.imul(w1, FNV_PRIME)) >>> 0;
+  const d = xorshift32(w3 ^ Math.imul(w2, FNV_PRIME)) >>> 0;
+
+  const hexA = hex32(a);
+  const hexB = hex32(b);
+  const hexC = hex32(c);
+  const hexD = hex32(d);
+
+  // Layout: AAAAAAAA-BBBB-4BBB-VCCC-CCCCDDDDDDDD
+  //   time_low      = hexA            (8)
+  //   time_mid      = hexB[0..4)      (4)
+  //   time_hi_ver   = '4' + hexB[4..7) (4, version nibble forced to 4)
+  //   clock_variant = variant + hexC[1..4) (4)
+  //   node          = hexC[4..8) + hexD (12)
+  const timeLow = hexA;
+  const timeMid = hexB.slice(0, 4);
+  const timeHiAndVersion = `4${hexB.slice(4, 7)}`;
+
+  // Variant nibble: high two bits must be '10' -> one of 8, 9, a, b.
+  // Derive it from the top nibble of hexC so it is still seed-dependent.
+  const variantSource = parseInt(hexC[0], 16);
+  const variantNibble = ((variantSource & 0x3) | 0x8).toString(16);
+  const clockSeqAndVariant = `${variantNibble}${hexC.slice(1, 4)}`;
+
+  const node = `${hexC.slice(4, 8)}${hexD}`;
+
+  return `${timeLow}-${timeMid}-${timeHiAndVersion}-${clockSeqAndVariant}-${node}`;
+}

--- a/packages/clash/src/engine-ts/broad.ts
+++ b/packages/clash/src/engine-ts/broad.ts
@@ -41,9 +41,15 @@ export function candidatePairs(
     }
   } else {
     for (let i = 0; i < groupA.length; i += 1) {
-      const hits = bvh.queryAABB(inflate(groupA[i].bounds, margin));
+      const a = groupA[i];
+      const hits = bvh.queryAABB(inflate(a.bounds, margin));
       for (const j of hits) {
         if (j <= i) continue;
+        const other = groupA[j];
+        // Skip same-entity pairs: an element split across several geometry
+        // sub-prims (common in IFC5/USD) produces multiple elements with the
+        // same durable key — that is one entity, not a self-clash.
+        if (a.key === other.key && a.model === other.model) continue;
         pairs.push([i, j]);
       }
     }

--- a/packages/clash/src/grouping.test.ts
+++ b/packages/clash/src/grouping.test.ts
@@ -1,0 +1,264 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+import { groupClashes } from './grouping.js';
+import type {
+  AABB,
+  Clash,
+  ClashElementRef,
+  ClashResult,
+  ClashSeverity,
+  Vec3,
+} from './types.js';
+
+function ref(key: string, tag: string, name?: string): ClashElementRef {
+  const r: ClashElementRef = { key, ref: 1, model: 'm', tag };
+  if (name !== undefined) r.name = name;
+  return r;
+}
+
+function boundsAround(p: Vec3, half = 0.1): AABB {
+  return {
+    min: [p[0] - half, p[1] - half, p[2] - half],
+    max: [p[0] + half, p[1] + half, p[2] + half],
+  };
+}
+
+interface ClashSpec {
+  id: string;
+  a: ClashElementRef;
+  b: ClashElementRef;
+  rule: string;
+  point: Vec3;
+  severity?: ClashSeverity;
+}
+
+function clash(spec: ClashSpec): Clash {
+  return {
+    id: spec.id,
+    a: spec.a,
+    b: spec.b,
+    rule: spec.rule,
+    status: 'hard',
+    distance: -0.01,
+    point: spec.point,
+    bounds: boundsAround(spec.point),
+    severity: spec.severity ?? 'major',
+  };
+}
+
+function makeResult(clashes: Clash[]): ClashResult {
+  return {
+    clashes,
+    summary: {
+      total: clashes.length,
+      byRule: {},
+      byTypePair: {},
+      bySeverity: { critical: 0, major: 0, minor: 0, info: 0 },
+    },
+    rulesRun: [],
+    settings: { tolerance: 0.002, excludeVoidsAndHosts: true },
+  };
+}
+
+const PIPE = ref('A', 'IfcPipeSegment');
+const BEAM = ref('B', 'IfcBeam');
+const PIPE2 = ref('C', 'IfcPipeSegment');
+const BEAM2 = ref('D', 'IfcBeam');
+
+describe('groupClashes — cluster', () => {
+  it('collapses co-located same-rule same-type-pair clashes and keeps a far one apart', () => {
+    const clashes = [
+      clash({ id: 'c1', a: PIPE, b: BEAM, rule: 'MEPxSTR', point: [0, 0, 0] }),
+      clash({ id: 'c2', a: PIPE, b: BEAM, rule: 'MEPxSTR', point: [0.5, 0, 0] }),
+      clash({ id: 'c3', a: PIPE2, b: BEAM2, rule: 'MEPxSTR', point: [100, 0, 0] }),
+    ];
+    const groups = groupClashes(makeResult(clashes), { by: 'cluster' });
+    expect(groups).toHaveLength(2);
+    const counts = groups.map((g) => g.members.length).sort((x, y) => y - x);
+    expect(counts).toEqual([2, 1]);
+  });
+
+  it('transitively joins a chain within epsilon', () => {
+    const clashes = [
+      clash({ id: 'c1', a: PIPE, b: BEAM, rule: 'MEPxSTR', point: [0, 0, 0] }),
+      clash({ id: 'c2', a: PIPE, b: BEAM, rule: 'MEPxSTR', point: [1.0, 0, 0] }),
+      clash({ id: 'c3', a: PIPE, b: BEAM, rule: 'MEPxSTR', point: [2.0, 0, 0] }),
+    ];
+    // epsilon 1.5: c1-c2 (1.0) and c2-c3 (1.0) join; c1-c3 (2.0) joins via c2.
+    const groups = groupClashes(makeResult(clashes), { by: 'cluster', epsilon: 1.5 });
+    expect(groups).toHaveLength(1);
+    expect(groups[0].members).toHaveLength(3);
+  });
+
+  it('keeps different rules apart even when co-located', () => {
+    const clashes = [
+      clash({ id: 'c1', a: PIPE, b: BEAM, rule: 'MEPxSTR', point: [0, 0, 0] }),
+      clash({ id: 'c2', a: PIPE, b: BEAM, rule: 'HVACxSTR', point: [0, 0, 0] }),
+    ];
+    const groups = groupClashes(makeResult(clashes), { by: 'cluster' });
+    expect(groups).toHaveLength(2);
+    for (const g of groups) expect(g.members).toHaveLength(1);
+  });
+
+  it('keeps different type-pairs apart even when co-located and same rule', () => {
+    const duct = ref('E', 'IfcDuctSegment');
+    const clashes = [
+      clash({ id: 'c1', a: PIPE, b: BEAM, rule: 'R', point: [0, 0, 0] }),
+      clash({ id: 'c2', a: duct, b: BEAM, rule: 'R', point: [0, 0, 0] }),
+    ];
+    const groups = groupClashes(makeResult(clashes), { by: 'cluster' });
+    expect(groups).toHaveLength(2);
+  });
+
+  it('treats type-pair order-independently (a,b vs b,a join)', () => {
+    const clashes = [
+      clash({ id: 'c1', a: PIPE, b: BEAM, rule: 'R', point: [0, 0, 0] }),
+      clash({ id: 'c2', a: BEAM, b: PIPE, rule: 'R', point: [0.2, 0, 0] }),
+    ];
+    const groups = groupClashes(makeResult(clashes), { by: 'cluster' });
+    expect(groups).toHaveLength(1);
+    expect(groups[0].members).toHaveLength(2);
+  });
+});
+
+describe('groupClashes — rule / typePair / element', () => {
+  it('rule: one group per distinct rule', () => {
+    const clashes = [
+      clash({ id: 'c1', a: PIPE, b: BEAM, rule: 'MEPxSTR', point: [0, 0, 0] }),
+      clash({ id: 'c2', a: PIPE, b: BEAM, rule: 'MEPxSTR', point: [50, 0, 0] }),
+      clash({ id: 'c3', a: PIPE, b: BEAM, rule: 'HVACxSTR', point: [0, 0, 0] }),
+    ];
+    const groups = groupClashes(makeResult(clashes), { by: 'rule' });
+    expect(groups).toHaveLength(2);
+    const byRule = new Map(groups.map((g) => [g.members[0].rule, g.members.length]));
+    expect(byRule.get('MEPxSTR')).toBe(2);
+    expect(byRule.get('HVACxSTR')).toBe(1);
+  });
+
+  it('rule: title and discipline map from presets', () => {
+    const clashes = [clash({ id: 'c1', a: PIPE, b: BEAM, rule: 'MEPxSTR', point: [0, 0, 0] })];
+    const [group] = groupClashes(makeResult(clashes), { by: 'rule' });
+    expect(group.discipline).toBe('MEP vs Structure');
+    expect(group.title).toContain('MEP vs Structure');
+    expect(group.title).toContain('MEPxSTR');
+  });
+
+  it('typePair: one group per distinct sorted type-pair', () => {
+    const duct = ref('E', 'IfcDuctSegment');
+    const clashes = [
+      clash({ id: 'c1', a: PIPE, b: BEAM, rule: 'R1', point: [0, 0, 0] }),
+      clash({ id: 'c2', a: BEAM, b: PIPE, rule: 'R2', point: [9, 0, 0] }),
+      clash({ id: 'c3', a: duct, b: BEAM, rule: 'R1', point: [0, 0, 0] }),
+    ];
+    const groups = groupClashes(makeResult(clashes), { by: 'typePair' });
+    // (IfcBeam,IfcPipeSegment) x2 across rules; (IfcBeam,IfcDuctSegment) x1.
+    expect(groups).toHaveLength(2);
+    const counts = groups.map((g) => g.members.length).sort((x, y) => y - x);
+    expect(counts).toEqual([2, 1]);
+  });
+
+  it('element: a clash contributes to BOTH element keys', () => {
+    const clashes = [
+      clash({ id: 'c1', a: PIPE, b: BEAM, rule: 'R', point: [0, 0, 0] }),
+      clash({ id: 'c2', a: PIPE, b: BEAM2, rule: 'R', point: [5, 0, 0] }),
+    ];
+    const groups = groupClashes(makeResult(clashes), { by: 'element' });
+    // Keys A (pipe, both clashes), B (beam, c1), D (beam2, c2).
+    expect(groups).toHaveLength(3);
+    const byTitleCount = groups.map((g) => g.members.length).sort((x, y) => y - x);
+    expect(byTitleCount).toEqual([2, 1, 1]);
+    const pipeGroup = groups.find((g) => g.members.length === 2);
+    expect(pipeGroup?.title).toContain('IfcPipeSegment');
+    expect(pipeGroup?.title).toContain('A');
+  });
+
+  it('element: title prefers element name when present', () => {
+    const named = ref('Z', 'IfcPipeSegment', 'Riser-1');
+    const clashes = [clash({ id: 'c1', a: named, b: BEAM, rule: 'R', point: [0, 0, 0] })];
+    const groups = groupClashes(makeResult(clashes), { by: 'element' });
+    const namedGroup = groups.find((g) => g.title.includes('Riser-1'));
+    expect(namedGroup).toBeDefined();
+  });
+});
+
+describe('groupClashes — storey fallback', () => {
+  it('degrades storey to rule grouping (no storey field on Clash)', () => {
+    const clashes = [
+      clash({ id: 'c1', a: PIPE, b: BEAM, rule: 'MEPxSTR', point: [0, 0, 0] }),
+      clash({ id: 'c2', a: PIPE, b: BEAM, rule: 'HVACxSTR', point: [0, 0, 0] }),
+    ];
+    const storey = groupClashes(makeResult(clashes), { by: 'storey' });
+    const rule = groupClashes(makeResult(clashes), { by: 'rule' });
+    expect(storey.map((g) => g.id)).toEqual(rule.map((g) => g.id));
+  });
+});
+
+describe('groupClashes — aggregates', () => {
+  it('severity is the max among members', () => {
+    const clashes = [
+      clash({ id: 'c1', a: PIPE, b: BEAM, rule: 'R', point: [0, 0, 0], severity: 'minor' }),
+      clash({ id: 'c2', a: PIPE, b: BEAM, rule: 'R', point: [0.3, 0, 0], severity: 'critical' }),
+      clash({ id: 'c3', a: PIPE, b: BEAM, rule: 'R', point: [0.6, 0, 0], severity: 'major' }),
+    ];
+    const [group] = groupClashes(makeResult(clashes), { by: 'cluster' });
+    expect(group.members).toHaveLength(3);
+    expect(group.severity).toBe('critical');
+  });
+
+  it('bounds union and mean representative point', () => {
+    const clashes = [
+      clash({ id: 'c1', a: PIPE, b: BEAM, rule: 'R', point: [0, 0, 0] }),
+      clash({ id: 'c2', a: PIPE, b: BEAM, rule: 'R', point: [1, 0, 0] }),
+    ];
+    const [group] = groupClashes(makeResult(clashes), { by: 'cluster', epsilon: 2 });
+    expect(group.representativePoint).toEqual([0.5, 0, 0]);
+    // bounds half-size 0.1 around each point => min -0.1, max 1.1.
+    expect(group.bounds.min[0]).toBeCloseTo(-0.1, 6);
+    expect(group.bounds.max[0]).toBeCloseTo(1.1, 6);
+  });
+
+  it('sorts groups by severity then member count desc', () => {
+    const clashes = [
+      // major group with 1 member
+      clash({ id: 'c1', a: PIPE, b: BEAM, rule: 'major-rule', point: [0, 0, 0], severity: 'major' }),
+      // critical group with 2 members
+      clash({ id: 'c2', a: PIPE, b: BEAM, rule: 'crit-rule', point: [10, 0, 0], severity: 'critical' }),
+      clash({ id: 'c3', a: PIPE, b: BEAM, rule: 'crit-rule', point: [10.3, 0, 0], severity: 'critical' }),
+    ];
+    const groups = groupClashes(makeResult(clashes), { by: 'cluster' });
+    expect(groups[0].severity).toBe('critical');
+    expect(groups[0].members).toHaveLength(2);
+    expect(groups[1].severity).toBe('major');
+  });
+});
+
+describe('groupClashes — determinism', () => {
+  it('produces identical ids for the same input twice', () => {
+    const build = (): ClashResult =>
+      makeResult([
+        clash({ id: 'c1', a: PIPE, b: BEAM, rule: 'R', point: [0, 0, 0] }),
+        clash({ id: 'c2', a: PIPE, b: BEAM, rule: 'R', point: [0.4, 0, 0] }),
+        clash({ id: 'c3', a: PIPE2, b: BEAM2, rule: 'R2', point: [50, 0, 0] }),
+      ]);
+    const first = groupClashes(build(), { by: 'cluster' });
+    const second = groupClashes(build(), { by: 'cluster' });
+    expect(first.map((g) => g.id)).toEqual(second.map((g) => g.id));
+    // Group id is independent of member input order.
+    const reversed = makeResult([
+      clash({ id: 'c2', a: PIPE, b: BEAM, rule: 'R', point: [0.4, 0, 0] }),
+      clash({ id: 'c1', a: PIPE, b: BEAM, rule: 'R', point: [0, 0, 0] }),
+      clash({ id: 'c3', a: PIPE2, b: BEAM2, rule: 'R2', point: [50, 0, 0] }),
+    ]);
+    const third = groupClashes(reversed, { by: 'cluster' });
+    expect(new Set(third.map((g) => g.id))).toEqual(new Set(first.map((g) => g.id)));
+  });
+
+  it('id has the grp- prefix and a stable hex hash', () => {
+    const clashes = [clash({ id: 'c1', a: PIPE, b: BEAM, rule: 'R', point: [0, 0, 0] })];
+    const [group] = groupClashes(makeResult(clashes), { by: 'cluster' });
+    expect(group.id).toMatch(/^grp-[0-9a-f]{8}$/);
+  });
+});

--- a/packages/clash/src/grouping.ts
+++ b/packages/clash/src/grouping.ts
@@ -1,0 +1,355 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Clash grouping (Phase 2) — collapse a flat `ClashResult` into `ClashGroup`s,
+ * the unit of a single BCF topic.
+ *
+ * Everything here is pure and deterministic: ids and ordering are derived only
+ * from the input clashes (FNV-1a over sorted member ids), never from the clock
+ * or any randomness. The BCF bridge owns any capping; this module never drops.
+ */
+
+import type { AABB } from '@ifc-lite/spatial';
+import { center } from './math/aabb.js';
+import { distSq } from './math/vec3.js';
+import { CLASH_RULE_PRESETS, DISCIPLINES } from './disciplines.js';
+import type {
+  Clash,
+  ClashGroup,
+  ClashResult,
+  ClashSeverity,
+  Vec3,
+} from './types.js';
+
+/** How to partition a `ClashResult` into groups. */
+export interface GroupOptions {
+  by: 'cluster' | 'rule' | 'typePair' | 'element' | 'storey';
+  /** Cluster radius in metres for `by: 'cluster'`. Defaults to 1.5 m. */
+  epsilon?: number;
+}
+
+const DEFAULT_EPSILON = 1.5;
+
+const SEVERITY_RANK: Record<ClashSeverity, number> = {
+  critical: 0,
+  major: 1,
+  minor: 2,
+  info: 3,
+};
+
+/** Stable 32-bit FNV-1a hash of a string, hex-encoded. Purely input-derived. */
+function fnv1a(input: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i) & 0xff;
+    // 32-bit FNV prime multiply via shifts to stay in unsigned range.
+    hash = (hash + ((hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24))) >>> 0;
+  }
+  return hash.toString(16).padStart(8, '0');
+}
+
+/** Union of two axis-aligned boxes. */
+function unionBounds(a: AABB, b: AABB): AABB {
+  return {
+    min: [
+      Math.min(a.min[0], b.min[0]),
+      Math.min(a.min[1], b.min[1]),
+      Math.min(a.min[2], b.min[2]),
+    ],
+    max: [
+      Math.max(a.max[0], b.max[0]),
+      Math.max(a.max[1], b.max[1]),
+      Math.max(a.max[2], b.max[2]),
+    ],
+  };
+}
+
+/** Union of all member bounds. `members` is assumed non-empty. */
+function unionOfBounds(members: Clash[]): AABB {
+  let acc = members[0].bounds;
+  for (let i = 1; i < members.length; i += 1) {
+    acc = unionBounds(acc, members[i].bounds);
+  }
+  return acc;
+}
+
+/** Mean of member points. `members` is assumed non-empty. */
+function meanPoint(members: Clash[]): Vec3 {
+  let x = 0;
+  let y = 0;
+  let z = 0;
+  for (const m of members) {
+    x += m.point[0];
+    y += m.point[1];
+    z += m.point[2];
+  }
+  const n = members.length;
+  return [x / n, y / n, z / n];
+}
+
+/** Most severe severity among members (critical wins). Assumes non-empty. */
+function maxSeverity(members: Clash[]): ClashSeverity {
+  let best: ClashSeverity = members[0].severity;
+  for (let i = 1; i < members.length; i += 1) {
+    if (SEVERITY_RANK[members[i].severity] < SEVERITY_RANK[best]) {
+      best = members[i].severity;
+    }
+  }
+  return best;
+}
+
+/** Sorted, separator-joined member ids — the basis for the stable group id. */
+function memberIdSignature(members: Clash[]): string {
+  const ids = members.map((m) => m.id).sort();
+  // Newline separates ids: it cannot occur inside an engine clash id (a single
+  // line of space-separated GUID/path tokens), so the join stays injective even
+  // if a model name or key contains spaces.
+  return ids.join('\n');
+}
+
+/**
+ * Stable group id. `discriminator` distinguishes groups that share a member set
+ * but mean different things — notably element-mode groups, where two elements
+ * that clash only with each other would otherwise collide on an identical id
+ * (and downstream produce duplicate BCF topic GUIDs).
+ */
+function groupId(members: Clash[], discriminator = ''): string {
+  return `grp-${fnv1a(`${discriminator}\n${memberIdSignature(members)}`)}`;
+}
+
+/** Sorted type-pair key, order-independent: `IfcBeam|IfcPipeSegment`. */
+function typePairKey(clash: Clash): string {
+  const [first, second] =
+    clash.a.tag <= clash.b.tag ? [clash.a.tag, clash.b.tag] : [clash.b.tag, clash.a.tag];
+  return `${first}|${second}`;
+}
+
+/** Discipline label for a rule, via presets then the discipline table. */
+function disciplineForRule(rule: string): string | undefined {
+  const preset = CLASH_RULE_PRESETS.find((p) => p.id === rule);
+  if (preset) {
+    return preset.name;
+  }
+  const upper = rule.toUpperCase();
+  for (const info of Object.values(DISCIPLINES)) {
+    if (upper === info.code) {
+      return info.label;
+    }
+  }
+  return undefined;
+}
+
+/** Human-readable title for a rule-based group. */
+function ruleTitle(rule: string): string {
+  const label = disciplineForRule(rule);
+  return label ? `${label} (${rule})` : `Rule ${rule}`;
+}
+
+function makeGroup(
+  members: Clash[],
+  title: string,
+  discipline: string | undefined,
+  discriminator = '',
+): ClashGroup {
+  const group: ClashGroup = {
+    id: groupId(members, discriminator),
+    title,
+    members,
+    bounds: unionOfBounds(members),
+    representativePoint: meanPoint(members),
+    severity: maxSeverity(members),
+  };
+  if (discipline !== undefined) {
+    group.discipline = discipline;
+  }
+  return group;
+}
+
+/**
+ * Spatial DBSCAN-style clustering: two clashes join iff they share the same
+ * `rule` AND the same sorted type-pair AND their `point`s are within `epsilon`
+ * (transitively). Partitioning by (rule, type-pair) first keeps unrelated
+ * conflicts apart even when co-located. O(n^2) within each partition.
+ */
+function clusterGroups(clashes: Clash[], epsilon: number): ClashGroup[] {
+  const partitions = new Map<string, Clash[]>();
+  for (const clash of clashes) {
+    const key = `${clash.rule}\n${typePairKey(clash)}`;
+    const bucket = partitions.get(key);
+    if (bucket) {
+      bucket.push(clash);
+    } else {
+      partitions.set(key, [clash]);
+    }
+  }
+
+  const epsilonSq = epsilon * epsilon;
+  const groups: ClashGroup[] = [];
+
+  for (const bucket of partitions.values()) {
+    const n = bucket.length;
+    const parent = new Array<number>(n);
+    for (let i = 0; i < n; i += 1) {
+      parent[i] = i;
+    }
+    const find = (i: number): number => {
+      let root = i;
+      while (parent[root] !== root) {
+        root = parent[root];
+      }
+      // Path compression keeps repeated lookups flat; deterministic.
+      let cur = i;
+      while (parent[cur] !== root) {
+        const next = parent[cur];
+        parent[cur] = root;
+        cur = next;
+      }
+      return root;
+    };
+    const union = (i: number, j: number): void => {
+      const ri = find(i);
+      const rj = find(j);
+      if (ri !== rj) {
+        // Attach the higher-index root under the lower to keep ids stable.
+        if (ri < rj) {
+          parent[rj] = ri;
+        } else {
+          parent[ri] = rj;
+        }
+      }
+    };
+
+    for (let i = 0; i < n; i += 1) {
+      for (let j = i + 1; j < n; j += 1) {
+        if (distSq(bucket[i].point, bucket[j].point) <= epsilonSq) {
+          union(i, j);
+        }
+      }
+    }
+
+    const byRoot = new Map<number, Clash[]>();
+    for (let i = 0; i < n; i += 1) {
+      const root = find(i);
+      const members = byRoot.get(root);
+      if (members) {
+        members.push(bucket[i]);
+      } else {
+        byRoot.set(root, [bucket[i]]);
+      }
+    }
+
+    for (const members of byRoot.values()) {
+      const sample = members[0];
+      const discipline = disciplineForRule(sample.rule);
+      const title = `${typePairKey(sample).replaceAll('|', ' vs ')} (${sample.rule})`;
+      groups.push(makeGroup(members, title, discipline));
+    }
+  }
+
+  return groups;
+}
+
+function ruleGroups(clashes: Clash[]): ClashGroup[] {
+  const byRule = new Map<string, Clash[]>();
+  for (const clash of clashes) {
+    const bucket = byRule.get(clash.rule);
+    if (bucket) {
+      bucket.push(clash);
+    } else {
+      byRule.set(clash.rule, [clash]);
+    }
+  }
+  const groups: ClashGroup[] = [];
+  for (const [rule, members] of byRule) {
+    groups.push(makeGroup(members, ruleTitle(rule), disciplineForRule(rule)));
+  }
+  return groups;
+}
+
+function typePairGroups(clashes: Clash[]): ClashGroup[] {
+  const byPair = new Map<string, Clash[]>();
+  for (const clash of clashes) {
+    const key = typePairKey(clash);
+    const bucket = byPair.get(key);
+    if (bucket) {
+      bucket.push(clash);
+    } else {
+      byPair.set(key, [clash]);
+    }
+  }
+  const groups: ClashGroup[] = [];
+  for (const [key, members] of byPair) {
+    groups.push(makeGroup(members, key.replaceAll('|', ' vs '), undefined));
+  }
+  return groups;
+}
+
+function elementGroups(clashes: Clash[]): ClashGroup[] {
+  // Each clash contributes to BOTH participating element keys.
+  const byKey = new Map<string, Clash[]>();
+  for (const clash of clashes) {
+    for (const ref of [clash.a, clash.b]) {
+      const bucket = byKey.get(ref.key);
+      if (bucket) {
+        bucket.push(clash);
+      } else {
+        byKey.set(ref.key, [clash]);
+      }
+    }
+  }
+  const groups: ClashGroup[] = [];
+  for (const [key, members] of byKey) {
+    const ref = members[0].a.key === key ? members[0].a : members[0].b;
+    const label = ref.name ?? key;
+    groups.push(makeGroup(members, `Clashes on ${ref.tag} ${label}`, undefined, `elem:${key}`));
+  }
+  return groups;
+}
+
+/**
+ * Group a clash result. `Clash` carries no storey, so `by: 'storey'` falls back
+ * to rule grouping (see module notes / report) rather than inventing a field.
+ */
+export function groupClashes(result: ClashResult, opts: GroupOptions): ClashGroup[] {
+  const clashes = result.clashes;
+  let groups: ClashGroup[];
+
+  switch (opts.by) {
+    case 'cluster':
+      groups = clusterGroups(clashes, opts.epsilon ?? DEFAULT_EPSILON);
+      break;
+    case 'rule':
+      groups = ruleGroups(clashes);
+      break;
+    case 'typePair':
+      groups = typePairGroups(clashes);
+      break;
+    case 'element':
+      groups = elementGroups(clashes);
+      break;
+    case 'storey':
+      // Clash carries no storey; degrade to rule grouping. See notes.
+      groups = ruleGroups(clashes);
+      break;
+    default: {
+      const exhaustive: never = opts.by;
+      throw new Error(`Unknown grouping mode: ${String(exhaustive)}`);
+    }
+  }
+
+  // Severity (critical first), then member count desc, tie-break by id asc.
+  groups.sort((a, b) => {
+    const sev = SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity];
+    if (sev !== 0) return sev;
+    const count = b.members.length - a.members.length;
+    if (count !== 0) return count;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+
+  return groups;
+}
+
+/** Re-exported for callers that want the cluster centre of a group's bounds. */
+export { center as groupCenter };

--- a/packages/clash/src/index.ts
+++ b/packages/clash/src/index.ts
@@ -31,3 +31,5 @@ export {
   parseTriageResponse,
   type ClashTriageResult,
 } from './triage.js';
+export { groupClashes, type GroupOptions } from './grouping.js';
+export { compareClashRuns, type ClashRevisionDiff } from './lifecycle.js';

--- a/packages/clash/src/lifecycle.test.ts
+++ b/packages/clash/src/lifecycle.test.ts
@@ -1,0 +1,126 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+import { compareClashRuns } from './lifecycle.js';
+import type { AABB, Clash, ClashResult, ClashSeverity } from './types.js';
+
+const BOUNDS: AABB = { min: [0, 0, 0], max: [1, 1, 1] };
+
+function makeClash(id: string, severity: ClashSeverity = 'major'): Clash {
+  return {
+    id,
+    a: { key: `${id}-a`, ref: 1, model: 'm', tag: 'IfcWall' },
+    b: { key: `${id}-b`, ref: 2, model: 'm', tag: 'IfcDuctSegment' },
+    rule: 'arch-vs-mep',
+    status: 'hard',
+    distance: -0.01,
+    point: [0.5, 0.5, 0.5],
+    bounds: BOUNDS,
+    severity,
+  };
+}
+
+function makeResult(clashes: Clash[]): ClashResult {
+  return {
+    clashes,
+    summary: {
+      total: clashes.length,
+      byRule: {},
+      byTypePair: {},
+      bySeverity: { critical: 0, major: 0, minor: 0, info: 0 },
+    },
+    rulesRun: [],
+    settings: { tolerance: 0.002, excludeVoidsAndHosts: true },
+  };
+}
+
+function ids(clashes: Clash[]): string[] {
+  return clashes.map((c) => c.id);
+}
+
+describe('compareClashRuns', () => {
+  it('partitions overlapping and non-overlapping ids', () => {
+    // previous: c1, c2, c3 ; next: c2, c3, c4
+    // -> resolved c1 ; persistent c2, c3 ; added c4
+    const previous = makeResult([makeClash('c3'), makeClash('c1'), makeClash('c2')]);
+    const next = makeResult([makeClash('c4'), makeClash('c2'), makeClash('c3')]);
+
+    const diff = compareClashRuns(previous, next);
+
+    expect(ids(diff.added)).toEqual(['c4']);
+    expect(ids(diff.persistent)).toEqual(['c2', 'c3']);
+    expect(ids(diff.resolved)).toEqual(['c1']);
+    expect(diff.summary).toEqual({ added: 1, persistent: 2, resolved: 1 });
+  });
+
+  it('sorts each array deterministically by id', () => {
+    const previous = makeResult([makeClash('b'), makeClash('a')]);
+    const next = makeResult([makeClash('z'), makeClash('a'), makeClash('m')]);
+
+    const diff = compareClashRuns(previous, next);
+
+    expect(ids(diff.added)).toEqual(['m', 'z']);
+    expect(ids(diff.persistent)).toEqual(['a']);
+    expect(ids(diff.resolved)).toEqual(['b']);
+  });
+
+  it('persistent returns the next run Clash, not the previous one', () => {
+    const prevClash = makeClash('shared', 'minor');
+    prevClash.distance = -0.5;
+    const nextClash = makeClash('shared', 'critical');
+    nextClash.distance = -0.02;
+
+    const diff = compareClashRuns(makeResult([prevClash]), makeResult([nextClash]));
+
+    expect(diff.persistent).toHaveLength(1);
+    expect(diff.persistent[0]).toBe(nextClash);
+    expect(diff.persistent[0]?.severity).toBe('critical');
+    expect(diff.persistent[0]?.distance).toBe(-0.02);
+  });
+
+  it('empty previous run: everything in next is added', () => {
+    const next = makeResult([makeClash('y'), makeClash('x')]);
+
+    const diff = compareClashRuns(makeResult([]), next);
+
+    expect(ids(diff.added)).toEqual(['x', 'y']);
+    expect(diff.persistent).toEqual([]);
+    expect(diff.resolved).toEqual([]);
+    expect(diff.summary).toEqual({ added: 2, persistent: 0, resolved: 0 });
+  });
+
+  it('empty next run: everything in previous is resolved', () => {
+    const previous = makeResult([makeClash('q'), makeClash('p')]);
+
+    const diff = compareClashRuns(previous, makeResult([]));
+
+    expect(diff.added).toEqual([]);
+    expect(diff.persistent).toEqual([]);
+    expect(ids(diff.resolved)).toEqual(['p', 'q']);
+    expect(diff.summary).toEqual({ added: 0, persistent: 0, resolved: 2 });
+  });
+
+  it('both runs empty: all buckets empty', () => {
+    const diff = compareClashRuns(makeResult([]), makeResult([]));
+
+    expect(diff.added).toEqual([]);
+    expect(diff.persistent).toEqual([]);
+    expect(diff.resolved).toEqual([]);
+    expect(diff.summary).toEqual({ added: 0, persistent: 0, resolved: 0 });
+  });
+
+  it('is deterministic across repeated calls', () => {
+    const previous = makeResult([makeClash('c2'), makeClash('c1')]);
+    const next = makeResult([makeClash('c2'), makeClash('c3')]);
+
+    const first = compareClashRuns(previous, next);
+    const second = compareClashRuns(previous, next);
+
+    expect(ids(first.added)).toEqual(ids(second.added));
+    expect(ids(first.persistent)).toEqual(ids(second.persistent));
+    expect(ids(first.resolved)).toEqual(ids(second.resolved));
+    expect(first.summary).toEqual(second.summary);
+  });
+});

--- a/packages/clash/src/lifecycle.ts
+++ b/packages/clash/src/lifecycle.ts
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Clash lifecycle across model revisions (Phase 5).
+ *
+ * Compares two clash runs and partitions their clashes into added / resolved /
+ * persistent buckets. Matching is by the stable `clash.id`, which is durable
+ * across revisions because it derives from the elements' durable keys
+ * (IfcGUID / USD prim path) plus the rule id — not from runtime refs that
+ * change between loads. This makes the diff stable: a clash that survives a
+ * revision keeps its id and is reported as `persistent` rather than as a
+ * resolve-plus-add churn.
+ */
+
+import type { Clash, ClashResult } from './types.js';
+
+/**
+ * The result of comparing a previous clash run to a later ("next") one.
+ *
+ * - `added`      clashes present in `next` but not in `previous` (new issues)
+ * - `persistent` clashes present in both runs (still open; the `next` Clash)
+ * - `resolved`   clashes present in `previous` but not in `next` (fixed/removed)
+ *
+ * Each array is sorted by `clash.id` for deterministic, diff-friendly output.
+ */
+export interface ClashRevisionDiff {
+  added: Clash[];
+  persistent: Clash[];
+  resolved: Clash[];
+  summary: { added: number; persistent: number; resolved: number };
+}
+
+/** Stable string compare for ids (ASCII/Unicode code-point order). */
+function byId(a: Clash, b: Clash): number {
+  if (a.id < b.id) return -1;
+  if (a.id > b.id) return 1;
+  return 0;
+}
+
+/**
+ * Index a run's clashes by their stable id for O(1) membership checks. The
+ * engine dedups clash ids within a run, so ids are unique here. If a caller
+ * passed a hand-built run with a repeated id, the map keeps the last occurrence
+ * for membership tests, while the added/persistent/resolved buckets below
+ * iterate the raw clash arrays — so a duplicate id would appear once per
+ * occurrence in its bucket and in the counts.
+ */
+function indexById(run: ClashResult): Map<string, Clash> {
+  const byKey = new Map<string, Clash>();
+  for (const clash of run.clashes) {
+    byKey.set(clash.id, clash);
+  }
+  return byKey;
+}
+
+/**
+ * Compare two clash runs and partition their clashes by lifecycle state.
+ *
+ * Pure and deterministic: the output depends only on the two inputs, never on
+ * the clock or any randomness. The `persistent` bucket returns the `next` run's
+ * Clash (the current geometry/point/distance for a still-open issue), so a
+ * caller can render the up-to-date state. Each array is sorted by id.
+ */
+export function compareClashRuns(previous: ClashResult, next: ClashResult): ClashRevisionDiff {
+  const prevById = indexById(previous);
+  const nextById = indexById(next);
+
+  const added: Clash[] = [];
+  const persistent: Clash[] = [];
+  const resolved: Clash[] = [];
+
+  for (const clash of next.clashes) {
+    if (prevById.has(clash.id)) {
+      // Present in both runs: still open. Report the next run's Clash so the
+      // caller sees current geometry, not the stale previous-revision copy.
+      persistent.push(clash);
+    } else {
+      added.push(clash);
+    }
+  }
+
+  for (const clash of previous.clashes) {
+    if (!nextById.has(clash.id)) {
+      resolved.push(clash);
+    }
+  }
+
+  added.sort(byId);
+  persistent.sort(byId);
+  resolved.sort(byId);
+
+  return {
+    added,
+    persistent,
+    resolved,
+    summary: {
+      added: added.length,
+      persistent: persistent.length,
+      resolved: resolved.length,
+    },
+  };
+}

--- a/packages/clash/src/regression.test.ts
+++ b/packages/clash/src/regression.test.ts
@@ -1,0 +1,105 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression tests for defects found by adversarial review of phases 2/5/6:
+ * - element-mode groups must not collide on the same id (-> duplicate BCF GUIDs)
+ * - the BCF clash-ids round-trip must survive commas in a clash id
+ * - the self-clash broad phase must skip same-key (same-entity) pairs
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readBCF, writeBCF } from '@ifc-lite/bcf';
+import { groupClashes } from './grouping.js';
+import { createBCFFromClashResult, mapBcfToClashes } from './bcf-bridge.js';
+import { createClashEngine } from './engine.js';
+import type { AABB, Clash, ClashElement, ClashElementRef, ClashResult, Vec3 } from './types.js';
+
+function ref(key: string, tag: string): ClashElementRef {
+  return { key, ref: 1, model: 'm', tag };
+}
+
+function boundsAround(p: Vec3): AABB {
+  return { min: [p[0] - 0.1, p[1] - 0.1, p[2] - 0.1], max: [p[0] + 0.1, p[1] + 0.1, p[2] + 0.1] };
+}
+
+function makeClash(id: string, a: ClashElementRef, b: ClashElementRef, point: Vec3): Clash {
+  return {
+    id, a, b, rule: 'r', status: 'hard', distance: -0.01,
+    point, bounds: boundsAround(point), severity: 'major',
+  };
+}
+
+function makeResult(clashes: Clash[]): ClashResult {
+  return {
+    clashes,
+    summary: {
+      total: clashes.length,
+      byRule: {}, byTypePair: {},
+      bySeverity: { critical: 0, major: 0, minor: 0, info: 0 },
+    },
+    rulesRun: [],
+    settings: { tolerance: 0.002, excludeVoidsAndHosts: true },
+  };
+}
+
+function boxElement(key: string, tag: string, cx: number): ClashElement {
+  const h = 0.5;
+  const v = [
+    cx - h, -h, -h, cx + h, -h, -h, cx + h, h, -h, cx - h, h, -h,
+    cx - h, -h, h, cx + h, -h, h, cx + h, h, h, cx - h, h, h,
+  ];
+  const indices = new Uint32Array([
+    0, 1, 2, 0, 2, 3, 4, 6, 5, 4, 7, 6, 0, 4, 5, 0, 5, 1,
+    1, 5, 6, 1, 6, 2, 2, 6, 7, 2, 7, 3, 3, 7, 4, 3, 4, 0,
+  ]);
+  const positions = new Float32Array(v);
+  return {
+    key, ref: 1, model: 'm', tag, positions, indices,
+    bounds: { min: [cx - h, -h, -h], max: [cx + h, h, h] },
+  };
+}
+
+describe('regression: element-mode group ids do not collide', () => {
+  it('gives two elements that clash only with each other distinct group ids', () => {
+    const a = ref('GUID-A', 'IfcPipeSegment');
+    const b = ref('GUID-B', 'IfcBeam');
+    const result = makeResult([makeClash('r m GUID-A m GUID-B', a, b, [0, 0, 0])]);
+
+    const groups = groupClashes(result, { by: 'element' });
+    expect(groups).toHaveLength(2);
+    expect(groups[0].id).not.toBe(groups[1].id);
+  });
+});
+
+describe('regression: BCF clash-ids round-trip survives commas in an id', () => {
+  it('recovers a clash id containing a comma (federated model label)', async () => {
+    // A realistic federated model label puts a comma inside the clash id.
+    const commaId = 'r Building A, Phase 2.ifc GUID-A m GUID-B';
+    const a = ref('GUID-A', 'IfcDuctSegment');
+    const b = ref('GUID-B', 'IfcBeam');
+    const result = makeResult([makeClash(commaId, a, b, [0, 0, 0])]);
+    const groups = groupClashes(result, { by: 'rule' });
+
+    const project = await createBCFFromClashResult(result, groups, { author: 'qa@example.com' });
+    const reloaded = await readBCF(await (await writeBCF(project)).arrayBuffer());
+    const map = mapBcfToClashes(reloaded);
+
+    expect(map.has(commaId)).toBe(true);
+    expect(map.get(commaId)?.status).toBe('Open');
+  });
+});
+
+describe('regression: self-clash skips same-key (same-entity) pairs', () => {
+  it('does not report a clash between two elements sharing a durable key', async () => {
+    // An IFC5 element split across two geometry sub-prims -> two overlapping
+    // ClashElements with the SAME key. That is one entity, not a clash.
+    const elements = [boxElement('SAME', 'IfcWall', 0), boxElement('SAME', 'IfcWall', 0.2)];
+    const engine = createClashEngine({ backend: 'ts' });
+    const result = await engine.run(elements, [
+      { id: 'self', name: 'wall self-clash', a: 'IfcWall', mode: 'hard' },
+    ]);
+    expect(result.summary.total).toBe(0);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -723,9 +723,15 @@ importers:
 
   packages/clash:
     dependencies:
+      '@ifc-lite/bcf':
+        specifier: workspace:^
+        version: link:../bcf
       '@ifc-lite/geometry':
         specifier: workspace:^
         version: link:../geometry
+      '@ifc-lite/ifcx':
+        specifier: workspace:^
+        version: link:../ifcx
       '@ifc-lite/parser':
         specifier: workspace:^
         version: link:../parser


### PR DESCRIPTION
Stacked on #891 (Phase 0). Adds the next, headless, fully-tested plan phases as additive `@ifc-lite/clash` modules. Built in parallel by four agents, then hardened by an adversarial-review pass.

## Phases

**P2 — grouping (`grouping.ts`, core)**
`groupClashes(result, { by })` with `cluster` (DBSCAN partitioned by rule + type-pair within `epsilon`), `rule`, `typePair`, `element`, `storey`. Deterministic group ids, max-severity, AABB-union bounds. *storey degrades to rule grouping (Clash carries no storey) — documented.*

**P2 — sensible BCF (`bcf-bridge.ts` → `@ifc-lite/clash/bcf`)** — the headline
`createBCFFromClashResult(result, groups, opts)` turns grouped clashes into a **manageable** set of BCF topics instead of thousands:
- one topic + framing viewpoint per group; selection + A/B coloring by IfcGUID
- **deterministic topic GUIDs** (`uuidFromSeed(group.id)`) → re-export *updates*, never duplicates
- severity → priority; **transparency** on `maxTopics`/`maxMembers` caps (overflow recorded, never silently dropped)
- percent-encoded `clash-ids` line → `mapBcfToClashes()` round-trips status by clash id (comma-safe)

**P5 — lifecycle (`lifecycle.ts`, core)**
`compareClashRuns(prev, next)` → `added` / `persistent` / `resolved` by stable clash id across model revisions.

**P6 — IFCx/USD adapter (`adapters/ifcx.ts` → `@ifc-lite/clash/ifcx`)**
`elementsFromIfcx()` maps a parsed IFCx model (prim path = key, component type = tag, world-space meshes, composition-derived exclusions) to `ClashElement[]`. **The same engine, grouping, and BCF bridge run on IFC5/USD with zero core changes** — the proof the architecture is representation-agnostic.

## Quality

- **Core boundary preserved:** only the `./bcf` and `./ifcx` subpaths import those deps; the core entry stays clean (verified).
- **Adversarial review** (5 agents) found and we fixed: element-mode group-id collision (→ duplicate BCF GUIDs), comma-unsafe BCF round-trip, same-key self-clash pairing, degenerate camera, plus injective hash separators. Regression tests added for each.
- Deterministic throughout (no clock/randomness in pure code); no `as any`/suppressions/empty-catch; ASCII-only source; modules under the size cap.
- **72 tests across 11 files**, strict `tsc` clean.

## Not in this PR (dedicated passes)
P1 viewer panel (needs the running app), P3 Rust→WASM core (crate + WASM rebuild + differential tests), P4 MCP/CLI/scripts (needs headless meshing), P7 desktop migration (separate repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)