### PR TITLE
docs(skill): fix unreachable getTypeName ref in use-ifclite

### DIFF
--- a/.claude/skills/use-ifclite/SKILL.md
+++ b/.claude/skills/use-ifclite/SKILL.md
@@ -83,8 +83,9 @@ These are non-negotiable when emitting IFC names or editing models:
 - **Exact IFC EXPRESS names, never aliases.** Types like `IfcWallStandardCase`,
   relationships like `IfcRelAggregates` (not `Aggregates`). Attributes in IFC
   PascalCase: `GlobalId`, `Name`, `Description`, `ObjectType`.
-- **STEP type names are stored UPPERCASE.** For display use the SDK's type-name
-  resolution (`getTypeName(id)`) — don't hand-case them.
+- **STEP type names are stored UPPERCASE.** Don't hand-case them — query
+  results already carry the resolved IFC type in `EntityData.type` (e.g.
+  `entity.type === 'IfcWall'`), so read that instead of reconstructing it.
 - **Single vs federated models are both first-class.** When multiple files are
   merged/federated, IDs are namespaced; resolve through the federation registry
   rather than assuming `globalId === expressId`. (Single-model fallback: they're


### PR DESCRIPTION
Follow-up to #915.

The use-ifclite skill's "Rules that keep IFC output correct" section pointed agents at a top-level \`getTypeName(id)\` for STEP type-name resolution. That function is **not exposed on the \`eval\`/\`run\` \`bim\` scope** (verified: 0 hits in \`ifc-lite schema\`; it only exists internally as \`store.entities.getTypeName()\` / parser utils). An agent following the rule literally would hit a ReferenceError.

Fix: point at the already-resolved type instead — query results carry the IFC type in \`EntityData.type\` (e.g. \`entity.type === 'IfcWall'\`), so no manual casing/resolution is needed.

Docs-only, one line. The rest of #915 was verified accurate against source (all 24 CLI commands, every documented flag, the 28 \`create\` types, all 72 MCP tool names, prompt templates, and \`view\` REST endpoints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated guidance on IFC type name handling to recommend using resolved IFC type values that are already readily available in the underlying data structure, rather than employing alternative retrieval methods, ensuring improved consistency and correctness in how IFC entity types are represented and displayed throughout your application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->