### PR TITLE
fix: double-sided pick pass · edit-gated Space Sketch · space bakes survive export

### DIFF
--- a/.changeset/pick-pass-and-space-export-fixes.md
+++ b/.changeset/pick-pass-and-space-export-fixes.md
@@ -1,0 +1,20 @@
+---
+"@ifc-lite/renderer": patch
+"@ifc-lite/create": patch
+"@ifc-lite/viewer": patch
+---
+
+fix(renderer): double-sided GPU pick pass — back-face culling could cull an
+element's entire camera-facing surface (IFC winding order varies), so clicks
+selected whatever was behind it (e.g. an IfcSpace behind a wall).
+
+fix(create): space bakes now survive the IFC round-trip —
+`addSpaceToStore` emits geometry in the model's native length unit
+(a space baked into a millimetre model used to export 1000× too small),
+and `resolveSpatialAnchor` no longer fails on models without
+`IfcOwnerHistory` (OPTIONAL from IFC4 onward); builders emit `$` instead.
+
+fix(viewer): Space Sketch surfaces real bake errors instead of counting
+them as "already a space" skips, reveals the (persisted) Spaces class
+visibility after a successful bake, and the toolbar button is edit-mode
+gated with a distinct icon.

--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -76,7 +76,7 @@ import { executeBasketIsolate } from '@/store/basket/basketCommands';
 import { useIfc } from '@/hooks/useIfc';
 import { cn } from '@/lib/utils';
 import { CSVExporter } from '@ifc-lite/export';
-import { FileSpreadsheet, FileJson, FileText, Filter, Upload, Pencil, LayoutDashboard } from 'lucide-react';
+import { FileSpreadsheet, FileJson, FileText, Filter, Upload, Pencil, DraftingCompass } from 'lucide-react';
 import { ExportDialog } from './ExportDialog';
 import { GLBExportDialog } from './GLBExportDialog';
 import { BulkPropertyEditor } from './BulkPropertyEditor';
@@ -1247,6 +1247,23 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
           user has a one-click recovery for any change. */}
       <UndoRedoButtons />
 
+      {/* Space Sketch is authoring chrome (it bakes IfcSpace
+          entities), so like every other authoring affordance it only
+          surfaces in edit mode — keeping the default toolbar lean.
+          It lives next to the Edit pill that reveals it, with the
+          same purple accent, and a drafting icon distinct from the
+          square/grid icons (Panels, Basket, View options). */}
+      {editEnabled && (
+        <ToolButton
+          tool="spaceSketch"
+          icon={DraftingCompass}
+          label="Space Sketch"
+          activeTool={activeTool}
+          onToolChange={setActiveTool}
+          activeAccentClass="bg-purple-600 text-white hover:bg-purple-700"
+        />
+      )}
+
       {/* Draw / modify gestures live in the existing Add Element
           panel (right-side `AddElementPanel`, opened via the Add
           Element button) and in the contextual Geometry edit card
@@ -1271,7 +1288,6 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
         onToolChange={setActiveTool}
         activeAccentClass="bg-amber-500 text-white hover:bg-amber-500/90"
       />
-      <ToolButton tool="spaceSketch" icon={LayoutDashboard} label="Space Sketch (DCEL)" activeTool={activeTool} onToolChange={setActiveTool} />
 
       {/* Floorplan dropdown */}
       {availableStoreys.length > 0 && (

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -389,6 +389,17 @@ export function SpaceSketchOverlay() {
   }, [storeys]);
 
   /**
+   * IfcSpace is class-hidden by default (TYPE_VISIBILITY_SEMANTIC_DEFAULTS).
+   * Flip the toggle on after a successful bake so the user sees what they
+   * just created — and, since the toggle persists, so the spaces are still
+   * visible when the exported file is reopened.
+   */
+  const revealSpaces = useCallback(() => {
+    const s = useViewerStore.getState();
+    if (!s.typeVisibility.spaces) s.toggleTypeVisibility('spaces');
+  }, []);
+
+  /**
    * Bake one storey's rooms to IfcSpace — the single path both "Bake" and
    * "Generate all" use, so they're consistent. (1) Replace: remove the spaces
    * this session previously dropped on the storey. (2) Skip rooms that overlap
@@ -402,13 +413,18 @@ export function SpaceSketchOverlay() {
     segments: Parameters<typeof offsetRoomFootprint>[1] | undefined,
     thicknesses: Parameters<typeof offsetRoomFootprint>[2] | undefined,
     authored: Pt[][],
-  ): { emitted: number; skipped: number } => {
-    if (!activeModelId) return { emitted: 0, skipped: 0 };
+  ): { emitted: number; skipped: number; error: string | null } => {
+    if (!activeModelId) return { emitted: 0, skipped: 0, error: null };
     for (const id of generatedRef.current.get(sid) ?? []) removeEntity(activeModelId, id);
     generatedRef.current.delete(sid);
     const height = floorToFloor(sid);
     const newIds: number[] = [];
     let skipped = 0;
+    // An addSpace failure (anchor resolution, missing mutation view, …) is
+    // NOT an "already a space" skip — keep the first error so the status
+    // line tells the user the truth instead of silently dropping spaces
+    // that would then be missing from the export.
+    let error: string | null = null;
     for (let oi = 0; oi < outlines.length; oi++) {
       const outline = outlines[oi];
       const [cx, cy] = centroid(outline);
@@ -420,10 +436,11 @@ export function SpaceSketchOverlay() {
         Name: `Space ${newIds.length + 1}`, ObjectType: GENERATED_SPACE_OBJECTTYPE,
         grossFloorArea: polyArea(outline),
       });
-      if (res && 'expressId' in res) newIds.push(res.expressId); else skipped++;
+      if (res && 'expressId' in res) newIds.push(res.expressId);
+      else error ??= (res && 'error' in res ? res.error : 'unknown error');
     }
     generatedRef.current.set(sid, newIds);
-    return { emitted: newIds.length, skipped };
+    return { emitted: newIds.length, skipped, error };
   }, [activeModelId, removeEntity, addSpace, floorToFloor, boundaryMode]);
 
   const bake = useCallback(() => {
@@ -435,9 +452,12 @@ export function SpaceSketchOverlay() {
     const outlines = (plate.snapshot() as Room[]).map((r) => r.outline);
     const ext = extractionRef.current;
     const authored = existingSpaceFootprintsByStorey(ifcDataStore).get(derivedStorey) ?? [];
-    const { emitted, skipped } = bakeStorey(derivedStorey, outlines, ext?.segments, ext?.thicknesses, authored);
-    setStatus(`Baked ${emitted} IfcSpace${skipped ? `, skipped ${skipped} (already a space)` : ''}.`);
-  }, [activeModelId, derivedStorey, ifcDataStore, bakeStorey]);
+    const { emitted, skipped, error } = bakeStorey(derivedStorey, outlines, ext?.segments, ext?.thicknesses, authored);
+    if (emitted > 0) revealSpaces();
+    setStatus(error
+      ? `Baked ${emitted} IfcSpace — others failed: ${error}`
+      : `Baked ${emitted} IfcSpace${skipped ? `, skipped ${skipped} (already a space)` : ''}.`);
+  }, [activeModelId, derivedStorey, ifcDataStore, bakeStorey, revealSpaces]);
 
   const bakeWholeBuilding = useCallback(async () => {
     if (!activeModelId || !ifcDataStore) { setStatus('No model loaded.'); return; }
@@ -445,6 +465,7 @@ export function SpaceSketchOverlay() {
     await ensureWasm();
     const authoredMap = existingSpaceFootprintsByStorey(ifcDataStore);
     let totalEmitted = 0, totalSkipped = 0, floors = 0;
+    let firstError: string | null = null;
     for (const st of storeys) {
       const { segments, wallThicknesses } = extractWallSegmentsForStorey(ifcDataStore, st.id);
       if (!segments.length) continue;
@@ -461,12 +482,16 @@ export function SpaceSketchOverlay() {
       const outlines = (plate!.snapshot() as Room[]).map((r) => r.outline);
       plate!.free();
       if (!outlines.length) continue;
-      const { emitted, skipped } = bakeStorey(st.id, outlines, segments, wallThicknesses, authoredMap.get(st.id) ?? []);
+      const { emitted, skipped, error } = bakeStorey(st.id, outlines, segments, wallThicknesses, authoredMap.get(st.id) ?? []);
       totalEmitted += emitted; totalSkipped += skipped;
+      firstError ??= error;
       if (emitted) floors++;
     }
-    setStatus(`Generated ${totalEmitted} IfcSpace across ${floors} storey(s)${totalSkipped ? `; skipped ${totalSkipped} existing` : ''}.`);
-  }, [activeModelId, ifcDataStore, storeys, bakeStorey]);
+    if (totalEmitted > 0) revealSpaces();
+    setStatus(firstError
+      ? `Generated ${totalEmitted} IfcSpace — others failed: ${firstError}`
+      : `Generated ${totalEmitted} IfcSpace across ${floors} storey(s)${totalSkipped ? `; skipped ${totalSkipped} existing` : ''}.`);
+  }, [activeModelId, ifcDataStore, storeys, bakeStorey, revealSpaces]);
 
   useEffect(() => () => {
     if (rafRef.current) cancelAnimationFrame(rafRef.current);

--- a/apps/viewer/src/store/slices/uiSlice.ts
+++ b/apps/viewer/src/store/slices/uiSlice.ts
@@ -27,6 +27,7 @@ const AUTHORING_TOOLS: ReadonlySet<string> = new Set([
   'addElement',
   'cesium-placement',
   'split',
+  'spaceSketch',
 ]);
 
 /**

--- a/packages/create/src/in-store/_emit-helpers.ts
+++ b/packages/create/src/in-store/_emit-helpers.ts
@@ -142,19 +142,28 @@ export function emitBodyRepresentation(
 }
 
 /**
+ * OwnerHistory STEP reference, or `$` when the model has none —
+ * IfcRoot.OwnerHistory is OPTIONAL from IFC4 onward, and minimal files
+ * (including ifc-lite's own exports) legitimately omit the entity.
+ */
+export function ownerHistoryRef(ownerHistoryId: number | null): string | null {
+  return ownerHistoryId == null ? null : `#${ownerHistoryId}`;
+}
+
+/**
  * Emit a fresh IfcRelContainedInSpatialStructure that anchors a single
  * element to its storey. Easier than mutating an existing rel — STEP
  * importers fold parallel rels back into one container at parse time.
  */
 export function emitRelContainedInSpatialStructure(
   editor: StoreEditor,
-  ownerHistoryId: number,
+  ownerHistoryId: number | null,
   elementId: number,
   storeyId: number,
 ): number {
   return editor.addEntity('IfcRelContainedInSpatialStructure', [
     generateIfcGuid(),
-    `#${ownerHistoryId}`,
+    ownerHistoryRef(ownerHistoryId),
     null,
     null,
     [`#${elementId}`],
@@ -169,7 +178,7 @@ export function emitRelContainedInSpatialStructure(
  * type-specific tail (PredefinedType, OperationType, etc.).
  */
 export function ifcElementHeader(
-  ownerHistoryId: number,
+  ownerHistoryId: number | null,
   placementId: number,
   productShapeId: number,
   params: { Name?: string; Description?: string; ObjectType?: string; Tag?: string },
@@ -177,7 +186,7 @@ export function ifcElementHeader(
 ): Array<unknown> {
   return [
     generateIfcGuid(),
-    `#${ownerHistoryId}`,
+    ownerHistoryRef(ownerHistoryId),
     params.Name ?? defaultName,
     params.Description ?? null,
     params.ObjectType ?? null,

--- a/packages/create/src/in-store/anchor.ts
+++ b/packages/create/src/in-store/anchor.ts
@@ -15,8 +15,12 @@
 export type SpatialAnchorSchema = 'IFC2X3' | 'IFC4' | 'IFC4X3' | 'IFC5';
 
 export interface SpatialAnchor {
-  /** IfcOwnerHistory expressId — referenced by every IfcRoot. */
-  ownerHistoryId: number;
+  /**
+   * IfcOwnerHistory expressId, or null when the model has none.
+   * IfcRoot.OwnerHistory is OPTIONAL from IFC4 onward — minimal files
+   * legitimately omit the entity, and builders emit `$` for it.
+   */
+  ownerHistoryId: number | null;
   /** IfcGeometricRepresentationSubContext for 'Body' (or its IfcGeometricRepresentationContext fallback). */
   bodyContextId: number;
   /** IfcGeometricRepresentationSubContext for 'Axis' (or its IfcGeometricRepresentationContext fallback). */

--- a/packages/create/src/in-store/anchor.ts
+++ b/packages/create/src/in-store/anchor.ts
@@ -35,4 +35,24 @@ export interface SpatialAnchor {
    * Defaults to `'IFC4'` when unset for backward compatibility.
    */
   schema?: SpatialAnchorSchema;
+  /**
+   * Model length-unit scale: metres per native unit (1 for a metre file,
+   * 0.001 for millimetres). Builder params are always metres (renderer
+   * frame); geometry coordinates are divided by this on emit so they land
+   * in the file's native unit. Defaults to 1 when unset. Without this, a
+   * space baked into a millimetre model exported 1000× too small (its
+   * mesh looked right in-session because that one is built in metres).
+   */
+  lengthUnitScale?: number;
+}
+
+/**
+ * Convert a metre value to the anchor's native length unit for STEP emit.
+ * Rounded to 9 decimals to absorb the float noise the division introduces
+ * (2.8 / 0.001 = 2799.9999999999995 → 2800).
+ */
+export function toNativeLength(anchor: SpatialAnchor, metres: number): number {
+  const scale = anchor.lengthUnitScale;
+  if (!scale || !Number.isFinite(scale) || scale <= 0 || scale === 1) return metres;
+  return Math.round((metres / scale) * 1e9) / 1e9;
 }

--- a/packages/create/src/in-store/beam.ts
+++ b/packages/create/src/in-store/beam.ts
@@ -23,6 +23,7 @@ import type { StoreEditor } from '@ifc-lite/mutations';
 import { vecCross, vecNorm } from '../ifc-creator-math.js';
 import type { Point3D } from '../types.js';
 import type { SpatialAnchor } from './anchor.js';
+import { ownerHistoryRef } from './_emit-helpers.js';
 
 export interface BeamInStoreParams {
   Start: [number, number, number];
@@ -126,7 +127,7 @@ export function addBeamToStore(
   // `IfcBeam.PredefinedType` only exists from IFC4 onward.
   const beamAttrs: Array<unknown> = [
     generateIfcGuid(),
-    `#${ownerHistoryId}`,
+    ownerHistoryRef(ownerHistoryId),
     params.Name ?? 'Beam',
     params.Description ?? null,
     params.ObjectType ?? null,
@@ -141,7 +142,7 @@ export function addBeamToStore(
 
   const relContainedId = editor.addEntity('IfcRelContainedInSpatialStructure', [
     generateIfcGuid(),
-    `#${ownerHistoryId}`,
+    ownerHistoryRef(ownerHistoryId),
     null,
     null,
     [`#${beamId}`],

--- a/packages/create/src/in-store/column.ts
+++ b/packages/create/src/in-store/column.ts
@@ -19,6 +19,7 @@
 import { generateIfcGuid } from '@ifc-lite/encoding';
 import type { StoreEditor } from '@ifc-lite/mutations';
 import type { SpatialAnchor } from './anchor.js';
+import { ownerHistoryRef } from './_emit-helpers.js';
 
 export interface ColumnInStoreParams {
   /** Base centre of the column, in storey-local coordinates (metres). */
@@ -118,7 +119,7 @@ export function addColumnToStore(
   // would produce an invalid 9-arg entity record.
   const columnAttrs: Array<unknown> = [
     generateIfcGuid(),
-    `#${ownerHistoryId}`,
+    ownerHistoryRef(ownerHistoryId),
     params.Name ?? 'Column',
     params.Description ?? null,
     params.ObjectType ?? null,
@@ -136,7 +137,7 @@ export function addColumnToStore(
   // existing one and produces an equivalent result on import.
   const relContainedId = editor.addEntity('IfcRelContainedInSpatialStructure', [
     generateIfcGuid(),
-    `#${ownerHistoryId}`,
+    ownerHistoryRef(ownerHistoryId),
     null,
     null,
     [`#${columnId}`],

--- a/packages/create/src/in-store/resolve-anchor.ts
+++ b/packages/create/src/in-store/resolve-anchor.ts
@@ -47,7 +47,11 @@ export function resolveSpatialAnchor(store: IfcDataStore, storeyExpressId: numbe
       const s = extractLengthUnitScale(store.source, store.entityIndex);
       if (Number.isFinite(s) && s > 0) lengthUnitScale = s;
     }
-  } catch { /* default to metres */ }
+  } catch (error) {
+    // Keep the metre fallback, but don't hide the failure — a wrong scale
+    // emits silently mis-sized geometry.
+    console.warn('resolveSpatialAnchor: failed to extract length unit scale; defaulting to metres', error);
+  }
 
   return { ownerHistoryId, bodyContextId, axisContextId, storeyId: storeyExpressId, storeyPlacementId, schema, lengthUnitScale };
 }

--- a/packages/create/src/in-store/resolve-anchor.ts
+++ b/packages/create/src/in-store/resolve-anchor.ts
@@ -15,10 +15,9 @@ import { EntityExtractor, getAttributeNames, type IfcDataStore } from '@ifc-lite
 import type { SpatialAnchor, SpatialAnchorSchema } from './anchor.js';
 
 export function resolveSpatialAnchor(store: IfcDataStore, storeyExpressId: number): SpatialAnchor {
+  // OwnerHistory is OPTIONAL from IFC4 onward — minimal files (including
+  // ifc-lite's own exports) legitimately omit it. Builders emit `$` then.
   const ownerHistoryId = findOwnerHistoryId(store);
-  if (ownerHistoryId === null) {
-    throw new Error('resolveSpatialAnchor: no IfcOwnerHistory found in store');
-  }
 
   const bodyContextId = findBodyContextId(store);
   if (bodyContextId === null) {

--- a/packages/create/src/in-store/resolve-anchor.ts
+++ b/packages/create/src/in-store/resolve-anchor.ts
@@ -11,7 +11,7 @@
  * IfcLocalPlacement.
  */
 
-import { EntityExtractor, getAttributeNames, type IfcDataStore } from '@ifc-lite/parser';
+import { EntityExtractor, extractLengthUnitScale, getAttributeNames, type IfcDataStore } from '@ifc-lite/parser';
 import type { SpatialAnchor, SpatialAnchorSchema } from './anchor.js';
 
 export function resolveSpatialAnchor(store: IfcDataStore, storeyExpressId: number): SpatialAnchor {
@@ -36,7 +36,20 @@ export function resolveSpatialAnchor(store: IfcDataStore, storeyExpressId: numbe
   }
 
   const schema = (store.schemaVersion ?? 'IFC4') as SpatialAnchorSchema;
-  return { ownerHistoryId, bodyContextId, axisContextId, storeyId: storeyExpressId, storeyPlacementId, schema };
+
+  // Builder params are metres; the file may not be (e.g. millimetre Revit
+  // exports). Resolve the length-unit scale here so builders can emit
+  // coordinates in the file's native unit — mirrors the read-side
+  // conversion in extract-walls.ts.
+  let lengthUnitScale = 1.0;
+  try {
+    if (store.source) {
+      const s = extractLengthUnitScale(store.source, store.entityIndex);
+      if (Number.isFinite(s) && s > 0) lengthUnitScale = s;
+    }
+  } catch { /* default to metres */ }
+
+  return { ownerHistoryId, bodyContextId, axisContextId, storeyId: storeyExpressId, storeyPlacementId, schema, lengthUnitScale };
 }
 
 function findOwnerHistoryId(store: IfcDataStore): number | null {

--- a/packages/create/src/in-store/slab.ts
+++ b/packages/create/src/in-store/slab.ts
@@ -25,6 +25,7 @@
 import { generateIfcGuid } from '@ifc-lite/encoding';
 import type { StoreEditor } from '@ifc-lite/mutations';
 import type { SpatialAnchor } from './anchor.js';
+import { ownerHistoryRef } from './_emit-helpers.js';
 
 export type SlabInStoreParams = SlabRectangleParams | SlabPolygonParams;
 
@@ -174,7 +175,7 @@ export function addSlabToStore(
   // `IfcSlab.PredefinedType` only exists from IFC4 onward.
   const slabAttrs: Array<unknown> = [
     generateIfcGuid(),
-    `#${ownerHistoryId}`,
+    ownerHistoryRef(ownerHistoryId),
     params.Name ?? 'Slab',
     params.Description ?? null,
     params.ObjectType ?? null,
@@ -189,7 +190,7 @@ export function addSlabToStore(
 
   const relContainedId = editor.addEntity('IfcRelContainedInSpatialStructure', [
     generateIfcGuid(),
-    `#${ownerHistoryId}`,
+    ownerHistoryRef(ownerHistoryId),
     null,
     null,
     [`#${slabId}`],

--- a/packages/create/src/in-store/space.test.ts
+++ b/packages/create/src/in-store/space.test.ts
@@ -138,6 +138,33 @@ describe('addSpaceToStore', () => {
     expect(byId.get(result.relAggregatesId)?.attributes[1]).toBeNull();
   });
 
+  // Params are metres; a millimetre model (lengthUnitScale 0.001) must get
+  // native-unit coordinates or the space reopens 1000× too small while its
+  // in-session mesh (built in metres) looks correct.
+  it('emits native-unit geometry for non-metre models', () => {
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(makeStore(40), view);
+    const result = addSpaceToStore(
+      editor,
+      { ownerHistoryId: 5, bodyContextId: 14, storeyId: 43, storeyPlacementId: 54, lengthUnitScale: 0.001 },
+      { Profile: 'polygon', OuterCurve: [[0, 0], [4, 0], [4, 3], [0, 3]], Height: 3, grossFloorArea: 12 },
+    );
+    const byId = new Map(view.getNewEntities().map((e) => [e.expressId, e]));
+    expect(byId.get(result.profileId)?.type).toBe('IfcArbitraryClosedProfileDef');
+    // Solid extrusion depth in millimetres
+    expect(byId.get(result.solidId)?.attributes[3]).toBeCloseTo(3000, 6);
+    // Polyline points in millimetres — find one of the corner points
+    const points = view.getNewEntities().filter((e) => e.type === 'IfcCartesianPoint');
+    const corner = points.find((p) => Array.isArray(p.attributes[0])
+      && (p.attributes[0] as number[])[0] === 4000 && (p.attributes[0] as number[])[1] === 3000);
+    expect(corner, 'expected a (4000, 3000) mm corner point').toBeTruthy();
+    // Areas/volumes stay in m²/m³ (their own units); LENGTH quantities scale.
+    const named = namedQ(view, result.spaceId);
+    expect(named['GrossFloorArea']).toBeCloseTo(12, 6);
+    expect(named['Height']).toBeCloseTo(3000, 6);
+    expect(named['GrossVolume']).toBeCloseTo(36, 6);
+  });
+
   it('rejects non-positive Height', () => {
     const view = new MutablePropertyView(null, 'm1');
     const editor = new StoreEditor(makeStore(10), view);

--- a/packages/create/src/in-store/space.test.ts
+++ b/packages/create/src/in-store/space.test.ts
@@ -121,6 +121,23 @@ describe('addSpaceToStore', () => {
     expect(byId.get(result.spaceBoundaryIds[1])?.attributes[8]).toBe('.INTERNAL.');
   });
 
+  // OwnerHistory is OPTIONAL from IFC4 onward — minimal files (including
+  // ifc-lite's own exports) omit it entirely. The bake must still work,
+  // emitting `$` instead of failing anchor resolution (the Space Sketch
+  // tool silently lost every baked space on such files).
+  it('emits $ OwnerHistory when the model has none', () => {
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(makeStore(40), view);
+    const result = addSpaceToStore(
+      editor,
+      { ownerHistoryId: null, bodyContextId: 14, storeyId: 43, storeyPlacementId: 54 },
+      { Position: [0, 0, 0], Width: 4, Depth: 3, Height: 3 },
+    );
+    const byId = new Map(view.getNewEntities().map((e) => [e.expressId, e]));
+    expect(byId.get(result.spaceId)?.attributes[1]).toBeNull();          // OwnerHistory = $
+    expect(byId.get(result.relAggregatesId)?.attributes[1]).toBeNull();
+  });
+
   it('rejects non-positive Height', () => {
     const view = new MutablePropertyView(null, 'm1');
     const editor = new StoreEditor(makeStore(10), view);

--- a/packages/create/src/in-store/space.ts
+++ b/packages/create/src/in-store/space.ts
@@ -25,6 +25,7 @@ import {
   emitLocalPlacement,
   emitPolygonProfile,
   emitRectangleProfile,
+  ownerHistoryRef,
 } from './_emit-helpers.js';
 
 export type SpaceInStoreParams = SpaceRectangleParams | SpacePolygonParams;
@@ -156,7 +157,7 @@ export function addSpaceToStore(
   // INTERNAL is a valid value in both enums, so it makes a safe default.
   const attrs: Array<unknown> = [
     generateIfcGuid(),
-    `#${anchor.ownerHistoryId}`,
+    ownerHistoryRef(anchor.ownerHistoryId),
     params.Name ?? 'Space',
     params.Description ?? null,
     params.ObjectType ?? null,
@@ -173,7 +174,7 @@ export function addSpaceToStore(
   // ContainedInSpatialStructure rel that IfcElement subtypes use.
   const relAggregatesId = editor.addEntity('IfcRelAggregates', [
     generateIfcGuid(),
-    `#${anchor.ownerHistoryId}`,
+    ownerHistoryRef(anchor.ownerHistoryId),
     null,
     null,
     `#${anchor.storeyId}`,
@@ -217,7 +218,7 @@ export function addSpaceToStore(
   for (const boundary of params.boundaries ?? []) {
     const boundaryId = editor.addEntity('IfcRelSpaceBoundary', [
       generateIfcGuid(),
-      `#${anchor.ownerHistoryId}`,
+      ownerHistoryRef(anchor.ownerHistoryId),
       null,
       null,
       `#${spaceId}`,

--- a/packages/create/src/in-store/space.ts
+++ b/packages/create/src/in-store/space.ts
@@ -18,7 +18,7 @@
 
 import { generateIfcGuid } from '@ifc-lite/encoding';
 import type { StoreEditor } from '@ifc-lite/mutations';
-import type { SpatialAnchor } from './anchor.js';
+import { toNativeLength, type SpatialAnchor } from './anchor.js';
 import {
   emitBodyRepresentation,
   emitExtrudedSolid,
@@ -142,11 +142,20 @@ export function addSpaceToStore(
     throw new Error('addSpaceToStore: Width and Depth must be positive');
   }
 
-  const placementId = emitLocalPlacement(editor, anchor.storeyPlacementId, placementOrigin);
+  // Geometry coordinates must land in the file's native length unit —
+  // params are metres, the file may be millimetres (a space baked into a
+  // mm model used to export 1000× too small). Quantities keep their own
+  // units below (AREAUNIT/VOLUMEUNIT are typically SI m²/m³ regardless).
+  const n = (metres: number) => toNativeLength(anchor, metres);
+  const placementId = emitLocalPlacement(
+    editor,
+    anchor.storeyPlacementId,
+    [n(placementOrigin[0]), n(placementOrigin[1]), n(placementOrigin[2])],
+  );
   const profileId = polygon
-    ? emitPolygonProfile(editor, params.OuterCurve)
-    : emitRectangleProfile(editor, params.Width, params.Depth, params.Width / 2, params.Depth / 2);
-  const solidId = emitExtrudedSolid(editor, profileId, params.Height);
+    ? emitPolygonProfile(editor, params.OuterCurve.map(([x, y]): [number, number] => [n(x), n(y)]))
+    : emitRectangleProfile(editor, n(params.Width), n(params.Depth), n(params.Width / 2), n(params.Depth / 2));
+  const solidId = emitExtrudedSolid(editor, profileId, n(params.Height));
   const { shapeRepId, productShapeId } = emitBodyRepresentation(editor, anchor.bodyContextId, solidId);
 
   // IfcSpace attribute order:
@@ -191,11 +200,13 @@ export function addSpaceToStore(
     ? polygonPerimeter(params.OuterCurve)
     : 2 * (params.Width + params.Depth);
   const grossArea = params.grossFloorArea ?? area;
+  // LENGTH quantities follow the project length unit (mm in a mm file);
+  // AREA/VOLUME have their own units which are SI m²/m³ in practice.
   editor.addQuantitySet(spaceId, 'Qto_SpaceBaseQuantities', [
     { name: 'GrossFloorArea', value: grossArea, quantityType: 'AREA' },
     { name: 'NetFloorArea', value: params.netFloorArea ?? area, quantityType: 'AREA' },
-    { name: 'GrossPerimeter', value: perimeter, quantityType: 'LENGTH' },
-    { name: 'Height', value: params.Height, quantityType: 'LENGTH' },
+    { name: 'GrossPerimeter', value: n(perimeter), quantityType: 'LENGTH' },
+    { name: 'Height', value: n(params.Height), quantityType: 'LENGTH' },
     { name: 'GrossVolume', value: grossArea * params.Height, quantityType: 'VOLUME' },
   ]);
 

--- a/packages/create/src/in-store/wall.ts
+++ b/packages/create/src/in-store/wall.ts
@@ -22,6 +22,7 @@ import type { StoreEditor } from '@ifc-lite/mutations';
 import { vecNorm } from '../ifc-creator-math.js';
 import type { Point3D } from '../types.js';
 import type { SpatialAnchor } from './anchor.js';
+import { ownerHistoryRef } from './_emit-helpers.js';
 
 export interface WallInStoreParams {
   /** Start of the wall axis, in storey-local coordinates (metres). */
@@ -126,7 +127,7 @@ export function addWallToStore(
   // `IfcWall.PredefinedType` only exists from IFC4 onward.
   const wallAttrs: Array<unknown> = [
     generateIfcGuid(),
-    `#${ownerHistoryId}`,
+    ownerHistoryRef(ownerHistoryId),
     params.Name ?? 'Wall',
     params.Description ?? null,
     params.ObjectType ?? null,
@@ -144,7 +145,7 @@ export function addWallToStore(
 
   const relContainedId = editor.addEntity('IfcRelContainedInSpatialStructure', [
     generateIfcGuid(),
-    `#${ownerHistoryId}`,
+    ownerHistoryRef(ownerHistoryId),
     null,
     null,
     [`#${wallId}`],

--- a/packages/renderer/src/picker.ts
+++ b/packages/renderer/src/picker.ts
@@ -152,7 +152,10 @@ export class Picker {
       },
       primitive: {
         topology: 'triangle-list',
-        cullMode: 'back',
+        // Must match the visual pipelines' cullMode: 'none' — IFC winding
+        // order varies, so back-face culling can cull an object's entire
+        // camera-facing surface and let whatever is behind it win the pick.
+        cullMode: 'none',
       },
       depthStencil: {
         format: 'depth32float',


### PR DESCRIPTION
## 1. Selection picks the object behind (fix)

Clicking an object with another object directly behind it often selected the one **behind** — e.g. with spaces loaded, clicking an outer wall selected the IfcSpace behind it.

**Root cause:** the GPU color-ID pick pass (`packages/renderer/src/picker.ts`) used `cullMode: 'back'` while **every visual pipeline** uses `cullMode: 'none'`, because IFC winding order is unreliable (`pipeline.ts:143`). Elements whose camera-facing triangles wind "inward" were culled from the pick pass entirely, so whatever was behind them won the depth test. The reverse-Z depth setup was already correct; the CPU raycast fallback (>50K entities) is double-sided, which is why large models picked fine.

**Fix:** pick pass renders double-sided, matching the visual pipelines.

## 2. Toolbar: Space Sketch decongestion (refactor)

- `spaceSketch` registered in `AUTHORING_TOOLS`: exiting edit mode resets the tool (the overlay used to survive edit-mode exit); entering it flips edit mode on.
- The button only renders in edit mode, next to the Edit pill, purple accent, distinct `DraftingCompass` icon (the old `LayoutDashboard` collided with Panels/Basket/View-options). Viewer-only users never see it.

## 3. Baked spaces "missing" from IFC export (fixes)

Spaces created with Space Sketch appeared baked in 3D, counted in Export Changes, but reopening the exported IFC showed none. **Four stacked causes**, found by reproducing the full flow in the running viewer:

1. **Unit-scale bug (the big one):** `addSpaceToStore` wrote metre coordinates regardless of the file's length unit. In a millimetre model (e.g. Revit's 821_TallBuilding), a 4×3×2.8 m space serialized as a 4×3×2.8 **mm** speck — present in the file, invisible on reopen. The in-session mesh is built separately in renderer-metres, so the bake looked correct until the round-trip. → `resolveSpatialAnchor` now resolves `lengthUnitScale` (mirroring the read-side conversion in `extract-walls.ts`) and the space builder emits placement/profile/extrusion/LENGTH-quantities in native units. Verified live: mm model → bake → export now contains `IFCEXTRUDEDAREASOLID(…,2800.)` and `(4000., 3000.)` corner points.
2. **OwnerHistory hard-fail:** `resolveSpatialAnchor` threw on models without `IfcOwnerHistory` — but it's OPTIONAL from IFC4 onward (ifc-lite's own exports omit it). Every in-store builder failed on such files. → `ownerHistoryId` is nullable; builders emit `$`.
3. **Silent error swallowing:** the sketch tool folded `addSpace` errors into "skipped (already a space)". → real errors now surface in the status line.
4. **Visibility default:** `typeVisibility.spaces` defaults to off, so even correctly exported spaces are hidden on reopen. → successful bake flips the (persisted) Spaces toggle on.

**Known pre-existing limitation (follow-up):** the other in-store builders (wall/slab/beam/column/door/window/roof/plate/member) still assume metre files on their geometry emit — same latent bug for non-metre models via Add Element. The `toNativeLength` helper introduced here is the mechanism to fix them; doing all nine needs per-builder auditing and is out of scope for this bugfix PR.

## Verification

- Live end-to-end in the running viewer (chrome-devtools): mm model → bake → Export Changes → STEP contains native-unit IFCSPACE → reopen meshes + renders the spaces (screenshots in session)
- `packages/create`: 85 tests pass (new regression tests: `$`-OwnerHistory bake, native-unit emit)
- `tsc --noEmit` clean: renderer, create, cli, mcp, viewer
- Viewer suite: 962+ pass / 0 fail
- Branch rebased onto `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Space Sketch tool now appears in edit mode with an updated icon and active styling.

* **Improvements**
  * Space bakes now surface real errors, reveal the Spaces layer after successful generation, and persist geometry through IFC round-trips.
  * Better handling of non-metric project units when exporting spaces.
  * Improved viewport picking accuracy to reduce mis-selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->