### PR TITLE
feat(grids): render structural grids in apps/viewer (#967)

### DIFF
--- a/.changeset/grids-apps-viewer.md
+++ b/.changeset/grids-apps-viewer.md
@@ -1,0 +1,22 @@
+---
+"@ifc-lite/renderer": minor
+"@ifc-lite/viewer": minor
+---
+
+feat(grids): render structural grids in apps/viewer (#967)
+
+Wire the structural-grid SDK from #966 into the in-repo viewer, mirroring the
+alignment-lines stack (lines-only for now).
+
+- **`@ifc-lite/renderer`**: `uploadGridLines3D` / `clearGridLines3D` (+ internal
+  `hasGridLines3D` / `drawGridLines3D`) — a dedicated grid line buffer drawn
+  through the existing line pipeline, independent of the annotation/alignment
+  overlays. Unlike alignment, grid lines don't expand model bounds (they sit
+  behind a visibility toggle and routinely extend past the envelope). Also frees
+  the alignment + grid line buffers on overlay `dispose()`.
+- **`@ifc-lite/viewer`**: `useGridLines3D` hook (mirrors `useAlignmentLines3D`,
+  calls `GeometryProcessor.parseGridLines`), wired in `Viewport` and gated by the
+  existing `ifcGrid` type-visibility toggle.
+
+3D tag/bubble labels and full polyline sampling for curved axes are deferred (see
+#967).

--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -46,6 +46,7 @@ import {
   type SectionClipForGrid,
 } from '../../hooks/useSymbolicAnnotations.js';
 import { useAlignmentLines3D } from '../../hooks/useAlignmentLines3D.js';
+import { useGridLines3D } from '../../hooks/useGridLines3D.js';
 
 interface ViewportProps {
   geometry: MeshData[] | null;
@@ -900,6 +901,20 @@ export function Viewport({
       renderer.uploadAlignmentLines3D(alignmentVertices3D);
     }
   }, [alignmentVertices3D, isInitialized]);
+
+  // Structural-grid (IfcGridAxis) lines, gated by the `ifcGrid` type-visibility
+  // toggle (issue #967). Parsed once per source + cached; only the upload/clear
+  // is toggled so flipping visibility doesn't re-parse.
+  const gridVertices3D = useGridLines3D();
+  useEffect(() => {
+    const renderer = rendererRef.current;
+    if (!renderer || !isInitialized) return;
+    if (!ifcGridVisible || gridVertices3D.length === 0) {
+      renderer.clearGridLines3D();
+    } else {
+      renderer.uploadGridLines3D(gridVertices3D);
+    }
+  }, [gridVertices3D, ifcGridVisible, isInitialized]);
 
   // Upload IfcAnnotation text + fill data for the WebGPU symbolic overlay
   // pipelines. Map the hook's per-annotation records into the SymbolicFillInput

--- a/apps/viewer/src/hooks/source-key.ts
+++ b/apps/viewer/src/hooks/source-key.ts
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { IfcDataStore } from '@ifc-lite/parser';
+
+// Per-source-object memo so the full-content hash runs only once per loaded
+// buffer (the same Uint8Array instance is reused across re-renders).
+const SOURCE_KEY_CACHE = new WeakMap<Uint8Array, string>();
+
+/**
+ * Stable per-source cache key — a **full-content** FNV-1a hash (not sampled
+ * byte windows), so two distinct IFC binaries can't collide and reuse the wrong
+ * cache entry (which would render another model's overlay). The O(n) hash is
+ * memoised per source object via a WeakMap, so it runs once per loaded buffer.
+ *
+ * Shared by the per-source overlay hooks (alignment + grid lines) so they stay
+ * in lockstep — see #967 review (CodeRabbit aliasing finding applied to both).
+ */
+export function sourceKey(store: IfcDataStore | null | undefined): string | null {
+  const source = store?.source;
+  if (!source || source.byteLength === 0) return null;
+
+  const cached = SOURCE_KEY_CACHE.get(source);
+  if (cached) return cached;
+
+  let h = 0x811c9dc5;
+  for (let i = 0; i < source.length; i++) {
+    h ^= source[i];
+    h = Math.imul(h, 0x01000193);
+  }
+  const key = `b${source.byteLength}-${(h >>> 0).toString(16)}`;
+  SOURCE_KEY_CACHE.set(source, key);
+  return key;
+}

--- a/apps/viewer/src/hooks/useAlignmentLines3D.ts
+++ b/apps/viewer/src/hooks/useAlignmentLines3D.ts
@@ -23,34 +23,9 @@ import { GeometryProcessor } from '@ifc-lite/geometry';
 import { useViewerStore } from '@/store';
 import { useShallow } from 'zustand/react/shallow';
 import type { IfcDataStore } from '@ifc-lite/parser';
+import { sourceKey } from './source-key.js';
 
 const EMPTY_F32 = new Float32Array(0);
-
-/**
- * Stable per-source cache key — FNV-1a over head/mid/tail byte windows folded
- * with the length, so two structurally distinct sources can't alias even when
- * they share an exact byte length (a real risk in federated views). Identical
- * scheme to `useSymbolicAnnotations`' `sourceKey`.
- */
-function sourceKey(store: IfcDataStore | null | undefined): string | null {
-  const source = store?.source;
-  if (!source || source.byteLength === 0) return null;
-  const len = source.byteLength;
-  const sampleLen = Math.min(32, len);
-  const head = source.subarray(0, sampleLen);
-  const tail = source.subarray(len - sampleLen, len);
-  const midOffset = Math.max(0, Math.floor(len / 2) - Math.floor(sampleLen / 2));
-  const mid = source.subarray(midOffset, Math.min(midOffset + sampleLen, len));
-  const hashOne = (bytes: Uint8Array): string => {
-    let h = 0x811c9dc5;
-    for (let i = 0; i < bytes.length; i++) {
-      h ^= bytes[i];
-      h = Math.imul(h, 0x01000193);
-    }
-    return (h >>> 0).toString(16);
-  };
-  return `b${len}-${hashOne(head)}-${hashOne(mid)}-${hashOne(tail)}`;
-}
 
 // ─── Shared parse cache ──────────────────────────────────────────────────────
 // One WASM walk per model source; cached so re-renders (and federated views

--- a/apps/viewer/src/hooks/useGridLines3D.ts
+++ b/apps/viewer/src/hooks/useGridLines3D.ts
@@ -1,0 +1,165 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Extraction of IfcGrid / IfcGridAxis centerlines for the 3D viewport
+ * (issue #967, follow-up to #945/#966).
+ *
+ * IfcGrid carries its axes as IfcGridAxis curves (not a `Representation`), so
+ * they never produce a mesh in the streaming batch mesher. The WASM
+ * `parseGridLines` API resolves every axis through the same placement +
+ * unit-scale + RTC pipeline as the meshes and returns a flat 3D line-list in
+ * renderer Y-up world space, which we feed to `renderer.uploadGridLines3D`.
+ * This mirrors `useAlignmentLines3D`.
+ *
+ * Unlike alignment (always-on), grids are gated by the `ifcGrid` type-visibility
+ * toggle — but the parse itself is unconditional and cached; the Viewport only
+ * uploads/clears based on the toggle.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { GeometryProcessor } from '@ifc-lite/geometry';
+import { useViewerStore } from '@/store';
+import { useShallow } from 'zustand/react/shallow';
+import type { IfcDataStore } from '@ifc-lite/parser';
+
+const EMPTY_F32 = new Float32Array(0);
+
+/**
+ * Stable per-source cache key — FNV-1a over head/mid/tail byte windows folded
+ * with the length, so two structurally distinct sources can't alias even when
+ * they share an exact byte length (a real risk in federated views). Identical
+ * scheme to `useAlignmentLines3D`' `sourceKey`.
+ */
+function sourceKey(store: IfcDataStore | null | undefined): string | null {
+  const source = store?.source;
+  if (!source || source.byteLength === 0) return null;
+  const len = source.byteLength;
+  const sampleLen = Math.min(32, len);
+  const head = source.subarray(0, sampleLen);
+  const tail = source.subarray(len - sampleLen, len);
+  const midOffset = Math.max(0, Math.floor(len / 2) - Math.floor(sampleLen / 2));
+  const mid = source.subarray(midOffset, Math.min(midOffset + sampleLen, len));
+  const hashOne = (bytes: Uint8Array): string => {
+    let h = 0x811c9dc5;
+    for (let i = 0; i < bytes.length; i++) {
+      h ^= bytes[i];
+      h = Math.imul(h, 0x01000193);
+    }
+    return (h >>> 0).toString(16);
+  };
+  return `b${len}-${hashOne(head)}-${hashOne(mid)}-${hashOne(tail)}`;
+}
+
+// ─── Shared parse cache ──────────────────────────────────────────────────────
+// One WASM walk per model source; cached so re-renders (and federated views
+// that share a source) don't re-parse.
+const PARSE_CACHE = new Map<string, Float32Array>();
+const PARSE_INFLIGHT = new Map<string, Promise<void>>();
+
+type CacheListener = () => void;
+const CACHE_LISTENERS = new Set<CacheListener>();
+function notifyCacheChange(): void {
+  for (const fn of CACHE_LISTENERS) fn();
+}
+
+async function parseGridLinesFor(store: IfcDataStore): Promise<Float32Array> {
+  const source = store.source;
+  if (!source || source.byteLength === 0) return EMPTY_F32;
+  const processor = new GeometryProcessor();
+  try {
+    await processor.init();
+    const verts = processor.parseGridLines(source);
+    return verts && verts.length > 0 ? verts : EMPTY_F32;
+  } finally {
+    processor.dispose();
+  }
+}
+
+function ensureParseFor(stores: IfcDataStore[]): void {
+  for (const store of stores) {
+    const key = sourceKey(store);
+    if (!key) continue;
+    if (PARSE_CACHE.has(key)) continue;
+    if (PARSE_INFLIGHT.has(key)) continue;
+
+    const promise = (async () => {
+      try {
+        const verts = await parseGridLinesFor(store);
+        PARSE_CACHE.set(key, verts);
+        notifyCacheChange();
+      } catch (error) {
+        // Cache empty on failure so we don't retry a doomed parse every tick.
+        // eslint-disable-next-line no-console
+        console.warn('[useGridLines3D] parse failed:', error);
+        PARSE_CACHE.set(key, EMPTY_F32);
+        notifyCacheChange();
+      } finally {
+        PARSE_INFLIGHT.delete(key);
+      }
+    })();
+    PARSE_INFLIGHT.set(key, promise);
+  }
+}
+
+/** Read the active store set from the viewer store. Federation-aware. */
+function useActiveStores(): IfcDataStore[] {
+  const { models, ifcDataStore } = useViewerStore(
+    useShallow((s) => ({ models: s.models, ifcDataStore: s.ifcDataStore })),
+  );
+  return useMemo(() => {
+    const out: IfcDataStore[] = [];
+    if (models.size > 0) {
+      for (const [, m] of models) if (m.ifcDataStore) out.push(m.ifcDataStore);
+    } else if (ifcDataStore) {
+      out.push(ifcDataStore);
+    }
+    return out;
+  }, [models, ifcDataStore]);
+}
+
+/**
+ * Sample every loaded model's IfcGridAxis lines into a single flat
+ * `[x0,y0,z0, x1,y1,z1, …]` line-list in renderer world space (Y-up,
+ * RTC-subtracted, metres). Returns a stable empty array when no model carries a
+ * grid. Parsing is unconditional + cached; the Viewport gates rendering on the
+ * `ifcGrid` type-visibility toggle.
+ */
+export function useGridLines3D(): Float32Array {
+  const stores = useActiveStores();
+  const [version, setVersion] = useState(0);
+
+  useEffect(() => {
+    ensureParseFor(stores);
+    const listener: CacheListener = () => setVersion((v) => v + 1);
+    CACHE_LISTENERS.add(listener);
+    return () => {
+      CACHE_LISTENERS.delete(listener);
+    };
+  }, [stores]);
+
+  return useMemo(() => {
+    void version; // depend on parse-completion ticks
+    const arrays: Float32Array[] = [];
+    let total = 0;
+    for (const store of stores) {
+      const key = sourceKey(store);
+      if (!key) continue;
+      const cached = PARSE_CACHE.get(key);
+      if (cached && cached.length > 0) {
+        arrays.push(cached);
+        total += cached.length;
+      }
+    }
+    if (total === 0) return EMPTY_F32;
+    if (arrays.length === 1) return arrays[0];
+    const merged = new Float32Array(total);
+    let offset = 0;
+    for (const a of arrays) {
+      merged.set(a, offset);
+      offset += a.length;
+    }
+    return merged;
+  }, [stores, version]);
+}

--- a/apps/viewer/src/hooks/useGridLines3D.ts
+++ b/apps/viewer/src/hooks/useGridLines3D.ts
@@ -23,34 +23,9 @@ import { GeometryProcessor } from '@ifc-lite/geometry';
 import { useViewerStore } from '@/store';
 import { useShallow } from 'zustand/react/shallow';
 import type { IfcDataStore } from '@ifc-lite/parser';
+import { sourceKey } from './source-key.js';
 
 const EMPTY_F32 = new Float32Array(0);
-
-/**
- * Stable per-source cache key — FNV-1a over head/mid/tail byte windows folded
- * with the length, so two structurally distinct sources can't alias even when
- * they share an exact byte length (a real risk in federated views). Identical
- * scheme to `useAlignmentLines3D`' `sourceKey`.
- */
-function sourceKey(store: IfcDataStore | null | undefined): string | null {
-  const source = store?.source;
-  if (!source || source.byteLength === 0) return null;
-  const len = source.byteLength;
-  const sampleLen = Math.min(32, len);
-  const head = source.subarray(0, sampleLen);
-  const tail = source.subarray(len - sampleLen, len);
-  const midOffset = Math.max(0, Math.floor(len / 2) - Math.floor(sampleLen / 2));
-  const mid = source.subarray(midOffset, Math.min(midOffset + sampleLen, len));
-  const hashOne = (bytes: Uint8Array): string => {
-    let h = 0x811c9dc5;
-    for (let i = 0; i < bytes.length; i++) {
-      h ^= bytes[i];
-      h = Math.imul(h, 0x01000193);
-    }
-    return (h >>> 0).toString(16);
-  };
-  return `b${len}-${hashOne(head)}-${hashOne(mid)}-${hashOne(tail)}`;
-}
 
 // ─── Shared parse cache ──────────────────────────────────────────────────────
 // One WASM walk per model source; cached so re-renders (and federated views

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -2029,6 +2029,9 @@ export class Renderer {
             if (this.section2DOverlayRenderer?.hasAlignmentLines3D()) {
                 this.section2DOverlayRenderer.drawAlignmentLines3D(pass, viewProj);
             }
+            if (this.section2DOverlayRenderer?.hasGridLines3D()) {
+                this.section2DOverlayRenderer.drawGridLines3D(pass, viewProj);
+            }
             if (this.symbolicTextPipeline?.hasGeometry()) {
                 // Pass viewport pixel dimensions so the shader can scale glyphs
                 // to a constant on-screen size (BIMvision-style annotations)
@@ -2451,6 +2454,29 @@ export class Renderer {
     clearAlignmentLines3D(): void {
         if (this.section2DOverlayRenderer) {
             this.section2DOverlayRenderer.clearAlignmentLines3D();
+            this.requestRender();
+        }
+    }
+
+    /**
+     * Upload structural-grid (IfcGridAxis) segments as a flat [x,y,z,x,y,z,...]
+     * line-list in world space (issue #967). Rendered as thin lines, mirroring
+     * the alignment overlay. Pass an empty Float32Array to clear.
+     *
+     * Unlike alignment, grids do NOT expand model bounds: they're behind a
+     * visibility toggle, so toggling them on must not reframe the camera (and
+     * grid axes routinely extend past the model envelope).
+     */
+    uploadGridLines3D(vertices: Float32Array): void {
+        if (!this.section2DOverlayRenderer) return;
+        this.section2DOverlayRenderer.uploadGridLines3D(vertices);
+        this.requestRender();
+    }
+
+    /** Clear the structural-grid overlay. */
+    clearGridLines3D(): void {
+        if (this.section2DOverlayRenderer) {
+            this.section2DOverlayRenderer.clearGridLines3D();
             this.requestRender();
         }
     }

--- a/packages/renderer/src/section-2d-overlay.ts
+++ b/packages/renderer/src/section-2d-overlay.ts
@@ -131,6 +131,12 @@ export class Section2DOverlayRenderer {
   private alignmentLineVertexBuffer: GPUBuffer | null = null;
   private alignmentLineVertexCount = 0;
 
+  // Standalone 3D structural-grid (IfcGridAxis) overlay. Independent buffer so
+  // grid visibility is independent of the annotation/alignment overlays, but
+  // reuses the same line pipeline (issue #967).
+  private gridLineVertexBuffer: GPUBuffer | null = null;
+  private gridLineVertexCount = 0;
+
   constructor(device: GPUDevice, format: GPUTextureFormat, sampleCount: number = 4) {
     this.device = device;
     this.format = format;
@@ -793,6 +799,63 @@ export class Section2DOverlayRenderer {
   }
 
   /**
+   * Upload structural-grid (IfcGridAxis) segments as a flat
+   * `[x,y,z, x,y,z, …]` line-list in world space (issue #967). Mirrors
+   * `uploadAlignmentLines3D` with a separate buffer so grid visibility is
+   * independent. Pass an empty array (or omit) to clear.
+   */
+  uploadGridLines3D(vertices: Float32Array): void {
+    this.init();
+
+    if (this.gridLineVertexBuffer) {
+      this.gridLineVertexBuffer.destroy();
+      this.gridLineVertexBuffer = null;
+    }
+    this.gridLineVertexCount = 0;
+
+    if (vertices.length < 6) return;
+
+    this.gridLineVertexBuffer = this.device.createBuffer({
+      size: vertices.byteLength,
+      usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+    });
+    this.device.queue.writeBuffer(this.gridLineVertexBuffer, 0, vertices);
+    this.gridLineVertexCount = vertices.length / 3;
+  }
+
+  clearGridLines3D(): void {
+    if (this.gridLineVertexBuffer) {
+      this.gridLineVertexBuffer.destroy();
+      this.gridLineVertexBuffer = null;
+    }
+    this.gridLineVertexCount = 0;
+  }
+
+  hasGridLines3D(): boolean {
+    return this.gridLineVertexCount > 0;
+  }
+
+  /**
+   * Draw the structural-grid overlay. Identical pipeline/uniform setup as
+   * `drawAlignmentLines3D`, reading from the separate grid buffer.
+   */
+  drawGridLines3D(pass: GPURenderPassEncoder, viewProj: Float32Array): void {
+    this.init();
+    if (!this.linePipeline || !this.uniformBuffer || !this.bindGroup) return;
+    if (!this.gridLineVertexBuffer || this.gridLineVertexCount === 0) return;
+
+    const uniforms = new Float32Array(20);
+    uniforms.set(viewProj, 0);
+    // planeOffset = 0 — vertices are already in world space.
+    this.device.queue.writeBuffer(this.uniformBuffer, 0, uniforms);
+
+    pass.setPipeline(this.linePipeline);
+    pass.setBindGroup(0, this.bindGroup);
+    pass.setVertexBuffer(0, this.gridLineVertexBuffer);
+    pass.draw(this.gridLineVertexCount);
+  }
+
+  /**
    * Check if there is geometry to draw
    */
   hasGeometry(): boolean {
@@ -909,6 +972,8 @@ export class Section2DOverlayRenderer {
   dispose(): void {
     this.clearGeometry();
     this.clearAnnotationLines3D();
+    this.clearAlignmentLines3D();
+    this.clearGridLines3D();
     if (this.uniformBuffer) {
       this.uniformBuffer.destroy();
       this.uniformBuffer = null;


### PR DESCRIPTION
Follow-up to #966 (closes #967). Wires the structural-grid SDK into the in-repo viewer, **lines-only**, mirroring the existing alignment-lines stack.

## Changes

**`@ifc-lite/renderer`**
- `uploadGridLines3D` / `clearGridLines3D` (+ internal `hasGridLines3D` / `drawGridLines3D`) — a dedicated grid line vertex buffer drawn through the existing line pipeline, independent of the annotation/alignment overlays (mirrors `uploadAlignmentLines3D`).
- Grid lines deliberately **do not expand model bounds** — they're behind a visibility toggle, so flipping them on must not reframe the camera, and grid axes routinely extend past the model envelope.
- `Section2DOverlayRenderer.dispose()` now also frees the alignment + grid line buffers (the alignment one was previously leaked).

**`@ifc-lite/viewer`**
- `useGridLines3D` hook (mirrors `useAlignmentLines3D`; calls `GeometryProcessor.parseGridLines`, parsed once per source + cached).
- Wired in `Viewport`, gated by the **existing `ifcGrid` type-visibility toggle** (`toggleTypeVisibility('ifcGrid')` already in `MainToolbar`) — so no new toggle UI; the same control that hides grids in the 2D section now also governs the 3D overlay.

## Scope / deferred (per #967)
- [x] `useGridLines3D` hook
- [x] `uploadGridLines3D` line pipeline
- [x] Visibility toggle (reused existing `ifcGrid` entry)
- [ ] 3D tag/bubble labels — deferred
- [ ] Full polyline sampling for arc/trimmed axes — deferred (`parseGridAxes`/`parseGridLines` emit first/last chord today)

## Verification
- `pnpm --filter @ifc-lite/renderer build` + `--filter @ifc-lite/geometry build` clean.
- `apps/viewer` typecheck clean for the touched files (pre-existing `jspdf`/`exceljs` module errors in `lib/lists/export` are unrelated).
- Manually verified grids render aligned with the streamed meshes and toggle on/off via the IfcGrid visibility control.

---
Assisted with AI, checked and verified by human.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structural grid rendering added to the 3D viewer, showing IFC grid axis centerlines.
  * Grid visibility tied to the existing grid toggle.
  * Federated/model-aggregate support so grids from multiple sources render together.
  * Faster, more stable grid loading with background parsing and caching to reduce re-parsing and redundant work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->