### PR TITLE
fix(viewer): only show the Model/Types 3D switch when the model has type geometry

### DIFF
--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -462,6 +462,10 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
   // occurrences (default), 'types' shows the type-library shapes.
   const typeViewMode = useViewerStore((state) => state.typeViewMode);
   const setTypeViewMode = useViewerStore((state) => state.setTypeViewMode);
+  // Only models with type-library geometry (RepresentationMap shapes) can show
+  // anything in "Types" mode, so the switch is hidden for the common
+  // occurrence-only model. Derived in ViewportContainer from the merged meshes.
+  const hasTypeGeometry = useViewerStore((state) => state.hasTypeGeometry);
   // How many of the five class toggles are on — surfaced in the menu
   // header so the user sees scene state at a glance.
   const visibleClassCount = [
@@ -1414,46 +1418,52 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
               RepresentationMap whose shape is drawn at its MappingOrigin; "Types"
               shows that type library, "Model" shows the placed occurrences. The
               two are mutually exclusive — toggling re-filters the cached mesh set
-              instantly (no reload). */}
-          <div className="px-1.5 pb-1 pt-0.5">
-            <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-              3D View
-            </span>
-          </div>
-          <div className="flex gap-1 px-1.5 pb-1.5" role="radiogroup" aria-label="3D view mode">
-            <button
-              type="button"
-              role="radio"
-              aria-checked={typeViewMode === 'model'}
-              onClick={() => setTypeViewMode('model')}
-              className={cn(
-                'flex flex-1 items-center justify-center gap-1.5 rounded-md border px-2 py-1.5 text-xs font-medium transition-colors',
-                typeViewMode === 'model'
-                  ? 'border-primary/40 bg-primary/10 text-foreground'
-                  : 'border-transparent text-muted-foreground hover:bg-muted/50',
-              )}
-            >
-              <Boxes className="h-3.5 w-3.5 shrink-0" />
-              Model
-            </button>
-            <button
-              type="button"
-              role="radio"
-              aria-checked={typeViewMode === 'types'}
-              onClick={() => setTypeViewMode('types')}
-              className={cn(
-                'flex flex-1 items-center justify-center gap-1.5 rounded-md border px-2 py-1.5 text-xs font-medium transition-colors',
-                typeViewMode === 'types'
-                  ? 'border-primary/40 bg-primary/10 text-foreground'
-                  : 'border-transparent text-muted-foreground hover:bg-muted/50',
-              )}
-            >
-              <Shapes className="h-3.5 w-3.5 shrink-0" />
-              Types
-            </button>
-          </div>
+              instantly (no reload). Only rendered when the model actually has
+              type-library geometry — most carry only occurrence geometry, where
+              "Types" would be empty, so the switch would just be a dead control. */}
+          {hasTypeGeometry && (
+            <>
+              <div className="px-1.5 pb-1 pt-0.5">
+                <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                  3D View
+                </span>
+              </div>
+              <div className="flex gap-1 px-1.5 pb-1.5" role="radiogroup" aria-label="3D view mode">
+                <button
+                  type="button"
+                  role="radio"
+                  aria-checked={typeViewMode === 'model'}
+                  onClick={() => setTypeViewMode('model')}
+                  className={cn(
+                    'flex flex-1 items-center justify-center gap-1.5 rounded-md border px-2 py-1.5 text-xs font-medium transition-colors',
+                    typeViewMode === 'model'
+                      ? 'border-primary/40 bg-primary/10 text-foreground'
+                      : 'border-transparent text-muted-foreground hover:bg-muted/50',
+                  )}
+                >
+                  <Boxes className="h-3.5 w-3.5 shrink-0" />
+                  Model
+                </button>
+                <button
+                  type="button"
+                  role="radio"
+                  aria-checked={typeViewMode === 'types'}
+                  onClick={() => setTypeViewMode('types')}
+                  className={cn(
+                    'flex flex-1 items-center justify-center gap-1.5 rounded-md border px-2 py-1.5 text-xs font-medium transition-colors',
+                    typeViewMode === 'types'
+                      ? 'border-primary/40 bg-primary/10 text-foreground'
+                      : 'border-transparent text-muted-foreground hover:bg-muted/50',
+                  )}
+                >
+                  <Shapes className="h-3.5 w-3.5 shrink-0" />
+                  Types
+                </button>
+              </div>
 
-          <DropdownMenuSeparator className="my-1" />
+              <DropdownMenuSeparator className="my-1" />
+            </>
+          )}
 
           <div className="flex items-center justify-between gap-2 px-1.5 pb-1 pt-0.5">
             <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">

--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -67,6 +67,7 @@ export function ViewportContainer() {
   const selectedStoreys = useViewerStore((s) => s.selectedStoreys);
   const typeVisibility = useViewerStore((s) => s.typeVisibility);
   const typeViewMode = useViewerStore((s) => s.typeViewMode);
+  const setHasTypeGeometry = useViewerStore((s) => s.setHasTypeGeometry);
   const isolatedEntities = useViewerStore((s) => s.isolatedEntities);
   const classFilter = useViewerStore((s) => s.classFilter);
   const resetViewerState = useViewerStore((s) => s.resetViewerState);
@@ -501,6 +502,52 @@ export function ViewportContainer() {
   // Check if any models are loaded (even if hidden) - used to show empty 3D vs starting UI
   const hasLoadedModels = storeModels.size > 0 || (geometryResult?.meshes && geometryResult.meshes.length > 0);
 
+  // Does the rendered geometry carry any type-library geometry? geometryClass
+  // 1 = orphan type, 2 = instanced type; class 0 = placed occurrence. The
+  // Model/Types switch is only meaningful — and "Types" only renders anything —
+  // when class 1/2 meshes exist, so we surface this to gate the toolbar control
+  // (#957 follow-up). Scanned incrementally (O(batch)) and short-circuited once
+  // any type mesh is seen, so the common occurrence-only model costs at most a
+  // single linear pass that stops early.
+  const typeGeoSourceRef = useRef<MeshData[] | null>(null);
+  const typeGeoScanLenRef = useRef(0);
+  const sawTypeGeometryRef = useRef(false);
+  const hasTypeGeometry = useMemo(() => {
+    const meshes = mergedGeometryResult?.meshes;
+    if (!meshes || meshes.length === 0) {
+      typeGeoSourceRef.current = meshes ?? null;
+      typeGeoScanLenRef.current = meshes?.length ?? 0;
+      sawTypeGeometryRef.current = false;
+      return false;
+    }
+    // New source array, or it shrank (new file / replace) → rescan from scratch.
+    if (typeGeoSourceRef.current !== meshes || meshes.length < typeGeoScanLenRef.current) {
+      typeGeoSourceRef.current = meshes;
+      typeGeoScanLenRef.current = 0;
+      sawTypeGeometryRef.current = false;
+    }
+    if (!sawTypeGeometryRef.current) {
+      for (let i = typeGeoScanLenRef.current; i < meshes.length; i++) {
+        if ((meshes[i].geometryClass ?? 0) !== 0) { sawTypeGeometryRef.current = true; break; }
+      }
+    }
+    typeGeoScanLenRef.current = meshes.length;
+    return sawTypeGeometryRef.current;
+    // geometryContentVersion bumps per streaming batch — picks up type geometry
+    // that arrives in a later batch even when the meshes array is mutated in place.
+  }, [mergedGeometryResult, geometryContentVersion]);
+
+  // Persisted view mode may be 'types' from a prior model; fall back to 'model'
+  // when the current geometry has no type library so "Types" never renders an
+  // empty scene (and the now-hidden switch can't be used to recover).
+  const effectiveViewMode = hasTypeGeometry ? typeViewMode : 'model';
+
+  // Publish to the store so the toolbar can hide the Model/Types switch when
+  // there is no type geometry to reveal.
+  useEffect(() => {
+    setHasTypeGeometry(hasTypeGeometry);
+  }, [hasTypeGeometry, setHasTypeGeometry]);
+
   // PERF: Incremental geometry filtering using refs.
   // Instead of creating a new 200K+ element array every batch (~200ms),
   // we push ONLY new meshes into a cached array — O(batch_size) not O(total).
@@ -509,7 +556,7 @@ export function ViewportContainer() {
   const filteredSourceLenRef = useRef(0);
   const filteredSourceRef = useRef<MeshData[] | null>(null);
   const filteredTypeVisRef = useRef(typeVisibility);
-  const filteredTypeModeRef = useRef(typeViewMode);
+  const filteredTypeModeRef = useRef(effectiveViewMode);
   const filteredVersionRef = useRef(0);
 
   const filteredGeometry = useMemo(() => {
@@ -531,14 +578,14 @@ export function ViewportContainer() {
       prevVis.spaces !== typeVisibility.spaces ||
       prevVis.openings !== typeVisibility.openings ||
       prevVis.site !== typeVisibility.site ||
-      filteredTypeModeRef.current !== typeViewMode;
+      filteredTypeModeRef.current !== effectiveViewMode;
     const sourceChanged = filteredSourceRef.current !== allMeshes;
     if (typeVisChanged || sourceChanged || allMeshes.length < filteredSourceLenRef.current) {
       cache.length = 0;
       filteredSourceLenRef.current = 0;
       filteredSourceRef.current = allMeshes;
       filteredTypeVisRef.current = typeVisibility;
-      filteredTypeModeRef.current = typeViewMode;
+      filteredTypeModeRef.current = effectiveViewMode;
     }
 
     const needsFilter = !typeVisibility.spaces || !typeVisibility.openings || !typeVisibility.site;
@@ -555,7 +602,7 @@ export function ViewportContainer() {
       // (else the AC20 duplicate boxes at the MappingOrigin reappear); in 'types'
       // mode hide occurrences (class 0) so only the type library shows.
       const geometryClass = mesh.geometryClass ?? 0;
-      if (typeViewMode === 'types') {
+      if (effectiveViewMode === 'types') {
         if (geometryClass === 0) continue;
       } else if (geometryClass === 2) {
         continue;
@@ -587,7 +634,7 @@ export function ViewportContainer() {
     // Return the same array reference — downstream change detection uses
     // geometryVersion (which increments each batch) instead of array identity.
     return cache;
-  }, [mergedGeometryResult, typeVisibility, typeViewMode]);
+  }, [mergedGeometryResult, typeVisibility, effectiveViewMode]);
 
   // Version counter that changes every batch — triggers useGeometryStreaming
   // without requiring a new geometry array reference.

--- a/apps/viewer/src/store/slices/mutationSlice.ts
+++ b/apps/viewer/src/store/slices/mutationSlice.ts
@@ -47,6 +47,7 @@ import { getEntityBounds } from '@/utils/viewportUtils';
 import { toGlobalIdFromModels } from '../globalId.js';
 import { buildElementMesh, type ElementMeshPayload } from './addElementMeshes.js';
 import type { AddElementType } from './addElementSlice.js';
+import type { TypeViewMode } from '../constants.js';
 import {
   resolvePlacementChain,
   resolveRotationState,
@@ -91,6 +92,23 @@ export const DUPLICATE_DEFAULT_DIRECTION: DuplicateDirection = '+X';
 
 /** Fallback step in metres when the source has no mesh in geometry. */
 const DUPLICATE_FALLBACK_STEP = 1;
+
+/**
+ * New occurrence geometry from an authoring action (add element, duplicate,
+ * split) is a class-0 mesh, which the 3D "Types" view deliberately hides. If
+ * the user is in Types view when they commit such an action, flip back to
+ * Model so the element they just created actually renders — otherwise the
+ * toast says "added" but nothing appears. No-op when already in Model view
+ * (so it never needlessly overwrites the persisted preference). Reads the
+ * live store via the cross-slice `get()`.
+ */
+function revealAddedGeometryInModelView(get: () => unknown): void {
+  const cross = get() as {
+    typeViewMode?: TypeViewMode;
+    setTypeViewMode?: (mode: TypeViewMode) => void;
+  };
+  if (cross.typeViewMode === 'types') cross.setTypeViewMode?.('model');
+}
 
 interface ViewerBox {
   /** Per-axis sizes in viewer scene coordinates. */
@@ -921,6 +939,7 @@ function runInStoreElementBuilder(
         appendGeometryBatch?: (batch: MeshData[]) => void;
       };
       cross.appendGeometryBatch?.([mesh]);
+      revealAddedGeometryInModelView(get);
     }
   }
 
@@ -2104,6 +2123,7 @@ export const createMutationSlice: StateCreator<
         appendGeometryBatch?: (batch: MeshData[]) => void;
       };
       cross.appendGeometryBatch?.([columnMesh]);
+      revealAddedGeometryInModelView(get);
     }
 
     set((s) => {
@@ -2352,6 +2372,7 @@ export const createMutationSlice: StateCreator<
         appendGeometryBatch?: (batch: MeshData[]) => void;
       };
       cross.appendGeometryBatch?.(clonedMeshes);
+      revealAddedGeometryInModelView(get);
     }
 
     return { expressId: newId, globalId: newGlobalId };

--- a/apps/viewer/src/store/slices/visibilitySlice.ts
+++ b/apps/viewer/src/store/slices/visibilitySlice.ts
@@ -30,6 +30,12 @@ export interface VisibilitySlice {
   /** 3D view mode for the Model/Types switch (#957 follow-up). 'model' shows
    *  placed occurrences (default); 'types' shows the type-library shapes. */
   typeViewMode: TypeViewMode;
+  /** True when the rendered geometry contains any type-library geometry
+   *  (geometryClass 1 = orphan type, 2 = instanced type) — i.e. the Model/Types
+   *  switch has something to reveal in "Types" mode. Derived from the merged
+   *  mesh set by ViewportContainer; most models carry only occurrence geometry
+   *  (class 0), so the switch stays hidden for them. */
+  hasTypeGeometry: boolean;
 
   // State (multi-model)
   /** Hidden entities per model */
@@ -58,6 +64,10 @@ export interface VisibilitySlice {
   resetTypeVisibility: () => void;
   /** Set the Model/Types 3D view mode (and persist). */
   setTypeViewMode: (mode: TypeViewMode) => void;
+  /** Set whether the current geometry contains type-library geometry — drives
+   *  whether the Model/Types switch renders at all. Runtime-only (not persisted);
+   *  re-derived from geometry on every load. */
+  setHasTypeGeometry: (value: boolean) => void;
   /** Set all hidden entities at once (for BCF viewpoint application) */
   setHiddenEntities: (ids: Set<number>) => void;
   /** Set all isolated entities at once (for BCF viewpoint with defaultVisibility=false) */
@@ -92,6 +102,8 @@ export const createVisibilitySlice: StateCreator<VisibilitySlice, [], [], Visibi
   // Read persisted toggles fresh so the user's choices survive reloads.
   typeVisibility: getPersistedTypeVisibility(),
   typeViewMode: getPersistedTypeViewMode(),
+  // Derived from geometry at load time — no model is open yet, so default false.
+  hasTypeGeometry: false,
 
   // Initial state (multi-model)
   hiddenEntitiesByModel: new Map(),
@@ -241,6 +253,11 @@ export const createVisibilitySlice: StateCreator<VisibilitySlice, [], [], Visibi
     }
     return { typeViewMode: mode };
   }),
+
+  setHasTypeGeometry: (value) => set((state) => (
+    // No-op when unchanged so the toolbar doesn't re-render on every batch.
+    state.hasTypeGeometry === value ? {} : { hasTypeGeometry: value }
+  )),
 
   // Actions (multi-model)
   hideEntityInModel: (modelId, expressId) => set((state) => {

--- a/apps/viewer/src/store/slices/visibilitySlice.ts
+++ b/apps/viewer/src/store/slices/visibilitySlice.ts
@@ -255,8 +255,11 @@ export const createVisibilitySlice: StateCreator<VisibilitySlice, [], [], Visibi
   }),
 
   setHasTypeGeometry: (value) => set((state) => (
-    // No-op when unchanged so the toolbar doesn't re-render on every batch.
-    state.hasTypeGeometry === value ? {} : { hasTypeGeometry: value }
+    // Return the SAME state reference when unchanged — a fresh `{}` would still
+    // merge into a new state object and notify every subscriber (incl. the
+    // whole-state useSyncExternalStore in ViewportContainer). Same ref → Zustand
+    // skips the notification entirely.
+    state.hasTypeGeometry === value ? state : { hasTypeGeometry: value }
   )),
 
   // Actions (multi-model)


### PR DESCRIPTION
## Problem

The #957 follow-up added a **Model / Types** switch to the 3D View panel, but it rendered for *every* loaded model. "Types" mode only displays type-library geometry (`geometryClass` 1 = orphan type, 2 = instanced type); most models carry only occurrence geometry (`class 0`), so for them the switch was a dead control — toggling to "Types" produced an empty scene.

## Fix

Gate the switch on whether the rendered geometry actually contains any type geometry.

- **`visibilitySlice`** — add a runtime-only `hasTypeGeometry` flag (default `false`) plus a `setHasTypeGeometry` setter that no-ops when unchanged, so the toolbar doesn't re-render on every streaming batch.
- **`ViewportContainer`** — derive `hasTypeGeometry` from the merged mesh set with an incremental, early-exiting scan: it short-circuits the moment a `geometryClass !== 0` mesh is seen (so the common occurrence-only model costs at most one short linear pass), and it re-derives per streaming batch so type geometry arriving late still flips it on. The flag is published to the store via `useEffect`. The filter now runs through `effectiveViewMode = hasTypeGeometry ? typeViewMode : 'model'`, so a persisted `'types'` preference from a prior model can't strand the user on an empty scene with a now-hidden switch.
- **`MainToolbar`** — wrap the "3D View" heading, the Model/Types buttons, and the trailing separator in `{hasTypeGeometry && (…)}`.

## Behavior

- Occurrence-only model (the common case) → switch hidden.
- Model with orphan/instanced type geometry → switch shows; "Types" always has content.
- Federation: switch shows if **any** loaded model has type geometry; removing the last type-geometry model hides it again.
- Stale `'types'` preference meeting a no-type model → falls back to the model view, no empty scene.

## Gating choice

Gates on **any** type geometry (`class 1` *or* `2`), giving the clean invariant "show the switch exactly when Types mode would render something." The alternative — gating only on instanced types (`class 2`) — would also hide the switch for the rare pure-orphan-library model where Model and Types views are identical anyway. Easy to narrow if preferred.

## Verification

- `tsc --noEmit`: only the pre-existing `@ifc-lite/diff` module-resolution errors (CI-built bindings, not built locally); none in the edited files.
- `visibilitySlice` tests: 36/36 pass.
- No existing test asserts the switch always renders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The 3D viewer now intelligently detects whether loaded models contain type-library geometry and conditionally displays the "Types" option in the Model/Types view mode selector. This smart behavior prevents showing irrelevant visualization options for models that don't support type geometry, providing a cleaner interface experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->