### PR TITLE
fix(cache): persist geometryClass so the Model/Types switch survives cache hits

### DIFF
--- a/.changeset/cache-geometryclass.md
+++ b/.changeset/cache-geometryclass.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/cache": patch
+---
+
+Persist `geometryClass` in the binary geometry section so the viewer's Model/Types view switch survives a cache hit. The format previously serialized everything except the per-mesh provenance tag, so restored meshes all came back as class 0 — instanced type-library geometry reappeared in Model mode and the Model/Types switch disappeared. Bumps `FORMAT_VERSION` 4 → 5 (older caches read back as class 0; consumers should key their cache entries on `FORMAT_VERSION` so a bump invalidates stale entries and re-meshes fresh).

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -27,7 +27,7 @@ import {
 } from '@ifc-lite/geometry';
 import { acquireFileBuffer, type AcquiredBuffer } from '../utils/acquireFileBuffer.js';
 import { buildSpatialIndexGuarded, buildSpatialIndexForModel } from '../utils/loadingUtils.js';
-import { type GeometryData } from '@ifc-lite/cache';
+import { type GeometryData, FORMAT_VERSION } from '@ifc-lite/cache';
 
 import { SERVER_URL, USE_SERVER, CACHE_SIZE_THRESHOLD, CACHE_MAX_SOURCE_SIZE, getDynamicBatchConfig } from '../utils/ifcConfig.js';
 import {
@@ -563,7 +563,10 @@ export function useIfcLoader() {
       const fingerprint = computeFastFingerprint(buffer);
       // Desktop Tauri cache commands only accept [A-Za-z0-9_-], so keep the
       // persisted key filename-safe and independent of the original filename.
-      const cacheKey = `ifc-${buffer.byteLength}-${fingerprint}-v4`;
+      // Pin to the cache FORMAT_VERSION so a format bump invalidates stale
+      // entries (e.g. v5 added the geometryClass tag the Model/Types switch
+      // needs); a manual literal here silently kept serving incompatible data.
+      const cacheKey = `ifc-${buffer.byteLength}-${fingerprint}-v${FORMAT_VERSION}`;
 
       // Cache + server are PRIMARY-ONLY: a federated add is WASM-only with no
       // cache/server round-trip (matches the former parseStepBufferViewerModel).

--- a/packages/cache/src/cache.test.ts
+++ b/packages/cache/src/cache.test.ts
@@ -181,6 +181,9 @@ describe('BinaryCacheWriter and BinaryCacheReader', () => {
         normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
         indices: new Uint32Array([0, 1, 2]),
         color: [0.8, 0.8, 0.8, 1.0],
+        // Instanced type-library shape (#957) — must survive the cache round
+        // trip or the viewer's Model/Types switch breaks on cache hits.
+        geometryClass: 2,
       },
     ];
 
@@ -207,6 +210,7 @@ describe('BinaryCacheWriter and BinaryCacheReader', () => {
     expect(result.geometry).toBeTruthy();
     expect(result.geometry!.meshes.length).toBe(1);
     expect(result.geometry!.meshes[0].expressId).toBe(4);
+    expect(result.geometry!.meshes[0].geometryClass).toBe(2);
     expect(result.geometry!.totalVertices).toBe(3);
     expect(result.geometry!.totalTriangles).toBe(1);
   });

--- a/packages/cache/src/sections/geometry.ts
+++ b/packages/cache/src/sections/geometry.ts
@@ -21,6 +21,9 @@ import { BufferWriter, BufferReader } from '../utils/buffer-utils.js';
  *     - vertexCount: uint32
  *     - indexCount: uint32
  *     - color: float32[4]
+ *     - ifcType: string            (version >= 2)
+ *     - geometryClass: uint8       (version >= 5) — 0 occurrence, 1 orphan
+ *                                   type, 2 instanced type (Model/Types switch)
  *     - positions: Float32Array[vertexCount * 3]
  *     - normals: Float32Array[vertexCount * 3]
  *     - indices: Uint32Array[indexCount]
@@ -87,6 +90,11 @@ export function writeGeometry(
     // Write ifcType (as string length + UTF-8 bytes)
     const ifcType = mesh.ifcType || '';
     writer.writeString(ifcType);
+
+    // Write geometryClass (#957 Model/Types switch). Without this the viewer's
+    // view-mode filter sees every cache-restored mesh as class 0: instanced
+    // type-library geometry reappears in Model mode and the switch disappears.
+    writer.writeUint8(mesh.geometryClass ?? 0);
 
     // Write geometry arrays
     writer.writeTypedArray(mesh.positions);
@@ -191,6 +199,11 @@ export function readGeometry(reader: BufferReader, version: number = 2): {
       ifcType = reader.readString() || undefined;
     }
 
+    // Read geometryClass (version 5+) — the Model/Types view-switch tag.
+    // Older caches default to 0 (occurrence); v4 entries are bypassed by the
+    // viewer's bumped cache key, so they re-mesh fresh rather than load here.
+    const geometryClass = version >= 5 ? reader.readUint8() : 0;
+
     const positions = reader.readFloat32Array(vertexCount * 3);
     const normals = reader.readFloat32Array(vertexCount * 3);
     const indices = reader.readUint32Array(indexCount);
@@ -202,6 +215,7 @@ export function readGeometry(reader: BufferReader, version: number = 2): {
       indices,
       color,
       ifcType,
+      geometryClass,
     });
   }
 

--- a/packages/cache/src/types.ts
+++ b/packages/cache/src/types.ts
@@ -12,8 +12,16 @@ import type { MeshData, CoordinateInfo } from '@ifc-lite/geometry';
 /** Magic bytes: "IFCL" */
 export const MAGIC = 0x4C434649; // "IFCL" in little-endian
 
-/** Current format version */
-export const FORMAT_VERSION = 4;
+/**
+ * Current format version.
+ *
+ * v5: per-mesh `geometryClass` byte (Model/Types view switch, #957). Earlier
+ * caches restored every mesh as class 0, so instanced type-library geometry
+ * (class 2) rendered in Model mode and the Model/Types switch vanished
+ * (`hasTypeGeometry` saw no non-zero classes). Bumping the version also bumps
+ * the viewer's cache key, so stale v4 entries miss and re-mesh fresh.
+ */
+export const FORMAT_VERSION = 5;
 
 /** Section types in the binary format */
 export enum SectionType {


### PR DESCRIPTION
## Problem

On ArchiCAD/AC20 exports, **type-library geometry reappeared in Model mode and the Model/Types 3D switch vanished** — but only after the file had been loaded once. Reported on latest-main production with `AC20-Institute-Var-2.ifc`: clicking a wall returned `IfcWallType`, and the Model/Types toggle was gone from the Visibility panel.

## Root cause — the geometry cache, not the renderer

The viewer caches meshed geometry in IndexedDB. The binary geometry section (`packages/cache/src/sections/geometry.ts`) serialized `expressId / counts / color / ifcType / positions / normals / indices` — **but not `geometryClass`** (0 = occurrence, 1 = orphan type, 2 = instanced type-library shape).

On a **cache hit**, `loadFromCache` restores meshes straight into the scene via `setGeometryResult`, bypassing the wasm path — so every mesh came back as **class 0**. That breaks both halves of the Model/Types feature at once:

- the view-mode filter no longer hides class-2 geometry in Model mode → instanced type shapes render coincident with the real walls (and picking resolves to `IfcWallType`)
- `hasTypeGeometry` finds no non-zero classes → the Model/Types switch is hidden

Classic "worked a while back, broken now": a **fresh** load (wasm, correctly tagged) is fine; the **second** load of the same file (cache hit) is broken.

The recent kernel-unification PRs (#1088 / #1084) are **not** at fault — verified on `AC20-Institute` via both `buildPrePassOnce` and `buildPrePassStreaming`: **235 class-2 meshes, `IfcWallType`×121 tagged correctly**. The break was purely the cache layer.

## Fix

- `geometry.ts`: write `geometryClass` (one `u8` per mesh), read gated on `version >= 5`
- `types.ts`: `FORMAT_VERSION` 4 → 5
- `useIfcLoader.ts`: pin the cache key to `FORMAT_VERSION` (was a hand-typed `-v4` literal). The bump invalidates stale entries, so the broken v4 entry misses → re-meshes fresh → re-caches as v5. **Auto-heals — no manual cache clear.**
- `cache.test.ts`: round-trip now asserts `geometryClass` survives

## Verification

- `@ifc-lite/cache` builds clean; **16/16** tests pass (incl. the new class-2 round-trip)
- Confirmed the wasm path already tags class 2 correctly on the user's file via both prepass entry points

## Note for reviewers

Any per-mesh provenance/flag added to `MeshData` in future must also be added to the cache (de)serialization, or it silently vanishes on cache hits while fresh loads look fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)