### PR TITLE
feat(server): georeferencing + length-unit scale on all geometry endpoints (#900 parity)

### DIFF
--- a/.changeset/feat-900-georeferencing-units-parity.md
+++ b/.changeset/feat-900-georeferencing-units-parity.md
@@ -1,0 +1,37 @@
+---
+"@ifc-lite/server-bin": minor
+"@ifc-lite/server-client": minor
+---
+
+Surface georeferencing and the length-unit scale from the Server's geometry
+endpoints, continuing the `@ifc-lite/parse` parity work (issue #900).
+
+The browser parser exposes `IfcMapConversion` / `IfcProjectedCRS` georeferencing
+(`extractGeoreferencing`) and the length-unit scale (`extractLengthUnitScale`),
+but the server returned only a coarse `is_geo_referenced` boolean and kept the
+unit scale internal. Both are now carried inline on `ModelMetadata`, so they
+reach **every** geometry endpoint at once (JSON, SSE, Parquet, optimized Parquet,
+and the cached-geometry paths) — no new endpoint or fetch round-trip.
+
+Server (shipped in the `@ifc-lite/server-bin` binary):
+
+- `ModelMetadata` gains `length_unit_scale: Option<f64>` and
+  `georeferencing: Option<Georeferencing>` (CRS name / geodetic + vertical datum
+  / map projection, false eastings/northings, orthogonal height, X-axis
+  direction, scale, derived grid-north `rotation_degrees`, and a column-major
+  local→map `transform_matrix`).
+- Georeferencing reuses the existing shared `ifc_lite_core::GeoRefExtractor`
+  (the same extraction the native/desktop paths use, including the IFC2x3
+  `ePSet_MapConversion` fallback) via a new `ifc_lite_processing::extract_georeferencing`.
+- Populated in the shared geometry pipeline (`process_geometry_filtered`) and the
+  server's streaming `Complete` event (extracted on a blocking thread).
+
+Client (`@ifc-lite/server-client`):
+
+- New `Georeferencing` type; `ModelMetadata` gains optional `length_unit_scale`
+  and `georeferencing`.
+
+Regression coverage: `rust/processing/tests/issue_900_georeferencing_metadata.rs`
+asserts a georeferenced metre model surfaces the CRS + offsets + rotation and a
+millimetre model reports `length_unit_scale = 0.001` with no georeferencing, plus
+unit tests in `georeferencing.rs`.

--- a/apps/server/src/services/streaming.rs
+++ b/apps/server/src/services/streaming.rs
@@ -472,6 +472,20 @@ pub fn process_streaming(
         // Generate cache key for the complete result
         let cache_key = DiskCache::generate_key(prepared.content.as_bytes());
 
+        // Extract georeferencing on a blocking thread so the streaming Complete
+        // event carries the same map-conversion/CRS metadata as the synchronous
+        // endpoints (issue #900). Cheap relative to geometry; never blocks the
+        // async executor.
+        let georef_content = prepared.content.clone();
+        let georeferencing = tokio::task::spawn_blocking(move || {
+            ifc_lite_processing::extract_georeferencing(&georef_content)
+        })
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!(error = %e, "Georeferencing extraction task panicked");
+            None
+        });
+
         yield StreamEvent::Complete {
             stats: ProcessingStats {
                 total_meshes: all_meshes.len(),
@@ -499,6 +513,8 @@ pub fn process_streaming(
                         || prepared.rtc_offset.1 != 0.0
                         || prepared.rtc_offset.2 != 0.0,
                 },
+                length_unit_scale: Some(prepared.unit_scale),
+                georeferencing,
             },
             cache_key,
             mesh_coordinate_space: Some(prepared.mesh_coordinate_space.to_string()),

--- a/docs/guide/server.md
+++ b/docs/guide/server.md
@@ -132,6 +132,14 @@ console.log(`From cache: ${result.stats.from_cache}`);
 | `/api/v1/parse/parquet-stream` | POST | Streaming Parquet (SSE) |
 | `/api/v1/parse/metadata` | POST | Quick metadata only (no geometry) |
 
+Every geometry endpoint's `ModelMetadata` carries `length_unit_scale` (factor to
+convert model length values to metres, e.g. `0.001` for millimetres) and, when
+the model has an `IfcMapConversion` / `IfcProjectedCRS`, a `georeferencing`
+object (CRS name, datum, false eastings/northings, orthogonal height, grid-north
+rotation, and a local→map 4×4 matrix) — matching `@ifc-lite/parse`. For the
+JSON/SSE endpoints it's on `metadata`; for the Parquet endpoints it's in the
+`X-IFC-Metadata` header.
+
 ### Cache Endpoints
 
 | Endpoint | Method | Description |

--- a/packages/server-client/src/types.ts
+++ b/packages/server-client/src/types.ts
@@ -42,6 +42,49 @@ export interface ModelMetadata {
   geometry_entity_count: number;
   /** Coordinate system information */
   coordinate_info: CoordinateInfo;
+  /**
+   * Length unit scale to convert model length values to metres (e.g. `0.001`
+   * for millimetres). Absent on older servers — treat as `1`.
+   */
+  length_unit_scale?: number;
+  /**
+   * Georeferencing (`IfcMapConversion` + `IfcProjectedCRS`). Absent when the
+   * model carries no map-conversion data.
+   */
+  georeferencing?: Georeferencing;
+}
+
+/**
+ * Georeferencing metadata (`IfcMapConversion` + `IfcProjectedCRS`).
+ *
+ * Surfaced on every geometry endpoint's `ModelMetadata`, matching the browser
+ * parser's `extractGeoreferencing`.
+ */
+export interface Georeferencing {
+  /** Projected CRS name from `IfcProjectedCRS.Name` (e.g. "EPSG:32632"). */
+  crs_name?: string;
+  /** Geodetic datum (e.g. "WGS84"). */
+  geodetic_datum?: string;
+  /** Vertical datum (e.g. "NAVD88"). */
+  vertical_datum?: string;
+  /** Map projection (e.g. "UTM"). */
+  map_projection?: string;
+  /** False easting — X offset to the map CRS, in the project's length unit. */
+  eastings: number;
+  /** False northing — Y offset to the map CRS, in the project's length unit. */
+  northings: number;
+  /** Orthogonal height — Z offset to the map CRS. */
+  orthogonal_height: number;
+  /** X-axis abscissa: cosine of the rotation to grid north. */
+  x_axis_abscissa: number;
+  /** X-axis ordinate: sine of the rotation to grid north. */
+  x_axis_ordinate: number;
+  /** Scale factor applied during the local→map transform (default 1). */
+  scale: number;
+  /** Rotation to grid north in degrees, derived from the X-axis direction. */
+  rotation_degrees: number;
+  /** Local→map transform as a column-major 4×4 matrix (16 values). */
+  transform_matrix: number[];
 }
 
 /**

--- a/rust/core/src/georef.rs
+++ b/rust/core/src/georef.rs
@@ -252,7 +252,10 @@ impl GeoRefExtractor {
         for (id, ifc_type) in entity_types {
             if *ifc_type == IfcType::IfcPropertySet {
                 let entity = decoder.decode_by_id(*id)?;
-                if let Some(name) = entity.get_string(0) {
+                // IfcPropertySet.Name is attribute 2 (attribute 0 is GlobalId);
+                // reading attribute 0 here never matched the ePSet, so the
+                // IFC2x3 georeferencing fallback was dead (issue #900 review).
+                if let Some(name) = entity.get_string(2) {
                     if name == "ePSet_MapConversion" || name == "EPset_MapConversion" {
                         return Self::parse_pset_map_conversion(decoder, &entity);
                     }

--- a/rust/processing/src/georeferencing.rs
+++ b/rust/processing/src/georeferencing.rs
@@ -1,0 +1,167 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Georeferencing extraction for the HTTP server response.
+//!
+//! The browser parser (`@ifc-lite/parse`) exposes `IfcMapConversion` /
+//! `IfcProjectedCRS` georeferencing via `extractGeoreferencing`. The server
+//! previously surfaced only a coarse `is_geo_referenced` boolean, so consumers
+//! couldn't recover the real-world CRS, false eastings/northings, or grid-north
+//! rotation. This module reuses the shared `ifc_lite_core::GeoRefExtractor`
+//! (the same extraction the desktop/native paths use) and maps it into a
+//! serializable, server-friendly shape carried inline on every geometry
+//! endpoint's `ModelMetadata` (issue #900 parity follow-up).
+
+use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner, GeoRefExtractor, IfcType};
+use serde::{Deserialize, Serialize};
+
+/// Georeferencing metadata (`IfcMapConversion` + `IfcProjectedCRS`).
+///
+/// Mirrors `ifc_lite_core::GeoReference` with two derived conveniences
+/// (`rotation_degrees`, `transform_matrix`) so consumers don't have to
+/// recompute the rotation or the local→map matrix.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct Georeferencing {
+    /// Projected CRS name from `IfcProjectedCRS.Name` (e.g. `"EPSG:32632"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub crs_name: Option<String>,
+    /// Geodetic datum (e.g. `"WGS84"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub geodetic_datum: Option<String>,
+    /// Vertical datum (e.g. `"NAVD88"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vertical_datum: Option<String>,
+    /// Map projection (e.g. `"UTM"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub map_projection: Option<String>,
+    /// False easting — X offset to the map CRS, in the project's length unit.
+    pub eastings: f64,
+    /// False northing — Y offset to the map CRS, in the project's length unit.
+    pub northings: f64,
+    /// Orthogonal height — Z offset to the map CRS.
+    pub orthogonal_height: f64,
+    /// X-axis abscissa: cosine of the rotation to grid north.
+    pub x_axis_abscissa: f64,
+    /// X-axis ordinate: sine of the rotation to grid north.
+    pub x_axis_ordinate: f64,
+    /// Scale factor applied during the local→map transform (default `1.0`).
+    pub scale: f64,
+    /// Rotation to grid north in degrees, derived from the X-axis direction.
+    pub rotation_degrees: f64,
+    /// Local→map transform as a column-major 4×4 matrix (16 values).
+    pub transform_matrix: [f64; 16],
+}
+
+impl Georeferencing {
+    fn from_core(geo: &ifc_lite_core::GeoReference) -> Self {
+        Self {
+            crs_name: geo.crs_name.clone(),
+            geodetic_datum: geo.geodetic_datum.clone(),
+            vertical_datum: geo.vertical_datum.clone(),
+            map_projection: geo.map_projection.clone(),
+            eastings: geo.eastings,
+            northings: geo.northings,
+            orthogonal_height: geo.orthogonal_height,
+            x_axis_abscissa: geo.x_axis_abscissa,
+            x_axis_ordinate: geo.x_axis_ordinate,
+            scale: geo.scale,
+            rotation_degrees: geo.rotation().to_degrees(),
+            transform_matrix: geo.to_matrix(),
+        }
+    }
+}
+
+/// Extract georeferencing from an IFC file, returning `None` when the model
+/// carries no `IfcMapConversion` / `ePSet_MapConversion` data.
+///
+/// Only the entity types the extractor needs (`IfcMapConversion`,
+/// `IfcProjectedCRS`, and `IfcPropertySet` for the IFC2x3 `ePSet_MapConversion`
+/// fallback) are collected from the scan — their `IfcType` is known from the
+/// entity name, so no decoding happens while building the candidate list.
+pub fn extract_georeferencing(content: &str) -> Option<Georeferencing> {
+    let entity_index = build_entity_index(content);
+    let mut decoder = EntityDecoder::with_index(content, entity_index);
+
+    let mut entity_types: Vec<(u32, IfcType)> = Vec::new();
+    let mut scanner = EntityScanner::new(content);
+    while let Some((id, type_name, _start, _end)) = scanner.next_entity() {
+        match type_name {
+            "IFCMAPCONVERSION" => entity_types.push((id, IfcType::IfcMapConversion)),
+            "IFCPROJECTEDCRS" => entity_types.push((id, IfcType::IfcProjectedCRS)),
+            "IFCPROPERTYSET" => entity_types.push((id, IfcType::IfcPropertySet)),
+            _ => {}
+        }
+    }
+
+    if entity_types.is_empty() {
+        return None;
+    }
+
+    match GeoRefExtractor::extract(&mut decoder, &entity_types) {
+        Ok(Some(geo)) => Some(Georeferencing::from_core(&geo)),
+        Ok(None) => None,
+        Err(e) => {
+            tracing::debug!(error = %e, "Georeferencing extraction failed");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GEOREF_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('georef fixture'),'2;1');
+FILE_NAME('georef.ifc','2026-06-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#10=IFCPROJECTEDCRS('EPSG:32632','WGS84 / UTM zone 32N','WGS84',$,'UTM','32N',$);
+#11=IFCMAPCONVERSION(#2,#10,1000.5,2000.25,42.0,0.866025,0.5,1.0);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+    #[test]
+    fn extracts_map_conversion_and_crs() {
+        let geo = extract_georeferencing(GEOREF_IFC).expect("expected georeferencing");
+        assert_eq!(geo.crs_name.as_deref(), Some("EPSG:32632"));
+        assert_eq!(geo.geodetic_datum.as_deref(), Some("WGS84"));
+        assert_eq!(geo.map_projection.as_deref(), Some("UTM"));
+        assert!((geo.eastings - 1000.5).abs() < 1e-6);
+        assert!((geo.northings - 2000.25).abs() < 1e-6);
+        assert!((geo.orthogonal_height - 42.0).abs() < 1e-6);
+        // XAxisAbscissa/Ordinate = cos/sin(30°) → rotation_degrees ≈ 30.
+        assert!(
+            (geo.rotation_degrees - 30.0).abs() < 1e-3,
+            "rotation should be ~30°, got {}",
+            geo.rotation_degrees
+        );
+        // Translation column of the local→map matrix carries the offsets.
+        assert!((geo.transform_matrix[12] - 1000.5).abs() < 1e-6);
+        assert!((geo.transform_matrix[13] - 2000.25).abs() < 1e-6);
+    }
+
+    #[test]
+    fn returns_none_without_georeferencing() {
+        let plain = r#"ISO-10303-21;
+HEADER;
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+        assert!(extract_georeferencing(plain).is_none());
+    }
+}

--- a/rust/processing/src/georeferencing.rs
+++ b/rust/processing/src/georeferencing.rs
@@ -151,6 +151,33 @@ END-ISO-10303-21;
         assert!((geo.transform_matrix[13] - 2000.25).abs() < 1e-6);
     }
 
+    /// IFC2x3 models carry georeferencing via an `ePSet_MapConversion` property
+    /// set rather than `IfcMapConversion`. Regression for the core extractor bug
+    /// that read `IfcPropertySet.Name` from attribute 0 (GlobalId) instead of 2.
+    const IFC2X3_PSET_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ifc2x3 georef pset fixture'),'2;1');
+FILE_NAME('georef2x3.ifc','2026-06-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#1=IFCPROPERTYSINGLEVALUE('Eastings',$,IFCLENGTHMEASURE(1000.5),$);
+#2=IFCPROPERTYSINGLEVALUE('Northings',$,IFCLENGTHMEASURE(2000.25),$);
+#3=IFCPROPERTYSINGLEVALUE('OrthogonalHeight',$,IFCLENGTHMEASURE(42.),$);
+#4=IFCPROPERTYSET('0PSet00000000000000001',$,'ePSet_MapConversion',$,(#1,#2,#3));
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+    #[test]
+    fn extracts_ifc2x3_epset_map_conversion_fallback() {
+        let geo = extract_georeferencing(IFC2X3_PSET_IFC)
+            .expect("expected georeferencing from ePSet_MapConversion");
+        assert!((geo.eastings - 1000.5).abs() < 1e-6);
+        assert!((geo.northings - 2000.25).abs() < 1e-6);
+        assert!((geo.orthogonal_height - 42.0).abs() < 1e-6);
+    }
+
     #[test]
     fn returns_none_without_georeferencing() {
         let plain = r#"ISO-10303-21;

--- a/rust/processing/src/lib.rs
+++ b/rust/processing/src/lib.rs
@@ -7,10 +7,12 @@
 //! This crate extracts the core processing logic so it can be used by both
 //! the HTTP server and the native FFI library.
 
+mod georeferencing;
 mod processor;
 mod symbolic;
 mod types;
 
+pub use georeferencing::{extract_georeferencing, Georeferencing};
 pub use processor::{
     convert_mesh_to_site_local, process_geometry, process_geometry_filtered,
     process_geometry_streaming, process_geometry_streaming_filtered,

--- a/rust/processing/src/processor.rs
+++ b/rust/processing/src/processor.rs
@@ -1366,6 +1366,8 @@ pub fn process_geometry_streaming_filtered_with_options(
                 origin_shift: [rtc_offset.0, rtc_offset.1, rtc_offset.2],
                 is_geo_referenced: has_rtc_offset,
             },
+            length_unit_scale: Some(unit_scale),
+            georeferencing: crate::extract_georeferencing(content),
         },
         stats: ProcessingStats {
             total_meshes,

--- a/rust/processing/src/types/response.rs
+++ b/rust/processing/src/types/response.rs
@@ -5,6 +5,7 @@
 //! Shared response types for the IFC processing API.
 
 use super::mesh::MeshData;
+use crate::georeferencing::Georeferencing;
 use crate::symbolic::SymbolicData;
 use serde::{Deserialize, Serialize};
 
@@ -52,6 +53,17 @@ pub struct ModelMetadata {
     pub geometry_entity_count: usize,
     /// Coordinate system information.
     pub coordinate_info: CoordinateInfo,
+    /// Length unit scale to convert model length values to metres (e.g. `0.001`
+    /// for millimetres). `None` when not yet computed; consumers treat it as
+    /// `1.0`. Brings the server to parity with the browser parser's
+    /// `extractLengthUnitScale` (issue #900).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub length_unit_scale: Option<f64>,
+    /// Georeferencing (`IfcMapConversion` + `IfcProjectedCRS`). `None` when the
+    /// model carries no map-conversion data. Mirrors the browser parser's
+    /// `extractGeoreferencing` (issue #900).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub georeferencing: Option<Georeferencing>,
 }
 
 /// Coordinate system information.

--- a/rust/processing/tests/issue_900_georeferencing_metadata.rs
+++ b/rust/processing/tests/issue_900_georeferencing_metadata.rs
@@ -1,0 +1,116 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Issue #900 parity follow-up: the server's geometry pipeline must surface
+//! georeferencing (`IfcMapConversion` / `IfcProjectedCRS`) and the length-unit
+//! scale on `ModelMetadata`, matching the browser parser's `extractGeoreferencing`
+//! / `extractLengthUnitScale`. Every server geometry endpoint embeds the
+//! `ModelMetadata` built by `process_geometry_filtered`, so asserting it here
+//! covers all of them at once.
+
+use ifc_lite_processing::{process_geometry_filtered, OpeningFilterMode};
+
+/// Metre-unit model with a georeferenced map conversion + a small extruded wall.
+const GEOREF_MODEL: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('issue-900 georef fixture'),'2;1');
+FILE_NAME('georef.ifc','2026-06-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#10=IFCPROJECTEDCRS('EPSG:32632','WGS84 / UTM zone 32N','WGS84',$,'UTM','32N',$);
+#11=IFCMAPCONVERSION(#2,#10,1000.5,2000.25,42.0,0.866025,0.5,1.0);
+#20=IFCCARTESIANPOINT((0.,0.));
+#21=IFCAXIS2PLACEMENT2D(#20,$);
+#22=IFCRECTANGLEPROFILEDEF(.AREA.,$,#21,1.0,0.2);
+#23=IFCDIRECTION((0.,0.,1.));
+#24=IFCEXTRUDEDAREASOLID(#22,#5,#23,3.0);
+#25=IFCSHAPEREPRESENTATION(#2,'Body','SweptSolid',(#24));
+#26=IFCPRODUCTDEFINITIONSHAPE($,$,(#25));
+#27=IFCLOCALPLACEMENT($,#5);
+#28=IFCWALL('Wall00000000000000001',$,'W1',$,$,#27,#26,$,$);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+/// Millimetre-unit model with geometry but no georeferencing.
+const PLAIN_MM_MODEL: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('issue-900 plain mm fixture'),'2;1');
+FILE_NAME('plain.ifc','2026-06-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('1$ScRe4drECQ4DMSqUjd6e',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);
+#20=IFCCARTESIANPOINT((0.,0.));
+#21=IFCAXIS2PLACEMENT2D(#20,$);
+#22=IFCRECTANGLEPROFILEDEF(.AREA.,$,#21,1000.,200.);
+#23=IFCDIRECTION((0.,0.,1.));
+#24=IFCEXTRUDEDAREASOLID(#22,#5,#23,3000.);
+#25=IFCSHAPEREPRESENTATION(#2,'Body','SweptSolid',(#24));
+#26=IFCPRODUCTDEFINITIONSHAPE($,$,(#25));
+#27=IFCLOCALPLACEMENT($,#5);
+#28=IFCWALL('Wall00000000000000002',$,'W2',$,$,#27,#26,$,$);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+#[test]
+fn metadata_surfaces_georeferencing_and_metre_unit_scale() {
+    let result = process_geometry_filtered(GEOREF_MODEL, OpeningFilterMode::Default);
+    let md = &result.metadata;
+
+    assert_eq!(
+        md.length_unit_scale,
+        Some(1.0),
+        "metre file should report a length unit scale of 1.0"
+    );
+
+    let geo = md
+        .georeferencing
+        .as_ref()
+        .expect("georeferencing should be present for a model with IfcMapConversion");
+    assert_eq!(geo.crs_name.as_deref(), Some("EPSG:32632"));
+    assert_eq!(geo.geodetic_datum.as_deref(), Some("WGS84"));
+    assert_eq!(geo.map_projection.as_deref(), Some("UTM"));
+    assert!((geo.eastings - 1000.5).abs() < 1e-6);
+    assert!((geo.northings - 2000.25).abs() < 1e-6);
+    assert!((geo.orthogonal_height - 42.0).abs() < 1e-6);
+    // cos/sin(30°) → ~30° rotation to grid north.
+    assert!(
+        (geo.rotation_degrees - 30.0).abs() < 1e-3,
+        "expected ~30° grid-north rotation, got {}",
+        geo.rotation_degrees
+    );
+    // Local→map matrix translation column carries the offsets.
+    assert!((geo.transform_matrix[12] - 1000.5).abs() < 1e-6);
+    assert!((geo.transform_matrix[13] - 2000.25).abs() < 1e-6);
+}
+
+#[test]
+fn metadata_reports_millimetre_unit_scale_and_no_georef() {
+    let result = process_geometry_filtered(PLAIN_MM_MODEL, OpeningFilterMode::Default);
+    let md = &result.metadata;
+
+    assert_eq!(
+        md.length_unit_scale,
+        Some(0.001),
+        "millimetre file should report a length unit scale of 0.001"
+    );
+    assert!(
+        md.georeferencing.is_none(),
+        "model without IfcMapConversion should not report georeferencing"
+    );
+}


### PR DESCRIPTION
Follow-up to #906 (which closed the IfcAnnotation/IfcGrid gap). This is the next item from the broad parity pass against `@ifc-lite/parse`: **georeferencing** and the **length-unit scale**.

## Why

The browser parser exposes `IfcMapConversion` / `IfcProjectedCRS` georeferencing (`extractGeoreferencing`) and the length-unit scale (`extractLengthUnitScale`). The server returned only a coarse `is_geo_referenced` boolean and kept the unit scale internal — so API consumers couldn't recover the real-world CRS, false eastings/northings, grid-north rotation, or the mm→m factor.

A complete georeferencing extractor **already existed unused** in shared Rust (`ifc_lite_core::GeoRefExtractor`), so this is a lightweight wire-up rather than a port.

## What

Both values now ride inline on `ModelMetadata`, which every geometry endpoint already embeds — so they reach **all** of them at once (JSON `/parse`, SSE `/parse/stream`, `/parse/parquet`, `/parse/parquet/optimized`, `/parse/parquet-stream`, and the cached-geometry paths) with no new endpoint or fetch round-trip. For the Parquet endpoints they travel in the existing `X-IFC-Metadata` header (georef is small/fixed-size, unlike the symbol stream).

**Server (`@ifc-lite/server-bin`):**
- `ModelMetadata` gains `length_unit_scale: Option<f64>` and `georeferencing: Option<Georeferencing>` (CRS name, geodetic + vertical datum, map projection, false eastings/northings, orthogonal height, X-axis direction, scale, derived `rotation_degrees`, column-major local→map `transform_matrix`).
- New `ifc_lite_processing::extract_georeferencing` reuses `ifc_lite_core::GeoRefExtractor` (same extraction the native/desktop paths use, incl. the IFC2x3 `ePSet_MapConversion` fallback).
- Populated in `process_geometry_filtered` and the server streaming `Complete` event (extracted on a blocking thread).

**Client (`@ifc-lite/server-client`):** new `Georeferencing` type + optional `ModelMetadata.length_unit_scale` / `georeferencing`.

`process_geometry_filtered` is server-only (the browser uses its own `process_geometry_batch`), so the browser geometry path is unaffected.

## Test plan
- [x] `cargo test -p ifc-lite-processing` — incl. `georeferencing.rs` unit tests and `issue_900_georeferencing_metadata.rs` (metre model surfaces CRS/offsets/~30° rotation; mm model reports `length_unit_scale = 0.001` and no georef).
- [x] `cargo test -p ifc-lite-server` green; `cargo check -p ifc-lite-server` clean.
- [x] `@ifc-lite/server-client` builds (`tsc`).
- [x] Confirmed `ModelMetadata` is server-only (WASM uses `ifc-lite-processing` solely for `extract_symbolic_data`).

## Remaining broad-pass gaps (separate follow-ups)
Still TS-only in `@ifc-lite/parse`, needing Rust ports + data-model tables: **classifications** (`IfcClassificationReference`), **structured materials** (`IfcMaterialLayerSet` w/ thicknesses), **documents**, and **schedule/4D**. Tracked for follow-up PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Geometry endpoints now include optional `length_unit_scale` metadata to convert model length units to meters.
  * Geometry endpoints now include optional `georeferencing` metadata with CRS details, coordinate offsets, rotation, and transformation matrix.

* **Documentation**
  * Server guide updated to document the new georeferencing and unit scale fields available in all geometry endpoint responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->