### PR TITLE
feat(server): geometry-pipeline parity with the wasm path

### DIFF
--- a/.changeset/server-pipeline-parity.md
+++ b/.changeset/server-pipeline-parity.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/server-client': minor
+---
+
+Server pipeline parity (alignment audit follow-up):
+
+- New `ParseRequestOptions.tessellationQuality` option on `parse` / `parseParquet` / `parseParquetStream` / `parseParquetOptimized` / `parseStream` — the server now honours the same `lowest…highest` detail levels the wasm path exposes via `setTessellationQuality` (#976's server half). Default stays `medium`, byte-identical to historical output, and maps to the pre-existing cache keys.
+- The cached-geometry fast path forwards the quality option, so a `high` request can never be served a `medium` cache entry.
+- Fixed the "[client] Cache key mismatch" warning that fired on every fresh upload: the server cache key is the file hash plus request suffixes, so the sanity check now verifies derivation instead of equality.

--- a/apps/server/src/parity_tests.rs
+++ b/apps/server/src/parity_tests.rs
@@ -240,7 +240,13 @@ async fn symbolic_endpoint_pending_for_unknown_key() {
 /// `/parse/parquet-stream`) attaches `symbolic_data` to its `Complete` event.
 #[tokio::test]
 async fn streaming_complete_event_carries_symbolic_data() {
-    let events: Vec<StreamEvent> = process_streaming(FIXTURE.to_string(), 100, 1000)
+    let events: Vec<StreamEvent> = process_streaming(
+        FIXTURE.to_string(),
+        100,
+        1000,
+        ifc_lite_processing::OpeningFilterMode::Default,
+        ifc_lite_processing::TessellationQuality::default(),
+    )
         .collect()
         .await;
 

--- a/apps/server/src/routes/parse.rs
+++ b/apps/server/src/routes/parse.rs
@@ -26,7 +26,10 @@ use axum::{
 use flate2::read::GzDecoder;
 use futures::stream::StreamExt;
 use ifc_lite_core::EntityScanner;
-use ifc_lite_processing::{extract_symbolic_data, SymbolicData};
+use ifc_lite_processing::{
+    extract_symbolic_data, process_geometry_filtered_with_quality, SymbolicData,
+    TessellationQuality,
+};
 use serde::{Deserialize, Serialize};
 use std::convert::Infallible;
 use std::io::Read;
@@ -37,16 +40,47 @@ pub struct ParseQuery {
     /// Opening filter mode: "default", "ignore_all", or "ignore_opaque".
     #[serde(default)]
     pub opening_filter: OpeningFilterMode,
+    /// Tessellation detail level (#976): "lowest" | "low" | "medium" | "high"
+    /// | "highest". Omitted = "medium" (byte-identical to the historical
+    /// output — and to what the wasm path produces without
+    /// `setTessellationQuality`, keeping client and server meshes in parity).
+    #[serde(default)]
+    pub tessellation_quality: Option<String>,
 }
 
-fn reject_unsupported_streaming_opening_filter(query: &ParseQuery) -> Result<(), ApiError> {
-    if query.opening_filter == OpeningFilterMode::Default {
-        return Ok(());
+impl ParseQuery {
+    /// Resolve and validate the requested tessellation level.
+    fn resolved_tessellation_quality(&self) -> Result<TessellationQuality, ApiError> {
+        match self.tessellation_quality.as_deref() {
+            None => Ok(TessellationQuality::default()),
+            Some(s) => TessellationQuality::parse_label(s).ok_or_else(|| {
+                ApiError::BadRequest(format!(
+                    "Unknown tessellation_quality '{s}' — expected lowest | low | medium | high | highest"
+                ))
+            }),
+        }
     }
+}
 
-    Err(ApiError::BadRequest(
-        "opening_filter is not yet supported for streaming endpoints; use /api/v1/parse or /api/v1/parse/parquet instead".into(),
-    ))
+/// Cache-key segment for a tessellation level. Empty for the default level so
+/// every pre-existing cache entry (all written at implicit `medium`) stays
+/// valid; non-default levels get distinct entries.
+fn quality_cache_suffix(quality: TessellationQuality) -> String {
+    if quality == TessellationQuality::default() {
+        String::new()
+    } else {
+        format!("-q{}", quality.label())
+    }
+}
+
+/// Request-level cache key: file hash + opening-filter suffix + quality suffix.
+fn request_cache_key(data: &[u8], query: &ParseQuery, quality: TessellationQuality) -> String {
+    format!(
+        "{}-{}{}",
+        DiskCache::generate_key(data),
+        query.opening_filter.cache_key_suffix(),
+        quality_cache_suffix(quality)
+    )
 }
 
 /// Build the parquet geometry cache key for a given file hash and opening filter.
@@ -54,21 +88,36 @@ fn reject_unsupported_streaming_opening_filter(query: &ParseQuery) -> Result<(),
 /// Must stay in sync with the writer in `parse_parquet` / `parse_parquet_stream`,
 /// which derives the same suffix from `OpeningFilterMode::cache_key_suffix()`.
 ///
-/// Version bumped `v2` → `v3` with issue #900: geometry entries cached before the
-/// symbolic sidecar existed have no `{cache_key}-symbolic-v1` companion, so serving
-/// them would make `GET /api/v1/parse/symbolic/{cache_key}` return `202` forever and
-/// the parquet-stream fast-path emit no symbols. Bumping invalidates those entries so
-/// the next request reprocesses and writes the sidecar alongside the geometry.
-fn parquet_cache_key(hash: &str, opening_filter: OpeningFilterMode) -> String {
-    format!("{}-{}-parquet-v3", hash, opening_filter.cache_key_suffix())
+/// Version bumped `v2` → `v3` with issue #900 (symbolic sidecar), and `v3` → `v4`
+/// with the alignment audit: the server default path switched to per-item
+/// sub-meshes, streamed geometry now comes from the canonical pipeline
+/// (material chain + indexed colours + aggregate void propagation), and
+/// native builds compute normals — entries cached by the old pipelines
+/// would serve visibly different meshes.
+fn parquet_cache_key(
+    hash: &str,
+    opening_filter: OpeningFilterMode,
+    quality: TessellationQuality,
+) -> String {
+    format!(
+        "{}-{}{}-parquet-v4",
+        hash,
+        opening_filter.cache_key_suffix(),
+        quality_cache_suffix(quality)
+    )
 }
 
 /// Build the parquet metadata cache key for a given file hash and opening filter.
-fn parquet_metadata_cache_key(hash: &str, opening_filter: OpeningFilterMode) -> String {
+fn parquet_metadata_cache_key(
+    hash: &str,
+    opening_filter: OpeningFilterMode,
+    quality: TessellationQuality,
+) -> String {
     format!(
-        "{}-{}-parquet-metadata-v3",
+        "{}-{}{}-parquet-metadata-v4",
         hash,
-        opening_filter.cache_key_suffix()
+        opening_filter.cache_key_suffix(),
+        quality_cache_suffix(quality)
     )
 }
 
@@ -190,11 +239,8 @@ pub async fn parse_full(
     let data = extract_file(&mut multipart, state.config.max_file_size_mb).await?;
 
     // Generate cache key (include opening filter so different modes get different cache entries)
-    let cache_key = format!(
-        "{}-{}",
-        DiskCache::generate_key(&data),
-        query.opening_filter.cache_key_suffix()
-    );
+    let tessellation_quality = query.resolved_tessellation_quality()?;
+    let cache_key = request_cache_key(&data, &query, tessellation_quality);
 
     // Check cache first
     if let Some(mut cached) = state.cache.get::<ParseResponse>(&cache_key).await? {
@@ -214,7 +260,8 @@ pub async fn parse_full(
     // callers can render IfcGrid axes and IfcAnnotation polylines from
     // the same response without re-uploading the file.
     let (result, symbolic_data) = tokio::task::spawn_blocking(move || {
-        let result = process_geometry_filtered(&content, opening_filter);
+        let result =
+            process_geometry_filtered_with_quality(&content, opening_filter, tessellation_quality);
         let symbolic = ifc_lite_processing::extract_symbolic_data(&content);
         (result, symbolic)
     })
@@ -254,7 +301,7 @@ pub async fn parse_stream(
     mut multipart: Multipart,
 ) -> Result<axum::response::Response, ApiError> {
     use axum::response::IntoResponse;
-    reject_unsupported_streaming_opening_filter(&query)?;
+    let tessellation_quality = query.resolved_tessellation_quality()?;
 
     // Extract file
     let data = extract_file(&mut multipart, state.config.max_file_size_mb).await?;
@@ -264,8 +311,14 @@ pub async fn parse_stream(
     let max_batch_size = state.config.max_batch_size;
 
     // Create streaming response with dynamic batch sizing
-    let stream =
-        process_streaming(content, initial_batch_size, max_batch_size).map(|event: StreamEvent| {
+    let stream = process_streaming(
+        content,
+        initial_batch_size,
+        max_batch_size,
+        query.opening_filter,
+        tessellation_quality,
+    )
+    .map(|event: StreamEvent| {
             let json = serde_json::to_string(&event).unwrap_or_else(|e| {
                 serde_json::to_string(&StreamEvent::Error {
                     message: e.to_string(),
@@ -338,23 +391,18 @@ pub async fn parse_parquet_stream(
     use futures::StreamExt;
     use std::sync::{Arc, Mutex};
 
-    reject_unsupported_streaming_opening_filter(&query)?;
-
     // Extract file
     let data = extract_file(&mut multipart, state.config.max_file_size_mb).await?;
 
-    // Generate cache key before processing (include opening filter)
-    let cache_key = format!(
-        "{}-{}",
-        DiskCache::generate_key(&data),
-        query.opening_filter.cache_key_suffix()
-    );
+    // Generate cache key before processing (include opening filter + quality)
+    let tessellation_quality = query.resolved_tessellation_quality()?;
+    let cache_key = request_cache_key(&data, &query, tessellation_quality);
     let cache_key_clone = cache_key.clone();
 
     // OPTIMIZATION: Check cache first and fast-path return if available
     // This avoids re-processing files that are already cached
-    let parquet_cache_key = format!("{}-parquet-v3", cache_key);
-    let metadata_cache_key = format!("{}-parquet-metadata-v3", cache_key);
+    let parquet_cache_key = format!("{}-parquet-v4", cache_key);
+    let metadata_cache_key = format!("{}-parquet-metadata-v4", cache_key);
 
     if let (Some(cached_parquet), Some(cached_metadata_json)) = (
         state.cache.get_bytes(&parquet_cache_key).await?,
@@ -437,7 +485,14 @@ pub async fn parse_parquet_stream(
     let cache_key_for_geometry = cache_key.clone();
 
     // Create streaming response that yields Parquet batches
-    let stream = process_streaming(content.clone(), initial_batch_size, max_batch_size).map(move |event: StreamEvent| {
+    let stream = process_streaming(
+        content.clone(),
+        initial_batch_size,
+        max_batch_size,
+        query.opening_filter,
+        tessellation_quality,
+    )
+    .map(move |event: StreamEvent| {
         let sse_event = match event {
             StreamEvent::Start { total_estimate } => {
                 ParquetStreamEvent::Start {
@@ -532,7 +587,7 @@ pub async fn parse_parquet_stream(
                         combined_parquet.extend_from_slice(&0u32.to_le_bytes()); // data_model_len = 0
 
                         // Cache geometry (same format as non-streaming)
-                        let parquet_cache_key = format!("{}-parquet-v3", key);
+                        let parquet_cache_key = format!("{}-parquet-v4", key);
                         if let Err(e) = cache.set_bytes(&parquet_cache_key, &combined_parquet).await {
                             tracing::error!(error = %e, "Failed to cache geometry from stream");
                         } else {
@@ -554,7 +609,7 @@ pub async fn parse_parquet_stream(
                             data_model_stats: None, // Data model cached separately via data model endpoint
                         };
                         if let Ok(metadata_json) = serde_json::to_vec(&metadata_header) {
-                            let metadata_cache_key = format!("{}-parquet-metadata-v3", key);
+                            let metadata_cache_key = format!("{}-parquet-metadata-v4", key);
                             if let Err(e) = cache.set_bytes(&metadata_cache_key, &metadata_json).await {
                                 tracing::error!(error = %e, "Failed to cache metadata from stream");
                             } else {
@@ -703,15 +758,12 @@ pub async fn parse_parquet(
     let data = extract_file(&mut multipart, state.config.max_file_size_mb).await?;
 
     // Generate cache key (include opening filter so different modes get different cache entries)
-    let cache_key = format!(
-        "{}-{}",
-        DiskCache::generate_key(&data),
-        query.opening_filter.cache_key_suffix()
-    );
+    let tessellation_quality = query.resolved_tessellation_quality()?;
+    let cache_key = request_cache_key(&data, &query, tessellation_quality);
 
     // Check cache first (before any processing)
-    let parquet_cache_key = format!("{}-parquet-v3", cache_key);
-    let metadata_cache_key = format!("{}-parquet-metadata-v3", cache_key);
+    let parquet_cache_key = format!("{}-parquet-v4", cache_key);
+    let metadata_cache_key = format!("{}-parquet-metadata-v4", cache_key);
 
     if let (Some(cached_parquet), Some(cached_metadata_json)) = (
         state.cache.get_bytes(&parquet_cache_key).await?,
@@ -757,7 +809,7 @@ pub async fn parse_parquet(
             let ((geometry_result, data_model), symbolic_data) = rayon::join(
                 || {
                     rayon::join(
-                        || process_geometry_filtered(&content, opening_filter),
+                        || process_geometry_filtered_with_quality(&content, opening_filter, tessellation_quality),
                         || extract_data_model(&content),
                     )
                 },
@@ -842,8 +894,8 @@ pub async fn parse_parquet(
     let metadata_json = serde_json::to_string(&metadata_header)?;
 
     // Cache the results for future requests
-    let parquet_cache_key = format!("{}-parquet-v3", cache_key_clone);
-    let metadata_cache_key = format!("{}-parquet-metadata-v3", cache_key_clone);
+    let parquet_cache_key = format!("{}-parquet-v4", cache_key_clone);
+    let metadata_cache_key = format!("{}-parquet-metadata-v4", cache_key_clone);
     let combined_parquet_clone = combined_parquet.clone();
     let metadata_json_clone = metadata_json.clone();
     let cache = state.cache.clone();
@@ -919,11 +971,8 @@ pub async fn parse_parquet_optimized(
     let data = extract_file(&mut multipart, state.config.max_file_size_mb).await?;
 
     // Generate cache key (include opening filter so different modes get different cache entries)
-    let cache_key = format!(
-        "{}-{}",
-        DiskCache::generate_key(&data),
-        query.opening_filter.cache_key_suffix()
-    );
+    let tessellation_quality = query.resolved_tessellation_quality()?;
+    let cache_key = request_cache_key(&data, &query, tessellation_quality);
 
     tracing::info!(
         cache_key = %cache_key,
@@ -940,7 +989,7 @@ pub async fn parse_parquet_optimized(
     // (issue #900) — it's cached and served via the symbolic fetch endpoint.
     let (result, symbolic_data) = tokio::task::spawn_blocking(move || {
         rayon::join(
-            || process_geometry_filtered(&content, opening_filter),
+            || process_geometry_filtered_with_quality(&content, opening_filter, tessellation_quality),
             || extract_symbolic_data(&content),
         )
     })
@@ -1109,7 +1158,11 @@ pub async fn check_cache(
     Query(query): Query<ParseQuery>,
     axum::extract::Path(hash): axum::extract::Path<String>,
 ) -> Result<Response, ApiError> {
-    let parquet_cache_key = parquet_cache_key(&hash, query.opening_filter);
+    let parquet_cache_key = parquet_cache_key(
+        &hash,
+        query.opening_filter,
+        query.resolved_tessellation_quality()?,
+    );
 
     match state.cache.get_bytes(&parquet_cache_key).await? {
         Some(_) => {
@@ -1147,8 +1200,16 @@ pub async fn get_cached_geometry(
     Query(query): Query<ParseQuery>,
     axum::extract::Path(hash): axum::extract::Path<String>,
 ) -> Result<Response, ApiError> {
-    let parquet_cache_key = parquet_cache_key(&hash, query.opening_filter);
-    let metadata_cache_key = parquet_metadata_cache_key(&hash, query.opening_filter);
+    let parquet_cache_key = parquet_cache_key(
+        &hash,
+        query.opening_filter,
+        query.resolved_tessellation_quality()?,
+    );
+    let metadata_cache_key = parquet_metadata_cache_key(
+        &hash,
+        query.opening_filter,
+        query.resolved_tessellation_quality()?,
+    );
 
     match (
         state.cache.get_bytes(&parquet_cache_key).await?,
@@ -1186,33 +1247,51 @@ mod tests {
     use super::*;
 
     /// Regression test for #587: the reader (`check_cache`) used to look up
-    /// `{hash}-parquet-v3`, while the writer (`parse_parquet`) stored
-    /// `{hash}-{opening_filter}-parquet-v3`, so the check always returned 404.
+    /// `{hash}-parquet-v4`, while the writer (`parse_parquet`) stored
+    /// `{hash}-{opening_filter}-parquet-v4`, so the check always returned 404.
     /// The shared helper must produce the same key the writer stores under.
     #[test]
     fn parquet_cache_key_matches_writer_format() {
         let hash = "0ab20f4e4014";
 
         // The writer composes `cache_key = format!("{hash}-{suffix}")` and then
-        // `format!("{cache_key}-parquet-v3")`. The helper must produce the same string.
+        // `format!("{cache_key}-parquet-v4")`. The helper must produce the same string.
         for mode in [
             OpeningFilterMode::Default,
             OpeningFilterMode::IgnoreAll,
             OpeningFilterMode::IgnoreOpaque,
         ] {
-            let writer_cache_key = format!("{}-{}", hash, mode.cache_key_suffix());
-            let writer_parquet_key = format!("{}-parquet-v3", writer_cache_key);
-            let writer_metadata_key = format!("{}-parquet-metadata-v3", writer_cache_key);
+            for quality in [
+                TessellationQuality::Medium,
+                TessellationQuality::Low,
+                TessellationQuality::Highest,
+            ] {
+                let writer_cache_key = format!(
+                    "{}-{}{}",
+                    hash,
+                    mode.cache_key_suffix(),
+                    quality_cache_suffix(quality)
+                );
+                let writer_parquet_key = format!("{}-parquet-v4", writer_cache_key);
+                let writer_metadata_key = format!("{}-parquet-metadata-v4", writer_cache_key);
 
-            assert_eq!(parquet_cache_key(hash, mode), writer_parquet_key);
-            assert_eq!(parquet_metadata_cache_key(hash, mode), writer_metadata_key);
+                assert_eq!(parquet_cache_key(hash, mode, quality), writer_parquet_key);
+                assert_eq!(
+                    parquet_metadata_cache_key(hash, mode, quality),
+                    writer_metadata_key
+                );
+            }
         }
     }
 
+    /// The default (medium) level maps to the LEGACY key shape — pre-existing
+    /// cache entries written before the quality knob stay valid.
     #[test]
     fn parquet_cache_key_default_filter_uses_default_suffix() {
-        let key = parquet_cache_key("abc", OpeningFilterMode::Default);
-        assert_eq!(key, "abc-default-parquet-v3");
+        let key = parquet_cache_key("abc", OpeningFilterMode::Default, TessellationQuality::Medium);
+        assert_eq!(key, "abc-default-parquet-v4");
+        let key = parquet_cache_key("abc", OpeningFilterMode::Default, TessellationQuality::High);
+        assert_eq!(key, "abc-default-qhigh-parquet-v4");
     }
 
     /// The symbolic cache key (issue #900) is derived from the full

--- a/apps/server/src/services/streaming.rs
+++ b/apps/server/src/services/streaming.rs
@@ -3,679 +3,129 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 //! Streaming geometry processing with Server-Sent Events.
+//!
+//! Thin bridge over the canonical `ifc_lite_processing` pipeline: the
+//! blocking task runs `process_geometry_streaming_filtered_with_options`
+//! (the same code path as `POST /api/v1/parse` and the wasm
+//! `processGeometryBatch` boundary) and forwards its batch callbacks through
+//! an unbounded channel as [`StreamEvent`]s.
+//!
+//! This file used to host a third, bespoke geometry pipeline with its own
+//! scan, style index (SurfaceColour-only, no material chain, no indexed
+//! colour maps), no aggregate void propagation, no submeshes and no type
+//! geometry — meshes streamed from `/parse/stream` could differ from every
+//! other surface (alignment audit). Supersede means delete: it is gone, and
+//! the streaming endpoints inherit every pipeline feature (and bug fix)
+//! automatically, including `opening_filter` support which the bespoke
+//! pipeline never had.
 
 use crate::services::cache::DiskCache;
-use crate::types::{CoordinateInfo, MeshData, ModelMetadata, ProcessingStats, StreamEvent};
+use crate::types::StreamEvent;
 use async_stream::stream;
 use futures::Stream;
-use ifc_lite_core::{
-    build_entity_index, scan_placement_bounds, DecodedEntity, EntityDecoder, EntityIndex,
-    EntityScanner, IfcType,
+use ifc_lite_processing::{
+    extract_symbolic_data, process_geometry_streaming_filtered_with_options, OpeningFilterMode,
+    StreamingOptions, TessellationQuality,
 };
-use ifc_lite_geometry::{calculate_normals, GeometryRouter};
-use ifc_lite_processing::{convert_mesh_to_site_local, extract_symbolic_data, SymbolicData};
-use rayon::prelude::*;
-use rustc_hash::FxHashMap;
 use std::pin::Pin;
-use std::sync::Arc;
 use tokio::sync::mpsc;
 
-/// Job for processing a single entity.
-#[derive(Clone)]
-struct EntityJob {
-    id: u32,
-    type_name: String,
-    ifc_type: IfcType,
-    start: usize,
-    end: usize,
-}
-
-/// Pre-computed data for streaming (all Send-safe).
-struct PreparedData {
-    content: Arc<String>,
-    entity_index: Arc<EntityIndex>,
-    style_index: Arc<FxHashMap<u32, [f32; 4]>>,
-    void_index: Arc<FxHashMap<u32, Vec<u32>>>,
-    jobs: Vec<EntityJob>,
-    schema_version: String,
-    total_entities: usize,
-    parse_time_ms: u64,
-    /// OPTIMIZATION: Precomputed unit scale to avoid parsing content per mesh
-    unit_scale: f64,
-    /// RTC offset for large-coordinate models (preserves precision in f32 output)
-    rtc_offset: (f64, f64, f64),
-    /// Coordinate space of serialized mesh vertices: `site_local`, `model_rtc`, or `raw_ifc`.
-    mesh_coordinate_space: &'static str,
-    /// IfcSite placement, already cheaply cloneable for the worker pool, and
-    /// only populated when the selected coordinate space is `site_local`.
-    /// Lets `process_batch` rotate mesh vertices into the site axis frame.
-    site_local_rotation: Option<Arc<Vec<f64>>>,
-    /// IfcSite ObjectPlacement as a column-major 4×4 matrix (metres).
-    site_transform: Option<Vec<f64>>,
-    /// IfcBuilding ObjectPlacement as a column-major 4×4 matrix (metres).
-    building_transform: Option<Vec<f64>>,
-}
-
-/// Extract entity references from a list attribute.
-fn get_refs_from_list(entity: &DecodedEntity, index: usize) -> Option<Vec<u32>> {
-    let list = entity.get_list(index)?;
-    let refs: Vec<u32> = list.iter().filter_map(|v| v.as_entity_ref()).collect();
-    if refs.is_empty() {
-        None
-    } else {
-        Some(refs)
-    }
-}
-
-/// Prepare all data needed for streaming (runs synchronously).
-fn prepare_streaming_data(content: String) -> PreparedData {
-    let parse_start = std::time::Instant::now();
-
-    // Build entity index
-    let entity_index = Arc::new(build_entity_index(&content));
-    let mut decoder = EntityDecoder::with_arc_index(&content, entity_index.clone());
-
-    // OPTIMIZATION: Build style indices in a single pass (previously two separate scans)
-    let style_index = build_style_indices(&content, &mut decoder);
-
-    // Collect jobs and build void index
-    let mut scanner = EntityScanner::new(&content);
-    let mut void_index: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
-    let mut jobs: Vec<EntityJob> = Vec::with_capacity(2000);
-    let mut schema_version = "IFC2X3".to_string();
-    let mut total_entities = 0usize;
-    let mut site_entity_pos: Option<(usize, usize)> = None;
-    let mut building_entity_pos: Option<(usize, usize)> = None;
-
-    while let Some((id, type_name, start, end)) = scanner.next_entity() {
-        total_entities += 1;
-
-        if type_name == "IFCRELVOIDSELEMENT" {
-            if let Ok(entity) = decoder.decode_at(start, end) {
-                if let (Some(host), Some(opening)) = (entity.get_ref(4), entity.get_ref(5)) {
-                    void_index.entry(host).or_default().push(opening);
-                }
-            }
-        } else if type_name == "IFCSITE" && site_entity_pos.is_none() {
-            site_entity_pos = Some((start, end));
-        } else if type_name == "IFCBUILDING" && building_entity_pos.is_none() {
-            building_entity_pos = Some((start, end));
-        }
-
-        if ifc_lite_core::has_geometry_by_name(type_name) {
-            if let Ok(entity) = decoder.decode_at(start, end) {
-                jobs.push(EntityJob {
-                    id,
-                    type_name: type_name.to_string(),
-                    ifc_type: entity.ifc_type,
-                    start,
-                    end,
-                });
-            }
-        }
-    }
-
-    // Detect schema
-    if content.contains("IFC4X3") {
-        schema_version = "IFC4X3".into();
-    } else if content.contains("IFC4") {
-        schema_version = "IFC4".into();
-    }
-
-    // Preprocess FacetedBreps and extract unit_scale + rtc_offset
-    let mut router = GeometryRouter::with_units(&content, &mut decoder);
-    // Resolve site/building placement transforms for cache consistency.
-    let site_transform: Option<Vec<f64>> = site_entity_pos.and_then(|(start, end)| {
-        let entity = decoder.decode_at(start, end).ok()?;
-        let matrix = router
-            .resolve_scaled_placement(&entity, &mut decoder)
-            .ok()?;
-        Some(matrix.to_vec())
-    });
-    let building_transform: Option<Vec<f64>> = building_entity_pos.and_then(|(start, end)| {
-        let entity = decoder.decode_at(start, end).ok()?;
-        let matrix = router
-            .resolve_scaled_placement(&entity, &mut decoder)
-            .ok()?;
-        Some(matrix.to_vec())
-    });
-
-    let rtc_jobs: Vec<(u32, usize, usize, IfcType)> = jobs
-        .iter()
-        .map(|j| (j.id, j.start, j.end, j.ifc_type))
-        .collect();
-    let detected_rtc_offset =
-        router.detect_rtc_offset_with_fallback(&rtc_jobs, &mut decoder, &content);
-
-    // Three-tier coordinate-space selection, mirroring the non-streaming path:
-    //   1. site_local: IfcSite placement has a non-identity translation.
-    //   2. model_rtc:  fall back to the detected anchor for large-coordinate files.
-    //   3. raw_ifc:    neither anchor applies.
-    const PLACEMENT_IDENTITY_EPSILON: f64 = 1e-9;
-    let site_rtc = site_transform
-        .as_ref()
-        .map(|st| (st[12], st[13], st[14]))
-        .filter(|t| {
-            t.0.abs() > PLACEMENT_IDENTITY_EPSILON
-                || t.1.abs() > PLACEMENT_IDENTITY_EPSILON
-                || t.2.abs() > PLACEMENT_IDENTITY_EPSILON
-        });
-    let detected_has_offset = detected_rtc_offset.0.abs() > PLACEMENT_IDENTITY_EPSILON
-        || detected_rtc_offset.1.abs() > PLACEMENT_IDENTITY_EPSILON
-        || detected_rtc_offset.2.abs() > PLACEMENT_IDENTITY_EPSILON;
-    let (rtc_offset, mesh_coordinate_space): ((f64, f64, f64), &'static str) =
-        if let Some(site) = site_rtc {
-            (site, "site_local")
-        } else if detected_has_offset {
-            (detected_rtc_offset, "model_rtc")
-        } else {
-            ((0.0, 0.0, 0.0), "raw_ifc")
-        };
-    router.set_rtc_offset(rtc_offset);
-    // OPTIMIZATION: Extract unit_scale before dropping router
-    // This allows process_batch to use with_scale() instead of with_units() per mesh
-    let unit_scale = router.unit_scale();
-    drop(router); // Explicitly drop non-Send router
-
-    let parse_time_ms = parse_start.elapsed().as_millis() as u64;
-
-    let site_local_rotation = if mesh_coordinate_space == "site_local" {
-        site_transform.clone().map(Arc::new)
-    } else {
-        None
-    };
-
-    PreparedData {
-        content: Arc::new(content),
-        entity_index, // Already Arc
-        style_index: Arc::new(style_index),
-        void_index: Arc::new(void_index),
-        jobs,
-        schema_version,
-        total_entities,
-        parse_time_ms,
-        unit_scale,
-        rtc_offset,
-        mesh_coordinate_space,
-        site_local_rotation,
-        site_transform,
-        building_transform,
-    }
-}
-
-/// Process a batch of jobs (runs in blocking thread).
-fn process_batch(
-    jobs: Vec<EntityJob>,
-    content: Arc<String>,
-    entity_index: Arc<EntityIndex>,
-    style_index: Arc<FxHashMap<u32, [f32; 4]>>,
-    void_index: Arc<FxHashMap<u32, Vec<u32>>>,
-    unit_scale: f64,
-    rtc_offset: (f64, f64, f64),
-    site_local_rotation: Option<Arc<Vec<f64>>>,
-) -> Vec<MeshData> {
-    jobs.par_iter()
-        .filter_map(|job| {
-            let mut local_decoder = EntityDecoder::with_arc_index(&content, entity_index.clone());
-
-            if let Ok(entity) = local_decoder.decode_at(job.start, job.end) {
-                let has_representation = entity.get(6).is_some_and(|a| !a.is_null());
-                if !has_representation {
-                    return None;
-                }
-
-                // OPTIMIZATION: Use with_scale() instead of with_units()
-                // unit_scale is precomputed once, avoiding content parsing per mesh
-                let local_router = GeometryRouter::with_scale_and_rtc(unit_scale, rtc_offset);
-
-                if let Ok(mut mesh) = local_router.process_element_with_voids(
-                    &entity,
-                    &mut local_decoder,
-                    void_index.as_ref(),
-                ) {
-                    if !mesh.is_empty() {
-                        if mesh.normals.is_empty() {
-                            calculate_normals(&mut mesh);
-                        }
-
-                        let color = style_index
-                            .get(&job.id)
-                            .copied()
-                            .unwrap_or_else(|| {
-                                ifc_lite_processing::default_color_for_type(job.ifc_type).to_array()
-                            });
-
-                        let mut mesh_data = MeshData::new(
-                            job.id,
-                            job.ifc_type.name().to_string(),
-                            mesh.positions,
-                            mesh.normals,
-                            mesh.indices,
-                            color,
-                        );
-                        convert_mesh_to_site_local(
-                            &mut mesh_data,
-                            site_local_rotation.as_deref(),
-                        );
-                        return Some(mesh_data);
-                    }
-                }
-            }
-            None
-        })
-        .collect()
-}
-
-/// Calculate dynamic batch size based on batch number and total job count.
-/// For large files, use MUCH larger batches to maximize parallel throughput and reduce overhead.
-fn calculate_batch_size(
-    batch_number: usize,
-    initial_batch_size: usize,
-    max_batch_size: usize,
-    total_jobs: usize,
-) -> usize {
-    // For huge files (>50k jobs), use VERY aggressive batching to minimize batch count
-    let adjusted_max = if total_jobs > 50_000 {
-        // Very large files: 10k-20k entities per batch (minimize batch overhead)
-        (max_batch_size * 20).min(20_000)
-    } else if total_jobs > 10_000 {
-        // Large files: 5k-10k entities per batch
-        (max_batch_size * 10).min(10_000)
-    } else if total_jobs > 1_000 {
-        // Medium files: 2k-5k entities per batch
-        (max_batch_size * 5).min(5_000)
-    } else {
-        max_batch_size
-    };
-
-    match batch_number {
-        1..=2 => initial_batch_size, // Fast first frame (2 batches for quick start)
-        3..=5 => (initial_batch_size + adjusted_max) / 2, // Ramp up quickly
-        _ => adjusted_max,           // Full throughput (much larger batches)
-    }
-}
-
-/// Generate streaming geometry events with dynamic batch sizing.
+/// Generate streaming geometry events backed by the canonical pipeline.
 pub fn process_streaming(
     content: String,
     initial_batch_size: usize,
     max_batch_size: usize,
+    opening_filter: OpeningFilterMode,
+    tessellation_quality: TessellationQuality,
 ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send>> {
-    Box::pin(stream! {
-        let total_start = std::time::Instant::now();
+    let (tx, mut rx) = mpsc::unbounded_channel::<StreamEvent>();
 
-        // Prepare data in blocking task (all CPU-intensive work)
-        let prepared = tokio::task::spawn_blocking(move || {
-            prepare_streaming_data(content)
-        }).await;
+    let handle = tokio::task::spawn_blocking(move || {
+        let cache_key = DiskCache::generate_key(content.as_bytes());
 
-        let prepared = match prepared {
-            Ok(p) => p,
-            Err(e) => {
-                yield StreamEvent::Error {
-                    message: format!("Failed to prepare data: {}", e),
-                };
-                return;
-            }
-        };
+        let mut started = false;
+        let mut batch_number = 0usize;
+        let mut last_type = String::new();
 
-        let total_jobs = prepared.jobs.len();
-        let geometry_entity_count = total_jobs;
-
-        yield StreamEvent::Start {
-            total_estimate: total_jobs,
-        };
-
-        yield StreamEvent::Progress {
-            processed: 0,
-            total: total_jobs,
-            current_type: "indexing".into(),
-        };
-
-        let mut total_processed = 0;
-        let mut all_meshes: Vec<MeshData> = Vec::new();
-        let mut total_vertices = 0usize;
-        let mut total_triangles = 0usize;
-
-        // PIPELINED BATCH PROCESSING: Process multiple batches concurrently
-        // Pipeline depth: more batches in flight = better CPU utilization
-        let pipeline_depth = if total_jobs > 50_000 { 4 } else if total_jobs > 10_000 { 3 } else { 2 };
-        let mut job_index = 0;
-        let mut next_batch_num = 1;
-        let mut next_expected_batch = 1;
-        let mut completed_batches: std::collections::BTreeMap<usize, (usize, String, Vec<MeshData>)> = std::collections::BTreeMap::new();
-
-        // Use a channel to receive completed batches
-        let (tx, mut rx) = mpsc::unbounded_channel::<(usize, Result<(usize, String, Vec<MeshData>), String>)>();
-        let mut in_flight = 0;
-
-        loop {
-            // Start new batches up to pipeline depth
-            while in_flight < pipeline_depth && job_index < prepared.jobs.len() {
-                let batch_num = next_batch_num;
-                next_batch_num += 1;
-                in_flight += 1;
-
-                let current_batch_size = calculate_batch_size(
-                    batch_num,
-                    initial_batch_size,
-                    max_batch_size,
-                    total_jobs,
-                );
-                let end_index = (job_index + current_batch_size).min(prepared.jobs.len());
-                let chunk: Vec<EntityJob> = prepared.jobs[job_index..end_index].to_vec();
-                job_index = end_index;
-
-                let chunk_len = chunk.len();
-                let last_type_name = chunk.last().map(|j| j.type_name.clone()).unwrap_or_default();
-
-                let chunk_vec = chunk;
-                let content_bg = prepared.content.clone();
-                let index_bg = prepared.entity_index.clone();
-                let void_bg = prepared.void_index.clone();
-                let style_bg = prepared.style_index.clone();
-                let unit_scale = prepared.unit_scale;
-                let rtc_offset = prepared.rtc_offset;
-                let site_local_rotation = prepared.site_local_rotation.clone();
-                let tx_clone = tx.clone();
-
-                // Spawn batch processing task
-                tokio::spawn(async move {
-                    let result = tokio::task::spawn_blocking(move || {
-                        process_batch(
-                            chunk_vec,
-                            content_bg,
-                            index_bg,
-                            style_bg,
-                            void_bg,
-                            unit_scale,
-                            rtc_offset,
-                            site_local_rotation,
-                        )
-                    }).await;
-
-                    let batch_result = match result {
-                        Ok(meshes) => Ok((chunk_len, last_type_name, meshes)),
-                        Err(e) => Err(format!("Batch processing failed: {}", e)),
-                    };
-
-                    let _ = tx_clone.send((batch_num, batch_result));
-                });
-            }
-
-            // Receive completed batches (non-blocking)
-            while let Ok((batch_num, result)) = rx.try_recv() {
-                in_flight -= 1;
-                match result {
-                    Ok(data) => {
-                        completed_batches.insert(batch_num, data);
-                    }
-                    Err(e) => {
-                        yield StreamEvent::Error {
-                            message: format!("Batch {}: {}", batch_num, e),
-                        };
-                    }
+        let result = process_geometry_streaming_filtered_with_options(
+            &content,
+            opening_filter,
+            StreamingOptions {
+                initial_batch_size,
+                throughput_batch_size: max_batch_size,
+                tessellation_quality,
+                // Batches are forwarded as they are emitted — retaining them
+                // in the ProcessingResult would double peak memory.
+                retain_emitted_meshes: false,
+                ..StreamingOptions::default()
+            },
+            |meshes, processed, total| {
+                if !started {
+                    started = true;
+                    let _ = tx.send(StreamEvent::Start {
+                        total_estimate: total,
+                    });
+                    let _ = tx.send(StreamEvent::Progress {
+                        processed: 0,
+                        total,
+                        current_type: "indexing".into(),
+                    });
                 }
-            }
-
-            // Yield completed batches in order
-            while let Some((chunk_len, last_type_name, meshes)) = completed_batches.remove(&next_expected_batch) {
-                total_processed += chunk_len;
-                let batch_number = next_expected_batch;
-
-                // Update stats
-                for mesh in &meshes {
-                    total_vertices += mesh.vertex_count();
-                    total_triangles += mesh.triangle_count();
+                if let Some(mesh) = meshes.last() {
+                    last_type = mesh.ifc_type.clone();
                 }
-
                 if !meshes.is_empty() {
-                    all_meshes.extend(meshes.iter().cloned());
-                    yield StreamEvent::Batch {
-                        meshes,
+                    batch_number += 1;
+                    let _ = tx.send(StreamEvent::Batch {
+                        meshes: meshes.to_vec(),
                         batch_number,
-                    };
+                    });
                 }
+                let _ = tx.send(StreamEvent::Progress {
+                    processed,
+                    total,
+                    current_type: last_type.clone(),
+                });
+            },
+            // Styling is eager on this path (`fast_first_batch` defaults to
+            // false), so colour updates never fire.
+            |_| {},
+            |_| {},
+        );
 
-                yield StreamEvent::Progress {
-                    processed: total_processed,
-                    total: total_jobs,
-                    current_type: last_type_name,
-                };
-
-                next_expected_batch += 1;
-            }
-
-            // Check if we're done
-            if job_index >= prepared.jobs.len() && in_flight == 0 && completed_batches.is_empty() {
-                break;
-            }
-
-            // Yield control to allow other tasks to run
-            tokio::task::yield_now().await;
+        if !started {
+            // Zero-geometry model: the batch callback never ran. Emit Start
+            // so consumers still observe the Start → Complete contract.
+            let _ = tx.send(StreamEvent::Start { total_estimate: 0 });
         }
 
-        let total_time = total_start.elapsed();
+        // 2D symbolic stream (IfcAnnotation + IfcGrid) on the same blocking
+        // thread — parity with the synchronous endpoints (issue #900).
+        // Georeferencing already rides in `result.metadata`.
+        let symbolic_data = extract_symbolic_data(&content);
 
-        // Generate cache key for the complete result
-        let cache_key = DiskCache::generate_key(prepared.content.as_bytes());
-
-        // Extract the 2D symbolic stream (IfcAnnotation + IfcGrid) once, on a
-        // blocking thread, so the streaming Complete event reaches parity with
-        // the synchronous `POST /api/v1/parse` response (issue #900).
-        let symbolic_content = prepared.content.clone();
-        let symbolic_data = tokio::task::spawn_blocking(move || {
-            extract_symbolic_data(&symbolic_content)
-        })
-        .await
-        .unwrap_or_else(|e| {
-            tracing::error!(error = %e, "Symbolic-data extraction task panicked");
-            SymbolicData::default()
-        });
-
-        // Extract georeferencing on a blocking thread so the streaming Complete
-        // event carries the same map-conversion/CRS metadata as the synchronous
-        // endpoints (issue #900). Cheap relative to geometry; never blocks the
-        // async executor.
-        let georef_content = prepared.content.clone();
-        let georeferencing = tokio::task::spawn_blocking(move || {
-            ifc_lite_processing::extract_georeferencing(&georef_content)
-        })
-        .await
-        .unwrap_or_else(|e| {
-            tracing::error!(error = %e, "Georeferencing extraction task panicked");
-            None
-        });
-
-        yield StreamEvent::Complete {
-            stats: ProcessingStats {
-                total_meshes: all_meshes.len(),
-                total_vertices,
-                total_triangles,
-                parse_time_ms: prepared.parse_time_ms,
-                entity_scan_time_ms: 0,
-                lookup_time_ms: 0,
-                preprocess_time_ms: 0,
-                geometry_time_ms: total_time.as_millis() as u64 - prepared.parse_time_ms,
-                total_time_ms: total_time.as_millis() as u64,
-                from_cache: false,
-                ..Default::default()
-            },
-            metadata: ModelMetadata {
-                schema_version: prepared.schema_version,
-                entity_count: prepared.total_entities,
-                geometry_entity_count,
-                coordinate_info: CoordinateInfo {
-                    origin_shift: [
-                        prepared.rtc_offset.0,
-                        prepared.rtc_offset.1,
-                        prepared.rtc_offset.2,
-                    ],
-                    is_geo_referenced: prepared.rtc_offset.0 != 0.0
-                        || prepared.rtc_offset.1 != 0.0
-                        || prepared.rtc_offset.2 != 0.0,
-                },
-                length_unit_scale: Some(prepared.unit_scale),
-                georeferencing,
-            },
+        let _ = tx.send(StreamEvent::Complete {
+            stats: result.stats,
+            metadata: result.metadata,
             cache_key,
-            mesh_coordinate_space: Some(prepared.mesh_coordinate_space.to_string()),
-            site_transform: prepared.site_transform,
-            building_transform: prepared.building_transform,
+            mesh_coordinate_space: result.mesh_coordinate_space,
+            site_transform: result.site_transform,
+            building_transform: result.building_transform,
             symbolic_data,
-        };
+        });
+        // `tx` drops here, closing the channel and ending the stream below.
+    });
+
+    Box::pin(stream! {
+        while let Some(event) = rx.recv().await {
+            yield event;
+        }
+        // Surface a panicked/cancelled blocking task as a stream error
+        // instead of silently truncating the SSE stream.
+        if let Err(e) = handle.await {
+            yield StreamEvent::Error {
+                message: format!("Streaming geometry task failed: {e}"),
+            };
+        }
     })
 }
-
-// Helper functions for style extraction
-
-/// OPTIMIZATION: Build both style indices in a single pass through entities.
-/// Previously, build_geometry_style_index and build_element_style_index each scanned all entities.
-/// This combined function scans once and builds both maps together, reducing I/O overhead.
-fn build_style_indices(content: &str, decoder: &mut EntityDecoder) -> FxHashMap<u32, [f32; 4]> {
-    // Phase 1: Single scan to collect styled items and geometry-bearing elements
-    let mut geometry_styles: FxHashMap<u32, [f32; 4]> = FxHashMap::default();
-    let mut element_repr_ids: Vec<(u32, u32)> = Vec::with_capacity(2000); // (element_id, repr_id)
-    let mut scanner = EntityScanner::new(content);
-
-    while let Some((id, type_name, start, end)) = scanner.next_entity() {
-        // Collect IfcStyledItem data
-        if type_name == "IFCSTYLEDITEM" {
-            if let Ok(styled_item) = decoder.decode_at(start, end) {
-                if let Some(geometry_id) = styled_item.get_ref(0) {
-                    if !geometry_styles.contains_key(&geometry_id) {
-                        if let Some(color) = extract_color_from_styled_item(&styled_item, decoder) {
-                            geometry_styles.insert(geometry_id, color);
-                        }
-                    }
-                }
-            }
-        }
-        // Collect geometry-bearing element representation IDs
-        else if ifc_lite_core::has_geometry_by_name(type_name) {
-            if let Ok(element) = decoder.decode_at(start, end) {
-                if let Some(repr_id) = element.get_ref(6) {
-                    element_repr_ids.push((id, repr_id));
-                }
-            }
-        }
-    }
-
-    // Phase 2: Build element style index using collected data (no re-scan needed)
-    let mut element_styles: FxHashMap<u32, [f32; 4]> = FxHashMap::default();
-    for (element_id, repr_id) in element_repr_ids {
-        if let Some(color) = find_color_in_representation(repr_id, &geometry_styles, decoder) {
-            element_styles.insert(element_id, color);
-        }
-    }
-
-    element_styles
-}
-
-fn find_color_in_representation(
-    repr_id: u32,
-    geometry_styles: &FxHashMap<u32, [f32; 4]>,
-    decoder: &mut EntityDecoder,
-) -> Option<[f32; 4]> {
-    let repr = decoder.decode_by_id(repr_id).ok()?;
-    let repr_list = get_refs_from_list(&repr, 2)?;
-
-    for shape_repr_id in repr_list {
-        if let Ok(shape_repr) = decoder.decode_by_id(shape_repr_id) {
-            if let Some(items) = get_refs_from_list(&shape_repr, 3) {
-                for item_id in items {
-                    if let Some(color) = geometry_styles.get(&item_id) {
-                        return Some(*color);
-                    }
-
-                    if let Ok(item) = decoder.decode_by_id(item_id) {
-                        if item.ifc_type == IfcType::IfcMappedItem {
-                            if let Some(source_id) = item.get_ref(0) {
-                                if let Ok(source) = decoder.decode_by_id(source_id) {
-                                    if let Some(mapped_repr_id) = source.get_ref(1) {
-                                        if let Some(color) = find_color_in_shape_representation(
-                                            mapped_repr_id,
-                                            geometry_styles,
-                                            decoder,
-                                        ) {
-                                            return Some(color);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    None
-}
-
-fn find_color_in_shape_representation(
-    repr_id: u32,
-    geometry_styles: &FxHashMap<u32, [f32; 4]>,
-    decoder: &mut EntityDecoder,
-) -> Option<[f32; 4]> {
-    let repr = decoder.decode_by_id(repr_id).ok()?;
-    let items = get_refs_from_list(&repr, 3)?;
-
-    for item_id in items {
-        if let Some(color) = geometry_styles.get(&item_id) {
-            return Some(*color);
-        }
-    }
-
-    None
-}
-
-fn extract_color_from_styled_item(
-    styled_item: &DecodedEntity,
-    decoder: &mut EntityDecoder,
-) -> Option<[f32; 4]> {
-    let style_refs = get_refs_from_list(styled_item, 1)?;
-
-    for style_id in style_refs {
-        if let Ok(style) = decoder.decode_by_id(style_id) {
-            if let Some(inner_refs) = get_refs_from_list(&style, 0) {
-                for inner_id in inner_refs {
-                    if let Some(color) = extract_surface_style_color(inner_id, decoder) {
-                        return Some(color);
-                    }
-                }
-            }
-            if let Some(color) = extract_surface_style_color(style_id, decoder) {
-                return Some(color);
-            }
-        }
-    }
-
-    None
-}
-
-fn extract_surface_style_color(style_id: u32, decoder: &mut EntityDecoder) -> Option<[f32; 4]> {
-    let style = decoder.decode_by_id(style_id).ok()?;
-    let rendering_refs = get_refs_from_list(&style, 2)?;
-
-    for rendering_id in rendering_refs {
-        if let Ok(rendering) = decoder.decode_by_id(rendering_id) {
-            if let Some(color_id) = rendering.get_ref(0) {
-                if let Ok(color) = decoder.decode_by_id(color_id) {
-                    let r = color.get_float(1).unwrap_or(0.8) as f32;
-                    let g = color.get_float(2).unwrap_or(0.8) as f32;
-                    let b = color.get_float(3).unwrap_or(0.8) as f32;
-                    let alpha: f32 = 1.0 - rendering.get_float(8).unwrap_or(0.0) as f32;
-
-                    return Some([r, g, b, alpha.max(0.0).min(1.0)]);
-                }
-            }
-        }
-    }
-
-    None
-}
-
-// Default IFC-type colors now come from the single canonical table in
-// `ifc_lite_processing::default_color_for_type` (issue #913). Do not
-// reintroduce a per-service table here.

--- a/packages/server-client/src/client.ts
+++ b/packages/server-client/src/client.ts
@@ -69,6 +69,30 @@ async function computeFileHash(file: File | ArrayBuffer): Promise<string> {
  * console.log(`Meshes: ${result.meshes.length}`);
  * ```
  */
+/**
+ * Per-request parse options shared by all parse endpoints.
+ */
+export interface ParseRequestOptions {
+  /**
+   * Tessellation detail level (#976). Omitted = `'medium'`, which is
+   * byte-identical to the historical output — and to what the wasm path
+   * produces without `setTessellationQuality`, so client-side and
+   * server-side meshes stay in parity. Non-default levels get distinct
+   * server cache entries.
+   */
+  tessellationQuality?: 'lowest' | 'low' | 'medium' | 'high' | 'highest';
+}
+
+/** Build the query string shared by the parse endpoints. */
+function parseQuery(options?: ParseRequestOptions): string {
+  const params = new URLSearchParams();
+  if (options?.tessellationQuality && options.tessellationQuality !== 'medium') {
+    params.set('tessellation_quality', options.tessellationQuality);
+  }
+  const qs = params.toString();
+  return qs ? `?${qs}` : '';
+}
+
 export class IfcServerClient {
   private baseUrl: string;
   private timeout: number;
@@ -118,7 +142,7 @@ export class IfcServerClient {
    * }
    * ```
    */
-  async parse(file: File | ArrayBuffer): Promise<ParseResponse> {
+  async parse(file: File | ArrayBuffer, options?: ParseRequestOptions): Promise<ParseResponse> {
     // Compress file before upload for faster transfer
     const compressedFile = await compressGzip(file);
     const fileName = file instanceof File ? file.name : 'model.ifc';
@@ -126,7 +150,7 @@ export class IfcServerClient {
     const formData = new FormData();
     formData.append('file', compressedFile, fileName);
 
-    const response = await fetch(`${this.baseUrl}/api/v1/parse`, {
+    const response = await fetch(`${this.baseUrl}/api/v1/parse${parseQuery(options)}`, {
       method: 'POST',
       body: formData,
       signal: AbortSignal.timeout(this.timeout),
@@ -164,7 +188,7 @@ export class IfcServerClient {
    * }
    * ```
    */
-  async parseParquet(file: File | ArrayBuffer): Promise<ParquetParseResponse> {
+  async parseParquet(file: File | ArrayBuffer, options?: ParseRequestOptions): Promise<ParquetParseResponse> {
     // Check if Parquet decoding is available
     const parquetReady = await isParquetAvailable();
     if (!parquetReady) {
@@ -182,7 +206,7 @@ export class IfcServerClient {
 
     // Step 2: Check if already cached
     const cacheCheckStart = performance.now();
-    const cacheCheck = await fetch(`${this.baseUrl}/api/v1/cache/check/${hash}`, {
+    const cacheCheck = await fetch(`${this.baseUrl}/api/v1/cache/check/${hash}${parseQuery(options)}`, {
       method: 'GET',
       signal: AbortSignal.timeout(5000), // 5s timeout for cache check
     });
@@ -191,12 +215,12 @@ export class IfcServerClient {
     if (cacheCheck.ok) {
       // Cache HIT - fetch directly without uploading!
       console.log(`[client] Cache HIT (check: ${cacheCheckTime.toFixed(0)}ms) - skipping upload`);
-      return this.fetchCachedGeometry(hash);
+      return this.fetchCachedGeometry(hash, options);
     }
 
     // Cache MISS - upload and process as usual
     console.log(`[client] Cache MISS (check: ${cacheCheckTime.toFixed(0)}ms) - uploading file`);
-    return this.uploadAndProcessParquet(file, hash);
+    return this.uploadAndProcessParquet(file, hash, options);
   }
 
   /**
@@ -226,7 +250,8 @@ export class IfcServerClient {
    */
   async parseParquetStream(
     file: File | ArrayBuffer,
-    onBatch: (batch: ParquetBatch) => void
+    onBatch: (batch: ParquetBatch) => void,
+    options?: ParseRequestOptions
   ): Promise<ParquetStreamResult> {
     const parquetReady = await isParquetAvailable();
     if (!parquetReady) {
@@ -294,7 +319,7 @@ export class IfcServerClient {
     formData.append('file', file instanceof File ? file : new Blob([file]), fileName);
 
     const uploadStart = performance.now();
-    const response = await fetch(`${this.baseUrl}/api/v1/parse/parquet-stream`, {
+    const response = await fetch(`${this.baseUrl}/api/v1/parse/parquet-stream${parseQuery(options)}`, {
       method: 'POST',
       body: formData,
       signal: AbortSignal.timeout(this.timeout),
@@ -410,9 +435,12 @@ export class IfcServerClient {
    * Fetch cached geometry directly without uploading the file.
    * @private
    */
-  private async fetchCachedGeometry(hash: string): Promise<ParquetParseResponse> {
+  private async fetchCachedGeometry(
+    hash: string,
+    options?: ParseRequestOptions
+  ): Promise<ParquetParseResponse> {
     const fetchStart = performance.now();
-    const response = await fetch(`${this.baseUrl}/api/v1/cache/geometry/${hash}`, {
+    const response = await fetch(`${this.baseUrl}/api/v1/cache/geometry/${hash}${parseQuery(options)}`, {
       method: 'GET',
       signal: AbortSignal.timeout(this.timeout),
     });
@@ -444,7 +472,7 @@ export class IfcServerClient {
    * Upload file and process on server.
    * @private
    */
-  private async uploadAndProcessParquet(file: File | ArrayBuffer, hash: string): Promise<ParquetParseResponse> {
+  private async uploadAndProcessParquet(file: File | ArrayBuffer, hash: string, options?: ParseRequestOptions): Promise<ParquetParseResponse> {
     const fileSize = file instanceof File ? file.size : file.byteLength;
     const fileName = file instanceof File ? file.name : 'model.ifc';
 
@@ -467,7 +495,7 @@ export class IfcServerClient {
     formData.append('file', uploadFile as Blob, fileName);
 
     const uploadStart = performance.now();
-    const response = await fetch(`${this.baseUrl}/api/v1/parse/parquet`, {
+    const response = await fetch(`${this.baseUrl}/api/v1/parse/parquet${parseQuery(options)}`, {
       method: 'POST',
       body: formData,
       signal: AbortSignal.timeout(this.timeout),
@@ -487,9 +515,11 @@ export class IfcServerClient {
 
     const metadata: ParquetMetadataHeader = JSON.parse(metadataHeader);
 
-    // Verify hash matches (sanity check)
-    if (metadata.cache_key !== hash) {
-      console.warn(`[client] Cache key mismatch: expected ${hash.substring(0, 16)}..., got ${metadata.cache_key.substring(0, 16)}...`);
+    // Sanity check: the server cache key is the file hash plus request
+    // suffixes (`{hash}-{opening_filter}[-q{level}]`), so verify derivation,
+    // not equality — the old equality check warned on every fresh upload.
+    if (!metadata.cache_key.startsWith(hash)) {
+      console.warn(`[client] Cache key mismatch: expected a key derived from ${hash.substring(0, 16)}..., got ${metadata.cache_key.substring(0, 16)}...`);
     }
 
     // Get binary payload
@@ -738,7 +768,7 @@ export class IfcServerClient {
    * console.log(`Payload: ${result.parquet_stats.payload_size} bytes`);
    * ```
    */
-  async parseParquetOptimized(file: File | ArrayBuffer): Promise<OptimizedParquetParseResponse> {
+  async parseParquetOptimized(file: File | ArrayBuffer, options?: ParseRequestOptions): Promise<OptimizedParquetParseResponse> {
     // Check if Parquet decoding is available
     const parquetReady = await isParquetAvailable();
     if (!parquetReady) {
@@ -755,7 +785,7 @@ export class IfcServerClient {
     const formData = new FormData();
     formData.append('file', compressedFile, fileName);
 
-    const response = await fetch(`${this.baseUrl}/api/v1/parse/parquet/optimized`, {
+    const response = await fetch(`${this.baseUrl}/api/v1/parse/parquet/optimized${parseQuery(options)}`, {
       method: 'POST',
       body: formData,
       signal: AbortSignal.timeout(this.timeout),
@@ -832,7 +862,10 @@ export class IfcServerClient {
    * }
    * ```
    */
-  async *parseStream(file: File | ArrayBuffer): AsyncGenerator<StreamEvent> {
+  async *parseStream(
+    file: File | ArrayBuffer,
+    options?: ParseRequestOptions
+  ): AsyncGenerator<StreamEvent> {
     const formData = new FormData();
     const blob = file instanceof File ? file : new Blob([file], { type: 'application/octet-stream' });
     formData.append(
@@ -841,7 +874,7 @@ export class IfcServerClient {
       file instanceof File ? file.name : 'model.ifc'
     );
 
-    const response = await fetch(`${this.baseUrl}/api/v1/parse/stream`, {
+    const response = await fetch(`${this.baseUrl}/api/v1/parse/stream${parseQuery(options)}`, {
       method: 'POST',
       body: formData,
       // Don't set Content-Type header - browser will set it with boundary for FormData

--- a/rust/geometry/src/csg.rs
+++ b/rust/geometry/src/csg.rs
@@ -1289,14 +1289,13 @@ fn add_triangle_to_mesh(mesh: &mut Mesh, triangle: &Triangle) {
 }
 
 /// Calculate smooth normals for a mesh.
-/// On desktop, this is a no-op because the frontend computes normals in JS
-/// after decoding (normals are not sent over IPC to save bandwidth).
-/// WASM path keeps full normal calculation.
-#[cfg(not(target_arch = "wasm32"))]
-#[inline]
-pub fn calculate_normals(_mesh: &mut Mesh) {}
-
-#[cfg(target_arch = "wasm32")]
+///
+/// One real implementation on every target. This used to be a no-op on
+/// native (a leftover of the decommissioned desktop IPC path, which
+/// recomputed normals in JS): the server silently shipped EMPTY normal
+/// buffers for brep/surface/swept meshes, which the parquet writer
+/// zero-padded and the glTF exporter dropped — while the same model loaded
+/// via wasm had real normals (alignment audit).
 #[inline]
 pub fn calculate_normals(mesh: &mut Mesh) {
     let vertex_count = mesh.vertex_count();

--- a/rust/geometry/src/tessellation.rs
+++ b/rust/geometry/src/tessellation.rs
@@ -38,6 +38,55 @@ pub enum TessellationQuality {
 }
 
 impl TessellationQuality {
+    /// Stable lowercase label — the single string surface shared by the wasm
+    /// `setTessellationQuality` setter and the server's `tessellation_quality`
+    /// query parameter, so the two consumer-facing spellings cannot drift.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Lowest => "lowest",
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::Highest => "highest",
+        }
+    }
+
+    /// Parse a consumer-facing label (case-insensitive). Inverse of
+    /// [`label`](Self::label); `None` for unknown spellings.
+    pub fn parse_label(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "lowest" => Some(Self::Lowest),
+            "low" => Some(Self::Low),
+            "medium" => Some(Self::Medium),
+            "high" => Some(Self::High),
+            "highest" => Some(Self::Highest),
+            _ => None,
+        }
+    }
+
+    /// Dense 0-4 index (Lowest..Highest). Used by the wasm bindings to store
+    /// the level in an atomic; total inverse of [`from_index`](Self::from_index).
+    pub fn to_index(self) -> u8 {
+        match self {
+            Self::Lowest => 0,
+            Self::Low => 1,
+            Self::Medium => 2,
+            Self::High => 3,
+            Self::Highest => 4,
+        }
+    }
+
+    /// Inverse of [`to_index`](Self::to_index); unknown values map to `Medium`.
+    pub fn from_index(idx: u8) -> Self {
+        match idx {
+            0 => Self::Lowest,
+            1 => Self::Low,
+            3 => Self::High,
+            4 => Self::Highest,
+            _ => Self::Medium,
+        }
+    }
+
     /// Density multiplier applied to segment counts.
     ///
     /// `Medium == 1.0` is load-bearing: it guarantees [`scale_segments`] is the

--- a/rust/processing/src/lib.rs
+++ b/rust/processing/src/lib.rs
@@ -14,8 +14,12 @@ mod symbolic;
 mod types;
 
 pub use georeferencing::{extract_georeferencing, Georeferencing};
+/// Re-exported so the server can name the quality level without a direct
+/// `ifc-lite-geometry` dependency edge for one enum.
+pub use ifc_lite_geometry::TessellationQuality;
 pub use processor::{
     convert_mesh_to_site_local, process_geometry, process_geometry_filtered,
+    process_geometry_filtered_with_quality,
     process_geometry_streaming, process_geometry_streaming_filtered,
     process_geometry_streaming_filtered_with_options, process_geometry_streaming_with_options,
     process_geometry_streaming_with_options_and_bootstrap,

--- a/rust/processing/src/processor.rs
+++ b/rust/processing/src/processor.rs
@@ -12,9 +12,10 @@ use crate::types::response::{
     QuickMetadataEntitySummary, QuickMetadataSpatialNode,
 };
 use ifc_lite_core::{
-    build_entity_index, scan_placement_bounds, AttributeValue, DecodedEntity, EntityDecoder,
+    build_entity_index, AttributeValue, DecodedEntity, EntityDecoder,
     EntityIndex, EntityScanner, IfcType,
 };
+use ifc_lite_geometry::TessellationQuality;
 use ifc_lite_geometry::{calculate_normals, GeometryRouter};
 use rayon::prelude::*;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -76,6 +77,13 @@ pub struct StreamingOptions {
     pub emit_quick_metadata_bootstrap: bool,
     /// Retain emitted meshes in the returned ProcessingResult.
     pub retain_emitted_meshes: bool,
+    /// Tessellation detail level (#976). `Medium` reproduces the historical
+    /// output byte-for-byte; consumer-selectable on the wasm path via
+    /// `setTessellationQuality`, and on the server via the
+    /// `tessellation_quality` query parameter. 2D symbolic extraction
+    /// (`symbolic.rs`) deliberately ignores the level — symbols are
+    /// resolution-independent line work.
+    pub tessellation_quality: TessellationQuality,
 }
 
 impl Default for StreamingOptions {
@@ -88,6 +96,7 @@ impl Default for StreamingOptions {
             include_presentation_layers: true,
             emit_quick_metadata_bootstrap: false,
             retain_emitted_meshes: true,
+            tessellation_quality: TessellationQuality::default(),
         }
     }
 }
@@ -744,12 +753,24 @@ pub fn process_geometry_streaming_with_options_and_bootstrap(
 
 /// Process IFC content with parallel geometry extraction and a configurable opening filter.
 pub fn process_geometry_filtered(content: &str, opening_filter: OpeningFilterMode) -> ProcessingResult {
+    process_geometry_filtered_with_quality(content, opening_filter, TessellationQuality::default())
+}
+
+/// Like [`process_geometry_filtered`] with a consumer-selected tessellation
+/// detail level (#976) — the server half of the quality knob the wasm path
+/// exposes via `setTessellationQuality`.
+pub fn process_geometry_filtered_with_quality(
+    content: &str,
+    opening_filter: OpeningFilterMode,
+    tessellation_quality: TessellationQuality,
+) -> ProcessingResult {
     process_geometry_streaming_filtered_with_options(
         content,
         opening_filter,
         StreamingOptions {
             initial_batch_size: usize::MAX,
             throughput_batch_size: usize::MAX,
+            tessellation_quality,
             ..StreamingOptions::default()
         },
         |_, _, _| {},
@@ -1278,6 +1299,7 @@ pub fn process_geometry_streaming_filtered_with_options(
     // Preprocess complex geometry
     let preprocess_start = std::time::Instant::now();
     let mut router = GeometryRouter::with_units(content, &mut decoder);
+    router.set_tessellation_quality(options.tessellation_quality);
 
     // Resolve IfcSite and IfcBuilding placement transforms.
     let site_transform: Option<Vec<f64>> = site_entity_pos.and_then(|(start, end)| {
@@ -1486,6 +1508,7 @@ pub fn process_geometry_streaming_filtered_with_options(
                     &entity_index_arc,
                     unit_scale,
                     rtc_offset,
+                    options.tessellation_quality,
                     void_index_arc.as_ref(),
                     skipped_entity_ids.as_ref(),
                     geometry_style_index.as_ref(),
@@ -1622,6 +1645,7 @@ fn process_entity_job(
     entity_index_arc: &Arc<EntityIndex>,
     unit_scale: f64,
     rtc_offset: (f64, f64, f64),
+    tessellation_quality: TessellationQuality,
     void_index: &FxHashMap<u32, Vec<u32>>,
     skipped_entity_ids: &HashSet<u32>,
     geometry_style_index: &FxHashMap<u32, GeometryStyleInfo>,
@@ -1653,7 +1677,9 @@ fn process_entity_job(
         return Vec::new();
     }
 
-    let local_router = GeometryRouter::with_scale_and_rtc(unit_scale, rtc_offset);
+    let mut local_router = GeometryRouter::with_scale_and_quality(unit_scale, tessellation_quality);
+    local_router.set_rtc_offset(rtc_offset);
+    let local_router = local_router;
     let result = (|| -> Vec<MeshData> {
     let global_id = job.global_id.clone();
     let name = job.name.clone();
@@ -1680,69 +1706,105 @@ fn process_entity_job(
         );
     }
 
-    if is_opening_with_subparts(&job.ifc_type) {
-        if let Ok(sub_meshes) = local_router.process_element_with_submeshes(&entity, &mut local_decoder) {
+    let has_openings = void_index.get(&job.id).is_some_and(|v| !v.is_empty());
+
+    // Shared per-sub emission: per-item colour resolution through the
+    // canonical `resolve_submesh_color` precedence (#913 §4.2), identical to
+    // the wasm `processGeometryBatch` path so browser and backend can't
+    // drift on sub-mesh colouring.
+    let mut emit_sub_meshes = |sub_meshes: ifc_lite_geometry::SubMeshCollection,
+                               local_decoder: &mut EntityDecoder|
+     -> Vec<MeshData> {
+        let mut out: Vec<MeshData> = Vec::with_capacity(sub_meshes.len());
+        // Material colours for this element, used when a sub-mesh has no
+        // direct style — alternated so frame (opaque) and glazing
+        // (transparent) split across the window's parts (#913 §2.3).
+        let material_colors = element_material_colors.get(&job.id);
+        let mut mat_color_idx = 0usize;
+
+        for sub in sub_meshes.sub_meshes {
+            let mut sub_mesh = sub.mesh;
+            if sub_mesh.is_empty() {
+                continue;
+            }
+
+            if sub_mesh.normals.is_empty() {
+                calculate_normals(&mut sub_mesh);
+            }
+
+            let style = geometry_style_index.get(&sub.geometry_id);
+            // Direct style wins; else chase IfcMappedItem so mapped
+            // sub-geometry inherits its underlying style (#913 §2.7).
+            let direct_color = style.map(|s| s.color).or_else(|| {
+                find_geometry_item_color(sub.geometry_id, geometry_style_index, local_decoder)
+            });
+            let color = crate::style::resolve_submesh_color(
+                direct_color,
+                material_colors.map(|v| v.as_slice()),
+                &mut mat_color_idx,
+                element_color,
+            );
+            let material_name = style
+                .and_then(|s| s.material_name.as_ref())
+                .map(ToString::to_string);
+            let material_name = material_name.or_else(|| {
+                infer_opening_subpart_material_name(&job.ifc_type, color, sub.geometry_id)
+            });
+
+            let mut mesh_data = MeshData::new(
+                job.id,
+                job.ifc_type.name().to_string(),
+                sub_mesh.positions,
+                sub_mesh.normals,
+                sub_mesh.indices,
+                color,
+            )
+            .with_element_metadata(global_id.clone(), name.clone(), presentation_layer.clone())
+            .with_properties(space_zone_properties.clone())
+            .with_style_metadata(material_name, Some(sub.geometry_id));
+            convert_mesh_to_site_local(&mut mesh_data, site_local_rotation);
+            out.push(mesh_data);
+        }
+        out
+    };
+
+    if has_openings {
+        // Voided elements FIRST — branch order matches the wasm path, so a
+        // voided window is CUT rather than rendered uncut-as-subparts.
+        // Prefer the submesh-aware cut (per-part colours survive the void
+        // subtraction); the single-mesh cut below stays as the fallback.
+        if let Ok(sub_meshes) = local_router.process_element_with_submeshes_and_voids(
+            &entity,
+            &mut local_decoder,
+            void_index,
+        ) {
             if !sub_meshes.is_empty() {
-                let mut out: Vec<MeshData> = Vec::with_capacity(sub_meshes.len());
-                // Material colours for this element, used when a sub-mesh has no
-                // direct style — alternated so frame (opaque) and glazing
-                // (transparent) split across the window's parts (#913 §2.3).
-                let material_colors = element_material_colors.get(&job.id);
-                let mut mat_color_idx = 0usize;
-
-                for sub in sub_meshes.sub_meshes {
-                    let mut sub_mesh = sub.mesh;
-                    if sub_mesh.is_empty() {
-                        continue;
-                    }
-
-                    if sub_mesh.normals.is_empty() {
-                        calculate_normals(&mut sub_mesh);
-                    }
-
-                    let style = geometry_style_index.get(&sub.geometry_id);
-                    // Direct style wins; else chase IfcMappedItem so mapped
-                    // sub-geometry inherits its underlying style (#913 §2.7).
-                    let direct_color = style.map(|s| s.color).or_else(|| {
-                        find_geometry_item_color(
-                            sub.geometry_id,
-                            geometry_style_index,
-                            &mut local_decoder,
-                        )
-                    });
-                    // The shared resolver owns the precedence below the direct
-                    // style + the transparent/opaque alternation (#913 §4.2), so
-                    // the browser and the backend can't drift on it.
-                    let color = crate::style::resolve_submesh_color(
-                        direct_color,
-                        material_colors.map(|v| v.as_slice()),
-                        &mut mat_color_idx,
-                        element_color,
-                    );
-                    let material_name = style
-                        .and_then(|s| s.material_name.as_ref())
-                        .map(ToString::to_string);
-                    let material_name = material_name.or_else(|| {
-                        infer_opening_subpart_material_name(&job.ifc_type, color, sub.geometry_id)
-                    });
-
-                    let mut mesh_data = MeshData::new(
-                        job.id,
-                        job.ifc_type.name().to_string(),
-                        sub_mesh.positions,
-                        sub_mesh.normals,
-                        sub_mesh.indices,
-                        color,
-                    )
-                    .with_element_metadata(global_id.clone(), name.clone(), presentation_layer.clone())
-                    .with_properties(space_zone_properties.clone())
-                    .with_style_metadata(material_name, Some(sub.geometry_id));
-                    convert_mesh_to_site_local(&mut mesh_data, site_local_rotation);
-                    out.push(mesh_data);
-                }
-
+                let out = emit_sub_meshes(sub_meshes, &mut local_decoder);
                 if !out.is_empty() {
                     return out;
+                }
+            }
+        }
+    } else {
+        // #858: an IfcIndexedColourMap colours faces of a single face set —
+        // those elements keep the single-mesh + palette-split path below.
+        let has_indexed_colour = !indexed_colour_full.is_empty()
+            && find_indexed_colour_for_element(&entity, indexed_colour_full, &mut local_decoder)
+                .is_some();
+        if !has_indexed_colour {
+            // Submesh path for ALL types (parity with `processGeometryBatch`):
+            // per-item colours AND per-item error skipping — one unsupported
+            // representation item no longer makes the whole element invisible
+            // in server/parquet output while it renders partially in the
+            // browser.
+            if let Ok(sub_meshes) =
+                local_router.process_element_with_submeshes(&entity, &mut local_decoder)
+            {
+                if !sub_meshes.is_empty() {
+                    let out = emit_sub_meshes(sub_meshes, &mut local_decoder);
+                    if !out.is_empty() {
+                        return out;
+                    }
                 }
             }
         }

--- a/rust/processing/tests/element_failure_parity.rs
+++ b/rust/processing/tests/element_failure_parity.rs
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Per-item failure parity with the wasm path (alignment audit).
+//!
+//! `processGeometryBatch` always used the submesh path, where an unsupported
+//! representation item is skipped and the rest of the element still renders.
+//! The server's default path used single-mesh `process_element`, whose item
+//! loop bails with `?` — one exotic item made the WHOLE element invisible in
+//! server/parquet output while the browser showed it partially. This pins the
+//! server-side skip behaviour.
+
+use ifc_lite_processing::{process_geometry, process_geometry_filtered, OpeningFilterMode};
+
+/// A wall whose Body carries one supported extruded solid AND one
+/// unsupported representation item (`IFCSECTIONEDSPINE` — no processor).
+const MIXED_ITEMS_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('alignment-audit mixed-items fixture'),'2;1');
+FILE_NAME('mixed.ifc','2026-06-12T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6e',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+
+#10=IFCWALL('1MixedItemsWall000001',$,'Wall',$,$,#11,#12,$,$);
+#11=IFCLOCALPLACEMENT($,#5);
+#12=IFCPRODUCTDEFINITIONSHAPE($,$,(#13));
+#13=IFCSHAPEREPRESENTATION(#2,'Body','SweptSolid',(#14,#20));
+#14=IFCEXTRUDEDAREASOLID(#15,#5,#16,3.0);
+#15=IFCRECTANGLEPROFILEDEF(.AREA.,$,$,4.0,0.3);
+#16=IFCDIRECTION((0.,0.,1.));
+#20=IFCSECTIONEDSPINE(#21,(#15),(#5));
+#21=IFCCOMPOSITECURVE((),$);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+#[test]
+fn unsupported_item_no_longer_kills_the_element() {
+    let result = process_geometry(MIXED_ITEMS_IFC);
+    assert!(
+        !result.meshes.is_empty(),
+        "wall with one supported solid + one unsupported item must still \
+         produce geometry on the server path (wasm parity)"
+    );
+    assert!(result.stats.total_triangles > 0);
+}
+
+#[test]
+fn opening_filters_unaffected_by_submesh_default() {
+    // The submesh default must not regress the opening-filter modes.
+    for mode in [
+        OpeningFilterMode::Default,
+        OpeningFilterMode::IgnoreAll,
+        OpeningFilterMode::IgnoreOpaque,
+    ] {
+        let result = process_geometry_filtered(MIXED_ITEMS_IFC, mode);
+        assert!(!result.meshes.is_empty(), "no meshes under {mode:?}");
+    }
+}

--- a/rust/processing/tests/tessellation_quality_server.rs
+++ b/rust/processing/tests/tessellation_quality_server.rs
@@ -1,0 +1,95 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Server half of the tessellation-quality knob (issue #976).
+//!
+//! The wasm path has honoured `setTessellationQuality` since #1025; the
+//! server pipeline silently pinned `Medium`. These tests pin that
+//! `process_geometry_filtered_with_quality` actually threads the level into
+//! the per-job routers — so a server consumer requesting `highest` gets the
+//! same densification a browser consumer gets, and the default stays
+//! byte-identical to the historical output (cache keys for `medium` map to
+//! the legacy shape, see `apps/server/src/routes/parse.rs`).
+
+use ifc_lite_processing::{
+    process_geometry_filtered, process_geometry_filtered_with_quality, OpeningFilterMode,
+    TessellationQuality,
+};
+
+/// One pipe (`IfcFlowSegment` with a swept-disk body) — the tube ring count
+/// scales with quality, so vertex counts must rise monotonically.
+const PIPE_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('issue-976 server tessellation fixture'),'2;1');
+FILE_NAME('pipe.ifc','2026-06-12T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+
+#10=IFCFLOWSEGMENT('1PipeQualityFixture01',$,'Pipe',$,$,#11,#12,$);
+#11=IFCLOCALPLACEMENT($,#5);
+#12=IFCPRODUCTDEFINITIONSHAPE($,$,(#13));
+#13=IFCSHAPEREPRESENTATION(#2,'Body','AdvancedSweptSolid',(#14));
+#14=IFCSWEPTDISKSOLID(#17,0.05,$,$,$);
+#15=IFCCARTESIANPOINT((0.,0.,0.));
+#16=IFCCARTESIANPOINT((0.,0.,2.));
+#17=IFCPOLYLINE((#15,#16));
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+fn vertex_count(quality: TessellationQuality) -> usize {
+    let result =
+        process_geometry_filtered_with_quality(PIPE_IFC, OpeningFilterMode::Default, quality);
+    assert!(
+        !result.meshes.is_empty(),
+        "pipe fixture produced no meshes at {quality:?}"
+    );
+    result.stats.total_vertices
+}
+
+#[test]
+fn quality_threads_into_server_geometry() {
+    let low = vertex_count(TessellationQuality::Lowest);
+    let medium = vertex_count(TessellationQuality::Medium);
+    let highest = vertex_count(TessellationQuality::Highest);
+
+    assert!(
+        low < medium && medium < highest,
+        "swept-disk vertex counts must rise monotonically with quality \
+         (lowest={low}, medium={medium}, highest={highest})"
+    );
+}
+
+#[test]
+fn default_quality_is_byte_identical_to_legacy_entrypoint() {
+    let legacy = process_geometry_filtered(PIPE_IFC, OpeningFilterMode::Default);
+    let medium = process_geometry_filtered_with_quality(
+        PIPE_IFC,
+        OpeningFilterMode::Default,
+        TessellationQuality::Medium,
+    );
+    assert_eq!(legacy.stats.total_vertices, medium.stats.total_vertices);
+    assert_eq!(legacy.stats.total_triangles, medium.stats.total_triangles);
+}
+
+#[test]
+fn quality_labels_round_trip() {
+    for q in [
+        TessellationQuality::Lowest,
+        TessellationQuality::Low,
+        TessellationQuality::Medium,
+        TessellationQuality::High,
+        TessellationQuality::Highest,
+    ] {
+        assert_eq!(TessellationQuality::parse_label(q.label()), Some(q));
+        assert_eq!(TessellationQuality::from_index(q.to_index()), q);
+    }
+}

--- a/rust/wasm-bindings/src/api/gpu_meshes.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes.rs
@@ -1046,25 +1046,78 @@ impl IfcAPI {
                     hash_tolerance.map(|tol| GeometryHasher::new(tol, hash_world_rtc));
 
                 if has_openings {
-                    if let Ok(mut mesh) =
-                        router.process_element_with_voids(&entity, &mut decoder, &void_index)
-                    {
-                        if !mesh.is_empty() {
-                            if mesh.normals.len() != mesh.positions.len() {
-                                calculate_normals(&mut mesh);
+                    // Submesh-aware cut first (server parity): per-part
+                    // colours survive the void subtraction, so a voided
+                    // multi-layer wall or window keeps frame/glass split.
+                    let mut used_voided_submesh = false;
+                    if let Ok(sub_meshes) = router.process_element_with_submeshes_and_voids(
+                        &entity,
+                        &mut decoder,
+                        &void_index,
+                    ) {
+                        if !sub_meshes.is_empty() {
+                            let default_color = default_color_for_type(ifc_type).to_array();
+                            let element_color = element_styles.get(&id).copied();
+                            let mut mat_color_idx = 0usize;
+                            for sub in sub_meshes.sub_meshes {
+                                let geometry_id = sub.geometry_id;
+                                let mut mesh = sub.mesh;
+                                if mesh.is_empty() {
+                                    continue;
+                                }
+                                if mesh.normals.len() != mesh.positions.len() {
+                                    calculate_normals(&mut mesh);
+                                }
+                                let color = resolve_submesh_color(
+                                    geometry_id,
+                                    &geometry_styles,
+                                    &mut decoder,
+                                    None,
+                                    &mut mat_color_idx,
+                                    element_color,
+                                    default_color,
+                                );
+                                let ifc_type_name = type_name_cache
+                                    .entry(ifc_type)
+                                    .or_insert_with(|| ifc_type.name().to_string())
+                                    .clone();
+                                if let Some(h) = entity_hasher.as_mut() {
+                                    h.add_mesh(&mesh.positions, &mesh.indices);
+                                }
+                                emit_submesh_with_palette_split(
+                                    &mut mesh_collection,
+                                    id,
+                                    &ifc_type_name,
+                                    geometry_id,
+                                    mesh,
+                                    color,
+                                    &indexed_colour_full,
+                                );
+                                used_voided_submesh = true;
                             }
-                            let color = element_styles
-                                .get(&id)
-                                .copied()
-                                .unwrap_or_else(|| default_color_for_type(ifc_type).to_array());
-                            let ifc_type_name = type_name_cache
-                                .entry(ifc_type)
-                                .or_insert_with(|| ifc_type.name().to_string())
-                                .clone();
-                            if let Some(h) = entity_hasher.as_mut() {
-                                h.add_mesh(&mesh.positions, &mesh.indices);
+                        }
+                    }
+                    if !used_voided_submesh {
+                        if let Ok(mut mesh) =
+                            router.process_element_with_voids(&entity, &mut decoder, &void_index)
+                        {
+                            if !mesh.is_empty() {
+                                if mesh.normals.len() != mesh.positions.len() {
+                                    calculate_normals(&mut mesh);
+                                }
+                                let color = element_styles
+                                    .get(&id)
+                                    .copied()
+                                    .unwrap_or_else(|| default_color_for_type(ifc_type).to_array());
+                                let ifc_type_name = type_name_cache
+                                    .entry(ifc_type)
+                                    .or_insert_with(|| ifc_type.name().to_string())
+                                    .clone();
+                                if let Some(h) = entity_hasher.as_mut() {
+                                    h.add_mesh(&mesh.positions, &mesh.indices);
+                                }
+                                mesh_collection.add(MeshDataJs::new(id, ifc_type_name, mesh, color));
                             }
-                            mesh_collection.add(MeshDataJs::new(id, ifc_type_name, mesh, color));
                         }
                     }
                 } else {

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -355,15 +355,11 @@ impl IfcAPI {
     pub fn set_tessellation_quality(&self, level: Option<String>) -> Result<(), JsValue> {
         let discriminant = match level.as_deref() {
             None => TESSELLATION_QUALITY_MEDIUM,
-            Some(s) => match s.to_ascii_lowercase().as_str() {
-                "lowest" => 0,
-                "low" => 1,
-                "medium" => TESSELLATION_QUALITY_MEDIUM,
-                "high" => 3,
-                "highest" => 4,
-                other => {
+            Some(s) => match ifc_lite_geometry::TessellationQuality::parse_label(s) {
+                Some(q) => q.to_index(),
+                None => {
                     return Err(JsValue::from_str(&format!(
-                        "Unknown tessellation quality '{other}' — expected \
+                        "Unknown tessellation quality '{s}' — expected \
                          lowest | low | medium | high | highest"
                     )))
                 }
@@ -393,11 +389,7 @@ impl IfcAPI {
             .tessellation_quality
             .load(std::sync::atomic::Ordering::Relaxed)
         {
-            0 => TessellationQuality::Lowest,
-            1 => TessellationQuality::Low,
-            3 => TessellationQuality::High,
-            4 => TessellationQuality::Highest,
-            _ => TessellationQuality::Medium,
+            idx => TessellationQuality::from_index(idx),
         }
     }
 

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -3574,6 +3574,7 @@
     "ParquetStreamProgressEvent: interface",
     "ParquetStreamResult: interface",
     "ParquetStreamStartEvent: interface",
+    "ParseRequestOptions: interface",
     "ParseResponse: interface",
     "ProcessingStats: interface",
     "Quantity: interface",


### PR DESCRIPTION
Stacked on #1071. Lands the four confirmed server-side drift findings from the alignment audit that were too large for the first PR — full recipes were documented there.

## What changed

1. **Tessellation quality server knob** (#976's server half, silently dropped at epic close): `?tessellation_quality=lowest|low|medium|high|highest` on every parse endpoint, threaded through `StreamingOptions` into the per-job routers. `medium` (and omission) maps to the **legacy cache keys**, so existing caches stay valid; other levels get distinct entries. The label↔enum mapping lives once on `TessellationQuality`, shared with the wasm `setTessellationQuality` setter. `@ifc-lite/server-client` gains `ParseRequestOptions.tessellationQuality` on all five parse methods, forwarded on the cached fast path too (a `high` request can't be served a `medium` cache entry).

2. **Element-failure + colour granularity parity**: the server default path now uses `process_element_with_submeshes` — per-item colours through the shared `resolve_submesh_color` precedence and per-item error skipping, so one unsupported representation item no longer makes the whole element invisible in server/parquet output while the browser renders it partially. Voided elements take the submesh-aware cut first and the voids-vs-subparts branch order now matches the wasm path (a voided window is CUT, not rendered uncut-as-subparts). The wasm voided branch gained the same submesh-aware cut. #858 indexed-colour elements keep the palette-split path.

3. **SSE `/parse/stream` bespoke pipeline deleted** (~560 lines): `streaming.rs` is now a thin bridge over `process_geometry_streaming_filtered_with_options` — batches forward through a channel as `StreamEvent`s with an unchanged wire shape. Streamed meshes now get the material chain, indexed colour maps, aggregate void propagation, submeshes, type geometry, and the CSG diagnostics stats. This also **restores `opening_filter` on the streaming endpoints** (the old pipeline rejected it).

4. **`calculate_normals` is real on every target**: the native no-op (decommissioned desktop-IPC leftover) made the server ship empty normal buffers for brep/surface/swept meshes — zero-padded by the parquet writer, dropped by glTF export — while wasm loads of the same model had real normals.

**Parquet cache `v3` → `v4`**: entries written by the old pipelines would serve visibly different meshes.

Also: the client `Cache key mismatch` console warning fired on **every** fresh upload (server keys are `{hash}-{filter}[-q{level}]`; the check compared equality with the bare hash) — now verifies derivation.

## Verification

- `cargo test --workspace` — 78 binaries green, including new `tessellation_quality_server` (threading + default byte-identity + label round-trip) and `element_failure_parity` (mixed supported/unsupported items), updated cache-key matrix tests, and the #900 parity tests now running through the bridge
- `pnpm typecheck` 31/31, `pnpm build` 37/37, `pnpm test:wasm-contract` 16/16 on the rebuilt runtime
- `api-surface.json` updated for the new `ParseRequestOptions` export (changeset: server-client minor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)