### PR TITLE
refactor(cache): rename cache IfcDataStore→CacheDataStore + typed hydrateCacheStore adapter (#952)

### DIFF
--- a/.changeset/cache-datastore-rename.md
+++ b/.changeset/cache-datastore-rename.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/cache": major
+---
+
+Rename the serialized data-store type `IfcDataStore` → `CacheDataStore`.
+
+This removes the name collision with `@ifc-lite/parser`'s runtime `IfcDataStore` — the two are structurally different (the cache type is the on-disk/serialized shape, keyed on a numeric `schema` enum, with no `source`/`parseTime`/accessors). Consumers importing the type from `@ifc-lite/cache` must switch `IfcDataStore` → `CacheDataStore`.

--- a/apps/viewer/src/hooks/useIfcCache.ts
+++ b/apps/viewer/src/hooks/useIfcCache.ts
@@ -13,11 +13,12 @@ import { useCallback } from 'react';
 import {
   BinaryCacheWriter,
   BinaryCacheReader,
+  SchemaVersion,
   type CachedEntityIndexColumns,
-  type IfcDataStore as CacheDataStore,
+  type CacheDataStore,
   type GeometryData,
 } from '@ifc-lite/cache';
-import { SpatialHierarchyBuilder, StepTokenizer, CompactEntityIndex, CompactEntityIndexBuilder, extractLengthUnitScale, attachDataStoreAccessors, type IfcDataStore } from '@ifc-lite/parser';
+import { SpatialHierarchyBuilder, StepTokenizer, CompactEntityIndex, CompactEntityIndexBuilder, extractLengthUnitScale, attachDataStoreAccessors, type IfcDataStore, type IfcStoreData } from '@ifc-lite/parser';
 import { buildSpatialIndexGuarded } from '../utils/loadingUtils.js';
 import type { MeshData } from '@ifc-lite/geometry';
 
@@ -50,6 +51,63 @@ function buildEntityIndexFromCachedColumns(columns: CachedEntityIndexColumns): I
     ids.push(columns.ids[i]);
   }
   return { byId, byType };
+}
+
+/**
+ * Build the viewer's runtime {@link IfcDataStore} from a deserialized
+ * {@link CacheDataStore}. This is the typed cache→runtime adapter (#952): the
+ * data tables (strings/entities/properties/quantities/relationships/
+ * spatialHierarchy) are the same `@ifc-lite/data` types in both stores, so the
+ * mapping is compiler-checked — there is no `as unknown as IfcDataStore` escape
+ * hatch, and a future required store member becomes a compile error here instead
+ * of a silent runtime crash. The only field that differs is `schema` (cache) →
+ * `schemaVersion` (runtime). Lazy entity/property/quantity accessors are wired
+ * via {@link attachDataStoreAccessors}; with a `source` + `entityIndex` they
+ * read live, otherwise they fall back to the pre-built cache tables.
+ */
+/**
+ * Map the cache's numeric {@link SchemaVersion} enum to the runtime store's
+ * string schema union. The cache format predates IFC5 (it stores IFC2X3/IFC4/
+ * IFC4X3 only), so anything else round-trips as IFC2X3 — matching the inverse
+ * mapping the save path uses.
+ */
+function cacheSchemaToVersion(schema: SchemaVersion): IfcDataStore['schemaVersion'] {
+  switch (schema) {
+    case SchemaVersion.IFC4: return 'IFC4';
+    case SchemaVersion.IFC4X3: return 'IFC4X3';
+    default: return 'IFC2X3';
+  }
+}
+
+function hydrateCacheStore(
+  cacheStore: CacheDataStore,
+  extras: {
+    source: Uint8Array;
+    fileSize: number;
+    entityIndex: IfcDataStore['entityIndex'];
+    onDemandPropertyMap?: Map<number, number[]>;
+    onDemandQuantityMap?: Map<number, number[]>;
+    onDemandMaterialMap?: Map<number, number>;
+  },
+): IfcDataStore {
+  const storeData: IfcStoreData = {
+    schemaVersion: cacheSchemaToVersion(cacheStore.schema),
+    entityCount: cacheStore.entityCount,
+    fileSize: extras.fileSize,
+    parseTime: 0,
+    source: extras.source,
+    strings: cacheStore.strings,
+    entities: cacheStore.entities,
+    properties: cacheStore.properties,
+    quantities: cacheStore.quantities,
+    relationships: cacheStore.relationships,
+    entityIndex: extras.entityIndex,
+    spatialHierarchy: cacheStore.spatialHierarchy,
+    onDemandPropertyMap: extras.onDemandPropertyMap,
+    onDemandQuantityMap: extras.onDemandQuantityMap,
+    onDemandMaterialMap: extras.onDemandMaterialMap,
+  };
+  return attachDataStoreAccessors(storeData);
 }
 
 // ============================================================================
@@ -123,31 +181,29 @@ export function useIfcCache() {
       const result = await reader.read(cacheResult.buffer);
       const cacheReadTime = performance.now() - cacheLoadStart;
 
-      // Convert cache data store to viewer data store format.
-      // The cache reader emits a cache-shaped store; this function mutates it
-      // in place into the parser `IfcDataStore` the viewer requires (adding
-      // source, entityIndex, on-demand maps, spatialHierarchy). Cast through
-      // `unknown` to the target shape so the subsequent property writes stay
-      // type-checked against the parser types.
-      const dataStore = result.dataStore as unknown as IfcDataStore;
-
       // Restore the source buffer — required for on-demand property extraction
       // AND the lazy entity accessors (getEntity/getProperties/...). The web
-      // cache persists `sourceBuffer`; the desktop cache does not, so fall back
-      // to the freshly read file buffer when the caller provides it. Without a
-      // source, the accessors can't be attached and a cache hit would crash the
-      // Properties panel with "store.getEntity is not a function".
+      // cache persists `sourceBuffer`; fall back to the freshly read file buffer
+      // when the caller provides it. Without a source the accessors return empty
+      // (and getProperties falls back to the pre-built cache tables).
+      const cacheStore = result.dataStore;
       const sourceBuffer = cacheResult.sourceBuffer ?? fallbackSourceBuffer;
+      let source: Uint8Array = new Uint8Array(0);
+      let entityIndex: IfcDataStore['entityIndex'] = { byId: new Map(), byType: new Map() };
+      let onDemandPropertyMap: Map<number, number[]> | undefined;
+      let onDemandQuantityMap: Map<number, number[]> | undefined;
+      let onDemandMaterialMap: Map<number, number> | undefined;
+
       if (sourceBuffer) {
-        dataStore.source = new Uint8Array(sourceBuffer);
+        source = new Uint8Array(sourceBuffer);
 
         if (result.entityIndex) {
-          dataStore.entityIndex = buildEntityIndexFromCachedColumns(result.entityIndex);
+          entityIndex = buildEntityIndexFromCachedColumns(result.entityIndex);
         } else {
           // Backward compatibility for v3 caches: rebuild byte offsets from the
           // source once, then future v4 writes persist this section.
-          const tokenizer = new StepTokenizer(dataStore.source);
-          const estimatedCount = dataStore.entities?.count ?? 100_000;
+          const tokenizer = new StepTokenizer(source);
+          const estimatedCount = cacheStore.entities?.count ?? 100_000;
           const indexBuilder = new CompactEntityIndexBuilder(estimatedCount);
           const byType = new Map<string, number[]>();
 
@@ -160,35 +216,32 @@ export function useIfcCache() {
             }
             typeList.push(ref.expressId);
           }
-          const compactByIdIndex = indexBuilder.build();
-          dataStore.entityIndex = { byId: compactByIdIndex, byType };
+          entityIndex = { byId: indexBuilder.build(), byType };
         }
 
-        // Rebuild on-demand maps from relationships
+        // Rebuild on-demand maps from relationships.
         // Pass entityIndex which contains ALL entity types including IfcPropertySet/IfcElementQuantity
-        // (the entity table may not include these since they're filtered during fresh parse)
-        const { onDemandPropertyMap, onDemandQuantityMap, onDemandMaterialMap } = rebuildOnDemandMaps(
-          dataStore.entities,
-          dataStore.relationships,
-          dataStore.entityIndex
-        );
-        dataStore.onDemandPropertyMap = onDemandPropertyMap;
-        dataStore.onDemandQuantityMap = onDemandQuantityMap;
-        // Materials tab + per-material totals read onDemandMaterialMap; without
-        // this a cache hit left the Materials grouping empty (#982 follow-up).
-        dataStore.onDemandMaterialMap = onDemandMaterialMap;
-
-        // Reattach the lazy entity/property/quantity accessors. A freshly parsed
-        // store carries these (wired by attachDataStoreAccessors), but the cache
-        // format only serialises data — so a cache-restored store would be
-        // missing getEntity()/getProperties()/etc. and crash any query path
-        // (e.g. the Properties panel: "store.getEntity is not a function").
-        // Safe here: source, entityIndex and the on-demand maps are all set.
-        attachDataStoreAccessors(dataStore as IfcDataStore);
+        // (the entity table may not include these since they're filtered during fresh parse).
+        ({ onDemandPropertyMap, onDemandQuantityMap, onDemandMaterialMap } = rebuildOnDemandMaps(
+          cacheStore.entities,
+          cacheStore.relationships,
+          entityIndex
+        ));
       } else {
         console.warn('[useIfcCache] No source buffer in cache - on-demand property extraction disabled');
-        dataStore.source = new Uint8Array(0);
       }
+
+      // Typed cache→runtime hydration (#952): builds the parser-shaped
+      // IfcDataStore with compiler-checked field mapping (no `as unknown` cast)
+      // and wires the lazy accessors via attachDataStoreAccessors.
+      const dataStore = hydrateCacheStore(cacheStore, {
+        source,
+        fileSize: sourceBuffer?.byteLength ?? 0,
+        entityIndex,
+        onDemandPropertyMap,
+        onDemandQuantityMap,
+        onDemandMaterialMap,
+      });
 
       // Rebuild spatial hierarchy from cache data (cache doesn't serialize it)
       // Use SpatialHierarchyBuilder to extract elevations from source buffer

--- a/packages/cache/src/cache.test.ts
+++ b/packages/cache/src/cache.test.ts
@@ -18,7 +18,7 @@ import {
   RelationshipType,
 } from '@ifc-lite/data';
 import { BinaryCacheWriter, BinaryCacheReader, xxhash64, SchemaVersion, FORMAT_VERSION } from './index.js';
-import type { IfcDataStore } from './types.js';
+import type { CacheDataStore } from './types.js';
 import type { MeshData, CoordinateInfo } from '@ifc-lite/geometry';
 
 describe('xxhash64', () => {
@@ -44,7 +44,7 @@ describe('xxhash64', () => {
 });
 
 describe('BinaryCacheWriter and BinaryCacheReader', () => {
-  let dataStore: IfcDataStore;
+  let dataStore: CacheDataStore;
   let sourceBuffer: ArrayBuffer;
 
   beforeEach(() => {

--- a/packages/cache/src/index.ts
+++ b/packages/cache/src/index.ts
@@ -48,7 +48,7 @@ export type {
   CachedEntityIndexColumns,
   CacheEntityIndex,
   CacheEntityRef,
-  IfcDataStore,
+  CacheDataStore,
 } from './types.js';
 
 // Utilities

--- a/packages/cache/src/reader.ts
+++ b/packages/cache/src/reader.ts
@@ -12,7 +12,7 @@ import {
   type CacheHeaderInfo,
   type CacheReadOptions,
   type CacheReadResult,
-  type IfcDataStore,
+  type CacheDataStore,
 } from './types.js';
 import { BufferReader } from './utils/buffer-utils.js';
 import { xxhash64 } from './utils/hash.js';
@@ -106,7 +106,7 @@ export class BinaryCacheReader {
     reader.position = relationshipsSection.offset;
     const relationships = readRelationships(reader);
 
-    const dataStore: IfcDataStore = {
+    const dataStore: CacheDataStore = {
       schema: header.schema,
       entityCount: header.entityCount,
       strings,

--- a/packages/cache/src/types.ts
+++ b/packages/cache/src/types.ts
@@ -118,7 +118,7 @@ export interface CacheHeaderInfo {
 /**
  * Complete data store for IFC model
  */
-export interface IfcDataStore {
+export interface CacheDataStore {
   schema: SchemaVersion;
   entityCount: number;
   strings: StringTable;
@@ -154,7 +154,7 @@ export interface CachedEntityIndexColumns {
  * Result from reading cache
  */
 export interface CacheReadResult {
-  dataStore: IfcDataStore;
+  dataStore: CacheDataStore;
   entityIndex?: CachedEntityIndexColumns;
   geometry?: {
     meshes: MeshData[];

--- a/packages/cache/src/writer.ts
+++ b/packages/cache/src/writer.ts
@@ -17,7 +17,7 @@ import {
   type CacheHeader,
   type SectionEntry,
   type CacheWriteOptions,
-  type IfcDataStore,
+  type CacheDataStore,
 } from './types.js';
 import { BufferWriter } from './utils/buffer-utils.js';
 import { xxhash64 } from './utils/hash.js';
@@ -47,7 +47,7 @@ export class BinaryCacheWriter {
    * @returns ArrayBuffer containing the binary cache
    */
   async write(
-    dataStore: IfcDataStore,
+    dataStore: CacheDataStore,
     geometry: GeometryData | undefined,
     sourceBuffer: ArrayBuffer,
     options: CacheWriteOptions = {}


### PR DESCRIPTION
Stacked on #992. Addresses the two high-value items from #952.

## What & why

**1. Name collision killed.** The cache's *serialized* store was also called `IfcDataStore`, colliding with the parser's *runtime* `IfcDataStore` — the viewer was already importing it `as CacheDataStore` to work around it. Renamed to `CacheDataStore` across `packages/cache`.

**2. The dangerous cast is gone.** `useIfcCache` bridged cache→runtime with `result.dataStore as unknown as IfcDataStore` — the escape hatch that disabled all type-checking and let the #950 `store.getEntity is not a function` crash slip through. Replaced with a typed `hydrateCacheStore()` adapter. The cache and runtime stores share the same `@ifc-lite/data` table types, so the field mapping is **compiler-checked** — a future required store member is now a compile error here instead of a silent runtime crash.

## The cast was hiding real bugs

The moment the construction became typed, tsc surfaced two genuine mismatches:
- **`schema` (cache numeric `SchemaVersion` enum) vs `schemaVersion` (runtime string union)** — the exact drift #952 named. Now an explicit `cacheSchemaToVersion()` conversion (the cache format predates IFC5, matching the save path's inverse mapping).
- a `Uint8Array<ArrayBufferLike>` vs `<ArrayBuffer>` generic mismatch.

The adapter also seeds the previously-missing required fields (`parseTime`, `fileSize`) the cast silently omitted. As a small robustness win, no-source cache hits now get safe no-op accessors (`getProperties` falls back to the pre-built cache tables) instead of crashing.

## Notes
- The desktop removal (#992) already deleted the *other* #952 cast site (`desktopModelSnapshot.ts`), so this is the last one.
- `schema` is kept as the cache's binary-format field; the adapter is the single typed boundary that maps it to `schemaVersion`.
- Remaining #952 item — a wasm-free typecheck lane — left as a separate infra follow-up.

## Verification
- `packages/cache` typechecks clean; **16/16 cache tests pass** (incl. the serialization round-trip).
- Viewer typechecks clean — `useIfcCache` has **0 errors** (the only remaining viewer tsc errors are the pre-existing geometry/wasm-binding-staleness noise, identical on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)