### PR TITLE
feat(geometry): thread prepass unit scales + material colours through the TS host

### DIFF
--- a/docs/architecture/geometry-pipeline.md
+++ b/docs/architecture/geometry-pipeline.md
@@ -4,7 +4,34 @@ Detailed architecture of geometry processing in IFClite.
 
 ## Overview
 
-The geometry pipeline transforms IFC shape representations into GPU-ready triangle meshes:
+The geometry pipeline transforms IFC shape representations into GPU-ready triangle meshes.
+
+**One pipeline, two orchestrations.** Since the 2026-06 unification series
+(#1080 → #1088 → #1084 → shared prepass), per-element mesh production and
+prepass resolution exist exactly once, in `ifc-lite-processing`:
+
+- **`processing::element::produce_element_meshes`** — THE per-element decision
+  tree (type-product geometry #957, submesh-aware void cuts, per-item #858
+  palette splits, single-mesh fallback chain). Run by the native rayon loop
+  (server/CLI) and by the browser's `processGeometryBatch` per job. The only
+  sanctioned behavioural fork is `TypeGeometryMode` (an export suppresses
+  instanced type geometry; the viewer emits it tagged for its Model/Types
+  switch).
+- **`processing::prepass`** — the shared post-scan resolver (styled-item
+  precedence, IfcIndexedColourMap #663/#858, the #407 material chain, voids
+  with #845 aggregate propagation) plus `resolve_unit_scales` (length AND
+  plane-angle, resolved once with a documented fallback ladder for
+  late-in-file `IFCPROJECT`) and the flat wire codecs for the JS boundary.
+  The scan loops stay per-orchestration (native scan with properties/quick
+  metadata; browser `buildPrePassOnce`/`buildPrePassStreaming` with
+  incremental job emission), but they only span-stash — all semantics resolve
+  in the shared module.
+
+Geometry/styling fixes belong in those two modules; re-inlining logic in
+`processor.rs` or `gpu_meshes.rs` re-creates the historic both-sides drift
+(#858, #913, #957, #961 each had to be fixed twice before the unification).
+
+The per-representation processing below is shared by construction:
 
 ```mermaid
 flowchart TB

--- a/packages/geometry/src/geometry-parallel.ts
+++ b/packages/geometry/src/geometry-parallel.ts
@@ -30,6 +30,8 @@ import type { StreamingGeometryEvent } from './index.js';
 import { pickWorkerCount } from './worker-count.js';
 
 interface PrepassMeta {
+  /** Prepass-resolved plane-angle→radians scale; seeds worker batch decoders. */
+  planeAngleToRadians?: number;
   unitScale: number;
   rtcOffset: Float64Array;
   needsShift: boolean;
@@ -383,6 +385,7 @@ export async function* processParallel(
         type: 'stream-start' as const,
         sharedBuffer,
         unitScale: prepassMeta.unitScale,
+        planeAngleToRadians: prepassMeta.planeAngleToRadians,
         rtcX, rtcY, rtcZ,
         needsShift: effectiveNeedsShift,
         voidKeys: emptyU32,
@@ -496,6 +499,7 @@ export async function* processParallel(
       if (evt.type === 'meta') {
         prepassMeta = {
           unitScale: evt.unitScale as number,
+          planeAngleToRadians: (evt.planeAngleToRadians as number | undefined) ?? undefined,
           rtcOffset: evt.rtcOffset as Float64Array,
           needsShift: evt.needsShift as boolean,
           buildingRotation: (evt.buildingRotation as number | null | undefined) ?? null,
@@ -526,6 +530,9 @@ export async function* processParallel(
         const voidKeys = evt.voidKeys as Uint32Array;
         const voidCounts = evt.voidCounts as Uint32Array;
         const voidValues = evt.voidValues as Uint32Array;
+        const materialElementIds = (evt.materialElementIds as Uint32Array | undefined) ?? new Uint32Array(0);
+        const materialColorCounts = (evt.materialColorCounts as Uint32Array | undefined) ?? new Uint32Array(0);
+        const materialColors = (evt.materialColors as Uint8Array | undefined) ?? new Uint8Array(0);
         console.log(`[stream] styles @ ${elapsed()}ms (${styleIds.length} styled, ${voidKeys.length} void hosts), draining ${queuedChunks.length} queued chunks`);
 
         for (const w of workers) {
@@ -538,6 +545,9 @@ export async function* processParallel(
             const vKeys = voidKeys.slice();
             const vCounts = voidCounts.slice();
             const vValues = voidValues.slice();
+            const mIds = materialElementIds.slice();
+            const mCounts = materialColorCounts.slice();
+            const mColors = materialColors.slice();
             w.postMessage(
               {
                 type: 'set-styles' as const,
@@ -546,8 +556,14 @@ export async function* processParallel(
                 voidKeys: vKeys,
                 voidCounts: vCounts,
                 voidValues: vValues,
+                materialElementIds: mIds,
+                materialColorCounts: mCounts,
+                materialColors: mColors,
               },
-              [sIds.buffer, sColors.buffer, vKeys.buffer, vCounts.buffer, vValues.buffer],
+              [
+                sIds.buffer, sColors.buffer, vKeys.buffer, vCounts.buffer, vValues.buffer,
+                mIds.buffer, mCounts.buffer, mColors.buffer,
+              ],
             );
           } catch (err) {
             console.warn('[stream] set-styles dispatch failed:', err);

--- a/packages/geometry/src/geometry.worker.ts
+++ b/packages/geometry/src/geometry.worker.ts
@@ -44,6 +44,14 @@ export interface GeometryWorkerStreamStartMessage {
   voidValues: Uint32Array;
   styleIds: Uint32Array;
   styleColors: Uint8Array;
+  /** Prepass-resolved plane-angle→radians scale (meta event). Seeds each
+   *  batch decoder so arc tessellation never re-pays an O(file) scan. */
+  planeAngleToRadians?: number;
+  /** #407/#913 §2.3 per-element material colour lists (flat encoding) —
+   *  drive the transparent/opaque sub-mesh alternation. */
+  materialElementIds?: Uint32Array;
+  materialColorCounts?: Uint32Array;
+  materialColors?: Uint8Array;
 }
 
 export interface GeometryWorkerStreamChunkMessage {
@@ -68,6 +76,10 @@ export interface GeometryWorkerSetStylesMessage {
   voidValues: Uint32Array;
   styleIds: Uint32Array;
   styleColors: Uint8Array;
+  /** #407/#913 §2.3 material colour lists (streamed `styles` event). */
+  materialElementIds?: Uint32Array;
+  materialColorCounts?: Uint32Array;
+  materialColors?: Uint8Array;
 }
 
 /**
@@ -328,6 +340,10 @@ interface ProcessingSession {
   voidValues: Uint32Array;
   styleIds: Uint32Array;
   styleColors: Uint8Array;
+  planeAngleToRadians: number | undefined;
+  materialElementIds: Uint32Array | undefined;
+  materialColorCounts: Uint32Array | undefined;
+  materialColors: Uint8Array | undefined;
   pendingMeshes: GeometryWorkerBatchMessage['meshes'];
   pendingTransfers: ArrayBuffer[];
   totalMeshesEmitted: number;
@@ -374,6 +390,10 @@ function startSession(input: {
   voidValues: Uint32Array;
   styleIds: Uint32Array;
   styleColors: Uint8Array;
+  planeAngleToRadians?: number;
+  materialElementIds?: Uint32Array;
+  materialColorCounts?: Uint32Array;
+  materialColors?: Uint8Array;
 }): ProcessingSession {
   return {
     sharedBuffer: input.sharedBuffer,
@@ -387,6 +407,10 @@ function startSession(input: {
     voidValues: input.voidValues,
     styleIds: input.styleIds,
     styleColors: input.styleColors,
+    planeAngleToRadians: input.planeAngleToRadians,
+    materialElementIds: input.materialElementIds,
+    materialColorCounts: input.materialColorCounts,
+    materialColors: input.materialColors,
     pendingMeshes: [],
     pendingTransfers: [],
     totalMeshesEmitted: 0,
@@ -520,6 +544,8 @@ async function processBatch(session: ProcessingSession, jobs: Uint32Array): Prom
       session.rtcX, session.rtcY, session.rtcZ, session.needsShift,
       session.voidKeys, session.voidCounts, session.voidValues,
       session.styleIds, session.styleColors,
+      session.planeAngleToRadians,
+      session.materialElementIds, session.materialColorCounts, session.materialColors,
     );
     collectMeshes(session, collection);
   } catch (err) {
@@ -666,6 +692,10 @@ async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<vo
         voidValues: e.data.voidValues,
         styleIds: e.data.styleIds,
         styleColors: e.data.styleColors,
+        planeAngleToRadians: e.data.planeAngleToRadians,
+        materialElementIds: e.data.materialElementIds,
+        materialColorCounts: e.data.materialColorCounts,
+        materialColors: e.data.materialColors,
       });
       return;
     }
@@ -690,6 +720,9 @@ async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<vo
       activeSession.voidKeys = e.data.voidKeys;
       activeSession.voidCounts = e.data.voidCounts;
       activeSession.voidValues = e.data.voidValues;
+      activeSession.materialElementIds = e.data.materialElementIds;
+      activeSession.materialColorCounts = e.data.materialColorCounts;
+      activeSession.materialColors = e.data.materialColors;
       return;
     }
 

--- a/packages/geometry/src/index.ts
+++ b/packages/geometry/src/index.ts
@@ -66,6 +66,12 @@ interface ByteStreamingPrePassResult {
   voidValues: Uint32Array;
   styleIds: Uint32Array;
   styleColors: Uint8Array;
+  /** Prepass-resolved plane-angle→radians scale (additive wire field). */
+  planeAngleToRadians?: number;
+  /** #407/#913 §2.3 per-element material colour lists (flat encoding). */
+  materialElementIds?: Uint32Array;
+  materialColorCounts?: Uint32Array;
+  materialColors?: Uint8Array;
 }
 
 export interface GeometryProcessorOptions {
@@ -351,6 +357,10 @@ export class GeometryProcessor {
           prePass.voidValues,
           prePass.styleIds,
           prePass.styleColors,
+          prePass.planeAngleToRadians,
+          prePass.materialElementIds,
+          prePass.materialColorCounts,
+          prePass.materialColors,
         );
         meshes.push(...convertMeshCollectionToBatch(collection));
       }
@@ -435,6 +445,10 @@ export class GeometryProcessor {
           prePass.voidValues,
           prePass.styleIds,
           prePass.styleColors,
+          prePass.planeAngleToRadians,
+          prePass.materialElementIds,
+          prePass.materialColorCounts,
+          prePass.materialColors,
         );
 
         const batch = convertMeshCollectionToBatch(collection);

--- a/packages/viewer/src/viewer-html.ts
+++ b/packages/viewer/src/viewer-html.ts
@@ -1322,6 +1322,7 @@ async function parseMeshesViaPrePass(api, content, opts) {
         const collection = api.processGeometryBatch(
           bytes, jobSlice, pre.unitScale, rtcX, rtcY, rtcZ, pre.needsShift,
           pre.voidKeys, pre.voidCounts, pre.voidValues, pre.styleIds, pre.styleColors,
+          pre.planeAngleToRadians, pre.materialElementIds, pre.materialColorCounts, pre.materialColors,
         );
         // The MeshDataJs getters copy into JS-owned typed arrays, so onBatch
         // consumers keep working after we free the WASM handles. Free every

--- a/scripts/test-wasm-contract.mjs
+++ b/scripts/test-wasm-contract.mjs
@@ -238,6 +238,66 @@ test('unit scale resolves conversion-based units (inch fixture → 0.0254)', () 
   }
 });
 
+test('prepass resolves planeAngleToRadians on the wire', () => {
+  // The shared resolver (prepass::resolve_unit_scales) resolves BOTH unit
+  // scales once and ships the plane-angle scale to workers so batch decoders
+  // are seeded instead of re-paying an O(file) IFCPROJECT hunt per call.
+  const bytes = new TextEncoder().encode(columnContent);
+  const pre = api.buildPrePassOnce(bytes);
+  try {
+    assert.equal(typeof pre.planeAngleToRadians, 'number',
+      'buildPrePassOnce must carry planeAngleToRadians');
+    assert.ok(pre.planeAngleToRadians > 0,
+      `plane-angle scale must be positive, got ${pre.planeAngleToRadians}`);
+  } finally {
+    api.clearPrePassCache();
+  }
+});
+
+test('streaming meta resolves units with IFCPROJECT moved to the END of DATA', () => {
+  // IfcOpenShell/Revit exports put IFCPROJECT + the unit chain near the end
+  // of the file. The streaming prepass must not wait for it (workers would
+  // idle until ~90% of the scan) NOR default silently to metres — the shared
+  // resolver finds the project by SIMD substring search and re-resolves
+  // against a full index. Transplant the fixture's project + unit chain to
+  // the end of DATA and require identical meta.
+  const projectBlock = [];
+  const remaining = [];
+  for (const line of columnContent.split('\n')) {
+    if (/^#\d+=\s*IFC(PROJECT|UNITASSIGNMENT|SIUNIT|CONVERSIONBASEDUNIT|MEASUREWITHUNIT|DIMENSIONALEXPONENTS)\(/.test(line)) {
+      projectBlock.push(line);
+    } else {
+      remaining.push(line);
+    }
+  }
+  assert.ok(projectBlock.length >= 2, 'fixture must contain a project + unit chain');
+  const joined = remaining.join('\n');
+  // Splice before the LAST `ENDSEC;` — the first one closes the HEADER.
+  const lastEnd = joined.lastIndexOf('ENDSEC;');
+  assert.ok(lastEnd > 0, 'fixture must close its DATA section');
+  const lateProject =
+    joined.slice(0, lastEnd) + projectBlock.join('\n') + '\n' + joined.slice(lastEnd);
+  assert.ok(lateProject.includes('IFCPROJECT'), 'transplant kept the project');
+  assert.ok(
+    lateProject.indexOf('IFCPROJECT') > lateProject.length / 2,
+    'project must now sit in the back half of the file',
+  );
+
+  const bytes = new TextEncoder().encode(lateProject);
+  const events = [];
+  api.buildPrePassStreaming(bytes, (evt) => events.push(evt), 4096);
+  api.clearPrePassCache();
+
+  const meta = events.find((e) => e.type === 'meta');
+  assert.ok(meta, 'streaming must emit meta');
+  assert.ok(Math.abs(meta.unitScale - 0.0254) < 1e-9,
+    `late-IFCPROJECT inch model must still yield unitScale 0.0254, got ${meta.unitScale}`);
+  assert.equal(typeof meta.planeAngleToRadians, 'number',
+    'meta must carry planeAngleToRadians');
+  const complete = events.find((e) => e.type === 'complete');
+  assert.ok(complete && complete.totalJobs > 0, 'streaming must complete with jobs');
+});
+
 test('unit scale resolves plain SI metres (georef fixture → 1.0)', () => {
   if (!GEOREF_AVAILABLE) {
     console.log('     (skipped — georef fixture missing, run `pnpm fixtures`)');

--- a/tests/e2e/viewer-smoke.e2e.spec.ts
+++ b/tests/e2e/viewer-smoke.e2e.spec.ts
@@ -246,12 +246,23 @@ test.describe('Viewer functional smoke (AC20-FZK-Haus)', () => {
   test('page reports no uncaught errors on a clean load', async ({ page }) => {
     const errors: string[] = [];
     page.on('pageerror', (err) => errors.push(String(err)));
+    // The geometry-stream stall watchdog surfaces as a console.error, not a
+    // pageerror — catch it explicitly. A healthy load must never trip it
+    // (worker liveness heartbeats + bounded batches keep events flowing).
+    const stallErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error' && /Geometry stream stalled/.test(msg.text())) {
+        stallErrors.push(msg.text());
+      }
+    });
 
     const viewer = new ViewerBenchmarkPage(page);
     await viewer.setup();
     await viewer.loadFile(join(process.cwd(), FIXTURE));
     await waitForMeshCount(viewer, page, 120000);
     await page.waitForTimeout(2000); // let post-load work (metadata, spatial) settle
+
+    expect(stallErrors, `stream watchdog fired:\n${stallErrors.join('\n')}`).toEqual([]);
 
     // Under software WebGPU (CI) the device itself is unstable — losing
     // it mid-upload throws device-class errors that say nothing about


### PR DESCRIPTION
## What

Step 5 (final) of the pipeline-unification series, stacked on #1092. The Rust side put `planeAngleToRadians` and the #407 per-element material colour lists on the prepass wire; this threads them through every TS consumer so the browser actually benefits:

- **`geometry-parallel.ts`**: `meta.planeAngleToRadians` rides `stream-start`; the `styles` event's `materialElementIds/ColorCounts/Colors` ride `set-styles` to every worker (transferred per-worker like the style arrays).
- **`geometry.worker.ts`**: the session carries the new fields and passes them as `processGeometryBatch`'s trailing args — batch decoders are seeded from the wire (per-worker resolve cache remains the fallback), and the canonical producer's **#913 §2.3 transparent/opaque material alternation now fires in the browser** exactly like on the server (it was inert — empty map — since the wasm batch moved onto the shared producer in #1084).
- **`index.ts`** (`collectMeshesViaPrePass` / `processStreamingBytes`) and the standalone **`viewer-html.ts`** pass the new `buildPrePassOnce` fields on their single-instance paths.

## Contract + e2e hardening

- `scripts/test-wasm-contract.mjs`: pins `planeAngleToRadians` on the `buildPrePassOnce` result, and adds a **late-IFCPROJECT transplant test** — the fixture's project + unit chain moved to the END of DATA must still resolve `unitScale 0.0254` in the streaming `meta` (the resolver's substring-search + full-index ladder), not silently default to metres.
- `tests/e2e/viewer-smoke.e2e.spec.ts`: a healthy load must never trip the geometry-stream stall watchdog (console.error assertion).
- `docs/architecture/geometry-pipeline.md`: documents the unified architecture — the element core + shared prepass, the `TypeGeometryMode` fork, and where geometry/styling fixes belong.

## Verification

wasm contract **19/19** (incl. the two new pins), `@ifc-lite/geometry` vitest **57/57**, turbo typecheck green, viewer smoke e2e **2/2** with the threading live (317 meshes unchanged — the alternation only affects unstyled submeshes of elements with material lists, e.g. window glazing).

This completes the unification series: per-element mesh production, prepass resolution, unit-scale resolution, and the wire codecs each exist exactly once, consumed by both orchestrations.