### PR TITLE
fix(geometry): centre U/L/T parametric profiles on their bounding box

### DIFF
--- a/.changeset/centre-parametric-profiles.md
+++ b/.changeset/centre-parametric-profiles.md
@@ -1,0 +1,12 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Centre parameterised profiles on their bounding box.
+
+`IfcUShapeProfileDef`, `IfcLShapeProfileDef` and `IfcTShapeProfileDef` were
+generated from a corner instead of centred on their bounding box, so channels were
+offset by half the flange width, angles by half their leg lengths and tees by half
+their depth. The base profile is now centred before the swept-area `Position`
+placement is applied, matching the symmetric profiles (I-shape, rectangle, …) and
+the IfcOpenShell/Tekla/Revit convention.

--- a/rust/geometry/src/profile.rs
+++ b/rust/geometry/src/profile.rs
@@ -30,6 +30,47 @@ impl Profile2D {
         self.holes.push(hole);
     }
 
+    /// Translate the profile so the centre of its outer bounding box sits at the
+    /// origin.
+    ///
+    /// IFC parameterised profiles (I/U/L/T/C/Z/…) are defined centred on their
+    /// bounding box, and the swept-area `Position` placement is applied relative
+    /// to that centred origin. Some per-shape builders are easier to read when
+    /// written from a corner; centring them here in one place keeps every
+    /// parametric profile consistent with the spec. Holes are shifted by the same
+    /// offset so they stay aligned with the outer boundary. No-op for profiles
+    /// that are already centred.
+    pub fn center_on_bbox(&mut self) {
+        if self.outer.is_empty() {
+            return;
+        }
+        let mut min_x = f64::INFINITY;
+        let mut min_y = f64::INFINITY;
+        let mut max_x = f64::NEG_INFINITY;
+        let mut max_y = f64::NEG_INFINITY;
+        for p in &self.outer {
+            min_x = min_x.min(p.x);
+            min_y = min_y.min(p.y);
+            max_x = max_x.max(p.x);
+            max_y = max_y.max(p.y);
+        }
+        let cx = (min_x + max_x) / 2.0;
+        let cy = (min_y + max_y) / 2.0;
+        if cx == 0.0 && cy == 0.0 {
+            return;
+        }
+        for p in &mut self.outer {
+            p.x -= cx;
+            p.y -= cy;
+        }
+        for hole in &mut self.holes {
+            for p in hole {
+                p.x -= cx;
+                p.y -= cy;
+            }
+        }
+    }
+
     /// Triangulate the profile using earcutr
     /// Returns triangle indices into the flattened vertex array
     pub fn triangulate(&self) -> Result<Triangulation> {

--- a/rust/geometry/src/profiles.rs
+++ b/rust/geometry/src/profiles.rs
@@ -559,6 +559,13 @@ impl ProfileProcessor {
             ))),
         }?;
 
+        // Parameterised profiles are defined centred on their bounding box, and the
+        // Position placement below is applied relative to that centred origin.
+        // Several asymmetric builders (L/U/T/C) emit their points from a corner, so
+        // centre every parametric profile here in one place. Already-centred shapes
+        // (rectangle, circle, I, Z, …) are unaffected.
+        base_profile.center_on_bbox();
+
         // Apply Profile Position transform (attribute 2: IfcAxis2Placement2D)
         if let Some(pos_attr) = profile.get(2) {
             if !pos_attr.is_null() {
@@ -2786,6 +2793,73 @@ mod tests {
 
         assert_eq!(profile.outer.len(), 12); // I-shape has 12 vertices
         assert!(!profile.outer.is_empty());
+    }
+
+    /// (min_x, min_y, max_x, max_y) of a profile's outer boundary.
+    fn outer_bbox(profile: &Profile2D) -> (f64, f64, f64, f64) {
+        let mut min_x = f64::INFINITY;
+        let mut min_y = f64::INFINITY;
+        let mut max_x = f64::NEG_INFINITY;
+        let mut max_y = f64::NEG_INFINITY;
+        for p in &profile.outer {
+            min_x = min_x.min(p.x);
+            min_y = min_y.min(p.y);
+            max_x = max_x.max(p.x);
+            max_y = max_y.max(p.y);
+        }
+        (min_x, min_y, max_x, max_y)
+    }
+
+    fn process_content(content: &str, id: u32) -> Profile2D {
+        let mut decoder = EntityDecoder::new(content);
+        let processor = ProfileProcessor::new(IfcSchema::new());
+        let entity = decoder.decode_by_id(id).unwrap();
+        processor.process(&entity, &mut decoder).unwrap()
+    }
+
+    // A U-shape (channel) is centred on its bounding box: X spans
+    // -FlangeWidth/2..+FlangeWidth/2, not 0..FlangeWidth. Regression for channels
+    // being offset by half the flange width.
+    #[test]
+    fn test_u_shape_is_centered() {
+        // Depth 160, FlangeWidth 64, WebThickness 5, FlangeThickness 8.4
+        let profile =
+            process_content("#1=IFCUSHAPEPROFILEDEF(.AREA.,$,$,160.,64.,5.,8.4,$,$,$,$);\n", 1);
+        let (min_x, min_y, max_x, max_y) = outer_bbox(&profile);
+        assert!((min_x + max_x).abs() < 1e-9, "X not centred: {min_x}..{max_x}");
+        assert!((min_y + max_y).abs() < 1e-9, "Y not centred: {min_y}..{max_y}");
+        assert!((max_x - min_x - 64.0).abs() < 1e-9, "width should be FlangeWidth");
+        assert!((max_y - min_y - 160.0).abs() < 1e-9, "height should be Depth");
+    }
+
+    // An L-shape (angle) is centred on its bounding box rather than having its
+    // corner at the origin.
+    #[test]
+    fn test_l_shape_is_centered() {
+        // Depth 100, Width 80, Thickness 10
+        let profile =
+            process_content("#1=IFCLSHAPEPROFILEDEF(.AREA.,$,$,100.,80.,10.,$,$,$,$,$);\n", 1);
+        let (min_x, min_y, max_x, max_y) = outer_bbox(&profile);
+        assert!((min_x + max_x).abs() < 1e-9, "X not centred: {min_x}..{max_x}");
+        assert!((min_y + max_y).abs() < 1e-9, "Y not centred: {min_y}..{max_y}");
+        assert!((max_x - min_x - 80.0).abs() < 1e-9, "width should be Width");
+        assert!((max_y - min_y - 100.0).abs() < 1e-9, "height should be Depth");
+    }
+
+    // A T-shape is centred on its bounding box: Y spans -Depth/2..+Depth/2,
+    // not 0..Depth.
+    #[test]
+    fn test_t_shape_is_centered() {
+        // Depth 100, FlangeWidth 80, WebThickness 10, FlangeThickness 12
+        let profile = process_content(
+            "#1=IFCTSHAPEPROFILEDEF(.AREA.,$,$,100.,80.,10.,12.,$,$,$,$,$);\n",
+            1,
+        );
+        let (min_x, min_y, max_x, max_y) = outer_bbox(&profile);
+        assert!((min_x + max_x).abs() < 1e-9, "X not centred: {min_x}..{max_x}");
+        assert!((min_y + max_y).abs() < 1e-9, "Y not centred: {min_y}..{max_y}");
+        assert!((max_x - min_x - 80.0).abs() < 1e-9, "width should be FlangeWidth");
+        assert!((max_y - min_y - 100.0).abs() < 1e-9, "height should be Depth");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`IfcUShapeProfileDef`, `IfcLShapeProfileDef` and `IfcTShapeProfileDef` are generated from a corner instead of centred on their bounding box, so swept solids using them are offset by half a dimension:

- **U-shape (channel):** built `0 … FlangeWidth` in X (Y already centred) → offset by **+FlangeWidth/2**
- **L-shape (angle):** corner at origin (`0 … Width`, `0 … Depth`) → offset by half each leg
- **T-shape:** built `0 … Depth` in Y (X already centred) → offset by **+Depth/2**

The swept-area `Position` placement is applied relative to that origin, so the offset shows up directly in the model. The symmetric profiles (I-shape, asymmetric-I, rectangle, circle, Z, hollow) are already centred, so only the asymmetric ones are affected.

### Evidence (real file, U16 channel, `FlangeWidth = 64 mm`)

`IfcAPI.extractProfiles` outer points, before:
```
X range: 0 … 0.064   (centre +0.032)   ← offset by half the flange width
Y range: -0.08 … 0.08 (centre 0)        ← already centred
```
after this change:
```
X range: -0.032 … 0.032 (centre 0)
Y range: -0.08 … 0.08   (centre 0)
```

## Fix

- Add `Profile2D::center_on_bbox()`.
- Call it in `process_parametric` after building the base profile and **before** the `Position` transform, so every parametric profile is centred on its bounding box — the convention already documented for `process_asymmetric_i_shape` (matches IfcOpenShell / Tekla / Revit). It is a no-op for the already-centred shapes.

## Tests

Added regression tests `test_u_shape_is_centered`, `test_l_shape_is_centered`, `test_t_shape_is_centered` (assert the outer bounding box is centred on the origin and has the expected extents).

```
cargo test -p ifc-lite-geometry --no-default-features profiles::tests
```

Also verified end-to-end against a rebuilt wasm bundle (`extractProfiles` now returns centred outlines; channels render in the correct position in the viewer).

## Note / possible follow-up

While here I noticed `process_c_shape` (`IfcCShapeProfileDef`) uses `Girth` for the flange extent and ignores `Width`, and emits no inturned lips — that looks like a separate dimensional bug (wrong size, not just position). Left out of this PR to keep it focused; happy to file/fix separately.

A changeset (`@ifc-lite/wasm` patch) is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * U-Shape, L-Shape, and T-Shape parametric profiles now generate centered on their bounding box origin instead of from a corner. Internal geometry offsets have changed; models using these profiles may render differently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->