### PR TITLE
feat(release): publish ifc-lite-clash, ifc-lite-processing and ifc-lite-wasm to crates.io

### DIFF
--- a/rust/processing/Cargo.toml
+++ b/rust/processing/Cargo.toml
@@ -10,13 +10,16 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Shared IFC processing pipeline and types used by server and FFI"
+keywords = ["ifc", "bim", "geometry", "pipeline", "aec"]
+categories = ["parsing", "algorithms"]
+readme = "../../README.md"
 
 [dependencies]
-ifc-lite-core = { path = "../core" }
+ifc-lite-core = { version = "4.0.0", path = "../core" }
 # CSG runs on the pure-Rust exact kernel inside ifc-lite-geometry on every
 # target (the Manifold C++ kernel was removed in the kernel consolidation —
 # see docs/architecture/geometry-pipeline.md).
-ifc-lite-geometry = { path = "../geometry", default-features = false }
+ifc-lite-geometry = { version = "4.0.0", path = "../geometry", default-features = false }
 rayon = "1.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/rust/wasm-bindings/Cargo.toml
+++ b/rust/wasm-bindings/Cargo.toml
@@ -29,12 +29,12 @@ ifc-lite-core.workspace = true
 # same kernel on wasm32 and native. The Manifold C++ kernel and its
 # LLVM/emsdk build prerequisites were removed in the kernel
 # consolidation (docs/architecture/geometry-pipeline.md).
-ifc-lite-geometry = { path = "../geometry", default-features = false, features = [] }
+ifc-lite-geometry = { version = "4.0.0", path = "../geometry", default-features = false, features = [] }
 # Canonical 2D-symbol extractor lives here; the wasm bindings just
 # delegate (issue #843 follow-up — full parity, one implementation).
-ifc-lite-processing = { path = "../processing" }
+ifc-lite-processing = { version = "4.0.0", path = "../processing" }
 # Pure-geometry clash kernel (BVH broad phase + exact triangle narrow phase).
-ifc-lite-clash = { path = "../clash" }
+ifc-lite-clash = { version = "4.0.0", path = "../clash" }
 js-sys = "=0.3.83"
 rayon = "1.10"
 # `ifc-lite-geometry` uses rayon `par_iter` (e.g. FacetedBrep

--- a/scripts/release-crates.mjs
+++ b/scripts/release-crates.mjs
@@ -13,16 +13,9 @@
  *   - version already on crates.io  → skip (expected, logged)
  *   - version missing               → `cargo publish`; any failure FAILS the release
  *
- * Only `ifc-lite-core` and `ifc-lite-geometry` are published.
- * `ifc-lite-processing` and `ifc-lite-clash` have never been on crates.io and
- * carry version-less `path` dependencies, which makes them — and
- * `ifc-lite-wasm`, which depends on both — unpublishable as-is. Publishing
- * them is a deliberate public-surface decision, not a release-script default;
- * if that decision is made, add versions to their path deps and append them
- * (and `ifc-lite-wasm`) here in dependency order.
- *
- * `cargo publish` (≥1.66) blocks until the new version is visible in the
- * index, so no sleep is needed between dependent publishes.
+ * Crates are listed in dependency order: `cargo publish` (≥1.66) blocks
+ * until the new version is visible in the index, so no sleep is needed
+ * between dependent publishes.
  */
 
 import { execSync } from 'child_process';
@@ -32,8 +25,15 @@ import { dirname, join } from 'path';
 
 const rootDir = join(dirname(fileURLToPath(import.meta.url)), '..');
 
-// Dependency order: geometry depends on core.
-const CRATES = ['ifc-lite-core', 'ifc-lite-geometry'];
+// Dependency order: geometry depends on core; clash is dependency-free;
+// processing depends on core+geometry; wasm depends on all four.
+const CRATES = [
+  'ifc-lite-core',
+  'ifc-lite-geometry',
+  'ifc-lite-clash',
+  'ifc-lite-processing',
+  'ifc-lite-wasm',
+];
 
 const cargoToml = readFileSync(join(rootDir, 'Cargo.toml'), 'utf8');
 const versionMatch = cargoToml.match(

--- a/scripts/sync-versions.js
+++ b/scripts/sync-versions.js
@@ -82,12 +82,35 @@ function syncVersions() {
   );
 
   cargoToml = cargoToml.replace(
-    /(ifc-lite-(?:core|geometry|wasm)\s*=\s*\{\s*version\s*=\s*")[^"]+(")/g,
+    /(ifc-lite-(?:core|geometry|processing|clash|wasm)\s*=\s*\{\s*version\s*=\s*")[^"]+(")/g,
     `$1${version}$2`
   );
 
   writeFileSync(cargoTomlPath, cargoToml);
   console.log(`✅ Updated Cargo.toml workspace version to ${version}`);
+
+  // Crate manifests carry `version = "…"` on their internal `path`
+  // dependencies so they are publishable to crates.io (cargo strips the
+  // path and keeps the version requirement on publish). Those literals
+  // must track the workspace version or every workspace build breaks with
+  // a version/path mismatch after a bump.
+  for (const member of ['core', 'geometry', 'processing', 'clash', 'wasm-bindings']) {
+    const memberTomlPath = join(rootDir, 'rust', member, 'Cargo.toml');
+    let memberToml;
+    try {
+      memberToml = readFileSync(memberTomlPath, 'utf8');
+    } catch {
+      continue;
+    }
+    const updated = memberToml.replace(
+      /(ifc-lite-(?:core|geometry|processing|clash|wasm)\s*=\s*\{\s*version\s*=\s*")[^"]+(")/g,
+      `$1${version}$2`
+    );
+    if (updated !== memberToml) {
+      writeFileSync(memberTomlPath, updated);
+      console.log(`✅ Updated rust/${member}/Cargo.toml internal dep versions to ${version}`);
+    }
+  }
 
   // Update root package.json
   if (rootPackageJson.version !== version) {


### PR DESCRIPTION
## Summary

Follow-up to #1082, executing the parked public-surface decision: put `ifc-lite-clash` and `ifc-lite-processing` on crates.io so `ifc-lite-wasm` (frozen there at 2.3.0) can publish again. All three go out at the workspace version 4.0.0 on the next release-triggering push to main.

## Changes

- **`rust/processing/Cargo.toml` / `rust/wasm-bindings/Cargo.toml`**: add `version` requirements to the internal `path` deps — cargo strips the path and keeps the version on publish; without a version it refuses to publish at all (the root cause of wasm's silent freeze). Geometry's `default` feature set is empty (`default = []`), so the existing `default-features = false` overrides remain semantically inert.
- **`scripts/sync-versions.js`**: now also rewrites those member-manifest version literals and the `processing`/`clash` pins in the root manifest on every sync, so a future version bump can't leave them stale (a stale literal breaks every workspace build with a version/path mismatch).
- **`scripts/release-crates.mjs`**: publish list is now core → geometry → clash → processing → wasm, in dependency order.
- **processing metadata**: keywords/categories/readme added to match its published siblings (`ifc-lite-clash` already had full metadata and zero dependencies — no manifest change needed there).

## Validation

- `cargo publish --dry-run -p ifc-lite-clash` → packages + uploads cleanly (20K crate)
- `cargo publish --dry-run -p ifc-lite-processing` → cleanly verified against the live `core`/`geometry` 4.0.0 on crates.io (83K crate)
- `ifc-lite-wasm` can't dry-run standalone (its registry deps `clash@4.0.0`/`processing@4.0.0` only exist mid-release, same ordering pattern as geometry-after-core in every prior release); `cargo package --list` verified its contents
- `node scripts/sync-versions.js` idempotent at 4.0.0; `cargo update --workspace` → lockfile unchanged
- No `publish = false` flags anywhere; all crate dirs are source-only and small

## Note

First-time crate creation runs under `CARGO_REGISTRY_TOKEN` — if that token was scoped to publish-existing-only, the release will now fail **loudly** (no more `|| true`) and the token scope needs widening to allow new crates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency version specifications across multiple packages to explicit version 4.0.0.
  * Extended the release process to publish additional packages.
  * Enhanced version synchronization tooling to manage more crate manifests.
  * Added package metadata including keywords, categories, and documentation references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->