### PR TITLE
feat(viewer): unify storey state + relocate level display into the hierarchy

### DIFF
--- a/apps/viewer/src/components/viewer/CommandPalette.tsx
+++ b/apps/viewer/src/components/viewer/CommandPalette.tsx
@@ -69,6 +69,7 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useViewerStore } from '@/store';
+import { applyLevelDisplayMode } from '@/store/levelDisplay';
 import { goHomeFromStore, resetVisibilityForHomeFromStore } from '@/store/homeView';
 import {
   executeBasketSet,
@@ -327,11 +328,11 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
       { id: 'view:frame', label: 'Frame Selection', keywords: 'zoom focus selected', category: 'View', icon: Crosshair, shortcut: 'F',
         action: () => { useViewerStore.getState().cameraCallbacks.frameSelection?.(); } },
       { id: 'view:stacked', label: 'Level — Stacked', keywords: 'level display mode stacked default storey storeys', category: 'View', icon: Layers3,
-        action: () => { useViewerStore.getState().setLevelDisplayMode('stacked'); } },
+        action: () => { applyLevelDisplayMode('stacked'); } },
       { id: 'view:exploded', label: 'Level — Exploded', keywords: 'level display mode exploded explode lift storey storeys gap', category: 'View', icon: ChevronsUpDown,
-        action: () => { useViewerStore.getState().setLevelDisplayMode('exploded'); } },
-      { id: 'view:solo', label: 'Level — Solo', keywords: 'level display mode solo isolate storey single only', category: 'View', icon: SquareStack,
-        action: () => { useViewerStore.getState().setLevelDisplayMode('solo'); } },
+        action: () => { applyLevelDisplayMode('exploded'); } },
+      { id: 'view:solo', label: 'Level — Solo', keywords: 'level display mode solo isolate storey single only top', category: 'View', icon: SquareStack,
+        action: () => { applyLevelDisplayMode('solo'); } },
       { id: 'view:projection', label: 'Projection', keywords: 'perspective orthographic ortho toggle switch', category: 'View', icon: Orbit,
         action: () => { useViewerStore.getState().toggleProjectionMode(); } },
       { id: 'view:top', label: 'Top View', keywords: 'camera plan', category: 'View', icon: ArrowUp, shortcut: '1',

--- a/apps/viewer/src/components/viewer/HierarchyPanel.tsx
+++ b/apps/viewer/src/components/viewer/HierarchyPanel.tsx
@@ -49,6 +49,7 @@ export function HierarchyPanel() {
   const setStoreysSelection = useViewerStore((s) => s.setStoreysSelection);
   const clearStoreySelection = useViewerStore((s) => s.clearStoreySelection);
   const setActiveStorey = useViewerStore((s) => s.setActiveStorey);
+  const setLevelDisplayMode = useViewerStore((s) => s.setLevelDisplayMode);
   const isolateEntities = useViewerStore((s) => s.isolateEntities);
   const isolatedEntities = useViewerStore((s) => s.isolatedEntities);
   const clearIsolation = useViewerStore((s) => s.clearIsolation);
@@ -409,11 +410,16 @@ export function HierarchyPanel() {
           selectedStoreys.size === storeyIds.length;
 
         if (allAlreadySelected) {
-          // Toggle off - clear selection to show all
+          // Toggle off - clear selection to show all. The level-display guard
+          // (useLevelDisplayEffect) drops Solo → Stacked when no storey is
+          // isolated, so the mode flag follows.
           clearStoreySelection();
         } else {
-          // Select this storey (replaces any existing selection)
+          // Select this storey (replaces any existing selection). Isolating a
+          // single storey IS Solo, so reflect that in the level-display mode —
+          // keeps the storey-tab control + in-viewport chip in sync.
           setStoreysSelection(storeyIds);
+          setLevelDisplayMode('solo');
         }
       }
     } else if (node.type === 'IfcSpace') {
@@ -454,7 +460,7 @@ export function HierarchyPanel() {
         setSelectedEntity(resolveEntityRef(globalId));
       }
     }
-  }, [selectedStoreys, setStoreysSelection, clearStoreySelection, setActiveStorey, setSelectedEntityId, setSelectedEntityIds, setSelectedEntity, setSelectedEntities, setActiveModel, toggleExpand, unifiedStoreys, models, isolateEntities, getNodeElements, setHierarchyBasketSelection, toGlobalId, groupingMode, setClassFilter]);
+  }, [selectedStoreys, setStoreysSelection, clearStoreySelection, setActiveStorey, setLevelDisplayMode, setSelectedEntityId, setSelectedEntityIds, setSelectedEntity, setSelectedEntities, setActiveModel, toggleExpand, unifiedStoreys, models, isolateEntities, getNodeElements, setHierarchyBasketSelection, toGlobalId, groupingMode, setClassFilter]);
 
   // Compute selection and visibility state for a node
   const computeNodeState = useCallback((node: TreeNode): { isSelected: boolean; nodeHidden: boolean; modelVisible?: boolean } => {

--- a/apps/viewer/src/components/viewer/HierarchyPanel.tsx
+++ b/apps/viewer/src/components/viewer/HierarchyPanel.tsx
@@ -24,6 +24,7 @@ import type { TreeNode } from './hierarchy/types';
 import { isSpatialContainer } from './hierarchy/types';
 import { useHierarchyTree } from './hierarchy/useHierarchyTree';
 import { HierarchyNode, SectionHeader } from './hierarchy/HierarchyNode';
+import { StoreyDisplayControls } from './hierarchy/StoreyDisplayControls';
 
 export function HierarchyPanel() {
   const {
@@ -47,6 +48,7 @@ export function HierarchyPanel() {
   const setStoreySelection = useViewerStore((s) => s.setStoreySelection);
   const setStoreysSelection = useViewerStore((s) => s.setStoreysSelection);
   const clearStoreySelection = useViewerStore((s) => s.clearStoreySelection);
+  const setActiveStorey = useViewerStore((s) => s.setActiveStorey);
   const isolateEntities = useViewerStore((s) => s.isolateEntities);
   const isolatedEntities = useViewerStore((s) => s.isolatedEntities);
   const clearIsolation = useViewerStore((s) => s.clearIsolation);
@@ -364,6 +366,15 @@ export function HierarchyPanel() {
         ? unified.storeys.map(s => s.storeyId)
         : node.expressIds;
 
+      // Update the shared active storey (model-aware) so Space Sketch, the
+      // Solo level-display mode, and the floorplan all follow the storey the
+      // user just clicked. For a multi-model unified storey, pick the first
+      // constituent as the representative.
+      const activeRep = unified && unified.storeys.length > 0
+        ? { modelId: unified.storeys[0].modelId, expressId: unified.storeys[0].storeyId }
+        : { modelId: node.modelIds[0] || 'legacy', expressId: storeyIds[0] };
+      if (activeRep.expressId != null) setActiveStorey(activeRep);
+
       // Set entity refs for property panel display
       if (unified && unified.storeys.length > 1) {
         // Multi-model unified storey: show all storeys combined in property panel
@@ -443,7 +454,7 @@ export function HierarchyPanel() {
         setSelectedEntity(resolveEntityRef(globalId));
       }
     }
-  }, [selectedStoreys, setStoreysSelection, clearStoreySelection, setSelectedEntityId, setSelectedEntityIds, setSelectedEntity, setSelectedEntities, setActiveModel, toggleExpand, unifiedStoreys, models, isolateEntities, getNodeElements, setHierarchyBasketSelection, toGlobalId, groupingMode, setClassFilter]);
+  }, [selectedStoreys, setStoreysSelection, clearStoreySelection, setActiveStorey, setSelectedEntityId, setSelectedEntityIds, setSelectedEntity, setSelectedEntities, setActiveModel, toggleExpand, unifiedStoreys, models, isolateEntities, getNodeElements, setHierarchyBasketSelection, toGlobalId, groupingMode, setClassFilter]);
 
   // Compute selection and visibility state for a node
   const computeNodeState = useCallback((node: TreeNode): { isSelected: boolean; nodeHidden: boolean; modelVisible?: boolean } => {
@@ -621,6 +632,7 @@ export function HierarchyPanel() {
           {/* Storeys Section */}
           <div style={{ height: `${splitRatio * 100}%` }} className="flex flex-col min-h-0">
             <SectionHeader icon={Layers} title="Building Storeys" count={storeysNodes.length} />
+            <StoreyDisplayControls />
             <div ref={storeysRef} className="flex-1 overflow-auto scrollbar-thin bg-white dark:bg-black">
               <div
                 style={{
@@ -737,6 +749,10 @@ export function HierarchyPanel() {
 
       {/* Section Header */}
       <SectionHeader icon={groupingMode === 'spatial' ? Building2 : groupingMode === 'type' ? Layers : groupingMode === 'material' ? Palette : FileBox} title={groupingMode === 'spatial' ? 'Hierarchy' : groupingMode === 'type' ? 'By Class' : groupingMode === 'material' ? 'By Material' : 'By Type'} count={filteredNodes.length} />
+
+      {/* Level display (Stacked / Exploded / Solo) + floorplan — only in the
+          spatial view where storeys are the organising concept. */}
+      {groupingMode === 'spatial' && <StoreyDisplayControls />}
 
       {/* Tree */}
       <div ref={parentRef} className="flex-1 overflow-auto scrollbar-thin bg-white dark:bg-black">

--- a/apps/viewer/src/components/viewer/LevelDisplayIndicator.tsx
+++ b/apps/viewer/src/components/viewer/LevelDisplayIndicator.tsx
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Persistent in-viewport indicator for a non-default level display mode.
+ *
+ * Replaces the 1.5px toolbar dot that used to be the only signal an
+ * Exploded / Solo view was active — easy to miss, and the control itself
+ * has now moved into the hierarchy. A small chip in the viewport tells the
+ * user at a glance "you are isolated to storey X" / "levels are exploded",
+ * with a one-click return to Stacked.
+ *
+ * Anchored top-left so it never covers the ViewCube (top-right) or the
+ * Sun & Sky panel (top-32 right).
+ */
+
+import { ChevronsUpDown, SquareStack, X } from 'lucide-react';
+import { useViewerStore } from '@/store';
+import { useFloorplanView } from '@/hooks/useFloorplanView';
+
+export function LevelDisplayIndicator() {
+  const mode = useViewerStore((s) => s.levelDisplayMode);
+  const explodedGap = useViewerStore((s) => s.explodedGap);
+  const activeStorey = useViewerStore((s) => s.activeStorey);
+  const setLevelDisplayMode = useViewerStore((s) => s.setLevelDisplayMode);
+  const { availableStoreys } = useFloorplanView();
+
+  if (mode === 'stacked') return null;
+
+  const Icon = mode === 'exploded' ? ChevronsUpDown : SquareStack;
+  const soloName = activeStorey
+    ? availableStoreys.find((s) => s.modelId === activeStorey.modelId && s.expressId === activeStorey.expressId)?.name
+    : undefined;
+  const label =
+    mode === 'exploded'
+      ? `Exploded · ${explodedGap} m gap`
+      : `Solo · ${soloName ?? 'storey'}`;
+
+  return (
+    <div className="absolute top-4 left-4 z-10 flex items-center gap-1.5 rounded-md border border-purple-300/60 bg-background/90 px-2 py-1 text-xs font-medium text-foreground shadow-sm backdrop-blur dark:border-purple-500/40">
+      <Icon className="h-3.5 w-3.5 text-purple-500" />
+      <span className="tabular-nums">{label}</span>
+      <button
+        type="button"
+        onClick={() => setLevelDisplayMode('stacked')}
+        title="Back to stacked"
+        aria-label="Back to stacked view"
+        className="ml-0.5 inline-flex h-4 w-4 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+      >
+        <X className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}

--- a/apps/viewer/src/components/viewer/LevelDisplayIndicator.tsx
+++ b/apps/viewer/src/components/viewer/LevelDisplayIndicator.tsx
@@ -17,13 +17,13 @@
 
 import { ChevronsUpDown, SquareStack, X } from 'lucide-react';
 import { useViewerStore } from '@/store';
+import { applyLevelDisplayMode } from '@/store/levelDisplay';
 import { useFloorplanView } from '@/hooks/useFloorplanView';
 
 export function LevelDisplayIndicator() {
   const mode = useViewerStore((s) => s.levelDisplayMode);
   const explodedGap = useViewerStore((s) => s.explodedGap);
   const activeStorey = useViewerStore((s) => s.activeStorey);
-  const setLevelDisplayMode = useViewerStore((s) => s.setLevelDisplayMode);
   const { availableStoreys } = useFloorplanView();
 
   if (mode === 'stacked') return null;
@@ -43,7 +43,7 @@ export function LevelDisplayIndicator() {
       <span className="tabular-nums">{label}</span>
       <button
         type="button"
-        onClick={() => setLevelDisplayMode('stacked')}
+        onClick={() => applyLevelDisplayMode('stacked')}
         title="Back to stacked"
         aria-label="Back to stacked view"
         className="ml-0.5 inline-flex h-4 w-4 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"

--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -46,9 +46,6 @@ import {
   Sun,
   Move,
   PenLine,
-  Layers3,
-  SquareStack,
-  ChevronsUpDown,
   Undo2,
   Redo2,
   Boxes,
@@ -84,7 +81,6 @@ import { BulkPropertyEditor } from './BulkPropertyEditor';
 import { DataConnector } from './DataConnector';
 import { ExportChangesButton } from './ExportChangesButton';
 import { SearchInline } from './SearchInline';
-import { useFloorplanView } from '@/hooks/useFloorplanView';
 import { recordRecentFiles, cacheFileBlobs } from '@/lib/recent-files';
 import { ThemeSwitch } from './ThemeSwitch';
 import { ExtensionToolbarSlot } from '@/components/extensions/ExtensionToolbarSlot';
@@ -182,128 +178,6 @@ function ClassVisibilityRow({ icon, label, description, checked, onChange }: Cla
       </span>
       <Switch checked={checked} onCheckedChange={onChange} />
     </label>
-  );
-}
-
-/**
- * Stacked / Exploded / Solo level display dropdown. Pinned next
- * to the Quick Floorplan dropdown so storey-related controls
- * cluster visually. Shows a small purple dot on the trigger when
- * mode is not Stacked, so the user can tell at a glance that an
- * Exploded / Solo view is active.
- *
- * Gating: parent renders this only when there are ≥ 2 storeys
- * — single-storey models have no use for level display modes.
- */
-interface LevelDisplayDropdownProps {
-  availableStoreys: Array<{ modelId: string; expressId: number; name: string; elevation: number }>;
-}
-
-function LevelDisplayDropdown({ availableStoreys }: LevelDisplayDropdownProps) {
-  const levelDisplayMode = useViewerStore((s) => s.levelDisplayMode);
-  const setLevelDisplayMode = useViewerStore((s) => s.setLevelDisplayMode);
-  const explodedGap = useViewerStore((s) => s.explodedGap);
-  const setExplodedGap = useViewerStore((s) => s.setExplodedGap);
-  const soloStorey = useViewerStore((s) => s.soloStorey);
-  const setSoloStorey = useViewerStore((s) => s.setSoloStorey);
-
-  const dirty = levelDisplayMode !== 'stacked';
-  return (
-    <DropdownMenu>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              aria-label="Level display mode"
-              className="relative"
-            >
-              {levelDisplayMode === 'exploded' ? (
-                <ChevronsUpDown className="h-4 w-4" />
-              ) : levelDisplayMode === 'solo' ? (
-                <SquareStack className="h-4 w-4" />
-              ) : (
-                <Layers3 className="h-4 w-4" />
-              )}
-              {dirty && (
-                <span
-                  aria-hidden="true"
-                  className="absolute top-1 right-1 h-1.5 w-1.5 rounded-full bg-purple-500 ring-1 ring-background"
-                />
-              )}
-            </Button>
-          </DropdownMenuTrigger>
-        </TooltipTrigger>
-        <TooltipContent>Level display ({levelDisplayMode})</TooltipContent>
-      </Tooltip>
-      <DropdownMenuContent className="w-72">
-        <DropdownMenuLabel>Level display</DropdownMenuLabel>
-        <DropdownMenuCheckboxItem
-          checked={levelDisplayMode === 'stacked'}
-          onCheckedChange={() => setLevelDisplayMode('stacked')}
-        >
-          <Layers3 className="h-4 w-4 mr-2" /> Stacked
-          <span className="ml-auto text-[10px] opacity-50">default</span>
-        </DropdownMenuCheckboxItem>
-        <DropdownMenuCheckboxItem
-          checked={levelDisplayMode === 'exploded'}
-          onCheckedChange={() => setLevelDisplayMode('exploded')}
-        >
-          <ChevronsUpDown className="h-4 w-4 mr-2" /> Exploded
-        </DropdownMenuCheckboxItem>
-        {levelDisplayMode === 'exploded' && (
-          <div className="px-2 pb-1.5 pt-1 flex items-center gap-2 text-xs">
-            <span className="text-zinc-500">Gap (m)</span>
-            <input
-              type="number"
-              min={0}
-              max={100}
-              step={0.5}
-              value={explodedGap}
-              onChange={(e) => {
-                // Guard non-finite — clearing the field or typing
-                // a stray "e" would yield NaN, which the offset
-                // math would silently propagate. The slice setter
-                // also clamps to [0, 100] for the range guard.
-                const next = e.currentTarget.valueAsNumber;
-                if (Number.isFinite(next)) setExplodedGap(next);
-              }}
-              className="w-16 px-1.5 py-0.5 border border-zinc-300 dark:border-zinc-700
-                bg-white dark:bg-zinc-950 text-xs font-mono rounded
-                focus:outline-none focus:ring-1 focus:ring-purple-500"
-            />
-          </div>
-        )}
-        <DropdownMenuCheckboxItem
-          checked={levelDisplayMode === 'solo'}
-          onCheckedChange={() => setLevelDisplayMode('solo')}
-        >
-          <SquareStack className="h-4 w-4 mr-2" /> Solo
-        </DropdownMenuCheckboxItem>
-        {levelDisplayMode === 'solo' && (
-          <>
-            <DropdownMenuSeparator />
-            <DropdownMenuLabel className="text-[10px] uppercase tracking-wide">Storey</DropdownMenuLabel>
-            {availableStoreys.map((storey) => (
-              <DropdownMenuItem
-                key={`${storey.modelId}-${storey.expressId}`}
-                onClick={() => setSoloStorey({ modelId: storey.modelId, expressId: storey.expressId })}
-                className={cn(
-                  soloStorey?.modelId === storey.modelId &&
-                    soloStorey?.expressId === storey.expressId &&
-                    'bg-purple-100 dark:bg-purple-950/40',
-                )}
-              >
-                <Building2 className="h-4 w-4 mr-2" />
-                {storey.name}
-                <span className="ml-auto text-[10px] opacity-60">{storey.elevation.toFixed(1)}m</span>
-              </DropdownMenuItem>
-            ))}
-          </>
-        )}
-      </DropdownMenuContent>
-    </DropdownMenu>
   );
 }
 
@@ -439,9 +313,6 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
     window.addEventListener('ifc-lite:load-file', handler);
     return () => window.removeEventListener('ifc-lite:load-file', handler);
   }, [loadFile]);
-
-  // Floorplan view
-  const { availableStoreys, activateFloorplan } = useFloorplanView();
 
   // Check if we have models loaded (for showing add model button)
   const hasModelsLoaded = models.size > 0 || (geometryResult?.meshes && geometryResult.meshes.length > 0);
@@ -1296,38 +1167,11 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
         activeAccentClass="bg-amber-500 text-white hover:bg-amber-500/90"
       />
 
-      {/* Floorplan dropdown */}
-      {availableStoreys.length > 0 && (
-        <DropdownMenu>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon-sm">
-                  <Building2 className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
-            </TooltipTrigger>
-            <TooltipContent>Quick Floorplan</TooltipContent>
-          </Tooltip>
-          <DropdownMenuContent>
-            {availableStoreys.map((storey) => (
-              <DropdownMenuItem
-                key={`${storey.modelId}-${storey.expressId}`}
-                onClick={() => activateFloorplan(storey)}
-              >
-                <Building2 className="h-4 w-4 mr-2" />
-                {storey.name}
-                <span className="ml-auto text-xs opacity-60">{storey.elevation.toFixed(1)}m</span>
-              </DropdownMenuItem>
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
-      )}
-
-      {/* Level display mode (Stacked / Exploded / Solo). Only
-          surfaces when the active model has at least 2 storeys —
-          single-storey models have nothing useful to show. */}
-      {availableStoreys.length >= 2 && <LevelDisplayDropdown availableStoreys={availableStoreys} />}
+      {/* Storey navigation + level display (Stacked / Exploded / Solo) moved
+          into the Hierarchy panel's Building Storeys section so every "level"
+          concept lives in one place — see `StoreyDisplayControls`. The two
+          adjacent storey buttons that used to sit here (Quick Floorplan +
+          Level display) were retired to fix the duplicate-button confusion. */}
 
       <Separator orientation="vertical" className="h-6 mx-1" />
 

--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -7,6 +7,7 @@ import { useLevelDisplayEffect } from '@/hooks/useLevelDisplayEffect';
 import { Viewport } from './Viewport';
 import { ViewportOverlays } from './ViewportOverlays';
 import { MergeLayersBanner } from './MergeLayersBanner';
+import { LevelDisplayIndicator } from './LevelDisplayIndicator';
 import { ToolOverlays } from './ToolOverlays';
 import { AnnotationLayer } from './annotations/AnnotationLayer';
 import { Section2DPanel } from './Section2DPanel';
@@ -1153,6 +1154,7 @@ export function ViewportContainer() {
           top of the canvas. Only renders when the user has flipped the
           merge-layers toggle while a model is in scope. */}
       <MergeLayersBanner />
+      <LevelDisplayIndicator />
       <ToolOverlays />
       <BasketPresentationDock />
       <Section2DPanel

--- a/apps/viewer/src/components/viewer/hierarchy/StoreyDisplayControls.tsx
+++ b/apps/viewer/src/components/viewer/hierarchy/StoreyDisplayControls.tsx
@@ -1,0 +1,131 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Storey display controls — Stacked / Exploded / Solo, relocated from the
+ * toolbar into the hierarchy's Building Storeys section so every "level"
+ * concept lives where the user already thinks about storeys.
+ *
+ * The storey rows are the picker: Solo isolates the shared `activeStorey`
+ * (set when a storey row is clicked), so there's no separate storey dropdown
+ * and no lowest-storey cold-start surprise. The Floorplan button on the right
+ * activates a top-down section view of the active storey — folding in the
+ * old toolbar Quick-Floorplan dropdown so storey navigation + display sit
+ * together.
+ *
+ * Self-gates: renders only with ≥ 2 storeys (single-storey models have no
+ * use for level display modes or floorplan navigation).
+ */
+
+import { Layers3, ChevronsUpDown, SquareStack, Building2 } from 'lucide-react';
+import { useViewerStore } from '@/store';
+import { useFloorplanView } from '@/hooks/useFloorplanView';
+import { cn } from '@/lib/utils';
+import type { LevelDisplayMode } from '@/store/slices/levelDisplaySlice';
+
+const MODES: Array<{ key: LevelDisplayMode; label: string; Icon: typeof Layers3; hint: string }> = [
+  { key: 'stacked', label: 'Stacked', Icon: Layers3, hint: 'Every storey at its real elevation (default)' },
+  { key: 'exploded', label: 'Exploded', Icon: ChevronsUpDown, hint: 'Lift each storey apart vertically' },
+  { key: 'solo', label: 'Solo', Icon: SquareStack, hint: 'Show only the active storey' },
+];
+
+export function StoreyDisplayControls() {
+  const { availableStoreys, activateFloorplan } = useFloorplanView();
+  const levelDisplayMode = useViewerStore((s) => s.levelDisplayMode);
+  const setLevelDisplayMode = useViewerStore((s) => s.setLevelDisplayMode);
+  const explodedGap = useViewerStore((s) => s.explodedGap);
+  const setExplodedGap = useViewerStore((s) => s.setExplodedGap);
+  const activeStorey = useViewerStore((s) => s.activeStorey);
+  const setActiveStorey = useViewerStore((s) => s.setActiveStorey);
+  const setStoreysSelection = useViewerStore((s) => s.setStoreysSelection);
+
+  // Level display only makes sense with multiple storeys to stack/explode/solo.
+  if (availableStoreys.length < 2) return null;
+
+  const activeInfo = activeStorey
+    ? availableStoreys.find((s) => s.modelId === activeStorey.modelId && s.expressId === activeStorey.expressId) ?? null
+    : null;
+
+  const handleMode = (mode: LevelDisplayMode) => {
+    if (mode === 'solo' && !activeStorey) {
+      // No focused storey yet → default to the top storey instead of
+      // cold-starting on the (often near-empty) lowest storey.
+      // availableStoreys is sorted by elevation descending, so [0] is highest.
+      const top = availableStoreys[0];
+      setActiveStorey({ modelId: top.modelId, expressId: top.expressId });
+      // Mirror into the renderer storey filter so the row highlights and the
+      // two isolation channels agree on the same storey.
+      setStoreysSelection([top.expressId]);
+    }
+    setLevelDisplayMode(mode);
+  };
+
+  return (
+    <div className="border-b border-zinc-200 dark:border-zinc-800 bg-zinc-50/60 dark:bg-zinc-950/40 px-2 py-1.5">
+      <div className="flex items-center gap-1">
+        <div className="inline-flex flex-1 rounded-md border border-zinc-200 dark:border-zinc-800 p-0.5">
+          {MODES.map(({ key, label, Icon, hint }) => (
+            <button
+              key={key}
+              type="button"
+              title={hint}
+              aria-pressed={levelDisplayMode === key}
+              onClick={() => handleMode(key)}
+              className={cn(
+                'flex flex-1 items-center justify-center gap-1 rounded px-1.5 py-1 text-[11px] font-medium transition-colors',
+                levelDisplayMode === key
+                  ? 'bg-primary text-primary-foreground'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-muted/60',
+              )}
+            >
+              <Icon className="h-3.5 w-3.5 shrink-0" />
+              <span className="truncate">{label}</span>
+            </button>
+          ))}
+        </div>
+        <button
+          type="button"
+          disabled={!activeInfo}
+          title={activeInfo ? `Floorplan: ${activeInfo.name}` : 'Pick a storey to floorplan it'}
+          aria-label="Floorplan the active storey"
+          onClick={() => activeInfo && activateFloorplan(activeInfo)}
+          className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-zinc-200 dark:border-zinc-800 text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-40"
+        >
+          <Building2 className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      {levelDisplayMode === 'exploded' && (
+        <div className="mt-1.5 flex items-center gap-2 text-[11px] text-muted-foreground">
+          <span>Gap</span>
+          <input
+            type="number"
+            min={0}
+            max={100}
+            step={0.5}
+            value={explodedGap}
+            onChange={(e) => {
+              const next = e.currentTarget.valueAsNumber;
+              if (Number.isFinite(next)) setExplodedGap(next);
+            }}
+            className="w-16 rounded border border-zinc-300 bg-white px-1.5 py-0.5 font-mono text-[11px] focus:outline-none focus:ring-1 focus:ring-primary dark:border-zinc-700 dark:bg-zinc-950"
+          />
+          <span>m between levels</span>
+        </div>
+      )}
+
+      {levelDisplayMode === 'solo' && (
+        <div className="mt-1 text-[10px] leading-tight text-muted-foreground">
+          {activeInfo ? (
+            <>
+              Showing <span className="font-medium text-foreground">{activeInfo.name}</span> · click a storey to switch
+            </>
+          ) : (
+            'Click a storey to solo it'
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/viewer/src/components/viewer/hierarchy/StoreyDisplayControls.tsx
+++ b/apps/viewer/src/components/viewer/hierarchy/StoreyDisplayControls.tsx
@@ -20,6 +20,7 @@
 
 import { Layers3, ChevronsUpDown, SquareStack, Building2 } from 'lucide-react';
 import { useViewerStore } from '@/store';
+import { applyLevelDisplayMode } from '@/store/levelDisplay';
 import { useFloorplanView } from '@/hooks/useFloorplanView';
 import { cn } from '@/lib/utils';
 import type { LevelDisplayMode } from '@/store/slices/levelDisplaySlice';
@@ -33,12 +34,9 @@ const MODES: Array<{ key: LevelDisplayMode; label: string; Icon: typeof Layers3;
 export function StoreyDisplayControls() {
   const { availableStoreys, activateFloorplan } = useFloorplanView();
   const levelDisplayMode = useViewerStore((s) => s.levelDisplayMode);
-  const setLevelDisplayMode = useViewerStore((s) => s.setLevelDisplayMode);
   const explodedGap = useViewerStore((s) => s.explodedGap);
   const setExplodedGap = useViewerStore((s) => s.setExplodedGap);
   const activeStorey = useViewerStore((s) => s.activeStorey);
-  const setActiveStorey = useViewerStore((s) => s.setActiveStorey);
-  const setStoreysSelection = useViewerStore((s) => s.setStoreysSelection);
 
   // Level display only makes sense with multiple storeys to stack/explode/solo.
   if (availableStoreys.length < 2) return null;
@@ -47,19 +45,10 @@ export function StoreyDisplayControls() {
     ? availableStoreys.find((s) => s.modelId === activeStorey.modelId && s.expressId === activeStorey.expressId) ?? null
     : null;
 
-  const handleMode = (mode: LevelDisplayMode) => {
-    if (mode === 'solo' && !activeStorey) {
-      // No focused storey yet → default to the top storey instead of
-      // cold-starting on the (often near-empty) lowest storey.
-      // availableStoreys is sorted by elevation descending, so [0] is highest.
-      const top = availableStoreys[0];
-      setActiveStorey({ modelId: top.modelId, expressId: top.expressId });
-      // Mirror into the renderer storey filter so the row highlights and the
-      // two isolation channels agree on the same storey.
-      setStoreysSelection([top.expressId]);
-    }
-    setLevelDisplayMode(mode);
-  };
+  // One unified transition: Solo isolates the active/top storey via the storey
+  // filter; Stacked / Exploded clear that isolation. No second channel to
+  // strand. (Solo's default storey is the top one, not the empty basement.)
+  const handleMode = (mode: LevelDisplayMode) => applyLevelDisplayMode(mode);
 
   return (
     <div className="border-b border-zinc-200 dark:border-zinc-800 bg-zinc-50/60 dark:bg-zinc-950/40 px-2 py-1.5">

--- a/apps/viewer/src/components/viewer/hierarchy/StoreyDisplayControls.tsx
+++ b/apps/viewer/src/components/viewer/hierarchy/StoreyDisplayControls.tsx
@@ -38,12 +38,19 @@ export function StoreyDisplayControls() {
   const setExplodedGap = useViewerStore((s) => s.setExplodedGap);
   const activeStorey = useViewerStore((s) => s.activeStorey);
 
-  // Level display only makes sense with multiple storeys to stack/explode/solo.
-  if (availableStoreys.length < 2) return null;
+  // Nothing storey-related to offer without a storey at all.
+  if (availableStoreys.length < 1) return null;
+
+  // Stacked / Exploded / Solo only make sense with multiple storeys; Floorplan
+  // works for a single storey too (it replaced the toolbar Quick-Floorplan).
+  const showModes = availableStoreys.length >= 2;
 
   const activeInfo = activeStorey
     ? availableStoreys.find((s) => s.modelId === activeStorey.modelId && s.expressId === activeStorey.expressId) ?? null
     : null;
+  // Single-storey models have one obvious target, so floorplan it directly
+  // without first requiring a storey pick (matches the old Quick-Floorplan).
+  const floorplanTarget = activeInfo ?? (availableStoreys.length === 1 ? availableStoreys[0] : null);
 
   // One unified transition: Solo isolates the active/top storey via the storey
   // filter; Stacked / Exploded clear that isolation. No second channel to
@@ -53,39 +60,44 @@ export function StoreyDisplayControls() {
   return (
     <div className="border-b border-zinc-200 dark:border-zinc-800 bg-zinc-50/60 dark:bg-zinc-950/40 px-2 py-1.5">
       <div className="flex items-center gap-1">
-        <div className="inline-flex flex-1 rounded-md border border-zinc-200 dark:border-zinc-800 p-0.5">
-          {MODES.map(({ key, label, Icon, hint }) => (
-            <button
-              key={key}
-              type="button"
-              title={hint}
-              aria-pressed={levelDisplayMode === key}
-              onClick={() => handleMode(key)}
-              className={cn(
-                'flex flex-1 items-center justify-center gap-1 rounded px-1.5 py-1 text-[11px] font-medium transition-colors',
-                levelDisplayMode === key
-                  ? 'bg-primary text-primary-foreground'
-                  : 'text-muted-foreground hover:text-foreground hover:bg-muted/60',
-              )}
-            >
-              <Icon className="h-3.5 w-3.5 shrink-0" />
-              <span className="truncate">{label}</span>
-            </button>
-          ))}
-        </div>
+        {showModes && (
+          <div className="inline-flex flex-1 rounded-md border border-zinc-200 dark:border-zinc-800 p-0.5">
+            {MODES.map(({ key, label, Icon, hint }) => (
+              <button
+                key={key}
+                type="button"
+                title={hint}
+                aria-pressed={levelDisplayMode === key}
+                onClick={() => handleMode(key)}
+                className={cn(
+                  'flex flex-1 items-center justify-center gap-1 rounded px-1.5 py-1 text-[11px] font-medium transition-colors',
+                  levelDisplayMode === key
+                    ? 'bg-primary text-primary-foreground'
+                    : 'text-muted-foreground hover:text-foreground hover:bg-muted/60',
+                )}
+              >
+                <Icon className="h-3.5 w-3.5 shrink-0" />
+                <span className="truncate">{label}</span>
+              </button>
+            ))}
+          </div>
+        )}
         <button
           type="button"
-          disabled={!activeInfo}
-          title={activeInfo ? `Floorplan: ${activeInfo.name}` : 'Pick a storey to floorplan it'}
+          disabled={!floorplanTarget}
+          title={floorplanTarget ? `Floorplan: ${floorplanTarget.name}` : 'Pick a storey to floorplan it'}
           aria-label="Floorplan the active storey"
-          onClick={() => activeInfo && activateFloorplan(activeInfo)}
-          className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-zinc-200 dark:border-zinc-800 text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-40"
+          onClick={() => floorplanTarget && activateFloorplan(floorplanTarget)}
+          className={cn(
+            'inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-zinc-200 dark:border-zinc-800 text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-40',
+            !showModes && 'ml-auto',
+          )}
         >
           <Building2 className="h-3.5 w-3.5" />
         </button>
       </div>
 
-      {levelDisplayMode === 'exploded' && (
+      {showModes && levelDisplayMode === 'exploded' && (
         <div className="mt-1.5 flex items-center gap-2 text-[11px] text-muted-foreground">
           <span>Gap</span>
           <input
@@ -104,7 +116,7 @@ export function StoreyDisplayControls() {
         </div>
       )}
 
-      {levelDisplayMode === 'solo' && (
+      {showModes && levelDisplayMode === 'solo' && (
         <div className="mt-1 text-[10px] leading-tight text-muted-foreground">
           {activeInfo ? (
             <>

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -222,9 +222,28 @@ export function SpaceSketchOverlay() {
   }, [underlay, showBuilding, hist]);
   const [storeyId, setStoreyId] = useState<number | null>(null);
   const lastDerivedRef = useRef<number | null>(null);
+  // Connect to the shared active storey instead of always defaulting to the
+  // lowest storey: seed from whatever the user already picked in the hierarchy,
+  // and follow it when it changes while the panel is open. The in-panel storey
+  // <select> stays as a local override; a later hierarchy pick wins.
+  const activeStorey = useViewerStore((s) => s.activeStorey);
+  const lastActiveStoreyRef = useRef<number | null>(null);
   useEffect(() => {
-    if (storeyId == null && storeys.length) setStoreyId(storeys[0].id);
-  }, [storeys, storeyId]);
+    if (!storeys.length) return;
+    const sketchModelId = activeModelId ?? 'legacy';
+    const activeHere =
+      activeStorey && activeStorey.modelId === sketchModelId && storeys.some((s) => s.id === activeStorey.expressId)
+        ? activeStorey.expressId
+        : null;
+    // Follow the shared active storey when it changes to one in this model.
+    if (activeHere != null && activeHere !== lastActiveStoreyRef.current) {
+      lastActiveStoreyRef.current = activeHere;
+      setStoreyId(activeHere);
+      return;
+    }
+    // Initial seed: prefer the active storey, else the lowest.
+    if (storeyId == null) setStoreyId(activeHere ?? storeys[0].id);
+  }, [storeys, storeyId, activeStorey, activeModelId]);
 
   // Click anywhere outside the panel closes the tool. Esc closes too.
   useEffect(() => {

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -221,13 +221,15 @@ export function SpaceSketchOverlay() {
     ));
   }, [underlay, showBuilding, hist]);
   const [storeyId, setStoreyId] = useState<number | null>(null);
-  const lastDerivedRef = useRef<number | null>(null);
+  const lastDerivedRef = useRef<string | null>(null);
   // Connect to the shared active storey instead of always defaulting to the
   // lowest storey: seed from whatever the user already picked in the hierarchy,
   // and follow it when it changes while the panel is open. The in-panel storey
   // <select> stays as a local override; a later hierarchy pick wins.
   const activeStorey = useViewerStore((s) => s.activeStorey);
-  const lastActiveStoreyRef = useRef<number | null>(null);
+  // Keyed by `${modelId}:${expressId}` (not a bare id) so switching to another
+  // model that happens to share a storey express-id still counts as a change.
+  const lastActiveStoreyRef = useRef<string | null>(null);
   useEffect(() => {
     if (!storeys.length) return;
     const sketchModelId = activeModelId ?? 'legacy';
@@ -235,9 +237,10 @@ export function SpaceSketchOverlay() {
       activeStorey && activeStorey.modelId === sketchModelId && storeys.some((s) => s.id === activeStorey.expressId)
         ? activeStorey.expressId
         : null;
+    const activeKey = activeHere == null ? null : `${sketchModelId}:${activeHere}`;
     // Follow the shared active storey when it changes to one in this model.
-    if (activeHere != null && activeHere !== lastActiveStoreyRef.current) {
-      lastActiveStoreyRef.current = activeHere;
+    if (activeKey != null && activeKey !== lastActiveStoreyRef.current) {
+      lastActiveStoreyRef.current = activeKey;
       setStoreyId(activeHere);
       return;
     }
@@ -394,11 +397,15 @@ export function SpaceSketchOverlay() {
   // the first storey auto-selects) so the user doesn't have to click Derive.
   // Guarded so it fires once per storey, and never clobbers a loaded demo.
   useEffect(() => {
-    if (storeyId != null && ifcDataStore && lastDerivedRef.current !== storeyId) {
-      lastDerivedRef.current = storeyId;
+    // Key by model + storey so switching to another model with the same storey
+    // express-id still re-derives (a bare-id guard would treat it as unchanged
+    // and leave the previous model's rooms on screen).
+    const deriveKey = storeyId == null ? null : `${activeModelId ?? 'legacy'}:${storeyId}`;
+    if (deriveKey != null && ifcDataStore && lastDerivedRef.current !== deriveKey) {
+      lastDerivedRef.current = deriveKey;
       void deriveFromStorey();
     }
-  }, [storeyId, ifcDataStore, deriveFromStorey]);
+  }, [storeyId, activeModelId, ifcDataStore, deriveFromStorey]);
 
   const floorToFloor = useCallback((sid: number): number => {
     const idx = storeys.findIndex((s) => s.id === sid);

--- a/apps/viewer/src/hooks/useLevelDisplayEffect.ts
+++ b/apps/viewer/src/hooks/useLevelDisplayEffect.ts
@@ -44,6 +44,9 @@ export function useLevelDisplayEffect(): void {
   const levelDisplayMode = useViewerStore((s) => s.levelDisplayMode);
   const explodedGap = useViewerStore((s) => s.explodedGap);
   const soloStorey = useViewerStore((s) => s.soloStorey);
+  // Shared active storey (set by the hierarchy / Space Sketch / the storey-tab
+  // control). Solo follows it so isolating a level is one connected concept.
+  const activeStorey = useViewerStore((s) => s.activeStorey);
   const models = useViewerStore((s) => s.models);
   const activeModelId = useViewerStore((s) => s.activeModelId);
   const appliedStoreyOffsets = useViewerStore((s) => s.appliedStoreyOffsets);
@@ -109,8 +112,12 @@ export function useLevelDisplayEffect(): void {
     // storey express-ids isolate the right one. Slice default is
     // null → pick the lowest-elevation storey of the active model.
     if (levelDisplayMode === 'solo') {
-      let targetModelId: string | null = soloStorey?.modelId ?? null;
-      let storeyId: number | null = soloStorey?.expressId ?? null;
+      // Prefer the shared active storey, then any explicit soloStorey, then
+      // cold-start on the active model's lowest storey (the legacy fallback,
+      // now rarely hit because the storey-tab control seeds the active storey
+      // on Solo and every storey click updates it).
+      let targetModelId: string | null = activeStorey?.modelId ?? soloStorey?.modelId ?? null;
+      let storeyId: number | null = activeStorey?.expressId ?? soloStorey?.expressId ?? null;
       if (targetModelId === null || storeyId === null) {
         // Cold-start default — fall back to the active model's
         // lowest storey ONLY when the slice has no explicit pick.
@@ -151,6 +158,7 @@ export function useLevelDisplayEffect(): void {
     levelDisplayMode,
     explodedGap,
     soloStorey,
+    activeStorey,
     models,
     activeModelId,
     setPendingMeshTranslations,

--- a/apps/viewer/src/hooks/useLevelDisplayEffect.ts
+++ b/apps/viewer/src/hooks/useLevelDisplayEffect.ts
@@ -3,68 +3,55 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Drive Exploded / Solo level display modes from the slice state.
+ * Drive the Exploded level-display offsets, and keep the Solo mode flag honest.
  *
  * Stacked:
- *   - Subtract any previously-applied Exploded offsets so the
- *     renderer's mesh positions revert to their loaded values.
- *   - Clear isolation if we're coming out of Solo.
+ *   - Subtract any previously-applied Exploded offsets so the renderer's mesh
+ *     positions revert to their loaded values.
  *
  * Exploded:
- *   - Compute per-storey offsets via `computeStoreyOffsets` for
- *     each loaded model.
- *   - Diff against the per-model `appliedStoreyOffsets` and push
- *     the deltas into `pendingMeshTranslations` so the renderer
- *     applies them on the next frame.
- *   - Stash the new applied offsets on the slice so the next
- *     toggle / gap change knows what to subtract.
+ *   - Compute per-storey offsets via `computeStoreyOffsets` for each loaded
+ *     model, diff against the per-model `appliedStoreyOffsets`, and push the
+ *     deltas into `pendingMeshTranslations`. Stash the new applied offsets so
+ *     the next toggle / gap change knows what to subtract.
  *
  * Solo:
- *   - Use the existing `setIsolatedEntities` channel to gate
- *     visibility to the chosen storey's entities (resolved to
- *     federation global ids).
+ *   - NOT handled here. Solo == "this storey isolated", which is the existing
+ *     `selectedStoreys` filter (resolved to globalIds by `computedIsolatedIds`
+ *     in ViewportContainer). `applyLevelDisplayMode` sets that filter on entry
+ *     and clears it on exit, so there is ONE isolation channel and it can never
+ *     get stranded across a mode switch. Solo also carries no Exploded offsets,
+ *     so the offset effect below reverts any lift when entering Solo.
  *
- * The hook reads from a slim selector (`useViewerStore`) and only
- * runs its work when `levelDisplayMode`, `explodedGap`, or the
- * set of loaded models changes. No per-frame work.
+ * The second effect is a guard: if the storey isolation is cleared anywhere
+ * else (hierarchy footer ×, Home / Show-all, Esc), drop the Solo flag back to
+ * Stacked so the segmented control and the in-viewport chip stay truthful.
  */
 
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useViewerStore } from '@/store';
 import { toGlobalIdFromModels } from '@/store/globalId';
 import {
   computeStoreyOffsets,
   diffStoreyOffsets,
   buildEntityTranslations,
-  entitiesInStorey,
   type StoreyOffsets,
 } from '@/lib/level-offsets';
 
 export function useLevelDisplayEffect(): void {
   const levelDisplayMode = useViewerStore((s) => s.levelDisplayMode);
   const explodedGap = useViewerStore((s) => s.explodedGap);
-  const soloStorey = useViewerStore((s) => s.soloStorey);
-  // Shared active storey (set by the hierarchy / Space Sketch / the storey-tab
-  // control). Solo follows it so isolating a level is one connected concept.
-  const activeStorey = useViewerStore((s) => s.activeStorey);
   const models = useViewerStore((s) => s.models);
-  const activeModelId = useViewerStore((s) => s.activeModelId);
   const appliedStoreyOffsets = useViewerStore((s) => s.appliedStoreyOffsets);
   const setAppliedStoreyOffsets = useViewerStore((s) => s.setAppliedStoreyOffsets);
   const setPendingMeshTranslations = useViewerStore((s) => s.setPendingMeshTranslations);
-  const setIsolatedEntities = useViewerStore((s) => s.setIsolatedEntities);
-
-  // Track the last-applied mode so the cleanup logic can tell
-  // "user is exiting Exploded" from "user is changing gap inside
-  // Exploded". Without this, the diff math handles both, but
-  // having a discrete flag makes it cheap to skip Solo→Solo
-  // re-entry without touching translations.
-  const lastModeRef = useRef(levelDisplayMode);
+  const selectedStoreys = useViewerStore((s) => s.selectedStoreys);
+  const setLevelDisplayMode = useViewerStore((s) => s.setLevelDisplayMode);
 
   useEffect(() => {
-    // Compute the target Exploded offsets per model. `target` is
-    // empty when Exploded isn't active — diff against the
-    // previously-applied offsets will revert any lifts.
+    // Compute the target Exploded offsets per model. `target` is empty unless
+    // Exploded is active — diffing against the previously-applied offsets then
+    // reverts any lift (covers Stacked and Solo).
     const target: typeof appliedStoreyOffsets = new Map();
     if (levelDisplayMode === 'exploded') {
       for (const [modelId, model] of models) {
@@ -74,10 +61,9 @@ export function useLevelDisplayEffect(): void {
       }
     }
 
-    // Build the renderer-frame translation map by diffing the
-    // target against the slice's applied snapshot, per model. Sum
-    // into a single Map<globalId, [dx,dy,dz]> so one push covers
-    // the whole scene.
+    // Build the renderer-frame translation map by diffing the target against
+    // the slice's applied snapshot, per model. Sum into a single
+    // Map<globalId, [dx,dy,dz]> so one push covers the whole scene.
     const aggregated = new Map<number, [number, number, number]>();
     const modelIds = new Set<string>([
       ...models.keys(),
@@ -106,63 +92,17 @@ export function useLevelDisplayEffect(): void {
       setPendingMeshTranslations(aggregated);
     }
     setAppliedStoreyOffsets(target);
-
-    // Solo isolation. Resolve against the (modelId, expressId)
-    // pair the slice stores so federated scenes with overlapping
-    // storey express-ids isolate the right one. Slice default is
-    // null → pick the lowest-elevation storey of the active model.
-    if (levelDisplayMode === 'solo') {
-      // Prefer the shared active storey, then any explicit soloStorey, then
-      // cold-start on the active model's lowest storey (the legacy fallback,
-      // now rarely hit because the storey-tab control seeds the active storey
-      // on Solo and every storey click updates it).
-      let targetModelId: string | null = activeStorey?.modelId ?? soloStorey?.modelId ?? null;
-      let storeyId: number | null = activeStorey?.expressId ?? soloStorey?.expressId ?? null;
-      if (targetModelId === null || storeyId === null) {
-        // Cold-start default — fall back to the active model's
-        // lowest storey ONLY when the slice has no explicit pick.
-        const fallbackModelId = activeModelId ?? models.keys().next().value ?? null;
-        const fallbackStore = fallbackModelId ? models.get(fallbackModelId)?.ifcDataStore : undefined;
-        if (fallbackModelId && fallbackStore) {
-          const elevations = fallbackStore.spatialHierarchy?.storeyElevations;
-          if (elevations && elevations.size > 0) {
-            const lowest = [...elevations.entries()].sort((a, b) => a[1] - b[1])[0][0];
-            targetModelId = fallbackModelId;
-            storeyId = lowest;
-          }
-        }
-      }
-      const targetStore = targetModelId ? models.get(targetModelId)?.ifcDataStore : undefined;
-      if (targetModelId !== null && storeyId !== null && targetStore) {
-        const resolvedModelId = targetModelId;
-        const toGlobalId = (localExpressId: number): number =>
-          toGlobalIdFromModels(models, resolvedModelId, localExpressId);
-        const ids = entitiesInStorey(targetStore, storeyId, toGlobalId);
-        setIsolatedEntities(new Set(ids));
-      } else {
-        setIsolatedEntities(null);
-      }
-    } else if (lastModeRef.current === 'solo') {
-      // Leaving Solo → drop isolation. (User may have manually
-      // re-isolated via the basket; we still clear because the
-      // Solo cleanup should be predictable. Tradeoff documented.)
-      setIsolatedEntities(null);
-    }
-
-    lastModeRef.current = levelDisplayMode;
-    // appliedStoreyOffsets is intentionally NOT a dep — we write
-    // to it as a side effect; depending on it would loop. The
-    // ref-based last-mode check covers the Solo→other case.
+    // appliedStoreyOffsets is intentionally NOT a dep — we write to it as a
+    // side effect; depending on it would loop.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    levelDisplayMode,
-    explodedGap,
-    soloStorey,
-    activeStorey,
-    models,
-    activeModelId,
-    setPendingMeshTranslations,
-    setIsolatedEntities,
-    setAppliedStoreyOffsets,
-  ]);
+  }, [levelDisplayMode, explodedGap, models, setPendingMeshTranslations, setAppliedStoreyOffsets]);
+
+  // Guard: Solo is "a storey isolated via selectedStoreys". If that isolation
+  // is dropped from anywhere else, Solo is no longer active — fall back to
+  // Stacked so the mode flag matches what's on screen.
+  useEffect(() => {
+    if (levelDisplayMode === 'solo' && selectedStoreys.size === 0) {
+      setLevelDisplayMode('stacked');
+    }
+  }, [levelDisplayMode, selectedStoreys, setLevelDisplayMode]);
 }

--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -215,6 +215,9 @@ const createViewerStore = () => create<ViewerState>()((...args) => ({
       selectedEntityId: null,
       selectedEntityIds: new Set(),
       selectedStoreys: new Set(),
+      // Drop the shared active storey — it references the outgoing model, so a
+      // new file must not inherit a stale storey for Solo / Space Sketch.
+      activeStorey: null,
 
       // Selection (multi-model)
       selectedEntity: null,

--- a/apps/viewer/src/store/levelDisplay.ts
+++ b/apps/viewer/src/store/levelDisplay.ts
@@ -46,6 +46,16 @@ export function pickTopStorey(): EntityRef | null {
   return bestRef;
 }
 
+/** True when the storey ref still resolves to a loaded model + storey. Guards
+ *  against a stale `activeStorey` left over after a model is removed or the
+ *  viewer is reset for a new file. */
+function storeyExists(ref: EntityRef): boolean {
+  const s = useViewerStore.getState();
+  const ds = (ref.modelId === 'legacy' ? s.ifcDataStore : s.models.get(ref.modelId)?.ifcDataStore) as ElevationCarrier;
+  const elevs = ds?.spatialHierarchy?.storeyElevations;
+  return !!elevs && elevs.has(ref.expressId);
+}
+
 /**
  * Apply a level-display mode through the single unified storey-isolation
  * channel.
@@ -60,7 +70,11 @@ export function pickTopStorey(): EntityRef | null {
 export function applyLevelDisplayMode(mode: LevelDisplayMode, soloRef?: EntityRef | null): void {
   const s = useViewerStore.getState();
   if (mode === 'solo') {
-    const ref = soloRef ?? s.activeStorey ?? pickTopStorey();
+    // Prefer an explicit ref, then the active storey — but only if it still
+    // resolves to a loaded storey (it may be stale after a model removal /
+    // reset). Otherwise fall back to the top storey of the current scene.
+    const candidate = soloRef ?? s.activeStorey;
+    const ref = candidate && storeyExists(candidate) ? candidate : pickTopStorey();
     if (!ref) return; // nothing to solo (no storeys) — leave the mode unchanged
     s.setActiveStorey(ref);
     s.setStoreysSelection([ref.expressId]);

--- a/apps/viewer/src/store/levelDisplay.ts
+++ b/apps/viewer/src/store/levelDisplay.ts
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Level-display transitions — the ONE place that maps Stacked / Exploded /
+ * Solo onto state, so every entry point (the storey-tab control, the command
+ * palette, the in-viewport chip, a hierarchy storey click) behaves identically.
+ *
+ * Solo and "isolate this storey" are the same thing, so they share ONE channel:
+ * the storey isolation filter (`selectedStoreys`). Solo isolates the active (or
+ * top) storey through it; switching to Stacked / Exploded clears it — so the
+ * isolation can never get stranded when the mode changes. (Previously Solo used
+ * a second `isolatedEntities` channel that mode switches didn't clear, leaving
+ * the model stuck isolated.)
+ */
+
+import { useViewerStore } from './index.js';
+import type { EntityRef } from './types.js';
+import type { LevelDisplayMode } from './slices/levelDisplaySlice.js';
+
+type ElevationCarrier = { spatialHierarchy?: { storeyElevations?: Map<number, number> } | null } | null | undefined;
+
+/** Highest-elevation storey across loaded models (model-aware). Used as the
+ *  Solo default when nothing is focused — the top storey, not the empty
+ *  basement the old cold-start landed on. */
+export function pickTopStorey(): EntityRef | null {
+  const s = useViewerStore.getState();
+  let bestRef: EntityRef | null = null;
+  let bestElev = -Infinity;
+  const consider = (modelId: string, ds: ElevationCarrier) => {
+    const elevs = ds?.spatialHierarchy?.storeyElevations;
+    if (!elevs) return;
+    for (const [id, elev] of elevs) {
+      if (elev > bestElev) {
+        bestElev = elev;
+        bestRef = { modelId, expressId: id };
+      }
+    }
+  };
+  if (s.models.size > 0) {
+    for (const [modelId, model] of s.models) consider(modelId, model.ifcDataStore as ElevationCarrier);
+  } else {
+    consider('legacy', s.ifcDataStore as ElevationCarrier);
+  }
+  return bestRef;
+}
+
+/**
+ * Apply a level-display mode through the single unified storey-isolation
+ * channel.
+ *
+ * - `solo`  : focus + isolate one storey (the passed ref, else the active
+ *             storey, else the top storey). Sets `activeStorey` +
+ *             `selectedStoreys` so the hierarchy row highlights and the
+ *             renderer isolates via the existing `computedIsolatedIds` path.
+ * - others  : clear the storey isolation so Stacked / Exploded show every
+ *             storey (Exploded then lifts them apart via the offset effect).
+ */
+export function applyLevelDisplayMode(mode: LevelDisplayMode, soloRef?: EntityRef | null): void {
+  const s = useViewerStore.getState();
+  if (mode === 'solo') {
+    const ref = soloRef ?? s.activeStorey ?? pickTopStorey();
+    if (!ref) return; // nothing to solo (no storeys) — leave the mode unchanged
+    s.setActiveStorey(ref);
+    s.setStoreysSelection([ref.expressId]);
+    s.setLevelDisplayMode('solo');
+  } else {
+    s.clearStoreySelection();
+    s.setLevelDisplayMode(mode);
+  }
+}

--- a/apps/viewer/src/store/slices/levelDisplaySlice.ts
+++ b/apps/viewer/src/store/slices/levelDisplaySlice.ts
@@ -13,11 +13,11 @@
  *                           ascending. Index 0 stays at its
  *                           native Y; subsequent storeys move up
  *                           by `gap`.
- *   - Solo                : only entities in the chosen `soloStorey`
- *                           render. Driven by the existing
- *                           visibilitySlice.setIsolatedEntities so
- *                           we don't ship a second isolation
- *                           channel.
+ *   - Solo                : only the active storey renders. Solo is
+ *                           NOT a second isolation channel — it reuses
+ *                           the storey filter (`selectedStoreys`), set
+ *                           and cleared together with the mode by
+ *                           `store/levelDisplay.applyLevelDisplayMode`.
  *
  * The slice owns mode + parameters only. The actual mesh
  * translation (Exploded) and isolation (Solo) are applied by a
@@ -44,23 +44,8 @@ export type AppliedStoreyOffsets = Map<
   Map<number /* storey express id */, number /* applied Y offset (m, renderer frame) */>
 >;
 
-/**
- * Solo target — must carry both modelId and expressId because
- * express ids are scoped per model. In a federated session two
- * different models often have storeys with overlapping ids, so a
- * bare expressId would silently pick the wrong storey on the
- * wrong model.
- */
-export interface SoloStoreyRef {
-  modelId: string;
-  expressId: number;
-}
-
 export interface LevelDisplaySlice {
   levelDisplayMode: LevelDisplayMode;
-  /** Storey for Solo. Null = effect picks the lowest storey on
-   * the active model on activation. */
-  soloStorey: SoloStoreyRef | null;
   /** Per-storey gap in metres for Exploded. Default 4 m. */
   explodedGap: number;
   /**
@@ -72,7 +57,6 @@ export interface LevelDisplaySlice {
   appliedStoreyOffsets: AppliedStoreyOffsets;
 
   setLevelDisplayMode: (mode: LevelDisplayMode) => void;
-  setSoloStorey: (ref: SoloStoreyRef | null) => void;
   setExplodedGap: (metres: number) => void;
   /** Effect-only: record the offsets that were just flushed to
    * the renderer so the next toggle knows what to subtract. */
@@ -82,17 +66,14 @@ export interface LevelDisplaySlice {
 const LEVEL_DISPLAY_DEFAULTS = {
   mode: 'stacked' as LevelDisplayMode,
   gap: 4,
-  soloStorey: null as SoloStoreyRef | null,
 };
 
 export const createLevelDisplaySlice: StateCreator<LevelDisplaySlice, [], [], LevelDisplaySlice> = (set) => ({
   levelDisplayMode: LEVEL_DISPLAY_DEFAULTS.mode,
-  soloStorey: LEVEL_DISPLAY_DEFAULTS.soloStorey,
   explodedGap: LEVEL_DISPLAY_DEFAULTS.gap,
   appliedStoreyOffsets: new Map(),
 
   setLevelDisplayMode: (levelDisplayMode) => set({ levelDisplayMode }),
-  setSoloStorey: (soloStorey) => set({ soloStorey }),
   setExplodedGap: (metres) => {
     // Guard against non-finite / non-positive — UI lets the user
     // type, but a 0 gap means "Exploded = Stacked" and a negative

--- a/apps/viewer/src/store/slices/levelDisplaySlice.ts
+++ b/apps/viewer/src/store/slices/levelDisplaySlice.ts
@@ -19,12 +19,13 @@
  *                           and cleared together with the mode by
  *                           `store/levelDisplay.applyLevelDisplayMode`.
  *
- * The slice owns mode + parameters only. The actual mesh
- * translation (Exploded) and isolation (Solo) are applied by a
- * separate hook in the viewer — `useLevelDisplayEffect` — which
- * watches the slice and the active model's spatial hierarchy and
- * flushes per-entity updates to the renderer via
- * `pendingMeshTranslations` and `setIsolatedEntities`.
+ * The slice owns mode + parameters only. The Exploded mesh
+ * translation is applied by `useLevelDisplayEffect`, which watches
+ * the slice and flushes per-entity offsets to the renderer via
+ * `pendingMeshTranslations`. Solo isolation is NOT applied here —
+ * it rides the storey filter (`selectedStoreys`), driven by
+ * `store/levelDisplay.applyLevelDisplayMode`; the effect only adds
+ * a guard that drops Solo → Stacked when that filter is cleared.
  *
  * Reversibility: the slice keeps the LAST APPLIED offset per
  * storey so the effect can compute the delta between target and

--- a/apps/viewer/src/store/slices/selectionSlice.test.ts
+++ b/apps/viewer/src/store/slices/selectionSlice.test.ts
@@ -286,4 +286,33 @@ describe('SelectionSlice', () => {
       assert.strictEqual(state.selectedStoreys.size, 0);
     });
   });
+
+  describe('shared active storey', () => {
+    it('defaults to null', () => {
+      assert.strictEqual(state.activeStorey, null);
+    });
+
+    it('sets a model-aware active storey', () => {
+      const ref: EntityRef = { modelId: 'model-1', expressId: 42 };
+      state.setActiveStorey(ref);
+      assert.deepStrictEqual(state.activeStorey, ref);
+    });
+
+    it('clears the active storey with null', () => {
+      state.setActiveStorey({ modelId: 'model-1', expressId: 42 });
+      state.setActiveStorey(null);
+      assert.strictEqual(state.activeStorey, null);
+    });
+
+    it('is independent of the selectedStoreys renderer filter', () => {
+      // The active storey is the single, model-aware focus; selectedStoreys
+      // is the multi-select isolation filter. Writing one must not mutate the
+      // other (the hierarchy sets both deliberately on a single-storey click).
+      state.setActiveStorey({ modelId: 'model-1', expressId: 7 });
+      assert.strictEqual(state.selectedStoreys.size, 0);
+
+      state.setStoreysSelection([7, 8]);
+      assert.deepStrictEqual(state.activeStorey, { modelId: 'model-1', expressId: 7 });
+    });
+  });
 });

--- a/apps/viewer/src/store/slices/selectionSlice.ts
+++ b/apps/viewer/src/store/slices/selectionSlice.ts
@@ -18,6 +18,17 @@ export interface SelectionSlice {
   selectedEntityId: number | null;
   selectedEntityIds: Set<number>;
   selectedStoreys: Set<number>;
+  /**
+   * The single storey the user is currently focused on, model-aware so
+   * federated scenes with overlapping express-ids resolve the right one.
+   * This is the shared "active storey" source of truth: the hierarchy sets
+   * it when a storey row is clicked, and Space Sketch, the Solo level-display
+   * mode, and the floorplan all read it — so picking a storey once makes
+   * every storey-aware surface respect it (instead of each defaulting to its
+   * own storey). Independent of `selectedStoreys` (which is the multi-select
+   * renderer filter); a single-storey click sets both.
+   */
+  activeStorey: EntityRef | null;
 
   // State (multi-model)
   /** Primary selected entity with model context */
@@ -35,6 +46,8 @@ export interface SelectionSlice {
   setStoreySelection: (id: number) => void;
   setStoreysSelection: (ids: number[]) => void;
   clearStoreySelection: () => void;
+  /** Set the shared active storey (or null to clear). */
+  setActiveStorey: (ref: EntityRef | null) => void;
   addToSelection: (id: number) => void;
   removeFromSelection: (id: number) => void;
   toggleSelection: (id: number) => void;
@@ -74,6 +87,7 @@ export const createSelectionSlice: StateCreator<SelectionSlice, [], [], Selectio
   selectedEntityId: null,
   selectedEntityIds: new Set(),
   selectedStoreys: new Set(),
+  activeStorey: null,
 
   // Initial state (multi-model)
   selectedEntity: null,
@@ -110,6 +124,8 @@ export const createSelectionSlice: StateCreator<SelectionSlice, [], [], Selectio
   setStoreysSelection: (ids) => set({ selectedStoreys: new Set(ids) }),
 
   clearStoreySelection: () => set({ selectedStoreys: new Set() }),
+
+  setActiveStorey: (activeStorey) => set({ activeStorey }),
 
   addToSelection: (id) => set((state) => {
     const newSelection = new Set(state.selectedEntityIds);


### PR DESCRIPTION
## Why

A tester couldn't form a correct model of the toolbar's **Stacked / Exploded / Solo** button: the trigger was icon-only and the icon encoded *current state* (so it read as "a stack of layers" at 16px), it sat right next to a second storey button (Quick Floorplan), and activating Solo cold-started on the **lowest** storey — often a near-empty basement — which read as "broken." Underneath, three surfaces each kept their **own** idea of "the storey": the hierarchy (`selectedStoreys`), Space Sketch (its private `storeyId`, defaulting to `storeys[0]`), and Level-display Solo (`soloStorey`). Pick a storey in one place and the others ignored it.

## What

A single, model-aware **active storey** is now the source of truth, and the level controls move to where users already think about levels — the hierarchy's **Building Storeys** section.

**Shared state**
- `selectionSlice`: new `activeStorey: EntityRef | null` + `setActiveStorey`. Distinct from the multi-select `selectedStoreys` renderer filter; a single-storey click sets both.

**Every storey-aware surface reads it**
- **Hierarchy** — a storey-row click sets the active storey (resolving the representative `{modelId, expressId}`, including multi-model unified storeys).
- **Space Sketch** — seeds `storeyId` from the active storey (when it belongs to the active model) and *follows* it while open, instead of always `storeys[0]`. The in-panel `<select>` stays a local override.
- **Solo level display** — `useLevelDisplayEffect` targets `activeStorey → soloStorey → lowest-storey fallback`, killing the empty-basement cold-start on the primary UI path.

**Relocated control + retired duplicates**
- New `StoreyDisplayControls` — a `[Stacked | Exploded | Solo]` segmented control + Exploded gap input + a **Floorplan-the-active-storey** button, atop Building Storeys (self-gates on ≥2 storeys). The storey rows *are* the Solo picker; engaging Solo with nothing focused defaults to the **top** storey.
- `MainToolbar` — removed the `LevelDisplayDropdown` and the adjacent Quick-Floorplan dropdown (the two-confusable-buttons problem) plus now-unused imports.

**Persistent viewport signal**
- New `LevelDisplayIndicator` — a top-left chip (`Solo · 1. Geschoss` / `Exploded · 4 m gap`) with one-click return to Stacked, replacing the easy-to-miss 1.5px toolbar dot. Anchored to clear the ViewCube and Sun & Sky panel.

**Also included** (same files/area): Space Sketch Ctrl+Z / Ctrl+Shift+Z now drive the sketch's own undo history rather than the model behind it.

## Behavior change worth noting

The toolbar no longer floorplans an arbitrary storey directly — you pick a storey in the hierarchy (making it active), then hit Floorplan. This is the deliberate "pick once, every tool respects it" model. The command palette (`Level — Stacked/Exploded/Solo`) is unchanged as a power-user fallback.

## Test plan

- `selectionSlice` unit tests extended for `activeStorey` (set / clear / independence from `selectedStoreys`) — `tsx --test` green (31/31).
- `tsc --noEmit` clean on all touched files.
- Manual: click a storey in the hierarchy → Space Sketch opens on it; toggle Solo → isolates the active storey + shows the chip; switch storeys while in Solo → follows; Exploded gap input works; Floorplan button activates the top-down view for the active storey.

## Out of scope / follow-ups

- Skipped the optional per-row "● active" dot in `HierarchyNode` — the existing selection highlight already marks the active storey (kept `HierarchyNode` untouched to limit blast radius).
- `setSoloStorey` is now caller-less (the effect still reads `soloStorey` as a secondary fallback); left the slice API intact rather than widening this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * On-screen level indicator in the viewer showing Exploded gap or Solo storey with quick-dismiss.
  * Storey controls moved into the Hierarchy panel: Stacked / Exploded / Solo modes, adjustable gap, and click-to-solo behavior.

* **Refactor**
  * Toolbar level controls removed; indicator and controls now surfaced via hierarchy/viewport.
  * Level-display handling centralized so solo/stacked/exploded behave consistently across views.

* **Bug Fixes**
  * Active storey resets when loading a new file; overlays now sync to the shared active storey.

* **Tests**
  * Added tests for shared active storey state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->