### PR TITLE
feat(georef): TS↔Rust extraction parity (phase 1)

### DIFF
--- a/.changeset/georef-parity.md
+++ b/.changeset/georef-parity.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/parser': minor
+'@ifc-lite/server-client': minor
+---
+
+Georeferencing TS↔Rust parity (alignment audit phase 1):
+
+- `@ifc-lite/parser`: `extractGeoreferencing` gains the IFC2x3 `ePSet_MapConversion` fallback with the same precedence as the Rust extractor (`IfcMapConversion` → ePSet → legacy `IfcSite` lat/long); `GeoreferenceInfo.source` union widens to include `'ePSetMapConversion'`.
+- `@ifc-lite/server-client`: `Georeferencing` gains optional `crs_description`, `map_zone`, `map_unit`, `map_unit_scale`, and `source` fields — the server now reports MapUnit-scaled conversions (e.g. 0.001 for millimetre-based files), picks the FIRST authored `IfcMapConversion` like the browser parser, normalises non-unit X-axis directions so `transform_matrix` agrees with `rotation_degrees`, and recognises site-only models via the `IfcSite.RefLatitude/RefLongitude` fallback.

--- a/packages/parser/src/georef-extractor.ts
+++ b/packages/parser/src/georef-extractor.ts
@@ -71,7 +71,7 @@ export interface GeoreferenceInfo {
   hasGeoreference: boolean;
   mapConversion?: MapConversion;
   projectedCRS?: ProjectedCRS;
-  source?: 'mapConversion' | 'siteLocation';
+  source?: 'mapConversion' | 'ePSetMapConversion' | 'siteLocation';
   // Computed transformation matrix (4x4) from local to world coordinates
   transformMatrix?: number[];
 }
@@ -114,6 +114,14 @@ export function extractGeoreferencing(
   }
 
   if (!info.hasGeoreference) {
+    // IFC2x3 ePSet_MapConversion fallback BEFORE the legacy site fallback —
+    // same precedence as the Rust extractor (ifc_lite_core::GeoRefExtractor),
+    // which previously found these models georeferenced while the browser
+    // reported none (alignment audit).
+    const epset = extractEPSetMapConversion(entities, entitiesByType);
+    if (epset) {
+      return epset;
+    }
     const legacySite = extractLegacySiteGeoreference(entities, entitiesByType);
     if (legacySite) {
       return legacySite;
@@ -121,6 +129,68 @@ export function extractGeoreferencing(
   }
 
   return info;
+}
+
+/**
+ * IFC2x3 fallback: a property set named `ePSet_MapConversion` /
+ * `EPset_MapConversion` carrying Eastings/Northings/OrthogonalHeight (+
+ * optional XAxisAbscissa/XAxisOrdinate/Scale) as IfcPropertySingleValue
+ * entries. Mirrors `GeoRefExtractor::parse_pset_map_conversion` in
+ * rust/core/src/georef.rs.
+ */
+function extractEPSetMapConversion(
+  entities: Map<number, IfcEntity>,
+  entitiesByType: Map<string, number[]>,
+): GeoreferenceInfo | null {
+  const psetIds = entitiesByType.get('IfcPropertySet') || [];
+  for (const psetId of psetIds) {
+    const pset = entities.get(psetId);
+    if (!pset) continue;
+    // IfcPropertySet: GlobalId (0), OwnerHistory (1), Name (2), Description (3), HasProperties (4)
+    const name = getString(pset.attributes[2]);
+    if (name !== 'ePSet_MapConversion' && name !== 'EPset_MapConversion') continue;
+
+    const values: Record<string, number> = {};
+    const props = pset.attributes[4];
+    if (Array.isArray(props)) {
+      for (const propRef of props) {
+        const propId = getReference(propRef);
+        if (!propId) continue;
+        const prop = entities.get(propId);
+        if (!prop) continue;
+        // IfcPropertySingleValue: Name (0), Description (1), NominalValue (2)
+        const propName = getString(prop.attributes[0]);
+        const value = getNumber(prop.attributes[2]);
+        if (propName && value !== undefined) {
+          values[propName] = value;
+        }
+      }
+    }
+
+    const eastings = values['Eastings'] ?? 0;
+    const northings = values['Northings'] ?? 0;
+    const orthogonalHeight = values['OrthogonalHeight'] ?? 0;
+    if (eastings === 0 && northings === 0 && orthogonalHeight === 0) continue;
+
+    const mapConversion: MapConversion = {
+      id: pset.expressId,
+      sourceCRS: 0,
+      targetCRS: 0,
+      eastings,
+      northings,
+      orthogonalHeight,
+      xAxisAbscissa: values['XAxisAbscissa'],
+      xAxisOrdinate: values['XAxisOrdinate'],
+      scale: values['Scale'],
+    };
+    return {
+      hasGeoreference: true,
+      source: 'ePSetMapConversion',
+      mapConversion,
+      transformMatrix: computeTransformMatrix(mapConversion),
+    };
+  }
+  return null;
 }
 
 function getAttributeValueByName(entity: IfcEntity, attributeName: string): unknown {

--- a/packages/parser/test/georef-extractor.test.ts
+++ b/packages/parser/test/georef-extractor.test.ts
@@ -282,4 +282,71 @@ describe('Georeferencing Extractor', () => {
     expect(georef.transformMatrix).toBeUndefined();
     expect(getCoordinateSystemDescription(georef)).toContain('Site:');
   });
+
+  // Helper for the IFC2x3 ePSet_MapConversion fixtures. Values mirror the
+  // Rust parity fixtures in rust/processing/src/georeferencing.rs so the
+  // two extractors are pinned to identical outputs.
+  function epsetEntities(name: string) {
+    const entities = new Map<number, IfcEntity>();
+    entities.set(1, {
+      expressId: 1,
+      type: 'IfcPropertySingleValue',
+      attributes: ['Eastings', null, 1000.5, null],
+    });
+    entities.set(2, {
+      expressId: 2,
+      type: 'IfcPropertySingleValue',
+      attributes: ['Northings', null, 2000.25, null],
+    });
+    entities.set(3, {
+      expressId: 3,
+      type: 'IfcPropertySingleValue',
+      attributes: ['OrthogonalHeight', null, 42, null],
+    });
+    entities.set(4, {
+      expressId: 4,
+      type: 'IfcPropertySet',
+      attributes: ['0PSet00000000000000001', null, name, null, ['#1', '#2', '#3']],
+    });
+    const entitiesByType = new Map<string, number[]>();
+    entitiesByType.set('IfcPropertySingleValue', [1, 2, 3]);
+    entitiesByType.set('IfcPropertySet', [4]);
+    return { entities, entitiesByType };
+  }
+
+  it('extracts IFC2X3 ePSet_MapConversion fallback (Rust parity)', () => {
+    for (const name of ['ePSet_MapConversion', 'EPset_MapConversion']) {
+      const { entities, entitiesByType } = epsetEntities(name);
+      const georef = extractGeoreferencing(entities, entitiesByType);
+
+      expect(georef.hasGeoreference).toBe(true);
+      expect(georef.source).toBe('ePSetMapConversion');
+      expect(georef.mapConversion?.eastings).toBeCloseTo(1000.5, 9);
+      expect(georef.mapConversion?.northings).toBeCloseTo(2000.25, 9);
+      expect(georef.mapConversion?.orthogonalHeight).toBeCloseTo(42, 9);
+      expect(georef.transformMatrix?.[12]).toBeCloseTo(1000.5, 9);
+    }
+  });
+
+  it('prefers ePSet_MapConversion over the legacy site fallback (Rust precedence)', () => {
+    const { entities, entitiesByType } = epsetEntities('ePSet_MapConversion');
+
+    const siteAttrNames = getAttributeNames('IfcSite');
+    const attributes = new Array(siteAttrNames.length).fill(null);
+    attributes[siteAttrNames.indexOf('RefLatitude')] = [50, 2, 20];
+    attributes[siteAttrNames.indexOf('RefLongitude')] = [14, 28, 0];
+    entities.set(300, { expressId: 300, type: 'IfcSite', attributes });
+    entitiesByType.set('IfcSite', [300]);
+
+    const georef = extractGeoreferencing(entities, entitiesByType);
+    expect(georef.source).toBe('ePSetMapConversion');
+    expect(georef.mapConversion?.eastings).toBeCloseTo(1000.5, 9);
+  });
+
+  it('ignores property sets that are not the map-conversion ePSet', () => {
+    const { entities, entitiesByType } = epsetEntities('Pset_SomethingElse');
+    const georef = extractGeoreferencing(entities, entitiesByType);
+    expect(georef.hasGeoreference).toBe(false);
+    expect(georef.source).toBeUndefined();
+  });
 });

--- a/packages/server-client/src/types.ts
+++ b/packages/server-client/src/types.ts
@@ -85,6 +85,16 @@ export interface Georeferencing {
   rotation_degrees: number;
   /** Local→map transform as a column-major 4×4 matrix (16 values). */
   transform_matrix: number[];
+  /** CRS description from `IfcProjectedCRS.Description`. */
+  crs_description?: string;
+  /** Map zone (e.g. "32N") from `IfcProjectedCRS.MapZone`. */
+  map_zone?: string;
+  /** Map unit name from `IfcProjectedCRS.MapUnit` (e.g. "MILLIMETRE"). */
+  map_unit?: string;
+  /** Scale converting MapConversion values to metres (0.001 for mm). */
+  map_unit_scale?: number;
+  /** Provenance: "mapConversion" | "ePSetMapConversion" | "siteLocation". */
+  source?: string;
 }
 
 /**

--- a/rust/core/src/georef.rs
+++ b/rust/core/src/georef.rs
@@ -12,17 +12,57 @@ use crate::error::Result;
 use crate::generated::IfcType;
 use crate::schema_gen::DecodedEntity;
 
+/// Where the georeferencing data was authored in the file.
+///
+/// Single discriminator shared (string-for-string) with the TS parser's
+/// `GeoreferenceInfo.source`, so server consumers and browser consumers see
+/// the same provenance for the same model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GeoRefSource {
+    /// IFC4 `IfcMapConversion` (+ optional `IfcProjectedCRS`).
+    MapConversion,
+    /// IFC2x3 `ePSet_MapConversion` property-set fallback.
+    EPSetMapConversion,
+    /// Legacy `IfcSite.RefLatitude`/`RefLongitude` (WGS84 degrees).
+    SiteLocation,
+}
+
+impl GeoRefSource {
+    /// Stable wire label (matches the TS parser's `source` union).
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::MapConversion => "mapConversion",
+            Self::EPSetMapConversion => "ePSetMapConversion",
+            Self::SiteLocation => "siteLocation",
+        }
+    }
+}
+
 /// Georeferencing information extracted from IFC model
 #[derive(Debug, Clone)]
 pub struct GeoReference {
     /// CRS name (e.g., "EPSG:32632")
     pub crs_name: Option<String>,
+    /// CRS description from `IfcProjectedCRS.Description`.
+    pub crs_description: Option<String>,
     /// Geodetic datum (e.g., "WGS84")
     pub geodetic_datum: Option<String>,
     /// Vertical datum (e.g., "NAVD88")
     pub vertical_datum: Option<String>,
     /// Map projection (e.g., "UTM Zone 32N")
     pub map_projection: Option<String>,
+    /// Map zone (e.g., "32N") from `IfcProjectedCRS.MapZone`.
+    pub map_zone: Option<String>,
+    /// Map unit name resolved from `IfcProjectedCRS.MapUnit`
+    /// (e.g. "METRE", "MILLIMETRE"). `None` when no MapUnit is authored —
+    /// per spec the project length unit then applies.
+    pub map_unit: Option<String>,
+    /// Scale factor converting MapConversion values to metres, derived from
+    /// `MapUnit` (0.001 for millimetres). `None` when no MapUnit is authored.
+    pub map_unit_scale: Option<f64>,
+    /// Where the data was authored (`IfcMapConversion`, ePSet fallback, or
+    /// legacy `IfcSite` lat/long).
+    pub source: GeoRefSource,
     /// False easting (X offset to map CRS)
     pub eastings: f64,
     /// False northing (Y offset to map CRS)
@@ -41,9 +81,14 @@ impl Default for GeoReference {
     fn default() -> Self {
         Self {
             crs_name: None,
+            crs_description: None,
             geodetic_datum: None,
             vertical_datum: None,
             map_projection: None,
+            map_zone: None,
+            map_unit: None,
+            map_unit_scale: None,
+            source: GeoRefSource::MapConversion,
             eastings: 0.0,
             northings: 0.0,
             orthogonal_height: 0.0,
@@ -73,6 +118,22 @@ impl GeoReference {
     #[inline]
     pub fn rotation(&self) -> f64 {
         self.x_axis_ordinate.atan2(self.x_axis_abscissa)
+    }
+
+    /// Normalize the X-axis direction to a unit vector.
+    ///
+    /// `IfcMapConversion.XAxisAbscissa/Ordinate` form a DIRECTION — files may
+    /// author non-unit components. `local_to_map`/`to_matrix` use them
+    /// directly as cos/sin, so without normalization those disagreed with
+    /// [`rotation`](Self::rotation) (which `atan2`-normalizes) within one
+    /// payload, and with the TS parser's matrix (alignment audit). Called at
+    /// parse time by every extraction path.
+    fn normalize_axis(&mut self) {
+        let len = self.x_axis_abscissa.hypot(self.x_axis_ordinate);
+        if len > f64::EPSILON && (len - 1.0).abs() > f64::EPSILON {
+            self.x_axis_abscissa /= len;
+            self.x_axis_ordinate /= len;
+        }
     }
 
     /// Transform local coordinates to map coordinates
@@ -153,32 +214,47 @@ pub struct GeoRefExtractor;
 
 impl GeoRefExtractor {
     /// Extract georeferencing from decoder
+    ///
+    /// Precedence (identical to the TS parser): `IfcMapConversion` →
+    /// `ePSet_MapConversion` (IFC2x3) → legacy `IfcSite` lat/long.
     pub fn extract(
         decoder: &mut EntityDecoder,
         entity_types: &[(u32, IfcType)],
     ) -> Result<Option<GeoReference>> {
-        // Find IfcMapConversion and IfcProjectedCRS entities
+        // Find IfcMapConversion and IfcProjectedCRS entities. FIRST one wins
+        // (same pick as the TS parser, which reads `mapConversionIds[0]`) —
+        // last-wins silently flipped the served conversion on files with
+        // several authored conversions (alignment audit).
         let mut map_conversion_id: Option<u32> = None;
         let mut projected_crs_id: Option<u32> = None;
 
         for (id, ifc_type) in entity_types {
             match ifc_type {
                 IfcType::IfcMapConversion => {
-                    map_conversion_id = Some(*id);
+                    if map_conversion_id.is_none() {
+                        map_conversion_id = Some(*id);
+                    }
                 }
                 IfcType::IfcProjectedCRS => {
-                    projected_crs_id = Some(*id);
+                    if projected_crs_id.is_none() {
+                        projected_crs_id = Some(*id);
+                    }
                 }
                 _ => {}
             }
         }
 
-        // If no map conversion, try IFC2X3 property set fallback
+        // If no map conversion, try IFC2X3 property set fallback, then the
+        // legacy IfcSite lat/long fallback (TS parity).
         if map_conversion_id.is_none() {
-            return Self::extract_from_pset(decoder, entity_types);
+            if let Some(georef) = Self::extract_from_pset(decoder, entity_types)? {
+                return Ok(Some(georef));
+            }
+            return Self::extract_from_site(decoder, entity_types);
         }
 
         let mut georef = GeoReference::new();
+        georef.source = GeoRefSource::MapConversion;
 
         // Parse IfcMapConversion
         // Attributes: SourceCRS, TargetCRS, Eastings, Northings, OrthogonalHeight,
@@ -193,8 +269,10 @@ impl GeoRefExtractor {
         //             MapProjection, MapZone, MapUnit
         if let Some(id) = projected_crs_id {
             let entity = decoder.decode_by_id(id)?;
-            Self::parse_projected_crs(&entity, &mut georef);
+            Self::parse_projected_crs(&entity, decoder, &mut georef);
         }
+
+        georef.normalize_axis();
 
         if georef.has_georef() {
             Ok(Some(georef))
@@ -232,10 +310,18 @@ impl GeoRefExtractor {
     }
 
     /// Parse IfcProjectedCRS entity
-    fn parse_projected_crs(entity: &DecodedEntity, georef: &mut GeoReference) {
+    fn parse_projected_crs(
+        entity: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+        georef: &mut GeoReference,
+    ) {
         // Index 0: Name (e.g., "EPSG:32632")
         if let Some(name) = entity.get_string(0) {
             georef.crs_name = Some(name.to_string());
+        }
+        // Index 1: Description
+        if let Some(desc) = entity.get_string(1) {
+            georef.crs_description = Some(desc.to_string());
         }
         // Index 2: GeodeticDatum
         if let Some(datum) = entity.get_string(2) {
@@ -248,6 +334,42 @@ impl GeoRefExtractor {
         // Index 4: MapProjection
         if let Some(proj) = entity.get_string(4) {
             georef.map_projection = Some(proj.to_string());
+        }
+        // Index 5: MapZone
+        if let Some(zone) = entity.get_string(5) {
+            georef.map_zone = Some(zone.to_string());
+        }
+        // Index 6: MapUnit (IfcNamedUnit ref). Mirrors the TS parser: when a
+        // MapUnit IS authored, default to METRE/1.0 and refine from the
+        // IFCSIUNIT prefix — a millimetre-based conversion must scale by
+        // 0.001 on the server exactly like in the browser. When absent, the
+        // project length unit applies (spec default) and both stay `None`.
+        if let Some(unit_ref) = entity.get_ref(6) {
+            let mut unit_name = "METRE".to_string();
+            let mut unit_scale = 1.0_f64;
+            if let Ok(unit_entity) = decoder.decode_by_id(unit_ref) {
+                if unit_entity.ifc_type == IfcType::IfcSIUnit {
+                    // IFCSIUNIT: [0] Dimensions, [1] UnitType, [2] Prefix, [3] Name
+                    if let Some(prefix_attr) = unit_entity.get(2) {
+                        if !prefix_attr.is_null() {
+                            if let Some(prefix) = prefix_attr.as_enum() {
+                                let multiplier = crate::units::get_si_prefix_multiplier(prefix);
+                                if (multiplier - 1.0).abs() > f64::EPSILON {
+                                    unit_scale = multiplier;
+                                    let prefix_upper = prefix.to_ascii_uppercase();
+                                    unit_name = if prefix_upper == "MILLI" {
+                                        "MILLIMETRE".to_string()
+                                    } else {
+                                        format!("{prefix_upper}METRE")
+                                    };
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            georef.map_unit = Some(unit_name);
+            georef.map_unit_scale = Some(unit_scale);
         }
     }
 
@@ -279,6 +401,7 @@ impl GeoRefExtractor {
         pset: &DecodedEntity,
     ) -> Result<Option<GeoReference>> {
         let mut georef = GeoReference::new();
+        georef.source = GeoRefSource::EPSetMapConversion;
 
         // HasProperties is typically at index 4
         if let Some(props_list) = pset.get_list(4) {
@@ -326,11 +449,81 @@ impl GeoRefExtractor {
             }
         }
 
+        georef.normalize_axis();
+
         if georef.has_georef() {
             Ok(Some(georef))
         } else {
             Ok(None)
         }
+    }
+
+    /// Legacy `IfcSite.RefLatitude`/`RefLongitude` fallback (TS parity).
+    ///
+    /// Mirrors the TS parser's `extractLegacySiteGeoreference`: WGS84
+    /// degrees land in eastings (longitude) / northings (latitude) with the
+    /// site `RefElevation` as orthogonal height, under an `EPSG:4326`
+    /// pseudo-CRS — so `hasGeoreference`/`has_georef` agree between the
+    /// browser and the server for site-only models.
+    fn extract_from_site(
+        decoder: &mut EntityDecoder,
+        entity_types: &[(u32, IfcType)],
+    ) -> Result<Option<GeoReference>> {
+        for (id, ifc_type) in entity_types {
+            if *ifc_type != IfcType::IfcSite {
+                continue;
+            }
+            let site = decoder.decode_by_id(*id)?;
+            // IfcSite: RefLatitude (9), RefLongitude (10), RefElevation (11).
+            let latitude = Self::compound_plane_angle_to_degrees(&site, 9);
+            let longitude = Self::compound_plane_angle_to_degrees(&site, 10);
+            let (Some(latitude), Some(longitude)) = (latitude, longitude) else {
+                continue;
+            };
+            let elevation = site.get_float(11).unwrap_or(0.0);
+
+            let mut georef = GeoReference::new();
+            georef.source = GeoRefSource::SiteLocation;
+            georef.crs_name = Some("EPSG:4326".to_string());
+            georef.crs_description = Some("Legacy IfcSite geolocation".to_string());
+            georef.geodetic_datum = Some("WGS84".to_string());
+            georef.map_projection = Some("Geographic".to_string());
+            georef.map_unit = Some("DEGREE".to_string());
+            georef.eastings = longitude;
+            georef.northings = latitude;
+            georef.orthogonal_height = elevation;
+            return Ok(Some(georef));
+        }
+        Ok(None)
+    }
+
+    /// Convert an `IfcCompoundPlaneAngleMeasure` attribute (list of 3-4
+    /// integers: degrees, minutes, seconds, optional millionth-seconds) to
+    /// decimal degrees. Same sign handling as the TS parser: any negative
+    /// component makes the whole angle negative.
+    fn compound_plane_angle_to_degrees(entity: &DecodedEntity, index: usize) -> Option<f64> {
+        let list = entity.get_list(index)?;
+        let mut numbers = Vec::with_capacity(4);
+        for value in list {
+            if let Some(v) = value.as_float() {
+                numbers.push(v);
+            }
+        }
+        if numbers.len() < 3 {
+            return None;
+        }
+        let millionths = numbers.get(3).copied().unwrap_or(0.0);
+        let sign = if numbers[0] < 0.0 || numbers[1] < 0.0 || numbers[2] < 0.0 || millionths < 0.0
+        {
+            -1.0
+        } else {
+            1.0
+        };
+        let degrees = numbers[0].abs();
+        let minutes = numbers[1].abs();
+        let seconds = numbers[2].abs();
+        let millionths = millionths.abs();
+        Some(sign * (degrees + minutes / 60.0 + (seconds + millionths / 1_000_000.0) / 3600.0))
     }
 }
 

--- a/rust/core/src/lib.rs
+++ b/rust/core/src/lib.rs
@@ -83,7 +83,7 @@ pub use fast_parse::{
     parse_indices_direct, process_triangulated_faceset_direct, should_use_fast_path, FastMeshData,
 };
 pub use generated::IfcType;
-pub use georef::{GeoRefExtractor, GeoReference, RtcOffset};
+pub use georef::{GeoRefExtractor, GeoRefSource, GeoReference, RtcOffset};
 pub use legacy_entities::{
     get_legacy_entity_info, is_legacy_entity, map_legacy_to_base_type, LegacyEntityInfo,
 };

--- a/rust/processing/src/georeferencing.rs
+++ b/rust/processing/src/georeferencing.rs
@@ -51,6 +51,25 @@ pub struct Georeferencing {
     pub rotation_degrees: f64,
     /// Local→map transform as a column-major 4×4 matrix (16 values).
     pub transform_matrix: [f64; 16],
+    /// CRS description from `IfcProjectedCRS.Description`.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub crs_description: Option<String>,
+    /// Map zone (e.g. `"32N"`) from `IfcProjectedCRS.MapZone`.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub map_zone: Option<String>,
+    /// Map unit name resolved from `IfcProjectedCRS.MapUnit` (e.g. `"METRE"`,
+    /// `"MILLIMETRE"`); absent when no MapUnit is authored.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub map_unit: Option<String>,
+    /// Scale factor converting MapConversion values to metres (0.001 for
+    /// millimetres); absent when no MapUnit is authored.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub map_unit_scale: Option<f64>,
+    /// Provenance: `"mapConversion"`, `"ePSetMapConversion"`, or
+    /// `"siteLocation"` — same labels as the TS parser's
+    /// `GeoreferenceInfo.source`.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub source: Option<String>,
 }
 
 impl Georeferencing {
@@ -68,6 +87,11 @@ impl Georeferencing {
             scale: geo.scale,
             rotation_degrees: geo.rotation().to_degrees(),
             transform_matrix: geo.to_matrix(),
+            crs_description: geo.crs_description.clone(),
+            map_zone: geo.map_zone.clone(),
+            map_unit: geo.map_unit.clone(),
+            map_unit_scale: geo.map_unit_scale,
+            source: Some(geo.source.label().to_string()),
         }
     }
 }
@@ -90,6 +114,8 @@ pub fn extract_georeferencing(content: &str) -> Option<Georeferencing> {
             "IFCMAPCONVERSION" => entity_types.push((id, IfcType::IfcMapConversion)),
             "IFCPROJECTEDCRS" => entity_types.push((id, IfcType::IfcProjectedCRS)),
             "IFCPROPERTYSET" => entity_types.push((id, IfcType::IfcPropertySet)),
+            // Legacy IfcSite RefLatitude/RefLongitude fallback (TS parity).
+            "IFCSITE" => entity_types.push((id, IfcType::IfcSite)),
             _ => {}
         }
     }
@@ -149,6 +175,13 @@ END-ISO-10303-21;
         // Translation column of the local→map matrix carries the offsets.
         assert!((geo.transform_matrix[12] - 1000.5).abs() < 1e-6);
         assert!((geo.transform_matrix[13] - 2000.25).abs() < 1e-6);
+        // New parity fields (alignment audit): description/zone + provenance.
+        assert_eq!(geo.crs_description.as_deref(), Some("WGS84 / UTM zone 32N"));
+        assert_eq!(geo.map_zone.as_deref(), Some("32N"));
+        // No MapUnit authored → project length unit applies (both None).
+        assert_eq!(geo.map_unit, None);
+        assert_eq!(geo.map_unit_scale, None);
+        assert_eq!(geo.source.as_deref(), Some("mapConversion"));
     }
 
     /// IFC2x3 models carry georeferencing via an `ePSet_MapConversion` property
@@ -176,6 +209,129 @@ END-ISO-10303-21;
         assert!((geo.eastings - 1000.5).abs() < 1e-6);
         assert!((geo.northings - 2000.25).abs() < 1e-6);
         assert!((geo.orthogonal_height - 42.0).abs() < 1e-6);
+    }
+
+    /// Millimetre MapUnit: the conversion offsets are authored in mm and the
+    /// served `map_unit_scale` must say 0.001 — the TS parser already did
+    /// this; the server previously ignored MapUnit entirely (alignment
+    /// audit). Values mirror packages/parser/test/georef-extractor.test.ts.
+    const MM_MAPUNIT_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('georef mm fixture'),'2;1');
+FILE_NAME('georef-mm.ifc','2026-06-12T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#7=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);
+#10=IFCPROJECTEDCRS('EPSG:25832',$,'ETRS89',$,'UTM','32N',#7);
+#11=IFCMAPCONVERSION(#2,#10,512000000.,5400000000.,0.,1.,0.,1.0);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+    #[test]
+    fn resolves_millimetre_map_unit_scale() {
+        let geo = extract_georeferencing(MM_MAPUNIT_IFC).expect("georef");
+        assert_eq!(geo.map_unit.as_deref(), Some("MILLIMETRE"));
+        assert_eq!(geo.map_unit_scale, Some(0.001));
+        assert_eq!(geo.map_zone.as_deref(), Some("32N"));
+    }
+
+    /// Two authored IfcMapConversions: the FIRST one wins, matching the TS
+    /// parser's `mapConversionIds[0]` pick (the server used to serve the
+    /// LAST one — alignment audit).
+    const TWO_CONVERSIONS_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('georef two-conversions fixture'),'2;1');
+FILE_NAME('georef-two.ifc','2026-06-12T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#10=IFCPROJECTEDCRS('EPSG:32632',$,'WGS84',$,'UTM','32N',$);
+#11=IFCMAPCONVERSION(#2,#10,111.0,222.0,0.,1.,0.,1.0);
+#12=IFCMAPCONVERSION(#2,#10,999.0,888.0,0.,1.,0.,1.0);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+    #[test]
+    fn first_map_conversion_wins() {
+        let geo = extract_georeferencing(TWO_CONVERSIONS_IFC).expect("georef");
+        assert!((geo.eastings - 111.0).abs() < 1e-9);
+        assert!((geo.northings - 222.0).abs() < 1e-9);
+    }
+
+    /// Non-unit XAxisAbscissa/Ordinate (a DIRECTION, not cos/sin): the
+    /// rotation and the transform matrix must agree with each other and
+    /// with the TS parser's atan2-normalised matrix. Pre-fix, the matrix
+    /// used the raw components as cos/sin and disagreed with
+    /// `rotation_degrees` inside the same payload (alignment audit).
+    const NON_UNIT_AXIS_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('georef non-unit-axis fixture'),'2;1');
+FILE_NAME('georef-axis.ifc','2026-06-12T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#10=IFCPROJECTEDCRS('EPSG:32632',$,'WGS84',$,'UTM','32N',$);
+#11=IFCMAPCONVERSION(#2,#10,1000.,2000.,0.,3.0,4.0,1.0);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+    #[test]
+    fn non_unit_axis_is_normalised() {
+        let geo = extract_georeferencing(NON_UNIT_AXIS_IFC).expect("georef");
+        // (3,4) direction → unit (0.6, 0.8); rotation ≈ 53.130°.
+        assert!((geo.x_axis_abscissa - 0.6).abs() < 1e-9);
+        assert!((geo.x_axis_ordinate - 0.8).abs() < 1e-9);
+        assert!((geo.rotation_degrees - 53.13010235415598).abs() < 1e-9);
+        // Matrix rotation cell == cos(rotation) — self-consistent payload.
+        assert!((geo.transform_matrix[0] - 0.6).abs() < 1e-9);
+        assert!((geo.transform_matrix[1] - 0.8).abs() < 1e-9);
+    }
+
+    /// Site-only model: `IfcSite.RefLatitude/RefLongitude` must produce a
+    /// georeference exactly like the TS parser's legacy-site fallback —
+    /// previously the server reported NO georeferencing for these models
+    /// while the browser said `hasGeoreference: true` (alignment audit).
+    /// Mirrors the values in packages/parser/test/georef-extractor.test.ts.
+    const SITE_ONLY_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('georef site-only fixture'),'2;1');
+FILE_NAME('georef-site.ifc','2026-06-12T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#11=IFCLOCALPLACEMENT($,#5);
+#10=IFCSITE('0Site0000000000000001',$,'Site',$,$,#11,$,$,.ELEMENT.,(47,22,30,0),(8,32,15,0),420.5,$,$);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+    #[test]
+    fn site_lat_long_fallback_matches_ts_parser() {
+        let geo = extract_georeferencing(SITE_ONLY_IFC).expect("site georef");
+        assert_eq!(geo.source.as_deref(), Some("siteLocation"));
+        assert_eq!(geo.crs_name.as_deref(), Some("EPSG:4326"));
+        assert_eq!(geo.geodetic_datum.as_deref(), Some("WGS84"));
+        assert_eq!(geo.map_unit.as_deref(), Some("DEGREE"));
+        // 47°22'30" → 47.375; 8°32'15" → 8.5375 (longitude in eastings,
+        // latitude in northings — same packing as the TS fallback).
+        assert!((geo.northings - 47.375).abs() < 1e-9, "lat {}", geo.northings);
+        assert!((geo.eastings - 8.5375).abs() < 1e-9, "long {}", geo.eastings);
+        assert!((geo.orthogonal_height - 420.5).abs() < 1e-9);
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #1073 (which stacks on #1071). Lands the georeferencing drift finding from the alignment audit — the highest-severity confirmed item left.

## The drift

The two live extractors — `rust/core::GeoRefExtractor` (REST/SSE `ModelMetadata.georeferencing`) and `@ifc-lite/parser` `extractGeoreferencing` (viewer panels, Cesium/KMZ, MCP tools) — disagreed four verified ways: an IFC2x3 ePSet model was georeferenced on the server but not in the browser; a site-only model was georeferenced in the browser but not on the server; millimetre-based MapConversions scaled wrong server-side (MapUnit ignored); and files with non-unit `XAxisAbscissa/Ordinate` got a `transform_matrix` that disagreed with `rotation_degrees` *within the same payload*.

## The fix — one superset, identical precedence

`IfcMapConversion` → `ePSet_MapConversion` → legacy `IfcSite` lat/long, on both sides:

| Change | Side |
|---|---|
| First authored conversion wins (was last-wins) | Rust |
| `Description`/`MapZone`/`MapUnit` parsed; `map_unit_scale` via the shared SI-prefix table | Rust |
| X-axis normalised at parse → matrix ⇄ rotation self-consistent | Rust |
| `IfcSite.RefLatitude/RefLongitude` fallback (compound angle → decimal degrees, same eastings/northings packing as TS, `EPSG:4326` pseudo-CRS) | Rust |
| `ePSet_MapConversion` fallback added, placed before the site fallback | TS |
| `source` provenance shared string-for-string (`mapConversion` / `ePSetMapConversion` / `siteLocation`) | both |

Server `Georeferencing` + `@ifc-lite/server-client` gain optional `crs_description` / `map_zone` / `map_unit` / `map_unit_scale` / `source` (serde-default — backward compatible; no breaking shape change).

## Parity guard

Mirrored fixtures pinned on both sides (values cross-referenced in comments): mm MapUnit → 0.001, two conversions → first wins, non-unit (3,4) axis → 53.130° with matching matrix cells, site 47°22'30"/8°32'15" → 47.375/8.5375, ePSet beats site. Rust: 7 georeferencing tests; TS: 171 parser tests (3 new suites).

Deferred to phase 2 (documented in the audit): exposing GeoRefExtractor through wasm-bindings and shrinking the TS extractor to a shim — blocked on cache-restored models lacking source bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)