### PR TITLE
fix(geometry): rotated/engulfing opening must not over-cut the host (#555433)

### DIFF
--- a/rust/geometry/src/csg.rs
+++ b/rust/geometry/src/csg.rs
@@ -518,6 +518,21 @@ impl ClippingProcessor {
         self.failures.borrow().len()
     }
 
+    /// Whether any failure recorded since index `since` (a prior
+    /// [`failure_count`](Self::failure_count)) was an `OperandTooLarge`
+    /// rejection — i.e. the BSP polygon cap returned the host unchanged for a
+    /// genuinely complex cutter (issue #635), as opposed to a kernel error /
+    /// no-overlap / no real intersection. Lets the void router tell "too complex
+    /// to cut, fall back to the AABB box" apart from "the cutter doesn't really
+    /// intersect, keep the host".
+    pub(crate) fn has_operand_too_large_since(&self, since: usize) -> bool {
+        let failures = self.failures.borrow();
+        let since = since.min(failures.len());
+        failures[since..]
+            .iter()
+            .any(|f| matches!(f.reason, BoolFailureReason::OperandTooLarge { .. }))
+    }
+
     /// Internal: append a failure record. Public-crate so the boolean
     /// processor in `processors/boolean.rs` can record fallbacks that
     /// happen above the kernel layer.

--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -1305,6 +1305,7 @@ impl GeometryRouter {
                     }
 
                     let tri_before = result.triangle_count();
+                    let failures_before = clipper.failure_count();
                     let mut csg_succeeded = false;
                     // Tracks whether CSG returned the host *unchanged* (the kernel
                     // either found no real intersection, or errored on a grazing/
@@ -1397,7 +1398,16 @@ impl GeometryRouter {
                                 && covers(final_min.y, final_max.y, wall_min.y, wall_max.y)
                                 && covers(final_min.z, final_max.z, wall_min.z, wall_max.z)
                         };
-                        if !(csg_unchanged && engulfs_host) {
+                        // Only suppress the fallback when "unchanged" means the
+                        // kernel found no real cut (a kernel error / no-overlap on
+                        // a grazing engulfing cutter). If instead it was the BSP
+                        // polygon cap rejecting a genuinely complex cutter
+                        // (`OperandTooLarge`, issue #635 — the production server
+                        // runs the BSP kernel), the void is real and MUST get the
+                        // AABB box: skipping it on the 3% engulf heuristic would
+                        // leave the wall entirely uncut (Codex review, #947).
+                        let capped = clipper.has_operand_too_large_since(failures_before);
+                        if !(csg_unchanged && engulfs_host && !capped) {
                             let aabb_cut =
                                 self.cut_rectangular_opening(&result, final_min, final_max);
                             if !aabb_cut.is_empty() && aabb_cut.triangle_count() != tri_before {

--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -1306,6 +1306,10 @@ impl GeometryRouter {
 
                     let tri_before = result.triangle_count();
                     let mut csg_succeeded = false;
+                    // Tracks whether CSG returned the host *unchanged* (the kernel
+                    // either found no real intersection, or errored on a grazing/
+                    // coplanar cutter and returned the un-cut host).
+                    let mut csg_unchanged = false;
                     match clipper.subtract_mesh(&result, opening_mesh) {
                         Ok(csg_result) => {
                             let min_tris = (tri_before / CSG_TRIANGLE_RETENTION_DIVISOR)
@@ -1319,6 +1323,7 @@ impl GeometryRouter {
                             // round/curved opening (issue #635) — the host mesh is
                             // returned unchanged, leaving the void uncut.
                             let changed = csg_result.triangle_count() != tri_before;
+                            csg_unchanged = !changed;
                             if !csg_result.is_empty()
                                 && csg_result.triangle_count() >= min_tris
                                 && changed
@@ -1367,10 +1372,37 @@ impl GeometryRouter {
                         } else {
                             (*open_min_pt, *open_max_pt)
                         };
-                        let aabb_cut =
-                            self.cut_rectangular_opening(&result, final_min, final_max);
-                        if !aabb_cut.is_empty() && aabb_cut.triangle_count() != tri_before {
-                            result = aabb_cut;
+                        // Near-engulf guard. When CSG returned the host *unchanged*
+                        // (no cut) AND the opening's AABB covers the whole wall on
+                        // every axis, the rectangular fallback would cut that
+                        // engulfing box and delete the wall. This is the signature
+                        // of a non-rectangular opening whose bounding box engulfs
+                        // the host while its real profile excludes it: the kernel
+                        // errors on the grazing/coplanar cutter and returns the
+                        // un-cut host, which is already the correct result vs
+                        // IfcOpenShell (advanced #555433's facade-scale void
+                        // #555493). Keep the un-cut host instead of over-cutting.
+                        // Normal windows/doors — including the issue-635 high-poly
+                        // round openings the AABB box approximates — sit INSIDE the
+                        // wall and never engulf it, so they still take the fallback.
+                        // The 3% per-axis tolerance absorbs an opening that reaches
+                        // ~flush with a wall face (its near plane).
+                        let engulfs_host = {
+                            let tol = 0.03_f64;
+                            let covers = |omin: f64, omax: f64, wmin: f64, wmax: f64| {
+                                let slack = (wmax - wmin).abs().max(1.0e-9) * tol;
+                                omin <= wmin + slack && omax >= wmax - slack
+                            };
+                            covers(final_min.x, final_max.x, wall_min.x, wall_max.x)
+                                && covers(final_min.y, final_max.y, wall_min.y, wall_max.y)
+                                && covers(final_min.z, final_max.z, wall_min.z, wall_max.z)
+                        };
+                        if !(csg_unchanged && engulfs_host) {
+                            let aabb_cut =
+                                self.cut_rectangular_opening(&result, final_min, final_max);
+                            if !aabb_cut.is_empty() && aabb_cut.triangle_count() != tri_before {
+                                result = aabb_cut;
+                            }
                         }
                     }
                 }

--- a/rust/geometry/tests/wall_opening_cut_regression.rs
+++ b/rust/geometry/tests/wall_opening_cut_regression.rs
@@ -238,3 +238,31 @@ fn wall_555268_7_openings_cuts_take_effect() {
     );
     let _ = mn;
 }
+
+/// Wall #555433 ("Muro básico:STB 30") carries 3 openings, one of which
+/// (#555493) is a non-rectangular facade-scale void whose world-aligned
+/// bounding box engulfs the wall on every axis while its real profile excludes
+/// the wall. The Manifold kernel errors on the grazing/coplanar cutter and
+/// returns the un-cut host — which is the correct result (IfcOpenShell keeps the
+/// wall) — but the recorded failure used to trigger the rectangular AABB
+/// fallback, which cut the engulfing box and collapsed the wall to a 1.5%-volume
+/// sliver (bbox_iou 0.01 vs IOS). The near-engulf guard now keeps the un-cut
+/// host when CSG produced no change and the opening engulfs the wall. The wall
+/// is ~0.30 × 9.015 × 4.292 m; assert it survives at near-full extent.
+#[test]
+fn wall_555433_engulfing_opening_does_not_collapse_wall() {
+    let Some(mesh) = process(555433) else { return };
+    let (mn, mx) = bbox(&mesh.positions).expect(
+        "engulfing-opening fallback deleted the wall — the near-engulf guard in \
+         apply_void_context regressed",
+    );
+    let ext = (mx.0 - mn.0, mx.1 - mn.1, mx.2 - mn.2);
+    // IfcOpenShell keeps the full wall extent (0.30, 9.015, 4.292); the two
+    // genuine small openings don't change it. Require no collapse.
+    assert!(
+        ext.1 > 8.5 && ext.2 > 4.0,
+        "wall collapsed after engulfing-opening cut: extent ({}, {}, {})",
+        ext.0, ext.1, ext.2
+    );
+    let _ = mn;
+}


### PR DESCRIPTION
Stacked on #943. Fixes the deferred rotated/oversized-opening over-cut.

## Problem
advanced_model wall #555433 ("Muro básico:STB 30") collapsed to a **1.5%-volume sliver** (bbox_iou 0.01 vs IfcOpenShell, which keeps the full wall).

Root cause (traced step-by-step): opening #555493 is a **non-rectangular facade-scale void** whose world-aligned bounding box engulfs the wall on every axis while its **real profile excludes the wall**. The Manifold kernel **errors** on the grazing/coplanar cutter and returns the **un-cut host** — which is already the correct result — but the recorded failure drove the rectangular **AABB fallback**, which cut the *engulfing* box and deleted the wall.

(ifc-lite builds the opening mesh correctly — it's geometrically identical to IOS once welded: 16 verts, vol 271.094, hull 297.33. The kernel just can't subtract this particular grazing slab.)

## Fix
In `apply_void_context`, when CSG produced **no change** AND the (extended) opening AABB covers the whole wall on every axis (3% per-axis tolerance), **keep the un-cut host** instead of running the AABB fallback. Normal windows/doors sit *inside* the wall and never engulf it — and the issue-635 high-poly round openings (whose box approximation is the whole point of the fallback) are within-wall — so they still take the fallback.

## Verification
- **advanced #555433**: bbox_iou 0.01 → ~1.0; extent now `0.30 × 9.015 × 4.292` matching IOS. **advanced fails 1 → 0.**
- No new fails on duplex / ISSUE_126 / ISSUE_129. A few engulfing-opening walls shift `pass → warn:hausdorff` — bbox/voxel/hull still pass, i.e. the solids are geometrically correct and visually match IOS's negligible graze-cut; only the warning-only max-distance metric flags them.
- Full `ifc-lite-geometry` + `ifc-lite-processing` suites green (Manifold **and** BSP); existing `wall_opening_cut_regression` cases (#553010/#612315/#555268…) still pass. Adds `wall_555433_engulfing_opening_does_not_collapse_wall`.

### Honest limitation
The guard is a heuristic: when CSG returns "no change" for an engulfing opening it can't perfectly tell "doesn't intersect" (keep wall, #555433) from "should cut but kernel failed" (a handful of walls now `warn:hausdorff` instead of `pass`). The trade — eliminating catastrophic vanishing-wall **fails** for a few warning-only tessellation flags — is net-positive for rendering. A fully correct fix needs CSG-kernel robustness on grazing/coplanar cutters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where walls with large non-rectangular openings could be incorrectly modified when the opening's bounding geometry covered the entire wall, preventing unnecessary over-cutting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->