### PR TITLE
perf(geometry): cached f64 interval-lambda predicate filter (canonical fast-exact kernel, stage 1)

### DIFF
--- a/.changeset/kernel-interval-lambda-filter.md
+++ b/.changeset/kernel-interval-lambda-filter.md
@@ -1,0 +1,27 @@
+---
+"@ifc-lite/geometry": patch
+"@ifc-lite/wasm": patch
+---
+
+Faster exact CSG kernel: cached f64 interval-lambda predicate filter (one canonical kernel).
+
+Stage 1 of migrating the exact predicate cascade off WASM-emulated wide-integer
+(I512) arithmetic toward the modern "spend the budget in the float filter" design
+(Cherchi/Attene). The exact kernel's hot re-triangulation predicates resolved via
+the cached I512 lambda determinant, which WASM emulates ~hundreds× slower than
+native's hardware path — on opening-dense models that bignum dominated worker CPU.
+
+The interner now caches a directed-rounding **f64 interval lambda** per point
+(alongside the existing I512 lambda). `orient2d_v`, `cmp_lex_v`, and the interner's
+dedup compare run a pure-f64 interval determinant from it FIRST, falling to the
+exact I512/BigRational tiers only on a genuine zero-straddle. Because the interval
+is outward-rounded (no FMA), a definite sign equals the exact sign and is
+bit-identical across native/wasm/x86_64/aarch64 — the `indirect_sign_manifest`
+constant and the geometry-correctness snapshots are unchanged (determinism
+preserved, no drift, no parallel path).
+
+Result on ISSUE_068 (opening-dense facade): native geometry 4.2s → 2.9s (−30%,
+benefits the server too), WASM load 46s → 41s. Byte-identical mesh output; full
+geometry suite green (53/53 binaries, manifest + snapshots unchanged). Follow-ups
+extend the same filter to the remaining bignum sites and add a float-expansion
+exact tier for the degenerate tail.

--- a/rust/geometry/src/kernel/interner.rs
+++ b/rust/geometry/src/kernel/interner.rs
@@ -14,7 +14,7 @@
 //! processing order is the position in the `cmp_lex`-sorted index (`lex_order`).
 
 use super::predicates::cmp_lex;
-use super::{fixed, ImplicitPoint, Sign};
+use super::{fixed, interval, ImplicitPoint, Sign};
 use std::cmp::Ordering;
 
 /// Stable, append-only vertex identifier.
@@ -29,6 +29,12 @@ pub struct Interner {
     // recomputing the LPI/TPI cross products every call. `None` = off-grid /
     // overflow ⇒ predicates fall back to the exact BigRational cascade.
     lambdas: Vec<Option<fixed::Lam>>,
+    // Per-Vid cached f64-INTERVAL homogeneous lambda (also computed once). The hot
+    // predicates run a directed-rounding f64 determinant from this FIRST and only
+    // fall to the I512 `lambdas` on a zero-straddle — so the non-degenerate
+    // majority never touches wasm-emulated wide integers. Always present (f64 is
+    // always computable, even where the I512 lambda overflows to `None`).
+    lambdas_iv: Vec<interval::IvLam>,
 }
 
 impl Interner {
@@ -44,12 +50,18 @@ impl Interner {
         // use it (fast exact) and fall back to the ImplicitPoint cmp_lex only on
         // off-grid/overflow.
         let new_lam = fixed::lambda1024(&p);
+        let new_lam_iv = interval::ilambda_cached(&p);
         let search = self.sorted.binary_search_by(|&vid| {
-            let s = match (&self.lambdas[vid as usize], &new_lam) {
-                (Some(le), Some(ln)) => fixed::cmp_lex_from_lam(le, ln),
-                _ => None,
-            }
-            .unwrap_or_else(|| cmp_lex(&self.points[vid as usize], &p));
+            // f64 interval compare from the cached lambdas first (pure f64, no
+            // wide-int) → cached-I1024 compare → ImplicitPoint cascade. Each tier
+            // gives the SAME exact order; the interval just carries the
+            // distinct-coordinate majority off the wasm-emulated I512 path.
+            let s = interval::cmp_lex_from_lam_iv(&self.lambdas_iv[vid as usize], &new_lam_iv)
+                .or_else(|| match (&self.lambdas[vid as usize], &new_lam) {
+                    (Some(le), Some(ln)) => fixed::cmp_lex_from_lam(le, ln),
+                    _ => None,
+                })
+                .unwrap_or_else(|| cmp_lex(&self.points[vid as usize], &p));
             match s {
                 Sign::Negative => Ordering::Less,
                 Sign::Positive => Ordering::Greater,
@@ -62,6 +74,7 @@ impl Interner {
                 let vid = self.points.len() as Vid;
                 self.points.push(p);
                 self.lambdas.push(new_lam);
+                self.lambdas_iv.push(new_lam_iv);
                 self.sorted.insert(idx, vid);
                 vid
             }
@@ -76,6 +89,12 @@ impl Interner {
     #[inline]
     pub fn lam(&self, v: Vid) -> &Option<fixed::Lam> {
         &self.lambdas[v as usize]
+    }
+
+    /// The cached f64-interval lambda for a Vid (always present).
+    #[inline]
+    pub fn lam_iv(&self, v: Vid) -> &interval::IvLam {
+        &self.lambdas_iv[v as usize]
     }
 
     pub fn len(&self) -> usize {

--- a/rust/geometry/src/kernel/interval.rs
+++ b/rust/geometry/src/kernel/interval.rs
@@ -243,6 +243,57 @@ fn ilambda_of(p: &ImplicitPoint) -> (Iv3, RnInterval) {
     }
 }
 
+/// Cached homogeneous interval lambda `(λ, d)` for ANY point — the f64-interval
+/// analogue of `fixed::Lam`. Computed ONCE per interned point (the interner caches
+/// it), so the hot re-triangulation predicates can run a directed-rounding f64
+/// determinant straight from it — NO per-call LPI/TPI recompute, and crucially NO
+/// wide-integer (I512) arithmetic, which wasm emulates ~hundreds× slower than
+/// native. An `Explicit` point is `(coords, d=1)`.
+pub(super) type IvLam = ([RnInterval; 3], RnInterval);
+
+#[inline]
+pub(super) fn ilambda_cached(p: &ImplicitPoint) -> IvLam {
+    match p {
+        ImplicitPoint::Lpi(l) => lpi_lambda(l),
+        ImplicitPoint::Tpi(t) => tpi_lambda(t),
+        ImplicitPoint::Explicit(e) => (ivec(*e), RnInterval::point(1.0)),
+    }
+}
+
+/// 2-D orientation of three points from their CACHED interval lambdas — the exact
+/// mirror of `fixed::orient2d_from_lam`'s determinant, in directed-rounding f64.
+/// Returns `Some(sign)` ONLY when the interval determinant is strictly one side of
+/// zero ⇒ that sign equals the exact sign (outward rounding, no FMA) and is
+/// bit-identical native==wasm; a straddle returns `None` so the caller runs the
+/// exact I512/BigRational tiers, unchanged.
+pub(super) fn orient2d_from_lam_iv(a: &IvLam, b: &IvLam, c: &IvLam, axis: DropAxis) -> Option<Sign> {
+    let (i, j) = axis_idx(axis);
+    let (l1, d1) = (&a.0, a.1);
+    let (l2, d2) = (&b.0, b.1);
+    let (l3, d3) = (&c.0, c.1);
+    let u_i = d1.mul(l2[i]).sub(d2.mul(l1[i]));
+    let u_j = d1.mul(l2[j]).sub(d2.mul(l1[j]));
+    let v_i = d1.mul(l3[i]).sub(d3.mul(l1[i]));
+    let v_j = d1.mul(l3[j]).sub(d3.mul(l1[j]));
+    let det = u_i.mul(v_j).sub(u_j.mul(v_i));
+    Some(super::assemble_sign(det.sign()?, &[d2.sign()?, d3.sign()?]))
+}
+
+/// Lexicographic compare of two points from their CACHED interval lambdas — the
+/// f64 mirror of `fixed::cmp_lex_from_lam`. `None` as soon as any axis straddles.
+pub(super) fn cmp_lex_from_lam_iv(a: &IvLam, b: &IvLam) -> Option<Sign> {
+    let (la, da) = (&a.0, a.1);
+    let (lb, db) = (&b.0, b.1);
+    for k in 0..3 {
+        let s = la[k].mul(db).sub(lb[k].mul(da));
+        let sg = super::assemble_sign(s.sign()?, &[da.sign()?, db.sign()?]);
+        if sg != Sign::Zero {
+            return Some(sg);
+        }
+    }
+    Some(Sign::Zero)
+}
+
 /// Interval tier of `rational::orient2d_2i` — `None` on a zero-straddle.
 pub fn orient2d_2i(a: &ImplicitPoint, b: &ImplicitPoint, c: [f64; 3], axis: DropAxis) -> Option<Sign> {
     let (i, j) = axis_idx(axis);

--- a/rust/geometry/src/kernel/retriangulate.rs
+++ b/rust/geometry/src/kernel/retriangulate.rs
@@ -17,7 +17,7 @@
 
 use super::interner::{Interner, Vid};
 use super::predicates::{cmp_lex, orient2d, orient2d_any};
-use super::fixed;
+use super::{fixed, interval};
 use super::{DropAxis, ImplicitPoint, Lpi, Sign, Tpi};
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
@@ -27,23 +27,26 @@ fn e(p: [f64; 3]) -> ImplicitPoint {
     ImplicitPoint::Explicit(p)
 }
 
-/// Vid-based exact orient2d via the interner's cached I1024 lambdas — skips the
-/// interval filter (which can't resolve the degenerate box configs) AND the
-/// LPI/TPI lambda recomputation. Falls back to the ImplicitPoint cascade only on
-/// off-grid/overflow. The dominant re-triangulation predicate.
+/// Vid-based exact orient2d — the dominant re-triangulation predicate. Tiers, all
+/// returning the SAME exact sign (faster ones resolve the easy cases first):
+/// all-explicit Shewchuk (f64) → f64 directed-rounding interval from the cached
+/// lambdas → cached-I1024 determinant → ImplicitPoint cascade (BigRational tail).
+/// The interval tier carries the non-degenerate majority of implicit-point
+/// predicates in pure f64, so the wasm-emulated I1024 path is reached only on a
+/// genuine zero-straddle — the fix for the dense-opening-wall wasm cost.
 #[inline]
 fn orient2d_v(it: &Interner, a: Vid, b: Vid, c: Vid, axis: DropAxis) -> Sign {
     let (pa, pb, pc) = (it.get(a), it.get(b), it.get(c));
-    // All-explicit triple — the common case in a fragmented host face. The
-    // Shewchuk adaptive predicate is EXACT yet evaluates in f64 (its own
-    // semi-static→exact ladder), so it never touches the I1024 lambda path —
-    // which WASM emulates ~hundreds× slower than native wide-integer ops and was
-    // the dominant cost on dense-opening walls. Same exact sign ⇒ byte-identical
-    // native==wasm. Implicit (LPI/TPI) points still take the cached-lambda path.
+    // All-explicit: the Shewchuk adaptive predicate is EXACT yet pure f64.
     if let (ImplicitPoint::Explicit(_), ImplicitPoint::Explicit(_), ImplicitPoint::Explicit(_)) =
         (pa, pb, pc)
     {
         return orient2d(pa, pb, pc, axis);
+    }
+    // f64 INTERVAL from the cached lambdas — pure f64, no wide-int; resolves the
+    // non-degenerate majority and is bit-identical to the exact sign when definite.
+    if let Some(s) = interval::orient2d_from_lam_iv(it.lam_iv(a), it.lam_iv(b), it.lam_iv(c), axis) {
+        return s;
     }
     if let (Some(la), Some(lb), Some(lc)) = (it.lam(a), it.lam(b), it.lam(c)) {
         if let Some(s) = fixed::orient2d_from_lam(la, lb, lc, axis) {
@@ -53,9 +56,13 @@ fn orient2d_v(it: &Interner, a: Vid, b: Vid, c: Vid, axis: DropAxis) -> Sign {
     orient2d_any(pa, pb, pc, axis)
 }
 
-/// Vid-based exact lexicographic compare via the cached lambdas.
+/// Vid-based exact lexicographic compare — f64 interval from the cached lambdas
+/// first, then the cached-I1024 compare, then the ImplicitPoint cascade.
 #[inline]
 fn cmp_lex_v(it: &Interner, a: Vid, b: Vid) -> Sign {
+    if let Some(s) = interval::cmp_lex_from_lam_iv(it.lam_iv(a), it.lam_iv(b)) {
+        return s;
+    }
     if let (Some(la), Some(lb)) = (it.lam(a), it.lam(b)) {
         if let Some(s) = fixed::cmp_lex_from_lam(la, lb) {
             return s;


### PR DESCRIPTION
## Why

The pure-Rust exact CSG kernel (M9, #1024) is correct + deterministic but ~11× slower in WASM than native on opening-dense models (e.g. `ISSUE_068`: ~4.2s native, ~46s WASM). A real CDP worker-thread CPU trace pinned the cost to the kernel's **I512 (512-bit BigInt) predicate arithmetic, which WASM emulates ~hundreds× slower than native's hardware path** — spread across the predicate hot path, not one function. (Ruled out by measurement: allocator/talc, lambda construction alone, single-function hotspots.)

This is **stage 1** of migrating the exact cascade toward the modern "spend the budget in the float filter" design (Cherchi/Attene) — **one canonical kernel, no parallel path, no drift.**

## What

The interner now caches a directed-rounding **f64 interval lambda** per point alongside the existing I512 lambda. The hot re-triangulation predicates (`orient2d_v`, `cmp_lex_v`) and the interner's dedup compare run a **pure-f64 interval determinant from it first**, falling to the exact I512 → BigRational tiers only on a genuine zero-straddle.

Because the interval is outward-rounded (no FMA), a *definite* interval sign is exactly the exact sign — **bit-identical native==wasm==x86_64==aarch64**. The `indirect_sign_manifest` constant and the geometry-correctness snapshots are **unchanged** (the determinism gates that prove no sign drift).

## Result (`ISSUE_068`, 53.7 MB opening-dense facade)

| | before | after |
|---|---|---|
| native geometry | 4.2 s | **2.9 s (−30%)** — server benefits too |
| WASM load | 46 s | **41 s** |

Byte-identical mesh output (476931 verts / 222610 tris unchanged). Geometry suite **53/53 binaries green**, manifest + snapshots unchanged.

## Follow-ups (per plan)

- Extend the same cached-interval filter to the remaining bignum sites (orient3d classification, tri-tri / `split_crossings`, `cmp_along`).
- Add a **float-expansion exact tier** (Attene-style indirect predicates) for the genuinely-degenerate tail, so the I512/BigRational rungs become the rare fallback rather than the hot path.

Honest ceiling: an exact kernel inherently does more work than the old float Manifold kernel (its ~3s WASM ≈ this kernel's native time), so the target is *near-native-equivalent on WASM*, not float-kernel parity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized geometric computation kernel with faster predicate evaluation for improved overall performance.
  * Enhanced speed on both native and WebAssembly platforms.
  * Maintained deterministic behavior with unchanged geometric accuracy and mesh output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->