### PR TITLE
fix(ifcx): dedupe geometry emission for multi-parent containment edges

### DIFF
--- a/.changeset/ifcx-multiparent-geometry-dedup.md
+++ b/.changeset/ifcx-multiparent-geometry-dedup.md
@@ -1,0 +1,13 @@
+---
+"@ifc-lite/ifcx": patch
+---
+
+fix(ifcx): stop duplicating geometry for entities with multiple incoming
+containment edges. A node reachable through more than one parent (e.g. a
+wall hanging under both its storey and a space boundary, as the IFC5
+exporter legitimately emits) was traversed once per incoming edge and its
+mesh emitted each time — an export round-trip multiplied per-entity
+triangle counts by the number of edges (Hello Wall: ×4). Extraction now
+deduplicates per (node path, entity context, accumulated transform), so
+aliased containment edges emit once while shared type bodies referenced
+from multiple instances and genuine instancing still emit per context.

--- a/packages/export/src/ifcx-roundtrip.test.ts
+++ b/packages/export/src/ifcx-roundtrip.test.ts
@@ -254,17 +254,15 @@ describe.skipIf(!FIXTURE_AVAILABLE)('IFCX export round-trip fidelity (Hello Wall
     expect(meshPathSet(reparsed)).toEqual(before);
   });
 
-  // BUG: per-entity triangle totals are NOT preserved across the round-trip
-  // (Hello Wall: wall 54 → 216 triangles, windows 44 → 176 each, i.e. ×4).
-  // The exported FILE is correct — each entity node carries its merged mesh
-  // exactly once — but the exporter materialises the flattened containment
-  // maps as children (storey→wall AND space→wall, etc.), giving mesh-bearing
-  // nodes multiple incoming edges, and parseIfcx's geometry extractor then
-  // emits one mesh fragment per incoming traversal path. Either the exporter
-  // must emit each entity under a single spatial parent, or the extractor
-  // must deduplicate visited nodes. Strict assertion kept so the fix
-  // un-fails this test.
-  it.fails('preserves per-entity triangle counts (geometry not duplicated)', async () => {
+  // Regression: per-entity triangle totals used to multiply across the
+  // round-trip (Hello Wall: wall 54 → 216 triangles, ×4 = one copy per
+  // incoming containment edge). The exporter materialises flattened
+  // containment maps as children (storey→wall AND space→wall), giving
+  // mesh-bearing nodes multiple incoming edges; parseIfcx's geometry
+  // extractor now deduplicates emission per (node path, accumulated
+  // transform), so aliased traversal paths emit once while genuine
+  // instancing (different world transform) still emits.
+  it('preserves per-entity triangle counts (geometry not duplicated)', async () => {
     const original = await parseFixture();
     const reparsed = await roundTrip(original, FULL_FIDELITY);
 

--- a/packages/ifcx/src/geometry-extractor.test.ts
+++ b/packages/ifcx/src/geometry-extractor.test.ts
@@ -138,6 +138,42 @@ describe('extractGeometry', () => {
     assert.deepStrictEqual(meshes.map((mesh) => mesh.ifcType).sort(), ['IfcWindow', 'IfcWindow']);
   });
 
+  it('emits a multi-parent entity mesh once (aliased containment edges, PR #1041 round-trip ×4)', () => {
+    // Hello Wall shape: the wall hangs under BOTH the storey (containment)
+    // and the space (boundary) — same entity, same placement. The exporter
+    // legitimately materialises both edges; extraction must not duplicate
+    // the wall's triangles per incoming edge.
+    const storey = createNode('storey');
+    storey.attributes.set(ATTR.CLASS, ifcClass('IfcBuildingStorey'));
+
+    const space = createNode('space');
+    space.attributes.set(ATTR.CLASS, ifcClass('IfcSpace'));
+
+    const wall = createNode('wall');
+    wall.attributes.set(ATTR.CLASS, ifcClass('IfcWall'));
+    wall.attributes.set(ATTR.MESH, createMesh());
+
+    attachChild(storey, space, 'Space');
+    attachChild(storey, wall, 'Wall');
+    attachChild(space, wall, 'Wall');
+
+    const composed = new Map<string, ComposedNode>([
+      [storey.path, storey],
+      [space.path, space],
+      [wall.path, wall],
+    ]);
+    const pathToId = new Map([
+      [storey.path, 1],
+      [space.path, 2],
+      [wall.path, 3],
+    ]);
+
+    const meshes = extractGeometry(composed, pathToId);
+
+    assert.strictEqual(meshes.length, 1, 'wall mesh must emit once, not once per incoming edge');
+    assert.strictEqual(meshes[0].expressId, 3);
+  });
+
   it('preserves inherited type-definition state through classed helper descendants', () => {
     const root = createNode('root');
     root.attributes.set(ATTR.CLASS, ifcClass('IfcWall'));

--- a/packages/ifcx/src/geometry-extractor.test.ts
+++ b/packages/ifcx/src/geometry-extractor.test.ts
@@ -174,6 +174,82 @@ describe('extractGeometry', () => {
     assert.strictEqual(meshes[0].expressId, 3);
   });
 
+  it('dedupes an alias path with an explicit identity xformop against a bare path', () => {
+    // "No transform" and an explicit identity usd::xformop produce
+    // identical world geometry — the dedupe key must canonicalize them.
+    const storey = createNode('storey');
+    storey.attributes.set(ATTR.CLASS, ifcClass('IfcBuildingStorey'));
+
+    const space = createNode('space');
+    space.attributes.set(ATTR.CLASS, ifcClass('IfcSpace'));
+    space.attributes.set(ATTR.TRANSFORM, {
+      transform: [
+        [1, 0, 0, 0],
+        [0, 1, 0, 0],
+        [0, 0, 1, 0],
+        [0, 0, 0, 1],
+      ],
+    });
+
+    const wall = createNode('wall');
+    wall.attributes.set(ATTR.CLASS, ifcClass('IfcWall'));
+    wall.attributes.set(ATTR.MESH, createMesh());
+
+    attachChild(storey, space, 'Space');
+    attachChild(storey, wall, 'Wall');
+    attachChild(space, wall, 'Wall');
+
+    const composed = new Map<string, ComposedNode>([
+      [storey.path, storey],
+      [space.path, space],
+      [wall.path, wall],
+    ]);
+    const pathToId = new Map([
+      [storey.path, 1],
+      [space.path, 2],
+      [wall.path, 3],
+    ]);
+
+    const meshes = extractGeometry(composed, pathToId);
+    assert.strictEqual(meshes.length, 1, 'identity xformop alias must still dedupe');
+  });
+
+  it('keeps both emissions when alias lineages resolve different presentation', () => {
+    // Two parents styling the same shared body differently produce
+    // genuinely different MeshData — dedupe must NOT collapse them.
+    const root = createNode('root');
+    root.attributes.set(ATTR.CLASS, ifcClass('IfcWall'));
+
+    const redGroup = createNode('red-group');
+    redGroup.attributes.set(ATTR.DIFFUSE_COLOR, [1, 0, 0]);
+
+    const blueGroup = createNode('blue-group');
+    blueGroup.attributes.set(ATTR.DIFFUSE_COLOR, [0, 0, 1]);
+
+    const body = createNode('body');
+    body.attributes.set(ATTR.MESH, createMesh());
+
+    attachChild(root, redGroup, 'Red');
+    attachChild(root, blueGroup, 'Blue');
+    attachChild(redGroup, body, 'Body');
+    attachChild(blueGroup, body, 'Body');
+
+    const composed = new Map<string, ComposedNode>([
+      [root.path, root],
+      [redGroup.path, redGroup],
+      [blueGroup.path, blueGroup],
+      [body.path, body],
+    ]);
+    const pathToId = new Map([[root.path, 1]]);
+
+    const meshes = extractGeometry(composed, pathToId);
+    assert.strictEqual(meshes.length, 2, 'differently styled lineages must both emit');
+    assert.deepStrictEqual(
+      meshes.map((m) => m.color.slice(0, 3)).sort((a, b) => a[0] - b[0]),
+      [[0, 0, 1], [1, 0, 0]],
+    );
+  });
+
   it('preserves inherited type-definition state through classed helper descendants', () => {
     const root = createNode('root');
     root.attributes.set(ATTR.CLASS, ifcClass('IfcWall'));

--- a/packages/ifcx/src/geometry-extractor.ts
+++ b/packages/ifcx/src/geometry-extractor.ts
@@ -52,17 +52,22 @@ export function extractGeometry(
   // once per traversal path, which used to duplicate its mesh — the
   // export round-trip multiplied triangle counts by the number of
   // incoming edges. Emit once per (node path, entity context, accumulated
-  // transform): an aliased containment edge resolves to the SAME entity
-  // and placement → skip; a shared type body reached from two instances
-  // resolves to different expressIds (and instancing to different
-  // transforms) → still emits.
+  // transform, resolved presentation): two frames collapse only when
+  // every lineage-derived output is identical, i.e. a true alias. A
+  // shared type body reached from two instances (different expressIds),
+  // genuine instancing (different transforms), or differently styled
+  // ancestors (different resolved color) all still emit.
   const emitted = new Set<string>();
 
   walkComposedFrames(composed, (frame) => {
     const inheritedContext = frame.parent ? contextByFrame.get(frame.parent) ?? null : null;
     const parentTransform = frame.parent ? transformByFrame.get(frame.parent) ?? null : null;
     const context = resolveContext(frame.node, inheritedContext, pathToId);
-    const transform = combineTransforms(getNodeTransform(frame.node), parentTransform);
+    // Canonicalize: an explicit identity usd::xformop and "no transform"
+    // produce identical geometry and must dedupe against each other.
+    const transform = canonicalizeTransform(
+      combineTransforms(getNodeTransform(frame.node), parentTransform)
+    );
     const lineage = getNodeLineage(frame);
 
     contextByFrame.set(frame, context);
@@ -70,17 +75,36 @@ export function extractGeometry(
 
     const mesh = frame.node.attributes.get(ATTR.MESH) as UsdMesh | undefined;
     if (mesh && context && !context.isTypeDefinition && !isInvisible(lineage)) {
-      const emitKey = `${frame.node.path}|${context.expressId}|${transform ? transform.join(',') : 'identity'}`;
+      const color = resolvePresentation(lineage);
+      const emitKey = [
+        frame.node.path,
+        context.expressId,
+        transform ? transform.join(',') : 'identity',
+        color ? color.join(',') : 'default',
+      ].join('|');
       if (!emitted.has(emitKey)) {
         emitted.add(emitKey);
         const meshData = convertUsdMesh(mesh, context.expressId, context.ifcType, transform);
-        applyPresentation(meshData, lineage);
+        if (color) {
+          meshData.color = color;
+        }
         meshes.push(meshData);
       }
     }
   });
 
   return meshes;
+}
+
+const IDENTITY_MATRIX = Object.freeze([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+
+/** Map an explicit identity matrix to null so it keys/behaves like "no transform". */
+function canonicalizeTransform(transform: Float32Array | null): Float32Array | null {
+  if (!transform) return null;
+  for (let i = 0; i < 16; i++) {
+    if (transform[i] !== IDENTITY_MATRIX[i]) return transform;
+  }
+  return null;
 }
 
 /**
@@ -265,9 +289,12 @@ function isInvisible(lineage: ComposedNode[]): boolean {
 }
 
 /**
- * Apply presentation attributes (color, opacity) to mesh.
+ * Resolve presentation attributes (color, opacity) from the lineage.
+ * Returns null when no ancestor carries a diffuse color (caller keeps
+ * the default). Resolved BEFORE mesh conversion so the dedupe key can
+ * distinguish differently-styled traversal paths.
  */
-function applyPresentation(mesh: MeshData, lineage: ComposedNode[]): void {
+function resolvePresentation(lineage: ComposedNode[]): [number, number, number, number] | null {
   // Check this node and its ancestors for presentation attributes
   for (let i = lineage.length - 1; i >= 0; i--) {
     const current = lineage[i];
@@ -277,10 +304,10 @@ function applyPresentation(mesh: MeshData, lineage: ComposedNode[]): void {
     if (diffuse) {
       const [r, g, b] = diffuse;
       const a = opacity ?? 1.0;
-      mesh.color = [r, g, b, a];
-      return;
+      return [r, g, b, a];
     }
   }
+  return null;
 }
 
 /**

--- a/packages/ifcx/src/geometry-extractor.ts
+++ b/packages/ifcx/src/geometry-extractor.ts
@@ -47,6 +47,16 @@ export function extractGeometry(
   const meshes: MeshData[] = [];
   const contextByFrame = new WeakMap<TraversalFrame, GeometryContext | null>();
   const transformByFrame = new WeakMap<TraversalFrame, Float32Array | null>();
+  // A node reachable through multiple parents (e.g. storey→wall AND
+  // space→wall containment edges, as our own exporter emits) is visited
+  // once per traversal path, which used to duplicate its mesh — the
+  // export round-trip multiplied triangle counts by the number of
+  // incoming edges. Emit once per (node path, entity context, accumulated
+  // transform): an aliased containment edge resolves to the SAME entity
+  // and placement → skip; a shared type body reached from two instances
+  // resolves to different expressIds (and instancing to different
+  // transforms) → still emits.
+  const emitted = new Set<string>();
 
   walkComposedFrames(composed, (frame) => {
     const inheritedContext = frame.parent ? contextByFrame.get(frame.parent) ?? null : null;
@@ -60,9 +70,13 @@ export function extractGeometry(
 
     const mesh = frame.node.attributes.get(ATTR.MESH) as UsdMesh | undefined;
     if (mesh && context && !context.isTypeDefinition && !isInvisible(lineage)) {
-      const meshData = convertUsdMesh(mesh, context.expressId, context.ifcType, transform);
-      applyPresentation(meshData, lineage);
-      meshes.push(meshData);
+      const emitKey = `${frame.node.path}|${context.expressId}|${transform ? transform.join(',') : 'identity'}`;
+      if (!emitted.has(emitKey)) {
+        emitted.add(emitKey);
+        const meshData = convertUsdMesh(mesh, context.expressId, context.ifcType, transform);
+        applyPresentation(meshData, lineage);
+        meshes.push(meshData);
+      }
     }
   });
 


### PR DESCRIPTION
## Why

The #1041 round-trip corpus pinned a real fidelity bug with a strict `it.fails`: re-parsing an exported IFCX multiplied per-entity triangle counts by the number of incoming containment edges (Hello Wall wall: 54 → 216 triangles, ×4). The exported file is correct — the exporter legitimately materialises the flattened containment maps as children (storey→wall **and** space→wall) — but `parseIfcx`'s geometry extractor emitted one mesh per incoming traversal path. This is the collab-canonical parse path, so duplicated render geometry also affected CRDT recipients.

## Fix

`extractGeometry` now deduplicates emission per **(node path, entity context, accumulated transform)**:
- aliased containment edges resolve to the same entity + same placement → emit once
- a shared type body referenced from two instances resolves to **different expressIds** → still emits per instance (the existing `emits shared inherited mesh geometry for each non-type instance context` test pins this — a naive path-only dedup would have broken it)
- genuine instancing differs in accumulated transform → still emits

## Tests

- Flips the #1041 `it.fails` round-trip assertion to a passing strict test (per-entity triangle totals preserved)
- New direct unit test mirroring the Hello Wall multi-parent shape
- Verified: ifcx 12/12, export round-trip 8/8, full `turbo test` over export/ifcx/collab/viewer: 33/33
- Changeset included (@ifc-lite/ifcx patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)