### PR TITLE
fix(viewer): normalize Cesium static-copy paths for Windows builds

### DIFF
--- a/apps/viewer/vite.config.ts
+++ b/apps/viewer/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig, normalizePath } from 'vite';
 import react from '@vitejs/plugin-react';
 import wasm from 'vite-plugin-wasm';
 import topLevelAwait from 'vite-plugin-top-level-await';
@@ -223,12 +223,16 @@ export default defineConfig({
     (() => {
       const cesiumPkg = path.dirname(require.resolve('cesium/package.json'));
       const cesiumBuild = path.join(cesiumPkg, 'Build', 'Cesium');
+      // vite-plugin-static-copy globs `src` with tinyglobby, which treats `\` as
+      // an escape char — so the raw Windows paths from path.join match nothing
+      // ("No file was found to copy"). normalizePath -> forward slashes fixes it
+      // cross-platform (no-op on POSIX).
       return viteStaticCopy({
         targets: [
-          { src: path.join(cesiumBuild, 'Workers'), dest: 'cesium' },
-          { src: path.join(cesiumBuild, 'ThirdParty'), dest: 'cesium' },
-          { src: path.join(cesiumBuild, 'Assets'), dest: 'cesium' },
-          { src: path.join(cesiumBuild, 'Widgets'), dest: 'cesium' },
+          { src: normalizePath(path.join(cesiumBuild, 'Workers')), dest: 'cesium' },
+          { src: normalizePath(path.join(cesiumBuild, 'ThirdParty')), dest: 'cesium' },
+          { src: normalizePath(path.join(cesiumBuild, 'Assets')), dest: 'cesium' },
+          { src: normalizePath(path.join(cesiumBuild, 'Widgets')), dest: 'cesium' },
         ],
       });
     })(),


### PR DESCRIPTION
## Problem

`pnpm --filter @ifc-lite/viewer build` (and the full `pnpm build`) **fails on Windows** at the very end, after all 5322 modules transform and the bundle is written:

```
[vite-plugin-static-copy:build] No file was found to copy on
D:\...\node_modules\.pnpm\cesium@1.142.0\node_modules\cesium\Build\Cesium\Workers src.
```

The directory exists and is full (110 files) — so the message is misleading.

## Cause

`vite-plugin-static-copy@4` globs each target `src` through **tinyglobby**, which treats `\` as a glob escape character. On Windows `path.join(cesiumBuild, 'Workers')` returns a **backslash** path, so the glob matches nothing and the plugin throws. Linux CI never reproduces this because POSIX paths already use forward slashes — which is why this slips past the existing build pipeline.

## Fix

Wrap the joined Cesium asset paths (`Workers` / `ThirdParty` / `Assets` / `Widgets`) in vite's `normalizePath`, converting them to forward slashes on every platform. It is a no-op on POSIX, so CI behaviour is unchanged; it only unblocks Windows contributors building the viewer locally.

## Verification

- Before: `@ifc-lite/viewer#build` fails as above on Windows 10.
- After: `pnpm --filter @ifc-lite/viewer build` succeeds, and the full `pnpm build` is green (38/38 tasks).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where Cesium build assets were not being properly copied on Windows systems during the build process, ensuring all necessary asset files are included in the viewer application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->