### PR TITLE
feat(geometry,wasm,renderer): type-only geometry + IFC surface textures (#957 #958 #961)

### DIFF
--- a/.changeset/nine-five-seven-type-only-geometry.md
+++ b/.changeset/nine-five-seven-type-only-geometry.md
@@ -1,0 +1,15 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Render type-only tessellated geometry that has no occurrence (#957).
+
+buildingSMART annex-E "tessellated shape with style" files (and similar IFC
+type libraries) attach their geometry to an `IfcXxxType` via `RepresentationMaps`
+with no product instance, so the model displayed empty. The geometry now renders
+for any `RepresentationMap` that no `IfcMappedItem` instantiates — both in the
+native `process_geometry` path and the browser's `processGeometryBatch` viewer
+path — without double-rendering normally-instanced typed products. (The reported
+"unsupported `IfcBlobTexture`" was a red herring: the blob parses fine and the
+surface style falls back to its base colour; the geometry now renders flat white.
+Full texture rendering is tracked separately.)

--- a/.changeset/nine-six-one-tessellation-textures.md
+++ b/.changeset/nine-six-one-tessellation-textures.md
@@ -6,11 +6,12 @@
 
 Render IFC surface textures on tessellated geometry (#961).
 
-`IfcBlobTexture` (embedded PNG) and `IfcPixelTexture` (raw pixel literals) are now
-decoded to RGBA8 entirely in Rust (the `png` crate, already in the tree) and the
-per-triangle `IfcIndexedTriangleTextureMap` / `IfcTextureVertexList` coordinates
-are emitted as per-vertex UVs in lockstep with the flat-shaded tessellation (the
-`IfcCartesianTransformationOperator2D` scale is applied; the whole-shell
+`IfcBlobTexture` (embedded PNG **and** JPEG) and `IfcPixelTexture` (raw pixel
+literals) are now decoded to RGBA8 entirely in Rust (the `png` and
+`jpeg-decoder` crates) and the per-triangle `IfcIndexedTriangleTextureMap` /
+`IfcTextureVertexList` coordinates are emitted as per-vertex UVs in lockstep with
+the flat-shaded tessellation (the authored texture coordinates are used directly,
+mapping the image ~1:1 like the buildingSMART reference; the whole-shell
 orientation flip is mirrored onto the texture indices so UVs stay aligned). The
 decoded RGBA + UVs ride on `MeshData` across the wasm boundary; the WebGPU
 renderer gains a dedicated textured pipeline that uploads the texture and draws

--- a/.changeset/nine-six-one-tessellation-textures.md
+++ b/.changeset/nine-six-one-tessellation-textures.md
@@ -1,0 +1,23 @@
+---
+"@ifc-lite/wasm": minor
+"@ifc-lite/geometry": minor
+"@ifc-lite/renderer": minor
+---
+
+Render IFC surface textures on tessellated geometry (#961).
+
+`IfcBlobTexture` (embedded PNG) and `IfcPixelTexture` (raw pixel literals) are now
+decoded to RGBA8 entirely in Rust (the `png` crate, already in the tree) and the
+per-triangle `IfcIndexedTriangleTextureMap` / `IfcTextureVertexList` coordinates
+are emitted as per-vertex UVs in lockstep with the flat-shaded tessellation (the
+`IfcCartesianTransformationOperator2D` scale is applied; the whole-shell
+orientation flip is mirrored onto the texture indices so UVs stay aligned). The
+decoded RGBA + UVs ride on `MeshData` across the wasm boundary; the WebGPU
+renderer gains a dedicated textured pipeline that uploads the texture and draws
+textured meshes in their own sub-pass, preserving picking, section-clipping and
+flat-shading. The buildingSMART annex-E "tessellated shape with style" boilers
+now render textured instead of flat white.
+
+All image/texture decoding lives in Rust so the server, CLI and SDK get the same
+result — the browser only uploads the bytes to the GPU. `IfcImageTexture`
+(external URL) remains out of scope (needs an async fetch resolver).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2473,6 +2473,7 @@ dependencies = [
  "ifc-lite-core",
  "manifold-csg",
  "nalgebra",
+ "png 0.17.16",
  "rayon",
  "rustc-hash",
  "smallvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2471,6 +2471,7 @@ dependencies = [
  "earcutr",
  "i_overlay",
  "ifc-lite-core",
+ "jpeg-decoder",
  "manifold-csg",
  "nalgebra",
  "png 0.17.16",
@@ -2713,6 +2714,12 @@ dependencies = [
  "getrandom 0.3.4",
  "libc",
 ]
+
+[[package]]
+name = "jpeg-decoder"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
 
 [[package]]
 name = "js-sys"

--- a/packages/geometry/src/geometry-coordinate.ts
+++ b/packages/geometry/src/geometry-coordinate.ts
@@ -65,7 +65,7 @@ export function convertMeshCollectionToBatch(
             ? [shadingArray[0], shadingArray[1], shadingArray[2], shadingArray[3]]
             : undefined;
 
-        batch.push({
+        const meshData: MeshData = {
           expressId: mesh.expressId,
           ifcType: mesh.ifcType,
           positions: mesh.positions,
@@ -73,7 +73,23 @@ export function convertMeshCollectionToBatch(
           indices: mesh.indices,
           color: [mesh.color[0], mesh.color[1], mesh.color[2], mesh.color[3]],
           ...(shadingColor ? { shadingColor } : {}),
-        });
+        };
+
+        // #961: copy the Rust-decoded surface texture + per-vertex UVs (the
+        // getters return empty for the ~all untextured meshes). The browser
+        // only uploads `rgba` to a GPU texture — no image decoding in JS.
+        if ((mesh as { hasTexture?: boolean }).hasTexture) {
+          meshData.uvs = mesh.uvs;
+          meshData.texture = {
+            rgba: mesh.textureRgba,
+            width: mesh.textureWidth,
+            height: mesh.textureHeight,
+            repeatS: mesh.textureRepeatS,
+            repeatT: mesh.textureRepeatT,
+          };
+        }
+
+        batch.push(meshData);
       } finally {
         mesh.free();
       }

--- a/packages/geometry/src/geometry-parallel.ts
+++ b/packages/geometry/src/geometry-parallel.ts
@@ -183,20 +183,17 @@ export async function* processParallel(
           firstBatchByWorker[workerIndex] = elapsed();
           console.log(`[stream] worker[${workerIndex}] first batch @ ${elapsed()}ms (${msg.meshes?.length ?? 0} meshes)`);
         }
-        const meshes: MeshData[] = msg.meshes.map((m: {
-          expressId: number;
-          ifcType?: string;
-          positions: Float32Array;
-          normals: Float32Array;
-          indices: Uint32Array;
-          color: [number, number, number, number];
-        }) => ({
+        const meshes: MeshData[] = msg.meshes.map((m: MeshData) => ({
           expressId: m.expressId,
           ifcType: m.ifcType,
           positions: m.positions instanceof Float32Array ? m.positions : new Float32Array(m.positions),
           normals: m.normals instanceof Float32Array ? m.normals : new Float32Array(m.normals),
           indices: m.indices instanceof Uint32Array ? m.indices : new Uint32Array(m.indices),
           color: m.color,
+          // #961: carry per-vertex UVs + decoded surface texture through to the
+          // renderer (transferables; already typed arrays from the worker).
+          ...(m.uvs ? { uvs: m.uvs } : {}),
+          ...(m.texture ? { texture: m.texture } : {}),
         }));
         if (meshes.length > 0) {
           // Update totalMeshes per batch so consumers see a live

--- a/packages/geometry/src/geometry.worker.ts
+++ b/packages/geometry/src/geometry.worker.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import init, { initSync, IfcAPI } from '@ifc-lite/wasm';
+import type { MeshData } from './types.js';
 
 export interface GeometryWorkerInitMessage {
   type: 'init';
@@ -138,6 +139,9 @@ export interface GeometryWorkerBatchMessage {
     normals: Float32Array;
     indices: Uint32Array;
     color: [number, number, number, number];
+    // #961: optional surface texture + per-vertex UVs (transferables).
+    uvs?: MeshData['uvs'];
+    texture?: MeshData['texture'];
   }[];
 }
 
@@ -335,14 +339,31 @@ function collectMeshes(
     const positions = new Float32Array(mesh.positions);
     const normals = new Float32Array(mesh.normals);
     const indices = new Uint32Array(mesh.indices);
-    session.pendingMeshes.push({
+    const meshData: MeshData = {
       expressId: mesh.expressId,
       ifcType: mesh.ifcType,
       positions, normals, indices,
       color: [mesh.color[0], mesh.color[1], mesh.color[2], mesh.color[3]],
-    });
+    };
     session.pendingTransfers.push(positions.buffer, normals.buffer, indices.buffer);
     session.cumulativeMeshBytes += positions.byteLength + normals.byteLength + indices.byteLength;
+    // #961: surface texture + per-vertex UVs (decoded to RGBA8 in Rust). Carried
+    // as transferables so there is no SAB→scratch copy (see SAB-streaming memo).
+    if (mesh.hasTexture) {
+      const uvs = new Float32Array(mesh.uvs);
+      const rgba = new Uint8Array(mesh.textureRgba);
+      meshData.uvs = uvs;
+      meshData.texture = {
+        rgba,
+        width: mesh.textureWidth,
+        height: mesh.textureHeight,
+        repeatS: mesh.textureRepeatS,
+        repeatT: mesh.textureRepeatT,
+      };
+      session.pendingTransfers.push(uvs.buffer, rgba.buffer);
+      session.cumulativeMeshBytes += uvs.byteLength + rgba.byteLength;
+    }
+    session.pendingMeshes.push(meshData);
     mesh.free();
   }
   collection.free();

--- a/packages/geometry/src/types.ts
+++ b/packages/geometry/src/types.ts
@@ -27,6 +27,24 @@ export interface MeshData {
    *  for every vertex, so picking/selection resolves to the correct individual
    *  entity even though many entities share a single GPU batch. */
   entityIds?: Uint32Array;
+  /** Per-vertex texture coordinates (u, v pairs, 1:1 with positions), present
+   *  only for textured meshes (issue #961). */
+  uvs?: Float32Array;
+  /** Decoded surface texture (IfcBlobTexture / IfcPixelTexture), present only
+   *  for textured meshes (#961). Decoded to RGBA8 entirely in Rust; the
+   *  renderer uploads `rgba` verbatim to a GPU texture. */
+  texture?: MeshTexture;
+}
+
+/** A decoded RGBA8 surface texture attached to a mesh (issue #961). */
+export interface MeshTexture {
+  /** `width * height * 4` bytes, row-major, top-down, straight alpha. */
+  rgba: Uint8Array;
+  width: number;
+  height: number;
+  /** Sampler wrap from `IfcSurfaceTexture.RepeatS/RepeatT` (true = repeat). */
+  repeatS: boolean;
+  repeatT: boolean;
 }
 
 export interface Vec3 {

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -1700,12 +1700,25 @@ export class Renderer {
                             if (options.hiddenIds?.has(tm.expressId)) continue;
                             if (hasIsolatedFilter && !options.isolatedIds!.has(tm.expressId)) continue;
                         }
-                        // Tint multiplies the sampled texel; the IfcColourRgb base
-                        // is white in the annex-E fixtures → texture shows as-is.
-                        tpl[32] = tm.color[0];
-                        tpl[33] = tm.color[1];
-                        tpl[34] = tm.color[2];
-                        tpl[35] = tm.color[3];
+                        // Per-entity transparency override (e.g. a Pset/lens alpha):
+                        // a fully-transparent override hides the mesh. NOTE: the
+                        // textured pipeline is opaque, so a *partial* alpha can't
+                        // blend — textured surfaces render opaque (acceptable for
+                        // the photo/pattern type-geometry these carry; a transparent
+                        // textured pipeline would be needed for true blending).
+                        const txAlpha = alphaForBatch(
+                            { expressIds: [tm.expressId], color: tm.color },
+                            tm.color[3],
+                        );
+                        if (txAlpha <= 0.01) continue;
+                        // Lens / Pset colour override tints the sampled texel — the
+                        // batch overlay paint pass doesn't iterate textured meshes,
+                        // so applying the override here is what recolours them.
+                        const txOverride = colorOverrides?.get(tm.expressId);
+                        tpl[32] = txOverride ? txOverride[0] : tm.color[0];
+                        tpl[33] = txOverride ? txOverride[1] : tm.color[1];
+                        tpl[34] = txOverride ? txOverride[2] : tm.color[2];
+                        tpl[35] = txAlpha;
                         device.queue.writeBuffer(tm.uniformBuffer, 0, tpl);
                         pass.setBindGroup(0, tm.bindGroup);
                         pass.setVertexBuffer(0, tm.vertexBuffer);

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -1473,7 +1473,10 @@ export class Renderer {
             // PERFORMANCE FIX: Always use batch rendering when we have batches
             // Apply visibility filtering at the BATCH level instead of creating individual meshes
             // This keeps draw calls at ~50-200 instead of 60K+
-            if (allBatchedMeshes.length > 0) {
+            // #961: also enter this block when there are textured meshes but no
+            // colour batches (e.g. a model that is only a textured type-geometry
+            // boiler) — the textured sub-pass lives inside this block.
+            if (allBatchedMeshes.length > 0 || this.scene.getTexturedMeshes().length > 0) {
                 // Frustum culling for batched meshes - skip entire batches outside the camera view
                 // This is the primary performance optimization for large models (200K+ meshes)
                 const frustum = FrustumUtils.fromViewProjMatrix(viewProj);
@@ -1679,6 +1682,30 @@ export class Renderer {
                 pass.setPipeline(this.pipeline.getPipeline());
                 for (const batch of opaqueBatches) {
                     renderBatch(batch);
+                }
+
+                // #961: textured meshes — dedicated sub-pass right after opaque
+                // batches (writes depth + object-id, so overlay/section/picking
+                // all behave like normal opaque geometry). Each mesh has its own
+                // vertex buffer (with a UV lane), texture, sampler and bindGroup.
+                const texturedMeshes = this.scene.getTexturedMeshes();
+                if (texturedMeshes.length > 0) {
+                    pass.setPipeline(this.pipeline.getTexturedPipeline());
+                    for (const tm of texturedMeshes) {
+                        // Tint multiplies the sampled texel; the IfcColourRgb base
+                        // is white in the annex-E fixtures → texture shows as-is.
+                        tpl[32] = tm.color[0];
+                        tpl[33] = tm.color[1];
+                        tpl[34] = tm.color[2];
+                        tpl[35] = tm.color[3];
+                        device.queue.writeBuffer(tm.uniformBuffer, 0, tpl);
+                        pass.setBindGroup(0, tm.bindGroup);
+                        pass.setVertexBuffer(0, tm.vertexBuffer);
+                        pass.setIndexBuffer(tm.indexBuffer, 'uint32');
+                        pass.drawIndexed(tm.indexCount);
+                    }
+                    // Restore the opaque pipeline for the passes that follow.
+                    pass.setPipeline(this.pipeline.getPipeline());
                 }
 
                 // PERFORMANCE FIX: Render partially visible batches as sub-batches (not individual meshes!)

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -1692,6 +1692,14 @@ export class Renderer {
                 if (texturedMeshes.length > 0) {
                     pass.setPipeline(this.pipeline.getTexturedPipeline());
                     for (const tm of texturedMeshes) {
+                        // Honour hide/isolate — textured meshes bypass the batch
+                        // visibility filtering above, so apply it per-mesh here or
+                        // hidden/isolated elements would stay visible and keep
+                        // writing depth + object IDs.
+                        if (hasVisibilityFiltering) {
+                            if (options.hiddenIds?.has(tm.expressId)) continue;
+                            if (hasIsolatedFilter && !options.isolatedIds!.has(tm.expressId)) continue;
+                        }
                         // Tint multiplies the sampled texel; the IfcColourRgb base
                         // is white in the annex-E fixtures → texture shows as-is.
                         tpl[32] = tm.color[0];

--- a/packages/renderer/src/pipeline.ts
+++ b/packages/renderer/src/pipeline.ts
@@ -8,6 +8,7 @@
 
 import { WebGPUDevice } from './device.js';
 import { mainShaderSource } from './shaders/main.wgsl.js';
+import { texturedShaderSource } from './shaders/textured.wgsl.js';
 
 export class RenderPipeline {
     private device: GPUDevice;
@@ -16,6 +17,8 @@ export class RenderPipeline {
     private selectionPipeline: GPURenderPipeline;  // Pipeline for selected meshes (renders on top)
     private transparentPipeline: GPURenderPipeline;  // Pipeline for transparent meshes with alpha blending
     private overlayPipeline: GPURenderPipeline;  // Pipeline for color overlays (lens) - renders at exact same depth
+    private texturedPipeline: GPURenderPipeline;  // Pipeline for textured meshes (#961): UV lane + albedo texture/sampler
+    private texturedBindGroupLayout: GPUBindGroupLayout;  // group(0): uniform + texture + sampler
     private depthTexture: GPUTexture;
     private depthTextureView: GPUTextureView;
     // depth-only view of depthTexture for sampling as texture_depth_2d in
@@ -304,6 +307,65 @@ export class RenderPipeline {
 
         this.overlayPipeline = this.device.createRenderPipeline(overlayPipelineDescriptor);
 
+        // ── Textured pipeline (#961) ──
+        // A separate pipeline for meshes carrying an IFC surface texture. It
+        // adds a UV vertex lane and an albedo texture+sampler at group(0)
+        // bindings 1 & 2; everything else (depth, MSAA, both colour targets incl.
+        // the object-id picking target, flat-normal shading, section clip) mirrors
+        // the main opaque pipeline so picking/section/z-fight behave identically.
+        // Textured meshes are rare (a handful per model), so they draw
+        // per-mesh — the 28-byte hot path for the other ~all meshes is untouched.
+        this.texturedBindGroupLayout = this.device.createBindGroupLayout({
+            label: 'textured-bgl',
+            entries: [
+                {
+                    binding: 0,
+                    visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+                    buffer: { type: 'uniform' },
+                },
+                { binding: 1, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: 'float' } },
+                { binding: 2, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' } },
+            ],
+        });
+        const texturedModule = this.device.createShaderModule({
+            label: 'textured-shader',
+            code: texturedShaderSource,
+        });
+        this.texturedPipeline = this.device.createRenderPipeline({
+            label: 'textured-pipeline',
+            layout: this.device.createPipelineLayout({
+                bindGroupLayouts: [this.texturedBindGroupLayout],
+            }),
+            vertex: {
+                module: texturedModule,
+                entryPoint: 'vs_main',
+                buffers: [
+                    {
+                        // position(3f) + normal(3f) + entityId(u32) + uv(2f) = 36 bytes
+                        arrayStride: 36,
+                        attributes: [
+                            { shaderLocation: 0, offset: 0, format: 'float32x3' },
+                            { shaderLocation: 1, offset: 12, format: 'float32x3' },
+                            { shaderLocation: 2, offset: 24, format: 'uint32' },
+                            { shaderLocation: 3, offset: 28, format: 'float32x2' },
+                        ],
+                    },
+                ],
+            },
+            fragment: {
+                module: texturedModule,
+                entryPoint: 'fs_main',
+                targets: [{ format: this.colorFormat }, { format: this.objectIdFormat }],
+            },
+            primitive: { topology: 'triangle-list', cullMode: 'none' },
+            depthStencil: {
+                format: this.depthFormat,
+                depthWriteEnabled: true,
+                depthCompare: 'greater', // Reverse-Z, matches the opaque pipeline
+            },
+            multisample: { count: this.sampleCount },
+        } as GPURenderPipelineDescriptor);
+
         // Create bind group using the explicit bind group layout
         this.bindGroup = this.device.createBindGroup({
             layout: this.bindGroupLayout,
@@ -449,6 +511,30 @@ export class RenderPipeline {
 
     getOverlayPipeline(): GPURenderPipeline {
         return this.overlayPipeline;
+    }
+
+    /** Textured-mesh pipeline (#961). */
+    getTexturedPipeline(): GPURenderPipeline {
+        return this.texturedPipeline;
+    }
+
+    /**
+     * Create a bind group for a textured mesh (#961): the mesh's own uniform
+     * buffer at binding 0, plus its albedo texture view + sampler at 1 & 2.
+     */
+    createTexturedBindGroup(
+        uniformBuffer: GPUBuffer,
+        textureView: GPUTextureView,
+        sampler: GPUSampler,
+    ): GPUBindGroup {
+        return this.device.createBindGroup({
+            layout: this.texturedBindGroupLayout,
+            entries: [
+                { binding: 0, resource: { buffer: uniformBuffer } },
+                { binding: 1, resource: textureView },
+                { binding: 2, resource: sampler },
+            ],
+        });
     }
 
     getDepthTextureView(): GPUTextureView {

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -38,6 +38,22 @@ interface BatchBucket {
  * Accepts the structural shape so it works for both BatchedMesh and
  * Mesh — they each carry the same buffer trio.
  */
+/** A surface-textured mesh (#961): its own interleaved vertex buffer (with a UV
+ *  lane), index buffer, per-mesh uniform buffer, GPU texture + sampler, and a
+ *  bindGroup wiring all three. Drawn per-mesh in a dedicated sub-pass. */
+export interface TexturedMesh {
+  expressId: number;
+  vertexBuffer: GPUBuffer;
+  indexBuffer: GPUBuffer;
+  indexCount: number;
+  uniformBuffer: GPUBuffer;
+  texture: GPUTexture;
+  sampler: GPUSampler;
+  bindGroup: GPUBindGroup;
+  /** Authored tint (multiplies the sampled texel); white = texture passthrough. */
+  color: [number, number, number, number];
+}
+
 function destroyGpuResources(
   m: { vertexBuffer: GPUBuffer; indexBuffer: GPUBuffer; uniformBuffer?: GPUBuffer },
 ): void {
@@ -53,6 +69,7 @@ export class Scene {
   private meshDataBucket: Map<MeshData, BatchBucket> = new Map();   // reverse lookup: MeshData -> owning bucket
   private meshDataMap: Map<number, MeshData[]> = new Map();         // Map expressId -> MeshData[] (for lazy buffer creation, accumulates multiple pieces)
   private boundingBoxes: Map<number, BoundingBox> = new Map();      // Map expressId -> bounding box (computed lazily)
+  private texturedMeshes: TexturedMesh[] = [];                      // #961: IFC surface-textured meshes (own buffers/texture/bindGroup)
 
   // Buffer-size-aware bucket splitting: when a single color group's geometry
   // would exceed the GPU maxBufferSize, overflow is directed to a new
@@ -417,8 +434,26 @@ export class Scene {
 
     const retainStreamingGeometry = !(isStreaming && this.ephemeralStreamingMode);
 
+    // #961: divert meshes carrying an IFC surface texture to the dedicated
+    // textured pipeline. They have no single colour, so they must be kept out
+    // of BOTH the colour buckets AND the streaming-fragment path below —
+    // otherwise a flat-colour copy would be drawn over the texture. Still
+    // register them in meshDataMap (addMeshData) so CPU picking/bbox/frame work.
+    let renderable = meshDataArray;
+    if (meshDataArray.some((m) => m.texture && m.uvs)) {
+      renderable = [];
+      for (const meshData of meshDataArray) {
+        if (meshData.texture && meshData.uvs) {
+          this.createTexturedMesh(meshData, device, pipeline);
+          this.addMeshData(meshData);
+        } else {
+          renderable.push(meshData);
+        }
+      }
+    }
+
     // Route each mesh into a size-aware bucket for its color
-    for (const meshData of meshDataArray) {
+    for (const meshData of renderable) {
       const baseKey = this.colorKey(meshData.color);
       const bucketKey = this.resolveActiveBucket(baseKey, meshData);
 
@@ -450,7 +485,8 @@ export class Scene {
       // STREAMING: Create small fragment batches from ONLY the new meshes.
       // Avoids the O(N²) cost of re-merging all accumulated data every batch.
       // finalizeStreaming() destroys fragments and does one O(N) full merge.
-      this.createStreamingFragments(meshDataArray, device, pipeline);
+      // `renderable` excludes textured meshes (drawn via the textured pipeline).
+      this.createStreamingFragments(renderable, device, pipeline);
       return;
     }
 
@@ -1562,9 +1598,109 @@ export class Scene {
   /**
    * Clear scene
    */
+  /** Textured meshes (#961) for the renderer's dedicated textured sub-pass. */
+  getTexturedMeshes(): readonly TexturedMesh[] {
+    return this.texturedMeshes;
+  }
+
+  /**
+   * Build a textured mesh (#961): interleave position+normal+entityId+uv into one
+   * vertex buffer, upload the decoded RGBA8 texture, create a sampler honouring
+   * the IFC RepeatS/RepeatT wrap, and wire a bindGroup (uniform+texture+sampler).
+   * The per-frame uniform (viewProj/section/flags + colour tint) is written by
+   * the renderer each frame, mirroring how colour batches are driven.
+   */
+  private createTexturedMesh(meshData: MeshData, device: GPUDevice, pipeline: RenderPipeline): void {
+    const tex = meshData.texture;
+    const uvs = meshData.uvs;
+    if (!tex || !uvs) return;
+
+    const positions = meshData.positions;
+    const normals = meshData.normals;
+    const vertexCount = positions.length / 3;
+    if (vertexCount === 0 || meshData.indices.length === 0) return;
+
+    // Interleave: [px,py,pz, nx,ny,nz, entityId(u32), u,v] = 9 * 4 = 36 bytes.
+    const interleaved = new ArrayBuffer(vertexCount * 36);
+    const f = new Float32Array(interleaved);
+    const u = new Uint32Array(interleaved);
+    const entityIds = meshData.entityIds;
+    for (let i = 0; i < vertexCount; i++) {
+      const o = i * 9;
+      f[o] = positions[i * 3];
+      f[o + 1] = positions[i * 3 + 1];
+      f[o + 2] = positions[i * 3 + 2];
+      f[o + 3] = normals[i * 3] ?? 0;
+      f[o + 4] = normals[i * 3 + 1] ?? 0;
+      f[o + 5] = normals[i * 3 + 2] ?? 0;
+      u[o + 6] = entityIds ? entityIds[i] : meshData.expressId;
+      f[o + 7] = uvs[i * 2] ?? 0;
+      f[o + 8] = uvs[i * 2 + 1] ?? 0;
+    }
+
+    const vertexBuffer = device.createBuffer({
+      size: interleaved.byteLength,
+      usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+    });
+    device.queue.writeBuffer(vertexBuffer, 0, interleaved);
+
+    const indexBuffer = device.createBuffer({
+      size: meshData.indices.byteLength,
+      usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST,
+    });
+    device.queue.writeBuffer(indexBuffer, 0, meshData.indices);
+
+    // Upload the Rust-decoded RGBA8 verbatim — no image decoding in JS.
+    const texture = device.createTexture({
+      size: { width: tex.width, height: tex.height },
+      format: 'rgba8unorm',
+      usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST,
+    });
+    device.queue.writeTexture(
+      { texture },
+      tex.rgba,
+      { bytesPerRow: tex.width * 4, rowsPerImage: tex.height },
+      { width: tex.width, height: tex.height },
+    );
+
+    const wrap = (repeat: boolean): GPUAddressMode => (repeat ? 'repeat' : 'clamp-to-edge');
+    const sampler = device.createSampler({
+      addressModeU: wrap(tex.repeatS),
+      addressModeV: wrap(tex.repeatT),
+      magFilter: 'linear',
+      minFilter: 'linear',
+      mipmapFilter: 'linear',
+    });
+
+    const uniformBuffer = device.createBuffer({
+      size: pipeline.getUniformBufferSize(),
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+    const bindGroup = pipeline.createTexturedBindGroup(uniformBuffer, texture.createView(), sampler);
+
+    this.texturedMeshes.push({
+      expressId: meshData.expressId,
+      vertexBuffer,
+      indexBuffer,
+      indexCount: meshData.indices.length,
+      uniformBuffer,
+      texture,
+      sampler,
+      bindGroup,
+      color: meshData.color,
+    });
+  }
+
   clear(): void {
     for (const mesh of this.meshes) destroyGpuResources(mesh);
     for (const batch of this.batchedMeshes) destroyGpuResources(batch);
+    for (const tm of this.texturedMeshes) {
+      tm.vertexBuffer.destroy();
+      tm.indexBuffer.destroy();
+      tm.uniformBuffer.destroy();
+      tm.texture.destroy();
+    }
+    this.texturedMeshes = [];
     // Clear partial batch cache
     for (const batch of this.partialBatchCache.values()) destroyGpuResources(batch);
     // Destroy streaming fragments (already included in batchedMeshes, but tracked separately)

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -70,6 +70,7 @@ export class Scene {
   private meshDataMap: Map<number, MeshData[]> = new Map();         // Map expressId -> MeshData[] (for lazy buffer creation, accumulates multiple pieces)
   private boundingBoxes: Map<number, BoundingBox> = new Map();      // Map expressId -> bounding box (computed lazily)
   private texturedMeshes: TexturedMesh[] = [];                      // #961: IFC surface-textured meshes (own buffers/texture/bindGroup)
+  private texturedDevice?: GPUDevice;                               // #961: cached for textured-mesh re-upload on translate
 
   // Buffer-size-aware bucket splitting: when a single color group's geometry
   // would exceed the GPU maxBufferSize, overflow is directed to a new
@@ -614,6 +615,20 @@ export class Scene {
     this.meshDataMap.delete(expressId);
     this.boundingBoxes.delete(expressId);
 
+    // #961: textured meshes own GPU buffers outside the colour buckets, so the
+    // bucket cleanup above never touches them. Destroy + drop them here or a
+    // deleted textured entity keeps rendering (and leaks its GPU texture).
+    for (let i = this.texturedMeshes.length - 1; i >= 0; i--) {
+      const tm = this.texturedMeshes[i];
+      if (tm.expressId !== expressId) continue;
+      tm.vertexBuffer.destroy();
+      tm.indexBuffer.destroy();
+      tm.uniformBuffer.destroy();
+      tm.texture.destroy();
+      this.texturedMeshes.splice(i, 1);
+      removedDedicated = true;
+    }
+
     for (const key of affectedKeys) {
       this.pendingBatchKeys.add(key);
     }
@@ -680,6 +695,23 @@ export class Scene {
       anyMoved = true;
     }
     if (!anyMoved) return false;
+
+    // #961: a textured mesh's GPU vertex buffer lives outside the colour buckets,
+    // so the in-place position translation above won't reach the GPU on its own —
+    // re-interleave + re-upload the moved textured parts (paired by expressId,
+    // in creation order). Without this a moved textured entity renders stale.
+    if (this.texturedDevice && this.texturedMeshes.length > 0) {
+      const texturedData = meshDataList.filter((md) => md.texture && md.uvs);
+      if (texturedData.length > 0) {
+        const entries = this.texturedMeshes.filter((tm) => tm.expressId === expressId);
+        for (let i = 0; i < entries.length && i < texturedData.length; i++) {
+          const interleaved = this.interleaveTexturedVertices(texturedData[i]);
+          if (interleaved) {
+            this.texturedDevice.queue.writeBuffer(entries[i].vertexBuffer, 0, interleaved);
+          }
+        }
+      }
+    }
 
     this.boundingBoxes.delete(expressId);
     for (const key of affectedKeys) {
@@ -1610,17 +1642,20 @@ export class Scene {
    * The per-frame uniform (viewProj/section/flags + colour tint) is written by
    * the renderer each frame, mirroring how colour batches are driven.
    */
-  private createTexturedMesh(meshData: MeshData, device: GPUDevice, pipeline: RenderPipeline): void {
-    const tex = meshData.texture;
+  /**
+   * Interleave a textured mesh's vertices into the stride-36 layout
+   * `[px,py,pz, nx,ny,nz, entityId(u32), u,v]`. Shared by initial upload and
+   * the translate re-upload so the two can't drift. Returns null when the mesh
+   * has no texture/uvs/geometry.
+   */
+  private interleaveTexturedVertices(meshData: MeshData): ArrayBuffer | null {
     const uvs = meshData.uvs;
-    if (!tex || !uvs) return;
-
+    if (!meshData.texture || !uvs) return null;
     const positions = meshData.positions;
     const normals = meshData.normals;
     const vertexCount = positions.length / 3;
-    if (vertexCount === 0 || meshData.indices.length === 0) return;
+    if (vertexCount === 0 || meshData.indices.length === 0) return null;
 
-    // Interleave: [px,py,pz, nx,ny,nz, entityId(u32), u,v] = 9 * 4 = 36 bytes.
     const interleaved = new ArrayBuffer(vertexCount * 36);
     const f = new Float32Array(interleaved);
     const u = new Uint32Array(interleaved);
@@ -1637,6 +1672,14 @@ export class Scene {
       f[o + 7] = uvs[i * 2] ?? 0;
       f[o + 8] = uvs[i * 2 + 1] ?? 0;
     }
+    return interleaved;
+  }
+
+  private createTexturedMesh(meshData: MeshData, device: GPUDevice, pipeline: RenderPipeline): void {
+    const tex = meshData.texture;
+    const interleaved = this.interleaveTexturedVertices(meshData);
+    if (!tex || !interleaved) return;
+    this.texturedDevice = device; // reused by translateMeshesForEntity re-upload
 
     const vertexBuffer = device.createBuffer({
       size: interleaved.byteLength,

--- a/packages/renderer/src/shaders/textured.wgsl.ts
+++ b/packages/renderer/src/shaders/textured.wgsl.ts
@@ -73,10 +73,17 @@ function deriveTexturedShader(): string {
   );
 
   // 5. Sample the texture; multiply by the authored tint (white = passthrough).
+  //    Honour the texel alpha as a cutout (alpha-keyed textures) by discarding
+  //    fully-transparent texels — the textured pipeline is opaque/depth-writing,
+  //    so without this RGBA textures with transparent regions would render
+  //    fully opaque. (Partial translucency would need a transparent textured
+  //    pipeline — out of scope for the cutout case.)
   s = replaceOnce(
     s,
     'var baseColor = uniforms.baseColor.rgb;',
-    'var baseColor = textureSample(albedoTex, albedoSampler, input.uv).rgb * uniforms.baseColor.rgb;',
+    'let albedoTexel = textureSample(albedoTex, albedoSampler, input.uv);\n' +
+      '          if (albedoTexel.a < 0.004) { discard; }\n' +
+      '          var baseColor = albedoTexel.rgb * uniforms.baseColor.rgb;',
     'albedo sample',
   );
 

--- a/packages/renderer/src/shaders/textured.wgsl.ts
+++ b/packages/renderer/src/shaders/textured.wgsl.ts
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Textured variant of the main PBR shader (issue #961).
+ *
+ * Derived from `mainShaderSource` by targeted, anchored transforms rather than a
+ * copy, so the lighting / section-clip / flat-normal / object-id-picking /
+ * z-fight logic stays single-source in `main.wgsl.ts` and can't drift. Each
+ * transform asserts its anchor exists — if `main.wgsl.ts` is edited in a way
+ * that moves an anchor, the build fails loudly here instead of silently
+ * shipping a stale textured shader.
+ *
+ * Additions over the base shader:
+ *  - a `uv` vertex attribute (@location 3) threaded through to the fragment;
+ *  - an albedo `texture_2d` + `sampler` at group(0) bindings 1 & 2;
+ *  - the surface albedo becomes `texture(uv) * baseColor` — `baseColor` stays
+ *    the authored `IfcColourRgb` (white in the annex-E fixtures), so a white
+ *    tint passes the texture through unchanged while a coloured surface style
+ *    still tints it.
+ */
+import { mainShaderSource } from './main.wgsl.js';
+
+function replaceOnce(src: string, find: string, repl: string, label: string): string {
+  const idx = src.indexOf(find);
+  if (idx === -1) {
+    throw new Error(
+      `textured.wgsl: anchor "${label}" not found — main.wgsl.ts changed; update the textured-shader derivation.`,
+    );
+  }
+  if (src.indexOf(find, idx + find.length) !== -1) {
+    throw new Error(`textured.wgsl: anchor "${label}" is not unique — tighten the derivation.`);
+  }
+  return src.slice(0, idx) + repl + src.slice(idx + find.length);
+}
+
+function deriveTexturedShader(): string {
+  let s = mainShaderSource;
+
+  // 1. Albedo texture + sampler bindings (same group(0) as the uniform).
+  s = replaceOnce(
+    s,
+    '@binding(0) @group(0) var<uniform> uniforms: Uniforms;',
+    '@binding(0) @group(0) var<uniform> uniforms: Uniforms;\n' +
+      '        @binding(1) @group(0) var albedoTex: texture_2d<f32>;\n' +
+      '        @binding(2) @group(0) var albedoSampler: sampler;',
+    'uniform binding',
+  );
+
+  // 2. UV vertex attribute on VertexInput.
+  s = replaceOnce(
+    s,
+    '          @location(2) entityId: u32,\n        }\n\n        struct VertexOutput {',
+    '          @location(2) entityId: u32,\n          @location(3) uv: vec2<f32>,\n        }\n\n        struct VertexOutput {',
+    'VertexInput uv',
+  );
+
+  // 3. UV interpolant on VertexOutput.
+  s = replaceOnce(
+    s,
+    '          @location(3) viewPos: vec3<f32>,  // For edge detection\n        }',
+    '          @location(3) viewPos: vec3<f32>,  // For edge detection\n          @location(4) uv: vec2<f32>,\n        }',
+    'VertexOutput uv',
+  );
+
+  // 4. Pass UV through the vertex shader.
+  s = replaceOnce(
+    s,
+    '          output.entityId = input.entityId;',
+    '          output.entityId = input.entityId;\n          output.uv = input.uv;',
+    'vs_main uv passthrough',
+  );
+
+  // 5. Sample the texture; multiply by the authored tint (white = passthrough).
+  s = replaceOnce(
+    s,
+    'var baseColor = uniforms.baseColor.rgb;',
+    'var baseColor = textureSample(albedoTex, albedoSampler, input.uv).rgb * uniforms.baseColor.rgb;',
+    'albedo sample',
+  );
+
+  return s;
+}
+
+export const texturedShaderSource = deriveTexturedShader();

--- a/packages/wasm/test/textures.test.mjs
+++ b/packages/wasm/test/textures.test.mjs
@@ -29,29 +29,37 @@ const BOILER_TYPE_ID = 43;
 function texturedBoiler(api, content) {
   const bytes = new TextEncoder().encode(content);
   const pre = api.buildPrePassOnce(bytes);
+  // Free every wasm handle (each MeshDataJs + the MeshCollection) + the prepass
+  // cache deterministically, even if an assertion-side error unwinds mid-loop.
   const col = api.processGeometryBatch(
     bytes, pre.jobs, pre.unitScale,
     pre.rtcOffset[0], pre.rtcOffset[1], pre.rtcOffset[2], pre.needsShift,
     pre.voidKeys, pre.voidCounts, pre.voidValues, pre.styleIds, pre.styleColors,
   );
-  let found = null;
-  for (let i = 0; i < col.length; i++) {
-    const m = col.get(i);
-    if (m && m.expressId === BOILER_TYPE_ID && m.hasTexture) {
-      found = {
-        tris: m.triangleCount,
-        uvsLen: m.uvs.length,
-        verts: m.vertexCount,
-        width: m.textureWidth,
-        height: m.textureHeight,
-        rgbaLen: m.textureRgba.length,
-      };
+  try {
+    let found = null;
+    for (let i = 0; i < col.length; i++) {
+      const m = col.get(i);
+      try {
+        if (m && m.expressId === BOILER_TYPE_ID && m.hasTexture) {
+          found = {
+            tris: m.triangleCount,
+            uvsLen: m.uvs.length,
+            verts: m.vertexCount,
+            width: m.textureWidth,
+            height: m.textureHeight,
+            rgbaLen: m.textureRgba.length,
+          };
+        }
+      } finally {
+        m.free();
+      }
     }
-    m.free();
+    return found;
+  } finally {
+    col.free();
+    if (api.clearPrePassCache) api.clearPrePassCache();
   }
-  col.free();
-  if (api.clearPrePassCache) api.clearPrePassCache();
-  return found;
 }
 
 describe('@ifc-lite/wasm surface textures on the viewer path (#961)', () => {
@@ -69,12 +77,15 @@ describe('@ifc-lite/wasm surface textures on the viewer path (#961)', () => {
       const { initSync, IfcAPI } = await import(wasmJsPath);
       initSync(readFileSync(wasmPath));
       const api = new IfcAPI();
-
-      const boiler = texturedBoiler(api, readFileSync(fixturePath, 'utf8'));
-      assert.ok(boiler, `boiler #${BOILER_TYPE_ID} should carry a texture`);
-      assert.ok(boiler.width > 0 && boiler.height > 0, 'texture has size');
-      assert.equal(boiler.rgbaLen, boiler.width * boiler.height * 4, 'RGBA8 buffer is w*h*4');
-      assert.equal(boiler.uvsLen, boiler.verts * 2, 'UVs are 1:1 with vertices (u,v per vertex)');
+      try {
+        const boiler = texturedBoiler(api, readFileSync(fixturePath, 'utf8'));
+        assert.ok(boiler, `boiler #${BOILER_TYPE_ID} should carry a texture`);
+        assert.ok(boiler.width > 0 && boiler.height > 0, 'texture has size');
+        assert.equal(boiler.rgbaLen, boiler.width * boiler.height * 4, 'RGBA8 buffer is w*h*4');
+        assert.equal(boiler.uvsLen, boiler.verts * 2, 'UVs are 1:1 with vertices (u,v per vertex)');
+      } finally {
+        api.free?.();
+      }
     });
   }
 });

--- a/packages/wasm/test/textures.test.mjs
+++ b/packages/wasm/test/textures.test.mjs
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Issue #961 — surface textures reach the LIVE VIEWER path. The browser renders
+ * through `buildPrePassOnce` + `processGeometryBatch`; this test drives that
+ * exact path and asserts the boiler mesh carries the Rust-decoded RGBA texture
+ * + per-vertex UVs (the renderer then uploads `textureRgba` to a GPU texture).
+ *
+ * IfcBlobTexture (PNG, decoded in Rust via the `png` crate) and IfcPixelTexture
+ * (raw pixel literals) both resolve to RGBA8 with UVs 1:1 with positions.
+ */
+
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'node:test';
+
+const packageDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const rootDir = join(packageDir, '..', '..');
+const wasmPath = join(packageDir, 'pkg', 'ifc-lite_bg.wasm');
+const wasmJsPath = join(packageDir, 'pkg', 'ifc-lite.js');
+const annexDir = join(rootDir, 'tests', 'models', 'buildingsmart', 'annex_e', 'tessellated-shape-with-style');
+
+const BOILER_TYPE_ID = 43;
+
+function texturedBoiler(api, content) {
+  const bytes = new TextEncoder().encode(content);
+  const pre = api.buildPrePassOnce(bytes);
+  const col = api.processGeometryBatch(
+    bytes, pre.jobs, pre.unitScale,
+    pre.rtcOffset[0], pre.rtcOffset[1], pre.rtcOffset[2], pre.needsShift,
+    pre.voidKeys, pre.voidCounts, pre.voidValues, pre.styleIds, pre.styleColors,
+  );
+  let found = null;
+  for (let i = 0; i < col.length; i++) {
+    const m = col.get(i);
+    if (m && m.expressId === BOILER_TYPE_ID && m.hasTexture) {
+      found = {
+        tris: m.triangleCount,
+        uvsLen: m.uvs.length,
+        verts: m.vertexCount,
+        width: m.textureWidth,
+        height: m.textureHeight,
+        rgbaLen: m.textureRgba.length,
+      };
+    }
+    m.free();
+  }
+  col.free();
+  if (api.clearPrePassCache) api.clearPrePassCache();
+  return found;
+}
+
+describe('@ifc-lite/wasm surface textures on the viewer path (#961)', () => {
+  for (const name of ['tessellation-with-blob-texture.ifc', 'tessellation-with-pixel-texture.ifc']) {
+    it(`decodes + attaches a texture for ${name}`, async (t) => {
+      if (!existsSync(wasmPath) || !existsSync(wasmJsPath)) {
+        t.skip('wasm bundle not built — run `bash scripts/build-wasm.sh`');
+        return;
+      }
+      const fixturePath = join(annexDir, name);
+      if (!existsSync(fixturePath)) {
+        t.skip('fixture missing — run `pnpm fixtures`');
+        return;
+      }
+      const { initSync, IfcAPI } = await import(wasmJsPath);
+      initSync(readFileSync(wasmPath));
+      const api = new IfcAPI();
+
+      const boiler = texturedBoiler(api, readFileSync(fixturePath, 'utf8'));
+      assert.ok(boiler, `boiler #${BOILER_TYPE_ID} should carry a texture`);
+      assert.ok(boiler.width > 0 && boiler.height > 0, 'texture has size');
+      assert.equal(boiler.rgbaLen, boiler.width * boiler.height * 4, 'RGBA8 buffer is w*h*4');
+      assert.equal(boiler.uvsLen, boiler.verts * 2, 'UVs are 1:1 with vertices (u,v per vertex)');
+    });
+  }
+});

--- a/packages/wasm/test/type-only-geometry.test.mjs
+++ b/packages/wasm/test/type-only-geometry.test.mjs
@@ -67,26 +67,32 @@ describe('@ifc-lite/wasm type-only IfcRepresentationMap geometry (#957)', () => 
 
       initSync(readFileSync(wasmPath));
       const api = new IfcAPI();
+      // `parseMeshesViaPrePass` frees its own wasm handles (each MeshDataJs +
+      // the MeshCollection) internally and calls clearPrePassCache, returning a
+      // plain JS facade — so only the IfcAPI handle needs freeing here.
+      try {
+        const content = readFileSync(fixturePath, 'utf8');
+        const result = parseMeshesViaPrePass(api, content);
 
-      const content = readFileSync(fixturePath, 'utf8');
-      const result = parseMeshesViaPrePass(api, content);
+        const boiler = [];
+        for (let i = 0; i < result.length; i++) {
+          const m = result.get(i);
+          if (m && m.expressId === BOILER_TYPE_ID) boiler.push(m);
+        }
 
-      const boiler = [];
-      for (let i = 0; i < result.length; i++) {
-        const m = result.get(i);
-        if (m && m.expressId === BOILER_TYPE_ID) boiler.push(m);
+        assert.ok(
+          boiler.length >= 1,
+          `expected the IfcBoilerType #${BOILER_TYPE_ID} type-only geometry to render; got 0 meshes`,
+        );
+        const totalTris = boiler.reduce((n, m) => n + m.triangleCount, 0);
+        assert.equal(totalTris, 64, `boiler should produce 64 triangles, got ${totalTris}`);
+        assert.ok(
+          boiler.every((m) => approxColor(m.color, WHITE)),
+          'type geometry should inherit the authored white IfcSurfaceStyle',
+        );
+      } finally {
+        api.free?.();
       }
-
-      assert.ok(
-        boiler.length >= 1,
-        `expected the IfcBoilerType #${BOILER_TYPE_ID} type-only geometry to render; got 0 meshes`,
-      );
-      const totalTris = boiler.reduce((n, m) => n + m.triangleCount, 0);
-      assert.equal(totalTris, 64, `boiler should produce 64 triangles, got ${totalTris}`);
-      assert.ok(
-        boiler.every((m) => approxColor(m.color, WHITE)),
-        'type geometry should inherit the authored white IfcSurfaceStyle',
-      );
     });
   }
 });

--- a/packages/wasm/test/type-only-geometry.test.mjs
+++ b/packages/wasm/test/type-only-geometry.test.mjs
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Issue #957 regression guard — the LIVE VIEWER path.
+ *
+ * The browser viewer renders through `buildPrePassOnce` + `processGeometryBatch`
+ * (the path `parseMeshesViaPrePass` drives). buildingSMART annex-E
+ * "tessellated shape with style" files attach their geometry to an
+ * `IfcBoilerType` via `RepresentationMaps` with no occurrence — the product-only
+ * job enumeration produced zero meshes, so the model rendered empty. The
+ * orphan-RepresentationMap pass must now make the boiler visible (flat white;
+ * texture fidelity is a separate follow-up).
+ *
+ * A rust `process_geometry` test cannot catch a regression on THIS path — the
+ * wasm prepass + processGeometryBatch enumerate jobs separately.
+ */
+
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'node:test';
+
+const packageDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const rootDir = join(packageDir, '..', '..');
+const wasmPath = join(packageDir, 'pkg', 'ifc-lite_bg.wasm');
+const wasmJsPath = join(packageDir, 'pkg', 'ifc-lite.js');
+const annexDir = join(
+  rootDir,
+  'tests',
+  'models',
+  'buildingsmart',
+  'annex_e',
+  'tessellated-shape-with-style',
+);
+
+const BOILER_TYPE_ID = 43;
+const WHITE = [1.0, 1.0, 1.0];
+
+function approxColor(c, target) {
+  return target.every((v, i) => Math.abs(c[i] - v) < 1e-3);
+}
+
+describe('@ifc-lite/wasm type-only IfcRepresentationMap geometry (#957)', () => {
+  for (const name of [
+    'tessellation-with-blob-texture.ifc',
+    'tessellation-with-image-texture.ifc',
+    'tessellation-with-pixel-texture.ifc',
+  ]) {
+    it(`renders type-only geometry for ${name} on the processGeometryBatch path`, async (t) => {
+      if (!existsSync(wasmPath) || !existsSync(wasmJsPath)) {
+        t.skip('wasm bundle not built — run `bash scripts/build-wasm.sh` first');
+        return;
+      }
+      const fixturePath = join(annexDir, name);
+      if (!existsSync(fixturePath)) {
+        t.skip('fixture missing — run `pnpm fixtures` first');
+        return;
+      }
+
+      const { initSync, IfcAPI } = await import(wasmJsPath);
+      const { parseMeshesViaPrePass } = await import(
+        join(rootDir, 'scripts', 'lib', 'mesh-via-prepass.mjs')
+      );
+
+      initSync(readFileSync(wasmPath));
+      const api = new IfcAPI();
+
+      const content = readFileSync(fixturePath, 'utf8');
+      const result = parseMeshesViaPrePass(api, content);
+
+      const boiler = [];
+      for (let i = 0; i < result.length; i++) {
+        const m = result.get(i);
+        if (m && m.expressId === BOILER_TYPE_ID) boiler.push(m);
+      }
+
+      assert.ok(
+        boiler.length >= 1,
+        `expected the IfcBoilerType #${BOILER_TYPE_ID} type-only geometry to render; got 0 meshes`,
+      );
+      const totalTris = boiler.reduce((n, m) => n + m.triangleCount, 0);
+      assert.equal(totalTris, 64, `boiler should produce 64 triangles, got ${totalTris}`);
+      assert.ok(
+        boiler.every((m) => approxColor(m.color, WHITE)),
+        'type geometry should inherit the authored white IfcSurfaceStyle',
+      );
+    });
+  }
+});

--- a/rust/geometry/Cargo.toml
+++ b/rust/geometry/Cargo.toml
@@ -55,6 +55,11 @@ rustc-hash = "2.1"
 # (miniz_oxide / fdeflate) — wasm-safe.
 png = "0.17"
 
+# JPEG decode for IfcBlobTexture with RasterFormat 'JPG'/'JPEG' (issue #961).
+# `default-features = false` drops the `rayon` parallelism (no threads on
+# wasm32) — pure-Rust, wasm-safe. ~adds a small decoder to the bundle.
+jpeg-decoder = { version = "0.3", default-features = false }
+
 # Small vector optimization for frequently allocated small collections
 smallvec = "1.13"
 

--- a/rust/geometry/Cargo.toml
+++ b/rust/geometry/Cargo.toml
@@ -50,6 +50,11 @@ rayon = "1.10"
 # Fast hashing
 rustc-hash = "2.1"
 
+# PNG decode for IfcBlobTexture (issue #961). Already in the dependency tree
+# (transitive), so it adds no new wasm weight. Pure-Rust inflate
+# (miniz_oxide / fdeflate) — wasm-safe.
+png = "0.17"
+
 # Small vector optimization for frequently allocated small collections
 smallvec = "1.13"
 

--- a/rust/geometry/src/lib.rs
+++ b/rust/geometry/src/lib.rs
@@ -110,8 +110,9 @@ pub use mesh::{CoordinateShift, Mesh, SubMesh, SubMeshCollection};
 pub use processors::{
     AdvancedBrepProcessor, BooleanClippingProcessor, ExtrudedAreaSolidProcessor,
     ExtrudedAreaSolidTaperedProcessor, FaceBasedSurfaceModelProcessor, FacetedBrepProcessor,
-    MappedItemProcessor, PolygonalFaceSetProcessor, RevolvedAreaSolidProcessor,
-    SurfaceOfLinearExtrusionProcessor, SweptDiskSolidProcessor, TriangulatedFaceSetProcessor,
+    build_texture_index, MappedItemProcessor, MeshTexture, PolygonalFaceSetProcessor,
+    ResolvedTextureMap, RevolvedAreaSolidProcessor, SurfaceOfLinearExtrusionProcessor,
+    SweptDiskSolidProcessor, TriangulatedFaceSetProcessor,
 };
 pub use alignment::{AlignmentCurve, AlignmentFrame};
 pub use profile::{Profile2D, Profile2DWithVoids, ProfileType, VoidInfo};

--- a/rust/geometry/src/processors/mod.rs
+++ b/rust/geometry/src/processors/mod.rs
@@ -32,6 +32,7 @@ mod sectioned;
 mod surface;
 mod swept;
 mod tessellated;
+pub mod texture;
 
 #[cfg(test)]
 mod tests;
@@ -51,6 +52,7 @@ pub use sectioned::SectionedSolidHorizontalProcessor;
 pub use surface::SurfaceOfLinearExtrusionProcessor;
 pub use swept::{RevolvedAreaSolidProcessor, SweptDiskSolidProcessor};
 pub use tessellated::{PolygonalFaceSetProcessor, TriangulatedFaceSetProcessor};
+pub use texture::{build_texture_index, MeshTexture, ResolvedTextureMap};
 
 /// Extract CoordIndex bytes from IfcTriangulatedFaceSet raw entity
 ///

--- a/rust/geometry/src/processors/tessellated.rs
+++ b/rust/geometry/src/processors/tessellated.rs
@@ -20,16 +20,17 @@ impl TriangulatedFaceSetProcessor {
     pub fn new() -> Self {
         Self
     }
-}
 
-impl GeometryProcessor for TriangulatedFaceSetProcessor {
-    #[inline]
-    fn process(
-        &self,
+    /// Parse an `IfcTriangulatedFaceSet`'s positions + triangle indices and
+    /// apply the closed-shell outward orientation. Returns
+    /// `(positions, indices, flipped)` where `flipped` is whether the whole
+    /// shell was winding-flipped — the texture path needs it to keep the
+    /// parallel `TexCoordIndex` in lockstep (#961). Shared by `process` and
+    /// [`Self::process_with_texture`] so there is one parse/orient code path.
+    fn parse_positions_and_orient(
         entity: &DecodedEntity,
         decoder: &mut EntityDecoder,
-        _schema: &IfcSchema,
-    ) -> Result<Mesh> {
+    ) -> Result<(Vec<f32>, Vec<u32>, bool)> {
         // IfcTriangulatedFaceSet attributes:
         // 0: Coordinates (IfcCartesianPointList3D)
         // 1: Normals (optional)
@@ -111,9 +112,54 @@ impl GeometryProcessor for TriangulatedFaceSetProcessor {
             .unwrap_or(false);
 
         let mut indices = indices;
-        if !is_open {
-            PolygonalFaceSetProcessor::orient_closed_shell_outward(&positions, &mut indices);
+        let flipped = if !is_open {
+            PolygonalFaceSetProcessor::orient_closed_shell_outward(&positions, &mut indices)
+        } else {
+            false
+        };
+
+        Ok((positions, indices, flipped))
+    }
+
+    /// Tessellate a textured `IfcTriangulatedFaceSet` (#961): builds the same
+    /// flat-shaded mesh as [`process`] plus a per-vertex UV array aligned 1:1
+    /// with the emitted vertices. `map.tex_coord_index` is parallel to the
+    /// original `CoordIndex`; the same whole-shell winding flip is applied to it
+    /// so corners stay aligned after orientation.
+    pub fn process_with_texture(
+        &self,
+        entity: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+        map: &crate::processors::texture::ResolvedTextureMap,
+    ) -> Result<(Mesh, Vec<f32>)> {
+        let (positions, indices, flipped) = Self::parse_positions_and_orient(entity, decoder)?;
+        let mut tex_coord_index = map.tex_coord_index.clone();
+        if flipped {
+            for tri in tex_coord_index.iter_mut() {
+                tri.swap(1, 2);
+            }
         }
+        let (mut mesh, uvs) = PolygonalFaceSetProcessor::build_flat_shaded_mesh_with_uvs(
+            &positions,
+            &indices,
+            &map.tex_coords,
+            &tex_coord_index,
+            map,
+        );
+        mesh.validate_indices();
+        Ok((mesh, uvs))
+    }
+}
+
+impl GeometryProcessor for TriangulatedFaceSetProcessor {
+    #[inline]
+    fn process(
+        &self,
+        entity: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+        _schema: &IfcSchema,
+    ) -> Result<Mesh> {
+        let (positions, indices, _flipped) = Self::parse_positions_and_orient(entity, decoder)?;
 
         // Flat-shade by duplicating vertices per-triangle. Without this, the
         // downstream per-vertex normal accumulator (`csg::calculate_normals`)
@@ -427,14 +473,18 @@ impl PolygonalFaceSetProcessor {
     }
 
     #[inline]
-    fn orient_closed_shell_outward(positions: &[f32], indices: &mut [u32]) {
+    /// Flip every triangle's winding to face outward when the shell is
+    /// inward-facing. Returns `true` if a (whole-shell) flip was applied — the
+    /// texture path needs this to swap the parallel `TexCoordIndex` in lockstep
+    /// (issue #961), or corners 1/2 of the UVs mirror on a flipped shell.
+    pub(crate) fn orient_closed_shell_outward(positions: &[f32], indices: &mut [u32]) -> bool {
         if indices.len() < 3 || positions.len() < 9 {
-            return;
+            return false;
         }
 
         let vertex_count = positions.len() / 3;
         if vertex_count == 0 {
-            return;
+            return false;
         }
 
         // Mesh centroid
@@ -498,7 +548,9 @@ impl PolygonalFaceSetProcessor {
             for tri in indices.chunks_exact_mut(3) {
                 tri.swap(1, 2);
             }
+            return true;
         }
+        false
     }
 
     #[inline]
@@ -564,6 +616,86 @@ impl PolygonalFaceSetProcessor {
             indices: flat_indices,
             rtc_applied: false,
         }
+    }
+
+    /// Like [`Self::build_flat_shaded_mesh`] but also emits a per-vertex UV
+    /// array aligned 1:1 with the duplicated vertices (issue #961).
+    ///
+    /// `tex_coord_index` is parallel to `indices` (and already winding-flipped
+    /// to match it); each triangle's three 1-based entries index `tex_coords`.
+    /// Triangles dropped by the out-of-range vertex guard are dropped from both
+    /// positions and UVs in lockstep, so the UV/vertex alignment is exact.
+    /// Out-of-range texcoord corners fall back to (0, 0).
+    pub(crate) fn build_flat_shaded_mesh_with_uvs(
+        positions: &[f32],
+        indices: &[u32],
+        tex_coords: &[[f32; 2]],
+        tex_coord_index: &[[u32; 3]],
+        map: &crate::processors::texture::ResolvedTextureMap,
+    ) -> (Mesh, Vec<f32>) {
+        let mut flat_positions: Vec<f32> = Vec::with_capacity(indices.len() * 3);
+        let mut flat_normals: Vec<f32> = Vec::with_capacity(indices.len() * 3);
+        let mut flat_indices: Vec<u32> = Vec::with_capacity(indices.len());
+        let mut uvs: Vec<f32> = Vec::with_capacity((indices.len() / 3) * 6);
+
+        let vertex_count = positions.len() / 3;
+        let mut next_index: u32 = 0;
+
+        for (tri_i, tri) in indices.chunks_exact(3).enumerate() {
+            let i0 = tri[0] as usize;
+            let i1 = tri[1] as usize;
+            let i2 = tri[2] as usize;
+            if i0 >= vertex_count || i1 >= vertex_count || i2 >= vertex_count {
+                continue;
+            }
+
+            // Face normal — identical computation to build_flat_shaded_mesh.
+            let p0 = (positions[i0 * 3] as f64, positions[i0 * 3 + 1] as f64, positions[i0 * 3 + 2] as f64);
+            let p1 = (positions[i1 * 3] as f64, positions[i1 * 3 + 1] as f64, positions[i1 * 3 + 2] as f64);
+            let p2 = (positions[i2 * 3] as f64, positions[i2 * 3 + 1] as f64, positions[i2 * 3 + 2] as f64);
+            let e1 = (p1.0 - p0.0, p1.1 - p0.1, p1.2 - p0.2);
+            let e2 = (p2.0 - p0.0, p2.1 - p0.1, p2.2 - p0.2);
+            let nx = e1.1 * e2.2 - e1.2 * e2.1;
+            let ny = e1.2 * e2.0 - e1.0 * e2.2;
+            let nz = e1.0 * e2.1 - e1.1 * e2.0;
+            let len = (nx * nx + ny * ny + nz * nz).sqrt();
+            let (nx, ny, nz) = if len > 1e-12 {
+                (nx / len, ny / len, nz / len)
+            } else {
+                (0.0, 0.0, 1.0)
+            };
+
+            let tri_uv = tex_coord_index.get(tri_i);
+            for (corner, &idx) in [i0, i1, i2].iter().enumerate() {
+                flat_positions.push(positions[idx * 3]);
+                flat_positions.push(positions[idx * 3 + 1]);
+                flat_positions.push(positions[idx * 3 + 2]);
+                flat_normals.push(nx as f32);
+                flat_normals.push(ny as f32);
+                flat_normals.push(nz as f32);
+                let uv = tri_uv
+                    .and_then(|t| {
+                        let one_based = t[corner] as usize;
+                        tex_coords.get(one_based.checked_sub(1)?).copied()
+                    })
+                    .map(|raw| map.transform_uv(raw))
+                    .unwrap_or([0.0, 0.0]);
+                uvs.push(uv[0]);
+                uvs.push(uv[1]);
+                flat_indices.push(next_index);
+                next_index += 1;
+            }
+        }
+
+        (
+            Mesh {
+                positions: flat_positions,
+                normals: flat_normals,
+                indices: flat_indices,
+                rtc_applied: false,
+            },
+            uvs,
+        )
     }
 }
 

--- a/rust/geometry/src/processors/tessellated.rs
+++ b/rust/geometry/src/processors/tessellated.rs
@@ -144,7 +144,6 @@ impl TriangulatedFaceSetProcessor {
             &indices,
             &map.tex_coords,
             &tex_coord_index,
-            map,
         );
         mesh.validate_indices();
         Ok((mesh, uvs))
@@ -631,7 +630,6 @@ impl PolygonalFaceSetProcessor {
         indices: &[u32],
         tex_coords: &[[f32; 2]],
         tex_coord_index: &[[u32; 3]],
-        map: &crate::processors::texture::ResolvedTextureMap,
     ) -> (Mesh, Vec<f32>) {
         let mut flat_positions: Vec<f32> = Vec::with_capacity(indices.len() * 3);
         let mut flat_normals: Vec<f32> = Vec::with_capacity(indices.len() * 3);
@@ -673,12 +671,16 @@ impl PolygonalFaceSetProcessor {
                 flat_normals.push(nx as f32);
                 flat_normals.push(ny as f32);
                 flat_normals.push(nz as f32);
+                // Use the authored texture coordinates directly. The optional
+                // IfcSurfaceTexture.TextureTransform is intentionally NOT applied:
+                // its Scale over-tiles the texture (the buildingSMART annex-E
+                // reference renders these coords ~1:1), and the TexCoords already
+                // carry any intended offset.
                 let uv = tri_uv
                     .and_then(|t| {
                         let one_based = t[corner] as usize;
                         tex_coords.get(one_based.checked_sub(1)?).copied()
                     })
-                    .map(|raw| map.transform_uv(raw))
                     .unwrap_or([0.0, 0.0]);
                 uvs.push(uv[0]);
                 uvs.push(uv[1]);

--- a/rust/geometry/src/processors/tessellated.rs
+++ b/rust/geometry/src/processors/tessellated.rs
@@ -682,8 +682,14 @@ impl PolygonalFaceSetProcessor {
                         tex_coords.get(one_based.checked_sub(1)?).copied()
                     })
                     .unwrap_or([0.0, 0.0]);
+                // Flip V: IFC texture coordinates use a bottom-left origin (v up,
+                // OpenGL/STEP convention), but GPU sampling + glTF export use a
+                // top-left origin. Converting here (Rust = single source) keeps the
+                // image upright for every consumer (viewer, server, CLI, export)
+                // instead of each one re-flipping. Verified against the
+                // buildingSMART annex-E reference render.
                 uvs.push(uv[0]);
-                uvs.push(uv[1]);
+                uvs.push(1.0 - uv[1]);
                 flat_indices.push(next_index);
                 next_index += 1;
             }

--- a/rust/geometry/src/processors/texture.rs
+++ b/rust/geometry/src/processors/texture.rs
@@ -1,0 +1,348 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! IFC surface-texture resolution (issue #961).
+//!
+//! Decodes `IfcBlobTexture` (embedded PNG) and `IfcPixelTexture` (raw pixels)
+//! to RGBA8, and resolves `IfcIndexedTriangleTextureMap` per-triangle texture
+//! coordinates aligned with the tessellated face set. All texture logic lives
+//! in Rust so the server, CLI, SDK and the browser (wasm) path share one
+//! implementation — no Rust/TS drift. The browser layer only uploads the
+//! decoded RGBA to a GPU texture; it performs no IFC or image decoding.
+//!
+//! `IfcImageTexture` (external URL) is intentionally out of scope here — it
+//! needs an async fetch resolver outside the geometry pipeline; tracked as a
+//! follow-up.
+
+use ifc_lite_core::{DecodedEntity, EntityDecoder, EntityScanner, IfcType};
+use rustc_hash::FxHashMap;
+
+/// A decoded RGBA8 image ready for GPU upload.
+#[derive(Debug, Clone)]
+pub struct MeshTexture {
+    /// `width * height * 4` bytes, row-major, top-down, straight alpha.
+    pub rgba: Vec<u8>,
+    pub width: u32,
+    pub height: u32,
+    /// `IfcSurfaceTexture.RepeatS/RepeatT` → sampler wrap (repeat vs clamp).
+    pub repeat_s: bool,
+    pub repeat_t: bool,
+}
+
+/// A fully resolved `IfcIndexedTriangleTextureMap` for one face set.
+#[derive(Debug, Clone)]
+pub struct ResolvedTextureMap {
+    pub texture: MeshTexture,
+    /// `IfcTextureVertexList.TexCoordsList` as `[u, v]` (0-based storage).
+    pub tex_coords: Vec<[f32; 2]>,
+    /// `TexCoordIndex`: per-triangle 1-based indices into `tex_coords`,
+    /// parallel to the face set's `CoordIndex`.
+    pub tex_coord_index: Vec<[u32; 3]>,
+    /// `IfcCartesianTransformationOperator2D` applied to each UV:
+    /// `uv' = origin + scale * (axis ⊗ uv)` where `axis` is the X ref-direction.
+    pub uv_scale: f32,
+    pub uv_origin: [f32; 2],
+    pub uv_axis: [f32; 2],
+}
+
+impl ResolvedTextureMap {
+    /// Apply the 2D transform to a raw `[u, v]`.
+    #[inline]
+    pub fn transform_uv(&self, uv: [f32; 2]) -> [f32; 2] {
+        // axis = (cos, sin) → rotate, then scale, then translate.
+        let (ax, ay) = (self.uv_axis[0], self.uv_axis[1]);
+        let rx = ax * uv[0] - ay * uv[1];
+        let ry = ay * uv[0] + ax * uv[1];
+        [
+            self.uv_origin[0] + self.uv_scale * rx,
+            self.uv_origin[1] + self.uv_scale * ry,
+        ]
+    }
+}
+
+/// Decode a STEP binary literal as surfaced by the decoder (the parser strips
+/// the surrounding double quotes; the first hex character is the count of
+/// unused leading bits — `0` for the byte-aligned data every IFC texture
+/// fixture uses). Strips that leading character and hex-decodes the remainder
+/// pairwise. Returns the raw bytes (e.g. a complete PNG file for a blob, or one
+/// pixel's colour components for a pixel literal).
+pub fn decode_step_binary(s: &str) -> Vec<u8> {
+    let s = s.trim().trim_matches('"');
+    if s.len() < 3 {
+        return Vec::new();
+    }
+    let hex = s.as_bytes();
+    let mut out = Vec::with_capacity(hex.len() / 2);
+    // Skip index 0 (the unused-bits indicator); decode the rest in pairs.
+    let mut i = 1;
+    while i + 1 < hex.len() {
+        match (hex_val(hex[i]), hex_val(hex[i + 1])) {
+            (Some(h), Some(l)) => out.push((h << 4) | l),
+            _ => break,
+        }
+        i += 2;
+    }
+    out
+}
+
+#[inline]
+fn hex_val(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// Decode a PNG byte buffer to RGBA8. Returns `(rgba, width, height)`.
+fn decode_png(bytes: &[u8]) -> Option<(Vec<u8>, u32, u32)> {
+    let mut decoder = png::Decoder::new(bytes);
+    // EXPAND: palette → RGB, sub-8-bit grayscale → 8-bit, tRNS → alpha.
+    // STRIP_16: 16-bit channels → 8-bit. Leaves Rgb/Rgba/Grayscale/GA at 8-bit.
+    decoder.set_transformations(png::Transformations::EXPAND | png::Transformations::STRIP_16);
+    let mut reader = decoder.read_info().ok()?;
+    let mut buf = vec![0u8; reader.output_buffer_size()];
+    let info = reader.next_frame(&mut buf).ok()?;
+    let (w, h) = (info.width, info.height);
+    let px = (w as usize) * (h as usize);
+    let src = &buf[..info.buffer_size()];
+    let mut rgba = Vec::with_capacity(px * 4);
+    match info.color_type {
+        png::ColorType::Rgba => rgba.extend_from_slice(&src[..px * 4]),
+        png::ColorType::Rgb => {
+            for c in src.chunks_exact(3) {
+                rgba.extend_from_slice(&[c[0], c[1], c[2], 255]);
+            }
+        }
+        png::ColorType::Grayscale => {
+            for &g in src.iter() {
+                rgba.extend_from_slice(&[g, g, g, 255]);
+            }
+        }
+        png::ColorType::GrayscaleAlpha => {
+            for c in src.chunks_exact(2) {
+                rgba.extend_from_slice(&[c[0], c[0], c[0], c[1]]);
+            }
+        }
+        // EXPAND should have removed Indexed; bail if a decoder ever leaves it.
+        png::ColorType::Indexed => return None,
+    }
+    if rgba.len() != px * 4 {
+        return None;
+    }
+    Some((rgba, w, h))
+}
+
+/// Decode `IfcBlobTexture` → RGBA8. Attributes (IFC4):
+/// RepeatS(0), RepeatT(1), Mode(2), TextureTransform(3), Parameter(4),
+/// RasterFormat(5), RasterCode(6).
+fn decode_blob_texture(entity: &DecodedEntity) -> Option<MeshTexture> {
+    let raster_code = entity.get(6).and_then(|a| a.as_string())?;
+    let bytes = decode_step_binary(raster_code);
+    if bytes.len() < 8 {
+        return None;
+    }
+    // Only PNG is handled here (RasterFormat == 'PNG'); the magic check guards
+    // against other RasterFormats slipping through.
+    const PNG_MAGIC: [u8; 8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+    if bytes[..8] != PNG_MAGIC {
+        return None;
+    }
+    let (rgba, width, height) = decode_png(&bytes)?;
+    Some(MeshTexture {
+        rgba,
+        width,
+        height,
+        repeat_s: read_bool(entity, 0).unwrap_or(true),
+        repeat_t: read_bool(entity, 1).unwrap_or(true),
+    })
+}
+
+/// Decode `IfcPixelTexture` → RGBA8. Attributes (IFC4):
+/// RepeatS(0), RepeatT(1), Mode(2), TextureTransform(3), Parameter(4),
+/// Width(5), Height(6), ColourComponents(7), Pixel(8 = list of BINARY).
+fn decode_pixel_texture(entity: &DecodedEntity) -> Option<MeshTexture> {
+    let width = entity.get(5).and_then(|a| a.as_int())? as u32;
+    let height = entity.get(6).and_then(|a| a.as_int())? as u32;
+    let components = entity.get(7).and_then(|a| a.as_int())? as usize;
+    if width == 0 || height == 0 || !(1..=4).contains(&components) {
+        return None;
+    }
+    let pixels = entity.get(8).and_then(|a| a.as_list())?;
+    let expected = (width as usize) * (height as usize);
+    let mut rgba = Vec::with_capacity(expected * 4);
+    for px in pixels.iter() {
+        let s = px.as_string()?;
+        let comp = decode_step_binary(s);
+        if comp.len() < components {
+            return None;
+        }
+        // Expand 1..=4 colour components to RGBA8.
+        let (r, g, b, a) = match components {
+            1 => (comp[0], comp[0], comp[0], 255),
+            2 => (comp[0], comp[0], comp[0], comp[1]),
+            3 => (comp[0], comp[1], comp[2], 255),
+            _ => (comp[0], comp[1], comp[2], comp[3]),
+        };
+        rgba.extend_from_slice(&[r, g, b, a]);
+    }
+    if rgba.len() != expected * 4 {
+        return None;
+    }
+    Some(MeshTexture {
+        rgba,
+        width,
+        height,
+        repeat_s: read_bool(entity, 0).unwrap_or(true),
+        repeat_t: read_bool(entity, 1).unwrap_or(true),
+    })
+}
+
+fn read_bool(entity: &DecodedEntity, idx: usize) -> Option<bool> {
+    entity.get(idx).and_then(|a| a.as_enum()).map(|v| v == "T")
+}
+
+/// Resolve an `IfcSurfaceTexture` subtype reference to a decoded image.
+fn resolve_surface_texture(texture_id: u32, decoder: &mut EntityDecoder) -> Option<MeshTexture> {
+    let entity = decoder.decode_by_id(texture_id).ok()?;
+    match entity.ifc_type {
+        IfcType::IfcBlobTexture => decode_blob_texture(&entity),
+        IfcType::IfcPixelTexture => decode_pixel_texture(&entity),
+        // IfcImageTexture (URL) deferred — needs async fetch outside the kernel.
+        _ => None,
+    }
+}
+
+/// Parse the optional `IfcCartesianTransformationOperator2D` texture transform.
+/// Attributes: Axis1(0), Axis2(1), LocalOrigin(2), Scale(3 default 1).
+fn parse_texture_transform(transform_id: u32, decoder: &mut EntityDecoder) -> ([f32; 2], [f32; 2], f32) {
+    let mut origin = [0.0f32, 0.0];
+    let mut axis = [1.0f32, 0.0];
+    let mut scale = 1.0f32;
+    if let Ok(op) = decoder.decode_by_id(transform_id) {
+        if op.ifc_type == IfcType::IfcCartesianTransformationOperator2D {
+            if let Some(scale_v) = op.get(3).and_then(|a| a.as_float()) {
+                scale = scale_v as f32;
+            }
+            if let Some(origin_id) = op.get_ref(2) {
+                if let Some(p) = read_point2(origin_id, decoder) {
+                    origin = p;
+                }
+            }
+            if let Some(axis_id) = op.get_ref(0) {
+                if let Some(d) = read_point2(axis_id, decoder) {
+                    let len = (d[0] * d[0] + d[1] * d[1]).sqrt();
+                    if len > 1e-9 {
+                        axis = [d[0] / len, d[1] / len];
+                    }
+                }
+            }
+        }
+    }
+    (origin, axis, scale)
+}
+
+/// Read a 2D `IfcCartesianPoint` / `IfcDirection` (first two coordinates).
+fn read_point2(id: u32, decoder: &mut EntityDecoder) -> Option<[f32; 2]> {
+    let p = decoder.decode_by_id(id).ok()?;
+    let coords = p.get(0)?.as_list()?;
+    let x = coords.first().and_then(|v| v.as_float())? as f32;
+    let y = coords.get(1).and_then(|v| v.as_float())? as f32;
+    Some([x, y])
+}
+
+/// Resolve a single `IfcIndexedTriangleTextureMap` entity into a
+/// [`ResolvedTextureMap`] keyed by the face set it maps to.
+/// Attributes: Maps(0 = list of IfcSurfaceTexture), MappedTo(1 = face set),
+/// TexCoords(2 = IfcTextureVertexList), TexCoordIndex(3 = list of 3 ints).
+fn resolve_triangle_texture_map(
+    entity: &DecodedEntity,
+    decoder: &mut EntityDecoder,
+) -> Option<(u32, ResolvedTextureMap)> {
+    let face_set_id = entity.get_ref(1)?;
+
+    // Maps[0] → surface texture.
+    let maps = entity.get(0)?.as_list()?;
+    let texture_id = maps.iter().find_map(|m| m.as_entity_ref())?;
+    let texture = resolve_surface_texture(texture_id, decoder)?;
+
+    // Pull the optional 2D transform off the surface texture (attr 3).
+    let (uv_origin, uv_axis, uv_scale) = decoder
+        .decode_by_id(texture_id)
+        .ok()
+        .and_then(|t| t.get_ref(3))
+        .map(|tid| parse_texture_transform(tid, decoder))
+        .unwrap_or(([0.0, 0.0], [1.0, 0.0], 1.0));
+
+    // TexCoords → IfcTextureVertexList.TexCoordsList (attr 0).
+    let tvl_id = entity.get_ref(2)?;
+    let tvl = decoder.decode_by_id(tvl_id).ok()?;
+    let coord_list = tvl.get(0)?.as_list()?;
+    let tex_coords: Vec<[f32; 2]> = coord_list
+        .iter()
+        .filter_map(|c| {
+            let uv = c.as_list()?;
+            let u = uv.first().and_then(|v| v.as_float())? as f32;
+            let v = uv.get(1).and_then(|v| v.as_float())? as f32;
+            Some([u, v])
+        })
+        .collect();
+    if tex_coords.is_empty() {
+        return None;
+    }
+
+    // TexCoordIndex (attr 3) → per-triangle [i, j, k].
+    let index_attr = entity.get(3)?.as_list()?;
+    let tex_coord_index: Vec<[u32; 3]> = index_attr
+        .iter()
+        .filter_map(|tri| {
+            let t = tri.as_list()?;
+            let a = t.first().and_then(|v| v.as_int())? as u32;
+            let b = t.get(1).and_then(|v| v.as_int())? as u32;
+            let c = t.get(2).and_then(|v| v.as_int())? as u32;
+            Some([a, b, c])
+        })
+        .collect();
+    if tex_coord_index.is_empty() {
+        return None;
+    }
+
+    Some((
+        face_set_id,
+        ResolvedTextureMap {
+            texture,
+            tex_coords,
+            tex_coord_index,
+            uv_scale,
+            uv_origin,
+            uv_axis,
+        },
+    ))
+}
+
+/// Scan the model for `IfcIndexedTriangleTextureMap` entities and build an index
+/// keyed by the face set id each one maps to (issue #961). Cheap substring
+/// bail-out keeps untextured files (the overwhelming majority) off the scan.
+pub fn build_texture_index(
+    content: &str,
+    decoder: &mut EntityDecoder,
+) -> FxHashMap<u32, ResolvedTextureMap> {
+    let mut index = FxHashMap::default();
+    if !content.contains("IFCINDEXEDTRIANGLETEXTUREMAP") {
+        return index;
+    }
+    let mut scanner = EntityScanner::new(content);
+    while let Some((id, type_name, start, end)) = scanner.next_entity() {
+        if type_name != "IFCINDEXEDTRIANGLETEXTUREMAP" {
+            continue;
+        }
+        if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
+            if let Some((face_set_id, resolved)) = resolve_triangle_texture_map(&entity, decoder) {
+                index.entry(face_set_id).or_insert(resolved);
+            }
+        }
+    }
+    index
+}

--- a/rust/geometry/src/processors/texture.rs
+++ b/rust/geometry/src/processors/texture.rs
@@ -39,30 +39,14 @@ pub struct ResolvedTextureMap {
     /// `TexCoordIndex`: per-triangle 1-based indices into `tex_coords`,
     /// parallel to the face set's `CoordIndex`.
     pub tex_coord_index: Vec<[u32; 3]>,
-    /// `IfcCartesianTransformationOperator2D[nonUniform]` applied to each UV:
-    /// `uv' = origin + (scaleX, scaleY) * (axis ⊗ uv)`, `axis` = X ref-direction.
-    /// `uv_scale_y` equals `uv_scale` for the uniform operator and uses `Scale2`
-    /// for the non-uniform subtype.
-    pub uv_scale: f32,
-    pub uv_scale_y: f32,
-    pub uv_origin: [f32; 2],
-    pub uv_axis: [f32; 2],
 }
 
-impl ResolvedTextureMap {
-    /// Apply the 2D transform to a raw `[u, v]`.
-    #[inline]
-    pub fn transform_uv(&self, uv: [f32; 2]) -> [f32; 2] {
-        // axis = (cos, sin) → rotate, then (possibly non-uniform) scale, then translate.
-        let (ax, ay) = (self.uv_axis[0], self.uv_axis[1]);
-        let rx = ax * uv[0] - ay * uv[1];
-        let ry = ay * uv[0] + ax * uv[1];
-        [
-            self.uv_origin[0] + self.uv_scale * rx,
-            self.uv_origin[1] + self.uv_scale_y * ry,
-        ]
-    }
-}
+// NOTE: `IfcSurfaceTexture.TextureTransform` (IfcCartesianTransformationOperator2D)
+// is intentionally NOT applied. The authored `IfcTextureVertexList` coordinates
+// already map the image as intended (the buildingSMART annex-E reference renders
+// them ~1:1); applying the operator's Scale (e.g. 48 in the blob fixture)
+// over-tiles the texture into noise. If a future file genuinely needs a UV
+// rotation/offset we can revisit, but no test fixture requires it.
 
 /// Decode a STEP binary literal as surfaced by the decoder (the parser strips
 /// the surrounding double quotes; the first hex character is the count of
@@ -256,60 +240,6 @@ fn resolve_surface_texture(texture_id: u32, decoder: &mut EntityDecoder) -> Opti
     }
 }
 
-/// Parse the optional `IfcCartesianTransformationOperator2D` (or its
-/// `…2DnonUniform` subtype) texture transform. Returns
-/// `(origin, axis, scale_x, scale_y)`. Attributes: Axis1(0), Axis2(1),
-/// LocalOrigin(2), Scale(3 default 1); the non-uniform subtype adds Scale2(4)
-/// for the Y axis (defaults to Scale when absent).
-fn parse_texture_transform(
-    transform_id: u32,
-    decoder: &mut EntityDecoder,
-) -> ([f32; 2], [f32; 2], f32, f32) {
-    let mut origin = [0.0f32, 0.0];
-    let mut axis = [1.0f32, 0.0];
-    let mut scale = 1.0f32;
-    let mut scale_y = 1.0f32;
-    if let Ok(op) = decoder.decode_by_id(transform_id) {
-        let is_2d = op.ifc_type == IfcType::IfcCartesianTransformationOperator2D;
-        let is_2d_nonuniform =
-            op.ifc_type == IfcType::IfcCartesianTransformationOperator2DnonUniform;
-        if is_2d || is_2d_nonuniform {
-            if let Some(scale_v) = op.get(3).and_then(|a| a.as_float()) {
-                scale = scale_v as f32;
-            }
-            // Non-uniform: Scale2 (attr 4) drives the Y axis; default to Scale.
-            scale_y = if is_2d_nonuniform {
-                op.get(4).and_then(|a| a.as_float()).map(|v| v as f32).unwrap_or(scale)
-            } else {
-                scale
-            };
-            if let Some(origin_id) = op.get_ref(2) {
-                if let Some(p) = read_point2(origin_id, decoder) {
-                    origin = p;
-                }
-            }
-            if let Some(axis_id) = op.get_ref(0) {
-                if let Some(d) = read_point2(axis_id, decoder) {
-                    let len = (d[0] * d[0] + d[1] * d[1]).sqrt();
-                    if len > 1e-9 {
-                        axis = [d[0] / len, d[1] / len];
-                    }
-                }
-            }
-        }
-    }
-    (origin, axis, scale, scale_y)
-}
-
-/// Read a 2D `IfcCartesianPoint` / `IfcDirection` (first two coordinates).
-fn read_point2(id: u32, decoder: &mut EntityDecoder) -> Option<[f32; 2]> {
-    let p = decoder.decode_by_id(id).ok()?;
-    let coords = p.get(0)?.as_list()?;
-    let x = coords.first().and_then(|v| v.as_float())? as f32;
-    let y = coords.get(1).and_then(|v| v.as_float())? as f32;
-    Some([x, y])
-}
-
 /// Resolve a single `IfcIndexedTriangleTextureMap` entity into a
 /// [`ResolvedTextureMap`] keyed by the face set it maps to.
 /// Attributes: Maps(0 = list of IfcSurfaceTexture), MappedTo(1 = face set),
@@ -324,14 +254,6 @@ fn resolve_triangle_texture_map(
     let maps = entity.get(0)?.as_list()?;
     let texture_id = maps.iter().find_map(|m| m.as_entity_ref())?;
     let texture = resolve_surface_texture(texture_id, decoder)?;
-
-    // Pull the optional 2D transform off the surface texture (attr 3).
-    let (uv_origin, uv_axis, uv_scale, uv_scale_y) = decoder
-        .decode_by_id(texture_id)
-        .ok()
-        .and_then(|t| t.get_ref(3))
-        .map(|tid| parse_texture_transform(tid, decoder))
-        .unwrap_or(([0.0, 0.0], [1.0, 0.0], 1.0, 1.0));
 
     // TexCoords → IfcTextureVertexList.TexCoordsList (attr 0).
     let tvl_id = entity.get_ref(2)?;
@@ -372,10 +294,6 @@ fn resolve_triangle_texture_map(
             texture,
             tex_coords,
             tex_coord_index,
-            uv_scale,
-            uv_scale_y,
-            uv_origin,
-            uv_axis,
         },
     ))
 }

--- a/rust/geometry/src/processors/texture.rs
+++ b/rust/geometry/src/processors/texture.rs
@@ -189,12 +189,20 @@ fn decode_blob_texture(entity: &DecodedEntity) -> Option<MeshTexture> {
 /// RepeatS(0), RepeatT(1), Mode(2), TextureTransform(3), Parameter(4),
 /// Width(5), Height(6), ColourComponents(7), Pixel(8 = list of BINARY).
 fn decode_pixel_texture(entity: &DecodedEntity) -> Option<MeshTexture> {
-    let width = entity.get(5).and_then(|a| a.as_int())? as u32;
-    let height = entity.get(6).and_then(|a| a.as_int())? as u32;
-    let components = entity.get(7).and_then(|a| a.as_int())? as usize;
-    if width == 0 || height == 0 || !(1..=4).contains(&components) {
+    // Validate the signed values BEFORE casting — a malformed `-1` would become
+    // u32::MAX and try to reserve absurd memory. Bound the dimensions
+    // (16384² RGBA ≈ 1 GiB) so a hostile/garbage file is rejected cleanly.
+    let width = entity.get(5).and_then(|a| a.as_int())?;
+    let height = entity.get(6).and_then(|a| a.as_int())?;
+    let components = entity.get(7).and_then(|a| a.as_int())?;
+    const MAX_DIM: i64 = 16384;
+    if width <= 0 || height <= 0 || width > MAX_DIM || height > MAX_DIM || !(1..=4).contains(&components)
+    {
         return None;
     }
+    let width = width as u32;
+    let height = height as u32;
+    let components = components as usize;
     let pixels = entity.get(8).and_then(|a| a.as_list())?;
     let expected = (width as usize) * (height as usize);
     let mut rgba = Vec::with_capacity(expected * 4);

--- a/rust/geometry/src/processors/texture.rs
+++ b/rust/geometry/src/processors/texture.rs
@@ -83,6 +83,12 @@ fn hex_val(b: u8) -> Option<u8> {
     }
 }
 
+/// Upper bound on a decoded texture's width/height. 16384² RGBA ≈ 1 GiB — a
+/// hostile/garbage image header claiming larger dimensions is rejected BEFORE
+/// any pixel buffer is allocated, so a crafted file can't drive an OOM. Matches
+/// the `IfcPixelTexture` bound.
+const MAX_TEX_DIM: u32 = 16384;
+
 /// Decode a PNG byte buffer to RGBA8. Returns `(rgba, width, height)`.
 fn decode_png(bytes: &[u8]) -> Option<(Vec<u8>, u32, u32)> {
     let mut decoder = png::Decoder::new(bytes);
@@ -90,6 +96,15 @@ fn decode_png(bytes: &[u8]) -> Option<(Vec<u8>, u32, u32)> {
     // STRIP_16: 16-bit channels → 8-bit. Leaves Rgb/Rgba/Grayscale/GA at 8-bit.
     decoder.set_transformations(png::Transformations::EXPAND | png::Transformations::STRIP_16);
     let mut reader = decoder.read_info().ok()?;
+    // Reject an oversized header before `output_buffer_size()` allocates.
+    let png_info = reader.info();
+    if png_info.width == 0
+        || png_info.height == 0
+        || png_info.width > MAX_TEX_DIM
+        || png_info.height > MAX_TEX_DIM
+    {
+        return None;
+    }
     let mut buf = vec![0u8; reader.output_buffer_size()];
     let info = reader.next_frame(&mut buf).ok()?;
     let (w, h) = (info.width, info.height);
@@ -125,8 +140,18 @@ fn decode_png(bytes: &[u8]) -> Option<(Vec<u8>, u32, u32)> {
 /// Decode a JPEG byte buffer to RGBA8. Returns `(rgba, width, height)`.
 fn decode_jpeg(bytes: &[u8]) -> Option<(Vec<u8>, u32, u32)> {
     let mut decoder = jpeg_decoder::Decoder::new(bytes);
-    let pixels = decoder.decode().ok()?;
+    // Read just the headers first so an oversized image is rejected before the
+    // full `decode()` allocates its pixel buffer.
+    decoder.read_info().ok()?;
     let info = decoder.info()?;
+    if info.width == 0
+        || info.height == 0
+        || info.width as u32 > MAX_TEX_DIM
+        || info.height as u32 > MAX_TEX_DIM
+    {
+        return None;
+    }
+    let pixels = decoder.decode().ok()?;
     let (w, h) = (info.width as usize, info.height as usize);
     let px = w * h;
     let mut rgba = Vec::with_capacity(px * 4);
@@ -195,8 +220,12 @@ fn decode_pixel_texture(entity: &DecodedEntity) -> Option<MeshTexture> {
     let width = entity.get(5).and_then(|a| a.as_int())?;
     let height = entity.get(6).and_then(|a| a.as_int())?;
     let components = entity.get(7).and_then(|a| a.as_int())?;
-    const MAX_DIM: i64 = 16384;
-    if width <= 0 || height <= 0 || width > MAX_DIM || height > MAX_DIM || !(1..=4).contains(&components)
+    let max_dim = MAX_TEX_DIM as i64;
+    if width <= 0
+        || height <= 0
+        || width > max_dim
+        || height > max_dim
+        || !(1..=4).contains(&components)
     {
         return None;
     }
@@ -263,35 +292,40 @@ fn resolve_triangle_texture_map(
     let texture_id = maps.iter().find_map(|m| m.as_entity_ref())?;
     let texture = resolve_surface_texture(texture_id, decoder)?;
 
-    // TexCoords → IfcTextureVertexList.TexCoordsList (attr 0).
+    // TexCoords → IfcTextureVertexList.TexCoordsList (attr 0). Use `map` +
+    // `collect::<Option<_>>` (NOT filter_map): a malformed entry must reject the
+    // whole map, not silently drop a row. Dropping one shifts every later row
+    // left, and `tex_coord_index[n]` must stay parallel to triangle `n` in
+    // build_flat_shaded_mesh_with_uvs — a compressed list scrambles all UVs.
     let tvl_id = entity.get_ref(2)?;
     let tvl = decoder.decode_by_id(tvl_id).ok()?;
     let coord_list = tvl.get(0)?.as_list()?;
     let tex_coords: Vec<[f32; 2]> = coord_list
         .iter()
-        .filter_map(|c| {
+        .map(|c| {
             let uv = c.as_list()?;
             let u = uv.first().and_then(|v| v.as_float())? as f32;
             let v = uv.get(1).and_then(|v| v.as_float())? as f32;
             Some([u, v])
         })
-        .collect();
+        .collect::<Option<Vec<_>>>()?;
     if tex_coords.is_empty() {
         return None;
     }
 
-    // TexCoordIndex (attr 3) → per-triangle [i, j, k].
+    // TexCoordIndex (attr 3) → per-triangle [i, j, k]. Same all-or-nothing rule
+    // so the index stays 1:1 with the triangle list.
     let index_attr = entity.get(3)?.as_list()?;
     let tex_coord_index: Vec<[u32; 3]> = index_attr
         .iter()
-        .filter_map(|tri| {
+        .map(|tri| {
             let t = tri.as_list()?;
             let a = t.first().and_then(|v| v.as_int())? as u32;
             let b = t.get(1).and_then(|v| v.as_int())? as u32;
             let c = t.get(2).and_then(|v| v.as_int())? as u32;
             Some([a, b, c])
         })
-        .collect();
+        .collect::<Option<Vec<_>>>()?;
     if tex_coord_index.is_empty() {
         return None;
     }

--- a/rust/geometry/src/processors/texture.rs
+++ b/rust/geometry/src/processors/texture.rs
@@ -39,9 +39,12 @@ pub struct ResolvedTextureMap {
     /// `TexCoordIndex`: per-triangle 1-based indices into `tex_coords`,
     /// parallel to the face set's `CoordIndex`.
     pub tex_coord_index: Vec<[u32; 3]>,
-    /// `IfcCartesianTransformationOperator2D` applied to each UV:
-    /// `uv' = origin + scale * (axis ⊗ uv)` where `axis` is the X ref-direction.
+    /// `IfcCartesianTransformationOperator2D[nonUniform]` applied to each UV:
+    /// `uv' = origin + (scaleX, scaleY) * (axis ⊗ uv)`, `axis` = X ref-direction.
+    /// `uv_scale_y` equals `uv_scale` for the uniform operator and uses `Scale2`
+    /// for the non-uniform subtype.
     pub uv_scale: f32,
+    pub uv_scale_y: f32,
     pub uv_origin: [f32; 2],
     pub uv_axis: [f32; 2],
 }
@@ -50,13 +53,13 @@ impl ResolvedTextureMap {
     /// Apply the 2D transform to a raw `[u, v]`.
     #[inline]
     pub fn transform_uv(&self, uv: [f32; 2]) -> [f32; 2] {
-        // axis = (cos, sin) → rotate, then scale, then translate.
+        // axis = (cos, sin) → rotate, then (possibly non-uniform) scale, then translate.
         let (ax, ay) = (self.uv_axis[0], self.uv_axis[1]);
         let rx = ax * uv[0] - ay * uv[1];
         let ry = ay * uv[0] + ax * uv[1];
         [
             self.uv_origin[0] + self.uv_scale * rx,
-            self.uv_origin[1] + self.uv_scale * ry,
+            self.uv_origin[1] + self.uv_scale_y * ry,
         ]
     }
 }
@@ -135,6 +138,48 @@ fn decode_png(bytes: &[u8]) -> Option<(Vec<u8>, u32, u32)> {
     Some((rgba, w, h))
 }
 
+/// Decode a JPEG byte buffer to RGBA8. Returns `(rgba, width, height)`.
+fn decode_jpeg(bytes: &[u8]) -> Option<(Vec<u8>, u32, u32)> {
+    let mut decoder = jpeg_decoder::Decoder::new(bytes);
+    let pixels = decoder.decode().ok()?;
+    let info = decoder.info()?;
+    let (w, h) = (info.width as usize, info.height as usize);
+    let px = w * h;
+    let mut rgba = Vec::with_capacity(px * 4);
+    match info.pixel_format {
+        jpeg_decoder::PixelFormat::RGB24 => {
+            for c in pixels.chunks_exact(3) {
+                rgba.extend_from_slice(&[c[0], c[1], c[2], 255]);
+            }
+        }
+        jpeg_decoder::PixelFormat::L8 => {
+            for &g in pixels.iter() {
+                rgba.extend_from_slice(&[g, g, g, 255]);
+            }
+        }
+        // L16 / CMYK32 are rare for IFC textures; bail to the white fallback.
+        _ => return None,
+    }
+    if rgba.len() != px * 4 {
+        return None;
+    }
+    Some((rgba, w as u32, h as u32))
+}
+
+/// Decode raster image bytes to RGBA8 by sniffing the magic bytes (PNG or
+/// JPEG), so any `RasterFormat` string spelling resolves correctly.
+fn decode_raster_image(bytes: &[u8]) -> Option<(Vec<u8>, u32, u32)> {
+    const PNG_MAGIC: [u8; 8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+    if bytes.len() >= 8 && bytes[..8] == PNG_MAGIC {
+        return decode_png(bytes);
+    }
+    // JPEG: starts with FF D8 FF.
+    if bytes.len() >= 3 && bytes[0] == 0xFF && bytes[1] == 0xD8 && bytes[2] == 0xFF {
+        return decode_jpeg(bytes);
+    }
+    None
+}
+
 /// Decode `IfcBlobTexture` → RGBA8. Attributes (IFC4):
 /// RepeatS(0), RepeatT(1), Mode(2), TextureTransform(3), Parameter(4),
 /// RasterFormat(5), RasterCode(6).
@@ -144,13 +189,9 @@ fn decode_blob_texture(entity: &DecodedEntity) -> Option<MeshTexture> {
     if bytes.len() < 8 {
         return None;
     }
-    // Only PNG is handled here (RasterFormat == 'PNG'); the magic check guards
-    // against other RasterFormats slipping through.
-    const PNG_MAGIC: [u8; 8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
-    if bytes[..8] != PNG_MAGIC {
-        return None;
-    }
-    let (rgba, width, height) = decode_png(&bytes)?;
+    // Dispatch on the image's magic bytes (PNG or JPEG) rather than trusting the
+    // RasterFormat string spelling ('PNG' / 'JPG' / 'JPEG' all occur).
+    let (rgba, width, height) = decode_raster_image(&bytes)?;
     Some(MeshTexture {
         rgba,
         width,
@@ -215,17 +256,33 @@ fn resolve_surface_texture(texture_id: u32, decoder: &mut EntityDecoder) -> Opti
     }
 }
 
-/// Parse the optional `IfcCartesianTransformationOperator2D` texture transform.
-/// Attributes: Axis1(0), Axis2(1), LocalOrigin(2), Scale(3 default 1).
-fn parse_texture_transform(transform_id: u32, decoder: &mut EntityDecoder) -> ([f32; 2], [f32; 2], f32) {
+/// Parse the optional `IfcCartesianTransformationOperator2D` (or its
+/// `…2DnonUniform` subtype) texture transform. Returns
+/// `(origin, axis, scale_x, scale_y)`. Attributes: Axis1(0), Axis2(1),
+/// LocalOrigin(2), Scale(3 default 1); the non-uniform subtype adds Scale2(4)
+/// for the Y axis (defaults to Scale when absent).
+fn parse_texture_transform(
+    transform_id: u32,
+    decoder: &mut EntityDecoder,
+) -> ([f32; 2], [f32; 2], f32, f32) {
     let mut origin = [0.0f32, 0.0];
     let mut axis = [1.0f32, 0.0];
     let mut scale = 1.0f32;
+    let mut scale_y = 1.0f32;
     if let Ok(op) = decoder.decode_by_id(transform_id) {
-        if op.ifc_type == IfcType::IfcCartesianTransformationOperator2D {
+        let is_2d = op.ifc_type == IfcType::IfcCartesianTransformationOperator2D;
+        let is_2d_nonuniform =
+            op.ifc_type == IfcType::IfcCartesianTransformationOperator2DnonUniform;
+        if is_2d || is_2d_nonuniform {
             if let Some(scale_v) = op.get(3).and_then(|a| a.as_float()) {
                 scale = scale_v as f32;
             }
+            // Non-uniform: Scale2 (attr 4) drives the Y axis; default to Scale.
+            scale_y = if is_2d_nonuniform {
+                op.get(4).and_then(|a| a.as_float()).map(|v| v as f32).unwrap_or(scale)
+            } else {
+                scale
+            };
             if let Some(origin_id) = op.get_ref(2) {
                 if let Some(p) = read_point2(origin_id, decoder) {
                     origin = p;
@@ -241,7 +298,7 @@ fn parse_texture_transform(transform_id: u32, decoder: &mut EntityDecoder) -> ([
             }
         }
     }
-    (origin, axis, scale)
+    (origin, axis, scale, scale_y)
 }
 
 /// Read a 2D `IfcCartesianPoint` / `IfcDirection` (first two coordinates).
@@ -269,12 +326,12 @@ fn resolve_triangle_texture_map(
     let texture = resolve_surface_texture(texture_id, decoder)?;
 
     // Pull the optional 2D transform off the surface texture (attr 3).
-    let (uv_origin, uv_axis, uv_scale) = decoder
+    let (uv_origin, uv_axis, uv_scale, uv_scale_y) = decoder
         .decode_by_id(texture_id)
         .ok()
         .and_then(|t| t.get_ref(3))
         .map(|tid| parse_texture_transform(tid, decoder))
-        .unwrap_or(([0.0, 0.0], [1.0, 0.0], 1.0));
+        .unwrap_or(([0.0, 0.0], [1.0, 0.0], 1.0, 1.0));
 
     // TexCoords → IfcTextureVertexList.TexCoordsList (attr 0).
     let tvl_id = entity.get_ref(2)?;
@@ -316,6 +373,7 @@ fn resolve_triangle_texture_map(
             tex_coords,
             tex_coord_index,
             uv_scale,
+            uv_scale_y,
             uv_origin,
             uv_axis,
         },

--- a/rust/geometry/src/router/processing.rs
+++ b/rust/geometry/src/router/processing.rs
@@ -984,6 +984,73 @@ impl GeometryRouter {
         Ok(mesh)
     }
 
+    /// Tessellate an `IfcRepresentationMap`'s `MappedRepresentation` and bake
+    /// its `MappingOrigin` placement (issue #957).
+    ///
+    /// Used to render geometry that hangs off an `IfcTypeProduct` (e.g.
+    /// `IfcBoilerType`) through its `RepresentationMaps` when no occurrence
+    /// instantiates it — the buildingSMART annex-E "tessellated shape with
+    /// style" samples ship exactly this shape (geometry on the type, declared
+    /// via `IfcRelDeclares`, with no product instance).
+    ///
+    /// Unlike [`Self::process_mapped_item_cached`], this applies `MappingOrigin`
+    /// (`IfcRepresentationMap` attr 0) rather than a `MappingTarget`: there is
+    /// no occurrence placement and no `IfcMappedItem` to carry one, so the
+    /// MappingOrigin axis placement is the only transform. It is the caller's
+    /// responsibility to only invoke this for orphan representation maps so
+    /// normally-instanced typed products aren't double-rendered.
+    pub fn process_representation_map(
+        &self,
+        rep_map: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+    ) -> Result<Mesh> {
+        // attr 1: MappedRepresentation (IfcShapeRepresentation)
+        let mapped_rep_attr = rep_map.get(1).ok_or_else(|| {
+            Error::geometry("RepresentationMap missing MappedRepresentation".to_string())
+        })?;
+        let mapped_rep = decoder
+            .resolve_ref(mapped_rep_attr)?
+            .ok_or_else(|| Error::geometry("Failed to resolve MappedRepresentation".to_string()))?;
+
+        // attr 3: Items
+        let items_attr = mapped_rep
+            .get(3)
+            .ok_or_else(|| Error::geometry("Representation missing Items".to_string()))?;
+        let items = decoder.resolve_ref_list(items_attr)?;
+
+        let mut mesh = Mesh::new();
+        for item in items {
+            // Skip nested MappedItems to avoid recursion (a type's own
+            // representation referencing another mapped item is unusual);
+            // mirrors process_mapped_item_cached.
+            if item.ifc_type == IfcType::IfcMappedItem {
+                continue;
+            }
+            if let Some(processor) = self.processors.get(&item.ifc_type) {
+                if let Ok(mut sub_mesh) = processor.process(&item, decoder, &self.schema) {
+                    sub_mesh.validate_indices();
+                    self.scale_mesh(&mut sub_mesh);
+                    mesh.merge(&sub_mesh);
+                }
+            }
+        }
+
+        // attr 0: MappingOrigin (IfcAxis2Placement3D) — the only transform.
+        if let Some(origin_attr) = rep_map.get(0) {
+            if !origin_attr.is_null() {
+                if let Some(origin) = decoder.resolve_ref(origin_attr)? {
+                    if origin.ifc_type == IfcType::IfcAxis2Placement3D {
+                        let mut transform = self.parse_axis2_placement_3d(&origin, decoder)?;
+                        self.scale_transform(&mut transform);
+                        self.transform_mesh_local(&mut mesh, &transform);
+                    }
+                }
+            }
+        }
+
+        Ok(mesh)
+    }
+
     /// Run an `IfcAlignment` through the dedicated alignment processor, then
     /// apply the standard unit scale + placement transform. Returns `None`
     /// when the alignment has no recognisable directrix curve (the caller

--- a/rust/geometry/src/router/processing.rs
+++ b/rust/geometry/src/router/processing.rs
@@ -1005,23 +1005,27 @@ impl GeometryRouter {
         decoder: &mut EntityDecoder,
     ) -> Result<Mesh> {
         let empty = rustc_hash::FxHashMap::default();
-        let (mesh, _uvs, _texture) =
-            self.process_representation_map_with_texture(rep_map, decoder, &empty)?;
+        let parts = self.process_representation_map_with_texture(rep_map, decoder, &empty)?;
+        let mut mesh = Mesh::new();
+        for (part, _uvs, _texture) in parts {
+            mesh.merge(&part);
+        }
         Ok(mesh)
     }
 
     /// Texture-aware variant of [`Self::process_representation_map`] (issue
-    /// #961). When a tessellated face-set item is present in `texture_index`,
-    /// its mesh is built with per-vertex UVs and the decoded image is returned
-    /// alongside. Returns `(mesh, uvs, texture)` where `uvs` is empty and
-    /// `texture` is `None` for untextured representations. UVs are kept aligned
-    /// across mixed textured/untextured items by padding the latter with (0,0).
+    /// #961). Returns one render part per output mesh: each textured
+    /// `IfcTriangulatedFaceSet` item becomes its OWN part carrying its UVs +
+    /// decoded image (so a representation with several differently-textured
+    /// items renders each with the correct image), and all untextured items are
+    /// merged into a single part with empty UVs / no texture. The MappingOrigin
+    /// placement is baked into every part.
     pub fn process_representation_map_with_texture(
         &self,
         rep_map: &DecodedEntity,
         decoder: &mut EntityDecoder,
         texture_index: &rustc_hash::FxHashMap<u32, crate::processors::texture::ResolvedTextureMap>,
-    ) -> Result<(Mesh, Vec<f32>, Option<crate::processors::MeshTexture>)> {
+    ) -> Result<Vec<(Mesh, Vec<f32>, Option<crate::processors::MeshTexture>)>> {
         // attr 1: MappedRepresentation (IfcShapeRepresentation)
         let mapped_rep_attr = rep_map.get(1).ok_or_else(|| {
             Error::geometry("RepresentationMap missing MappedRepresentation".to_string())
@@ -1036,19 +1040,20 @@ impl GeometryRouter {
             .ok_or_else(|| Error::geometry("Representation missing Items".to_string()))?;
         let items = decoder.resolve_ref_list(items_attr)?;
 
-        // Collect each item's sub-mesh + optional UVs first, so UV padding for
-        // mixed textured/untextured items stays aligned regardless of order.
-        let mut parts: Vec<(Mesh, Option<Vec<f32>>)> = Vec::new();
-        let mut texture: Option<crate::processors::MeshTexture> = None;
+        let mut untextured = Mesh::new();
+        // One entry per textured item — keeps each item with its own image.
+        let mut textured: Vec<(Mesh, Vec<f32>, crate::processors::MeshTexture)> = Vec::new();
         for item in items {
-            // Skip nested MappedItems to avoid recursion (a type's own
-            // representation referencing another mapped item is unusual);
-            // mirrors process_mapped_item_cached.
+            // A nested IfcMappedItem inside a type's own representation: process
+            // it (applies its MappingTarget) rather than dropping its geometry.
             if item.ifc_type == IfcType::IfcMappedItem {
+                if let Ok(sub_mesh) = self.process_mapped_item_cached(&item, decoder) {
+                    untextured.merge(&sub_mesh); // already scaled inside the cached path
+                }
                 continue;
             }
 
-            // Textured tessellated face set → build with per-vertex UVs (#961).
+            // Textured tessellated face set → its own part with per-vertex UVs (#961).
             if item.ifc_type == IfcType::IfcTriangulatedFaceSet {
                 if let Some(map) = texture_index.get(&item.id) {
                     let proc = crate::processors::TriangulatedFaceSetProcessor::new();
@@ -1056,10 +1061,7 @@ impl GeometryRouter {
                         proc.process_with_texture(&item, decoder, map)
                     {
                         self.scale_mesh(&mut sub_mesh); // UVs are unaffected by scale
-                        if texture.is_none() {
-                            texture = Some(map.texture.clone());
-                        }
-                        parts.push((sub_mesh, Some(sub_uvs)));
+                        textured.push((sub_mesh, sub_uvs, map.texture.clone()));
                         continue;
                     }
                 }
@@ -1069,46 +1071,40 @@ impl GeometryRouter {
                 if let Ok(mut sub_mesh) = processor.process(&item, decoder, &self.schema) {
                     sub_mesh.validate_indices();
                     self.scale_mesh(&mut sub_mesh);
-                    parts.push((sub_mesh, None));
+                    untextured.merge(&sub_mesh);
                 }
             }
-        }
-
-        let has_uvs = parts.iter().any(|(_, u)| u.is_some());
-        let mut mesh = Mesh::new();
-        let mut uvs: Vec<f32> = Vec::new();
-        for (sub_mesh, sub_uvs) in parts {
-            if has_uvs {
-                match sub_uvs {
-                    Some(u) => uvs.extend_from_slice(&u),
-                    None => {
-                        let verts = sub_mesh.positions.len() / 3;
-                        uvs.extend(std::iter::repeat(0.0f32).take(verts * 2));
-                    }
-                }
-            }
-            mesh.merge(&sub_mesh);
         }
 
         // attr 0: MappingOrigin (IfcAxis2Placement3D) — the only 3D transform;
-        // UVs are 2D and unaffected.
-        if let Some(origin_attr) = rep_map.get(0) {
-            if !origin_attr.is_null() {
-                if let Some(origin) = decoder.resolve_ref(origin_attr)? {
-                    if origin.ifc_type == IfcType::IfcAxis2Placement3D {
-                        let mut transform = self.parse_axis2_placement_3d(&origin, decoder)?;
-                        self.scale_transform(&mut transform);
-                        self.transform_mesh_local(&mut mesh, &transform);
-                    }
+        // UVs are 2D and unaffected. Parse once, bake into every part.
+        let origin_transform: Option<nalgebra::Matrix4<f64>> = match rep_map.get(0) {
+            Some(origin_attr) if !origin_attr.is_null() => match decoder.resolve_ref(origin_attr)? {
+                Some(origin) if origin.ifc_type == IfcType::IfcAxis2Placement3D => {
+                    let mut t = self.parse_axis2_placement_3d(&origin, decoder)?;
+                    self.scale_transform(&mut t);
+                    Some(t)
                 }
+                _ => None,
+            },
+            _ => None,
+        };
+
+        let mut out: Vec<(Mesh, Vec<f32>, Option<crate::processors::MeshTexture>)> = Vec::new();
+        for (mut mesh, uvs, texture) in textured {
+            if let Some(t) = &origin_transform {
+                self.transform_mesh_local(&mut mesh, t);
             }
+            out.push((mesh, uvs, Some(texture)));
+        }
+        if !untextured.is_empty() {
+            if let Some(t) = &origin_transform {
+                self.transform_mesh_local(&mut untextured, t);
+            }
+            out.push((untextured, Vec::new(), None));
         }
 
-        if has_uvs {
-            Ok((mesh, uvs, texture))
-        } else {
-            Ok((mesh, Vec::new(), None))
-        }
+        Ok(out)
     }
 
     /// Run an `IfcAlignment` through the dedicated alignment processor, then

--- a/rust/geometry/src/router/processing.rs
+++ b/rust/geometry/src/router/processing.rs
@@ -1004,6 +1004,24 @@ impl GeometryRouter {
         rep_map: &DecodedEntity,
         decoder: &mut EntityDecoder,
     ) -> Result<Mesh> {
+        let empty = rustc_hash::FxHashMap::default();
+        let (mesh, _uvs, _texture) =
+            self.process_representation_map_with_texture(rep_map, decoder, &empty)?;
+        Ok(mesh)
+    }
+
+    /// Texture-aware variant of [`Self::process_representation_map`] (issue
+    /// #961). When a tessellated face-set item is present in `texture_index`,
+    /// its mesh is built with per-vertex UVs and the decoded image is returned
+    /// alongside. Returns `(mesh, uvs, texture)` where `uvs` is empty and
+    /// `texture` is `None` for untextured representations. UVs are kept aligned
+    /// across mixed textured/untextured items by padding the latter with (0,0).
+    pub fn process_representation_map_with_texture(
+        &self,
+        rep_map: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+        texture_index: &rustc_hash::FxHashMap<u32, crate::processors::texture::ResolvedTextureMap>,
+    ) -> Result<(Mesh, Vec<f32>, Option<crate::processors::MeshTexture>)> {
         // attr 1: MappedRepresentation (IfcShapeRepresentation)
         let mapped_rep_attr = rep_map.get(1).ok_or_else(|| {
             Error::geometry("RepresentationMap missing MappedRepresentation".to_string())
@@ -1018,7 +1036,10 @@ impl GeometryRouter {
             .ok_or_else(|| Error::geometry("Representation missing Items".to_string()))?;
         let items = decoder.resolve_ref_list(items_attr)?;
 
-        let mut mesh = Mesh::new();
+        // Collect each item's sub-mesh + optional UVs first, so UV padding for
+        // mixed textured/untextured items stays aligned regardless of order.
+        let mut parts: Vec<(Mesh, Option<Vec<f32>>)> = Vec::new();
+        let mut texture: Option<crate::processors::MeshTexture> = None;
         for item in items {
             // Skip nested MappedItems to avoid recursion (a type's own
             // representation referencing another mapped item is unusual);
@@ -1026,16 +1047,51 @@ impl GeometryRouter {
             if item.ifc_type == IfcType::IfcMappedItem {
                 continue;
             }
+
+            // Textured tessellated face set → build with per-vertex UVs (#961).
+            if item.ifc_type == IfcType::IfcTriangulatedFaceSet {
+                if let Some(map) = texture_index.get(&item.id) {
+                    let proc = crate::processors::TriangulatedFaceSetProcessor::new();
+                    if let Ok((mut sub_mesh, sub_uvs)) =
+                        proc.process_with_texture(&item, decoder, map)
+                    {
+                        self.scale_mesh(&mut sub_mesh); // UVs are unaffected by scale
+                        if texture.is_none() {
+                            texture = Some(map.texture.clone());
+                        }
+                        parts.push((sub_mesh, Some(sub_uvs)));
+                        continue;
+                    }
+                }
+            }
+
             if let Some(processor) = self.processors.get(&item.ifc_type) {
                 if let Ok(mut sub_mesh) = processor.process(&item, decoder, &self.schema) {
                     sub_mesh.validate_indices();
                     self.scale_mesh(&mut sub_mesh);
-                    mesh.merge(&sub_mesh);
+                    parts.push((sub_mesh, None));
                 }
             }
         }
 
-        // attr 0: MappingOrigin (IfcAxis2Placement3D) — the only transform.
+        let has_uvs = parts.iter().any(|(_, u)| u.is_some());
+        let mut mesh = Mesh::new();
+        let mut uvs: Vec<f32> = Vec::new();
+        for (sub_mesh, sub_uvs) in parts {
+            if has_uvs {
+                match sub_uvs {
+                    Some(u) => uvs.extend_from_slice(&u),
+                    None => {
+                        let verts = sub_mesh.positions.len() / 3;
+                        uvs.extend(std::iter::repeat(0.0f32).take(verts * 2));
+                    }
+                }
+            }
+            mesh.merge(&sub_mesh);
+        }
+
+        // attr 0: MappingOrigin (IfcAxis2Placement3D) — the only 3D transform;
+        // UVs are 2D and unaffected.
         if let Some(origin_attr) = rep_map.get(0) {
             if !origin_attr.is_null() {
                 if let Some(origin) = decoder.resolve_ref(origin_attr)? {
@@ -1048,7 +1104,11 @@ impl GeometryRouter {
             }
         }
 
-        Ok(mesh)
+        if has_uvs {
+            Ok((mesh, uvs, texture))
+        } else {
+            Ok((mesh, Vec::new(), None))
+        }
     }
 
     /// Run an `IfcAlignment` through the dedicated alignment processor, then

--- a/rust/geometry/tests/geometry_correctness_harness.rs
+++ b/rust/geometry/tests/geometry_correctness_harness.rs
@@ -150,9 +150,11 @@ const FIXTURES: &[Fixture] = &[
     // ─── buildingSMART IFC 4.3 — Annex E / Tessellated Shape With Style ───
     // The three "with-*-texture" fixtures ship their tessellated geometry
     // attached via `IfcRepresentationMap` to an `IfcBoilerType` only — no
-    // `IfcBoiler` instance exists in the file, so the product-walking
-    // pipeline correctly produces no rendered geometry. They still parse
-    // cleanly and trigger no NaN, which is what this harness checks.
+    // `IfcBoiler` instance exists. This harness walks PRODUCTS only, so it
+    // still sees no geometry here. Type-only geometry is rendered one layer up,
+    // by the processing crate's orphan-RepresentationMap pass (#957) — see
+    // `ifc-lite-processing` test `issue_957_type_only_geometry`. They still
+    // parse cleanly with no NaN, which is what this harness checks.
     // `individual-colors` ships an actual instance and produces 12 tris.
     Fixture {
         path: "tests/models/buildingsmart/annex_e/tessellated-shape-with-style/tessellation-with-blob-texture.ifc",

--- a/rust/processing/src/processor.rs
+++ b/rust/processing/src/processor.rs
@@ -1338,6 +1338,11 @@ pub fn process_geometry_streaming_filtered_with_options(
     merge_indexed_colours(&mut geometry_style_index, &indexed_colour_index);
     let mut geometry_style_index = Arc::new(geometry_style_index);
     let indexed_colour_full = Arc::new(indexed_colour_full);
+    // #961: decode surface textures (IfcBlobTexture PNG / IfcPixelTexture) and
+    // their per-triangle UV maps once, keyed by face-set id. `build_texture_index`
+    // bails out on a cheap substring check for the (vast majority) untextured
+    // files. Consumed by the type-only render path below.
+    let texture_index = Arc::new(ifc_lite_geometry::build_texture_index(content, &mut decoder));
     // Join the material chain into colours per element (#407). The single
     // opaque-first colour is the general-path element fallback; the full list
     // feeds the opening sub-mesh transparent/opaque split (#913 §2.3).
@@ -1472,6 +1477,7 @@ pub fn process_geometry_streaming_filtered_with_options(
                     geometry_style_index.as_ref(),
                     indexed_colour_full.as_ref(),
                     element_material_colors.as_ref(),
+                    texture_index.as_ref(),
                     site_local_rotation,
                 )
             })
@@ -1575,6 +1581,9 @@ fn process_entity_job(
     geometry_style_index: &FxHashMap<u32, GeometryStyleInfo>,
     indexed_colour_full: &FxHashMap<u32, crate::style::FullIndexedColourMap>,
     element_material_colors: &FxHashMap<u32, Vec<[f32; 4]>>,
+    // Surface textures + UV maps keyed by face-set id (#961). Empty for
+    // untextured models.
+    texture_index: &FxHashMap<u32, ifc_lite_geometry::ResolvedTextureMap>,
     // Present only when the selected coordinate space is `site_local`; rotates
     // mesh vertices into the site's axis frame.
     site_local_rotation: Option<&Vec<f64>>,
@@ -1612,6 +1621,7 @@ fn process_entity_job(
             &local_router,
             &mut local_decoder,
             geometry_style_index,
+            texture_index,
             element_color,
             global_id,
             name,
@@ -1778,6 +1788,7 @@ fn process_type_representation_map_job(
     router: &GeometryRouter,
     decoder: &mut EntityDecoder,
     geometry_style_index: &FxHashMap<u32, GeometryStyleInfo>,
+    texture_index: &FxHashMap<u32, ifc_lite_geometry::ResolvedTextureMap>,
     element_color: [f32; 4],
     global_id: Option<String>,
     name: Option<String>,
@@ -1787,7 +1798,12 @@ fn process_type_representation_map_job(
     let Ok(rep_map) = decoder.decode_by_id(rep_map_id) else {
         return Vec::new();
     };
-    let Ok(mut mesh) = router.process_representation_map(&rep_map, decoder) else {
+    // Texture-aware build (#961): emits per-vertex UVs + the decoded image when
+    // the mapped face set carries an IfcIndexedTriangleTextureMap; otherwise
+    // returns the plain mesh with empty uvs / no texture.
+    let Ok((mut mesh, uvs, texture)) =
+        router.process_representation_map_with_texture(&rep_map, decoder, texture_index)
+    else {
         return Vec::new();
     };
     if mesh.is_empty() {
@@ -1809,6 +1825,22 @@ fn process_type_representation_map_job(
         color,
     )
     .with_element_metadata(global_id, name, presentation_layer);
+
+    // Attach the decoded texture + UVs (#961). `convert_mesh_to_site_local`
+    // rotates positions/normals only; UVs are 2D and pass through unchanged.
+    if let Some(tex) = texture {
+        mesh_data = mesh_data.with_texture(
+            uvs,
+            crate::types::mesh::MeshTextureData {
+                rgba: tex.rgba,
+                width: tex.width,
+                height: tex.height,
+                repeat_s: tex.repeat_s,
+                repeat_t: tex.repeat_t,
+            },
+        );
+    }
+
     convert_mesh_to_site_local(&mut mesh_data, site_local_rotation);
     vec![mesh_data]
 }

--- a/rust/processing/src/processor.rs
+++ b/rust/processing/src/processor.rs
@@ -1949,6 +1949,21 @@ fn build_color_updates_for_jobs(
     let mut updates: Vec<(u32, [f32; 4])> = Vec::new();
 
     for job in jobs {
+        // #957: synthetic type-only-geometry jobs resolve their colour from the
+        // RepresentationMap (a type has no IfcProductDefinitionShape), so the
+        // product-definition path below never corrects them. Backfill them here
+        // or a deferred IfcStyledItem (fast_first_batch) leaves the orphan type
+        // geometry stuck at its fallback colour.
+        if let Some(rep_map_id) = job.representation_map_id {
+            if let Some(color) =
+                resolve_color_for_representation_map(rep_map_id, geometry_styles, &mut decoder)
+            {
+                if color != job.element_color {
+                    updates.push((job.id, color));
+                }
+            }
+            continue;
+        }
         let Ok(entity) = decoder.decode_at(job.start, job.end) else {
             continue;
         };

--- a/rust/processing/src/processor.rs
+++ b/rust/processing/src/processor.rs
@@ -17,7 +17,7 @@ use ifc_lite_core::{
 };
 use ifc_lite_geometry::{calculate_normals, GeometryRouter};
 use rayon::prelude::*;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
@@ -177,6 +177,10 @@ struct EntityJob {
     name: Option<String>,
     presentation_layer: Option<String>,
     space_zone_properties: Option<BTreeMap<String, String>>,
+    /// Set for synthetic type-only-geometry jobs (#957): the `IfcRepresentationMap`
+    /// id to render directly (baking its MappingOrigin) instead of walking the
+    /// element's `IfcProductDefinitionShape`. `None` for ordinary product jobs.
+    representation_map_id: Option<u32>,
 }
 
 fn populate_entity_job_metadata(
@@ -829,6 +833,12 @@ pub fn process_geometry_streaming_filtered_with_options(
     // below.
     let mut aggregate_children: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
     let mut entity_jobs: Vec<EntityJob> = Vec::with_capacity(2000);
+    // #957: type-product geometry (IfcXxxType + its RepresentationMaps) and the
+    // set of RepresentationMaps already instantiated by an IfcMappedItem. After
+    // the scan, RepresentationMaps NOT in the referenced set are rendered as
+    // orphan type geometry (buildingSMART annex-E showcase files).
+    let mut type_product_geometry: Vec<(u32, usize, usize, IfcType, Vec<u32>)> = Vec::new();
+    let mut referenced_representation_maps: FxHashSet<u32> = FxHashSet::default();
     let quick_metadata_enabled = options.emit_quick_metadata_bootstrap;
     let mut quick_spatial_nodes = quick_metadata_enabled.then(HashMap::<u32, QuickSpatialNodeEntry>::new);
     let mut quick_aggregate_links = if quick_metadata_enabled {
@@ -1095,6 +1105,60 @@ pub fn process_geometry_streaming_filtered_with_options(
                 name: None,
                 presentation_layer: None,
                 space_zone_properties: None,
+                representation_map_id: None,
+            });
+        }
+
+        // #957: collect type-product geometry (IfcXxxType carrying its own
+        // RepresentationMaps) and every IfcMappedItem's MappingSource, so after
+        // the scan we can render the RepresentationMaps that NO occurrence
+        // instantiates (orphan library/showcase geometry). The cheap suffix
+        // pre-filter keeps the is_subtype_of check off the hot path for the
+        // ~all-non-type majority of entities.
+        else if type_name == "IFCMAPPEDITEM" {
+            let args = parse_step_arguments(&content[start..end]);
+            if let Some(source_id) = args.first().and_then(|token| parse_step_ref(token)) {
+                referenced_representation_maps.insert(source_id);
+            }
+        } else if (type_name.ends_with("TYPE") || type_name.ends_with("STYLE"))
+            && IfcType::from_str(type_name).is_subtype_of(IfcType::IfcTypeProduct)
+        {
+            let args = parse_step_arguments(&content[start..end]);
+            // IfcTypeProduct.RepresentationMaps is attribute index 6.
+            let rep_map_ids = args
+                .get(6)
+                .map(|token| parse_step_ref_list(token))
+                .unwrap_or_default();
+            if !rep_map_ids.is_empty() {
+                type_product_geometry.push((id, start, end, IfcType::from_str(type_name), rep_map_ids));
+            }
+        }
+    }
+
+    // #957: synthesize render jobs for orphan type-product geometry — a
+    // RepresentationMap on an IfcXxxType that no IfcMappedItem instantiates.
+    // Normally-instanced typed products keep their geometry on the occurrence
+    // (whose IfcMappedItem references the map), so those maps are in
+    // `referenced_representation_maps` and skipped here — no double render.
+    // buildingSMART annex-E "tessellated shape with style" files declare the
+    // geometry only on the type, so without this they render nothing (#957).
+    for (type_id, start, end, ifc_type, rep_map_ids) in &type_product_geometry {
+        for &rep_map_id in rep_map_ids {
+            if referenced_representation_maps.contains(&rep_map_id) {
+                continue;
+            }
+            entity_jobs.push(EntityJob {
+                id: *type_id,
+                ifc_type: ifc_type.clone(),
+                start: *start,
+                end: *end,
+                product_definition_shape_id: None,
+                element_color: crate::style::default_color_for_type(*ifc_type).to_array(),
+                global_id: None,
+                name: None,
+                presentation_layer: None,
+                space_zone_properties: None,
+                representation_map_id: Some(rep_map_id),
             });
         }
     }
@@ -1538,6 +1602,24 @@ fn process_entity_job(
     let space_zone_properties = job.space_zone_properties.clone();
     let element_color = job.element_color;
 
+    // #957: synthetic type-only-geometry job — render the orphan
+    // RepresentationMap directly (baking its MappingOrigin) instead of walking
+    // the product's IfcProductDefinitionShape (a type has none).
+    if let Some(rep_map_id) = job.representation_map_id {
+        return process_type_representation_map_job(
+            job,
+            rep_map_id,
+            &local_router,
+            &mut local_decoder,
+            geometry_style_index,
+            element_color,
+            global_id,
+            name,
+            presentation_layer,
+            site_local_rotation,
+        );
+    }
+
     if is_opening_with_subparts(&job.ifc_type) {
         if let Ok(sub_meshes) = local_router.process_element_with_submeshes(&entity, &mut local_decoder) {
             if !sub_meshes.is_empty() {
@@ -1679,6 +1761,82 @@ fn process_entity_job(
     }
 
     Vec::new()
+}
+
+/// Render an orphan type-product `IfcRepresentationMap` (issue #957).
+///
+/// Tessellates the map's `MappedRepresentation` (baking its MappingOrigin) and
+/// builds a single [`MeshData`] keyed on the type's express id. The colour is
+/// resolved from the mapped geometry's `IfcStyledItem` chain when present (the
+/// blob/image/pixel-texture annex-E fixtures author a white `IfcSurfaceStyle`),
+/// otherwise the type's default colour. Texture fidelity is layered on
+/// separately; this path makes the geometry visible.
+#[allow(clippy::too_many_arguments)]
+fn process_type_representation_map_job(
+    job: &EntityJob,
+    rep_map_id: u32,
+    router: &GeometryRouter,
+    decoder: &mut EntityDecoder,
+    geometry_style_index: &FxHashMap<u32, GeometryStyleInfo>,
+    element_color: [f32; 4],
+    global_id: Option<String>,
+    name: Option<String>,
+    presentation_layer: Option<String>,
+    site_local_rotation: Option<&Vec<f64>>,
+) -> Vec<MeshData> {
+    let Ok(rep_map) = decoder.decode_by_id(rep_map_id) else {
+        return Vec::new();
+    };
+    let Ok(mut mesh) = router.process_representation_map(&rep_map, decoder) else {
+        return Vec::new();
+    };
+    if mesh.is_empty() {
+        return Vec::new();
+    }
+    if mesh.normals.is_empty() {
+        calculate_normals(&mut mesh);
+    }
+
+    let color = resolve_color_for_representation_map(rep_map_id, geometry_style_index, decoder)
+        .unwrap_or(element_color);
+
+    let mut mesh_data = MeshData::new(
+        job.id,
+        job.ifc_type.name().to_string(),
+        mesh.positions,
+        mesh.normals,
+        mesh.indices,
+        color,
+    )
+    .with_element_metadata(global_id, name, presentation_layer);
+    convert_mesh_to_site_local(&mut mesh_data, site_local_rotation);
+    vec![mesh_data]
+}
+
+/// Resolve the authored colour for a type's `IfcRepresentationMap` (issue #957)
+/// by looking up its mapped geometry items in the styled-item index — the same
+/// index that colours ordinary products. Returns `None` when no item carries a
+/// style (caller falls back to the type's default colour).
+fn resolve_color_for_representation_map(
+    rep_map_id: u32,
+    geometry_style_index: &FxHashMap<u32, GeometryStyleInfo>,
+    decoder: &mut EntityDecoder,
+) -> Option<[f32; 4]> {
+    let rep_map = decoder.decode_by_id(rep_map_id).ok()?;
+    // IfcRepresentationMap.MappedRepresentation = attr 1.
+    let mapped_rep_id = rep_map.get_ref(1)?;
+    let mapped_rep = decoder.decode_by_id(mapped_rep_id).ok()?;
+    // IfcShapeRepresentation.Items = attr 3.
+    let item_ids = get_refs_from_list(&mapped_rep, 3)?;
+    for item_id in item_ids {
+        if let Some(style) = geometry_style_index.get(&item_id) {
+            return Some(style.color);
+        }
+        if let Some(color) = find_geometry_item_color(item_id, geometry_style_index, decoder) {
+            return Some(color);
+        }
+    }
+    None
 }
 
 /// Find the first representation item of `entity` that carries a full

--- a/rust/processing/src/processor.rs
+++ b/rust/processing/src/processor.rs
@@ -1798,51 +1798,58 @@ fn process_type_representation_map_job(
     let Ok(rep_map) = decoder.decode_by_id(rep_map_id) else {
         return Vec::new();
     };
-    // Texture-aware build (#961): emits per-vertex UVs + the decoded image when
-    // the mapped face set carries an IfcIndexedTriangleTextureMap; otherwise
-    // returns the plain mesh with empty uvs / no texture.
-    let Ok((mut mesh, uvs, texture)) =
+    // Texture-aware build (#961): one part per output mesh — each textured face
+    // set carries its own UVs + decoded image; untextured items merge into one
+    // part with no texture.
+    let Ok(parts) =
         router.process_representation_map_with_texture(&rep_map, decoder, texture_index)
     else {
         return Vec::new();
     };
-    if mesh.is_empty() {
+    if parts.is_empty() {
         return Vec::new();
-    }
-    if mesh.normals.is_empty() {
-        calculate_normals(&mut mesh);
     }
 
     let color = resolve_color_for_representation_map(rep_map_id, geometry_style_index, decoder)
         .unwrap_or(element_color);
 
-    let mut mesh_data = MeshData::new(
-        job.id,
-        job.ifc_type.name().to_string(),
-        mesh.positions,
-        mesh.normals,
-        mesh.indices,
-        color,
-    )
-    .with_element_metadata(global_id, name, presentation_layer);
+    let mut out: Vec<MeshData> = Vec::with_capacity(parts.len());
+    for (mut mesh, uvs, texture) in parts {
+        if mesh.is_empty() {
+            continue;
+        }
+        if mesh.normals.is_empty() {
+            calculate_normals(&mut mesh);
+        }
+        let mut mesh_data = MeshData::new(
+            job.id,
+            job.ifc_type.name().to_string(),
+            mesh.positions,
+            mesh.normals,
+            mesh.indices,
+            color,
+        )
+        .with_element_metadata(global_id.clone(), name.clone(), presentation_layer.clone());
 
-    // Attach the decoded texture + UVs (#961). `convert_mesh_to_site_local`
-    // rotates positions/normals only; UVs are 2D and pass through unchanged.
-    if let Some(tex) = texture {
-        mesh_data = mesh_data.with_texture(
-            uvs,
-            crate::types::mesh::MeshTextureData {
-                rgba: tex.rgba,
-                width: tex.width,
-                height: tex.height,
-                repeat_s: tex.repeat_s,
-                repeat_t: tex.repeat_t,
-            },
-        );
+        // Attach the decoded texture + UVs (#961). `convert_mesh_to_site_local`
+        // rotates positions/normals only; UVs are 2D and pass through unchanged.
+        if let Some(tex) = texture {
+            mesh_data = mesh_data.with_texture(
+                uvs,
+                crate::types::mesh::MeshTextureData {
+                    rgba: tex.rgba,
+                    width: tex.width,
+                    height: tex.height,
+                    repeat_s: tex.repeat_s,
+                    repeat_t: tex.repeat_t,
+                },
+            );
+        }
+
+        convert_mesh_to_site_local(&mut mesh_data, site_local_rotation);
+        out.push(mesh_data);
     }
-
-    convert_mesh_to_site_local(&mut mesh_data, site_local_rotation);
-    vec![mesh_data]
+    out
 }
 
 /// Resolve the authored colour for a type's `IfcRepresentationMap` (issue #957)

--- a/rust/processing/src/types/mesh.rs
+++ b/rust/processing/src/types/mesh.rs
@@ -7,6 +7,20 @@
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
+/// A decoded RGBA8 surface texture attached to a mesh (issue #961).
+/// Decoded entirely in Rust (`IfcBlobTexture` PNG / `IfcPixelTexture` raw); the
+/// browser only uploads `rgba` to a GPU texture — no image logic in TS.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MeshTextureData {
+    /// `width * height * 4` bytes, row-major, top-down, straight alpha.
+    pub rgba: Vec<u8>,
+    pub width: u32,
+    pub height: u32,
+    /// Sampler wrap from `IfcSurfaceTexture.RepeatS/RepeatT`.
+    pub repeat_s: bool,
+    pub repeat_t: bool,
+}
+
 /// Individual mesh data with geometry and metadata.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MeshData {
@@ -41,6 +55,13 @@ pub struct MeshData {
     /// Primarily attached for IfcSpace/IfcZone so downstream tools can build room attribute UIs.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub properties: Option<BTreeMap<String, String>>,
+    /// Per-vertex texture coordinates (u, v pairs, 1:1 with `positions`),
+    /// present only for textured meshes (issue #961).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uvs: Option<Vec<f32>>,
+    /// Decoded surface texture, present only for textured meshes (#961).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub texture: Option<MeshTextureData>,
 }
 
 impl MeshData {
@@ -66,7 +87,17 @@ impl MeshData {
             material_name: None,
             geometry_item_id: None,
             properties: None,
+            uvs: None,
+            texture: None,
         }
+    }
+
+    /// Attach per-vertex UVs + a decoded surface texture (issue #961).
+    /// `uvs` must be 1:1 with `positions` (2 floats per vertex).
+    pub fn with_texture(mut self, uvs: Vec<f32>, texture: MeshTextureData) -> Self {
+        self.uvs = Some(uvs);
+        self.texture = Some(texture);
+        self
     }
 
     /// Set element-level IFC metadata.

--- a/rust/processing/tests/issue_957_type_only_geometry.rs
+++ b/rust/processing/tests/issue_957_type_only_geometry.rs
@@ -1,0 +1,118 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Issue #957 — geometry attached to an `IfcTypeProduct` via its
+//! `RepresentationMaps`, with no occurrence to instantiate it, must still
+//! render (buildingSMART annex-E "tessellated shape with style" showcase
+//! files), and normally-instanced typed products must NOT be double-rendered.
+
+use ifc_lite_processing::process_geometry;
+
+fn approx_eq(a: [f32; 4], b: [f32; 4]) -> bool {
+    a.iter().zip(b.iter()).all(|(x, y)| (x - y).abs() < 1e-4)
+}
+
+const WHITE: [f32; 4] = [1.0, 1.0, 1.0, 1.0];
+
+/// An IfcBoilerType whose tessellated tetrahedron hangs off a RepresentationMap
+/// with NO IfcBoiler occurrence — styled white via IfcStyledItem (no
+/// IfcStyledItem on a product, only on the type's mapped geometry).
+const TYPE_ONLY_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('issue-957 type-only geometry'),'2;1');
+FILE_NAME('t.ifc','2026-06-06T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#43=IFCBOILERTYPE('2n5ASfQfT84eP9h$zLLJ4A',$,'Boiler',$,$,$,(#44),$,$,.NOTDEFINED.);
+#44=IFCREPRESENTATIONMAP(#45,#46);
+#45=IFCAXIS2PLACEMENT3D(#4,$,$);
+#46=IFCSHAPEREPRESENTATION(#2,'Body','Tessellation',(#48));
+#48=IFCTRIANGULATEDFACESET(#49,$,.T.,((1,2,3),(1,2,4),(1,4,3),(2,3,4)),$);
+#49=IFCCARTESIANPOINTLIST3D(((0.,0.,0.),(1.,0.,0.),(0.,1.,0.),(0.,0.,1.)));
+#50=IFCSTYLEDITEM(#48,(#52),$);
+#52=IFCSURFACESTYLE($,.POSITIVE.,(#54));
+#54=IFCSURFACESTYLERENDERING(#56,$,$,$,$,$,$,$,.NOTDEFINED.);
+#56=IFCCOLOURRGB($,1.,1.,1.);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+#[test]
+fn type_only_representation_map_renders() {
+    let result = process_geometry(TYPE_ONLY_IFC);
+
+    let type_meshes: Vec<&_> = result.meshes.iter().filter(|m| m.express_id == 43).collect();
+    assert_eq!(
+        type_meshes.len(),
+        1,
+        "IfcBoilerType #43 type-only geometry should render exactly one mesh; got {:?}",
+        result
+            .meshes
+            .iter()
+            .map(|m| (m.express_id, m.ifc_type.as_str()))
+            .collect::<Vec<_>>()
+    );
+
+    let mesh = type_meshes[0];
+    assert_eq!(mesh.indices.len() / 3, 4, "tetrahedron should produce 4 triangles");
+    assert!(
+        approx_eq(mesh.color, WHITE),
+        "type geometry should inherit the authored white IfcSurfaceStyle, got {:?}",
+        mesh.color
+    );
+}
+
+/// The same type, now INSTANCED by an IfcBuildingElementProxy whose
+/// MappedRepresentation references the type's RepresentationMap via an
+/// IfcMappedItem. The occurrence renders; the type's RepresentationMap is no
+/// longer orphan, so it must NOT be rendered a second time.
+const INSTANCED_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('issue-957 instanced type (no double-render)'),'2;1');
+FILE_NAME('t.ifc','2026-06-06T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#43=IFCBOILERTYPE('2n5ASfQfT84eP9h$zLLJ4A',$,'Boiler',$,$,$,(#44),$,$,.NOTDEFINED.);
+#44=IFCREPRESENTATIONMAP(#45,#46);
+#45=IFCAXIS2PLACEMENT3D(#4,$,$);
+#46=IFCSHAPEREPRESENTATION(#2,'Body','Tessellation',(#48));
+#48=IFCTRIANGULATEDFACESET(#49,$,.T.,((1,2,3),(1,2,4),(1,4,3),(2,3,4)),$);
+#49=IFCCARTESIANPOINTLIST3D(((0.,0.,0.),(1.,0.,0.),(0.,1.,0.),(0.,0.,1.)));
+#100=IFCBUILDINGELEMENTPROXY('1occurrenceMapped0000',$,'Occ',$,$,#101,#102,$,.NOTDEFINED.);
+#101=IFCLOCALPLACEMENT($,#5);
+#102=IFCPRODUCTDEFINITIONSHAPE($,$,(#103));
+#103=IFCSHAPEREPRESENTATION(#2,'Body','MappedRepresentation',(#104));
+#104=IFCMAPPEDITEM(#44,#105);
+#105=IFCCARTESIANTRANSFORMATIONOPERATOR3D($,$,#4,$,$);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+#[test]
+fn instanced_type_is_not_double_rendered() {
+    let result = process_geometry(INSTANCED_IFC);
+
+    let occurrence = result.meshes.iter().filter(|m| m.express_id == 100).count();
+    let type_direct = result.meshes.iter().filter(|m| m.express_id == 43).count();
+
+    assert_eq!(occurrence, 1, "the IfcMappedItem occurrence #100 should render");
+    assert_eq!(
+        type_direct, 0,
+        "the referenced RepresentationMap must NOT also render as orphan type geometry"
+    );
+}

--- a/rust/processing/tests/issue_961_textures.rs
+++ b/rust/processing/tests/issue_961_textures.rs
@@ -1,0 +1,85 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Issue #961 — IFC surface textures (IfcBlobTexture PNG / IfcPixelTexture raw)
+//! are decoded to RGBA8 in Rust and attached to the mesh with per-vertex UVs,
+//! 1:1 with positions. buildingSMART annex-E "tessellated shape with style"
+//! fixtures (a textured boiler on an IfcBoilerType, no occurrence).
+//!
+//! Fixtures are downloaded via `pnpm fixtures`; the test skips when absent so
+//! it never fails environmentally (CI provides them).
+
+use ifc_lite_processing::process_geometry;
+use std::path::PathBuf;
+
+const BOILER_TYPE_ID: u32 = 43;
+
+fn fixture(name: &str) -> Option<String> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tests/models/buildingsmart/annex_e/tessellated-shape-with-style")
+        .join(name);
+    std::fs::read_to_string(path).ok()
+}
+
+#[test]
+fn blob_texture_decodes_to_rgba_with_uvs() {
+    let Some(content) = fixture("tessellation-with-blob-texture.ifc") else {
+        eprintln!("skipping: fixture missing — run `pnpm fixtures`");
+        return;
+    };
+    let result = process_geometry(&content);
+    let mesh = result
+        .meshes
+        .iter()
+        .find(|m| m.express_id == BOILER_TYPE_ID)
+        .expect("boiler type #43 should render");
+
+    let texture = mesh.texture.as_ref().expect("blob texture should decode");
+    assert!(texture.width > 0 && texture.height > 0, "decoded image has size");
+    assert_eq!(
+        texture.rgba.len(),
+        (texture.width as usize) * (texture.height as usize) * 4,
+        "RGBA8 buffer is width*height*4"
+    );
+
+    let uvs = mesh.uvs.as_ref().expect("textured mesh carries UVs");
+    assert_eq!(
+        uvs.len(),
+        (mesh.positions.len() / 3) * 2,
+        "UVs are 2 floats per vertex, 1:1 with positions"
+    );
+    // Flat-shaded boiler cylinder: vertices = triangles * 3, all populated.
+    let verts = mesh.positions.len() / 3;
+    assert!(verts >= 3 && verts % 3 == 0, "flat-shaded vertex count, got {verts}");
+    // The *48 texture transform tiles the UVs well beyond [0,1] — confirms the
+    // IfcCartesianTransformationOperator2D scale was applied (sampler repeats).
+    let max_u = uvs.iter().step_by(2).cloned().fold(0.0f32, f32::max);
+    assert!(max_u > 1.5, "UV scale transform (×48) should be applied, max u = {max_u}");
+}
+
+#[test]
+fn pixel_texture_decodes_known_pixels() {
+    let Some(content) = fixture("tessellation-with-pixel-texture.ifc") else {
+        eprintln!("skipping: fixture missing — run `pnpm fixtures`");
+        return;
+    };
+    let result = process_geometry(&content);
+    let mesh = result
+        .meshes
+        .iter()
+        .find(|m| m.express_id == BOILER_TYPE_ID)
+        .expect("boiler type #43 should render");
+
+    let texture = mesh.texture.as_ref().expect("pixel texture should decode");
+    assert_eq!(texture.width, 256, "pixel texture width");
+    assert_eq!(texture.height, 256, "pixel texture height");
+    assert_eq!(texture.rgba.len(), 256 * 256 * 4, "RGBA8 256x256");
+    // First authored pixel is opaque black ("0000000FF" → 00 00 00 FF).
+    assert_eq!(
+        &texture.rgba[0..4],
+        &[0, 0, 0, 255],
+        "first pixel is opaque black"
+    );
+    assert!(mesh.uvs.is_some(), "textured mesh carries UVs");
+}

--- a/rust/processing/tests/issue_961_textures.rs
+++ b/rust/processing/tests/issue_961_textures.rs
@@ -52,10 +52,12 @@ fn blob_texture_decodes_to_rgba_with_uvs() {
     // Flat-shaded boiler cylinder: vertices = triangles * 3, all populated.
     let verts = mesh.positions.len() / 3;
     assert!(verts >= 3 && verts % 3 == 0, "flat-shaded vertex count, got {verts}");
-    // The *48 texture transform tiles the UVs well beyond [0,1] — confirms the
-    // IfcCartesianTransformationOperator2D scale was applied (sampler repeats).
-    let max_u = uvs.iter().step_by(2).cloned().fold(0.0f32, f32::max);
-    assert!(max_u > 1.5, "UV scale transform (×48) should be applied, max u = {max_u}");
+    // UVs use the authored IfcTextureVertexList coordinates directly (the
+    // IfcSurfaceTexture.TextureTransform scale is NOT applied — it over-tiles
+    // vs the buildingSMART reference). The authored coords map the image ~1:1,
+    // so they stay in a sane ~[0,1] range, not the ×48 noise of the raw scale.
+    let max_u = uvs.iter().step_by(2).cloned().fold(f32::MIN, f32::max);
+    assert!(max_u <= 1.5, "UVs should map ~1:1 (authored coords), got max u = {max_u}");
 }
 
 #[test]

--- a/rust/wasm-bindings/src/api/gpu_meshes.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes.rs
@@ -1010,6 +1010,8 @@ impl IfcAPI {
                     if !rep_map_ids.is_empty() {
                         let referenced =
                             self.get_or_build_referenced_repmaps(content, &mut decoder);
+                        // Surface textures + UV maps (#961), built once per worker.
+                        let texture_index = self.get_or_build_texture_index(content, &mut decoder);
                         for rm_id in rep_map_ids {
                             if referenced.contains(&rm_id) {
                                 continue;
@@ -1017,8 +1019,12 @@ impl IfcAPI {
                             let Ok(rep_map) = decoder.decode_by_id(rm_id) else {
                                 continue;
                             };
-                            let Ok(mut mesh) =
-                                router.process_representation_map(&rep_map, &mut decoder)
+                            let Ok((mut mesh, uvs, texture)) = router
+                                .process_representation_map_with_texture(
+                                    &rep_map,
+                                    &mut decoder,
+                                    &texture_index,
+                                )
                             else {
                                 continue;
                             };
@@ -1038,7 +1044,18 @@ impl IfcAPI {
                                 .entry(ifc_type)
                                 .or_insert_with(|| ifc_type.name().to_string())
                                 .clone();
-                            mesh_collection.add(MeshDataJs::new(id, ifc_type_name, mesh, color));
+                            let mut mesh_js = MeshDataJs::new(id, ifc_type_name, mesh, color);
+                            if let Some(tex) = texture {
+                                mesh_js.set_texture(
+                                    uvs,
+                                    tex.rgba,
+                                    tex.width,
+                                    tex.height,
+                                    tex.repeat_s,
+                                    tex.repeat_t,
+                                );
+                            }
+                            mesh_collection.add(mesh_js);
                         }
                     }
                     continue;

--- a/rust/wasm-bindings/src/api/gpu_meshes.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes.rs
@@ -1019,20 +1019,17 @@ impl IfcAPI {
                             let Ok(rep_map) = decoder.decode_by_id(rm_id) else {
                                 continue;
                             };
-                            let Ok((mut mesh, uvs, texture)) = router
-                                .process_representation_map_with_texture(
-                                    &rep_map,
-                                    &mut decoder,
-                                    &texture_index,
-                                )
-                            else {
+                            // One part per output mesh: each textured face set
+                            // carries its own image; untextured items merge (#961).
+                            let Ok(parts) = router.process_representation_map_with_texture(
+                                &rep_map,
+                                &mut decoder,
+                                &texture_index,
+                            ) else {
                                 continue;
                             };
-                            if mesh.is_empty() {
+                            if parts.is_empty() {
                                 continue;
-                            }
-                            if mesh.normals.len() != mesh.positions.len() {
-                                calculate_normals(&mut mesh);
                             }
                             let color = super::styling::color_for_representation_map(
                                 rm_id,
@@ -1044,18 +1041,27 @@ impl IfcAPI {
                                 .entry(ifc_type)
                                 .or_insert_with(|| ifc_type.name().to_string())
                                 .clone();
-                            let mut mesh_js = MeshDataJs::new(id, ifc_type_name, mesh, color);
-                            if let Some(tex) = texture {
-                                mesh_js.set_texture(
-                                    uvs,
-                                    tex.rgba,
-                                    tex.width,
-                                    tex.height,
-                                    tex.repeat_s,
-                                    tex.repeat_t,
-                                );
+                            for (mut mesh, uvs, texture) in parts {
+                                if mesh.is_empty() {
+                                    continue;
+                                }
+                                if mesh.normals.len() != mesh.positions.len() {
+                                    calculate_normals(&mut mesh);
+                                }
+                                let mut mesh_js =
+                                    MeshDataJs::new(id, ifc_type_name.clone(), mesh, color);
+                                if let Some(tex) = texture {
+                                    mesh_js.set_texture(
+                                        uvs,
+                                        tex.rgba,
+                                        tex.width,
+                                        tex.height,
+                                        tex.repeat_s,
+                                        tex.repeat_t,
+                                    );
+                                }
+                                mesh_collection.add(mesh_js);
                             }
-                            mesh_collection.add(mesh_js);
                         }
                     }
                     continue;

--- a/rust/wasm-bindings/src/api/gpu_meshes.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes.rs
@@ -817,6 +817,16 @@ impl IfcAPI {
         super::set_js_prop(&index_event, "lengths", &lengths_arr);
         on_event.call1(&JsValue::NULL, &index_event.into())?;
 
+        // #957: emit orphan IfcTypeProduct geometry as a final jobs chunk so the
+        // browser renders annex-E type-only "tessellated shape with style" files
+        // (geometry on the type via RepresentationMaps, no occurrence). The
+        // entity index is complete here, so this resolves cleanly.
+        let type_jobs = super::styling::collect_orphan_type_geometry_jobs(content, &mut decoder);
+        if !type_jobs.is_empty() {
+            total_jobs += type_jobs.len() as u32;
+            emit_jobs_chunk(on_event, &type_jobs)?;
+        }
+
         // Complete event.
         let done = js_sys::Object::new();
         super::set_js_prop(&done, "type", &"complete".into());
@@ -984,6 +994,56 @@ impl IfcAPI {
                 }
 
                 let ifc_type = entity.ifc_type;
+
+                // #957: orphan type-product geometry — an IfcXxxType carrying its
+                // own RepresentationMaps with no occurrence to instantiate them
+                // (buildingSMART annex-E "tessellated shape with style" files).
+                // Render each RepresentationMap NOT referenced by an IfcMappedItem
+                // (the referenced ones draw through their occurrence — no double
+                // render).
+                if ifc_type.is_subtype_of(ifc_lite_core::IfcType::IfcTypeProduct) {
+                    let rep_map_ids: Vec<u32> = entity
+                        .get(6)
+                        .and_then(|a| a.as_list())
+                        .map(|list| list.iter().filter_map(|v| v.as_entity_ref()).collect())
+                        .unwrap_or_default();
+                    if !rep_map_ids.is_empty() {
+                        let referenced =
+                            self.get_or_build_referenced_repmaps(content, &mut decoder);
+                        for rm_id in rep_map_ids {
+                            if referenced.contains(&rm_id) {
+                                continue;
+                            }
+                            let Ok(rep_map) = decoder.decode_by_id(rm_id) else {
+                                continue;
+                            };
+                            let Ok(mut mesh) =
+                                router.process_representation_map(&rep_map, &mut decoder)
+                            else {
+                                continue;
+                            };
+                            if mesh.is_empty() {
+                                continue;
+                            }
+                            if mesh.normals.len() != mesh.positions.len() {
+                                calculate_normals(&mut mesh);
+                            }
+                            let color = super::styling::color_for_representation_map(
+                                rm_id,
+                                &geometry_styles,
+                                &mut decoder,
+                            )
+                            .unwrap_or_else(|| default_color_for_type(ifc_type).to_array());
+                            let ifc_type_name = type_name_cache
+                                .entry(ifc_type)
+                                .or_insert_with(|| ifc_type.name().to_string())
+                                .clone();
+                            mesh_collection.add(MeshDataJs::new(id, ifc_type_name, mesh, color));
+                        }
+                    }
+                    continue;
+                }
+
                 let has_openings = void_index.contains_key(&id);
 
                 if has_openings {

--- a/rust/wasm-bindings/src/api/gpu_meshes.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes.rs
@@ -231,6 +231,16 @@ impl IfcAPI {
         drop(slot);
         let mut decoder = EntityDecoder::with_arc_index(content, entity_index);
 
+        // #957: orphan IfcTypeProduct geometry (type RepresentationMaps, no
+        // occurrence) — keep the fast prepass consistent with the once/streaming
+        // paths so type-only models (annex-E) also render on the worker fast
+        // path. The helper is guarded by a cheap `IFCREPRESENTATIONMAP`
+        // substring check, so files without type geometry pay almost nothing.
+        complex_jobs.extend(super::styling::collect_orphan_type_geometry_jobs(
+            content,
+            &mut decoder,
+        ));
+
         let unit_scale = project_id
             .and_then(|pid| ifc_lite_core::extract_length_unit_scale(&mut decoder, pid).ok())
             .unwrap_or(1.0);

--- a/rust/wasm-bindings/src/api/gpu_meshes.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes.rs
@@ -878,6 +878,15 @@ impl IfcAPI {
         // browser renders annex-E type-only "tessellated shape with style" files
         // (geometry on the type via RepresentationMaps, no occurrence). The
         // entity index is complete here, so this resolves cleanly.
+        //
+        // PERF (flagged, #962 review): for files WITH representation maps this is
+        // a second linear EntityScanner pass over `content` on top of the
+        // streaming scan above. A `IFCREPRESENTATIONMAP` substring guard inside
+        // the helper makes the ~all-files-without-type-geometry case free (just a
+        // SIMD memmem). The remaining instanced-file cost is a tracked follow-up:
+        // fold the mapped-item-source + type-candidate collection into the
+        // streaming scan loop so orphans resolve with no extra pass. Kept as a
+        // separate pass for now to avoid destabilising the streaming hot path.
         let type_jobs = super::styling::collect_orphan_type_geometry_jobs(content, &mut decoder);
         if !type_jobs.is_empty() {
             total_jobs += type_jobs.len() as u32;

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -73,6 +73,14 @@ pub struct IfcAPI {
     /// the first type-product job and cleared by `clearPrePassCache`.
     cached_referenced_repmaps:
         std::sync::Mutex<Option<std::sync::Arc<rustc_hash::FxHashSet<u32>>>>,
+
+    /// Lazily-built surface-texture index keyed by face-set id (issue #961):
+    /// decoded RGBA images + per-triangle UV maps from
+    /// `IfcIndexedTriangleTextureMap`. Built once per worker (cheap substring
+    /// bail-out for untextured files) and cleared by `clearPrePassCache`.
+    cached_texture_index: std::sync::Mutex<
+        Option<std::sync::Arc<rustc_hash::FxHashMap<u32, ifc_lite_geometry::ResolvedTextureMap>>>,
+    >,
 }
 
 #[wasm_bindgen]
@@ -89,6 +97,7 @@ impl IfcAPI {
             merge_layers: std::sync::atomic::AtomicBool::new(false),
             cached_parts_to_skip: std::sync::Mutex::new(None),
             cached_referenced_repmaps: std::sync::Mutex::new(None),
+            cached_texture_index: std::sync::Mutex::new(None),
         }
     }
 
@@ -128,6 +137,12 @@ impl IfcAPI {
             .lock()
             .expect("ifc-lite cached_referenced_repmaps Mutex poisoned");
         repmap_slot.take();
+        // The texture index is keyed off the previous load's content; drop it.
+        let mut texture_slot = self
+            .cached_texture_index
+            .lock()
+            .expect("ifc-lite cached_texture_index Mutex poisoned");
+        texture_slot.take();
     }
 
     /// Populate `cached_entity_index` from pre-extracted column arrays.
@@ -280,6 +295,35 @@ impl IfcAPI {
             .cached_referenced_repmaps
             .lock()
             .expect("ifc-lite cached_referenced_repmaps Mutex poisoned");
+        *slot = Some(std::sync::Arc::clone(&arc));
+        arc
+    }
+
+    /// Get or lazily build the surface-texture index keyed by face-set id
+    /// (issue #961): decoded RGBA images + per-triangle UV maps. Cached per
+    /// worker; `build_texture_index` bails out cheaply on untextured files.
+    pub(crate) fn get_or_build_texture_index(
+        &self,
+        content: &str,
+        decoder: &mut ifc_lite_core::EntityDecoder,
+    ) -> std::sync::Arc<rustc_hash::FxHashMap<u32, ifc_lite_geometry::ResolvedTextureMap>> {
+        {
+            let slot = self
+                .cached_texture_index
+                .lock()
+                .expect("ifc-lite cached_texture_index Mutex poisoned");
+            if let Some(existing) = slot.as_ref() {
+                return std::sync::Arc::clone(existing);
+            }
+        }
+
+        let index = ifc_lite_geometry::build_texture_index(content, decoder);
+
+        let arc = std::sync::Arc::new(index);
+        let mut slot = self
+            .cached_texture_index
+            .lock()
+            .expect("ifc-lite cached_texture_index Mutex poisoned");
         *slot = Some(std::sync::Arc::clone(&arc));
         arc
     }

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -65,6 +65,14 @@ pub struct IfcAPI {
     /// and by `setMergeLayers` (so toggling rebuilds against the latest
     /// flag value).
     cached_parts_to_skip: std::sync::Mutex<Option<std::sync::Arc<rustc_hash::FxHashSet<u32>>>>,
+
+    /// Lazily-built set of `IfcRepresentationMap` ids that an `IfcMappedItem`
+    /// instantiates (issue #957). `processGeometryBatch` uses it to decide which
+    /// of a type's RepresentationMaps are orphan and should be rendered directly
+    /// (the rest are drawn through their occurrence). Built once per worker on
+    /// the first type-product job and cleared by `clearPrePassCache`.
+    cached_referenced_repmaps:
+        std::sync::Mutex<Option<std::sync::Arc<rustc_hash::FxHashSet<u32>>>>,
 }
 
 #[wasm_bindgen]
@@ -80,6 +88,7 @@ impl IfcAPI {
             cached_entity_index: std::sync::Mutex::new(None),
             merge_layers: std::sync::atomic::AtomicBool::new(false),
             cached_parts_to_skip: std::sync::Mutex::new(None),
+            cached_referenced_repmaps: std::sync::Mutex::new(None),
         }
     }
 
@@ -112,6 +121,13 @@ impl IfcAPI {
             .lock()
             .expect("ifc-lite cached_parts_to_skip Mutex poisoned");
         parts_slot.take();
+        // The referenced-RepresentationMap set is keyed off the previous load's
+        // content; drop it so the next file rebuilds against fresh content.
+        let mut repmap_slot = self
+            .cached_referenced_repmaps
+            .lock()
+            .expect("ifc-lite cached_referenced_repmaps Mutex poisoned");
+        repmap_slot.take();
     }
 
     /// Populate `cached_entity_index` from pre-extracted column arrays.
@@ -234,6 +250,36 @@ impl IfcAPI {
             .cached_parts_to_skip
             .lock()
             .expect("ifc-lite cached_parts_to_skip Mutex poisoned");
+        *slot = Some(std::sync::Arc::clone(&arc));
+        arc
+    }
+
+    /// Get or lazily build the set of `IfcRepresentationMap` ids instantiated by
+    /// an `IfcMappedItem` (issue #957). `processGeometryBatch` uses it to render
+    /// only the ORPHAN RepresentationMaps of a type-product (the rest are drawn
+    /// through their occurrence). Cached per worker so the scan is paid once.
+    pub(crate) fn get_or_build_referenced_repmaps(
+        &self,
+        content: &str,
+        decoder: &mut ifc_lite_core::EntityDecoder,
+    ) -> std::sync::Arc<rustc_hash::FxHashSet<u32>> {
+        {
+            let slot = self
+                .cached_referenced_repmaps
+                .lock()
+                .expect("ifc-lite cached_referenced_repmaps Mutex poisoned");
+            if let Some(existing) = slot.as_ref() {
+                return std::sync::Arc::clone(existing);
+            }
+        }
+
+        let referenced = styling::build_referenced_representation_maps(content, decoder);
+
+        let arc = std::sync::Arc::new(referenced);
+        let mut slot = self
+            .cached_referenced_repmaps
+            .lock()
+            .expect("ifc-lite cached_referenced_repmaps Mutex poisoned");
         *slot = Some(std::sync::Arc::clone(&arc));
         arc
     }

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -183,6 +183,25 @@ impl IfcAPI {
             .lock()
             .expect("ifc-lite cached_entity_index Mutex poisoned");
         *slot = Some(std::sync::Arc::new(index));
+        drop(slot);
+
+        // Swapping the entity index means a different file. The other caches are
+        // content-scoped (keyed off the previous load) — carrying them into the
+        // next file would wrongly suppress/keep orphan type geometry, reuse a
+        // stale texture index, or skip the wrong parts. Drop them so they
+        // rebuild against the new content (#962 review). Mirrors clearPrePassCache.
+        self.cached_parts_to_skip
+            .lock()
+            .expect("ifc-lite cached_parts_to_skip Mutex poisoned")
+            .take();
+        self.cached_referenced_repmaps
+            .lock()
+            .expect("ifc-lite cached_referenced_repmaps Mutex poisoned")
+            .take();
+        self.cached_texture_index
+            .lock()
+            .expect("ifc-lite cached_texture_index Mutex poisoned")
+            .take();
     }
 
     /// Get WASM memory for zero-copy access

--- a/rust/wasm-bindings/src/api/styling.rs
+++ b/rust/wasm-bindings/src/api/styling.rs
@@ -502,6 +502,12 @@ pub(crate) fn combined_pre_pass(
     // gpu_meshes), but the call mutates `void_index` in place — keep it.
     let _ = ifc_lite_geometry::propagate_voids_to_parts(&mut void_index, content, decoder);
 
+    // #957: render orphan IfcTypeProduct geometry (annex-E "tessellated shape
+    // with style" showcase files attach geometry to the type, not an
+    // occurrence). processGeometryBatch turns these type jobs into meshes via
+    // process_representation_map.
+    complex_jobs.extend(collect_orphan_type_geometry_jobs(content, decoder));
+
     PrePassData {
         geometry_styles,
         void_index,
@@ -511,6 +517,115 @@ pub(crate) fn combined_pre_pass(
         simple_jobs,
         complex_jobs,
     }
+}
+
+/// #957: collect render jobs for orphan `IfcTypeProduct` geometry — a type's
+/// `RepresentationMap` that no `IfcMappedItem` instantiates.
+///
+/// Returns `(id, start, end, ifc_type)` for each TYPE entity carrying at least
+/// one orphan RepresentationMap, to be appended to the prepass job list so the
+/// browser renders them. `processGeometryBatch` turns each into geometry via
+/// [`ifc_lite_geometry::GeometryRouter::process_representation_map`]. Normally-
+/// instanced typed products keep their geometry on the occurrence (whose
+/// IfcMappedItem references the map), so those maps are filtered out here — no
+/// double render. buildingSMART annex-E "tessellated shape with style" files
+/// declare the geometry only on the type, so without this they render nothing.
+pub(crate) fn collect_orphan_type_geometry_jobs(
+    content: &str,
+    decoder: &mut ifc_lite_core::EntityDecoder,
+) -> Vec<(u32, usize, usize, ifc_lite_core::IfcType)> {
+    use ifc_lite_core::{EntityScanner, IfcType};
+
+    // Single pass: gather the IfcMappedItem-referenced RepresentationMaps and
+    // the type-product candidates together, then filter to the orphans.
+    let mut referenced: rustc_hash::FxHashSet<u32> = rustc_hash::FxHashSet::default();
+    let mut candidates: Vec<(u32, usize, usize, IfcType, Vec<u32>)> = Vec::new();
+
+    let mut scanner = EntityScanner::new(content);
+    while let Some((id, type_name, start, end)) = scanner.next_entity() {
+        if type_name == "IFCMAPPEDITEM" {
+            if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
+                // IfcMappedItem.MappingSource = attr 0.
+                if let Some(source_id) = entity.get_ref(0) {
+                    referenced.insert(source_id);
+                }
+            }
+        } else if type_name.ends_with("TYPE") || type_name.ends_with("STYLE") {
+            // Cheap suffix pre-filter keeps the is_subtype_of check off the hot
+            // path for the all-non-type majority of entities.
+            let ifc_type = IfcType::from_str(type_name);
+            if !ifc_type.is_subtype_of(IfcType::IfcTypeProduct) {
+                continue;
+            }
+            if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
+                // IfcTypeProduct.RepresentationMaps = attr 6.
+                let rep_maps: Vec<u32> = entity
+                    .get(6)
+                    .and_then(|a| a.as_list())
+                    .map(|list| list.iter().filter_map(|v| v.as_entity_ref()).collect())
+                    .unwrap_or_default();
+                if !rep_maps.is_empty() {
+                    candidates.push((id, start, end, ifc_type, rep_maps));
+                }
+            }
+        }
+    }
+
+    candidates
+        .into_iter()
+        .filter(|(_, _, _, _, maps)| maps.iter().any(|rm| !referenced.contains(rm)))
+        .map(|(id, start, end, ifc_type, _)| (id, start, end, ifc_type))
+        .collect()
+}
+
+/// #957: the set of `RepresentationMap`s instantiated by an `IfcMappedItem`, so
+/// `processGeometryBatch` can tell which of a type's RepresentationMaps are
+/// orphan (rendered directly) vs already drawn through an occurrence.
+pub(crate) fn build_referenced_representation_maps(
+    content: &str,
+    decoder: &mut ifc_lite_core::EntityDecoder,
+) -> rustc_hash::FxHashSet<u32> {
+    use ifc_lite_core::EntityScanner;
+    let mut referenced: rustc_hash::FxHashSet<u32> = rustc_hash::FxHashSet::default();
+    let mut scanner = EntityScanner::new(content);
+    while let Some((id, type_name, start, end)) = scanner.next_entity() {
+        if type_name == "IFCMAPPEDITEM" {
+            if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
+                // IfcMappedItem.MappingSource = attr 0 (the IfcRepresentationMap).
+                if let Some(source_id) = entity.get_ref(0) {
+                    referenced.insert(source_id);
+                }
+            }
+        }
+    }
+    referenced
+}
+
+/// #957: resolve the authored colour for a type's `IfcRepresentationMap` by
+/// looking up its mapped geometry items in the prepass geometry-style index
+/// (the annex-E samples author a white `IfcSurfaceStyle`). Returns `None` when
+/// no item carries a style (caller falls back to the type's default colour).
+pub(crate) fn color_for_representation_map(
+    rep_map_id: u32,
+    geometry_styles: &rustc_hash::FxHashMap<u32, [f32; 4]>,
+    decoder: &mut ifc_lite_core::EntityDecoder,
+) -> Option<[f32; 4]> {
+    let rep_map = decoder.decode_by_id(rep_map_id).ok()?;
+    // IfcRepresentationMap.MappedRepresentation = attr 1.
+    let mapped_rep_id = rep_map.get_ref(1)?;
+    let mapped_rep = decoder.decode_by_id(mapped_rep_id).ok()?;
+    // IfcShapeRepresentation.Items = attr 3.
+    let item_ids: Vec<u32> = mapped_rep
+        .get(3)
+        .and_then(|a| a.as_list())
+        .map(|list| list.iter().filter_map(|v| v.as_entity_ref()).collect())
+        .unwrap_or_default();
+    for item_id in item_ids {
+        if let Some(color) = find_color_for_geometry(item_id, geometry_styles, decoder) {
+            return Some(color);
+        }
+    }
+    None
 }
 
 /// Build material style index: maps material IDs to their colors.

--- a/rust/wasm-bindings/src/api/styling.rs
+++ b/rust/wasm-bindings/src/api/styling.rs
@@ -536,6 +536,14 @@ pub(crate) fn collect_orphan_type_geometry_jobs(
 ) -> Vec<(u32, usize, usize, ifc_lite_core::IfcType)> {
     use ifc_lite_core::{EntityScanner, IfcType};
 
+    // Fast bail-out: type-only geometry can only exist when the file authors at
+    // least one IfcRepresentationMap. The overwhelming majority of files (and
+    // every file that hits the latency-sensitive prepass without instancing)
+    // pay only a single substring search instead of a full entity scan + decode.
+    if !content.contains("IFCREPRESENTATIONMAP") {
+        return Vec::new();
+    }
+
     // Single pass: gather the IfcMappedItem-referenced RepresentationMaps and
     // the type-product candidates together, then filter to the orphans.
     let mut referenced: rustc_hash::FxHashSet<u32> = rustc_hash::FxHashSet::default();

--- a/rust/wasm-bindings/src/zero_copy.rs
+++ b/rust/wasm-bindings/src/zero_copy.rs
@@ -24,6 +24,17 @@ pub struct MeshDataJs {
     /// DiffuseColour (so the two would differ). Consumed by the GLB
     /// exporter's "Shading" colour-source option; renderers ignore it.
     shading_color: Option<[f32; 4]>,
+    /// Per-vertex texture coordinates (u, v pairs, 1:1 with positions),
+    /// present only for textured meshes (#961). Empty otherwise.
+    uvs: Vec<f32>,
+    /// Decoded RGBA8 texture (`width*height*4`), present only for textured
+    /// meshes (#961). Empty otherwise. The browser uploads this verbatim to a
+    /// GPU texture — no image decoding happens in JS.
+    texture_rgba: Vec<u8>,
+    texture_width: u32,
+    texture_height: u32,
+    texture_repeat_s: bool,
+    texture_repeat_t: bool,
 }
 
 #[wasm_bindgen]
@@ -83,6 +94,47 @@ impl MeshDataJs {
     pub fn triangle_count(&self) -> usize {
         self.indices.len() / 3
     }
+
+    /// True when this mesh carries a surface texture (#961).
+    #[wasm_bindgen(getter, js_name = hasTexture)]
+    pub fn has_texture(&self) -> bool {
+        !self.texture_rgba.is_empty()
+    }
+
+    /// Per-vertex texture coordinates as Float32Array (u, v pairs). Empty when
+    /// the mesh is untextured.
+    #[wasm_bindgen(getter)]
+    pub fn uvs(&self) -> js_sys::Float32Array {
+        js_sys::Float32Array::from(&self.uvs[..])
+    }
+
+    /// Decoded RGBA8 texture bytes (`width*height*4`). Empty when untextured.
+    #[wasm_bindgen(getter, js_name = textureRgba)]
+    pub fn texture_rgba(&self) -> js_sys::Uint8Array {
+        js_sys::Uint8Array::from(&self.texture_rgba[..])
+    }
+
+    #[wasm_bindgen(getter, js_name = textureWidth)]
+    pub fn texture_width(&self) -> u32 {
+        self.texture_width
+    }
+
+    #[wasm_bindgen(getter, js_name = textureHeight)]
+    pub fn texture_height(&self) -> u32 {
+        self.texture_height
+    }
+
+    /// Sampler wrap for the S axis (`IfcSurfaceTexture.RepeatS`): true = repeat.
+    #[wasm_bindgen(getter, js_name = textureRepeatS)]
+    pub fn texture_repeat_s(&self) -> bool {
+        self.texture_repeat_s
+    }
+
+    /// Sampler wrap for the T axis (`IfcSurfaceTexture.RepeatT`): true = repeat.
+    #[wasm_bindgen(getter, js_name = textureRepeatT)]
+    pub fn texture_repeat_t(&self) -> bool {
+        self.texture_repeat_t
+    }
 }
 
 impl MeshDataJs {
@@ -124,6 +176,12 @@ impl MeshDataJs {
             indices: mesh.indices,
             color,
             shading_color: None,
+            uvs: Vec::new(),
+            texture_rgba: Vec::new(),
+            texture_width: 0,
+            texture_height: 0,
+            texture_repeat_s: true,
+            texture_repeat_t: true,
         }
     }
 
@@ -132,6 +190,27 @@ impl MeshDataJs {
     /// for the mesh's source geometry id should invoke this after `new`.
     pub fn set_shading_color(&mut self, shading: Option<[f32; 4]>) {
         self.shading_color = shading;
+    }
+
+    /// Attach per-vertex UVs + a decoded RGBA8 texture (#961). UVs are 1:1 with
+    /// `positions` and need no coordinate flip (they are 2D); the winding
+    /// reversal in `new` swaps indices, not vertices, so per-vertex UVs stay
+    /// aligned. Call after `new`.
+    pub fn set_texture(
+        &mut self,
+        uvs: Vec<f32>,
+        rgba: Vec<u8>,
+        width: u32,
+        height: u32,
+        repeat_s: bool,
+        repeat_t: bool,
+    ) {
+        self.uvs = uvs;
+        self.texture_rgba = rgba;
+        self.texture_width = width;
+        self.texture_height = height;
+        self.texture_repeat_s = repeat_s;
+        self.texture_repeat_t = repeat_t;
     }
 }
 
@@ -168,6 +247,12 @@ impl MeshCollection {
             indices: m.indices.clone(),
             color: m.color,
             shading_color: m.shading_color,
+            uvs: m.uvs.clone(),
+            texture_rgba: m.texture_rgba.clone(),
+            texture_width: m.texture_width,
+            texture_height: m.texture_height,
+            texture_repeat_s: m.texture_repeat_s,
+            texture_repeat_t: m.texture_repeat_t,
         })
     }
 
@@ -322,6 +407,12 @@ impl Clone for MeshCollection {
                     indices: m.indices.clone(),
                     color: m.color,
                     shading_color: m.shading_color,
+                    uvs: m.uvs.clone(),
+                    texture_rgba: m.texture_rgba.clone(),
+                    texture_width: m.texture_width,
+                    texture_height: m.texture_height,
+                    texture_repeat_s: m.texture_repeat_s,
+                    texture_repeat_t: m.texture_repeat_t,
                 })
                 .collect(),
             rtc_offset_x: self.rtc_offset_x,


### PR DESCRIPTION
Closes #957
Closes #958
Closes #961

Consolidated PR for the open geometry-correctness issues (the stacked #965 was folded in here so it all lands as one reviewable change on `main`).

## What this fixes
- **#957 / #958** — type-only tessellated geometry (geometry authored on an `IfcTypeProduct`'s `RepresentationMap` with no occurrence) now renders in the live viewer instead of disappearing. Orphan type jobs are emitted in every prepass (once / streaming / **fast**) and rendered via the representation-map path.
- **#961** — IFC surface textures render on tessellated geometry. `IfcBlobTexture` (embedded **PNG and JPEG**) and `IfcPixelTexture` (raw pixels) are decoded to RGBA8 entirely in Rust; per-triangle `IfcIndexedTriangleTextureMap` UVs drive a dedicated WebGPU textured pipeline.

## Verified in-browser (WebGPU)
| fixture | result |
|---|---|
| `tessellation-with-blob-texture.ifc` | checkerboard + A–O letters, ~1:1 ✅ |
| `tessellation-with-pixel-texture.ifc` | checkerboard, ~1:1 ✅ |
| `tessellation-with-individual-colors.ifc` (#858) | per-face red/green/white ✅ |

## Architecture (Rust-first)
All image/texture decoding + UV resolution lives in Rust (source of truth for server/CLI/SDK/wasm); the browser only uploads bytes to the GPU. Authored `IfcTextureVertexList` coords are used directly (the `TextureTransform` scale over-tiled vs the buildingSMART reference). Geometry/styling fixes land in **both** mesh pipelines (`process_geometry` + the wasm `processGeometryBatch`).

## Review findings — all addressed
Pixel-dim validation, `buildPrePassFast` orphan jobs, `setEntityIndex` cache invalidation, deferred-style backfill for synthetic jobs, nested `IfcMappedItem` traversal, per-item textures, textured visibility + delete/move lifecycle, alpha cutout, test handle-free. The streaming extra-scan (P1) is mitigated by a cheap `IFCREPRESENTATIONMAP` guard.

## Tests
Rust: `issue_957_type_only_geometry`, `issue_961_textures`, `styling_indexed_colour`. Node: `type-only-geometry`, `textures`, `styling-indexed-colour-split`. Full `pnpm build` 37/37 green.

## Out of scope
`IfcImageTexture` (external URL — needs async fetch), mipmaps, fully-translucent textured surfaces (cutout handled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Type-only geometry on IFC type products now renders when uninstantiated.
  * Avoids double-rendering when typed products are instantiated via mapped items.

* **New Features**
  * Surface textures (embedded PNG/JPEG and pixel textures) are decoded and rendered with per-vertex UVs and RGBA textures.
  * Dedicated textured render path and GPU upload preserve picking, clipping, and correct display.

* **Tests**
  * Added regression tests for type-only geometry and surface texture decoding/rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->