### PR TITLE
docs: correct dev server port to 3000 (was 5173)

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ cargo install wasm-pack   # or: curl https://rustwasm.github.io/wasm-pack/instal
 # 2. Clone and build
 git clone https://github.com/LTplus-AG/ifc-lite.git
 cd ifc-lite
-pnpm install && pnpm build && pnpm dev   # opens viewer at localhost:5173
+pnpm install && pnpm build && pnpm dev   # opens viewer at localhost:3000
 ```
 
 If you need IFC fixtures for tests, benchmarks, or stress tests, fetch them with:

--- a/apps/landing/index.html
+++ b/apps/landing/index.html
@@ -186,7 +186,7 @@
 <div class="out">  ✓ wasm core    ifc-lite-core@<span class="num">0.9.1</span> (Rust)</div>
 <div style="height:8px"></div>
 <div><span class="prompt">$</span> <span class="cmd">cd my-viewer &amp;&amp; npm run dev</span></div>
-<div class="out">  <span class="ok">▲</span> ready on http://localhost:5173</div>
+<div class="out">  <span class="ok">▲</span> ready on http://localhost:3000</div>
 <div class="out">  drop an .ifc file anywhere on the canvas</div>
 <div style="height:8px"></div>
 <div class="cmt"># includes: drag-drop, hierarchy, properties, 2D drawings</div>

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -160,7 +160,7 @@ cd apps/viewer
 pnpm dev
 ```
 
-Open http://localhost:5173 in your browser.
+Open http://localhost:3000 in your browser.
 
 ### Building WASM
 

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -47,7 +47,7 @@ Process IFC files entirely in the browser using WebAssembly.
     npm run dev
     ```
 
-Open `http://localhost:5173` and drag an IFC file onto the viewer.
+Open `http://localhost:3000` and drag an IFC file onto the viewer.
 
 !!! tip "No WebGPU? Use Three.js or Babylon.js"
     The `threejs` and `babylonjs` templates use WebGL, which works in all modern browsers. See the [Three.js](../tutorials/threejs-integration.md) and [Babylon.js](../tutorials/babylonjs-integration.md) integration guides for details.

--- a/examples/threejs-viewer/README.md
+++ b/examples/threejs-viewer/README.md
@@ -33,7 +33,7 @@ npm run dev
 > `@ifc-lite/geometry@1.11.0` uses it internally but omitted it from its own `dependencies`.
 > It will be declared transitively in the next patch release and can be removed then.
 
-Open `http://localhost:5173` and drop an IFC file. Click any element to see its IFC data in the side panel.
+Open `http://localhost:3000` and drop an IFC file. Click any element to see its IFC data in the side panel.
 
 ## Key files
 

--- a/packages/create-ifc-lite/src/templates/babylonjs.ts
+++ b/packages/create-ifc-lite/src/templates/babylonjs.ts
@@ -270,7 +270,7 @@ npm install
 npm run dev
 \`\`\`
 
-Open http://localhost:5173 and drop an IFC file.
+Open http://localhost:3000 and drop an IFC file.
 
 ## Learn More
 

--- a/packages/create-ifc-lite/src/templates/threejs.ts
+++ b/packages/create-ifc-lite/src/templates/threejs.ts
@@ -289,7 +289,7 @@ npm install
 npm run dev
 \`\`\`
 
-Open http://localhost:5173 and drop an IFC file.
+Open http://localhost:3000 and drop an IFC file.
 
 ## Learn More
 


### PR DESCRIPTION
Minor docs fix: the viewer dev server runs on **port 3000**, but several
docs still pointed at the Vite default `localhost:5173`. Updated the stray
references in:

- `README.md`
- `docs/guide/quickstart.md`, `docs/contributing/setup.md`
- `apps/landing/index.html`
- `examples/threejs-viewer/README.md`
- `packages/create-ifc-lite/src/templates/{babylonjs,threejs}.ts`

Pure `5173 → 3000` string change, one line per file. No behaviour change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all development server port references from `localhost:5173` to `localhost:3000` across setup guides, quickstart instructions, and generated project templates to reflect the correct local development server address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->