### PR TITLE
fix(geometry): preserve profile voids re-encoded as opening elements (#964)

### DIFF
--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -498,29 +498,9 @@ fn ray_triangle_param(
     Some(e2.dot(&qvec) * inv_det)
 }
 
-/// Whether `mesh` is already hollow at `point` along `axis` — i.e. the
-/// infinite line through `point` in the `axis` direction does not cross a
-/// single host triangle.
-///
-/// Issue #964: some exporters (Revit) double-encode a void — once baked into
-/// the host's `IfcArbitraryProfileDefWithVoids` profile and again as a
-/// redundant `IfcOpeningElement`. The body geometry already carries the
-/// (correct, possibly round/polygonal) hole, so when the redundant opening's
-/// CSG subtraction finds nothing to remove the AABB fallback must NOT fire:
-/// cutting the opening's bounding box would carve a rectangle over the
-/// already-correct hole. A ray cast through the opening centroid along its
-/// extrusion axis hits zero host triangles exactly when the hole is already
-/// open there.
-///
-/// Deliberately strict: returns `true` only when there is NO host material on
-/// the line (both sides clear). A genuinely solid host — e.g. the issue #635
-/// round window in an un-voided wall — sandwiches `point` between two faces,
-/// so the fallback still fires there. Any ambiguity (material on one side)
-/// keeps the existing cut behaviour.
-fn host_already_open_along_axis(mesh: &Mesh, point: Point3<f64>, axis: &Vector3<f64>) -> bool {
-    let Some(axis) = axis.try_normalize(NORMALIZE_EPSILON) else {
-        return false;
-    };
+/// Whether the infinite line through `point` along `axis` crosses any
+/// triangle of `mesh`.
+fn axis_line_crosses_mesh(mesh: &Mesh, point: Point3<f64>, axis: &Vector3<f64>) -> bool {
     for tri in mesh.indices.chunks_exact(3) {
         let (Some(a), Some(b), Some(c)) = (
             mesh_point(mesh, tri[0]),
@@ -529,8 +509,54 @@ fn host_already_open_along_axis(mesh: &Mesh, point: Point3<f64>, axis: &Vector3<
         ) else {
             continue;
         };
-        if ray_triangle_param(point, &axis, a, b, c).is_some() {
-            return false; // host material on the line — not an existing void
+        if ray_triangle_param(point, axis, a, b, c).is_some() {
+            return true;
+        }
+    }
+    false
+}
+
+/// Whether `opening` is a redundant cutter — every column through its footprint
+/// (along `axis`) is *already* open in `host`, so subtracting it would remove
+/// nothing.
+///
+/// Issue #964: some exporters (Revit) double-encode a void — once baked into
+/// the host's `IfcArbitraryProfileDefWithVoids` profile and again as a
+/// redundant `IfcOpeningElement`. The body geometry already carries the
+/// (correct, possibly round/polygonal) hole, so when the redundant opening's
+/// CSG subtraction finds nothing to remove the AABB fallback must NOT fire:
+/// cutting the opening's bounding box would carve a rectangle over the
+/// already-correct hole.
+///
+/// Clearance is probed across the *whole* footprint, not just the centroid:
+/// the centroid plus every cutter vertex pulled slightly inward toward the
+/// centroid (so the samples stay strictly inside the real round/polygonal
+/// footprint rather than its bounding box). The opening is redundant only when
+/// a ray along `axis` through *every* sample hits zero host triangles. If any
+/// sample still finds host material — e.g. a circular opening centred inside an
+/// already-cut rectangle but spilling out into solid host beyond it — the
+/// cutter has real work left and the fallback proceeds. A genuinely solid host
+/// (the issue #635 round window in an un-voided wall) is rejected at the very
+/// first sample, so the fallback still fires there. No regression.
+fn opening_redundant_with_host(host: &Mesh, opening: &Mesh, axis: &Vector3<f64>) -> bool {
+    let Some(axis) = axis.try_normalize(NORMALIZE_EPSILON) else {
+        return false;
+    };
+    let Some(centroid) = mesh_vertex_centroid(opening) else {
+        return false;
+    };
+    // Pull each footprint sample 10% toward the centroid so a sample sitting
+    // exactly on a hole boundary that coincides with the cutter wall lands
+    // strictly inside the existing void.
+    const PULL_TO_CENTROID: f64 = 0.1;
+    if axis_line_crosses_mesh(host, centroid, &axis) {
+        return false;
+    }
+    for v in opening.positions.chunks_exact(3) {
+        let vertex = Point3::new(v[0] as f64, v[1] as f64, v[2] as f64);
+        let sample = vertex + (centroid - vertex) * PULL_TO_CENTROID;
+        if axis_line_crosses_mesh(host, sample, &axis) {
+            return false;
         }
     }
     true
@@ -1484,9 +1510,8 @@ impl GeometryRouter {
                         // Issue #964: suppress the destructive AABB box when the
                         // host already has this void cut into it (a void
                         // double-encoded as both a profile inner curve and a
-                        // redundant IfcOpeningElement). A ray through the
-                        // opening centroid along its extrusion axis hits no host
-                        // material exactly when the hole is already open there;
+                        // redundant IfcOpeningElement). When every column through
+                        // the opening footprint is already open in the host,
                         // cutting the bounding box would replace a correct
                         // round/polygonal hole with a rectangle. Unlike the
                         // engulf heuristic this is a positive void detection, so
@@ -1495,11 +1520,8 @@ impl GeometryRouter {
                         let probe_axis = dir.unwrap_or_else(|| {
                             wall_thinnest_axis_dir(&wall_min, &wall_max)
                         });
-                        let redundant_void = mesh_vertex_centroid(opening_mesh)
-                            .map(|centroid| {
-                                host_already_open_along_axis(&result, centroid, &probe_axis)
-                            })
-                            .unwrap_or(false);
+                        let redundant_void =
+                            opening_redundant_with_host(&result, opening_mesh, &probe_axis);
                         let suppress_fallback =
                             redundant_void || (csg_unchanged && engulfs_host && !capped);
                         if !suppress_fallback {

--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -465,6 +465,93 @@ fn mesh_point(mesh: &Mesh, index: u32) -> Option<Point3<f64>> {
     ))
 }
 
+/// Möller–Trumbore ray/triangle intersection returning the signed ray
+/// parameter `t` (signed distance along `dir` from `origin`), or `None` when
+/// the ray misses the triangle or runs parallel to it. `dir` must be
+/// normalized. Used by [`host_already_open_along_axis`].
+fn ray_triangle_param(
+    origin: Point3<f64>,
+    dir: &Vector3<f64>,
+    a: Point3<f64>,
+    b: Point3<f64>,
+    c: Point3<f64>,
+) -> Option<f64> {
+    const EPS: f64 = 1e-9;
+    let e1 = b - a;
+    let e2 = c - a;
+    let pvec = dir.cross(&e2);
+    let det = e1.dot(&pvec);
+    if det.abs() < EPS {
+        return None; // ray parallel to the triangle plane
+    }
+    let inv_det = 1.0 / det;
+    let tvec = origin - a;
+    let u = tvec.dot(&pvec) * inv_det;
+    if !(-EPS..=1.0 + EPS).contains(&u) {
+        return None;
+    }
+    let qvec = tvec.cross(&e1);
+    let v = dir.dot(&qvec) * inv_det;
+    if v < -EPS || u + v > 1.0 + EPS {
+        return None;
+    }
+    Some(e2.dot(&qvec) * inv_det)
+}
+
+/// Whether `mesh` is already hollow at `point` along `axis` — i.e. the
+/// infinite line through `point` in the `axis` direction does not cross a
+/// single host triangle.
+///
+/// Issue #964: some exporters (Revit) double-encode a void — once baked into
+/// the host's `IfcArbitraryProfileDefWithVoids` profile and again as a
+/// redundant `IfcOpeningElement`. The body geometry already carries the
+/// (correct, possibly round/polygonal) hole, so when the redundant opening's
+/// CSG subtraction finds nothing to remove the AABB fallback must NOT fire:
+/// cutting the opening's bounding box would carve a rectangle over the
+/// already-correct hole. A ray cast through the opening centroid along its
+/// extrusion axis hits zero host triangles exactly when the hole is already
+/// open there.
+///
+/// Deliberately strict: returns `true` only when there is NO host material on
+/// the line (both sides clear). A genuinely solid host — e.g. the issue #635
+/// round window in an un-voided wall — sandwiches `point` between two faces,
+/// so the fallback still fires there. Any ambiguity (material on one side)
+/// keeps the existing cut behaviour.
+fn host_already_open_along_axis(mesh: &Mesh, point: Point3<f64>, axis: &Vector3<f64>) -> bool {
+    let Some(axis) = axis.try_normalize(NORMALIZE_EPSILON) else {
+        return false;
+    };
+    for tri in mesh.indices.chunks_exact(3) {
+        let (Some(a), Some(b), Some(c)) = (
+            mesh_point(mesh, tri[0]),
+            mesh_point(mesh, tri[1]),
+            mesh_point(mesh, tri[2]),
+        ) else {
+            continue;
+        };
+        if ray_triangle_param(point, &axis, a, b, c).is_some() {
+            return false; // host material on the line — not an existing void
+        }
+    }
+    true
+}
+
+/// Centroid (vertex average) of a mesh, or `None` when it has no vertices.
+fn mesh_vertex_centroid(mesh: &Mesh) -> Option<Point3<f64>> {
+    let n = mesh.positions.len() / 3;
+    if n == 0 {
+        return None;
+    }
+    let (mut sx, mut sy, mut sz) = (0.0f64, 0.0f64, 0.0f64);
+    for chunk in mesh.positions.chunks_exact(3) {
+        sx += chunk[0] as f64;
+        sy += chunk[1] as f64;
+        sz += chunk[2] as f64;
+    }
+    let inv = 1.0 / n as f64;
+    Some(Point3::new(sx * inv, sy * inv, sz * inv))
+}
+
 fn extent_along_axis(mesh: &Mesh, axis: &Vector3<f64>) -> Option<f64> {
     let mut min = f64::INFINITY;
     let mut max = f64::NEG_INFINITY;
@@ -1346,19 +1433,6 @@ impl GeometryRouter {
                     // dramatically less wrong than a missing void on a wall
                     // that is supposed to host a window or door.
                     if !csg_succeeded {
-                        // Diagnostic for issue #635: when the AABB fallback
-                        // fires, log the opening triangle count so we can
-                        // verify (e.g. round windows after Part A's profile
-                        // simplification) that normal openings hit CSG and
-                        // only genuinely-broken ones land here.
-                        #[cfg(any(debug_assertions, test))]
-                        {
-                            let opening_tris = opening_mesh.triangle_count();
-                            eprintln!(
-                                "[issue-635] AABB fallback used: opening={} tris (over MAX_CSG_POLYGONS_PER_MESH or no change)",
-                                opening_tris
-                            );
-                        }
                         let dir = extrusion_dir.or_else(|| {
                             Some(wall_thinnest_axis_dir(&wall_min, &wall_max))
                         });
@@ -1407,7 +1481,40 @@ impl GeometryRouter {
                         // AABB box: skipping it on the 3% engulf heuristic would
                         // leave the wall entirely uncut (Codex review, #947).
                         let capped = clipper.has_operand_too_large_since(failures_before);
-                        if !(csg_unchanged && engulfs_host && !capped) {
+                        // Issue #964: suppress the destructive AABB box when the
+                        // host already has this void cut into it (a void
+                        // double-encoded as both a profile inner curve and a
+                        // redundant IfcOpeningElement). A ray through the
+                        // opening centroid along its extrusion axis hits no host
+                        // material exactly when the hole is already open there;
+                        // cutting the bounding box would replace a correct
+                        // round/polygonal hole with a rectangle. Unlike the
+                        // engulf heuristic this is a positive void detection, so
+                        // it overrides `capped` too (the void demonstrably
+                        // exists — there is nothing left to approximate).
+                        let probe_axis = dir.unwrap_or_else(|| {
+                            wall_thinnest_axis_dir(&wall_min, &wall_max)
+                        });
+                        let redundant_void = mesh_vertex_centroid(opening_mesh)
+                            .map(|centroid| {
+                                host_already_open_along_axis(&result, centroid, &probe_axis)
+                            })
+                            .unwrap_or(false);
+                        let suppress_fallback =
+                            redundant_void || (csg_unchanged && engulfs_host && !capped);
+                        if !suppress_fallback {
+                            // Diagnostic for issue #635: log the opening
+                            // triangle count when the AABB fallback actually
+                            // fires, so round windows (post profile
+                            // simplification) can be confirmed to hit CSG and
+                            // only genuinely-uncut voids land on the box cut.
+                            #[cfg(any(debug_assertions, test))]
+                            {
+                                eprintln!(
+                                    "[issue-635] AABB fallback used: opening={} tris (over MAX_CSG_POLYGONS_PER_MESH or no change)",
+                                    opening_mesh.triangle_count()
+                                );
+                            }
                             let aabb_cut =
                                 self.cut_rectangular_opening(&result, final_min, final_max);
                             if !aabb_cut.is_empty() && aabb_cut.triangle_count() != tri_before {

--- a/rust/geometry/tests/issue_964_arbitrary_profile_voids.rs
+++ b/rust/geometry/tests/issue_964_arbitrary_profile_voids.rs
@@ -91,7 +91,9 @@ fn redundant_openings_do_not_rectangularize_profile_voids() {
     let content = match std::fs::read_to_string(fixture_path()) {
         Ok(s) => s,
         Err(_) => {
-            eprintln!("skipping issue-964 regression: fixture missing at {FIXTURE}");
+            eprintln!(
+                "skipping issue-964 regression: fixture missing at {FIXTURE}; run `pnpm fixtures`"
+            );
             return;
         }
     };

--- a/rust/geometry/tests/issue_964_arbitrary_profile_voids.rs
+++ b/rust/geometry/tests/issue_964_arbitrary_profile_voids.rs
@@ -1,0 +1,136 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Issue #964 — complex profile voids render as rectangles.
+//!
+//! The reporter's slab (GUID `3qy29DaXf0ivOFkuocsP7z`, express #6443) is a
+//! Revit export that *double-encodes* its voids: the slab body is an
+//! `IfcExtrudedAreaSolid` over an `IfcArbitraryProfileDefWithVoids` whose
+//! inner curves already cut a rectangle, an ellipse and a hexagon, AND the
+//! same three voids are re-authored as `IfcOpeningElement`s linked by
+//! `IfcRelVoidsElement`.
+//!
+//! The slab *body* tessellates the round/polygonal holes correctly. The bug
+//! was in the redundant opening pass: CSG finds nothing to remove (the host
+//! is already hollow there) and the AABB fallback then carves each opening's
+//! bounding box, replacing the correct ellipse/hexagon holes with rectangles.
+//!
+//! This test drives the production void path (`process_element_with_voids`)
+//! and asserts the slab's solid bottom-cap area after the opening pass stays
+//! equal to the un-cut body's — i.e. the openings did not rectangularize the
+//! holes. The buggy AABB fallback removed ~3% more material (each round/hex
+//! hole grew to its bounding box), which this tolerance rejects.
+
+use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner};
+use ifc_lite_geometry::{propagate_voids_to_parts, GeometryRouter, Mesh};
+use rustc_hash::FxHashMap;
+use std::path::PathBuf;
+
+const FIXTURE: &str = "tests/models/issues/964_slab_arbitrary_profile_voids.ifc";
+/// IfcSlab `3qy29DaXf0ivOFkuocsP7z` — body uses IfcArbitraryProfileDefWithVoids.
+const SLAB_ID: u32 = 6443;
+
+fn fixture_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join(FIXTURE)
+}
+
+/// Build the void index the same way production does (scan IfcRelVoidsElement).
+fn build_void_index_like_production(content: &str) -> FxHashMap<u32, Vec<u32>> {
+    let mut void_index: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
+    let mut scanner = EntityScanner::new(content);
+    let mut decoder = EntityDecoder::new(content);
+    while let Some((id, type_name, start, end)) = scanner.next_entity() {
+        if type_name == "IFCRELVOIDSELEMENT" {
+            if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
+                if let (Some(host_id), Some(opening_id)) = (entity.get_ref(4), entity.get_ref(5)) {
+                    void_index.entry(host_id).or_default().push(opening_id);
+                }
+            }
+        }
+    }
+    let _ = propagate_voids_to_parts(&mut void_index, content, &mut decoder);
+    void_index
+}
+
+/// Sum of |XY area| of triangles lying on the mesh's bottom face (z ≈ z_min).
+/// For an extruded slab this equals the solid cross-section area: outer
+/// rectangle minus the holes. Round/hex holes ⇒ ~7.46e6; if a hole is cut to
+/// its bounding box instead ⇒ ~7.24e6.
+fn bottom_cap_area(mesh: &Mesh) -> f64 {
+    let mut z_min = f32::INFINITY;
+    for p in mesh.positions.chunks_exact(3) {
+        if p[2] < z_min {
+            z_min = p[2];
+        }
+    }
+    let tol = 1e-3_f32;
+    let mut area = 0.0f64;
+    for tri in mesh.indices.chunks_exact(3) {
+        let a = tri[0] as usize * 3;
+        let b = tri[1] as usize * 3;
+        let c = tri[2] as usize * 3;
+        if (mesh.positions[a + 2] - z_min).abs() < tol
+            && (mesh.positions[b + 2] - z_min).abs() < tol
+            && (mesh.positions[c + 2] - z_min).abs() < tol
+        {
+            let (ax, ay) = (mesh.positions[a] as f64, mesh.positions[a + 1] as f64);
+            let (bx, by) = (mesh.positions[b] as f64, mesh.positions[b + 1] as f64);
+            let (cx, cy) = (mesh.positions[c] as f64, mesh.positions[c + 1] as f64);
+            area += ((bx - ax) * (cy - ay) - (cx - ax) * (by - ay)).abs() * 0.5;
+        }
+    }
+    area
+}
+
+#[test]
+fn redundant_openings_do_not_rectangularize_profile_voids() {
+    let content = match std::fs::read_to_string(fixture_path()) {
+        Ok(s) => s,
+        Err(_) => {
+            eprintln!("skipping issue-964 regression: fixture missing at {FIXTURE}");
+            return;
+        }
+    };
+
+    let void_index = build_void_index_like_production(&content);
+    assert!(
+        void_index.get(&SLAB_ID).map(|v| v.len()).unwrap_or(0) >= 2,
+        "expected the slab to carry redundant IfcOpeningElements"
+    );
+
+    let entity_index = build_entity_index(&content);
+    let mut decoder = EntityDecoder::with_index(&content, entity_index);
+    let router = GeometryRouter::with_scale(1.0);
+
+    let slab = decoder.decode_by_id(SLAB_ID).expect("decode slab");
+
+    // Body alone (profile-with-voids): the reference correct hole area.
+    let body = router.process_element(&slab, &mut decoder).expect("body");
+    let body_area = bottom_cap_area(&body);
+    assert!(body_area > 1.0, "body produced no bottom cap");
+
+    // Production void path: opening boolean cuts applied on top of the body.
+    let slab = decoder.decode_by_id(SLAB_ID).expect("decode slab");
+    let cut = router
+        .process_element_with_voids(&slab, &mut decoder, &void_index)
+        .expect("voided slab");
+    let cut_area = bottom_cap_area(&cut);
+
+    // The redundant openings must leave the solid cross-section unchanged: the
+    // ellipse and hexagon holes stay round/hex, not their bounding boxes.
+    // The pre-fix AABB fallback removed ~3% more material; allow 0.5% slack
+    // for re-tessellation around the (harmless) rectangular opening.
+    let rel_diff = (body_area - cut_area).abs() / body_area;
+    assert!(
+        rel_diff < 0.005,
+        "opening pass changed the slab's solid area by {:.2}% (body={:.1}, cut={:.1}); \
+         the complex profile voids were likely rectangularized by the AABB fallback",
+        rel_diff * 100.0,
+        body_area,
+        cut_area,
+    );
+}

--- a/tests/models/manifest.json
+++ b/tests/models/manifest.json
@@ -749,6 +749,11 @@
       "size": 129717
     },
     {
+      "path": "issues/964_slab_arbitrary_profile_voids.ifc",
+      "sha256": "525d01150923b5a50277fd5ad3ba0dac7df3c27e76c0fbd87edcf110e2c8c674",
+      "size": 682646
+    },
+    {
       "path": "various/01_BIMcollab_Example_ARC.ifc",
       "sha256": "87392cf24264b023e65d8ca1dab1eb8996643c1aa51b9dff9d518ed8904151fc",
       "size": 18230149


### PR DESCRIPTION
Fixes #964 — complex `IfcSlab` voids (ellipse, hexagon) rendered as rectangles.

## Root cause
The reporter's slab **double-encodes its voids** (a Revit/ODA export pattern): once baked into the body's `IfcArbitraryProfileDefWithVoids` swept profile (which tessellates the correct round/polygonal holes via earcut), and again as redundant `IfcOpeningElement` + `IfcRelVoidsElement`.

The viewer void path (`process_element_with_voids` → `apply_void_context`) builds the correct body, then runs the redundant opening boolean cuts on top. Since the host is *already void* at those locations, CSG removes nothing (Manifold returns the host unchanged / errors `NotManifold`). The code read that as "CSG failed" and applied the **AABB bounding-box fallback** (built for #635 round windows) — carving a rectangle over each correct ellipse/hex hole.

Verified precisely: slab body bottom-cap solid area = `7,464,903`; with the buggy opening pass = `7,235,744` (**exact AABB-bbox match**).

## Fix
Before the AABB fallback fires, cast a ray through the opening centroid along its extrusion axis. **Zero** host-triangle hits means the host is already open there → suppress the destructive box cut. This positive void detection overrides the `capped`/engulf heuristics.

A genuinely solid host (e.g. #635's round window in an un-voided wall) sandwiches the centroid between two faces → the fallback still fires, so **no regression**.

Post-fix area = `7,464,906` ≈ the body's `7,464,903` — round/hex holes preserved.

## Tests
- New `issue_964_arbitrary_profile_voids.rs` drives the production void path and asserts the opening pass doesn't change the slab's solid cross-section area. Confirmed it **fails on old code** (3.07% area loss) and **passes with the fix**.
- Fixture added to `manifest.json` and uploaded to the `fixtures-v1` release (fetch + hash verified).
- **All 311 geometry tests pass** (incl. #635, #832, #853). `cargo check --workspace` clean; clippy at baseline (no new warnings).

## Debugging note
The slab body is a valid closed, consistently-wound, genus-3 manifold, yet `manifold3d::from_mesh_f64` rejects it `NotManifold` — because the mesh fed to the ellipse/hex CSG is the *post-rectangular-clip* host (the rect-opening + reveal path introduces bad half-edges). So a `NotManifold` CSG failure here does not mean the original body is broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redundant-opening detection to avoid incorrect simplification of arbitrarily-shaped holes; AABB fallback suppression now skips unnecessary rectangularization and diagnostic logging only appears when fallback runs.

* **Tests**
  * Added a regression test and fixture validating redundant-opening handling for complex slab void geometries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->