### PR TITLE
fix(embed-sdk): point DEFAULT_ORIGIN at embed.ifclite.com

### DIFF
--- a/.changeset/embed-sdk-default-origin.md
+++ b/.changeset/embed-sdk-default-origin.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/embed-sdk": patch
+---
+
+Fix the default embed viewer origin: `embed.ifc-lite.com` does not exist (NXDOMAIN), the hosted viewer lives at `embed.ifclite.com`. Without an explicit `origin` option, `IFCLiteEmbed.create()` pointed the iframe at a dead domain and rejected with a handshake timeout after 15s. Existing SDK versions can work around this by passing `origin: 'https://embed.ifclite.com'`.

--- a/packages/embed-sdk/src/index.ts
+++ b/packages/embed-sdk/src/index.ts
@@ -90,7 +90,7 @@ export type { ViewPreset, SectionAxis, ModelStats, EntityProperties, ModelInfo }
 // Default embed origin
 // ============================================================================
 
-const DEFAULT_ORIGIN = 'https://embed.ifc-lite.com';
+const DEFAULT_ORIGIN = 'https://embed.ifclite.com';
 
 // ============================================================================
 // IFCLiteEmbed class


### PR DESCRIPTION
## Problem

`@ifc-lite/embed-sdk` ships `DEFAULT_ORIGIN = 'https://embed.ifc-lite.com'` (hyphenated). That domain has **no DNS records** (NXDOMAIN) — the hosted embed viewer actually lives at `https://embed.ifclite.com`.

Result: every `IFCLiteEmbed.create()` call that doesn't pass an explicit `origin` mounts an iframe pointing at a dead domain and rejects with `Embed viewer handshake timed out` after 15s. Reported in the wild by a user embedding the viewer in a Power BI custom visual (whose AI assistant misdiagnosed the dead iframe as a COEP incompatibility).

## Fix

One-line change to the constant, plus a patch changeset.

Verified:
- `embed.ifclite.com/v1` serves the viewer (HTTP 200) with `frame-ancestors *`, `COEP: credentialless` — embedding from third-party hosts works as designed
- `dig ifc-lite.com` → no A/NS records, so the old default can never resolve
- `tsc --noEmit` clean in `packages/embed-sdk`

## Note for existing versions

Published SDK versions have the dead default baked in and can't be rescued via DNS (the `ifc-lite.com` domain isn't owned). Workaround documented in the changeset: pass `origin: 'https://embed.ifclite.com'` explicitly.