### PR TITLE
fix(renderer): flat selection highlight, no object-colour bleed

### DIFF
--- a/.changeset/selection-highlight-flat-color.md
+++ b/.changeset/selection-highlight-flat-color.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/renderer": patch
+---
+
+Fix selected-object colour bleeding through the selection highlight. The highlight was a fresnel *glow* — `mix(litColor, highlightColor, fresnel * 0.5 + 0.2)` — so at a face viewed head-on the mix factor floored at 0.2, leaving ~80% of the lit object colour visible (e.g. the green IfcSite and red roof slab showed through the blue highlight, as a lighting-dependent gradient). The selection highlight is now a single flat colour, so a selected object reads as one uniform blue with no base-colour bleed and no gradient.

--- a/packages/renderer/src/shaders/main.wgsl.ts
+++ b/packages/renderer/src/shaders/main.wgsl.ts
@@ -209,13 +209,17 @@ export const mainShaderSource = `
           let isSelected = (uniforms.flags.x & 1u) == 1u;
           let isOverlay = (uniforms.flags.x & 2u) == 2u;
 
-          // Selection highlight - add glow/fresnel effect
+          // Selection highlight — a single FLAT selection colour.
+          //
+          // No lighting-dependent (luminance) or view-dependent (fresnel)
+          // term: the selected object must read as one uniform colour, not
+          // a shaded/gradient surface. The previous fresnel-glow mix left
+          // 80 % of the lit object colour visible at face centres (the
+          // green-site / red-roof bleed-through). A constant colour here
+          // also stays flat through the downstream tone-mapping, since
+          // those are per-pixel functions of a now-constant input.
           if (isSelected) {
-            let V = normalize(-input.worldPos);
-            let NdotV = max(dot(N, V), 0.0);
-            let fresnel = pow(1.0 - NdotV, 2.0);
-            let highlightColor = vec3<f32>(0.3, 0.6, 1.0);
-            color = mix(color, highlightColor, fresnel * 0.5 + 0.2);
+            color = vec3<f32>(0.3, 0.6, 1.0);
           }
 
           // Beautiful fresnel effect for transparent materials (glass)


### PR DESCRIPTION
## What
Selected objects in the WASM web viewer showed their own colour bleeding through the selection highlight — e.g. the green `IfcSite` and the red roof slab tinted the blue highlight as a lighting-dependent gradient.

| before | after |
|---|---|
| green/red base colour visible through the highlight, strongest at flat face centres | uniform flat blue, no bleed, no gradient |

## Root cause
The selection highlight in `packages/renderer/src/shaders/main.wgsl.ts` was a fresnel **glow**, not a colour override:

```wgsl
color = mix(color, highlightColor, fresnel * 0.5 + 0.2);
```

At a face viewed head-on `fresnel ≈ 0`, so the mix factor floored at **0.2** → ~80% of the lit object colour showed through, only 20% highlight (up to ~70% at grazing edges). That's the green-site / red-roof bleed.

The glow has been there since March (`03dd6e1e`); the derivative-based flat-shading change (#872, `680f9793`) altered how the fresnel reads per face and made it more obvious. Unrelated to #1013 (geometry side-wall normals).

## Fix
Replace the glow with a single flat selection colour:

```wgsl
if (isSelected) {
  color = vec3<f32>(0.3, 0.6, 1.0);
}
```

A selected object now reads as one uniform blue — no base-colour bleed, no gradient. A constant colour also stays flat through the downstream tone-mapping (those are per-pixel functions of a now-constant input).

## Notes
- `@ifc-lite/renderer` patch changeset included.
- Edge-outline pass (when edges are enabled) still draws crease lines on selected objects — that's outline, not a face gradient; left as-is.
- Verified locally in the viewer (FZK-Haus): selecting the site / roof shows flat blue with no bleed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed selection highlighting to render uniformly on selected objects without color interference from underlying materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->