### PR TITLE
fix(release): advance Cargo workspace to 4.0.0 and unmask crates.io publish failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1464,11 +1464,11 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ifc-lite-clash"
-version = "3.2.0"
+version = "4.0.0"
 
 [[package]]
 name = "ifc-lite-core"
-version = "3.2.0"
+version = "4.0.0"
 dependencies = [
  "fast-float2",
  "futures-core",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-geometry"
-version = "3.2.0"
+version = "4.0.0"
 dependencies = [
  "approx",
  "bnum",
@@ -1510,7 +1510,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-processing"
-version = "3.2.0"
+version = "4.0.0"
 dependencies = [
  "ifc-lite-core",
  "ifc-lite-geometry",
@@ -1523,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-server"
-version = "3.2.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-wasm"
-version = "3.2.0"
+version = "4.0.0"
 dependencies = [
  "console_error_panic_hook",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,18 +3,18 @@ members = ["rust/core", "rust/geometry", "rust/processing", "rust/clash", "rust/
 resolver = "2"
 
 [workspace.package]
-version = "3.2.0"
+version = "4.0.0"
 edition = "2021"
 authors = ["IFC-Lite Contributors"]
 license = "MPL-2.0"
 repository = "https://github.com/LTplus-AG/ifc-lite"
 
 [workspace.dependencies]
-ifc-lite-core = { version = "3.2.0", path = "rust/core" }
-ifc-lite-geometry = { version = "3.2.0", path = "rust/geometry" }
-ifc-lite-processing = { version = "2.1.7", path = "rust/processing" }
-ifc-lite-clash = { version = "3.0.0", path = "rust/clash" }
-ifc-lite-wasm = { version = "3.2.0", path = "rust/wasm-bindings" }
+ifc-lite-core = { version = "4.0.0", path = "rust/core" }
+ifc-lite-geometry = { version = "4.0.0", path = "rust/geometry" }
+ifc-lite-processing = { version = "4.0.0", path = "rust/processing" }
+ifc-lite-clash = { version = "4.0.0", path = "rust/clash" }
+ifc-lite-wasm = { version = "4.0.0", path = "rust/wasm-bindings" }
 
 [profile.release]
 opt-level = 3           # Optimize for speed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ifc-lite",
-  "version": "3.2.0",
+  "version": "4.0.0",
   "description": "High-performance browser IFC parser & renderer",
   "private": true,
   "type": "module",
@@ -47,7 +47,7 @@
     "version": "changeset version && node scripts/sync-versions.js",
     "release": "pnpm build && pnpm test:esm && pnpm release:npm && pnpm release:crates",
     "release:npm": "changeset publish",
-    "release:crates": "cargo publish -p ifc-lite-core --allow-dirty || true && sleep 30 && cargo publish -p ifc-lite-geometry --allow-dirty || true && sleep 30 && cargo publish -p ifc-lite-wasm --allow-dirty || true",
+    "release:crates": "node scripts/release-crates.mjs",
     "publish:npm": "pnpm -r publish --access public",
     "publish:dry": "pnpm -r publish --access public --dry-run",
     "test:benchmark": "playwright test tests/benchmark/benchmark.spec.ts",

--- a/scripts/release-crates.mjs
+++ b/scripts/release-crates.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+
+/**
+ * Publishes the publishable Rust crates to crates.io.
+ *
+ * Replaces the old `cargo publish … || true` chain, which silently swallowed
+ * EVERY failure: duplicate-version no-ops (expected when the workspace
+ * version didn't advance) looked identical to real breakage, so
+ * `ifc-lite-wasm` sat broken at 2.3.0 for months and the raw-bytes core API
+ * almost shipped to npm without ever reaching crates.io.
+ *
+ * Behaviour per crate:
+ *   - version already on crates.io  → skip (expected, logged)
+ *   - version missing               → `cargo publish`; any failure FAILS the release
+ *
+ * Only `ifc-lite-core` and `ifc-lite-geometry` are published.
+ * `ifc-lite-processing` and `ifc-lite-clash` have never been on crates.io and
+ * carry version-less `path` dependencies, which makes them — and
+ * `ifc-lite-wasm`, which depends on both — unpublishable as-is. Publishing
+ * them is a deliberate public-surface decision, not a release-script default;
+ * if that decision is made, add versions to their path deps and append them
+ * (and `ifc-lite-wasm`) here in dependency order.
+ *
+ * `cargo publish` (≥1.66) blocks until the new version is visible in the
+ * index, so no sleep is needed between dependent publishes.
+ */
+
+import { execSync } from 'child_process';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const rootDir = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+// Dependency order: geometry depends on core.
+const CRATES = ['ifc-lite-core', 'ifc-lite-geometry'];
+
+const cargoToml = readFileSync(join(rootDir, 'Cargo.toml'), 'utf8');
+const versionMatch = cargoToml.match(
+  /\[workspace\.package\][^[]*?version\s*=\s*"([^"]+)"/
+);
+if (!versionMatch) {
+  console.error('❌ Could not read [workspace.package] version from Cargo.toml');
+  process.exit(1);
+}
+const version = versionMatch[1];
+
+async function isPublished(crate, ver) {
+  const res = await fetch(`https://crates.io/api/v1/crates/${crate}/${ver}`, {
+    headers: { 'User-Agent': 'ifc-lite-release (github.com/LTplus-AG/ifc-lite)' },
+  });
+  if (res.status === 404) return false;
+  if (!res.ok) {
+    throw new Error(`crates.io returned ${res.status} for ${crate}@${ver}`);
+  }
+  const body = await res.json();
+  return !body.errors;
+}
+
+for (const crate of CRATES) {
+  if (await isPublished(crate, version)) {
+    console.log(`⏭️  ${crate}@${version} already on crates.io — skipping`);
+    continue;
+  }
+  console.log(`📦 Publishing ${crate}@${version} …`);
+  execSync(`cargo publish -p ${crate} --allow-dirty`, {
+    cwd: rootDir,
+    stdio: 'inherit',
+  });
+  console.log(`✅ Published ${crate}@${version}`);
+}


### PR DESCRIPTION
## Summary

Addresses the review finding on #1081: with the npm bump to `@ifc-lite/wasm@2.8.0` sitting below the root version, `scripts/sync-versions.js` leaves the Cargo workspace at the already-published 3.2.0, every `cargo publish` fails as a duplicate, and `|| true` suppresses the failures — the raw-byte Rust API from #1070 would never reach crates.io.

Investigation confirmed the masking went further than the duplicate case: `ifc-lite-wasm` has been stuck at **2.3.0** on crates.io because it depends on `ifc-lite-processing` and `ifc-lite-clash`, which were never published and declare version-less `path` dependencies — every wasm publish since then failed silently.

## Changes

- **`Cargo.toml`**: `[workspace.package]` 3.2.0 → 4.0.0 (the #1070 changelog explicitly calls the `ifc-lite-core` API change breaking); all internal workspace dep pins follow (this also fixes the stale `ifc-lite-processing = 2.1.7` / `ifc-lite-clash = 3.0.0` pins that no longer matched their crates).
- **root `package.json`**: 4.0.0 — `sync-versions.js` takes the max of workspace npm versions *and* the root version, so this anchors Cargo at 4.0.0 until npm catches up (verified idempotent).
- **`scripts/release-crates.mjs`** (replaces the `|| true` chain): skips a crate when its exact version is already on crates.io, otherwise publishes and **fails the release** on any error. `cargo publish` ≥1.66 blocks until index visibility, so the `sleep 30`s are gone.
- **Scope**: publishes `ifc-lite-core` + `ifc-lite-geometry` only. Putting `ifc-lite-processing`/`ifc-lite-clash` (and then `ifc-lite-wasm`) on crates.io is a deliberate public-surface decision — if wanted, add versions to their path deps and append them to the script in dependency order.

## Validation

- `node scripts/sync-versions.js` → resolves 4.0.0, idempotent (no further diff)
- crates.io probe logic: `ifc-lite-core@3.2.0` → exists/skip, `@4.0.0` → 404/publish
- `cargo publish --dry-run -p ifc-lite-core --allow-dirty` → packages + uploads cleanly
- `cargo publish --dry-run -p ifc-lite-geometry` fails standalone only because it requires `ifc-lite-core@4.0.0` from the index — that version exists mid-release once core publishes (same ordering every prior release used)
- `cargo update --workspace` refreshed `Cargo.lock`

Merge this before #1081 so the version-packages release publishes the 4.0.0 crates with the raw-bytes API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Version bumped to 4.0.0 across all workspace crates
  * Release process automation improved for streamlined publishing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->