### PR TITLE
feat(lists): target lists beyond IFC class — material, classification, storey (#925)

### DIFF
--- a/.changeset/lists-targeting-925.md
+++ b/.changeset/lists-targeting-925.md
@@ -1,0 +1,14 @@
+---
+"@ifc-lite/lists": minor
+---
+
+Lists can now target elements beyond IFC class (#925).
+
+- `ListDefinition` with an empty `entityTypes` targets all model elements
+  (resolved via the new optional `ListDataProvider.getAllEntityIds()`).
+- `PropertyCondition.source` gains `material` | `classification` | `spatial`
+  (storey), backed by optional provider accessors `getMaterialNames`,
+  `getClassifications`, and `getStoreyName`.
+
+All new provider methods are optional, so existing `ListDataProvider`
+implementers keep working unchanged.

--- a/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
@@ -249,8 +249,9 @@ export function ListBuilder({ providers, initial, onSave, onCancel, onExecute }:
 
           {selectedTypes.size === 0 && (
             <p className="text-[11px] text-muted-foreground">
-              No entity types selected — this list targets <strong>all elements</strong>. Add
-              filters above (e.g. Name, Material, Classification, Storey) to narrow it.
+              No entity types selected — this list targets <strong>all model elements</strong>
+              {' '}(everything with geometry). Add filters above (e.g. Name, Material,
+              Classification, Storey) to narrow it.
             </p>
           )}
 

--- a/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
@@ -28,8 +28,9 @@ import type {
   ColumnDefinition,
   DiscoveredColumns,
   PropertyCondition,
+  ConditionOperator,
 } from '@ifc-lite/lists';
-import { discoverColumns } from '@ifc-lite/lists';
+import { discoverColumns, ENTITY_ATTRIBUTES } from '@ifc-lite/lists';
 
 // Building element types available for selection
 const SELECTABLE_TYPES: { type: IfcTypeEnum; label: string }[] = [
@@ -71,6 +72,7 @@ export function ListBuilder({ providers, initial, onSave, onCancel, onExecute }:
   const [columns, setColumns] = useState<ColumnDefinition[]>(initial?.columns ?? []);
   const [conditions, setConditions] = useState<PropertyCondition[]>(initial?.conditions ?? []);
   const [columnsExpanded, setColumnsExpanded] = useState(true);
+  const [filtersExpanded, setFiltersExpanded] = useState(true);
 
   // Count entities per type across all providers
   const typeCounts = useMemo(() => {
@@ -85,9 +87,11 @@ export function ListBuilder({ providers, initial, onSave, onCancel, onExecute }:
     return counts;
   }, [providers]);
 
-  // Discover available columns whenever selected types change (across all providers)
-  const discovered = useMemo<DiscoveredColumns | null>(() => {
-    if (selectedTypes.size === 0) return null;
+  // Discover available columns whenever selected types change (across all
+  // providers). With no types selected the list targets every element, so
+  // discovery returns the built-in attributes only (pset/qto discovery needs
+  // a type to sample) — that's enough to pick Name/Class/etc. columns.
+  const discovered = useMemo<DiscoveredColumns>(() => {
     return discoverColumns(providers, Array.from(selectedTypes));
   }, [providers, selectedTypes]);
 
@@ -124,6 +128,18 @@ export function ListBuilder({ providers, initial, onSave, onCancel, onExecute }:
       next[target] = tmp;
       return next;
     });
+  }, []);
+
+  const addCondition = useCallback((condition: PropertyCondition) => {
+    setConditions(prev => [...prev, condition]);
+  }, []);
+
+  const updateCondition = useCallback((idx: number, condition: PropertyCondition) => {
+    setConditions(prev => prev.map((c, i) => (i === idx ? condition : c)));
+  }, []);
+
+  const removeCondition = useCallback((idx: number) => {
+    setConditions(prev => prev.filter((_, i) => i !== idx));
   }, []);
 
   const buildDefinition = useCallback((): ListDefinition => {
@@ -217,12 +233,29 @@ export function ListBuilder({ providers, initial, onSave, onCancel, onExecute }:
             </div>
           </div>
 
-          {selectedTypes.size > 0 && discovered && (
-            <>
-              <Separator />
+          <Separator />
 
-              {/* Column Selection */}
-              <div>
+          {/* Filters / Conditions */}
+          <ConditionsSection
+            conditions={conditions}
+            expanded={filtersExpanded}
+            onToggle={() => setFiltersExpanded((v) => !v)}
+            onAdd={addCondition}
+            onUpdate={updateCondition}
+            onRemove={removeCondition}
+          />
+
+          <Separator />
+
+          {selectedTypes.size === 0 && (
+            <p className="text-[11px] text-muted-foreground">
+              No entity types selected — this list targets <strong>all elements</strong>. Add
+              filters above (e.g. Name, Material, Classification, Storey) to narrow it.
+            </p>
+          )}
+
+          {/* Column Selection */}
+          <div>
                 <button
                   className="flex items-center gap-1 text-xs font-medium text-muted-foreground uppercase tracking-wider w-full"
                   onClick={() => setColumnsExpanded(!columnsExpanded)}
@@ -282,8 +315,6 @@ export function ListBuilder({ providers, initial, onSave, onCancel, onExecute }:
                   </div>
                 )}
               </div>
-            </>
-          )}
         </div>
       </ScrollArea>
 
@@ -293,7 +324,7 @@ export function ListBuilder({ providers, initial, onSave, onCancel, onExecute }:
           variant="default"
           size="sm"
           onClick={handleRun}
-          disabled={selectedTypes.size === 0 || columns.length === 0}
+          disabled={columns.length === 0}
           className="text-xs h-7"
         >
           <Play className="h-3 w-3 mr-1" />
@@ -303,7 +334,7 @@ export function ListBuilder({ providers, initial, onSave, onCancel, onExecute }:
           variant="outline"
           size="sm"
           onClick={handleSave}
-          disabled={selectedTypes.size === 0 || columns.length === 0}
+          disabled={columns.length === 0}
           className="text-xs h-7"
         >
           <Save className="h-3 w-3 mr-1" />
@@ -482,5 +513,209 @@ function PickerItem({
       <span className="truncate">{label}</span>
       {selected && <span className="ml-auto text-[10px] text-muted-foreground">added</span>}
     </button>
+  );
+}
+
+// ============================================================================
+// Conditions (filters)
+// ============================================================================
+
+type ConditionSource = PropertyCondition['source'];
+
+const CONDITION_SOURCES: { source: ConditionSource; label: string }[] = [
+  { source: 'attribute', label: 'Attribute' },
+  { source: 'property', label: 'Property' },
+  { source: 'quantity', label: 'Quantity' },
+  { source: 'material', label: 'Material' },
+  { source: 'classification', label: 'Classification' },
+  { source: 'spatial', label: 'Storey' },
+];
+
+const OPERATOR_LABEL: Record<ConditionOperator, string> = {
+  equals: '=',
+  notEquals: '≠',
+  contains: 'contains',
+  gt: '>',
+  lt: '<',
+  gte: '≥',
+  lte: '≤',
+  exists: 'is set',
+};
+
+function operatorsFor(source: ConditionSource): ConditionOperator[] {
+  switch (source) {
+    case 'quantity':
+      return ['equals', 'notEquals', 'gt', 'gte', 'lt', 'lte', 'exists'];
+    case 'material':
+    case 'classification':
+      return ['contains', 'equals', 'notEquals', 'exists'];
+    default:
+      return ['equals', 'notEquals', 'contains', 'exists'];
+  }
+}
+
+function defaultConditionFor(source: ConditionSource): PropertyCondition {
+  switch (source) {
+    case 'property':
+      return { source, psetName: '', propertyName: '', operator: 'equals', value: '' };
+    case 'quantity':
+      return { source, psetName: '', propertyName: '', operator: 'gt', value: '' };
+    case 'material':
+      return { source, propertyName: 'Material', operator: 'contains', value: '' };
+    case 'classification':
+      return { source, propertyName: 'Classification', operator: 'contains', value: '' };
+    case 'spatial':
+      return { source, propertyName: 'Storey', operator: 'equals', value: '' };
+    case 'attribute':
+    default:
+      return { source: 'attribute', propertyName: 'Name', operator: 'contains', value: '' };
+  }
+}
+
+const SELECT_CLASS =
+  'h-6 rounded border border-border bg-background px-1 text-xs focus:outline-none focus:ring-1 focus:ring-ring';
+
+interface ConditionsSectionProps {
+  conditions: PropertyCondition[];
+  expanded: boolean;
+  onToggle: () => void;
+  onAdd: (condition: PropertyCondition) => void;
+  onUpdate: (idx: number, condition: PropertyCondition) => void;
+  onRemove: (idx: number) => void;
+}
+
+function ConditionsSection({
+  conditions,
+  expanded,
+  onToggle,
+  onAdd,
+  onUpdate,
+  onRemove,
+}: ConditionsSectionProps) {
+  return (
+    <div>
+      <button
+        className="flex items-center gap-1 text-xs font-medium text-muted-foreground uppercase tracking-wider w-full"
+        onClick={onToggle}
+      >
+        {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+        Filters ({conditions.length})
+      </button>
+
+      {expanded && (
+        <div className="mt-2 space-y-1">
+          {conditions.map((condition, idx) => (
+            <ConditionRow
+              key={idx}
+              condition={condition}
+              onChange={(next) => onUpdate(idx, next)}
+              onRemove={() => onRemove(idx)}
+            />
+          ))}
+          <button
+            onClick={() => onAdd(defaultConditionFor('attribute'))}
+            className="flex items-center gap-1 px-1 py-0.5 text-xs text-muted-foreground hover:text-foreground"
+          >
+            <Plus className="h-3 w-3" /> Add filter
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ConditionRow({
+  condition,
+  onChange,
+  onRemove,
+}: {
+  condition: PropertyCondition;
+  onChange: (next: PropertyCondition) => void;
+  onRemove: () => void;
+}) {
+  const ops = operatorsFor(condition.source);
+  const showValue = condition.operator !== 'exists';
+  const showSetFields = condition.source === 'property' || condition.source === 'quantity';
+
+  const valuePlaceholder =
+    condition.source === 'spatial'
+      ? 'storey name'
+      : condition.source === 'material'
+        ? 'material'
+        : condition.source === 'classification'
+          ? 'code or name'
+          : 'value';
+
+  return (
+    <div className="flex flex-wrap items-center gap-1 rounded bg-muted/50 px-2 py-1 text-xs">
+      <select
+        value={condition.source}
+        onChange={(e) => onChange(defaultConditionFor(e.target.value as ConditionSource))}
+        className={SELECT_CLASS}
+        aria-label="Filter dimension"
+      >
+        {CONDITION_SOURCES.map((s) => (
+          <option key={s.source} value={s.source}>{s.label}</option>
+        ))}
+      </select>
+
+      {condition.source === 'attribute' && (
+        <select
+          value={condition.propertyName}
+          onChange={(e) => onChange({ ...condition, propertyName: e.target.value })}
+          className={SELECT_CLASS}
+          aria-label="Attribute"
+        >
+          {ENTITY_ATTRIBUTES.map((a) => (
+            <option key={a} value={a}>{a}</option>
+          ))}
+        </select>
+      )}
+
+      {showSetFields && (
+        <>
+          <Input
+            value={condition.psetName ?? ''}
+            placeholder={condition.source === 'quantity' ? 'Qto_…' : 'Pset_…'}
+            onChange={(e) => onChange({ ...condition, psetName: e.target.value })}
+            className="h-6 w-28 text-xs"
+          />
+          <Input
+            value={condition.propertyName}
+            placeholder="name"
+            onChange={(e) => onChange({ ...condition, propertyName: e.target.value })}
+            className="h-6 w-24 text-xs"
+          />
+        </>
+      )}
+
+      <select
+        value={condition.operator}
+        onChange={(e) => onChange({ ...condition, operator: e.target.value as ConditionOperator })}
+        className={SELECT_CLASS}
+        aria-label="Operator"
+      >
+        {ops.map((op) => (
+          <option key={op} value={op}>{OPERATOR_LABEL[op]}</option>
+        ))}
+      </select>
+
+      {showValue && (
+        <Input
+          value={String(condition.value ?? '')}
+          placeholder={valuePlaceholder}
+          onChange={(e) => onChange({ ...condition, value: e.target.value })}
+          className="h-6 flex-1 min-w-[6rem] text-xs"
+        />
+      )}
+
+      <button
+        onClick={onRemove}
+        aria-label="Remove filter"
+        className="ml-auto text-muted-foreground hover:text-destructive"
+      >
+        <Trash2 className="h-3 w-3" />
+      </button>
+    </div>
   );
 }

--- a/apps/viewer/src/lib/lists/adapter.ts
+++ b/apps/viewer/src/lib/lists/adapter.ts
@@ -92,10 +92,15 @@ export function createListDataProvider(store: IfcDataStore): ListDataProvider {
 
     getAllEntityIds(): number[] {
       if (allIdsCache) return allIdsCache;
+      // Restrict "all elements" to geometry-bearing (selectable) products.
+      // The raw expressId column also holds relationships, property sets,
+      // materials, classifications and other non-element records — a
+      // class-less list should not surface those as rows.
       const ids: number[] = [];
       const col = store.entities.expressId;
       for (let i = 0; i < col.length; i++) {
-        if (col[i]) ids.push(col[i]);
+        const id = col[i];
+        if (id && store.entities.hasGeometry(id)) ids.push(id);
       }
       allIdsCache = ids;
       return ids;

--- a/apps/viewer/src/lib/lists/adapter.ts
+++ b/apps/viewer/src/lib/lists/adapter.ts
@@ -11,10 +11,30 @@
  * and Tag which are not stored during the fast initial parse.
  */
 
-import type { IfcDataStore } from '@ifc-lite/parser';
-import { extractPropertiesOnDemand, extractQuantitiesOnDemand, extractEntityAttributesOnDemand } from '@ifc-lite/parser';
+import type { IfcDataStore, MaterialInfo } from '@ifc-lite/parser';
+import {
+  extractPropertiesOnDemand,
+  extractQuantitiesOnDemand,
+  extractEntityAttributesOnDemand,
+  extractMaterialsOnDemand,
+  extractClassificationsOnDemand,
+} from '@ifc-lite/parser';
 import type { PropertySet, QuantitySet } from '@ifc-lite/data';
-import type { ListDataProvider } from '@ifc-lite/lists';
+import type { ListDataProvider, ListClassificationRef } from '@ifc-lite/lists';
+
+/** Collect every material-name string an element exposes — top-level
+ *  material plus layer / constituent / profile names and list members. */
+function materialNamesOf(info: MaterialInfo | null): string[] {
+  if (!info) return [];
+  const names: string[] = [];
+  const push = (s: string | undefined) => { if (s) names.push(s); };
+  push(info.name);
+  for (const l of info.layers ?? []) { push(l.materialName); push(l.name); }
+  for (const c of info.constituents ?? []) { push(c.materialName); push(c.name); }
+  for (const p of info.profiles ?? []) { push(p.materialName); push(p.name); }
+  for (const m of info.materials ?? []) push(m.name);
+  return names;
+}
 
 /**
  * Create a ListDataProvider backed by an IfcDataStore.
@@ -25,6 +45,10 @@ export function createListDataProvider(store: IfcDataStore): ListDataProvider {
   // These are not stored during initial parse to keep load times fast,
   // but are needed for list display. Cache avoids re-parsing per column.
   const attrCache = new Map<number, { description: string; objectType: string; tag: string }>();
+
+  // Lazily materialised list of every non-empty express id — used for
+  // class-less list targeting. Cached because the provider outlives a run.
+  let allIdsCache: number[] | null = null;
 
   function getOnDemandAttrs(id: number): { description: string; objectType: string; tag: string } {
     const cached = attrCache.get(id);
@@ -64,6 +88,37 @@ export function createListDataProvider(store: IfcDataStore): ListDataProvider {
         return extractQuantitiesOnDemand(store, entityId) as QuantitySet[];
       }
       return store.quantities?.getForEntity(entityId) ?? [];
+    },
+
+    getAllEntityIds(): number[] {
+      if (allIdsCache) return allIdsCache;
+      const ids: number[] = [];
+      const col = store.entities.expressId;
+      for (let i = 0; i < col.length; i++) {
+        if (col[i]) ids.push(col[i]);
+      }
+      allIdsCache = ids;
+      return ids;
+    },
+
+    getMaterialNames(entityId: number): string[] {
+      return materialNamesOf(extractMaterialsOnDemand(store, entityId));
+    },
+
+    getClassifications(entityId: number): ListClassificationRef[] {
+      return extractClassificationsOnDemand(store, entityId).map((c) => ({
+        system: c.system,
+        code: c.identification,
+        name: c.name,
+      }));
+    },
+
+    getStoreyName(entityId: number): string {
+      const hierarchy = store.spatialHierarchy;
+      if (!hierarchy) return '';
+      const storeyId = hierarchy.elementToStorey.get(entityId);
+      if (!storeyId) return '';
+      return store.entities.getName(storeyId) || '';
     },
   };
 }

--- a/packages/lists/src/engine.test.ts
+++ b/packages/lists/src/engine.test.ts
@@ -66,6 +66,24 @@ function createMockProvider(): ListDataProvider {
     ]],
   ]);
 
+  const materialNames = new Map<number, string[]>([
+    [1, ['Concrete C30/37']],
+    [2, ['Brick', 'Rigid Insulation']],
+    [3, ['Concrete C30/37']],
+  ]);
+
+  const classifications = new Map<number, Array<{ system?: string; code?: string; name?: string }>>([
+    [1, [{ system: 'Uniclass 2015', code: 'Pr_20_93', name: 'External wall' }]],
+    [2, []],
+    [3, [{ system: 'Uniclass 2015', code: 'Ss_30_10', name: 'Floor slab' }]],
+  ]);
+
+  const storeyNames = new Map<number, string>([
+    [1, 'Level 0'],
+    [2, 'Level 1'],
+    [3, 'Level 0'],
+  ]);
+
   return {
     getEntitiesByType: (type) => typeIndex.get(type) ?? [],
     getEntityName: (id) => entities.get(id)?.name ?? '',
@@ -76,6 +94,10 @@ function createMockProvider(): ListDataProvider {
     getEntityTypeName: (id) => entities.get(id)?.type ?? '',
     getPropertySets: (id) => propertySets.get(id) ?? [],
     getQuantitySets: (id) => quantitySets.get(id) ?? [],
+    getAllEntityIds: () => Array.from(entities.keys()),
+    getMaterialNames: (id) => materialNames.get(id) ?? [],
+    getClassifications: (id) => classifications.get(id) ?? [],
+    getStoreyName: (id) => storeyNames.get(id) ?? '',
   };
 }
 
@@ -210,6 +232,93 @@ describe('executeList', () => {
 
     const result = executeList(def, provider);
     expect(result.totalCount).toBe(3);
+  });
+
+  it('targets all elements when entityTypes is empty (no class constraint)', () => {
+    const provider = createMockProvider();
+    const def: ListDefinition = {
+      id: 'test-all',
+      name: 'Test',
+      createdAt: 0,
+      updatedAt: 0,
+      entityTypes: [],
+      conditions: [
+        { source: 'attribute', propertyName: 'Name', operator: 'contains', value: '01' },
+      ],
+      columns: [{ id: 'name', source: 'attribute', propertyName: 'Name' }],
+    };
+
+    const result = executeList(def, provider);
+    // Wall-01 and Slab-01 match across all classes.
+    expect(result.rows.map(r => r.values[0]).sort()).toEqual(['Slab-01', 'Wall-01']);
+  });
+
+  it('filters by material name (multi-valued, any-match)', () => {
+    const provider = createMockProvider();
+    const def: ListDefinition = {
+      id: 'test-mat',
+      name: 'Test',
+      createdAt: 0,
+      updatedAt: 0,
+      entityTypes: [],
+      conditions: [
+        { source: 'material', propertyName: 'Material', operator: 'contains', value: 'insulation' },
+      ],
+      columns: [{ id: 'name', source: 'attribute', propertyName: 'Name' }],
+    };
+    const result = executeList(def, provider);
+    // Only Wall-02 has an insulation layer.
+    expect(result.rows.map(r => r.values[0])).toEqual(['Wall-02']);
+  });
+
+  it('filters by classification code or name', () => {
+    const provider = createMockProvider();
+    const byCode = executeList({
+      id: 'c1', name: 'T', createdAt: 0, updatedAt: 0, entityTypes: [],
+      conditions: [{ source: 'classification', propertyName: 'Classification', operator: 'contains', value: 'Pr_20' }],
+      columns: [{ id: 'name', source: 'attribute', propertyName: 'Name' }],
+    }, provider);
+    expect(byCode.rows.map(r => r.values[0])).toEqual(['Wall-01']);
+
+    const byName = executeList({
+      id: 'c2', name: 'T', createdAt: 0, updatedAt: 0, entityTypes: [],
+      conditions: [{ source: 'classification', propertyName: 'Classification', operator: 'contains', value: 'slab' }],
+      columns: [{ id: 'name', source: 'attribute', propertyName: 'Name' }],
+    }, provider);
+    expect(byName.rows.map(r => r.values[0])).toEqual(['Slab-01']);
+  });
+
+  it('classification exists matches only classified elements', () => {
+    const provider = createMockProvider();
+    const result = executeList({
+      id: 'c3', name: 'T', createdAt: 0, updatedAt: 0, entityTypes: [],
+      conditions: [{ source: 'classification', propertyName: 'Classification', operator: 'exists', value: '' }],
+      columns: [{ id: 'name', source: 'attribute', propertyName: 'Name' }],
+    }, provider);
+    // Wall-02 has no classification.
+    expect(result.rows.map(r => r.values[0]).sort()).toEqual(['Slab-01', 'Wall-01']);
+  });
+
+  it('filters by storey (spatial source)', () => {
+    const provider = createMockProvider();
+    const result = executeList({
+      id: 'sp1', name: 'T', createdAt: 0, updatedAt: 0, entityTypes: [],
+      conditions: [{ source: 'spatial', propertyName: 'Storey', operator: 'equals', value: 'Level 0' }],
+      columns: [{ id: 'name', source: 'attribute', propertyName: 'Name' }],
+    }, provider);
+    expect(result.rows.map(r => r.values[0]).sort()).toEqual(['Slab-01', 'Wall-01']);
+  });
+
+  it('class-less targeting yields nothing when the provider cannot enumerate', () => {
+    const provider = createMockProvider();
+    // Simulate an older provider without getAllEntityIds.
+    delete (provider as { getAllEntityIds?: unknown }).getAllEntityIds;
+    const result = executeList({
+      id: 'noall', name: 'T', createdAt: 0, updatedAt: 0, entityTypes: [],
+      conditions: [],
+      columns: [{ id: 'name', source: 'attribute', propertyName: 'Name' }],
+    }, provider);
+    expect(result.totalCount).toBe(0);
   });
 
   it('sorts results when sortBy is configured', () => {

--- a/packages/lists/src/engine.ts
+++ b/packages/lists/src/engine.ts
@@ -68,13 +68,21 @@ export function executeList(
 function resolveSourceSet(definition: ListDefinition, provider: ListDataProvider): number[] {
   const { entityTypes, conditions } = definition;
 
-  // Collect entity IDs by type - gather arrays first, then flatten once
-  const chunks: number[][] = [];
-  for (const type of entityTypes) {
-    const ids = provider.getEntitiesByType(type);
-    if (ids.length > 0) chunks.push(ids);
+  let entityIds: number[];
+  if (entityTypes.length === 0) {
+    // No class constraint — target every element in the model. Requires
+    // the provider to enumerate all ids; older providers without it
+    // resolve to an empty set rather than throwing.
+    entityIds = provider.getAllEntityIds?.() ?? [];
+  } else {
+    // Collect entity IDs by type - gather arrays first, then flatten once
+    const chunks: number[][] = [];
+    for (const type of entityTypes) {
+      const ids = provider.getEntitiesByType(type);
+      if (ids.length > 0) chunks.push(ids);
+    }
+    entityIds = chunks.length === 1 ? chunks[0] : chunks.flat();
   }
-  const entityIds = chunks.length === 1 ? chunks[0] : chunks.flat();
 
   // Apply conditions as filters
   if (conditions.length === 0) {
@@ -102,6 +110,13 @@ function matchesCondition(
   condition: PropertyCondition,
   provider: ListDataProvider,
 ): boolean {
+  // Material and classification are multi-valued (an element can have many
+  // material layers or classification refs) so they use any/none semantics
+  // rather than the scalar comparison below.
+  if (condition.source === 'material' || condition.source === 'classification') {
+    return matchesMultiValuedCondition(entityId, condition, provider);
+  }
+
   const actualValue = getConditionValue(entityId, condition, provider);
 
   if (condition.operator === 'exists') {
@@ -144,9 +159,56 @@ function getConditionValue(
       return getPropertyValue(entityId, condition.psetName ?? '', condition.propertyName, provider);
     case 'quantity':
       return getQuantityValue(entityId, condition.psetName ?? '', condition.propertyName, provider);
+    case 'spatial':
+      return provider.getStoreyName?.(entityId) || null;
     default:
       return null;
   }
+}
+
+/**
+ * Match a multi-valued condition (material / classification). Positive
+ * operators match if ANY candidate value satisfies them; `notEquals`
+ * matches only if NO candidate equals the value. An element with no
+ * materials / classifications never matches (including `notEquals`),
+ * except `exists` which is a pure presence check.
+ */
+function matchesMultiValuedCondition(
+  entityId: number,
+  condition: PropertyCondition,
+  provider: ListDataProvider,
+): boolean {
+  const candidates = condition.source === 'material'
+    ? (provider.getMaterialNames?.(entityId) ?? [])
+    : classificationCandidates(provider.getClassifications?.(entityId) ?? []);
+
+  if (condition.operator === 'exists') return candidates.length > 0;
+  if (candidates.length === 0) return false;
+
+  const target = String(condition.value).toLowerCase();
+  switch (condition.operator) {
+    case 'equals':
+      return candidates.some(c => c.toLowerCase() === target);
+    case 'contains':
+      return candidates.some(c => c.toLowerCase().includes(target));
+    case 'notEquals':
+      return candidates.every(c => c.toLowerCase() !== target);
+    default:
+      // gt/lt/gte/lte have no meaning for material/classification strings.
+      return false;
+  }
+}
+
+/** Flatten classification refs into a candidate string list (code + name). */
+function classificationCandidates(
+  refs: ReadonlyArray<{ code?: string; name?: string }>,
+): string[] {
+  const out: string[] = [];
+  for (const ref of refs) {
+    if (ref.code) out.push(ref.code);
+    if (ref.name) out.push(ref.name);
+  }
+  return out;
 }
 
 // ============================================================================

--- a/packages/lists/src/index.ts
+++ b/packages/lists/src/index.ts
@@ -12,6 +12,7 @@ export type {
   ColumnDefinition,
   PropertyCondition,
   ConditionOperator,
+  ListClassificationRef,
   DiscoveredColumns,
   EntityAttribute,
 } from './types.js';

--- a/packages/lists/src/types.ts
+++ b/packages/lists/src/types.ts
@@ -53,6 +53,31 @@ export interface ListDataProvider {
   getPropertySets(expressId: number): PropertySet[];
   /** Get all quantity sets for an entity (handles on-demand extraction) */
   getQuantitySets(expressId: number): QuantitySet[];
+
+  // ── Optional accessors (added for richer list targeting / columns) ──
+  // Implementers built before these existed keep working: the engine
+  // degrades gracefully when a method is absent (no-class lists resolve
+  // to no rows; material/classification/storey conditions never match).
+
+  /**
+   * All entity express IDs in the model. Used to target a list at every
+   * element regardless of IFC class (when `entityTypes` is empty).
+   */
+  getAllEntityIds?(): number[];
+  /** Material name(s) for the element — top-level material plus any
+   *  layer / constituent / profile / list-member names. */
+  getMaterialNames?(expressId: number): string[];
+  /** Classification references associated with the element. */
+  getClassifications?(expressId: number): ListClassificationRef[];
+  /** Building-storey name the element belongs to, or '' when unplaced. */
+  getStoreyName?(expressId: number): string;
+}
+
+/** A classification reference exposed to the list engine (code + name). */
+export interface ListClassificationRef {
+  system?: string;
+  code?: string;
+  name?: string;
 }
 
 // ============================================================================
@@ -84,10 +109,18 @@ export interface ListDefinition {
 // ============================================================================
 
 export interface PropertyCondition {
-  source: 'attribute' | 'property' | 'quantity';
+  /**
+   * Where the compared value comes from:
+   * - `attribute` — a built-in attribute (Name, Class, Description, …)
+   * - `property` / `quantity` — a pset / qto value (uses `psetName`)
+   * - `material` — any of the element's material names (multi-valued)
+   * - `classification` — any classification code or name (multi-valued)
+   * - `spatial` — the element's building-storey name
+   */
+  source: 'attribute' | 'property' | 'quantity' | 'material' | 'classification' | 'spatial';
   /** Property set name (for property/quantity sources) */
   psetName?: string;
-  /** Property name within the set */
+  /** Property name within the set. Ignored for material/classification/spatial. */
   propertyName: string;
   operator: ConditionOperator;
   value: string | number | boolean;


### PR DESCRIPTION
Closes #925. Part of the #928 epic (user feedback #917 §1). Builds on the filter dimensions from #921; the `ListDataProvider` extension here is also the prerequisite for #922 (custom list columns).

## Problem
A list could only be scoped by **IFC class** (`entityTypes`) plus attribute/property/quantity conditions, and the builder *required* at least one class. Users asked to target by **name, material, classification, storey** and to build lists **not anchored to a class** (e.g. "find elements whose class is wrong by searching names").

## Change

**`@ifc-lite/lists` (engine, framework-agnostic)**
- `resolveSourceSet`: empty `entityTypes` now means **all elements**, via a new optional `ListDataProvider.getAllEntityIds()`. Providers without it degrade to no rows (no throw).
- `PropertyCondition.source` gains `'material' | 'classification' | 'spatial'`:
  - **material / classification** are multi-valued — any-match for positive ops, none-violates for `notEquals`, `exists` = presence.
  - **spatial** (storey name) routes through the existing scalar path.
- New optional provider accessors: `getMaterialNames`, `getClassifications`, `getStoreyName`.
- (Name targeting already worked via an `attribute` condition on `Name` — now reachable since class is optional.)

**viewer**
- `adapter.ts`: implements the new accessors via `extractMaterialsOnDemand` / `extractClassificationsOnDemand` / `spatialHierarchy`; `getAllEntityIds` is cached.
- `ListBuilder.tsx`: entity-type selection is now **optional** (column discovery falls back to built-in attributes); Run/Save gate on having columns only; a new **Filters** section lets users add/edit attribute/property/quantity/material/classification/storey conditions (the builder previously had *no* condition UI at all).

## Backward compatibility
- New provider methods are **optional** — the SDK (`packages/sdk`) and any other `ListDataProvider` implementer keep working unchanged.
- Persisted lists are unaffected (empty `entityTypes` is the only new shape; existing defs always have types).

## Architectural note
`@ifc-lite/lists` is a standalone package and can't import the viewer-local `FilterRule` taxonomy (#921), and relocating that type now would conflict with the open #921 PR. So the lists package's **native** condition model is extended with matching operator/source names — a thin `FilterRule → ListCondition` translator is all #927 (create-list-from-filter) will need. Full taxonomy unification can follow once #921 merges.

## Verification
- `@ifc-lite/lists` vitest: **20 pass / 0 fail**, incl. new cases for class-less targeting, material (multi-valued), classification by code/name + `exists`, storey, and graceful degradation without `getAllEntityIds`.
- `pnpm typecheck` (lists package build + viewer): **no errors in any changed file**. (Fresh-worktree `Cannot find module @ifc-lite/{wasm,clash,…}` noise is pre-existing, unrelated.)

## Follow-ups
- #922 reuses the `ListDataProvider` material/classification/storey accessors for **columns**.
- Schema-discovery dropdowns for material/classification values (currently typed inputs) and grouping (#926) are separate.