### PR TITLE
fix(ids): accept IFCLABEL for enumerated standard pset properties in audit

### DIFF
--- a/.changeset/ids-audit-enum-datatype.md
+++ b/.changeset/ids-audit-enum-datatype.md
@@ -1,0 +1,19 @@
+---
+"@ifc-lite/ids": patch
+---
+
+fix(ids): accept IFCLABEL for enumerated standard pset properties in the IDS audit.
+
+The audit flagged `W_IFC_DATATYPE_MISMATCH` for any dataType declared on a
+standard enumerated property (e.g. `Pset_ProjectCommon.ProjectType`,
+`Pset_Address.Purpose`) because enumeration kinds carry no dataType in the
+generated pset definitions. PEnum values serialize as IfcLabel, so IFCLABEL
+is the canonical IDS dataType — upstream IdsLib's `HasDataTypes` maps
+`EnumerationPropertyType` to `["IFCLABEL"]`, and authoring tools (ACCA
+usBIM.IDS, IDSedit) emit IFCLABEL for these properties. A genuinely wrong
+dataType on an enumerated property still errors, and the message now names
+the expected type instead of "typed enumeration".
+
+Property shapes with no known backing type (e.g. table values) are now
+skipped instead of mismatching against every declaration, matching upstream
+behavior when `HasDataTypes` returns false.

--- a/packages/ids/src/audit/audit.test.ts
+++ b/packages/ids/src/audit/audit.test.ts
@@ -183,6 +183,59 @@ describe('auditIDSDocument — IFC schema cross-checks', () => {
     expect(codes(r.issues)).toContain('E_IFC_PROP_NOT_IN_PSET');
   });
 
+  // #1062 — standard enumerated properties (PEnum_*) serialize as
+  // IfcLabel, so IFCLABEL is the canonical IDS dataType for them and
+  // must not be flagged (mirrors upstream IdsLib's HasDataTypes).
+  it('accepts IFCLABEL for a standard enumerated pset property', async () => {
+    const xml = wrap(`<specification name="Project info" ifcVersion="IFC4X3_ADD2">
+      <applicability>
+        <entity><name><simpleValue>IFCPROJECT</simpleValue></name></entity>
+      </applicability>
+      <requirements>
+        <property dataType="IFCLABEL">
+          <propertySet><simpleValue>Pset_ProjectCommon</simpleValue></propertySet>
+          <baseName><simpleValue>ProjectType</simpleValue></baseName>
+        </property>
+      </requirements>
+    </specification>`);
+    const r = await auditIDSDocument(xml);
+    expect(codes(r.issues)).not.toContain('W_IFC_DATATYPE_MISMATCH');
+  });
+
+  it('accepts IFCLABEL for Pset_Address.Purpose (enumerated)', async () => {
+    const xml = wrap(`<specification name="Site address" ifcVersion="IFC4X3_ADD2">
+      <applicability>
+        <entity><name><simpleValue>IFCSITE</simpleValue></name></entity>
+      </applicability>
+      <requirements>
+        <property dataType="IFCLABEL">
+          <propertySet><simpleValue>Pset_Address</simpleValue></propertySet>
+          <baseName><simpleValue>Purpose</simpleValue></baseName>
+        </property>
+      </requirements>
+    </specification>`);
+    const r = await auditIDSDocument(xml);
+    expect(codes(r.issues)).not.toContain('W_IFC_DATATYPE_MISMATCH');
+  });
+
+  it('still flags a non-label dataType on an enumerated pset property', async () => {
+    const xml = wrap(`<specification name="Wrong enum type" ifcVersion="IFC4X3_ADD2">
+      <applicability>
+        <entity><name><simpleValue>IFCPROJECT</simpleValue></name></entity>
+      </applicability>
+      <requirements>
+        <property dataType="IFCINTEGER">
+          <propertySet><simpleValue>Pset_ProjectCommon</simpleValue></propertySet>
+          <baseName><simpleValue>ProjectType</simpleValue></baseName>
+        </property>
+      </requirements>
+    </specification>`);
+    const r = await auditIDSDocument(xml);
+    const issue = r.issues.find((i) => i.code === 'W_IFC_DATATYPE_MISMATCH');
+    expect(issue).toBeDefined();
+    expect(issue?.message).toContain('IfcLabel');
+  });
+
   it('warns on an unknown Pset_*-prefixed pset (reserved prefix)', async () => {
     const xml = wrap(`<specification name="Reserved prefix" ifcVersion="IFC4">
       <applicability>

--- a/packages/ids/src/audit/ifc-schema/index.ts
+++ b/packages/ids/src/audit/ifc-schema/index.ts
@@ -476,23 +476,32 @@ function checkDataTypeMatch(
   // `IfcLabel`) or the canonical IDS template form (`IFCPROPERTYSINGLEVALUE`
   // for kind=`single`, `IFCPROPERTYENUMERATEDVALUE` for kind=`enumeration`,
   // etc.), we don't warn.
+  //
+  // Enumerated properties (PEnum_*) carry no `dataType` in the pset
+  // definitions — their values serialize as IfcLabel, so IFCLABEL is the
+  // canonical IDS dataType for them. Mirrors upstream IdsLib's
+  // `HasDataTypes` (EnumerationPropertyType → ["IFCLABEL"]).
   const declaredUpper = declared.toUpperCase();
-  if (prop.dataType && prop.dataType.toUpperCase() === declaredUpper) return;
+  const expected =
+    prop.dataType ?? (prop.kind === 'enumeration' ? 'IfcLabel' : undefined);
+  if (expected && expected.toUpperCase() === declaredUpper) return;
   const idsTemplate = idsTemplateForKind(prop.kind);
   if (idsTemplate && declaredUpper === idsTemplate) return;
+  // No backing datatype known for this property shape (e.g. table
+  // values, which carry two datatypes we don't model) — skip rather
+  // than guess, like upstream when `HasDataTypes` returns false.
+  if (!expected) return;
   // Upstream IDS-Audit-tool treats this as an error (Report 303 family)
   // — declaring a different dataType than the standard pset specifies is
   // an authoring mistake, not a stylistic warning.
   issues.push({
     severity: 'error',
     code: 'W_IFC_DATATYPE_MISMATCH',
-    message: `${psetName}.${propName} is typed ${
-      prop.dataType ?? prop.kind
-    } in the standard, not ${declared}`,
+    message: `${psetName}.${propName} is typed ${expected} in the standard, not ${declared}`,
     path: `${path}.dataType`,
     facetType: 'property',
     detail: {
-      expected: prop.dataType ?? prop.kind,
+      expected,
       actual: declared,
       property: propName,
     },


### PR DESCRIPTION
## Problem

Loading an IDS that requires a standard **enumerated** pset property with `dataType="IFCLABEL"` (e.g. `Pset_ProjectCommon.ProjectType`, `Pset_Address.Purpose`) produced a false `W_IFC_DATATYPE_MISMATCH` audit error:

> Pset_ProjectCommon.ProjectType is typed enumeration in the standard, not IFCLABEL

The message also sent authors hunting for a non-existent enum datatype (there is no `...TYPEENUM` dataType in IDS), while ACCA usBIM.IDS, IDSedit, and the official buildingSMART IDS-Audit-tool all accept `IFCLABEL` for these properties.

## Root cause

Enumeration-kind properties carry no `dataType` in the generated pset definitions (`kind: "enumeration"` + `enumeration: [...]`), so `checkDataTypeMatch` flagged **every** declared dataType on them — including the correct one. Upstream IdsLib explicitly maps enumerated properties to `IFCLABEL`:

```csharp
case EnumerationPropertyType ep:
    // We assume that enumerations are stored as labels, ...
    dataType = ["IFCLABEL"];
    return true;
```

## Fix

- Treat `IFCLABEL` as the expected dataType for enumeration-kind standard pset properties (mirrors upstream `HasDataTypes`).
- A genuinely wrong dataType on an enumerated property (e.g. `IFCINTEGER`) still errors, and the message now names the expected type (`IfcLabel`) instead of the unhelpful "typed enumeration".
- Skip the check entirely when no backing type is known (e.g. table-value properties, `kind: "unknown"`) instead of mismatching against every declaration — same as upstream when `HasDataTypes` returns false. Previously even the fixture-documented *valid* declarations (`Pset_SoundGeneration.SoundCurve` with `IFCSOUNDPOWERMEASURE`/`IFCFREQUENCYMEASURE`) were flagged.

## Tests

- 3 new regression tests covering both psets from the report plus the still-flags-wrong-type case.
- Full `@ifc-lite/ids` suite: 256/256 passing, including the upstream audit fixture corpus; package typecheck clean.

Fixes #1062

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of enumerated properties in IFC schemas for correct datatype handling.
  * Enhanced datatype mismatch error messages to display accurate expected values.
  * Refined validation logic to better process standard enumerated property sets without generating false warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->