### PR TITLE
fix(geometry): don't double-render instanced type geometry (#957 follow-up)

### DIFF
--- a/.changeset/type-only-geometry-instanced-gate.md
+++ b/.changeset/type-only-geometry-instanced-gate.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Fix duplicate geometry rendered at wrong positions for ArchiCAD/AC20-style IFC files (regression from #957/#962 "type-only geometry").
+
+The #957 orphan-`IfcTypeProduct` pass rendered a type's `IfcRepresentationMap` whenever no `IfcMappedItem` referenced it. But real-world exporters (e.g. ArchiCAD AC20: `AC20-FZK-Haus`, `C20-Institute-Var-2`) attach a `RepresentationMap` to nearly every door/window/furniture **type** while the **occurrence** carries its own direct body geometry — the type and occurrence are linked only by `IfcRelDefinesByType`, so the map is referenced by no `IfcMappedItem`. Every such type was therefore mis-classified as "orphan" and double-rendered at its `MappingOrigin`, producing a cluster of duplicate boxes at the wrong position (e.g. ~140 spurious meshes in `AC20-FZK-Haus`).
+
+Type-only geometry is now rendered only when the type has **no occurrence** — i.e. it is not the `RelatingType` of any `IfcRelDefinesByType`. The genuinely-orphan buildingSMART annex-E "tessellated shape with style" case (a type with no occurrence) still renders. Fixed across both mesh pipelines (the native `process_geometry` path and the viewer `buildPrePass*` + `processGeometryBatch` path) plus the render-time gate, with regression tests on both.

--- a/apps/viewer/src/hooks/ingest/federationAlign.ts
+++ b/apps/viewer/src/hooks/ingest/federationAlign.ts
@@ -172,6 +172,13 @@ function buildGeorefAlignmentTransform(source: ModelGeoref, reference: ModelGeor
 
   const yVx = (-refAxis.o * eVx + refAxis.a * nVx) * invRefDenom;
   const yVz = (-refAxis.o * eVz + refAxis.a * nVz) * invRefDenom;
+  // NOTE: the refOffset handling is intentionally asymmetric between X and Z and
+  // must NOT be "symmetrised". refOffset is subtracted from the FINAL viewer
+  // coordinate on every axis. X maps positively (`tx = +xC`), so its offset is
+  // folded into xC above. Z maps to the NEGATED north axis (`tz = -yC`), so its
+  // offset is applied after the negation, leaving yC offset-free here. This
+  // matches alignGeometryAcrossCrs: alignedZ = refWorldZ - refOffset.z with
+  // refWorldZ = -ifcYr. Folding -refOffset.z into yC would flip its sign.
   const yC = (-refAxis.o * eC + refAxis.a * nC) * invRefDenom;
 
   return {

--- a/packages/wasm/test/type-only-geometry.test.mjs
+++ b/packages/wasm/test/type-only-geometry.test.mjs
@@ -96,3 +96,82 @@ describe('@ifc-lite/wasm type-only IfcRepresentationMap geometry (#957)', () => 
     });
   }
 });
+
+/**
+ * Issue #957 follow-up regression guard — the LIVE VIEWER path.
+ *
+ * ArchiCAD/AC20 exports attach a RepresentationMap to a typed product while the
+ * OCCURRENCE carries its own direct body geometry (no IfcMappedItem). The type
+ * and occurrence are linked only by IfcRelDefinesByType, so the map is referenced
+ * by no IfcMappedItem. Without the IfcRelDefinesByType gate, processGeometryBatch
+ * draws the type's map at its MappingOrigin — a duplicate of the occurrence at the
+ * wrong position. The instanced type must render ZERO type-only meshes here.
+ */
+const INSTANCED_DIRECT_GEOMETRY_IFC = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('issue-957 instanced type, direct-geometry occurrence'),'2;1');
+FILE_NAME('t.ifc','2026-06-07T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#43=IFCBOILERTYPE('2n5ASfQfT84eP9h$zLLJ4A',$,'Boiler',$,$,$,(#44),$,$,.NOTDEFINED.);
+#44=IFCREPRESENTATIONMAP(#45,#46);
+#45=IFCAXIS2PLACEMENT3D(#4,$,$);
+#46=IFCSHAPEREPRESENTATION(#2,'Body','Tessellation',(#48));
+#48=IFCTRIANGULATEDFACESET(#49,$,.T.,((1,2,3),(1,2,4),(1,4,3),(2,3,4)),$);
+#49=IFCCARTESIANPOINTLIST3D(((0.,0.,0.),(1.,0.,0.),(0.,1.,0.),(0.,0.,1.)));
+#100=IFCBOILER('1occurrenceDirect000',$,'Occ',$,$,#101,#102,$,.NOTDEFINED.);
+#101=IFCLOCALPLACEMENT($,#5);
+#102=IFCPRODUCTDEFINITIONSHAPE($,$,(#103));
+#103=IFCSHAPEREPRESENTATION(#2,'Body','Tessellation',(#106));
+#106=IFCTRIANGULATEDFACESET(#107,$,.T.,((1,2,3),(1,2,4),(1,4,3),(2,3,4)),$);
+#107=IFCCARTESIANPOINTLIST3D(((0.,0.,0.),(2.,0.,0.),(0.,2.,0.),(0.,0.,2.)));
+#110=IFCRELDEFINESBYTYPE('3defByTypeLink00000000',$,$,$,(#100),#43);
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+describe('@ifc-lite/wasm instanced-type geometry is not double-rendered (#957 follow-up)', () => {
+  it('does not draw a type-only mesh when the type has an occurrence (IfcRelDefinesByType)', async (t) => {
+    if (!existsSync(wasmPath) || !existsSync(wasmJsPath)) {
+      t.skip('wasm bundle not built — run `bash scripts/build-wasm.sh` first');
+      return;
+    }
+
+    const { initSync, IfcAPI } = await import(wasmJsPath);
+    const { parseMeshesViaPrePass } = await import(
+      join(rootDir, 'scripts', 'lib', 'mesh-via-prepass.mjs')
+    );
+
+    initSync(readFileSync(wasmPath));
+    const api = new IfcAPI();
+    try {
+      const result = parseMeshesViaPrePass(api, INSTANCED_DIRECT_GEOMETRY_IFC);
+
+      let occurrence = 0;
+      let typeDirect = 0;
+      for (let i = 0; i < result.length; i++) {
+        const m = result.get(i);
+        if (!m) continue;
+        if (m.expressId === 100) occurrence++;
+        if (m.expressId === 43) typeDirect++;
+      }
+
+      assert.ok(occurrence >= 1, 'the IfcBoiler occurrence #100 (direct geometry) should render');
+      assert.equal(
+        typeDirect,
+        0,
+        'an IfcRelDefinesByType-instanced type must NOT render its RepresentationMap as ' +
+          'orphan type geometry on the viewer path (the AC20 duplicate-box regression)',
+      );
+    } finally {
+      api.free?.();
+    }
+  });
+});

--- a/rust/processing/src/processor.rs
+++ b/rust/processing/src/processor.rs
@@ -839,6 +839,15 @@ pub fn process_geometry_streaming_filtered_with_options(
     // orphan type geometry (buildingSMART annex-E showcase files).
     let mut type_product_geometry: Vec<(u32, usize, usize, IfcType, Vec<u32>)> = Vec::new();
     let mut referenced_representation_maps: FxHashSet<u32> = FxHashSet::default();
+    // #957 follow-up: type ids that an IfcRelDefinesByType instantiates (the type
+    // has at least one occurrence). Such a type's geometry is already drawn through
+    // its occurrences — directly or via an IfcMappedItem — so it must NOT also be
+    // rendered as orphan type-only geometry. Real-world exporters (e.g. ArchiCAD
+    // AC20) attach a RepresentationMap to nearly every door/window/furniture type
+    // while the occurrence carries its own body, leaving the type map referenced by
+    // no IfcMappedItem; without this gate every such type double-renders at its
+    // MappingOrigin (duplicate boxes at the wrong position).
+    let mut instantiated_type_ids: FxHashSet<u32> = FxHashSet::default();
     let quick_metadata_enabled = options.emit_quick_metadata_bootstrap;
     let mut quick_spatial_nodes = quick_metadata_enabled.then(HashMap::<u32, QuickSpatialNodeEntry>::new);
     let mut quick_aggregate_links = if quick_metadata_enabled {
@@ -1120,6 +1129,13 @@ pub fn process_geometry_streaming_filtered_with_options(
             if let Some(source_id) = args.first().and_then(|token| parse_step_ref(token)) {
                 referenced_representation_maps.insert(source_id);
             }
+        } else if type_name == "IFCRELDEFINESBYTYPE" {
+            // IfcRelDefinesByType.RelatingType is the last attribute (index 5);
+            // record it so its type-only geometry is suppressed (it has occurrences).
+            let args = parse_step_arguments(&content[start..end]);
+            if let Some(type_id) = args.get(5).and_then(|token| parse_step_ref(token)) {
+                instantiated_type_ids.insert(type_id);
+            }
         } else if (type_name.ends_with("TYPE") || type_name.ends_with("STYLE"))
             && IfcType::from_str(type_name).is_subtype_of(IfcType::IfcTypeProduct)
         {
@@ -1143,6 +1159,11 @@ pub fn process_geometry_streaming_filtered_with_options(
     // buildingSMART annex-E "tessellated shape with style" files declare the
     // geometry only on the type, so without this they render nothing (#957).
     for (type_id, start, end, ifc_type, rep_map_ids) in &type_product_geometry {
+        // A type with occurrences (IfcRelDefinesByType) already renders through
+        // them; only genuinely orphan types (no occurrence) render their own map.
+        if instantiated_type_ids.contains(type_id) {
+            continue;
+        }
         for &rep_map_id in rep_map_ids {
             if referenced_representation_maps.contains(&rep_map_id) {
                 continue;

--- a/rust/processing/tests/issue_957_type_only_geometry.rs
+++ b/rust/processing/tests/issue_957_type_only_geometry.rs
@@ -116,3 +116,60 @@ fn instanced_type_is_not_double_rendered() {
         "the referenced RepresentationMap must NOT also render as orphan type geometry"
     );
 }
+
+/// The real-world regression behind the "duplicate boxes at wrong positions"
+/// report: ArchiCAD/AC20 exports attach a RepresentationMap to a typed product
+/// (e.g. IfcDoorType) while the OCCURRENCE carries its own DIRECT body geometry —
+/// it does NOT reference the type's map via an IfcMappedItem. The type and the
+/// occurrence are linked only by IfcRelDefinesByType. The map is therefore
+/// referenced by no IfcMappedItem, so the #957 orphan test alone would treat it as
+/// orphan and render it at its MappingOrigin — a duplicate of the door at the
+/// wrong position. The IfcRelDefinesByType gate must suppress it.
+const INSTANCED_DIRECT_GEOMETRY_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('issue-957 instanced type, direct-geometry occurrence'),'2;1');
+FILE_NAME('t.ifc','2026-06-07T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#43=IFCBOILERTYPE('2n5ASfQfT84eP9h$zLLJ4A',$,'Boiler',$,$,$,(#44),$,$,.NOTDEFINED.);
+#44=IFCREPRESENTATIONMAP(#45,#46);
+#45=IFCAXIS2PLACEMENT3D(#4,$,$);
+#46=IFCSHAPEREPRESENTATION(#2,'Body','Tessellation',(#48));
+#48=IFCTRIANGULATEDFACESET(#49,$,.T.,((1,2,3),(1,2,4),(1,4,3),(2,3,4)),$);
+#49=IFCCARTESIANPOINTLIST3D(((0.,0.,0.),(1.,0.,0.),(0.,1.,0.),(0.,0.,1.)));
+#100=IFCBOILER('1occurrenceDirect000',$,'Occ',$,$,#101,#102,$,.NOTDEFINED.);
+#101=IFCLOCALPLACEMENT($,#5);
+#102=IFCPRODUCTDEFINITIONSHAPE($,$,(#103));
+#103=IFCSHAPEREPRESENTATION(#2,'Body','Tessellation',(#106));
+#106=IFCTRIANGULATEDFACESET(#107,$,.T.,((1,2,3),(1,2,4),(1,4,3),(2,3,4)),$);
+#107=IFCCARTESIANPOINTLIST3D(((0.,0.,0.),(2.,0.,0.),(0.,2.,0.),(0.,0.,2.)));
+#110=IFCRELDEFINESBYTYPE('3defByTypeLink00000000',$,$,$,(#100),#43);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+#[test]
+fn instanced_type_with_direct_geometry_occurrence_is_not_double_rendered() {
+    let result = process_geometry(INSTANCED_DIRECT_GEOMETRY_IFC);
+
+    let occurrence = result.meshes.iter().filter(|m| m.express_id == 100).count();
+    let type_direct = result.meshes.iter().filter(|m| m.express_id == 43).count();
+
+    assert_eq!(
+        occurrence, 1,
+        "the IfcBoiler occurrence #100 (direct body geometry) should render"
+    );
+    assert_eq!(
+        type_direct, 0,
+        "an IfcRelDefinesByType-instanced type must NOT render its RepresentationMap \
+         as orphan type geometry (the AC20 duplicate-box regression), even though no \
+         IfcMappedItem references the map"
+    );
+}

--- a/rust/wasm-bindings/src/api/gpu_meshes.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes.rs
@@ -1087,6 +1087,17 @@ impl IfcAPI {
                 // (the referenced ones draw through their occurrence — no double
                 // render).
                 if ifc_type.is_subtype_of(ifc_lite_core::IfcType::IfcTypeProduct) {
+                    // #957 follow-up: a type that an IfcRelDefinesByType instantiates
+                    // already renders through its occurrences (directly or via an
+                    // IfcMappedItem). Drawing its RepresentationMap here too would
+                    // double-render it at the MappingOrigin — the AC20/ArchiCAD
+                    // "duplicate boxes at the wrong position" regression. Only
+                    // genuinely orphan types (no occurrence) reach the render below.
+                    let instantiated =
+                        self.get_or_build_instantiated_type_ids(content, &mut decoder);
+                    if instantiated.contains(&id) {
+                        continue;
+                    }
                     let rep_map_ids: Vec<u32> = entity
                         .get(6)
                         .and_then(|a| a.as_list())

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -75,6 +75,15 @@ pub struct IfcAPI {
     cached_referenced_repmaps:
         std::sync::Mutex<Option<std::sync::Arc<rustc_hash::FxHashSet<u32>>>>,
 
+    /// Lazily-built set of type ids that an `IfcRelDefinesByType` instantiates
+    /// (the type has an occurrence). `processGeometryBatch` uses it to suppress
+    /// type-only geometry for instanced types — their geometry already draws
+    /// through their occurrences, so rendering the type's RepresentationMap too
+    /// would double-render it at the MappingOrigin. Built once per worker and
+    /// cleared by `clearPrePassCache`.
+    cached_instantiated_type_ids:
+        std::sync::Mutex<Option<std::sync::Arc<rustc_hash::FxHashSet<u32>>>>,
+
     /// Lazily-built surface-texture index keyed by face-set id (issue #961):
     /// decoded RGBA images + per-triangle UV maps from
     /// `IfcIndexedTriangleTextureMap`. Built once per worker (cheap substring
@@ -123,6 +132,7 @@ impl IfcAPI {
             merge_layers: std::sync::atomic::AtomicBool::new(false),
             cached_parts_to_skip: std::sync::Mutex::new(None),
             cached_referenced_repmaps: std::sync::Mutex::new(None),
+            cached_instantiated_type_ids: std::sync::Mutex::new(None),
             cached_texture_index: std::sync::Mutex::new(None),
             cached_indexed_colour_maps: std::sync::Mutex::new(None),
             compute_geometry_hashes: std::sync::atomic::AtomicBool::new(false),
@@ -168,6 +178,12 @@ impl IfcAPI {
             .lock()
             .expect("ifc-lite cached_referenced_repmaps Mutex poisoned");
         repmap_slot.take();
+        // The instantiated-type-ids set is keyed off the previous load's content.
+        let mut inst_slot = self
+            .cached_instantiated_type_ids
+            .lock()
+            .expect("ifc-lite cached_instantiated_type_ids Mutex poisoned");
+        inst_slot.take();
         // The texture index is keyed off the previous load's content; drop it.
         let mut texture_slot = self
             .cached_texture_index
@@ -235,6 +251,10 @@ impl IfcAPI {
         self.cached_referenced_repmaps
             .lock()
             .expect("ifc-lite cached_referenced_repmaps Mutex poisoned")
+            .take();
+        self.cached_instantiated_type_ids
+            .lock()
+            .expect("ifc-lite cached_instantiated_type_ids Mutex poisoned")
             .take();
         self.cached_texture_index
             .lock()
@@ -388,6 +408,36 @@ impl IfcAPI {
             .cached_referenced_repmaps
             .lock()
             .expect("ifc-lite cached_referenced_repmaps Mutex poisoned");
+        *slot = Some(std::sync::Arc::clone(&arc));
+        arc
+    }
+
+    /// Get or lazily build the set of type ids that an `IfcRelDefinesByType`
+    /// instantiates (#957 follow-up). `processGeometryBatch` uses it to suppress
+    /// type-only geometry for instanced types (the geometry already draws through
+    /// their occurrences). Cached per worker so the scan is paid once.
+    pub(crate) fn get_or_build_instantiated_type_ids(
+        &self,
+        content: &str,
+        decoder: &mut ifc_lite_core::EntityDecoder,
+    ) -> std::sync::Arc<rustc_hash::FxHashSet<u32>> {
+        {
+            let slot = self
+                .cached_instantiated_type_ids
+                .lock()
+                .expect("ifc-lite cached_instantiated_type_ids Mutex poisoned");
+            if let Some(existing) = slot.as_ref() {
+                return std::sync::Arc::clone(existing);
+            }
+        }
+
+        let instantiated = styling::build_instantiated_type_ids(content, decoder);
+
+        let arc = std::sync::Arc::new(instantiated);
+        let mut slot = self
+            .cached_instantiated_type_ids
+            .lock()
+            .expect("ifc-lite cached_instantiated_type_ids Mutex poisoned");
         *slot = Some(std::sync::Arc::clone(&arc));
         arc
     }

--- a/rust/wasm-bindings/src/api/styling.rs
+++ b/rust/wasm-bindings/src/api/styling.rs
@@ -544,9 +544,18 @@ pub(crate) fn collect_orphan_type_geometry_jobs(
         return Vec::new();
     }
 
-    // Single pass: gather the IfcMappedItem-referenced RepresentationMaps and
-    // the type-product candidates together, then filter to the orphans.
+    // Single pass: gather the IfcMappedItem-referenced RepresentationMaps, the
+    // types that an IfcRelDefinesByType instantiates, and the type-product
+    // candidates together, then filter to the orphans.
     let mut referenced: rustc_hash::FxHashSet<u32> = rustc_hash::FxHashSet::default();
+    // Types with at least one occurrence (IfcRelDefinesByType). Their geometry is
+    // already drawn through the occurrence — directly or via IfcMappedItem — so the
+    // type's own RepresentationMap must NOT be rendered as orphan type-only
+    // geometry. ArchiCAD/AC20 exports attach a RepresentationMap to nearly every
+    // typed product while the occurrence carries its own body, so the map is
+    // referenced by no IfcMappedItem; without this gate the type double-renders at
+    // its MappingOrigin (duplicate boxes at the wrong position).
+    let mut instantiated: rustc_hash::FxHashSet<u32> = rustc_hash::FxHashSet::default();
     let mut candidates: Vec<(u32, usize, usize, IfcType, Vec<u32>)> = Vec::new();
 
     let mut scanner = EntityScanner::new(content);
@@ -556,6 +565,13 @@ pub(crate) fn collect_orphan_type_geometry_jobs(
                 // IfcMappedItem.MappingSource = attr 0.
                 if let Some(source_id) = entity.get_ref(0) {
                     referenced.insert(source_id);
+                }
+            }
+        } else if type_name == "IFCRELDEFINESBYTYPE" {
+            if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
+                // IfcRelDefinesByType.RelatingType = attr 5 (the typed product).
+                if let Some(type_id) = entity.get_ref(5) {
+                    instantiated.insert(type_id);
                 }
             }
         } else if type_name.ends_with("TYPE") || type_name.ends_with("STYLE") {
@@ -581,6 +597,7 @@ pub(crate) fn collect_orphan_type_geometry_jobs(
 
     candidates
         .into_iter()
+        .filter(|(id, _, _, _, _)| !instantiated.contains(id))
         .filter(|(_, _, _, _, maps)| maps.iter().any(|rm| !referenced.contains(rm)))
         .map(|(id, start, end, ifc_type, _)| (id, start, end, ifc_type))
         .collect()
@@ -607,6 +624,31 @@ pub(crate) fn build_referenced_representation_maps(
         }
     }
     referenced
+}
+
+/// #957 follow-up: the set of type ids that an `IfcRelDefinesByType` instantiates
+/// (i.e. the type has at least one occurrence). `processGeometryBatch` uses it to
+/// suppress type-only geometry for such types — their geometry is already drawn
+/// through their occurrences, so rendering the type's RepresentationMap as well
+/// would double-render it at the MappingOrigin (duplicate at the wrong position).
+pub(crate) fn build_instantiated_type_ids(
+    content: &str,
+    decoder: &mut ifc_lite_core::EntityDecoder,
+) -> rustc_hash::FxHashSet<u32> {
+    use ifc_lite_core::EntityScanner;
+    let mut instantiated: rustc_hash::FxHashSet<u32> = rustc_hash::FxHashSet::default();
+    let mut scanner = EntityScanner::new(content);
+    while let Some((id, type_name, start, end)) = scanner.next_entity() {
+        if type_name == "IFCRELDEFINESBYTYPE" {
+            if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
+                // IfcRelDefinesByType.RelatingType = attr 5 (the typed product).
+                if let Some(type_id) = entity.get_ref(5) {
+                    instantiated.insert(type_id);
+                }
+            }
+        }
+    }
+    instantiated
 }
 
 /// #957: resolve the authored colour for a type's `IfcRepresentationMap` by


### PR DESCRIPTION
## Problem

After the #957/#962 *type-only geometry* feature, ArchiCAD/AC20 models render **duplicate boxes at wrong positions** — and selecting one shows an `IfcDoorType` (a *type*, not an occurrence).

**Root cause:** the #957 orphan pass renders an `IfcTypeProduct`'s `IfcRepresentationMap` at its `MappingOrigin` whenever **no `IfcMappedItem` references the map**. That assumption breaks on real-world ArchiCAD/AC20 exports, which attach a `RepresentationMap` to nearly every instanced door/window/furniture **type** while the **occurrence** carries its own *direct* body geometry — type and occurrence are linked only by `IfcRelDefinesByType`, so the map is referenced by no `IfcMappedItem`.

Evidence (`tests/models/ara3d/AC20-FZK-Haus.ifc`): **145** `IfcRepresentationMap`s, only **5** referenced by an `IfcMappedItem`; the selected door type is instanced via `IFCRELDEFINESBYTYPE(...,(#17468),#17730)`. So ~140 types per file were mis-classified as orphan and double-rendered at the local origin.

## Fix

Render type geometry only when the type has **no occurrence** — i.e. it is not the `RelatingType` of any `IfcRelDefinesByType`. The genuinely-orphan buildingSMART annex-E *"tessellated shape with style"* case (a type with no occurrence) still renders, so #957 is preserved.

Gated in **both** mesh pipelines plus the render-time path:

- `rust/processing/src/processor.rs` — native `process_geometry`: collect `instantiated_type_ids`, skip them in the orphan synthesis loop.
- `rust/wasm-bindings/src/api/{styling,mod,gpu_meshes}.rs` — filter instanced types from `collect_orphan_type_geometry_jobs`, add a per-worker `cached_instantiated_type_ids`, and gate the `processGeometryBatch` render loop.

Also documents (comment only) why `federationAlign.ts`'s `refOffset` handling is intentionally asymmetric between the X and (negated) Z axes — an adversarial review flagged it as a sign error, but it is correct and matches the sibling `alignGeometryAcrossCrs`.

## Verification

- `cargo test -p ifc-lite-processing` ✅ — new direct-geometry-occurrence regression test passes; annex-E orphan case still renders.
- Rebuilt wasm; `node --test packages/wasm/test/type-only-geometry.test.mjs` ✅ 4/4 (viewer path).
- **End-to-end via the viewer path** (`build_pre_pass_once` + `processGeometryBatch`): `AC20-FZK-Haus` and `C20-Institute-Var-2` now render **0** type-product meshes (was ~140); type-only annex-E fixtures still render.

## Follow-up

This gate is the seam for a planned **3D "Model vs Types" view switch** — type meshes are keyed by the type's express id and can be emitted as a toggleable layer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a regression where type-only geometry was rendered twice at incorrect positions for ArchiCAD/AC20-style IFC files, preventing duplicate geometry from appearing.
  * Applied the fix across both geometry rendering pipelines.

* **Tests**
  * Added regression tests to prevent future occurrences of this issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->