### PR TITLE
chore: sync api-surface snapshot with TessellationQuality export

### DIFF
--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -1580,6 +1580,7 @@
     "SymbolicPolyline: class (type-only)",
     "SymbolicRepIdentifier: type",
     "SymbolicRepresentationCollection: class (type-only)",
+    "TessellationQuality: type",
     "Vec3: interface",
     "WatchdogInputs: interface",
     "WorkerCountInputs: interface",


### PR DESCRIPTION
#1043 added the `TessellationQuality` type export to `@ifc-lite/geometry` but the API-surface snapshot wasn't regenerated, so the guard now fails on the release PR (#1050). Adds the one missing entry; the export already ships with a changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)