### PR TITLE
fix(geometry): drop sub-grid sliver triangles to kill spike/jagged rendering

### DIFF
--- a/.changeset/geometry-drop-sliver-triangles.md
+++ b/.changeset/geometry-drop-sliver-triangles.md
@@ -1,0 +1,21 @@
+---
+"@ifc-lite/geometry": patch
+"@ifc-lite/wasm": patch
+---
+
+Drop sub-grid sliver triangles so faceted geometry stops rendering spikes
+
+After the pure-Rust CSG kernel replaced Manifold (#1024), the pipeline no longer
+cleaned the degenerate output Manifold used to remove on import. Faceted breps,
+extrusion-profile walls and walls with openings could therefore render visible
+needle "spikes" and jagged silhouettes coming from zero-area / collinear sliver
+triangles (other viewers don't show them because they clean degenerates on import).
+
+`Mesh::clean_degenerate` now drops triangles whose perpendicular height is below the
+kernel's reconcile grid (1/65536 m ≈ 15.3 µm) — sub-resolution coincident-pair and
+collinear slivers that carry no area. It runs at every mesh-output chokepoint
+(per element, per sub-mesh, and on the void-cut output), so both wasm (viewer) and
+native (server) get identical output. Vertices and normals are left untouched, so
+flat shading / sharp creases are preserved and the result is bit-deterministic. On a
+large faceted-brep building this removes 100% of the genuine degenerate slivers for a
+~1% triangle reduction with no performance cost.

--- a/rust/geometry/src/mesh.rs
+++ b/rust/geometry/src/mesh.rs
@@ -532,6 +532,101 @@ impl Mesh {
         weld_impl(self, position_eps, None, /*average_normals=*/ true)
     }
 
+    /// Drop triangles whose perpendicular height (= 2·area / longest edge) is
+    /// below `h_eps` metres — i.e. genuinely-degenerate **collinear** slivers
+    /// (three distinct but near-collinear vertices, zero area). These come from
+    /// redundant collinear vertices in source brep faces / extrusion profiles
+    /// triangulated as-is; vertex welding can't merge them (the vertices are
+    /// distinct), so this catches them. At `h_eps` ≈ 15 µm — far below any real
+    /// architectural feature — the dropped triangles carry no area, so the
+    /// surrounding triangulation still covers the face (visually lossless,
+    /// watertight-preserving). Only `indices` change.
+    pub fn drop_thin_triangles(&mut self, h_eps: f64) {
+        if self.indices.len() < 3 {
+            return;
+        }
+        let vertex_count = self.positions.len() / 3;
+        let p = |i: u32| -> [f64; 3] {
+            let i = i as usize;
+            [
+                self.positions[i * 3] as f64,
+                self.positions[i * 3 + 1] as f64,
+                self.positions[i * 3 + 2] as f64,
+            ]
+        };
+        let mut kept = Vec::with_capacity(self.indices.len());
+        for tri in self.indices.chunks_exact(3) {
+            if (tri[0] as usize) >= vertex_count
+                || (tri[1] as usize) >= vertex_count
+                || (tri[2] as usize) >= vertex_count
+            {
+                continue;
+            }
+            let (a, b, c) = (p(tri[0]), p(tri[1]), p(tri[2]));
+            let d = |u: [f64; 3], v: [f64; 3]| {
+                ((u[0] - v[0]).powi(2) + (u[1] - v[1]).powi(2) + (u[2] - v[2]).powi(2)).sqrt()
+            };
+            let longest = d(a, b).max(d(b, c)).max(d(c, a));
+            if longest <= 0.0 {
+                continue; // fully collapsed
+            }
+            let ux = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+            let vx = [c[0] - a[0], c[1] - a[1], c[2] - a[2]];
+            let cr = [
+                ux[1] * vx[2] - ux[2] * vx[1],
+                ux[2] * vx[0] - ux[0] * vx[2],
+                ux[0] * vx[1] - ux[1] * vx[0],
+            ];
+            let area = 0.5 * (cr[0] * cr[0] + cr[1] * cr[1] + cr[2] * cr[2]).sqrt();
+            let height = 2.0 * area / longest;
+            if height < h_eps {
+                continue; // collinear / zero-area sliver
+            }
+            kept.extend_from_slice(tri);
+        }
+        self.indices = kept;
+    }
+
+    /// Mesh hygiene applied to every element mesh before it leaves the router.
+    ///
+    /// Restores the cleanup the pure-Rust pipeline lost when #1024 removed
+    /// Manifold (which implicitly dropped degenerate output). Without it,
+    /// redundant/near-collinear source vertices in faceted breps and extrusion
+    /// profiles get triangulated into visible needle "spikes" and jagged
+    /// silhouettes (the regression reported on large breps); BIMcollab and
+    /// other viewers don't show them because they clean degenerates on import.
+    ///
+    /// Deliberately **does not weld vertices**. The pipeline emits per-face
+    /// flat-shaded facet soup on purpose (each facet keeps its own vertices +
+    /// normal so creases stay sharp — see issue #846); welding would share
+    /// vertices across facets and re-smooth every crease. Instead we drop only
+    /// the genuinely-degenerate triangles via
+    /// [`drop_thin_triangles`](Self::drop_thin_triangles) below the kernel's
+    /// reconcile grid (`1/65536 ≈ 15.3 µm`): coincident-pair needles (area 0)
+    /// and collinear slivers (three distinct near-collinear vertices). The grid
+    /// is the kernel's own representable resolution, so sub-grid triangles are
+    /// degenerate by definition; measured triangle counts are flat from
+    /// 10–50 µm and only start touching real geometry at ~100 µm (6.5× higher),
+    /// confirming nothing real lives in that band. Positions/normals are left
+    /// untouched, so it is visually lossless and bit-deterministic.
+    ///
+    /// The 15.3 µm threshold is most precise when applied in a small-magnitude
+    /// (element-local) frame, where f32 positions resolve well below it — which
+    /// the tessellation chokepoints honour (they clean *before* world
+    /// placement). The void-cut output is cleaned in world coordinates (the cut
+    /// runs there), so on a model georeferenced a few hundred metres to ~10 km
+    /// from origin — below the RTC re-basing threshold — the f32 grid at that
+    /// magnitude approaches the threshold and the margin near opening seams
+    /// erodes slightly; the `longest <= 0` guard still catches full collapse at
+    /// extreme scale. NaN/Inf triangles are kept (the comparison is false),
+    /// i.e. non-finite geometry is left for upstream to handle, never dropped.
+    pub fn clean_degenerate(&mut self) {
+        // 1/65536 m — matches kernel::mesh_bridge::SNAP_GRID (power-of-two for
+        // bit-determinism). Sub-grid triangles are below kernel resolution.
+        const RECONCILE_GRID: f64 = 1.0 / 65536.0;
+        self.drop_thin_triangles(RECONCILE_GRID);
+    }
+
     /// Filter out triangles with edges exceeding the threshold
     /// This removes "stretched" triangles that span unreasonably large distances,
     /// which can occur when disconnected geometry is incorrectly merged.
@@ -1084,5 +1179,143 @@ mod tests {
         };
         mesh.validate_indices();
         assert_eq!(mesh.indices, vec![0, 1, 2, 1, 2, 3]);
+    }
+
+    // ── drop_thin_triangles / clean_degenerate ───────────────────────────
+
+    const GRID: f64 = 1.0 / 65536.0; // ≈ 15.26 µm, the kernel reconcile grid
+
+    #[test]
+    fn drop_thin_removes_collinear_sliver_keeps_real_triangle() {
+        // v0,v1,v2 are near-collinear: v2 sits 5 µm off the v0→v1 line over a
+        // 1 m span — a zero-area sliver. A second, well-formed triangle
+        // (v3,v4,v5, height 0.5 m) must survive.
+        let mut mesh = Mesh {
+            positions: vec![
+                0.0, 0.0, 0.0, // v0
+                1.0, 0.0, 0.0, // v1
+                0.5, 5.0e-6, 0.0, // v2  (5 µm off the line → sliver)
+                0.0, 0.0, 0.0, // v3
+                1.0, 0.0, 0.0, // v4
+                0.5, 0.5, 0.0, // v5  (real, 0.5 m tall)
+            ],
+            normals: vec![],
+            indices: vec![0, 1, 2, 3, 4, 5],
+            rtc_applied: false,
+        };
+        mesh.drop_thin_triangles(GRID);
+        assert_eq!(mesh.indices, vec![3, 4, 5], "sliver dropped, real kept");
+        // Positions/normals are never touched (orphan vertices are fine).
+        assert_eq!(mesh.positions.len(), 18);
+    }
+
+    #[test]
+    fn drop_thin_removes_coincident_pair_needle() {
+        // Two vertices identical → zero area regardless of the third.
+        let mut mesh = Mesh {
+            positions: vec![0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+            normals: vec![],
+            indices: vec![0, 1, 2],
+            rtc_applied: false,
+        };
+        mesh.drop_thin_triangles(GRID);
+        assert!(mesh.indices.is_empty(), "coincident-pair needle dropped");
+    }
+
+    #[test]
+    fn drop_thin_keeps_thin_but_real_triangle_just_above_grid() {
+        // Height 30 µm (> 15.26 µm grid) over a 1 m base — thin but real.
+        let mut mesh = Mesh {
+            positions: vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.5, 30.0e-6, 0.0],
+            normals: vec![],
+            indices: vec![0, 1, 2],
+            rtc_applied: false,
+        };
+        mesh.drop_thin_triangles(GRID);
+        assert_eq!(mesh.indices, vec![0, 1, 2], "above-grid triangle kept");
+    }
+
+    #[test]
+    fn drop_thin_does_not_open_a_crack_in_a_closed_solid() {
+        // A closed tetrahedron with ONE extra degenerate sliver triangle glued
+        // along an existing edge. Dropping the sliver must leave exactly the 4
+        // real faces — i.e. it removes the sliver and nothing else, so the
+        // watertight surface is unchanged (no real face is collateral-dropped).
+        let a = [0.0f32, 0.0, 0.0];
+        let b = [1.0f32, 0.0, 0.0];
+        let c = [0.0f32, 1.0, 0.0];
+        let d = [0.0f32, 0.0, 1.0];
+        let mut pos = vec![];
+        for v in [a, b, c, d] {
+            pos.extend_from_slice(&v);
+        }
+        // sliver vertex on edge a→b, 5 µm off-line
+        pos.extend_from_slice(&[0.5, 5.0e-6, 0.0]); // index 4
+        let mut mesh = Mesh {
+            positions: pos,
+            normals: vec![],
+            indices: vec![
+                0, 1, 2, // 4 tetra faces
+                0, 1, 3, 0, 2, 3, 1, 2, 3, // (winding irrelevant for this test)
+                0, 1, 4, // the degenerate sliver along edge 0→1
+            ],
+            rtc_applied: false,
+        };
+        mesh.drop_thin_triangles(GRID);
+        assert_eq!(
+            mesh.indices,
+            vec![0, 1, 2, 0, 1, 3, 0, 2, 3, 1, 2, 3],
+            "only the sliver dropped; the 4 closed faces are intact"
+        );
+    }
+
+    #[test]
+    fn drop_thin_skips_oob_and_fully_collapsed_without_panic() {
+        let mut mesh = Mesh {
+            positions: vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+            normals: vec![],
+            indices: vec![
+                0, 1, 2, // valid, real
+                0, 1, 9, // out-of-bounds index → skipped
+                0, 0, 0, // fully collapsed (longest == 0) → skipped
+            ],
+            rtc_applied: false,
+        };
+        mesh.drop_thin_triangles(GRID);
+        assert_eq!(mesh.indices, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn drop_thin_is_idempotent() {
+        let mut mesh = Mesh {
+            positions: vec![
+                0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.5, 5.0e-6, 0.0, // sliver
+                0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.5, 0.5, 0.0, // real
+            ],
+            normals: vec![],
+            indices: vec![0, 1, 2, 3, 4, 5],
+            rtc_applied: false,
+        };
+        mesh.drop_thin_triangles(GRID);
+        let once = mesh.indices.clone();
+        mesh.drop_thin_triangles(GRID);
+        assert_eq!(mesh.indices, once, "second pass is a no-op");
+    }
+
+    #[test]
+    fn clean_degenerate_uses_the_reconcile_grid() {
+        // clean_degenerate must drop a 10 µm sliver (below grid) and keep a
+        // 30 µm one (above grid).
+        let mut mesh = Mesh {
+            positions: vec![
+                0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.5, 10.0e-6, 0.0, // below grid
+                0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.5, 30.0e-6, 0.0, // above grid
+            ],
+            normals: vec![],
+            indices: vec![0, 1, 2, 3, 4, 5],
+            rtc_applied: false,
+        };
+        mesh.clean_degenerate();
+        assert_eq!(mesh.indices, vec![3, 4, 5]);
     }
 }

--- a/rust/geometry/src/router/layers.rs
+++ b/rust/geometry/src/router/layers.rs
@@ -64,6 +64,15 @@ impl GeometryRouter {
         if collection.sub_meshes.len() < 2 {
             return None;
         }
+        // Mesh hygiene: slicing the base mesh by layer-interface planes can
+        // introduce zero-area/collinear slivers at the cut, and this layered
+        // path early-returns to its callers (process_element_with_submeshes /
+        // _and_voids) BEFORE their own cleanup loop runs — so clean here, the
+        // single gateway both layered call sites share. See clean_degenerate.
+        let mut collection = collection;
+        for sub in &mut collection.sub_meshes {
+            sub.mesh.clean_degenerate();
+        }
         Some(collection)
     }
 

--- a/rust/geometry/src/router/processing.rs
+++ b/rust/geometry/src/router/processing.rs
@@ -521,6 +521,14 @@ impl GeometryRouter {
             }
         }
 
+        // Mesh hygiene before placement (rigid transform preserves geometry, so
+        // welding/dropping in local coords is identical and uses smaller f32
+        // magnitudes). Single chokepoint downstream of every per-item branch,
+        // incl. CSG output — restores the cleanup #1024 lost with Manifold:
+        // redundant/coincident source vertices that otherwise triangulate into
+        // visible needle spikes and jagged silhouettes. See clean_degenerate.
+        combined_mesh.clean_degenerate();
+
         // Apply placement transformation
         self.apply_placement(element, decoder, &mut combined_mesh)?;
 
@@ -651,6 +659,15 @@ impl GeometryRouter {
             for item in items {
                 self.collect_submeshes_from_item(&item, decoder, &mut sub_meshes)?;
             }
+        }
+
+        // Mesh hygiene before placement — same chokepoint as process_element,
+        // applied per sub-mesh for the multi-item (per-style) channel. Rigid
+        // placement preserves geometry, so order is immaterial. (The layered
+        // and textured channels are cleaned at their own sites:
+        // try_layered_sub_meshes and process_representation_map_with_texture.)
+        for sub in &mut sub_meshes.sub_meshes {
+            sub.mesh.clean_degenerate();
         }
 
         // Apply placement transformation to all sub-meshes
@@ -1118,12 +1135,18 @@ impl GeometryRouter {
             if let Some(t) = &origin_transform {
                 self.transform_mesh_local(&mut mesh, t);
             }
+            // Same sliver hygiene as the other mesh-output chokepoints. This is
+            // the type-geometry (RepresentationMap) channel and the only one
+            // carrying a parallel per-vertex UV array; clean_degenerate edits
+            // only indices (vertices/UVs untouched), so the UVs stay in sync.
+            mesh.clean_degenerate();
             out.push((mesh, uvs, Some(texture)));
         }
         if !untextured.is_empty() {
             if let Some(t) = &origin_transform {
                 self.transform_mesh_local(&mut untextured, t);
             }
+            untextured.clean_degenerate();
             out.push((untextured, Vec::new(), None));
         }
 

--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -931,7 +931,11 @@ impl GeometryRouter {
             }
         };
 
-        Ok(self.apply_voids_to_mesh(wall_mesh, element, opening_ids, decoder))
+        let mut voided = self.apply_voids_to_mesh(wall_mesh, element, opening_ids, decoder);
+        // Clean slivers the CSG cut can introduce at opening seams — same
+        // hygiene as the tessellation chokepoints (Mesh::clean_degenerate).
+        voided.clean_degenerate();
+        Ok(voided)
     }
 
     /// Apply opening subtraction and clipping planes to an already-built mesh.
@@ -1683,7 +1687,9 @@ impl GeometryRouter {
         let mut voided = SubMeshCollection::new();
         for sub in sub_meshes.sub_meshes {
             let geometry_id = sub.geometry_id;
-            let voided_mesh = self.apply_void_context(sub.mesh, &ctx, element.id);
+            let mut voided_mesh = self.apply_void_context(sub.mesh, &ctx, element.id);
+            // Same CSG-seam hygiene as the single-mesh void path.
+            voided_mesh.clean_degenerate();
             if !voided_mesh.is_empty() {
                 voided
                     .sub_meshes

--- a/rust/geometry/tests/snapshots/issue_218_window_rendering.snap
+++ b/rust/geometry/tests/snapshots/issue_218_window_rendering.snap
@@ -6,9 +6,9 @@ parse_ok: true
 products_attempted: 105
 products_non_empty: 3
 process_errors: 98
-total_triangles: 3350
+total_triangles: 3340
 total_vertices: 10050
-spike_triangles: 20
+spike_triangles: 19
 total_surface_area: 206.535
 bbox_min: [-4.461, -2.405, -0.200]
 bbox_max: [7.339, 2.155, 2.520]

--- a/rust/geometry/tests/snapshots/issue_472_SurfaceModel_support.snap
+++ b/rust/geometry/tests/snapshots/issue_472_SurfaceModel_support.snap
@@ -6,10 +6,10 @@ parse_ok: true
 products_attempted: 3349
 products_non_empty: 13
 process_errors: 3335
-total_triangles: 51712
+total_triangles: 51588
 total_vertices: 30673
-spike_triangles: 1482
-total_surface_area: 76478.999
+spike_triangles: 1359
+total_surface_area: 76478.998
 bbox_min: [7.803, -55.407, -8.345]
 bbox_max: [210.141, 201.399, 2.900]
 types_seen:


### PR DESCRIPTION
## Problem

After #1024 replaced Manifold with the pure-Rust CSG kernel, the geometry pipeline lost the implicit degenerate-output cleanup Manifold did on import. Faceted breps, extrusion-profile walls, and walls with openings started rendering visible needle **spikes** and jagged silhouettes — zero-area / collinear sliver triangles that other viewers don't show because they clean degenerates on import.

## Root cause (validated by data, not screenshots)

The spikes are genuine **degenerate triangles**: coincident-pair needles from duplicated profile/brep vertices, and collinear slivers from redundant collinear vertices, plus a few introduced by CSG opening cuts. Using a scale-aware damage metric with a *local-frame control* (recentre each mesh to its centroid to separate genuine degeneracy from f32-world-storage):

| | genuine degenerate slivers | triangles | geom time |
|---|---|---|---|
| before | **861** | 222,042 | 0.82 s |
| after | **0** | 219,744 (−1.0%) | 0.78 s |

A threshold sweep showed the triangle count is **flat from 10–50 µm** (no real geometry lives there) and only starts removing real geometry at ~100 µm — a clean gap. The kernel's own reconcile grid (`1/65536 m ≈ 15.3 µm`) sits in that dead zone.

The residual f32-world-storage damage (real thin triangles at a few hundred metres of georef offset) is a **separate** RTC/local-frame concern and is deliberately left untouched.

## Fix

`Mesh::drop_thin_triangles(h_eps)` drops triangles whose perpendicular height (`2·area / longest_edge`) is below `h_eps`; `Mesh::clean_degenerate()` calls it at the kernel grid. Applied at **every** mesh-output chokepoint so wasm (viewer) and native (server) get identical output:
- `process_element` (combined mesh) and `process_element_submeshes` (per sub-mesh)
- the type-geometry / textured `RepresentationMap` channel
- the layered material-slice gateway (`try_layered_sub_meshes`)
- both void-cut outputs

It **does not weld vertices** — the pipeline emits per-face flat-shaded facet soup on purpose (#846); welding would re-smooth creases. It edits only indices (positions/normals untouched), so it is visually lossless, preserves flat shading, and is bit-deterministic (FMA-free f64 threshold).

## Why a post-pass drop (not an upstream tessellation fix)

This is the layer Manifold operated at, and slivers arrive from many sources (brep faces, extrusion profiles, CSG cuts). One drop at the output chokepoints covers them uniformly — fixing each tessellator separately is the parallel-paths trap. Investigating *why* specific tessellators emit redundant collinear vertices is a reasonable follow-up.

## Testing

- All **53 geometry test binaries pass** (446 tests), incl. watertightness, CSG quality, void production/submesh, wall-opening-cut, and the #846 revolved-beam crease test.
- **7 new unit tests** for `drop_thin_triangles` / `clean_degenerate`: collinear sliver, coincident-pair needle, thin-but-real kept, no-crack-in-a-closed-solid, OOB/collapsed skip, idempotence, grid threshold.
- 2 insta snapshots re-pinned (both spike-count improvements; surface area lossless). The weekly determinism job re-asserts these byte-for-byte on arm64.

The change was adversarially reviewed across 5 lenses (math/edge-cases, cross-arch determinism, watertightness, "is it a band-aid?", path coverage); the two coverage gaps it surfaced (textured channel, layered walls) are fixed here.

## Known limitation (documented in code)

The void-cut output is cleaned in world coordinates (the cut runs there), so on a model georeferenced a few hundred metres–10 km from origin (below the RTC re-basing threshold) the 15.3 µm margin near opening seams erodes slightly; the `longest <= 0` guard still catches full collapse at extreme scale. The non-void tessellation path cleans in local frame (precise). Tracked alongside the RTC/local-frame work.

## Relationship to other PRs

- **Supersedes #1111** — this height-based drop replaces the aspect-ratio backstop (which missed collinear slivers).
- **Orthogonal to #1112** — that fixes the #1109 escalation hang (performance), not slivers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed faceted geometry rendering spikes caused by degenerate "sliver triangles" from collinear or zero-area mesh elements.
  * Degenerate triangles below the CSG reconcile grid threshold are now removed across all geometry processing pathways, while preserving vertex data for sharp creases and consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->