### PR TITLE
refactor(prepass): one shared post-scan resolver + unit-scale ladder for every pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1514,6 +1514,7 @@ version = "4.0.0"
 dependencies = [
  "ifc-lite-core",
  "ifc-lite-geometry",
+ "memchr",
  "rayon",
  "rustc-hash",
  "serde",

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -91,7 +91,7 @@ export class IfcAPI {
    * Process geometry for a subset of pre-scanned entities.
    * Takes raw bytes and pre-pass data from buildPrePassOnce.
    */
-  processGeometryBatch(data: Uint8Array, jobs_flat: Uint32Array, unit_scale: number, rtc_x: number, rtc_y: number, rtc_z: number, needs_shift: boolean, void_keys: Uint32Array, void_counts: Uint32Array, void_values: Uint32Array, style_ids: Uint32Array, style_colors: Uint8Array): MeshCollection;
+  processGeometryBatch(data: Uint8Array, jobs_flat: Uint32Array, unit_scale: number, rtc_x: number, rtc_y: number, rtc_z: number, needs_shift: boolean, void_keys: Uint32Array, void_counts: Uint32Array, void_values: Uint32Array, style_ids: Uint32Array, style_colors: Uint8Array, plane_angle_to_radians?: number | null, material_element_ids?: Uint32Array | null, material_color_counts?: Uint32Array | null, material_colors_rgba?: Uint8Array | null): MeshCollection;
   /**
    * Streaming pre-pass: emits geometry jobs in chunks via a JS callback
    * instead of waiting for the full file scan to complete.
@@ -845,7 +845,7 @@ export interface InitOutput {
   readonly ifcapi_parseGridAxes: (a: number, b: number, c: number) => number;
   readonly ifcapi_parseGridLines: (a: number, b: number, c: number) => number;
   readonly ifcapi_parseSymbolicRepresentations: (a: number, b: number, c: number) => number;
-  readonly ifcapi_processGeometryBatch: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number, k: number, l: number, m: number, n: number, o: number, p: number, q: number, r: number, s: number, t: number) => number;
+  readonly ifcapi_processGeometryBatch: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number, k: number, l: number, m: number, n: number, o: number, p: number, q: number, r: number, s: number, t: number, u: number, v: number, w: number, x: number, y: number, z: number, a1: number, b1: number) => number;
   readonly ifcapi_scanEntitiesFast: (a: number, b: number, c: number) => number;
   readonly ifcapi_scanEntitiesFastBytes: (a: number, b: number, c: number) => number;
   readonly ifcapi_scanGeometryEntitiesFast: (a: number, b: number, c: number) => number;

--- a/rust/processing/Cargo.toml
+++ b/rust/processing/Cargo.toml
@@ -23,5 +23,6 @@ ifc-lite-geometry = { version = "4.0.0", path = "../geometry", default-features 
 rayon = "1.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+memchr = "2.8"
 rustc-hash = "2.1"
 tracing = "0.1"

--- a/rust/processing/src/lib.rs
+++ b/rust/processing/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod element;
 mod georeferencing;
+pub mod prepass;
 mod processor;
 pub mod style;
 mod symbolic;

--- a/rust/processing/src/prepass.rs
+++ b/rust/processing/src/prepass.rs
@@ -1,0 +1,640 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Canonical prepass resolution — the single post-scan step that turns the
+//! entity spans a scan collected into the style / material / void context the
+//! per-element producer ([`crate::element`]) consumes.
+//!
+//! Both pipelines run this exact code:
+//! - the native orchestrator (`processor.rs`) span-stashes during its scan and
+//!   resolves here before the rayon loop;
+//! - the browser prepasses (`buildPrePassOnce` / `buildPrePassStreaming` in
+//!   `wasm-bindings`) span-stash during their scans and resolve here before
+//!   serialising the flat wire arrays.
+//!
+//! The two scan loops remain per-pipeline (they are mechanical `match`-arms
+//! over type names with pipeline-specific extras: quick-metadata, properties,
+//! incremental job emission), but everything SEMANTIC — styled-item
+//! precedence, IfcIndexedColourMap fallback, the #407 material chain, void
+//! collection and aggregate propagation (#845), and unit-scale resolution —
+//! lives here exactly once. The historic #858/#913-class drift was always in
+//! this resolution layer, not in the span stashing.
+
+use crate::style::{FullIndexedColourMap, GeometryStyleInfo};
+use ifc_lite_core::{DecodedEntity, EntityDecoder};
+use rustc_hash::FxHashMap;
+
+/// One stashed entity span: `(express_id, start, end)`.
+pub type Span = (u32, usize, usize);
+
+/// Entity spans a scan collected for post-scan resolution. Both scan loops
+/// fill this; neither decodes these entities mid-scan.
+#[derive(Debug, Default)]
+pub struct PrepassSpans {
+    /// `IFCSTYLEDITEM` — geometry-attached AND orphan (material appearance);
+    /// the resolver classifies them (the classifying decode is the cost of
+    /// telling the two apart).
+    pub styled_items: Vec<Span>,
+    /// `IFCINDEXEDCOLOURMAP` (#663/#858 — CATIA/3DEXPERIENCE per-triangle
+    /// palettes, IFC4's second colouring mechanism).
+    pub indexed_colour_maps: Vec<Span>,
+    /// `IFCMATERIALDEFINITIONREPRESENTATION` (#407 material chain).
+    pub material_def_reprs: Vec<Span>,
+    /// `IFCRELASSOCIATESMATERIAL` (#407 material chain).
+    pub rel_associates_material: Vec<Span>,
+    /// `IFCRELVOIDSELEMENT` — host → opening.
+    pub void_rels: Vec<Span>,
+    /// `IFCRELFILLSELEMENT` — opening → filling (window/door); drives the
+    /// native opening filter. Cheap to collect everywhere.
+    pub fills_rels: Vec<Span>,
+    /// `IFCRELAGGREGATES` — parent → children, for aggregate void
+    /// propagation (#845, IfcWallElementedCase etc.).
+    pub aggregate_rels: Vec<Span>,
+}
+
+/// Resolution switches. Both pipelines use the same resolver with different
+/// collection needs.
+#[derive(Debug, Clone, Copy)]
+pub struct ResolveOptions {
+    /// Collect the FULL per-triangle palette maps (#858). The native pipeline
+    /// consumes them in-process; the browser prepass leaves this off (each
+    /// process worker rebuilds its own copy — shipping full palettes over the
+    /// JS boundary would dwarf the styles arrays).
+    pub collect_indexed_colour_full: bool,
+    /// Defer geometry-attached styled items: classify and resolve ORPHAN
+    /// styled items now (#913 §2c — the material chain needs them up front),
+    /// but return attached spans unresolved on
+    /// [`ResolvedPrepass::deferred_attached_styled_spans`] for a later
+    /// [`resolve_styled_item_spans`] replay. Native `fast_first_batch` mode.
+    pub defer_attached_styles: bool,
+}
+
+impl Default for ResolveOptions {
+    fn default() -> Self {
+        Self {
+            collect_indexed_colour_full: true,
+            defer_attached_styles: false,
+        }
+    }
+}
+
+/// Everything the post-scan resolution produces.
+#[derive(Debug, Default)]
+pub struct ResolvedPrepass {
+    /// Geometry item id → resolved style (styled items first in file order,
+    /// then IfcIndexedColourMap dominant colours fill the gaps — styled items
+    /// win, #913 precedence).
+    pub geometry_style_index: FxHashMap<u32, GeometryStyleInfo>,
+    /// Geometry item id → dominant palette colour (#858).
+    pub indexed_colour_index: FxHashMap<u32, [f32; 4]>,
+    /// Geometry item id → full per-triangle palette (#858); empty unless
+    /// [`ResolveOptions::collect_indexed_colour_full`].
+    pub indexed_colour_full: FxHashMap<u32, FullIndexedColourMap>,
+    /// Orphan `IfcStyledItem` colours (material appearances, #407).
+    pub orphan_styled_items: FxHashMap<u32, [f32; 4]>,
+    /// Material id → styled representation ids (#407).
+    pub material_def_reprs: FxHashMap<u32, Vec<u32>>,
+    /// Element id → material(-select) id (#407).
+    pub element_to_material: FxHashMap<u32, u32>,
+    /// Element id → material colour list (#407/#913 §2.3 transparent/opaque
+    /// alternation for window/door parts). The canonical join.
+    pub element_material_colors: FxHashMap<u32, Vec<[f32; 4]>>,
+    /// Host element id → opening ids, AFTER aggregate propagation (#845).
+    pub void_index: FxHashMap<u32, Vec<u32>>,
+    /// Opening id → filling element id (native opening filter input).
+    pub filling_by_opening: FxHashMap<u32, u32>,
+    /// Geometry-attached styled-item spans NOT resolved because
+    /// [`ResolveOptions::defer_attached_styles`] was set; replay them with
+    /// [`resolve_styled_item_spans`].
+    pub deferred_attached_styled_spans: Vec<(usize, usize)>,
+}
+
+/// THE canonical post-scan resolution. Spans are processed in file order so
+/// first-wins precedence matches what the historic inline scans produced.
+pub fn resolve_prepass(
+    spans: &PrepassSpans,
+    decoder: &mut EntityDecoder,
+    opts: ResolveOptions,
+) -> ResolvedPrepass {
+    let mut out = ResolvedPrepass::default();
+
+    // ── Styled items: orphan (material appearance) vs geometry-attached ──
+    for &(id, start, end) in &spans.styled_items {
+        let Ok(styled_item) = decoder.decode_at_with_id(id, start, end) else {
+            if opts.defer_attached_styles {
+                // Undecodable now — let the replay try again later, matching
+                // the historic defer behaviour.
+                out.deferred_attached_styled_spans.push((start, end));
+            }
+            continue;
+        };
+        if styled_item.get_ref(0).is_none() {
+            // Orphan styled item (null Item) = a material appearance (#407).
+            // Always resolved up front — even in defer mode — or
+            // material-only-styled elements render default-gray (#913 §2c).
+            if let Some(info) = extract_style_info_from_styled_item(&styled_item, decoder) {
+                out.orphan_styled_items.insert(id, info.color);
+            }
+        } else if opts.defer_attached_styles {
+            out.deferred_attached_styled_spans.push((start, end));
+        } else {
+            collect_geometry_style_info(&mut out.geometry_style_index, &styled_item, decoder);
+        }
+    }
+
+    // ── IfcIndexedColourMap (#663/#858) ──
+    for &(id, start, end) in &spans.indexed_colour_maps {
+        let Ok(icm) = decoder.decode_at_with_id(id, start, end) else {
+            continue;
+        };
+        let Some(full) = crate::style::resolve_indexed_colour_map_full(&icm, decoder) else {
+            continue;
+        };
+        let geometry_id = full.geometry_id;
+        out.indexed_colour_index
+            .entry(geometry_id)
+            .or_insert(full.dominant().to_array());
+        if opts.collect_indexed_colour_full {
+            out.indexed_colour_full.entry(geometry_id).or_insert(full);
+        }
+    }
+
+    // ── Material chain inputs (#407) ──
+    for &(id, start, end) in &spans.material_def_reprs {
+        if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
+            // RepresentedMaterial (attr 3) → Representations (attr 2).
+            if let Some(material_id) = entity.get_ref(3) {
+                if let Some(reprs) = refs_from_list(&entity, 2) {
+                    out.material_def_reprs
+                        .entry(material_id)
+                        .or_default()
+                        .extend(reprs);
+                }
+            }
+        }
+    }
+    for &(id, start, end) in &spans.rel_associates_material {
+        if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
+            // RelatingMaterial (attr 5) ← RelatedObjects (attr 4).
+            if let Some(material_select_id) = entity.get_ref(5) {
+                if let Some(related) = refs_from_list(&entity, 4) {
+                    for element_id in related {
+                        out.element_to_material.insert(element_id, material_select_id);
+                    }
+                }
+            }
+        }
+    }
+
+    // ── Voids + fills + aggregate propagation (#845) ──
+    for &(id, start, end) in &spans.void_rels {
+        if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
+            if let (Some(host), Some(opening)) = (entity.get_ref(4), entity.get_ref(5)) {
+                out.void_index.entry(host).or_default().push(opening);
+            }
+        }
+    }
+    for &(id, start, end) in &spans.fills_rels {
+        if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
+            // attr 4 = RelatingOpeningElement, attr 5 = RelatedBuildingElement.
+            if let (Some(opening_id), Some(filling_id)) = (entity.get_ref(4), entity.get_ref(5)) {
+                out.filling_by_opening.insert(opening_id, filling_id);
+            }
+        }
+    }
+    if !out.void_index.is_empty() && !spans.aggregate_rels.is_empty() {
+        let mut aggregate_children: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
+        for &(id, start, end) in &spans.aggregate_rels {
+            if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
+                let Some(parent_id) = entity.get_ref(4) else {
+                    continue;
+                };
+                if let Some(children) = refs_from_list(&entity, 5) {
+                    aggregate_children
+                        .entry(parent_id)
+                        .or_default()
+                        .extend(children);
+                }
+            }
+        }
+        ifc_lite_geometry::propagate_voids_via_aggregates(
+            &mut out.void_index,
+            &aggregate_children,
+        );
+    }
+
+    // ── Material chain join (#407): element id → colour list ──
+    out.element_material_colors = crate::style::build_element_material_colors(
+        &out.material_def_reprs,
+        &out.orphan_styled_items,
+        &out.element_to_material,
+        decoder,
+    );
+
+    out
+}
+
+/// Resolve geometry-attached styled-item spans into a style index — the
+/// defer-mode replay (`fast_first_batch`), and the building block
+/// [`resolve_prepass`] uses internally.
+pub fn resolve_styled_item_spans(
+    spans: &[(usize, usize)],
+    decoder: &mut EntityDecoder,
+) -> FxHashMap<u32, GeometryStyleInfo> {
+    let mut styles: FxHashMap<u32, GeometryStyleInfo> = FxHashMap::default();
+    for &(start, end) in spans {
+        if let Ok(styled_item) = decoder.decode_at(start, end) {
+            if styled_item.get_ref(0).is_some() {
+                collect_geometry_style_info(&mut styles, &styled_item, decoder);
+            }
+        }
+    }
+    styles
+}
+
+/// Fold `IfcIndexedColourMap` dominant colours into the style index, keyed by
+/// target geometry id. `or_insert` preserves IFCSTYLEDITEM precedence: a
+/// geometry that already has a direct style keeps it; the indexed colour only
+/// fills the gaps (#913).
+pub fn merge_indexed_colours(
+    geometry_styles: &mut FxHashMap<u32, GeometryStyleInfo>,
+    indexed_colours: &FxHashMap<u32, [f32; 4]>,
+) {
+    for (&geometry_id, &color) in indexed_colours {
+        geometry_styles
+            .entry(geometry_id)
+            .or_insert_with(|| GeometryStyleInfo::from_color(color));
+    }
+}
+
+/// The file's unit scales, resolved exactly once per parse.
+#[derive(Debug, Clone, Copy)]
+pub struct UnitScales {
+    /// Length unit → metres (1.0 for metre files, 0.001 for millimetre files).
+    pub length_unit_scale: f64,
+    /// Plane-angle unit → radians (1.0 for RADIAN files, π/180 for DEGREE).
+    pub plane_angle_to_radians: f64,
+    /// The `IFCPROJECT` express id the scales were resolved from, when found.
+    pub project_id: Option<u32>,
+}
+
+impl Default for UnitScales {
+    fn default() -> Self {
+        Self {
+            length_unit_scale: 1.0,
+            plane_angle_to_radians: 1.0,
+            project_id: None,
+        }
+    }
+}
+
+/// Resolve BOTH unit scales once, against the decoder's (possibly partial)
+/// entity index, with the documented fallback ladder:
+///
+/// 1. `project_id` hint (recorded by the scan) — O(1) decode via the index.
+/// 2. No hint? Find `IFCPROJECT` by SIMD substring search (it is a singleton
+///    and many exporters — IfcOpenShell, Revit — emit it near the END of the
+///    file, after the scan's early-meta point).
+/// 3. Resolution chain incomplete on a PARTIAL index (streaming early-meta:
+///    the IFCSIUNIT chain may sit past the scan point)? Re-resolve against a
+///    freshly built FULL index rather than silently defaulting — a millimetre
+///    model resolved as metres renders 1000× oversized.
+///
+/// This is the only sanctioned place that hunts for `IFCPROJECT`; per-element
+/// decoders are seeded from the result (`EntityDecoder::seed_unit_scales`) so
+/// the historic O(file)-scan-per-decoder stall class stays dead.
+pub fn resolve_unit_scales(
+    content: &[u8],
+    project_id_hint: Option<u32>,
+    decoder: &mut EntityDecoder,
+) -> UnitScales {
+    let project_id = project_id_hint.or_else(|| find_ifcproject_id(content));
+    let Some(pid) = project_id else {
+        return UnitScales::default();
+    };
+
+    // Fast path: resolve on the caller's decoder/index.
+    let length = ifc_lite_core::try_extract_length_unit_scale(decoder, pid);
+    let angle = ifc_lite_core::extract_plane_angle_to_radians(decoder, pid).ok();
+
+    if let (Some(length_unit_scale), Some(plane_angle_to_radians)) = (length, angle) {
+        return UnitScales {
+            length_unit_scale,
+            plane_angle_to_radians,
+            project_id,
+        };
+    }
+
+    // Chain incomplete (partial index) — resolve against a full index.
+    let full_index = ifc_lite_core::build_entity_index(content);
+    let mut full_decoder = EntityDecoder::with_index(content, full_index);
+    UnitScales {
+        length_unit_scale: length.or_else(|| {
+            ifc_lite_core::extract_length_unit_scale(&mut full_decoder, pid).ok()
+        })
+        .unwrap_or(1.0),
+        plane_angle_to_radians: angle
+            .or_else(|| {
+                ifc_lite_core::extract_plane_angle_to_radians(&mut full_decoder, pid).ok()
+            })
+            .unwrap_or(1.0),
+        project_id,
+    }
+}
+
+/// Find the singleton `IFCPROJECT`'s express id by SIMD substring search —
+/// no full entity scan. Returns `None` when the file has no project.
+pub fn find_ifcproject_id(content: &[u8]) -> Option<u32> {
+    let mut from = 0usize;
+    while let Some(rel) = memchr::memmem::find(&content[from..], b"=IFCPROJECT(") {
+        let eq = from + rel;
+        // Backtrack over the express id digits to the '#'.
+        let mut i = eq;
+        while i > 0 && content[i - 1].is_ascii_digit() {
+            i -= 1;
+        }
+        if i > 0 && content[i - 1] == b'#' && i < eq {
+            let mut id: u32 = 0;
+            for &b in &content[i..eq] {
+                id = id.wrapping_mul(10).wrapping_add((b - b'0') as u32);
+            }
+            return Some(id);
+        }
+        // `=IFCPROJECT(` without a leading `#<digits>` (e.g. inside a string)
+        // — keep searching.
+        from = eq + 1;
+    }
+    None
+}
+
+/// Flat wire encodings of the resolved styles for the browser's
+/// `styleIds`/`styleColors` arrays: the rich style index flattened to
+/// `(ids, rgba8)`, with IfcIndexedColourMap dominants, flat material colours,
+/// and per-element first material colours filling the gaps — the exact
+/// layered precedence the browser prepasses have always shipped.
+pub fn flat_styles_rgba8(resolved: &ResolvedPrepass, decoder: &mut EntityDecoder) -> (Vec<u32>, Vec<u8>) {
+    let mut merged: FxHashMap<u32, [f32; 4]> = resolved
+        .geometry_style_index
+        .iter()
+        .map(|(&id, info)| (id, info.color))
+        .collect();
+    for (&geometry_id, &color) in &resolved.indexed_colour_index {
+        merged.entry(geometry_id).or_insert(color);
+    }
+    // Flat material_id → colour, then element id → first material colour, so
+    // `processGeometryBatch`'s per-element fallback picks them up.
+    let material_styles = crate::style::build_material_style_index(
+        &resolved.material_def_reprs,
+        &resolved.orphan_styled_items,
+        decoder,
+    );
+    for (&mat_id, &color) in crate::style::flatten_material_color_index(&material_styles).iter() {
+        merged.entry(mat_id).or_insert(color);
+    }
+    for (&element_id, colors) in &resolved.element_material_colors {
+        if let Some(&color) = colors.first() {
+            merged.entry(element_id).or_insert(color);
+        }
+    }
+
+    let mut ids: Vec<u32> = Vec::with_capacity(merged.len());
+    let mut rgba: Vec<u8> = Vec::with_capacity(merged.len() * 4);
+    for (&id, &color) in &merged {
+        ids.push(id);
+        rgba.extend_from_slice(&crate::style::Rgba::from_array(color).to_rgba8());
+    }
+    (ids, rgba)
+}
+
+/// Flat wire encoding of the void index: `(keys, counts, values)` in the
+/// shape `processGeometryBatch` accepts.
+pub fn flat_voids(void_index: &FxHashMap<u32, Vec<u32>>) -> (Vec<u32>, Vec<u32>, Vec<u32>) {
+    let mut keys: Vec<u32> = Vec::with_capacity(void_index.len());
+    let mut counts: Vec<u32> = Vec::with_capacity(void_index.len());
+    let mut values: Vec<u32> = Vec::new();
+    for (&host_id, openings) in void_index {
+        keys.push(host_id);
+        counts.push(openings.len() as u32);
+        values.extend(openings.iter().copied());
+    }
+    (keys, counts, values)
+}
+
+/// Flat wire encoding of the element material colour lists (#407/#913 §2.3):
+/// `(element_ids, counts, rgba8)` — `counts[i]` colours belong to
+/// `element_ids[i]`, in order, 4 bytes each.
+pub fn flat_material_colors(
+    element_material_colors: &FxHashMap<u32, Vec<[f32; 4]>>,
+) -> (Vec<u32>, Vec<u32>, Vec<u8>) {
+    let mut ids: Vec<u32> = Vec::with_capacity(element_material_colors.len());
+    let mut counts: Vec<u32> = Vec::with_capacity(element_material_colors.len());
+    let mut rgba: Vec<u8> = Vec::new();
+    for (&element_id, colors) in element_material_colors {
+        if colors.is_empty() {
+            continue;
+        }
+        ids.push(element_id);
+        counts.push(colors.len() as u32);
+        for &c in colors {
+            rgba.extend_from_slice(&crate::style::Rgba::from_array(c).to_rgba8());
+        }
+    }
+    (ids, counts, rgba)
+}
+
+/// Decode the flat material-colour wire arrays back into the canonical map —
+/// the inverse of [`flat_material_colors`], used by `processGeometryBatch`.
+pub fn material_colors_from_flat(
+    element_ids: &[u32],
+    counts: &[u32],
+    rgba: &[u8],
+) -> FxHashMap<u32, Vec<[f32; 4]>> {
+    let mut out: FxHashMap<u32, Vec<[f32; 4]>> = FxHashMap::default();
+    let mut offset = 0usize;
+    for (i, &element_id) in element_ids.iter().enumerate() {
+        let Some(&count) = counts.get(i) else { break };
+        let count = count as usize;
+        let mut colors: Vec<[f32; 4]> = Vec::with_capacity(count);
+        for c in 0..count {
+            let base = (offset + c) * 4;
+            if base + 3 >= rgba.len() {
+                break;
+            }
+            colors.push(
+                crate::style::Rgba::from_rgba8([
+                    rgba[base],
+                    rgba[base + 1],
+                    rgba[base + 2],
+                    rgba[base + 3],
+                ])
+                .to_array(),
+            );
+        }
+        offset += count;
+        if !colors.is_empty() {
+            out.insert(element_id, colors);
+        }
+    }
+    out
+}
+
+// ── Styled-item resolution chain (moved from processor.rs — shared) ──
+
+/// Resolve a geometry-attached `IfcStyledItem` into the style index with
+/// first-wins precedence per geometry id (file order = authored intent).
+pub(crate) fn collect_geometry_style_info(
+    geometry_styles: &mut FxHashMap<u32, GeometryStyleInfo>,
+    styled_item: &DecodedEntity,
+    decoder: &mut EntityDecoder,
+) {
+    let Some(geometry_id) = styled_item.get_ref(0) else {
+        return;
+    };
+    if geometry_styles.contains_key(&geometry_id) {
+        return;
+    }
+    if let Some(style_info) = extract_style_info_from_styled_item(styled_item, decoder) {
+        geometry_styles.insert(geometry_id, style_info);
+    }
+}
+
+/// Extract colour + name from an `IfcStyledItem` by traversing its style
+/// references (directly or through `IfcPresentationStyleAssignment`).
+pub(crate) fn extract_style_info_from_styled_item(
+    styled_item: &DecodedEntity,
+    decoder: &mut EntityDecoder,
+) -> Option<GeometryStyleInfo> {
+    let style_refs = refs_from_list(styled_item, 1)?;
+
+    for style_id in style_refs {
+        if let Ok(style) = decoder.decode_by_id(style_id) {
+            // IfcPresentationStyleAssignment has nested style refs at attr 0.
+            if let Some(inner_refs) = refs_from_list(&style, 0) {
+                for inner_id in inner_refs {
+                    if let Some(info) = extract_surface_style_info(inner_id, decoder) {
+                        return Some(info);
+                    }
+                }
+            }
+
+            // Or the style ref points directly to IfcSurfaceStyle.
+            if let Some(info) = extract_surface_style_info(style_id, decoder) {
+                return Some(info);
+            }
+        }
+    }
+
+    None
+}
+
+/// Extract colour + style name from an `IfcSurfaceStyle`. Colour resolution is
+/// the canonical [`crate::style::extract_surface_style_colors`], shared with
+/// the browser pre-pass so the server and viewer can't disagree on
+/// `SurfaceColour` vs `DiffuseColour` precedence (#997).
+fn extract_surface_style_info(
+    style_id: u32,
+    decoder: &mut EntityDecoder,
+) -> Option<GeometryStyleInfo> {
+    let style = decoder.decode_by_id(style_id).ok()?;
+    let material_name = normalize_style_name(style.get_string(0));
+    let (color, shading_color) = crate::style::extract_surface_style_colors(style_id, decoder)?;
+    Some(GeometryStyleInfo {
+        color,
+        shading_color,
+        material_name,
+    })
+}
+
+fn normalize_style_name(raw: Option<&str>) -> Option<String> {
+    let name = raw?.trim();
+    if name.is_empty() || name == "$" {
+        return None;
+    }
+    if name.eq_ignore_ascii_case("<unnamed>") || name.eq_ignore_ascii_case("unnamed") {
+        return None;
+    }
+    Some(name.to_string())
+}
+
+/// Extract entity references from a list attribute.
+fn refs_from_list(entity: &DecodedEntity, index: usize) -> Option<Vec<u32>> {
+    let list = entity.get_list(index)?;
+    let refs: Vec<u32> = list.iter().filter_map(|v| v.as_entity_ref()).collect();
+    if refs.is_empty() {
+        None
+    } else {
+        Some(refs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_ifcproject_id_late_in_file() {
+        let ifc = b"ISO-10303-21;\nDATA;\n#1=IFCWALL('x',$,$,$,$,$,$,$,$);\n#999123=IFCPROJECT('g',$,'P',$,$,$,$,$,$);\nENDSEC;\n";
+        assert_eq!(find_ifcproject_id(ifc), Some(999123));
+    }
+
+    #[test]
+    fn find_ifcproject_id_absent() {
+        let ifc = b"ISO-10303-21;\nDATA;\n#1=IFCWALL('x',$,$,$,$,$,$,$,$);\nENDSEC;\n";
+        assert_eq!(find_ifcproject_id(ifc), None);
+    }
+
+    #[test]
+    fn find_ifcproject_id_skips_string_decoys() {
+        let ifc = b"DATA;\n#5=IFCWALL('decoy =IFCPROJECT( in a name',$);\n#7=IFCPROJECT('g',$);\n";
+        assert_eq!(find_ifcproject_id(ifc), Some(7));
+    }
+
+    #[test]
+    fn material_colors_flat_round_trip() {
+        let mut map: FxHashMap<u32, Vec<[f32; 4]>> = FxHashMap::default();
+        map.insert(10, vec![[0.5, 0.5, 0.5, 1.0], [0.7, 0.9, 0.5, 0.2]]);
+        map.insert(42, vec![[1.0, 0.0, 0.0, 1.0]]);
+
+        let (ids, counts, rgba) = flat_material_colors(&map);
+        let back = material_colors_from_flat(&ids, &counts, &rgba);
+
+        assert_eq!(back.len(), 2);
+        assert_eq!(back[&42].len(), 1);
+        assert_eq!(back[&10].len(), 2);
+        // RGBA8 quantization: equal within 1/255.
+        for (orig, round) in map[&10].iter().zip(back[&10].iter()) {
+            for (a, b) in orig.iter().zip(round.iter()) {
+                assert!((a - b).abs() <= 1.0 / 255.0 + 1e-6);
+            }
+        }
+    }
+
+    #[test]
+    fn resolve_unit_scales_resolves_degrees_and_millimetres() {
+        const IFC: &[u8] = br#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('u.ifc','2026-06-12T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCWALL('w',$,$,$,$,$,$,$,$);
+#10=IFCPROJECT('g',$,'P',$,$,$,$,$,#11);
+#11=IFCUNITASSIGNMENT((#12,#13));
+#12=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);
+#13=IFCCONVERSIONBASEDUNIT(#14,.PLANEANGLEUNIT.,'DEGREE',#15);
+#14=IFCDIMENSIONALEXPONENTS(0,0,0,0,0,0,0);
+#15=IFCMEASUREWITHUNIT(IFCPLANEANGLEMEASURE(0.017453292519943295),#16);
+#16=IFCSIUNIT(*,.PLANEANGLEUNIT.,$,.RADIAN.);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+        // No hint: found by substring search; resolved on a fresh decoder.
+        let mut decoder = EntityDecoder::new(IFC);
+        let scales = resolve_unit_scales(IFC, None, &mut decoder);
+        assert_eq!(scales.project_id, Some(10));
+        assert!((scales.length_unit_scale - 0.001).abs() < 1e-12);
+        assert!((scales.plane_angle_to_radians - 0.017_453_292_519_943_295).abs() < 1e-12);
+    }
+}

--- a/rust/processing/src/processor.rs
+++ b/rust/processing/src/processor.rs
@@ -840,34 +840,20 @@ pub fn process_geometry_streaming_filtered_with_options(
     let mut decoder = EntityDecoder::with_arc_index(content, entity_index.clone());
     tracing::debug!("Built entity index");
 
-    let mut geometry_style_index: FxHashMap<u32, GeometryStyleInfo> = FxHashMap::default();
-    // IfcIndexedColourMap data, keyed by target geometry id (issue #913).
-    // Collected eagerly regardless of `defer_style_updates`. The dominant
-    // colour is merged into `geometry_style_index` (styled items win); the full
-    // per-triangle map drives sub-mesh splitting at emission (#858).
-    let mut indexed_colour_index: FxHashMap<u32, [f32; 4]> = FxHashMap::default();
-    let mut indexed_colour_full: FxHashMap<u32, crate::style::FullIndexedColourMap> =
-        FxHashMap::default();
-    // Material-chain colour inputs (issue #407): orphan IfcStyledItem colours,
-    // material → styled representations, and element → material associations.
-    // Joined into `element_material_color` after the scan.
-    let mut orphan_styled_items: FxHashMap<u32, [f32; 4]> = FxHashMap::default();
-    let mut material_def_reprs: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
-    let mut element_to_material: FxHashMap<u32, u32> = FxHashMap::default();
+    // Styled items / indexed colour maps / material chain / voids / fills /
+    // aggregates are span-stashed during the scan and resolved afterwards by
+    // the SHARED resolver (`crate::prepass::resolve_prepass`) — the exact code
+    // the browser prepasses run, so the #858/#913-class resolution drift
+    // cannot recur.
+    let mut prepass_spans = crate::prepass::PrepassSpans::default();
+    let mut project_id: Option<u32> = None;
     let mut presentation_layer_by_assigned_id: FxHashMap<u32, String> = FxHashMap::default();
     let mut property_values_by_id: FxHashMap<u32, (String, String)> = FxHashMap::default();
     let mut property_sets_by_id: FxHashMap<u32, PropertySetDefinition> = FxHashMap::default();
     let mut rel_defines_by_properties: Vec<RelDefinesByPropertiesLink> = Vec::new();
 
-    // Collect geometry entities and build void index
+    // Collect geometry entities
     let mut scanner = EntityScanner::new(content);
-    let mut void_index: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
-    let mut filling_by_opening: FxHashMap<u32, u32> = FxHashMap::default();
-    // Parent → aggregated children, used to propagate void cuts from a
-    // host with no body (e.g. IFC4 IfcWallElementedCase) to the parts
-    // that actually carry the geometry. See `propagate_voids_to_parts`
-    // below.
-    let mut aggregate_children: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
     let mut entity_jobs: Vec<EntityJob> = Vec::with_capacity(2000);
     // #957: type-product geometry (IfcXxxType + its RepresentationMaps) and the
     // set of RepresentationMaps already instantiated by an IfcMappedItem. After
@@ -910,7 +896,6 @@ pub fn process_geometry_streaming_filtered_with_options(
     let defer_style_updates = options.fast_first_batch
         && opening_filter == OpeningFilterMode::Default
         && !options.include_presentation_layers;
-    let mut deferred_styled_item_positions: Vec<(usize, usize)> = Vec::new();
 
     while let Some((id, type_name, start, end)) = scanner.next_entity() {
         total_entities += 1;
@@ -958,89 +943,22 @@ pub fn process_geometry_streaming_filtered_with_options(
         }
 
         if type_name == "IFCINDEXEDCOLOURMAP" {
-            // Collect authored tessellation colours so the backend matches the
-            // browser on CATIA-style exports that have no IFCSTYLEDITEM (#663,
-            // #858).
-            if let Ok(icm) = decoder.decode_at(start, end) {
-                if let Some(full) =
-                    crate::style::resolve_indexed_colour_map_full(&icm, &mut decoder)
-                {
-                    let geometry_id = full.geometry_id;
-                    indexed_colour_index
-                        .entry(geometry_id)
-                        .or_insert(full.dominant().to_array());
-                    indexed_colour_full.entry(geometry_id).or_insert(full);
-                }
-            }
+            // Span-stashed for the shared post-scan resolver (#663, #858).
+            prepass_spans.indexed_colour_maps.push((id, start, end));
             continue;
         }
 
         if type_name == "IFCSTYLEDITEM" {
-            if defer_style_updates {
-                // Only *geometry-attached* styled items are deferred (rebuilt
-                // from saved byte positions after the first batch). Orphan
-                // styled items (null Item) are material appearances (#407) that
-                // feed the material chain — resolved once, up front, before the
-                // deferred rebuild — so they must be collected now or
-                // material-only-styled elements render as the default gray even
-                // after the deferred pass (#913 §2c). The classifying decode is
-                // the cost of telling the two apart.
-                if let Ok(styled_item) = decoder.decode_at(start, end) {
-                    if styled_item.get_ref(0).is_none() {
-                        if let Some(info) =
-                            extract_style_info_from_styled_item(&styled_item, &mut decoder)
-                        {
-                            orphan_styled_items.insert(id, info.color);
-                        }
-                        continue;
-                    }
-                }
-                // Geometry-attached (or undecodable) → defer the rebuild.
-                deferred_styled_item_positions.push((start, end));
-                continue;
-            }
-            if let Ok(styled_item) = decoder.decode_at(start, end) {
-                if styled_item.get_ref(0).is_none() {
-                    // Orphan styled item (null Item) = a material appearance
-                    // (#407). Collect its colour for the material chain.
-                    if let Some(info) =
-                        extract_style_info_from_styled_item(&styled_item, &mut decoder)
-                    {
-                        orphan_styled_items.insert(id, info.color);
-                    }
-                } else {
-                    collect_geometry_style_info(
-                        &mut geometry_style_index,
-                        &styled_item,
-                        &mut decoder,
-                    );
-                }
-            }
+            // Span-stashed; the shared resolver classifies orphan (material
+            // appearance, #407 — always resolved up front) vs
+            // geometry-attached (deferred in fast_first_batch mode, #913 §2c).
+            prepass_spans.styled_items.push((id, start, end));
             continue;
         } else if type_name == "IFCMATERIALDEFINITIONREPRESENTATION" {
-            // RepresentedMaterial (attr 3) → Representations (attr 2).
-            if let Ok(entity) = decoder.decode_at(start, end) {
-                if let Some(material_id) = entity.get_ref(3) {
-                    if let Some(reprs) = get_refs_from_list(&entity, 2) {
-                        material_def_reprs
-                            .entry(material_id)
-                            .or_default()
-                            .extend(reprs);
-                    }
-                }
-            }
+            prepass_spans.material_def_reprs.push((id, start, end));
             continue;
         } else if type_name == "IFCRELASSOCIATESMATERIAL" {
-            // RelatingMaterial (attr 5) ← RelatedObjects (attr 4).
-            if let Ok(entity) = decoder.decode_at(start, end) {
-                if let Some(material_select_id) = entity.get_ref(5) {
-                    if let Some(related) = get_refs_from_list(&entity, 4) {
-                        for element_id in related {
-                            element_to_material.insert(element_id, material_select_id);
-                        }
-                    }
-                }
-            }
+            prepass_spans.rel_associates_material.push((id, start, end));
             continue;
         } else if type_name == "IFCPRESENTATIONLAYERASSIGNMENT" {
             if !options.include_presentation_layers {
@@ -1084,36 +1002,17 @@ pub fn process_geometry_streaming_filtered_with_options(
             }
             continue;
         } else if type_name == "IFCRELVOIDSELEMENT" {
-            if let Ok(entity) = decoder.decode_at(start, end) {
-                if let (Some(host), Some(opening)) = (entity.get_ref(4), entity.get_ref(5)) {
-                    void_index.entry(host).or_default().push(opening);
-                }
-            }
+            prepass_spans.void_rels.push((id, start, end));
         } else if type_name == "IFCRELFILLSELEMENT" {
-            if let Ok(entity) = decoder.decode_at(start, end) {
-                // attr 4 = RelatingOpeningElement, attr 5 = RelatedBuildingElement (window/door)
-                if let (Some(opening_id), Some(filling_id)) = (entity.get_ref(4), entity.get_ref(5))
-                {
-                    filling_by_opening.insert(opening_id, filling_id);
-                }
-            }
+            prepass_spans.fills_rels.push((id, start, end));
         } else if type_name == "IFCRELAGGREGATES" {
-            // Independent of quick-metadata mode: keep a parent → children
-            // index so we can push voids down to aggregated parts when the
-            // host element has no body of its own (IfcWallElementedCase).
-            let args = parse_step_arguments(&content[start..end]);
-            if let Some(parent_id) = args.get(4).and_then(|token| parse_step_ref(token)) {
-                let kids = args
-                    .get(5)
-                    .map(|token| parse_step_ref_list(token))
-                    .unwrap_or_default();
-                if !kids.is_empty() {
-                    aggregate_children
-                        .entry(parent_id)
-                        .or_default()
-                        .extend(kids);
-                }
-            }
+            // Independent of quick-metadata mode: the shared resolver decodes
+            // these into the parent → children map that pushes voids down to
+            // aggregated parts when the host has no body of its own
+            // (IfcWallElementedCase, #845).
+            prepass_spans.aggregate_rels.push((id, start, end));
+        } else if type_name == "IFCPROJECT" && project_id.is_none() {
+            project_id = Some(id);
         } else if type_name == "IFCSITE" && site_entity_pos.is_none() {
             site_entity_pos = Some((start, end));
         } else if type_name == "IFCBUILDING" && building_entity_pos.is_none() {
@@ -1224,13 +1123,28 @@ pub fn process_geometry_streaming_filtered_with_options(
         }
     }
 
-    // IfcWallElementedCase + friends: when an opening voids a host that
-    // aggregates parts (drywall panels, studs, tracks) and has no body
-    // representation of its own, the opening must propagate to every
-    // aggregated descendant so the part meshes get the cut. Without this
-    // propagation the cut silently no-ops (the host has nothing to clip)
-    // and panels/studs cover what should be the window/door hole.
-    ifc_lite_geometry::propagate_voids_via_aggregates(&mut void_index, &aggregate_children);
+    // ── Shared post-scan resolution (`crate::prepass`) ──
+    // Styled items (orphan vs attached, defer-aware), IfcIndexedColourMap,
+    // the #407 material chain join, voids + fills, and the #845 aggregate
+    // void propagation — the exact code the browser prepasses run.
+    let resolved = crate::prepass::resolve_prepass(
+        &prepass_spans,
+        &mut decoder,
+        crate::prepass::ResolveOptions {
+            collect_indexed_colour_full: true,
+            defer_attached_styles: defer_style_updates,
+        },
+    );
+    let crate::prepass::ResolvedPrepass {
+        mut geometry_style_index,
+        indexed_colour_index,
+        indexed_colour_full,
+        element_material_colors,
+        void_index,
+        filling_by_opening,
+        deferred_attached_styled_spans: deferred_styled_item_positions,
+        ..
+    } = resolved;
 
     let entity_scan_time = entity_scan_start.elapsed();
 
@@ -1328,7 +1242,17 @@ pub fn process_geometry_streaming_filtered_with_options(
 
     // Preprocess complex geometry
     let preprocess_start = std::time::Instant::now();
-    let mut router = GeometryRouter::with_units(content, &mut decoder);
+    // Resolve BOTH unit scales once via the shared resolver (the scan recorded
+    // IFCPROJECT's id, so this is an O(1) decode — no more full-file hunts:
+    // the historic `with_units` + `plane_angle_to_radians` pair each re-walked
+    // the whole DATA section). Seed the shared decoder so every later consumer
+    // (opening filter, metadata phase, deferred-style replay) inherits them.
+    let unit_scales = crate::prepass::resolve_unit_scales(content, project_id, &mut decoder);
+    decoder.seed_unit_scales(
+        unit_scales.length_unit_scale,
+        unit_scales.plane_angle_to_radians,
+    );
+    let mut router = GeometryRouter::with_scale(unit_scales.length_unit_scale);
     router.set_tessellation_quality(options.tessellation_quality);
 
     // Resolve IfcSite and IfcBuilding placement transforms.
@@ -1393,19 +1317,18 @@ pub fn process_geometry_streaming_filtered_with_options(
     let unit_scale = router.unit_scale();
     let rtc_offset = router.rtc_offset();
     // Resolve the plane-angle scale ONCE on the warm shared decoder, then seed
-    // every per-element worker decoder below (EntityDecoder::seed_unit_scales;
-    // the length scale is `unit_scale`, already resolved by the router). Both
-    // resolvers scan the whole DATA section for the singleton IFCPROJECT, which
-    // IfcOpenShell emits near the *end* of the file — and the parallel path
-    // builds a fresh (cold-cache) decoder per element, so without seeding every
-    // arc-bearing element re-pays that ~O(file) scan (≈135 ms each on a 75 MB
-    // model where IFCPROJECT sits at byte ~68 MB).
-    let seed_plane_angle_to_radians = decoder.plane_angle_to_radians();
+    // every per-element worker decoder below (EntityDecoder::seed_unit_scales).
+    // Resolved once by the shared `prepass::resolve_unit_scales` above — the
+    // parallel path builds a fresh (cold-cache) decoder per element, so
+    // without seeding every arc-bearing element would re-pay an O(file)
+    // IFCPROJECT scan (≈135 ms each on a 75 MB model where IFCPROJECT sits at
+    // byte ~68 MB).
+    let seed_plane_angle_to_radians = unit_scales.plane_angle_to_radians;
     let void_index_arc = Arc::new(filtered_void_index);
     let skipped_entity_ids = Arc::new(skipped_entity_ids);
     // Fold indexed-colour-map colours in where no IFCSTYLEDITEM already claimed
     // the geometry (styled items win, matching the browser precedence).
-    merge_indexed_colours(&mut geometry_style_index, &indexed_colour_index);
+    crate::prepass::merge_indexed_colours(&mut geometry_style_index, &indexed_colour_index);
     let mut geometry_style_index = Arc::new(geometry_style_index);
     let indexed_colour_full = Arc::new(indexed_colour_full);
     // #961: decode surface textures (IfcBlobTexture PNG / IfcPixelTexture) and
@@ -1416,15 +1339,9 @@ pub fn process_geometry_streaming_filtered_with_options(
         content,
         &mut decoder,
     ));
-    // Join the material chain into colours per element (#407). The single
+    // Material chain joined by the shared resolver (#407). The single
     // opaque-first colour is the general-path element fallback; the full list
     // feeds the opening sub-mesh transparent/opaque split (#913 §2.3).
-    let element_material_colors = crate::style::build_element_material_colors(
-        &material_def_reprs,
-        &orphan_styled_items,
-        &element_to_material,
-        &mut decoder,
-    );
     let element_material_color: FxHashMap<u32, [f32; 4]> = element_material_colors
         .iter()
         .filter_map(|(&id, colors)| crate::style::pick_opaque_first(colors).map(|c| (id, c)))
@@ -1583,21 +1500,17 @@ pub fn process_geometry_streaming_filtered_with_options(
             if !deferred_styles_applied {
                 // Replay saved IFCSTYLEDITEM positions instead of re-scanning
                 // the entire file.  This eliminates ~0.5-1 s for 1 GB files.
-                let mut rebuilt_styles: FxHashMap<u32, GeometryStyleInfo> = FxHashMap::default();
-                {
+                // The replay is the shared resolver's styled-item building
+                // block, so deferred and up-front resolution cannot drift.
+                let mut rebuilt_styles = {
                     let mut style_decoder =
                         EntityDecoder::with_arc_index(content, entity_index_arc.clone());
-                    for &(start, end) in &deferred_styled_item_positions {
-                        if let Ok(styled_item) = style_decoder.decode_at(start, end) {
-                            collect_geometry_style_info(
-                                &mut rebuilt_styles,
-                                &styled_item,
-                                &mut style_decoder,
-                            );
-                        }
-                    }
-                }
-                merge_indexed_colours(&mut rebuilt_styles, &indexed_colour_index);
+                    crate::prepass::resolve_styled_item_spans(
+                        &deferred_styled_item_positions,
+                        &mut style_decoder,
+                    )
+                };
+                crate::prepass::merge_indexed_colours(&mut rebuilt_styles, &indexed_colour_index);
                 geometry_style_index = Arc::new(rebuilt_styles);
                 let deferred_color_updates = build_color_updates_for_jobs(
                     &entity_jobs[..processed_jobs],
@@ -1787,41 +1700,6 @@ fn process_entity_job(
 }
 
 
-/// Fold `IfcIndexedColourMap` colours into the style index, keyed by target
-/// geometry id. `or_insert` preserves IFCSTYLEDITEM precedence: a geometry that
-/// already has a direct style keeps it; the indexed colour only fills the gaps.
-fn merge_indexed_colours(
-    geometry_styles: &mut FxHashMap<u32, GeometryStyleInfo>,
-    indexed_colours: &FxHashMap<u32, [f32; 4]>,
-) {
-    for (&geometry_id, &color) in indexed_colours {
-        geometry_styles
-            .entry(geometry_id)
-            .or_insert_with(|| GeometryStyleInfo {
-                color,
-                shading_color: None,
-                material_name: None,
-            });
-    }
-}
-
-fn collect_geometry_style_info(
-    geometry_styles: &mut FxHashMap<u32, GeometryStyleInfo>,
-    styled_item: &DecodedEntity,
-    decoder: &mut EntityDecoder,
-) {
-    let Some(geometry_id) = styled_item.get_ref(0) else {
-        return;
-    };
-
-    if geometry_styles.contains_key(&geometry_id) {
-        return;
-    }
-
-    if let Some(style_info) = extract_style_info_from_styled_item(styled_item, decoder) {
-        geometry_styles.insert(geometry_id, style_info);
-    }
-}
 
 fn build_color_updates_for_jobs(
     jobs: &[EntityJob],
@@ -2052,67 +1930,6 @@ fn find_color_in_shape_representation(
     }
 
     None
-}
-
-/// Extract color from an IfcStyledItem by traversing style references.
-fn extract_style_info_from_styled_item(
-    styled_item: &DecodedEntity,
-    decoder: &mut EntityDecoder,
-) -> Option<GeometryStyleInfo> {
-    let style_refs = get_refs_from_list(styled_item, 1)?;
-
-    for style_id in style_refs {
-        if let Ok(style) = decoder.decode_by_id(style_id) {
-            // IfcPresentationStyleAssignment has nested style refs at attr 0.
-            if let Some(inner_refs) = get_refs_from_list(&style, 0) {
-                for inner_id in inner_refs {
-                    if let Some(info) = extract_surface_style_info(inner_id, decoder) {
-                        return Some(info);
-                    }
-                }
-            }
-
-            // Or the style ref points directly to IfcSurfaceStyle.
-            if let Some(info) = extract_surface_style_info(style_id, decoder) {
-                return Some(info);
-            }
-        }
-    }
-
-    None
-}
-
-/// Extract colour + style name from an `IfcSurfaceStyle`. Colour resolution is
-/// the canonical [`crate::style::extract_surface_style_colors`], shared with the
-/// browser pre-pass so the server and viewer can't disagree on
-/// `SurfaceColour` vs `DiffuseColour` precedence (see that fn for the #859/#871
-/// semantics — `SurfaceColour` is the apparent colour; a `DiffuseColour`
-/// `IfcColourRgb` becomes the optional `shading_color`, not the rendered colour).
-fn extract_surface_style_info(
-    style_id: u32,
-    decoder: &mut EntityDecoder,
-) -> Option<GeometryStyleInfo> {
-    let style = decoder.decode_by_id(style_id).ok()?;
-    let material_name = normalize_style_name(style.get_string(0));
-    let (color, shading_color) = crate::style::extract_surface_style_colors(style_id, decoder)?;
-    Some(GeometryStyleInfo {
-        color,
-        shading_color,
-        material_name,
-    })
-}
-
-fn normalize_style_name(raw: Option<&str>) -> Option<String> {
-    let name = raw?.trim();
-    if name.is_empty() || name == "$" {
-        return None;
-    }
-
-    if name.eq_ignore_ascii_case("<unnamed>") || name.eq_ignore_ascii_case("unnamed") {
-        return None;
-    }
-
-    Some(name.to_string())
 }
 
 /// Apply the opening filter and return which entity IDs to suppress and a filtered void index.

--- a/rust/wasm-bindings/src/api/gpu_meshes.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes.rs
@@ -53,11 +53,16 @@ impl IfcAPI {
         // Run combined pre-pass
         let pre_pass = combined_pre_pass(content, &mut decoder);
 
-        // Extract unit scale
-        let unit_scale = pre_pass
-            .project_id
-            .and_then(|pid| ifc_lite_core::extract_length_unit_scale(&mut decoder, pid).ok())
-            .unwrap_or(1.0);
+        // Resolve BOTH unit scales once via the shared resolver (handles a
+        // missing project-id hint and partial-index chains internally) and
+        // seed the decoder so nothing downstream re-pays the IFCPROJECT hunt.
+        let unit_scales = ifc_lite_processing::prepass::resolve_unit_scales(
+            content,
+            pre_pass.project_id,
+            &mut decoder,
+        );
+        let unit_scale = unit_scales.length_unit_scale;
+        decoder.seed_unit_scales(unit_scale, unit_scales.plane_angle_to_radians);
         let mut router = GeometryRouter::with_scale(unit_scale);
 
         // Detect RTC offset
@@ -95,50 +100,38 @@ impl IfcAPI {
             idx += 3;
         }
 
-        // Serialize void_index as 3 flat arrays: keys, counts, values
-        let void_keys_vec: Vec<u32> = pre_pass.void_index.keys().copied().collect();
-        let mut void_counts_vec: Vec<u32> = Vec::with_capacity(void_keys_vec.len());
-        let mut void_values_vec: Vec<u32> = Vec::new();
-        for &key in &void_keys_vec {
-            if let Some(openings) = pre_pass.void_index.get(&key) {
-                void_counts_vec.push(openings.len() as u32);
-                void_values_vec.extend_from_slice(openings);
-            }
-        }
+        // Flat wire encodings from the shared resolver: styles (layered
+        // precedence), voids, and the #407 material colour lists.
+        let (style_ids_vec, style_colors_vec) = ifc_lite_processing::prepass::flat_styles_rgba8(
+            &pre_pass.resolved,
+            &mut decoder,
+        );
+        let (void_keys_vec, void_counts_vec, void_values_vec) =
+            ifc_lite_processing::prepass::flat_voids(&pre_pass.resolved.void_index);
+        let (mat_ids_vec, mat_counts_vec, mat_colors_vec) =
+            ifc_lite_processing::prepass::flat_material_colors(
+                &pre_pass.resolved.element_material_colors,
+            );
 
-        let void_keys = js_sys::Uint32Array::new_with_length(void_keys_vec.len() as u32);
-        for (i, &k) in void_keys_vec.iter().enumerate() {
-            void_keys.set_index(i as u32, k);
-        }
-        let void_counts = js_sys::Uint32Array::new_with_length(void_counts_vec.len() as u32);
-        for (i, &c) in void_counts_vec.iter().enumerate() {
-            void_counts.set_index(i as u32, c);
-        }
-        let void_values = js_sys::Uint32Array::new_with_length(void_values_vec.len() as u32);
-        for (i, &v) in void_values_vec.iter().enumerate() {
-            void_values.set_index(i as u32, v);
-        }
-
-        // Serialize geometry_styles as two arrays: styleIds (u32) + styleColors (u8 RGBA)
-        let styles_len = pre_pass.geometry_styles.len();
-        let style_ids = js_sys::Uint32Array::new_with_length(styles_len as u32);
-        let style_colors = js_sys::Uint8Array::new_with_length((styles_len * 4) as u32);
-        let mut si = 0u32;
-        for (&id, &color) in &pre_pass.geometry_styles {
-            style_ids.set_index(si, id);
-            let ci = si * 4;
-            style_colors.set_index(ci, (color[0] * 255.0) as u8);
-            style_colors.set_index(ci + 1, (color[1] * 255.0) as u8);
-            style_colors.set_index(ci + 2, (color[2] * 255.0) as u8);
-            style_colors.set_index(ci + 3, (color[3] * 255.0) as u8);
-            si += 1;
-        }
+        let void_keys = js_sys::Uint32Array::from(void_keys_vec.as_slice());
+        let void_counts = js_sys::Uint32Array::from(void_counts_vec.as_slice());
+        let void_values = js_sys::Uint32Array::from(void_values_vec.as_slice());
+        let style_ids = js_sys::Uint32Array::from(style_ids_vec.as_slice());
+        let style_colors = js_sys::Uint8Array::from(style_colors_vec.as_slice());
+        let material_element_ids = js_sys::Uint32Array::from(mat_ids_vec.as_slice());
+        let material_color_counts = js_sys::Uint32Array::from(mat_counts_vec.as_slice());
+        let material_colors = js_sys::Uint8Array::from(mat_colors_vec.as_slice());
 
         // Build result object
         let result = js_sys::Object::new();
         super::set_js_prop(&result, "jobs", &jobs_flat);
         super::set_js_prop(&result, "totalJobs", &(total_jobs as f64).into());
         super::set_js_prop(&result, "unitScale", &unit_scale.into());
+        super::set_js_prop(
+            &result,
+            "planeAngleToRadians",
+            &unit_scales.plane_angle_to_radians.into(),
+        );
 
         let rtc_arr = js_sys::Float64Array::new_with_length(3);
         rtc_arr.set_index(0, rtc_offset.0);
@@ -157,6 +150,11 @@ impl IfcAPI {
         super::set_js_prop(&result, "voidValues", &void_values);
         super::set_js_prop(&result, "styleIds", &style_ids);
         super::set_js_prop(&result, "styleColors", &style_colors);
+        // #407/#913 §2.3: per-element material colour lists so the batch path
+        // can run the transparent/opaque sub-mesh alternation.
+        super::set_js_prop(&result, "materialElementIds", &material_element_ids);
+        super::set_js_prop(&result, "materialColorCounts", &material_color_counts);
+        super::set_js_prop(&result, "materialColors", &material_colors);
 
         result.into()
     }
@@ -211,21 +209,10 @@ impl IfcAPI {
         let mut project_id: Option<u32> = None;
         let mut site_position: Option<(u32, usize, usize)> = None;
         let mut meta_emitted = false;
+        // Plane-angle scale, resolved with the meta by the shared resolver and
+        // carried on the meta event so workers seed their batch decoders.
+        let mut plane_angle_to_radians = 1.0f64;
 
-        // Style/void/material data collected during the scan — same shape as
-        // `combined_pre_pass` collects for `buildPrePassOnce`. Emitted as a
-        // `styles` event after the scan completes so workers can switch from
-        // default colors to resolved colors mid-stream and the host can fire a
-        // `colorUpdate` to retroactively fix already-emitted meshes.
-        let mut geometry_styles: rustc_hash::FxHashMap<u32, [f32; 4]> =
-            rustc_hash::FxHashMap::default();
-        let mut void_index: rustc_hash::FxHashMap<u32, Vec<u32>> = rustc_hash::FxHashMap::default();
-        let mut orphan_styled_items: rustc_hash::FxHashMap<u32, [f32; 4]> =
-            rustc_hash::FxHashMap::default();
-        let mut material_def_reprs: rustc_hash::FxHashMap<u32, Vec<u32>> =
-            rustc_hash::FxHashMap::default();
-        let mut element_to_material: rustc_hash::FxHashMap<u32, u32> =
-            rustc_hash::FxHashMap::default();
         // Hold a chunk buffer that we drain to JS — these are the last
         // `chunk_size` jobs awaiting flush. After `meta` the buffer is
         // drained as the first jobs event; subsequent flushes happen at
@@ -259,17 +246,10 @@ impl IfcAPI {
         // Spans of entities that need decoding for style collection — we
         // can't decode mid-scan because the decoder borrows `content` and
         // would need `entity_index` populated for any references it follows.
-        // Stash the spans here and process them after the scan in one pass.
-        let mut styled_item_spans: Vec<(u32, usize, usize)> = Vec::new();
-        // IfcIndexedColourMap entries — the second IFC4 colouring mechanism
-        // used by CATIA / 3DEXPERIENCE exports (#663). Resolved in the same
-        // post-scan pass as IfcStyledItem.
-        let mut indexed_colour_map_spans: Vec<(u32, usize, usize)> = Vec::new();
-        let mut material_entity_spans: Vec<(u32, &'static str, usize, usize)> = Vec::new();
-        let mut void_rel_spans: Vec<(u32, usize, usize)> = Vec::new();
-        // IfcRelAggregates spans — decoded post-scan into the parent→children
-        // map that drives aggregate void propagation (no extra file scan).
-        let mut aggregate_rel_spans: Vec<(u32, usize, usize)> = Vec::new();
+        // Stash them in the SHARED span container and resolve after the scan
+        // with `ifc_lite_processing::prepass::resolve_prepass` — the exact
+        // resolver the native pipeline and `buildPrePassOnce` run.
+        let mut prepass_spans = ifc_lite_processing::prepass::PrepassSpans::default();
 
         while let Some((id, type_name, start, end)) = scanner.next_entity() {
             // Build entity index inline (same data we'd otherwise re-scan for).
@@ -290,27 +270,25 @@ impl IfcAPI {
                     total_jobs += 1;
                 }
                 "IFCSTYLEDITEM" => {
-                    styled_item_spans.push((id, start, end));
+                    prepass_spans.styled_items.push((id, start, end));
                 }
                 "IFCINDEXEDCOLOURMAP" => {
-                    indexed_colour_map_spans.push((id, start, end));
+                    prepass_spans.indexed_colour_maps.push((id, start, end));
                 }
                 "IFCMATERIALDEFINITIONREPRESENTATION" => {
-                    material_entity_spans.push((
-                        id,
-                        "IFCMATERIALDEFINITIONREPRESENTATION",
-                        start,
-                        end,
-                    ));
+                    prepass_spans.material_def_reprs.push((id, start, end));
                 }
                 "IFCRELASSOCIATESMATERIAL" => {
-                    material_entity_spans.push((id, "IFCRELASSOCIATESMATERIAL", start, end));
+                    prepass_spans.rel_associates_material.push((id, start, end));
                 }
                 "IFCRELVOIDSELEMENT" => {
-                    void_rel_spans.push((id, start, end));
+                    prepass_spans.void_rels.push((id, start, end));
+                }
+                "IFCRELFILLSELEMENT" => {
+                    prepass_spans.fills_rels.push((id, start, end));
                 }
                 "IFCRELAGGREGATES" => {
-                    aggregate_rel_spans.push((id, start, end));
+                    prepass_spans.aggregate_rels.push((id, start, end));
                 }
                 _ => {
                     if has_geometry_by_name(type_name) {
@@ -326,35 +304,27 @@ impl IfcAPI {
                 }
             }
 
-            // Once we have project + enough sample jobs, resolve the meta
-            // (unit scale + RTC offset + building rotation) and emit it
-            // along with the buffered first chunk so workers can start.
-            if !meta_emitted && project_id.is_some() && buffered_jobs.len() >= RTC_SAMPLE_THRESHOLD
-            {
+            // Once enough sample jobs are buffered, resolve the meta (unit
+            // scales + RTC offset + building rotation) and emit it along with
+            // the buffered first chunk so workers can start. The gate
+            // deliberately does NOT wait for IFCPROJECT: IfcOpenShell/Revit
+            // exports emit it near the END of the file, and waiting would
+            // delay every worker until ~90% of the scan on such models. The
+            // shared resolver finds a not-yet-scanned project by SIMD
+            // substring search and resolves partial-index chains against a
+            // full index instead of silently defaulting (a millimetre model
+            // resolved as metres renders 1000× oversized).
+            if !meta_emitted && buffered_jobs.len() >= RTC_SAMPLE_THRESHOLD {
                 // Build a decoder over the partial entity index built so far.
                 let mut decoder = EntityDecoder::with_index(content, entity_index.clone());
-                let pid = project_id.expect("project_id checked");
-
-                // Resolve the length-unit scale. The assignment + IFCSIUNIT
-                // usually sit near the top of a STEP file, so the partial
-                // index resolves them directly (fast path). But many real
-                // exports (Revit) place the IFCPROJECT / IFCUNITASSIGNMENT
-                // AFTER the bulk of geometry — there the partial index does
-                // not yet contain the assigned IFCSIUNIT, and silently
-                // defaulting to metres renders a millimetre model 1000×
-                // oversized (and dwarfs any correctly-scaled federated peer).
-                // When the chain isn't fully decodable here, resolve against a
-                // complete index instead of trusting the metres default.
-                let unit_scale =
-                    match ifc_lite_core::try_extract_length_unit_scale(&mut decoder, pid) {
-                        Some(scale) => scale,
-                        None => {
-                            let full_index = ifc_lite_core::build_entity_index(content);
-                            let mut full_decoder = EntityDecoder::with_index(content, full_index);
-                            ifc_lite_core::extract_length_unit_scale(&mut full_decoder, pid)
-                                .unwrap_or(1.0)
-                        }
-                    };
+                let unit_scales = ifc_lite_processing::prepass::resolve_unit_scales(
+                    content,
+                    project_id,
+                    &mut decoder,
+                );
+                let unit_scale = unit_scales.length_unit_scale;
+                decoder.seed_unit_scales(unit_scale, unit_scales.plane_angle_to_radians);
+                plane_angle_to_radians = unit_scales.plane_angle_to_radians;
 
                 let router = GeometryRouter::with_scale(unit_scale);
                 let is_large = |t: (f64, f64, f64)| {
@@ -407,6 +377,11 @@ impl IfcAPI {
                 let meta = js_sys::Object::new();
                 super::set_js_prop(&meta, "type", &"meta".into());
                 super::set_js_prop(&meta, "unitScale", &unit_scale.into());
+                super::set_js_prop(
+                    &meta,
+                    "planeAngleToRadians",
+                    &plane_angle_to_radians.into(),
+                );
                 let rtc_arr = js_sys::Float64Array::new_with_length(3);
                 rtc_arr.set_index(0, rtc_offset.0);
                 rtc_arr.set_index(1, rtc_offset.1);
@@ -442,9 +417,14 @@ impl IfcAPI {
             // sub-50-job file the scan is essentially instant anyway, so
             // buying a second pass here is irrelevant.
             let mut decoder = EntityDecoder::with_index(content, entity_index.clone());
-            let unit_scale = project_id
-                .and_then(|pid| ifc_lite_core::extract_length_unit_scale(&mut decoder, pid).ok())
-                .unwrap_or(1.0);
+            let unit_scales = ifc_lite_processing::prepass::resolve_unit_scales(
+                content,
+                project_id,
+                &mut decoder,
+            );
+            let unit_scale = unit_scales.length_unit_scale;
+            decoder.seed_unit_scales(unit_scale, unit_scales.plane_angle_to_radians);
+            plane_angle_to_radians = unit_scales.plane_angle_to_radians;
             let router = GeometryRouter::with_scale(unit_scale);
             let rtc_offset =
                 router.detect_rtc_offset_with_fallback(&buffered_jobs, &mut decoder, content);
@@ -457,6 +437,11 @@ impl IfcAPI {
             let meta = js_sys::Object::new();
             super::set_js_prop(&meta, "type", &"meta".into());
             super::set_js_prop(&meta, "unitScale", &unit_scale.into());
+            super::set_js_prop(
+                &meta,
+                "planeAngleToRadians",
+                &plane_angle_to_radians.into(),
+            );
             let rtc_arr = js_sys::Float64Array::new_with_length(3);
             rtc_arr.set_index(0, rtc_offset.0);
             rtc_arr.set_index(1, rtc_offset.1);
@@ -507,167 +492,76 @@ impl IfcAPI {
         // BFS kernel runs without any extra file pass — keeping streaming
         // loads void-parity with `buildPrePassOnce` and the server.
         let mut decoder = EntityDecoder::with_arc_index(content, entity_index_arc);
+        decoder.seed_unit_scales(1.0, plane_angle_to_radians);
 
-        for &(id, start, end) in &styled_item_spans {
-            if let Ok(styled_item) = decoder.decode_at_with_id(id, start, end) {
-                if let Some(geometry_id) = styled_item.get_ref(0) {
-                    if !geometry_styles.contains_key(&geometry_id) {
-                        if let Some(styles_attr) = styled_item.get(1) {
-                            if let Some(color) =
-                                super::styling::extract_color_from_styles(styles_attr, &mut decoder)
-                            {
-                                geometry_styles.insert(geometry_id, color);
-                            }
-                        }
-                    }
-                } else {
-                    // Orphan IfcStyledItem (null Item) — material-based color.
-                    if let Some(styles_attr) = styled_item.get(1) {
-                        if let Some(color) =
-                            super::styling::extract_color_from_styles(styles_attr, &mut decoder)
-                        {
-                            orphan_styled_items.insert(id, color);
-                        }
-                    }
-                }
-            }
-        }
-
-        // Resolve IfcIndexedColourMap entries — IFC4's per-tessellated-face-set
-        // colouring mechanism used by CATIA / 3DEXPERIENCE exports (#663).
-        // IfcStyledItem entries above win when both target the same geometry,
-        // so `entry().or_insert` preserves the authored-intent path.
-        for &(id, start, end) in &indexed_colour_map_spans {
-            if let Some((geometry_id, color)) =
-                super::styling::extract_color_from_indexed_colour_map_span(
-                    id,
-                    start,
-                    end,
-                    &mut decoder,
-                )
-            {
-                geometry_styles.entry(geometry_id).or_insert(color);
-            }
-        }
-
-        for &(id, type_name, start, end) in &material_entity_spans {
-            super::styling::collect_material_entity(
-                id,
-                type_name,
-                start,
-                end,
-                &mut decoder,
-                &mut orphan_styled_items,
-                &mut material_def_reprs,
-                &mut element_to_material,
-            );
-        }
-
-        for &(id, start, end) in &void_rel_spans {
-            if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
-                if let (Some(host_id), Some(opening_id)) = (entity.get_ref(4), entity.get_ref(5)) {
-                    void_index.entry(host_id).or_default().push(opening_id);
-                }
-            }
-        }
-
-        // Aggregate void propagation (shared kernel, parity with the once
-        // path and the server): openings authored on an aggregating host
-        // (IfcWallElementedCase panels, IfcRoof→IfcSlab skylights) must cut
-        // every descendant part. Decode the stashed IfcRelAggregates spans
-        // into the parent→children map — no extra file scan.
-        if !void_index.is_empty() && !aggregate_rel_spans.is_empty() {
-            let mut aggregate_children: rustc_hash::FxHashMap<u32, Vec<u32>> =
-                rustc_hash::FxHashMap::default();
-            for &(id, start, end) in &aggregate_rel_spans {
-                if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
-                    let Some(parent_id) = entity.get_ref(4) else {
-                        continue;
-                    };
-                    if let Some(list) = entity.get(5).and_then(|a| a.as_list()) {
-                        let children: Vec<u32> =
-                            list.iter().filter_map(|i| i.as_entity_ref()).collect();
-                        if !children.is_empty() {
-                            aggregate_children.entry(parent_id).or_default().extend(children);
-                        }
-                    }
-                }
-            }
-            ifc_lite_geometry::propagate_voids_via_aggregates(&mut void_index, &aggregate_children);
-        }
-
-        // Resolve material chains → element colors.
-        let material_styles = super::styling::build_material_style_index(
-            &material_def_reprs,
-            &orphan_styled_items,
+        // Shared post-scan resolution — the exact resolver the native
+        // pipeline and `buildPrePassOnce` run. Full per-triangle palettes
+        // (#858) stay per-worker rebuilds; the wire carries dominants only.
+        let resolved = ifc_lite_processing::prepass::resolve_prepass(
+            &prepass_spans,
             &mut decoder,
+            ifc_lite_processing::prepass::ResolveOptions {
+                collect_indexed_colour_full: false,
+                defer_attached_styles: false,
+            },
         );
-        let element_material_styles = super::styling::build_element_material_styles(
-            &element_to_material,
-            &material_styles,
-            &mut decoder,
-        );
-        // Flat material_id → color, merge into geometry_styles for layered
-        // resolution per `combined_pre_pass`.
-        for (&mat_id, &color) in
-            super::styling::flatten_material_color_index(&material_styles).iter()
-        {
-            geometry_styles.entry(mat_id).or_insert(color);
-        }
-        // For elements that have a single resolved material color, register
-        // it so processGeometryBatch's per-type fallback picks it up.
-        for (&element_id, colors) in &element_material_styles {
-            if let Some(&color) = colors.first() {
-                geometry_styles.entry(element_id).or_insert(color);
-            }
-        }
 
-        // Serialise styles + voids and post a `styles`
+        // Serialise styles + voids + material colour lists and post a `styles`
         // event before `complete` so the host can dispatch them to all
         // process workers and emit a colorUpdate for already-rendered meshes.
-        let styles_len = geometry_styles.len();
-        let style_ids = js_sys::Uint32Array::new_with_length(styles_len as u32);
-        let style_colors = js_sys::Uint8Array::new_with_length((styles_len * 4) as u32);
-        let mut si = 0u32;
-        for (&id, &color) in &geometry_styles {
-            style_ids.set_index(si, id);
-            let ci = si * 4;
-            style_colors.set_index(ci, (color[0] * 255.0).clamp(0.0, 255.0) as u8);
-            style_colors.set_index(ci + 1, (color[1] * 255.0).clamp(0.0, 255.0) as u8);
-            style_colors.set_index(ci + 2, (color[2] * 255.0).clamp(0.0, 255.0) as u8);
-            style_colors.set_index(ci + 3, (color[3] * 255.0).clamp(0.0, 255.0) as u8);
-            si += 1;
-        }
+        let (style_ids_vec, style_colors_vec) =
+            ifc_lite_processing::prepass::flat_styles_rgba8(&resolved, &mut decoder);
+        let (void_keys_vec, void_counts_vec, void_values_vec) =
+            ifc_lite_processing::prepass::flat_voids(&resolved.void_index);
+        let (mat_ids_vec, mat_counts_vec, mat_colors_vec) =
+            ifc_lite_processing::prepass::flat_material_colors(
+                &resolved.element_material_colors,
+            );
 
-        // void_index → flat (keys, counts, values) arrays in the same shape
-        // processGeometryBatch already accepts.
-        let mut void_keys_vec: Vec<u32> = Vec::with_capacity(void_index.len());
-        let mut void_counts_vec: Vec<u32> = Vec::with_capacity(void_index.len());
-        let mut void_values_vec: Vec<u32> = Vec::new();
-        for (&host_id, openings) in &void_index {
-            void_keys_vec.push(host_id);
-            void_counts_vec.push(openings.len() as u32);
-            void_values_vec.extend(openings.iter().copied());
-        }
-        let void_keys = js_sys::Uint32Array::new_with_length(void_keys_vec.len() as u32);
-        for (i, &k) in void_keys_vec.iter().enumerate() {
-            void_keys.set_index(i as u32, k);
-        }
-        let void_counts = js_sys::Uint32Array::new_with_length(void_counts_vec.len() as u32);
-        for (i, &c) in void_counts_vec.iter().enumerate() {
-            void_counts.set_index(i as u32, c);
-        }
-        let void_values = js_sys::Uint32Array::new_with_length(void_values_vec.len() as u32);
-        for (i, &v) in void_values_vec.iter().enumerate() {
-            void_values.set_index(i as u32, v);
-        }
         let styles_event = js_sys::Object::new();
         super::set_js_prop(&styles_event, "type", &"styles".into());
-        super::set_js_prop(&styles_event, "styleIds", &style_ids);
-        super::set_js_prop(&styles_event, "styleColors", &style_colors);
-        super::set_js_prop(&styles_event, "voidKeys", &void_keys);
-        super::set_js_prop(&styles_event, "voidCounts", &void_counts);
-        super::set_js_prop(&styles_event, "voidValues", &void_values);
+        super::set_js_prop(
+            &styles_event,
+            "styleIds",
+            &js_sys::Uint32Array::from(style_ids_vec.as_slice()),
+        );
+        super::set_js_prop(
+            &styles_event,
+            "styleColors",
+            &js_sys::Uint8Array::from(style_colors_vec.as_slice()),
+        );
+        super::set_js_prop(
+            &styles_event,
+            "voidKeys",
+            &js_sys::Uint32Array::from(void_keys_vec.as_slice()),
+        );
+        super::set_js_prop(
+            &styles_event,
+            "voidCounts",
+            &js_sys::Uint32Array::from(void_counts_vec.as_slice()),
+        );
+        super::set_js_prop(
+            &styles_event,
+            "voidValues",
+            &js_sys::Uint32Array::from(void_values_vec.as_slice()),
+        );
+        // #407/#913 §2.3: per-element material colour lists so the batch path
+        // can run the transparent/opaque sub-mesh alternation.
+        super::set_js_prop(
+            &styles_event,
+            "materialElementIds",
+            &js_sys::Uint32Array::from(mat_ids_vec.as_slice()),
+        );
+        super::set_js_prop(
+            &styles_event,
+            "materialColorCounts",
+            &js_sys::Uint32Array::from(mat_counts_vec.as_slice()),
+        );
+        super::set_js_prop(
+            &styles_event,
+            "materialColors",
+            &js_sys::Uint8Array::from(mat_colors_vec.as_slice()),
+        );
         on_event.call1(&JsValue::NULL, &styles_event.into())?;
 
         // Export the entity_index as 3 column arrays so process workers
@@ -744,6 +638,14 @@ impl IfcAPI {
         void_values: &[u32],
         style_ids: &[u32],   // geometry style entity IDs
         style_colors: &[u8], // [r, g, b, a, r, g, b, a, ...] (0-255)
+        // Trailing optional wire fields (additive — older callers omit them):
+        // the prepass-resolved plane-angle scale (falls back to the per-worker
+        // cache when absent), and the #407 per-element material colour lists
+        // in `flat_material_colors` encoding.
+        plane_angle_to_radians: Option<f64>,
+        material_element_ids: Option<Vec<u32>>,
+        material_color_counts: Option<Vec<u32>>,
+        material_colors_rgba: Option<Vec<u8>>,
     ) -> MeshCollection {
         use super::styling::resolve_element_color;
         use ifc_lite_core::EntityDecoder;
@@ -800,7 +702,8 @@ impl IfcAPI {
         // and `plane_angle_to_radians()` would otherwise walk the whole DATA
         // section per batch on files whose IFCPROJECT sits near the end
         // (IfcOpenShell exports) — the geometry-stream stall on large models.
-        let plane_angle_to_radians = self.get_or_resolve_plane_angle(&mut decoder);
+        let plane_angle_to_radians = plane_angle_to_radians
+            .unwrap_or_else(|| self.get_or_resolve_plane_angle(&mut decoder));
         decoder.seed_unit_scales(unit_scale, plane_angle_to_radians);
 
         // Create geometry router with unit scale and the consumer-selected
@@ -901,11 +804,20 @@ impl IfcAPI {
         // Surface textures + UV maps (#961), built once per worker (cheap
         // substring bail-out for untextured files).
         let texture_index = self.get_or_build_texture_index(content, &mut decoder);
-        // The browser prepass doesn't ship material-chain colour lists yet
-        // (planned with the shared-prepass step); the alternation inside the
-        // producer simply never fires on an empty map — today's behaviour.
-        let element_material_colors: rustc_hash::FxHashMap<u32, Vec<[f32; 4]>> =
-            rustc_hash::FxHashMap::default();
+        // #407/#913 §2.3: per-element material colour lists from the prepass
+        // wire, so the canonical producer's transparent/opaque sub-mesh
+        // alternation fires in the browser exactly like on the server.
+        // Absent (older callers) ⇒ empty map ⇒ alternation never fires.
+        let element_material_colors: rustc_hash::FxHashMap<u32, Vec<[f32; 4]>> = match (
+            material_element_ids.as_deref(),
+            material_color_counts.as_deref(),
+            material_colors_rgba.as_deref(),
+        ) {
+            (Some(ids), Some(counts), Some(rgba)) => {
+                ifc_lite_processing::prepass::material_colors_from_flat(ids, counts, rgba)
+            }
+            _ => rustc_hash::FxHashMap::default(),
+        };
 
         let ctx = MeshProductionContext {
             void_index: &void_index,

--- a/rust/wasm-bindings/src/api/styling.rs
+++ b/rust/wasm-bindings/src/api/styling.rs
@@ -4,45 +4,6 @@
 
 //! Styling, color extraction, and building rotation for IFC-Lite API
 
-/// Resolve the geometry ID + dominant colour from an `IfcIndexedColourMap`.
-///
-/// Schema (IFC4):
-/// - attr 0: `MappedTo` → IfcTessellatedFaceSet (target geometry)
-/// - attr 1: `Opacity` (optional REAL, 0..1 — 1.0 when omitted)
-/// - attr 2: `Colours` → IfcColourRgbList
-/// - attr 3: `ColourIndex` → list of 1-based indices into `Colours`
-///
-/// CATIA exports almost always reference a single colour, so picking
-/// `colour[ColourIndex[0]]` is the right call. For multi-colour maps we
-/// pick the most-frequent index — captures the dominant tone, leaves the
-/// per-face variation for a future mesh-data upgrade.
-///
-/// Used by the streaming pre-pass in `gpu_meshes.rs` which has already
-/// collected entity spans during its scan — hence the span-based signature
-/// rather than entity-id-only.
-pub(crate) fn extract_color_from_indexed_colour_map_span(
-    id: u32,
-    start: usize,
-    end: usize,
-    decoder: &mut ifc_lite_core::EntityDecoder,
-) -> Option<(u32, [f32; 4])> {
-    extract_color_from_indexed_colour_map(id, start, end, decoder)
-}
-
-fn extract_color_from_indexed_colour_map(
-    id: u32,
-    start: usize,
-    end: usize,
-    decoder: &mut ifc_lite_core::EntityDecoder,
-) -> Option<(u32, [f32; 4])> {
-    // Delegate to the canonical resolver in `ifc_lite_processing::style`
-    // (issue #913, Phase 2e). The browser keeps only the span→entity decode;
-    // the dominant-colour logic lives once, shared with the backend.
-    let entity = decoder.decode_at_with_id(id, start, end).ok()?;
-    let map = ifc_lite_processing::style::resolve_indexed_colour_map_full(&entity, decoder)?;
-    Some((map.geometry_id, map.dominant().to_array()))
-}
-
 /// Find color for a geometry item, following MappedItem references if needed.
 /// This handles the case where IfcStyledItem points to geometry inside a MappedRepresentation,
 /// not to the MappedItem itself.
@@ -189,12 +150,9 @@ fn extract_color_from_style_assignment(
 /// Data collected during the combined single-pass scan.
 /// For a 487 MB file this saves ~2-3 s by eliminating redundant full-file scans.
 pub(crate) struct PrePassData {
-    /// Geometry ID → apparent rendering color (IfcStyledItem →
-    /// IfcSurfaceStyleRendering.DiffuseColour with SurfaceColour fallback,
-    /// or IfcIndexedColourMap dominant colour).
-    pub geometry_styles: rustc_hash::FxHashMap<u32, [f32; 4]>,
-    /// Host element → opening elements (from IfcRelVoidsElement)
-    pub void_index: rustc_hash::FxHashMap<u32, Vec<u32>>,
+    /// The shared post-scan resolution (styles, material chain, voids) — the
+    /// exact resolver the native pipeline and the streaming prepass run.
+    pub resolved: ifc_lite_processing::prepass::ResolvedPrepass,
     /// IfcProject entity ID (for unit extraction)
     pub project_id: Option<u32>,
     /// IfcSite entity position (id, start, end) — for building rotation extraction
@@ -206,95 +164,39 @@ pub(crate) struct PrePassData {
 }
 
 /// Single EntityScanner pass that collects everything needed before geometry
-/// processing. Replaces the former sequence of:
-///   build_geometry_style_index  (full scan)
-///   build_element_style_index   (full scan + 208 K decodes)
-///   pre-pass for void + brep    (full scan)
-///   processing scan              (full scan)
+/// processing: the scan loop stashes spans, and ALL semantic resolution
+/// (styled-item precedence, #663/#858 indexed colours, the #407 material
+/// chain, voids + #845 aggregate propagation) runs in the SHARED
+/// `ifc_lite_processing::prepass::resolve_prepass` — the same code the native
+/// pipeline and `buildPrePassStreaming` run.
 pub(crate) fn combined_pre_pass(
     content: &[u8],
     decoder: &mut ifc_lite_core::EntityDecoder,
 ) -> PrePassData {
     use ifc_lite_core::EntityScanner;
-    use rustc_hash::FxHashMap;
+    use ifc_lite_processing::prepass::{resolve_prepass, PrepassSpans, ResolveOptions};
 
     let estimated_elements = content.len() / 2000;
 
-    let mut geometry_styles: FxHashMap<u32, [f32; 4]> = FxHashMap::default();
-    // IfcIndexedColourMap side-map (#663). Merged into `geometry_styles` after
-    // the scan so IfcStyledItem keeps precedence regardless of scan order.
-    let mut colour_map_styles: FxHashMap<u32, [f32; 4]> = FxHashMap::default();
-    let mut void_index: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
+    let mut spans = PrepassSpans::default();
     let mut project_id: Option<u32> = None;
     let mut site_position: Option<(u32, usize, usize)> = None;
     let mut simple_jobs = Vec::with_capacity(estimated_elements / 2);
     let mut complex_jobs = Vec::with_capacity(estimated_elements / 2);
 
-    // Material chain collection: orphan styled items, material def reprs, rel associates
-    // Orphan IfcStyledItem (null Item): styled_item_id → color
-    let mut orphan_styled_items: FxHashMap<u32, [f32; 4]> = FxHashMap::default();
-    // IfcMaterialDefinitionRepresentation: material_id → [styled_repr_id, ...]
-    let mut material_def_reprs: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
-    // IfcRelAssociatesMaterial: element_id → material_select_id
-    let mut element_to_material: FxHashMap<u32, u32> = FxHashMap::default();
-
     let mut scanner = EntityScanner::new(content);
 
     while let Some((id, type_name, start, end)) = scanner.next_entity() {
         match type_name {
-            "IFCSTYLEDITEM" => {
-                if let Ok(styled_item) = decoder.decode_at_with_id(id, start, end) {
-                    if let Some(geometry_id) = styled_item.get_ref(0) {
-                        // Normal IfcStyledItem with Item reference → geometry_styles
-                        if !geometry_styles.contains_key(&geometry_id) {
-                            if let Some(styles_attr) = styled_item.get(1) {
-                                if let Some(color) = extract_color_from_styles(styles_attr, decoder)
-                                {
-                                    geometry_styles.insert(geometry_id, color);
-                                }
-                            }
-                        }
-                    } else {
-                        // Orphan IfcStyledItem (null Item) — material-based color
-                        if let Some(styles_attr) = styled_item.get(1) {
-                            if let Some(color) = extract_color_from_styles(styles_attr, decoder) {
-                                orphan_styled_items.insert(id, color);
-                            }
-                        }
-                    }
-                }
+            "IFCSTYLEDITEM" => spans.styled_items.push((id, start, end)),
+            "IFCINDEXEDCOLOURMAP" => spans.indexed_colour_maps.push((id, start, end)),
+            "IFCMATERIALDEFINITIONREPRESENTATION" => {
+                spans.material_def_reprs.push((id, start, end))
             }
-            "IFCINDEXEDCOLOURMAP" => {
-                // IFC4 per-face-set colour mechanism used by CATIA /
-                // 3DEXPERIENCE exports (#663). Held in a side map and merged
-                // below with lower precedence than IfcStyledItem.
-                if let Some((geometry_id, color)) =
-                    extract_color_from_indexed_colour_map(id, start, end, decoder)
-                {
-                    colour_map_styles.entry(geometry_id).or_insert(color);
-                }
-            }
-            "IFCMATERIALDEFINITIONREPRESENTATION" | "IFCRELASSOCIATESMATERIAL" => {
-                collect_material_entity(
-                    id,
-                    type_name,
-                    start,
-                    end,
-                    decoder,
-                    &mut orphan_styled_items,
-                    &mut material_def_reprs,
-                    &mut element_to_material,
-                );
-            }
-            "IFCRELVOIDSELEMENT" => {
-                if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
-                    if let (Some(host_id), Some(opening_id)) =
-                        (entity.get_ref(4), entity.get_ref(5))
-                    {
-                        void_index.entry(host_id).or_default().push(opening_id);
-                    }
-                }
-            }
+            "IFCRELASSOCIATESMATERIAL" => spans.rel_associates_material.push((id, start, end)),
+            "IFCRELVOIDSELEMENT" => spans.void_rels.push((id, start, end)),
+            "IFCRELFILLSELEMENT" => spans.fills_rels.push((id, start, end)),
+            "IFCRELAGGREGATES" => spans.aggregate_rels.push((id, start, end)),
             "IFCPROJECT" => {
                 if project_id.is_none() {
                     project_id = Some(id);
@@ -320,49 +222,17 @@ pub(crate) fn combined_pre_pass(
         }
     }
 
-    // IfcStyledItem wins; only geometries WITHOUT a styled-item entry pick up
-    // their IfcIndexedColourMap colour (#663). Done after the scan so scan
-    // order doesn't decide precedence.
-    for (geometry_id, color) in colour_map_styles {
-        geometry_styles.entry(geometry_id).or_insert(color);
-    }
-
-    // Build material style index: material_id → [color, ...]
-    // Chain: material → IfcMaterialDefinitionRepresentation → IfcStyledRepresentation → orphan IfcStyledItem
-    let material_styles =
-        build_material_style_index(&material_def_reprs, &orphan_styled_items, decoder);
-
-    // Build element → material colors map
-    let element_material_styles =
-        build_element_material_styles(&element_to_material, &material_styles, decoder);
-
-    // Flat material_id → color map; merge into geometry_styles so per-layer
-    // slices (whose geometry_id = IfcMaterial id) resolve through the normal
-    // path. IFC express IDs are globally unique across types so no collision.
-    for (&mat_id, &color) in flatten_material_color_index(&material_styles).iter() {
-        geometry_styles.entry(mat_id).or_insert(color);
-    }
-
-    // Mirror what `buildPrePassStreaming` already does in `gpu_meshes.rs`
-    // (the `for (&element_id, colors) in &element_material_styles { … }`
-    // block): fold each element's single resolved material colour into
-    // `geometry_styles` keyed by the **element** express ID. Without this,
-    // the path that goes through `combined_pre_pass` (`buildPrePassOnce`)
-    // leaves the colour unread — `resolve_element_color`'s element-id fallback
-    // finds nothing and material-chain-only elements render as the
-    // per-type grey default on those APIs. The streaming path didn't
-    // exhibit the bug because it folds entries inline.
-    for (&element_id, colors) in &element_material_styles {
-        if let Some(&color) = colors.first() {
-            geometry_styles.entry(element_id).or_insert(color);
-        }
-    }
-
-    // Propagate voids from aggregate parents (IfcWall) to children (IfcBuildingElementPart)
-    // so that multilayer wall parts also get window/door cutouts. The returned
-    // part→parent map is unused here (the merge-layers skip-set is rebuilt in
-    // gpu_meshes), but the call mutates `void_index` in place — keep it.
-    let _ = ifc_lite_geometry::propagate_voids_to_parts(&mut void_index, content, decoder);
+    // Shared post-scan resolution. Full per-triangle palettes stay per-worker
+    // rebuilds (`get_or_build_indexed_colour_maps`); the prepass only ships
+    // the dominant colours on the wire.
+    let resolved = resolve_prepass(
+        &spans,
+        decoder,
+        ResolveOptions {
+            collect_indexed_colour_full: false,
+            defer_attached_styles: false,
+        },
+    );
 
     // #957 + Model/Types switch: emit IfcTypeProduct RepresentationMap geometry
     // (annex-E orphan types AND instanced type-library shapes). processGeometryBatch
@@ -370,8 +240,7 @@ pub(crate) fn combined_pre_pass(
     complex_jobs.extend(collect_type_geometry_jobs(content, decoder));
 
     PrePassData {
-        geometry_styles,
-        void_index,
+        resolved,
         project_id,
         site_position,
         simple_jobs,
@@ -503,129 +372,6 @@ pub(crate) fn build_instantiated_type_ids(
     instantiated
 }
 
-/// Build material style index: maps material IDs to their colors.
-/// Follows: material → IfcMaterialDefinitionRepresentation → IfcStyledRepresentation → orphan IfcStyledItem
-pub(crate) fn build_material_style_index(
-    material_def_reprs: &rustc_hash::FxHashMap<u32, Vec<u32>>,
-    orphan_styled_items: &rustc_hash::FxHashMap<u32, [f32; 4]>,
-    decoder: &mut ifc_lite_core::EntityDecoder,
-) -> rustc_hash::FxHashMap<u32, Vec<[f32; 4]>> {
-    // Canonical implementation lives in `ifc_lite_processing::style` (#913).
-    ifc_lite_processing::style::build_material_style_index(
-        material_def_reprs,
-        orphan_styled_items,
-        decoder,
-    )
-}
-
-/// Build element → material colors map.
-/// Resolves the full chain from element → IfcRelAssociatesMaterial → material select →
-/// individual materials → colors.
-/// Handles: IfcMaterial, IfcMaterialList, IfcMaterialLayerSet, IfcMaterialLayerSetUsage,
-///          IfcMaterialConstituentSet (IFC4), IfcMaterialProfileSet (IFC4)
-pub(crate) fn build_element_material_styles(
-    element_to_material: &rustc_hash::FxHashMap<u32, u32>,
-    material_styles: &rustc_hash::FxHashMap<u32, Vec<[f32; 4]>>,
-    decoder: &mut ifc_lite_core::EntityDecoder,
-) -> rustc_hash::FxHashMap<u32, Vec<[f32; 4]>> {
-    use rustc_hash::FxHashMap;
-
-    let mut result: FxHashMap<u32, Vec<[f32; 4]>> = FxHashMap::default();
-
-    for (&element_id, &material_select_id) in element_to_material {
-        let mut colors: Vec<[f32; 4]> = Vec::new();
-
-        // Collect all individual material IDs from the material select
-        // (canonical SELECT-walk in `ifc_lite_processing::style`, #913).
-        let material_ids =
-            ifc_lite_processing::style::resolve_material_ids(material_select_id, decoder);
-
-        for material_id in material_ids {
-            if let Some(mat_colors) = material_styles.get(&material_id) {
-                colors.extend(mat_colors);
-            }
-        }
-
-        if !colors.is_empty() {
-            result.insert(element_id, colors);
-        }
-    }
-
-    result
-}
-
-/// Flatten a `material_id -> Vec<color>` map into `material_id -> color` by
-/// picking the first opaque color per material. Used to key layered sub-mesh
-/// colour lookups on material ID — each layer slice's `geometry_id` is its
-/// `IfcMaterial` entity ID. Canonical impl in `ifc_lite_processing::style` (#913).
-pub(crate) fn flatten_material_color_index(
-    material_styles: &rustc_hash::FxHashMap<u32, Vec<[f32; 4]>>,
-) -> rustc_hash::FxHashMap<u32, [f32; 4]> {
-    ifc_lite_processing::style::flatten_material_color_index(material_styles)
-}
-
-/// Process a single entity for material-related data collection.
-/// Called from both `combined_pre_pass` (inline in the scan loop) and
-/// `collect_material_data` (standalone scan).
-pub(crate) fn collect_material_entity(
-    id: u32,
-    type_name: &str,
-    start: usize,
-    end: usize,
-    decoder: &mut ifc_lite_core::EntityDecoder,
-    orphan_styled_items: &mut rustc_hash::FxHashMap<u32, [f32; 4]>,
-    material_def_reprs: &mut rustc_hash::FxHashMap<u32, Vec<u32>>,
-    element_to_material: &mut rustc_hash::FxHashMap<u32, u32>,
-) {
-    match type_name {
-        "IFCSTYLEDITEM" => {
-            if let Ok(styled_item) = decoder.decode_at_with_id(id, start, end) {
-                // Only collect orphan styled items (null Item attribute)
-                if styled_item.get_ref(0).is_none() {
-                    if let Some(styles_attr) = styled_item.get(1) {
-                        if let Some(color) = extract_color_from_styles(styles_attr, decoder) {
-                            orphan_styled_items.insert(id, color);
-                        }
-                    }
-                }
-            }
-        }
-        "IFCMATERIALDEFINITIONREPRESENTATION" => {
-            if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
-                if let Some(material_id) = entity.get_ref(3) {
-                    if let Some(reprs_attr) = entity.get(2) {
-                        if let Some(list) = reprs_attr.as_list() {
-                            for item in list {
-                                if let Some(repr_id) = item.as_entity_ref() {
-                                    material_def_reprs
-                                        .entry(material_id)
-                                        .or_default()
-                                        .push(repr_id);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        "IFCRELASSOCIATESMATERIAL" => {
-            if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
-                if let Some(material_select_id) = entity.get_ref(5) {
-                    if let Some(related_attr) = entity.get(4) {
-                        if let Some(list) = related_attr.as_list() {
-                            for item in list {
-                                if let Some(element_id) = item.as_entity_ref() {
-                                    element_to_material.insert(element_id, material_select_id);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        _ => {}
-    }
-}
 
 /// Resolve element color inline during processing by following its
 /// representation chain. Replaces the upfront `build_element_style_index`


### PR DESCRIPTION
## What

Step 4 of the pipeline-unification series (#1080 → #1088 → #1084 → this). The **semantic half of the prepass** — styled-item precedence, IfcIndexedColourMap fallback (#663/#858), the #407 material chain, void collection with #845 aggregate propagation, and unit-scale resolution — existed **three times**: inline in `processor.rs`'s scan, inline in `combined_pre_pass` (`buildPrePassOnce`), and in `buildPrePassStreaming`'s post-scan block. It now exists exactly once: **`rust/processing/src/prepass.rs`**. The scan loops stay per-pipeline (mechanical span-stashing with pipeline-specific extras), but a styles/voids/materials fix now lands in one place.

- `PrepassSpans` + `resolve_prepass(spans, decoder, opts)` — defer-aware (native `fast_first_batch` replay via `resolve_styled_item_spans`), full per-triangle palettes optional (browser ships dominants only; workers rebuild full maps as before).
- `resolve_unit_scales(...)` — **both** scales, one resolver, documented ladder: scan hint → SIMD `find_ifcproject_id` substring search → full-index re-resolve for incomplete partial-index chains. Native loses **two full-file walks** (the old `with_units` + `plane_angle_to_radians` hunts): 21 s → **18.3 s** on the 75 MB steel model. The streaming prepass **no longer waits for a late IFCPROJECT** to emit `meta` — workers start at the sample threshold even when Revit/IfcOpenShell put the project at the end of the file.
- Flat wire codecs (`flat_styles_rgba8`/`flat_voids`/`flat_material_colors` + inverse) — the JS boundary encoding lives next to the data.
- **Additive wire**: `planeAngleToRadians` on the prepass result + `meta` event; `materialElementIds/ColorCounts/Colors` on the result + `styles` event; `processGeometryBatch` takes them as trailing optionals (regenerated `pkg/ifc-lite.d.ts` shows `?: | null`). The browser gains the #913 §2.3 material alternation once the TS host threads them (next PR); absent args preserve today's behaviour exactly — proven by the unmodified viewer e2e passing.
- Deleted: the duplicated resolution blocks + wasm-local helpers (`collect_material_entity`, `build_element_material_styles` & wrappers, `extract_color_from_indexed_colour_map*`).

## Verification

- Rust tests green (processing incl. **5 new prepass unit tests**: late/absent/decoy IFCPROJECT search, flat-codec round-trip, degree+millimetre scale resolution).
- wasm contract **17/17**; wasm pkg behavioural tests **11/11**; geometry regression corpus **39/39**; viewer smoke e2e **2/2** (unchanged TS host).
- Native output **bit-identical** on the 75 MB steel model (20,577 meshes / 2,063,757 verts / 1,071,102 tris) and the door-hang model (1,255 meshes); 18.3 s vs 21 s before.

Next (final PR): thread `planeAngleToRadians` + material arrays through the TS host, late-IFCPROJECT e2e fixture, benchmark prepass metrics, docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-element material color support for improved visual representation of building components.
  * Enhanced material styling and geometry processing pipeline.

* **Bug Fixes**
  * Improved material chain and styling precedence handling.

* **Refactor**
  * Refactored internal geometry processing to use shared resolver for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->