### PR TITLE
ci(vercel): fix ignore-step base (HEAD^ fallback) + doc command paths

### DIFF
--- a/scripts/README-vercel-cost.md
+++ b/scripts/README-vercel-cost.md
@@ -96,14 +96,24 @@ Two structural problems:
 
 ### 3a. Set each project's Ignored Build Step (dashboard → Settings → Git)
 
+GOTCHA — Vercel runs the Ignored Build Step from each project's **Root
+Directory**, not the repo root. So the command path is relative to that root.
+The viewer's root is `./`; embed's is `apps/viewer-embed` (hence `../../`);
+landing's is `apps/landing` (so it just checks `.`, its own folder).
+
 ```
-ifc-lite               →  bash scripts/vercel-ignore-build.sh viewer
-ifc-lite-viewer-embed  →  bash scripts/vercel-ignore-build.sh embed
-ifc-lite-dev           →  bash scripts/vercel-ignore-build.sh landing
+ifc-lite (root ./)                  →  bash scripts/vercel-ignore-build.sh viewer
+ifc-lite-viewer-embed (apps/viewer-embed) →  bash ../../scripts/vercel-ignore-build.sh embed
+ifc-lite-dev (apps/landing)         →  git diff HEAD^ HEAD --quiet -- .
 ```
 
+The landing page is static and depends only on `apps/landing`, so the plain
+`git diff -- .` (`.` = the landing folder, since the step runs from there) is
+simpler than the script. viewer/embed need the script because their relevant
+inputs span `rust/**`, `packages/**`, and config.
+
 After this, `ifc-lite-dev` skips ~all commits (only rebuilds when
-`apps/landing/**` changes), and viewer/embed stop rebuilding for each other.
+`apps/landing` changes), and viewer/embed stop rebuilding for each other.
 
 ### 3b. Build machine + previews (dashboard, per project)
 - **`ifc-lite-dev` → Build machine: Standard or Elastic** (NOT Turbo). It's a

--- a/scripts/vercel-ignore-build.sh
+++ b/scripts/vercel-ignore-build.sh
@@ -51,13 +51,19 @@ SCOPE="${1:-viewer}"
 # closed → DEPLOY, the safe default).
 cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)" || true
 
-# Vercel exposes the commit being built and its parent. Use the parent
-# pointer that Vercel sets (`VERCEL_GIT_PREVIOUS_SHA`) when available
-# — for production deploys this points at the previous *successful*
-# production deploy's commit, which is what we want to compare against.
-# Fall back to HEAD^ for branch/preview deploys with no previous.
-BASE="${VERCEL_GIT_PREVIOUS_SHA:-HEAD^}"
+# Pick the commit to diff against. `VERCEL_GIT_PREVIOUS_SHA` (the previous
+# successful deploy) is the most accurate base, BUT it usually points at a
+# commit that ISN'T in Vercel's shallow clone — `git diff` then dies with
+# "fatal: bad object <sha>", the check fails, and we deploy every time
+# (never skipping). So only use it when it's actually present in the clone;
+# otherwise fall back to HEAD^, which the shallow clone does include.
+BASE="${VERCEL_GIT_PREVIOUS_SHA:-}"
+if [ -z "$BASE" ] || ! git cat-file -e "${BASE}^{commit}" 2>/dev/null; then
+  BASE="HEAD^"
+fi
 HEAD_SHA="${VERCEL_GIT_COMMIT_SHA:-HEAD}"
+# Guard HEAD_SHA too: if Vercel's SHA isn't in the clone, use the literal HEAD.
+git cat-file -e "${HEAD_SHA}^{commit}" 2>/dev/null || HEAD_SHA="HEAD"
 
 # Shared inputs every Rust+WASM app (viewer, viewer-embed) depends on.
 # The landing page is static and depends on NONE of these.


### PR DESCRIPTION
Follow-up to #981, from verifying the live Vercel deploys.

## Bug: projects never skipped
`scripts/vercel-ignore-build.sh` used `VERCEL_GIT_PREVIOUS_SHA` as the diff base, but on Vercel that commit usually isn't in the shallow clone, so `git diff` died with `fatal: bad object <sha>` and every deploy fell through to "build" (observed live: the embed project's ignore step ran but never skipped).

Fix: use `VERCEL_GIT_PREVIOUS_SHA` only when `git cat-file -e` confirms it's in the clone; otherwise fall back to `HEAD^` (which the shallow clone includes). Same guard on `HEAD_SHA`. Still fails safe to DEPLOY on any uncertainty — never a stale skip. Verified locally: the bad-object case no longer errors, and a real in-clone base correctly SKIPs an embed-irrelevant commit.

## Doc fix
The Ignored Build Step runs from each project's **Root Directory**, not the repo root (confirmed live: `bash scripts/...` → "No such file" from `apps/viewer-embed`). Updated `scripts/README-vercel-cost.md` so the commands are root-relative:
- `ifc-lite` (`./`) → `bash scripts/vercel-ignore-build.sh viewer`
- `ifc-lite-viewer-embed` (`apps/viewer-embed`) → `bash ../../scripts/vercel-ignore-build.sh embed`
- `ifc-lite-dev` (`apps/landing`) → `git diff HEAD^ HEAD --quiet -- .`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CI/CD documentation to clarify how build step commands are evaluated relative to each project's root directory, with updated examples for different project configurations.

* **Chores**
  * Enhanced CI/CD build script to more reliably handle shallow repository clones by implementing fallback mechanisms when required environment variables are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->