### PR TITLE
feat(viewer): 3D Model/Types view switch (#957 follow-up)

### DIFF
--- a/.changeset/model-types-view-switch.md
+++ b/.changeset/model-types-view-switch.md
@@ -1,0 +1,12 @@
+---
+"@ifc-lite/wasm": minor
+"@ifc-lite/geometry": minor
+---
+
+Add a 3D **Model / Types** view switch (turns the #957 type geometry into a feature).
+
+The viewer mesh path (`processGeometryBatch`) now always emits an `IfcTypeProduct`'s `RepresentationMap` geometry, tagging each mesh with a `geometryClass`: `0` = occurrence, `1` = orphan type (no occurrence — buildingSMART annex-E showcase files), `2` = instanced type-library shape (a type linked to an occurrence via `IfcRelDefinesByType`). `MeshDataJs.geometryClass` (wasm) and `MeshData.geometryClass` (`@ifc-lite/geometry`) carry it across the boundary.
+
+The viewer's Visibility menu gains a Model/Types segmented control. **Model** (default) shows occurrences + orphan types and hides class‑2 type-library shapes — so the AC20/ArchiCAD "duplicate boxes at the wrong position" never appear. **Types** shows the type library (classes 1 + 2 at their map origins) and hides occurrences. The switch re-filters the cached mesh set instantly (no reload) and the choice persists across reloads.
+
+The native `process_geometry` path is unchanged — it still suppresses instanced-type geometry so server/CLI/SDK exports never duplicate it.

--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -50,6 +50,8 @@ import {
   ChevronsUpDown,
   Undo2,
   Redo2,
+  Boxes,
+  Shapes,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
@@ -540,6 +542,10 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
   const typeVisibility = useViewerStore((state) => state.typeVisibility);
   const toggleTypeVisibility = useViewerStore((state) => state.toggleTypeVisibility);
   const resetTypeVisibility = useViewerStore((state) => state.resetTypeVisibility);
+  // #957 follow-up: Model/Types 3D view switch — 'model' shows placed
+  // occurrences (default), 'types' shows the type-library shapes.
+  const typeViewMode = useViewerStore((state) => state.typeViewMode);
+  const setTypeViewMode = useViewerStore((state) => state.setTypeViewMode);
   // How many of the five class toggles are on — surfaced in the menu
   // header so the user sees scene state at a glance.
   const visibleClassCount = [
@@ -1532,6 +1538,51 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
           model lacks is a no-op.
         */}
         <DropdownMenuContent align="start" className="w-[300px] p-1.5">
+          {/* Model / Types 3D view switch (#957 follow-up). A type carries a
+              RepresentationMap whose shape is drawn at its MappingOrigin; "Types"
+              shows that type library, "Model" shows the placed occurrences. The
+              two are mutually exclusive — toggling re-filters the cached mesh set
+              instantly (no reload). */}
+          <div className="px-1.5 pb-1 pt-0.5">
+            <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+              3D View
+            </span>
+          </div>
+          <div className="flex gap-1 px-1.5 pb-1.5" role="radiogroup" aria-label="3D view mode">
+            <button
+              type="button"
+              role="radio"
+              aria-checked={typeViewMode === 'model'}
+              onClick={() => setTypeViewMode('model')}
+              className={cn(
+                'flex flex-1 items-center justify-center gap-1.5 rounded-md border px-2 py-1.5 text-xs font-medium transition-colors',
+                typeViewMode === 'model'
+                  ? 'border-primary/40 bg-primary/10 text-foreground'
+                  : 'border-transparent text-muted-foreground hover:bg-muted/50',
+              )}
+            >
+              <Boxes className="h-3.5 w-3.5 shrink-0" />
+              Model
+            </button>
+            <button
+              type="button"
+              role="radio"
+              aria-checked={typeViewMode === 'types'}
+              onClick={() => setTypeViewMode('types')}
+              className={cn(
+                'flex flex-1 items-center justify-center gap-1.5 rounded-md border px-2 py-1.5 text-xs font-medium transition-colors',
+                typeViewMode === 'types'
+                  ? 'border-primary/40 bg-primary/10 text-foreground'
+                  : 'border-transparent text-muted-foreground hover:bg-muted/50',
+              )}
+            >
+              <Shapes className="h-3.5 w-3.5 shrink-0" />
+              Types
+            </button>
+          </div>
+
+          <DropdownMenuSeparator className="my-1" />
+
           <div className="flex items-center justify-between gap-2 px-1.5 pb-1 pt-0.5">
             <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
               Visibility

--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -69,6 +69,7 @@ export function ViewportContainer() {
   const releaseGeometryMemory = useViewerStore((s) => s.releaseGeometryMemory);
   const selectedStoreys = useViewerStore((s) => s.selectedStoreys);
   const typeVisibility = useViewerStore((s) => s.typeVisibility);
+  const typeViewMode = useViewerStore((s) => s.typeViewMode);
   const isolatedEntities = useViewerStore((s) => s.isolatedEntities);
   const classFilter = useViewerStore((s) => s.classFilter);
   const resetViewerState = useViewerStore((s) => s.resetViewerState);
@@ -526,6 +527,7 @@ export function ViewportContainer() {
   const filteredSourceLenRef = useRef(0);
   const filteredSourceRef = useRef<MeshData[] | null>(null);
   const filteredTypeVisRef = useRef(typeVisibility);
+  const filteredTypeModeRef = useRef(typeViewMode);
   const filteredVersionRef = useRef(0);
 
   const filteredGeometry = useMemo(() => {
@@ -540,18 +542,21 @@ export function ViewportContainer() {
     const allMeshes = mergedGeometryResult.meshes;
     const cache = filteredCacheRef.current;
 
-    // Full rebuild if: type visibility changed, source shrunk (new file), or empty cache
+    // Full rebuild if: type visibility changed, view mode changed, source shrunk
+    // (new file), or empty cache
     const prevVis = filteredTypeVisRef.current;
     const typeVisChanged =
       prevVis.spaces !== typeVisibility.spaces ||
       prevVis.openings !== typeVisibility.openings ||
-      prevVis.site !== typeVisibility.site;
+      prevVis.site !== typeVisibility.site ||
+      filteredTypeModeRef.current !== typeViewMode;
     const sourceChanged = filteredSourceRef.current !== allMeshes;
     if (typeVisChanged || sourceChanged || allMeshes.length < filteredSourceLenRef.current) {
       cache.length = 0;
       filteredSourceLenRef.current = 0;
       filteredSourceRef.current = allMeshes;
       filteredTypeVisRef.current = typeVisibility;
+      filteredTypeModeRef.current = typeViewMode;
     }
 
     const needsFilter = !typeVisibility.spaces || !typeVisibility.openings || !typeVisibility.site;
@@ -561,6 +566,18 @@ export function ViewportContainer() {
     for (let i = filteredSourceLenRef.current; i < allMeshes.length; i++) {
       const mesh = allMeshes[i];
       const ifcType = mesh.ifcType;
+
+      // Model/Types view switch (#957 follow-up). geometryClass: 0 = occurrence,
+      // 1 = orphan type (no occurrence — shown in BOTH modes since it's the only
+      // geometry), 2 = instanced type-library shape. In 'model' mode hide class 2
+      // (else the AC20 duplicate boxes at the MappingOrigin reappear); in 'types'
+      // mode hide occurrences (class 0) so only the type library shows.
+      const geometryClass = mesh.geometryClass ?? 0;
+      if (typeViewMode === 'types') {
+        if (geometryClass === 0) continue;
+      } else if (geometryClass === 2) {
+        continue;
+      }
 
       if (needsFilter) {
         if (ifcType === 'IfcSpace' && !typeVisibility.spaces) continue;
@@ -588,7 +605,7 @@ export function ViewportContainer() {
     // Return the same array reference — downstream change detection uses
     // geometryVersion (which increments each batch) instead of array identity.
     return cache;
-  }, [mergedGeometryResult, typeVisibility]);
+  }, [mergedGeometryResult, typeVisibility, typeViewMode]);
 
   // Version counter that changes every batch — triggers useGeometryStreaming
   // without requiring a new geometry array reference.

--- a/apps/viewer/src/store/constants.ts
+++ b/apps/viewer/src/store/constants.ts
@@ -222,6 +222,29 @@ export function getPersistedTypeVisibility(): TypeVisibility {
   };
 }
 
+/**
+ * The 3D view mode for the Model/Types switch (#957 follow-up).
+ *   'model' — show placed occurrences (the default; the building as designed).
+ *   'types' — show the type-library shapes (each IfcTypeProduct's
+ *             RepresentationMap at its MappingOrigin), hiding occurrences.
+ * Orphan type geometry (a type with no occurrence, e.g. annex-E showcase files)
+ * shows in BOTH modes since it is the only geometry the file has.
+ */
+export type TypeViewMode = 'model' | 'types';
+
+export const TYPE_VIEW_MODE_STORAGE_KEY = 'ifc-lite-type-view-mode';
+export const TYPE_VIEW_MODE_DEFAULT: TypeViewMode = 'model';
+
+/** Resolve the persisted Model/Types view mode (read fresh, like type visibility). */
+export function getPersistedTypeViewMode(): TypeViewMode {
+  if (typeof window === 'undefined') return TYPE_VIEW_MODE_DEFAULT;
+  try {
+    return localStorage.getItem(TYPE_VIEW_MODE_STORAGE_KEY) === 'types' ? 'types' : 'model';
+  } catch {
+    return TYPE_VIEW_MODE_DEFAULT;
+  }
+}
+
 // ============================================================================
 // Data Defaults
 // ============================================================================

--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -50,7 +50,7 @@ import { createPointCloudSlice, type PointCloudSlice, POINT_CLOUD_DEFAULTS } fro
 import { invalidateVisibleBasketCache } from './basketVisibleSet.js';
 
 // Import constants for reset function
-import { CAMERA_DEFAULTS, SECTION_PLANE_DEFAULTS, UI_DEFAULTS, getPersistedTypeVisibility } from './constants.js';
+import { CAMERA_DEFAULTS, SECTION_PLANE_DEFAULTS, UI_DEFAULTS, getPersistedTypeVisibility, getPersistedTypeViewMode } from './constants.js';
 
 // Re-export types for consumers
 export type * from './types.js';
@@ -221,6 +221,7 @@ const createViewerStore = () => create<ViewerState>()((...args) => ({
       // Re-read persisted toggles on every file load so a new model never
       // reverts the user's visibility choices (e.g. "Show Annotations").
       typeVisibility: getPersistedTypeVisibility(),
+      typeViewMode: getPersistedTypeViewMode(),
 
       // Visibility (multi-model)
       hiddenEntitiesByModel: new Map(),

--- a/apps/viewer/src/store/slices/visibilitySlice.ts
+++ b/apps/viewer/src/store/slices/visibilitySlice.ts
@@ -11,7 +11,14 @@
 
 import type { StateCreator } from 'zustand';
 import type { TypeVisibility, EntityRef } from '../types.js';
-import { getPersistedTypeVisibility, TYPE_VISIBILITY_STORAGE_KEYS, TYPE_VISIBILITY_SEMANTIC_DEFAULTS } from '../constants.js';
+import {
+  getPersistedTypeVisibility,
+  TYPE_VISIBILITY_STORAGE_KEYS,
+  TYPE_VISIBILITY_SEMANTIC_DEFAULTS,
+  getPersistedTypeViewMode,
+  TYPE_VIEW_MODE_STORAGE_KEY,
+  type TypeViewMode,
+} from '../constants.js';
 
 export interface VisibilitySlice {
   // State (legacy - single model)
@@ -20,6 +27,9 @@ export interface VisibilitySlice {
   /** Class-level filter (from Class tab type-group clicks) — independent of isolatedEntities */
   classFilter: { ids: Set<number>; label: string } | null;
   typeVisibility: TypeVisibility;
+  /** 3D view mode for the Model/Types switch (#957 follow-up). 'model' shows
+   *  placed occurrences (default); 'types' shows the type-library shapes. */
+  typeViewMode: TypeViewMode;
 
   // State (multi-model)
   /** Hidden entities per model */
@@ -46,6 +56,8 @@ export interface VisibilitySlice {
   toggleTypeVisibility: (type: 'spaces' | 'openings' | 'site' | 'ifcAnnotations' | 'ifcGrid') => void;
   /** Restore every type-visibility toggle to its semantic default (and persist). */
   resetTypeVisibility: () => void;
+  /** Set the Model/Types 3D view mode (and persist). */
+  setTypeViewMode: (mode: TypeViewMode) => void;
   /** Set all hidden entities at once (for BCF viewpoint application) */
   setHiddenEntities: (ids: Set<number>) => void;
   /** Set all isolated entities at once (for BCF viewpoint with defaultVisibility=false) */
@@ -79,6 +91,7 @@ export const createVisibilitySlice: StateCreator<VisibilitySlice, [], [], Visibi
   classFilter: null,
   // Read persisted toggles fresh so the user's choices survive reloads.
   typeVisibility: getPersistedTypeVisibility(),
+  typeViewMode: getPersistedTypeViewMode(),
 
   // Initial state (multi-model)
   hiddenEntitiesByModel: new Map(),
@@ -219,6 +232,14 @@ export const createVisibilitySlice: StateCreator<VisibilitySlice, [], [], Visibi
         });
     }
     return { typeVisibility: { ...TYPE_VISIBILITY_SEMANTIC_DEFAULTS } };
+  }),
+
+  setTypeViewMode: (mode) => set(() => {
+    if (typeof window !== 'undefined') {
+      try { localStorage.setItem(TYPE_VIEW_MODE_STORAGE_KEY, mode); }
+      catch { /* private-mode storage rejection — non-fatal */ }
+    }
+    return { typeViewMode: mode };
   }),
 
   // Actions (multi-model)

--- a/packages/geometry/src/geometry-coordinate.ts
+++ b/packages/geometry/src/geometry-coordinate.ts
@@ -76,6 +76,9 @@ export function convertMeshCollectionToBatch(
           indices: mesh.indices,
           color: [color[0], color[1], color[2], color[3]],
           ...(shadingColor ? { shadingColor } : {}),
+          // #957 follow-up: carry the Model/Types geometry class so the viewer's
+          // view-mode filter can show/hide type-library geometry.
+          geometryClass: (mesh as { geometryClass?: number }).geometryClass ?? 0,
         };
 
         // #961: copy the Rust-decoded surface texture + per-vertex UVs (the

--- a/packages/geometry/src/geometry-parallel.ts
+++ b/packages/geometry/src/geometry-parallel.ts
@@ -194,6 +194,10 @@ export async function* processParallel(
           // renderer (transferables; already typed arrays from the worker).
           ...(m.uvs ? { uvs: m.uvs } : {}),
           ...(m.texture ? { texture: m.texture } : {}),
+          // #957 follow-up: carry the Model/Types geometry class through the
+          // worker→main re-map (else the viewer's view-mode filter sees only
+          // class 0 and the Types view renders nothing).
+          ...(m.geometryClass !== undefined ? { geometryClass: m.geometryClass } : {}),
         }));
         if (meshes.length > 0) {
           // Update totalMeshes per batch so consumers see a live

--- a/packages/geometry/src/geometry.worker.ts
+++ b/packages/geometry/src/geometry.worker.ts
@@ -349,6 +349,9 @@ function collectMeshes(
           ifcType: mesh.ifcType,
           positions, normals, indices,
           color: [color[0], color[1], color[2], color[3]],
+          // Provenance for the Model/Types switch (0=occurrence, 1=orphan type,
+          // 2=instanced type). Older wasm bundles lack the getter → default 0.
+          geometryClass: mesh.geometryClass ?? 0,
         };
         session.pendingTransfers.push(positions.buffer, normals.buffer, indices.buffer);
         session.cumulativeMeshBytes += positions.byteLength + normals.byteLength + indices.byteLength;

--- a/packages/geometry/src/types.ts
+++ b/packages/geometry/src/types.ts
@@ -34,6 +34,13 @@ export interface MeshData {
    *  for textured meshes (#961). Decoded to RGBA8 entirely in Rust; the
    *  renderer uploads `rgba` verbatim to a GPU texture. */
   texture?: MeshTexture;
+  /** Geometry provenance for the viewer's Model/Types view switch (#957 follow-up):
+   *  0 = occurrence (placed IfcProduct), 1 = orphan type geometry (an
+   *  IfcTypeProduct RepresentationMap with no occurrence — shown in BOTH modes),
+   *  2 = instanced type geometry (the type-library shape of a type that HAS an
+   *  occurrence — hidden in Model mode, shown in Types mode). Absent/0 for caches
+   *  and non-wasm paths. */
+  geometryClass?: number;
 }
 
 /** A decoded RGBA8 surface texture attached to a mesh (issue #961). */

--- a/packages/wasm/test/type-only-geometry.test.mjs
+++ b/packages/wasm/test/type-only-geometry.test.mjs
@@ -90,6 +90,11 @@ describe('@ifc-lite/wasm type-only IfcRepresentationMap geometry (#957)', () => 
           boiler.every((m) => approxColor(m.color, WHITE)),
           'type geometry should inherit the authored white IfcSurfaceStyle',
         );
+        assert.ok(
+          boiler.every((m) => m.geometryClass === 1),
+          'a genuinely-orphan type (no occurrence) must be geometryClass=1 so it shows in BOTH ' +
+            'Model and Types modes (it is the only geometry the file has)',
+        );
       } finally {
         api.free?.();
       }
@@ -98,14 +103,15 @@ describe('@ifc-lite/wasm type-only IfcRepresentationMap geometry (#957)', () => 
 });
 
 /**
- * Issue #957 follow-up regression guard — the LIVE VIEWER path.
+ * Issue #957 follow-up + Model/Types view switch — the LIVE VIEWER path.
  *
  * ArchiCAD/AC20 exports attach a RepresentationMap to a typed product while the
  * OCCURRENCE carries its own direct body geometry (no IfcMappedItem). The type
  * and occurrence are linked only by IfcRelDefinesByType, so the map is referenced
- * by no IfcMappedItem. Without the IfcRelDefinesByType gate, processGeometryBatch
- * draws the type's map at its MappingOrigin — a duplicate of the occurrence at the
- * wrong position. The instanced type must render ZERO type-only meshes here.
+ * by no IfcMappedItem. The viewer path now EMITS the instanced type's geometry
+ * tagged geometryClass=2 (vs class 1 for genuinely-orphan annex-E types, class 0
+ * for occurrences) so the Model/Types switch can hide it in Model mode (avoiding
+ * the duplicate-box-at-MappingOrigin regression) and show it in Types mode.
  */
 const INSTANCED_DIRECT_GEOMETRY_IFC = `ISO-10303-21;
 HEADER;
@@ -137,8 +143,8 @@ ENDSEC;
 END-ISO-10303-21;
 `;
 
-describe('@ifc-lite/wasm instanced-type geometry is not double-rendered (#957 follow-up)', () => {
-  it('does not draw a type-only mesh when the type has an occurrence (IfcRelDefinesByType)', async (t) => {
+describe('@ifc-lite/wasm instanced-type geometry is tagged for the Model/Types switch (#957 follow-up)', () => {
+  it('emits the instanced type as geometryClass=2 and the occurrence as class 0', async (t) => {
     if (!existsSync(wasmPath) || !existsSync(wasmJsPath)) {
       t.skip('wasm bundle not built — run `bash scripts/build-wasm.sh` first');
       return;
@@ -154,21 +160,28 @@ describe('@ifc-lite/wasm instanced-type geometry is not double-rendered (#957 fo
     try {
       const result = parseMeshesViaPrePass(api, INSTANCED_DIRECT_GEOMETRY_IFC);
 
-      let occurrence = 0;
-      let typeDirect = 0;
+      const occurrence = [];
+      const typeDirect = [];
       for (let i = 0; i < result.length; i++) {
         const m = result.get(i);
         if (!m) continue;
-        if (m.expressId === 100) occurrence++;
-        if (m.expressId === 43) typeDirect++;
+        if (m.expressId === 100) occurrence.push(m);
+        if (m.expressId === 43) typeDirect.push(m);
       }
 
-      assert.ok(occurrence >= 1, 'the IfcBoiler occurrence #100 (direct geometry) should render');
-      assert.equal(
-        typeDirect,
-        0,
-        'an IfcRelDefinesByType-instanced type must NOT render its RepresentationMap as ' +
-          'orphan type geometry on the viewer path (the AC20 duplicate-box regression)',
+      assert.ok(occurrence.length >= 1, 'the IfcBoiler occurrence #100 (direct geometry) should render');
+      assert.ok(
+        occurrence.every((m) => m.geometryClass === 0),
+        'occurrence meshes must be geometryClass=0 (Model)',
+      );
+      assert.ok(
+        typeDirect.length >= 1,
+        'the instanced type #43 geometry is now EMITTED (for the Types view), not suppressed',
+      );
+      assert.ok(
+        typeDirect.every((m) => m.geometryClass === 2),
+        'an IfcRelDefinesByType-instanced type must be tagged geometryClass=2 so the viewer ' +
+          'hides it in Model mode (no duplicate box) and shows it in Types mode',
       );
     } finally {
       api.free?.();

--- a/rust/wasm-bindings/src/api/gpu_meshes.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes.rs
@@ -278,12 +278,13 @@ impl IfcAPI {
         drop(slot);
         let mut decoder = EntityDecoder::with_arc_index(content, entity_index);
 
-        // #957: orphan IfcTypeProduct geometry (type RepresentationMaps, no
-        // occurrence) — keep the fast prepass consistent with the once/streaming
-        // paths so type-only models (annex-E) also render on the worker fast
-        // path. The helper is guarded by a cheap `IFCREPRESENTATIONMAP`
-        // substring check, so files without type geometry pay almost nothing.
-        complex_jobs.extend(super::styling::collect_orphan_type_geometry_jobs(
+        // #957 + Model/Types switch: IfcTypeProduct RepresentationMap geometry
+        // (orphan annex-E types AND instanced type-library shapes) — keep the fast
+        // prepass consistent with the once/streaming paths. processGeometryBatch
+        // tags each with a geometry_class for the viewer's view mode. The helper is
+        // guarded by a cheap `IFCREPRESENTATIONMAP` substring check, so files
+        // without type geometry pay almost nothing.
+        complex_jobs.extend(super::styling::collect_type_geometry_jobs(
             content,
             &mut decoder,
         ));
@@ -887,7 +888,7 @@ impl IfcAPI {
         // fold the mapped-item-source + type-candidate collection into the
         // streaming scan loop so orphans resolve with no extra pass. Kept as a
         // separate pass for now to avoid destabilising the streaming hot path.
-        let type_jobs = super::styling::collect_orphan_type_geometry_jobs(content, &mut decoder);
+        let type_jobs = super::styling::collect_type_geometry_jobs(content, &mut decoder);
         if !type_jobs.is_empty() {
             total_jobs += type_jobs.len() as u32;
             emit_jobs_chunk(on_event, &type_jobs)?;
@@ -1087,17 +1088,22 @@ impl IfcAPI {
                 // (the referenced ones draw through their occurrence — no double
                 // render).
                 if ifc_type.is_subtype_of(ifc_lite_core::IfcType::IfcTypeProduct) {
-                    // #957 follow-up: a type that an IfcRelDefinesByType instantiates
-                    // already renders through its occurrences (directly or via an
-                    // IfcMappedItem). Drawing its RepresentationMap here too would
-                    // double-render it at the MappingOrigin — the AC20/ArchiCAD
-                    // "duplicate boxes at the wrong position" regression. Only
-                    // genuinely orphan types (no occurrence) reach the render below.
+                    // #957 follow-up + Model/Types view switch: type-product
+                    // RepresentationMap geometry is ALWAYS emitted here, tagged with
+                    // a geometry_class so the viewer can choose what to show:
+                    //   class 1 = orphan type (no occurrence) — part of "the model"
+                    //             since nothing else renders it (annex-E showcase).
+                    //   class 2 = instanced type (an IfcRelDefinesByType links it to
+                    //             an occurrence that already draws the real geometry).
+                    //             Hidden in Model mode (else the AC20/ArchiCAD
+                    //             duplicate-boxes-at-MappingOrigin regression returns);
+                    //             shown in Types mode as the type-library shape.
+                    // The native process_geometry path still SUPPRESSES class 2 (an
+                    // export must not duplicate geometry); only the interactive viewer
+                    // emits both and filters by view mode at render time.
                     let instantiated =
                         self.get_or_build_instantiated_type_ids(content, &mut decoder);
-                    if instantiated.contains(&id) {
-                        continue;
-                    }
+                    let type_class: u8 = if instantiated.contains(&id) { 2 } else { 1 };
                     let rep_map_ids: Vec<u32> = entity
                         .get(6)
                         .and_then(|a| a.as_list())
@@ -1146,6 +1152,7 @@ impl IfcAPI {
                                 }
                                 let mut mesh_js =
                                     MeshDataJs::new(id, ifc_type_name.clone(), mesh, color);
+                                mesh_js.set_geometry_class(type_class);
                                 if let Some(tex) = texture {
                                     mesh_js.set_texture(
                                         uvs,

--- a/rust/wasm-bindings/src/api/styling.rs
+++ b/rust/wasm-bindings/src/api/styling.rs
@@ -502,11 +502,10 @@ pub(crate) fn combined_pre_pass(
     // gpu_meshes), but the call mutates `void_index` in place — keep it.
     let _ = ifc_lite_geometry::propagate_voids_to_parts(&mut void_index, content, decoder);
 
-    // #957: render orphan IfcTypeProduct geometry (annex-E "tessellated shape
-    // with style" showcase files attach geometry to the type, not an
-    // occurrence). processGeometryBatch turns these type jobs into meshes via
-    // process_representation_map.
-    complex_jobs.extend(collect_orphan_type_geometry_jobs(content, decoder));
+    // #957 + Model/Types switch: emit IfcTypeProduct RepresentationMap geometry
+    // (annex-E orphan types AND instanced type-library shapes). processGeometryBatch
+    // tags each with a geometry_class so the viewer can show/hide it per view mode.
+    complex_jobs.extend(collect_type_geometry_jobs(content, decoder));
 
     PrePassData {
         geometry_styles,
@@ -519,43 +518,40 @@ pub(crate) fn combined_pre_pass(
     }
 }
 
-/// #957: collect render jobs for orphan `IfcTypeProduct` geometry — a type's
-/// `RepresentationMap` that no `IfcMappedItem` instantiates.
+/// Collect render jobs for `IfcTypeProduct` `RepresentationMap` geometry — every
+/// type carrying at least one map that no `IfcMappedItem` already draws.
 ///
-/// Returns `(id, start, end, ifc_type)` for each TYPE entity carrying at least
-/// one orphan RepresentationMap, to be appended to the prepass job list so the
-/// browser renders them. `processGeometryBatch` turns each into geometry via
-/// [`ifc_lite_geometry::GeometryRouter::process_representation_map`]. Normally-
-/// instanced typed products keep their geometry on the occurrence (whose
-/// IfcMappedItem references the map), so those maps are filtered out here — no
-/// double render. buildingSMART annex-E "tessellated shape with style" files
-/// declare the geometry only on the type, so without this they render nothing.
-pub(crate) fn collect_orphan_type_geometry_jobs(
+/// Returns `(id, start, end, ifc_type)` per type, appended to the prepass job
+/// list. `processGeometryBatch` turns each into geometry via
+/// [`ifc_lite_geometry::GeometryRouter::process_representation_map`] and tags it
+/// with a `geometry_class` — orphan (no occurrence) vs instanced (an
+/// `IfcRelDefinesByType` links it to an occurrence) — so the viewer's Model/Types
+/// switch can show or hide it (see `gpu_meshes.rs`). A map already referenced by
+/// an `IfcMappedItem` is drawn through its occurrence's mapped representation, so
+/// a type whose maps are ALL referenced yields no renderable job and is skipped.
+///
+/// buildingSMART annex-E "tessellated shape with style" files declare geometry
+/// only on the type (orphan, class 1); ArchiCAD/AC20 files attach a map to nearly
+/// every instanced type while the occurrence carries its own body (class 2,
+/// hidden in Model mode so it does not double-render at the MappingOrigin).
+pub(crate) fn collect_type_geometry_jobs(
     content: &str,
     decoder: &mut ifc_lite_core::EntityDecoder,
 ) -> Vec<(u32, usize, usize, ifc_lite_core::IfcType)> {
     use ifc_lite_core::{EntityScanner, IfcType};
 
-    // Fast bail-out: type-only geometry can only exist when the file authors at
-    // least one IfcRepresentationMap. The overwhelming majority of files (and
-    // every file that hits the latency-sensitive prepass without instancing)
-    // pay only a single substring search instead of a full entity scan + decode.
+    // Fast bail-out: type geometry can only exist when the file authors at least
+    // one IfcRepresentationMap. The overwhelming majority of files pay only a
+    // single substring search instead of a full entity scan + decode.
     if !content.contains("IFCREPRESENTATIONMAP") {
         return Vec::new();
     }
 
-    // Single pass: gather the IfcMappedItem-referenced RepresentationMaps, the
-    // types that an IfcRelDefinesByType instantiates, and the type-product
-    // candidates together, then filter to the orphans.
+    // Single pass: gather the IfcMappedItem-referenced RepresentationMaps and the
+    // type-product candidates, then drop types whose maps are all referenced
+    // (those are drawn through their occurrence's mapped representation). The
+    // orphan-vs-instanced class is assigned later, in the render loop.
     let mut referenced: rustc_hash::FxHashSet<u32> = rustc_hash::FxHashSet::default();
-    // Types with at least one occurrence (IfcRelDefinesByType). Their geometry is
-    // already drawn through the occurrence — directly or via IfcMappedItem — so the
-    // type's own RepresentationMap must NOT be rendered as orphan type-only
-    // geometry. ArchiCAD/AC20 exports attach a RepresentationMap to nearly every
-    // typed product while the occurrence carries its own body, so the map is
-    // referenced by no IfcMappedItem; without this gate the type double-renders at
-    // its MappingOrigin (duplicate boxes at the wrong position).
-    let mut instantiated: rustc_hash::FxHashSet<u32> = rustc_hash::FxHashSet::default();
     let mut candidates: Vec<(u32, usize, usize, IfcType, Vec<u32>)> = Vec::new();
 
     let mut scanner = EntityScanner::new(content);
@@ -565,13 +561,6 @@ pub(crate) fn collect_orphan_type_geometry_jobs(
                 // IfcMappedItem.MappingSource = attr 0.
                 if let Some(source_id) = entity.get_ref(0) {
                     referenced.insert(source_id);
-                }
-            }
-        } else if type_name == "IFCRELDEFINESBYTYPE" {
-            if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
-                // IfcRelDefinesByType.RelatingType = attr 5 (the typed product).
-                if let Some(type_id) = entity.get_ref(5) {
-                    instantiated.insert(type_id);
                 }
             }
         } else if type_name.ends_with("TYPE") || type_name.ends_with("STYLE") {
@@ -597,7 +586,6 @@ pub(crate) fn collect_orphan_type_geometry_jobs(
 
     candidates
         .into_iter()
-        .filter(|(id, _, _, _, _)| !instantiated.contains(id))
         .filter(|(_, _, _, _, maps)| maps.iter().any(|rm| !referenced.contains(rm)))
         .map(|(id, start, end, ifc_type, _)| (id, start, end, ifc_type))
         .collect()

--- a/rust/wasm-bindings/src/zero_copy.rs
+++ b/rust/wasm-bindings/src/zero_copy.rs
@@ -35,6 +35,14 @@ pub struct MeshDataJs {
     texture_height: u32,
     texture_repeat_s: bool,
     texture_repeat_t: bool,
+    /// Geometry provenance for the viewer's Model/Types view switch:
+    /// 0 = occurrence (a placed IfcProduct), 1 = orphan type geometry (an
+    /// IfcTypeProduct RepresentationMap with NO occurrence — buildingSMART
+    /// annex-E showcase files; part of "the model" since nothing else renders
+    /// it), 2 = instanced type geometry (an IfcTypeProduct that IS instantiated
+    /// via IfcRelDefinesByType — the type-library shape, hidden in Model mode to
+    /// avoid double-rendering, shown in Types mode). See #957 follow-up.
+    geometry_class: u8,
 }
 
 #[wasm_bindgen]
@@ -135,6 +143,14 @@ impl MeshDataJs {
     pub fn texture_repeat_t(&self) -> bool {
         self.texture_repeat_t
     }
+
+    /// Geometry provenance for the viewer's Model/Types switch (#957 follow-up):
+    /// 0 = occurrence, 1 = orphan type geometry (no occurrence), 2 = instanced
+    /// type geometry (hidden in Model mode, shown in Types mode).
+    #[wasm_bindgen(getter, js_name = geometryClass)]
+    pub fn geometry_class(&self) -> u8 {
+        self.geometry_class
+    }
 }
 
 impl MeshDataJs {
@@ -182,7 +198,14 @@ impl MeshDataJs {
             texture_height: 0,
             texture_repeat_s: true,
             texture_repeat_t: true,
+            geometry_class: 0,
         }
+    }
+
+    /// Tag this mesh's geometry provenance for the Model/Types view switch
+    /// (0 = occurrence, 1 = orphan type, 2 = instanced type). Call after `new`.
+    pub fn set_geometry_class(&mut self, class: u8) {
+        self.geometry_class = class;
     }
 
     /// Attach an optional SurfaceColour for the GLB exporter's "Shading"
@@ -259,6 +282,7 @@ impl MeshCollection {
             texture_height: m.texture_height,
             texture_repeat_s: m.texture_repeat_s,
             texture_repeat_t: m.texture_repeat_t,
+            geometry_class: m.geometry_class,
         })
     }
 
@@ -455,6 +479,7 @@ impl Clone for MeshCollection {
                     texture_height: m.texture_height,
                     texture_repeat_s: m.texture_repeat_s,
                     texture_repeat_t: m.texture_repeat_t,
+                    geometry_class: m.geometry_class,
                 })
                 .collect(),
             rtc_offset_x: self.rtc_offset_x,

--- a/scripts/lib/mesh-via-prepass.mjs
+++ b/scripts/lib/mesh-via-prepass.mjs
@@ -52,6 +52,7 @@ export function parseMeshesViaPrePass(api, content) {
             color: m.color,
             vertexCount: m.vertexCount,
             triangleCount: m.triangleCount,
+            geometryClass: m.geometryClass,
             free: () => {},
           });
           totalVertices += m.vertexCount;


### PR DESCRIPTION
Stacked on #994. Turns the #957 type geometry into a feature: a **Model / Types** segmented control in the viewer's Visibility menu flips the 3D scene between the placed occurrences and the type-library shapes.

> Base this PR on `main` once #994 merges.

## How it works

The viewer mesh path (`processGeometryBatch`) now **always emits** an `IfcTypeProduct`'s `RepresentationMap` geometry, tagged with a `geometry_class`:

| class | meaning | Model view | Types view |
|------:|---------|:----------:|:----------:|
| 0 | occurrence (placed `IfcProduct`) | ✅ | — |
| 1 | orphan type (no occurrence — annex-E showcase) | ✅ | ✅ |
| 2 | instanced type-library shape (`IfcRelDefinesByType`) | — | ✅ |

`MeshDataJs.geometryClass` (wasm) and `MeshData.geometryClass` (`@ifc-lite/geometry`) carry it across the boundary. `ViewportContainer` filters the cached mesh set by class + mode — **Model** hides class 2 (so the AC20/ArchiCAD duplicate boxes at the MappingOrigin never appear), **Types** hides occurrences. The switch re-filters the cached meshes **instantly** (no reload — same machinery as the existing `typeVisibility` toggles) and the choice persists across reloads.

`collect_orphan_type_geometry_jobs` → `collect_type_geometry_jobs` (emits all types with a renderable map); the render-time gate assigns the class instead of skipping instanced types. The **native** `process_geometry` path is unchanged — it still suppresses instanced-type geometry so server/CLI/SDK exports never duplicate it (intentional viewer/export divergence).

## Verification

- `cargo check -p ifc-lite-wasm` ✅
- `node --test packages/wasm/test/type-only-geometry.test.mjs` ✅ 4/4 — orphan type → class 1, instanced type → class 2.
- End-to-end via the viewer path (rebuilt wasm): `AC20-FZK-Haus` → 285 occurrences + 32 instanced-type shapes; **Model view = 285 visible** (no duplicates), **Types view = 32** (the library). `C20-Institute-Var-2` → 2668 / 235.
- `@ifc-lite/viewer` typecheck ✅, `@ifc-lite/geometry` build ✅.

**Not yet done:** live in-browser visual confirmation of the toggle (no URL model-load to automate); the React wiring mirrors the proven `typeVisibility` filter path. Easy to smoke-test in `pnpm dev`.