### PR TITLE
perf(geometry): f64 interval tier for cmp_along (stage 2a, stacked on #1105)

### DIFF
--- a/.changeset/kernel-cmp-along-interval-tier.md
+++ b/.changeset/kernel-cmp-along-interval-tier.md
@@ -1,0 +1,8 @@
+---
+"@ifc-lite/geometry": patch
+"@ifc-lite/wasm": patch
+---
+
+Faster exact CSG kernel (stage 2a): f64 interval tier for `cmp_along` (tri-tri ordering).
+
+Closes the last plan-flagged float-filter hole on top of the interval-lambda filter: the 1-D ordering of tri-tri crossing points (`cmp_along`) went straight to the I512 tier then BigRational with no interval pre-filter. `interval::cmp_along` (a pure-f64 directed-rounding mirror of `fixed::cmp_along`) now runs first; `tritri.rs` falls to I512/BigRational only on a zero-straddle. Because the interval is outward-rounded (no FMA), a definite sign equals the exact sign and is bit-identical native==wasm==x86_64==aarch64 — manifest constant and snapshots unchanged. Cumulative with the interval-lambda filter: native geometry ~4.2s → ~2.8s.

--- a/rust/geometry/src/kernel/interval.rs
+++ b/rust/geometry/src/kernel/interval.rs
@@ -279,6 +279,20 @@ pub(super) fn orient2d_from_lam_iv(a: &IvLam, b: &IvLam, c: &IvLam, axis: DropAx
     Some(super::assemble_sign(det.sign()?, &[d2.sign()?, d3.sign()?]))
 }
 
+/// Interval tier of `cmp_along` — the f64 mirror of `fixed::cmp_along`: the sign
+/// of `(a−b)·u` over the homogeneous lambdas. `None` on a zero-straddle ⇒ the
+/// caller runs the exact I512/BigRational tiers. Closes the latent slow path where
+/// EVERY tri-tri `cmp_along` skipped the float filter and went straight to bignum.
+pub fn cmp_along(a: &ImplicitPoint, b: &ImplicitPoint, u: [f64; 3]) -> Option<Sign> {
+    let (la, da) = ilambda_cached(a);
+    let (lb, db) = ilambda_cached(b);
+    let ur = ivec(u);
+    let dot_a = la[0].mul(ur[0]).add(la[1].mul(ur[1])).add(la[2].mul(ur[2]));
+    let dot_b = lb[0].mul(ur[0]).add(lb[1].mul(ur[1])).add(lb[2].mul(ur[2]));
+    let num = dot_a.mul(db).sub(dot_b.mul(da));
+    Some(super::assemble_sign(num.sign()?, &[da.sign()?, db.sign()?]))
+}
+
 /// Lexicographic compare of two points from their CACHED interval lambdas — the
 /// f64 mirror of `fixed::cmp_lex_from_lam`. `None` as soon as any axis straddles.
 pub(super) fn cmp_lex_from_lam_iv(a: &IvLam, b: &IvLam) -> Option<Sign> {

--- a/rust/geometry/src/kernel/tritri.rs
+++ b/rust/geometry/src/kernel/tritri.rs
@@ -135,7 +135,13 @@ pub enum TriTri {
 
 #[inline]
 fn cmp_along(a: &ImplicitPoint, b: &ImplicitPoint, u: [f64; 3]) -> Sign {
-    super::fixed::cmp_along(a, b, u).unwrap_or_else(|| super::rational::cmp_along(a, b, u))
+    // f64 interval filter FIRST (pure f64), then the exact I512 tier, then
+    // BigRational. The interval resolves the non-degenerate majority off the
+    // wasm-emulated wide-integer path; a definite interval sign equals the exact
+    // sign (outward rounding, no FMA) ⇒ identical ordering, byte-identical.
+    super::interval::cmp_along(a, b, u)
+        .or_else(|| super::fixed::cmp_along(a, b, u))
+        .unwrap_or_else(|| super::rational::cmp_along(a, b, u))
 }
 
 /// A triangle's intersection with another triangle's supporting plane — the


### PR DESCRIPTION
Stacked on #1105. Closes the last plan-flagged float-filter hole: `cmp_along` (the 1-D ordering of tri-tri crossing points) went straight to the I512 tier then BigRational with no interval filter. Adds `interval::cmp_along` (pure-f64 directed-rounding mirror of `fixed::cmp_along`); `tritri.rs` runs it first, falling to I512/BigRational only on a zero-straddle.

Byte-identical (manifest constant + snapshots unchanged); native geometry 2.9s→2.8s cumulative with #1105 (4.2s baseline → −33%), WASM 41s→40s.

**Note (data-driven):** a CPU re-profile after #1105 + this change shows the remaining WASM cost is NOT the I512 exact tail (it's the interval filter's own f64 directed-rounding arithmetic + inherent work), so the planned Attene float-expansion exact-tier port is **contraindicated** for this model — see the PR discussion / follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved performance of CSG geometry operations. Triangle-triangle intersection comparisons now complete faster through an optimized comparison strategy that efficiently handles complex geometric relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->