### PR TITLE
test(export): STEP/IFCX round-trip fidelity corpus

### DIFF
--- a/packages/export/package.json
+++ b/packages/export/package.json
@@ -27,6 +27,7 @@
     "jszip": "^3.10.0"
   },
   "devDependencies": {
+    "@ifc-lite/ifcx": "workspace:^",
     "typescript": "^6.0.3",
     "vitest": "^4.1.0"
   },

--- a/packages/export/src/ifcx-roundtrip.test.ts
+++ b/packages/export/src/ifcx-roundtrip.test.ts
@@ -1,0 +1,308 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * IFCX (IFC5) export round-trip fidelity tests.
+ *
+ * Contract under test: `parseIfcx` → `Ifc5Exporter.export()` → `parseIfcx`
+ * preserves the ENTITY-level model. Scope notes from reading
+ * ifc5-exporter.ts — the exporter does NOT reproduce the raw node graph:
+ *
+ * - Only nodes carrying `bsi::ifc::class` become entities; pure geometry
+ *   carrier children ("Body", "Axis", "Void", ...) are merged into their
+ *   owning entity's `usd::usdgeom::mesh` attribute. Raw-node-count equality
+ *   is therefore NOT part of the contract; entity path-set equality is.
+ * - `onlyTreeEntities` defaults to true and drops entities outside the
+ *   spatial tree (e.g. type objects). Fidelity tests run with
+ *   `onlyTreeEntities: false`; the default subset behaviour is pinned as
+ *   its own contract test below.
+ * - `onlyKnownProperties` defaults to true and drops properties without an
+ *   official IFC5 schema (IFC5_KNOWN_PROP_NAMES). Fidelity tests run with
+ *   `onlyKnownProperties: false`; the default is pinned separately.
+ *
+ * All comparisons are set-based — node ordering and representational
+ * differences (e.g. names moving from incoming-edge labels into an explicit
+ * `bsi::ifc::prop::Name` attribute) are legitimate.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { existsSync, readFileSync } from 'fs';
+import { resolve } from 'path';
+import { parseIfcx, type IfcxParseResult } from '@ifc-lite/ifcx';
+import type { IfcDataStore } from '@ifc-lite/parser';
+import type { GeometryResult } from '@ifc-lite/geometry';
+import { IfcTypeEnumToString, type IfcTypeEnum } from '@ifc-lite/data';
+import { Ifc5Exporter, type Ifc5ExportOptions } from './ifc5-exporter.js';
+
+const FIXTURE = resolve(__dirname, '../../../tests/models/ifc5/Hello_Wall_hello-wall.ifcx');
+const FIXTURE_AVAILABLE = existsSync(FIXTURE);
+
+function toArrayBuffer(buf: Buffer): ArrayBuffer {
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+}
+
+async function parseFixture(): Promise<IfcxParseResult> {
+  return parseIfcx(toArrayBuffer(readFileSync(FIXTURE)));
+}
+
+/**
+ * Adapt an IfcxParseResult to the IfcDataStore surface the exporter reads
+ * (entities/strings/spatialHierarchy/properties — it never touches
+ * entityIndex or source for IFC5 input).
+ */
+function asDataStore(parsed: IfcxParseResult): IfcDataStore {
+  return {
+    ...parsed,
+    source: new Uint8Array(0),
+    entityIndex: { byId: new Map(), byType: new Map() },
+  } as unknown as IfcDataStore;
+}
+
+async function roundTrip(
+  parsed: IfcxParseResult,
+  options: Ifc5ExportOptions,
+): Promise<IfcxParseResult> {
+  const exporter = new Ifc5Exporter(
+    asDataStore(parsed),
+    // parseIfcx pre-tessellates IFC5 geometry; feed it back as the
+    // exporter's geometry source the same way the viewer does.
+    { meshes: parsed.meshes } as unknown as GeometryResult,
+  );
+  const result = exporter.export(options);
+  return parseIfcx(toArrayBuffer(Buffer.from(new TextEncoder().encode(result.content))));
+}
+
+/** Lossless export options used by the fidelity tests. */
+const FULL_FIDELITY: Ifc5ExportOptions = {
+  onlyTreeEntities: false,
+  onlyKnownProperties: false,
+};
+
+/** Entity node paths (IFCX uses the node path as GlobalId). */
+function pathSet(parsed: IfcxParseResult): Set<string> {
+  return new Set(parsed.idToPath.values());
+}
+
+/** path -> { name, ifcClass } */
+function entityInfoByPath(parsed: IfcxParseResult): Map<string, { name: string; ifcClass: string }> {
+  const out = new Map<string, { name: string; ifcClass: string }>();
+  const { entities, strings } = parsed;
+  for (let i = 0; i < entities.count; i++) {
+    const path = parsed.idToPath.get(entities.expressId[i]);
+    if (!path) continue;
+    out.set(path, {
+      name: strings.get(entities.name[i]) ?? '',
+      ifcClass: IfcTypeEnumToString(entities.typeEnum[i] as IfcTypeEnum),
+    });
+  }
+  return out;
+}
+
+/** Hierarchy relations as "parentPath>childPath" edge strings. */
+function hierarchyEdges(parsed: IfcxParseResult): Set<string> {
+  const edges = new Set<string>();
+  const toPath = (id: number) => parsed.idToPath.get(id) ?? `#${id}`;
+  const hierarchy = parsed.spatialHierarchy;
+
+  if (hierarchy?.project) {
+    const walk = (node: { expressId: number; children: Array<{ expressId: number; children: never[] }> }) => {
+      for (const child of node.children) {
+        edges.add(`${toPath(node.expressId)}>${toPath(child.expressId)}`);
+        walk(child as never);
+      }
+    };
+    walk(hierarchy.project as never);
+  }
+  for (const map of [hierarchy?.bySite, hierarchy?.byBuilding, hierarchy?.byStorey, hierarchy?.bySpace]) {
+    if (!map) continue;
+    for (const [parentId, childIds] of map) {
+      for (const childId of childIds) {
+        edges.add(`${toPath(parentId)}>${toPath(childId)}`);
+      }
+    }
+  }
+  return edges;
+}
+
+/** path -> set of "propName=jsonValue" strings. */
+function propsByPath(parsed: IfcxParseResult): Map<string, Set<string>> {
+  const out = new Map<string, Set<string>>();
+  const { entities } = parsed;
+  for (let i = 0; i < entities.count; i++) {
+    const expressId = entities.expressId[i];
+    const path = parsed.idToPath.get(expressId);
+    if (!path) continue;
+    const flat = new Set<string>();
+    for (const pset of parsed.properties.getForEntity(expressId)) {
+      for (const prop of pset.properties) {
+        flat.add(`${prop.name}=${JSON.stringify(prop.value)}`);
+      }
+    }
+    out.set(path, flat);
+  }
+  return out;
+}
+
+/** Paths of entities carrying tessellated geometry. */
+function meshPathSet(parsed: IfcxParseResult): Set<string> {
+  const out = new Set<string>();
+  for (const mesh of parsed.meshes) {
+    const path = parsed.idToPath.get(mesh.expressId);
+    if (path) out.add(path);
+  }
+  return out;
+}
+
+/** path -> total triangle count across all mesh fragments. */
+function triangleTotals(parsed: IfcxParseResult): Map<string, number> {
+  const out = new Map<string, number>();
+  for (const mesh of parsed.meshes) {
+    const path = parsed.idToPath.get(mesh.expressId);
+    if (!path) continue;
+    out.set(path, (out.get(path) ?? 0) + mesh.indices.length / 3);
+  }
+  return out;
+}
+
+/** Entity paths reachable from the spatial hierarchy (tree + containment). */
+function spatialTreePaths(parsed: IfcxParseResult): Set<string> {
+  const ids = new Set<number>();
+  const hierarchy = parsed.spatialHierarchy;
+  if (hierarchy?.project) {
+    const walk = (node: { expressId: number; children: Array<never> }) => {
+      ids.add(node.expressId);
+      for (const child of node.children) walk(child);
+    };
+    walk(hierarchy.project as never);
+  }
+  for (const map of [hierarchy?.bySite, hierarchy?.byBuilding, hierarchy?.byStorey, hierarchy?.bySpace]) {
+    if (!map) continue;
+    for (const childIds of map.values()) {
+      for (const id of childIds) ids.add(id);
+    }
+  }
+  const paths = new Set<string>();
+  for (const id of ids) {
+    const path = parsed.idToPath.get(id);
+    if (path) paths.add(path);
+  }
+  return paths;
+}
+
+describe.skipIf(!FIXTURE_AVAILABLE)('IFCX export round-trip fidelity (Hello Wall)', () => {
+  it('preserves the entity node path set exactly', async () => {
+    const original = await parseFixture();
+    // Guard: the fixture must actually contain a non-trivial model.
+    expect(original.entityCount).toBeGreaterThanOrEqual(9);
+
+    const reparsed = await roundTrip(original, FULL_FIDELITY);
+
+    expect(pathSet(reparsed)).toEqual(pathSet(original));
+    expect(reparsed.entityCount).toBe(original.entityCount);
+  });
+
+  it('preserves IFC class and name for every entity', async () => {
+    const original = await parseFixture();
+    const reparsed = await roundTrip(original, FULL_FIDELITY);
+
+    const before = entityInfoByPath(original);
+    const after = entityInfoByPath(reparsed);
+    for (const [path, info] of before) {
+      expect(after.get(path), `entity ${path}`).toEqual(info);
+    }
+  });
+
+  it('preserves hierarchy relations', async () => {
+    const original = await parseFixture();
+    const reparsed = await roundTrip(original, FULL_FIDELITY);
+
+    const before = hierarchyEdges(original);
+    expect(before.size).toBeGreaterThan(0);
+    expect(hierarchyEdges(reparsed)).toEqual(before);
+  });
+
+  it('preserves all property name/value pairs (re-parse may add Name)', async () => {
+    const original = await parseFixture();
+    const reparsed = await roundTrip(original, FULL_FIDELITY);
+
+    const before = propsByPath(original);
+    const after = propsByPath(reparsed);
+
+    // Guard against a vacuous pass: the fixture has real properties.
+    const totalProps = [...before.values()].reduce((n, s) => n + s.size, 0);
+    expect(totalProps).toBeGreaterThan(0);
+
+    // Superset assertion: every original property must survive. The exporter
+    // legitimately ADDS `bsi::ifc::prop::Name` for entities whose name was
+    // only encoded as an incoming-edge label in the source file, so exact
+    // set equality would be wrong — but nothing may be LOST.
+    for (const [path, props] of before) {
+      const reparsedProps = after.get(path) ?? new Set<string>();
+      for (const prop of props) {
+        expect(reparsedProps.has(prop), `property "${prop}" on ${path}`).toBe(true);
+      }
+    }
+  });
+
+  it('preserves the set of geometry-bearing entities', async () => {
+    const original = await parseFixture();
+    const reparsed = await roundTrip(original, FULL_FIDELITY);
+
+    const before = meshPathSet(original);
+    expect(before.size).toBeGreaterThan(0);
+    expect(meshPathSet(reparsed)).toEqual(before);
+  });
+
+  // BUG: per-entity triangle totals are NOT preserved across the round-trip
+  // (Hello Wall: wall 54 → 216 triangles, windows 44 → 176 each, i.e. ×4).
+  // The exported FILE is correct — each entity node carries its merged mesh
+  // exactly once — but the exporter materialises the flattened containment
+  // maps as children (storey→wall AND space→wall, etc.), giving mesh-bearing
+  // nodes multiple incoming edges, and parseIfcx's geometry extractor then
+  // emits one mesh fragment per incoming traversal path. Either the exporter
+  // must emit each entity under a single spatial parent, or the extractor
+  // must deduplicate visited nodes. Strict assertion kept so the fix
+  // un-fails this test.
+  it.fails('preserves per-entity triangle counts (geometry not duplicated)', async () => {
+    const original = await parseFixture();
+    const reparsed = await roundTrip(original, FULL_FIDELITY);
+
+    expect(Object.fromEntries(triangleTotals(reparsed)))
+      .toEqual(Object.fromEntries(triangleTotals(original)));
+  });
+
+  // ---------------------------------------------------------------------
+  // Default-option contracts (documented subset behaviour, not bugs)
+  // ---------------------------------------------------------------------
+
+  it('default onlyTreeEntities drops exactly the non-spatial-tree entities', async () => {
+    const original = await parseFixture();
+    const reparsed = await roundTrip(original, { onlyKnownProperties: false });
+
+    const expected = spatialTreePaths(original);
+    // Hello Wall has one entity outside the spatial tree (the inherited
+    // window type prototype node) — make sure the contract test is not
+    // vacuously identical to the full-fidelity test.
+    expect(expected.size).toBeLessThan(pathSet(original).size);
+    expect(pathSet(reparsed)).toEqual(expected);
+  });
+
+  it('default onlyKnownProperties keeps schema-known props and drops unknown ones', async () => {
+    const original = await parseFixture();
+    const reparsed = await roundTrip(original, {});
+
+    const before = propsByPath(original);
+    const after = propsByPath(reparsed);
+
+    // The wall carries both a known prop (IsExternal) and an unknown one
+    // (the NL-SfB "class" reference, which has no official IFC5 prop schema).
+    const wallPath = [...before.entries()]
+      .find(([, props]) => [...props].some((p) => p.startsWith('class=')))?.[0];
+    expect(wallPath).toBeDefined();
+
+    const wallAfter = after.get(wallPath!) ?? new Set<string>();
+    expect([...wallAfter].some((p) => p.startsWith('IsExternal='))).toBe(true);
+    expect([...wallAfter].some((p) => p.startsWith('class='))).toBe(false);
+  });
+});

--- a/packages/export/src/step-roundtrip.test.ts
+++ b/packages/export/src/step-roundtrip.test.ts
@@ -1,0 +1,195 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * STEP export round-trip fidelity tests.
+ *
+ * Contract under test: `StepExporter.export()` without mutations is a
+ * FULL-MODEL pass-through — it re-emits every entity line verbatim from the
+ * source buffer (same expressIds, same attribute text) and only regenerates
+ * the ISO-10303-21 header. So a parse → export → re-parse cycle must
+ * preserve the complete model: per-type entity counts, GlobalIds, property
+ * sets, and units. (Schema CONVERSION and mutation application are separate
+ * code paths covered by step-exporter.test.ts / schema-converter.test.ts;
+ * here we always export to the source schema so no conversion runs.)
+ *
+ * All comparisons are set/count based — byte equality is intentionally NOT
+ * asserted because header text and line ordering may legitimately differ.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { existsSync, readFileSync } from 'fs';
+import { resolve } from 'path';
+import { IfcParser, type IfcDataStore } from '@ifc-lite/parser';
+import { StepExporter } from './step-exporter.js';
+
+const MODELS_DIR = resolve(__dirname, '../../../tests/models');
+
+// Small (< 1 MB) real-world fixtures covering IFC2X3 and IFC4. Fixtures are
+// fetched on demand via `pnpm fixtures` (AGENTS.md §9); skip cleanly when
+// they aren't on disk so a fresh checkout doesn't crash with ENOENT.
+const FIXTURES = [
+  {
+    name: 'various/test.ifc',
+    schema: 'IFC2X3' as const,
+    lengthUnitScale: 1, // metres
+    hasPsets: false,
+  },
+  {
+    name: 'buildingsmart/wall-with-opening-and-window.ifc',
+    schema: 'IFC4' as const,
+    lengthUnitScale: 0.001, // millimetres
+    hasPsets: true,
+  },
+  {
+    name: 'buildingsmart/basin-tessellation.ifc',
+    schema: 'IFC4' as const,
+    lengthUnitScale: 0.001, // millimetres
+    hasPsets: false,
+  },
+];
+
+const FIXTURES_AVAILABLE = FIXTURES.every((f) => existsSync(resolve(MODELS_DIR, f.name)));
+
+function toArrayBuffer(buf: Buffer): ArrayBuffer {
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+}
+
+async function parseFixture(name: string): Promise<IfcDataStore> {
+  const parser = new IfcParser();
+  return parser.parseColumnar(toArrayBuffer(readFileSync(resolve(MODELS_DIR, name))));
+}
+
+async function roundTrip(store: IfcDataStore): Promise<IfcDataStore> {
+  // Export to the SOURCE schema so the pass-through path runs (no conversion).
+  const result = new StepExporter(store).export({ schema: store.schemaVersion });
+  const parser = new IfcParser();
+  return parser.parseColumnar(toArrayBuffer(Buffer.from(result.content)));
+}
+
+/** Per-IFC-type entity counts, e.g. { IFCWALL: 2, IFCSLAB: 1, ... } */
+function typeCounts(store: IfcDataStore): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const [type, ids] of store.entityIndex.byType) {
+    counts[type] = ids.length;
+  }
+  return counts;
+}
+
+/** All non-empty GlobalIds in the entity table. */
+function globalIdSet(store: IfcDataStore): Set<string> {
+  const out = new Set<string>();
+  const { entities, strings } = store;
+  for (let i = 0; i < entities.count; i++) {
+    const globalId = strings.get(entities.globalId[i]);
+    if (globalId) out.add(globalId);
+  }
+  return out;
+}
+
+/**
+ * Canonical pset snapshot per entity: expressId -> sorted
+ * [psetName, propName, value] triples. ExpressIds are stable across the
+ * round-trip because the exporter re-emits original entity lines.
+ */
+function psetSnapshot(store: IfcDataStore): Map<number, string> {
+  const out = new Map<number, string>();
+  const { entities } = store;
+  for (let i = 0; i < entities.count; i++) {
+    const expressId = entities.expressId[i];
+    const psets = store.getProperties(expressId);
+    if (!psets.length) continue;
+    const triples: Array<[string, string, unknown]> = [];
+    for (const pset of psets) {
+      for (const prop of pset.properties) {
+        triples.push([pset.name, prop.name, prop.value]);
+      }
+    }
+    triples.sort((a, b) => `${a[0]}|${a[1]}`.localeCompare(`${b[0]}|${b[1]}`));
+    out.set(expressId, JSON.stringify(triples));
+  }
+  return out;
+}
+
+describe.skipIf(!FIXTURES_AVAILABLE)('STEP export round-trip fidelity', () => {
+  for (const fixture of FIXTURES) {
+    describe(fixture.name, () => {
+      it('preserves schema version and per-type entity counts', async () => {
+        const original = await parseFixture(fixture.name);
+        expect(original.schemaVersion).toBe(fixture.schema);
+
+        const reparsed = await roundTrip(original);
+
+        expect(reparsed.schemaVersion).toBe(original.schemaVersion);
+        expect(reparsed.entityCount).toBe(original.entityCount);
+        // Full per-type map equality: catches both dropped entities and
+        // entities whose type token got mangled on export.
+        expect(typeCounts(reparsed)).toEqual(typeCounts(original));
+      });
+
+      it('preserves the GlobalId set', async () => {
+        const original = await parseFixture(fixture.name);
+        const reparsed = await roundTrip(original);
+
+        const originalIds = globalIdSet(original);
+        // Guard against a vacuous pass on a fixture with no rooted entities.
+        expect(originalIds.size).toBeGreaterThan(0);
+        expect(globalIdSet(reparsed)).toEqual(originalIds);
+      });
+
+      it('preserves property sets (names and values) per entity', async () => {
+        const original = await parseFixture(fixture.name);
+        const reparsed = await roundTrip(original);
+
+        const before = psetSnapshot(original);
+        const after = psetSnapshot(reparsed);
+
+        if (fixture.hasPsets) {
+          // Guard: this fixture is the one exercising real pset content.
+          expect(before.size).toBeGreaterThan(0);
+        }
+        expect(after.size).toBe(before.size);
+        for (const [expressId, snapshot] of before) {
+          expect(after.get(expressId), `psets of #${expressId}`).toBe(snapshot);
+        }
+      });
+
+      it('preserves project units', async () => {
+        const original = await parseFixture(fixture.name);
+        const reparsed = await roundTrip(original);
+
+        // Known absolute value guards against a units regression that
+        // breaks both parses identically.
+        expect(original.lengthUnitScale).toBe(fixture.lengthUnitScale);
+        expect(reparsed.lengthUnitScale).toBe(original.lengthUnitScale);
+
+        // Unit entities themselves must survive verbatim.
+        const unitTypes = ['IFCSIUNIT', 'IFCCONVERSIONBASEDUNIT', 'IFCUNITASSIGNMENT'];
+        for (const type of unitTypes) {
+          expect(
+            reparsed.entityIndex.byType.get(type)?.length ?? 0,
+            `${type} count`,
+          ).toBe(original.entityIndex.byType.get(type)?.length ?? 0);
+        }
+      });
+
+      it('re-exports geometry entity references intact (export of re-parse is stable)', async () => {
+        // Second-generation check: exporting the re-parsed model again must
+        // produce the same DATA section content (the pass-through is
+        // idempotent). This catches mangled entity refs that still happen
+        // to re-parse without error.
+        const original = await parseFixture(fixture.name);
+        const gen1 = new StepExporter(original).export({ schema: original.schemaVersion });
+        const reparsed = await roundTrip(original);
+        const gen2 = new StepExporter(reparsed).export({ schema: reparsed.schemaVersion });
+
+        const dataSection = (bytes: Uint8Array) => {
+          const text = new TextDecoder().decode(bytes);
+          return text.slice(text.indexOf('DATA;'));
+        };
+        expect(dataSection(gen2.content)).toBe(dataSection(gen1.content));
+      });
+    });
+  }
+});

--- a/packages/export/vitest.config.ts
+++ b/packages/export/vitest.config.ts
@@ -14,6 +14,10 @@ export default defineConfig({
       '@ifc-lite/ifcx': path.resolve(__dirname, '../ifcx/src/index.ts'),
       '@ifc-lite/mutations': path.resolve(__dirname, '../mutations/src/index.ts'),
       '@ifc-lite/parser': path.resolve(__dirname, '../parser/src/index.ts'),
+      // ifcx's entity-extractor imports @ifc-lite/pointcloud; alias it to src so
+      // the suite resolves on a clean checkout without built dists. pointcloud's
+      // src pulls in no further workspace deps (only laz-perf + node builtins).
+      '@ifc-lite/pointcloud': path.resolve(__dirname, '../pointcloud/src/index.ts'),
     },
   },
   test: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -872,6 +872,9 @@ importers:
         specifier: ^0.7.1
         version: 0.7.1
     devDependencies:
+      '@ifc-lite/ifcx':
+        specifier: workspace:^
+        version: link:../ifcx
       typescript:
         specifier: ^6.0.3
         version: 6.0.3


### PR DESCRIPTION
## What

Until now, export tests only checked output *syntax* — an exporter that drops properties or mangles geometry refs would ship silently. This adds round-trip fidelity tests: parse a real fixture → export → **re-parse the exported output** → compare model content with set/count comparisons (never byte equality, since header text and ordering may legitimately differ).

## STEP (`packages/export/src/step-roundtrip.test.ts`)

**What the exporter turned out to support:** `StepExporter.export()` without mutations is a *full-model pass-through* — it re-emits every entity line verbatim from the source buffer (same expressIds, same attribute text) and only regenerates the ISO-10303-21 header. The tests export to the source schema so the conversion path (covered elsewhere) never runs.

Fixtures: `various/test.ifc` (IFC2X3, metres), `buildingsmart/wall-with-opening-and-window.ifc` (IFC4, mm, real psets), `buildingsmart/basin-tessellation.ifc` (IFC4, mm). Per fixture:

- per-IFC-type entity counts identical (full map equality — catches dropped entities and mangled type tokens)
- GlobalId set identical (non-vacuous: asserts > 0 first)
- per-entity pset snapshots (pset name + prop name + value triples) identical
- units: `lengthUnitScale` round-trips *and* matches the known absolute value; `IFCSIUNIT`/`IFCCONVERSIONBASEDUNIT`/`IFCUNITASSIGNMENT` counts identical
- second-generation stability: exporting the re-parsed model yields a byte-identical DATA section (catches mangled refs that still happen to re-parse)

Result: **STEP round-trips with full fidelity** on all three fixtures. No bugs found.

## IFCX (`packages/export/src/ifcx-roundtrip.test.ts`)

**What the exporter turned out to support:** `Ifc5Exporter` does *not* reproduce the raw node graph. Only `bsi::ifc::class`-bearing nodes become entities; geometry-carrier children (`Body`, `Axis`, …) are merged into the owning entity's `usd::usdgeom::mesh`. Two defaults subset the output: `onlyTreeEntities: true` drops entities outside the spatial tree (e.g. type objects), `onlyKnownProperties: true` drops props without an official IFC5 schema. Fidelity tests run with both disabled; the defaults are pinned as their own contract tests.

On `ifc5/Hello_Wall_hello-wall.ifcx`:

- entity path set preserved exactly (IFCX paths double as GlobalIds)
- IFC class + name preserved per entity
- hierarchy edge set (parent path → child path) preserved
- property name/value pairs: superset assertion — nothing may be lost; the exporter legitimately *adds* `bsi::ifc::prop::Name` for entities whose name was only an incoming-edge label
- geometry-bearing entity set preserved
- contract: default `onlyTreeEntities` drops exactly the non-spatial-tree entities (the window type prototype)
- contract: default `onlyKnownProperties` keeps `IsExternal`, drops the NL-SfB `class` reference

## Fidelity bug found (kept strict, marked `it.fails`)

**IFCX round-trip multiplies per-entity triangle counts ×4 on Hello Wall** (wall 54 → 216 tris, each window 44 → 176). The exported *file* is correct — each entity node carries its merged mesh exactly once — but the exporter materialises the flattened containment maps as `children` (storey→wall *and* space→wall, etc.), giving mesh-bearing nodes multiple incoming edges, and `parseIfcx`'s geometry extractor emits one mesh fragment per incoming traversal path. Fix is either single-parent children emission in `ifc5-exporter.ts` or visited-node dedup in `@ifc-lite/ifcx`'s geometry extractor. The strict assertion is kept as `it.fails(...)` so the eventual fix un-fails it.

## Notes

- `@ifc-lite/ifcx` added as a devDependency of `@ifc-lite/export` (vitest config already aliased it to source; this keeps the workspace graph honest).
- `pnpm turbo test --filter=@ifc-lite/export`: 9 files, 125 passed + 1 expected fail.
- Fixture-dependent suites skip cleanly (`describe.skipIf`) when `tests/models` isn't populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)