### PR TITLE
fix(geometry): seven correctness fixes from the IFC-vs-IfcOpenShell sweep

### DIFF
--- a/rust/core/src/decoder.rs
+++ b/rust/core/src/decoder.rs
@@ -50,6 +50,11 @@ pub struct EntityDecoder<'a> {
     /// default (and Renga-style files) is 1.0 (RADIAN); degree-unit files
     /// resolve to π/180.
     plane_angle_to_radians_cache: Option<f64>,
+    /// Lazy-cached multiplier converting file length units to metres.
+    /// Populated on first call to [`Self::length_unit_scale`]. 1.0 for metre
+    /// files, 0.001 for millimetre files, etc. Used to express absolute
+    /// tolerances (e.g. curve-tessellation chord deviation) in file units.
+    length_unit_scale_cache: Option<f64>,
 }
 
 impl<'a> EntityDecoder<'a> {
@@ -61,6 +66,7 @@ impl<'a> EntityDecoder<'a> {
             entity_index: None,
             point_cache: FxHashMap::default(),
             plane_angle_to_radians_cache: None,
+            length_unit_scale_cache: None,
         }
     }
 
@@ -72,6 +78,7 @@ impl<'a> EntityDecoder<'a> {
             entity_index: Some(Arc::new(index)),
             point_cache: FxHashMap::default(),
             plane_angle_to_radians_cache: None,
+            length_unit_scale_cache: None,
         }
     }
 
@@ -83,6 +90,7 @@ impl<'a> EntityDecoder<'a> {
             entity_index: Some(index),
             point_cache: FxHashMap::default(),
             plane_angle_to_radians_cache: None,
+            length_unit_scale_cache: None,
         }
     }
 
@@ -213,6 +221,36 @@ impl<'a> EntityDecoder<'a> {
             None => 1.0,
         };
         self.plane_angle_to_radians_cache = Some(scale);
+        scale
+    }
+
+    /// Multiplier that converts file length units to metres (1.0 for metre
+    /// files, 0.001 for millimetre files, …). Lazy-resolved on first call by
+    /// scanning for IFCPROJECT and reading its IFCUNITASSIGNMENT, then cached.
+    /// Returns `1.0` when no length unit is declared.
+    ///
+    /// Use this to express an *absolute* metric tolerance in file units —
+    /// e.g. a curve-tessellation chord-deviation budget that stays constant in
+    /// millimetres whether the file is authored in mm or m.
+    pub fn length_unit_scale(&mut self) -> f64 {
+        if let Some(cached) = self.length_unit_scale_cache {
+            return cached;
+        }
+
+        let mut scanner = crate::parser::EntityScanner::new(self.content);
+        let mut project_id: Option<u32> = None;
+        while let Some((id, type_name, _, _)) = scanner.next_entity() {
+            if type_name == "IFCPROJECT" {
+                project_id = Some(id);
+                break;
+            }
+        }
+
+        let scale = match project_id {
+            Some(pid) => crate::units::try_extract_length_unit_scale(self, pid).unwrap_or(1.0),
+            None => 1.0,
+        };
+        self.length_unit_scale_cache = Some(scale);
         scale
     }
 

--- a/rust/geometry/src/csg.rs
+++ b/rust/geometry/src/csg.rs
@@ -1543,6 +1543,15 @@ impl ClippingProcessor {
         false
     }
 
+    /// Kernel-neutral check: does a DIFFERENCE result look collapsed relative
+    /// to its host? Wraps [`Self::manifold_result_looks_degenerate`] under a
+    /// name that reads correctly off the Manifold path too — used by the
+    /// polygonal-bounded half-space clip to fall back to a robust unbounded
+    /// plane clip when either kernel degenerates on coincident faces.
+    pub(crate) fn difference_result_looks_degenerate(host: &Mesh, result: &Mesh) -> bool {
+        Self::manifold_result_looks_degenerate(host, result)
+    }
+
     /// Run `host - opening` through the legacy in-tree BSP CSG kernel.
     /// Returns `None` if the BSP path can't accept the inputs (operands
     /// past the per-mesh polygon cap, degenerate polygon extraction,

--- a/rust/geometry/src/processors/advanced_face.rs
+++ b/rust/geometry/src/processors/advanced_face.rs
@@ -1282,6 +1282,23 @@ fn sample_curve_polyline(
                 return sample_bspline_edge_curve(&basis, &p_start, sense, decoder);
             }
         }
+        if basis_kind == "IFCLINE" {
+            // A trimmed line is just the segment between its two cartesian trim
+            // points. Falling through to `sample_curve_polyline(&basis)` below
+            // would discard Trim1/Trim2 and sample the *raw* IfcLine, whose
+            // IfcVector magnitude is a tool-emitted unit length (e.g. Revit's
+            // 0.3048 = 1 ft) wholly unrelated to the trimmed extent. For a
+            // surface-of-revolution generator profile that inflates the
+            // revolved radius/extent ~50-70x (light-fixture #189538 hull 9.5x,
+            // proxy #209435 hull 3.2x in ISSUE_159).
+            if let (Some(p_start), Some(p_end)) = (p1, p2) {
+                return if sense {
+                    vec![p_start, p_end]
+                } else {
+                    vec![p_end, p_start]
+                };
+            }
+        }
         return sample_curve_polyline(&basis, decoder);
     }
     Vec::new()

--- a/rust/geometry/src/processors/boolean.rs
+++ b/rust/geometry/src/processors/boolean.rs
@@ -362,6 +362,23 @@ impl BooleanClippingProcessor {
         }
         .normalize();
 
+        // The prism is extruded perpendicular to the polygon plane (along
+        // Position.Z), but ONLY toward the material side of the base surface —
+        // the side this DIFFERENCE removes. A spec-correct
+        // IfcPolygonalBoundedHalfSpace prism is infinite along ±Position.Z and
+        // then intersected with the half-space; our one-directional prism
+        // approximates that, so it MUST point at the material side. Position.Z
+        // is authored independently of AgreementFlag (the duplex "Party Wall"
+        // clips author Position.Z parallel to +normal while AgreementFlag puts
+        // the material on -normal), so flip its sign when it points away from
+        // the material side. The cross-section stays perpendicular to
+        // Position.Z, preserving the tilted-cutter fix (#583).
+        let ext_dir = if z_axis.dot(&material_side_dir) >= 0.0 {
+            z_axis
+        } else {
+            -z_axis
+        };
+
         // Project each polygon vertex from its position in Position's XY
         // plane onto the slope plane along Position's Z-axis. This yields a
         // (possibly tilted) polygon that lies ON the slope plane and forms
@@ -434,33 +451,33 @@ impl BooleanClippingProcessor {
         };
         let max_projection_z = host_corners
             .iter()
-            .map(|corner| (corner - base_centroid).dot(&z_axis))
+            .map(|corner| (corner - base_centroid).dot(&ext_dir))
             .fold(0.0_f64, f64::max);
         let depth = max_projection_z.max(host_diag) + 1.0;
 
-        // Top cap = base cap translated along POSITION.Z by `depth`.
+        // Top cap = base cap translated along the material-side extrusion
+        // direction by `depth`.
         let top_world: Vec<Point3<f64>> =
-            base_world.iter().map(|p| *p + z_axis * depth).collect();
+            base_world.iter().map(|p| *p + ext_dir * depth).collect();
 
         // Winding: build_tilted_prism_mesh REVERSES the bottom cap
         // (triangles emitted in reverse order) and KEEPS the top cap.
         // For a closed solid with outward-facing caps:
-        //   - Bottom cap outward normal: -z_axis (pointing DOWN, OUT of
-        //     prism whose interior is ABOVE the slope plane)
-        //   - Top cap outward normal: +z_axis (pointing UP, OUT)
+        //   - Bottom cap outward normal: -ext_dir (pointing OUT of the prism,
+        //     whose interior is on the +ext_dir side of the slope plane)
+        //   - Top cap outward normal: +ext_dir (pointing OUT)
         // After the in-builder reversal, the bottom cap inherits the
-        // polygon's REVERSED normal. We need REVERSED == -z_axis, so the
-        // polygon's natural normal must be +z_axis. Reverse the polygon
-        // ONLY if its natural normal currently points in -z_axis.
+        // polygon's REVERSED normal. We need REVERSED == -ext_dir, so the
+        // polygon's natural normal must be +ext_dir. Reverse the polygon
+        // ONLY if its natural normal currently points in -ext_dir.
         let mut base = base_world;
         let mut top = top_world;
         let mut contour_2d = contour_2d;
-        if Self::polygon_normal(&base).dot(&z_axis) < 0.0 {
+        if Self::polygon_normal(&base).dot(&ext_dir) < 0.0 {
             base.reverse();
             top.reverse();
             contour_2d.reverse();
         }
-        let _ = material_side_dir; // retained for clarity / future use
 
         self.build_tilted_prism_mesh(&contour_2d, &base, &top)
     }
@@ -730,12 +747,26 @@ impl BooleanClippingProcessor {
                     let subtract_result = clipper.subtract_mesh(&mesh, &bound_mesh);
                     self.drain_clipper_failures(&clipper);
                     if let Ok(clipped) = subtract_result {
-                        return Ok(self.guard_against_full_host_removal(
-                            mesh,
-                            clipped,
-                            plane_point,
-                            plane_normal,
-                        ));
+                        // The bounded-prism subtract is fragile on coincident
+                        // faces: when the clip polygon spans the full host
+                        // cross-section, the prism's in-plane side walls land
+                        // exactly on the host's side faces and the CSG kernel
+                        // can collapse the host to a near-empty sliver
+                        // (duplex.ifc "Party Wall" segments #4287/#4399 —
+                        // 12-tri box → 2-tri quad on the legacy BSP kernel the
+                        // native server uses). When the result looks degenerate
+                        // we fall through to the robust unbounded plane clip
+                        // below: a strict superset of the bounded cut that is
+                        // exactly correct whenever the polygon already covers
+                        // the host's projected cross-section.
+                        if !ClippingProcessor::difference_result_looks_degenerate(&mesh, &clipped) {
+                            return Ok(self.guard_against_full_host_removal(
+                                mesh,
+                                clipped,
+                                plane_point,
+                                plane_normal,
+                            ));
+                        }
                     }
                 }
 

--- a/rust/geometry/src/profiles.rs
+++ b/rust/geometry/src/profiles.rs
@@ -2047,10 +2047,39 @@ impl ProfileProcessor {
             end_angle -= 2.0 * std::f64::consts::PI;
         }
 
-        // Calculate arc angle and adaptive segment count
-        // Use ~8 segments per 90° (quarter circle), minimum 2
+        // Adaptive segment count.
+        //
+        // Angular floor: ~8 segments per 90° (quarter circle), minimum 2 —
+        // preserves the previous density for small arcs so nothing regresses.
+        //
+        // Chord-deviation budget: the angular floor is radius-INDEPENDENT, so a
+        // large-radius arc collapses to a coarse polyline (a 12.5 m-radius, 17°
+        // arc got only 2 segments → 35 mm chord deviation on a 500 mm wall,
+        // ISSUE_129). Cap the sagitta to an absolute ~0.5 mm by adding segments
+        // for large physical radii. The budget is expressed in metres and
+        // converted through the file's length-unit scale, so it is the same
+        // 0.5 mm whether the model is authored in mm or m. The sagitta/radius
+        // ratio is `1 - cos(step/2)`; solve for the max step that keeps it
+        // within budget. Bounded so a mis-resolved unit can't explode the count.
         let arc_angle = (end_angle - start_angle).abs();
-        let num_segments = ((arc_angle / std::f64::consts::FRAC_PI_2 * 8.0).ceil() as usize).max(2);
+        let by_angle = (arc_angle / std::f64::consts::FRAC_PI_2 * 8.0).ceil() as usize;
+        let by_chord = {
+            const CHORD_TOL_M: f64 = 5.0e-4; // 0.5 mm absolute deviation budget
+            let r_eff = radius.abs().max(radius2.abs());
+            let radius_m = r_eff * decoder.length_unit_scale();
+            if radius_m > CHORD_TOL_M {
+                let rel = (CHORD_TOL_M / radius_m).clamp(1e-9, 0.5);
+                let max_step = 2.0 * (1.0 - rel).acos();
+                if max_step > 1e-9 {
+                    (arc_angle / max_step).ceil() as usize
+                } else {
+                    0
+                }
+            } else {
+                0
+            }
+        };
+        let num_segments = by_angle.max(by_chord).clamp(2, 128);
         let mut points = Vec::with_capacity(num_segments + 1);
 
         let angle_range = if sense {

--- a/rust/geometry/src/profiles.rs
+++ b/rust/geometry/src/profiles.rs
@@ -482,10 +482,26 @@ fn rounded_rectangle_outline(
     points
 }
 
+/// Append `pt` unless it coincides (within 1 µm on both axes) with the current
+/// last point. Adjacent arcs/segments in a steel-section contour can meet at the
+/// exact same coordinate — e.g. an L-shape where `width == thickness + fillet +
+/// edge` puts the toe arc's end on the inner fillet's start — and emitting both
+/// hands a zero-length edge to downstream tessellation/CSG. Mirrors the
+/// seam-degeneracy guard in `rounded_rectangle_outline`.
+fn push_dedup(out: &mut Vec<Point2<f64>>, pt: Point2<f64>) {
+    if out
+        .last()
+        .map_or(true, |p| (p.x - pt.x).abs() > 1.0e-9 || (p.y - pt.y).abs() > 1.0e-9)
+    {
+        out.push(pt);
+    }
+}
+
 /// Append a circular arc (radius `r`, centre (`cx`,`cy`)) sweeping from angle
-/// `a0` to `a1` as `segments + 1` points. Used to round parametric steel-section
-/// corners (IfcLShapeProfileDef FilletRadius / EdgeRadius, etc.). When the
-/// radius is below 1 µm the single corner point at `a0` is emitted instead.
+/// `a0` to `a1` as up to `segments + 1` points. Used to round parametric
+/// steel-section corners (IfcLShapeProfileDef FilletRadius / EdgeRadius, etc.).
+/// Coincident endpoints (with the prior contour point, or a zero-length arc) are
+/// dropped via [`push_dedup`].
 fn push_arc(
     out: &mut Vec<Point2<f64>>,
     cx: f64,
@@ -499,7 +515,7 @@ fn push_arc(
     for i in 0..=n {
         let t = i as f64 / n as f64;
         let a = a0 + (a1 - a0) * t;
-        out.push(Point2::new(cx + r * a.cos(), cy + r * a.sin()));
+        push_dedup(out, Point2::new(cx + r * a.cos(), cy + r * a.sin()));
     }
 }
 
@@ -571,15 +587,20 @@ fn fillet_outline(
             .map(|(_, r)| *r)
             .unwrap_or(0.0);
         if r > 1.0e-9 {
-            out.extend(round_corner(
-                sharp[(i + n - 1) % n],
-                sharp[i],
-                sharp[(i + 1) % n],
-                r,
-                segments,
-            ));
+            for pt in round_corner(sharp[(i + n - 1) % n], sharp[i], sharp[(i + 1) % n], r, segments)
+            {
+                push_dedup(&mut out, pt);
+            }
         } else {
-            out.push(sharp[i]);
+            push_dedup(&mut out, sharp[i]);
+        }
+    }
+    // Drop a closing-seam duplicate (first ≈ last) so the closed contour carries
+    // no zero-length edge across the wrap.
+    if out.len() > 1 {
+        let (first, last) = (out[0], out[out.len() - 1]);
+        if (first.x - last.x).abs() <= 1.0e-9 && (first.y - last.y).abs() <= 1.0e-9 {
+            out.pop();
         }
     }
     out

--- a/rust/geometry/src/profiles.rs
+++ b/rust/geometry/src/profiles.rs
@@ -482,6 +482,27 @@ fn rounded_rectangle_outline(
     points
 }
 
+/// Append a circular arc (radius `r`, centre (`cx`,`cy`)) sweeping from angle
+/// `a0` to `a1` as `segments + 1` points. Used to round parametric steel-section
+/// corners (IfcLShapeProfileDef FilletRadius / EdgeRadius, etc.). When the
+/// radius is below 1 µm the single corner point at `a0` is emitted instead.
+fn push_arc(
+    out: &mut Vec<Point2<f64>>,
+    cx: f64,
+    cy: f64,
+    r: f64,
+    a0: f64,
+    a1: f64,
+    segments: usize,
+) {
+    let n = segments.max(1);
+    for i in 0..=n {
+        let t = i as f64 / n as f64;
+        let a = a0 + (a1 - a0) * t;
+        out.push(Point2::new(cx + r * a.cos(), cy + r * a.sin()));
+    }
+}
+
 /// Profile processor - processes IFC profiles into 2D contours
 pub struct ProfileProcessor {
     schema: IfcSchema,
@@ -1174,27 +1195,57 @@ impl ProfileProcessor {
     /// Process L-shape profile (angle)
     /// IfcLShapeProfileDef: ProfileType, ProfileName, Position, Depth, Width, Thickness, ...
     fn process_l_shape(&self, profile: &DecodedEntity) -> Result<Profile2D> {
+        // IfcLShapeProfileDef: Depth(3), Width(4), Thickness(5), FilletRadius(6),
+        // EdgeRadius(7), LegSlope(8). Built corner-at-origin (heel at (0,0),
+        // horizontal leg along +X, vertical leg along +Y); `center_on_bbox`
+        // re-centres it. LegSlope (tapered legs) is rare and not modelled.
         let depth = profile
             .get_float(3)
             .ok_or_else(|| Error::geometry("L-Shape missing Depth".to_string()))?;
         let width = profile
             .get_float(4)
             .ok_or_else(|| Error::geometry("L-Shape missing Width".to_string()))?;
-        let thickness = profile
+        let t = profile
             .get_float(5)
             .ok_or_else(|| Error::geometry("L-Shape missing Thickness".to_string()))?;
 
-        // L-shape profile (counter-clockwise from origin)
-        let points = vec![
-            Point2::new(0.0, 0.0),
-            Point2::new(width, 0.0),
-            Point2::new(width, thickness),
-            Point2::new(thickness, thickness),
-            Point2::new(thickness, depth),
-            Point2::new(0.0, depth),
-        ];
+        // FilletRadius rounds the inner re-entrant corner (concave, adds
+        // material); EdgeRadius rounds the two leg toes (convex, removes the
+        // sharp tips). Both optional; clamp so the arcs stay inside the legs.
+        let rf = profile
+            .get_float(6)
+            .unwrap_or(0.0)
+            .clamp(0.0, (width - t).min(depth - t).max(0.0));
+        let re = profile.get_float(7).unwrap_or(0.0).clamp(0.0, t * 0.999);
+        const SEG: usize = 6;
+        let half_pi = std::f64::consts::FRAC_PI_2;
+        let pi = std::f64::consts::PI;
 
-        Ok(Profile2D::new(points))
+        // Counter-clockwise from the heel.
+        let mut p: Vec<Point2<f64>> = Vec::new();
+        p.push(Point2::new(0.0, 0.0)); // heel (outer corner) — sharp
+        p.push(Point2::new(width, 0.0)); // horizontal leg outer end — sharp
+        // horizontal leg toe (width, t): convex EdgeRadius
+        if re > 1.0e-9 {
+            push_arc(&mut p, width - re, t - re, re, 0.0, half_pi, SEG);
+        } else {
+            p.push(Point2::new(width, t));
+        }
+        // inner re-entrant corner (t, t): concave FilletRadius
+        if rf > 1.0e-9 {
+            push_arc(&mut p, t + rf, t + rf, rf, 1.5 * pi, pi, SEG);
+        } else {
+            p.push(Point2::new(t, t));
+        }
+        // vertical leg toe (t, depth): convex EdgeRadius
+        if re > 1.0e-9 {
+            push_arc(&mut p, t - re, depth - re, re, 0.0, half_pi, SEG);
+        } else {
+            p.push(Point2::new(t, depth));
+        }
+        p.push(Point2::new(0.0, depth)); // vertical leg outer end — sharp
+
+        Ok(Profile2D::new(p))
     }
 
     /// Process U-shape profile (channel)
@@ -2885,6 +2936,45 @@ mod tests {
         assert!((min_y + max_y).abs() < 1e-9, "Y not centred: {min_y}..{max_y}");
         assert!((max_x - min_x - 80.0).abs() < 1e-9, "width should be Width");
         assert!((max_y - min_y - 100.0).abs() < 1e-9, "height should be Depth");
+    }
+
+    // L-shape FilletRadius (inner re-entrant corner, adds material) and
+    // EdgeRadius (leg toes, removes material) must be honoured — pre-fix the
+    // section was a sharp 6-point polygon (~5% oversized convex hull on steel
+    // angles, ISSUE_021 beams). L100/100/10 with FilletRadius=12, EdgeRadius=6.
+    #[test]
+    fn test_l_shape_honours_fillet_and_edge_radii() {
+        let profile = process_content(
+            "#1=IFCLSHAPEPROFILEDEF(.AREA.,$,$,100.,100.,10.,12.,6.,$,$,$);\n",
+            1,
+        );
+        // Rounded corners => far more than the 6 sharp vertices.
+        assert!(
+            profile.outer.len() > 6,
+            "fillets not generated: {} points",
+            profile.outer.len()
+        );
+        // bbox is still Width × Depth (radii sit inside the legs).
+        let (min_x, min_y, max_x, max_y) = outer_bbox(&profile);
+        assert!((max_x - min_x - 100.0).abs() < 1e-6, "width {}", max_x - min_x);
+        assert!((max_y - min_y - 100.0).abs() < 1e-6, "height {}", max_y - min_y);
+        // Closed-form area: sharp 1900 + inner fillet r1²(1−π/4) − two toe
+        // edges 2·r2²(1−π/4) = 1900 + (144−72)(1−π/4) ≈ 1915.45 mm². The
+        // 6-segment arc tessellation introduces a small inscribed-polygon error.
+        let k = 1.0 - std::f64::consts::FRAC_PI_4;
+        let expected = 1900.0 + (144.0 - 72.0) * k;
+        let n = profile.outer.len();
+        let mut area = 0.0;
+        for i in 0..n {
+            let a = profile.outer[i];
+            let b = profile.outer[(i + 1) % n];
+            area += a.x * b.y - b.x * a.y;
+        }
+        area = area.abs() * 0.5;
+        assert!(
+            (area - expected).abs() < 5.0,
+            "L fillet area {area:.2} vs expected {expected:.2} — wrong fillet sign/placement"
+        );
     }
 
     // A T-shape is centred on its bounding box: Y spans -Depth/2..+Depth/2,

--- a/rust/geometry/src/profiles.rs
+++ b/rust/geometry/src/profiles.rs
@@ -503,6 +503,88 @@ fn push_arc(
     }
 }
 
+/// Round a (right-angle) corner with a tangent fillet of radius `r`, replacing
+/// the sharp `corner` with an arc tangent to the incoming edge `prev->corner`
+/// and the outgoing edge `corner->next`. Returns the arc points from the
+/// incoming tangent point to the outgoing one (so the caller drops the sharp
+/// corner). The fillet centre is placed on the side the edges turn toward, so
+/// the same call rounds a concave (re-entrant, material-adding) corner and a
+/// convex (toe, material-removing) corner correctly. When `r` is below 1 µm or
+/// the edges are degenerate, the sharp `corner` is returned unchanged.
+///
+/// Used for the steel-section web/flange fillets and toe edge radii
+/// (IfcL/U/T/I-ShapeProfileDef). For a 90° corner the tangent points sit `r`
+/// from the corner along each edge and the centre at `corner - e_in*r + e_out*r`.
+fn round_corner(
+    prev: Point2<f64>,
+    corner: Point2<f64>,
+    next: Point2<f64>,
+    r: f64,
+    segments: usize,
+) -> Vec<Point2<f64>> {
+    if r <= 1.0e-9 {
+        return vec![corner];
+    }
+    let ein = corner - prev;
+    let eout = next - corner;
+    let (ein_n, eout_n) = (ein.norm(), eout.norm());
+    // Need both edges at least `r` long to fit the tangent points, else the
+    // fillet would overrun the edge — fall back to a sharp corner.
+    if ein_n < r || eout_n < r {
+        return vec![corner];
+    }
+    let ein = ein / ein_n;
+    let eout = eout / eout_n;
+    let t_in = corner - ein * r; // tangent point on the incoming edge
+    let t_out = corner + eout * r; // tangent point on the outgoing edge
+    let center = corner - ein * r + eout * r;
+    let mut a0 = (t_in.y - center.y).atan2(t_in.x - center.x);
+    let mut a1 = (t_out.y - center.y).atan2(t_out.x - center.x);
+    // Sweep the short way (a 90° corner gives a quarter arc).
+    while a1 - a0 > std::f64::consts::PI {
+        a1 -= 2.0 * std::f64::consts::PI;
+    }
+    while a0 - a1 > std::f64::consts::PI {
+        a1 += 2.0 * std::f64::consts::PI;
+    }
+    let mut out = Vec::with_capacity(segments + 1);
+    push_arc(&mut out, center.x, center.y, r, a0, a1, segments);
+    out
+}
+
+/// Build a closed outline from `sharp` corners, rounding the corners named in
+/// `radii` (index → radius) with tangent fillets via [`round_corner`]. Corners
+/// not listed (or with radius ≤ 0) stay sharp. Indices wrap, so a corner at the
+/// seam still sees its true neighbours. Used by the L/U/T/I parametric steel
+/// sections; the radius's concave/convex sense is handled by `round_corner`.
+fn fillet_outline(
+    sharp: &[Point2<f64>],
+    radii: &[(usize, f64)],
+    segments: usize,
+) -> Vec<Point2<f64>> {
+    let n = sharp.len();
+    let mut out: Vec<Point2<f64>> = Vec::with_capacity(n + radii.len() * segments);
+    for i in 0..n {
+        let r = radii
+            .iter()
+            .find(|(idx, _)| *idx == i)
+            .map(|(_, r)| *r)
+            .unwrap_or(0.0);
+        if r > 1.0e-9 {
+            out.extend(round_corner(
+                sharp[(i + n - 1) % n],
+                sharp[i],
+                sharp[(i + 1) % n],
+                r,
+                segments,
+            ));
+        } else {
+            out.push(sharp[i]);
+        }
+    }
+    out
+}
+
 /// Profile processor - processes IFC profiles into 2D contours
 pub struct ProfileProcessor {
     schema: IfcSchema,
@@ -973,31 +1055,42 @@ impl ProfileProcessor {
             .get_float(6)
             .ok_or_else(|| Error::geometry("I-Shape missing FlangeThickness".to_string()))?;
 
+        // FilletRadius (attr 7) rounds the four web↔flange junctions (concave,
+        // adds the root-fillet material). FlangeEdgeRadius (8) and FlangeSlope
+        // (9) are not yet modelled (rare; absent in the ara3d set).
+        let fillet = profile
+            .get_float(7)
+            .unwrap_or(0.0)
+            .clamp(0.0, ((overall_depth - 2.0 * flange_thickness) * 0.5)
+                .min((overall_width - web_thickness) * 0.5)
+                .max(0.0));
+
         let half_width = overall_width / 2.0;
         let half_depth = overall_depth / 2.0;
         let half_web = web_thickness / 2.0;
+        let ftf_bot = -half_depth + flange_thickness;
+        let ftf_top = half_depth - flange_thickness;
 
-        // Create I-shape profile (counter-clockwise from bottom-left)
-        let points = vec![
-            // Bottom flange
-            Point2::new(-half_width, -half_depth),
-            Point2::new(half_width, -half_depth),
-            Point2::new(half_width, -half_depth + flange_thickness),
-            // Right side of web
-            Point2::new(half_web, -half_depth + flange_thickness),
-            Point2::new(half_web, half_depth - flange_thickness),
-            // Top flange
-            Point2::new(half_width, half_depth - flange_thickness),
-            Point2::new(half_width, half_depth),
-            Point2::new(-half_width, half_depth),
-            Point2::new(-half_width, half_depth - flange_thickness),
-            // Left side of web
-            Point2::new(-half_web, half_depth - flange_thickness),
-            Point2::new(-half_web, -half_depth + flange_thickness),
-            Point2::new(-half_width, -half_depth + flange_thickness),
+        // Sharp outline (counter-clockwise from bottom-left). Indices 3, 4, 9,
+        // 10 are the web↔flange junctions that take the fillet.
+        let sharp = [
+            Point2::new(-half_width, -half_depth), // 0
+            Point2::new(half_width, -half_depth),  // 1
+            Point2::new(half_width, ftf_bot),      // 2
+            Point2::new(half_web, ftf_bot),        // 3  junction
+            Point2::new(half_web, ftf_top),        // 4  junction
+            Point2::new(half_width, ftf_top),      // 5
+            Point2::new(half_width, half_depth),   // 6
+            Point2::new(-half_width, half_depth),  // 7
+            Point2::new(-half_width, ftf_top),     // 8
+            Point2::new(-half_web, ftf_top),       // 9  junction
+            Point2::new(-half_web, ftf_bot),       // 10 junction
+            Point2::new(-half_width, ftf_bot),     // 11
         ];
-
-        Ok(Profile2D::new(points))
+        const SEG: usize = 6;
+        // Indices 3, 4, 9, 10 are the four web↔flange junctions.
+        let radii = [(3, fillet), (4, fillet), (9, fillet), (10, fillet)];
+        Ok(Profile2D::new(fillet_outline(&sharp, &radii, SEG)))
     }
 
     /// Process asymmetric I-shape profile.
@@ -1264,21 +1357,31 @@ impl ProfileProcessor {
             .get_float(6)
             .ok_or_else(|| Error::geometry("U-Shape missing FlangeThickness".to_string()))?;
 
+        // FilletRadius (attr 7) rounds the two inner web↔flange junctions
+        // (concave); EdgeRadius (attr 8) rounds the two flange toes (convex).
+        // FlangeSlope (9) not modelled.
         let half_depth = depth / 2.0;
+        let ft = flange_thickness;
+        let rf = profile
+            .get_float(7)
+            .unwrap_or(0.0)
+            .clamp(0.0, (flange_width - web_thickness).min(half_depth - ft).max(0.0));
+        let re = profile.get_float(8).unwrap_or(0.0).clamp(0.0, ft * 0.999);
 
-        // U-shape profile (counter-clockwise)
-        let points = vec![
-            Point2::new(0.0, -half_depth),
-            Point2::new(flange_width, -half_depth),
-            Point2::new(flange_width, -half_depth + flange_thickness),
-            Point2::new(web_thickness, -half_depth + flange_thickness),
-            Point2::new(web_thickness, half_depth - flange_thickness),
-            Point2::new(flange_width, half_depth - flange_thickness),
-            Point2::new(flange_width, half_depth),
-            Point2::new(0.0, half_depth),
+        // Sharp outline (counter-clockwise). 2,5 = flange toes; 3,4 = junctions.
+        let sharp = [
+            Point2::new(0.0, -half_depth),               // 0 back-bottom outer
+            Point2::new(flange_width, -half_depth),       // 1 bottom toe outer
+            Point2::new(flange_width, -half_depth + ft),  // 2 bottom toe inner (edge)
+            Point2::new(web_thickness, -half_depth + ft), // 3 bottom junction (fillet)
+            Point2::new(web_thickness, half_depth - ft),  // 4 top junction (fillet)
+            Point2::new(flange_width, half_depth - ft),   // 5 top toe inner (edge)
+            Point2::new(flange_width, half_depth),        // 6 top toe outer
+            Point2::new(0.0, half_depth),                 // 7 back-top outer
         ];
-
-        Ok(Profile2D::new(points))
+        const SEG: usize = 6;
+        let radii = [(2, re), (3, rf), (4, rf), (5, re)];
+        Ok(Profile2D::new(fillet_outline(&sharp, &radii, SEG)))
     }
 
     /// Process T-shape profile
@@ -1297,22 +1400,42 @@ impl ProfileProcessor {
             .get_float(6)
             .ok_or_else(|| Error::geometry("T-Shape missing FlangeThickness".to_string()))?;
 
+        // FilletRadius (attr 7) rounds the two web↔flange junctions (concave);
+        // FlangeEdgeRadius (8) rounds the flange toes; WebEdgeRadius (9) rounds
+        // the web's free end. Flange/Web slopes (10/11) not modelled.
         let half_flange = flange_width / 2.0;
         let half_web = web_thickness / 2.0;
+        let ft = flange_thickness;
+        let ftf = depth - ft; // flange inner face Y
+        let rf = profile
+            .get_float(7)
+            .unwrap_or(0.0)
+            .clamp(0.0, (half_flange - half_web).min(ftf).max(0.0));
+        let r_fl = profile.get_float(8).unwrap_or(0.0).clamp(0.0, ft * 0.999);
+        let r_web = profile.get_float(9).unwrap_or(0.0).clamp(0.0, half_web * 0.999);
 
-        // T-shape profile (counter-clockwise)
-        let points = vec![
-            Point2::new(-half_web, 0.0),
-            Point2::new(-half_web, depth - flange_thickness),
-            Point2::new(-half_flange, depth - flange_thickness),
-            Point2::new(-half_flange, depth),
-            Point2::new(half_flange, depth),
-            Point2::new(half_flange, depth - flange_thickness),
-            Point2::new(half_web, depth - flange_thickness),
-            Point2::new(half_web, 0.0),
+        // Sharp outline (counter-clockwise). 1,6 = junctions; 2,5 = flange toes;
+        // 0,7 = web free-end corners.
+        let sharp = [
+            Point2::new(-half_web, 0.0),       // 0 web bottom-left (web edge)
+            Point2::new(-half_web, ftf),       // 1 left junction (fillet)
+            Point2::new(-half_flange, ftf),    // 2 flange left toe inner (flange edge)
+            Point2::new(-half_flange, depth),  // 3 flange left toe top
+            Point2::new(half_flange, depth),   // 4 flange right toe top
+            Point2::new(half_flange, ftf),     // 5 flange right toe inner (flange edge)
+            Point2::new(half_web, ftf),        // 6 right junction (fillet)
+            Point2::new(half_web, 0.0),        // 7 web bottom-right (web edge)
         ];
-
-        Ok(Profile2D::new(points))
+        const SEG: usize = 6;
+        let radii = [
+            (0, r_web),
+            (1, rf),
+            (2, r_fl),
+            (5, r_fl),
+            (6, rf),
+            (7, r_web),
+        ];
+        Ok(Profile2D::new(fillet_outline(&sharp, &radii, SEG)))
     }
 
     /// Process C-shape profile (channel with lips)
@@ -2885,6 +3008,111 @@ mod tests {
 
         assert_eq!(profile.outer.len(), 12); // I-shape has 12 vertices
         assert!(!profile.outer.is_empty());
+    }
+
+    /// Shoelace area of a profile's outer boundary.
+    fn outer_area(profile: &Profile2D) -> f64 {
+        let p = &profile.outer;
+        let n = p.len();
+        let mut a = 0.0;
+        for i in 0..n {
+            let b = p[(i + 1) % n];
+            a += p[i].x * b.y - b.x * p[i].y;
+        }
+        a.abs() * 0.5
+    }
+
+    // I-shape FilletRadius rounds the four web↔flange junctions (concave, adds
+    // root-fillet material). ISSUE_021 I-beam #4416: W180 D171 tw6 tf9.5,
+    // FilletRadius 15. Closed-form area: sharp 4332 + 4·r²(1−π/4) ≈ 4525.1 mm².
+    #[test]
+    fn test_i_shape_honours_fillet_radius() {
+        let sharp = process_content(
+            "#1=IFCISHAPEPROFILEDEF(.AREA.,$,$,180.,171.,6.,9.5,$,$,$);\n",
+            1,
+        );
+        let filleted = process_content(
+            "#1=IFCISHAPEPROFILEDEF(.AREA.,$,$,180.,171.,6.,9.5,15.,$,$);\n",
+            1,
+        );
+        assert_eq!(sharp.outer.len(), 12, "sharp I should stay 12 points");
+        assert!(
+            filleted.outer.len() > 12,
+            "fillets not generated: {} points",
+            filleted.outer.len()
+        );
+        // Closed-form uses ideal arcs; the 6-segment-per-corner tessellation of
+        // four concave fillets over-estimates by ~8 mm² (chords bow outward on a
+        // concave fillet). Tolerance absorbs that while still pinning the sign
+        // (filleted ≈ 4525, clearly above sharp 4332).
+        let k = 1.0 - std::f64::consts::FRAC_PI_4;
+        let expected = 4332.0 + 4.0 * 15.0 * 15.0 * k;
+        let area = outer_area(&filleted);
+        assert!(
+            (area - expected).abs() < 15.0 && area > outer_area(&sharp) + 100.0,
+            "I fillet area {area:.2} vs expected {expected:.2} (sharp {:.2})",
+            outer_area(&sharp)
+        );
+        // bbox unchanged (fillets are interior).
+        let (mnx, mny, mxx, mxy) = outer_bbox(&filleted);
+        assert!((mxx - mnx - 180.0).abs() < 1e-6 && (mxy - mny - 171.0).abs() < 1e-6);
+    }
+
+    // U-shape (channel): FilletRadius rounds the 2 inner web↔flange junctions
+    // (concave, +), EdgeRadius rounds the 2 flange toes (convex, −). Depth 200,
+    // FlangeWidth 80, WebThickness 10, FlangeThickness 12, FilletRadius 12,
+    // EdgeRadius 6. Sharp 3680 + 2·12²(1−π/4) − 2·6²(1−π/4) ≈ 3726.3 mm².
+    #[test]
+    fn test_u_shape_honours_radii() {
+        let sharp = process_content(
+            "#1=IFCUSHAPEPROFILEDEF(.AREA.,$,$,200.,80.,10.,12.,$,$,$,$);\n",
+            1,
+        );
+        let filleted = process_content(
+            "#1=IFCUSHAPEPROFILEDEF(.AREA.,$,$,200.,80.,10.,12.,12.,6.,$,$);\n",
+            1,
+        );
+        assert_eq!(sharp.outer.len(), 8);
+        assert!(filleted.outer.len() > 8, "U fillets not generated");
+        let k = 1.0 - std::f64::consts::FRAC_PI_4;
+        let expected = 3680.0 + 2.0 * 144.0 * k - 2.0 * 36.0 * k;
+        let area = outer_area(&filleted);
+        assert!(
+            (area - expected).abs() < 12.0,
+            "U area {area:.2} vs expected {expected:.2}"
+        );
+        // bbox unchanged: FlangeWidth × Depth.
+        let (mnx, mny, mxx, mxy) = outer_bbox(&filleted);
+        assert!((mxx - mnx - 80.0).abs() < 1e-6 && (mxy - mny - 200.0).abs() < 1e-6);
+    }
+
+    // T-shape: FilletRadius at the 2 web↔flange junctions (concave, +),
+    // FlangeEdgeRadius at the 2 flange toes and WebEdgeRadius at the 2 web-end
+    // corners (convex, −). Depth 100, FlangeWidth 80, WebThickness 10,
+    // FlangeThickness 12, FilletRadius 8, FlangeEdgeRadius 4, WebEdgeRadius 3.
+    // Sharp 1840 + 2·8²(1−π/4) − 2·4²(1−π/4) − 2·3²(1−π/4) ≈ 1856.8 mm².
+    #[test]
+    fn test_t_shape_honours_radii() {
+        let sharp = process_content(
+            "#1=IFCTSHAPEPROFILEDEF(.AREA.,$,$,100.,80.,10.,12.,$,$,$,$,$);\n",
+            1,
+        );
+        let filleted = process_content(
+            "#1=IFCTSHAPEPROFILEDEF(.AREA.,$,$,100.,80.,10.,12.,8.,4.,3.,$,$);\n",
+            1,
+        );
+        assert_eq!(sharp.outer.len(), 8);
+        assert!(filleted.outer.len() > 8, "T fillets not generated");
+        let k = 1.0 - std::f64::consts::FRAC_PI_4;
+        let expected = 1840.0 + 2.0 * 64.0 * k - 2.0 * 16.0 * k - 2.0 * 9.0 * k;
+        let area = outer_area(&filleted);
+        assert!(
+            (area - expected).abs() < 10.0,
+            "T area {area:.2} vs expected {expected:.2}"
+        );
+        // bbox unchanged: FlangeWidth × Depth.
+        let (mnx, mny, mxx, mxy) = outer_bbox(&filleted);
+        assert!((mxx - mnx - 80.0).abs() < 1e-6 && (mxy - mny - 100.0).abs() < 1e-6);
     }
 
     /// (min_x, min_y, max_x, max_y) of a profile's outer boundary.

--- a/rust/geometry/src/profiles.rs
+++ b/rust/geometry/src/profiles.rs
@@ -1267,10 +1267,14 @@ impl ProfileProcessor {
     /// Process C-shape profile (channel with lips)
     /// IfcCShapeProfileDef: ProfileType, ProfileName, Position, Depth, Width, WallThickness, Girth, ...
     fn process_c_shape(&self, profile: &DecodedEntity) -> Result<Profile2D> {
+        // IfcCShapeProfileDef: Depth(3), Width(4), WallThickness(5), Girth(6),
+        // InternalFilletRadius(7). A lipped channel symmetric about its X-axis:
+        // a web on the left, top/bottom flanges spanning the full Width, and
+        // return lips of length Girth at the flange tips.
         let depth = profile
             .get_float(3)
             .ok_or_else(|| Error::geometry("C-Shape missing Depth".to_string()))?;
-        let _width = profile
+        let width = profile
             .get_float(4)
             .ok_or_else(|| Error::geometry("C-Shape missing Width".to_string()))?;
         let wall_thickness = profile
@@ -1279,17 +1283,25 @@ impl ProfileProcessor {
         let girth = profile.get_float(6).unwrap_or(wall_thickness * 2.0); // Lip length
 
         let half_depth = depth / 2.0;
+        let t = wall_thickness;
 
-        // C-shape profile (counter-clockwise)
+        // Counter-clockwise outline. Previously this used `girth` as the X
+        // extent and dropped `width` entirely, so the channel came out only
+        // ~girth wide (a few × the thickness) instead of its full Width. The
+        // flanges now span [0, Width]; the lips turn inward by Girth at x=Width.
         let points = vec![
-            Point2::new(girth, -half_depth),
-            Point2::new(0.0, -half_depth),
-            Point2::new(0.0, half_depth),
-            Point2::new(girth, half_depth),
-            Point2::new(girth, half_depth - wall_thickness),
-            Point2::new(wall_thickness, half_depth - wall_thickness),
-            Point2::new(wall_thickness, -half_depth + wall_thickness),
-            Point2::new(girth, -half_depth + wall_thickness),
+            Point2::new(0.0, -half_depth),                  // bottom-left outer
+            Point2::new(width, -half_depth),                // bottom-right outer
+            Point2::new(width, -half_depth + girth),        // bottom lip tip
+            Point2::new(width - t, -half_depth + girth),    // bottom lip inner
+            Point2::new(width - t, -half_depth + t),        // bottom flange inner
+            Point2::new(t, -half_depth + t),                // web inner bottom
+            Point2::new(t, half_depth - t),                 // web inner top
+            Point2::new(width - t, half_depth - t),         // top flange inner
+            Point2::new(width - t, half_depth - girth),     // top lip inner
+            Point2::new(width, half_depth - girth),         // top lip tip
+            Point2::new(width, half_depth),                 // top-right outer
+            Point2::new(0.0, half_depth),                   // top-left outer
         ];
 
         Ok(Profile2D::new(points))
@@ -2860,6 +2872,31 @@ mod tests {
         assert!((min_y + max_y).abs() < 1e-9, "Y not centred: {min_y}..{max_y}");
         assert!((max_x - min_x - 80.0).abs() < 1e-9, "width should be FlangeWidth");
         assert!((max_y - min_y - 100.0).abs() < 1e-9, "height should be Depth");
+    }
+
+    // A C-shape (lipped channel) must span its full Width × Depth. Pre-fix
+    // `process_c_shape` dropped the Width attribute (4) and used Girth (6) as
+    // the X extent, so the channel came out only ~Girth wide.
+    #[test]
+    fn test_c_shape_spans_width_and_depth() {
+        // Depth 200, Width 80, WallThickness 6, Girth 20.
+        let profile = process_content(
+            "#1=IFCCSHAPEPROFILEDEF(.AREA.,$,$,200.,80.,6.,20.,$);\n",
+            1,
+        );
+        let (min_x, min_y, max_x, max_y) = outer_bbox(&profile);
+        assert!((min_x + max_x).abs() < 1e-9, "X not centred: {min_x}..{max_x}");
+        assert!((min_y + max_y).abs() < 1e-9, "Y not centred: {min_y}..{max_y}");
+        assert!(
+            (max_x - min_x - 80.0).abs() < 1e-9,
+            "width should be Width (80), got {}",
+            max_x - min_x
+        );
+        assert!(
+            (max_y - min_y - 200.0).abs() < 1e-9,
+            "height should be Depth (200), got {}",
+            max_y - min_y
+        );
     }
 
     #[test]

--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -2252,13 +2252,28 @@ impl GeometryRouter {
             let tri_min_z = v0.z.min(v1.z).min(v2.z);
             let tri_max_z = v0.z.max(v1.z).max(v2.z);
 
+            // Per-axis "completely outside" slack, scaled by the box-plane
+            // coordinate magnitude. The host mesh is stored f32 and promoted to
+            // f64 here, while the opening box bounds are pure f64; at
+            // building-scale world coordinates (tens of metres) the f32 quantum
+            // (|coord| * 2^-23 ≈ 1.2e-7 * |coord|, ~4e-6 m at 33 m) exceeds a
+            // fixed 1e-6 m EPSILON. A wall face authored exactly flush with the
+            // opening's near plane (door extruded from the back surface —
+            // ISSUE_126 #77438 / #83694) then rounds ~1.4e-6 m *outside* the
+            // box, so a fixed-epsilon test mis-classifies it as "completely
+            // outside", the back face survives un-cut, and the opening is sealed
+            // (non-manifold). Track the f32 round-trip error per axis.
+            let eps_x = EPSILON.max(open_min.x.abs().max(open_max.x.abs()) * 1e-6);
+            let eps_y = EPSILON.max(open_min.y.abs().max(open_max.y.abs()) * 1e-6);
+            let eps_z = EPSILON.max(open_min.z.abs().max(open_max.z.abs()) * 1e-6);
+
             // If triangle is completely outside opening, keep it as-is
-            if tri_max_x <= open_min.x - EPSILON
-                || tri_min_x >= open_max.x + EPSILON
-                || tri_max_y <= open_min.y - EPSILON
-                || tri_min_y >= open_max.y + EPSILON
-                || tri_max_z <= open_min.z - EPSILON
-                || tri_min_z >= open_max.z + EPSILON
+            if tri_max_x <= open_min.x - eps_x
+                || tri_min_x >= open_max.x + eps_x
+                || tri_max_y <= open_min.y - eps_y
+                || tri_min_y >= open_max.y + eps_y
+                || tri_max_z <= open_min.z - eps_z
+                || tri_min_z >= open_max.z + eps_z
             {
                 let base = result.vertex_count() as u32;
                 result.add_vertex(v0, n0);
@@ -2377,7 +2392,16 @@ impl GeometryRouter {
             let tri_max = p0.max(p1).max(p2);
             let box_extent = box_half_extents[axis_idx];
 
-            if tri_max < -box_extent - SAT_EPSILON || tri_min > box_extent + SAT_EPSILON {
+            // Scale the separation slack by the world-coordinate magnitude on
+            // this axis so it absorbs the f32 round-trip slop of the host mesh
+            // (stored f32, promoted to f64 here) at building-scale coordinates;
+            // a fixed 1e-6 m is below the f32 quantum at tens of metres, so a
+            // triangle exactly coplanar with the box face (ISSUE_126 #77438 back
+            // face, flush with the door opening's near plane) reads as separated
+            // and survives the cut un-clipped.
+            let axis_eps =
+                SAT_EPSILON.max(box_center[axis_idx].abs().max(box_extent.abs()) * 1e-6);
+            if tri_max < -box_extent - axis_eps || tri_min > box_extent + axis_eps {
                 return false; // Separated on this axis
             }
         }
@@ -2410,8 +2434,20 @@ impl GeometryRouter {
         // pipeline) becomes a separation gap of ~1.7e-6 in projection units,
         // which a fixed 1e-6 epsilon misses — leaving the wall's outer face
         // un-clipped (Smiley-West uncut walls, follow-up to #584).
+        //
+        // The *physical* slack must additionally absorb the f32 round-trip slop
+        // of the host mesh: at building-scale world coordinates (tens of metres)
+        // the f32 quantum is |coord| * 2^-23 ≈ 1.2e-7 * |coord|, which exceeds a
+        // fixed 1e-6 m. A wall face flush with the opening's near plane (door
+        // extruded from the back surface — ISSUE_126 #77438 / #83694, coords
+        // ~33 m) lands ~1.4e-6 m outside the box; a fixed 1e-6 physical slack
+        // still reports separation and the back face survives un-cut, sealing
+        // the opening. Scale the physical slack by the box-center magnitude so
+        // it tracks the f32 error, then by the normal magnitude as before.
+        let phys_slack = SAT_EPSILON
+            .max(box_center.x.abs().max(box_center.y.abs()).max(box_center.z.abs()) * 1e-6);
         let normal_magnitude = triangle_normal.norm();
-        let t2_epsilon = SAT_EPSILON * normal_magnitude.max(1.0);
+        let t2_epsilon = phys_slack * normal_magnitude.max(1.0);
         if triangle_offset.abs() > box_projection + t2_epsilon {
             return false; // Separated by triangle plane
         }
@@ -2450,8 +2486,14 @@ impl GeometryRouter {
                         box_half_extents[i] * axis_normalized.dot(&box_axis_vec).abs();
                 }
 
-                if tri_max < -box_projection - SAT_EPSILON
-                    || tri_min > box_projection + SAT_EPSILON
+                // Same f32-round-trip-aware physical slack as Test 2: the
+                // cross-product axis is normalized, so projections are physical
+                // units and a fixed 1e-6 m misses building-scale f32 slop on a
+                // triangle coplanar with a box face (ISSUE_126 #77438 back face
+                // — box-edge × triangle-edge yields a ±X axis, the very axis the
+                // coplanar back face is separated on).
+                if tri_max < -box_projection - phys_slack
+                    || tri_min > box_projection + phys_slack
                 {
                     return false; // Separated on this axis
                 }
@@ -2490,7 +2532,25 @@ impl GeometryRouter {
         open_max: &Point3<f64>,
     ) {
         let clipper = ClippingProcessor::new();
-        let epsilon = clipper.epsilon;
+        // The plane classification (`d >= -epsilon` = inside/front) must absorb
+        // the host mesh's f32 round-trip slop: the mesh is stored f32 and
+        // promoted to f64 here while the box planes are pure f64. At
+        // building-scale world coordinates (tens of metres) the f32 quantum
+        // (|coord| * 2^-23 ≈ 1.2e-7 * |coord|) exceeds a fixed 1e-6 m, so a wall
+        // face flush with a box plane (ISSUE_126 #77438 back face, ~33 m,
+        // ~1.4e-6 m off the +X plane) is classified entirely "outside" and the
+        // whole triangle survives un-clipped — the opening is sealed by the
+        // un-cut back face. Scale the classification epsilon by the box-plane
+        // coordinate magnitude so it tracks that f32 error.
+        let coord_mag = open_min
+            .x
+            .abs()
+            .max(open_max.x.abs())
+            .max(open_min.y.abs())
+            .max(open_max.y.abs())
+            .max(open_min.z.abs())
+            .max(open_max.z.abs());
+        let epsilon = clipper.epsilon.max(coord_mag * 1e-6);
 
         // Clear buffers for reuse (retains capacity)
         buffers.clear();

--- a/rust/geometry/tests/issue_821_difference_emptied_host.rs
+++ b/rust/geometry/tests/issue_821_difference_emptied_host.rs
@@ -24,8 +24,16 @@
 //!
 //! Reference viewers (BIMVision in the user's comparison screenshot)
 //! defensively revert to the un-cut host when DIFFERENCE wipes out a
-//! non-empty host. The processor now does the same and records the
-//! fallback as `BoolFailureReason::DifferenceEmptiedHost`.
+//! non-empty host, and the processor's `DifferenceEmptiedHost` guard does the
+//! same as a safety net.
+//!
+//! Since the `IfcPolygonalBoundedHalfSpace` material-side fix, though, these
+//! walls no longer *empty* in the first place: the polygonal cutters were
+//! being built on the wrong side of the plane (engulfing the wall); built on
+//! the correct AgreementFlag side they clip to nothing here, so the walls
+//! survive at full extent matching IfcOpenShell without the fallback. So the
+//! first test pins that correct outcome, and the second exercises the guard
+//! directly with a synthetic full-cover clip.
 //!
 //! Fixture: `tests/models/issues/821_TallBuilding.ifc`.
 
@@ -93,16 +101,16 @@ fn level_1_outside_walls_are_not_emptied_by_top_trim_clips() {
 
         assert!(
             !mesh.positions.is_empty() && !mesh.indices.is_empty(),
-            "wall #{} produced an empty mesh — DIFFERENCE clip emptied the host \
-             (issue #821: the spec-strict subtract removes the whole wall, the \
-             fallback must revert to the un-cut host)",
+            "wall #{} produced an empty mesh — issue #821: the polygonal cutters \
+             must clip on the correct AgreementFlag side (and the emptied-host \
+             guard is the safety net), leaving the wall at full extent",
             wall_id,
         );
 
-        // Sanity: the un-cut wall body is an 8200×200×3850 (or rotated)
-        // extrusion. Verifying the Z-span survived at full height proves
-        // the fallback actually used the wall body rather than an
-        // unrelated mesh.
+        // Sanity: the wall body is an 8200×200×3850 (or rotated) extrusion, and
+        // IfcOpenShell keeps it at exactly that extent (the trims clip to
+        // nothing). Verifying the Z-span survived at full height proves the
+        // cutters clipped correctly rather than removing the wall.
         let mut min = [f32::INFINITY; 3];
         let mut max = [f32::NEG_INFINITY; 3];
         for p in mesh.positions.chunks_exact(3) {
@@ -142,69 +150,56 @@ fn level_1_outside_walls_are_not_emptied_by_top_trim_clips() {
     }
 }
 
+/// The `DifferenceEmptiedHost` guard reverts a DIFFERENCE that wipes out a
+/// non-empty host when the cutter plane rides the host surface (the defensive
+/// fallback BIMVision-style viewers use), recording the loss.
+///
+/// The issue #821 walls above no longer reach this guard: their emptying was
+/// caused by `IfcPolygonalBoundedHalfSpace` cutters built on the wrong side of
+/// the plane (engulfing the wall), and that root cause is now fixed — the
+/// cutters clip correctly and the walls survive at full extent without the
+/// fallback (see `level_1_outside_walls_are_not_emptied_by_top_trim_clips`).
+///
+/// So exercise the guard directly with a synthetic case that genuinely empties
+/// the host: a 10×10×10 box minus a half-space whose plane sits 5 mm above the
+/// box's top face (within the guard's coincidence tolerance) with
+/// `AgreementFlag = .T.`. The DIFFERENCE removes everything; the guard must
+/// revert to the box and record `DifferenceEmptiedHost`.
 #[test]
 fn difference_emptied_host_is_recorded_in_csg_failures() {
-    let Some(content) = read_fixture() else {
-        return;
-    };
-
-    let entity_index = ifc_lite_core::build_entity_index(&content);
-    let mut decoder = EntityDecoder::with_index(&content, entity_index);
-
-    // Process each wall's body chain directly through `BooleanClippingProcessor`
-    // so we can drain its own failure log. The router's `take_csg_failures`
-    // sees only the *router*-attributed failures (those routed through the
-    // void-aware path) and would silently report 0 here even when the guard
-    // is firing inside the boolean processor on every call.
+    let content = "\
+ISO-10303-21;
+HEADER;FILE_DESCRIPTION((''),'2;1');FILE_NAME('','',(),(),'','','');FILE_SCHEMA(('IFC4'));ENDSEC;
+DATA;
+#1=IFCRECTANGLEPROFILEDEF(.AREA.,$,$,10.,10.);
+#2=IFCCARTESIANPOINT((0.,0.,0.));
+#3=IFCDIRECTION((0.,0.,1.));
+#4=IFCAXIS2PLACEMENT3D(#2,#3,$);
+#5=IFCEXTRUDEDAREASOLID(#1,#4,#3,10.);
+#6=IFCCARTESIANPOINT((0.,0.,10.005));
+#7=IFCAXIS2PLACEMENT3D(#6,#3,$);
+#8=IFCPLANE(#7);
+#9=IFCHALFSPACESOLID(#8,.T.);
+#10=IFCBOOLEANCLIPPINGRESULT(.DIFFERENCE.,#5,#9);
+ENDSEC;
+END-ISO-10303-21;
+";
+    let entity_index = ifc_lite_core::build_entity_index(content);
+    let mut decoder = EntityDecoder::with_index(content, entity_index);
     let schema = ifc_lite_core::IfcSchema::new();
     let boolean = ifc_lite_geometry::BooleanClippingProcessor::new();
 
-    for &wall_id in BROKEN_OUTSIDE_WALLS {
-        let wall = decoder
-            .decode_by_id(wall_id)
-            .unwrap_or_else(|e| panic!("decode wall #{} ({})", wall_id, e));
-        let rep_id = wall.get_ref(6).expect("wall has representation");
-        let product_shape = decoder.decode_by_id(rep_id).expect("decode rep");
-        let reprs = product_shape
-            .get(2)
-            .and_then(|a| a.as_list())
-            .expect("rep list");
-        for r in reprs {
-            let Some(shape_repr_id) = r.as_entity_ref() else {
-                continue;
-            };
-            let shape_repr = decoder.decode_by_id(shape_repr_id).expect("decode shape");
-            let rep_type = shape_repr
-                .get(2)
-                .and_then(|a| a.as_string().map(String::from))
-                .unwrap_or_default();
-            if rep_type != "Clipping" && rep_type != "Body" {
-                continue;
-            }
-            let items = shape_repr
-                .get(3)
-                .and_then(|a| a.as_list())
-                .expect("items list");
-            for it in items {
-                let Some(item_id) = it.as_entity_ref() else {
-                    continue;
-                };
-                let Ok(item) = decoder.decode_by_id(item_id) else {
-                    continue;
-                };
-                if item.ifc_type != ifc_lite_core::IfcType::IfcBooleanClippingResult
-                    && item.ifc_type != ifc_lite_core::IfcType::IfcBooleanResult
-                {
-                    continue;
-                }
-                let _ =
-                    ifc_lite_geometry::GeometryProcessor::process(&boolean, &item, &mut decoder, &schema);
-            }
-        }
-    }
+    let item = decoder.decode_by_id(10).expect("decode boolean clipping result");
+    let mesh = ifc_lite_geometry::GeometryProcessor::process(&boolean, &item, &mut decoder, &schema)
+        .expect("process boolean clipping result");
 
-    let failures = boolean.take_failures();
-    let total_emptied: usize = failures
+    // The guard must revert to the un-cut box, not emit an empty mesh.
+    assert!(
+        !mesh.indices.is_empty(),
+        "expected the guard to revert to the host box, got an empty mesh",
+    );
+    let total_emptied: usize = boolean
+        .take_failures()
         .iter()
         .filter(|f| {
             matches!(
@@ -215,8 +210,7 @@ fn difference_emptied_host_is_recorded_in_csg_failures() {
         .count();
     assert!(
         total_emptied > 0,
-        "expected ≥1 DifferenceEmptiedHost diagnostic when processing the \
-         three broken outside walls — got 0 (the guard never fired and \
-         this test was previously a silent pass)",
+        "expected a DifferenceEmptiedHost diagnostic when a full-cover clip \
+         empties a non-empty host — got {total_emptied}",
     );
 }

--- a/rust/geometry/tests/polygonal_bounded_half_space_side_regression.rs
+++ b/rust/geometry/tests/polygonal_bounded_half_space_side_regression.rs
@@ -38,28 +38,32 @@ fn bbox_extent(p: &[f32]) -> (f32, f32, f32) {
     (mx.0 - mn.0, mx.1 - mn.1, mx.2 - mn.2)
 }
 
-fn process(id: u32) -> Option<Mesh> {
-    if !std::path::Path::new(FIXTURE).exists() {
-        eprintln!(
-            "skipping: fixture {FIXTURE} not present — run `pnpm fixtures` to download"
-        );
-        return None;
-    }
-    let content = std::fs::read_to_string(FIXTURE).ok()?;
+/// Process an element's geometry. Panics (fails the test loudly) on any
+/// parse/decode/geometry error — only a *missing fixture* is a legitimate skip,
+/// and that is checked by the caller before this runs.
+fn process(id: u32) -> Mesh {
+    let content =
+        std::fs::read_to_string(FIXTURE).unwrap_or_else(|e| panic!("read {FIXTURE}: {e}"));
     let entity_index = build_entity_index(&content);
     let mut decoder = EntityDecoder::with_index(&content, entity_index);
     let router = GeometryRouter::with_units(&content, &mut decoder);
     let void_index: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
-    let entity = decoder.decode_by_id(id).ok()?;
+    let entity = decoder
+        .decode_by_id(id)
+        .unwrap_or_else(|e| panic!("decode #{id}: {e}"));
     router
         .process_element_with_voids(&entity, &mut decoder, &void_index)
-        .ok()
+        .unwrap_or_else(|e| panic!("process #{id}: {e}"))
 }
 
 #[test]
 fn party_wall_polygonal_clip_keeps_material_side() {
+    if !std::path::Path::new(FIXTURE).exists() {
+        eprintln!("skipping: fixture {FIXTURE} not present — run `pnpm fixtures` to download");
+        return;
+    }
     for id in [4287u32, 4399u32] {
-        let Some(mesh) = process(id) else { return };
+        let mesh = process(id);
         let ext = bbox_extent(&mesh.positions);
         // IOS reference: extent (4.201, 0.493, 2.795). Pre-fix Y collapsed to
         // 0.057 (kept the wrong half-space side).

--- a/rust/geometry/tests/polygonal_bounded_half_space_side_regression.rs
+++ b/rust/geometry/tests/polygonal_bounded_half_space_side_regression.rs
@@ -1,0 +1,75 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Regression: `IfcPolygonalBoundedHalfSpace` clip must remove the side the
+//! `AgreementFlag` designates as material, regardless of how the cutter's
+//! `Position.Z` axis is authored.
+//!
+//! duplex.ifc "Party Wall - CMU Residential" segments #4287 / #4399 are
+//! rectangular walls (XDim 4.201, YDim 0.550, height 2.795) whose ends are
+//! trimmed by two `IfcPolygonalBoundedHalfSpace` cutters. For the
+//! Y-thickness cutter, `Position.Z` is authored parallel to the plane's
+//! `+normal` while `AgreementFlag = TRUE` puts the material on `-normal`.
+//!
+//! The bounded-prism builder used to extrude the cutter prism along `+Position.Z`
+//! unconditionally — i.e. AWAY from the material side — so the DIFFERENCE
+//! kept the thin 0.057 m slice that should have been removed instead of the
+//! 0.493 m bulk. IfcOpenShell (pip 0.8.2, use-world-coords) keeps the bulk:
+//! extent (4.201, 0.493, 2.795). Pin that.
+
+use ifc_lite_core::{build_entity_index, EntityDecoder};
+use ifc_lite_geometry::{GeometryRouter, Mesh};
+use rustc_hash::FxHashMap;
+
+const FIXTURE: &str = "../../tests/models/ara3d/duplex.ifc";
+
+fn bbox_extent(p: &[f32]) -> (f32, f32, f32) {
+    let mut mn = (f32::INFINITY, f32::INFINITY, f32::INFINITY);
+    let mut mx = (f32::NEG_INFINITY, f32::NEG_INFINITY, f32::NEG_INFINITY);
+    for c in p.chunks_exact(3) {
+        mn.0 = mn.0.min(c[0]);
+        mn.1 = mn.1.min(c[1]);
+        mn.2 = mn.2.min(c[2]);
+        mx.0 = mx.0.max(c[0]);
+        mx.1 = mx.1.max(c[1]);
+        mx.2 = mx.2.max(c[2]);
+    }
+    (mx.0 - mn.0, mx.1 - mn.1, mx.2 - mn.2)
+}
+
+fn process(id: u32) -> Option<Mesh> {
+    if !std::path::Path::new(FIXTURE).exists() {
+        eprintln!(
+            "skipping: fixture {FIXTURE} not present — run `pnpm fixtures` to download"
+        );
+        return None;
+    }
+    let content = std::fs::read_to_string(FIXTURE).ok()?;
+    let entity_index = build_entity_index(&content);
+    let mut decoder = EntityDecoder::with_index(&content, entity_index);
+    let router = GeometryRouter::with_units(&content, &mut decoder);
+    let void_index: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
+    let entity = decoder.decode_by_id(id).ok()?;
+    router
+        .process_element_with_voids(&entity, &mut decoder, &void_index)
+        .ok()
+}
+
+#[test]
+fn party_wall_polygonal_clip_keeps_material_side() {
+    for id in [4287u32, 4399u32] {
+        let Some(mesh) = process(id) else { return };
+        let ext = bbox_extent(&mesh.positions);
+        // IOS reference: extent (4.201, 0.493, 2.795). Pre-fix Y collapsed to
+        // 0.057 (kept the wrong half-space side).
+        let tol = 0.01_f32;
+        assert!(
+            (ext.0 - 4.201).abs() < tol
+                && (ext.1 - 0.493).abs() < tol
+                && (ext.2 - 2.795).abs() < tol,
+            "#{id}: polygonal half-space clip kept the wrong side — \
+             extent {ext:?}, expected ~(4.201, 0.493, 2.795)"
+        );
+    }
+}


### PR DESCRIPTION
Found by running the `profiling/correctness` framework (native ifc-lite vs IfcOpenShell 0.8.2, Manifold **and** BSP kernels) across the ara3d model set, then adversarially verifying each finding. Seven independent geometry fixes, one commit each, each verified with **zero deterministic-metric regressions** (full `ifc-lite-geometry` + `ifc-lite-core` + `ifc-lite-processing` suites green under `manifold-csg` and `--no-default-features`).

| # | Fix | Symptom (model) | Verified |
|---|---|---|---|
| 1 | `IfcPolygonalBoundedHalfSpace` clip removes the **AgreementFlag material side** | duplex Party Walls kept a 0.057 m sliver of a 0.493 m wall (bbox_iou 0) | both kernels match IOS |
| 2 | Trimmed **IfcLine** basis on `IfcSurfaceOfRevolution` honors its cartesian trim | ISSUE_159 IfcLightFixture hull **9.5×** too big | fixture fail:position 12 → 0 |
| 3 | Scale opening-cut epsilons by **coordinate magnitude** (f32 round-trip) | ISSUE_126 thin walls sealed un-cut at ~33 m coords | wall fails 4 → 0 |
| 4 | `IfcCShapeProfileDef` uses **Width** for the flange (was Girth) | latent — provably wrong | unit test |
| 5 | **Radius-aware arc tessellation** for trimmed conics | ISSUE_129 curved walls — 35 mm chord deviation on a 500 mm wall | fail:shape 26 → 5 |
| 6 | `IfcLShapeProfileDef` FilletRadius + **EdgeRadius** (sharp toes oversized the hull) | ISSUE_021 steel L-angles | fail:volume 13 → 0 (hull 1.0585 → 1.0008) |
| 7 | `IfcU/T/IShapeProfileDef` Fillet/Edge radii (completes parametric-section fillets) | rendering fidelity (no failing verdict) | closed-form area tests |

Fixes 6–7 add `round_corner` / `fillet_outline` / `push_arc` helpers (concave root fillets + convex toe edges from one routine); fix 5 adds `EntityDecoder::length_unit_scale()` for an absolute mm chord budget. Fillet geometry was derived from the IfcOpenShell reference cross-sections and validated by closed-form area.

New tests: `polygonal_bounded_half_space_side_regression.rs`, and `test_{c,l,i,u,t}_shape_*` profile tests. Existing arc/fillet/wall-opening/CSG tests (#583/#635/#820/#854, `wall_opening_cut_regression`) all still pass.

**Note on fix 7:** I/U/T `FilletRadius` is internal (web↔flange junctions) — it doesn't change the convex hull the volume threshold keys on, so no model in the set *fails* on it (unlike the L-shape toe `EdgeRadius`, which does). It's correctness/fidelity, area-validated; it doesn't regress any deterministic metric (bbox/voxel/hull), only adds the real root-fillet geometry.

Stacked: #947 (rotated/engulfing opening over-cut) builds on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed polygonal half-space clipping to respect correct side determination based on agreement flags.
  * Improved corner and edge rounding accuracy for I, U, T, L, and C-shaped steel profiles.
  * Corrected trimmed curve handling for surface-of-revolution geometry generation.
  * Enhanced tolerance handling for rectangular opening clipping to improve precision with floating-point conversions.
  * Added proper IFC unit scale conversion for geometry processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->