### PR TITLE
feat: render IfcBlobTexture / IfcPixelTexture on tessellated geometry (#961)

### DIFF
--- a/.changeset/nine-six-one-tessellation-textures.md
+++ b/.changeset/nine-six-one-tessellation-textures.md
@@ -1,0 +1,23 @@
+---
+"@ifc-lite/wasm": minor
+"@ifc-lite/geometry": minor
+"@ifc-lite/renderer": minor
+---
+
+Render IFC surface textures on tessellated geometry (#961).
+
+`IfcBlobTexture` (embedded PNG) and `IfcPixelTexture` (raw pixel literals) are now
+decoded to RGBA8 entirely in Rust (the `png` crate, already in the tree) and the
+per-triangle `IfcIndexedTriangleTextureMap` / `IfcTextureVertexList` coordinates
+are emitted as per-vertex UVs in lockstep with the flat-shaded tessellation (the
+`IfcCartesianTransformationOperator2D` scale is applied; the whole-shell
+orientation flip is mirrored onto the texture indices so UVs stay aligned). The
+decoded RGBA + UVs ride on `MeshData` across the wasm boundary; the WebGPU
+renderer gains a dedicated textured pipeline that uploads the texture and draws
+textured meshes in their own sub-pass, preserving picking, section-clipping and
+flat-shading. The buildingSMART annex-E "tessellated shape with style" boilers
+now render textured instead of flat white.
+
+All image/texture decoding lives in Rust so the server, CLI and SDK get the same
+result — the browser only uploads the bytes to the GPU. `IfcImageTexture`
+(external URL) remains out of scope (needs an async fetch resolver).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2473,6 +2473,7 @@ dependencies = [
  "ifc-lite-core",
  "manifold-csg",
  "nalgebra",
+ "png 0.17.16",
  "rayon",
  "rustc-hash",
  "smallvec",

--- a/packages/geometry/src/geometry-coordinate.ts
+++ b/packages/geometry/src/geometry-coordinate.ts
@@ -65,7 +65,7 @@ export function convertMeshCollectionToBatch(
             ? [shadingArray[0], shadingArray[1], shadingArray[2], shadingArray[3]]
             : undefined;
 
-        batch.push({
+        const meshData: MeshData = {
           expressId: mesh.expressId,
           ifcType: mesh.ifcType,
           positions: mesh.positions,
@@ -73,7 +73,23 @@ export function convertMeshCollectionToBatch(
           indices: mesh.indices,
           color: [mesh.color[0], mesh.color[1], mesh.color[2], mesh.color[3]],
           ...(shadingColor ? { shadingColor } : {}),
-        });
+        };
+
+        // #961: copy the Rust-decoded surface texture + per-vertex UVs (the
+        // getters return empty for the ~all untextured meshes). The browser
+        // only uploads `rgba` to a GPU texture — no image decoding in JS.
+        if ((mesh as { hasTexture?: boolean }).hasTexture) {
+          meshData.uvs = mesh.uvs;
+          meshData.texture = {
+            rgba: mesh.textureRgba,
+            width: mesh.textureWidth,
+            height: mesh.textureHeight,
+            repeatS: mesh.textureRepeatS,
+            repeatT: mesh.textureRepeatT,
+          };
+        }
+
+        batch.push(meshData);
       } finally {
         mesh.free();
       }

--- a/packages/geometry/src/geometry-parallel.ts
+++ b/packages/geometry/src/geometry-parallel.ts
@@ -183,20 +183,17 @@ export async function* processParallel(
           firstBatchByWorker[workerIndex] = elapsed();
           console.log(`[stream] worker[${workerIndex}] first batch @ ${elapsed()}ms (${msg.meshes?.length ?? 0} meshes)`);
         }
-        const meshes: MeshData[] = msg.meshes.map((m: {
-          expressId: number;
-          ifcType?: string;
-          positions: Float32Array;
-          normals: Float32Array;
-          indices: Uint32Array;
-          color: [number, number, number, number];
-        }) => ({
+        const meshes: MeshData[] = msg.meshes.map((m: MeshData) => ({
           expressId: m.expressId,
           ifcType: m.ifcType,
           positions: m.positions instanceof Float32Array ? m.positions : new Float32Array(m.positions),
           normals: m.normals instanceof Float32Array ? m.normals : new Float32Array(m.normals),
           indices: m.indices instanceof Uint32Array ? m.indices : new Uint32Array(m.indices),
           color: m.color,
+          // #961: carry per-vertex UVs + decoded surface texture through to the
+          // renderer (transferables; already typed arrays from the worker).
+          ...(m.uvs ? { uvs: m.uvs } : {}),
+          ...(m.texture ? { texture: m.texture } : {}),
         }));
         if (meshes.length > 0) {
           // Update totalMeshes per batch so consumers see a live

--- a/packages/geometry/src/geometry.worker.ts
+++ b/packages/geometry/src/geometry.worker.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import init, { initSync, IfcAPI } from '@ifc-lite/wasm';
+import type { MeshData } from './types.js';
 
 export interface GeometryWorkerInitMessage {
   type: 'init';
@@ -138,6 +139,9 @@ export interface GeometryWorkerBatchMessage {
     normals: Float32Array;
     indices: Uint32Array;
     color: [number, number, number, number];
+    // #961: optional surface texture + per-vertex UVs (transferables).
+    uvs?: MeshData['uvs'];
+    texture?: MeshData['texture'];
   }[];
 }
 
@@ -335,14 +339,31 @@ function collectMeshes(
     const positions = new Float32Array(mesh.positions);
     const normals = new Float32Array(mesh.normals);
     const indices = new Uint32Array(mesh.indices);
-    session.pendingMeshes.push({
+    const meshData: MeshData = {
       expressId: mesh.expressId,
       ifcType: mesh.ifcType,
       positions, normals, indices,
       color: [mesh.color[0], mesh.color[1], mesh.color[2], mesh.color[3]],
-    });
+    };
     session.pendingTransfers.push(positions.buffer, normals.buffer, indices.buffer);
     session.cumulativeMeshBytes += positions.byteLength + normals.byteLength + indices.byteLength;
+    // #961: surface texture + per-vertex UVs (decoded to RGBA8 in Rust). Carried
+    // as transferables so there is no SAB→scratch copy (see SAB-streaming memo).
+    if (mesh.hasTexture) {
+      const uvs = new Float32Array(mesh.uvs);
+      const rgba = new Uint8Array(mesh.textureRgba);
+      meshData.uvs = uvs;
+      meshData.texture = {
+        rgba,
+        width: mesh.textureWidth,
+        height: mesh.textureHeight,
+        repeatS: mesh.textureRepeatS,
+        repeatT: mesh.textureRepeatT,
+      };
+      session.pendingTransfers.push(uvs.buffer, rgba.buffer);
+      session.cumulativeMeshBytes += uvs.byteLength + rgba.byteLength;
+    }
+    session.pendingMeshes.push(meshData);
     mesh.free();
   }
   collection.free();

--- a/packages/geometry/src/types.ts
+++ b/packages/geometry/src/types.ts
@@ -27,6 +27,24 @@ export interface MeshData {
    *  for every vertex, so picking/selection resolves to the correct individual
    *  entity even though many entities share a single GPU batch. */
   entityIds?: Uint32Array;
+  /** Per-vertex texture coordinates (u, v pairs, 1:1 with positions), present
+   *  only for textured meshes (issue #961). */
+  uvs?: Float32Array;
+  /** Decoded surface texture (IfcBlobTexture / IfcPixelTexture), present only
+   *  for textured meshes (#961). Decoded to RGBA8 entirely in Rust; the
+   *  renderer uploads `rgba` verbatim to a GPU texture. */
+  texture?: MeshTexture;
+}
+
+/** A decoded RGBA8 surface texture attached to a mesh (issue #961). */
+export interface MeshTexture {
+  /** `width * height * 4` bytes, row-major, top-down, straight alpha. */
+  rgba: Uint8Array;
+  width: number;
+  height: number;
+  /** Sampler wrap from `IfcSurfaceTexture.RepeatS/RepeatT` (true = repeat). */
+  repeatS: boolean;
+  repeatT: boolean;
 }
 
 export interface Vec3 {

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -1473,7 +1473,10 @@ export class Renderer {
             // PERFORMANCE FIX: Always use batch rendering when we have batches
             // Apply visibility filtering at the BATCH level instead of creating individual meshes
             // This keeps draw calls at ~50-200 instead of 60K+
-            if (allBatchedMeshes.length > 0) {
+            // #961: also enter this block when there are textured meshes but no
+            // colour batches (e.g. a model that is only a textured type-geometry
+            // boiler) — the textured sub-pass lives inside this block.
+            if (allBatchedMeshes.length > 0 || this.scene.getTexturedMeshes().length > 0) {
                 // Frustum culling for batched meshes - skip entire batches outside the camera view
                 // This is the primary performance optimization for large models (200K+ meshes)
                 const frustum = FrustumUtils.fromViewProjMatrix(viewProj);
@@ -1679,6 +1682,30 @@ export class Renderer {
                 pass.setPipeline(this.pipeline.getPipeline());
                 for (const batch of opaqueBatches) {
                     renderBatch(batch);
+                }
+
+                // #961: textured meshes — dedicated sub-pass right after opaque
+                // batches (writes depth + object-id, so overlay/section/picking
+                // all behave like normal opaque geometry). Each mesh has its own
+                // vertex buffer (with a UV lane), texture, sampler and bindGroup.
+                const texturedMeshes = this.scene.getTexturedMeshes();
+                if (texturedMeshes.length > 0) {
+                    pass.setPipeline(this.pipeline.getTexturedPipeline());
+                    for (const tm of texturedMeshes) {
+                        // Tint multiplies the sampled texel; the IfcColourRgb base
+                        // is white in the annex-E fixtures → texture shows as-is.
+                        tpl[32] = tm.color[0];
+                        tpl[33] = tm.color[1];
+                        tpl[34] = tm.color[2];
+                        tpl[35] = tm.color[3];
+                        device.queue.writeBuffer(tm.uniformBuffer, 0, tpl);
+                        pass.setBindGroup(0, tm.bindGroup);
+                        pass.setVertexBuffer(0, tm.vertexBuffer);
+                        pass.setIndexBuffer(tm.indexBuffer, 'uint32');
+                        pass.drawIndexed(tm.indexCount);
+                    }
+                    // Restore the opaque pipeline for the passes that follow.
+                    pass.setPipeline(this.pipeline.getPipeline());
                 }
 
                 // PERFORMANCE FIX: Render partially visible batches as sub-batches (not individual meshes!)

--- a/packages/renderer/src/pipeline.ts
+++ b/packages/renderer/src/pipeline.ts
@@ -8,6 +8,7 @@
 
 import { WebGPUDevice } from './device.js';
 import { mainShaderSource } from './shaders/main.wgsl.js';
+import { texturedShaderSource } from './shaders/textured.wgsl.js';
 
 export class RenderPipeline {
     private device: GPUDevice;
@@ -16,6 +17,8 @@ export class RenderPipeline {
     private selectionPipeline: GPURenderPipeline;  // Pipeline for selected meshes (renders on top)
     private transparentPipeline: GPURenderPipeline;  // Pipeline for transparent meshes with alpha blending
     private overlayPipeline: GPURenderPipeline;  // Pipeline for color overlays (lens) - renders at exact same depth
+    private texturedPipeline: GPURenderPipeline;  // Pipeline for textured meshes (#961): UV lane + albedo texture/sampler
+    private texturedBindGroupLayout: GPUBindGroupLayout;  // group(0): uniform + texture + sampler
     private depthTexture: GPUTexture;
     private depthTextureView: GPUTextureView;
     // depth-only view of depthTexture for sampling as texture_depth_2d in
@@ -304,6 +307,65 @@ export class RenderPipeline {
 
         this.overlayPipeline = this.device.createRenderPipeline(overlayPipelineDescriptor);
 
+        // ── Textured pipeline (#961) ──
+        // A separate pipeline for meshes carrying an IFC surface texture. It
+        // adds a UV vertex lane and an albedo texture+sampler at group(0)
+        // bindings 1 & 2; everything else (depth, MSAA, both colour targets incl.
+        // the object-id picking target, flat-normal shading, section clip) mirrors
+        // the main opaque pipeline so picking/section/z-fight behave identically.
+        // Textured meshes are rare (a handful per model), so they draw
+        // per-mesh — the 28-byte hot path for the other ~all meshes is untouched.
+        this.texturedBindGroupLayout = this.device.createBindGroupLayout({
+            label: 'textured-bgl',
+            entries: [
+                {
+                    binding: 0,
+                    visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+                    buffer: { type: 'uniform' },
+                },
+                { binding: 1, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: 'float' } },
+                { binding: 2, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' } },
+            ],
+        });
+        const texturedModule = this.device.createShaderModule({
+            label: 'textured-shader',
+            code: texturedShaderSource,
+        });
+        this.texturedPipeline = this.device.createRenderPipeline({
+            label: 'textured-pipeline',
+            layout: this.device.createPipelineLayout({
+                bindGroupLayouts: [this.texturedBindGroupLayout],
+            }),
+            vertex: {
+                module: texturedModule,
+                entryPoint: 'vs_main',
+                buffers: [
+                    {
+                        // position(3f) + normal(3f) + entityId(u32) + uv(2f) = 36 bytes
+                        arrayStride: 36,
+                        attributes: [
+                            { shaderLocation: 0, offset: 0, format: 'float32x3' },
+                            { shaderLocation: 1, offset: 12, format: 'float32x3' },
+                            { shaderLocation: 2, offset: 24, format: 'uint32' },
+                            { shaderLocation: 3, offset: 28, format: 'float32x2' },
+                        ],
+                    },
+                ],
+            },
+            fragment: {
+                module: texturedModule,
+                entryPoint: 'fs_main',
+                targets: [{ format: this.colorFormat }, { format: this.objectIdFormat }],
+            },
+            primitive: { topology: 'triangle-list', cullMode: 'none' },
+            depthStencil: {
+                format: this.depthFormat,
+                depthWriteEnabled: true,
+                depthCompare: 'greater', // Reverse-Z, matches the opaque pipeline
+            },
+            multisample: { count: this.sampleCount },
+        } as GPURenderPipelineDescriptor);
+
         // Create bind group using the explicit bind group layout
         this.bindGroup = this.device.createBindGroup({
             layout: this.bindGroupLayout,
@@ -449,6 +511,30 @@ export class RenderPipeline {
 
     getOverlayPipeline(): GPURenderPipeline {
         return this.overlayPipeline;
+    }
+
+    /** Textured-mesh pipeline (#961). */
+    getTexturedPipeline(): GPURenderPipeline {
+        return this.texturedPipeline;
+    }
+
+    /**
+     * Create a bind group for a textured mesh (#961): the mesh's own uniform
+     * buffer at binding 0, plus its albedo texture view + sampler at 1 & 2.
+     */
+    createTexturedBindGroup(
+        uniformBuffer: GPUBuffer,
+        textureView: GPUTextureView,
+        sampler: GPUSampler,
+    ): GPUBindGroup {
+        return this.device.createBindGroup({
+            layout: this.texturedBindGroupLayout,
+            entries: [
+                { binding: 0, resource: { buffer: uniformBuffer } },
+                { binding: 1, resource: textureView },
+                { binding: 2, resource: sampler },
+            ],
+        });
     }
 
     getDepthTextureView(): GPUTextureView {

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -38,6 +38,22 @@ interface BatchBucket {
  * Accepts the structural shape so it works for both BatchedMesh and
  * Mesh — they each carry the same buffer trio.
  */
+/** A surface-textured mesh (#961): its own interleaved vertex buffer (with a UV
+ *  lane), index buffer, per-mesh uniform buffer, GPU texture + sampler, and a
+ *  bindGroup wiring all three. Drawn per-mesh in a dedicated sub-pass. */
+export interface TexturedMesh {
+  expressId: number;
+  vertexBuffer: GPUBuffer;
+  indexBuffer: GPUBuffer;
+  indexCount: number;
+  uniformBuffer: GPUBuffer;
+  texture: GPUTexture;
+  sampler: GPUSampler;
+  bindGroup: GPUBindGroup;
+  /** Authored tint (multiplies the sampled texel); white = texture passthrough. */
+  color: [number, number, number, number];
+}
+
 function destroyGpuResources(
   m: { vertexBuffer: GPUBuffer; indexBuffer: GPUBuffer; uniformBuffer?: GPUBuffer },
 ): void {
@@ -53,6 +69,7 @@ export class Scene {
   private meshDataBucket: Map<MeshData, BatchBucket> = new Map();   // reverse lookup: MeshData -> owning bucket
   private meshDataMap: Map<number, MeshData[]> = new Map();         // Map expressId -> MeshData[] (for lazy buffer creation, accumulates multiple pieces)
   private boundingBoxes: Map<number, BoundingBox> = new Map();      // Map expressId -> bounding box (computed lazily)
+  private texturedMeshes: TexturedMesh[] = [];                      // #961: IFC surface-textured meshes (own buffers/texture/bindGroup)
 
   // Buffer-size-aware bucket splitting: when a single color group's geometry
   // would exceed the GPU maxBufferSize, overflow is directed to a new
@@ -417,8 +434,26 @@ export class Scene {
 
     const retainStreamingGeometry = !(isStreaming && this.ephemeralStreamingMode);
 
+    // #961: divert meshes carrying an IFC surface texture to the dedicated
+    // textured pipeline. They have no single colour, so they must be kept out
+    // of BOTH the colour buckets AND the streaming-fragment path below —
+    // otherwise a flat-colour copy would be drawn over the texture. Still
+    // register them in meshDataMap (addMeshData) so CPU picking/bbox/frame work.
+    let renderable = meshDataArray;
+    if (meshDataArray.some((m) => m.texture && m.uvs)) {
+      renderable = [];
+      for (const meshData of meshDataArray) {
+        if (meshData.texture && meshData.uvs) {
+          this.createTexturedMesh(meshData, device, pipeline);
+          this.addMeshData(meshData);
+        } else {
+          renderable.push(meshData);
+        }
+      }
+    }
+
     // Route each mesh into a size-aware bucket for its color
-    for (const meshData of meshDataArray) {
+    for (const meshData of renderable) {
       const baseKey = this.colorKey(meshData.color);
       const bucketKey = this.resolveActiveBucket(baseKey, meshData);
 
@@ -450,7 +485,8 @@ export class Scene {
       // STREAMING: Create small fragment batches from ONLY the new meshes.
       // Avoids the O(N²) cost of re-merging all accumulated data every batch.
       // finalizeStreaming() destroys fragments and does one O(N) full merge.
-      this.createStreamingFragments(meshDataArray, device, pipeline);
+      // `renderable` excludes textured meshes (drawn via the textured pipeline).
+      this.createStreamingFragments(renderable, device, pipeline);
       return;
     }
 
@@ -1562,9 +1598,109 @@ export class Scene {
   /**
    * Clear scene
    */
+  /** Textured meshes (#961) for the renderer's dedicated textured sub-pass. */
+  getTexturedMeshes(): readonly TexturedMesh[] {
+    return this.texturedMeshes;
+  }
+
+  /**
+   * Build a textured mesh (#961): interleave position+normal+entityId+uv into one
+   * vertex buffer, upload the decoded RGBA8 texture, create a sampler honouring
+   * the IFC RepeatS/RepeatT wrap, and wire a bindGroup (uniform+texture+sampler).
+   * The per-frame uniform (viewProj/section/flags + colour tint) is written by
+   * the renderer each frame, mirroring how colour batches are driven.
+   */
+  private createTexturedMesh(meshData: MeshData, device: GPUDevice, pipeline: RenderPipeline): void {
+    const tex = meshData.texture;
+    const uvs = meshData.uvs;
+    if (!tex || !uvs) return;
+
+    const positions = meshData.positions;
+    const normals = meshData.normals;
+    const vertexCount = positions.length / 3;
+    if (vertexCount === 0 || meshData.indices.length === 0) return;
+
+    // Interleave: [px,py,pz, nx,ny,nz, entityId(u32), u,v] = 9 * 4 = 36 bytes.
+    const interleaved = new ArrayBuffer(vertexCount * 36);
+    const f = new Float32Array(interleaved);
+    const u = new Uint32Array(interleaved);
+    const entityIds = meshData.entityIds;
+    for (let i = 0; i < vertexCount; i++) {
+      const o = i * 9;
+      f[o] = positions[i * 3];
+      f[o + 1] = positions[i * 3 + 1];
+      f[o + 2] = positions[i * 3 + 2];
+      f[o + 3] = normals[i * 3] ?? 0;
+      f[o + 4] = normals[i * 3 + 1] ?? 0;
+      f[o + 5] = normals[i * 3 + 2] ?? 0;
+      u[o + 6] = entityIds ? entityIds[i] : meshData.expressId;
+      f[o + 7] = uvs[i * 2] ?? 0;
+      f[o + 8] = uvs[i * 2 + 1] ?? 0;
+    }
+
+    const vertexBuffer = device.createBuffer({
+      size: interleaved.byteLength,
+      usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+    });
+    device.queue.writeBuffer(vertexBuffer, 0, interleaved);
+
+    const indexBuffer = device.createBuffer({
+      size: meshData.indices.byteLength,
+      usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST,
+    });
+    device.queue.writeBuffer(indexBuffer, 0, meshData.indices);
+
+    // Upload the Rust-decoded RGBA8 verbatim — no image decoding in JS.
+    const texture = device.createTexture({
+      size: { width: tex.width, height: tex.height },
+      format: 'rgba8unorm',
+      usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST,
+    });
+    device.queue.writeTexture(
+      { texture },
+      tex.rgba,
+      { bytesPerRow: tex.width * 4, rowsPerImage: tex.height },
+      { width: tex.width, height: tex.height },
+    );
+
+    const wrap = (repeat: boolean): GPUAddressMode => (repeat ? 'repeat' : 'clamp-to-edge');
+    const sampler = device.createSampler({
+      addressModeU: wrap(tex.repeatS),
+      addressModeV: wrap(tex.repeatT),
+      magFilter: 'linear',
+      minFilter: 'linear',
+      mipmapFilter: 'linear',
+    });
+
+    const uniformBuffer = device.createBuffer({
+      size: pipeline.getUniformBufferSize(),
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+    const bindGroup = pipeline.createTexturedBindGroup(uniformBuffer, texture.createView(), sampler);
+
+    this.texturedMeshes.push({
+      expressId: meshData.expressId,
+      vertexBuffer,
+      indexBuffer,
+      indexCount: meshData.indices.length,
+      uniformBuffer,
+      texture,
+      sampler,
+      bindGroup,
+      color: meshData.color,
+    });
+  }
+
   clear(): void {
     for (const mesh of this.meshes) destroyGpuResources(mesh);
     for (const batch of this.batchedMeshes) destroyGpuResources(batch);
+    for (const tm of this.texturedMeshes) {
+      tm.vertexBuffer.destroy();
+      tm.indexBuffer.destroy();
+      tm.uniformBuffer.destroy();
+      tm.texture.destroy();
+    }
+    this.texturedMeshes = [];
     // Clear partial batch cache
     for (const batch of this.partialBatchCache.values()) destroyGpuResources(batch);
     // Destroy streaming fragments (already included in batchedMeshes, but tracked separately)

--- a/packages/renderer/src/shaders/textured.wgsl.ts
+++ b/packages/renderer/src/shaders/textured.wgsl.ts
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Textured variant of the main PBR shader (issue #961).
+ *
+ * Derived from `mainShaderSource` by targeted, anchored transforms rather than a
+ * copy, so the lighting / section-clip / flat-normal / object-id-picking /
+ * z-fight logic stays single-source in `main.wgsl.ts` and can't drift. Each
+ * transform asserts its anchor exists — if `main.wgsl.ts` is edited in a way
+ * that moves an anchor, the build fails loudly here instead of silently
+ * shipping a stale textured shader.
+ *
+ * Additions over the base shader:
+ *  - a `uv` vertex attribute (@location 3) threaded through to the fragment;
+ *  - an albedo `texture_2d` + `sampler` at group(0) bindings 1 & 2;
+ *  - the surface albedo becomes `texture(uv) * baseColor` — `baseColor` stays
+ *    the authored `IfcColourRgb` (white in the annex-E fixtures), so a white
+ *    tint passes the texture through unchanged while a coloured surface style
+ *    still tints it.
+ */
+import { mainShaderSource } from './main.wgsl.js';
+
+function replaceOnce(src: string, find: string, repl: string, label: string): string {
+  const idx = src.indexOf(find);
+  if (idx === -1) {
+    throw new Error(
+      `textured.wgsl: anchor "${label}" not found — main.wgsl.ts changed; update the textured-shader derivation.`,
+    );
+  }
+  if (src.indexOf(find, idx + find.length) !== -1) {
+    throw new Error(`textured.wgsl: anchor "${label}" is not unique — tighten the derivation.`);
+  }
+  return src.slice(0, idx) + repl + src.slice(idx + find.length);
+}
+
+function deriveTexturedShader(): string {
+  let s = mainShaderSource;
+
+  // 1. Albedo texture + sampler bindings (same group(0) as the uniform).
+  s = replaceOnce(
+    s,
+    '@binding(0) @group(0) var<uniform> uniforms: Uniforms;',
+    '@binding(0) @group(0) var<uniform> uniforms: Uniforms;\n' +
+      '        @binding(1) @group(0) var albedoTex: texture_2d<f32>;\n' +
+      '        @binding(2) @group(0) var albedoSampler: sampler;',
+    'uniform binding',
+  );
+
+  // 2. UV vertex attribute on VertexInput.
+  s = replaceOnce(
+    s,
+    '          @location(2) entityId: u32,\n        }\n\n        struct VertexOutput {',
+    '          @location(2) entityId: u32,\n          @location(3) uv: vec2<f32>,\n        }\n\n        struct VertexOutput {',
+    'VertexInput uv',
+  );
+
+  // 3. UV interpolant on VertexOutput.
+  s = replaceOnce(
+    s,
+    '          @location(3) viewPos: vec3<f32>,  // For edge detection\n        }',
+    '          @location(3) viewPos: vec3<f32>,  // For edge detection\n          @location(4) uv: vec2<f32>,\n        }',
+    'VertexOutput uv',
+  );
+
+  // 4. Pass UV through the vertex shader.
+  s = replaceOnce(
+    s,
+    '          output.entityId = input.entityId;',
+    '          output.entityId = input.entityId;\n          output.uv = input.uv;',
+    'vs_main uv passthrough',
+  );
+
+  // 5. Sample the texture; multiply by the authored tint (white = passthrough).
+  s = replaceOnce(
+    s,
+    'var baseColor = uniforms.baseColor.rgb;',
+    'var baseColor = textureSample(albedoTex, albedoSampler, input.uv).rgb * uniforms.baseColor.rgb;',
+    'albedo sample',
+  );
+
+  return s;
+}
+
+export const texturedShaderSource = deriveTexturedShader();

--- a/packages/wasm/test/textures.test.mjs
+++ b/packages/wasm/test/textures.test.mjs
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Issue #961 — surface textures reach the LIVE VIEWER path. The browser renders
+ * through `buildPrePassOnce` + `processGeometryBatch`; this test drives that
+ * exact path and asserts the boiler mesh carries the Rust-decoded RGBA texture
+ * + per-vertex UVs (the renderer then uploads `textureRgba` to a GPU texture).
+ *
+ * IfcBlobTexture (PNG, decoded in Rust via the `png` crate) and IfcPixelTexture
+ * (raw pixel literals) both resolve to RGBA8 with UVs 1:1 with positions.
+ */
+
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'node:test';
+
+const packageDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const rootDir = join(packageDir, '..', '..');
+const wasmPath = join(packageDir, 'pkg', 'ifc-lite_bg.wasm');
+const wasmJsPath = join(packageDir, 'pkg', 'ifc-lite.js');
+const annexDir = join(rootDir, 'tests', 'models', 'buildingsmart', 'annex_e', 'tessellated-shape-with-style');
+
+const BOILER_TYPE_ID = 43;
+
+function texturedBoiler(api, content) {
+  const bytes = new TextEncoder().encode(content);
+  const pre = api.buildPrePassOnce(bytes);
+  const col = api.processGeometryBatch(
+    bytes, pre.jobs, pre.unitScale,
+    pre.rtcOffset[0], pre.rtcOffset[1], pre.rtcOffset[2], pre.needsShift,
+    pre.voidKeys, pre.voidCounts, pre.voidValues, pre.styleIds, pre.styleColors,
+  );
+  let found = null;
+  for (let i = 0; i < col.length; i++) {
+    const m = col.get(i);
+    if (m && m.expressId === BOILER_TYPE_ID && m.hasTexture) {
+      found = {
+        tris: m.triangleCount,
+        uvsLen: m.uvs.length,
+        verts: m.vertexCount,
+        width: m.textureWidth,
+        height: m.textureHeight,
+        rgbaLen: m.textureRgba.length,
+      };
+    }
+    m.free();
+  }
+  col.free();
+  if (api.clearPrePassCache) api.clearPrePassCache();
+  return found;
+}
+
+describe('@ifc-lite/wasm surface textures on the viewer path (#961)', () => {
+  for (const name of ['tessellation-with-blob-texture.ifc', 'tessellation-with-pixel-texture.ifc']) {
+    it(`decodes + attaches a texture for ${name}`, async (t) => {
+      if (!existsSync(wasmPath) || !existsSync(wasmJsPath)) {
+        t.skip('wasm bundle not built — run `bash scripts/build-wasm.sh`');
+        return;
+      }
+      const fixturePath = join(annexDir, name);
+      if (!existsSync(fixturePath)) {
+        t.skip('fixture missing — run `pnpm fixtures`');
+        return;
+      }
+      const { initSync, IfcAPI } = await import(wasmJsPath);
+      initSync(readFileSync(wasmPath));
+      const api = new IfcAPI();
+
+      const boiler = texturedBoiler(api, readFileSync(fixturePath, 'utf8'));
+      assert.ok(boiler, `boiler #${BOILER_TYPE_ID} should carry a texture`);
+      assert.ok(boiler.width > 0 && boiler.height > 0, 'texture has size');
+      assert.equal(boiler.rgbaLen, boiler.width * boiler.height * 4, 'RGBA8 buffer is w*h*4');
+      assert.equal(boiler.uvsLen, boiler.verts * 2, 'UVs are 1:1 with vertices (u,v per vertex)');
+    });
+  }
+});

--- a/rust/geometry/Cargo.toml
+++ b/rust/geometry/Cargo.toml
@@ -50,6 +50,11 @@ rayon = "1.10"
 # Fast hashing
 rustc-hash = "2.1"
 
+# PNG decode for IfcBlobTexture (issue #961). Already in the dependency tree
+# (transitive), so it adds no new wasm weight. Pure-Rust inflate
+# (miniz_oxide / fdeflate) — wasm-safe.
+png = "0.17"
+
 # Small vector optimization for frequently allocated small collections
 smallvec = "1.13"
 

--- a/rust/geometry/src/lib.rs
+++ b/rust/geometry/src/lib.rs
@@ -110,8 +110,9 @@ pub use mesh::{CoordinateShift, Mesh, SubMesh, SubMeshCollection};
 pub use processors::{
     AdvancedBrepProcessor, BooleanClippingProcessor, ExtrudedAreaSolidProcessor,
     ExtrudedAreaSolidTaperedProcessor, FaceBasedSurfaceModelProcessor, FacetedBrepProcessor,
-    MappedItemProcessor, PolygonalFaceSetProcessor, RevolvedAreaSolidProcessor,
-    SurfaceOfLinearExtrusionProcessor, SweptDiskSolidProcessor, TriangulatedFaceSetProcessor,
+    build_texture_index, MappedItemProcessor, MeshTexture, PolygonalFaceSetProcessor,
+    ResolvedTextureMap, RevolvedAreaSolidProcessor, SurfaceOfLinearExtrusionProcessor,
+    SweptDiskSolidProcessor, TriangulatedFaceSetProcessor,
 };
 pub use alignment::{AlignmentCurve, AlignmentFrame};
 pub use profile::{Profile2D, Profile2DWithVoids, ProfileType, VoidInfo};

--- a/rust/geometry/src/processors/mod.rs
+++ b/rust/geometry/src/processors/mod.rs
@@ -32,6 +32,7 @@ mod sectioned;
 mod surface;
 mod swept;
 mod tessellated;
+pub mod texture;
 
 #[cfg(test)]
 mod tests;
@@ -51,6 +52,7 @@ pub use sectioned::SectionedSolidHorizontalProcessor;
 pub use surface::SurfaceOfLinearExtrusionProcessor;
 pub use swept::{RevolvedAreaSolidProcessor, SweptDiskSolidProcessor};
 pub use tessellated::{PolygonalFaceSetProcessor, TriangulatedFaceSetProcessor};
+pub use texture::{build_texture_index, MeshTexture, ResolvedTextureMap};
 
 /// Extract CoordIndex bytes from IfcTriangulatedFaceSet raw entity
 ///

--- a/rust/geometry/src/processors/tessellated.rs
+++ b/rust/geometry/src/processors/tessellated.rs
@@ -20,16 +20,17 @@ impl TriangulatedFaceSetProcessor {
     pub fn new() -> Self {
         Self
     }
-}
 
-impl GeometryProcessor for TriangulatedFaceSetProcessor {
-    #[inline]
-    fn process(
-        &self,
+    /// Parse an `IfcTriangulatedFaceSet`'s positions + triangle indices and
+    /// apply the closed-shell outward orientation. Returns
+    /// `(positions, indices, flipped)` where `flipped` is whether the whole
+    /// shell was winding-flipped — the texture path needs it to keep the
+    /// parallel `TexCoordIndex` in lockstep (#961). Shared by `process` and
+    /// [`Self::process_with_texture`] so there is one parse/orient code path.
+    fn parse_positions_and_orient(
         entity: &DecodedEntity,
         decoder: &mut EntityDecoder,
-        _schema: &IfcSchema,
-    ) -> Result<Mesh> {
+    ) -> Result<(Vec<f32>, Vec<u32>, bool)> {
         // IfcTriangulatedFaceSet attributes:
         // 0: Coordinates (IfcCartesianPointList3D)
         // 1: Normals (optional)
@@ -111,9 +112,54 @@ impl GeometryProcessor for TriangulatedFaceSetProcessor {
             .unwrap_or(false);
 
         let mut indices = indices;
-        if !is_open {
-            PolygonalFaceSetProcessor::orient_closed_shell_outward(&positions, &mut indices);
+        let flipped = if !is_open {
+            PolygonalFaceSetProcessor::orient_closed_shell_outward(&positions, &mut indices)
+        } else {
+            false
+        };
+
+        Ok((positions, indices, flipped))
+    }
+
+    /// Tessellate a textured `IfcTriangulatedFaceSet` (#961): builds the same
+    /// flat-shaded mesh as [`process`] plus a per-vertex UV array aligned 1:1
+    /// with the emitted vertices. `map.tex_coord_index` is parallel to the
+    /// original `CoordIndex`; the same whole-shell winding flip is applied to it
+    /// so corners stay aligned after orientation.
+    pub fn process_with_texture(
+        &self,
+        entity: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+        map: &crate::processors::texture::ResolvedTextureMap,
+    ) -> Result<(Mesh, Vec<f32>)> {
+        let (positions, indices, flipped) = Self::parse_positions_and_orient(entity, decoder)?;
+        let mut tex_coord_index = map.tex_coord_index.clone();
+        if flipped {
+            for tri in tex_coord_index.iter_mut() {
+                tri.swap(1, 2);
+            }
         }
+        let (mut mesh, uvs) = PolygonalFaceSetProcessor::build_flat_shaded_mesh_with_uvs(
+            &positions,
+            &indices,
+            &map.tex_coords,
+            &tex_coord_index,
+            map,
+        );
+        mesh.validate_indices();
+        Ok((mesh, uvs))
+    }
+}
+
+impl GeometryProcessor for TriangulatedFaceSetProcessor {
+    #[inline]
+    fn process(
+        &self,
+        entity: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+        _schema: &IfcSchema,
+    ) -> Result<Mesh> {
+        let (positions, indices, _flipped) = Self::parse_positions_and_orient(entity, decoder)?;
 
         // Flat-shade by duplicating vertices per-triangle. Without this, the
         // downstream per-vertex normal accumulator (`csg::calculate_normals`)
@@ -427,14 +473,18 @@ impl PolygonalFaceSetProcessor {
     }
 
     #[inline]
-    fn orient_closed_shell_outward(positions: &[f32], indices: &mut [u32]) {
+    /// Flip every triangle's winding to face outward when the shell is
+    /// inward-facing. Returns `true` if a (whole-shell) flip was applied — the
+    /// texture path needs this to swap the parallel `TexCoordIndex` in lockstep
+    /// (issue #961), or corners 1/2 of the UVs mirror on a flipped shell.
+    pub(crate) fn orient_closed_shell_outward(positions: &[f32], indices: &mut [u32]) -> bool {
         if indices.len() < 3 || positions.len() < 9 {
-            return;
+            return false;
         }
 
         let vertex_count = positions.len() / 3;
         if vertex_count == 0 {
-            return;
+            return false;
         }
 
         // Mesh centroid
@@ -498,7 +548,9 @@ impl PolygonalFaceSetProcessor {
             for tri in indices.chunks_exact_mut(3) {
                 tri.swap(1, 2);
             }
+            return true;
         }
+        false
     }
 
     #[inline]
@@ -564,6 +616,86 @@ impl PolygonalFaceSetProcessor {
             indices: flat_indices,
             rtc_applied: false,
         }
+    }
+
+    /// Like [`Self::build_flat_shaded_mesh`] but also emits a per-vertex UV
+    /// array aligned 1:1 with the duplicated vertices (issue #961).
+    ///
+    /// `tex_coord_index` is parallel to `indices` (and already winding-flipped
+    /// to match it); each triangle's three 1-based entries index `tex_coords`.
+    /// Triangles dropped by the out-of-range vertex guard are dropped from both
+    /// positions and UVs in lockstep, so the UV/vertex alignment is exact.
+    /// Out-of-range texcoord corners fall back to (0, 0).
+    pub(crate) fn build_flat_shaded_mesh_with_uvs(
+        positions: &[f32],
+        indices: &[u32],
+        tex_coords: &[[f32; 2]],
+        tex_coord_index: &[[u32; 3]],
+        map: &crate::processors::texture::ResolvedTextureMap,
+    ) -> (Mesh, Vec<f32>) {
+        let mut flat_positions: Vec<f32> = Vec::with_capacity(indices.len() * 3);
+        let mut flat_normals: Vec<f32> = Vec::with_capacity(indices.len() * 3);
+        let mut flat_indices: Vec<u32> = Vec::with_capacity(indices.len());
+        let mut uvs: Vec<f32> = Vec::with_capacity((indices.len() / 3) * 6);
+
+        let vertex_count = positions.len() / 3;
+        let mut next_index: u32 = 0;
+
+        for (tri_i, tri) in indices.chunks_exact(3).enumerate() {
+            let i0 = tri[0] as usize;
+            let i1 = tri[1] as usize;
+            let i2 = tri[2] as usize;
+            if i0 >= vertex_count || i1 >= vertex_count || i2 >= vertex_count {
+                continue;
+            }
+
+            // Face normal — identical computation to build_flat_shaded_mesh.
+            let p0 = (positions[i0 * 3] as f64, positions[i0 * 3 + 1] as f64, positions[i0 * 3 + 2] as f64);
+            let p1 = (positions[i1 * 3] as f64, positions[i1 * 3 + 1] as f64, positions[i1 * 3 + 2] as f64);
+            let p2 = (positions[i2 * 3] as f64, positions[i2 * 3 + 1] as f64, positions[i2 * 3 + 2] as f64);
+            let e1 = (p1.0 - p0.0, p1.1 - p0.1, p1.2 - p0.2);
+            let e2 = (p2.0 - p0.0, p2.1 - p0.1, p2.2 - p0.2);
+            let nx = e1.1 * e2.2 - e1.2 * e2.1;
+            let ny = e1.2 * e2.0 - e1.0 * e2.2;
+            let nz = e1.0 * e2.1 - e1.1 * e2.0;
+            let len = (nx * nx + ny * ny + nz * nz).sqrt();
+            let (nx, ny, nz) = if len > 1e-12 {
+                (nx / len, ny / len, nz / len)
+            } else {
+                (0.0, 0.0, 1.0)
+            };
+
+            let tri_uv = tex_coord_index.get(tri_i);
+            for (corner, &idx) in [i0, i1, i2].iter().enumerate() {
+                flat_positions.push(positions[idx * 3]);
+                flat_positions.push(positions[idx * 3 + 1]);
+                flat_positions.push(positions[idx * 3 + 2]);
+                flat_normals.push(nx as f32);
+                flat_normals.push(ny as f32);
+                flat_normals.push(nz as f32);
+                let uv = tri_uv
+                    .and_then(|t| {
+                        let one_based = t[corner] as usize;
+                        tex_coords.get(one_based.checked_sub(1)?).copied()
+                    })
+                    .map(|raw| map.transform_uv(raw))
+                    .unwrap_or([0.0, 0.0]);
+                uvs.push(uv[0]);
+                uvs.push(uv[1]);
+                flat_indices.push(next_index);
+                next_index += 1;
+            }
+        }
+
+        (
+            Mesh {
+                positions: flat_positions,
+                normals: flat_normals,
+                indices: flat_indices,
+                rtc_applied: false,
+            },
+            uvs,
+        )
     }
 }
 

--- a/rust/geometry/src/processors/texture.rs
+++ b/rust/geometry/src/processors/texture.rs
@@ -1,0 +1,348 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! IFC surface-texture resolution (issue #961).
+//!
+//! Decodes `IfcBlobTexture` (embedded PNG) and `IfcPixelTexture` (raw pixels)
+//! to RGBA8, and resolves `IfcIndexedTriangleTextureMap` per-triangle texture
+//! coordinates aligned with the tessellated face set. All texture logic lives
+//! in Rust so the server, CLI, SDK and the browser (wasm) path share one
+//! implementation — no Rust/TS drift. The browser layer only uploads the
+//! decoded RGBA to a GPU texture; it performs no IFC or image decoding.
+//!
+//! `IfcImageTexture` (external URL) is intentionally out of scope here — it
+//! needs an async fetch resolver outside the geometry pipeline; tracked as a
+//! follow-up.
+
+use ifc_lite_core::{DecodedEntity, EntityDecoder, EntityScanner, IfcType};
+use rustc_hash::FxHashMap;
+
+/// A decoded RGBA8 image ready for GPU upload.
+#[derive(Debug, Clone)]
+pub struct MeshTexture {
+    /// `width * height * 4` bytes, row-major, top-down, straight alpha.
+    pub rgba: Vec<u8>,
+    pub width: u32,
+    pub height: u32,
+    /// `IfcSurfaceTexture.RepeatS/RepeatT` → sampler wrap (repeat vs clamp).
+    pub repeat_s: bool,
+    pub repeat_t: bool,
+}
+
+/// A fully resolved `IfcIndexedTriangleTextureMap` for one face set.
+#[derive(Debug, Clone)]
+pub struct ResolvedTextureMap {
+    pub texture: MeshTexture,
+    /// `IfcTextureVertexList.TexCoordsList` as `[u, v]` (0-based storage).
+    pub tex_coords: Vec<[f32; 2]>,
+    /// `TexCoordIndex`: per-triangle 1-based indices into `tex_coords`,
+    /// parallel to the face set's `CoordIndex`.
+    pub tex_coord_index: Vec<[u32; 3]>,
+    /// `IfcCartesianTransformationOperator2D` applied to each UV:
+    /// `uv' = origin + scale * (axis ⊗ uv)` where `axis` is the X ref-direction.
+    pub uv_scale: f32,
+    pub uv_origin: [f32; 2],
+    pub uv_axis: [f32; 2],
+}
+
+impl ResolvedTextureMap {
+    /// Apply the 2D transform to a raw `[u, v]`.
+    #[inline]
+    pub fn transform_uv(&self, uv: [f32; 2]) -> [f32; 2] {
+        // axis = (cos, sin) → rotate, then scale, then translate.
+        let (ax, ay) = (self.uv_axis[0], self.uv_axis[1]);
+        let rx = ax * uv[0] - ay * uv[1];
+        let ry = ay * uv[0] + ax * uv[1];
+        [
+            self.uv_origin[0] + self.uv_scale * rx,
+            self.uv_origin[1] + self.uv_scale * ry,
+        ]
+    }
+}
+
+/// Decode a STEP binary literal as surfaced by the decoder (the parser strips
+/// the surrounding double quotes; the first hex character is the count of
+/// unused leading bits — `0` for the byte-aligned data every IFC texture
+/// fixture uses). Strips that leading character and hex-decodes the remainder
+/// pairwise. Returns the raw bytes (e.g. a complete PNG file for a blob, or one
+/// pixel's colour components for a pixel literal).
+pub fn decode_step_binary(s: &str) -> Vec<u8> {
+    let s = s.trim().trim_matches('"');
+    if s.len() < 3 {
+        return Vec::new();
+    }
+    let hex = s.as_bytes();
+    let mut out = Vec::with_capacity(hex.len() / 2);
+    // Skip index 0 (the unused-bits indicator); decode the rest in pairs.
+    let mut i = 1;
+    while i + 1 < hex.len() {
+        match (hex_val(hex[i]), hex_val(hex[i + 1])) {
+            (Some(h), Some(l)) => out.push((h << 4) | l),
+            _ => break,
+        }
+        i += 2;
+    }
+    out
+}
+
+#[inline]
+fn hex_val(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// Decode a PNG byte buffer to RGBA8. Returns `(rgba, width, height)`.
+fn decode_png(bytes: &[u8]) -> Option<(Vec<u8>, u32, u32)> {
+    let mut decoder = png::Decoder::new(bytes);
+    // EXPAND: palette → RGB, sub-8-bit grayscale → 8-bit, tRNS → alpha.
+    // STRIP_16: 16-bit channels → 8-bit. Leaves Rgb/Rgba/Grayscale/GA at 8-bit.
+    decoder.set_transformations(png::Transformations::EXPAND | png::Transformations::STRIP_16);
+    let mut reader = decoder.read_info().ok()?;
+    let mut buf = vec![0u8; reader.output_buffer_size()];
+    let info = reader.next_frame(&mut buf).ok()?;
+    let (w, h) = (info.width, info.height);
+    let px = (w as usize) * (h as usize);
+    let src = &buf[..info.buffer_size()];
+    let mut rgba = Vec::with_capacity(px * 4);
+    match info.color_type {
+        png::ColorType::Rgba => rgba.extend_from_slice(&src[..px * 4]),
+        png::ColorType::Rgb => {
+            for c in src.chunks_exact(3) {
+                rgba.extend_from_slice(&[c[0], c[1], c[2], 255]);
+            }
+        }
+        png::ColorType::Grayscale => {
+            for &g in src.iter() {
+                rgba.extend_from_slice(&[g, g, g, 255]);
+            }
+        }
+        png::ColorType::GrayscaleAlpha => {
+            for c in src.chunks_exact(2) {
+                rgba.extend_from_slice(&[c[0], c[0], c[0], c[1]]);
+            }
+        }
+        // EXPAND should have removed Indexed; bail if a decoder ever leaves it.
+        png::ColorType::Indexed => return None,
+    }
+    if rgba.len() != px * 4 {
+        return None;
+    }
+    Some((rgba, w, h))
+}
+
+/// Decode `IfcBlobTexture` → RGBA8. Attributes (IFC4):
+/// RepeatS(0), RepeatT(1), Mode(2), TextureTransform(3), Parameter(4),
+/// RasterFormat(5), RasterCode(6).
+fn decode_blob_texture(entity: &DecodedEntity) -> Option<MeshTexture> {
+    let raster_code = entity.get(6).and_then(|a| a.as_string())?;
+    let bytes = decode_step_binary(raster_code);
+    if bytes.len() < 8 {
+        return None;
+    }
+    // Only PNG is handled here (RasterFormat == 'PNG'); the magic check guards
+    // against other RasterFormats slipping through.
+    const PNG_MAGIC: [u8; 8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+    if bytes[..8] != PNG_MAGIC {
+        return None;
+    }
+    let (rgba, width, height) = decode_png(&bytes)?;
+    Some(MeshTexture {
+        rgba,
+        width,
+        height,
+        repeat_s: read_bool(entity, 0).unwrap_or(true),
+        repeat_t: read_bool(entity, 1).unwrap_or(true),
+    })
+}
+
+/// Decode `IfcPixelTexture` → RGBA8. Attributes (IFC4):
+/// RepeatS(0), RepeatT(1), Mode(2), TextureTransform(3), Parameter(4),
+/// Width(5), Height(6), ColourComponents(7), Pixel(8 = list of BINARY).
+fn decode_pixel_texture(entity: &DecodedEntity) -> Option<MeshTexture> {
+    let width = entity.get(5).and_then(|a| a.as_int())? as u32;
+    let height = entity.get(6).and_then(|a| a.as_int())? as u32;
+    let components = entity.get(7).and_then(|a| a.as_int())? as usize;
+    if width == 0 || height == 0 || !(1..=4).contains(&components) {
+        return None;
+    }
+    let pixels = entity.get(8).and_then(|a| a.as_list())?;
+    let expected = (width as usize) * (height as usize);
+    let mut rgba = Vec::with_capacity(expected * 4);
+    for px in pixels.iter() {
+        let s = px.as_string()?;
+        let comp = decode_step_binary(s);
+        if comp.len() < components {
+            return None;
+        }
+        // Expand 1..=4 colour components to RGBA8.
+        let (r, g, b, a) = match components {
+            1 => (comp[0], comp[0], comp[0], 255),
+            2 => (comp[0], comp[0], comp[0], comp[1]),
+            3 => (comp[0], comp[1], comp[2], 255),
+            _ => (comp[0], comp[1], comp[2], comp[3]),
+        };
+        rgba.extend_from_slice(&[r, g, b, a]);
+    }
+    if rgba.len() != expected * 4 {
+        return None;
+    }
+    Some(MeshTexture {
+        rgba,
+        width,
+        height,
+        repeat_s: read_bool(entity, 0).unwrap_or(true),
+        repeat_t: read_bool(entity, 1).unwrap_or(true),
+    })
+}
+
+fn read_bool(entity: &DecodedEntity, idx: usize) -> Option<bool> {
+    entity.get(idx).and_then(|a| a.as_enum()).map(|v| v == "T")
+}
+
+/// Resolve an `IfcSurfaceTexture` subtype reference to a decoded image.
+fn resolve_surface_texture(texture_id: u32, decoder: &mut EntityDecoder) -> Option<MeshTexture> {
+    let entity = decoder.decode_by_id(texture_id).ok()?;
+    match entity.ifc_type {
+        IfcType::IfcBlobTexture => decode_blob_texture(&entity),
+        IfcType::IfcPixelTexture => decode_pixel_texture(&entity),
+        // IfcImageTexture (URL) deferred — needs async fetch outside the kernel.
+        _ => None,
+    }
+}
+
+/// Parse the optional `IfcCartesianTransformationOperator2D` texture transform.
+/// Attributes: Axis1(0), Axis2(1), LocalOrigin(2), Scale(3 default 1).
+fn parse_texture_transform(transform_id: u32, decoder: &mut EntityDecoder) -> ([f32; 2], [f32; 2], f32) {
+    let mut origin = [0.0f32, 0.0];
+    let mut axis = [1.0f32, 0.0];
+    let mut scale = 1.0f32;
+    if let Ok(op) = decoder.decode_by_id(transform_id) {
+        if op.ifc_type == IfcType::IfcCartesianTransformationOperator2D {
+            if let Some(scale_v) = op.get(3).and_then(|a| a.as_float()) {
+                scale = scale_v as f32;
+            }
+            if let Some(origin_id) = op.get_ref(2) {
+                if let Some(p) = read_point2(origin_id, decoder) {
+                    origin = p;
+                }
+            }
+            if let Some(axis_id) = op.get_ref(0) {
+                if let Some(d) = read_point2(axis_id, decoder) {
+                    let len = (d[0] * d[0] + d[1] * d[1]).sqrt();
+                    if len > 1e-9 {
+                        axis = [d[0] / len, d[1] / len];
+                    }
+                }
+            }
+        }
+    }
+    (origin, axis, scale)
+}
+
+/// Read a 2D `IfcCartesianPoint` / `IfcDirection` (first two coordinates).
+fn read_point2(id: u32, decoder: &mut EntityDecoder) -> Option<[f32; 2]> {
+    let p = decoder.decode_by_id(id).ok()?;
+    let coords = p.get(0)?.as_list()?;
+    let x = coords.first().and_then(|v| v.as_float())? as f32;
+    let y = coords.get(1).and_then(|v| v.as_float())? as f32;
+    Some([x, y])
+}
+
+/// Resolve a single `IfcIndexedTriangleTextureMap` entity into a
+/// [`ResolvedTextureMap`] keyed by the face set it maps to.
+/// Attributes: Maps(0 = list of IfcSurfaceTexture), MappedTo(1 = face set),
+/// TexCoords(2 = IfcTextureVertexList), TexCoordIndex(3 = list of 3 ints).
+fn resolve_triangle_texture_map(
+    entity: &DecodedEntity,
+    decoder: &mut EntityDecoder,
+) -> Option<(u32, ResolvedTextureMap)> {
+    let face_set_id = entity.get_ref(1)?;
+
+    // Maps[0] → surface texture.
+    let maps = entity.get(0)?.as_list()?;
+    let texture_id = maps.iter().find_map(|m| m.as_entity_ref())?;
+    let texture = resolve_surface_texture(texture_id, decoder)?;
+
+    // Pull the optional 2D transform off the surface texture (attr 3).
+    let (uv_origin, uv_axis, uv_scale) = decoder
+        .decode_by_id(texture_id)
+        .ok()
+        .and_then(|t| t.get_ref(3))
+        .map(|tid| parse_texture_transform(tid, decoder))
+        .unwrap_or(([0.0, 0.0], [1.0, 0.0], 1.0));
+
+    // TexCoords → IfcTextureVertexList.TexCoordsList (attr 0).
+    let tvl_id = entity.get_ref(2)?;
+    let tvl = decoder.decode_by_id(tvl_id).ok()?;
+    let coord_list = tvl.get(0)?.as_list()?;
+    let tex_coords: Vec<[f32; 2]> = coord_list
+        .iter()
+        .filter_map(|c| {
+            let uv = c.as_list()?;
+            let u = uv.first().and_then(|v| v.as_float())? as f32;
+            let v = uv.get(1).and_then(|v| v.as_float())? as f32;
+            Some([u, v])
+        })
+        .collect();
+    if tex_coords.is_empty() {
+        return None;
+    }
+
+    // TexCoordIndex (attr 3) → per-triangle [i, j, k].
+    let index_attr = entity.get(3)?.as_list()?;
+    let tex_coord_index: Vec<[u32; 3]> = index_attr
+        .iter()
+        .filter_map(|tri| {
+            let t = tri.as_list()?;
+            let a = t.first().and_then(|v| v.as_int())? as u32;
+            let b = t.get(1).and_then(|v| v.as_int())? as u32;
+            let c = t.get(2).and_then(|v| v.as_int())? as u32;
+            Some([a, b, c])
+        })
+        .collect();
+    if tex_coord_index.is_empty() {
+        return None;
+    }
+
+    Some((
+        face_set_id,
+        ResolvedTextureMap {
+            texture,
+            tex_coords,
+            tex_coord_index,
+            uv_scale,
+            uv_origin,
+            uv_axis,
+        },
+    ))
+}
+
+/// Scan the model for `IfcIndexedTriangleTextureMap` entities and build an index
+/// keyed by the face set id each one maps to (issue #961). Cheap substring
+/// bail-out keeps untextured files (the overwhelming majority) off the scan.
+pub fn build_texture_index(
+    content: &str,
+    decoder: &mut EntityDecoder,
+) -> FxHashMap<u32, ResolvedTextureMap> {
+    let mut index = FxHashMap::default();
+    if !content.contains("IFCINDEXEDTRIANGLETEXTUREMAP") {
+        return index;
+    }
+    let mut scanner = EntityScanner::new(content);
+    while let Some((id, type_name, start, end)) = scanner.next_entity() {
+        if type_name != "IFCINDEXEDTRIANGLETEXTUREMAP" {
+            continue;
+        }
+        if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
+            if let Some((face_set_id, resolved)) = resolve_triangle_texture_map(&entity, decoder) {
+                index.entry(face_set_id).or_insert(resolved);
+            }
+        }
+    }
+    index
+}

--- a/rust/geometry/src/router/processing.rs
+++ b/rust/geometry/src/router/processing.rs
@@ -1004,6 +1004,24 @@ impl GeometryRouter {
         rep_map: &DecodedEntity,
         decoder: &mut EntityDecoder,
     ) -> Result<Mesh> {
+        let empty = rustc_hash::FxHashMap::default();
+        let (mesh, _uvs, _texture) =
+            self.process_representation_map_with_texture(rep_map, decoder, &empty)?;
+        Ok(mesh)
+    }
+
+    /// Texture-aware variant of [`Self::process_representation_map`] (issue
+    /// #961). When a tessellated face-set item is present in `texture_index`,
+    /// its mesh is built with per-vertex UVs and the decoded image is returned
+    /// alongside. Returns `(mesh, uvs, texture)` where `uvs` is empty and
+    /// `texture` is `None` for untextured representations. UVs are kept aligned
+    /// across mixed textured/untextured items by padding the latter with (0,0).
+    pub fn process_representation_map_with_texture(
+        &self,
+        rep_map: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+        texture_index: &rustc_hash::FxHashMap<u32, crate::processors::texture::ResolvedTextureMap>,
+    ) -> Result<(Mesh, Vec<f32>, Option<crate::processors::MeshTexture>)> {
         // attr 1: MappedRepresentation (IfcShapeRepresentation)
         let mapped_rep_attr = rep_map.get(1).ok_or_else(|| {
             Error::geometry("RepresentationMap missing MappedRepresentation".to_string())
@@ -1018,7 +1036,10 @@ impl GeometryRouter {
             .ok_or_else(|| Error::geometry("Representation missing Items".to_string()))?;
         let items = decoder.resolve_ref_list(items_attr)?;
 
-        let mut mesh = Mesh::new();
+        // Collect each item's sub-mesh + optional UVs first, so UV padding for
+        // mixed textured/untextured items stays aligned regardless of order.
+        let mut parts: Vec<(Mesh, Option<Vec<f32>>)> = Vec::new();
+        let mut texture: Option<crate::processors::MeshTexture> = None;
         for item in items {
             // Skip nested MappedItems to avoid recursion (a type's own
             // representation referencing another mapped item is unusual);
@@ -1026,16 +1047,51 @@ impl GeometryRouter {
             if item.ifc_type == IfcType::IfcMappedItem {
                 continue;
             }
+
+            // Textured tessellated face set → build with per-vertex UVs (#961).
+            if item.ifc_type == IfcType::IfcTriangulatedFaceSet {
+                if let Some(map) = texture_index.get(&item.id) {
+                    let proc = crate::processors::TriangulatedFaceSetProcessor::new();
+                    if let Ok((mut sub_mesh, sub_uvs)) =
+                        proc.process_with_texture(&item, decoder, map)
+                    {
+                        self.scale_mesh(&mut sub_mesh); // UVs are unaffected by scale
+                        if texture.is_none() {
+                            texture = Some(map.texture.clone());
+                        }
+                        parts.push((sub_mesh, Some(sub_uvs)));
+                        continue;
+                    }
+                }
+            }
+
             if let Some(processor) = self.processors.get(&item.ifc_type) {
                 if let Ok(mut sub_mesh) = processor.process(&item, decoder, &self.schema) {
                     sub_mesh.validate_indices();
                     self.scale_mesh(&mut sub_mesh);
-                    mesh.merge(&sub_mesh);
+                    parts.push((sub_mesh, None));
                 }
             }
         }
 
-        // attr 0: MappingOrigin (IfcAxis2Placement3D) — the only transform.
+        let has_uvs = parts.iter().any(|(_, u)| u.is_some());
+        let mut mesh = Mesh::new();
+        let mut uvs: Vec<f32> = Vec::new();
+        for (sub_mesh, sub_uvs) in parts {
+            if has_uvs {
+                match sub_uvs {
+                    Some(u) => uvs.extend_from_slice(&u),
+                    None => {
+                        let verts = sub_mesh.positions.len() / 3;
+                        uvs.extend(std::iter::repeat(0.0f32).take(verts * 2));
+                    }
+                }
+            }
+            mesh.merge(&sub_mesh);
+        }
+
+        // attr 0: MappingOrigin (IfcAxis2Placement3D) — the only 3D transform;
+        // UVs are 2D and unaffected.
         if let Some(origin_attr) = rep_map.get(0) {
             if !origin_attr.is_null() {
                 if let Some(origin) = decoder.resolve_ref(origin_attr)? {
@@ -1048,7 +1104,11 @@ impl GeometryRouter {
             }
         }
 
-        Ok(mesh)
+        if has_uvs {
+            Ok((mesh, uvs, texture))
+        } else {
+            Ok((mesh, Vec::new(), None))
+        }
     }
 
     /// Run an `IfcAlignment` through the dedicated alignment processor, then

--- a/rust/processing/src/processor.rs
+++ b/rust/processing/src/processor.rs
@@ -1338,6 +1338,11 @@ pub fn process_geometry_streaming_filtered_with_options(
     merge_indexed_colours(&mut geometry_style_index, &indexed_colour_index);
     let mut geometry_style_index = Arc::new(geometry_style_index);
     let indexed_colour_full = Arc::new(indexed_colour_full);
+    // #961: decode surface textures (IfcBlobTexture PNG / IfcPixelTexture) and
+    // their per-triangle UV maps once, keyed by face-set id. `build_texture_index`
+    // bails out on a cheap substring check for the (vast majority) untextured
+    // files. Consumed by the type-only render path below.
+    let texture_index = Arc::new(ifc_lite_geometry::build_texture_index(content, &mut decoder));
     // Join the material chain into colours per element (#407). The single
     // opaque-first colour is the general-path element fallback; the full list
     // feeds the opening sub-mesh transparent/opaque split (#913 §2.3).
@@ -1472,6 +1477,7 @@ pub fn process_geometry_streaming_filtered_with_options(
                     geometry_style_index.as_ref(),
                     indexed_colour_full.as_ref(),
                     element_material_colors.as_ref(),
+                    texture_index.as_ref(),
                     site_local_rotation,
                 )
             })
@@ -1575,6 +1581,9 @@ fn process_entity_job(
     geometry_style_index: &FxHashMap<u32, GeometryStyleInfo>,
     indexed_colour_full: &FxHashMap<u32, crate::style::FullIndexedColourMap>,
     element_material_colors: &FxHashMap<u32, Vec<[f32; 4]>>,
+    // Surface textures + UV maps keyed by face-set id (#961). Empty for
+    // untextured models.
+    texture_index: &FxHashMap<u32, ifc_lite_geometry::ResolvedTextureMap>,
     // Present only when the selected coordinate space is `site_local`; rotates
     // mesh vertices into the site's axis frame.
     site_local_rotation: Option<&Vec<f64>>,
@@ -1612,6 +1621,7 @@ fn process_entity_job(
             &local_router,
             &mut local_decoder,
             geometry_style_index,
+            texture_index,
             element_color,
             global_id,
             name,
@@ -1778,6 +1788,7 @@ fn process_type_representation_map_job(
     router: &GeometryRouter,
     decoder: &mut EntityDecoder,
     geometry_style_index: &FxHashMap<u32, GeometryStyleInfo>,
+    texture_index: &FxHashMap<u32, ifc_lite_geometry::ResolvedTextureMap>,
     element_color: [f32; 4],
     global_id: Option<String>,
     name: Option<String>,
@@ -1787,7 +1798,12 @@ fn process_type_representation_map_job(
     let Ok(rep_map) = decoder.decode_by_id(rep_map_id) else {
         return Vec::new();
     };
-    let Ok(mut mesh) = router.process_representation_map(&rep_map, decoder) else {
+    // Texture-aware build (#961): emits per-vertex UVs + the decoded image when
+    // the mapped face set carries an IfcIndexedTriangleTextureMap; otherwise
+    // returns the plain mesh with empty uvs / no texture.
+    let Ok((mut mesh, uvs, texture)) =
+        router.process_representation_map_with_texture(&rep_map, decoder, texture_index)
+    else {
         return Vec::new();
     };
     if mesh.is_empty() {
@@ -1809,6 +1825,22 @@ fn process_type_representation_map_job(
         color,
     )
     .with_element_metadata(global_id, name, presentation_layer);
+
+    // Attach the decoded texture + UVs (#961). `convert_mesh_to_site_local`
+    // rotates positions/normals only; UVs are 2D and pass through unchanged.
+    if let Some(tex) = texture {
+        mesh_data = mesh_data.with_texture(
+            uvs,
+            crate::types::mesh::MeshTextureData {
+                rgba: tex.rgba,
+                width: tex.width,
+                height: tex.height,
+                repeat_s: tex.repeat_s,
+                repeat_t: tex.repeat_t,
+            },
+        );
+    }
+
     convert_mesh_to_site_local(&mut mesh_data, site_local_rotation);
     vec![mesh_data]
 }

--- a/rust/processing/src/types/mesh.rs
+++ b/rust/processing/src/types/mesh.rs
@@ -7,6 +7,20 @@
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
+/// A decoded RGBA8 surface texture attached to a mesh (issue #961).
+/// Decoded entirely in Rust (`IfcBlobTexture` PNG / `IfcPixelTexture` raw); the
+/// browser only uploads `rgba` to a GPU texture — no image logic in TS.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MeshTextureData {
+    /// `width * height * 4` bytes, row-major, top-down, straight alpha.
+    pub rgba: Vec<u8>,
+    pub width: u32,
+    pub height: u32,
+    /// Sampler wrap from `IfcSurfaceTexture.RepeatS/RepeatT`.
+    pub repeat_s: bool,
+    pub repeat_t: bool,
+}
+
 /// Individual mesh data with geometry and metadata.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MeshData {
@@ -41,6 +55,13 @@ pub struct MeshData {
     /// Primarily attached for IfcSpace/IfcZone so downstream tools can build room attribute UIs.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub properties: Option<BTreeMap<String, String>>,
+    /// Per-vertex texture coordinates (u, v pairs, 1:1 with `positions`),
+    /// present only for textured meshes (issue #961).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uvs: Option<Vec<f32>>,
+    /// Decoded surface texture, present only for textured meshes (#961).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub texture: Option<MeshTextureData>,
 }
 
 impl MeshData {
@@ -66,7 +87,17 @@ impl MeshData {
             material_name: None,
             geometry_item_id: None,
             properties: None,
+            uvs: None,
+            texture: None,
         }
+    }
+
+    /// Attach per-vertex UVs + a decoded surface texture (issue #961).
+    /// `uvs` must be 1:1 with `positions` (2 floats per vertex).
+    pub fn with_texture(mut self, uvs: Vec<f32>, texture: MeshTextureData) -> Self {
+        self.uvs = Some(uvs);
+        self.texture = Some(texture);
+        self
     }
 
     /// Set element-level IFC metadata.

--- a/rust/processing/tests/issue_961_textures.rs
+++ b/rust/processing/tests/issue_961_textures.rs
@@ -1,0 +1,85 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Issue #961 — IFC surface textures (IfcBlobTexture PNG / IfcPixelTexture raw)
+//! are decoded to RGBA8 in Rust and attached to the mesh with per-vertex UVs,
+//! 1:1 with positions. buildingSMART annex-E "tessellated shape with style"
+//! fixtures (a textured boiler on an IfcBoilerType, no occurrence).
+//!
+//! Fixtures are downloaded via `pnpm fixtures`; the test skips when absent so
+//! it never fails environmentally (CI provides them).
+
+use ifc_lite_processing::process_geometry;
+use std::path::PathBuf;
+
+const BOILER_TYPE_ID: u32 = 43;
+
+fn fixture(name: &str) -> Option<String> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tests/models/buildingsmart/annex_e/tessellated-shape-with-style")
+        .join(name);
+    std::fs::read_to_string(path).ok()
+}
+
+#[test]
+fn blob_texture_decodes_to_rgba_with_uvs() {
+    let Some(content) = fixture("tessellation-with-blob-texture.ifc") else {
+        eprintln!("skipping: fixture missing — run `pnpm fixtures`");
+        return;
+    };
+    let result = process_geometry(&content);
+    let mesh = result
+        .meshes
+        .iter()
+        .find(|m| m.express_id == BOILER_TYPE_ID)
+        .expect("boiler type #43 should render");
+
+    let texture = mesh.texture.as_ref().expect("blob texture should decode");
+    assert!(texture.width > 0 && texture.height > 0, "decoded image has size");
+    assert_eq!(
+        texture.rgba.len(),
+        (texture.width as usize) * (texture.height as usize) * 4,
+        "RGBA8 buffer is width*height*4"
+    );
+
+    let uvs = mesh.uvs.as_ref().expect("textured mesh carries UVs");
+    assert_eq!(
+        uvs.len(),
+        (mesh.positions.len() / 3) * 2,
+        "UVs are 2 floats per vertex, 1:1 with positions"
+    );
+    // Flat-shaded boiler cylinder: vertices = triangles * 3, all populated.
+    let verts = mesh.positions.len() / 3;
+    assert!(verts >= 3 && verts % 3 == 0, "flat-shaded vertex count, got {verts}");
+    // The *48 texture transform tiles the UVs well beyond [0,1] — confirms the
+    // IfcCartesianTransformationOperator2D scale was applied (sampler repeats).
+    let max_u = uvs.iter().step_by(2).cloned().fold(0.0f32, f32::max);
+    assert!(max_u > 1.5, "UV scale transform (×48) should be applied, max u = {max_u}");
+}
+
+#[test]
+fn pixel_texture_decodes_known_pixels() {
+    let Some(content) = fixture("tessellation-with-pixel-texture.ifc") else {
+        eprintln!("skipping: fixture missing — run `pnpm fixtures`");
+        return;
+    };
+    let result = process_geometry(&content);
+    let mesh = result
+        .meshes
+        .iter()
+        .find(|m| m.express_id == BOILER_TYPE_ID)
+        .expect("boiler type #43 should render");
+
+    let texture = mesh.texture.as_ref().expect("pixel texture should decode");
+    assert_eq!(texture.width, 256, "pixel texture width");
+    assert_eq!(texture.height, 256, "pixel texture height");
+    assert_eq!(texture.rgba.len(), 256 * 256 * 4, "RGBA8 256x256");
+    // First authored pixel is opaque black ("0000000FF" → 00 00 00 FF).
+    assert_eq!(
+        &texture.rgba[0..4],
+        &[0, 0, 0, 255],
+        "first pixel is opaque black"
+    );
+    assert!(mesh.uvs.is_some(), "textured mesh carries UVs");
+}

--- a/rust/wasm-bindings/src/api/gpu_meshes.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes.rs
@@ -1010,6 +1010,8 @@ impl IfcAPI {
                     if !rep_map_ids.is_empty() {
                         let referenced =
                             self.get_or_build_referenced_repmaps(content, &mut decoder);
+                        // Surface textures + UV maps (#961), built once per worker.
+                        let texture_index = self.get_or_build_texture_index(content, &mut decoder);
                         for rm_id in rep_map_ids {
                             if referenced.contains(&rm_id) {
                                 continue;
@@ -1017,8 +1019,12 @@ impl IfcAPI {
                             let Ok(rep_map) = decoder.decode_by_id(rm_id) else {
                                 continue;
                             };
-                            let Ok(mut mesh) =
-                                router.process_representation_map(&rep_map, &mut decoder)
+                            let Ok((mut mesh, uvs, texture)) = router
+                                .process_representation_map_with_texture(
+                                    &rep_map,
+                                    &mut decoder,
+                                    &texture_index,
+                                )
                             else {
                                 continue;
                             };
@@ -1038,7 +1044,18 @@ impl IfcAPI {
                                 .entry(ifc_type)
                                 .or_insert_with(|| ifc_type.name().to_string())
                                 .clone();
-                            mesh_collection.add(MeshDataJs::new(id, ifc_type_name, mesh, color));
+                            let mut mesh_js = MeshDataJs::new(id, ifc_type_name, mesh, color);
+                            if let Some(tex) = texture {
+                                mesh_js.set_texture(
+                                    uvs,
+                                    tex.rgba,
+                                    tex.width,
+                                    tex.height,
+                                    tex.repeat_s,
+                                    tex.repeat_t,
+                                );
+                            }
+                            mesh_collection.add(mesh_js);
                         }
                     }
                     continue;

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -73,6 +73,14 @@ pub struct IfcAPI {
     /// the first type-product job and cleared by `clearPrePassCache`.
     cached_referenced_repmaps:
         std::sync::Mutex<Option<std::sync::Arc<rustc_hash::FxHashSet<u32>>>>,
+
+    /// Lazily-built surface-texture index keyed by face-set id (issue #961):
+    /// decoded RGBA images + per-triangle UV maps from
+    /// `IfcIndexedTriangleTextureMap`. Built once per worker (cheap substring
+    /// bail-out for untextured files) and cleared by `clearPrePassCache`.
+    cached_texture_index: std::sync::Mutex<
+        Option<std::sync::Arc<rustc_hash::FxHashMap<u32, ifc_lite_geometry::ResolvedTextureMap>>>,
+    >,
 }
 
 #[wasm_bindgen]
@@ -89,6 +97,7 @@ impl IfcAPI {
             merge_layers: std::sync::atomic::AtomicBool::new(false),
             cached_parts_to_skip: std::sync::Mutex::new(None),
             cached_referenced_repmaps: std::sync::Mutex::new(None),
+            cached_texture_index: std::sync::Mutex::new(None),
         }
     }
 
@@ -128,6 +137,12 @@ impl IfcAPI {
             .lock()
             .expect("ifc-lite cached_referenced_repmaps Mutex poisoned");
         repmap_slot.take();
+        // The texture index is keyed off the previous load's content; drop it.
+        let mut texture_slot = self
+            .cached_texture_index
+            .lock()
+            .expect("ifc-lite cached_texture_index Mutex poisoned");
+        texture_slot.take();
     }
 
     /// Populate `cached_entity_index` from pre-extracted column arrays.
@@ -280,6 +295,35 @@ impl IfcAPI {
             .cached_referenced_repmaps
             .lock()
             .expect("ifc-lite cached_referenced_repmaps Mutex poisoned");
+        *slot = Some(std::sync::Arc::clone(&arc));
+        arc
+    }
+
+    /// Get or lazily build the surface-texture index keyed by face-set id
+    /// (issue #961): decoded RGBA images + per-triangle UV maps. Cached per
+    /// worker; `build_texture_index` bails out cheaply on untextured files.
+    pub(crate) fn get_or_build_texture_index(
+        &self,
+        content: &str,
+        decoder: &mut ifc_lite_core::EntityDecoder,
+    ) -> std::sync::Arc<rustc_hash::FxHashMap<u32, ifc_lite_geometry::ResolvedTextureMap>> {
+        {
+            let slot = self
+                .cached_texture_index
+                .lock()
+                .expect("ifc-lite cached_texture_index Mutex poisoned");
+            if let Some(existing) = slot.as_ref() {
+                return std::sync::Arc::clone(existing);
+            }
+        }
+
+        let index = ifc_lite_geometry::build_texture_index(content, decoder);
+
+        let arc = std::sync::Arc::new(index);
+        let mut slot = self
+            .cached_texture_index
+            .lock()
+            .expect("ifc-lite cached_texture_index Mutex poisoned");
         *slot = Some(std::sync::Arc::clone(&arc));
         arc
     }

--- a/rust/wasm-bindings/src/zero_copy.rs
+++ b/rust/wasm-bindings/src/zero_copy.rs
@@ -24,6 +24,17 @@ pub struct MeshDataJs {
     /// DiffuseColour (so the two would differ). Consumed by the GLB
     /// exporter's "Shading" colour-source option; renderers ignore it.
     shading_color: Option<[f32; 4]>,
+    /// Per-vertex texture coordinates (u, v pairs, 1:1 with positions),
+    /// present only for textured meshes (#961). Empty otherwise.
+    uvs: Vec<f32>,
+    /// Decoded RGBA8 texture (`width*height*4`), present only for textured
+    /// meshes (#961). Empty otherwise. The browser uploads this verbatim to a
+    /// GPU texture — no image decoding happens in JS.
+    texture_rgba: Vec<u8>,
+    texture_width: u32,
+    texture_height: u32,
+    texture_repeat_s: bool,
+    texture_repeat_t: bool,
 }
 
 #[wasm_bindgen]
@@ -83,6 +94,47 @@ impl MeshDataJs {
     pub fn triangle_count(&self) -> usize {
         self.indices.len() / 3
     }
+
+    /// True when this mesh carries a surface texture (#961).
+    #[wasm_bindgen(getter, js_name = hasTexture)]
+    pub fn has_texture(&self) -> bool {
+        !self.texture_rgba.is_empty()
+    }
+
+    /// Per-vertex texture coordinates as Float32Array (u, v pairs). Empty when
+    /// the mesh is untextured.
+    #[wasm_bindgen(getter)]
+    pub fn uvs(&self) -> js_sys::Float32Array {
+        js_sys::Float32Array::from(&self.uvs[..])
+    }
+
+    /// Decoded RGBA8 texture bytes (`width*height*4`). Empty when untextured.
+    #[wasm_bindgen(getter, js_name = textureRgba)]
+    pub fn texture_rgba(&self) -> js_sys::Uint8Array {
+        js_sys::Uint8Array::from(&self.texture_rgba[..])
+    }
+
+    #[wasm_bindgen(getter, js_name = textureWidth)]
+    pub fn texture_width(&self) -> u32 {
+        self.texture_width
+    }
+
+    #[wasm_bindgen(getter, js_name = textureHeight)]
+    pub fn texture_height(&self) -> u32 {
+        self.texture_height
+    }
+
+    /// Sampler wrap for the S axis (`IfcSurfaceTexture.RepeatS`): true = repeat.
+    #[wasm_bindgen(getter, js_name = textureRepeatS)]
+    pub fn texture_repeat_s(&self) -> bool {
+        self.texture_repeat_s
+    }
+
+    /// Sampler wrap for the T axis (`IfcSurfaceTexture.RepeatT`): true = repeat.
+    #[wasm_bindgen(getter, js_name = textureRepeatT)]
+    pub fn texture_repeat_t(&self) -> bool {
+        self.texture_repeat_t
+    }
 }
 
 impl MeshDataJs {
@@ -124,6 +176,12 @@ impl MeshDataJs {
             indices: mesh.indices,
             color,
             shading_color: None,
+            uvs: Vec::new(),
+            texture_rgba: Vec::new(),
+            texture_width: 0,
+            texture_height: 0,
+            texture_repeat_s: true,
+            texture_repeat_t: true,
         }
     }
 
@@ -132,6 +190,27 @@ impl MeshDataJs {
     /// for the mesh's source geometry id should invoke this after `new`.
     pub fn set_shading_color(&mut self, shading: Option<[f32; 4]>) {
         self.shading_color = shading;
+    }
+
+    /// Attach per-vertex UVs + a decoded RGBA8 texture (#961). UVs are 1:1 with
+    /// `positions` and need no coordinate flip (they are 2D); the winding
+    /// reversal in `new` swaps indices, not vertices, so per-vertex UVs stay
+    /// aligned. Call after `new`.
+    pub fn set_texture(
+        &mut self,
+        uvs: Vec<f32>,
+        rgba: Vec<u8>,
+        width: u32,
+        height: u32,
+        repeat_s: bool,
+        repeat_t: bool,
+    ) {
+        self.uvs = uvs;
+        self.texture_rgba = rgba;
+        self.texture_width = width;
+        self.texture_height = height;
+        self.texture_repeat_s = repeat_s;
+        self.texture_repeat_t = repeat_t;
     }
 }
 
@@ -168,6 +247,12 @@ impl MeshCollection {
             indices: m.indices.clone(),
             color: m.color,
             shading_color: m.shading_color,
+            uvs: m.uvs.clone(),
+            texture_rgba: m.texture_rgba.clone(),
+            texture_width: m.texture_width,
+            texture_height: m.texture_height,
+            texture_repeat_s: m.texture_repeat_s,
+            texture_repeat_t: m.texture_repeat_t,
         })
     }
 
@@ -322,6 +407,12 @@ impl Clone for MeshCollection {
                     indices: m.indices.clone(),
                     color: m.color,
                     shading_color: m.shading_color,
+                    uvs: m.uvs.clone(),
+                    texture_rgba: m.texture_rgba.clone(),
+                    texture_width: m.texture_width,
+                    texture_height: m.texture_height,
+                    texture_repeat_s: m.texture_repeat_s,
+                    texture_repeat_t: m.texture_repeat_t,
                 })
                 .collect(),
             rtc_offset_x: self.rtc_offset_x,


### PR DESCRIPTION
Closes #961.

## Summary

Implements #961 — render IFC surface textures on tessellated geometry. The buildingSMART annex-E "tessellated shape with style" boilers now render **textured** instead of flat white.

**Stacked on #957** (`fix/957-type-geometry-blob-texture`) — textures build on the type-only-geometry foundation. Review/merge #957 first; this PR auto-retargets to `main` after.

## Verified in-browser (WebGPU)

| fixture | before | after |
|---|---|---|
| `tessellation-with-blob-texture.ifc` (PNG) | flat white | textured ✅ |
| `tessellation-with-pixel-texture.ifc` (raw pixels) | flat white | textured ✅ |
| untextured models | — | unchanged ✅ (no regression) |

Picking, section-clipping and flat-shading still work on textured meshes (the textured shader is derived from `main.wgsl` so those stay single-source).

## Architecture (Rust-first — no Rust/TS drift)

All image/texture decoding lives in **Rust**, so the server, CLI and SDK get the same result; the browser only uploads bytes to the GPU.

- **`rust/geometry/src/processors/texture.rs`** — `decode_step_binary` + `IfcBlobTexture` (PNG via the `png` crate, already in the tree → no wasm bloat) / `IfcPixelTexture` (raw) → RGBA8; resolve `IfcIndexedTriangleTextureMap` + `IfcTextureVertexList` + `IfcCartesianTransformationOperator2D`.
- **`tessellated.rs`** — `build_flat_shaded_mesh_with_uvs` emits per-vertex UVs in lockstep with the flat-shaded vertices (single emission path, no drift). `orient_closed_shell_outward` now returns the whole-shell flip so the parallel `TexCoordIndex` is flipped to match — UVs stay aligned.
- **transport** — `MeshData` / `MeshDataJs` gain `uvs` + decoded `texture`; the worker, `geometry-parallel`, and the `collection→MeshData` converter carry them through as transferables.
- **renderer** — a dedicated textured pipeline (UV vertex lane + albedo `texture_2d`/`sampler` at `group(0)`) drawn in its own sub-pass after the opaque batches; writes the object-id + depth targets so picking/section behave like normal opaque geometry. Textured meshes bypass colour bucketing and upload the Rust-decoded RGBA via `writeTexture` (no `createImageBitmap`).

## Tests

- `ifc-lite-processing` `issue_961_textures` — blob PNG decodes to RGBA + UVs 1:1 with positions + ×48 transform applied; pixel texture decodes 256×256 with a known black pixel.
- `@ifc-lite/wasm` `textures.test.mjs` — drives the viewer path (`buildPrePassOnce`+`processGeometryBatch`) and asserts the boiler carries an RGBA texture + UVs for both fixtures.
- Full `pnpm build` (37/37) + rust suites green.

## Out of scope / follow-ups
- `IfcImageTexture` (external URL) — needs an async fetch resolver outside the geometry pipeline.
- Texture v-origin (IFC bottom-left vs WebGPU top-left) is visually indistinguishable on the tiled noise fixtures; flagged for confirmation against the reference render.
- Occurrence-level textured geometry (these fixtures are type-only); the decode/UV helpers are reusable.
- Mipmaps (linear-only sampling for now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)