### PR TITLE
refactor(wasm): run processGeometryBatch on the canonical per-element producer

### DIFF
--- a/rust/wasm-bindings/src/api/gpu_meshes.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes.rs
@@ -12,53 +12,15 @@ use crate::zero_copy::{MeshCollection, MeshDataJs};
 use js_sys::Function;
 use wasm_bindgen::prelude::*;
 
-/// Emit a sub-mesh, splitting it into one mesh per `IfcIndexedColourMap` palette
-/// group when the face set carries a per-triangle colour map whose triangle
-/// count still matches the produced mesh (issue #858). This restores the split
-/// the live viewer lost when the geometry pipeline was unified onto
-/// `processGeometryBatch` (#874) — the prepass only carries one dominant colour
-/// per geometry, so without this the green/yellow triangles collapse into red.
-///
-/// Falls back to a single `color` mesh when there is no map, when the map no
-/// longer applies (CSG/void retopology changed the triangle count), or when
-/// fewer than two distinct palette colours are used — the same guards the native
-/// processor relies on (see `split_mesh_by_indexed_colour`).
-fn emit_submesh_with_palette_split(
-    mesh_collection: &mut MeshCollection,
-    express_id: u32,
-    ifc_type_name: &str,
-    geometry_id: u32,
-    mesh: ifc_lite_geometry::Mesh,
-    color: [f32; 4],
-    indexed_colour_full: &rustc_hash::FxHashMap<
-        u32,
-        ifc_lite_processing::style::FullIndexedColourMap,
-    >,
-) {
-    if let Some(full) = indexed_colour_full.get(&geometry_id) {
-        if let Some(groups) = ifc_lite_processing::style::split_mesh_by_indexed_colour(&mesh, full)
-        {
-            for (rgba, mut part) in groups {
-                if part.normals.len() != part.positions.len() {
-                    ifc_lite_geometry::calculate_normals(&mut part);
-                }
-                mesh_collection.add(MeshDataJs::new(
-                    express_id,
-                    ifc_type_name.to_string(),
-                    part,
-                    rgba.to_array(),
-                ));
-            }
-            return;
-        }
+fn decode_ifc_bytes<'a>(data: &'a [u8]) -> &'a str {
+    match std::str::from_utf8(data) {
+        Ok(content) => content,
+        Err(error) => wasm_bindgen::throw_str(&format!("Invalid UTF-8 IFC data: {error}")),
     }
-    mesh_collection.add(MeshDataJs::new(
-        express_id,
-        ifc_type_name.to_string(),
-        mesh,
-        color,
-    ));
 }
+
+// The per-submesh #858 palette split lives inside the canonical per-element
+// producer (`ifc_lite_processing::element`) — shared with the native pipeline.
 
 #[wasm_bindgen]
 impl IfcAPI {
@@ -783,10 +745,14 @@ impl IfcAPI {
         style_ids: &[u32],   // geometry style entity IDs
         style_colors: &[u8], // [r, g, b, a, r, g, b, a, ...] (0-255)
     ) -> MeshCollection {
-        use super::styling::{resolve_element_color, resolve_submesh_color};
+        use super::styling::resolve_element_color;
         use ifc_lite_core::EntityDecoder;
-        use ifc_lite_geometry::{calculate_normals, GeometryHasher, GeometryRouter};
-        use ifc_lite_processing::default_color_for_type;
+        use ifc_lite_geometry::GeometryRouter;
+        use ifc_lite_processing::element::{
+            plan_type_geometry, produce_element_meshes, ElementJobKind, ElementMeshJob,
+            GeometryHashConfig, MeshProductionContext, MeshProductionOptions, TypeGeometryMode,
+        };
+        use ifc_lite_processing::style::GeometryStyleInfo;
 
         let content = data;
 
@@ -910,10 +876,6 @@ impl IfcAPI {
             mesh_collection.set_rtc_offset(rtc_x, rtc_y, rtc_z);
         }
 
-        // Cache IFC type name strings
-        let mut type_name_cache: rustc_hash::FxHashMap<ifc_lite_core::IfcType, String> =
-            rustc_hash::FxHashMap::default();
-
         // When merge-layers is on, fetch (or lazily build) the set of
         // IfcBuildingElementPart express IDs to skip. Built once per worker
         // and reused across every subsequent batch on the same content via
@@ -925,13 +887,55 @@ impl IfcAPI {
         };
 
         // IfcIndexedColourMap index (geometry id → full per-triangle palette),
-        // built once per worker. Drives the #858 per-palette-group split below
-        // so a face set whose ColourIndex assigns several colours to different
-        // triangles renders multi-coloured instead of collapsing to the single
-        // dominant colour the prepass `geometry_styles` carries.
+        // built once per worker (#858) — the canonical producer splits face
+        // sets per palette group so multi-coloured triangles don't collapse to
+        // the single dominant colour the prepass `geometry_styles` carries.
         let indexed_colour_full = self.get_or_build_indexed_colour_maps(content, &mut decoder);
 
-        // Process only the entities specified in jobs_flat
+        // Lift the flat wire styles into the canonical styled-item index the
+        // shared producer consumes (colour-only — exactly what the wire has).
+        let geometry_style_index: rustc_hash::FxHashMap<u32, GeometryStyleInfo> = geometry_styles
+            .iter()
+            .map(|(&id, &c)| (id, GeometryStyleInfo::from_color(c)))
+            .collect();
+        // Surface textures + UV maps (#961), built once per worker (cheap
+        // substring bail-out for untextured files).
+        let texture_index = self.get_or_build_texture_index(content, &mut decoder);
+        // The browser prepass doesn't ship material-chain colour lists yet
+        // (planned with the shared-prepass step); the alternation inside the
+        // producer simply never fires on an empty map — today's behaviour.
+        let element_material_colors: rustc_hash::FxHashMap<u32, Vec<[f32; 4]>> =
+            rustc_hash::FxHashMap::default();
+
+        let ctx = MeshProductionContext {
+            void_index: &void_index,
+            geometry_style_index: &geometry_style_index,
+            indexed_colour_full: &indexed_colour_full,
+            element_material_colors: &element_material_colors,
+            texture_index: &texture_index,
+            // The browser's axis change (IFC Z-up → WebGL Y-up) happens at the
+            // FFI boundary in `MeshDataJs::from_mesh_data`, not here.
+            site_local_rotation: None,
+        };
+        let opts = MeshProductionOptions {
+            geometry_hash: hash_tolerance.map(|tolerance| GeometryHashConfig {
+                tolerance,
+                world_rtc: hash_world_rtc,
+            }),
+        };
+
+        // CSG diagnostics, aggregated across the batch: the canonical producer
+        // drains the (warm, batch-shared) router per element so one element's
+        // failures never bleed into the next; we collect them here and hand
+        // them to the logger below.
+        let mut batch_csg_failures: rustc_hash::FxHashMap<
+            u32,
+            Vec<ifc_lite_geometry::BoolFailure>,
+        > = rustc_hash::FxHashMap::default();
+
+        // Process only the entities specified in jobs_flat — every job runs
+        // THE canonical per-element producer (`ifc_lite_processing::element`),
+        // the same code the native pipeline runs.
         for chunk in jobs_flat.chunks(3) {
             if chunk.len() < 3 {
                 break;
@@ -944,257 +948,73 @@ impl IfcAPI {
                 continue;
             }
 
-            if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
-                // IfcAlignment exception — see `parse_meshes`.
-                let has_representation = entity.get(6).map(|a| !a.is_null()).unwrap_or(false);
-                let is_alignment = entity.ifc_type == ifc_lite_core::IfcType::IfcAlignment;
-                if !has_representation && !is_alignment {
+            let Ok(entity) = decoder.decode_at_with_id(id, start, end) else {
+                continue;
+            };
+            let ifc_type = entity.ifc_type;
+
+            // #957: type products render their planned RepresentationMaps. The
+            // viewer emits BOTH orphan (class 1) and instanced (class 2) maps —
+            // `EmitTagged` — so the Model/Types switch can filter at render
+            // time; the native pipeline plans the same jobs with
+            // `SuppressInstanced` (an export must not duplicate geometry).
+            let kind = if ifc_type.is_subtype_of(ifc_lite_core::IfcType::IfcTypeProduct) {
+                let rep_map_ids: Vec<u32> = entity
+                    .get(6)
+                    .and_then(|a| a.as_list())
+                    .map(|list| list.iter().filter_map(|v| v.as_entity_ref()).collect())
+                    .unwrap_or_default();
+                if rep_map_ids.is_empty() {
                     continue;
                 }
-
-                let ifc_type = entity.ifc_type;
-
-                // #957: orphan type-product geometry — an IfcXxxType carrying its
-                // own RepresentationMaps with no occurrence to instantiate them
-                // (buildingSMART annex-E "tessellated shape with style" files).
-                // Render each RepresentationMap NOT referenced by an IfcMappedItem
-                // (the referenced ones draw through their occurrence — no double
-                // render).
-                if ifc_type.is_subtype_of(ifc_lite_core::IfcType::IfcTypeProduct) {
-                    // #957 follow-up + Model/Types view switch: type-product
-                    // RepresentationMap geometry is ALWAYS emitted here, tagged with
-                    // a geometry_class so the viewer can choose what to show:
-                    //   class 1 = orphan type (no occurrence) — part of "the model"
-                    //             since nothing else renders it (annex-E showcase).
-                    //   class 2 = instanced type (an IfcRelDefinesByType links it to
-                    //             an occurrence that already draws the real geometry).
-                    //             Hidden in Model mode (else the AC20/ArchiCAD
-                    //             duplicate-boxes-at-MappingOrigin regression returns);
-                    //             shown in Types mode as the type-library shape.
-                    // The native process_geometry path still SUPPRESSES class 2 (an
-                    // export must not duplicate geometry); only the interactive viewer
-                    // emits both and filters by view mode at render time.
-                    let instantiated =
-                        self.get_or_build_instantiated_type_ids(content, &mut decoder);
-                    let type_class: u8 = if instantiated.contains(&id) { 2 } else { 1 };
-                    let rep_map_ids: Vec<u32> = entity
-                        .get(6)
-                        .and_then(|a| a.as_list())
-                        .map(|list| list.iter().filter_map(|v| v.as_entity_ref()).collect())
-                        .unwrap_or_default();
-                    if !rep_map_ids.is_empty() {
-                        let referenced =
-                            self.get_or_build_referenced_repmaps(content, &mut decoder);
-                        // Surface textures + UV maps (#961), built once per worker.
-                        let texture_index = self.get_or_build_texture_index(content, &mut decoder);
-                        for rm_id in rep_map_ids {
-                            if referenced.contains(&rm_id) {
-                                continue;
-                            }
-                            let Ok(rep_map) = decoder.decode_by_id(rm_id) else {
-                                continue;
-                            };
-                            // One part per output mesh: each textured face set
-                            // carries its own image; untextured items merge (#961).
-                            let Ok(parts) = router.process_representation_map_with_texture(
-                                &rep_map,
-                                &mut decoder,
-                                &texture_index,
-                            ) else {
-                                continue;
-                            };
-                            if parts.is_empty() {
-                                continue;
-                            }
-                            let color = super::styling::color_for_representation_map(
-                                rm_id,
-                                &geometry_styles,
-                                &mut decoder,
-                            )
-                            .unwrap_or_else(|| default_color_for_type(ifc_type).to_array());
-                            let ifc_type_name = type_name_cache
-                                .entry(ifc_type)
-                                .or_insert_with(|| ifc_type.name().to_string())
-                                .clone();
-                            for (mut mesh, uvs, texture) in parts {
-                                if mesh.is_empty() {
-                                    continue;
-                                }
-                                if mesh.normals.len() != mesh.positions.len() {
-                                    calculate_normals(&mut mesh);
-                                }
-                                let mut mesh_js =
-                                    MeshDataJs::new(id, ifc_type_name.clone(), mesh, color);
-                                mesh_js.set_geometry_class(type_class);
-                                if let Some(tex) = texture {
-                                    mesh_js.set_texture(
-                                        uvs,
-                                        tex.rgba,
-                                        tex.width,
-                                        tex.height,
-                                        tex.repeat_s,
-                                        tex.repeat_t,
-                                    );
-                                }
-                                mesh_collection.add(mesh_js);
-                            }
-                        }
-                    }
+                let referenced = self.get_or_build_referenced_repmaps(content, &mut decoder);
+                let instantiated = self.get_or_build_instantiated_type_ids(content, &mut decoder);
+                let rep_maps = plan_type_geometry(
+                    &rep_map_ids,
+                    &referenced,
+                    instantiated.contains(&id),
+                    TypeGeometryMode::EmitTagged,
+                );
+                if rep_maps.is_empty() {
                     continue;
                 }
+                ElementJobKind::TypeProduct { rep_maps }
+            } else {
+                ElementJobKind::Product
+            };
 
-                let has_openings = void_index.contains_key(&id);
+            let produced = produce_element_meshes(
+                &ElementMeshJob {
+                    id,
+                    ifc_type,
+                    entity: &entity,
+                    kind,
+                    element_color: element_styles.get(&id).copied(),
+                    // The viewer gets element metadata from the parser worker.
+                    metadata: None,
+                },
+                &ctx,
+                &opts,
+                &mut decoder,
+                &router,
+            );
 
-                // One fingerprint accumulator per entity. All of an entity's
-                // submeshes are produced within this single loop iteration, so
-                // the hash is fully resolved here — no cross-batch merge.
-                let mut entity_hasher =
-                    hash_tolerance.map(|tol| GeometryHasher::new(tol, hash_world_rtc));
-
-                if has_openings {
-                    // Submesh-aware cut first (server parity): per-part
-                    // colours survive the void subtraction, so a voided
-                    // multi-layer wall or window keeps frame/glass split.
-                    let mut used_voided_submesh = false;
-                    if let Ok(sub_meshes) = router.process_element_with_submeshes_and_voids(
-                        &entity,
-                        &mut decoder,
-                        &void_index,
-                    ) {
-                        if !sub_meshes.is_empty() {
-                            let default_color = default_color_for_type(ifc_type).to_array();
-                            let element_color = element_styles.get(&id).copied();
-                            let mut mat_color_idx = 0usize;
-                            for sub in sub_meshes.sub_meshes {
-                                let geometry_id = sub.geometry_id;
-                                let mut mesh = sub.mesh;
-                                if mesh.is_empty() {
-                                    continue;
-                                }
-                                if mesh.normals.len() != mesh.positions.len() {
-                                    calculate_normals(&mut mesh);
-                                }
-                                let color = resolve_submesh_color(
-                                    geometry_id,
-                                    &geometry_styles,
-                                    &mut decoder,
-                                    None,
-                                    &mut mat_color_idx,
-                                    element_color,
-                                    default_color,
-                                );
-                                let ifc_type_name = type_name_cache
-                                    .entry(ifc_type)
-                                    .or_insert_with(|| ifc_type.name().to_string())
-                                    .clone();
-                                if let Some(h) = entity_hasher.as_mut() {
-                                    h.add_mesh(&mesh.positions, &mesh.indices);
-                                }
-                                emit_submesh_with_palette_split(
-                                    &mut mesh_collection,
-                                    id,
-                                    &ifc_type_name,
-                                    geometry_id,
-                                    mesh,
-                                    color,
-                                    &indexed_colour_full,
-                                );
-                                used_voided_submesh = true;
-                            }
-                        }
-                    }
-                    if !used_voided_submesh {
-                        if let Ok(mut mesh) =
-                            router.process_element_with_voids(&entity, &mut decoder, &void_index)
-                        {
-                            if !mesh.is_empty() {
-                                if mesh.normals.len() != mesh.positions.len() {
-                                    calculate_normals(&mut mesh);
-                                }
-                                let color = element_styles
-                                    .get(&id)
-                                    .copied()
-                                    .unwrap_or_else(|| default_color_for_type(ifc_type).to_array());
-                                let ifc_type_name = type_name_cache
-                                    .entry(ifc_type)
-                                    .or_insert_with(|| ifc_type.name().to_string())
-                                    .clone();
-                                if let Some(h) = entity_hasher.as_mut() {
-                                    h.add_mesh(&mesh.positions, &mesh.indices);
-                                }
-                                mesh_collection.add(MeshDataJs::new(id, ifc_type_name, mesh, color));
-                            }
-                        }
-                    }
-                } else {
-                    // Submesh path for ALL types: per-geometry-item colors
-                    // (window glass transparency, multi-material doors) and —
-                    // crucially — unsupported representation items are skipped
-                    // instead of aborting the entire element (process_element
-                    // uses `?`).
-                    {
-                        if let Ok(sub_meshes) =
-                            router.process_element_with_submeshes(&entity, &mut decoder)
-                        {
-                            if !sub_meshes.is_empty() {
-                                let default_color = default_color_for_type(ifc_type).to_array();
-                                let element_color = element_styles.get(&id).copied();
-                                let mut mat_color_idx = 0usize;
-                                for sub in sub_meshes.sub_meshes {
-                                    let geometry_id = sub.geometry_id;
-                                    let mut mesh = sub.mesh;
-                                    if mesh.is_empty() {
-                                        continue;
-                                    }
-                                    if mesh.normals.len() != mesh.positions.len() {
-                                        calculate_normals(&mut mesh);
-                                    }
-                                    let color = resolve_submesh_color(
-                                        geometry_id,
-                                        &geometry_styles,
-                                        &mut decoder,
-                                        None,
-                                        &mut mat_color_idx,
-                                        element_color,
-                                        default_color,
-                                    );
-                                    let ifc_type_name = type_name_cache
-                                        .entry(ifc_type)
-                                        .or_insert_with(|| ifc_type.name().to_string())
-                                        .clone();
-                                    if let Some(h) = entity_hasher.as_mut() {
-                                        h.add_mesh(&mesh.positions, &mesh.indices);
-                                    }
-                                    emit_submesh_with_palette_split(
-                                        &mut mesh_collection,
-                                        id,
-                                        &ifc_type_name,
-                                        geometry_id,
-                                        mesh,
-                                        color,
-                                        &indexed_colour_full,
-                                    );
-                                }
-                            }
-                        }
-                    }
-                }
-
-                // Record the entity's geometry fingerprint (if any geometry
-                // was produced and hashing is enabled).
-                if let Some(h) = entity_hasher {
-                    if !h.is_empty() {
-                        mesh_collection.push_geometry_hash(id, h.finish());
-                    }
-                }
+            for mesh_data in produced.meshes {
+                mesh_collection.add(MeshDataJs::from_mesh_data(mesh_data));
+            }
+            if let Some(hash) = produced.geometry_hash {
+                mesh_collection.push_geometry_hash(id, hash);
+            }
+            for (product_id, fails) in produced.csg_failures {
+                batch_csg_failures.entry(product_id).or_default().extend(fails);
             }
         }
 
-        // Drain & surface the opening / CSG diagnostics. The viewer's
-        // large-file path goes processAdaptive -> processParallel -> Web
-        // Workers -> `processGeometryBatch`, so the drain has to run here
-        // or the diagnostic helper never fires for real-world files.
-        let _ = super::drain_and_log_csg_diagnostics(&router);
+        // Surface the opening / CSG diagnostics. The viewer's large-file path
+        // goes processAdaptive -> processParallel -> Web Workers ->
+        // `processGeometryBatch`, so the log has to fire here or the
+        // diagnostic helper never runs for real-world files.
+        let _ = super::drain_and_log_csg_diagnostics(&router, batch_csg_failures);
 
         mesh_collection
     }

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -682,9 +682,19 @@ fn set_js_prop_jv(obj: &JsValue, key: &JsValue, value: &JsValue) -> bool {
 /// failure summary at `console.warn` only when there's at least one
 /// failure to report. Per-host detail is included for the worst-failing
 /// products (capped to keep the log readable on large files).
-pub(super) fn drain_and_log_csg_diagnostics(router: &ifc_lite_geometry::GeometryRouter) -> JsValue {
+pub(super) fn drain_and_log_csg_diagnostics(
+    router: &ifc_lite_geometry::GeometryRouter,
+    // Failures already drained per element by the canonical producer
+    // (`ifc_lite_processing::element` empties the warm batch router after
+    // every element so failures can't bleed between elements). Merged with
+    // whatever still sits on the router (non-canonical paths).
+    collected_failures: rustc_hash::FxHashMap<u32, Vec<ifc_lite_geometry::BoolFailure>>,
+) -> JsValue {
     let cls = router.take_classification_stats();
-    let csg_failures = router.take_csg_failures();
+    let mut csg_failures = router.take_csg_failures();
+    for (product_id, fails) in collected_failures {
+        csg_failures.entry(product_id).or_default().extend(fails);
+    }
     let host_diags = router.take_host_opening_diagnostics();
 
     let cls_total = cls.rectangular + cls.diagonal + cls.non_rectangular;

--- a/rust/wasm-bindings/src/api/styling.rs
+++ b/rust/wasm-bindings/src/api/styling.rs
@@ -503,33 +503,6 @@ pub(crate) fn build_instantiated_type_ids(
     instantiated
 }
 
-/// #957: resolve the authored colour for a type's `IfcRepresentationMap` by
-/// looking up its mapped geometry items in the prepass geometry-style index
-/// (the annex-E samples author a white `IfcSurfaceStyle`). Returns `None` when
-/// no item carries a style (caller falls back to the type's default colour).
-pub(crate) fn color_for_representation_map(
-    rep_map_id: u32,
-    geometry_styles: &rustc_hash::FxHashMap<u32, [f32; 4]>,
-    decoder: &mut ifc_lite_core::EntityDecoder,
-) -> Option<[f32; 4]> {
-    let rep_map = decoder.decode_by_id(rep_map_id).ok()?;
-    // IfcRepresentationMap.MappedRepresentation = attr 1.
-    let mapped_rep_id = rep_map.get_ref(1)?;
-    let mapped_rep = decoder.decode_by_id(mapped_rep_id).ok()?;
-    // IfcShapeRepresentation.Items = attr 3.
-    let item_ids: Vec<u32> = mapped_rep
-        .get(3)
-        .and_then(|a| a.as_list())
-        .map(|list| list.iter().filter_map(|v| v.as_entity_ref()).collect())
-        .unwrap_or_default();
-    for item_id in item_ids {
-        if let Some(color) = find_color_for_geometry(item_id, geometry_styles, decoder) {
-            return Some(color);
-        }
-    }
-    None
-}
-
 /// Build material style index: maps material IDs to their colors.
 /// Follows: material → IfcMaterialDefinitionRepresentation → IfcStyledRepresentation → orphan IfcStyledItem
 pub(crate) fn build_material_style_index(
@@ -652,33 +625,6 @@ pub(crate) fn collect_material_entity(
         }
         _ => {}
     }
-}
-
-/// Resolve color for a sub-mesh using the fallback chain:
-/// direct geometry style -> material-based style -> element style -> default.
-///
-/// `mat_color_idx` is the current index for material color alternation (transparent/opaque).
-/// It is incremented when a material fallback is attempted (caller should track this).
-pub(crate) fn resolve_submesh_color(
-    geometry_id: u32,
-    geometry_styles: &rustc_hash::FxHashMap<u32, [f32; 4]>,
-    decoder: &mut ifc_lite_core::EntityDecoder,
-    material_colors: Option<&Vec<[f32; 4]>>,
-    mat_color_idx: &mut usize,
-    element_color: Option<[f32; 4]>,
-    default_color: [f32; 4],
-) -> [f32; 4] {
-    // Step 1 (the direct geometry style, incl. IfcMappedItem traversal) is the
-    // browser's own lookup over its `[f32; 4]` style map. The precedence below
-    // it and the transparent/opaque alternation are the shared resolver, so the
-    // browser and the backend can't drift on them (#913 §4.2).
-    let direct_color = find_color_for_geometry(geometry_id, geometry_styles, decoder);
-    ifc_lite_processing::style::resolve_submesh_color(
-        direct_color,
-        material_colors.map(|v| v.as_slice()),
-        mat_color_idx,
-        element_color.unwrap_or(default_color),
-    )
 }
 
 /// Resolve element color inline during processing by following its

--- a/rust/wasm-bindings/src/zero_copy.rs
+++ b/rust/wasm-bindings/src/zero_copy.rs
@@ -235,6 +235,36 @@ impl MeshDataJs {
         self.texture_repeat_s = repeat_s;
         self.texture_repeat_t = repeat_t;
     }
+
+    /// Build from the canonical per-element producer's [`MeshData`]
+    /// (`ifc_lite_processing::element`): wraps [`MeshDataJs::new`] (IFC Z-up →
+    /// WebGL Y-up + winding reversal), copies the `geometry_class` tag and the
+    /// optional texture/UVs. Element metadata the browser doesn't carry
+    /// (global_id / name / presentation layer / material name / properties) is
+    /// dropped — the viewer gets it from the parser worker instead.
+    pub fn from_mesh_data(m: ifc_lite_processing::MeshData) -> Self {
+        let mesh = Mesh {
+            positions: m.positions,
+            normals: m.normals,
+            indices: m.indices,
+            // Positions are final here (the canonical producer already applied
+            // placement/RTC); the flag only guards upstream double-subtraction.
+            rtc_applied: true,
+        };
+        let mut js = Self::new(m.express_id, m.ifc_type, mesh, m.color);
+        js.set_geometry_class(m.geometry_class);
+        if let (Some(uvs), Some(tex)) = (m.uvs, m.texture) {
+            js.set_texture(
+                uvs,
+                tex.rgba,
+                tex.width,
+                tex.height,
+                tex.repeat_s,
+                tex.repeat_t,
+            );
+        }
+        js
+    }
 }
 
 /// Collection of mesh data for returning multiple meshes


### PR DESCRIPTION
## What

Step 3 of the pipeline-unification series (stacked on #1083). The browser batch path's **inlined copy of the per-element decision tree is deleted**; every job now runs `ifc_lite_processing::element::produce_element_meshes` — the exact code the native pipeline runs — with `EmitTagged` type-geometry mode (the viewer's Model/Types switch) and per-element geometry-hash config (#971/#924).

- `processGeometryBatch` lifts the flat wire styles into the canonical `GeometryStyleInfo` index, builds the shared `MeshProductionContext` (empty material-colour map until the shared prepass ships those lists), plans type jobs via `plan_type_geometry(EmitTagged)`, and marshals results through the new `MeshDataJs::from_mesh_data` (Z-up→Y-up + winding stays at the FFI boundary; `geometry_class` + texture carried over).
- Deleted: the inlined tree (~250 lines), `emit_submesh_with_palette_split`, `type_name_cache`, and the dead styling wrappers (`resolve_submesh_color`, `color_for_representation_map`).
- `drain_and_log_csg_diagnostics` now takes the batch-aggregated failures: the canonical producer drains the warm batch router **per element** (one element's failures can't bleed into the next) and returns them on `ProducedElementMeshes.csg_failures`.

## Deliberate behavioural deltas on the browser path (from the converged tree)

- Elements whose submesh path produces nothing now **fall back to the single-mesh chain** (voids → plain element) instead of disappearing.
- The voided single-mesh fallback gains the element-level #858 palette split.

## Verification

- wasm contract: **16/16**
- wasm pkg behavioral tests: **11/11** (indexed-colour split, tessellation quality ×3, textures #961 ×2, type-only #957 ×4 incl. class tags, package)
- geometry regression suite: **39/39** fixture files byte-compatible
- viewer smoke e2e: **2/2** (AC20-FZK-Haus, 317 meshes, pick + section plane, no uncaught errors)
- `cargo check -p ifc-lite-wasm` clean

Net **−202 lines** in wasm-bindings. From this PR on, a geometry/styling fix lands in `element.rs` once and both the server and the viewer get it.

Next: PR 4 unifies the prepass scan (shared `run_prepass` + sink, `planeAngleToRadians` on the wire, late-IFCPROJECT early-meta hardening).