### PR TITLE
fix(styling): canonical surface-style colour extraction — fixes server/viewer DiffuseColour disagreement (Phase 3)

### DIFF
--- a/rust/processing/src/processor.rs
+++ b/rust/processing/src/processor.rs
@@ -2255,91 +2255,24 @@ fn extract_style_info_from_styled_item(
     None
 }
 
-/// Extract color + style name from an IfcSurfaceStyle.
-///
-/// IfcSurfaceStyleRendering carries two related colours:
-///   - `SurfaceColour` (attr 0): the base colour authored on the style.
-///   - `DiffuseColour` (attr 2, optional): the apparent rendered colour.
-///     Either an IfcColourRgb (replaces the colour outright) or an
-///     IfcNormalisedRatioMeasure (a 0..1 factor against SurfaceColour).
-///
-/// We return the DiffuseColour-derived value as the primary `color`
-/// (industry-standard rendered appearance) and keep SurfaceColour in
-/// `shading_color` when the two differ, so downstream consumers (e.g. the
-/// GLB exporter) can offer both choices.
+/// Extract colour + style name from an `IfcSurfaceStyle`. Colour resolution is
+/// the canonical [`crate::style::extract_surface_style_colors`], shared with the
+/// browser pre-pass so the server and viewer can't disagree on
+/// `SurfaceColour` vs `DiffuseColour` precedence (see that fn for the #859/#871
+/// semantics — `SurfaceColour` is the apparent colour; a `DiffuseColour`
+/// `IfcColourRgb` becomes the optional `shading_color`, not the rendered colour).
 fn extract_surface_style_info(
     style_id: u32,
     decoder: &mut EntityDecoder,
 ) -> Option<GeometryStyleInfo> {
     let style = decoder.decode_by_id(style_id).ok()?;
     let material_name = normalize_style_name(style.get_string(0));
-
-    // IfcSurfaceStyle: Attr 2 = Styles (list of rendering styles)
-    let rendering_refs = get_refs_from_list(&style, 2)?;
-
-    for rendering_id in rendering_refs {
-        if let Ok(rendering) = decoder.decode_by_id(rendering_id) {
-            // IfcSurfaceStyleRendering: Attr 0 = SurfaceColour
-            if let Some(color_id) = rendering.get_ref(0) {
-                if let Ok(color) = decoder.decode_by_id(color_id) {
-                    // IfcColourRgb: Attr 1 = Red, Attr 2 = Green, Attr 3 = Blue
-                    let sr = color.get_float(1).unwrap_or(0.8) as f32;
-                    let sg = color.get_float(2).unwrap_or(0.8) as f32;
-                    let sb = color.get_float(3).unwrap_or(0.8) as f32;
-
-                    // Transparency: 0.0 = opaque, 1.0 = transparent
-                    let alpha: f32 = (1.0 - rendering.get_float(1).unwrap_or(0.0) as f32)
-                        .clamp(0.0, 1.0);
-
-                    let surface_rgba = [sr, sg, sb, alpha];
-
-                    // DiffuseColour (attr 2): SELECT(IfcColourRgb,
-                    // IfcNormalisedRatioMeasure). The decoder exposes
-                    // entity references via `get_ref` and inline floats via
-                    // `get_float`; we probe both.
-                    let (rendering_rgba, shading) = if let Some(diffuse_id) =
-                        rendering.get_ref(2)
-                    {
-                        if let Ok(diffuse) = decoder.decode_by_id(diffuse_id) {
-                            let dr = diffuse.get_float(1).unwrap_or(sr as f64) as f32;
-                            let dg = diffuse.get_float(2).unwrap_or(sg as f64) as f32;
-                            let db = diffuse.get_float(3).unwrap_or(sb as f64) as f32;
-                            let rendering_rgba = [dr, dg, db, alpha];
-                            let shading = if rendering_rgba == surface_rgba {
-                                None
-                            } else {
-                                Some(surface_rgba)
-                            };
-                            (rendering_rgba, shading)
-                        } else {
-                            (surface_rgba, None)
-                        }
-                    } else if let Some(factor) = rendering.get_float(2) {
-                        // IfcNormalisedRatioMeasure factor applied against
-                        // SurfaceColour, clamped to the legal 0..1 range.
-                        let f = (factor as f32).clamp(0.0, 1.0);
-                        let rendering_rgba = [sr * f, sg * f, sb * f, alpha];
-                        let shading = if rendering_rgba == surface_rgba {
-                            None
-                        } else {
-                            Some(surface_rgba)
-                        };
-                        (rendering_rgba, shading)
-                    } else {
-                        (surface_rgba, None)
-                    };
-
-                    return Some(GeometryStyleInfo {
-                        color: rendering_rgba,
-                        shading_color: shading,
-                        material_name: material_name.clone(),
-                    });
-                }
-            }
-        }
-    }
-
-    None
+    let (color, shading_color) = crate::style::extract_surface_style_colors(style_id, decoder)?;
+    Some(GeometryStyleInfo {
+        color,
+        shading_color,
+        material_name,
+    })
 }
 
 fn normalize_style_name(raw: Option<&str>) -> Option<String> {

--- a/rust/processing/src/style/mod.rs
+++ b/rust/processing/src/style/mod.rs
@@ -32,6 +32,7 @@ use ifc_lite_core::IfcType;
 
 mod indexed_colour;
 mod material;
+mod surface;
 // Public styling resolvers — the single shared implementation that both the
 // native pipeline and the browser `wasm-bindings` call (issue #913, Phase 2e).
 // `split_mesh_by_indexed_colour` is also public so the browser `processGeometryBatch`
@@ -45,6 +46,7 @@ pub use material::{
     pick_material_style_for_submesh, pick_opaque_first, resolve_material_ids,
     resolve_submesh_color,
 };
+pub use surface::extract_surface_style_colors;
 
 /// Alpha at or above which a color is treated as opaque.
 ///

--- a/rust/processing/src/style/surface.rs
+++ b/rust/processing/src/style/surface.rs
@@ -1,0 +1,111 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+//! Canonical `IfcSurfaceStyle` → colour extraction, shared by the processing
+//! (server/CLI) and wasm (viewer) geometry pipelines so they cannot drift on
+//! surface-style rendering semantics — the coordinate/colour analogue of the
+//! single default-colour table (#913).
+
+use ifc_lite_core::{EntityDecoder, IfcType};
+
+/// Read an `IfcColourRgb` as linear `[r, g, b, 1.0]` (alpha is filled by the
+/// caller from the rendering's transparency). Missing components default to 0.8
+/// (mid-grey), matching the historical behaviour on both pipelines.
+fn read_colour_rgb(color_id: u32, decoder: &mut EntityDecoder) -> Option<[f32; 4]> {
+    let color = decoder.decode_by_id(color_id).ok()?;
+    if color.ifc_type != IfcType::IfcColourRgb {
+        return None;
+    }
+    // IfcColourRgb: Name(0), Red(1), Green(2), Blue(3) — same in IFC2x3 and IFC4.
+    let r = color.get_float(1).unwrap_or(0.8) as f32;
+    let g = color.get_float(2).unwrap_or(0.8) as f32;
+    let b = color.get_float(3).unwrap_or(0.8) as f32;
+    Some([r, g, b, 1.0])
+}
+
+/// Colours of a single `IfcSurfaceStyleRendering` / `IfcSurfaceStyleShading`.
+///
+/// Returns `(apparent, shading)`:
+/// - `apparent` is `SurfaceColour` (attr 0), modulated by `DiffuseColour`
+///   (attr 2) **only** when the author supplied it as an
+///   `IfcNormalisedRatioMeasure` factor. `SurfaceColour` is the apparent surface
+///   colour per the IFC spec and how web-ifc / IfcOpenShell / BlenderBIM read
+///   the chain.
+/// - `shading` is populated only when a *distinct* `DiffuseColour` `IfcColourRgb`
+///   is authored, for downstream consumers that want the diffuse override (the
+///   GLB exporter's "Shading" source).
+///
+/// A `DiffuseColour = IfcColourRgb(0, 0, 0)` therefore does NOT black out the
+/// surface — that is the spec's "no diffuse reflection contribution", and the
+/// regression #859/#871 fixed (otherwise every `IfcSignal` / `IfcReferent` on
+/// the railway fixture rendered opaque black).
+fn rendering_colours(
+    rendering_id: u32,
+    decoder: &mut EntityDecoder,
+) -> Option<([f32; 4], Option<[f32; 4]>)> {
+    let rendering = decoder.decode_by_id(rendering_id).ok()?;
+    match rendering.ifc_type {
+        IfcType::IfcSurfaceStyleRendering | IfcType::IfcSurfaceStyleShading => {
+            // Attr 0: SurfaceColour, Attr 1: Transparency (0=opaque, 1=transparent),
+            // Attr 2: DiffuseColour — SELECT(IfcColourRgb, IfcNormalisedRatioMeasure),
+            // only present on IfcSurfaceStyleRendering.
+            let color_ref = rendering.get_ref(0)?;
+            let [sr, sg, sb, _] = read_colour_rgb(color_ref, decoder)?;
+
+            let transparency = rendering.get_float(1).unwrap_or(0.0);
+            let alpha = (1.0 - transparency as f32).clamp(0.0, 1.0);
+            let surface_rgba = [sr, sg, sb, alpha];
+
+            let mut apparent = surface_rgba;
+            let mut shading: Option<[f32; 4]> = None;
+
+            if rendering.ifc_type == IfcType::IfcSurfaceStyleRendering {
+                if let Some(diffuse_id) = rendering.get_ref(2) {
+                    if let Some([dr, dg, db, _]) = read_colour_rgb(diffuse_id, decoder) {
+                        let diffuse_rgba = [dr, dg, db, alpha];
+                        // Surface the diffuse override only when it actually
+                        // differs — it is NOT the apparent colour.
+                        if diffuse_rgba != surface_rgba {
+                            shading = Some(diffuse_rgba);
+                        }
+                    }
+                } else if let Some(factor) = rendering.get_float(2) {
+                    let f = (factor as f32).clamp(0.0, 1.0);
+                    apparent = [sr * f, sg * f, sb * f, alpha];
+                }
+            }
+
+            Some((apparent, shading))
+        }
+        _ => None,
+    }
+}
+
+/// Extract the apparent surface colour (and an optional distinct shading colour)
+/// from an `IfcSurfaceStyle`, walking its `Styles` list (attr 2) and returning
+/// the first rendering's `(apparent, shading)` pair.
+///
+/// This is the **single source of truth** for surface-style colour, consumed by
+/// both the server geometry processor and the browser pre-pass, so the two
+/// cannot disagree on `SurfaceColour` vs `DiffuseColour` precedence.
+pub fn extract_surface_style_colors(
+    surface_style_id: u32,
+    decoder: &mut EntityDecoder,
+) -> Option<([f32; 4], Option<[f32; 4]>)> {
+    let style = decoder.decode_by_id(surface_style_id).ok()?;
+    if style.ifc_type != IfcType::IfcSurfaceStyle {
+        return None;
+    }
+    // IfcSurfaceStyle: Name(0), Side(1), Styles(2: list of surface-style elements).
+    let styles_attr = style.get(2)?;
+    let list = styles_attr.as_list()?;
+    for item in list {
+        if let Some(element_id) = item.as_entity_ref() {
+            if let Some(pair) = rendering_colours(element_id, decoder) {
+                return Some(pair);
+            }
+        }
+    }
+    None
+}

--- a/rust/processing/tests/styling_parity.rs
+++ b/rust/processing/tests/styling_parity.rs
@@ -278,3 +278,69 @@ fn no_duplicate_default_color_tables() {
          `processing::style` — use `default_color_for_type` instead (issue #913): {offenders:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// "No second surface-style colour extractor" guard.
+//
+// The `IfcSurfaceStyle → IfcSurfaceStyleRendering → IfcColourRgb` leaf has one
+// home: `ifc_lite_processing::style::extract_surface_style_colors`. The browser
+// `wasm-bindings` used to carry its own copy (`extract_color_from_rendering` /
+// `extract_color_rgb`), which silently disagreed with the server on
+// SurfaceColour-vs-DiffuseColour precedence (#859/#871). Forbid those function
+// names from reappearing so the two pipelines can't re-fork. (The 2D drafting
+// palette in `symbolic.rs` uses differently-named `extract_color_from_*`
+// helpers and is unaffected.)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn no_duplicate_surface_style_color_extraction() {
+    let Some(root) = repo_root() else {
+        eprintln!("repo root not found (packaged context) — skipping guard");
+        return;
+    };
+
+    let allow = |rel: &str| {
+        rel.ends_with("rust/processing/tests/styling_parity.rs")
+            // Standalone debug examples can't depend on the downstream
+            // `processing` crate, so they carry their own ad-hoc extraction.
+            // They are not a production pipeline and don't affect server/viewer
+            // parity, so they're exempt from this guard.
+            || rel.starts_with("rust/geometry/examples/")
+    };
+
+    let mut files = Vec::new();
+    collect_rs_files(&root.join("rust"), &mut files);
+    collect_rs_files(&root.join("apps"), &mut files);
+
+    let mut offenders = Vec::new();
+    for path in files {
+        let rel = path
+            .strip_prefix(&root)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        if allow(&rel) {
+            continue;
+        }
+        let Ok(src) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let declares = src.lines().any(|line| {
+            let line = line.trim_start();
+            ["fn ", "pub fn ", "pub(crate) fn "].iter().any(|p| {
+                line.starts_with(&format!("{p}extract_color_from_rendering"))
+                    || line.starts_with(&format!("{p}extract_color_rgb"))
+            })
+        });
+        if declares {
+            offenders.push(rel);
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "surface-style colour extraction must live only in \
+         `ifc_lite_processing::style::extract_surface_style_colors`; found a per-pipeline \
+         copy in: {offenders:?}"
+    );
+}

--- a/rust/wasm-bindings/src/api/styling.rs
+++ b/rust/wasm-bindings/src/api/styling.rs
@@ -95,8 +95,9 @@ pub(crate) fn find_color_for_geometry(
     None
 }
 
-/// Extract `(rendering_color, shading_color)` from IfcStyledItem.Styles.
-/// See `extract_color_from_rendering` for the tuple semantics.
+/// Extract `(apparent_color, shading_color)` from IfcStyledItem.Styles.
+/// See [`ifc_lite_processing::style::extract_surface_style_colors`] for the
+/// tuple semantics.
 pub(crate) fn extract_color_pair_from_styles(
     styles_attr: &ifc_lite_core::AttributeValue,
     decoder: &mut ifc_lite_core::EntityDecoder,
@@ -127,8 +128,12 @@ pub(crate) fn extract_color_from_styles(
     extract_color_pair_from_styles(styles_attr, decoder).map(|(c, _)| c)
 }
 
-/// Extract color from IfcPresentationStyleAssignment or IfcSurfaceStyle.
-/// See `extract_color_from_rendering` for the tuple semantics.
+/// Extract colour from `IfcPresentationStyle(Assignment)` or `IfcSurfaceStyle`,
+/// delegating the surface-style colour leaf to the canonical
+/// [`ifc_lite_processing::style::extract_surface_style_colors`] (#913-style
+/// single source of truth — so the viewer and server can't disagree on
+/// `SurfaceColour` vs `DiffuseColour` precedence). Returns
+/// `(apparent_color, optional_shading_color)`.
 fn extract_color_from_style_assignment(
     style_id: u32,
     decoder: &mut ifc_lite_core::EntityDecoder,
@@ -139,12 +144,14 @@ fn extract_color_from_style_assignment(
 
     match style.ifc_type {
         IfcType::IfcPresentationStyle => {
-            // IfcPresentationStyle has Styles at attr 0
+            // IfcPresentationStyle has Styles at attr 0.
             let styles_attr = style.get(0)?;
             if let Some(list) = styles_attr.as_list() {
                 for item in list {
                     if let Some(inner_id) = item.as_entity_ref() {
-                        if let Some(pair) = extract_color_from_surface_style(inner_id, decoder) {
+                        if let Some(pair) =
+                            ifc_lite_processing::style::extract_surface_style_colors(inner_id, decoder)
+                        {
                             return Some(pair);
                         }
                     }
@@ -152,17 +159,18 @@ fn extract_color_from_style_assignment(
             }
         }
         IfcType::IfcSurfaceStyle => {
-            return extract_color_from_surface_style(style_id, decoder);
+            return ifc_lite_processing::style::extract_surface_style_colors(style_id, decoder);
         }
         _ => {
-            // FIX: Handle IfcPresentationStyleAssignment (IFC2x3 entity not in IFC4 schema)
-            // IfcPresentationStyleAssignment has Styles list at attribute 0
-            // It's decoded as Unknown type, so we check by structure
+            // IfcPresentationStyleAssignment (IFC2x3 entity absent from the IFC4
+            // schema) decodes as Unknown; its Styles list is at attribute 0.
             let styles_attr = style.get(0)?;
             if let Some(list) = styles_attr.as_list() {
                 for item in list {
                     if let Some(inner_id) = item.as_entity_ref() {
-                        if let Some(pair) = extract_color_from_surface_style(inner_id, decoder) {
+                        if let Some(pair) =
+                            ifc_lite_processing::style::extract_surface_style_colors(inner_id, decoder)
+                        {
                             return Some(pair);
                         }
                     }
@@ -172,145 +180,6 @@ fn extract_color_from_style_assignment(
     }
 
     None
-}
-
-/// Extract color from IfcSurfaceStyle. See `extract_color_from_rendering`
-/// for the meaning of the tuple.
-fn extract_color_from_surface_style(
-    style_id: u32,
-    decoder: &mut ifc_lite_core::EntityDecoder,
-) -> Option<([f32; 4], Option<[f32; 4]>)> {
-    use ifc_lite_core::IfcType;
-
-    let style = decoder.decode_by_id(style_id).ok()?;
-
-    if style.ifc_type != IfcType::IfcSurfaceStyle {
-        return None;
-    }
-
-    // IfcSurfaceStyle: Name, Side, Styles (list of surface style elements)
-    // Attribute 2: Styles
-    let styles_attr = style.get(2)?;
-
-    if let Some(list) = styles_attr.as_list() {
-        for item in list {
-            if let Some(element_id) = item.as_entity_ref() {
-                if let Some(pair) = extract_color_from_rendering(element_id, decoder) {
-                    return Some(pair);
-                }
-            }
-        }
-    }
-
-    None
-}
-
-/// Extract color from IfcSurfaceStyleRendering or IfcSurfaceStyleShading.
-///
-/// Returns `(rendering_color, shading_color)`:
-///   - `rendering_color` is the apparent surface colour: `SurfaceColour`
-///     (attr 0) by default, scaled by `DiffuseColour` (attr 2) when the
-///     author supplied it as an `IfcNormalisedRatioMeasure` factor.
-///     Matches how web-ifc, IfcOpenShell, BlenderBIM, and the IFC spec
-///     prose treat the chain — `SurfaceColour` IS the apparent surface
-///     colour; `DiffuseColour` is the diffuse-reflection contribution
-///     used by full PBR/Phong renderers and is meaningless for the flat
-///     viewer pipeline when its only effect is to drop everything to
-///     black.
-///   - `shading_color` is the alternative the GLB exporter's "Shading"
-///     source picks up — populated only when a distinct `DiffuseColour`
-///     IfcColourRgb is authored, so downstream pipelines that DO want
-///     the per-component diffuse override can still get it.
-///
-/// Pre-fix this preferred `DiffuseColour` over `SurfaceColour`. That
-/// regressed on every IFC file that authors `DiffuseColour =
-/// IfcColourRgb(0, 0, 0)` (which the spec defines as "no diffuse
-/// reflection contribution", NOT "render the surface in black") — most
-/// notably the railway fixture on issue #859 / PR #871, where every
-/// IfcSignal / IfcReferent rendered as opaque black on the dark
-/// viewport background and the user reported "viewport blank" even
-/// though 33 meshes had streamed correctly.
-fn extract_color_from_rendering(
-    rendering_id: u32,
-    decoder: &mut ifc_lite_core::EntityDecoder,
-) -> Option<([f32; 4], Option<[f32; 4]>)> {
-    use ifc_lite_core::IfcType;
-
-    let rendering = decoder.decode_by_id(rendering_id).ok()?;
-
-    match rendering.ifc_type {
-        IfcType::IfcSurfaceStyleRendering | IfcType::IfcSurfaceStyleShading => {
-            // Attr 0: SurfaceColour (inherited from IfcSurfaceStyleShading)
-            // Attr 1: Transparency (inherited, 0.0=opaque, 1.0=transparent)
-            // Attr 2: DiffuseColour — SELECT(IfcColourRgb,
-            //         IfcNormalisedRatioMeasure). Only on IfcSurfaceStyleRendering.
-            let color_ref = rendering.get_ref(0)?;
-            let [sr, sg, sb, _] = extract_color_rgb(color_ref, decoder)?;
-
-            let transparency = rendering.get_float(1).unwrap_or(0.0);
-            let alpha = (1.0 - transparency as f32).clamp(0.0, 1.0);
-            let surface_rgba = [sr, sg, sb, alpha];
-
-            // SurfaceColour is the canonical apparent colour. Only let
-            // DiffuseColour modulate it when it's a normalised-ratio
-            // factor (which IS a multiplicative modifier of
-            // SurfaceColour per spec). When DiffuseColour is an
-            // IfcColourRgb we store it as the optional `shading`
-            // override for downstream consumers (GLB exporter's
-            // "Shading" source) but do NOT use it as the rendered
-            // colour — that would replace the entire surface tint
-            // with a value the IFC author intended as a reflectance
-            // coefficient, which turns most files black on the flat
-            // viewer pipeline.
-            let mut rendering_rgba = surface_rgba;
-            let mut shading: Option<[f32; 4]> = None;
-
-            if rendering.ifc_type == IfcType::IfcSurfaceStyleRendering {
-                if let Some(diffuse_id) = rendering.get_ref(2) {
-                    if let Some([dr, dg, db, _]) = extract_color_rgb(diffuse_id, decoder) {
-                        let diffuse_rgba = [dr, dg, db, alpha];
-                        // Surface the diffuse override to the GLB
-                        // exporter only when it actually differs from
-                        // the surface colour.
-                        if diffuse_rgba != surface_rgba {
-                            shading = Some(diffuse_rgba);
-                        }
-                    }
-                } else if let Some(factor) = rendering.get_float(2) {
-                    let f = (factor as f32).clamp(0.0, 1.0);
-                    rendering_rgba = [sr * f, sg * f, sb * f, alpha];
-                }
-            }
-
-            return Some((rendering_rgba, shading));
-        }
-        _ => {}
-    }
-
-    None
-}
-
-/// Extract RGB color from IfcColourRgb
-fn extract_color_rgb(
-    color_id: u32,
-    decoder: &mut ifc_lite_core::EntityDecoder,
-) -> Option<[f32; 4]> {
-    use ifc_lite_core::IfcType;
-
-    let color = decoder.decode_by_id(color_id).ok()?;
-
-    if color.ifc_type != IfcType::IfcColourRgb {
-        return None;
-    }
-
-    // IfcColourRgb: Name, Red, Green, Blue
-    // Note: In IFC2x3, attributes are at indices 1, 2, 3 (0 is Name)
-    // In IFC4, attributes are also at 1, 2, 3
-    let red = color.get_float(1).unwrap_or(0.8);
-    let green = color.get_float(2).unwrap_or(0.8);
-    let blue = color.get_float(3).unwrap_or(0.8);
-
-    Some([red as f32, green as f32, blue as f32, 1.0])
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Stacked on #996. The second Phase 3 canonical-Rust unification — and it surfaced a **real cross-pipeline colour bug**.

## The bug (verified)
The `IfcSurfaceStyle → IfcSurfaceStyleRendering → IfcColourRgb` leaf was extracted independently by the two pipelines, and they **disagreed**:
- **Viewer** (`extract_color_from_rendering`): `SurfaceColour` is the apparent colour; a distinct `DiffuseColour` `IfcColourRgb` is kept only as an optional shading override. This is the documented **#859/#871** fix — `DiffuseColour = IfcColourRgb(0,0,0)` means "no diffuse reflection," **not** "render black."
- **Processor** (`extract_surface_style_info`): returned the **DiffuseColour** as the primary colour.

So the **server / CLI / GLB** path rendered the *opposite* colour from the viewer for any model with a distinct `DiffuseColour`, and still carried the #859/#871 black-out bug server-side. Nothing guarded it (`styling_parity` only covered the default-colour table).

## The fix (canonical Rust, the #913 pattern)
- New **`ifc_lite_processing::style::extract_surface_style_colors`** — the single source of truth, using the viewer's spec-correct semantics.
- Both the processor's `extract_surface_style_info` and the viewer's `extract_color_from_style_assignment` now consume it; **deleted** the viewer's superseded `extract_color_from_surface_style` / `extract_color_from_rendering` / `extract_color_rgb`.
- New **`styling_parity` guard** fails the build if a per-pipeline `extract_color_from_rendering` / `extract_color_rgb` reappears (the 2D drafting palette in `symbolic.rs` and standalone `rust/geometry/examples/` debug tools use different names / can't reach the downstream crate, so they're exempt).

Net **+99 / −229**.

## ⚠️ Behaviour change (server-side, intended)
The processor / CLI / GLB path now matches the viewer: **`SurfaceColour` is the apparent colour**; a distinct `DiffuseColour` `IfcColourRgb` becomes `shading_color`, not the rendered colour. This **fixes** the server black-out on files like the #859 railway fixture — but it changes server/GLB colour output for any file with a distinct `DiffuseColour`, so it needs the colour fixtures to confirm.

## Verification
- `cargo test -p ifc-lite-processing` → lib **18/18** + `styling_parity` **5/5** (incl. the new surface-style guard, which also *caught* a stray copy in a geometry example).
- `cargo check -p ifc-lite-wasm --target wasm32-unknown-unknown` → clean.
- **The colour-output change must validate against the #859 railway + colour-regression fixtures in CI** — the worktree has no fixtures (`pnpm fixtures`), so those run server-side in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)