### PR TITLE
fix(drawing-2d): scope construction projection to the current floor + exclude openings (#979)

### DIFF
--- a/.changeset/floor-scoped-projection.md
+++ b/.changeset/floor-scoped-projection.md
@@ -1,0 +1,21 @@
+---
+"@ifc-lite/drawing-2d": minor
+"@ifc-lite/wasm": patch
+---
+
+Scope construction projection to the current floor and exclude openings (#979 follow-up).
+
+- **Current-floor scoping.** On a plan cut of a multi-storey model the projection
+  bands now clamp to the storey the cut sits in, instead of projecting the whole
+  model height — so a roof two levels up no longer draws on the ground-floor plan.
+  New `@ifc-lite/drawing-2d` exports back this: `currentFloorBands` (pure band
+  math) and `storeyFloorsFromMeshes` (per-storey floor levels from mesh-Y in the
+  render frame, plus the `StoreyFloorMesh` type). The caller derives band depths
+  from these; storey-less / single-storey / federated models fall back to the
+  full-extent bands unchanged.
+- **Opening exclusion.** `IfcOpeningElement` and the rest of the
+  `IfcFeatureElement` family no longer participate in projection.
+  `Drawing2DGenerator.generate` filters them from BOTH the profile and the
+  mesh-silhouette paths via the new `isFeatureElementType` helper, and the Rust
+  `extract_profiles` (`@ifc-lite/wasm`) skips `is_subtype_of(IfcFeatureElement)`
+  at the source so opening void cross-sections never become projection profiles.

--- a/apps/viewer/src/components/viewer/Section2DPanel.tsx
+++ b/apps/viewer/src/components/viewer/Section2DPanel.tsx
@@ -598,7 +598,7 @@ export function Section2DPanel({
                 <Tag className="h-4 w-4" />
               </Button>
 
-              {/* Construction projection toggle (issue #979) — plan only */}
+              {/* Construction projection toggle (issue #979) — cardinal cuts only */}
               <Button
                 variant={displayOptions.showConstructionProjection ? 'default' : 'ghost'}
                 size="icon-sm"
@@ -608,7 +608,7 @@ export function Section2DPanel({
                     ? 'Hide construction projection (overhead & visible reference lines)'
                     : 'Show construction projection (overhead & visible reference lines)'
                 }
-                disabled={sectionPlane.axis !== 'down' || sectionPlane.custom !== undefined}
+                disabled={sectionPlane.custom !== undefined}
               >
                 <BoxSelect className="h-4 w-4" />
               </Button>
@@ -786,7 +786,7 @@ export function Section2DPanel({
                   </DropdownMenuItem>
                   <DropdownMenuItem
                     onClick={toggleConstructionProjection}
-                    disabled={sectionPlane.axis !== 'down' || sectionPlane.custom !== undefined}
+                    disabled={sectionPlane.custom !== undefined}
                   >
                     <BoxSelect className="h-4 w-4 mr-2" />
                     Construction Projection {displayOptions.showConstructionProjection ? 'On' : 'Off'}

--- a/apps/viewer/src/hooks/useDrawingGeneration.ts
+++ b/apps/viewer/src/hooks/useDrawingGeneration.ts
@@ -518,10 +518,14 @@ export function useDrawingGeneration({
       // a plan ('down') cut with projection on, a single model (storey ids are
       // LOCAL express ids — federation would mismatch global mesh ids), no
       // active manual isolation or storey selection (those already scope the
-      // set and the user's explicit choice wins), and spatial-hierarchy data
-      // present (absent on cache-reopened models). Otherwise keep the shipped
-      // full-extent behavior so single-storey / cache-loaded / federated models
-      // don't regress.
+      // set and the user's explicit choice wins), spatial-hierarchy data
+      // present (absent on cache-reopened models), and at most ONE building.
+      // A single IFC can hold several IfcBuildings with staggered storey
+      // elevations; flattening all their storey minima into one band mis-scopes
+      // (a cut on building B's ground floor capped by building A's upper
+      // storey), so multi-building models fall back to full extent too.
+      // Otherwise keep the shipped full-extent behavior so single-storey /
+      // cache-loaded / federated / multi-building models don't regress.
       const sh = ifcDataStore?.spatialHierarchy;
       const canScopeFloor =
         projectionOn &&
@@ -530,7 +534,8 @@ export function useDrawingGeneration({
         models.size <= 1 &&
         combinedIsolatedIds === null &&
         !(computedIsolatedIds && computedIsolatedIds.size > 0) &&
-        !!sh;
+        sh !== undefined &&
+        sh.byBuilding.size <= 1;
       if (canScopeFloor && sh) {
         const cached = storeyFloorsCacheRef.current;
         const floors =

--- a/apps/viewer/src/hooks/useDrawingGeneration.ts
+++ b/apps/viewer/src/hooks/useDrawingGeneration.ts
@@ -18,6 +18,8 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Drawing2DGenerator,
   createSectionConfig,
+  currentFloorBands,
+  storeyFloorsFromMeshes,
   type Drawing2D,
   type DrawingLine,
   type SectionConfig,
@@ -25,6 +27,7 @@ import {
   type MeshOutline2D,
 } from '@ifc-lite/drawing-2d';
 import { GeometryProcessor, type GeometryResult } from '@ifc-lite/geometry';
+import type { SpatialHierarchy } from '@ifc-lite/data';
 import * as IfcWasm from '@ifc-lite/wasm';
 import { customPlaneCenter } from '@/store';
 
@@ -66,7 +69,11 @@ export const ANNOTATION_VIEW_DEPTH = 1.2;
 
 interface UseDrawingGenerationParams {
   geometryResult: GeometryResult | null | undefined;
-  ifcDataStore: { source: Uint8Array } | null;
+  // `spatialHierarchy` (optional — absent on cache-reopened models) backs the
+  // current-floor projection scoping (issue #979 follow-up). The runtime
+  // already passes the full DataStore from `useIfc()`, so this is a pure type
+  // widen, not new prop threading.
+  ifcDataStore: { source: Uint8Array; spatialHierarchy?: SpatialHierarchy } | null;
   /**
    * Section plane state. `custom` is the optional face-pick override
    * (issue #243); when set the cutter cuts on that arbitrary plane and
@@ -159,6 +166,15 @@ export function useDrawingGeneration({
   // the shared dlmalloc heap grows/reuses (AGENTS.md §7).
   const profileCacheRef = useRef<{
     profiles: ProfileEntry[];
+    sourceId: string | null;
+  } | null>(null);
+
+  // Cache for per-storey floor levels used to scope construction projection to
+  // the current floor (issue #979 follow-up). Derived from mesh-Y, so it only
+  // changes when the model/visibility set changes — keyed on the same
+  // `modelCacheKey` as the profile cache.
+  const storeyFloorsCacheRef = useRef<{
+    floors: number[];
     sourceId: string | null;
   } | null>(null);
 
@@ -484,16 +500,61 @@ export function useDrawingGeneration({
       // Calculate max depth as half the model extent
       const maxDepth = (axisMax - axisMin) * 0.5;
 
-      // Construction-projection bands (issue #979). Project the full model
-      // extent on each side of the cut and let the band classifier split by
-      // side (below → solid, above → dashed). Full extent makes single-storey
-      // models with an overhead roof (e.g. AC20) "just work"; multi-storey
-      // bleed is naturally scoped when the user isolates a storey (the meshes
-      // are already filtered to it below). Flip-invariant: the classifier
-      // applies the flip sign itself. Floor at 1mm so a degenerate zero-extent
-      // model (or a storey collapsed to a single slab) doesn't yield 0-width
-      // bands that cull every element sitting on the plane.
+      // Construction-projection bands (issue #979 + current-floor follow-up).
+      // Project geometry on each side of the cut and let the band classifier
+      // split it (below → solid, above → dashed). `fullExtent` (the whole model
+      // height) is the baseline; for a multi-storey model on a plan cut the
+      // bands are instead clamped to the storey the cut sits in, so other
+      // floors don't bleed onto the plan (e.g. a roof two levels up — the
+      // reported bug). Flip-invariant: the classifier applies the flip sign
+      // itself. Floor at 1mm so a degenerate zero-extent model (or a storey
+      // collapsed to a single slab) doesn't yield 0-width bands that cull every
+      // element sitting on the plane.
       const fullExtent = Math.max(axisMax - axisMin, 1e-3);
+      let belowDepth = fullExtent;
+      let aboveDepth = fullExtent;
+
+      // Auto-scope to the current floor only when it's safe and meaningful:
+      // a plan ('down') cut with projection on, a single model (storey ids are
+      // LOCAL express ids — federation would mismatch global mesh ids), no
+      // active manual isolation or storey selection (those already scope the
+      // set and the user's explicit choice wins), and spatial-hierarchy data
+      // present (absent on cache-reopened models). Otherwise keep the shipped
+      // full-extent behavior so single-storey / cache-loaded / federated models
+      // don't regress.
+      const sh = ifcDataStore?.spatialHierarchy;
+      const canScopeFloor =
+        projectionOn &&
+        sectionPlane.axis === 'down' &&
+        !sectionPlane.custom &&
+        models.size <= 1 &&
+        combinedIsolatedIds === null &&
+        !(computedIsolatedIds && computedIsolatedIds.size > 0) &&
+        !!sh;
+      if (canScopeFloor && sh) {
+        const cached = storeyFloorsCacheRef.current;
+        const floors =
+          cached && cached.sourceId === modelCacheKey
+            ? cached.floors
+            : storeyFloorsFromMeshes(geometryResult.meshes, sh.elementToStorey);
+        if (!cached || cached.sourceId !== modelCacheKey) {
+          storeyFloorsCacheRef.current = { floors, sourceId: modelCacheKey };
+        }
+        // Need ≥2 storeys to scope: with 0/1 storey there is no "other floor"
+        // to exclude, and full extent keeps an overhead roof projecting.
+        if (floors.length >= 2) {
+          // `currentFloorBands` returns GEOMETRIC depths — `below` toward the
+          // floor, `above` toward the ceiling. The band classifier reads them
+          // in FLIP-ADJUSTED depth space (d<0 = `below` slot), so on a flipped
+          // plan cut (looking up — a reflected-ceiling-plan style view) the
+          // floor/ceiling map to the opposite slots and the magnitudes must be
+          // swapped. The shipped full-extent bands were symmetric so this never
+          // mattered before; the asymmetric storey bands make flip significant.
+          const bands = currentFloorBands(floors, position, axisMin, axisMax);
+          belowDepth = sectionPlane.flipped ? bands.above : bands.below;
+          aboveDepth = sectionPlane.flipped ? bands.below : bands.above;
+        }
+      }
 
       // Adjust progress to account for symbolic parsing phase (0-20%)
       const progressOffset = symbolicLines.length > 0 ? 20 : 0;
@@ -505,8 +566,8 @@ export function useDrawingGeneration({
       // Create section config
       const config: SectionConfig = createSectionConfig(axis, position, {
         projectionDepth: maxDepth,
-        projectionBelowDepth: fullExtent,
-        projectionAboveDepth: fullExtent,
+        projectionBelowDepth: belowDepth,
+        projectionAboveDepth: aboveDepth,
         includeHiddenLines: displayOptions.showHiddenLines,
         scale: displayOptions.scale,
       });

--- a/apps/viewer/src/hooks/useDrawingGeneration.ts
+++ b/apps/viewer/src/hooks/useDrawingGeneration.ts
@@ -67,6 +67,15 @@ export const AXIS_MAP: Record<'down' | 'front' | 'side', 'x' | 'y' | 'z'> = {
 // live in is already in metres (WASM applies `unit_scale` upstream).
 export const ANNOTATION_VIEW_DEPTH = 1.2;
 
+// View depth BEHIND a vertical (front/side) section cut within which
+// construction projection is drawn, as a fraction of the model extent along the
+// cut axis (issue #979 follow-up). A vertical section has no "storey" to scope
+// to, so it projects a bounded slab behind the cut — near geometry solid,
+// occluded/far dashed (hidden-line pass) — and culls the cut-away front half
+// and anything past this depth. Half the model depth is a sensible default;
+// tune here if sections feel too deep or too shallow.
+export const SECTION_VIEW_DEPTH_FRACTION = 0.5;
+
 interface UseDrawingGenerationParams {
   geometryResult: GeometryResult | null | undefined;
   // `spatialHierarchy` (optional — absent on cache-reopened models) backs the
@@ -392,21 +401,27 @@ export function useDrawingGeneration({
       }
     }
 
-    // Construction projection is plan-only (issue #979): the cut must be the
-    // cardinal 'down' axis and not a face-picked custom plane. The UI disables
-    // the toggle off-plan, but the persisted flag can stay true when the user
-    // switches axis — so gate generation here too, otherwise front/side/custom
-    // sections keep emitting projection the user can't turn off.
-    const projectionSupported = sectionPlane.axis === 'down' && !sectionPlane.custom;
+    // Construction projection runs on any CARDINAL cut (plan 'down' + vertical
+    // 'front'/'side'), but NOT a face-picked custom plane (the band classifier
+    // and outline binding are cardinal-only). Plan and section use different
+    // boundaries: plan scopes to the current storey; a vertical section has no
+    // "storey", so it projects a bounded view depth behind the cut (see the
+    // band computation below). The UI gates the toggle to the same set; the
+    // persisted flag can survive a switch to a custom plane, so gate here too.
+    const projectionSupported = !sectionPlane.custom;
     const projectionOn = projectionSupported && displayOptions.showConstructionProjection;
 
     // ── Construction projection profiles (issue #979) ────────────────────────
     // Extract extruded-area-solid profiles for the clean projection path. Only
-    // when projection is on; cached per model since they don't move with the
-    // section. Single-model (modelIndex 0) for now, mirroring the symbolic
-    // path's federation limitation.
+    // for PLAN cuts: the profile projector draws a solid's base footprint, which
+    // is the plan representation but collapses to a base edge on a vertical
+    // section — so front/side cuts use the mesh-silhouette/outline path instead
+    // (profiles stay empty → every mesh silhouettes). Cached per model since
+    // they don't move with the section. Single-model (modelIndex 0) for now,
+    // mirroring the symbolic path's federation limitation.
+    const profilesNeeded = projectionOn && sectionPlane.axis === 'down';
     let profiles: ProfileEntry[] = [];
-    if (projectionOn && ifcDataStore?.source) {
+    if (profilesNeeded && ifcDataStore?.source) {
       const pcache = profileCacheRef.current;
       if (pcache && pcache.sourceId === modelCacheKey) {
         profiles = pcache.profiles;
@@ -477,8 +492,10 @@ export function useDrawingGeneration({
           profiles = [];
         }
       }
-    } else if (profileCacheRef.current) {
-      // Toggle off: drop the cache so a re-enable re-extracts cleanly.
+    } else if (!projectionOn && profileCacheRef.current) {
+      // Projection fully off: drop the cache so a re-enable re-extracts cleanly.
+      // A plan↔section switch (projection still on) keeps the cache so flipping
+      // back to a plan reuses the extracted profiles.
       profileCacheRef.current = null;
     }
 
@@ -559,6 +576,18 @@ export function useDrawingGeneration({
           belowDepth = sectionPlane.flipped ? bands.above : bands.below;
           aboveDepth = sectionPlane.flipped ? bands.below : bands.above;
         }
+      }
+
+      // Vertical section (front/side): storeys don't bound it. Project a
+      // bounded view depth BEHIND the cut and cull the cut-away front half +
+      // anything past that depth. "Behind" is always the `below` (d<0) band:
+      // the band classifier's flip and the view direction's flip cancel, so
+      // this is flip-invariant (no swap needed). Near geometry draws solid;
+      // the hidden-line pass dashes occluded/far parts. (Profiles aren't
+      // extracted off-plan, so this geometry comes from the mesh silhouette.)
+      if (projectionOn && !sectionPlane.custom && sectionPlane.axis !== 'down') {
+        belowDepth = Math.max((axisMax - axisMin) * SECTION_VIEW_DEPTH_FRACTION, 1e-3);
+        aboveDepth = 1e-3; // cull the half in front of the cut
       }
 
       // Adjust progress to account for symbolic parsing phase (0-20%)

--- a/packages/drawing-2d/src/drawing-generator.ts
+++ b/packages/drawing-2d/src/drawing-generator.ts
@@ -44,6 +44,7 @@ import {
   getViewDirectionForPlane,
   outlineToProjectionLines,
 } from './projection-bands.js';
+import { isFeatureElementType } from './feature-elements.js';
 import {
   boundsEmpty,
   boundsExtendPoint,
@@ -207,15 +208,26 @@ export class Drawing2DGenerator {
         above: config.projectionAboveDepth ?? config.projectionDepth,
       };
 
+      // Feature elements (IfcOpeningElement & the void/feature family) are
+      // boolean operands, not building structure — they must never project
+      // (issue #979 follow-up). Filter them from BOTH the profile path and the
+      // silhouette path: dropping them only from profiles would push them onto
+      // the silhouette path (they'd fall out of `coveredKeys` and their raw
+      // mesh would then be silhouetted), so the two must be filtered together.
+      // The Rust extractor already skips them at the source, but a CI-lagged
+      // WASM bundle can still emit opening profiles, and opening MESHES always
+      // reach `meshes` — so this TS filter is the load-bearing guard.
+      const projectionProfiles = profiles?.filter((p) => !isFeatureElementType(p.ifcType));
+
       // Per-element dedup: elements with an extracted profile take their
       // projection from the clean profile path only; the silhouette fallback
       // skips them.
       const coveredKeys = new Set<EntityKey>();
-      if (profiles && profiles.length > 0) {
-        for (const profile of profiles) {
+      if (projectionProfiles && projectionProfiles.length > 0) {
+        for (const profile of projectionProfiles) {
           coveredKeys.add(makeEntityKey(profile.modelIndex, profile.expressId));
         }
-        projectionLines.push(...projectProfiles(profiles, config.plane, bands));
+        projectionLines.push(...projectProfiles(projectionProfiles, config.plane, bands));
       }
 
       if (opts.includeEdges) {
@@ -224,12 +236,11 @@ export class Drawing2DGenerator {
         // out. Prefer the winding-robust Rust `meshOutline2d` footprint when an
         // outlineProvider is supplied; fall back per-mesh to the normal-based
         // silhouette (which can break on ifc-lite's unreliable winding).
-        const meshesForSilhouette =
-          coveredKeys.size > 0
-            ? meshes.filter(
-                (m) => !coveredKeys.has(makeEntityKey(m.modelIndex ?? 0, m.expressId)),
-              )
-            : meshes;
+        const meshesForSilhouette = meshes.filter(
+          (m) =>
+            !isFeatureElementType(m.ifcType) &&
+            !coveredKeys.has(makeEntityKey(m.modelIndex ?? 0, m.expressId)),
+        );
 
         const viewDir = getViewDirectionForPlane(config.plane);
         for (const mesh of meshesForSilhouette) {
@@ -294,7 +305,13 @@ export class Drawing2DGenerator {
         config.projectionAboveDepth ?? config.projectionDepth,
       );
 
-      // Build depth buffer and classify lines
+      // Build depth buffer and classify lines. The occluder set deliberately
+      // keeps the FULL `meshes` (incl. feature-element/opening meshes that are
+      // filtered out of projection above): an opening mesh is coincident with
+      // the void in its host wall, which writes the same depth, so it never
+      // changes occlusion — and dropping it could only ever REVEAL a
+      // through-wall line that should stay hidden. Don't "tidy" this to the
+      // filtered set.
       this.hiddenLineClassifier.buildDepthBuffer(
         meshes,
         config.plane.axis,

--- a/packages/drawing-2d/src/feature-elements.test.ts
+++ b/packages/drawing-2d/src/feature-elements.test.ts
@@ -1,0 +1,131 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+import type { MeshData } from '@ifc-lite/geometry';
+import type { ProfileEntry, SectionConfig } from './types.js';
+import { Drawing2DGenerator } from './drawing-generator.js';
+import { isFeatureElementType } from './feature-elements.js';
+
+describe('isFeatureElementType', () => {
+  it('flags the IfcFeatureElement / void family', () => {
+    for (const t of [
+      'IfcOpeningElement',
+      'IfcOpeningStandardCase',
+      'IfcVoidingFeature',
+      'IfcEarthworksCut',
+      'IfcProjectionElement',
+      'IfcSurfaceFeature',
+      'IfcFeatureElementSubtraction',
+      'IfcFeatureElementAddition',
+      'IfcFeatureElement',
+    ]) {
+      expect(isFeatureElementType(t)).toBe(true);
+    }
+  });
+
+  it('is case-insensitive', () => {
+    expect(isFeatureElementType('IFCOPENINGELEMENT')).toBe(true);
+    expect(isFeatureElementType('ifcopeningelement')).toBe(true);
+  });
+
+  it('does NOT flag real building structure (incl. doors/windows in the void)', () => {
+    for (const t of ['IfcWall', 'IfcSlab', 'IfcColumn', 'IfcBeam', 'IfcDoor', 'IfcWindow', 'IfcRoof']) {
+      expect(isFeatureElementType(t)).toBe(false);
+    }
+  });
+
+  it('treats missing/empty type as non-feature', () => {
+    expect(isFeatureElementType(undefined)).toBe(false);
+    expect(isFeatureElementType(null)).toBe(false);
+    expect(isFeatureElementType('')).toBe(false);
+  });
+});
+
+// ─── Integration: openings must not project via EITHER path ───────────────────
+
+function createTransform(tx = 0, ty = 0, tz = 0): Float32Array {
+  return new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, tx, ty, tz, 1]);
+}
+
+function createProfile(expressId: number, ifcType: string): ProfileEntry {
+  return {
+    expressId,
+    ifcType,
+    outerPoints: new Float32Array([0, 0, 2, 0, 2, 1, 0, 1]),
+    holeCounts: new Uint32Array(),
+    holePoints: new Float32Array(),
+    transform: createTransform(),
+    extrusionDir: new Float32Array([0, 0, 1]),
+    extrusionDepth: 1,
+    modelIndex: 0,
+  };
+}
+
+function createBoxMesh(expressId: number, ifcType: string, minX: number, maxX: number): MeshData {
+  return {
+    expressId,
+    ifcType,
+    modelIndex: 0,
+    positions: new Float32Array([
+      minX, 0, 0, maxX, 0, 0, maxX, 1, 0, minX, 1, 0,
+      minX, 0, 1, maxX, 0, 1, maxX, 1, 1, minX, 1, 1,
+    ]),
+    normals: new Float32Array(8 * 3),
+    indices: new Uint32Array([
+      0, 1, 2, 0, 2, 3, 4, 6, 5, 4, 7, 6,
+      0, 4, 5, 0, 5, 1, 1, 5, 6, 1, 6, 2,
+      2, 6, 7, 2, 7, 3, 3, 7, 4, 3, 4, 0,
+    ]),
+    color: [1, 1, 1, 1],
+  };
+}
+
+const sectionConfig: SectionConfig = {
+  plane: { axis: 'x', position: 1, flipped: false },
+  projectionDepth: 2,
+  includeHiddenLines: false,
+  creaseAngle: 30,
+  scale: 100,
+};
+
+describe('feature-element projection exclusion (issue #979)', () => {
+  it('excludes opening profiles AND opening meshes from projection', async () => {
+    const generator = new Drawing2DGenerator();
+
+    // Real wall: present as a profile (clean path) — should project.
+    const wallProfile = createProfile(10, 'IfcWall');
+    // Opening present BOTH as a profile (stale-wasm case) and as a standalone
+    // mesh (the prepass always meshes openings) — must project via neither.
+    const openingProfile = createProfile(20, 'IfcOpeningElement');
+    const openingMesh = createBoxMesh(20, 'IfcOpeningElement', 1.2, 1.8);
+    // A non-extruded element with no profile that DOES project via silhouette.
+    const beamMesh = createBoxMesh(30, 'IfcBeam', 1.2, 1.8);
+
+    const drawing = await generator.generate(
+      [openingMesh, beamMesh],
+      sectionConfig,
+      {
+        useGPU: false,
+        includeHiddenLines: false,
+        includeProjection: true,
+        includeEdges: true,
+        mergeLines: false,
+      },
+      [wallProfile, openingProfile],
+    );
+
+    const projectionIds = new Set(
+      drawing.lines.filter((l) => l.category === 'projection').map((l) => l.entityId),
+    );
+    const openingLines = drawing.lines.filter((l) => l.ifcType === 'IfcOpeningElement');
+
+    // The opening (#20) must not appear via the profile path or the silhouette path.
+    expect(projectionIds.has(20)).toBe(false);
+    expect(openingLines.length).toBe(0);
+    // Real structure still projects.
+    expect(projectionIds.has(10)).toBe(true); // wall profile
+    expect(projectionIds.has(30)).toBe(true); // beam silhouette
+  });
+});

--- a/packages/drawing-2d/src/feature-elements.ts
+++ b/packages/drawing-2d/src/feature-elements.ts
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Feature-element classification for 2D drawing projection (issue #979).
+ *
+ * `IfcFeatureElement` descendants — openings, voids, earthworks cuts,
+ * projection/surface features — are boolean subtraction/addition operands, NOT
+ * building structure. They must never participate in the construction
+ * projection: their void cross-sections would draw spurious rectangles inside
+ * walls and clutter the plan.
+ *
+ * The Rust profile extractor (`rust/geometry/src/profile_extractor.rs`) already
+ * skips these at the source via `IfcType::is_subtype_of(IfcFeatureElement)`,
+ * but that only covers the clean-profile path. The mesh-silhouette fallback in
+ * `Drawing2DGenerator` consumes raw `MeshData` (which still contains
+ * `IfcOpeningElement` meshes), and a stale/CI-lagged WASM bundle can still emit
+ * opening profiles — so the projection stage filters BOTH paths with this same
+ * canonical type set, keeping the TS and Rust families from drifting.
+ *
+ * Caveat: `MeshData.ifcType` is optional ("backward compatibility with old
+ * caches"). A cache-restored mesh that lacks `ifcType` reads as a non-feature
+ * element here and could still silhouette — the same exposure as before this
+ * fix (such meshes were always silhouetted). Populating `ifcType` on the
+ * cache-restore path would close that residual gap.
+ *
+ * The set is the concrete (instantiable) `IfcFeatureElement` leaf types plus
+ * the abstract roots, matched case-insensitively. `IfcDoor`/`IfcWindow` are
+ * deliberately absent — they descend from `IfcBuiltElement`, not
+ * `IfcFeatureElement`, and are real structure that must keep projecting.
+ */
+
+/** Canonical IFC feature-element type names (lower-cased for O(1) lookup). */
+const FEATURE_ELEMENT_TYPES: ReadonlySet<string> = new Set([
+  'ifcfeatureelement',
+  'ifcfeatureelementsubtraction',
+  'ifcfeatureelementaddition',
+  'ifcopeningelement',
+  'ifcopeningstandardcase',
+  'ifcvoidingfeature',
+  'ifcearthworkscut',
+  'ifcprojectionelement',
+  'ifcsurfacefeature',
+]);
+
+/**
+ * Whether `ifcType` is an `IfcFeatureElement` subtype (an opening/void/feature
+ * operand) that must be excluded from construction projection. `undefined`/
+ * unknown types are treated as real geometry (not a feature element).
+ */
+export function isFeatureElementType(ifcType: string | undefined | null): boolean {
+  if (!ifcType) return false;
+  return FEATURE_ELEMENT_TYPES.has(ifcType.toLowerCase());
+}

--- a/packages/drawing-2d/src/index.ts
+++ b/packages/drawing-2d/src/index.ts
@@ -118,6 +118,11 @@ export {
 } from './projection-bands.js';
 export type { ProjectionBand, ProjectionBandDepths } from './projection-bands.js';
 
+// Current-floor scoping + feature-element exclusion (issue #979 follow-up)
+export { currentFloorBands, storeyFloorsFromMeshes } from './storey-bands.js';
+export type { StoreyFloorMesh } from './storey-bands.js';
+export { isFeatureElementType } from './feature-elements.js';
+
 // ═══════════════════════════════════════════════════════════════════════════
 // HIDDEN LINE REMOVAL
 // ═══════════════════════════════════════════════════════════════════════════

--- a/packages/drawing-2d/src/storey-bands.test.ts
+++ b/packages/drawing-2d/src/storey-bands.test.ts
@@ -1,0 +1,138 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+import { currentFloorBands, storeyFloorsFromMeshes, type StoreyFloorMesh } from './storey-bands.js';
+import { classifyDepthRange, signedAxisDepth } from './projection-bands.js';
+
+// A mesh that occupies world-Y [minY, maxY]; only the Y values matter here.
+function meshY(expressId: number, minY: number, maxY: number): StoreyFloorMesh {
+  return {
+    expressId,
+    positions: new Float32Array([0, minY, 0, 1, maxY, 0, 1, minY, 1]),
+  };
+}
+
+describe('storeyFloorsFromMeshes', () => {
+  it('returns each storey floor as the min member-Y, sorted ascending', () => {
+    const meshes = [
+      meshY(1, 0.0, 2.6), // ground wall
+      meshY(2, 0.0, 0.2), // ground slab
+      meshY(3, 2.7, 5.0), // attic wall + roof
+    ];
+    const elementToStorey = new Map([
+      [1, 100], [2, 100], // storey 100 (ground)
+      [3, 200],           // storey 200 (attic)
+    ]);
+    // Float32Array round-trips the literals, so compare with a tolerance.
+    const floors = storeyFloorsFromMeshes(meshes, elementToStorey);
+    expect(floors).toHaveLength(2);
+    expect(floors[0]).toBeCloseTo(0.0, 5);
+    expect(floors[1]).toBeCloseTo(2.7, 5);
+  });
+
+  it('reflects the slab-underside reality: a slab extruded below the datum lowers the level', () => {
+    // Attic floor slab modelled from 2.5..2.7 (underside 0.2 below the 2.7 datum).
+    const meshes = [meshY(1, 0.0, 2.6), meshY(2, 2.5, 2.7)];
+    const elementToStorey = new Map([[1, 100], [2, 200]]);
+    // The attic level reads as 2.5 (the slab underside), not the 2.7 datum.
+    const floors = storeyFloorsFromMeshes(meshes, elementToStorey);
+    expect(floors).toHaveLength(2);
+    expect(floors[0]).toBeCloseTo(0.0, 5);
+    expect(floors[1]).toBeCloseTo(2.5, 5);
+  });
+
+  it('skips storeyless meshes (site, roof-on-building) and empty storeys', () => {
+    const meshes = [
+      meshY(1, 0.0, 2.6), // ground
+      meshY(9, -1.0, 0.0), // site terrain — NOT in elementToStorey
+    ];
+    const elementToStorey = new Map([[1, 100]]);
+    expect(storeyFloorsFromMeshes(meshes, elementToStorey)).toEqual([0.0]);
+  });
+
+  it('documents the storey-spanning limitation: an upper-storey element reaching down collapses levels', () => {
+    // A stair assigned to the ATTIC (200) but spanning down to the ground floor
+    // pulls storey 200's min-Y to 0, colliding with the ground floor.
+    const meshes = [
+      meshY(1, 0.0, 2.6), // ground wall → storey 100
+      meshY(3, 2.7, 5.0), // attic wall → storey 200
+      meshY(4, 0.0, 2.7), // attic stair spanning down → storey 200
+    ];
+    const elementToStorey = new Map([[1, 100], [3, 200], [4, 200]]);
+    // Known limitation: storey 200's level collapses to 0, so the two storeys
+    // are no longer distinguished by floor level. Scoping then degrades toward
+    // full-extent for such cuts (never worse than the pre-fix baseline).
+    expect(storeyFloorsFromMeshes(meshes, elementToStorey)).toEqual([0.0, 0.0]);
+  });
+});
+
+describe('currentFloorBands', () => {
+  // AC20-FZK-Haus-like two-storey model: ground @0, attic @2.7, a little site
+  // below the ground (axisMin = -0.3) and a pitched roof up to axisMax = 5.
+  const FLOORS = [0, 2.7];
+  const AXIS_MIN = -0.3;
+  const AXIS_MAX = 5;
+
+  it('ground-floor cut: floor extends down to the model bottom, ceil to the attic floor', () => {
+    const { below, above } = currentFloorBands(FLOORS, 1.0, AXIS_MIN, AXIS_MAX);
+    // below = position - min(axisMin, floor0) = 1.0 - (-0.3) = 1.3 (site shows)
+    expect(below).toBeCloseTo(1.3, 6);
+    // above = nextFloor - position = 2.7 - 1.0 = 1.7 (capped at the attic floor)
+    expect(above).toBeCloseTo(1.7, 6);
+  });
+
+  it('ground-floor cut culls the roof two levels up', () => {
+    const { below, above } = currentFloorBands(FLOORS, 1.0, AXIS_MIN, AXIS_MAX);
+    // The roof BODY sits well above the attic floor (3.5..5); relative to the
+    // ground cut its depth (2.5..4.0) clears the overhead band (above = 1.7).
+    const dMin = signedAxisDepth(3.5, 1.0, false); // 2.5
+    const dMax = signedAxisDepth(AXIS_MAX, 1.0, false); // 4.0
+    expect(classifyDepthRange(dMin, dMax, { below, above })).toBe('cull');
+  });
+
+  it('attic cut: top storey ceil extends up to the model top so the roof projects', () => {
+    const { below, above } = currentFloorBands(FLOORS, 2.8, AXIS_MIN, AXIS_MAX);
+    expect(below).toBeCloseTo(0.1, 6); // 2.8 - 2.7
+    expect(above).toBeCloseTo(2.2, 6); // max(axisMax, 2.7) - 2.8 = 5 - 2.8
+    // The roof (above 2.8) now classifies as overhead (dashed), not culled.
+    const dMin = signedAxisDepth(2.9, 2.8, false);
+    const dMax = signedAxisDepth(AXIS_MAX, 2.8, false);
+    expect(classifyDepthRange(dMin, dMax, { below, above })).toBe('overhead');
+  });
+
+  it('attic cut culls the ground floor below', () => {
+    const { below, above } = currentFloorBands(FLOORS, 2.8, AXIS_MIN, AXIS_MAX);
+    // A ground-floor wall spanning 0..2.6 is entirely below the attic floor.
+    const dMin = signedAxisDepth(0, 2.8, false); // -2.8
+    const dMax = signedAxisDepth(2.6, 2.8, false); // -0.2
+    expect(classifyDepthRange(dMin, dMax, { below, above })).toBe('cull');
+  });
+
+  it('scopes a middle storey to its neighbours (no axis-extent bleed)', () => {
+    const floors = [0, 3, 6];
+    const { below, above } = currentFloorBands(floors, 4.0, -1, 9);
+    expect(below).toBeCloseTo(1.0, 6); // 4 - 3 (this storey's own floor)
+    expect(above).toBeCloseTo(2.0, 6); // 6 - 4 (next storey's floor, not axisMax)
+  });
+
+  it('a cut below the lowest floor still belongs to the bottom storey', () => {
+    const { below, above } = currentFloorBands([0, 3], -0.5, -2, 9);
+    // k = 0; floor = min(axisMin, 0) = -2; ceil = 3.
+    expect(below).toBeCloseTo(1.5, 6); // -0.5 - (-2)
+    expect(above).toBeCloseTo(3.5, 6); // 3 - (-0.5)
+  });
+
+  it('floors every band at minDepth so a cut on a boundary never yields 0 width', () => {
+    // Cut exactly on the attic floor (2.7): k = 1 (top), floor = 2.7.
+    const { below } = currentFloorBands([0, 2.7], 2.7, 0, 2.7);
+    expect(below).toBe(1e-3); // position - floor = 0 → clamped
+  });
+
+  it('single storey degenerates to full extent around the one floor', () => {
+    const { below, above } = currentFloorBands([0], 1.0, -1, 5);
+    expect(below).toBeCloseTo(2.0, 6); // 1 - min(-1, 0) = 1 - (-1)
+    expect(above).toBeCloseTo(4.0, 6); // max(5, 0) - 1
+  });
+});

--- a/packages/drawing-2d/src/storey-bands.ts
+++ b/packages/drawing-2d/src/storey-bands.ts
@@ -1,0 +1,130 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Current-floor projection scoping for 2D floor plans (issue #979 follow-up).
+ *
+ * The construction projection (issue #979) originally projected the FULL model
+ * height on each side of the cut, so every storey's geometry bled onto every
+ * plan — a roof two floors up would draw (dashed) on the ground-floor plan.
+ * This module scopes the projection bands to the storey the cut sits in.
+ *
+ * # Coordinate frame (critical)
+ * The storey floor levels passed here MUST be derived from MESH geometry in the
+ * render frame (the same RTC-shifted, Y-up, metric frame as the section `cut`
+ * position) — never from the `IfcBuildingStorey.Elevation` attribute, which
+ * omits the building/site placement Z and is wrong for georeferenced models.
+ * This module is pure scalar arithmetic and is agnostic to how the levels were
+ * obtained; the viewer hook (`useDrawingGeneration`) does the derivation.
+ */
+
+import type { ProjectionBandDepths } from './projection-bands.js';
+
+/** Minimal mesh shape needed to derive storey floor levels (structural — avoids
+ *  a hard dependency on `@ifc-lite/geometry`'s `MeshData`). */
+export interface StoreyFloorMesh {
+  readonly expressId: number;
+  readonly positions: Float32Array; // interleaved [x, y, z, …] in the render frame
+}
+
+/**
+ * Per-storey floor levels (ascending) derived from mesh geometry, for
+ * current-floor projection scoping (issue #979 follow-up).
+ *
+ * Each storey's level is the MINIMUM world-Y over its member meshes, read from
+ * `positions` in the RTC-shifted render frame — the SAME frame as the section
+ * cut position. This deliberately avoids `IfcBuildingStorey.Elevation`, which
+ * omits the building/site placement Z and is wrong for georeferenced models.
+ *
+ * `elementToStorey` keys are LOCAL express ids, so callers must restrict this to
+ * single-model use (mesh `expressId` then equals the local id). Storeys whose
+ * members produced no mesh contribute no level and are dropped.
+ *
+ * # Known limitations (bounded; documented intentionally)
+ * - The min-Y is the underside of the storey's lowest member, typically the
+ *   floor SLAB which conventionally extrudes a little BELOW the level datum — so
+ *   the returned level sits ~one slab thickness below the architectural floor.
+ *   The effect is a small (~slab-thickness) over-projection at storey
+ *   boundaries, not a whole-floor bleed.
+ * - An element assigned to an upper storey but geometrically descending into a
+ *   lower one (a stair flight, a double-height shaft) pulls that storey's level
+ *   down, which can collapse two levels together; the scoping then degrades
+ *   toward the unscoped full-extent behavior for that cut — never worse than the
+ *   pre-#979-follow-up baseline. A placement-Z / percentile derivation is a
+ *   possible future hardening.
+ */
+export function storeyFloorsFromMeshes(
+  meshes: ReadonlyArray<StoreyFloorMesh>,
+  elementToStorey: ReadonlyMap<number, number>,
+): number[] {
+  const storeyMinY = new Map<number, number>();
+  for (const mesh of meshes) {
+    const storeyId = elementToStorey.get(mesh.expressId);
+    if (storeyId === undefined) continue;
+    const pos = mesh.positions;
+    let minY = Infinity;
+    for (let i = 1; i < pos.length; i += 3) {
+      if (pos[i] < minY) minY = pos[i];
+    }
+    if (!Number.isFinite(minY)) continue;
+    const cur = storeyMinY.get(storeyId);
+    if (cur === undefined || minY < cur) storeyMinY.set(storeyId, minY);
+  }
+  return [...storeyMinY.values()].sort((a, b) => a - b);
+}
+
+/**
+ * Compute the construction-projection band depths for the storey containing the
+ * cut, given the per-storey floor levels (ascending) and the model's axis
+ * extent — all along the cut axis, in the same render-frame metric space as
+ * `position`.
+ *
+ * The current storey `k` is the highest storey whose floor is at or below the
+ * cut. Its vertical slab is `[floor_k, ceil_k)`:
+ *  - the bottom storey extends DOWN to the model bottom (`axisMin`) so site /
+ *    foundation / terrain below the ground floor still projects (solid);
+ *  - the top storey extends UP to the model top (`axisMax`) so the roof / eaves
+ *    above the top storey still projects (dashed);
+ *  - an intermediate storey is clamped to the next storey's floor (its ceiling),
+ *    so the floor above is culled.
+ *
+ * The returned depths feed `ProjectionBandDepths` unchanged: `below` becomes the
+ * VISIBLE/solid band (toward the floor) and `above` the OVERHEAD/dashed band.
+ * Every depth is floored at `minDepth` so a cut sitting exactly on a storey
+ * boundary never yields a zero-width band that culls everything on the plane.
+ *
+ * @param storeyFloors  Per-storey floor levels along the cut axis, ASCENDING,
+ *                      length ≥ 1 (caller should fall back to full-extent bands
+ *                      when fewer than 2 storeys exist).
+ * @param position      Cut position along the axis (render-frame).
+ * @param axisMin       Model minimum along the axis (render-frame).
+ * @param axisMax       Model maximum along the axis (render-frame).
+ * @param minDepth      Lower clamp for each band depth (default 1 mm).
+ */
+export function currentFloorBands(
+  storeyFloors: number[],
+  position: number,
+  axisMin: number,
+  axisMax: number,
+  minDepth = 1e-3,
+): ProjectionBandDepths {
+  const n = storeyFloors.length;
+
+  // Current storey = highest floor at or below the cut (storeyFloors ascending).
+  // A cut below the lowest floor still belongs to the bottom storey (k = 0).
+  let k = 0;
+  for (let i = 0; i < n; i++) {
+    if (storeyFloors[i] <= position) k = i;
+    else break;
+  }
+
+  const floor = k === 0 ? Math.min(axisMin, storeyFloors[0]) : storeyFloors[k];
+  const ceil =
+    k === n - 1 ? Math.max(axisMax, storeyFloors[n - 1]) : storeyFloors[k + 1];
+
+  return {
+    below: Math.max(position - floor, minDepth),
+    above: Math.max(ceil - position, minDepth),
+  };
+}

--- a/rust/geometry/src/profile_extractor.rs
+++ b/rust/geometry/src/profile_extractor.rs
@@ -105,6 +105,17 @@ pub fn extract_profiles(content: &str, model_index: u32) -> Vec<ExtractedProfile
             Err(_) => continue,
         };
 
+        // Issue #979: feature elements (IfcOpeningElement and the rest of the
+        // void/feature family) are boolean subtraction/addition operands, not
+        // building structure — they must never emit a construction-projection
+        // profile. `is_subtype_of` walks the supertype chain, so this single
+        // check covers Opening / Voiding / Earthworks / Projection / Surface
+        // features without touching IfcDoor/IfcWindow (which descend from
+        // IfcBuiltElement, not IfcFeatureElement).
+        if entity.ifc_type.is_subtype_of(IfcType::IfcFeatureElement) {
+            continue;
+        }
+
         // ObjectPlacement (attr 5) → element world transform (IFC Z-up, native units)
         let element_transform = get_placement_transform(entity.get(5), &mut decoder);
 

--- a/rust/geometry/tests/issue_979_feature_element_profiles.rs
+++ b/rust/geometry/tests/issue_979_feature_element_profiles.rs
@@ -1,0 +1,70 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Issue #979 (construction projection) follow-up: feature elements must not
+//! emit construction-projection profiles.
+//!
+//! `IfcOpeningElement` (and the rest of the `IfcFeatureElement` family) are
+//! boolean subtraction/addition operands, not building structure. They have
+//! `IfcExtrudedAreaSolid` `Body` representations, so before the fix
+//! `extract_profiles` happily pulled their void cross-sections in and the 2D
+//! floor-plan projection drew spurious rectangles inside walls. AC20-FZK-Haus
+//! carries 17 `IFCOPENINGELEMENT` entities — a good regression fixture.
+
+use ifc_lite_geometry::extract_profiles;
+use std::path::PathBuf;
+
+fn fixture(rel: &str) -> Option<String> {
+    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join(rel);
+    std::fs::read_to_string(p).ok()
+}
+
+#[test]
+fn ac20_extracts_no_feature_element_profiles() {
+    let Some(content) = fixture("tests/models/ara3d/AC20-FZK-Haus.ifc") else {
+        eprintln!("AC20-FZK-Haus.ifc fixture missing — skipping");
+        return;
+    };
+
+    // Sanity-check the fixture still contains the openings the test guards
+    // against, so a future fixture swap can't silently make this test vacuous.
+    let opening_count = content.matches("IFCOPENINGELEMENT(").count();
+    assert!(
+        opening_count > 0,
+        "fixture should contain IfcOpeningElement entities (found {opening_count})"
+    );
+
+    let profiles = extract_profiles(&content, 0);
+
+    // No profile should belong to a feature/void element type.
+    let feature_profiles: Vec<&str> = profiles
+        .iter()
+        .map(|p| p.ifc_type.as_str())
+        .filter(|t| {
+            t.eq_ignore_ascii_case("IfcOpeningElement")
+                || t.eq_ignore_ascii_case("IfcOpeningStandardCase")
+                || t.eq_ignore_ascii_case("IfcVoidingFeature")
+                || t.eq_ignore_ascii_case("IfcFeatureElementSubtraction")
+                || t.eq_ignore_ascii_case("IfcProjectionElement")
+                || t.eq_ignore_ascii_case("IfcSurfaceFeature")
+        })
+        .collect();
+    assert!(
+        feature_profiles.is_empty(),
+        "feature/void elements must not produce projection profiles, got: {feature_profiles:?}"
+    );
+
+    // The fix must not have nuked real structure: walls still extrude profiles.
+    let wall_profiles = profiles
+        .iter()
+        .filter(|p| p.ifc_type.eq_ignore_ascii_case("IfcWall"))
+        .count();
+    assert!(
+        wall_profiles > 0,
+        "real building elements (walls) should still produce profiles"
+    );
+}

--- a/rust/geometry/tests/issue_979_feature_element_profiles.rs
+++ b/rust/geometry/tests/issue_979_feature_element_profiles.rs
@@ -58,13 +58,21 @@ fn ac20_extracts_no_feature_element_profiles() {
         "feature/void elements must not produce projection profiles, got: {feature_profiles:?}"
     );
 
-    // The fix must not have nuked real structure: walls still extrude profiles.
-    let wall_profiles = profiles
-        .iter()
-        .filter(|p| p.ifc_type.eq_ignore_ascii_case("IfcWall"))
-        .count();
+    // The fix must not have nuked real structure: AC20 is full of extruded
+    // walls/slabs/columns, so extraction must still yield structural profiles.
+    // Match by substring (case-insensitive) rather than an exact type string —
+    // FZK-Haus walls are `IfcWallStandardCase`, not `IfcWall`.
+    let types: Vec<&str> = profiles.iter().map(|p| p.ifc_type.as_str()).collect();
     assert!(
-        wall_profiles > 0,
-        "real building elements (walls) should still produce profiles"
+        !profiles.is_empty(),
+        "feature-element exclusion must not nuke real structure; AC20 should still yield profiles"
+    );
+    let structural = profiles.iter().filter(|p| {
+        let t = p.ifc_type.to_ascii_lowercase();
+        t.contains("wall") || t.contains("slab") || t.contains("column") || t.contains("beam")
+    }).count();
+    assert!(
+        structural > 0,
+        "common structural elements (wall/slab/column/beam) should still produce profiles; got: {types:?}"
     );
 }


### PR DESCRIPTION
Follow-up to #979 / PR #989, addressing the two issues raised in the thread:

> the components of the projection should be limited to the current floor, not all floors

> The IfcOpeningElement in the AC20 model should not participate in the projection, as it is not a component of the building structure

## 1. Current-floor scoping

The projection bands were the **full model height** on each side of the cut, so every storey's geometry bled onto every plan — on AC20 the pitched roof (above the attic at 2.7 m) drew dashed even on a ground-floor cut.

Now, on a plan cut of a multi-storey model, the bands clamp to the storey the cut sits in:
- **below** reaches down to the current storey's floor (or the model bottom for the lowest storey, so site / foundation still shows);
- **above** reaches up to the next storey's floor (or the model top for the top storey, so the roof still shows on the attic plan).

Floor levels come from **mesh-Y in the render frame** — the same frame as the cut position — **not** `IfcBuildingStorey.Elevation`, which omits the building/site placement Z and is wrong for georeferenced models.

Heavily guarded so nothing regresses — it only engages for a single model, ≥2 storeys, a plan (`down`) non-custom cut, no active manual isolation/storey selection, and when `spatialHierarchy` is present (absent on cache-reopened models). Otherwise the shipped full-extent bands are kept verbatim.

## 2. Opening exclusion

`IfcOpeningElement` and the rest of the `IfcFeatureElement` family (voids, earthworks cuts, projection/surface features) no longer project. They are boolean operands, not building structure.

- **Rust source of truth:** `extract_profiles` skips `is_subtype_of(IfcFeatureElement)` — one check covers the whole family without touching `IfcDoor`/`IfcWindow` (which descend from `IfcBuiltElement`).
- **TS (load-bearing):** `Drawing2DGenerator` filters feature elements from **both** the profile and the mesh-silhouette projection paths. A Rust-only fix wouldn't be enough — dropping openings from the profile path would let them fall out of `coveredKeys` and re-appear via the silhouette path (opening meshes reach `geometryResult.meshes`).

## Verification

- New Rust test `issue_979_feature_element_profiles` — AC20 yields **0** feature-element profiles (17 openings before), walls still extract.
- New drawing-2d tests (41 pass): `isFeatureElementType`, `currentFloorBands` (AC20 ground/attic scenarios + edge cases), `storeyFloorsFromMeshes`, and an integration test proving openings project via **neither** path.
- `@ifc-lite/viewer` `tsc --noEmit` clean; `@ifc-lite/drawing-2d` builds.

On AC20-FZK-Haus: a ground cut hides the roof, an attic cut still shows it dashed, and no opening rectangles draw.

## Known limitation (documented in `storey-bands.ts`)

Storey levels come from min member-Y, so they sit ~one floor-slab thickness low, and an upper-storey element that geometrically descends into a lower storey (a stair, a double-height shaft) can collapse two levels and mis-scope that one cut — degrading toward the unscoped full-extent behavior, **never worse than the pre-fix baseline**. A placement-Z / percentile derivation is a possible future hardening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Floor-scoped construction projection: 2D projections for multi-storey plans are now clamped to the current floor, preventing geometry from other levels affecting plan cuts.
  * Opening/feature-element exclusion: Openings and feature elements no longer contribute to 2D projection, removing spurious void silhouettes.

* **Tests**
  * Added tests confirming openings are excluded from both profile- and silhouette-based projection paths and that real structural profiles still project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## 3. Front/side section projection (review follow-up)

Construction projection was plan-only. Per review, vertical (front/side)
sections can't use storeys as a boundary, so they now project a **bounded view
depth behind the cut**:

- The toggle is enabled for front/side (still disabled for face-picked custom planes).
- A section projects `SECTION_VIEW_DEPTH_FRACTION` (default 0.5) of the model
  depth **behind** the cut — near geometry solid, occluded/far dashed via the
  hidden-line pass — and culls the cut-away front half + anything beyond. The
  "behind" side is flip-invariant (the classifier's flip and the view-direction
  flip cancel).
- Profiles are extracted for **plan cuts only** (a profile's base footprint
  collapses to a base edge on a vertical section); front/side use the
  mesh-silhouette/outline path, whose 2D projection already matches
  `projectTo2D` for every cardinal axis.
