### PR TITLE
ci: cut CI/CD spend — free runners, per-project Vercel skip, prebuilt WASM

### DIFF
--- a/.github/workflows/desktop-compat.yml
+++ b/.github/workflows/desktop-compat.yml
@@ -33,8 +33,10 @@ permissions:
 jobs:
   desktop-frontend-build:
     name: Desktop frontend build
+    # Stays on Depot: this job compiles the WASM bundle from source
+    # (setup-wasm-build + pnpm build + build:desktop).
     runs-on: depot-ubuntu-24.04-4
-    timeout-minutes: 10
+    timeout-minutes: 12
 
     steps:
       - name: Checkout ifc-lite (PR branch)
@@ -76,7 +78,9 @@ jobs:
 
   desktop-override-audit:
     name: Desktop override audit
-    runs-on: depot-ubuntu-24.04-4
+    # Free runner — this job only checks that override-target files exist
+    # (a few `[ -f ]` tests). No build, no compile, no cache needed.
+    runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,7 +55,12 @@ jobs:
           lfs: false
           persist-credentials: false
 
+      # QEMU is only needed to emulate the non-native arm64 build, which we
+      # now only do on `release: published` (see the `platforms` expression
+      # below). Skipping it on main pushes shaves setup time off the frequent
+      # amd64-only builds.
       - name: Set up QEMU
+        if: github.event_name == 'release'
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Set up Docker Buildx
@@ -93,5 +98,15 @@ jobs:
             ${{ steps.meta.outputs.labels }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
           cache-from: type=gha
+          # mode=max keeps the cargo-chef "cooked deps" stage in the cache —
+          # that layer is what makes warm builds finish in minutes instead of
+          # recompiling the whole workspace (incl. the manifold-csg-sys C++
+          # kernel), so dropping to mode=min would *raise* compute minutes.
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
+          # Build arm64 only for actual releases (distribution images). On the
+          # frequent push-to-main builds (~1/3 of commits touch rust/** and
+          # trigger this workflow) we build amd64 only — the arm64 leg runs
+          # under slow QEMU emulation and doubled both build time AND the gha
+          # cache that drives Depot's per-GB storage bill. The `latest`/sha
+          # main images stay amd64; multi-arch manifests ship on release.
+          platforms: ${{ github.event_name == 'release' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,12 @@ jobs:
   # Doc-only and non-test changes skip every expensive job below.
   changes:
     name: Detect changes
-    runs-on: depot-ubuntu-24.04
+    # Free GitHub-hosted runner. ifc-lite is a PUBLIC repo, so standard
+    # `ubuntu-latest` runners are free + unlimited (GitHub only bills public
+    # repos for *larger* runners). Light jobs — path filter, lint, the gate —
+    # don't need Depot's paid cores; only the Rust/WASM-compile jobs do.
+    # See scripts/README-vercel-cost.md for the full runner-cost rationale.
+    runs-on: ubuntu-latest
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
       frontend: ${{ steps.filter.outputs.frontend }}
@@ -163,8 +168,9 @@ jobs:
     name: Typecheck
     needs: [changes, build]
     if: needs.changes.outputs.frontend == 'true'
-    runs-on: depot-ubuntu-24.04-4
-    timeout-minutes: 10
+    # tsc is not CPU-bound; the free 2-core runner is fine and costs nothing.
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -187,7 +193,8 @@ jobs:
     name: Lint
     needs: [changes, build]
     if: needs.changes.outputs.frontend == 'true'
-    runs-on: depot-ubuntu-24.04
+    # Free runner — eslint runs against source, no compile.
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -207,8 +214,9 @@ jobs:
     name: Node tests
     needs: [changes, build]
     if: needs.changes.outputs.frontend == 'true' || needs.changes.outputs.rust == 'true'
-    runs-on: depot-ubuntu-24.04-4
-    timeout-minutes: 15
+    # Free runner — vitest consumes the prebuilt artifact; not compile-bound.
+    runs-on: ubuntu-latest
+    timeout-minutes: 18
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -240,8 +248,13 @@ jobs:
     name: Rust tests
     needs: changes
     if: needs.changes.outputs.rust == 'true'
-    runs-on: depot-ubuntu-24.04-8
-    timeout-minutes: 20
+    # Stays on Depot for the uncapped, fast cargo cache (GitHub's free cache
+    # is 10 GB LRU and would thrash the Rust target dir). Right-sized 8→4
+    # cores: Depot bills minutes × (vCPU/2), so -8 is 4× and -4 is 2× the
+    # base rate — halving per-minute cost for ~1.5× wall-clock. Timeout
+    # bumped to absorb the slower wall-clock.
+    runs-on: depot-ubuntu-24.04-4
+    timeout-minutes: 28
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -292,8 +305,11 @@ jobs:
     name: Rust tests (Manifold CSG kernel)
     needs: changes
     if: needs.changes.outputs.geometry == 'true'
-    runs-on: depot-ubuntu-24.04-8
-    timeout-minutes: 25
+    # Stays on Depot (cmake + Manifold/Clipper2 C++ compile + cargo cache).
+    # Right-sized 8→4 cores (Depot bills × vCPU/2). Timeout bumped for the
+    # slower wall-clock on 4 cores.
+    runs-on: depot-ubuntu-24.04-4
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -327,7 +343,8 @@ jobs:
     name: Build + WASM + Rust + Node
     needs: [changes, build, typecheck, lint, node-tests, rust-tests, manifold-tests]
     if: always()
-    runs-on: depot-ubuntu-24.04
+    # Free runner — the gate just inspects upstream job results.
+    runs-on: ubuntu-latest
     steps:
       - name: Gate on dependencies
         run: |

--- a/scripts/README-vercel-cost.md
+++ b/scripts/README-vercel-cost.md
@@ -112,27 +112,39 @@ After this, `ifc-lite-dev` skips ~all commits (only rebuilds when
   production, or ignore non-`main` refs). A landing page rarely needs PR previews.
 - `ifc-lite` and `ifc-lite-viewer-embed`: keep **Standard 4-core** (correct).
 
-### 3c. Biggest remaining viewer-build lever (needs a decision) 🔬
-Every viewer/embed build re-provisions the WASM toolchain from scratch —
+### 3c. Prebuilt-WASM fast path — IMPLEMENTED (option A) ✅
+Every viewer/embed build was re-provisioning the WASM toolchain from scratch —
 re-cloning emsdk and **re-downloading ~270 MB of wasm-binaries** + the Rust
 toolchain — *despite* "Restored build cache from previous deployment". The
-`/vercel/cache/emsdk` dir is not surviving between builds (likely a Vercel
-build-cache size/scope limit). That's ~40–60 s of wasted build on every viewer
-build, on two projects, on every relevant commit.
+`/vercel/cache/emsdk` dir does not reliably survive between builds. That was
+~40–60 s of wasted bootstrap on every viewer/embed build, on every commit.
 
 `rust/wasm-bindings/Cargo.toml` enables `manifold-csg-wasm-uu`, so emsdk **is**
-genuinely required to compile from source — it is not dead weight. Two ways out,
-pick one (out of scope for this PR — flag for follow-up):
+genuinely required to compile from source — it is not dead weight.
 
-- **(A) Use the published WASM instead of compiling.** `scripts/fetch-prebuilt-wasm.mjs`
-  already downloads `@ifc-lite/wasm@<version>` from npm. Wiring the Vercel build
-  to fetch prebuilt when `rust/**` is unchanged turns multi-minute builds into
-  ~30 s for the ~2/3 of commits that don't touch Rust. Tradeoff: a *preview* of a
-  Rust-changing PR would ship the last-published WASM (production after release is
-  always correct). Acceptable for most previews; confirm before adopting.
-- **(B) Make `/vercel/cache/emsdk` actually persist** (pin emsdk version, shrink
-  the cached prefix to just `upstream/bin` + libc++ headers, verify it survives).
-  Keeps from-source correctness on every preview; needs cache-size investigation.
+**What was implemented:** `scripts/vercel-install.sh` now has an early fast path.
+It computes `@ifc-lite/wasm@<version>` from `packages/wasm/package.json`, makes
+the tag reachable (best-effort `git fetch`), and only when `git diff` proves
+`rust/** + Cargo.{toml,lock} + rust-toolchain.toml + scripts/build-wasm.sh` are
+**byte-identical to that release tag**, it runs `scripts/fetch-prebuilt-wasm.mjs`
+to drop the published bundle into `packages/wasm/pkg/` and skips the entire
+Rust/emsdk bootstrap. The from-source build phase then no-ops via the existing
+soft-skip in `build-wasm.sh` (no wasm-pack on PATH + artifact present → success).
+
+**Why it's safe:** any uncertainty — version unreadable, tag not reachable in
+Vercel's shallow clone, npm 404, fetch failure, or *any* Rust change since the
+release — falls through to the unchanged from-source build. It can never ship a
+stale WASM bundle. On Rust-changing PR previews it compiles from source exactly
+as before; on the ~2/3 of deploys that don't touch Rust it skips minutes of work.
+
+**Needs one real-deploy check:** confirm Vercel's shallow clone lets the
+`git fetch` of the release tag succeed (logs will print `🅰 … using prebuilt`
+vs `🛠 … building from source`). If tags are unreachable, set the project's
+Git "fetch tags"/depth or switch to the alternative below.
+
+**Alternative (B), not used:** make `/vercel/cache/emsdk` persist (pin emsdk,
+shrink the cached prefix, verify survival). Keeps from-source on every preview;
+needs cache-size investigation. Kept here in case (A)'s tag fetch proves flaky.
 
 ---
 

--- a/scripts/README-vercel-cost.md
+++ b/scripts/README-vercel-cost.md
@@ -1,0 +1,147 @@
+<!--
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+-->
+
+# CI/CD cost playbook (Vercel · Depot · GitHub Actions)
+
+`ifc-lite` is a **public** repo with very high activity (~100 merged PRs and
+~250 commits to `main` per month). That combination makes CI/CD spend the
+dominant infra cost. This doc records why the spend happens and the levers
+that control it. It is referenced from `scripts/vercel-ignore-build.sh` and
+`.github/workflows/test.yml`.
+
+Snapshot that triggered this work (June 2026):
+
+| Provider | ~Monthly | Why |
+|---|---|---|
+| Depot (GitHub Actions runners + cache) | ~$147 | Heavy CI jobs run on **paid** Depot runners; cache grew to 173 GB |
+| GitHub Actions | **$0** | Public repo → standard runners are free + unlimited |
+| Vercel (builds) | ~$165 | 3 repo-linked projects rebuild on **every** commit; 1 was on the 30-core Turbo machine |
+
+---
+
+## 1. The runner economics (read this first)
+
+- **Public repos get free, *unlimited* standard `ubuntu-latest` runners.** GitHub
+  only bills public repos for **larger** runners (4/8/16-core) — and those are
+  *more expensive than Depot* (GH 8-core $0.022/min vs Depot $0.016/min). So you
+  cannot "save" by moving big jobs to GitHub larger runners; the only free option
+  is the standard 2-core `ubuntu-latest`.
+- **Depot bills normalized minutes = `wall-minutes × (vCPU / 2)`.** A
+  `depot-ubuntu-24.04` (2 vCPU) is 1×; `-4` is 2×; `-8` is 4×. So an 8-core job
+  costs **4× per wall-minute** of the base. Right-sizing `-8 → -4` halves the
+  per-minute cost for ~1.5× wall-clock.
+- **Depot's value is the uncapped, fast cache** (no 10 GB LRU cap like GitHub's
+  free Actions cache) + native arm64 runners. Keep Rust-compile jobs there so
+  the cargo target dir doesn't thrash; push everything cheap to free runners.
+
+### What runs where now (after this change)
+
+| Job | Runner | Rationale |
+|---|---|---|
+| `changes`, `lint`, `typecheck`, `node-tests`, `test` gate | `ubuntu-latest` (free) | Not compile-bound; free + unlimited on a public repo |
+| `desktop-override-audit` | `ubuntu-latest` (free) | Only `[ -f ]` file checks |
+| `build` (WASM) | `depot-ubuntu-24.04-4` | Compiles the WASM bundle (emsdk/LLVM); needs cores + cache |
+| `desktop-frontend-build` | `depot-ubuntu-24.04-4` | Compiles WASM from source |
+| `rust-tests` | `depot-ubuntu-24.04-4` (was `-8`) | Kept on Depot for the cargo cache; right-sized for cost |
+| `manifold-tests` | `depot-ubuntu-24.04-4` (was `-8`) | cmake + Manifold/Clipper2 C++; cache-bound |
+
+`release.yml`, `docs.yml`, `sdk-canary.yml` already use free `ubuntu-latest`.
+
+### Depot — do this in the dashboard (one-time)
+- **Cache → Retention: 7 days** (default is 14 days, *no size cap* — that's how it
+  reached 173 GB). Combined with the docker arm64 change below this is the main
+  cache-cost lever.
+
+---
+
+## 2. Docker image builds (`.github/workflows/docker.yml`)
+
+`docker.yml` fires on every push to `main` that touches `rust/**` / `Cargo.*` /
+`apps/server/**` (~1/3 of commits) and builds `linux/amd64,linux/arm64`. The
+arm64 leg runs under **QEMU emulation** (slow) and **doubles the `type=gha`
+cache** that drives Depot's per-GB bill.
+
+Change: build **amd64 only on push-to-main** (`latest`/sha images), and
+**multi-arch only on `release: published`** (distribution images). `mode=max` is
+intentionally kept — it caches the cargo-chef "cooked deps" layer that makes
+warm builds finish in minutes; `mode=min` would *raise* compute minutes.
+
+Future option if arm64-on-main is ever wanted again: use Depot's **native arm64
+runners** (`depot-ubuntu-24.04-arm-*`, AWS Graviton, no QEMU) via a build matrix
+instead of emulation.
+
+---
+
+## 3. Vercel builds — the real picture
+
+Three repo-linked projects, all building on **every** push (preview + prod),
+because Vercel's monorepo default deploys every connected project per commit:
+
+| Project | Domain | Build machine | What it builds |
+|---|---|---|---|
+| `ifc-lite` | ifc-lite-ltplus.vercel.app | Standard 4-core ✅ | Viewer (Rust+WASM from source) |
+| `ifc-lite-viewer-embed` | embed.ifclite.com | Standard 4-core ✅ | Embed (Rust+WASM from source) |
+| `ifc-lite-dev` | **ifclite.dev** (landing) | **Turbo 30-core** 🔴 | Static landing — `0 tasks, 182 ms` |
+
+Two structural problems:
+
+1. **No per-project scoping.** A pure-geometry Rust PR rebuilt the *landing
+   page*; a landing copy-edit could spin up the *viewer*. Fixed in code:
+   `scripts/vercel-ignore-build.sh` now takes a scope arg (see §3a).
+2. **The landing page runs on the 30-core Turbo machine** ($0.126/min — 9× the
+   Standard $0.014/min rate) to copy static files. Pure waste; fix in dashboard.
+
+### 3a. Set each project's Ignored Build Step (dashboard → Settings → Git)
+
+```
+ifc-lite               →  bash scripts/vercel-ignore-build.sh viewer
+ifc-lite-viewer-embed  →  bash scripts/vercel-ignore-build.sh embed
+ifc-lite-dev           →  bash scripts/vercel-ignore-build.sh landing
+```
+
+After this, `ifc-lite-dev` skips ~all commits (only rebuilds when
+`apps/landing/**` changes), and viewer/embed stop rebuilding for each other.
+
+### 3b. Build machine + previews (dashboard, per project)
+- **`ifc-lite-dev` → Build machine: Standard or Elastic** (NOT Turbo). It's a
+  182 ms static build; 30 cores is pure cost.
+- **`ifc-lite-dev` → disable preview deployments** (Settings → Git → Deploy only
+  production, or ignore non-`main` refs). A landing page rarely needs PR previews.
+- `ifc-lite` and `ifc-lite-viewer-embed`: keep **Standard 4-core** (correct).
+
+### 3c. Biggest remaining viewer-build lever (needs a decision) 🔬
+Every viewer/embed build re-provisions the WASM toolchain from scratch —
+re-cloning emsdk and **re-downloading ~270 MB of wasm-binaries** + the Rust
+toolchain — *despite* "Restored build cache from previous deployment". The
+`/vercel/cache/emsdk` dir is not surviving between builds (likely a Vercel
+build-cache size/scope limit). That's ~40–60 s of wasted build on every viewer
+build, on two projects, on every relevant commit.
+
+`rust/wasm-bindings/Cargo.toml` enables `manifold-csg-wasm-uu`, so emsdk **is**
+genuinely required to compile from source — it is not dead weight. Two ways out,
+pick one (out of scope for this PR — flag for follow-up):
+
+- **(A) Use the published WASM instead of compiling.** `scripts/fetch-prebuilt-wasm.mjs`
+  already downloads `@ifc-lite/wasm@<version>` from npm. Wiring the Vercel build
+  to fetch prebuilt when `rust/**` is unchanged turns multi-minute builds into
+  ~30 s for the ~2/3 of commits that don't touch Rust. Tradeoff: a *preview* of a
+  Rust-changing PR would ship the last-published WASM (production after release is
+  always correct). Acceptable for most previews; confirm before adopting.
+- **(B) Make `/vercel/cache/emsdk` actually persist** (pin emsdk version, shrink
+  the cached prefix to just `upstream/bin` + libc++ headers, verify it survives).
+  Keeps from-source correctness on every preview; needs cache-size investigation.
+
+---
+
+## 4. Pricing reference (verified against vendor docs, 2025/2026)
+
+- Depot: $0.004/min base (2 vCPU); minutes × `vCPU/2`; cache $0.20/GB after 25 GB
+  included; retention 7/14/30 d (default 14, no size cap). Native arm64 = Graviton.
+- GitHub Actions: standard runners free + unlimited on public repos; larger
+  runners always billed even on public repos (Linux 4-core $0.012, 8-core $0.022).
+- Vercel builds: Standard 4-core $0.014/min, Enhanced 8-core $0.03, Turbo 30-core
+  $0.126, Elastic $0.0035/CPU-min. Remote Cache auto-enabled on Vercel builds.
+  "Skip unaffected projects" / Ignored Build Step is the monorepo cost lever.

--- a/scripts/vercel-ignore-build.sh
+++ b/scripts/vercel-ignore-build.sh
@@ -43,6 +43,14 @@ set -uo pipefail
 # Defaults to `viewer` so the historical no-arg command keeps working.
 SCOPE="${1:-viewer}"
 
+# Run from the git repo root so the pathspecs below resolve correctly no
+# matter which Root Directory a Vercel project sets — Vercel invokes the
+# Ignored Build Step from the project's Root Directory, and the embed
+# project's root is `apps/viewer-embed`, not the repo root. Fall back to the
+# current dir if we're somehow not in a git work tree (git diff then fails
+# closed → DEPLOY, the safe default).
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)" || true
+
 # Vercel exposes the commit being built and its parent. Use the parent
 # pointer that Vercel sets (`VERCEL_GIT_PREVIOUS_SHA`) when available
 # — for production deploys this points at the previous *successful*

--- a/scripts/vercel-ignore-build.sh
+++ b/scripts/vercel-ignore-build.sh
@@ -3,13 +3,25 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Vercel "Ignored Build Step" entry point.
+# Vercel "Ignored Build Step" entry point — PROJECT-SCOPED.
 #
-# Paste this script's path into the Vercel project's
+# Set this as each Vercel project's
 #   Settings → Git → Ignored Build Step
-# field:
+# command, passing the scope for that project:
 #
-#   bash scripts/vercel-ignore-build.sh
+#   ifc-lite (viewer)        →  bash scripts/vercel-ignore-build.sh viewer
+#   ifc-lite-viewer-embed    →  bash scripts/vercel-ignore-build.sh embed
+#   ifc-lite-dev (landing)   →  bash scripts/vercel-ignore-build.sh landing
+#
+# Why per-scope: all three projects are wired to the same repo, so by
+# default EVERY push deploys ALL of them (Vercel monorepo default). The
+# heavy viewer / viewer-embed projects each compile Rust + WASM from
+# source (rust toolchain + emsdk + cargo, several minutes), and the
+# landing page is a static no-op build — yet a pure-geometry Rust PR was
+# rebuilding the landing, and a landing copy-edit was spinning up the
+# viewer. Scoping each project to the paths it actually consumes is the
+# single biggest Vercel build-minute lever for this repo.
+# See scripts/README-vercel-cost.md for the full cost rationale.
 #
 # Vercel runs the script for every push. Per the Vercel docs:
 #
@@ -17,19 +29,19 @@
 #   exit 1  → run the deploy as normal
 #   any other → run the deploy as normal
 #
-# We skip when the commit changes nothing the viewer build cares about:
-# no Rust source, no Cargo manifests, no rust-toolchain pin, no
-# package manifests, no build/CI scripts, no viewer/renderer/wasm code,
-# no shared package code, no Vite/Turbo config. The default decision
-# when in doubt is to DEPLOY (exit 1), so this is conservative — a
-# false negative wastes a build, a false positive ships a stale viewer.
+# The default decision when in doubt is to DEPLOY (exit 1), so this is
+# conservative — a false negative wastes a build, a false positive ships
+# a stale deploy.
 #
-# Pairs with Turbo Remote Cache (see scripts/README-vercel-cost.md):
-# Turbo handles per-task cache hits when something Rust-adjacent
-# changed; this script handles the no-op-change case where Turbo
-# would otherwise still spin up a fresh Vercel build container only
-# to find every task cached.
+# Pairs with Turbo Remote Cache (auto-enabled on Vercel builds): Turbo
+# handles per-task cache hits when something relevant changed; this
+# script handles the no-op case where Vercel would otherwise spin up a
+# fresh build container only to find every task cached (or nothing to do).
 set -uo pipefail
+
+# Scope selects which paths count as "relevant" for this project.
+# Defaults to `viewer` so the historical no-arg command keeps working.
+SCOPE="${1:-viewer}"
 
 # Vercel exposes the commit being built and its parent. Use the parent
 # pointer that Vercel sets (`VERCEL_GIT_PREVIOUS_SHA`) when available
@@ -39,13 +51,9 @@ set -uo pipefail
 BASE="${VERCEL_GIT_PREVIOUS_SHA:-HEAD^}"
 HEAD_SHA="${VERCEL_GIT_COMMIT_SHA:-HEAD}"
 
-echo "🔍 Vercel ignored-build-step check"
-echo "   BASE=$BASE  HEAD=$HEAD_SHA"
-
-# `git diff --quiet` returns 0 when there are no changes matching the
-# pathspec, 1 when there are. We want to *skip* the build only when
-# every pathspec returns 0 (no relevant changes).
-RELEVANT=(
+# Shared inputs every Rust+WASM app (viewer, viewer-embed) depends on.
+# The landing page is static and depends on NONE of these.
+COMMON=(
   # Rust sources + manifests + lockfile (anything Rust-adjacent rebuilds WASM)
   'Cargo.toml'
   'Cargo.lock'
@@ -57,9 +65,7 @@ RELEVANT=(
   'scripts/vercel-install.sh'
   'scripts/run-build-wasm.mjs'
   'scripts/fetch-prebuilt-wasm.mjs'
-  # Anything that participates in the viewer bundle.
-  'apps/viewer/**'
-  'apps/viewer-embed/**'
+  # Shared workspace packages consumed by both apps.
   'packages/**/src/**'
   'packages/**/package.json'
   'packages/wasm/**'
@@ -73,8 +79,33 @@ RELEVANT=(
   'vercel.json'
 )
 
+case "$SCOPE" in
+  viewer)
+    RELEVANT=("${COMMON[@]}" 'apps/viewer/**')
+    ;;
+  embed)
+    RELEVANT=("${COMMON[@]}" 'apps/viewer-embed/**')
+    ;;
+  landing)
+    # Static landing page (apps/landing): plain HTML/CSS/JS, no deps, no
+    # compile. It depends ONLY on its own files — never on Rust/WASM or
+    # the shared packages — so it must NOT rebuild on viewer/geometry PRs.
+    RELEVANT=('apps/landing/**')
+    ;;
+  *)
+    echo "❌ Unknown scope '$SCOPE' (expected: viewer | embed | landing)." >&2
+    echo "   Defaulting to DEPLOY to stay safe." >&2
+    exit 1
+    ;;
+esac
+
+echo "🔍 Vercel ignored-build-step check (scope=$SCOPE)"
+echo "   BASE=$BASE  HEAD=$HEAD_SHA"
+
+# `git diff --quiet` returns 0 when there are no changes matching the
+# pathspec, 1 when there are. Skip the build only when no relevant path changed.
 if git diff --quiet "$BASE" "$HEAD_SHA" -- "${RELEVANT[@]}"; then
-  echo "✅ No relevant changes — skipping deploy."
+  echo "✅ No changes relevant to '$SCOPE' — skipping deploy."
   exit 0
 fi
 

--- a/scripts/vercel-install.sh
+++ b/scripts/vercel-install.sh
@@ -38,14 +38,18 @@ WASM_TAG="@ifc-lite/wasm@${WASM_VERSION}"
 WASM_SRC_PATHS=(rust Cargo.lock Cargo.toml rust-toolchain.toml scripts/build-wasm.sh)
 
 if [ -n "${WASM_VERSION:-}" ] && command -v git >/dev/null 2>&1; then
-  # Vercel clones shallow and usually without tags — best-effort fetch the one
-  # release tag we need. Failure is fine; the verify below then falls through.
-  if ! git rev-parse -q --verify "refs/tags/${WASM_TAG}^{commit}" >/dev/null 2>&1; then
-    git fetch --no-tags --depth=1 origin \
-      "refs/tags/${WASM_TAG}:refs/tags/${WASM_TAG}" >/dev/null 2>&1 || true
+  _tag_present() { git rev-parse -q --verify "refs/tags/${WASM_TAG}^{commit}" >/dev/null 2>&1; }
+  if ! _tag_present; then
+    # Vercel clones shallow without tags — fetch just this one release tag so
+    # we can diff against it. Surfaced (not silenced) so a blocked fetch is
+    # visible in the build log rather than masquerading as "source changed".
+    echo "ℹ️  Fetching release tag ${WASM_TAG} (shallow)…"
+    git fetch --depth=1 origin "+refs/tags/${WASM_TAG}:refs/tags/${WASM_TAG}" 2>&1 \
+      | sed 's/^/     git-fetch: /' || true
   fi
-  if git rev-parse -q --verify "refs/tags/${WASM_TAG}^{commit}" >/dev/null 2>&1 \
-     && git diff --quiet "refs/tags/${WASM_TAG}" HEAD -- "${WASM_SRC_PATHS[@]}"; then
+  if ! _tag_present; then
+    echo "🛠  Release tag ${WASM_TAG} not reachable in this clone — building WASM from source."
+  elif git diff --quiet "refs/tags/${WASM_TAG}" HEAD -- "${WASM_SRC_PATHS[@]}"; then
     echo "🅰  WASM source identical to ${WASM_TAG} — using prebuilt npm bundle,"
     echo "   skipping Rust toolchain + emsdk bootstrap + from-source compile."
     if node scripts/fetch-prebuilt-wasm.mjs; then
@@ -55,8 +59,9 @@ if [ -n "${WASM_VERSION:-}" ] && command -v git >/dev/null 2>&1; then
     fi
     echo "⚠️  Prebuilt WASM fetch failed — falling back to from-source build."
   else
-    echo "🛠  WASM source differs from ${WASM_TAG} (or tag unreachable) —"
-    echo "   building WASM from source."
+    echo "🛠  Rust sources changed since ${WASM_TAG} — building WASM from source."
+    git diff --name-only "refs/tags/${WASM_TAG}" HEAD -- "${WASM_SRC_PATHS[@]}" \
+      | sed 's/^/     changed: /' | head -20 || true
   fi
 fi
 # ── From-source build (Rust changed, or no matching/reachable release tag) ────

--- a/scripts/vercel-install.sh
+++ b/scripts/vercel-install.sh
@@ -36,6 +36,10 @@ WASM_TAG="@ifc-lite/wasm@${WASM_VERSION}"
 # Conservative superset: any Rust workspace change invalidates the fast path,
 # even one that doesn't reach the wasm-bindings crate. Correctness over savings.
 WASM_SRC_PATHS=(rust Cargo.lock Cargo.toml rust-toolchain.toml scripts/build-wasm.sh)
+# Vercel's build checkout has NO usable `origin` remote (confirmed: `git fetch
+# origin` → "'origin' does not appear to be a git repository"). Fetch the tag
+# straight from the public GitHub URL instead — anonymous read needs no auth.
+WASM_REPO_URL="https://github.com/${VERCEL_GIT_REPO_OWNER:-LTplus-AG}/${VERCEL_GIT_REPO_SLUG:-ifc-lite}.git"
 
 if [ -n "${WASM_VERSION:-}" ] && command -v git >/dev/null 2>&1; then
   _tag_present() { git rev-parse -q --verify "refs/tags/${WASM_TAG}^{commit}" >/dev/null 2>&1; }
@@ -43,8 +47,8 @@ if [ -n "${WASM_VERSION:-}" ] && command -v git >/dev/null 2>&1; then
     # Vercel clones shallow without tags — fetch just this one release tag so
     # we can diff against it. Surfaced (not silenced) so a blocked fetch is
     # visible in the build log rather than masquerading as "source changed".
-    echo "ℹ️  Fetching release tag ${WASM_TAG} (shallow)…"
-    git fetch --depth=1 origin "+refs/tags/${WASM_TAG}:refs/tags/${WASM_TAG}" 2>&1 \
+    echo "ℹ️  Fetching release tag ${WASM_TAG} from ${WASM_REPO_URL} (shallow)…"
+    git fetch --depth=1 "${WASM_REPO_URL}" "+refs/tags/${WASM_TAG}:refs/tags/${WASM_TAG}" 2>&1 \
       | sed 's/^/     git-fetch: /' || true
   fi
   if ! _tag_present; then

--- a/scripts/vercel-install.sh
+++ b/scripts/vercel-install.sh
@@ -18,6 +18,49 @@
 # ~30-60 s; warm cache adds essentially nothing.
 set -euo pipefail
 
+# ── Prebuilt-WASM fast path (see scripts/README-vercel-cost.md §3c) ───────────
+#
+# The from-source bootstrap below re-clones emsdk and re-downloads ~270 MB of
+# wasm-binaries + the Rust toolchain on every deploy (the /vercel/cache copy
+# doesn't reliably persist). On the ~2/3 of deploys that don't touch Rust we
+# can skip ALL of that and use the already-published @ifc-lite/wasm from npm.
+#
+# CORRECTNESS GUARD — we only take this path when git proves the WASM source
+# (rust/** + Cargo manifests + toolchain pin + build script) is byte-identical
+# to the `@ifc-lite/wasm@<version>` release tag that produced the published
+# binary. Any uncertainty — version unreadable, tag unreachable in Vercel's
+# shallow clone, npm 404, fetch failure — falls through to the full from-source
+# build below (today's behaviour). This path can never ship a stale WASM bundle.
+WASM_VERSION="$(node -p "require('./packages/wasm/package.json').version" 2>/dev/null || true)"
+WASM_TAG="@ifc-lite/wasm@${WASM_VERSION}"
+# Conservative superset: any Rust workspace change invalidates the fast path,
+# even one that doesn't reach the wasm-bindings crate. Correctness over savings.
+WASM_SRC_PATHS=(rust Cargo.lock Cargo.toml rust-toolchain.toml scripts/build-wasm.sh)
+
+if [ -n "${WASM_VERSION:-}" ] && command -v git >/dev/null 2>&1; then
+  # Vercel clones shallow and usually without tags — best-effort fetch the one
+  # release tag we need. Failure is fine; the verify below then falls through.
+  if ! git rev-parse -q --verify "refs/tags/${WASM_TAG}^{commit}" >/dev/null 2>&1; then
+    git fetch --no-tags --depth=1 origin \
+      "refs/tags/${WASM_TAG}:refs/tags/${WASM_TAG}" >/dev/null 2>&1 || true
+  fi
+  if git rev-parse -q --verify "refs/tags/${WASM_TAG}^{commit}" >/dev/null 2>&1 \
+     && git diff --quiet "refs/tags/${WASM_TAG}" HEAD -- "${WASM_SRC_PATHS[@]}"; then
+    echo "🅰  WASM source identical to ${WASM_TAG} — using prebuilt npm bundle,"
+    echo "   skipping Rust toolchain + emsdk bootstrap + from-source compile."
+    if node scripts/fetch-prebuilt-wasm.mjs; then
+      echo "📦 Running pnpm install --frozen-lockfile..."
+      pnpm install --frozen-lockfile
+      exit 0
+    fi
+    echo "⚠️  Prebuilt WASM fetch failed — falling back to from-source build."
+  else
+    echo "🛠  WASM source differs from ${WASM_TAG} (or tag unreachable) —"
+    echo "   building WASM from source."
+  fi
+fi
+# ── From-source build (Rust changed, or no matching/reachable release tag) ────
+
 if ! command -v rustup >/dev/null 2>&1; then
   echo "📦 Installing rustup (minimal profile, no default toolchain)..."
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \


### PR DESCRIPTION
## Why
`ifc-lite` is a **public** repo (free, unlimited GitHub standard runners), yet
nearly all CI ran on **paid Depot runners**, and all three repo-linked Vercel
projects rebuilt on every commit — one of them (the static landing page) on the
30-core Turbo machine. June snapshot: ~$147/mo Depot + ~$165/mo Vercel.

Full analysis + the dashboard steps that pair with this PR live in
`scripts/README-vercel-cost.md`.

## GitHub Actions (Depot bill)
- Move light jobs to **free `ubuntu-latest`**: `changes`, `lint`, `typecheck`,
  `node-tests`, the aggregate gate, and `desktop-override-audit`.
- Keep the WASM/Rust-compile jobs on Depot (uncapped fast cargo cache):
  `build`, `desktop-frontend-build`, `rust-tests`, `manifold-tests`.
- Right-size `rust-tests` + `manifold-tests` **`-8` → `-4`** cores. Depot bills
  `minutes × (vCPU/2)`, so this halves their per-minute rate; timeouts bumped to
  absorb the slower wall-clock.

## Docker
- Build **amd64 only on push-to-main**; full `linux/amd64,linux/arm64` only on
  **release**. The arm64 leg ran under QEMU emulation and doubled both build time
  and the `type=gha` cache driving Depot's per-GB bill. `mode=max` kept (it caches
  the cargo-chef deps layer; `mode=min` would *raise* compute).

## Vercel
- `scripts/vercel-ignore-build.sh` is now **project-scoped** (`viewer|embed|landing`)
  so projects stop rebuilding for each other's changes. Defaults to `viewer` so the
  existing no-arg command keeps working.
- `scripts/vercel-install.sh` gains a **prebuilt-WASM fast path**: when `git`
  proves `rust/** + Cargo.{toml,lock} + rust-toolchain.toml + scripts/build-wasm.sh`
  are byte-identical to the `@ifc-lite/wasm@<version>` release tag, it fetches the
  published bundle and **skips the ~270 MB emsdk + Rust bootstrap + from-source
  compile**. Any uncertainty (unreadable version, unreachable tag, npm 404, fetch
  failure, or *any* Rust change) falls through to the unchanged from-source build —
  it can never ship a stale WASM bundle.

## Dashboard steps to apply alongside this PR (see the doc)
- `ifc-lite` → Ignored Build Step: `bash scripts/vercel-ignore-build.sh viewer`
- `ifc-lite-viewer-embed` → `bash scripts/vercel-ignore-build.sh embed`
- `ifc-lite-dev` (landing) → off the 30-core Turbo machine; skip via folder check
- Depot → cache retention 7 days

## Verification
- YAML + bash validated; the project-scoped skip and the prebuilt guard were
  tested against real commits/tags locally.
- **One real-deploy check:** the first preview deploy should print `🅰 … using
  prebuilt` (fast path live) or `🛠 … building from source` (tag unreachable in
  Vercel's shallow clone → harmless fallback). If always from-source, see the
  alternative in `scripts/README-vercel-cost.md` §3c.