### PR TITLE
fix(viewer): free leaked symbolic WASM handles (heap corruption on cache loads)

### DIFF
--- a/apps/viewer/src/hooks/useDrawingGeneration.ts
+++ b/apps/viewer/src/hooks/useDrawingGeneration.ts
@@ -179,18 +179,29 @@ export function useDrawingGeneration({
           try {
             await processor.init();
 
+            // SymbolicRepresentationCollection and each getPolyline/getCircle
+            // item are wasm-bindgen handles owning WASM memory — free them
+            // deterministically (AGENTS.md §7). Leaking them to GC lets the
+            // FinalizationRegistry free them later against an already-grown/
+            // reused shared dlmalloc heap, corrupting the allocator free-list.
             const symbolicCollection = processor.parseSymbolicRepresentations(ifcDataStore!.source);
             // For single-model (legacy) mode, model index is always 0
             // Multi-model symbolic parsing would require iterating over each model separately
             const symbolicModelIndex = 0;
 
-            if (symbolicCollection && !symbolicCollection.isEmpty) {
+            if (symbolicCollection) {
+              try {
+                if (!symbolicCollection.isEmpty) {
               // Process polylines
               for (let i = 0; i < symbolicCollection.polylineCount; i++) {
                 const poly = symbolicCollection.getPolyline(i);
                 if (!poly) continue;
+                try {
 
                 entitiesWithSymbols.add(poly.expressId);
+                // poly.points is consumed synchronously within this iteration
+                // (centroid sum + segment pushes read scalar values out of it);
+                // the array itself is never stored, so no copy is needed.
                 const points = poly.points;
                 const pointCount = poly.pointCount;
                 // WASM exposes `worldY` on every symbolic primitive — the
@@ -249,12 +260,16 @@ export function useDrawingGeneration({
                     worldZ: polyWorldZ,
                   });
                 }
+                } finally {
+                  poly.free();
+                }
               }
 
               // Process circles/arcs
               for (let i = 0; i < symbolicCollection.circleCount; i++) {
                 const circle = symbolicCollection.getCircle(i);
                 if (!circle) continue;
+                try {
 
                 entitiesWithSymbols.add(circle.expressId);
                 const numSegments = circle.isFullCircle ? 32 : 16;
@@ -293,6 +308,13 @@ export function useDrawingGeneration({
                     worldZ: circleWorldZ,
                   });
                 }
+                } finally {
+                  circle.free();
+                }
+              }
+                }
+              } finally {
+                symbolicCollection.free();
               }
             }
           } finally {

--- a/apps/viewer/src/hooks/useSymbolicAnnotations.ts
+++ b/apps/viewer/src/hooks/useSymbolicAnnotations.ts
@@ -248,6 +248,11 @@ async function parseAnnotations(
   const processor = new GeometryProcessor();
   try {
     await processor.init();
+    // SymbolicRepresentationCollection and each getPolyline/getCircle/getText/
+    // getFill item are wasm-bindgen handles owning WASM memory — free them
+    // deterministically (AGENTS.md §7). Leaking them to GC lets the
+    // FinalizationRegistry free them later against an already-grown/reused
+    // shared dlmalloc heap, corrupting the allocator free-list.
     const collection = processor.parseSymbolicRepresentations(source);
     if (debugEnabled()) {
       console.log(
@@ -257,7 +262,9 @@ async function parseAnnotations(
           : 'null',
       );
     }
-    if (!collection || collection.isEmpty) return result;
+    if (!collection) return result;
+    try {
+    if (collection.isEmpty) return result;
 
     // Resolve a bucket by elevation rather than by storey id.
     //
@@ -313,34 +320,44 @@ async function parseAnnotations(
     for (let i = 0; i < collection.polylineCount; i++) {
       const poly = collection.getPolyline(i);
       if (!poly) continue;
-      if (poly.ifcType !== 'IfcAnnotation' && poly.ifcType !== 'IfcGridAxis') continue;
-      const bucket = ensureBucket(poly.expressId, poly.worldY, poly.ifcType);
-      const looseTarget = poly.ifcType === 'IfcGridAxis' ? result.gridLoose : result.loose;
-      const out = bucket ? bucket.lines : looseTarget;
-      polylineToSegments(poly.points, poly.pointCount, poly.isClosed, out);
+      try {
+        if (poly.ifcType !== 'IfcAnnotation' && poly.ifcType !== 'IfcGridAxis') continue;
+        const bucket = ensureBucket(poly.expressId, poly.worldY, poly.ifcType);
+        const looseTarget = poly.ifcType === 'IfcGridAxis' ? result.gridLoose : result.loose;
+        const out = bucket ? bucket.lines : looseTarget;
+        // poly.points is consumed synchronously here (not stored), so no copy needed.
+        polylineToSegments(poly.points, poly.pointCount, poly.isClosed, out);
+      } finally {
+        poly.free();
+      }
     }
 
     for (let i = 0; i < collection.circleCount; i++) {
       const circle = collection.getCircle(i);
       if (!circle) continue;
-      if (circle.ifcType !== 'IfcAnnotation' && circle.ifcType !== 'IfcGridAxis') continue;
-      const bucket = ensureBucket(circle.expressId, circle.worldY, circle.ifcType);
-      const looseTarget = circle.ifcType === 'IfcGridAxis' ? result.gridLoose : result.loose;
-      const out = bucket ? bucket.lines : looseTarget;
-      circleToSegments(
-        circle.centerX,
-        circle.centerY,
-        circle.radius,
-        circle.startAngle,
-        circle.endAngle,
-        circle.isFullCircle,
-        out,
-      );
+      try {
+        if (circle.ifcType !== 'IfcAnnotation' && circle.ifcType !== 'IfcGridAxis') continue;
+        const bucket = ensureBucket(circle.expressId, circle.worldY, circle.ifcType);
+        const looseTarget = circle.ifcType === 'IfcGridAxis' ? result.gridLoose : result.loose;
+        const out = bucket ? bucket.lines : looseTarget;
+        circleToSegments(
+          circle.centerX,
+          circle.centerY,
+          circle.radius,
+          circle.startAngle,
+          circle.endAngle,
+          circle.isFullCircle,
+          out,
+        );
+      } finally {
+        circle.free();
+      }
     }
 
     for (let i = 0; i < collection.textCount; i++) {
       const text = collection.getText(i);
       if (!text) continue;
+      try {
       if (text.ifcType !== 'IfcAnnotation' && text.ifcType !== 'IfcGridAxis') continue;
       // Skip empty literals so the renderer doesn't waste an instance slot.
       // Decode STEP escapes — `\X2\NNNN\X0\` (UTF-16 hex code units) and
@@ -398,30 +415,45 @@ async function parseAnnotations(
         };
         (bucket ? bucket.texts : looseTextTarget).push(t2d);
       }
+      } finally {
+        text.free();
+      }
     }
 
     for (let i = 0; i < collection.fillCount; i++) {
       const fill = collection.getFill(i);
       if (!fill) continue;
-      if (fill.ifcType !== 'IfcAnnotation' && fill.ifcType !== 'IfcGridAxis') continue;
-      const points = fill.points;
-      if (points.length < 6) continue; // <3 vertices = no polygon
-      const f2d: AnnotationFill2D = {
-        points,
-        holesOffsets: fill.holesOffsets,
-        color: [fill.fillR, fill.fillG, fill.fillB, fill.fillA],
-        hatching: fill.hasHatching
-          ? {
-              spacing: fill.hatchSpacing,
-              angle: fill.hatchAngle,
-              angleSecondary: Number.isNaN(fill.hatchAngleSecondary) ? null : fill.hatchAngleSecondary,
-              lineWidth: fill.hatchLineWidth,
-            }
-          : undefined,
-      };
-      const bucket = ensureBucket(fill.expressId, fill.worldY, fill.ifcType);
-      const looseFillTarget = fill.ifcType === 'IfcGridAxis' ? result.gridLooseFills : result.looseFills;
-      (bucket ? bucket.fills : looseFillTarget).push(f2d);
+      try {
+        if (fill.ifcType !== 'IfcAnnotation' && fill.ifcType !== 'IfcGridAxis') continue;
+        // fill.points / fill.holesOffsets are getter results that may be views
+        // into WASM memory; they're STORED into f2d (outlive this iteration),
+        // so copy them before the handle is freed below. Element types match
+        // the AnnotationFill2D fields (Float32Array / Uint32Array).
+        const points = new Float32Array(fill.points);
+        if (points.length < 6) continue; // <3 vertices = no polygon
+        const holesOffsets = new Uint32Array(fill.holesOffsets);
+        const f2d: AnnotationFill2D = {
+          points,
+          holesOffsets,
+          color: [fill.fillR, fill.fillG, fill.fillB, fill.fillA],
+          hatching: fill.hasHatching
+            ? {
+                spacing: fill.hatchSpacing,
+                angle: fill.hatchAngle,
+                angleSecondary: Number.isNaN(fill.hatchAngleSecondary) ? null : fill.hatchAngleSecondary,
+                lineWidth: fill.hatchLineWidth,
+              }
+            : undefined,
+        };
+        const bucket = ensureBucket(fill.expressId, fill.worldY, fill.ifcType);
+        const looseFillTarget = fill.ifcType === 'IfcGridAxis' ? result.gridLooseFills : result.looseFills;
+        (bucket ? bucket.fills : looseFillTarget).push(f2d);
+      } finally {
+        fill.free();
+      }
+    }
+    } finally {
+      collection.free();
     }
   } finally {
     processor.dispose();


### PR DESCRIPTION
## Problem
Loading a model (most reliably a **cache-loaded** one) flooded the console with thousands of `RuntimeError: memory access out of bounds` plus a Rust allocator panic and **crashed the page**:

```
panicked at dlmalloc-0.2.10/src/dlmalloc.rs:1201:
assertion failed: psize >= size + min_overhead
… SymbolicPolylineFinalization / SymbolicTextFinalization / SymbolicFillAreaFinalization
```

Reproduces on a freshly built **origin/main** WASM (not a branch/staging artifact).

## Root cause
Symbolic-representation parsing leaks **every** wasm-bindgen handle. `GeometryProcessor.parseSymbolicRepresentations` returns a `SymbolicRepresentationCollection`, and each `getPolyline/getCircle/getText/getFill` returns a per-item handle — all own WASM linear memory. Neither consumer (`useSymbolicAnnotations`, `useDrawingGeneration`) ever called `.free()`, so they were reclaimed only by the `FinalizationRegistry` at a non-deterministic later time. By then a subsequent parse had grown/reused the single shared dlmalloc heap, so the GC `__wbg_*_free` ran against a stale free-list and corrupted it — the next allocation trips the assertion. It surfaces most reliably on cache loads because annotations/grids default-on, so the symbolic parse always runs against a freshly pressured main-realm heap.

The sibling `parseGridAxes` already frees deterministically (`try/finally`, AGENTS.md §7) — the symbolic path was the lone exception.

## Fix
Mirror `parseGridAxes`: wrap each item in `try { … } finally { item.free() }` (so it frees on the existing early-`continue`s and on throw) and free the collection in an outer `finally`. Stored arrays (`fill.points`, `fill.holesOffsets`) are **copied** before the item is freed (the getters may return views into WASM memory); arrays consumed synchronously (`poly.points` → `polylineToSegments`) are not.

Consumer-level (no public API change): `apps/viewer/src/hooks/useSymbolicAnnotations.ts` + `apps/viewer/src/hooks/useDrawingGeneration.ts`.

## Verification
- Viewer typecheck clean.
- **In-browser, origin/main:** a cache-hit load that previously flooded with ~2.5k–5k OOB errors and crashed the page now **completes with zero console errors**, page alive, annotations intact. The clean fresh load is unaffected.

Pairs with #980 (missing entity accessors on cache restore) — together they make cache-loaded models fully usable again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)