### PR TITLE
feat(viewer): discoverable advanced filter on the menubar search (#923)

### DIFF
--- a/apps/viewer/src/components/ui/tabs.tsx
+++ b/apps/viewer/src/components/ui/tabs.tsx
@@ -30,7 +30,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      'inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+      'inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
       className
     )}
     {...props}

--- a/apps/viewer/src/components/viewer/SearchInline.tsx
+++ b/apps/viewer/src/components/viewer/SearchInline.tsx
@@ -401,8 +401,10 @@ export function SearchInline() {
         e.preventDefault();
         // ⌘↵ / Ctrl+↵ opens the advanced modal instead of committing — the
         // inline query is preserved so the modal opens already populated.
+        // Text-search entry point, so land on the Search tab.
         if (e.metaKey || e.ctrlKey) {
           setSearchOpen(false);
+          setSearchModalTab('search');
           setSearchModalOpen(true);
           return;
         }
@@ -422,7 +424,7 @@ export function SearchInline() {
         if (target) commitResult(target, idx, e.shiftKey, liveResults, live);
       }
     },
-    [commitResult, results, searchHighlightIndex, searchOpen, setSearchHighlightIndex, setSearchModalOpen, setSearchOpen],
+    [commitResult, results, searchHighlightIndex, searchOpen, setSearchHighlightIndex, setSearchModalOpen, setSearchModalTab, setSearchOpen],
   );
 
   const hasFilters = activeRuleCount > 0;
@@ -532,6 +534,7 @@ export function SearchInline() {
           onHover={(i) => setSearchHighlightIndex(i)}
           onOpenAdvanced={() => {
             setSearchOpen(false);
+            setSearchModalTab('search');
             setSearchModalOpen(true);
           }}
         />

--- a/apps/viewer/src/components/viewer/SearchInline.tsx
+++ b/apps/viewer/src/components/viewer/SearchInline.tsx
@@ -25,7 +25,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Search, Clock, X } from 'lucide-react';
+import { Search, Clock, X, SlidersHorizontal } from 'lucide-react';
 import { useShallow } from 'zustand/react/shallow';
 import { Input } from '@/components/ui/input';
 import { useViewerStore } from '@/store';
@@ -79,6 +79,9 @@ export function SearchInline() {
     exitVimCycle,
     stepVimCycle,
     setSearchModalOpen,
+    setSearchModalTab,
+    activeRuleCount,
+    clearFilterRules,
     models,
     setSelectedEntity,
     setSelectedEntityId,
@@ -99,6 +102,9 @@ export function SearchInline() {
       exitVimCycle: s.exitVimCycle,
       stepVimCycle: s.stepVimCycle,
       setSearchModalOpen: s.setSearchModalOpen,
+      setSearchModalTab: s.setSearchModalTab,
+      activeRuleCount: s.searchFilter.rules.length,
+      clearFilterRules: s.clearFilterRules,
       models: s.models,
       setSelectedEntity: s.setSelectedEntity,
       setSelectedEntityId: s.setSelectedEntityId,
@@ -419,6 +425,16 @@ export function SearchInline() {
     [commitResult, results, searchHighlightIndex, searchOpen, setSearchHighlightIndex, setSearchModalOpen, setSearchOpen],
   );
 
+  const hasFilters = activeRuleCount > 0;
+
+  /** Open the advanced modal straight to the Filter builder — the
+   *  always-visible entry point to structured filtering. */
+  const openAdvancedFilter = useCallback(() => {
+    setSearchOpen(false);
+    setSearchModalTab('filter');
+    setSearchModalOpen(true);
+  }, [setSearchOpen, setSearchModalTab, setSearchModalOpen]);
+
   const queryTrimmedLen = searchQuery.trim().length;
   const showPopover = searchOpen && (results.length > 0 || queryTrimmedLen > 0 || recents.length > 0);
   const showRecents = searchOpen && queryTrimmedLen === 0 && recents.length > 0;
@@ -437,11 +453,52 @@ export function SearchInline() {
         }}
         onFocus={() => setSearchOpen(true)}
         onKeyDown={handleInputKeyDown}
+        className={cn(hasFilters ? 'pr-[4.5rem]' : 'pr-9')}
         aria-label="Search entities"
         aria-autocomplete="list"
         aria-expanded={showPopover}
         aria-controls="search-inline-popover"
       />
+      {/* Advanced-filter affordance — always visible so structured
+          filtering is discoverable without the ⌘⇧F shortcut. Shows the
+          active rule count and a quick-clear when a filter is applied. */}
+      <div className="absolute right-1.5 top-1/2 -translate-y-1/2 flex items-center gap-0.5">
+        {hasFilters && (
+          <button
+            type="button"
+            aria-label="Clear filters"
+            title="Clear filters"
+            onMouseDown={(e) => {
+              e.preventDefault();
+              clearFilterRules();
+            }}
+            className="rounded p-1 text-muted-foreground transition-colors hover:bg-zinc-100 hover:text-foreground dark:hover:bg-zinc-800"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        )}
+        <button
+          type="button"
+          aria-label={hasFilters ? `Advanced filter — ${activeRuleCount} active` : 'Advanced filter'}
+          aria-pressed={hasFilters}
+          title="Advanced filter (⌘⇧F)"
+          onMouseDown={(e) => {
+            e.preventDefault();
+            openAdvancedFilter();
+          }}
+          className={cn(
+            'flex items-center gap-1 rounded px-1.5 py-1 text-xs transition-colors',
+            hasFilters
+              ? 'bg-primary/10 text-primary hover:bg-primary/15'
+              : 'text-muted-foreground hover:bg-zinc-100 hover:text-foreground dark:hover:bg-zinc-800',
+          )}
+        >
+          <SlidersHorizontal className="h-3.5 w-3.5" />
+          {hasFilters && (
+            <span className="font-mono text-[10px] font-semibold leading-none">{activeRuleCount}</span>
+          )}
+        </button>
+      </div>
       {/* Vim cycle hint — shows below the input whenever a cycle is active
           and the popover is closed. Clicking it exits the cycle. */}
       {searchVimCycle && !showPopover && (

--- a/apps/viewer/src/components/viewer/SearchModal.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.tsx
@@ -49,7 +49,6 @@ export function SearchModal() {
     searchIndexes,
     models,
     setSearchModalOpen,
-    toggleSearchModal,
     setSearchModalTab,
     setSearchQuery,
   } = useViewerStore(
@@ -60,7 +59,6 @@ export function SearchModal() {
       searchIndexes: s.searchIndexes,
       models: s.models,
       setSearchModalOpen: s.setSearchModalOpen,
-      toggleSearchModal: s.toggleSearchModal,
       setSearchModalTab: s.setSearchModalTab,
       setSearchQuery: s.setSearchQuery,
     })),
@@ -129,19 +127,26 @@ export function SearchModal() {
     return out;
   }, [tier0Models, tier1Indexes, debouncedQuery]);
 
-  /** Global ⌘⇧F / Ctrl+⇧F toggle — opens from anywhere, also closes when open. */
+  /** Global ⌘⇧F / Ctrl+⇧F toggle — opens from anywhere, also closes when open.
+   *  This is a text-search entry point, so opening always lands on the Search
+   *  tab (the controlled tab otherwise remembers the last-used Filter tab). */
   useEffect(() => {
     const handler = (e: globalThis.KeyboardEvent) => {
       const isAdvancedShortcut =
         (e.ctrlKey || e.metaKey) && e.shiftKey && (e.key === 'f' || e.key === 'F');
       if (isAdvancedShortcut) {
         e.preventDefault();
-        toggleSearchModal();
+        if (searchModalOpen) {
+          setSearchModalOpen(false);
+        } else {
+          setSearchModalTab('search');
+          setSearchModalOpen(true);
+        }
       }
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [toggleSearchModal]);
+  }, [searchModalOpen, setSearchModalOpen, setSearchModalTab]);
 
   /**
    * Record the query in recents on the modal-close *transition* — once

--- a/apps/viewer/src/components/viewer/SearchModal.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.tsx
@@ -45,19 +45,23 @@ export function SearchModal() {
   const {
     searchQuery,
     searchModalOpen,
+    searchModalTab,
     searchIndexes,
     models,
     setSearchModalOpen,
     toggleSearchModal,
+    setSearchModalTab,
     setSearchQuery,
   } = useViewerStore(
     useShallow((s) => ({
       searchQuery: s.searchQuery,
       searchModalOpen: s.searchModalOpen,
+      searchModalTab: s.searchModalTab,
       searchIndexes: s.searchIndexes,
       models: s.models,
       setSearchModalOpen: s.setSearchModalOpen,
       toggleSearchModal: s.toggleSearchModal,
+      setSearchModalTab: s.setSearchModalTab,
       setSearchQuery: s.setSearchQuery,
     })),
   );
@@ -189,7 +193,11 @@ export function SearchModal() {
         onEscapeKeyDown={close}
       >
         <DialogTitle className="sr-only">Advanced Search</DialogTitle>
-        <Tabs defaultValue="search" className="flex flex-col flex-1 min-h-0">
+        <Tabs
+          value={searchModalTab}
+          onValueChange={(v) => setSearchModalTab(v as typeof searchModalTab)}
+          className="flex flex-col flex-1 min-h-0"
+        >
           <div className="flex items-center justify-between border-b px-4 py-3">
             <TabsList>
               <TabsTrigger value="search">

--- a/apps/viewer/src/store/slices/searchSlice.ts
+++ b/apps/viewer/src/store/slices/searchSlice.ts
@@ -60,6 +60,10 @@ export interface SearchVimCycleState {
  */
 export type SearchFieldFilter = MatchField | 'all';
 
+/** Which tab the advanced modal renders. Lets callers (e.g. the inline
+ *  filter button) open straight to the Filter builder. */
+export type SearchModalTab = 'search' | 'filter';
+
 /**
  * Tabular result from a Filter run. Flat snapshot so the modal can
  * re-render rows without holding live evaluator state.
@@ -109,6 +113,8 @@ export interface SearchSlice {
   searchVimCycle: SearchVimCycleState | null;
   /** Advanced search modal (⌘⇧F) is open. */
   searchModalOpen: boolean;
+  /** Which tab the advanced modal shows. Remembered across opens. */
+  searchModalTab: SearchModalTab;
   /** Field chip filter active inside the modal. Defaults to 'all'. */
   searchFieldFilter: SearchFieldFilter;
   /** Per-modelId include filter inside the modal. `null` means all models included. */
@@ -147,6 +153,7 @@ export interface SearchSlice {
 
   setSearchModalOpen: (open: boolean) => void;
   toggleSearchModal: () => void;
+  setSearchModalTab: (tab: SearchModalTab) => void;
   setSearchFieldFilter: (filter: SearchFieldFilter) => void;
   /** Toggle a model in/out of the include filter. If the filter is null,
    *  the first toggle materialises it as "all models except this one". */
@@ -187,6 +194,7 @@ export const createSearchSlice: StateCreator<SearchSlice, [], [], SearchSlice> =
   searchIndexes: new Map(),
   searchVimCycle: null,
   searchModalOpen: false,
+  searchModalTab: 'search',
   searchFieldFilter: 'all',
   searchModelFilter: null,
   searchFilterResult: null,
@@ -239,6 +247,7 @@ export const createSearchSlice: StateCreator<SearchSlice, [], [], SearchSlice> =
 
   setSearchModalOpen: (searchModalOpen) => set({ searchModalOpen }),
   toggleSearchModal: () => set((state) => ({ searchModalOpen: !state.searchModalOpen })),
+  setSearchModalTab: (searchModalTab) => set({ searchModalTab }),
   setSearchFieldFilter: (searchFieldFilter) => set({ searchFieldFilter }),
 
   toggleSearchModelFilter: (modelId, availableModelIds) =>


### PR DESCRIPTION
Closes #923. Part of the #928 epic (user feedback #917 §2).

## Problem
The advanced structured-filter builder was only reachable via the **⌘⇧F** shortcut or by expanding the inline search popover (hidden until you focus/type), so users rarely discovered it.

## Change
An always-visible filter affordance **coupled to the existing `SearchInline` menubar field** (rather than a separate toolbar button):

- **`SearchInline.tsx`** — adds a persistent filter icon button (`SlidersHorizontal`) inside the search field that opens the advanced modal straight to the **Filter** builder. When rules are active it shows an accent-colored **count badge** and a **× quick-clear**; the input reserves right-padding accordingly.
- **`searchSlice.ts`** — lifts the advanced modal's active tab into the store (`searchModalTab` + `setSearchModalTab`), remembered across opens.
- **`SearchModal.tsx`** — makes the Search/Filter `Tabs` controlled by `searchModalTab` (was uncontrolled `defaultValue="search"`).

## Unchanged
⌘⇧F shortcut, inline text search, and the popover "Advanced" link all behave as before.

## Verification
- `pnpm typecheck` (viewer): no errors in the 3 changed files.
- Not run in a browser (would require the wasm build); change is a self-contained UI affordance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Advanced filter controls are now visible in the search bar, displaying active rule count and a clear filters option.
  * Improved keyboard shortcut handling for the search modal (⌘⇧F / Ctrl+⇧F).

* **Style**
  * Enhanced visual indicators for active tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->