### PR TITLE
chore(drawing-2d): remove 12 unused exports; keep symbol API (@public)

### DIFF
--- a/.changeset/drawing-2d-dead-export-sweep.md
+++ b/.changeset/drawing-2d-dead-export-sweep.md
@@ -1,0 +1,12 @@
+---
+"@ifc-lite/drawing-2d": patch
+---
+
+Remove 12 never-consumed exports flagged by `knip` (opening query helpers, the
+`createX` style/layer factory functions, and `buildOpeningRelationshipsFromData`).
+They had zero consumers anywhere in the repo, so this is internal cleanup with no
+behavioural change. The architectural-symbol generators (`generateNorthArrow`,
+`generateSectionMark`, `generateLevelMark`, the door/window `…At` variants,
+`generateOpeningSymbols`, `generateSimpleWindowLines`) are kept as intended
+public API and marked `@public`; the used classes, constants, and the
+`OpeningFilterOptions` type are untouched.

--- a/knip.json
+++ b/knip.json
@@ -9,6 +9,16 @@
     "packages/create-ifc-lite/src/templates/**",
     "apps/viewer/src/lib/scripts/templates/**"
   ],
-  "ignoreBinaries": ["wasm-pack", "cargo", "rustup", "serve"],
-  "ignoreWorkspaces": ["examples/*"]
+  "ignoreBinaries": [
+    "wasm-pack",
+    "cargo",
+    "rustup",
+    "serve"
+  ],
+  "ignoreWorkspaces": [
+    "examples/*"
+  ],
+  "tags": [
+    "-public"
+  ]
 }

--- a/packages/drawing-2d/src/openings/opening-relationship-builder.ts
+++ b/packages/drawing-2d/src/openings/opening-relationship-builder.ts
@@ -13,7 +13,6 @@ import type {
   FillRelationship,
   EntityMetadata,
   DoorOperationType,
-  Vec3,
 } from '../types.js';
 
 /**
@@ -134,19 +133,4 @@ export class OpeningRelationshipBuilder {
 
     return 'SINGLE_SWING_LEFT'; // Default
   }
-}
-
-/**
- * Create OpeningRelationships from raw data
- */
-export function buildOpeningRelationshipsFromData(
-  voids: VoidRelationship[],
-  fills: FillRelationship[],
-  entityMetadata?: Map<number, EntityMetadata>,
-  modelIndex: number = 0
-): OpeningRelationships {
-  return new OpeningRelationshipBuilder(entityMetadata)
-    .addVoidRelationships(voids)
-    .addFillRelationships(fills)
-    .build(modelIndex);
 }

--- a/packages/drawing-2d/src/openings/opening-utils.ts
+++ b/packages/drawing-2d/src/openings/opening-utils.ts
@@ -8,7 +8,6 @@
 
 import type {
   OpeningRelationships,
-  OpeningInfo,
   VoidRelationship,
   FillRelationship,
   EntityMetadata,
@@ -51,16 +50,6 @@ export function getFillingElement(
 }
 
 /**
- * Get opening info by entity ID (works for both opening and filling elements)
- */
-export function getOpeningInfo(
-  relationships: OpeningRelationships,
-  entityId: number
-): OpeningInfo | undefined {
-  return relationships.openingInfo.get(entityId);
-}
-
-/**
  * Check if an IFC type represents an opening element
  */
 export function isOpeningElement(ifcType: string): boolean {
@@ -83,109 +72,3 @@ export function isDoorOrWindow(ifcType: string): boolean {
   );
 }
 
-/**
- * Check if an IFC type is a host element that can have openings
- */
-export function isHostElement(ifcType: string): boolean {
-  const upper = ifcType.toUpperCase();
-  return (
-    upper.includes('WALL') ||
-    upper.includes('SLAB') ||
-    upper.includes('ROOF') ||
-    upper.includes('FLOOR')
-  );
-}
-
-/**
- * Get all host element IDs that have openings
- */
-export function getHostsWithOpenings(
-  relationships: OpeningRelationships
-): number[] {
-  return Array.from(relationships.voidedBy.keys());
-}
-
-/**
- * Get all door opening infos
- */
-export function getDoorOpenings(
-  relationships: OpeningRelationships
-): OpeningInfo[] {
-  const result: OpeningInfo[] = [];
-  const seen = new Set<number>();
-
-  for (const [, info] of relationships.openingInfo) {
-    if (info.type === 'door' && !seen.has(info.openingId)) {
-      result.push(info);
-      seen.add(info.openingId);
-    }
-  }
-  return result;
-}
-
-/**
- * Get all window opening infos
- */
-export function getWindowOpenings(
-  relationships: OpeningRelationships
-): OpeningInfo[] {
-  const result: OpeningInfo[] = [];
-  const seen = new Set<number>();
-
-  for (const [, info] of relationships.openingInfo) {
-    if (info.type === 'window' && !seen.has(info.openingId)) {
-      result.push(info);
-      seen.add(info.openingId);
-    }
-  }
-  return result;
-}
-
-/**
- * Filter entity IDs to exclude opening elements
- * Useful for filtering meshes before section cutting
- */
-export function filterOutOpeningElements(
-  entityIds: number[],
-  relationships: OpeningRelationships
-): number[] {
-  const openingIds = new Set<number>();
-
-  // Collect all opening and filling element IDs
-  for (const openingIdList of relationships.voidedBy.values()) {
-    for (const id of openingIdList) {
-      openingIds.add(id);
-    }
-  }
-  for (const fillingId of relationships.filledBy.values()) {
-    openingIds.add(fillingId);
-  }
-
-  return entityIds.filter((id) => !openingIds.has(id));
-}
-
-/**
- * Get the entity IDs that should be included in cut lines (hosts only)
- * Excludes opening elements and their filling elements
- */
-export function getHostEntityIds(
-  allEntityIds: number[],
-  relationships: OpeningRelationships,
-  ifcTypes: Map<number, string>
-): number[] {
-  const result: number[] = [];
-
-  for (const id of allEntityIds) {
-    const ifcType = ifcTypes.get(id);
-    if (!ifcType) continue;
-
-    // Skip opening elements and doors/windows
-    if (isOpeningElement(ifcType) || isDoorOrWindow(ifcType)) {
-      continue;
-    }
-
-    result.push(id);
-  }
-
-  return result;
-}

--- a/packages/drawing-2d/src/styling/layer-mapping.ts
+++ b/packages/drawing-2d/src/styling/layer-mapping.ts
@@ -14,7 +14,6 @@ import type {
   AIALayerCode,
   SemanticLineType,
   ArchitecturalLine,
-  LineWeight,
 } from '../types.js';
 
 /**
@@ -334,13 +333,4 @@ export class LayerMapper {
  */
 export function getLayerForIfcType(ifcType: string): AIALayerCode {
   return IFC_TYPE_TO_LAYER[ifcType] ?? 'A-WALL';
-}
-
-/**
- * Create a default layer mapper
- */
-export function createLayerMapper(
-  customLayers?: LayerDefinition[]
-): LayerMapper {
-  return new LayerMapper(customLayers ?? DEFAULT_LAYERS);
 }

--- a/packages/drawing-2d/src/styling/line-styles.ts
+++ b/packages/drawing-2d/src/styling/line-styles.ts
@@ -131,22 +131,3 @@ export class LineStyler {
     return rules.join('\n');
   }
 }
-
-/**
- * Create a default line styler
- */
-export function createLineStyler(): LineStyler {
-  return new LineStyler();
-}
-
-/**
- * Apply hidden line style (for lines marked as hidden)
- */
-export function applyHiddenStyle(line: ArchitecturalLine): ArchitecturalLine {
-  return {
-    ...line,
-    lineStyle: 'dashed',
-    lineWeight: 'hairline',
-    semanticType: 'hidden',
-  };
-}

--- a/packages/drawing-2d/src/styling/line-weights.ts
+++ b/packages/drawing-2d/src/styling/line-weights.ts
@@ -209,12 +209,3 @@ export class LineWeightAssigner {
     return LINE_WEIGHT_CONFIG[weight].widthPx;
   }
 }
-
-/**
- * Create a default line weight assigner
- */
-export function createLineWeightAssigner(
-  customWeights?: Record<string, LineWeight>
-): LineWeightAssigner {
-  return new LineWeightAssigner(customWeights);
-}

--- a/packages/drawing-2d/src/symbols/symbol-utils.ts
+++ b/packages/drawing-2d/src/symbols/symbol-utils.ts
@@ -31,6 +31,7 @@ export function generateDoorSymbol(
 
 /**
  * Generate a door symbol at a specific position
+ * @public
  */
 export function generateDoorSymbolAt(
   center: Point2D,
@@ -58,6 +59,7 @@ export function generateWindowSymbol(
 
 /**
  * Generate a window symbol at a specific position
+ * @public
  */
 export function generateWindowSymbolAt(
   center: Point2D,
@@ -96,6 +98,7 @@ export function generateStairArrow(
 
 /**
  * Generate a north arrow symbol
+ * @public
  */
 export function generateNorthArrow(
   position: Point2D,
@@ -113,6 +116,7 @@ export function generateNorthArrow(
 
 /**
  * Generate a section mark symbol
+ * @public
  */
 export function generateSectionMark(
   position: Point2D,
@@ -134,6 +138,7 @@ export function generateSectionMark(
 
 /**
  * Generate a level mark symbol
+ * @public
  */
 export function generateLevelMark(
   position: Point2D,
@@ -156,6 +161,7 @@ export function generateLevelMark(
 /**
  * Determine wall direction from opening bounds
  * Returns normalized direction along the longer axis
+ * @public
  */
 export function inferWallDirection(bounds2D: Bounds2D): Point2D {
   const width = bounds2D.max.x - bounds2D.min.x;
@@ -170,6 +176,7 @@ export function inferWallDirection(bounds2D: Bounds2D): Point2D {
 
 /**
  * Generate symbols for all openings
+ * @public
  */
 export function generateOpeningSymbols(
   openings: OpeningInfo[],

--- a/packages/drawing-2d/src/symbols/window-symbol.ts
+++ b/packages/drawing-2d/src/symbols/window-symbol.ts
@@ -287,6 +287,7 @@ export class WindowSymbolGenerator {
 
 /**
  * Generate simple window lines (frame only, no symbol object)
+ * @public
  */
 export function generateSimpleWindowLines(
   center: Point2D,


### PR DESCRIPTION
Follow-up to #989 (merged). While deleting the construction-projection feature's orphaned edge path, `knip` surfaced **pre-existing** unused exports in `@ifc-lite/drawing-2d`. Per AGENTS.md §28 ("an unused public export is permanent semver liability") this removes the genuinely-dead ones and explicitly marks the intended-public API.

All removed exports were verified to have **zero consumers anywhere** in `apps/` + `packages/` (incl. the SDK) via repo-wide grep + `pnpm knip`.

### Removed (12 — unambiguous dead code)
- **`openings/opening-utils.ts`** — query helpers: `getOpeningInfo`, `isHostElement`, `getHostsWithOpenings`, `getDoorOpenings`, `getWindowOpenings`, `filterOutOpeningElements`, `getHostEntityIds`
- **`openings/opening-relationship-builder.ts`** — `buildOpeningRelationshipsFromData`
- **`styling/{layer-mapping,line-styles,line-weights}.ts`** — the `createX` factory functions (`createLayerMapper`, `createLineStyler`, `createLineWeightAssigner`) + `applyHiddenStyle` (the classes they wrap stay)

…plus the imports those bodies stranded.

### Kept as intended public API — marked `@public`
The architectural-symbol generators (`generateNorthArrow`, `generateSectionMark`, `generateLevelMark`, `generateDoorSymbolAt`, `generateWindowSymbolAt`, `generateOpeningSymbols`, `inferWallDirection`, `generateSimpleWindowLines`) are a coherent drawing-symbol surface kept for consumers. They're annotated `@public` and knip is configured with `tags: ["-public"]` so they're no longer flagged as dead — making the intent explicit and preventing a future sweep from re-removing them.

### Kept (other)
`OpeningFilterOptions` — knip false positive; the `OpeningFilter` class consumes it. All used classes/consts untouched.

### Verification
`tsc --noEmit` clean · `vitest` pass · `knip` clean (12 gone; symbols excluded via `@public`; `OpeningFilterOptions` is the documented false positive) · repo-wide grep of every removed symbol → zero refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)