### PR TITLE
perf(renderer): cache per-mesh AABB in BVH build

### DIFF
--- a/packages/renderer/src/bvh.test.ts
+++ b/packages/renderer/src/bvh.test.ts
@@ -1,0 +1,213 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { BVH } from './bvh.js';
+import type { Ray } from './raycaster.js';
+import type { MeshData } from '@ifc-lite/geometry';
+
+/**
+ * The BVH is a conservative broad-phase: `getMeshesForRay` may return extra
+ * candidates, but it must never DROP a mesh whose AABB the ray actually crosses
+ * (that would make picking/snapping miss real geometry). These tests pin that
+ * "no false negatives" invariant against a brute-force reference, plus the
+ * degenerate cases (small scene, unbuilt, empty mesh).
+ */
+
+interface AABBLike {
+  min: { x: number; y: number; z: number };
+  max: { x: number; y: number; z: number };
+}
+
+// Axis-aligned cube (8 corners) centred at (cx,cy,cz) with half-size h.
+function boxMesh(expressId: number, cx: number, cy: number, cz: number, h = 0.4): MeshData {
+  const c: number[] = [];
+  for (const sx of [-1, 1]) {
+    for (const sy of [-1, 1]) {
+      for (const sz of [-1, 1]) {
+        c.push(cx + sx * h, cy + sy * h, cz + sz * h);
+      }
+    }
+  }
+  return {
+    expressId,
+    positions: new Float32Array(c),
+    normals: new Float32Array(c.length),
+    indices: new Uint32Array([0, 1, 2]),
+    color: [0, 0, 0, 1],
+    name: `box-${expressId}`,
+  } as unknown as MeshData;
+}
+
+// Mesh with no vertices — its AABB stays Infinity/-Infinity (contributes nothing
+// to a union, yields a NaN centroid), so every node it lands in is pruned.
+function emptyMesh(expressId: number): MeshData {
+  return {
+    expressId,
+    positions: new Float32Array(0),
+    normals: new Float32Array(0),
+    indices: new Uint32Array(0),
+    color: [0, 0, 0, 1],
+    name: `empty-${expressId}`,
+  } as unknown as MeshData;
+}
+
+function meshAabb(m: MeshData): AABBLike {
+  const p = m.positions;
+  let minX = Infinity, minY = Infinity, minZ = Infinity;
+  let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+  for (let i = 0; i < p.length; i += 3) {
+    minX = Math.min(minX, p[i]);
+    minY = Math.min(minY, p[i + 1]);
+    minZ = Math.min(minZ, p[i + 2]);
+    maxX = Math.max(maxX, p[i]);
+    maxY = Math.max(maxY, p[i + 1]);
+    maxZ = Math.max(maxZ, p[i + 2]);
+  }
+  return { min: { x: minX, y: minY, z: minZ }, max: { x: maxX, y: maxY, z: maxZ } };
+}
+
+// Slab test mirroring BVH.rayIntersectsAABB, used as the ground truth.
+function rayHitsAabb(ray: Ray, b: AABBLike): boolean {
+  let tmin = -Infinity;
+  let tmax = Infinity;
+  for (const ax of ['x', 'y', 'z'] as const) {
+    if (Math.abs(ray.direction[ax]) < 0.0000001) {
+      if (ray.origin[ax] < b.min[ax] || ray.origin[ax] > b.max[ax]) return false;
+    } else {
+      const inv = 1 / ray.direction[ax];
+      let t0 = (b.min[ax] - ray.origin[ax]) * inv;
+      let t1 = (b.max[ax] - ray.origin[ax]) * inv;
+      if (t0 > t1) {
+        const tmp = t0;
+        t0 = t1;
+        t1 = tmp;
+      }
+      tmin = Math.max(tmin, t0);
+      tmax = Math.min(tmax, t1);
+      if (tmin > tmax) return false;
+    }
+  }
+  return tmax >= 0;
+}
+
+function bruteForceHits(ray: Ray, meshes: MeshData[]): Set<number> {
+  const out = new Set<number>();
+  meshes.forEach((m, i) => {
+    if (rayHitsAabb(ray, meshAabb(m))) out.add(i);
+  });
+  return out;
+}
+
+// 6×6 grid of cubes in the z=0 plane (36 meshes > maxMeshesPerLeaf=8, so the
+// tree actually splits), plus a few stacked in z to exercise the third axis.
+function gridScene(): MeshData[] {
+  const meshes: MeshData[] = [];
+  let id = 1;
+  for (let x = 0; x < 6; x++) {
+    for (let y = 0; y < 6; y++) {
+      meshes.push(boxMesh(id++, x, y, 0));
+    }
+  }
+  for (let z = 1; z <= 4; z++) {
+    meshes.push(boxMesh(id++, 2, 2, z));
+  }
+  return meshes;
+}
+
+describe('BVH', () => {
+  it('never drops a mesh the ray actually crosses (superset of brute force)', () => {
+    const meshes = gridScene();
+    const bvh = new BVH();
+    bvh.build(meshes);
+
+    const rays: Ray[] = [
+      // Straight down through the (2,2) column.
+      { origin: { x: 2, y: 2, z: 10 }, direction: { x: 0, y: 0, z: -1 } },
+      // Along +x sweeping the y=3 row at z=0.
+      { origin: { x: -10, y: 3, z: 0 }, direction: { x: 1, y: 0, z: 0 } },
+      // Along +y sweeping the x=5 column at z=0.
+      { origin: { x: 5, y: -10, z: 0 }, direction: { x: 0, y: 1, z: 0 } },
+      // Diagonal through the grid.
+      { origin: { x: -5, y: -5, z: 5 }, direction: { x: 1, y: 1, z: -1 } },
+      // Clear miss, well outside every AABB.
+      { origin: { x: 100, y: 100, z: 100 }, direction: { x: 0, y: 0, z: 1 } },
+    ];
+
+    for (const ray of rays) {
+      const brute = bruteForceHits(ray, meshes);
+      const candidates = new Set(bvh.getMeshesForRay(ray, meshes));
+      for (const idx of brute) {
+        assert.ok(
+          candidates.has(idx),
+          `ray ${JSON.stringify(ray.origin)}→${JSON.stringify(ray.direction)} dropped mesh ${idx} (true AABB hit)`
+        );
+      }
+      // Candidates must be valid indices into the mesh array.
+      for (const idx of candidates) {
+        assert.ok(idx >= 0 && idx < meshes.length, `candidate index ${idx} out of range`);
+      }
+    }
+  });
+
+  it('finds the expected count on an axis sweep', () => {
+    const meshes = gridScene();
+    const bvh = new BVH();
+    bvh.build(meshes);
+
+    // +x ray at y=3,z=0 crosses exactly the 6 cubes of the y=3 row.
+    const ray: Ray = { origin: { x: -10, y: 3, z: 0 }, direction: { x: 1, y: 0, z: 0 } };
+    const brute = bruteForceHits(ray, meshes);
+    assert.strictEqual(brute.size, 6);
+    const candidates = new Set(bvh.getMeshesForRay(ray, meshes));
+    for (const idx of brute) assert.ok(candidates.has(idx));
+  });
+
+  it('handles a small scene (≤ leaf size) without dropping hits', () => {
+    const meshes = [boxMesh(1, 0, 0, 0), boxMesh(2, 5, 0, 0), boxMesh(3, 0, 5, 0)];
+    const bvh = new BVH();
+    bvh.build(meshes);
+    const ray: Ray = { origin: { x: 0, y: 0, z: 10 }, direction: { x: 0, y: 0, z: -1 } };
+    const candidates = new Set(bvh.getMeshesForRay(ray, meshes));
+    assert.ok(candidates.has(0)); // the cube at the origin
+  });
+
+  it('returns all indices when not built', () => {
+    const meshes = [boxMesh(1, 0, 0, 0), boxMesh(2, 1, 0, 0)];
+    const bvh = new BVH();
+    const ray: Ray = { origin: { x: 0, y: 0, z: 10 }, direction: { x: 0, y: 0, z: -1 } };
+    assert.deepStrictEqual(bvh.getMeshesForRay(ray, meshes), [0, 1]);
+  });
+
+  it('prunes a clear miss to zero candidates', () => {
+    const meshes = gridScene();
+    const bvh = new BVH();
+    bvh.build(meshes);
+    // Far outside every AABB → the root node must be pruned, no candidates.
+    const ray: Ray = { origin: { x: 100, y: 100, z: 100 }, direction: { x: 0, y: 0, z: 1 } };
+    assert.strictEqual(bruteForceHits(ray, meshes).size, 0);
+    assert.strictEqual(bvh.getMeshesForRay(ray, meshes).length, 0);
+  });
+
+  it('does not break when a mesh has no vertices (mixed with real ones)', () => {
+    const meshes = [...gridScene(), emptyMesh(999)];
+    const bvh = new BVH();
+    assert.doesNotThrow(() => bvh.build(meshes));
+    const ray: Ray = { origin: { x: 2, y: 2, z: 10 }, direction: { x: 0, y: 0, z: -1 } };
+    const brute = bruteForceHits(ray, meshes);
+    const candidates = new Set(bvh.getMeshesForRay(ray, meshes));
+    for (const idx of brute) assert.ok(candidates.has(idx));
+  });
+
+  it('builds from only empty meshes without throwing or returning candidates', () => {
+    // > maxMeshesPerLeaf (8) empty meshes so the tree splits into all-empty leaves.
+    const meshes = Array.from({ length: 12 }, (_, i) => emptyMesh(i + 1));
+    const bvh = new BVH();
+    assert.doesNotThrow(() => bvh.build(meshes));
+    // Every node has an Infinity/-Infinity AABB, so all rays prune to nothing.
+    const ray: Ray = { origin: { x: 0, y: 0, z: 10 }, direction: { x: 0, y: 0, z: -1 } };
+    assert.strictEqual(bvh.getMeshesForRay(ray, meshes).length, 0);
+  });
+});

--- a/packages/renderer/src/bvh.ts
+++ b/packages/renderer/src/bvh.ts
@@ -18,20 +18,58 @@ export class BVH {
   private root: BVHNode | null = null;
   private readonly maxMeshesPerLeaf = 8;
 
+  // Per-mesh AABB cache (6 floats/mesh: minX,minY,minZ,maxX,maxY,maxZ), filled
+  // once per build. Storing in a Float32Array is lossless for f32 positions, so
+  // unioning these and deriving centroids as (min+max)/2 reproduces exactly the
+  // split order and node bounds the old per-vertex recompute produced — without
+  // re-scanning every vertex at every recursion level.
+  private meshAABBs: Float32Array | null = null;
+
   /**
    * Build BVH from meshes
    */
   build(meshes: MeshData[]): void {
     if (meshes.length === 0) {
       this.root = null;
+      this.meshAABBs = null;
       return;
     }
+
+    // Single O(total verts) pass: cache each mesh's AABB. An empty mesh keeps
+    // Infinity/-Infinity, so it contributes nothing to a union (matching the old
+    // per-vertex calculateBounds) and yields a NaN centroid (matching the old
+    // getMeshCenter) — behaviour is unchanged for that degenerate case.
+    const aabbs = new Float32Array(meshes.length * 6);
+    for (let m = 0; m < meshes.length; m++) {
+      const positions = meshes[m].positions;
+      let minX = Infinity, minY = Infinity, minZ = Infinity;
+      let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+      for (let i = 0; i < positions.length; i += 3) {
+        const x = positions[i];
+        const y = positions[i + 1];
+        const z = positions[i + 2];
+        minX = Math.min(minX, x);
+        minY = Math.min(minY, y);
+        minZ = Math.min(minZ, z);
+        maxX = Math.max(maxX, x);
+        maxY = Math.max(maxY, y);
+        maxZ = Math.max(maxZ, z);
+      }
+      const o = m * 6;
+      aabbs[o] = minX;
+      aabbs[o + 1] = minY;
+      aabbs[o + 2] = minZ;
+      aabbs[o + 3] = maxX;
+      aabbs[o + 4] = maxY;
+      aabbs[o + 5] = maxZ;
+    }
+    this.meshAABBs = aabbs;
 
     // Create mesh indices array
     const meshIndices = meshes.map((_, i) => i);
 
-    // Build tree recursively
-    this.root = this.buildNode(meshes, meshIndices);
+    // Build tree recursively (uses the cached AABBs, not the vertex arrays)
+    this.root = this.buildNode(meshIndices);
   }
 
   /**
@@ -50,9 +88,9 @@ export class BVH {
   /**
    * Build a BVH node recursively
    */
-  private buildNode(meshes: MeshData[], meshIndices: number[]): BVHNode {
-    // Calculate bounding box for all meshes
-    const bounds = this.calculateBounds(meshes, meshIndices);
+  private buildNode(meshIndices: number[]): BVHNode {
+    // Calculate bounding box by unioning the cached per-mesh AABBs
+    const bounds = this.unionCachedBounds(meshIndices);
 
     // Leaf node if few enough meshes
     if (meshIndices.length <= this.maxMeshesPerLeaf) {
@@ -63,13 +101,12 @@ export class BVH {
       };
     }
 
-    // Split meshes along longest axis
+    // Split meshes along longest axis, sorting on cached centroids
     const axis = this.getLongestAxis(bounds);
-    const sortedIndices = [...meshIndices].sort((a, b) => {
-      const centerA = this.getMeshCenter(meshes[a])[axis];
-      const centerB = this.getMeshCenter(meshes[b])[axis];
-      return centerA - centerB;
-    });
+    const k = axis === 'x' ? 0 : axis === 'y' ? 1 : 2;
+    const sortedIndices = [...meshIndices].sort(
+      (a, b) => this.cachedCenter(a, k) - this.cachedCenter(b, k)
+    );
 
     const mid = Math.floor(sortedIndices.length / 2);
     const leftIndices = sortedIndices.slice(0, mid);
@@ -79,8 +116,8 @@ export class BVH {
     return {
       bounds,
       meshIndices: [],
-      left: this.buildNode(meshes, leftIndices),
-      right: this.buildNode(meshes, rightIndices),
+      left: this.buildNode(leftIndices),
+      right: this.buildNode(rightIndices),
       isLeaf: false,
     };
   }
@@ -148,63 +185,36 @@ export class BVH {
   }
 
   /**
-   * Calculate bounding box for a set of meshes
+   * Union the cached per-mesh AABBs for a set of mesh indices (no vertex scan)
    */
-  private calculateBounds(meshes: MeshData[], meshIndices: number[]): AABB {
+  private unionCachedBounds(meshIndices: number[]): AABB {
+    const aabbs = this.meshAABBs!;
     const bounds: AABB = {
       min: { x: Infinity, y: Infinity, z: Infinity },
       max: { x: -Infinity, y: -Infinity, z: -Infinity },
     };
 
     for (const index of meshIndices) {
-      const mesh = meshes[index];
-      const positions = mesh.positions;
-
-      for (let i = 0; i < positions.length; i += 3) {
-        const x = positions[i];
-        const y = positions[i + 1];
-        const z = positions[i + 2];
-
-        bounds.min.x = Math.min(bounds.min.x, x);
-        bounds.min.y = Math.min(bounds.min.y, y);
-        bounds.min.z = Math.min(bounds.min.z, z);
-
-        bounds.max.x = Math.max(bounds.max.x, x);
-        bounds.max.y = Math.max(bounds.max.y, y);
-        bounds.max.z = Math.max(bounds.max.z, z);
-      }
+      const o = index * 6;
+      bounds.min.x = Math.min(bounds.min.x, aabbs[o]);
+      bounds.min.y = Math.min(bounds.min.y, aabbs[o + 1]);
+      bounds.min.z = Math.min(bounds.min.z, aabbs[o + 2]);
+      bounds.max.x = Math.max(bounds.max.x, aabbs[o + 3]);
+      bounds.max.y = Math.max(bounds.max.y, aabbs[o + 4]);
+      bounds.max.z = Math.max(bounds.max.z, aabbs[o + 5]);
     }
 
     return bounds;
   }
 
   /**
-   * Get center of mesh bounding box
+   * Center of a cached mesh AABB along an axis (k = 0|1|2). Derived in f64 from
+   * the lossless f32 bounds, so it equals the old getMeshCenter exactly.
    */
-  private getMeshCenter(mesh: MeshData): { x: number; y: number; z: number } {
-    const positions = mesh.positions;
-    let minX = Infinity, minY = Infinity, minZ = Infinity;
-    let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
-
-    for (let i = 0; i < positions.length; i += 3) {
-      const x = positions[i];
-      const y = positions[i + 1];
-      const z = positions[i + 2];
-
-      minX = Math.min(minX, x);
-      minY = Math.min(minY, y);
-      minZ = Math.min(minZ, z);
-
-      maxX = Math.max(maxX, x);
-      maxY = Math.max(maxY, y);
-      maxZ = Math.max(maxZ, z);
-    }
-
-    return {
-      x: (minX + maxX) / 2,
-      y: (minY + maxY) / 2,
-      z: (minZ + maxZ) / 2,
-    };
+  private cachedCenter(index: number, k: number): number {
+    const aabbs = this.meshAABBs!;
+    const o = index * 6;
+    return (aabbs[o + k] + aabbs[o + 3 + k]) / 2;
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes the multi-second main-thread freeze on the first CPU raycast
(orbit-pivot-under-cursor, measure snapping) on large models, reported in #944.

`BVH.build` re-derived each mesh's centroid/bounds from its **full vertex array**
repeatedly:

- `getMeshCenter` was called twice per comparison inside the sort comparator → a
  full-mesh vertex scan on every comparison,
- `calculateBounds` re-scanned the whole subtree at every `buildNode` level.

≈ `O(N·logN·V)` redundant vertex iteration.

## Change (direction 1 from the issue)

- One `O(total verts)` pass caches every mesh's AABB into a `Float32Array`
  (6 floats/mesh).
- `buildNode` sorts/splits on **cached centroids** and unions **cached child
  AABBs** instead of re-scanning vertices.
- Storing the AABB in f32 is lossless for f32 `positions`, and centroids are
  derived in f64, so the split order and node bounds are **identical** to the old
  path → `getMeshesForRay` returns the same candidate set.
- `BVH.build` stays **synchronous** with the same signature (backward compatible).

Async build (worker / prefetch) is intentionally **not** included here — deferred
per the issue discussion.

## Test

Adds `packages/renderer/src/bvh.test.ts` (`node:test`, matching the package's
existing test style) pinning the "no false negatives" invariant: `getMeshesForRay`
must be a superset of a brute-force AABB-hit reference, plus degenerate cases —
small scene, unbuilt BVH, clear-miss pruning (zero candidates), an empty-vertex
mesh mixed with real ones, and an all-empty scene.

Run: `npx tsx --test packages/renderer/src/bvh.test.ts` → 7/7 pass.

## Before / after

Real ~700K-element model (110,752 meshes / 35.9M verts):

| | BVH.build |
|---|---|
| before (vertex rescans) | 28,902 ms |
| after (cached AABB) | 548 ms |
| | **52.8× faster** |

First measure / orbit-pivot no longer freezes the tab for ~29 s.

---

_Assisted with AI; reviewed and checked by a human._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for ray-casting behavior across multiple scene configurations and edge cases.

* **Refactor**
  * Optimized ray-casting performance through internal caching improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->