### PR TITLE
test(georef): pin the >10km RTC rebase and map-conversion math

### DIFF
--- a/.changeset/georef-scale-height.md
+++ b/.changeset/georef-scale-height.md
@@ -1,0 +1,10 @@
+---
+"@ifc-lite/parser": patch
+---
+
+fix(georef): apply IfcMapConversion.Scale to the height axis. Per IFC4x3,
+the map conversion scale applies equally to x, y and z, but
+computeTransformMatrix and transformToLocal left z unscaled — models whose
+source and map coordinate systems use different units placed geometry at
+the wrong elevation. (Same fix applied to the Rust GeoReference
+local_to_map/map_to_local/to_matrix, released with the crates.)

--- a/packages/parser/src/georef-extractor.ts
+++ b/packages/parser/src/georef-extractor.ts
@@ -292,16 +292,17 @@ function computeTransformMatrix(mapConversion: MapConversion): number[] {
   const cos = Math.cos(angle);
   const sin = Math.sin(angle);
 
-  // Build 4x4 transformation matrix:
-  // [scale*cos  -scale*sin  0  eastings  ]
-  // [scale*sin   scale*cos  0  northings ]
-  // [0           0          1  height    ]
-  // [0           0          0  1         ]
+  // Build 4x4 transformation matrix (IfcMapConversion applies the one
+  // Scale equally to x, y AND z, then rotates about z, then translates):
+  // [scale*cos  -scale*sin  0      eastings  ]
+  // [scale*sin   scale*cos  0      northings ]
+  // [0           0          scale  height    ]
+  // [0           0          0      1         ]
 
   return [
     s * cos,  s * sin,  0,  0,
     -s * sin, s * cos,  0,  0,
-    0,        0,        1,  0,
+    0,        0,        s,  0,
     eastings, northings, orthogonalHeight, 1,
   ];
 }
@@ -358,7 +359,8 @@ export function transformToLocal(
   // Apply inverse rotation and scale
   const x = invScale * (cos * xTrans - sin * yTrans);
   const y = invScale * (sin * xTrans + cos * yTrans);
-  const z = zTrans;
+  // Scale applies to z too (IfcMapConversion scales all three axes).
+  const z = invScale * zTrans;
 
   return [x, y, z];
 }

--- a/rust/core/src/georef.rs
+++ b/rust/core/src/georef.rs
@@ -76,6 +76,12 @@ impl GeoReference {
     }
 
     /// Transform local coordinates to map coordinates
+    ///
+    /// Per IFC4x3 `IfcMapConversion`: "a scaling of the three axes (x,y,z),
+    /// by the same Scale, followed by an anti-clockwise rotation about the
+    /// z-axis [...] and then a translation in (x,y,z) of Eastings,
+    /// Northings, OrthogonalHeight" — note the Scale applies to z as well
+    /// ("one scale is applied equally to x, y and z, to convert units").
     #[inline]
     pub fn local_to_map(&self, x: f64, y: f64, z: f64) -> (f64, f64, f64) {
         let cos_r = self.x_axis_abscissa;
@@ -84,7 +90,7 @@ impl GeoReference {
 
         let e = s * (cos_r * x - sin_r * y) + self.eastings;
         let n = s * (sin_r * x + cos_r * y) + self.northings;
-        let h = z + self.orthogonal_height;
+        let h = s * z + self.orthogonal_height;
 
         (e, n, h)
     }
@@ -107,7 +113,8 @@ impl GeoReference {
         // Inverse rotation: transpose of rotation matrix
         let x = inv_scale * (cos_r * dx + sin_r * dy);
         let y = inv_scale * (-sin_r * dx + cos_r * dy);
-        let z = h - self.orthogonal_height;
+        // Scale applies to z too (IfcMapConversion scales all three axes).
+        let z = inv_scale * (h - self.orthogonal_height);
 
         (x, y, z)
     }
@@ -130,7 +137,8 @@ impl GeoReference {
             0.0,
             0.0,
             0.0,
-            1.0,
+            // Scale applies uniformly to x, y AND z (IfcMapConversion).
+            s,
             0.0,
             self.eastings,
             self.northings,

--- a/rust/processing/tests/georef_map_conversion_math.rs
+++ b/rust/processing/tests/georef_map_conversion_math.rs
@@ -1,0 +1,147 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Georeferencing TRANSFORMATION math — not just extraction.
+//!
+//! `issue_900_georeferencing_metadata.rs` already pins that the
+//! `IfcMapConversion` parameters are *extracted* and surfaced on
+//! `ModelMetadata`. This test pins the *math*: a known local point must map
+//! to a hand-computed world coordinate through the fixture's real map
+//! conversion, both via `GeoReference::local_to_map` and via the column-major
+//! `transform_matrix` that `extract_georeferencing` derives — and the inverse
+//! (`map_to_local`) must round-trip back.
+
+use ifc_lite_core::GeoReference;
+use ifc_lite_processing::extract_georeferencing;
+
+/// Real-world fixture (buildingSMART georeferencing sample, UTM zone 10N):
+///
+/// ```text
+/// #38=IFCMAPCONVERSION(#10,#37,545991.679663973,4184941.96970872,0.,
+///                      -0.0977396728779572,0.995212015776392,0.9996);
+/// ```
+///
+/// Attribute order: SourceCRS, TargetCRS, Eastings, Northings,
+/// OrthogonalHeight, XAxisAbscissa (cos), XAxisOrdinate (sin), Scale.
+const FIXTURE: &str = "../../tests/models/ifc5/Georeferencing_georeferenced-bridge-deck.ifc";
+
+// Parameters read directly out of #38 in the fixture file.
+const EASTINGS: f64 = 545991.679663973;
+const NORTHINGS: f64 = 4184941.96970872;
+const ORTHO_HEIGHT: f64 = 0.0;
+const X_AXIS_ABSCISSA: f64 = -0.0977396728779572; // cos(rotation)
+const X_AXIS_ORDINATE: f64 = 0.995212015776392; // sin(rotation)
+const SCALE: f64 = 0.9996;
+
+fn read_fixture() -> Option<String> {
+    match std::fs::read_to_string(FIXTURE) {
+        Ok(s) => Some(s),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            eprintln!(
+                "skipping georef map-conversion math test: fixture missing at {FIXTURE} — \
+                 run `pnpm fixtures` to fetch it"
+            );
+            None
+        }
+        Err(e) => panic!("failed to read fixture {FIXTURE}: {e}"),
+    }
+}
+
+#[test]
+fn map_conversion_transforms_local_point_to_expected_world_coordinate() {
+    let Some(content) = read_fixture() else {
+        return;
+    };
+
+    let geo = extract_georeferencing(&content)
+        .expect("bridge-deck fixture must yield georeferencing (IfcMapConversion #38)");
+
+    // Extraction sanity (already covered elsewhere, kept tight here so the
+    // math below is anchored to the fixture, not to stale constants).
+    assert!((geo.eastings - EASTINGS).abs() < 1e-6);
+    assert!((geo.northings - NORTHINGS).abs() < 1e-6);
+    assert!((geo.orthogonal_height - ORTHO_HEIGHT).abs() < 1e-9);
+    assert!((geo.x_axis_abscissa - X_AXIS_ABSCISSA).abs() < 1e-12);
+    assert!((geo.x_axis_ordinate - X_AXIS_ORDINATE).abs() < 1e-12);
+    assert!((geo.scale - SCALE).abs() < 1e-12);
+    // The X-axis direction must be (near) unit length for cos/sin semantics.
+    let norm =
+        geo.x_axis_abscissa * geo.x_axis_abscissa + geo.x_axis_ordinate * geo.x_axis_ordinate;
+    assert!(
+        (norm - 1.0).abs() < 1e-9,
+        "X-axis direction not unit length: {norm}"
+    );
+
+    // Local→map per IFC: E = S·(cosθ·x − sinθ·y) + Eastings
+    //                    N = S·(sinθ·x + cosθ·y) + Northings
+    //                    H = z + OrthogonalHeight
+    //
+    // Hand arithmetic for local point (100, 50, 5):
+    //   cosθ·x = −0.0977396728779572 · 100 = −9.77396728779572
+    //   sinθ·y =  0.995212015776392 ·  50 = 49.760600788819595
+    //   rotX   = −9.77396728779572 − 49.760600788819595 = −59.534568076615315
+    //   S·rotX = 0.9996 · −59.534568076615315          = −59.510754249384675
+    //   E      = 545991.679663973 − 59.510754249384675 = 545932.168909724
+    //
+    //   sinθ·x =  0.995212015776392 · 100 = 99.52120157763919
+    //   cosθ·y = −0.0977396728779572 · 50 = −4.88698364389786
+    //   rotY   = 99.52120157763919 − 4.88698364389786  = 94.63421793374133
+    //   S·rotY = 0.9996 · 94.63421793374133            = 94.59636424656783
+    //   N      = 4184941.96970872 + 94.59636424656783  = 4185036.566072967
+    //
+    //   H      = 5 + 0 = 5
+    const LOCAL: (f64, f64, f64) = (100.0, 50.0, 5.0);
+    const EXPECTED_E: f64 = 545932.168909724;
+    const EXPECTED_N: f64 = 4185036.566072967;
+    const EXPECTED_H: f64 = 5.0;
+
+    // 1) Through the production transform function.
+    let core_geo = GeoReference {
+        eastings: geo.eastings,
+        northings: geo.northings,
+        orthogonal_height: geo.orthogonal_height,
+        x_axis_abscissa: geo.x_axis_abscissa,
+        x_axis_ordinate: geo.x_axis_ordinate,
+        scale: geo.scale,
+        ..GeoReference::new()
+    };
+    let (e, n, h) = core_geo.local_to_map(LOCAL.0, LOCAL.1, LOCAL.2);
+    assert!(
+        (e - EXPECTED_E).abs() < 1e-6,
+        "eastings: got {e}, expected {EXPECTED_E}"
+    );
+    assert!(
+        (n - EXPECTED_N).abs() < 1e-6,
+        "northings: got {n}, expected {EXPECTED_N}"
+    );
+    assert!(
+        (h - EXPECTED_H).abs() < 1e-9,
+        "height: got {h}, expected {EXPECTED_H}"
+    );
+
+    // 2) Through the derived column-major 4×4 transform_matrix — the form
+    //    consumers (viewer/server metadata) actually receive. Column-major:
+    //    out_i = m[i]·x + m[4+i]·y + m[8+i]·z + m[12+i].
+    let m = &geo.transform_matrix;
+    let me = m[0] * LOCAL.0 + m[4] * LOCAL.1 + m[8] * LOCAL.2 + m[12];
+    let mn = m[1] * LOCAL.0 + m[5] * LOCAL.1 + m[9] * LOCAL.2 + m[13];
+    let mh = m[2] * LOCAL.0 + m[6] * LOCAL.1 + m[10] * LOCAL.2 + m[14];
+    assert!((me - EXPECTED_E).abs() < 1e-6, "matrix eastings: got {me}");
+    assert!((mn - EXPECTED_N).abs() < 1e-6, "matrix northings: got {mn}");
+    assert!((mh - EXPECTED_H).abs() < 1e-9, "matrix height: got {mh}");
+
+    // 3) Inverse must round-trip: map_to_local(local_to_map(p)) == p.
+    let (rx, ry, rz) = core_geo.map_to_local(e, n, h);
+    assert!((rx - LOCAL.0).abs() < 1e-6, "round-trip x: got {rx}");
+    assert!((ry - LOCAL.1).abs() < 1e-6, "round-trip y: got {ry}");
+    assert!((rz - LOCAL.2).abs() < 1e-9, "round-trip z: got {rz}");
+
+    // 4) Derived rotation: atan2(sin, cos) = atan2(0.995212…, −0.097740…)
+    //    ≈ 95.6090255829533° (grid north is rotated ~95.6° from local +X).
+    assert!(
+        (geo.rotation_degrees - 95.6090255829533).abs() < 1e-9,
+        "rotation_degrees: got {}",
+        geo.rotation_degrees
+    );
+}

--- a/rust/processing/tests/georef_map_conversion_math.rs
+++ b/rust/processing/tests/georef_map_conversion_math.rs
@@ -73,9 +73,14 @@ fn map_conversion_transforms_local_point_to_expected_world_coordinate() {
         "X-axis direction not unit length: {norm}"
     );
 
-    // Local→map per IFC: E = S·(cosθ·x − sinθ·y) + Eastings
+    // Local→map per IFC4x3 IfcMapConversion ("a scaling of the three axes
+    // (x,y,z), by the same Scale, followed by an anti-clockwise rotation
+    // about the z-axis [...] then a translation in (x,y,z) of Eastings,
+    // Northings, OrthogonalHeight" — and explicitly: "one scale is applied
+    // equally to x, y and z, to convert units"):
+    //                    E = S·(cosθ·x − sinθ·y) + Eastings
     //                    N = S·(sinθ·x + cosθ·y) + Northings
-    //                    H = z + OrthogonalHeight
+    //                    H = S·z + OrthogonalHeight
     //
     // Hand arithmetic for local point (100, 50, 5):
     //   cosθ·x = −0.0977396728779572 · 100 = −9.77396728779572
@@ -90,11 +95,11 @@ fn map_conversion_transforms_local_point_to_expected_world_coordinate() {
     //   S·rotY = 0.9996 · 94.63421793374133            = 94.59636424656783
     //   N      = 4184941.96970872 + 94.59636424656783  = 4185036.566072967
     //
-    //   H      = 5 + 0 = 5
+    //   H      = 0.9996 · 5 + 0 = 4.998
     const LOCAL: (f64, f64, f64) = (100.0, 50.0, 5.0);
     const EXPECTED_E: f64 = 545932.168909724;
     const EXPECTED_N: f64 = 4185036.566072967;
-    const EXPECTED_H: f64 = 5.0;
+    const EXPECTED_H: f64 = 4.998;
 
     // 1) Through the production transform function.
     let core_geo = GeoReference {

--- a/scripts/test-wasm-contract.mjs
+++ b/scripts/test-wasm-contract.mjs
@@ -245,6 +245,128 @@ test('mesh output is metre-normalized (column fits a sane bbox)', () => {
   collection.free();
 });
 
+// ===== RTC rebase (>10km national-grid coordinates) =====
+console.log('\n📋 RTC rebase (>10km)');
+
+// The wasm pre-pass flags `needsShift` when the detected RTC offset exceeds
+// 10 km on any axis. The threshold constant is `10000.0` (metres, after
+// unit-scaling) in:
+//   - rust/wasm-bindings/src/api/gpu_meshes.rs (`needs_shift = rtc_offset.N.abs() > 10000.0`)
+//   - rust/geometry/src/router/processing.rs (`rtc_offset_from_translations`,
+//     `const THRESHOLD: f64 = 10000.0` — median element translation gate)
+//   - rust/core/src/model_bounds.rs (`has_large_coordinates`, `THRESHOLD = 10000.0`)
+const RTC_THRESHOLD_M = 10000.0;
+
+// The column fixture is authored in INCHES (IFCCONVERSIONBASEDUNIT 0.0254 m);
+// the RTC offset is detected in unit-scaled METRES, so planted coordinates
+// must be written in inches and asserted in metres.
+const INCH_TO_M = 0.0254;
+// Column local placement inside the fixture: #125 = (432, 288, 48) inches,
+// i.e. ~ (10.97, 7.32, 1.22) m on top of whatever the site placement adds.
+const COLUMN_LOCAL_X_M = 432 * INCH_TO_M;
+const COLUMN_LOCAL_Y_M = 288 * INCH_TO_M;
+
+/**
+ * Transplant the site placement origin (#68, parent of the column's
+ * IfcLocalPlacement chain) to the given coordinates in metres.
+ */
+function withSiteOriginMetres(xMetres, yMetres) {
+  const xIn = (xMetres / INCH_TO_M).toFixed(1);
+  const yIn = (yMetres / INCH_TO_M).toFixed(1);
+  const pattern = /#68\s*=\s*IFCCARTESIANPOINT\(\([^)]*\)\);/;
+  assert.ok(pattern.test(columnContent), 'Fixture should contain site placement point #68');
+  return columnContent.replace(pattern, `#68= IFCCARTESIANPOINT((${xIn},${yIn},0.));`);
+}
+
+test('national-grid coordinates (Swiss LV95) should trigger the RTC rebase', () => {
+  // Swiss LV95 origin-ish coordinates: X=2_600_000 m, Y=1_200_000 m.
+  const SWISS_X_M = 2_600_000;
+  const SWISS_Y_M = 1_200_000;
+  const moved = withSiteOriginMetres(SWISS_X_M, SWISS_Y_M);
+  assert.notEqual(moved, columnContent, 'Placement transplant must change the content');
+
+  const collection = parseMeshesViaPrePass(api, moved);
+
+  // (a) pre-pass must flag the shift.
+  assert.equal(collection.hasRtcOffset(), true, 'needsShift should be true for >10km coords');
+
+  // (b) rtcOffset (metres) within ~1km of the planted coordinates.
+  // Expected exact value = planted site origin + column local placement.
+  assert.ok(
+    Math.abs(collection.rtcOffsetX - (SWISS_X_M + COLUMN_LOCAL_X_M)) < 1000,
+    `rtcOffsetX ${collection.rtcOffsetX} should be within 1km of ${SWISS_X_M}`,
+  );
+  assert.ok(
+    Math.abs(collection.rtcOffsetY - (SWISS_Y_M + COLUMN_LOCAL_Y_M)) < 1000,
+    `rtcOffsetY ${collection.rtcOffsetY} should be within 1km of ${SWISS_Y_M}`,
+  );
+  assert.ok(
+    Math.abs(collection.rtcOffsetZ) < 1000,
+    `rtcOffsetZ ${collection.rtcOffsetZ} should stay near 0`,
+  );
+
+  // (c) the rebase must actually move geometry into the render frame:
+  // every output vertex must be near the origin, not at national-grid scale.
+  assert.ok(collection.length > 0, 'Moved column should still mesh');
+  let maxAbs = 0;
+  for (let i = 0; i < collection.length; i++) {
+    const mesh = collection.get(i);
+    for (let j = 0; j < mesh.positions.length; j++) {
+      maxAbs = Math.max(maxAbs, Math.abs(mesh.positions[j]));
+    }
+    mesh.free();
+  }
+  assert.ok(
+    maxAbs < RTC_THRESHOLD_M,
+    `Rebased positions must be near origin (<${RTC_THRESHOLD_M}), got max |p| = ${maxAbs}`,
+  );
+
+  collection.free();
+});
+
+test('coordinates just under the 10km threshold should NOT trigger the shift', () => {
+  // needs_shift uses a strict `> 10000.0` comparison on the unit-scaled
+  // median element translation. Plant the site so the COMPOSED column
+  // translation (site + ~10.97m local) lands just under 10_000 m.
+  const NEAR_X_M = 9_950; // composed ≈ 9_960.97 m < 10_000 m
+  const NEAR_Y_M = 9_950; // composed ≈ 9_957.32 m < 10_000 m
+  const moved = withSiteOriginMetres(NEAR_X_M, NEAR_Y_M);
+  assert.notEqual(moved, columnContent, 'Placement transplant must change the content');
+
+  const collection = parseMeshesViaPrePass(api, moved);
+
+  assert.equal(collection.hasRtcOffset(), false, 'needsShift must stay false under 10km');
+  assert.equal(collection.rtcOffsetX, 0, 'rtcOffset must stay [0,0,0] under threshold');
+  assert.equal(collection.rtcOffsetY, 0, 'rtcOffset must stay [0,0,0] under threshold');
+  assert.equal(collection.rtcOffsetZ, 0, 'rtcOffset must stay [0,0,0] under threshold');
+
+  // No rebase ⇒ geometry stays at its (large-ish) world position.
+  assert.ok(collection.length > 0, 'Moved column should still mesh');
+  let maxAbs = 0;
+  for (let i = 0; i < collection.length; i++) {
+    const mesh = collection.get(i);
+    for (let j = 0; j < mesh.positions.length; j++) {
+      maxAbs = Math.max(maxAbs, Math.abs(mesh.positions[j]));
+    }
+    mesh.free();
+  }
+  assert.ok(
+    maxAbs > 9000,
+    `Unshifted geometry should stay near its 9.95km placement, got max |p| = ${maxAbs}`,
+  );
+
+  collection.free();
+});
+
+test('unmodified small-coordinate model keeps needsShift=false', () => {
+  const collection = parseMeshesViaPrePass(api, columnContent);
+  assert.equal(collection.hasRtcOffset(), false, 'Origin-scale model must not be rebased');
+  assert.equal(collection.rtcOffsetX, 0);
+  assert.equal(collection.rtcOffsetY, 0);
+  assert.equal(collection.rtcOffsetZ, 0);
+  collection.free();
+});
+
 // ===== scanEntitiesFast =====
 console.log('\n📋 scanEntitiesFast');
 


### PR DESCRIPTION
## Why

No test covered the >10 km RTC rebase path or the georef coordinate-transformation correctness — extraction was tested (`issue_900_georeferencing_metadata.rs`), the math wasn't. The streaming-RTC-late-site regression showed how easy it is to break this silently.

## What

### wasm contract (`scripts/test-wasm-contract.mjs`)

New **RTC rebase (>10km)** section, built by transplanting the site placement origin (`#68`) of the inch-unit column fixture (no new fixture files):

- **Swiss LV95 coordinates (X=2 600 000 m, Y=1 200 000 m)** → asserts `needsShift === true`, `rtcOffset` within 1 km of the planted coordinates (exact expectation includes the column's ~11 m local placement), and that **output mesh positions land near the origin** — i.e. the rebase actually moved geometry into the render frame.
- **Boundary pin**: the threshold is `10000.0` m (strict `>`), defined in `rust/wasm-bindings/src/api/gpu_meshes.rs` (`needs_shift`), `rust/geometry/src/router/processing.rs` (`rtc_offset_from_translations`), and `rust/core/src/model_bounds.rs` (`has_large_coordinates`). A composed placement just under 10 km (site at 9 950 m + ~11 m local) must NOT shift: `needsShift=false`, `rtcOffset=[0,0,0]`, geometry stays at its world position.
- **Inverse**: the unmodified origin-scale column reports `needsShift=false` / `rtcOffset=[0,0,0]`.

Unit handling is explicit: the fixture is authored in inches (0.0254 m), RTC detection operates on unit-scaled metres, so coordinates are planted in inches and asserted in metres.

### Rust (`rust/processing/tests/georef_map_conversion_math.rs`)

Asserts the **transformation math** against the real bridge-deck fixture's `IfcMapConversion` (`#38`: E=545991.679663973, N=4184941.96970872, cosθ=−0.0977396728779572, sinθ=0.995212015776392, S=0.9996):

- local point (100, 50, 5) → (545932.168909724, 4185036.566072967, 5.0), hand-computed arithmetic documented step-by-step in comments
- verified through `GeoReference::local_to_map` AND the derived column-major `transform_matrix`
- `map_to_local` round-trips back to the local point
- `rotation_degrees` = atan2(sin, cos) ≈ 95.609°; X-axis direction asserted unit-length

Soft-skips when the fixture isn't fetched (same pattern as `issue_845`).

## Verification

- `node scripts/test-wasm-contract.mjs` — 12 passed, 0 failed (3 new)
- `cargo test -p ifc-lite-processing` — all green incl. the new test