### PR TITLE
chore: add changesets for merged geometry/wasm fixes (#943, #947, #948)

### DIFF
--- a/.changeset/geometry-correctness-sweep.md
+++ b/.changeset/geometry-correctness-sweep.md
@@ -1,0 +1,12 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Geometry correctness: seven fixes found by the IFC-vs-IfcOpenShell sweep (#943), each verified on both the Manifold and legacy BSP CSG kernels.
+
+- `IfcPolygonalBoundedHalfSpace` clip now removes the side the `AgreementFlag` designates as material (party/outside walls no longer collapse to a sliver).
+- Trimmed `IfcLine` basis on `IfcSurfaceOfRevolution` honours its cartesian trim (revolved fixtures were ~9.5× oversized).
+- Opening-cut epsilons scale with coordinate magnitude, so thin walls at building-scale coordinates are actually cut through instead of left sealed.
+- `IfcCShapeProfileDef` uses `Width` (not `Girth`) for the flange.
+- Radius-aware arc tessellation for trimmed conics — large-radius curved walls render smooth instead of faceted.
+- `IfcL/U/T/IShapeProfileDef` honour `FilletRadius` / `EdgeRadius` (rounded steel-section root fillets and toes).

--- a/.changeset/georef-streaming-rtc.md
+++ b/.changeset/georef-streaming-rtc.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Geometry: fix ~0.5 m vertex jitter on georeferenced models (#948). When a model's world offset lives in spatial-structure placements emitted late in the file (e.g. a Revit/French export with `IfcSite` at the end), `buildPrePassStreaming` detected the RTC offset from the partial index built up to the first ~50 geometry jobs, missed the offset, and the ~8×10⁶ m coordinates were cast to f32 (~0.5 m grid) before reaching the GPU. The streaming pre-pass now re-detects against a full index when the partial pass finds no offset and the `IfcSite` has not yet been scanned, so vertices are shifted local before the f32 cast. Gated so origin-local / early-site models do not pay for a second index build.

--- a/.changeset/opening-engulf-overcut.md
+++ b/.changeset/opening-engulf-overcut.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Geometry: a rotated/engulfing opening no longer over-cuts its host wall (#947, advanced_model #555433, which collapsed to a ~1.5%-volume sliver). When a non-rectangular opening's bounding box engulfs the wall but its real profile excludes it, the kernel returns the un-cut host — which is correct — so the void router now keeps that result instead of falling back to a rectangular AABB cut that would delete the wall. High-poly openings rejected by the BSP operand cap (issue-635) still receive the AABB box, so genuinely-complex voids are not left uncut.


### PR DESCRIPTION
Adds the changesets for the three geometry/wasm fixes that merged without them. All are `@ifc-lite/wasm` patches (Rust geometry/wasm pipeline; dependents auto-bump):

- `geometry-correctness-sweep` (#943) — seven IFC-vs-IfcOpenShell correctness fixes
- `opening-engulf-overcut` (#947) — rotated/engulfing opening over-cut (#555433)
- `georef-streaming-rtc` (#948) — georeferenced f32 jitter (streaming RTC vs full index)

Note: #948 needs `packages/wasm/pkg` rebuilt in the release run to take effect in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected seven IFC geometry calculations affecting surface trimming, profile dimensions, rounded fillets, and tessellation accuracy.
  * Fixed vertex jitter in georeferenced models.
  * Resolved issue where non-rectangular openings were over-cutting their host walls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->