### PR TITLE
test(geometry): property-based CSG invariants (proptest)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,6 +532,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,6 +1046,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1468,6 +1489,7 @@ dependencies = [
  "manifold-csg",
  "nalgebra",
  "png",
+ "proptest",
  "rayon",
  "robust",
  "rustc-hash",
@@ -2174,6 +2196,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2191,6 +2222,31 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -2212,6 +2268,44 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "rawpointer"
@@ -2329,6 +2423,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -2892,6 +2998,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2926,6 +3038,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/rust/geometry/Cargo.toml
+++ b/rust/geometry/Cargo.toml
@@ -74,6 +74,11 @@ manifold-csg = { version = "0.3", default-features = false, optional = true }
 
 [dev-dependencies]
 approx = "0.5"
+# Property-based testing for the CSG kernel invariants
+# (tests/csg_property_test.rs): volume bounds, NaN-freedom, watertightness
+# over bounded randomized inputs. Case counts are set explicitly per
+# property to keep the suite fast.
+proptest = "1.6"
 # Snapshot testing for the geometry correctness harness
 # (tests/geometry_correctness_harness.rs). Plain string snapshots only, so
 # no serde-format features are needed. Accept intentional geometry changes

--- a/rust/geometry/tests/csg_property_test.rs
+++ b/rust/geometry/tests/csg_property_test.rs
@@ -1,0 +1,572 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Property-based invariants for the CSG pipeline (proptest).
+//!
+//! Everything else in `tests/` is example-based (specific IFC fixtures /
+//! regression scenarios). This suite instead checks *invariants* over
+//! bounded randomized inputs:
+//!
+//! 1. Axis-aligned box difference (`ClippingProcessor::subtract_mesh`,
+//!    which dispatches to the Manifold kernel under the default
+//!    `manifold-csg` feature and to the legacy BSP port without it):
+//!    NaN/Inf-freedom, volume bounds, exact analytic volume for AABB
+//!    pairs, emptiness under containment, identity under disjointness,
+//!    and watertightness of the output.
+//! 2. Star-shaped polygon extrusion (`extrude_profile`): non-empty,
+//!    NaN-free, watertight, volume == shoelace-area × depth.
+//! 3. 2D boolean rect-pair subtraction (`bool2d::subtract_2d`): area
+//!    bounds + exact analytic area, and no self-intersecting output
+//!    contours.
+//!
+//! Case counts are set explicitly per property (48–64) so the whole
+//! suite stays well under a minute. Volumes are checked against the
+//! f32-quantized inputs (Mesh stores f32 positions), with tolerances
+//! that account for the kernel's deliberate ~10 µm cutter inflation
+//! (`manifold_kernel::mesh_to_manifold_perturbed`) and f32 round-trips.
+//!
+//! If a property ever fails, proptest shrinks to a minimal
+//! counterexample and records it in
+//! `tests/csg_property_test.proptest-regressions` — commit that file so
+//! the counterexample is replayed forever.
+
+use ifc_lite_geometry::{
+    compute_signed_area, extrude_profile, subtract_2d, ClippingProcessor, Mesh, Point2, Point3,
+    Profile2D, Vector3,
+};
+use proptest::prelude::*;
+use std::collections::HashMap;
+use std::f64::consts::TAU;
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/// Quantize an f64 coordinate through f32, the precision `Mesh` actually
+/// stores. Analytic expectations are computed from quantized values so
+/// the properties measure *kernel* error, not authoring error.
+fn q(v: f64) -> f64 {
+    v as f32 as f64
+}
+
+/// Axis-aligned box mesh `[min, min+size]` with outward-CCW winding
+/// (same layout as the `manifold_kernel` unit tests).
+fn box_mesh(min: [f64; 3], size: [f64; 3]) -> Mesh {
+    let mut m = Mesh::with_capacity(8, 36);
+    let n = Vector3::new(0.0, 0.0, 0.0);
+    let p = |dx: f64, dy: f64, dz: f64| {
+        Point3::new(
+            min[0] + dx * size[0],
+            min[1] + dy * size[1],
+            min[2] + dz * size[2],
+        )
+    };
+    let corners = [
+        p(0.0, 0.0, 0.0),
+        p(1.0, 0.0, 0.0),
+        p(1.0, 1.0, 0.0),
+        p(0.0, 1.0, 0.0),
+        p(0.0, 0.0, 1.0),
+        p(1.0, 0.0, 1.0),
+        p(1.0, 1.0, 1.0),
+        p(0.0, 1.0, 1.0),
+    ];
+    for c in &corners {
+        m.add_vertex(*c, n);
+    }
+    let faces: [[u32; 6]; 6] = [
+        [0, 2, 1, 0, 3, 2],
+        [4, 5, 6, 4, 6, 7],
+        [0, 4, 7, 0, 7, 3],
+        [1, 2, 6, 1, 6, 5],
+        [0, 1, 5, 0, 5, 4],
+        [3, 7, 6, 3, 6, 2],
+    ];
+    for f in &faces {
+        m.add_triangle(f[0], f[1], f[2]);
+        m.add_triangle(f[3], f[4], f[5]);
+    }
+    m
+}
+
+/// Signed volume of a (closed) triangle mesh via the divergence theorem,
+/// accumulated in f64. Positive for outward-CCW shells.
+fn mesh_volume(mesh: &Mesh) -> f64 {
+    let pos = &mesh.positions;
+    let mut six_v = 0.0f64;
+    for tri in mesh.indices.chunks_exact(3) {
+        let v = |i: u32| {
+            let b = i as usize * 3;
+            [pos[b] as f64, pos[b + 1] as f64, pos[b + 2] as f64]
+        };
+        let (a, b, c) = (v(tri[0]), v(tri[1]), v(tri[2]));
+        six_v += a[0] * (b[1] * c[2] - b[2] * c[1])
+            + a[1] * (b[2] * c[0] - b[0] * c[2])
+            + a[2] * (b[0] * c[1] - b[1] * c[0]);
+    }
+    six_v / 6.0
+}
+
+/// Every position component must be finite (no NaN / Inf).
+fn all_finite(mesh: &Mesh) -> bool {
+    mesh.positions.iter().all(|v| v.is_finite())
+}
+
+/// Watertightness: after welding by position, every directed edge must be
+/// matched by exactly one opposite directed edge (each undirected edge is
+/// shared by exactly two triangles with consistent winding). Empty meshes
+/// count as watertight (the empty shell is closed).
+fn is_watertight(mesh: &Mesh) -> bool {
+    if mesh.is_empty() {
+        return true;
+    }
+    let welded = mesh.welded_by_position(1e-6);
+    let mut edges: HashMap<(u32, u32), i64> = HashMap::new();
+    for tri in welded.indices.chunks_exact(3) {
+        for k in 0..3 {
+            let a = tri[k];
+            let b = tri[(k + 1) % 3];
+            // +1 for the edge in (min,max) orientation, -1 for the reverse:
+            // a closed, consistently wound surface nets to 0 on every edge.
+            let key = (a.min(b), a.max(b));
+            *edges.entry(key).or_insert(0) += if a < b { 1 } else { -1 };
+        }
+    }
+    edges.values().all(|&count| count == 0)
+}
+
+/// Shoelace area of a simple polygon (positive for CCW input).
+fn shoelace_area(pts: &[Point2<f64>]) -> f64 {
+    let n = pts.len();
+    let mut sum = 0.0;
+    for i in 0..n {
+        let j = (i + 1) % n;
+        sum += pts[i].x * pts[j].y - pts[j].x * pts[i].y;
+    }
+    sum / 2.0
+}
+
+/// Proper-crossing self-intersection scan over a closed loop, O(n²).
+/// Mirrors the (private) `profiles::closed_loop_self_intersects` logic:
+/// only interior crossings of non-adjacent segments count; shared
+/// endpoints between neighbouring segments do not.
+fn closed_loop_self_intersects(loop_: &[Point2<f64>]) -> bool {
+    let n = loop_.len();
+    if n < 4 {
+        return false;
+    }
+    let orient = |a: &Point2<f64>, b: &Point2<f64>, c: &Point2<f64>| -> f64 {
+        (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x)
+    };
+    let crosses = |a: &Point2<f64>, b: &Point2<f64>, c: &Point2<f64>, d: &Point2<f64>| -> bool {
+        let d1 = orient(a, b, c);
+        let d2 = orient(a, b, d);
+        let d3 = orient(c, d, a);
+        let d4 = orient(c, d, b);
+        d1 * d2 < 0.0 && d3 * d4 < 0.0
+    };
+    for i in 0..n {
+        let a = &loop_[i];
+        let b = &loop_[(i + 1) % n];
+        for j_off in 2..n - 1 {
+            let j = (i + j_off) % n;
+            let c = &loop_[j];
+            let d = &loop_[(j + 1) % n];
+            if crosses(a, b, c, d) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Analytic AABB ∩ AABB volume from (already-quantized) min/size pairs.
+fn aabb_intersection_volume(
+    a_min: [f64; 3],
+    a_size: [f64; 3],
+    b_min: [f64; 3],
+    b_size: [f64; 3],
+) -> f64 {
+    let mut vol = 1.0;
+    for axis in 0..3 {
+        let lo = a_min[axis].max(b_min[axis]);
+        let hi = (a_min[axis] + a_size[axis]).min(b_min[axis] + b_size[axis]);
+        if hi <= lo {
+            return 0.0;
+        }
+        vol *= hi - lo;
+    }
+    vol
+}
+
+// ---------------------------------------------------------------------------
+// Property 1: box-pair boolean difference
+// ---------------------------------------------------------------------------
+
+/// A box pair plus the configuration it was generated under (kept for
+/// debuggability when proptest prints a counterexample).
+#[derive(Debug, Clone)]
+struct BoxPair {
+    config: &'static str,
+    a_min: [f64; 3],
+    a_size: [f64; 3],
+    b_min: [f64; 3],
+    b_size: [f64; 3],
+}
+
+fn quantized(min: [f64; 3], size: [f64; 3]) -> ([f64; 3], [f64; 3]) {
+    // Quantize the *corners* (that's what add_vertex stores), then derive
+    // the size from the quantized corners so analytic volume matches the
+    // authored mesh bit-for-bit.
+    let qmin = [q(min[0]), q(min[1]), q(min[2])];
+    let qmax = [
+        q(min[0] + size[0]),
+        q(min[1] + size[1]),
+        q(min[2] + size[2]),
+    ];
+    (
+        qmin,
+        [qmax[0] - qmin[0], qmax[1] - qmin[1], qmax[2] - qmin[2]],
+    )
+}
+
+prop_compose! {
+    fn arb_box_a()(
+        min in proptest::array::uniform3(-10.0f64..10.0),
+        size in proptest::array::uniform3(0.1f64..5.0),
+    ) -> ([f64; 3], [f64; 3]) {
+        (min, size)
+    }
+}
+
+fn arb_box_pair() -> impl Strategy<Value = BoxPair> {
+    arb_box_a().prop_flat_map(|(a_min, a_size)| {
+        let random = (
+            proptest::array::uniform3(-12.0f64..12.0),
+            proptest::array::uniform3(0.1f64..6.0),
+        )
+            .prop_map(move |(b_min, b_size)| BoxPair {
+                config: "random",
+                a_min,
+                a_size,
+                b_min,
+                b_size,
+            });
+        // B strictly contains A (uniform margin on every side).
+        let contained = (0.05f64..1.0).prop_map(move |margin| BoxPair {
+            config: "b-contains-a",
+            a_min,
+            a_size,
+            b_min: [a_min[0] - margin, a_min[1] - margin, a_min[2] - margin],
+            b_size: [
+                a_size[0] + 2.0 * margin,
+                a_size[1] + 2.0 * margin,
+                a_size[2] + 2.0 * margin,
+            ],
+        });
+        // B disjoint from A: shifted past A's max corner along one axis.
+        let disjoint = (
+            0usize..3,
+            0.01f64..2.0,
+            proptest::array::uniform3(0.1f64..5.0),
+        )
+            .prop_map(move |(axis, gap, b_size)| {
+                let mut b_min = a_min;
+                b_min[axis] = a_min[axis] + a_size[axis] + gap;
+                BoxPair {
+                    config: "disjoint",
+                    a_min,
+                    a_size,
+                    b_min,
+                    b_size,
+                }
+            });
+        // B exactly face-touching A (gap = 0): the coplanar-classifier
+        // precision boundary the cutter inflation exists for.
+        let touching =
+            (0usize..3, proptest::array::uniform3(0.1f64..5.0)).prop_map(move |(axis, b_size)| {
+                let mut b_min = a_min;
+                b_min[axis] = a_min[axis] + a_size[axis];
+                BoxPair {
+                    config: "touching",
+                    a_min,
+                    a_size,
+                    b_min,
+                    b_size,
+                }
+            });
+        prop_oneof![
+            3 => random,
+            1 => contained,
+            1 => disjoint,
+            1 => touching,
+        ]
+    })
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 64,
+        // Failures (if any) are persisted next to this file; commit the
+        // generated csg_property_test.proptest-regressions.
+        ..ProptestConfig::default()
+    })]
+
+    /// difference(A, B) over axis-aligned box pairs:
+    /// (a) no NaN/Inf vertices,
+    /// (b) vol(A) − vol(B) − ε ≤ vol(A−B) ≤ vol(A) + ε,
+    /// (c) empty when B strictly contains A,
+    /// (d) vol(A−B) == vol(A) when disjoint,
+    /// plus the exact analytic identity vol(A−B) == vol(A) − vol(A∩B)
+    /// and watertightness of the result.
+    #[test]
+    fn box_difference_volume_invariants(pair in arb_box_pair()) {
+        let (a_min, a_size) = quantized(pair.a_min, pair.a_size);
+        let (b_min, b_size) = quantized(pair.b_min, pair.b_size);
+
+        let a = box_mesh(a_min, a_size);
+        let b = box_mesh(b_min, b_size);
+        let vol_a = a_size[0] * a_size[1] * a_size[2];
+        let vol_b = b_size[0] * b_size[1] * b_size[2];
+        let vol_ab = aabb_intersection_volume(a_min, a_size, b_min, b_size);
+
+        let processor = ClippingProcessor::new();
+        let result = processor
+            .subtract_mesh(&a, &b)
+            .expect("subtract_mesh must not error");
+
+        // (a) numeric sanity
+        prop_assert!(all_finite(&result), "result has NaN/Inf positions");
+
+        let vol = mesh_volume(&result);
+        prop_assert!(vol.is_finite(), "result volume is not finite");
+
+        // Tolerance: f32 round-trips of ~10-unit coordinates plus the
+        // deliberate ~10 µm cutter inflation, both scaled by operand
+        // surface areas. 1e-3·(1 + volA + volB) bounds that comfortably
+        // while staying far below any meaningful feature volume.
+        let eps = 1e-3 * (1.0 + vol_a + vol_b);
+
+        // (b) volume bounds
+        prop_assert!(
+            vol <= vol_a + eps,
+            "vol(A-B)={vol} exceeds vol(A)={vol_a} (config {})",
+            pair.config
+        );
+        prop_assert!(
+            vol >= vol_a - vol_b - eps,
+            "vol(A-B)={vol} below vol(A)-vol(B)={} (config {})",
+            vol_a - vol_b,
+            pair.config
+        );
+
+        // Exact analytic identity for AABB pairs (subsumes (c)/(d) but we
+        // keep those as explicit, more legible assertions below).
+        prop_assert!(
+            (vol - (vol_a - vol_ab)).abs() <= eps,
+            "vol(A-B)={vol} != vol(A)-vol(A∩B)={} (config {})",
+            vol_a - vol_ab,
+            pair.config
+        );
+
+        // (c) containment ⇒ empty
+        if pair.config == "b-contains-a" {
+            prop_assert!(
+                result.is_empty() || vol.abs() <= eps,
+                "B contains A but result is non-empty with vol={vol}"
+            );
+        }
+
+        // (d) disjoint ⇒ A unchanged
+        if pair.config == "disjoint" {
+            prop_assert!(
+                (vol - vol_a).abs() <= eps,
+                "disjoint subtraction changed volume: {vol} vs {vol_a}"
+            );
+        }
+
+        // Watertightness. Guaranteed by construction on the Manifold
+        // kernel. The legacy BSP port (`bsp_csg.rs`,
+        // --no-default-features) is not watertight in general (per-node
+        // re-triangulation can leave T-junctions on oblique cuts), but
+        // for axis-aligned box pairs every clip plane is axis-aligned
+        // and the property holds empirically (640+ random cases) — so
+        // keep it asserted on both kernels. If this ever fails under
+        // --no-default-features it is the known server-vs-viewer kernel
+        // drift surfacing; commit the recorded counterexample.
+        prop_assert!(
+            is_watertight(&result),
+            "difference result is not watertight (config {})",
+            pair.config
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Property 2: star-shaped polygon extrusion
+// ---------------------------------------------------------------------------
+
+/// Star-shaped simple polygon around the origin: strictly increasing
+/// angles (built from normalized positive gaps so no two vertices
+/// coincide) with bounded radii. Always simple, always CCW.
+///
+/// The "angle-sorted ⇒ simple CCW polygon" guarantee only holds when the
+/// origin is interior, i.e. every angular gap is < π. With gaps drawn
+/// from 0.1..1.0 a 3-gon could get a normalized gap of up to
+/// 2π/1.2 ≈ 5.2 rad > π, flipping orientation (proptest shrank this to a
+/// CW triangle spanning angles 0.56/5.72/6.28 — a generator bug, not a
+/// kernel bug). Gaps in 0.55..1.0 cap the worst case (n = 3) at
+/// 2π·(1.0/2.1) ≈ 2.99 < π.
+fn arb_star_polygon() -> impl Strategy<Value = Vec<Point2<f64>>> {
+    (3usize..10)
+        .prop_flat_map(|n| {
+            (
+                proptest::collection::vec(0.55f64..1.0, n),
+                proptest::collection::vec(0.3f64..4.0, n),
+            )
+        })
+        .prop_map(|(gaps, radii)| {
+            let total: f64 = gaps.iter().sum();
+            let mut angle = 0.0;
+            gaps.iter()
+                .zip(&radii)
+                .map(|(gap, r)| {
+                    angle += gap / total * TAU;
+                    Point2::new(r * angle.cos(), r * angle.sin())
+                })
+                .collect()
+        })
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 64, ..ProptestConfig::default() })]
+
+    /// extrude_profile over random star-shaped polygons: mesh is
+    /// non-empty, NaN-free, watertight, and its volume equals
+    /// shoelace-area × depth.
+    #[test]
+    fn extrusion_volume_equals_area_times_depth(
+        polygon in arb_star_polygon(),
+        depth in 0.1f64..5.0,
+    ) {
+        let area = shoelace_area(&polygon);
+        prop_assert!(area > 0.0, "generator must produce CCW polygons");
+
+        let profile = Profile2D::new(polygon);
+        let mesh = extrude_profile(&profile, depth, None)
+            .expect("extrusion of a simple CCW polygon must succeed");
+
+        prop_assert!(!mesh.is_empty(), "extrusion produced an empty mesh");
+        prop_assert!(all_finite(&mesh), "extrusion has NaN/Inf positions");
+        prop_assert!(is_watertight(&mesh), "extrusion is not watertight");
+
+        // Caps + side walls are authored in f32; coordinates stay < 4, so
+        // a relative 1e-3 tolerance dwarfs the f32 quantization error.
+        let expected = area * depth;
+        let vol = mesh_volume(&mesh).abs();
+        prop_assert!(
+            (vol - expected).abs() <= 1e-6 + 1e-3 * expected,
+            "extruded volume {vol} != area×depth {expected}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Property 3: 2D boolean rect-pair subtraction
+// ---------------------------------------------------------------------------
+
+fn rect_contour(min: [f64; 2], size: [f64; 2]) -> Vec<Point2<f64>> {
+    vec![
+        Point2::new(min[0], min[1]),
+        Point2::new(min[0] + size[0], min[1]),
+        Point2::new(min[0] + size[0], min[1] + size[1]),
+        Point2::new(min[0], min[1] + size[1]),
+    ]
+}
+
+/// Total area of a profile: |outer| minus the sum of |holes|.
+fn profile_area(p: &Profile2D) -> f64 {
+    let outer = compute_signed_area(&p.outer).abs();
+    let holes: f64 = p.holes.iter().map(|h| compute_signed_area(h).abs()).sum();
+    outer - holes
+}
+
+prop_compose! {
+    /// Rect pair where B is strictly smaller than A in BOTH dimensions.
+    /// This guarantees B can neither contain A nor split A into multiple
+    /// disjoint pieces — `subtract_2d` documents that it keeps only the
+    /// FIRST shape of a multi-shape result, so a splitting cutter would
+    /// test that API truncation, not the boolean kernel.
+    fn arb_rect_pair()(
+        a_min in proptest::array::uniform2(-10.0f64..10.0),
+        a_size in proptest::array::uniform2(1.0f64..10.0),
+        b_scale in proptest::array::uniform2(0.05f64..0.95),
+        // B's center offset relative to A's center, in units of A's size:
+        // covers disjoint (|offset| ≥ ~1), straddling, and fully interior.
+        b_offset in proptest::array::uniform2(-1.5f64..1.5),
+    ) -> (Vec<Point2<f64>>, Vec<Point2<f64>>, f64, f64, f64) {
+        let b_size = [a_size[0] * b_scale[0], a_size[1] * b_scale[1]];
+        let b_min = [
+            a_min[0] + (0.5 + b_offset[0]) * a_size[0] - 0.5 * b_size[0],
+            a_min[1] + (0.5 + b_offset[1]) * a_size[1] - 0.5 * b_size[1],
+        ];
+        let overlap_w = (a_min[0] + a_size[0]).min(b_min[0] + b_size[0])
+            - a_min[0].max(b_min[0]);
+        let overlap_h = (a_min[1] + a_size[1]).min(b_min[1] + b_size[1])
+            - a_min[1].max(b_min[1]);
+        let overlap = overlap_w.max(0.0) * overlap_h.max(0.0);
+        (
+            rect_contour(a_min, a_size),
+            rect_contour(b_min, b_size),
+            a_size[0] * a_size[1],
+            b_size[0] * b_size[1],
+            overlap,
+        )
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 48, ..ProptestConfig::default() })]
+
+    /// subtract_2d over random rect pairs (B smaller than A in both
+    /// dimensions): area(A) − area(B) − ε ≤ area(A−B) ≤ area(A) + ε,
+    /// exact analytic identity area(A−B) == area(A) − overlap, and no
+    /// self-intersecting output contours.
+    #[test]
+    fn rect_subtraction_area_invariants(
+        (a, b, area_a, area_b, overlap) in arb_rect_pair(),
+    ) {
+        let profile = Profile2D::new(a);
+        let result = subtract_2d(&profile, &b)
+            .expect("rect-rect subtract_2d must succeed");
+
+        let area = profile_area(&result);
+        // i_overlay runs an exact integer overlay on an adaptive grid;
+        // observed error is far below 1e-6 relative at these magnitudes.
+        let eps = 1e-6 * (1.0 + area_a);
+
+        prop_assert!(area <= area_a + eps, "area(A-B)={area} > area(A)={area_a}");
+        prop_assert!(
+            area >= area_a - area_b - eps,
+            "area(A-B)={area} < area(A)-area(B)={}",
+            area_a - area_b
+        );
+        prop_assert!(
+            (area - (area_a - overlap)).abs() <= eps,
+            "area(A-B)={area} != area(A)-overlap={}",
+            area_a - overlap
+        );
+
+        prop_assert!(
+            !closed_loop_self_intersects(&result.outer),
+            "output outer contour self-intersects"
+        );
+        for hole in &result.holes {
+            prop_assert!(
+                !closed_loop_self_intersects(hole),
+                "output hole contour self-intersects"
+            );
+        }
+    }
+}

--- a/rust/geometry/tests/csg_property_test.rs
+++ b/rust/geometry/tests/csg_property_test.rs
@@ -113,27 +113,91 @@ fn all_finite(mesh: &Mesh) -> bool {
     mesh.positions.iter().all(|v| v.is_finite())
 }
 
-/// Watertightness: after welding by position, every directed edge must be
-/// matched by exactly one opposite directed edge (each undirected edge is
-/// shared by exactly two triangles with consistent winding). Empty meshes
-/// count as watertight (the empty shell is closed).
-fn is_watertight(mesh: &Mesh) -> bool {
+/// Watertightness: after welding by position, every undirected edge must be
+/// used by exactly two triangles, once in each direction (manifold edge with
+/// consistent winding). Counting *totals* per direction — not just the signed
+/// difference — also rejects non-manifold edges with 2+2 opposite incidences
+/// and duplicated closed shells, which a pure cancellation check would pass.
+/// Empty meshes count as watertight (the empty shell is closed).
+///
+/// Returns `None` when watertight, otherwise a description of the first
+/// violating edge (endpoint indices/positions and the directed-use split).
+fn watertight_violation(mesh: &Mesh) -> Option<String> {
     if mesh.is_empty() {
-        return true;
+        return None;
     }
     let welded = mesh.welded_by_position(1e-6);
-    let mut edges: HashMap<(u32, u32), i64> = HashMap::new();
+    // (min,max) vertex pair -> (uses as (min..max), uses as (max..min)).
+    let mut edges: HashMap<(u32, u32), (u32, u32)> = HashMap::new();
     for tri in welded.indices.chunks_exact(3) {
         for k in 0..3 {
             let a = tri[k];
             let b = tri[(k + 1) % 3];
-            // +1 for the edge in (min,max) orientation, -1 for the reverse:
-            // a closed, consistently wound surface nets to 0 on every edge.
-            let key = (a.min(b), a.max(b));
-            *edges.entry(key).or_insert(0) += if a < b { 1 } else { -1 };
+            if a == b {
+                return Some(format!(
+                    "degenerate edge ({a}, {b}): triangle repeats a welded vertex"
+                ));
+            }
+            let entry = edges.entry((a.min(b), a.max(b))).or_insert((0, 0));
+            if a < b {
+                entry.0 += 1;
+            } else {
+                entry.1 += 1;
+            }
         }
     }
-    edges.values().all(|&count| count == 0)
+    edges
+        .iter()
+        .find(|(_, &(fwd, rev))| (fwd, rev) != (1, 1))
+        .map(|(&(a, b), &(fwd, rev))| {
+            let p = |i: u32| {
+                let base = i as usize * 3;
+                &welded.positions[base..base + 3]
+            };
+            format!(
+                "edge ({a}, {b}) [{:?} -> {:?}] has {} directed uses \
+                 ({fwd} forward, {rev} reverse); expected exactly one in each direction",
+                p(a),
+                p(b),
+                fwd + rev
+            )
+        })
+}
+
+/// Guard the checker itself: a signed-cancellation-only check would pass a
+/// duplicated closed shell (every edge gets 2 forward + 2 reverse uses, net
+/// 0) and an open mesh with a flipped patch. The total-incidence check must
+/// reject both while accepting a plain closed box.
+#[test]
+fn watertight_checker_rejects_non_manifold_and_open_meshes() {
+    let unit = [0.0, 0.0, 0.0];
+    let size = [1.0, 1.0, 1.0];
+
+    // Closed box: watertight.
+    let mesh = box_mesh(unit, size);
+    assert_eq!(watertight_violation(&mesh), None);
+
+    // Duplicated shell: signed counts still cancel, but every edge has
+    // 4 total uses (2 forward, 2 reverse) — must be rejected.
+    let mut doubled = box_mesh(unit, size);
+    let tris = doubled.indices.clone();
+    for tri in tris.chunks_exact(3) {
+        doubled.add_triangle(tri[0], tri[1], tri[2]);
+    }
+    let violation = watertight_violation(&doubled).expect("duplicated shell must be rejected");
+    assert!(
+        violation.contains("4 directed uses (2 forward, 2 reverse)"),
+        "unexpected message: {violation}"
+    );
+
+    // Open mesh (one triangle removed): boundary edges have one use.
+    let mut open = box_mesh(unit, size);
+    open.indices.truncate(open.indices.len() - 3);
+    let violation = watertight_violation(&open).expect("open mesh must be rejected");
+    assert!(
+        violation.contains("expected exactly one in each direction"),
+        "unexpected message: {violation}"
+    );
 }
 
 /// Shoelace area of a simple polygon (positive for CCW input).
@@ -395,10 +459,12 @@ proptest! {
         // keep it asserted on both kernels. If this ever fails under
         // --no-default-features it is the known server-vs-viewer kernel
         // drift surfacing; commit the recorded counterexample.
+        let violation = watertight_violation(&result);
         prop_assert!(
-            is_watertight(&result),
-            "difference result is not watertight (config {})",
-            pair.config
+            violation.is_none(),
+            "difference result is not watertight (config {}): {}",
+            pair.config,
+            violation.as_deref().unwrap_or("")
         );
     }
 }
@@ -459,7 +525,12 @@ proptest! {
 
         prop_assert!(!mesh.is_empty(), "extrusion produced an empty mesh");
         prop_assert!(all_finite(&mesh), "extrusion has NaN/Inf positions");
-        prop_assert!(is_watertight(&mesh), "extrusion is not watertight");
+        let violation = watertight_violation(&mesh);
+        prop_assert!(
+            violation.is_none(),
+            "extrusion is not watertight: {}",
+            violation.as_deref().unwrap_or("")
+        );
 
         // Caps + side walls are authored in f32; coordinates stay < 4, so
         // a relative 1e-3 tolerance dwarfs the f32 quantization error.


### PR DESCRIPTION
## Summary

The geometry test suite was entirely example-based (fixture/regression tests); kernel invariants were unverified across the input space. This adds `proptest` as a dev-dependency of `ifc-lite-geometry` and a new `tests/csg_property_test.rs` with three property groups over bounded random inputs:

### 1. Box-pair boolean difference (64 cases)
Via `ClippingProcessor::subtract_mesh` — the public entry that dispatches to the **Manifold** kernel under the default `manifold-csg` feature and to the legacy **BSP** port under `--no-default-features`. Generation covers random, B-contains-A, disjoint, and exactly face-touching configurations (the coplanar-classifier precision boundary the ~10 µm cutter inflation exists for). Asserts:
- no NaN/Inf vertices
- `vol(A) − vol(B) − ε ≤ vol(A−B) ≤ vol(A) + ε`
- exact analytic identity `vol(A−B) == vol(A) − vol(A∩B)` for AABB pairs
- empty result when B strictly contains A; `vol == vol(A)` when disjoint
- watertight output (directed-edge pairing after position weld)

### 2. Star-shaped polygon extrusion (64 cases)
`extrude_profile` over angle-sorted star polygons: non-empty, NaN-free, watertight, and `volume == shoelace-area × depth`.

### 3. 2D boolean rect-pair subtraction (48 cases)
`bool2d::subtract_2d`: `area(A) − area(B) − ε ≤ area(A−B) ≤ area(A) + ε`, exact `area(A) − overlap` identity, and no self-intersecting output contours (reimplements the private `profiles::closed_loop_self_intersects` proper-crossing scan). B is constrained smaller than A in both dimensions because `subtract_2d` documents keeping only the *first* shape of a multi-shape result — a splitting cutter would test that API truncation, not the boolean kernel.

## Tolerances
Analytic expectations are computed from **f32-quantized** inputs (`Mesh` stores f32 positions), so the epsilons only absorb the deliberate ~10 µm cutter inflation (`mesh_to_manifold_perturbed`) and kernel rounding: `1e-3·(1 + volA + volB)` for 3D, `1e-6` relative for the f64 i_overlay 2D path.

## Verification
- `cargo test -p ifc-lite-geometry --test csg_property_test`: green in ~0.03 s (Manifold)
- `--no-default-features` (BSP): green in ~0.04 s
- 24+ repeated seeded runs per kernel (proptest reseeds each run), plus a 512-case run — no surviving counterexamples, so there is no `proptest-regressions` file to commit
- Mutation check: corrupting the volume upper bound makes the property fail and shrink to a minimal box pair, confirming the assertions have teeth

## Findings
- **No kernel drift surfaced for this input class**: the BSP path passes all volume properties *and* (empirically, 640+ ungated cases) watertightness on axis-aligned box pairs, since every clip plane is axis-aligned. The watertight assertion is therefore kept active on both kernels, with a comment that a future `--no-default-features` failure is the known server-vs-viewer drift surfacing and the recorded counterexample should be committed.
- **One generator bug caught by shrinking during development** (fixed in this PR, not a kernel bug): angular gaps drawn from 0.1..1.0 allowed a 3-gon gap > π, which puts the origin outside the polygon and flips the "angle-sorted ⇒ CCW" guarantee (shrunk to a CW triangle spanning angles 0.56/5.72/6.28). Gaps are now drawn from 0.55..1.0, capping the worst-case gap at ~2.99 < π.