### PR TITLE
fix(geometry): drop degenerate f32 triangles to kill gross fan corruption

### DIFF
--- a/.changeset/geometry-degenerate-f32-triangle-backstop.md
+++ b/.changeset/geometry-degenerate-f32-triangle-backstop.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Drop degenerate f32 triangles so large georeferenced models stop showing gross "fan" corruption.
+
+When a mesh is stored at f32 precision while its vertices sit at building-scale world coordinates (e.g. a model whose extent reaches ~220 m from the coordinate origin), the f32 mantissa only resolves ~15 µm there. Vertices closer together than one ULP round to the same — or near-same — f32 value, so the triangles joining them collapse into zero-area slivers; when the third vertex is far away the result is a long, thin triangle that visibly fans across the whole model.
+
+`Mesh::drop_degenerate_triangles` now runs in `build_mesh_data` — the single funnel every element `MeshData` passes through on both the native and WASM pipelines — and removes only unambiguously-degenerate triangles: a bit-identical f32 vertex pair (exact zero area) or an aspect ratio above 1e5. These slivers carry no area, so neighbouring triangles of the same face already cover the surface and the removal is visually lossless. On a 54 MB georeferenced building model this drops all 664 catastrophic fans (0.29% of triangles) with no change to the remaining geometry, no kernel-determinism impact (predicate-sign manifests unchanged), and the synthetic-coordinate correctness harness stays byte-identical. The complete fix (local-frame / tiled vertex storage that keeps the vertices distinct) is tracked separately; this is the backstop that keeps the viewer clean meanwhile.

--- a/rust/geometry/src/mesh.rs
+++ b/rust/geometry/src/mesh.rs
@@ -426,6 +426,85 @@ impl Mesh {
         self.indices = valid;
     }
 
+    /// Drop triangles that collapsed into degenerate needles when the mesh was
+    /// stored at f32 precision.
+    ///
+    /// At building-scale world coordinates (e.g. ~220 m) an f32 mantissa only
+    /// resolves ~15 µm, so two genuinely-distinct vertices less than one ULP
+    /// apart round to the *same* (or near-same) f32 value. The triangle that
+    /// joined them becomes a zero-area sliver — and when its third vertex is far
+    /// away, a long thin "fan" that visibly spans the model (the gross
+    /// corruption seen on large georeferenced buildings).
+    ///
+    /// These slivers carry effectively no area, so the neighbouring triangles of
+    /// the same face already cover the surface; removing them is visually
+    /// lossless while eliminating the fans. The proper fix (local-frame / tiled
+    /// vertex storage) keeps the vertices distinct in the first place; this is
+    /// the backstop for meshes that still arrive degenerate.
+    ///
+    /// Conservative by design — only drops triangles that are *unambiguously*
+    /// garbage: a bit-identical f32 vertex pair (exact zero area) or an aspect
+    /// ratio (longest edge / shortest edge) above 1e5. Legitimate thin members
+    /// (mullions, braces) sit far below that. Only `indices` change; the vertex
+    /// buffer and per-vertex data are left intact, so the operation is
+    /// deterministic and keeps vertex indices stable.
+    pub fn drop_degenerate_triangles(&mut self) {
+        if self.indices.len() < 3 {
+            return;
+        }
+        const MAX_ASPECT: f64 = 1.0e5;
+        let vertex_count = self.positions.len() / 3;
+        let vert = |i: u32| -> Option<[f64; 3]> {
+            let i = i as usize;
+            if i >= vertex_count {
+                return None;
+            }
+            Some([
+                self.positions[i * 3] as f64,
+                self.positions[i * 3 + 1] as f64,
+                self.positions[i * 3 + 2] as f64,
+            ])
+        };
+        let bits = |i: u32| -> [u32; 3] {
+            let i = i as usize;
+            [
+                self.positions[i * 3].to_bits(),
+                self.positions[i * 3 + 1].to_bits(),
+                self.positions[i * 3 + 2].to_bits(),
+            ]
+        };
+        let dist = |a: [f64; 3], b: [f64; 3]| -> f64 {
+            ((a[0] - b[0]).powi(2) + (a[1] - b[1]).powi(2) + (a[2] - b[2]).powi(2)).sqrt()
+        };
+
+        let mut kept = Vec::with_capacity(self.indices.len());
+        for tri in self.indices.chunks_exact(3) {
+            let (ia, ib, ic) = (tri[0], tri[1], tri[2]);
+            // Bit-identical f32 vertex pair → exact zero-area collapse.
+            let (ba, bb, bc) = (bits(ia), bits(ib), bits(ic));
+            if ba == bb || bb == bc || ba == bc {
+                continue;
+            }
+            let (va, vb, vc) = match (vert(ia), vert(ib), vert(ic)) {
+                (Some(a), Some(b), Some(c)) => (a, b, c),
+                _ => continue, // out-of-range index: drop (matches validate_indices)
+            };
+            let e0 = dist(va, vb);
+            let e1 = dist(vb, vc);
+            let e2 = dist(vc, va);
+            let min_edge = e0.min(e1).min(e2);
+            let max_edge = e0.max(e1).max(e2);
+            // Catastrophic needle: a sliver whose longest edge dwarfs its
+            // shortest by >1e5. min_edge==0 is already handled by the bit check
+            // above, so a finite ratio here means near-but-not-identical f32.
+            if min_edge > 0.0 && max_edge / min_edge > MAX_ASPECT {
+                continue;
+            }
+            kept.extend_from_slice(tri);
+        }
+        self.indices = kept;
+    }
+
     /// Check if mesh is empty
     #[inline]
     pub fn is_empty(&self) -> bool {

--- a/rust/processing/src/element.rs
+++ b/rust/processing/src/element.rs
@@ -486,6 +486,16 @@ fn produce_type_geometry(
     out
 }
 
+/// Whether the f32-collapse degenerate-triangle backstop is disabled.
+///
+/// On by default. Set `IFC_LITE_DISABLE_DEGENERATE_BACKSTOP=1` to keep the raw
+/// (possibly fan-corrupted) triangles — an escape hatch for debugging the
+/// heuristic or measuring exactly what it removes. Read once and cached.
+fn degenerate_backstop_disabled() -> bool {
+    static DISABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *DISABLED.get_or_init(|| std::env::var("IFC_LITE_DISABLE_DEGENERATE_BACKSTOP").is_ok())
+}
+
 /// Construct the final [`MeshData`]: metadata stamp, style metadata,
 /// geometry-class tag, and the optional site-local rotation. ALWAYS the last
 /// step — geometry hashing happens before this (native IFC frame).
@@ -504,7 +514,9 @@ fn build_mesh_data(
     // span large georeferenced models. Drop the unambiguously-degenerate ones
     // here — the single funnel for every element MeshData. (Proper fix is
     // local-frame / tiled vertex storage; this keeps the viewer clean meanwhile.)
-    mesh.drop_degenerate_triangles();
+    if !degenerate_backstop_disabled() {
+        mesh.drop_degenerate_triangles();
+    }
     let mut mesh_data = MeshData::new(
         job.id,
         job.ifc_type.name().to_string(),

--- a/rust/processing/src/element.rs
+++ b/rust/processing/src/element.rs
@@ -491,13 +491,20 @@ fn produce_type_geometry(
 /// step — geometry hashing happens before this (native IFC frame).
 fn build_mesh_data(
     job: &ElementMeshJob<'_>,
-    mesh: Mesh,
+    mut mesh: Mesh,
     color: [f32; 4],
     material_name: Option<String>,
     geometry_item_id: Option<u32>,
     geometry_class: u8,
     ctx: &MeshProductionContext<'_>,
 ) -> MeshData {
+    // Backstop for f32 vertex-storage collapse: at building-scale world
+    // coordinates an f32 mantissa can't separate sub-15µm-apart vertices, so
+    // triangles collapse into zero-area / long-thin "fan" slivers that visibly
+    // span large georeferenced models. Drop the unambiguously-degenerate ones
+    // here — the single funnel for every element MeshData. (Proper fix is
+    // local-frame / tiled vertex storage; this keeps the viewer clean meanwhile.)
+    mesh.drop_degenerate_triangles();
     let mut mesh_data = MeshData::new(
         job.id,
         job.ifc_type.name().to_string(),


### PR DESCRIPTION
## Problem

Large **georeferenced** models render gross triangle "fans" that span the whole building — visible as thin white sheets cutting across the geometry. This is **pre-existing on `main`** and affects **both** the native and WASM/viewer pipelines (they share `produce_element_meshes`).

### Root cause: f32 vertex-storage collapse

Element meshes are stored at **f32** precision, but their vertices sit at **building-scale world coordinates** (a model whose extent reaches ~220 m from the coordinate origin). At that magnitude an f32 mantissa resolves only **~15 µm**. Two genuinely-distinct vertices closer together than one ULP round to the *same* (or near-same) f32 value, so the triangle joining them collapses into a **zero-area sliver** — and when its third vertex is far away, a long thin triangle that fans across the model.

This is the storage step, not the kernel: the f64 geometry is correct; the corruption appears only once it's cast to f32 at world scale.

## Fix (backstop)

`Mesh::drop_degenerate_triangles` runs in `build_mesh_data` — the **single funnel** every element `MeshData` passes through on both pipelines — and removes only **unambiguously-degenerate** triangles:

- a **bit-identical f32 vertex pair** (exact zero area), or
- an **aspect ratio > 1e5** (longest edge / shortest edge).

These slivers carry no area, so the neighbouring triangles of the same face already cover the surface — the removal is **visually lossless**. Only `indices` change; the vertex buffer is untouched, so the op is deterministic and keeps vertex indices stable.

An operability escape hatch — `IFC_LITE_DISABLE_DEGENERATE_BACKSTOP=1` (native only; read once) — keeps the raw triangles for debugging/measuring the heuristic.

## Verification

### Corpus-wide (28 models, backstop off vs on)

Every model: **`fans_on` = 0**. No fix failures, no over-aggressive drops.

- **12 models "clean"** — no fans either way, **0 triangles dropped** → proves the backstop is a no-op on healthy/normal-scale geometry.
- **16 models "fixed"** — fan corruption was far more widespread than just one model. Examples:

| model | fans (raw) | fans (fixed) | triangles dropped | drop % |
|---|---|---|---|---|
| ISSUE_053 (Holter Tower) | 7966 | 0 | 7966 / 2.33 M | 0.34% |
| dental_clinic | 1316 | 0 | 796 / 168 k | 0.47% |
| ISSUE_129 | 1040 | 0 | 981 / 128 k | 0.77% |
| S_Office | 790 | 0 | 790 / 217 k | 0.36% |
| ISSUE_021 | 728 | 0 | 728 / 252 k | 0.29% |
| (target model) | 664 | 0 | 650 / 222 k | 0.29% |
| schependomlaan | 230 | 0 | 230 / 135 k | 0.17% |
| ISSUE_102_M3D-CON-CD | 140 | 0 | 140 / 2.29 M | 0.006% |

(Smallest model `example.ifc` drops 6.66% — but it's a tiny 12 k-triangle model that is badly georeferenced, and every dropped triangle was a genuine aspect>1e5 fan.)

### Determinism + suites
- Predicate-sign **manifests unchanged** (kernel determinism intact)
- **`geometry_correctness_harness` byte-identical** — synthetic small-coordinate geometry never collapses, so the backstop is a no-op there
- Full `ifc-lite-geometry` + `ifc-lite-processing` suites pass
- WASM rebuilds clean; binding surface (`.d.ts`) unchanged

### Visual
Loaded the 54 MB target model in the real-Chrome / WebGPU viewer (headed Playwright): the full building complex now renders clean — the building-spanning fans are gone, geometry intact, 60 fps.

## Scope / follow-up

This is the **backstop**. The complete fix — local-frame / tiled vertex storage that keeps the vertices distinct in the first place (so nothing collapses, at any model scale) — is a larger multi-stage effort (Rust origin threading through every CSG path → WASM/worker/types → camera-relative WebGPU renderer → cache bump) and is tracked separately. This PR keeps the viewer clean meanwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed geometry rendering artifacts in large georeferenced models caused by degenerate triangles. The system now filters out unambiguously-degenerate zero-area and extremely thin “sliver” triangles during mesh data building to prevent visible “fan” distortion while preserving intended surface coverage.
  * The behavior is enabled by default and can be turned off by setting `IFC_LITE_DISABLE_DEGENERATE_BACKSTOP`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->