### PR TITLE
test(fixtures): register Roof-01_BCAD.ifc for #1007 regression coverage

### DIFF
--- a/tests/models/manifest.json
+++ b/tests/models/manifest.json
@@ -759,6 +759,11 @@
       "size": 682646
     },
     {
+      "path": "issues/1007_roof_brep_opening_winding.ifc",
+      "sha256": "1740106fe498b12e36b09a4d752d4de538559fbbfadb5aa339e3150ffaf19592",
+      "size": 129717
+    },
+    {
       "path": "various/01_BIMcollab_Example_ARC.ifc",
       "sha256": "87392cf24264b023e65d8ca1dab1eb8996643c1aa51b9dff9d518ed8904151fc",
       "size": 18230149


### PR DESCRIPTION
Registers the faceted-Brep roof from #1007 (`roof_02_a`, `IfcRoof 3j5N7RPpvA1PwiM18Uv4fc`) in the fixture manifest as `issues/1007_roof_brep_opening_winding.ifc`.

- The asset is **already on the `fixtures-v1` release** (content-addressed by sha256 `1740106f…`); this only adds the manifest entry.
- Verified locally: `node scripts/fixtures/fetch-fixtures.mjs issues/1007_roof_brep_opening_winding.ifc` → `fetched=1 errors=0`, hash matches.

## Why
#1007 (inward-facing cut faces on a faceted-Brep roof with tilted openings) is fixed by **#1005's** geometry-driven boolean routing — its reporter verified it. This PR just makes the model available so a regression test can pin it once #1005 merges. No code change.

Reproduced for the record on current `main`: `roof_02_a` comes out with 60/123 inward normals via the analytic AABB-clip path; it should be all-outward after #1005 routes the tilted cutter through the real boolean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for geometry handling with new test fixture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->