### PR TITLE
fix(create): emit native length units in all in-store builders

### DIFF
--- a/.changeset/native-unit-builders.md
+++ b/.changeset/native-unit-builders.md
@@ -1,0 +1,15 @@
+---
+"@ifc-lite/create": patch
+---
+
+fix(create): every in-store builder now emits geometry in the model's
+native length unit. Wall, slab, beam, column, door, window, roof, plate,
+and member wrote metre coordinates regardless of the file's length unit —
+an element added to a millimetre model (typical Revit export) serialized
+1000× too small, while its in-session mesh (built separately in renderer
+metres) looked correct until the export round-trip. The duplicate flow
+had the inverse bug: its metre offset was added to the source's
+native-unit location, so a duplicate in a mm file landed ~1000× too
+close (visually on top of the source). Door/window OverallHeight /
+OverallWidth attributes are converted too. Completes the conversion the
+space builder received in #1029 via `SpatialAnchor.lengthUnitScale`.

--- a/packages/create/src/in-store/anchor.ts
+++ b/packages/create/src/in-store/anchor.ts
@@ -56,3 +56,13 @@ export function toNativeLength(anchor: SpatialAnchor, metres: number): number {
   if (!scale || !Number.isFinite(scale) || scale <= 0 || scale === 1) return metres;
   return Math.round((metres / scale) * 1e9) / 1e9;
 }
+
+/** 2D point variant of {@link toNativeLength}. */
+export function toNativePoint2(anchor: SpatialAnchor, p: readonly [number, number]): [number, number] {
+  return [toNativeLength(anchor, p[0]), toNativeLength(anchor, p[1])];
+}
+
+/** 3D point variant of {@link toNativeLength}. */
+export function toNativePoint3(anchor: SpatialAnchor, p: readonly [number, number, number]): [number, number, number] {
+  return [toNativeLength(anchor, p[0]), toNativeLength(anchor, p[1]), toNativeLength(anchor, p[2])];
+}

--- a/packages/create/src/in-store/beam.ts
+++ b/packages/create/src/in-store/beam.ts
@@ -22,7 +22,7 @@ import { generateIfcGuid } from '@ifc-lite/encoding';
 import type { StoreEditor } from '@ifc-lite/mutations';
 import { vecCross, vecNorm } from '../ifc-creator-math.js';
 import type { Point3D } from '../types.js';
-import type { SpatialAnchor } from './anchor.js';
+import { toNativeLength, toNativePoint3, type SpatialAnchor } from './anchor.js';
 import { ownerHistoryRef } from './_emit-helpers.js';
 
 export interface BeamInStoreParams {
@@ -63,6 +63,15 @@ export function addBeamToStore(
 ): BeamBuildResult {
   const { ownerHistoryId, bodyContextId, storeyId, storeyPlacementId } = anchor;
 
+  // Params are metres; convert dimensioned fields to the file's native
+  // length unit before emit (see SpatialAnchor.lengthUnitScale).
+  params = {
+    ...params,
+    Start: toNativePoint3(anchor, params.Start),
+    End: toNativePoint3(anchor, params.End),
+    Width: toNativeLength(anchor, params.Width),
+    Height: toNativeLength(anchor, params.Height),
+  };
   const dx = params.End[0] - params.Start[0];
   const dy = params.End[1] - params.Start[1];
   const dz = params.End[2] - params.Start[2];

--- a/packages/create/src/in-store/column.ts
+++ b/packages/create/src/in-store/column.ts
@@ -68,6 +68,13 @@ export function addColumnToStore(
 ): ColumnBuildResult {
   const { ownerHistoryId, bodyContextId, storeyId, storeyPlacementId } = anchor;
 
+  if (
+    !Number.isFinite(params.Width) || !Number.isFinite(params.Depth) || !Number.isFinite(params.Height)
+    || params.Width <= 0 || params.Depth <= 0 || params.Height <= 0
+  ) {
+    throw new Error('addColumnToStore: Width, Depth, and Height must be finite positive numbers');
+  }
+
   // Params are metres; convert dimensioned fields to the file's native
   // length unit before emit (see SpatialAnchor.lengthUnitScale).
   params = {

--- a/packages/create/src/in-store/column.ts
+++ b/packages/create/src/in-store/column.ts
@@ -18,7 +18,7 @@
 
 import { generateIfcGuid } from '@ifc-lite/encoding';
 import type { StoreEditor } from '@ifc-lite/mutations';
-import type { SpatialAnchor } from './anchor.js';
+import { toNativeLength, toNativePoint3, type SpatialAnchor } from './anchor.js';
 import { ownerHistoryRef } from './_emit-helpers.js';
 
 export interface ColumnInStoreParams {
@@ -67,6 +67,16 @@ export function addColumnToStore(
   params: ColumnInStoreParams,
 ): ColumnBuildResult {
   const { ownerHistoryId, bodyContextId, storeyId, storeyPlacementId } = anchor;
+
+  // Params are metres; convert dimensioned fields to the file's native
+  // length unit before emit (see SpatialAnchor.lengthUnitScale).
+  params = {
+    ...params,
+    Position: toNativePoint3(anchor, params.Position),
+    Width: toNativeLength(anchor, params.Width),
+    Depth: toNativeLength(anchor, params.Depth),
+    Height: toNativeLength(anchor, params.Height),
+  };
 
   // Local placement chain: IfcCartesianPoint → IfcAxis2Placement3D →
   // IfcLocalPlacement (parent = storey placement).

--- a/packages/create/src/in-store/door.ts
+++ b/packages/create/src/in-store/door.ts
@@ -17,7 +17,7 @@
  */
 
 import type { StoreEditor } from '@ifc-lite/mutations';
-import type { SpatialAnchor } from './anchor.js';
+import { toNativeLength, toNativePoint3, type SpatialAnchor } from './anchor.js';
 import {
   emitBodyRepresentation,
   emitExtrudedSolid,
@@ -92,10 +92,20 @@ export function addDoorToStore(
   if (params.Width <= 0 || params.Height <= 0) {
     throw new Error('addDoorToStore: Width and Height must be positive');
   }
-  const thickness = params.FrameThickness ?? 0.05;
-  if (thickness <= 0) {
+  if ((params.FrameThickness ?? 0.05) <= 0) {
     throw new Error('addDoorToStore: FrameThickness must be positive');
   }
+  // Params are metres; convert dimensioned fields (incl. the OverallWidth/
+  // OverallHeight attributes emitted below) to the file's native length
+  // unit before emit (see SpatialAnchor.lengthUnitScale).
+  params = {
+    ...params,
+    Position: toNativePoint3(anchor, params.Position),
+    Width: toNativeLength(anchor, params.Width),
+    Height: toNativeLength(anchor, params.Height),
+    FrameThickness: toNativeLength(anchor, params.FrameThickness ?? 0.05),
+  };
+  const thickness = params.FrameThickness as number;
 
   const placementId = emitLocalPlacement(editor, anchor.storeyPlacementId, params.Position);
   // Profile centred at the placement origin so the leaf is bottom-

--- a/packages/create/src/in-store/duplicate.ts
+++ b/packages/create/src/in-store/duplicate.ts
@@ -91,6 +91,13 @@ export interface SourceAttributes {
   /** Express id of the IfcBuildingStorey containing the source — emit a fresh IfcRelContainedInSpatialStructure pointing at it. Null skips the rel. */
   storeyId: number | null;
   /**
+   * Model length-unit scale (metres per native unit; 0.001 for mm).
+   * `sourceLocation` is in the file's native units while
+   * `options.offset` is metres, so the offset is converted before
+   * being applied. Defaults to 1 (metre file) when unset.
+   */
+  lengthUnitScale?: number;
+  /**
    * Association rels containing the source. Each one is replayed
    * against the duplicate so the export carries the same psets,
    * qsets, material, classifications, documents, and type binding
@@ -139,11 +146,18 @@ export function duplicateInStore(
     );
   }
 
+  // Offset is metres; the source location is in the file's native
+  // length unit — convert before adding (a mm file would otherwise get
+  // a duplicate sitting ~1000× too close, visually on top of the source).
+  const scale = source.lengthUnitScale;
+  const toNative = scale && Number.isFinite(scale) && scale > 0 && scale !== 1
+    ? (m: number) => Math.round((m / scale) * 1e9) / 1e9
+    : (m: number) => m;
   const offset: Vec3 = options.offset ?? [1, 0, 0];
   const newLocation: Vec3 = [
-    source.sourceLocation[0] + offset[0],
-    source.sourceLocation[1] + offset[1],
-    source.sourceLocation[2] + offset[2],
+    source.sourceLocation[0] + toNative(offset[0]),
+    source.sourceLocation[1] + toNative(offset[1]),
+    source.sourceLocation[2] + toNative(offset[2]),
   ];
 
   // 1. New IfcCartesianPoint at the offset position.

--- a/packages/create/src/in-store/member.ts
+++ b/packages/create/src/in-store/member.ts
@@ -14,7 +14,7 @@
 import type { StoreEditor } from '@ifc-lite/mutations';
 import { vecCross, vecNorm } from '../ifc-creator-math.js';
 import type { Point3D } from '../types.js';
-import type { SpatialAnchor } from './anchor.js';
+import { toNativeLength, toNativePoint3, type SpatialAnchor } from './anchor.js';
 import {
   emitBodyRepresentation,
   emitExtrudedSolid,
@@ -59,6 +59,15 @@ export function addMemberToStore(
   anchor: SpatialAnchor,
   params: MemberInStoreParams,
 ): MemberBuildResult {
+  // Params are metres; convert dimensioned fields to the file's native
+  // length unit before emit (see SpatialAnchor.lengthUnitScale).
+  params = {
+    ...params,
+    Start: toNativePoint3(anchor, params.Start),
+    End: toNativePoint3(anchor, params.End),
+    Width: toNativeLength(anchor, params.Width),
+    Height: toNativeLength(anchor, params.Height),
+  };
   const dx = params.End[0] - params.Start[0];
   const dy = params.End[1] - params.Start[1];
   const dz = params.End[2] - params.Start[2];

--- a/packages/create/src/in-store/native-units.test.ts
+++ b/packages/create/src/in-store/native-units.test.ts
@@ -1,0 +1,203 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Native length-unit emission across every in-store builder.
+ *
+ * Builder params are metres (the renderer frame); the emitted STEP
+ * coordinates must land in the file's native length unit or a space/
+ * wall/… baked into a millimetre model exports 1000× too small while
+ * its in-session mesh (built separately in metres) looks correct.
+ * One test per builder pins the conversion (lengthUnitScale 0.001).
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  MutablePropertyView,
+  StoreEditor,
+  type MutationEntityRef,
+  type MutationStoreShape,
+  type NewEntity,
+} from '@ifc-lite/mutations';
+import type { SpatialAnchor } from './anchor.js';
+import { addWallToStore } from './wall.js';
+import { addSlabToStore } from './slab.js';
+import { addBeamToStore } from './beam.js';
+import { addColumnToStore } from './column.js';
+import { addDoorToStore } from './door.js';
+import { addWindowToStore } from './window.js';
+import { addRoofToStore } from './roof.js';
+import { addPlateToStore } from './plate.js';
+import { addMemberToStore } from './member.js';
+import { duplicateInStore } from './duplicate.js';
+
+function makeStore(maxId: number): MutationStoreShape {
+  const byId = new Map<number, MutationEntityRef>();
+  for (let id = 1; id <= maxId; id++) {
+    byId.set(id, { expressId: id, type: 'IFCDUMMY', byteOffset: 0, byteLength: 1, lineNumber: id });
+  }
+  return { entityIndex: { byId } };
+}
+
+/** Millimetre-file anchor: 0.001 metres per native unit. */
+const MM_ANCHOR: SpatialAnchor = {
+  ownerHistoryId: 5,
+  bodyContextId: 14,
+  storeyId: 43,
+  storeyPlacementId: 54,
+  lengthUnitScale: 0.001,
+};
+
+function harness(): { view: MutablePropertyView; editor: StoreEditor; byId: () => Map<number, NewEntity> } {
+  const view = new MutablePropertyView(null, 'm1');
+  const editor = new StoreEditor(makeStore(60), view);
+  return { view, editor, byId: () => new Map(view.getNewEntities().map((e) => [e.expressId, e])) };
+}
+
+describe('in-store builders emit native length units (mm model)', () => {
+  it('wall: profile dims, profile origin, and extrusion in mm', () => {
+    const { editor, byId } = harness();
+    const r = addWallToStore(editor, MM_ANCHOR, { Start: [0, 0, 0], End: [5, 0, 0], Thickness: 0.2, Height: 3 });
+    const ents = byId();
+    const profile = ents.get(r.profileId);
+    expect(profile?.attributes[3]).toBeCloseTo(5000, 6);  // XDim = length
+    expect(profile?.attributes[4]).toBeCloseTo(200, 6);   // YDim = thickness
+    expect(ents.get(r.solidId)?.attributes[3]).toBeCloseTo(3000, 6);
+  });
+
+  it('slab (polygon): outline points and extrusion in mm', () => {
+    const { view, editor, byId } = harness();
+    const r = addSlabToStore(editor, MM_ANCHOR, {
+      Profile: 'polygon', OuterCurve: [[0, 0], [4, 0], [4, 3], [0, 3]], Thickness: 0.25,
+    });
+    expect(byId().get(r.solidId)?.attributes[3]).toBeCloseTo(250, 6);
+    const corner = view.getNewEntities().find((e) => e.type === 'IfcCartesianPoint'
+      && Array.isArray(e.attributes[0])
+      && (e.attributes[0] as number[])[0] === 4000 && (e.attributes[0] as number[])[1] === 3000);
+    expect(corner, 'expected a (4000, 3000) mm outline point').toBeTruthy();
+  });
+
+  it('beam: start point, cross-section, and length in mm', () => {
+    const { view, editor, byId } = harness();
+    const r = addBeamToStore(editor, MM_ANCHOR, { Start: [1, 0, 3], End: [5, 0, 3], Width: 0.3, Height: 0.5 });
+    const ents = byId();
+    expect(ents.get(r.profileId)?.attributes[3]).toBeCloseTo(300, 6);
+    expect(ents.get(r.profileId)?.attributes[4]).toBeCloseTo(500, 6);
+    expect(ents.get(r.solidId)?.attributes[3]).toBeCloseTo(4000, 6); // beam length
+    const start = view.getNewEntities().find((e) => e.type === 'IfcCartesianPoint'
+      && Array.isArray(e.attributes[0]) && (e.attributes[0] as number[])[0] === 1000);
+    expect(start, 'expected the (1000, 0, 3000) mm start point').toBeTruthy();
+  });
+
+  it('column: position, profile dims, and height in mm', () => {
+    const { view, editor, byId } = harness();
+    const r = addColumnToStore(editor, MM_ANCHOR, { Position: [2, 3, 0], Width: 0.4, Depth: 0.4, Height: 3 });
+    const ents = byId();
+    expect(ents.get(r.profileId)?.attributes[3]).toBeCloseTo(400, 6);
+    expect(ents.get(r.solidId)?.attributes[3]).toBeCloseTo(3000, 6);
+    const pos = view.getNewEntities().find((e) => e.type === 'IfcCartesianPoint'
+      && Array.isArray(e.attributes[0])
+      && (e.attributes[0] as number[])[0] === 2000 && (e.attributes[0] as number[])[1] === 3000);
+    expect(pos, 'expected the (2000, 3000, 0) mm position').toBeTruthy();
+  });
+
+  it('door: OverallHeight/OverallWidth attributes and solid in mm', () => {
+    const { editor, byId } = harness();
+    const r = addDoorToStore(editor, MM_ANCHOR, { Position: [1, 0, 0], Width: 0.9, Height: 2.1 });
+    const ents = byId();
+    const door = ents.get(r.doorId);
+    expect(door?.attributes[8]).toBeCloseTo(2100, 6); // OverallHeight
+    expect(door?.attributes[9]).toBeCloseTo(900, 6);  // OverallWidth
+    expect(ents.get(r.solidId)?.attributes[3]).toBeCloseTo(2100, 6);
+    expect(ents.get(r.profileId)?.attributes[4]).toBeCloseTo(50, 6); // default 0.05 m frame
+  });
+
+  it('window: OverallHeight/OverallWidth attributes and solid in mm', () => {
+    const { editor, byId } = harness();
+    const r = addWindowToStore(editor, MM_ANCHOR, { Position: [1, 0, 1], Width: 1.2, Height: 1.4 });
+    const ents = byId();
+    const win = ents.get(r.windowId);
+    expect(win?.attributes[8]).toBeCloseTo(1400, 6);
+    expect(win?.attributes[9]).toBeCloseTo(1200, 6);
+    expect(ents.get(r.solidId)?.attributes[3]).toBeCloseTo(1400, 6);
+  });
+
+  it('roof (rectangle): profile dims and thickness in mm', () => {
+    const { editor, byId } = harness();
+    const r = addRoofToStore(editor, MM_ANCHOR, { Position: [0, 0, 6], Width: 10, Depth: 8, Thickness: 0.3 });
+    const ents = byId();
+    expect(ents.get(r.profileId)?.attributes[3]).toBeCloseTo(10000, 6);
+    expect(ents.get(r.profileId)?.attributes[4]).toBeCloseTo(8000, 6);
+    expect(ents.get(r.solidId)?.attributes[3]).toBeCloseTo(300, 6);
+  });
+
+  it('plate (polygon): outline and thickness in mm', () => {
+    const { view, editor, byId } = harness();
+    const r = addPlateToStore(editor, MM_ANCHOR, {
+      Profile: 'polygon', OuterCurve: [[0, 0], [2, 0], [2, 1], [0, 1]], Thickness: 0.02,
+    });
+    expect(byId().get(r.solidId)?.attributes[3]).toBeCloseTo(20, 6);
+    const corner = view.getNewEntities().find((e) => e.type === 'IfcCartesianPoint'
+      && Array.isArray(e.attributes[0])
+      && (e.attributes[0] as number[])[0] === 2000 && (e.attributes[0] as number[])[1] === 1000);
+    expect(corner, 'expected a (2000, 1000) mm outline point').toBeTruthy();
+  });
+
+  it('member: cross-section and length in mm', () => {
+    const { editor, byId } = harness();
+    const r = addMemberToStore(editor, MM_ANCHOR, { Start: [0, 0, 0], End: [0, 0, 2.5], Width: 0.1, Height: 0.1 });
+    const ents = byId();
+    expect(ents.get(r.profileId)?.attributes[3]).toBeCloseTo(100, 6);
+    expect(ents.get(r.solidId)?.attributes[3]).toBeCloseTo(2500, 6);
+  });
+
+  it('metre models (no lengthUnitScale) emit params verbatim', () => {
+    const { editor, byId } = harness();
+    const r = addWallToStore(
+      editor,
+      { ownerHistoryId: 5, bodyContextId: 14, storeyId: 43, storeyPlacementId: 54 },
+      { Start: [0, 0, 0], End: [5, 0, 0], Thickness: 0.2, Height: 3 },
+    );
+    expect(byId().get(r.solidId)?.attributes[3]).toBe(3);
+  });
+});
+
+describe('duplicateInStore offset in native units', () => {
+  it('converts the metre offset onto a mm-file source location', () => {
+    const { view, editor } = harness();
+    const r = duplicateInStore(editor, {
+      type: 'IfcWall',
+      attributes: ['gid', null, 'Wall', null, null, '#10', '#11', null],
+      placementExpressId: 10,
+      parentPlacementId: 9,
+      sourceLocation: [1000, 0, 0],   // 1 m, in mm
+      representationId: 11,
+      ownerHistoryId: null,
+      axisRef: null,
+      refDirectionRef: null,
+      storeyId: 43,
+      lengthUnitScale: 0.001,
+    }, { offset: [2, 0, 0] });        // 2 m
+    const point = view.getNewEntities().find((e) => e.expressId === r.newPointId);
+    expect(point?.attributes[0]).toEqual([3000, 0, 0]); // 1 m + 2 m = 3000 mm
+  });
+
+  it('defaults to metres when the source carries no scale', () => {
+    const { view, editor } = harness();
+    const r = duplicateInStore(editor, {
+      type: 'IfcWall',
+      attributes: ['gid', null, 'Wall', null, null, '#10', '#11', null],
+      placementExpressId: 10,
+      parentPlacementId: 9,
+      sourceLocation: [1, 0, 0],
+      representationId: 11,
+      ownerHistoryId: null,
+      axisRef: null,
+      refDirectionRef: null,
+      storeyId: 43,
+    }, { offset: [2, 0, 0] });
+    const point = view.getNewEntities().find((e) => e.expressId === r.newPointId);
+    expect(point?.attributes[0]).toEqual([3, 0, 0]);
+  });
+});

--- a/packages/create/src/in-store/plate.ts
+++ b/packages/create/src/in-store/plate.ts
@@ -10,7 +10,7 @@
  */
 
 import type { StoreEditor } from '@ifc-lite/mutations';
-import type { SpatialAnchor } from './anchor.js';
+import { toNativeLength, toNativePoint2, toNativePoint3, type SpatialAnchor } from './anchor.js';
 import {
   emitBodyRepresentation,
   emitExtrudedSolid,
@@ -67,23 +67,39 @@ export function addPlateToStore(
   anchor: SpatialAnchor,
   params: PlateInStoreParams,
 ): PlateBuildResult {
-  const polygon = isPolygonParams(params);
-  const placementOrigin: [number, number, number] = polygon
-    ? params.Position ?? [0, 0, 0]
-    : params.Position;
-
   if (params.Thickness <= 0) {
     throw new Error('addPlateToStore: Thickness must be positive');
   }
-  if (!polygon && (params.Width <= 0 || params.Depth <= 0)) {
+  if (!isPolygonParams(params) && (params.Width <= 0 || params.Depth <= 0)) {
     throw new Error('addPlateToStore: Width and Depth must be positive');
   }
+  // Params are metres; convert dimensioned fields to the file's native
+  // length unit before emit (see SpatialAnchor.lengthUnitScale). A new
+  // `const` binding (not a `params` reassignment) keeps TS's aliased
+  // discriminator narrowing intact for the union type.
+  const p: PlateInStoreParams = isPolygonParams(params)
+    ? {
+        ...params,
+        OuterCurve: params.OuterCurve.map((pt) => toNativePoint2(anchor, pt)),
+        Position: params.Position ? toNativePoint3(anchor, params.Position) : params.Position,
+        Thickness: toNativeLength(anchor, params.Thickness),
+      }
+    : {
+        ...params,
+        Position: toNativePoint3(anchor, params.Position),
+        Width: toNativeLength(anchor, params.Width),
+        Depth: toNativeLength(anchor, params.Depth),
+        Thickness: toNativeLength(anchor, params.Thickness),
+      };
+  const placementOrigin: [number, number, number] = isPolygonParams(p)
+    ? p.Position ?? [0, 0, 0]
+    : p.Position;
 
   const placementId = emitLocalPlacement(editor, anchor.storeyPlacementId, placementOrigin);
-  const profileId = polygon
-    ? emitPolygonProfile(editor, params.OuterCurve)
-    : emitRectangleProfile(editor, params.Width, params.Depth, params.Width / 2, params.Depth / 2);
-  const solidId = emitExtrudedSolid(editor, profileId, params.Thickness);
+  const profileId = isPolygonParams(p)
+    ? emitPolygonProfile(editor, p.OuterCurve)
+    : emitRectangleProfile(editor, p.Width, p.Depth, p.Width / 2, p.Depth / 2);
+  const solidId = emitExtrudedSolid(editor, profileId, p.Thickness);
   const { shapeRepId, productShapeId } = emitBodyRepresentation(editor, anchor.bodyContextId, solidId);
 
   const attrs = ifcElementHeader(anchor.ownerHistoryId, placementId, productShapeId, params, 'Plate');

--- a/packages/create/src/in-store/resolve-source.ts
+++ b/packages/create/src/in-store/resolve-source.ts
@@ -13,7 +13,7 @@
  * backend layer can call it without needing parser internals.
  */
 
-import { EntityExtractor, type IfcDataStore } from '@ifc-lite/parser';
+import { EntityExtractor, extractLengthUnitScale, type IfcDataStore } from '@ifc-lite/parser';
 import type { IfcAttributeValue } from '@ifc-lite/mutations';
 import type { SourceAttributes, SourceAssociation, Vec3 } from './duplicate.js';
 
@@ -148,6 +148,17 @@ export function resolveDuplicateSource(
   // / type binding.
   const associations = collectSourceAssociations(store, extractor, sourceExpressId);
 
+  // Metres per native unit (0.001 for a millimetre file) — lets the
+  // duplicate flow convert its metre offset onto the native-unit
+  // sourceLocation. Falls back to 1 (metres) on extraction failure.
+  let lengthUnitScale = 1.0;
+  try {
+    const s = extractLengthUnitScale(store.source, store.entityIndex);
+    if (Number.isFinite(s) && s > 0) lengthUnitScale = s;
+  } catch (error) {
+    console.warn('resolveDuplicateSource: failed to extract length unit scale; defaulting to metres', error);
+  }
+
   return {
     // Canonical PascalCase (e.g. "IfcWall"); falls back to the raw
     // extractor type when the entity table doesn't recognise the id
@@ -162,6 +173,7 @@ export function resolveDuplicateSource(
     axisRef,
     refDirectionRef,
     storeyId,
+    lengthUnitScale,
     associations,
   };
 }

--- a/packages/create/src/in-store/roof.ts
+++ b/packages/create/src/in-store/roof.ts
@@ -12,7 +12,7 @@
  */
 
 import type { StoreEditor } from '@ifc-lite/mutations';
-import type { SpatialAnchor } from './anchor.js';
+import { toNativeLength, toNativePoint2, toNativePoint3, type SpatialAnchor } from './anchor.js';
 import {
   emitBodyRepresentation,
   emitExtrudedSolid,
@@ -67,23 +67,39 @@ export function addRoofToStore(
   anchor: SpatialAnchor,
   params: RoofInStoreParams,
 ): RoofBuildResult {
-  const polygon = isPolygonParams(params);
-  const placementOrigin: [number, number, number] = polygon
-    ? params.Position ?? [0, 0, 0]
-    : params.Position;
-
   if (params.Thickness <= 0) {
     throw new Error('addRoofToStore: Thickness must be positive');
   }
-  if (!polygon && (params.Width <= 0 || params.Depth <= 0)) {
+  if (!isPolygonParams(params) && (params.Width <= 0 || params.Depth <= 0)) {
     throw new Error('addRoofToStore: Width and Depth must be positive');
   }
+  // Params are metres; convert dimensioned fields to the file's native
+  // length unit before emit (see SpatialAnchor.lengthUnitScale). A new
+  // `const` binding (not a `params` reassignment) keeps TS's aliased
+  // discriminator narrowing intact for the union type.
+  const p: RoofInStoreParams = isPolygonParams(params)
+    ? {
+        ...params,
+        OuterCurve: params.OuterCurve.map((pt) => toNativePoint2(anchor, pt)),
+        Position: params.Position ? toNativePoint3(anchor, params.Position) : params.Position,
+        Thickness: toNativeLength(anchor, params.Thickness),
+      }
+    : {
+        ...params,
+        Position: toNativePoint3(anchor, params.Position),
+        Width: toNativeLength(anchor, params.Width),
+        Depth: toNativeLength(anchor, params.Depth),
+        Thickness: toNativeLength(anchor, params.Thickness),
+      };
+  const placementOrigin: [number, number, number] = isPolygonParams(p)
+    ? p.Position ?? [0, 0, 0]
+    : p.Position;
 
   const placementId = emitLocalPlacement(editor, anchor.storeyPlacementId, placementOrigin);
-  const profileId = polygon
-    ? emitPolygonProfile(editor, params.OuterCurve)
-    : emitRectangleProfile(editor, params.Width, params.Depth, params.Width / 2, params.Depth / 2);
-  const solidId = emitExtrudedSolid(editor, profileId, params.Thickness);
+  const profileId = isPolygonParams(p)
+    ? emitPolygonProfile(editor, p.OuterCurve)
+    : emitRectangleProfile(editor, p.Width, p.Depth, p.Width / 2, p.Depth / 2);
+  const solidId = emitExtrudedSolid(editor, profileId, p.Thickness);
   const { shapeRepId, productShapeId } = emitBodyRepresentation(editor, anchor.bodyContextId, solidId);
 
   const attrs = ifcElementHeader(anchor.ownerHistoryId, placementId, productShapeId, params, 'Roof');

--- a/packages/create/src/in-store/slab.ts
+++ b/packages/create/src/in-store/slab.ts
@@ -24,7 +24,7 @@
 
 import { generateIfcGuid } from '@ifc-lite/encoding';
 import type { StoreEditor } from '@ifc-lite/mutations';
-import type { SpatialAnchor } from './anchor.js';
+import { toNativeLength, toNativePoint2, toNativePoint3, type SpatialAnchor } from './anchor.js';
 import { ownerHistoryRef } from './_emit-helpers.js';
 
 export type SlabInStoreParams = SlabRectangleParams | SlabPolygonParams;
@@ -121,17 +121,34 @@ export function addSlabToStore(
   params: SlabInStoreParams,
 ): SlabBuildResult {
   const { ownerHistoryId, bodyContextId, storeyId, storeyPlacementId } = anchor;
-  const polygon = isPolygonParams(params);
-  const placementOrigin: [number, number, number] = polygon
-    ? params.Position ?? [0, 0, 0]
-    : params.Position;
 
   if (params.Thickness <= 0) {
     throw new Error('addSlabToStore: Thickness must be positive');
   }
-  if (!polygon && (params.Width <= 0 || params.Depth <= 0)) {
+  if (!isPolygonParams(params) && (params.Width <= 0 || params.Depth <= 0)) {
     throw new Error('addSlabToStore: Width and Depth must be positive');
   }
+  // Params are metres; convert dimensioned fields to the file's native
+  // length unit before emit (see SpatialAnchor.lengthUnitScale). A new
+  // `const` binding (not a `params` reassignment) keeps TS's aliased
+  // discriminator narrowing intact for the union type.
+  const p: SlabInStoreParams = isPolygonParams(params)
+    ? {
+        ...params,
+        OuterCurve: params.OuterCurve.map((pt) => toNativePoint2(anchor, pt)),
+        Position: params.Position ? toNativePoint3(anchor, params.Position) : params.Position,
+        Thickness: toNativeLength(anchor, params.Thickness),
+      }
+    : {
+        ...params,
+        Position: toNativePoint3(anchor, params.Position),
+        Width: toNativeLength(anchor, params.Width),
+        Depth: toNativeLength(anchor, params.Depth),
+        Thickness: toNativeLength(anchor, params.Thickness),
+      };
+  const placementOrigin: [number, number, number] = isPolygonParams(p)
+    ? p.Position ?? [0, 0, 0]
+    : p.Position;
 
   // Placement at the chosen origin (no rotation).
   const slabOriginPt = editor.addEntity('IfcCartesianPoint', [placementOrigin]).expressId;
@@ -145,9 +162,9 @@ export function addSlabToStore(
     `#${slabAxis}`,
   ]).expressId;
 
-  const profileId = polygon
-    ? emitPolygonProfile(editor, params.OuterCurve)
-    : emitRectangleProfile(editor, params.Width, params.Depth);
+  const profileId = isPolygonParams(p)
+    ? emitPolygonProfile(editor, p.OuterCurve)
+    : emitRectangleProfile(editor, p.Width, p.Depth);
 
   // Extruded along +Z by Thickness.
   const solidOriginPt = editor.addEntity('IfcCartesianPoint', [[0, 0, 0]]).expressId;
@@ -157,7 +174,7 @@ export function addSlabToStore(
     `#${profileId}`,
     `#${solidAxis}`,
     `#${extrudeDirection}`,
-    params.Thickness,
+    p.Thickness,
   ]).expressId;
 
   const shapeRepId = editor.addEntity('IfcShapeRepresentation', [

--- a/packages/create/src/in-store/wall.ts
+++ b/packages/create/src/in-store/wall.ts
@@ -21,7 +21,7 @@ import { generateIfcGuid } from '@ifc-lite/encoding';
 import type { StoreEditor } from '@ifc-lite/mutations';
 import { vecNorm } from '../ifc-creator-math.js';
 import type { Point3D } from '../types.js';
-import type { SpatialAnchor } from './anchor.js';
+import { toNativeLength, toNativePoint3, type SpatialAnchor } from './anchor.js';
 import { ownerHistoryRef } from './_emit-helpers.js';
 
 export interface WallInStoreParams {
@@ -59,6 +59,17 @@ export function addWallToStore(
   if (params.Thickness <= 0 || params.Height <= 0) {
     throw new Error('addWallToStore: Thickness and Height must be positive');
   }
+  // Params are metres; convert dimensioned fields to the file's native
+  // length unit so the emitted STEP coordinates are correctly scaled
+  // (see SpatialAnchor.lengthUnitScale). Directions normalise the scale
+  // away and the validation checks are scale-invariant.
+  params = {
+    ...params,
+    Start: toNativePoint3(anchor, params.Start),
+    End: toNativePoint3(anchor, params.End),
+    Thickness: toNativeLength(anchor, params.Thickness),
+    Height: toNativeLength(anchor, params.Height),
+  };
   const dx = params.End[0] - params.Start[0];
   const dy = params.End[1] - params.Start[1];
   const dz = params.End[2] - params.Start[2];

--- a/packages/create/src/in-store/window.ts
+++ b/packages/create/src/in-store/window.ts
@@ -9,7 +9,7 @@
  */
 
 import type { StoreEditor } from '@ifc-lite/mutations';
-import type { SpatialAnchor } from './anchor.js';
+import { toNativeLength, toNativePoint3, type SpatialAnchor } from './anchor.js';
 import {
   emitBodyRepresentation,
   emitExtrudedSolid,
@@ -75,10 +75,20 @@ export function addWindowToStore(
   if (params.Width <= 0 || params.Height <= 0) {
     throw new Error('addWindowToStore: Width and Height must be positive');
   }
-  const thickness = params.FrameThickness ?? 0.05;
-  if (thickness <= 0) {
+  if ((params.FrameThickness ?? 0.05) <= 0) {
     throw new Error('addWindowToStore: FrameThickness must be positive');
   }
+  // Params are metres; convert dimensioned fields (incl. the OverallWidth/
+  // OverallHeight attributes emitted below) to the file's native length
+  // unit before emit (see SpatialAnchor.lengthUnitScale).
+  params = {
+    ...params,
+    Position: toNativePoint3(anchor, params.Position),
+    Width: toNativeLength(anchor, params.Width),
+    Height: toNativeLength(anchor, params.Height),
+    FrameThickness: toNativeLength(anchor, params.FrameThickness ?? 0.05),
+  };
+  const thickness = params.FrameThickness as number;
 
   const placementId = emitLocalPlacement(editor, anchor.storeyPlacementId, params.Position);
   const profileId = emitRectangleProfile(editor, params.Width, thickness);


### PR DESCRIPTION
## Problem

#1029 fixed the **space** builder writing metre coordinates into non-metre files (a space baked into a millimetre Revit model exported as a mm-scale speck). Every other in-store builder had the same latent bug: **wall, slab, beam, column, door, window, roof, plate, member** all emitted metre coordinates regardless of the file's length unit. An element added to a mm model serialized 1000× too small — invisible on reopen — while its in-session mesh (built separately in renderer metres) looked correct, hiding the bug until the export round-trip.

`duplicateInStore` had the **inverse** bug: its metre offset was added to the source's **native-unit** location read raw from the file, so a duplicate in a mm file landed ~1000× too close — visually on top of the source.

## Fix

- Each builder converts its dimensioned params once at the top via the `SpatialAnchor.lengthUnitScale` mechanism introduced in #1029 (`toNativeLength` + new `toNativePoint2/3` helpers). Directions are normalised (scale-invariant) and validation checks are sign/ratio-based, so the rest of each builder body is untouched.
- Door/window `OverallHeight`/`OverallWidth` attributes (IfcPositiveLengthMeasure — project length unit) convert too.
- `resolveDuplicateSource` now resolves `lengthUnitScale` and `duplicateInStore` converts its metre offset before adding it to the native-unit source location.
- The union-param builders (slab/roof/plate) bind converted params to a new `const` rather than reassigning `params`, keeping TypeScript's aliased discriminator narrowing intact.

## Verification

- New consolidated `native-units.test.ts`: one mm-model test per builder (profile dims, placement points, extrusion depths ×1000; door/window attribute slots), duplicate offset conversion, and a metre-model verbatim case — 12 tests.
- `packages/create`: 97 tests pass; `tsc --noEmit` clean.
- Consumers typecheck clean: `apps/viewer`, `packages/cli`, `packages/mcp`.
- Full viewer suite: 962 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed geometry scale mismatches when exporting from millimetre-based models (e.g., Revit exports), preventing coordinates from being serialized incorrectly.
  * Fixed duplicate element positioning in non-metre-based models that caused elements to be placed ~1000× too close to the source.
  * Improved conversion of door and window dimension attributes across different unit systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->