### PR TITLE
chore(ids): add changeset for xs:pattern matching fixes (#1100, #1101)

### DIFF
--- a/.changeset/ids-pattern-matching-fixes.md
+++ b/.changeset/ids-pattern-matching-fixes.md
@@ -1,0 +1,18 @@
+---
+"@ifc-lite/ids": patch
+---
+
+Fix IDS `xs:pattern` value-restriction matching (#1100, #1101).
+
+- Pattern facets now match the lexical form of the value gated by the
+  restriction's `@base`, so `<restriction base="xs:decimal"><pattern value="^.*$"/>`
+  ("any decimal value present") passes on numeric properties instead of
+  failing every one. A number under an `xs:string` base (or a boolean
+  under a numeric base) is still a type mismatch, matching the
+  buildingSMART corpus.
+- XSD `\p{...}` / `\P{...}`, `\d`, `\w`, `\i`, `\c` are now translated to
+  their Unicode equivalents (compiled with the `u` flag) via a single
+  shared translator, so e.g. `\p{L}+` no longer wrongly matches digits.
+  The translator is character-class aware (`[\w]` → `[\p{L}\p{Nd}]`) and
+  approximates constructs JS can't model (Unicode block escapes,
+  char-class subtraction) permissively rather than rejecting valid values.


### PR DESCRIPTION
Both `@ifc-lite/ids` `xs:pattern` fixes — #1100 (lexical/base-gated value matching) and #1101 (XSD Unicode-class translation) — were merged to `main` without a changeset, so the package (currently 1.15.10) wouldn't get a release bump.

This adds the missing `patch` changeset covering both. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)