### PR TITLE
feat: add use-ifclite Claude Code skill

### DIFF
--- a/.claude/skills/use-ifclite/SKILL.md
+++ b/.claude/skills/use-ifclite/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: use-ifclite
+description: >-
+  Work with IFC / BIM files (.ifc, .ifcx, IFC2X3 / IFC4 / IFC4X3 / IFC5) from the
+  terminal using the ifc-lite CLI — inspect, query, validate (IDS), export
+  (CSV/JSON/IFC/glTF/Parquet), create elements, merge, convert schema versions,
+  diff, clash-check, run BCF collaboration, and script the SDK. Use whenever a
+  task involves reading, analysing, generating, or editing IFC building models,
+  or when the user mentions IFC, BIM, BCF, IDS, or buildingSMART. Also covers
+  running ifc-lite as an MCP server for tool-calling agents.
+---
+
+# Using ifc-lite
+
+`ifc-lite` is a headless BIM toolkit for IFC files. It was built for LLM
+terminals: every command takes `--json`, **stdout is data, stderr is status**,
+and exit `0`/`1` means pass/fail. Prefer it over hand-parsing IFC text.
+
+## Start here (every session)
+
+```bash
+ifc-lite --help            # all commands
+ifc-lite schema            # full SDK API as JSON (namespaces, methods, params) — read before writing eval/run code
+ifc-lite info model.ifc --json   # schema version, entity counts, storeys, top types
+```
+
+If `ifc-lite` isn't installed, run via `npx @ifc-lite/cli <command>` or install
+with `npm install -g @ifc-lite/cli`.
+
+## Core workflows
+
+```bash
+# Query entities (use exact IFC type names; comma-separated for multiple)
+ifc-lite query model.ifc --type IfcWall --json
+ifc-lite query model.ifc --type IfcWall --where "Pset_WallCommon.IsExternal=true" --json
+ifc-lite query model.ifc --type IfcWall --all --json    # props, quantities, materials, classifications, relationships
+ifc-lite query model.ifc --type IfcDoor --count
+
+# Inspect one entity fully
+ifc-lite props model.ifc --id 42
+
+# Export
+ifc-lite export model.ifc --format csv --type IfcWall --columns Name,GlobalId,Pset_WallCommon.FireRating --out walls.csv
+ifc-lite export model.ifc --format ifc --schema IFC4 --out filtered.ifc
+
+# Validate against IDS rules (exit 1 on failure)
+ifc-lite ids model.ifc requirements.ids --json
+
+# Create IFC from scratch (30+ element types)
+ifc-lite create wall --start 0,0,0 --end 5,0,0 --height 3 --thickness 0.2 --out wall.ifc
+
+# Combine / convert / compare
+ifc-lite merge arch.ifc struct.ifc mep.ifc --out federated.ifc
+ifc-lite convert model.ifc --schema IFC4 --out v4.ifc
+ifc-lite diff v1.ifc v2.ifc --by-entity --json
+
+# Structural sanity check
+ifc-lite validate model.ifc --json
+```
+
+## The power tools: `eval` and `run`
+
+When no flag fits, drop into the full SDK. The `bim` object is the entire
+`@ifc-lite/sdk` surface (discover it with `ifc-lite schema`).
+
+```bash
+ifc-lite eval model.ifc "bim.query().byType('IfcWall').count()"
+ifc-lite eval model.ifc "bim.storeys().map(s => s.name)"
+ifc-lite run analysis.js model.ifc           # a .js file with `bim` available globally
+```
+
+`ifc-lite ask model.ifc "how many walls?"` maps plain-English questions to common
+recipes — handy for quick one-offs, but `eval` is more precise.
+
+For the **complete command + flag reference** (every command, all flags, the 30+
+`create` element types, `bsdd`, `clash`, `lod`, `view`/`analyze`), read
+[`cli-reference.md`](./cli-reference.md).
+
+## Rules that keep IFC output correct
+
+These are non-negotiable when emitting IFC names or editing models:
+
+- **Exact IFC EXPRESS names, never aliases.** Types like `IfcWallStandardCase`,
+  relationships like `IfcRelAggregates` (not `Aggregates`). Attributes in IFC
+  PascalCase: `GlobalId`, `Name`, `Description`, `ObjectType`.
+- **STEP type names are stored UPPERCASE.** For display use the SDK's type-name
+  resolution (`getTypeName(id)`) — don't hand-case them.
+- **Single vs federated models are both first-class.** When multiple files are
+  merged/federated, IDs are namespaced; resolve through the federation registry
+  rather than assuming `globalId === expressId`. (Single-model fallback: they're
+  equal.)
+- **`--where` filters** use `PsetName.PropName=Value` (e.g.
+  `Pset_WallCommon.IsExternal=true`).
+- **Coordinates are IFC Z-up** `[x, y, z]` when creating elements.
+
+## Tips for agent use
+
+1. Always pass `--json`; pipe to `jq` for filtering.
+2. Run `ifc-lite schema` before writing `eval`/`run` code.
+3. Use `--count` for quick counts; `--all` to get full entity data in one call.
+4. Use `create --from-json` (reads stdin) for programmatic generation.
+5. Don't loop calling per-entity extraction; fetch in bulk with `query --all`.
+
+## Running as an MCP server (tool-calling agents)
+
+For agents that speak the Model Context Protocol, `@ifc-lite/mcp` exposes the
+same capabilities as ~70 typed tools (model/query/IDS/BCF/clash/export/viewer/
+mutation) plus pre-baked prompts.
+
+```bash
+ifc-lite mcp ./model.ifc                 # stdio transport (default)
+ifc-lite mcp ./model.ifc --read-only     # hide all mutation tools
+ifc-lite mcp ./arch.ifc ./struct.ifc --federate
+ifc-lite mcp --transport http --port 8765 --token <secret>
+# (equivalent standalone binary: ifc-lite-mcp …)
+```
+
+Tool families and the discovery-first calling pattern are documented in
+[`mcp-tools.md`](./mcp-tools.md).

--- a/.claude/skills/use-ifclite/cli-reference.md
+++ b/.claude/skills/use-ifclite/cli-reference.md
@@ -1,0 +1,176 @@
+# ifc-lite CLI — full command reference
+
+Headless BIM toolkit. Every command supports `--json` (machine-readable).
+**stdout = data, stderr = status, exit 0 = success / 1 = failure.** Run
+`ifc-lite <command> --help` for the live signature, and `ifc-lite schema` for
+the full SDK API used by `eval`/`run`.
+
+| Command | Purpose |
+|---------|---------|
+| `info` | Model summary: schema, entity counts, storeys, top types |
+| `query` | Query entities by type/property with optional full data |
+| `props` | All data for a single entity by id |
+| `stats` | Entity-type statistics |
+| `export` | Export to CSV / JSON / IFC STEP |
+| `lod` | Lightweight LOD0 (JSON) / LOD1 (GLB) preview artifacts |
+| `ids` | Validate against IDS rules |
+| `bcf` | BCF collaboration (create / list / add-comment) |
+| `create` | Create IFC elements (30+ types) |
+| `merge` | Merge multiple IFC files into one federated model |
+| `convert` | Convert between IFC schema versions |
+| `diff` | Compare two IFC files |
+| `validate` | Structural validation |
+| `clash` | Clash detection between element sets |
+| `bsdd` | buildingSMART Data Dictionary lookup |
+| `mutate` | Modify entities / properties |
+| `analyze` | Push color overlays to a running viewer |
+| `view` | Launch the 3D viewer with a REST API |
+| `eval` | Evaluate a JS SDK expression |
+| `run` | Run a JS script with `bim` in scope |
+| `ask` | Natural-language recipe engine |
+| `schema` | Dump the SDK API schema as JSON |
+| `ext` | Author / validate / pack / sign / test IFClite extensions |
+
+## query
+
+```bash
+ifc-lite query model.ifc --type IfcWall,IfcDoor --json
+ifc-lite query model.ifc --type IfcWall --where "Pset_WallCommon.IsExternal=true"
+ifc-lite query model.ifc --type IfcWall --all --json
+ifc-lite query model.ifc --type IfcWall --limit 10 --offset 20
+ifc-lite query model.ifc --spatial            # storeys → elements tree
+```
+
+Flags: `--type <T>` · `--where <Pset.Prop=Value>` · `--props` · `--quantities` ·
+`--materials` · `--classifications` · `--attributes` · `--relationships` ·
+`--type-props` · `--documents` · `--all` · `--count` · `--spatial` ·
+`--limit <N>` · `--offset <N>` · `--json`
+
+## props
+
+```bash
+ifc-lite props model.ifc --id 42
+```
+
+Returns `attributes`, `properties`, `quantities`, `classifications`,
+`materials`, `typeProperties`, `relationships`.
+
+## export
+
+```bash
+ifc-lite export model.ifc --format csv --type IfcWall \
+  --columns Name,Type,Pset_WallCommon.IsExternal,Pset_WallCommon.FireRating --out walls.csv
+ifc-lite export model.ifc --format ifc --schema IFC4 --out filtered.ifc
+```
+
+Flags: `--format csv|json|ifc` · `--type <T>` · `--columns <a,b,Pset.Prop>` ·
+`--separator <sep>` · `--schema IFC2X3|IFC4|IFC4X3` · `--limit <N>` · `--out <file>`
+
+(For glTF / Parquet / IFC5 export use the SDK `@ifc-lite/export` package or
+`eval`.)
+
+## lod
+
+```bash
+ifc-lite lod model.ifc --level 0 --out model.lod0.json
+ifc-lite lod model.ifc --level 1 --out model.glb --meta model.lod1.json
+```
+
+Flags: `--level 0|1` · `--out <file>` (required for LOD1) · `--meta <file>` ·
+`--quality low|medium|high` · `--json`. LOD0 = bbox/transform/centroid/identity
+JSON; LOD1 = GLB + metadata (falls back to box geometry if meshing fails).
+
+## ids
+
+```bash
+ifc-lite ids model.ifc requirements.ids --json --locale de
+```
+
+Flags: `--json` · `--locale en|de|fr`. Exit 0 (pass) / 1 (fail).
+
+## bcf
+
+```bash
+ifc-lite bcf create --title "Missing fire door" --description "Level 2" --out issue.bcf
+ifc-lite bcf list issues.bcf
+ifc-lite bcf add-comment --file issues.bcf --text "Fixed in rev 3" --out updated.bcf
+```
+
+## create
+
+30+ element types, with `--pset` / `--qset` / `--material` / `--color`, or
+`--from-json` (reads stdin). `--out <file>` is required.
+
+| Category | Types |
+|----------|-------|
+| Walls | `wall`, `curtain-wall` |
+| Floors/Roofs | `slab`, `roof`, `gable-roof` |
+| Columns | `column`, `circular-column`, `hollow-circular-column` |
+| Beams | `beam`, `i-shape-beam`, `rectangle-hollow-beam` |
+| Members | `member`, `l-shape-member`, `t-shape-member`, `u-shape-member` |
+| Openings | `door`, `window`, `wall-door`, `wall-window` |
+| Circulation | `stair`, `ramp`, `railing` |
+| Foundation | `footing`, `pile` |
+| Other | `space`, `plate`, `furnishing`, `proxy` |
+
+```bash
+ifc-lite create wall --start 0,0,0 --end 5,0,0 --height 3 --thickness 0.2 --out wall.ifc
+ifc-lite create slab --width 10 --depth 8 --thickness 0.3 --out slab.ifc
+ifc-lite create wall --out w.ifc \
+  --pset '{"Name":"Pset_WallCommon","Properties":[{"Name":"IsExternal","NominalValue":true}]}'
+echo '{"Start":[0,0,0],"End":[10,0,0],"Height":3,"Thickness":0.2}' | ifc-lite create wall --from-json --out wall.ifc
+```
+
+Common flags: `--start/--end/--position <x,y,z>` · `--height/--width/--depth/--thickness <N>` ·
+`--name` · `--project` · `--storey` · `--elevation` · `--pset/--qset/--material <json>` ·
+`--color <r,g,b>` · `--from-json` · `--out <file>` · `--json`. Coordinates are IFC **Z-up**.
+
+## merge / convert / diff / validate
+
+```bash
+ifc-lite merge arch.ifc struct.ifc --out federated.ifc --json   # unifies storeys by name+elevation, offsets ids
+ifc-lite convert model.ifc --schema IFC4 --out v4.ifc           # IFC2X3|IFC4|IFC4X3|IFC5
+ifc-lite diff v1.ifc v2.ifc --by-entity --json                  # GlobalId-based entity tracking
+ifc-lite validate model.ifc --json                              # required entities, single IfcProject, GlobalId uniqueness
+```
+
+## bsdd
+
+```bash
+ifc-lite bsdd class IfcWall        # definition, related types, properties
+ifc-lite bsdd search "concrete wall"
+ifc-lite bsdd psets IfcWall        # standard property sets
+ifc-lite bsdd qsets IfcSlab        # standard quantity sets
+```
+
+## eval / run / schema
+
+```bash
+ifc-lite eval model.ifc "bim.query().byType('IfcDoor').toArray().filter(d => d.name.includes('Fire'))"
+ifc-lite run analysis.js model.ifc          # `bim` is global in the script
+ifc-lite schema            # full API JSON (namespaces: model, query, viewer, mutate, create, export, ids, bcf)
+ifc-lite schema --compact  # names + descriptions only
+```
+
+`eval` is the most flexible tool — arbitrary SDK code without a dedicated
+subcommand. Always run `ifc-lite schema` first to learn method names/params.
+
+## view / analyze (3D viewer)
+
+```bash
+ifc-lite view model.ifc --port 3456 --no-open       # serves a REST API: /api/command, /api/create, /api/export, /api/status
+ifc-lite analyze model.ifc --viewer 3456 --type IfcWall --missing "Pset_WallCommon.FireRating" --color red --isolate --flyto
+```
+
+`analyze` supports `--where`, `--missing`, `--heatmap <Pset.Prop>`,
+`--palette blue-red|green-red|rainbow`, `--rules <file>`. See the viewer-api
+guide for the full REST surface.
+
+## Pipe patterns
+
+```bash
+ifc-lite query model.ifc --type IfcDoor --json | jq -r '.[].name'
+for f in *.ifc; do echo "$f: $(ifc-lite query "$f" --type IfcWall --count) walls"; done
+ifc-lite merge arch.ifc struct.ifc --out fed.ifc && ifc-lite validate fed.ifc
+ifc-lite bsdd psets IfcWall | jq '.["Pset_WallCommon"]'
+```

--- a/.claude/skills/use-ifclite/mcp-tools.md
+++ b/.claude/skills/use-ifclite/mcp-tools.md
@@ -1,0 +1,91 @@
+# ifc-lite as an MCP server
+
+`@ifc-lite/mcp` exposes ifc-lite as an agent-native Model Context Protocol
+server (stdio + Streamable HTTP). Use this when an MCP-capable agent should
+call BIM operations as typed tools instead of shelling out to the CLI.
+
+## Launching
+
+```bash
+ifc-lite mcp ./model.ifc                       # stdio (default transport)
+ifc-lite mcp ./model.ifc --read-only           # hide all mutation tools
+ifc-lite mcp ./arch.ifc ./struct.ifc --federate
+ifc-lite mcp --transport http --port 8765 --token <secret>
+ifc-lite mcp ./model.ifc --viewer              # auto-open the 3D viewer
+```
+
+The standalone binary `ifc-lite-mcp …` accepts the same flags. Useful options:
+`--read-only`, `--federate`, `--transport stdio|http`, `--port`, `--host`
+(loopback by default; non-loopback needs `--token` or `--insecure`), `--token`
+(repeatable; full or read-only scope), `--bsdd <url>`, `--allow <path>`
+(restrict filesystem access).
+
+Register it with Claude Code via your MCP config, e.g.:
+
+```json
+{
+  "mcpServers": {
+    "ifc-lite": { "command": "ifc-lite", "args": ["mcp", "./model.ifc", "--read-only"] }
+  }
+}
+```
+
+## Calling pattern: discovery first
+
+The read-only discovery tools are always on — call them before anything else:
+
+1. `model_list` / `model_info` — what's loaded, schema, counts, units, georeferencing.
+2. `schema_describe` — entity metadata, inheritance chains, attribute shapes.
+3. Then query / validate / mutate / export as needed.
+
+## Tool families (~70 tools)
+
+**Models** — `model_info`, `model_list`, `model_load`, `model_unload`,
+`model_save`, `model_audit`, `model_diff`.
+
+**Discovery & metadata** — `schema_describe`, `units`, `georeferencing`,
+`classifications_list`, `materials_list`, `spatial_hierarchy`,
+`containment_chain`, `relationships`.
+
+**Query** — `query_entities`, `count_entities`, `get_entity`,
+`get_entities_bulk`, `properties_unique`, `quantity_diff`.
+
+**Geometry** — `geometry_get`, `geometry_bbox`, `geometry_area`,
+`geometry_volume`, `raycast`.
+
+**Validation** — `ids_validate`, `ids_explain`, `gherkin_check`.
+
+**Clash** — `clash_check`, `clash_matrix`.
+
+**bSDD** — `bsdd_search`, `bsdd_class`, `bsdd_match`, `bsdd_property_sets`.
+
+**Mutations** (hidden under `--read-only`) — `entity_create`, `entity_delete`,
+`entity_set_attribute`, `entity_set_property`, `entity_delete_property`,
+`mutation_batch`, `mutation_diff`, `mutation_undo`.
+
+**Export** — `export_csv`, `export_json`, `export_ifc`, `export_ifcx`,
+`export_glb`, `export_pdf_report`.
+
+**BCF** — `bcf_topic_create`, `bcf_topic_update`, `bcf_topic_close`,
+`bcf_topic_list`, `bcf_viewpoint_create`, `bcf_export`.
+
+**Viewer** (interactive 3D, when launched with `--viewer`) — `viewer_open`,
+`viewer_close`, `viewer_status`, `viewer_colorize`, `viewer_color_by_property`,
+`viewer_color_by_storey`, `viewer_isolate`, `viewer_hide`, `viewer_show`,
+`viewer_fly_to`, `viewer_set_section`, `viewer_clear_section`, `viewer_reset`,
+`viewer_get_selection`, `viewer_wait_for_selection`, `viewer_describe_selection`,
+`viewer_ask`.
+
+## Pre-baked prompts
+
+The server ships prompt templates that package a BIM-expert intent plus the
+right tool sequence, e.g. `audit_model`, `find_fire_rated_doors`,
+`generate_bcf_from_ids`, `compare_versions`, `space_program_check`. Surface
+these to the user as one-click starting points where the host supports MCP
+prompts.
+
+## Same correctness rules as the CLI
+
+Exact IFC EXPRESS names, PascalCase attributes, full relationship entity names,
+and federation-aware ID resolution all apply identically — see the main
+`SKILL.md`.

--- a/.claude/skills/use-ifclite/mcp-tools.md
+++ b/.claude/skills/use-ifclite/mcp-tools.md
@@ -17,8 +17,9 @@ ifc-lite mcp ./model.ifc --viewer              # auto-open the 3D viewer
 The standalone binary `ifc-lite-mcp …` accepts the same flags. Useful options:
 `--read-only`, `--federate`, `--transport stdio|http`, `--port`, `--host`
 (loopback by default; non-loopback needs `--token` or `--insecure`), `--token`
-(repeatable; full or read-only scope), `--bsdd <url>`, `--allow <path>`
-(restrict filesystem access).
+(a single bearer token for HTTP auth; combine with `--read-only` to scope the
+whole server read-only), `--bsdd <url>`, `--allow <path>` (restrict filesystem
+access).
 
 Register it with Claude Code via your MCP config, e.g.:
 


### PR DESCRIPTION
Adds .claude/skills/use-ifclite/ teaching agents to drive IFC/BIM
workflows through the ifc-lite CLI (CLI-first), with a secondary
section on running ifc-lite as an MCP server. Resolves #912.

- SKILL.md: trigger-oriented frontmatter + concise CLI cookbook,
  eval/run power tools, schema-compliance rules, MCP launch.
- cli-reference.md: full command/flag reference (progressive disclosure).
- mcp-tools.md: MCP launch flags and the ~70 tools grouped by family.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive ifc-lite docs: full user guide, CLI command reference with examples/flags, MCP server usage and transports, and tool descriptions.
  * Included best practices and correctness rules for IFC output, agent-oriented tips (JSON/bulk querying), and pipeline examples for shell integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->