### PR TITLE
fix(viewer): correct slab split for non-metre IFC models

### DIFF
--- a/apps/viewer/src/components/viewer/PropertiesPanel.tsx
+++ b/apps/viewer/src/components/viewer/PropertiesPanel.tsx
@@ -970,21 +970,28 @@ export function PropertiesPanel() {
     }));
   }, [nativeDetails]);
 
+  // Overlay (authored) entities — split halves, duplicates, scripted
+  // adds — live only in the StoreEditor overlay, NOT the parsed store.
+  // `modelQuery.entity()` always returns a node, and its getters fall
+  // back to the 'Unknown'/'' sentinels for ids absent from the parsed
+  // table (entity-table.ts#getTypeName). Those non-null sentinels would
+  // shadow the overlay record in an `entityNode ?? overlay` chain, so
+  // when an overlay record exists it MUST take precedence.
   const renderedEntityType = isNativeLazySelection
     ? (nativeDetails?.summary.type ?? 'Loading...')
-    : (entityNode?.type ?? overlayEntity?.type ?? 'Unknown');
+    : (overlayEntity?.type ?? entityNode?.type ?? 'Unknown');
   const renderedEntityName = isNativeLazySelection
     ? (nativeDetails?.summary.name ?? `#${selectedEntity?.expressId ?? ''}`)
-    : (entityNode?.name ?? overlayAttr(2) ?? undefined);
+    : (overlayAttr(2) ?? entityNode?.name ?? undefined);
   const renderedEntityGlobalId = isNativeLazySelection
     ? (nativeDetails?.summary.globalId ?? null)
-    : (entityNode?.globalId ?? overlayAttr(0));
+    : (overlayAttr(0) ?? entityNode?.globalId);
   const renderedEntityDescription = isNativeLazySelection
     ? undefined
-    : (entityNode?.description ?? overlayAttr(3) ?? undefined);
+    : (overlayAttr(3) ?? entityNode?.description ?? undefined);
   const renderedEntityObjectType = isNativeLazySelection
     ? undefined
-    : (entityNode?.objectType ?? overlayAttr(4) ?? undefined);
+    : (overlayAttr(4) ?? entityNode?.objectType ?? undefined);
   const renderedSpatialInfo = isNativeLazySelection ? nativeSpatialInfo : spatialInfo;
   const renderedOccurrenceProperties = isNativeLazySelection ? nativeOccurrenceProperties : occurrenceProperties;
   const renderedInheritedTypeProperties = isNativeLazySelection ? [] : inheritedTypeProperties;

--- a/apps/viewer/src/lib/length-unit-scale.ts
+++ b/apps/viewer/src/lib/length-unit-scale.ts
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Model length-unit → metres scale, memoised per `IfcDataStore`.
+ *
+ * The viewer's render + authoring space is **metres**: the geometry
+ * pipeline bakes the file's length-unit scale into tessellated vertices,
+ * raycast hit-points come back in metres, and `spatialHierarchy.
+ * storeyElevations` are pre-scaled. But raw coordinate reads straight off
+ * the STEP model — split footprints, placement chains — arrive in the
+ * file's **native** units (e.g. millimetres). Multiply those by this
+ * factor to bring them into the same metre space as everything else.
+ *
+ * Returns `1` when the scale can't be determined (already-metres models,
+ * or bounded-geometry mode having released the source buffer) — the
+ * safe identity that leaves native-unit reads untouched.
+ */
+
+import { extractLengthUnitScale, type IfcDataStore } from '@ifc-lite/parser';
+
+const scaleCache = new WeakMap<IfcDataStore, number>();
+
+export function getModelLengthUnitScale(dataStore: IfcDataStore | null | undefined): number {
+  if (!dataStore) return 1;
+  const cached = scaleCache.get(dataStore);
+  if (cached !== undefined) return cached;
+
+  // The columnar parser stashes the scale on the store; the wasm fast
+  // path does not, so fall back to extracting it from the source bytes.
+  let scale = typeof dataStore.lengthUnitScale === 'number' ? dataStore.lengthUnitScale : undefined;
+  if (scale === undefined || !Number.isFinite(scale) || scale <= 0) {
+    if (!dataStore.source?.length || !dataStore.entityIndex) return 1;
+    scale = extractLengthUnitScale(dataStore.source, dataStore.entityIndex);
+  }
+  if (!Number.isFinite(scale) || scale <= 0) scale = 1;
+
+  scaleCache.set(dataStore, scale);
+  return scale;
+}

--- a/apps/viewer/src/lib/slab-edit.test.ts
+++ b/apps/viewer/src/lib/slab-edit.test.ts
@@ -128,6 +128,34 @@ describe('slab-edit', () => {
     assert.deepStrictEqual(chain.footprint[2], [109, 72]);
   });
 
+  it('normalizes a non-unit-length Axis/RefDirection in the solid Position', () => {
+    // IfcDirection.DirectionRatios are ratios, not guaranteed unit
+    // vectors. A valid Axis=(0,0,2) must not leak its length into the
+    // Y basis (Y = Z×X) or skew the Gram-Schmidt projection — otherwise
+    // the footprint disagrees with the (normalizing) renderer. With
+    // proper normalization the result matches an identity-rotation
+    // placement: solidXform(p) = (100 + p.x, 50 + p.y).
+    const entities = makePolygonSlabFixture();
+    entities.push(
+      { expressId: 70, type: 'IFCCARTESIANPOINT', attributes: [[100, 50, 0]] },
+      { expressId: 71, type: 'IFCDIRECTION', attributes: [[0, 0, 2]] }, // non-unit Axis (Z)
+      { expressId: 72, type: 'IFCDIRECTION', attributes: [[3, 0, 0]] }, // non-unit RefDirection (X)
+      { expressId: 73, type: 'IFCAXIS2PLACEMENT3D', attributes: [70, 71, 72] },
+    );
+    entities.find((e) => e.expressId === 93)!.attributes = [92, 73, null, 0.25];
+
+    const editor = new StubStoreEditor(entities) as unknown as Parameters<typeof resolveSlabEditChain>[2];
+    const view = new StubView() as unknown as Parameters<typeof resolveSlabEditChain>[1];
+    const chain = resolveSlabEditChain(dataStoreStub, view, editor, 100);
+    assert.ok(chain);
+    //   (0,0) → (100,50) → +placement(10,20) → (110,70)
+    //   (2,0) → (102,50) → (112,70)
+    //   (1,2) → (101,52) → (111,72)   [buggy raw-Axis would give y=74]
+    assert.deepStrictEqual(chain.footprint[0], [110, 70]);
+    assert.deepStrictEqual(chain.footprint[1], [112, 70]);
+    assert.deepStrictEqual(chain.footprint[2], [111, 72]);
+  });
+
   it('ignores lengthUnitScale for authored (overlay) entities', () => {
     // The in-store builders already emit metres, so a freshly-authored
     // slab must NOT be re-scaled even on a millimetre model — otherwise

--- a/apps/viewer/src/lib/slab-edit.test.ts
+++ b/apps/viewer/src/lib/slab-edit.test.ts
@@ -99,6 +99,50 @@ describe('slab-edit', () => {
     assert.deepStrictEqual(chain.footprint[2], [11, 22]);
   });
 
+  it('applies the IfcExtrudedAreaSolid.Position transform (offset + axis flip)', () => {
+    // Real authoring tools bake the slab's plan offset/rotation into the
+    // solid Position rather than the IfcLocalPlacement. Here the solid is
+    // placed at (100, 50) with RefDirection (-1,0,0) + Axis (0,0,-1) — the
+    // 180°-about-the-vertical flip seen in the BIMcollab fixture (#90).
+    const entities = makePolygonSlabFixture();
+    entities.push(
+      { expressId: 70, type: 'IFCCARTESIANPOINT', attributes: [[100, 50, 0]] },
+      { expressId: 71, type: 'IFCDIRECTION', attributes: [[0, 0, -1]] }, // Axis (Z)
+      { expressId: 72, type: 'IFCDIRECTION', attributes: [[-1, 0, 0]] }, // RefDirection (X)
+      { expressId: 73, type: 'IFCAXIS2PLACEMENT3D', attributes: [70, 71, 72] },
+    );
+    // Point the solid's Position slot (attr 1) at the new placement.
+    entities.find((e) => e.expressId === 93)!.attributes = [92, 73, null, 0.25];
+
+    const editor = new StubStoreEditor(entities) as unknown as Parameters<typeof resolveSlabEditChain>[2];
+    const view = new StubView() as unknown as Parameters<typeof resolveSlabEditChain>[1];
+    const chain = resolveSlabEditChain(dataStoreStub, view, editor, 100);
+    assert.ok(chain);
+    // X = (-1,0,0), Y = Z×X = (0,1,0) → solidXform(p) = (100 - p.x, 50 + p.y).
+    // Then + placement origin (10, 20).
+    //   (0,0) → (100,50) → (110,70)
+    //   (2,0) → (98,50)  → (108,70)
+    //   (1,2) → (99,52)  → (109,72)
+    assert.deepStrictEqual(chain.footprint[0], [110, 70]);
+    assert.deepStrictEqual(chain.footprint[1], [108, 70]);
+    assert.deepStrictEqual(chain.footprint[2], [109, 72]);
+  });
+
+  it('ignores lengthUnitScale for authored (overlay) entities', () => {
+    // The in-store builders already emit metres, so a freshly-authored
+    // slab must NOT be re-scaled even on a millimetre model — otherwise
+    // re-splitting a just-cut half would shrink it 1000×. The stub serves
+    // overlay entities, so the footprint stays in its given units despite
+    // the 0.001 scale.
+    const entities = makePolygonSlabFixture();
+    const editor = new StubStoreEditor(entities) as unknown as Parameters<typeof resolveSlabEditChain>[2];
+    const view = new StubView() as unknown as Parameters<typeof resolveSlabEditChain>[1];
+    const chain = resolveSlabEditChain(dataStoreStub, view, editor, 100, 0.001);
+    assert.ok(chain);
+    assert.deepStrictEqual(chain.footprint[0], [10, 20]);
+    assert.strictEqual(chain.thickness, 0.25);
+  });
+
   it('strips the redundant closing vertex from an IfcPolyline', () => {
     const entities = makePolygonSlabFixture();
     // Append a duplicate of the first vertex to the polyline.

--- a/apps/viewer/src/lib/slab-edit.ts
+++ b/apps/viewer/src/lib/slab-edit.ts
@@ -35,6 +35,7 @@ import type { MutablePropertyView, StoreEditor } from '@ifc-lite/mutations';
 import {
   asExpressIdRef,
   asCoordinateTriple,
+  asDirectionRatios,
   readAttributes,
   resolvePlacementChain,
 } from './placement-core.js';
@@ -59,6 +60,83 @@ const SLAB_LIKE_STEP_TYPES: Record<string, SlabLikeType> = {
 
 function stepTypeToSlabLike(stepType: string): SlabLikeType | null {
   return SLAB_LIKE_STEP_TYPES[stepType.toUpperCase()] ?? null;
+}
+
+/**
+ * A 2D rigid transform mapping a profile-coordinate point into the
+ * solid's local plan (XY). Built from the `IfcExtrudedAreaSolid`'s
+ * `Position` (an `IfcAxis2Placement3D`), it folds in the in-place
+ * translation + rotation that real-world authoring tools bake there.
+ * In-store-built slabs carry an identity Position, so the resolver
+ * defaults to the identity transform for them.
+ */
+type Xform2D = (p: [number, number]) => [number, number];
+
+const IDENTITY_XFORM2D: Xform2D = (p) => [p[0], p[1]];
+
+function readDirection(
+  dataStore: IfcDataStore,
+  view: MutablePropertyView,
+  editor: StoreEditor,
+  id: number | null,
+): [number, number, number] | null {
+  if (id === null) return null;
+  const attrs = readAttributes(dataStore, view, editor, id);
+  return attrs ? asDirectionRatios(attrs[0]) : null;
+}
+
+/**
+ * Build the plan-space transform for an `IfcExtrudedAreaSolid.Position`.
+ * The profile lives in the placement's local XY plane; we map a profile
+ * point `(px, py)` to `origin + px·X + py·Y` and keep the XY components
+ * (the footprint is the plan). X comes from RefDirection (orthonormalised
+ * against the Axis/Z), Y = Z × X — matching the IFC placement convention,
+ * including axis flips (e.g. Axis `(0,0,-1)`, RefDirection `(-1,0,0)`).
+ * Returns identity when the placement is absent or degenerate.
+ */
+function resolveSolidPositionXform(
+  dataStore: IfcDataStore,
+  view: MutablePropertyView,
+  editor: StoreEditor,
+  placementId: number | null,
+): Xform2D {
+  if (placementId === null) return IDENTITY_XFORM2D;
+  const attrs = readAttributes(dataStore, view, editor, placementId);
+  if (!attrs) return IDENTITY_XFORM2D;
+
+  // IfcAxis2Placement3D: [0] Location · [1] Axis (Z) · [2] RefDirection (X).
+  const locId = asExpressIdRef(attrs[0]);
+  let ox = 0;
+  let oy = 0;
+  if (locId !== null) {
+    const locAttrs = readAttributes(dataStore, view, editor, locId);
+    const c = locAttrs ? asCoordinateTriple(locAttrs[0]) : null;
+    if (c) {
+      ox = c[0];
+      oy = c[1];
+    }
+  }
+
+  const z = readDirection(dataStore, view, editor, asExpressIdRef(attrs[1])) ?? [0, 0, 1];
+  const refX = readDirection(dataStore, view, editor, asExpressIdRef(attrs[2])) ?? [1, 0, 0];
+
+  // Orthonormalise X against Z (Gram-Schmidt), then Y = Z × X.
+  const dot = refX[0] * z[0] + refX[1] * z[1] + refX[2] * z[2];
+  let xv: [number, number, number] = [
+    refX[0] - dot * z[0],
+    refX[1] - dot * z[1],
+    refX[2] - dot * z[2],
+  ];
+  const xlen = Math.hypot(xv[0], xv[1], xv[2]);
+  if (xlen < 1e-9) return IDENTITY_XFORM2D;
+  xv = [xv[0] / xlen, xv[1] / xlen, xv[2] / xlen];
+  const yv: [number, number, number] = [
+    z[1] * xv[2] - z[2] * xv[1],
+    z[2] * xv[0] - z[0] * xv[2],
+    z[0] * xv[1] - z[1] * xv[0],
+  ];
+
+  return (p) => [ox + p[0] * xv[0] + p[1] * yv[0], oy + p[0] * xv[1] + p[1] * yv[1]];
 }
 
 export interface SlabEditChain {
@@ -106,22 +184,23 @@ function rectangleFootprint(
   profileOrigin2D: [number, number],
   xdim: number,
   ydim: number,
+  solidXform: Xform2D,
 ): Point2D[] {
-  // The profile's local frame maps directly to storey-local XY for
-  // a slab (no in-plane rotation; the builder writes Position +
-  // null Axis + null RefDirection so the placement is axis-aligned).
+  // Rectangle corners in the profile coordinate system (centred on the
+  // profile origin), mapped through the solid Position into plan space,
+  // then offset by the slab's placement origin.
   const [px, py] = placementOrigin;
   const [cx, cy] = profileOrigin2D;
-  const xMin = px + cx - xdim / 2;
-  const xMax = px + cx + xdim / 2;
-  const yMin = py + cy - ydim / 2;
-  const yMax = py + cy + ydim / 2;
-  return [
-    [xMin, yMin],
-    [xMax, yMin],
-    [xMax, yMax],
-    [xMin, yMax],
+  const corners: Point2D[] = [
+    [cx - xdim / 2, cy - ydim / 2],
+    [cx + xdim / 2, cy - ydim / 2],
+    [cx + xdim / 2, cy + ydim / 2],
+    [cx - xdim / 2, cy + ydim / 2],
   ];
+  return corners.map((c) => {
+    const [wx, wy] = solidXform(c);
+    return [px + wx, py + wy] as Point2D;
+  });
 }
 
 /**
@@ -136,6 +215,7 @@ function polylineFootprint(
   polylineId: number,
   placementOrigin: [number, number, number],
   profileOrigin2D: [number, number],
+  solidXform: Xform2D,
 ): Point2D[] | null {
   const attrs = readAttributes(dataStore, view, editor, polylineId);
   if (!attrs) return null;
@@ -155,7 +235,10 @@ function polylineFootprint(
     // tolerantly — IFC files in the wild sometimes pad with Z=0.
     const coords = asCoordinateTriple(ptAttrs[0]);
     if (!coords) return null;
-    out.push([px + cx + coords[0], py + cy + coords[1]]);
+    // Point in profile CS → solid plan (Position translation + rotation)
+    // → slab placement origin.
+    const [wx, wy] = solidXform([cx + coords[0], cy + coords[1]]);
+    out.push([px + wx, py + wy]);
   }
   // IfcPolyline for a closed profile may or may not repeat the
   // first vertex at the end — strip if present, our clip API
@@ -171,20 +254,55 @@ function polylineFootprint(
 }
 
 /**
+ * Scale a chain's coordinate-bearing fields (footprint, placement
+ * origin, thickness) by `scale`. Identity when `scale === 1`. Used to
+ * lift a native-unit (e.g. millimetre) STEP read into the viewer's
+ * metre working space — see `resolveSlabEditChain`'s `lengthUnitScale`.
+ */
+function scaleSlabChain(chain: SlabEditChain, scale: number): SlabEditChain {
+  if (scale === 1) return chain;
+  return {
+    ...chain,
+    placementOrigin: [
+      chain.placementOrigin[0] * scale,
+      chain.placementOrigin[1] * scale,
+      chain.placementOrigin[2] * scale,
+    ],
+    footprint: chain.footprint.map(([x, y]) => [x * scale, y * scale] as Point2D),
+    thickness: chain.thickness * scale,
+  };
+}
+
+/**
  * Resolve the slab chain (placement + footprint + extrusion). Works
  * for IfcSlab / IfcRoof / IfcPlate / IfcSpace whose representation
  * matches the in-store builder shape; null otherwise.
+ *
+ * `lengthUnitScale` is the model's native-unit → metre factor (e.g.
+ * `0.001` for a millimetre file). Raw STEP coordinate reads are in
+ * native units, but the rest of the split flow — raycast cut points,
+ * preview meshes, selection hit-tests — lives in metres, so the
+ * resolved footprint/thickness are scaled to match. Authored overlay
+ * entities are skipped: the in-store builders already emit metres, so
+ * scaling them would double-apply (re-splitting a freshly-cut half).
  */
 export function resolveSlabEditChain(
   dataStore: IfcDataStore,
   view: MutablePropertyView,
   editor: StoreEditor,
   expressId: number,
+  lengthUnitScale = 1,
 ): SlabEditChain | null {
   const rawType = readEntityType(dataStore, view, editor, expressId);
   if (!rawType) return null;
   const elementType = stepTypeToSlabLike(rawType);
   if (!elementType) return null;
+
+  // Overlay (authored) entities are stored in metres by the in-store
+  // builders; only native STEP reads need the unit scale applied.
+  // `getNewEntity` returns null (not undefined) for source entities.
+  const isAuthored = editor.getNewEntity(expressId) != null;
+  const scale = isAuthored ? 1 : lengthUnitScale;
 
   const chain = resolvePlacementChain(dataStore, view, editor, expressId);
   if (!chain) return null;
@@ -211,6 +329,18 @@ export function resolveSlabEditChain(
   const profileId = asExpressIdRef(solidAttrs[0]);
   const thicknessRaw = solidAttrs[3];
   if (profileId === null || typeof thicknessRaw !== 'number') return null;
+
+  // IfcExtrudedAreaSolid.Position (attr 1) is an IfcAxis2Placement3D that
+  // places the profile in the solid's frame — real authoring tools bake
+  // the slab's plan offset + rotation here (in-store-built slabs leave it
+  // identity). Fold it into the footprint so the preview, cut line, and
+  // resulting halves land where the rendered mesh actually is.
+  const solidXform = resolveSolidPositionXform(
+    dataStore,
+    view,
+    editor,
+    asExpressIdRef(solidAttrs[1]),
+  );
 
   // Profile dispatch — rectangle vs polygon, both produced by
   // addSlabToStore. Source-buffer slabs with mapped representations,
@@ -244,29 +374,29 @@ export function resolveSlabEditChain(
     const xdim = profileAttrs[3];
     const ydim = profileAttrs[4];
     if (typeof xdim !== 'number' || typeof ydim !== 'number') return null;
-    return {
+    return scaleSlabChain({
       elementType,
       placementOrigin,
-      footprint: rectangleFootprint(placementOrigin, profileOrigin2D, xdim, ydim),
+      footprint: rectangleFootprint(placementOrigin, profileOrigin2D, xdim, ydim, solidXform),
       extrudedSolidId: solidId,
       thickness: thicknessRaw,
       profileKind: 'rectangle',
-    };
+    }, scale);
   }
   if (profileType && profileType.toUpperCase() === 'IFCARBITRARYCLOSEDPROFILEDEF') {
     // OuterCurve at attr 2.
     const polylineId = asExpressIdRef(profileAttrs[2]);
     if (polylineId === null) return null;
-    const fp = polylineFootprint(dataStore, view, editor, polylineId, placementOrigin, profileOrigin2D);
+    const fp = polylineFootprint(dataStore, view, editor, polylineId, placementOrigin, profileOrigin2D, solidXform);
     if (!fp) return null;
-    return {
+    return scaleSlabChain({
       elementType,
       placementOrigin,
       footprint: fp,
       extrudedSolidId: solidId,
       thickness: thicknessRaw,
       profileKind: 'polygon',
-    };
+    }, scale);
   }
   return null;
 }

--- a/apps/viewer/src/lib/slab-edit.ts
+++ b/apps/viewer/src/lib/slab-edit.ts
@@ -117,10 +117,19 @@ function resolveSolidPositionXform(
     }
   }
 
-  const z = readDirection(dataStore, view, editor, asExpressIdRef(attrs[1])) ?? [0, 0, 1];
+  // IfcDirection ratios are NOT guaranteed unit length, so normalise Z
+  // before using it as a basis vector — otherwise the Gram-Schmidt
+  // projection (which assumes |Z|=1) and Y = Z × X both pick up |Z| as a
+  // stray scale factor, skewing the footprint away from the rendered mesh
+  // for files with e.g. Axis=(0,0,2). The Rust profile extractor
+  // normalises the same placement.
+  const rawZ = readDirection(dataStore, view, editor, asExpressIdRef(attrs[1])) ?? [0, 0, 1];
+  const zlen = Math.hypot(rawZ[0], rawZ[1], rawZ[2]);
+  if (zlen < 1e-9) return IDENTITY_XFORM2D;
+  const z: [number, number, number] = [rawZ[0] / zlen, rawZ[1] / zlen, rawZ[2] / zlen];
   const refX = readDirection(dataStore, view, editor, asExpressIdRef(attrs[2])) ?? [1, 0, 0];
 
-  // Orthonormalise X against Z (Gram-Schmidt), then Y = Z × X.
+  // Orthonormalise X against the unit Z (Gram-Schmidt), then Y = Z × X.
   const dot = refX[0] * z[0] + refX[1] * z[1] + refX[2] * z[2];
   let xv: [number, number, number] = [
     refX[0] - dot * z[0],
@@ -130,6 +139,7 @@ function resolveSolidPositionXform(
   const xlen = Math.hypot(xv[0], xv[1], xv[2]);
   if (xlen < 1e-9) return IDENTITY_XFORM2D;
   xv = [xv[0] / xlen, xv[1] / xlen, xv[2] / xlen];
+  // Z and X are now orthonormal, so Y = Z × X is already unit length.
   const yv: [number, number, number] = [
     z[1] * xv[2] - z[2] * xv[1],
     z[2] * xv[0] - z[0] * xv[2],

--- a/apps/viewer/src/store/slices/mutationSlice.ts
+++ b/apps/viewer/src/store/slices/mutationSlice.ts
@@ -69,6 +69,7 @@ import {
   computeSlabSplitGeometry,
   type SlabLikeType,
 } from '@/lib/slab-edit.js';
+import { getModelLengthUnitScale } from '@/lib/length-unit-scale.js';
 import type { Point2D } from '@/lib/polygon-clip.js';
 
 /**
@@ -676,7 +677,9 @@ function generateChangeSetId(): string {
  */
 function getOrCreateStoreEditor(
   get: () => ViewerState,
-  set: (partial: Partial<ViewerState>) => void,
+  // Editors are cached in-place on the (non-reactive) `storeEditors`
+  // Map below, so the Zustand setter is intentionally unused here.
+  _set: (partial: Partial<ViewerState>) => void,
   modelId: string,
 ): StoreEditor | null {
   const state = get();
@@ -691,9 +694,14 @@ function getOrCreateStoreEditor(
   if (!dataStore) return null;
 
   const editor = new StoreEditor(dataStore, view);
-  const next = new Map(state.storeEditors);
-  next.set(modelId, editor);
-  set({ storeEditors: next });
+  // `storeEditors` is an internal, non-reactive cache (no component
+  // subscribes to it). Mutate the existing Map in place rather than
+  // `set({...})` — the read functions (readSlabFootprint, etc.) call
+  // this during render via GeometryEditCard's `splittable` memo, and a
+  // reactive `set()` there triggers React's "cannot update a component
+  // while rendering a different component" warning. In-place caching
+  // keeps the editor memoised without scheduling a render-phase update.
+  state.storeEditors.set(modelId, editor);
   return editor;
 }
 
@@ -1862,7 +1870,7 @@ export const createMutationSlice: StateCreator<
     if (!editor) return null;
     const dataStore = get().models.get(modelId)?.ifcDataStore;
     if (!dataStore) return null;
-    const chain = resolveSlabEditChain(dataStore, view, editor, expressId);
+    const chain = resolveSlabEditChain(dataStore, view, editor, expressId, getModelLengthUnitScale(dataStore));
     if (!chain) return null;
     const storeyId = dataStore.spatialHierarchy?.elementToStorey.get(expressId);
     const storeyElevation =
@@ -1883,7 +1891,7 @@ export const createMutationSlice: StateCreator<
     const { view, editor, dataStore, storeyExpressId } = ctx;
     const state = get();
 
-    const chain = resolveSlabEditChain(dataStore, view, editor, expressId);
+    const chain = resolveSlabEditChain(dataStore, view, editor, expressId, getModelLengthUnitScale(dataStore));
     if (!chain) {
       return {
         ok: false,


### PR DESCRIPTION
## Problem

Element splitting (shortcut **K**) only worked for slabs in metre-unit models with identity solid placements. On a millimetre model (e.g. `tests/models/various/02_BIMcollab_Example_STR_random_C_ebkp.ifc`) the slab split was unusable:

- **Whole model disappears, only two slabs remain.** The split read raw native (mm) coordinates into the metre-space renderer, so the two halves were built 1000× too large and far outside the model. The camera refit flew out to ~km scale and the real model collapsed to a dot.
- **Preview/result in the wrong spot.** The footprint ignored the slab's `IfcExtrudedAreaSolid.Position`, so the dashed preview, the cut line, and the resulting halves were offset/rotated from the rendered mesh.
- **Split result shows "UNKNOWN / Unknown".** Authored (overlay) entities resolved to the `'Unknown'` sentinel from the parsed-store query.
- A React `"cannot update a component while rendering"` warning fired during the split flow.

## Fixes

| Area | Change |
|---|---|
| **Unit scale** | New memoised `getModelLengthUnitScale()`; `resolveSlabEditChain` scales the footprint/thickness to metres, **skipping authored overlay entities** (already metres) so re-splitting a fresh half doesn't double-scale. |
| **Solid placement** | Fold `IfcExtrudedAreaSolid.Position` (translation + rotation) into the footprint. In-store-built slabs keep identity, so they're unaffected. |
| **Properties panel** | Overlay (authored) records now take precedence over the parsed-store `'Unknown'` sentinels, so split halves resolve as `IfcSlab` with their name. |
| **React warning** | `storeEditors` is an internal non-reactive cache; `getOrCreateStoreEditor` now caches in place instead of a render-phase `set()`. |

## Verification

- All 5 slabs in the BIMcollab sample: resolved footprint now matches the rendered mesh exactly (Δ ≈ 0).
- End-to-end via the real pointer flow (synthetic events through the actual handlers): cut lands on the slab, halves tile the source, model stays visible at correct scale, half resolves as `IfcSlab`.
- Source entities unaffected (still resolve type/name/property sets).
- New regression tests for the solid-Position transform and the authored-entity unit-scale skip. `slab-edit`/`placement-edit` suites pass; `tsc` clean.

## Not included / follow-ups

- **`IfcWallStandardCase` splitting** is still unsupported (these walls use an Axis+Body rep pair, no explicit RefDirection, and arbitrary profiles; the current splitter is parametric). Tracked as a separate change.
- Cloned **property sets** on split halves don't yet surface in the panel (overlay pset resolution); the type/name now do.
- Full parent-placement-chain composition + RTC origin shift for geolocated/offset models (this sample has identity parents + zero shift).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added length-unit scaling to improve model geometry handling.

* **Bug Fixes**
  * Slab editing now respects actual in-place orientation when computing footprints.
  * Slab split/preview geometry correctly accounts for non-default model length units.
  * Properties panel now prefers overlay data when displaying entity details.

* **Tests**
  * Added tests covering slab geometry transforms, direction normalization, and unit-scaling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->