### PR TITLE
test(wasm): wire real-WASM contract tests into CI (processGeometryBatch boundary)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -270,6 +270,8 @@ jobs:
         # silently consume the whole job budget.
         timeout-minutes: 5
         run: pnpm test:integration
+      - name: WASM contract tests (real processGeometryBatch boundary)
+        run: pnpm test:wasm-contract
 
   rust-tests:
     name: Rust tests

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:collab": "pnpm --filter @ifc-lite/collab --filter @ifc-lite/collab-server test",
     "test:api": "tsx --tsconfig tests/tsconfig.json --test \"tests/api/**/*.test.ts\"",
     "test:integration": "tsx --tsconfig tests/tsconfig.json tests/integration.test.ts",
+    "test:wasm-contract": "node scripts/test-wasm-contract.mjs",
     "check:test-wiring": "node scripts/check-test-wiring.mjs",
     "test:regression": "node scripts/test-geometry-regression.mjs",
     "test:esm": "node scripts/verify-esm-entrypoints.mjs",

--- a/scripts/test-wasm-contract.mjs
+++ b/scripts/test-wasm-contract.mjs
@@ -149,6 +149,82 @@ END-ISO-10303-21;`;
   collection.free();
 });
 
+// ===== Pre-pass contract (viewer boundary) =====
+// The TS GeometryProcessor (packages/geometry) destructures these exact
+// fields off buildPrePassOnce() and forwards them to processGeometryBatch.
+// If a wasm-bindings change renames or drops one, the viewer breaks at
+// runtime while every mocked TS test stays green — this pins the contract.
+console.log('\n📋 buildPrePassOnce contract');
+
+test('pre-pass exposes every field the viewer consumes', () => {
+  const bytes = new TextEncoder().encode(columnContent);
+  const pre = api.buildPrePassOnce(bytes);
+  try {
+    assert.equal(typeof pre.totalJobs, 'number');
+    assert.ok(pre.jobs, 'jobs must exist');
+    assert.equal(typeof pre.unitScale, 'number');
+    assert.ok(pre.rtcOffset, 'rtcOffset must exist');
+    assert.equal(pre.rtcOffset.length, 3, 'rtcOffset must be [x, y, z]');
+    for (const v of pre.rtcOffset) {
+      assert.ok(Number.isFinite(v), 'rtcOffset components must be finite');
+    }
+    assert.equal(typeof pre.needsShift, 'boolean');
+    assert.equal(typeof pre.buildingRotation, 'number');
+    // Void + style transport arrays (may be empty, must be present)
+    for (const key of ['voidKeys', 'voidCounts', 'voidValues', 'styleIds', 'styleColors']) {
+      assert.ok(pre[key] !== undefined && pre[key] !== null, `${key} must exist`);
+    }
+  } finally {
+    api.clearPrePassCache();
+  }
+});
+
+test('unit scale resolves conversion-based units (inch fixture → 0.0254)', () => {
+  // column-straight-rectangle-tessellation.ifc declares METRE as the SI
+  // unit but overrides length with IFCCONVERSIONBASEDUNIT 'inch'. The
+  // recurring unit-bug class is exactly this chain resolving wrong.
+  const bytes = new TextEncoder().encode(columnContent);
+  const pre = api.buildPrePassOnce(bytes);
+  try {
+    assert.ok(Math.abs(pre.unitScale - 0.0254) < 1e-9,
+      `inch model must yield unitScale 0.0254, got ${pre.unitScale}`);
+  } finally {
+    api.clearPrePassCache();
+  }
+});
+
+test('unit scale resolves plain SI metres (georef fixture → 1.0)', () => {
+  const georefContent = readFileSync(GEOREF_IFC, 'utf-8');
+  const bytes = new TextEncoder().encode(georefContent);
+  const pre = api.buildPrePassOnce(bytes);
+  try {
+    assert.equal(pre.unitScale, 1, `metre model must yield unitScale 1, got ${pre.unitScale}`);
+    assert.equal(pre.needsShift, false, 'local-coordinate model must not trigger RTC shift');
+  } finally {
+    api.clearPrePassCache();
+  }
+});
+
+test('mesh output is metre-normalized (column fits a sane bbox)', () => {
+  // The inch fixture's column is ~3 m tall. If unit scaling silently
+  // stopped being applied, positions come out in inches (×39) — assert
+  // the overall bbox stays in building-scale metres.
+  const collection = parseMeshesViaPrePass(api, columnContent);
+  assert.ok(collection.length > 0, 'fixture must mesh');
+  let maxAbs = 0;
+  for (let i = 0; i < collection.length; i++) {
+    const mesh = collection.get(i);
+    for (let j = 0; j < mesh.positions.length; j++) {
+      const a = Math.abs(mesh.positions[j]);
+      if (a > maxAbs) maxAbs = a;
+    }
+    mesh.free();
+  }
+  assert.ok(maxAbs > 0.1, `column extent ${maxAbs} suspiciously small — unit scale over-applied?`);
+  assert.ok(maxAbs < 50, `column extent ${maxAbs} m — unit scale not applied?`);
+  collection.free();
+});
+
 // ===== scanEntitiesFast =====
 console.log('\n📋 scanEntitiesFast');
 

--- a/scripts/test-wasm-contract.mjs
+++ b/scripts/test-wasm-contract.mjs
@@ -6,7 +6,7 @@
  * Focus on structural invariants, not exact values.
  */
 
-import { readFileSync } from 'fs';
+import { readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import assert from 'node:assert/strict';
@@ -23,9 +23,25 @@ const GEOREF_IFC = join(FIXTURES_DIR, 'ifc5/Georeferencing_georeferenced-bridge-
 
 console.log('🧪 WASM API Contract Tests\n');
 
+// Per AGENTS.md §Test fixtures: skip cleanly (exit 0) when fixtures or
+// the wasm runtime aren't on disk, pointing at the command that fixes it.
+const WASM_BIN = join(ROOT_DIR, 'packages/wasm/pkg/ifc-lite_bg.wasm');
+if (!existsSync(WASM_BIN)) {
+  console.log('⚠️  wasm runtime missing — run `bash scripts/build-wasm.sh`. Skipping.');
+  process.exit(0);
+}
+if (!existsSync(COLUMN_IFC)) {
+  console.log('⚠️  column fixture missing — run `pnpm fixtures`. Skipping.');
+  process.exit(0);
+}
+const GEOREF_AVAILABLE = existsSync(GEOREF_IFC);
+if (!GEOREF_AVAILABLE) {
+  console.log('⚠️  georef fixture missing — run `pnpm fixtures`. Georef tests will be skipped.');
+}
+
 // Initialize WASM
 console.log('📦 Loading WASM...');
-const wasmBuffer = readFileSync(join(ROOT_DIR, 'packages/wasm/pkg/ifc-lite_bg.wasm'));
+const wasmBuffer = readFileSync(WASM_BIN);
 initSync(wasmBuffer);
 console.log('✅ WASM initialized\n');
 
@@ -194,6 +210,10 @@ test('unit scale resolves conversion-based units (inch fixture → 0.0254)', () 
 });
 
 test('unit scale resolves plain SI metres (georef fixture → 1.0)', () => {
+  if (!GEOREF_AVAILABLE) {
+    console.log('     (skipped — georef fixture missing, run `pnpm fixtures`)');
+    return;
+  }
   const georefContent = readFileSync(GEOREF_IFC, 'utf-8');
   const bytes = new TextEncoder().encode(georefContent);
   const pre = api.buildPrePassOnce(bytes);


### PR DESCRIPTION
Stacked on #1036.

## Why

`scripts/test-wasm-contract.mjs` existed but was wired to nothing — the only test in the repo that exercises the **real** `buildPrePassOnce` + `processGeometryBatch` path (the pipeline the viewer actually uses) never ran. Meanwhile every TS-side geometry test mocks `@ifc-lite/wasm` entirely, so a wasm-bindings signature/serialization change passes the whole suite and breaks only at viewer runtime — the exact failure class of #858 / #957 ("rust test passes while the viewer stays broken").

## What

- Run the contract script in the node-tests CI job as `pnpm test:wasm-contract` (wasm pkg comes from build artifacts, fixtures from the cache — no new infra).
- **Pin the pre-pass field surface** the TS `GeometryProcessor` destructures: `totalJobs`, `jobs`, `unitScale`, `rtcOffset[3]`, `needsShift`, `buildingRotation`, `voidKeys/voidCounts/voidValues`, `styleIds/styleColors`. A rename or drop now fails CI instead of the viewer.
- **Pin unit-scale resolution across two unit systems** (the repo's most recurrent bug class): inch conversion-based unit → `0.0254`, plain SI metre → `1.0`. Notably the column fixture declares `.METRE.` as SI unit but overrides length with `IFCCONVERSIONBASEDUNIT 'inch'` — exactly the chain that goes wrong.
- **Assert metre-normalized mesh output** (bbox sanity on the column fixture) so a silently dropped unit scale can't ship.
- Also uses the previously dead `GEOREF_IFC` fixture variable for the SI-metre + no-RTC-shift case.

13/13 locally. Known limitation, deliberately out of scope here: no fixture small enough triggers the >10 km RTC rebase path — that needs a synthesized large-coordinate fixture and is part of the georef-transformation work in the test plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)