### PR TITLE
fix(wasm): render per-triangle IfcIndexedColourMap colours in viewer (#858)

### DIFF
--- a/.changeset/eighty-eight-indexed-colour-split.md
+++ b/.changeset/eighty-eight-indexed-colour-split.md
@@ -1,0 +1,12 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Fix `IfcIndexedColourMap` per-triangle colours being ignored in the viewer (#858).
+
+The browser geometry path (`processGeometryBatch`) only carried one dominant
+colour per tessellated face set, so a face set whose `ColourIndex` assigns
+different colours to different triangles rendered as a single solid colour. The
+per-palette-group split (shared with the native processor) is now applied on the
+WASM batch path too, so multi-coloured `IfcTriangulatedFaceSet` geometry renders
+with all its authored colours again.

--- a/packages/wasm/test/styling-indexed-colour-split.test.mjs
+++ b/packages/wasm/test/styling-indexed-colour-split.test.mjs
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Issue #858 regression guard — the LIVE VIEWER path.
+ *
+ * The browser viewer renders through `buildPrePassOnce` + `processGeometryBatch`
+ * (the path `parseMeshesViaPrePass` drives). That path used to collapse an
+ * `IfcIndexedColourMap` to a single dominant colour, so a face set whose
+ * `ColourIndex` paints different triangles different colours rendered as one
+ * solid colour (#858 "reappeared" after the #874 mesh-pipeline unification).
+ *
+ * The native `process_geometry` path always split correctly and its rust test
+ * stayed green — which is exactly why this needs a WASM-path test: only this
+ * level exercises `processGeometryBatch` and would have caught the regression.
+ *
+ * Fixture `tests/models/issues/858_indexed_colour_map.ifc`: an
+ * IfcBuildingElementProxy #302 whose IfcTriangulatedFaceSet (12 tris) is
+ * coloured red(8)/green(2)/yellow(2) purely via IfcIndexedColourMap +
+ * IfcColourRgbList (no IfcStyledItem). The split must produce 3 sub-meshes.
+ */
+
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'node:test';
+
+const packageDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const rootDir = join(packageDir, '..', '..');
+const wasmPath = join(packageDir, 'pkg', 'ifc-lite_bg.wasm');
+const wasmJsPath = join(packageDir, 'pkg', 'ifc-lite.js');
+const fixturePath = join(rootDir, 'tests', 'models', 'issues', '858_indexed_colour_map.ifc');
+
+const PROXY_ID = 302;
+const RED = [1.0, 0.0, 0.0];
+const GREEN = [0.0, 0.501960784313725, 0.0];
+const YELLOW = [1.0, 1.0, 0.0];
+
+function approxColor(c, target) {
+  return target.every((v, i) => Math.abs(c[i] - v) < 1e-3);
+}
+
+describe('@ifc-lite/wasm IfcIndexedColourMap per-triangle split (#858)', () => {
+  it('splits a face set into one sub-mesh per palette group on the processGeometryBatch path', async (t) => {
+    if (!existsSync(wasmPath) || !existsSync(wasmJsPath)) {
+      t.skip('wasm bundle not built — run `bash scripts/build-wasm.sh` first');
+      return;
+    }
+    if (!existsSync(fixturePath)) {
+      t.skip('fixture missing — run `pnpm fixtures` first');
+      return;
+    }
+
+    const { initSync, IfcAPI } = await import(wasmJsPath);
+    const { parseMeshesViaPrePass } = await import(
+      join(rootDir, 'scripts', 'lib', 'mesh-via-prepass.mjs')
+    );
+
+    initSync(readFileSync(wasmPath));
+    const api = new IfcAPI();
+
+    const content = readFileSync(fixturePath, 'utf8');
+    const result = parseMeshesViaPrePass(api, content);
+
+    const pieces = [];
+    for (let i = 0; i < result.length; i++) {
+      const m = result.get(i);
+      if (m && m.expressId === PROXY_ID) pieces.push(m);
+    }
+
+    assert.equal(
+      pieces.length,
+      3,
+      `expected 3 palette sub-meshes for proxy #${PROXY_ID}, got ${pieces.length}: ` +
+        JSON.stringify(pieces.map((m) => ({ color: Array.from(m.color), tris: m.triangleCount }))),
+    );
+
+    const red = pieces.find((m) => approxColor(m.color, RED));
+    const green = pieces.find((m) => approxColor(m.color, GREEN));
+    const yellow = pieces.find((m) => approxColor(m.color, YELLOW));
+
+    assert.ok(red, 'missing red sub-mesh — palette split collapsed to dominant colour');
+    assert.ok(green, 'missing green sub-mesh');
+    assert.ok(yellow, 'missing yellow sub-mesh');
+
+    assert.equal(red.triangleCount, 8, 'red group should keep 8 triangles');
+    assert.equal(green.triangleCount, 2, 'green group should keep 2 triangles');
+    assert.equal(yellow.triangleCount, 2, 'yellow group should keep 2 triangles');
+
+    const totalTris = pieces.reduce((n, m) => n + m.triangleCount, 0);
+    assert.equal(totalTris, 12, 'split must preserve the original 12 triangles');
+  });
+});

--- a/rust/processing/src/style/indexed_colour.rs
+++ b/rust/processing/src/style/indexed_colour.rs
@@ -123,7 +123,7 @@ pub fn resolve_indexed_colour_map_full(
 /// means CSG/void cutting changed the topology, so the per-triangle mapping no
 /// longer applies. Triangle `i` of the mesh corresponds to `CoordIndex[i]`
 /// because the triangulated-face-set processor preserves triangle order.
-pub(crate) fn split_mesh_by_indexed_colour(
+pub fn split_mesh_by_indexed_colour(
     mesh: &Mesh,
     map: &FullIndexedColourMap,
 ) -> Option<Vec<(Rgba, Mesh)>> {

--- a/rust/processing/src/style/mod.rs
+++ b/rust/processing/src/style/mod.rs
@@ -34,15 +34,17 @@ mod indexed_colour;
 mod material;
 // Public styling resolvers — the single shared implementation that both the
 // native pipeline and the browser `wasm-bindings` call (issue #913, Phase 2e).
-// `split_mesh_by_indexed_colour` stays crate-internal: it is a mesh-pipeline
-// concern the processor owns, not a colour-resolution primitive consumers need.
-pub use indexed_colour::{resolve_indexed_colour_map_full, FullIndexedColourMap};
+// `split_mesh_by_indexed_colour` is also public so the browser `processGeometryBatch`
+// path can restore the per-triangle palette split it lost in the #874 mesh-pipeline
+// unification (issue #858) — keeping one shared splitter rather than a wasm copy.
+pub use indexed_colour::{
+    resolve_indexed_colour_map_full, split_mesh_by_indexed_colour, FullIndexedColourMap,
+};
 pub use material::{
     build_element_material_colors, build_material_style_index, flatten_material_color_index,
     pick_material_style_for_submesh, pick_opaque_first, resolve_material_ids,
     resolve_submesh_color,
 };
-pub(crate) use indexed_colour::split_mesh_by_indexed_colour;
 
 /// Alpha at or above which a color is treated as opaque.
 ///

--- a/rust/wasm-bindings/src/api/gpu_meshes.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes.rs
@@ -19,6 +19,53 @@ fn decode_ifc_bytes<'a>(data: &'a [u8]) -> &'a str {
     }
 }
 
+/// Emit a sub-mesh, splitting it into one mesh per `IfcIndexedColourMap` palette
+/// group when the face set carries a per-triangle colour map whose triangle
+/// count still matches the produced mesh (issue #858). This restores the split
+/// the live viewer lost when the geometry pipeline was unified onto
+/// `processGeometryBatch` (#874) — the prepass only carries one dominant colour
+/// per geometry, so without this the green/yellow triangles collapse into red.
+///
+/// Falls back to a single `color` mesh when there is no map, when the map no
+/// longer applies (CSG/void retopology changed the triangle count), or when
+/// fewer than two distinct palette colours are used — the same guards the native
+/// processor relies on (see `split_mesh_by_indexed_colour`).
+fn emit_submesh_with_palette_split(
+    mesh_collection: &mut MeshCollection,
+    express_id: u32,
+    ifc_type_name: &str,
+    geometry_id: u32,
+    mesh: ifc_lite_geometry::Mesh,
+    color: [f32; 4],
+    indexed_colour_full: &rustc_hash::FxHashMap<
+        u32,
+        ifc_lite_processing::style::FullIndexedColourMap,
+    >,
+) {
+    if let Some(full) = indexed_colour_full.get(&geometry_id) {
+        if let Some(groups) = ifc_lite_processing::style::split_mesh_by_indexed_colour(&mesh, full) {
+            for (rgba, mut part) in groups {
+                if part.normals.len() != part.positions.len() {
+                    ifc_lite_geometry::calculate_normals(&mut part);
+                }
+                mesh_collection.add(MeshDataJs::new(
+                    express_id,
+                    ifc_type_name.to_string(),
+                    part,
+                    rgba.to_array(),
+                ));
+            }
+            return;
+        }
+    }
+    mesh_collection.add(MeshDataJs::new(
+        express_id,
+        ifc_type_name.to_string(),
+        mesh,
+        color,
+    ));
+}
+
 #[wasm_bindgen]
 impl IfcAPI {
     /// Run the pre-pass ONCE and return serialized results for worker distribution.
@@ -962,6 +1009,13 @@ impl IfcAPI {
             std::sync::Arc::new(rustc_hash::FxHashSet::default())
         };
 
+        // IfcIndexedColourMap index (geometry id → full per-triangle palette),
+        // built once per worker. Drives the #858 per-palette-group split below
+        // so a face set whose ColourIndex assigns several colours to different
+        // triangles renders multi-coloured instead of collapsing to the single
+        // dominant colour the prepass `geometry_styles` carries.
+        let indexed_colour_full = self.get_or_build_indexed_colour_maps(content, &mut decoder);
+
         // Process only the entities specified in jobs_flat
         for chunk in jobs_flat.chunks(3) {
             if chunk.len() < 3 {
@@ -1028,6 +1082,7 @@ impl IfcAPI {
                                 let element_color = element_styles.get(&id).copied();
                                 let mut mat_color_idx = 0usize;
                                 for sub in sub_meshes.sub_meshes {
+                                    let geometry_id = sub.geometry_id;
                                     let mut mesh = sub.mesh;
                                     if mesh.is_empty() {
                                         continue;
@@ -1036,7 +1091,7 @@ impl IfcAPI {
                                         calculate_normals(&mut mesh);
                                     }
                                     let color = resolve_submesh_color(
-                                        sub.geometry_id,
+                                        geometry_id,
                                         &geometry_styles,
                                         &mut decoder,
                                         None,
@@ -1048,12 +1103,15 @@ impl IfcAPI {
                                         .entry(ifc_type)
                                         .or_insert_with(|| ifc_type.name().to_string())
                                         .clone();
-                                    mesh_collection.add(MeshDataJs::new(
+                                    emit_submesh_with_palette_split(
+                                        &mut mesh_collection,
                                         id,
-                                        ifc_type_name,
+                                        &ifc_type_name,
+                                        geometry_id,
                                         mesh,
                                         color,
-                                    ));
+                                        &indexed_colour_full,
+                                    );
                                     used_submesh = true;
                                 }
                             }
@@ -1072,6 +1130,7 @@ impl IfcAPI {
                                 let element_color = element_styles.get(&id).copied();
                                 let mut mat_color_idx = 0usize;
                                 for sub in sub_meshes.sub_meshes {
+                                    let geometry_id = sub.geometry_id;
                                     let mut mesh = sub.mesh;
                                     if mesh.is_empty() {
                                         continue;
@@ -1080,7 +1139,7 @@ impl IfcAPI {
                                         calculate_normals(&mut mesh);
                                     }
                                     let color = resolve_submesh_color(
-                                        sub.geometry_id,
+                                        geometry_id,
                                         &geometry_styles,
                                         &mut decoder,
                                         None,
@@ -1092,12 +1151,15 @@ impl IfcAPI {
                                         .entry(ifc_type)
                                         .or_insert_with(|| ifc_type.name().to_string())
                                         .clone();
-                                    mesh_collection.add(MeshDataJs::new(
+                                    emit_submesh_with_palette_split(
+                                        &mut mesh_collection,
                                         id,
-                                        ifc_type_name,
+                                        &ifc_type_name,
+                                        geometry_id,
                                         mesh,
                                         color,
-                                    ));
+                                        &indexed_colour_full,
+                                    );
                                 }
                             }
                         }

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -65,6 +65,16 @@ pub struct IfcAPI {
     /// and by `setMergeLayers` (so toggling rebuilds against the latest
     /// flag value).
     cached_parts_to_skip: std::sync::Mutex<Option<std::sync::Arc<rustc_hash::FxHashSet<u32>>>>,
+
+    /// Lazily-built `IfcIndexedColourMap` index keyed by target geometry id,
+    /// used by `processGeometryBatch` to split a tessellated face set into one
+    /// sub-mesh per palette group (issue #858). The browser geometry path lost
+    /// this split in the #874 mesh-pipeline unification — it kept only the
+    /// dominant colour per geometry. Built once per worker on first batch call
+    /// (a single extra entity scan, cached) and cleared by `clearPrePassCache`.
+    cached_indexed_colour_maps: std::sync::Mutex<
+        Option<std::sync::Arc<rustc_hash::FxHashMap<u32, ifc_lite_processing::style::FullIndexedColourMap>>>,
+    >,
 }
 
 #[wasm_bindgen]
@@ -80,6 +90,7 @@ impl IfcAPI {
             cached_entity_index: std::sync::Mutex::new(None),
             merge_layers: std::sync::atomic::AtomicBool::new(false),
             cached_parts_to_skip: std::sync::Mutex::new(None),
+            cached_indexed_colour_maps: std::sync::Mutex::new(None),
         }
     }
 
@@ -112,6 +123,13 @@ impl IfcAPI {
             .lock()
             .expect("ifc-lite cached_parts_to_skip Mutex poisoned");
         parts_slot.take();
+        // The indexed-colour-map index is also keyed off the previous load's
+        // content; drop it so the next file rebuilds against fresh content.
+        let mut icm_slot = self
+            .cached_indexed_colour_maps
+            .lock()
+            .expect("ifc-lite cached_indexed_colour_maps Mutex poisoned");
+        icm_slot.take();
     }
 
     /// Populate `cached_entity_index` from pre-extracted column arrays.
@@ -234,6 +252,55 @@ impl IfcAPI {
             .cached_parts_to_skip
             .lock()
             .expect("ifc-lite cached_parts_to_skip Mutex poisoned");
+        *slot = Some(std::sync::Arc::clone(&arc));
+        arc
+    }
+
+    /// Get or lazily build the `IfcIndexedColourMap` index (geometry id →
+    /// full per-triangle palette) used by `processGeometryBatch` to split a
+    /// tessellated face set into one sub-mesh per palette group (issue #858).
+    ///
+    /// Mirrors the native processor's collection pass (processor.rs ~905):
+    /// one entity scan that decodes every `IFCINDEXEDCOLOURMAP` and resolves
+    /// it to a [`FullIndexedColourMap`]. Cached per worker so the scan is paid
+    /// once, not per batch. Returns an empty map when the file authors none
+    /// (the common case), so callers can cheaply `.get(&geometry_id)`.
+    pub(crate) fn get_or_build_indexed_colour_maps(
+        &self,
+        content: &str,
+        decoder: &mut ifc_lite_core::EntityDecoder,
+    ) -> std::sync::Arc<rustc_hash::FxHashMap<u32, ifc_lite_processing::style::FullIndexedColourMap>>
+    {
+        {
+            let slot = self
+                .cached_indexed_colour_maps
+                .lock()
+                .expect("ifc-lite cached_indexed_colour_maps Mutex poisoned");
+            if let Some(existing) = slot.as_ref() {
+                return std::sync::Arc::clone(existing);
+            }
+        }
+
+        let mut map: rustc_hash::FxHashMap<u32, ifc_lite_processing::style::FullIndexedColourMap> =
+            rustc_hash::FxHashMap::default();
+        let mut scanner = ifc_lite_core::EntityScanner::new(content);
+        while let Some((_id, type_name, start, end)) = scanner.next_entity() {
+            if type_name == "IFCINDEXEDCOLOURMAP" {
+                if let Ok(icm) = decoder.decode_at(start, end) {
+                    if let Some(full) =
+                        ifc_lite_processing::style::resolve_indexed_colour_map_full(&icm, decoder)
+                    {
+                        map.entry(full.geometry_id).or_insert(full);
+                    }
+                }
+            }
+        }
+
+        let arc = std::sync::Arc::new(map);
+        let mut slot = self
+            .cached_indexed_colour_maps
+            .lock()
+            .expect("ifc-lite cached_indexed_colour_maps Mutex poisoned");
         *slot = Some(std::sync::Arc::clone(&arc));
         arc
     }

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -283,6 +283,19 @@ impl IfcAPI {
 
         let mut map: rustc_hash::FxHashMap<u32, ifc_lite_processing::style::FullIndexedColourMap> =
             rustc_hash::FxHashMap::default();
+        // Fast bail-out for the overwhelming common case: files with no
+        // IfcIndexedColourMap pay only a single substring search (SIMD memmem),
+        // not a full entity scan + decode, on the first batch of every worker.
+        // The empty result is still cached so later batches skip even that.
+        if !content.contains("IFCINDEXEDCOLOURMAP") {
+            let arc = std::sync::Arc::new(map);
+            let mut slot = self
+                .cached_indexed_colour_maps
+                .lock()
+                .expect("ifc-lite cached_indexed_colour_maps Mutex poisoned");
+            *slot = Some(std::sync::Arc::clone(&arc));
+            return arc;
+        }
         let mut scanner = ifc_lite_core::EntityScanner::new(content);
         while let Some((_id, type_name, start, end)) = scanner.next_entity() {
             if type_name == "IFCINDEXEDCOLOURMAP" {


### PR DESCRIPTION
## Summary

Fixes #858 — an `IfcTriangulatedFaceSet` coloured per-triangle via `IfcIndexedColourMap` rendered as a single solid colour in the viewer (the reporter's red/green/yellow box showed all red).

## Root cause

The live browser viewer renders through `buildPrePassOnce` + `processGeometryBatch` (the WASM batch path), which only carried **one dominant colour per geometry** — `extract_color_from_indexed_colour_map` collapses the palette via `.dominant()`. The per-triangle split (`split_mesh_by_indexed_colour`) lived only in the native `process_geometry` path.

The split was originally added to the WASM path in #867, but #874 ("Unify geometry mesh-production path") migrated the viewer onto `processGeometryBatch` and dropped it there — so the native rust test stayed green while the viewer regressed ("reappeared in the latest version").

## Fix

- `split_mesh_by_indexed_colour` is now `pub` (one shared splitter, no wasm copy).
- `processGeometryBatch` builds an `IfcIndexedColourMap` index (geometry id → full per-triangle palette) once per worker (cached, mirroring `cached_parts_to_skip`) and, at sub-mesh emission, splits each face set into one mesh per palette group.
- Falls back to the single dominant colour when no map applies (CSG/void retopology changed the triangle count) or fewer than two colours are used — the same guards the native processor uses, so behaviour matches `process_geometry`.
- No prepass→worker protocol change.

The renderer already buckets meshes by colour and handles N sub-meshes per `expressId`, so no JS/renderer change was needed.

## Tests

- New `packages/wasm/test/styling-indexed-colour-split.test.mjs` drives the **actual viewer path** (`parseMeshesViaPrePass` → `buildPrePassOnce`+`processGeometryBatch`) on `tests/models/issues/858_indexed_colour_map.ifc` and asserts proxy #302 yields **3 sub-meshes** (red 8 / green 2 / yellow 2 tris). A rust-only test cannot catch this regression — the native path already passed.
- All `ifc-lite-processing` tests pass; existing `faceset_is_split_per_triangle_palette_group` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * WASM viewer now correctly preserves and renders per-triangle colors for models using indexed color maps (no longer collapses to a single dominant color).

* **Tests**
  * Added a regression test to ensure multi-colored triangle rendering remains correct.

* **Chores**
  * Improved internal handling and caching of indexed color data to make rendering more reliable and consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->