### PR TITLE
feat(server): classifications, materials & documents in the data model (#900 parity)

### DIFF
--- a/.changeset/feat-900-datamodel-classifications-materials-documents.md
+++ b/.changeset/feat-900-datamodel-classifications-materials-documents.md
@@ -1,0 +1,42 @@
+---
+"@ifc-lite/server-bin": minor
+"@ifc-lite/server-client": minor
+---
+
+Expand the Server data model with **classifications**, **structured materials**,
+and **documents**, continuing the `@ifc-lite/parse` parity work (issue #900).
+
+The browser parser exposes these via `extractClassifications` / `extractMaterials`
+/ `extractDocumentsOnDemand`, but the server's data model only recorded the bare
+`IfcRelAssociatesMaterial` relationship triple (and nothing for classifications or
+documents). Now each is resolved into a flat, element-keyed shape on the data
+model fetched from `GET /api/v1/parse/data-model/{cache_key}`.
+
+Server (shipped in the `@ifc-lite/server-bin` binary), in `extract_data_model`:
+
+- **Classifications** (`IfcRelAssociatesClassification` → `IfcClassificationReference`):
+  element id, code (`Identification`), reference name, location, and the owning
+  system name (resolved by walking `ReferencedSource` to `IfcClassification`).
+- **Materials** (`IfcRelAssociatesMaterial`): resolves `IfcMaterial`,
+  `IfcMaterialLayerSet(Usage)`, `IfcMaterialList`, and `IfcMaterialConstituentSet`
+  into per-layer rows — set name, layer index, material name, **thickness in
+  metres** (unit-scaled), `IsVentilated`, and category.
+- **Documents** (`IfcRelAssociatesDocument` → `IfcDocumentReference` /
+  `IfcDocumentInformation`): identification, name, location, description.
+
+Each becomes a new Parquet table appended to the data-model payload. The tables
+are appended **after** the existing five, so the format stays backward
+compatible — older clients ignore the trailing bytes, and the updated decoder
+reads them only when present (no data-model cache-version bump, so no stale-cache
+`202` trap; new data appears once a file is reprocessed).
+
+Client (`@ifc-lite/server-client`):
+
+- New `ClassificationAssociation`, `MaterialAssociation`, `DocumentAssociation`
+  types; `DataModel` gains `classifications`, `materials`, `documents` (empty when
+  served by an older server/cache).
+
+Regression coverage: `data_model.rs` unit tests assert a wall with a two-layer
+material set (mm → metre thickness scaling), a Uniclass classification reference
+(system name resolved through `ReferencedSource`), and a document reference are
+all extracted and element-keyed.

--- a/apps/server/src/services/data_model.rs
+++ b/apps/server/src/services/data_model.rs
@@ -601,6 +601,8 @@ fn extract_relationships(
         "IFCRELDEFINESBYPROPERTIES",
         "IFCRELDEFINESBYTYPE",
         "IFCRELASSOCIATESMATERIAL",
+        "IFCRELASSOCIATESCLASSIFICATION",
+        "IFCRELASSOCIATESDOCUMENT",
         "IFCRELVOIDSELEMENT",
         "IFCRELFILLSELEMENT",
     ];
@@ -634,6 +636,11 @@ fn extract_relationship(entity: &DecodedEntity, type_name: &str) -> Option<Vec<R
     let (relating_idx, related_idx) = match type_upper.as_str() {
         "IFCRELDEFINESBYPROPERTIES" => (5, 4), // RelatingPropertyDefinition at 5, RelatedObjects at 4
         "IFCRELCONTAINEDINSPATIALSTRUCTURE" => (5, 4), // RelatingStructure at 5, RelatedElements at 4
+        // IfcRelAssociates* family: RelatingX (Material/Classification/Document)
+        // is the single ref at attribute 5; RelatedObjects is the list at 4.
+        "IFCRELASSOCIATESMATERIAL"
+        | "IFCRELASSOCIATESCLASSIFICATION"
+        | "IFCRELASSOCIATESDOCUMENT" => (5, 4),
         _ => (4, 5), // Standard: RelatingObject at 4, RelatedObjects at 5
     };
 
@@ -868,6 +875,7 @@ fn resolve_material(decoder: &mut EntityDecoder, id: u32, unit_scale: f64) -> Ve
             // IfcMaterialConstituentSet: Name(0), Description(1),
             // MaterialConstituents(2). Each IfcMaterialConstituent has
             // Name(0), Description(1), Material(2), Fraction(3), Category(4).
+            let set_name = entity.get_string(0).map(|s| s.to_string());
             let constituent_ids: Vec<u32> = entity
                 .get_list(2)
                 .map(|l| l.iter().filter_map(|v| v.as_entity_ref()).collect())
@@ -882,7 +890,7 @@ fn resolve_material(decoder: &mut EntityDecoder, id: u32, unit_scale: f64) -> Ve
                         .and_then(|mid| material_name_of(decoder, mid))
                         .or_else(|| constituent.get_string(0).map(|s| s.to_string()))?;
                     Some(ResolvedLayer {
-                        set_name: None,
+                        set_name: set_name.clone(),
                         layer_index: i as u32,
                         material_name,
                         thickness: None,
@@ -1438,10 +1446,33 @@ END-ISO-10303-21;
         assert_eq!(d.location.as_deref(), Some("https://docs.example/spec"));
 
         // Material constituent set on the column (#60) — constituents read from
-        // attribute 2 (the set name is attribute 0).
+        // attribute 2, set name preserved from attribute 0.
         let column_mats: Vec<_> = dm.materials.iter().filter(|m| m.element_id == 60).collect();
         assert_eq!(column_mats.len(), 1, "expected one constituent for the column");
         assert_eq!(column_mats[0].material_name, "Steel");
+        assert_eq!(column_mats[0].set_name.as_deref(), Some("ColSet"));
+
+        // The IfcRelAssociates* family must also land in the generic relationship
+        // graph (relating = the material/classification/document, related = element).
+        let has_rel = |ty: &str, relating: u32, related: u32| {
+            dm.relationships.iter().any(|r| {
+                r.rel_type.eq_ignore_ascii_case(ty)
+                    && r.relating_id == relating
+                    && r.related_id == related
+            })
+        };
+        assert!(
+            has_rel("IFCRELASSOCIATESCLASSIFICATION", 41, 28),
+            "classification association missing from relationships"
+        );
+        assert!(
+            has_rel("IFCRELASSOCIATESDOCUMENT", 50, 28),
+            "document association missing from relationships"
+        );
+        assert!(
+            has_rel("IFCRELASSOCIATESMATERIAL", 34, 28),
+            "material association missing from relationships"
+        );
 
         // Material profile set on the beam (#70).
         let beam_mats: Vec<_> = dm.materials.iter().filter(|m| m.element_id == 70).collect();

--- a/apps/server/src/services/data_model.rs
+++ b/apps/server/src/services/data_model.rs
@@ -23,6 +23,14 @@ pub struct DataModel {
     pub quantity_sets: Vec<QuantitySet>,
     /// Relationships (type, relating, related[]).
     pub relationships: Vec<Relationship>,
+    /// Classification references associated with elements
+    /// (`IfcRelAssociatesClassification`).
+    pub classifications: Vec<ClassificationAssociation>,
+    /// Materials / material layers associated with elements
+    /// (`IfcRelAssociatesMaterial`).
+    pub materials: Vec<MaterialAssociation>,
+    /// Documents associated with elements (`IfcRelAssociatesDocument`).
+    pub documents: Vec<DocumentAssociation>,
     /// Spatial hierarchy data with nodes and lookup maps.
     pub spatial_hierarchy: SpatialHierarchyData,
 }
@@ -97,6 +105,62 @@ pub struct Relationship {
     pub relating_id: u32,
     /// Related entity ID (one Relationship per related entity).
     pub related_id: u32,
+}
+
+/// A classification reference associated with one element, flattened from
+/// `IfcRelAssociatesClassification` → `IfcClassificationReference`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClassificationAssociation {
+    /// Element the classification is assigned to.
+    pub element_id: u32,
+    /// Classification system name (`IfcClassification.Name`), resolved by
+    /// walking `ReferencedSource`. `None` when not resolvable.
+    pub system_name: Option<String>,
+    /// Code / `IfcClassificationReference.Identification`
+    /// (`ItemReference` in IFC2x3).
+    pub identification: Option<String>,
+    /// Human-readable reference name (`IfcClassificationReference.Name`).
+    pub name: Option<String>,
+    /// Location / URI of the reference.
+    pub location: Option<String>,
+}
+
+/// A material (or one material layer) associated with an element, flattened
+/// from `IfcRelAssociatesMaterial`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MaterialAssociation {
+    /// Element the material is assigned to.
+    pub element_id: u32,
+    /// Layer-set name (`IfcMaterialLayerSet.LayerSetName`); `None` for a single
+    /// material, list, or constituent set.
+    pub set_name: Option<String>,
+    /// 0-based index of this layer within its set (0 for a single material).
+    pub layer_index: u32,
+    /// Material name (`IfcMaterial.Name`).
+    pub material_name: String,
+    /// Layer thickness in **metres** (already unit-scaled). `None` for
+    /// non-layered materials.
+    pub thickness: Option<f64>,
+    /// `IfcMaterialLayer.IsVentilated` (`None` when unknown / not a layer).
+    pub is_ventilated: Option<bool>,
+    /// Material/layer category (`IfcMaterialLayer.Category` / `IfcMaterial.Category`).
+    pub category: Option<String>,
+}
+
+/// A document associated with an element, flattened from
+/// `IfcRelAssociatesDocument` → `IfcDocumentReference` / `IfcDocumentInformation`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DocumentAssociation {
+    /// Element the document is assigned to.
+    pub element_id: u32,
+    /// `Identification` (`ItemReference`/`DocumentId` in older schemas).
+    pub identification: Option<String>,
+    /// Document name.
+    pub name: Option<String>,
+    /// Location / URI.
+    pub location: Option<String>,
+    /// Description.
+    pub description: Option<String>,
 }
 
 /// Spatial hierarchy node.
@@ -274,6 +338,21 @@ pub fn extract_data_model(content: &str) -> DataModel {
         "Extracted length unit scale"
     );
 
+    // Extract classifications, materials, and documents in parallel. These
+    // follow the same `IfcRelAssociates*` pattern as the relationship pass but
+    // resolve the referenced object (classification reference, material layer
+    // set, document) into a flat, element-keyed shape (issue #900 parity).
+    // Materials need the length-unit scale to report layer thickness in metres.
+    let ((classifications, materials), documents) = rayon::join(
+        || {
+            rayon::join(
+                || extract_classifications(&all_entities, &content_arc, &entity_index),
+                || extract_materials(&all_entities, &content_arc, &entity_index, length_unit_scale),
+            )
+        },
+        || extract_documents(&all_entities, &content_arc, &entity_index),
+    );
+
     // Build spatial hierarchy (depends on relationships and entities)
     let spatial_hierarchy = build_spatial_hierarchy(
         &relationships,
@@ -289,6 +368,9 @@ pub fn extract_data_model(content: &str) -> DataModel {
         property_sets = property_sets.len(),
         quantity_sets = quantity_sets.len(),
         relationships = relationships.len(),
+        classifications = classifications.len(),
+        materials = materials.len(),
+        documents = documents.len(),
         spatial_nodes = spatial_hierarchy.nodes.len(),
         extract_time_ms = extract_time.as_millis(),
         "Data model extraction complete"
@@ -299,6 +381,9 @@ pub fn extract_data_model(content: &str) -> DataModel {
         property_sets,
         quantity_sets,
         relationships,
+        classifications,
+        materials,
+        documents,
         spatial_hierarchy,
     }
 }
@@ -574,6 +659,374 @@ fn extract_relationship(entity: &DecodedEntity, type_name: &str) -> Option<Vec<R
             })
             .collect(),
     )
+}
+
+/// Read an `IfcLogical` / `IfcBoolean` attribute as a tri-state `Option<bool>`
+/// (`.U.` / absent → `None`).
+fn read_logical(entity: &DecodedEntity, index: usize) -> Option<bool> {
+    let token = entity.get(index)?.as_enum()?;
+    match token {
+        "T" | "TRUE" | "true" => Some(true),
+        "F" | "FALSE" | "false" => Some(false),
+        _ => None,
+    }
+}
+
+/// Collect the `RelatedObjects` (attribute 4) entity ids of an `IfcRelAssociates*`.
+fn related_object_ids(rel: &DecodedEntity) -> Vec<u32> {
+    rel.get_list(4)
+        .map(|list| list.iter().filter_map(|v| v.as_entity_ref()).collect())
+        .unwrap_or_default()
+}
+
+/// Resolve an `IfcClassificationReference` / `IfcClassification` into
+/// `(identification, name, location, system_name)`. Walks `ReferencedSource`
+/// up to the owning `IfcClassification` (bounded to avoid cycles).
+fn resolve_classification(
+    decoder: &mut EntityDecoder,
+    id: u32,
+) -> (Option<String>, Option<String>, Option<String>, Option<String>) {
+    let Ok(entity) = decoder.decode_by_id(id) else {
+        return (None, None, None, None);
+    };
+
+    if entity.ifc_type.as_str().eq_ignore_ascii_case("IFCCLASSIFICATION") {
+        // Directly an IfcClassification: Name is attribute 3.
+        return (None, None, None, entity.get_string(3).map(|s| s.to_string()));
+    }
+
+    // IfcClassificationReference: Location(0), Identification(1), Name(2),
+    // ReferencedSource(3).
+    let location = entity.get_string(0).map(|s| s.to_string());
+    let identification = entity.get_string(1).map(|s| s.to_string());
+    let name = entity.get_string(2).map(|s| s.to_string());
+
+    // Walk ReferencedSource up to the IfcClassification for the system name.
+    let mut system_name = None;
+    let mut source = entity.get_ref(3);
+    let mut depth = 0;
+    while let Some(src_id) = source {
+        if depth >= 8 {
+            break;
+        }
+        depth += 1;
+        let Ok(src) = decoder.decode_by_id(src_id) else { break };
+        if src.ifc_type.as_str().eq_ignore_ascii_case("IFCCLASSIFICATION") {
+            system_name = src.get_string(3).map(|s| s.to_string());
+            break;
+        }
+        // Another IfcClassificationReference — keep walking its ReferencedSource.
+        source = src.get_ref(3);
+    }
+
+    (identification, name, location, system_name)
+}
+
+/// Extract classification associations (`IfcRelAssociatesClassification`).
+fn extract_classifications(
+    jobs: &[EntityJob],
+    content: &Arc<String>,
+    entity_index: &Arc<ifc_lite_core::EntityIndex>,
+) -> Vec<ClassificationAssociation> {
+    let rel_jobs: Vec<_> = jobs
+        .iter()
+        .filter(|job| job.type_name.eq_ignore_ascii_case("IFCRELASSOCIATESCLASSIFICATION"))
+        .collect();
+
+    tracing::debug!(count = rel_jobs.len(), "Extracting classifications");
+
+    rel_jobs
+        .par_iter()
+        .flat_map(|job| {
+            let mut decoder = EntityDecoder::with_arc_index(content, entity_index.clone());
+            let Ok(rel) = decoder.decode_at(job.start, job.end) else {
+                return Vec::new();
+            };
+            let related = related_object_ids(&rel);
+            // RelatingClassification is attribute 5.
+            let Some(class_id) = rel.get_ref(5) else {
+                return Vec::new();
+            };
+            let (identification, name, location, system_name) =
+                resolve_classification(&mut decoder, class_id);
+
+            related
+                .into_iter()
+                .map(|element_id| ClassificationAssociation {
+                    element_id,
+                    system_name: system_name.clone(),
+                    identification: identification.clone(),
+                    name: name.clone(),
+                    location: location.clone(),
+                })
+                .collect()
+        })
+        .collect()
+}
+
+/// One resolved material layer (intermediate, before element fan-out).
+struct ResolvedLayer {
+    set_name: Option<String>,
+    layer_index: u32,
+    material_name: String,
+    thickness: Option<f64>,
+    is_ventilated: Option<bool>,
+    category: Option<String>,
+}
+
+/// Resolve an `IfcMaterialLayer`'s referenced `IfcMaterial` name.
+fn material_name_of(decoder: &mut EntityDecoder, material_id: u32) -> Option<String> {
+    let mat = decoder.decode_by_id(material_id).ok()?;
+    // IfcMaterial.Name is attribute 0.
+    mat.get_string(0).map(|s| s.to_string())
+}
+
+/// Resolve a `RelatingMaterial` into a flat list of layers. Handles
+/// `IfcMaterial`, `IfcMaterialLayerSet`, `IfcMaterialLayerSetUsage` (→ set),
+/// `IfcMaterialList`, and `IfcMaterialConstituentSet`. `unit_scale` converts
+/// layer thickness to metres.
+fn resolve_material(decoder: &mut EntityDecoder, id: u32, unit_scale: f64) -> Vec<ResolvedLayer> {
+    let Ok(entity) = decoder.decode_by_id(id) else {
+        return Vec::new();
+    };
+    let ty = entity.ifc_type.as_str().to_ascii_uppercase();
+
+    match ty.as_str() {
+        "IFCMATERIAL" => entity
+            .get_string(0)
+            .map(|name| {
+                vec![ResolvedLayer {
+                    set_name: None,
+                    layer_index: 0,
+                    material_name: name.to_string(),
+                    thickness: None,
+                    is_ventilated: None,
+                    category: entity.get_string(2).map(|s| s.to_string()),
+                }]
+            })
+            .unwrap_or_default(),
+        "IFCMATERIALLAYERSETUSAGE" => {
+            // ForLayerSet is attribute 0.
+            match entity.get_ref(0) {
+                Some(set_id) => resolve_material(decoder, set_id, unit_scale),
+                None => Vec::new(),
+            }
+        }
+        "IFCMATERIALLAYERSET" => {
+            let set_name = entity.get_string(1).map(|s| s.to_string());
+            let layer_ids: Vec<u32> = entity
+                .get_list(0)
+                .map(|l| l.iter().filter_map(|v| v.as_entity_ref()).collect())
+                .unwrap_or_default();
+            layer_ids
+                .into_iter()
+                .enumerate()
+                .filter_map(|(i, layer_id)| {
+                    let layer = decoder.decode_by_id(layer_id).ok()?;
+                    // IfcMaterialLayer: Material(0), LayerThickness(1),
+                    // IsVentilated(2), Name(3), Description(4), Category(5).
+                    let material_name = layer
+                        .get_ref(0)
+                        .and_then(|mid| material_name_of(decoder, mid))
+                        .unwrap_or_else(|| "Unnamed".to_string());
+                    let thickness = layer.get_float(1).map(|t| t * unit_scale);
+                    let is_ventilated = read_logical(&layer, 2);
+                    let category = layer.get_string(5).map(|s| s.to_string());
+                    Some(ResolvedLayer {
+                        set_name: set_name.clone(),
+                        layer_index: i as u32,
+                        material_name,
+                        thickness,
+                        is_ventilated,
+                        category,
+                    })
+                })
+                .collect()
+        }
+        "IFCMATERIALLIST" => {
+            let mat_ids: Vec<u32> = entity
+                .get_list(0)
+                .map(|l| l.iter().filter_map(|v| v.as_entity_ref()).collect())
+                .unwrap_or_default();
+            mat_ids
+                .into_iter()
+                .enumerate()
+                .filter_map(|(i, mid)| {
+                    let material_name = material_name_of(decoder, mid)?;
+                    Some(ResolvedLayer {
+                        set_name: None,
+                        layer_index: i as u32,
+                        material_name,
+                        thickness: None,
+                        is_ventilated: None,
+                        category: None,
+                    })
+                })
+                .collect()
+        }
+        "IFCMATERIALCONSTITUENTSET" => {
+            // Constituents is attribute 0; each IfcMaterialConstituent has
+            // Name(0), Description(1), Material(2), Fraction(3), Category(4).
+            let constituent_ids: Vec<u32> = entity
+                .get_list(0)
+                .map(|l| l.iter().filter_map(|v| v.as_entity_ref()).collect())
+                .unwrap_or_default();
+            constituent_ids
+                .into_iter()
+                .enumerate()
+                .filter_map(|(i, cid)| {
+                    let constituent = decoder.decode_by_id(cid).ok()?;
+                    let material_name = constituent
+                        .get_ref(2)
+                        .and_then(|mid| material_name_of(decoder, mid))
+                        .or_else(|| constituent.get_string(0).map(|s| s.to_string()))?;
+                    Some(ResolvedLayer {
+                        set_name: None,
+                        layer_index: i as u32,
+                        material_name,
+                        thickness: None,
+                        is_ventilated: None,
+                        category: constituent.get_string(4).map(|s| s.to_string()),
+                    })
+                })
+                .collect()
+        }
+        _ => Vec::new(),
+    }
+}
+
+/// Extract material associations (`IfcRelAssociatesMaterial`).
+fn extract_materials(
+    jobs: &[EntityJob],
+    content: &Arc<String>,
+    entity_index: &Arc<ifc_lite_core::EntityIndex>,
+    unit_scale: f64,
+) -> Vec<MaterialAssociation> {
+    let rel_jobs: Vec<_> = jobs
+        .iter()
+        .filter(|job| job.type_name.eq_ignore_ascii_case("IFCRELASSOCIATESMATERIAL"))
+        .collect();
+
+    tracing::debug!(count = rel_jobs.len(), "Extracting materials");
+
+    rel_jobs
+        .par_iter()
+        .flat_map(|job| {
+            let mut decoder = EntityDecoder::with_arc_index(content, entity_index.clone());
+            let Ok(rel) = decoder.decode_at(job.start, job.end) else {
+                return Vec::new();
+            };
+            let related = related_object_ids(&rel);
+            // RelatingMaterial is attribute 5.
+            let Some(material_id) = rel.get_ref(5) else {
+                return Vec::new();
+            };
+            let layers = resolve_material(&mut decoder, material_id, unit_scale);
+            if layers.is_empty() {
+                return Vec::new();
+            }
+
+            related
+                .into_iter()
+                .flat_map(|element_id| {
+                    layers.iter().map(move |layer| MaterialAssociation {
+                        element_id,
+                        set_name: layer.set_name.clone(),
+                        layer_index: layer.layer_index,
+                        material_name: layer.material_name.clone(),
+                        thickness: layer.thickness,
+                        is_ventilated: layer.is_ventilated,
+                        category: layer.category.clone(),
+                    })
+                })
+                .collect()
+        })
+        .collect()
+}
+
+/// Resolve an `IfcDocumentReference` / `IfcDocumentInformation` into
+/// `(identification, name, location, description)`.
+fn resolve_document(
+    decoder: &mut EntityDecoder,
+    id: u32,
+) -> (Option<String>, Option<String>, Option<String>, Option<String>) {
+    let Ok(entity) = decoder.decode_by_id(id) else {
+        return (None, None, None, None);
+    };
+    let ty = entity.ifc_type.as_str().to_ascii_uppercase();
+
+    if ty == "IFCDOCUMENTINFORMATION" {
+        // Identification(0), Name(1), Description(2), Location(3).
+        return (
+            entity.get_string(0).map(|s| s.to_string()),
+            entity.get_string(1).map(|s| s.to_string()),
+            entity.get_string(3).map(|s| s.to_string()),
+            entity.get_string(2).map(|s| s.to_string()),
+        );
+    }
+
+    // IfcDocumentReference: Location(0), Identification(1), Name(2),
+    // Description(3), ReferencedDocument(4).
+    let mut location = entity.get_string(0).map(|s| s.to_string());
+    let mut identification = entity.get_string(1).map(|s| s.to_string());
+    let mut name = entity.get_string(2).map(|s| s.to_string());
+    let mut description = entity.get_string(3).map(|s| s.to_string());
+
+    // Backfill missing fields from the referenced IfcDocumentInformation.
+    if let Some(info_id) = entity.get_ref(4) {
+        if let Ok(info) = decoder.decode_by_id(info_id) {
+            if info.ifc_type.as_str().eq_ignore_ascii_case("IFCDOCUMENTINFORMATION") {
+                identification = identification.or_else(|| info.get_string(0).map(|s| s.to_string()));
+                name = name.or_else(|| info.get_string(1).map(|s| s.to_string()));
+                description = description.or_else(|| info.get_string(2).map(|s| s.to_string()));
+                location = location.or_else(|| info.get_string(3).map(|s| s.to_string()));
+            }
+        }
+    }
+
+    (identification, name, location, description)
+}
+
+/// Extract document associations (`IfcRelAssociatesDocument`).
+fn extract_documents(
+    jobs: &[EntityJob],
+    content: &Arc<String>,
+    entity_index: &Arc<ifc_lite_core::EntityIndex>,
+) -> Vec<DocumentAssociation> {
+    let rel_jobs: Vec<_> = jobs
+        .iter()
+        .filter(|job| job.type_name.eq_ignore_ascii_case("IFCRELASSOCIATESDOCUMENT"))
+        .collect();
+
+    tracing::debug!(count = rel_jobs.len(), "Extracting documents");
+
+    rel_jobs
+        .par_iter()
+        .flat_map(|job| {
+            let mut decoder = EntityDecoder::with_arc_index(content, entity_index.clone());
+            let Ok(rel) = decoder.decode_at(job.start, job.end) else {
+                return Vec::new();
+            };
+            let related = related_object_ids(&rel);
+            // RelatingDocument is attribute 5.
+            let Some(doc_id) = rel.get_ref(5) else {
+                return Vec::new();
+            };
+            let (identification, name, location, description) =
+                resolve_document(&mut decoder, doc_id);
+
+            related
+                .into_iter()
+                .map(|element_id| DocumentAssociation {
+                    element_id,
+                    identification: identification.clone(),
+                    name: name.clone(),
+                    location: location.clone(),
+                    description: description.clone(),
+                })
+                .collect()
+        })
+        .collect()
 }
 
 /// Build spatial hierarchy from relationships.
@@ -855,4 +1308,96 @@ fn extract_elevation_if_storey(
     }
 
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// IFC4 model (millimetre units) with a wall carrying a two-layer material
+    /// set, a Uniclass classification reference, and a document reference — one
+    /// of each association type (issue #900).
+    const ASSOCIATIONS_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('issue-900 associations fixture'),'2;1');
+FILE_NAME('assoc.ifc','2026-06-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);
+#28=IFCWALL('Wall00000000000000001',$,'W1',$,$,$,$,$,$);
+/* Material layer set: 200mm Concrete + 50mm ventilated Insulation */
+#30=IFCMATERIAL('Concrete',$,$);
+#31=IFCMATERIAL('Insulation',$,$);
+#32=IFCMATERIALLAYER(#30,200.,.F.,'Core',$,$,$);
+#33=IFCMATERIALLAYER(#31,50.,.T.,'Insul',$,$,$);
+#34=IFCMATERIALLAYERSET((#32,#33),'WallSet',$);
+#35=IFCRELASSOCIATESMATERIAL('Mat0000000000000000001',$,$,$,(#28),#34);
+/* Classification */
+#40=IFCCLASSIFICATION('Uniclass 2015','2',$,'Uniclass 2015',$,$,$);
+#41=IFCCLASSIFICATIONREFERENCE('https://uniclass.example','EF_25_10_25','Walls',#40,$,$);
+#42=IFCRELASSOCIATESCLASSIFICATION('Cls0000000000000000001',$,$,$,(#28),#41);
+/* Document */
+#50=IFCDOCUMENTREFERENCE('https://docs.example/spec','DOC-001','Wall spec',$,$);
+#51=IFCRELASSOCIATESDOCUMENT('Doc0000000000000000001',$,$,$,(#28),#50);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+    #[test]
+    fn extracts_classification_material_and_document_associations() {
+        let dm = extract_data_model(ASSOCIATIONS_IFC);
+
+        // Classification: one reference assigned to the wall (#28).
+        assert_eq!(dm.classifications.len(), 1, "expected one classification");
+        let c = &dm.classifications[0];
+        assert_eq!(c.element_id, 28);
+        assert_eq!(c.system_name.as_deref(), Some("Uniclass 2015"));
+        assert_eq!(c.identification.as_deref(), Some("EF_25_10_25"));
+        assert_eq!(c.name.as_deref(), Some("Walls"));
+
+        // Materials: two layers, thickness reported in metres (mm * 0.001).
+        assert_eq!(dm.materials.len(), 2, "expected two material layers");
+        let mut layers = dm.materials.clone();
+        layers.sort_by_key(|m| m.layer_index);
+        assert_eq!(layers[0].element_id, 28);
+        assert_eq!(layers[0].set_name.as_deref(), Some("WallSet"));
+        assert_eq!(layers[0].material_name, "Concrete");
+        assert!((layers[0].thickness.unwrap() - 0.2).abs() < 1e-9, "200mm -> 0.2m");
+        assert_eq!(layers[0].is_ventilated, Some(false));
+        assert_eq!(layers[1].material_name, "Insulation");
+        assert!((layers[1].thickness.unwrap() - 0.05).abs() < 1e-9, "50mm -> 0.05m");
+        assert_eq!(layers[1].is_ventilated, Some(true));
+
+        // Document.
+        assert_eq!(dm.documents.len(), 1, "expected one document");
+        let d = &dm.documents[0];
+        assert_eq!(d.element_id, 28);
+        assert_eq!(d.identification.as_deref(), Some("DOC-001"));
+        assert_eq!(d.name.as_deref(), Some("Wall spec"));
+        assert_eq!(d.location.as_deref(), Some("https://docs.example/spec"));
+    }
+
+    #[test]
+    fn associations_empty_without_relationships() {
+        let plain = r#"ISO-10303-21;
+HEADER;
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,$,$);
+#28=IFCWALL('Wall00000000000000001',$,'W1',$,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+        let dm = extract_data_model(plain);
+        assert!(dm.classifications.is_empty());
+        assert!(dm.materials.is_empty());
+        assert!(dm.documents.is_empty());
+    }
 }

--- a/apps/server/src/services/data_model.rs
+++ b/apps/server/src/services/data_model.rs
@@ -865,10 +865,11 @@ fn resolve_material(decoder: &mut EntityDecoder, id: u32, unit_scale: f64) -> Ve
                 .collect()
         }
         "IFCMATERIALCONSTITUENTSET" => {
-            // Constituents is attribute 0; each IfcMaterialConstituent has
+            // IfcMaterialConstituentSet: Name(0), Description(1),
+            // MaterialConstituents(2). Each IfcMaterialConstituent has
             // Name(0), Description(1), Material(2), Fraction(3), Category(4).
             let constituent_ids: Vec<u32> = entity
-                .get_list(0)
+                .get_list(2)
                 .map(|l| l.iter().filter_map(|v| v.as_entity_ref()).collect())
                 .unwrap_or_default();
             constituent_ids
@@ -887,6 +888,43 @@ fn resolve_material(decoder: &mut EntityDecoder, id: u32, unit_scale: f64) -> Ve
                         thickness: None,
                         is_ventilated: None,
                         category: constituent.get_string(4).map(|s| s.to_string()),
+                    })
+                })
+                .collect()
+        }
+        "IFCMATERIALPROFILESETUSAGE" => {
+            // ForProfileSet is attribute 0.
+            match entity.get_ref(0) {
+                Some(set_id) => resolve_material(decoder, set_id, unit_scale),
+                None => Vec::new(),
+            }
+        }
+        "IFCMATERIALPROFILESET" => {
+            // IfcMaterialProfileSet: Name(0), Description(1), MaterialProfiles(2).
+            // Each IfcMaterialProfile: Name(0), Description(1), Material(2),
+            // Profile(3), Priority(4), Category(5). Profiles carry no layer
+            // thickness, so thickness stays `None`.
+            let set_name = entity.get_string(0).map(|s| s.to_string());
+            let profile_ids: Vec<u32> = entity
+                .get_list(2)
+                .map(|l| l.iter().filter_map(|v| v.as_entity_ref()).collect())
+                .unwrap_or_default();
+            profile_ids
+                .into_iter()
+                .enumerate()
+                .filter_map(|(i, pid)| {
+                    let profile = decoder.decode_by_id(pid).ok()?;
+                    let material_name = profile
+                        .get_ref(2)
+                        .and_then(|mid| material_name_of(decoder, mid))
+                        .or_else(|| profile.get_string(0).map(|s| s.to_string()))?;
+                    Some(ResolvedLayer {
+                        set_name: set_name.clone(),
+                        layer_index: i as u32,
+                        material_name,
+                        thickness: None,
+                        is_ventilated: None,
+                        category: profile.get_string(5).map(|s| s.to_string()),
                     })
                 })
                 .collect()
@@ -1345,6 +1383,18 @@ DATA;
 /* Document */
 #50=IFCDOCUMENTREFERENCE('https://docs.example/spec','DOC-001','Wall spec',$,$);
 #51=IFCRELASSOCIATESDOCUMENT('Doc0000000000000000001',$,$,$,(#28),#50);
+/* Column with a material constituent set */
+#60=IFCCOLUMN('Col0000000000000000001',$,'C1',$,$,$,$,$,$);
+#61=IFCMATERIAL('Steel',$,$);
+#62=IFCMATERIALCONSTITUENT('Core',$,#61,$,'load-bearing');
+#63=IFCMATERIALCONSTITUENTSET('ColSet',$,(#62));
+#64=IFCRELASSOCIATESMATERIAL('Mat0000000000000000002',$,$,$,(#60),#63);
+/* Beam with a material profile set */
+#70=IFCBEAM('Bem0000000000000000001',$,'B1',$,$,$,$,$,$);
+#71=IFCMATERIAL('Timber',$,$);
+#72=IFCMATERIALPROFILE('Flange',$,#71,$,$,$);
+#73=IFCMATERIALPROFILESET('BeamSet',$,(#72),$);
+#74=IFCRELASSOCIATESMATERIAL('Mat0000000000000000003',$,$,$,(#70),#73);
 ENDSEC;
 END-ISO-10303-21;
 "#;
@@ -1361,10 +1411,15 @@ END-ISO-10303-21;
         assert_eq!(c.identification.as_deref(), Some("EF_25_10_25"));
         assert_eq!(c.name.as_deref(), Some("Walls"));
 
-        // Materials: two layers, thickness reported in metres (mm * 0.001).
-        assert_eq!(dm.materials.len(), 2, "expected two material layers");
-        let mut layers = dm.materials.clone();
+        // Materials: the wall (#28) has two layers, thickness in metres (mm * 0.001).
+        let mut layers: Vec<_> = dm
+            .materials
+            .iter()
+            .filter(|m| m.element_id == 28)
+            .cloned()
+            .collect();
         layers.sort_by_key(|m| m.layer_index);
+        assert_eq!(layers.len(), 2, "expected two wall layers");
         assert_eq!(layers[0].element_id, 28);
         assert_eq!(layers[0].set_name.as_deref(), Some("WallSet"));
         assert_eq!(layers[0].material_name, "Concrete");
@@ -1381,6 +1436,18 @@ END-ISO-10303-21;
         assert_eq!(d.identification.as_deref(), Some("DOC-001"));
         assert_eq!(d.name.as_deref(), Some("Wall spec"));
         assert_eq!(d.location.as_deref(), Some("https://docs.example/spec"));
+
+        // Material constituent set on the column (#60) — constituents read from
+        // attribute 2 (the set name is attribute 0).
+        let column_mats: Vec<_> = dm.materials.iter().filter(|m| m.element_id == 60).collect();
+        assert_eq!(column_mats.len(), 1, "expected one constituent for the column");
+        assert_eq!(column_mats[0].material_name, "Steel");
+
+        // Material profile set on the beam (#70).
+        let beam_mats: Vec<_> = dm.materials.iter().filter(|m| m.element_id == 70).collect();
+        assert_eq!(beam_mats.len(), 1, "expected one profile for the beam");
+        assert_eq!(beam_mats[0].material_name, "Timber");
+        assert_eq!(beam_mats[0].set_name.as_deref(), Some("BeamSet"));
     }
 
     #[test]

--- a/apps/server/src/services/parquet_data_model.rs
+++ b/apps/server/src/services/parquet_data_model.rs
@@ -646,3 +646,111 @@ fn write_parquet_batch(batch: RecordBatch) -> Result<Vec<u8>, DataModelParquetEr
 
     Ok(buffer)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::data_model::DataModel;
+    use arrow::array::Array;
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+
+    fn read_section(section: &[u8]) -> RecordBatch {
+        let reader = ParquetRecordBatchReaderBuilder::try_new(bytes::Bytes::copy_from_slice(section))
+            .expect("parquet reader")
+            .build()
+            .expect("build reader");
+        let batches: Vec<RecordBatch> = reader.map(|b| b.expect("batch")).collect();
+        arrow::compute::concat_batches(&batches[0].schema(), &batches).expect("concat")
+    }
+
+    /// Split the combined data-model payload into its length-prefixed sections.
+    fn split_sections(payload: &[u8]) -> Vec<Vec<u8>> {
+        let mut out = Vec::new();
+        let mut offset = 0usize;
+        while offset + 4 <= payload.len() {
+            let len = u32::from_le_bytes(payload[offset..offset + 4].try_into().unwrap()) as usize;
+            offset += 4;
+            out.push(payload[offset..offset + len].to_vec());
+            offset += len;
+        }
+        out
+    }
+
+    /// Roundtrip: the classification/material/document tables (issue #900) must
+    /// serialize without error and read back with the expected rows. This
+    /// executes the new `serialize_*_table` paths that the extraction tests don't.
+    #[test]
+    fn serializes_and_reads_back_association_tables() {
+        let dm = DataModel {
+            entities: vec![],
+            property_sets: vec![],
+            quantity_sets: vec![],
+            relationships: vec![],
+            classifications: vec![ClassificationAssociation {
+                element_id: 7,
+                system_name: Some("Uniclass 2015".into()),
+                identification: Some("EF_25_10".into()),
+                name: Some("Walls".into()),
+                location: None,
+            }],
+            materials: vec![
+                MaterialAssociation {
+                    element_id: 7,
+                    set_name: Some("WallSet".into()),
+                    layer_index: 0,
+                    material_name: "Concrete".into(),
+                    thickness: Some(0.2),
+                    is_ventilated: Some(false),
+                    category: None,
+                },
+                MaterialAssociation {
+                    element_id: 7,
+                    set_name: Some("WallSet".into()),
+                    layer_index: 1,
+                    material_name: "Insulation".into(),
+                    thickness: None,
+                    is_ventilated: None,
+                    category: Some("thermal".into()),
+                },
+            ],
+            documents: vec![DocumentAssociation {
+                element_id: 7,
+                identification: Some("DOC-1".into()),
+                name: Some("Spec".into()),
+                location: None,
+                description: None,
+            }],
+            spatial_hierarchy: SpatialHierarchyData {
+                nodes: vec![],
+                project_id: 0,
+                element_to_storey: vec![],
+                element_to_building: vec![],
+                element_to_site: vec![],
+                element_to_space: vec![],
+            },
+        };
+
+        let payload = serialize_data_model_to_parquet(&dm).expect("serialize");
+        let sections = split_sections(&payload);
+        // entities, properties, quantities, relationships, spatial, classifications, materials, documents
+        assert_eq!(sections.len(), 8, "expected 8 length-prefixed sections");
+
+        let classifications = read_section(&sections[5]);
+        assert_eq!(classifications.num_rows(), 1);
+
+        let materials = read_section(&sections[6]);
+        assert_eq!(materials.num_rows(), 2);
+        // Nullable thickness column survives the roundtrip (row 0 = 0.2, row 1 = null).
+        let thickness = materials
+            .column_by_name("thickness")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
+        assert!((thickness.value(0) - 0.2).abs() < 1e-9);
+        assert!(thickness.is_null(1));
+
+        let documents = read_section(&sections[7]);
+        assert_eq!(documents.num_rows(), 1);
+    }
+}

--- a/apps/server/src/services/parquet_data_model.rs
+++ b/apps/server/src/services/parquet_data_model.rs
@@ -5,12 +5,12 @@
 //! Parquet serialization for IFC data model (entities, properties, relationships, spatial hierarchy).
 
 use crate::services::data_model::{
-    DataModel, EntityMetadata, PropertySet, QuantitySet, Relationship, SpatialHierarchyData,
-    SpatialNode,
+    ClassificationAssociation, DataModel, DocumentAssociation, EntityMetadata, MaterialAssociation,
+    PropertySet, QuantitySet, Relationship, SpatialHierarchyData, SpatialNode,
 };
 use arrow::array::builder::ListBuilder;
 use arrow::array::UInt32Builder;
-use arrow::array::{BooleanArray, StringArray, UInt16Array, UInt32Array};
+use arrow::array::{BooleanArray, Float64Array, StringArray, UInt16Array, UInt32Array};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use parquet::arrow::ArrowWriter;
@@ -72,7 +72,23 @@ pub fn serialize_data_model_to_parquet(
     let relationships_data = relationships_data?;
     let spatial_data = spatial_data?;
 
-    // Write format: [entities_len][entities_data][properties_len][properties_data][quantities_len][quantities_data][relationships_len][relationships_data][spatial_len][spatial_data]
+    // Classification / material / document tables (issue #900). Appended after
+    // the original five so older decoders that stop at `spatial` simply ignore
+    // the trailing bytes — the format stays backward compatible.
+    let ((classifications_data, materials_data), documents_data) = rayon::join(
+        || {
+            rayon::join(
+                || serialize_classifications_table(&data_model.classifications),
+                || serialize_materials_table(&data_model.materials),
+            )
+        },
+        || serialize_documents_table(&data_model.documents),
+    );
+    let classifications_data = classifications_data?;
+    let materials_data = materials_data?;
+    let documents_data = documents_data?;
+
+    // Write format: [entities_len][entities_data][properties_len][properties_data][quantities_len][quantities_data][relationships_len][relationships_data][spatial_len][spatial_data][classifications_len][...][materials_len][...][documents_len][...]
     let mut result = Vec::new();
     result.extend_from_slice(&(entities_data.len() as u32).to_le_bytes());
     result.extend_from_slice(&entities_data);
@@ -84,8 +100,145 @@ pub fn serialize_data_model_to_parquet(
     result.extend_from_slice(&relationships_data);
     result.extend_from_slice(&(spatial_data.len() as u32).to_le_bytes());
     result.extend_from_slice(&spatial_data);
+    result.extend_from_slice(&(classifications_data.len() as u32).to_le_bytes());
+    result.extend_from_slice(&classifications_data);
+    result.extend_from_slice(&(materials_data.len() as u32).to_le_bytes());
+    result.extend_from_slice(&materials_data);
+    result.extend_from_slice(&(documents_data.len() as u32).to_le_bytes());
+    result.extend_from_slice(&documents_data);
 
     Ok(result)
+}
+
+/// Serialize classification associations table.
+fn serialize_classifications_table(
+    rows: &[ClassificationAssociation],
+) -> Result<Vec<u8>, DataModelParquetError> {
+    let count = rows.len();
+    let mut element_ids = Vec::with_capacity(count);
+    let mut system_names: Vec<Option<String>> = Vec::with_capacity(count);
+    let mut identifications: Vec<Option<String>> = Vec::with_capacity(count);
+    let mut names: Vec<Option<String>> = Vec::with_capacity(count);
+    let mut locations: Vec<Option<String>> = Vec::with_capacity(count);
+
+    for row in rows {
+        element_ids.push(row.element_id);
+        system_names.push(row.system_name.clone());
+        identifications.push(row.identification.clone());
+        names.push(row.name.clone());
+        locations.push(row.location.clone());
+    }
+
+    let schema = Schema::new(vec![
+        Field::new("element_id", DataType::UInt32, false),
+        Field::new("system_name", DataType::Utf8, true),
+        Field::new("identification", DataType::Utf8, true),
+        Field::new("name", DataType::Utf8, true),
+        Field::new("location", DataType::Utf8, true),
+    ]);
+
+    let batch = RecordBatch::try_new(
+        Arc::new(schema),
+        vec![
+            Arc::new(UInt32Array::from(element_ids)),
+            Arc::new(StringArray::from(system_names)),
+            Arc::new(StringArray::from(identifications)),
+            Arc::new(StringArray::from(names)),
+            Arc::new(StringArray::from(locations)),
+        ],
+    )?;
+
+    write_parquet_batch(batch)
+}
+
+/// Serialize material associations table.
+fn serialize_materials_table(
+    rows: &[MaterialAssociation],
+) -> Result<Vec<u8>, DataModelParquetError> {
+    let count = rows.len();
+    let mut element_ids = Vec::with_capacity(count);
+    let mut set_names: Vec<Option<String>> = Vec::with_capacity(count);
+    let mut layer_indices = Vec::with_capacity(count);
+    let mut material_names = Vec::with_capacity(count);
+    let mut thicknesses: Vec<Option<f64>> = Vec::with_capacity(count);
+    let mut ventilated: Vec<Option<bool>> = Vec::with_capacity(count);
+    let mut categories: Vec<Option<String>> = Vec::with_capacity(count);
+
+    for row in rows {
+        element_ids.push(row.element_id);
+        set_names.push(row.set_name.clone());
+        layer_indices.push(row.layer_index);
+        material_names.push(row.material_name.clone());
+        thicknesses.push(row.thickness);
+        ventilated.push(row.is_ventilated);
+        categories.push(row.category.clone());
+    }
+
+    let schema = Schema::new(vec![
+        Field::new("element_id", DataType::UInt32, false),
+        Field::new("set_name", DataType::Utf8, true),
+        Field::new("layer_index", DataType::UInt32, false),
+        Field::new("material_name", DataType::Utf8, false),
+        Field::new("thickness", DataType::Float64, true),
+        Field::new("is_ventilated", DataType::Boolean, true),
+        Field::new("category", DataType::Utf8, true),
+    ]);
+
+    let batch = RecordBatch::try_new(
+        Arc::new(schema),
+        vec![
+            Arc::new(UInt32Array::from(element_ids)),
+            Arc::new(StringArray::from(set_names)),
+            Arc::new(UInt32Array::from(layer_indices)),
+            Arc::new(StringArray::from(material_names)),
+            Arc::new(Float64Array::from(thicknesses)),
+            Arc::new(BooleanArray::from(ventilated)),
+            Arc::new(StringArray::from(categories)),
+        ],
+    )?;
+
+    write_parquet_batch(batch)
+}
+
+/// Serialize document associations table.
+fn serialize_documents_table(
+    rows: &[DocumentAssociation],
+) -> Result<Vec<u8>, DataModelParquetError> {
+    let count = rows.len();
+    let mut element_ids = Vec::with_capacity(count);
+    let mut identifications: Vec<Option<String>> = Vec::with_capacity(count);
+    let mut names: Vec<Option<String>> = Vec::with_capacity(count);
+    let mut locations: Vec<Option<String>> = Vec::with_capacity(count);
+    let mut descriptions: Vec<Option<String>> = Vec::with_capacity(count);
+
+    for row in rows {
+        element_ids.push(row.element_id);
+        identifications.push(row.identification.clone());
+        names.push(row.name.clone());
+        locations.push(row.location.clone());
+        descriptions.push(row.description.clone());
+    }
+
+    let schema = Schema::new(vec![
+        Field::new("element_id", DataType::UInt32, false),
+        Field::new("identification", DataType::Utf8, true),
+        Field::new("name", DataType::Utf8, true),
+        Field::new("location", DataType::Utf8, true),
+        Field::new("description", DataType::Utf8, true),
+    ]);
+
+    let batch = RecordBatch::try_new(
+        Arc::new(schema),
+        vec![
+            Arc::new(UInt32Array::from(element_ids)),
+            Arc::new(StringArray::from(identifications)),
+            Arc::new(StringArray::from(names)),
+            Arc::new(StringArray::from(locations)),
+            Arc::new(StringArray::from(descriptions)),
+        ],
+    )?;
+
+    write_parquet_batch(batch)
 }
 
 /// Serialize entities table.

--- a/apps/viewer/src/utils/serverDataModel.test.ts
+++ b/apps/viewer/src/utils/serverDataModel.test.ts
@@ -38,6 +38,9 @@ describe('convertServerDataModel', () => {
         { rel_type: 'IFCRELAGGREGATES', relating_id: 2, related_id: 3 },
         { rel_type: 'IFCRELCONTAINEDINSPATIALSTRUCTURE', relating_id: 3, related_id: 4 },
       ],
+      classifications: [],
+      materials: [],
+      documents: [],
       spatialHierarchy: {
         nodes: [
           {
@@ -101,6 +104,9 @@ describe('convertServerDataModel', () => {
         { rel_type: 'IFCRELNESTS', relating_id: 1, related_id: 2 },
         { rel_type: 'IFCRELASSOCIATESDOCUMENT', relating_id: 3, related_id: 2 },
       ],
+      classifications: [],
+      materials: [],
+      documents: [],
       spatialHierarchy: {
         nodes: [
           {

--- a/docs/guide/server.md
+++ b/docs/guide/server.md
@@ -289,7 +289,13 @@ const available = await client.isParquetSupported();
 
 ## Data Model
 
-The server computes a complete data model including:
+The server computes a complete data model including entities, property sets,
+quantity sets, relationships, spatial hierarchy, and — matching `@ifc-lite/parse`
+— per-element **classifications** (`IfcClassificationReference`), **materials**
+(`IfcMaterialLayerSet` layers with metre thicknesses), and **documents**
+(`IfcDocumentReference`). The latter three are exposed as flat, element-keyed
+arrays on the decoded `DataModel` (`classifications`, `materials`, `documents`)
+and decode to empty arrays when served by an older server/cache.
 
 ### Entities
 

--- a/packages/server-client/src/data-model-decoder.ts
+++ b/packages/server-client/src/data-model-decoder.ts
@@ -70,11 +70,56 @@ export interface SpatialHierarchy {
   element_to_space: Map<number, number>;
 }
 
+/** A classification reference associated with one element. */
+export interface ClassificationAssociation {
+  element_id: number;
+  /** Classification system name (`IfcClassification.Name`). */
+  system_name?: string;
+  /** Code / `IfcClassificationReference.Identification`. */
+  identification?: string;
+  /** Human-readable reference name. */
+  name?: string;
+  /** Location / URI. */
+  location?: string;
+}
+
+/** A material (or one material layer) associated with an element. */
+export interface MaterialAssociation {
+  element_id: number;
+  /** Layer-set name; absent for a single material / list / constituent set. */
+  set_name?: string;
+  /** 0-based layer index within its set (0 for a single material). */
+  layer_index: number;
+  material_name: string;
+  /** Layer thickness in metres (already unit-scaled); absent if not a layer. */
+  thickness?: number;
+  is_ventilated?: boolean;
+  category?: string;
+}
+
+/** A document associated with an element. */
+export interface DocumentAssociation {
+  element_id: number;
+  identification?: string;
+  name?: string;
+  location?: string;
+  description?: string;
+}
+
 export interface DataModel {
   entities: Map<number, EntityMetadata>;
   propertySets: Map<number, PropertySet>;
   quantitySets: Map<number, QuantitySet>;
   relationships: Relationship[];
+  /**
+   * Classification references per element (`IfcRelAssociatesClassification`).
+   * Empty when served by an older server / cache that predates this field.
+   */
+  classifications: ClassificationAssociation[];
+  /** Materials / material layers per element (`IfcRelAssociatesMaterial`). */
+  materials: MaterialAssociation[];
+  /** Documents per element (`IfcRelAssociatesDocument`). */
+  documents: DocumentAssociation[];
   spatialHierarchy: SpatialHierarchy;
 }
 
@@ -126,6 +171,26 @@ export async function decodeDataModel(data: ArrayBuffer): Promise<DataModel> {
   const spatialLen = view.getUint32(offset, true);
   offset += 4;
   const spatialData = new Uint8Array(data, offset, spatialLen);
+  offset += spatialLen;
+
+  // Read an optional appended length-prefixed section, returning null when no
+  // bytes remain (older servers/caches omit the classification/material/document
+  // tables — see the writer in parquet_data_model.rs).
+  const readOptionalSection = (): Uint8Array | null => {
+    if (offset + 4 > data.byteLength) return null;
+    const len = view.getUint32(offset, true);
+    offset += 4;
+    if (len === 0 || offset + len > data.byteLength) {
+      offset += len;
+      return null;
+    }
+    const section = new Uint8Array(data, offset, len);
+    offset += len;
+    return section;
+  };
+  const classificationsData = readOptionalSection();
+  const materialsData = readOptionalSection();
+  const documentsData = readOptionalSection();
 
   // Parse Parquet tables
   const entitiesTable = parquet.readParquet(entitiesData);
@@ -343,11 +408,79 @@ export async function decodeDataModel(data: ArrayBuffer): Promise<DataModel> {
     parseLookupTable(elementToSpaceData),
   ];
 
+  // Classification associations (issue #900). Absent on older caches.
+  const classifications: ClassificationAssociation[] = [];
+  if (classificationsData) {
+    const t = arrow.tableFromIPC(parquet.readParquet(classificationsData).intoIPCStream());
+    const elementIds = t.getChild('element_id')?.toArray() as Uint32Array;
+    const systemNames = t.getChild('system_name')?.toArray() as (string | null)[];
+    const identifications = t.getChild('identification')?.toArray() as (string | null)[];
+    const namesArr = t.getChild('name')?.toArray() as (string | null)[];
+    const locations = t.getChild('location')?.toArray() as (string | null)[];
+    for (let i = 0; i < elementIds.length; i++) {
+      classifications.push({
+        element_id: elementIds[i],
+        system_name: systemNames?.[i] || undefined,
+        identification: identifications?.[i] || undefined,
+        name: namesArr?.[i] || undefined,
+        location: locations?.[i] || undefined,
+      });
+    }
+  }
+
+  // Material associations (issue #900).
+  const materials: MaterialAssociation[] = [];
+  if (materialsData) {
+    const t = arrow.tableFromIPC(parquet.readParquet(materialsData).intoIPCStream());
+    const elementIds = t.getChild('element_id')?.toArray() as Uint32Array;
+    const setNames = t.getChild('set_name')?.toArray() as (string | null)[];
+    const layerIndices = t.getChild('layer_index')?.toArray() as Uint32Array;
+    const materialNames = t.getChild('material_name')?.toArray() as (string | null)[];
+    const thicknesses = t.getChild('thickness')?.toArray() as (number | null)[];
+    const ventChild = t.getChild('is_ventilated');
+    const categories = t.getChild('category')?.toArray() as (string | null)[];
+    for (let i = 0; i < elementIds.length; i++) {
+      const vent = ventChild?.get(i);
+      materials.push({
+        element_id: elementIds[i],
+        set_name: setNames?.[i] || undefined,
+        layer_index: layerIndices[i],
+        material_name: materialNames?.[i] ?? '',
+        thickness: thicknesses?.[i] ?? undefined,
+        is_ventilated: vent === null || vent === undefined ? undefined : Boolean(vent),
+        category: categories?.[i] || undefined,
+      });
+    }
+  }
+
+  // Document associations (issue #900).
+  const documents: DocumentAssociation[] = [];
+  if (documentsData) {
+    const t = arrow.tableFromIPC(parquet.readParquet(documentsData).intoIPCStream());
+    const elementIds = t.getChild('element_id')?.toArray() as Uint32Array;
+    const identifications = t.getChild('identification')?.toArray() as (string | null)[];
+    const namesArr = t.getChild('name')?.toArray() as (string | null)[];
+    const locations = t.getChild('location')?.toArray() as (string | null)[];
+    const descriptions = t.getChild('description')?.toArray() as (string | null)[];
+    for (let i = 0; i < elementIds.length; i++) {
+      documents.push({
+        element_id: elementIds[i],
+        identification: identifications?.[i] || undefined,
+        name: namesArr?.[i] || undefined,
+        location: locations?.[i] || undefined,
+        description: descriptions?.[i] || undefined,
+      });
+    }
+  }
+
   return {
     entities,
     propertySets,
     quantitySets,
     relationships,
+    classifications,
+    materials,
+    documents,
     spatialHierarchy: {
       nodes: spatialNodes,
       project_id: projectId,

--- a/packages/server-client/src/data-model-decoder.ts
+++ b/packages/server-client/src/data-model-decoder.ts
@@ -173,16 +173,20 @@ export async function decodeDataModel(data: ArrayBuffer): Promise<DataModel> {
   const spatialData = new Uint8Array(data, offset, spatialLen);
   offset += spatialLen;
 
-  // Read an optional appended length-prefixed section, returning null when no
-  // bytes remain (older servers/caches omit the classification/material/document
-  // tables — see the writer in parquet_data_model.rs).
+  // Read an optional appended length-prefixed section. Returns null only when
+  // no length prefix remains — i.e. an older server/cache that omits the
+  // classification/material/document tables (see the writer in
+  // parquet_data_model.rs). Once a prefix is present, a zero length or a length
+  // that overruns the buffer means the payload is malformed, so we throw rather
+  // than silently dropping data as if it were an old payload.
   const readOptionalSection = (): Uint8Array | null => {
-    if (offset + 4 > data.byteLength) return null;
+    if (offset + 4 > data.byteLength) return null; // section absent (old payload)
     const len = view.getUint32(offset, true);
     offset += 4;
     if (len === 0 || offset + len > data.byteLength) {
-      offset += len;
-      return null;
+      throw new Error(
+        `Malformed data model: truncated appended section (len=${len}, remaining=${data.byteLength - offset})`
+      );
     }
     const section = new Uint8Array(data, offset, len);
     offset += len;

--- a/packages/server-client/src/index.ts
+++ b/packages/server-client/src/index.ts
@@ -31,4 +31,12 @@
 export * from './client.js';
 export * from './types.js';
 export { decodeParquetGeometry, decodeOptimizedParquetGeometry, isParquetAvailable } from './parquet-decoder.js';
-export { decodeDataModel, type DataModel, type Quantity, type QuantitySet } from './data-model-decoder.js';
+export {
+  decodeDataModel,
+  type DataModel,
+  type Quantity,
+  type QuantitySet,
+  type ClassificationAssociation,
+  type MaterialAssociation,
+  type DocumentAssociation,
+} from './data-model-decoder.js';


### PR DESCRIPTION
Third item from the broad parity pass against `@ifc-lite/parse` (after #906 symbols and #907 georeferencing). You picked classifications + structured materials + documents — bundled here since they share identical plumbing (the `DataModel` struct, the combined Parquet writer, and the TS decoder), so it's one decoder pass and one wire-format change rather than three near-duplicate PRs.

## Why

The browser parser exposes these via `extractClassifications` / `extractMaterials` / `extractDocumentsOnDemand`. The server's data model only recorded the bare `IfcRelAssociatesMaterial` relationship triple (and nothing for classifications or documents). Each is now resolved into a flat, element-keyed shape on the data model returned by `GET /api/v1/parse/data-model/{cache_key}`.

## What

**Server (`@ifc-lite/server-bin`), in `extract_data_model`:**
- **Classifications** (`IfcRelAssociatesClassification` → `IfcClassificationReference`): element id, code (`Identification`), reference name, location, and owning system name (resolved by walking `ReferencedSource` to `IfcClassification`).
- **Materials** (`IfcRelAssociatesMaterial`): resolves `IfcMaterial`, `IfcMaterialLayerSet(Usage)`, `IfcMaterialList`, and `IfcMaterialConstituentSet` into per-layer rows — set name, layer index, material name, **thickness in metres** (unit-scaled), `IsVentilated`, category.
- **Documents** (`IfcRelAssociatesDocument` → `IfcDocumentReference` / `IfcDocumentInformation`): identification, name, location, description.
- Extracted in parallel via `rayon::join`.

**Wire format:** three new Parquet tables appended **after** the existing five. Older clients ignore the trailing bytes; the updated decoder reads them only when present. **No data-model cache-version bump** — so no stale-cache `202` trap; the new tables appear once a file is reprocessed (e.g. after #906's geometry cache bump) and decode to empty arrays meanwhile.

**Client (`@ifc-lite/server-client`):** new `ClassificationAssociation` / `MaterialAssociation` / `DocumentAssociation` types; `DataModel` gains `classifications` / `materials` / `documents`.

## Test plan
- [x] `cargo test -p ifc-lite-server` — incl. new `data_model.rs` tests: a two-layer wall (mm→metre thickness scaling, `IsVentilated`), a Uniclass reference (system name resolved through `ReferencedSource`), and a document reference, all element-keyed; plus an empty-model negative case.
- [x] `@ifc-lite/server-client` builds (`tsc`).
- [x] Branched off `main`, independent of #907.

## Broad-pass status
With this, the gaps you selected are all covered. Remaining (not selected): **Schedule / 4D** (`IfcWorkSchedule` / `IfcTask`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Data model now includes per-element classifications, materials (layered with thickness and ventilation), and documents (id, name, location, description); client decoding supports optional appended tables and defaults to empty arrays for older payloads.
  * Server output appends the new tables while preserving backward-compatible payload layout.

* **Documentation**
  * Server Guide updated to describe the new data categories.

* **Tests**
  * Added tests covering extraction and roundtrip of classifications, materials, and documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->