### PR TITLE
refactor(processing): extract the canonical per-element mesh producer (element.rs)

### DIFF
--- a/rust/processing/src/element.rs
+++ b/rust/processing/src/element.rs
@@ -1,0 +1,749 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Canonical per-element mesh production — THE single decision tree that turns
+//! one IFC product (or type-product RepresentationMap) into renderable meshes.
+//!
+//! Both pipelines run this exact code:
+//! - the native orchestrator (`processor.rs`) calls [`produce_element_meshes`]
+//!   from its rayon loop with a fresh seeded decoder + router per element;
+//! - the browser batch path (`wasm-bindings` `processGeometryBatch`) calls it
+//!   per job with a warm per-batch decoder + router.
+//!
+//! History: the two pipelines used to carry diverging inline copies of this
+//! tree, and fixes had to land twice (#858, #913, #957, #961, #1071). Any
+//! change to mesh-production behaviour belongs HERE, exactly once. The only
+//! sanctioned behavioural fork is [`TypeGeometryMode`] — a product
+//! requirement, not drift: an export must never duplicate type geometry,
+//! while the interactive viewer renders it tagged for its Model/Types switch.
+//!
+//! The converged decision tree (union of the strongest behaviours of both
+//! former copies):
+//!
+//! ```text
+//! representation gate (IfcAlignment exempt)
+//! ├─ TypeProduct job (#957): render each planned RepresentationMap
+//! │    (textures #961, geometry_class tag, styled-item colour)
+//! └─ Product job:
+//!    ├─ has openings → submesh-aware void cut (per-part colours survive)
+//!    ├─ else        → submesh path for ALL types (per-item colours,
+//!    │                per-item error skipping, #858 palette split per item)
+//!    └─ fallback chain when the submesh path produced nothing:
+//!         void-aware single mesh → plain element → element-level #858 split
+//!         → single coloured mesh
+//! ```
+
+use crate::style::{FullIndexedColourMap, GeometryStyleInfo};
+use crate::types::mesh::{MeshData, MeshTextureData};
+use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcType};
+use ifc_lite_geometry::{
+    calculate_normals, BoolFailure, GeometryHasher, GeometryRouter, Mesh, ResolvedTextureMap,
+    SubMeshCollection,
+};
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::collections::BTreeMap;
+
+use crate::processor::{convert_mesh_to_site_local, get_refs_from_list};
+
+/// Element-level metadata stamped on every produced [`MeshData`]. The native
+/// pipeline resolves these during its metadata phase; the browser passes
+/// `None` (its viewer gets metadata from the parser worker instead).
+#[derive(Debug, Clone, Default)]
+pub struct ElementMeshMetadata {
+    pub global_id: Option<String>,
+    pub name: Option<String>,
+    pub presentation_layer: Option<String>,
+    pub space_zone_properties: Option<BTreeMap<String, String>>,
+}
+
+/// What the job renders.
+#[derive(Debug, Clone)]
+pub enum ElementJobKind {
+    /// Ordinary product occurrence — walk its IfcProductDefinitionShape.
+    Product,
+    /// #957 type geometry: render these RepresentationMaps directly (baking
+    /// their MappingOrigin), each pre-tagged with its geometry_class
+    /// (1 = orphan, 2 = instanced). Produce the list with
+    /// [`plan_type_geometry`] — callers must not hand-roll the filter.
+    TypeProduct { rep_maps: Vec<(u32, u8)> },
+}
+
+/// One unit of mesh production.
+pub struct ElementMeshJob<'a> {
+    pub id: u32,
+    pub ifc_type: IfcType,
+    /// The decoded product (or type-product) entity. Callers decode it —
+    /// they own skip-set checks and decode-failure policy.
+    pub entity: &'a DecodedEntity,
+    pub kind: ElementJobKind,
+    /// Caller-resolved element fallback colour (direct style > material
+    /// chain > type default). `None` ⇒ `default_color_for_type`.
+    pub element_color: Option<[f32; 4]>,
+    pub metadata: Option<&'a ElementMeshMetadata>,
+}
+
+/// Read-only shared state for one production run. Every field is a borrow of
+/// `Sync` data, so `&MeshProductionContext` can be captured by a rayon
+/// closure (native) or used serially (wasm).
+pub struct MeshProductionContext<'a> {
+    /// Host element id → opening ids (post void-propagation / opening filter).
+    pub void_index: &'a FxHashMap<u32, Vec<u32>>,
+    /// Geometry item id → resolved style (styled-item index).
+    pub geometry_style_index: &'a FxHashMap<u32, GeometryStyleInfo>,
+    /// Geometry item id → full per-triangle palette (#858).
+    pub indexed_colour_full: &'a FxHashMap<u32, FullIndexedColourMap>,
+    /// Element id → material colour list (#407/#913 transparent/opaque
+    /// alternation). Empty map when the caller has no material chain data.
+    pub element_material_colors: &'a FxHashMap<u32, Vec<[f32; 4]>>,
+    /// Surface textures + UV maps keyed by face-set id (#961).
+    pub texture_index: &'a FxHashMap<u32, ResolvedTextureMap>,
+    /// Site-local rotation (native `site_local` coordinate space only).
+    /// `None` for the browser — its Z-up→Y-up swap happens at the FFI
+    /// boundary, after this function.
+    pub site_local_rotation: Option<&'a Vec<f64>>,
+}
+
+/// RTC-invariant per-element fingerprint configuration (#971/#924).
+#[derive(Debug, Clone, Copy)]
+pub struct GeometryHashConfig {
+    /// Quantization grid in metres.
+    pub tolerance: f64,
+    /// World-reconstruction offset added back to local positions (the batch
+    /// RTC when a shift was applied, else zeros) so the file's RTC choice
+    /// never registers as a geometry change.
+    pub world_rtc: [f64; 3],
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct MeshProductionOptions {
+    /// `Some` ⇒ compute one fingerprint per element (browser diff feature).
+    /// Type-product jobs are never hashed (diffing type-library shapes is a
+    /// separate feature decision).
+    pub geometry_hash: Option<GeometryHashConfig>,
+}
+
+/// The #957 suppress-vs-tag decision — an explicit product-requirement fork,
+/// not drift. See [`plan_type_geometry`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TypeGeometryMode {
+    /// Native/export: instanced types are suppressed entirely (an export must
+    /// never duplicate geometry); orphan maps emit with geometry_class 1.
+    SuppressInstanced,
+    /// Viewer: instanced types emit too, tagged geometry_class 2, so the
+    /// Model/Types view switch can filter at render time.
+    EmitTagged,
+}
+
+/// The single home of the #957 orphan/instanced RepresentationMap decision.
+///
+/// A map referenced by an `IfcMappedItem` always draws through its occurrence
+/// — emitting it again would double-render at the MappingOrigin (the
+/// AC20/ArchiCAD duplicate-boxes regression), so referenced maps are filtered
+/// in every mode. What remains is classified by whether the type has an
+/// occurrence (`IfcRelDefinesByType`): orphans are class 1 (part of the
+/// model — nothing else renders them), instanced types are class 2 (the
+/// type-library shape) and only emitted in [`TypeGeometryMode::EmitTagged`].
+pub fn plan_type_geometry(
+    rep_map_ids: &[u32],
+    referenced_representation_maps: &FxHashSet<u32>,
+    type_is_instantiated: bool,
+    mode: TypeGeometryMode,
+) -> Vec<(u32, u8)> {
+    if mode == TypeGeometryMode::SuppressInstanced && type_is_instantiated {
+        return Vec::new();
+    }
+    let class: u8 = if type_is_instantiated { 2 } else { 1 };
+    rep_map_ids
+        .iter()
+        .filter(|rm| !referenced_representation_maps.contains(rm))
+        .map(|rm| (*rm, class))
+        .collect()
+}
+
+/// Everything one element produced.
+pub struct ProducedElementMeshes {
+    pub meshes: Vec<MeshData>,
+    /// Per-ELEMENT fingerprint, accumulated across all of the element's
+    /// meshes in the native IFC frame (pre-split, pre-site-rotation).
+    /// `None` when hashing is off, nothing was produced, or the job is a
+    /// TypeProduct.
+    pub geometry_hash: Option<u64>,
+    /// CSG diagnostics recorded while producing THIS element, attributed by
+    /// product id. The router is fully drained on return, so a warm router
+    /// reused across a batch never leaks one element's failures into the
+    /// next. Failures from a superseded strategy (a fallback re-attempting
+    /// the same cuts) are discarded — only the path that produced the
+    /// returned meshes contributes.
+    pub csg_failures: FxHashMap<u32, Vec<BoolFailure>>,
+}
+
+/// THE canonical per-element mesh producer.
+///
+/// Decoder and router are caller-supplied so each pipeline keeps its reuse
+/// policy: the native rayon loop builds a fresh seeded decoder + router per
+/// element; the browser batch path reuses one warm pair per batch. The
+/// decoder MUST have its unit-scale caches seeded
+/// (`EntityDecoder::seed_unit_scales`) — otherwise arc tessellation re-pays
+/// an O(file) IFCPROJECT scan per fresh decoder.
+pub fn produce_element_meshes(
+    job: &ElementMeshJob<'_>,
+    ctx: &MeshProductionContext<'_>,
+    opts: &MeshProductionOptions,
+    decoder: &mut EntityDecoder,
+    router: &GeometryRouter,
+) -> ProducedElementMeshes {
+    let mut hasher = match (&job.kind, opts.geometry_hash) {
+        (ElementJobKind::Product, Some(cfg)) => {
+            Some(GeometryHasher::new(cfg.tolerance, cfg.world_rtc))
+        }
+        _ => None,
+    };
+
+    let meshes = produce_inner(job, ctx, decoder, router, &mut hasher);
+
+    // Drain the router's per-element CSG diagnostics on EVERY return path so
+    // a warm (batch-reused) router starts the next element clean.
+    let csg_failures = router.take_csg_failures();
+
+    let geometry_hash = hasher.and_then(|h| if h.is_empty() { None } else { Some(h.finish()) });
+
+    ProducedElementMeshes {
+        meshes,
+        geometry_hash,
+        csg_failures,
+    }
+}
+
+fn produce_inner(
+    job: &ElementMeshJob<'_>,
+    ctx: &MeshProductionContext<'_>,
+    decoder: &mut EntityDecoder,
+    router: &GeometryRouter,
+    hasher: &mut Option<GeometryHasher>,
+) -> Vec<MeshData> {
+    // Representation gate, with the IfcAlignment exception: alignments carry
+    // their geometry on IfcAlignment*Segment children, so a null
+    // Representation attribute does not mean "nothing to render".
+    let has_representation = job.entity.get(6).is_some_and(|a| !a.is_null());
+    if !has_representation && job.ifc_type != IfcType::IfcAlignment {
+        return Vec::new();
+    }
+
+    let element_color = job
+        .element_color
+        .unwrap_or_else(|| crate::style::default_color_for_type(job.ifc_type).to_array());
+
+    if let ElementJobKind::TypeProduct { rep_maps } = &job.kind {
+        return produce_type_geometry(job, rep_maps, element_color, ctx, decoder, router);
+    }
+
+    let has_openings = ctx
+        .void_index
+        .get(&job.id)
+        .is_some_and(|openings| !openings.is_empty());
+
+    if has_openings {
+        // Voided elements: submesh-aware cut FIRST, so per-part colours
+        // survive the void subtraction (a voided window keeps frame/glass
+        // split; a voided multi-layer wall keeps its layer colours).
+        if let Ok(sub_meshes) =
+            router.process_element_with_submeshes_and_voids(job.entity, decoder, ctx.void_index)
+        {
+            if !sub_meshes.is_empty() {
+                let out = emit_sub_meshes(job, sub_meshes, element_color, ctx, decoder, hasher);
+                if !out.is_empty() {
+                    return out;
+                }
+            }
+        }
+    } else {
+        // Submesh path for ALL types: per-geometry-item colours (window glass
+        // transparency, multi-material doors) and per-item error skipping —
+        // one unsupported representation item no longer blanks the whole
+        // element (`process_element` aborts with `?`). #858 palette split
+        // happens per item inside `emit_sub_meshes`.
+        if let Ok(sub_meshes) = router.process_element_with_submeshes(job.entity, decoder) {
+            if !sub_meshes.is_empty() {
+                let out = emit_sub_meshes(job, sub_meshes, element_color, ctx, decoder, hasher);
+                if !out.is_empty() {
+                    return out;
+                }
+            }
+        }
+    }
+
+    // Fallback chain. A superseding strategy is about to re-process this
+    // element's representation and re-attempt the same (deterministic)
+    // cuts/booleans; discard the abandoned attempt's diagnostics so
+    // re-failures aren't double-counted. (The voids→plain-element
+    // mini-fallback below intentionally keeps its records: a failed/emptying
+    // cut that leaves the host uncut IS the diagnostic.)
+    let _ = router.take_csg_failures();
+
+    let mut mesh_candidate = router
+        .process_element_with_voids(job.entity, decoder, ctx.void_index)
+        .ok();
+    let needs_fallback = match mesh_candidate.as_ref() {
+        Some(mesh) => mesh.is_empty(),
+        None => true,
+    };
+    if needs_fallback {
+        mesh_candidate = router.process_element(job.entity, decoder).ok();
+    }
+
+    let Some(mut mesh) = mesh_candidate else {
+        return Vec::new();
+    };
+    if mesh.is_empty() {
+        return Vec::new();
+    }
+
+    // Multi-colour IfcIndexedColourMap → one mesh per palette group (#858),
+    // resolved by walking the element's representation for the colour-mapped
+    // face set. Only applies while the produced triangle count still matches
+    // the face set's CoordIndex (no CSG/void retopology) — the splitter
+    // guards this; otherwise the single dominant-coloured mesh below wins.
+    if !ctx.indexed_colour_full.is_empty() {
+        if let Some(full) =
+            find_indexed_colour_for_element(job.entity, ctx.indexed_colour_full, decoder)
+        {
+            let geometry_id = full.geometry_id;
+            if let Some(groups) = crate::style::split_mesh_by_indexed_colour(&mesh, full) {
+                if let Some(h) = hasher.as_mut() {
+                    h.add_mesh(&mesh.positions, &mesh.indices);
+                }
+                let mut out: Vec<MeshData> = Vec::with_capacity(groups.len());
+                for (color, mut part) in groups {
+                    if part.normals.len() != part.positions.len() {
+                        calculate_normals(&mut part);
+                    }
+                    out.push(build_mesh_data(
+                        job,
+                        part,
+                        color.to_array(),
+                        None,
+                        Some(geometry_id),
+                        0,
+                        ctx,
+                    ));
+                }
+                if !out.is_empty() {
+                    return out;
+                }
+            }
+        }
+    }
+
+    if mesh.normals.len() != mesh.positions.len() {
+        calculate_normals(&mut mesh);
+    }
+    if let Some(h) = hasher.as_mut() {
+        h.add_mesh(&mesh.positions, &mesh.indices);
+    }
+    vec![build_mesh_data(job, mesh, element_color, None, None, 0, ctx)]
+}
+
+/// Emit a sub-mesh collection: per-item colour resolution through the
+/// canonical `resolve_submesh_color` precedence (#913 §4.2), material-name
+/// inference for window/door parts, and the #858 per-item palette split.
+fn emit_sub_meshes(
+    job: &ElementMeshJob<'_>,
+    sub_meshes: SubMeshCollection,
+    element_color: [f32; 4],
+    ctx: &MeshProductionContext<'_>,
+    decoder: &mut EntityDecoder,
+    hasher: &mut Option<GeometryHasher>,
+) -> Vec<MeshData> {
+    let mut out: Vec<MeshData> = Vec::with_capacity(sub_meshes.len());
+    // Material colours for this element, used when a sub-mesh has no direct
+    // style — alternated so frame (opaque) and glazing (transparent) split
+    // across the window's parts (#913 §2.3).
+    let material_colors = ctx.element_material_colors.get(&job.id);
+    let mut mat_color_idx = 0usize;
+
+    for sub in sub_meshes.sub_meshes {
+        let mut sub_mesh = sub.mesh;
+        if sub_mesh.is_empty() {
+            continue;
+        }
+        if sub_mesh.normals.len() != sub_mesh.positions.len() {
+            calculate_normals(&mut sub_mesh);
+        }
+
+        let style = ctx.geometry_style_index.get(&sub.geometry_id);
+        // Direct style wins; else chase IfcMappedItem so mapped sub-geometry
+        // inherits its underlying style (#913 §2.7).
+        let direct_color = style.map(|s| s.color).or_else(|| {
+            find_geometry_item_color(sub.geometry_id, ctx.geometry_style_index, decoder)
+        });
+        let color = crate::style::resolve_submesh_color(
+            direct_color,
+            material_colors.map(|v| v.as_slice()),
+            &mut mat_color_idx,
+            element_color,
+        );
+        let material_name = style
+            .and_then(|s| s.material_name.as_ref())
+            .map(ToString::to_string)
+            .or_else(|| infer_opening_subpart_material_name(&job.ifc_type, color, sub.geometry_id));
+
+        if let Some(h) = hasher.as_mut() {
+            h.add_mesh(&sub_mesh.positions, &sub_mesh.indices);
+        }
+
+        // #858: a face set with a per-triangle colour map splits into one
+        // mesh per palette group (guards inside the splitter: triangle count
+        // must still match, ≥2 distinct colours). Palette colours supersede
+        // the resolved style colour for the split parts.
+        if let Some(full) = ctx.indexed_colour_full.get(&sub.geometry_id) {
+            if let Some(groups) = crate::style::split_mesh_by_indexed_colour(&sub_mesh, full) {
+                for (rgba, mut part) in groups {
+                    if part.normals.len() != part.positions.len() {
+                        calculate_normals(&mut part);
+                    }
+                    out.push(build_mesh_data(
+                        job,
+                        part,
+                        rgba.to_array(),
+                        None,
+                        Some(sub.geometry_id),
+                        0,
+                        ctx,
+                    ));
+                }
+                continue;
+            }
+        }
+
+        out.push(build_mesh_data(
+            job,
+            sub_mesh,
+            color,
+            material_name,
+            Some(sub.geometry_id),
+            0,
+            ctx,
+        ));
+    }
+    out
+}
+
+/// Render a type-product's planned RepresentationMaps (#957), texture-aware
+/// (#961), each mesh tagged with its planned geometry_class.
+fn produce_type_geometry(
+    job: &ElementMeshJob<'_>,
+    rep_maps: &[(u32, u8)],
+    element_color: [f32; 4],
+    ctx: &MeshProductionContext<'_>,
+    decoder: &mut EntityDecoder,
+    router: &GeometryRouter,
+) -> Vec<MeshData> {
+    let mut out: Vec<MeshData> = Vec::new();
+    for &(rep_map_id, geometry_class) in rep_maps {
+        let Ok(rep_map) = decoder.decode_by_id(rep_map_id) else {
+            continue;
+        };
+        // One part per output mesh: each textured face set carries its own
+        // UVs + decoded image; untextured items merge into one part (#961).
+        let Ok(parts) =
+            router.process_representation_map_with_texture(&rep_map, decoder, ctx.texture_index)
+        else {
+            continue;
+        };
+        if parts.is_empty() {
+            continue;
+        }
+
+        let color =
+            resolve_color_for_representation_map(rep_map_id, ctx.geometry_style_index, decoder)
+                .unwrap_or(element_color);
+
+        for (mut mesh, uvs, texture) in parts {
+            if mesh.is_empty() {
+                continue;
+            }
+            if mesh.normals.len() != mesh.positions.len() {
+                calculate_normals(&mut mesh);
+            }
+            let mut mesh_data =
+                build_mesh_data(job, mesh, color, None, None, geometry_class, ctx);
+            if let Some(tex) = texture {
+                mesh_data = mesh_data.with_texture(
+                    uvs,
+                    MeshTextureData {
+                        rgba: tex.rgba,
+                        width: tex.width,
+                        height: tex.height,
+                        repeat_s: tex.repeat_s,
+                        repeat_t: tex.repeat_t,
+                    },
+                );
+            }
+            out.push(mesh_data);
+        }
+    }
+    out
+}
+
+/// Construct the final [`MeshData`]: metadata stamp, style metadata,
+/// geometry-class tag, and the optional site-local rotation. ALWAYS the last
+/// step — geometry hashing happens before this (native IFC frame).
+fn build_mesh_data(
+    job: &ElementMeshJob<'_>,
+    mesh: Mesh,
+    color: [f32; 4],
+    material_name: Option<String>,
+    geometry_item_id: Option<u32>,
+    geometry_class: u8,
+    ctx: &MeshProductionContext<'_>,
+) -> MeshData {
+    let mut mesh_data = MeshData::new(
+        job.id,
+        job.ifc_type.name().to_string(),
+        mesh.positions,
+        mesh.normals,
+        mesh.indices,
+        color,
+    );
+    if let Some(meta) = job.metadata {
+        mesh_data = mesh_data
+            .with_element_metadata(
+                meta.global_id.clone(),
+                meta.name.clone(),
+                meta.presentation_layer.clone(),
+            )
+            .with_properties(meta.space_zone_properties.clone());
+    }
+    if material_name.is_some() || geometry_item_id.is_some() {
+        mesh_data = mesh_data.with_style_metadata(material_name, geometry_item_id);
+    }
+    if geometry_class != 0 {
+        mesh_data = mesh_data.with_geometry_class(geometry_class);
+    }
+    convert_mesh_to_site_local(&mut mesh_data, ctx.site_local_rotation);
+    mesh_data
+}
+
+/// Resolve a geometry item's authored colour: direct style on the item, else
+/// chase `IfcMappedItem → IfcRepresentationMap → MappedRepresentation.Items`
+/// recursively (#913 §2.7 — mapped sub-geometry inherits its underlying
+/// item's style).
+pub(crate) fn find_geometry_item_color(
+    geometry_id: u32,
+    geometry_styles: &FxHashMap<u32, GeometryStyleInfo>,
+    decoder: &mut EntityDecoder,
+) -> Option<[f32; 4]> {
+    // Direct style on this exact geometry item wins.
+    if let Some(style) = geometry_styles.get(&geometry_id) {
+        return Some(style.color);
+    }
+
+    // Otherwise, if it's a mapped item, chase the mapping to the underlying
+    // geometry and resolve there (recursing handles nested mapped items).
+    let geom = decoder.decode_by_id(geometry_id).ok()?;
+    if geom.ifc_type != IfcType::IfcMappedItem {
+        return None;
+    }
+    // IfcMappedItem.MappingSource (attr 0) → IfcRepresentationMap.
+    let mapping_source_id = geom.get_ref(0)?;
+    // IfcRepresentationMap.MappedRepresentation (attr 1) → IfcShapeRepresentation.
+    let representation_map = decoder.decode_by_id(mapping_source_id).ok()?;
+    let mapped_representation_id = representation_map.get_ref(1)?;
+    let mapped_representation = decoder.decode_by_id(mapped_representation_id).ok()?;
+    // IfcShapeRepresentation.Items (attr 3).
+    let items = get_refs_from_list(&mapped_representation, 3)?;
+    for underlying in items {
+        if let Some(color) = find_geometry_item_color(underlying, geometry_styles, decoder) {
+            return Some(color);
+        }
+    }
+    None
+}
+
+/// Resolve the authored colour for a type's `IfcRepresentationMap` (#957) by
+/// looking up its mapped geometry items in the styled-item index — the same
+/// index that colours ordinary products. `None` ⇒ caller falls back to the
+/// type's default colour.
+pub(crate) fn resolve_color_for_representation_map(
+    rep_map_id: u32,
+    geometry_style_index: &FxHashMap<u32, GeometryStyleInfo>,
+    decoder: &mut EntityDecoder,
+) -> Option<[f32; 4]> {
+    let rep_map = decoder.decode_by_id(rep_map_id).ok()?;
+    // IfcRepresentationMap.MappedRepresentation = attr 1.
+    let mapped_rep_id = rep_map.get_ref(1)?;
+    let mapped_rep = decoder.decode_by_id(mapped_rep_id).ok()?;
+    // IfcShapeRepresentation.Items = attr 3.
+    let item_ids = get_refs_from_list(&mapped_rep, 3)?;
+    for item_id in item_ids {
+        if let Some(style) = geometry_style_index.get(&item_id) {
+            return Some(style.color);
+        }
+        if let Some(color) = find_geometry_item_color(item_id, geometry_style_index, decoder) {
+            return Some(color);
+        }
+    }
+    None
+}
+
+/// Find the first representation item of `entity` that carries a full
+/// `IfcIndexedColourMap` (#858). Drives the element-level palette split on
+/// the single-mesh fallback path.
+pub(crate) fn find_indexed_colour_for_element<'a>(
+    entity: &DecodedEntity,
+    indexed_colour_full: &'a FxHashMap<u32, FullIndexedColourMap>,
+    decoder: &mut EntityDecoder,
+) -> Option<&'a FullIndexedColourMap> {
+    let pds_id = entity.get_ref(6)?;
+    let pds = decoder.decode_by_id(pds_id).ok()?;
+    let repr_ids = get_refs_from_list(&pds, 2)?;
+    for repr_id in repr_ids {
+        if let Ok(repr) = decoder.decode_by_id(repr_id) {
+            if let Some(items) = get_refs_from_list(&repr, 3) {
+                for item_id in items {
+                    if let Some(full) = indexed_colour_full.get(&item_id) {
+                        return Some(full);
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+fn is_opening_with_subparts(ifc_type: &IfcType) -> bool {
+    matches!(ifc_type, IfcType::IfcWindow | IfcType::IfcDoor)
+}
+
+/// Synthesize a material name for window/door sub-parts that carry no
+/// authored style: transparency is a practical proxy for glazing in many BIM
+/// exports.
+pub(crate) fn infer_opening_subpart_material_name(
+    ifc_type: &IfcType,
+    color: [f32; 4],
+    geometry_id: u32,
+) -> Option<String> {
+    if !is_opening_with_subparts(ifc_type) {
+        return None;
+    }
+
+    let prefix = match ifc_type {
+        IfcType::IfcDoor => "Door",
+        _ => "Window",
+    };
+
+    if color[3] <= 0.65 {
+        return Some(format!("{}_Glass", prefix));
+    }
+
+    Some(format!("{}_Frame_{}", prefix, geometry_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn refs(ids: &[u32]) -> FxHashSet<u32> {
+        ids.iter().copied().collect()
+    }
+
+    #[test]
+    fn plan_type_geometry_orphan_type_emits_unreferenced_maps_as_class_1() {
+        for mode in [TypeGeometryMode::SuppressInstanced, TypeGeometryMode::EmitTagged] {
+            let planned = plan_type_geometry(&[10, 11, 12], &refs(&[11]), false, mode);
+            assert_eq!(
+                planned,
+                vec![(10, 1), (12, 1)],
+                "orphan type: unreferenced maps render as class 1 in {mode:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn plan_type_geometry_instantiated_type_suppressed_for_export_tagged_for_viewer() {
+        let suppress = plan_type_geometry(
+            &[10, 11],
+            &refs(&[]),
+            true,
+            TypeGeometryMode::SuppressInstanced,
+        );
+        assert!(
+            suppress.is_empty(),
+            "an export must never duplicate an instanced type's geometry"
+        );
+
+        let tagged =
+            plan_type_geometry(&[10, 11], &refs(&[]), true, TypeGeometryMode::EmitTagged);
+        assert_eq!(
+            tagged,
+            vec![(10, 2), (11, 2)],
+            "the viewer renders instanced type maps tagged class 2 for the Types view"
+        );
+    }
+
+    #[test]
+    fn plan_type_geometry_referenced_maps_never_emit() {
+        let planned = plan_type_geometry(
+            &[10],
+            &refs(&[10]),
+            false,
+            TypeGeometryMode::EmitTagged,
+        );
+        assert!(
+            planned.is_empty(),
+            "a map an IfcMappedItem instantiates draws through its occurrence"
+        );
+    }
+
+    #[test]
+    fn find_geometry_item_color_follows_mapped_item() {
+        // #100 IfcMappedItem → #101 IfcRepresentationMap → #103
+        // IfcShapeRepresentation whose Items = (#110). The style lives on the
+        // underlying item #110, not on the mapped item, so a flat lookup of
+        // #100 misses it — the resolver must chase the mapping (#913 §2.7).
+        const IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('m.ifc','2026-06-04T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,$,$);
+#100=IFCMAPPEDITEM(#101,#105);
+#101=IFCREPRESENTATIONMAP(#102,#103);
+#102=IFCAXIS2PLACEMENT3D(#104,$,$);
+#103=IFCSHAPEREPRESENTATION(#2,'Body','MappedRepresentation',(#110));
+#104=IFCCARTESIANPOINT((0.,0.,0.));
+#105=IFCCARTESIANTRANSFORMATIONOPERATOR3D($,$,#104,$,$);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+        let blue = [0.1, 0.2, 0.9, 1.0];
+        let mut styles: FxHashMap<u32, GeometryStyleInfo> = FxHashMap::default();
+        styles.insert(110, GeometryStyleInfo::from_color(blue));
+
+        let mut decoder = EntityDecoder::new(IFC);
+
+        // Mapped item, no direct style → inherits the underlying item's colour.
+        assert_eq!(find_geometry_item_color(100, &styles, &mut decoder), Some(blue));
+        // A direct style still wins.
+        assert_eq!(find_geometry_item_color(110, &styles, &mut decoder), Some(blue));
+        // A non-mapped, unstyled item (the representation map itself) → None.
+        assert_eq!(find_geometry_item_color(101, &styles, &mut decoder), None);
+    }
+
+    #[test]
+    fn infer_opening_material_names_glass_vs_frame() {
+        let glass =
+            infer_opening_subpart_material_name(&IfcType::IfcWindow, [0.7, 0.9, 0.5, 0.3], 42);
+        assert_eq!(glass.as_deref(), Some("Window_Glass"));
+
+        let frame =
+            infer_opening_subpart_material_name(&IfcType::IfcDoor, [0.5, 0.5, 0.5, 1.0], 7);
+        assert_eq!(frame.as_deref(), Some("Door_Frame_7"));
+
+        let none = infer_opening_subpart_material_name(&IfcType::IfcWall, [1.0; 4], 1);
+        assert!(none.is_none(), "only windows/doors get inferred part names");
+    }
+}

--- a/rust/processing/src/lib.rs
+++ b/rust/processing/src/lib.rs
@@ -7,6 +7,7 @@
 //! This crate extracts the core processing logic so it can be used by both
 //! the HTTP server and the native FFI library.
 
+pub mod element;
 mod georeferencing;
 mod processor;
 pub mod style;

--- a/rust/processing/src/processor.rs
+++ b/rust/processing/src/processor.rs
@@ -16,7 +16,7 @@ use ifc_lite_core::{
     EntityIndex, EntityScanner, IfcType,
 };
 use ifc_lite_geometry::TessellationQuality;
-use ifc_lite_geometry::{calculate_normals, GeometryRouter};
+use ifc_lite_geometry::GeometryRouter;
 use rayon::prelude::*;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -249,22 +249,10 @@ fn populate_entity_job_metadata(
     }
 }
 
-#[derive(Debug, Clone)]
-struct GeometryStyleInfo {
-    /// Apparent colour for rendering: IfcSurfaceStyleRendering.DiffuseColour
-    /// when authored, otherwise the SurfaceColour. Matches what most IFC
-    /// viewers display.
-    color: [f32; 4],
-    /// SurfaceColour, populated only when the file authored a distinct
-    /// DiffuseColour. Read by the WASM bridge's parallel extractor so the
-    /// GLB exporter can offer "Shading" as a colour source; the
-    /// processing-crate `MeshData` doesn't propagate it (server pipeline
-    /// has no GLB consumer yet), so the field is intentionally read-only
-    /// here.
-    #[allow(dead_code)]
-    shading_color: Option<[f32; 4]>,
-    material_name: Option<String>,
-}
+// `GeometryStyleInfo` moved to `crate::style` — it is shared by this
+// orchestrator, the canonical per-element producer (`crate::element`), and
+// (via `from_color`) the browser batch path.
+use crate::style::GeometryStyleInfo;
 
 #[derive(Debug, Clone)]
 struct PropertySetDefinition {
@@ -279,7 +267,7 @@ struct RelDefinesByPropertiesLink {
 }
 
 /// Extract entity references from a list attribute.
-fn get_refs_from_list(entity: &DecodedEntity, index: usize) -> Option<Vec<u32>> {
+pub(crate) fn get_refs_from_list(entity: &DecodedEntity, index: usize) -> Option<Vec<u32>> {
     let list = entity.get_list(index)?;
     let refs: Vec<u32> = list.iter().filter_map(|v| v.as_entity_ref()).collect();
     if refs.is_empty() {
@@ -1210,18 +1198,19 @@ pub fn process_geometry_streaming_filtered_with_options(
     // buildingSMART annex-E "tessellated shape with style" files declare the
     // geometry only on the type, so without this they render nothing (#957).
     for (type_id, start, end, ifc_type, rep_map_ids) in &type_product_geometry {
-        // A type with occurrences (IfcRelDefinesByType) already renders through
-        // them; only genuinely orphan types (no occurrence) render their own map.
-        if instantiated_type_ids.contains(type_id) {
-            continue;
-        }
-        for &rep_map_id in rep_map_ids {
-            if referenced_representation_maps.contains(&rep_map_id) {
-                continue;
-            }
+        // The orphan/instanced decision is canonical in
+        // `element::plan_type_geometry`; the native pipeline suppresses
+        // instanced types entirely (an export must never duplicate geometry),
+        // so every planned map here renders as an orphan (class 1).
+        for (rep_map_id, _class) in crate::element::plan_type_geometry(
+            rep_map_ids,
+            &referenced_representation_maps,
+            instantiated_type_ids.contains(type_id),
+            crate::element::TypeGeometryMode::SuppressInstanced,
+        ) {
             entity_jobs.push(EntityJob {
                 id: *type_id,
-                ifc_type: ifc_type.clone(),
+                ifc_type: *ifc_type,
                 start: *start,
                 end: *end,
                 product_definition_shape_id: None,
@@ -1739,381 +1728,64 @@ fn process_entity_job(
         Err(_) => return Vec::new(),
     };
 
-    let has_representation = entity.get(6).is_some_and(|a| !a.is_null());
-    if !has_representation {
-        return Vec::new();
-    }
-
     let mut local_router = GeometryRouter::with_scale_and_quality(unit_scale, tessellation_quality);
     local_router.set_rtc_offset(rtc_offset);
     let local_router = local_router;
-    let result = (|| -> Vec<MeshData> {
-    let global_id = job.global_id.clone();
-    let name = job.name.clone();
-    let presentation_layer = job.presentation_layer.clone();
-    let space_zone_properties = job.space_zone_properties.clone();
-    let element_color = job.element_color;
 
-    // #957: synthetic type-only-geometry job — render the orphan
-    // RepresentationMap directly (baking its MappingOrigin) instead of walking
-    // the product's IfcProductDefinitionShape (a type has none).
-    if let Some(rep_map_id) = job.representation_map_id {
-        return process_type_representation_map_job(
-            job,
-            rep_map_id,
-            &local_router,
-            &mut local_decoder,
-            geometry_style_index,
-            texture_index,
-            element_color,
-            global_id,
-            name,
-            presentation_layer,
-            site_local_rotation,
-        );
-    }
-
-    let has_openings = void_index.get(&job.id).is_some_and(|v| !v.is_empty());
-
-    // Shared per-sub emission: per-item colour resolution through the
-    // canonical `resolve_submesh_color` precedence (#913 §4.2), identical to
-    // the wasm `processGeometryBatch` path so browser and backend can't
-    // drift on sub-mesh colouring.
-    let mut emit_sub_meshes = |sub_meshes: ifc_lite_geometry::SubMeshCollection,
-                               local_decoder: &mut EntityDecoder|
-     -> Vec<MeshData> {
-        let mut out: Vec<MeshData> = Vec::with_capacity(sub_meshes.len());
-        // Material colours for this element, used when a sub-mesh has no
-        // direct style — alternated so frame (opaque) and glazing
-        // (transparent) split across the window's parts (#913 §2.3).
-        let material_colors = element_material_colors.get(&job.id);
-        let mut mat_color_idx = 0usize;
-
-        for sub in sub_meshes.sub_meshes {
-            let mut sub_mesh = sub.mesh;
-            if sub_mesh.is_empty() {
-                continue;
-            }
-
-            if sub_mesh.normals.is_empty() {
-                calculate_normals(&mut sub_mesh);
-            }
-
-            let style = geometry_style_index.get(&sub.geometry_id);
-            // Direct style wins; else chase IfcMappedItem so mapped
-            // sub-geometry inherits its underlying style (#913 §2.7).
-            let direct_color = style.map(|s| s.color).or_else(|| {
-                find_geometry_item_color(sub.geometry_id, geometry_style_index, local_decoder)
-            });
-            let color = crate::style::resolve_submesh_color(
-                direct_color,
-                material_colors.map(|v| v.as_slice()),
-                &mut mat_color_idx,
-                element_color,
-            );
-            let material_name = style
-                .and_then(|s| s.material_name.as_ref())
-                .map(ToString::to_string);
-            let material_name = material_name.or_else(|| {
-                infer_opening_subpart_material_name(&job.ifc_type, color, sub.geometry_id)
-            });
-
-            let mut mesh_data = MeshData::new(
-                job.id,
-                job.ifc_type.name().to_string(),
-                sub_mesh.positions,
-                sub_mesh.normals,
-                sub_mesh.indices,
-                color,
-            )
-            .with_element_metadata(global_id.clone(), name.clone(), presentation_layer.clone())
-            .with_properties(space_zone_properties.clone())
-            .with_style_metadata(material_name, Some(sub.geometry_id));
-            convert_mesh_to_site_local(&mut mesh_data, site_local_rotation);
-            out.push(mesh_data);
-        }
-        out
+    let metadata = crate::element::ElementMeshMetadata {
+        global_id: job.global_id.clone(),
+        name: job.name.clone(),
+        presentation_layer: job.presentation_layer.clone(),
+        space_zone_properties: job.space_zone_properties.clone(),
+    };
+    // #957: the scan loop plans type geometry with `SuppressInstanced` (see
+    // `plan_type_geometry`), so a synthetic job's map always renders as an
+    // orphan — geometry_class 1.
+    let kind = match job.representation_map_id {
+        Some(rep_map_id) => crate::element::ElementJobKind::TypeProduct {
+            rep_maps: vec![(rep_map_id, 1)],
+        },
+        None => crate::element::ElementJobKind::Product,
+    };
+    let ctx = crate::element::MeshProductionContext {
+        void_index,
+        geometry_style_index,
+        indexed_colour_full,
+        element_material_colors,
+        texture_index,
+        site_local_rotation,
     };
 
-    if has_openings {
-        // Voided elements FIRST — branch order matches the wasm path, so a
-        // voided window is CUT rather than rendered uncut-as-subparts.
-        // Prefer the submesh-aware cut (per-part colours survive the void
-        // subtraction); the single-mesh cut below stays as the fallback.
-        if let Ok(sub_meshes) = local_router.process_element_with_submeshes_and_voids(
-            &entity,
-            &mut local_decoder,
-            void_index,
-        ) {
-            if !sub_meshes.is_empty() {
-                let out = emit_sub_meshes(sub_meshes, &mut local_decoder);
-                if !out.is_empty() {
-                    return out;
-                }
-            }
-        }
-    } else {
-        // #858: an IfcIndexedColourMap colours faces of a single face set —
-        // those elements keep the single-mesh + palette-split path below.
-        let has_indexed_colour = !indexed_colour_full.is_empty()
-            && find_indexed_colour_for_element(&entity, indexed_colour_full, &mut local_decoder)
-                .is_some();
-        if !has_indexed_colour {
-            // Submesh path for ALL types (parity with `processGeometryBatch`):
-            // per-item colours AND per-item error skipping — one unsupported
-            // representation item no longer makes the whole element invisible
-            // in server/parquet output while it renders partially in the
-            // browser.
-            if let Ok(sub_meshes) =
-                local_router.process_element_with_submeshes(&entity, &mut local_decoder)
-            {
-                if !sub_meshes.is_empty() {
-                    let out = emit_sub_meshes(sub_meshes, &mut local_decoder);
-                    if !out.is_empty() {
-                        return out;
-                    }
-                }
-            }
-        }
-    }
+    let produced = crate::element::produce_element_meshes(
+        &crate::element::ElementMeshJob {
+            id: job.id,
+            ifc_type: job.ifc_type,
+            entity: &entity,
+            kind,
+            element_color: Some(job.element_color),
+            metadata: Some(&metadata),
+        },
+        &ctx,
+        // Geometry hashing is a viewer diff feature — off on the native path.
+        &crate::element::MeshProductionOptions::default(),
+        &mut local_decoder,
+        &local_router,
+    );
 
-    // A superseding strategy is about to re-process this element's
-    // representation and re-attempt the same (deterministic) cuts/booleans.
-    // Discard the abandoned attempt's diagnostics so only the path that
-    // actually produced the returned meshes contributes to
-    // total_csg_failures / products_with_failures — otherwise re-failures
-    // are double-counted. (`take_csg_failures` is the drain == clear; the
-    // voids→plain-element mini-fallback below intentionally keeps its
-    // records: a failed/emptying cut that leaves the host uncut IS the
-    // diagnostic.)
-    let _ = local_router.take_csg_failures();
-
-    let mut mesh_candidate = local_router
-        .process_element_with_voids(&entity, &mut local_decoder, void_index)
-        .ok();
-    let needs_fallback = match mesh_candidate.as_ref() {
-        Some(mesh) => mesh.is_empty(),
-        None => true,
-    };
-    if needs_fallback {
-        mesh_candidate = local_router
-            .process_element(&entity, &mut local_decoder)
-            .ok();
-    }
-
-    if let Some(mut mesh) = mesh_candidate {
-        if !mesh.is_empty() {
-            // Multi-colour IfcIndexedColourMap → one sub-mesh per palette group
-            // (#858). Only applies when the produced triangle count still
-            // matches the face set's CoordIndex (no CSG/void retopology);
-            // otherwise we keep the single dominant-coloured mesh below.
-            if !indexed_colour_full.is_empty() {
-                if let Some(full) = find_indexed_colour_for_element(
-                    &entity,
-                    indexed_colour_full,
-                    &mut local_decoder,
-                ) {
-                    let geometry_id = full.geometry_id;
-                    if let Some(groups) = crate::style::split_mesh_by_indexed_colour(&mesh, full) {
-                        let mut out: Vec<MeshData> = Vec::with_capacity(groups.len());
-                        for (color, mut part) in groups {
-                            if part.normals.is_empty() {
-                                calculate_normals(&mut part);
-                            }
-                            let mut mesh_data = MeshData::new(
-                                job.id,
-                                job.ifc_type.name().to_string(),
-                                part.positions,
-                                part.normals,
-                                part.indices,
-                                color.to_array(),
-                            )
-                            .with_element_metadata(
-                                global_id.clone(),
-                                name.clone(),
-                                presentation_layer.clone(),
-                            )
-                            .with_properties(space_zone_properties.clone())
-                            .with_style_metadata(None, Some(geometry_id));
-                            convert_mesh_to_site_local(&mut mesh_data, site_local_rotation);
-                            out.push(mesh_data);
-                        }
-                        if !out.is_empty() {
-                            return out;
-                        }
-                    }
-                }
-            }
-
-            if mesh.normals.is_empty() {
-                calculate_normals(&mut mesh);
-            }
-
-            let mut mesh_data = MeshData::new(
-                job.id,
-                job.ifc_type.name().to_string(),
-                mesh.positions,
-                mesh.normals,
-                mesh.indices,
-                element_color,
-            )
-            .with_element_metadata(global_id, name, presentation_layer)
-            .with_properties(space_zone_properties);
-            convert_mesh_to_site_local(&mut mesh_data, site_local_rotation);
-            return vec![mesh_data];
-        }
-    }
-
-    Vec::new()
-    })();
-
-    // Drain the per-job router's CSG diagnostics into the shared collector
-    // BEFORE the router drops. The wasm path surfaces these in the browser
-    // console (`drain_and_log_csg_diagnostics`); without this drain the
-    // server silently discarded every failed opening cut, and the
-    // thread-local pending mapped-boolean buffer accumulated across
-    // requests on the long-lived rayon pool threads.
-    let failures = local_router.take_csg_failures();
-    if !failures.is_empty() {
+    // Surface this element's CSG diagnostics in the shared collector. The
+    // wasm path logs them in the browser console; without this the server
+    // would silently discard every failed opening cut.
+    if !produced.csg_failures.is_empty() {
         if let Ok(mut collector) = csg_failure_collector.lock() {
-            for (product_id, fails) in failures {
+            for (product_id, fails) in produced.csg_failures {
                 collector.entry(product_id).or_default().extend(fails);
             }
         }
     }
 
-    result
+    produced.meshes
 }
 
-/// Render an orphan type-product `IfcRepresentationMap` (issue #957).
-///
-/// Tessellates the map's `MappedRepresentation` (baking its MappingOrigin) and
-/// builds a single [`MeshData`] keyed on the type's express id. The colour is
-/// resolved from the mapped geometry's `IfcStyledItem` chain when present (the
-/// blob/image/pixel-texture annex-E fixtures author a white `IfcSurfaceStyle`),
-/// otherwise the type's default colour. Texture fidelity is layered on
-/// separately; this path makes the geometry visible.
-#[allow(clippy::too_many_arguments)]
-fn process_type_representation_map_job(
-    job: &EntityJob,
-    rep_map_id: u32,
-    router: &GeometryRouter,
-    decoder: &mut EntityDecoder,
-    geometry_style_index: &FxHashMap<u32, GeometryStyleInfo>,
-    texture_index: &FxHashMap<u32, ifc_lite_geometry::ResolvedTextureMap>,
-    element_color: [f32; 4],
-    global_id: Option<String>,
-    name: Option<String>,
-    presentation_layer: Option<String>,
-    site_local_rotation: Option<&Vec<f64>>,
-) -> Vec<MeshData> {
-    let Ok(rep_map) = decoder.decode_by_id(rep_map_id) else {
-        return Vec::new();
-    };
-    // Texture-aware build (#961): one part per output mesh — each textured face
-    // set carries its own UVs + decoded image; untextured items merge into one
-    // part with no texture.
-    let Ok(parts) =
-        router.process_representation_map_with_texture(&rep_map, decoder, texture_index)
-    else {
-        return Vec::new();
-    };
-    if parts.is_empty() {
-        return Vec::new();
-    }
-
-    let color = resolve_color_for_representation_map(rep_map_id, geometry_style_index, decoder)
-        .unwrap_or(element_color);
-
-    let mut out: Vec<MeshData> = Vec::with_capacity(parts.len());
-    for (mut mesh, uvs, texture) in parts {
-        if mesh.is_empty() {
-            continue;
-        }
-        if mesh.normals.is_empty() {
-            calculate_normals(&mut mesh);
-        }
-        let mut mesh_data = MeshData::new(
-            job.id,
-            job.ifc_type.name().to_string(),
-            mesh.positions,
-            mesh.normals,
-            mesh.indices,
-            color,
-        )
-        .with_element_metadata(global_id.clone(), name.clone(), presentation_layer.clone());
-
-        // Attach the decoded texture + UVs (#961). `convert_mesh_to_site_local`
-        // rotates positions/normals only; UVs are 2D and pass through unchanged.
-        if let Some(tex) = texture {
-            mesh_data = mesh_data.with_texture(
-                uvs,
-                crate::types::mesh::MeshTextureData {
-                    rgba: tex.rgba,
-                    width: tex.width,
-                    height: tex.height,
-                    repeat_s: tex.repeat_s,
-                    repeat_t: tex.repeat_t,
-                },
-            );
-        }
-
-        convert_mesh_to_site_local(&mut mesh_data, site_local_rotation);
-        out.push(mesh_data);
-    }
-    out
-}
-
-/// Resolve the authored colour for a type's `IfcRepresentationMap` (issue #957)
-/// by looking up its mapped geometry items in the styled-item index — the same
-/// index that colours ordinary products. Returns `None` when no item carries a
-/// style (caller falls back to the type's default colour).
-fn resolve_color_for_representation_map(
-    rep_map_id: u32,
-    geometry_style_index: &FxHashMap<u32, GeometryStyleInfo>,
-    decoder: &mut EntityDecoder,
-) -> Option<[f32; 4]> {
-    let rep_map = decoder.decode_by_id(rep_map_id).ok()?;
-    // IfcRepresentationMap.MappedRepresentation = attr 1.
-    let mapped_rep_id = rep_map.get_ref(1)?;
-    let mapped_rep = decoder.decode_by_id(mapped_rep_id).ok()?;
-    // IfcShapeRepresentation.Items = attr 3.
-    let item_ids = get_refs_from_list(&mapped_rep, 3)?;
-    for item_id in item_ids {
-        if let Some(style) = geometry_style_index.get(&item_id) {
-            return Some(style.color);
-        }
-        if let Some(color) = find_geometry_item_color(item_id, geometry_style_index, decoder) {
-            return Some(color);
-        }
-    }
-    None
-}
-
-/// Find the first representation item of `entity` that carries a full
-/// `IfcIndexedColourMap` (issue #858). Used to drive per-triangle sub-mesh
-/// splitting in the single-mesh emission path.
-fn find_indexed_colour_for_element<'a>(
-    entity: &DecodedEntity,
-    indexed_colour_full: &'a FxHashMap<u32, crate::style::FullIndexedColourMap>,
-    decoder: &mut EntityDecoder,
-) -> Option<&'a crate::style::FullIndexedColourMap> {
-    let pds_id = entity.get_ref(6)?;
-    let pds = decoder.decode_by_id(pds_id).ok()?;
-    let repr_ids = get_refs_from_list(&pds, 2)?;
-    for repr_id in repr_ids {
-        if let Ok(repr) = decoder.decode_by_id(repr_id) {
-            if let Some(items) = get_refs_from_list(&repr, 3) {
-                for item_id in items {
-                    if let Some(full) = indexed_colour_full.get(&item_id) {
-                        return Some(full);
-                    }
-                }
-            }
-        }
-    }
-    None
-}
 
 /// Fold `IfcIndexedColourMap` colours into the style index, keyed by target
 /// geometry id. `or_insert` preserves IFCSTYLEDITEM precedence: a geometry that
@@ -2167,9 +1839,11 @@ fn build_color_updates_for_jobs(
         // or a deferred IfcStyledItem (fast_first_batch) leaves the orphan type
         // geometry stuck at its fallback colour.
         if let Some(rep_map_id) = job.representation_map_id {
-            if let Some(color) =
-                resolve_color_for_representation_map(rep_map_id, geometry_styles, &mut decoder)
-            {
+            if let Some(color) = crate::element::resolve_color_for_representation_map(
+                rep_map_id,
+                geometry_styles,
+                &mut decoder,
+            ) {
                 if color != job.element_color {
                     updates.push((job.id, color));
                 }
@@ -2377,44 +2051,6 @@ fn find_color_in_shape_representation(
         }
     }
 
-    None
-}
-
-/// Resolve a single geometry item's colour, following `IfcMappedItem` into its
-/// mapped representation when the item itself carries no direct style. Mirrors
-/// the browser's `find_color_for_geometry` so mapped / instanced sub-geometry
-/// inherits its underlying style in the sub-mesh path too (issue #913 §2.7) —
-/// the element-level walk (`find_color_in_representation`) already did this, but
-/// the per-sub-mesh lookup was a flat `geometry_styles.get`.
-fn find_geometry_item_color(
-    geometry_id: u32,
-    geometry_styles: &FxHashMap<u32, GeometryStyleInfo>,
-    decoder: &mut EntityDecoder,
-) -> Option<[f32; 4]> {
-    // Direct style on this exact geometry item wins.
-    if let Some(style) = geometry_styles.get(&geometry_id) {
-        return Some(style.color);
-    }
-
-    // Otherwise, if it's a mapped item, chase the mapping to the underlying
-    // geometry and resolve there (recursing handles nested mapped items).
-    let geom = decoder.decode_by_id(geometry_id).ok()?;
-    if geom.ifc_type != IfcType::IfcMappedItem {
-        return None;
-    }
-    // IfcMappedItem.MappingSource (attr 0) → IfcRepresentationMap.
-    let mapping_source_id = geom.get_ref(0)?;
-    // IfcRepresentationMap.MappedRepresentation (attr 1) → IfcShapeRepresentation.
-    let representation_map = decoder.decode_by_id(mapping_source_id).ok()?;
-    let mapped_representation_id = representation_map.get_ref(1)?;
-    let mapped_representation = decoder.decode_by_id(mapped_representation_id).ok()?;
-    // IfcShapeRepresentation.Items (attr 3).
-    let items = get_refs_from_list(&mapped_representation, 3)?;
-    for underlying in items {
-        if let Some(color) = find_geometry_item_color(underlying, geometry_styles, decoder) {
-            return Some(color);
-        }
-    }
     None
 }
 
@@ -2669,31 +2305,6 @@ fn has_glass_style(style: &GeometryStyleInfo) -> bool {
     false
 }
 
-fn is_opening_with_subparts(ifc_type: &IfcType) -> bool {
-    matches!(ifc_type, IfcType::IfcWindow | IfcType::IfcDoor)
-}
-
-fn infer_opening_subpart_material_name(
-    ifc_type: &IfcType,
-    color: [f32; 4],
-    geometry_id: u32,
-) -> Option<String> {
-    if !is_opening_with_subparts(ifc_type) {
-        return None;
-    }
-
-    let prefix = match ifc_type {
-        IfcType::IfcDoor => "Door",
-        _ => "Window",
-    };
-
-    // Transparency is a practical proxy for glazing in many BIM exports.
-    if color[3] <= 0.65 {
-        return Some(format!("{}_Glass", prefix));
-    }
-
-    Some(format!("{}_Frame_{}", prefix, geometry_id))
-}
 
 // Default IFC-type colors now come from the single canonical table in
 // `crate::style::default_color_for_type` (issue #913). Do not reintroduce a
@@ -2707,54 +2318,6 @@ mod tests {
         pairs.iter().map(|(k, v)| (*k, v.to_vec())).collect()
     }
 
-    #[test]
-    fn find_geometry_item_color_follows_mapped_item() {
-        // #100 IfcMappedItem → #101 IfcRepresentationMap → #103
-        // IfcShapeRepresentation whose Items = (#110). The style lives on the
-        // underlying item #110, not on the mapped item, so a flat lookup of
-        // #100 misses it — the resolver must chase the mapping (#913 §2.7).
-        const IFC: &str = r#"ISO-10303-21;
-HEADER;
-FILE_DESCRIPTION((''),'2;1');
-FILE_NAME('m.ifc','2026-06-04T00:00:00',(''),(''),'','','');
-FILE_SCHEMA(('IFC4'));
-ENDSEC;
-DATA;
-#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,$,$);
-#100=IFCMAPPEDITEM(#101,#105);
-#101=IFCREPRESENTATIONMAP(#102,#103);
-#102=IFCAXIS2PLACEMENT3D(#104,$,$);
-#103=IFCSHAPEREPRESENTATION(#2,'Body','MappedRepresentation',(#110));
-#104=IFCCARTESIANPOINT((0.,0.,0.));
-#105=IFCCARTESIANTRANSFORMATIONOPERATOR3D($,$,#104,$,$);
-ENDSEC;
-END-ISO-10303-21;
-"#;
-        let blue = [0.1, 0.2, 0.9, 1.0];
-        let mut styles: FxHashMap<u32, GeometryStyleInfo> = FxHashMap::default();
-        styles.insert(
-            110,
-            GeometryStyleInfo {
-                color: blue,
-                shading_color: None,
-                material_name: None,
-            },
-        );
-
-        let mut decoder = EntityDecoder::new(IFC);
-
-        // Mapped item, no direct style → inherits the underlying item's colour.
-        assert_eq!(
-            find_geometry_item_color(100, &styles, &mut decoder),
-            Some(blue)
-        );
-        // A direct style still wins.
-        assert_eq!(
-            find_geometry_item_color(110, &styles, &mut decoder),
-            Some(blue)
-        );
-        // A non-mapped, unstyled item (the representation map itself) → None.
-        assert_eq!(find_geometry_item_color(101, &styles, &mut decoder), None);
-    }
-
+    // `find_geometry_item_color_follows_mapped_item` lives in
+    // `crate::element::tests`, next to the resolver it pins.
 }

--- a/rust/processing/src/style/mod.rs
+++ b/rust/processing/src/style/mod.rs
@@ -54,6 +54,41 @@ pub use surface::extract_surface_style_colors;
 /// vs frame (opaque) styles. Matches the browser's `TRANSPARENCY_ALPHA_THRESHOLD`.
 pub const TRANSPARENCY_ALPHA_THRESHOLD: f32 = 0.95;
 
+/// Resolved appearance of one geometry item (the value side of the
+/// styled-item index keyed by geometry express id).
+///
+/// Lives here — not in `processor.rs` — because it is shared by the native
+/// pipeline, the canonical per-element producer ([`crate::element`]), and the
+/// browser `wasm-bindings` batch path, which lifts its flat `(id, rgba8)`
+/// wire arrays into this richer form via [`GeometryStyleInfo::from_color`].
+#[derive(Debug, Clone)]
+pub struct GeometryStyleInfo {
+    /// Apparent colour for rendering: IfcSurfaceStyleRendering.DiffuseColour
+    /// when authored, otherwise the SurfaceColour. Matches what most IFC
+    /// viewers display.
+    pub color: [f32; 4],
+    /// SurfaceColour, populated only when the file authored a distinct
+    /// DiffuseColour. Read by the WASM bridge's parallel extractor so the
+    /// GLB exporter can offer "Shading" as a colour source; the
+    /// processing-crate `MeshData` doesn't propagate it (server pipeline
+    /// has no GLB consumer yet).
+    pub shading_color: Option<[f32; 4]>,
+    pub material_name: Option<String>,
+}
+
+impl GeometryStyleInfo {
+    /// Lift a bare RGBA colour (e.g. from the browser prepass's flat
+    /// `styleIds`/`styleColors` wire arrays) into the rich form. No shading
+    /// colour, no material name — exactly the fidelity the wire carries.
+    pub fn from_color(color: [f32; 4]) -> Self {
+        Self {
+            color,
+            shading_color: None,
+            material_name: None,
+        }
+    }
+}
+
 /// Canonical straight-alpha RGBA color, components in `0.0..=1.0`.
 ///
 /// Serializes transparently as a bare `[f32; 4]` JSON array, so it is a

--- a/rust/processing/src/types/mesh.rs
+++ b/rust/processing/src/types/mesh.rs
@@ -62,6 +62,18 @@ pub struct MeshData {
     /// Decoded surface texture, present only for textured meshes (#961).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub texture: Option<MeshTextureData>,
+    /// Provenance of the geometry for the viewer's Model/Types switch (#957):
+    /// 0 = ordinary occurrence, 1 = orphan type-product RepresentationMap (no
+    /// occurrence instantiates it), 2 = instanced type-product map (the type
+    /// library shape; its occurrences already draw the real geometry).
+    /// Serde-default so existing JSON payloads and disk caches stay readable;
+    /// skipped when 0 so ordinary meshes serialize byte-identically.
+    #[serde(default, skip_serializing_if = "geometry_class_is_occurrence")]
+    pub geometry_class: u8,
+}
+
+fn geometry_class_is_occurrence(class: &u8) -> bool {
+    *class == 0
 }
 
 impl MeshData {
@@ -89,7 +101,14 @@ impl MeshData {
             properties: None,
             uvs: None,
             texture: None,
+            geometry_class: 0,
         }
+    }
+
+    /// Tag the geometry's provenance for the Model/Types view switch (#957).
+    pub fn with_geometry_class(mut self, geometry_class: u8) -> Self {
+        self.geometry_class = geometry_class;
+        self
     }
 
     /// Attach per-vertex UVs + a decoded surface texture (issue #961).


### PR DESCRIPTION
## What

Step 2 of the pipeline-unification series (stacked on #1080). The per-element decision tree that turns one IFC product (or #957 type-product RepresentationMap) into meshes existed **twice** — inlined in `processor.rs` (native) and in the wasm `processGeometryBatch` loop — and fixes had to land in both (#858, #913, #957, #961, #1071 all bit this). It now exists exactly once: **`rust/processing/src/element.rs`**.

- `produce_element_meshes(job, ctx, opts, decoder, router)` — the converged tree:
  representation gate (IfcAlignment exempt) → type-product arm (#957, textures #961, `geometry_class` tag) → submesh-aware void cut / submesh-for-all-types with per-item #858 palette split → single-mesh fallback chain (voids → plain element → element-level #858 split). Decoder/router are caller-supplied: the native rayon loop keeps its fresh-seeded-per-element policy, the wasm batch path (next PR) its warm per-batch pair. Per-element geometry hashing (#971/#924) and metadata stamping are config, not forks.
- `plan_type_geometry(...)` + `TypeGeometryMode::{SuppressInstanced, EmitTagged}` — the #957 orphan/instanced decision is an explicit, documented product-requirement fork (an export must never duplicate geometry; the viewer tags class 1/2 for its Model/Types switch), no longer two parallel filters.
- `MeshData.geometry_class` (serde-default, skipped when 0) — additive; ordinary meshes serialize byte-identically; old caches stay readable.
- `GeometryStyleInfo` → `crate::style` (pub, plus `from_color` for the wasm flat-array lift). Per-element CSG diagnostics ride `ProducedElementMeshes.csg_failures`, with the router fully drained per element so a warm batch router never leaks one element's failures into the next.
- `processor.rs`: `process_entity_job` is now a thin adapter (net **−489 lines**).

## Deliberate converged-tree deltas on the native path

- IfcAlignment exempt from the representation gate (wasm behaviour adopted).
- Indexed-colour (#858) elements without openings take the submesh path with per-item palette split instead of single-mesh + element-level split — equivalent output on the pinned fixtures (`styling_indexed_colour` green unchanged).
- Normals recompute on `normals.len() != positions.len()` (stricter superset).

## Verification

- All Rust tests green **unchanged**: processing 54/54 (styling submesh/indexed-colour/material-chain/parity, #957 type-only, element-failure parity, #845 voids, #961 textures), geometry lib 313/313, server 18/18.
- New unit tests: `plan_type_geometry` matrix (orphan/instanced × suppress/tagged × referenced filtering), opening material-name inference, mapped-item colour chase (moved with the resolver).
- `element.rs` clippy-clean; `cargo check --target wasm32-unknown-unknown -p ifc-lite-processing` passes.
- 75 MB real-model run through the new core is **bit-identical**: 20,577 meshes / 2,063,859 verts / 1,071,134 tris, same wall time.

Next: PR 3 rewires `processGeometryBatch` onto this core and deletes its inlined copy (~330 lines).