### PR TITLE
refactor(geometry): canonical site-rotation extraction shared by processor + viewer (Phase 3)

### DIFF
--- a/rust/geometry/src/lib.rs
+++ b/rust/geometry/src/lib.rs
@@ -127,6 +127,7 @@ pub use router::{
 pub use transform::{
     apply_rtc_offset, parse_axis2_placement_3d, parse_axis2_placement_3d_from_id,
     parse_cartesian_point, parse_cartesian_point_from_id, parse_direction, parse_direction_from_id,
+    rotation_angle_about_z,
 };
 pub use triangulation::triangulate_polygon;
 pub use void_analysis::{

--- a/rust/geometry/src/transform.rs
+++ b/rust/geometry/src/transform.rs
@@ -323,6 +323,29 @@ pub fn apply_rtc_offset(mesh: &mut Mesh, rtc: (f64, f64, f64)) {
     });
 }
 
+/// The building/site rotation about the world vertical (Z) axis, derived from a
+/// resolved **column-major** 4×4 placement matrix (as returned by
+/// [`crate::GeometryRouter::resolve_scaled_placement`]). The local X-axis (the
+/// placement's RefDirection, composed through the full parent chain and
+/// normalized) is column 0 — elements `[0]`, `[1]`, `[2]` — so its angle in the
+/// world XY plane is `atan2(m[1], m[0])`.
+///
+/// This is the single source of truth for site rotation: the processor consumes
+/// the full matrix (baking the inverse rotation into vertices for the
+/// `site_local` frame) while the viewer takes this angle for its render-frame
+/// rotation — both off the *same* resolved matrix, so they cannot drift on
+/// nested, scaled, or tilted-axis placements (where `atan2` of the raw
+/// top-level RefDirection is incomplete). Returns `None` for a degenerate
+/// (zero-length) projected X-axis.
+pub fn rotation_angle_about_z(matrix: &[f64; 16]) -> Option<f64> {
+    let x = matrix[0];
+    let y = matrix[1];
+    if x * x + y * y < 1e-10 {
+        return None;
+    }
+    Some(y.atan2(x))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -331,5 +354,38 @@ mod tests {
     fn test_parse_direction() {
         // This would require a mock decoder, so we'll test integration-style
         // in the processor tests instead
+    }
+
+    #[test]
+    fn rotation_angle_about_z_handles_identity_rotation_and_scale() {
+        // Identity → 0 rad.
+        let mut m = [0.0f64; 16];
+        m[0] = 1.0;
+        m[5] = 1.0;
+        m[10] = 1.0;
+        m[15] = 1.0;
+        assert!(rotation_angle_about_z(&m).unwrap().abs() < 1e-12);
+
+        // 45° about Z: column-0 X-axis = (cos45, sin45, 0). Matches the legacy
+        // atan2(RefDirection.y, RefDirection.x) for an axis-aligned placement.
+        let a = std::f64::consts::FRAC_PI_4;
+        let mut r = [0.0f64; 16];
+        r[0] = a.cos();
+        r[1] = a.sin();
+        r[4] = -a.sin();
+        r[5] = a.cos();
+        r[10] = 1.0;
+        r[15] = 1.0;
+        assert!((rotation_angle_about_z(&r).unwrap() - a).abs() < 1e-12);
+
+        // Uniform scale is angle-invariant (resolve_scaled_placement may carry scale).
+        let mut s = r;
+        for v in s.iter_mut().take(3) {
+            *v *= 3.0;
+        }
+        assert!((rotation_angle_about_z(&s).unwrap() - a).abs() < 1e-9);
+
+        // Degenerate (zero-length) projected X-axis → None.
+        assert!(rotation_angle_about_z(&[0.0f64; 16]).is_none());
     }
 }

--- a/rust/wasm-bindings/src/api/gpu_meshes.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes.rs
@@ -122,7 +122,7 @@ impl IfcAPI {
         // Extract building rotation
         let building_rotation = pre_pass
             .site_position
-            .and_then(|pos| extract_building_rotation_from_site(pos, &mut decoder));
+            .and_then(|pos| extract_building_rotation_from_site(pos, &router, &mut decoder));
 
         // Build combined job list: simple first, then complex
         let total_jobs = pre_pass.simple_jobs.len() + pre_pass.complex_jobs.len();
@@ -307,7 +307,7 @@ impl IfcAPI {
             || rtc_offset.2.abs() > 10000.0;
 
         let building_rotation =
-            site_position.and_then(|pos| extract_building_rotation_from_site(pos, &mut decoder));
+            site_position.and_then(|pos| extract_building_rotation_from_site(pos, &router, &mut decoder));
 
         // Serialize job list
         let total_jobs = simple_jobs.len() + complex_jobs.len();
@@ -597,7 +597,7 @@ impl IfcAPI {
                 let needs_shift = is_large(rtc_offset);
 
                 let building_rotation = site_position
-                    .and_then(|pos| extract_building_rotation_from_site(pos, &mut decoder));
+                    .and_then(|pos| extract_building_rotation_from_site(pos, &router, &mut decoder));
 
                 // Emit meta event.
                 let meta = js_sys::Object::new();
@@ -649,7 +649,7 @@ impl IfcAPI {
                 || rtc_offset.1.abs() > 10000.0
                 || rtc_offset.2.abs() > 10000.0;
             let building_rotation = site_position
-                .and_then(|pos| extract_building_rotation_from_site(pos, &mut decoder));
+                .and_then(|pos| extract_building_rotation_from_site(pos, &router, &mut decoder));
 
             let meta = js_sys::Object::new();
             super::set_js_prop(&meta, "type", &"meta".into());

--- a/rust/wasm-bindings/src/api/styling.rs
+++ b/rust/wasm-bindings/src/api/styling.rs
@@ -868,115 +868,21 @@ fn walk_representation_for_direct_color(
 // `ifc_lite_processing::default_color_for_type` (issue #913). The browser path
 // calls it directly (see `gpu_meshes.rs`); do not reintroduce a table here.
 
-/// Extract building rotation from a pre-collected IfcSite position (avoids re-scanning).
-/// Returns rotation angle in radians, or None if not found.
+/// Site/building rotation angle (radians) for the viewer's render-frame
+/// rotation, or `None` if absent. Derived from the **canonical** resolved
+/// placement matrix (`GeometryRouter::resolve_scaled_placement`) + the shared
+/// [`ifc_lite_geometry::rotation_angle_about_z`], so it cannot drift from the
+/// processor's site-local frame on nested / scaled / tilted placements (the old
+/// `atan2`-of-raw-top-level-RefDirection walk was incomplete for those).
 pub(crate) fn extract_building_rotation_from_site(
     site_pos: (u32, usize, usize),
+    router: &ifc_lite_geometry::GeometryRouter,
     decoder: &mut ifc_lite_core::EntityDecoder,
 ) -> Option<f64> {
     let (site_id, start, end) = site_pos;
     let site_entity = decoder.decode_at_with_id(site_id, start, end).ok()?;
-
-    // Get ObjectPlacement (attribute 5 for IfcProduct)
-    let placement_attr = site_entity.get(5).filter(|a| !a.is_null())?;
-    let placement = decoder.resolve_ref(placement_attr).ok()??;
-
-    // Find top-level placement (parent is null)
-    let top_level_placement = find_top_level_placement(&placement, decoder);
-
-    // Extract rotation from top-level placement's RefDirection
-    extract_rotation_from_placement(&top_level_placement, decoder)
-}
-
-/// Find the top-level placement (one with null parent)
-fn find_top_level_placement(
-    placement: &ifc_lite_core::DecodedEntity,
-    decoder: &mut ifc_lite_core::EntityDecoder,
-) -> ifc_lite_core::DecodedEntity {
-    use ifc_lite_core::IfcType;
-
-    // Check if this is a local placement
-    if placement.ifc_type != IfcType::IfcLocalPlacement {
-        return placement.clone();
-    }
-
-    // Check parent (attribute 0: PlacementRelTo)
-    let parent_attr = match placement.get(0) {
-        Some(attr) if !attr.is_null() => attr,
-        _ => return placement.clone(), // No parent - this is top-level
-    };
-
-    // Resolve parent and recurse
-    if let Ok(Some(parent)) = decoder.resolve_ref(parent_attr) {
-        find_top_level_placement(&parent, decoder)
-    } else {
-        placement.clone() // Parent resolution failed - return current
-    }
-}
-
-/// Extract rotation angle from IfcAxis2Placement3D's RefDirection
-/// Returns rotation angle in radians (atan2 of RefDirection Y/X components)
-fn extract_rotation_from_placement(
-    placement: &ifc_lite_core::DecodedEntity,
-    decoder: &mut ifc_lite_core::EntityDecoder,
-) -> Option<f64> {
-    use ifc_lite_core::IfcType;
-
-    // Get RelativePlacement (attribute 1: IfcAxis2Placement3D)
-    let rel_attr = match placement.get(1) {
-        Some(attr) if !attr.is_null() => attr,
-        _ => return None,
-    };
-
-    let axis_placement = match decoder.resolve_ref(rel_attr) {
-        Ok(Some(p)) => p,
-        _ => return None,
-    };
-
-    // Check if it's IfcAxis2Placement3D
-    if axis_placement.ifc_type != IfcType::IfcAxis2Placement3D {
-        return None;
-    }
-
-    // Get RefDirection (attribute 2: IfcDirection)
-    let ref_dir_attr = match axis_placement.get(2) {
-        Some(attr) if !attr.is_null() => attr,
-        _ => return None,
-    };
-
-    let ref_dir = match decoder.resolve_ref(ref_dir_attr) {
-        Ok(Some(d)) => d,
-        _ => return None,
-    };
-
-    if ref_dir.ifc_type != IfcType::IfcDirection {
-        return None;
-    }
-
-    // Get direction ratios (attribute 0: list of floats)
-    let ratios_attr = match ref_dir.get(0) {
-        Some(attr) => attr,
-        _ => return None,
-    };
-
-    let ratios = match ratios_attr.as_list() {
-        Some(list) => list,
-        _ => return None,
-    };
-
-    // Extract X and Y components (Z is up in IFC)
-    let dx = ratios.first().and_then(|v| v.as_float()).unwrap_or(0.0);
-    let dy = ratios.get(1).and_then(|v| v.as_float()).unwrap_or(0.0);
-
-    // Calculate rotation angle: atan2(dy, dx)
-    // This gives the angle of the building's X-axis relative to world X-axis
-    let len_sq = dx * dx + dy * dy;
-    if len_sq < 1e-10 {
-        return None; // Zero-length direction
-    }
-
-    let rotation = dy.atan2(dx);
-    Some(rotation)
+    let matrix = router.resolve_scaled_placement(&site_entity, decoder).ok()?;
+    ifc_lite_geometry::rotation_angle_about_z(&matrix)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
First of the Phase 3 canonical-Rust unifications. #913 unified colour *resolution* across the processing (server/CLI) and wasm (viewer) geometry pipelines; this does the same for **site/building rotation**, which was still derived two different ways.

## The drift (verified)
- **Processor**: takes the full placement matrix from the canonical `GeometryRouter::resolve_scaled_placement`.
- **Viewer (wasm)**: walked the placement itself (`find_top_level_placement`) and took `atan2` of the raw top-level RefDirection (`extract_rotation_from_placement`).

They agree for axis-aligned, identity-scale placements but **diverge on nested / scaled / tilted-axis placements** — a real rotated-site rendering bug — and nothing guarded it.

## The fix (canonical Rust)
- Add `ifc_lite_geometry::rotation_angle_about_z(matrix)` — the single source of truth for the Z-rotation of a resolved column-major placement matrix (`atan2(m[1], m[0])` of the local X-axis), with a unit test (identity, 45°, uniform-scale invariance, degenerate → `None`).
- The viewer's `extract_building_rotation_from_site` now resolves the site via the **same** `resolve_scaled_placement` and calls the shared helper — so it can't drift from the processor, and now handles nested/scaled placements correctly (the old `atan2` walk didn't).
- **Deleted** the viewer's superseded `find_top_level_placement` + `extract_rotation_from_placement` (supersede-means-delete, per AGENTS.md).

Internal Rust only — no `@ifc-lite/wasm` JS API change (rotation is still emitted to the render frame identically), so no changeset.

## Verification
- `cargo test -p ifc-lite-geometry --lib` → **11/11 pass** (incl. the new helper test).
- `cargo check -p ifc-lite-wasm --target wasm32-unknown-unknown` → clean.
- The 3 `wall_opening_cut_regression` failures are pre-existing fixture-absent skips (`run pnpm fixtures`), unrelated to this change.

Part of Phase 3; the surface-style **colour-extraction** unification follows as a stacked PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Building rotation angle calculation has been refined to use standardized placement resolution for improved consistency and accuracy across nested placements, scaling configurations, and complex geometry scenarios.

* **Tests**
  * Expanded test coverage for rotation angle computations, validating identity rotations, angular transformations, scaling invariance behavior, and handling of degenerate cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->