### PR TITLE
feat(geometry): pure-Rust tier-1 through-opening carve (i_overlay re-extrude)

### DIFF
--- a/rust/geometry/src/extrusion.rs
+++ b/rust/geometry/src/extrusion.rs
@@ -203,6 +203,33 @@ pub fn extrude_profile_with_voids(
     Ok(mesh)
 }
 
+/// Pure-Rust tier-1 through-opening carve (CSG-kernel-free).
+///
+/// Subtracts each opening's cross-section contour from the host swept profile
+/// via the robust 2D boolean ([`crate::bool2d::subtract_multiple_2d`],
+/// i_overlay — **no polygon cap**, so round/arched openings are cut exactly),
+/// then re-extrudes. `extrude_profile` turns the resulting holes into the
+/// opening reveal walls automatically, with no internal cap (a true
+/// through-opening).
+///
+/// This is the kernel-free fast path for coplanar through-openings — the
+/// dominant window/door case — replacing the BSP/Manifold mesh subtract for
+/// that class. Because i_overlay is robust and deterministic, the result is
+/// platform-identical: no BSP 128-poly cap (→ no square AABB holes), no C++.
+///
+/// `openings` are closed contours in the host profile's 2D coordinate system;
+/// contours that don't overlap the profile are dropped by the boolean, so a
+/// non-overlapping or empty set degrades to a plain extrusion.
+pub fn extrude_profile_through_openings(
+    host: &Profile2D,
+    openings: &[Vec<Point2<f64>>],
+    depth: f64,
+    transform: Option<Matrix4<f64>>,
+) -> Result<Mesh> {
+    let carved = crate::bool2d::subtract_multiple_2d(host, openings)?;
+    extrude_profile(&carved, depth, transform)
+}
+
 /// Create geometry for a partial-depth void
 ///
 /// Generates:
@@ -929,5 +956,40 @@ mod tests {
         // Original perimeter is 28; resampled chord-perimeter is ≤ original
         // (chords cut corners). Allow up to 5% loss.
         assert!(total > 26.5 && total <= 28.0 + 1e-6, "resampled perimeter = {}", total);
+    }
+
+    #[test]
+    fn carve_round_through_opening_keeps_round_hole_no_cap() {
+        // Tier-1 pure-Rust carve: a round (24-gon) opening through a 4×3 m wall.
+        let wall = create_rectangle(4.0, 3.0); // centred at origin
+        let circle: Vec<Point2<f64>> = (0..24)
+            .map(|i| {
+                let a = i as f64 * core::f64::consts::TAU / 24.0;
+                Point2::new(0.5 * a.cos(), 0.5 * a.sin())
+            })
+            .collect();
+        let openings = vec![circle.clone()];
+
+        let mesh = extrude_profile_through_openings(&wall, &openings, 0.2, None).unwrap();
+        assert!(!mesh.is_empty(), "carve must yield geometry");
+
+        // The 2D boolean keeps the ROUND hole (i_overlay preserves the 24-gon) —
+        // it is NOT collapsed to a 4-vertex AABB square (the BSP-cap failure that
+        // makes the server export square holes).
+        let carved = crate::bool2d::subtract_multiple_2d(&wall, &openings).unwrap();
+        assert_eq!(carved.holes.len(), 1, "one through-opening hole");
+        assert!(
+            carved.holes[0].len() >= 8,
+            "round hole preserved, not square-reduced: {} verts",
+            carved.holes[0].len()
+        );
+
+        // True through-opening: spans the full extrusion depth, no internal cap.
+        let (mn, mx) = mesh.bounds();
+        assert!((mn.z - 0.0).abs() < 1e-5 && (mx.z - 0.2).abs() < 1e-4, "through-depth z=[{},{}]", mn.z, mx.z);
+
+        // Deterministic (i_overlay): identical bytes on repeat.
+        let mesh2 = extrude_profile_through_openings(&wall, &openings, 0.2, None).unwrap();
+        assert_eq!(mesh.positions, mesh2.positions, "carve must be deterministic");
     }
 }


### PR DESCRIPTION
First **kernel-replacement** primitive for the pure-Rust CSG direction (independent of #1017 — uses `bool2d` + `extrude_profile`, already on `main`).

## What
`extrude_profile_through_openings(host_profile, openings, depth, transform)`:
1. subtract each opening's cross-section from the host swept profile via the **robust 2D boolean** (`bool2d::subtract_multiple_2d` → i_overlay, **no polygon cap**);
2. re-extrude — `extrude_profile` turns the resulting holes into the opening **reveal walls** with **no internal cap** (a true through-opening).

## Why it matters
This is the **kernel-free fast path** for coplanar through-openings — the dominant window/door case. It carves **round/arched openings exactly** (no BSP 128-poly cap, so no square AABB holes — the server's #635 export bug at the root), is **pure Rust (no C++)**, and is **deterministic** (i_overlay is robust). It replaces the BSP/Manifold mesh subtract for this class once the void router routes qualifying openings to it.

## Test
A 24-gon opening through a 4×3 m wall: the carved profile keeps a **≥8-vertex round hole** (not a 4-vertex square), the mesh spans the full extrusion depth with **no cap**, and the carve is **byte-deterministic** on repeat.

## Scope
Additive — a new `pub fn` + test; **no existing path changed** (the void-router *routing* to this fast path, plus reveal/cap winding and the projection of opening geometry into the profile plane, is the follow-up). Part of the pure-Rust kernel consolidation; the determinism floor (#1016, merged) and exact classifier (#1017) are the prior slices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for creating 3D extrusions with true through-openings that completely penetrate objects without leaving internal caps, enabling precise geometric apertures.

* **Tests**
  * Validates that rounded apertures maintain geometric precision and consistently span full depth across repeated execution cycles, confirming deterministic behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->