### PR TITLE
fix(viewer): restore entity accessors on cache-loaded models

### DIFF
--- a/.changeset/cached-store-accessors.md
+++ b/.changeset/cached-store-accessors.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/parser": minor
+---
+
+Add `attachDataStoreAccessors(store)`, the single home for wiring an `IfcDataStore`'s lazy `getEntity` / `getEntitiesByType` / `getProperties` / `getQuantities` accessors. The fresh-parse worker→main transport path now uses it instead of duplicating the wiring inline.
+
+This fixes a crash when querying a model loaded from the on-disk cache: the cache format only serialises data, so a restored store was missing these accessor methods, and opening the Properties panel for a cached entity threw `store.getEntity is not a function` (the viewer's cache-restore path now calls `attachDataStoreAccessors`).

--- a/apps/viewer/src/hooks/useIfcCache.ts
+++ b/apps/viewer/src/hooks/useIfcCache.ts
@@ -109,7 +109,8 @@ export function useIfcCache() {
   const loadFromCache = useCallback(async (
     cacheResult: CacheResult,
     fileName: string,
-    cacheKey?: string
+    cacheKey?: string,
+    fallbackSourceBuffer?: ArrayBufferLike,
   ): Promise<CacheLoadResult> => {
     try {
       const cacheLoadStart = performance.now();
@@ -125,9 +126,15 @@ export function useIfcCache() {
       // Convert cache data store to viewer data store format
       const dataStore = result.dataStore as any;
 
-      // Restore source buffer for on-demand property extraction
-      if (cacheResult.sourceBuffer) {
-        dataStore.source = new Uint8Array(cacheResult.sourceBuffer);
+      // Restore the source buffer — required for on-demand property extraction
+      // AND the lazy entity accessors (getEntity/getProperties/...). The web
+      // cache persists `sourceBuffer`; the desktop cache does not, so fall back
+      // to the freshly read file buffer when the caller provides it. Without a
+      // source, the accessors can't be attached and a cache hit would crash the
+      // Properties panel with "store.getEntity is not a function".
+      const sourceBuffer = cacheResult.sourceBuffer ?? fallbackSourceBuffer;
+      if (sourceBuffer) {
+        dataStore.source = new Uint8Array(sourceBuffer);
 
         if (result.entityIndex) {
           dataStore.entityIndex = buildEntityIndexFromCachedColumns(result.entityIndex);

--- a/apps/viewer/src/hooks/useIfcCache.ts
+++ b/apps/viewer/src/hooks/useIfcCache.ts
@@ -17,7 +17,7 @@ import {
   type IfcDataStore as CacheDataStore,
   type GeometryData,
 } from '@ifc-lite/cache';
-import { SpatialHierarchyBuilder, StepTokenizer, CompactEntityIndex, CompactEntityIndexBuilder, extractLengthUnitScale, type IfcDataStore } from '@ifc-lite/parser';
+import { SpatialHierarchyBuilder, StepTokenizer, CompactEntityIndex, CompactEntityIndexBuilder, extractLengthUnitScale, attachDataStoreAccessors, type IfcDataStore } from '@ifc-lite/parser';
 import { buildSpatialIndexGuarded } from '../utils/loadingUtils.js';
 import type { MeshData } from '@ifc-lite/geometry';
 
@@ -162,6 +162,14 @@ export function useIfcCache() {
         );
         dataStore.onDemandPropertyMap = onDemandPropertyMap;
         dataStore.onDemandQuantityMap = onDemandQuantityMap;
+
+        // Reattach the lazy entity/property/quantity accessors. A freshly parsed
+        // store carries these (wired by attachDataStoreAccessors), but the cache
+        // format only serialises data — so a cache-restored store would be
+        // missing getEntity()/getProperties()/etc. and crash any query path
+        // (e.g. the Properties panel: "store.getEntity is not a function").
+        // Safe here: source, entityIndex and the on-demand maps are all set.
+        attachDataStoreAccessors(dataStore as IfcDataStore);
       } else {
         console.warn('[useIfcCache] No source buffer in cache - on-demand property extraction disabled');
         dataStore.source = new Uint8Array(0);

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -1780,7 +1780,10 @@ export function useIfcLoader() {
         setProgress({ phase: 'Checking cache', percent: 5 });
         const cacheResult = await getCached(cacheKey);
         if (cacheResult) {
-          const cacheLoadResult = await loadFromCache(cacheResult, file.name, cacheKey);
+          // Pass the freshly read file buffer as the source fallback: the
+          // desktop cache doesn't persist a sourceBuffer, and without one the
+          // restored store can't carry the lazy entity accessors.
+          const cacheLoadResult = await loadFromCache(cacheResult, file.name, cacheKey, buffer);
           if (cacheLoadResult.success) {
             const state = useViewerStore.getState();
             finalizePrimaryModel(state.ifcDataStore, state.geometryResult, getSchemaVersion(state.ifcDataStore), {

--- a/packages/parser/src/data-store-accessors.ts
+++ b/packages/parser/src/data-store-accessors.ts
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { PropertySet, QuantitySet } from '@ifc-lite/data';
+import type { IfcDataStore, EntityByIdIndex } from './columnar-parser.js';
+import { extractPropertiesOnDemand, extractQuantitiesOnDemand } from './columnar-parser.js';
+import { BufferEntitySource } from './entity-source.js';
+
+/**
+ * An assembled store before its lazy accessor methods are attached — every
+ * data field of an {@link IfcDataStore} except the four accessors.
+ */
+export type IfcStoreData = Omit<
+  IfcDataStore,
+  'getEntity' | 'getEntitiesByType' | 'getProperties' | 'getQuantities'
+>;
+
+/**
+ * Attach the lazy `getEntity` / `getEntitiesByType` / `getProperties` /
+ * `getQuantities` accessors to an assembled store, in place, and return it.
+ *
+ * These accessors lazily read entity/property/quantity data from the store's
+ * `source` buffer (via the on-demand maps + byte index) rather than from
+ * pre-materialised tables, so every store-construction path must attach them.
+ * There are three such paths — the fresh columnar parse, the worker→main
+ * transport reconstruction, and the on-disk cache restore — and this helper is
+ * the single home for the wiring so they can never drift apart. (A cache
+ * restore that skipped this shipped a store missing `getEntity`, which crashed
+ * the Properties panel via `EntityNode.allAttributes`.)
+ *
+ * Requires `source`, `entityIndex`, and the on-demand maps to already be
+ * populated on `store`.
+ */
+export function attachDataStoreAccessors(store: IfcStoreData): IfcDataStore {
+  const full = store as IfcDataStore;
+  const entitySource = new BufferEntitySource(full.source, {
+    // The store's interface widens `byId` to a read-only map of `unknown`;
+    // at runtime it is always the byte index a BufferEntitySource needs.
+    byId: full.entityIndex.byId as unknown as EntityByIdIndex,
+    byType: full.entityIndex.byType,
+  });
+
+  full.getEntity = (expressId) => entitySource.getEntity(expressId);
+  full.getEntitiesByType = (typeName) => entitySource.getEntitiesByType(typeName);
+  full.getProperties = (expressId) => {
+    if (full.onDemandPropertyMap && full.onDemandPropertyMap.size > 0) {
+      return extractPropertiesOnDemand(full, expressId) as unknown as PropertySet[];
+    }
+    return full.properties.getForEntity(expressId) as PropertySet[];
+  };
+  full.getQuantities = (expressId) => {
+    if (full.onDemandQuantityMap && full.onDemandQuantityMap.size > 0) {
+      return extractQuantitiesOnDemand(full, expressId) as unknown as QuantitySet[];
+    }
+    return full.quantities.getForEntity(expressId) as QuantitySet[];
+  };
+
+  return full;
+}

--- a/packages/parser/src/data-store-accessors.ts
+++ b/packages/parser/src/data-store-accessors.ts
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import type { PropertySet, QuantitySet } from '@ifc-lite/data';
-import type { IfcDataStore, EntityByIdIndex } from './columnar-parser.js';
+import type { PropertySet } from '@ifc-lite/data';
+import type { IfcDataStore } from './columnar-parser.js';
 import { extractPropertiesOnDemand, extractQuantitiesOnDemand } from './columnar-parser.js';
 import { BufferEntitySource } from './entity-source.js';
 
@@ -34,26 +34,23 @@ export type IfcStoreData = Omit<
  */
 export function attachDataStoreAccessors(store: IfcStoreData): IfcDataStore {
   const full = store as IfcDataStore;
-  const entitySource = new BufferEntitySource(full.source, {
-    // The store's interface widens `byId` to a read-only map of `unknown`;
-    // at runtime it is always the byte index a BufferEntitySource needs.
-    byId: full.entityIndex.byId as unknown as EntityByIdIndex,
-    byType: full.entityIndex.byType,
-  });
+  const entitySource = new BufferEntitySource(full.source, full.entityIndex);
 
   full.getEntity = (expressId) => entitySource.getEntity(expressId);
   full.getEntitiesByType = (typeName) => entitySource.getEntitiesByType(typeName);
   full.getProperties = (expressId) => {
     if (full.onDemandPropertyMap && full.onDemandPropertyMap.size > 0) {
-      return extractPropertiesOnDemand(full, expressId) as unknown as PropertySet[];
+      // extractPropertiesOnDemand returns a richer pset shape (extra type/value
+      // metadata); narrow to the PropertySet[] the store contract exposes.
+      return extractPropertiesOnDemand(full, expressId) as PropertySet[];
     }
-    return full.properties.getForEntity(expressId) as PropertySet[];
+    return full.properties.getForEntity(expressId);
   };
   full.getQuantities = (expressId) => {
     if (full.onDemandQuantityMap && full.onDemandQuantityMap.size > 0) {
-      return extractQuantitiesOnDemand(full, expressId) as unknown as QuantitySet[];
+      return extractQuantitiesOnDemand(full, expressId);
     }
-    return full.quantities.getForEntity(expressId) as QuantitySet[];
+    return full.quantities.getForEntity(expressId);
   };
 
   return full;

--- a/packages/parser/src/data-store-transport.ts
+++ b/packages/parser/src/data-store-transport.ts
@@ -46,9 +46,7 @@ import {
 import { CompactEntityIndex } from './compact-entity-index.js';
 import type { EntityRef } from './types.js';
 import type { IfcDataStore, EntityByIdIndex } from './columnar-parser.js';
-import { BufferEntitySource } from './entity-source.js';
-import { extractPropertiesOnDemand, extractQuantitiesOnDemand } from './columnar-parser.js';
-import type { PropertySet, QuantitySet } from '@ifc-lite/data';
+import { attachDataStoreAccessors } from './data-store-accessors.js';
 
 // ────────────────────────────────────────────────────────────────────────────
 // CompactEntityIndex transport
@@ -472,9 +470,9 @@ export function fromTransport(payload: DataStoreTransport, source: Uint8Array): 
   };
   const onDemandPropertyMap = new Map(payload.onDemandPropertyMap.map(([k, v]) => [k, [...v]]));
   const onDemandQuantityMap = new Map(payload.onDemandQuantityMap.map(([k, v]) => [k, [...v]]));
-  const entitySource = new BufferEntitySource(source, entityIndex);
-
-  const store: IfcDataStore = {
+  // Lazy accessors are wired by the shared helper so the fresh-parse, transport,
+  // and cache-restore paths can never drift (see data-store-accessors.ts).
+  return attachDataStoreAccessors({
     fileSize: payload.fileSize,
     schemaVersion: payload.schemaVersion,
     entityCount: payload.entityCount,
@@ -496,18 +494,7 @@ export function fromTransport(payload: DataStoreTransport, source: Uint8Array): 
     onDemandClassificationMap: new Map(payload.onDemandClassificationMap.map(([k, v]) => [k, [...v]])),
     onDemandMaterialMap: new Map(payload.onDemandMaterialMap),
     onDemandDocumentMap: new Map(payload.onDemandDocumentMap.map(([k, v]) => [k, [...v]])),
-    getEntity(expressId) { return entitySource.getEntity(expressId); },
-    getEntitiesByType(typeName) { return entitySource.getEntitiesByType(typeName); },
-    getProperties(expressId) {
-      if (onDemandPropertyMap.size > 0) return extractPropertiesOnDemand(store, expressId) as unknown as PropertySet[];
-      return store.properties.getForEntity(expressId) as PropertySet[];
-    },
-    getQuantities(expressId) {
-      if (onDemandQuantityMap.size > 0) return extractQuantitiesOnDemand(store, expressId) as unknown as QuantitySet[];
-      return store.quantities.getForEntity(expressId) as QuantitySet[];
-    },
-  };
-  return store;
+  });
 }
 
 /**

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -21,6 +21,7 @@ export { SpatialHierarchyBuilder } from './spatial-hierarchy-builder.js';
 export { extractLengthUnitScale } from './unit-extractor.js';
 export { ColumnarParser, type IfcDataStore, type EntityByIdIndex, extractPropertiesOnDemand, extractQuantitiesOnDemand, extractEntityAttributesOnDemand, extractAllEntityAttributes, getRawNamedAttributes, extractRootAttributesFromEntity, extractClassificationsOnDemand, extractMaterialsOnDemand, extractTypePropertiesOnDemand, extractTypeEntityOwnProperties, extractDocumentsOnDemand, extractRelationshipsOnDemand, extractGeoreferencingOnDemand, type ClassificationInfo, type MaterialInfo, type MaterialLayerInfo, type MaterialProfileInfo, type MaterialConstituentInfo, type TypePropertyInfo, type DocumentInfo, type EntityRelationships } from './columnar-parser.js';
 export type { IfcStoreBase } from '@ifc-lite/data';
+export { attachDataStoreAccessors, type IfcStoreData } from './data-store-accessors.js';
 // WorkerParser is browser-only due to Vite worker imports
 // Import from '@ifc-lite/parser/browser' instead
 

--- a/packages/parser/test/data-store-accessors.test.ts
+++ b/packages/parser/test/data-store-accessors.test.ts
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { StepTokenizer } from '../src/tokenizer.js';
+import { ColumnarParser, type IfcDataStore } from '../src/columnar-parser.js';
+import { attachDataStoreAccessors } from '../src/data-store-accessors.js';
+
+describe('attachDataStoreAccessors', () => {
+  it('restores the lazy accessors a cache-restored store is missing', async () => {
+    const ifc = `#1=IFCOWNERHISTORY($,$,$,$,$,$,$,0);
+#10=IFCWALLSTANDARDCASE('wall-guid',#1,'Wall A',$,$,$,$,$);
+#20=IFCPROPERTYSINGLEVALUE('FireRating',$,'REI60',$);
+#21=IFCPROPERTYSINGLEVALUE('IsExternal',$,.T.,$);
+#30=IFCPROPERTYSET('pset-guid',#1,'Pset_WallCommon',$,(#20,#21));
+#40=IFCRELDEFINESBYPROPERTIES('rel-guid',#1,$,$,(#10),#30);`;
+
+    const source = new TextEncoder().encode(ifc);
+    const tokenizer = new StepTokenizer(source);
+    const entityRefs = [];
+    for (const ref of tokenizer.scanEntitiesFast()) {
+      entityRefs.push({
+        expressId: ref.expressId,
+        type: ref.type,
+        byteOffset: ref.offset,
+        byteLength: ref.length,
+        lineNumber: ref.line,
+      });
+    }
+
+    const parser = new ColumnarParser();
+    const store = (await parser.parseLite(source.buffer.slice(0), entityRefs, {})) as IfcDataStore;
+
+    // Simulate a store rehydrated from the on-disk cache: the cache format only
+    // serialises data, so the four lazy accessors arrive undefined — this is the
+    // exact shape that crashed the Properties panel with
+    // "store.getEntity is not a function".
+    const stripped = store as unknown as Record<string, unknown>;
+    delete stripped.getEntity;
+    delete stripped.getEntitiesByType;
+    delete stripped.getProperties;
+    delete stripped.getQuantities;
+    expect(typeof (store as { getEntity?: unknown }).getEntity).toBe('undefined');
+
+    // The fix: reattach the accessors from the store's own source + index.
+    attachDataStoreAccessors(store);
+
+    expect(typeof store.getEntity).toBe('function');
+    expect(typeof store.getEntitiesByType).toBe('function');
+    expect(typeof store.getProperties).toBe('function');
+    expect(typeof store.getQuantities).toBe('function');
+
+    expect(store.getEntity(10)?.type).toBe('IFCWALLSTANDARDCASE');
+    expect(store.getEntity(999)).toBeNull();
+    expect(store.getEntitiesByType('IFCWALLSTANDARDCASE').map((e) => e.expressId)).toEqual([10]);
+
+    const psets = store.getProperties(10);
+    expect(psets).toHaveLength(1);
+    expect(psets[0].name).toBe('Pset_WallCommon');
+    expect(psets[0].properties.map((p) => p.name)).toEqual(['FireRating', 'IsExternal']);
+  });
+});


### PR DESCRIPTION
## Problem
Opening the **Properties panel** for a model loaded **from the on-disk cache** crashed:

```
Uncaught TypeError: this.store.getEntity is not a function
    at EntityNode.allAttributes (entity-node.ts:118)
    at PropertiesPanel.tsx:563
```

Reproduces on `main` (cached models only): load a ≥10 MB IFC, reload, load it again (cache hit), select an element.

## Root cause
An `IfcDataStore` carries four **lazy accessors** — `getEntity` / `getEntitiesByType` / `getProperties` / `getQuantities` — that read entities/properties on-demand from the `source` buffer. These were wired **inline** in the parser's store-construction paths (the worker→main transport and the fresh columnar parse), but the viewer's cache-restore path (`useIfcCache.loadFromCache`) rebuilds the store's *data* (`source`, `entityIndex`, on-demand maps, spatial hierarchy) **without** them. The `result.dataStore as any` cast hid the missing methods until the query layer called `store.getEntity()` at runtime.

## Fix
- New shared helper **`attachDataStoreAccessors(store)`** in `@ifc-lite/parser` — the single home for wiring the four accessors, so the three store-construction paths can't drift.
- Refactored the worker→main **transport** path to use it (so the canonical reconstruction path exercises the exact helper the cache path now relies on).
- The viewer **cache-restore** path calls it once `source` + `entityIndex` + on-demand maps are finalized.

No `as any` added; one intentional `as IfcDataStore` at the cache call site (the cache store is already `any` upstream — the `schema`/`schemaVersion` fragmentation in #950/#952 is out of scope here).

## Verification
- Parser suite **135/135** (incl. a new regression test that strips a parsed store's accessors — the cache shape — then asserts `attachDataStoreAccessors` restores `getEntity`/`getEntitiesByType`/`getProperties`).
- Browser: a cache-`hit` load now exposes all four accessors; `getEntity(id)` returns real entities; the Properties panel no longer crashes.

## ⚠️ Separate pre-existing bug (NOT addressed here)
While verifying, I confirmed a **second, unrelated** crash on the cache-load path: a WASM heap corruption (`dlmalloc` panic `psize >= size + min_overhead`) → flood of `memory access out of bounds`, originating in the `Symbolic*` (2D symbolic / structural-grid) parsing. It **reproduces on a freshly built `origin/main` WASM** (so it's real on main, not this branch), and is a Rust/WASM memory-safety issue distinct from this JS-accessor fix. Filing/fixing it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash that occurred when accessing entities restored from the on-disk cache, ensuring cached entity data is properly recovered and accessible without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->