### PR TITLE
base class for data store

### DIFF
--- a/apps/viewer/src/components/viewer/PropertiesPanel.tsx
+++ b/apps/viewer/src/components/viewer/PropertiesPanel.tsx
@@ -512,7 +512,7 @@ export function PropertiesPanel() {
     if (!entityNode) return [];
 
     const rawProps = entityNode.properties();
-    let result = rawProps.map(pset => ({
+    let result: DisplayPropertySet[] = rawProps.map(pset => ({
       name: pset.name,
       properties: pset.properties.map(p => ({ name: p.name, value: p.value, isMutated: false })),
       isNewPset: false,

--- a/apps/viewer/src/sdk/adapters/export-adapter.ts
+++ b/apps/viewer/src/sdk/adapters/export-adapter.ts
@@ -153,13 +153,13 @@ export function createExportAdapter(store: StoreApi): ExportBackendMethods {
     if (!model?.ifcDataStore) return [];
 
     const node = new EntityNode(model.ifcDataStore, ref.expressId);
-    return node.properties().map((pset: { name: string; globalId?: string; properties: Array<{ name: string; type: number; value: string | number | boolean | null }> }) => ({
+    return node.properties().map((pset) => ({
       name: pset.name,
       globalId: pset.globalId,
-      properties: pset.properties.map((p: { name: string; type: number; value: string | number | boolean | null }) => ({
+      properties: pset.properties.map((p) => ({
         name: p.name,
         type: p.type,
-        value: p.value,
+        value: p.value as string | number | boolean | null,
       })),
     }));
   }

--- a/apps/viewer/src/sdk/adapters/query-adapter.ts
+++ b/apps/viewer/src/sdk/adapters/query-adapter.ts
@@ -136,13 +136,13 @@ export function createQueryAdapter(store: StoreApi): QueryBackendMethods {
     if (!model?.ifcDataStore) return [];
 
     const node = new EntityNode(model.ifcDataStore, ref.expressId);
-    return node.properties().map((pset: { name: string; globalId?: string; properties: Array<{ name: string; type: number; value: string | number | boolean | null }> }) => ({
+    return node.properties().map((pset) => ({
       name: pset.name,
       globalId: pset.globalId,
-      properties: pset.properties.map((p: { name: string; type: number; value: string | number | boolean | null }) => ({
+      properties: pset.properties.map((p) => ({
         name: p.name,
         type: p.type,
-        value: p.value,
+        value: p.value as string | number | boolean | null,
       })),
     }));
   }

--- a/apps/viewer/src/utils/nativeSpatialDataStore.ts
+++ b/apps/viewer/src/utils/nativeSpatialDataStore.ts
@@ -267,5 +267,11 @@ export function buildIfcDataStoreFromNativeMetadata(snapshot: NativeMetadataSnap
     quantities: undefined as unknown as IfcDataStore['quantities'],
     relationships: undefined as unknown as IfcDataStore['relationships'],
     spatialHierarchy: hierarchy,
+    // Native spatial snapshots are metadata-only (no source buffer / property
+    // or quantity tables), so the IfcStoreBase accessors return empties.
+    getEntity: () => null,
+    getEntitiesByType: () => [],
+    getProperties: () => [],
+    getQuantities: () => [],
   } as IfcDataStore;
 }

--- a/apps/viewer/src/utils/serverDataModel.ts
+++ b/apps/viewer/src/utils/serverDataModel.ts
@@ -711,5 +711,12 @@ export function convertServerDataModel(
     relationships,
     spatialHierarchy,
     spatialIndex,
+    // IfcStoreBase accessors: server-parsed models carry pre-built property/
+    // quantity tables but no source buffer, so entity extraction is unavailable
+    // (the `entities` table remains the primary path for basic attributes).
+    getEntity: () => null,
+    getEntitiesByType: () => [],
+    getProperties: (expressId: number) => properties.getForEntity(expressId),
+    getQuantities: (expressId: number) => quantities.getForEntity(expressId),
   };
 }

--- a/packages/cli/src/headless-backend.ts
+++ b/packages/cli/src/headless-backend.ts
@@ -38,7 +38,7 @@ import type {
   QueryDescriptor,
   ModelInfo,
 } from '@ifc-lite/sdk';
-import type { IfcStoreBase as IfcDataStore } from '@ifc-lite/data';
+import type { IfcDataStore } from '@ifc-lite/parser';
 import { MutablePropertyView, StoreEditor } from '@ifc-lite/mutations';
 import {
   addBeamToStore,
@@ -236,7 +236,7 @@ export class HeadlessBackend implements BimBackend {
         properties: pset.properties.map((p) => ({
           name: p.name,
           type: p.type,
-          value: p.value,
+          value: p.value as string | number | boolean | null,
         })),
       }));
     }

--- a/packages/cli/src/headless-backend.ts
+++ b/packages/cli/src/headless-backend.ts
@@ -38,7 +38,7 @@ import type {
   QueryDescriptor,
   ModelInfo,
 } from '@ifc-lite/sdk';
-import type { IfcDataStore } from '@ifc-lite/parser';
+import type { IfcStoreBase as IfcDataStore } from '@ifc-lite/data';
 import { MutablePropertyView, StoreEditor } from '@ifc-lite/mutations';
 import {
   addBeamToStore,

--- a/packages/data/src/data-store.ts
+++ b/packages/data/src/data-store.ts
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { PropertySet, PropertyValue } from './property-table.js';
+import type { QuantitySet } from './quantity-table.js';
+import type { Edge } from './relationship-graph.js';
+import type { SpatialHierarchy, IfcEntity, IfcTypeEnum, RelationshipType } from './types.js';
+import type { SpatialIndex } from './spatial-types.js';
+
+interface ReadonlyMapLike<K, V> {
+  get(key: K): V | undefined;
+  has(key: K): boolean;
+  [Symbol.iterator](): IterableIterator<[K, V]>;
+}
+
+interface EntityTable {
+  readonly count: number;
+  readonly expressId: ArrayLike<number>;
+  getGlobalId(expressId: number): string;
+  getName(expressId: number): string;
+  getDescription(expressId: number): string;
+  getObjectType(expressId: number): string;
+  getTypeName(expressId: number): string;
+  getByType(type: IfcTypeEnum): number[];
+}
+
+interface RelationshipEdges {
+  getEdges(entityId: number, type?: RelationshipType): Edge[];
+}
+
+interface RelationshipGraph {
+  forward: RelationshipEdges;
+  inverse: RelationshipEdges;
+  getRelated(entityId: number, relType: RelationshipType, direction: 'forward' | 'inverse'): number[];
+}
+
+interface PropertyTable {
+  getForEntity(expressId: number): PropertySet[];
+  getPropertyValue(expressId: number, psetName: string, propName: string): PropertyValue | null;
+  findByProperty(propName: string, operator: string, value: PropertyValue): number[];
+}
+
+interface QuantityTable {
+  getForEntity(expressId: number): QuantitySet[];
+}
+
+export interface IfcStoreBase {
+  schemaVersion: 'IFC2X3' | 'IFC4' | 'IFC4X3' | 'IFC5';
+  entityCount: number;
+  fileSize: number;
+
+  entities: EntityTable;
+  relationships: RelationshipGraph;
+  properties: PropertyTable;
+  quantities: QuantityTable;
+
+  entityIndex: {
+    byId: ReadonlyMapLike<number, unknown>;
+    byType: ReadonlyMapLike<string, number[]>;
+  };
+
+  spatialHierarchy?: SpatialHierarchy;
+  spatialIndex?: SpatialIndex;
+
+  getEntity(expressId: number): IfcEntity | null;
+  getEntitiesByType(typeName: string): IfcEntity[];
+  getProperties(expressId: number): PropertySet[];
+  getQuantities(expressId: number): QuantitySet[];
+}

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -33,6 +33,7 @@ export * from './types.js';
 // Explicitly export const enums for runtime use
 export { IfcTypeEnum, PropertyValueType, QuantityType, RelationshipType, EntityFlags } from './types.js';
 export type { SpatialNode, SpatialHierarchy } from './types.js';
+export type { IfcStoreBase } from './data-store.js';
 export * from './spatial-types.js';
 export * from './epsg-types.js';
 export {

--- a/packages/data/src/spatial-types.ts
+++ b/packages/data/src/spatial-types.ts
@@ -4,6 +4,11 @@
 
 import { IfcTypeEnum, IfcTypeEnumFromString, IfcTypeEnumToString } from './types.js';
 
+export interface SpatialIndex {
+  queryAABB(bounds: { min: [number, number, number]; max: [number, number, number] }): number[];
+  raycast(origin: [number, number, number], direction: [number, number, number]): number[];
+}
+
 export const SPATIAL_STRUCTURE_TYPE_ENUMS = [
   IfcTypeEnum.IfcProject,
   IfcTypeEnum.IfcSite,

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -525,3 +525,16 @@ export function IfcTypeEnumFromString(str: string): IfcTypeEnum {
 export function IfcTypeEnumToString(type: IfcTypeEnum): string {
   return TYPE_ENUM_TO_STRING.get(type) ?? 'Unknown';
 }
+
+export type IfcAttributeValue =
+  | string
+  | number
+  | boolean
+  | null
+  | IfcAttributeValue[];
+
+export interface IfcEntity {
+  expressId: number;
+  type: string;
+  attributes: IfcAttributeValue[];
+}

--- a/packages/mcp/src/headless-backend.ts
+++ b/packages/mcp/src/headless-backend.ts
@@ -44,7 +44,7 @@ import type {
   QueryDescriptor,
   ModelInfo,
 } from '@ifc-lite/sdk';
-import type { IfcDataStore } from '@ifc-lite/parser';
+import type { IfcStoreBase as IfcDataStore } from '@ifc-lite/data';
 import { MutablePropertyView, StoreEditor } from '@ifc-lite/mutations';
 import { EntityNode } from '@ifc-lite/query';
 import { RelationshipType, IfcTypeEnum, IfcTypeEnumFromString } from '@ifc-lite/data';

--- a/packages/mcp/src/headless-backend.ts
+++ b/packages/mcp/src/headless-backend.ts
@@ -44,7 +44,7 @@ import type {
   QueryDescriptor,
   ModelInfo,
 } from '@ifc-lite/sdk';
-import type { IfcStoreBase as IfcDataStore } from '@ifc-lite/data';
+import type { IfcDataStore } from '@ifc-lite/parser';
 import { MutablePropertyView, StoreEditor } from '@ifc-lite/mutations';
 import { EntityNode } from '@ifc-lite/query';
 import { RelationshipType, IfcTypeEnum, IfcTypeEnumFromString } from '@ifc-lite/data';
@@ -208,7 +208,7 @@ export class HeadlessLikeBackend implements BimBackend {
       return node.properties().map((pset) => ({
         name: pset.name,
         globalId: pset.globalId,
-        properties: pset.properties.map((p) => ({ name: p.name, type: p.type, value: p.value })),
+        properties: pset.properties.map((p) => ({ name: p.name, type: p.type, value: p.value as string | number | boolean | null })),
       }));
     }
 

--- a/packages/parser/src/columnar-parser-indexes.ts
+++ b/packages/parser/src/columnar-parser-indexes.ts
@@ -15,11 +15,7 @@ import {
     QuantityType,
 } from '@ifc-lite/data';
 
-// SpatialIndex interface - matches BVH from @ifc-lite/spatial
-export interface SpatialIndex {
-    queryAABB(bounds: { min: [number, number, number]; max: [number, number, number] }): number[];
-    raycast(origin: [number, number, number], direction: [number, number, number]): number[];
-}
+export type { SpatialIndex } from '@ifc-lite/data';
 
 /**
  * Entity-by-ID lookup interface. Supports both Map<number, EntityRef> (legacy)

--- a/packages/parser/src/columnar-parser.ts
+++ b/packages/parser/src/columnar-parser.ts
@@ -25,7 +25,8 @@ import {
     RelationshipType,
     QuantityType,
 } from '@ifc-lite/data';
-import type { SpatialHierarchy, QuantityTable, PropertyValue } from '@ifc-lite/data';
+import type { SpatialHierarchy, QuantityTable, PropertyValue, PropertySet, QuantitySet, IfcStoreBase, IfcEntity, IfcAttributeValue } from '@ifc-lite/data';
+import { BufferEntitySource } from './entity-source.js';
 import { batchExtractGlobalIdAndName } from './columnar-parser-attributes.js';
 import {
     GEOMETRY_TYPES,
@@ -48,10 +49,7 @@ import type { SpatialIndex, EntityByIdIndex } from './columnar-parser-indexes.js
 // Re-export interfaces/types from extracted modules for public API compatibility
 export type { SpatialIndex, EntityByIdIndex } from './columnar-parser-indexes.js';
 
-export interface IfcDataStore {
-    fileSize: number;
-    schemaVersion: 'IFC2X3' | 'IFC4' | 'IFC4X3' | 'IFC5';
-    entityCount: number;
+export interface IfcDataStore extends IfcStoreBase {
     parseTime: number;
 
     source: Uint8Array;
@@ -63,9 +61,6 @@ export interface IfcDataStore {
     properties: ReturnType<PropertyTableBuilder['build']>;
     quantities: QuantityTable;
     relationships: ReturnType<RelationshipGraphBuilder['build']>;
-
-    spatialHierarchy?: SpatialHierarchy;
-    spatialIndex?: SpatialIndex;
 
     /**
      * On-demand property lookup: entityId -> array of property set expressIds
@@ -513,6 +508,7 @@ export class ColumnarParser {
         // The hierarchy panel can render immediately while property/association
         // parsing continues. This lets the panel appear at the same time as
         // geometry streaming completes.
+        const entitySource = new BufferEntitySource(uint8Buffer, entityIndex);
         const earlyStore: IfcDataStore = {
             fileSize: buffer.byteLength,
             schemaVersion,
@@ -527,6 +523,10 @@ export class ColumnarParser {
             relationships: hierarchyRelGraph,
             spatialHierarchy,
             lengthUnitScale,
+            getEntity(expressId) { return entitySource.getEntity(expressId); },
+            getEntitiesByType(typeName) { return entitySource.getEntitiesByType(typeName); },
+            getProperties(expressId) { return this.properties.getForEntity(expressId); },
+            getQuantities(expressId) { return this.quantities.getForEntity(expressId); },
         };
         options.onSpatialReady?.(earlyStore);
 
@@ -638,7 +638,7 @@ export class ColumnarParser {
         const parseTime = performance.now() - startTime;
         options.onProgress?.({ phase: 'complete', percent: 100 });
 
-        return {
+        const finalStore: IfcDataStore = {
             ...earlyStore,
             parseTime,
             relationships: fullRelationshipGraph,
@@ -649,7 +649,18 @@ export class ColumnarParser {
             onDemandMaterialMap,
             onDemandDocumentMap,
             lengthUnitScale,
+            getEntity(expressId) { return entitySource.getEntity(expressId); },
+            getEntitiesByType(typeName) { return entitySource.getEntitiesByType(typeName); },
+            getProperties(expressId) {
+                if (onDemandPropertyMap.size > 0) return extractPropertiesOnDemand(this as IfcDataStore, expressId) as PropertySet[];
+                return this.properties.getForEntity(expressId);
+            },
+            getQuantities(expressId) {
+                if (onDemandQuantityMap.size > 0) return extractQuantitiesOnDemand(this as IfcDataStore, expressId) as QuantitySet[];
+                return this.quantities.getForEntity(expressId);
+            },
         };
+        return finalStore;
     }
 
     /**
@@ -944,6 +955,26 @@ export function extractAllEntityAttributes(
         }
     }
 
+    return result;
+}
+
+/**
+ * Returns named raw attribute pairs for an entity, filtered to display-relevant attributes.
+ * Skips structural/reference attributes using the IFC schema. Used by query layer for coercion.
+ */
+export function getRawNamedAttributes(
+    entity: IfcEntity
+): Array<{ name: string; raw: IfcAttributeValue }> {
+    const attrs = entity.attributes || [];
+    const attrNames = getAttributeNames(entity.type);
+
+    const result: Array<{ name: string; raw: IfcAttributeValue }> = [];
+    const len = Math.min(attrs.length, attrNames.length);
+    for (let i = 0; i < len; i++) {
+        const attrName = attrNames[i];
+        if (SKIP_DISPLAY_ATTRS.has(attrName)) continue;
+        result.push({ name: attrName, raw: attrs[i] });
+    }
     return result;
 }
 

--- a/packages/parser/src/columnar-parser.ts
+++ b/packages/parser/src/columnar-parser.ts
@@ -831,8 +831,10 @@ function getEntityRefFromStore(store: IfcDataStore, expressId: number): EntityRe
 }
 
 /**
- * Extract entity attributes on-demand from source buffer
- * Returns globalId, name, description, objectType, tag for any IfcRoot-derived entity.
+ * Extract entity attributes on-demand from source buffer.
+ * Returns globalId, name, description, objectType, tag mapped by schema name
+ * (see {@link extractRootAttributesFromEntity}), so the result stays correct
+ * for entity types whose attribute order differs from the IfcElement layout.
  * This is used for entities that weren't fully parsed during initial load.
  */
 export function extractEntityAttributesOnDemand(
@@ -850,18 +852,7 @@ export function extractEntityAttributesOnDemand(
         return { globalId: '', name: '', description: '', objectType: '', tag: '' };
     }
 
-    const attrs = entity.attributes || [];
-    // IfcRoot attributes: [GlobalId, OwnerHistory, Name, Description]
-    // IfcObject adds: [ObjectType] at index 4
-    // IfcProduct adds: [ObjectPlacement, Representation] at indices 5-6
-    // IfcElement adds: [Tag] at index 7
-    const globalId = typeof attrs[0] === 'string' ? attrs[0] : '';
-    const name = typeof attrs[2] === 'string' ? attrs[2] : '';
-    const description = typeof attrs[3] === 'string' ? attrs[3] : '';
-    const objectType = typeof attrs[4] === 'string' ? attrs[4] : '';
-    const tag = typeof attrs[7] === 'string' ? attrs[7] : '';
-
-    return { globalId, name, description, objectType, tag };
+    return extractRootAttributesFromEntity(entity);
 }
 
 /**
@@ -976,6 +967,72 @@ export function getRawNamedAttributes(
         result.push({ name: attrName, raw: attrs[i] });
     }
     return result;
+}
+
+interface RootAttrIndices {
+    known: boolean;
+    globalId: number;
+    name: number;
+    description: number;
+    objectType: number;
+    tag: number;
+}
+
+// getAttributeNames() walks the schema registry (an O(types) scan for the
+// UPPERCASE STEP names entities carry), so memoise the per-type index lookup.
+// There are only a few hundred distinct types but potentially millions of
+// entities, keeping the on-demand path cheap even when called per entity.
+const rootAttrIndexCache = new Map<string, RootAttrIndices>();
+
+function getRootAttrIndices(type: string): RootAttrIndices {
+    let idx = rootAttrIndexCache.get(type);
+    if (!idx) {
+        const names = getAttributeNames(type);
+        idx = {
+            known: names.length > 0,
+            globalId: names.indexOf('GlobalId'),
+            name: names.indexOf('Name'),
+            description: names.indexOf('Description'),
+            objectType: names.indexOf('ObjectType'),
+            tag: names.indexOf('Tag'),
+        };
+        rootAttrIndexCache.set(type, idx);
+    }
+    return idx;
+}
+
+/**
+ * Resolve the common IfcRoot-family display attributes (GlobalId, Name,
+ * Description, ObjectType, Tag) from an entity's raw attribute array.
+ *
+ * These are mapped by schema-derived attribute *name*, not fixed index. The
+ * fixed indices `[0],[2],[3],[4],[7]` only hold for the IfcElement layout: for
+ * a spatial element `attrs[7]` is LongName (not Tag), and for a resource entity
+ * like IfcMaterial `attrs[0]` is Name (not GlobalId). Name-mapping keeps all of
+ * these correct for every entity type, returning '' for attributes the type
+ * does not declare.
+ *
+ * For types the schema registry does not recognise (e.g. an IFC4x3 infra leaf
+ * outside the codegen pin, or a vendor extension) we fall back to the canonical
+ * IfcRoot/IfcElement positions so we never regress vs. the old fixed-index path.
+ */
+export function extractRootAttributesFromEntity(
+    entity: IfcEntity
+): { globalId: string; name: string; description: string; objectType: string; tag: string } {
+    const attrs = entity.attributes || [];
+    const idx = getRootAttrIndices(entity.type);
+    const pick = (schemaIndex: number, fallbackIndex: number): string => {
+        const i = idx.known ? schemaIndex : fallbackIndex;
+        const raw = i >= 0 ? attrs[i] : undefined;
+        return typeof raw === 'string' ? raw : '';
+    };
+    return {
+        globalId: pick(idx.globalId, 0),
+        name: pick(idx.name, 2),
+        description: pick(idx.description, 3),
+        objectType: pick(idx.objectType, 4),
+        tag: pick(idx.tag, 7),
+    };
 }
 
 // Re-export on-demand extraction functions from focused module

--- a/packages/parser/src/data-store-transport.ts
+++ b/packages/parser/src/data-store-transport.ts
@@ -46,6 +46,9 @@ import {
 import { CompactEntityIndex } from './compact-entity-index.js';
 import type { EntityRef } from './types.js';
 import type { IfcDataStore, EntityByIdIndex } from './columnar-parser.js';
+import { BufferEntitySource } from './entity-source.js';
+import { extractPropertiesOnDemand, extractQuantitiesOnDemand } from './columnar-parser.js';
+import type { PropertySet, QuantitySet } from '@ifc-lite/data';
 
 // ────────────────────────────────────────────────────────────────────────────
 // CompactEntityIndex transport
@@ -463,6 +466,14 @@ export function fromTransport(payload: DataStoreTransport, source: Uint8Array): 
     ? spatialHierarchyFromColumns(payload.spatialHierarchy)
     : undefined;
 
+  const entityIndex = {
+    byId: byIdIndex as unknown as EntityByIdIndex,
+    byType,
+  };
+  const onDemandPropertyMap = new Map(payload.onDemandPropertyMap.map(([k, v]) => [k, [...v]]));
+  const onDemandQuantityMap = new Map(payload.onDemandQuantityMap.map(([k, v]) => [k, [...v]]));
+  const entitySource = new BufferEntitySource(source, entityIndex);
+
   const store: IfcDataStore = {
     fileSize: payload.fileSize,
     schemaVersion: payload.schemaVersion,
@@ -470,10 +481,7 @@ export function fromTransport(payload: DataStoreTransport, source: Uint8Array): 
     parseTime: payload.parseTime,
 
     source,
-    entityIndex: {
-      byId: byIdIndex as unknown as EntityByIdIndex,
-      byType,
-    },
+    entityIndex,
     deferredEntityIndex: deferredEntityIndex as unknown as EntityByIdIndex | undefined,
 
     strings,
@@ -483,11 +491,21 @@ export function fromTransport(payload: DataStoreTransport, source: Uint8Array): 
     relationships,
     spatialHierarchy,
 
-    onDemandPropertyMap: new Map(payload.onDemandPropertyMap.map(([k, v]) => [k, [...v]])),
-    onDemandQuantityMap: new Map(payload.onDemandQuantityMap.map(([k, v]) => [k, [...v]])),
+    onDemandPropertyMap,
+    onDemandQuantityMap,
     onDemandClassificationMap: new Map(payload.onDemandClassificationMap.map(([k, v]) => [k, [...v]])),
     onDemandMaterialMap: new Map(payload.onDemandMaterialMap),
     onDemandDocumentMap: new Map(payload.onDemandDocumentMap.map(([k, v]) => [k, [...v]])),
+    getEntity(expressId) { return entitySource.getEntity(expressId); },
+    getEntitiesByType(typeName) { return entitySource.getEntitiesByType(typeName); },
+    getProperties(expressId) {
+      if (onDemandPropertyMap.size > 0) return extractPropertiesOnDemand(store, expressId) as unknown as PropertySet[];
+      return store.properties.getForEntity(expressId) as PropertySet[];
+    },
+    getQuantities(expressId) {
+      if (onDemandQuantityMap.size > 0) return extractQuantitiesOnDemand(store, expressId) as unknown as QuantitySet[];
+      return store.quantities.getForEntity(expressId) as QuantitySet[];
+    },
   };
   return store;
 }

--- a/packages/parser/src/entity-source.ts
+++ b/packages/parser/src/entity-source.ts
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { IfcEntity } from '@ifc-lite/data';
+import type { EntityByIdIndex } from './columnar-parser-indexes.js';
+import { EntityExtractor } from './entity-extractor.js';
+
+interface EntityLookup {
+  byId: EntityByIdIndex;
+  byType: Map<string, number[]> | { get(key: string): number[] | undefined };
+}
+
+export class BufferEntitySource {
+  private extractor: EntityExtractor;
+  private index: EntityLookup;
+
+  constructor(source: Uint8Array, index: EntityLookup) {
+    this.extractor = new EntityExtractor(source);
+    this.index = index;
+  }
+
+  getEntity(expressId: number): IfcEntity | null {
+    const ref = this.index.byId.get(expressId);
+    if (!ref) return null;
+    return this.extractor.extractEntity(ref);
+  }
+
+  getEntitiesByType(typeName: string): IfcEntity[] {
+    const ids = this.index.byType.get(typeName.toUpperCase()) ?? [];
+    const result: IfcEntity[] = [];
+    for (const id of ids) {
+      const entity = this.getEntity(id);
+      if (entity) result.push(entity);
+    }
+    return result;
+  }
+}

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -19,7 +19,8 @@ export { QuantityExtractor } from './quantity-extractor.js';
 export { RelationshipExtractor } from './relationship-extractor.js';
 export { SpatialHierarchyBuilder } from './spatial-hierarchy-builder.js';
 export { extractLengthUnitScale } from './unit-extractor.js';
-export { ColumnarParser, type IfcDataStore, type EntityByIdIndex, extractPropertiesOnDemand, extractQuantitiesOnDemand, extractEntityAttributesOnDemand, extractAllEntityAttributes, extractClassificationsOnDemand, extractMaterialsOnDemand, extractTypePropertiesOnDemand, extractTypeEntityOwnProperties, extractDocumentsOnDemand, extractRelationshipsOnDemand, extractGeoreferencingOnDemand, type ClassificationInfo, type MaterialInfo, type MaterialLayerInfo, type MaterialProfileInfo, type MaterialConstituentInfo, type TypePropertyInfo, type DocumentInfo, type EntityRelationships } from './columnar-parser.js';
+export { ColumnarParser, type IfcDataStore, type EntityByIdIndex, extractPropertiesOnDemand, extractQuantitiesOnDemand, extractEntityAttributesOnDemand, extractAllEntityAttributes, getRawNamedAttributes, extractClassificationsOnDemand, extractMaterialsOnDemand, extractTypePropertiesOnDemand, extractTypeEntityOwnProperties, extractDocumentsOnDemand, extractRelationshipsOnDemand, extractGeoreferencingOnDemand, type ClassificationInfo, type MaterialInfo, type MaterialLayerInfo, type MaterialProfileInfo, type MaterialConstituentInfo, type TypePropertyInfo, type DocumentInfo, type EntityRelationships } from './columnar-parser.js';
+export type { IfcStoreBase } from '@ifc-lite/data';
 // WorkerParser is browser-only due to Vite worker imports
 // Import from '@ifc-lite/parser/browser' instead
 
@@ -127,7 +128,7 @@ export interface ParseOptions {
   disableWorkerScan?: boolean;
   /** Called when spatial hierarchy is ready, BEFORE property/association parsing completes.
    *  Use this to show the hierarchy panel early while the full parse finishes. */
-  onSpatialReady?: (partialStore: import('./columnar-parser.js').IfcDataStore) => void;
+  onSpatialReady?: (partialStore: IfcDataStore) => void;
   /**
    * Pre-built entity index from another worker (typically the streaming
    * geometry pre-pass). When supplied, `parseColumnar` skips both the

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -19,7 +19,7 @@ export { QuantityExtractor } from './quantity-extractor.js';
 export { RelationshipExtractor } from './relationship-extractor.js';
 export { SpatialHierarchyBuilder } from './spatial-hierarchy-builder.js';
 export { extractLengthUnitScale } from './unit-extractor.js';
-export { ColumnarParser, type IfcDataStore, type EntityByIdIndex, extractPropertiesOnDemand, extractQuantitiesOnDemand, extractEntityAttributesOnDemand, extractAllEntityAttributes, getRawNamedAttributes, extractClassificationsOnDemand, extractMaterialsOnDemand, extractTypePropertiesOnDemand, extractTypeEntityOwnProperties, extractDocumentsOnDemand, extractRelationshipsOnDemand, extractGeoreferencingOnDemand, type ClassificationInfo, type MaterialInfo, type MaterialLayerInfo, type MaterialProfileInfo, type MaterialConstituentInfo, type TypePropertyInfo, type DocumentInfo, type EntityRelationships } from './columnar-parser.js';
+export { ColumnarParser, type IfcDataStore, type EntityByIdIndex, extractPropertiesOnDemand, extractQuantitiesOnDemand, extractEntityAttributesOnDemand, extractAllEntityAttributes, getRawNamedAttributes, extractRootAttributesFromEntity, extractClassificationsOnDemand, extractMaterialsOnDemand, extractTypePropertiesOnDemand, extractTypeEntityOwnProperties, extractDocumentsOnDemand, extractRelationshipsOnDemand, extractGeoreferencingOnDemand, type ClassificationInfo, type MaterialInfo, type MaterialLayerInfo, type MaterialProfileInfo, type MaterialConstituentInfo, type TypePropertyInfo, type DocumentInfo, type EntityRelationships } from './columnar-parser.js';
 export type { IfcStoreBase } from '@ifc-lite/data';
 // WorkerParser is browser-only due to Vite worker imports
 // Import from '@ifc-lite/parser/browser' instead

--- a/packages/parser/src/types.ts
+++ b/packages/parser/src/types.ts
@@ -19,22 +19,8 @@ export interface EntityIndex {
   byType: Map<string, number[]>;
 }
 
-/**
- * IFC attribute value - can be primitive, reference, or nested list
- * Uses `unknown` for runtime type checking in extractors
- */
-export type IfcAttributeValue =
-  | string
-  | number
-  | boolean
-  | null
-  | IfcAttributeValue[];
-
-export interface IfcEntity {
-  expressId: number;
-  type: string;
-  attributes: IfcAttributeValue[];
-}
+import type { IfcEntity } from '@ifc-lite/data';
+export type { IfcAttributeValue, IfcEntity } from '@ifc-lite/data';
 
 export interface PropertyValue {
   type: 'string' | 'number' | 'boolean' | 'null' | 'reference';

--- a/packages/parser/test/attribute-extractor.test.ts
+++ b/packages/parser/test/attribute-extractor.test.ts
@@ -142,4 +142,63 @@ describe('Entity Attribute Extraction', () => {
     expect(attrs.description).toBe('');
     expect(attrs.objectType).toBe('');
   });
+
+  // ── Schema-mapped (non-IfcElement) layouts ──────────────────────
+  // The fixed indices [0],[2],[3],[4],[7] only hold for IfcElement. These
+  // assert the attributes are resolved by schema name so other layouts stay
+  // correct (regression guard for the positional-index extraction).
+
+  function storeFor(step: string, expressId: number): IfcDataStore {
+    const source = new TextEncoder().encode(step);
+    const ref: EntityRef = {
+      expressId,
+      type: step.match(/=\s*(\w+)/)![1],
+      byteOffset: 0,
+      byteLength: source.length,
+      lineNumber: 1,
+    };
+    return {
+      source,
+      entityIndex: { byId: new Map([[expressId, ref]]), byType: new Map() },
+    } as unknown as IfcDataStore;
+  }
+
+  it('does not surface a spatial element LongName as Tag (IfcSite)', () => {
+    // IfcSite has no Tag attribute; `attrs[7]` is LongName. The IfcElement
+    // positional layout would wrongly report LongName as the entity Tag.
+    const step = `#1=IFCSITE('site-guid',$,'Site Name','Site Desc','SiteObjType',$,$,'My Long Name',.ELEMENT.,$,$,$,$,$);`;
+    const attrs = extractEntityAttributesOnDemand(storeFor(step, 1), 1);
+
+    expect(attrs.globalId).toBe('site-guid');
+    expect(attrs.name).toBe('Site Name');
+    expect(attrs.description).toBe('Site Desc');
+    expect(attrs.objectType).toBe('SiteObjType');
+    expect(attrs.tag).toBe(''); // not 'My Long Name'
+  });
+
+  it('reads resource-entity attributes by name (IfcMaterial)', () => {
+    // IfcMaterial attribute order is [Name, Description, Category] — it has no
+    // GlobalId, so `attrs[0]` is the material Name, not a GlobalId.
+    const step = `#2=IFCMATERIAL('Concrete','Cast in place','concrete');`;
+    const attrs = extractEntityAttributesOnDemand(storeFor(step, 2), 2);
+
+    expect(attrs.globalId).toBe(''); // not 'Concrete'
+    expect(attrs.name).toBe('Concrete'); // not 'concrete'
+    expect(attrs.description).toBe('Cast in place');
+    expect(attrs.objectType).toBe('');
+    expect(attrs.tag).toBe('');
+  });
+
+  it('falls back to the IfcElement layout for schema-unknown types', () => {
+    // Unknown/vendor types aren't in the registry; preserve the legacy
+    // positional behaviour rather than returning empty strings.
+    const step = `#3=IFCFOOBARXYZ('foo-guid',$,'Foo Name','Foo Desc','Foo Type',$,$,'Foo Tag');`;
+    const attrs = extractEntityAttributesOnDemand(storeFor(step, 3), 3);
+
+    expect(attrs.globalId).toBe('foo-guid');
+    expect(attrs.name).toBe('Foo Name');
+    expect(attrs.description).toBe('Foo Desc');
+    expect(attrs.objectType).toBe('Foo Type');
+    expect(attrs.tag).toBe('Foo Tag');
+  });
 });

--- a/packages/parser/test/entity-source.test.ts
+++ b/packages/parser/test/entity-source.test.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 import { describe, it, expect } from 'vitest';
 import { BufferEntitySource } from '../src/entity-source.js';
 import type { EntityIndex } from '../src/types.js';

--- a/packages/parser/test/entity-source.test.ts
+++ b/packages/parser/test/entity-source.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { BufferEntitySource } from '../src/entity-source.js';
+import type { EntityIndex } from '../src/types.js';
+
+function makeIndex(step: string): { source: Uint8Array; index: EntityIndex } {
+  const source = new TextEncoder().encode(step);
+  const index: EntityIndex = {
+    byId: new Map([[10, { expressId: 10, type: 'IFCWALL', byteOffset: 0, byteLength: source.length, lineNumber: 1 }]]),
+    byType: new Map([['IFCWALL', [10]]]),
+  };
+  return { source, index };
+}
+
+describe('BufferEntitySource', () => {
+  it('getEntity returns parsed entity for known expressId', () => {
+    const { source, index } = makeIndex(`#10=IFCWALL('abc',$,'My Wall',$,$,$,$,.NOTDEFINED.);`);
+    const src = new BufferEntitySource(source, index);
+    const entity = src.getEntity(10);
+    expect(entity).not.toBeNull();
+    expect(entity!.expressId).toBe(10);
+    expect(entity!.type).toBe('IFCWALL');
+    expect(entity!.attributes[2]).toBe('My Wall');
+  });
+
+  it('getEntity returns null for unknown expressId', () => {
+    const { source, index } = makeIndex(`#10=IFCWALL('abc',$,'My Wall',$,$,$,$,.NOTDEFINED.);`);
+    const src = new BufferEntitySource(source, index);
+    expect(src.getEntity(999)).toBeNull();
+  });
+
+  it('getEntitiesByType returns all entities of that type', () => {
+    const { source, index } = makeIndex(`#10=IFCWALL('a',$,'W1',$,$,$,$,.NOTDEFINED.);`);
+    const src = new BufferEntitySource(source, index);
+    const walls = src.getEntitiesByType('IFCWALL');
+    expect(walls).toHaveLength(1);
+    expect(walls[0].expressId).toBe(10);
+  });
+
+  it('getEntitiesByType returns empty array for unknown type', () => {
+    const { source, index } = makeIndex(`#10=IFCWALL('abc',$,'W',$,$,$,$,.NOTDEFINED.);`);
+    const src = new BufferEntitySource(source, index);
+    expect(src.getEntitiesByType('IFCBEAM')).toEqual([]);
+  });
+});

--- a/packages/query/src/entity-node.ts
+++ b/packages/query/src/entity-node.ts
@@ -6,7 +6,7 @@
  * Entity node for graph traversal
  */
 
-import type { IfcStoreBase as IfcDataStore, IfcEntity, IfcAttributeValue } from '@ifc-lite/data';
+import type { IfcStoreBase as IfcDataStore, IfcEntity, IfcAttributeValue, PropertySet, QuantitySet, PropertyValue } from '@ifc-lite/data';
 import { getRawNamedAttributes } from '@ifc-lite/parser';
 import { RelationshipType } from '@ifc-lite/data';
 
@@ -224,17 +224,17 @@ export class EntityNode {
   }
 
   // Data access - delegates to IfcDataStore interface methods
-  properties(): ReturnType<typeof this.store.getProperties> {
+  properties(): PropertySet[] {
     return this.store.getProperties(this.expressId);
   }
 
-  property(psetName: string, propName: string): ReturnType<typeof this.store.properties.getPropertyValue> {
+  property(psetName: string, propName: string): PropertyValue | null {
     const props = this.store.getProperties(this.expressId);
     const pset = props.find(p => p.name === psetName);
     return pset?.properties.find(p => p.name === propName)?.value ?? null;
   }
 
-  quantities(): ReturnType<typeof this.store.getQuantities> {
+  quantities(): QuantitySet[] {
     return this.store.getQuantities(this.expressId);
   }
 

--- a/packages/query/src/entity-node.ts
+++ b/packages/query/src/entity-node.ts
@@ -7,7 +7,7 @@
  */
 
 import type { IfcStoreBase as IfcDataStore, IfcEntity, IfcAttributeValue, PropertySet, QuantitySet, PropertyValue } from '@ifc-lite/data';
-import { getRawNamedAttributes } from '@ifc-lite/parser';
+import { getRawNamedAttributes, extractRootAttributesFromEntity } from '@ifc-lite/parser';
 import { RelationshipType } from '@ifc-lite/data';
 
 function coerceRaw(raw: IfcAttributeValue): string | number | boolean | null {
@@ -62,14 +62,12 @@ export class EntityNode {
   private getOnDemandAttributes(): { globalId: string; name: string; description: string; objectType: string; tag: string } {
     if (this._cachedAttributes) return this._cachedAttributes;
     const entity = this.store.getEntity(this.expressId);
-    const attrs = entity?.attributes ?? [];
-    const result = {
-      globalId: typeof attrs[0] === 'string' ? attrs[0] : '',
-      name: typeof attrs[2] === 'string' ? attrs[2] : '',
-      description: typeof attrs[3] === 'string' ? attrs[3] : '',
-      objectType: typeof attrs[4] === 'string' ? attrs[4] : '',
-      tag: typeof attrs[7] === 'string' ? attrs[7] : '',
-    };
+    // Map by schema attribute name, not fixed index: `attrs[7]` is Tag only for
+    // IfcElement — for an IfcSite it is LongName, and for an IfcMaterial
+    // `attrs[0]` is Name rather than GlobalId. See extractRootAttributesFromEntity.
+    const result = entity
+      ? extractRootAttributesFromEntity(entity)
+      : { globalId: '', name: '', description: '', objectType: '', tag: '' };
     this._cachedAttributes = result;
     return result;
   }

--- a/packages/query/src/entity-node.ts
+++ b/packages/query/src/entity-node.ts
@@ -6,9 +6,44 @@
  * Entity node for graph traversal
  */
 
-import type { IfcDataStore } from '@ifc-lite/parser';
-import { extractPropertiesOnDemand, extractQuantitiesOnDemand, extractEntityAttributesOnDemand, extractAllEntityAttributes } from '@ifc-lite/parser';
+import type { IfcStoreBase as IfcDataStore, IfcEntity, IfcAttributeValue } from '@ifc-lite/data';
+import { getRawNamedAttributes } from '@ifc-lite/parser';
 import { RelationshipType } from '@ifc-lite/data';
+
+function coerceRaw(raw: IfcAttributeValue): string | number | boolean | null {
+  if (typeof raw === 'string') {
+    if (raw === '.U.' || raw === '.X.') return null;
+    if (raw === '.T.') return true;
+    if (raw === '.F.') return false;
+    return raw.startsWith('.') && raw.endsWith('.') ? raw.slice(1, -1) : raw;
+  }
+  if (typeof raw === 'number' || typeof raw === 'boolean') return raw;
+  if (Array.isArray(raw) && raw.length === 2) {
+    const tag = String(raw[0]).toUpperCase();
+    const inner = raw[1];
+    if (tag.includes('BOOLEAN')) return inner === '.T.' || inner === true;
+    if (tag.includes('LOGICAL')) {
+      if (inner === '.U.' || inner === '.X.') return null;
+      return inner === '.T.' || inner === true;
+    }
+    if (typeof inner === 'number' || typeof inner === 'boolean') return inner;
+    if (typeof inner === 'string' && inner) {
+      return inner.startsWith('.') && inner.endsWith('.') ? inner.slice(1, -1) : inner;
+    }
+  }
+  return null;
+}
+
+export function extractAllEntityAttributesFromEntity(
+  entity: IfcEntity
+): Array<{ name: string; value: string | number | boolean }> {
+  const result: Array<{ name: string; value: string | number | boolean }> = [];
+  for (const { name, raw } of getRawNamedAttributes(entity)) {
+    const value = coerceRaw(raw);
+    if (value !== null) result.push({ name, value });
+  }
+  return result;
+}
 
 export class EntityNode {
   private store: IfcDataStore;
@@ -25,17 +60,18 @@ export class EntityNode {
    * Only extracts if stored values are empty and source buffer is available
    */
   private getOnDemandAttributes(): { globalId: string; name: string; description: string; objectType: string; tag: string } {
-    if (this._cachedAttributes) {
-      return this._cachedAttributes;
-    }
-
-    // Only extract on-demand if source buffer is available
-    const attrs = (this.store.source && this.store.entityIndex)
-      ? extractEntityAttributesOnDemand(this.store, this.expressId)
-      : { globalId: '', name: '', description: '', objectType: '', tag: '' };
-
-    this._cachedAttributes = attrs;
-    return attrs;
+    if (this._cachedAttributes) return this._cachedAttributes;
+    const entity = this.store.getEntity(this.expressId);
+    const attrs = entity?.attributes ?? [];
+    const result = {
+      globalId: typeof attrs[0] === 'string' ? attrs[0] : '',
+      name: typeof attrs[2] === 'string' ? attrs[2] : '',
+      description: typeof attrs[3] === 'string' ? attrs[3] : '',
+      objectType: typeof attrs[4] === 'string' ? attrs[4] : '',
+      tag: typeof attrs[7] === 'string' ? attrs[7] : '',
+    };
+    this._cachedAttributes = result;
+    return result;
   }
 
   get globalId(): string {
@@ -81,9 +117,11 @@ export class EntityNode {
    * Skips GlobalId (shown separately), OwnerHistory, and geometry references.
    */
   allAttributes(): Array<{ name: string; value: string | number | boolean }> {
-    if (this.store.source && this.store.entityIndex) {
-      return extractAllEntityAttributes(this.store, this.expressId);
+    const entity = this.store.getEntity(this.expressId);
+    if (entity) {
+      return extractAllEntityAttributesFromEntity(entity);
     }
+
     // Fallback: return individually known attributes
     const attrs: Array<{ name: string; value: string | number | boolean }> = [];
     if (this.name) attrs.push({ name: 'Name', value: this.name });
@@ -185,46 +223,25 @@ export class EntityNode {
     return null;
   }
 
-  // Data access - uses on-demand extraction when available (preferred)
-  properties(): Array<{ name: string; globalId?: string; properties: Array<{ name: string; type: number; value: any }> }> {
-    // Use on-demand extraction if map is available (fast single-entity access)
-    if (this.store.onDemandPropertyMap) {
-      return extractPropertiesOnDemand(this.store, this.expressId);
-    }
-    // Fallback to pre-computed property table (server-parsed data, IFCX)
-    return this.store.properties.getForEntity(this.expressId);
+  // Data access - delegates to IfcDataStore interface methods
+  properties(): ReturnType<typeof this.store.getProperties> {
+    return this.store.getProperties(this.expressId);
   }
 
   property(psetName: string, propName: string): ReturnType<typeof this.store.properties.getPropertyValue> {
-    // For single property lookup, on-demand would be slower than table lookup
-    // But if no table, extract on-demand and search
-    if (this.store.onDemandPropertyMap && !this.store.properties.getForEntity(this.expressId).length) {
-      const props = this.properties();
-      const pset = props.find(p => p.name === psetName);
-      const prop = pset?.properties.find(p => p.name === propName);
-      return prop?.value ?? null;
-    }
-    return this.store.properties.getPropertyValue(this.expressId, psetName, propName);
+    const props = this.store.getProperties(this.expressId);
+    const pset = props.find(p => p.name === psetName);
+    return pset?.properties.find(p => p.name === propName)?.value ?? null;
   }
 
-  quantities(): Array<{ name: string; quantities: Array<{ name: string; type: number; value: number }> }> {
-    // Use on-demand extraction if map is available (fast single-entity access)
-    if (this.store.onDemandQuantityMap) {
-      return extractQuantitiesOnDemand(this.store, this.expressId);
-    }
-    // Fallback to pre-computed quantity table (server-parsed data, IFCX)
-    return this.store.quantities.getForEntity(this.expressId);
+  quantities(): ReturnType<typeof this.store.getQuantities> {
+    return this.store.getQuantities(this.expressId);
   }
 
   quantity(qsetName: string, quantityName: string): number | null {
-    // For single quantity lookup, use on-demand if no table data
-    if (this.store.onDemandQuantityMap && !this.store.quantities.getForEntity(this.expressId).length) {
-      const qsets = this.quantities();
-      const qset = qsets.find(q => q.name === qsetName);
-      const qty = qset?.quantities.find(q => q.name === quantityName);
-      return qty?.value ?? null;
-    }
-    return this.store.quantities.getQuantityValue(this.expressId, qsetName, quantityName);
+    const qsets = this.store.getQuantities(this.expressId);
+    const qset = qsets.find(q => q.name === qsetName);
+    return qset?.quantities.find(q => q.name === quantityName)?.value ?? null;
   }
 
   private getRelated(relType: RelationshipType, direction: 'forward' | 'inverse'): EntityNode[] {

--- a/packages/query/src/entity-query.ts
+++ b/packages/query/src/entity-query.ts
@@ -6,7 +6,7 @@
  * Fluent query builder for entities
  */
 
-import type { IfcDataStore } from '@ifc-lite/parser';
+import type { IfcStoreBase as IfcDataStore } from '@ifc-lite/data';
 import { IfcTypeEnum } from '@ifc-lite/data';
 import { QueryResultEntity } from './query-result-entity.js';
 

--- a/packages/query/src/query-result-entity.ts
+++ b/packages/query/src/query-result-entity.ts
@@ -6,53 +6,10 @@
  * Query result entity - lazy-loaded entity data
  */
 
-import type { IfcDataStore } from '@ifc-lite/parser';
-import { extractPropertiesOnDemand, extractQuantitiesOnDemand } from '@ifc-lite/parser';
-import type { PropertySet, QuantitySet, Property, Quantity, PropertyValue } from '@ifc-lite/data';
-import { PropertyValueType, QuantityType } from '@ifc-lite/data';
+import type { IfcStoreBase as IfcDataStore } from '@ifc-lite/data';
+import type { PropertySet, QuantitySet, PropertyValue } from '@ifc-lite/data';
 import type { MeshData } from '@ifc-lite/geometry';
 import { EntityNode } from './entity-node.js';
-
-function hasOnDemandProperties(store: IfcDataStore): boolean {
-  return !!store.onDemandPropertyMap && !!store.source && store.source.length > 0;
-}
-
-function hasOnDemandQuantities(store: IfcDataStore): boolean {
-  return !!store.onDemandQuantityMap && !!store.source && store.source.length > 0;
-}
-
-function loadPropertiesFromStore(store: IfcDataStore, expressId: number): PropertySet[] {
-  const preParsed = store.properties.getForEntity(expressId);
-  if (preParsed.length > 0 || !hasOnDemandProperties(store)) {
-    return preParsed;
-  }
-  const raw = extractPropertiesOnDemand(store, expressId);
-  return raw.map((pset): PropertySet => ({
-    name: pset.name,
-    globalId: pset.globalId ?? '',
-    properties: pset.properties.map((p): Property => ({
-      name: p.name,
-      type: p.type as PropertyValueType,
-      value: p.value as PropertyValue,
-    })),
-  }));
-}
-
-function loadQuantitiesFromStore(store: IfcDataStore, expressId: number): QuantitySet[] {
-  const preParsed = store.quantities ? store.quantities.getForEntity(expressId) : [];
-  if (preParsed.length > 0 || !hasOnDemandQuantities(store)) {
-    return preParsed;
-  }
-  const raw = extractQuantitiesOnDemand(store, expressId);
-  return raw.map((qset): QuantitySet => ({
-    name: qset.name,
-    quantities: qset.quantities.map((q): Quantity => ({
-      name: q.name,
-      type: q.type as QuantityType,
-      value: q.value,
-    })),
-  }));
-}
 
 export class QueryResultEntity {
   private store: IfcDataStore;
@@ -84,14 +41,14 @@ export class QueryResultEntity {
     if (this._properties !== undefined) {
       return this._properties;
     }
-    return loadPropertiesFromStore(this.store, this.expressId);
+    return this.store.getProperties(this.expressId);
   }
 
   get quantities(): QuantitySet[] {
     if (this._quantities !== undefined) {
       return this._quantities;
     }
-    return loadQuantitiesFromStore(this.store, this.expressId);
+    return this.store.getQuantities(this.expressId);
   }
 
   get geometry(): MeshData | null {
@@ -103,10 +60,7 @@ export class QueryResultEntity {
   }
 
   getProperty(psetName: string, propName: string): PropertyValue | null {
-    const direct = this.store.properties.getPropertyValue(this.expressId, psetName, propName);
-    if (direct !== null) return direct;
-    if (!hasOnDemandProperties(this.store)) return null;
-    for (const pset of loadPropertiesFromStore(this.store, this.expressId)) {
+    for (const pset of this.store.getProperties(this.expressId)) {
       if (pset.name !== psetName) continue;
       for (const p of pset.properties) {
         if (p.name === propName) return p.value;
@@ -117,13 +71,13 @@ export class QueryResultEntity {
 
   loadProperties(): void {
     if (this._properties === undefined) {
-      this._properties = loadPropertiesFromStore(this.store, this.expressId);
+      this._properties = this.store.getProperties(this.expressId);
     }
   }
 
   loadQuantities(): void {
     if (this._quantities === undefined) {
-      this._quantities = loadQuantitiesFromStore(this.store, this.expressId);
+      this._quantities = this.store.getQuantities(this.expressId);
     }
   }
   

--- a/packages/query/test/entity-node-attribute-layout.test.ts
+++ b/packages/query/test/entity-node-attribute-layout.test.ts
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression test for the on-demand attribute fallback in EntityNode.
+ *
+ * `getOnDemandAttributes()` resolves GlobalId/Name/Description/ObjectType/Tag
+ * by schema-mapped attribute *name*, not fixed index. The fixed indices
+ * `[0],[2],[3],[4],[7]` only describe the IfcElement layout — for an IfcSite
+ * `attrs[7]` is LongName, so positional extraction would leak LongName into
+ * `tag`. This asserts the schema-correct behaviour for a non-IfcElement entity.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { StepTokenizer, ColumnarParser } from '@ifc-lite/parser';
+import { EntityNode } from '../src/entity-node.js';
+
+async function parseFixture(ifc: string) {
+  const source = new TextEncoder().encode(ifc);
+  const tokenizer = new StepTokenizer(source);
+  const entityRefs: Array<{
+    expressId: number;
+    type: string;
+    byteOffset: number;
+    byteLength: number;
+    lineNumber: number;
+  }> = [];
+  for (const ref of tokenizer.scanEntitiesFast()) {
+    entityRefs.push({
+      expressId: ref.expressId,
+      type: ref.type,
+      byteOffset: ref.offset,
+      byteLength: ref.length,
+      lineNumber: ref.line,
+    });
+  }
+  const parser = new ColumnarParser();
+  return parser.parseLite(source.buffer.slice(0), entityRefs, {});
+}
+
+describe('EntityNode on-demand attribute layout', () => {
+  const ifc = `#1=IFCOWNERHISTORY($,$,$,$,$,$,$,0);
+#10=IFCSITE('site-guid',#1,'Site Name','Site Desc','SiteObjType',$,$,'My Long Name',.ELEMENT.,$,$,$,$,$);`;
+
+  it('does not report an IfcSite LongName as its Tag', async () => {
+    const store = await parseFixture(ifc);
+    const site = new EntityNode(store as never, 10);
+
+    // `tag` always uses the on-demand path; IfcSite has no Tag attribute, so
+    // it must be empty rather than the LongName sitting at attribute index 7.
+    expect(site.tag).toBe('');
+    expect(site.globalId).toBe('site-guid');
+    expect(site.name).toBe('Site Name');
+    expect(site.description).toBe('Site Desc');
+    expect(site.objectType).toBe('SiteObjType');
+  });
+});

--- a/packages/query/test/mock-store.ts
+++ b/packages/query/test/mock-store.ts
@@ -134,6 +134,21 @@ export function createMockStore(opts: MockStoreOptions = {}) {
     byType.get(upper)!.push(e.expressId);
   }
 
+  const entityMap = new Map<number, { expressId: number; type: string; attributes: unknown[] }>();
+  for (const e of opts.entities ?? []) {
+    entityMap.set(e.expressId, {
+      expressId: e.expressId,
+      type: e.type,
+      attributes: [
+        e.globalId || null,
+        null, // OwnerHistory
+        e.name || null,
+        e.description || null,
+        e.objectType || null,
+      ],
+    });
+  }
+
   return {
     fileSize: 0,
     schemaVersion: 'IFC4' as const,
@@ -148,6 +163,14 @@ export function createMockStore(opts: MockStoreOptions = {}) {
     properties,
     quantities,
     relationships,
+
+    getEntity: (expressId: number) => entityMap.get(expressId) ?? null,
+    getEntitiesByType: (typeName: string) => {
+      const ids = byType.get(typeName.toUpperCase()) ?? [];
+      return ids.map((id: number) => entityMap.get(id)).filter(Boolean);
+    },
+    getProperties: (expressId: number) => properties.getForEntity(expressId),
+    getQuantities: (expressId: number) => quantities.getForEntity(expressId),
 
     // These are optional on IfcDataStore and can be undefined for mock
     spatialHierarchy: undefined,


### PR DESCRIPTION
A step towards decoupling the data store to support other storage paradigms (mentioned in #916)

`IfcStoreBase` (`@ifc-lite/data`) - A new lean consumer interface with only the fields needed by non-parser packages, and four accessor methods (getEntity, getEntitiesByType, getProperties, getQuantities). The full parser store now extends the base and the four accessor methods are now implemented on the store object itself.

`EntityNode`, `EntityQuery`, and `QueryResultEntity` now import `IfcStoreBase` instead of the full parser store since they only need the base accessor methods. Headless backends (`@ifc-lite/cli`, `@ifc-lite/mcp`) also migrated.

Assisted but I had to clean up a lot of stuff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized data-store interface with unified entity/property/quantity access and spatial-index queries (AABB, raycast).
  * Improved attribute extraction so entity names/tags display more accurately; property values are normalized across adapters and viewer.

* **Refactor**
  * Consolidated core types and centralized store/lookup behavior for consistent runtime access.

* **Tests**
  * Added tests for entity lookup, attribute extraction, and on-demand attribute fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->