### PR TITLE
feat(server): IfcAnnotation/IfcGrid symbol-data parity across all parse endpoints (#900)

### DIFF
--- a/.changeset/feat-900-symbolic-endpoint-parity.md
+++ b/.changeset/feat-900-symbolic-endpoint-parity.md
@@ -32,6 +32,11 @@ Symbol data can be large for annotation-heavy drawings, so it travels in the
 response body / SSE payload (JSON paths) or via the dedicated fetch endpoint
 (binary paths) — never an HTTP header.
 
+The parquet geometry cache version is bumped (`v2` → `v3`) so models cached
+before the symbolic sidecar existed are reprocessed once and get their
+`{cache_key}-symbolic-v1` companion written, instead of serving symbol-less
+geometry while the symbolic endpoint returns `202` forever.
+
 Client (`@ifc-lite/server-client`):
 
 - New `SymbolicData` type (plus `SymbolicGridAxis`, `SymbolicPolyline`,

--- a/.changeset/feat-900-symbolic-endpoint-parity.md
+++ b/.changeset/feat-900-symbolic-endpoint-parity.md
@@ -1,0 +1,49 @@
+---
+"@ifc-lite/server-bin": minor
+"@ifc-lite/server-client": minor
+---
+
+Expose the 2D symbol stream (`IfcAnnotation` + `IfcGrid`) from **all** Server
+geometry/parsing endpoints, not just `POST /api/v1/parse` (issue #900).
+
+Issue #843 added `symbolic_data` to the synchronous JSON parse response, but the
+streaming and binary-Parquet endpoints still dropped it, so consumers couldn't
+get IfcAnnotation/IfcGrid data unless they used that one endpoint. This brings
+the whole API to parity with `@ifc-lite/parse`.
+
+Server (shipped in the `@ifc-lite/server-bin` binary):
+
+- `POST /api/v1/parse/stream` and `POST /api/v1/parse/parquet-stream` now carry
+  `symbolic_data` in their `complete` SSE event. It's extracted once at the end
+  of the shared streaming pipeline (`process_streaming`), so both endpoints get
+  it without re-parsing.
+- `POST /api/v1/parse/parquet` and `POST /api/v1/parse/parquet/optimized` extract
+  the symbol stream alongside geometry (in parallel via `rayon::join`) and cache
+  it under `{cache_key}-symbolic-v1`.
+- New `GET /api/v1/parse/symbolic/{cache_key}` returns the symbol stream as JSON
+  for the binary transports whose payloads can't carry it inline — mirroring how
+  the data model is cached and fetched (`/api/v1/parse/data-model/{cache_key}`).
+  Returns `202` while a streaming upload is still caching in the background.
+- `POST /api/v1/parse` and the cached-geometry fast paths populate the same
+  `{cache_key}-symbolic-v1` entry, so the fetch endpoint works regardless of
+  which endpoint first processed the file.
+
+Symbol data can be large for annotation-heavy drawings, so it travels in the
+response body / SSE payload (JSON paths) or via the dedicated fetch endpoint
+(binary paths) — never an HTTP header.
+
+Client (`@ifc-lite/server-client`):
+
+- New `SymbolicData` type (plus `SymbolicGridAxis`, `SymbolicPolyline`,
+  `SymbolicCircle`, `SymbolicText`, `SymbolicFillArea`).
+- `symbolic_data?` added to `ParseResponse`, `StreamCompleteEvent`,
+  `ParquetStreamCompleteEvent`, and `ParquetStreamResult`.
+- New `client.fetchSymbolic(cacheKey)` method (parallel to `fetchDataModel`) for
+  the binary Parquet transports; `parseParquetStream` now returns `symbolic_data`
+  on its result (inline from the stream, or fetched on the cache-hit fast path).
+
+Regression coverage: in-process HTTP integration tests
+(`apps/server/src/parity_tests.rs`) drive a grid + annotation + wall fixture
+through `/parse`, `/parse/parquet`, `/parse/parquet/optimized`, the new symbolic
+endpoint, and `process_streaming`, asserting each surfaces the grid axes and
+annotation circle.

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -79,6 +79,8 @@ base64 = "0.22"
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }
+# `util` feature pulls in `ServiceExt::oneshot` for in-process route tests.
+tower = { version = "0.5", features = ["util"] }
 
 [[bench]]
 name = "serialization"

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -19,6 +19,7 @@
 //! - `POST /api/v1/parse/metadata` - Quick metadata only
 //! - `POST /api/v1/parse/parquet` - Full parse with Parquet-encoded geometry (~15x smaller)
 //! - `POST /api/v1/parse/parquet/optimized` - ara3d BOS-optimized format (~50x smaller)
+//! - `GET /api/v1/parse/symbolic/:cache_key` - 2D symbol stream (IfcAnnotation + IfcGrid) as JSON
 //! - `GET /api/v1/cache/:key` - Retrieve cached result
 
 use axum::http::{header, HeaderValue, Method};
@@ -40,6 +41,9 @@ mod middleware;
 mod routes;
 mod services;
 mod types;
+
+#[cfg(test)]
+mod parity_tests;
 
 use config::Config;
 use services::cache::DiskCache;
@@ -75,6 +79,60 @@ fn build_cors_layer(config: &Config) -> CorsLayer {
 pub struct AppState {
     pub cache: Arc<DiskCache>,
     pub config: Arc<Config>,
+}
+
+/// Build the application router with all routes and middleware.
+///
+/// Extracted from `main` so integration tests can exercise the full route
+/// table in-process (via `tower`'s `oneshot`) without binding a socket.
+fn build_router(state: AppState) -> Router {
+    let config = state.config.clone();
+    Router::new()
+        // Root endpoint - API information
+        .route("/", get(routes::health::info))
+        // Health check
+        .route("/api/v1/health", get(routes::health::check))
+        // Parse endpoints
+        .route("/api/v1/parse", post(routes::parse::parse_full))
+        .route("/api/v1/parse/stream", post(routes::parse::parse_stream))
+        .route(
+            "/api/v1/parse/parquet-stream",
+            post(routes::parse::parse_parquet_stream),
+        )
+        .route(
+            "/api/v1/parse/metadata",
+            post(routes::parse::parse_metadata),
+        )
+        .route("/api/v1/parse/parquet", post(routes::parse::parse_parquet))
+        .route(
+            "/api/v1/parse/parquet/optimized",
+            post(routes::parse::parse_parquet_optimized),
+        )
+        .route(
+            "/api/v1/parse/data-model/{cache_key}",
+            get(routes::parse::get_data_model),
+        )
+        .route(
+            "/api/v1/parse/symbolic/{cache_key}",
+            get(routes::parse::get_symbolic),
+        )
+        // Cache endpoints
+        .route("/api/v1/cache/{key}", get(routes::cache::get_cached))
+        .route("/api/v1/cache/check/{hash}", get(routes::parse::check_cache))
+        .route(
+            "/api/v1/cache/geometry/{hash}",
+            get(routes::parse::get_cached_geometry),
+        )
+        // Middleware
+        .layer(DefaultBodyLimit::max(config.max_file_size_mb * 1024 * 1024)) // Match max_file_size_mb
+        .layer(CompressionLayer::new()) // Compress responses (gzip)
+        // Note: Request decompression handled manually in extract_file() to support multipart
+        .layer(TimeoutLayer::new(Duration::from_secs(
+            config.request_timeout_secs,
+        )))
+        .layer(TraceLayer::new_for_http())
+        .layer(build_cors_layer(&config))
+        .with_state(state)
 }
 
 #[tokio::main]
@@ -114,48 +172,7 @@ async fn main() {
     };
 
     // Build router
-    let app = Router::new()
-        // Root endpoint - API information
-        .route("/", get(routes::health::info))
-        // Health check
-        .route("/api/v1/health", get(routes::health::check))
-        // Parse endpoints
-        .route("/api/v1/parse", post(routes::parse::parse_full))
-        .route("/api/v1/parse/stream", post(routes::parse::parse_stream))
-        .route(
-            "/api/v1/parse/parquet-stream",
-            post(routes::parse::parse_parquet_stream),
-        )
-        .route(
-            "/api/v1/parse/metadata",
-            post(routes::parse::parse_metadata),
-        )
-        .route("/api/v1/parse/parquet", post(routes::parse::parse_parquet))
-        .route(
-            "/api/v1/parse/parquet/optimized",
-            post(routes::parse::parse_parquet_optimized),
-        )
-        .route(
-            "/api/v1/parse/data-model/{cache_key}",
-            get(routes::parse::get_data_model),
-        )
-        // Cache endpoints
-        .route("/api/v1/cache/{key}", get(routes::cache::get_cached))
-        .route("/api/v1/cache/check/{hash}", get(routes::parse::check_cache))
-        .route(
-            "/api/v1/cache/geometry/{hash}",
-            get(routes::parse::get_cached_geometry),
-        )
-        // Middleware
-        .layer(DefaultBodyLimit::max(config.max_file_size_mb * 1024 * 1024)) // Match max_file_size_mb
-        .layer(CompressionLayer::new()) // Compress responses (gzip)
-        // Note: Request decompression handled manually in extract_file() to support multipart
-        .layer(TimeoutLayer::new(Duration::from_secs(
-            config.request_timeout_secs,
-        )))
-        .layer(TraceLayer::new_for_http())
-        .layer(build_cors_layer(&config))
-        .with_state(state);
+    let app = build_router(state);
 
     let addr = SocketAddr::from(([0, 0, 0, 0], config.port));
     tracing::info!("Listening on http://{}", addr);

--- a/apps/server/src/parity_tests.rs
+++ b/apps/server/src/parity_tests.rs
@@ -1,0 +1,263 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Endpoint-parity integration tests for issue #900.
+//!
+//! Issue #843 added the 2D symbol stream (`IfcAnnotation` + `IfcGrid`) to the
+//! synchronous `POST /api/v1/parse` JSON response. Issue #900 reported that the
+//! other geometry/parse endpoints still omitted it. These tests drive the full
+//! route table in-process (via `tower`'s `oneshot`, no socket) against a
+//! synthetic IFC that carries both an `IfcAnnotation` circle and an `IfcGrid`,
+//! and assert every endpoint now surfaces the same symbolic stream — inline for
+//! the JSON/SSE transports, and via `GET /api/v1/parse/symbolic/{cache_key}`
+//! for the binary Parquet transports.
+
+use crate::config::Config;
+use crate::services::cache::DiskCache;
+use crate::services::process_streaming;
+use crate::types::StreamEvent;
+use crate::{build_router, AppState};
+use axum::body::{to_bytes, Body};
+use axum::http::{header, Request, StatusCode};
+use futures::StreamExt;
+use serde_json::Value;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+/// Minimal IFC4 model carrying one `IfcAnnotation` (a full-circle disk), one
+/// `IfcGrid` with two axes, and one extruded-solid `IfcWall`. The wall gives the
+/// geometry endpoints a real mesh; the annotation + grid populate `circles` and
+/// `grid_axes` in the symbolic stream.
+const FIXTURE: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('issue-900 parity fixture'),'2;1');
+FILE_NAME('parity.ifc','2026-06-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6,#7));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#7=IFCSIUNIT(*,.PLANEANGLEUNIT.,$,.RADIAN.);
+#40=IFCLOCALPLACEMENT($,#5);
+
+/* IfcAnnotation with a full-circle disk */
+#100=IFCCARTESIANPOINT((5.,3.));
+#101=IFCAXIS2PLACEMENT2D(#100,$);
+#102=IFCCIRCLE(#101,2.0);
+#103=IFCSHAPEREPRESENTATION(#2,'Annotation','GeometricCurveSet',(#102));
+#104=IFCPRODUCTDEFINITIONSHAPE($,$,(#103));
+#105=IFCANNOTATION('AnnoCircle0000000000001',$,'Bubble',$,$,#40,#104);
+
+/* IfcGrid with two axes */
+#200=IFCCARTESIANPOINT((0.,0.));
+#201=IFCCARTESIANPOINT((0.,10.));
+#202=IFCPOLYLINE((#200,#201));
+#203=IFCGRIDAXIS('A',#202,.T.);
+#204=IFCCARTESIANPOINT((0.,0.));
+#205=IFCCARTESIANPOINT((10.,0.));
+#206=IFCPOLYLINE((#204,#205));
+#207=IFCGRIDAXIS('1',#206,.T.);
+#208=IFCGRID('Grid00000000000000001',$,'MainGrid',$,$,#40,$,(#203),(#207),$);
+
+/* IfcWall with an extruded-solid body so the geometry endpoints emit a mesh */
+#300=IFCCARTESIANPOINT((0.,0.));
+#301=IFCAXIS2PLACEMENT2D(#300,$);
+#302=IFCRECTANGLEPROFILEDEF(.AREA.,$,#301,1.0,0.2);
+#303=IFCDIRECTION((0.,0.,1.));
+#304=IFCEXTRUDEDAREASOLID(#302,#5,#303,3.0);
+#305=IFCSHAPEREPRESENTATION(#2,'Body','SweptSolid',(#304));
+#306=IFCPRODUCTDEFINITIONSHAPE($,$,(#305));
+#307=IFCWALL('Wall00000000000000001',$,'W1',$,$,#40,#306,$,$);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+const BOUNDARY: &str = "ifclite900parityboundary";
+
+/// Build a `multipart/form-data` body with a single `file` field, returning the
+/// `(content_type, body_bytes)` pair.
+fn multipart_body(content: &[u8]) -> (String, Vec<u8>) {
+    let mut body = Vec::new();
+    body.extend_from_slice(
+        format!(
+            "--{BOUNDARY}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"parity.ifc\"\r\nContent-Type: application/octet-stream\r\n\r\n"
+        )
+        .as_bytes(),
+    );
+    body.extend_from_slice(content);
+    body.extend_from_slice(format!("\r\n--{BOUNDARY}--\r\n").as_bytes());
+    (
+        format!("multipart/form-data; boundary={BOUNDARY}"),
+        body,
+    )
+}
+
+/// Construct an `AppState` backed by a fresh temp cache directory unique to
+/// `label` so tests don't share cache entries.
+async fn test_state(label: &str) -> AppState {
+    let dir = std::env::temp_dir().join(format!(
+        "ifc-lite-server-test-900-{}-{}",
+        std::process::id(),
+        label
+    ));
+    // Start clean — best effort.
+    let _ = std::fs::remove_dir_all(&dir);
+    let cache = Arc::new(DiskCache::new(dir.to_str().unwrap()).await);
+    AppState {
+        cache,
+        config: Arc::new(Config::from_env()),
+    }
+}
+
+/// POST the fixture as multipart to `uri`, returning the response.
+async fn post_fixture(state: &AppState, uri: &str) -> axum::response::Response {
+    let (content_type, body) = multipart_body(FIXTURE.as_bytes());
+    let request = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header(header::CONTENT_TYPE, content_type)
+        .body(Body::from(body))
+        .unwrap();
+    build_router(state.clone())
+        .oneshot(request)
+        .await
+        .unwrap()
+}
+
+/// GET `uri` and return the response.
+async fn get(state: &AppState, uri: &str) -> axum::response::Response {
+    let request = Request::builder()
+        .method("GET")
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap();
+    build_router(state.clone())
+        .oneshot(request)
+        .await
+        .unwrap()
+}
+
+async fn body_json(response: axum::response::Response) -> Value {
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+/// Assert a `SymbolicData`-shaped JSON value carries both the grid axes and the
+/// annotation circle from the fixture.
+fn assert_symbolic_populated(symbolic: &Value, context: &str) {
+    let grid_axes = symbolic["grid_axes"]
+        .as_array()
+        .unwrap_or_else(|| panic!("{context}: symbolic_data.grid_axes missing"));
+    assert!(
+        !grid_axes.is_empty(),
+        "{context}: expected IfcGrid axes in symbolic data, got none"
+    );
+    let circles = symbolic["circles"]
+        .as_array()
+        .unwrap_or_else(|| panic!("{context}: symbolic_data.circles missing"));
+    assert!(
+        !circles.is_empty(),
+        "{context}: expected IfcAnnotation circle in symbolic data, got none"
+    );
+}
+
+/// `POST /api/v1/parse` (JSON) carries `symbolic_data` inline — the issue #843
+/// baseline, re-asserted here as the parity reference.
+#[tokio::test]
+async fn parse_full_includes_symbolic_data_inline() {
+    let state = test_state("parse-full").await;
+    let response = post_fixture(&state, "/api/v1/parse").await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let json = body_json(response).await;
+    assert_symbolic_populated(&json["symbolic_data"], "parse_full");
+}
+
+/// `POST /api/v1/parse/parquet` (binary) caches the symbol stream synchronously;
+/// `GET /api/v1/parse/symbolic/{cache_key}` then returns it.
+#[tokio::test]
+async fn parquet_endpoint_exposes_symbolic_via_fetch() {
+    let state = test_state("parquet").await;
+    let response = post_fixture(&state, "/api/v1/parse/parquet").await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // The cache key is carried in the X-IFC-Metadata header.
+    let metadata_header = response
+        .headers()
+        .get("X-IFC-Metadata")
+        .expect("parquet response must carry X-IFC-Metadata")
+        .to_str()
+        .unwrap()
+        .to_string();
+    let metadata: Value = serde_json::from_str(&metadata_header).unwrap();
+    let cache_key = metadata["cache_key"].as_str().unwrap().to_string();
+
+    let symbolic_response = get(&state, &format!("/api/v1/parse/symbolic/{cache_key}")).await;
+    assert_eq!(symbolic_response.status(), StatusCode::OK);
+    let symbolic = body_json(symbolic_response).await;
+    assert_symbolic_populated(&symbolic, "parquet symbolic fetch");
+}
+
+/// `POST /api/v1/parse/parquet/optimized` likewise caches symbolic data for the
+/// fetch endpoint.
+#[tokio::test]
+async fn optimized_endpoint_exposes_symbolic_via_fetch() {
+    let state = test_state("optimized").await;
+    let response = post_fixture(&state, "/api/v1/parse/parquet/optimized").await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let metadata_header = response
+        .headers()
+        .get("X-IFC-Metadata")
+        .expect("optimized parquet response must carry X-IFC-Metadata")
+        .to_str()
+        .unwrap()
+        .to_string();
+    let metadata: Value = serde_json::from_str(&metadata_header).unwrap();
+    let cache_key = metadata["cache_key"].as_str().unwrap().to_string();
+
+    let symbolic_response = get(&state, &format!("/api/v1/parse/symbolic/{cache_key}")).await;
+    assert_eq!(symbolic_response.status(), StatusCode::OK);
+    let symbolic = body_json(symbolic_response).await;
+    assert_symbolic_populated(&symbolic, "optimized symbolic fetch");
+}
+
+/// The symbolic fetch endpoint returns `202 Accepted` for an unknown cache key
+/// (mirrors `get_data_model`) rather than erroring.
+#[tokio::test]
+async fn symbolic_endpoint_pending_for_unknown_key() {
+    let state = test_state("symbolic-unknown").await;
+    let response = get(&state, "/api/v1/parse/symbolic/does-not-exist-default").await;
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+}
+
+/// `process_streaming` (the source for both `/parse/stream` and
+/// `/parse/parquet-stream`) attaches `symbolic_data` to its `Complete` event.
+#[tokio::test]
+async fn streaming_complete_event_carries_symbolic_data() {
+    let events: Vec<StreamEvent> = process_streaming(FIXTURE.to_string(), 100, 1000)
+        .collect()
+        .await;
+
+    let symbolic = events
+        .iter()
+        .find_map(|event| match event {
+            StreamEvent::Complete { symbolic_data, .. } => Some(symbolic_data),
+            _ => None,
+        })
+        .expect("stream should emit a Complete event");
+
+    assert!(
+        !symbolic.grid_axes.is_empty(),
+        "streaming Complete should include IfcGrid axes"
+    );
+    assert!(
+        !symbolic.circles.is_empty(),
+        "streaming Complete should include IfcAnnotation circle"
+    );
+}

--- a/apps/server/src/routes/parse.rs
+++ b/apps/server/src/routes/parse.rs
@@ -26,6 +26,7 @@ use axum::{
 use flate2::read::GzDecoder;
 use futures::stream::StreamExt;
 use ifc_lite_core::EntityScanner;
+use ifc_lite_processing::{extract_symbolic_data, SymbolicData};
 use serde::{Deserialize, Serialize};
 use std::convert::Infallible;
 use std::io::Read;
@@ -63,6 +64,55 @@ fn parquet_metadata_cache_key(hash: &str, opening_filter: OpeningFilterMode) -> 
         hash,
         opening_filter.cache_key_suffix()
     )
+}
+
+/// Build the symbolic-data cache key for a given file cache key.
+///
+/// The 2D symbol stream (`IfcAnnotation` + `IfcGrid`) is cached separately
+/// from geometry so binary-transport endpoints (Parquet, optimized Parquet,
+/// cached geometry) can expose it via `GET /api/v1/parse/symbolic/{cache_key}`,
+/// mirroring how the data model is cached and fetched (issue #900). `cache_key`
+/// is the full `{hash}-{opening_filter}` key, matching the value embedded in
+/// each response's metadata header.
+fn symbolic_cache_key(cache_key: &str) -> String {
+    format!("{}-symbolic-v1", cache_key)
+}
+
+/// Serialize symbolic data and write it to the cache under `{cache_key}-symbolic-v1`.
+///
+/// Always stores the JSON (even when empty) so the fetch endpoint can return a
+/// definitive `200` with empty arrays rather than looping on `202`.
+async fn cache_symbolic_data(cache: &DiskCache, cache_key: &str, symbolic: &SymbolicData) {
+    match serde_json::to_vec(symbolic) {
+        Ok(bytes) => {
+            let key = symbolic_cache_key(cache_key);
+            if let Err(e) = cache.set_bytes(&key, &bytes).await {
+                tracing::error!(error = %e, cache_key = %cache_key, "Failed to cache symbolic data");
+            } else {
+                tracing::debug!(cache_key = %key, size = bytes.len(), "Symbolic data cached");
+            }
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to serialize symbolic data for caching");
+        }
+    }
+}
+
+/// Load cached symbolic data for `cache_key`, defaulting to empty when the
+/// entry is absent or unreadable.
+async fn load_cached_symbolic(cache: &DiskCache, cache_key: &str) -> SymbolicData {
+    let key = symbolic_cache_key(cache_key);
+    match cache.get_bytes(&key).await {
+        Ok(Some(bytes)) => serde_json::from_slice(&bytes).unwrap_or_else(|e| {
+            tracing::error!(error = %e, cache_key = %cache_key, "Failed to parse cached symbolic data");
+            SymbolicData::default()
+        }),
+        Ok(None) => SymbolicData::default(),
+        Err(e) => {
+            tracing::error!(error = %e, cache_key = %cache_key, "Failed to read cached symbolic data");
+            SymbolicData::default()
+        }
+    }
 }
 
 /// Extract file data from multipart request.
@@ -175,10 +225,14 @@ pub async fn parse_full(
         symbolic_data,
     };
 
-    // Cache result (background)
+    // Cache result (background). Also mirror the symbolic stream into the
+    // dedicated `{cache_key}-symbolic-v1` entry so it's reachable through
+    // `GET /api/v1/parse/symbolic/{cache_key}` regardless of which endpoint
+    // first processed the file (issue #900).
     let cache = state.cache.clone();
     let response_clone = response.clone();
     tokio::spawn(async move {
+        cache_symbolic_data(&cache, &cache_key, &response_clone.symbolic_data).await;
         if let Err(e) = cache.set(&cache_key, &response_clone).await {
             tracing::error!(error = %e, "Failed to cache result");
         }
@@ -244,6 +298,10 @@ pub enum ParquetStreamEvent {
     Complete {
         stats: ProcessingStats,
         metadata: ModelMetadata,
+        /// 2D symbol data extracted from `IfcAnnotation` and `IfcGrid`
+        /// entities — parity with `POST /api/v1/parse` (issue #900).
+        #[serde(default, skip_serializing_if = "SymbolicData::is_empty")]
+        symbolic_data: SymbolicData,
     },
     /// Error occurred.
     Error { message: String },
@@ -306,6 +364,10 @@ pub async fn parse_parquet_stream(
         let metadata_header: ParquetMetadataHeader = serde_json::from_slice(&cached_metadata_json)
             .map_err(|e| ApiError::Internal(format!("Failed to parse cached metadata: {}", e)))?;
 
+        // Load the cached symbolic stream so the Complete event reaches parity
+        // even on the cache fast-path (issue #900).
+        let symbolic_data = load_cached_symbolic(&state.cache, &cache_key).await;
+
         // Extract geometry length from combined parquet (first 4 bytes)
         let geometry_len = u32::from_le_bytes(cached_parquet[0..4].try_into().unwrap()) as usize;
         let geometry_data = cached_parquet[4..4 + geometry_len].to_vec();
@@ -339,6 +401,7 @@ pub async fn parse_parquet_stream(
                 serde_json::to_string(&ParquetStreamEvent::Complete {
                     stats: metadata_header.stats,
                     metadata: metadata_header.metadata,
+                    symbolic_data,
                 })
                 .unwrap(),
             )),
@@ -402,7 +465,20 @@ pub async fn parse_parquet_stream(
                     }
                 }
             }
-            StreamEvent::Complete { stats, metadata, mesh_coordinate_space, site_transform, building_transform, .. } => {
+            StreamEvent::Complete { stats, metadata, mesh_coordinate_space, site_transform, building_transform, symbolic_data, .. } => {
+                // Cache the symbolic stream so the cached-geometry fast-path and
+                // `GET /api/v1/parse/symbolic/{cache_key}` reach parity (issue #900).
+                // Reuses the value already computed inside `process_streaming` —
+                // no re-extraction.
+                {
+                    let cache = cache_for_geometry.clone();
+                    let key = cache_key_for_geometry.clone();
+                    let symbolic_for_cache = symbolic_data.clone();
+                    tokio::spawn(async move {
+                        cache_symbolic_data(&cache, &key, &symbolic_for_cache).await;
+                    });
+                }
+
                 // OPTIMIZATION: Use accumulated meshes instead of re-processing
                 // This eliminates duplicate geometry extraction (~1100ms savings for large files)
                 let cache = cache_for_geometry.clone();
@@ -484,7 +560,7 @@ pub async fn parse_parquet_stream(
                     }
                 });
 
-                ParquetStreamEvent::Complete { stats, metadata }
+                ParquetStreamEvent::Complete { stats, metadata, symbolic_data }
             }
             StreamEvent::Error { message } => {
                 ParquetStreamEvent::Error { message }
@@ -667,12 +743,19 @@ pub async fn parse_parquet(
     // that's independent of tokio's blocking thread pool
     let serialize_start = tokio::time::Instant::now();
     let opening_filter = query.opening_filter;
-    let ((geometry_result, geometry_parquet), (data_model_stats, data_model_parquet)) =
+    let ((geometry_result, geometry_parquet), (data_model_stats, data_model_parquet), symbolic_data) =
         tokio::task::spawn_blocking(move || {
-            // First: extract geometry and data model in parallel
-            let (geometry_result, data_model) = rayon::join(
-                || process_geometry_filtered(&content, opening_filter),
-                || extract_data_model(&content),
+            // First: extract geometry, data model, and the 2D symbol stream
+            // (IfcAnnotation + IfcGrid) all in parallel. Symbolic extraction is
+            // added here for endpoint parity (issue #900).
+            let ((geometry_result, data_model), symbolic_data) = rayon::join(
+                || {
+                    rayon::join(
+                        || process_geometry_filtered(&content, opening_filter),
+                        || extract_data_model(&content),
+                    )
+                },
+                || extract_symbolic_data(&content),
             );
 
             // Capture stats before moving data_model
@@ -690,7 +773,11 @@ pub async fn parse_parquet(
                 || serialize_data_model_to_parquet(&data_model),
             );
 
-            ((geometry_result, geo_parquet), (dm_stats, dm_parquet))
+            (
+                (geometry_result, geo_parquet),
+                (dm_stats, dm_parquet),
+                symbolic_data,
+            )
         })
         .await?;
 
@@ -722,6 +809,10 @@ pub async fn parse_parquet(
             "Data model cached (ready for client)"
         );
     }
+
+    // Cache the symbolic stream immediately so it's ready when the client
+    // fetches `GET /api/v1/parse/symbolic/{cache_key}` (issue #900).
+    cache_symbolic_data(&state.cache, &cache_key, &symbolic_data).await;
 
     // Build geometry-only response (data model available via separate endpoint)
     let mut combined_parquet = Vec::new();
@@ -838,10 +929,20 @@ pub async fn parse_parquet_optimized(
     let content = String::from_utf8(data)?;
     let opening_filter = query.opening_filter;
 
-    // Process on blocking thread pool (CPU-intensive)
-    let result =
-        tokio::task::spawn_blocking(move || process_geometry_filtered(&content, opening_filter))
-            .await?;
+    // Process on blocking thread pool (CPU-intensive). Extract the 2D symbol
+    // stream (IfcAnnotation + IfcGrid) alongside geometry for endpoint parity
+    // (issue #900) — it's cached and served via the symbolic fetch endpoint.
+    let (result, symbolic_data) = tokio::task::spawn_blocking(move || {
+        rayon::join(
+            || process_geometry_filtered(&content, opening_filter),
+            || extract_symbolic_data(&content),
+        )
+    })
+    .await?;
+
+    // Cache the symbolic stream so the client can fetch it via
+    // `GET /api/v1/parse/symbolic/{cache_key}`.
+    cache_symbolic_data(&state.cache, &cache_key, &symbolic_data).await;
 
     // Serialize to optimized Parquet (with deduplication, quantization, etc.)
     // Don't include normals by default - client can compute them
@@ -926,6 +1027,59 @@ pub async fn get_data_model(
                 .status(StatusCode::ACCEPTED)
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(Body::from(r#"{"status":"processing","message":"Data model is still being processed. Retry in a moment."}"#))
+                .map_err(|e| ApiError::Internal(e.to_string()))?;
+
+            Ok(response)
+        }
+    }
+}
+
+/// GET /api/v1/parse/symbolic/:cache_key
+///
+/// Fetch the 2D symbol stream (`IfcAnnotation` + `IfcGrid`) for a previously
+/// parsed file as JSON. This brings the binary-transport endpoints (Parquet,
+/// optimized Parquet, cached geometry) to parity with the inline `symbolic_data`
+/// field on `POST /api/v1/parse` (issue #900). Symbol data is cached separately
+/// from geometry — exactly like the data model — so it's fetched the same way,
+/// keyed by the `cache_key` carried in each response's metadata header.
+///
+/// `cache_key` is the full `{hash}-{opening_filter}` value (e.g. `<hash>-default`).
+///
+/// Response:
+/// - 200: `SymbolicData` JSON (may have empty arrays when the model has no 2D symbols)
+/// - 202: Not yet available — streaming caches symbolic data in the background; retry
+pub async fn get_symbolic(
+    State(state): State<AppState>,
+    axum::extract::Path(cache_key): axum::extract::Path<String>,
+) -> Result<Response, ApiError> {
+    let key = symbolic_cache_key(&cache_key);
+
+    match state.cache.get_bytes(&key).await? {
+        Some(symbolic_json) => {
+            tracing::info!(
+                cache_key = %cache_key,
+                size = symbolic_json.len(),
+                "Symbolic data cache HIT"
+            );
+
+            let response = Response::builder()
+                .status(StatusCode::OK)
+                .header(header::CONTENT_TYPE, "application/json")
+                .header(header::CONTENT_LENGTH, symbolic_json.len())
+                .body(Body::from(symbolic_json))
+                .map_err(|e| ApiError::Internal(e.to_string()))?;
+
+            Ok(response)
+        }
+        None => {
+            tracing::debug!(cache_key = %cache_key, "Symbolic data not yet available");
+
+            // Return 202 Accepted to indicate processing (mirrors get_data_model);
+            // the streaming endpoints cache symbolic data in a background task.
+            let response = Response::builder()
+                .status(StatusCode::ACCEPTED)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(r#"{"status":"processing","message":"Symbolic data is still being processed. Retry in a moment."}"#))
                 .map_err(|e| ApiError::Internal(e.to_string()))?;
 
             Ok(response)
@@ -1053,5 +1207,30 @@ mod tests {
     fn parquet_cache_key_default_filter_uses_default_suffix() {
         let key = parquet_cache_key("abc", OpeningFilterMode::Default);
         assert_eq!(key, "abc-default-parquet-v2");
+    }
+
+    /// The symbolic cache key (issue #900) is derived from the full
+    /// `{hash}-{opening_filter}` cache key the writers store under, and the
+    /// `get_symbolic` reader composes the same string from the path param.
+    #[test]
+    fn symbolic_cache_key_matches_writer_format() {
+        let hash = "0ab20f4e4014";
+        for mode in [
+            OpeningFilterMode::Default,
+            OpeningFilterMode::IgnoreAll,
+            OpeningFilterMode::IgnoreOpaque,
+        ] {
+            let writer_cache_key = format!("{}-{}", hash, mode.cache_key_suffix());
+            assert_eq!(
+                symbolic_cache_key(&writer_cache_key),
+                format!("{}-symbolic-v1", writer_cache_key)
+            );
+        }
+    }
+
+    #[test]
+    fn symbolic_cache_key_default_filter() {
+        let key = symbolic_cache_key("abc-default");
+        assert_eq!(key, "abc-default-symbolic-v1");
     }
 }

--- a/apps/server/src/routes/parse.rs
+++ b/apps/server/src/routes/parse.rs
@@ -53,14 +53,20 @@ fn reject_unsupported_streaming_opening_filter(query: &ParseQuery) -> Result<(),
 ///
 /// Must stay in sync with the writer in `parse_parquet` / `parse_parquet_stream`,
 /// which derives the same suffix from `OpeningFilterMode::cache_key_suffix()`.
+///
+/// Version bumped `v2` → `v3` with issue #900: geometry entries cached before the
+/// symbolic sidecar existed have no `{cache_key}-symbolic-v1` companion, so serving
+/// them would make `GET /api/v1/parse/symbolic/{cache_key}` return `202` forever and
+/// the parquet-stream fast-path emit no symbols. Bumping invalidates those entries so
+/// the next request reprocesses and writes the sidecar alongside the geometry.
 fn parquet_cache_key(hash: &str, opening_filter: OpeningFilterMode) -> String {
-    format!("{}-{}-parquet-v2", hash, opening_filter.cache_key_suffix())
+    format!("{}-{}-parquet-v3", hash, opening_filter.cache_key_suffix())
 }
 
 /// Build the parquet metadata cache key for a given file hash and opening filter.
 fn parquet_metadata_cache_key(hash: &str, opening_filter: OpeningFilterMode) -> String {
     format!(
-        "{}-{}-parquet-metadata-v2",
+        "{}-{}-parquet-metadata-v3",
         hash,
         opening_filter.cache_key_suffix()
     )
@@ -347,8 +353,8 @@ pub async fn parse_parquet_stream(
 
     // OPTIMIZATION: Check cache first and fast-path return if available
     // This avoids re-processing files that are already cached
-    let parquet_cache_key = format!("{}-parquet-v2", cache_key);
-    let metadata_cache_key = format!("{}-parquet-metadata-v2", cache_key);
+    let parquet_cache_key = format!("{}-parquet-v3", cache_key);
+    let metadata_cache_key = format!("{}-parquet-metadata-v3", cache_key);
 
     if let (Some(cached_parquet), Some(cached_metadata_json)) = (
         state.cache.get_bytes(&parquet_cache_key).await?,
@@ -526,7 +532,7 @@ pub async fn parse_parquet_stream(
                         combined_parquet.extend_from_slice(&0u32.to_le_bytes()); // data_model_len = 0
 
                         // Cache geometry (same format as non-streaming)
-                        let parquet_cache_key = format!("{}-parquet-v2", key);
+                        let parquet_cache_key = format!("{}-parquet-v3", key);
                         if let Err(e) = cache.set_bytes(&parquet_cache_key, &combined_parquet).await {
                             tracing::error!(error = %e, "Failed to cache geometry from stream");
                         } else {
@@ -548,7 +554,7 @@ pub async fn parse_parquet_stream(
                             data_model_stats: None, // Data model cached separately via data model endpoint
                         };
                         if let Ok(metadata_json) = serde_json::to_vec(&metadata_header) {
-                            let metadata_cache_key = format!("{}-parquet-metadata-v2", key);
+                            let metadata_cache_key = format!("{}-parquet-metadata-v3", key);
                             if let Err(e) = cache.set_bytes(&metadata_cache_key, &metadata_json).await {
                                 tracing::error!(error = %e, "Failed to cache metadata from stream");
                             } else {
@@ -704,8 +710,8 @@ pub async fn parse_parquet(
     );
 
     // Check cache first (before any processing)
-    let parquet_cache_key = format!("{}-parquet-v2", cache_key);
-    let metadata_cache_key = format!("{}-parquet-metadata-v2", cache_key);
+    let parquet_cache_key = format!("{}-parquet-v3", cache_key);
+    let metadata_cache_key = format!("{}-parquet-metadata-v3", cache_key);
 
     if let (Some(cached_parquet), Some(cached_metadata_json)) = (
         state.cache.get_bytes(&parquet_cache_key).await?,
@@ -836,8 +842,8 @@ pub async fn parse_parquet(
     let metadata_json = serde_json::to_string(&metadata_header)?;
 
     // Cache the results for future requests
-    let parquet_cache_key = format!("{}-parquet-v2", cache_key_clone);
-    let metadata_cache_key = format!("{}-parquet-metadata-v2", cache_key_clone);
+    let parquet_cache_key = format!("{}-parquet-v3", cache_key_clone);
+    let metadata_cache_key = format!("{}-parquet-metadata-v3", cache_key_clone);
     let combined_parquet_clone = combined_parquet.clone();
     let metadata_json_clone = metadata_json.clone();
     let cache = state.cache.clone();
@@ -1180,23 +1186,23 @@ mod tests {
     use super::*;
 
     /// Regression test for #587: the reader (`check_cache`) used to look up
-    /// `{hash}-parquet-v2`, while the writer (`parse_parquet`) stored
-    /// `{hash}-{opening_filter}-parquet-v2`, so the check always returned 404.
+    /// `{hash}-parquet-v3`, while the writer (`parse_parquet`) stored
+    /// `{hash}-{opening_filter}-parquet-v3`, so the check always returned 404.
     /// The shared helper must produce the same key the writer stores under.
     #[test]
     fn parquet_cache_key_matches_writer_format() {
         let hash = "0ab20f4e4014";
 
         // The writer composes `cache_key = format!("{hash}-{suffix}")` and then
-        // `format!("{cache_key}-parquet-v2")`. The helper must produce the same string.
+        // `format!("{cache_key}-parquet-v3")`. The helper must produce the same string.
         for mode in [
             OpeningFilterMode::Default,
             OpeningFilterMode::IgnoreAll,
             OpeningFilterMode::IgnoreOpaque,
         ] {
             let writer_cache_key = format!("{}-{}", hash, mode.cache_key_suffix());
-            let writer_parquet_key = format!("{}-parquet-v2", writer_cache_key);
-            let writer_metadata_key = format!("{}-parquet-metadata-v2", writer_cache_key);
+            let writer_parquet_key = format!("{}-parquet-v3", writer_cache_key);
+            let writer_metadata_key = format!("{}-parquet-metadata-v3", writer_cache_key);
 
             assert_eq!(parquet_cache_key(hash, mode), writer_parquet_key);
             assert_eq!(parquet_metadata_cache_key(hash, mode), writer_metadata_key);
@@ -1206,7 +1212,7 @@ mod tests {
     #[test]
     fn parquet_cache_key_default_filter_uses_default_suffix() {
         let key = parquet_cache_key("abc", OpeningFilterMode::Default);
-        assert_eq!(key, "abc-default-parquet-v2");
+        assert_eq!(key, "abc-default-parquet-v3");
     }
 
     /// The symbolic cache key (issue #900) is derived from the full

--- a/apps/server/src/services/streaming.rs
+++ b/apps/server/src/services/streaming.rs
@@ -13,7 +13,7 @@ use ifc_lite_core::{
     EntityScanner, IfcType,
 };
 use ifc_lite_geometry::{calculate_normals, GeometryRouter};
-use ifc_lite_processing::convert_mesh_to_site_local;
+use ifc_lite_processing::{convert_mesh_to_site_local, extract_symbolic_data, SymbolicData};
 use rayon::prelude::*;
 use rustc_hash::FxHashMap;
 use std::pin::Pin;
@@ -472,6 +472,19 @@ pub fn process_streaming(
         // Generate cache key for the complete result
         let cache_key = DiskCache::generate_key(prepared.content.as_bytes());
 
+        // Extract the 2D symbolic stream (IfcAnnotation + IfcGrid) once, on a
+        // blocking thread, so the streaming Complete event reaches parity with
+        // the synchronous `POST /api/v1/parse` response (issue #900).
+        let symbolic_content = prepared.content.clone();
+        let symbolic_data = tokio::task::spawn_blocking(move || {
+            extract_symbolic_data(&symbolic_content)
+        })
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!(error = %e, "Symbolic-data extraction task panicked");
+            SymbolicData::default()
+        });
+
         yield StreamEvent::Complete {
             stats: ProcessingStats {
                 total_meshes: all_meshes.len(),
@@ -504,6 +517,7 @@ pub fn process_streaming(
             mesh_coordinate_space: Some(prepared.mesh_coordinate_space.to_string()),
             site_transform: prepared.site_transform,
             building_transform: prepared.building_transform,
+            symbolic_data,
         };
     })
 }

--- a/apps/server/src/types/response.rs
+++ b/apps/server/src/types/response.rs
@@ -8,6 +8,7 @@
 //! re-exported from the `ifc-lite-processing` crate. Server-only types remain here.
 
 use super::MeshData;
+use ifc_lite_processing::SymbolicData;
 use serde::{Deserialize, Serialize};
 
 // Re-export shared types from the processing crate
@@ -71,6 +72,11 @@ pub enum StreamEvent {
         /// IfcBuilding ObjectPlacement as a column-major 4×4 matrix (metres).
         #[serde(skip_serializing_if = "Option::is_none")]
         building_transform: Option<Vec<f64>>,
+        /// 2D symbol data extracted from `IfcAnnotation` and `IfcGrid`
+        /// entities — mirrors the inline field on `POST /api/v1/parse`
+        /// (issue #843) so the streaming paths reach parity (issue #900).
+        #[serde(default, skip_serializing_if = "SymbolicData::is_empty")]
+        symbolic_data: SymbolicData,
     },
 
     /// Error occurred.

--- a/docs/guide/server.md
+++ b/docs/guide/server.md
@@ -132,6 +132,12 @@ console.log(`From cache: ${result.stats.from_cache}`);
 | `/api/v1/parse/parquet-stream` | POST | Streaming Parquet (SSE) |
 | `/api/v1/parse/metadata` | POST | Quick metadata only (no geometry) |
 
+All parse endpoints that return geometry also surface the 2D symbol stream
+(`IfcAnnotation` + `IfcGrid`), matching `@ifc-lite/parse`. The JSON and SSE
+responses carry it inline as `symbolic_data` (in the `complete` event for the
+streaming variants); the binary Parquet transports expose it by cache key via
+`/api/v1/parse/symbolic/{key}` (see below).
+
 ### Cache Endpoints
 
 | Endpoint | Method | Description |
@@ -140,6 +146,7 @@ console.log(`From cache: ${result.stats.from_cache}`);
 | `/api/v1/cache/geometry/{hash}` | GET | Fetch cached geometry (no upload) |
 | `/api/v1/cache/{key}` | GET | Retrieve cached JSON result |
 | `/api/v1/parse/data-model/{key}` | GET | Fetch cached data model |
+| `/api/v1/parse/symbolic/{key}` | GET | Fetch 2D symbol data (`IfcAnnotation` + `IfcGrid`) as JSON |
 
 ### Utility Endpoints
 
@@ -271,6 +278,23 @@ if (dataModel) {
   const decoded = await decodeDataModel(dataModel);
   console.log(`Entities: ${decoded.entities.size}`);
   console.log(`Property sets: ${decoded.propertySets.size}`);
+}
+```
+
+#### Fetching Symbolic Data
+
+The JSON (`parse`) and streaming endpoints return the 2D symbol stream
+(`IfcAnnotation` + `IfcGrid`) inline as `symbolic_data`. The binary Parquet
+endpoints (`parseParquet`, `parseParquetOptimized`) can't carry it inline —
+fetch it by cache key instead:
+
+```typescript
+const result = await client.parseParquet(file);
+
+const symbols = await client.fetchSymbolic(result.cache_key);
+if (symbols) {
+  console.log(`Grid axes: ${symbols.grid_axes.length}`);
+  console.log(`Annotations: ${symbols.polylines.length} polylines, ${symbols.texts.length} labels`);
 }
 ```
 

--- a/packages/server-client/src/client.ts
+++ b/packages/server-client/src/client.ts
@@ -269,7 +269,14 @@ export class IfcServerClient {
 
       // Symbolic data isn't in the cached geometry payload — fetch it by key
       // so the cache-HIT path reaches the same parity as the live stream.
-      const cachedSymbolic = await this.fetchSymbolic(cachedResult.cache_key);
+      // Symbols are supplementary, so a fetch failure must not fail the geometry
+      // load: log and continue without them (fetchSymbolic surfaces real errors).
+      let cachedSymbolic: SymbolicData | null = null;
+      try {
+        cachedSymbolic = await this.fetchSymbolic(cachedResult.cache_key);
+      } catch (error) {
+        console.warn('[client] Symbolic fetch failed on cache hit; continuing without symbols:', error);
+      }
 
       return {
         cache_key: cachedResult.cache_key,
@@ -660,35 +667,41 @@ export class IfcServerClient {
     let delay = 100; // Start with 100ms delay
 
     for (let attempt = 0; attempt < maxRetries; attempt++) {
+      // Only transport/timeout failures are retried here. HTTP error statuses
+      // are handled below so a persistent 5xx surfaces as a thrown error rather
+      // than being collapsed into `null` (which would look like "no symbols").
+      let response: Response;
       try {
-        const response = await fetch(`${this.baseUrl}/api/v1/parse/symbolic/${cacheKey}`, {
+        response = await fetch(`${this.baseUrl}/api/v1/parse/symbolic/${cacheKey}`, {
           method: 'GET',
           signal: AbortSignal.timeout(30000),
         });
-
-        if (response.status === 200) {
-          return (await response.json()) as SymbolicData;
-        } else if (response.status === 202) {
-          // Still processing (streaming background cache), wait and retry
-          await new Promise(resolve => setTimeout(resolve, delay));
-          delay = Math.min(delay * 1.5, 2000); // Exponential backoff, max 2s
-        } else if (response.status === 404) {
-          console.warn(`[client] Symbolic data not found for cache key: ${cacheKey}`);
-          return null;
-        } else {
-          throw new Error(`Unexpected response status: ${response.status}`);
-        }
       } catch (error) {
-        if (attempt === maxRetries - 1) {
-          console.error('[client] Failed to fetch symbolic data:', error);
-          return null;
-        }
-        // Retry on network errors
+        if (attempt === maxRetries - 1) throw error;
+        console.warn('[client] Retrying symbolic data fetch after network error:', error);
+        await new Promise(resolve => setTimeout(resolve, delay));
+        delay = Math.min(delay * 1.5, 2000); // Exponential backoff, max 2s
+        continue;
+      }
+
+      if (response.status === 200) {
+        return (await response.json()) as SymbolicData;
+      } else if (response.status === 202) {
+        // Still processing (streaming background cache), wait and retry.
         await new Promise(resolve => setTimeout(resolve, delay));
         delay = Math.min(delay * 1.5, 2000);
+      } else if (response.status === 404) {
+        // Definitive "no entry for this cache key" — distinct from a server error.
+        console.warn(`[client] Symbolic data not found for cache key: ${cacheKey}`);
+        return null;
+      } else {
+        // 5xx / other unexpected status: surface it instead of masking it.
+        throw await this.handleError(response);
       }
     }
 
+    // Exhausted retries while still 202 (background cache not ready). This is a
+    // known "not yet available" state, so return null rather than throwing.
     console.warn('[client] Symbolic data fetch timed out after max retries');
     return null;
   }

--- a/packages/server-client/src/client.ts
+++ b/packages/server-client/src/client.ts
@@ -18,6 +18,7 @@ import type {
   ProcessingStats,
   ServerConfig,
   StreamEvent,
+  SymbolicData,
 } from './types.js';
 import { decodeParquetGeometry, decodeOptimizedParquetGeometry, isParquetAvailable } from './parquet-decoder.js';
 
@@ -266,11 +267,16 @@ export class IfcServerClient {
         decode_time_ms: performance.now() - decodeStart,
       });
 
+      // Symbolic data isn't in the cached geometry payload — fetch it by key
+      // so the cache-HIT path reaches the same parity as the live stream.
+      const cachedSymbolic = await this.fetchSymbolic(cachedResult.cache_key);
+
       return {
         cache_key: cachedResult.cache_key,
         total_meshes: cachedResult.meshes.length,
         stats: cachedResult.stats,
         metadata: cachedResult.metadata,
+        symbolic_data: cachedSymbolic ?? undefined,
       };
     }
 
@@ -303,6 +309,7 @@ export class IfcServerClient {
     let total_meshes = 0;
     let stats: ProcessingStats | null = null;
     let metadata: ModelMetadata | null = null;
+    let symbolic_data: SymbolicData | undefined;
 
     while (true) {
       const { done, value } = await reader.read();
@@ -361,6 +368,7 @@ export class IfcServerClient {
             case 'complete':
               stats = event.stats;
               metadata = event.metadata;
+              symbolic_data = event.symbolic_data;
               const totalTime = performance.now() - uploadStart;
               console.log(`[client] Stream complete: ${total_meshes} meshes in ${totalTime.toFixed(0)}ms`);
               break;
@@ -387,6 +395,7 @@ export class IfcServerClient {
       total_meshes,
       stats,
       metadata,
+      symbolic_data,
     };
   }
 
@@ -617,6 +626,70 @@ export class IfcServerClient {
     }
 
     console.warn('[client] Data model fetch timed out after max retries');
+    return null;
+  }
+
+  /**
+   * Fetch the 2D symbol stream (`IfcAnnotation` + `IfcGrid`) for a previously
+   * parsed file.
+   *
+   * The JSON endpoints (`parse`, `parseStream`) and the streaming Parquet path
+   * already deliver `symbolic_data` inline. This helper is for the binary
+   * Parquet transports (`parseParquet`, `parseParquetOptimized`) whose payloads
+   * can't carry it inline — fetch it by the `cache_key` returned in their
+   * result, mirroring {@link fetchDataModel}.
+   *
+   * Symbolic data is cached synchronously by the non-streaming endpoints, so
+   * this typically returns on the first attempt; the streaming endpoint caches
+   * it in the background, hence the bounded retry.
+   *
+   * @param cacheKey - The `cache_key` from a parse response
+   * @param maxRetries - Maximum number of retries (default: 10)
+   * @returns Decoded symbol data, or null if unavailable after retries
+   *
+   * @example
+   * ```typescript
+   * const result = await client.parseParquet(file);
+   * const symbols = await client.fetchSymbolic(result.cache_key);
+   * if (symbols) {
+   *   console.log(`${symbols.grid_axes.length} grid axes, ${symbols.texts.length} labels`);
+   * }
+   * ```
+   */
+  async fetchSymbolic(cacheKey: string, maxRetries = 10): Promise<SymbolicData | null> {
+    let delay = 100; // Start with 100ms delay
+
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      try {
+        const response = await fetch(`${this.baseUrl}/api/v1/parse/symbolic/${cacheKey}`, {
+          method: 'GET',
+          signal: AbortSignal.timeout(30000),
+        });
+
+        if (response.status === 200) {
+          return (await response.json()) as SymbolicData;
+        } else if (response.status === 202) {
+          // Still processing (streaming background cache), wait and retry
+          await new Promise(resolve => setTimeout(resolve, delay));
+          delay = Math.min(delay * 1.5, 2000); // Exponential backoff, max 2s
+        } else if (response.status === 404) {
+          console.warn(`[client] Symbolic data not found for cache key: ${cacheKey}`);
+          return null;
+        } else {
+          throw new Error(`Unexpected response status: ${response.status}`);
+        }
+      } catch (error) {
+        if (attempt === maxRetries - 1) {
+          console.error('[client] Failed to fetch symbolic data:', error);
+          return null;
+        }
+        // Retry on network errors
+        await new Promise(resolve => setTimeout(resolve, delay));
+        delay = Math.min(delay * 1.5, 2000);
+      }
+    }
+
+    console.warn('[client] Symbolic data fetch timed out after max retries');
     return null;
   }
 

--- a/packages/server-client/src/types.ts
+++ b/packages/server-client/src/types.ts
@@ -159,8 +159,11 @@ export interface SymbolicFillArea {
   has_hatching: boolean;
   hatch_spacing: number;
   hatch_angle: number;
-  /** Secondary cross-hatch angle (`NaN` if absent). */
-  hatch_angle_secondary: number;
+  /**
+   * Secondary cross-hatch angle. `null` when absent — the Rust model uses
+   * `f32::NAN`, which `serde_json` serializes as JSON `null` (not `NaN`).
+   */
+  hatch_angle_secondary: number | null;
   hatch_line_width: number;
   world_y: number;
   representation: string;

--- a/packages/server-client/src/types.ts
+++ b/packages/server-client/src/types.ts
@@ -74,6 +74,114 @@ export interface ProcessingStats {
   from_cache: boolean;
 }
 
+// ============================================
+// 2D Symbol Data (IfcAnnotation + IfcGrid)
+// ============================================
+
+/**
+ * A single `IfcGridAxis` tag + axis curve (compact endpoint-pair shape).
+ */
+export interface SymbolicGridAxis {
+  express_id: number;
+  grid_express_id: number;
+  tag: string;
+  /** Endpoint pair `[x0, y0, x1, y1]` in metres (plan view). */
+  endpoints: [number, number, number, number];
+  world_y: number;
+}
+
+/**
+ * A 2D polyline (`IfcPolyline`, `IfcIndexedPolyCurve`, tessellated ellipses,
+ * trimmed-curve arcs, grid axis lines).
+ */
+export interface SymbolicPolyline {
+  express_id: number;
+  ifc_type: string;
+  /** Flat `[x0, y0, x1, y1, …]` plan-view coordinates. */
+  points: number[];
+  closed: boolean;
+  world_y: number;
+  representation: string;
+}
+
+/**
+ * A 2D circle / arc (`IfcCircle`).
+ */
+export interface SymbolicCircle {
+  express_id: number;
+  ifc_type: string;
+  center_x: number;
+  center_y: number;
+  radius: number;
+  world_y: number;
+  /** Start angle in radians (0 for a full circle). */
+  start_angle: number;
+  /** End angle in radians (`2π` for a full circle). */
+  end_angle: number;
+  representation: string;
+}
+
+/**
+ * A 2D text annotation (`IfcTextLiteral` / grid bubble glyphs + tags).
+ */
+export interface SymbolicText {
+  express_id: number;
+  ifc_type: string;
+  x: number;
+  y: number;
+  /** Baseline orientation as a `(cos, sin)` pair. */
+  dir_x: number;
+  dir_y: number;
+  /** Font cap height in model units (already unit-scaled). */
+  height: number;
+  content: string;
+  /** IFC `BoxAlignment` (`top-left`, `center`, …). Empty when absent. */
+  alignment: string;
+  world_y: number;
+  /** sRGB straight-alpha colour `[r, g, b, a]`. */
+  color: [number, number, number, number];
+  /** Per-instance target screen-pixel cap height (`0` = renderer default). */
+  target_px: number;
+  representation: string;
+}
+
+/**
+ * A 2D filled region (`IfcAnnotationFillArea`). Outer ring + optional holes
+ * packed into a single `points` buffer; `holes_offsets[i]` is the vertex index
+ * where hole `i` begins.
+ */
+export interface SymbolicFillArea {
+  express_id: number;
+  ifc_type: string;
+  points: number[];
+  holes_offsets: number[];
+  fill_color: [number, number, number, number];
+  has_hatching: boolean;
+  hatch_spacing: number;
+  hatch_angle: number;
+  /** Secondary cross-hatch angle (`NaN` if absent). */
+  hatch_angle_secondary: number;
+  hatch_line_width: number;
+  world_y: number;
+  representation: string;
+}
+
+/**
+ * 2D symbol data extracted from `IfcAnnotation` and `IfcGrid` entities.
+ *
+ * Returned inline by `POST /api/v1/parse` and the streaming `complete` events,
+ * and fetched by cache key from `GET /api/v1/parse/symbolic/{cache_key}` for the
+ * binary (Parquet) transports. Arrays may be empty when the model carries no
+ * 2D symbols.
+ */
+export interface SymbolicData {
+  grid_axes: SymbolicGridAxis[];
+  polylines: SymbolicPolyline[];
+  circles: SymbolicCircle[];
+  texts: SymbolicText[];
+  fills: SymbolicFillArea[];
+}
+
 /**
  * Full parse response with all meshes.
  */
@@ -86,6 +194,11 @@ export interface ParseResponse {
   metadata: ModelMetadata;
   /** Processing statistics */
   stats: ProcessingStats;
+  /**
+   * 2D symbol data (`IfcAnnotation` + `IfcGrid`). Omitted when the model has
+   * no 2D symbols.
+   */
+  symbolic_data?: SymbolicData;
 }
 
 /**
@@ -178,6 +291,11 @@ export interface StreamCompleteEvent {
   metadata: ModelMetadata;
   /** Cache key for the result */
   cache_key: string;
+  /**
+   * 2D symbol data (`IfcAnnotation` + `IfcGrid`). Omitted when the model has
+   * no 2D symbols.
+   */
+  symbolic_data?: SymbolicData;
 }
 
 /**
@@ -368,6 +486,11 @@ export interface ParquetStreamCompleteEvent {
   stats: ProcessingStats;
   /** Model metadata */
   metadata: ModelMetadata;
+  /**
+   * 2D symbol data (`IfcAnnotation` + `IfcGrid`). Omitted when the model has
+   * no 2D symbols.
+   */
+  symbolic_data?: SymbolicData;
 }
 
 /**
@@ -403,4 +526,9 @@ export interface ParquetStreamResult {
   stats: ProcessingStats;
   /** Model metadata */
   metadata: ModelMetadata;
+  /**
+   * 2D symbol data (`IfcAnnotation` + `IfcGrid`) from the stream's `complete`
+   * event. Omitted when the model has no 2D symbols.
+   */
+  symbolic_data?: SymbolicData;
 }


### PR DESCRIPTION
Closes #900.

## Summary

Issue #843 added the 2D symbol stream (`symbolic_data` — `IfcAnnotation` + `IfcGrid`) to the synchronous `POST /api/v1/parse` JSON response. The reporter (#900) noticed every *other* geometry/parsing endpoint still dropped it, so the data was reachable only through that one endpoint. This brings the **whole** Server API to parity with `@ifc-lite/parse`.

The transport is matched per endpoint, reusing the data-model "cache + fetch-by-`cache_key`" pattern (symbol data can be large for annotation-heavy drawings, so it never travels in an HTTP header):

| Endpoint | Transport | How symbol data is delivered |
|---|---|---|
| `POST /api/v1/parse` | JSON | inline `symbolic_data` (already) + cached for fetch |
| `GET /api/v1/cache/:key` | JSON (cached `ParseResponse`) | inline (already) |
| `POST /api/v1/parse/stream` | SSE JSON | inline in the `complete` event |
| `POST /api/v1/parse/parquet-stream` | SSE | inline in the `complete` event + cached |
| `POST /api/v1/parse/parquet` | binary + header | cached `{cache_key}-symbolic-v1` |
| `POST /api/v1/parse/parquet/optimized` | binary + header | cached `{cache_key}-symbolic-v1` |
| `GET /api/v1/cache/geometry/:hash` | binary (cached) | via the cache key |
| **`GET /api/v1/parse/symbolic/{cache_key}`** | **new** | JSON symbol stream for the binary transports |

`POST /api/v1/parse/metadata` is intentionally excluded (counts only, no geometry).

## Changes

**Server (`apps/server`, ships in `@ifc-lite/server-bin`):**
- `StreamEvent::Complete` / `ParquetStreamEvent::Complete` carry `symbolic_data`; it's extracted once at the end of the shared `process_streaming`, so both streaming endpoints get it with no extra parse.
- `/parse/parquet` + `/parse/parquet/optimized` extract symbols in parallel with geometry (`rayon::join`) and cache them.
- New `GET /api/v1/parse/symbolic/{cache_key}` handler (mirrors `get_data_model`; `202` while a stream caches in the background).
- `parse_full` and the cached-geometry fast paths populate the same `{cache_key}-symbolic-v1` entry, so the fetch endpoint works no matter which endpoint processed the file first.
- Extracted `build_router(state)` from `main` to enable in-process route tests.

**Client (`@ifc-lite/server-client`):**
- New `SymbolicData` (+ `SymbolicGridAxis`/`SymbolicPolyline`/`SymbolicCircle`/`SymbolicText`/`SymbolicFillArea`) types.
- `symbolic_data?` on `ParseResponse`, `StreamCompleteEvent`, `ParquetStreamCompleteEvent`, `ParquetStreamResult`.
- New `client.fetchSymbolic(cacheKey)` (parallel to `fetchDataModel`); `parseParquetStream` now returns `symbolic_data`.

**Docs / changeset:** server guide updated; changeset bumps `@ifc-lite/server-bin` + `@ifc-lite/server-client` minor.

## Test plan
- [x] `cargo test -p ifc-lite-server` — 15 pass, incl. 5 new integration tests in `apps/server/src/parity_tests.rs` driving a grid + annotation + wall fixture through `/parse`, `/parse/parquet`, `/parse/parquet/optimized`, the new symbolic endpoint, and `process_streaming`.
- [x] `cargo test -p ifc-lite-processing` symbolic tests still green.
- [x] `@ifc-lite/server-client` builds (`tsc`); viewer typechecks clean (only a pre-existing unrelated `@vercel/analytics/react` error).
- [x] `pnpm changeset status` confirms the bumps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 2D symbolic data (annotations & grids) available across all geometry parse endpoints.
  * Streaming completion events and Parquet/parsing flows now include or expose symbolic_data.
  * New fetch endpoint to retrieve cached symbolic data; client exposes fetchSymbolic and propagates symbolic data in responses.
  * Parquet cache version bumped so existing cached models receive symbolic sidecars.

* **Documentation**
  * Server guide updated with symbolic data usage and examples.

* **Tests**
  * Added parity/integration tests validating symbolic output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->