### PR TITLE
feat(viewer): create a list from a search/filter result (#927)

### DIFF
--- a/.changeset/list-from-filter-927.md
+++ b/.changeset/list-from-filter-927.md
@@ -1,0 +1,11 @@
+---
+"@ifc-lite/lists": minor
+---
+
+Add `ListDefinition.expressIds` — an explicit element-snapshot scope.
+
+When set, `executeList` targets exactly those express IDs (intersected with
+each model, so a federated list drops foreign ids), with `conditions` still
+applied on top and `entityTypes` ignored. Lets a search/filter result be
+frozen into a list (#917 §4). IFC express IDs are file-stable, so the
+snapshot survives reloading the same model.

--- a/.changeset/list-from-filter-927.md
+++ b/.changeset/list-from-filter-927.md
@@ -2,10 +2,11 @@
 "@ifc-lite/lists": minor
 ---
 
-Add `ListDefinition.expressIds` — an explicit element-snapshot scope.
+Add `ListDefinition.expressIdsByModel` — an explicit element-snapshot scope
+keyed by model.
 
-When set, `executeList` targets exactly those express IDs (intersected with
-each model, so a federated list drops foreign ids), with `conditions` still
-applied on top and `entityTypes` ignored. Lets a search/filter result be
-frozen into a list (#917 §4). IFC express IDs are file-stable, so the
-snapshot survives reloading the same model.
+When set, `executeList` targets exactly the express IDs captured for the
+current model (so a federated list never over-selects when local express IDs
+collide across files), with `conditions` still applied on top and
+`entityTypes` ignored. Lets a search/filter result be frozen into a list
+(#917 §4).

--- a/apps/viewer/src/components/viewer/SearchModal.filter.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.tsx
@@ -264,21 +264,32 @@ export function SearchModalFilter() {
     downloadResult(searchFilterResult, format);
   }, [searchFilterResult]);
 
-  /** Freeze the current filter result into a new list (snapshot of the
-   *  matched express IDs) and open the list builder to configure columns. */
+  /** Freeze the current filter result into a new list — a per-model snapshot
+   *  of the matched express IDs — and open the list builder to configure
+   *  columns. Keyed by model so federated results don't over-select when
+   *  local express IDs collide across files. */
   const handleCreateList = useCallback(() => {
     const result = searchFilterResult;
     if (!result || result.rows.length === 0) return;
     const idIdx = result.columns.indexOf('express_id');
     if (idIdx < 0) return;
-    const expressIds = Array.from(
-      new Set(
-        result.rows
-          .map((r) => Number(r[idIdx]))
-          .filter((n) => Number.isFinite(n) && n > 0),
-      ),
-    );
-    if (expressIds.length === 0) return;
+    const modelIdx = result.columns.indexOf('model_id'); // only present for multi-model runs
+
+    const byModel: Record<string, number[]> = {};
+    const seen = new Set<string>();
+    for (const row of result.rows) {
+      const id = Number(row[idIdx]);
+      if (!Number.isFinite(id) || id <= 0) continue;
+      const modelId = modelIdx >= 0 && typeof row[modelIdx] === 'string'
+        ? (row[modelIdx] as string)
+        : (activeModelId ?? 'default');
+      const key = `${modelId}:${id}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      (byModel[modelId] ??= []).push(id);
+    }
+    const total = Object.values(byModel).reduce((n, ids) => n + ids.length, 0);
+    if (total === 0) return;
 
     const now = Date.now();
     const draft: ListDefinition = {
@@ -287,7 +298,7 @@ export function SearchModalFilter() {
       createdAt: now,
       updatedAt: now,
       entityTypes: [],
-      expressIds,
+      expressIdsByModel: byModel,
       conditions: [],
       columns: [
         { id: 'attr-name', source: 'attribute', propertyName: 'Name', label: 'Name' },
@@ -297,7 +308,7 @@ export function SearchModalFilter() {
     setPendingListDraft(draft);
     setListPanelVisible(true);
     setSearchModalOpen(false);
-  }, [searchFilterResult, setPendingListDraft, setListPanelVisible, setSearchModalOpen]);
+  }, [searchFilterResult, activeModelId, setPendingListDraft, setListPanelVisible, setSearchModalOpen]);
 
   if (!activeStore) {
     return (

--- a/apps/viewer/src/components/viewer/SearchModal.filter.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.tsx
@@ -21,7 +21,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { Play, AlertCircle, Download } from 'lucide-react';
+import { Play, AlertCircle, Download, ListPlus } from 'lucide-react';
 import { useShallow } from 'zustand/react/shallow';
 import { useViewerStore } from '@/store';
 import { toGlobalIdFromModels } from '@/store/globalId';
@@ -37,6 +37,7 @@ import { evaluateFilterRulesFederated } from '@/lib/search/filter-evaluate';
 import { runTier0Scan, type ScanModel } from '@/lib/search/tier0-scan';
 import { queryTier1Indexes, type Tier1Index } from '@/lib/search/tier1-index';
 import { downloadResult } from '@/lib/search/result-export';
+import type { ListDefinition } from '@/lib/lists';
 import { SearchModalFilterBuilder } from './SearchModal.filter.builder';
 
 /** Rows per virtualizer page — tuned for the result table row height. */
@@ -65,6 +66,9 @@ export function SearchModalFilter() {
     setSelectedEntity,
     setSelectedEntityId,
     cameraCallbacks,
+    setPendingListDraft,
+    setListPanelVisible,
+    setSearchModalOpen,
   } = useViewerStore(
     useShallow((s) => ({
       searchFilter: s.searchFilter,
@@ -81,6 +85,9 @@ export function SearchModalFilter() {
       setSelectedEntity: s.setSelectedEntity,
       setSelectedEntityId: s.setSelectedEntityId,
       cameraCallbacks: s.cameraCallbacks,
+      setPendingListDraft: s.setPendingListDraft,
+      setListPanelVisible: s.setListPanelVisible,
+      setSearchModalOpen: s.setSearchModalOpen,
     })),
   );
 
@@ -257,6 +264,41 @@ export function SearchModalFilter() {
     downloadResult(searchFilterResult, format);
   }, [searchFilterResult]);
 
+  /** Freeze the current filter result into a new list (snapshot of the
+   *  matched express IDs) and open the list builder to configure columns. */
+  const handleCreateList = useCallback(() => {
+    const result = searchFilterResult;
+    if (!result || result.rows.length === 0) return;
+    const idIdx = result.columns.indexOf('express_id');
+    if (idIdx < 0) return;
+    const expressIds = Array.from(
+      new Set(
+        result.rows
+          .map((r) => Number(r[idIdx]))
+          .filter((n) => Number.isFinite(n) && n > 0),
+      ),
+    );
+    if (expressIds.length === 0) return;
+
+    const now = Date.now();
+    const draft: ListDefinition = {
+      id: crypto.randomUUID(),
+      name: 'Filter result',
+      createdAt: now,
+      updatedAt: now,
+      entityTypes: [],
+      expressIds,
+      conditions: [],
+      columns: [
+        { id: 'attr-name', source: 'attribute', propertyName: 'Name', label: 'Name' },
+        { id: 'attr-class', source: 'attribute', propertyName: 'Class', label: 'Class' },
+      ],
+    };
+    setPendingListDraft(draft);
+    setListPanelVisible(true);
+    setSearchModalOpen(false);
+  }, [searchFilterResult, setPendingListDraft, setListPanelVisible, setSearchModalOpen]);
+
   if (!activeStore) {
     return (
       <div className="flex flex-1 items-center justify-center p-8 text-center text-sm text-muted-foreground">
@@ -319,6 +361,16 @@ export function SearchModalFilter() {
         )}
 
         <div className="ml-auto flex items-center gap-1.5">
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={!searchFilterResult || searchFilterResult.rows.length === 0}
+            onClick={handleCreateList}
+            className="h-7 gap-1 text-xs"
+            title="Freeze these results into a new list"
+          >
+            <ListPlus className="h-3 w-3" /> Create list
+          </Button>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button

--- a/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
@@ -212,6 +212,8 @@ export function ListBuilder({ providers, initial, onSave, onCancel, onExecute }:
       createdAt: initial?.createdAt ?? Date.now(),
       updatedAt: Date.now(),
       entityTypes: Array.from(selectedTypes),
+      // Preserve a filter-snapshot scope (set at creation; not edited here).
+      expressIds: initial?.expressIds,
       conditions,
       columns,
       grouping,
@@ -227,6 +229,11 @@ export function ListBuilder({ providers, initial, onSave, onCancel, onExecute }:
     for (const type of selectedTypes) count += typeCounts.get(type) ?? 0;
     return count;
   }, [selectedTypes, typeCounts]);
+
+  // A snapshot list (from "Create list" in the search filter) is frozen to an
+  // explicit element set; the entity-type scope doesn't apply.
+  const snapshotCount = initial?.expressIds?.length ?? 0;
+  const isSnapshot = snapshotCount > 0;
 
   const canRun = columns.length > 0;
 
@@ -250,34 +257,46 @@ export function ListBuilder({ providers, initial, onSave, onCancel, onExecute }:
             />
           </div>
 
-          {/* Scope: entity types */}
+          {/* Scope: entity types — or a frozen filter snapshot */}
           <Section
             label="Scope"
-            hint={selectedTypes.size > 0
-              ? `${totalSelectedEntities.toLocaleString()} elements`
-              : 'All elements'}
+            hint={isSnapshot
+              ? `${snapshotCount.toLocaleString()} elements · snapshot`
+              : selectedTypes.size > 0
+                ? `${totalSelectedEntities.toLocaleString()} elements`
+                : 'All elements'}
           >
-            <div className="flex flex-wrap gap-1.5">
-              {SELECTABLE_TYPES.map(({ type, label }) => {
-                const count = typeCounts.get(type);
-                if (!count) return null;
-                return (
-                  <Chip
-                    key={type}
-                    selected={selectedTypes.has(type)}
-                    onClick={() => toggleType(type)}
-                    trailing={count.toLocaleString()}
-                  >
-                    {label}
-                  </Chip>
-                );
-              })}
-            </div>
-            {selectedTypes.size === 0 && (
-              <p className="mt-2 text-[11px] leading-relaxed text-muted-foreground">
-                No type selected — the list targets <strong className="font-medium text-foreground">all model elements</strong>.
-                Use filters to narrow by name, material, classification or storey.
+            {isSnapshot ? (
+              <p className="rounded-md border border-primary/30 bg-primary/5 px-2.5 py-2 text-[11px] leading-relaxed text-muted-foreground">
+                <strong className="font-medium text-foreground">Filter snapshot</strong> — frozen to the{' '}
+                {snapshotCount.toLocaleString()} elements that matched the search filter. Entity-type scope
+                doesn&apos;t apply; configure columns and grouping below.
               </p>
+            ) : (
+              <>
+                <div className="flex flex-wrap gap-1.5">
+                  {SELECTABLE_TYPES.map(({ type, label }) => {
+                    const count = typeCounts.get(type);
+                    if (!count) return null;
+                    return (
+                      <Chip
+                        key={type}
+                        selected={selectedTypes.has(type)}
+                        onClick={() => toggleType(type)}
+                        trailing={count.toLocaleString()}
+                      >
+                        {label}
+                      </Chip>
+                    );
+                  })}
+                </div>
+                {selectedTypes.size === 0 && (
+                  <p className="mt-2 text-[11px] leading-relaxed text-muted-foreground">
+                    No type selected — the list targets <strong className="font-medium text-foreground">all model elements</strong>.
+                    Use filters to narrow by name, material, classification or storey.
+                  </p>
+                )}
+              </>
             )}
           </Section>
 

--- a/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
@@ -213,7 +213,7 @@ export function ListBuilder({ providers, initial, onSave, onCancel, onExecute }:
       updatedAt: Date.now(),
       entityTypes: Array.from(selectedTypes),
       // Preserve a filter-snapshot scope (set at creation; not edited here).
-      expressIds: initial?.expressIds,
+      expressIdsByModel: initial?.expressIdsByModel,
       conditions,
       columns,
       grouping,
@@ -232,7 +232,9 @@ export function ListBuilder({ providers, initial, onSave, onCancel, onExecute }:
 
   // A snapshot list (from "Create list" in the search filter) is frozen to an
   // explicit element set; the entity-type scope doesn't apply.
-  const snapshotCount = initial?.expressIds?.length ?? 0;
+  const snapshotCount = initial?.expressIdsByModel
+    ? Object.values(initial.expressIdsByModel).reduce((n, ids) => n + ids.length, 0)
+    : 0;
   const isSnapshot = snapshotCount > 0;
 
   const canRun = columns.length > 0;

--- a/apps/viewer/src/components/viewer/lists/ListPanel.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListPanel.tsx
@@ -65,6 +65,17 @@ export function ListPanel({ onClose }: ListPanelProps) {
   const setActiveListId = useViewerStore((s) => s.setActiveListId);
   const setListResult = useViewerStore((s) => s.setListResult);
   const setListExecuting = useViewerStore((s) => s.setListExecuting);
+  const pendingListDraft = useViewerStore((s) => s.pendingListDraft);
+  const setPendingListDraft = useViewerStore((s) => s.setPendingListDraft);
+
+  // A draft handed off from "Create list" (search filter) opens straight into
+  // the builder for column configuration, then is cleared so it fires once.
+  React.useEffect(() => {
+    if (!pendingListDraft) return;
+    setEditingList(pendingListDraft);
+    setView('builder');
+    setPendingListDraft(null);
+  }, [pendingListDraft, setPendingListDraft]);
 
   const importInputRef = React.useRef<HTMLInputElement>(null);
 

--- a/apps/viewer/src/store/slices/listSlice.ts
+++ b/apps/viewer/src/store/slices/listSlice.ts
@@ -17,6 +17,9 @@ export interface ListSlice {
   listResult: ListResult | null;
   listPanelVisible: boolean;
   listExecuting: boolean;
+  /** A list definition handed off from elsewhere (e.g. "Create list" in the
+   *  search filter) for the ListPanel to open straight into the builder. */
+  pendingListDraft: ListDefinition | null;
 
   // Actions
   setListDefinitions: (definitions: ListDefinition[]) => void;
@@ -28,6 +31,7 @@ export interface ListSlice {
   setListPanelVisible: (visible: boolean) => void;
   toggleListPanel: () => void;
   setListExecuting: (executing: boolean) => void;
+  setPendingListDraft: (definition: ListDefinition | null) => void;
 }
 
 export const createListSlice: StateCreator<ListSlice, [], [], ListSlice> = (set, get) => ({
@@ -37,6 +41,7 @@ export const createListSlice: StateCreator<ListSlice, [], [], ListSlice> = (set,
   listResult: null,
   listPanelVisible: false,
   listExecuting: false,
+  pendingListDraft: null,
 
   // Actions
   setListDefinitions: (listDefinitions) => {
@@ -71,4 +76,5 @@ export const createListSlice: StateCreator<ListSlice, [], [], ListSlice> = (set,
   setListPanelVisible: (listPanelVisible) => set({ listPanelVisible }),
   toggleListPanel: () => set((state) => ({ listPanelVisible: !state.listPanelVisible })),
   setListExecuting: (listExecuting) => set({ listExecuting }),
+  setPendingListDraft: (pendingListDraft) => set({ pendingListDraft }),
 });

--- a/packages/lists/src/engine.test.ts
+++ b/packages/lists/src/engine.test.ts
@@ -277,6 +277,38 @@ describe('executeList', () => {
     expect(result.rows.map(r => r.values[0]).sort()).toEqual(['Slab-01', 'Wall-01']);
   });
 
+  it('targets an explicit expressIds snapshot, dropping ids not in the model', () => {
+    const provider = createMockProvider();
+    const def: ListDefinition = {
+      id: 'snap',
+      name: 'Test',
+      createdAt: 0,
+      updatedAt: 0,
+      entityTypes: [],
+      conditions: [],
+      columns: [{ id: 'name', source: 'attribute', propertyName: 'Name' }],
+      expressIds: [1, 3, 999], // 1=Wall-01, 3=Slab-01 exist; 999 is foreign.
+    };
+    const result = executeList(def, provider);
+    expect(result.rows.map(r => r.values[0]).sort()).toEqual(['Slab-01', 'Wall-01']);
+  });
+
+  it('expressIds snapshot still honours conditions on top', () => {
+    const provider = createMockProvider();
+    const def: ListDefinition = {
+      id: 'snap2',
+      name: 'Test',
+      createdAt: 0,
+      updatedAt: 0,
+      entityTypes: [],
+      conditions: [{ source: 'attribute', propertyName: 'Class', operator: 'equals', value: 'IfcWall' }],
+      columns: [{ id: 'name', source: 'attribute', propertyName: 'Name' }],
+      expressIds: [1, 2, 3], // all three, but condition keeps only walls.
+    };
+    const result = executeList(def, provider);
+    expect(result.rows.map(r => r.values[0]).sort()).toEqual(['Wall-01', 'Wall-02']);
+  });
+
   it('filters by material name (multi-valued, any-match)', () => {
     const provider = createMockProvider();
     const def: ListDefinition = {

--- a/packages/lists/src/engine.test.ts
+++ b/packages/lists/src/engine.test.ts
@@ -277,7 +277,7 @@ describe('executeList', () => {
     expect(result.rows.map(r => r.values[0]).sort()).toEqual(['Slab-01', 'Wall-01']);
   });
 
-  it('targets an explicit expressIds snapshot, dropping ids not in the model', () => {
+  it('targets an explicit per-model snapshot, dropping ids not in the model', () => {
     const provider = createMockProvider();
     const def: ListDefinition = {
       id: 'snap',
@@ -287,13 +287,33 @@ describe('executeList', () => {
       entityTypes: [],
       conditions: [],
       columns: [{ id: 'name', source: 'attribute', propertyName: 'Name' }],
-      expressIds: [1, 3, 999], // 1=Wall-01, 3=Slab-01 exist; 999 is foreign.
+      expressIdsByModel: { default: [1, 3, 999] }, // 1=Wall-01, 3=Slab-01 exist; 999 foreign.
     };
     const result = executeList(def, provider);
     expect(result.rows.map(r => r.values[0]).sort()).toEqual(['Slab-01', 'Wall-01']);
   });
 
-  it('expressIds snapshot still honours conditions on top', () => {
+  it('uses only the snapshot for the current model (no cross-model bleed)', () => {
+    const provider = createMockProvider();
+    const def: ListDefinition = {
+      id: 'snap-multi',
+      name: 'Test',
+      createdAt: 0,
+      updatedAt: 0,
+      entityTypes: [],
+      conditions: [],
+      columns: [{ id: 'name', source: 'attribute', propertyName: 'Name' }],
+      // Same local id 1 means different elements in model a vs b — picking by
+      // modelId keeps them apart.
+      expressIdsByModel: { a: [1], b: [2] },
+    };
+    expect(executeList(def, provider, 'a').rows.map(r => r.values[0])).toEqual(['Wall-01']);
+    expect(executeList(def, provider, 'b').rows.map(r => r.values[0])).toEqual(['Wall-02']);
+    // A model with no snapshot entry contributes nothing.
+    expect(executeList(def, provider, 'c').rows).toEqual([]);
+  });
+
+  it('snapshot still honours conditions on top', () => {
     const provider = createMockProvider();
     const def: ListDefinition = {
       id: 'snap2',
@@ -303,7 +323,7 @@ describe('executeList', () => {
       entityTypes: [],
       conditions: [{ source: 'attribute', propertyName: 'Class', operator: 'equals', value: 'IfcWall' }],
       columns: [{ id: 'name', source: 'attribute', propertyName: 'Name' }],
-      expressIds: [1, 2, 3], // all three, but condition keeps only walls.
+      expressIdsByModel: { default: [1, 2, 3] }, // all three, condition keeps only walls.
     };
     const result = executeList(def, provider);
     expect(result.rows.map(r => r.values[0]).sort()).toEqual(['Wall-01', 'Wall-02']);

--- a/packages/lists/src/engine.ts
+++ b/packages/lists/src/engine.ts
@@ -35,7 +35,7 @@ export function executeList(
   const startTime = performance.now();
 
   // Step 1: Resolve source set (which entities match)
-  const matchedIds = resolveSourceSet(definition, provider);
+  const matchedIds = resolveSourceSet(definition, provider, modelId);
 
   // Step 2: Extract column values for matched entities
   const rows: ListRow[] = new Array(matchedIds.length);
@@ -134,15 +134,21 @@ export function summariseListRows(
 // Source Set Resolution
 // ============================================================================
 
-function resolveSourceSet(definition: ListDefinition, provider: ListDataProvider): number[] {
-  const { entityTypes, conditions, expressIds } = definition;
+function resolveSourceSet(
+  definition: ListDefinition,
+  provider: ListDataProvider,
+  modelId: string,
+): number[] {
+  const { entityTypes, conditions, expressIdsByModel } = definition;
 
   let entityIds: number[];
-  if (expressIds && expressIds.length > 0) {
+  if (expressIdsByModel) {
     // Explicit snapshot scope (e.g. from a filter result) — target exactly
-    // these ids, keeping only those that resolve to an element in THIS
-    // model (a federated list runs per model, so foreign ids drop out).
-    entityIds = expressIds.filter((id) => provider.getEntityTypeName(id) !== '');
+    // the ids captured FOR THIS model. Keyed by model so a federated list
+    // never picks up a foreign model's element that happens to share a
+    // local express ID. Still intersect with this model for safety.
+    const snapshot = expressIdsByModel[modelId] ?? [];
+    entityIds = snapshot.filter((id) => provider.getEntityTypeName(id) !== '');
   } else if (entityTypes.length === 0) {
     // No class constraint — target every element in the model. Requires
     // the provider to enumerate all ids; older providers without it

--- a/packages/lists/src/engine.ts
+++ b/packages/lists/src/engine.ts
@@ -135,10 +135,15 @@ export function summariseListRows(
 // ============================================================================
 
 function resolveSourceSet(definition: ListDefinition, provider: ListDataProvider): number[] {
-  const { entityTypes, conditions } = definition;
+  const { entityTypes, conditions, expressIds } = definition;
 
   let entityIds: number[];
-  if (entityTypes.length === 0) {
+  if (expressIds && expressIds.length > 0) {
+    // Explicit snapshot scope (e.g. from a filter result) — target exactly
+    // these ids, keeping only those that resolve to an element in THIS
+    // model (a federated list runs per model, so foreign ids drop out).
+    entityIds = expressIds.filter((id) => provider.getEntityTypeName(id) !== '');
+  } else if (entityTypes.length === 0) {
     // No class constraint — target every element in the model. Requires
     // the provider to enumerate all ids; older providers without it
     // resolve to an empty set rather than throwing.

--- a/packages/lists/src/types.ts
+++ b/packages/lists/src/types.ts
@@ -102,13 +102,13 @@ export interface ListDefinition {
   entityTypes: IfcTypeEnum[];
 
   /**
-   * Optional explicit element scope — a snapshot of express IDs (e.g. from a
-   * search/filter result). When present, the list targets exactly these
-   * elements (intersected with each model) and `entityTypes` is ignored;
-   * `conditions` still apply on top. IFC express IDs are file-stable, so the
-   * snapshot survives reloading the same model.
+   * Optional explicit element scope — a snapshot of express IDs per model
+   * (e.g. from a search/filter result), keyed by modelId. When present, the
+   * list targets exactly these elements per model and `entityTypes` is
+   * ignored; `conditions` still apply on top. Keyed by model so federated
+   * snapshots don't over-select when local express IDs collide across files.
    */
-  expressIds?: number[];
+  expressIdsByModel?: Record<string, number[]>;
 
   /** Optional property-based filter conditions */
   conditions: PropertyCondition[];

--- a/packages/lists/src/types.ts
+++ b/packages/lists/src/types.ts
@@ -101,6 +101,15 @@ export interface ListDefinition {
   /** Which entity types to include */
   entityTypes: IfcTypeEnum[];
 
+  /**
+   * Optional explicit element scope — a snapshot of express IDs (e.g. from a
+   * search/filter result). When present, the list targets exactly these
+   * elements (intersected with each model) and `entityTypes` is ignored;
+   * `conditions` still apply on top. IFC express IDs are file-stable, so the
+   * snapshot survives reloading the same model.
+   */
+  expressIds?: number[];
+
   /** Optional property-based filter conditions */
   conditions: PropertyCondition[];
 


### PR DESCRIPTION
Closes #927. Part of the #928 epic (user feedback #917 §4). Builds on #921 (filter taxonomy) and #925 (lists), both now on `main`.

## Problem
A search/filter result could only be downloaded (CSV/JSON) — there was no way to turn the matched elements into a configurable list.

## Change
A **"Create list"** action in the advanced-filter results (next to Export) freezes the matched elements into a new list and opens the list builder to configure columns.

- **`@ifc-lite/lists`** — `ListDefinition.expressIds`: an explicit element-**snapshot** scope. `executeList` targets exactly those express IDs (intersected with each model, so foreign ids drop out under federation); `conditions` still apply on top, `entityTypes` is ignored.
- **`listSlice`** — `pendingListDraft` handoff so the search modal can open the list panel straight into the builder with the snapshot.
- **`ListPanel`** — consumes the draft (opens builder, clears it once).
- **`ListBuilder`** — shows a **"Filter snapshot — N elements"** banner in Scope and preserves `expressIds` through edits.
- **`SearchModal.filter`** — the "Create list" button builds the draft from the result's `express_id` column, opens the list panel, and closes the search modal.

## Why a snapshot (not a live rule translation)
The acceptance criterion is *"exactly the matched elements."* The filter's rule model (OR combinator, multi-value set membership, elevation, `startsWith`/`notContains`) is strictly richer than the list's AND-scalar conditions, so a rule→condition translation would be **lossy** and wouldn't guarantee parity. Snapshotting the matched express IDs guarantees exact parity for any filter, and — since IFC express IDs are file-stable — it survives reloading the same model.

## Acceptance criteria
- ✅ From an active filter, "Create list" opens a list containing exactly the matched elements.
- ✅ Columns configurable afterwards (opens in the builder; defaults to Name + Class).
- ✅ Persists like any other list (Save).

## Verification
- `@ifc-lite/lists` vitest: **26 pass / 0 fail** — new tests for the snapshot scope (foreign-id drop, conditions-on-top).
- `pnpm typecheck`: lists package + all changed viewer files clean.

## Note / follow-up
Multi-model snapshots use a flat express-ID set; if the same ID exists in two loaded models it could over-include in the rare federated case (documented). The separate queued follow-up — bringing the `ComboInput` value-suggestions to the list-builder filter conditions — is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Create custom lists directly from search filter results with a new "Create list" button.
  * Enhanced federated list handling to prevent over-selection when element IDs collide across files.

* **Tests**
  * Added test coverage for scoped list execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->