### PR TITLE
fix(geometry): skip smooth-curve simplification of thin curved profiles (#820)

### DIFF
--- a/rust/geometry/src/profiles.rs
+++ b/rust/geometry/src/profiles.rs
@@ -58,6 +58,14 @@ const RDP_EPSILON_RATIO: f64 = 1.0 / 100.0;
 /// Prevents collapsing tiny profiles where ratio-derived epsilon would be
 /// numerically negligible.
 const RDP_EPSILON_MIN: f64 = 5.0e-3;
+/// Minimum ratio of a profile's half-thickness (`area / perimeter`, its
+/// hydraulic radius) to its bounding-box diagonal for simplification to be
+/// attempted. Below this the profile is a *thin* curved sliver — e.g. a
+/// trimmed-circle wall whose inner and outer arcs sit only a wall-thickness
+/// apart (issue #820) — and RDP's diagonal-scaled epsilon would distort or fold
+/// its feature size; such profiles are left untouched. A round window
+/// (half-thickness ≈ radius/2) sits far above this (~0.25) and still simplifies.
+const THIN_FEATURE_RATIO: f64 = 0.05;
 /// Only attempt simplification when the polyline has at least this many
 /// vertices. Below this the polyline is already cheap enough.
 const SMOOTH_CURVE_MIN_VERTICES: usize = 24;
@@ -143,6 +151,69 @@ fn rdp_simplify_open(points: &[Point2<f64>], epsilon: f64) -> Vec<Point2<f64>> {
         .collect()
 }
 
+/// Vertex-count ceiling for the brute-force O(n²) self-intersection scan.
+/// Above this the scan is too expensive to run per profile; the *caller*
+/// treats an over-ceiling simplified loop as unconfirmed and falls back to the
+/// faithful original (fail-safe) rather than trusting it. A simplification that
+/// still has this many vertices barely beat the original anyway, so the
+/// fallback is essentially free.
+const SELF_INTERSECT_SCAN_MAX_VERTICES: usize = 1024;
+
+/// Whether the closed polygon described by `loop_` (open form — the closing
+/// edge from the last vertex back to the first is implied) has any pair of
+/// non-adjacent edges that properly cross. Used to reject a simplification
+/// that turned a simple profile loop into a self-intersecting one.
+///
+/// Brute-force O(n²), so only meaningful up to `SELF_INTERSECT_SCAN_MAX_VERTICES`
+/// vertices; above that it returns `false` without scanning and callers must
+/// apply their own size cap (see `simplify_smooth_curve_polyline`). Adjacent
+/// edges (which legitimately share a vertex) are skipped, and only *proper*
+/// crossings count, so the shared endpoints of consecutive segments never
+/// register as intersections.
+fn closed_loop_self_intersects(loop_: &[Point2<f64>]) -> bool {
+    let n = loop_.len();
+    if !(4..=SELF_INTERSECT_SCAN_MAX_VERTICES).contains(&n) {
+        return false;
+    }
+    // Orientation of the triplet (a, b, c): >0 CCW, <0 CW, 0 collinear.
+    #[inline]
+    fn orient(a: Point2<f64>, b: Point2<f64>, c: Point2<f64>) -> f64 {
+        (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x)
+    }
+    // Proper crossing of segment ab and segment cd (interiors intersect at a
+    // single point). Collinear/touching-endpoint cases return false — those
+    // are how consecutive boundary edges legitimately meet.
+    #[inline]
+    fn segments_properly_cross(
+        a: Point2<f64>,
+        b: Point2<f64>,
+        c: Point2<f64>,
+        d: Point2<f64>,
+    ) -> bool {
+        let d1 = orient(c, d, a);
+        let d2 = orient(c, d, b);
+        let d3 = orient(a, b, c);
+        let d4 = orient(a, b, d);
+        ((d1 > 0.0) != (d2 > 0.0)) && ((d3 > 0.0) != (d4 > 0.0))
+    }
+    for i in 0..n {
+        let a = loop_[i];
+        let b = loop_[(i + 1) % n];
+        for j in (i + 1)..n {
+            // Skip the two segments adjacent to edge i (they share a vertex).
+            if j == i || (j + 1) % n == i || (i + 1) % n == j {
+                continue;
+            }
+            let c = loop_[j];
+            let d = loop_[(j + 1) % n];
+            if segments_properly_cross(a, b, c, d) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 /// Best-effort downsampling of a polyline that might approximate a smooth
 /// curve. Closed-loop aware (last == first is preserved). Returns the
 /// original polyline unchanged when it doesn't look over-tessellated or
@@ -205,6 +276,7 @@ pub(crate) fn simplify_smooth_curve_polyline(points: &[Point2<f64>]) -> Vec<Poin
     // define the silhouette and slice across the fillet region instead.
     let mut perimeter = 0.0;
     let mut longest_edge: f64 = 0.0;
+    let mut area2 = 0.0; // 2× signed shoelace area
     for i in 0..n {
         let a = core[i];
         let b = core[(i + 1) % n];
@@ -215,6 +287,7 @@ pub(crate) fn simplify_smooth_curve_polyline(points: &[Point2<f64>]) -> Vec<Poin
         if len > longest_edge {
             longest_edge = len;
         }
+        area2 += a.x * b.y - b.x * a.y;
     }
     let mean_edge = perimeter / n as f64;
     if mean_edge / diag > SMOOTH_CURVE_SPACING_RATIO {
@@ -224,6 +297,33 @@ pub(crate) fn simplify_smooth_curve_polyline(points: &[Point2<f64>]) -> Vec<Poin
     if longest_edge / diag > SMOOTH_CURVE_LONGEST_EDGE_RATIO {
         // Mixed-geometry profile: at least one edge is too long to belong to
         // a uniformly-tessellated smooth curve. Leave the polyline alone.
+        return points.to_vec();
+    }
+
+    // Thin-feature gate (issue #820). RDP's epsilon is scaled to the bounding
+    // diagonal, which is right for a "fat" smooth shape — a round window is
+    // ~uniformly thick in every direction — but wrong for a *thin* one. A
+    // curved annular-sector wall is only a wall thickness deep yet metres
+    // across, so a diagonal-scaled chord-deviation budget is a large fraction
+    // of (or exceeds) the thickness. RDP then slides chords across the thin
+    // dimension, letting the inner and outer arcs drift independently: the
+    // footprint either folds into a self-intersecting flap (the visible #820
+    // bug) or silently gains/loses double-digit-percent area while staying
+    // topologically simple (the same distortion class as the +4.31% W410
+    // fillet bug). No epsilon you can still call "simplification" preserves a
+    // thin curved shape, so don't try — keep the faithful original.
+    //
+    // `area / perimeter` is the polygon's hydraulic radius (≈ half its mean
+    // thickness): ≈ thickness/2 for a thin sliver, ≈ radius/2 for a fat disk.
+    // Its ratio to the diagonal cleanly separates the two — ~0.0015 for the
+    // 100 mm × 24 m #820 wall vs ~0.25 for a round window — so a profile whose
+    // half-thickness is a tiny fraction of its extent is left untouched.
+    let half_thickness = if perimeter > f64::EPSILON {
+        area2.abs() / (2.0 * perimeter)
+    } else {
+        0.0
+    };
+    if half_thickness / diag < THIN_FEATURE_RATIO {
         return points.to_vec();
     }
 
@@ -252,6 +352,20 @@ pub(crate) fn simplify_smooth_curve_polyline(points: &[Point2<f64>]) -> Vec<Poin
     if simplified_core.len() < SIMPLIFIED_MIN_VERTICES || simplified_core.len() >= n {
         // Either too aggressive or no real reduction — keep the original
         // so we never make an opening worse than it already was.
+        return points.to_vec();
+    }
+
+    // Backstop: a valid simplification of a simple polygon stays simple. The
+    // thickness-capped epsilon above prevents RDP from crossing a thin seam in
+    // the common case, but pin placement and non-uniform sampling can still
+    // produce a self-intersecting loop, so reject any result we can't confirm
+    // is simple and keep the faithful original. Loops too large to scan within
+    // the O(n²) budget are treated as unconfirmed (fail-safe) rather than
+    // assumed clean — a simplification that still has >1024 vertices barely
+    // beat the original, so falling back to it costs almost nothing.
+    if simplified_core.len() > SELF_INTERSECT_SCAN_MAX_VERTICES
+        || closed_loop_self_intersects(&simplified_core)
+    {
         return points.to_vec();
     }
 
@@ -3062,6 +3176,127 @@ mod tests {
     use super::*;
 
     #[test]
+    fn closed_loop_self_intersects_detects_bowtie() {
+        // Simple unit square — no crossings.
+        let square = [
+            Point2::new(0.0, 0.0),
+            Point2::new(1.0, 0.0),
+            Point2::new(1.0, 1.0),
+            Point2::new(0.0, 1.0),
+        ];
+        assert!(!closed_loop_self_intersects(&square));
+
+        // Bow-tie: swapping the last two vertices makes the closing edges
+        // cross in the middle.
+        let bowtie = [
+            Point2::new(0.0, 0.0),
+            Point2::new(1.0, 0.0),
+            Point2::new(0.0, 1.0),
+            Point2::new(1.0, 1.0),
+        ];
+        assert!(closed_loop_self_intersects(&bowtie));
+
+        // Degenerate (fewer than 4 vertices) can't self-cross.
+        assert!(!closed_loop_self_intersects(&square[..3]));
+    }
+
+    /// Build a dense closed loop for a thin annular sector centred at
+    /// (0, -radius) (the issue #820 topology): an outer arc at `radius` and an
+    /// inner arc at `radius - thickness`, swept `span` radians and joined by
+    /// short radial caps. `seg` samples per arc.
+    fn annular_sector_loop(radius: f64, thickness: f64, span: f64, seg: usize) -> Vec<Point2<f64>> {
+        let c = Point2::new(0.0, -radius);
+        let mut loop_ = Vec::with_capacity(2 * seg + 2);
+        for i in 0..=seg {
+            let a = -span / 2.0 + span * (i as f64 / seg as f64);
+            loop_.push(Point2::new(c.x + radius * a.cos(), c.y + radius * a.sin()));
+        }
+        let inner = radius - thickness;
+        for i in 0..=seg {
+            let a = span / 2.0 - span * (i as f64 / seg as f64);
+            loop_.push(Point2::new(c.x + inner * a.cos(), c.y + inner * a.sin()));
+        }
+        loop_
+    }
+
+    fn loop_area(loop_: &[Point2<f64>]) -> f64 {
+        let n = loop_.len();
+        let mut a = 0.0;
+        for i in 0..n {
+            let p = loop_[i];
+            let q = loop_[(i + 1) % n];
+            a += p.x * q.y - q.x * p.y;
+        }
+        (a * 0.5).abs()
+    }
+
+    #[test]
+    fn simplify_thin_annular_sector_stays_simple_and_area_preserving() {
+        // Regression for issue #820 *and* the silent-area-distortion class the
+        // review flagged. A thin curved wall has a feature size (its thickness)
+        // far below the bbox diagonal; the thickness-capped RDP epsilon must
+        // keep every simplification both topologically simple (no folded-flap
+        // seam) and area-faithful. The first row is the real fixture's
+        // proportions (r=12000, 100 mm, 240°); the rest are the thicker/shorter
+        // sectors the reviewer reproduced losing/gaining 5–13% area under the
+        // un-capped epsilon.
+        let cases = [
+            (12000.0, 100.0, 240.0_f64),
+            (12000.0, 300.0, 240.0),
+            (12000.0, 600.0, 90.0),
+            (12000.0, 600.0, 180.0),
+        ];
+        for (radius, thickness, span_deg) in cases {
+            let span = span_deg.to_radians();
+            let dense = annular_sector_loop(radius, thickness, span, 200);
+            assert!(
+                !closed_loop_self_intersects(&dense),
+                "input sector r={radius} t={thickness} {span_deg}° should start simple",
+            );
+            let out = simplify_smooth_curve_polyline(&dense);
+
+            // Topology: never a folded-flap seam.
+            assert!(
+                !closed_loop_self_intersects(&out),
+                "simplified sector r={radius} t={thickness} {span_deg}° self-intersects",
+            );
+
+            // Area: within 2% of the dense original (was up to ±13% pre-fix).
+            let (a_in, a_out) = (loop_area(&dense), loop_area(&out));
+            let rel = (a_out - a_in).abs() / a_in;
+            assert!(
+                rel < 0.02,
+                "sector r={radius} t={thickness} {span_deg}°: area drift {:.1}% \
+                 (in={a_in:.0} out={a_out:.0}) — thin curved wall was distorted",
+                rel * 100.0,
+            );
+        }
+    }
+
+    #[test]
+    fn simplify_still_reduces_fat_round_disk() {
+        // Guards THIN_FEATURE_RATIO from being set so high it suppresses the
+        // issue #635 case it must preserve: an over-tessellated round window
+        // (a *fat* disk, half-thickness ≈ radius/2) must still simplify to a
+        // small recognizable polygon so void cuts fit the CSG polygon budget.
+        let mut disk = Vec::new();
+        let seg = 127;
+        for i in 0..seg {
+            let a = std::f64::consts::TAU * (i as f64 / seg as f64);
+            disk.push(Point2::new(0.5 * a.cos(), 0.5 * a.sin()));
+        }
+        let out = simplify_smooth_curve_polyline(&disk);
+        assert!(
+            out.len() < disk.len() && out.len() >= SIMPLIFIED_MIN_VERTICES,
+            "round disk should simplify from {} to [{SIMPLIFIED_MIN_VERTICES}, {}) verts, got {}",
+            disk.len(),
+            disk.len(),
+            out.len(),
+        );
+        assert!(!closed_loop_self_intersects(&out));
+    }
+
+    #[test]
     fn test_rectangle_profile() {
         let content = r#"
 #1=IFCRECTANGLEPROFILEDEF(.AREA.,$,$,100.0,200.0);
@@ -3744,4 +3979,15 @@ mod tests {
         assert!(approx_eq_p3(pts[0], Point3::new(0.0, 10.0, 0.0), 1e-9));
         assert!(approx_eq_p3(pts[1], Point3::new(0.0, 7.0, 0.0), 1e-9));
     }
+    #[test]
+    fn probe_ellipse_aspect_gate_TEMP() {
+        for &(asp, seg) in &[(8.0_f64,96usize),(9.0,96),(9.5,96),(10.0,96),(10.0,60),(20.0,96)] {
+            let (a,b)=(asp,1.0);
+            let mut pts=Vec::new();
+            for i in 0..seg { let t=std::f64::consts::TAU*(i as f64/seg as f64); pts.push(Point2::new(a*t.cos(),b*t.sin())); }
+            let out=simplify_smooth_curve_polyline(&pts);
+            eprintln!("PROBE aspect={} seg={} in={} out={} {}",asp,seg,pts.len(),out.len(), if out.len()==pts.len(){"SKIPPED"}else{"simplified"});
+        }
+    }
+
 }

--- a/rust/geometry/src/profiles.rs
+++ b/rust/geometry/src/profiles.rs
@@ -63,8 +63,9 @@ const RDP_EPSILON_MIN: f64 = 5.0e-3;
 /// attempted. Below this the profile is a *thin* curved sliver — e.g. a
 /// trimmed-circle wall whose inner and outer arcs sit only a wall-thickness
 /// apart (issue #820) — and RDP's diagonal-scaled epsilon would distort or fold
-/// its feature size; such profiles are left untouched. A round window
-/// (half-thickness ≈ radius/2) sits far above this (~0.25) and still simplifies.
+/// its feature size; such profiles are left untouched. A round window sits far
+/// above this (half-thickness ≈ r/2 against a bbox diagonal of 2·r·√2 gives
+/// ≈ 0.18, ~3.5× the gate) and still simplifies.
 const THIN_FEATURE_RATIO: f64 = 0.05;
 /// Only attempt simplification when the polyline has at least this many
 /// vertices. Below this the polyline is already cheap enough.
@@ -316,8 +317,9 @@ pub(crate) fn simplify_smooth_curve_polyline(points: &[Point2<f64>]) -> Vec<Poin
     // `area / perimeter` is the polygon's hydraulic radius (≈ half its mean
     // thickness): ≈ thickness/2 for a thin sliver, ≈ radius/2 for a fat disk.
     // Its ratio to the diagonal cleanly separates the two — ~0.0015 for the
-    // 100 mm × 24 m #820 wall vs ~0.25 for a round window — so a profile whose
-    // half-thickness is a tiny fraction of its extent is left untouched.
+    // 100 mm × 24 m #820 wall vs ~0.18 for a round window (r/2 over a 2·r·√2
+    // bbox diagonal) — so a profile whose half-thickness is a tiny fraction of
+    // its extent is left untouched.
     let half_thickness = if perimeter > f64::EPSILON {
         area2.abs() / (2.0 * perimeter)
     } else {
@@ -3979,15 +3981,4 @@ mod tests {
         assert!(approx_eq_p3(pts[0], Point3::new(0.0, 10.0, 0.0), 1e-9));
         assert!(approx_eq_p3(pts[1], Point3::new(0.0, 7.0, 0.0), 1e-9));
     }
-    #[test]
-    fn probe_ellipse_aspect_gate_TEMP() {
-        for &(asp, seg) in &[(8.0_f64,96usize),(9.0,96),(9.5,96),(10.0,96),(10.0,60),(20.0,96)] {
-            let (a,b)=(asp,1.0);
-            let mut pts=Vec::new();
-            for i in 0..seg { let t=std::f64::consts::TAU*(i as f64/seg as f64); pts.push(Point2::new(a*t.cos(),b*t.sin())); }
-            let out=simplify_smooth_curve_polyline(&pts);
-            eprintln!("PROBE aspect={} seg={} in={} out={} {}",asp,seg,pts.len(),out.len(), if out.len()==pts.len(){"SKIPPED"}else{"simplified"});
-        }
-    }
-
 }

--- a/rust/geometry/src/profiles.rs
+++ b/rust/geometry/src/profiles.rs
@@ -67,20 +67,23 @@ const RDP_EPSILON_MIN: f64 = 5.0e-3;
 /// above this (half-thickness ≈ r/2 against a bbox diagonal of 2·r·√2 gives
 /// ≈ 0.18, ~3.5× the gate) and still simplifies. Thinness alone is *not*
 /// sufficient to skip — an elongated filled ellipse is thin by this measure too
-/// yet simplifies fine — so it is paired with [`DOUBLE_BACK_REFLEX_FRACTION`].
+/// yet simplifies fine — so it is paired with [`DOUBLE_BACK_REFLEX_ARC_FRACTION`].
 const THIN_FEATURE_RATIO: f64 = 0.05;
-/// Fraction of a loop's vertices that must be *reflex* (turning against the
-/// loop's overall winding) for it to count as *doubling back* on itself rather
-/// than enclosing a convex-ish blob. A convex shape (filled ellipse, disk) has
-/// zero reflex vertices at any aspect ratio; an annular sector's entire inner
-/// arc is reflex, so ~half its vertices are (≈0.4–0.5). 0.15 sits clear of both
-/// — and, unlike a total-turning measure, it is insensitive to a *localized*
-/// spike: one inward notch or a sub-mm closing-seam jog on an otherwise convex
-/// thin opening is only 1–2 reflex vertices, far below the threshold, so such
-/// openings keep simplifying (else they regress to the issue #635 AABB cut).
-const DOUBLE_BACK_REFLEX_FRACTION: f64 = 0.15;
+/// Fraction of a loop's *perimeter length* that must run along reflex vertices
+/// (turning against the loop's overall winding) for it to count as *doubling
+/// back* on itself rather than enclosing a convex-ish blob. A convex shape
+/// (filled ellipse, disk) has zero reflex boundary at any aspect ratio; an
+/// annular sector's entire inner arc is reflex, so ~half its perimeter is
+/// (≈0.5). 0.15 sits clear of both, and measuring by arc *length* rather than
+/// vertex *count* makes it independent of how densely each boundary is sampled
+/// — a thin wall whose inner arc carries far fewer points than its outer arc
+/// still reads as ~0.5 (Codex review). It is likewise insensitive to a
+/// *localized* spike: one inward notch or a sub-mm closing-seam jog spans
+/// negligible arc length, so such convex thin openings keep simplifying (else
+/// they regress to the issue #635 AABB cut).
+const DOUBLE_BACK_REFLEX_ARC_FRACTION: f64 = 0.15;
 /// Per-vertex turning (as |sin| of the deflection angle) below which a vertex
-/// is treated as straight, not reflex — guards the reflex count against f64
+/// is treated as straight, not reflex — guards the reflex test against f64
 /// noise at near-collinear samples on a convex curve.
 const REFLEX_TURN_SIN_TOL: f64 = 1.0e-6;
 /// Only attempt simplification when the polyline has at least this many
@@ -235,21 +238,27 @@ fn closed_loop_self_intersects(loop_: &[Point2<f64>]) -> bool {
 }
 
 /// Whether the closed polygon (open form) `loop_` *doubles back* on itself —
-/// a large fraction of its vertices are reflex (turn against its winding),
-/// exceeding `DOUBLE_BACK_REFLEX_FRACTION`.
+/// the share of its perimeter that runs along reflex vertices (turning against
+/// its winding) exceeds `DOUBLE_BACK_REFLEX_ARC_FRACTION`.
 ///
-/// A convex shape (filled ellipse, disk) has no reflex vertices at any aspect
+/// A convex shape (filled ellipse, disk) has no reflex boundary at any aspect
 /// ratio. A loop that runs out along one boundary and back along another (an
 /// annular sector / thin curved wall) makes its entire return arc reflex, so
-/// ~half its vertices are. Counting reflex vertices — rather than summing total
-/// turning — is what makes this insensitive to a *localized* feature: one
-/// inward notch, or the sub-mm out-and-back jog where a composite curve closes,
-/// is only a vertex or two and cannot tip the fraction, whereas a total-turning
-/// measure double-counts such a spike and would wrongly flag the loop.
+/// ~half its perimeter is. Two properties matter:
+///   * Measuring reflex *arc length* (not vertex *count*) makes the test
+///     independent of per-boundary sampling density — a thin wall whose inner
+///     arc carries far fewer points than its outer arc still reads as ~0.5,
+///     whereas a count fraction would be skewed below the threshold.
+///   * It stays insensitive to a *localized* feature — one inward notch, or the
+///     sub-mm out-and-back jog where a composite curve closes — because that
+///     spans negligible arc length, whereas a total-turning measure
+///     double-counts such a spike and would wrongly flag the loop.
 ///
 /// Winding is taken from the signed area; a vertex is reflex when its turn
 /// opposes that winding by more than `REFLEX_TURN_SIN_TOL` (normalised so the
-/// tolerance is a true angle, not a length-scaled cross product).
+/// tolerance is a true angle, not a length-scaled cross product). Each reflex
+/// vertex contributes its outgoing edge length, so the reflex arc length and
+/// the perimeter are summed over the same edges.
 fn loop_doubles_back(loop_: &[Point2<f64>]) -> bool {
     let n = loop_.len();
     if n < 4 {
@@ -266,24 +275,28 @@ fn loop_doubles_back(loop_: &[Point2<f64>]) -> bool {
     }
     let winding = signed_area2.signum();
 
-    let mut reflex = 0usize;
+    let mut perimeter = 0.0;
+    let mut reflex_len = 0.0;
     for i in 0..n {
         let prev = loop_[(i + n - 1) % n];
         let cur = loop_[i];
         let next = loop_[(i + 1) % n];
         let (ex_in, ey_in) = (cur.x - prev.x, cur.y - prev.y);
         let (ex_out, ey_out) = (next.x - cur.x, next.y - cur.y);
-        let len = ((ex_in * ex_in + ey_in * ey_in) * (ex_out * ex_out + ey_out * ey_out)).sqrt();
-        if len <= 0.0 {
+        let out_len = (ex_out * ex_out + ey_out * ey_out).sqrt();
+        perimeter += out_len;
+        let in_len = (ex_in * ex_in + ey_in * ey_in).sqrt();
+        let denom = in_len * out_len;
+        if denom <= 0.0 {
             continue; // zero-length edge (duplicate vertex) — no turn
         }
         // sin(turn) = cross / (|e_in||e_out|); reflex when it opposes winding.
-        let sin_turn = (ex_in * ey_out - ey_in * ex_out) / len;
+        let sin_turn = (ex_in * ey_out - ey_in * ex_out) / denom;
         if sin_turn * winding < -REFLEX_TURN_SIN_TOL {
-            reflex += 1;
+            reflex_len += out_len;
         }
     }
-    (reflex as f64) / (n as f64) > DOUBLE_BACK_REFLEX_FRACTION
+    perimeter > 0.0 && reflex_len / perimeter > DOUBLE_BACK_REFLEX_ARC_FRACTION
 }
 
 /// Best-effort downsampling of a polyline that might approximate a smooth
@@ -394,11 +407,12 @@ pub(crate) fn simplify_smooth_curve_polyline(points: &[Point2<f64>]) -> Vec<Poin
     //    cut fits the BSP polygon budget (else round openings → AABB boxes,
     //    issue #635).
     //  * What actually breaks RDP is the boundary *doubling back* on itself.
-    //    A convex loop has no reflex vertices at any aspect ratio; an annular
-    //    sector's inner arc is entirely reflex, so ~half its vertices are.
-    //    `loop_doubles_back` measures that reflex fraction, which distinguishes
-    //    a thin ring from a thin ellipse and — unlike a total-turning measure —
-    //    ignores a lone notch or closing-seam jog. Requiring thinness too
+    //    A convex loop has no reflex boundary at any aspect ratio; an annular
+    //    sector's inner arc is entirely reflex, so ~half its perimeter is.
+    //    `loop_doubles_back` measures that reflex arc-length fraction, which
+    //    distinguishes a thin ring from a thin ellipse, is independent of how
+    //    densely each boundary is sampled, and — unlike a total-turning measure
+    //    — ignores a lone notch or closing-seam jog. Requiring thinness too
     //    leaves *fat* curved walls (thickness ≫ epsilon, no fold) free to
     //    simplify.
     let half_thickness = if perimeter > f64::EPSILON {
@@ -3472,6 +3486,36 @@ mod tests {
             !loop_doubles_back(&disk),
             "a sub-mm seam jog on a convex loop must not read as doubling back",
         );
+    }
+
+    #[test]
+    fn doubles_back_independent_of_per_boundary_sampling_density() {
+        // Codex review: measuring reflex VERTICES (not arc length) let a thin
+        // sector slip when its two arcs are sampled at very different densities.
+        // Their exact example: a 90° sector, r=12000, thickness=10, with the
+        // convex outer arc finely sampled (96 segs) and the reflex inner arc
+        // coarsely (16 segs). A count fraction reads ~0.13 (< gate) and the
+        // wall is wrongly simplified to ~55% area drift; an arc-length fraction
+        // reads ~0.5 because the inner and outer arcs are nearly equal LENGTH.
+        let centre = Point2::new(0.0, -12000.0);
+        let (r_out, r_in) = (12000.0, 12000.0 - 10.0);
+        let span = (90.0_f64).to_radians();
+        let mut loop_ = Vec::new();
+        for i in 0..=96 {
+            let a = -span / 2.0 + span * (i as f64 / 96.0);
+            loop_.push(Point2::new(centre.x + r_out * a.cos(), centre.y + r_out * a.sin()));
+        }
+        for i in 0..=16 {
+            let a = span / 2.0 - span * (i as f64 / 16.0);
+            loop_.push(Point2::new(centre.x + r_in * a.cos(), centre.y + r_in * a.sin()));
+        }
+        assert!(
+            loop_doubles_back(&loop_),
+            "a non-uniformly tessellated thin sector must still read as doubling back",
+        );
+        // And it is gated end-to-end: simplify returns the faithful original.
+        let out = simplify_smooth_curve_polyline(&loop_);
+        assert_eq!(out.len(), loop_.len(), "skewed-sampling thin sector must be gated");
     }
 
     #[test]

--- a/rust/geometry/src/profiles.rs
+++ b/rust/geometry/src/profiles.rs
@@ -67,16 +67,22 @@ const RDP_EPSILON_MIN: f64 = 5.0e-3;
 /// above this (half-thickness ≈ r/2 against a bbox diagonal of 2·r·√2 gives
 /// ≈ 0.18, ~3.5× the gate) and still simplifies. Thinness alone is *not*
 /// sufficient to skip — an elongated filled ellipse is thin by this measure too
-/// yet simplifies fine — so it is paired with [`DOUBLE_BACK_TURN_RATIO`].
+/// yet simplifies fine — so it is paired with [`DOUBLE_BACK_REFLEX_FRACTION`].
 const THIN_FEATURE_RATIO: f64 = 0.05;
-/// Total-absolute-turning threshold (in units of a full 2π turn) above which a
-/// closed loop is treated as *doubling back* on itself rather than enclosing a
-/// convex-ish blob. A convex polygon turns exactly 2π (ratio 1.0); an annular
-/// sector whose inner and outer arcs run opposite ways turns ≥ ~1.5× (the #820
-/// wall ~2.3×). 1.25 sits clear of both — above any convex shape's turning (so
-/// filled ellipses and disks are never gated) and below the thinnest
-/// doubling-back sector that distorts under RDP.
-const DOUBLE_BACK_TURN_RATIO: f64 = 1.25;
+/// Fraction of a loop's vertices that must be *reflex* (turning against the
+/// loop's overall winding) for it to count as *doubling back* on itself rather
+/// than enclosing a convex-ish blob. A convex shape (filled ellipse, disk) has
+/// zero reflex vertices at any aspect ratio; an annular sector's entire inner
+/// arc is reflex, so ~half its vertices are (≈0.4–0.5). 0.15 sits clear of both
+/// — and, unlike a total-turning measure, it is insensitive to a *localized*
+/// spike: one inward notch or a sub-mm closing-seam jog on an otherwise convex
+/// thin opening is only 1–2 reflex vertices, far below the threshold, so such
+/// openings keep simplifying (else they regress to the issue #635 AABB cut).
+const DOUBLE_BACK_REFLEX_FRACTION: f64 = 0.15;
+/// Per-vertex turning (as |sin| of the deflection angle) below which a vertex
+/// is treated as straight, not reflex — guards the reflex count against f64
+/// noise at near-collinear samples on a convex curve.
+const REFLEX_TURN_SIN_TOL: f64 = 1.0e-6;
 /// Only attempt simplification when the polyline has at least this many
 /// vertices. Below this the polyline is already cheap enough.
 const SMOOTH_CURVE_MIN_VERTICES: usize = 24;
@@ -212,7 +218,10 @@ fn closed_loop_self_intersects(loop_: &[Point2<f64>]) -> bool {
         let b = loop_[(i + 1) % n];
         for j in (i + 1)..n {
             // Skip the two segments adjacent to edge i (they share a vertex).
-            if j == i || (j + 1) % n == i || (i + 1) % n == j {
+            // `j > i` already holds, so only the wrap-around adjacency
+            // (j is the segment just before i) and the immediate successor
+            // (j == i + 1) can touch edge i.
+            if (j + 1) % n == i || (i + 1) % n == j {
                 continue;
             }
             let c = loop_[j];
@@ -226,31 +235,55 @@ fn closed_loop_self_intersects(loop_: &[Point2<f64>]) -> bool {
 }
 
 /// Whether the closed polygon (open form) `loop_` *doubles back* on itself —
-/// its total absolute turning exceeds `DOUBLE_BACK_TURN_RATIO` full turns.
+/// a large fraction of its vertices are reflex (turn against its winding),
+/// exceeding `DOUBLE_BACK_REFLEX_FRACTION`.
 ///
-/// A simple convex polygon turns by exactly 2π; any reflex structure adds to
-/// the absolute total, and a loop that runs out along one boundary and back
-/// along another (an annular sector / thin curved wall) turns ≥ ~1.5×. This
-/// separates such doubling-back loops from convex-ish blobs (filled ellipses,
-/// disks) which sit at exactly 1.0× regardless of how elongated they are.
+/// A convex shape (filled ellipse, disk) has no reflex vertices at any aspect
+/// ratio. A loop that runs out along one boundary and back along another (an
+/// annular sector / thin curved wall) makes its entire return arc reflex, so
+/// ~half its vertices are. Counting reflex vertices — rather than summing total
+/// turning — is what makes this insensitive to a *localized* feature: one
+/// inward notch, or the sub-mm out-and-back jog where a composite curve closes,
+/// is only a vertex or two and cannot tip the fraction, whereas a total-turning
+/// measure double-counts such a spike and would wrongly flag the loop.
+///
+/// Winding is taken from the signed area; a vertex is reflex when its turn
+/// opposes that winding by more than `REFLEX_TURN_SIN_TOL` (normalised so the
+/// tolerance is a true angle, not a length-scaled cross product).
 fn loop_doubles_back(loop_: &[Point2<f64>]) -> bool {
     let n = loop_.len();
-    if n < 3 {
+    if n < 4 {
         return false;
     }
-    let mut total_turn = 0.0;
+    let mut signed_area2 = 0.0;
+    for i in 0..n {
+        let a = loop_[i];
+        let b = loop_[(i + 1) % n];
+        signed_area2 += a.x * b.y - b.x * a.y;
+    }
+    if signed_area2 == 0.0 {
+        return false;
+    }
+    let winding = signed_area2.signum();
+
+    let mut reflex = 0usize;
     for i in 0..n {
         let prev = loop_[(i + n - 1) % n];
         let cur = loop_[i];
         let next = loop_[(i + 1) % n];
         let (ex_in, ey_in) = (cur.x - prev.x, cur.y - prev.y);
         let (ex_out, ey_out) = (next.x - cur.x, next.y - cur.y);
-        let cross = ex_in * ey_out - ey_in * ex_out;
-        let dot = ex_in * ex_out + ey_in * ey_out;
-        // atan2(0, 0) — a zero-length edge — yields 0, contributing nothing.
-        total_turn += cross.atan2(dot).abs();
+        let len = ((ex_in * ex_in + ey_in * ey_in) * (ex_out * ex_out + ey_out * ey_out)).sqrt();
+        if len <= 0.0 {
+            continue; // zero-length edge (duplicate vertex) — no turn
+        }
+        // sin(turn) = cross / (|e_in||e_out|); reflex when it opposes winding.
+        let sin_turn = (ex_in * ey_out - ey_in * ex_out) / len;
+        if sin_turn * winding < -REFLEX_TURN_SIN_TOL {
+            reflex += 1;
+        }
     }
-    total_turn > std::f64::consts::TAU * DOUBLE_BACK_TURN_RATIO
+    (reflex as f64) / (n as f64) > DOUBLE_BACK_REFLEX_FRACTION
 }
 
 /// Best-effort downsampling of a polyline that might approximate a smooth
@@ -361,11 +394,13 @@ pub(crate) fn simplify_smooth_curve_polyline(points: &[Point2<f64>]) -> Vec<Poin
     //    cut fits the BSP polygon budget (else round openings → AABB boxes,
     //    issue #635).
     //  * What actually breaks RDP is the boundary *doubling back* on itself.
-    //    A convex loop's total absolute turning is exactly 2π; an annular
-    //    sector's inner and outer arcs run opposite ways so it turns ≥ ~1.5×
-    //    that. Gating on turning distinguishes a thin ring (≈2.3×) from a thin
-    //    ellipse (1.0×); requiring thinness too leaves *fat* curved walls
-    //    (thickness ≫ epsilon, no fold) free to simplify.
+    //    A convex loop has no reflex vertices at any aspect ratio; an annular
+    //    sector's inner arc is entirely reflex, so ~half its vertices are.
+    //    `loop_doubles_back` measures that reflex fraction, which distinguishes
+    //    a thin ring from a thin ellipse and — unlike a total-turning measure —
+    //    ignores a lone notch or closing-seam jog. Requiring thinness too
+    //    leaves *fat* curved walls (thickness ≫ epsilon, no fold) free to
+    //    simplify.
     let half_thickness = if perimeter > f64::EPSILON {
         area2.abs() / (2.0 * perimeter)
     } else {
@@ -3390,6 +3425,53 @@ mod tests {
         // percent — acceptable for a void approximation (and the same as main).
         let rel = (loop_area(&out) - loop_area(&ellipse)).abs() / loop_area(&ellipse);
         assert!(rel < 0.08, "8:1 ellipse area drift {:.1}%", rel * 100.0);
+    }
+
+    #[test]
+    fn doubles_back_ignores_localized_spikes() {
+        // The reflex-fraction metric must flag a genuine two-arc annular sector
+        // but NOT a convex thin opening carrying a single localized defect — a
+        // lone inward notch or the sub-mm out-and-back jog where a composite
+        // curve closes. A total-turning measure double-counts such a spike and
+        // would wrongly gate these convex openings back into the #635 AABB cut.
+
+        // Genuine doubling-back: the #820 thin annular sector.
+        assert!(loop_doubles_back(&annular_sector_loop(
+            12000.0,
+            100.0,
+            (240.0_f64).to_radians(),
+            128
+        )));
+
+        // Clean convex ellipse — not doubling back.
+        let mut e = ellipse_loop(8.0, 128);
+        assert!(!loop_doubles_back(&e));
+
+        // ...with one deep inward notch at the blunt (x-tip) vertex. Find the
+        // vertex of greatest |x| and pull it 25% of the minor axis toward centre.
+        let tip = (0..e.len())
+            .max_by(|&i, &j| e[i].x.abs().partial_cmp(&e[j].x.abs()).unwrap())
+            .unwrap();
+        e[tip].x *= 0.75;
+        assert!(
+            !loop_doubles_back(&e),
+            "a single notch on a convex ellipse must not read as doubling back",
+        );
+
+        // Convex disk with a tiny out-and-back seam jog (a real, non-degenerate
+        // near-coincident self-intersection of the kind the #820 seam leaves).
+        let mut disk: Vec<Point2<f64>> = (0..128)
+            .map(|i| {
+                let t = std::f64::consts::TAU * (i as f64 / 128.0);
+                Point2::new(t.cos(), t.sin())
+            })
+            .collect();
+        // Insert a 1e-4 radial jog at vertex 0's neighbourhood.
+        disk.insert(1, Point2::new(disk[0].x * 0.9999, disk[0].y * 0.9999));
+        assert!(
+            !loop_doubles_back(&disk),
+            "a sub-mm seam jog on a convex loop must not read as doubling back",
+        );
     }
 
     #[test]

--- a/rust/geometry/src/profiles.rs
+++ b/rust/geometry/src/profiles.rs
@@ -65,8 +65,18 @@ const RDP_EPSILON_MIN: f64 = 5.0e-3;
 /// apart (issue #820) — and RDP's diagonal-scaled epsilon would distort or fold
 /// its feature size; such profiles are left untouched. A round window sits far
 /// above this (half-thickness ≈ r/2 against a bbox diagonal of 2·r·√2 gives
-/// ≈ 0.18, ~3.5× the gate) and still simplifies.
+/// ≈ 0.18, ~3.5× the gate) and still simplifies. Thinness alone is *not*
+/// sufficient to skip — an elongated filled ellipse is thin by this measure too
+/// yet simplifies fine — so it is paired with [`DOUBLE_BACK_TURN_RATIO`].
 const THIN_FEATURE_RATIO: f64 = 0.05;
+/// Total-absolute-turning threshold (in units of a full 2π turn) above which a
+/// closed loop is treated as *doubling back* on itself rather than enclosing a
+/// convex-ish blob. A convex polygon turns exactly 2π (ratio 1.0); an annular
+/// sector whose inner and outer arcs run opposite ways turns ≥ ~1.5× (the #820
+/// wall ~2.3×). 1.25 sits clear of both — above any convex shape's turning (so
+/// filled ellipses and disks are never gated) and below the thinnest
+/// doubling-back sector that distorts under RDP.
+const DOUBLE_BACK_TURN_RATIO: f64 = 1.25;
 /// Only attempt simplification when the polyline has at least this many
 /// vertices. Below this the polyline is already cheap enough.
 const SMOOTH_CURVE_MIN_VERTICES: usize = 24;
@@ -215,6 +225,34 @@ fn closed_loop_self_intersects(loop_: &[Point2<f64>]) -> bool {
     false
 }
 
+/// Whether the closed polygon (open form) `loop_` *doubles back* on itself —
+/// its total absolute turning exceeds `DOUBLE_BACK_TURN_RATIO` full turns.
+///
+/// A simple convex polygon turns by exactly 2π; any reflex structure adds to
+/// the absolute total, and a loop that runs out along one boundary and back
+/// along another (an annular sector / thin curved wall) turns ≥ ~1.5×. This
+/// separates such doubling-back loops from convex-ish blobs (filled ellipses,
+/// disks) which sit at exactly 1.0× regardless of how elongated they are.
+fn loop_doubles_back(loop_: &[Point2<f64>]) -> bool {
+    let n = loop_.len();
+    if n < 3 {
+        return false;
+    }
+    let mut total_turn = 0.0;
+    for i in 0..n {
+        let prev = loop_[(i + n - 1) % n];
+        let cur = loop_[i];
+        let next = loop_[(i + 1) % n];
+        let (ex_in, ey_in) = (cur.x - prev.x, cur.y - prev.y);
+        let (ex_out, ey_out) = (next.x - cur.x, next.y - cur.y);
+        let cross = ex_in * ey_out - ey_in * ex_out;
+        let dot = ex_in * ex_out + ey_in * ey_out;
+        // atan2(0, 0) — a zero-length edge — yields 0, contributing nothing.
+        total_turn += cross.atan2(dot).abs();
+    }
+    total_turn > std::f64::consts::TAU * DOUBLE_BACK_TURN_RATIO
+}
+
 /// Best-effort downsampling of a polyline that might approximate a smooth
 /// curve. Closed-loop aware (last == first is preserved). Returns the
 /// original polyline unchanged when it doesn't look over-tessellated or
@@ -301,31 +339,40 @@ pub(crate) fn simplify_smooth_curve_polyline(points: &[Point2<f64>]) -> Vec<Poin
         return points.to_vec();
     }
 
-    // Thin-feature gate (issue #820). RDP's epsilon is scaled to the bounding
-    // diagonal, which is right for a "fat" smooth shape — a round window is
-    // ~uniformly thick in every direction — but wrong for a *thin* one. A
-    // curved annular-sector wall is only a wall thickness deep yet metres
-    // across, so a diagonal-scaled chord-deviation budget is a large fraction
-    // of (or exceeds) the thickness. RDP then slides chords across the thin
-    // dimension, letting the inner and outer arcs drift independently: the
-    // footprint either folds into a self-intersecting flap (the visible #820
-    // bug) or silently gains/loses double-digit-percent area while staying
-    // topologically simple (the same distortion class as the +4.31% W410
-    // fillet bug). No epsilon you can still call "simplification" preserves a
-    // thin curved shape, so don't try — keep the faithful original.
+    // Thin doubling-back gate (issue #820). RDP's epsilon is scaled to the
+    // bounding diagonal, which is right for a "fat" smooth shape — a round
+    // window is ~uniformly thick in every direction — but wrong for a *thin*
+    // one that folds back on itself. A curved annular-sector wall is only a
+    // wall thickness deep yet metres across, so a diagonal-scaled chord budget
+    // is a large fraction of (or exceeds) the thickness; RDP then slides chords
+    // across the thin dimension, letting the inner and outer arcs drift
+    // independently: the footprint either folds into a self-intersecting flap
+    // (the visible #820 bug) or silently gains/loses double-digit-percent area
+    // while staying topologically simple (the same distortion class as the
+    // +4.31% W410 fillet bug). No epsilon you can still call "simplification"
+    // preserves such a shape, so don't try — keep the faithful original.
     //
-    // `area / perimeter` is the polygon's hydraulic radius (≈ half its mean
-    // thickness): ≈ thickness/2 for a thin sliver, ≈ radius/2 for a fat disk.
-    // Its ratio to the diagonal cleanly separates the two — ~0.0015 for the
-    // 100 mm × 24 m #820 wall vs ~0.18 for a round window (r/2 over a 2·r·√2
-    // bbox diagonal) — so a profile whose half-thickness is a tiny fraction of
-    // its extent is left untouched.
+    // Both conditions are required, because *thinness alone* is ambiguous:
+    //  * `area / perimeter` (the hydraulic radius, ≈ half the mean thickness)
+    //    over the diagonal is tiny both for a thin-walled ring (≈0.0015 for the
+    //    100 mm × 24 m #820 wall) AND for an elongated *filled* ellipse — an
+    //    8:1 opening sits at ≈0.048, below any thinness cutoff — yet the convex
+    //    ellipse simplifies perfectly and *must* keep simplifying so its void
+    //    cut fits the BSP polygon budget (else round openings → AABB boxes,
+    //    issue #635).
+    //  * What actually breaks RDP is the boundary *doubling back* on itself.
+    //    A convex loop's total absolute turning is exactly 2π; an annular
+    //    sector's inner and outer arcs run opposite ways so it turns ≥ ~1.5×
+    //    that. Gating on turning distinguishes a thin ring (≈2.3×) from a thin
+    //    ellipse (1.0×); requiring thinness too leaves *fat* curved walls
+    //    (thickness ≫ epsilon, no fold) free to simplify.
     let half_thickness = if perimeter > f64::EPSILON {
         area2.abs() / (2.0 * perimeter)
     } else {
         0.0
     };
-    if half_thickness / diag < THIN_FEATURE_RATIO {
+    let is_thin = half_thickness / diag < THIN_FEATURE_RATIO;
+    if is_thin && loop_doubles_back(core) {
         return points.to_vec();
     }
 
@@ -3296,6 +3343,53 @@ mod tests {
             out.len(),
         );
         assert!(!closed_loop_self_intersects(&out));
+    }
+
+    fn ellipse_loop(ar: f64, seg: usize) -> Vec<Point2<f64>> {
+        let (a, b) = (ar * 0.5, 0.5);
+        (0..seg)
+            .map(|i| {
+                let t = std::f64::consts::TAU * (i as f64 / seg as f64);
+                Point2::new(a * t.cos(), b * t.sin())
+            })
+            .collect()
+    }
+
+    #[test]
+    fn elongated_filled_ellipse_is_not_thin_gated() {
+        // Regression for the review's P1. An elongated *filled* ellipse is thin
+        // by the half-thickness/diagonal measure (an 8:1 ellipse sits at ~0.048,
+        // below THIN_FEATURE_RATIO, rising to ~0.020 at 20:1) — but it is convex
+        // and does NOT double back, so the thin gate must not fire on it. The
+        // earlier thinness-only gate wrongly skipped these, pinning a densely
+        // sampled elliptical opening at its full vertex count, overflowing the
+        // BSP void-cut budget and forcing the AABB-rectangle fallback (#635).
+        for ar in [6.0_f64, 8.0, 12.0, 20.0] {
+            assert!(
+                !loop_doubles_back(&ellipse_loop(ar, 128)),
+                "AR={ar} filled ellipse is convex — must not read as doubling back",
+            );
+        }
+
+        // With the gate no longer blocking it, an elongated ellipse simplifies
+        // exactly as it does without any thin gate (i.e. as on main): RDP +
+        // SIMPLIFIED_MIN_VERTICES. At 8:1, RDP retains ≥ the floor, so it
+        // genuinely reduces and stays simple. (Higher ratios bottom out at the
+        // floor and keep the original — a pre-existing #635 limitation, not the
+        // thin gate, and unchanged by this fix.)
+        let ellipse = ellipse_loop(8.0, 128);
+        let out = simplify_smooth_curve_polyline(&ellipse);
+        assert!(
+            out.len() < ellipse.len() && out.len() >= SIMPLIFIED_MIN_VERTICES,
+            "8:1 ellipse must still simplify (was wrongly thin-gated): {} -> {} verts",
+            ellipse.len(),
+            out.len(),
+        );
+        assert!(!closed_loop_self_intersects(&out));
+        // Inscribed simplification of an elongated convex opening shaves a few
+        // percent — acceptable for a void approximation (and the same as main).
+        let rel = (loop_area(&out) - loop_area(&ellipse)).abs() / loop_area(&ellipse);
+        assert!(rel < 0.08, "8:1 ellipse area drift {:.1}%", rel * 100.0);
     }
 
     #[test]


### PR DESCRIPTION
## Issue

Closes #820. The reporter saw the `RadianValuesOverPI` curved wall render with a **folded flap at the closing seam** ("reappeared" after the earlier plane-angle fix #834).

## Root cause

This was a *second* defect exposed once #834 let the wall render at full size. The wall is a **thin (100 mm) annular sector** — inner arc r=11900, outer arc r=12000, both centred at (0,−12000), swept ~240°, joined by two short radial caps.

The profile flows through `simplify_smooth_curve_polyline` (the issue-#635 RDP downsampler), whose chord-deviation epsilon is scaled to the **bounding-box diagonal** (≈327 mm here) — over **3× the wall thickness**. RDP slides chords clean across the thin dimension, so the inner and outer arcs drift independently:

- it drops the seam vertices where the boundary doubles back → the loop becomes **self-intersecting** (11 crossings, footprint area 4.08e6 vs the true 5.006e6 mm²) → earcut renders the folded flap; **or**
- on thicker/shorter curved walls it silently **gains/loses double-digit-percent area** while staying topologically simple — the same distortion class as the documented +4.31% W410 fillet bug.

## Fix

A **thin-feature gate**: a profile whose half-thickness (`area / perimeter`, its hydraulic radius) is below `THIN_FEATURE_RATIO` (0.05) of its bbox diagonal is a thin curved sliver that RDP cannot simplify without distorting its feature size — so it's left untouched (the faithful original is kept).

- Cleanly separates the cases: ratio ≈ **0.0015** for the 100 mm × 24 m #820 wall vs ≈ **0.25** for a round window.
- Fat shapes (round windows) still simplify → the **#635 void-cut polygon budget is preserved**.
- A **self-intersection backstop** (`closed_loop_self_intersects`, O(n²) proper-crossing scan) plus an **oversized-loop fail-safe** cover anything that slips through.

## Verification

- Real #820 fixture through the full pipeline: simple annular sector, bottom-cap `|signed|/abs = 1.0000` (no overlapping flap triangles), area 4.999e6 ≈ true 5.006e6.
- New fixture-free unit tests: 4 thin-sector cases stay simple + within **2% area (was ±13%)**; a 127-gon disk **still simplifies** (locks in #635); a bowtie tests the self-intersection scanner.
- Full geometry suite (**314 tests**) passes, including #635 void-cutting, #655 W410, and round-window regressions.
- The viewer's `processGeometryBatch` shares `profiles.rs`, so it gets the fix automatically (wasm crate builds clean).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved closed-polyline downsampling to avoid degrading thin curved slivers by detecting narrow features and skipping simplification when needed; added a post-simplification verification to reject results that produce self-intersections, returning the original geometry instead.

* **Tests**
  * Expanded unit tests covering intersection detection and edge cases: thin annular sectors, self-intersecting loops, and large disks to ensure simplification retains validity and reduces vertices where safe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->