### PR TITLE
fix: parse IFC source as raw bytes

### DIFF
--- a/.changeset/tidy-ifc-bytes.md
+++ b/.changeset/tidy-ifc-bytes.md
@@ -1,7 +1,21 @@
 ---
-"@ifc-lite/wasm": patch
+"@ifc-lite/wasm": minor
 ---
 
-Accept IFC files containing non-UTF-8 string bytes in raw-byte scanning,
-pre-pass, and geometry processing APIs instead of rejecting or sanitizing the
-entire file.
+Accept IFC files that contain non-UTF-8 string bytes instead of rejecting or
+sanitizing the whole file (fixes #1023).
+
+Raw-byte scanning, the pre-pass, and geometry-processing APIs now operate on
+byte slices, so files exported by BIM tools with Latin-1/Windows-1252
+characters (e.g. `é`, `ä`, `°`) load instead of erroring out. Invalid bytes are
+decoded lossily per field — only the affected string is touched — and the
+original raw bytes are preserved for callers that want to re-decode them. No
+full-file UTF-8 validation is performed, so large/memory-mapped files are not
+penalized.
+
+Note for Rust crate consumers — this is a breaking change to the
+`ifc-lite-core` public API: `EntityScanner`, `EntityDecoder`,
+`build_entity_index`, `parse_entity`, and `parse_stream` now accept
+`T: AsRef<[u8]> + ?Sized` (e.g. `&[u8]`, `&str`, `Vec<u8>`, mmap buffers)
+instead of `&str`. Existing `&str` callers continue to compile; code that
+relied on the input being `&str` should switch to byte slices.

--- a/.changeset/tidy-ifc-bytes.md
+++ b/.changeset/tidy-ifc-bytes.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Accept IFC files containing non-UTF-8 string bytes in raw-byte scanning,
+pre-pass, and geometry processing APIs instead of rejecting or sanitizing the
+entire file.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1464,11 +1464,11 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ifc-lite-clash"
-version = "3.1.3"
+version = "3.2.0"
 
 [[package]]
 name = "ifc-lite-core"
-version = "3.1.3"
+version = "3.2.0"
 dependencies = [
  "fast-float2",
  "futures-core",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-geometry"
-version = "3.1.3"
+version = "3.2.0"
 dependencies = [
  "approx",
  "bnum",
@@ -1510,7 +1510,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-processing"
-version = "3.1.3"
+version = "3.2.0"
 dependencies = [
  "ifc-lite-core",
  "ifc-lite-geometry",
@@ -1523,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-server"
-version = "3.1.3"
+version = "3.2.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-wasm"
-version = "3.1.3"
+version = "3.2.0"
 dependencies = [
  "console_error_panic_hook",
  "futures-util",

--- a/apps/server/src/error.rs
+++ b/apps/server/src/error.rs
@@ -24,9 +24,6 @@ pub enum ApiError {
     #[error("File too large: maximum size is {max_mb} MB")]
     FileTooLarge { max_mb: usize },
 
-    #[error("Invalid UTF-8 content")]
-    InvalidUtf8(#[from] std::string::FromUtf8Error),
-
     #[error("Multipart error: {0}")]
     Multipart(#[from] axum::extract::multipart::MultipartError),
 
@@ -62,7 +59,6 @@ impl IntoResponse for ApiError {
             ApiError::BadRequest(_) => (StatusCode::BAD_REQUEST, "BAD_REQUEST"),
             ApiError::MissingFile => (StatusCode::BAD_REQUEST, "MISSING_FILE"),
             ApiError::FileTooLarge { .. } => (StatusCode::PAYLOAD_TOO_LARGE, "FILE_TOO_LARGE"),
-            ApiError::InvalidUtf8(_) => (StatusCode::BAD_REQUEST, "INVALID_UTF8"),
             ApiError::Multipart(_) => (StatusCode::BAD_REQUEST, "MULTIPART_ERROR"),
             ApiError::Processing(_) => (StatusCode::INTERNAL_SERVER_ERROR, "PROCESSING_ERROR"),
             ApiError::Cache(_) => (StatusCode::INTERNAL_SERVER_ERROR, "CACHE_ERROR"),

--- a/apps/server/src/parity_tests.rs
+++ b/apps/server/src/parity_tests.rs
@@ -91,10 +91,7 @@ fn multipart_body(content: &[u8]) -> (String, Vec<u8>) {
     );
     body.extend_from_slice(content);
     body.extend_from_slice(format!("\r\n--{BOUNDARY}--\r\n").as_bytes());
-    (
-        format!("multipart/form-data; boundary={BOUNDARY}"),
-        body,
-    )
+    (format!("multipart/form-data; boundary={BOUNDARY}"), body)
 }
 
 /// Construct an `AppState` backed by a fresh temp cache directory unique to
@@ -116,17 +113,35 @@ async fn test_state(label: &str) -> AppState {
 
 /// POST the fixture as multipart to `uri`, returning the response.
 async fn post_fixture(state: &AppState, uri: &str) -> axum::response::Response {
-    let (content_type, body) = multipart_body(FIXTURE.as_bytes());
+    post_content(state, uri, FIXTURE.as_bytes()).await
+}
+
+async fn post_content(state: &AppState, uri: &str, content: &[u8]) -> axum::response::Response {
+    let (content_type, body) = multipart_body(content);
     let request = Request::builder()
         .method("POST")
         .uri(uri)
         .header(header::CONTENT_TYPE, content_type)
         .body(Body::from(body))
         .unwrap();
-    build_router(state.clone())
-        .oneshot(request)
-        .await
-        .unwrap()
+    build_router(state.clone()).oneshot(request).await.unwrap()
+}
+
+#[tokio::test]
+async fn issue_1023_parse_endpoints_accept_non_utf8_string_bytes() {
+    let state = test_state("issue-1023").await;
+    let mut bytes = FIXTURE.as_bytes().to_vec();
+    let name = bytes
+        .windows(b"MainGrid".len())
+        .position(|window| window == b"MainGrid")
+        .unwrap();
+    bytes[name] = 0xe9;
+
+    let metadata = post_content(&state, "/api/v1/parse/metadata", &bytes).await;
+    assert_eq!(metadata.status(), StatusCode::OK);
+
+    let full = post_content(&state, "/api/v1/parse", &bytes).await;
+    assert_eq!(full.status(), StatusCode::OK);
 }
 
 /// GET `uri` and return the response.
@@ -136,10 +151,7 @@ async fn get(state: &AppState, uri: &str) -> axum::response::Response {
         .uri(uri)
         .body(Body::empty())
         .unwrap();
-    build_router(state.clone())
-        .oneshot(request)
-        .await
-        .unwrap()
+    build_router(state.clone()).oneshot(request).await.unwrap()
 }
 
 async fn body_json(response: axum::response::Response) -> Value {
@@ -241,7 +253,7 @@ async fn symbolic_endpoint_pending_for_unknown_key() {
 #[tokio::test]
 async fn streaming_complete_event_carries_symbolic_data() {
     let events: Vec<StreamEvent> = process_streaming(
-        FIXTURE.to_string(),
+        FIXTURE.as_bytes().to_vec(),
         100,
         1000,
         ifc_lite_processing::OpeningFilterMode::Default,

--- a/apps/server/src/parity_tests.rs
+++ b/apps/server/src/parity_tests.rs
@@ -279,3 +279,27 @@ async fn streaming_complete_event_carries_symbolic_data() {
         "streaming Complete should include IfcAnnotation circle"
     );
 }
+
+#[tokio::test]
+async fn streaming_zero_batch_sizes_still_complete() {
+    let events = tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        process_streaming(
+            FIXTURE.as_bytes().to_vec(),
+            0,
+            0,
+            ifc_lite_processing::OpeningFilterMode::Default,
+            ifc_lite_processing::TessellationQuality::default(),
+        )
+        .collect::<Vec<_>>(),
+    )
+    .await
+    .expect("zero batch sizes must not stall streaming");
+
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, StreamEvent::Complete { .. })),
+        "stream should emit a Complete event"
+    );
+}

--- a/apps/server/src/routes/parse.rs
+++ b/apps/server/src/routes/parse.rs
@@ -5,6 +5,7 @@
 //! Parse endpoints for IFC file processing.
 
 use crate::error::ApiError;
+use crate::services::streaming::detect_schema_version;
 use crate::services::{
     cache::DiskCache, extract_data_model, process_geometry_filtered, process_streaming,
     serialize_data_model_to_parquet, serialize_to_parquet,
@@ -695,20 +696,7 @@ pub async fn parse_metadata(
             }
         }
 
-        // Detect schema version
-        let schema_version = if content
-            .windows(b"IFC4X3".len())
-            .any(|window| window == b"IFC4X3")
-        {
-            "IFC4X3"
-        } else if content
-            .windows(b"IFC4".len())
-            .any(|window| window == b"IFC4")
-        {
-            "IFC4"
-        } else {
-            "IFC2X3"
-        };
+        let schema_version = detect_schema_version(&content);
 
         MetadataResponse {
             entity_count,
@@ -1334,5 +1322,18 @@ mod tests {
     fn symbolic_cache_key_default_filter() {
         let key = symbolic_cache_key("abc-default");
         assert_eq!(key, "abc-default-symbolic-v1");
+    }
+
+    #[test]
+    fn schema_detection_uses_file_schema_declaration_only() {
+        let content = b"ISO-10303-21;
+HEADER;
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#1=IFCDOCUMENTINFORMATION('IFC4X3',$,$,$,$,$,$,$,$,$,$,$,$,$,$,$,$);
+ENDSEC;";
+
+        assert_eq!(detect_schema_version(content), "IFC2X3");
     }
 }

--- a/apps/server/src/routes/parse.rs
+++ b/apps/server/src/routes/parse.rs
@@ -252,7 +252,7 @@ pub async fn parse_full(
     tracing::info!(cache_key = %cache_key, size = data.len(), "Cache MISS - processing");
 
     // Parse content
-    let content = String::from_utf8(data)?;
+    let content = data;
     let opening_filter = query.opening_filter;
 
     // Process on blocking thread pool (CPU-intensive). Bundle the 3D
@@ -306,7 +306,7 @@ pub async fn parse_stream(
     // Extract file
     let data = extract_file(&mut multipart, state.config.max_file_size_mb).await?;
 
-    let content = String::from_utf8(data)?;
+    let content = data;
     let initial_batch_size = state.config.initial_batch_size;
     let max_batch_size = state.config.max_batch_size;
 
@@ -384,9 +384,9 @@ pub async fn parse_parquet_stream(
     Query(query): Query<ParseQuery>,
     mut multipart: Multipart,
 ) -> Result<axum::response::Response, ApiError> {
-    use axum::response::IntoResponse;
     use crate::services::serialize_to_parquet;
     use crate::types::MeshData;
+    use axum::response::IntoResponse;
     use base64::{engine::general_purpose::STANDARD, Engine};
     use futures::StreamExt;
     use std::sync::{Arc, Mutex};
@@ -472,7 +472,7 @@ pub async fn parse_parquet_stream(
         "Streaming cache MISS - processing file"
     );
 
-    let content = String::from_utf8(data)?;
+    let content = data;
     let initial_batch_size = state.config.initial_batch_size;
     let max_batch_size = state.config.max_batch_size;
     let cache = state.cache.clone();
@@ -680,7 +680,7 @@ pub async fn parse_metadata(
     let data = extract_file(&mut multipart, state.config.max_file_size_mb).await?;
 
     let file_size = data.len();
-    let content = String::from_utf8(data)?;
+    let content = data;
 
     // Fast path - just scan entities, no geometry processing
     let result = tokio::task::spawn_blocking(move || {
@@ -696,9 +696,15 @@ pub async fn parse_metadata(
         }
 
         // Detect schema version
-        let schema_version = if content.contains("IFC4X3") {
+        let schema_version = if content
+            .windows(b"IFC4X3".len())
+            .any(|window| window == b"IFC4X3")
+        {
             "IFC4X3"
-        } else if content.contains("IFC4") {
+        } else if content
+            .windows(b"IFC4".len())
+            .any(|window| window == b"IFC4")
+        {
             "IFC4"
         } else {
             "IFC2X3"
@@ -779,7 +785,11 @@ pub async fn parse_parquet(
         let response = Response::builder()
             .status(StatusCode::OK)
             .header(header::CONTENT_TYPE, "application/x-parquet-geometry")
-            .header("X-IFC-Metadata", String::from_utf8(cached_metadata_json)?)
+            .header(
+                "X-IFC-Metadata",
+                String::from_utf8(cached_metadata_json)
+                    .map_err(|error| ApiError::Internal(error.to_string()))?,
+            )
             .header(header::CONTENT_LENGTH, cached_parquet.len())
             .body(Body::from(cached_parquet))
             .map_err(|e| ApiError::Internal(e.to_string()))?;
@@ -794,15 +804,18 @@ pub async fn parse_parquet(
     );
 
     // Parse content
-    let content = String::from_utf8(data)?;
+    let content = data;
 
     // Process geometry and data model extraction + serialization ALL in parallel
     // rayon::join works correctly here because rayon has its own thread pool
     // that's independent of tokio's blocking thread pool
     let serialize_start = tokio::time::Instant::now();
     let opening_filter = query.opening_filter;
-    let ((geometry_result, geometry_parquet), (data_model_stats, data_model_parquet), symbolic_data) =
-        tokio::task::spawn_blocking(move || {
+    let (
+        (geometry_result, geometry_parquet),
+        (data_model_stats, data_model_parquet),
+        symbolic_data,
+    ) = tokio::task::spawn_blocking(move || {
             // First: extract geometry, data model, and the 2D symbol stream
             // (IfcAnnotation + IfcGrid) all in parallel. Symbolic extraction is
             // added here for endpoint parity (issue #900).
@@ -981,7 +994,7 @@ pub async fn parse_parquet_optimized(
     );
 
     // Parse content
-    let content = String::from_utf8(data)?;
+    let content = data;
     let opening_filter = query.opening_filter;
 
     // Process on blocking thread pool (CPU-intensive). Extract the 2D symbol
@@ -1225,7 +1238,11 @@ pub async fn get_cached_geometry(
             let response = Response::builder()
                 .status(StatusCode::OK)
                 .header(header::CONTENT_TYPE, "application/x-parquet-geometry")
-                .header("X-IFC-Metadata", String::from_utf8(metadata)?)
+                .header(
+                    "X-IFC-Metadata",
+                    String::from_utf8(metadata)
+                        .map_err(|error| ApiError::Internal(error.to_string()))?,
+                )
                 .header(header::CONTENT_LENGTH, parquet.len())
                 .body(Body::from(parquet))
                 .map_err(|e| ApiError::Internal(e.to_string()))?;

--- a/apps/server/src/services/data_model.rs
+++ b/apps/server/src/services/data_model.rs
@@ -212,7 +212,11 @@ struct EntityJob {
 }
 
 /// Extract complete data model from IFC content.
-pub fn extract_data_model(content: &str) -> DataModel {
+pub fn extract_data_model<T>(content: &T) -> DataModel
+where
+    T: AsRef<[u8]> + ?Sized,
+{
+    let content = content.as_ref();
     let extract_start = std::time::Instant::now();
     tracing::info!(
         content_size = content.len(),
@@ -305,7 +309,7 @@ pub fn extract_data_model(content: &str) -> DataModel {
     }
 
     // Parallel extraction using rayon::join
-    let content_arc = Arc::new(content.to_string());
+    let content_arc = Arc::new(content.to_vec());
     let (entities, ((property_sets, quantity_sets), relationships)) = rayon::join(
         || extract_entity_metadata(&all_entities, &content_arc, &entity_index),
         || {
@@ -347,7 +351,14 @@ pub fn extract_data_model(content: &str) -> DataModel {
         || {
             rayon::join(
                 || extract_classifications(&all_entities, &content_arc, &entity_index),
-                || extract_materials(&all_entities, &content_arc, &entity_index, length_unit_scale),
+                || {
+                    extract_materials(
+                        &all_entities,
+                        &content_arc,
+                        &entity_index,
+                        length_unit_scale,
+                    )
+                },
             )
         },
         || extract_documents(&all_entities, &content_arc, &entity_index),
@@ -391,12 +402,13 @@ pub fn extract_data_model(content: &str) -> DataModel {
 /// Extract entity metadata for all entities.
 fn extract_entity_metadata(
     jobs: &[EntityJob],
-    content: &Arc<String>,
+    content: &Arc<Vec<u8>>,
     entity_index: &Arc<ifc_lite_core::EntityIndex>,
 ) -> Vec<EntityMetadata> {
     jobs.par_iter()
         .filter_map(|job| {
-            let mut local_decoder = EntityDecoder::with_arc_index(content, entity_index.clone());
+            let mut local_decoder =
+                EntityDecoder::with_arc_index(content.as_slice(), entity_index.clone());
             let entity = local_decoder.decode_at(job.start, job.end).ok()?;
 
             let global_id = entity.get_string(0).map(|s| s.to_string());
@@ -417,7 +429,7 @@ fn extract_entity_metadata(
 /// Extract all property sets and their properties.
 fn extract_properties(
     jobs: &[EntityJob],
-    content: &Arc<String>,
+    content: &Arc<Vec<u8>>,
     entity_index: &Arc<ifc_lite_core::EntityIndex>,
 ) -> Vec<PropertySet> {
     // First, collect all PropertySet entities
@@ -432,7 +444,8 @@ fn extract_properties(
     pset_jobs
         .par_iter()
         .filter_map(|job| {
-            let mut local_decoder = EntityDecoder::with_arc_index(content, entity_index.clone());
+            let mut local_decoder =
+                EntityDecoder::with_arc_index(content.as_slice(), entity_index.clone());
             let entity = local_decoder.decode_at(job.start, job.end).ok()?;
 
             // IfcPropertySet: [0]=GlobalId, [1]=OwnerHistory, [2]=Name, [3]=Description, [4]=HasProperties
@@ -500,7 +513,7 @@ fn extract_property(entity: &DecodedEntity, _decoder: &mut EntityDecoder) -> Opt
 /// Extract all quantity sets (IfcElementQuantity) and their quantities.
 fn extract_quantities(
     jobs: &[EntityJob],
-    content: &Arc<String>,
+    content: &Arc<Vec<u8>>,
     entity_index: &Arc<ifc_lite_core::EntityIndex>,
 ) -> Vec<QuantitySet> {
     // First, collect all IfcElementQuantity entities
@@ -515,7 +528,8 @@ fn extract_quantities(
     qset_jobs
         .par_iter()
         .filter_map(|job| {
-            let mut local_decoder = EntityDecoder::with_arc_index(content, entity_index.clone());
+            let mut local_decoder =
+                EntityDecoder::with_arc_index(content.as_slice(), entity_index.clone());
             let entity = local_decoder.decode_at(job.start, job.end).ok()?;
 
             // IfcElementQuantity: [0]=GlobalId, [1]=OwnerHistory, [2]=Name, [3]=Description, [4]=MethodOfMeasurement, [5]=Quantities
@@ -591,7 +605,7 @@ fn extract_quantity_value(entity: &DecodedEntity) -> Option<Quantity> {
 /// Extract all relationships.
 fn extract_relationships(
     jobs: &[EntityJob],
-    content: &Arc<String>,
+    content: &Arc<Vec<u8>>,
     entity_index: &Arc<ifc_lite_core::EntityIndex>,
 ) -> Vec<Relationship> {
     // Filter for relationship entities
@@ -620,7 +634,8 @@ fn extract_relationships(
     rel_jobs
         .par_iter()
         .filter_map(|job| {
-            let mut local_decoder = EntityDecoder::with_arc_index(content, entity_index.clone());
+            let mut local_decoder =
+                EntityDecoder::with_arc_index(content.as_slice(), entity_index.clone());
             let entity = local_decoder.decode_at(job.start, job.end).ok()?;
 
             extract_relationship(&entity, &job.type_name)
@@ -692,14 +707,28 @@ fn related_object_ids(rel: &DecodedEntity) -> Vec<u32> {
 fn resolve_classification(
     decoder: &mut EntityDecoder,
     id: u32,
-) -> (Option<String>, Option<String>, Option<String>, Option<String>) {
+) -> (
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+) {
     let Ok(entity) = decoder.decode_by_id(id) else {
         return (None, None, None, None);
     };
 
-    if entity.ifc_type.as_str().eq_ignore_ascii_case("IFCCLASSIFICATION") {
+    if entity
+        .ifc_type
+        .as_str()
+        .eq_ignore_ascii_case("IFCCLASSIFICATION")
+    {
         // Directly an IfcClassification: Name is attribute 3.
-        return (None, None, None, entity.get_string(3).map(|s| s.to_string()));
+        return (
+            None,
+            None,
+            None,
+            entity.get_string(3).map(|s| s.to_string()),
+        );
     }
 
     // IfcClassificationReference: Location(0), Identification(1), Name(2),
@@ -717,8 +746,14 @@ fn resolve_classification(
             break;
         }
         depth += 1;
-        let Ok(src) = decoder.decode_by_id(src_id) else { break };
-        if src.ifc_type.as_str().eq_ignore_ascii_case("IFCCLASSIFICATION") {
+        let Ok(src) = decoder.decode_by_id(src_id) else {
+            break;
+        };
+        if src
+            .ifc_type
+            .as_str()
+            .eq_ignore_ascii_case("IFCCLASSIFICATION")
+        {
             system_name = src.get_string(3).map(|s| s.to_string());
             break;
         }
@@ -732,12 +767,15 @@ fn resolve_classification(
 /// Extract classification associations (`IfcRelAssociatesClassification`).
 fn extract_classifications(
     jobs: &[EntityJob],
-    content: &Arc<String>,
+    content: &Arc<Vec<u8>>,
     entity_index: &Arc<ifc_lite_core::EntityIndex>,
 ) -> Vec<ClassificationAssociation> {
     let rel_jobs: Vec<_> = jobs
         .iter()
-        .filter(|job| job.type_name.eq_ignore_ascii_case("IFCRELASSOCIATESCLASSIFICATION"))
+        .filter(|job| {
+            job.type_name
+                .eq_ignore_ascii_case("IFCRELASSOCIATESCLASSIFICATION")
+        })
         .collect();
 
     tracing::debug!(count = rel_jobs.len(), "Extracting classifications");
@@ -745,7 +783,8 @@ fn extract_classifications(
     rel_jobs
         .par_iter()
         .flat_map(|job| {
-            let mut decoder = EntityDecoder::with_arc_index(content, entity_index.clone());
+            let mut decoder =
+                EntityDecoder::with_arc_index(content.as_slice(), entity_index.clone());
             let Ok(rel) = decoder.decode_at(job.start, job.end) else {
                 return Vec::new();
             };
@@ -944,13 +983,16 @@ fn resolve_material(decoder: &mut EntityDecoder, id: u32, unit_scale: f64) -> Ve
 /// Extract material associations (`IfcRelAssociatesMaterial`).
 fn extract_materials(
     jobs: &[EntityJob],
-    content: &Arc<String>,
+    content: &Arc<Vec<u8>>,
     entity_index: &Arc<ifc_lite_core::EntityIndex>,
     unit_scale: f64,
 ) -> Vec<MaterialAssociation> {
     let rel_jobs: Vec<_> = jobs
         .iter()
-        .filter(|job| job.type_name.eq_ignore_ascii_case("IFCRELASSOCIATESMATERIAL"))
+        .filter(|job| {
+            job.type_name
+                .eq_ignore_ascii_case("IFCRELASSOCIATESMATERIAL")
+        })
         .collect();
 
     tracing::debug!(count = rel_jobs.len(), "Extracting materials");
@@ -958,7 +1000,8 @@ fn extract_materials(
     rel_jobs
         .par_iter()
         .flat_map(|job| {
-            let mut decoder = EntityDecoder::with_arc_index(content, entity_index.clone());
+            let mut decoder =
+                EntityDecoder::with_arc_index(content.as_slice(), entity_index.clone());
             let Ok(rel) = decoder.decode_at(job.start, job.end) else {
                 return Vec::new();
             };
@@ -995,7 +1038,12 @@ fn extract_materials(
 fn resolve_document(
     decoder: &mut EntityDecoder,
     id: u32,
-) -> (Option<String>, Option<String>, Option<String>, Option<String>) {
+) -> (
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+) {
     let Ok(entity) = decoder.decode_by_id(id) else {
         return (None, None, None, None);
     };
@@ -1021,8 +1069,13 @@ fn resolve_document(
     // Backfill missing fields from the referenced IfcDocumentInformation.
     if let Some(info_id) = entity.get_ref(4) {
         if let Ok(info) = decoder.decode_by_id(info_id) {
-            if info.ifc_type.as_str().eq_ignore_ascii_case("IFCDOCUMENTINFORMATION") {
-                identification = identification.or_else(|| info.get_string(0).map(|s| s.to_string()));
+            if info
+                .ifc_type
+                .as_str()
+                .eq_ignore_ascii_case("IFCDOCUMENTINFORMATION")
+            {
+                identification =
+                    identification.or_else(|| info.get_string(0).map(|s| s.to_string()));
                 name = name.or_else(|| info.get_string(1).map(|s| s.to_string()));
                 description = description.or_else(|| info.get_string(2).map(|s| s.to_string()));
                 location = location.or_else(|| info.get_string(3).map(|s| s.to_string()));
@@ -1036,12 +1089,15 @@ fn resolve_document(
 /// Extract document associations (`IfcRelAssociatesDocument`).
 fn extract_documents(
     jobs: &[EntityJob],
-    content: &Arc<String>,
+    content: &Arc<Vec<u8>>,
     entity_index: &Arc<ifc_lite_core::EntityIndex>,
 ) -> Vec<DocumentAssociation> {
     let rel_jobs: Vec<_> = jobs
         .iter()
-        .filter(|job| job.type_name.eq_ignore_ascii_case("IFCRELASSOCIATESDOCUMENT"))
+        .filter(|job| {
+            job.type_name
+                .eq_ignore_ascii_case("IFCRELASSOCIATESDOCUMENT")
+        })
         .collect();
 
     tracing::debug!(count = rel_jobs.len(), "Extracting documents");
@@ -1049,7 +1105,8 @@ fn extract_documents(
     rel_jobs
         .par_iter()
         .flat_map(|job| {
-            let mut decoder = EntityDecoder::with_arc_index(content, entity_index.clone());
+            let mut decoder =
+                EntityDecoder::with_arc_index(content.as_slice(), entity_index.clone());
             let Ok(rel) = decoder.decode_at(job.start, job.end) else {
                 return Vec::new();
             };
@@ -1079,7 +1136,7 @@ fn extract_documents(
 fn build_spatial_hierarchy(
     relationships: &[Relationship],
     entities: &[EntityMetadata],
-    content: &str,
+    content: &[u8],
     entity_index: &Arc<ifc_lite_core::EntityIndex>,
     length_unit_scale: f64,
 ) -> SpatialHierarchyData {
@@ -1431,10 +1488,16 @@ END-ISO-10303-21;
         assert_eq!(layers[0].element_id, 28);
         assert_eq!(layers[0].set_name.as_deref(), Some("WallSet"));
         assert_eq!(layers[0].material_name, "Concrete");
-        assert!((layers[0].thickness.unwrap() - 0.2).abs() < 1e-9, "200mm -> 0.2m");
+        assert!(
+            (layers[0].thickness.unwrap() - 0.2).abs() < 1e-9,
+            "200mm -> 0.2m"
+        );
         assert_eq!(layers[0].is_ventilated, Some(false));
         assert_eq!(layers[1].material_name, "Insulation");
-        assert!((layers[1].thickness.unwrap() - 0.05).abs() < 1e-9, "50mm -> 0.05m");
+        assert!(
+            (layers[1].thickness.unwrap() - 0.05).abs() < 1e-9,
+            "50mm -> 0.05m"
+        );
         assert_eq!(layers[1].is_ventilated, Some(true));
 
         // Document.
@@ -1448,7 +1511,11 @@ END-ISO-10303-21;
         // Material constituent set on the column (#60) — constituents read from
         // attribute 2, set name preserved from attribute 0.
         let column_mats: Vec<_> = dm.materials.iter().filter(|m| m.element_id == 60).collect();
-        assert_eq!(column_mats.len(), 1, "expected one constituent for the column");
+        assert_eq!(
+            column_mats.len(),
+            1,
+            "expected one constituent for the column"
+        );
         assert_eq!(column_mats[0].material_name, "Steel");
         assert_eq!(column_mats[0].set_name.as_deref(), Some("ColSet"));
 

--- a/apps/server/src/services/streaming.rs
+++ b/apps/server/src/services/streaming.rs
@@ -31,8 +31,12 @@ use std::pin::Pin;
 use tokio::sync::mpsc;
 
 /// Generate streaming geometry events backed by the canonical pipeline.
+///
+/// Takes the raw IFC bytes (issue #1023): localized non-UTF-8 byte sequences
+/// in the HEADER must not block otherwise valid models, so no `String`
+/// conversion happens anywhere on this path.
 pub fn process_streaming(
-    content: String,
+    content: Vec<u8>,
     initial_batch_size: usize,
     max_batch_size: usize,
     opening_filter: OpeningFilterMode,
@@ -41,7 +45,7 @@ pub fn process_streaming(
     let (tx, mut rx) = mpsc::unbounded_channel::<StreamEvent>();
 
     let handle = tokio::task::spawn_blocking(move || {
-        let cache_key = DiskCache::generate_key(content.as_bytes());
+        let cache_key = DiskCache::generate_key(&content);
 
         let mut started = false;
         let mut batch_number = 0usize;

--- a/apps/server/src/services/streaming.rs
+++ b/apps/server/src/services/streaming.rs
@@ -30,6 +30,37 @@ use ifc_lite_processing::{
 use std::pin::Pin;
 use tokio::sync::mpsc;
 
+fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+/// Detect the declared IFC schema from the STEP header.
+///
+/// Schema-like text in DATA values or comments must not influence metadata.
+pub(crate) fn detect_schema_version(content: &[u8]) -> &'static str {
+    let header_end = find_bytes(content, b"ENDSEC;").unwrap_or(content.len());
+    let header = &content[..header_end];
+    let Some(schema_start) = find_bytes(header, b"FILE_SCHEMA") else {
+        return "IFC2X3";
+    };
+    let declaration = &header[schema_start..];
+    let declaration_end = declaration
+        .iter()
+        .position(|byte| *byte == b';')
+        .unwrap_or(declaration.len());
+    let declaration = &declaration[..declaration_end];
+
+    if find_bytes(declaration, b"IFC4X3").is_some() {
+        "IFC4X3"
+    } else if find_bytes(declaration, b"IFC4").is_some() {
+        "IFC4"
+    } else {
+        "IFC2X3"
+    }
+}
+
 /// Generate streaming geometry events backed by the canonical pipeline.
 ///
 /// Takes the raw IFC bytes (issue #1023): localized non-UTF-8 byte sequences
@@ -42,6 +73,10 @@ pub fn process_streaming(
     opening_filter: OpeningFilterMode,
     tessellation_quality: TessellationQuality,
 ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send>> {
+    // Zero is a caller bug, not a reason to stall the stream.
+    let initial_batch_size = initial_batch_size.max(1);
+    let max_batch_size = max_batch_size.max(1);
+
     let (tx, mut rx) = mpsc::unbounded_channel::<StreamEvent>();
 
     let handle = tokio::task::spawn_blocking(move || {

--- a/rust/core/examples/test_real_ifc.rs
+++ b/rust/core/examples/test_real_ifc.rs
@@ -7,7 +7,7 @@ use ifc_lite_geometry::GeometryRouter;
 use std::fs;
 
 fn main() {
-    let content = fs::read_to_string("../../../01_Snowdon_Towers_Sample_Structural(1).ifc")
+    let content = fs::read("../../../01_Snowdon_Towers_Sample_Structural(1).ifc")
         .expect("Failed to read IFC file");
 
     println!("File size: {} bytes", content.len());

--- a/rust/core/src/decoder.rs
+++ b/rust/core/src/decoder.rs
@@ -21,7 +21,11 @@ pub type EntityIndex = FxHashMap<u32, (usize, usize)>;
 /// semantics so scan iteration and decoder lookup cannot disagree on malformed
 /// headers or semicolons embedded inside STEP strings.
 #[inline]
-pub fn build_entity_index(content: &str) -> EntityIndex {
+pub fn build_entity_index<T>(content: &T) -> EntityIndex
+where
+    T: AsRef<[u8]> + ?Sized,
+{
+    let content = content.as_ref();
     let estimated_entities = content.len() / 50;
     let mut index = FxHashMap::with_capacity_and_hasher(estimated_entities, Default::default());
     let mut scanner = EntityScanner::new(content);
@@ -32,9 +36,12 @@ pub fn build_entity_index(content: &str) -> EntityIndex {
     index
 }
 
-/// Entity decoder for lazy parsing - uses Arc for efficient cache sharing
+/// Entity decoder for lazy parsing from raw IFC bytes.
+///
+/// String attributes are decoded lossily when tokens become `AttributeValue`s;
+/// structural scanning and byte offsets always use the original source bytes.
 pub struct EntityDecoder<'a> {
-    content: &'a str,
+    content: &'a [u8],
     /// Cache of decoded entities (entity_id -> `Arc<DecodedEntity>`)
     /// Using Arc avoids expensive clones on cache hits
     cache: FxHashMap<u32, Arc<DecodedEntity>>,
@@ -59,7 +66,11 @@ pub struct EntityDecoder<'a> {
 
 impl<'a> EntityDecoder<'a> {
     /// Create new decoder
-    pub fn new(content: &'a str) -> Self {
+    pub fn new<T>(content: &'a T) -> Self
+    where
+        T: AsRef<[u8]> + ?Sized,
+    {
+        let content = content.as_ref();
         Self {
             content,
             cache: FxHashMap::default(),
@@ -71,7 +82,11 @@ impl<'a> EntityDecoder<'a> {
     }
 
     /// Create decoder with pre-built index (faster for repeated lookups)
-    pub fn with_index(content: &'a str, index: EntityIndex) -> Self {
+    pub fn with_index<T>(content: &'a T, index: EntityIndex) -> Self
+    where
+        T: AsRef<[u8]> + ?Sized,
+    {
+        let content = content.as_ref();
         Self {
             content,
             cache: FxHashMap::default(),
@@ -83,7 +98,11 @@ impl<'a> EntityDecoder<'a> {
     }
 
     /// Create decoder with shared Arc index (for parallel processing)
-    pub fn with_arc_index(content: &'a str, index: Arc<EntityIndex>) -> Self {
+    pub fn with_arc_index<T>(content: &'a T, index: Arc<EntityIndex>) -> Self
+    where
+        T: AsRef<[u8]> + ?Sized,
+    {
+        let content = content.as_ref();
         Self {
             content,
             cache: FxHashMap::default(),
@@ -126,16 +145,15 @@ impl<'a> EntityDecoder<'a> {
         }
         let line = &self.content[start..end];
         let (id, ifc_type, tokens) = parse_entity(line).map_err(|e| {
-            // Add debug info about what failed to parse. Truncate on a UTF-8
-            // char boundary so multi-byte UTF-8 in the entity body cannot
-            // panic the worker (decode_at must be panic-safe).
-            let mut cut = line.len().min(100);
-            while cut > 0 && !line.is_char_boundary(cut) {
-                cut -= 1;
-            }
+            // Add bounded, lossy debug info without requiring the source to be UTF-8.
+            let cut = line.len().min(100);
             Error::parse(
                 0,
-                format!("Failed to parse entity: {:?}, input: {:?}", e, &line[..cut]),
+                format!(
+                    "Failed to parse entity: {:?}, input: {:?}",
+                    e,
+                    String::from_utf8_lossy(&line[..cut])
+                ),
             )
         })?;
 
@@ -361,14 +379,6 @@ impl<'a> EntityDecoder<'a> {
     /// Returns the full entity line including type and attributes
     #[inline]
     pub fn get_raw_bytes(&mut self, entity_id: u32) -> Option<&'a [u8]> {
-        self.build_index();
-        let (start, end) = self.entity_index.as_ref()?.get(&entity_id).copied()?;
-        Some(&self.content.as_bytes()[start..end])
-    }
-
-    /// Get raw content string for an entity
-    #[inline]
-    pub fn get_raw_content(&mut self, entity_id: u32) -> Option<&'a str> {
         self.build_index();
         let (start, end) = self.entity_index.as_ref()?.get(&entity_id).copied()?;
         Some(&self.content[start..end])
@@ -706,7 +716,7 @@ impl<'a> EntityDecoder<'a> {
         // Ensure index is built once
         self.build_index();
         let index = self.entity_index.as_ref()?;
-        let bytes_full = self.content.as_bytes();
+        let bytes_full = self.content;
 
         // Get polyloop raw bytes
         let (start, end) = index.get(&entity_id).copied()?;
@@ -793,7 +803,7 @@ impl<'a> EntityDecoder<'a> {
         // Ensure index is built once
         self.build_index();
         let index = self.entity_index.as_ref()?;
-        let bytes_full = self.content.as_bytes();
+        let bytes_full = self.content;
 
         // Get polyloop raw bytes
         let (start, end) = index.get(&entity_id).copied()?;

--- a/rust/core/src/lib.rs
+++ b/rust/core/src/lib.rs
@@ -22,7 +22,7 @@
 //! use ifc_lite_core::{EntityScanner, parse_entity, IfcType};
 //!
 //! // Scan for entities
-//! let content = r#"#1=IFCPROJECT('guid',$,$,$,$,$,$,$,$);"#;
+//! let content = br#"#1=IFCPROJECT('guid',$,$,$,$,$,$,$,$);"#;
 //! let mut scanner = EntityScanner::new(content);
 //!
 //! while let Some((id, type_name, start, end)) = scanner.next_entity() {
@@ -30,7 +30,7 @@
 //! }
 //!
 //! // Parse individual entity
-//! let input = "#123=IFCWALL('guid',$,$,$,$,$,$,$);";
+//! let input = b"#123=IFCWALL('guid',$,$,$,$,$,$,$);";
 //! let (id, ifc_type, attrs) = parse_entity(input).unwrap();
 //! assert_eq!(ifc_type, IfcType::IfcWall);
 //! ```

--- a/rust/core/src/model_bounds.rs
+++ b/rust/core/src/model_bounds.rs
@@ -116,7 +116,11 @@ impl Default for ModelBounds {
 /// # Performance
 /// This scans through the file once, looking for IFCCARTESIANPOINT patterns.
 /// It's much faster than full entity parsing since it only extracts coordinates.
-pub fn scan_model_bounds(content: &str) -> ModelBounds {
+pub fn scan_model_bounds<T>(content: &T) -> ModelBounds
+where
+    T: AsRef<[u8]> + ?Sized,
+{
+    let content = content.as_ref();
     let mut bounds = ModelBounds::new();
 
     // Use EntityScanner for efficient scanning
@@ -149,7 +153,12 @@ pub fn scan_model_bounds(content: &str) -> ModelBounds {
 
 /// Extract coordinates from IfcCartesianPoint text
 /// Format: IFCCARTESIANPOINT((x,y)) or IFCCARTESIANPOINT((x,y,z))
-fn extract_point_coordinates(text: &str) -> Option<(f64, f64, Option<f64>)> {
+fn extract_point_coordinates<T>(bytes: &T) -> Option<(f64, f64, Option<f64>)>
+where
+    T: AsRef<[u8]> + ?Sized,
+{
+    let bytes = bytes.as_ref();
+    let text = std::str::from_utf8(bytes).ok()?;
     // Find the coordinate list between (( and ))
     let start = text.find("((")?;
     let end = text.rfind("))")?;
@@ -183,7 +192,11 @@ fn extract_point_coordinates(text: &str) -> Option<(f64, f64, Option<f64>)> {
 /// This variant specifically looks at IfcLocalPlacement and transformation
 /// coordinates, which are more representative of where geometry will be placed.
 /// Useful for models where cartesian points include local/relative coordinates.
-pub fn scan_placement_bounds(content: &str) -> ModelBounds {
+pub fn scan_placement_bounds<T>(content: &T) -> ModelBounds
+where
+    T: AsRef<[u8]> + ?Sized,
+{
+    let content = content.as_ref();
     let mut bounds = ModelBounds::new();
     let mut scanner = EntityScanner::new(content);
 
@@ -250,7 +263,12 @@ pub fn scan_placement_bounds(content: &str) -> ModelBounds {
 
 /// Extract first entity reference from text
 /// Looks for #xxx pattern
-fn extract_first_reference(text: &str) -> Option<u32> {
+fn extract_first_reference<T>(bytes: &T) -> Option<u32>
+where
+    T: AsRef<[u8]> + ?Sized,
+{
+    let bytes = bytes.as_ref();
+    let text = std::str::from_utf8(bytes).ok()?;
     // Find opening paren of attribute list
     let start = text.find('(')?;
     let rest = &text[start + 1..];

--- a/rust/core/src/parser.rs
+++ b/rust/core/src/parser.rs
@@ -19,23 +19,27 @@ use nom::{
 use crate::error::{Error, Result};
 use crate::generated::IfcType;
 
-/// STEP/IFC Token
+/// STEP/IFC token.
+///
+/// String-like tokens borrow their original bytes. Decode them only at a
+/// user-facing boundary so malformed real-world encodings cannot invalidate
+/// the structural parser.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Token<'a> {
     /// Entity reference: #123
     EntityRef(u32),
     /// String literal: 'text'
-    String(&'a str),
+    String(&'a [u8]),
     /// Integer: 42
     Integer(i64),
     /// Float: 3.14
     Float(f64),
     /// Enum: .TRUE., .FALSE., .UNKNOWN.
-    Enum(&'a str),
+    Enum(&'a [u8]),
     /// List: (1, 2, 3)
     List(Vec<Token<'a>>),
     /// Typed value: IFCPARAMETERVALUE(0.), IFCBOOLEAN(.T.)
-    TypedValue(&'a str, Vec<Token<'a>>),
+    TypedValue(&'a [u8], Vec<Token<'a>>),
     /// Null value: $
     Null,
     /// Asterisk (derived value): *
@@ -43,9 +47,9 @@ pub enum Token<'a> {
 }
 
 /// Parse entity reference: #123
-fn entity_ref(input: &str) -> IResult<&str, Token<'_>> {
+fn entity_ref(input: &[u8]) -> IResult<&[u8], Token<'_>> {
     map(
-        preceded(char('#'), map_res(digit1, |s: &str| s.parse::<u32>())),
+        preceded(char('#'), map_res(digit1, lexical_core::parse::<u32>)),
         Token::EntityRef,
     )(input)
 }
@@ -53,11 +57,11 @@ fn entity_ref(input: &str) -> IResult<&str, Token<'_>> {
 /// Parse string literal: 'text' or "text"
 /// IFC uses '' to escape a single quote within a string
 /// Uses memchr for SIMD-accelerated quote searching
-fn string_literal(input: &str) -> IResult<&str, Token<'_>> {
+fn string_literal(input: &[u8]) -> IResult<&[u8], Token<'_>> {
     // Helper to parse string content with escaped quotes - SIMD optimized
     #[inline]
-    fn parse_string_content(input: &str, quote_byte: u8) -> IResult<&str, &str> {
-        let bytes = input.as_bytes();
+    fn parse_string_content(input: &[u8], quote_byte: u8) -> IResult<&[u8], &[u8]> {
+        let bytes = input;
         let mut pos = 0;
 
         // Use memchr for SIMD-accelerated searching
@@ -94,9 +98,9 @@ fn string_literal(input: &str) -> IResult<&str, Token<'_>> {
 /// Parse integer: 42, -42
 /// Uses lexical-core for 10x faster parsing
 #[inline]
-fn integer(input: &str) -> IResult<&str, Token<'_>> {
-    map_res(recognize(tuple((opt(char('-')), digit1))), |s: &str| {
-        lexical_core::parse::<i64>(s.as_bytes())
+fn integer(input: &[u8]) -> IResult<&[u8], Token<'_>> {
+    map_res(recognize(tuple((opt(char('-')), digit1))), |s: &[u8]| {
+        lexical_core::parse::<i64>(s)
             .map(Token::Integer)
             .map_err(|_| "parse error")
     })(input)
@@ -106,7 +110,7 @@ fn integer(input: &str) -> IResult<&str, Token<'_>> {
 /// IFC allows floats like "0." without decimal digits
 /// Uses lexical-core for 10x faster parsing
 #[inline]
-fn float(input: &str) -> IResult<&str, Token<'_>> {
+fn float(input: &[u8]) -> IResult<&[u8], Token<'_>> {
     map_res(
         recognize(tuple((
             opt(char('-')),
@@ -115,8 +119,8 @@ fn float(input: &str) -> IResult<&str, Token<'_>> {
             opt(digit1), // Made optional to support "0." format
             opt(tuple((one_of("eE"), opt(one_of("+-")), digit1))),
         ))),
-        |s: &str| {
-            lexical_core::parse::<f64>(s.as_bytes())
+        |s: &[u8]| {
+            lexical_core::parse::<f64>(s)
                 .map(Token::Float)
                 .map_err(|_| "parse error")
         },
@@ -124,11 +128,11 @@ fn float(input: &str) -> IResult<&str, Token<'_>> {
 }
 
 /// Parse enum: .TRUE., .FALSE., .UNKNOWN., .ELEMENT.
-fn enum_value(input: &str) -> IResult<&str, Token<'_>> {
+fn enum_value(input: &[u8]) -> IResult<&[u8], Token<'_>> {
     map(
         delimited(
             char('.'),
-            take_while1(|c: char| c.is_alphanumeric() || c == '_'),
+            take_while1(|c: u8| c.is_ascii_alphanumeric() || c == b'_'),
             char('.'),
         ),
         Token::Enum,
@@ -136,12 +140,12 @@ fn enum_value(input: &str) -> IResult<&str, Token<'_>> {
 }
 
 /// Parse null: $
-fn null(input: &str) -> IResult<&str, Token<'_>> {
+fn null(input: &[u8]) -> IResult<&[u8], Token<'_>> {
     map(char('$'), |_| Token::Null)(input)
 }
 
 /// Parse derived: *
-fn derived(input: &str) -> IResult<&str, Token<'_>> {
+fn derived(input: &[u8]) -> IResult<&[u8], Token<'_>> {
     map(char('*'), |_| Token::Derived)(input)
 }
 
@@ -153,11 +157,11 @@ fn derived(input: &str) -> IResult<&str, Token<'_>> {
 const MAX_NESTING_DEPTH: u32 = 256;
 
 /// Parse typed value: IFCPARAMETERVALUE(0.), IFCBOOLEAN(.T.)
-fn typed_value_at_depth(input: &str, depth: u32) -> IResult<&str, Token<'_>> {
+fn typed_value_at_depth(input: &[u8], depth: u32) -> IResult<&[u8], Token<'_>> {
     map(
         pair(
             // Type name (all caps with optional numbers/underscores)
-            take_while1(|c: char| c.is_alphanumeric() || c == '_'),
+            take_while1(|c: u8| c.is_ascii_alphanumeric() || c == b'_'),
             // Arguments
             delimited(
                 char('('),
@@ -172,17 +176,17 @@ fn typed_value_at_depth(input: &str, depth: u32) -> IResult<&str, Token<'_>> {
 }
 
 /// Skip whitespace
-fn ws(input: &str) -> IResult<&str, ()> {
-    map(take_while(|c: char| c.is_whitespace()), |_| ())(input)
+fn ws(input: &[u8]) -> IResult<&[u8], ()> {
+    map(take_while(|c: u8| c.is_ascii_whitespace()), |_| ())(input)
 }
 
 /// Parse a token with optional surrounding whitespace
 /// Optimized ordering: test cheapest patterns first (single-char markers)
-fn token(input: &str) -> IResult<&str, Token<'_>> {
+fn token(input: &[u8]) -> IResult<&[u8], Token<'_>> {
     token_at_depth(input, 0)
 }
 
-fn token_at_depth(input: &str, depth: u32) -> IResult<&str, Token<'_>> {
+fn token_at_depth(input: &[u8], depth: u32) -> IResult<&[u8], Token<'_>> {
     if depth > MAX_NESTING_DEPTH {
         return Err(nom::Err::Failure(nom::error::Error::new(
             input,
@@ -213,11 +217,11 @@ fn token_at_depth(input: &str, depth: u32) -> IResult<&str, Token<'_>> {
 /// Parse list: (1, 2, 3) or nested lists
 /// Test-only wrapper for the depth-0 entry into list.
 #[cfg(test)]
-fn list(input: &str) -> IResult<&str, Token<'_>> {
+fn list(input: &[u8]) -> IResult<&[u8], Token<'_>> {
     list_at_depth(input, 0)
 }
 
-fn list_at_depth(input: &str, depth: u32) -> IResult<&str, Token<'_>> {
+fn list_at_depth(input: &[u8], depth: u32) -> IResult<&[u8], Token<'_>> {
     map(
         delimited(
             char('('),
@@ -230,14 +234,18 @@ fn list_at_depth(input: &str, depth: u32) -> IResult<&str, Token<'_>> {
     )(input)
 }
 
-/// Parse a complete entity line
+/// Parse a complete entity line from raw IFC bytes.
 /// Example: #123=IFCWALL('guid','owner',$,$,'name',$,$,$);
-pub fn parse_entity(input: &str) -> Result<(u32, IfcType, Vec<Token<'_>>)> {
-    let result: IResult<&str, (u32, &str, Vec<Token>)> = tuple((
+pub fn parse_entity<'a, T>(input: &'a T) -> Result<(u32, IfcType, Vec<Token<'a>>)>
+where
+    T: AsRef<[u8]> + ?Sized,
+{
+    let input = input.as_ref();
+    let result: IResult<&[u8], (u32, &[u8], Vec<Token>)> = tuple((
         // Entity ID: #123
         delimited(
             ws,
-            preceded(char('#'), map_res(digit1, |s: &str| s.parse::<u32>())),
+            preceded(char('#'), map_res(digit1, lexical_core::parse::<u32>)),
             ws,
         ),
         // Equals sign
@@ -246,7 +254,7 @@ pub fn parse_entity(input: &str) -> Result<(u32, IfcType, Vec<Token<'_>>)> {
             // Entity type: IFCWALL
             delimited(
                 ws,
-                take_while1(|c: char| c.is_alphanumeric() || c == '_'),
+                take_while1(|c: u8| c.is_ascii_alphanumeric() || c == b'_'),
                 ws,
             ),
         ),
@@ -260,6 +268,8 @@ pub fn parse_entity(input: &str) -> Result<(u32, IfcType, Vec<Token<'_>>)> {
 
     match result {
         Ok((_, (id, type_str, args))) => {
+            let type_str = std::str::from_utf8(type_str)
+                .map_err(|_| Error::parse(0, "Entity type is not ASCII/UTF-8"))?;
             let ifc_type = IfcType::from_str(type_str);
             Ok((id, ifc_type, args))
         }
@@ -267,12 +277,10 @@ pub fn parse_entity(input: &str) -> Result<(u32, IfcType, Vec<Token<'_>>)> {
     }
 }
 
-/// Fast entity scanner - scans file without full parsing
+/// Fast entity scanner over raw IFC bytes without full parsing.
 /// O(n) performance for finding entities by type
 /// Uses memchr for SIMD-accelerated byte searching
 pub struct EntityScanner<'a> {
-    #[allow(dead_code)]
-    content: &'a str,
     bytes: &'a [u8],
     position: usize,
 }
@@ -284,10 +292,12 @@ impl<'a> EntityScanner<'a> {
     /// stray `#` inside a header string (e.g. a CATIA `FILE_NAME` like
     /// `'…\X0\2#.ifc'`) can't be mistaken for an entity start and corrupt
     /// quote-parity for the rest of the file (issue #654).
-    pub fn new(content: &'a str) -> Self {
-        let bytes = content.as_bytes();
+    pub fn new<T>(content: &'a T) -> Self
+    where
+        T: AsRef<[u8]> + ?Sized,
+    {
+        let bytes = content.as_ref();
         Self {
-            content,
             bytes,
             position: data_section_start(bytes),
         }
@@ -303,10 +313,16 @@ impl<'a> EntityScanner<'a> {
     ///
     /// Does NOT auto-skip the HEADER section — that's the caller's
     /// responsibility, since shards expect the exact offset they were given.
-    pub fn new_at(content: &'a str, position: usize) -> Self {
-        let bytes = content.as_bytes();
+    pub fn new_at<T>(content: &'a T, position: usize) -> Self
+    where
+        T: AsRef<[u8]> + ?Sized,
+    {
+        let bytes = content.as_ref();
         let clamped = position.min(bytes.len());
-        Self { content, bytes, position: clamped }
+        Self {
+            bytes,
+            position: clamped,
+        }
     }
 
     /// Current byte offset of the scanner (start of the next entity to scan).
@@ -673,10 +689,7 @@ fn data_section_start(bytes: &[u8]) -> usize {
             pos += 1;
             continue;
         }
-        if b == b'D'
-            && pos + MARKER.len() <= len
-            && &bytes[pos..pos + MARKER.len()] == MARKER
-        {
+        if b == b'D' && pos + MARKER.len() <= len && &bytes[pos..pos + MARKER.len()] == MARKER {
             return pos + MARKER.len();
         }
         pos += 1;
@@ -692,30 +705,30 @@ mod tests {
     #[test]
     #[allow(clippy::approx_constant)]
     fn test_basic_tokens() {
-        type Parser = for<'a> fn(&'a str) -> IResult<&'a str, Token<'a>>;
-        let cases: &[(Parser, &str, Token)] = &[
-            (entity_ref, "#123", Token::EntityRef(123)),
-            (entity_ref, "#0", Token::EntityRef(0)),
-            (string_literal, "'hello'", Token::String("hello")),
+        type Parser = for<'a> fn(&'a [u8]) -> IResult<&'a [u8], Token<'a>>;
+        let cases: &[(Parser, &[u8], Token)] = &[
+            (entity_ref, b"#123", Token::EntityRef(123)),
+            (entity_ref, b"#0", Token::EntityRef(0)),
+            (string_literal, b"'hello'", Token::String(b"hello")),
             (
                 string_literal,
-                "'with spaces'",
-                Token::String("with spaces"),
+                b"'with spaces'",
+                Token::String(b"with spaces"),
             ),
-            (integer, "42", Token::Integer(42)),
-            (integer, "-42", Token::Integer(-42)),
-            (integer, "0", Token::Integer(0)),
-            (float, "3.14", Token::Float(3.14)),
-            (float, "-3.14", Token::Float(-3.14)),
-            (float, "1.5E-10", Token::Float(1.5e-10)),
-            (enum_value, ".TRUE.", Token::Enum("TRUE")),
-            (enum_value, ".FALSE.", Token::Enum("FALSE")),
-            (enum_value, ".ELEMENT.", Token::Enum("ELEMENT")),
+            (integer, b"42", Token::Integer(42)),
+            (integer, b"-42", Token::Integer(-42)),
+            (integer, b"0", Token::Integer(0)),
+            (float, b"3.14", Token::Float(3.14)),
+            (float, b"-3.14", Token::Float(-3.14)),
+            (float, b"1.5E-10", Token::Float(1.5e-10)),
+            (enum_value, b".TRUE.", Token::Enum(b"TRUE")),
+            (enum_value, b".FALSE.", Token::Enum(b"FALSE")),
+            (enum_value, b".ELEMENT.", Token::Enum(b"ELEMENT")),
         ];
         for (parse, input, expected) in cases {
             assert_eq!(
                 parse(input),
-                Ok(("", expected.clone())),
+                Ok((&b""[..], expected.clone())),
                 "tokenizing {input:?}"
             );
         }
@@ -723,7 +736,7 @@ mod tests {
 
     #[test]
     fn test_list() {
-        let result = list("(1,2,3)");
+        let result = list(b"(1,2,3)");
         assert!(result.is_ok());
         let (_, token) = result.unwrap();
         match token {
@@ -739,7 +752,7 @@ mod tests {
 
     #[test]
     fn test_nested_list() {
-        let result = list("(1,(2,3),4)");
+        let result = list(b"(1,(2,3),4)");
         assert!(result.is_ok());
         let (_, token) = result.unwrap();
         match token {
@@ -776,7 +789,7 @@ mod tests {
         // First test: simple list (should work)
         let simple = "(0.,0.,1.)";
         println!("Testing simple list: {}", simple);
-        let simple_result = list(simple);
+        let simple_result = list(simple.as_bytes());
         println!("Simple list result: {:?}", simple_result);
 
         // Second test: nested in entity (what's failing)
@@ -790,7 +803,7 @@ mod tests {
             // Try parsing just the arguments part
             println!("\nTrying to parse just arguments: ((0.,0.,1.))");
             let args_input = "((0.,0.,1.))";
-            let args_result = list(args_input);
+            let args_result = list(args_input.as_bytes());
             println!("Args list result: {:?}", args_result);
         }
 

--- a/rust/core/src/schema_gen.rs
+++ b/rust/core/src/schema_gen.rs
@@ -57,17 +57,19 @@ impl AttributeValue {
     pub fn from_token(token: &Token) -> Self {
         match token {
             Token::EntityRef(id) => AttributeValue::EntityRef(*id),
-            Token::String(s) => AttributeValue::String(s.to_string()),
+            Token::String(s) => AttributeValue::String(String::from_utf8_lossy(s).into_owned()),
             Token::Integer(i) => AttributeValue::Integer(*i),
             Token::Float(f) => AttributeValue::Float(*f),
-            Token::Enum(e) => AttributeValue::Enum(e.to_string()),
+            Token::Enum(e) => AttributeValue::Enum(String::from_utf8_lossy(e).into_owned()),
             Token::List(items) => {
                 AttributeValue::List(items.iter().map(Self::from_token).collect())
             }
             Token::TypedValue(type_name, args) => {
                 // For typed values like IFCPARAMETERVALUE(0.), extract the inner value
                 // Store as a list with the type name first, followed by args
-                let mut values = vec![AttributeValue::String(type_name.to_string())];
+                let mut values = vec![AttributeValue::String(
+                    String::from_utf8_lossy(type_name).into_owned(),
+                )];
                 values.extend(args.iter().map(Self::from_token));
                 AttributeValue::List(values)
             }
@@ -483,7 +485,7 @@ mod tests {
         let attr = AttributeValue::from_token(&token);
         assert_eq!(attr.as_entity_ref(), Some(123));
 
-        let token = Token::String("test");
+        let token = Token::String(b"test");
         let attr = AttributeValue::from_token(&token);
         assert_eq!(attr.as_string(), Some("test"));
     }

--- a/rust/core/src/streaming.rs
+++ b/rust/core/src/streaming.rs
@@ -101,10 +101,14 @@ impl Default for StreamConfig {
 }
 
 /// Stream IFC file parsing with events
-pub fn parse_stream(
-    content: &str,
+pub fn parse_stream<T>(
+    content: &T,
     config: StreamConfig,
-) -> Pin<Box<dyn Stream<Item = ParseEvent> + '_>> {
+) -> Pin<Box<dyn Stream<Item = ParseEvent> + '_>>
+where
+    T: AsRef<[u8]> + ?Sized,
+{
+    let content = content.as_ref();
     Box::pin(stream::unfold(
         ParserState::new(content, config),
         |mut state| async move { state.next_event().map(|event| (event, state)) },
@@ -113,7 +117,7 @@ pub fn parse_stream(
 
 /// Internal parser state for streaming
 struct ParserState<'a> {
-    content: &'a str,
+    content: &'a [u8],
     scanner: EntityScanner<'a>,
     config: StreamConfig,
     started: bool,
@@ -125,7 +129,7 @@ struct ParserState<'a> {
 }
 
 impl<'a> ParserState<'a> {
-    fn new(content: &'a str, config: StreamConfig) -> Self {
+    fn new(content: &'a [u8], config: StreamConfig) -> Self {
         Self {
             content,
             scanner: EntityScanner::new(content),

--- a/rust/core/tests/issue_1023_non_utf8_bytes.rs
+++ b/rust/core/tests/issue_1023_non_utf8_bytes.rs
@@ -1,0 +1,46 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner};
+
+fn fixture() -> Vec<u8> {
+    let mut bytes = b"ISO-10303-21;\nHEADER;\nFILE_NAME('caf?',$,$,$,$,$,$);\nENDSEC;\nDATA;\n#1=IFCWALL('guid',$,'M?rz',$,$,$,$,$);\n#2=IFCCARTESIANPOINT((1.,2.,3.));\nENDSEC;\nEND-ISO-10303-21;\n".to_vec();
+    for byte in &mut bytes {
+        if *byte == b'?' {
+            *byte = 0xe9;
+        }
+    }
+    bytes
+}
+
+#[test]
+fn issue_1023_scanner_accepts_non_utf8_and_preserves_offsets() {
+    let bytes = fixture();
+    let expected_start = bytes
+        .windows(b"#1=IFCWALL".len())
+        .position(|window| window == b"#1=IFCWALL")
+        .unwrap();
+
+    let mut scanner = EntityScanner::new(&bytes);
+    let (id, type_name, start, end) = scanner.next_entity().unwrap();
+
+    assert_eq!(id, 1);
+    assert_eq!(type_name, "IFCWALL");
+    assert_eq!(start, expected_start);
+    assert_eq!(&bytes[start..end], &fixture()[start..end]);
+}
+
+#[test]
+fn issue_1023_decoder_lossily_decodes_only_the_invalid_string() {
+    let bytes = fixture();
+    let index = build_entity_index(&bytes);
+    let mut decoder = EntityDecoder::with_index(&bytes, index);
+
+    let wall = decoder.decode_by_id(1).unwrap();
+    assert_eq!(wall.get_string(2), Some("M\u{fffd}rz"));
+
+    let point = decoder.decode_by_id(2).unwrap();
+    assert_eq!(point.get_list(0).unwrap().len(), 3);
+    assert!(decoder.get_raw_bytes(1).unwrap().contains(&0xe9));
+}

--- a/rust/geometry/src/material_layer_index.rs
+++ b/rust/geometry/src/material_layer_index.rs
@@ -110,7 +110,11 @@ impl MaterialLayerIndex {
     /// object ID. Elements that associate with a non-sliceable material are
     /// still inserted (as `NotSliceable`) so callers can distinguish
     /// "has a material, can't slice" from "no material association at all".
-    pub fn from_content(content: &str, decoder: &mut EntityDecoder) -> Self {
+    pub fn from_content<T>(content: &T, decoder: &mut EntityDecoder) -> Self
+    where
+        T: AsRef<[u8]> + ?Sized,
+    {
+        let content = content.as_ref();
         let mut index = Self::new();
         let mut scanner = EntityScanner::new(content);
 
@@ -227,15 +231,16 @@ fn resolve_buildup(material_select_id: u32, decoder: &mut EntityDecoder) -> Laye
 ///   1: LayerSetDirection (IfcLayerSetDirectionEnum)
 ///   2: DirectionSense (IfcDirectionSenseEnum)
 ///   3: OffsetFromReferenceLine (IfcLengthMeasure)
-fn resolve_layer_set_usage(
-    usage: &DecodedEntity,
-    decoder: &mut EntityDecoder,
-) -> LayerBuildup {
+fn resolve_layer_set_usage(usage: &DecodedEntity, decoder: &mut EntityDecoder) -> LayerBuildup {
     let layer_set_id = match usage.get_ref(0) {
         Some(id) => id,
         None => return LayerBuildup::NotSliceable,
     };
-    let axis = match usage.get(1).and_then(|a| a.as_enum()).map(str::to_ascii_uppercase) {
+    let axis = match usage
+        .get(1)
+        .and_then(|a| a.as_enum())
+        .map(str::to_ascii_uppercase)
+    {
         Some(s) if s == "AXIS1" => LayerAxis::Axis1,
         Some(s) if s == "AXIS2" => LayerAxis::Axis2,
         Some(s) if s == "AXIS3" => LayerAxis::Axis3,
@@ -243,7 +248,10 @@ fn resolve_layer_set_usage(
         // rather than guess, treat as unsliceable.
         _ => return LayerBuildup::NotSliceable,
     };
-    let direction_sense = match usage.get(2).and_then(|a| a.as_enum()).map(str::to_ascii_uppercase)
+    let direction_sense = match usage
+        .get(2)
+        .and_then(|a| a.as_enum())
+        .map(str::to_ascii_uppercase)
     {
         Some(s) if s == "POSITIVE" => 1.0_f64,
         Some(s) if s == "NEGATIVE" => -1.0_f64,
@@ -290,7 +298,10 @@ fn resolve_layer_set_usage(
             // Skip the layer rather than the whole buildup.
             continue;
         }
-        layers.push(LayerInfo { material_id, thickness });
+        layers.push(LayerInfo {
+            material_id,
+            thickness,
+        });
     }
 
     if layers.len() < 2 {

--- a/rust/geometry/src/processors/texture.rs
+++ b/rust/geometry/src/processors/texture.rs
@@ -347,11 +347,14 @@ fn resolve_triangle_texture_map(
 /// keyed by the face set id each one maps to (issue #961). Cheap substring
 /// bail-out keeps untextured files (the overwhelming majority) off the scan.
 pub fn build_texture_index(
-    content: &str,
+    content: &[u8],
     decoder: &mut EntityDecoder,
 ) -> FxHashMap<u32, ResolvedTextureMap> {
     let mut index = FxHashMap::default();
-    if !content.contains("IFCINDEXEDTRIANGLETEXTUREMAP") {
+    if !content
+        .windows(b"IFCINDEXEDTRIANGLETEXTUREMAP".len())
+        .any(|window| window == b"IFCINDEXEDTRIANGLETEXTUREMAP")
+    {
         return index;
     }
     let mut scanner = EntityScanner::new(content);

--- a/rust/geometry/src/profile_extractor.rs
+++ b/rust/geometry/src/profile_extractor.rs
@@ -82,7 +82,11 @@ pub struct ExtractedProfile {
 /// Extracts `IfcExtrudedAreaSolid` representations, including those nested
 /// inside `IfcMappedItem` chains (up to 3 levels deep).
 /// Returns an empty `Vec` for models with no such elements.
-pub fn extract_profiles(content: &str, model_index: u32) -> Vec<ExtractedProfile> {
+pub fn extract_profiles<T>(content: &T, model_index: u32) -> Vec<ExtractedProfile>
+where
+    T: AsRef<[u8]> + ?Sized,
+{
+    let content = content.as_ref();
     let entity_index = build_entity_index(content);
     let mut decoder = EntityDecoder::with_index(content, entity_index);
 
@@ -715,7 +719,7 @@ fn convert_ifc_to_webgl(m: &Matrix4<f64>) -> [f32; 16] {
 }
 
 /// Detect the IFC length unit scale factor from IFCPROJECT.
-fn detect_unit_scale(content: &str, decoder: &mut EntityDecoder) -> f64 {
+fn detect_unit_scale(content: &[u8], decoder: &mut EntityDecoder) -> f64 {
     let mut scanner = EntityScanner::new(content);
     while let Some((id, type_name, _, _)) = scanner.next_entity() {
         if type_name == "IFCPROJECT" {

--- a/rust/geometry/src/router/mod.rs
+++ b/rust/geometry/src/router/mod.rs
@@ -18,7 +18,6 @@ mod voids_2d;
 mod tests;
 
 use crate::material_layer_index::MaterialLayerIndex;
-use crate::tessellation::TessellationQuality;
 use crate::processors::{
     AdvancedBrepProcessor, BSplineSurfaceProcessor, BlockProcessor, BooleanClippingProcessor,
     CsgSolidProcessor, ExtrudedAreaSolidProcessor, ExtrudedAreaSolidTaperedProcessor,
@@ -27,6 +26,7 @@ use crate::processors::{
     SectionedSolidHorizontalProcessor, ShellBasedSurfaceModelProcessor, SphereProcessor,
     SweptDiskSolidProcessor, TriangulatedFaceSetProcessor,
 };
+use crate::tessellation::TessellationQuality;
 use crate::{BoolFailure, Mesh, Result};
 use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcSchema, IfcType};
 use nalgebra::Matrix4;
@@ -246,7 +246,11 @@ impl GeometryRouter {
 
     /// Create router and extract unit scale from IFC file
     /// Automatically finds IFCPROJECT and extracts length unit conversion
-    pub fn with_units(content: &str, decoder: &mut EntityDecoder) -> Self {
+    pub fn with_units<T>(content: &T, decoder: &mut EntityDecoder) -> Self
+    where
+        T: AsRef<[u8]> + ?Sized,
+    {
+        let content = content.as_ref();
         let mut scanner = ifc_lite_core::EntityScanner::new(content);
         let mut scale = 1.0;
 
@@ -270,11 +274,15 @@ impl GeometryRouter {
     /// * `content` - IFC file content
     /// * `decoder` - Entity decoder
     /// * `rtc_offset` - RTC offset to subtract from world coordinates (typically model centroid)
-    pub fn with_units_and_rtc(
-        content: &str,
+    pub fn with_units_and_rtc<T>(
+        content: &T,
         decoder: &mut ifc_lite_core::EntityDecoder,
         rtc_offset: (f64, f64, f64),
-    ) -> Self {
+    ) -> Self
+    where
+        T: AsRef<[u8]> + ?Sized,
+    {
+        let content = content.as_ref();
         let mut scanner = ifc_lite_core::EntityScanner::new(content);
         let mut scale = 1.0;
 
@@ -468,11 +476,7 @@ impl GeometryRouter {
 
     /// Total number of CSG failures across all products.
     pub fn csg_failure_total(&self) -> usize {
-        self.csg_failures
-            .borrow()
-            .values()
-            .map(|v| v.len())
-            .sum()
+        self.csg_failures.borrow().values().map(|v| v.len()).sum()
     }
 
     /// Internal: record a batch of failures against a product. Existing
@@ -564,11 +568,7 @@ impl GeometryRouter {
     /// Internal: tag the per-host diagnostic with the failure summary for
     /// this host. Drained from `ClippingProcessor::take_failures` after
     /// `apply_void_context` finishes.
-    pub(crate) fn record_host_failure_summary(
-        &self,
-        host_id: u32,
-        failures: &[BoolFailure],
-    ) {
+    pub(crate) fn record_host_failure_summary(&self, host_id: u32, failures: &[BoolFailure]) {
         if failures.is_empty() {
             return;
         }
@@ -579,15 +579,11 @@ impl GeometryRouter {
             // Short label for at-a-glance grouping. Full BoolFailure list
             // remains in `csg_failures` for callers that want detail.
             let label = match &failures[0].reason {
-                crate::diagnostics::BoolFailureReason::OperandTooLarge { .. } => {
-                    "OperandTooLarge"
-                }
+                crate::diagnostics::BoolFailureReason::OperandTooLarge { .. } => "OperandTooLarge",
                 crate::diagnostics::BoolFailureReason::EmptyOperand => "EmptyOperand",
                 crate::diagnostics::BoolFailureReason::DegenerateOperand => "DegenerateOperand",
                 crate::diagnostics::BoolFailureReason::NoBoundsOverlap => "NoBoundsOverlap",
-                crate::diagnostics::BoolFailureReason::KernelOutputInvalid => {
-                    "KernelOutputInvalid"
-                }
+                crate::diagnostics::BoolFailureReason::KernelOutputInvalid => "KernelOutputInvalid",
                 crate::diagnostics::BoolFailureReason::SolidSolidDifferenceSkipped => {
                     "SolidSolidDifferenceSkipped"
                 }

--- a/rust/geometry/src/router/processing.rs
+++ b/rust/geometry/src/router/processing.rs
@@ -306,11 +306,15 @@ impl GeometryRouter {
 
     /// Detect RTC offset by scanning the file for building elements.
     /// Used by synchronous parse paths.
-    pub fn detect_rtc_offset_from_first_element(
+    pub fn detect_rtc_offset_from_first_element<T>(
         &self,
-        content: &str,
+        content: &T,
         decoder: &mut EntityDecoder,
-    ) -> (f64, f64, f64) {
+    ) -> (f64, f64, f64)
+    where
+        T: AsRef<[u8]> + ?Sized,
+    {
+        let content = content.as_ref();
         use ifc_lite_core::EntityScanner;
 
         let mut scanner = EntityScanner::new(content);
@@ -374,7 +378,7 @@ impl GeometryRouter {
         &self,
         jobs: &[(u32, usize, usize, IfcType)],
         decoder: &mut EntityDecoder,
-        content: &str,
+        content: &[u8],
     ) -> (f64, f64, f64) {
         match self.detect_rtc_offset_from_jobs(jobs, decoder) {
             Some(offset) => offset,
@@ -831,7 +835,8 @@ impl GeometryRouter {
 
         // Check if we have a processor for this type
         if let Some(processor) = self.processors.get(&item.ifc_type) {
-            let mut mesh = processor.process(item, decoder, &self.schema, self.tessellation_quality)?;
+            let mut mesh =
+                processor.process(item, decoder, &self.schema, self.tessellation_quality)?;
             // Safety net: strip any out-of-bounds indices before downstream use
             mesh.validate_indices();
 
@@ -1095,14 +1100,16 @@ impl GeometryRouter {
         // attr 0: MappingOrigin (IfcAxis2Placement3D) — the only 3D transform;
         // UVs are 2D and unaffected. Parse once, bake into every part.
         let origin_transform: Option<nalgebra::Matrix4<f64>> = match rep_map.get(0) {
-            Some(origin_attr) if !origin_attr.is_null() => match decoder.resolve_ref(origin_attr)? {
+            Some(origin_attr) if !origin_attr.is_null() => {
+                match decoder.resolve_ref(origin_attr)? {
                 Some(origin) if origin.ifc_type == IfcType::IfcAxis2Placement3D => {
                     let mut t = self.parse_axis2_placement_3d(&origin, decoder)?;
                     self.scale_transform(&mut t);
                     Some(t)
                 }
                 _ => None,
-            },
+                }
+            }
             _ => None,
         };
 
@@ -1136,7 +1143,8 @@ impl GeometryRouter {
             Some(p) => Arc::clone(p),
             None => return Ok(None),
         };
-        let mut mesh = match processor.process(element, decoder, &self.schema, self.tessellation_quality) {
+        let mut mesh =
+            match processor.process(element, decoder, &self.schema, self.tessellation_quality) {
             Ok(m) => m,
             // Missing Axis or unparseable curve isn't fatal — fall back so
             // the caller can still walk a normal representation if present.

--- a/rust/geometry/src/void_index.rs
+++ b/rust/geometry/src/void_index.rs
@@ -81,11 +81,14 @@ pub fn propagate_voids_via_aggregates(
 
 /// Scan `content` for `IfcRelAggregates` and build the full (unfiltered)
 /// parent → children map used by [`propagate_voids_via_aggregates`].
-pub fn build_aggregate_children_index(
-    content: &str,
+pub fn build_aggregate_children_index<T>(
+    content: &T,
     decoder: &mut EntityDecoder,
-) -> FxHashMap<u32, Vec<u32>> {
-    let mut scanner = EntityScanner::new(content);
+) -> FxHashMap<u32, Vec<u32>>
+where
+    T: AsRef<[u8]> + ?Sized,
+{
+    let mut scanner = EntityScanner::new(content.as_ref());
     let mut aggregate_children: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
     while let Some((id, type_name, start, end)) = scanner.next_entity() {
         if type_name != "IFCRELAGGREGATES" {
@@ -142,11 +145,15 @@ pub fn build_aggregate_children_index(
 /// left out of the returned map so the caller can never "skip" the only
 /// geometry available for the assembly.
 #[must_use = "the returned part → parent map is needed to honour the merge-layers toggle"]
-pub fn propagate_voids_to_parts(
+pub fn propagate_voids_to_parts<T>(
     void_index: &mut FxHashMap<u32, Vec<u32>>,
-    content: &str,
+    content: &T,
     decoder: &mut EntityDecoder,
-) -> FxHashMap<u32, u32> {
+) -> FxHashMap<u32, u32>
+where
+    T: AsRef<[u8]> + ?Sized,
+{
+    let content = content.as_ref();
     let aggregate_children = build_aggregate_children_index(content, decoder);
 
     // Void propagation: recursive + type-agnostic over the FULL aggregate
@@ -194,10 +201,14 @@ pub fn propagate_voids_to_parts(
 /// is filled and discarded (callers that also need the propagated voids should
 /// call [`propagate_voids_to_parts`] directly with their own `void_index`).
 #[must_use]
-pub fn compute_parts_to_skip(
-    content: &str,
+pub fn compute_parts_to_skip<T>(
+    content: &T,
     decoder: &mut EntityDecoder,
-) -> rustc_hash::FxHashSet<u32> {
+) -> rustc_hash::FxHashSet<u32>
+where
+    T: AsRef<[u8]> + ?Sized,
+{
+    let content = content.as_ref();
     let material_layer_index = crate::MaterialLayerIndex::from_content(content, decoder);
     let mut void_index_scratch: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
     let part_to_parent = propagate_voids_to_parts(&mut void_index_scratch, content, decoder);
@@ -243,7 +254,11 @@ impl VoidIndex {
     ///
     /// # Returns
     /// A populated VoidIndex
-    pub fn from_content(content: &str, decoder: &mut EntityDecoder) -> Self {
+    pub fn from_content<T>(content: &T, decoder: &mut EntityDecoder) -> Self
+    where
+        T: AsRef<[u8]> + ?Sized,
+    {
+        let content = content.as_ref();
         let mut index = Self::new();
         let mut scanner = EntityScanner::new(content);
 

--- a/rust/processing/src/georeferencing.rs
+++ b/rust/processing/src/georeferencing.rs
@@ -103,7 +103,11 @@ impl Georeferencing {
 /// `IfcProjectedCRS`, and `IfcPropertySet` for the IFC2x3 `ePSet_MapConversion`
 /// fallback) are collected from the scan — their `IfcType` is known from the
 /// entity name, so no decoding happens while building the candidate list.
-pub fn extract_georeferencing(content: &str) -> Option<Georeferencing> {
+pub fn extract_georeferencing<T>(content: &T) -> Option<Georeferencing>
+where
+    T: AsRef<[u8]> + ?Sized,
+{
+    let content = content.as_ref();
     let entity_index = build_entity_index(content);
     let mut decoder = EntityDecoder::with_index(content, entity_index);
 

--- a/rust/processing/src/processor.rs
+++ b/rust/processing/src/processor.rs
@@ -552,22 +552,22 @@ fn is_quick_spatial_type_ci(type_name: &str) -> bool {
         || type_name.eq_ignore_ascii_case("IFCRAILWAYPART")
 }
 
-fn parse_step_arguments<'a>(entity_text: &'a str) -> Vec<&'a str> {
-    let Some(open_idx) = entity_text.find('(') else {
+fn parse_step_arguments(entity_bytes: &[u8]) -> Vec<&[u8]> {
+    let Some(open_idx) = entity_bytes.iter().position(|byte| *byte == b'(') else {
         return Vec::new();
     };
-    let Some(close_idx) = entity_text.rfind(')') else {
+    let Some(close_idx) = entity_bytes.iter().rposition(|byte| *byte == b')') else {
         return Vec::new();
     };
     if close_idx <= open_idx {
         return Vec::new();
     }
-    let args = &entity_text[open_idx + 1..close_idx];
+    let args = &entity_bytes[open_idx + 1..close_idx];
     let mut parts = Vec::new();
     let mut in_string = false;
     let mut depth = 0i32;
     let mut start = 0usize;
-    let bytes = args.as_bytes();
+    let bytes = args;
     let mut index = 0usize;
     while index < bytes.len() {
         match bytes[index] {
@@ -581,7 +581,7 @@ fn parse_step_arguments<'a>(entity_text: &'a str) -> Vec<&'a str> {
             b'(' if !in_string => depth += 1,
             b')' if !in_string => depth -= 1,
             b',' if !in_string && depth == 0 => {
-                parts.push(args[start..index].trim());
+                parts.push(args[start..index].trim_ascii());
                 start = index + 1;
             }
             _ => {}
@@ -589,47 +589,55 @@ fn parse_step_arguments<'a>(entity_text: &'a str) -> Vec<&'a str> {
         index += 1;
     }
     if start <= args.len() {
-        parts.push(args[start..].trim());
+        parts.push(args[start..].trim_ascii());
     }
     parts
 }
 
-fn parse_step_string(token: &str) -> Option<String> {
-    let trimmed = token.trim();
-    if trimmed.len() < 2 || !trimmed.starts_with('\'') || !trimmed.ends_with('\'') {
+fn parse_step_string(token: &[u8]) -> Option<String> {
+    let trimmed = token.trim_ascii();
+    if trimmed.len() < 2 || trimmed[0] != b'\'' || trimmed[trimmed.len() - 1] != b'\'' {
         return None;
     }
-    Some(trimmed[1..trimmed.len() - 1].replace("''", "'"))
+    Some(String::from_utf8_lossy(&trimmed[1..trimmed.len() - 1]).replace("''", "'"))
 }
 
-fn parse_step_ref(token: &str) -> Option<u32> {
-    token.trim().strip_prefix('#')?.parse::<u32>().ok()
+fn parse_step_ref(token: &[u8]) -> Option<u32> {
+    std::str::from_utf8(token.trim_ascii().strip_prefix(b"#")?)
+        .ok()?
+        .parse()
+        .ok()
 }
 
-fn parse_step_ref_list(token: &str) -> Vec<u32> {
-    let trimmed = token.trim();
+fn parse_step_ref_list(token: &[u8]) -> Vec<u32> {
+    let trimmed = token.trim_ascii();
     let inner = trimmed
-        .strip_prefix('(')
-        .and_then(|value| value.strip_suffix(')'))
+        .strip_prefix(b"(")
+        .and_then(|value| value.strip_suffix(b")"))
         .unwrap_or(trimmed);
-    inner.split(',').filter_map(parse_step_ref).collect()
+    inner.split(|byte| *byte == b',').filter_map(parse_step_ref).collect()
 }
 
-fn extract_name_from_args(args: &[&str], fallback: &str) -> String {
+fn extract_name_from_args(args: &[&[u8]], fallback: &str) -> String {
     args.get(2)
         .and_then(|token| parse_step_string(token))
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| fallback.to_string())
 }
 
-fn extract_storey_elevation_from_args(args: &[&str]) -> Option<f64> {
+fn extract_storey_elevation_from_args(args: &[&[u8]]) -> Option<f64> {
     for index in [9usize, 8usize] {
-        if let Some(value) = args.get(index).and_then(|token| token.trim().parse::<f64>().ok()) {
+        if let Some(value) = args
+            .get(index)
+            .and_then(|token| std::str::from_utf8(token.trim_ascii()).ok())
+            .and_then(|token| token.parse::<f64>().ok())
+        {
             return Some(value);
         }
     }
     args.iter()
-        .filter_map(|token| token.trim().parse::<f64>().ok())
+        .filter_map(|token| std::str::from_utf8(token.trim_ascii()).ok())
+        .filter_map(|token| token.parse::<f64>().ok())
         .find(|value| value.abs() < 10_000.0)
 }
 
@@ -643,13 +651,20 @@ fn build_quick_spatial_tree_node(
         .ok_or_else(|| format!("Quick spatial node #{express_id} not found"))?;
     let mut children = Vec::with_capacity(node.children.len());
     for child_id in &node.children {
-        children.push(build_quick_spatial_tree_node(*child_id, nodes, element_summaries)?);
+        children.push(build_quick_spatial_tree_node(
+            *child_id,
+            nodes,
+            element_summaries,
+        )?);
     }
     let elements = node
         .elements
         .iter()
         .map(|element_id| {
-            element_summaries.get(element_id).cloned().unwrap_or(QuickMetadataEntitySummary {
+            element_summaries
+                .get(element_id)
+                .cloned()
+                .unwrap_or(QuickMetadataEntitySummary {
                 express_id: *element_id,
                 type_name: "IfcProduct".to_string(),
                 name: format!("IfcProduct #{}", element_id),
@@ -694,13 +709,16 @@ fn geometry_priority_score(ifc_type: &IfcType) -> u8 {
 }
 
 /// Process IFC content with parallel geometry extraction (default opening filter).
-pub fn process_geometry(content: &str) -> ProcessingResult {
-    process_geometry_filtered(content, OpeningFilterMode::Default)
+pub fn process_geometry<T>(content: &T) -> ProcessingResult
+where
+    T: AsRef<[u8]> + ?Sized,
+{
+    process_geometry_filtered(content.as_ref(), OpeningFilterMode::Default)
 }
 
 /// Process IFC content with parallel geometry extraction and emit batches as they complete.
 pub fn process_geometry_streaming(
-    content: &str,
+    content: &[u8],
     batch_size: usize,
     on_batch: impl FnMut(&[MeshData], usize, usize),
 ) -> ProcessingResult {
@@ -718,7 +736,7 @@ pub fn process_geometry_streaming(
 
 /// Process IFC content with parallel geometry extraction and configurable streaming behavior.
 pub fn process_geometry_streaming_with_options(
-    content: &str,
+    content: &[u8],
     options: StreamingOptions,
     on_batch: impl FnMut(&[MeshData], usize, usize),
     on_color_update: impl FnMut(&[(u32, [f32; 4])]),
@@ -735,7 +753,7 @@ pub fn process_geometry_streaming_with_options(
 /// Process IFC content with parallel geometry extraction and emit a quick metadata bootstrap
 /// once the scan phase completes.
 pub fn process_geometry_streaming_with_options_and_bootstrap(
-    content: &str,
+    content: &[u8],
     options: StreamingOptions,
     on_batch: impl FnMut(&[MeshData], usize, usize),
     on_color_update: impl FnMut(&[(u32, [f32; 4])]),
@@ -752,18 +770,28 @@ pub fn process_geometry_streaming_with_options_and_bootstrap(
 }
 
 /// Process IFC content with parallel geometry extraction and a configurable opening filter.
-pub fn process_geometry_filtered(content: &str, opening_filter: OpeningFilterMode) -> ProcessingResult {
+pub fn process_geometry_filtered<T>(
+    content: &T,
+    opening_filter: OpeningFilterMode,
+) -> ProcessingResult
+where
+    T: AsRef<[u8]> + ?Sized,
+{
     process_geometry_filtered_with_quality(content, opening_filter, TessellationQuality::default())
 }
 
 /// Like [`process_geometry_filtered`] with a consumer-selected tessellation
 /// detail level (#976) — the server half of the quality knob the wasm path
 /// exposes via `setTessellationQuality`.
-pub fn process_geometry_filtered_with_quality(
-    content: &str,
+pub fn process_geometry_filtered_with_quality<T>(
+    content: &T,
     opening_filter: OpeningFilterMode,
     tessellation_quality: TessellationQuality,
-) -> ProcessingResult {
+) -> ProcessingResult
+where
+    T: AsRef<[u8]> + ?Sized,
+{
+    let content = content.as_ref();
     process_geometry_streaming_filtered_with_options(
         content,
         opening_filter,
@@ -781,7 +809,7 @@ pub fn process_geometry_filtered_with_quality(
 
 /// Process IFC content with parallel geometry extraction and a configurable streaming batch size.
 pub fn process_geometry_streaming_filtered(
-    content: &str,
+    content: &[u8],
     opening_filter: OpeningFilterMode,
     batch_size: usize,
     on_batch: impl FnMut(&[MeshData], usize, usize),
@@ -803,7 +831,7 @@ pub fn process_geometry_streaming_filtered(
 
 /// Process IFC content with parallel geometry extraction and configurable streaming behavior.
 pub fn process_geometry_streaming_filtered_with_options(
-    content: &str,
+    content: &[u8],
     opening_filter: OpeningFilterMode,
     options: StreamingOptions,
     mut on_batch: impl FnMut(&[MeshData], usize, usize),
@@ -869,7 +897,8 @@ pub fn process_geometry_streaming_filtered_with_options(
     // MappingOrigin (duplicate boxes at the wrong position).
     let mut instantiated_type_ids: FxHashSet<u32> = FxHashSet::default();
     let quick_metadata_enabled = options.emit_quick_metadata_bootstrap;
-    let mut quick_spatial_nodes = quick_metadata_enabled.then(HashMap::<u32, QuickSpatialNodeEntry>::new);
+    let mut quick_spatial_nodes =
+        quick_metadata_enabled.then(HashMap::<u32, QuickSpatialNodeEntry>::new);
     let mut quick_aggregate_links = if quick_metadata_enabled {
         Vec::<(u32, Vec<u32>)>::new()
     } else {
@@ -890,10 +919,9 @@ pub fn process_geometry_streaming_filtered_with_options(
     let mut site_entity_pos: Option<(usize, usize)> = None;
     let mut building_entity_pos: Option<(usize, usize)> = None;
 
-    let defer_style_updates =
-        options.fast_first_batch &&
-        opening_filter == OpeningFilterMode::Default &&
-        !options.include_presentation_layers;
+    let defer_style_updates = options.fast_first_batch
+        && opening_filter == OpeningFilterMode::Default
+        && !options.include_presentation_layers;
     let mut deferred_styled_item_positions: Vec<(usize, usize)> = Vec::new();
 
     while let Some((id, type_name, start, end)) = scanner.next_entity() {
@@ -1135,7 +1163,6 @@ pub fn process_geometry_streaming_filtered_with_options(
                 representation_map_id: None,
             });
         }
-
         // #957: collect type-product geometry (IfcXxxType carrying its own
         // RepresentationMaps) and every IfcMappedItem's MappingSource, so after
         // the scan we can render the RepresentationMaps that NO occurrence
@@ -1164,7 +1191,13 @@ pub fn process_geometry_streaming_filtered_with_options(
                 .map(|token| parse_step_ref_list(token))
                 .unwrap_or_default();
             if !rep_map_ids.is_empty() {
-                type_product_geometry.push((id, start, end, IfcType::from_str(type_name), rep_map_ids));
+                type_product_geometry.push((
+                    id,
+                    start,
+                    end,
+                    IfcType::from_str(type_name),
+                    rep_map_ids,
+                ));
             }
         }
     }
@@ -1238,9 +1271,15 @@ pub fn process_geometry_streaming_filtered_with_options(
     );
 
     // Detect schema version
-    if content.contains("IFC4X3") {
+    if content
+        .windows(b"IFC4X3".len())
+        .any(|window| window == b"IFC4X3")
+    {
         schema_version = "IFC4X3".into();
-    } else if content.contains("IFC4") {
+    } else if content
+        .windows(b"IFC4".len())
+        .any(|window| window == b"IFC4")
+    {
         schema_version = "IFC4".into();
     }
 
@@ -1286,7 +1325,9 @@ pub fn process_geometry_streaming_filtered_with_options(
                 .map(|node| node.express_id);
         }
         let spatial_tree = root_id
-            .map(|root| build_quick_spatial_tree_node(root, &spatial_nodes, &quick_element_summaries))
+            .map(|root| {
+                build_quick_spatial_tree_node(root, &spatial_nodes, &quick_element_summaries)
+            })
             .transpose()
             .unwrap_or(None);
         on_quick_metadata_bootstrap(&QuickMetadataBootstrap {
@@ -1373,7 +1414,10 @@ pub fn process_geometry_streaming_filtered_with_options(
     // their per-triangle UV maps once, keyed by face-set id. `build_texture_index`
     // bails out on a cheap substring check for the (vast majority) untextured
     // files. Consumed by the type-only render path below.
-    let texture_index = Arc::new(ifc_lite_geometry::build_texture_index(content, &mut decoder));
+    let texture_index = Arc::new(ifc_lite_geometry::build_texture_index(
+        content,
+        &mut decoder,
+    ));
     // Join the material chain into colours per element (#407). The single
     // opaque-first colour is the general-path element fallback; the full list
     // feeds the opening sub-mesh transparent/opaque split (#913 §2.3).
@@ -1391,9 +1435,7 @@ pub fn process_geometry_streaming_filtered_with_options(
 
     let total_jobs = entity_jobs.len();
     let initial_chunk_size = options.initial_batch_size.max(1);
-    let throughput_chunk_size = options
-        .throughput_batch_size
-        .max(initial_chunk_size);
+    let throughput_chunk_size = options.throughput_batch_size.max(initial_chunk_size);
     let mut color_cache_by_product_definition_shape: FxHashMap<u32, Option<[f32; 4]>> =
         FxHashMap::default();
     let mut layer_cache_by_product_definition_shape: FxHashMap<u32, Option<String>> =
@@ -1426,7 +1468,8 @@ pub fn process_geometry_streaming_filtered_with_options(
             // Phase 1: parallel decode with thread-local EntityDecoder
             let entity_index_for_meta = entity_index_arc.clone();
             jobs_chunk.par_iter_mut().for_each(|job| {
-                if job.global_id.is_some() || job.name.is_some()
+                if job.global_id.is_some()
+                    || job.name.is_some()
                     || job.product_definition_shape_id.is_some()
                 {
                     return;
@@ -1523,7 +1566,10 @@ pub fn process_geometry_streaming_filtered_with_options(
 
         processed_jobs += jobs_chunk.len();
         total_vertices += chunk_meshes.iter().map(|m| m.vertex_count()).sum::<usize>();
-        total_triangles += chunk_meshes.iter().map(|m| m.triangle_count()).sum::<usize>();
+        total_triangles += chunk_meshes
+            .iter()
+            .map(|m| m.triangle_count())
+            .sum::<usize>();
 
         if !chunk_meshes.is_empty() {
             total_meshes += chunk_meshes.len();
@@ -1540,10 +1586,15 @@ pub fn process_geometry_streaming_filtered_with_options(
                 // the entire file.  This eliminates ~0.5-1 s for 1 GB files.
                 let mut rebuilt_styles: FxHashMap<u32, GeometryStyleInfo> = FxHashMap::default();
                 {
-                    let mut style_decoder = EntityDecoder::with_arc_index(content, entity_index_arc.clone());
+                    let mut style_decoder =
+                        EntityDecoder::with_arc_index(content, entity_index_arc.clone());
                     for &(start, end) in &deferred_styled_item_positions {
                         if let Ok(styled_item) = style_decoder.decode_at(start, end) {
-                            collect_geometry_style_info(&mut rebuilt_styles, &styled_item, &mut style_decoder);
+                            collect_geometry_style_info(
+                                &mut rebuilt_styles,
+                                &styled_item,
+                                &mut style_decoder,
+                            );
                         }
                     }
                 }
@@ -1641,7 +1692,7 @@ pub fn process_geometry_streaming_filtered_with_options(
 
 fn process_entity_job(
     job: &EntityJob,
-    content: &str,
+    content: &[u8],
     entity_index_arc: &Arc<EntityIndex>,
     unit_scale: f64,
     rtc_offset: (f64, f64, f64),
@@ -1829,7 +1880,9 @@ fn process_entity_job(
         None => true,
     };
     if needs_fallback {
-        mesh_candidate = local_router.process_element(&entity, &mut local_decoder).ok();
+        mesh_candidate = local_router
+            .process_element(&entity, &mut local_decoder)
+            .ok();
     }
 
     if let Some(mut mesh) = mesh_candidate {
@@ -1839,9 +1892,11 @@ fn process_entity_job(
             // matches the face set's CoordIndex (no CSG/void retopology);
             // otherwise we keep the single dominant-coloured mesh below.
             if !indexed_colour_full.is_empty() {
-                if let Some(full) =
-                    find_indexed_colour_for_element(&entity, indexed_colour_full, &mut local_decoder)
-                {
+                if let Some(full) = find_indexed_colour_for_element(
+                    &entity,
+                    indexed_colour_full,
+                    &mut local_decoder,
+                ) {
                     let geometry_id = full.geometry_id;
                     if let Some(groups) = crate::style::split_mesh_by_indexed_colour(&mesh, full) {
                         let mut out: Vec<MeshData> = Vec::with_capacity(groups.len());
@@ -2083,7 +2138,7 @@ fn collect_geometry_style_info(
 fn build_color_updates_for_jobs(
     jobs: &[EntityJob],
     geometry_styles: &FxHashMap<u32, GeometryStyleInfo>,
-    content: &str,
+    content: &[u8],
     entity_index: &Arc<EntityIndex>,
 ) -> Vec<(u32, [f32; 4])> {
     let mut decoder = EntityDecoder::with_arc_index(content, entity_index.clone());
@@ -2633,10 +2688,7 @@ mod tests {
     use super::*;
 
     fn map(pairs: &[(u32, &[u32])]) -> FxHashMap<u32, Vec<u32>> {
-        pairs
-            .iter()
-            .map(|(k, v)| (*k, v.to_vec()))
-            .collect()
+        pairs.iter().map(|(k, v)| (*k, v.to_vec())).collect()
     }
 
     #[test]
@@ -2666,15 +2718,25 @@ END-ISO-10303-21;
         let mut styles: FxHashMap<u32, GeometryStyleInfo> = FxHashMap::default();
         styles.insert(
             110,
-            GeometryStyleInfo { color: blue, shading_color: None, material_name: None },
+            GeometryStyleInfo {
+                color: blue,
+                shading_color: None,
+                material_name: None,
+            },
         );
 
         let mut decoder = EntityDecoder::new(IFC);
 
         // Mapped item, no direct style → inherits the underlying item's colour.
-        assert_eq!(find_geometry_item_color(100, &styles, &mut decoder), Some(blue));
+        assert_eq!(
+            find_geometry_item_color(100, &styles, &mut decoder),
+            Some(blue)
+        );
         // A direct style still wins.
-        assert_eq!(find_geometry_item_color(110, &styles, &mut decoder), Some(blue));
+        assert_eq!(
+            find_geometry_item_color(110, &styles, &mut decoder),
+            Some(blue)
+        );
         // A non-mapped, unstyled item (the representation map itself) → None.
         assert_eq!(find_geometry_item_color(101, &styles, &mut decoder), None);
     }

--- a/rust/processing/src/symbolic.rs
+++ b/rust/processing/src/symbolic.rs
@@ -241,7 +241,11 @@ impl SymbolicData {
 /// Annotation / FootPrint / Axis representation, and return the full
 /// symbolic primitive collection. Pure-Rust (no `wasm_bindgen`), so it
 /// works inside the HTTP server.
-pub fn extract_symbolic_data(content: &str) -> SymbolicData {
+pub fn extract_symbolic_data<T>(content: &T) -> SymbolicData
+where
+    T: AsRef<[u8]> + ?Sized,
+{
+    let content = content.as_ref();
     let entity_index = build_entity_index(content);
     let mut decoder = EntityDecoder::with_index(content, entity_index);
 
@@ -1511,7 +1515,7 @@ fn sample_grid_axis_endpoints(
 // IfcStyledItem reverse index + colour resolution.
 // ────────────────────────────────────────────────────────────────────────────
 
-fn build_styled_item_index(content: &str, decoder: &mut EntityDecoder) -> HashMap<u32, Vec<u32>> {
+fn build_styled_item_index(content: &[u8], decoder: &mut EntityDecoder) -> HashMap<u32, Vec<u32>> {
     let collect_refs = |attr: &AttributeValue| -> Vec<u32> {
         if let Some(list) = attr.as_list() {
             list.iter().filter_map(|v| v.as_entity_ref()).collect()

--- a/rust/processing/tests/georef_map_conversion_math.rs
+++ b/rust/processing/tests/georef_map_conversion_math.rs
@@ -54,7 +54,7 @@ fn map_conversion_transforms_local_point_to_expected_world_coordinate() {
         return;
     };
 
-    let geo = extract_georeferencing(&content)
+    let geo = extract_georeferencing(content.as_bytes())
         .expect("bridge-deck fixture must yield georeferencing (IfcMapConversion #38)");
 
     // Extraction sanity (already covered elsewhere, kept tight here so the

--- a/rust/processing/tests/styling_material_chain.rs
+++ b/rust/processing/tests/styling_material_chain.rs
@@ -82,7 +82,7 @@ fn proxy_inherits_material_appearance_in_fast_first_batch_streaming() {
     // Pre-fix the deferred path collected no orphan styled items and this proxy
     // rendered the default gray; now it must be the material blue.
     let result = process_geometry_streaming_with_options(
-        MATERIAL_IFC,
+        MATERIAL_IFC.as_bytes(),
         // `defer_style_updates` = fast_first_batch && Default opening filter &&
         // !include_presentation_layers — all three required to hit the deferred
         // branch this test guards.

--- a/rust/wasm-bindings/src/api/gpu_meshes.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes.rs
@@ -385,18 +385,19 @@ impl IfcAPI {
                 // complete index instead of trusting the metres default.
                 let unit_scale =
                     match ifc_lite_core::try_extract_length_unit_scale(&mut decoder, pid) {
-                    Some(scale) => scale,
-                    None => {
-                        let full_index = ifc_lite_core::build_entity_index(content);
+                        Some(scale) => scale,
+                        None => {
+                            let full_index = ifc_lite_core::build_entity_index(content);
                             let mut full_decoder = EntityDecoder::with_index(content, full_index);
-                        ifc_lite_core::extract_length_unit_scale(&mut full_decoder, pid)
-                            .unwrap_or(1.0)
-                    }
-                };
+                            ifc_lite_core::extract_length_unit_scale(&mut full_decoder, pid)
+                                .unwrap_or(1.0)
+                        }
+                    };
 
                 let router = GeometryRouter::with_scale(unit_scale);
-                let is_large =
-                    |t: (f64, f64, f64)| t.0.abs() > 10000.0 || t.1.abs() > 10000.0 || t.2.abs() > 10000.0;
+                let is_large = |t: (f64, f64, f64)| {
+                    t.0.abs() > 10000.0 || t.1.abs() > 10000.0 || t.2.abs() > 10000.0
+                };
                 let detected_rtc = router.detect_rtc_offset_from_jobs(&buffered_jobs, &mut decoder);
                 let mut rtc_offset = detected_rtc.unwrap_or((0.0, 0.0, 0.0));
 

--- a/rust/wasm-bindings/src/api/gpu_meshes.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes.rs
@@ -12,13 +12,6 @@ use crate::zero_copy::{MeshCollection, MeshDataJs};
 use js_sys::Function;
 use wasm_bindgen::prelude::*;
 
-fn decode_ifc_bytes<'a>(data: &'a [u8]) -> &'a str {
-    match std::str::from_utf8(data) {
-        Ok(content) => content,
-        Err(error) => wasm_bindgen::throw_str(&format!("Invalid UTF-8 IFC data: {error}")),
-    }
-}
-
 /// Emit a sub-mesh, splitting it into one mesh per `IfcIndexedColourMap` palette
 /// group when the face set carries a per-triangle colour map whose triangle
 /// count still matches the produced mesh (issue #858). This restores the split
@@ -43,7 +36,8 @@ fn emit_submesh_with_palette_split(
     >,
 ) {
     if let Some(full) = indexed_colour_full.get(&geometry_id) {
-        if let Some(groups) = ifc_lite_processing::style::split_mesh_by_indexed_colour(&mesh, full) {
+        if let Some(groups) = ifc_lite_processing::style::split_mesh_by_indexed_colour(&mesh, full)
+        {
             for (rgba, mut part) in groups {
                 if part.normals.len() != part.positions.len() {
                     ifc_lite_geometry::calculate_normals(&mut part);
@@ -76,7 +70,7 @@ impl IfcAPI {
         use ifc_lite_core::EntityDecoder;
         use ifc_lite_geometry::GeometryRouter;
 
-        let content = decode_ifc_bytes(data);
+        let content = data;
 
         // Build entity index — wrap in Arc so processGeometryBatch can
         // share it across many calls without cloning the HashMap.
@@ -240,7 +234,7 @@ impl IfcAPI {
         use ifc_lite_geometry::GeometryRouter;
 
         let chunk_size = chunk_size.max(1024) as usize;
-        let content = decode_ifc_bytes(data);
+        let content = data;
 
         // Single-pass scan: gather (id, start, end, type) for everything,
         // tag geometry-bearing rows so we can emit jobs incrementally.
@@ -340,7 +334,12 @@ impl IfcAPI {
                     indexed_colour_map_spans.push((id, start, end));
                 }
                 "IFCMATERIALDEFINITIONREPRESENTATION" => {
-                    material_entity_spans.push((id, "IFCMATERIALDEFINITIONREPRESENTATION", start, end));
+                    material_entity_spans.push((
+                        id,
+                        "IFCMATERIALDEFINITIONREPRESENTATION",
+                        start,
+                        end,
+                    ));
                 }
                 "IFCRELASSOCIATESMATERIAL" => {
                     material_entity_spans.push((id, "IFCRELASSOCIATESMATERIAL", start, end));
@@ -368,9 +367,7 @@ impl IfcAPI {
             // Once we have project + enough sample jobs, resolve the meta
             // (unit scale + RTC offset + building rotation) and emit it
             // along with the buffered first chunk so workers can start.
-            if !meta_emitted
-                && project_id.is_some()
-                && buffered_jobs.len() >= RTC_SAMPLE_THRESHOLD
+            if !meta_emitted && project_id.is_some() && buffered_jobs.len() >= RTC_SAMPLE_THRESHOLD
             {
                 // Build a decoder over the partial entity index built so far.
                 let mut decoder = EntityDecoder::with_index(content, entity_index.clone());
@@ -386,15 +383,12 @@ impl IfcAPI {
                 // oversized (and dwarfs any correctly-scaled federated peer).
                 // When the chain isn't fully decodable here, resolve against a
                 // complete index instead of trusting the metres default.
-                let unit_scale = match ifc_lite_core::try_extract_length_unit_scale(
-                    &mut decoder,
-                    pid,
-                ) {
+                let unit_scale =
+                    match ifc_lite_core::try_extract_length_unit_scale(&mut decoder, pid) {
                     Some(scale) => scale,
                     None => {
                         let full_index = ifc_lite_core::build_entity_index(content);
-                        let mut full_decoder =
-                            EntityDecoder::with_index(content, full_index);
+                            let mut full_decoder = EntityDecoder::with_index(content, full_index);
                         ifc_lite_core::extract_length_unit_scale(&mut full_decoder, pid)
                             .unwrap_or(1.0)
                     }
@@ -442,8 +436,9 @@ impl IfcAPI {
                 }
                 let needs_shift = is_large(rtc_offset);
 
-                let building_rotation = site_position
-                    .and_then(|pos| extract_building_rotation_from_site(pos, &router, &mut decoder));
+                let building_rotation = site_position.and_then(|pos| {
+                    extract_building_rotation_from_site(pos, &router, &mut decoder)
+                });
 
                 // Emit meta event.
                 let meta = js_sys::Object::new();
@@ -581,7 +576,12 @@ impl IfcAPI {
         // so `entry().or_insert` preserves the authored-intent path.
         for &(id, start, end) in &indexed_colour_map_spans {
             if let Some((geometry_id, color)) =
-                super::styling::extract_color_from_indexed_colour_map_span(id, start, end, &mut decoder)
+                super::styling::extract_color_from_indexed_colour_map_span(
+                    id,
+                    start,
+                    end,
+                    &mut decoder,
+                )
             {
                 geometry_styles.entry(geometry_id).or_insert(color);
             }
@@ -602,9 +602,7 @@ impl IfcAPI {
 
         for &(id, start, end) in &void_rel_spans {
             if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
-                if let (Some(host_id), Some(opening_id)) =
-                    (entity.get_ref(4), entity.get_ref(5))
-                {
+                if let (Some(host_id), Some(opening_id)) = (entity.get_ref(4), entity.get_ref(5)) {
                     void_index.entry(host_id).or_default().push(opening_id);
                 }
             }
@@ -786,10 +784,10 @@ impl IfcAPI {
     ) -> MeshCollection {
         use super::styling::{resolve_element_color, resolve_submesh_color};
         use ifc_lite_core::EntityDecoder;
-        use ifc_lite_processing::default_color_for_type;
         use ifc_lite_geometry::{calculate_normals, GeometryHasher, GeometryRouter};
+        use ifc_lite_processing::default_color_for_type;
 
-        let content = decode_ifc_bytes(data);
+        let content = data;
 
         // Geometry fingerprinting for the viewer's revision-diff feature.
         // When enabled we hash each entity's meshes *before* MeshDataJs::new

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -78,8 +78,7 @@ pub struct IfcAPI {
     /// of a type's RepresentationMaps are orphan and should be rendered directly
     /// (the rest are drawn through their occurrence). Built once per worker on
     /// the first type-product job and cleared by `clearPrePassCache`.
-    cached_referenced_repmaps:
-        std::sync::Mutex<Option<std::sync::Arc<rustc_hash::FxHashSet<u32>>>>,
+    cached_referenced_repmaps: std::sync::Mutex<Option<std::sync::Arc<rustc_hash::FxHashSet<u32>>>>,
 
     /// Lazily-built set of type ids that an `IfcRelDefinesByType` instantiates
     /// (the type has an occurrence). `processGeometryBatch` uses it to suppress
@@ -105,7 +104,11 @@ pub struct IfcAPI {
     /// dominant colour per geometry. Built once per worker on first batch call
     /// (a single extra entity scan, cached) and cleared by `clearPrePassCache`.
     cached_indexed_colour_maps: std::sync::Mutex<
-        Option<std::sync::Arc<rustc_hash::FxHashMap<u32, ifc_lite_processing::style::FullIndexedColourMap>>>,
+        Option<
+            std::sync::Arc<
+                rustc_hash::FxHashMap<u32, ifc_lite_processing::style::FullIndexedColourMap>,
+            >,
+        >,
     >,
 
     /// When `true`, `processGeometryBatch` computes a per-entity geometry
@@ -152,9 +155,7 @@ impl IfcAPI {
             geometry_hash_tolerance_bits: std::sync::atomic::AtomicU64::new(
                 ifc_lite_geometry::DEFAULT_GEOM_HASH_TOLERANCE.to_bits(),
             ),
-            tessellation_quality: std::sync::atomic::AtomicU8::new(
-                TESSELLATION_QUALITY_MEDIUM,
-            ),
+            tessellation_quality: std::sync::atomic::AtomicU8::new(TESSELLATION_QUALITY_MEDIUM),
         }
     }
 
@@ -241,8 +242,7 @@ impl IfcAPI {
         if n == 0 || starts.len() != n || lengths.len() != n {
             return;
         }
-        let mut index =
-            ifc_lite_core::EntityIndex::with_capacity_and_hasher(n, Default::default());
+        let mut index = ifc_lite_core::EntityIndex::with_capacity_and_hasher(n, Default::default());
         for i in 0..n {
             let start = starts[i] as usize;
             let length = lengths[i] as usize;
@@ -331,7 +331,8 @@ impl IfcAPI {
         use std::sync::atomic::Ordering::Relaxed;
         match tolerance {
             Some(t) if t > 0.0 => {
-                self.geometry_hash_tolerance_bits.store(t.to_bits(), Relaxed);
+                self.geometry_hash_tolerance_bits
+                    .store(t.to_bits(), Relaxed);
                 self.compute_geometry_hashes.store(true, Relaxed);
             }
             _ => self.compute_geometry_hashes.store(false, Relaxed),
@@ -376,8 +377,7 @@ impl IfcAPI {
     /// skip `IfcBuildingElementPart` emission. Not exposed to JS — JS
     /// callers control the flag via [`Self::set_merge_layers`].
     pub(crate) fn merge_layers(&self) -> bool {
-        self.merge_layers
-            .load(std::sync::atomic::Ordering::Relaxed)
+        self.merge_layers.load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Active tessellation quality, read once at the top of
@@ -399,7 +399,9 @@ impl IfcAPI {
     pub(crate) fn geometry_hash_tolerance(&self) -> Option<f64> {
         use std::sync::atomic::Ordering::Relaxed;
         if self.compute_geometry_hashes.load(Relaxed) {
-            Some(f64::from_bits(self.geometry_hash_tolerance_bits.load(Relaxed)))
+            Some(f64::from_bits(
+                self.geometry_hash_tolerance_bits.load(Relaxed),
+            ))
         } else {
             None
         }
@@ -416,7 +418,7 @@ impl IfcAPI {
     /// still cheaply test `parts.contains(&id)` without a branch.
     pub(crate) fn get_or_build_parts_to_skip(
         &self,
-        content: &str,
+        content: &[u8],
         decoder: &mut ifc_lite_core::EntityDecoder,
     ) -> std::sync::Arc<rustc_hash::FxHashSet<u32>> {
         {
@@ -449,7 +451,7 @@ impl IfcAPI {
     /// through their occurrence). Cached per worker so the scan is paid once.
     pub(crate) fn get_or_build_referenced_repmaps(
         &self,
-        content: &str,
+        content: &[u8],
         decoder: &mut ifc_lite_core::EntityDecoder,
     ) -> std::sync::Arc<rustc_hash::FxHashSet<u32>> {
         {
@@ -479,7 +481,7 @@ impl IfcAPI {
     /// their occurrences). Cached per worker so the scan is paid once.
     pub(crate) fn get_or_build_instantiated_type_ids(
         &self,
-        content: &str,
+        content: &[u8],
         decoder: &mut ifc_lite_core::EntityDecoder,
     ) -> std::sync::Arc<rustc_hash::FxHashSet<u32>> {
         {
@@ -508,7 +510,7 @@ impl IfcAPI {
     /// worker; `build_texture_index` bails out cheaply on untextured files.
     pub(crate) fn get_or_build_texture_index(
         &self,
-        content: &str,
+        content: &[u8],
         decoder: &mut ifc_lite_core::EntityDecoder,
     ) -> std::sync::Arc<rustc_hash::FxHashMap<u32, ifc_lite_geometry::ResolvedTextureMap>> {
         {
@@ -543,7 +545,7 @@ impl IfcAPI {
     /// (the common case), so callers can cheaply `.get(&geometry_id)`.
     pub(crate) fn get_or_build_indexed_colour_maps(
         &self,
-        content: &str,
+        content: &[u8],
         decoder: &mut ifc_lite_core::EntityDecoder,
     ) -> std::sync::Arc<rustc_hash::FxHashMap<u32, ifc_lite_processing::style::FullIndexedColourMap>>
     {
@@ -563,7 +565,10 @@ impl IfcAPI {
         // IfcIndexedColourMap pay only a single substring search (SIMD memmem),
         // not a full entity scan + decode, on the first batch of every worker.
         // The empty result is still cached so later batches skip even that.
-        if !content.contains("IFCINDEXEDCOLOURMAP") {
+        if !content
+            .windows(b"IFCINDEXEDCOLOURMAP".len())
+            .any(|window| window == b"IFCINDEXEDCOLOURMAP")
+        {
             let arc = std::sync::Arc::new(map);
             let mut slot = self
                 .cached_indexed_colour_maps
@@ -625,9 +630,7 @@ fn set_js_prop_jv(obj: &JsValue, key: &JsValue, value: &JsValue) -> bool {
 /// failure summary at `console.warn` only when there's at least one
 /// failure to report. Per-host detail is included for the worst-failing
 /// products (capped to keep the log readable on large files).
-pub(super) fn drain_and_log_csg_diagnostics(
-    router: &ifc_lite_geometry::GeometryRouter,
-) -> JsValue {
+pub(super) fn drain_and_log_csg_diagnostics(router: &ifc_lite_geometry::GeometryRouter) -> JsValue {
     let cls = router.take_classification_stats();
     let csg_failures = router.take_csg_failures();
     let host_diags = router.take_host_opening_diagnostics();
@@ -653,7 +656,11 @@ pub(super) fn drain_and_log_csg_diagnostics(
     let cls_obj = js_sys::Object::new();
     set_js_prop(&cls_obj, "rectangular", &(cls.rectangular as f64).into());
     set_js_prop(&cls_obj, "diagonal", &(cls.diagonal as f64).into());
-    set_js_prop(&cls_obj, "nonRectangular", &(cls.non_rectangular as f64).into());
+    set_js_prop(
+        &cls_obj,
+        "nonRectangular",
+        &(cls.non_rectangular as f64).into(),
+    );
     set_js_prop(
         &cls_obj,
         "floorOpeningGuardSaved",
@@ -709,8 +716,10 @@ pub(super) fn drain_and_log_csg_diagnostics(
 
         // Per-host-type aggregate: how many of each host type had openings,
         // how many had failures, and which kinds dominated.
-        let mut by_host_type: std::collections::HashMap<String, (usize, usize, usize, usize, usize)> =
-            std::collections::HashMap::new();
+        let mut by_host_type: std::collections::HashMap<
+            String,
+            (usize, usize, usize, usize, usize),
+        > = std::collections::HashMap::new();
         for hd in host_diags.values() {
             let entry = by_host_type
                 .entry(hd.host_type.clone())

--- a/rust/wasm-bindings/src/api/parsing.rs
+++ b/rust/wasm-bindings/src/api/parsing.rs
@@ -8,29 +8,6 @@ use super::IfcAPI;
 use ifc_lite_core::{EntityScanner, ParseEvent};
 use wasm_bindgen::prelude::*;
 
-/// Length-preserving replacement of every non-ASCII byte (>= 0x80) with `b'?'`.
-///
-/// Real IFC/STEP files routinely contain Latin-1 / Windows-1252 bytes in the
-/// HEADER section (e.g. accented author names), which are invalid UTF-8.
-/// Building a `&str` from such bytes via `from_utf8_unchecked` is undefined
-/// behavior, so callers validate first and only fall back to this when the
-/// bytes are not valid UTF-8. Each invalid byte is replaced 1:1 so the byte
-/// offsets returned to JS stay aligned to the original buffer (JS re-reads it
-/// via safeUtf8Decode). ASCII — including the entire DATA section — is
-/// untouched.
-fn sanitize_ascii(data: &[u8]) -> String {
-    let mut buf = data.to_vec();
-    for b in buf.iter_mut() {
-        if *b >= 0x80 {
-            *b = b'?';
-        }
-    }
-    // SAFETY-equivalent: every byte is now < 0x80, i.e. valid ASCII / UTF-8,
-    // so this conversion cannot fail.
-    String::from_utf8(buf).expect("ascii after sanitize")
-}
-
-
 #[wasm_bindgen]
 impl IfcAPI {
     /// Fast entity scanning using SIMD-accelerated Rust scanner
@@ -38,7 +15,7 @@ impl IfcAPI {
     /// Much faster than TypeScript byte-by-byte scanning (5-10x speedup)
     #[wasm_bindgen(js_name = scanEntitiesFast)]
     pub fn scan_entities_fast(&self, content: &str) -> JsValue {
-        Self::scan_entities_fast_inner(content)
+        Self::scan_entities_fast_inner(content.as_bytes())
     }
 
     /// Fast entity scanning from raw bytes (avoids TextDecoder.decode on JS side).
@@ -46,22 +23,10 @@ impl IfcAPI {
     /// JS string creation and UTF-16→UTF-8 conversion.
     #[wasm_bindgen(js_name = scanEntitiesFastBytes)]
     pub fn scan_entities_fast_bytes(&self, data: &[u8]) -> JsValue {
-        // IFC/STEP DATA is ASCII, but HEADER fields may carry non-UTF-8 bytes
-        // (Latin-1/Windows-1252). Validate first; only allocate a sanitized,
-        // length-preserving buffer when invalid so entity byte offsets stay
-        // aligned to the original buffer JS re-reads.
-        let owned: String;
-        let content: &str = match std::str::from_utf8(data) {
-            Ok(s) => s,
-            Err(_) => {
-                owned = sanitize_ascii(data);
-                &owned
-            }
-        };
-        Self::scan_entities_fast_inner(content)
+        Self::scan_entities_fast_inner(data)
     }
 
-    fn scan_entities_fast_inner(content: &str) -> JsValue {
+    fn scan_entities_fast_inner(content: &[u8]) -> JsValue {
         use serde::{Deserialize, Serialize};
         use serde_wasm_bindgen::to_value;
 
@@ -78,7 +43,7 @@ impl IfcAPI {
 
         let mut scanner = EntityScanner::new(content);
         let mut refs = Vec::new();
-        let bytes = content.as_bytes();
+        let bytes = content;
 
         // Track line numbers efficiently: count newlines up to each entity start
         let mut last_position = 0;
@@ -134,7 +99,7 @@ impl IfcAPI {
             byte_length: usize,
         }
 
-        let mut scanner = EntityScanner::new(content);
+        let mut scanner = EntityScanner::new(content.as_bytes());
         let mut refs = Vec::new();
 
         // Only scan entities that have geometry - skip IFCCARTESIANPOINT, IFCDIRECTION, etc.

--- a/rust/wasm-bindings/src/api/styling.rs
+++ b/rust/wasm-bindings/src/api/styling.rs
@@ -149,9 +149,9 @@ fn extract_color_from_style_assignment(
             if let Some(list) = styles_attr.as_list() {
                 for item in list {
                     if let Some(inner_id) = item.as_entity_ref() {
-                        if let Some(pair) =
-                            ifc_lite_processing::style::extract_surface_style_colors(inner_id, decoder)
-                        {
+                        if let Some(pair) = ifc_lite_processing::style::extract_surface_style_colors(
+                            inner_id, decoder,
+                        ) {
                             return Some(pair);
                         }
                     }
@@ -168,9 +168,9 @@ fn extract_color_from_style_assignment(
             if let Some(list) = styles_attr.as_list() {
                 for item in list {
                     if let Some(inner_id) = item.as_entity_ref() {
-                        if let Some(pair) =
-                            ifc_lite_processing::style::extract_surface_style_colors(inner_id, decoder)
-                        {
+                        if let Some(pair) = ifc_lite_processing::style::extract_surface_style_colors(
+                            inner_id, decoder,
+                        ) {
                             return Some(pair);
                         }
                     }
@@ -212,7 +212,7 @@ pub(crate) struct PrePassData {
 ///   pre-pass for void + brep    (full scan)
 ///   processing scan              (full scan)
 pub(crate) fn combined_pre_pass(
-    content: &str,
+    content: &[u8],
     decoder: &mut ifc_lite_core::EntityDecoder,
 ) -> PrePassData {
     use ifc_lite_core::EntityScanner;
@@ -248,8 +248,7 @@ pub(crate) fn combined_pre_pass(
                         // Normal IfcStyledItem with Item reference → geometry_styles
                         if !geometry_styles.contains_key(&geometry_id) {
                             if let Some(styles_attr) = styled_item.get(1) {
-                                if let Some(color) =
-                                    extract_color_from_styles(styles_attr, decoder)
+                                if let Some(color) = extract_color_from_styles(styles_attr, decoder)
                                 {
                                     geometry_styles.insert(geometry_id, color);
                                 }
@@ -397,7 +396,7 @@ pub(crate) fn combined_pre_pass(
 /// every instanced type while the occurrence carries its own body (class 2,
 /// hidden in Model mode so it does not double-render at the MappingOrigin).
 pub(crate) fn collect_type_geometry_jobs(
-    content: &str,
+    content: &[u8],
     decoder: &mut ifc_lite_core::EntityDecoder,
 ) -> Vec<(u32, usize, usize, ifc_lite_core::IfcType)> {
     use ifc_lite_core::{EntityScanner, IfcType};
@@ -405,7 +404,10 @@ pub(crate) fn collect_type_geometry_jobs(
     // Fast bail-out: type geometry can only exist when the file authors at least
     // one IfcRepresentationMap. The overwhelming majority of files pay only a
     // single substring search instead of a full entity scan + decode.
-    if !content.contains("IFCREPRESENTATIONMAP") {
+    if !content
+        .windows(b"IFCREPRESENTATIONMAP".len())
+        .any(|window| window == b"IFCREPRESENTATIONMAP")
+    {
         return Vec::new();
     }
 
@@ -457,7 +459,7 @@ pub(crate) fn collect_type_geometry_jobs(
 /// `processGeometryBatch` can tell which of a type's RepresentationMaps are
 /// orphan (rendered directly) vs already drawn through an occurrence.
 pub(crate) fn build_referenced_representation_maps(
-    content: &str,
+    content: &[u8],
     decoder: &mut ifc_lite_core::EntityDecoder,
 ) -> rustc_hash::FxHashSet<u32> {
     use ifc_lite_core::EntityScanner;
@@ -482,7 +484,7 @@ pub(crate) fn build_referenced_representation_maps(
 /// through their occurrences, so rendering the type's RepresentationMap as well
 /// would double-render it at the MappingOrigin (duplicate at the wrong position).
 pub(crate) fn build_instantiated_type_ids(
-    content: &str,
+    content: &[u8],
     decoder: &mut ifc_lite_core::EntityDecoder,
 ) -> rustc_hash::FxHashSet<u32> {
     use ifc_lite_core::EntityScanner;
@@ -773,7 +775,9 @@ pub(crate) fn extract_building_rotation_from_site(
 ) -> Option<f64> {
     let (site_id, start, end) = site_pos;
     let site_entity = decoder.decode_at_with_id(site_id, start, end).ok()?;
-    let matrix = router.resolve_scaled_placement(&site_entity, decoder).ok()?;
+    let matrix = router
+        .resolve_scaled_placement(&site_entity, decoder)
+        .ok()?;
     ifc_lite_geometry::rotation_angle_about_z(&matrix)
 }
 

--- a/scripts/test-wasm-contract.mjs
+++ b/scripts/test-wasm-contract.mjs
@@ -165,6 +165,35 @@ END-ISO-10303-21;`;
   collection.free();
 });
 
+test('issue #1023: raw byte geometry and scans accept non-UTF-8 string bytes', () => {
+  const bytes = new TextEncoder().encode(columnContent);
+  const marker = new TextEncoder().encode('Column #1');
+  const markerStart = bytes.findIndex((_, index) =>
+    marker.every((byte, offset) => bytes[index + offset] === byte));
+  assert.ok(markerStart >= 0, 'fixture marker must exist');
+  bytes[markerStart] = 0xe9;
+
+  const refs = api.scanEntitiesFastBytes(bytes);
+  assert.ok(refs.length > 0, 'byte scan must still find entities');
+
+  const pre = api.buildPrePassOnce(bytes);
+  try {
+    assert.ok(pre.totalJobs > 0, 'pre-pass must still produce geometry jobs');
+    const collection = api.processGeometryBatch(
+      bytes, pre.jobs, pre.unitScale,
+      pre.rtcOffset[0], pre.rtcOffset[1], pre.rtcOffset[2], pre.needsShift,
+      pre.voidKeys, pre.voidCounts, pre.voidValues, pre.styleIds, pre.styleColors,
+    );
+    try {
+      assert.ok(collection.length > 0, 'geometry batch must still produce meshes');
+    } finally {
+      collection.free();
+    }
+  } finally {
+    api.clearPrePassCache();
+  }
+});
+
 // ===== Pre-pass contract (viewer boundary) =====
 // The TS GeometryProcessor (packages/geometry) destructures these exact
 // fields off buildPrePassOnce() and forwards them to processGeometryBatch.


### PR DESCRIPTION
## Summary

- make the Rust core scanner, tokenizer, decoder, streaming parser, bounds scans, geometry, and processing paths consume raw IFC bytes
- decode string-like STEP tokens lossily only when producing user-facing attribute strings, preserving original byte offsets and avoiding whole-file UTF-8 validation/sanitization
- pass raw bytes through WASM geometry APIs and server endpoints so localized non-UTF-8 bytes no longer block otherwise valid models
- add core, server, and real-WASM regressions for issue #1023

Closes #1023

## Validation

- `cargo check --workspace --all-targets`
- `cargo test --workspace`
- `bash scripts/build-wasm.sh`
- `pnpm test:wasm-contract`
- `pnpm typecheck`
- `pnpm test`
- `node scripts/check-api-surface.mjs`
- `node scripts/check-test-wiring.mjs`
- `git diff --check`

`pnpm knip` was also run; it reports the repository's existing unused-code/dependency baseline and no issue-specific removal regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Rust crate API: Core parsing functions now accept `AsRef<[u8]>` generic byte inputs instead of `&str` string references.

* **New Features**
  * IFC files with non-UTF-8 string bytes are now accepted instead of rejected or fully sanitized.
  * Per-field lossy UTF-8 decoding preserves original raw bytes for callers.
  * Improved error reporting distinguishes file size issues from parsing errors.

* **Improvements**
  * Byte-level scanning and processing optimized throughout the IFC parser.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->