### PR TITLE
feat(viewer): in-table grouping, aggregation & resizable list columns (#938)

### DIFF
--- a/apps/viewer/src/components/viewer/lists/ColumnHeaderMenu.tsx
+++ b/apps/viewer/src/components/viewer/lists/ColumnHeaderMenu.tsx
@@ -1,0 +1,84 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Per-column actions menu for the Lists results table header. Brings
+ * grouping / aggregation / sorting onto the table itself so the user never
+ * has to round-trip through the list settings.
+ */
+
+import { ArrowUp, ArrowDown, Group, Ungroup, Sigma, Palette, MoreVertical } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuSeparator,
+} from '@/components/ui/dropdown-menu';
+import { cn } from '@/lib/utils';
+
+interface ColumnHeaderMenuProps {
+  isNumeric: boolean;
+  isGroupedBy: boolean;
+  isSummed: boolean;
+  active: boolean;
+  onSort: (dir: 'asc' | 'desc') => void;
+  onToggleGroup: () => void;
+  onToggleSum: () => void;
+  onColorBy: () => void;
+}
+
+export function ColumnHeaderMenu({
+  isNumeric, isGroupedBy, isSummed, active,
+  onSort, onToggleGroup, onToggleSum, onColorBy,
+}: ColumnHeaderMenuProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          aria-label="Column options"
+          onClick={(e) => e.stopPropagation()}
+          className={cn(
+            'shrink-0 rounded-sm p-0.5 transition-opacity hover:text-foreground',
+            active
+              ? 'text-primary opacity-100'
+              : 'text-muted-foreground opacity-0 group-hover/col:opacity-100 data-[state=open]:opacity-100',
+          )}
+        >
+          <MoreVertical className="h-3 w-3" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-52">
+        <DropdownMenuItem className="gap-2 text-xs" onClick={() => onSort('asc')}>
+          <ArrowUp className="h-3.5 w-3.5" /> Sort ascending
+        </DropdownMenuItem>
+        <DropdownMenuItem className="gap-2 text-xs" onClick={() => onSort('desc')}>
+          <ArrowDown className="h-3.5 w-3.5" /> Sort descending
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem className="gap-2 text-xs" onClick={onToggleGroup}>
+          {isGroupedBy
+            ? (<><Ungroup className="h-3.5 w-3.5" /> Remove grouping</>)
+            : (<><Group className="h-3.5 w-3.5" /> Group by this column</>)}
+        </DropdownMenuItem>
+        <DropdownMenuCheckboxItem
+          className="text-xs"
+          checked={isSummed}
+          disabled={!isNumeric}
+          onCheckedChange={onToggleSum}
+        >
+          <span className="flex items-center gap-2">
+            <Sigma className="h-3.5 w-3.5" />
+            {isNumeric ? 'Sum / total this column' : 'Sum (numeric only)'}
+          </span>
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem className="gap-2 text-xs" onClick={onColorBy}>
+          <Palette className="h-3.5 w-3.5" /> Colour by this column
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
@@ -271,11 +271,11 @@ export function ListBuilder({ providers, stores, initial, onSave, onCancel, onEx
 
   const buildDefinition = useCallback((): ListDefinition => {
     const groupValid = groupByColumnId && columns.some(c => c.id === groupByColumnId);
-    const grouping = groupValid
-      ? {
-          columnId: groupByColumnId,
-          sumColumnIds: columns.filter(c => sumColumnIds.has(c.id)).map(c => c.id),
-        }
+    const sumCols = columns.filter(c => sumColumnIds.has(c.id)).map(c => c.id);
+    // Keep grouping when there's a valid group column OR any sum column — sums
+    // alone still produce grand totals, and may have been set from the table.
+    const grouping = (groupValid || sumCols.length > 0)
+      ? { columnId: groupValid ? groupByColumnId : '', sumColumnIds: sumCols }
       : undefined;
     return {
       id: initial?.id ?? crypto.randomUUID(),

--- a/apps/viewer/src/components/viewer/lists/ListGroupingBar.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListGroupingBar.tsx
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Status / control strip above the results table. Shows the active grouping
+ * and sum columns as removable chips, plus expand/collapse and live totals —
+ * the connective tissue between the table and the list definition.
+ */
+
+import { Group, Sigma, X, ChevronsDownUp, ChevronsUpDown } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface ListGroupingBarProps {
+  groupLabel: string | null;
+  sums: { id: string; label: string }[];
+  groupCount: number;
+  count: number;
+  allExpanded: boolean;
+  onClearGroup: () => void;
+  onRemoveSum: (id: string) => void;
+  onToggleExpandAll: () => void;
+}
+
+function Chip({ icon, children, onRemove }: { icon: React.ReactNode; children: React.ReactNode; onRemove: () => void }) {
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full border border-primary/30 bg-primary/10 py-0.5 pl-2 pr-1 text-[11px] font-medium text-foreground">
+      {icon}
+      <span className="max-w-[12rem] truncate">{children}</span>
+      <button
+        onClick={onRemove}
+        className="ml-0.5 rounded-full p-0.5 text-muted-foreground hover:bg-primary/20 hover:text-foreground"
+        aria-label="Remove"
+      >
+        <X className="h-3 w-3" />
+      </button>
+    </span>
+  );
+}
+
+export function ListGroupingBar({
+  groupLabel, sums, groupCount, count, allExpanded,
+  onClearGroup, onRemoveSum, onToggleExpandAll,
+}: ListGroupingBarProps) {
+  const grouped = groupLabel !== null;
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 border-b bg-muted/30 px-3 py-1.5 text-xs">
+      {grouped && (
+        <button
+          onClick={onToggleExpandAll}
+          className="mr-0.5 inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] text-muted-foreground hover:bg-muted hover:text-foreground"
+          title={allExpanded ? 'Collapse all groups' : 'Expand all groups'}
+        >
+          {allExpanded ? <ChevronsDownUp className="h-3.5 w-3.5" /> : <ChevronsUpDown className="h-3.5 w-3.5" />}
+        </button>
+      )}
+
+      {grouped
+        ? <Chip icon={<Group className="h-3 w-3 text-primary" />} onRemove={onClearGroup}>Grouped by {groupLabel}</Chip>
+        : <span className="text-muted-foreground">No grouping — use a column&apos;s <span className="font-medium text-foreground">⋮</span> menu to group or sum</span>}
+
+      {sums.map((s) => (
+        <Chip key={s.id} icon={<Sigma className="h-3 w-3 text-primary" />} onRemove={() => onRemoveSum(s.id)}>{s.label}</Chip>
+      ))}
+
+      <span className={cn('ml-auto whitespace-nowrap font-medium text-muted-foreground')}>
+        {grouped && <>{groupCount.toLocaleString()} group{groupCount === 1 ? '' : 's'} · </>}
+        {count.toLocaleString()} element{count === 1 ? '' : 's'}
+      </span>
+    </div>
+  );
+}

--- a/apps/viewer/src/components/viewer/lists/ListPanel.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListPanel.tsx
@@ -40,7 +40,7 @@ import {
   exportListDefinition,
   createListDataProvider,
 } from '@/lib/lists';
-import type { ListDefinition, ListResult, ListDataProvider } from '@/lib/lists';
+import type { ListDefinition, ListResult, ListDataProvider, ListGrouping } from '@/lib/lists';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import { ListBuilder } from './ListBuilder';
 import { ListResultsTable } from './ListResultsTable';
@@ -184,6 +184,24 @@ export function ListPanel({ onClose }: ListPanelProps) {
     }
   }, [editingList]);
 
+  // Grouping/summing changed directly from the results table: update the
+  // executed definition (so Settings reflects it), persist if it's saved, and
+  // re-derive groups/summary over the current rows for a consistent result.
+  const handleGroupingFromTable = useCallback((grouping: ListGrouping | undefined) => {
+    const def = editingList;
+    if (!def) return;
+    const next: ListDefinition = { ...def, grouping };
+    setEditingList(next);
+    if (listDefinitions.some((d) => d.id === def.id)) {
+      updateListDefinition(def.id, { grouping });
+    }
+    const current = useViewerStore.getState().listResult;
+    if (current) {
+      const summ = summariseListRows(next, current.rows);
+      setListResult({ ...current, groups: summ.groups, summary: summ.summary });
+    }
+  }, [editingList, listDefinitions, updateListDefinition, setListResult]);
+
   const handleImport = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
@@ -280,7 +298,11 @@ export function ListPanel({ onClose }: ListPanelProps) {
       )}
 
       {view === 'results' && listResult && (
-        <ListResultsTable result={listResult} />
+        <ListResultsTable
+          result={listResult}
+          grouping={editingList?.grouping}
+          onGroupingChange={handleGroupingFromTable}
+        />
       )}
 
       {/* Hidden import input */}

--- a/apps/viewer/src/components/viewer/lists/ListResultsTable.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListResultsTable.tsx
@@ -330,7 +330,7 @@ export function ListResultsTable({ result, grouping, onGroupingChange }: ListRes
                             <span className="ml-1 shrink-0 rounded-full bg-foreground/10 px-1.5 text-[10px] tabular-nums text-muted-foreground">{item.count.toLocaleString()}</span>
                           </>
                         )}
-                        {colIdx !== 0 && sumColumnIds.includes(col.id) && (
+                        {sumColumnIds.includes(col.id) && (
                           <span className="ml-auto font-mono tabular-nums">{formatCellValue(item.sums[col.id])}</span>
                         )}
                       </div>
@@ -369,7 +369,7 @@ export function ListResultsTable({ result, grouping, onGroupingChange }: ListRes
               {columns.map((col, colIdx) => (
                 <div key={col.id} className="flex items-center border-r border-border/30 px-2 py-1 text-xs font-semibold shrink-0" style={{ width: columnWidths[colIdx] }}>
                   {colIdx === 0 && <span className="text-muted-foreground">Total · {totals.count.toLocaleString()}</span>}
-                  {colIdx !== 0 && sumColumnIds.includes(col.id) && (
+                  {sumColumnIds.includes(col.id) && (
                     <span className="ml-auto font-mono tabular-nums text-foreground">{formatCellValue(totals.sums[col.id])}</span>
                   )}
                 </div>

--- a/apps/viewer/src/components/viewer/lists/ListResultsTable.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListResultsTable.tsx
@@ -3,46 +3,60 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * ListResultsTable - Virtualized table displaying list execution results
+ * ListResultsTable — virtualized results grid with in-table grouping &
+ * aggregation. The column header is the control surface (sort · group · sum
+ * · colour) and every action writes back to the ListDefinition, so the table
+ * and the list settings stay in sync. Columns are drag-resizable.
  *
- * PERF: Uses @tanstack/react-virtual for efficient rendering of large result sets.
- * Only renders visible rows, supports 100K+ rows smoothly.
- * Clicking a row selects the entity in the 3D viewer.
+ * PERF: @tanstack/react-virtual renders only visible items (group headers +
+ * rows), so 100K+ rows stay smooth.
  */
 
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { ArrowUp, ArrowDown, Search, Palette, Eye, EyeOff, Download } from 'lucide-react';
+import { ArrowUp, ArrowDown, Search, Eye, EyeOff, Download, ChevronRight, ChevronDown } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useViewerStore } from '@/store';
 import { getVisibleBasketEntityRefsFromStore } from '@/store/basketVisibleSet';
-import type { ListResult, ListRow, CellValue, ColumnDefinition } from '@ifc-lite/lists';
+import type { ListResult, ListRow, ColumnDefinition, ListGrouping } from '@ifc-lite/lists';
 import { listResultToCSV } from '@ifc-lite/lists';
 import { cn } from '@/lib/utils';
 import { columnToAutoColor } from '@/lib/lists/columnToAutoColor';
 import { AUTO_COLOR_FROM_LIST_ID } from '@/store/slices/lensSlice';
+import { ColumnHeaderMenu } from './ColumnHeaderMenu';
+import { ListGroupingBar } from './ListGroupingBar';
+import {
+  formatCellValue, compareCells, detectNumericColumns, autoColumnWidth,
+  buildGroupedView, flatTotals, type DisplayItem, type Totals,
+} from './list-table-utils';
 
 interface ListResultsTableProps {
   result: ListResult;
+  /** Active grouping from the executed definition (table ↔ settings sync). */
+  grouping?: ListGrouping;
+  /** Persist a grouping change made from the table back to the definition. */
+  onGroupingChange?: (grouping: ListGrouping | undefined) => void;
 }
 
-export function ListResultsTable({ result }: ListResultsTableProps) {
+export function ListResultsTable({ result, grouping, onGroupingChange }: ListResultsTableProps) {
   const parentRef = useRef<HTMLDivElement>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [sortCol, setSortCol] = useState<number | null>(null);
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
   const [filterByVisibility, setFilterByVisibility] = useState(true);
+  const [colorByColIdx, setColorByColIdx] = useState<number | null>(null);
+  const [widthOverrides, setWidthOverrides] = useState<Record<string, number>>({});
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
 
   const setSelectedEntityId = useViewerStore((s) => s.setSelectedEntityId);
   const setSelectedEntity = useViewerStore((s) => s.setSelectedEntity);
   const selectedEntityId = useViewerStore((s) => s.selectedEntityId);
   const activateAutoColorFromColumn = useViewerStore((s) => s.activateAutoColorFromColumn);
   const activeLensId = useViewerStore((s) => s.activeLensId);
-  const [colorByColIdx, setColorByColIdx] = useState<number | null>(null);
 
-  // Subscribe to visibility state so we re-filter when 3D visibility changes
+  // Visibility state — re-filter when 3D visibility changes.
   const hiddenEntities = useViewerStore((s) => s.hiddenEntities);
   const isolatedEntities = useViewerStore((s) => s.isolatedEntities);
   const classFilter = useViewerStore((s) => s.classFilter);
@@ -55,116 +69,156 @@ export function ListResultsTable({ result }: ListResultsTableProps) {
   const activeBasketViewId = useViewerStore((s) => s.activeBasketViewId);
   const geometryResult = useViewerStore((s) => s.geometryResult);
 
-  // Filter rows by 3D visibility
+  const columns = result.columns;
+  const numericCols = useMemo(() => detectNumericColumns(columns, result.rows), [columns, result.rows]);
+
   const visibilityFilteredRows = useMemo(() => {
     if (!filterByVisibility) return result.rows;
-
-    const visibleRefs = getVisibleBasketEntityRefsFromStore();
     const visibleSet = new Set<string>();
-    for (const ref of visibleRefs) {
-      visibleSet.add(`${ref.modelId}:${ref.expressId}`);
-    }
-
-    return result.rows.filter(row => {
-      // List uses 'default' for single-model, visibility uses 'legacy'
+    for (const ref of getVisibleBasketEntityRefsFromStore()) visibleSet.add(`${ref.modelId}:${ref.expressId}`);
+    return result.rows.filter((row) => {
       const modelId = row.modelId === 'default' ? 'legacy' : row.modelId;
       return visibleSet.has(`${modelId}:${row.entityId}`);
     });
   }, [
-    result.rows, filterByVisibility,
-    hiddenEntities, isolatedEntities, classFilter, lensHiddenIds,
-    selectedStoreys, typeVisibility, hiddenEntitiesByModel,
-    isolatedEntitiesByModel, models, activeBasketViewId, geometryResult,
+    result.rows, filterByVisibility, hiddenEntities, isolatedEntities, classFilter, lensHiddenIds,
+    selectedStoreys, typeVisibility, hiddenEntitiesByModel, isolatedEntitiesByModel, models,
+    activeBasketViewId, geometryResult,
   ]);
 
-  // Filter rows by search query
   const filteredRows = useMemo(() => {
     if (!searchQuery) return visibilityFilteredRows;
     const q = searchQuery.toLowerCase();
-    return visibilityFilteredRows.filter(row =>
-      row.values.some(v => v !== null && String(v).toLowerCase().includes(q))
-    );
+    return visibilityFilteredRows.filter((row) =>
+      row.values.some((v) => v !== null && String(v).toLowerCase().includes(q)));
   }, [visibilityFilteredRows, searchQuery]);
 
-  // Sort rows
   const sortedRows = useMemo(() => {
     if (sortCol === null) return filteredRows;
-    const sorted = [...filteredRows];
-    sorted.sort((a, b) => {
-      const va = a.values[sortCol];
-      const vb = b.values[sortCol];
-      return compareCells(va, vb) * (sortDir === 'asc' ? 1 : -1);
-    });
-    return sorted;
+    return [...filteredRows].sort((a, b) =>
+      compareCells(a.values[sortCol], b.values[sortCol]) * (sortDir === 'asc' ? 1 : -1));
   }, [filteredRows, sortCol, sortDir]);
 
-  const handleHeaderClick = useCallback((colIndex: number) => {
-    if (sortCol === colIndex) {
-      setSortDir(prev => prev === 'asc' ? 'desc' : 'asc');
-    } else {
-      setSortCol(colIndex);
-      setSortDir('asc');
+  // ── Grouping / aggregation derived from the definition ──
+  const groupByColumnId = grouping?.columnId ?? '';
+  const sumColumnIds = useMemo(() => grouping?.sumColumnIds ?? [], [grouping]);
+  const isGrouped = groupByColumnId !== '' && columns.some((c) => c.id === groupByColumnId);
+  const groupColLabel = useMemo(() => {
+    const c = columns.find((c) => c.id === groupByColumnId);
+    return c ? (c.label ?? c.propertyName) : null;
+  }, [columns, groupByColumnId]);
+
+  const { items, groupCount, totals, groupKeys } = useMemo<{
+    items: DisplayItem[]; groupCount: number; totals: Totals; groupKeys: string[];
+  }>(() => {
+    if (isGrouped) {
+      const view = buildGroupedView(sortedRows, columns, { columnId: groupByColumnId, sumColumnIds }, expandedGroups);
+      return {
+        items: view.items, groupCount: view.groupCount, totals: view.totals,
+        groupKeys: view.items.filter((i) => i.kind === 'group').map((i) => (i as { key: string }).key),
+      };
     }
-  }, [sortCol]);
-
-  const handleColorByColumn = useCallback((col: ColumnDefinition, colIdx: number) => {
-    const spec = columnToAutoColor(col);
-    const label = col.label ?? col.propertyName;
-    activateAutoColorFromColumn(spec, label);
-    setColorByColIdx(colIdx);
-  }, [activateAutoColorFromColumn]);
-
-  const handleExportCSV = useCallback(() => {
-    const exportResult: ListResult = {
-      columns: result.columns,
-      rows: sortedRows,
-      totalCount: sortedRows.length,
-      executionTime: result.executionTime,
+    return {
+      items: sortedRows.map((row): DisplayItem => ({ kind: 'row', row })),
+      groupCount: 0,
+      totals: flatTotals(sortedRows, columns, sumColumnIds),
+      groupKeys: [],
     };
-    const csv = listResultToCSV(exportResult);
-    const blob = new Blob([csv], { type: 'text/csv' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'list-export.csv';
-    a.click();
-    setTimeout(() => URL.revokeObjectURL(url), 1000);
-  }, [result.columns, result.executionTime, sortedRows]);
+  }, [isGrouped, sortedRows, columns, groupByColumnId, sumColumnIds, expandedGroups]);
 
-  const handleRowClick = useCallback((row: ListRow) => {
-    setSelectedEntity({ modelId: row.modelId, expressId: row.entityId });
-    // For single-model, selectedEntityId is the expressId
-    // For multi-model, we'd need the global ID, but we set expressId for now
-    setSelectedEntityId(row.entityId);
-  }, [setSelectedEntity, setSelectedEntityId]);
-
-  // Column widths
-  const columnWidths = useMemo(() => {
-    return result.columns.map(col => {
-      const label = col.label ?? col.propertyName;
-      // Estimate width: min 80px, max 250px, based on header + content
-      return Math.max(80, Math.min(250, label.length * 8 + 40));
-    });
-  }, [result.columns]);
-
+  const columnWidths = useMemo(
+    () => columns.map((c, i) => widthOverrides[c.id] ?? autoColumnWidth(c.label ?? c.propertyName, result.rows, i)),
+    [columns, widthOverrides, result.rows]);
   const totalWidth = useMemo(() => columnWidths.reduce((a, b) => a + b, 0), [columnWidths]);
 
   const virtualizer = useVirtualizer({
-    count: sortedRows.length,
+    count: items.length,
     getScrollElement: () => parentRef.current,
-    estimateSize: () => 28,
-    overscan: 20,
+    estimateSize: (i) => (items[i]?.kind === 'group' ? 30 : 28),
+    overscan: 18,
+    getItemKey: (i) => {
+      const it = items[i];
+      if (it?.kind === 'group') return `g:${it.key}`;
+      const r = (it as { row: ListRow }).row;
+      return `r:${r.modelId}:${r.entityId}:${i}`;
+    },
   });
+
+  // ── Handlers ──
+  const handleHeaderClick = useCallback((colIndex: number) => {
+    setSortCol((prev) => {
+      if (prev === colIndex) { setSortDir((d) => (d === 'asc' ? 'desc' : 'asc')); return prev; }
+      setSortDir('asc'); return colIndex;
+    });
+  }, []);
+
+  const handleColorByColumn = useCallback((col: ColumnDefinition, colIdx: number) => {
+    activateAutoColorFromColumn(columnToAutoColor(col), col.label ?? col.propertyName);
+    setColorByColIdx(colIdx);
+  }, [activateAutoColorFromColumn]);
+
+  const toggleGroupBy = useCallback((colId: string) => {
+    if (!onGroupingChange) return;
+    if (groupByColumnId === colId) onGroupingChange(sumColumnIds.length ? { columnId: '', sumColumnIds } : undefined);
+    else onGroupingChange({ columnId: colId, sumColumnIds });
+  }, [onGroupingChange, groupByColumnId, sumColumnIds]);
+
+  const toggleSum = useCallback((colId: string) => {
+    if (!onGroupingChange) return;
+    const next = sumColumnIds.includes(colId) ? sumColumnIds.filter((x) => x !== colId) : [...sumColumnIds, colId];
+    onGroupingChange((groupByColumnId || next.length) ? { columnId: groupByColumnId, sumColumnIds: next } : undefined);
+  }, [onGroupingChange, groupByColumnId, sumColumnIds]);
+
+  const toggleGroupExpand = useCallback((key: string) => {
+    setExpandedGroups((prev) => { const n = new Set(prev); if (n.has(key)) n.delete(key); else n.add(key); return n; });
+  }, []);
+  const allExpanded = groupKeys.length > 0 && groupKeys.every((k) => expandedGroups.has(k));
+  const toggleExpandAll = useCallback(() => {
+    setExpandedGroups(allExpanded ? new Set() : new Set(groupKeys));
+  }, [allExpanded, groupKeys]);
+
+  const startResize = useCallback((e: React.MouseEvent, colId: string, colIdx: number) => {
+    e.preventDefault(); e.stopPropagation();
+    const startX = e.clientX;
+    const startWidth = columnWidths[colIdx];
+    const onMove = (ev: MouseEvent) => setWidthOverrides((p) => ({ ...p, [colId]: Math.max(56, startWidth + (ev.clientX - startX)) }));
+    const onUp = () => {
+      window.removeEventListener('mousemove', onMove); window.removeEventListener('mouseup', onUp);
+      document.body.style.cursor = ''; document.body.style.userSelect = '';
+    };
+    window.addEventListener('mousemove', onMove); window.addEventListener('mouseup', onUp);
+    document.body.style.cursor = 'col-resize'; document.body.style.userSelect = 'none';
+  }, [columnWidths]);
+
+  const handleExportCSV = useCallback(() => {
+    const csv = listResultToCSV({ columns, rows: sortedRows, totalCount: sortedRows.length, executionTime: result.executionTime });
+    const url = URL.createObjectURL(new Blob([csv], { type: 'text/csv' }));
+    const a = document.createElement('a'); a.href = url; a.download = 'list-export.csv'; a.click();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }, [columns, result.executionTime, sortedRows]);
+
+  const handleRowClick = useCallback((row: ListRow) => {
+    setSelectedEntity({ modelId: row.modelId, expressId: row.entityId });
+    setSelectedEntityId(row.entityId);
+  }, [setSelectedEntity, setSelectedEntityId]);
+
+  const sumChips = useMemo(
+    () => sumColumnIds.map((id) => {
+      const c = columns.find((c) => c.id === id);
+      return { id, label: c ? (c.label ?? c.propertyName) : id };
+    }),
+    [sumColumnIds, columns]);
+  const showSumRow = sumColumnIds.length > 0;
 
   return (
     <div className="flex-1 flex flex-col min-h-0">
-      {/* Search bar */}
+      {/* Search / actions */}
       <div className="flex items-center gap-2 px-3 py-1.5 border-b">
         <Search className="h-3.5 w-3.5 text-muted-foreground" />
         <Input
           placeholder="Filter results..."
           value={searchQuery}
-          onChange={e => setSearchQuery(e.target.value)}
+          onChange={(e) => setSearchQuery(e.target.value)}
           className="h-7 text-xs border-0 shadow-none focus-visible:ring-0 px-0"
         />
         <span className="text-xs text-muted-foreground whitespace-nowrap">
@@ -172,30 +226,15 @@ export function ListResultsTable({ result }: ListResultsTableProps) {
         </span>
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              className={cn(
-                'h-6 w-6 shrink-0',
-                filterByVisibility && 'text-primary',
-              )}
-              onClick={() => setFilterByVisibility(prev => !prev)}
-            >
+            <Button variant="ghost" size="icon-sm" className={cn('h-6 w-6 shrink-0', filterByVisibility && 'text-primary')} onClick={() => setFilterByVisibility((p) => !p)}>
               {filterByVisibility ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}
             </Button>
           </TooltipTrigger>
-          <TooltipContent>
-            {filterByVisibility ? 'Showing visible objects only' : 'Showing all objects'}
-          </TooltipContent>
+          <TooltipContent>{filterByVisibility ? 'Showing visible objects only' : 'Showing all objects'}</TooltipContent>
         </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              className="h-6 w-6 shrink-0"
-              onClick={handleExportCSV}
-            >
+            <Button variant="ghost" size="icon-sm" className="h-6 w-6 shrink-0" onClick={handleExportCSV}>
               <Download className="h-3.5 w-3.5" />
             </Button>
           </TooltipTrigger>
@@ -203,87 +242,116 @@ export function ListResultsTable({ result }: ListResultsTableProps) {
         </Tooltip>
       </div>
 
-      {/* Grouping & totals summary */}
-      {result.groups && result.summary && (
-        <GroupSummaryPanel result={result} />
+      {/* Grouping / totals control strip */}
+      {(isGrouped || showSumRow) && onGroupingChange && (
+        <ListGroupingBar
+          groupLabel={isGrouped ? groupColLabel : null}
+          sums={sumChips}
+          groupCount={groupCount}
+          count={totals.count}
+          allExpanded={allExpanded}
+          onClearGroup={() => onGroupingChange(sumColumnIds.length ? { columnId: '', sumColumnIds } : undefined)}
+          onRemoveSum={(id) => toggleSum(id)}
+          onToggleExpandAll={toggleExpandAll}
+        />
       )}
 
       {/* Table */}
       <div ref={parentRef} className="flex-1 overflow-auto min-h-0">
         <div style={{ minWidth: totalWidth }}>
           {/* Header */}
-          <div className="flex sticky top-0 bg-muted/80 backdrop-blur-sm border-b z-10">
-            {result.columns.map((col, colIdx) => {
-              const isColoredCol = activeLensId === AUTO_COLOR_FROM_LIST_ID && colorByColIdx === colIdx;
+          <div className="flex sticky top-0 z-10 bg-muted/80 backdrop-blur-sm border-b">
+            {columns.map((col, colIdx) => {
+              const colored = activeLensId === AUTO_COLOR_FROM_LIST_ID && colorByColIdx === colIdx;
+              const groupedBy = groupByColumnId === col.id;
+              const summed = sumColumnIds.includes(col.id);
               return (
                 <div
                   key={col.id}
                   className={cn(
-                    'flex items-center gap-0.5 px-2 py-1.5 text-xs font-medium text-muted-foreground border-r border-border/50 shrink-0 group/col',
-                    isColoredCol && 'bg-primary/10',
+                    'group/col relative flex items-center gap-0.5 border-r border-border/50 px-2 py-1.5 text-xs font-medium text-muted-foreground shrink-0',
+                    colored && 'bg-primary/10',
+                    (groupedBy || summed) && 'text-foreground',
                   )}
                   style={{ width: columnWidths[colIdx] }}
                 >
-                  <button
-                    className="flex items-center gap-1 flex-1 min-w-0 hover:text-foreground"
-                    onClick={() => handleHeaderClick(colIdx)}
-                  >
-                    <span className="truncate">
-                      {col.label ?? col.propertyName}
-                    </span>
-                    {sortCol === colIdx && (
-                      sortDir === 'asc'
-                        ? <ArrowUp className="h-3 w-3 shrink-0" />
-                        : <ArrowDown className="h-3 w-3 shrink-0" />
-                    )}
+                  <button className="flex min-w-0 flex-1 items-center gap-1 hover:text-foreground" onClick={() => handleHeaderClick(colIdx)}>
+                    {groupedBy && <ChevronDown className="h-3 w-3 shrink-0 text-primary" aria-label="grouped" />}
+                    <span className="truncate">{col.label ?? col.propertyName}</span>
+                    {summed && <span className="text-primary">Σ</span>}
+                    {sortCol === colIdx && (sortDir === 'asc' ? <ArrowUp className="h-3 w-3 shrink-0" /> : <ArrowDown className="h-3 w-3 shrink-0" />)}
                   </button>
-                  <button
-                    className={cn(
-                      'shrink-0 p-0.5 rounded-sm transition-opacity',
-                      isColoredCol
-                        ? 'text-primary opacity-100'
-                        : 'opacity-0 group-hover/col:opacity-100 text-muted-foreground hover:text-primary',
-                    )}
-                    onClick={(e) => { e.stopPropagation(); handleColorByColumn(col, colIdx); }}
-                    title={`Color by ${col.label ?? col.propertyName}`}
-                  >
-                    <Palette className="h-3 w-3" />
-                  </button>
+                  {onGroupingChange && (
+                    <ColumnHeaderMenu
+                      isNumeric={numericCols[colIdx]}
+                      isGroupedBy={groupedBy}
+                      isSummed={summed}
+                      active={groupedBy || summed || colored}
+                      onSort={(dir) => { setSortCol(colIdx); setSortDir(dir); }}
+                      onToggleGroup={() => toggleGroupBy(col.id)}
+                      onToggleSum={() => toggleSum(col.id)}
+                      onColorBy={() => handleColorByColumn(col, colIdx)}
+                    />
+                  )}
+                  <div
+                    onMouseDown={(e) => startResize(e, col.id, colIdx)}
+                    onClick={(e) => e.stopPropagation()}
+                    onDoubleClick={() => setWidthOverrides((p) => { const n = { ...p }; delete n[col.id]; return n; })}
+                    className="absolute right-0 top-0 h-full w-1.5 cursor-col-resize hover:bg-primary/40"
+                    title="Drag to resize · double-click to auto-fit"
+                  />
                 </div>
               );
             })}
           </div>
 
-          {/* Virtualized rows */}
-          <div
-            style={{
-              height: `${virtualizer.getTotalSize()}px`,
-              width: '100%',
-              position: 'relative',
-            }}
-          >
-            {virtualizer.getVirtualItems().map(virtualRow => {
-              const row = sortedRows[virtualRow.index];
-              const isSelected = row.entityId === selectedEntityId;
+          {/* Virtualized rows / group headers */}
+          <div style={{ height: `${virtualizer.getTotalSize()}px`, width: '100%', position: 'relative' }}>
+            {virtualizer.getVirtualItems().map((vRow) => {
+              const item = items[vRow.index];
+              if (!item) return null;
+              const transform = `translateY(${vRow.start}px)`;
 
+              if (item.kind === 'group') {
+                const expanded = expandedGroups.has(item.key);
+                return (
+                  <div
+                    key={vRow.key}
+                    className="absolute left-0 top-0 flex w-full cursor-pointer border-b border-border/40 bg-muted/50 hover:bg-muted/70"
+                    style={{ transform }}
+                    onClick={() => toggleGroupExpand(item.key)}
+                  >
+                    {columns.map((col, colIdx) => (
+                      <div key={col.id} className="flex items-center gap-1 border-r border-border/20 px-2 py-1 text-xs font-medium shrink-0" style={{ width: columnWidths[colIdx] }}>
+                        {colIdx === 0 && (
+                          <>
+                            {expanded ? <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" /> : <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
+                            <span className="truncate" title={item.label}>{item.label}</span>
+                            <span className="ml-1 shrink-0 rounded-full bg-foreground/10 px-1.5 text-[10px] tabular-nums text-muted-foreground">{item.count.toLocaleString()}</span>
+                          </>
+                        )}
+                        {colIdx !== 0 && sumColumnIds.includes(col.id) && (
+                          <span className="ml-auto font-mono tabular-nums">{formatCellValue(item.sums[col.id])}</span>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                );
+              }
+
+              const row = item.row;
+              const isSelected = row.entityId === selectedEntityId;
               return (
                 <div
-                  key={virtualRow.key}
-                  data-index={virtualRow.index}
-                  ref={virtualizer.measureElement}
-                  className={cn(
-                    'flex absolute top-0 left-0 w-full border-b border-border/30 cursor-pointer hover:bg-muted/40',
-                    isSelected && 'bg-primary/10'
-                  )}
-                  style={{
-                    transform: `translateY(${virtualRow.start}px)`,
-                  }}
+                  key={vRow.key}
+                  className={cn('absolute left-0 top-0 flex w-full cursor-pointer border-b border-border/30 hover:bg-muted/40', isSelected && 'bg-primary/10')}
+                  style={{ transform }}
                   onClick={() => handleRowClick(row)}
                 >
                   {row.values.map((value, colIdx) => (
                     <div
                       key={colIdx}
-                      className="px-2 py-1 text-xs truncate border-r border-border/20 shrink-0"
+                      className={cn('border-r border-border/20 px-2 py-1 text-xs truncate shrink-0', numericCols[colIdx] && 'text-right font-mono tabular-nums', isGrouped && colIdx === 0 && 'pl-6')}
                       style={{ width: columnWidths[colIdx] }}
                       title={value !== null ? String(value) : ''}
                     >
@@ -294,70 +362,22 @@ export function ListResultsTable({ result }: ListResultsTableProps) {
               );
             })}
           </div>
+
+          {/* Grand-totals footer (sticky, aligned under columns) */}
+          {showSumRow && (
+            <div className="flex sticky bottom-0 z-10 border-t-2 border-border bg-muted/90 backdrop-blur-sm">
+              {columns.map((col, colIdx) => (
+                <div key={col.id} className="flex items-center border-r border-border/30 px-2 py-1 text-xs font-semibold shrink-0" style={{ width: columnWidths[colIdx] }}>
+                  {colIdx === 0 && <span className="text-muted-foreground">Total · {totals.count.toLocaleString()}</span>}
+                  {colIdx !== 0 && sumColumnIds.includes(col.id) && (
+                    <span className="ml-auto font-mono tabular-nums text-foreground">{formatCellValue(totals.sums[col.id])}</span>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       </div>
     </div>
   );
-}
-
-function GroupSummaryPanel({ result }: { result: ListResult }) {
-  const groups = result.groups ?? [];
-  const summary = result.summary;
-  const sumColIds = summary ? Object.keys(summary.sums) : [];
-  const labelOf = (id: string): string => {
-    const col = result.columns.find(c => c.id === id);
-    return col?.label ?? col?.propertyName ?? id;
-  };
-
-  return (
-    <div className="border-b bg-muted/30 px-3 py-2 text-xs max-h-48 overflow-auto">
-      <div className="flex items-center gap-2 mb-1 font-medium">
-        <span>
-          {groups.length} group{groups.length === 1 ? '' : 's'} · {summary?.count ?? 0} elements
-        </span>
-        {sumColIds.length > 0 && (
-          <span className="ml-auto flex flex-wrap gap-x-3 gap-y-0.5 justify-end text-muted-foreground">
-            {sumColIds.map(id => (
-              <span key={id}>
-                Σ {labelOf(id)}:{' '}
-                <span className="font-mono text-foreground">{formatCellValue(summary!.sums[id])}</span>
-              </span>
-            ))}
-          </span>
-        )}
-      </div>
-      <div className="space-y-0.5">
-        {groups.map(g => (
-          <div key={g.key} className="flex items-center gap-2">
-            <span className="flex-1 truncate" title={g.label}>{g.label}</span>
-            <span className="font-mono text-muted-foreground w-14 text-right shrink-0">{g.count}</span>
-            {sumColIds.map(id => (
-              <span key={id} className="font-mono w-24 text-right shrink-0">
-                {formatCellValue(g.sums[id])}
-              </span>
-            ))}
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function formatCellValue(value: CellValue): string {
-  if (value === null || value === undefined) return '';
-  if (typeof value === 'boolean') return value ? 'Yes' : 'No';
-  if (typeof value === 'number') {
-    // Format numbers: integers as-is, decimals with up to 4 decimal places
-    if (Number.isInteger(value)) return String(value);
-    return value.toFixed(4).replace(/\.?0+$/, '');
-  }
-  return String(value);
-}
-
-function compareCells(a: CellValue, b: CellValue): number {
-  if (a === null && b === null) return 0;
-  if (a === null) return -1;
-  if (b === null) return 1;
-  if (typeof a === 'number' && typeof b === 'number') return a - b;
-  return String(a).localeCompare(String(b));
 }

--- a/apps/viewer/src/components/viewer/lists/list-table-utils.ts
+++ b/apps/viewer/src/components/viewer/lists/list-table-utils.ts
@@ -1,0 +1,123 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Pure helpers for the Lists results table — value formatting, comparison,
+ * numeric-column detection, content-aware column widths, and the grouping /
+ * aggregation that powers the in-table (settings-free) grouped view.
+ */
+
+import type { CellValue, ColumnDefinition, ListRow, ListGrouping } from '@ifc-lite/lists';
+
+export function formatCellValue(value: CellValue): string {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+  if (typeof value === 'number') {
+    if (Number.isInteger(value)) return value.toLocaleString();
+    return value.toFixed(4).replace(/\.?0+$/, '');
+  }
+  return String(value);
+}
+
+export function compareCells(a: CellValue, b: CellValue): number {
+  if (a === null && b === null) return 0;
+  if (a === null) return -1;
+  if (b === null) return 1;
+  if (typeof a === 'number' && typeof b === 'number') return a - b;
+  return String(a).localeCompare(String(b));
+}
+
+/** A column is numeric (summable) when every sampled non-empty value is a
+ *  finite number and at least one such value exists. */
+export function detectNumericColumns(columns: ColumnDefinition[], rows: ListRow[]): boolean[] {
+  const sample = rows.slice(0, 120);
+  return columns.map((_, i) => {
+    let sawNumber = false;
+    for (const r of sample) {
+      const v = r.values[i];
+      if (v === null || v === undefined || v === '') continue;
+      if (typeof v === 'number' && Number.isFinite(v)) { sawNumber = true; continue; }
+      return false;
+    }
+    return sawNumber;
+  });
+}
+
+/** Content-aware default width: fits the header + the widest sampled value
+ *  (≈7px/char), clamped to a readable range. */
+export function autoColumnWidth(label: string, rows: ListRow[], colIdx: number): number {
+  let maxLen = label.length;
+  const sample = rows.slice(0, 200);
+  for (const r of sample) {
+    const v = r.values[colIdx];
+    if (v === null || v === undefined) continue;
+    const len = (typeof v === 'number' ? formatCellValue(v) : String(v)).length;
+    if (len > maxLen) maxLen = len;
+  }
+  return Math.max(80, Math.min(460, maxLen * 7 + 34));
+}
+
+export type DisplayItem =
+  | { kind: 'group'; key: string; label: string; count: number; sums: Record<string, number> }
+  | { kind: 'row'; row: ListRow };
+
+export interface Totals { count: number; sums: Record<string, number> }
+export interface GroupedView { items: DisplayItem[]; groupCount: number; totals: Totals }
+
+function sumIndices(columns: ColumnDefinition[], sumColumnIds: string[]) {
+  return sumColumnIds
+    .map((id) => ({ id, idx: columns.findIndex((c) => c.id === id) }))
+    .filter((s) => s.idx >= 0);
+}
+
+/** Bucket already-filtered/sorted rows by the group-by column, accumulate
+ *  per-group + grand count/sums, and flatten into a virtualizable list
+ *  (group header followed by its rows when the group is expanded). */
+export function buildGroupedView(
+  rows: ListRow[],
+  columns: ColumnDefinition[],
+  grouping: ListGrouping,
+  expanded: Set<string>,
+): GroupedView {
+  const groupIdx = columns.findIndex((c) => c.id === grouping.columnId);
+  const sums = sumIndices(columns, grouping.sumColumnIds);
+  const zero = (): Record<string, number> => Object.fromEntries(sums.map((s) => [s.id, 0]));
+
+  const totals: Totals = { count: rows.length, sums: zero() };
+  const byKey = new Map<string, { key: string; label: string; count: number; sums: Record<string, number>; rows: ListRow[] }>();
+
+  for (const row of rows) {
+    const raw = groupIdx >= 0 ? row.values[groupIdx] : null;
+    const label = raw === null || raw === undefined || raw === '' ? '(none)' : formatCellValue(raw);
+    let g = byKey.get(label);
+    if (!g) { g = { key: label, label, count: 0, sums: zero(), rows: [] }; byKey.set(label, g); }
+    g.count++;
+    g.rows.push(row);
+    for (const s of sums) {
+      const v = row.values[s.idx];
+      if (typeof v === 'number' && Number.isFinite(v)) { g.sums[s.id] += v; totals.sums[s.id] += v; }
+    }
+  }
+
+  const groups = Array.from(byKey.values()).sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+  const items: DisplayItem[] = [];
+  for (const g of groups) {
+    items.push({ kind: 'group', key: g.key, label: g.label, count: g.count, sums: g.sums });
+    if (expanded.has(g.key)) for (const r of g.rows) items.push({ kind: 'row', row: r });
+  }
+  return { items, groupCount: groups.length, totals };
+}
+
+/** Grand totals for the flat (ungrouped) view when sum columns are active. */
+export function flatTotals(rows: ListRow[], columns: ColumnDefinition[], sumColumnIds: string[]): Totals {
+  const sums = sumIndices(columns, sumColumnIds);
+  const acc: Record<string, number> = Object.fromEntries(sums.map((s) => [s.id, 0]));
+  for (const r of rows) {
+    for (const s of sums) {
+      const v = r.values[s.idx];
+      if (typeof v === 'number' && Number.isFinite(v)) acc[s.id] += v;
+    }
+  }
+  return { count: rows.length, sums: acc };
+}

--- a/apps/viewer/src/lib/lists/index.ts
+++ b/apps/viewer/src/lib/lists/index.ts
@@ -14,6 +14,7 @@ export type {
   ConditionOperator,
   DiscoveredColumns,
   EntityAttribute,
+  ListGrouping,
 } from '@ifc-lite/lists';
 export {
   ENTITY_ATTRIBUTES,


### PR DESCRIPTION
Closes #938 (user feedback from @BIMvoice).

## The feedback
1. **Grouping "does not work"** + *"group by name, show count."*
2. **Columns can't be resized** — long values are unreadable.

## What changed
The results table is now the **control surface** for grouping/aggregation — no more disconnected round-trip through Settings:

- **Column header `⋮` menu** — Sort asc/desc · **Group by this column** · **Sum / total** (numeric columns) · Colour by.
- **Grouping bar** — removable *Grouped by …* and *Σ …* chips, expand/collapse-all, and live **group + element counts**.
- **Inline collapsible groups** — group rows render in the table (column-aligned per-group **count + sums**), expand to drill into members; virtualized so 100K+ rows stay smooth. Defaults to collapsed → instant "group by name, show count" overview.
- **Sticky grand-totals footer** under the summed columns.
- **Resizable columns** — drag a header edge (double-click to auto-fit), and the default widths are now **content-aware** (previously header-label width only, capped at 250px, so content was truncated).
- **Two-way sync** — every table action writes back to the `ListDefinition` (persists like any other list and keeps the Settings builder in sync); the builder now keeps grouping when only sums are set.

> Note: the grouping *engine* fix (so groups/summary aren't dropped on execute) already shipped in **#934** — this PR makes grouping **discoverable and operable from the table itself**, which is what the report was really about.

## Notes
- Split into `list-table-utils.ts`, `ColumnHeaderMenu.tsx`, `ListGroupingBar.tsx` to keep files within the size budget (`ListResultsTable` 384 lines).
- Viewer-only (reuses `@ifc-lite/lists`) — no package API change, no changeset.
- Typecheck clean. Built with the frontend-design skill: a refined, industrial precision-grid that matches the existing dense viewer UI (light/dark tokens), not a reskin.

Not yet browser-verified end-to-end (needs a wasm build); happy to run the viewer to confirm if you'd like.