### PR TITLE
feat(solar): add @ifc-lite/solar — solar position + 3D sun-path geometry

### DIFF
--- a/.changeset/solar-package.md
+++ b/.changeset/solar-package.md
@@ -1,0 +1,8 @@
+---
+"@ifc-lite/solar": minor
+---
+
+Add `@ifc-lite/solar`: a dependency-free package for solar position (NOAA
+algorithm), sunrise/sunset/solar-noon, and 3D sun-path dome geometry (day
+paths, hourly analemmas, graticule) emitted as ENU unit vectors for the
+georeferenced viewer.

--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -47,6 +47,7 @@
     "@ifc-lite/sandbox": "workspace:^",
     "@ifc-lite/sdk": "workspace:^",
     "@ifc-lite/server-client": "workspace:^",
+    "@ifc-lite/solar": "workspace:^",
     "@ifc-lite/spatial": "workspace:^",
     "@ifc-lite/wasm": "workspace:^",
     "@radix-ui/react-alert-dialog": "^1.1.6",

--- a/apps/viewer/src/components/viewer/CesiumOverlay.tsx
+++ b/apps/viewer/src/components/viewer/CesiumOverlay.tsx
@@ -261,6 +261,10 @@ export function CesiumOverlay({
   const solarShowSunPath = useViewerStore((s) => s.solarShowSunPath);
   const solarShowShadows = useViewerStore((s) => s.solarShowShadows);
   const setSolarSunInfo = useViewerStore((s) => s.setSolarSunInfo);
+  // Re-run the solar effect once the deferred GLB load completes, so the IFC
+  // model's shadow mode is applied even when the study was enabled before the
+  // model finished loading into Cesium.
+  const cesiumGlbLoaded = useViewerStore((s) => s.cesiumGlbLoaded);
 
   // Track the Cesium model (IFC geometry loaded as glTF for correct world positioning)
   const cesiumModelRef = useRef<{ modelMatrix: any; shadows?: any; destroy?: () => void } | null>(null);
@@ -777,6 +781,7 @@ export function CesiumOverlay({
   }, [
     status,
     bridgeVersion,
+    cesiumGlbLoaded,
     solarEnabled,
     solarDateMs,
     solarShowSunPath,

--- a/apps/viewer/src/components/viewer/CesiumOverlay.tsx
+++ b/apps/viewer/src/components/viewer/CesiumOverlay.tsx
@@ -746,16 +746,18 @@ export function CesiumOverlay({
             // New day or site → rebuild static geometry (day arc + analemmas).
             sunPathDomeRef.current?.destroy();
             const bounds = coordinateInfo?.originalBounds;
-            const radius = bounds
-              ? Math.max(
-                  40,
-                  0.9 * Math.hypot(
-                    bounds.max.x - bounds.min.x,
-                    bounds.max.y - bounds.min.y,
-                    bounds.max.z - bounds.min.z,
-                  ),
+            // Size the dome to roughly the model footprint, but clamp to an
+            // architectural scale: with many federated models the combined
+            // bounds can span kilometres, which would push the dome arcs so
+            // far out they read as nothing. Half-diagonal ≈ bounding radius.
+            const rawRadius = bounds
+              ? 0.5 * Math.hypot(
+                  bounds.max.x - bounds.min.x,
+                  bounds.max.y - bounds.min.y,
+                  bounds.max.z - bounds.min.z,
                 )
               : 80;
+            const radius = Math.min(250, Math.max(40, rawRadius));
             sunPathDomeRef.current = new SunPathDome(Cesium, viewer, {
               origin: { latitude, longitude, height },
               radius,

--- a/apps/viewer/src/components/viewer/CesiumOverlay.tsx
+++ b/apps/viewer/src/components/viewer/CesiumOverlay.tsx
@@ -741,30 +741,34 @@ export function CesiumOverlay({
 
       if (solarShowSunPath) {
         const dayKey = `${date.getUTCFullYear()}-${date.getUTCMonth()}-${date.getUTCDate()}:${latitude.toFixed(4)},${longitude.toFixed(4)}`;
-        if (!sunPathDomeRef.current || sunPathDomeDayRef.current !== dayKey) {
-          // New day or site → rebuild static geometry (day arc + analemmas).
-          sunPathDomeRef.current?.destroy();
-          const bounds = coordinateInfo?.originalBounds;
-          const radius = bounds
-            ? Math.max(
-                40,
-                0.9 * Math.hypot(
-                  bounds.max.x - bounds.min.x,
-                  bounds.max.y - bounds.min.y,
-                  bounds.max.z - bounds.min.z,
-                ),
-              )
-            : 80;
-          sunPathDomeRef.current = new SunPathDome(Cesium, viewer, {
-            origin: { latitude, longitude, height },
-            radius,
-            date,
-            showAnalemmas: true,
-          });
-          sunPathDomeDayRef.current = dayKey;
-        } else {
-          // Same day, new time → just move the sun marker + beam.
-          sunPathDomeRef.current.update(date);
+        try {
+          if (!sunPathDomeRef.current || sunPathDomeDayRef.current !== dayKey) {
+            // New day or site → rebuild static geometry (day arc + analemmas).
+            sunPathDomeRef.current?.destroy();
+            const bounds = coordinateInfo?.originalBounds;
+            const radius = bounds
+              ? Math.max(
+                  40,
+                  0.9 * Math.hypot(
+                    bounds.max.x - bounds.min.x,
+                    bounds.max.y - bounds.min.y,
+                    bounds.max.z - bounds.min.z,
+                  ),
+                )
+              : 80;
+            sunPathDomeRef.current = new SunPathDome(Cesium, viewer, {
+              origin: { latitude, longitude, height },
+              radius,
+              date,
+              showAnalemmas: true,
+            });
+            sunPathDomeDayRef.current = dayKey;
+          } else {
+            // Same day, new time → just move the sun marker + beam.
+            sunPathDomeRef.current.update(date);
+          }
+        } catch (err) {
+          console.warn('[CesiumOverlay] sun-path dome build/update failed:', err);
         }
       } else if (sunPathDomeRef.current) {
         sunPathDomeRef.current.destroy();

--- a/apps/viewer/src/components/viewer/CesiumOverlay.tsx
+++ b/apps/viewer/src/components/viewer/CesiumOverlay.tsx
@@ -30,6 +30,8 @@ import {
   shouldPreferOrthometricTerrain,
 } from '@/lib/geo/cesium-placement';
 import { getEffectiveHorizontalScale, resolveMapUnitToMetreScale } from '@/lib/geo/geo-scale';
+import { applySolarScene, SunPathDome } from '@/lib/geo/cesium-sun';
+import { sunPosition, sunTimes } from '@ifc-lite/solar';
 
 // Lazy-loaded Cesium module and CSS
 let cesiumPromise: Promise<typeof import('cesium')> | null = null;
@@ -253,9 +255,27 @@ export function CesiumOverlay({
   const setCesiumTerrainClipY = useViewerStore((s) => s.setCesiumTerrainClipY);
   const setCesiumGlbLoaded = useViewerStore((s) => s.setCesiumGlbLoaded);
 
+  // Solar study state — drives the sun-path dome + shadow study.
+  const solarEnabled = useViewerStore((s) => s.solarEnabled);
+  const solarDateMs = useViewerStore((s) => s.solarDateMs);
+  const solarShowSunPath = useViewerStore((s) => s.solarShowSunPath);
+  const solarShowShadows = useViewerStore((s) => s.solarShowShadows);
+  const setSolarSunInfo = useViewerStore((s) => s.setSolarSunInfo);
+
   // Track the Cesium model (IFC geometry loaded as glTF for correct world positioning)
-  const cesiumModelRef = useRef<{ modelMatrix: any; destroy?: () => void } | null>(null);
+  const cesiumModelRef = useRef<{ modelMatrix: any; shadows?: any; destroy?: () => void } | null>(null);
   const glbCacheRef = useRef<{ meshCount: number; glb: Uint8Array } | null>(null);
+  // Active 3D context tileset (Google Photorealistic / OSM buildings) — kept so
+  // solar mode can toggle its shadow casting/receiving.
+  const tilesetRef = useRef<{ shadows?: any } | null>(null);
+  // Active sun-path dome entity collection (null when solar study is off).
+  const sunPathDomeRef = useRef<SunPathDome | null>(null);
+  // UTC calendar day the dome's static geometry (day-arc, analemmas) was built
+  // for. Intra-day time scrubs only move the sun marker; a new day rebuilds.
+  const sunPathDomeDayRef = useRef<string | null>(null);
+  // Whether the solar study has ever touched Cesium scene state. Guards us
+  // from mutating the default (non-solar) lighting on plain mount.
+  const solarTouchedSceneRef = useRef(false);
 
   // Last-known placement altitude (in metres) used to keep the user's WORLD
   // camera position stable across bridge rebuilds. When the user toggles the
@@ -357,7 +377,7 @@ export function CesiumOverlay({
         }
 
         // Add data source layer
-        await addDataSourceLayer(Cesium, viewer, dataSource, ionToken);
+        tilesetRef.current = await addDataSourceLayer(Cesium, viewer, dataSource, ionToken);
 
         if (cancelled) { viewer.destroy(); return; }
 
@@ -386,6 +406,11 @@ export function CesiumOverlay({
       // so Effect 2c must re-load the GLB into the next viewer instance.
       cesiumModelRef.current = null;
       bridgeRef.current = null;
+      // The destroyed viewer also took the tileset + sun-path entities.
+      tilesetRef.current = null;
+      sunPathDomeRef.current = null;
+      sunPathDomeDayRef.current = null;
+      solarTouchedSceneRef.current = false;
       setStatus('idle');
     };
   }, [cesiumEnabled, ionToken, terrainEnabled, dataSource]);
@@ -664,6 +689,102 @@ export function CesiumOverlay({
     // bridge.modelOrigin.height by Effect 2.
   }, [mapConversion, projectedCRS, coordinateInfo, lengthUnitScale, bridgeVersion]);
 
+  // ─── Effect 4: Solar study — sun-path dome + shadows ────────────────────
+  // Drives Cesium's sun/lighting/shadow map from the studied instant, builds
+  // (and live-updates) the 3D sun-path dome anchored at the model origin, and
+  // publishes the resolved sun position/times back to the store for the panel.
+  useEffect(() => {
+    const viewer = viewerRef.current;
+    const bridge = bridgeRef.current;
+    const Cesium = cesiumModule;
+    if (status !== 'ready' || !viewer || !bridge || !Cesium) return;
+
+    // Never mutate the default Cesium lighting until the study is first
+    // enabled — a plain georeferenced model shouldn't have its context
+    // re-lit just because this effect mounts with solar off.
+    if (!solarEnabled && !solarTouchedSceneRef.current) return;
+    solarTouchedSceneRef.current = true;
+
+    const date = new Date(solarDateMs);
+    const { latitude, longitude, height } = bridge.modelOrigin;
+
+    // Cast/receive shadows on the IFC model and the context tileset.
+    const shadowMode = solarEnabled && solarShowShadows
+      ? Cesium.ShadowMode.ENABLED
+      : Cesium.ShadowMode.DISABLED;
+    if (cesiumModelRef.current) cesiumModelRef.current.shadows = shadowMode;
+    if (tilesetRef.current) tilesetRef.current.shadows = shadowMode;
+
+    applySolarScene(Cesium, viewer, {
+      date,
+      enabled: solarEnabled,
+      shadows: solarShowShadows,
+    });
+
+    if (solarEnabled) {
+      // Publish the readout for the panel.
+      const times = sunTimes(date, latitude, longitude);
+      const sp = sunPosition(date, latitude, longitude);
+      setSolarSunInfo({
+        latitude,
+        longitude,
+        azimuth: sp.azimuth,
+        altitude: sp.altitude,
+        sunriseMs: times.sunrise ? times.sunrise.getTime() : null,
+        sunsetMs: times.sunset ? times.sunset.getTime() : null,
+        solarNoonMs: times.solarNoon.getTime(),
+      });
+
+      if (solarShowSunPath) {
+        const dayKey = `${date.getUTCFullYear()}-${date.getUTCMonth()}-${date.getUTCDate()}:${latitude.toFixed(4)},${longitude.toFixed(4)}`;
+        if (!sunPathDomeRef.current || sunPathDomeDayRef.current !== dayKey) {
+          // New day or site → rebuild static geometry (day arc + analemmas).
+          sunPathDomeRef.current?.destroy();
+          const bounds = coordinateInfo?.originalBounds;
+          const radius = bounds
+            ? Math.max(
+                40,
+                0.9 * Math.hypot(
+                  bounds.max.x - bounds.min.x,
+                  bounds.max.y - bounds.min.y,
+                  bounds.max.z - bounds.min.z,
+                ),
+              )
+            : 80;
+          sunPathDomeRef.current = new SunPathDome(Cesium, viewer, {
+            origin: { latitude, longitude, height },
+            radius,
+            date,
+            showAnalemmas: true,
+          });
+          sunPathDomeDayRef.current = dayKey;
+        } else {
+          // Same day, new time → just move the sun marker + beam.
+          sunPathDomeRef.current.update(date);
+        }
+      } else if (sunPathDomeRef.current) {
+        sunPathDomeRef.current.destroy();
+        sunPathDomeRef.current = null;
+        sunPathDomeDayRef.current = null;
+      }
+    } else if (sunPathDomeRef.current) {
+      sunPathDomeRef.current.destroy();
+      sunPathDomeRef.current = null;
+      sunPathDomeDayRef.current = null;
+    }
+
+    viewer.scene.requestRender();
+  }, [
+    status,
+    bridgeVersion,
+    solarEnabled,
+    solarDateMs,
+    solarShowSunPath,
+    solarShowShadows,
+    coordinateInfo,
+    setSolarSunInfo,
+  ]);
+
   // ─── Effect 3: Camera sync loop ─────────────────────────────────────────
   useEffect(() => {
     if (status !== 'ready') return;
@@ -745,31 +866,43 @@ export function CesiumOverlay({
 }
 
 /**
- * Add the Google Photorealistic 3D Tiles layer to the Cesium viewer.
+ * Add the selected 3D context layer to the Cesium viewer. Returns the created
+ * tileset so callers can toggle its shadow casting/receiving for solar
+ * studies (`null` if none could be created).
  */
 async function addDataSourceLayer(
   Cesium: typeof import('cesium'),
   viewer: InstanceType<typeof import('cesium').Viewer>,
   dataSource: string,
   ionToken: string,
-) {
+): Promise<InstanceType<typeof import('cesium').Cesium3DTileset> | null> {
   try {
     switch (dataSource) {
+      case 'osm-buildings': {
+        // OpenStreetMap Buildings — flat-shaded extruded footprints, the grey
+        // massing context used for sun-path / overshadowing studies.
+        const tileset = await Cesium.createOsmBuildingsAsync();
+        viewer.scene.primitives.add(tileset);
+        return tileset;
+      }
       case 'google-photorealistic':
       default: {
         try {
           const tileset = await Cesium.createGooglePhotorealistic3DTileset();
-        viewer.scene.primitives.add(tileset);
+          viewer.scene.primitives.add(tileset);
+          return tileset;
         } catch {
           if (ionToken) {
             const tileset = await Cesium.Cesium3DTileset.fromIonAssetId(2275207);
             viewer.scene.primitives.add(tileset);
+            return tileset;
           }
+          return null;
         }
-        break;
       }
     }
   } catch (err) {
     console.warn('[CesiumOverlay] Failed to add data source:', dataSource, err);
+    return null;
   }
 }

--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -42,6 +42,7 @@ import {
   FileCode2,
   CalendarClock,
   Globe2,
+  Sun,
   Move,
   Settings,
   PenLine,
@@ -587,6 +588,10 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
   const toggleCesium = useViewerStore((state) => state.toggleCesium);
   const cesiumPlacementEditMode = useViewerStore((state) => state.cesiumPlacementEditMode);
   const setCesiumPlacementEditMode = useViewerStore((state) => state.setCesiumPlacementEditMode);
+  // Solar sun-path / shadow study state
+  const solarEnabled = useViewerStore((state) => state.solarEnabled);
+  const toggleSolar = useViewerStore((state) => state.toggleSolar);
+  const setCesiumEnabled = useViewerStore((state) => state.setCesiumEnabled);
   const storeModels = useViewerStore((state) => state.models);
   const desktopEntitlement = useViewerStore((state) => state.desktopEntitlement);
   const analysisExtensionState = useSyncExternalStore(
@@ -1671,6 +1676,30 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
               </TooltipContent>
             </Tooltip>
           )}
+          {/* Sun-path + shadow study — needs the Cesium context, so enabling
+              it turns Cesium on too. */}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant={solarEnabled ? 'default' : 'ghost'}
+                size="icon-sm"
+                aria-label={solarEnabled ? 'Hide sun-path study' : 'Show sun-path study'}
+                aria-pressed={solarEnabled}
+                onClick={(e) => {
+                  (e.currentTarget as HTMLButtonElement).blur();
+                  const willEnable = !solarEnabled;
+                  toggleSolar();
+                  if (willEnable) setCesiumEnabled(true);
+                }}
+                className={cn(solarEnabled && 'bg-amber-500 text-zinc-950 hover:bg-amber-400')}
+              >
+                <Sun className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {solarEnabled ? 'Hide' : 'Show'} sun-path &amp; shadow study
+            </TooltipContent>
+          </Tooltip>
         </>
       )}
 

--- a/apps/viewer/src/components/viewer/SolarPanel.tsx
+++ b/apps/viewer/src/components/viewer/SolarPanel.tsx
@@ -11,10 +11,10 @@
  * and on Cesium for the OSM/photorealistic context that casts shadows.
  *
  * Time handling: the studied instant is always stored as an absolute UTC
- * epoch. For display the panel can show either UTC or *local solar time*
- * derived from the site longitude (15°/hour) — civil-timezone-agnostic on
- * purpose, since sun-path studies care about solar time and a longitude
- * offset needs no timezone database or DST rules.
+ * epoch. For display the panel defaults to *local solar time* derived from the
+ * site longitude (15°/hour) — civil-timezone-agnostic on purpose, since
+ * sun-path studies care about solar time and a longitude offset needs no
+ * timezone database or DST rules. The user can switch the readout to UTC.
  */
 
 import { useEffect, useRef } from 'react';
@@ -154,17 +154,18 @@ export function SolarPanel() {
   };
 
   return (
-    <div className="absolute top-2 right-2 z-20 w-64 rounded-md bg-white/90 dark:bg-[#1a1b26]/90 backdrop-blur-sm border border-zinc-200 dark:border-[#292e42] shadow-lg p-3 text-xs font-mono text-zinc-700 dark:text-[#a9b1d6]">
-      <div className="flex items-center justify-between mb-2">
-        <span className="font-black uppercase tracking-wide text-zinc-900 dark:text-white">Sun Path</span>
+    <div className="absolute top-4 right-4 z-10 pointer-events-auto w-60 bg-background/90 backdrop-blur-sm rounded-lg border shadow-lg p-2 flex flex-col gap-2 text-xs">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          Sun Path
+        </span>
         <button
           type="button"
+          aria-pressed={enabled}
           onClick={toggleStudy}
           className={cn(
-            'px-2 py-0.5 rounded text-[10px] font-bold uppercase border transition-colors',
-            enabled
-              ? 'bg-[#9ece6a] text-black border-[#9ece6a]'
-              : 'bg-transparent border-zinc-300 dark:border-[#414868] hover:border-[#9ece6a]',
+            'px-2 py-0.5 rounded text-[10px] font-semibold uppercase transition-colors',
+            enabled ? 'bg-teal-600 text-white' : 'text-muted-foreground hover:bg-muted hover:text-foreground',
           )}
         >
           {enabled ? 'On' : 'Off'}
@@ -174,15 +175,15 @@ export function SolarPanel() {
       {enabled && (
         <>
           {/* Date + play/pause */}
-          <div className="flex items-end gap-1.5 mb-2">
-            <label className="block flex-1">
-              <span className="flex justify-between text-[10px] uppercase text-zinc-500 dark:text-[#565f89]">
+          <div className="flex items-end gap-1.5">
+            <label className="flex flex-col gap-0.5 flex-1">
+              <span className="flex justify-between text-[9px] uppercase tracking-wider text-muted-foreground">
                 <span>Date</span>
                 <button
                   type="button"
                   onClick={() => setUseLocalTime(!useLocalTime)}
                   title="Toggle UTC / local solar time (from site longitude)"
-                  className="hover:text-[#7aa2f7] transition-colors"
+                  className="hover:text-foreground transition-colors"
                 >
                   {tzLabel}
                 </button>
@@ -191,18 +192,17 @@ export function SolarPanel() {
                 type="date"
                 value={toDateInputValue(dateMs, offsetMin)}
                 onChange={(e) => setDateMs(composeMs(e.target.value, minutes, offsetMin))}
-                className="mt-0.5 w-full bg-zinc-100 dark:bg-[#24283b] rounded px-1.5 py-1 border border-zinc-200 dark:border-[#414868]"
+                className="w-full bg-muted/40 rounded px-1.5 py-1 border text-foreground"
               />
             </label>
             <button
               type="button"
               onClick={togglePlaying}
               aria-label={playing ? 'Pause sweep' : 'Play sweep'}
+              aria-pressed={playing}
               className={cn(
-                'h-[26px] w-[26px] flex items-center justify-center rounded border transition-colors shrink-0',
-                playing
-                  ? 'bg-[#f7768e] text-black border-[#f7768e]'
-                  : 'bg-transparent border-zinc-300 dark:border-[#414868] hover:border-[#f7768e]',
+                'h-[26px] w-[26px] flex items-center justify-center rounded transition-colors shrink-0',
+                playing ? 'bg-teal-600 text-white' : 'text-muted-foreground hover:bg-muted hover:text-foreground',
               )}
             >
               {playing ? <Pause className="h-3.5 w-3.5" /> : <Play className="h-3.5 w-3.5" />}
@@ -210,10 +210,10 @@ export function SolarPanel() {
           </div>
 
           {/* Time of day */}
-          <label className="block mb-2">
-            <span className="flex justify-between text-[10px] uppercase text-zinc-500 dark:text-[#565f89]">
+          <label className="flex flex-col gap-0.5">
+            <span className="flex justify-between text-[9px] uppercase tracking-wider text-muted-foreground">
               <span>Time</span>
-              <span className="tabular-nums">{formatTime(dateMs, offsetMin)}</span>
+              <span className="tabular-nums text-foreground">{formatTime(dateMs, offsetMin)}</span>
             </span>
             <input
               type="range"
@@ -222,25 +222,26 @@ export function SolarPanel() {
               step={5}
               value={minutes}
               onChange={(e) => setDateMs(composeMs(toDateInputValue(dateMs, offsetMin), Number(e.target.value), offsetMin))}
-              className="mt-1 w-full accent-[#9ece6a]"
+              className="w-full accent-teal-600"
             />
           </label>
 
           {/* Sweep mode */}
-          <div className="mb-2">
-            <span className="text-[10px] uppercase text-zinc-500 dark:text-[#565f89]">Sweep</span>
-            <div className="mt-0.5 flex gap-1">
+          <div className="flex flex-col gap-0.5">
+            <span className="text-[9px] uppercase tracking-wider text-muted-foreground">Sweep</span>
+            <div className="flex gap-1">
               {SWEEP_MODES.map((m) => (
                 <button
                   key={m.value}
                   type="button"
                   title={m.hint}
+                  aria-pressed={sweepMode === m.value}
                   onClick={() => setSweepMode(m.value)}
                   className={cn(
-                    'flex-1 px-1.5 py-1 rounded text-[10px] border transition-colors',
+                    'flex-1 px-1.5 py-1 rounded text-[10px] transition-colors',
                     sweepMode === m.value
-                      ? 'bg-[#e0af68] text-black border-[#e0af68]'
-                      : 'bg-transparent border-zinc-300 dark:border-[#414868] hover:border-[#e0af68]',
+                      ? 'bg-teal-600 text-white'
+                      : 'text-muted-foreground hover:bg-muted hover:text-foreground',
                   )}
                 >
                   {m.label}
@@ -250,26 +251,27 @@ export function SolarPanel() {
           </div>
 
           {/* Toggles */}
-          <div className="flex gap-2 mb-2">
+          <div className="flex gap-1">
             <ToggleChip label="Dome" active={showSunPath} onClick={() => setShowSunPath(!showSunPath)} />
             <ToggleChip label="Shadows" active={showShadows} onClick={() => setShowShadows(!showShadows)} />
           </div>
 
           {/* Context source */}
-          <div className="mb-2">
-            <span className="text-[10px] uppercase text-zinc-500 dark:text-[#565f89]">Context</span>
-            <div className="mt-0.5 flex gap-1">
+          <div className="flex flex-col gap-0.5">
+            <span className="text-[9px] uppercase tracking-wider text-muted-foreground">Context</span>
+            <div className="flex gap-1">
               {CONTEXT_SOURCES.map((src) => (
                 <button
                   key={src.value}
                   type="button"
                   title={src.hint}
+                  aria-pressed={dataSource === src.value}
                   onClick={() => setDataSource(src.value)}
                   className={cn(
-                    'flex-1 px-1.5 py-1 rounded text-[10px] border transition-colors',
+                    'flex-1 px-1.5 py-1 rounded text-[10px] transition-colors',
                     dataSource === src.value
-                      ? 'bg-[#7aa2f7] text-black border-[#7aa2f7]'
-                      : 'bg-transparent border-zinc-300 dark:border-[#414868] hover:border-[#7aa2f7]',
+                      ? 'bg-teal-600 text-white'
+                      : 'text-muted-foreground hover:bg-muted hover:text-foreground',
                   )}
                 >
                   {src.label}
@@ -279,7 +281,7 @@ export function SolarPanel() {
           </div>
 
           {/* Readout */}
-          <div className="mt-2 pt-2 border-t border-zinc-200 dark:border-[#292e42] grid grid-cols-2 gap-x-2 gap-y-0.5 tabular-nums">
+          <div className="mt-1 pt-2 border-t grid grid-cols-2 gap-x-2 gap-y-0.5 tabular-nums">
             <Readout label="Azimuth" value={sunInfo ? `${sunInfo.azimuth.toFixed(1)}°` : '—'} />
             <Readout label="Altitude" value={sunInfo ? `${sunInfo.altitude.toFixed(1)}°` : '—'} />
             <Readout label="Sunrise" value={formatTime(sunInfo?.sunriseMs ?? null, offsetMin)} />
@@ -302,11 +304,10 @@ function ToggleChip({ label, active, onClick }: { label: string; active: boolean
     <button
       type="button"
       onClick={onClick}
+      aria-pressed={active}
       className={cn(
-        'flex-1 px-2 py-1 rounded text-[10px] font-bold uppercase border transition-colors',
-        active
-          ? 'bg-[#bb9af7] text-black border-[#bb9af7]'
-          : 'bg-transparent border-zinc-300 dark:border-[#414868] hover:border-[#bb9af7]',
+        'flex-1 px-2 py-1 rounded text-[10px] font-semibold uppercase transition-colors',
+        active ? 'bg-teal-600 text-white' : 'text-muted-foreground hover:bg-muted hover:text-foreground',
       )}
     >
       {label}
@@ -318,8 +319,8 @@ function ToggleChip({ label, active, onClick }: { label: string; active: boolean
 function Readout({ label, value }: { label: string; value: string }) {
   return (
     <>
-      <span className="text-zinc-500 dark:text-[#565f89]">{label}</span>
-      <span className="text-right text-zinc-900 dark:text-white">{value}</span>
+      <span className="text-muted-foreground">{label}</span>
+      <span className="text-right text-foreground">{value}</span>
     </>
   );
 }

--- a/apps/viewer/src/components/viewer/SolarPanel.tsx
+++ b/apps/viewer/src/components/viewer/SolarPanel.tsx
@@ -10,38 +10,59 @@
  * because the study relies on the model's real-world site for sun position
  * and on Cesium for the OSM/photorealistic context that casts shadows.
  *
- * Times are handled in UTC throughout so the studied instant is unambiguous
- * regardless of the host machine's timezone; the panel labels them as UTC.
+ * Time handling: the studied instant is always stored as an absolute UTC
+ * epoch. For display the panel can show either UTC or *local solar time*
+ * derived from the site longitude (15°/hour) — civil-timezone-agnostic on
+ * purpose, since sun-path studies care about solar time and a longitude
+ * offset needs no timezone database or DST rules.
  */
 
+import { useEffect, useRef } from 'react';
+import { Play, Pause } from 'lucide-react';
 import { useViewerStore } from '@/store';
 import { cn } from '@/lib/utils';
 import type { CesiumDataSource } from '@/store/slices/cesiumSlice';
+import type { SolarSweepMode } from '@/store/slices/solarSlice';
 
-/** Epoch ms → "YYYY-MM-DD" for the UTC day (for <input type="date">). */
-function toDateInputValue(ms: number): string {
-  const d = new Date(ms);
+const MS_PER_MIN = 60_000;
+const MS_PER_DAY = 86_400_000;
+
+/** Longitude → display offset in minutes (local solar time), or 0 for UTC. */
+function offsetMinutesFor(useLocal: boolean, longitude: number | undefined): number {
+  if (!useLocal || longitude === undefined) return 0;
+  return Math.round((longitude / 15) * 60);
+}
+
+/** Epoch ms shifted into the display frame (UTC + offset). */
+function toDisplay(ms: number, offsetMin: number): Date {
+  return new Date(ms + offsetMin * MS_PER_MIN);
+}
+
+/** "YYYY-MM-DD" of the display-frame day for an instant. */
+function toDateInputValue(ms: number, offsetMin: number): string {
+  const d = toDisplay(ms, offsetMin);
   const mm = String(d.getUTCMonth() + 1).padStart(2, '0');
   const dd = String(d.getUTCDate()).padStart(2, '0');
   return `${d.getUTCFullYear()}-${mm}-${dd}`;
 }
 
-/** Minutes since UTC midnight of the day containing `ms`. */
-function minutesOfDay(ms: number): number {
-  const d = new Date(ms);
+/** Minutes since midnight in the display frame. */
+function minutesOfDay(ms: number, offsetMin: number): number {
+  const d = toDisplay(ms, offsetMin);
   return d.getUTCHours() * 60 + d.getUTCMinutes();
 }
 
-/** Compose a new epoch ms from a date string + minutes-of-day. */
-function composeMs(dateStr: string, minutes: number): number {
+/** Compose an absolute UTC epoch from a display-frame date string + minutes. */
+function composeMs(dateStr: string, minutes: number, offsetMin: number): number {
   const [y, m, d] = dateStr.split('-').map(Number);
-  return Date.UTC(y, (m ?? 1) - 1, d ?? 1, Math.floor(minutes / 60), minutes % 60, 0);
+  const displayMs = Date.UTC(y, (m ?? 1) - 1, d ?? 1, Math.floor(minutes / 60), minutes % 60, 0);
+  return displayMs - offsetMin * MS_PER_MIN;
 }
 
-/** Epoch ms → "HH:MM" UTC. */
-function formatTime(ms: number | null): string {
+/** Epoch ms → "HH:MM" in the display frame. */
+function formatTime(ms: number | null, offsetMin: number): string {
   if (ms === null) return '—';
-  const d = new Date(ms);
+  const d = toDisplay(ms, offsetMin);
   return `${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}`;
 }
 
@@ -49,6 +70,17 @@ const CONTEXT_SOURCES: Array<{ value: CesiumDataSource; label: string; hint: str
   { value: 'osm-buildings', label: 'OSM Buildings', hint: 'Grey extruded footprints — classic massing context' },
   { value: 'google-photorealistic', label: 'Photorealistic', hint: 'Google 3D Tiles — textured real-world context' },
 ];
+
+const SWEEP_MODES: Array<{ value: SolarSweepMode; label: string; hint: string }> = [
+  { value: 'day', label: 'Day', hint: 'Sweep the time of day' },
+  { value: 'year', label: 'Year', hint: 'Sweep the date across the year' },
+];
+
+/** Wall-clock cadence for the animation sweep. */
+const TICK_MS = 80;
+/** Per-tick advance: 8 minutes of solar time (day) or 2 days (year). */
+const DAY_STEP_MIN = 8;
+const YEAR_STEP_DAYS = 2;
 
 export function SolarPanel() {
   const cesiumAvailable = useViewerStore((s) => s.cesiumAvailable);
@@ -62,19 +94,62 @@ export function SolarPanel() {
   const showShadows = useViewerStore((s) => s.solarShowShadows);
   const setShowShadows = useViewerStore((s) => s.setSolarShowShadows);
   const sunInfo = useViewerStore((s) => s.solarSunInfo);
+  const useLocalTime = useViewerStore((s) => s.solarUseLocalTime);
+  const setUseLocalTime = useViewerStore((s) => s.setSolarUseLocalTime);
+  const playing = useViewerStore((s) => s.solarPlaying);
+  const togglePlaying = useViewerStore((s) => s.toggleSolarPlaying);
+  const sweepMode = useViewerStore((s) => s.solarSweepMode);
+  const setSweepMode = useViewerStore((s) => s.setSolarSweepMode);
 
   const setCesiumEnabled = useViewerStore((s) => s.setCesiumEnabled);
   const dataSource = useViewerStore((s) => s.cesiumDataSource);
   const setDataSource = useViewerStore((s) => s.setCesiumDataSource);
 
+  // ── Animation sweep loop ────────────────────────────────────────────────
+  // Reads/writes the studied instant imperatively each tick to avoid stale
+  // closures, and wraps within the current day (day sweep) or year (year
+  // sweep) so the animation loops cleanly.
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  useEffect(() => {
+    if (!enabled || !playing) return;
+    intervalRef.current = setInterval(() => {
+      const store = useViewerStore.getState();
+      const current = store.solarDateMs;
+      const d = new Date(current);
+      let next: number;
+      if (store.solarSweepMode === 'day') {
+        const dayStart = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+        const minutes = (current - dayStart) / MS_PER_MIN;
+        const nextMinutes = (minutes + DAY_STEP_MIN) % 1440;
+        next = dayStart + nextMinutes * MS_PER_MIN;
+      } else {
+        const yearStart = Date.UTC(d.getUTCFullYear(), 0, 1);
+        const dayOfYear = Math.floor((current - yearStart) / MS_PER_DAY);
+        const isLeap = (d.getUTCFullYear() % 4 === 0 && d.getUTCFullYear() % 100 !== 0) || d.getUTCFullYear() % 400 === 0;
+        const daysInYear = isLeap ? 366 : 365;
+        const timeOfDay = current - (yearStart + dayOfYear * MS_PER_DAY);
+        const nextDay = (dayOfYear + YEAR_STEP_DAYS) % daysInYear;
+        next = yearStart + nextDay * MS_PER_DAY + timeOfDay;
+      }
+      store.setSolarDateMs(next);
+    }, TICK_MS);
+    return () => {
+      if (intervalRef.current !== null) clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    };
+  }, [enabled, playing, sweepMode]);
+
   if (!cesiumAvailable) return null;
 
-  const minutes = minutesOfDay(dateMs);
+  const offsetMin = offsetMinutesFor(useLocalTime, sunInfo?.longitude);
+  const minutes = minutesOfDay(dateMs, offsetMin);
+  const tzLabel = useLocalTime
+    ? `Site${sunInfo ? ` (UTC${offsetMin >= 0 ? '+' : '−'}${Math.abs(offsetMin / 60).toFixed(1)})` : ''}`
+    : 'UTC';
 
   const toggleStudy = () => {
     const next = !enabled;
     setEnabled(next);
-    // The study renders in Cesium, so turning it on implies the context is on.
     if (next) setCesiumEnabled(true);
   };
 
@@ -98,22 +173,47 @@ export function SolarPanel() {
 
       {enabled && (
         <>
-          {/* Date */}
-          <label className="block mb-2">
-            <span className="text-[10px] uppercase text-zinc-500 dark:text-[#565f89]">Date (UTC)</span>
-            <input
-              type="date"
-              value={toDateInputValue(dateMs)}
-              onChange={(e) => setDateMs(composeMs(e.target.value, minutes))}
-              className="mt-0.5 w-full bg-zinc-100 dark:bg-[#24283b] rounded px-1.5 py-1 border border-zinc-200 dark:border-[#414868]"
-            />
-          </label>
+          {/* Date + play/pause */}
+          <div className="flex items-end gap-1.5 mb-2">
+            <label className="block flex-1">
+              <span className="flex justify-between text-[10px] uppercase text-zinc-500 dark:text-[#565f89]">
+                <span>Date</span>
+                <button
+                  type="button"
+                  onClick={() => setUseLocalTime(!useLocalTime)}
+                  title="Toggle UTC / local solar time (from site longitude)"
+                  className="hover:text-[#7aa2f7] transition-colors"
+                >
+                  {tzLabel}
+                </button>
+              </span>
+              <input
+                type="date"
+                value={toDateInputValue(dateMs, offsetMin)}
+                onChange={(e) => setDateMs(composeMs(e.target.value, minutes, offsetMin))}
+                className="mt-0.5 w-full bg-zinc-100 dark:bg-[#24283b] rounded px-1.5 py-1 border border-zinc-200 dark:border-[#414868]"
+              />
+            </label>
+            <button
+              type="button"
+              onClick={togglePlaying}
+              aria-label={playing ? 'Pause sweep' : 'Play sweep'}
+              className={cn(
+                'h-[26px] w-[26px] flex items-center justify-center rounded border transition-colors shrink-0',
+                playing
+                  ? 'bg-[#f7768e] text-black border-[#f7768e]'
+                  : 'bg-transparent border-zinc-300 dark:border-[#414868] hover:border-[#f7768e]',
+              )}
+            >
+              {playing ? <Pause className="h-3.5 w-3.5" /> : <Play className="h-3.5 w-3.5" />}
+            </button>
+          </div>
 
           {/* Time of day */}
           <label className="block mb-2">
             <span className="flex justify-between text-[10px] uppercase text-zinc-500 dark:text-[#565f89]">
-              <span>Time (UTC)</span>
-              <span className="tabular-nums">{formatTime(dateMs)}</span>
+              <span>Time</span>
+              <span className="tabular-nums">{formatTime(dateMs, offsetMin)}</span>
             </span>
             <input
               type="range"
@@ -121,10 +221,33 @@ export function SolarPanel() {
               max={1439}
               step={5}
               value={minutes}
-              onChange={(e) => setDateMs(composeMs(toDateInputValue(dateMs), Number(e.target.value)))}
+              onChange={(e) => setDateMs(composeMs(toDateInputValue(dateMs, offsetMin), Number(e.target.value), offsetMin))}
               className="mt-1 w-full accent-[#9ece6a]"
             />
           </label>
+
+          {/* Sweep mode */}
+          <div className="mb-2">
+            <span className="text-[10px] uppercase text-zinc-500 dark:text-[#565f89]">Sweep</span>
+            <div className="mt-0.5 flex gap-1">
+              {SWEEP_MODES.map((m) => (
+                <button
+                  key={m.value}
+                  type="button"
+                  title={m.hint}
+                  onClick={() => setSweepMode(m.value)}
+                  className={cn(
+                    'flex-1 px-1.5 py-1 rounded text-[10px] border transition-colors',
+                    sweepMode === m.value
+                      ? 'bg-[#e0af68] text-black border-[#e0af68]'
+                      : 'bg-transparent border-zinc-300 dark:border-[#414868] hover:border-[#e0af68]',
+                  )}
+                >
+                  {m.label}
+                </button>
+              ))}
+            </div>
+          </div>
 
           {/* Toggles */}
           <div className="flex gap-2 mb-2">
@@ -159,9 +282,9 @@ export function SolarPanel() {
           <div className="mt-2 pt-2 border-t border-zinc-200 dark:border-[#292e42] grid grid-cols-2 gap-x-2 gap-y-0.5 tabular-nums">
             <Readout label="Azimuth" value={sunInfo ? `${sunInfo.azimuth.toFixed(1)}°` : '—'} />
             <Readout label="Altitude" value={sunInfo ? `${sunInfo.altitude.toFixed(1)}°` : '—'} />
-            <Readout label="Sunrise" value={formatTime(sunInfo?.sunriseMs ?? null)} />
-            <Readout label="Sunset" value={formatTime(sunInfo?.sunsetMs ?? null)} />
-            <Readout label="Noon" value={formatTime(sunInfo?.solarNoonMs ?? null)} />
+            <Readout label="Sunrise" value={formatTime(sunInfo?.sunriseMs ?? null, offsetMin)} />
+            <Readout label="Sunset" value={formatTime(sunInfo?.sunsetMs ?? null, offsetMin)} />
+            <Readout label="Noon" value={formatTime(sunInfo?.solarNoonMs ?? null, offsetMin)} />
             <Readout
               label="Site"
               value={sunInfo ? `${sunInfo.latitude.toFixed(2)}, ${sunInfo.longitude.toFixed(2)}` : '—'}

--- a/apps/viewer/src/components/viewer/SolarPanel.tsx
+++ b/apps/viewer/src/components/viewer/SolarPanel.tsx
@@ -296,6 +296,7 @@ export function SolarPanel() {
   );
 }
 
+/** Small pill toggle button used for the dome/shadow switches. */
 function ToggleChip({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
   return (
     <button
@@ -313,6 +314,7 @@ function ToggleChip({ label, active, onClick }: { label: string; active: boolean
   );
 }
 
+/** One label/value cell in the sun readout grid. */
 function Readout({ label, value }: { label: string; value: string }) {
   return (
     <>

--- a/apps/viewer/src/components/viewer/SolarPanel.tsx
+++ b/apps/viewer/src/components/viewer/SolarPanel.tsx
@@ -1,0 +1,200 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Solar study panel — controls the georeferenced 3D sun-path dome + shadow
+ * study rendered in the Cesium context overlay.
+ *
+ * Renders only when the loaded model is georeferenced (`cesiumAvailable`),
+ * because the study relies on the model's real-world site for sun position
+ * and on Cesium for the OSM/photorealistic context that casts shadows.
+ *
+ * Times are handled in UTC throughout so the studied instant is unambiguous
+ * regardless of the host machine's timezone; the panel labels them as UTC.
+ */
+
+import { useViewerStore } from '@/store';
+import { cn } from '@/lib/utils';
+import type { CesiumDataSource } from '@/store/slices/cesiumSlice';
+
+/** Epoch ms → "YYYY-MM-DD" for the UTC day (for <input type="date">). */
+function toDateInputValue(ms: number): string {
+  const d = new Date(ms);
+  const mm = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(d.getUTCDate()).padStart(2, '0');
+  return `${d.getUTCFullYear()}-${mm}-${dd}`;
+}
+
+/** Minutes since UTC midnight of the day containing `ms`. */
+function minutesOfDay(ms: number): number {
+  const d = new Date(ms);
+  return d.getUTCHours() * 60 + d.getUTCMinutes();
+}
+
+/** Compose a new epoch ms from a date string + minutes-of-day. */
+function composeMs(dateStr: string, minutes: number): number {
+  const [y, m, d] = dateStr.split('-').map(Number);
+  return Date.UTC(y, (m ?? 1) - 1, d ?? 1, Math.floor(minutes / 60), minutes % 60, 0);
+}
+
+/** Epoch ms → "HH:MM" UTC. */
+function formatTime(ms: number | null): string {
+  if (ms === null) return '—';
+  const d = new Date(ms);
+  return `${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}`;
+}
+
+const CONTEXT_SOURCES: Array<{ value: CesiumDataSource; label: string; hint: string }> = [
+  { value: 'osm-buildings', label: 'OSM Buildings', hint: 'Grey extruded footprints — classic massing context' },
+  { value: 'google-photorealistic', label: 'Photorealistic', hint: 'Google 3D Tiles — textured real-world context' },
+];
+
+export function SolarPanel() {
+  const cesiumAvailable = useViewerStore((s) => s.cesiumAvailable);
+
+  const enabled = useViewerStore((s) => s.solarEnabled);
+  const setEnabled = useViewerStore((s) => s.setSolarEnabled);
+  const dateMs = useViewerStore((s) => s.solarDateMs);
+  const setDateMs = useViewerStore((s) => s.setSolarDateMs);
+  const showSunPath = useViewerStore((s) => s.solarShowSunPath);
+  const setShowSunPath = useViewerStore((s) => s.setSolarShowSunPath);
+  const showShadows = useViewerStore((s) => s.solarShowShadows);
+  const setShowShadows = useViewerStore((s) => s.setSolarShowShadows);
+  const sunInfo = useViewerStore((s) => s.solarSunInfo);
+
+  const setCesiumEnabled = useViewerStore((s) => s.setCesiumEnabled);
+  const dataSource = useViewerStore((s) => s.cesiumDataSource);
+  const setDataSource = useViewerStore((s) => s.setCesiumDataSource);
+
+  if (!cesiumAvailable) return null;
+
+  const minutes = minutesOfDay(dateMs);
+
+  const toggleStudy = () => {
+    const next = !enabled;
+    setEnabled(next);
+    // The study renders in Cesium, so turning it on implies the context is on.
+    if (next) setCesiumEnabled(true);
+  };
+
+  return (
+    <div className="absolute top-2 right-2 z-20 w-64 rounded-md bg-white/90 dark:bg-[#1a1b26]/90 backdrop-blur-sm border border-zinc-200 dark:border-[#292e42] shadow-lg p-3 text-xs font-mono text-zinc-700 dark:text-[#a9b1d6]">
+      <div className="flex items-center justify-between mb-2">
+        <span className="font-black uppercase tracking-wide text-zinc-900 dark:text-white">Sun Path</span>
+        <button
+          type="button"
+          onClick={toggleStudy}
+          className={cn(
+            'px-2 py-0.5 rounded text-[10px] font-bold uppercase border transition-colors',
+            enabled
+              ? 'bg-[#9ece6a] text-black border-[#9ece6a]'
+              : 'bg-transparent border-zinc-300 dark:border-[#414868] hover:border-[#9ece6a]',
+          )}
+        >
+          {enabled ? 'On' : 'Off'}
+        </button>
+      </div>
+
+      {enabled && (
+        <>
+          {/* Date */}
+          <label className="block mb-2">
+            <span className="text-[10px] uppercase text-zinc-500 dark:text-[#565f89]">Date (UTC)</span>
+            <input
+              type="date"
+              value={toDateInputValue(dateMs)}
+              onChange={(e) => setDateMs(composeMs(e.target.value, minutes))}
+              className="mt-0.5 w-full bg-zinc-100 dark:bg-[#24283b] rounded px-1.5 py-1 border border-zinc-200 dark:border-[#414868]"
+            />
+          </label>
+
+          {/* Time of day */}
+          <label className="block mb-2">
+            <span className="flex justify-between text-[10px] uppercase text-zinc-500 dark:text-[#565f89]">
+              <span>Time (UTC)</span>
+              <span className="tabular-nums">{formatTime(dateMs)}</span>
+            </span>
+            <input
+              type="range"
+              min={0}
+              max={1439}
+              step={5}
+              value={minutes}
+              onChange={(e) => setDateMs(composeMs(toDateInputValue(dateMs), Number(e.target.value)))}
+              className="mt-1 w-full accent-[#9ece6a]"
+            />
+          </label>
+
+          {/* Toggles */}
+          <div className="flex gap-2 mb-2">
+            <ToggleChip label="Dome" active={showSunPath} onClick={() => setShowSunPath(!showSunPath)} />
+            <ToggleChip label="Shadows" active={showShadows} onClick={() => setShowShadows(!showShadows)} />
+          </div>
+
+          {/* Context source */}
+          <div className="mb-2">
+            <span className="text-[10px] uppercase text-zinc-500 dark:text-[#565f89]">Context</span>
+            <div className="mt-0.5 flex gap-1">
+              {CONTEXT_SOURCES.map((src) => (
+                <button
+                  key={src.value}
+                  type="button"
+                  title={src.hint}
+                  onClick={() => setDataSource(src.value)}
+                  className={cn(
+                    'flex-1 px-1.5 py-1 rounded text-[10px] border transition-colors',
+                    dataSource === src.value
+                      ? 'bg-[#7aa2f7] text-black border-[#7aa2f7]'
+                      : 'bg-transparent border-zinc-300 dark:border-[#414868] hover:border-[#7aa2f7]',
+                  )}
+                >
+                  {src.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Readout */}
+          <div className="mt-2 pt-2 border-t border-zinc-200 dark:border-[#292e42] grid grid-cols-2 gap-x-2 gap-y-0.5 tabular-nums">
+            <Readout label="Azimuth" value={sunInfo ? `${sunInfo.azimuth.toFixed(1)}°` : '—'} />
+            <Readout label="Altitude" value={sunInfo ? `${sunInfo.altitude.toFixed(1)}°` : '—'} />
+            <Readout label="Sunrise" value={formatTime(sunInfo?.sunriseMs ?? null)} />
+            <Readout label="Sunset" value={formatTime(sunInfo?.sunsetMs ?? null)} />
+            <Readout label="Noon" value={formatTime(sunInfo?.solarNoonMs ?? null)} />
+            <Readout
+              label="Site"
+              value={sunInfo ? `${sunInfo.latitude.toFixed(2)}, ${sunInfo.longitude.toFixed(2)}` : '—'}
+            />
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function ToggleChip({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'flex-1 px-2 py-1 rounded text-[10px] font-bold uppercase border transition-colors',
+        active
+          ? 'bg-[#bb9af7] text-black border-[#bb9af7]'
+          : 'bg-transparent border-zinc-300 dark:border-[#414868] hover:border-[#bb9af7]',
+      )}
+    >
+      {label}
+    </button>
+  );
+}
+
+function Readout({ label, value }: { label: string; value: string }) {
+  return (
+    <>
+      <span className="text-zinc-500 dark:text-[#565f89]">{label}</span>
+      <span className="text-right text-zinc-900 dark:text-white">{value}</span>
+    </>
+  );
+}

--- a/apps/viewer/src/components/viewer/SolarPanel.tsx
+++ b/apps/viewer/src/components/viewer/SolarPanel.tsx
@@ -115,14 +115,20 @@ export function SolarPanel() {
     intervalRef.current = setInterval(() => {
       const store = useViewerStore.getState();
       const current = store.solarDateMs;
-      const d = new Date(current);
       let next: number;
       if (store.solarSweepMode === 'day') {
-        const dayStart = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
-        const minutes = (current - dayStart) / MS_PER_MIN;
+        // Wrap in the same display frame the slider edits in, so the day seam
+        // lands at displayed midnight (not UTC midnight) and the date doesn't
+        // flip mid-sweep when site/local time is active.
+        const offsetMin = offsetMinutesFor(store.solarUseLocalTime, store.solarSunInfo?.longitude);
+        const displayMs = current + offsetMin * MS_PER_MIN;
+        const disp = new Date(displayMs);
+        const dayStart = Date.UTC(disp.getUTCFullYear(), disp.getUTCMonth(), disp.getUTCDate());
+        const minutes = (displayMs - dayStart) / MS_PER_MIN;
         const nextMinutes = (minutes + DAY_STEP_MIN) % 1440;
-        next = dayStart + nextMinutes * MS_PER_MIN;
+        next = dayStart + nextMinutes * MS_PER_MIN - offsetMin * MS_PER_MIN;
       } else {
+        const d = new Date(current);
         const yearStart = Date.UTC(d.getUTCFullYear(), 0, 1);
         const dayOfYear = Math.floor((current - yearStart) / MS_PER_DAY);
         const isLeap = (d.getUTCFullYear() % 4 === 0 && d.getUTCFullYear() % 100 !== 0) || d.getUTCFullYear() % 400 === 0;
@@ -176,7 +182,9 @@ export function SolarPanel() {
         <>
           {/* Date + play/pause */}
           <div className="flex items-end gap-1.5">
-            <label className="flex flex-col gap-0.5 flex-1">
+            {/* Not a <label>: the tz toggle is interactive, so wrapping the
+                input in a label would forward tz clicks to the date picker. */}
+            <div className="flex flex-col gap-0.5 flex-1">
               <span className="flex justify-between text-[9px] uppercase tracking-wider text-muted-foreground">
                 <span>Date</span>
                 <button
@@ -190,11 +198,12 @@ export function SolarPanel() {
               </span>
               <input
                 type="date"
+                aria-label="Sun study date"
                 value={toDateInputValue(dateMs, offsetMin)}
                 onChange={(e) => setDateMs(composeMs(e.target.value, minutes, offsetMin))}
                 className="w-full bg-muted/40 rounded px-1.5 py-1 border text-foreground"
               />
-            </label>
+            </div>
             <button
               type="button"
               onClick={togglePlaying}

--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -14,6 +14,7 @@ import { BasketPresentationDock } from './BasketPresentationDock';
 import { BCFOverlay } from './bcf/BCFOverlay';
 import { CesiumOverlay } from './CesiumOverlay';
 import { CesiumPlacementEditor } from './CesiumPlacementEditor';
+import { SolarPanel } from './SolarPanel';
 import { getViewerStoreApi, useViewerStore } from '@/store';
 import { toGlobalIdFromModels } from '@/store/globalId';
 import { collectIfcBuildingStoreyElementsWithIfcSpace } from '@/store/basketVisibleSet';
@@ -1075,6 +1076,8 @@ export function ViewportContainer() {
           storeyElevations={georef.storeyElevations}
         />
       )}
+      {/* Solar sun-path + shadow study panel (self-gates on georeference; web only) */}
+      {georef && !isTauri() && <SolarPanel />}
       {cesiumEnabled && georef?.mapConversion && !isTauri() && georef.baseMapConversion && (
         <CesiumPlacementEditor
           modelId={georef.sourceModelId}

--- a/apps/viewer/src/lib/geo/cesium-sun.ts
+++ b/apps/viewer/src/lib/geo/cesium-sun.ts
@@ -127,7 +127,13 @@ export class SunPathDome {
 
     this.buildStatic();
     this.update(options.date);
-    void viewer.dataSources.add(this.dataSource);
+    // Await attach, THEN request a render: the viewer runs in requestRenderMode,
+    // so a render requested before the data source is attached would paint
+    // nothing and the dome would stay invisible until the next camera move.
+    viewer.dataSources
+      .add(this.dataSource)
+      .then(() => viewer.scene.requestRender())
+      .catch((err) => console.warn('[SunPathDome] failed to add data source:', err));
   }
 
   /** Map a single ENU direction (unit) at the dome radius to an ECEF position. */
@@ -153,6 +159,9 @@ export class SunPathDome {
         positions,
         width,
         material: this.Cesium.Color.fromBytes(rgb[0], rgb[1], rgb[2], 235),
+        // Draw the dome even where it sits behind terrain / 3D tiles or the
+        // model, dimmer, so the full sun path stays legible in 3D.
+        depthFailMaterial: this.Cesium.Color.fromBytes(rgb[0], rgb[1], rgb[2], 90),
         arcType: this.Cesium.ArcType.NONE,
       },
     });
@@ -226,6 +235,7 @@ export class SunPathDome {
           positions: [originEcef, sunEcef],
           width: 2,
           material: this.Cesium.Color.fromBytes(SUN_COLOR[0], SUN_COLOR[1], SUN_COLOR[2], 160),
+          depthFailMaterial: this.Cesium.Color.fromBytes(SUN_COLOR[0], SUN_COLOR[1], SUN_COLOR[2], 70),
           arcType: this.Cesium.ArcType.NONE,
         },
       });

--- a/apps/viewer/src/lib/geo/cesium-sun.ts
+++ b/apps/viewer/src/lib/geo/cesium-sun.ts
@@ -1,0 +1,251 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Cesium sun helpers — turn the renderer-agnostic geometry from
+ * `@ifc-lite/solar` into real Cesium scene state for a georeferenced sun-path
+ * + shadow study:
+ *
+ *   • applySolarScene  — drive Cesium's sun, lighting and shadow map from a
+ *                        chosen instant (the model + OSM context then cast and
+ *                        receive real shadows).
+ *   • SunPathDome      — a self-contained set of polyline/point entities for
+ *                        the 3D dome (day arc, hourly analemmas, graticule,
+ *                        cardinals, and the live sun marker + beam).
+ *
+ * All dome geometry is positioned by mapping the solar package's ENU unit
+ * vectors through `eastNorthUpToFixedFrame(origin)`, the same ENU→ECEF frame
+ * the coordinate bridge uses, so the dome is pinned to the model's true site.
+ */
+
+import {
+  analemmaPaths,
+  dayPath,
+  domeGraticule,
+  azimuthAltitudeToEnu,
+  sunPosition,
+  type Enu,
+} from '@ifc-lite/solar';
+
+type CesiumNs = typeof import('cesium');
+type CesiumViewer = InstanceType<typeof import('cesium').Viewer>;
+
+export interface SolarSceneOptions {
+  /** Studied instant. */
+  date: Date;
+  /** Master enable — false restores the neutral (no-sun) overlay state. */
+  enabled: boolean;
+  /** Whether to render the shadow map (mutual model ↔ context shadows). */
+  shadows: boolean;
+}
+
+/**
+ * Drive Cesium's sun, lighting and shadow map from the studied instant.
+ * Idempotent — safe to call every time the date or toggles change.
+ */
+export function applySolarScene(
+  Cesium: CesiumNs,
+  viewer: CesiumViewer,
+  options: SolarSceneOptions,
+): void {
+  const scene = viewer.scene;
+  const { enabled, shadows, date } = options;
+
+  if (!enabled) {
+    // Restore the transparent-compositing defaults set up in CesiumOverlay.
+    if (scene.sun) scene.sun.show = false;
+    scene.globe.enableLighting = false;
+    viewer.shadows = false;
+    scene.light = new Cesium.DirectionalLight({
+      direction: new Cesium.Cartesian3(0.5, -1.0, -0.3),
+    });
+    return;
+  }
+
+  // Pin the simulation clock to the studied instant so Cesium's SunLight and
+  // shadow map are computed for exactly this date/time.
+  const julian = Cesium.JulianDate.fromDate(date);
+  viewer.clock.shouldAnimate = false;
+  viewer.clock.currentTime = julian;
+  scene.light = new Cesium.SunLight();
+  if (scene.sun) scene.sun.show = false; // keep the sun billboard off (transparent compositing)
+  scene.globe.enableLighting = true;
+  viewer.shadows = shadows;
+  if (viewer.shadowMap) {
+    viewer.shadowMap.enabled = shadows;
+    viewer.shadowMap.softShadows = true;
+    viewer.shadowMap.darkness = 0.35;
+  }
+  scene.requestRender();
+}
+
+export interface SunPathDomeOptions {
+  /** Site origin (model georef). */
+  origin: { longitude: number; latitude: number; height: number };
+  /** Dome radius in metres. */
+  radius: number;
+  /** Studied instant (positions the live sun marker). */
+  date: Date;
+  /** Show the hourly analemma figure-eights. */
+  showAnalemmas?: boolean;
+}
+
+const DAY_ARC_COLOR = [255, 200, 40] as const; // warm yellow
+const ANALEMMA_COLOR = [120, 170, 255] as const; // cool blue
+const GRID_COLOR = [255, 255, 255] as const;
+const SUN_COLOR = [255, 230, 120] as const;
+
+/**
+ * A self-contained collection of Cesium entities forming the 3D sun-path
+ * dome. Construct once for a site/date, then call {@link update} as the
+ * studied instant changes (only the sun marker + beam move), and
+ * {@link destroy} to remove every entity.
+ */
+export class SunPathDome {
+  private readonly Cesium: CesiumNs;
+  private readonly viewer: CesiumViewer;
+  private readonly dataSource: InstanceType<typeof import('cesium').CustomDataSource>;
+  private readonly options: SunPathDomeOptions;
+  private readonly enuToEcef: InstanceType<typeof import('cesium').Matrix4>;
+  private sunMarker: InstanceType<typeof import('cesium').Entity> | null = null;
+  private sunBeam: InstanceType<typeof import('cesium').Entity> | null = null;
+
+  constructor(Cesium: CesiumNs, viewer: CesiumViewer, options: SunPathDomeOptions) {
+    this.Cesium = Cesium;
+    this.viewer = viewer;
+    this.options = options;
+    this.dataSource = new Cesium.CustomDataSource('ifc-lite-sun-path');
+
+    const originCart = Cesium.Cartesian3.fromDegrees(
+      options.origin.longitude,
+      options.origin.latitude,
+      options.origin.height,
+    );
+    this.enuToEcef = Cesium.Transforms.eastNorthUpToFixedFrame(originCart);
+
+    this.buildStatic();
+    this.update(options.date);
+    void viewer.dataSources.add(this.dataSource);
+  }
+
+  /** Map a single ENU direction (unit) at the dome radius to an ECEF position. */
+  private enuDirToEcef(dir: Enu, radiusScale = 1): InstanceType<typeof import('cesium').Cartesian3> {
+    const r = this.options.radius * radiusScale;
+    return this.Cesium.Matrix4.multiplyByPoint(
+      this.enuToEcef,
+      new this.Cesium.Cartesian3(dir.e * r, dir.n * r, dir.u * r),
+      new this.Cesium.Cartesian3(),
+    );
+  }
+
+  private polyline(
+    dirs: Enu[],
+    rgb: readonly [number, number, number],
+    width: number,
+  ): void {
+    if (dirs.length < 2) return;
+    const positions = dirs.map((d) => this.enuDirToEcef(d));
+    this.dataSource.entities.add({
+      polyline: {
+        positions,
+        width,
+        material: this.Cesium.Color.fromBytes(rgb[0], rgb[1], rgb[2], 235),
+        arcType: this.Cesium.ArcType.NONE,
+      },
+    });
+  }
+
+  /** Build the date-independent geometry: graticule, cardinals, analemmas, day arc. */
+  private buildStatic(): void {
+    const { origin, radius, date } = this.options;
+
+    // Graticule — altitude rings + azimuth spokes.
+    const grat = domeGraticule({ altitudeStep: 15, azimuthStep: 30 });
+    for (const ring of grat.altitudeRings) {
+      this.polyline(ring.ring, GRID_COLOR, ring.altitude === 0 ? 2 : 1);
+    }
+    for (const spoke of grat.azimuthSpokes) {
+      this.polyline(spoke.arc, GRID_COLOR, 1);
+    }
+
+    // Cardinal / ordinal labels on the horizon.
+    for (const c of grat.cardinals) {
+      this.dataSource.entities.add({
+        position: this.enuDirToEcef(c.dir, 1.05),
+        label: {
+          text: c.label,
+          font: '600 14px sans-serif',
+          fillColor: this.Cesium.Color.WHITE,
+          outlineColor: this.Cesium.Color.BLACK,
+          outlineWidth: 2,
+          style: this.Cesium.LabelStyle.FILL_AND_OUTLINE,
+          disableDepthTestDistance: Number.POSITIVE_INFINITY,
+        },
+      });
+    }
+
+    // Hourly analemmas (figure-eights) across the year.
+    if (this.options.showAnalemmas ?? true) {
+      const year = date.getUTCFullYear();
+      for (const path of analemmaPaths(year, origin.latitude, origin.longitude, { dayStep: 5 })) {
+        const above = path.samples.filter((s) => s.aboveHorizon).map((s) => s.dir);
+        this.polyline(above, ANALEMMA_COLOR, 1);
+      }
+    }
+
+    // Day arc for the studied date.
+    const arc = dayPath(date, origin.latitude, origin.longitude, { stepMinutes: 10 });
+    this.polyline(arc.map((s) => s.dir), DAY_ARC_COLOR, 2);
+
+    void radius;
+  }
+
+  /** Reposition the live sun marker + beam for a new instant. */
+  update(date: Date): void {
+    const { origin } = this.options;
+    const pos = sunPosition(date, origin.latitude, origin.longitude);
+    const dir = azimuthAltitudeToEnu(pos.azimuth, pos.altitude);
+    const show = pos.altitude >= 0;
+    const sunEcef = this.enuDirToEcef(dir);
+    const originEcef = this.enuDirToEcef({ e: 0, n: 0, u: 0 });
+
+    if (!this.sunMarker) {
+      this.sunMarker = this.dataSource.entities.add({
+        position: sunEcef,
+        point: {
+          pixelSize: 16,
+          color: this.Cesium.Color.fromBytes(SUN_COLOR[0], SUN_COLOR[1], SUN_COLOR[2], 255),
+          outlineColor: this.Cesium.Color.fromBytes(255, 140, 0, 255),
+          outlineWidth: 3,
+          disableDepthTestDistance: Number.POSITIVE_INFINITY,
+        },
+      });
+      this.sunBeam = this.dataSource.entities.add({
+        polyline: {
+          positions: [originEcef, sunEcef],
+          width: 2,
+          material: this.Cesium.Color.fromBytes(SUN_COLOR[0], SUN_COLOR[1], SUN_COLOR[2], 160),
+          arcType: this.Cesium.ArcType.NONE,
+        },
+      });
+    } else {
+      this.sunMarker.position = new this.Cesium.ConstantPositionProperty(sunEcef);
+      if (this.sunBeam?.polyline) {
+        this.sunBeam.polyline.positions = new this.Cesium.ConstantProperty([originEcef, sunEcef]);
+      }
+    }
+    if (this.sunMarker.point) {
+      this.sunMarker.point.show = new this.Cesium.ConstantProperty(show);
+    }
+    if (this.sunBeam?.polyline) {
+      this.sunBeam.polyline.show = new this.Cesium.ConstantProperty(show);
+    }
+    this.viewer.scene.requestRender();
+  }
+
+  destroy(): void {
+    this.dataSource.entities.removeAll();
+    void this.viewer.dataSources.remove(this.dataSource, true);
+  }
+}

--- a/apps/viewer/src/lib/geo/cesium-sun.ts
+++ b/apps/viewer/src/lib/geo/cesium-sun.ts
@@ -132,7 +132,16 @@ export class SunPathDome {
     // nothing and the dome would stay invisible until the next camera move.
     viewer.dataSources
       .add(this.dataSource)
-      .then(() => viewer.scene.requestRender())
+      .then(() => {
+        viewer.scene.requestRender();
+        console.log('[SunPathDome] built', {
+          lat: options.origin.latitude,
+          lon: options.origin.longitude,
+          height: options.origin.height,
+          radius: options.radius,
+          entities: this.dataSource.entities.values.length,
+        });
+      })
       .catch((err) => console.warn('[SunPathDome] failed to add data source:', err));
   }
 

--- a/apps/viewer/src/lib/geo/cesium-sun.ts
+++ b/apps/viewer/src/lib/geo/cesium-sun.ts
@@ -111,6 +111,7 @@ export class SunPathDome {
   private sunMarker: InstanceType<typeof import('cesium').Entity> | null = null;
   private sunBeam: InstanceType<typeof import('cesium').Entity> | null = null;
 
+  /** Build the dome's data source + static geometry and add it to the viewer. */
   constructor(Cesium: CesiumNs, viewer: CesiumViewer, options: SunPathDomeOptions) {
     this.Cesium = Cesium;
     this.viewer = viewer;
@@ -139,6 +140,7 @@ export class SunPathDome {
     );
   }
 
+  /** Add a polyline entity from a list of ENU directions at the dome radius. */
   private polyline(
     dirs: Enu[],
     rgb: readonly [number, number, number],
@@ -158,7 +160,7 @@ export class SunPathDome {
 
   /** Build the date-independent geometry: graticule, cardinals, analemmas, day arc. */
   private buildStatic(): void {
-    const { origin, radius, date } = this.options;
+    const { origin, date } = this.options;
 
     // Graticule — altitude rings + azimuth spokes.
     const grat = domeGraticule({ altitudeStep: 15, azimuthStep: 30 });
@@ -197,8 +199,6 @@ export class SunPathDome {
     // Day arc for the studied date.
     const arc = dayPath(date, origin.latitude, origin.longitude, { stepMinutes: 10 });
     this.polyline(arc.map((s) => s.dir), DAY_ARC_COLOR, 2);
-
-    void radius;
   }
 
   /** Reposition the live sun marker + beam for a new instant. */
@@ -244,6 +244,7 @@ export class SunPathDome {
     this.viewer.scene.requestRender();
   }
 
+  /** Remove every dome entity and detach the data source from the viewer. */
   destroy(): void {
     this.dataSource.entities.removeAll();
     void this.viewer.dataSources.remove(this.dataSource, true);

--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -37,6 +37,7 @@ import { createClashSlice, type ClashSlice } from './slices/clashSlice.js';
 import { createScriptSlice, type ScriptSlice } from './slices/scriptSlice.js';
 import { createChatSlice, type ChatSlice } from './slices/chatSlice.js';
 import { createCesiumSlice, type CesiumSlice } from './slices/cesiumSlice.js';
+import { createSolarSlice, type SolarSlice } from './slices/solarSlice.js';
 import { createDesktopEntitlementSlice, type DesktopEntitlementSlice } from './slices/desktopEntitlementSlice.js';
 import { createScheduleSlice, type ScheduleSlice } from './slices/scheduleSlice.js';
 import { createPlaybackSlice, type PlaybackSlice } from './slices/playbackSlice.js';
@@ -134,6 +135,7 @@ export type ViewerState = LoadingSlice &
   ScriptSlice &
   ChatSlice &
   CesiumSlice &
+  SolarSlice &
   DesktopEntitlementSlice &
   ScheduleSlice &
   PlaybackSlice &
@@ -185,6 +187,7 @@ const createViewerStore = () => create<ViewerState>()((...args) => ({
   ...createScriptSlice(...args),
   ...createChatSlice(...args),
   ...createCesiumSlice(...args),
+  ...createSolarSlice(...args),
   ...createDesktopEntitlementSlice(...args),
   ...createScheduleSlice(...args),
   ...createPlaybackSlice(...args),

--- a/apps/viewer/src/store/slices/cesiumSlice.ts
+++ b/apps/viewer/src/store/slices/cesiumSlice.ts
@@ -19,7 +19,7 @@ import type { MapConversion } from '@ifc-lite/parser';
 
 import { clearTerrainElevationCache } from '@/lib/geo/terrain-elevation';
 
-export type CesiumDataSource = 'google-photorealistic';
+export type CesiumDataSource = 'google-photorealistic' | 'osm-buildings';
 
 export interface CesiumPlacementDraft {
   eastings: number;
@@ -126,8 +126,8 @@ function saveToStorage(key: string, value: string): void {
 }
 
 function loadDataSource(): CesiumDataSource {
-  // Only Google Photorealistic is supported; upgrade any stale stored value.
-  return 'google-photorealistic';
+  const stored = loadFromStorage(STORAGE_KEY_DATA_SOURCE, 'google-photorealistic');
+  return stored === 'osm-buildings' ? 'osm-buildings' : 'google-photorealistic';
 }
 
 /** Resolve the Cesium ion token: user override > build-time default */

--- a/apps/viewer/src/store/slices/solarSlice.ts
+++ b/apps/viewer/src/store/slices/solarSlice.ts
@@ -85,7 +85,9 @@ export const createSolarSlice: StateCreator<SolarSlice, [], [], SolarSlice> = (s
   solarShowSunPath: true,
   solarShowShadows: true,
   solarSunInfo: null,
-  solarUseLocalTime: false,
+  // Default to the site's local solar time (derived from longitude): for a
+  // sun-path study "9am" should mean 9am at the site, not UTC.
+  solarUseLocalTime: true,
   solarPlaying: false,
   solarSweepMode: 'day',
 

--- a/apps/viewer/src/store/slices/solarSlice.ts
+++ b/apps/viewer/src/store/slices/solarSlice.ts
@@ -1,0 +1,79 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Solar study state slice — drives the georeferenced 3D sun-path dome and
+ * shadow study rendered in the Cesium context overlay.
+ *
+ * The slice itself only owns *intent* (which instant to study, what to show).
+ * The heavy lifting — computing the sun direction, enabling Cesium's sun /
+ * shadows, and building the dome geometry — happens in CesiumOverlay, which
+ * reads this state and writes the resolved {@link SolarSunInfo} back here for
+ * the readout panel.
+ *
+ * Solar study requires Cesium (it renders the model + OSM context with mutual
+ * shadows), so the UI turns Cesium on when the study is enabled.
+ */
+
+import type { StateCreator } from 'zustand';
+
+/** Resolved solar readout for the currently studied instant + site. */
+export interface SolarSunInfo {
+  /** Site latitude in degrees (north positive), from the model georeference. */
+  latitude: number;
+  /** Site longitude in degrees (east positive). */
+  longitude: number;
+  /** Sun azimuth in degrees clockwise from true north. */
+  azimuth: number;
+  /** Sun altitude in degrees above the horizon (negative below). */
+  altitude: number;
+  /** Sunrise epoch ms, or null (polar night / midnight sun). */
+  sunriseMs: number | null;
+  /** Sunset epoch ms, or null. */
+  sunsetMs: number | null;
+  /** Solar-noon epoch ms. */
+  solarNoonMs: number;
+}
+
+export interface SolarSlice {
+  /** Whether the sun-path / shadow study is active. */
+  solarEnabled: boolean;
+  /** Studied instant as epoch milliseconds (UTC). */
+  solarDateMs: number;
+  /** Draw the 3D sun-path dome (analemmas, day arc, graticule). */
+  solarShowSunPath: boolean;
+  /** Render real cast shadows (model ↔ OSM context) via Cesium. */
+  solarShowShadows: boolean;
+  /** Resolved sun position/times for the readout panel; null until computed. */
+  solarSunInfo: SolarSunInfo | null;
+
+  setSolarEnabled: (enabled: boolean) => void;
+  toggleSolar: () => void;
+  setSolarDateMs: (ms: number) => void;
+  setSolarShowSunPath: (show: boolean) => void;
+  setSolarShowShadows: (show: boolean) => void;
+  setSolarSunInfo: (info: SolarSunInfo | null) => void;
+}
+
+/** Default studied instant: a bright equinox midday so the dome reads well. */
+function defaultSolarDateMs(): number {
+  return Date.UTC(new Date().getUTCFullYear(), 2, 20, 12, 0, 0);
+}
+
+export const createSolarSlice: StateCreator<SolarSlice, [], [], SolarSlice> = (set) => ({
+  solarEnabled: false,
+  solarDateMs: defaultSolarDateMs(),
+  solarShowSunPath: true,
+  solarShowShadows: true,
+  solarSunInfo: null,
+
+  setSolarEnabled: (enabled) =>
+    set(enabled ? { solarEnabled: true } : { solarEnabled: false, solarSunInfo: null }),
+  toggleSolar: () =>
+    set((s) => (s.solarEnabled ? { solarEnabled: false, solarSunInfo: null } : { solarEnabled: true })),
+  setSolarDateMs: (ms) => set({ solarDateMs: ms }),
+  setSolarShowSunPath: (show) => set({ solarShowSunPath: show }),
+  setSolarShowShadows: (show) => set({ solarShowShadows: show }),
+  setSolarSunInfo: (info) => set({ solarSunInfo: info }),
+});

--- a/apps/viewer/src/store/slices/solarSlice.ts
+++ b/apps/viewer/src/store/slices/solarSlice.ts
@@ -36,6 +36,9 @@ export interface SolarSunInfo {
   solarNoonMs: number;
 }
 
+/** Which dimension the animation sweep advances. */
+export type SolarSweepMode = 'day' | 'year';
+
 export interface SolarSlice {
   /** Whether the sun-path / shadow study is active. */
   solarEnabled: boolean;
@@ -47,6 +50,17 @@ export interface SolarSlice {
   solarShowShadows: boolean;
   /** Resolved sun position/times for the readout panel; null until computed. */
   solarSunInfo: SolarSunInfo | null;
+  /**
+   * Display times in local solar time derived from the site longitude
+   * (15°/hour) instead of UTC. This is civil-timezone-agnostic on purpose —
+   * sun-path studies care about solar time, and a longitude offset needs no
+   * timezone database or DST rules.
+   */
+  solarUseLocalTime: boolean;
+  /** Whether the animation sweep is playing. */
+  solarPlaying: boolean;
+  /** Which dimension the sweep advances (time-of-day vs day-of-year). */
+  solarSweepMode: SolarSweepMode;
 
   setSolarEnabled: (enabled: boolean) => void;
   toggleSolar: () => void;
@@ -54,6 +68,10 @@ export interface SolarSlice {
   setSolarShowSunPath: (show: boolean) => void;
   setSolarShowShadows: (show: boolean) => void;
   setSolarSunInfo: (info: SolarSunInfo | null) => void;
+  setSolarUseLocalTime: (use: boolean) => void;
+  setSolarPlaying: (playing: boolean) => void;
+  toggleSolarPlaying: () => void;
+  setSolarSweepMode: (mode: SolarSweepMode) => void;
 }
 
 /** Default studied instant: a bright equinox midday so the dome reads well. */
@@ -67,13 +85,24 @@ export const createSolarSlice: StateCreator<SolarSlice, [], [], SolarSlice> = (s
   solarShowSunPath: true,
   solarShowShadows: true,
   solarSunInfo: null,
+  solarUseLocalTime: false,
+  solarPlaying: false,
+  solarSweepMode: 'day',
 
   setSolarEnabled: (enabled) =>
-    set(enabled ? { solarEnabled: true } : { solarEnabled: false, solarSunInfo: null }),
+    set(enabled
+      ? { solarEnabled: true }
+      : { solarEnabled: false, solarSunInfo: null, solarPlaying: false }),
   toggleSolar: () =>
-    set((s) => (s.solarEnabled ? { solarEnabled: false, solarSunInfo: null } : { solarEnabled: true })),
+    set((s) => (s.solarEnabled
+      ? { solarEnabled: false, solarSunInfo: null, solarPlaying: false }
+      : { solarEnabled: true })),
   setSolarDateMs: (ms) => set({ solarDateMs: ms }),
   setSolarShowSunPath: (show) => set({ solarShowSunPath: show }),
   setSolarShowShadows: (show) => set({ solarShowShadows: show }),
   setSolarSunInfo: (info) => set({ solarSunInfo: info }),
+  setSolarUseLocalTime: (use) => set({ solarUseLocalTime: use }),
+  setSolarPlaying: (playing) => set({ solarPlaying: playing }),
+  toggleSolarPlaying: () => set((s) => ({ solarPlaying: !s.solarPlaying })),
+  setSolarSweepMode: (mode) => set({ solarSweepMode: mode }),
 });

--- a/packages/solar/README.md
+++ b/packages/solar/README.md
@@ -1,0 +1,47 @@
+# @ifc-lite/solar
+
+Solar position, sunrise/sunset and 3D sun-path geometry for IFC-Lite.
+
+Pure, dependency-free math. Given a site latitude/longitude and an instant it
+computes where the sun is, and generates the sampled curves that make up a 3D
+**sun-path dome** — the day arc, the hourly analemmas, and the static
+graticule (altitude rings, azimuth spokes, compass labels).
+
+Outputs are renderer-agnostic: plain angles plus **ENU unit vectors**
+(east / north / up), matching the IFC + Cesium georeferencing convention used
+by the viewer, so a renderer only multiplies by a dome radius and adds the
+site origin.
+
+## Usage
+
+```ts
+import { sunPosition, sunTimes, dayPath, analemmaPaths, domeGraticule } from '@ifc-lite/solar';
+
+// Where is the sun right now at this site?
+const { azimuth, altitude } = sunPosition(new Date(), 51.4769, -0.0005);
+
+// Sunrise / sunset / solar noon for the day.
+const { sunrise, sunset, solarNoon } = sunTimes(new Date(), 51.4769, -0.0005);
+
+// Geometry for a 3D dome.
+const arc        = dayPath(new Date(), 51.4769, -0.0005);   // today's path
+const analemmas  = analemmaPaths(2024, 51.4769, -0.0005);   // hourly figure-eights
+const graticule  = domeGraticule();                          // rings + spokes + N/E/S/W
+```
+
+## Accuracy
+
+Uses the NOAA Solar Calculation algorithm (a truncated Meeus/VSOP model),
+accurate to within ~0.01° of azimuth/altitude for 1900–2100 — well beyond what
+architectural shadow / right-to-light studies require.
+
+## Conventions
+
+- **Azimuth**: degrees clockwise from true north (N = 0°, E = 90°, S = 180°, W = 270°).
+- **Altitude**: degrees above the horizon (negative below).
+- **Time**: a JavaScript `Date`, interpreted as the absolute UTC instant
+  (`getTime()`), so callers never reason about the host timezone.
+
+## License
+
+MPL-2.0

--- a/packages/solar/package.json
+++ b/packages/solar/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@ifc-lite/solar",
+  "version": "1.14.6",
+  "description": "Solar position, sunrise/sunset and 3D sun-path geometry for IFC-Lite",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "pnpm exec tsc",
+    "dev": "pnpm exec tsc --watch",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3",
+    "vitest": "^1.6.0"
+  },
+  "license": "MPL-2.0",
+  "author": "Louis True",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LTplus-AG/ifc-lite.git",
+    "directory": "packages/solar"
+  },
+  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
+  "keywords": [
+    "ifc",
+    "bim",
+    "solar",
+    "sun-path",
+    "shadow",
+    "aec"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ]
+}

--- a/packages/solar/src/index.ts
+++ b/packages/solar/src/index.ts
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * @ifc-lite/solar — solar position, sunrise/sunset and 3D sun-path geometry.
+ *
+ * Pure, dependency-free math: given a site latitude/longitude and an instant,
+ * compute where the sun is, and generate the sampled curves for a 3D
+ * sun-path dome (day paths, hourly analemmas, graticule). Renderer-agnostic —
+ * outputs are plain angles and ENU unit vectors.
+ */
+
+export {
+  sunPosition,
+  sunPositionFromGeometry,
+  solarGeometry,
+  toJulianDay,
+  type SunPosition,
+} from './solar-position.js';
+
+export { sunTimes, type SunTimes } from './sun-times.js';
+
+export {
+  azimuthAltitudeToEnu,
+  dayPath,
+  analemmaPaths,
+  domeGraticule,
+  type Enu,
+  type SunSample,
+  type DayPathOptions,
+  type AnalemmaPath,
+  type AnalemmaOptions,
+  type Graticule,
+  type GraticuleOptions,
+} from './sun-path.js';

--- a/packages/solar/src/solar-position.test.ts
+++ b/packages/solar/src/solar-position.test.ts
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { sunPosition, solarGeometry } from './solar-position.js';
+import { sunTimes } from './sun-times.js';
+
+// London, on the prime meridian — keeps longitude ≈ 0 so UTC ≈ solar time.
+const LAT = 51.4769;
+const LON = 0;
+
+describe('solarGeometry', () => {
+  it('declination is ~0 at the spring equinox', () => {
+    const { declination } = solarGeometry(new Date('2024-03-20T12:00:00Z'));
+    expect(Math.abs(declination)).toBeLessThan(1);
+  });
+
+  it('declination is ~+23.4 at the summer solstice', () => {
+    const { declination } = solarGeometry(new Date('2024-06-20T12:00:00Z'));
+    expect(declination).toBeGreaterThan(23);
+    expect(declination).toBeLessThan(23.5);
+  });
+
+  it('declination is ~-23.4 at the winter solstice', () => {
+    const { declination } = solarGeometry(new Date('2024-12-21T12:00:00Z'));
+    expect(declination).toBeLessThan(-23);
+    expect(declination).toBeGreaterThan(-23.5);
+  });
+});
+
+describe('sunPosition', () => {
+  it('points due south at altitude ≈ (90 − lat) at solar noon on the equinox', () => {
+    const noon = sunTimes(new Date('2024-03-20T12:00:00Z'), LAT, LON).solarNoon;
+    const { azimuth, altitude } = sunPosition(noon, LAT, LON);
+    expect(altitude).toBeCloseTo(90 - LAT, 0); // within ~1°
+    expect(azimuth).toBeCloseTo(180, 0);
+  });
+
+  it('climbs higher at the summer solstice than the winter solstice', () => {
+    const summerNoon = sunTimes(new Date('2024-06-20T12:00:00Z'), LAT, LON).solarNoon;
+    const winterNoon = sunTimes(new Date('2024-12-21T12:00:00Z'), LAT, LON).solarNoon;
+    const summerAlt = sunPosition(summerNoon, LAT, LON).altitude;
+    const winterAlt = sunPosition(winterNoon, LAT, LON).altitude;
+    expect(summerAlt).toBeGreaterThan(winterAlt + 40);
+    expect(summerAlt).toBeCloseTo(90 - LAT + 23.44, 0);
+    expect(winterAlt).toBeCloseTo(90 - LAT - 23.44, 0);
+  });
+
+  it('rises in the east and sets in the west', () => {
+    const day = '2024-06-20';
+    const morning = sunPosition(new Date(`${day}T06:00:00Z`), LAT, LON);
+    const evening = sunPosition(new Date(`${day}T19:00:00Z`), LAT, LON);
+    // Morning azimuth in the eastern half (0–180), evening in the western half.
+    expect(morning.azimuth).toBeGreaterThan(0);
+    expect(morning.azimuth).toBeLessThan(180);
+    expect(evening.azimuth).toBeGreaterThan(180);
+    expect(evening.azimuth).toBeLessThan(360);
+  });
+
+  it('is below the horizon at local midnight', () => {
+    const midnight = sunPosition(new Date('2024-06-20T00:00:00Z'), LAT, LON);
+    expect(midnight.altitude).toBeLessThan(0);
+  });
+});
+
+describe('sunTimes', () => {
+  it('gives ~12h of daylight at the equinox', () => {
+    const t = sunTimes(new Date('2024-03-20T12:00:00Z'), LAT, LON);
+    expect(t.sunrise).not.toBeNull();
+    expect(t.sunset).not.toBeNull();
+    const hours = (t.sunset!.getTime() - t.sunrise!.getTime()) / 3_600_000;
+    expect(hours).toBeCloseTo(12, 0);
+  });
+
+  it('gives a long day at the summer solstice', () => {
+    const t = sunTimes(new Date('2024-06-20T12:00:00Z'), LAT, LON);
+    const hours = (t.sunset!.getTime() - t.sunrise!.getTime()) / 3_600_000;
+    expect(hours).toBeGreaterThan(16);
+  });
+
+  it('detects polar night above the Arctic Circle in winter', () => {
+    const t = sunTimes(new Date('2024-12-21T12:00:00Z'), 78, 15);
+    expect(t.alwaysDown).toBe(true);
+    expect(t.sunrise).toBeNull();
+  });
+
+  it('detects the midnight sun above the Arctic Circle in summer', () => {
+    const t = sunTimes(new Date('2024-06-20T12:00:00Z'), 78, 15);
+    expect(t.alwaysUp).toBe(true);
+    expect(t.sunset).toBeNull();
+  });
+
+  it('places sunrise before solar noon before sunset', () => {
+    const t = sunTimes(new Date('2024-09-15T12:00:00Z'), LAT, LON);
+    expect(t.sunrise!.getTime()).toBeLessThan(t.solarNoon.getTime());
+    expect(t.solarNoon.getTime()).toBeLessThan(t.sunset!.getTime());
+  });
+});

--- a/packages/solar/src/solar-position.test.ts
+++ b/packages/solar/src/solar-position.test.ts
@@ -62,6 +62,20 @@ describe('sunPosition', () => {
     const midnight = sunPosition(new Date('2024-06-20T00:00:00Z'), LAT, LON);
     expect(midnight.altitude).toBeLessThan(0);
   });
+
+  it('returns finite azimuth/altitude exactly at the poles', () => {
+    // cos(latitude) = 0 at ±90°; the acos azimuth form would divide by zero.
+    for (const lat of [90, -90]) {
+      const p = sunPosition(new Date('2024-06-20T12:00:00Z'), lat, 0);
+      expect(Number.isFinite(p.azimuth)).toBe(true);
+      expect(Number.isFinite(p.altitude)).toBe(true);
+      expect(p.azimuth).toBeGreaterThanOrEqual(0);
+      expect(p.azimuth).toBeLessThan(360);
+    }
+    // North Pole in summer: sun above the horizon at roughly +declination.
+    const np = sunPosition(new Date('2024-06-20T12:00:00Z'), 90, 0);
+    expect(np.altitude).toBeGreaterThan(0);
+  });
 });
 
 describe('sunTimes', () => {
@@ -95,5 +109,20 @@ describe('sunTimes', () => {
     const t = sunTimes(new Date('2024-09-15T12:00:00Z'), LAT, LON);
     expect(t.sunrise!.getTime()).toBeLessThan(t.solarNoon.getTime());
     expect(t.solarNoon.getTime()).toBeLessThan(t.sunset!.getTime());
+  });
+
+  it('handles exact poles without producing Invalid Date', () => {
+    // North Pole, summer → midnight sun; winter → polar night. No NaN/Invalid.
+    const npSummer = sunTimes(new Date('2024-06-20T12:00:00Z'), 90, 0);
+    expect(npSummer.alwaysUp).toBe(true);
+    expect(npSummer.sunrise).toBeNull();
+    expect(Number.isFinite(npSummer.solarNoon.getTime())).toBe(true);
+
+    const npWinter = sunTimes(new Date('2024-12-21T12:00:00Z'), 90, 0);
+    expect(npWinter.alwaysDown).toBe(true);
+
+    // South Pole mirrors the North Pole.
+    const spSummer = sunTimes(new Date('2024-12-21T12:00:00Z'), -90, 0);
+    expect(spSummer.alwaysUp).toBe(true);
   });
 });

--- a/packages/solar/src/solar-position.ts
+++ b/packages/solar/src/solar-position.ts
@@ -40,7 +40,7 @@ export function toJulianDay(date: Date): number {
   return date.getTime() / 86_400_000 + 2_440_587.5;
 }
 
-/** Julian centuries since J2000.0. */
+/** Julian centuries elapsed since the J2000.0 epoch (2000-01-01 12:00 TT). */
 function julianCentury(jd: number): number {
   return (jd - 2_451_545.0) / 36_525;
 }
@@ -138,30 +138,27 @@ export function sunPositionFromGeometry(
   const zenith = Math.acos(clamp(cosZenith, -1, 1));
   const altitude = 90 - zenith * RAD;
 
-  // Azimuth measured clockwise from north.
-  let azimuth: number;
-  const sinZenith = Math.sin(zenith);
-  if (Math.abs(sinZenith) < 1e-9) {
-    // Sun directly overhead/underfoot — azimuth is undefined; pick north.
-    azimuth = 0;
-  } else {
-    const cosAz = clamp(
-      (Math.sin(latRad) * Math.cos(zenith) - Math.sin(decRad)) /
-        (Math.cos(latRad) * sinZenith),
-      -1,
-      1,
-    );
-    const az = Math.acos(cosAz) * RAD;
-    azimuth = hourAngle > 0 ? mod360(az + 180) : mod360(540 - az);
-  }
+  // Azimuth measured clockwise from north, derived from the horizontal ENU
+  // components of the solar vector. atan2 keeps the quadrant correct and stays
+  // finite at the poles, where the acos form divides by cos(latitude) = 0.
+  const east = -Math.cos(decRad) * Math.sin(haRad);
+  const north =
+    Math.cos(latRad) * Math.sin(decRad) -
+    Math.sin(latRad) * Math.cos(decRad) * Math.cos(haRad);
+  const azimuth =
+    Math.abs(east) < 1e-9 && Math.abs(north) < 1e-9
+      ? 0 // Sun directly overhead/underfoot — azimuth is undefined; pick north.
+      : mod360(Math.atan2(east, north) * RAD);
 
   return { azimuth, altitude, declination, equationOfTime };
 }
 
+/** Normalise an angle in degrees to the [0, 360) range. */
 function mod360(v: number): number {
   return ((v % 360) + 360) % 360;
 }
 
+/** Clamp a value to the inclusive [lo, hi] range (guards acos domain errors). */
 function clamp(v: number, lo: number, hi: number): number {
   return v < lo ? lo : v > hi ? hi : v;
 }

--- a/packages/solar/src/solar-position.ts
+++ b/packages/solar/src/solar-position.ts
@@ -1,0 +1,167 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Solar position from the NOAA Solar Calculation algorithm.
+ *
+ * This is the same set of equations used by the NOAA Global Monitoring
+ * Laboratory's online calculator (a truncated VSOP/Meeus model). It is
+ * accurate to within ~0.01° of azimuth/altitude for years 1900–2100, which
+ * is far more than enough for architectural shadow / right-to-light studies.
+ *
+ * All angles are degrees in the public API. Azimuth is measured clockwise
+ * from true north (N=0°, E=90°, S=180°, W=270°) to match compass / IFC
+ * grid-north conventions. Altitude is degrees above the horizon (negative
+ * when the sun is below the horizon).
+ *
+ * Time is always a JavaScript `Date` interpreted in UTC (`Date.getTime()`),
+ * so the caller never has to reason about the host machine's timezone — pass
+ * the absolute instant and the site longitude and the math is exact.
+ */
+
+const DEG = Math.PI / 180;
+const RAD = 180 / Math.PI;
+
+/** The Sun's apparent position in the local horizontal (topocentric) frame. */
+export interface SunPosition {
+  /** Degrees clockwise from true north (0–360). */
+  azimuth: number;
+  /** Degrees above the horizon (negative below). */
+  altitude: number;
+  /** Solar declination in degrees (for sun-path construction / debugging). */
+  declination: number;
+  /** Equation of time in minutes (apparent − mean solar time). */
+  equationOfTime: number;
+}
+
+/** Julian Day Number for a UTC instant. */
+export function toJulianDay(date: Date): number {
+  return date.getTime() / 86_400_000 + 2_440_587.5;
+}
+
+/** Julian centuries since J2000.0. */
+function julianCentury(jd: number): number {
+  return (jd - 2_451_545.0) / 36_525;
+}
+
+interface SolarGeometry {
+  declination: number; // degrees
+  equationOfTime: number; // minutes
+}
+
+/**
+ * Date-only solar geometry (declination + equation of time). These vary
+ * slowly over a day, so sun-path samplers can compute them once per day and
+ * reuse them across many hour-angle evaluations.
+ */
+export function solarGeometry(date: Date): SolarGeometry {
+  const t = julianCentury(toJulianDay(date));
+
+  const meanLong = mod360(280.46646 + t * (36_000.76983 + t * 0.0003032));
+  const meanAnom = 357.52911 + t * (35_999.05029 - 0.0001537 * t);
+  const eccent = 0.016708634 - t * (0.000042037 + 0.0000001267 * t);
+
+  const center =
+    Math.sin(meanAnom * DEG) * (1.914602 - t * (0.004817 + 0.000014 * t)) +
+    Math.sin(2 * meanAnom * DEG) * (0.019993 - 0.000101 * t) +
+    Math.sin(3 * meanAnom * DEG) * 0.000289;
+
+  const trueLong = meanLong + center;
+  const appLong = trueLong - 0.00569 - 0.00478 * Math.sin((125.04 - 1934.136 * t) * DEG);
+
+  const meanObliquity =
+    23 + (26 + (21.448 - t * (46.815 + t * (0.00059 - t * 0.001813))) / 60) / 60;
+  const obliquity = meanObliquity + 0.00256 * Math.cos((125.04 - 1934.136 * t) * DEG);
+
+  const declination =
+    Math.asin(Math.sin(obliquity * DEG) * Math.sin(appLong * DEG)) * RAD;
+
+  const y = Math.tan((obliquity / 2) * DEG) ** 2;
+  const equationOfTime =
+    4 *
+    RAD *
+    (y * Math.sin(2 * meanLong * DEG) -
+      2 * eccent * Math.sin(meanAnom * DEG) +
+      4 * eccent * y * Math.sin(meanAnom * DEG) * Math.cos(2 * meanLong * DEG) -
+      0.5 * y * y * Math.sin(4 * meanLong * DEG) -
+      1.25 * eccent * eccent * Math.sin(2 * meanAnom * DEG));
+
+  return { declination, equationOfTime };
+}
+
+/**
+ * Local horizontal position of the Sun at an absolute instant for a site.
+ *
+ * @param date      Absolute instant (interpreted as UTC via getTime()).
+ * @param latitude  Site latitude in degrees (north positive).
+ * @param longitude Site longitude in degrees (east positive).
+ */
+export function sunPosition(date: Date, latitude: number, longitude: number): SunPosition {
+  const { declination, equationOfTime } = solarGeometry(date);
+  return sunPositionFromGeometry(date, latitude, longitude, declination, equationOfTime);
+}
+
+/**
+ * Sun position when the (date-only) solar geometry is already known. Lets
+ * tight loops over a single day avoid recomputing the slow VSOP terms.
+ */
+export function sunPositionFromGeometry(
+  date: Date,
+  latitude: number,
+  longitude: number,
+  declination: number,
+  equationOfTime: number,
+): SunPosition {
+  // Minutes since UTC midnight of the given instant.
+  const utcMinutes =
+    date.getUTCHours() * 60 +
+    date.getUTCMinutes() +
+    date.getUTCSeconds() / 60 +
+    date.getUTCMilliseconds() / 60_000;
+
+  // True solar time in minutes (longitude shifts the local meridian; 4 min/°).
+  let trueSolarMinutes = utcMinutes + equationOfTime + 4 * longitude;
+  trueSolarMinutes = ((trueSolarMinutes % 1440) + 1440) % 1440;
+
+  // Hour angle: 0° at solar noon, negative in the morning, positive afternoon.
+  let hourAngle = trueSolarMinutes / 4 - 180;
+  if (hourAngle < -180) hourAngle += 360;
+
+  const latRad = latitude * DEG;
+  const decRad = declination * DEG;
+  const haRad = hourAngle * DEG;
+
+  const cosZenith =
+    Math.sin(latRad) * Math.sin(decRad) +
+    Math.cos(latRad) * Math.cos(decRad) * Math.cos(haRad);
+  const zenith = Math.acos(clamp(cosZenith, -1, 1));
+  const altitude = 90 - zenith * RAD;
+
+  // Azimuth measured clockwise from north.
+  let azimuth: number;
+  const sinZenith = Math.sin(zenith);
+  if (Math.abs(sinZenith) < 1e-9) {
+    // Sun directly overhead/underfoot — azimuth is undefined; pick north.
+    azimuth = 0;
+  } else {
+    const cosAz = clamp(
+      (Math.sin(latRad) * Math.cos(zenith) - Math.sin(decRad)) /
+        (Math.cos(latRad) * sinZenith),
+      -1,
+      1,
+    );
+    const az = Math.acos(cosAz) * RAD;
+    azimuth = hourAngle > 0 ? mod360(az + 180) : mod360(540 - az);
+  }
+
+  return { azimuth, altitude, declination, equationOfTime };
+}
+
+function mod360(v: number): number {
+  return ((v % 360) + 360) % 360;
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return v < lo ? lo : v > hi ? hi : v;
+}

--- a/packages/solar/src/sun-path.test.ts
+++ b/packages/solar/src/sun-path.test.ts
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import {
+  azimuthAltitudeToEnu,
+  dayPath,
+  analemmaPaths,
+  domeGraticule,
+} from './sun-path.js';
+
+const LAT = 51.4769;
+const LON = 0;
+
+describe('azimuthAltitudeToEnu', () => {
+  it('maps north/east/up correctly', () => {
+    const north = azimuthAltitudeToEnu(0, 0);
+    expect(north.n).toBeCloseTo(1, 6);
+    expect(north.e).toBeCloseTo(0, 6);
+
+    const east = azimuthAltitudeToEnu(90, 0);
+    expect(east.e).toBeCloseTo(1, 6);
+    expect(east.n).toBeCloseTo(0, 6);
+
+    const zenith = azimuthAltitudeToEnu(0, 90);
+    expect(zenith.u).toBeCloseTo(1, 6);
+  });
+
+  it('returns unit-length vectors', () => {
+    for (const [az, alt] of [[37, 12], [200, 55], [310, 80]] as const) {
+      const v = azimuthAltitudeToEnu(az, alt);
+      const len = Math.hypot(v.e, v.n, v.u);
+      expect(len).toBeCloseTo(1, 6);
+    }
+  });
+});
+
+describe('dayPath', () => {
+  it('returns an above-horizon arc ordered through the day', () => {
+    const arc = dayPath(new Date('2024-06-20T12:00:00Z'), LAT, LON, { stepMinutes: 15 });
+    expect(arc.length).toBeGreaterThan(10);
+    expect(arc.every((s) => s.aboveHorizon && s.dir.u >= 0)).toBe(true);
+    for (let i = 1; i < arc.length; i++) {
+      expect(arc[i].time.getTime()).toBeGreaterThan(arc[i - 1].time.getTime());
+    }
+  });
+
+  it('can include below-horizon samples when asked', () => {
+    const all = dayPath(new Date('2024-06-20T12:00:00Z'), LAT, LON, {
+      stepMinutes: 30,
+      aboveHorizonOnly: false,
+    });
+    expect(all.some((s) => !s.aboveHorizon)).toBe(true);
+    expect(all.some((s) => s.aboveHorizon)).toBe(true);
+  });
+
+  it('traces a longer summer arc than a winter arc', () => {
+    const summer = dayPath(new Date('2024-06-20T12:00:00Z'), LAT, LON, { stepMinutes: 10 });
+    const winter = dayPath(new Date('2024-12-21T12:00:00Z'), LAT, LON, { stepMinutes: 10 });
+    expect(summer.length).toBeGreaterThan(winter.length);
+  });
+});
+
+describe('analemmaPaths', () => {
+  it('produces hour curves that all reach above the horizon', () => {
+    const paths = analemmaPaths(2024, LAT, LON, { dayStep: 10 });
+    expect(paths.length).toBeGreaterThan(0);
+    for (const p of paths) {
+      expect(p.samples.some((s) => s.aboveHorizon)).toBe(true);
+      expect(p.hour).toBeGreaterThanOrEqual(0);
+      expect(p.hour).toBeLessThan(24);
+    }
+  });
+
+  it('includes a midday analemma but not a deep-night one in the UK', () => {
+    const hours = analemmaPaths(2024, LAT, LON, { dayStep: 10 }).map((p) => p.hour);
+    expect(hours).toContain(12);
+    expect(hours).not.toContain(1);
+  });
+});
+
+describe('domeGraticule', () => {
+  it('includes the horizon ring and eight cardinal labels', () => {
+    const g = domeGraticule();
+    expect(g.altitudeRings[0].altitude).toBe(0);
+    expect(g.cardinals).toHaveLength(8);
+    const north = g.cardinals.find((c) => c.label === 'N')!;
+    expect(north.dir.n).toBeCloseTo(1, 6);
+  });
+
+  it('builds altitude rings and azimuth spokes at the requested spacing', () => {
+    const g = domeGraticule({ altitudeStep: 30, azimuthStep: 90 });
+    // Horizon (0) + 30 + 60 = 3 rings.
+    expect(g.altitudeRings.map((r) => r.altitude)).toEqual([0, 30, 60]);
+    // 0,90,180,270 → 4 spokes.
+    expect(g.azimuthSpokes).toHaveLength(4);
+  });
+});

--- a/packages/solar/src/sun-path.ts
+++ b/packages/solar/src/sun-path.ts
@@ -54,6 +54,7 @@ export function azimuthAltitudeToEnu(azimuthDeg: number, altitudeDeg: number): E
   };
 }
 
+/** Build a {@link SunSample} (position + dome direction) for one instant. */
 function sampleAt(date: Date, lat: number, lon: number, decl: number, eot: number): SunSample {
   const pos = sunPositionFromGeometry(date, lat, lon, decl, eot);
   return {
@@ -202,6 +203,7 @@ export function domeGraticule(options: GraticuleOptions = {}): Graticule {
   return { altitudeRings, azimuthSpokes, cardinals };
 }
 
+/** True if `year` is a Gregorian leap year (366 days). */
 function isLeap(year: number): boolean {
   return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
 }

--- a/packages/solar/src/sun-path.ts
+++ b/packages/solar/src/sun-path.ts
@@ -1,0 +1,207 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Sun-path geometry — the sampled curves that make up a 3D sun-path dome:
+ *
+ *   • day paths   — the arc the sun traces across a single day
+ *   • analemmas   — the figure-of-eight a fixed clock-hour traces over a year
+ *   • graticule   — the static altitude rings + azimuth spokes + cardinals
+ *
+ * Everything is returned as unit direction vectors in a local ENU frame
+ * (east, north, up), so a renderer only has to multiply by a dome radius and
+ * add the site origin. The frame matches the IFC/Cesium convention used by
+ * the viewer's georeferencing bridge (north = grid/true north, up = +Z).
+ */
+
+import {
+  solarGeometry,
+  sunPositionFromGeometry,
+  type SunPosition,
+} from './solar-position.js';
+
+const DEG = Math.PI / 180;
+
+/** Unit direction in the local east-north-up frame. */
+export interface Enu {
+  e: number;
+  n: number;
+  u: number;
+}
+
+/** A single sampled sun position with its direction on the dome. */
+export interface SunSample extends SunPosition {
+  time: Date;
+  /** Unit direction on the dome (below-horizon samples have u < 0). */
+  dir: Enu;
+  aboveHorizon: boolean;
+}
+
+/**
+ * Convert an azimuth (deg clockwise from north) + altitude (deg above
+ * horizon) into a unit ENU direction. This is the bridge between solar
+ * angles and 3D dome geometry.
+ */
+export function azimuthAltitudeToEnu(azimuthDeg: number, altitudeDeg: number): Enu {
+  const az = azimuthDeg * DEG;
+  const alt = altitudeDeg * DEG;
+  const cosAlt = Math.cos(alt);
+  return {
+    e: Math.sin(az) * cosAlt,
+    n: Math.cos(az) * cosAlt,
+    u: Math.sin(alt),
+  };
+}
+
+function sampleAt(date: Date, lat: number, lon: number, decl: number, eot: number): SunSample {
+  const pos = sunPositionFromGeometry(date, lat, lon, decl, eot);
+  return {
+    ...pos,
+    time: date,
+    dir: azimuthAltitudeToEnu(pos.azimuth, pos.altitude),
+    aboveHorizon: pos.altitude >= 0,
+  };
+}
+
+export interface DayPathOptions {
+  /** Sampling step in minutes (default 10). */
+  stepMinutes?: number;
+  /** When true (default), drop samples below the horizon. */
+  aboveHorizonOnly?: boolean;
+}
+
+/**
+ * Sample the sun's path across the UTC calendar day containing `date`.
+ * Returns an ordered polyline (morning → evening).
+ */
+export function dayPath(
+  date: Date,
+  latitude: number,
+  longitude: number,
+  options: DayPathOptions = {},
+): SunSample[] {
+  const step = options.stepMinutes ?? 10;
+  const aboveOnly = options.aboveHorizonOnly ?? true;
+  // Declination/EoT vary negligibly across a day — compute once at noon.
+  const noon = new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 12, 0, 0),
+  );
+  const { declination, equationOfTime } = solarGeometry(noon);
+
+  const dayStart = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+  const samples: SunSample[] = [];
+  for (let m = 0; m <= 1440; m += step) {
+    const s = sampleAt(new Date(dayStart + m * 60_000), latitude, longitude, declination, equationOfTime);
+    if (aboveOnly && !s.aboveHorizon) continue;
+    samples.push(s);
+  }
+  return samples;
+}
+
+export interface AnalemmaPath {
+  /** Solar clock-hour this analemma is sampled at (0–23, UTC-day local solar). */
+  hour: number;
+  samples: SunSample[];
+}
+
+export interface AnalemmaOptions {
+  /** Day step across the year (default 5 → ~73 points per analemma). */
+  dayStep?: number;
+  /** Only include analemmas with at least one above-horizon sample. */
+  aboveHorizonOnly?: boolean;
+}
+
+/**
+ * Build the figure-of-eight analemma for every whole hour across `year`.
+ * Each analemma fixes the local time-of-day and walks the calendar, which is
+ * what gives the dome its characteristic vertical hour-curves.
+ */
+export function analemmaPaths(
+  year: number,
+  latitude: number,
+  longitude: number,
+  options: AnalemmaOptions = {},
+): AnalemmaPath[] {
+  const dayStep = options.dayStep ?? 5;
+  const aboveOnly = options.aboveHorizonOnly ?? true;
+  // Longitude offset so "hour" means local solar-ish time rather than UTC.
+  const lonHourOffset = longitude / 15;
+
+  const paths: AnalemmaPath[] = [];
+  for (let hour = 0; hour < 24; hour++) {
+    const samples: SunSample[] = [];
+    const start = Date.UTC(year, 0, 1);
+    const daysInYear = isLeap(year) ? 366 : 365;
+    for (let day = 0; day < daysInYear; day += dayStep) {
+      const dayMs = start + day * 86_400_000;
+      const d = new Date(dayMs);
+      const { declination, equationOfTime } = solarGeometry(d);
+      // Local hour → UTC instant for this day.
+      const utcHour = hour - lonHourOffset;
+      const instant = new Date(dayMs + utcHour * 3_600_000);
+      samples.push(sampleAt(instant, latitude, longitude, declination, equationOfTime));
+    }
+    if (aboveOnly && !samples.some((s) => s.aboveHorizon)) continue;
+    paths.push({ hour, samples });
+  }
+  return paths;
+}
+
+export interface Graticule {
+  /** Concentric altitude rings (each a closed loop of ENU directions). */
+  altitudeRings: { altitude: number; ring: Enu[] }[];
+  /** Azimuth spokes from horizon to zenith (each a meridian arc). */
+  azimuthSpokes: { azimuth: number; arc: Enu[] }[];
+  /** Cardinal/ordinal direction markers on the horizon. */
+  cardinals: { label: string; dir: Enu }[];
+}
+
+export interface GraticuleOptions {
+  /** Altitude rings every N degrees (default 15 → 15,30,45,60,75). */
+  altitudeStep?: number;
+  /** Azimuth spokes every N degrees (default 30). */
+  azimuthStep?: number;
+  /** Angular resolution of generated arcs in degrees (default 5). */
+  resolution?: number;
+}
+
+/**
+ * The static dome graticule: altitude rings, azimuth spokes and the eight
+ * compass labels. Independent of date/site — purely the reference grid the
+ * sun paths are drawn against.
+ */
+export function domeGraticule(options: GraticuleOptions = {}): Graticule {
+  const altStep = options.altitudeStep ?? 15;
+  const azStep = options.azimuthStep ?? 30;
+  const res = options.resolution ?? 5;
+
+  const altitudeRings: Graticule['altitudeRings'] = [];
+  for (let alt = altStep; alt < 90; alt += altStep) {
+    const ring: Enu[] = [];
+    for (let az = 0; az <= 360; az += res) ring.push(azimuthAltitudeToEnu(az, alt));
+    altitudeRings.push({ altitude: alt, ring });
+  }
+  // Horizon ring (altitude 0) is always present.
+  const horizon: Enu[] = [];
+  for (let az = 0; az <= 360; az += res) horizon.push(azimuthAltitudeToEnu(az, 0));
+  altitudeRings.unshift({ altitude: 0, ring: horizon });
+
+  const azimuthSpokes: Graticule['azimuthSpokes'] = [];
+  for (let az = 0; az < 360; az += azStep) {
+    const arc: Enu[] = [];
+    for (let alt = 0; alt <= 90; alt += res) arc.push(azimuthAltitudeToEnu(az, alt));
+    azimuthSpokes.push({ azimuth: az, arc });
+  }
+
+  const cardinals: Graticule['cardinals'] = [
+    ['N', 0], ['NE', 45], ['E', 90], ['SE', 135],
+    ['S', 180], ['SW', 225], ['W', 270], ['NW', 315],
+  ].map(([label, az]) => ({ label: label as string, dir: azimuthAltitudeToEnu(az as number, 0) }));
+
+  return { altitudeRings, azimuthSpokes, cardinals };
+}
+
+function isLeap(year: number): boolean {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+}

--- a/packages/solar/src/sun-times.ts
+++ b/packages/solar/src/sun-times.ts
@@ -52,6 +52,17 @@ export function sunTimes(date: Date, latitude: number, longitude: number): SunTi
 
   const latRad = latitude * DEG;
   const decRad = declination * DEG;
+
+  // Exact poles: cos(latitude) = 0 makes the hour-angle formula divide by zero
+  // (cosHa = NaN), which would skip both polar branches and yield Invalid Date.
+  // At a pole the sun holds a near-constant altitude ≈ declination all day, so
+  // decide always-up vs always-down directly from that altitude.
+  if (Math.abs(Math.cos(latRad)) < 1e-12) {
+    const poleAltitude = latitude > 0 ? declination : -declination;
+    const alwaysUp = poleAltitude >= -(SUNRISE_ZENITH - 90);
+    return { sunrise: null, sunset: null, solarNoon, alwaysUp, alwaysDown: !alwaysUp };
+  }
+
   const cosHa =
     Math.cos(SUNRISE_ZENITH * DEG) / (Math.cos(latRad) * Math.cos(decRad)) -
     Math.tan(latRad) * Math.tan(decRad);

--- a/packages/solar/src/sun-times.ts
+++ b/packages/solar/src/sun-times.ts
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Sunrise / sunset / solar-noon times, derived from the same NOAA solar
+ * geometry as {@link sunPosition}. Returned as absolute `Date` instants (UTC)
+ * so callers can format them in whatever timezone the site uses.
+ */
+
+import { solarGeometry, toJulianDay } from './solar-position.js';
+
+const DEG = Math.PI / 180;
+const RAD = 180 / Math.PI;
+
+/** Standard refraction-corrected solar zenith for sunrise/sunset (90° 50′). */
+const SUNRISE_ZENITH = 90.833;
+
+export interface SunTimes {
+  /** Sunrise instant, or null if the sun never rises that day (polar night). */
+  sunrise: Date | null;
+  /** Sunset instant, or null if the sun never sets that day (midnight sun). */
+  sunset: Date | null;
+  /** Solar noon (sun crosses the local meridian). Always defined. */
+  solarNoon: Date;
+  /** True if the sun is above the horizon for the whole UTC day. */
+  alwaysUp: boolean;
+  /** True if the sun is below the horizon for the whole UTC day. */
+  alwaysDown: boolean;
+}
+
+/**
+ * Compute sunrise/sunset/solar-noon for the UTC calendar day containing
+ * `date`, at the given site.
+ *
+ * @param date      Any instant within the desired UTC day.
+ * @param latitude  Site latitude in degrees (north positive).
+ * @param longitude Site longitude in degrees (east positive).
+ */
+export function sunTimes(date: Date, latitude: number, longitude: number): SunTimes {
+  // Anchor to solar geometry at local solar noon for best accuracy.
+  const noonProbe = new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 12, 0, 0),
+  );
+  const { declination, equationOfTime } = solarGeometry(noonProbe);
+
+  // Solar noon (UTC minutes from midnight): meridian transit corrected for
+  // longitude and the equation of time.
+  const solarNoonMinutes = 720 - 4 * longitude - equationOfTime;
+  const dayStart = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+  const solarNoon = new Date(dayStart + solarNoonMinutes * 60_000);
+
+  const latRad = latitude * DEG;
+  const decRad = declination * DEG;
+  const cosHa =
+    Math.cos(SUNRISE_ZENITH * DEG) / (Math.cos(latRad) * Math.cos(decRad)) -
+    Math.tan(latRad) * Math.tan(decRad);
+
+  if (cosHa < -1) {
+    // Sun never sets this day.
+    return { sunrise: null, sunset: null, solarNoon, alwaysUp: true, alwaysDown: false };
+  }
+  if (cosHa > 1) {
+    // Sun never rises this day.
+    return { sunrise: null, sunset: null, solarNoon, alwaysUp: false, alwaysDown: true };
+  }
+
+  const haMinutes = (Math.acos(cosHa) * RAD) * 4; // 4 minutes per degree
+  return {
+    sunrise: new Date(solarNoon.getTime() - haMinutes * 60_000),
+    sunset: new Date(solarNoon.getTime() + haMinutes * 60_000),
+    solarNoon,
+    alwaysUp: false,
+    alwaysDown: false,
+  };
+}

--- a/packages/solar/tsconfig.json
+++ b/packages/solar/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.packages.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -325,6 +325,9 @@ importers:
       '@ifc-lite/server-client':
         specifier: workspace:^
         version: link:../../packages/server-client
+      '@ifc-lite/solar':
+        specifier: workspace:^
+        version: link:../../packages/solar
       '@ifc-lite/spatial':
         specifier: workspace:^
         version: link:../../packages/spatial
@@ -1378,6 +1381,15 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+
+  packages/solar:
+    devDependencies:
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.13)(@types/node@25.9.1)(happy-dom@20.9.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
 
   packages/spatial:
     dependencies:


### PR DESCRIPTION
New dependency-free package providing:
- NOAA solar position (azimuth/altitude), accurate to ~0.01° for 1900–2100
- sunrise/sunset/solar-noon with polar night / midnight-sun handling
- 3D sun-path dome geometry: day paths, hourly analemmas, and graticule
  (altitude rings, azimuth spokes, compass labels) as ENU unit vectors

21 unit tests covering equinox/solstice geometry, day length, polar cases,
and dome sampling. Foundation for the georeferenced sun-path + shadow-study
feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New solar package: NOAA-based sun position, sunrise/sunset/noon and 3D sun‑path geometry (ENU vectors)
  * Viewer solar study: live sun readouts, sun‑path dome, shadows, context source choice (Photorealistic or OSM Buildings)
  * SolarPanel UI + toolbar control with date/time picker, play/pause day/year sweeps, and UTC/local solar‑time toggle

* **Documentation**
  * Package README with usage examples and accuracy notes

* **Tests**
  * Vitest coverage for solar calculations and geometry/paths
<!-- end of auto-generated comment: release notes by coderabbit.ai -->