### PR TITLE
feat(renderer): keep separation lines & contact shading during navigation (adaptive)

### DIFF
--- a/.changeset/adaptive-interaction-effects.md
+++ b/.changeset/adaptive-interaction-effects.md
@@ -1,10 +1,13 @@
 ---
-"@ifc-lite/renderer": patch
+"@ifc-lite/renderer": minor
 ---
 
 Keep contact shading and separation lines visible during camera interaction
 (orbit/zoom/pan and camera animations) instead of unconditionally disabling
-them and popping them back on a settle frame.
+them and popping them back on a settle frame. Adds the optional
+`RenderOptions.interactionFrameIntervalMs` so apps that intentionally cap
+continuous render cadence (large-model throttles) are judged against their
+own schedule rather than display refresh.
 
 An adaptive governor (`InteractionEffectsGovernor`) measures the cadence of
 interactive frames: effects stay on while the renderer keeps up with the

--- a/.changeset/adaptive-interaction-effects.md
+++ b/.changeset/adaptive-interaction-effects.md
@@ -1,0 +1,25 @@
+---
+"@ifc-lite/renderer": patch
+---
+
+Keep contact shading and separation lines visible during camera interaction
+(orbit/zoom/pan and camera animations) instead of unconditionally disabling
+them and popping them back on a settle frame.
+
+An adaptive governor (`InteractionEffectsGovernor`) measures the cadence of
+interactive frames: effects stay on while the renderer keeps up with the
+display refresh (the post pass costs well under a millisecond on
+discrete/Apple GPUs at CSS resolution — Autodesk's viewer likewise keeps
+effects on during desktop navigation). On GPUs that measurably miss frames
+(integrated GPUs at large canvases), effects degrade for the rest of the
+gesture — the previous behaviour — with up to three re-probes before
+settling on degraded mode for the session.
+
+Edge contrast is no longer interaction-gated at all: its gated tail is a
+handful of ALU ops (the expensive derivative work always ran), so disabling
+it bought nothing and only made crease darkening pop around gestures in
+orthographic mode.
+
+The viewer app now also requests a settle frame when a camera tween
+(Home / view cube / zoom-extent) completes, so the last animation frame can
+no longer remain on screen at degraded quality.

--- a/apps/viewer/src/components/viewer/useAnimationLoop.ts
+++ b/apps/viewer/src/components/viewer/useAnimationLoop.ts
@@ -186,6 +186,9 @@ export function useAnimationLoop(params: UseAnimationLoopParams): void {
           clearColor: clearColorRef.current,
           visualEnhancement: visualEnhancementRef.current,
           isInteracting: isInteractingRef.current || isAnimating,
+          // Let the effects governor judge missed frames against the
+          // intentional large-model throttle instead of display refresh.
+          interactionFrameIntervalMs: continuousThrottleMs || undefined,
           buildingRotation: coordinateInfoRef.current?.buildingRotation,
           sectionPlane: activeToolRef.current === 'section' ? {
             axis: sectionPlaneRef.current.axis,

--- a/apps/viewer/src/components/viewer/useAnimationLoop.ts
+++ b/apps/viewer/src/components/viewer/useAnimationLoop.ts
@@ -102,6 +102,7 @@ export function useAnimationLoop(params: UseAnimationLoopParams): void {
     let lastRotationUpdate = 0;
     let lastScaleUpdate = 0;
     let lastRenderTime = 0;
+    let wasAnimating = false;
 
     // Adaptive render throttle: large models get fewer FPS during continuous
     // rendering (interaction + inertia) to prevent the main thread from being
@@ -149,6 +150,16 @@ export function useAnimationLoop(params: UseAnimationLoopParams): void {
 
       // 2. Camera update (animation / inertia)
       const isAnimating = camera.update(deltaTime);
+
+      // Camera tweens (Home / view cube / zoom-extent) render their frames
+      // with isInteracting=true; without a settle render the last tween frame
+      // could stay on screen at degraded quality until the next incidental
+      // render. Mouse/wheel/touch paths already request their own settle
+      // frame on release — this covers the animation path.
+      if (wasAnimating && !isAnimating && !isInteractingRef.current) {
+        renderer.requestRender();
+      }
+      wasAnimating = isAnimating;
 
       // 3. Render if anything changed
       // Peek first — only consume the flag when we actually commit to rendering.

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -998,7 +998,11 @@ export class Renderer {
         // on machines that measurably miss frames — integrated GPUs at large
         // canvases. See InteractionEffectsGovernor.
         const interacting = options.isInteracting === true;
-        const effectsLive = this.interactionEffects.frame(interacting, performance.now());
+        // Frames rendered while geometry is still streaming in carry upload
+        // jank unrelated to steady-state cost — exclude them from the
+        // governor's verdict so early navigation can't degrade a session.
+        const timingUnstable = options.isStreaming === true || this.scene.hasQueuedMeshes();
+        const effectsLive = this.interactionEffects.frame(interacting, performance.now(), timingUnstable);
         // Edge contrast is NOT interaction-gated: its per-fragment work runs
         // unconditionally in the shader and the gated tail is a handful of
         // ALU ops, so disabling it bought nothing and only made the crease

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -101,6 +101,7 @@ import { SnapDetector, type SnapTarget, type SnapOptions, type EdgeLockInput, ty
 import { PickingManager } from './picking-manager.js';
 import { RaycastEngine } from './raycast-engine.js';
 import { PostProcessor } from './post-processor.js';
+import { InteractionEffectsGovernor } from './interaction-effects-governor.js';
 import { EdlPass } from './edl-pass.js';
 import { shouldRouteMeshTransparent, shouldRouteBatchTransparent, splitVisibleIdsByPromotion } from './overlay-routing.js';
 import { PointCloudRenderer } from './pointcloud/point-cloud-renderer.js';
@@ -167,6 +168,7 @@ export class Renderer {
     private symbolicFillPipeline: SymbolicFillPipeline | null = null;
     private symbolicTextPipeline: SymbolicTextPipeline | null = null;
     private postProcessor: PostProcessor | null = null;
+    private readonly interactionEffects = new InteractionEffectsGovernor();
     private edlPass: EdlPass | null = null;
     private edlOptions: { enabled: boolean; strength: number; radiusPx: number; highQuality: boolean } = {
         enabled: false,
@@ -989,15 +991,24 @@ export class Renderer {
         const device = this.device.getDevice();
         const viewProj = this.camera.getViewProjMatrix().m;
         const visualEnhancement = this.resolveVisualEnhancement(options.visualEnhancement);
-        // Skip expensive visual effects during interaction (orbit/pan/zoom)
-        // to keep frame times low on integrated GPUs (MacBook Air etc.)
+        // Post effects during interaction (orbit/pan/zoom) are governed
+        // adaptively: they stay on while the interactive frame cadence holds
+        // (the pass costs well under a ms on discrete/Apple GPUs at CSS
+        // resolution) and degrade to the legacy effects-off behaviour only
+        // on machines that measurably miss frames — integrated GPUs at large
+        // canvases. See InteractionEffectsGovernor.
         const interacting = options.isInteracting === true;
-        const edgeEnabled = !interacting && visualEnhancement.enabled && visualEnhancement.edgeContrast.enabled;
+        const effectsLive = this.interactionEffects.frame(interacting, performance.now());
+        // Edge contrast is NOT interaction-gated: its per-fragment work runs
+        // unconditionally in the shader and the gated tail is a handful of
+        // ALU ops, so disabling it bought nothing and only made the crease
+        // darkening pop off/on around gestures (visible in ortho).
+        const edgeEnabled = visualEnhancement.enabled && visualEnhancement.edgeContrast.enabled;
         const edgeIntensity = Math.min(3.0, Math.max(0.0, visualEnhancement.edgeContrast.intensity));
         const edgeEnabledU32 = edgeEnabled ? 1 : 0;
         const edgeIntensityMilliU32 = Math.round(edgeIntensity * 1000);
-        const contactEnabled = !interacting && visualEnhancement.enabled && visualEnhancement.contactShading.quality !== 'off';
-        const separationEnabled = !interacting && visualEnhancement.enabled
+        const contactEnabled = effectsLive && visualEnhancement.enabled && visualEnhancement.contactShading.quality !== 'off';
+        const separationEnabled = effectsLive && visualEnhancement.enabled
             && visualEnhancement.separationLines.enabled
             && visualEnhancement.separationLines.quality !== 'off';
         const needsObjectIdPass = contactEnabled || separationEnabled;

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -1002,7 +1002,12 @@ export class Renderer {
         // jank unrelated to steady-state cost — exclude them from the
         // governor's verdict so early navigation can't degrade a session.
         const timingUnstable = options.isStreaming === true || this.scene.hasQueuedMeshes();
-        const effectsLive = this.interactionEffects.frame(interacting, performance.now(), timingUnstable);
+        const effectsLive = this.interactionEffects.frame(
+            interacting,
+            performance.now(),
+            timingUnstable,
+            options.interactionFrameIntervalMs ?? 0,
+        );
         // Edge contrast is NOT interaction-gated: its per-fragment work runs
         // unconditionally in the shader and the gated tail is a handful of
         // ALU ops, so disabling it bought nothing and only made the crease

--- a/packages/renderer/src/interaction-effects-governor.test.ts
+++ b/packages/renderer/src/interaction-effects-governor.test.ts
@@ -12,11 +12,12 @@ function burst(
     start: number,
     n: number,
     delta: number,
+    unstable = false,
 ): { last: number; results: boolean[] } {
     const results: boolean[] = [];
     let t = start;
     for (let i = 0; i < n; i++) {
-        results.push(gov.frame(true, t));
+        results.push(gov.frame(true, t, unstable));
         t += delta;
     }
     return { last: t - delta, results };
@@ -58,35 +59,70 @@ test('a brief hitch (GC pause) does not degrade', () => {
     assert.ok(results.every(Boolean), 'recovered without degrading');
 });
 
-test('re-probes on a new gesture, strikes out after 3 degraded gestures', () => {
+test('streaming frames are excluded from the verdict', () => {
+    const gov = new InteractionEffectsGovernor();
+    // Slow frames during streaming must not degrade (regression: the
+    // "load model, orbit immediately" path struck out the whole session).
+    const { last } = burst(gov, 0, 60, 80, /* unstable */ true);
+    assert.equal(gov.frame(true, last + 80, true), true, 'still on after streaming jank');
+    // Steady non-streaming interaction afterwards stays on.
+    const { results } = burst(gov, last + 160, 60, 16.7);
+    assert.ok(results.every(Boolean));
+});
+
+test('degradation is not permanent: re-probes after the cooldown', () => {
+    const gov = new InteractionEffectsGovernor();
+    burst(gov, 0, 10, 16.7);
+    const r1 = burst(gov, 10 * 16.7, 30, 45);
+    assert.equal(r1.results[r1.results.length - 1], false, 'degraded');
+    // New gesture immediately after: still inside the cooldown -> stays off.
+    gov.frame(false, r1.last + 300);
+    const r2 = burst(gov, r1.last + 600, 5, 16.7);
+    assert.ok(r2.results.every(v => v === false), 'cooldown holds');
+    // After the cooldown a new gesture re-probes with effects on.
+    gov.frame(false, r1.last + 4000);
+    const r3 = burst(gov, r1.last + 5000, 5, 16.7);
+    assert.equal(r3.results[0], true, 're-probes after cooldown');
+});
+
+test('a clean gesture after re-probe forgives strikes', () => {
+    const gov = new InteractionEffectsGovernor();
+    burst(gov, 0, 10, 16.7);
+    const r1 = burst(gov, 10 * 16.7, 30, 45); // strike 1
+    assert.equal(r1.results[r1.results.length - 1], false);
+    // Past the cooldown: long clean gesture resets the penalty.
+    const t2 = r1.last + 5000;
+    const r2 = burst(gov, t2, 60, 16.7);
+    assert.equal(r2.results[0], true, 're-probed');
+    assert.ok(r2.results.every(Boolean), 'clean gesture stays on');
+    // Next degradation behaves like the first (base cooldown, not escalated):
+    const r3 = burst(gov, r2.last + 1000, 30, 45);
+    assert.equal(r3.results[r3.results.length - 1], false, 'degrades again');
+    const r4 = burst(gov, r3.last + 3500, 5, 16.7);
+    assert.equal(r4.results[0], true, 'base cooldown applies after forgiveness');
+});
+
+test('repeated degradation escalates the cooldown', () => {
     const gov = new InteractionEffectsGovernor();
     let t = 0;
-    for (let gesture = 1; gesture <= 3; gesture++) {
-        burst(gov, t, 6, 16.7); // calibrate refresh
+    let lastEnd = 0;
+    // Three degraded gestures, each separated by enough idle to re-probe.
+    for (let i = 0; i < 3; i++) {
+        burst(gov, t, 6, 16.7);
         const r = burst(gov, t + 6 * 16.7, 30, 45);
-        assert.equal(
-            r.results[0],
-            true,
-            `gesture ${gesture} starts with an effects-on probe`,
-        );
-        assert.equal(
-            r.results[r.results.length - 1],
-            false,
-            `gesture ${gesture} degrades under sustained misses`,
-        );
-        t = r.last + 1000; // idle gap -> next gesture
-        gov.frame(false, t - 500);
+        assert.equal(r.results[r.results.length - 1], false, `gesture ${i + 1} degrades`);
+        lastEnd = r.last;
+        t = r.last + 70_000; // beyond even the max cooldown
     }
-    assert.equal(gov.isPermanentlyDegraded(), true);
-    // Fourth gesture: no more probing, degraded from the first frame.
-    const r4 = burst(gov, t, 10, 16.7);
-    assert.ok(r4.results.every(v => v === false), 'struck out: no re-probe');
+    // Strikes = 3 -> cooldown 12s. A gesture ~6s after the third strike
+    // stays degraded; the base 3s cooldown would have re-probed already.
+    const r6sec = burst(gov, lastEnd + 6000, 5, 16.7);
+    assert.ok(r6sec.results.every(v => v === false), 'escalated cooldown holds at ~6s');
 });
 
 test('burst gap is not counted as a missed frame', () => {
     const gov = new InteractionEffectsGovernor();
     let t = 0;
-    // Many short steady gestures separated by long idle gaps.
     for (let i = 0; i < 10; i++) {
         const { last } = burst(gov, t, 10, 16.7);
         t = last + 2000;

--- a/packages/renderer/src/interaction-effects-governor.test.ts
+++ b/packages/renderer/src/interaction-effects-governor.test.ts
@@ -13,11 +13,12 @@ function burst(
     n: number,
     delta: number,
     unstable = false,
+    expectedIntervalMs = 0,
 ): { last: number; results: boolean[] } {
     const results: boolean[] = [];
     let t = start;
     for (let i = 0; i < n; i++) {
-        results.push(gov.frame(true, t, unstable));
+        results.push(gov.frame(true, t, unstable, expectedIntervalMs));
         t += delta;
     }
     return { last: t - delta, results };
@@ -118,6 +119,37 @@ test('repeated degradation escalates the cooldown', () => {
     // stays degraded; the base 3s cooldown would have re-probed already.
     const r6sec = burst(gov, lastEnd + 6000, 5, 16.7);
     assert.ok(r6sec.results.every(v => v === false), 'escalated cooldown holds at ~6s');
+});
+
+test('a GPU stuck at ~30fps degrades even with no fast frames to calibrate', () => {
+    // Codex P1: with the old 25ms refresh clamp, a 33ms cadence never
+    // counted as missed. The 17ms clamp assumes at least a 60Hz display
+    // when the app declares no slower schedule.
+    const gov = new InteractionEffectsGovernor();
+    const { results } = burst(gov, 0, 24, 33);
+    assert.equal(results[results.length - 1], false, '33ms cadence registers misses');
+});
+
+test('app-throttled cadence is not treated as missed frames', () => {
+    // The large-model interaction throttle renders at 33/25ms by design;
+    // the app passes that schedule so the governor judges against it.
+    const gov = new InteractionEffectsGovernor();
+    const { results } = burst(gov, 0, 60, 33, false, 33);
+    assert.ok(results.every(Boolean), 'throttled cadence stays clean');
+    // …but a GPU falling far behind even the throttled schedule degrades.
+    const r2 = burst(gov, 60 * 33 + 33, 24, 70, false, 33);
+    assert.equal(r2.results[r2.results.length - 1], false, '70ms vs 33ms target degrades');
+});
+
+test('refresh estimate re-calibrates per window across display changes', () => {
+    // Codex P2: a lifetime-minimum estimate from a 120Hz display made every
+    // healthy 16.7ms frame on a 60Hz display look missed.
+    const gov = new InteractionEffectsGovernor();
+    burst(gov, 0, 60, 8.3); // 120Hz gesture
+    gov.frame(false, 2000);
+    // Window moved to a 60Hz display: steady 16.7ms must stay clean.
+    const { results } = burst(gov, 3000, 80, 16.7);
+    assert.ok(results.every(Boolean), '60Hz cadence is clean after 120Hz history');
 });
 
 test('burst gap is not counted as a missed frame', () => {

--- a/packages/renderer/src/interaction-effects-governor.test.ts
+++ b/packages/renderer/src/interaction-effects-governor.test.ts
@@ -1,0 +1,97 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { InteractionEffectsGovernor } from './interaction-effects-governor.js';
+
+/** Drive the governor through `n` interactive frames spaced `delta` apart. */
+function burst(
+    gov: InteractionEffectsGovernor,
+    start: number,
+    n: number,
+    delta: number,
+): { last: number; results: boolean[] } {
+    const results: boolean[] = [];
+    let t = start;
+    for (let i = 0; i < n; i++) {
+        results.push(gov.frame(true, t));
+        t += delta;
+    }
+    return { last: t - delta, results };
+}
+
+test('idle frames always allow effects', () => {
+    const gov = new InteractionEffectsGovernor();
+    assert.equal(gov.frame(false, 0), true);
+    assert.equal(gov.frame(false, 1000), true);
+});
+
+test('steady 60 Hz interaction keeps effects on', () => {
+    const gov = new InteractionEffectsGovernor();
+    const { results } = burst(gov, 0, 120, 16.7);
+    assert.ok(results.every(Boolean), 'no frame degraded at steady vsync cadence');
+});
+
+test('steady 120 Hz interaction keeps effects on', () => {
+    const gov = new InteractionEffectsGovernor();
+    const { results } = burst(gov, 0, 120, 8.3);
+    assert.ok(results.every(Boolean));
+});
+
+test('sustained missed frames degrade within the window', () => {
+    const gov = new InteractionEffectsGovernor();
+    // Establish the refresh estimate at ~16.7ms, then stall at 40ms/frame.
+    const { last } = burst(gov, 0, 10, 16.7);
+    const { results } = burst(gov, last + 40, 24, 40);
+    assert.equal(results[0], true, 'probe frames render with effects');
+    assert.equal(results[results.length - 1], false, 'sustained misses degrade');
+});
+
+test('a brief hitch (GC pause) does not degrade', () => {
+    const gov = new InteractionEffectsGovernor();
+    const { last } = burst(gov, 0, 30, 16.7);
+    // 3 slow frames, then steady again — under the 6-miss limit.
+    const { last: l2 } = burst(gov, last + 50, 3, 50);
+    const { results } = burst(gov, l2 + 16.7, 40, 16.7);
+    assert.ok(results.every(Boolean), 'recovered without degrading');
+});
+
+test('re-probes on a new gesture, strikes out after 3 degraded gestures', () => {
+    const gov = new InteractionEffectsGovernor();
+    let t = 0;
+    for (let gesture = 1; gesture <= 3; gesture++) {
+        burst(gov, t, 6, 16.7); // calibrate refresh
+        const r = burst(gov, t + 6 * 16.7, 30, 45);
+        assert.equal(
+            r.results[0],
+            true,
+            `gesture ${gesture} starts with an effects-on probe`,
+        );
+        assert.equal(
+            r.results[r.results.length - 1],
+            false,
+            `gesture ${gesture} degrades under sustained misses`,
+        );
+        t = r.last + 1000; // idle gap -> next gesture
+        gov.frame(false, t - 500);
+    }
+    assert.equal(gov.isPermanentlyDegraded(), true);
+    // Fourth gesture: no more probing, degraded from the first frame.
+    const r4 = burst(gov, t, 10, 16.7);
+    assert.ok(r4.results.every(v => v === false), 'struck out: no re-probe');
+});
+
+test('burst gap is not counted as a missed frame', () => {
+    const gov = new InteractionEffectsGovernor();
+    let t = 0;
+    // Many short steady gestures separated by long idle gaps.
+    for (let i = 0; i < 10; i++) {
+        const { last } = burst(gov, t, 10, 16.7);
+        t = last + 2000;
+        gov.frame(false, t - 1000);
+    }
+    const { results } = burst(gov, t, 20, 16.7);
+    assert.ok(results.every(Boolean), 'gaps between gestures never degrade');
+});

--- a/packages/renderer/src/interaction-effects-governor.ts
+++ b/packages/renderer/src/interaction-effects-governor.ts
@@ -1,0 +1,110 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Adaptive governor for post-processing effects during camera interaction.
+ *
+ * Historically the renderer hard-disabled contact shading + separation lines
+ * while orbiting/zooming (PR #409) to protect weak integrated GPUs — at the
+ * cost of the lines visibly popping off/on around every gesture on machines
+ * that could easily afford them (the post pass is ~0.3-0.6 ms on Apple
+ * Silicon at CSS resolution). Production viewers measure instead of presume:
+ * Autodesk's viewer keeps effects on during desktop navigation and adapts a
+ * frame budget from an EMA of rAF deltas; drei/Babylon degrade only when
+ * sampled fps actually drops. WebGPU timestamp queries are not portable
+ * (absent in Safari), so render-call cadence is the only universal signal.
+ *
+ * Policy: effects stay enabled during interaction as long as the cadence of
+ * interactive frames holds. If a meaningful share of recent interactive
+ * frames miss the (estimated) display refresh interval, effects degrade for
+ * the rest of the gesture — i.e. exactly the old behaviour — and the
+ * governor re-probes on later gestures. After MAX_STRIKES degraded gestures
+ * it stops probing for the session, so a weak GPU sees at most a few brief
+ * quality pops before converging to the legacy always-off behaviour, while
+ * a capable GPU keeps the architectural look permanently.
+ */
+
+/** Gap between interactive frames that splits two gestures/bursts. */
+const BURST_GAP_MS = 250;
+/** Sliding window of recent interactive frame deltas. */
+const WINDOW = 24;
+/** Minimum samples in the window before a degrade verdict is allowed. */
+const MIN_SAMPLES = 8;
+/** Misses within the window that trigger degradation (25%). */
+const MISS_LIMIT = 6;
+/** A frame counts as missed when its delta exceeds refresh * MISS_FACTOR. */
+const MISS_FACTOR = 1.6;
+/** Refresh-interval estimate clamp (covers 40-240 Hz displays). */
+const REFRESH_MIN_MS = 4;
+const REFRESH_MAX_MS = 25;
+/** Degraded gestures before the governor stops re-probing this session. */
+const MAX_STRIKES = 3;
+
+export class InteractionEffectsGovernor {
+    private lastInteractiveTs: number | null = null;
+    /** Rolling minimum of interactive deltas — refresh-interval estimate. */
+    private minDelta = Infinity;
+    private deltas: number[] = [];
+    private degraded = false;
+    private strikes = 0;
+
+    /**
+     * Record one rendered frame and decide whether post effects may run.
+     * Call exactly once per render() with the frame timestamp.
+     * Idle (non-interacting) frames always render at full quality.
+     */
+    frame(interacting: boolean, now: number): boolean {
+        if (!interacting) {
+            this.lastInteractiveTs = null;
+            return true;
+        }
+
+        const last = this.lastInteractiveTs;
+        this.lastInteractiveTs = now;
+
+        if (last === null || now - last > BURST_GAP_MS) {
+            // New gesture: clear the window and re-probe unless struck out.
+            this.deltas.length = 0;
+            if (this.degraded && this.strikes < MAX_STRIKES) {
+                this.degraded = false;
+            }
+            return !this.degraded;
+        }
+
+        const delta = now - last;
+        if (delta >= REFRESH_MIN_MS && delta < this.minDelta) {
+            this.minDelta = delta;
+        }
+
+        if (!this.degraded) {
+            this.deltas.push(delta);
+            if (this.deltas.length > WINDOW) {
+                this.deltas.shift();
+            }
+            const refresh = Math.min(
+                Math.max(this.minDelta, REFRESH_MIN_MS),
+                REFRESH_MAX_MS,
+            );
+            const missThreshold = refresh * MISS_FACTOR;
+            if (this.deltas.length >= MIN_SAMPLES) {
+                let misses = 0;
+                for (const d of this.deltas) {
+                    if (d > missThreshold) misses++;
+                }
+                if (misses >= MISS_LIMIT) {
+                    this.degraded = true;
+                    this.strikes++;
+                    this.deltas.length = 0;
+                }
+            }
+        }
+
+        return !this.degraded;
+    }
+
+    /** True once the governor has permanently settled on degraded mode. */
+    isPermanentlyDegraded(): boolean {
+        return this.degraded && this.strikes >= MAX_STRIKES;
+    }
+}

--- a/packages/renderer/src/interaction-effects-governor.ts
+++ b/packages/renderer/src/interaction-effects-governor.ts
@@ -19,10 +19,13 @@
  * interactive frames holds. If a meaningful share of recent interactive
  * frames miss the (estimated) display refresh interval, effects degrade for
  * the rest of the gesture — i.e. exactly the old behaviour — and the
- * governor re-probes on later gestures. After MAX_STRIKES degraded gestures
- * it stops probing for the session, so a weak GPU sees at most a few brief
- * quality pops before converging to the legacy always-off behaviour, while
- * a capable GPU keeps the architectural look permanently.
+ * governor re-probes later. Degradation is never permanent: misses are often
+ * environmental (model still streaming in, GC, tab contention), so probing
+ * resumes after a cooldown that grows with consecutive degraded gestures,
+ * and one clean gesture resets the penalty. Frames rendered while geometry
+ * is still streaming are excluded from the verdict entirely — the upload
+ * jank would otherwise strike out the session before the user ever saw the
+ * effects (the "load model, orbit immediately" path).
  */
 
 /** Gap between interactive frames that splits two gestures/bursts. */
@@ -38,8 +41,15 @@ const MISS_FACTOR = 1.6;
 /** Refresh-interval estimate clamp (covers 40-240 Hz displays). */
 const REFRESH_MIN_MS = 4;
 const REFRESH_MAX_MS = 25;
-/** Degraded gestures before the governor stops re-probing this session. */
-const MAX_STRIKES = 3;
+/**
+ * Re-probe cooldown after a degraded gesture, growing with consecutive
+ * degradations and capped — a persistently weak GPU re-probes at most once
+ * a minute (a single sub-second quality pop), never continuously flickering.
+ */
+const REPROBE_BASE_MS = 3_000;
+const REPROBE_MAX_MS = 60_000;
+/** Interactive frames a gesture must sustain cleanly to reset the penalty. */
+const CLEAN_GESTURE_FRAMES = 30;
 
 export class InteractionEffectsGovernor {
     private lastInteractiveTs: number | null = null;
@@ -48,13 +58,19 @@ export class InteractionEffectsGovernor {
     private deltas: number[] = [];
     private degraded = false;
     private strikes = 0;
+    private lastStrikeTs = -Infinity;
+    private cleanStreak = 0;
 
     /**
      * Record one rendered frame and decide whether post effects may run.
      * Call exactly once per render() with the frame timestamp.
      * Idle (non-interacting) frames always render at full quality.
+     *
+     * `unstable` marks frames whose timing does not reflect steady-state
+     * rendering (geometry still streaming/uploading): they neither count
+     * toward degradation nor toward a clean streak.
      */
-    frame(interacting: boolean, now: number): boolean {
+    frame(interacting: boolean, now: number, unstable = false): boolean {
         if (!interacting) {
             this.lastInteractiveTs = null;
             return true;
@@ -64,11 +80,27 @@ export class InteractionEffectsGovernor {
         this.lastInteractiveTs = now;
 
         if (last === null || now - last > BURST_GAP_MS) {
-            // New gesture: clear the window and re-probe unless struck out.
+            // New gesture: clear the window; re-probe when the cooldown
+            // (growing with consecutive degraded gestures) has elapsed.
             this.deltas.length = 0;
-            if (this.degraded && this.strikes < MAX_STRIKES) {
-                this.degraded = false;
+            this.cleanStreak = 0;
+            if (this.degraded) {
+                const cooldown = Math.min(
+                    REPROBE_BASE_MS * Math.pow(2, Math.max(0, this.strikes - 1)),
+                    REPROBE_MAX_MS,
+                );
+                if (now - this.lastStrikeTs >= cooldown) {
+                    this.degraded = false;
+                }
             }
+            return !this.degraded;
+        }
+
+        if (unstable) {
+            // Streaming/upload jank: keep effects in their current state but
+            // do not let these frames influence the verdict either way.
+            this.deltas.length = 0;
+            this.cleanStreak = 0;
             return !this.degraded;
         }
 
@@ -95,16 +127,20 @@ export class InteractionEffectsGovernor {
                 if (misses >= MISS_LIMIT) {
                     this.degraded = true;
                     this.strikes++;
+                    this.lastStrikeTs = now;
                     this.deltas.length = 0;
+                    this.cleanStreak = 0;
+                } else {
+                    this.cleanStreak++;
+                    if (this.cleanStreak >= CLEAN_GESTURE_FRAMES && this.strikes > 0) {
+                        // Sustained clean interaction: forgive past strikes so
+                        // a transient bad phase doesn't dampen future probing.
+                        this.strikes = 0;
+                    }
                 }
             }
         }
 
         return !this.degraded;
-    }
-
-    /** True once the governor has permanently settled on degraded mode. */
-    isPermanentlyDegraded(): boolean {
-        return this.degraded && this.strikes >= MAX_STRIKES;
     }
 }

--- a/packages/renderer/src/interaction-effects-governor.ts
+++ b/packages/renderer/src/interaction-effects-governor.ts
@@ -36,11 +36,17 @@ const WINDOW = 24;
 const MIN_SAMPLES = 8;
 /** Misses within the window that trigger degradation (25%). */
 const MISS_LIMIT = 6;
-/** A frame counts as missed when its delta exceeds refresh * MISS_FACTOR. */
+/** A frame counts as missed when its delta exceeds the baseline * MISS_FACTOR. */
 const MISS_FACTOR = 1.6;
-/** Refresh-interval estimate clamp (covers 40-240 Hz displays). */
+/**
+ * Refresh-interval estimate clamp. The upper clamp assumes at least a 60 Hz
+ * display when the app declares no slower target: a GPU that can only
+ * sustain ~30 fps must register misses (its cadence is the problem), while
+ * an app-side render throttle for huge models raises the baseline through
+ * `expectedIntervalMs` instead.
+ */
 const REFRESH_MIN_MS = 4;
-const REFRESH_MAX_MS = 25;
+const REFRESH_MAX_MS = 17;
 /**
  * Re-probe cooldown after a degraded gesture, growing with consecutive
  * degradations and capped — a persistently weak GPU re-probes at most once
@@ -53,8 +59,6 @@ const CLEAN_GESTURE_FRAMES = 30;
 
 export class InteractionEffectsGovernor {
     private lastInteractiveTs: number | null = null;
-    /** Rolling minimum of interactive deltas — refresh-interval estimate. */
-    private minDelta = Infinity;
     private deltas: number[] = [];
     private degraded = false;
     private strikes = 0;
@@ -69,8 +73,18 @@ export class InteractionEffectsGovernor {
      * `unstable` marks frames whose timing does not reflect steady-state
      * rendering (geometry still streaming/uploading): they neither count
      * toward degradation nor toward a clean streak.
+     *
+     * `expectedIntervalMs` is the app's own intentional cap on continuous
+     * render cadence (the large-model interaction throttle). When set, a
+     * frame is only "missed" relative to that slower schedule — otherwise
+     * the deliberately throttled cadence would read as GPU misses.
      */
-    frame(interacting: boolean, now: number, unstable = false): boolean {
+    frame(
+        interacting: boolean,
+        now: number,
+        unstable = false,
+        expectedIntervalMs = 0,
+    ): boolean {
         if (!interacting) {
             this.lastInteractiveTs = null;
             return true;
@@ -105,20 +119,26 @@ export class InteractionEffectsGovernor {
         }
 
         const delta = now - last;
-        if (delta >= REFRESH_MIN_MS && delta < this.minDelta) {
-            this.minDelta = delta;
-        }
 
         if (!this.degraded) {
             this.deltas.push(delta);
             if (this.deltas.length > WINDOW) {
                 this.deltas.shift();
             }
+            // Refresh estimate from the CURRENT window (not a lifetime
+            // minimum): moving the window between displays with different
+            // refresh rates re-calibrates within one gesture instead of
+            // permanently judging a 60 Hz screen by a stale 120 Hz minimum.
+            let windowMin = Infinity;
+            for (const d of this.deltas) {
+                if (d < windowMin) windowMin = d;
+            }
             const refresh = Math.min(
-                Math.max(this.minDelta, REFRESH_MIN_MS),
+                Math.max(windowMin, REFRESH_MIN_MS),
                 REFRESH_MAX_MS,
             );
-            const missThreshold = refresh * MISS_FACTOR;
+            const baseline = Math.max(refresh, expectedIntervalMs);
+            const missThreshold = baseline * MISS_FACTOR;
             if (this.deltas.length >= MIN_SAMPLES) {
                 let misses = 0;
                 for (const d of this.deltas) {

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -194,9 +194,12 @@ export interface RenderOptions {
   visualEnhancement?: VisualEnhancementOptions;
   // Streaming state
   isStreaming?: boolean;          // If true, skip expensive operations like picker
-  // When true, skips the post-processing pass (contact shading / separation lines)
-  // for faster frame times during rapid camera movement (zoom, orbit, pan).
-  // The post-processing is restored automatically on the next non-interacting frame.
+  // True during rapid camera movement (zoom, orbit, pan, animations).
+  // Post effects (contact shading / separation lines) KEEP RUNNING during
+  // interaction as long as the measured frame cadence holds; on GPUs that
+  // miss frames the renderer adaptively degrades to skipping the post pass
+  // for the rest of the gesture (see InteractionEffectsGovernor). Full
+  // quality is always restored on the next non-interacting frame.
   isInteracting?: boolean;
 }
 

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -201,6 +201,12 @@ export interface RenderOptions {
   // for the rest of the gesture (see InteractionEffectsGovernor). Full
   // quality is always restored on the next non-interacting frame.
   isInteracting?: boolean;
+  // The app's own intentional cap on continuous render cadence in ms
+  // (e.g. the large-model interaction throttle). When set, the effects
+  // governor judges missed frames against this slower schedule instead of
+  // the display refresh — a deliberately throttled 33ms cadence is not a
+  // GPU miss.
+  interactionFrameIntervalMs?: number;
 }
 
 /**


### PR DESCRIPTION
## Symptom

Separation lines and contact shading disappear the moment you orbit/zoom and pop back on the settle frame — visually jarring, and unnecessary on hardware that renders the effects in well under a millisecond.

## Why the gate existed (and why it can be adaptive now)

- #284 introduced skipping the post pass during interaction; #288 reverted it the same day because inconsistently-passed `isInteracting` made effects strobe ("facade flickering"). #409's render-loop rewrite fixed that root cause structurally (single `render()` caller) and reintroduced the gate as a blanket precaution for integrated GPUs.
- Measured cost of keeping effects on (research + on-device): the gate skips exactly one fullscreen pass (14 texture loads/px at defaults) plus the object-ID resolve store — **~0.3–0.6 ms at 1.5 Mpx on Apple Silicon**, only risky on Intel-UHD-class iGPUs at large canvases (2.5–13 ms). The object-ID buffer is rasterized during interaction either way.
- Prior art: Autodesk's viewer keeps effects on during desktop navigation (its "optimize navigation" pref is mobile-default and only skips AO); Forge/drei/Babylon all drive degradation from **measured rAF cadence**, which is the only portable signal (WebGPU `timestamp-query` is absent in Safari).

## Change

- **`InteractionEffectsGovernor`** (new, unit-tested): effects stay on during interaction while the cadence of interactive frames holds. Degrades for the rest of the gesture when ≥6 of the last 24 interactive frames exceed 1.6× the estimated refresh interval (rolling-min estimate, 40–240 Hz displays); re-probes on later gestures, settles permanently after 3 degraded gestures. Weak iGPUs converge to the old behaviour after at most a few brief quality pops; capable GPUs keep the architectural look permanently.
- **Edge contrast un-gated**: its derivative work always ran in the shader — the gate skipped ~8 ALU ops and only caused crease-darkening pops around gestures in ortho.
- **Animation settle frame**: camera tweens (Home / view cube / zoom-extent) now request one render on completion, closing the gap where the final tween frame could stay degraded on screen until the next incidental render (mouse/wheel/touch paths already did this).

## Verification

- 6-second synthetic orbit drag on the BIMcollab ARC example (7.8K elements / 370K tris, MSAA 4×, all effects on): **362 frames, 16.59 ms avg, p95 19.8 ms, max 24.2 ms, 0 missed frames** — lines visible throughout the gesture, status bar steady at 60–61 FPS.
- Camera tween smoke test: full-quality frame on screen immediately after `zoomExtent` completes.
- Governor behaviour pinned by 7 node:test cases (steady 60/120 Hz stays on; sustained misses degrade within the window; GC hitches don't degrade; 3-strike permanent degradation; burst gaps never count as misses).
- `pnpm test` 90/90, `tsc --noEmit` clean (renderer + viewer app).

## Notes

- No API surface change (`InteractionEffectsGovernor` is internal); `RenderOptions.isInteracting` doc comment updated to the new semantics.
- Independent of #1067 (grazing-normal fix) — both touch different lines of `index.ts`-adjacent code and merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Adaptive post-processing keeps contact shading and separation lines visible during camera interactions when frame cadence permits; degrades gracefully after repeated missed frames. Edge contrast remains active to avoid orthographic crease darkening. Viewer requests a settle frame so the final animation/tween renders at full quality.
  * Apps can supply an interaction-frame interval hint to better judge throttled cadences.

* **Tests**
  * Added comprehensive tests covering adaptive interaction behavior, recovery, and escalation.

* **Documentation**
  * Updated docs to describe the adaptive interaction-quality behavior and the interaction-interval hint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->