### PR TITLE
feat(clash): Rust/WASM geometry kernel + differential parity (Phase 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2422,6 +2422,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "ifc-lite-clash"
+version = "3.0.0"
+
+[[package]]
 name = "ifc-lite-core"
 version = "3.0.0"
 dependencies = [
@@ -2528,6 +2532,7 @@ version = "3.0.0"
 dependencies = [
  "console_error_panic_hook",
  "futures-util",
+ "ifc-lite-clash",
  "ifc-lite-core",
  "ifc-lite-geometry",
  "ifc-lite-processing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["rust/core", "rust/geometry", "rust/processing", "rust/wasm-bindings", "apps/server", "apps/desktop/src-tauri"]
+members = ["rust/core", "rust/geometry", "rust/processing", "rust/clash", "rust/wasm-bindings", "apps/server", "apps/desktop/src-tauri"]
 resolver = "2"
 
 [workspace.package]
@@ -13,6 +13,7 @@ repository = "https://github.com/LTplus-AG/ifc-lite"
 ifc-lite-core = { version = "3.0.0", path = "rust/core" }
 ifc-lite-geometry = { version = "3.0.0", path = "rust/geometry" }
 ifc-lite-processing = { version = "2.1.7", path = "rust/processing" }
+ifc-lite-clash = { version = "3.0.0", path = "rust/clash" }
 ifc-lite-wasm = { version = "3.0.0", path = "rust/wasm-bindings" }
 
 [profile.release]

--- a/packages/clash/package.json
+++ b/packages/clash/package.json
@@ -22,6 +22,10 @@
     "./bcf": {
       "import": "./dist/bcf-bridge.js",
       "types": "./dist/bcf-bridge.d.ts"
+    },
+    "./wasm": {
+      "import": "./dist/engine-wasm/index.js",
+      "types": "./dist/engine-wasm/index.d.ts"
     }
   },
   "scripts": {
@@ -35,7 +39,8 @@
     "@ifc-lite/parser": "workspace:^",
     "@ifc-lite/query": "workspace:^",
     "@ifc-lite/bcf": "workspace:^",
-    "@ifc-lite/ifcx": "workspace:^"
+    "@ifc-lite/ifcx": "workspace:^",
+    "@ifc-lite/wasm": "workspace:^"
   },
   "devDependencies": {
     "typescript": "^6.0.3",

--- a/packages/clash/src/differential.test.ts
+++ b/packages/clash/src/differential.test.ts
@@ -1,0 +1,129 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Differential test: the Rust/WASM kernel must produce the same clashes as the
+ * pure-TypeScript reference engine. Both run through the identical orchestrator,
+ * so any divergence is in the geometry kernel. We assert identical clash sets
+ * (by id), status and severity, with distances and points within epsilon
+ * (f64 summation order can differ by ~1e-12 across the two implementations).
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { createClashEngine } from './engine.js';
+import { disciplineMatrixRules } from './disciplines.js';
+import { WasmClashEngine, initClashWasm } from './engine-wasm/index.js';
+import type { ClashElement, ClashResult, ClashRule, Vec3 } from './types.js';
+
+const EPS = 1e-6;
+
+function makeBox(center: Vec3, size: number): { positions: Float32Array; indices: Uint32Array } {
+  const h = size / 2;
+  const [cx, cy, cz] = center;
+  const v = [
+    cx - h, cy - h, cz - h, cx + h, cy - h, cz - h, cx + h, cy + h, cz - h, cx - h, cy + h, cz - h,
+    cx - h, cy - h, cz + h, cx + h, cy - h, cz + h, cx + h, cy + h, cz + h, cx - h, cy + h, cz + h,
+  ];
+  const indices = new Uint32Array([
+    0, 1, 2, 0, 2, 3, 4, 6, 5, 4, 7, 6, 0, 4, 5, 0, 5, 1,
+    1, 5, 6, 1, 6, 2, 2, 6, 7, 2, 7, 3, 3, 7, 4, 3, 4, 0,
+  ]);
+  return { positions: new Float32Array(v), indices };
+}
+
+let refCounter = 1;
+function box(key: string, tag: string, center: Vec3, size = 1): ClashElement {
+  const { positions, indices } = makeBox(center, size);
+  const h = size / 2;
+  return {
+    key,
+    ref: refCounter++,
+    model: 'm',
+    tag,
+    positions,
+    indices,
+    bounds: {
+      min: [center[0] - h, center[1] - h, center[2] - h],
+      max: [center[0] + h, center[1] + h, center[2] + h],
+    },
+  };
+}
+
+const ts = createClashEngine({ backend: 'ts' });
+const wasm = new WasmClashEngine();
+
+function assertParity(a: ClashResult, b: ClashResult): void {
+  expect(b.clashes.length).toBe(a.clashes.length);
+  const byId = new Map(b.clashes.map((c) => [c.id, c]));
+  for (const x of a.clashes) {
+    const y = byId.get(x.id);
+    expect(y, `clash ${x.id} should exist in the WASM result`).toBeDefined();
+    if (!y) continue;
+    expect(y.status).toBe(x.status);
+    expect(y.severity).toBe(x.severity);
+    expect(Math.abs(y.distance - x.distance)).toBeLessThan(EPS);
+    for (let i = 0; i < 3; i += 1) {
+      expect(Math.abs(y.point[i] - x.point[i])).toBeLessThan(EPS);
+    }
+  }
+}
+
+async function bothAgree(elements: ClashElement[], rules: ClashRule[]): Promise<number> {
+  const a = await ts.run(elements, rules);
+  const b = await wasm.run(elements, rules);
+  assertParity(a, b);
+  return a.clashes.length;
+}
+
+beforeAll(async () => {
+  // Load the web-target wasm in Node by feeding the bytes directly.
+  const wasmPath = fileURLToPath(new URL('../../wasm/pkg/ifc-lite_bg.wasm', import.meta.url));
+  await initClashWasm(readFileSync(wasmPath));
+});
+
+describe('differential: WASM kernel === TS kernel', () => {
+  it('agrees on a hard clash', async () => {
+    const els = [box('A', 'IfcWall', [0, 0, 0]), box('B', 'IfcDuctSegment', [0.5, 0, 0])];
+    const n = await bothAgree(els, [{ id: 'r', name: 'r', a: 'IfcWall', b: 'IfcDuct*', mode: 'hard' }]);
+    expect(n).toBe(1);
+  });
+
+  it('agrees on clearance (inside and outside the gap)', async () => {
+    const els = [box('A', 'IfcWall', [0, 0, 0]), box('B', 'IfcDuctSegment', [2, 0, 0])];
+    expect(await bothAgree(els, [{ id: 'r', name: 'r', a: 'IfcWall', b: 'IfcDuct*', mode: 'clearance', clearance: 0.5 }])).toBe(0);
+    expect(await bothAgree(els, [{ id: 'r', name: 'r', a: 'IfcWall', b: 'IfcDuct*', mode: 'clearance', clearance: 1.5 }])).toBe(1);
+  });
+
+  it('agrees on touch (suppressed and reported)', async () => {
+    const els = [box('A', 'IfcWall', [0, 0, 0]), box('B', 'IfcDuctSegment', [1, 0, 0])];
+    expect(await bothAgree(els, [{ id: 'r', name: 'r', a: 'IfcWall', b: 'IfcDuct*', mode: 'hard' }])).toBe(0);
+    expect(await bothAgree(els, [{ id: 'r', name: 'r', a: 'IfcWall', b: 'IfcDuct*', mode: 'hard', reportTouch: true }])).toBe(1);
+  });
+
+  it('agrees on a self-clash', async () => {
+    const els = [
+      box('A', 'IfcBeam', [0, 0, 0]),
+      box('B', 'IfcBeam', [0.5, 0, 0]),
+      box('C', 'IfcBeam', [10, 0, 0]),
+    ];
+    expect(await bothAgree(els, [{ id: 'self', name: 'self', a: 'IfcBeam', mode: 'hard' }])).toBe(1);
+  });
+
+  it('agrees across the full discipline matrix on a mixed model', async () => {
+    const els = [
+      box('w1', 'IfcWall', [0, 0, 0]),
+      box('d1', 'IfcDuctSegment', [0.4, 0, 0]),
+      box('b1', 'IfcBeam', [0.4, 0, 0]),
+      box('p1', 'IfcPipeSegment', [3, 0, 0]),
+      box('c1', 'IfcColumn', [3.3, 0, 0]),
+      box('s1', 'IfcSlab', [3.3, 0, 0]),
+      box('cab', 'IfcCableSegment', [6, 0, 0]),
+      box('p2', 'IfcPipeSegment', [6.3, 0, 0]),
+    ];
+    const n = await bothAgree(els, disciplineMatrixRules('hard'));
+    expect(n).toBeGreaterThan(0);
+  });
+});

--- a/packages/clash/src/engine-ts/index.ts
+++ b/packages/clash/src/engine-ts/index.ts
@@ -2,151 +2,29 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { matchesSelector } from '../selectors.js';
-import { inferClashSeverity } from '../disciplines.js';
-import { isExcluded } from '../exclude.js';
-import {
-  DEFAULT_CLASH_SETTINGS,
-  type Clash,
-  type ClashElement,
-  type ClashElementRef,
-  type ClashResult,
-  type ClashRule,
-  type ClashSettings,
-  type ClashSeverity,
-  type ClashSummary,
-} from '../types.js';
-import { candidatePairs } from './broad.js';
-import { testPair } from './narrow.js';
-import { TriMesh } from './tri-mesh.js';
+import type { ClashElement, ClashResult, ClashRule, ClashSettings } from '../types.js';
+import { runClash } from './orchestrator.js';
+import { TsKernel } from './ts-kernel.js';
+
+export type { ClashKernel, NarrowRecord, RuleDetection } from './kernel.js';
+export { runClash } from './orchestrator.js';
+export { TsKernel } from './ts-kernel.js';
 
 /** A clash engine: a pure async function of (elements, rules, settings). */
 export interface ClashEngine {
   run(elements: ClashElement[], rules: ClashRule[], settings?: ClashSettings): Promise<ClashResult>;
 }
 
-/** Reference engine: spatial BVH broad phase + exact triangle narrow phase. */
+/**
+ * Reference engine: the shared orchestrator driving the pure-TypeScript geometry
+ * kernel (spatial BVH broad phase + exact triangle narrow phase).
+ */
 export class TsClashEngine implements ClashEngine {
-  async run(
+  run(
     elements: ClashElement[],
     rules: ClashRule[],
     settings: ClashSettings = {},
   ): Promise<ClashResult> {
-    const tolerance = settings.tolerance ?? DEFAULT_CLASH_SETTINGS.tolerance;
-    const excludeVoidsAndHosts =
-      settings.excludeVoidsAndHosts ?? DEFAULT_CLASH_SETTINGS.excludeVoidsAndHosts;
-    const exclusions = excludeVoidsAndHosts ? settings.exclusions : undefined;
-    const maxPairs = settings.maxCandidatePairs ?? Infinity;
-
-    const triCache = new WeakMap<ClashElement, TriMesh>();
-    const triFor = (el: ClashElement): TriMesh => {
-      let mesh = triCache.get(el);
-      if (!mesh) {
-        mesh = new TriMesh(el.positions, el.indices, el.transform);
-        triCache.set(el, mesh);
-      }
-      return mesh;
-    };
-
-    const clashes: Clash[] = [];
-    const seen = new Set<string>();
-    let droppedPairs = 0;
-
-    for (const rule of rules) {
-      const groupA = elements.filter((e) => matchesSelector(e.tag, rule.a));
-      const groupB = rule.b ? elements.filter((e) => matchesSelector(e.tag, rule.b!)) : null;
-      const ruleTolerance = rule.tolerance ?? tolerance;
-      const margin = Math.max(ruleTolerance, rule.clearance ?? 0);
-
-      const pairs = candidatePairs(groupA, groupB, margin);
-      settings.onProgress?.({ phase: 'broad', rule: rule.id, done: pairs.length, total: pairs.length });
-
-      const resolveB = groupB ?? groupA;
-      let processed = 0;
-      for (const [i, j] of pairs) {
-        if (settings.signal?.aborted) {
-          throw new DOMException('Clash run aborted', 'AbortError');
-        }
-        if (processed >= maxPairs) {
-          droppedPairs += pairs.length - processed;
-          break;
-        }
-        processed += 1;
-
-        const elA = groupA[i];
-        const elB = resolveB[j];
-        if (exclusions && isExcluded(exclusions, elA.key, elB.key)) continue;
-
-        const res = testPair(elA, triFor(elA), elB, triFor(elB), rule, ruleTolerance);
-        settings.onProgress?.({ phase: 'narrow', rule: rule.id, done: processed, total: pairs.length });
-        if (!res) continue;
-
-        const id = clashId(elA, elB, rule.id);
-        if (seen.has(id)) continue;
-        seen.add(id);
-
-        clashes.push({
-          id,
-          a: toRef(elA),
-          b: toRef(elB),
-          rule: rule.id,
-          status: res.status,
-          distance: res.distance,
-          point: res.point,
-          bounds: res.bounds,
-          severity: rule.severity ?? inferClashSeverity(elA.tag, elB.tag),
-        });
-      }
-    }
-
-    clashes.sort(byKeyThenRule);
-
-    const result: ClashResult = {
-      clashes,
-      summary: buildSummary(clashes),
-      rulesRun: rules,
-      settings: { tolerance, excludeVoidsAndHosts },
-    };
-    if (droppedPairs > 0) {
-      result.truncated = { reason: 'maxCandidatePairs', droppedPairs };
-    }
-    return result;
+    return runClash(elements, rules, settings, new TsKernel());
   }
-}
-
-function toRef(el: ClashElement): ClashElementRef {
-  return { key: el.key, ref: el.ref, model: el.model, tag: el.tag, name: el.name };
-}
-
-/** Stable, deterministic clash identity from the two durable keys + rule. */
-function clashId(a: ClashElement, b: ClashElement, ruleId: string): string {
-  const ka = `${a.model} ${a.key}`;
-  const kb = `${b.model} ${b.key}`;
-  const [lo, hi] = ka < kb ? [ka, kb] : [kb, ka];
-  return `${ruleId} ${lo} ${hi}`;
-}
-
-function byKeyThenRule(x: Clash, y: Clash): number {
-  return (
-    cmp(x.a.key, y.a.key) ||
-    cmp(x.b.key, y.b.key) ||
-    cmp(x.rule, y.rule)
-  );
-}
-
-function cmp(a: string, b: string): number {
-  return a < b ? -1 : a > b ? 1 : 0;
-}
-
-function buildSummary(clashes: Clash[]): ClashSummary {
-  const byRule: Record<string, number> = {};
-  const byTypePair: Record<string, number> = {};
-  const bySeverity: Record<ClashSeverity, number> = { critical: 0, major: 0, minor: 0, info: 0 };
-  for (const c of clashes) {
-    byRule[c.rule] = (byRule[c.rule] ?? 0) + 1;
-    const pair = [c.a.tag, c.b.tag].sort().join(' vs ');
-    byTypePair[pair] = (byTypePair[pair] ?? 0) + 1;
-    bySeverity[c.severity] += 1;
-  }
-  return { total: clashes.length, byRule, byTypePair, bySeverity };
 }

--- a/packages/clash/src/engine-ts/kernel.ts
+++ b/packages/clash/src/engine-ts/kernel.ts
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { AABB, ClashElement, ClashRule, ClashStatus, Vec3 } from '../types.js';
+
+/**
+ * One detected clash, in kernel terms: a pair of GLOBAL element indices plus the
+ * geometric verdict. The orchestrator turns this into a `Clash` (identity,
+ * severity, exclusions). This is the seam between orchestration (shared, pure
+ * TypeScript) and the geometry kernel (TypeScript today, Rust/WASM in Phase 3).
+ */
+export interface NarrowRecord {
+  /** Global index into the ingested `elements` array. */
+  a: number;
+  /** Global index into the ingested `elements` array. */
+  b: number;
+  status: ClashStatus;
+  distance: number;
+  point: Vec3;
+  bounds: AABB;
+}
+
+export interface RuleDetection {
+  records: NarrowRecord[];
+  /** Candidate pairs skipped by a `maxPairs` cap (for transparency). */
+  candidatesDropped: number;
+}
+
+/**
+ * The geometry backend: broad phase + narrow phase for one rule. Implementations
+ * must be interchangeable — given the same elements and rule they produce the
+ * same records (modulo floating-point), which is what the differential test
+ * pins. Selection, exclusions, severity and identity live in the orchestrator,
+ * never here.
+ */
+export interface ClashKernel {
+  /** Ingest the elements once (build any indices). */
+  prepare(elements: ClashElement[]): void;
+  /**
+   * Detect clashes for one rule. `groupA`/`groupB` are GLOBAL element indices;
+   * `groupB === null` means a self-clash within `groupA`. Returned records carry
+   * GLOBAL element indices. `maxPairs` caps candidate pairs (Infinity = no cap).
+   */
+  detectRule(
+    elements: ClashElement[],
+    groupA: number[],
+    groupB: number[] | null,
+    rule: ClashRule,
+    tolerance: number,
+    maxPairs: number,
+  ): RuleDetection;
+  /** Release any resources (e.g. a WASM session). Optional. */
+  dispose?(): void;
+}

--- a/packages/clash/src/engine-ts/orchestrator.ts
+++ b/packages/clash/src/engine-ts/orchestrator.ts
@@ -1,0 +1,147 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { matchesSelector } from '../selectors.js';
+import { inferClashSeverity } from '../disciplines.js';
+import { isExcluded } from '../exclude.js';
+import {
+  DEFAULT_CLASH_SETTINGS,
+  type Clash,
+  type ClashElement,
+  type ClashElementRef,
+  type ClashResult,
+  type ClashRule,
+  type ClashSettings,
+  type ClashSeverity,
+  type ClashSummary,
+} from '../types.js';
+import type { ClashKernel } from './kernel.js';
+
+/**
+ * Backend-agnostic clash orchestration: selection, exclusions, severity, stable
+ * identity, dedup, ordering and summary. The geometry (broad + narrow phase) is
+ * delegated to a `ClashKernel` (TypeScript or Rust/WASM), so swapping backends
+ * changes nothing observable except speed — which is exactly what makes the two
+ * engines differentially comparable.
+ */
+export async function runClash(
+  elements: ClashElement[],
+  rules: ClashRule[],
+  settings: ClashSettings,
+  kernel: ClashKernel,
+): Promise<ClashResult> {
+  const tolerance = settings.tolerance ?? DEFAULT_CLASH_SETTINGS.tolerance;
+  const excludeVoidsAndHosts =
+    settings.excludeVoidsAndHosts ?? DEFAULT_CLASH_SETTINGS.excludeVoidsAndHosts;
+  const exclusions = excludeVoidsAndHosts ? settings.exclusions : undefined;
+  const maxPairs = settings.maxCandidatePairs ?? Infinity;
+
+  kernel.prepare(elements);
+
+  const clashes: Clash[] = [];
+  const seen = new Set<string>();
+  let droppedPairs = 0;
+
+  for (const rule of rules) {
+    if (settings.signal?.aborted) {
+      throw new DOMException('Clash run aborted', 'AbortError');
+    }
+
+    const groupA: number[] = [];
+    const groupB: number[] | null = rule.b ? [] : null;
+    for (let i = 0; i < elements.length; i += 1) {
+      const tag = elements[i].tag;
+      if (matchesSelector(tag, rule.a)) groupA.push(i);
+      if (groupB && matchesSelector(tag, rule.b!)) groupB.push(i);
+    }
+
+    const ruleTolerance = rule.tolerance ?? tolerance;
+    settings.onProgress?.({ phase: 'broad', rule: rule.id, done: 0, total: 0 });
+
+    const { records, candidatesDropped } = kernel.detectRule(
+      elements,
+      groupA,
+      groupB,
+      rule,
+      ruleTolerance,
+      maxPairs,
+    );
+    droppedPairs += candidatesDropped;
+
+    let processed = 0;
+    for (const rec of records) {
+      if (settings.signal?.aborted) {
+        throw new DOMException('Clash run aborted', 'AbortError');
+      }
+      const elA = elements[rec.a];
+      const elB = elements[rec.b];
+      if (exclusions && isExcluded(exclusions, elA.key, elB.key)) continue;
+
+      const id = clashId(elA, elB, rule.id);
+      if (seen.has(id)) continue;
+      seen.add(id);
+
+      clashes.push({
+        id,
+        a: toRef(elA),
+        b: toRef(elB),
+        rule: rule.id,
+        status: rec.status,
+        distance: rec.distance,
+        point: rec.point,
+        bounds: rec.bounds,
+        severity: rule.severity ?? inferClashSeverity(elA.tag, elB.tag),
+      });
+      processed += 1;
+      settings.onProgress?.({ phase: 'narrow', rule: rule.id, done: processed, total: records.length });
+    }
+  }
+
+  kernel.dispose?.();
+  clashes.sort(byKeyThenRule);
+
+  const result: ClashResult = {
+    clashes,
+    summary: buildSummary(clashes),
+    rulesRun: rules,
+    settings: { tolerance, excludeVoidsAndHosts },
+  };
+  if (droppedPairs > 0) {
+    result.truncated = { reason: 'maxCandidatePairs', droppedPairs };
+  }
+  return result;
+}
+
+function toRef(el: ClashElement): ClashElementRef {
+  return { key: el.key, ref: el.ref, model: el.model, tag: el.tag, name: el.name };
+}
+
+/** Stable, deterministic clash identity from the two durable keys + rule. */
+function clashId(a: ClashElement, b: ClashElement, ruleId: string): string {
+  const ka = `${a.model} ${a.key}`;
+  const kb = `${b.model} ${b.key}`;
+  const [lo, hi] = ka < kb ? [ka, kb] : [kb, ka];
+  return `${ruleId} ${lo} ${hi}`;
+}
+
+function byKeyThenRule(x: Clash, y: Clash): number {
+  return cmp(x.a.key, y.a.key) || cmp(x.b.key, y.b.key) || cmp(x.rule, y.rule);
+}
+
+function cmp(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function buildSummary(clashes: Clash[]): ClashSummary {
+  const byRule: Record<string, number> = {};
+  const byTypePair: Record<string, number> = {};
+  const bySeverity: Record<ClashSeverity, number> = { critical: 0, major: 0, minor: 0, info: 0 };
+  for (const c of clashes) {
+    byRule[c.rule] = (byRule[c.rule] ?? 0) + 1;
+    const pair = [c.a.tag, c.b.tag].sort().join(' vs ');
+    byTypePair[pair] = (byTypePair[pair] ?? 0) + 1;
+    bySeverity[c.severity] += 1;
+  }
+  return { total: clashes.length, byRule, byTypePair, bySeverity };
+}

--- a/packages/clash/src/engine-ts/orchestrator.ts
+++ b/packages/clash/src/engine-ts/orchestrator.ts
@@ -76,6 +76,10 @@ export async function runClash(
       }
       const elA = elements[rec.a];
       const elB = elements[rec.b];
+      // Same durable key + model = one entity split across geometry sub-prims
+      // (common in IFC5/USD), not a self-clash. Filter here so every kernel —
+      // TS or WASM, regardless of how its broad phase dedups — behaves alike.
+      if (elA.key === elB.key && elA.model === elB.model) continue;
       if (exclusions && isExcluded(exclusions, elA.key, elB.key)) continue;
 
       const id = clashId(elA, elB, rule.id);

--- a/packages/clash/src/engine-ts/ts-kernel.ts
+++ b/packages/clash/src/engine-ts/ts-kernel.ts
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { ClashElement } from '../types.js';
+import { candidatePairs } from './broad.js';
+import { testPair } from './narrow.js';
+import { TriMesh } from './tri-mesh.js';
+import type { ClashKernel, NarrowRecord, RuleDetection } from './kernel.js';
+
+/**
+ * Pure-TypeScript geometry kernel: spatial BVH broad phase + exact
+ * triangle-triangle narrow phase. Also the reference oracle the Rust/WASM kernel
+ * is differentially tested against.
+ */
+export class TsKernel implements ClashKernel {
+  private readonly triCache = new WeakMap<ClashElement, TriMesh>();
+
+  prepare(): void {
+    // Triangle BVHs are built lazily per element on first use, and cached for
+    // the lifetime of this kernel so an element shared across rules pays once.
+  }
+
+  private triFor(el: ClashElement): TriMesh {
+    let mesh = this.triCache.get(el);
+    if (!mesh) {
+      mesh = new TriMesh(el.positions, el.indices, el.transform);
+      this.triCache.set(el, mesh);
+    }
+    return mesh;
+  }
+
+  detectRule(
+    elements: ClashElement[],
+    groupAIdx: number[],
+    groupBIdx: number[] | null,
+    rule: import('../types.js').ClashRule,
+    tolerance: number,
+    maxPairs: number,
+  ): RuleDetection {
+    const groupA = groupAIdx.map((i) => elements[i]);
+    const groupB = groupBIdx ? groupBIdx.map((i) => elements[i]) : null;
+    const resolveB = groupB ?? groupA;
+    const resolveBIdx = groupBIdx ?? groupAIdx;
+    const margin = Math.max(tolerance, rule.clearance ?? 0);
+
+    const pairs = candidatePairs(groupA, groupB, margin);
+    const records: NarrowRecord[] = [];
+    let processed = 0;
+    let candidatesDropped = 0;
+
+    for (const [i, j] of pairs) {
+      if (processed >= maxPairs) {
+        candidatesDropped = pairs.length - processed;
+        break;
+      }
+      processed += 1;
+      const elA = groupA[i];
+      const elB = resolveB[j];
+      const res = testPair(elA, this.triFor(elA), elB, this.triFor(elB), rule, tolerance);
+      if (!res) continue;
+      records.push({
+        a: groupAIdx[i],
+        b: resolveBIdx[j],
+        status: res.status,
+        distance: res.distance,
+        point: res.point,
+        bounds: res.bounds,
+      });
+    }
+
+    return { records, candidatesDropped };
+  }
+}

--- a/packages/clash/src/engine-wasm/index.ts
+++ b/packages/clash/src/engine-wasm/index.ts
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * WASM-backed clash engine (`@ifc-lite/clash/wasm`).
+ *
+ * Behind a subpath so `@ifc-lite/wasm` never enters the core import graph. The
+ * engine reuses the shared orchestrator with a `WasmKernel`, so its results are
+ * identical to the TS engine's (the differential test pins this).
+ */
+
+import initWasm, { ClashSession, type InitInput } from '@ifc-lite/wasm';
+import { runClash } from '../engine-ts/orchestrator.js';
+import type { ClashEngine } from '../engine-ts/index.js';
+import type { ClashElement, ClashResult, ClashRule, ClashSettings } from '../types.js';
+import { WasmKernel } from './wasm-kernel.js';
+
+let initPromise: Promise<void> | null = null;
+
+/**
+ * Initialize the WASM module once (idempotent). In a browser, call with no
+ * arguments — wasm-bindgen resolves the `.wasm` via `import.meta.url`. In Node
+ * (or any non-bundler host), pass the `.wasm` bytes (a `BufferSource`) or a URL.
+ */
+export function initClashWasm(input?: InitInput): Promise<void> {
+  if (!initPromise) {
+    const loaded = input === undefined ? initWasm() : initWasm({ module_or_path: input });
+    initPromise = loaded.then(() => undefined);
+  }
+  return initPromise;
+}
+
+export class WasmClashEngine implements ClashEngine {
+  async run(
+    elements: ClashElement[],
+    rules: ClashRule[],
+    settings: ClashSettings = {},
+  ): Promise<ClashResult> {
+    await initClashWasm();
+    const session = new ClashSession();
+    return runClash(elements, rules, settings, new WasmKernel(session));
+  }
+}
+
+export { WasmKernel } from './wasm-kernel.js';

--- a/packages/clash/src/engine-wasm/wasm-kernel.ts
+++ b/packages/clash/src/engine-wasm/wasm-kernel.ts
@@ -1,0 +1,122 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { ClashSession } from '@ifc-lite/wasm';
+import type { AABB, ClashElement, ClashRule, ClashStatus, Mat4, Vec3 } from '../types.js';
+import type { ClashKernel, NarrowRecord, RuleDetection } from '../engine-ts/kernel.js';
+
+const STATUS: ClashStatus[] = ['hard', 'clearance', 'touch'];
+
+/** Transform a point by a column-major 4x4 matrix. */
+function applyMat4(m: Mat4, x: number, y: number, z: number): Vec3 {
+  return [
+    m[0] * x + m[4] * y + m[8] * z + m[12],
+    m[1] * x + m[5] * y + m[9] * z + m[13],
+    m[2] * x + m[6] * y + m[10] * z + m[14],
+  ];
+}
+
+/**
+ * WASM geometry kernel: ingests element geometry into a Rust `ClashSession`
+ * (flat arenas) and runs each rule's broad + narrow phase in Rust. Produces the
+ * same `NarrowRecord`s as `TsKernel` — the orchestrator above is identical, so
+ * the two engines are differentially comparable.
+ *
+ * Any per-element `transform` is baked into the world-space arena here, because
+ * the Rust kernel consumes world-space geometry directly (no transform path).
+ */
+export class WasmKernel implements ClashKernel {
+  constructor(private readonly session: ClashSession) {}
+
+  prepare(elements: ClashElement[]): void {
+    const positions: number[] = [];
+    const posRanges: number[] = [];
+    const indices: number[] = [];
+    const idxRanges: number[] = [];
+    const aabbs: number[] = [];
+
+    for (const el of elements) {
+      const posOffset = positions.length;
+      const t = el.transform;
+      if (t) {
+        for (let i = 0; i + 2 < el.positions.length; i += 3) {
+          const [x, y, z] = applyMat4(t, el.positions[i], el.positions[i + 1], el.positions[i + 2]);
+          positions.push(x, y, z);
+        }
+      } else {
+        for (let i = 0; i < el.positions.length; i += 1) {
+          positions.push(el.positions[i]);
+        }
+      }
+      posRanges.push(posOffset, el.positions.length);
+
+      const idxOffset = indices.length;
+      for (let i = 0; i < el.indices.length; i += 1) {
+        indices.push(el.indices[i]);
+      }
+      idxRanges.push(idxOffset, el.indices.length);
+
+      aabbs.push(
+        el.bounds.min[0], el.bounds.min[1], el.bounds.min[2],
+        el.bounds.max[0], el.bounds.max[1], el.bounds.max[2],
+      );
+    }
+
+    this.session.ingest(
+      Float32Array.from(positions),
+      Uint32Array.from(posRanges),
+      Uint32Array.from(indices),
+      Uint32Array.from(idxRanges),
+      Float32Array.from(aabbs),
+    );
+  }
+
+  detectRule(
+    _elements: ClashElement[],
+    groupAIdx: number[],
+    groupBIdx: number[] | null,
+    rule: ClashRule,
+    tolerance: number,
+    _maxPairs: number,
+  ): RuleDetection {
+    const mode = rule.mode === 'clearance' ? 1 : 0;
+    const clearance = rule.clearance ?? 0;
+    const reportTouch = rule.reportTouch ?? false;
+    const groupA = Uint32Array.from(groupAIdx);
+    const groupB = groupBIdx ? Uint32Array.from(groupBIdx) : new Uint32Array(0);
+
+    const res = this.session.runRule(groupA, groupB, mode, tolerance, clearance, reportTouch);
+    // Each getter returns a fresh copy; read once into locals, then free.
+    const a = res.a;
+    const b = res.b;
+    const status = res.status;
+    const distance = res.distance;
+    const points = res.points;
+    const bounds = res.bounds;
+
+    const records: NarrowRecord[] = [];
+    for (let k = 0; k < a.length; k += 1) {
+      const bnds: AABB = {
+        min: [bounds[k * 6], bounds[k * 6 + 1], bounds[k * 6 + 2]],
+        max: [bounds[k * 6 + 3], bounds[k * 6 + 4], bounds[k * 6 + 5]],
+      };
+      records.push({
+        a: a[k],
+        b: b[k],
+        status: STATUS[status[k]] ?? 'hard',
+        distance: distance[k],
+        point: [points[k * 3], points[k * 3 + 1], points[k * 3 + 2]],
+        bounds: bnds,
+      });
+    }
+
+    res.free();
+    // The WASM kernel processes every candidate pair (no maxPairs cap).
+    return { records, candidatesDropped: 0 };
+  }
+
+  dispose(): void {
+    this.session.free();
+  }
+}

--- a/packages/clash/src/engine.ts
+++ b/packages/clash/src/engine.ts
@@ -21,8 +21,12 @@ export interface CreateClashEngineOptions {
 export function createClashEngine(options: CreateClashEngineOptions = {}): ClashEngine {
   const backend = options.backend ?? 'auto';
   if (backend === 'wasm') {
-    throw new Error('The WASM clash backend lands in Phase 3; use backend "ts" or "auto".');
+    throw new Error(
+      'Import { WasmClashEngine } from "@ifc-lite/clash/wasm" instead — the WASM backend ' +
+        'needs async init and is kept off the core import graph (subpath-only).',
+    );
   }
-  // 'auto' resolves to the TS engine until the WASM backend exists.
+  // 'auto' resolves to the in-process TS engine. The Rust/WASM backend is opt-in
+  // via @ifc-lite/clash/wasm (it requires an async module init before use).
   return new TsClashEngine();
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -741,6 +741,9 @@ importers:
       '@ifc-lite/spatial':
         specifier: workspace:^
         version: link:../spatial
+      '@ifc-lite/wasm':
+        specifier: workspace:^
+        version: link:../wasm
     devDependencies:
       typescript:
         specifier: ^6.0.3

--- a/rust/clash/Cargo.toml
+++ b/rust/clash/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "ifc-lite-clash"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "High-performance geometry kernel for IFC clash detection"
+keywords = ["ifc", "bim", "clash", "geometry", "aec"]
+categories = ["algorithms", "data-structures"]
+readme = "../../README.md"
+
+[dependencies]

--- a/rust/clash/src/aabb.rs
+++ b/rust/clash/src/aabb.rs
@@ -1,0 +1,133 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Axis-aligned bounding boxes and the cheap separation/overlap helpers the
+//! clash engine relies on.
+//!
+//! Faithful port of `packages/clash/src/math/aabb.ts`.
+
+use crate::vec3::Vec3;
+
+/// An axis-aligned bounding box with explicit `min`/`max` corners.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub struct Aabb {
+    pub min: [f64; 3],
+    pub max: [f64; 3],
+}
+
+impl Aabb {
+    #[inline]
+    pub fn new(min: [f64; 3], max: [f64; 3]) -> Self {
+        Self { min, max }
+    }
+
+    /// Axis-aligned bounds of a packed `[x, y, z, ...]` position buffer.
+    ///
+    /// Mirrors `fromPositions`; the optional transform from the TS source is
+    /// dropped because the native API ingests world-space geometry directly.
+    pub fn from_positions(positions: &[f64]) -> Aabb {
+        if positions.len() < 3 {
+            return Aabb::new([0.0, 0.0, 0.0], [0.0, 0.0, 0.0]);
+        }
+        let mut min = [f64::INFINITY; 3];
+        let mut max = [f64::NEG_INFINITY; 3];
+        let mut i = 0;
+        while i + 2 < positions.len() {
+            for axis in 0..3 {
+                let v = positions[i + axis];
+                if v < min[axis] {
+                    min[axis] = v;
+                }
+                if v > max[axis] {
+                    max[axis] = v;
+                }
+            }
+            i += 3;
+        }
+        Aabb::new(min, max)
+    }
+
+    /// Expand bounds by `m` on every side.
+    #[inline]
+    pub fn inflate(&self, m: f64) -> Aabb {
+        Aabb::new(
+            [self.min[0] - m, self.min[1] - m, self.min[2] - m],
+            [self.max[0] + m, self.max[1] + m, self.max[2] + m],
+        )
+    }
+
+    #[inline]
+    pub fn center(&self) -> Vec3 {
+        [
+            (self.min[0] + self.max[0]) / 2.0,
+            (self.min[1] + self.max[1]) / 2.0,
+            (self.min[2] + self.max[2]) / 2.0,
+        ]
+    }
+
+    #[inline]
+    pub fn intersects(&self, b: &Aabb) -> bool {
+        self.min[0] <= b.max[0]
+            && self.max[0] >= b.min[0]
+            && self.min[1] <= b.max[1]
+            && self.max[1] >= b.min[1]
+            && self.min[2] <= b.max[2]
+            && self.max[2] >= b.min[2]
+    }
+}
+
+/// Signed gap between two boxes: `>0` is the Euclidean separation, `<0` is the
+/// penetration depth (negative of the minimum-axis overlap).
+pub fn signed_gap(a: &Aabb, b: &Aabb) -> f64 {
+    let mut squared_distance = 0.0;
+    let mut min_overlap = f64::INFINITY;
+    let mut penetrating = true;
+    for i in 0..3 {
+        let gap = (b.min[i] - a.max[i]).max(a.min[i] - b.max[i]);
+        if gap > 0.0 {
+            squared_distance += gap * gap;
+            penetrating = false;
+        } else {
+            let overlap = a.max[i].min(b.max[i]) - a.min[i].max(b.min[i]);
+            if overlap < min_overlap {
+                min_overlap = overlap;
+            }
+        }
+    }
+    if penetrating {
+        -min_overlap
+    } else {
+        squared_distance.sqrt()
+    }
+}
+
+/// The intersection box of two overlapping bounds (clamped to be non-inverted).
+pub fn overlap_bounds(a: &Aabb, b: &Aabb) -> Aabb {
+    let mut min = [
+        a.min[0].max(b.min[0]),
+        a.min[1].max(b.min[1]),
+        a.min[2].max(b.min[2]),
+    ];
+    let mut max = [
+        a.max[0].min(b.max[0]),
+        a.max[1].min(b.max[1]),
+        a.max[2].min(b.max[2]),
+    ];
+    for i in 0..3 {
+        if max[i] < min[i] {
+            let mid = (min[i] + max[i]) / 2.0;
+            min[i] = mid;
+            max[i] = mid;
+        }
+    }
+    Aabb::new(min, max)
+}
+
+/// Bounds enclosing two points.
+pub fn bounds_of_points(a: Vec3, b: Vec3) -> Aabb {
+    Aabb::new(
+        [a[0].min(b[0]), a[1].min(b[1]), a[2].min(b[2])],
+        [a[0].max(b[0]), a[1].max(b[1]), a[2].max(b[2])],
+    )
+}

--- a/rust/clash/src/bvh.rs
+++ b/rust/clash/src/bvh.rs
@@ -1,0 +1,133 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Simple median-split AABB BVH for spatial queries.
+//!
+//! Faithful port of the `build` / `queryAABB` behaviour in
+//! `packages/spatial/src/bvh.ts`: longest-axis split, sort items by center
+//! along that axis, split the sorted list in half, and re-check leaf bounds on
+//! query. Each item carries an `id` (returned by queries) and its bounds.
+
+use crate::aabb::Aabb;
+
+struct Node {
+    bounds: Aabb,
+    left: Option<Box<Node>>,
+    right: Option<Box<Node>>,
+    /// Item ids for a leaf node; empty for internal nodes.
+    ids: Vec<u32>,
+}
+
+/// A bounding-volume hierarchy over a set of `(id, bounds)` items.
+pub struct Bvh {
+    root: Option<Box<Node>>,
+    bounds: Vec<Aabb>,
+    ids: Vec<u32>,
+}
+
+impl Bvh {
+    /// Build a BVH from `items` of `(id, bounds)`. `id` is what queries return.
+    pub fn build(items: &[(u32, Aabb)]) -> Self {
+        let bounds: Vec<Aabb> = items.iter().map(|&(_, b)| b).collect();
+        let ids: Vec<u32> = items.iter().map(|&(id, _)| id).collect();
+        let root = if items.is_empty() {
+            None
+        } else {
+            let mut indices: Vec<usize> = (0..items.len()).collect();
+            Some(build_node(&mut indices, &bounds))
+        };
+        Self { root, bounds, ids }
+    }
+
+    /// Return the ids of items whose bounds intersect `query`.
+    pub fn query_aabb(&self, query: &Aabb) -> Vec<u32> {
+        let mut results = Vec::new();
+        if let Some(root) = &self.root {
+            self.query_node(root, query, &mut results);
+        }
+        results
+    }
+
+    fn query_node(&self, node: &Node, query: &Aabb, results: &mut Vec<u32>) {
+        if !node.bounds.intersects(query) {
+            return;
+        }
+        if !node.ids.is_empty() {
+            for &idx in &node.ids {
+                if self.bounds[idx as usize].intersects(query) {
+                    results.push(self.ids[idx as usize]);
+                }
+            }
+        } else {
+            if let Some(left) = &node.left {
+                self.query_node(left, query, results);
+            }
+            if let Some(right) = &node.right {
+                self.query_node(right, query, results);
+            }
+        }
+    }
+}
+
+fn compute_bounds(indices: &[usize], bounds: &[Aabb]) -> Aabb {
+    let mut min = [f64::INFINITY; 3];
+    let mut max = [f64::NEG_INFINITY; 3];
+    for &idx in indices {
+        let b = &bounds[idx];
+        for axis in 0..3 {
+            if b.min[axis] < min[axis] {
+                min[axis] = b.min[axis];
+            }
+            if b.max[axis] > max[axis] {
+                max[axis] = b.max[axis];
+            }
+        }
+    }
+    Aabb::new(min, max)
+}
+
+fn build_node(indices: &mut [usize], bounds: &[Aabb]) -> Box<Node> {
+    if indices.len() == 1 {
+        let idx = indices[0];
+        return Box::new(Node {
+            bounds: bounds[idx],
+            left: None,
+            right: None,
+            ids: vec![idx as u32],
+        });
+    }
+
+    let node_bounds = compute_bounds(indices, bounds);
+
+    // Choose split axis (longest axis), matching the TS tie-breaking exactly.
+    let extent = [
+        node_bounds.max[0] - node_bounds.min[0],
+        node_bounds.max[1] - node_bounds.min[1],
+        node_bounds.max[2] - node_bounds.min[2],
+    ];
+    let axis = if extent[0] > extent[1] && extent[0] > extent[2] {
+        0
+    } else if extent[1] > extent[2] {
+        1
+    } else {
+        2
+    };
+
+    // Sort by center along axis. The TS comparator subtracts centers; a stable
+    // sort by that key reproduces the same ordering.
+    indices.sort_by(|&a, &b| {
+        let ca = (bounds[a].min[axis] + bounds[a].max[axis]) / 2.0;
+        let cb = (bounds[b].min[axis] + bounds[b].max[axis]) / 2.0;
+        ca.partial_cmp(&cb).unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    let mid = indices.len() / 2;
+    let (left_indices, right_indices) = indices.split_at_mut(mid);
+    Box::new(Node {
+        bounds: node_bounds,
+        left: Some(build_node(left_indices, bounds)),
+        right: Some(build_node(right_indices, bounds)),
+        ids: Vec::new(),
+    })
+}

--- a/rust/clash/src/lib.rs
+++ b/rust/clash/src/lib.rs
@@ -1,0 +1,45 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! # IFC-Lite Clash
+//!
+//! High-performance geometry kernel for clash detection. This is a faithful
+//! native port of the TypeScript reference engine in `packages/clash`: the same
+//! AABB/vector math, triangle-triangle intersection (SAT) and minimum-distance
+//! routines, per-element triangle BVHs, broad-phase candidate generation, and —
+//! crucially — the exact narrow-phase classification.
+//!
+//! All geometric computation is performed in `f64`, even though vertices and
+//! AABBs are sourced from `f32` buffers.
+//!
+//! ## Usage
+//!
+//! ```
+//! use ifc_lite_clash::ClashSession;
+//!
+//! let mut session = ClashSession::new();
+//! // positions: concatenated per-element vertex coords (x, y, z, ...)
+//! // pos_ranges: [float_offset, float_len] per element
+//! // indices: concatenated per-element LOCAL triangle indices
+//! // idx_ranges: [idx_offset, idx_len] per element
+//! // aabbs: [minx, miny, minz, maxx, maxy, maxz] per element
+//! session.ingest(&[], &[], &[], &[], &[]);
+//! let result = session.run_rule(&[], &[], 0, 0.0, 0.0, false);
+//! assert!(result.records.is_empty());
+//! ```
+
+mod aabb;
+mod bvh;
+mod narrow;
+mod triangle;
+mod tri_mesh;
+mod vec3;
+mod session;
+
+pub use aabb::Aabb;
+pub use narrow::ClashStatus;
+pub use session::{ClashRecord, ClashSession, RuleResult};
+
+#[cfg(test)]
+mod tests;

--- a/rust/clash/src/narrow.rs
+++ b/rust/clash/src/narrow.rs
@@ -1,0 +1,151 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Narrow-phase classification for one candidate element pair.
+//!
+//! Faithful port of `packages/clash/src/engine-ts/narrow.ts`. The control flow,
+//! comparisons, and result construction match the TS reference bit-for-bit in
+//! logic so this kernel and the TS engine agree on classification.
+
+use crate::aabb::{bounds_of_points, overlap_bounds, signed_gap, Aabb};
+use crate::triangle::{tri_tri_distance, tri_tri_intersect};
+use crate::tri_mesh::TriMesh;
+use crate::vec3::{centroid, mid, Vec3};
+
+/// Clash classification. Discriminants match the public ABI (`Hard = 0`, etc.).
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum ClashStatus {
+    Hard = 0,
+    Clearance = 1,
+    Touch = 2,
+}
+
+/// The narrow-phase outcome for one element pair.
+pub struct NarrowResult {
+    pub status: ClashStatus,
+    pub distance: f64,
+    pub point: Vec3,
+    pub bounds: Aabb,
+}
+
+/// Run the narrow phase for a candidate element pair.
+///
+/// `mode`: `0` = hard, `1` = clearance. `tolerance` and `clearance` carry the
+/// rule parameters; `report_touch` toggles face-contact reporting. Returns
+/// `None` when the pair is not a clash.
+#[allow(clippy::too_many_arguments)]
+pub fn test_pair(
+    aabb_a: &Aabb,
+    tri_a: &TriMesh,
+    aabb_b: &Aabb,
+    tri_b: &TriMesh,
+    mode: u8,
+    tolerance: f64,
+    clearance: f64,
+    report_touch: bool,
+) -> Option<NarrowResult> {
+    let is_clearance = mode == 1;
+    let margin = tolerance.max(if is_clearance { clearance } else { 0.0 });
+
+    // Iterate the smaller mesh, querying the larger one's BVH.
+    let a_smaller = tri_a.count <= tri_b.count;
+    let (small, large) = if a_smaller {
+        (tri_a, tri_b)
+    } else {
+        (tri_b, tri_a)
+    };
+
+    let mut intersects = false;
+    let mut contact_sum: [f64; 3] = [0.0, 0.0, 0.0];
+    let mut contact_n: u32 = 0;
+    let mut min_dist = f64::INFINITY;
+    let mut closest_a: Vec3 = aabb_a.min;
+    let mut closest_b: Vec3 = aabb_b.min;
+
+    for ts in 0..small.count {
+        let sb = small.tri_bounds(ts);
+        let hits = large.query_tris(&sb.inflate(margin));
+        if hits.is_empty() {
+            continue;
+        }
+        let [s0, s1, s2] = small.tri(ts);
+        for tl in hits {
+            let [l0, l1, l2] = large.tri(tl as usize);
+            if tri_tri_intersect(s0, s1, s2, l0, l1, l2) {
+                intersects = true;
+                let c = mid(centroid(s0, s1, s2), centroid(l0, l1, l2));
+                contact_sum[0] += c[0];
+                contact_sum[1] += c[1];
+                contact_sum[2] += c[2];
+                contact_n += 1;
+            } else if !intersects {
+                // Distance only matters while we might still be clearance/touch.
+                let (dist, p_a, p_b) = tri_tri_distance(s0, s1, s2, l0, l1, l2);
+                if dist < min_dist {
+                    min_dist = dist;
+                    closest_a = p_a;
+                    closest_b = p_b;
+                }
+            }
+        }
+    }
+
+    let overlap = overlap_bounds(aabb_a, aabb_b);
+
+    if intersects {
+        let point: Vec3 = if contact_n > 0 {
+            let n = contact_n as f64;
+            [contact_sum[0] / n, contact_sum[1] / n, contact_sum[2] / n]
+        } else {
+            overlap.center()
+        };
+        // Phase-0 penetration estimate from AABB overlap.
+        let penetration = (-signed_gap(aabb_a, aabb_b)).max(0.0);
+        return Some(NarrowResult {
+            status: ClashStatus::Hard,
+            distance: -penetration,
+            point,
+            bounds: overlap,
+        });
+    }
+
+    if min_dist == f64::INFINITY {
+        // Broad-phase candidate with no triangle-level proximity — not a clash.
+        return None;
+    }
+
+    if min_dist < tolerance {
+        // Surfaces coincide/touch with no genuine crossing. Distinguish a
+        // volumetric overlap from mere face contact via AABB penetration depth.
+        let gap = signed_gap(aabb_a, aabb_b);
+        if gap < -tolerance {
+            return Some(NarrowResult {
+                status: ClashStatus::Hard,
+                distance: gap,
+                point: overlap.center(),
+                bounds: overlap,
+            });
+        }
+        if !report_touch {
+            return None;
+        }
+        return Some(NarrowResult {
+            status: ClashStatus::Touch,
+            distance: min_dist,
+            point: mid(closest_a, closest_b),
+            bounds: bounds_of_points(closest_a, closest_b),
+        });
+    }
+
+    if is_clearance && min_dist <= clearance {
+        return Some(NarrowResult {
+            status: ClashStatus::Clearance,
+            distance: min_dist,
+            point: mid(closest_a, closest_b),
+            bounds: bounds_of_points(closest_a, closest_b),
+        });
+    }
+
+    None
+}

--- a/rust/clash/src/session.rs
+++ b/rust/clash/src/session.rs
@@ -1,0 +1,267 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Public clash session: ingest element geometry, then run rules.
+//!
+//! The broad phase mirrors `packages/clash/src/engine-ts/broad.ts` (BVH over
+//! group_a element AABBs, query each group_b element inflated by `margin`); the
+//! narrow phase delegates to [`crate::narrow::test_pair`]. Records carry GLOBAL
+//! element indices.
+
+use std::cell::RefCell;
+use std::collections::HashSet;
+
+use crate::aabb::Aabb;
+use crate::bvh::Bvh;
+use crate::narrow::{test_pair, ClashStatus};
+use crate::tri_mesh::TriMesh;
+
+/// One classified clash between two elements (GLOBAL element indices).
+pub struct ClashRecord {
+    pub a: u32,
+    pub b: u32,
+    pub status: ClashStatus,
+    pub distance: f64,
+    pub point: [f64; 3],
+    /// `[minx, miny, minz, maxx, maxy, maxz]`.
+    pub bounds: [f64; 6],
+}
+
+/// The records produced by a single rule run.
+pub struct RuleResult {
+    pub records: Vec<ClashRecord>,
+}
+
+/// Per-element geometry plus a lazily built per-triangle BVH.
+struct Element {
+    aabb: Aabb,
+    positions: Vec<f64>,
+    indices: Vec<u32>,
+    /// Built on first narrow-phase use, then cached for the session lifetime.
+    mesh: RefCell<Option<TriMesh>>,
+}
+
+/// A clash session: stores per-element geometry, element AABBs, and caches the
+/// per-element triangle BVHs that the narrow phase needs.
+pub struct ClashSession {
+    elements: Vec<Element>,
+}
+
+impl Default for ClashSession {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ClashSession {
+    pub fn new() -> Self {
+        Self {
+            elements: Vec::new(),
+        }
+    }
+
+    /// Ingest `N` elements from flat arenas.
+    ///
+    /// - `positions`: concatenated per-element vertex coords (`x, y, z, ...`).
+    /// - `pos_ranges`: 2 per element = `[float_offset, float_len]`.
+    /// - `indices`: concatenated per-element LOCAL (0-based within that
+    ///   element's vertices) triangle indices.
+    /// - `idx_ranges`: 2 per element = `[idx_offset, idx_len]`.
+    /// - `aabbs`: 6 per element = `[minx, miny, minz, maxx, maxy, maxz]`.
+    ///
+    /// Vertex/AABB coords are `f32`-sourced; they are stored and computed in
+    /// `f64`.
+    pub fn ingest(
+        &mut self,
+        positions: &[f32],
+        pos_ranges: &[u32],
+        indices: &[u32],
+        idx_ranges: &[u32],
+        aabbs: &[f32],
+    ) {
+        let n = pos_ranges.len() / 2;
+        self.elements.reserve(n);
+        for e in 0..n {
+            let pos_off = pos_ranges[e * 2] as usize;
+            let pos_len = pos_ranges[e * 2 + 1] as usize;
+            let idx_off = idx_ranges[e * 2] as usize;
+            let idx_len = idx_ranges[e * 2 + 1] as usize;
+
+            let element_positions: Vec<f64> = positions[pos_off..pos_off + pos_len]
+                .iter()
+                .map(|&v| v as f64)
+                .collect();
+            let element_indices: Vec<u32> = indices[idx_off..idx_off + idx_len].to_vec();
+
+            let ab = e * 6;
+            let aabb = Aabb::new(
+                [
+                    aabbs[ab] as f64,
+                    aabbs[ab + 1] as f64,
+                    aabbs[ab + 2] as f64,
+                ],
+                [
+                    aabbs[ab + 3] as f64,
+                    aabbs[ab + 4] as f64,
+                    aabbs[ab + 5] as f64,
+                ],
+            );
+
+            self.elements.push(Element {
+                aabb,
+                positions: element_positions,
+                indices: element_indices,
+                mesh: RefCell::new(None),
+            });
+        }
+    }
+
+    /// Build (or reuse) the cached triangle mesh for global element `idx` and
+    /// run `f` against it. Avoids re-borrowing the `RefCell` across the call.
+    fn with_mesh<R>(&self, idx: u32, f: impl FnOnce(&TriMesh) -> R) -> R {
+        let element = &self.elements[idx as usize];
+        {
+            let mut slot = element.mesh.borrow_mut();
+            if slot.is_none() {
+                *slot = Some(TriMesh::new(
+                    element.positions.clone(),
+                    element.indices.clone(),
+                ));
+            }
+        }
+        let slot = element.mesh.borrow();
+        f(slot.as_ref().expect("mesh built above"))
+    }
+
+    /// Run one rule.
+    ///
+    /// `group_a` / `group_b` are GLOBAL element indices. An empty `group_b`
+    /// requests a self-clash within `group_a` (pairs with `i < j` by position
+    /// in `group_a`). `mode`: `0` = hard, `1` = clearance. Records carry GLOBAL
+    /// element indices.
+    #[allow(clippy::too_many_arguments)]
+    pub fn run_rule(
+        &self,
+        group_a: &[u32],
+        group_b: &[u32],
+        mode: u8,
+        tolerance: f64,
+        clearance: f64,
+        report_touch: bool,
+    ) -> RuleResult {
+        let is_clearance = mode == 1;
+        let margin = tolerance.max(if is_clearance { clearance } else { 0.0 });
+
+        let pairs = self.candidate_pairs(group_a, group_b, margin);
+
+        let mut records = Vec::new();
+        for (a_global, b_global) in pairs {
+            let result = self.with_mesh(a_global, |mesh_a| {
+                self.with_mesh(b_global, |mesh_b| {
+                    test_pair(
+                        &self.elements[a_global as usize].aabb,
+                        mesh_a,
+                        &self.elements[b_global as usize].aabb,
+                        mesh_b,
+                        mode,
+                        tolerance,
+                        clearance,
+                        report_touch,
+                    )
+                })
+            });
+            if let Some(r) = result {
+                records.push(ClashRecord {
+                    a: a_global,
+                    b: b_global,
+                    status: r.status,
+                    distance: r.distance,
+                    point: r.point,
+                    bounds: [
+                        r.bounds.min[0],
+                        r.bounds.min[1],
+                        r.bounds.min[2],
+                        r.bounds.max[0],
+                        r.bounds.max[1],
+                        r.bounds.max[2],
+                    ],
+                });
+            }
+        }
+
+        RuleResult { records }
+    }
+
+    /// Broad-phase candidate global-index pairs.
+    ///
+    /// Builds a BVH over `group_a`'s element AABBs. For a group pair, each
+    /// `group_b` element queries inflated by `margin`; duplicates are removed
+    /// and identical element indices are skipped. For self-clash (`group_b`
+    /// empty) each `group_a` element queries the BVH, keeping pairs whose
+    /// position in `group_a` satisfies `i < j`.
+    fn candidate_pairs(
+        &self,
+        group_a: &[u32],
+        group_b: &[u32],
+        margin: f64,
+    ) -> Vec<(u32, u32)> {
+        if group_a.is_empty() {
+            return Vec::new();
+        }
+
+        // BVH item id is the POSITION in group_a, so query hits map back to the
+        // group_a slot (and thus the global element index).
+        let items: Vec<(u32, Aabb)> = group_a
+            .iter()
+            .enumerate()
+            .map(|(i, &g)| (i as u32, self.elements[g as usize].aabb))
+            .collect();
+        let bvh = Bvh::build(&items);
+
+        let mut pairs: Vec<(u32, u32)> = Vec::new();
+
+        if !group_b.is_empty() {
+            let mut seen: HashSet<(u32, u32)> = HashSet::new();
+            for &b_global in group_b {
+                let b_aabb = self.elements[b_global as usize].aabb;
+                let hits = bvh.query_aabb(&b_aabb.inflate(margin));
+                for i in hits {
+                    let a_global = group_a[i as usize];
+                    // Skip identical element index (same entity).
+                    if a_global == b_global {
+                        continue;
+                    }
+                    let dedup = if a_global < b_global {
+                        (a_global, b_global)
+                    } else {
+                        (b_global, a_global)
+                    };
+                    if !seen.insert(dedup) {
+                        continue;
+                    }
+                    pairs.push((a_global, b_global));
+                }
+            }
+        } else {
+            for (i, &a_global) in group_a.iter().enumerate() {
+                let a_aabb = self.elements[a_global as usize].aabb;
+                let hits = bvh.query_aabb(&a_aabb.inflate(margin));
+                for j in hits {
+                    let j = j as usize;
+                    if j <= i {
+                        continue;
+                    }
+                    let b_global = group_a[j];
+                    // Skip identical element index (same entity).
+                    if a_global == b_global {
+                        continue;
+                    }
+                    pairs.push((a_global, b_global));
+                }
+            }
+        }
+
+        pairs
+    }
+}

--- a/rust/clash/src/tests.rs
+++ b/rust/clash/src/tests.rs
@@ -1,0 +1,201 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Golden tests mirroring the TypeScript reference suite plus triangle-math
+//! unit tests.
+
+use crate::narrow::ClashStatus;
+use crate::session::ClashSession;
+use crate::triangle::{tri_tri_distance, tri_tri_intersect};
+use crate::vec3::Vec3;
+
+/// Axis-aligned unit cube (side 1) centred at `[cx, cy, cz]`.
+///
+/// Returns `(positions, indices, aabb)`: 8 vertices packed `x, y, z`, 12
+/// triangles as LOCAL (0-based) indices, and the 6-float AABB
+/// `[minx, miny, minz, maxx, maxy, maxz]`.
+fn unit_cube(cx: f32, cy: f32, cz: f32) -> (Vec<f32>, Vec<u32>, Vec<f32>) {
+    let h = 0.5f32;
+    // 8 corners.
+    let corners = [
+        [cx - h, cy - h, cz - h],
+        [cx + h, cy - h, cz - h],
+        [cx + h, cy + h, cz - h],
+        [cx - h, cy + h, cz - h],
+        [cx - h, cy - h, cz + h],
+        [cx + h, cy - h, cz + h],
+        [cx + h, cy + h, cz + h],
+        [cx - h, cy + h, cz + h],
+    ];
+    let mut positions = Vec::with_capacity(24);
+    for c in &corners {
+        positions.extend_from_slice(c);
+    }
+    // 12 triangles (two per face), winding is irrelevant for these tests.
+    let indices: Vec<u32> = vec![
+        // -z
+        0, 1, 2, 0, 2, 3, // +z
+        4, 6, 5, 4, 7, 6, // -y
+        0, 5, 1, 0, 4, 5, // +y
+        3, 2, 6, 3, 6, 7, // -x
+        0, 3, 7, 0, 7, 4, // +x
+        1, 5, 6, 1, 6, 2,
+    ];
+    let aabb = vec![cx - h, cy - h, cz - h, cx + h, cy + h, cz + h];
+    (positions, indices, aabb)
+}
+
+/// Build a session from a list of cubes, packing the flat arenas the API needs.
+fn session_of_cubes(cubes: &[(f32, f32, f32)]) -> ClashSession {
+    let mut positions: Vec<f32> = Vec::new();
+    let mut pos_ranges: Vec<u32> = Vec::new();
+    let mut indices: Vec<u32> = Vec::new();
+    let mut idx_ranges: Vec<u32> = Vec::new();
+    let mut aabbs: Vec<f32> = Vec::new();
+
+    for &(cx, cy, cz) in cubes {
+        let (p, idx, ab) = unit_cube(cx, cy, cz);
+        let pos_off = positions.len() as u32;
+        let pos_len = p.len() as u32;
+        let idx_off = indices.len() as u32;
+        let idx_len = idx.len() as u32;
+
+        positions.extend_from_slice(&p);
+        indices.extend_from_slice(&idx);
+        aabbs.extend_from_slice(&ab);
+        pos_ranges.push(pos_off);
+        pos_ranges.push(pos_len);
+        idx_ranges.push(idx_off);
+        idx_ranges.push(idx_len);
+    }
+
+    let mut session = ClashSession::new();
+    session.ingest(&positions, &pos_ranges, &indices, &idx_ranges, &aabbs);
+    session
+}
+
+const HARD: u8 = 0;
+const CLEARANCE: u8 = 1;
+
+#[test]
+fn overlapping_cubes_hard() {
+    let session = session_of_cubes(&[(0.0, 0.0, 0.0), (0.5, 0.0, 0.0)]);
+    let result = session.run_rule(&[0, 1], &[], HARD, 0.001, 0.0, false);
+    assert_eq!(result.records.len(), 1, "expected exactly one hard clash");
+    let rec = &result.records[0];
+    assert_eq!(rec.status, ClashStatus::Hard);
+    assert!(rec.distance < 0.0, "penetration distance must be negative, got {}", rec.distance);
+}
+
+#[test]
+fn separated_cubes_hard_none() {
+    let session = session_of_cubes(&[(0.0, 0.0, 0.0), (2.0, 0.0, 0.0)]);
+    let result = session.run_rule(&[0, 1], &[], HARD, 0.001, 0.0, false);
+    assert_eq!(result.records.len(), 0, "separated cubes are not a hard clash");
+}
+
+#[test]
+fn separated_cubes_clearance_hit() {
+    // Cubes at x=0 and x=2: faces at x=0.5 and x=1.5 -> gap 1.0.
+    let session = session_of_cubes(&[(0.0, 0.0, 0.0), (2.0, 0.0, 0.0)]);
+    let result = session.run_rule(&[0, 1], &[], CLEARANCE, 0.001, 1.5, false);
+    assert_eq!(result.records.len(), 1, "clearance 1.5 should report the gap");
+    let rec = &result.records[0];
+    assert_eq!(rec.status, ClashStatus::Clearance);
+    assert!((rec.distance - 1.0).abs() < 1e-6, "gap should be ~1.0, got {}", rec.distance);
+}
+
+#[test]
+fn separated_cubes_clearance_miss() {
+    let session = session_of_cubes(&[(0.0, 0.0, 0.0), (2.0, 0.0, 0.0)]);
+    let result = session.run_rule(&[0, 1], &[], CLEARANCE, 0.001, 0.5, false);
+    assert_eq!(result.records.len(), 0, "clearance 0.5 < gap 1.0 -> no record");
+}
+
+#[test]
+fn touching_faces_no_touch_report() {
+    // Cubes at x=0 and x=1: faces coincide at x=0.5 -> contact, not penetration.
+    let session = session_of_cubes(&[(0.0, 0.0, 0.0), (1.0, 0.0, 0.0)]);
+    let result = session.run_rule(&[0, 1], &[], HARD, 0.001, 0.0, false);
+    assert_eq!(result.records.len(), 0, "touch with report_touch=false -> none");
+}
+
+#[test]
+fn touching_faces_with_touch_report() {
+    let session = session_of_cubes(&[(0.0, 0.0, 0.0), (1.0, 0.0, 0.0)]);
+    let result = session.run_rule(&[0, 1], &[], HARD, 0.001, 0.0, true);
+    assert_eq!(result.records.len(), 1, "touch with report_touch=true -> one record");
+    assert_eq!(result.records[0].status, ClashStatus::Touch);
+}
+
+#[test]
+fn self_clash_group() {
+    // Three cubes: two overlap, one is far away. group_b empty -> self-clash.
+    let session = session_of_cubes(&[(0.0, 0.0, 0.0), (0.5, 0.0, 0.0), (10.0, 0.0, 0.0)]);
+    let result = session.run_rule(&[0, 1, 2], &[], HARD, 0.001, 0.0, false);
+    assert_eq!(result.records.len(), 1, "only the overlapping pair clashes");
+    let rec = &result.records[0];
+    assert_eq!(rec.status, ClashStatus::Hard);
+    // Records carry GLOBAL element indices; the overlapping pair is (0, 1).
+    assert_eq!((rec.a, rec.b), (0, 1));
+}
+
+// --- Triangle math unit tests -------------------------------------------------
+
+#[test]
+fn tritri_intersect_piercing() {
+    // Triangle A in the z=0 plane; triangle B pierces straight through it.
+    let a0: Vec3 = [-1.0, -1.0, 0.0];
+    let a1: Vec3 = [1.0, -1.0, 0.0];
+    let a2: Vec3 = [0.0, 1.0, 0.0];
+    let b0: Vec3 = [0.0, 0.0, -1.0];
+    let b1: Vec3 = [0.0, 0.0, 1.0];
+    let b2: Vec3 = [0.5, 0.5, 0.0];
+    assert!(tri_tri_intersect(a0, a1, a2, b0, b1, b2), "piercing should intersect");
+}
+
+#[test]
+fn tritri_intersect_separated() {
+    let a0: Vec3 = [-1.0, -1.0, 0.0];
+    let a1: Vec3 = [1.0, -1.0, 0.0];
+    let a2: Vec3 = [0.0, 1.0, 0.0];
+    // Same triangle translated +2 in z: clearly separated.
+    let b0: Vec3 = [-1.0, -1.0, 2.0];
+    let b1: Vec3 = [1.0, -1.0, 2.0];
+    let b2: Vec3 = [0.0, 1.0, 2.0];
+    assert!(!tri_tri_intersect(a0, a1, a2, b0, b1, b2), "separated should not intersect");
+}
+
+#[test]
+fn tritri_intersect_coincident() {
+    // Identical coplanar triangles: coplanar overlap is treated as touching,
+    // i.e. NOT a hard intersection.
+    let a0: Vec3 = [-1.0, -1.0, 0.0];
+    let a1: Vec3 = [1.0, -1.0, 0.0];
+    let a2: Vec3 = [0.0, 1.0, 0.0];
+    assert!(!tri_tri_intersect(a0, a1, a2, a0, a1, a2), "coincident should not intersect");
+}
+
+#[test]
+fn tritri_distance_parallel_gap() {
+    let a0: Vec3 = [-1.0, -1.0, 0.0];
+    let a1: Vec3 = [1.0, -1.0, 0.0];
+    let a2: Vec3 = [0.0, 1.0, 0.0];
+    // Same triangle, shifted +0.5 in z.
+    let b0: Vec3 = [-1.0, -1.0, 0.5];
+    let b1: Vec3 = [1.0, -1.0, 0.5];
+    let b2: Vec3 = [0.0, 1.0, 0.5];
+    let (dist, _, _) = tri_tri_distance(a0, a1, a2, b0, b1, b2);
+    assert!((dist - 0.5).abs() < 1e-9, "parallel gap should be 0.5, got {dist}");
+}
+
+#[test]
+fn tritri_distance_touching() {
+    let a0: Vec3 = [-1.0, -1.0, 0.0];
+    let a1: Vec3 = [1.0, -1.0, 0.0];
+    let a2: Vec3 = [0.0, 1.0, 0.0];
+    // Coplanar, sharing the vertex region -> distance ~0.
+    let (dist, _, _) = tri_tri_distance(a0, a1, a2, a0, a1, a2);
+    assert!(dist.abs() < 1e-9, "coincident triangles distance should be 0, got {dist}");
+}

--- a/rust/clash/src/tri_mesh.rs
+++ b/rust/clash/src/tri_mesh.rs
@@ -1,0 +1,102 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Per-element triangle mesh with a per-triangle BVH for narrow-phase queries.
+//!
+//! Faithful port of `packages/clash/src/engine-ts/tri-mesh.ts`. Geometry is
+//! ingested from `f32` buffers but stored and queried in `f64`; vertices are
+//! already world-space, so no transform is applied.
+
+use crate::aabb::Aabb;
+use crate::bvh::Bvh;
+use crate::vec3::Vec3;
+
+/// A triangle mesh with a per-triangle BVH over its triangle AABBs.
+pub struct TriMesh {
+    /// World-space vertex coordinates, packed `[x, y, z, ...]` in `f64`.
+    positions: Vec<f64>,
+    /// Triangle indices, local (0-based) within this mesh's vertices.
+    indices: Vec<u32>,
+    /// Number of triangles.
+    pub count: usize,
+    bvh: Bvh,
+}
+
+impl TriMesh {
+    /// Build from world-space `positions` (`f64`) and local triangle `indices`.
+    pub fn new(positions: Vec<f64>, indices: Vec<u32>) -> Self {
+        let count = indices.len() / 3;
+        let mut items: Vec<(u32, Aabb)> = Vec::with_capacity(count);
+        // Build the per-triangle bounds inline so we can populate the BVH before
+        // moving the buffers into the struct.
+        for t in 0..count {
+            let bounds = tri_bounds(&positions, &indices, t);
+            items.push((t as u32, bounds));
+        }
+        let bvh = Bvh::build(&items);
+        Self {
+            positions,
+            indices,
+            count,
+            bvh,
+        }
+    }
+
+    /// World-space vertex `i`.
+    #[inline]
+    pub fn vertex(&self, i: u32) -> Vec3 {
+        let o = (i as usize) * 3;
+        [self.positions[o], self.positions[o + 1], self.positions[o + 2]]
+    }
+
+    /// The three world-space vertices of triangle `t`.
+    #[inline]
+    pub fn tri(&self, t: usize) -> [Vec3; 3] {
+        let o = t * 3;
+        [
+            self.vertex(self.indices[o]),
+            self.vertex(self.indices[o + 1]),
+            self.vertex(self.indices[o + 2]),
+        ]
+    }
+
+    /// Axis-aligned bounds of triangle `t`.
+    #[inline]
+    pub fn tri_bounds(&self, t: usize) -> Aabb {
+        tri_bounds(&self.positions, &self.indices, t)
+    }
+
+    /// Triangle indices whose bounds intersect `bounds`.
+    pub fn query_tris(&self, bounds: &Aabb) -> Vec<u32> {
+        if self.count == 0 {
+            return Vec::new();
+        }
+        self.bvh.query_aabb(bounds)
+    }
+}
+
+fn tri_bounds(positions: &[f64], indices: &[u32], t: usize) -> Aabb {
+    let o = t * 3;
+    let va = vertex(positions, indices[o]);
+    let vb = vertex(positions, indices[o + 1]);
+    let vc = vertex(positions, indices[o + 2]);
+    Aabb::new(
+        [
+            va[0].min(vb[0]).min(vc[0]),
+            va[1].min(vb[1]).min(vc[1]),
+            va[2].min(vb[2]).min(vc[2]),
+        ],
+        [
+            va[0].max(vb[0]).max(vc[0]),
+            va[1].max(vb[1]).max(vc[1]),
+            va[2].max(vb[2]).max(vc[2]),
+        ],
+    )
+}
+
+#[inline]
+fn vertex(positions: &[f64], i: u32) -> Vec3 {
+    let o = (i as usize) * 3;
+    [positions[o], positions[o + 1], positions[o + 2]]
+}

--- a/rust/clash/src/triangle.rs
+++ b/rust/clash/src/triangle.rs
@@ -1,0 +1,249 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Triangle-triangle intersection (SAT) and minimum-distance routines.
+//!
+//! Faithful port of `packages/clash/src/math/triangle-intersect.ts` and
+//! `triangle-distance.ts`.
+
+use crate::vec3::{add, cross, dist_sq, dot, scale, sub, Vec3};
+
+const EPS: f64 = 1e-12;
+
+/// Exact triangle-triangle intersection via the Separating Axis Theorem.
+///
+/// Tests the 2 face normals plus the up-to-9 edge-edge cross-product axes
+/// (axes whose squared length is `<= eps` are skipped). Returns `true` only
+/// when the triangle *interiors* overlap; bare touching (coincident
+/// faces/edges/vertices) reports `false`. The `<=` comparison makes exact
+/// contact count as separation (a touch), not interpenetration.
+pub fn tri_tri_intersect(
+    a0: Vec3,
+    a1: Vec3,
+    a2: Vec3,
+    b0: Vec3,
+    b1: Vec3,
+    b2: Vec3,
+) -> bool {
+    let edges_a = [sub(a1, a0), sub(a2, a1), sub(a0, a2)];
+    let edges_b = [sub(b1, b0), sub(b2, b1), sub(b0, b2)];
+
+    let mut axes: Vec<Vec3> = Vec::with_capacity(11);
+    axes.push(cross(edges_a[0], edges_a[1]));
+    axes.push(cross(edges_b[0], edges_b[1]));
+    for &ea in &edges_a {
+        for &eb in &edges_b {
+            let axis = cross(ea, eb);
+            if dot(axis, axis) > EPS {
+                axes.push(axis);
+            }
+        }
+    }
+
+    let va = [a0, a1, a2];
+    let vb = [b0, b1, b2];
+
+    for axis in axes {
+        let mut min_a = f64::INFINITY;
+        let mut max_a = f64::NEG_INFINITY;
+        let mut min_b = f64::INFINITY;
+        let mut max_b = f64::NEG_INFINITY;
+        for &v in &va {
+            let p = dot(v, axis);
+            if p < min_a {
+                min_a = p;
+            }
+            if p > max_a {
+                max_a = p;
+            }
+        }
+        for &v in &vb {
+            let p = dot(v, axis);
+            if p < min_b {
+                min_b = p;
+            }
+            if p > max_b {
+                max_b = p;
+            }
+        }
+        // `<=` so exact contact counts as separation (touch), not interpenetration.
+        if max_a <= min_b || max_b <= min_a {
+            return false;
+        }
+    }
+
+    true
+}
+
+#[inline]
+fn clamp(v: f64, lo: f64, hi: f64) -> f64 {
+    if v < lo {
+        lo
+    } else if v > hi {
+        hi
+    } else {
+        v
+    }
+}
+
+/// Closest points between two segments `[p1, q1]` and `[p2, q2]`.
+///
+/// Ericson, *Real-Time Collision Detection* §5.1.9. Returns squared distance
+/// and the closest point on each segment.
+pub fn closest_pt_seg_seg(p1: Vec3, q1: Vec3, p2: Vec3, q2: Vec3) -> (f64, Vec3, Vec3) {
+    let d1 = sub(q1, p1);
+    let d2v = sub(q2, p2);
+    let r = sub(p1, p2);
+    let a = dot(d1, d1);
+    let e = dot(d2v, d2v);
+    let f = dot(d2v, r);
+
+    let s;
+    let mut t;
+
+    if a <= EPS && e <= EPS {
+        s = 0.0;
+        t = 0.0;
+    } else if a <= EPS {
+        s = 0.0;
+        t = clamp(f / e, 0.0, 1.0);
+    } else {
+        let c = dot(d1, r);
+        if e <= EPS {
+            t = 0.0;
+            s = clamp(-c / a, 0.0, 1.0);
+        } else {
+            let b = dot(d1, d2v);
+            let denom = a * e - b * b;
+            s = if denom != 0.0 {
+                clamp((b * f - c * e) / denom, 0.0, 1.0)
+            } else {
+                0.0
+            };
+            t = (b * s + f) / e;
+            if t < 0.0 {
+                t = 0.0;
+                // s recomputed below — shadow the outer binding.
+                let s2 = clamp(-c / a, 0.0, 1.0);
+                let c1 = add(p1, scale(d1, s2));
+                let c2 = add(p2, scale(d2v, t));
+                return (dist_sq(c1, c2), c1, c2);
+            } else if t > 1.0 {
+                t = 1.0;
+                let s2 = clamp((b - c) / a, 0.0, 1.0);
+                let c1 = add(p1, scale(d1, s2));
+                let c2 = add(p2, scale(d2v, t));
+                return (dist_sq(c1, c2), c1, c2);
+            }
+        }
+    }
+
+    let c1 = add(p1, scale(d1, s));
+    let c2 = add(p2, scale(d2v, t));
+    (dist_sq(c1, c2), c1, c2)
+}
+
+/// Closest point on triangle `(a, b, c)` to point `p`.
+///
+/// Ericson, *Real-Time Collision Detection* §5.1.5.
+pub fn closest_pt_point_triangle(p: Vec3, a: Vec3, b: Vec3, c: Vec3) -> Vec3 {
+    let ab = sub(b, a);
+    let ac = sub(c, a);
+    let ap = sub(p, a);
+    let d1 = dot(ab, ap);
+    let d2 = dot(ac, ap);
+    if d1 <= 0.0 && d2 <= 0.0 {
+        return a;
+    }
+
+    let bp = sub(p, b);
+    let d3 = dot(ab, bp);
+    let d4 = dot(ac, bp);
+    if d3 >= 0.0 && d4 <= d3 {
+        return b;
+    }
+
+    let vc = d1 * d4 - d3 * d2;
+    if vc <= 0.0 && d1 >= 0.0 && d3 <= 0.0 {
+        let v = d1 / (d1 - d3);
+        return add(a, scale(ab, v));
+    }
+
+    let cp = sub(p, c);
+    let d5 = dot(ab, cp);
+    let d6 = dot(ac, cp);
+    if d6 >= 0.0 && d5 <= d6 {
+        return c;
+    }
+
+    let vb = d5 * d2 - d1 * d6;
+    if vb <= 0.0 && d2 >= 0.0 && d6 <= 0.0 {
+        let w = d2 / (d2 - d6);
+        return add(a, scale(ac, w));
+    }
+
+    let va = d3 * d6 - d5 * d4;
+    if va <= 0.0 && (d4 - d3) >= 0.0 && (d5 - d6) >= 0.0 {
+        let w = (d4 - d3) / ((d4 - d3) + (d5 - d6));
+        return add(b, scale(sub(c, b), w));
+    }
+
+    let denom = 1.0 / (va + vb + vc);
+    let v = vb * denom;
+    let w = vc * denom;
+    add(a, add(scale(ab, v), scale(ac, w)))
+}
+
+/// Minimum distance between two triangles, with the closest point on each.
+///
+/// Correct for **disjoint** triangles; intersecting triangles must be detected
+/// separately with [`tri_tri_intersect`]. Returns `(dist, pA, pB)`.
+pub fn tri_tri_distance(
+    a0: Vec3,
+    a1: Vec3,
+    a2: Vec3,
+    b0: Vec3,
+    b1: Vec3,
+    b2: Vec3,
+) -> (f64, Vec3, Vec3) {
+    let ea = [(a0, a1), (a1, a2), (a2, a0)];
+    let eb = [(b0, b1), (b1, b2), (b2, b0)];
+
+    let mut best = f64::INFINITY;
+    let mut p_a: Vec3 = a0;
+    let mut p_b: Vec3 = b0;
+
+    for &(s0, s1) in &ea {
+        for &(t0, t1) in &eb {
+            let (d2, c1, c2) = closest_pt_seg_seg(s0, s1, t0, t1);
+            if d2 < best {
+                best = d2;
+                p_a = c1;
+                p_b = c2;
+            }
+        }
+    }
+
+    for &v in &[a0, a1, a2] {
+        let c = closest_pt_point_triangle(v, b0, b1, b2);
+        let d2 = dist_sq(v, c);
+        if d2 < best {
+            best = d2;
+            p_a = v;
+            p_b = c;
+        }
+    }
+
+    for &v in &[b0, b1, b2] {
+        let c = closest_pt_point_triangle(v, a0, a1, a2);
+        let d2 = dist_sq(v, c);
+        if d2 < best {
+            best = d2;
+            p_a = c;
+            p_b = v;
+        }
+    }
+
+    (best.sqrt(), p_a, p_b)
+}

--- a/rust/clash/src/vec3.rs
+++ b/rust/clash/src/vec3.rs
@@ -1,0 +1,66 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! 3-component f64 vector helpers.
+//!
+//! Faithful port of `packages/clash/src/math/vec3.ts`. All clash math runs in
+//! `f64` even though geometry is sourced from `f32` buffers.
+
+/// A 3-component vector stored as `[x, y, z]`.
+pub type Vec3 = [f64; 3];
+
+#[inline]
+pub fn sub(a: Vec3, b: Vec3) -> Vec3 {
+    [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+}
+
+#[inline]
+pub fn add(a: Vec3, b: Vec3) -> Vec3 {
+    [a[0] + b[0], a[1] + b[1], a[2] + b[2]]
+}
+
+#[inline]
+pub fn scale(a: Vec3, s: f64) -> Vec3 {
+    [a[0] * s, a[1] * s, a[2] * s]
+}
+
+#[inline]
+pub fn cross(a: Vec3, b: Vec3) -> Vec3 {
+    [
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    ]
+}
+
+#[inline]
+pub fn dot(a: Vec3, b: Vec3) -> f64 {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+}
+
+#[inline]
+pub fn dist_sq(a: Vec3, b: Vec3) -> f64 {
+    let dx = a[0] - b[0];
+    let dy = a[1] - b[1];
+    let dz = a[2] - b[2];
+    dx * dx + dy * dy + dz * dz
+}
+
+#[inline]
+pub fn mid(a: Vec3, b: Vec3) -> Vec3 {
+    [
+        (a[0] + b[0]) / 2.0,
+        (a[1] + b[1]) / 2.0,
+        (a[2] + b[2]) / 2.0,
+    ]
+}
+
+#[inline]
+pub fn centroid(a: Vec3, b: Vec3, c: Vec3) -> Vec3 {
+    [
+        (a[0] + b[0] + c[0]) / 3.0,
+        (a[1] + b[1] + c[1]) / 3.0,
+        (a[2] + b[2] + c[2]) / 3.0,
+    ]
+}

--- a/rust/wasm-bindings/Cargo.toml
+++ b/rust/wasm-bindings/Cargo.toml
@@ -43,6 +43,8 @@ ifc-lite-geometry = { path = "../geometry", default-features = false, features =
 # Canonical 2D-symbol extractor lives here; the wasm bindings just
 # delegate (issue #843 follow-up — full parity, one implementation).
 ifc-lite-processing = { path = "../processing" }
+# Pure-geometry clash kernel (BVH broad phase + exact triangle narrow phase).
+ifc-lite-clash = { path = "../clash" }
 js-sys = "=0.3.83"
 rayon = "1.10"
 # `ifc-lite-geometry` uses rayon `par_iter` (e.g. FacetedBrep

--- a/rust/wasm-bindings/src/api/clash.rs
+++ b/rust/wasm-bindings/src/api/clash.rs
@@ -1,0 +1,144 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! WASM surface for the clash kernel.
+//!
+//! Thin wrapper over `ifc_lite_clash::ClashSession`. The JS<->WASM contract is
+//! deliberately pure numeric arrays: selection, exclusions, severity and
+//! identity all live in the TypeScript orchestrator, so this layer only ingests
+//! geometry and runs one rule's broad + narrow phase at a time.
+
+use ifc_lite_clash::ClashSession as CoreSession;
+use wasm_bindgen::prelude::*;
+
+/// A clash session: ingest element geometry once, then run rules repeatedly.
+#[wasm_bindgen]
+pub struct ClashSession {
+    inner: CoreSession,
+}
+
+#[wasm_bindgen]
+impl ClashSession {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self {
+            inner: CoreSession::new(),
+        }
+    }
+
+    /// Ingest N elements from flat arenas.
+    ///
+    /// - `positions`: concatenated per-element vertex coords (x,y,z,...)
+    /// - `pos_ranges`: 2 per element = [float_offset, float_len]
+    /// - `indices`: concatenated per-element LOCAL (0-based) triangle indices
+    /// - `idx_ranges`: 2 per element = [idx_offset, idx_len]
+    /// - `aabbs`: 6 per element = [minx,miny,minz,maxx,maxy,maxz]
+    #[wasm_bindgen]
+    pub fn ingest(
+        &mut self,
+        positions: &[f32],
+        pos_ranges: &[u32],
+        indices: &[u32],
+        idx_ranges: &[u32],
+        aabbs: &[f32],
+    ) {
+        self.inner
+            .ingest(positions, pos_ranges, indices, idx_ranges, aabbs);
+    }
+
+    /// Run one rule. `group_a`/`group_b` are GLOBAL element indices; an empty
+    /// `group_b` means a self-clash within `group_a`. `mode`: 0 = hard,
+    /// 1 = clearance. Records carry GLOBAL element indices.
+    #[wasm_bindgen(js_name = runRule)]
+    pub fn run_rule(
+        &self,
+        group_a: &[u32],
+        group_b: &[u32],
+        mode: u8,
+        tolerance: f64,
+        clearance: f64,
+        report_touch: bool,
+    ) -> ClashRunResult {
+        let result =
+            self.inner
+                .run_rule(group_a, group_b, mode, tolerance, clearance, report_touch);
+
+        let n = result.records.len();
+        let mut a = Vec::with_capacity(n);
+        let mut b = Vec::with_capacity(n);
+        let mut status = Vec::with_capacity(n);
+        let mut distance = Vec::with_capacity(n);
+        let mut points = Vec::with_capacity(n * 3);
+        let mut bounds = Vec::with_capacity(n * 6);
+
+        for record in &result.records {
+            a.push(record.a);
+            b.push(record.b);
+            status.push(record.status as u8);
+            distance.push(record.distance);
+            points.extend_from_slice(&record.point);
+            bounds.extend_from_slice(&record.bounds);
+        }
+
+        ClashRunResult {
+            a,
+            b,
+            status,
+            distance,
+            points,
+            bounds,
+        }
+    }
+}
+
+impl Default for ClashSession {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Packed result of one rule run. Parallel arrays, one entry per clash record;
+/// `points` has 3 per record and `bounds` has 6 per record.
+#[wasm_bindgen]
+pub struct ClashRunResult {
+    a: Vec<u32>,
+    b: Vec<u32>,
+    status: Vec<u8>,
+    distance: Vec<f64>,
+    points: Vec<f64>,
+    bounds: Vec<f64>,
+}
+
+#[wasm_bindgen]
+impl ClashRunResult {
+    #[wasm_bindgen(getter)]
+    pub fn a(&self) -> Vec<u32> {
+        self.a.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn b(&self) -> Vec<u32> {
+        self.b.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn status(&self) -> Vec<u8> {
+        self.status.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn distance(&self) -> Vec<f64> {
+        self.distance.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn points(&self) -> Vec<f64> {
+        self.points.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn bounds(&self) -> Vec<f64> {
+        self.bounds.clone()
+    }
+}

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -6,11 +6,14 @@
 //!
 //! Modern async/await API for parsing IFC files.
 
+mod clash;
 mod extract_profiles;
 mod gpu_meshes;
 mod parsing;
 pub(crate) mod styling;
 mod symbolic;
+
+pub use clash::{ClashRunResult, ClashSession};
 
 use ifc_lite_core::EntityIndex;
 use wasm_bindgen::prelude::*;


### PR DESCRIPTION
Stacked on #892. The clash kernel now has a high-performance **Rust implementation compiled to WASM**, behind the same orchestrator as the TS engine and **proven equal to it** by a differential test.

## What

- **`rust/clash`** (new crate `ifc-lite-clash`): pure-std geometry kernel — AABB BVH broad phase + exact triangle-triangle intersection (SAT) and minimum distance (Ericson), per-element triangle BVHs, and the narrow-phase classification ported **f64-faithfully** from the TS engine. 12 cargo tests + doctest, clippy-clean, no `unsafe`.
- **`rust/wasm-bindings/src/api/clash.rs`**: `#[wasm_bindgen] ClashSession` — ingest flat geometry arenas, `runRule` → packed typed-array results. The JS↔WASM contract is **pure numbers**; selection / exclusions / severity / identity stay in TS.
- **`@ifc-lite/clash/wasm`** (subpath): `WasmClashEngine` + `initClashWasm`, reusing the shared orchestrator with a `WasmKernel`. Kept **off the core import graph** so `@ifc-lite/wasm` is never pulled into the core.
- **Engine refactor** (one commit): the TS engine is now `orchestrator + ClashKernel`. `TsKernel` is the reference oracle; the WASM kernel drops in behind the same seam — which is what makes the two **differentially comparable**.

## Differential test

Loads the web-target WASM in Node (by feeding the `.wasm` bytes) and asserts **WASM === TS** across hard / clearance / touch / self-clash and the **full discipline matrix**: identical clash sets (by id), status and severity; distances and points within `1e-6` (f64 summation order differs by ~1e-12).

## Notes

- `backend: 'auto'` stays the in-process TS engine; WASM is **opt-in** via the subpath (it needs async module init). A host (viewer worker, CLI-in-Node) chooses it explicitly.
- Generated `packages/wasm/pkg` artifacts are **gitignored** and rebuilt by CI (`build-wasm.sh`), so this PR is source-only — no binary diff.
- The same-entity (duplicate-key) self-clash skip was moved into the shared orchestrator so every kernel behaves alike regardless of how its broad phase dedups.
- Full suite: **12 files, 77 tests**; `cargo test -p ifc-lite-clash` green.

## Still remaining (dedicated passes)
P1 viewer panel, P4 MCP/CLI/scripts, P7 desktop migration. Worker-pool sharding of the WASM narrow phase (the 3b scaling sub-step) is also a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)