### PR TITLE
feat(spaces): interactive Space Sketch (DCEL) editor + wall-derivation fixes

### DIFF
--- a/.changeset/space-sketch-dcel.md
+++ b/.changeset/space-sketch-dcel.md
@@ -2,9 +2,11 @@
 "@ifc-lite/create": minor
 "@ifc-lite/wasm": minor
 "@ifc-lite/viewer": minor
+"@ifc-lite/cli": minor
+"@ifc-lite/sdk": minor
 ---
 
-feat(spaces): interactive Space Sketch (DCEL) editor
+feat(spaces): interactive Space Sketch (DCEL) editor + headless generation
 
 A topology-aware space editor built on a persistent half-edge (DCEL) plate in
 the Rust geometry core, exposed via a stateful `SpacePlateHandle` wasm binding:
@@ -21,3 +23,8 @@ the Rust geometry core, exposed via a stateful `SpacePlateHandle` wasm binding:
 - Viewer "Space Sketch" tool: storey list with resolved names, auto-derive on
   selection, auto-escalating + manual snap tolerance to close centreline corner
   gaps.
+- **Headless generation** — derive IfcSpace across storeys from the CLI
+  (`ifc-lite generate-spaces`), the SDK (`bim.spaces.generate`), or as a library
+  function (`generateSpaces` from `@ifc-lite/create`), with auto-escalating snap,
+  storey-datum ("slab") floor-to-floor heights, and rectangular corner cleanup
+  ported into the TS detector.

--- a/.changeset/space-sketch-dcel.md
+++ b/.changeset/space-sketch-dcel.md
@@ -1,0 +1,23 @@
+---
+"@ifc-lite/create": minor
+"@ifc-lite/wasm": minor
+"@ifc-lite/viewer": minor
+---
+
+feat(spaces): interactive Space Sketch (DCEL) editor
+
+A topology-aware space editor built on a persistent half-edge (DCEL) plate in
+the Rust geometry core, exposed via a stateful `SpacePlateHandle` wasm binding:
+
+- **Derive** rooms from a storey's walls, **drag** a shared vertex (both rooms
+  follow), **split** a room between corners *or* new nodes added anywhere on a
+  wall, **merge** rooms across a shared wall, with undo/redo, and **bake** to
+  real `IfcSpace` (via the existing `addSpace` path).
+- **Wall-axis recognition fixes** in `@ifc-lite/create`: read the extractor's
+  reliable entity type instead of the columnar table's `'Unknown'` sentinel
+  (every `Curve2D` Axis polyline — e.g. all of AC20-FZK-Haus — was skipped), and
+  a body-footprint fallback (face sets, `IfcFacetedBrep`, vertically-extruded
+  rect / arbitrary / IndexedPolyCurve profiles) for walls without an Axis.
+- Viewer "Space Sketch" tool: storey list with resolved names, auto-derive on
+  selection, auto-escalating + manual snap tolerance to close centreline corner
+  gaps.

--- a/.changeset/space-sketch-dcel.md
+++ b/.changeset/space-sketch-dcel.md
@@ -28,3 +28,9 @@ the Rust geometry core, exposed via a stateful `SpacePlateHandle` wasm binding:
   function (`generateSpaces` from `@ifc-lite/create`), with auto-escalating snap,
   storey-datum ("slab") floor-to-floor heights, and rectangular corner cleanup
   ported into the TS detector.
+- **Production-grade baked spaces** — every derived `IfcSpace` now carries
+  `Qto_SpaceBaseQuantities` (GrossFloorArea / NetFloorArea / GrossPerimeter /
+  Height / GrossVolume, schema-aware) and an `IfcRelSpaceBoundary` per bounding
+  wall. Generated spaces are stamped with `ObjectType 'IfcLite:GeneratedSpace'`,
+  and a re-run skips a model that already contains them (idempotent; `--force`
+  to override).

--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -76,7 +76,7 @@ import { executeBasketIsolate } from '@/store/basket/basketCommands';
 import { useIfc } from '@/hooks/useIfc';
 import { cn } from '@/lib/utils';
 import { CSVExporter } from '@ifc-lite/export';
-import { FileSpreadsheet, FileJson, FileText, Filter, Upload, Pencil } from 'lucide-react';
+import { FileSpreadsheet, FileJson, FileText, Filter, Upload, Pencil, LayoutDashboard } from 'lucide-react';
 import { ExportDialog } from './ExportDialog';
 import { GLBExportDialog } from './GLBExportDialog';
 import { BulkPropertyEditor } from './BulkPropertyEditor';
@@ -95,7 +95,7 @@ import {
   subscribeAnalysisExtensions,
 } from '@/services/analysis-extensions';
 
-type Tool = 'select' | 'walk' | 'measure' | 'section' | 'annotate' | 'addElement' | 'split';
+type Tool = 'select' | 'walk' | 'measure' | 'section' | 'annotate' | 'addElement' | 'split' | 'spaceSketch';
 type WorkspacePanel = 'script' | 'list' | 'bcf' | 'ids' | 'lens' | 'addElement' | string;
 
 // #region FIX: Move ToolButton OUTSIDE MainToolbar to prevent recreation on every render
@@ -1271,6 +1271,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
         onToolChange={setActiveTool}
         activeAccentClass="bg-amber-500 text-white hover:bg-amber-500/90"
       />
+      <ToolButton tool="spaceSketch" icon={LayoutDashboard} label="Space Sketch (DCEL)" activeTool={activeTool} onToolChange={setActiveTool} />
 
       {/* Floorplan dropdown */}
       {availableStoreys.length > 0 && (

--- a/apps/viewer/src/components/viewer/ToolOverlays.tsx
+++ b/apps/viewer/src/components/viewer/ToolOverlays.tsx
@@ -14,9 +14,14 @@ import { GizmoOverlay } from './tools/GizmoOverlay';
 import { WallEndpointOverlay } from './tools/WallEndpointOverlay';
 import { SplitOverlay } from './tools/SplitOverlay';
 import { SplitNumericInput } from './tools/SplitNumericInput';
+import { SpaceSketchOverlay } from './tools/SpaceSketchOverlay';
 
 export function ToolOverlays() {
   const activeTool = useViewerStore((s) => s.activeTool);
+
+  if (activeTool === 'spaceSketch') {
+    return <SpaceSketchOverlay />;
+  }
 
   if (activeTool === 'measure') {
     return <MeasureOverlay />;

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -122,6 +122,7 @@ export function SpaceSketchOverlay() {
   const svgRef = useRef<SVGSVGElement | null>(null);
   const fitRef = useRef<Fit>({ scale: 1, minX: 0, minY: 0 });
   const rafRef = useRef<number | null>(null);
+  const rebuildTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const moveRef = useRef<{ x: number; y: number; shift: boolean } | null>(null);
 
   const dragRef = useRef<number | null>(null);
@@ -286,8 +287,17 @@ export function SpaceSketchOverlay() {
   const rebuildWithSnap = useCallback((tol: number | null) => {
     snapTolRef.current = tol;
     setSnapTol(tol);
-    const lb = lastBuildRef.current;
-    if (lb) void buildFrom(lb.coords, lb.sources, lb.label, lb.storey);
+    if (tol != null) setUsedTol(tol); // move the slider thumb/label immediately
+    // Debounce the actual rebuild: the range input fires onChange on every
+    // tick, and buildFrom is async + frees/creates wasm handles — rebuilding
+    // per tick raced the shared heap and froze the editor. Rebuild once the
+    // slider settles.
+    if (rebuildTimerRef.current) clearTimeout(rebuildTimerRef.current);
+    rebuildTimerRef.current = setTimeout(() => {
+      rebuildTimerRef.current = null;
+      const lb = lastBuildRef.current;
+      if (lb) void buildFrom(lb.coords, lb.sources, lb.label, lb.storey);
+    }, 180);
   }, [buildFrom]);
 
   const deriveFromStorey = useCallback(async () => {
@@ -370,6 +380,7 @@ export function SpaceSketchOverlay() {
 
   useEffect(() => () => {
     if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    if (rebuildTimerRef.current) clearTimeout(rebuildTimerRef.current);
     freeHistory();
     plateRef.current?.free();
     plateRef.current = null;

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -23,7 +23,7 @@ import { useViewerStore } from '@/store';
 import { useConstructionUnderlay } from '@/hooks/useConstructionUnderlay';
 import { useIfc } from '@/hooks/useIfc';
 import init, { SpacePlateHandle } from '@ifc-lite/wasm';
-import { extractWallSegmentsForStorey } from '@ifc-lite/create';
+import { extractWallSegmentsForStorey, insetRoomFootprint } from '@ifc-lite/create';
 
 let wasmReady: Promise<void> | null = null;
 function ensureWasm(): Promise<void> {
@@ -143,6 +143,12 @@ export function SpaceSketchOverlay() {
   const [usedTol, setUsedTol] = useState(0.1);
   const snapTolRef = useRef<number | null>(null);
   const lastBuildRef = useRef<{ coords: Float64Array; sources: Int32Array; label: string; storey: number | null } | null>(null);
+  // Wall segments + thicknesses from the last derive, kept for net-footprint
+  // inset at bake (so the IfcSpace solid stops at the inner wall face).
+  const extractionRef = useRef<{
+    segments: Parameters<typeof insetRoomFootprint>[1];
+    thicknesses: Parameters<typeof insetRoomFootprint>[2];
+  } | null>(null);
   const [hist, setHist] = useState(0);
   const [status, setStatus] = useState('Load the demo plate or derive from a storey.');
   const [showBuilding, setShowBuilding] = useState(true);
@@ -268,11 +274,12 @@ export function SpaceSketchOverlay() {
   const deriveFromStorey = useCallback(async () => {
     if (!ifcDataStore || storeyId == null) { setStatus('No model / storey to derive from.'); return; }
     try {
-      const { segments, considered, skipped } = extractWallSegmentsForStorey(ifcDataStore, storeyId);
+      const { segments, considered, skipped, wallThicknesses } = extractWallSegmentsForStorey(ifcDataStore, storeyId);
       if (!segments.length) {
         setStatus(`No wall axes on storey ${storeyId} (${considered} walls, ${skipped.length} skipped).`);
         return;
       }
+      extractionRef.current = { segments, thicknesses: wallThicknesses };
       const coords = new Float64Array(segments.length * 4);
       const sources = new Int32Array(segments.length).fill(-1);
       segments.forEach((s, i) => {
@@ -304,10 +311,22 @@ export function SpaceSketchOverlay() {
       return;
     }
     const snap = plate.snapshot() as Room[];
+    const extraction = extractionRef.current;
+    const polyArea = (pts: Pt[]) => {
+      let a = 0;
+      for (let k = 0; k < pts.length; k++) { const p = pts[k], q = pts[(k + 1) % pts.length]; a += p[0] * q[1] - q[0] * p[1]; }
+      return Math.abs(a) / 2;
+    };
     let ok = 0, err = 0;
     snap.forEach((r, i) => {
+      // Inset to the inner (net) wall face so the IfcSpace doesn't run to the
+      // wall centreline; keep the centreline area as GrossFloorArea.
+      const outline = extraction
+        ? insetRoomFootprint(r.outline, extraction.segments, extraction.thicknesses)
+        : r.outline;
       const res = addSpace(activeModelId, derivedStorey, {
-        Profile: 'polygon', OuterCurve: r.outline, Height: BAKE_HEIGHT, Name: `Space ${i + 1}`,
+        Profile: 'polygon', OuterCurve: outline, Height: BAKE_HEIGHT, Name: `Space ${i + 1}`,
+        grossFloorArea: polyArea(r.outline),
       });
       if (res && 'expressId' in res) ok++; else err++;
     });

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -360,7 +360,15 @@ export function SpaceSketchOverlay() {
 
   const svgPoint = (e: React.PointerEvent): Pt => {
     const rect = svgRef.current!.getBoundingClientRect();
-    return [e.clientX - rect.left, e.clientY - rect.top];
+    // Clamp to the canvas: during a drag the pointer is captured, so moving it
+    // past the panel (e.g. dragging a vertex down off the bottom) would report
+    // coordinates far outside the SVG → a huge off-screen world position. That
+    // pushed the room off-canvas ("disappears") and made the SVG rasterise a
+    // polygon spanning to extreme coordinates, freezing the browser.
+    return [
+      Math.max(0, Math.min(SVG_W, e.clientX - rect.left)),
+      Math.max(0, Math.min(SVG_H, e.clientY - rect.top)),
+    ];
   };
 
   const pickVertex = useCallback((wx: number, wy: number): number | null => {

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -409,10 +409,12 @@ export function SpaceSketchOverlay() {
     const height = floorToFloor(sid);
     const newIds: number[] = [];
     let skipped = 0;
-    for (const outline of outlines) {
+    for (let oi = 0; oi < outlines.length; oi++) {
+      const outline = outlines[oi];
       const [cx, cy] = centroid(outline);
       if (authored.some((fp) => pointInPoly(cx, cy, fp))) { skipped++; continue; }
-      const inset = segments && thicknesses ? offsetRoomFootprint(outline, segments, thicknesses, boundaryMode) : outline;
+      const others = outlines.filter((_, j) => j !== oi);
+      const inset = segments && thicknesses ? offsetRoomFootprint(outline, segments, thicknesses, boundaryMode, others) : outline;
       const res = addSpace(activeModelId, sid, {
         Profile: 'polygon', OuterCurve: inset, Height: height,
         Name: `Space ${newIds.length + 1}`, ObjectType: GENERATED_SPACE_OBJECTTYPE,
@@ -700,8 +702,8 @@ export function SpaceSketchOverlay() {
   // editable vertices stay on the centreline (the topology). `center` shows the
   // raw centreline.
   const ext = extractionRef.current;
-  const displayOutline = (outline: Pt[]): Pt[] =>
-    boundaryMode === 'center' || !ext ? outline : offsetRoomFootprint(outline, ext.segments, ext.thicknesses, boundaryMode);
+  const displayOutline = (outline: Pt[], others: Pt[][]): Pt[] =>
+    boundaryMode === 'center' || !ext ? outline : offsetRoomFootprint(outline, ext.segments, ext.thicknesses, boundaryMode, others);
 
   return (
     <div ref={panelRef} className="absolute left-1/2 top-4 -translate-x-1/2 z-30 rounded-xl border bg-background/95 shadow-xl backdrop-blur p-3 select-none pointer-events-auto"
@@ -773,7 +775,7 @@ export function SpaceSketchOverlay() {
 
         {rooms.map((r, ri) => {
           const color = ROOM_COLORS[ri % ROOM_COLORS.length];
-          const disp = displayOutline(r.outline);
+          const disp = displayOutline(r.outline, rooms.filter((_, j) => j !== ri).map((x) => x.outline));
           const pts = disp.map((p) => `${sX(f, p[0])},${sY(f, p[1])}`).join(' ');
           const [cwx, cwy] = centroid(disp);
           const cx = sX(f, cwx), cy = sY(f, cwy);

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -23,7 +23,13 @@ import { useViewerStore } from '@/store';
 import { useConstructionUnderlay } from '@/hooks/useConstructionUnderlay';
 import { useIfc } from '@/hooks/useIfc';
 import init, { SpacePlateHandle } from '@ifc-lite/wasm';
-import { extractWallSegmentsForStorey, insetRoomFootprint } from '@ifc-lite/create';
+import {
+  extractWallSegmentsForStorey,
+  insetRoomFootprint,
+  existingSpaceFootprintsByStorey,
+  GENERATED_SPACE_OBJECTTYPE,
+} from '@ifc-lite/create';
+import { X, Undo2, Redo2, Building2, Layers } from 'lucide-react';
 
 let wasmReady: Promise<void> | null = null;
 function ensureWasm(): Promise<void> {
@@ -60,9 +66,25 @@ const MAX_UNDO = 40;
 const BAKE_HEIGHT = 3;
 const EPS = 1e-6;
 
-const DEMO_SEGS = {
-  coords: Float64Array.from([0, 0, 8, 0, 8, 0, 8, 3, 8, 3, 0, 3, 0, 3, 0, 0, 4, 0, 4, 3]),
-  sources: Int32Array.from([1, 2, 3, 4, 99]),
+/** Absolute polygon area (shoelace), m². */
+function polyArea(pts: Pt[]): number {
+  let a = 0;
+  for (let k = 0; k < pts.length; k++) { const p = pts[k], q = pts[(k + 1) % pts.length]; a += p[0] * q[1] - q[0] * p[1]; }
+  return Math.abs(a) / 2;
+}
+/** Ray-cast point-in-polygon. */
+function pointInPoly(x: number, y: number, poly: Pt[]): boolean {
+  let inside = false;
+  for (let i = 0, j = poly.length - 1; i < poly.length; j = i++) {
+    const xi = poly[i][0], yi = poly[i][1], xj = poly[j][0], yj = poly[j][1];
+    if ((yi > y) !== (yj > y) && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi) inside = !inside;
+  }
+  return inside;
+}
+const centroid = (pts: Pt[]): Pt => {
+  let cx = 0, cy = 0;
+  for (const p of pts) { cx += p[0]; cy += p[1]; }
+  return [cx / pts.length, cy / pts.length];
 };
 
 interface Fit { scale: number; minX: number; minY: number }
@@ -114,15 +136,19 @@ const ROOM_COLORS = ['#6366f1', '#10b981', '#f59e0b', '#ec4899', '#06b6d4', '#84
 export function SpaceSketchOverlay() {
   const setActiveTool = useViewerStore((s) => s.setActiveTool);
   const addSpace = useViewerStore((s) => s.addSpace);
-  const generateAllSpaces = useViewerStore((s) => s.generateAllSpaces);
+  const removeEntity = useViewerStore((s) => s.removeEntity);
   const activeModelId = useViewerStore((s) => s.activeModelId);
   const { ifcDataStore } = useIfc();
 
   const plateRef = useRef<SpacePlateHandle | null>(null);
   const svgRef = useRef<SVGSVGElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
   const fitRef = useRef<Fit>({ scale: 1, minX: 0, minY: 0 });
   const rafRef = useRef<number | null>(null);
   const rebuildTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // IfcSpace expressIds this session created per storey — so a re-bake (or
+  // "Generate all") replaces the spaces it dropped instead of duplicating.
+  const generatedRef = useRef<Map<number, number[]>>(new Map());
   const moveRef = useRef<{ x: number; y: number; shift: boolean } | null>(null);
 
   const dragRef = useRef<number | null>(null);
@@ -196,6 +222,20 @@ export function SpaceSketchOverlay() {
   useEffect(() => {
     if (storeyId == null && storeys.length) setStoreyId(storeys[0].id);
   }, [storeys, storeyId]);
+
+  // Click anywhere outside the panel closes the tool. Esc closes too.
+  useEffect(() => {
+    const onDown = (e: PointerEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) setActiveTool('select');
+    };
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setActiveTool('select'); };
+    document.addEventListener('pointerdown', onDown, true);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('pointerdown', onDown, true);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [setActiveTool]);
 
   const refreshRooms = useCallback(() => {
     const plate = plateRef.current;
@@ -332,51 +372,90 @@ export function SpaceSketchOverlay() {
     }
   }, [storeyId, ifcDataStore, deriveFromStorey]);
 
-  const bake = useCallback(() => {
-    const plate = plateRef.current;
-    if (!plate) return;
-    if (!activeModelId || derivedStorey == null) {
-      setStatus('Bake needs rooms derived from a storey (the demo has no model to write into).');
-      return;
-    }
-    const snap = plate.snapshot() as Room[];
-    const extraction = extractionRef.current;
-    const polyArea = (pts: Pt[]) => {
-      let a = 0;
-      for (let k = 0; k < pts.length; k++) { const p = pts[k], q = pts[(k + 1) % pts.length]; a += p[0] * q[1] - q[0] * p[1]; }
-      return Math.abs(a) / 2;
-    };
-    // Floor-to-floor height so the space reaches the slab above (not a fixed 3 m).
-    const idx = storeys.findIndex((s) => s.id === derivedStorey);
+  const floorToFloor = useCallback((sid: number): number => {
+    const idx = storeys.findIndex((s) => s.id === sid);
     const next = idx >= 0 ? storeys[idx + 1] : undefined;
     const ff = next ? next.elev - storeys[idx].elev : BAKE_HEIGHT;
-    const height = ff > 0.1 && ff < 50 ? ff : BAKE_HEIGHT;
-    let ok = 0, err = 0;
-    snap.forEach((r, i) => {
-      // Inset to the inner (net) wall face so the IfcSpace doesn't run to the
-      // wall centreline; keep the centreline area as GrossFloorArea.
-      const outline = extraction
-        ? insetRoomFootprint(r.outline, extraction.segments, extraction.thicknesses)
-        : r.outline;
-      const res = addSpace(activeModelId, derivedStorey, {
-        Profile: 'polygon', OuterCurve: outline, Height: height, Name: `Space ${i + 1}`,
-        grossFloorArea: polyArea(r.outline),
-      });
-      if (res && 'expressId' in res) ok++; else err++;
-    });
-    setStatus(`Baked ${ok} IfcSpace${ok === 1 ? '' : 's'} (h=${height.toFixed(1)} m) → storey #${derivedStorey}${err ? ` (${err} failed)` : ''}.`);
-  }, [activeModelId, derivedStorey, addSpace, storeys]);
+    return ff > 0.1 && ff < 50 ? ff : BAKE_HEIGHT;
+  }, [storeys]);
 
-  const bakeWholeBuilding = useCallback(() => {
-    if (!activeModelId) { setStatus('No model loaded to write spaces into.'); return; }
-    const res = generateAllSpaces(activeModelId);
-    if ('error' in res) { setStatus(`Generate failed: ${res.error}`); return; }
-    const floors = res.storeys.filter((s) => s.result.emitted.length > 0).length;
-    setStatus(
-      `Generated ${res.totalEmitted} IfcSpace across ${floors} storey(s)` +
-      (res.skippedExisting ? `; skipped ${res.skippedExisting} overlapping existing spaces` : '') + '.',
-    );
-  }, [activeModelId, generateAllSpaces]);
+  /**
+   * Bake one storey's rooms to IfcSpace — the single path both "Bake" and
+   * "Generate all" use, so they're consistent. (1) Replace: remove the spaces
+   * this session previously dropped on the storey. (2) Skip rooms that overlap
+   * an existing authored space (dedup). (3) Emit each via `addSpace`, which
+   * mirrors a mesh into the 3D scene immediately. Net (inner-face) outline,
+   * floor-to-floor height. Returns counts.
+   */
+  const bakeStorey = useCallback((
+    sid: number,
+    outlines: Pt[][],
+    segments: Parameters<typeof insetRoomFootprint>[1] | undefined,
+    thicknesses: Parameters<typeof insetRoomFootprint>[2] | undefined,
+    authored: Pt[][],
+  ): { emitted: number; skipped: number } => {
+    if (!activeModelId) return { emitted: 0, skipped: 0 };
+    for (const id of generatedRef.current.get(sid) ?? []) removeEntity(activeModelId, id);
+    generatedRef.current.delete(sid);
+    const height = floorToFloor(sid);
+    const newIds: number[] = [];
+    let skipped = 0;
+    for (const outline of outlines) {
+      const [cx, cy] = centroid(outline);
+      if (authored.some((fp) => pointInPoly(cx, cy, fp))) { skipped++; continue; }
+      const inset = segments && thicknesses ? insetRoomFootprint(outline, segments, thicknesses) : outline;
+      const res = addSpace(activeModelId, sid, {
+        Profile: 'polygon', OuterCurve: inset, Height: height,
+        Name: `Space ${newIds.length + 1}`, ObjectType: GENERATED_SPACE_OBJECTTYPE,
+        grossFloorArea: polyArea(outline),
+      });
+      if (res && 'expressId' in res) newIds.push(res.expressId); else skipped++;
+    }
+    generatedRef.current.set(sid, newIds);
+    return { emitted: newIds.length, skipped };
+  }, [activeModelId, removeEntity, addSpace, floorToFloor]);
+
+  const bake = useCallback(() => {
+    const plate = plateRef.current;
+    if (!plate || !activeModelId || derivedStorey == null || !ifcDataStore) {
+      setStatus('Derive a storey first.');
+      return;
+    }
+    const outlines = (plate.snapshot() as Room[]).map((r) => r.outline);
+    const ext = extractionRef.current;
+    const authored = existingSpaceFootprintsByStorey(ifcDataStore).get(derivedStorey) ?? [];
+    const { emitted, skipped } = bakeStorey(derivedStorey, outlines, ext?.segments, ext?.thicknesses, authored);
+    setStatus(`Baked ${emitted} IfcSpace${skipped ? `, skipped ${skipped} (already a space)` : ''}.`);
+  }, [activeModelId, derivedStorey, ifcDataStore, bakeStorey]);
+
+  const bakeWholeBuilding = useCallback(async () => {
+    if (!activeModelId || !ifcDataStore) { setStatus('No model loaded.'); return; }
+    setStatus('Generating spaces for every storey…');
+    await ensureWasm();
+    const authoredMap = existingSpaceFootprintsByStorey(ifcDataStore);
+    let totalEmitted = 0, totalSkipped = 0, floors = 0;
+    for (const st of storeys) {
+      const { segments, wallThicknesses } = extractWallSegmentsForStorey(ifcDataStore, st.id);
+      if (!segments.length) continue;
+      const coords = new Float64Array(segments.length * 4);
+      const sources = new Int32Array(segments.length).fill(-1);
+      segments.forEach((s, i) => { coords[i * 4] = s.a[0]; coords[i * 4 + 1] = s.a[1]; coords[i * 4 + 2] = s.b[0]; coords[i * 4 + 3] = s.b[1]; });
+      let plate: SpacePlateHandle | null = null;
+      for (const tol of [0.1, 0.25, 0.5]) {
+        const p = new SpacePlateHandle(coords, sources, tol, 0.5);
+        plate?.free();
+        plate = p;
+        if (p.roomCount > 0) break;
+      }
+      const outlines = (plate!.snapshot() as Room[]).map((r) => r.outline);
+      plate!.free();
+      if (!outlines.length) continue;
+      const { emitted, skipped } = bakeStorey(st.id, outlines, segments, wallThicknesses, authoredMap.get(st.id) ?? []);
+      totalEmitted += emitted; totalSkipped += skipped;
+      if (emitted) floors++;
+    }
+    setStatus(`Generated ${totalEmitted} IfcSpace across ${floors} storey(s)${totalSkipped ? `; skipped ${totalSkipped} existing` : ''}.`);
+  }, [activeModelId, ifcDataStore, storeys, bakeStorey]);
 
   useEffect(() => () => {
     if (rafRef.current) cancelAnimationFrame(rafRef.current);
@@ -606,51 +685,52 @@ export function SpaceSketchOverlay() {
     for (let y = gy0; y <= gy1; y += gridStep) gridLines.push({ x1: PAD, y1: sY(f, y), x2: SVG_W - PAD, y2: sY(f, y) });
   }
 
-  const btn = 'px-2 py-1 rounded border hover:bg-muted disabled:opacity-40';
+  const iconBtn = 'inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-40';
   const previewEnd = splitHover ?? cursorWorld;
 
   return (
-    <div className="absolute left-1/2 top-4 -translate-x-1/2 z-30 rounded-lg border bg-background/95 shadow-xl backdrop-blur p-3 select-none pointer-events-auto"
+    <div ref={panelRef} className="absolute left-1/2 top-4 -translate-x-1/2 z-30 rounded-xl border bg-background/95 shadow-xl backdrop-blur p-3 select-none pointer-events-auto"
          style={{ width: SVG_W + 24 }}>
-      <div className="flex items-center justify-between mb-2">
-        <div className="text-sm font-semibold">Space Sketch <span className="text-muted-foreground font-normal">(DCEL)</span></div>
-        <button className="text-xs px-2 py-0.5 rounded border hover:bg-muted" onClick={() => setActiveTool('select')}>Close</button>
+      <div className="flex items-center justify-between mb-2.5">
+        <div className="flex items-center gap-2 text-sm font-semibold">
+          <Layers className="h-4 w-4 text-muted-foreground" /> Space Sketch
+        </div>
+        <button className={iconBtn} onClick={() => setActiveTool('select')} title="Close (Esc)"><X className="h-4 w-4" /></button>
       </div>
 
-      <div className="flex flex-wrap items-center gap-1.5 mb-2 text-xs">
-        <button className={btn} onClick={() => buildFrom(DEMO_SEGS.coords, DEMO_SEGS.sources, 'Demo', null)}>Demo plate</button>
-        <select className="px-1 py-1 rounded border bg-background max-w-[150px]" value={storeyId ?? ''} onChange={(e) => setStoreyId(Number(e.target.value))} disabled={!storeys.length}>
+      {/* Storey + whole-building */}
+      <div className="flex items-center gap-2 mb-2">
+        <select className="h-8 flex-1 min-w-0 rounded-md border bg-background px-2 text-xs" value={storeyId ?? ''}
+          onChange={(e) => setStoreyId(Number(e.target.value))} disabled={!storeys.length}>
           {storeys.length ? storeys.map((s) => <option key={s.id} value={s.id}>{s.name}</option>) : <option>no model</option>}
         </select>
-        <button className={btn} onClick={() => { lastDerivedRef.current = null; void deriveFromStorey(); }} disabled={!storeys.length} title="Re-derive this storey">Derive</button>
-        <span className="mx-1 w-px self-stretch bg-border" />
-        {(['drag', 'split', 'merge'] as Mode[]).map((m) => (
-          <button key={m}
-            className={`px-2 py-1 rounded border capitalize ${mode === m ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'}`}
-            onClick={() => { setMode(m); setSplitPick(null); setSplitHover(null); setHover(null); }}>{m}</button>
-        ))}
-        <span className="mx-1 w-px self-stretch bg-border" />
-        <button className={btn} onClick={undo} disabled={!canUndo} title="Undo">↶</button>
-        <button className={btn} onClick={redo} disabled={!canRedo} title="Redo">↷</button>
-        <button className={`${btn} ${showBuilding ? 'bg-primary/80 text-primary-foreground' : ''}`}
-          onClick={() => setShowBuilding((v) => !v)}
-          title="Show building elements (plan cut ~1.2 m above the floor) for orientation">Building</button>
-        <button className={`${btn} ${derivedStorey != null && rooms.length ? 'bg-emerald-600 text-white hover:bg-emerald-600/90' : ''}`}
-          onClick={bake} disabled={derivedStorey == null || !rooms.length}
-          title={derivedStorey == null ? 'Derive from a storey first' : 'Create IfcSpace for each room'}>Bake → IfcSpace</button>
-        <button className={`${btn} ${activeModelId ? 'bg-indigo-600 text-white hover:bg-indigo-600/90' : ''}`}
-          onClick={bakeWholeBuilding} disabled={!activeModelId}
-          title="Derive + bake IfcSpace for every storey at once (auto floor-to-floor height, skips storeys/rooms that already have spaces)">Whole building</button>
+        <button className="h-8 shrink-0 rounded-md bg-indigo-600 px-3 text-xs font-medium text-white hover:bg-indigo-700 disabled:opacity-40"
+          onClick={() => void bakeWholeBuilding()} disabled={!activeModelId}
+          title="Create IfcSpace for every storey at once — auto floor-to-floor height, skips rooms that already have a space">Generate all</button>
       </div>
 
-      <div className="flex items-center gap-2 mb-2 text-[11px] text-muted-foreground" title="Corner-closing tolerance. Larger closes bigger gaps but can over-merge.">
-        <span>snap</span>
-        <input type="range" min={0.05} max={1} step={0.05} value={usedTol} className="flex-1 accent-primary"
-          disabled={!rooms.length} onChange={(e) => rebuildWithSnap(Number(e.target.value))} />
-        <span className="tabular-nums w-20 text-right">{usedTol.toFixed(2)} m{snapTol == null ? ' · auto' : ''}</span>
-        {snapTol != null && (
-          <button className="px-1.5 py-0.5 rounded border hover:bg-muted" onClick={() => rebuildWithSnap(null)}>auto</button>
-        )}
+      {/* Edit tools (mode · history · underlay · snap) */}
+      <div className="flex items-center gap-1.5 mb-2">
+        <div className="inline-flex rounded-md border p-0.5">
+          {(['drag', 'split', 'merge'] as Mode[]).map((m) => (
+            <button key={m}
+              className={`rounded px-2 py-0.5 text-xs capitalize transition-colors ${mode === m ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'}`}
+              onClick={() => { setMode(m); setSplitPick(null); setSplitHover(null); setHover(null); }}
+              disabled={!rooms.length}>{m}</button>
+          ))}
+        </div>
+        <button className={iconBtn} onClick={undo} disabled={!canUndo} title="Undo"><Undo2 className="h-4 w-4" /></button>
+        <button className={iconBtn} onClick={redo} disabled={!canRedo} title="Redo"><Redo2 className="h-4 w-4" /></button>
+        <button className={`${iconBtn} ${showBuilding ? 'bg-primary/10 text-primary hover:bg-primary/15' : ''}`}
+          onClick={() => setShowBuilding((v) => !v)}
+          title="Show surrounding building elements (plan cut ~1.2 m above the floor)"><Building2 className="h-4 w-4" /></button>
+        <div className="ml-auto flex items-center gap-1.5 text-[11px] text-muted-foreground"
+          title="Corner-closing tolerance — larger closes bigger gaps but can over-merge">
+          <input type="range" min={0.05} max={1} step={0.05} value={usedTol} className="w-20 accent-primary"
+            disabled={!rooms.length} onChange={(e) => rebuildWithSnap(Number(e.target.value))} />
+          <button className="tabular-nums hover:text-foreground" onClick={() => rebuildWithSnap(null)}
+            title="Reset to automatic snap">{usedTol.toFixed(2)} m{snapTol == null ? ' · auto' : ''}</button>
+        </div>
       </div>
 
       <svg ref={svgRef} width={SVG_W} height={SVG_H} style={{ cursor }}
@@ -710,14 +790,20 @@ export function SpaceSketchOverlay() {
         })}
       </svg>
 
-      <div className="mt-2 flex items-center justify-between text-xs text-muted-foreground">
-        <span>{rooms.length} room(s) · {total.toFixed(1)} m² (gross / centreline)</span>
-        <span className="truncate max-w-[55%] text-right">{status}</span>
+      <div className="mt-2.5 flex items-center gap-2">
+        <button className="h-8 shrink-0 rounded-md bg-emerald-600 px-3 text-xs font-medium text-white hover:bg-emerald-700 disabled:opacity-40"
+          onClick={bake} disabled={derivedStorey == null || !rooms.length}
+          title="Write this storey's rooms as IfcSpace — replaces any this tool already dropped here">Bake storey</button>
+        <div className="min-w-0 flex-1 text-right text-xs text-muted-foreground leading-tight">
+          <div>{rooms.length} room(s) · {total.toFixed(1)} m²</div>
+          {status && <div className="truncate">{status}</div>}
+        </div>
       </div>
-      <div className="mt-1 text-[11px] text-muted-foreground">
-        {mode === 'drag' && 'Drag a vertex — shared vertices move both rooms; snaps to others, Shift = ortho.'}
-        {mode === 'split' && 'Click two points — corners or anywhere on a wall (new nodes added as needed).'}
-        {mode === 'merge' && 'Hover highlights the wall + both rooms; click to merge them.'}
+      <div className="mt-1.5 text-[11px] text-muted-foreground">
+        {!rooms.length && 'Pick a storey to derive its rooms, or “Generate all” for the whole building.'}
+        {!!rooms.length && mode === 'drag' && 'Drag a vertex — shared vertices move both rooms; snaps to others, Shift = ortho.'}
+        {!!rooms.length && mode === 'split' && 'Click two points — corners or anywhere on a wall (new nodes added as needed).'}
+        {!!rooms.length && mode === 'merge' && 'Hover highlights the wall + both rooms; click to merge them.'}
       </div>
     </div>
   );

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -414,7 +414,12 @@ export function SpaceSketchOverlay() {
       }
       if (snapped) { tx = snapped[0]; ty = snapped[1]; }
       setSnapPos(snapped);
-      try { plate.dragVertex(vid, tx, ty); refreshRooms(); } catch { /* teardown */ }
+      try {
+        plate.dragVertex(vid, tx, ty);
+        refreshRooms();
+      } catch (e) {
+        console.debug('[space-sketch] dragVertex failed (plate torn down mid-drag?)', e);
+      }
       return;
     }
 
@@ -470,7 +475,11 @@ export function SpaceSketchOverlay() {
         commitUndo(snap); refreshRooms(); setHover(null);
         setStatus(`Merged across wall — ${plate.roomCount} room(s) left.`);
       } catch (err) {
-        snap.free();
+        // Roll back to the pre-merge snapshot (mirror performSplit) in case
+        // mergeFaces mutated before throwing.
+        plate.free();
+        plateRef.current = snap;
+        refreshRooms();
         setStatus(`Merge rejected: ${String(err).replace(/^Error:\s*/, '')}`);
       }
       return;

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -20,6 +20,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useViewerStore } from '@/store';
+import { useConstructionUnderlay } from '@/hooks/useConstructionUnderlay';
 import { useIfc } from '@/hooks/useIfc';
 import init, { SpacePlateHandle } from '@ifc-lite/wasm';
 import { extractWallSegmentsForStorey } from '@ifc-lite/create';
@@ -144,6 +145,7 @@ export function SpaceSketchOverlay() {
   const lastBuildRef = useRef<{ coords: Float64Array; sources: Int32Array; label: string; storey: number | null } | null>(null);
   const [hist, setHist] = useState(0);
   const [status, setStatus] = useState('Load the demo plate or derive from a storey.');
+  const [showBuilding, setShowBuilding] = useState(true);
 
   // Every IfcBuildingStorey with its resolved name + elevation, low → high.
   const storeys = useMemo(() => {
@@ -157,6 +159,12 @@ export function SpaceSketchOverlay() {
     list.sort((a, b) => a.elev - b.elev);
     return list;
   }, [ifcDataStore]);
+
+  const derivedFloorElev = useMemo(
+    () => (derivedStorey == null ? null : storeys.find((s) => s.id === derivedStorey)?.elev ?? null),
+    [derivedStorey, storeys],
+  );
+  const { lines: underlay } = useConstructionUnderlay(showBuilding && rooms.length > 0, derivedFloorElev);
   const [storeyId, setStoreyId] = useState<number | null>(null);
   const lastDerivedRef = useRef<number | null>(null);
   useEffect(() => {
@@ -551,6 +559,9 @@ export function SpaceSketchOverlay() {
         <span className="mx-1 w-px self-stretch bg-border" />
         <button className={btn} onClick={undo} disabled={!canUndo} title="Undo">↶</button>
         <button className={btn} onClick={redo} disabled={!canRedo} title="Redo">↷</button>
+        <button className={`${btn} ${showBuilding ? 'bg-primary/80 text-primary-foreground' : ''}`}
+          onClick={() => setShowBuilding((v) => !v)}
+          title="Show building elements (plan cut ~1.2 m above the floor) for orientation">Building</button>
         <button className={`${btn} ${derivedStorey != null && rooms.length ? 'bg-emerald-600 text-white hover:bg-emerald-600/90' : ''}`}
           onClick={bake} disabled={derivedStorey == null || !rooms.length}
           title={derivedStorey == null ? 'Derive from a storey first' : 'Create IfcSpace for each room'}>Bake → IfcSpace</button>
@@ -571,6 +582,17 @@ export function SpaceSketchOverlay() {
         onPointerDown={onPointerDown} onPointerMove={onPointerMove} onPointerUp={endDrag}
         onPointerLeave={() => { setHover(null); setSplitHover(null); }}>
         {gridLines.map((l, i) => <line key={`g${i}`} {...l} stroke="currentColor" strokeOpacity={0.06} strokeWidth={1} />)}
+
+        {/* Building-element underlay (plan cut ~1.2 m above the storey) for orientation. */}
+        {showBuilding && underlay.map((l, i) => (
+          <line key={`b${i}`}
+            x1={sX(f, l.a[0])} y1={sY(f, l.a[1])} x2={sX(f, l.b[0])} y2={sY(f, l.b[1])}
+            stroke="currentColor"
+            strokeOpacity={l.hidden ? 0.16 : 0.34}
+            strokeWidth={l.hidden ? 0.8 : 1.1}
+            strokeDasharray={l.hidden ? '3 3' : undefined}
+            pointerEvents="none" />
+        ))}
 
         {rooms.map((r, ri) => {
           const color = ROOM_COLORS[ri % ROOM_COLORS.length];

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -171,6 +171,24 @@ export function SpaceSketchOverlay() {
     [derivedStorey, storeys],
   );
   const { lines: underlay } = useConstructionUnderlay(showBuilding && rooms.length > 0, derivedFloorElev);
+
+  // Pre-render the (potentially large) building underlay once per (re)derive,
+  // NOT on every drag frame — re-creating hundreds of SVG lines each frame
+  // froze the editor (and the runaway drag dragged the room off-canvas). It
+  // only changes when the plate is rebuilt, tracked by `hist`.
+  const underlayEls = useMemo(() => {
+    if (!showBuilding || underlay.length === 0) return null;
+    const f = fitRef.current;
+    return underlay.map((l, i) => (
+      <line key={`b${i}`}
+        x1={sX(f, l.a[0])} y1={sY(f, l.a[1])} x2={sX(f, l.b[0])} y2={sY(f, l.b[1])}
+        stroke="currentColor"
+        strokeOpacity={l.hidden ? 0.16 : 0.34}
+        strokeWidth={l.hidden ? 0.8 : 1.1}
+        strokeDasharray={l.hidden ? '3 3' : undefined}
+        pointerEvents="none" />
+    ));
+  }, [underlay, showBuilding, hist]);
   const [storeyId, setStoreyId] = useState<number | null>(null);
   const lastDerivedRef = useRef<number | null>(null);
   useEffect(() => {
@@ -603,15 +621,7 @@ export function SpaceSketchOverlay() {
         {gridLines.map((l, i) => <line key={`g${i}`} {...l} stroke="currentColor" strokeOpacity={0.06} strokeWidth={1} />)}
 
         {/* Building-element underlay (plan cut ~1.2 m above the storey) for orientation. */}
-        {showBuilding && underlay.map((l, i) => (
-          <line key={`b${i}`}
-            x1={sX(f, l.a[0])} y1={sY(f, l.a[1])} x2={sX(f, l.b[0])} y2={sY(f, l.b[1])}
-            stroke="currentColor"
-            strokeOpacity={l.hidden ? 0.16 : 0.34}
-            strokeWidth={l.hidden ? 0.8 : 1.1}
-            strokeDasharray={l.hidden ? '3 3' : undefined}
-            pointerEvents="none" />
-        ))}
+        {underlayEls}
 
         {rooms.map((r, ri) => {
           const color = ROOM_COLORS[ri % ROOM_COLORS.length];

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -114,6 +114,7 @@ const ROOM_COLORS = ['#6366f1', '#10b981', '#f59e0b', '#ec4899', '#06b6d4', '#84
 export function SpaceSketchOverlay() {
   const setActiveTool = useViewerStore((s) => s.setActiveTool);
   const addSpace = useViewerStore((s) => s.addSpace);
+  const generateAllSpaces = useViewerStore((s) => s.generateAllSpaces);
   const activeModelId = useViewerStore((s) => s.activeModelId);
   const { ifcDataStore } = useIfc();
 
@@ -335,6 +336,11 @@ export function SpaceSketchOverlay() {
       for (let k = 0; k < pts.length; k++) { const p = pts[k], q = pts[(k + 1) % pts.length]; a += p[0] * q[1] - q[0] * p[1]; }
       return Math.abs(a) / 2;
     };
+    // Floor-to-floor height so the space reaches the slab above (not a fixed 3 m).
+    const idx = storeys.findIndex((s) => s.id === derivedStorey);
+    const next = idx >= 0 ? storeys[idx + 1] : undefined;
+    const ff = next ? next.elev - storeys[idx].elev : BAKE_HEIGHT;
+    const height = ff > 0.1 && ff < 50 ? ff : BAKE_HEIGHT;
     let ok = 0, err = 0;
     snap.forEach((r, i) => {
       // Inset to the inner (net) wall face so the IfcSpace doesn't run to the
@@ -343,13 +349,24 @@ export function SpaceSketchOverlay() {
         ? insetRoomFootprint(r.outline, extraction.segments, extraction.thicknesses)
         : r.outline;
       const res = addSpace(activeModelId, derivedStorey, {
-        Profile: 'polygon', OuterCurve: outline, Height: BAKE_HEIGHT, Name: `Space ${i + 1}`,
+        Profile: 'polygon', OuterCurve: outline, Height: height, Name: `Space ${i + 1}`,
         grossFloorArea: polyArea(r.outline),
       });
       if (res && 'expressId' in res) ok++; else err++;
     });
-    setStatus(`Baked ${ok} IfcSpace${ok === 1 ? '' : 's'} → storey #${derivedStorey}${err ? ` (${err} failed)` : ''}.`);
-  }, [activeModelId, derivedStorey, addSpace]);
+    setStatus(`Baked ${ok} IfcSpace${ok === 1 ? '' : 's'} (h=${height.toFixed(1)} m) → storey #${derivedStorey}${err ? ` (${err} failed)` : ''}.`);
+  }, [activeModelId, derivedStorey, addSpace, storeys]);
+
+  const bakeWholeBuilding = useCallback(() => {
+    if (!activeModelId) { setStatus('No model loaded to write spaces into.'); return; }
+    const res = generateAllSpaces(activeModelId);
+    if ('error' in res) { setStatus(`Generate failed: ${res.error}`); return; }
+    const floors = res.storeys.filter((s) => s.result.emitted.length > 0).length;
+    setStatus(
+      `Generated ${res.totalEmitted} IfcSpace across ${floors} storey(s)` +
+      (res.skippedExisting ? `; skipped ${res.skippedExisting} overlapping existing spaces` : '') + '.',
+    );
+  }, [activeModelId, generateAllSpaces]);
 
   useEffect(() => () => {
     if (rafRef.current) cancelAnimationFrame(rafRef.current);
@@ -610,6 +627,9 @@ export function SpaceSketchOverlay() {
         <button className={`${btn} ${derivedStorey != null && rooms.length ? 'bg-emerald-600 text-white hover:bg-emerald-600/90' : ''}`}
           onClick={bake} disabled={derivedStorey == null || !rooms.length}
           title={derivedStorey == null ? 'Derive from a storey first' : 'Create IfcSpace for each room'}>Bake → IfcSpace</button>
+        <button className={`${btn} ${activeModelId ? 'bg-indigo-600 text-white hover:bg-indigo-600/90' : ''}`}
+          onClick={bakeWholeBuilding} disabled={!activeModelId}
+          title="Derive + bake IfcSpace for every storey at once (auto floor-to-floor height, skips storeys/rooms that already have spaces)">Whole building</button>
       </div>
 
       <div className="flex items-center gap-2 mb-2 text-[11px] text-muted-foreground" title="Corner-closing tolerance. Larger closes bigger gaps but can over-merge.">

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -1,0 +1,625 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Space Sketch (DCEL) — interactive test surface for the persistent
+ * `SpacePlateHandle` topology editor (rust/geometry `space_dcel`).
+ *
+ * Self-contained: owns its own wasm handle + local state (no shared slice).
+ * Seed from the active storey's walls (or a demo plate), drag a shared vertex
+ * (both rooms follow), split a room — between corners OR new nodes added
+ * anywhere on a wall — merge two rooms, then Bake to real `IfcSpace` through
+ * the viewer's existing `addSpace`.
+ *
+ * Fluency (RFC §4.2): hover telegraphs the op; dragging snaps to other
+ * vertices (Shift = ortho). Undo/redo snapshots the plate via `duplicate()`
+ * (each clone owns its heap, freed deterministically — never JS GC). 2D plan
+ * sketch; 3D-on-model registration is the next step.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useViewerStore } from '@/store';
+import { useIfc } from '@/hooks/useIfc';
+import init, { SpacePlateHandle } from '@ifc-lite/wasm';
+import { extractWallSegmentsForStorey } from '@ifc-lite/create';
+
+let wasmReady: Promise<void> | null = null;
+function ensureWasm(): Promise<void> {
+  if (!wasmReady) wasmReady = init().then(() => undefined);
+  return wasmReady;
+}
+
+interface Room {
+  face: number;
+  area: number;
+  simple: boolean;
+  outline: [number, number][];
+}
+interface Boundary {
+  edge: number;
+  source: number | null;
+}
+type Mode = 'drag' | 'split' | 'merge';
+type Pt = [number, number];
+type Hover =
+  | { kind: 'vertex'; pos: Pt }
+  | { kind: 'edge'; edge: number; rooms: number[]; a: Pt; b: Pt }
+  | null;
+/** A split endpoint the user picked — an existing corner, or a point on a wall
+ *  edge (which becomes a new node when the cut is committed). */
+type SplitTarget = { kind: 'vertex'; vid: number; pos: Pt } | { kind: 'edge'; edge: number; pos: Pt };
+
+const SVG_W = 580;
+const SVG_H = 460;
+const PAD = 36;
+const PICK_PX = 12;
+const SNAP_PX = 10;
+const MAX_UNDO = 40;
+const BAKE_HEIGHT = 3;
+const EPS = 1e-6;
+
+const DEMO_SEGS = {
+  coords: Float64Array.from([0, 0, 8, 0, 8, 0, 8, 3, 8, 3, 0, 3, 0, 3, 0, 0, 4, 0, 4, 3]),
+  sources: Int32Array.from([1, 2, 3, 4, 99]),
+};
+
+interface Fit { scale: number; minX: number; minY: number }
+
+function computeFit(rooms: Room[]): Fit {
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  for (const r of rooms) for (const [x, y] of r.outline) {
+    minX = Math.min(minX, x); minY = Math.min(minY, y);
+    maxX = Math.max(maxX, x); maxY = Math.max(maxY, y);
+  }
+  if (!isFinite(minX)) return { scale: 1, minX: 0, minY: 0 };
+  const scale = Math.min((SVG_W - 2 * PAD) / Math.max(maxX - minX, 1e-6), (SVG_H - 2 * PAD) / Math.max(maxY - minY, 1e-6));
+  return { scale, minX, minY };
+}
+
+const sX = (f: Fit, x: number) => PAD + (x - f.minX) * f.scale;
+const sY = (f: Fit, y: number) => SVG_H - PAD - (y - f.minY) * f.scale;
+const wX = (f: Fit, sx: number) => f.minX + (sx - PAD) / f.scale;
+const wY = (f: Fit, sy: number) => f.minY + (SVG_H - PAD - sy) / f.scale;
+
+function distToSeg(px: number, py: number, ax: number, ay: number, bx: number, by: number): number {
+  const dx = bx - ax, dy = by - ay;
+  const len2 = dx * dx + dy * dy || 1e-9;
+  let t = ((px - ax) * dx + (py - ay) * dy) / len2;
+  t = Math.max(0, Math.min(1, t));
+  return Math.hypot(px - (ax + t * dx), py - (ay + t * dy));
+}
+
+function projectOnSeg(p: Pt, a: Pt, b: Pt): Pt {
+  const dx = b[0] - a[0], dy = b[1] - a[1];
+  const len2 = dx * dx + dy * dy || 1e-9;
+  let t = ((p[0] - a[0]) * dx + (p[1] - a[1]) * dy) / len2;
+  t = Math.max(0, Math.min(1, t));
+  return [a[0] + t * dx, a[1] + t * dy];
+}
+
+function uniqueVerts(rooms: Room[]): Pt[] {
+  const seen = new Set<string>();
+  const out: Pt[] = [];
+  for (const r of rooms) for (const p of r.outline) {
+    const k = `${p[0].toFixed(4)},${p[1].toFixed(4)}`;
+    if (!seen.has(k)) { seen.add(k); out.push(p); }
+  }
+  return out;
+}
+
+const ROOM_COLORS = ['#6366f1', '#10b981', '#f59e0b', '#ec4899', '#06b6d4', '#84cc16', '#a855f7', '#ef4444'];
+
+export function SpaceSketchOverlay() {
+  const setActiveTool = useViewerStore((s) => s.setActiveTool);
+  const addSpace = useViewerStore((s) => s.addSpace);
+  const activeModelId = useViewerStore((s) => s.activeModelId);
+  const { ifcDataStore } = useIfc();
+
+  const plateRef = useRef<SpacePlateHandle | null>(null);
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const fitRef = useRef<Fit>({ scale: 1, minX: 0, minY: 0 });
+  const rafRef = useRef<number | null>(null);
+  const moveRef = useRef<{ x: number; y: number; shift: boolean } | null>(null);
+
+  const dragRef = useRef<number | null>(null);
+  const dragStartRef = useRef<Pt | null>(null);
+  const otherVertsRef = useRef<Pt[]>([]);
+  const pendingUndoRef = useRef<SpacePlateHandle | null>(null);
+  const draggedRef = useRef(false);
+
+  const undoRef = useRef<SpacePlateHandle[]>([]);
+  const redoRef = useRef<SpacePlateHandle[]>([]);
+
+  const [rooms, setRooms] = useState<Room[]>([]);
+  const [mode, setMode] = useState<Mode>('drag');
+  const [hover, setHover] = useState<Hover>(null);
+  const [splitPick, setSplitPick] = useState<SplitTarget | null>(null);
+  const [splitHover, setSplitHover] = useState<Pt | null>(null);
+  const [snapPos, setSnapPos] = useState<Pt | null>(null);
+  const [derivedStorey, setDerivedStorey] = useState<number | null>(null);
+  const [snapTol, setSnapTol] = useState<number | null>(null); // null = auto-escalate
+  const [usedTol, setUsedTol] = useState(0.1);
+  const snapTolRef = useRef<number | null>(null);
+  const lastBuildRef = useRef<{ coords: Float64Array; sources: Int32Array; label: string; storey: number | null } | null>(null);
+  const [hist, setHist] = useState(0);
+  const [status, setStatus] = useState('Load the demo plate or derive from a storey.');
+
+  // Every IfcBuildingStorey with its resolved name + elevation, low → high.
+  const storeys = useMemo(() => {
+    if (!ifcDataStore) return [] as { id: number; name: string; elev: number }[];
+    const elevs = ifcDataStore.spatialHierarchy?.storeyElevations;
+    const list = ifcDataStore.getEntitiesByType('IfcBuildingStorey').map((s) => ({
+      id: s.expressId,
+      name: ifcDataStore.entities.getName(s.expressId) || `Storey #${s.expressId}`,
+      elev: elevs?.get(s.expressId) ?? 0,
+    }));
+    list.sort((a, b) => a.elev - b.elev);
+    return list;
+  }, [ifcDataStore]);
+  const [storeyId, setStoreyId] = useState<number | null>(null);
+  const lastDerivedRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (storeyId == null && storeys.length) setStoreyId(storeys[0].id);
+  }, [storeys, storeyId]);
+
+  const refreshRooms = useCallback(() => {
+    const plate = plateRef.current;
+    if (plate) setRooms(plate.snapshot() as Room[]);
+  }, []);
+
+  const freeHistory = useCallback(() => {
+    undoRef.current.forEach((h) => h.free());
+    redoRef.current.forEach((h) => h.free());
+    undoRef.current = [];
+    redoRef.current = [];
+    pendingUndoRef.current?.free();
+    pendingUndoRef.current = null;
+  }, []);
+
+  const commitUndo = useCallback((snap: SpacePlateHandle) => {
+    undoRef.current.push(snap);
+    if (undoRef.current.length > MAX_UNDO) undoRef.current.shift()!.free();
+    redoRef.current.forEach((h) => h.free());
+    redoRef.current = [];
+    setHist((v) => v + 1);
+  }, []);
+
+  const resetInteraction = useCallback(() => {
+    setHover(null); setSplitPick(null); setSplitHover(null); setSnapPos(null);
+    dragRef.current = null; dragStartRef.current = null;
+    pendingUndoRef.current?.free(); pendingUndoRef.current = null;
+  }, []);
+
+  const undo = useCallback(() => {
+    const plate = plateRef.current;
+    if (!plate || !undoRef.current.length) return;
+    redoRef.current.push(plate);
+    plateRef.current = undoRef.current.pop()!;
+    resetInteraction(); refreshRooms(); setHist((v) => v + 1);
+    setStatus('Undo.');
+  }, [resetInteraction, refreshRooms]);
+
+  const redo = useCallback(() => {
+    const plate = plateRef.current;
+    if (!plate || !redoRef.current.length) return;
+    undoRef.current.push(plate);
+    plateRef.current = redoRef.current.pop()!;
+    resetInteraction(); refreshRooms(); setHist((v) => v + 1);
+    setStatus('Redo.');
+  }, [resetInteraction, refreshRooms]);
+
+  const buildFrom = useCallback(async (coords: Float64Array, sources: Int32Array, label: string, storey: number | null) => {
+    try {
+      await ensureWasm();
+      plateRef.current?.free();
+      freeHistory();
+      // Real wall centrelines don't meet exactly at corners — they're offset
+      // by ~half the wall thickness. A tight snap leaves the loop open (0
+      // rooms). Auto-escalate: take the first tolerance that encloses rooms,
+      // else the largest tried (least surprising than silently finding none).
+      lastBuildRef.current = { coords, sources, label, storey };
+      const manual = snapTolRef.current;
+      let plate: SpacePlateHandle | null = null;
+      let used = 0.1;
+      if (manual != null) {
+        plate = new SpacePlateHandle(coords, sources, manual, 0.5);
+        used = manual;
+      } else {
+        for (const tol of [0.1, 0.25, 0.5]) {
+          const p = new SpacePlateHandle(coords, sources, tol, 0.5);
+          plate?.free();
+          plate = p;
+          used = tol;
+          if (p.roomCount > 0) break;
+        }
+      }
+      plateRef.current = plate!;
+      setUsedTol(used);
+      const snap = plate!.snapshot() as Room[];
+      fitRef.current = computeFit(snap);
+      resetInteraction();
+      setDerivedStorey(storey);
+      setRooms(snap); setHist((v) => v + 1);
+      const total = snap.reduce((s, r) => s + r.area, 0);
+      setStatus(`${label}: ${snap.length} room(s), ${total.toFixed(1)} m² · snap ${used}m${manual == null ? ' (auto)' : ''}.`);
+    } catch (e) {
+      setStatus(`Build failed: ${String(e)}`);
+    }
+  }, [freeHistory, resetInteraction]);
+
+  // Manual snap override (null → back to auto-escalate). Rebuilds the current
+  // plate from its source segments at the chosen tolerance.
+  const rebuildWithSnap = useCallback((tol: number | null) => {
+    snapTolRef.current = tol;
+    setSnapTol(tol);
+    const lb = lastBuildRef.current;
+    if (lb) void buildFrom(lb.coords, lb.sources, lb.label, lb.storey);
+  }, [buildFrom]);
+
+  const deriveFromStorey = useCallback(async () => {
+    if (!ifcDataStore || storeyId == null) { setStatus('No model / storey to derive from.'); return; }
+    try {
+      const { segments, considered, skipped } = extractWallSegmentsForStorey(ifcDataStore, storeyId);
+      if (!segments.length) {
+        setStatus(`No wall axes on storey ${storeyId} (${considered} walls, ${skipped.length} skipped).`);
+        return;
+      }
+      const coords = new Float64Array(segments.length * 4);
+      const sources = new Int32Array(segments.length).fill(-1);
+      segments.forEach((s, i) => {
+        coords[i * 4] = s.a[0]; coords[i * 4 + 1] = s.a[1];
+        coords[i * 4 + 2] = s.b[0]; coords[i * 4 + 3] = s.b[1];
+      });
+      const name = ifcDataStore.entities.getName(storeyId) || `Storey #${storeyId}`;
+      await buildFrom(coords, sources, name, storeyId);
+    } catch (e) {
+      setStatus(`Derive failed: ${String(e)}`);
+    }
+  }, [ifcDataStore, storeyId, buildFrom]);
+
+  // Auto-detect: derive rooms the moment a storey is chosen (and on open, when
+  // the first storey auto-selects) so the user doesn't have to click Derive.
+  // Guarded so it fires once per storey, and never clobbers a loaded demo.
+  useEffect(() => {
+    if (storeyId != null && ifcDataStore && lastDerivedRef.current !== storeyId) {
+      lastDerivedRef.current = storeyId;
+      void deriveFromStorey();
+    }
+  }, [storeyId, ifcDataStore, deriveFromStorey]);
+
+  const bake = useCallback(() => {
+    const plate = plateRef.current;
+    if (!plate) return;
+    if (!activeModelId || derivedStorey == null) {
+      setStatus('Bake needs rooms derived from a storey (the demo has no model to write into).');
+      return;
+    }
+    const snap = plate.snapshot() as Room[];
+    let ok = 0, err = 0;
+    snap.forEach((r, i) => {
+      const res = addSpace(activeModelId, derivedStorey, {
+        Profile: 'polygon', OuterCurve: r.outline, Height: BAKE_HEIGHT, Name: `Space ${i + 1}`,
+      });
+      if (res && 'expressId' in res) ok++; else err++;
+    });
+    setStatus(`Baked ${ok} IfcSpace${ok === 1 ? '' : 's'} → storey #${derivedStorey}${err ? ` (${err} failed)` : ''}.`);
+  }, [activeModelId, derivedStorey, addSpace]);
+
+  useEffect(() => () => {
+    if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    freeHistory();
+    plateRef.current?.free();
+    plateRef.current = null;
+  }, [freeHistory]);
+
+  const svgPoint = (e: React.PointerEvent): Pt => {
+    const rect = svgRef.current!.getBoundingClientRect();
+    return [e.clientX - rect.left, e.clientY - rect.top];
+  };
+
+  const pickVertex = useCallback((wx: number, wy: number): number | null => {
+    const plate = plateRef.current;
+    if (!plate) return null;
+    const v = plate.findVertexNear(wx, wy, PICK_PX / fitRef.current.scale);
+    return v === undefined ? null : v;
+  }, []);
+
+  const nearestVertPos = useCallback((wx: number, wy: number): Pt | null => {
+    let best: Pt | null = null, bestD = PICK_PX / fitRef.current.scale;
+    for (const r of rooms) for (const p of r.outline) {
+      const d = Math.hypot(p[0] - wx, p[1] - wy);
+      if (d < bestD) { bestD = d; best = p; }
+    }
+    return best;
+  }, [rooms]);
+
+  const pickEdge = useCallback((wx: number, wy: number): { face: number; edge: number; a: Pt; b: Pt } | null => {
+    const plate = plateRef.current;
+    if (!plate) return null;
+    const tol = PICK_PX / fitRef.current.scale;
+    let best: { face: number; edge: number; a: Pt; b: Pt; d: number } | null = null;
+    for (const r of rooms) {
+      const bounds = plate.boundingElements(r.face) as Boundary[];
+      const n = r.outline.length;
+      for (let i = 0; i < n; i++) {
+        const a = r.outline[i], b = r.outline[(i + 1) % n];
+        const d = distToSeg(wx, wy, a[0], a[1], b[0], b[1]);
+        if (d <= tol && (!best || d < best.d) && bounds[i]) best = { face: r.face, edge: bounds[i].edge, a, b, d };
+      }
+    }
+    return best ? { face: best.face, edge: best.edge, a: best.a, b: best.b } : null;
+  }, [rooms]);
+
+  // Resolve a click to a split endpoint: snap to an existing corner, else a
+  // point projected onto the nearest wall edge (a new node on commit).
+  const resolveSplitTarget = useCallback((wx: number, wy: number): SplitTarget | null => {
+    const v = pickVertex(wx, wy);
+    if (v != null) { const pos = nearestVertPos(wx, wy); return pos ? { kind: 'vertex', vid: v, pos } : null; }
+    const e = pickEdge(wx, wy);
+    if (e) return { kind: 'edge', edge: e.edge, pos: projectOnSeg([wx, wy], e.a, e.b) };
+    return null;
+  }, [pickVertex, nearestVertPos, pickEdge]);
+
+  // Commit a split between two targets, inserting nodes for edge endpoints.
+  // The whole gesture is atomic: on any failure the inserted nodes roll back.
+  const performSplit = useCallback((first: SplitTarget, second: SplitTarget) => {
+    const plate = plateRef.current;
+    if (!plate) return;
+    if (first.kind === 'edge' && second.kind === 'edge' && first.edge === second.edge) {
+      setStatus('Pick points on two different edges (or corners).'); return;
+    }
+    const snapshot = plate.duplicate();
+    try {
+      const va = first.kind === 'vertex' ? first.vid : plate.splitEdge(first.edge, first.pos[0], first.pos[1]);
+      const vb = second.kind === 'vertex' ? second.vid : plate.splitEdge(second.edge, second.pos[0], second.pos[1]);
+      if (va === vb) throw new Error('DegenerateCut: same point');
+      const fresh = plate.snapshot() as Room[];
+      const onBoundary = (r: Room, p: Pt) => r.outline.some((q) => Math.abs(q[0] - p[0]) < EPS && Math.abs(q[1] - p[1]) < EPS);
+      const room = fresh.find((r) => onBoundary(r, first.pos) && onBoundary(r, second.pos));
+      if (!room) throw new Error('points are not on the same room');
+      plate.splitFace(room.face, va, vb, -1);
+    } catch (err) {
+      plate.free();
+      plateRef.current = snapshot; // roll back inserted nodes + partial cut
+      refreshRooms();
+      setStatus(`Split rejected: ${String(err).replace(/^Error:\s*/, '')}`);
+      return;
+    }
+    commitUndo(snapshot);
+    refreshRooms();
+    setStatus(`Split — ${plate.roomCount} room(s).`);
+  }, [commitUndo, refreshRooms]);
+
+  const processMove = useCallback(() => {
+    rafRef.current = null;
+    const m = moveRef.current;
+    const plate = plateRef.current;
+    if (!m || !plate) return;
+    const wx = wX(fitRef.current, m.x), wy = wY(fitRef.current, m.y);
+
+    const vid = dragRef.current;
+    if (vid != null) {
+      draggedRef.current = true;
+      let tx = wx, ty = wy;
+      if (m.shift && dragStartRef.current) {
+        const [ox, oy] = dragStartRef.current;
+        if (Math.abs(wx - ox) >= Math.abs(wy - oy)) ty = oy; else tx = ox;
+      }
+      const tol = SNAP_PX / fitRef.current.scale;
+      let snapped: Pt | null = null, bestD = tol;
+      for (const p of otherVertsRef.current) {
+        const d = Math.hypot(p[0] - tx, p[1] - ty);
+        if (d < bestD) { bestD = d; snapped = p; }
+      }
+      if (snapped) { tx = snapped[0]; ty = snapped[1]; }
+      setSnapPos(snapped);
+      try { plate.dragVertex(vid, tx, ty); refreshRooms(); } catch { /* teardown */ }
+      return;
+    }
+
+    if (mode === 'merge') {
+      const e = pickEdge(wx, wy);
+      if (e) {
+        const nbr = plate.neighborAcross(e.edge);
+        setHover({ kind: 'edge', edge: e.edge, rooms: [e.face, ...(nbr !== undefined ? [nbr] : [])], a: e.a, b: e.b });
+      } else setHover(null);
+    } else if (mode === 'split') {
+      const t = resolveSplitTarget(wx, wy);
+      setSplitHover(t ? t.pos : null);
+      setHover(t && t.kind === 'vertex' ? { kind: 'vertex', pos: t.pos } : null);
+    } else {
+      const v = pickVertex(wx, wy);
+      const pos = v != null ? nearestVertPos(wx, wy) : null;
+      setHover(v != null && pos ? { kind: 'vertex', pos } : null);
+    }
+  }, [mode, pickEdge, pickVertex, nearestVertPos, resolveSplitTarget, refreshRooms]);
+
+  const onPointerMove = useCallback((e: React.PointerEvent) => {
+    const [x, y] = svgPoint(e);
+    moveRef.current = { x, y, shift: e.shiftKey };
+    if (rafRef.current == null) rafRef.current = requestAnimationFrame(processMove);
+  }, [processMove]);
+
+  const onPointerDown = useCallback((e: React.PointerEvent) => {
+    const plate = plateRef.current;
+    if (!plate) return;
+    const [sx, sy] = svgPoint(e);
+    const wx = wX(fitRef.current, sx), wy = wY(fitRef.current, sy);
+
+    if (mode === 'drag') {
+      const v = pickVertex(wx, wy);
+      if (v == null) return;
+      const start = nearestVertPos(wx, wy);
+      dragRef.current = v;
+      dragStartRef.current = start;
+      draggedRef.current = false;
+      pendingUndoRef.current = plate.duplicate();
+      otherVertsRef.current = start
+        ? uniqueVerts(rooms).filter((p) => Math.hypot(p[0] - start[0], p[1] - start[1]) > 1e-6)
+        : uniqueVerts(rooms);
+      svgRef.current?.setPointerCapture(e.pointerId);
+      return;
+    }
+    if (mode === 'merge') {
+      const hit = pickEdge(wx, wy);
+      if (!hit) { setStatus('No edge under cursor.'); return; }
+      const snap = plate.duplicate();
+      try {
+        plate.mergeFaces(hit.edge);
+        commitUndo(snap); refreshRooms(); setHover(null);
+        setStatus(`Merged across wall — ${plate.roomCount} room(s) left.`);
+      } catch (err) {
+        snap.free();
+        setStatus(`Merge rejected: ${String(err).replace(/^Error:\s*/, '')}`);
+      }
+      return;
+    }
+    if (mode === 'split') {
+      const target = resolveSplitTarget(wx, wy);
+      if (!target) { setStatus('Click a corner or anywhere on a wall.'); return; }
+      if (!splitPick) { setSplitPick(target); setStatus('Pick the second point (corner or wall) on the same room.'); return; }
+      const first = splitPick;
+      setSplitPick(null);
+      performSplit(first, target);
+    }
+  }, [mode, pickVertex, nearestVertPos, pickEdge, rooms, splitPick, resolveSplitTarget, performSplit, commitUndo, refreshRooms]);
+
+  const endDrag = useCallback((e: React.PointerEvent) => {
+    if (dragRef.current == null) return;
+    dragRef.current = null; dragStartRef.current = null; setSnapPos(null);
+    svgRef.current?.releasePointerCapture(e.pointerId);
+    if (draggedRef.current && pendingUndoRef.current) commitUndo(pendingUndoRef.current);
+    else pendingUndoRef.current?.free();
+    pendingUndoRef.current = null;
+    const total = rooms.reduce((s, r) => s + r.area, 0);
+    if (draggedRef.current) setStatus(`Drag done — ${rooms.length} room(s), ${total.toFixed(1)} m² (conserved).`);
+  }, [rooms, commitUndo]);
+
+  const f = fitRef.current;
+  const total = rooms.reduce((s, r) => s + r.area, 0);
+  const mergeRooms = hover?.kind === 'edge' ? new Set(hover.rooms) : null;
+  const cursorWorld = moveRef.current ? [wX(f, moveRef.current.x), wY(f, moveRef.current.y)] as Pt : null;
+  const cursor = dragRef.current != null ? 'grabbing' : (mode === 'drag' && hover?.kind === 'vertex') ? 'grab' : 'crosshair';
+  const canUndo = undoRef.current.length > 0;
+  const canRedo = redoRef.current.length > 0;
+  void hist;
+
+  const gridStep = f.scale > 14 ? 1 : f.scale > 5 ? 2 : 5;
+  const gridLines: { x1: number; y1: number; x2: number; y2: number }[] = [];
+  if (rooms.length) {
+    const gx0 = Math.floor(wX(f, PAD) / gridStep) * gridStep;
+    const gx1 = Math.ceil(wX(f, SVG_W - PAD) / gridStep) * gridStep;
+    const gy0 = Math.floor(wY(f, SVG_H - PAD) / gridStep) * gridStep;
+    const gy1 = Math.ceil(wY(f, PAD) / gridStep) * gridStep;
+    for (let x = gx0; x <= gx1; x += gridStep) gridLines.push({ x1: sX(f, x), y1: PAD, x2: sX(f, x), y2: SVG_H - PAD });
+    for (let y = gy0; y <= gy1; y += gridStep) gridLines.push({ x1: PAD, y1: sY(f, y), x2: SVG_W - PAD, y2: sY(f, y) });
+  }
+
+  const btn = 'px-2 py-1 rounded border hover:bg-muted disabled:opacity-40';
+  const previewEnd = splitHover ?? cursorWorld;
+
+  return (
+    <div className="absolute left-1/2 top-4 -translate-x-1/2 z-30 rounded-lg border bg-background/95 shadow-xl backdrop-blur p-3 select-none pointer-events-auto"
+         style={{ width: SVG_W + 24 }}>
+      <div className="flex items-center justify-between mb-2">
+        <div className="text-sm font-semibold">Space Sketch <span className="text-muted-foreground font-normal">(DCEL)</span></div>
+        <button className="text-xs px-2 py-0.5 rounded border hover:bg-muted" onClick={() => setActiveTool('select')}>Close</button>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-1.5 mb-2 text-xs">
+        <button className={btn} onClick={() => buildFrom(DEMO_SEGS.coords, DEMO_SEGS.sources, 'Demo', null)}>Demo plate</button>
+        <select className="px-1 py-1 rounded border bg-background max-w-[150px]" value={storeyId ?? ''} onChange={(e) => setStoreyId(Number(e.target.value))} disabled={!storeys.length}>
+          {storeys.length ? storeys.map((s) => <option key={s.id} value={s.id}>{s.name}</option>) : <option>no model</option>}
+        </select>
+        <button className={btn} onClick={() => { lastDerivedRef.current = null; void deriveFromStorey(); }} disabled={!storeys.length} title="Re-derive this storey">Derive</button>
+        <span className="mx-1 w-px self-stretch bg-border" />
+        {(['drag', 'split', 'merge'] as Mode[]).map((m) => (
+          <button key={m}
+            className={`px-2 py-1 rounded border capitalize ${mode === m ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'}`}
+            onClick={() => { setMode(m); setSplitPick(null); setSplitHover(null); setHover(null); }}>{m}</button>
+        ))}
+        <span className="mx-1 w-px self-stretch bg-border" />
+        <button className={btn} onClick={undo} disabled={!canUndo} title="Undo">↶</button>
+        <button className={btn} onClick={redo} disabled={!canRedo} title="Redo">↷</button>
+        <button className={`${btn} ${derivedStorey != null && rooms.length ? 'bg-emerald-600 text-white hover:bg-emerald-600/90' : ''}`}
+          onClick={bake} disabled={derivedStorey == null || !rooms.length}
+          title={derivedStorey == null ? 'Derive from a storey first' : 'Create IfcSpace for each room'}>Bake → IfcSpace</button>
+      </div>
+
+      <div className="flex items-center gap-2 mb-2 text-[11px] text-muted-foreground" title="Corner-closing tolerance. Larger closes bigger gaps but can over-merge.">
+        <span>snap</span>
+        <input type="range" min={0.05} max={1} step={0.05} value={usedTol} className="flex-1 accent-primary"
+          disabled={!rooms.length} onChange={(e) => rebuildWithSnap(Number(e.target.value))} />
+        <span className="tabular-nums w-20 text-right">{usedTol.toFixed(2)} m{snapTol == null ? ' · auto' : ''}</span>
+        {snapTol != null && (
+          <button className="px-1.5 py-0.5 rounded border hover:bg-muted" onClick={() => rebuildWithSnap(null)}>auto</button>
+        )}
+      </div>
+
+      <svg ref={svgRef} width={SVG_W} height={SVG_H} style={{ cursor }}
+        className="rounded border bg-muted/20 touch-none"
+        onPointerDown={onPointerDown} onPointerMove={onPointerMove} onPointerUp={endDrag}
+        onPointerLeave={() => { setHover(null); setSplitHover(null); }}>
+        {gridLines.map((l, i) => <line key={`g${i}`} {...l} stroke="currentColor" strokeOpacity={0.06} strokeWidth={1} />)}
+
+        {rooms.map((r, ri) => {
+          const color = ROOM_COLORS[ri % ROOM_COLORS.length];
+          const pts = r.outline.map((p) => `${sX(f, p[0])},${sY(f, p[1])}`).join(' ');
+          const cx = r.outline.reduce((s, p) => s + sX(f, p[0]), 0) / r.outline.length;
+          const cy = r.outline.reduce((s, p) => s + sY(f, p[1]), 0) / r.outline.length;
+          const lit = mergeRooms?.has(r.face);
+          const bad = !r.simple;
+          return (
+            <g key={r.face}>
+              <polygon points={pts} fill={bad ? '#ef4444' : color} fillOpacity={lit ? 0.42 : bad ? 0.3 : 0.16}
+                stroke={bad ? '#ef4444' : color} strokeWidth={lit ? 3 : 2} />
+              <text x={cx} y={cy - 5} textAnchor="middle" fontSize={12} fontWeight={600} fill="currentColor" className="pointer-events-none">{r.area.toFixed(2)}</text>
+              <text x={cx} y={cy + 9} textAnchor="middle" fontSize={9} fill="currentColor" opacity={0.55} className="pointer-events-none">m²</text>
+            </g>
+          );
+        })}
+
+        {hover?.kind === 'edge' && (
+          <line x1={sX(f, hover.a[0])} y1={sY(f, hover.a[1])} x2={sX(f, hover.b[0])} y2={sY(f, hover.b[1])} stroke="#ef4444" strokeWidth={4} strokeLinecap="round" />
+        )}
+        {splitPick && previewEnd && (
+          <line x1={sX(f, splitPick.pos[0])} y1={sY(f, splitPick.pos[1])} x2={sX(f, previewEnd[0])} y2={sY(f, previewEnd[1])}
+            stroke="#3b82f6" strokeWidth={1.5} strokeDasharray="5 4" />
+        )}
+        {/* split candidate node (corner or new node on a wall) */}
+        {mode === 'split' && splitHover && (
+          <circle cx={sX(f, splitHover[0])} cy={sY(f, splitHover[1])} r={5} fill="#3b82f6" fillOpacity={0.5} stroke="#3b82f6" strokeWidth={1.5} pointerEvents="none" />
+        )}
+        {/* first committed split pick */}
+        {splitPick && (
+          <circle cx={sX(f, splitPick.pos[0])} cy={sY(f, splitPick.pos[1])} r={5} fill="#3b82f6" stroke="#fff" strokeWidth={1.5} pointerEvents="none" />
+        )}
+        {snapPos && (
+          <g pointerEvents="none">
+            <circle cx={sX(f, snapPos[0])} cy={sY(f, snapPos[1])} r={9} fill="none" stroke="#22c55e" strokeWidth={1.5} />
+            <circle cx={sX(f, snapPos[0])} cy={sY(f, snapPos[1])} r={2.5} fill="#22c55e" />
+          </g>
+        )}
+
+        {uniqueVerts(rooms).map((p, i) => {
+          const isHover = hover?.kind === 'vertex' && Math.abs(hover.pos[0] - p[0]) < EPS && Math.abs(hover.pos[1] - p[1]) < EPS;
+          return (
+            <circle key={i} cx={sX(f, p[0])} cy={sY(f, p[1])} r={isHover ? 6 : 4}
+              fill={isHover ? '#fbbf24' : '#fff'} stroke="#334155" strokeWidth={1.5} pointerEvents="none" />
+          );
+        })}
+      </svg>
+
+      <div className="mt-2 flex items-center justify-between text-xs text-muted-foreground">
+        <span>{rooms.length} room(s) · {total.toFixed(1)} m² (gross / centreline)</span>
+        <span className="truncate max-w-[55%] text-right">{status}</span>
+      </div>
+      <div className="mt-1 text-[11px] text-muted-foreground">
+        {mode === 'drag' && 'Drag a vertex — shared vertices move both rooms; snaps to others, Shift = ortho.'}
+        {mode === 'split' && 'Click two points — corners or anywhere on a wall (new nodes added as needed).'}
+        {mode === 'merge' && 'Hover highlights the wall + both rooms; click to merge them.'}
+      </div>
+    </div>
+  );
+}

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -25,9 +25,10 @@ import { useIfc } from '@/hooks/useIfc';
 import init, { SpacePlateHandle } from '@ifc-lite/wasm';
 import {
   extractWallSegmentsForStorey,
-  insetRoomFootprint,
+  offsetRoomFootprint,
   existingSpaceFootprintsByStorey,
   GENERATED_SPACE_OBJECTTYPE,
+  type BoundaryMode,
 } from '@ifc-lite/create';
 import { X, Undo2, Redo2, Building2, Layers } from 'lucide-react';
 
@@ -146,6 +147,7 @@ export function SpaceSketchOverlay() {
   const fitRef = useRef<Fit>({ scale: 1, minX: 0, minY: 0 });
   const rafRef = useRef<number | null>(null);
   const rebuildTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const buildSeqRef = useRef(0);
   // IfcSpace expressIds this session created per storey — so a re-bake (or
   // "Generate all") replaces the spaces it dropped instead of duplicating.
   const generatedRef = useRef<Map<number, number[]>>(new Map());
@@ -174,12 +176,13 @@ export function SpaceSketchOverlay() {
   // Wall segments + thicknesses from the last derive, kept for net-footprint
   // inset at bake (so the IfcSpace solid stops at the inner wall face).
   const extractionRef = useRef<{
-    segments: Parameters<typeof insetRoomFootprint>[1];
-    thicknesses: Parameters<typeof insetRoomFootprint>[2];
+    segments: Parameters<typeof offsetRoomFootprint>[1];
+    thicknesses: Parameters<typeof offsetRoomFootprint>[2];
   } | null>(null);
   const [hist, setHist] = useState(0);
   const [status, setStatus] = useState('Load the demo plate or derive from a storey.');
   const [showBuilding, setShowBuilding] = useState(true);
+  const [boundaryMode, setBoundaryMode] = useState<BoundaryMode>('inner');
 
   // Every IfcBuildingStorey with its resolved name + elevation, low → high.
   const storeys = useMemo(() => {
@@ -284,8 +287,13 @@ export function SpaceSketchOverlay() {
   }, [resetInteraction, refreshRooms]);
 
   const buildFrom = useCallback(async (coords: Float64Array, sources: Int32Array, label: string, storey: number | null) => {
+    // Re-entrancy guard: a rapid rebuild (snap slider) must not let an older
+    // async build free/replace the plate a newer one is using — that races the
+    // shared wasm heap. Only the latest build applies; superseded ones bail.
+    const seq = ++buildSeqRef.current;
     try {
       await ensureWasm();
+      if (seq !== buildSeqRef.current) return;
       plateRef.current?.free();
       freeHistory();
       // Real wall centrelines don't meet exactly at corners — they're offset
@@ -308,6 +316,7 @@ export function SpaceSketchOverlay() {
           if (p.roomCount > 0) break;
         }
       }
+      if (seq !== buildSeqRef.current) { plate?.free(); return; }
       plateRef.current = plate!;
       setUsedTol(used);
       const snap = plate!.snapshot() as Room[];
@@ -390,8 +399,8 @@ export function SpaceSketchOverlay() {
   const bakeStorey = useCallback((
     sid: number,
     outlines: Pt[][],
-    segments: Parameters<typeof insetRoomFootprint>[1] | undefined,
-    thicknesses: Parameters<typeof insetRoomFootprint>[2] | undefined,
+    segments: Parameters<typeof offsetRoomFootprint>[1] | undefined,
+    thicknesses: Parameters<typeof offsetRoomFootprint>[2] | undefined,
     authored: Pt[][],
   ): { emitted: number; skipped: number } => {
     if (!activeModelId) return { emitted: 0, skipped: 0 };
@@ -403,7 +412,7 @@ export function SpaceSketchOverlay() {
     for (const outline of outlines) {
       const [cx, cy] = centroid(outline);
       if (authored.some((fp) => pointInPoly(cx, cy, fp))) { skipped++; continue; }
-      const inset = segments && thicknesses ? insetRoomFootprint(outline, segments, thicknesses) : outline;
+      const inset = segments && thicknesses ? offsetRoomFootprint(outline, segments, thicknesses, boundaryMode) : outline;
       const res = addSpace(activeModelId, sid, {
         Profile: 'polygon', OuterCurve: inset, Height: height,
         Name: `Space ${newIds.length + 1}`, ObjectType: GENERATED_SPACE_OBJECTTYPE,
@@ -413,7 +422,7 @@ export function SpaceSketchOverlay() {
     }
     generatedRef.current.set(sid, newIds);
     return { emitted: newIds.length, skipped };
-  }, [activeModelId, removeEntity, addSpace, floorToFloor]);
+  }, [activeModelId, removeEntity, addSpace, floorToFloor, boundaryMode]);
 
   const bake = useCallback(() => {
     const plate = plateRef.current;
@@ -687,6 +696,12 @@ export function SpaceSketchOverlay() {
 
   const iconBtn = 'inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-40';
   const previewEnd = splitHover ?? cursorWorld;
+  // The 2D preview (and bake) show the room at the chosen wall boundary; the
+  // editable vertices stay on the centreline (the topology). `center` shows the
+  // raw centreline.
+  const ext = extractionRef.current;
+  const displayOutline = (outline: Pt[]): Pt[] =>
+    boundaryMode === 'center' || !ext ? outline : offsetRoomFootprint(outline, ext.segments, ext.thicknesses, boundaryMode);
 
   return (
     <div ref={panelRef} className="absolute left-1/2 top-4 -translate-x-1/2 z-30 rounded-xl border bg-background/95 shadow-xl backdrop-blur p-3 select-none pointer-events-auto"
@@ -709,7 +724,7 @@ export function SpaceSketchOverlay() {
           title="Create IfcSpace for every storey at once — auto floor-to-floor height, skips rooms that already have a space">Generate all</button>
       </div>
 
-      {/* Edit tools (mode · history · underlay · snap) */}
+      {/* Edit: mode + history */}
       <div className="flex items-center gap-1.5 mb-2">
         <div className="inline-flex rounded-md border p-0.5">
           {(['drag', 'split', 'merge'] as Mode[]).map((m) => (
@@ -721,16 +736,30 @@ export function SpaceSketchOverlay() {
         </div>
         <button className={iconBtn} onClick={undo} disabled={!canUndo} title="Undo"><Undo2 className="h-4 w-4" /></button>
         <button className={iconBtn} onClick={redo} disabled={!canRedo} title="Redo"><Redo2 className="h-4 w-4" /></button>
-        <button className={`${iconBtn} ${showBuilding ? 'bg-primary/10 text-primary hover:bg-primary/15' : ''}`}
-          onClick={() => setShowBuilding((v) => !v)}
-          title="Show surrounding building elements (plan cut ~1.2 m above the floor)"><Building2 className="h-4 w-4" /></button>
         <div className="ml-auto flex items-center gap-1.5 text-[11px] text-muted-foreground"
           title="Corner-closing tolerance — larger closes bigger gaps but can over-merge">
+          <span>snap</span>
           <input type="range" min={0.05} max={1} step={0.05} value={usedTol} className="w-20 accent-primary"
-            disabled={!rooms.length} onChange={(e) => rebuildWithSnap(Number(e.target.value))} />
+            disabled={derivedStorey == null} onChange={(e) => rebuildWithSnap(Number(e.target.value))} />
           <button className="tabular-nums hover:text-foreground" onClick={() => rebuildWithSnap(null)}
-            title="Reset to automatic snap">{usedTol.toFixed(2)} m{snapTol == null ? ' · auto' : ''}</button>
+            title="Reset to automatic snap">{usedTol.toFixed(2)}m{snapTol == null ? '·a' : ''}</button>
         </div>
+      </div>
+
+      {/* View: boundary relative to walls + building underlay */}
+      <div className="flex items-center gap-2 mb-2 text-[11px] text-muted-foreground">
+        <span title="Where the space boundary sits relative to its walls — drives the 2D preview and the bake">Boundary</span>
+        <div className="inline-flex rounded-md border p-0.5">
+          {(['center', 'inner', 'outer'] as BoundaryMode[]).map((m) => (
+            <button key={m}
+              className={`rounded px-2 py-0.5 capitalize transition-colors ${boundaryMode === m ? 'bg-primary text-primary-foreground' : 'hover:text-foreground'}`}
+              onClick={() => setBoundaryMode(m)}
+              title={m === 'center' ? 'Wall centreline' : m === 'inner' ? 'Inner (net) face' : 'Outer (gross) face'}>{m}</button>
+          ))}
+        </div>
+        <button className={`${iconBtn} ml-auto ${showBuilding ? 'bg-primary/10 text-primary hover:bg-primary/15' : ''}`}
+          onClick={() => setShowBuilding((v) => !v)}
+          title="Show surrounding building elements (plan cut ~1.2 m above the floor)"><Building2 className="h-4 w-4" /></button>
       </div>
 
       <svg ref={svgRef} width={SVG_W} height={SVG_H} style={{ cursor }}
@@ -744,16 +773,22 @@ export function SpaceSketchOverlay() {
 
         {rooms.map((r, ri) => {
           const color = ROOM_COLORS[ri % ROOM_COLORS.length];
-          const pts = r.outline.map((p) => `${sX(f, p[0])},${sY(f, p[1])}`).join(' ');
-          const cx = r.outline.reduce((s, p) => s + sX(f, p[0]), 0) / r.outline.length;
-          const cy = r.outline.reduce((s, p) => s + sY(f, p[1]), 0) / r.outline.length;
+          const disp = displayOutline(r.outline);
+          const pts = disp.map((p) => `${sX(f, p[0])},${sY(f, p[1])}`).join(' ');
+          const [cwx, cwy] = centroid(disp);
+          const cx = sX(f, cwx), cy = sY(f, cwy);
           const lit = mergeRooms?.has(r.face);
           const bad = !r.simple;
+          const area = boundaryMode === 'center' ? r.area : polyArea(disp);
           return (
             <g key={r.face}>
+              {boundaryMode !== 'center' && (
+                <polygon points={r.outline.map((p) => `${sX(f, p[0])},${sY(f, p[1])}`).join(' ')}
+                  fill="none" stroke={color} strokeOpacity={0.25} strokeDasharray="3 3" strokeWidth={1} />
+              )}
               <polygon points={pts} fill={bad ? '#ef4444' : color} fillOpacity={lit ? 0.42 : bad ? 0.3 : 0.16}
                 stroke={bad ? '#ef4444' : color} strokeWidth={lit ? 3 : 2} />
-              <text x={cx} y={cy - 5} textAnchor="middle" fontSize={12} fontWeight={600} fill="currentColor" className="pointer-events-none">{r.area.toFixed(2)}</text>
+              <text x={cx} y={cy - 5} textAnchor="middle" fontSize={12} fontWeight={600} fill="currentColor" className="pointer-events-none">{area.toFixed(2)}</text>
               <text x={cx} y={cy + 9} textAnchor="middle" fontSize={9} fill="currentColor" opacity={0.55} className="pointer-events-none">m²</text>
             </g>
           );

--- a/apps/viewer/src/hooks/useConstructionUnderlay.ts
+++ b/apps/viewer/src/hooks/useConstructionUnderlay.ts
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Faint plan-cut underlay of building elements (walls/doors/columns ~1.2 m
+ * above the storey floor) for the 2D Space Sketch, registered into the same
+ * model-metre frame as the room outlines so the user keeps building orientation
+ * while editing rooms.
+ *
+ * The construction projection (the same one the sections canvas uses) runs on
+ * render-frame meshes (Y-up, RTC-shifted). For a plan (down = `'y'`) cut,
+ * `projectTo2D` yields `(renderX, renderZ)`, and `renderX = ifcX − rtc.x +
+ * shift.x`, `renderZ = −ifcY + rtc.y + shift.z`. We invert that back to the
+ * room frame `(ifcX, ifcY)` so the underlay overlays the rooms directly.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { Drawing2DGenerator, createSectionConfig } from '@ifc-lite/drawing-2d';
+import type { CoordinateInfo } from '@ifc-lite/geometry';
+import { useViewerStore } from '@/store';
+
+export interface UnderlayLine {
+  a: [number, number];
+  b: [number, number];
+  /** Dashed (above-cut / occluded) vs solid (at/below cut). */
+  hidden: boolean;
+}
+
+export function useConstructionUnderlay(
+  enabled: boolean,
+  floorElevation: number | null,
+): { lines: UnderlayLine[]; loading: boolean } {
+  const geometryResult = useViewerStore((s) => s.geometryResult);
+  const [lines, setLines] = useState<UnderlayLine[]>([]);
+  const [loading, setLoading] = useState(false);
+  const genRef = useRef<Drawing2DGenerator | null>(null);
+
+  useEffect(() => {
+    const meshes = geometryResult?.meshes;
+    if (!enabled || floorElevation === null || !meshes || meshes.length === 0) {
+      setLines([]);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+
+    const coord = geometryResult?.coordinateInfo as CoordinateInfo | undefined;
+    const rtc = coord?.wasmRtcOffset ?? { x: 0, y: 0, z: 0 };
+    const shift = coord?.originShift ?? { x: 0, y: 0, z: 0 };
+    // Plan cut at floor + 1.2 m, in render-frame Y.
+    const cutY = floorElevation + 1.2 - rtc.z + shift.y;
+    // Inverse of the plan projection → room (ifcX, ifcY) frame.
+    const cx = rtc.x - shift.x;
+    const cy = rtc.y + shift.z;
+
+    const config = createSectionConfig('y', cutY, {
+      projectionDepth: 1.5,
+      projectionBelowDepth: 1.4,
+      projectionAboveDepth: 0.8,
+    });
+
+    void (async () => {
+      try {
+        const gen = genRef.current ?? new Drawing2DGenerator();
+        genRef.current = gen;
+        await gen.initialize();
+        const drawing = await gen.generate(meshes, config, {
+          includeProjection: true,
+          includeEdges: false,
+          includeHiddenLines: false,
+          mergeLines: true,
+        });
+        if (cancelled) return;
+        const out: UnderlayLine[] = drawing.lines.map((l) => ({
+          a: [l.line.start.x + cx, cy - l.line.start.y] as [number, number],
+          b: [l.line.end.x + cx, cy - l.line.end.y] as [number, number],
+          hidden: l.visibility === 'hidden',
+        }));
+        setLines(out);
+      } catch {
+        if (!cancelled) setLines([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, floorElevation, geometryResult]);
+
+  return { lines, loading };
+}

--- a/apps/viewer/src/store/slices/mutationSlice.ts
+++ b/apps/viewer/src/store/slices/mutationSlice.ts
@@ -27,12 +27,15 @@ import {
   duplicateInStore,
   resolveDuplicateSource,
   generateSpacesFromWalls,
+  generateSpaces,
   type BeamInStoreParams,
   type ColumnInStoreParams,
   type DoorInStoreParams,
   type DuplicateInStoreOptions,
   type GenerateSpacesOptions,
   type GenerateSpacesResult,
+  type GenerateSpacesAllOptions,
+  type GenerateSpacesAllResult,
   type MemberInStoreParams,
   type PlateInStoreParams,
   type RoofInStoreParams,
@@ -627,6 +630,15 @@ export interface MutationSlice {
     storeyExpressId: number,
     options?: GenerateSpacesOptions,
   ) => GenerateSpacesResult | { error: string };
+  /**
+   * Derive IfcSpace across every storey at once (whole building): auto
+   * floor-to-floor heights, auto-escalating snap, per-space dedup against
+   * existing spaces. Writes to the model overlay (undoable, marks dirty).
+   */
+  generateAllSpaces: (
+    modelId: string,
+    options?: GenerateSpacesAllOptions,
+  ) => GenerateSpacesAllResult | { error: string };
   /**
    * Duplicate an existing IfcRoot product in a chosen direction.
    * Offset magnitude is one source-bbox dimension along the picked
@@ -2272,6 +2284,60 @@ export const createMutationSlice: StateCreator<
       const newDirty = new Set(s.dirtyModels);
       newDirty.add(modelId);
 
+      return {
+        undoStacks: newUndoStacks,
+        redoStacks: newRedoStacks,
+        dirtyModels: newDirty,
+        mutationVersion: s.mutationVersion + 1,
+      };
+    });
+
+    return result;
+  },
+
+  generateAllSpaces: (modelId, options) => {
+    const state = get();
+    const dataStore = state.models.get(modelId)?.ifcDataStore;
+    if (!dataStore) return { error: `No model loaded for id "${modelId}"` };
+    const view = state.mutationViews.get(modelId);
+    if (!view) return { error: 'Model has no editable mutation view yet' };
+    const editor = getOrCreateStoreEditor(get, set, modelId);
+    if (!editor) return { error: 'Failed to create store editor' };
+
+    let result: GenerateSpacesAllResult;
+    try {
+      result = generateSpaces(
+        editor,
+        dataStore,
+        { storeys: 'all', height: 'auto', snap: 'auto', ...options },
+        { getNewEntities: () => view.getNewEntities() },
+      );
+    } catch (err) {
+      return { error: err instanceof Error ? err.message : 'Failed to generate spaces' };
+    }
+
+    const emitted = result.storeys.flatMap((s) => s.result.emitted);
+    if (emitted.length === 0) return result;
+
+    set((s) => {
+      const newUndoStacks = new Map(s.undoStacks);
+      const stack = [...(newUndoStacks.get(modelId) ?? [])];
+      const ts = Date.now();
+      for (const e of emitted) {
+        stack.push({
+          id: `mut_ifcspace_${e.result.spaceId}_${ts}_${Math.random().toString(36).substring(2, 9)}`,
+          type: 'CREATE_ENTITY',
+          timestamp: ts,
+          modelId,
+          entityId: e.result.spaceId,
+          attributeName: 'IFCSPACE',
+        });
+      }
+      newUndoStacks.set(modelId, stack);
+      const newRedoStacks = new Map(s.redoStacks);
+      newRedoStacks.set(modelId, []);
+      const newDirty = new Set(s.dirtyModels);
+      newDirty.add(modelId);
       return {
         undoStacks: newUndoStacks,
         redoStacks: newRedoStacks,

--- a/apps/viewer/src/store/slices/mutationSlice.ts
+++ b/apps/viewer/src/store/slices/mutationSlice.ts
@@ -27,15 +27,12 @@ import {
   duplicateInStore,
   resolveDuplicateSource,
   generateSpacesFromWalls,
-  generateSpaces,
   type BeamInStoreParams,
   type ColumnInStoreParams,
   type DoorInStoreParams,
   type DuplicateInStoreOptions,
   type GenerateSpacesOptions,
   type GenerateSpacesResult,
-  type GenerateSpacesAllOptions,
-  type GenerateSpacesAllResult,
   type MemberInStoreParams,
   type PlateInStoreParams,
   type RoofInStoreParams,
@@ -630,15 +627,6 @@ export interface MutationSlice {
     storeyExpressId: number,
     options?: GenerateSpacesOptions,
   ) => GenerateSpacesResult | { error: string };
-  /**
-   * Derive IfcSpace across every storey at once (whole building): auto
-   * floor-to-floor heights, auto-escalating snap, per-space dedup against
-   * existing spaces. Writes to the model overlay (undoable, marks dirty).
-   */
-  generateAllSpaces: (
-    modelId: string,
-    options?: GenerateSpacesAllOptions,
-  ) => GenerateSpacesAllResult | { error: string };
   /**
    * Duplicate an existing IfcRoot product in a chosen direction.
    * Offset magnitude is one source-bbox dimension along the picked
@@ -2284,60 +2272,6 @@ export const createMutationSlice: StateCreator<
       const newDirty = new Set(s.dirtyModels);
       newDirty.add(modelId);
 
-      return {
-        undoStacks: newUndoStacks,
-        redoStacks: newRedoStacks,
-        dirtyModels: newDirty,
-        mutationVersion: s.mutationVersion + 1,
-      };
-    });
-
-    return result;
-  },
-
-  generateAllSpaces: (modelId, options) => {
-    const state = get();
-    const dataStore = state.models.get(modelId)?.ifcDataStore;
-    if (!dataStore) return { error: `No model loaded for id "${modelId}"` };
-    const view = state.mutationViews.get(modelId);
-    if (!view) return { error: 'Model has no editable mutation view yet' };
-    const editor = getOrCreateStoreEditor(get, set, modelId);
-    if (!editor) return { error: 'Failed to create store editor' };
-
-    let result: GenerateSpacesAllResult;
-    try {
-      result = generateSpaces(
-        editor,
-        dataStore,
-        { storeys: 'all', height: 'auto', snap: 'auto', ...options },
-        { getNewEntities: () => view.getNewEntities() },
-      );
-    } catch (err) {
-      return { error: err instanceof Error ? err.message : 'Failed to generate spaces' };
-    }
-
-    const emitted = result.storeys.flatMap((s) => s.result.emitted);
-    if (emitted.length === 0) return result;
-
-    set((s) => {
-      const newUndoStacks = new Map(s.undoStacks);
-      const stack = [...(newUndoStacks.get(modelId) ?? [])];
-      const ts = Date.now();
-      for (const e of emitted) {
-        stack.push({
-          id: `mut_ifcspace_${e.result.spaceId}_${ts}_${Math.random().toString(36).substring(2, 9)}`,
-          type: 'CREATE_ENTITY',
-          timestamp: ts,
-          modelId,
-          entityId: e.result.spaceId,
-          attributeName: 'IFCSPACE',
-        });
-      }
-      newUndoStacks.set(modelId, stack);
-      const newRedoStacks = new Map(s.redoStacks);
-      newRedoStacks.set(modelId, []);
-      const newDirty = new Set(s.dirtyModels);
-      newDirty.add(modelId);
       return {
         undoStacks: newUndoStacks,
         redoStacks: newRedoStacks,

--- a/packages/cli/src/commands/generate-spaces.ts
+++ b/packages/cli/src/commands/generate-spaces.ts
@@ -1,0 +1,169 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `ifc-lite generate-spaces` — derive IfcSpace from a model's walls (footprint)
+ * with slab/roof-aware heights (storey datums), and write the augmented IFC.
+ */
+
+import { writeFile } from 'node:fs/promises';
+import { createHeadlessContext } from '../loader.js';
+import { getFlag, getAllFlags, hasFlag, fatal, printJson } from '../output.js';
+import { MutablePropertyView, StoreEditor } from '@ifc-lite/mutations';
+import { StepExporter } from '@ifc-lite/export';
+import { extractPropertiesOnDemand } from '@ifc-lite/parser';
+import { generateSpaces, listStoreys, type GenerateSpacesAllOptions } from '@ifc-lite/create';
+
+type Schema = 'IFC2X3' | 'IFC4' | 'IFC4X3' | 'IFC5';
+
+const USAGE = `Usage: ifc-lite generate-spaces <file.ifc> --out <out.ifc> [options]
+
+Derive IfcSpace volumes from the building's walls (room footprints), using the
+storey datums (slab levels) for floor-to-floor height.
+
+Options:
+  --out <file.ifc>        Output IFC with the new IfcSpace (omit with --dry-run)
+  --storey <id|name|all>  Storey express id, name (substring), or all (default)
+  --snap <m|auto>         Corner-closing tolerance in metres, or auto (default)
+  --height <m|auto>       Space height in metres, or auto = floor-to-floor (default)
+  --top-height <m>        Height for the topmost storey under auto (default 3)
+  --min-area <m2>         Drop regions below this area (default 0.5)
+  --name-pattern <p>      Name template; {n}=index, {storey}=storey name (default "Space {n}")
+  --predefined-type <t>   IfcSpacePredefinedType (default INTERNAL)
+  --divider-type <t>      Extra element type to treat as a wall divider (repeatable)
+  --dry-run               Detect + report only; write nothing
+  --list-storeys          List storeys (id, name, elevation) and exit
+  --json                  Machine-readable output`;
+
+export async function generateSpacesCommand(args: string[]): Promise<void> {
+  const filePath = args.find((a) => !a.startsWith('-'));
+  if (!filePath) fatal(USAGE);
+
+  const out = getFlag(args, '--out');
+  const storeyArg = getFlag(args, '--storey');
+  const snapArg = getFlag(args, '--snap') ?? 'auto';
+  const heightArg = getFlag(args, '--height') ?? 'auto';
+  const minArea = Number(getFlag(args, '--min-area') ?? '0.5');
+  const topHeight = Number(getFlag(args, '--top-height') ?? '3');
+  const namePattern = getFlag(args, '--name-pattern');
+  const predefinedType = getFlag(args, '--predefined-type');
+  const dividerTypes = getAllFlags(args, '--divider-type');
+  const dryRun = hasFlag(args, '--dry-run');
+  const json = hasFlag(args, '--json');
+  const debug = hasFlag(args, '--debug');
+
+  const { store } = await createHeadlessContext(filePath!);
+
+  if (hasFlag(args, '--list-storeys')) {
+    const sts = listStoreys(store);
+    if (json) printJson(sts);
+    else if (!sts.length) process.stderr.write('No IfcBuildingStorey found.\n');
+    else for (const s of sts) process.stderr.write(`#${s.id}\t${s.name}\t(elev ${s.elevation.toFixed(2)} m)\n`);
+    return;
+  }
+
+  if (!out && !dryRun) fatal('--out <file.ifc> is required (or use --dry-run to report only)');
+
+  // ── resolve storey selection ──
+  let storeys: 'all' | number[] = 'all';
+  if (storeyArg && storeyArg.toLowerCase() !== 'all') {
+    const all = listStoreys(store);
+    const num = Number(storeyArg);
+    if (Number.isFinite(num) && all.some((s) => s.id === num)) {
+      storeys = [num];
+    } else {
+      const matched = all.filter((s) => s.name.toLowerCase().includes(storeyArg.toLowerCase()));
+      if (!matched.length) {
+        const avail = all.map((s) => `${s.name} (#${s.id})`).join(', ') || '(none)';
+        fatal(`Storey "${storeyArg}" not found. Available: ${avail}`);
+      }
+      storeys = matched.map((s) => s.id);
+    }
+  }
+
+  const snap = snapArg === 'auto' ? 'auto' : Number(snapArg);
+  const height = heightArg === 'auto' ? 'auto' : Number(heightArg);
+  if (snap !== 'auto' && !Number.isFinite(snap)) fatal('--snap must be a number (metres) or "auto"');
+  if (height !== 'auto' && !Number.isFinite(height)) fatal('--height must be a number (metres) or "auto"');
+  if (!Number.isFinite(minArea) || minArea < 0) fatal('--min-area must be a non-negative number');
+
+  // ── mutation overlay + editor ──
+  const view = new MutablePropertyView(null, 'default');
+  view.setOnDemandExtractor((id: number) => extractPropertiesOnDemand(store, id));
+  const editor = new StoreEditor(store, view);
+
+  const opts: GenerateSpacesAllOptions = {
+    storeys,
+    snap,
+    height,
+    minArea,
+    topStoreyHeight: topHeight,
+    namePattern,
+    predefinedType,
+    extraDividerTypes: dividerTypes.length ? dividerTypes : undefined,
+    dryRun,
+    debug,
+  };
+  // The detector logs a per-storey `console.info` line (handy in the viewer's
+  // devtools) and the auto-snap dry-runs multiply it; silence it for the CLI so
+  // stdout stays clean — critical for `--json`. `--debug` keeps it.
+  const origInfo = console.info;
+  const origDebug = console.debug;
+  if (!debug) {
+    console.info = () => {};
+    console.debug = () => {};
+  }
+  let res;
+  try {
+    res = generateSpaces(editor, store, opts);
+  } finally {
+    console.info = origInfo;
+    console.debug = origDebug;
+  }
+
+  if (!dryRun && out) {
+    const schema = (store.schemaVersion ?? 'IFC4') as Schema;
+    const exporter = new StepExporter(store, view);
+    const exported = exporter.export({ schema, applyMutations: true });
+    await writeFile(out, exported.content);
+  }
+
+  if (json) {
+    printJson({
+      input: filePath,
+      output: dryRun ? null : out,
+      dryRun,
+      totalDetected: res.totalDetected,
+      totalEmitted: res.totalEmitted,
+      storeys: res.storeys.map((s) => ({
+        id: s.id,
+        name: s.name,
+        elevation: s.elevation,
+        height: s.height,
+        snap: s.snapUsed,
+        detected: s.result.detected.length,
+        emitted: s.result.emitted.length,
+        wallsConsidered: s.result.wallsConsidered,
+        wallsContributing: s.result.wallsContributing,
+        wallsSkipped: s.result.wallsSkipped.length,
+        areas: s.result.detected.map((d) => Number(d.area.toFixed(2))),
+      })),
+    });
+    return;
+  }
+
+  for (const s of res.storeys) {
+    const areas = s.result.detected.map((d) => d.area.toFixed(1)).join(' / ') || '—';
+    const emit = dryRun ? '' : ` → ${s.result.emitted.length} IfcSpace`;
+    process.stderr.write(
+      `${s.name} (#${s.id}, elev ${s.elevation.toFixed(2)} m): ${s.result.detected.length} room(s)${emit}` +
+      `  [h=${s.height.toFixed(2)} m, snap=${s.snapUsed} m]  areas ${areas} m²\n`,
+    );
+  }
+  process.stderr.write(
+    `Total: ${res.totalDetected} room(s)` +
+    (dryRun ? ' (dry-run — nothing written)' : `, ${res.totalEmitted} IfcSpace emitted`) + '\n',
+  );
+  if (out && !dryRun) process.stderr.write(`Written to ${out}\n`);
+}

--- a/packages/cli/src/commands/generate-spaces.ts
+++ b/packages/cli/src/commands/generate-spaces.ts
@@ -31,6 +31,7 @@ Options:
   --min-area <m2>         Drop regions below this area (default 0.5)
   --name-pattern <p>      Name template; {n}=index, {storey}=storey name (default "Space {n}")
   --predefined-type <t>   IfcSpacePredefinedType (default INTERNAL)
+  --boundary <mode>       Space boundary vs walls: center | inner | outer (default inner)
   --divider-type <t>      Extra element type to treat as a wall divider (repeatable)
   --dry-run               Detect + report only; write nothing
   --force                 Re-derive even if the model already has generated spaces (may duplicate)
@@ -49,6 +50,8 @@ export async function generateSpacesCommand(args: string[]): Promise<void> {
   const topHeight = Number(getFlag(args, '--top-height') ?? '3');
   const namePattern = getFlag(args, '--name-pattern');
   const predefinedType = getFlag(args, '--predefined-type');
+  const boundaryArg = (getFlag(args, '--boundary') ?? 'inner') as 'center' | 'inner' | 'outer';
+  if (!['center', 'inner', 'outer'].includes(boundaryArg)) fatal('--boundary must be center, inner, or outer');
   const dividerTypes = getAllFlags(args, '--divider-type');
   const dryRun = hasFlag(args, '--dry-run');
   const force = hasFlag(args, '--force');
@@ -105,6 +108,7 @@ export async function generateSpacesCommand(args: string[]): Promise<void> {
     namePattern,
     predefinedType,
     extraDividerTypes: dividerTypes.length ? dividerTypes : undefined,
+    boundaryMode: boundaryArg,
     dryRun,
     force,
     debug,

--- a/packages/cli/src/commands/generate-spaces.ts
+++ b/packages/cli/src/commands/generate-spaces.ts
@@ -33,6 +33,7 @@ Options:
   --predefined-type <t>   IfcSpacePredefinedType (default INTERNAL)
   --divider-type <t>      Extra element type to treat as a wall divider (repeatable)
   --dry-run               Detect + report only; write nothing
+  --force                 Re-derive even if the model already has generated spaces (may duplicate)
   --list-storeys          List storeys (id, name, elevation) and exit
   --json                  Machine-readable output`;
 
@@ -50,6 +51,7 @@ export async function generateSpacesCommand(args: string[]): Promise<void> {
   const predefinedType = getFlag(args, '--predefined-type');
   const dividerTypes = getAllFlags(args, '--divider-type');
   const dryRun = hasFlag(args, '--dry-run');
+  const force = hasFlag(args, '--force');
   const json = hasFlag(args, '--json');
   const debug = hasFlag(args, '--debug');
 
@@ -104,6 +106,7 @@ export async function generateSpacesCommand(args: string[]): Promise<void> {
     predefinedType,
     extraDividerTypes: dividerTypes.length ? dividerTypes : undefined,
     dryRun,
+    force,
     debug,
   };
   // The detector logs a per-storey `console.info` line (handy in the viewer's
@@ -123,18 +126,27 @@ export async function generateSpacesCommand(args: string[]): Promise<void> {
     console.debug = origDebug;
   }
 
-  if (!dryRun && out) {
+  if (!dryRun && out && res.skippedExisting === 0) {
     const schema = (store.schemaVersion ?? 'IFC4') as Schema;
     const exporter = new StepExporter(store, view);
     const exported = exporter.export({ schema, applyMutations: true });
     await writeFile(out, exported.content);
   }
 
+  if (res.skippedExisting > 0 && !json) {
+    process.stderr.write(
+      `Skipped: model already contains ${res.skippedExisting} generated space(s) — ` +
+      `nothing written. Derive from the original file, or pass --force to re-derive (may duplicate).\n`,
+    );
+    return;
+  }
+
   if (json) {
     printJson({
       input: filePath,
-      output: dryRun ? null : out,
+      output: dryRun || res.skippedExisting > 0 ? null : out,
       dryRun,
+      skippedExisting: res.skippedExisting,
       totalDetected: res.totalDetected,
       totalEmitted: res.totalEmitted,
       storeys: res.storeys.map((s) => ({

--- a/packages/cli/src/commands/generate-spaces.ts
+++ b/packages/cli/src/commands/generate-spaces.ts
@@ -126,27 +126,22 @@ export async function generateSpacesCommand(args: string[]): Promise<void> {
     console.debug = origDebug;
   }
 
-  if (!dryRun && out && res.skippedExisting === 0) {
+  // Write whenever we emitted at least one space (other storeys may have been
+  // skipped for already having spaces).
+  if (!dryRun && out && res.totalEmitted > 0) {
     const schema = (store.schemaVersion ?? 'IFC4') as Schema;
     const exporter = new StepExporter(store, view);
     const exported = exporter.export({ schema, applyMutations: true });
     await writeFile(out, exported.content);
   }
 
-  if (res.skippedExisting > 0 && !json) {
-    process.stderr.write(
-      `Skipped: model already contains ${res.skippedExisting} generated space(s) — ` +
-      `nothing written. Derive from the original file, or pass --force to re-derive (may duplicate).\n`,
-    );
-    return;
-  }
-
   if (json) {
     printJson({
       input: filePath,
-      output: dryRun || res.skippedExisting > 0 ? null : out,
+      output: !dryRun && out && res.totalEmitted > 0 ? out : null,
       dryRun,
       skippedExisting: res.skippedExisting,
+      skippedStoreys: res.skippedStoreys.map((s) => ({ id: s.id, name: s.name, existingSpaces: s.existingSpaces })),
       totalDetected: res.totalDetected,
       totalEmitted: res.totalEmitted,
       storeys: res.storeys.map((s) => ({
@@ -174,9 +169,13 @@ export async function generateSpacesCommand(args: string[]): Promise<void> {
       `  [h=${s.height.toFixed(2)} m, snap=${s.snapUsed} m]  areas ${areas} m²\n`,
     );
   }
+  for (const s of res.skippedStoreys) {
+    process.stderr.write(`${s.name} (#${s.id}): skipped — already has ${s.existingSpaces} IfcSpace (use --force to add anyway).\n`);
+  }
   process.stderr.write(
     `Total: ${res.totalDetected} room(s)` +
-    (dryRun ? ' (dry-run — nothing written)' : `, ${res.totalEmitted} IfcSpace emitted`) + '\n',
+    (dryRun ? ' (dry-run — nothing written)' : `, ${res.totalEmitted} IfcSpace emitted`) +
+    (res.skippedExisting ? `; skipped ${res.skippedStoreys.length} storey(s) with ${res.skippedExisting} existing space(s)` : '') + '\n',
   );
-  if (out && !dryRun) process.stderr.write(`Written to ${out}\n`);
+  if (out && !dryRun && res.totalEmitted > 0) process.stderr.write(`Written to ${out}\n`);
 }

--- a/packages/cli/src/commands/generate-spaces.ts
+++ b/packages/cli/src/commands/generate-spaces.ts
@@ -87,6 +87,7 @@ export async function generateSpacesCommand(args: string[]): Promise<void> {
   if (snap !== 'auto' && !Number.isFinite(snap)) fatal('--snap must be a number (metres) or "auto"');
   if (height !== 'auto' && !Number.isFinite(height)) fatal('--height must be a number (metres) or "auto"');
   if (!Number.isFinite(minArea) || minArea < 0) fatal('--min-area must be a non-negative number');
+  if (!Number.isFinite(topHeight) || topHeight <= 0) fatal('--top-height must be a positive number (metres)');
 
   // ── mutation overlay + editor ──
   const view = new MutablePropertyView(null, 'default');

--- a/packages/cli/src/commands/generate-spaces.ts
+++ b/packages/cli/src/commands/generate-spaces.ts
@@ -141,7 +141,6 @@ export async function generateSpacesCommand(args: string[]): Promise<void> {
       output: !dryRun && out && res.totalEmitted > 0 ? out : null,
       dryRun,
       skippedExisting: res.skippedExisting,
-      skippedStoreys: res.skippedStoreys.map((s) => ({ id: s.id, name: s.name, existingSpaces: s.existingSpaces })),
       totalDetected: res.totalDetected,
       totalEmitted: res.totalEmitted,
       storeys: res.storeys.map((s) => ({
@@ -169,13 +168,10 @@ export async function generateSpacesCommand(args: string[]): Promise<void> {
       `  [h=${s.height.toFixed(2)} m, snap=${s.snapUsed} m]  areas ${areas} m²\n`,
     );
   }
-  for (const s of res.skippedStoreys) {
-    process.stderr.write(`${s.name} (#${s.id}): skipped — already has ${s.existingSpaces} IfcSpace (use --force to add anyway).\n`);
-  }
   process.stderr.write(
     `Total: ${res.totalDetected} room(s)` +
     (dryRun ? ' (dry-run — nothing written)' : `, ${res.totalEmitted} IfcSpace emitted`) +
-    (res.skippedExisting ? `; skipped ${res.skippedStoreys.length} storey(s) with ${res.skippedExisting} existing space(s)` : '') + '\n',
+    (res.skippedExisting ? `; skipped ${res.skippedExisting} overlapping an existing space` : '') + '\n',
   );
   if (out && !dryRun && res.totalEmitted > 0) process.stderr.write(`Written to ${out}\n`);
 }

--- a/packages/cli/src/headless-backend.ts
+++ b/packages/cli/src/headless-backend.ts
@@ -20,6 +20,7 @@ import type {
   ViewerBackendMethods,
   MutateBackendMethods,
   StoreBackendMethods,
+  SpacesBackendMethods,
   SpatialBackendMethods,
   ExportBackendMethods,
   LensBackendMethods,
@@ -62,6 +63,9 @@ import {
   type SpaceInStoreParams,
   type WallInStoreParams,
   type WindowInStoreParams,
+  generateSpaces,
+  listStoreys,
+  type GenerateSpacesAllOptions,
 } from '@ifc-lite/create';
 import { EntityNode } from '@ifc-lite/query';
 import { RelationshipType, IfcTypeEnum, IfcTypeEnumFromString } from '@ifc-lite/data';
@@ -162,6 +166,7 @@ export class HeadlessBackend implements BimBackend {
   readonly lens: LensBackendMethods;
   readonly files: FilesBackendMethods;
   readonly schedule: ScheduleBackendMethods;
+  readonly spaces: SpacesBackendMethods;
 
   private dataStore: IfcDataStore;
   private modelName: string;
@@ -183,6 +188,17 @@ export class HeadlessBackend implements BimBackend {
     this.lens = this.createLensAdapter();
     this.files = this.createFilesAdapter();
     this.schedule = this.createScheduleAdapter();
+    this.spaces = this.createSpacesAdapter();
+  }
+
+  private createSpacesAdapter(): SpacesBackendMethods {
+    return {
+      listStoreys: () => listStoreys(this.dataStore),
+      // Spaces are written via the shared StoreEditor/MutablePropertyView, so
+      // they're picked up by this backend's export adapter (StepExporter).
+      generate: (options?: GenerateSpacesAllOptions) =>
+        generateSpaces(this.getOrCreateStoreEditor(), this.dataStore, options),
+    };
   }
 
   subscribe(_event: BimEventType, _handler: (data: unknown) => void): () => void {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -28,6 +28,7 @@ import { validateCommand } from './commands/validate.js';
 import { bsddCommand } from './commands/bsdd.js';
 import { statsCommand } from './commands/stats.js';
 import { mutateCommand } from './commands/mutate.js';
+import { generateSpacesCommand } from './commands/generate-spaces.js';
 import { askCommand } from './commands/ask.js';
 import { viewCommand } from './commands/view.js';
 import { analyzeCommand } from './commands/analyze.js';
@@ -78,6 +79,7 @@ const HELP = `
     bsdd      <class|search|psets|qsets> <arg>     buildingSMART Data Dictionary lookup
     stats     <file.ifc>                          Auto-calculated model KPIs and health check
     mutate    <file.ifc> --id N --set P=V --out F  Modify properties/attributes and save
+    generate-spaces <file.ifc> --out F           Derive IfcSpace from walls (slab/roof-aware height)
     ask       <file.ifc> "<question>"            Natural language BIM queries
     view      <file.ifc> [--port N]              Interactive 3D viewer in browser
     analyze   <file.ifc> --viewer <port>        Query + visualize analysis results
@@ -233,6 +235,9 @@ async function main(): Promise<void> {
       break;
     case 'mutate':
       await mutateCommand(commandArgs);
+      break;
+    case 'generate-spaces':
+      await generateSpacesCommand(commandArgs);
       break;
     case 'ask':
       await askCommand(commandArgs);

--- a/packages/create/src/in-store/auto-space-detect.test.ts
+++ b/packages/create/src/in-store/auto-space-detect.test.ts
@@ -8,6 +8,21 @@ import { detectEnclosedAreas, type Segment } from './auto-space-detect.js';
 const seg = (a: [number, number], b: [number, number]): Segment => ({ a, b });
 
 describe('detectEnclosedAreas', () => {
+  it('snaps offset wall centrelines into a clean rectangle (corner cleanup)', () => {
+    // 8×8 room whose centrelines miss each corner by ~0.1 m (one overshoots,
+    // the neighbour undershoots) — the real-world case that produced
+    // trapezoids. Corner-snap must recover the exact rectangle (area 64).
+    const segs: Segment[] = [
+      seg([-0.1, 8.0], [8.1, 8.0]), // top, overshoots both ends
+      seg([8.0, 7.9], [8.0, -0.1]), // right, undershoots top
+      seg([8.1, 0.0], [-0.1, 0.0]), // bottom
+      seg([0.0, 8.1], [0.0, 0.1]),  // left, undershoots bottom
+    ];
+    const rooms = detectEnclosedAreas(segs, { snapTolerance: 0.25, minArea: 0.5 });
+    expect(rooms).toHaveLength(1);
+    expect(rooms[0].area).toBeCloseTo(64, 5);
+  });
+
   it('finds a single rectangular room', () => {
     const segs: Segment[] = [
       seg([0, 0], [4, 0]),

--- a/packages/create/src/in-store/auto-space-detect.ts
+++ b/packages/create/src/in-store/auto-space-detect.ts
@@ -129,6 +129,14 @@ export function detectEnclosedAreasWithStats(
     return { spaces: [], stats };
   }
 
+  // ── 0. Corner cleanup (mirrors the Rust SpacePlate arrangement) ──
+  // Real wall centrelines miss each corner by ~half a wall thickness (one
+  // overshoots, the neighbour undershoots), so a plain endpoint snap closes
+  // them at a skewed point → trapezoids. Pull each wall-end onto the true
+  // line-intersection with the nearest crossing wall so orthogonal walls form
+  // clean rectangles. T-junctions fall out for free.
+  segments = snapCornersToIntersections(segments, snap);
+
   // ── 1. Snap endpoints ──
   // Spatial hash keyed on a snap-sized grid so endpoint resolution stays
   // O(1) average instead of O(N) linear scans. We probe the cell + its 8
@@ -444,6 +452,42 @@ export function detectEnclosedAreasWithStats(
  * parametric distance `t ∈ [0, 1]` along ab. Returns null for
  * zero-length segments.
  */
+/** Intersection of the two infinite lines through `a1→b1` and `a2→b2`; null if (near-)parallel. */
+function lineIntersection(a1: Vec2, b1: Vec2, a2: Vec2, b2: Vec2): Vec2 | null {
+  const d1x = b1[0] - a1[0], d1y = b1[1] - a1[1];
+  const d2x = b2[0] - a2[0], d2y = b2[1] - a2[1];
+  const denom = d1x * d2y - d1y * d2x;
+  if (Math.abs(denom) < EPS) return null;
+  const t = ((a2[0] - a1[0]) * d2y - (a2[1] - a1[1]) * d2x) / denom;
+  return [a1[0] + t * d1x, a1[1] + t * d1y];
+}
+
+/**
+ * Pull each wall-end onto the true line-intersection with the nearest crossing
+ * wall within `tol`, so offset centrelines close into clean (e.g. rectangular)
+ * rooms instead of trapezoids. Intersections use the original geometry; ends
+ * with no crossing wall within `tol` are left as-is (leaks stay leaks).
+ * Returns a fresh array — inputs untouched.
+ */
+function snapCornersToIntersections(segments: Segment[], tol: number): Segment[] {
+  const lines = segments.map((s) => [s.a, s.b] as const);
+  const n = segments.length;
+  const tol2 = tol * tol;
+  const snapEnd = (e: Vec2, i: number): Vec2 => {
+    let best: Vec2 | null = null;
+    let bestD2 = tol2;
+    for (let j = 0; j < n; j++) {
+      if (j === i) continue;
+      const p = lineIntersection(lines[i][0], lines[i][1], lines[j][0], lines[j][1]);
+      if (!p) continue;
+      const d2 = (p[0] - e[0]) ** 2 + (p[1] - e[1]) ** 2;
+      if (d2 < bestD2) { bestD2 = d2; best = p; }
+    }
+    return best ?? e;
+  };
+  return segments.map((s, i) => ({ a: snapEnd(s.a, i), b: snapEnd(s.b, i) }));
+}
+
 function closestPointOnSegment(
   q: Vec2, a: Vec2, b: Vec2,
 ): { point: Vec2; t: number } | null {

--- a/packages/create/src/in-store/auto-space-detect.ts
+++ b/packages/create/src/in-store/auto-space-detect.ts
@@ -480,6 +480,11 @@ function snapCornersToIntersections(segments: Segment[], tol: number): Segment[]
       if (j === i) continue;
       const p = lineIntersection(lines[i][0], lines[i][1], lines[j][0], lines[j][1]);
       if (!p) continue;
+      // The intersection must lie near segment j's FINITE extent, not just its
+      // infinite line — else a distant aligned wall could pull this end onto a
+      // phantom corner and fabricate a room that was never there.
+      const host = closestPointOnSegment(p, lines[j][0], lines[j][1]);
+      if (!host || (host.point[0] - p[0]) ** 2 + (host.point[1] - p[1]) ** 2 > tol2) continue;
       const d2 = (p[0] - e[0]) ** 2 + (p[1] - e[1]) ** 2;
       if (d2 < bestD2) { bestD2 = d2; best = p; }
     }

--- a/packages/create/src/in-store/extract-walls.test.ts
+++ b/packages/create/src/in-store/extract-walls.test.ts
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import type { IfcDataStore } from '@ifc-lite/parser';
+import { resolveEntityTypeName } from './extract-walls.js';
+
+/**
+ * Regression for the AC20-FZK-Haus "no rooms" bug: the columnar entity table
+ * only indexes products, so `getTypeName` returns the literal `'Unknown'` for
+ * geometry primitives (IfcPolyline, IfcCartesianPoint, profiles). The Axis
+ * reader used `getTypeName(id) || entity.type`, and since `'Unknown'` is
+ * truthy it shadowed the extractor's reliable type — so every `Curve2D` Axis
+ * polyline was skipped and no wall axis was found. `resolveEntityTypeName`
+ * must ignore the `'Unknown'` sentinel and fall back to the extractor type.
+ */
+describe('resolveEntityTypeName', () => {
+  const storeWith = (tableName: string) =>
+    ({ entities: { getTypeName: () => tableName } } as unknown as IfcDataStore);
+
+  it("falls back to the extractor type when the table says 'Unknown'", () => {
+    // This is the exact FZK case: an IfcPolyline axis item.
+    expect(resolveEntityTypeName(storeWith('Unknown'), { type: 'IFCPOLYLINE' }, 15031))
+      .toBe('ifcpolyline');
+  });
+
+  it('prefers the columnar table when it resolves a real product type', () => {
+    expect(resolveEntityTypeName(storeWith('IfcWallStandardCase'), { type: undefined }, 1))
+      .toBe('ifcwallstandardcase');
+  });
+
+  it("returns '' when neither source knows the type", () => {
+    expect(resolveEntityTypeName(storeWith('Unknown'), {}, 1)).toBe('');
+  });
+});

--- a/packages/create/src/in-store/extract-walls.ts
+++ b/packages/create/src/in-store/extract-walls.ts
@@ -314,6 +314,29 @@ function collectDividerIdsOnStorey(
 }
 
 /**
+ * Count existing `IfcSpace` per storey (aggregated or contained). Used to skip
+ * storeys that already have spaces, so generation doesn't create duplicates
+ * overlapping authored (or previously-generated) ones. Keyed by storey
+ * expressId; storeys with no spaces are omitted.
+ */
+export function spaceCountByStorey(store: IfcDataStore): Map<number, number> {
+  const out = new Map<number, number>();
+  if (!store.source) return out;
+  const extractor = new EntityExtractor(store.source);
+  const aggregated = buildRelatingChildrenIndex(store, extractor, 'IFCRELAGGREGATES', 4, 5);
+  const contained = buildRelatingChildrenIndex(store, extractor, 'IFCRELCONTAINEDINSPATIALSTRUCTURE', 5, 4);
+  for (const st of store.getEntitiesByType('IfcBuildingStorey')) {
+    const kids = [...(aggregated.get(st.expressId) ?? []), ...(contained.get(st.expressId) ?? [])];
+    let n = 0;
+    for (const id of kids) {
+      if ((store.entities.getTypeName(id) ?? '').toUpperCase() === 'IFCSPACE') n++;
+    }
+    if (n > 0) out.set(st.expressId, n);
+  }
+  return out;
+}
+
+/**
  * Index every relationship of `relType` by its "relating" attribute, so a
  * lookup of "what's anchored to id X" becomes O(1) instead of an O(R)
  * scan of every relationship.

--- a/packages/create/src/in-store/extract-walls.ts
+++ b/packages/create/src/in-store/extract-walls.ts
@@ -314,24 +314,40 @@ function collectDividerIdsOnStorey(
 }
 
 /**
- * Count existing `IfcSpace` per storey (aggregated or contained). Used to skip
- * storeys that already have spaces, so generation doesn't create duplicates
- * overlapping authored (or previously-generated) ones. Keyed by storey
- * expressId; storeys with no spaces are omitted.
+ * Footprint polygons (model-local metres, same frame as the extracted wall
+ * segments) of existing `IfcSpace` per storey — so generation can skip *only*
+ * the new rooms that overlap an already-present space (per-space dedup), while
+ * still adding rooms an empty part of the floor lacks. Keyed by storey
+ * expressId; storeys with no resolvable space footprints are omitted.
  */
-export function spaceCountByStorey(store: IfcDataStore): Map<number, number> {
-  const out = new Map<number, number>();
+export function existingSpaceFootprintsByStorey(store: IfcDataStore): Map<number, Vec2[][]> {
+  const out = new Map<number, Vec2[][]>();
   if (!store.source) return out;
   const extractor = new EntityExtractor(store.source);
+  const scale = extractLengthUnitScale(store.source, store.entityIndex) ?? 1;
   const aggregated = buildRelatingChildrenIndex(store, extractor, 'IFCRELAGGREGATES', 4, 5);
   const contained = buildRelatingChildrenIndex(store, extractor, 'IFCRELCONTAINEDINSPATIALSTRUCTURE', 5, 4);
   for (const st of store.getEntitiesByType('IfcBuildingStorey')) {
     const kids = [...(aggregated.get(st.expressId) ?? []), ...(contained.get(st.expressId) ?? [])];
-    let n = 0;
+    const footprints: Vec2[][] = [];
     for (const id of kids) {
-      if ((store.entities.getTypeName(id) ?? '').toUpperCase() === 'IFCSPACE') n++;
+      if ((store.entities.getTypeName(id) ?? '').toUpperCase() !== 'IFCSPACE') continue;
+      const ref = store.entityIndex.byId.get(id);
+      if (!ref) continue;
+      const ent = extractor.extractEntity(ref);
+      if (!ent) continue;
+      const placementId = numericAttr(ent.attributes[5]);   // ObjectPlacement
+      const representationId = numericAttr(ent.attributes[6]); // Representation
+      if (placementId === null || representationId === null) continue;
+      const frame = readPlacementFrame(store, extractor, undefined, placementId);
+      const localPts = gatherBodyFootprintPoints(store, extractor, undefined, representationId);
+      if (!frame || !localPts || localPts.length < 3) continue;
+      footprints.push(localPts.map((p) => {
+        const w = applyFrame(frame, p);
+        return [w[0] * scale, w[1] * scale] as Vec2;
+      }));
     }
-    if (n > 0) out.set(st.expressId, n);
+    if (footprints.length) out.set(st.expressId, footprints);
   }
   return out;
 }

--- a/packages/create/src/in-store/extract-walls.ts
+++ b/packages/create/src/in-store/extract-walls.ts
@@ -410,8 +410,246 @@ function computeWallSegment(
     return finaliseSegment(start, end, wallId, log, 'rect-profile');
   }
 
-  log(`wall #${wallId}: no Axis representation and no IfcRectangleProfileDef body — skipping`);
+  // Strategy 3 — body-footprint centreline. For walls with only a meshed
+  // body (IfcTriangulatedFaceSet / IfcPolygonalFaceSet) and no Axis/rect
+  // profile, project the body vertices to the local ground plane (drop the
+  // local vertical Z) and take the principal axis of that footprint as the
+  // wall centreline. Covers tessellated exports that the two shape-specific
+  // strategies miss.
+  const footprint = gatherBodyFootprintPoints(store, extractor, overlay, representationId);
+  if (footprint && footprint.length >= 3) {
+    const centreline = principalAxisCentreline(footprint);
+    if (centreline) {
+      const start = applyFrame(frame, centreline[0]);
+      const end = applyFrame(frame, centreline[1]);
+      return finaliseSegment(start, end, wallId, log, 'body-footprint');
+    }
+  }
+
+  log(`wall #${wallId}: no Axis representation, no IfcRectangleProfileDef body, no meshed footprint — skipping`);
   return { segment: null, reason: 'no-axis-or-rect-profile' };
+}
+
+/**
+ * Gather the wall body's ground-plane footprint points (local frame, raw
+ * units) from a meshed representation. Reads the vertex list of every
+ * `IfcTriangulatedFaceSet` / `IfcPolygonalFaceSet` item in a non-`Axis`
+ * representation and drops the local vertical (Z), which is up in the
+ * wall-local frame before placement. Returns null when there's no mesh body.
+ */
+function gatherBodyFootprintPoints(
+  store: IfcDataStore,
+  extractor: EntityExtractor,
+  overlay: OverlayWallReader | undefined,
+  representationId: number,
+): Vec2[] | null {
+  const productShape = readEntity(store, extractor, overlay, representationId);
+  if (!productShape) return null;
+  const reps = productShape.attributes[2];
+  if (!Array.isArray(reps)) return null;
+
+  const pts: Vec2[] = [];
+  for (const repRef of reps) {
+    const repId = numericAttr(repRef);
+    if (repId === null) continue;
+    const rep = readEntity(store, extractor, overlay, repId);
+    if (!rep) continue;
+    const identifier = stringAttr(rep.attributes[1]);
+    if (identifier && identifier.toLowerCase() === 'axis') continue; // handled by Strategy 1
+    const items = rep.attributes[3];
+    if (!Array.isArray(items)) continue;
+    for (const itemRef of items) {
+      const itemId = numericAttr(itemRef);
+      if (itemId === null) continue;
+      const item = readEntity(store, extractor, overlay, itemId);
+      if (!item) continue;
+      const itemType = resolveEntityTypeName(store, item, itemId);
+      if (itemType === 'ifctriangulatedfaceset' || itemType === 'ifcpolygonalfaceset') {
+        // Vertices live in an IfcCartesianPointList3D at attribute 0; its
+        // attribute 0 is the flat list of [x, y, z] triples (rep frame).
+        const coordId = numericAttr(item.attributes[0]);
+        if (coordId === null) continue;
+        const coordList = readEntity(store, extractor, overlay, coordId);
+        if (!coordList || !Array.isArray(coordList.attributes[0])) continue;
+        for (const p of coordList.attributes[0] as IfcAttributeValue[]) {
+          const v = readVec3(p);
+          if (v) pts.push([v[0], v[1]]);
+        }
+      } else if (itemType === 'ifcextrudedareasolid') {
+        gatherExtrudedFootprint(store, extractor, overlay, item, pts);
+      } else if (itemType === 'ifcfacetedbrep') {
+        gatherBrepFootprint(store, extractor, overlay, item, pts);
+      }
+    }
+  }
+  return pts.length >= 3 ? pts : null;
+}
+
+/** 2D affine frame (XY of an IfcAxis2Placement2D/3D). */
+interface Frame2 { o: Vec2; x: Vec2; y: Vec2 }
+const IDENTITY2: Frame2 = { o: [0, 0], x: [1, 0], y: [0, 1] };
+const apply2 = (f: Frame2, p: Vec2): Vec2 => [
+  f.o[0] + f.x[0] * p[0] + f.y[0] * p[1],
+  f.o[1] + f.x[1] * p[0] + f.y[1] * p[1],
+];
+
+/** Read an IfcAxis2Placement2D/3D into its XY affine frame (Z ignored). */
+function readPlacement2(
+  store: IfcDataStore, extractor: EntityExtractor, overlay: OverlayWallReader | undefined, ref: unknown,
+): Frame2 {
+  const id = numericAttr(ref as IfcAttributeValue);
+  if (id === null) return IDENTITY2;
+  const ent = readEntity(store, extractor, overlay, id);
+  if (!ent) return IDENTITY2;
+  const o = readCartesianPoint2D(store, extractor, overlay, ent.attributes[0]) ?? [0, 0];
+  // RefDirection: attr 1 on the 2D placement, attr 2 on the 3D placement.
+  const is3d = resolveEntityTypeName(store, ent, id) === 'ifcaxis2placement3d';
+  const refDir = readCartesianPoint2D(store, extractor, overlay, ent.attributes[is3d ? 2 : 1]);
+  let xx = 1, xy = 0;
+  if (refDir) { const l = Math.hypot(refDir[0], refDir[1]) || 1; xx = refDir[0] / l; xy = refDir[1] / l; }
+  return { o, x: [xx, xy], y: [-xy, xx] };
+}
+
+/**
+ * Footprint of a vertically-extruded solid = its swept profile placed into the
+ * rep frame. Handles rectangle and arbitrary-(polyline-)closed profiles; skips
+ * non-vertical extrusions (the profile wouldn't be a plan footprint then).
+ */
+function gatherExtrudedFootprint(
+  store: IfcDataStore, extractor: EntityExtractor, overlay: OverlayWallReader | undefined,
+  solid: { type?: string; attributes: IfcAttributeValue[] }, out: Vec2[],
+): void {
+  // IfcExtrudedAreaSolid = SweptArea(0), Position(1), ExtrudedDirection(2), Depth(3).
+  // The swept profile is a *plan* footprint only when the extrusion ends up
+  // world-vertical: ExtrudedDirection must be the solid's local Z AND the
+  // solid's Position must keep that Z world-up. Multi-layer walls (e.g. #218)
+  // extrude along their thickness via a Position rotated to a horizontal axis —
+  // their profile is an elevation, not a footprint, so skip rather than emit a
+  // bogus centreline.
+  const dirId = numericAttr(solid.attributes[2]);
+  if (dirId !== null) {
+    const d = readVec3(readEntity(store, extractor, overlay, dirId)?.attributes[0]);
+    if (d && Math.abs(d[2]) < 0.9) return;
+  }
+  const posId = numericAttr(solid.attributes[1]);
+  if (posId !== null) {
+    const posEnt = readEntity(store, extractor, overlay, posId);
+    const axisId = posEnt ? numericAttr(posEnt.attributes[1]) : null;
+    if (axisId !== null) {
+      const az = readVec3(readEntity(store, extractor, overlay, axisId)?.attributes[0]);
+      if (az && Math.abs(az[2]) < 0.9) return; // solid's local Z isn't world-up
+    }
+  }
+  const solidPos = readPlacement2(store, extractor, overlay, solid.attributes[1]);
+  const profileId = numericAttr(solid.attributes[0]);
+  if (profileId === null) return;
+  const profile = readEntity(store, extractor, overlay, profileId);
+  if (!profile) return;
+  const ptype = resolveEntityTypeName(store, profile, profileId);
+  if (ptype === 'ifcrectangleprofiledef') {
+    const ppos = readPlacement2(store, extractor, overlay, profile.attributes[2]);
+    const xd = numericAttr(profile.attributes[3]) ?? 0;
+    const yd = numericAttr(profile.attributes[4]) ?? 0;
+    if (xd <= 0 || yd <= 0) return;
+    const corners: Vec2[] = [[-xd / 2, -yd / 2], [xd / 2, -yd / 2], [xd / 2, yd / 2], [-xd / 2, yd / 2]];
+    for (const c of corners) out.push(apply2(solidPos, apply2(ppos, c)));
+  } else if (ptype === 'ifcarbitraryclosedprofiledef' || ptype === 'ifcarbitraryprofiledefwithvoids') {
+    // OuterCurve at attr 2 for both; read its points as the footprint cloud
+    // (PCA only needs the cloud, not edge order). Polyline or IndexedPolyCurve.
+    const ocId = numericAttr(profile.attributes[2]);
+    if (ocId === null) return;
+    const oc = readEntity(store, extractor, overlay, ocId);
+    if (!oc) return;
+    const octype = resolveEntityTypeName(store, oc, ocId);
+    if (octype === 'ifcpolyline' && Array.isArray(oc.attributes[0])) {
+      for (const ptRef of oc.attributes[0]) {
+        const v = readCartesianPoint2D(store, extractor, overlay, ptRef);
+        if (v) out.push(apply2(solidPos, v));
+      }
+    } else if (octype === 'ifcindexedpolycurve') {
+      // IfcIndexedPolyCurve.Points → IfcCartesianPointList2D (flat [x,y] list).
+      const listId = numericAttr(oc.attributes[0]);
+      if (listId === null) return;
+      const list = readEntity(store, extractor, overlay, listId);
+      if (!list || !Array.isArray(list.attributes[0])) return;
+      for (const p of list.attributes[0] as IfcAttributeValue[]) {
+        const v = readVec3(p);
+        if (v) out.push(apply2(solidPos, [v[0], v[1]]));
+      }
+    }
+  }
+}
+
+/**
+ * Footprint of an IfcFacetedBrep = all its shell vertices projected to XY.
+ * Walks Outer (IfcClosedShell) → faces → bounds → IfcPolyLoop → points. The
+ * vertices are already in the rep frame, so no extra placement is needed.
+ */
+function gatherBrepFootprint(
+  store: IfcDataStore, extractor: EntityExtractor, overlay: OverlayWallReader | undefined,
+  brep: { type?: string; attributes: IfcAttributeValue[] }, out: Vec2[],
+): void {
+  const shellId = numericAttr(brep.attributes[0]);
+  if (shellId === null) return;
+  const shell = readEntity(store, extractor, overlay, shellId);
+  if (!shell || !Array.isArray(shell.attributes[0])) return;
+  for (const faceRef of shell.attributes[0]) {
+    const faceId = numericAttr(faceRef);
+    if (faceId === null) continue;
+    const face = readEntity(store, extractor, overlay, faceId);
+    if (!face || !Array.isArray(face.attributes[0])) continue;
+    for (const boundRef of face.attributes[0]) {
+      const boundId = numericAttr(boundRef);
+      if (boundId === null) continue;
+      const bound = readEntity(store, extractor, overlay, boundId);
+      if (!bound) continue;
+      const loopId = numericAttr(bound.attributes[0]);
+      if (loopId === null) continue;
+      const loop = readEntity(store, extractor, overlay, loopId);
+      if (!loop || !Array.isArray(loop.attributes[0])) continue;
+      for (const ptRef of loop.attributes[0]) {
+        const v = readCartesianPoint2D(store, extractor, overlay, ptRef);
+        if (v) out.push(v);
+      }
+    }
+  }
+}
+
+/**
+ * Principal-axis centreline of a 2D point cloud (PCA). A wall footprint is a
+ * thin elongated rectangle, so the largest-eigenvalue direction is the wall's
+ * length and the centroid sits on the centreline — exactly the axis we want.
+ * Returns the centroid-anchored segment spanning the footprint's extent along
+ * that axis, or null if it collapses to a point.
+ */
+function principalAxisCentreline(points: Vec2[]): [Vec2, Vec2] | null {
+  const n = points.length;
+  let cx = 0, cy = 0;
+  for (const [x, y] of points) { cx += x; cy += y; }
+  cx /= n; cy /= n;
+
+  let sxx = 0, sxy = 0, syy = 0;
+  for (const [x, y] of points) {
+    const dx = x - cx, dy = y - cy;
+    sxx += dx * dx; sxy += dx * dy; syy += dy * dy;
+  }
+  const tr = sxx + syy;
+  const disc = Math.sqrt(Math.max(0, (tr * tr) / 4 - (sxx * syy - sxy * sxy)));
+  const lambda = tr / 2 + disc; // largest eigenvalue
+  let ex = sxy, ey = lambda - sxx;
+  if (Math.hypot(ex, ey) < 1e-12) { ex = lambda - syy; ey = sxy; }
+  const elen = Math.hypot(ex, ey);
+  if (elen < 1e-12) return null;
+  ex /= elen; ey /= elen;
+
+  let tmin = Infinity, tmax = -Infinity;
+  for (const [x, y] of points) {
+    const t = (x - cx) * ex + (y - cy) * ey;
+    if (t < tmin) tmin = t;
+    if (t > tmax) tmax = t;
+  }
+  if (tmax - tmin < AXIS_EPS) return null;
+  return [[cx + ex * tmin, cy + ey * tmin], [cx + ex * tmax, cy + ey * tmax]];
 }
 
 function finaliseSegment(start: Vec2, end: Vec2, wallId: number, log: Logger, source: string): ExtractAttempt {
@@ -513,7 +751,7 @@ function readAxisRepresentationEndpoints(
       if (itemId === null) continue;
       const item = readEntity(store, extractor, overlay, itemId);
       if (!item) continue;
-      const itemType = (store.entities.getTypeName(itemId) || item.type || '').toLowerCase();
+      const itemType = resolveEntityTypeName(store, item, itemId);
       if (itemType !== 'ifcpolyline') continue;
       // IfcPolyline.Points = list of IfcCartesianPoint refs (attribute 0).
       const pointsRefs = item.attributes[0];
@@ -571,7 +809,7 @@ function readWallLength(
       if (profileId === null) continue;
       const profile = readEntity(store, extractor, overlay, profileId);
       if (!profile) continue;
-      const profileType = profileTypeName(store, profile, profileId);
+      const profileType = resolveEntityTypeName(store, profile, profileId);
       if (profileType !== 'ifcrectangleprofiledef') continue;
       // IfcRectangleProfileDef.XDim = attribute index 3.
       const xdim = numericAttr(profile.attributes[3]);
@@ -581,13 +819,22 @@ function readWallLength(
   return null;
 }
 
-function profileTypeName(
+/**
+ * Robust IFC type-name for an entity read from source. The columnar entity
+ * table only indexes products/named entities, so `getTypeName` returns
+ * `'Unknown'` for geometry primitives (IfcPolyline, IfcCartesianPoint,
+ * profiles, solids). The extractor's `entity.type` is always reliable — so
+ * prefer the table only when it actually resolved, otherwise fall back to the
+ * extractor type. (Reading the table's `'Unknown'` literally was what made
+ * every `Curve2D` Axis polyline — e.g. all of AC20-FZK-Haus — get skipped.)
+ */
+export function resolveEntityTypeName(
   store: IfcDataStore,
-  profile: { type?: string },
-  profileId: number,
+  entity: { type?: string },
+  entityId: number,
 ): string {
-  const fromTable = store.entities.getTypeName(profileId);
-  const name = (fromTable && fromTable !== 'Unknown' ? fromTable : profile.type) ?? '';
+  const fromTable = store.entities.getTypeName(entityId);
+  const name = (fromTable && fromTable !== 'Unknown' ? fromTable : entity.type) ?? '';
   return name.toLowerCase();
 }
 

--- a/packages/create/src/in-store/extract-walls.ts
+++ b/packages/create/src/in-store/extract-walls.ts
@@ -33,6 +33,7 @@
 import {
   EntityExtractor,
   extractLengthUnitScale,
+  extractMaterialsOnDemand,
   type IfcDataStore,
   type IfcAttributeValue,
 } from '@ifc-lite/parser';
@@ -69,6 +70,13 @@ export interface WallExtractionResult {
   segments: Segment[];
   /** Wall expressIds that contributed an axis segment. */
   contributingWallIds: number[];
+  /**
+   * Per-segment wall thickness in metres (parallel to `segments` /
+   * `contributingWallIds`), from the wall's material layer set; `undefined`
+   * when the wall carries no resolvable layer thickness. Used to inset the
+   * centreline footprint to a net (inner-face) area.
+   */
+  wallThicknesses: (number | undefined)[];
   /** Walls dropped by the extractor, with the reason. */
   skipped: WallSkip[];
   /** Best-effort total wall count visible on the storey (existing + overlay). */
@@ -125,6 +133,7 @@ export function extractWallSegmentsForStorey(
 ): WallExtractionResult {
   const segments: Segment[] = [];
   const contributing: number[] = [];
+  const wallThicknesses: (number | undefined)[] = [];
   const skipped: WallSkip[] = [];
   const debug = !!options.debug;
   const log = debug ? (...args: unknown[]) => console.debug('[extract-walls]', ...args) : () => {};
@@ -146,7 +155,7 @@ export function extractWallSegmentsForStorey(
 
   if (!store.source) {
     log('no source bytes on data store — extraction cannot run');
-    return { segments, contributingWallIds: contributing, skipped, considered: 0, lengthUnitScale };
+    return { segments, contributingWallIds: contributing, wallThicknesses, skipped, considered: 0, lengthUnitScale };
   }
 
   const dividerTypes = new Set(DEFAULT_DIVIDER_TYPES);
@@ -163,6 +172,7 @@ export function extractWallSegmentsForStorey(
     if (result.segment) {
       segments.push(scaleSegment(result.segment, lengthUnitScale));
       contributing.push(id);
+      wallThicknesses.push(wallThicknessFromMaterial(store, id));
     } else {
       skipped.push({ wallId: id, reason: result.reason ?? 'no-axis-or-rect-profile' });
     }
@@ -179,6 +189,7 @@ export function extractWallSegmentsForStorey(
         // metre coords — don't double-scale.
         segments.push(result.segment);
         contributing.push(ent.expressId);
+        wallThicknesses.push(undefined); // overlay walls carry no material yet
       } else {
         skipped.push({ wallId: ent.expressId, reason: result.reason ?? 'no-axis-or-rect-profile' });
       }
@@ -201,10 +212,25 @@ export function extractWallSegmentsForStorey(
   return {
     segments,
     contributingWallIds: contributing,
+    wallThicknesses,
     skipped,
     considered: dividerIds.length + overlayCount,
     lengthUnitScale,
   };
+}
+
+/**
+ * Total thickness (metres) of a wall's material layer set, or `undefined` when
+ * the wall has no resolvable layers. The material resolver already scales layer
+ * thicknesses to metres, so no further unit conversion is applied.
+ */
+function wallThicknessFromMaterial(store: IfcDataStore, wallId: number): number | undefined {
+  const info = extractMaterialsOnDemand(store, wallId);
+  const layers = info?.layers;
+  if (!layers || layers.length === 0) return undefined;
+  let total = 0;
+  for (const layer of layers) total += layer.thickness ?? 0;
+  return total > 0 ? total : undefined;
 }
 
 function scaleSegment(seg: Segment, scale: number): Segment {

--- a/packages/create/src/in-store/generate-spaces-all.ts
+++ b/packages/create/src/in-store/generate-spaces-all.ts
@@ -1,0 +1,175 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * High-level orchestrator over {@link generateSpacesFromWalls}: derive
+ * `IfcSpace` across one, several, or all storeys in a model, with
+ * auto-escalating snap tolerance and storey-aware heights. This is the engine
+ * the CLI (`ifc-lite generate-spaces`) and SDK (`bim.spaces.generate`) share.
+ *
+ * Footprint comes from the storey's walls (+ other dividers); the vertical
+ * extent ("from slabs/roofs") is taken from the storey datums — storeys sit at
+ * slab levels, so `height: 'auto'` uses floor-to-floor from `storeyElevations`,
+ * and the topmost storey (capped by the roof) falls back to `topStoreyHeight`.
+ * Geometry-exact slab/roof undersides are a future refinement.
+ */
+
+import type { IfcDataStore } from '@ifc-lite/parser';
+import type { StoreEditor } from '@ifc-lite/mutations';
+import {
+  generateSpacesFromWalls,
+  type GenerateSpacesOptions,
+  type GenerateSpacesResult,
+} from './generate-spaces.js';
+import type { OverlayWallReader } from './extract-walls.js';
+
+/** Snap tolerances tried, in order, when `snap: 'auto'`. First that encloses
+ *  rooms wins (least over-merging); else the largest is used. */
+const AUTO_SNAP_LADDER = [0.1, 0.25, 0.5] as const;
+const DEFAULT_TOP_HEIGHT = 3;
+
+export interface GenerateSpacesAllOptions {
+  /** Which storeys: `'all'` (default) or specific express ids. */
+  storeys?: 'all' | number[];
+  /** Corner-closing tolerance (m), or `'auto'` (default) to escalate the ladder. */
+  snap?: number | 'auto';
+  /** Drop regions below this area (m²). Default 0.5. */
+  minArea?: number;
+  /** Space height (m), or `'auto'` (default) = floor-to-floor from storey elevations. */
+  height?: number | 'auto';
+  /** Height for the topmost storey under `'auto'` (no storey above). Default 3. */
+  topStoreyHeight?: number;
+  /** Name pattern; `{n}` → 1-based index per storey, `{storey}` → storey name. */
+  namePattern?: string;
+  /** IfcSpacePredefinedType (default INTERNAL). */
+  predefinedType?: string;
+  /** Extra divider element types (case-insensitive) beyond the defaults. */
+  extraDividerTypes?: string[];
+  /** Detect + report only; emit no IfcSpace. */
+  dryRun?: boolean;
+  debug?: boolean;
+}
+
+export interface StoreyInfo {
+  id: number;
+  name: string;
+  elevation: number;
+}
+
+export interface GenerateSpacesStoreyResult extends StoreyInfo {
+  /** Height used for this storey's spaces (m). */
+  height: number;
+  /** Snap tolerance used (m) — the resolved value when `snap: 'auto'`. */
+  snapUsed: number;
+  result: GenerateSpacesResult;
+}
+
+export interface GenerateSpacesAllResult {
+  storeys: GenerateSpacesStoreyResult[];
+  totalDetected: number;
+  totalEmitted: number;
+}
+
+/** Every IfcBuildingStorey with resolved name + elevation, low → high. */
+export function listStoreys(store: IfcDataStore): StoreyInfo[] {
+  const elevs = store.spatialHierarchy?.storeyElevations;
+  const list = store.getEntitiesByType('IfcBuildingStorey').map((s) => ({
+    id: s.expressId,
+    name: store.entities.getName(s.expressId) || `Storey #${s.expressId}`,
+    elevation: elevs?.get(s.expressId) ?? 0,
+  }));
+  list.sort((a, b) => a.elevation - b.elevation);
+  return list;
+}
+
+export function generateSpaces(
+  editor: StoreEditor,
+  store: IfcDataStore,
+  options: GenerateSpacesAllOptions = {},
+  overlay?: OverlayWallReader,
+): GenerateSpacesAllResult {
+  const all = listStoreys(store);
+  const want = options.storeys;
+  const selected = want === undefined || want === 'all'
+    ? all
+    : all.filter((s) => want.includes(s.id));
+
+  const minArea = options.minArea ?? 0.5;
+  const topH = options.topStoreyHeight ?? DEFAULT_TOP_HEIGHT;
+  const snapMode = options.snap ?? 'auto';
+  const heightMode = options.height ?? 'auto';
+
+  const storeys: GenerateSpacesStoreyResult[] = [];
+  let totalDetected = 0;
+  let totalEmitted = 0;
+
+  for (const st of selected) {
+    const height = resolveHeight(heightMode, st, all, topH);
+    const snapUsed = resolveSnap(snapMode, editor, store, st.id, minArea, overlay);
+
+    const namePattern = (options.namePattern ?? 'Space {n}').replaceAll('{storey}', st.name);
+    const result = generateSpacesFromWalls(
+      editor,
+      store,
+      st.id,
+      {
+        snapTolerance: snapUsed,
+        minArea,
+        height,
+        namePattern,
+        predefinedType: options.predefinedType,
+        extraDividerTypes: options.extraDividerTypes,
+        dryRun: options.dryRun,
+        debug: options.debug,
+      } satisfies GenerateSpacesOptions,
+      overlay,
+    );
+
+    totalDetected += result.detected.length;
+    totalEmitted += result.emitted.length;
+    storeys.push({ ...st, height, snapUsed, result });
+  }
+
+  return { storeys, totalDetected, totalEmitted };
+}
+
+function resolveHeight(
+  mode: number | 'auto',
+  st: StoreyInfo,
+  all: StoreyInfo[],
+  topH: number,
+): number {
+  if (typeof mode === 'number') return mode > 0 ? mode : topH;
+  const idx = all.findIndex((s) => s.id === st.id);
+  const next = idx >= 0 ? all[idx + 1] : undefined;
+  const h = next ? next.elevation - st.elevation : topH;
+  // Guard against bad/degenerate elevation data.
+  return h > 0.1 && h < 50 ? h : topH;
+}
+
+function resolveSnap(
+  mode: number | 'auto',
+  editor: StoreEditor,
+  store: IfcDataStore,
+  storeyId: number,
+  minArea: number,
+  overlay?: OverlayWallReader,
+): number {
+  if (typeof mode === 'number') return mode;
+  // Escalate via dry runs (no emission) and take the first tolerance that
+  // encloses any room; else the largest tried.
+  let used: number = AUTO_SNAP_LADDER[0];
+  for (const tol of AUTO_SNAP_LADDER) {
+    used = tol;
+    const dry = generateSpacesFromWalls(
+      editor,
+      store,
+      storeyId,
+      { snapTolerance: tol, minArea, dryRun: true },
+      overlay,
+    );
+    if (dry.detected.length > 0) break;
+  }
+  return used;
+}

--- a/packages/create/src/in-store/generate-spaces-all.ts
+++ b/packages/create/src/in-store/generate-spaces-all.ts
@@ -15,15 +15,14 @@
  * Geometry-exact slab/roof undersides are a future refinement.
  */
 
-import { EntityExtractor, type IfcDataStore } from '@ifc-lite/parser';
+import type { IfcDataStore } from '@ifc-lite/parser';
 import type { StoreEditor } from '@ifc-lite/mutations';
 import {
   generateSpacesFromWalls,
-  GENERATED_SPACE_OBJECTTYPE,
   type GenerateSpacesOptions,
   type GenerateSpacesResult,
 } from './generate-spaces.js';
-import type { OverlayWallReader } from './extract-walls.js';
+import { spaceCountByStorey, type OverlayWallReader } from './extract-walls.js';
 
 /** Snap tolerances tried, in order, when `snap: 'auto'`. First that encloses
  *  rooms wins (least over-merging); else the largest is used. */
@@ -72,31 +71,23 @@ export interface GenerateSpacesStoreyResult extends StoreyInfo {
   result: GenerateSpacesResult;
 }
 
+export interface GenerateSpacesStoreySkip extends StoreyInfo {
+  /** Existing IfcSpace already on the storey (why it was skipped). */
+  existingSpaces: number;
+}
+
 export interface GenerateSpacesAllResult {
   storeys: GenerateSpacesStoreyResult[];
   totalDetected: number;
   totalEmitted: number;
   /**
-   * Number of pre-existing generated spaces found in the model. When > 0 and
-   * `force` is not set, the run was skipped (idempotency) — nothing emitted.
+   * Storeys skipped because they already contain IfcSpace (authored or from a
+   * prior run) — generation there would duplicate/overlap them. Empty when
+   * `force` is set. Sum of their `existingSpaces` is the total skipped.
    */
+  skippedStoreys: GenerateSpacesStoreySkip[];
+  /** Total existing spaces across skipped storeys. */
   skippedExisting: number;
-}
-
-/** Count IfcSpace already stamped with the generated-space marker (a prior run). */
-function countGeneratedSpaces(store: IfcDataStore): number {
-  if (!store.source) return 0;
-  const ids = store.entityIndex?.byType?.get('IFCSPACE');
-  if (!ids || ids.length === 0) return 0;
-  const extractor = new EntityExtractor(store.source);
-  let count = 0;
-  for (const id of ids) {
-    const ref = store.entityIndex.byId.get(id);
-    if (!ref) continue;
-    // IfcSpace.ObjectType is positional attribute index 4.
-    if (extractor.extractEntity(ref)?.attributes?.[4] === GENERATED_SPACE_OBJECTTYPE) count++;
-  }
-  return count;
 }
 
 /** Every IfcBuildingStorey with resolved name + elevation, low → high. */
@@ -117,18 +108,29 @@ export function generateSpaces(
   options: GenerateSpacesAllOptions = {},
   overlay?: OverlayWallReader,
 ): GenerateSpacesAllResult {
-  // Idempotency: if the model already carries spaces from a prior run, skip
-  // (unless forced) so re-processing our own output can't duplicate them.
-  const skippedExisting = options.force || options.dryRun ? 0 : countGeneratedSpaces(store);
-  if (skippedExisting > 0) {
-    return { storeys: [], totalDetected: 0, totalEmitted: 0, skippedExisting };
-  }
-
   const all = listStoreys(store);
   const want = options.storeys;
-  const selected = want === undefined || want === 'all'
+  let selected = want === undefined || want === 'all'
     ? all
     : all.filter((s) => want.includes(s.id));
+
+  // Skip storeys that already contain IfcSpace (authored or from a prior run)
+  // so we don't create duplicates overlapping them — unless `force` or a
+  // detect-only dry run. Per-storey, so empty floors still generate.
+  const skippedStoreys: GenerateSpacesStoreySkip[] = [];
+  if (!options.force && !options.dryRun) {
+    const existing = spaceCountByStorey(store);
+    if (existing.size > 0) {
+      selected = selected.filter((s) => {
+        const n = existing.get(s.id);
+        if (n) {
+          skippedStoreys.push({ ...s, existingSpaces: n });
+          return false;
+        }
+        return true;
+      });
+    }
+  }
 
   const minArea = options.minArea ?? 0.5;
   const topH = options.topStoreyHeight ?? DEFAULT_TOP_HEIGHT;
@@ -166,7 +168,13 @@ export function generateSpaces(
     storeys.push({ ...st, height, snapUsed, result });
   }
 
-  return { storeys, totalDetected, totalEmitted, skippedExisting: 0 };
+  return {
+    storeys,
+    totalDetected,
+    totalEmitted,
+    skippedStoreys,
+    skippedExisting: skippedStoreys.reduce((s, x) => s + x.existingSpaces, 0),
+  };
 }
 
 function resolveHeight(

--- a/packages/create/src/in-store/generate-spaces-all.ts
+++ b/packages/create/src/in-store/generate-spaces-all.ts
@@ -22,7 +22,7 @@ import {
   type GenerateSpacesOptions,
   type GenerateSpacesResult,
 } from './generate-spaces.js';
-import { spaceCountByStorey, type OverlayWallReader } from './extract-walls.js';
+import { existingSpaceFootprintsByStorey, type OverlayWallReader } from './extract-walls.js';
 
 /** Snap tolerances tried, in order, when `snap: 'auto'`. First that encloses
  *  rooms wins (least over-merging); else the largest is used. */
@@ -71,22 +71,15 @@ export interface GenerateSpacesStoreyResult extends StoreyInfo {
   result: GenerateSpacesResult;
 }
 
-export interface GenerateSpacesStoreySkip extends StoreyInfo {
-  /** Existing IfcSpace already on the storey (why it was skipped). */
-  existingSpaces: number;
-}
-
 export interface GenerateSpacesAllResult {
   storeys: GenerateSpacesStoreyResult[];
   totalDetected: number;
   totalEmitted: number;
   /**
-   * Storeys skipped because they already contain IfcSpace (authored or from a
-   * prior run) — generation there would duplicate/overlap them. Empty when
-   * `force` is set. Sum of their `existingSpaces` is the total skipped.
+   * Detected rooms skipped because they overlap an existing space (authored or
+   * from a prior run) — per-space, so non-overlapping rooms on the same storey
+   * are still emitted. Always 0 when `force` is set.
    */
-  skippedStoreys: GenerateSpacesStoreySkip[];
-  /** Total existing spaces across skipped storeys. */
   skippedExisting: number;
 }
 
@@ -110,27 +103,13 @@ export function generateSpaces(
 ): GenerateSpacesAllResult {
   const all = listStoreys(store);
   const want = options.storeys;
-  let selected = want === undefined || want === 'all'
+  const selected = want === undefined || want === 'all'
     ? all
     : all.filter((s) => want.includes(s.id));
 
-  // Skip storeys that already contain IfcSpace (authored or from a prior run)
-  // so we don't create duplicates overlapping them — unless `force` or a
-  // detect-only dry run. Per-storey, so empty floors still generate.
-  const skippedStoreys: GenerateSpacesStoreySkip[] = [];
-  if (!options.force && !options.dryRun) {
-    const existing = spaceCountByStorey(store);
-    if (existing.size > 0) {
-      selected = selected.filter((s) => {
-        const n = existing.get(s.id);
-        if (n) {
-          skippedStoreys.push({ ...s, existingSpaces: n });
-          return false;
-        }
-        return true;
-      });
-    }
-  }
+  // Per-space dedup: skip detected rooms that overlap an existing space, while
+  // still emitting non-overlapping rooms on the same storey. `force` opts out.
+  const footprintsByStorey = options.force ? new Map() : existingSpaceFootprintsByStorey(store);
 
   const minArea = options.minArea ?? 0.5;
   const topH = options.topStoreyHeight ?? DEFAULT_TOP_HEIGHT;
@@ -140,6 +119,7 @@ export function generateSpaces(
   const storeys: GenerateSpacesStoreyResult[] = [];
   let totalDetected = 0;
   let totalEmitted = 0;
+  let skippedExisting = 0;
 
   for (const st of selected) {
     const height = resolveHeight(heightMode, st, all, topH);
@@ -159,22 +139,18 @@ export function generateSpaces(
         extraDividerTypes: options.extraDividerTypes,
         dryRun: options.dryRun,
         debug: options.debug,
+        skipFootprints: footprintsByStorey.get(st.id),
       } satisfies GenerateSpacesOptions,
       overlay,
     );
 
     totalDetected += result.detected.length;
     totalEmitted += result.emitted.length;
+    skippedExisting += result.skippedExisting;
     storeys.push({ ...st, height, snapUsed, result });
   }
 
-  return {
-    storeys,
-    totalDetected,
-    totalEmitted,
-    skippedStoreys,
-    skippedExisting: skippedStoreys.reduce((s, x) => s + x.existingSpaces, 0),
-  };
+  return { storeys, totalDetected, totalEmitted, skippedExisting };
 }
 
 function resolveHeight(

--- a/packages/create/src/in-store/generate-spaces-all.ts
+++ b/packages/create/src/in-store/generate-spaces-all.ts
@@ -21,6 +21,7 @@ import {
   generateSpacesFromWalls,
   type GenerateSpacesOptions,
   type GenerateSpacesResult,
+  type BoundaryMode,
 } from './generate-spaces.js';
 import { existingSpaceFootprintsByStorey, type OverlayWallReader } from './extract-walls.js';
 
@@ -46,6 +47,8 @@ export interface GenerateSpacesAllOptions {
   predefinedType?: string;
   /** Extra divider element types (case-insensitive) beyond the defaults. */
   extraDividerTypes?: string[];
+  /** Where the space boundary sits relative to its walls. Default 'inner'. */
+  boundaryMode?: BoundaryMode;
   /** Detect + report only; emit no IfcSpace. */
   dryRun?: boolean;
   /**
@@ -138,6 +141,7 @@ export function generateSpaces(
         predefinedType: options.predefinedType,
         extraDividerTypes: options.extraDividerTypes,
         dryRun: options.dryRun,
+        boundaryMode: options.boundaryMode,
         debug: options.debug,
         skipFootprints: footprintsByStorey.get(st.id),
       } satisfies GenerateSpacesOptions,

--- a/packages/create/src/in-store/generate-spaces-all.ts
+++ b/packages/create/src/in-store/generate-spaces-all.ts
@@ -15,10 +15,11 @@
  * Geometry-exact slab/roof undersides are a future refinement.
  */
 
-import type { IfcDataStore } from '@ifc-lite/parser';
+import { EntityExtractor, type IfcDataStore } from '@ifc-lite/parser';
 import type { StoreEditor } from '@ifc-lite/mutations';
 import {
   generateSpacesFromWalls,
+  GENERATED_SPACE_OBJECTTYPE,
   type GenerateSpacesOptions,
   type GenerateSpacesResult,
 } from './generate-spaces.js';
@@ -48,6 +49,12 @@ export interface GenerateSpacesAllOptions {
   extraDividerTypes?: string[];
   /** Detect + report only; emit no IfcSpace. */
   dryRun?: boolean;
+  /**
+   * Re-derive even when the model already contains spaces from a prior run.
+   * Off by default — the run is skipped so re-processing its own output can't
+   * duplicate spaces. `true` bypasses the guard (may duplicate).
+   */
+  force?: boolean;
   debug?: boolean;
 }
 
@@ -69,6 +76,27 @@ export interface GenerateSpacesAllResult {
   storeys: GenerateSpacesStoreyResult[];
   totalDetected: number;
   totalEmitted: number;
+  /**
+   * Number of pre-existing generated spaces found in the model. When > 0 and
+   * `force` is not set, the run was skipped (idempotency) — nothing emitted.
+   */
+  skippedExisting: number;
+}
+
+/** Count IfcSpace already stamped with the generated-space marker (a prior run). */
+function countGeneratedSpaces(store: IfcDataStore): number {
+  if (!store.source) return 0;
+  const ids = store.entityIndex?.byType?.get('IFCSPACE');
+  if (!ids || ids.length === 0) return 0;
+  const extractor = new EntityExtractor(store.source);
+  let count = 0;
+  for (const id of ids) {
+    const ref = store.entityIndex.byId.get(id);
+    if (!ref) continue;
+    // IfcSpace.ObjectType is positional attribute index 4.
+    if (extractor.extractEntity(ref)?.attributes?.[4] === GENERATED_SPACE_OBJECTTYPE) count++;
+  }
+  return count;
 }
 
 /** Every IfcBuildingStorey with resolved name + elevation, low → high. */
@@ -89,6 +117,13 @@ export function generateSpaces(
   options: GenerateSpacesAllOptions = {},
   overlay?: OverlayWallReader,
 ): GenerateSpacesAllResult {
+  // Idempotency: if the model already carries spaces from a prior run, skip
+  // (unless forced) so re-processing our own output can't duplicate them.
+  const skippedExisting = options.force || options.dryRun ? 0 : countGeneratedSpaces(store);
+  if (skippedExisting > 0) {
+    return { storeys: [], totalDetected: 0, totalEmitted: 0, skippedExisting };
+  }
+
   const all = listStoreys(store);
   const want = options.storeys;
   const selected = want === undefined || want === 'all'
@@ -131,7 +166,7 @@ export function generateSpaces(
     storeys.push({ ...st, height, snapUsed, result });
   }
 
-  return { storeys, totalDetected, totalEmitted };
+  return { storeys, totalDetected, totalEmitted, skippedExisting: 0 };
 }
 
 function resolveHeight(

--- a/packages/create/src/in-store/generate-spaces.ts
+++ b/packages/create/src/in-store/generate-spaces.ts
@@ -32,6 +32,13 @@ import {
 } from './auto-space-detect.js';
 import { addSpaceToStore, type SpaceBuildResult } from './space.js';
 
+/**
+ * IfcSpace.ObjectType marker stamped on every derived space, so a re-run can
+ * recognise its own output and skip it instead of duplicating (idempotency),
+ * and so generated spaces are filterable downstream.
+ */
+export const GENERATED_SPACE_OBJECTTYPE = 'IfcLite:GeneratedSpace';
+
 export interface GenerateSpacesOptions {
   /** Snap tolerance for wall-end vertex merge in METRES. Default 0.1 m. */
   snapTolerance?: number;
@@ -151,6 +158,7 @@ export function generateSpacesFromWalls(
       OuterCurve: region.outline,
       Height: height,
       Name: name,
+      ObjectType: GENERATED_SPACE_OBJECTTYPE,
       LongName: options.longName,
       PredefinedType: options.predefinedType,
       boundaryElementIds: matchBoundaryWalls(

--- a/packages/create/src/in-store/generate-spaces.ts
+++ b/packages/create/src/in-store/generate-spaces.ts
@@ -185,7 +185,7 @@ export function generateSpacesFromWalls(
     // Bake the solid at the inner (net) face — IfcSpace should stop at the room
     // side of the walls, not run to their centreline. GrossFloorArea keeps the
     // centreline measure; NetFloorArea falls out of the inset OuterCurve.
-    const netOutline = offsetRoomFootprint(region.outline, extraction.segments, extraction.wallThicknesses, options.boundaryMode ?? 'inner');
+    const netOutline = offsetRoomFootprint(region.outline, extraction.segments, extraction.wallThicknesses, options.boundaryMode ?? 'inner', others);
     const result = addSpaceToStore(editor, anchor, {
       Profile: 'polygon',
       OuterCurve: netOutline,
@@ -260,28 +260,52 @@ function edgeRunsAlong(a: Vec2, b: Vec2, seg: Segment): boolean {
 /** How a space boundary relates to its bounding walls. */
 export type BoundaryMode = 'center' | 'inner' | 'outer';
 
+/** Drop vertices whose two adjacent edges are collinear (e.g. a T-junction
+ *  point left on a straight wall run). Such a vertex makes its two adjacent
+ *  offset lines parallel, so they don't intersect — the offset then falls back
+ *  to the un-offset centreline point and the corner skews. */
+function simplifyCollinear(pts: Vec2[]): Vec2[] {
+  const n = pts.length;
+  if (n < 4) return pts;
+  const out: Vec2[] = [];
+  for (let i = 0; i < n; i++) {
+    const p = pts[(i - 1 + n) % n], c = pts[i], q = pts[(i + 1) % n];
+    let ax = c[0] - p[0], ay = c[1] - p[1];
+    let bx = q[0] - c[0], by = q[1] - c[1];
+    const al = Math.hypot(ax, ay) || 1, bl = Math.hypot(bx, by) || 1;
+    ax /= al; ay /= al; bx /= bl; by /= bl;
+    if (Math.abs(ax * by - ay * bx) > 1e-4) out.push(c); // keep real corners only
+  }
+  return out.length >= 3 ? out : pts;
+}
+
 /**
  * Offset a (centreline) room outline to the chosen wall boundary: `center` =
  * the centreline as-is; `inner` = each edge shifted toward the room by half the
  * wall thickness (net / inner face); `outer` = shifted away by half (gross /
  * outer face). Re-corners by intersecting adjacent offset edges. `segments[k]`
- * has thickness `wallThicknesses[k]`. Returns the original outline if the
- * offset degenerates (e.g. an inner inset of a room thinner than its walls).
- * Exact for orthogonal rooms; a close approximation at non-right corners.
+ * has thickness `wallThicknesses[k]`. `otherRooms` (other rooms' centreline
+ * outlines) lets `outer` keep shared/internal edges on the centreline so
+ * neighbouring rooms meet there instead of overlapping inside the wall.
+ * Returns the original outline if the offset degenerates (e.g. an inner inset
+ * of a room thinner than its walls). Exact for orthogonal rooms.
  */
 export function offsetRoomFootprint(
   outline: Vec2[],
   segments: Segment[],
   wallThicknesses: ReadonlyArray<number | undefined>,
   mode: BoundaryMode = 'inner',
+  otherRooms: Vec2[][] = [],
 ): Vec2[] {
-  const n = outline.length;
-  if (mode === 'center' || n < 3) return outline;
+  if (mode === 'center') return outline;
+  const simple = simplifyCollinear(outline);
+  const n = simple.length;
+  if (n < 3) return outline;
   const sign = mode === 'inner' ? 1 : -1; // inner → inward, outer → outward
   const lines: { p: Vec2; d: Vec2 }[] = [];
   for (let i = 0; i < n; i++) {
-    const a = outline[i];
-    const b = outline[(i + 1) % n];
+    const a = simple[i];
+    const b = simple[(i + 1) % n];
     let dx = b[0] - a[0];
     let dy = b[1] - a[1];
     const l = Math.hypot(dx, dy);
@@ -292,7 +316,15 @@ export function offsetRoomFootprint(
       const t = wallThicknesses[k];
       if (t !== undefined && t / 2 > half && edgeRunsAlong(a, b, segments[k])) half = t / 2;
     }
-    const off = sign * half;
+    let off = sign * half;
+    // A shared (internal) edge has another room on its OUTWARD side. Pushing it
+    // outward (outer mode) would overlap that room, so pin shared edges to the
+    // centreline; only edges facing outside the building actually push out.
+    if (mode === 'outer' && half > 0 && otherRooms.length) {
+      const mx = (a[0] + b[0]) / 2 + dy * 0.1; // outward = right normal (dy, -dx)
+      const my = (a[1] + b[1]) / 2 - dx * 0.1;
+      if (otherRooms.some((poly) => pointInPolygon(mx, my, poly))) off = 0;
+    }
     // Inward normal of a CCW outline is to the left of a→b: (-dy, dx).
     lines.push({ p: [a[0] - dy * off, a[1] + dx * off], d: [dx, dy] });
   }
@@ -300,14 +332,13 @@ export function offsetRoomFootprint(
   for (let i = 0; i < n; i++) {
     const prev = lines[(i - 1 + n) % n];
     const cur = lines[i];
-    verts.push(lineIntersect(prev.p, prev.d, cur.p, cur.d) ?? outline[i]);
+    verts.push(lineIntersect(prev.p, prev.d, cur.p, cur.d) ?? simple[i]);
   }
   if (!verts.every((v) => Number.isFinite(v[0]) && Number.isFinite(v[1]))) return outline;
-  const gross = polygonArea(outline);
+  const gross = polygonArea(simple);
   const got = polygonArea(verts);
   if (got <= 1e-6) return outline;
   if (mode === 'inner' && got > gross + 1e-6) return outline; // inset inverted
-  if (mode === 'outer' && got < gross - 1e-6) return outline; // shouldn't shrink
   return verts;
 }
 

--- a/packages/create/src/in-store/generate-spaces.ts
+++ b/packages/create/src/in-store/generate-spaces.ts
@@ -27,6 +27,8 @@ import {
   detectEnclosedAreasWithStats,
   type DetectedSpace,
   type DetectStats,
+  type Segment,
+  type Vec2,
 } from './auto-space-detect.js';
 import { addSpaceToStore, type SpaceBuildResult } from './space.js';
 
@@ -151,6 +153,11 @@ export function generateSpacesFromWalls(
       Name: name,
       LongName: options.longName,
       PredefinedType: options.predefinedType,
+      boundaryElementIds: matchBoundaryWalls(
+        region.outline,
+        extraction.segments,
+        extraction.contributingWallIds,
+      ),
     });
     emitted.push({ region, result, name });
   });
@@ -163,4 +170,49 @@ export function generateSpacesFromWalls(
     detectionStats: detection.stats,
     emitted,
   };
+}
+
+/**
+ * Map each edge of a detected room outline back to the wall(s) it runs along,
+ * so the bake can emit IfcRelSpaceBoundary linking the space to its real
+ * bounding walls. `segments[k]` was extracted from `wallIds[k]` (1:1), and an
+ * outline edge lies on a wall's centreline, so we match by: parallel direction,
+ * the edge midpoint sitting on the wall's line, and overlapping extent.
+ * (Corner-snap only moves endpoints along a wall's line, so the line — hence
+ * the match — is unaffected.)
+ */
+function matchBoundaryWalls(outline: Vec2[], segments: Segment[], wallIds: number[]): number[] {
+  const PERP_TOL = 0.2;   // m — edge sits on the wall centreline
+  const PARALLEL_TOL = 0.03;
+  const OVERLAP_MARGIN = 0.3; // m
+  const ids = new Set<number>();
+  const n = outline.length;
+  for (let i = 0; i < n; i++) {
+    const a = outline[i];
+    const b = outline[(i + 1) % n];
+    const mx = (a[0] + b[0]) / 2;
+    const my = (a[1] + b[1]) / 2;
+    let ex = b[0] - a[0];
+    let ey = b[1] - a[1];
+    const el = Math.hypot(ex, ey);
+    if (el < 1e-6) continue;
+    ex /= el; ey /= el;
+    for (let k = 0; k < segments.length; k++) {
+      const sa = segments[k].a;
+      const sb = segments[k].b;
+      let sx = sb[0] - sa[0];
+      let sy = sb[1] - sa[1];
+      const sl = Math.hypot(sx, sy);
+      if (sl < 1e-6) continue;
+      sx /= sl; sy /= sl;
+      if (Math.abs(ex * sy - ey * sx) > PARALLEL_TOL) continue; // not parallel
+      const t = (mx - sa[0]) * sx + (my - sa[1]) * sy;          // projection onto wall (m)
+      const px = sa[0] + sx * t;
+      const py = sa[1] + sy * t;
+      if (Math.hypot(mx - px, my - py) > PERP_TOL) continue;     // edge off the wall line
+      if (t < -OVERLAP_MARGIN || t > sl + OVERLAP_MARGIN) continue; // no extent overlap
+      ids.add(wallIds[k]);
+    }
+  }
+  return [...ids];
 }

--- a/packages/create/src/in-store/generate-spaces.ts
+++ b/packages/create/src/in-store/generate-spaces.ts
@@ -72,6 +72,14 @@ export interface GenerateSpacesOptions {
    * members, and railings.
    */
   extraDividerTypes?: string[];
+  /**
+   * Footprint polygons (same metre frame as the detected rooms) of existing
+   * spaces on this storey. A detected room whose centroid falls inside one is
+   * an overlap with an already-present space and is skipped — so re-running
+   * (or filling a partly-spaced floor) doesn't duplicate spaces. Per-space, not
+   * per-storey: non-overlapping rooms are still emitted.
+   */
+  skipFootprints?: Vec2[][];
 }
 
 export interface GenerateSpacesResult {
@@ -87,6 +95,8 @@ export interface GenerateSpacesResult {
   detectionStats: DetectStats;
   /** Per-region builder result. Empty when `dryRun: true`. */
   emitted: Array<{ region: DetectedSpace; result: SpaceBuildResult; name: string }>;
+  /** Detected rooms skipped because they overlap an existing space. */
+  skippedExisting: number;
 }
 
 export function generateSpacesFromWalls(
@@ -134,8 +144,22 @@ export function generateSpacesFromWalls(
     `(dropped ${detection.stats.outerFacesDropped} outer + ${detection.stats.belowMinAreaDropped} small) [${unitNote}].`,
   );
 
+  // Per-space dedup: drop detected rooms whose centroid lands inside an
+  // existing space footprint, so we don't duplicate already-present spaces
+  // (non-overlapping rooms on the same storey are still emitted).
+  const skipFootprints = options.skipFootprints ?? [];
+  const overlapsExisting = (outline: Vec2[]): boolean => {
+    if (skipFootprints.length === 0) return false;
+    let cx = 0, cy = 0;
+    for (const p of outline) { cx += p[0]; cy += p[1]; }
+    cx /= outline.length; cy /= outline.length;
+    return skipFootprints.some((fp) => pointInPolygon(cx, cy, fp));
+  };
+  const rooms = detected.filter((r) => !overlapsExisting(r.outline));
+  const skippedExisting = detected.length - rooms.length;
+
   const emitted: GenerateSpacesResult['emitted'] = [];
-  if (options.dryRun || detected.length === 0) {
+  if (options.dryRun || rooms.length === 0) {
     return {
       wallsConsidered: extraction.considered,
       wallsContributing: extraction.contributingWallIds.length,
@@ -143,6 +167,7 @@ export function generateSpacesFromWalls(
       detected,
       detectionStats: detection.stats,
       emitted,
+      skippedExisting,
     };
   }
 
@@ -151,8 +176,8 @@ export function generateSpacesFromWalls(
     throw new Error(`generateSpacesFromWalls: no resolvable spatial anchor for storey #${storeyExpressId}`);
   }
 
-  const allOutlines = detected.map((r) => r.outline);
-  detected.forEach((region, i) => {
+  const allOutlines = rooms.map((r) => r.outline);
+  rooms.forEach((region, i) => {
     const name = namePattern.replace('{n}', String(i + 1));
     const others = allOutlines.filter((_, j) => j !== i);
     // Bake the solid at the inner (net) face — IfcSpace should stop at the room
@@ -185,6 +210,7 @@ export function generateSpacesFromWalls(
     detected,
     detectionStats: detection.stats,
     emitted,
+    skippedExisting,
   };
 }
 

--- a/packages/create/src/in-store/generate-spaces.ts
+++ b/packages/create/src/in-store/generate-spaces.ts
@@ -30,7 +30,7 @@ import {
   type Segment,
   type Vec2,
 } from './auto-space-detect.js';
-import { addSpaceToStore, type SpaceBuildResult } from './space.js';
+import { addSpaceToStore, type SpaceBuildResult, type SpaceBoundaryInput } from './space.js';
 
 /**
  * IfcSpace.ObjectType marker stamped on every derived space, so a re-run can
@@ -151,8 +151,10 @@ export function generateSpacesFromWalls(
     throw new Error(`generateSpacesFromWalls: no resolvable spatial anchor for storey #${storeyExpressId}`);
   }
 
+  const allOutlines = detected.map((r) => r.outline);
   detected.forEach((region, i) => {
     const name = namePattern.replace('{n}', String(i + 1));
+    const others = allOutlines.filter((_, j) => j !== i);
     const result = addSpaceToStore(editor, anchor, {
       Profile: 'polygon',
       OuterCurve: region.outline,
@@ -161,10 +163,11 @@ export function generateSpacesFromWalls(
       ObjectType: GENERATED_SPACE_OBJECTTYPE,
       LongName: options.longName,
       PredefinedType: options.predefinedType,
-      boundaryElementIds: matchBoundaryWalls(
+      boundaries: buildSpaceBoundaries(
         region.outline,
         extraction.segments,
         extraction.contributingWallIds,
+        others,
       ),
     });
     emitted.push({ region, result, name });
@@ -180,47 +183,88 @@ export function generateSpacesFromWalls(
   };
 }
 
-/**
- * Map each edge of a detected room outline back to the wall(s) it runs along,
- * so the bake can emit IfcRelSpaceBoundary linking the space to its real
- * bounding walls. `segments[k]` was extracted from `wallIds[k]` (1:1), and an
- * outline edge lies on a wall's centreline, so we match by: parallel direction,
- * the edge midpoint sitting on the wall's line, and overlapping extent.
- * (Corner-snap only moves endpoints along a wall's line, so the line — hence
- * the match — is unaffected.)
- */
-function matchBoundaryWalls(outline: Vec2[], segments: Segment[], wallIds: number[]): number[] {
-  const PERP_TOL = 0.2;   // m — edge sits on the wall centreline
+/** Ray-cast point-in-polygon test. */
+function pointInPolygon(x: number, y: number, poly: Vec2[]): boolean {
+  let inside = false;
+  for (let i = 0, j = poly.length - 1; i < poly.length; j = i++) {
+    const xi = poly[i][0], yi = poly[i][1];
+    const xj = poly[j][0], yj = poly[j][1];
+    if ((yi > y) !== (yj > y) && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi) inside = !inside;
+  }
+  return inside;
+}
+
+/** Wall ids whose centreline an outline edge runs along (parallel, on the
+ *  line, overlapping extent). `segments[k]` was extracted from `wallIds[k]`. */
+function matchEdgeWalls(a: Vec2, b: Vec2, segments: Segment[], wallIds: number[]): number[] {
+  const PERP_TOL = 0.2;       // m — edge sits on the wall centreline
   const PARALLEL_TOL = 0.03;
   const OVERLAP_MARGIN = 0.3; // m
-  const ids = new Set<number>();
+  const out: number[] = [];
+  const mx = (a[0] + b[0]) / 2;
+  const my = (a[1] + b[1]) / 2;
+  let ex = b[0] - a[0];
+  let ey = b[1] - a[1];
+  const el = Math.hypot(ex, ey);
+  if (el < 1e-6) return out;
+  ex /= el; ey /= el;
+  for (let k = 0; k < segments.length; k++) {
+    const sa = segments[k].a;
+    const sb = segments[k].b;
+    let sx = sb[0] - sa[0];
+    let sy = sb[1] - sa[1];
+    const sl = Math.hypot(sx, sy);
+    if (sl < 1e-6) continue;
+    sx /= sl; sy /= sl;
+    if (Math.abs(ex * sy - ey * sx) > PARALLEL_TOL) continue;     // not parallel
+    const t = (mx - sa[0]) * sx + (my - sa[1]) * sy;              // projection onto wall (m)
+    const px = sa[0] + sx * t;
+    const py = sa[1] + sy * t;
+    if (Math.hypot(mx - px, my - py) > PERP_TOL) continue;        // edge off the wall line
+    if (t < -OVERLAP_MARGIN || t > sl + OVERLAP_MARGIN) continue; // no extent overlap
+    out.push(wallIds[k]);
+  }
+  return out;
+}
+
+/**
+ * Build the IfcRelSpaceBoundary inputs for one room: map each outline edge to
+ * the wall it runs along, classifying the boundary INTERNAL when another room
+ * lies on the far side of that edge (a partition) or EXTERNAL when it's the
+ * building perimeter. "Far side" is the edge midpoint nudged along its outward
+ * normal — robust to neighbours that split the shared run differently than this
+ * room does (where exact edge-matching would miss). A wall stays INTERNAL if
+ * any of its edges has a room on the far side. One boundary per distinct wall.
+ */
+function buildSpaceBoundaries(
+  outline: Vec2[],
+  segments: Segment[],
+  wallIds: number[],
+  otherRooms: Vec2[][],
+): SpaceBoundaryInput[] {
+  const NUDGE = 0.1; // m past the shared centreline into the neighbour
+  const byWall = new Map<number, 'INTERNAL' | 'EXTERNAL'>();
   const n = outline.length;
   for (let i = 0; i < n; i++) {
     const a = outline[i];
     const b = outline[(i + 1) % n];
-    const mx = (a[0] + b[0]) / 2;
-    const my = (a[1] + b[1]) / 2;
-    let ex = b[0] - a[0];
-    let ey = b[1] - a[1];
-    const el = Math.hypot(ex, ey);
-    if (el < 1e-6) continue;
-    ex /= el; ey /= el;
-    for (let k = 0; k < segments.length; k++) {
-      const sa = segments[k].a;
-      const sb = segments[k].b;
-      let sx = sb[0] - sa[0];
-      let sy = sb[1] - sa[1];
-      const sl = Math.hypot(sx, sy);
-      if (sl < 1e-6) continue;
-      sx /= sl; sy /= sl;
-      if (Math.abs(ex * sy - ey * sx) > PARALLEL_TOL) continue; // not parallel
-      const t = (mx - sa[0]) * sx + (my - sa[1]) * sy;          // projection onto wall (m)
-      const px = sa[0] + sx * t;
-      const py = sa[1] + sy * t;
-      if (Math.hypot(mx - px, my - py) > PERP_TOL) continue;     // edge off the wall line
-      if (t < -OVERLAP_MARGIN || t > sl + OVERLAP_MARGIN) continue; // no extent overlap
-      ids.add(wallIds[k]);
+    let dx = b[0] - a[0];
+    let dy = b[1] - a[1];
+    const dl = Math.hypot(dx, dy);
+    if (dl < 1e-6) continue;
+    dx /= dl; dy /= dl;
+    // Outward normal of a CCW outline is to the right of a→b.
+    const mx = (a[0] + b[0]) / 2 + dy * NUDGE;
+    const my = (a[1] + b[1]) / 2 - dx * NUDGE;
+    const cls = otherRooms.some((poly) => pointInPolygon(mx, my, poly)) ? 'INTERNAL' : 'EXTERNAL';
+    for (const wallId of matchEdgeWalls(a, b, segments, wallIds)) {
+      if (byWall.get(wallId) === 'INTERNAL') continue; // once internal, stays internal
+      byWall.set(wallId, cls);
     }
   }
-  return [...ids];
+  return [...byWall].map(([elementId, internalOrExternal]) => ({
+    elementId,
+    internalOrExternal,
+    physicalOrVirtual: 'PHYSICAL' as const,
+  }));
 }

--- a/packages/create/src/in-store/generate-spaces.ts
+++ b/packages/create/src/in-store/generate-spaces.ts
@@ -80,6 +80,8 @@ export interface GenerateSpacesOptions {
    * per-storey: non-overlapping rooms are still emitted.
    */
   skipFootprints?: Vec2[][];
+  /** Where the space boundary sits relative to its walls. Default 'inner'. */
+  boundaryMode?: BoundaryMode;
 }
 
 export interface GenerateSpacesResult {
@@ -183,7 +185,7 @@ export function generateSpacesFromWalls(
     // Bake the solid at the inner (net) face — IfcSpace should stop at the room
     // side of the walls, not run to their centreline. GrossFloorArea keeps the
     // centreline measure; NetFloorArea falls out of the inset OuterCurve.
-    const netOutline = insetRoomFootprint(region.outline, extraction.segments, extraction.wallThicknesses);
+    const netOutline = offsetRoomFootprint(region.outline, extraction.segments, extraction.wallThicknesses, options.boundaryMode ?? 'inner');
     const result = addSpaceToStore(editor, anchor, {
       Profile: 'polygon',
       OuterCurve: netOutline,
@@ -255,23 +257,27 @@ function edgeRunsAlong(a: Vec2, b: Vec2, seg: Segment): boolean {
   return t >= -OVERLAP_MARGIN && t <= sl + OVERLAP_MARGIN;
 }
 
+/** How a space boundary relates to its bounding walls. */
+export type BoundaryMode = 'center' | 'inner' | 'outer';
+
 /**
- * Inset a (centreline) room outline to its inner-face / net footprint: shift
- * each edge inward by half the thickness of the wall it runs along (0 where the
- * wall thickness is unknown), then re-corner by intersecting adjacent offset
- * edges. `segments[k]` has thickness `wallThicknesses[k]`. Returns the original
- * outline unchanged if the inset degenerates (e.g. a room thinner than its
- * walls). Exact for orthogonal rooms; a close approximation at non-right
- * corners. Shared by the bake (geometry) and net-area quantity, and by the
- * viewer's Space Sketch bake.
+ * Offset a (centreline) room outline to the chosen wall boundary: `center` =
+ * the centreline as-is; `inner` = each edge shifted toward the room by half the
+ * wall thickness (net / inner face); `outer` = shifted away by half (gross /
+ * outer face). Re-corners by intersecting adjacent offset edges. `segments[k]`
+ * has thickness `wallThicknesses[k]`. Returns the original outline if the
+ * offset degenerates (e.g. an inner inset of a room thinner than its walls).
+ * Exact for orthogonal rooms; a close approximation at non-right corners.
  */
-export function insetRoomFootprint(
+export function offsetRoomFootprint(
   outline: Vec2[],
   segments: Segment[],
   wallThicknesses: ReadonlyArray<number | undefined>,
+  mode: BoundaryMode = 'inner',
 ): Vec2[] {
   const n = outline.length;
-  if (n < 3) return outline;
+  if (mode === 'center' || n < 3) return outline;
+  const sign = mode === 'inner' ? 1 : -1; // inner → inward, outer → outward
   const lines: { p: Vec2; d: Vec2 }[] = [];
   for (let i = 0; i < n; i++) {
     const a = outline[i];
@@ -281,13 +287,14 @@ export function insetRoomFootprint(
     const l = Math.hypot(dx, dy);
     if (l < 1e-6) return outline;
     dx /= l; dy /= l;
-    let half = 0; // inset = half the thickest wall this edge runs along
+    let half = 0; // half the thickest wall this edge runs along
     for (let k = 0; k < segments.length; k++) {
       const t = wallThicknesses[k];
       if (t !== undefined && t / 2 > half && edgeRunsAlong(a, b, segments[k])) half = t / 2;
     }
+    const off = sign * half;
     // Inward normal of a CCW outline is to the left of a→b: (-dy, dx).
-    lines.push({ p: [a[0] - dy * half, a[1] + dx * half], d: [dx, dy] });
+    lines.push({ p: [a[0] - dy * off, a[1] + dx * off], d: [dx, dy] });
   }
   const verts: Vec2[] = [];
   for (let i = 0; i < n; i++) {
@@ -295,9 +302,13 @@ export function insetRoomFootprint(
     const cur = lines[i];
     verts.push(lineIntersect(prev.p, prev.d, cur.p, cur.d) ?? outline[i]);
   }
+  if (!verts.every((v) => Number.isFinite(v[0]) && Number.isFinite(v[1]))) return outline;
   const gross = polygonArea(outline);
-  const net = polygonArea(verts);
-  return net > 1e-6 && net <= gross + 1e-6 ? verts : outline;
+  const got = polygonArea(verts);
+  if (got <= 1e-6) return outline;
+  if (mode === 'inner' && got > gross + 1e-6) return outline; // inset inverted
+  if (mode === 'outer' && got < gross - 1e-6) return outline; // shouldn't shrink
+  return verts;
 }
 
 /** Ray-cast point-in-polygon test. */

--- a/packages/create/src/in-store/generate-spaces.ts
+++ b/packages/create/src/in-store/generate-spaces.ts
@@ -152,6 +152,11 @@ export function generateSpacesFromWalls(
   }
 
   const allOutlines = detected.map((r) => r.outline);
+  const thicknessById = new Map<number, number>();
+  extraction.contributingWallIds.forEach((id, k) => {
+    const t = extraction.wallThicknesses[k];
+    if (t !== undefined) thicknessById.set(id, t);
+  });
   detected.forEach((region, i) => {
     const name = namePattern.replace('{n}', String(i + 1));
     const others = allOutlines.filter((_, j) => j !== i);
@@ -169,6 +174,13 @@ export function generateSpacesFromWalls(
         extraction.contributingWallIds,
         others,
       ),
+      netFloorArea: computeNetArea(
+        region.outline,
+        extraction.segments,
+        extraction.contributingWallIds,
+        thicknessById,
+        region.area,
+      ),
     });
     emitted.push({ region, result, name });
   });
@@ -181,6 +193,71 @@ export function generateSpacesFromWalls(
     detectionStats: detection.stats,
     emitted,
   };
+}
+
+/** Absolute polygon area (shoelace), m². */
+function polygonArea(pts: Vec2[]): number {
+  let acc = 0;
+  for (let i = 0; i < pts.length; i++) {
+    const p = pts[i];
+    const q = pts[(i + 1) % pts.length];
+    acc += p[0] * q[1] - q[0] * p[1];
+  }
+  return Math.abs(acc) / 2;
+}
+
+/** Intersection of two lines given as point + unit direction; null if parallel. */
+function lineIntersect(
+  p0: Vec2, d0: Vec2, p1: Vec2, d1: Vec2,
+): Vec2 | null {
+  const denom = d0[0] * d1[1] - d0[1] * d1[0];
+  if (Math.abs(denom) < 1e-9) return null;
+  const t = ((p1[0] - p0[0]) * d1[1] - (p1[1] - p0[1]) * d1[0]) / denom;
+  return [p0[0] + d0[0] * t, p0[1] + d0[1] * t];
+}
+
+/**
+ * Net (inner-face) floor area: inset each outline edge inward by half the
+ * thickness of the wall bounding it (0 where unknown), then re-corner by
+ * intersecting adjacent offset edges. Falls back to the gross area if the inset
+ * degenerates (e.g. a room thinner than its walls). Exact for orthogonal rooms;
+ * a close approximation at non-right corners.
+ */
+function computeNetArea(
+  outline: Vec2[],
+  segments: Segment[],
+  wallIds: number[],
+  thicknessById: Map<number, number>,
+  grossArea: number,
+): number {
+  const n = outline.length;
+  if (n < 3) return grossArea;
+  // Offset line per edge: a point on the inward-shifted edge + the edge dir.
+  const lines: { p: Vec2; d: Vec2 }[] = [];
+  for (let i = 0; i < n; i++) {
+    const a = outline[i];
+    const b = outline[(i + 1) % n];
+    let dx = b[0] - a[0];
+    let dy = b[1] - a[1];
+    const l = Math.hypot(dx, dy);
+    if (l < 1e-6) return grossArea;
+    dx /= l; dy /= l;
+    let half = 0; // inset = half the thickest wall bounding this edge
+    for (const w of matchEdgeWalls(a, b, segments, wallIds)) {
+      const t = thicknessById.get(w);
+      if (t !== undefined && t / 2 > half) half = t / 2;
+    }
+    // Inward normal of a CCW outline is to the left of a→b: (-dy, dx).
+    lines.push({ p: [a[0] - dy * half, a[1] + dx * half], d: [dx, dy] });
+  }
+  const verts: Vec2[] = [];
+  for (let i = 0; i < n; i++) {
+    const prev = lines[(i - 1 + n) % n];
+    const cur = lines[i];
+    verts.push(lineIntersect(prev.p, prev.d, cur.p, cur.d) ?? outline[i]);
+  }
+  const net = polygonArea(verts);
+  return net > 0 && net <= grossArea + 1e-6 ? net : grossArea;
 }
 
 /** Ray-cast point-in-polygon test. */

--- a/packages/create/src/in-store/generate-spaces.ts
+++ b/packages/create/src/in-store/generate-spaces.ts
@@ -152,17 +152,16 @@ export function generateSpacesFromWalls(
   }
 
   const allOutlines = detected.map((r) => r.outline);
-  const thicknessById = new Map<number, number>();
-  extraction.contributingWallIds.forEach((id, k) => {
-    const t = extraction.wallThicknesses[k];
-    if (t !== undefined) thicknessById.set(id, t);
-  });
   detected.forEach((region, i) => {
     const name = namePattern.replace('{n}', String(i + 1));
     const others = allOutlines.filter((_, j) => j !== i);
+    // Bake the solid at the inner (net) face — IfcSpace should stop at the room
+    // side of the walls, not run to their centreline. GrossFloorArea keeps the
+    // centreline measure; NetFloorArea falls out of the inset OuterCurve.
+    const netOutline = insetRoomFootprint(region.outline, extraction.segments, extraction.wallThicknesses);
     const result = addSpaceToStore(editor, anchor, {
       Profile: 'polygon',
-      OuterCurve: region.outline,
+      OuterCurve: netOutline,
       Height: height,
       Name: name,
       ObjectType: GENERATED_SPACE_OBJECTTYPE,
@@ -174,13 +173,7 @@ export function generateSpacesFromWalls(
         extraction.contributingWallIds,
         others,
       ),
-      netFloorArea: computeNetArea(
-        region.outline,
-        extraction.segments,
-        extraction.contributingWallIds,
-        thicknessById,
-        region.area,
-      ),
+      grossFloorArea: region.area,
     });
     emitted.push({ region, result, name });
   });
@@ -216,23 +209,43 @@ function lineIntersect(
   return [p0[0] + d0[0] * t, p0[1] + d0[1] * t];
 }
 
+/** Does outline edge a→b run along wall segment `seg` (parallel, on its
+ *  centreline, overlapping extent)? */
+function edgeRunsAlong(a: Vec2, b: Vec2, seg: Segment): boolean {
+  const PERP_TOL = 0.2, PARALLEL_TOL = 0.03, OVERLAP_MARGIN = 0.3;
+  let ex = b[0] - a[0], ey = b[1] - a[1];
+  const el = Math.hypot(ex, ey);
+  if (el < 1e-6) return false;
+  ex /= el; ey /= el;
+  let sx = seg.b[0] - seg.a[0], sy = seg.b[1] - seg.a[1];
+  const sl = Math.hypot(sx, sy);
+  if (sl < 1e-6) return false;
+  sx /= sl; sy /= sl;
+  if (Math.abs(ex * sy - ey * sx) > PARALLEL_TOL) return false;
+  const mx = (a[0] + b[0]) / 2, my = (a[1] + b[1]) / 2;
+  const t = (mx - seg.a[0]) * sx + (my - seg.a[1]) * sy;
+  const px = seg.a[0] + sx * t, py = seg.a[1] + sy * t;
+  if (Math.hypot(mx - px, my - py) > PERP_TOL) return false;
+  return t >= -OVERLAP_MARGIN && t <= sl + OVERLAP_MARGIN;
+}
+
 /**
- * Net (inner-face) floor area: inset each outline edge inward by half the
- * thickness of the wall bounding it (0 where unknown), then re-corner by
- * intersecting adjacent offset edges. Falls back to the gross area if the inset
- * degenerates (e.g. a room thinner than its walls). Exact for orthogonal rooms;
- * a close approximation at non-right corners.
+ * Inset a (centreline) room outline to its inner-face / net footprint: shift
+ * each edge inward by half the thickness of the wall it runs along (0 where the
+ * wall thickness is unknown), then re-corner by intersecting adjacent offset
+ * edges. `segments[k]` has thickness `wallThicknesses[k]`. Returns the original
+ * outline unchanged if the inset degenerates (e.g. a room thinner than its
+ * walls). Exact for orthogonal rooms; a close approximation at non-right
+ * corners. Shared by the bake (geometry) and net-area quantity, and by the
+ * viewer's Space Sketch bake.
  */
-function computeNetArea(
+export function insetRoomFootprint(
   outline: Vec2[],
   segments: Segment[],
-  wallIds: number[],
-  thicknessById: Map<number, number>,
-  grossArea: number,
-): number {
+  wallThicknesses: ReadonlyArray<number | undefined>,
+): Vec2[] {
   const n = outline.length;
-  if (n < 3) return grossArea;
-  // Offset line per edge: a point on the inward-shifted edge + the edge dir.
+  if (n < 3) return outline;
   const lines: { p: Vec2; d: Vec2 }[] = [];
   for (let i = 0; i < n; i++) {
     const a = outline[i];
@@ -240,12 +253,12 @@ function computeNetArea(
     let dx = b[0] - a[0];
     let dy = b[1] - a[1];
     const l = Math.hypot(dx, dy);
-    if (l < 1e-6) return grossArea;
+    if (l < 1e-6) return outline;
     dx /= l; dy /= l;
-    let half = 0; // inset = half the thickest wall bounding this edge
-    for (const w of matchEdgeWalls(a, b, segments, wallIds)) {
-      const t = thicknessById.get(w);
-      if (t !== undefined && t / 2 > half) half = t / 2;
+    let half = 0; // inset = half the thickest wall this edge runs along
+    for (let k = 0; k < segments.length; k++) {
+      const t = wallThicknesses[k];
+      if (t !== undefined && t / 2 > half && edgeRunsAlong(a, b, segments[k])) half = t / 2;
     }
     // Inward normal of a CCW outline is to the left of a→b: (-dy, dx).
     lines.push({ p: [a[0] - dy * half, a[1] + dx * half], d: [dx, dy] });
@@ -256,8 +269,9 @@ function computeNetArea(
     const cur = lines[i];
     verts.push(lineIntersect(prev.p, prev.d, cur.p, cur.d) ?? outline[i]);
   }
+  const gross = polygonArea(outline);
   const net = polygonArea(verts);
-  return net > 0 && net <= grossArea + 1e-6 ? net : grossArea;
+  return net > 1e-6 && net <= gross + 1e-6 ? verts : outline;
 }
 
 /** Ray-cast point-in-polygon test. */

--- a/packages/create/src/in-store/space.test.ts
+++ b/packages/create/src/in-store/space.test.ts
@@ -58,6 +58,63 @@ describe('addSpaceToStore', () => {
     expect(profile?.type).toBe('IfcArbitraryClosedProfileDef');
   });
 
+  it('emits Qto_SpaceBaseQuantities with area / perimeter / height / volume', () => {
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(makeStore(40), view);
+    const result = addSpaceToStore(
+      editor,
+      { ownerHistoryId: 5, bodyContextId: 14, storeyId: 43, storeyPlacementId: 54 },
+      { Position: [0, 0, 0], Width: 4, Depth: 3, Height: 3 },
+    );
+    const byId = new Map(view.getNewEntities().map((e) => [e.expressId, e]));
+    const eq = byId.get(result.elementQuantityId);
+    expect(eq?.type).toBe('IfcElementQuantity');
+    expect(eq?.attributes[2]).toBe('Qto_SpaceBaseQuantities');
+    const named = Object.fromEntries(
+      (eq?.attributes[5] as string[]).map((ref) => {
+        const q = byId.get(Number(ref.slice(1)));
+        return [q?.attributes[0], q?.attributes[3]];
+      }),
+    );
+    expect(named['GrossFloorArea']).toBeCloseTo(12, 6); // 4×3
+    expect(named['NetFloorArea']).toBeCloseTo(12, 6);
+    expect(named['GrossPerimeter']).toBeCloseTo(14, 6); // 2(4+3)
+    expect(named['Height']).toBeCloseTo(3, 6);
+    expect(named['GrossVolume']).toBeCloseTo(36, 6); // 12×3
+
+    const rel = byId.get(result.relQuantityId);
+    expect(rel?.type).toBe('IfcRelDefinesByProperties');
+    expect(rel?.attributes[4]).toEqual([`#${result.spaceId}`]);
+    expect(rel?.attributes[5]).toBe(`#${result.elementQuantityId}`);
+  });
+
+  it('emits one classified IfcRelSpaceBoundary per bounding element', () => {
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(makeStore(40), view);
+    const result = addSpaceToStore(
+      editor,
+      { ownerHistoryId: 5, bodyContextId: 14, storeyId: 43, storeyPlacementId: 54 },
+      {
+        Profile: 'polygon',
+        OuterCurve: [[0, 0], [4, 0], [4, 3], [0, 3]],
+        Height: 3,
+        boundaries: [
+          { elementId: 30, internalOrExternal: 'EXTERNAL' },
+          { elementId: 31, internalOrExternal: 'INTERNAL' },
+        ],
+      },
+    );
+    const byId = new Map(view.getNewEntities().map((e) => [e.expressId, e]));
+    expect(result.spaceBoundaryIds).toHaveLength(2);
+    const b0 = byId.get(result.spaceBoundaryIds[0]);
+    expect(b0?.type).toBe('IfcRelSpaceBoundary');
+    expect(b0?.attributes[4]).toBe(`#${result.spaceId}`); // RelatingSpace
+    expect(b0?.attributes[5]).toBe('#30');                // RelatedBuildingElement
+    expect(b0?.attributes[7]).toBe('.PHYSICAL.');
+    expect(b0?.attributes[8]).toBe('.EXTERNAL.');
+    expect(byId.get(result.spaceBoundaryIds[1])?.attributes[8]).toBe('.INTERNAL.');
+  });
+
   it('rejects non-positive Height', () => {
     const view = new MutablePropertyView(null, 'm1');
     const editor = new StoreEditor(makeStore(10), view);

--- a/packages/create/src/in-store/space.test.ts
+++ b/packages/create/src/in-store/space.test.ts
@@ -88,6 +88,26 @@ describe('addSpaceToStore', () => {
     expect(rel?.attributes[5]).toBe(`#${result.elementQuantityId}`);
   });
 
+  it('uses the netFloorArea override for NetFloorArea (gross unchanged)', () => {
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(makeStore(40), view);
+    const result = addSpaceToStore(
+      editor,
+      { ownerHistoryId: 5, bodyContextId: 14, storeyId: 43, storeyPlacementId: 54 },
+      { Position: [0, 0, 0], Width: 4, Depth: 3, Height: 3, netFloorArea: 10 },
+    );
+    const byId = new Map(view.getNewEntities().map((e) => [e.expressId, e]));
+    const eq = byId.get(result.elementQuantityId);
+    const named = Object.fromEntries(
+      (eq?.attributes[5] as string[]).map((ref) => {
+        const q = byId.get(Number(ref.slice(1)));
+        return [q?.attributes[0], q?.attributes[3]];
+      }),
+    );
+    expect(named['GrossFloorArea']).toBeCloseTo(12, 6);
+    expect(named['NetFloorArea']).toBeCloseTo(10, 6);
+  });
+
   it('emits one classified IfcRelSpaceBoundary per bounding element', () => {
     const view = new MutablePropertyView(null, 'm1');
     const editor = new StoreEditor(makeStore(40), view);

--- a/packages/create/src/in-store/space.test.ts
+++ b/packages/create/src/in-store/space.test.ts
@@ -58,7 +58,14 @@ describe('addSpaceToStore', () => {
     expect(profile?.type).toBe('IfcArbitraryClosedProfileDef');
   });
 
-  it('emits Qto_SpaceBaseQuantities with area / perimeter / height / volume', () => {
+  // Read the Qto_SpaceBaseQuantities the bake attaches via the property view —
+  // the same source the properties panel + exporter read.
+  const namedQ = (view: MutablePropertyView, id: number): Record<string, number> => {
+    const qto = view.getQuantitiesForEntity(id).find((s) => s.name === 'Qto_SpaceBaseQuantities');
+    return Object.fromEntries((qto?.quantities ?? []).map((q) => [q.name, q.value]));
+  };
+
+  it('attaches Qto_SpaceBaseQuantities (area / perimeter / height / volume) to the view', () => {
     const view = new MutablePropertyView(null, 'm1');
     const editor = new StoreEditor(makeStore(40), view);
     const result = addSpaceToStore(
@@ -66,26 +73,12 @@ describe('addSpaceToStore', () => {
       { ownerHistoryId: 5, bodyContextId: 14, storeyId: 43, storeyPlacementId: 54 },
       { Position: [0, 0, 0], Width: 4, Depth: 3, Height: 3 },
     );
-    const byId = new Map(view.getNewEntities().map((e) => [e.expressId, e]));
-    const eq = byId.get(result.elementQuantityId);
-    expect(eq?.type).toBe('IfcElementQuantity');
-    expect(eq?.attributes[2]).toBe('Qto_SpaceBaseQuantities');
-    const named = Object.fromEntries(
-      (eq?.attributes[5] as string[]).map((ref) => {
-        const q = byId.get(Number(ref.slice(1)));
-        return [q?.attributes[0], q?.attributes[3]];
-      }),
-    );
+    const named = namedQ(view, result.spaceId);
     expect(named['GrossFloorArea']).toBeCloseTo(12, 6); // 4×3
     expect(named['NetFloorArea']).toBeCloseTo(12, 6);
     expect(named['GrossPerimeter']).toBeCloseTo(14, 6); // 2(4+3)
     expect(named['Height']).toBeCloseTo(3, 6);
     expect(named['GrossVolume']).toBeCloseTo(36, 6); // 12×3
-
-    const rel = byId.get(result.relQuantityId);
-    expect(rel?.type).toBe('IfcRelDefinesByProperties');
-    expect(rel?.attributes[4]).toEqual([`#${result.spaceId}`]);
-    expect(rel?.attributes[5]).toBe(`#${result.elementQuantityId}`);
   });
 
   it('uses the netFloorArea override for NetFloorArea (gross unchanged)', () => {
@@ -96,14 +89,7 @@ describe('addSpaceToStore', () => {
       { ownerHistoryId: 5, bodyContextId: 14, storeyId: 43, storeyPlacementId: 54 },
       { Position: [0, 0, 0], Width: 4, Depth: 3, Height: 3, netFloorArea: 10 },
     );
-    const byId = new Map(view.getNewEntities().map((e) => [e.expressId, e]));
-    const eq = byId.get(result.elementQuantityId);
-    const named = Object.fromEntries(
-      (eq?.attributes[5] as string[]).map((ref) => {
-        const q = byId.get(Number(ref.slice(1)));
-        return [q?.attributes[0], q?.attributes[3]];
-      }),
-    );
+    const named = namedQ(view, result.spaceId);
     expect(named['GrossFloorArea']).toBeCloseTo(12, 6);
     expect(named['NetFloorArea']).toBeCloseTo(10, 6);
   });

--- a/packages/create/src/in-store/space.ts
+++ b/packages/create/src/in-store/space.ts
@@ -58,8 +58,11 @@ export interface SpaceRectangleParams {
   PredefinedType?: string;
   /** Bounding elements → one IfcRelSpaceBoundary each. */
   boundaries?: SpaceBoundaryInput[];
-  /** Net (inner-face) floor area in m²; defaults to gross when omitted. */
+  /** Net (inner-face) floor area in m²; defaults to the OuterCurve area. */
   netFloorArea?: number;
+  /** Gross (centreline) floor area in m² for the GrossFloorArea quantity +
+   *  GrossVolume; defaults to the OuterCurve area when omitted. */
+  grossFloorArea?: number;
 }
 
 export interface SpacePolygonParams {
@@ -78,6 +81,9 @@ export interface SpacePolygonParams {
   /** Net (inner-face) floor area in m² for Qto_SpaceBaseQuantities; defaults
    *  to the gross/centreline area when omitted. */
   netFloorArea?: number;
+  /** Gross (centreline) floor area in m² for GrossFloorArea + GrossVolume;
+   *  defaults to the OuterCurve area when omitted. */
+  grossFloorArea?: number;
 }
 
 export interface SpaceBuildResult {
@@ -193,12 +199,16 @@ export function addSpaceToStore(
     if (ifc4) qattrs.push(null);
     return editor.addEntity(type, qattrs as Parameters<StoreEditor['addEntity']>[1]).expressId;
   };
+  // OuterCurve is the net (inner-face) footprint when generated from walls, so
+  // its `area` is the net area; GrossFloorArea/GrossVolume take the supplied
+  // centreline measure (falling back to the OuterCurve area).
+  const grossArea = params.grossFloorArea ?? area;
   const quantityIds = [
-    quantity('IfcQuantityArea', 'GrossFloorArea', area),
+    quantity('IfcQuantityArea', 'GrossFloorArea', grossArea),
     quantity('IfcQuantityArea', 'NetFloorArea', params.netFloorArea ?? area),
     quantity('IfcQuantityLength', 'GrossPerimeter', perimeter),
     quantity('IfcQuantityLength', 'Height', params.Height),
-    quantity('IfcQuantityVolume', 'GrossVolume', area * params.Height),
+    quantity('IfcQuantityVolume', 'GrossVolume', grossArea * params.Height),
   ];
   const elementQuantityId = editor.addEntity('IfcElementQuantity', [
     generateIfcGuid(),

--- a/packages/create/src/in-store/space.ts
+++ b/packages/create/src/in-store/space.ts
@@ -45,6 +45,9 @@ export interface SpaceRectangleParams {
    * IfcInternalOrExternalEnum. Defaults to INTERNAL.
    */
   PredefinedType?: string;
+  /** Express ids of the building elements bounding this space → one
+   *  IfcRelSpaceBoundary each (PHYSICAL/INTERNAL). */
+  boundaryElementIds?: number[];
 }
 
 export interface SpacePolygonParams {
@@ -58,6 +61,9 @@ export interface SpacePolygonParams {
   ObjectType?: string;
   /** See SpaceRectangleParams.PredefinedType. */
   PredefinedType?: string;
+  /** Express ids of the building elements bounding this space → one
+   *  IfcRelSpaceBoundary each (PHYSICAL/INTERNAL). */
+  boundaryElementIds?: number[];
 }
 
 export interface SpaceBuildResult {
@@ -72,6 +78,8 @@ export interface SpaceBuildResult {
   elementQuantityId: number;
   /** IfcRelDefinesByProperties linking the space to its quantities. */
   relQuantityId: number;
+  /** One IfcRelSpaceBoundary per bounding element (empty if none supplied). */
+  spaceBoundaryIds: number[];
 }
 
 /** Absolute polygon area (shoelace), m². */
@@ -195,6 +203,27 @@ export function addSpaceToStore(
     `#${elementQuantityId}`,
   ] as Parameters<StoreEditor['addEntity']>[1]).expressId;
 
+  // Space boundaries — one IfcRelSpaceBoundary per bounding element. Attribute
+  // order is stable across IFC2X3/IFC4: GlobalId, OwnerHistory, Name,
+  // Description, RelatingSpace, RelatedBuildingElement, ConnectionGeometry,
+  // PhysicalOrVirtualBoundary, InternalOrExternalBoundary. Connection geometry
+  // + internal/external classification are future refinements.
+  const spaceBoundaryIds: number[] = [];
+  for (const elementId of params.boundaryElementIds ?? []) {
+    const boundaryId = editor.addEntity('IfcRelSpaceBoundary', [
+      generateIfcGuid(),
+      `#${anchor.ownerHistoryId}`,
+      null,
+      null,
+      `#${spaceId}`,
+      `#${elementId}`,
+      null,
+      '.PHYSICAL.',
+      '.INTERNAL.',
+    ] as Parameters<StoreEditor['addEntity']>[1]).expressId;
+    spaceBoundaryIds.push(boundaryId);
+  }
+
   return {
     spaceId,
     placementId,
@@ -205,5 +234,6 @@ export function addSpaceToStore(
     relAggregatesId,
     elementQuantityId,
     relQuantityId,
+    spaceBoundaryIds,
   };
 }

--- a/packages/create/src/in-store/space.ts
+++ b/packages/create/src/in-store/space.ts
@@ -94,10 +94,6 @@ export interface SpaceBuildResult {
   shapeRepId: number;
   productShapeId: number;
   relAggregatesId: number;
-  /** IfcElementQuantity (Qto_SpaceBaseQuantities) emitted for the space. */
-  elementQuantityId: number;
-  /** IfcRelDefinesByProperties linking the space to its quantities. */
-  relQuantityId: number;
   /** One IfcRelSpaceBoundary per bounding element (empty if none supplied). */
   spaceBoundaryIds: number[];
 }
@@ -184,48 +180,23 @@ export function addSpaceToStore(
     [`#${spaceId}`],
   ]).expressId;
 
-  // Qto_SpaceBaseQuantities — every derived space carries base quantities for
-  // downstream schedules / energy / FM. Area is the centreline (gross)
-  // footprint; NetFloorArea == gross until we inset by wall thickness.
+  // Qto_SpaceBaseQuantities — attached via the property view (createQuantitySet)
+  // rather than as raw IfcElementQuantity entities, so they surface in the
+  // properties panel (getQuantitiesForEntity) AND export, from one source.
+  // `area` is the OuterCurve (net when generated from walls) footprint;
+  // GrossFloorArea/GrossVolume take the supplied centreline measure.
   const area = polygon ? polygonArea(params.OuterCurve) : params.Width * params.Depth;
   const perimeter = polygon
     ? polygonPerimeter(params.OuterCurve)
     : 2 * (params.Width + params.Depth);
-  const ifc4 = (anchor.schema ?? 'IFC4') !== 'IFC2X3';
-  const quantity = (type: string, name: string, value: number): number => {
-    // IfcQuantityArea/Length/Volume: (Name, Description, Unit, *Value[, Formula]).
-    // The trailing Formula slot exists only in IFC4+.
-    const qattrs: unknown[] = [name, null, null, value];
-    if (ifc4) qattrs.push(null);
-    return editor.addEntity(type, qattrs as Parameters<StoreEditor['addEntity']>[1]).expressId;
-  };
-  // OuterCurve is the net (inner-face) footprint when generated from walls, so
-  // its `area` is the net area; GrossFloorArea/GrossVolume take the supplied
-  // centreline measure (falling back to the OuterCurve area).
   const grossArea = params.grossFloorArea ?? area;
-  const quantityIds = [
-    quantity('IfcQuantityArea', 'GrossFloorArea', grossArea),
-    quantity('IfcQuantityArea', 'NetFloorArea', params.netFloorArea ?? area),
-    quantity('IfcQuantityLength', 'GrossPerimeter', perimeter),
-    quantity('IfcQuantityLength', 'Height', params.Height),
-    quantity('IfcQuantityVolume', 'GrossVolume', grossArea * params.Height),
-  ];
-  const elementQuantityId = editor.addEntity('IfcElementQuantity', [
-    generateIfcGuid(),
-    `#${anchor.ownerHistoryId}`,
-    'Qto_SpaceBaseQuantities',
-    null,
-    null,
-    quantityIds.map((id) => `#${id}`),
-  ] as Parameters<StoreEditor['addEntity']>[1]).expressId;
-  const relQuantityId = editor.addEntity('IfcRelDefinesByProperties', [
-    generateIfcGuid(),
-    `#${anchor.ownerHistoryId}`,
-    null,
-    null,
-    [`#${spaceId}`],
-    `#${elementQuantityId}`,
-  ] as Parameters<StoreEditor['addEntity']>[1]).expressId;
+  editor.addQuantitySet(spaceId, 'Qto_SpaceBaseQuantities', [
+    { name: 'GrossFloorArea', value: grossArea, quantityType: 'AREA' },
+    { name: 'NetFloorArea', value: params.netFloorArea ?? area, quantityType: 'AREA' },
+    { name: 'GrossPerimeter', value: perimeter, quantityType: 'LENGTH' },
+    { name: 'Height', value: params.Height, quantityType: 'LENGTH' },
+    { name: 'GrossVolume', value: grossArea * params.Height, quantityType: 'VOLUME' },
+  ]);
 
   // Space boundaries — one IfcRelSpaceBoundary per bounding element. Attribute
   // order is stable across IFC2X3/IFC4: GlobalId, OwnerHistory, Name,
@@ -256,8 +227,6 @@ export function addSpaceToStore(
     shapeRepId,
     productShapeId,
     relAggregatesId,
-    elementQuantityId,
-    relQuantityId,
     spaceBoundaryIds,
   };
 }

--- a/packages/create/src/in-store/space.ts
+++ b/packages/create/src/in-store/space.ts
@@ -68,6 +68,32 @@ export interface SpaceBuildResult {
   shapeRepId: number;
   productShapeId: number;
   relAggregatesId: number;
+  /** IfcElementQuantity (Qto_SpaceBaseQuantities) emitted for the space. */
+  elementQuantityId: number;
+  /** IfcRelDefinesByProperties linking the space to its quantities. */
+  relQuantityId: number;
+}
+
+/** Absolute polygon area (shoelace), m². */
+function polygonArea(pts: ReadonlyArray<readonly [number, number]>): number {
+  let acc = 0;
+  for (let i = 0; i < pts.length; i++) {
+    const p = pts[i];
+    const q = pts[(i + 1) % pts.length];
+    acc += p[0] * q[1] - q[0] * p[1];
+  }
+  return Math.abs(acc) / 2;
+}
+
+/** Polygon perimeter, m. */
+function polygonPerimeter(pts: ReadonlyArray<readonly [number, number]>): number {
+  let s = 0;
+  for (let i = 0; i < pts.length; i++) {
+    const p = pts[i];
+    const q = pts[(i + 1) % pts.length];
+    s += Math.hypot(q[0] - p[0], q[1] - p[1]);
+  }
+  return s;
 }
 
 function isPolygonParams(p: SpaceInStoreParams): p is SpacePolygonParams {
@@ -130,5 +156,54 @@ export function addSpaceToStore(
     [`#${spaceId}`],
   ]).expressId;
 
-  return { spaceId, placementId, profileId, solidId, shapeRepId, productShapeId, relAggregatesId };
+  // Qto_SpaceBaseQuantities — every derived space carries base quantities for
+  // downstream schedules / energy / FM. Area is the centreline (gross)
+  // footprint; NetFloorArea == gross until we inset by wall thickness.
+  const area = polygon ? polygonArea(params.OuterCurve) : params.Width * params.Depth;
+  const perimeter = polygon
+    ? polygonPerimeter(params.OuterCurve)
+    : 2 * (params.Width + params.Depth);
+  const ifc4 = (anchor.schema ?? 'IFC4') !== 'IFC2X3';
+  const quantity = (type: string, name: string, value: number): number => {
+    // IfcQuantityArea/Length/Volume: (Name, Description, Unit, *Value[, Formula]).
+    // The trailing Formula slot exists only in IFC4+.
+    const qattrs: unknown[] = [name, null, null, value];
+    if (ifc4) qattrs.push(null);
+    return editor.addEntity(type, qattrs as Parameters<StoreEditor['addEntity']>[1]).expressId;
+  };
+  const quantityIds = [
+    quantity('IfcQuantityArea', 'GrossFloorArea', area),
+    quantity('IfcQuantityArea', 'NetFloorArea', area),
+    quantity('IfcQuantityLength', 'GrossPerimeter', perimeter),
+    quantity('IfcQuantityLength', 'Height', params.Height),
+    quantity('IfcQuantityVolume', 'GrossVolume', area * params.Height),
+  ];
+  const elementQuantityId = editor.addEntity('IfcElementQuantity', [
+    generateIfcGuid(),
+    `#${anchor.ownerHistoryId}`,
+    'Qto_SpaceBaseQuantities',
+    null,
+    null,
+    quantityIds.map((id) => `#${id}`),
+  ] as Parameters<StoreEditor['addEntity']>[1]).expressId;
+  const relQuantityId = editor.addEntity('IfcRelDefinesByProperties', [
+    generateIfcGuid(),
+    `#${anchor.ownerHistoryId}`,
+    null,
+    null,
+    [`#${spaceId}`],
+    `#${elementQuantityId}`,
+  ] as Parameters<StoreEditor['addEntity']>[1]).expressId;
+
+  return {
+    spaceId,
+    placementId,
+    profileId,
+    solidId,
+    shapeRepId,
+    productShapeId,
+    relAggregatesId,
+    elementQuantityId,
+    relQuantityId,
+  };
 }

--- a/packages/create/src/in-store/space.ts
+++ b/packages/create/src/in-store/space.ts
@@ -198,6 +198,16 @@ export function addSpaceToStore(
     { name: 'GrossVolume', value: grossArea * params.Height, quantityType: 'VOLUME' },
   ]);
 
+  // Pset_SpaceCommon — the standard IfcSpace pset, so the space carries real
+  // properties (not just an empty schema template). Planned areas mirror the
+  // measured ones; interior space ⇒ not external by default.
+  editor.addPropertySet(spaceId, 'Pset_SpaceCommon', [
+    { name: 'Reference', value: params.Name ?? '', type: 'LABEL' },
+    { name: 'IsExternal', value: false, type: 'BOOLEAN' },
+    { name: 'GrossPlannedArea', value: grossArea, type: 'REAL' },
+    { name: 'NetPlannedArea', value: params.netFloorArea ?? area, type: 'REAL' },
+  ]);
+
   // Space boundaries — one IfcRelSpaceBoundary per bounding element. Attribute
   // order is stable across IFC2X3/IFC4: GlobalId, OwnerHistory, Name,
   // Description, RelatingSpace, RelatedBuildingElement, ConnectionGeometry,

--- a/packages/create/src/in-store/space.ts
+++ b/packages/create/src/in-store/space.ts
@@ -29,6 +29,17 @@ import {
 
 export type SpaceInStoreParams = SpaceRectangleParams | SpacePolygonParams;
 
+/** A bounding element for a space → one IfcRelSpaceBoundary. */
+export interface SpaceBoundaryInput {
+  /** Express id of the bounding building element (e.g. a wall). */
+  elementId: number;
+  /** INTERNAL (other side is another space) / EXTERNAL (building exterior) /
+   *  NOTDEFINED. Defaults to NOTDEFINED. */
+  internalOrExternal?: 'INTERNAL' | 'EXTERNAL' | 'NOTDEFINED';
+  /** PHYSICAL (a real element) / VIRTUAL. Defaults to PHYSICAL. */
+  physicalOrVirtual?: 'PHYSICAL' | 'VIRTUAL';
+}
+
 export interface SpaceRectangleParams {
   Position: [number, number, number];
   Width: number;
@@ -45,9 +56,8 @@ export interface SpaceRectangleParams {
    * IfcInternalOrExternalEnum. Defaults to INTERNAL.
    */
   PredefinedType?: string;
-  /** Express ids of the building elements bounding this space → one
-   *  IfcRelSpaceBoundary each (PHYSICAL/INTERNAL). */
-  boundaryElementIds?: number[];
+  /** Bounding elements → one IfcRelSpaceBoundary each. */
+  boundaries?: SpaceBoundaryInput[];
 }
 
 export interface SpacePolygonParams {
@@ -61,9 +71,8 @@ export interface SpacePolygonParams {
   ObjectType?: string;
   /** See SpaceRectangleParams.PredefinedType. */
   PredefinedType?: string;
-  /** Express ids of the building elements bounding this space → one
-   *  IfcRelSpaceBoundary each (PHYSICAL/INTERNAL). */
-  boundaryElementIds?: number[];
+  /** Bounding elements → one IfcRelSpaceBoundary each. */
+  boundaries?: SpaceBoundaryInput[];
 }
 
 export interface SpaceBuildResult {
@@ -209,17 +218,17 @@ export function addSpaceToStore(
   // PhysicalOrVirtualBoundary, InternalOrExternalBoundary. Connection geometry
   // + internal/external classification are future refinements.
   const spaceBoundaryIds: number[] = [];
-  for (const elementId of params.boundaryElementIds ?? []) {
+  for (const boundary of params.boundaries ?? []) {
     const boundaryId = editor.addEntity('IfcRelSpaceBoundary', [
       generateIfcGuid(),
       `#${anchor.ownerHistoryId}`,
       null,
       null,
       `#${spaceId}`,
-      `#${elementId}`,
+      `#${boundary.elementId}`,
       null,
-      '.PHYSICAL.',
-      '.INTERNAL.',
+      `.${boundary.physicalOrVirtual ?? 'PHYSICAL'}.`,
+      `.${boundary.internalOrExternal ?? 'NOTDEFINED'}.`,
     ] as Parameters<StoreEditor['addEntity']>[1]).expressId;
     spaceBoundaryIds.push(boundaryId);
   }

--- a/packages/create/src/in-store/space.ts
+++ b/packages/create/src/in-store/space.ts
@@ -58,6 +58,8 @@ export interface SpaceRectangleParams {
   PredefinedType?: string;
   /** Bounding elements → one IfcRelSpaceBoundary each. */
   boundaries?: SpaceBoundaryInput[];
+  /** Net (inner-face) floor area in m²; defaults to gross when omitted. */
+  netFloorArea?: number;
 }
 
 export interface SpacePolygonParams {
@@ -73,6 +75,9 @@ export interface SpacePolygonParams {
   PredefinedType?: string;
   /** Bounding elements → one IfcRelSpaceBoundary each. */
   boundaries?: SpaceBoundaryInput[];
+  /** Net (inner-face) floor area in m² for Qto_SpaceBaseQuantities; defaults
+   *  to the gross/centreline area when omitted. */
+  netFloorArea?: number;
 }
 
 export interface SpaceBuildResult {
@@ -190,7 +195,7 @@ export function addSpaceToStore(
   };
   const quantityIds = [
     quantity('IfcQuantityArea', 'GrossFloorArea', area),
-    quantity('IfcQuantityArea', 'NetFloorArea', area),
+    quantity('IfcQuantityArea', 'NetFloorArea', params.netFloorArea ?? area),
     quantity('IfcQuantityLength', 'GrossPerimeter', perimeter),
     quantity('IfcQuantityLength', 'Height', params.Height),
     quantity('IfcQuantityVolume', 'GrossVolume', area * params.Height),

--- a/packages/create/src/index.ts
+++ b/packages/create/src/index.ts
@@ -59,6 +59,7 @@ export {
 } from './in-store/extract-walls.js';
 export {
   generateSpacesFromWalls,
+  insetRoomFootprint,
   type GenerateSpacesOptions,
   type GenerateSpacesResult,
 } from './in-store/generate-spaces.js';

--- a/packages/create/src/index.ts
+++ b/packages/create/src/index.ts
@@ -61,6 +61,7 @@ export {
 export {
   generateSpacesFromWalls,
   insetRoomFootprint,
+  GENERATED_SPACE_OBJECTTYPE,
   type GenerateSpacesOptions,
   type GenerateSpacesResult,
 } from './in-store/generate-spaces.js';

--- a/packages/create/src/index.ts
+++ b/packages/create/src/index.ts
@@ -60,10 +60,11 @@ export {
 } from './in-store/extract-walls.js';
 export {
   generateSpacesFromWalls,
-  insetRoomFootprint,
+  offsetRoomFootprint,
   GENERATED_SPACE_OBJECTTYPE,
   type GenerateSpacesOptions,
   type GenerateSpacesResult,
+  type BoundaryMode,
 } from './in-store/generate-spaces.js';
 export {
   generateSpaces,

--- a/packages/create/src/index.ts
+++ b/packages/create/src/index.ts
@@ -62,6 +62,14 @@ export {
   type GenerateSpacesOptions,
   type GenerateSpacesResult,
 } from './in-store/generate-spaces.js';
+export {
+  generateSpaces,
+  listStoreys,
+  type GenerateSpacesAllOptions,
+  type GenerateSpacesAllResult,
+  type GenerateSpacesStoreyResult,
+  type StoreyInfo,
+} from './in-store/generate-spaces-all.js';
 
 export type {
   // Geometry primitives

--- a/packages/create/src/index.ts
+++ b/packages/create/src/index.ts
@@ -54,7 +54,7 @@ export {
 } from './in-store/auto-space-detect.js';
 export {
   extractWallSegmentsForStorey,
-  spaceCountByStorey,
+  existingSpaceFootprintsByStorey,
   type OverlayWallReader,
   type WallExtractionResult,
 } from './in-store/extract-walls.js';
@@ -70,7 +70,6 @@ export {
   type GenerateSpacesAllOptions,
   type GenerateSpacesAllResult,
   type GenerateSpacesStoreyResult,
-  type GenerateSpacesStoreySkip,
   type StoreyInfo,
 } from './in-store/generate-spaces-all.js';
 

--- a/packages/create/src/index.ts
+++ b/packages/create/src/index.ts
@@ -54,6 +54,7 @@ export {
 } from './in-store/auto-space-detect.js';
 export {
   extractWallSegmentsForStorey,
+  spaceCountByStorey,
   type OverlayWallReader,
   type WallExtractionResult,
 } from './in-store/extract-walls.js';
@@ -69,6 +70,7 @@ export {
   type GenerateSpacesAllOptions,
   type GenerateSpacesAllResult,
   type GenerateSpacesStoreyResult,
+  type GenerateSpacesStoreySkip,
   type StoreyInfo,
 } from './in-store/generate-spaces-all.js';
 

--- a/packages/mutations/src/store-editor.ts
+++ b/packages/mutations/src/store-editor.ts
@@ -18,7 +18,7 @@
  */
 
 import type { MutablePropertyView } from './mutable-property-view.js';
-import { QuantityType } from '@ifc-lite/data';
+import { QuantityType, PropertyValueType } from '@ifc-lite/data';
 import type {
   IfcAttributeValue,
   MutationEntityRef as EntityRef,
@@ -31,6 +31,9 @@ export const OVERLAY_BYTE_OFFSET = -1;
 
 /** Quantity kinds accepted by {@link StoreEditor.addQuantitySet}. */
 export type QuantityKind = 'LENGTH' | 'AREA' | 'VOLUME' | 'COUNT' | 'WEIGHT' | 'TIME';
+
+/** Property value kinds accepted by {@link StoreEditor.addPropertySet}. */
+export type PropertyKind = 'TEXT' | 'LABEL' | 'REAL' | 'INTEGER' | 'BOOLEAN';
 
 /**
  * Schema-aware normaliser injected from outside the package.
@@ -226,6 +229,30 @@ export class StoreEditor {
       entityId,
       qsetName,
       quantities.map((q) => ({ name: q.name, value: q.value, quantityType: kind[q.quantityType], unit: q.unit })),
+    );
+  }
+
+  /**
+   * Attach a property set to an entity via the property view, so it surfaces in
+   * the properties panel AND exports to IfcPropertySet — the single source the
+   * rest of the app reads (the panel doesn't resolve raw overlay entities).
+   */
+  addPropertySet(
+    entityId: number,
+    psetName: string,
+    properties: Array<{ name: string; value: string | number | boolean; type: PropertyKind; unit?: string }>,
+  ): void {
+    const kind: Record<PropertyKind, PropertyValueType> = {
+      TEXT: PropertyValueType.Text,
+      LABEL: PropertyValueType.Label,
+      REAL: PropertyValueType.Real,
+      INTEGER: PropertyValueType.Integer,
+      BOOLEAN: PropertyValueType.Boolean,
+    };
+    this.view.createPropertySet(
+      entityId,
+      psetName,
+      properties.map((p) => ({ name: p.name, value: p.value, type: kind[p.type], unit: p.unit })),
     );
   }
 

--- a/packages/mutations/src/store-editor.ts
+++ b/packages/mutations/src/store-editor.ts
@@ -18,6 +18,7 @@
  */
 
 import type { MutablePropertyView } from './mutable-property-view.js';
+import { QuantityType } from '@ifc-lite/data';
 import type {
   IfcAttributeValue,
   MutationEntityRef as EntityRef,
@@ -27,6 +28,9 @@ import type {
 
 /** Sentinel byteOffset that flags an `EntityRef` as overlay-only (no source bytes). */
 export const OVERLAY_BYTE_OFFSET = -1;
+
+/** Quantity kinds accepted by {@link StoreEditor.addQuantitySet}. */
+export type QuantityKind = 'LENGTH' | 'AREA' | 'VOLUME' | 'COUNT' | 'WEIGHT' | 'TIME';
 
 /**
  * Schema-aware normaliser injected from outside the package.
@@ -196,6 +200,33 @@ export class StoreEditor {
   /** All overlay-created entities, in insertion order. */
   getNewEntities(): NewEntity[] {
     return this.view.getNewEntities();
+  }
+
+  /**
+   * Attach a quantity set to an entity via the property view, so it surfaces in
+   * the properties panel (`getQuantitiesForEntity`) AND exports to
+   * IfcElementQuantity — the single source the rest of the app reads. Prefer
+   * this over emitting raw quantity / element-quantity entities, which the
+   * panel doesn't resolve.
+   */
+  addQuantitySet(
+    entityId: number,
+    qsetName: string,
+    quantities: Array<{ name: string; value: number; quantityType: QuantityKind; unit?: string }>,
+  ): void {
+    const kind: Record<QuantityKind, QuantityType> = {
+      LENGTH: QuantityType.Length,
+      AREA: QuantityType.Area,
+      VOLUME: QuantityType.Volume,
+      COUNT: QuantityType.Count,
+      WEIGHT: QuantityType.Weight,
+      TIME: QuantityType.Time,
+    };
+    this.view.createQuantitySet(
+      entityId,
+      qsetName,
+      quantities.map((q) => ({ name: q.name, value: q.value, quantityType: kind[q.quantityType], unit: q.unit })),
+    );
   }
 
   private computeMaxExistingId(): number {

--- a/packages/sdk/src/context.ts
+++ b/packages/sdk/src/context.ts
@@ -32,6 +32,7 @@ import { SandboxNamespace } from './namespaces/sandbox.js';
 import { FilesNamespace } from './namespaces/files.js';
 import { ScheduleNamespace } from './namespaces/schedule.js';
 import { ClashNamespace } from './namespaces/clash.js';
+import { SpacesNamespace } from './namespaces/spaces.js';
 import { RemoteBackend } from './transport/remote-backend.js';
 
 export class BimContext {
@@ -53,6 +54,7 @@ export class BimContext {
   readonly files: FilesNamespace;
   readonly schedule: ScheduleNamespace;
   readonly clash: ClashNamespace;
+  readonly spaces: SpacesNamespace;
 
   private _queryNamespace: QueryNamespace;
   private _backend: BimBackend;
@@ -86,6 +88,7 @@ export class BimContext {
     this.files = new FilesNamespace(this._backend);
     this.schedule = new ScheduleNamespace(this._backend);
     this.clash = new ClashNamespace();
+    this.spaces = new SpacesNamespace(this._backend);
     // Cache the bound function so every access returns the same reference
     this._boundOn = this.events.on.bind(this.events);
   }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -117,6 +117,7 @@ export type {
   ViewerBackendMethods,
   MutateBackendMethods,
   StoreBackendMethods,
+  SpacesBackendMethods,
   AddColumnInStoreParams,
   AddWallInStoreParams,
   AddSlabInStoreParams,
@@ -190,6 +191,7 @@ export { ScheduleNamespace } from './namespaces/schedule.js';
 
 // Clash — geometric interference detection over caller-provided ClashElement[]
 export { ClashNamespace } from './namespaces/clash.js';
+export { SpacesNamespace } from './namespaces/spaces.js';
 export type { ClashGroupBy, ClashRunOptions, ClashMatrixOptions } from './namespaces/clash.js';
 // Re-export the clash core types so hosts can type elements/rules/results
 // without taking a second direct dependency on @ifc-lite/clash.

--- a/packages/sdk/src/namespaces/spaces.ts
+++ b/packages/sdk/src/namespaces/spaces.ts
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { BimBackend } from '../types.js';
+import type {
+  GenerateSpacesAllOptions,
+  GenerateSpacesAllResult,
+  StoreyInfo,
+} from '@ifc-lite/create';
+
+/**
+ * Derive `IfcSpace` from a model's walls (room footprints) with slab/roof-aware
+ * heights. Available on local/headless contexts (direct store access); a remote
+ * backend whose store lives server-side will throw.
+ *
+ * @example
+ * const result = bim.spaces.generate({ height: 'auto', snap: 'auto' });
+ * const ifc = await bim.export.toStep(); // includes the new IfcSpace
+ */
+export class SpacesNamespace {
+  constructor(private backend: BimBackend) {}
+
+  private impl() {
+    if (!this.backend.spaces) {
+      throw new Error(
+        'spaces: not available on this backend — space derivation needs direct ' +
+        'store access (use a headless/local context, not a remote transport).',
+      );
+    }
+    return this.backend.spaces;
+  }
+
+  /** Every `IfcBuildingStorey` (id, name, elevation), low → high. */
+  storeys(): StoreyInfo[] {
+    return this.impl().listStoreys();
+  }
+
+  /**
+   * Derive `IfcSpace` across the selected storeys (default: all). Footprint
+   * comes from walls; `height: 'auto'` (default) uses floor-to-floor from
+   * storey elevations; `snap: 'auto'` (default) escalates the corner-closing
+   * tolerance. The spaces are written to the model's mutation overlay — call
+   * `bim.export.toStep()` to obtain IFC bytes including them.
+   */
+  generate(options?: GenerateSpacesAllOptions): GenerateSpacesAllResult {
+    return this.impl().generate(options);
+  }
+}

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -9,6 +9,12 @@
  * External tools (ifc-scripts, ifc-flow) depend on these types.
  */
 
+import type {
+  GenerateSpacesAllOptions,
+  GenerateSpacesAllResult,
+  StoreyInfo,
+} from '@ifc-lite/create';
+
 // ============================================================================
 // Entity References
 // ============================================================================
@@ -705,6 +711,21 @@ export interface ScheduleBackendMethods {
  * BimHost (wire protocol) uses dispatchToBackend() to route string-based
  * SdkRequests to the typed namespace methods.
  */
+/**
+ * Derive IfcSpace from a model's walls/slabs/roofs. Optional on the backend:
+ * local backends with direct store access implement it; remote backends (whose
+ * store lives server-side) leave it undefined.
+ */
+export interface SpacesBackendMethods {
+  /** Every IfcBuildingStorey (id, name, elevation), low → high. */
+  listStoreys(): StoreyInfo[];
+  /**
+   * Derive IfcSpace across the selected storeys, writing them to the backend's
+   * mutation overlay. Persist with `bim.export.toStep()`.
+   */
+  generate(options?: GenerateSpacesAllOptions): GenerateSpacesAllResult;
+}
+
 export interface BimBackend {
   readonly model: ModelBackendMethods;
   readonly query: QueryBackendMethods;
@@ -718,6 +739,8 @@ export interface BimBackend {
   readonly lens: LensBackendMethods;
   readonly files: FilesBackendMethods;
   readonly schedule: ScheduleBackendMethods;
+  /** Space derivation — present only on local backends with store access. */
+  readonly spaces?: SpacesBackendMethods;
 
   /** Subscribe to viewer events */
   subscribe(event: BimEventType, handler: (data: unknown) => void): () => void;

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -1008,9 +1008,6 @@ export interface InitOutput {
   readonly symbolictext_worldY: (a: number) => number;
   readonly symbolictext_x: (a: number) => number;
   readonly symbolictext_y: (a: number) => number;
-  readonly __wasm_bindgen_func_elem_719: (a: number, b: number, c: number) => void;
-  readonly __wasm_bindgen_func_elem_718: (a: number, b: number) => void;
-  readonly __wasm_bindgen_func_elem_758: (a: number, b: number, c: number, d: number) => void;
   readonly __wbindgen_export: (a: number, b: number) => number;
   readonly __wbindgen_export2: (a: number, b: number, c: number, d: number) => number;
   readonly __wbindgen_export3: (a: number) => void;

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -538,6 +538,86 @@ export class ProfileEntryJs {
   readonly transform: Float32Array;
 }
 
+export class SpacePlateHandle {
+  free(): void;
+  [Symbol.dispose](): void;
+  /**
+   * Insert a new vertex at `(x, y)` on edge `edge`, subdividing it (no new
+   * face). Returns the new vertex id — use it as a `splitFace` endpoint to
+   * cut between points that weren't existing corners. Project `(x, y)` onto
+   * the edge to keep areas unchanged.
+   */
+  splitEdge(edge: number, x: number, y: number): number;
+  /**
+   * Subdivide a face with a partition between two of its vertices. `source`
+   * `-1` marks a brand-new partition (materialised as a fresh wall at bake).
+   * Returns the kept face and the new face.
+   */
+  splitFace(face: number, va: number, vb: number, source: number): any;
+  /**
+   * Move a vertex; returns the rooms it changed. A shared wall is one edge
+   * whose endpoints are shared vertices, so one drag updates both rooms.
+   */
+  dragVertex(v: number, x: number, y: number): any;
+  /**
+   * Remove a shared wall, unioning the two rooms it separated. Returns the
+   * surviving room.
+   */
+  mergeFaces(edge: number): any;
+  /**
+   * Flat outline `[x0, y0, x1, y1, …]` of a face (no repeated closing vertex).
+   */
+  faceOutline(face: number): Float64Array;
+  /**
+   * The room on the far side of a half-edge (its twin's face), or
+   * `undefined`. O(1) — the "who's across this wall" query.
+   */
+  neighborAcross(edge: number): number | undefined;
+  /**
+   * Set a face's floor / ceiling planes (the vertical dimension that turns a
+   * 2D face into a prismatic space at bake).
+   */
+  setFaceHeight(face: number, floor_z: number, ceiling_z: number, non_planar: boolean): void;
+  /**
+   * Nearest live vertex id to `(x, y)` within `tol`, or `undefined`.
+   */
+  findVertexNear(x: number, y: number, tol: number): number | undefined;
+  /**
+   * Bounding half-edges of a face paired with their source element —
+   * `[{ edge, source }, …]` — for `IfcRelSpaceBoundary` at bake.
+   */
+  boundingElements(face: number): any;
+  /**
+   * Build a plate from flat wall-axis segments.
+   *
+   * `segCoords`: `[ax, ay, bx, by, …]` (length a multiple of 4).
+   * `segSources`: one `i32` per segment, `-1` for none.
+   * `snapTolerance` / `minArea`: pass `<= 0` to take the defaults.
+   */
+  constructor(seg_coords: Float64Array, seg_sources: Int32Array, snap_tolerance: number, min_area: number);
+  /**
+   * Face ids of every live room.
+   */
+  roomIds(): Uint32Array;
+  /**
+   * All live rooms as `{ face, area, simple, outline }` patches.
+   */
+  snapshot(): any;
+  /**
+   * Deep-copy the plate for an undo/redo snapshot. The clone owns its own
+   * heap; the caller must `.free()` it like any handle.
+   */
+  duplicate(): SpacePlateHandle;
+  /**
+   * Absolute area (m²) of a face.
+   */
+  faceArea(face: number): number;
+  /**
+   * Number of live rooms.
+   */
+  readonly roomCount: number;
+}
+
 export class SymbolicCircle {
   private constructor();
   free(): void;
@@ -757,6 +837,7 @@ export interface InitOutput {
   readonly __wbg_meshoutlinejs_free: (a: number, b: number) => void;
   readonly __wbg_profilecollection_free: (a: number, b: number) => void;
   readonly __wbg_profileentryjs_free: (a: number, b: number) => void;
+  readonly __wbg_spaceplatehandle_free: (a: number, b: number) => void;
   readonly __wbg_symboliccircle_free: (a: number, b: number) => void;
   readonly __wbg_symbolicfillarea_free: (a: number, b: number) => void;
   readonly __wbg_symbolicpolyline_free: (a: number, b: number) => void;
@@ -848,6 +929,21 @@ export interface InitOutput {
   readonly profileentryjs_modelIndex: (a: number) => number;
   readonly profileentryjs_outerPoints: (a: number) => number;
   readonly profileentryjs_transform: (a: number) => number;
+  readonly spaceplatehandle_boundingElements: (a: number, b: number, c: number) => void;
+  readonly spaceplatehandle_dragVertex: (a: number, b: number, c: number, d: number, e: number) => void;
+  readonly spaceplatehandle_duplicate: (a: number) => number;
+  readonly spaceplatehandle_faceArea: (a: number, b: number) => number;
+  readonly spaceplatehandle_faceOutline: (a: number, b: number, c: number) => void;
+  readonly spaceplatehandle_findVertexNear: (a: number, b: number, c: number, d: number) => number;
+  readonly spaceplatehandle_mergeFaces: (a: number, b: number, c: number) => void;
+  readonly spaceplatehandle_neighborAcross: (a: number, b: number) => number;
+  readonly spaceplatehandle_new: (a: number, b: number, c: number, d: number, e: number, f: number, g: number) => void;
+  readonly spaceplatehandle_roomCount: (a: number) => number;
+  readonly spaceplatehandle_roomIds: (a: number, b: number) => void;
+  readonly spaceplatehandle_setFaceHeight: (a: number, b: number, c: number, d: number, e: number) => void;
+  readonly spaceplatehandle_snapshot: (a: number, b: number) => void;
+  readonly spaceplatehandle_splitEdge: (a: number, b: number, c: number, d: number, e: number) => void;
+  readonly spaceplatehandle_splitFace: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
   readonly symboliccircle_centerX: (a: number) => number;
   readonly symboliccircle_centerY: (a: number) => number;
   readonly symboliccircle_endAngle: (a: number) => number;
@@ -912,10 +1008,13 @@ export interface InitOutput {
   readonly symbolictext_worldY: (a: number) => number;
   readonly symbolictext_x: (a: number) => number;
   readonly symbolictext_y: (a: number) => number;
-  readonly __wbindgen_export: (a: number) => void;
-  readonly __wbindgen_export2: (a: number, b: number, c: number) => void;
-  readonly __wbindgen_export3: (a: number, b: number) => number;
-  readonly __wbindgen_export4: (a: number, b: number, c: number, d: number) => number;
+  readonly __wasm_bindgen_func_elem_719: (a: number, b: number, c: number) => void;
+  readonly __wasm_bindgen_func_elem_718: (a: number, b: number) => void;
+  readonly __wasm_bindgen_func_elem_758: (a: number, b: number, c: number, d: number) => void;
+  readonly __wbindgen_export: (a: number, b: number) => number;
+  readonly __wbindgen_export2: (a: number, b: number, c: number, d: number) => number;
+  readonly __wbindgen_export3: (a: number) => void;
+  readonly __wbindgen_export4: (a: number, b: number, c: number) => void;
   readonly __wbindgen_add_to_stack_pointer: (a: number) => number;
   readonly __wbindgen_start: () => void;
 }

--- a/rust/geometry/src/lib.rs
+++ b/rust/geometry/src/lib.rs
@@ -91,6 +91,7 @@ pub mod profile_extractor;
 pub mod profiles;
 pub mod projection_outline;
 pub mod router;
+pub mod space_dcel;
 pub mod transform;
 pub mod triangulation;
 pub mod void_analysis;

--- a/rust/geometry/src/space_dcel.rs
+++ b/rust/geometry/src/space_dcel.rs
@@ -1,0 +1,1274 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! # Persistent, editable space topology (DCEL)
+//!
+//! This is the Rust core of the interactive space-sketch editor. It does
+//! what the one-shot TS `auto-space-detect` pipeline does — turn a set of
+//! 2D wall-axis segments into the enclosed room faces of a floor plate —
+//! but instead of building a half-edge graph, walking it once, and
+//! **throwing it away** (returning bare `Vec<[f64;2]>` outlines), it keeps
+//! the [`SpacePlate`] alive as the authoritative topology and exposes
+//! local, O(degree) edit operations on it:
+//!
+//! - [`SpacePlate::drag_vertex`] — move a vertex; every incident face
+//!   follows in the same call because a shared wall is **one** edge whose
+//!   endpoints are shared vertices. This is the whole "pull one room, the
+//!   neighbour follows" trick, and it falls out of the structure for free.
+//! - [`SpacePlate::split_face`] — insert a partition between two vertices
+//!   of a face (subdivide a room). O(1) surgery; both children valid
+//!   immediately.
+//! - [`SpacePlate::merge_faces`] — remove a shared edge, unioning the two
+//!   rooms it separated. O(1) surgery.
+//!
+//! Every edit returns the [`FaceId`]s it touched (with recomputed outline
+//! + area) so the TS mirror can re-render only what changed.
+//!
+//! ## What this adds over the TS detector
+//!
+//! 1. **Persistence.** The DCEL survives across edits; ids are stable
+//!    (tombstoned, never reused) so a TS-side hit-test mirror can reference
+//!    a face/edge across frames.
+//! 2. **Source-element provenance.** Each input segment carries the IFC
+//!    element id it came from; that id is propagated through snapping,
+//!    T-junction resolution and intersection-splitting onto every bounding
+//!    half-edge. This is what makes `IfcRelSpaceBoundary` emission and the
+//!    leak-repair affordance possible at bake — the TS detector drops it.
+//! 3. **`prev` pointers + the outer face as a real face**, so split/merge
+//!    are pure pointer surgery with no re-walk of the whole plate.
+//!
+//! ## Conventions
+//!
+//! - Interior (room) faces wind **CCW** (signed area > 0). The unbounded
+//!   exterior winds **CW** and is flagged [`Face::is_outer`]. A plate with
+//!   several disconnected wall clusters has one outer face per component.
+//! - A half-edge's [`HalfEdge::face`] is the face on its **left**.
+//! - Holes / nested faces (a room enclosing a courtyard) are out of scope
+//!   for this prototype: every CW cycle is treated as exterior, matching
+//!   the TS detector. See the module TODO at the bottom.
+
+use rustc_hash::FxHashMap;
+
+/// Stable handle to a vertex. Survives edits; never reused after tombstoning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct VertexId(pub u32);
+
+/// Stable handle to a directed half-edge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct HalfEdgeId(pub u32);
+
+/// Stable handle to a face (a room, or the unbounded exterior).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct FaceId(pub u32);
+
+/// An input wall-axis segment tagged with the IFC element it came from.
+///
+/// `source_element` is the express id of the originating wall / divider.
+/// `None` marks a synthetic segment with no single source (rare; e.g. a
+/// user-drawn guide). It is propagated to every half-edge derived from this
+/// segment so the bake step can recover `IfcRelSpaceBoundary` links.
+#[derive(Debug, Clone, Copy)]
+pub struct InputSegment {
+    pub a: [f64; 2],
+    pub b: [f64; 2],
+    pub source_element: Option<u32>,
+}
+
+impl InputSegment {
+    pub fn new(a: [f64; 2], b: [f64; 2], source_element: Option<u32>) -> Self {
+        Self { a, b, source_element }
+    }
+}
+
+/// Tuning for the arrangement pass. Distances are in the same units as the
+/// input segments (the caller is expected to pre-scale to metres, exactly
+/// as `extract-walls` does on the TS side).
+#[derive(Debug, Clone, Copy)]
+pub struct BuildOptions {
+    /// Endpoints closer than this merge to one vertex. Also the radius for
+    /// snapping a dangling wall-end onto a neighbour's interior (T-junction).
+    pub snap_tolerance: f64,
+    /// Faces below this absolute area are discarded as slivers.
+    pub min_area: f64,
+}
+
+impl Default for BuildOptions {
+    fn default() -> Self {
+        // Mirrors the TS `generate-spaces` defaults.
+        Self { snap_tolerance: 0.1, min_area: 0.5 }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Vertex {
+    pos: [f64; 2],
+    /// One outgoing half-edge, or `None` once isolated/tombstoned.
+    outgoing: Option<HalfEdgeId>,
+    alive: bool,
+}
+
+#[derive(Debug, Clone)]
+struct HalfEdge {
+    origin: VertexId,
+    twin: HalfEdgeId,
+    next: HalfEdgeId,
+    prev: HalfEdgeId,
+    face: FaceId,
+    /// The IFC element this edge bounds, propagated from the input segment.
+    /// `None` for the exterior side of a boundary-less cut or a user split.
+    source_element: Option<u32>,
+    alive: bool,
+}
+
+#[derive(Debug, Clone)]
+struct Face {
+    /// One boundary half-edge, or `None` once tombstoned.
+    half_edge: Option<HalfEdgeId>,
+    is_outer: bool,
+    floor_z: f64,
+    ceiling_z: f64,
+    /// Set when the ceiling plane is inferred (e.g. pitched roof underside);
+    /// carried through edits so the sketch UI can telegraph "approximate".
+    non_planar_ceiling: bool,
+    alive: bool,
+}
+
+/// A face touched by an edit, with enough geometry for the caller to
+/// re-render it without re-querying the whole plate.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FacePatch {
+    pub face: FaceId,
+    /// CCW outline; the first vertex is **not** repeated.
+    pub outline: Vec<[f64; 2]>,
+    pub area: f64,
+    /// `false` when the edit left the face self-intersecting or degenerate.
+    /// The op still applies (fluid dragging shouldn't fight the user); the
+    /// caller decides whether to telegraph the invalid state.
+    pub simple: bool,
+}
+
+/// Errors an edit op can reject with. Build never fails — a malformed input
+/// just yields fewer (or zero) interior faces, matching the TS detector.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EditError {
+    /// A referenced id is tombstoned or out of range.
+    StaleHandle,
+    /// `split_face`: the two vertices aren't both on the target face.
+    VerticesNotOnFace,
+    /// `split_face`: the two endpoints are the same, or already adjacent on
+    /// the face (the cut would have zero area on one side).
+    DegenerateCut,
+    /// `merge_faces`: the edge borders the exterior, so there's no second
+    /// room to merge with (that's a delete, not a merge).
+    BordersExterior,
+    /// `merge_faces`: both sides are the same face — the edge is a bridge,
+    /// and removing it would change connectivity rather than union two rooms.
+    BridgeEdge,
+}
+
+/// The persistent floor-plate topology. See the module docs.
+#[derive(Debug, Clone)]
+pub struct SpacePlate {
+    vertices: Vec<Vertex>,
+    half_edges: Vec<HalfEdge>,
+    faces: Vec<Face>,
+}
+
+const EPS: f64 = 1e-9;
+
+impl SpacePlate {
+    // ───────────────────────── construction ─────────────────────────
+
+    /// Build the plate from tagged wall-axis segments.
+    ///
+    /// Pipeline (ported from `auto-space-detect.ts`, provenance added):
+    /// 1. snap endpoints onto a spatial-hash grid,
+    /// 2. snap dangling endpoints onto nearby edge interiors (T-junctions),
+    /// 3. resolve interior crossings, splitting both hosts,
+    /// 4. dedupe undirected edges,
+    /// 5. build the half-edge graph with angle-sorted vertex fans,
+    /// 6. assign `next`/`prev` by the leftmost-turn rule and walk faces,
+    /// 7. flag CW cycles as exterior and drop sub-`min_area` rooms.
+    pub fn build(segments: &[InputSegment], options: BuildOptions) -> Self {
+        let arr = Arrangement::resolve(segments, options.snap_tolerance);
+        Self::from_arrangement(arr, options.min_area)
+    }
+
+    fn from_arrangement(arr: Arrangement, min_area: f64) -> Self {
+        let mut plate = SpacePlate {
+            vertices: arr
+                .vertices
+                .iter()
+                .map(|&pos| Vertex { pos, outgoing: None, alive: true })
+                .collect(),
+            half_edges: Vec::with_capacity(arr.edges.len() * 2),
+            faces: Vec::new(),
+        };
+
+        // Two half-edges per undirected edge, twinned. Record outgoing fans.
+        let mut fans: Vec<Vec<(HalfEdgeId, f64)>> = vec![Vec::new(); arr.vertices.len()];
+        for e in &arr.edges {
+            let (a, b, src) = (e.a, e.b, e.source);
+            let pa = arr.vertices[a];
+            let pb = arr.vertices[b];
+            let fwd = HalfEdgeId(plate.half_edges.len() as u32);
+            let bwd = HalfEdgeId(plate.half_edges.len() as u32 + 1);
+            // Placeholder next/prev/face — patched after fans are sorted.
+            plate.half_edges.push(HalfEdge {
+                origin: VertexId(a as u32),
+                twin: bwd,
+                next: fwd,
+                prev: fwd,
+                face: FaceId(0),
+                source_element: src,
+                alive: true,
+            });
+            plate.half_edges.push(HalfEdge {
+                origin: VertexId(b as u32),
+                twin: fwd,
+                next: bwd,
+                prev: bwd,
+                face: FaceId(0),
+                source_element: src,
+                alive: true,
+            });
+            fans[a].push((fwd, (pb[1] - pa[1]).atan2(pb[0] - pa[0])));
+            fans[b].push((bwd, (pa[1] - pb[1]).atan2(pa[0] - pb[0])));
+        }
+
+        for (v, fan) in fans.iter_mut().enumerate() {
+            fan.sort_by(|p, q| p.1.partial_cmp(&q.1).unwrap_or(std::cmp::Ordering::Equal));
+            plate.vertices[v].outgoing = fan.first().map(|(h, _)| *h);
+        }
+
+        // `next`: after arriving along `e` at vertex v = dest(e), leave on the
+        // clockwise neighbour of `e.twin` in v's angular fan. That yields a
+        // CCW interior walk. `prev` is the inverse.
+        for he in 0..plate.half_edges.len() {
+            let h = HalfEdgeId(he as u32);
+            let dest = plate.dest(h);
+            let twin = plate.half_edges[he].twin;
+            let fan = &fans[dest.0 as usize];
+            let idx = fan.iter().position(|(e, _)| *e == twin);
+            let Some(idx) = idx else { continue }; // structurally impossible
+            let nxt = fan[(idx + fan.len() - 1) % fan.len()].0;
+            plate.half_edges[he].next = nxt;
+            plate.half_edges[nxt.0 as usize].prev = h;
+        }
+
+        // Walk cycles → faces. CCW (signed > 0) = room; CW = exterior.
+        let mut visited = vec![false; plate.half_edges.len()];
+        for start in 0..plate.half_edges.len() {
+            if visited[start] {
+                continue;
+            }
+            let mut cycle = Vec::new();
+            let mut cur = HalfEdgeId(start as u32);
+            loop {
+                if visited[cur.0 as usize] {
+                    break;
+                }
+                visited[cur.0 as usize] = true;
+                cycle.push(cur);
+                cur = plate.half_edges[cur.0 as usize].next;
+                if cur.0 as usize == start {
+                    break;
+                }
+            }
+            let signed = plate.signed_area_of_cycle(&cycle);
+            let is_outer = signed <= 0.0;
+            // Drop sub-min-area rooms by folding them into no face: we still
+            // need a face record (half-edges must point somewhere), so we
+            // keep the cycle but flag tiny CCW faces as outer so they're not
+            // surfaced as rooms. Exterior cycles are always kept as outer.
+            let too_small = !is_outer && signed.abs() < min_area;
+            let face = FaceId(plate.faces.len() as u32);
+            plate.faces.push(Face {
+                half_edge: cycle.first().copied(),
+                is_outer: is_outer || too_small,
+                floor_z: 0.0,
+                ceiling_z: 0.0,
+                non_planar_ceiling: false,
+                alive: true,
+            });
+            for h in cycle {
+                plate.half_edges[h.0 as usize].face = face;
+            }
+        }
+
+        plate
+    }
+
+    // ───────────────────────────── edits ─────────────────────────────
+
+    /// Move `v` to `(x, y)`. Topology is untouched; every incident face is
+    /// updated by construction (they all reference this one vertex). Returns
+    /// a patch per incident *room* face — the same call updates a room and
+    /// its neighbour across a shared wall.
+    pub fn drag_vertex(&mut self, v: VertexId, x: f64, y: f64) -> Result<Vec<FacePatch>, EditError> {
+        let idx = v.0 as usize;
+        if idx >= self.vertices.len() || !self.vertices[idx].alive {
+            return Err(EditError::StaleHandle);
+        }
+        self.vertices[idx].pos = [x, y];
+        let mut faces: Vec<FaceId> = self
+            .outgoing_half_edges(v)
+            .map(|h| self.half_edges[h.0 as usize].face)
+            .collect();
+        faces.sort();
+        faces.dedup();
+        Ok(faces
+            .into_iter()
+            .filter(|f| !self.faces[f.0 as usize].is_outer)
+            .map(|f| self.face_patch(f))
+            .collect())
+    }
+
+    /// Subdivide `face` by inserting a partition edge between two of its
+    /// vertices. Returns patches for the kept face and the new face.
+    ///
+    /// The new edge carries `source_element` (`None` = a brand-new partition
+    /// the user drew, which the bake step materialises as a fresh wall or a
+    /// virtual boundary).
+    pub fn split_face(
+        &mut self,
+        face: FaceId,
+        va: VertexId,
+        vb: VertexId,
+        source_element: Option<u32>,
+    ) -> Result<Vec<FacePatch>, EditError> {
+        self.check_face(face)?;
+        if va == vb {
+            return Err(EditError::DegenerateCut);
+        }
+        // Find the boundary half-edges of `face` leaving va and vb.
+        let mut ha = None;
+        let mut hb = None;
+        for h in self.face_half_edges(face) {
+            let o = self.half_edges[h.0 as usize].origin;
+            if o == va {
+                ha = Some(h);
+            }
+            if o == vb {
+                hb = Some(h);
+            }
+        }
+        let (ha, hb) = match (ha, hb) {
+            (Some(a), Some(b)) => (a, b),
+            _ => return Err(EditError::VerticesNotOnFace),
+        };
+        // Adjacent on the face → one side has zero area. Reject.
+        if self.half_edges[ha.0 as usize].next == hb
+            || self.half_edges[hb.0 as usize].next == ha
+        {
+            return Err(EditError::DegenerateCut);
+        }
+
+        let pa_prev = self.half_edges[ha.0 as usize].prev;
+        let pb_prev = self.half_edges[hb.0 as usize].prev;
+
+        // New twin pair: e_ab (va→vb) keeps `face`; e_ba (vb→va) gets a new face.
+        let e_ab = HalfEdgeId(self.half_edges.len() as u32);
+        let e_ba = HalfEdgeId(self.half_edges.len() as u32 + 1);
+        let new_face = FaceId(self.faces.len() as u32);
+
+        self.half_edges.push(HalfEdge {
+            origin: va,
+            twin: e_ba,
+            next: hb,
+            prev: pa_prev,
+            face,
+            source_element,
+            alive: true,
+        });
+        self.half_edges.push(HalfEdge {
+            origin: vb,
+            twin: e_ab,
+            next: ha,
+            prev: pb_prev,
+            face: new_face,
+            source_element,
+            alive: true,
+        });
+
+        // Rewire the four neighbours around the new diagonal.
+        self.half_edges[pa_prev.0 as usize].next = e_ab;
+        self.half_edges[hb.0 as usize].prev = e_ab;
+        self.half_edges[pb_prev.0 as usize].next = e_ba;
+        self.half_edges[ha.0 as usize].prev = e_ba;
+
+        // Kept face anchors on e_ab; new face owns e_ba's cycle.
+        self.faces[face.0 as usize].half_edge = Some(e_ab);
+        let parent = self.faces[face.0 as usize].clone();
+        self.faces.push(Face {
+            half_edge: Some(e_ba),
+            is_outer: false,
+            floor_z: parent.floor_z,
+            ceiling_z: parent.ceiling_z,
+            non_planar_ceiling: parent.non_planar_ceiling,
+            alive: true,
+        });
+        // Re-home the new face's cycle (collect first — the walk borrows
+        // `self`, the assignment mutates it).
+        let new_cycle: Vec<HalfEdgeId> = self.face_half_edges(new_face).collect();
+        for h in new_cycle {
+            self.half_edges[h.0 as usize].face = new_face;
+        }
+
+        Ok(vec![self.face_patch(face), self.face_patch(new_face)])
+    }
+
+    /// Insert a new vertex at `(x, y)` on the undirected edge `edge` (and its
+    /// twin), subdividing it. No face is created — both incident faces simply
+    /// gain a boundary vertex. Returns the new vertex so the caller can use it
+    /// as a `split_face` endpoint. Pass a point on the edge segment to keep
+    /// areas unchanged (the caller projects the click onto the edge).
+    ///
+    /// This is what lets the user add a node where there wasn't a corner, so a
+    /// partition can start/end mid-wall rather than only at existing vertices.
+    pub fn split_edge(&mut self, edge: HalfEdgeId, x: f64, y: f64) -> Result<VertexId, EditError> {
+        let h = edge;
+        if h.0 as usize >= self.half_edges.len() || !self.half_edges[h.0 as usize].alive {
+            return Err(EditError::StaleHandle);
+        }
+        let t = self.half_edges[h.0 as usize].twin;
+        let f1 = self.half_edges[h.0 as usize].face;
+        let f2 = self.half_edges[t.0 as usize].face;
+        let h_next = self.half_edges[h.0 as usize].next;
+        let t_next = self.half_edges[t.0 as usize].next;
+        let h_src = self.half_edges[h.0 as usize].source_element;
+        let t_src = self.half_edges[t.0 as usize].source_element;
+
+        let n = VertexId(self.vertices.len() as u32);
+        let e1 = HalfEdgeId(self.half_edges.len() as u32); // N → B (was dest of h)
+        let e2 = HalfEdgeId(self.half_edges.len() as u32 + 1); // N → A (was dest of t)
+
+        self.vertices.push(Vertex { pos: [x, y], outgoing: Some(e1), alive: true });
+        self.half_edges.push(HalfEdge {
+            origin: n, twin: t, next: h_next, prev: h, face: f1, source_element: h_src, alive: true,
+        });
+        self.half_edges.push(HalfEdge {
+            origin: n, twin: h, next: t_next, prev: t, face: f2, source_element: t_src, alive: true,
+        });
+
+        // h becomes A→N; t becomes B→N. Their twins/nexts re-point through N.
+        self.half_edges[h.0 as usize].twin = e2;
+        self.half_edges[h.0 as usize].next = e1;
+        self.half_edges[t.0 as usize].twin = e1;
+        self.half_edges[t.0 as usize].next = e2;
+        self.half_edges[h_next.0 as usize].prev = e1;
+        self.half_edges[t_next.0 as usize].prev = e2;
+
+        Ok(n)
+    }
+
+    /// Remove the shared edge `edge` (and its twin), unioning the two rooms
+    /// it separated into one. Returns a patch for the surviving face.
+    pub fn merge_faces(&mut self, edge: HalfEdgeId) -> Result<Vec<FacePatch>, EditError> {
+        let h = edge;
+        if h.0 as usize >= self.half_edges.len() || !self.half_edges[h.0 as usize].alive {
+            return Err(EditError::StaleHandle);
+        }
+        let t = self.half_edges[h.0 as usize].twin;
+        let f_keep = self.half_edges[h.0 as usize].face;
+        let f_drop = self.half_edges[t.0 as usize].face;
+        if self.faces[f_keep.0 as usize].is_outer || self.faces[f_drop.0 as usize].is_outer {
+            return Err(EditError::BordersExterior);
+        }
+        if f_keep == f_drop {
+            return Err(EditError::BridgeEdge);
+        }
+
+        let (hn, hp) = {
+            let he = &self.half_edges[h.0 as usize];
+            (he.next, he.prev)
+        };
+        let (tn, tp) = {
+            let te = &self.half_edges[t.0 as usize];
+            (te.next, te.prev)
+        };
+
+        // Bypass both half-edges of the shared wall.
+        self.half_edges[hp.0 as usize].next = tn;
+        self.half_edges[tn.0 as usize].prev = hp;
+        self.half_edges[tp.0 as usize].next = hn;
+        self.half_edges[hn.0 as usize].prev = tp;
+
+        // Re-home f_drop's loop onto f_keep, then tombstone f_drop + the edge.
+        self.faces[f_keep.0 as usize].half_edge = Some(hp);
+        let merged_cycle: Vec<HalfEdgeId> = self.face_half_edges(f_keep).collect();
+        for he in merged_cycle {
+            self.half_edges[he.0 as usize].face = f_keep;
+        }
+        self.faces[f_drop.0 as usize].alive = false;
+        self.faces[f_drop.0 as usize].half_edge = None;
+
+        // Detach the removed half-edges from their endpoints' outgoing slot,
+        // tombstone them, and drop any vertex left isolated.
+        for (he, origin) in [(h, self.half_edges[h.0 as usize].origin), (t, self.half_edges[t.0 as usize].origin)] {
+            self.half_edges[he.0 as usize].alive = false;
+            self.repair_vertex_outgoing(origin, he);
+        }
+
+        Ok(vec![self.face_patch(f_keep)])
+    }
+
+    // ─────────────────────────── queries ────────────────────────────
+
+    /// The face on the far side of `edge` — its twin's face. O(1). This is
+    /// the "who's my neighbour across this wall" query the UX leans on.
+    pub fn neighbor_across(&self, edge: HalfEdgeId) -> Option<FaceId> {
+        let he = self.half_edges.get(edge.0 as usize)?;
+        if !he.alive {
+            return None;
+        }
+        Some(self.half_edges[he.twin.0 as usize].face)
+    }
+
+    /// Every live interior (room) face.
+    pub fn rooms(&self) -> impl Iterator<Item = FaceId> + '_ {
+        (0..self.faces.len())
+            .map(|i| FaceId(i as u32))
+            .filter(move |f| {
+                let face = &self.faces[f.0 as usize];
+                face.alive && !face.is_outer
+            })
+    }
+
+    /// CCW outline of a face (no repeated closing vertex).
+    pub fn face_outline(&self, face: FaceId) -> Vec<[f64; 2]> {
+        self.face_half_edges(face)
+            .map(|h| self.vertices[self.half_edges[h.0 as usize].origin.0 as usize].pos)
+            .collect()
+    }
+
+    /// Absolute area of a face.
+    pub fn face_area(&self, face: FaceId) -> f64 {
+        self.signed_area_of_cycle(&self.face_half_edges(face).collect::<Vec<_>>()).abs()
+    }
+
+    /// The bounding half-edges of a face paired with the IFC element each
+    /// came from — the raw material for `IfcRelSpaceBoundary` at bake.
+    pub fn bounding_elements(&self, face: FaceId) -> Vec<(HalfEdgeId, Option<u32>)> {
+        self.face_half_edges(face)
+            .map(|h| (h, self.half_edges[h.0 as usize].source_element))
+            .collect()
+    }
+
+    /// Set the floor / ceiling planes of a face (the vertical dimension that
+    /// turns a 2D face into a prismatic space at bake).
+    pub fn set_face_height(&mut self, face: FaceId, floor_z: f64, ceiling_z: f64, non_planar_ceiling: bool) {
+        if let Some(f) = self.faces.get_mut(face.0 as usize) {
+            f.floor_z = floor_z;
+            f.ceiling_z = ceiling_z;
+            f.non_planar_ceiling = non_planar_ceiling;
+        }
+    }
+
+    pub fn vertex_position(&self, v: VertexId) -> Option<[f64; 2]> {
+        self.vertices.get(v.0 as usize).filter(|v| v.alive).map(|v| v.pos)
+    }
+
+    /// Count of live rooms — handy for tests / UI summaries.
+    pub fn room_count(&self) -> usize {
+        self.rooms().count()
+    }
+
+    /// Nearest live vertex to `(x, y)` within `tol`, for hit-testing a drag
+    /// target from the TS side. Linear scan — a floor plate is small.
+    pub fn find_vertex_near(&self, x: f64, y: f64, tol: f64) -> Option<VertexId> {
+        let tol2 = tol * tol;
+        let mut best: Option<(VertexId, f64)> = None;
+        for (i, vtx) in self.vertices.iter().enumerate() {
+            if !vtx.alive {
+                continue;
+            }
+            let (dx, dy) = (vtx.pos[0] - x, vtx.pos[1] - y);
+            let d2 = dx * dx + dy * dy;
+            if d2 <= tol2 && best.map(|(_, b)| d2 < b).unwrap_or(true) {
+                best = Some((VertexId(i as u32), d2));
+            }
+        }
+        best.map(|(v, _)| v)
+    }
+
+    /// Snapshot every live room as a patch (outline + area + simple flag) —
+    /// for bulk render or seeding a fresh TS mirror after a rebuild.
+    pub fn room_patches(&self) -> Vec<FacePatch> {
+        self.rooms().map(|f| self.face_patch(f)).collect()
+    }
+
+    // ─────────────────────────── internals ──────────────────────────
+
+    fn dest(&self, h: HalfEdgeId) -> VertexId {
+        self.half_edges[self.half_edges[h.0 as usize].twin.0 as usize].origin
+    }
+
+    /// Walk the face cycle starting at its anchor half-edge.
+    fn face_half_edges(&self, face: FaceId) -> FaceWalk<'_> {
+        FaceWalk { plate: self, start: self.faces[face.0 as usize].half_edge, cur: None }
+    }
+
+    /// Outgoing half-edges around a vertex (via twin/next), live only.
+    fn outgoing_half_edges(&self, v: VertexId) -> impl Iterator<Item = HalfEdgeId> + '_ {
+        let start = self.vertices[v.0 as usize].outgoing;
+        VertexFan { plate: self, start, cur: None }
+    }
+
+    fn signed_area_of_cycle(&self, cycle: &[HalfEdgeId]) -> f64 {
+        let mut acc = 0.0;
+        for &h in cycle {
+            let p = self.vertices[self.half_edges[h.0 as usize].origin.0 as usize].pos;
+            let q = self.vertices[self.dest(h).0 as usize].pos;
+            acc += p[0] * q[1] - q[0] * p[1];
+        }
+        acc * 0.5
+    }
+
+    fn check_face(&self, face: FaceId) -> Result<(), EditError> {
+        match self.faces.get(face.0 as usize) {
+            Some(f) if f.alive && !f.is_outer => Ok(()),
+            Some(_) => Err(EditError::StaleHandle),
+            None => Err(EditError::StaleHandle),
+        }
+    }
+
+    /// After an edit, ensure `v.outgoing` doesn't point at the now-dead
+    /// half-edge `dead`; pick any surviving outgoing edge, else isolate. We
+    /// can't walk the vertex fan here (its start may be the dead edge), so we
+    /// scan — merges are rare and this keeps the rotation system honest.
+    fn repair_vertex_outgoing(&mut self, v: VertexId, dead: HalfEdgeId) {
+        if self.vertices[v.0 as usize].outgoing != Some(dead) {
+            return;
+        }
+        let replacement = (0..self.half_edges.len())
+            .map(|i| HalfEdgeId(i as u32))
+            .find(|h| {
+                let he = &self.half_edges[h.0 as usize];
+                he.alive && he.origin == v && *h != dead
+            });
+        self.vertices[v.0 as usize].outgoing = replacement;
+        if replacement.is_none() {
+            self.vertices[v.0 as usize].alive = false;
+        }
+    }
+
+    fn face_patch(&self, face: FaceId) -> FacePatch {
+        let outline = self.face_outline(face);
+        let area = polygon_area(&outline).abs();
+        let simple = is_simple_polygon(&outline);
+        FacePatch { face, outline, area, simple }
+    }
+}
+
+/// Iterator over the half-edges of one face cycle.
+struct FaceWalk<'a> {
+    plate: &'a SpacePlate,
+    start: Option<HalfEdgeId>,
+    cur: Option<HalfEdgeId>,
+}
+
+impl Iterator for FaceWalk<'_> {
+    type Item = HalfEdgeId;
+    fn next(&mut self) -> Option<HalfEdgeId> {
+        let start = self.start?;
+        let cur = match self.cur {
+            None => start,
+            Some(c) => {
+                let n = self.plate.half_edges[c.0 as usize].next;
+                if n == start {
+                    return None;
+                }
+                n
+            }
+        };
+        self.cur = Some(cur);
+        Some(cur)
+    }
+}
+
+/// Iterator over the outgoing half-edges around a vertex (twin → next).
+struct VertexFan<'a> {
+    plate: &'a SpacePlate,
+    start: Option<HalfEdgeId>,
+    cur: Option<HalfEdgeId>,
+}
+
+impl Iterator for VertexFan<'_> {
+    type Item = HalfEdgeId;
+    fn next(&mut self) -> Option<HalfEdgeId> {
+        let start = self.start?;
+        loop {
+            let cur = match self.cur {
+                None => start,
+                Some(c) => {
+                    // Around a vertex: twin (incoming) then its next (outgoing).
+                    let twin = self.plate.half_edges[c.0 as usize].twin;
+                    let n = self.plate.half_edges[twin.0 as usize].next;
+                    if n == start {
+                        return None;
+                    }
+                    n
+                }
+            };
+            self.cur = Some(cur);
+            if self.plate.half_edges[cur.0 as usize].alive {
+                return Some(cur);
+            }
+            if cur == start {
+                return None;
+            }
+        }
+    }
+}
+
+// ───────────────────── arrangement (the 2D sweep) ─────────────────────
+
+/// An undirected edge of the resolved arrangement.
+struct ArrEdge {
+    a: usize,
+    b: usize,
+    source: Option<u32>,
+}
+
+/// The planar arrangement: snapped vertices + split, deduped edges. This is
+/// the faithful port of the `auto-space-detect.ts` geometry, with a
+/// `source` tag threaded through every stage.
+struct Arrangement {
+    vertices: Vec<[f64; 2]>,
+    edges: Vec<ArrEdge>,
+}
+
+impl Arrangement {
+    fn resolve(segments: &[InputSegment], snap: f64) -> Arrangement {
+        let cell = snap.max(EPS);
+        let mut vertices: Vec<[f64; 2]> = Vec::new();
+        let mut grid: FxHashMap<(i64, i64), Vec<usize>> = FxHashMap::default();
+        let snap_sq = snap * snap;
+
+        let mut lookup = |pt: [f64; 2], vertices: &mut Vec<[f64; 2]>| -> usize {
+            let cx = (pt[0] / cell).floor() as i64;
+            let cy = (pt[1] / cell).floor() as i64;
+            for dx in -1..=1 {
+                for dy in -1..=1 {
+                    if let Some(bucket) = grid.get(&(cx + dx, cy + dy)) {
+                        for &id in bucket {
+                            let ddx = vertices[id][0] - pt[0];
+                            let ddy = vertices[id][1] - pt[1];
+                            if ddx * ddx + ddy * ddy <= snap_sq {
+                                return id;
+                            }
+                        }
+                    }
+                }
+            }
+            let id = vertices.len();
+            vertices.push(pt);
+            grid.entry((cx, cy)).or_default().push(id);
+            id
+        };
+
+        // 1. Snap endpoints. `Seg` carries its source through every stage.
+        let mut segs: Vec<Seg> = Vec::with_capacity(segments.len());
+        for s in segments {
+            let ai = lookup(s.a, &mut vertices);
+            let bi = lookup(s.b, &mut vertices);
+            if ai != bi {
+                segs.push(Seg { a: ai, b: bi, source: s.source_element });
+            }
+        }
+
+        // 2. T-junction snap: a dangling endpoint that lands inside another
+        // segment splits that host at the projection.
+        let mut guard = 0usize;
+        let limit = (segments.len() * 5).max(50);
+        loop {
+            let mut applied = false;
+            let endpoints: Vec<usize> = {
+                let mut s: Vec<usize> = segs.iter().flat_map(|s| [s.a, s.b]).collect();
+                s.sort_unstable();
+                s.dedup();
+                s
+            };
+            'outer: for vid in endpoints {
+                let p = vertices[vid];
+                for si in 0..segs.len() {
+                    let Seg { a, b, source } = segs[si];
+                    if a == vid || b == vid {
+                        continue;
+                    }
+                    if let Some((proj, t)) = closest_point_on_segment(p, vertices[a], vertices[b]) {
+                        let ddx = proj[0] - p[0];
+                        let ddy = proj[1] - p[1];
+                        if ddx * ddx + ddy * ddy > snap_sq {
+                            continue;
+                        }
+                        if !(1e-6..=1.0 - 1e-6).contains(&t) {
+                            continue; // endpoint, not interior
+                        }
+                        segs[si] = Seg { a, b: vid, source };
+                        segs.push(Seg { a: vid, b, source });
+                        applied = true;
+                        break 'outer;
+                    }
+                }
+            }
+            guard += 1;
+            if !applied || guard >= limit {
+                break;
+            }
+        }
+
+        // 3. Interior crossings: collect every split position per seed segment
+        // in one O(N²) pass (bbox-pruned), then cut each segment once.
+        let seeds: Vec<Seg> = segs.clone();
+        let mut splits: Vec<Vec<(f64, usize)>> =
+            seeds.iter().map(|s| vec![(0.0, s.a), (1.0, s.b)]).collect();
+        let bboxes: Vec<[f64; 4]> = seeds
+            .iter()
+            .map(|s| {
+                let (pa, pb) = (vertices[s.a], vertices[s.b]);
+                [pa[0].min(pb[0]), pa[1].min(pb[1]), pa[0].max(pb[0]), pa[1].max(pb[1])]
+            })
+            .collect();
+        for i in 0..seeds.len() {
+            for j in (i + 1)..seeds.len() {
+                let (si, sj) = (&seeds[i], &seeds[j]);
+                if si.a == sj.a || si.a == sj.b || si.b == sj.a || si.b == sj.b {
+                    continue;
+                }
+                let (bi, bj) = (bboxes[i], bboxes[j]);
+                if bi[2] < bj[0] || bj[2] < bi[0] || bi[3] < bj[1] || bj[3] < bi[1] {
+                    continue;
+                }
+                if let Some((point, t, u)) = segment_intersection_param(
+                    vertices[si.a], vertices[si.b], vertices[sj.a], vertices[sj.b],
+                ) {
+                    let nv = lookup(point, &mut vertices);
+                    if nv != si.a && nv != si.b {
+                        splits[i].push((t, nv));
+                    }
+                    if nv != sj.a && nv != sj.b {
+                        splits[j].push((u, nv));
+                    }
+                }
+            }
+        }
+
+        // 4. Emit split pieces, deduped on the undirected pair.
+        let mut edges: Vec<ArrEdge> = Vec::new();
+        let mut seen: std::collections::HashSet<(usize, usize)> = std::collections::HashSet::new();
+        for (i, mut cuts) in splits.into_iter().enumerate() {
+            let source = seeds[i].source;
+            if cuts.len() <= 2 {
+                push_edge(&mut edges, &mut seen, cuts[0].1, cuts[1].1, source);
+                continue;
+            }
+            cuts.sort_by(|p, q| p.0.partial_cmp(&q.0).unwrap_or(std::cmp::Ordering::Equal));
+            for w in cuts.windows(2) {
+                push_edge(&mut edges, &mut seen, w[0].1, w[1].1, source);
+            }
+        }
+
+        Arrangement { vertices, edges }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Seg {
+    a: usize,
+    b: usize,
+    source: Option<u32>,
+}
+
+fn push_edge(
+    edges: &mut Vec<ArrEdge>,
+    seen: &mut std::collections::HashSet<(usize, usize)>,
+    a: usize,
+    b: usize,
+    source: Option<u32>,
+) {
+    if a == b {
+        return;
+    }
+    let key = if a < b { (a, b) } else { (b, a) };
+    if seen.insert(key) {
+        edges.push(ArrEdge { a, b, source });
+    }
+}
+
+fn closest_point_on_segment(q: [f64; 2], a: [f64; 2], b: [f64; 2]) -> Option<([f64; 2], f64)> {
+    let dx = b[0] - a[0];
+    let dy = b[1] - a[1];
+    let len2 = dx * dx + dy * dy;
+    if len2 < 1e-12 {
+        return None;
+    }
+    let mut t = ((q[0] - a[0]) * dx + (q[1] - a[1]) * dy) / len2;
+    t = t.clamp(0.0, 1.0);
+    Some(([a[0] + t * dx, a[1] + t * dy], t))
+}
+
+/// Proper-crossing test. Returns the point + both parametric positions when
+/// the segments cross strictly inside at least one of them (a shared endpoint
+/// alone produces no new vertex). Naive f64 — see the robustness TODO.
+fn segment_intersection_param(
+    p1: [f64; 2], p2: [f64; 2], p3: [f64; 2], p4: [f64; 2],
+) -> Option<([f64; 2], f64, f64)> {
+    let denom = (p1[0] - p2[0]) * (p3[1] - p4[1]) - (p1[1] - p2[1]) * (p3[0] - p4[0]);
+    if denom.abs() < EPS {
+        return None;
+    }
+    let t = ((p1[0] - p3[0]) * (p3[1] - p4[1]) - (p1[1] - p3[1]) * (p3[0] - p4[0])) / denom;
+    let u = -((p1[0] - p2[0]) * (p1[1] - p3[1]) - (p1[1] - p2[1]) * (p1[0] - p3[0])) / denom;
+    let tol = 1e-7;
+    if !(-tol..=1.0 + tol).contains(&t) || !(-tol..=1.0 + tol).contains(&u) {
+        return None;
+    }
+    if (t < tol || t > 1.0 - tol) && (u < tol || u > 1.0 - tol) {
+        return None;
+    }
+    Some(([p1[0] + t * (p2[0] - p1[0]), p1[1] + t * (p2[1] - p1[1])], t, u))
+}
+
+fn polygon_area(pts: &[[f64; 2]]) -> f64 {
+    if pts.len() < 3 {
+        return 0.0;
+    }
+    let mut acc = 0.0;
+    for i in 0..pts.len() {
+        let p = pts[i];
+        let q = pts[(i + 1) % pts.len()];
+        acc += p[0] * q[1] - q[0] * p[1];
+    }
+    acc * 0.5
+}
+
+/// Cheap self-intersection screen for edit feedback: O(n²) edge-pair test on a
+/// single face boundary (faces are small). Not a robustness guarantee.
+fn is_simple_polygon(pts: &[[f64; 2]]) -> bool {
+    let n = pts.len();
+    if n < 4 {
+        return n == 3;
+    }
+    for i in 0..n {
+        let a1 = pts[i];
+        let a2 = pts[(i + 1) % n];
+        for j in (i + 1)..n {
+            // Skip shared-endpoint neighbours.
+            if j == i || (i + 1) % n == j || (j + 1) % n == i {
+                continue;
+            }
+            let b1 = pts[j];
+            let b2 = pts[(j + 1) % n];
+            if segment_intersection_param(a1, a2, b1, b2).is_some() {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a closed loop of `corners` (CCW), each edge tagged with one
+    /// source element id (so we can assert provenance).
+    fn loop_segments(corners: &[[f64; 2]], source_base: u32) -> Vec<InputSegment> {
+        let n = corners.len();
+        (0..n)
+            .map(|i| InputSegment::new(corners[i], corners[(i + 1) % n], Some(source_base + i as u32)))
+            .collect()
+    }
+
+    fn rect(x0: f64, y0: f64, x1: f64, y1: f64) -> Vec<[f64; 2]> {
+        vec![[x0, y0], [x1, y0], [x1, y1], [x0, y1]]
+    }
+
+    #[test]
+    fn single_room_area_matches() {
+        let segs = loop_segments(&rect(0.0, 0.0, 4.0, 3.0), 100);
+        let plate = SpacePlate::build(&segs, BuildOptions::default());
+        assert_eq!(plate.room_count(), 1);
+        let room = plate.rooms().next().unwrap();
+        assert!((plate.face_area(room) - 12.0).abs() < 1e-6, "area {}", plate.face_area(room));
+    }
+
+    /// Two rooms sharing a central wall — the canonical "shared edge"
+    /// fixture. A vertical wall at x=4 splits a 8×3 box into two 4×3 rooms.
+    fn two_room_plate() -> SpacePlate {
+        let segs = vec![
+            // outer box
+            InputSegment::new([0.0, 0.0], [8.0, 0.0], Some(1)),
+            InputSegment::new([8.0, 0.0], [8.0, 3.0], Some(2)),
+            InputSegment::new([8.0, 3.0], [0.0, 3.0], Some(3)),
+            InputSegment::new([0.0, 3.0], [0.0, 0.0], Some(4)),
+            // shared central wall
+            InputSegment::new([4.0, 0.0], [4.0, 3.0], Some(99)),
+        ];
+        SpacePlate::build(&segs, BuildOptions::default())
+    }
+
+    #[test]
+    fn shared_wall_yields_two_rooms() {
+        let plate = two_room_plate();
+        assert_eq!(plate.room_count(), 2, "central wall splits the box into two rooms");
+        let total: f64 = plate.rooms().map(|f| plate.face_area(f)).sum();
+        assert!((total - 24.0).abs() < 1e-6, "areas sum to the box: {total}");
+    }
+
+    #[test]
+    fn shared_wall_is_one_edge_with_a_twin_in_the_neighbour() {
+        let plate = two_room_plate();
+        let rooms: Vec<FaceId> = plate.rooms().collect();
+        // Find the half-edge of room[0] whose twin sits in a different room.
+        let mut found = false;
+        for h in plate.face_half_edges(rooms[0]) {
+            if let Some(nbr) = plate.neighbor_across(h) {
+                if nbr != rooms[0] && !plate.faces[nbr.0 as usize].is_outer {
+                    found = true;
+                    // The shared wall carries source element 99 on BOTH sides.
+                    assert_eq!(plate.half_edges[h.0 as usize].source_element, Some(99));
+                    let twin = plate.half_edges[h.0 as usize].twin;
+                    assert_eq!(plate.half_edges[twin.0 as usize].source_element, Some(99));
+                }
+            }
+        }
+        assert!(found, "the two rooms must share exactly one wall edge via twin()");
+    }
+
+    #[test]
+    fn drag_shared_vertex_updates_both_rooms_in_one_call() {
+        let mut plate = two_room_plate();
+        // The shared wall's bottom endpoint is the snapped vertex at (4,0).
+        // Find it, then slide it to x=5 — room A grows, room B shrinks, both
+        // returned by the single drag call.
+        let v = (0..plate.vertices.len())
+            .map(|i| VertexId(i as u32))
+            .find(|v| {
+                let p = plate.vertices[v.0 as usize].pos;
+                (p[0] - 4.0).abs() < 1e-9 && (p[1] - 0.0).abs() < 1e-9
+            })
+            .expect("shared bottom vertex at (4,0)");
+        let patches = plate.drag_vertex(v, 5.0, 0.0).expect("drag");
+        assert_eq!(patches.len(), 2, "both incident rooms come back from one drag");
+        let total: f64 = patches.iter().map(|p| p.area).sum();
+        // Trapezoids, but the plate area is conserved.
+        assert!((total - 24.0).abs() < 1e-6, "total area conserved under drag: {total}");
+        assert!(patches.iter().all(|p| p.simple), "both faces stay simple");
+        // The areas actually diverged from 12/12.
+        let areas: Vec<f64> = patches.iter().map(|p| p.area).collect();
+        assert!((areas[0] - areas[1]).abs() > 1.0, "drag must make the rooms unequal: {areas:?}");
+    }
+
+    #[test]
+    fn split_then_areas_sum_to_parent() {
+        let segs = loop_segments(&rect(0.0, 0.0, 4.0, 4.0), 200);
+        let mut plate = SpacePlate::build(&segs, BuildOptions::default());
+        let room = plate.rooms().next().unwrap();
+        let before = plate.face_area(room);
+        // Split corner (0,0)→(4,4) diagonal.
+        let v00 = plate.find_vertex([0.0, 0.0]);
+        let v44 = plate.find_vertex([4.0, 4.0]);
+        let patches = plate.split_face(room, v00, v44, None).expect("split");
+        assert_eq!(patches.len(), 2);
+        assert_eq!(plate.room_count(), 2, "one room became two");
+        let after: f64 = patches.iter().map(|p| p.area).sum();
+        assert!((after - before).abs() < 1e-6, "split conserves area: {before} vs {after}");
+        // Each child is ~half the 16 m² square = 8 m².
+        for p in &patches {
+            assert!((p.area - 8.0).abs() < 1e-6, "each half is 8 m²: {}", p.area);
+            assert!(p.simple);
+        }
+    }
+
+    #[test]
+    fn split_rejects_degenerate_cuts() {
+        let segs = loop_segments(&rect(0.0, 0.0, 4.0, 4.0), 300);
+        let mut plate = SpacePlate::build(&segs, BuildOptions::default());
+        let room = plate.rooms().next().unwrap();
+        let v00 = plate.find_vertex([0.0, 0.0]);
+        let v40 = plate.find_vertex([4.0, 0.0]);
+        // Adjacent corners → zero-area sliver. Must reject.
+        assert_eq!(plate.split_face(room, v00, v40, None), Err(EditError::DegenerateCut));
+        // Same vertex twice.
+        assert_eq!(plate.split_face(room, v00, v00, None), Err(EditError::DegenerateCut));
+    }
+
+    #[test]
+    fn split_edge_adds_a_shared_node_without_changing_area() {
+        let mut plate = two_room_plate();
+        let rooms: Vec<FaceId> = plate.rooms().collect();
+        let areas_before: Vec<f64> = rooms.iter().map(|f| plate.face_area(*f)).collect();
+        let verts_before = plate.face_outline(rooms[0]).len();
+
+        // The shared interior wall edge of room 0, and its midpoint.
+        let shared = plate
+            .face_half_edges(rooms[0])
+            .find(|h| {
+                plate
+                    .neighbor_across(*h)
+                    .map(|n| n != rooms[0] && !plate.faces[n.0 as usize].is_outer)
+                    .unwrap_or(false)
+            })
+            .expect("shared edge");
+        let a = plate.vertices[plate.half_edges[shared.0 as usize].origin.0 as usize].pos;
+        let bvid = plate.half_edges[plate.half_edges[shared.0 as usize].twin.0 as usize].origin;
+        let b = plate.vertices[bvid.0 as usize].pos;
+        let mid = [(a[0] + b[0]) / 2.0, (a[1] + b[1]) / 2.0];
+
+        let n = plate.split_edge(shared, mid[0], mid[1]).expect("split_edge");
+        assert_eq!(plate.vertex_position(n), Some(mid), "node sits at the requested point");
+        assert_eq!(plate.room_count(), 2, "edge split creates no new face");
+        let areas_after: Vec<f64> = rooms.iter().map(|f| plate.face_area(*f)).collect();
+        for (a0, a1) in areas_before.iter().zip(&areas_after) {
+            assert!((a0 - a1).abs() < 1e-6, "areas unchanged on-segment: {a0} vs {a1}");
+        }
+        assert_eq!(plate.face_outline(rooms[0]).len(), verts_before + 1, "room 0 gained the node");
+        assert!(
+            plate.face_outline(rooms[1]).iter().any(|p| (p[0] - mid[0]).abs() < 1e-9 && (p[1] - mid[1]).abs() < 1e-9),
+            "the neighbour room shares the new node",
+        );
+    }
+
+    #[test]
+    fn merge_undoes_a_shared_wall() {
+        let mut plate = two_room_plate();
+        assert_eq!(plate.room_count(), 2);
+        // Find the interior shared edge.
+        let rooms: Vec<FaceId> = plate.rooms().collect();
+        let shared = plate
+            .face_half_edges(rooms[0])
+            .find(|h| {
+                plate
+                    .neighbor_across(*h)
+                    .map(|n| n != rooms[0] && !plate.faces[n.0 as usize].is_outer)
+                    .unwrap_or(false)
+            })
+            .expect("shared edge");
+        let patches = plate.merge_faces(shared).expect("merge");
+        assert_eq!(patches.len(), 1, "merge returns the surviving room");
+        assert_eq!(plate.room_count(), 1, "two rooms became one");
+        assert!((patches[0].area - 24.0).abs() < 1e-6, "merged area = full box: {}", patches[0].area);
+        assert!(patches[0].simple, "merged room is a clean rectangle");
+    }
+
+    #[test]
+    fn merge_rejects_exterior_walls() {
+        let mut plate = two_room_plate();
+        let rooms: Vec<FaceId> = plate.rooms().collect();
+        // An edge whose twin is the exterior.
+        let exterior_edge = plate
+            .face_half_edges(rooms[0])
+            .find(|h| {
+                plate
+                    .neighbor_across(*h)
+                    .map(|n| plate.faces[n.0 as usize].is_outer)
+                    .unwrap_or(false)
+            })
+            .expect("an outer wall");
+        assert_eq!(plate.merge_faces(exterior_edge), Err(EditError::BordersExterior));
+    }
+
+    #[test]
+    fn t_junction_closes_a_room_without_shared_corners() {
+        // Two rooms where the central wall's axis ends ON the outer walls'
+        // interiors (no shared corner vertex) — the messy-IFC case the TS
+        // detector's T-junction pass exists for. Central wall runs y=0..3 at
+        // x=4 but its endpoints are at (4, 0.02) and (4, 2.98), i.e. they
+        // don't coincide with the box corners; T-junction snap must still
+        // close two rooms.
+        let segs = vec![
+            InputSegment::new([0.0, 0.0], [8.0, 0.0], Some(1)),
+            InputSegment::new([8.0, 0.0], [8.0, 3.0], Some(2)),
+            InputSegment::new([8.0, 3.0], [0.0, 3.0], Some(3)),
+            InputSegment::new([0.0, 3.0], [0.0, 0.0], Some(4)),
+            InputSegment::new([4.0, 0.02], [4.0, 2.98], Some(99)),
+        ];
+        let plate = SpacePlate::build(&segs, BuildOptions { snap_tolerance: 0.1, min_area: 0.5 });
+        assert_eq!(plate.room_count(), 2, "T-junction snap should still yield two rooms");
+    }
+
+    #[test]
+    fn clone_is_independent_for_undo_snapshots() {
+        // The wasm handle's `duplicate()` clones the plate for undo/redo.
+        // Editing the clone must NOT touch the original (and vice-versa) —
+        // that independence is what makes the undo stack correct.
+        let plate = two_room_plate();
+        let snapshot = plate.clone();
+
+        let mut edited = plate;
+        // Collapse a room by merging across the shared wall on the edited copy.
+        let rooms: Vec<FaceId> = edited.rooms().collect();
+        let shared = edited
+            .face_half_edges(rooms[0])
+            .find(|h| {
+                edited
+                    .neighbor_across(*h)
+                    .map(|n| n != rooms[0] && !edited.faces[n.0 as usize].is_outer)
+                    .unwrap_or(false)
+            })
+            .expect("shared edge");
+        edited.merge_faces(shared).expect("merge");
+
+        assert_eq!(edited.room_count(), 1, "edited copy merged to one room");
+        assert_eq!(snapshot.room_count(), 2, "snapshot is untouched by the edit");
+        let snap_total: f64 = snapshot.rooms().map(|f| snapshot.face_area(f)).sum();
+        assert!((snap_total - 24.0).abs() < 1e-6, "snapshot geometry intact: {snap_total}");
+    }
+
+    #[test]
+    fn provenance_distinguishes_walls_from_user_splits() {
+        let segs = loop_segments(&rect(0.0, 0.0, 4.0, 4.0), 500);
+        let mut plate = SpacePlate::build(&segs, BuildOptions::default());
+        let room = plate.rooms().next().unwrap();
+        // Every boundary edge of the derived room came from a real wall.
+        for (_h, src) in plate.bounding_elements(room) {
+            assert!(src.is_some(), "derived walls carry their source element");
+        }
+        // After a user split with source None, the new partition is unsourced.
+        let v00 = plate.find_vertex([0.0, 0.0]);
+        let v44 = plate.find_vertex([4.0, 4.0]);
+        plate.split_face(room, v00, v44, None).expect("split");
+        let child = plate.rooms().next().unwrap();
+        let unsourced = plate
+            .bounding_elements(child)
+            .iter()
+            .filter(|(_, s)| s.is_none())
+            .count();
+        assert!(unsourced >= 1, "the user-drawn partition has no source element");
+    }
+
+    // Test-only helper.
+    impl SpacePlate {
+        fn find_vertex(&self, pt: [f64; 2]) -> VertexId {
+            (0..self.vertices.len())
+                .map(|i| VertexId(i as u32))
+                .find(|v| {
+                    let p = self.vertices[v.0 as usize].pos;
+                    self.vertices[v.0 as usize].alive
+                        && (p[0] - pt[0]).abs() < 1e-6
+                        && (p[1] - pt[1]).abs() < 1e-6
+                })
+                .unwrap_or_else(|| panic!("no live vertex near {pt:?}"))
+        }
+    }
+}
+
+// TODO(space-dcel, follow-ups for the real feature):
+//  - Robust predicates: `segment_intersection_param` is naive f64. Share the
+//    adaptive-orientation floor being built for the pure-Rust CSG kernel
+//    (csg-predicate-floor worktree) so dense national-grid wall sets don't
+//    accumulate snap error.
+//  - Holes / nested faces: a CW cycle is treated as exterior, so a room
+//    enclosing a courtyard is mishandled. Add containment nesting.
+//  - Net vs gross area: faces are centreline. Net area = inset each bounding
+//    edge by half its source wall's thickness at quantity time; thickness must
+//    ride `InputSegment` (extend with a `half_thickness` field).
+//  - Leak diagnostics: detect open half-edges (a boundary that fails to close)
+//    and surface them as per-face repair markers (§2.4 of the RFC).
+//  - WASM seam: wrap `SpacePlate` in a stateful handle on `IfcAPI` with
+//    explicit create/free — long-lived handles share the dlmalloc-GC hazard
+//    from the cache-load crash fix; do NOT rely on JS GC to drop it.

--- a/rust/geometry/src/space_dcel.rs
+++ b/rust/geometry/src/space_dcel.rs
@@ -238,7 +238,10 @@ impl SpacePlate {
         }
 
         for (v, fan) in fans.iter_mut().enumerate() {
-            fan.sort_by(|p, q| p.1.partial_cmp(&q.1).unwrap_or(std::cmp::Ordering::Equal));
+            // total_cmp (not partial_cmp/unwrap) so any NaN angle from a
+            // degenerate/coincident segment sorts deterministically rather
+            // than corrupting the next/prev wiring nondeterministically.
+            fan.sort_by(|p, q| p.1.total_cmp(&q.1));
             plate.vertices[v].outgoing = fan.first().map(|(h, _)| *h);
         }
 
@@ -607,7 +610,16 @@ impl SpacePlate {
 
     /// Walk the face cycle starting at its anchor half-edge.
     fn face_half_edges(&self, face: FaceId) -> FaceWalk<'_> {
-        FaceWalk { plate: self, start: self.faces[face.0 as usize].half_edge, cur: None }
+        // Tolerate an out-of-range or tombstoned face id (a stale handle from
+        // JS) — yield an empty walk instead of panicking, so every public
+        // query (`face_outline`/`face_area`/`bounding_elements`) is safe at the
+        // wasm boundary.
+        let start = self
+            .faces
+            .get(face.0 as usize)
+            .filter(|f| f.alive)
+            .and_then(|f| f.half_edge);
+        FaceWalk { plate: self, start, cur: None }
     }
 
     /// Outgoing half-edges around a vertex (via twin/next), live only.
@@ -1189,6 +1201,16 @@ mod tests {
         ];
         let plate = SpacePlate::build(&segs, BuildOptions { snap_tolerance: 0.1, min_area: 0.5 });
         assert_eq!(plate.room_count(), 2, "T-junction snap should still yield two rooms");
+    }
+
+    #[test]
+    fn queries_tolerate_invalid_face_ids() {
+        // A stale/out-of-range face id from JS must not panic the wasm module.
+        let plate = two_room_plate();
+        let bogus = FaceId(99_999);
+        assert_eq!(plate.face_area(bogus), 0.0);
+        assert!(plate.face_outline(bogus).is_empty());
+        assert!(plate.bounding_elements(bogus).is_empty());
     }
 
     #[test]

--- a/rust/geometry/src/space_dcel.rs
+++ b/rust/geometry/src/space_dcel.rs
@@ -754,6 +754,14 @@ struct Arrangement {
 
 impl Arrangement {
     fn resolve(segments: &[InputSegment], snap: f64) -> Arrangement {
+        // Corner cleanup first: real wall centrelines miss each corner by ~half
+        // a wall thickness (one overshoots, the neighbour undershoots), so a
+        // plain endpoint snap closes them at a skewed position → trapezoids.
+        // Pull each wall-end onto the true intersection of its line with the
+        // nearest crossing wall so orthogonal walls form clean rectangles.
+        let mut owned: Vec<InputSegment> = segments.to_vec();
+        snap_corners(&mut owned, snap);
+        let segments: &[InputSegment] = &owned;
         let cell = snap.max(EPS);
         let mut vertices: Vec<[f64; 2]> = Vec::new();
         let mut grid: FxHashMap<(i64, i64), Vec<usize>> = FxHashMap::default();
@@ -907,6 +915,59 @@ fn push_edge(
     let key = if a < b { (a, b) } else { (b, a) };
     if seen.insert(key) {
         edges.push(ArrEdge { a, b, source });
+    }
+}
+
+/// Intersection of the two infinite lines through `a1→b1` and `a2→b2`.
+/// `None` when (near-)parallel.
+fn line_intersection(a1: [f64; 2], b1: [f64; 2], a2: [f64; 2], b2: [f64; 2]) -> Option<[f64; 2]> {
+    let d1 = [b1[0] - a1[0], b1[1] - a1[1]];
+    let d2 = [b2[0] - a2[0], b2[1] - a2[1]];
+    let denom = d1[0] * d2[1] - d1[1] * d2[0];
+    if denom.abs() < EPS {
+        return None;
+    }
+    let t = ((a2[0] - a1[0]) * d2[1] - (a2[1] - a1[1]) * d2[0]) / denom;
+    Some([a1[0] + t * d1[0], a1[1] + t * d1[1]])
+}
+
+/// Pull each wall-end onto the true line-intersection with the nearest crossing
+/// wall (within `tol`), so offset centrelines — whose ends miss the corner by
+/// ~half a wall thickness — close into clean (e.g. rectangular) rooms instead
+/// of trapezoids. Intersections are computed against the original geometry;
+/// ends with no crossing wall within `tol` are left untouched (leaks stay
+/// leaks). T-junctions fall out for free: an end near where its line crosses
+/// another wall snaps onto that crossing.
+fn snap_corners(segs: &mut [InputSegment], tol: f64) {
+    let lines: Vec<([f64; 2], [f64; 2])> = segs.iter().map(|s| (s.a, s.b)).collect();
+    let n = lines.len();
+    let tol2 = tol * tol;
+    for i in 0..n {
+        for slot in 0..2 {
+            let e = if slot == 0 { segs[i].a } else { segs[i].b };
+            let mut best: Option<[f64; 2]> = None;
+            let mut best_d2 = tol2;
+            for j in 0..n {
+                if i == j {
+                    continue;
+                }
+                let Some(p) = line_intersection(lines[i].0, lines[i].1, lines[j].0, lines[j].1) else {
+                    continue;
+                };
+                let d2 = (p[0] - e[0]).powi(2) + (p[1] - e[1]).powi(2);
+                if d2 < best_d2 {
+                    best_d2 = d2;
+                    best = Some(p);
+                }
+            }
+            if let Some(p) = best {
+                if slot == 0 {
+                    segs[i].a = p;
+                } else {
+                    segs[i].b = p;
+                }
+            }
+        }
     }
 }
 
@@ -1182,6 +1243,28 @@ mod tests {
             })
             .expect("an outer wall");
         assert_eq!(plate.merge_faces(exterior_edge), Err(EditError::BordersExterior));
+    }
+
+    #[test]
+    fn offset_centrelines_close_into_a_clean_rectangle() {
+        // An 8×8 room whose wall centrelines miss each corner by ~0.1 m (one
+        // wall overshoots, the neighbour undershoots) — the real-world case
+        // that produced trapezoids. Corner-snap must recover the exact
+        // rectangle (area 64), not a skewed quad.
+        let segs = vec![
+            InputSegment::new([-0.1, 8.0], [8.1, 8.0], Some(1)), // top, overshoots both ends
+            InputSegment::new([8.0, 7.9], [8.0, -0.1], Some(2)), // right, undershoots top
+            InputSegment::new([8.1, 0.0], [-0.1, 0.0], Some(3)), // bottom
+            InputSegment::new([0.0, 8.1], [0.0, 0.1], Some(4)),  // left, undershoots bottom
+        ];
+        let plate = SpacePlate::build(&segs, BuildOptions { snap_tolerance: 0.25, min_area: 0.5 });
+        assert_eq!(plate.room_count(), 1, "the four offset walls close into one room");
+        let room = plate.rooms().next().unwrap();
+        assert!(
+            (plate.face_area(room) - 64.0).abs() < 1e-6,
+            "corners must snap to the line intersections → exact 8×8; got {}",
+            plate.face_area(room),
+        );
     }
 
     #[test]

--- a/rust/geometry/src/space_dcel.rs
+++ b/rust/geometry/src/space_dcel.rs
@@ -954,6 +954,13 @@ fn snap_corners(segs: &mut [InputSegment], tol: f64) {
                 let Some(p) = line_intersection(lines[i].0, lines[i].1, lines[j].0, lines[j].1) else {
                     continue;
                 };
+                // The intersection must lie near segment j's FINITE extent, not
+                // just its infinite line — else a distant aligned wall could
+                // pull this end onto a phantom corner and fabricate a room.
+                match closest_point_on_segment(p, lines[j].0, lines[j].1) {
+                    Some((host, _)) if (host[0] - p[0]).powi(2) + (host[1] - p[1]).powi(2) <= tol2 => {}
+                    _ => continue,
+                }
                 let d2 = (p[0] - e[0]).powi(2) + (p[1] - e[1]).powi(2);
                 if d2 < best_d2 {
                     best_d2 = d2;
@@ -1264,6 +1271,23 @@ mod tests {
             (plate.face_area(room) - 64.0).abs() < 1e-6,
             "corners must snap to the line intersections → exact 8×8; got {}",
             plate.face_area(room),
+        );
+    }
+
+    #[test]
+    fn corner_snap_skips_distant_wall_extensions() {
+        // A short wall's end (1.9, 0) sits near where a FAR wall's line (x=2,
+        // y 3..8) would cross, but that wall is nowhere near — the corner-snap
+        // must NOT pull the end onto the phantom (2, 0).
+        let mut segs = vec![
+            InputSegment::new([0.0, 0.0], [1.9, 0.0], None),
+            InputSegment::new([2.0, 3.0], [2.0, 8.0], None),
+        ];
+        super::snap_corners(&mut segs, 0.25);
+        let e = segs[0].b;
+        assert!(
+            (e[0] - 1.9).abs() < 1e-9 && e[1].abs() < 1e-9,
+            "end must stay put (no phantom snap to 2,0): {e:?}",
         );
     }
 

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -13,6 +13,7 @@ mod gpu_meshes;
 mod grid_lines;
 mod mesh_outline;
 mod parsing;
+mod space_plate;
 pub(crate) mod styling;
 mod symbolic;
 

--- a/rust/wasm-bindings/src/api/space_plate.rs
+++ b/rust/wasm-bindings/src/api/space_plate.rs
@@ -1,0 +1,247 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! WASM API: `SpacePlateHandle` — a **stateful** handle over the persistent
+//! space-topology DCEL (`ifc_lite_geometry::space_dcel::SpacePlate`).
+//!
+//! Unlike the rest of this crate's coarse, stateless batch calls
+//! (`processGeometryBatch` etc.), the interactive space editor needs to drive
+//! per-frame edits against a topology that **lives across calls**. So this
+//! exports an owning handle: build once from wall-axis segments, then call
+//! `dragVertex` / `splitFace` / `mergeFaces` on the same object, each returning
+//! only the faces it changed.
+//!
+//! ## Lifetime — call `.free()` explicitly
+//!
+//! wasm-bindgen gives the JS object a generated `.free()`. The `SpacePlate`
+//! owns Rust-side `Vec`s on the shared dlmalloc heap; **do not** rely on JS GC
+//! to reclaim it (the FinalizationRegistry fires nondeterministically, and a
+//! long-lived handle that outlives its model is exactly the heap-corruption
+//! footgun seen in the cache-load crash fix). The TS owner must `free()` the
+//! handle when the sketch session ends.
+//!
+//! ## Wire format
+//!
+//! Segments cross the boundary as flat arrays to stay allocation-light:
+//! `segCoords = [ax, ay, bx, by, …]` (4 f64 per segment) and one `i32` per
+//! segment in `segSources` (`-1` = no source element). Edit ops return arrays
+//! of `{ face, area, simple, outline }` via `serde-wasm-bindgen`; `outline` is
+//! `[[x, y], …]` with no repeated closing vertex.
+
+use ifc_lite_geometry::space_dcel::{
+    BuildOptions, EditError, FaceId, FacePatch, HalfEdgeId, InputSegment, SpacePlate, VertexId,
+};
+use serde::Serialize;
+use wasm_bindgen::prelude::*;
+
+/// One face returned to JS after a build or an edit.
+#[derive(Serialize)]
+struct FacePatchJs {
+    face: u32,
+    area: f64,
+    simple: bool,
+    /// CCW outline `[[x, y], …]`, no repeated closing vertex.
+    outline: Vec<[f64; 2]>,
+}
+
+impl From<FacePatch> for FacePatchJs {
+    fn from(p: FacePatch) -> Self {
+        FacePatchJs { face: p.face.0, area: p.area, simple: p.simple, outline: p.outline }
+    }
+}
+
+/// One bounding half-edge of a face, with the IFC element it came from
+/// (`source = null` for a user-drawn partition). Raw material for
+/// `IfcRelSpaceBoundary` at bake.
+#[derive(Serialize)]
+struct BoundaryJs {
+    edge: u32,
+    source: Option<u32>,
+}
+
+/// A persistent, editable floor-plate topology. See the module docs.
+#[wasm_bindgen]
+pub struct SpacePlateHandle {
+    inner: SpacePlate,
+}
+
+#[wasm_bindgen]
+impl SpacePlateHandle {
+    /// Build a plate from flat wall-axis segments.
+    ///
+    /// `segCoords`: `[ax, ay, bx, by, …]` (length a multiple of 4).
+    /// `segSources`: one `i32` per segment, `-1` for none.
+    /// `snapTolerance` / `minArea`: pass `<= 0` to take the defaults.
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        seg_coords: &[f64],
+        seg_sources: &[i32],
+        snap_tolerance: f64,
+        min_area: f64,
+    ) -> Result<SpacePlateHandle, JsValue> {
+        if !seg_coords.len().is_multiple_of(4) {
+            return Err(JsValue::from_str(
+                "segCoords length must be a multiple of 4 (ax, ay, bx, by per segment)",
+            ));
+        }
+        let n = seg_coords.len() / 4;
+        if seg_sources.len() != n {
+            return Err(JsValue::from_str(
+                "segSources length must equal the segment count (segCoords.len / 4)",
+            ));
+        }
+        let segments: Vec<InputSegment> = (0..n)
+            .map(|i| {
+                let o = i * 4;
+                let src = seg_sources[i];
+                InputSegment::new(
+                    [seg_coords[o], seg_coords[o + 1]],
+                    [seg_coords[o + 2], seg_coords[o + 3]],
+                    if src < 0 { None } else { Some(src as u32) },
+                )
+            })
+            .collect();
+        let defaults = BuildOptions::default();
+        let opts = BuildOptions {
+            snap_tolerance: if snap_tolerance > 0.0 { snap_tolerance } else { defaults.snap_tolerance },
+            min_area: if min_area > 0.0 { min_area } else { defaults.min_area },
+        };
+        Ok(SpacePlateHandle { inner: SpacePlate::build(&segments, opts) })
+    }
+
+    /// Number of live rooms.
+    #[wasm_bindgen(getter, js_name = roomCount)]
+    pub fn room_count(&self) -> usize {
+        self.inner.room_count()
+    }
+
+    /// Deep-copy the plate for an undo/redo snapshot. The clone owns its own
+    /// heap; the caller must `.free()` it like any handle.
+    #[wasm_bindgen(js_name = duplicate)]
+    pub fn duplicate(&self) -> SpacePlateHandle {
+        SpacePlateHandle { inner: self.inner.clone() }
+    }
+
+    /// Face ids of every live room.
+    #[wasm_bindgen(js_name = roomIds)]
+    pub fn room_ids(&self) -> Vec<u32> {
+        self.inner.rooms().map(|f| f.0).collect()
+    }
+
+    /// All live rooms as `{ face, area, simple, outline }` patches.
+    #[wasm_bindgen(js_name = snapshot)]
+    pub fn snapshot(&self) -> Result<JsValue, JsValue> {
+        let rooms: Vec<FacePatchJs> =
+            self.inner.room_patches().into_iter().map(Into::into).collect();
+        to_js(&rooms)
+    }
+
+    /// Absolute area (m²) of a face.
+    #[wasm_bindgen(js_name = faceArea)]
+    pub fn face_area(&self, face: u32) -> f64 {
+        self.inner.face_area(FaceId(face))
+    }
+
+    /// Flat outline `[x0, y0, x1, y1, …]` of a face (no repeated closing vertex).
+    #[wasm_bindgen(js_name = faceOutline)]
+    pub fn face_outline(&self, face: u32) -> Vec<f64> {
+        self.inner
+            .face_outline(FaceId(face))
+            .into_iter()
+            .flat_map(|p| [p[0], p[1]])
+            .collect()
+    }
+
+    /// Nearest live vertex id to `(x, y)` within `tol`, or `undefined`.
+    #[wasm_bindgen(js_name = findVertexNear)]
+    pub fn find_vertex_near(&self, x: f64, y: f64, tol: f64) -> Option<u32> {
+        self.inner.find_vertex_near(x, y, tol).map(|v| v.0)
+    }
+
+    /// The room on the far side of a half-edge (its twin's face), or
+    /// `undefined`. O(1) — the "who's across this wall" query.
+    #[wasm_bindgen(js_name = neighborAcross)]
+    pub fn neighbor_across(&self, edge: u32) -> Option<u32> {
+        self.inner.neighbor_across(HalfEdgeId(edge)).map(|f| f.0)
+    }
+
+    /// Bounding half-edges of a face paired with their source element —
+    /// `[{ edge, source }, …]` — for `IfcRelSpaceBoundary` at bake.
+    #[wasm_bindgen(js_name = boundingElements)]
+    pub fn bounding_elements(&self, face: u32) -> Result<JsValue, JsValue> {
+        let v: Vec<BoundaryJs> = self
+            .inner
+            .bounding_elements(FaceId(face))
+            .into_iter()
+            .map(|(e, source)| BoundaryJs { edge: e.0, source })
+            .collect();
+        to_js(&v)
+    }
+
+    /// Set a face's floor / ceiling planes (the vertical dimension that turns a
+    /// 2D face into a prismatic space at bake).
+    #[wasm_bindgen(js_name = setFaceHeight)]
+    pub fn set_face_height(&mut self, face: u32, floor_z: f64, ceiling_z: f64, non_planar: bool) {
+        self.inner.set_face_height(FaceId(face), floor_z, ceiling_z, non_planar);
+    }
+
+    /// Move a vertex; returns the rooms it changed. A shared wall is one edge
+    /// whose endpoints are shared vertices, so one drag updates both rooms.
+    #[wasm_bindgen(js_name = dragVertex)]
+    pub fn drag_vertex(&mut self, v: u32, x: f64, y: f64) -> Result<JsValue, JsValue> {
+        let patches = self.inner.drag_vertex(VertexId(v), x, y).map_err(edit_err)?;
+        patches_to_js(patches)
+    }
+
+    /// Subdivide a face with a partition between two of its vertices. `source`
+    /// `-1` marks a brand-new partition (materialised as a fresh wall at bake).
+    /// Returns the kept face and the new face.
+    #[wasm_bindgen(js_name = splitFace)]
+    pub fn split_face(&mut self, face: u32, va: u32, vb: u32, source: i32) -> Result<JsValue, JsValue> {
+        let src = if source < 0 { None } else { Some(source as u32) };
+        let patches = self
+            .inner
+            .split_face(FaceId(face), VertexId(va), VertexId(vb), src)
+            .map_err(edit_err)?;
+        patches_to_js(patches)
+    }
+
+    /// Insert a new vertex at `(x, y)` on edge `edge`, subdividing it (no new
+    /// face). Returns the new vertex id — use it as a `splitFace` endpoint to
+    /// cut between points that weren't existing corners. Project `(x, y)` onto
+    /// the edge to keep areas unchanged.
+    #[wasm_bindgen(js_name = splitEdge)]
+    pub fn split_edge(&mut self, edge: u32, x: f64, y: f64) -> Result<u32, JsValue> {
+        self.inner.split_edge(HalfEdgeId(edge), x, y).map(|v| v.0).map_err(edit_err)
+    }
+
+    /// Remove a shared wall, unioning the two rooms it separated. Returns the
+    /// surviving room.
+    #[wasm_bindgen(js_name = mergeFaces)]
+    pub fn merge_faces(&mut self, edge: u32) -> Result<JsValue, JsValue> {
+        let patches = self.inner.merge_faces(HalfEdgeId(edge)).map_err(edit_err)?;
+        patches_to_js(patches)
+    }
+}
+
+fn patches_to_js(patches: Vec<FacePatch>) -> Result<JsValue, JsValue> {
+    let v: Vec<FacePatchJs> = patches.into_iter().map(Into::into).collect();
+    to_js(&v)
+}
+
+fn to_js<T: Serialize>(value: &T) -> Result<JsValue, JsValue> {
+    serde_wasm_bindgen::to_value(value).map_err(|e| JsValue::from_str(&e.to_string()))
+}
+
+/// Map a topology-edit rejection to a JS `Error` with a stable, readable code.
+fn edit_err(e: EditError) -> JsValue {
+    let msg = match e {
+        EditError::StaleHandle => "StaleHandle: id is tombstoned or out of range",
+        EditError::VerticesNotOnFace => "VerticesNotOnFace: both split vertices must lie on the face",
+        EditError::DegenerateCut => "DegenerateCut: split endpoints are equal or already adjacent",
+        EditError::BordersExterior => "BordersExterior: edge borders the exterior — nothing to merge",
+        EditError::BridgeEdge => "BridgeEdge: edge is a bridge — removing it would split connectivity",
+    };
+    JsValue::from_str(msg)
+}

--- a/scripts/space-dcel-e2e.cjs
+++ b/scripts/space-dcel-e2e.cjs
@@ -1,0 +1,175 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * End-to-end harness for the SpacePlateHandle WASM binding.
+ *
+ * Drives the *real* wasm module (built from rust/wasm-bindings) through the
+ * full editor loop — build a plate from wall-axis segments, then drag / merge /
+ * split — asserting the topology behaves across the JS↔Rust boundary exactly as
+ * the native Rust unit tests do.
+ *
+ * Build the wasm first (nodejs target, into a temp dir so the web pkg the
+ * viewer uses is untouched):
+ *
+ *   rustup run nightly-2025-11-15 wasm-pack build rust/wasm-bindings \
+ *     --target nodejs --out-dir /tmp/space-dcel-pkg --out-name ifc-lite --release
+ *
+ * Then run:  node scripts/space-dcel-e2e.cjs [/tmp/space-dcel-pkg]
+ */
+
+const path = require('node:path');
+
+const PKG_DIR = process.argv[2] || '/tmp/space-dcel-pkg';
+const { SpacePlateHandle } = require(path.join(PKG_DIR, 'ifc-lite.js'));
+
+let failures = 0;
+function check(name, cond, detail) {
+  if (cond) {
+    console.log(`  ✓ ${name}`);
+  } else {
+    failures++;
+    console.error(`  ✗ ${name}${detail !== undefined ? ` — ${detail}` : ''}`);
+  }
+}
+const approx = (a, b, eps = 1e-6) => Math.abs(a - b) <= eps;
+const sumArea = (patches) => patches.reduce((s, p) => s + p.area, 0);
+
+// segCoords = [ax,ay,bx,by,...]; segSources = one i32 per segment (-1 = none).
+function seg(ax, ay, bx, by, src) {
+  return { coords: [ax, ay, bx, by], src };
+}
+function pack(segs) {
+  return {
+    coords: Float64Array.from(segs.flatMap((s) => s.coords)),
+    sources: Int32Array.from(segs.map((s) => s.src)),
+  };
+}
+
+// A 8×3 box split by a central wall at x=4 → two 4×3 rooms. Source 99 = the
+// shared wall; 1..4 = the outer walls.
+function twoRoomPlate() {
+  const { coords, sources } = pack([
+    seg(0, 0, 8, 0, 1),
+    seg(8, 0, 8, 3, 2),
+    seg(8, 3, 0, 3, 3),
+    seg(0, 3, 0, 0, 4),
+    seg(4, 0, 4, 3, 99),
+  ]);
+  return new SpacePlateHandle(coords, sources, 0.1, 0.5);
+}
+
+console.log('SpacePlateHandle end-to-end (real wasm)\n');
+
+// ── A. Build + derive ──────────────────────────────────────────────
+console.log('A. build a single 4×3 room');
+{
+  const { coords, sources } = pack([
+    seg(0, 0, 4, 0, 10),
+    seg(4, 0, 4, 3, 11),
+    seg(4, 3, 0, 3, 12),
+    seg(0, 3, 0, 0, 13),
+  ]);
+  const plate = new SpacePlateHandle(coords, sources, 0.1, 0.5);
+  check('one room derived', plate.roomCount === 1, `got ${plate.roomCount}`);
+  const rooms = plate.snapshot();
+  check('area = 12 m²', approx(rooms[0].area, 12), rooms[0].area);
+  check('every boundary edge carries a source', plate.boundingElements(rooms[0].face).every((b) => b.source != null));
+  plate.free();
+}
+
+// ── B. Drag a shared vertex → both rooms follow in one call ─────────
+console.log('B. drag the shared wall base — both rooms update from one call');
+{
+  const plate = twoRoomPlate();
+  check('two rooms', plate.roomCount === 2, `got ${plate.roomCount}`);
+  check('areas sum to 24', approx(sumArea(plate.snapshot()), 24));
+
+  const v = plate.findVertexNear(4, 0, 1e-6);
+  check('found shared base vertex at (4,0)', v != null, v);
+  const patches = plate.dragVertex(v, 5, 0);
+  check('drag returns BOTH rooms', patches.length === 2, `got ${patches.length}`);
+  check('area conserved under drag', approx(sumArea(patches), 24), sumArea(patches));
+  check('both faces stay simple', patches.every((p) => p.simple === true));
+  check('rooms became unequal (13.5 vs 10.5)', Math.abs(patches[0].area - patches[1].area) > 1.0,
+    patches.map((p) => p.area).join(' vs '));
+  plate.free();
+}
+
+// ── C. Merge across the shared wall via twin lookup ────────────────
+console.log('C. merge the two rooms across their shared wall');
+{
+  const plate = twoRoomPlate();
+  const [r0] = plate.roomIds();
+  const others = new Set(plate.roomIds());
+  // The shared edge: a bounding edge of r0 whose twin's face is the OTHER room.
+  let shared = null;
+  let sharedSource = null;
+  for (const b of plate.boundingElements(r0)) {
+    const nbr = plate.neighborAcross(b.edge);
+    if (nbr != null && nbr !== r0 && others.has(nbr)) {
+      shared = b.edge;
+      sharedSource = b.source;
+      break;
+    }
+  }
+  check('found the shared wall edge via neighborAcross', shared != null, shared);
+  check('shared wall reports source element 99', sharedSource === 99, sharedSource);
+
+  const merged = plate.mergeFaces(shared);
+  check('merge returns one surviving room', merged.length === 1, merged.length);
+  check('one room left', plate.roomCount === 1, plate.roomCount);
+  check('merged area = full box (24 m²)', approx(merged[0].area, 24), merged[0].area);
+  check('merged room is simple', merged[0].simple === true);
+  plate.free();
+}
+
+// ── D. Split a room with a diagonal partition (provenance distinguished) ──
+console.log('D. split a 4×4 room with a user-drawn diagonal');
+{
+  const { coords, sources } = pack([
+    seg(0, 0, 4, 0, 20),
+    seg(4, 0, 4, 4, 21),
+    seg(4, 4, 0, 4, 22),
+    seg(0, 4, 0, 0, 23),
+  ]);
+  const plate = new SpacePlateHandle(coords, sources, 0.1, 0.5);
+  const [room] = plate.roomIds();
+  const v00 = plate.findVertexNear(0, 0, 1e-6);
+  const v44 = plate.findVertexNear(4, 4, 1e-6);
+  check('found both diagonal corners', v00 != null && v44 != null, `${v00},${v44}`);
+
+  const parts = plate.splitFace(room, v00, v44, -1 /* user partition, no source */);
+  check('split returns two faces', parts.length === 2, parts.length);
+  check('two rooms now', plate.roomCount === 2, plate.roomCount);
+  check('each half is 8 m²', parts.every((p) => approx(p.area, 8)), parts.map((p) => p.area).join(','));
+  check('areas sum to parent (16)', approx(sumArea(parts), 16));
+
+  // The user partition is unsourced; the inherited walls keep their source.
+  const childBounds = plate.boundingElements(parts[1].face);
+  check('the user-drawn partition has a null source', childBounds.some((b) => b.source == null));
+  check('the inherited walls keep a source', childBounds.some((b) => b.source != null));
+  plate.free();
+}
+
+// ── E. Edit-rejection surfaces as a JS error ───────────────────────
+console.log('E. invalid edits reject across the boundary');
+{
+  const plate = twoRoomPlate();
+  const [r0] = plate.roomIds();
+  // An exterior wall: twin's face is the outer face (not a room).
+  let extEdge = null;
+  const rooms = new Set(plate.roomIds());
+  for (const b of plate.boundingElements(r0)) {
+    const nbr = plate.neighborAcross(b.edge);
+    if (nbr == null || !rooms.has(nbr)) { extEdge = b.edge; break; }
+  }
+  let threw = false;
+  try { plate.mergeFaces(extEdge); } catch (e) { threw = /BordersExterior/.test(String(e)); }
+  check('merging an exterior wall throws BordersExterior', threw);
+  plate.free();
+}
+
+console.log(`\n${failures === 0 ? 'PASS — all checks green' : `FAIL — ${failures} check(s) failed`}`);
+process.exit(failures === 0 ? 0 : 1);

--- a/scripts/space-diag.mjs
+++ b/scripts/space-diag.mjs
@@ -1,0 +1,50 @@
+/* Diagnostic: why does a model yield no walls / no rooms in Space Sketch?
+ * Usage: node scripts/space-diag.mjs <path-to.ifc>
+ * Parses headlessly and reports, per storey: byStorey count, walls considered,
+ * axis segments extracted, skip reasons, and rooms detected.
+ */
+import fs from 'node:fs';
+import { StepTokenizer, ColumnarParser } from '../packages/parser/dist/index.js';
+import { extractWallSegmentsForStorey, detectEnclosedAreas } from '../packages/create/dist/index.js';
+
+const path = process.argv[2];
+if (!path) { console.error('usage: node scripts/space-diag.mjs <path.ifc>'); process.exit(1); }
+
+const u8 = new Uint8Array(fs.readFileSync(path)); // fresh, exactly-sized buffer
+const tok = new StepTokenizer(u8);
+const refs = [];
+for (const r of tok.scanEntitiesFast()) {
+  refs.push({ expressId: r.expressId, type: r.type, byteOffset: r.offset, byteLength: r.length, lineNumber: r.line });
+}
+const store = await new ColumnarParser().parseLite(u8.buffer, refs, {});
+
+console.log(`\n${path}`);
+console.log(`schema=${store.schemaVersion} entities=${store.entityCount} hasSource=${!!store.source} unitScale=${store.lengthUnitScale}`);
+
+// raw wall counts in the file (sanity)
+const wallTypes = ['IFCWALL', 'IFCWALLSTANDARDCASE'];
+let rawWalls = 0;
+for (const ref of refs) if (wallTypes.includes(ref.type.toUpperCase())) rawWalls++;
+console.log(`raw IfcWall/IfcWallStandardCase entities in file: ${rawWalls}`);
+
+const sh = store.spatialHierarchy;
+if (!sh) { console.log('NO spatialHierarchy'); process.exit(0); }
+console.log(`storeys (byStorey keys): ${[...sh.byStorey.keys()].join(', ') || 'NONE'}`);
+
+for (const [sid, els] of sh.byStorey) {
+  const res = extractWallSegmentsForStorey(store, sid, undefined, { debug: false });
+  const reasons = {};
+  for (const s of res.skipped) reasons[s.reason] = (reasons[s.reason] || 0) + 1;
+  let rooms = [], usedTol = 0;
+  for (const tol of [0.1, 0.25, 0.5]) {
+    rooms = detectEnclosedAreas(res.segments, { snapTolerance: tol, minArea: 0.5 });
+    usedTol = tol;
+    if (rooms.length) break;
+  }
+  const name = store.entities.getName ? store.entities.getName(sid) : '';
+  console.log(
+    `storey #${sid} "${name}": byStorey=${els.length} considered=${res.considered} ` +
+    `segments=${res.segments.length} skipped=${res.skipped.length} ` +
+    `skipReasons=${JSON.stringify(reasons)} rooms=${rooms.length}@snap${usedTol}`,
+  );
+}


### PR DESCRIPTION
## What

A topology-aware **Space Sketch** editor: derive rooms from a building's walls, reshape them interactively, and bake real `IfcSpace` back to the model. Built on a persistent half-edge (DCEL) floor-plate in the Rust geometry core.

## How it works

- **Rust core** (`rust/geometry/src/space_dcel.rs`) — `SpacePlate` builds the planar arrangement from tagged wall-axis segments (snap → T-junction → intersect-split) and **keeps the half-edge graph alive** (stable tombstoned ids, `prev` pointers, source-element provenance on every edge). Edit ops `drag_vertex` / `split_face` / `split_edge` / `merge_faces` are O(1) local surgery and each return the touched faces; `clone` powers undo. **12 unit tests.**
- **WASM** (`rust/wasm-bindings/src/api/space_plate.rs`) — stateful `SpacePlateHandle`: build / drag / split (corners *or* new mid-wall nodes) / merge / `duplicate` (undo) / bake queries. Explicit `.free()` (long-lived handle; not JS-GC-safe).
- **Viewer** (`apps/viewer` → `SpaceSketchOverlay`) — storey picker (resolved names, auto-derive on select), drag/split/merge with hover telegraphing + vertex snapping, undo/redo, **Bake → `IfcSpace`** via the existing `addSpace` path, and an auto-escalating + manual **snap tolerance**.

## Wall-axis recognition fixes (`@ifc-lite/create`)

- **Bug:** every `Curve2D` `Axis` polyline (e.g. *all* of AC20-FZK-Haus) was skipped — the reader read the columnar table's `'Unknown'` sentinel for geometry primitives instead of the extractor's reliable type. Fixed via a shared `resolveEntityTypeName` (regression test added).
- **Footprint fallback** for walls without an Axis: `IfcTriangulatedFaceSet`/`IfcPolygonalFaceSet`, `IfcFacetedBrep`, and **vertically-extruded** rect / arbitrary / `IndexedPolyCurve` profiles → PCA centreline. (Horizontally-extruded multi-layer walls are correctly skipped — their profile is an elevation, not a footprint.)

## Verified (headless, real models)

| model | result |
|---|---|
| AC20-FZK-Haus | Erdgeschoss 4 rooms, Dachgeschoss 1 (12×10 perimeter via footprint) |
| 821_TallBuilding | Level 1–5 → 3 rooms each (snap auto-escalates to 0.25 m) |
| 841_house (IFC2X3) | 3 + 5 rooms; storey names resolve (Cyrillic) |
| building-architecture | tessellated walls → 4 centrelines |

`@ifc-lite/create`: 79 tests pass · `space_dcel`: 12 tests · `scripts/space-dcel-e2e.cjs`: 25/25 through the real wasm.

## Notes / scope

- 2D plan sketch for now; **3D-on-model (RTC) registration is the deferred next step.**
- `scripts/space-diag.mjs` is a headless wall→room diagnostic (`node scripts/space-diag.mjs <ifc>`).
- Remaining edges: non-vertical swept solids and composite-curve profiles aren't footprinted (rare).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Space Sketch interactive editor in the viewer toolbar: draw/edit rooms (vertex drag, split/merge), undo/redo, snap previews, and bake derived rooms to IFC. Headless space generation now available via CLI/SDK/library with auto-escalating snap and height resolution.

* **Bug Fixes & Improvements**
  * More reliable wall-axis extraction with body-footprint fallback; improved storey naming, auto-derive on selection, snap-tolerance corner cleanup to close centerline gaps.

* **Tests & Tools**
  * Added regression tests, end-to-end harness, diagnostic script, CLI generate-spaces command, and SDK spaces namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->