### PR TITLE
feat(viewer): value-suggestion combobox in list-builder filter conditions

### DIFF
--- a/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
@@ -39,20 +39,27 @@ import { discoverColumns, ENTITY_ATTRIBUTES } from '@ifc-lite/lists';
 
 const NO_OPTIONS: readonly string[] = [];
 
-/** Distinct model values used to suggest condition values in the chip editors. */
+/**
+ * Distinct model values used to suggest condition values in the chip editors.
+ * Storeys are intentionally NOT here — they come cheaply from the spatial
+ * index, whereas these require sampling element property/material data.
+ */
 interface ListConditionValues {
   materials: string[];
   classifications: string[];
-  storeys: string[];
   /** propValueKey(pset, prop) → distinct values. */
   propertyValues: Map<string, string[]>;
 }
 
-/** Merge per-store value discovery into one suggestion set for the conditions. */
+/**
+ * Merge per-store value discovery into one suggestion set. This is the
+ * EXPENSIVE pass (samples element property/material/classification data), so
+ * it's only run when a property/material/classification condition exists —
+ * never for storey-only filters (storeys come from `discoverFilterSchema`).
+ */
 function discoverConditionValues(stores: IfcDataStore[]): ListConditionValues {
   const materials = new Set<string>();
   const classifications = new Set<string>();
-  const storeys = new Set<string>();
   const propertyValues = new Map<string, Set<string>>();
   for (const store of stores) {
     const v = discoverFilterValues(store);
@@ -63,12 +70,11 @@ function discoverConditionValues(stores: IfcDataStore[]): ListConditionValues {
       if (!bucket) { bucket = new Set(); propertyValues.set(k, bucket); }
       for (const val of arr) bucket.add(val);
     }
-    for (const [name] of discoverFilterSchema(store).storeys) storeys.add(name);
   }
   const sort = (s: Set<string>) => Array.from(s).sort();
   const pv = new Map<string, string[]>();
   for (const [k, s] of propertyValues) pv.set(k, sort(s));
-  return { materials: sort(materials), classifications: sort(classifications), storeys: sort(storeys), propertyValues: pv };
+  return { materials: sort(materials), classifications: sort(classifications), propertyValues: pv };
 }
 
 // Building element types available for selection
@@ -152,18 +158,29 @@ export function ListBuilder({ providers, stores, initial, onSave, onCancel, onEx
   );
   const [columns, setColumns] = useState<ColumnDefinition[]>(initial?.columns ?? []);
   const [conditions, setConditions] = useState<PropertyCondition[]>(initial?.conditions ?? []);
-  // Lazily-discovered distinct values for condition suggestions. Computed the
-  // first time a condition that benefits (property / material / classification
-  // / storey) exists, then reused.
+  // Lazily-discovered distinct values for condition suggestions. This is the
+  // EXPENSIVE sampling pass, so only run it when a property / material /
+  // classification condition exists — storey-only filters never trigger it.
   const [conditionValues, setConditionValues] = useState<ListConditionValues | null>(null);
   React.useEffect(() => {
     if (conditionValues || stores.length === 0) return;
     const needs = conditions.some(
-      (c) => c.source === 'property' || c.source === 'material' || c.source === 'classification' || c.source === 'spatial',
+      (c) => c.source === 'property' || c.source === 'material' || c.source === 'classification',
     );
     if (!needs) return;
     setConditionValues(discoverConditionValues(stores));
   }, [conditions, stores, conditionValues]);
+
+  // Storey names come cheaply from the spatial index (no element sampling),
+  // so they're always available without the expensive value pass above.
+  const storeyNames = useMemo<string[]>(() => {
+    if (stores.length === 0) return [];
+    const set = new Set<string>();
+    for (const store of stores) {
+      for (const [name] of discoverFilterSchema(store).storeys) set.add(name);
+    }
+    return Array.from(set).sort();
+  }, [stores]);
   const [groupByColumnId, setGroupByColumnId] = useState<string>(initial?.grouping?.columnId ?? '');
   const [sumColumnIds, setSumColumnIds] = useState<Set<string>>(
     new Set(initial?.grouping?.sumColumnIds ?? [])
@@ -363,6 +380,7 @@ export function ListBuilder({ providers, stores, initial, onSave, onCancel, onEx
               conditions={conditions}
               discovered={discovered}
               values={conditionValues}
+              storeys={storeyNames}
               onAdd={addCondition}
               onUpdate={updateCondition}
               onRemove={removeCondition}
@@ -812,6 +830,7 @@ function ConditionsBody({
   conditions,
   discovered,
   values,
+  storeys,
   onAdd,
   onUpdate,
   onRemove,
@@ -819,6 +838,7 @@ function ConditionsBody({
   conditions: PropertyCondition[];
   discovered: DiscoveredColumns;
   values: ListConditionValues | null;
+  storeys: string[];
   onAdd: (condition: PropertyCondition) => void;
   onUpdate: (idx: number, condition: PropertyCondition) => void;
   onRemove: (idx: number) => void;
@@ -831,6 +851,7 @@ function ConditionsBody({
           condition={condition}
           discovered={discovered}
           values={values}
+          storeys={storeys}
           onChange={(next) => onUpdate(idx, next)}
           onRemove={() => onRemove(idx)}
         />
@@ -849,12 +870,14 @@ function ConditionRow({
   condition,
   discovered,
   values,
+  storeys,
   onChange,
   onRemove,
 }: {
   condition: PropertyCondition;
   discovered: DiscoveredColumns;
   values: ListConditionValues | null;
+  storeys: string[];
   onChange: (next: PropertyCondition) => void;
   onRemove: () => void;
 }) {
@@ -883,10 +906,10 @@ function ConditionRow({
         return values?.propertyValues.get(propValueKey(condition.psetName ?? '', condition.propertyName)) ?? NO_OPTIONS;
       case 'material': return values?.materials ?? NO_OPTIONS;
       case 'classification': return values?.classifications ?? NO_OPTIONS;
-      case 'spatial': return values?.storeys ?? NO_OPTIONS;
+      case 'spatial': return storeys;
       default: return NO_OPTIONS;
     }
-  }, [condition.source, condition.psetName, condition.propertyName, values]);
+  }, [condition.source, condition.psetName, condition.propertyName, values, storeys]);
 
   const valuePlaceholder =
     condition.source === 'spatial' ? 'storey name'

--- a/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
@@ -16,10 +16,17 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { Play, Plus, Trash2, ChevronDown, ChevronRight, ChevronUp, Save, Check, GripVertical } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { ComboInput } from '@/components/ui/combo-input';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 import { IfcTypeEnum } from '@ifc-lite/data';
+import type { IfcDataStore } from '@ifc-lite/parser';
+import {
+  discoverFilterValues,
+  discoverFilterSchema,
+  propValueKey,
+} from '@/lib/search/filter-schema';
 import type {
   ListDataProvider,
   ListDefinition,
@@ -29,6 +36,40 @@ import type {
   ConditionOperator,
 } from '@ifc-lite/lists';
 import { discoverColumns, ENTITY_ATTRIBUTES } from '@ifc-lite/lists';
+
+const NO_OPTIONS: readonly string[] = [];
+
+/** Distinct model values used to suggest condition values in the chip editors. */
+interface ListConditionValues {
+  materials: string[];
+  classifications: string[];
+  storeys: string[];
+  /** propValueKey(pset, prop) → distinct values. */
+  propertyValues: Map<string, string[]>;
+}
+
+/** Merge per-store value discovery into one suggestion set for the conditions. */
+function discoverConditionValues(stores: IfcDataStore[]): ListConditionValues {
+  const materials = new Set<string>();
+  const classifications = new Set<string>();
+  const storeys = new Set<string>();
+  const propertyValues = new Map<string, Set<string>>();
+  for (const store of stores) {
+    const v = discoverFilterValues(store);
+    v.materials.forEach((m) => materials.add(m));
+    v.classifications.forEach((c) => classifications.add(c));
+    for (const [k, arr] of v.propertyValues) {
+      let bucket = propertyValues.get(k);
+      if (!bucket) { bucket = new Set(); propertyValues.set(k, bucket); }
+      for (const val of arr) bucket.add(val);
+    }
+    for (const [name] of discoverFilterSchema(store).storeys) storeys.add(name);
+  }
+  const sort = (s: Set<string>) => Array.from(s).sort();
+  const pv = new Map<string, string[]>();
+  for (const [k, s] of propertyValues) pv.set(k, sort(s));
+  return { materials: sort(materials), classifications: sort(classifications), storeys: sort(storeys), propertyValues: pv };
+}
 
 // Building element types available for selection
 const SELECTABLE_TYPES: { type: IfcTypeEnum; label: string }[] = [
@@ -95,13 +136,15 @@ function mergeDiscovered(parts: DiscoveredColumns[]): DiscoveredColumns {
 
 interface ListBuilderProps {
   providers: ListDataProvider[];
+  /** Backing stores for value discovery (condition value suggestions). */
+  stores: IfcDataStore[];
   initial: ListDefinition | null;
   onSave: (definition: ListDefinition) => void;
   onCancel: () => void;
   onExecute: (definition: ListDefinition) => void;
 }
 
-export function ListBuilder({ providers, initial, onSave, onCancel, onExecute }: ListBuilderProps) {
+export function ListBuilder({ providers, stores, initial, onSave, onCancel, onExecute }: ListBuilderProps) {
   const [name, setName] = useState(initial?.name ?? '');
   const [description, setDescription] = useState(initial?.description ?? '');
   const [selectedTypes, setSelectedTypes] = useState<Set<IfcTypeEnum>>(
@@ -109,6 +152,18 @@ export function ListBuilder({ providers, initial, onSave, onCancel, onExecute }:
   );
   const [columns, setColumns] = useState<ColumnDefinition[]>(initial?.columns ?? []);
   const [conditions, setConditions] = useState<PropertyCondition[]>(initial?.conditions ?? []);
+  // Lazily-discovered distinct values for condition suggestions. Computed the
+  // first time a condition that benefits (property / material / classification
+  // / storey) exists, then reused.
+  const [conditionValues, setConditionValues] = useState<ListConditionValues | null>(null);
+  React.useEffect(() => {
+    if (conditionValues || stores.length === 0) return;
+    const needs = conditions.some(
+      (c) => c.source === 'property' || c.source === 'material' || c.source === 'classification' || c.source === 'spatial',
+    );
+    if (!needs) return;
+    setConditionValues(discoverConditionValues(stores));
+  }, [conditions, stores, conditionValues]);
   const [groupByColumnId, setGroupByColumnId] = useState<string>(initial?.grouping?.columnId ?? '');
   const [sumColumnIds, setSumColumnIds] = useState<Set<string>>(
     new Set(initial?.grouping?.sumColumnIds ?? [])
@@ -306,6 +361,8 @@ export function ListBuilder({ providers, initial, onSave, onCancel, onExecute }:
           <Section label="Filters" hint={conditions.length > 0 ? `${conditions.length}` : undefined}>
             <ConditionsBody
               conditions={conditions}
+              discovered={discovered}
+              values={conditionValues}
               onAdd={addCondition}
               onUpdate={updateCondition}
               onRemove={removeCondition}
@@ -753,11 +810,15 @@ const SELECT_CLASS =
 
 function ConditionsBody({
   conditions,
+  discovered,
+  values,
   onAdd,
   onUpdate,
   onRemove,
 }: {
   conditions: PropertyCondition[];
+  discovered: DiscoveredColumns;
+  values: ListConditionValues | null;
   onAdd: (condition: PropertyCondition) => void;
   onUpdate: (idx: number, condition: PropertyCondition) => void;
   onRemove: (idx: number) => void;
@@ -768,6 +829,8 @@ function ConditionsBody({
         <ConditionRow
           key={idx}
           condition={condition}
+          discovered={discovered}
+          values={values}
           onChange={(next) => onUpdate(idx, next)}
           onRemove={() => onRemove(idx)}
         />
@@ -784,16 +847,46 @@ function ConditionsBody({
 
 function ConditionRow({
   condition,
+  discovered,
+  values,
   onChange,
   onRemove,
 }: {
   condition: PropertyCondition;
+  discovered: DiscoveredColumns;
+  values: ListConditionValues | null;
   onChange: (next: PropertyCondition) => void;
   onRemove: () => void;
 }) {
   const ops = operatorsFor(condition.source);
   const showValue = condition.operator !== 'exists';
-  const showSetFields = condition.source === 'property' || condition.source === 'quantity';
+  const isProperty = condition.source === 'property';
+  const isQuantity = condition.source === 'quantity';
+  const showSetFields = isProperty || isQuantity;
+
+  const setNameOptions = useMemo<string[]>(() => {
+    if (isProperty) return Array.from(discovered.properties.keys()).sort();
+    if (isQuantity) return Array.from(discovered.quantities.keys()).sort();
+    return [];
+  }, [discovered, isProperty, isQuantity]);
+
+  const propNameOptions = useMemo<string[]>(() => {
+    const set = condition.psetName ?? '';
+    if (isProperty) return [...(discovered.properties.get(set) ?? [])];
+    if (isQuantity) return [...(discovered.quantities.get(set) ?? [])];
+    return [];
+  }, [discovered, condition.psetName, isProperty, isQuantity]);
+
+  const valueOptions = useMemo<readonly string[]>(() => {
+    switch (condition.source) {
+      case 'property':
+        return values?.propertyValues.get(propValueKey(condition.psetName ?? '', condition.propertyName)) ?? NO_OPTIONS;
+      case 'material': return values?.materials ?? NO_OPTIONS;
+      case 'classification': return values?.classifications ?? NO_OPTIONS;
+      case 'spatial': return values?.storeys ?? NO_OPTIONS;
+      default: return NO_OPTIONS;
+    }
+  }, [condition.source, condition.psetName, condition.propertyName, values]);
 
   const valuePlaceholder =
     condition.source === 'spatial' ? 'storey name'
@@ -829,17 +922,19 @@ function ConditionRow({
 
       {showSetFields && (
         <>
-          <Input
+          <ComboInput
             value={condition.psetName ?? ''}
-            placeholder={condition.source === 'quantity' ? 'Qto_…' : 'Pset_…'}
-            onChange={(e) => onChange({ ...condition, psetName: e.target.value })}
-            className="h-7 w-28 text-xs"
+            options={setNameOptions}
+            placeholder={isQuantity ? 'Qto_…' : 'Pset_…'}
+            className="h-7 w-32 text-xs"
+            onChange={(v) => onChange({ ...condition, psetName: v })}
           />
-          <Input
+          <ComboInput
             value={condition.propertyName}
+            options={propNameOptions}
             placeholder="name"
-            onChange={(e) => onChange({ ...condition, propertyName: e.target.value })}
-            className="h-7 w-24 text-xs"
+            className="h-7 w-28 text-xs"
+            onChange={(v) => onChange({ ...condition, propertyName: v })}
           />
         </>
       )}
@@ -856,11 +951,12 @@ function ConditionRow({
       </select>
 
       {showValue && (
-        <Input
+        <ComboInput
           value={String(condition.value ?? '')}
+          options={valueOptions}
           placeholder={valuePlaceholder}
-          onChange={(e) => onChange({ ...condition, value: e.target.value })}
-          className="h-7 flex-1 min-w-[6rem] text-xs"
+          className="h-7 w-44 text-xs"
+          onChange={(v) => onChange({ ...condition, value: v })}
         />
       )}
 

--- a/apps/viewer/src/components/viewer/lists/ListPanel.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListPanel.tsx
@@ -41,6 +41,7 @@ import {
   createListDataProvider,
 } from '@/lib/lists';
 import type { ListDefinition, ListResult, ListDataProvider } from '@/lib/lists';
+import type { IfcDataStore } from '@ifc-lite/parser';
 import { ListBuilder } from './ListBuilder';
 import { ListResultsTable } from './ListResultsTable';
 
@@ -83,21 +84,22 @@ export function ListPanel({ onClose }: ListPanelProps) {
   // arrays can never drift out of alignment (skipping a model without
   // an ifcDataStore must not shift every later model's provider index).
   const modelProviderPairs = useMemo(() => {
-    const pairs: Array<{ modelId: string; provider: ListDataProvider }> = [];
+    const pairs: Array<{ modelId: string; provider: ListDataProvider; store: IfcDataStore }> = [];
     if (models.size > 0) {
       for (const [modelId, model] of models) {
         // Skip native-metadata models — they don't have a parsed
         // IfcDataStore, so the list provider can't query them.
         if (!model.ifcDataStore) continue;
-        pairs.push({ modelId, provider: createListDataProvider(model.ifcDataStore) });
+        pairs.push({ modelId, provider: createListDataProvider(model.ifcDataStore), store: model.ifcDataStore });
       }
     } else if (ifcDataStore) {
-      pairs.push({ modelId: 'default', provider: createListDataProvider(ifcDataStore) });
+      pairs.push({ modelId: 'default', provider: createListDataProvider(ifcDataStore), store: ifcDataStore });
     }
     return pairs;
   }, [models, ifcDataStore]);
 
   const allProviders = useMemo(() => modelProviderPairs.map((p) => p.provider), [modelProviderPairs]);
+  const allStores = useMemo(() => modelProviderPairs.map((p) => p.store), [modelProviderPairs]);
 
   const hasData = allProviders.length > 0;
 
@@ -269,6 +271,7 @@ export function ListPanel({ onClose }: ListPanelProps) {
       {view === 'builder' && hasData && (
         <ListBuilder
           providers={allProviders}
+          stores={allStores}
           initial={editingList}
           onSave={handleSaveList}
           onCancel={() => setView('library')}


### PR DESCRIPTION
The promised follow-up to #931: bring the search filter's value-suggestion combobox to the **list-builder filter conditions**, which still used plain inputs.

> ⚠️ **Stacked on #935 (#927).** Base is `worktree-issue-927-filter-to-list` (both touch `ListBuilder.tsx`/`ListPanel.tsx`); GitHub auto-retargets to `main` once #935 merges.

## Change
List condition rows now use the click-to-open `ComboInput` (from #931) instead of plain `<Input>`s:
- **Pset/Qto set + property name** fields suggest from the discovered column schema.
- **Value** field suggests real model values per source — **materials**, **classification** codes/names, **storeys**, and per‑(pset, property) **property values** — reusing `discoverFilterValues` / `discoverFilterSchema`.
- Discovery is **lazy** (first time a property / material / classification / storey condition exists) and cached; **free text is always allowed**.

`ListPanel` now passes the backing `stores` to `ListBuilder` for the value discovery.

## Verification
- `pnpm typecheck`: changed viewer files clean. Viewer-only change (reuses merged #931 helpers) — no package API change, no changeset.

This closes the consistency gap the user flagged ("top-notch UX for all our added features") — search filter and list builder now suggest the same real model values.