### PR TITLE
fix(geometry): orient extrusion side-wall normals outward regardless of profile winding

### DIFF
--- a/.changeset/extrusion-sidewall-normals.md
+++ b/.changeset/extrusion-sidewall-normals.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Fix inside-out shading on extruded solids whose outer profile is authored counter-clockwise (e.g. the AC20-FZK-Haus roof slab). `create_side_walls` stored the inward in-plane normal regardless of the loop winding, so under the renderer's normal-based, double-sided lighting the side faces shaded as if lit from inside. The side-wall normal is now oriented outward via the profile's signed area, so it agrees with the (already-outward) triangle winding. CW outer loops and holes are byte-identical to before; caps were already winding-independent. The tapered (`IfcExtrudedAreaSolidTapered`) path is oriented the same way for consistency.

--- a/rust/geometry/src/extrusion.rs
+++ b/rust/geometry/src/extrusion.rs
@@ -357,6 +357,25 @@ fn create_side_walls(boundary: &[nalgebra::Point2<f64>], depth: f64, mesh: &mut 
         Vec::new()
     };
 
+    // Orient the flat side-wall normals outward regardless of the profile's
+    // authored winding. An edge's cross-section normal is one of its two
+    // in-plane perpendiculars; which one points *out* of the solid depends on
+    // the loop's winding, so key it off the signed area (CCW > 0). Without
+    // this, a CCW-authored outer profile (e.g. the AC20-FZK-Haus roof slab,
+    // issue #1006 follow-up) got inward-facing side-wall normals and shaded
+    // inside-out under the renderer's normal-based, double-sided lighting.
+    // Holes are passed with the opposite (CW) winding, which flips the sign so
+    // their walls keep facing into the void — byte-identical to the previous
+    // behaviour for negative-area loops.
+    let signed_area2: f64 = (0..n)
+        .map(|i| {
+            let a = &boundary[i];
+            let b = &boundary[(i + 1) % n];
+            a.x * b.y - b.x * a.y
+        })
+        .sum();
+    let winding_sign = if signed_area2 < 0.0 { -1.0 } else { 1.0 };
+
     let base_index = mesh.vertex_count() as u32;
     let mut quad_count = 0u32;
 
@@ -372,8 +391,11 @@ fn create_side_walls(boundary: &[nalgebra::Point2<f64>], depth: f64, mesh: &mut 
             continue;
         }
 
-        let flat_normal = Vector3::new(-edge.y, edge.x, 0.0)
+        // Right-hand perpendicular (edge.y, -edge.x) is outward for a CCW loop;
+        // `winding_sign` corrects it for CW loops (and holes).
+        let flat_normal = Vector3::new(edge.y, -edge.x, 0.0)
             .try_normalize(1e-10)
+            .map(|v| v * winding_sign)
             .unwrap_or(Vector3::new(0.0, 0.0, 1.0));
         let n0 = if use_smooth_radial_normals {
             vertex_normals[i]
@@ -557,6 +579,17 @@ fn create_lofted_side_walls(
     if n < 2 || top.len() != n {
         return;
     }
+    // Orient outward by the bottom loop's winding, matching `create_side_walls`
+    // so tapered faces shade the same direction as uniform extrusions in the
+    // untapered limit (and outward regardless of authored winding).
+    let signed_area2: f64 = (0..n)
+        .map(|i| {
+            let a = &bottom[i];
+            let b = &bottom[(i + 1) % n];
+            a.x * b.y - b.x * a.y
+        })
+        .sum();
+    let winding_sign = if signed_area2 < 0.0 { -1.0 } else { 1.0 };
     let base_index = mesh.vertex_count() as u32;
     let mut quad_count = 0u32;
     for i in 0..n {
@@ -569,14 +602,13 @@ fn create_lofted_side_walls(
         let v1 = Point3::new(p1.x, p1.y, 0.0);
         let v2 = Point3::new(q1.x, q1.y, depth);
         let v3 = Point3::new(q0.x, q0.y, depth);
-        // Outward normal from the actual 3D quad. `edge_b × edge_a` matches
-        // the convention in `create_side_walls` (tangent rotated +90° CCW
-        // around +Z) so tapered faces shade the same direction as uniform
-        // extrusions in the untapered limit.
+        // Outward normal from the actual 3D quad. `edge_a × edge_b` is outward
+        // for a CCW loop; `winding_sign` corrects CW loops. Holes then flip to
+        // face into the void.
         let edge_a = v1 - v0;
         let edge_b = v3 - v0;
-        let mut normal = match edge_b.cross(&edge_a).try_normalize(1e-10) {
-            Some(n) => n,
+        let mut normal = match edge_a.cross(&edge_b).try_normalize(1e-10) {
+            Some(n) => n * winding_sign,
             None => continue,
         };
         if is_hole {
@@ -744,6 +776,58 @@ mod tests {
         assert!((max.y - 202.5).abs() < 0.01); // 2.5 + 200
         assert!((min.z - 300.0).abs() < 0.01); // 0 + 300
         assert!((max.z - 320.0).abs() < 0.01); // 20 + 300
+    }
+
+    /// Assert every flat (non-cap) side-wall normal points away from the mesh's
+    /// XY centroid — i.e. outward, not into the solid.
+    fn assert_side_walls_outward(mesh: &Mesh) {
+        let vc = mesh.vertex_count();
+        let (mut cx, mut cy) = (0.0f32, 0.0f32);
+        for i in 0..vc {
+            cx += mesh.positions[i * 3];
+            cy += mesh.positions[i * 3 + 1];
+        }
+        cx /= vc as f32;
+        cy /= vc as f32;
+
+        let mut checked = 0;
+        for i in 0..vc {
+            let nz = mesh.normals[i * 3 + 2];
+            if nz.abs() >= 0.5 {
+                continue; // cap vertex (normal ~ ±Z), not a side wall
+            }
+            let nx = mesh.normals[i * 3];
+            let ny = mesh.normals[i * 3 + 1];
+            let rx = mesh.positions[i * 3] - cx;
+            let ry = mesh.positions[i * 3 + 1] - cy;
+            let dot = nx * rx + ny * ry;
+            assert!(
+                dot > 0.0,
+                "side-wall normal points inward at vertex {i}: n=({nx},{ny}) r=({rx},{ry}) dot={dot}"
+            );
+            checked += 1;
+        }
+        assert!(checked > 0, "expected side-wall vertices to check");
+    }
+
+    #[test]
+    fn test_side_wall_normals_outward_ccw_profile() {
+        // create_rectangle is CCW. Before #1006-follow-up these side-wall normals
+        // pointed inward (the AC20-FZK-Haus roof slab shaded inside-out).
+        let profile = create_rectangle(10.0, 6.0);
+        let mesh = extrude_profile(&profile, 4.0, None).unwrap();
+        assert_side_walls_outward(&mesh);
+    }
+
+    #[test]
+    fn test_side_wall_normals_outward_cw_profile() {
+        // The same rectangle wound clockwise. This was the previously-correct
+        // case; the fix must keep CW outer walls outward (no sign regression).
+        let mut pts = create_rectangle(10.0, 6.0).outer;
+        pts.reverse();
+        let profile = Profile2D::new(pts);
+        let mesh = extrude_profile(&profile, 4.0, None).unwrap();
+        assert_side_walls_outward(&mesh);
     }
 
     #[test]


### PR DESCRIPTION
## What
`create_side_walls` (extruded-solid side faces) stored the **inward** in-plane perpendicular `(-edge.y, edge.x)`, which is outward only for **CW**-authored profiles. A **CCW** outer profile got inward-facing side-wall normals and shaded **inside-out** under the renderer's normal-based, double-sided lighting — even though the triangle winding was already outward.

This is the genuine geometry bug surfaced while triaging **#1006**. (#1006 itself is a stale-branch artifact — PR #1005 forks from before #994/#998/#1000, so it draws ungated instanced type geometry; that's not a `main` regression. This PR fixes the *real* normal-orientation defect found along the way.)

## Fix
- Orient the side-wall normal by the loop's **signed area**, so it always points out of the solid.
- **CW outer loops and holes are byte-identical to before** (for negative-area loops the new sign equals the old value); **caps were already winding-independent** (hardcoded ±Z).
- The tapered (`IfcExtrudedAreaSolidTapered`) `create_lofted_side_walls` path is oriented the same way so the existing lofted-vs-uniform consistency test still holds.

## Verification
Native pipeline (`process_geometry`) on `AC20-FZK-Haus.ifc`, roof slabs `07Enbsqm9…` / `2IxUUNUV…`:

| | stored-normal outward |
|---|---|
| before | **4 / 12** (8 inward → inside-out) |
| after | **12 / 12** ✅ |

- New regression tests: side-wall normals point outward for **both** CW and CCW profiles.
- Existing `wall_opening_cut_regression` suite passes (with fixtures staged) — positions/indices unchanged, only normal directions.

## Scope note (#1007)
#1007 (inward cut faces on a **faceted-Brep** host with voids) is a **separate** path (`add_reveal_quad` / analytic AABB clip, which #1005's Manifold routing rewrites) and its `Roof-01_BCAD.ifc` fixture isn't in the repo, so it's **not** addressed here. Tracked separately.

Changeset: `@ifc-lite/wasm` patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect shading on extruded solids with counter-clockwise oriented profiles. Side-wall normals now consistently face outward for both flat and tapered extrusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->