### PR TITLE
fix(geometry): unwedge large-model streaming — seed unit scales, bounded batches, worker heartbeat

### DIFF
--- a/packages/geometry/src/geometry-parallel.ts
+++ b/packages/geometry/src/geometry-parallel.ts
@@ -193,6 +193,15 @@ export async function* processParallel(
         wake();
         return;
       }
+      if (msg.type === 'progress') {
+        // Worker liveness heartbeat, posted before each bounded WASM call.
+        // Forward it so the consumer's stall watchdog measures "one WASM
+        // call went silent", not "no meshes lately" — a CSG-heavy stretch
+        // can keep every worker busy past the watchdog with nothing to show.
+        eventQueue.push({ type: 'progress', phase: 'workers' });
+        wake();
+        return;
+      }
       if (msg.type === 'batch') {
         if (firstBatchByWorker[workerIndex] === undefined) {
           firstBatchByWorker[workerIndex] = elapsed();
@@ -393,20 +402,30 @@ export async function* processParallel(
     if (workers.length === 0 || jobs.length === 0) return;
     // Round-robin sending whole chunks to single workers leaves N-1
     // workers idle whenever the chunk count is small. Instead split each
-    // Rust chunk evenly across all workers so every worker processes a
-    // slice of every chunk in parallel — full pool utilisation from the
-    // very first chunk.
+    // Rust chunk across all workers so every worker processes a slice of
+    // every chunk in parallel — full pool utilisation from the very first
+    // chunk.
+    //
+    // The split is INTERLEAVED (worker i takes jobs i, i+N, i+2N, …), not
+    // contiguous quarters: geometric complexity clusters by file region
+    // (e.g. all the CSG-heavy slabs of a steel model at the end of DATA),
+    // and a contiguous split hands one worker the entire heavy cluster
+    // while the rest go idle — the load's tail runs single-threaded.
+    // Striding spreads any hot region evenly across the pool.
     const totalSubJobs = Math.floor(jobs.length / 3);
     if (totalSubJobs === 0) return;
-    const subPerWorker = Math.ceil(totalSubJobs / workers.length);
     try {
       for (let i = 0; i < workers.length; i++) {
-        const start = i * subPerWorker * 3;
-        const end = Math.min(start + subPerWorker * 3, jobs.length);
-        if (start >= end) continue;
-        // `slice` allocates a new ArrayBuffer per piece so each can be in
-        // its own transfer list. Cheap relative to the WASM work that follows.
-        const sub = jobs.slice(start, end);
+        const subJobs = Math.floor((totalSubJobs - i + workers.length - 1) / workers.length);
+        if (subJobs === 0) continue;
+        // New ArrayBuffer per piece so each can be in its own transfer
+        // list. Cheap relative to the WASM work that follows.
+        const sub = new Uint32Array(subJobs * 3);
+        for (let j = 0, src = i * 3; j < subJobs * 3; j += 3, src += workers.length * 3) {
+          sub[j] = jobs[src];
+          sub[j + 1] = jobs[src + 1];
+          sub[j + 2] = jobs[src + 2];
+        }
         workers[i].postMessage(
           { type: 'stream-chunk' as const, jobsFlat: sub },
           [sub.buffer],

--- a/packages/geometry/src/geometry.worker.ts
+++ b/packages/geometry/src/geometry.worker.ts
@@ -161,6 +161,13 @@ export interface GeometryWorkerBatchMessage {
   }[];
 }
 
+export interface GeometryWorkerProgressMessage {
+  type: 'progress';
+  /** Jobs handed to WASM so far within the current slice (pre-call count). */
+  processedJobs: number;
+  totalJobs: number;
+}
+
 export interface GeometryWorkerCompleteMessage {
   type: 'complete';
   totalMeshes: number;
@@ -332,20 +339,30 @@ let activeSession: ProcessingSession | null = null;
 /**
  * Jobs per inner WASM call inside `processSliceStreaming`.
  *
- * IMPORTANT: this is NOT just about batch size for the host post — every
- * `processGeometryBatch` call allocates a fresh `EntityDecoder.cache`
- * (FxHashMap) in Rust. Splitting one streaming chunk into many small
- * WASM calls forces the decoder to re-decode the same shared sub-entities
- * (`IfcCartesianPoint`, placements, etc.) per call. Main does one big
- * call per worker and reaps the cache locality.
+ * Two forces pull in opposite directions:
  *
- * Setting this to a very large value means each fanned-out streaming
- * chunk maps to exactly one WASM call per worker — main-equivalent
- * cache behaviour while preserving streaming's early-job dispatch.
- * Per-flush mesh count is then bounded by the chunk size (≤ 25K-ish on
- * the 986 MB test file with 50K Rust chunk + 2-way fan-out).
+ * - Cache locality: every `processGeometryBatch` call allocates a fresh
+ *   `EntityDecoder.cache` (FxHashMap) in Rust, so smaller batches re-decode
+ *   shared sub-entities (`IfcCartesianPoint`, placements, …) per call.
+ *   This once justified an effectively-unbounded value (1M): one WASM call
+ *   per worker slice. The dominant per-call fixed cost back then was an
+ *   O(file) IFCPROJECT scan for unit scales — that is now resolved once per
+ *   worker and seeded into each batch decoder, so the remaining per-call
+ *   overhead is small.
+ *
+ * - Liveness: a `processGeometryBatch` call is synchronous WASM — no batch
+ *   events, no progressive rendering, and nothing feeds the stream watchdog
+ *   while it runs. With one call per slice, a CSG-heavy model wedges every
+ *   worker for its entire slice (minutes on 70 MB+ steel models): the host
+ *   sees zero events, the watchdog kills a *healthy* load, and the user
+ *   stares at an empty viewport until the first worker finishes everything.
+ *
+ * 512 keeps typical call duration well under a second (~1.6 ms/job measured
+ * on a 72 MB IFC4 model) so meshes stream in continuously and the watchdog
+ * only fires on real wedges, while keeping the re-decode overhead a few
+ * percent (shared-entity locality is mostly intra-batch at this size).
  */
-const STREAM_BATCH_SIZE = 1_000_000;
+const STREAM_BATCH_SIZE = 512;
 
 function startSession(input: {
   sharedBuffer: SharedArrayBuffer;
@@ -531,6 +548,15 @@ async function processBatch(session: ProcessingSession, jobs: Uint32Array): Prom
 async function processSliceStreaming(session: ProcessingSession, jobsFlat: Uint32Array): Promise<void> {
   const totalJobs = Math.floor(jobsFlat.length / 3);
   for (let jobOffset = 0; jobOffset < totalJobs; jobOffset += STREAM_BATCH_SIZE) {
+    // Liveness heartbeat BEFORE entering the synchronous WASM call: the host
+    // forwards it as a `progress` stream event so the consumer's stall
+    // watchdog measures "time inside one bounded WASM call", not "time since
+    // the last mesh" — a CSG-heavy region can legitimately produce nothing
+    // for tens of seconds while every worker is busy. Also covers batches
+    // that produce zero meshes (flushPending no-ops on empty).
+    (self as unknown as Worker).postMessage(
+      { type: 'progress', processedJobs: jobOffset, totalJobs } as GeometryWorkerProgressMessage,
+    );
     const start = jobOffset * 3;
     const end = Math.min(start + STREAM_BATCH_SIZE * 3, jobsFlat.length);
     await processBatch(session, jobsFlat.subarray(start, end));

--- a/rust/core/src/decoder.rs
+++ b/rust/core/src/decoder.rs
@@ -274,6 +274,23 @@ impl<'a> EntityDecoder<'a> {
         scale
     }
 
+    /// Pre-seed the unit-scale caches so [`Self::length_unit_scale`] and
+    /// [`Self::plane_angle_to_radians`] return immediately without the full-file
+    /// `IFCPROJECT` scan.
+    ///
+    /// Both lazy resolvers walk the whole DATA section to locate the (singleton)
+    /// `IFCPROJECT`. That scan is `O(file size)` and `IFCPROJECT` legally sits
+    /// anywhere — IfcOpenShell emits it near the *end*, so on a large model the
+    /// scan touches tens of MB. The cache is per-decoder, and the parallel
+    /// geometry pipeline builds a fresh decoder per element, so without seeding
+    /// every arc-bearing element re-pays the scan (≈135 ms each on a 75 MB
+    /// file). The orchestrator resolves both scales once on a warm shared
+    /// decoder and seeds each worker decoder here.
+    pub fn seed_unit_scales(&mut self, length_unit_scale: f64, plane_angle_to_radians: f64) {
+        self.length_unit_scale_cache = Some(length_unit_scale);
+        self.plane_angle_to_radians_cache = Some(plane_angle_to_radians);
+    }
+
     /// Resolve entity reference (follow #ID)
     /// Returns None for null/derived values
     #[inline]

--- a/rust/processing/src/processor.rs
+++ b/rust/processing/src/processor.rs
@@ -1403,6 +1403,15 @@ pub fn process_geometry_streaming_filtered_with_options(
     let entity_index_arc = entity_index; // Already Arc from above
     let unit_scale = router.unit_scale();
     let rtc_offset = router.rtc_offset();
+    // Resolve the plane-angle scale ONCE on the warm shared decoder, then seed
+    // every per-element worker decoder below (EntityDecoder::seed_unit_scales;
+    // the length scale is `unit_scale`, already resolved by the router). Both
+    // resolvers scan the whole DATA section for the singleton IFCPROJECT, which
+    // IfcOpenShell emits near the *end* of the file — and the parallel path
+    // builds a fresh (cold-cache) decoder per element, so without seeding every
+    // arc-bearing element re-pays that ~O(file) scan (≈135 ms each on a 75 MB
+    // model where IFCPROJECT sits at byte ~68 MB).
+    let seed_plane_angle_to_radians = decoder.plane_angle_to_radians();
     let void_index_arc = Arc::new(filtered_void_index);
     let skipped_entity_ids = Arc::new(skipped_entity_ids);
     // Fold indexed-colour-map colours in where no IFCSTYLEDITEM already claimed
@@ -1551,6 +1560,7 @@ pub fn process_geometry_streaming_filtered_with_options(
                     &entity_index_arc,
                     unit_scale,
                     rtc_offset,
+                    seed_plane_angle_to_radians,
                     options.tessellation_quality,
                     void_index_arc.as_ref(),
                     skipped_entity_ids.as_ref(),
@@ -1696,6 +1706,9 @@ fn process_entity_job(
     entity_index_arc: &Arc<EntityIndex>,
     unit_scale: f64,
     rtc_offset: (f64, f64, f64),
+    // Pre-resolved scales seeded into this job's decoder so arc tessellation and
+    // unit conversion never trigger a per-element full-file IFCPROJECT scan.
+    seed_plane_angle_to_radians: f64,
     tessellation_quality: TessellationQuality,
     void_index: &FxHashMap<u32, Vec<u32>>,
     skipped_entity_ids: &HashSet<u32>,
@@ -1717,6 +1730,9 @@ fn process_entity_job(
     }
 
     let mut local_decoder = EntityDecoder::with_arc_index(content, entity_index_arc.clone());
+    // Seed the unit-scale caches so curve/arc processing skips the O(file)
+    // IFCPROJECT scan that each fresh per-element decoder would otherwise repeat.
+    local_decoder.seed_unit_scales(unit_scale, seed_plane_angle_to_radians);
 
     let entity = match local_decoder.decode_at(job.start, job.end) {
         Ok(entity) => entity,

--- a/rust/wasm-bindings/src/api/gpu_meshes.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes.rs
@@ -829,6 +829,13 @@ impl IfcAPI {
             }
         };
         let mut decoder = EntityDecoder::with_arc_index(content, entity_index_arc);
+        // Seed the unit-scale caches so curve/arc tessellation never re-pays the
+        // O(file) IFCPROJECT scan: this decoder is fresh on every batch call,
+        // and `plane_angle_to_radians()` would otherwise walk the whole DATA
+        // section per batch on files whose IFCPROJECT sits near the end
+        // (IfcOpenShell exports) — the geometry-stream stall on large models.
+        let plane_angle_to_radians = self.get_or_resolve_plane_angle(&mut decoder);
+        decoder.seed_unit_scales(unit_scale, plane_angle_to_radians);
 
         // Create geometry router with unit scale and the consumer-selected
         // tessellation quality (issue #976) — Medium unless JS called

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -132,6 +132,17 @@ pub struct IfcAPI {
     /// without locking — same contract as `merge_layers`. Default is Medium,
     /// which reproduces the historical hardcoded densities byte-for-byte.
     tessellation_quality: std::sync::atomic::AtomicU8,
+
+    /// Lazily-resolved plane-angle → radians scale for the current content,
+    /// seeded into every batch decoder via `EntityDecoder::seed_unit_scales`.
+    /// `EntityDecoder::plane_angle_to_radians()` walks the whole DATA section
+    /// to find the singleton `IFCPROJECT` — which IfcOpenShell emits near the
+    /// *end* of the file — and its cache is per-decoder, so without this
+    /// per-worker cache every `processGeometryBatch` call re-pays an O(file)
+    /// scan the moment any arc-bearing profile is tessellated (≈ the geometry
+    /// stream stall on large models with late IFCPROJECT). Content-scoped:
+    /// cleared by `clearPrePassCache` and on entity-index swap.
+    cached_plane_angle_to_radians: std::sync::Mutex<Option<f64>>,
 }
 
 #[wasm_bindgen]
@@ -156,6 +167,7 @@ impl IfcAPI {
                 ifc_lite_geometry::DEFAULT_GEOM_HASH_TOLERANCE.to_bits(),
             ),
             tessellation_quality: std::sync::atomic::AtomicU8::new(TESSELLATION_QUALITY_MEDIUM),
+            cached_plane_angle_to_radians: std::sync::Mutex::new(None),
         }
     }
 
@@ -214,6 +226,11 @@ impl IfcAPI {
             .lock()
             .expect("ifc-lite cached_indexed_colour_maps Mutex poisoned");
         icm_slot.take();
+        // The plane-angle scale belongs to the previous load's content.
+        self.cached_plane_angle_to_radians
+            .lock()
+            .expect("ifc-lite cached_plane_angle_to_radians Mutex poisoned")
+            .take();
     }
 
     /// Populate `cached_entity_index` from pre-extracted column arrays.
@@ -279,6 +296,10 @@ impl IfcAPI {
         self.cached_indexed_colour_maps
             .lock()
             .expect("ifc-lite cached_indexed_colour_maps Mutex poisoned")
+            .take();
+        self.cached_plane_angle_to_radians
+            .lock()
+            .expect("ifc-lite cached_plane_angle_to_radians Mutex poisoned")
             .take();
     }
 
@@ -597,6 +618,37 @@ impl IfcAPI {
             .expect("ifc-lite cached_indexed_colour_maps Mutex poisoned");
         *slot = Some(std::sync::Arc::clone(&arc));
         arc
+    }
+
+    /// Resolve the file's plane-angle → radians scale once per worker and cache
+    /// it. The underlying `EntityDecoder::plane_angle_to_radians()` walks the
+    /// whole DATA section for `IFCPROJECT` (which IfcOpenShell emits near the
+    /// end of the file) and caches only per-decoder — but `processGeometryBatch`
+    /// builds a fresh decoder per call, so every batch would re-pay that
+    /// O(file) scan. Callers seed the batch decoder with the cached value via
+    /// `EntityDecoder::seed_unit_scales`.
+    pub(crate) fn get_or_resolve_plane_angle(
+        &self,
+        decoder: &mut ifc_lite_core::EntityDecoder,
+    ) -> f64 {
+        {
+            let slot = self
+                .cached_plane_angle_to_radians
+                .lock()
+                .expect("ifc-lite cached_plane_angle_to_radians Mutex poisoned");
+            if let Some(existing) = *slot {
+                return existing;
+            }
+        }
+
+        let scale = decoder.plane_angle_to_radians();
+
+        let mut slot = self
+            .cached_plane_angle_to_radians
+            .lock()
+            .expect("ifc-lite cached_plane_angle_to_radians Mutex poisoned");
+        *slot = Some(scale);
+        scale
     }
 }
 


### PR DESCRIPTION
## Problem

Loading a 75 MB IFC4 steel model stalled the viewer's geometry stream (`Geometry stream stalled after 17160ms … Last rendered meshes: 5285`) and never completed. The native pipeline on the same file ran ~135 ms per arc-bearing element (single-threaded full process never finished).

## Root causes (three, compounding)

1. **O(file) unit-scale scans per decoder.** `EntityDecoder::length_unit_scale()` / `plane_angle_to_radians()` each walk the whole DATA section to find the singleton `IFCPROJECT` — which IfcOpenShell emits near the **end** of the file (byte ~68 MB of 75 MB here) — and cache only per-decoder. The native parallel path builds a fresh decoder per element → every beam with a trimmed-curve profile re-paid the scan. The wasm path builds a fresh decoder per `processGeometryBatch` call → one scan per batch per worker.
2. **Unbounded worker batches starved the stream watchdog.** `STREAM_BATCH_SIZE` was 1M jobs: each worker ran its entire slice as ONE synchronous WASM call, so nothing rendered and no event reached the consumer until a worker finished everything — the watchdog killed a *healthy* load at 17 s.
3. **No liveness signal through CSG-heavy stretches.** A batch full of boolean-heavy slabs legitimately runs past the watchdog with zero meshes to show.

## Fix

- `EntityDecoder::seed_unit_scales()` — processor resolves both scales once on the warm shared decoder and seeds every per-element decoder; `processGeometryBatch` resolves the plane-angle scale once per worker (new content-scoped cached slot on `IfcAPI`) and seeds each batch decoder.
- `STREAM_BATCH_SIZE` 1M → 512 (affordable now that the per-call scan is seeded away): meshes stream continuously from ~2 s.
- Workers post a `progress` heartbeat before each WASM call; the host forwards it as the existing `progress` stream event — the watchdog now measures "one WASM call went silent", not "no meshes lately".
- Prepass job chunks are **strided** across workers instead of contiguous quarters — complexity clusters by file region (the CSG-heavy slabs at the end of DATA), and the contiguous split handed one worker the whole cluster while the rest idled.

## Verification

- Viewer (dev, WebGPU): the 75 MB model loads to completion — 20,577 meshes / 1.1 M tris, progressive rendering throughout, no watchdog error (previously: never completed).
- Native `process_geometry_streaming`: 30.4 s single-thread / 18 s multi-thread, max inter-batch gap 2.5 s (previously: did not finish in 150 s single-thread).
- `cargo test` (core/processing/geometry), wasm contract 16/16, `@ifc-lite/geometry` vitest 57/57, turbo typecheck 29/29 — all green.

Remaining browser-side slowness on the slab cluster is the known exact-CSG-kernel cost (amplified on wasm32, where i128 arithmetic is software-emulated) — tracked separately. This PR is step 1 of the pipeline-unification series (canonical per-element mesh core + shared prepass follow).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added progress tracking during geometry processing to prevent false timeout detection.

* **Performance**
  * Implemented caching for unit scale calculations to reduce repeated geometry analysis.
  * Optimized streaming batch sizes for improved responsiveness during long-running operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->