### PR TITLE
fix(ids): make IDS validation usable on large models — cache accessor lookups, bound report strings, fix CLI exit hang

### DIFF
--- a/.changeset/ids-validation-scale.md
+++ b/.changeset/ids-validation-scale.md
@@ -30,5 +30,12 @@ after printing its results. Four root fixes:
   `undefined (undefined/undefined)`), and skips retaining passing entity
   results for human-readable output (`--json` is unchanged).
 
+Behavior change (intentional): the CLI's PASS/FAIL verdict and exit code
+now come from the validator's per-spec status, which counts
+cardinality-only failures — a `minOccurs="1"` specification that matches
+zero entities now correctly FAILs (exit 1) where it previously passed
+silently. `bim.ids.summarize` likewise prefers the per-spec status when
+the report carries one, so `--json` and text mode agree on the verdict.
+
 Measured on the same model + IDS pack: 848 specs 19min→2min, 117 specs
 3.4min→12s, both with a clean exit instead of a hang.

--- a/.changeset/ids-validation-scale.md
+++ b/.changeset/ids-validation-scale.md
@@ -1,0 +1,34 @@
+---
+"@ifc-lite/parser": patch
+"@ifc-lite/ids": patch
+"@ifc-lite/sdk": patch
+"@ifc-lite/cli": patch
+---
+
+fix(ids): make IDS validation usable on large models with code-list IDS packs.
+
+Validating a 550k-entity model against an 848-spec IDS document took ~19
+minutes of CPU, produced multi-GB reports, and the CLI then hung forever
+after printing its results. Four root fixes:
+
+- parser: `yieldToEventLoop` leaked one open `MessageChannel` per yield;
+  in Node an open `MessagePort` holds a libuv handle, so every CLI command
+  on a large file kept the process alive after completion. Ports now close
+  (helper consolidated into one shared module).
+- ids: `validateIDS` wraps the accessor in a per-run memoizing cache so
+  property sets / types / attributes are extracted once per entity instead
+  of once per entity *per specification* (O(specs×entities) source
+  re-parses → O(entities)). Enumeration constraints additionally compile
+  into exact-match sets (real-world code lists carry 800+ values).
+- ids: per-entity result strings are now bounded — enumeration constraints
+  render at most 10 values in failure messages, and the entity-independent
+  requirement description is formatted once per requirement instead of per
+  entity result (reports for failing models dropped from GBs to MBs).
+- cli: `ifc-lite ids` now uses the canonical `@ifc-lite/ids/bridge`
+  accessor (the drifted local copy missed type-inherited property sets),
+  reports real progress (`spec 312/848 (37%)` instead of
+  `undefined (undefined/undefined)`), and skips retaining passing entity
+  results for human-readable output (`--json` is unchanged).
+
+Measured on the same model + IDS pack: 848 specs 19min→2min, 117 specs
+3.4min→12s, both with a clean exit instead of a hang.

--- a/apps/viewer/src/hooks/useIDS.ts
+++ b/apps/viewer/src/hooks/useIDS.ts
@@ -397,10 +397,21 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
         entityCount: dataStore.entityCount || accessor.getAllEntityIds().length,
       };
 
-      // Run validation
+      // Run validation. Progress events arrive far faster than React
+      // should re-render (per 100 entities / per spec) — each store
+      // update re-renders every IDS subscriber, which both slowed the
+      // run and dropped the frame rate. Throttle to ~8 updates/s and
+      // always pass the terminal event.
+      let lastProgressUpdate = 0;
       const validationReport = await validateIDS(document, accessor, modelInfo, {
         translator,
-        onProgress: setIdsProgress,
+        onProgress: (p) => {
+          const now = performance.now();
+          if (p.phase === 'complete' || now - lastProgressUpdate >= 120) {
+            lastProgressUpdate = now;
+            setIdsProgress(p);
+          }
+        },
         includePassingEntities: true,
       });
 

--- a/packages/cli/src/commands/ids.ts
+++ b/packages/cli/src/commands/ids.ts
@@ -9,17 +9,19 @@
  */
 
 import { readFile } from 'node:fs/promises';
-import { createHeadlessContext, loadIfcFile } from '../loader.js';
-import { printJson, formatTable, hasFlag, getFlag, fatal } from '../output.js';
-import type { IfcDataStore } from '@ifc-lite/parser';
-import { EntityNode } from '@ifc-lite/query';
-import {
-  extractClassificationsOnDemand,
-  extractMaterialsOnDemand,
-  extractAllEntityAttributes,
-  extractTypeEntityOwnProperties,
-} from '@ifc-lite/parser';
-import { RelationshipType } from '@ifc-lite/data';
+import { createHeadlessContext } from '../loader.js';
+import { printJson, hasFlag, getFlag, fatal } from '../output.js';
+import { createDataAccessor } from '@ifc-lite/ids/bridge';
+
+interface ValidatorSummary {
+  totalSpecifications: number;
+  passedSpecifications: number;
+  failedSpecifications: number;
+  totalEntitiesChecked: number;
+  totalEntitiesPassed: number;
+  totalEntitiesFailed: number;
+  overallPassRate: number;
+}
 
 export async function idsCommand(args: string[]): Promise<void> {
   const positional = args.filter(a => !a.startsWith('-'));
@@ -37,206 +39,48 @@ export async function idsCommand(args: string[]): Promise<void> {
   // Parse and validate
   const idsDoc = await bim.ids.parse(idsContent);
 
-  // Build accessor for validation
-  const accessor = buildIdsAccessor(store);
+  // The shared bridge accessor is the canonical IfcDataStore →
+  // IFCDataAccessor projection (same one the viewer and MCP server use).
+  const accessor = createDataAccessor(store);
 
-  const report = await bim.ids.validate(idsDoc, {
+  const report = (await bim.ids.validate(idsDoc, {
     accessor,
     modelInfo: { schemaVersion: store.schemaVersion },
     locale,
+    // For human-readable output only the failures matter; dropping
+    // passing entity results keeps the report bounded on large models.
+    includePassingEntities: jsonOutput,
     onProgress: (p) => {
-      if (!jsonOutput) {
-        process.stderr.write(`\r  Validating: ${p.specName} (${p.current}/${p.total})`);
+      if (!jsonOutput && p.phase !== 'complete') {
+        const spec = Math.min(p.specificationIndex + 1, p.totalSpecifications);
+        process.stderr.write(`\r  Validating: spec ${spec}/${p.totalSpecifications} (${p.percentage}%)`);
       }
     },
-  });
+  })) as {
+    summary: ValidatorSummary;
+    specificationResults: Array<{ entityResults: Array<{ passed: boolean }> }>;
+  };
 
   if (!jsonOutput) process.stderr.write('\n');
 
-  const summary = bim.ids.summarize(report as { specificationResults: Array<{ entityResults: Array<{ passed: boolean }> }> });
-
   if (jsonOutput) {
+    // Keep the established machine-readable summary shape.
+    const summary = bim.ids.summarize(report);
     printJson({ summary, report });
     return;
   }
 
+  // The validator computes its summary from full per-spec counts, so it
+  // stays correct even though passing entity results are not retained.
+  const summary = report.summary;
+
   process.stdout.write(`\n  IDS Validation Results\n`);
   process.stdout.write(`  ─────────────────────\n`);
   process.stdout.write(`  Specifications: ${summary.passedSpecifications}/${summary.totalSpecifications} passed\n`);
-  process.stdout.write(`  Entities:       ${summary.passedEntities}/${summary.totalEntities} passed\n`);
-  process.stdout.write(`  Failed:         ${summary.failedEntities} entities in ${summary.failedSpecifications} specs\n`);
+  process.stdout.write(`  Entities:       ${summary.totalEntitiesPassed}/${summary.totalEntitiesChecked} passed\n`);
+  process.stdout.write(`  Failed:         ${summary.totalEntitiesFailed} entities in ${summary.failedSpecifications} specs\n`);
 
   const exitCode = summary.failedSpecifications > 0 ? 1 : 0;
   process.stdout.write(`\n  Result: ${exitCode === 0 ? 'PASS' : 'FAIL'}\n\n`);
   process.exitCode = exitCode;
-}
-
-const REL_TYPE_MAP: Record<string, RelationshipType> = {
-  IfcRelAggregates: RelationshipType.Aggregates,
-  IfcRelContainedInSpatialStructure: RelationshipType.ContainsElements,
-  IfcRelNests: RelationshipType.Aggregates, // closest mapping
-  IfcRelVoidsElement: RelationshipType.VoidsElement,
-  IfcRelFillsElement: RelationshipType.FillsElement,
-};
-
-/**
- * Build a complete IFCDataAccessor for the IDS validator.
- * Implements all 12+ methods the validator expects.
- */
-function buildIdsAccessor(store: IfcDataStore): unknown {
-  return {
-    getEntityType(expressId: number): string | undefined {
-      return store.entities.getTypeName(expressId) || undefined;
-    },
-    getEntityName(expressId: number): string | undefined {
-      const node = new EntityNode(store, expressId);
-      return node.name || undefined;
-    },
-    getGlobalId(expressId: number): string | undefined {
-      const node = new EntityNode(store, expressId);
-      return node.globalId || undefined;
-    },
-    getDescription(expressId: number): string | undefined {
-      const node = new EntityNode(store, expressId);
-      return node.description || undefined;
-    },
-    getObjectType(expressId: number): string | undefined {
-      // Try EntityNode's objectType first (works for IfcObject subtypes)
-      const node = new EntityNode(store, expressId);
-      if (node.objectType) return node.objectType;
-
-      // For IfcTypeObject subtypes (IfcWallType, etc.), extract PredefinedType
-      // from entity attributes since they don't have ObjectType.
-      const allAttrs = extractAllEntityAttributes(store, expressId);
-      const predefinedType = allAttrs.find(a => a.name === 'PredefinedType');
-      if (predefinedType?.value && predefinedType.value !== 'NOTDEFINED') {
-        return typeof predefinedType.value === 'string' ? predefinedType.value : String(predefinedType.value);
-      }
-
-      // If PredefinedType is USERDEFINED/absent, check ObjectType from full attributes
-      const objTypeAttr = allAttrs.find(a => a.name === 'ObjectType');
-      if (objTypeAttr?.value) {
-        return typeof objTypeAttr.value === 'string' ? objTypeAttr.value : String(objTypeAttr.value);
-      }
-
-      return undefined;
-    },
-    getEntitiesByType(typeName: string): number[] {
-      const upper = typeName.toUpperCase();
-      return [...(store.entityIndex.byType.get(upper) ?? [])];
-    },
-    getAllEntityIds(): number[] {
-      const ids: number[] = [];
-      for (const [, typeIds] of store.entityIndex.byType) {
-        for (const id of typeIds) ids.push(id);
-      }
-      return ids;
-    },
-    getPropertyValue(expressId: number, propertySetName: string, propertyName: string) {
-      const node = new EntityNode(store, expressId);
-      const psets = node.properties();
-      for (const pset of psets) {
-        if (pset.name === propertySetName) {
-          for (const prop of pset.properties) {
-            if (prop.name === propertyName) {
-              return {
-                value: prop.value ?? null,
-                dataType: prop.type ?? 'IFCLABEL',
-                propertySetName: pset.name,
-                propertyName: prop.name,
-              };
-            }
-          }
-        }
-      }
-      return undefined;
-    },
-    getPropertySets(expressId: number) {
-      // Try EntityNode first (relationship-based properties for IfcObject instances)
-      const node = new EntityNode(store, expressId);
-      const psets = node.properties();
-
-      const mapPsets = (rawPsets: Array<{ name: string; properties: Array<{ name: string; type: unknown; value: unknown }> }>) =>
-        rawPsets.map(pset => ({
-          name: pset.name,
-          properties: pset.properties.map(p => ({
-            name: p.name,
-            value: p.value ?? null,
-            dataType: p.type ?? 'IFCLABEL',
-          })),
-        }));
-
-      if (psets.length > 0) {
-        return mapPsets(psets);
-      }
-
-      // For IfcTypeObject subtypes, extract from HasPropertySets attribute
-      const typePsets = extractTypeEntityOwnProperties(store, expressId);
-      if (typePsets.length > 0) {
-        return mapPsets(typePsets);
-      }
-
-      return [];
-    },
-    getClassifications(expressId: number) {
-      const classifications = extractClassificationsOnDemand(store, expressId);
-      return classifications.map(c => ({
-        system: c.system ?? '',
-        value: c.identification ?? '',
-        name: c.name ?? undefined,
-      }));
-    },
-    getMaterials(expressId: number) {
-      const materialData = extractMaterialsOnDemand(store, expressId);
-      if (!materialData) return [];
-      const materials: Array<{ name: string; category?: string }> = [];
-      if (materialData.name) {
-        materials.push({ name: materialData.name });
-      }
-      if (materialData.layers) {
-        for (const layer of materialData.layers) {
-          if (layer.materialName) {
-            materials.push({ name: layer.materialName, category: layer.category ?? undefined });
-          }
-        }
-      }
-      return materials;
-    },
-    getParent(expressId: number, relationType: string) {
-      const relEnum = REL_TYPE_MAP[relationType];
-      if (relEnum === undefined) return undefined;
-      const parents = store.relationships.getRelated(expressId, relEnum, 'inverse');
-      if (parents.length === 0) return undefined;
-      const parentId = parents[0];
-      const parentType = store.entities.getTypeName(parentId);
-      // Extract predefinedType from parent entity attributes
-      const parentAttrs = extractAllEntityAttributes(store, parentId);
-      const parentPredefined = parentAttrs.find(a => a.name === 'PredefinedType');
-      const predefinedType = parentPredefined?.value && parentPredefined.value !== 'NOTDEFINED'
-        ? parentPredefined.value
-        : undefined;
-
-      return {
-        expressId: parentId,
-        entityType: parentType ?? '',
-        predefinedType,
-      };
-    },
-    getAttribute(expressId: number, attributeName: string): string | undefined {
-      const node = new EntityNode(store, expressId);
-      switch (attributeName) {
-        case 'Name': return node.name || undefined;
-        case 'Description': return node.description || undefined;
-        case 'ObjectType': return node.objectType || undefined;
-        case 'GlobalId': return node.globalId || undefined;
-        case 'Tag': return node.tag || undefined;
-        default: {
-          // Fall back to full attribute extraction
-          const attrs = extractAllEntityAttributes(store, expressId);
-          const attr = attrs.find(a => a.name === attributeName);
-          return attr?.value != null ? String(attr.value) : undefined;
-        }
-      }
-    },
-  };
 }

--- a/packages/ids/src/constraints/comparators.ts
+++ b/packages/ids/src/constraints/comparators.ts
@@ -19,6 +19,21 @@
 const NUMERIC_RE = /^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/;
 
 /**
+ * Whether an IDS literal could ever match through `compareNumeric` —
+ * i.e. it is a strict numeric literal. Lets constraint matchers decide
+ * ONCE per constraint instead of running the regex inside per-entity
+ * hot loops.
+ */
+export function isStrictNumericLiteral(value: string): boolean {
+  return NUMERIC_RE.test(value);
+}
+
+/** Whether an IDS literal could ever match through `compareBoolean`. */
+export function isBooleanLiteral(value: string): boolean {
+  return value === 'true' || value === 'false';
+}
+
+/**
  * Numeric tolerance for floating-point comparisons.
  *
  * Mirrors upstream IfcOpenShell `ifctester`'s `is_x` rules: anchored

--- a/packages/ids/src/constraints/index.ts
+++ b/packages/ids/src/constraints/index.ts
@@ -19,6 +19,8 @@ import {
   compareNumeric,
   compareString,
   numericEpsilon,
+  isStrictNumericLiteral,
+  isBooleanLiteral,
 } from './comparators.js';
 
 /** Tolerance for the bounds matcher's exclusive comparators. */
@@ -64,6 +66,27 @@ export function matchConstraint(
 }
 
 /**
+ * Per-constraint comparator applicability. `compareNumeric` runs two
+ * regex tests and `compareBoolean` two equality checks per call — and
+ * simple-value matching sits inside per-entity × per-specification hot
+ * loops (name matching against every pset/property). Whether the IDS
+ * literal could EVER match numerically or boolean-ly depends only on
+ * the constraint, so decide it once.
+ */
+const SIMPLE_VALUE_COERCIBLE = new WeakMap<IDSSimpleValue, boolean>();
+
+function isCoercibleSimpleValue(constraint: IDSSimpleValue): boolean {
+  let coercible = SIMPLE_VALUE_COERCIBLE.get(constraint);
+  if (coercible === undefined) {
+    coercible =
+      isStrictNumericLiteral(constraint.value) ||
+      isBooleanLiteral(constraint.value);
+    SIMPLE_VALUE_COERCIBLE.set(constraint, coercible);
+  }
+  return coercible;
+}
+
+/**
  * Match against a simple value. Tries each comparator in order:
  * string → numeric → boolean. The first decisive result wins;
  * `undefined` lets the next strategy run.
@@ -76,6 +99,9 @@ function matchSimpleValue(
   const expected = constraint.value;
   const stringResult = compareString(expected, actualValue, caseInsensitive);
   if (stringResult !== undefined) return stringResult;
+  // A non-numeric, non-boolean literal can only match through string
+  // equality — skip the comparators that would return undefined anyway.
+  if (!isCoercibleSimpleValue(constraint)) return false;
   const numericResult = compareNumeric(expected, actualValue);
   if (numericResult !== undefined) return numericResult;
   const booleanResult = compareBoolean(expected, actualValue);
@@ -142,19 +168,24 @@ function xsdToJsRegex(xsdPattern: string): string {
  */
 const ENUM_VALUE_SETS = new WeakMap<
   IDSEnumerationConstraint,
-  { exact: Set<string>; upper: Set<string> }
+  { exact: Set<string>; upper: Set<string>; anyCoercible: boolean }
 >();
 
 function getEnumValueSets(constraint: IDSEnumerationConstraint): {
   exact: Set<string>;
   upper: Set<string>;
+  anyCoercible: boolean;
 } {
   let sets = ENUM_VALUE_SETS.get(constraint);
   if (!sets) {
     const exact = new Set(constraint.values);
     const upper = new Set<string>();
-    for (const v of constraint.values) upper.add(v.toUpperCase());
-    sets = { exact, upper };
+    let anyCoercible = false;
+    for (const v of constraint.values) {
+      upper.add(v.toUpperCase());
+      if (isStrictNumericLiteral(v) || isBooleanLiteral(v)) anyCoercible = true;
+    }
+    sets = { exact, upper, anyCoercible };
     ENUM_VALUE_SETS.set(constraint, sets);
   }
   return sets;
@@ -178,6 +209,9 @@ function matchEnumeration(
   const actualStr = String(actualValue);
   if (sets.exact.has(actualStr)) return true;
   if (caseInsensitive && sets.upper.has(actualStr.toUpperCase())) return true;
+  // Pure-string enumerations are fully decided by the set lookups —
+  // only numeric/boolean literals can still match in the slow walk.
+  if (!sets.anyCoercible) return false;
 
   return constraint.values.some((v) => {
     const stringResult = compareString(v, actualValue, caseInsensitive);
@@ -344,9 +378,26 @@ function getBoundsMismatchReason(
 }
 
 /**
+ * Per-constraint display-string cache. Failure paths format the same
+ * constraint for every non-matching entity — millions of times during
+ * applicability filtering — and the output depends only on the
+ * constraint object.
+ */
+const FORMAT_CACHE = new WeakMap<IDSConstraint, string>();
+
+/**
  * Format a constraint for display
  */
 export function formatConstraint(constraint: IDSConstraint): string {
+  let formatted = FORMAT_CACHE.get(constraint);
+  if (formatted === undefined) {
+    formatted = formatConstraintUncached(constraint);
+    FORMAT_CACHE.set(constraint, formatted);
+  }
+  return formatted;
+}
+
+function formatConstraintUncached(constraint: IDSConstraint): string {
   switch (constraint.type) {
     case 'simpleValue':
       return `"${constraint.value}"`;

--- a/packages/ids/src/constraints/index.ts
+++ b/packages/ids/src/constraints/index.ts
@@ -134,6 +134,33 @@ function xsdToJsRegex(xsdPattern: string): string {
 }
 
 /**
+ * Compiled exact-match sets per enumeration constraint. Real-world IDS
+ * code lists carry hundreds of values and are matched against every
+ * candidate entity, so the linear comparator walk dominated validation
+ * time. Constraint objects are stable per parsed document, making a
+ * WeakMap cache safe.
+ */
+const ENUM_VALUE_SETS = new WeakMap<
+  IDSEnumerationConstraint,
+  { exact: Set<string>; upper: Set<string> }
+>();
+
+function getEnumValueSets(constraint: IDSEnumerationConstraint): {
+  exact: Set<string>;
+  upper: Set<string>;
+} {
+  let sets = ENUM_VALUE_SETS.get(constraint);
+  if (!sets) {
+    const exact = new Set(constraint.values);
+    const upper = new Set<string>();
+    for (const v of constraint.values) upper.add(v.toUpperCase());
+    sets = { exact, upper };
+    ENUM_VALUE_SETS.set(constraint, sets);
+  }
+  return sets;
+}
+
+/**
  * Match against an enumeration. The actual value matches if ANY of the
  * declared options matches under string / numeric / boolean comparison
  * — same strategy table as `matchSimpleValue`, just iterated.
@@ -143,6 +170,15 @@ function matchEnumeration(
   actualValue: string | number | boolean,
   caseInsensitive: boolean
 ): boolean {
+  // O(1) fast path: a set hit is exactly the condition under which
+  // `compareString` would have returned true for some value, so this
+  // never changes the outcome — misses fall through to the full
+  // comparator walk for numeric / boolean semantics.
+  const sets = getEnumValueSets(constraint);
+  const actualStr = String(actualValue);
+  if (sets.exact.has(actualStr)) return true;
+  if (caseInsensitive && sets.upper.has(actualStr.toUpperCase())) return true;
+
   return constraint.values.some((v) => {
     const stringResult = compareString(v, actualValue, caseInsensitive);
     if (stringResult !== undefined) return stringResult;
@@ -225,6 +261,24 @@ function matchBounds(
 }
 
 /**
+ * Cap enumeration rendering. These strings are embedded in per-entity
+ * validation results — an uncapped 800-value code list produced ~20KB
+ * per result and ballooned reports into the gigabytes (OOM crash on
+ * large models). The full value list stays available on the constraint
+ * object itself.
+ */
+const MAX_ENUM_DISPLAY_VALUES = 10;
+
+function formatEnumValues(values: string[]): string {
+  const shown = values
+    .slice(0, MAX_ENUM_DISPLAY_VALUES)
+    .map((v) => `"${v}"`)
+    .join(', ');
+  const more = values.length - MAX_ENUM_DISPLAY_VALUES;
+  return more > 0 ? `[${shown}, … +${more} more]` : `[${shown}]`;
+}
+
+/**
  * Get a human-readable description of why a constraint match failed
  */
 export function getConstraintMismatchReason(
@@ -241,7 +295,7 @@ export function getConstraintMismatchReason(
     case 'pattern':
       return `"${actualValue}" does not match pattern "${constraint.pattern}"`;
     case 'enumeration':
-      return `"${actualValue}" is not one of [${constraint.values.map((v) => `"${v}"`).join(', ')}]`;
+      return `"${actualValue}" is not one of ${formatEnumValues(constraint.values)}`;
     case 'bounds':
       return getBoundsMismatchReason(constraint, actualValue);
     default:
@@ -302,7 +356,7 @@ export function formatConstraint(constraint: IDSConstraint): string {
       if (constraint.values.length === 1) {
         return `"${constraint.values[0]}"`;
       }
-      return `one of [${constraint.values.map((v) => `"${v}"`).join(', ')}]`;
+      return `one of ${formatEnumValues(constraint.values)}`;
     case 'bounds':
       return formatBounds(constraint);
     default:

--- a/packages/ids/src/facets/property-facet.ts
+++ b/packages/ids/src/facets/property-facet.ts
@@ -19,6 +19,44 @@ import { ifcMeasureToXsdTypes, literalCastsUnderAnyType } from '../constraints/x
 const DATATYPE_OPTS: MatchOptions = { caseInsensitive: true };
 
 /**
+ * Failure-detail string caches. During applicability filtering every
+ * non-matching entity takes a failure path, and these name lists were
+ * re-joined per specification — millions of identical joins per run.
+ * The validator's cached accessor returns stable array instances per
+ * entity, so a WeakMap keyed on them holds exactly one string each.
+ */
+const PSET_NAMES_CACHE = new WeakMap<PropertySetInfo[], string>();
+const PROP_NAMES_CACHE = new WeakMap<PropertySetInfo, string>();
+const QUALIFIED_PROP_NAMES_CACHE = new WeakMap<PropertySetInfo, string>();
+
+function availablePsetNames(propertySets: PropertySetInfo[]): string {
+  let names = PSET_NAMES_CACHE.get(propertySets);
+  if (names === undefined) {
+    names = propertySets.map((p) => p.name).join(', ');
+    PSET_NAMES_CACHE.set(propertySets, names);
+  }
+  return names;
+}
+
+function availablePropertyNames(pset: PropertySetInfo): string {
+  let names = PROP_NAMES_CACHE.get(pset);
+  if (names === undefined) {
+    names = pset.properties.map((p) => p.name).join(', ');
+    PROP_NAMES_CACHE.set(pset, names);
+  }
+  return names;
+}
+
+function qualifiedPropertyNames(pset: PropertySetInfo): string {
+  let names = QUALIFIED_PROP_NAMES_CACHE.get(pset);
+  if (names === undefined) {
+    names = pset.properties.map((p) => `${pset.name}.${p.name}`).join(', ');
+    QUALIFIED_PROP_NAMES_CACHE.set(pset, names);
+  }
+  return names;
+}
+
+/**
  * Check if an entity matches a property facet
  */
 export function checkPropertyFacet(
@@ -47,7 +85,7 @@ export function checkPropertyFacet(
   );
 
   if (matchingPsets.length === 0) {
-    const availablePsets = propertySets.map((p) => p.name).join(', ');
+    const availablePsets = availablePsetNames(propertySets);
     return {
       passed: false,
       actualValue: availablePsets || '(none)',
@@ -107,7 +145,7 @@ export function checkPropertyFacet(
   // Property not found in any matching pset
   const psetNames = matchingPsets.map((p) => p.name).join(', ');
   const availableProps = matchingPsets
-    .flatMap((pset) => pset.properties.map((p) => `${pset.name}.${p.name}`))
+    .map((pset) => qualifiedPropertyNames(pset))
     .join(', ');
 
   return {
@@ -149,7 +187,7 @@ function checkPropertyInPset(
         expected: formatConstraint(facet.baseName),
         context: {
           propertySet: pset.name,
-          availableProperties: pset.properties.map((p) => p.name).join(', '),
+          availableProperties: availablePropertyNames(pset),
         },
       },
     };

--- a/packages/ids/src/types.ts
+++ b/packages/ids/src/types.ts
@@ -596,6 +596,14 @@ export interface ValidatorOptions {
   onProgress?: (progress: ValidationProgress) => void;
   /** Whether to include passing entities in results (default: true) */
   includePassingEntities?: boolean;
+  /**
+   * How often (ms of CPU work) the validator yields to the event loop
+   * so a host UI can repaint and progress callbacks become visible
+   * (default: 40). Validation is otherwise pure CPU work whose awaits
+   * resolve through microtasks only — without these yields a browser
+   * cannot paint a single frame for the whole run.
+   */
+  yieldEveryMs?: number;
 }
 
 /** Validation progress information */

--- a/packages/ids/src/validation/validation-scale.test.ts
+++ b/packages/ids/src/validation/validation-scale.test.ts
@@ -206,6 +206,48 @@ describe('enumeration constraints — bounded rendering, unchanged matching', ()
   });
 });
 
+describe('validateIDS — yields to the event loop during validation', () => {
+  it('lets queued macrotasks (UI paints) run before validation completes', async () => {
+    // Validation is pure CPU work; all its awaits resolve through
+    // microtasks. Without explicit yields, a timer queued before the
+    // run would only fire AFTER the whole validation finished — which
+    // is exactly why the viewer's progress UI stayed frozen.
+    const specs = Array.from({ length: 5 }, (_, i) => makePropertySpec(i, 'Code'));
+    const accessor = createMockAccessor(makeEntities(200));
+
+    let macrotaskRan = false;
+    const timer = setTimeout(() => {
+      macrotaskRan = true;
+    }, 0);
+
+    try {
+      await validateIDS(makeDoc(specs), accessor, modelInfo, { yieldEveryMs: 0 });
+      expect(macrotaskRan).toBe(true);
+    } finally {
+      clearTimeout(timer);
+    }
+  });
+
+  it('reports filtering progress for large candidate scans', async () => {
+    const entityCount = 20000; // > 8192 triggers incremental filtering progress
+    const accessor = createMockAccessor(makeEntities(entityCount));
+    const spec = makePropertySpec(0, 'Code');
+
+    const filteringEvents: number[] = [];
+    await validateIDS(makeDoc([spec]), accessor, modelInfo, {
+      onProgress: (p) => {
+        if (p.phase === 'filtering' && p.totalEntities > 0) {
+          filteringEvents.push(p.entitiesProcessed);
+        }
+      },
+    });
+
+    // 20k candidates at 8192 granularity → events at 0, 8192, 16384.
+    expect(filteringEvents.length).toBeGreaterThanOrEqual(2);
+    expect(Math.max(...filteringEvents)).toBeGreaterThan(8000);
+  });
+});
+
 describe('createCachedAccessor', () => {
   it('memoizes undefined results and keyed lookups', () => {
     const base = createMockAccessor(makeEntities(1));

--- a/packages/ids/src/validation/validation-scale.test.ts
+++ b/packages/ids/src/validation/validation-scale.test.ts
@@ -1,0 +1,251 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Scale regressions for IDS validation.
+ *
+ * Real-world IDS documents (e.g. national code-list packs) carry
+ * hundreds of specifications over the same entity population, with
+ * enumeration constraints holding hundreds of values. Three pathologies
+ * made such documents unusable on large models:
+ *
+ *   1. Accessor lookups (property sets in particular) were re-extracted
+ *      once per specification per entity — O(specs × entities) source
+ *      parses, minutes-to-hours of CPU.
+ *   2. The entity-independent requirement description was re-formatted
+ *      for every entity result.
+ *   3. Enumeration constraints rendered ALL their values into every
+ *      failure string (~20KB per result for an 800-value code list),
+ *      ballooning reports into the gigabytes.
+ */
+
+import { validateIDS, createCachedAccessor } from './validator.js';
+import { createMockAccessor } from '../facets/test-helpers.js';
+import { formatConstraint, matchConstraint, getConstraintMismatchReason } from '../constraints/index.js';
+import type {
+  IDSDocument,
+  IDSSpecification,
+  IDSModelInfo,
+  IDSSimpleValue,
+  IDSEnumerationConstraint,
+  IFCDataAccessor,
+  TranslationService,
+} from '../types.js';
+
+const sv = (value: string): IDSSimpleValue => ({ type: 'simpleValue', value });
+
+const modelInfo: IDSModelInfo = {
+  modelId: 'test-model',
+  schemaVersion: 'IFC4',
+  entityCount: 10,
+};
+
+function makeDoc(specs: IDSSpecification[]): IDSDocument {
+  return { info: { title: 'Scale Test IDS' }, specifications: specs };
+}
+
+/** A spec whose applicability is a property facet only (no entity facet),
+ * forcing the full-population scan path. */
+function makePropertySpec(index: number, requiredProp: string): IDSSpecification {
+  return {
+    id: `spec-${index}`,
+    name: `Spec ${index}`,
+    ifcVersions: ['IFC4'],
+    applicability: {
+      facets: [
+        {
+          type: 'property',
+          propertySet: sv('Pset_CodeList'),
+          baseName: sv('CommonName'),
+          value: sv('Pump'),
+        },
+      ],
+    },
+    requirements: [
+      {
+        id: `req-${index}`,
+        facet: {
+          type: 'property',
+          propertySet: sv('Pset_CodeList'),
+          baseName: sv(requiredProp),
+        },
+        optionality: 'required',
+      },
+    ],
+    minOccurs: 0,
+  };
+}
+
+function makeEntities(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    expressId: i + 1,
+    type: 'IfcPump',
+    name: `Pump_${i + 1}`,
+    properties: [
+      { psetName: 'Pset_CodeList', propName: 'CommonName', value: 'Pump' },
+      { psetName: 'Pset_CodeList', propName: 'Code', value: `K-${i + 1}` },
+    ],
+  }));
+}
+
+describe('validateIDS — accessor lookups are cached across specifications', () => {
+  it('extracts property sets at most once per entity for the whole run', async () => {
+    const entityCount = 7;
+    const specCount = 25;
+
+    const base = createMockAccessor(makeEntities(entityCount));
+    let psetCalls = 0;
+    const counting: IFCDataAccessor = {
+      ...base,
+      getPropertySets(expressId: number) {
+        psetCalls++;
+        return base.getPropertySets(expressId);
+      },
+    };
+
+    const specs = Array.from({ length: specCount }, (_, i) =>
+      makePropertySpec(i, 'Code')
+    );
+    const report = await validateIDS(makeDoc(specs), counting, modelInfo);
+
+    expect(report.summary.totalSpecifications).toBe(specCount);
+    expect(report.summary.failedSpecifications).toBe(0);
+    // Every spec checks every entity (applicability + requirement), so the
+    // uncached behaviour was specs × entities × 2 calls. With the per-run
+    // cache the underlying accessor is hit once per entity.
+    expect(psetCalls).toBe(entityCount);
+  });
+
+  it('resolves getAllEntityIds once per run', async () => {
+    const base = createMockAccessor(makeEntities(3));
+    let allIdsCalls = 0;
+    const counting: IFCDataAccessor = {
+      ...base,
+      getAllEntityIds() {
+        allIdsCalls++;
+        return base.getAllEntityIds();
+      },
+    };
+
+    const specs = Array.from({ length: 10 }, (_, i) => makePropertySpec(i, 'Code'));
+    await validateIDS(makeDoc(specs), counting, modelInfo);
+
+    expect(allIdsCalls).toBe(1);
+  });
+});
+
+describe('validateIDS — requirement descriptions are formatted once per requirement', () => {
+  it('calls translator.describeRequirement once per requirement, not per entity', async () => {
+    let describeCalls = 0;
+    const translator: TranslationService = {
+      locale: 'en',
+      t: (key: string) => key,
+      describeFacet: () => 'facet',
+      describeConstraint: () => 'constraint',
+      describeFailure: () => 'failed',
+      describeRequirement: () => {
+        describeCalls++;
+        return 'described';
+      },
+      getStatusText: (status) => status,
+      getOptionalityText: (optionality) => optionality,
+      getRelationDescription: (relation) => relation,
+    };
+
+    const spec = makePropertySpec(0, 'Code');
+    await validateIDS(makeDoc([spec]), createMockAccessor(makeEntities(9)), modelInfo, {
+      translator,
+    });
+
+    expect(describeCalls).toBe(1);
+  });
+});
+
+describe('enumeration constraints — bounded rendering, unchanged matching', () => {
+  const values = Array.from({ length: 50 }, (_, i) => `Value_${i}`);
+  const enumeration: IDSEnumerationConstraint = { type: 'enumeration', values };
+
+  it('truncates large enumerations in formatConstraint', () => {
+    const formatted = formatConstraint(enumeration);
+    expect(formatted).toContain('"Value_0"');
+    expect(formatted).toContain('+40 more');
+    expect(formatted).not.toContain('Value_49');
+    // The whole point: bounded output regardless of enum size.
+    expect(formatted.length).toBeLessThan(300);
+  });
+
+  it('truncates large enumerations in mismatch reasons', () => {
+    const reason = getConstraintMismatchReason(enumeration, 'nope');
+    expect(reason).toContain('+40 more');
+    expect(reason.length).toBeLessThan(300);
+  });
+
+  it('keeps small enumerations fully rendered', () => {
+    const small: IDSEnumerationConstraint = {
+      type: 'enumeration',
+      values: ['A', 'B', 'C'],
+    };
+    expect(formatConstraint(small)).toBe('one of ["A", "B", "C"]');
+  });
+
+  it('fast path preserves exact, case-insensitive, and numeric matching', () => {
+    expect(matchConstraint(enumeration, 'Value_42')).toBe(true);
+    expect(matchConstraint(enumeration, 'value_42')).toBe(false);
+    expect(matchConstraint(enumeration, 'value_42', { caseInsensitive: true })).toBe(true);
+    expect(matchConstraint(enumeration, 'Value_999')).toBe(false);
+
+    const numeric: IDSEnumerationConstraint = {
+      type: 'enumeration',
+      values: ['1.5', '42'],
+    };
+    expect(matchConstraint(numeric, 42)).toBe(true);
+    expect(matchConstraint(numeric, '42.0')).toBe(true); // numeric fallback
+    expect(matchConstraint(numeric, 1.5)).toBe(true);
+    expect(matchConstraint(numeric, 2)).toBe(false);
+  });
+});
+
+describe('createCachedAccessor', () => {
+  it('memoizes undefined results and keyed lookups', () => {
+    const base = createMockAccessor(makeEntities(1));
+    let typeCalls = 0;
+    let attrCalls = 0;
+    const counting: IFCDataAccessor = {
+      ...base,
+      getEntityType(expressId: number) {
+        typeCalls++;
+        return base.getEntityType(expressId);
+      },
+      getAttribute(expressId: number, name: string) {
+        attrCalls++;
+        return base.getAttribute(expressId, name);
+      },
+    };
+
+    const cached = createCachedAccessor(counting);
+
+    // Unknown entity → undefined, still memoized.
+    expect(cached.getEntityType(999)).toBeUndefined();
+    expect(cached.getEntityType(999)).toBeUndefined();
+    expect(typeCalls).toBe(1);
+
+    cached.getAttribute(1, 'Name');
+    cached.getAttribute(1, 'Name');
+    cached.getAttribute(1, 'Tag');
+    expect(attrCalls).toBe(2);
+  });
+
+  it('only exposes optional methods the underlying accessor provides', () => {
+    const base = createMockAccessor(makeEntities(1));
+    const withoutOptionals: IFCDataAccessor = { ...base };
+    delete withoutOptionals.getPredefinedTypeRaw;
+    delete withoutOptionals.getAttributeNames;
+    delete withoutOptionals.getAncestors;
+
+    const cached = createCachedAccessor(withoutOptionals);
+    expect(cached.getPredefinedTypeRaw).toBeUndefined();
+    expect(cached.getAttributeNames).toBeUndefined();
+    expect(cached.getAncestors).toBeUndefined();
+  });
+});

--- a/packages/ids/src/validation/validator.ts
+++ b/packages/ids/src/validation/validator.ts
@@ -133,14 +133,17 @@ const nowMs = (): number =>
     ? globalThis.performance.now()
     : Date.now();
 
-/** Yield control back to the event loop (browser + Node). */
+/**
+ * Yield control back to the event loop (browser + Node).
+ *
+ * Deliberately NOT `scheduler.yield()`: its continuation runs at
+ * elevated priority, ahead of the host's already-queued normal tasks —
+ * including React's render work — so a CPU-bound loop yielding through
+ * it still starves the UI (canvas rAF kept painting while the progress
+ * panel never committed). A MessageChannel hop is a normal-priority
+ * task: everything queued before it, renders included, runs first.
+ */
 function yieldToEventLoop(): Promise<void> {
-  const maybeScheduler = (globalThis as typeof globalThis & {
-    scheduler?: { yield?: () => Promise<void> };
-  }).scheduler;
-  if (typeof maybeScheduler?.yield === 'function') {
-    return maybeScheduler.yield();
-  }
   return new Promise<void>((resolve) => {
     const channel = new MessageChannel();
     channel.port1.onmessage = () => {

--- a/packages/ids/src/validation/validator.ts
+++ b/packages/ids/src/validation/validator.ts
@@ -128,6 +128,50 @@ export function createCachedAccessor(accessor: IFCDataAccessor): IFCDataAccessor
  */
 type DescriptionCache = Map<IDSRequirement, string>;
 
+const nowMs = (): number =>
+  typeof globalThis.performance?.now === 'function'
+    ? globalThis.performance.now()
+    : Date.now();
+
+/** Yield control back to the event loop (browser + Node). */
+function yieldToEventLoop(): Promise<void> {
+  const maybeScheduler = (globalThis as typeof globalThis & {
+    scheduler?: { yield?: () => Promise<void> };
+  }).scheduler;
+  if (typeof maybeScheduler?.yield === 'function') {
+    return maybeScheduler.yield();
+  }
+  return new Promise<void>((resolve) => {
+    const channel = new MessageChannel();
+    channel.port1.onmessage = () => {
+      // Close both ports — an open MessagePort holds a libuv handle in
+      // Node and would keep the process alive after completion.
+      channel.port1.close();
+      channel.port2.close();
+      resolve();
+    };
+    channel.port2.postMessage(null);
+  });
+}
+
+/**
+ * Time-budgeted yielder. Validation is pure CPU work whose awaits all
+ * resolve through microtasks, so without real event-loop yields a
+ * browser host cannot paint a single frame for the whole run — the
+ * progress UI stays frozen no matter how often onProgress fires.
+ */
+function createYielder(budgetMs: number): () => Promise<void> | undefined {
+  let lastYield = nowMs();
+  return () => {
+    if (nowMs() - lastYield < budgetMs) return undefined;
+    return yieldToEventLoop().then(() => {
+      lastYield = nowMs();
+    });
+  };
+}
+
+type MaybeYield = ReturnType<typeof createYielder>;
+
 /**
  * Validate an IFC model against an IDS document
  */
@@ -141,6 +185,7 @@ export async function validateIDS(
 
   const cachedAccessor = createCachedAccessor(accessor);
   const descriptionCache: DescriptionCache = new Map();
+  const maybeYield = createYielder(options.yieldEveryMs ?? 40);
 
   const specificationResults: IDSSpecificationResult[] = [];
   const totalSpecs = document.specifications.length;
@@ -160,12 +205,17 @@ export async function validateIDS(
       });
     }
 
+    // Let the host paint between specifications even when individual
+    // specs are fast.
+    await maybeYield();
+
     const result = await validateSpecification(
       spec,
       cachedAccessor,
       modelInfo,
       options,
       descriptionCache,
+      maybeYield,
       (progress) => {
         if (onProgress) {
           onProgress({
@@ -217,13 +267,14 @@ async function validateSpecification(
   modelInfo: IDSModelInfo,
   options: ValidatorOptions,
   descriptionCache: DescriptionCache,
+  maybeYield: MaybeYield,
   onProgress?: (progress: Omit<ValidationProgress, 'specificationIndex' | 'totalSpecifications' | 'percentage'>) => void
 ): Promise<IDSSpecificationResult> {
   const { translator, maxEntities, includePassingEntities = true } = options;
   const modelId = modelInfo.modelId;
 
   // Phase 1: Find applicable entities
-  const applicableIds = findApplicableEntities(spec, accessor);
+  const applicableIds = await findApplicableEntities(spec, accessor, maybeYield, onProgress);
 
   // Apply max entities limit if specified
   const idsToCheck = maxEntities
@@ -245,6 +296,7 @@ async function validateSpecification(
         totalEntities,
       });
     }
+    if ((i & 31) === 0) await maybeYield();
 
     const entityResult = validateEntityRequirements(
       spec,
@@ -315,10 +367,12 @@ async function validateSpecification(
 /**
  * Find entities that match the applicability criteria
  */
-function findApplicableEntities(
+async function findApplicableEntities(
   spec: IDSSpecification,
-  accessor: IFCDataAccessor
-): number[] {
+  accessor: IFCDataAccessor,
+  maybeYield: MaybeYield,
+  onProgress?: (progress: Omit<ValidationProgress, 'specificationIndex' | 'totalSpecifications' | 'percentage'>) => void
+): Promise<number[]> {
   const applicabilityFacets = spec.applicability.facets;
 
   if (applicabilityFacets.length === 0) {
@@ -341,10 +395,25 @@ function findApplicableEntities(
     candidateIds = accessor.getAllEntityIds();
   }
 
-  // Filter candidates by all applicability facets
+  // Filter candidates by all applicability facets. With property-only
+  // applicability the candidate set is the whole model, so this scan is
+  // where large runs spend most of their time — report progress and
+  // yield so the host UI stays responsive.
   const applicableIds: number[] = [];
+  const totalCandidates = candidateIds.length;
 
-  for (const expressId of candidateIds) {
+  for (let i = 0; i < totalCandidates; i++) {
+    const expressId = candidateIds[i];
+
+    if (onProgress && totalCandidates > 8192 && (i & 8191) === 0) {
+      onProgress({
+        phase: 'filtering',
+        entitiesProcessed: i,
+        totalEntities: totalCandidates,
+      });
+    }
+    if ((i & 255) === 0) await maybeYield();
+
     let matches = true;
 
     for (const facet of applicabilityFacets) {

--- a/packages/ids/src/validation/validator.ts
+++ b/packages/ids/src/validation/validator.ts
@@ -22,9 +22,111 @@ import type {
   ValidatorOptions,
   ValidationProgress,
   TranslationService,
+  PartOfRelation,
 } from '../types.js';
 import { checkFacet, filterByFacet, type FacetCheckResult } from '../facets/index.js';
 import { formatConstraint } from '../constraints/index.js';
+
+/** Memoize a single-argument accessor lookup keyed by express ID. */
+function memoById<T>(fn: (expressId: number) => T): (expressId: number) => T {
+  const cache = new Map<number, T>();
+  return (expressId: number): T => {
+    if (cache.has(expressId)) return cache.get(expressId) as T;
+    const value = fn(expressId);
+    cache.set(expressId, value);
+    return value;
+  };
+}
+
+/** Memoize a two-argument accessor lookup keyed by express ID + name. */
+function memoByIdAndKey<T>(
+  fn: (expressId: number, key: string) => T
+): (expressId: number, key: string) => T {
+  const cache = new Map<string, T>();
+  return (expressId: number, key: string): T => {
+    const cacheKey = `${expressId}\u0000${key}`;
+    if (cache.has(cacheKey)) return cache.get(cacheKey) as T;
+    const value = fn(expressId, key);
+    cache.set(cacheKey, value);
+    return value;
+  };
+}
+
+/**
+ * Wrap an accessor so every per-entity lookup is computed at most once
+ * for the lifetime of one validation run.
+ *
+ * The validator re-checks the same entities once per specification, and
+ * real-world IDS documents carry hundreds of specifications over the
+ * same entity population. Most accessor implementations re-extract
+ * property sets from the raw source buffer on every call, which made
+ * validation O(specifications × entities × source-parses) — tens of
+ * minutes of CPU for documents that validate in seconds once cached.
+ */
+export function createCachedAccessor(accessor: IFCDataAccessor): IFCDataAccessor {
+  let allEntityIds: number[] | undefined;
+  const entitiesByType = new Map<string, number[]>();
+
+  const cached: IFCDataAccessor = {
+    getEntityType: memoById((id) => accessor.getEntityType(id)),
+    getEntityName: memoById((id) => accessor.getEntityName(id)),
+    getGlobalId: memoById((id) => accessor.getGlobalId(id)),
+    getDescription: memoById((id) => accessor.getDescription(id)),
+    getObjectType: memoById((id) => accessor.getObjectType(id)),
+    getPropertySets: memoById((id) => accessor.getPropertySets(id)),
+    getClassifications: memoById((id) => accessor.getClassifications(id)),
+    getMaterials: memoById((id) => accessor.getMaterials(id)),
+    getAttribute: memoByIdAndKey((id, name) => accessor.getAttribute(id, name)),
+    getParent: memoByIdAndKey((id, rel) =>
+      accessor.getParent(id, rel as PartOfRelation)
+    ) as IFCDataAccessor['getParent'],
+    getPropertyValue: (id, psetName, propName) =>
+      accessor.getPropertyValue(id, psetName, propName),
+    getEntitiesByType(typeName: string): number[] {
+      let ids = entitiesByType.get(typeName);
+      if (!ids) {
+        ids = accessor.getEntitiesByType(typeName);
+        entitiesByType.set(typeName, ids);
+      }
+      return ids;
+    },
+    getAllEntityIds(): number[] {
+      if (!allEntityIds) allEntityIds = accessor.getAllEntityIds();
+      return allEntityIds;
+    },
+  };
+
+  // Optional methods: only surface them when the underlying accessor
+  // does — facet checkers feature-detect these.
+  if (accessor.getPredefinedTypeRaw) {
+    cached.getPredefinedTypeRaw = memoById((id) =>
+      accessor.getPredefinedTypeRaw!(id)
+    );
+  }
+  if (accessor.getAttributeNames) {
+    cached.getAttributeNames = memoById((id) => accessor.getAttributeNames!(id));
+  }
+  if (accessor.getAttributeXsdTypes) {
+    cached.getAttributeXsdTypes = memoByIdAndKey((id, attr) =>
+      accessor.getAttributeXsdTypes!(id, attr)
+    ) as IFCDataAccessor['getAttributeXsdTypes'];
+  }
+  if (accessor.getAncestors) {
+    cached.getAncestors = memoByIdAndKey((id, rel) =>
+      accessor.getAncestors!(id, rel as PartOfRelation)
+    ) as IFCDataAccessor['getAncestors'];
+  }
+
+  return cached;
+}
+
+/**
+ * Per-run cache for requirement descriptions. A requirement's checked
+ * description is entity-independent, yet it used to be re-formatted for
+ * every entity result — for enumeration constraints that meant building
+ * the same multi-KB string thousands of times.
+ */
+type DescriptionCache = Map<IDSRequirement, string>;
 
 /**
  * Validate an IFC model against an IDS document
@@ -36,6 +138,9 @@ export async function validateIDS(
   options: ValidatorOptions = {}
 ): Promise<IDSValidationReport> {
   const { translator, onProgress, includePassingEntities = true } = options;
+
+  const cachedAccessor = createCachedAccessor(accessor);
+  const descriptionCache: DescriptionCache = new Map();
 
   const specificationResults: IDSSpecificationResult[] = [];
   const totalSpecs = document.specifications.length;
@@ -57,9 +162,10 @@ export async function validateIDS(
 
     const result = await validateSpecification(
       spec,
-      accessor,
+      cachedAccessor,
       modelInfo,
       options,
+      descriptionCache,
       (progress) => {
         if (onProgress) {
           onProgress({
@@ -110,6 +216,7 @@ async function validateSpecification(
   accessor: IFCDataAccessor,
   modelInfo: IDSModelInfo,
   options: ValidatorOptions,
+  descriptionCache: DescriptionCache,
   onProgress?: (progress: Omit<ValidationProgress, 'specificationIndex' | 'totalSpecifications' | 'percentage'>) => void
 ): Promise<IDSSpecificationResult> {
   const { translator, maxEntities, includePassingEntities = true } = options;
@@ -144,6 +251,7 @@ async function validateSpecification(
       expressId,
       modelId,
       accessor,
+      descriptionCache,
       translator
     );
 
@@ -263,13 +371,14 @@ function validateEntityRequirements(
   expressId: number,
   modelId: string,
   accessor: IFCDataAccessor,
+  descriptionCache: DescriptionCache,
   translator?: TranslationService
 ): IDSEntityResult {
   const requirementResults: IDSRequirementResult[] = [];
   let allPassed = true;
 
   for (const requirement of spec.requirements) {
-    const result = checkRequirement(requirement, expressId, accessor, translator);
+    const result = checkRequirement(requirement, expressId, accessor, descriptionCache, translator);
     requirementResults.push(result);
 
     if (result.status === 'fail') {
@@ -295,6 +404,7 @@ function checkRequirement(
   requirement: IDSRequirement,
   expressId: number,
   accessor: IFCDataAccessor,
+  descriptionCache: DescriptionCache,
   translator?: TranslationService
 ): IDSRequirementResult {
   const facetResult = checkFacet(requirement.facet, expressId, accessor);
@@ -376,10 +486,15 @@ function checkRequirement(
       status = facetResult.passed ? 'pass' : 'fail';
   }
 
-  // Generate checked description
-  const checkedDescription = translator
-    ? translator.describeRequirement(requirement)
-    : formatRequirementDescription(requirement);
+  // Generate checked description. It is entity-independent, so format
+  // it once per requirement per run — not once per entity result.
+  let checkedDescription = descriptionCache.get(requirement);
+  if (checkedDescription === undefined) {
+    checkedDescription = translator
+      ? translator.describeRequirement(requirement)
+      : formatRequirementDescription(requirement);
+    descriptionCache.set(requirement, checkedDescription);
+  }
 
   return {
     requirement,

--- a/packages/parser/src/columnar-parser.ts
+++ b/packages/parser/src/columnar-parser.ts
@@ -16,6 +16,7 @@ import { extractLengthUnitScale } from './unit-extractor.js';
 import { getAttributeNames, getInheritanceChain } from './ifc-schema.js';
 import { parsePropertyValue } from './on-demand-extractors.js';
 import { buildCompactEntityIndexAsync } from './compact-entity-index.js';
+import { yieldToEventLoop } from './yield-to-event-loop.js';
 import {
     StringTable,
     EntityTableBuilder,
@@ -116,20 +117,6 @@ function detectSchemaVersion(buffer: Uint8Array): IfcDataStore['schemaVersion'] 
     if (headerText.includes('IFC2X3')) return 'IFC2X3';
 
     return 'IFC4'; // Default fallback
-}
-
-function yieldToEventLoop(): Promise<void> {
-    const maybeScheduler = (globalThis as typeof globalThis & {
-        scheduler?: { yield?: () => Promise<void> };
-    }).scheduler;
-    if (typeof maybeScheduler?.yield === 'function') {
-        return maybeScheduler.yield();
-    }
-    return new Promise<void>((resolve) => {
-        const channel = new MessageChannel();
-        channel.port1.onmessage = () => resolve();
-        channel.port2.postMessage(null);
-    });
 }
 
 export class ColumnarParser {

--- a/packages/parser/src/compact-entity-index.ts
+++ b/packages/parser/src/compact-entity-index.ts
@@ -14,6 +14,7 @@
  */
 
 import type { EntityRef } from './types.js';
+import { yieldToEventLoop } from './yield-to-event-loop.js';
 
 /**
  * Compact read-only entity index backed by sorted typed arrays.
@@ -234,20 +235,6 @@ export class CompactEntityIndex {
       this.typeStrings.reduce((sum, s) => sum + s.length * 2, 0)
     );
   }
-}
-
-function yieldToEventLoop(): Promise<void> {
-  const maybeScheduler = (globalThis as typeof globalThis & {
-    scheduler?: { yield?: () => Promise<void> };
-  }).scheduler;
-  if (typeof maybeScheduler?.yield === 'function') {
-    return maybeScheduler.yield();
-  }
-  return new Promise<void>((resolve) => {
-    const channel = new MessageChannel();
-    channel.port1.onmessage = () => resolve();
-    channel.port2.postMessage(null);
-  });
 }
 
 /**

--- a/packages/parser/src/yield-to-event-loop.ts
+++ b/packages/parser/src/yield-to-event-loop.ts
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Yield control back to the event loop between parse chunks.
+ *
+ * Prefers the standard `scheduler.yield()` where available; otherwise
+ * falls back to a MessageChannel round-trip (faster than `setTimeout(0)`
+ * and available in both browsers and Node).
+ */
+export function yieldToEventLoop(): Promise<void> {
+  const maybeScheduler = (globalThis as typeof globalThis & {
+    scheduler?: { yield?: () => Promise<void> };
+  }).scheduler;
+  if (typeof maybeScheduler?.yield === 'function') {
+    return maybeScheduler.yield();
+  }
+  return new Promise<void>((resolve) => {
+    const channel = new MessageChannel();
+    channel.port1.onmessage = () => {
+      // Close both ports — an open MessagePort holds a libuv handle in
+      // Node, so leaking one per yield kept the process alive forever
+      // after parsing large files (the CLI printed results but never
+      // exited).
+      channel.port1.close();
+      channel.port2.close();
+      resolve();
+    };
+    channel.port2.postMessage(null);
+  });
+}

--- a/packages/parser/test/yield-to-event-loop.test.ts
+++ b/packages/parser/test/yield-to-event-loop.test.ts
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { yieldToEventLoop } from '../src/yield-to-event-loop.js';
+
+function countMessagePortHandles(): number {
+  const handles = (
+    process as unknown as { _getActiveHandles: () => unknown[] }
+  )._getActiveHandles();
+  return handles.filter(
+    (h) => (h as { constructor?: { name?: string } })?.constructor?.name === 'MessagePort'
+  ).length;
+}
+
+describe('yieldToEventLoop', () => {
+  it('does not leak MessagePort handles (CLI exit-hang regression)', async () => {
+    // Each yield used to leave a MessageChannel with an attached
+    // onmessage listener open. In Node an open MessagePort holds a
+    // libuv handle, so a parse with hundreds of yields kept the process
+    // alive forever — the CLI printed its results and then hung.
+    const before = countMessagePortHandles();
+
+    for (let i = 0; i < 50; i++) {
+      await yieldToEventLoop();
+    }
+
+    // Ports close inside the message handler, but Node finalises the
+    // underlying handle asynchronously — at most the last channel may
+    // still be mid-teardown here. Pre-fix, all 50 stayed open.
+    expect(countMessagePortHandles()).toBeLessThanOrEqual(before + 1);
+
+    // After a timer tick the teardown must have drained completely.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(countMessagePortHandles()).toBeLessThanOrEqual(before);
+  });
+});

--- a/packages/sdk/src/namespaces/ids.test.ts
+++ b/packages/sdk/src/namespaces/ids.test.ts
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { IDSNamespace } from './ids.js';
+
+const ids = new IDSNamespace();
+
+describe('IDSNamespace.summarize', () => {
+  it('derives spec pass/fail from entity results when no status is present', () => {
+    const summary = ids.summarize({
+      specificationResults: [
+        { entityResults: [{ passed: true }, { passed: false }] },
+        { entityResults: [{ passed: true }] },
+      ],
+    });
+
+    expect(summary.totalSpecifications).toBe(2);
+    expect(summary.failedSpecifications).toBe(1);
+    expect(summary.passedSpecifications).toBe(1);
+    expect(summary.totalEntities).toBe(3);
+    expect(summary.failedEntities).toBe(1);
+  });
+
+  it('prefers the validator spec status — cardinality-only failures count as failed', () => {
+    // A required spec matching zero entities has no entity results at
+    // all, yet the validator marks it failed. Deriving purely from
+    // entity results used to report it as passed, making this summary
+    // disagree with the validator's own report.summary (and the CLI's
+    // text-mode verdict).
+    const summary = ids.summarize({
+      specificationResults: [
+        { entityResults: [], status: 'fail' },
+        { entityResults: [{ passed: true }], status: 'pass' },
+        { entityResults: [], status: 'not_applicable' },
+      ],
+    });
+
+    expect(summary.totalSpecifications).toBe(3);
+    expect(summary.failedSpecifications).toBe(1);
+    // Legacy shape invariant: passed + failed = total, so a
+    // not-applicable spec counts as non-failed here.
+    expect(summary.passedSpecifications).toBe(2);
+  });
+
+  it('prohibited spec violated by passing entities counts as failed when status says so', () => {
+    const summary = ids.summarize({
+      specificationResults: [
+        // maxOccurs=0 spec: the matched entity "passes" its (empty)
+        // requirements but the spec itself fails on cardinality.
+        { entityResults: [{ passed: true }], status: 'fail' },
+      ],
+    });
+
+    expect(summary.failedSpecifications).toBe(1);
+    expect(summary.passedSpecifications).toBe(0);
+    expect(summary.failedEntities).toBe(0);
+  });
+});

--- a/packages/sdk/src/namespaces/ids.ts
+++ b/packages/sdk/src/namespaces/ids.ts
@@ -203,20 +203,31 @@ export class IDSNamespace {
   // --------------------------------------------------------------------------
 
   /** Summarize a validation report into pass/fail counts. */
-  summarize(report: { specificationResults: Array<{ entityResults: Array<{ passed: boolean }> }> }): IDSValidationSummary {
+  summarize(report: {
+    specificationResults: Array<{
+      entityResults: Array<{ passed: boolean }>;
+      status?: 'pass' | 'fail' | 'not_applicable';
+    }>;
+  }): IDSValidationSummary {
     let totalSpecs = 0, passedSpecs = 0, failedSpecs = 0;
     let totalEntities = 0, passedEntities = 0, failedEntities = 0;
 
     for (const spec of report.specificationResults) {
       totalSpecs++;
-      let specPassed = true;
+      let anyEntityFailed = false;
       for (const entity of spec.entityResults) {
         totalEntities++;
         if (entity.passed) passedEntities++;
-        else { failedEntities++; specPassed = false; }
+        else { failedEntities++; anyEntityFailed = true; }
       }
-      if (specPassed) passedSpecs++;
-      else failedSpecs++;
+      // Prefer the validator's own verdict when present: it also covers
+      // cardinality-only failures (e.g. a required spec matching zero
+      // entities), which entity results alone cannot express. Deriving
+      // from entities here used to make this summary disagree with the
+      // validator's report.summary for exactly those specs.
+      const specFailed = spec.status !== undefined ? spec.status === 'fail' : anyEntityFailed;
+      if (specFailed) failedSpecs++;
+      else passedSpecs++;
     }
 
     return { totalSpecifications: totalSpecs, passedSpecifications: passedSpecs, failedSpecifications: failedSpecs, totalEntities, passedEntities, failedEntities };

--- a/packages/sdk/src/namespaces/ids.ts
+++ b/packages/sdk/src/namespaces/ids.ts
@@ -25,15 +25,31 @@ export interface IDSValidationSummary {
 
 export type IDSSupportedLocale = 'en' | 'de' | 'fr';
 
+/** Progress shape emitted by the @ifc-lite/ids validator. */
+export interface IDSValidationProgress {
+  phase: 'filtering' | 'validating' | 'complete';
+  specificationIndex: number;
+  totalSpecifications: number;
+  entitiesProcessed: number;
+  totalEntities: number;
+  percentage: number;
+}
+
 export interface IDSValidateOptions {
   /** IFC data accessor — maps IFC model data for validation */
   accessor: unknown;
   /** Model info (schema version, name, etc.) for spec applicability checks */
   modelInfo?: { schemaVersion?: string; name?: string; [key: string]: unknown };
   /** Progress callback */
-  onProgress?: (progress: { current: number; total: number; specName: string }) => void;
+  onProgress?: (progress: IDSValidationProgress) => void;
   /** Locale for human-readable messages */
   locale?: IDSSupportedLocale;
+  /**
+   * Whether per-entity results for PASSING entities are retained in the
+   * report (default true). Disable for summary/failure-focused flows on
+   * large models — pass/fail counts stay correct either way.
+   */
+  includePassingEntities?: boolean;
 }
 
 // ============================================================================
@@ -82,6 +98,7 @@ export class IDSNamespace {
     return (mod.validateIDS as AnyFn)(idsDocument, options.accessor, options.modelInfo ?? {}, {
       onProgress: options.onProgress,
       locale: options.locale,
+      includePassingEntities: options.includePassingEntities,
     });
   }
 


### PR DESCRIPTION
## Problem

Running `ifc-lite ids` with a 550k-entity IFC model against a national code-list IDS pack (848 specifications, 800+-value enumerations) was unusable:

- ~19 minutes of CPU, looking frozen (progress printed `undefined (undefined/undefined)`)
- multi-GB per-entity result strings (heap-OOM territory on smaller machines; `--json` could die in `JSON.stringify`)
- after printing results, **the process hung forever** — every CLI command on a large file did
- in the viewer, the progress UI never painted during validation
- (the originally reported instant crash, `Error: DOMParser is not defined`, is the long-fixed published CLI 0.6.2 — upgrading the global install resolves that part)

## Root causes & fixes

1. **parser — exit hang**: `yieldToEventLoop()` created a `MessageChannel` per yield and never closed the ports. In Node an open `MessagePort` holds a libuv handle, so the event loop never drained. Ports now close; the duplicated helper is consolidated into one shared module with a handle-count regression test.

2. **ids — O(specs × entities) re-extraction**: every facet check re-extracted property sets from the raw source buffer, once per entity *per specification*. `validateIDS` now wraps the accessor in a per-run memoizing cache (`createCachedAccessor`) so each lookup happens once per entity. Enumeration constraints additionally compile into exact-match sets (WeakMap-cached; misses fall back to the unchanged comparator walk, so numeric/boolean/case semantics are identical).

3. **ids — unbounded report strings**: `formatConstraint`/mismatch reasons rendered *all* enumeration values (~20KB per result for an 845-value code list) and the entity-independent requirement description was re-formatted per entity result. Enumerations now render at most 10 values (`… +N more`), and descriptions are formatted once per requirement per run.

4. **ids — UI starvation**: validation is pure CPU work whose awaits resolve through microtasks, so a browser host could never paint. The validator now yields to the event loop on a time budget (default 40ms, `ValidatorOptions.yieldEveryMs`) — via a normal-priority MessageChannel hop, deliberately not `scheduler.yield()` whose elevated-priority continuations starve the host's queued render tasks. The applicability scan reports incremental `filtering` progress. The viewer throttles progress store updates to ~8/s.

5. **cli/sdk — drift + broken UX**: the CLI had its own EntityNode-based accessor (missed type-inherited psets); it now uses the canonical `@ifc-lite/ids/bridge` accessor like the MCP server. Progress now prints `spec 312/848 (37%)`. Text mode skips retaining passing entity results (`--json` unchanged). SDK forwards `includePassingEntities` and types `onProgress` with the validator's actual shape.

## Behavior change (disclosed in changeset)

The CLI verdict/exit code now derives from the validator's per-spec status, which counts **cardinality-only failures** — a `minOccurs="1"` spec matching zero entities now correctly FAILs (previously silently passed). `bim.ids.summarize` prefers the per-spec status when present so `--json` and text mode agree (caught by adversarial review, runtime-verified).

## Measured (same model + IDS packs)

| IDS pack | before | after |
|---|---|---|
| 848 specs | ~19 min CPU + hang | **~1 min, clean exit** |
| 277 specs | not reached | **45 s, clean exit** |
| 117 specs | 3.4 min + hang | **12 s, clean exit** |
| `--json` on the failing pack | GB-scale stringify | 256 MB valid JSON in 9 s |

Identical pass/fail counts pre/post fix; the only delta is +329 newly-applicable passing entities from the bridge accessor's type-inherited psets.

Tests: scale-regression suite in `packages/ids` (accessor call-counting, truncation, description memoization, enum fast-path equivalence, macrotask-yield regression), MessagePort leak test in `packages/parser`, summarize-status tests in `packages/sdk`.

Follow-ups worth tracking: run viewer IDS validation in a worker (off the main thread entirely); converge the viewer's own accessor copy (`apps/viewer/src/hooks/ids/idsDataAccessor`) on `@ifc-lite/ids/bridge`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed memory leak in CLI causing hangs during large model validation
  * Corrected IDS validation verdicts for cardinality requirements
  * Optimized validation performance via caching and per-run memoization
  * Improved progress reporting during validation and capped enumeration display in reports

<!-- end of auto-generated comment: release notes by coderabbit.ai -->