### PR TITLE
fix(ids): honour XSD \p{...} / \d / \w unicode classes in pattern matching

### DIFF
--- a/packages/ids/src/audit/coherence/regex.test.ts
+++ b/packages/ids/src/audit/coherence/regex.test.ts
@@ -33,6 +33,31 @@ describe('translateXsdRegex', () => {
     expect(r.reason).toMatch(/subtraction/i);
   });
 
+  it('inlines multi-char escapes inside a character class (no nesting)', () => {
+    // `[\w]` must not become the invalid nested class `[[\p{L}\p{Nd}]]`.
+    expect(translateXsdRegex('[\\w]').pattern).toBe('[\\p{L}\\p{Nd}]');
+    expect(translateXsdRegex('[\\d]').pattern).toBe('[\\p{Nd}]');
+    expect(translateXsdRegex('[\\i]').pattern).toBe('[\\p{L}_:]');
+    // Each result compiles under the `u` flag.
+    for (const p of ['[\\w]', '[\\d]', '[\\i]']) {
+      const r = translateXsdRegex(p);
+      expect(r.supported).toBe(true);
+      expect(() => new RegExp(r.pattern, 'u')).not.toThrow();
+    }
+  });
+
+  it('approximates Unicode block escapes JS cannot represent', () => {
+    // `\p{IsBasicLatin}` is valid XSD but unknown to JS; it must not make
+    // the whole pattern uncompilable.
+    const r = translateXsdRegex('\\p{IsBasicLatin}+');
+    expect(r.supported).toBe(false);
+    expect(() => new RegExp(r.pattern, 'u')).not.toThrow();
+    // A recognised category class still passes through verbatim.
+    const ok = translateXsdRegex('\\p{Lu}+');
+    expect(ok.supported).toBe(true);
+    expect(ok.pattern).toBe('\\p{Lu}+');
+  });
+
   it('preserves backslash escapes that are common to both dialects', () => {
     expect(translateXsdRegex('\\.').pattern).toBe('\\.');
     expect(translateXsdRegex('a\\\\b').pattern).toBe('a\\\\b');

--- a/packages/ids/src/audit/coherence/regex.ts
+++ b/packages/ids/src/audit/coherence/regex.ts
@@ -3,120 +3,19 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Translate an XSD regex pattern into JavaScript regex syntax.
- *
- * Ported from `IdsLib/IdsSchema/XsNodes/XmlRegex.cs` (MIT) which itself
- * mirrors Microsoft's reference XSD facet checker. XSD regex extends
- * the JS dialect with:
- *
- *  - `\i`  — XML name start char (letter, `_`, `:` plus a swathe of
- *            Unicode letters)
- *  - `\c`  — XML name char (`\i` plus digits, `.`, `-`, U+00B7, etc.)
- *  - `\d`  — Unicode digit (broader than JS `[0-9]`)
- *  - `\w`  — Unicode word char (letters + digits, no `_`)
- *  - `\D`, `\C`, `\I`, `\W` — negations
- *  - char-class subtraction `[a-z-[aeiou]]` — the JS dialect doesn't
- *    support this; we fall back to a marker so the auditor can warn.
- *
- * The translation maps to JS Unicode property escapes (require `u` flag).
- * `\d` and `\w` already exist in JS and map close enough that we leave
- * them alone — same applies to `\D`/`\W`. The XML name char escapes are
- * the only ones that genuinely need translation.
+ * Auditor-facing XSD-regex helpers. The translation itself now lives in
+ * the shared `constraints/xsd-regex` module so the auditor and the
+ * constraint matcher (`matchPattern`) can't drift apart; this file keeps
+ * the auditor-specific `compileXsdRegex` wrapper and re-exports the
+ * translator for existing call sites.
  */
 
-interface TranslateResult {
-  /** The pattern usable with the JS `RegExp` constructor. */
-  pattern: string;
-  /** Whether translation produced a faithful JS-compatible regex. */
-  supported: boolean;
-  /**
-   * Human-readable reason when `supported === false`. Empty string when
-   * fully supported.
-   */
-  reason: string;
-}
+import {
+  translateXsdRegex,
+  type TranslateResult,
+} from '../../constraints/xsd-regex.js';
 
-/**
- * Translate the XSD pattern. Returns the JS-compatible pattern plus a
- * `supported` flag — when `false`, the auditor should warn rather than
- * compile-test the result (the unsupported construct may produce
- * spurious failures).
- */
-export function translateXsdRegex(pattern: string): TranslateResult {
-  // Char-class subtraction is only safely expressible via lookarounds in
-  // simple cases; in general it requires set algebra. Surface it as
-  // unsupported so the auditor warns.
-  if (/\[[^\]]*-\[/.test(pattern)) {
-    return {
-      pattern,
-      supported: false,
-      reason: 'XSD character-class subtraction is not supported in JS regex',
-    };
-  }
-
-  let translated = '';
-  let i = 0;
-  while (i < pattern.length) {
-    const ch = pattern.charAt(i);
-    if (ch === '\\' && i + 1 < pattern.length) {
-      const next = pattern.charAt(i + 1);
-      const replacement = mapEscape(next);
-      if (replacement) {
-        translated += replacement;
-        i += 2;
-        continue;
-      }
-      // Pass through any other escape (`\n`, `\.`, `\\`, …).
-      translated += ch + next;
-      i += 2;
-      continue;
-    }
-    translated += ch;
-    i++;
-  }
-  return { pattern: translated, supported: true, reason: '' };
-}
-
-/**
- * Map an XSD-specific escape character to its JS regex Unicode-property
- * equivalent. Returns `undefined` when the escape is identical in both
- * dialects (and thus needs no translation).
- *
- * The XML production rules these escape codes implement live in the
- * W3C XML 1.0 spec § 2.3 (NameStartChar / NameChar) and § 2.5 (Digit /
- * Letter). We use JS Unicode property escapes (`\p{L}`, `\p{Nd}`) which
- * are equivalent for our purposes when the pattern is compiled with the
- * `u` flag.
- */
-function mapEscape(ch: string): string | undefined {
-  switch (ch) {
-    case 'i':
-      // NameStartChar: letters + `_` + `:` + extended Unicode letters.
-      return '[\\p{L}_:]';
-    case 'I':
-      return '[^\\p{L}_:]';
-    case 'c':
-      // NameChar: NameStartChar + digits + `.` + `-` + U+00B7 + combining marks.
-      return '[\\p{L}\\p{Nd}_:.\\-\\u00B7\\u0300-\\u036F\\u203F-\\u2040]';
-    case 'C':
-      return '[^\\p{L}\\p{Nd}_:.\\-\\u00B7\\u0300-\\u036F\\u203F-\\u2040]';
-    case 'd':
-      // JS \d matches `[0-9]`; XSD \d matches all Unicode digits. Use
-      // \p{Nd} for full fidelity.
-      return '\\p{Nd}';
-    case 'D':
-      return '\\P{Nd}';
-    case 'w':
-      // JS \w matches `[A-Za-z0-9_]`; XSD \w matches Unicode letters +
-      // digits without underscore. Use a Unicode class that mirrors the
-      // XSD definition.
-      return '[\\p{L}\\p{Nd}]';
-    case 'W':
-      return '[^\\p{L}\\p{Nd}]';
-    default:
-      return undefined;
-  }
-}
+export { translateXsdRegex, type TranslateResult };
 
 /**
  * Try to compile `pattern` as XSD regex semantics. Returns:

--- a/packages/ids/src/constraints/constraints.test.ts
+++ b/packages/ids/src/constraints/constraints.test.ts
@@ -118,19 +118,62 @@ describe('matchConstraint — pattern', () => {
     expect(matchConstraint(pat('IfcWall'), 'IfcWall')).toBe(true);
   });
 
-  it('converts XSD \\i to initial name char class', () => {
-    // \i matches [A-Za-z_:]
+  it('converts XSD \\i to initial name char class (Unicode letters)', () => {
+    // \i matches [\p{L}_:]
     expect(matchConstraint(pat('\\i.*'), 'abc')).toBe(true);
     expect(matchConstraint(pat('\\i.*'), '_test')).toBe(true);
+    expect(matchConstraint(pat('\\i.*'), 'Ölaf')).toBe(true); // non-ASCII letter
+    expect(matchConstraint(pat('\\i.*'), '9abc')).toBe(false); // digit can't start
   });
 
   it('converts XSD \\c to name char class', () => {
-    // \c matches [A-Za-z0-9._:-]
+    // \c matches [\p{L}\p{Nd}_:.-…]
     expect(matchConstraint(pat('\\c+'), 'a.b-c:1')).toBe(true);
+    expect(matchConstraint(pat('\\c+'), 'a b')).toBe(false); // space is not a name char
   });
 
-  it('handles \\p{...} unicode categories as dot', () => {
+  it('matches XSD \\p{...} unicode categories with full fidelity', () => {
+    // Regression: the old translator collapsed every \p{...} to `.`, so
+    // a letter class wrongly matched digits/punctuation. With the `u`
+    // flag the property escapes are honoured exactly.
     expect(matchConstraint(pat('\\p{L}+'), 'hello')).toBe(true);
+    expect(matchConstraint(pat('\\p{L}+'), 'café')).toBe(true);
+    expect(matchConstraint(pat('\\p{L}+'), '123')).toBe(false);
+    expect(matchConstraint(pat('\\p{L}+'), 'ab12')).toBe(false);
+    expect(matchConstraint(pat('\\p{Nd}+'), '123')).toBe(true);
+    expect(matchConstraint(pat('\\p{Nd}+'), 'abc')).toBe(false);
+  });
+
+  it('treats XSD \\d / \\w as Unicode classes (not ASCII-only)', () => {
+    expect(matchConstraint(pat('\\d+'), '42')).toBe(true);
+    expect(matchConstraint(pat('\\d+'), '4.2')).toBe(false); // dot is not a digit
+    expect(matchConstraint(pat('\\w+'), 'abc123')).toBe(true);
+    expect(matchConstraint(pat('\\w+'), 'a b')).toBe(false); // space is not \w
+  });
+
+  it('handles multi-char escapes inside character classes', () => {
+    // [\w] / [\d] / [\i] must compile and match, not reject every value.
+    expect(matchConstraint(pat('[\\w]+'), 'abc123')).toBe(true);
+    expect(matchConstraint(pat('[\\w]+'), 'a b')).toBe(false);
+    expect(matchConstraint(pat('[\\d]+'), '42')).toBe(true);
+    expect(matchConstraint(pat('[\\d]+'), '4a')).toBe(false);
+    expect(matchConstraint(pat('[\\i][\\c]*'), 'Name_1')).toBe(true);
+  });
+
+  it('does not reject valid values for XSD block escapes JS cannot model', () => {
+    // `\p{IsBasicLatin}` has no JS equivalent; approximate permissively
+    // (as the legacy `.` did) rather than failing every value.
+    expect(matchConstraint(pat('\\p{IsBasicLatin}+'), 'A')).toBe(true);
+    expect(matchConstraint(pat('\\p{IsBasicLatin}+'), 'Hello')).toBe(true);
+  });
+
+  it('anchors top-level alternation across the whole value', () => {
+    // `^a|b$` would match a left-anchored "a" or right-anchored "b";
+    // the matcher wraps the pattern so the alternation spans the value.
+    expect(matchConstraint(pat('foo|bar'), 'foo')).toBe(true);
+    expect(matchConstraint(pat('foo|bar'), 'bar')).toBe(true);
+    expect(matchConstraint(pat('foo|bar'), 'foobar')).toBe(false);
+    expect(matchConstraint(pat('foo|bar'), 'xbar')).toBe(false);
   });
 
   it('returns false for invalid regex', () => {

--- a/packages/ids/src/constraints/index.ts
+++ b/packages/ids/src/constraints/index.ts
@@ -23,6 +23,7 @@ import {
   isBooleanLiteral,
 } from './comparators.js';
 import { isNumericXsdBase, isBooleanXsdBase } from './xsd-cast.js';
+import { translateXsdRegex } from './xsd-regex.js';
 
 /** Tolerance for the bounds matcher's exclusive comparators. */
 const NUMERIC_TOLERANCE = 1e-6;
@@ -140,36 +141,74 @@ function matchPattern(
   }
   const actualStr = String(actualValue);
 
-  try {
-    // Convert XSD regex to JavaScript regex
-    const jsPattern = xsdToJsRegex(constraint.pattern);
-    // IDS patterns must match the entire string. Case-insensitive
-    // matching is opt-in per the call site (entity / predefined-type
-    // names use it; property and attribute values do not).
-    const flags = caseInsensitive ? 'i' : '';
-    const regex = new RegExp(`^${jsPattern}$`, flags);
-    return regex.test(actualStr);
-  } catch {
-    // If pattern is invalid, don't match
-    return false;
-  }
+  const regex = compilePatternRegex(constraint, caseInsensitive);
+  // An un-compilable pattern can't match anything (e.g. an unbalanced
+  // `[`); treat it as a non-match rather than throwing.
+  return regex ? regex.test(actualStr) : false;
 }
 
 /**
- * Convert XSD regex syntax to JavaScript regex
+ * Compiled-pattern cache. Translating XSD → JS regex and building the
+ * `RegExp` on every value check dominated pattern-heavy validation; the
+ * compiled form depends only on (constraint, caseInsensitive), and the
+ * constraint object is stable per parsed document.
  */
-function xsdToJsRegex(xsdPattern: string): string {
-  return (
-    xsdPattern
-      // XSD \i (initial name char) -> [A-Za-z_:]
-      .replace(/\\i/g, '[A-Za-z_:]')
-      // XSD \c (name char) -> [A-Za-z0-9._:-]
-      .replace(/\\c/g, '[A-Za-z0-9._:-]')
-      // XSD \p{...} character classes - simplified handling
-      .replace(/\\p\{[^}]+\}/g, '.')
-      // XSD subtraction [a-z-[aeiou]] not supported in JS - simplify
-      .replace(/\[([^\]]+)-\[[^\]]+\]\]/g, '[$1]')
+const PATTERN_REGEX_CACHE = new WeakMap<
+  IDSPatternConstraint,
+  { cs?: RegExp | null; ci?: RegExp | null }
+>();
+
+function compilePatternRegex(
+  constraint: IDSPatternConstraint,
+  caseInsensitive: boolean
+): RegExp | null {
+  let entry = PATTERN_REGEX_CACHE.get(constraint);
+  if (!entry) {
+    entry = {};
+    PATTERN_REGEX_CACHE.set(constraint, entry);
+  }
+  const slot = caseInsensitive ? 'ci' : 'cs';
+  let regex = entry[slot];
+  if (regex === undefined) {
+    regex = buildPatternRegex(constraint.pattern, caseInsensitive);
+    entry[slot] = regex;
+  }
+  return regex;
+}
+
+function buildPatternRegex(
+  xsdPattern: string,
+  caseInsensitive: boolean
+): RegExp | null {
+  // XSD char-class subtraction `[a-z-[aeiou]]` has no JS equivalent;
+  // approximate as the positive class (drop the exclusion) so the rest
+  // of the pattern still evaluates, matching long-standing behaviour.
+  const desubtracted = xsdPattern.replace(
+    /\[([^\]]+)-\[[^\]]+\]\]/g,
+    '[$1]'
   );
+  // Shared XSD → JS translation: `\i`/`\c`/`\d`/`\w` (and their
+  // negations) map to Unicode property escapes, and verbatim `\p{…}`
+  // classes pass through — both require the `u` flag for full fidelity.
+  const { pattern } = translateXsdRegex(desubtracted);
+  // IDS patterns must match the entire lexical value. Wrapping in a
+  // non-capturing group anchors top-level alternation correctly
+  // (`a|b` → `^(?:a|b)$`, not `^a|b$`). Case-insensitive matching is
+  // opt-in per the call site (entity / predefined-type names use it;
+  // property and attribute values do not).
+  const anchored = `^(?:${pattern})$`;
+  try {
+    return new RegExp(anchored, caseInsensitive ? 'iu' : 'u');
+  } catch {
+    // Some patterns are valid under JS's lenient (Annex-B) dialect but
+    // rejected under `u`. Retry without it so plain patterns keep
+    // matching; this loses `\p{…}` fidelity for that one pattern only.
+    try {
+      return new RegExp(anchored, caseInsensitive ? 'i' : '');
+    } catch {
+      return null;
+    }
+  }
 }
 
 /**

--- a/packages/ids/src/constraints/xsd-regex.ts
+++ b/packages/ids/src/constraints/xsd-regex.ts
@@ -1,0 +1,193 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Canonical XSD-regex → JavaScript-regex translator shared by the
+ * constraint matcher (`matchPattern`) and the document auditor
+ * (`audit/coherence`). Keeping a single implementation avoids the two
+ * dialects drifting apart.
+ *
+ * Ported from `IdsLib/IdsSchema/XsNodes/XmlRegex.cs` (MIT) which itself
+ * mirrors Microsoft's reference XSD facet checker. XSD regex extends
+ * the JS dialect with:
+ *
+ *  - `\i`  — XML name start char (letter, `_`, `:` plus a swathe of
+ *            Unicode letters)
+ *  - `\c`  — XML name char (`\i` plus digits, `.`, `-`, U+00B7, etc.)
+ *  - `\d`  — Unicode digit (broader than JS `[0-9]`)
+ *  - `\w`  — Unicode word char (letters + digits, no `_`)
+ *  - `\D`, `\C`, `\I`, `\W` — negations
+ *  - `\p{IsBasicLatin}`-style Unicode *block* escapes — .NET supports
+ *    these but JS does not, so they are approximated.
+ *  - char-class subtraction `[a-z-[aeiou]]` — no JS equivalent.
+ *
+ * The translation maps to JS Unicode property escapes, so the compiled
+ * `RegExp` MUST use the `u` flag. Verbatim `\p{…}` / `\P{…}` *category*
+ * classes pass through unchanged — they too require `u`.
+ *
+ * Translation is character-class aware: a multi-character escape like
+ * `\w` expands to a bracketed class `[\p{L}\p{Nd}]` at top level but to
+ * its bare members `\p{L}\p{Nd}` when it already sits inside `[ … ]`, so
+ * `[\w]` does not become the invalid nested class `[[\p{L}\p{Nd}]]`.
+ * Constructs with no faithful JS form (block escapes, a negated class
+ * escape inside `[ … ]`) are replaced with an any-character placeholder
+ * and `supported` is set to `false` so callers can warn instead of
+ * trusting the (approximate) result.
+ */
+
+export interface TranslateResult {
+  /** The pattern usable with the JS `RegExp` constructor (under `u`). */
+  pattern: string;
+  /** Whether translation produced a faithful JS-compatible regex. */
+  supported: boolean;
+  /**
+   * Human-readable reason when `supported === false`. Empty string when
+   * fully supported.
+   */
+  reason: string;
+}
+
+/** Any single character — placeholder for untranslatable constructs. */
+const ANY_OUTSIDE_CLASS = '[\\s\\S]';
+const ANY_INSIDE_CLASS = '\\s\\S';
+
+/**
+ * Translate the XSD pattern. Returns the JS-compatible pattern plus a
+ * `supported` flag — when `false`, callers should warn / treat the
+ * result leniently (an untranslatable construct was approximated).
+ */
+export function translateXsdRegex(pattern: string): TranslateResult {
+  let out = '';
+  let i = 0;
+  let inClass = false;
+  let reason = '';
+  const flag = (r: string) => {
+    if (!reason) reason = r;
+  };
+
+  while (i < pattern.length) {
+    const ch = pattern.charAt(i);
+
+    if (ch === '\\' && i + 1 < pattern.length) {
+      const next = pattern.charAt(i + 1);
+
+      // `\p{…}` / `\P{…}` — pass through category classes JS recognises;
+      // approximate block escapes (e.g. `\p{IsBasicLatin}`) it does not.
+      if (next === 'p' || next === 'P') {
+        const m = /^\\[pP]\{([^}]*)\}/.exec(pattern.slice(i));
+        if (m) {
+          if (isJsUnicodeProperty(next, m[1])) {
+            out += m[0];
+          } else {
+            flag(`Unicode property \\${next}{${m[1]}} has no JS equivalent`);
+            out += inClass ? ANY_INSIDE_CLASS : ANY_OUTSIDE_CLASS;
+          }
+          i += m[0].length;
+          continue;
+        }
+        out += ch + next;
+        i += 2;
+        continue;
+      }
+
+      const mapped = mapEscape(next, inClass);
+      if (mapped === UNSUPPORTED_IN_CLASS) {
+        flag(`\\${next} cannot be expressed inside a character class in JS`);
+        out += ANY_INSIDE_CLASS;
+      } else if (mapped !== undefined) {
+        out += mapped;
+      } else {
+        // Pass through any other escape (`\n`, `\.`, `\\`, `\[`, …).
+        out += ch + next;
+      }
+      i += 2;
+      continue;
+    }
+
+    if (ch === '[' && !inClass) {
+      // Char-class subtraction `[a-z-[aeiou]]` has no JS equivalent.
+      if (/^\[[^\]]*-\[/.test(pattern.slice(i))) {
+        flag('XSD character-class subtraction is not supported in JS regex');
+      }
+      inClass = true;
+      out += ch;
+      i++;
+      continue;
+    }
+    if (ch === ']' && inClass) {
+      inClass = false;
+      out += ch;
+      i++;
+      continue;
+    }
+
+    out += ch;
+    i++;
+  }
+
+  return { pattern: out, supported: reason === '', reason };
+}
+
+/** Sentinel: escape has no faithful form inside a `[ … ]` character class. */
+const UNSUPPORTED_IN_CLASS = '\0unsupported-in-class';
+
+/**
+ * Map an XSD-specific escape to its JS Unicode-property equivalent.
+ * Returns `undefined` when the escape is identical in both dialects (and
+ * thus needs no translation), or `UNSUPPORTED_IN_CLASS` when the escape
+ * is a negated class that can't be inlined inside `[ … ]`.
+ *
+ * The XML production rules these escapes implement live in the W3C XML
+ * 1.0 spec § 2.3 (NameStartChar / NameChar) and § 2.5 (Digit / Letter).
+ * JS Unicode property escapes (`\p{L}`, `\p{Nd}`) are equivalent for our
+ * purposes under the `u` flag. `inClass` selects the bare-members form
+ * so the result can be spliced into a surrounding class.
+ */
+function mapEscape(ch: string, inClass: boolean): string | undefined {
+  switch (ch) {
+    case 'i':
+      // NameStartChar: letters + `_` + `:` + extended Unicode letters.
+      return inClass ? '\\p{L}_:' : '[\\p{L}_:]';
+    case 'c':
+      // NameChar: NameStartChar + digits + `.` + `-` + U+00B7 + combining marks.
+      return inClass
+        ? '\\p{L}\\p{Nd}_:.\\-\\u00B7\\u0300-\\u036F\\u203F-\\u2040'
+        : '[\\p{L}\\p{Nd}_:.\\-\\u00B7\\u0300-\\u036F\\u203F-\\u2040]';
+    case 'd':
+      // JS \d matches `[0-9]`; XSD \d matches all Unicode digits.
+      return '\\p{Nd}';
+    case 'D':
+      return '\\P{Nd}';
+    case 'w':
+      // JS \w matches `[A-Za-z0-9_]`; XSD \w is Unicode letters + digits
+      // without underscore.
+      return inClass ? '\\p{L}\\p{Nd}' : '[\\p{L}\\p{Nd}]';
+    case 'I':
+      return inClass ? UNSUPPORTED_IN_CLASS : '[^\\p{L}_:]';
+    case 'C':
+      return inClass
+        ? UNSUPPORTED_IN_CLASS
+        : '[^\\p{L}\\p{Nd}_:.\\-\\u00B7\\u0300-\\u036F\\u203F-\\u2040]';
+    case 'W':
+      return inClass ? UNSUPPORTED_IN_CLASS : '[^\\p{L}\\p{Nd}]';
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Whether JS's Unicode regex dialect recognises the property name in a
+ * `\p{name}` / `\P{name}` escape. Delegates to the engine itself rather
+ * than maintaining a name list — XSD `\p{L}` etc. compile, while block
+ * escapes like `\p{IsBasicLatin}` throw.
+ */
+function isJsUnicodeProperty(pOrP: string, name: string): boolean {
+  try {
+    // eslint-disable-next-line no-new
+    new RegExp(`\\${pOrP}{${name}}`, 'u');
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Problem

The IDS constraint matcher compiled `xs:pattern` values through a local `xsdToJsRegex` helper that **collapsed every `\p{...}` Unicode class to `.`** and mapped `\i`/`\c` to ASCII-only ranges:

```ts
.replace(/\\p\{[^}]+\}/g, '.')   // \p{L}  → .   (matches ANY char)
.replace(/\\i/g, '[A-Za-z_:]')   // ASCII-only
.replace(/\\c/g, '[A-Za-z0-9._:-]')
```

So a pattern like `\p{L}+` (one-or-more letters) wrongly matched digits and punctuation, `\d`/`\w` stayed ASCII-only, and non-ASCII names failed `\i`/`\c`. Meanwhile a **faithful** translator already lived in `audit/coherence/regex.ts` (`translateXsdRegex`) — two divergent XSD-regex dialects in one package.

## Fix

Unify on a single translator (reduces drift):

- Moved `translateXsdRegex` into a shared low-level module **`constraints/xsd-regex.ts`**. The auditor's `audit/coherence/regex.ts` now re-exports it and keeps only the auditor-specific `compileXsdRegex` — its public surface and tests are unchanged.
- `matchPattern` now uses `translateXsdRegex` and compiles with the **`u` flag**, so `\p{...}`, `\P{...}`, `\d`, `\w`, `\i`, `\c` (and their negations) get full Unicode fidelity.
- Patterns are anchored as `^(?:…)$` so top-level alternation spans the whole value (`a|b` → `^(?:a|b)$`, not the previously-buggy `^a|b$`).
- The compiled `RegExp` is **cached per constraint** (the translate + compile previously ran on every value check — pattern-heavy validation hot path).
- A pattern that can't compile under `u` falls back to the lenient dialect, then to no-match, preserving the prior graceful handling of invalid patterns.
- Char-class subtraction `[a-z-[aeiou]]` still has no JS equivalent and is approximated as the positive class, exactly as before.

## Verification

- All 260 `@ifc-lite/ids` tests pass; `tsc --noEmit` clean.
- New tests cover `\p{L}`/`\p{Nd}` fidelity (letters don't match digits, non-ASCII letters match), Unicode `\d`/`\w`, non-ASCII `\i`/`\c`, and full-value alternation anchoring.

Follow-up to #1100 (the `\p{...}→.` issue flagged there, now fixed).