### PR TITLE
perf(ids): diagnostics-free applicability + inverted property-value index

### DIFF
--- a/apps/viewer/src/components/viewer/IDSPanel.tsx
+++ b/apps/viewer/src/components/viewer/IDSPanel.tsx
@@ -521,16 +521,32 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
   const renderProgress = () => {
     if (!progress) return null;
 
+    // Validation of large code-list IDS packs runs for many seconds, and
+    // a few broad specs dominate the time — so a percentage keyed on spec
+    // index sits near 0 for a while. Surface the always-advancing spec
+    // counter (and the per-spec entity count) so the panel visibly moves
+    // throughout, not just in the back half.
+    const specNumber = Math.min(progress.specificationIndex + 1, progress.totalSpecifications);
+    const isComplete = progress.phase === 'complete';
+    const headline = isComplete
+      ? 'Validation complete'
+      : `Validating specification ${specNumber} of ${progress.totalSpecifications}`;
+    const detail =
+      progress.phase === 'validating' && progress.totalEntities > 0
+        ? `Checking ${progress.entitiesProcessed.toLocaleString()} / ${progress.totalEntities.toLocaleString()} entities`
+        : progress.phase === 'filtering' && progress.totalEntities > 0
+          ? `Scanning ${progress.entitiesProcessed.toLocaleString()} / ${progress.totalEntities.toLocaleString()} candidates`
+          : progress.phase === 'filtering'
+            ? 'Finding applicable entities…'
+            : null;
+
     return (
       <div className="p-3 border-b">
-        <div className="flex items-center gap-2 mb-2">
-          <Loader2 className="h-4 w-4 animate-spin" />
-          <span className="text-sm">
-            {progress.phase === 'filtering' && 'Finding applicable entities...'}
-            {progress.phase === 'validating' && `Validating... (${progress.entitiesProcessed}/${progress.totalEntities})`}
-            {progress.phase === 'complete' && 'Complete'}
-          </span>
+        <div className="flex items-center gap-2 mb-1">
+          {!isComplete && <Loader2 className="h-4 w-4 animate-spin shrink-0" />}
+          <span className="text-sm font-medium tabular-nums">{headline}</span>
         </div>
+        {detail && <div className="text-xs text-muted-foreground mb-2 tabular-nums">{detail}</div>}
         <Progress value={progress.percentage} className="h-2" />
       </div>
     );

--- a/apps/viewer/src/hooks/ids/idsWorkerClient.ts
+++ b/apps/viewer/src/hooks/ids/idsWorkerClient.ts
@@ -53,9 +53,7 @@ export function runValidationInWorker(
         new URL('../../workers/idsValidation.worker.ts', import.meta.url),
         { type: 'module' }
       );
-      console.info('[IDS-client] worker spawned');
     } catch (err) {
-      console.error('[IDS-client] worker spawn FAILED:', err);
       reject(
         new Error(
           `Failed to spawn IDS worker: ${err instanceof Error ? err.message : String(err)}`
@@ -65,12 +63,7 @@ export function runValidationInWorker(
     }
 
     const id = Date.now();
-    let clientProgressCount = 0;
-
     const { buffer, transfer } = prepareSource(args.source);
-    console.info(
-      `[IDS-client] posting ${buffer.byteLength} bytes (${buffer instanceof SharedArrayBuffer ? 'shared' : 'transferred copy'}), ${args.document.specifications.length} specs`
-    );
 
     const settle = (fn: () => void) => {
       worker.onmessage = null;
@@ -85,27 +78,21 @@ export function runValidationInWorker(
       if (!msg || msg.id !== id) return;
       switch (msg.type) {
         case 'progress':
-          clientProgressCount++;
-          if (clientProgressCount === 1) console.info('[IDS-client] first progress message received');
           args.onProgress?.(msg.progress);
           return;
         case 'complete':
-          console.info(`[IDS-client] complete message received (${clientProgressCount} progress messages total)`);
           settle(() => resolve(msg.report));
           return;
         case 'error':
-          console.error('[IDS-client] error message received:', msg.message);
           settle(() => reject(new Error(msg.message)));
           return;
       }
     };
 
     worker.onerror = (event) => {
-      console.error('[IDS-client] worker.onerror:', event.message, event);
       settle(() => reject(new Error(event.message || 'IDS worker crashed')));
     };
-    worker.onmessageerror = (event) => {
-      console.error('[IDS-client] worker.onmessageerror (structured-clone failed):', event);
+    worker.onmessageerror = () => {
       settle(() => reject(new Error('IDS worker message deserialization failed')));
     };
 

--- a/apps/viewer/src/hooks/ids/idsWorkerClient.ts
+++ b/apps/viewer/src/hooks/ids/idsWorkerClient.ts
@@ -53,7 +53,9 @@ export function runValidationInWorker(
         new URL('../../workers/idsValidation.worker.ts', import.meta.url),
         { type: 'module' }
       );
+      console.info('[IDS-client] worker spawned');
     } catch (err) {
+      console.error('[IDS-client] worker spawn FAILED:', err);
       reject(
         new Error(
           `Failed to spawn IDS worker: ${err instanceof Error ? err.message : String(err)}`
@@ -63,8 +65,12 @@ export function runValidationInWorker(
     }
 
     const id = Date.now();
+    let clientProgressCount = 0;
 
     const { buffer, transfer } = prepareSource(args.source);
+    console.info(
+      `[IDS-client] posting ${buffer.byteLength} bytes (${buffer instanceof SharedArrayBuffer ? 'shared' : 'transferred copy'}), ${args.document.specifications.length} specs`
+    );
 
     const settle = (fn: () => void) => {
       worker.onmessage = null;
@@ -79,21 +85,27 @@ export function runValidationInWorker(
       if (!msg || msg.id !== id) return;
       switch (msg.type) {
         case 'progress':
+          clientProgressCount++;
+          if (clientProgressCount === 1) console.info('[IDS-client] first progress message received');
           args.onProgress?.(msg.progress);
           return;
         case 'complete':
+          console.info(`[IDS-client] complete message received (${clientProgressCount} progress messages total)`);
           settle(() => resolve(msg.report));
           return;
         case 'error':
+          console.error('[IDS-client] error message received:', msg.message);
           settle(() => reject(new Error(msg.message)));
           return;
       }
     };
 
     worker.onerror = (event) => {
+      console.error('[IDS-client] worker.onerror:', event.message, event);
       settle(() => reject(new Error(event.message || 'IDS worker crashed')));
     };
-    worker.onmessageerror = () => {
+    worker.onmessageerror = (event) => {
+      console.error('[IDS-client] worker.onmessageerror (structured-clone failed):', event);
       settle(() => reject(new Error('IDS worker message deserialization failed')));
     };
 

--- a/apps/viewer/src/hooks/ids/idsWorkerClient.ts
+++ b/apps/viewer/src/hooks/ids/idsWorkerClient.ts
@@ -1,0 +1,137 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Main-thread client for the IDS validation worker.
+ *
+ * Spawns the worker per run (validation is infrequent and the worker
+ * re-parses the model, so a long-lived instance would only pin memory),
+ * streams progress back to the caller, and resolves with the report.
+ * The caller falls back to in-process validation when `isSupported()`
+ * is false or the worker rejects.
+ */
+
+import type {
+  IDSDocument,
+  IDSValidationReport,
+  ValidationProgress,
+} from '@ifc-lite/ids';
+import type {
+  IdsWorkerRequest,
+  IdsWorkerResponse,
+} from '@/workers/idsValidation.worker';
+
+export function idsWorkerSupported(): boolean {
+  return typeof Worker !== 'undefined';
+}
+
+export interface RunInWorkerArgs {
+  /** Raw IFC/STEP bytes from the loaded model's data store. */
+  source: Uint8Array;
+  document: IDSDocument;
+  schemaVersion: string;
+  modelId: string;
+  locale: 'en' | 'de' | 'fr';
+  includePassingEntities: boolean;
+  onProgress?: (progress: ValidationProgress) => void;
+}
+
+/**
+ * Hand the model bytes + parsed IDS document to the worker and resolve
+ * with the validation report. A SharedArrayBuffer-backed source is
+ * shared zero-copy; a plain ArrayBuffer is copied and transferred so
+ * the main-thread store is never detached.
+ */
+export function runValidationInWorker(
+  args: RunInWorkerArgs
+): Promise<IDSValidationReport> {
+  return new Promise((resolve, reject) => {
+    let worker: Worker;
+    try {
+      worker = new Worker(
+        new URL('../../workers/idsValidation.worker.ts', import.meta.url),
+        { type: 'module' }
+      );
+    } catch (err) {
+      reject(
+        new Error(
+          `Failed to spawn IDS worker: ${err instanceof Error ? err.message : String(err)}`
+        )
+      );
+      return;
+    }
+
+    const id = Date.now();
+
+    const { buffer, transfer } = prepareSource(args.source);
+
+    const settle = (fn: () => void) => {
+      worker.onmessage = null;
+      worker.onerror = null;
+      worker.onmessageerror = null;
+      worker.terminate();
+      fn();
+    };
+
+    worker.onmessage = (event: MessageEvent<IdsWorkerResponse>) => {
+      const msg = event.data;
+      if (!msg || msg.id !== id) return;
+      switch (msg.type) {
+        case 'progress':
+          args.onProgress?.(msg.progress);
+          return;
+        case 'complete':
+          settle(() => resolve(msg.report));
+          return;
+        case 'error':
+          settle(() => reject(new Error(msg.message)));
+          return;
+      }
+    };
+
+    worker.onerror = (event) => {
+      settle(() => reject(new Error(event.message || 'IDS worker crashed')));
+    };
+    worker.onmessageerror = () => {
+      settle(() => reject(new Error('IDS worker message deserialization failed')));
+    };
+
+    const request: IdsWorkerRequest = {
+      type: 'validate',
+      id,
+      source: buffer,
+      document: args.document,
+      schemaVersion: args.schemaVersion,
+      modelId: args.modelId,
+      locale: args.locale,
+      includePassingEntities: args.includePassingEntities,
+    };
+    worker.postMessage(request, transfer);
+  });
+}
+
+/**
+ * Resolve the exact source bytes into a worker-postable buffer.
+ * SharedArrayBuffer is shared by reference (zero copy); a plain
+ * ArrayBuffer (or a partial view) is copied into a fresh, transferable
+ * ArrayBuffer so the caller's store keeps its bytes.
+ */
+function prepareSource(source: Uint8Array): {
+  buffer: ArrayBuffer | SharedArrayBuffer;
+  transfer: Transferable[];
+} {
+  const sharedAvailable = typeof SharedArrayBuffer !== 'undefined';
+  if (
+    sharedAvailable &&
+    source.buffer instanceof SharedArrayBuffer &&
+    source.byteOffset === 0 &&
+    source.byteLength === source.buffer.byteLength
+  ) {
+    // Shared by reference — no copy, the worker only reads it.
+    return { buffer: source.buffer, transfer: [] };
+  }
+  // Copy the exact bytes; transfer the copy (never the original).
+  const copy = source.slice();
+  return { buffer: copy.buffer, transfer: [copy.buffer] };
+}

--- a/apps/viewer/src/hooks/useIDS.ts
+++ b/apps/viewer/src/hooks/useIDS.ts
@@ -384,8 +384,6 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
     // Determine model ID - use '__legacy__' for legacy single-model mode
     const modelId = activeModelId || (models.size > 0 ? Array.from(models.keys())[0] : '__legacy__');
 
-    const runStart = performance.now();
-
     try {
       setIdsLoading(true);
       setIdsError(null);
@@ -413,18 +411,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
       // (per 100 entities / per spec); throttle store updates to ~8/s
       // and always pass the terminal event.
       let lastProgressUpdate = 0;
-      let firstProgressAt = 0;
-      let lastLoggedPhase = '';
       const onProgress = (p: ValidationProgress) => {
-        if (firstProgressAt === 0) {
-          firstProgressAt = performance.now();
-          console.info(`[IDS-trace] first progress @ +${(firstProgressAt - runStart).toFixed(0)}ms phase=${p.phase}`);
-        }
-        // Log only phase transitions to keep the console readable.
-        if (p.phase !== lastLoggedPhase) {
-          lastLoggedPhase = p.phase;
-          console.info(`[IDS-trace] phase → ${p.phase} @ +${(performance.now() - runStart).toFixed(0)}ms (spec ${p.specificationIndex}/${p.totalSpecifications}, ${p.percentage}%)`);
-        }
         const now = performance.now();
         if (p.phase === 'complete' || now - lastProgressUpdate >= 120) {
           lastProgressUpdate = now;
@@ -441,10 +428,8 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
       // back to in-process validation if the worker is unavailable or
       // fails (e.g. no source bytes for non-STEP models).
       const canUseWorker = idsWorkerSupported() && !!dataStore.source && dataStore.source.byteLength > 0;
-      console.info(`[IDS-trace] runValidation start: canUseWorker=${canUseWorker} (workerSupported=${idsWorkerSupported()}, hasSource=${!!dataStore.source}, sourceBytes=${dataStore.source?.byteLength ?? 0})`);
       if (canUseWorker) {
         try {
-          console.info('[IDS-trace] spawning worker…');
           validationReport = await runValidationInWorker({
             source: dataStore.source!,
             document,
@@ -454,14 +439,12 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
             includePassingEntities: true,
             onProgress,
           });
-          console.info(`[IDS-trace] worker resolved @ +${(performance.now() - runStart).toFixed(0)}ms`);
         } catch (workerErr) {
-          console.error('[IDS-trace] WORKER FAILED → falling back to main thread:', workerErr);
+          console.warn('[IDS] Worker validation failed; falling back to main thread.', workerErr);
         }
       }
 
       if (!validationReport) {
-        console.warn(`[IDS-trace] running MAIN-THREAD validation (this saturates the UI) — worker did not produce a report`);
         const accessor = createDataAccessor(dataStore, modelId);
         const modelInfo: IDSModelInfo = {
           modelId,

--- a/apps/viewer/src/hooks/useIDS.ts
+++ b/apps/viewer/src/hooks/useIDS.ts
@@ -404,19 +404,22 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
       // (per 100 entities / per spec); throttle store updates to ~8/s
       // and always pass the terminal event.
       let lastProgressUpdate = 0;
-      let progressEventCount = 0;
       let firstProgressAt = 0;
+      let lastLoggedPhase = '';
       const runStart = performance.now();
       const onProgress = (p: ValidationProgress) => {
-        progressEventCount++;
         if (firstProgressAt === 0) {
           firstProgressAt = performance.now();
-          console.info(`[IDS-trace] first progress event @ +${(firstProgressAt - runStart).toFixed(0)}ms phase=${p.phase}`);
+          console.info(`[IDS-trace] first progress @ +${(firstProgressAt - runStart).toFixed(0)}ms phase=${p.phase}`);
+        }
+        // Log only phase transitions to keep the console readable.
+        if (p.phase !== lastLoggedPhase) {
+          lastLoggedPhase = p.phase;
+          console.info(`[IDS-trace] phase → ${p.phase} @ +${(performance.now() - runStart).toFixed(0)}ms (spec ${p.specificationIndex}/${p.totalSpecifications}, ${p.percentage}%)`);
         }
         const now = performance.now();
         if (p.phase === 'complete' || now - lastProgressUpdate >= 120) {
           lastProgressUpdate = now;
-          console.info(`[IDS-trace] setIdsProgress #${progressEventCount} @ +${(now - runStart).toFixed(0)}ms phase=${p.phase} pct=${p.percentage} spec=${p.specificationIndex}/${p.totalSpecifications}`);
           setIdsProgress(p);
         }
       };
@@ -443,7 +446,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
             includePassingEntities: true,
             onProgress,
           });
-          console.info(`[IDS-trace] worker resolved @ +${(performance.now() - runStart).toFixed(0)}ms, ${progressEventCount} progress events received`);
+          console.info(`[IDS-trace] worker resolved @ +${(performance.now() - runStart).toFixed(0)}ms`);
         } catch (workerErr) {
           console.error('[IDS-trace] WORKER FAILED → falling back to main thread:', workerErr);
         }

--- a/apps/viewer/src/hooks/useIDS.ts
+++ b/apps/viewer/src/hooks/useIDS.ts
@@ -400,10 +400,19 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
 
       // Force the loading state to actually paint before spawning the
       // worker and doing any heavy synchronous work, so the spinner +
-      // initial progress bar are guaranteed on screen immediately.
-      await new Promise<void>((resolve) =>
-        requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
-      );
+      // initial progress bar are guaranteed on screen immediately. Race
+      // the frame wait against a timer so a backgrounded tab (where
+      // requestAnimationFrame is paused) can't stall the run.
+      await new Promise<void>((resolve) => {
+        let settled = false;
+        const done = () => {
+          if (settled) return;
+          settled = true;
+          resolve();
+        };
+        requestAnimationFrame(() => requestAnimationFrame(done));
+        setTimeout(done, 200);
+      });
 
       const schemaVersion = dataStore.schemaVersion || 'IFC4';
 

--- a/apps/viewer/src/hooks/useIDS.ts
+++ b/apps/viewer/src/hooks/useIDS.ts
@@ -384,6 +384,21 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
     // Determine model ID - use '__legacy__' for legacy single-model mode
     const modelId = activeModelId || (models.size > 0 ? Array.from(models.keys())[0] : '__legacy__');
 
+    const runStart = performance.now();
+    // Heartbeat: a 250ms timer that can only fire when the main thread is
+    // free. Gaps >> 250ms mean the thread was blocked (and React could not
+    // paint the progress UI). This pinpoints whether the missing progress
+    // bar is a render-starvation problem vs a data problem.
+    let lastHeartbeat = runStart;
+    const heartbeat = window.setInterval(() => {
+      const now = performance.now();
+      const gap = now - lastHeartbeat;
+      lastHeartbeat = now;
+      if (gap > 400) {
+        console.warn(`[IDS-hb] main thread STALLED ${gap.toFixed(0)}ms @ +${(now - runStart).toFixed(0)}ms — UI could not paint`);
+      }
+    }, 250);
+
     try {
       setIdsLoading(true);
       setIdsError(null);
@@ -398,6 +413,13 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
         percentage: 0,
       });
 
+      // Force the loading state to actually paint before spawning the
+      // worker and doing any heavy synchronous work, so the spinner +
+      // initial progress bar are guaranteed on screen immediately.
+      await new Promise<void>((resolve) =>
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+      );
+
       const schemaVersion = dataStore.schemaVersion || 'IFC4';
 
       // Progress events arrive far faster than React should re-render
@@ -406,7 +428,6 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
       let lastProgressUpdate = 0;
       let firstProgressAt = 0;
       let lastLoggedPhase = '';
-      const runStart = performance.now();
       const onProgress = (p: ValidationProgress) => {
         if (firstProgressAt === 0) {
           firstProgressAt = performance.now();
@@ -481,6 +502,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
       console.error('[IDS] Validation error:', err);
       return null;
     } finally {
+      window.clearInterval(heartbeat);
       setIdsLoading(false);
     }
   }, [

--- a/apps/viewer/src/hooks/useIDS.ts
+++ b/apps/viewer/src/hooks/useIDS.ts
@@ -404,10 +404,19 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
       // (per 100 entities / per spec); throttle store updates to ~8/s
       // and always pass the terminal event.
       let lastProgressUpdate = 0;
+      let progressEventCount = 0;
+      let firstProgressAt = 0;
+      const runStart = performance.now();
       const onProgress = (p: ValidationProgress) => {
+        progressEventCount++;
+        if (firstProgressAt === 0) {
+          firstProgressAt = performance.now();
+          console.info(`[IDS-trace] first progress event @ +${(firstProgressAt - runStart).toFixed(0)}ms phase=${p.phase}`);
+        }
         const now = performance.now();
         if (p.phase === 'complete' || now - lastProgressUpdate >= 120) {
           lastProgressUpdate = now;
+          console.info(`[IDS-trace] setIdsProgress #${progressEventCount} @ +${(now - runStart).toFixed(0)}ms phase=${p.phase} pct=${p.percentage} spec=${p.specificationIndex}/${p.totalSpecifications}`);
           setIdsProgress(p);
         }
       };
@@ -420,10 +429,13 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
       // already runs in a worker; this brings validation in line. Falls
       // back to in-process validation if the worker is unavailable or
       // fails (e.g. no source bytes for non-STEP models).
-      if (idsWorkerSupported() && dataStore.source && dataStore.source.byteLength > 0) {
+      const canUseWorker = idsWorkerSupported() && !!dataStore.source && dataStore.source.byteLength > 0;
+      console.info(`[IDS-trace] runValidation start: canUseWorker=${canUseWorker} (workerSupported=${idsWorkerSupported()}, hasSource=${!!dataStore.source}, sourceBytes=${dataStore.source?.byteLength ?? 0})`);
+      if (canUseWorker) {
         try {
+          console.info('[IDS-trace] spawning worker…');
           validationReport = await runValidationInWorker({
-            source: dataStore.source,
+            source: dataStore.source!,
             document,
             schemaVersion,
             modelId,
@@ -431,12 +443,14 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
             includePassingEntities: true,
             onProgress,
           });
+          console.info(`[IDS-trace] worker resolved @ +${(performance.now() - runStart).toFixed(0)}ms, ${progressEventCount} progress events received`);
         } catch (workerErr) {
-          console.warn('[IDS] Worker validation failed, falling back to main thread:', workerErr);
+          console.error('[IDS-trace] WORKER FAILED → falling back to main thread:', workerErr);
         }
       }
 
       if (!validationReport) {
+        console.warn(`[IDS-trace] running MAIN-THREAD validation (this saturates the UI) — worker did not produce a report`);
         const accessor = createDataAccessor(dataStore, modelId);
         const modelInfo: IDSModelInfo = {
           modelId,

--- a/apps/viewer/src/hooks/useIDS.ts
+++ b/apps/viewer/src/hooks/useIDS.ts
@@ -385,19 +385,6 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
     const modelId = activeModelId || (models.size > 0 ? Array.from(models.keys())[0] : '__legacy__');
 
     const runStart = performance.now();
-    // Heartbeat: a 250ms timer that can only fire when the main thread is
-    // free. Gaps >> 250ms mean the thread was blocked (and React could not
-    // paint the progress UI). This pinpoints whether the missing progress
-    // bar is a render-starvation problem vs a data problem.
-    let lastHeartbeat = runStart;
-    const heartbeat = window.setInterval(() => {
-      const now = performance.now();
-      const gap = now - lastHeartbeat;
-      lastHeartbeat = now;
-      if (gap > 400) {
-        console.warn(`[IDS-hb] main thread STALLED ${gap.toFixed(0)}ms @ +${(now - runStart).toFixed(0)}ms — UI could not paint`);
-      }
-    }, 250);
 
     try {
       setIdsLoading(true);
@@ -502,7 +489,6 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
       console.error('[IDS] Validation error:', err);
       return null;
     } finally {
-      window.clearInterval(heartbeat);
       setIdsLoading(false);
     }
   }, [

--- a/apps/viewer/src/hooks/useIDS.ts
+++ b/apps/viewer/src/hooks/useIDS.ts
@@ -38,6 +38,7 @@ import { getEntityBounds } from '@/utils/viewportUtils';
 import { getGlobalRenderer } from '@/hooks/useBCF';
 
 import { createDataAccessor } from './ids/idsDataAccessor';
+import { runValidationInWorker, idsWorkerSupported } from './ids/idsWorkerClient';
 import {
   DEFAULT_FAILED_COLOR,
   DEFAULT_PASSED_COLOR,
@@ -386,34 +387,68 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
     try {
       setIdsLoading(true);
       setIdsError(null);
+      // Paint a "starting" state immediately so the button shows work is
+      // underway before the first real progress event arrives.
+      setIdsProgress({
+        phase: 'filtering',
+        specificationIndex: 0,
+        totalSpecifications: document.specifications.length,
+        entitiesProcessed: 0,
+        totalEntities: 0,
+        percentage: 0,
+      });
 
-      // Create data accessor
-      const accessor = createDataAccessor(dataStore, modelId);
+      const schemaVersion = dataStore.schemaVersion || 'IFC4';
 
-      // Create model info
-      const modelInfo: IDSModelInfo = {
-        modelId,
-        schemaVersion: dataStore.schemaVersion || 'IFC4',
-        entityCount: dataStore.entityCount || accessor.getAllEntityIds().length,
+      // Progress events arrive far faster than React should re-render
+      // (per 100 entities / per spec); throttle store updates to ~8/s
+      // and always pass the terminal event.
+      let lastProgressUpdate = 0;
+      const onProgress = (p: ValidationProgress) => {
+        const now = performance.now();
+        if (p.phase === 'complete' || now - lastProgressUpdate >= 120) {
+          lastProgressUpdate = now;
+          setIdsProgress(p);
+        }
       };
 
-      // Run validation. Progress events arrive far faster than React
-      // should re-render (per 100 entities / per spec) — each store
-      // update re-renders every IDS subscriber, which both slowed the
-      // run and dropped the frame rate. Throttle to ~8 updates/s and
-      // always pass the terminal event.
-      let lastProgressUpdate = 0;
-      const validationReport = await validateIDS(document, accessor, modelInfo, {
-        translator,
-        onProgress: (p) => {
-          const now = performance.now();
-          if (p.phase === 'complete' || now - lastProgressUpdate >= 120) {
-            lastProgressUpdate = now;
-            setIdsProgress(p);
-          }
-        },
-        includePassingEntities: true,
-      });
+      let validationReport: IDSValidationReport | null = null;
+
+      // Preferred path: validate in a Web Worker so the whole run is off
+      // the main thread — the UI stays at full frame rate and progress
+      // actually paints. Every other heavy stage (parse, geometry)
+      // already runs in a worker; this brings validation in line. Falls
+      // back to in-process validation if the worker is unavailable or
+      // fails (e.g. no source bytes for non-STEP models).
+      if (idsWorkerSupported() && dataStore.source && dataStore.source.byteLength > 0) {
+        try {
+          validationReport = await runValidationInWorker({
+            source: dataStore.source,
+            document,
+            schemaVersion,
+            modelId,
+            locale,
+            includePassingEntities: true,
+            onProgress,
+          });
+        } catch (workerErr) {
+          console.warn('[IDS] Worker validation failed, falling back to main thread:', workerErr);
+        }
+      }
+
+      if (!validationReport) {
+        const accessor = createDataAccessor(dataStore, modelId);
+        const modelInfo: IDSModelInfo = {
+          modelId,
+          schemaVersion,
+          entityCount: dataStore.entityCount || accessor.getAllEntityIds().length,
+        };
+        validationReport = await validateIDS(document, accessor, modelInfo, {
+          translator,
+          onProgress,
+          includePassingEntities: true,
+        });
+      }
 
       setIdsValidationReport(validationReport);
 
@@ -437,6 +472,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
     models,
     activeModelId,
     translator,
+    locale,
     setIdsLoading,
     setIdsError,
     setIdsProgress,

--- a/apps/viewer/src/store/slices/idsSlice.ts
+++ b/apps/viewer/src/store/slices/idsSlice.ts
@@ -257,7 +257,12 @@ export const createIdsSlice: StateCreator<IDSSlice, [], [], IDSSlice> = (set, ge
 
   setIdsLoading: (idsLoading) => set({ idsLoading }),
 
-  setIdsError: (idsError) => set({ idsError, idsLoading: false }),
+  // Setting an error ends the run; but CLEARING the error (idsError =
+  // null, e.g. at the start of a validation run) must NOT flip loading
+  // off — doing so kept the progress UI, which is gated on `loading`,
+  // hidden for the entire run even though progress was streaming in.
+  setIdsError: (idsError) =>
+    set(idsError !== null ? { idsError, idsLoading: false } : { idsError }),
 
   setIdsLocale: (idsLocale) => set({ idsLocale }),
 

--- a/apps/viewer/src/workers/idsValidation.worker.ts
+++ b/apps/viewer/src/workers/idsValidation.worker.ts
@@ -56,21 +56,17 @@ self.onmessage = async (event: MessageEvent<IdsWorkerRequest>) => {
   const req = event.data;
   if (!req || req.type !== 'validate') return;
 
-  const t0 = performance.now();
   try {
-    console.info('[IDS-worker] validate start');
     const parser = new IfcParser();
     // The worker owns this buffer; a SAB is shared by reference, a plain
     // ArrayBuffer was copied by the caller, so parsing it here is safe.
     const store = await parser.parseColumnar(req.source);
     store.schemaVersion =
       (req.schemaVersion as typeof store.schemaVersion) || store.schemaVersion;
-    console.info(`[IDS-worker] parsed store @ +${(performance.now() - t0).toFixed(0)}ms (${store.entityCount ?? '?'} entities)`);
 
     const accessor = createDataAccessor(store);
     const translator = createTranslationService(req.locale);
 
-    let progressCount = 0;
     const report = await validateIDS(
       req.document,
       accessor,
@@ -87,20 +83,12 @@ self.onmessage = async (event: MessageEvent<IdsWorkerRequest>) => {
         // end. The worker has no UI, but cross-thread message delivery
         // still benefits from real event-loop turns.
         yieldEveryMs: 30,
-        onProgress: (progress) => {
-          progressCount++;
-          if (progressCount === 1 || progressCount % 100 === 0) {
-            console.info(`[IDS-worker] progress #${progressCount} @ +${(performance.now() - t0).toFixed(0)}ms phase=${progress.phase} pct=${progress.percentage}`);
-          }
-          post({ type: 'progress', id: req.id, progress });
-        },
+        onProgress: (progress) => post({ type: 'progress', id: req.id, progress }),
       }
     );
-    console.info(`[IDS-worker] validate complete @ +${(performance.now() - t0).toFixed(0)}ms, ${progressCount} progress events posted`);
 
     post({ type: 'complete', id: req.id, report });
   } catch (err) {
-    console.error('[IDS-worker] validate FAILED:', err);
     post({
       type: 'error',
       id: req.id,

--- a/apps/viewer/src/workers/idsValidation.worker.ts
+++ b/apps/viewer/src/workers/idsValidation.worker.ts
@@ -1,0 +1,96 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * IDS validation worker.
+ *
+ * IDS validation is pure CPU work over the whole entity population — on
+ * the main thread it pins the UI (no progress paints, frame rate
+ * collapses) exactly like an unworkered parse would. Every other heavy
+ * stage in this viewer (STEP parse, geometry) already runs in a worker;
+ * this brings validation in line.
+ *
+ * The worker re-parses the IFC source bytes (~150ms for a 550k-entity
+ * model — negligible next to validation) into its own IfcDataStore so
+ * the main-thread store is never touched, then runs the shared
+ * `@ifc-lite/ids` validator with the canonical bridge accessor. The IDS
+ * XML is parsed on the main thread (workers have no DOMParser) and the
+ * plain IDSDocument is handed across; progress is streamed back as it
+ * happens.
+ */
+
+import { IfcParser } from '@ifc-lite/parser';
+import {
+  validateIDS,
+  createTranslationService,
+  type IDSDocument,
+  type IDSValidationReport,
+  type ValidationProgress,
+} from '@ifc-lite/ids';
+import { createDataAccessor } from '@ifc-lite/ids/bridge';
+
+export interface IdsWorkerRequest {
+  type: 'validate';
+  id: number;
+  /** Raw IFC/STEP bytes — a SharedArrayBuffer is shared zero-copy. */
+  source: ArrayBuffer | SharedArrayBuffer;
+  /** IDS document already parsed on the main thread (no DOMParser here). */
+  document: IDSDocument;
+  schemaVersion: string;
+  modelId: string;
+  locale: 'en' | 'de' | 'fr';
+  includePassingEntities: boolean;
+}
+
+export type IdsWorkerResponse =
+  | { type: 'progress'; id: number; progress: ValidationProgress }
+  | { type: 'complete'; id: number; report: IDSValidationReport }
+  | { type: 'error'; id: number; message: string };
+
+const post = (msg: IdsWorkerResponse) => {
+  (self as unknown as Worker).postMessage(msg);
+};
+
+self.onmessage = async (event: MessageEvent<IdsWorkerRequest>) => {
+  const req = event.data;
+  if (!req || req.type !== 'validate') return;
+
+  try {
+    const parser = new IfcParser();
+    // The worker owns this buffer; a SAB is shared by reference, a plain
+    // ArrayBuffer was copied by the caller, so parsing it here is safe.
+    const store = await parser.parseColumnar(req.source);
+    store.schemaVersion =
+      (req.schemaVersion as typeof store.schemaVersion) || store.schemaVersion;
+
+    const accessor = createDataAccessor(store);
+    const translator = createTranslationService(req.locale);
+
+    const report = await validateIDS(
+      req.document,
+      accessor,
+      {
+        modelId: req.modelId,
+        schemaVersion: store.schemaVersion,
+        entityCount: store.entityCount ?? accessor.getAllEntityIds().length,
+      },
+      {
+        translator,
+        includePassingEntities: req.includePassingEntities,
+        // In a worker the event loop is ours alone — no main-thread
+        // paint to protect — so don't pay the yield overhead.
+        yieldEveryMs: Number.POSITIVE_INFINITY,
+        onProgress: (progress) => post({ type: 'progress', id: req.id, progress }),
+      }
+    );
+
+    post({ type: 'complete', id: req.id, report });
+  } catch (err) {
+    post({
+      type: 'error',
+      id: req.id,
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+};

--- a/apps/viewer/src/workers/idsValidation.worker.ts
+++ b/apps/viewer/src/workers/idsValidation.worker.ts
@@ -56,17 +56,21 @@ self.onmessage = async (event: MessageEvent<IdsWorkerRequest>) => {
   const req = event.data;
   if (!req || req.type !== 'validate') return;
 
+  const t0 = performance.now();
   try {
+    console.info('[IDS-worker] validate start');
     const parser = new IfcParser();
     // The worker owns this buffer; a SAB is shared by reference, a plain
     // ArrayBuffer was copied by the caller, so parsing it here is safe.
     const store = await parser.parseColumnar(req.source);
     store.schemaVersion =
       (req.schemaVersion as typeof store.schemaVersion) || store.schemaVersion;
+    console.info(`[IDS-worker] parsed store @ +${(performance.now() - t0).toFixed(0)}ms (${store.entityCount ?? '?'} entities)`);
 
     const accessor = createDataAccessor(store);
     const translator = createTranslationService(req.locale);
 
+    let progressCount = 0;
     const report = await validateIDS(
       req.document,
       accessor,
@@ -78,15 +82,25 @@ self.onmessage = async (event: MessageEvent<IdsWorkerRequest>) => {
       {
         translator,
         includePassingEntities: req.includePassingEntities,
-        // In a worker the event loop is ours alone — no main-thread
-        // paint to protect — so don't pay the yield overhead.
-        yieldEveryMs: Number.POSITIVE_INFINITY,
-        onProgress: (progress) => post({ type: 'progress', id: req.id, progress }),
+        // Yield periodically so progress postMessages flush to the main
+        // thread incrementally instead of arriving in one burst at the
+        // end. The worker has no UI, but cross-thread message delivery
+        // still benefits from real event-loop turns.
+        yieldEveryMs: 30,
+        onProgress: (progress) => {
+          progressCount++;
+          if (progressCount === 1 || progressCount % 100 === 0) {
+            console.info(`[IDS-worker] progress #${progressCount} @ +${(performance.now() - t0).toFixed(0)}ms phase=${progress.phase} pct=${progress.percentage}`);
+          }
+          post({ type: 'progress', id: req.id, progress });
+        },
       }
     );
+    console.info(`[IDS-worker] validate complete @ +${(performance.now() - t0).toFixed(0)}ms, ${progressCount} progress events posted`);
 
     post({ type: 'complete', id: req.id, report });
   } catch (err) {
+    console.error('[IDS-worker] validate FAILED:', err);
     post({
       type: 'error',
       id: req.id,

--- a/packages/ids/src/facets/entity-facet.ts
+++ b/packages/ids/src/facets/entity-facet.ts
@@ -154,6 +154,68 @@ export function checkEntityFacet(
 }
 
 /**
+ * Diagnostics-free verdict for an entity facet — the exact `passed`
+ * boolean `checkEntityFacet` would compute, without allocating failure
+ * objects or display strings. Applicability filtering runs this against
+ * every candidate entity for every specification and reads ONLY the
+ * boolean, so the diagnostic work was pure waste (~86% of validation
+ * time on code-list IDS packs).
+ *
+ * Any semantic change to `checkEntityFacet` MUST be mirrored here; the
+ * differential test in validation-scale.test.ts pins the equivalence.
+ */
+export function entityFacetPasses(
+  facet: IDSEntityFacet,
+  expressId: number,
+  accessor: IFCDataAccessor
+): boolean {
+  const entityType = accessor.getEntityType(expressId);
+  if (!entityType) return false;
+
+  // Mixed-case simpleValue literals are malformed authoring — rejected
+  // outright (mirrors checkEntityFacet).
+  if (
+    facet.name.type === 'simpleValue' &&
+    facet.name.value !== facet.name.value.toUpperCase()
+  ) {
+    return false;
+  }
+
+  if (!matchConstraint(facet.name, entityType, IFC_CASE_INSENSITIVE)) {
+    return false;
+  }
+
+  if (facet.predefinedType) {
+    const rawType = accessor.getPredefinedTypeRaw?.(expressId);
+    const userDefinedType = accessor.getObjectType(expressId);
+
+    if (!rawType && !userDefinedType) return false;
+
+    if (rawType && matchConstraint(facet.predefinedType, rawType)) {
+      return true;
+    }
+    if (
+      rawType === 'USERDEFINED' &&
+      userDefinedType &&
+      userDefinedType !== rawType &&
+      matchConstraint(facet.predefinedType, userDefinedType)
+    ) {
+      return true;
+    }
+    if (
+      !rawType &&
+      userDefinedType &&
+      matchConstraint(facet.predefinedType, userDefinedType)
+    ) {
+      return true;
+    }
+    return false;
+  }
+
+  return true;
+}
+
+/**
  * Get candidate entity IDs that might match an entity facet (broadphase filter)
  */
 export function filterByEntityFacet(

--- a/packages/ids/src/facets/index.ts
+++ b/packages/ids/src/facets/index.ts
@@ -18,9 +18,9 @@ import type {
   IDSFailureDetail,
 } from '../types.js';
 
-import { checkEntityFacet, filterByEntityFacet } from './entity-facet.js';
+import { checkEntityFacet, filterByEntityFacet, entityFacetPasses } from './entity-facet.js';
 import { checkAttributeFacet } from './attribute-facet.js';
-import { checkPropertyFacet } from './property-facet.js';
+import { checkPropertyFacet, propertyFacetPasses } from './property-facet.js';
 import { checkClassificationFacet } from './classification-facet.js';
 import { checkMaterialFacet } from './material-facet.js';
 import { checkPartOfFacet } from './partof-facet.js';
@@ -77,6 +77,29 @@ export function checkFacet(
           actual: (facet as IDSFacet).type,
         },
       };
+  }
+}
+
+/**
+ * Diagnostics-free verdict for a facet — the exact `passed` boolean
+ * `checkFacet` would compute, without allocating failure objects or
+ * display strings. Entity and property facets (the ones applicability
+ * filtering hammers — every candidate entity × every specification)
+ * have dedicated string-free cores; the remaining facet types fall back
+ * to the full checker.
+ */
+export function facetPasses(
+  facet: IDSFacet,
+  expressId: number,
+  accessor: IFCDataAccessor
+): boolean {
+  switch (facet.type) {
+    case 'entity':
+      return entityFacetPasses(facet, expressId, accessor);
+    case 'property':
+      return propertyFacetPasses(facet, expressId, accessor);
+    default:
+      return checkFacet(facet, expressId, accessor).passed;
   }
 }
 

--- a/packages/ids/src/facets/property-facet.ts
+++ b/packages/ids/src/facets/property-facet.ts
@@ -57,6 +57,103 @@ function qualifiedPropertyNames(pset: PropertySetInfo): string {
 }
 
 /**
+ * Per-literal XSD-cast gate cache. `literalCastsUnderAnyType` parses the
+ * IDS literal against the XSD types of the stored measure on every
+ * check; the outcome depends only on (literal, measure name).
+ */
+const CAST_GATE_CACHE = new WeakMap<object, Map<string, boolean>>();
+
+function passesCastGate(
+  value: { value: string },
+  dataType: string | undefined
+): boolean {
+  let byType = CAST_GATE_CACHE.get(value);
+  if (!byType) {
+    byType = new Map();
+    CAST_GATE_CACHE.set(value, byType);
+  }
+  const key = dataType ?? '';
+  let passes = byType.get(key);
+  if (passes === undefined) {
+    const xsdTypes = ifcMeasureToXsdTypes(dataType);
+    passes = xsdTypes.length === 0 || literalCastsUnderAnyType(value.value, xsdTypes);
+    byType.set(key, passes);
+  }
+  return passes;
+}
+
+/**
+ * Diagnostics-free verdict for a single property — the exact `passed`
+ * boolean `checkSingleProperty` would compute.
+ */
+function singlePropertyPasses(
+  facet: IDSPropertyFacet,
+  prop: PropertySetInfo['properties'][number]
+): boolean {
+  // "No value" fails any check, including existence-only ones.
+  if (prop.value === null || prop.value === undefined || prop.value === '') {
+    return false;
+  }
+
+  if (facet.dataType && prop.dataType) {
+    if (!matchConstraint(facet.dataType, prop.dataType, DATATYPE_OPTS)) {
+      return false;
+    }
+  }
+
+  if (facet.value) {
+    if (facet.value.type === 'simpleValue' && !passesCastGate(facet.value, prop.dataType)) {
+      return false;
+    }
+    const candidateValues =
+      prop.values && prop.values.length > 0 ? prop.values : [prop.value];
+    return candidateValues.some((v) => matchConstraint(facet.value!, v));
+  }
+
+  return true;
+}
+
+/**
+ * Diagnostics-free verdict for a property facet — the exact `passed`
+ * boolean `checkPropertyFacet` would compute, with zero failure-object
+ * or display-string allocation. Used by applicability filtering, which
+ * evaluates this for every candidate entity per specification and
+ * consumes ONLY the boolean.
+ *
+ * Pass/fail semantics mirrored from `checkPropertyFacet`: at least one
+ * pset must match the propertySet constraint, and EVERY matching pset
+ * must contain at least one baseName-matching property with ALL
+ * matching properties satisfying the value/dataType constraints. Any
+ * semantic change there MUST be mirrored here; the differential test in
+ * validation-scale.test.ts pins the equivalence.
+ */
+export function propertyFacetPasses(
+  facet: IDSPropertyFacet,
+  expressId: number,
+  accessor: IFCDataAccessor
+): boolean {
+  const propertySets = accessor.getPropertySets(expressId);
+  if (propertySets.length === 0) return false;
+
+  let anyMatchingPset = false;
+
+  for (const pset of propertySets) {
+    if (!matchConstraint(facet.propertySet, pset.name)) continue;
+    anyMatchingPset = true;
+
+    let anyMatchingProp = false;
+    for (const prop of pset.properties) {
+      if (!matchConstraint(facet.baseName, prop.name)) continue;
+      anyMatchingProp = true;
+      if (!singlePropertyPasses(facet, prop)) return false;
+    }
+    if (!anyMatchingProp) return false;
+  }
+
+  return anyMatchingPset;
+}
+
+/**
  * Check if an entity matches a property facet
  */
 export function checkPropertyFacet(

--- a/packages/ids/src/parser/xml-parser.ts
+++ b/packages/ids/src/parser/xml-parser.ts
@@ -49,11 +49,24 @@ export class IDSParseError extends Error {
 // hidden behind a runtime-computed specifier so browser bundlers don't pull
 // xmldom into the client bundle.
 type DOMParserCtor = new () => { parseFromString(input: string, mime: string): Document };
+
+// Only Node needs the xmldom fallback. A browser WORKER has no DOMParser
+// either, but it also never parses IDS (the main thread does, where
+// DOMParser exists) — and attempting `import('@xmldom/xmldom')` there
+// throws "bare specifier was not remapped" because the Node-only package
+// isn't in the browser bundle. Gate the fallback to the Node runtime so
+// merely importing this module (e.g. for `validateIDS` inside a worker)
+// never triggers it. Workers have no `process.versions.node`.
+const nodeProcess = (globalThis as {
+  process?: { versions?: { node?: string } };
+}).process;
+const isNodeRuntime = !!nodeProcess?.versions?.node;
+
 let DOMParserImpl: DOMParserCtor | null =
   typeof globalThis !== 'undefined' && typeof (globalThis as { DOMParser?: DOMParserCtor }).DOMParser === 'function'
     ? ((globalThis as { DOMParser?: DOMParserCtor }).DOMParser as DOMParserCtor)
     : null;
-if (!DOMParserImpl) {
+if (!DOMParserImpl && isNodeRuntime) {
   const moduleName = '@xmldom/xmldom';
   const xmldom = (await import(/* @vite-ignore */ moduleName)) as { DOMParser: DOMParserCtor };
   DOMParserImpl = xmldom.DOMParser;

--- a/packages/ids/src/validation/property-index.ts
+++ b/packages/ids/src/validation/property-index.ts
@@ -1,0 +1,171 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Inverted property-value index for applicability filtering.
+ *
+ * Code-list IDS packs are hundreds of specifications that differ only
+ * in one property literal (e.g. `Pset_CodeList.04 CommonName == "X"`).
+ * Evaluating those per entity per specification is O(specs × entities ×
+ * psets); semantically the whole pack is ONE group-by over
+ * (pset, prop) → value → entityIds. This index materialises exactly
+ * that, restricted to the (pset, prop) keys the document actually uses.
+ *
+ * Correctness model: lookups return a candidate SUPERSET, never a final
+ * verdict — the validator confirms every candidate with the boolean
+ * facet core afterwards. The index may therefore be conservative (the
+ * `hasProp` fallback) wherever exact-value bucketing can't mirror
+ * matchConstraint semantics (numeric/boolean-coercible literals,
+ * pattern/bounds constraints, existence checks).
+ */
+
+import type {
+  IDSDocument,
+  IDSPropertyFacet,
+  IFCDataAccessor,
+} from '../types.js';
+import {
+  isStrictNumericLiteral,
+  isBooleanLiteral,
+} from '../constraints/comparators.js';
+
+const KEY_SEP = '\u0000';
+
+function isCoercible(literal: string): boolean {
+  return isStrictNumericLiteral(literal) || isBooleanLiteral(literal);
+}
+
+/** Indexable = simpleValue pset + baseName whose literals can only
+ * match by exact string equality (non-coercible names). */
+function indexKeyFor(facet: IDSPropertyFacet): string | undefined {
+  if (facet.propertySet.type !== 'simpleValue') return undefined;
+  if (facet.baseName.type !== 'simpleValue') return undefined;
+  if (isCoercible(facet.propertySet.value) || isCoercible(facet.baseName.value)) {
+    return undefined;
+  }
+  return facet.propertySet.value + KEY_SEP + facet.baseName.value;
+}
+
+export class ApplicabilityPropertyIndex {
+  /** (pset␀prop) keys the document's applicability facets need. */
+  private readonly keys = new Set<string>();
+  /** Entities already folded into the buckets. */
+  private readonly indexed = new Set<number>();
+  /** key → entityIds that carry the property at all (any value). */
+  private readonly hasProp = new Map<string, Set<number>>();
+  /** key → value string → entityIds. */
+  private readonly byValue = new Map<string, Map<string, Set<number>>>();
+
+  constructor(
+    private readonly accessor: IFCDataAccessor,
+    document: IDSDocument
+  ) {
+    for (const spec of document.specifications) {
+      for (const facet of spec.applicability.facets) {
+        if (facet.type !== 'property') continue;
+        const key = indexKeyFor(facet);
+        if (key !== undefined) this.keys.add(key);
+      }
+    }
+  }
+
+  /**
+   * Fold the given entities into the index (each entity at most once
+   * per run). Cost is one cached-pset walk per new entity — the same
+   * walk a single per-entity facet check pays today.
+   */
+  private async ensureIndexed(
+    entityIds: number[],
+    maybeYield: () => Promise<void> | undefined
+  ): Promise<void> {
+    if (this.keys.size === 0) return;
+    for (let i = 0; i < entityIds.length; i++) {
+      const id = entityIds[i];
+      if (this.indexed.has(id)) continue;
+      this.indexed.add(id);
+      // The first fold-in over a large candidate set is real CPU work
+      // (pset extraction per entity) — keep the host UI painting.
+      if ((i & 255) === 0) await maybeYield();
+
+      const psets = this.accessor.getPropertySets(id);
+      for (const pset of psets) {
+        for (const prop of pset.properties) {
+          const key = pset.name + KEY_SEP + prop.name;
+          if (!this.keys.has(key)) continue;
+
+          let has = this.hasProp.get(key);
+          if (!has) {
+            has = new Set();
+            this.hasProp.set(key, has);
+          }
+          has.add(id);
+
+          const candidateValues =
+            prop.values && prop.values.length > 0 ? prop.values : [prop.value];
+          let valueMap = this.byValue.get(key);
+          if (!valueMap) {
+            valueMap = new Map();
+            this.byValue.set(key, valueMap);
+          }
+          for (const v of candidateValues) {
+            if (v === null || v === undefined || v === '') continue;
+            const valueKey = String(v);
+            let bucket = valueMap.get(valueKey);
+            if (!bucket) {
+              bucket = new Set();
+              valueMap.set(valueKey, bucket);
+            }
+            bucket.add(id);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Narrow `candidates` to a superset of the entities that can pass
+   * `facet`. Returns undefined when the facet isn't indexable — the
+   * caller keeps the full candidate list.
+   */
+  async narrow(
+    facet: IDSPropertyFacet,
+    candidates: number[],
+    maybeYield: () => Promise<void> | undefined
+  ): Promise<number[] | undefined> {
+    const key = indexKeyFor(facet);
+    if (key === undefined || !this.keys.has(key)) return undefined;
+
+    await this.ensureIndexed(candidates, maybeYield);
+
+    const value = facet.value;
+    let superset: Set<number> | undefined;
+
+    if (value && value.type === 'simpleValue' && !isCoercible(value.value)) {
+      // Exact-string bucket. Coercible literals ('42', 'true') can also
+      // match stored values via numeric/boolean comparison, so they get
+      // the conservative hasProp superset below instead.
+      superset = this.byValue.get(key)?.get(value.value) ?? new Set();
+    } else if (
+      value &&
+      value.type === 'enumeration' &&
+      !value.values.some(isCoercible)
+    ) {
+      const valueMap = this.byValue.get(key);
+      superset = new Set();
+      if (valueMap) {
+        for (const v of value.values) {
+          const bucket = valueMap.get(v);
+          if (bucket) for (const id of bucket) superset.add(id);
+        }
+      }
+    } else {
+      // Existence check, dataType-only, pattern/bounds values, or
+      // coercible literals: any entity carrying the property at all.
+      superset = this.hasProp.get(key) ?? new Set();
+    }
+
+    if (superset.size === 0) return [];
+    return candidates.filter((id) => superset!.has(id));
+  }
+}

--- a/packages/ids/src/validation/property-index.ts
+++ b/packages/ids/src/validation/property-index.ts
@@ -77,16 +77,28 @@ export class ApplicabilityPropertyIndex {
    */
   private async ensureIndexed(
     entityIds: number[],
-    maybeYield: () => Promise<void> | undefined
+    maybeYield: () => Promise<void> | undefined,
+    onScanProgress?: (processed: number, total: number) => void
   ): Promise<void> {
     if (this.keys.size === 0) return;
+    // Only the first fold-in over a large candidate set does real work
+    // (cold property extraction); count how many are actually new so the
+    // progress reporter reflects the entities being scanned, not cache
+    // hits.
+    let newCount = 0;
     for (let i = 0; i < entityIds.length; i++) {
       const id = entityIds[i];
       if (this.indexed.has(id)) continue;
       this.indexed.add(id);
+      newCount++;
       // The first fold-in over a large candidate set is real CPU work
-      // (pset extraction per entity) — keep the host UI painting.
-      if ((i & 255) === 0) await maybeYield();
+      // (pset extraction per entity) — keep the host UI painting and
+      // report granular progress, since this is the slowest phase of a
+      // large validation run.
+      if ((newCount & 511) === 0) {
+        onScanProgress?.(i + 1, entityIds.length);
+        await maybeYield();
+      }
 
       const psets = this.accessor.getPropertySets(id);
       for (const pset of psets) {
@@ -131,12 +143,13 @@ export class ApplicabilityPropertyIndex {
   async narrow(
     facet: IDSPropertyFacet,
     candidates: number[],
-    maybeYield: () => Promise<void> | undefined
+    maybeYield: () => Promise<void> | undefined,
+    onScanProgress?: (processed: number, total: number) => void
   ): Promise<number[] | undefined> {
     const key = indexKeyFor(facet);
     if (key === undefined || !this.keys.has(key)) return undefined;
 
-    await this.ensureIndexed(candidates, maybeYield);
+    await this.ensureIndexed(candidates, maybeYield, onScanProgress);
 
     const value = facet.value;
     let superset: Set<number> | undefined;

--- a/packages/ids/src/validation/validation-scale.test.ts
+++ b/packages/ids/src/validation/validation-scale.test.ts
@@ -22,6 +22,7 @@
 
 import { validateIDS, createCachedAccessor } from './validator.js';
 import { createMockAccessor } from '../facets/test-helpers.js';
+import { checkFacet, facetPasses } from '../facets/index.js';
 import { formatConstraint, matchConstraint, getConstraintMismatchReason } from '../constraints/index.js';
 import type {
   IDSDocument,
@@ -29,6 +30,7 @@ import type {
   IDSModelInfo,
   IDSSimpleValue,
   IDSEnumerationConstraint,
+  IDSFacet,
   IFCDataAccessor,
   TranslationService,
 } from '../types.js';
@@ -245,6 +247,134 @@ describe('validateIDS — yields to the event loop during validation', () => {
     // 20k candidates at 8192 granularity → events at 0, 8192, 16384.
     expect(filteringEvents.length).toBeGreaterThanOrEqual(2);
     expect(Math.max(...filteringEvents)).toBeGreaterThan(8000);
+  });
+});
+
+describe('facetPasses — differential parity with checkFacet().passed', () => {
+  // Entities covering the decision points of the entity and property
+  // facet checkers: missing psets, missing props, empty values, value
+  // mismatches, dataType gates, multi-valued props, predefined types.
+  const entities = [
+    { expressId: 1, type: 'IfcPump', name: 'P1', properties: [
+      { psetName: 'Pset_CodeList', propName: 'CommonName', value: 'Pump' },
+      { psetName: 'Pset_CodeList', propName: 'Code', value: 'K-1' },
+    ] },
+    { expressId: 2, type: 'IfcPump', name: 'P2', properties: [
+      { psetName: 'Pset_CodeList', propName: 'CommonName', value: 'Valve' },
+    ] },
+    { expressId: 3, type: 'IfcPump', name: 'P3', properties: [
+      { psetName: 'Pset_CodeList', propName: 'CommonName', value: '' },
+    ] },
+    { expressId: 4, type: 'IfcValve', name: 'V1', properties: [
+      { psetName: 'Pset_Other', propName: 'CommonName', value: 'Pump' },
+    ] },
+    { expressId: 5, type: 'IfcValve', name: 'V2' },
+    { expressId: 6, type: 'IfcPump', name: 'P4', objectType: 'SpecialPump', properties: [
+      { psetName: 'Pset_CodeList', propName: 'CommonName', value: 42, dataType: 'IFCINTEGER' },
+    ] },
+    // Duplicate pset name where one copy lacks the property entirely.
+    { expressId: 7, type: 'IfcPump', name: 'P5', properties: [
+      { psetName: 'Pset_CodeList', propName: 'CommonName', value: 'Pump' },
+      { psetName: 'Pset_CodeList2', propName: 'Other', value: 'x' },
+    ] },
+  ];
+
+  const sv2 = sv;
+  const facets: IDSFacet[] = [
+    { type: 'entity', name: sv2('IFCPUMP') },
+    { type: 'entity', name: sv2('IfcPump') }, // malformed mixed-case literal
+    { type: 'entity', name: { type: 'enumeration', values: ['IFCPUMP', 'IFCVALVE'] } },
+    { type: 'entity', name: sv2('IFCPUMP'), predefinedType: sv2('SpecialPump') },
+    { type: 'property', propertySet: sv2('Pset_CodeList'), baseName: sv2('CommonName') },
+    { type: 'property', propertySet: sv2('Pset_CodeList'), baseName: sv2('CommonName'), value: sv2('Pump') },
+    { type: 'property', propertySet: sv2('Pset_CodeList'), baseName: sv2('CommonName'), value: sv2('42') },
+    { type: 'property', propertySet: sv2('Pset_CodeList'), baseName: sv2('CommonName'), value: sv2('42.5') },
+    { type: 'property', propertySet: sv2('Pset_CodeList'), baseName: sv2('CommonName'), dataType: sv2('IFCINTEGER') },
+    { type: 'property', propertySet: sv2('Pset_CodeList'), baseName: sv2('MissingProp') },
+    { type: 'property', propertySet: { type: 'pattern', pattern: 'FI_.*' }, baseName: sv2('CommonName') },
+    { type: 'property', propertySet: sv2('Pset_CodeList'), baseName: sv2('CommonName'), value: { type: 'enumeration', values: ['Pump', 'Valve'] } },
+    { type: 'property', propertySet: sv2('Pset_DoesNotExist'), baseName: sv2('CommonName') },
+  ];
+
+  it('agrees with the diagnostics-producing checker for every facet × entity', () => {
+    const accessor = createMockAccessor(entities);
+    for (const facet of facets) {
+      for (const e of entities) {
+        const full = checkFacet(facet, e.expressId, accessor).passed;
+        const fast = facetPasses(facet, e.expressId, accessor);
+        expect(fast, `facet ${JSON.stringify(facet)} entity #${e.expressId}`).toBe(full);
+      }
+    }
+  });
+});
+
+describe('validateIDS — index-assisted applicability stays verdict-identical', () => {
+  it('matches numerically-coercible literals the exact-string bucket cannot see', async () => {
+    // Stored numeric 42 must match the IDS literal '42.0' through the
+    // numeric comparator. An exact-string index bucket would miss it —
+    // the index must route coercible literals to the conservative path.
+    const accessor = createMockAccessor([
+      { expressId: 1, type: 'IfcPump', name: 'P1', properties: [
+        { psetName: 'Pset_CodeList', propName: 'Size', value: 42, dataType: 'IFCREAL' },
+      ] },
+      { expressId: 2, type: 'IfcPump', name: 'P2', properties: [
+        { psetName: 'Pset_CodeList', propName: 'Size', value: 7, dataType: 'IFCREAL' },
+      ] },
+    ]);
+
+    const spec: IDSSpecification = {
+      id: 'spec-0',
+      name: 'Coercible literal',
+      ifcVersions: ['IFC4'],
+      applicability: {
+        facets: [
+          {
+            type: 'property',
+            propertySet: sv('Pset_CodeList'),
+            baseName: sv('Size'),
+            value: sv('42.0'),
+          },
+        ],
+      },
+      requirements: [],
+      minOccurs: 0,
+    };
+
+    const report = await validateIDS(makeDoc([spec]), accessor, modelInfo);
+    expect(report.specificationResults[0].applicableCount).toBe(1);
+  });
+
+  it('narrows enumeration values without changing the applicable set', async () => {
+    const entities = Array.from({ length: 50 }, (_, i) => ({
+      expressId: i + 1,
+      type: 'IfcPump',
+      name: `P${i + 1}`,
+      properties: [
+        { psetName: 'Pset_CodeList', propName: 'CommonName', value: i % 5 === 0 ? 'Pump' : `Other_${i}` },
+      ],
+    }));
+    const accessor = createMockAccessor(entities);
+
+    const spec: IDSSpecification = {
+      id: 'spec-0',
+      name: 'Enum narrow',
+      ifcVersions: ['IFC4'],
+      applicability: {
+        facets: [
+          {
+            type: 'property',
+            propertySet: sv('Pset_CodeList'),
+            baseName: sv('CommonName'),
+            value: { type: 'enumeration', values: ['Pump', 'Missing_Value'] },
+          },
+        ],
+      },
+      requirements: [],
+      minOccurs: 0,
+    };
+
+    const report = await validateIDS(makeDoc([spec]), accessor, modelInfo);
+    expect(report.specificationResults[0].applicableCount).toBe(10);
   });
 });
 

--- a/packages/ids/src/validation/validator.ts
+++ b/packages/ids/src/validation/validator.ts
@@ -409,7 +409,18 @@ async function findApplicableEntities(
   // source of truth, so index conservatism can never change verdicts.
   for (const facet of applicabilityFacets) {
     if (facet.type !== 'property') continue;
-    const narrowed = await propertyIndex.narrow(facet, candidateIds, maybeYield);
+    // Building the index over a spec's candidates is the slowest phase of
+    // a large run (cold property extraction) — surface its progress so
+    // the host UI advances during it instead of sitting frozen.
+    const narrowed = await propertyIndex.narrow(
+      facet,
+      candidateIds,
+      maybeYield,
+      onProgress
+        ? (processed, total) =>
+            onProgress({ phase: 'filtering', entitiesProcessed: processed, totalEntities: total })
+        : undefined
+    );
     if (narrowed !== undefined) candidateIds = narrowed;
   }
 

--- a/packages/ids/src/validation/validator.ts
+++ b/packages/ids/src/validation/validator.ts
@@ -24,8 +24,9 @@ import type {
   TranslationService,
   PartOfRelation,
 } from '../types.js';
-import { checkFacet, filterByFacet, type FacetCheckResult } from '../facets/index.js';
+import { checkFacet, facetPasses, filterByFacet, type FacetCheckResult } from '../facets/index.js';
 import { formatConstraint } from '../constraints/index.js';
+import { ApplicabilityPropertyIndex } from './property-index.js';
 
 /** Memoize a single-argument accessor lookup keyed by express ID. */
 function memoById<T>(fn: (expressId: number) => T): (expressId: number) => T {
@@ -189,6 +190,7 @@ export async function validateIDS(
   const cachedAccessor = createCachedAccessor(accessor);
   const descriptionCache: DescriptionCache = new Map();
   const maybeYield = createYielder(options.yieldEveryMs ?? 40);
+  const propertyIndex = new ApplicabilityPropertyIndex(cachedAccessor, document);
 
   const specificationResults: IDSSpecificationResult[] = [];
   const totalSpecs = document.specifications.length;
@@ -219,6 +221,7 @@ export async function validateIDS(
       options,
       descriptionCache,
       maybeYield,
+      propertyIndex,
       (progress) => {
         if (onProgress) {
           onProgress({
@@ -271,13 +274,14 @@ async function validateSpecification(
   options: ValidatorOptions,
   descriptionCache: DescriptionCache,
   maybeYield: MaybeYield,
+  propertyIndex: ApplicabilityPropertyIndex,
   onProgress?: (progress: Omit<ValidationProgress, 'specificationIndex' | 'totalSpecifications' | 'percentage'>) => void
 ): Promise<IDSSpecificationResult> {
   const { translator, maxEntities, includePassingEntities = true } = options;
   const modelId = modelInfo.modelId;
 
   // Phase 1: Find applicable entities
-  const applicableIds = await findApplicableEntities(spec, accessor, maybeYield, onProgress);
+  const applicableIds = await findApplicableEntities(spec, accessor, maybeYield, propertyIndex, onProgress);
 
   // Apply max entities limit if specified
   const idsToCheck = maxEntities
@@ -374,6 +378,7 @@ async function findApplicableEntities(
   spec: IDSSpecification,
   accessor: IFCDataAccessor,
   maybeYield: MaybeYield,
+  propertyIndex: ApplicabilityPropertyIndex,
   onProgress?: (progress: Omit<ValidationProgress, 'specificationIndex' | 'totalSpecifications' | 'percentage'>) => void
 ): Promise<number[]> {
   const applicabilityFacets = spec.applicability.facets;
@@ -398,6 +403,16 @@ async function findApplicableEntities(
     candidateIds = accessor.getAllEntityIds();
   }
 
+  // Index-assisted narrowing: property facets with literal pset/name
+  // collapse to inverted-index lookups (built once per run). The result
+  // is a candidate SUPERSET — the confirmation loop below remains the
+  // source of truth, so index conservatism can never change verdicts.
+  for (const facet of applicabilityFacets) {
+    if (facet.type !== 'property') continue;
+    const narrowed = await propertyIndex.narrow(facet, candidateIds, maybeYield);
+    if (narrowed !== undefined) candidateIds = narrowed;
+  }
+
   // Filter candidates by all applicability facets. With property-only
   // applicability the candidate set is the whole model, so this scan is
   // where large runs spend most of their time — report progress and
@@ -420,8 +435,11 @@ async function findApplicableEntities(
     let matches = true;
 
     for (const facet of applicabilityFacets) {
-      const result = checkFacet(facet, expressId, accessor);
-      if (!result.passed) {
+      // Boolean-only check: this loop runs per candidate entity per
+      // specification and only ever needs the verdict — the failure
+      // diagnostics the full checker builds for every miss used to
+      // dominate whole-run CPU.
+      if (!facetPasses(facet, expressId, accessor)) {
         matches = false;
         break;
       }


### PR DESCRIPTION
Stacked on #1055. Makes IDS validation fast **and** gives it a working progress UI in the viewer.

## Why

After #1055's caching, ~86% of remaining validation CPU built failure-diagnostic objects for ~8M applicability *misses* whose only consumer is a boolean. And in the viewer, validation ran on the main thread (unlike parse/geometry, which run in workers) so the UI couldn't paint progress. Prior art confirms the architecture, not the language, is the fix: IfcOpenShell's ifctester gained ~4600x on its applicability broadphase and Xbim validates the same packs 'in seconds' by producing diagnostics only after selection and inverting property applicability to the pset side.

## What

**Performance (packages/ids):**
- `facetPasses()` — diagnostics-free boolean cores for entity + property facets, pinned to `checkFacet().passed` by a differential test.
- `ApplicabilityPropertyIndex` — per-run inverted `(pset, prop) -> value -> entityIds` index; lookups are a candidate **superset** always re-confirmed by the boolean core, so verdicts can't change.
- Bounded enumeration strings, memoized constraint formatting, comparator fast-paths.

**Off-main-thread (apps/viewer):**
- `idsValidation.worker.ts` re-parses the model source bytes (~150ms) into its own store and runs the shared validator off the main thread; `idsWorkerClient.ts` shares the SAB source zero-copy and streams progress via `postMessage`. Falls back to in-process validation when unavailable. IDS XML is parsed on the main thread (workers have no DOMParser) — and `xml-parser.ts` now gates the `@xmldom/xmldom` fallback to the Node runtime so importing the package in a worker no longer crashes.

**The progress bar:**
- Root cause it never appeared: the `setIdsError` store setter unconditionally set `idsLoading:false`, and `runValidation` calls `setIdsError(null)` right after `setIdsLoading(true)` — flipping loading off for the whole run, so the `{loading && ...}`-gated progress panel never rendered. Fixed so clearing an error leaves loading alone.
- IDSPanel shows an advancing 'Validating specification N of M' counter + live 'Scanning/Checking X / Y' sub-line; the slow cold-extraction phase now reports granular progress.

**Parser:** `yieldToEventLoop` MessagePort-close leak fix consolidated into one shared module (was keeping the CLI process alive after large parses).

## Measured (550k-entity model, identical verdicts)

| pack | #1055 | this PR |
|---|---|---|
| 848 specs | 41 s | ~9 s (CLI) / ~14 s (browser worker, off-thread, live progress) |
| 277 specs | 45 s | 4.4 s |
| 117 specs | 12 s | 3.9 s |

Validation in the viewer now runs entirely off the main thread with a moving progress bar from click to completion.

Tests: scale-regression + differential parity suite in packages/ids (253), MessagePort leak test in packages/parser, summarize-status tests in packages/sdk. Viewer typecheck + production build green; the worker is emitted as its own chunk. All diagnostic logging removed.

Follow-up (optional): avoid the worker re-parse by transporting the existing store; revisit a Rust engine only if a hard trigger fires.