### PR TITLE
feat(geometry): per-element local frame — eliminate f32 fan corruption (supersedes #1113)

### DIFF
--- a/.changeset/geometry-degenerate-f32-triangle-backstop.md
+++ b/.changeset/geometry-degenerate-f32-triangle-backstop.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Drop degenerate f32 triangles so large georeferenced models stop showing gross "fan" corruption.
+
+When a mesh is stored at f32 precision while its vertices sit at building-scale world coordinates (e.g. a model whose extent reaches ~220 m from the coordinate origin), the f32 mantissa only resolves ~15 µm there. Vertices closer together than one ULP round to the same — or near-same — f32 value, so the triangles joining them collapse into zero-area slivers; when the third vertex is far away the result is a long, thin triangle that visibly fans across the whole model.
+
+`Mesh::drop_degenerate_triangles` now runs in `build_mesh_data` — the single funnel every element `MeshData` passes through on both the native and WASM pipelines — and removes only unambiguously-degenerate triangles: a bit-identical f32 vertex pair (exact zero area) or an aspect ratio above 1e5. These slivers carry no area, so neighbouring triangles of the same face already cover the surface and the removal is visually lossless. On a 54 MB georeferenced building model this drops all 664 catastrophic fans (0.29% of triangles) with no change to the remaining geometry, no kernel-determinism impact (predicate-sign manifests unchanged), and the synthetic-coordinate correctness harness stays byte-identical. The complete fix (local-frame / tiled vertex storage that keeps the vertices distinct) is tracked separately; this is the backstop that keeps the viewer clean meanwhile.

--- a/.changeset/geometry-drop-sliver-triangles.md
+++ b/.changeset/geometry-drop-sliver-triangles.md
@@ -1,0 +1,21 @@
+---
+"@ifc-lite/geometry": patch
+"@ifc-lite/wasm": patch
+---
+
+Drop sub-grid sliver triangles so faceted geometry stops rendering spikes
+
+After the pure-Rust CSG kernel replaced Manifold (#1024), the pipeline no longer
+cleaned the degenerate output Manifold used to remove on import. Faceted breps,
+extrusion-profile walls and walls with openings could therefore render visible
+needle "spikes" and jagged silhouettes coming from zero-area / collinear sliver
+triangles (other viewers don't show them because they clean degenerates on import).
+
+`Mesh::clean_degenerate` now drops triangles whose perpendicular height is below the
+kernel's reconcile grid (1/65536 m ≈ 15.3 µm) — sub-resolution coincident-pair and
+collinear slivers that carry no area. It runs at every mesh-output chokepoint
+(per element, per sub-mesh, and on the void-cut output), so both wasm (viewer) and
+native (server) get identical output. Vertices and normals are left untouched, so
+flat shading / sharp creases are preserved and the result is bit-deterministic. On a
+large faceted-brep building this removes 100% of the genuine degenerate slivers for a
+~1% triangle reduction with no performance cost.

--- a/.changeset/per-element-local-frame.md
+++ b/.changeset/per-element-local-frame.md
@@ -1,0 +1,20 @@
+---
+"@ifc-lite/geometry": minor
+"@ifc-lite/renderer": minor
+"@ifc-lite/wasm": patch
+"@ifc-lite/cache": patch
+"@ifc-lite/drawing-2d": patch
+"@ifc-lite/export": patch
+"@ifc-lite/clash": patch
+"@ifc-lite/spatial": patch
+---
+
+Per-element local frame: eliminate f32 "fan" corruption on building-scale and georeferenced models.
+
+When a mesh is stored at f32 precision while its vertices sit at building-scale world coordinates (a model whose extent reaches ~200 m from the coordinate origin), the f32 mantissa only resolves ~15 µm there, so vertices closer than one ULP collapse to the same value and the triangles joining them fan out as long needles across the model. Lowering the global RTC threshold is the wrong lever (it is reserved for >10 km federation re-basing), and a single global recentre still leaves the model genuinely spanning ~200 m.
+
+Each element's vertices are now stored RELATIVE to a per-element `MeshData.origin` (the f64 AABB centre, snapped to the kernel reconcile grid `1/65536 m`), so the f32 coordinates stay element-small and collapse-free at any building or georef scale; the world position is `origin + position`. The renderer reconstructs world space with a per-batch model-matrix translate around a single shared scene origin (so abutting elements in different colour batches stay bit-coincident with no seam z-fighting), and the selection-highlight / GPU-picker buffers replicate the batch's exact f32 path so highlights are bit-coincident with no depth bias. The local frame is ON for the wasm (viewer) path and opt-in for native/server, so determinism snapshots and server output stay absolute-coordinate byte-identical.
+
+Every world-space consumer of element geometry now folds `origin` (`world = origin + position`): camera/scene bounds, the CPU raycast + BVH narrow phase, snap detection, the section cutters (CPU + GPU), the BIM↔scan deviation BVH, the spatial index, clash (world-frame triangles fed to both the TS and Rust kernels), the glTF / IFC5 / Parquet exporters, the Cesium GLB overlay, the construction-projection outline + storey-band derivation, and the federation alignment / mesh-duplicate paths. `MeshData.origin` is serialized in the geometry cache (format version 6, which auto-heals stale entries). Position differences (normals, edge vectors, areas) are origin-invariant and unchanged.
+
+This composes with the sub-grid sliver hygiene pass: the local frame removes the f32-storage fans, and `Mesh::clean_degenerate` removes the sub-grid slivers the finer-grained CSG host emits.

--- a/apps/viewer/src/components/mcp/PlaygroundViewer.tsx
+++ b/apps/viewer/src/components/mcp/PlaygroundViewer.tsx
@@ -577,6 +577,11 @@ function createScene(container: HTMLElement): SceneHandle {
           clippingPlanes: sectionPlanes,
         });
         const mesh = new THREE.Mesh(geom, mat);
+        // Geometry buffers stay in the element's local frame for f32 precision;
+        // the per-mesh origin (already in the renderer Y-up frame) goes into the
+        // mesh transform so world = origin + position — mirroring the renderer's
+        // per-batch model-matrix translate. No-op when origin is absent.
+        if (md.origin) mesh.position.set(md.origin[0], md.origin[1], md.origin[2]);
         mesh.userData.expressId = md.expressId;
         mesh.userData.ifcType = md.ifcType;
         modelGroup.add(mesh);

--- a/apps/viewer/src/components/viewer/CesiumOverlay.tsx
+++ b/apps/viewer/src/components/viewer/CesiumOverlay.tsx
@@ -75,7 +75,20 @@ function buildMergedGLB(meshes: import('@ifc-lite/geometry').MeshData[]): Uint8A
   for (const m of meshes) {
     if (!m.positions?.length || !m.indices?.length) continue;
     const nv = m.positions.length / 3;
-    positions.set(m.positions, vertOff * 3);
+    // Positions are in the element's local frame (world = origin + position);
+    // fold the per-mesh origin while merging so the GLB is world-space. No-op
+    // when origin is absent/[0,0,0].
+    const ox = m.origin?.[0] ?? 0, oy = m.origin?.[1] ?? 0, oz = m.origin?.[2] ?? 0;
+    if (ox !== 0 || oy !== 0 || oz !== 0) {
+      for (let i = 0; i < nv; i++) {
+        const s = (vertOff + i) * 3, t = i * 3;
+        positions[s] = m.positions[t] + ox;
+        positions[s + 1] = m.positions[t + 1] + oy;
+        positions[s + 2] = m.positions[t + 2] + oz;
+      }
+    } else {
+      positions.set(m.positions, vertOff * 3);
+    }
     // Vertex colors from mesh color
     const r = Math.round((m.color?.[0] ?? 0.7) * 255);
     const g = Math.round((m.color?.[1] ?? 0.7) * 255);

--- a/apps/viewer/src/components/viewer/PropertiesPanel.tsx
+++ b/apps/viewer/src/components/viewer/PropertiesPanel.tsx
@@ -329,8 +329,13 @@ export function PropertiesPanel() {
       if (mesh.expressId !== targetExpressId) continue;
       found = true;
       const pos = mesh.positions;
+      // Positions are in the element's local frame (world = origin + position);
+      // fold the per-mesh origin so the reported bbox/centre is in the render
+      // frame, matching scene.getEntityBoundingBox. No-op when origin absent.
+      const o = mesh.origin;
+      const ox = o ? o[0] : 0, oy = o ? o[1] : 0, oz = o ? o[2] : 0;
       for (let i = 0; i < pos.length; i += 3) {
-        const x = pos[i], y = pos[i + 1], z = pos[i + 2];
+        const x = pos[i] + ox, y = pos[i + 1] + oy, z = pos[i + 2] + oz;
         if (x < minX) minX = x;
         if (y < minY) minY = y;
         if (z < minZ) minZ = z;

--- a/apps/viewer/src/components/viewer/useGeometryStreaming.ts
+++ b/apps/viewer/src/components/viewer/useGeometryStreaming.ts
@@ -634,8 +634,13 @@ function computeBounds(meshes: MeshData[]): { min: { x: number; y: number; z: nu
   let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
   for (let gi = 0; gi < meshes.length; gi++) {
     const positions = meshes[gi].positions;
+    // world = origin + position (per-element local frame); without folding the
+    // origin every element's local positions cluster near 0, so the camera fits
+    // to the origin while geometry draws at its true world coords → blank view.
+    const o = meshes[gi].origin;
+    const ox = o ? o[0] : 0, oy = o ? o[1] : 0, oz = o ? o[2] : 0;
     for (let i = 0; i < positions.length; i += 3) {
-      const x = positions[i], y = positions[i + 1], z = positions[i + 2];
+      const x = positions[i] + ox, y = positions[i + 1] + oy, z = positions[i + 2] + oz;
       if (Math.abs(x) < MAX_VALID_COORD && Math.abs(y) < MAX_VALID_COORD && Math.abs(z) < MAX_VALID_COORD) {
         if (x < minX) minX = x; if (y < minY) minY = y; if (z < minZ) minZ = z;
         if (x > maxX) maxX = x; if (y > maxY) maxY = y; if (z > maxZ) maxZ = z;

--- a/apps/viewer/src/hooks/ingest/federationAlign.ts
+++ b/apps/viewer/src/hooks/ingest/federationAlign.ts
@@ -223,10 +223,17 @@ function applyAlignmentTransformAndUpdateBounds(
 
   for (const mesh of geometry.meshes) {
     const positions = mesh.positions;
+    // Positions may be in the element's local frame (world = origin + position)
+    // on the wasm path. Fold the per-mesh origin into the world coord BEFORE the
+    // alignment affine; the result is written as absolute reference-frame coords
+    // and the stale origin is cleared below (else the renderer's model-matrix
+    // translate would double-count it). No-op when origin is absent/[0,0,0].
+    const o = mesh.origin;
+    const ox = o ? o[0] : 0, oy = o ? o[1] : 0, oz = o ? o[2] : 0;
     for (let i = 0; i < positions.length; i += 3) {
-      const x = positions[i];
-      const y = positions[i + 1];
-      const z = positions[i + 2];
+      const x = positions[i] + ox;
+      const y = positions[i + 1] + oy;
+      const z = positions[i + 2] + oz;
       if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) {
         continue;
       }
@@ -239,6 +246,9 @@ function applyAlignmentTransformAndUpdateBounds(
       positions[i + 2] = alignedZ;
       found = updateBounds(bounds, alignedX, alignedY, alignedZ) || found;
     }
+    // Positions are now absolute in the reference viewer frame; drop the stale
+    // local-frame origin so downstream consumers don't re-add it.
+    if (o) mesh.origin = [0, 0, 0];
 
     // Rotate normals by the transform's 3×3 linear part (translation omitted)
     // and renormalize. CRS alignment is a rigid rotation, so the linear part
@@ -330,10 +340,16 @@ async function alignGeometryAcrossCrs(
 
   for (const mesh of geometry.meshes) {
     const positions = mesh.positions;
+    // Fold the per-element local-frame origin into the world coord before the
+    // reprojection (proj4 is nonlinear, so it must run on the absolute world
+    // vertex). Output is absolute reference-frame coords; the stale origin is
+    // cleared below. No-op when origin is absent/[0,0,0].
+    const o = mesh.origin;
+    const oox = o ? o[0] : 0, ooy = o ? o[1] : 0, ooz = o ? o[2] : 0;
     for (let i = 0; i < positions.length; i += 3) {
-      const vx = positions[i];
-      const vy = positions[i + 1];
-      const vz = positions[i + 2];
+      const vx = positions[i] + oox;
+      const vy = positions[i + 1] + ooy;
+      const vz = positions[i + 2] + ooz;
       if (!Number.isFinite(vx) || !Number.isFinite(vy) || !Number.isFinite(vz)) continue;
 
       // viewer(Y-up, source-local) → world(Y-up) → IFC(Z-up, source)
@@ -391,6 +407,9 @@ async function alignGeometryAcrossCrs(
       positions[i + 2] = alignedZ;
       found = updateBounds(bounds, alignedX, alignedY, alignedZ) || found;
     }
+    // Positions are now absolute in the reference viewer frame; drop the stale
+    // local-frame origin so downstream consumers don't re-add it.
+    if (o) mesh.origin = [0, 0, 0];
   }
 
   if (!found) {

--- a/apps/viewer/src/hooks/useDrawingGeneration.ts
+++ b/apps/viewer/src/hooks/useDrawingGeneration.ts
@@ -700,9 +700,24 @@ export function useDrawingGeneration({
       // build → the generator falls back to the TS mesh silhouette.
       const outlineProvider =
         projectionOn && typeof meshOutline2dFn === 'function'
-          ? (mesh: { positions: Float32Array; indices: Uint32Array }, axis: 'x' | 'y' | 'z', flipped: boolean): MeshOutline2D | null => {
+          ? (mesh: { positions: Float32Array; indices: Uint32Array; origin?: readonly number[] }, axis: 'x' | 'y' | 'z', flipped: boolean): MeshOutline2D | null => {
               try {
-                const handle = meshOutline2dFn(mesh.positions, mesh.indices, AXIS_CODE[axis], flipped);
+                // Positions are in the element's local frame (world = origin +
+                // position). Feed WORLD positions to the outline extractor so its
+                // contours + axisMin/axisMax come back in the same render-frame
+                // world space as the (origin-folded) section cut. No-op when the
+                // origin is absent/[0,0,0].
+                const o = mesh.origin;
+                let outlinePositions = mesh.positions;
+                if (o && (o[0] !== 0 || o[1] !== 0 || o[2] !== 0)) {
+                  outlinePositions = new Float32Array(mesh.positions.length);
+                  for (let i = 0; i < mesh.positions.length; i += 3) {
+                    outlinePositions[i] = mesh.positions[i] + o[0];
+                    outlinePositions[i + 1] = mesh.positions[i + 1] + o[1];
+                    outlinePositions[i + 2] = mesh.positions[i + 2] + o[2];
+                  }
+                }
+                const handle = meshOutline2dFn(outlinePositions, mesh.indices, AXIS_CODE[axis], flipped);
                 if (!handle) return null;
                 try {
                   const contours: Float32Array[] = [];

--- a/apps/viewer/src/store/slices/mutationSlice.ts
+++ b/apps/viewer/src/store/slices/mutationSlice.ts
@@ -161,12 +161,16 @@ function cloneMeshesWithOffset(
   const out: MeshData[] = [];
   for (const m of meshes) {
     if (m.expressId !== sourceGlobalId) continue;
-    const positions = new Float32Array(m.positions.length);
-    for (let i = 0; i < m.positions.length; i += 3) {
-      positions[i]     = m.positions[i]     + viewerOffset.x;
-      positions[i + 1] = m.positions[i + 1] + viewerOffset.y;
-      positions[i + 2] = m.positions[i + 2] + viewerOffset.z;
-    }
+    // Positions are in the element's local frame (world = origin + position).
+    // Keep the buffer verbatim-local (f32-precise) and fold the duplicate's
+    // viewerOffset into the per-element origin instead, so the copy lands at
+    // original-world + offset without re-quantizing vertices at world scale.
+    const positions = new Float32Array(m.positions);
+    const origin: [number, number, number] = [
+      (m.origin?.[0] ?? 0) + viewerOffset.x,
+      (m.origin?.[1] ?? 0) + viewerOffset.y,
+      (m.origin?.[2] ?? 0) + viewerOffset.z,
+    ];
     out.push({
       expressId: newGlobalId,
       positions,
@@ -175,6 +179,7 @@ function cloneMeshesWithOffset(
       color: m.color,
       ifcType: m.ifcType,
       modelIndex: m.modelIndex,
+      origin,
       // Per-vertex entity ids only matter for color-merged batches;
       // a single-mesh duplicate carries one expressId everywhere.
       entityIds: m.entityIds ? new Uint32Array(m.entityIds.length).fill(newGlobalId) : undefined,

--- a/apps/viewer/src/utils/viewportUtils.ts
+++ b/apps/viewer/src/utils/viewportUtils.ts
@@ -119,10 +119,14 @@ export function getEntityBounds(
   // Aggregate bounds across all submeshes
   // Filter out corrupted/unshifted vertices (> 10km from origin)
   for (const mesh of matchingMeshes) {
+    // world = origin + position (per-element local frame; absent → absolute).
+    const ox = mesh.origin ? mesh.origin[0] : 0;
+    const oy = mesh.origin ? mesh.origin[1] : 0;
+    const oz = mesh.origin ? mesh.origin[2] : 0;
     for (let i = 0; i < mesh.positions.length; i += 3) {
-      const x = mesh.positions[i];
-      const y = mesh.positions[i + 1];
-      const z = mesh.positions[i + 2];
+      const x = mesh.positions[i] + ox;
+      const y = mesh.positions[i + 1] + oy;
+      const z = mesh.positions[i + 2] + oz;
       // Skip corrupted vertices (NaN, Inf, or huge coordinates from unshifted data)
       if (!isValidCoord(x, y, z)) {
         continue;
@@ -191,10 +195,14 @@ export function calculateGeometryBounds(meshes: MeshData[]): BoundingBox3D {
 
   // Filter out corrupted/unshifted vertices (> 10km from origin)
   for (const mesh of meshes) {
+    // world = origin + position (per-element local frame; absent → absolute).
+    const ox = mesh.origin ? mesh.origin[0] : 0;
+    const oy = mesh.origin ? mesh.origin[1] : 0;
+    const oz = mesh.origin ? mesh.origin[2] : 0;
     for (let i = 0; i < mesh.positions.length; i += 3) {
-      const x = mesh.positions[i];
-      const y = mesh.positions[i + 1];
-      const z = mesh.positions[i + 2];
+      const x = mesh.positions[i] + ox;
+      const y = mesh.positions[i + 1] + oy;
+      const z = mesh.positions[i + 2] + oz;
       // Skip corrupted vertices (NaN, Inf, or huge coordinates from unshifted data)
       if (!isValidCoord(x, y, z)) {
         continue;

--- a/packages/cache/src/sections/geometry.ts
+++ b/packages/cache/src/sections/geometry.ts
@@ -96,6 +96,14 @@ export function writeGeometry(
     // type-library geometry reappears in Model mode and the switch disappears.
     writer.writeUint8(mesh.geometryClass ?? 0);
 
+    // Write per-element local-frame origin (v6+, 3×f64): world = origin +
+    // position. [0,0,0] for absolute meshes. Without it a cache from a
+    // local-frame load restores small local positions with no origin → every
+    // element renders scattered near scene origin.
+    writer.writeFloat64(mesh.origin ? mesh.origin[0] : 0);
+    writer.writeFloat64(mesh.origin ? mesh.origin[1] : 0);
+    writer.writeFloat64(mesh.origin ? mesh.origin[2] : 0);
+
     // Write geometry arrays
     writer.writeTypedArray(mesh.positions);
     writer.writeTypedArray(mesh.normals);
@@ -204,6 +212,15 @@ export function readGeometry(reader: BufferReader, version: number = 2): {
     // viewer's bumped cache key, so they re-mesh fresh rather than load here.
     const geometryClass = version >= 5 ? reader.readUint8() : 0;
 
+    // Read per-element local-frame origin (version 6+); world = origin + position.
+    let origin: [number, number, number] | undefined;
+    if (version >= 6) {
+      const ox = reader.readFloat64();
+      const oy = reader.readFloat64();
+      const oz = reader.readFloat64();
+      if (ox || oy || oz) origin = [ox, oy, oz];
+    }
+
     const positions = reader.readFloat32Array(vertexCount * 3);
     const normals = reader.readFloat32Array(vertexCount * 3);
     const indices = reader.readUint32Array(indexCount);
@@ -216,6 +233,7 @@ export function readGeometry(reader: BufferReader, version: number = 2): {
       color,
       ifcType,
       geometryClass,
+      ...(origin ? { origin } : {}),
     });
   }
 

--- a/packages/cache/src/types.ts
+++ b/packages/cache/src/types.ts
@@ -20,8 +20,14 @@ export const MAGIC = 0x4C434649; // "IFCL" in little-endian
  * (class 2) rendered in Model mode and the Model/Types switch vanished
  * (`hasTypeGeometry` saw no non-zero classes). Bumping the version also bumps
  * the viewer's cache key, so stale v4 entries miss and re-mesh fresh.
+ *
+ * v6: per-mesh local-frame `origin` (3×f64) — the per-element AABB-centre the
+ * wasm pipeline stores so building-scale f32 vertices don't collapse into fans
+ * (world = origin + position). Without it, a cache restored from a local-frame
+ * load has small local positions but no origin → every element renders scattered
+ * near scene origin. The bump also invalidates pre-origin caches so they re-mesh.
  */
-export const FORMAT_VERSION = 5;
+export const FORMAT_VERSION = 6;
 
 /** Section types in the binary format */
 export enum SectionType {

--- a/packages/clash/src/adapters/step.ts
+++ b/packages/clash/src/adapters/step.ts
@@ -42,6 +42,21 @@ export interface StepAdapterResult {
   exclusions: ExclusionSet;
 }
 
+/**
+ * Lift local-frame vertices into the model's world frame: `world = origin + local`
+ * (the inverse of the renderer's per-element local frame). Returns a fresh f32
+ * array; only called when `origin` is non-zero.
+ */
+function worldFramePositions(local: Float32Array, o: [number, number, number]): Float32Array {
+  const out = new Float32Array(local.length);
+  for (let i = 0; i + 2 < local.length; i += 3) {
+    out[i] = local[i] + o[0];
+    out[i + 1] = local[i + 1] + o[1];
+    out[i + 2] = local[i + 2] + o[2];
+  }
+  return out;
+}
+
 export function elementsFromStep(options: StepAdapterOptions): StepAdapterResult {
   const { store, meshes, modelId, federation, worldTransform, buildExclusions = true } = options;
 
@@ -52,6 +67,18 @@ export function elementsFromStep(options: StepAdapterOptions): StepAdapterResult
     if (!mesh.positions || mesh.positions.length === 0) continue;
     const expressId = mesh.expressId;
     const node = new EntityNode(store, expressId);
+
+    // The wasm geometry path stores positions in the element's LOCAL frame
+    // (world = origin + position; see `MeshData.origin`). Clash works in world
+    // space — the `ClashElement` contract is world-frame triangles, and the
+    // narrow phase is f32-quantized to stay byte-identical with the Rust kernel
+    // — so fold the per-element origin into a world-frame positions array here.
+    // No-op (shares the input buffer) when origin is absent/zero, e.g. the
+    // native/server path or legacy meshing.
+    const o = mesh.origin;
+    const positions = o && (o[0] !== 0 || o[1] !== 0 || o[2] !== 0)
+      ? worldFramePositions(mesh.positions, o)
+      : mesh.positions;
 
     // Read stored (table-backed) values directly. `node.globalId` / `node.name`
     // fall back to `extractEntityAttributesOnDemand` when the table value is
@@ -74,8 +101,8 @@ export function elementsFromStep(options: StepAdapterOptions): StepAdapterResult
       tag: node.type || mesh.ifcType || 'IfcProduct',
       name: storedName || undefined,
       storey: node.storey()?.name || undefined,
-      bounds: fromPositions(mesh.positions, worldTransform),
-      positions: mesh.positions,
+      bounds: fromPositions(positions, worldTransform),
+      positions,
       indices: mesh.indices,
       transform: worldTransform,
     };

--- a/packages/drawing-2d/src/gpu-section-cutter.ts
+++ b/packages/drawing-2d/src/gpu-section-cutter.ts
@@ -414,8 +414,15 @@ export class GPUSectionCutter {
     let entityCounter = 0;
 
     for (const mesh of meshes) {
-      const { positions, indices, expressId, ifcType, modelIndex } = mesh;
+      const { positions, indices, expressId, ifcType, modelIndex, origin } = mesh;
       const triangleCount = indices.length / 3;
+
+      // Positions are stored in the element's local frame; the GPU plane test
+      // runs in world space, so lift each vertex by the per-mesh origin
+      // (world = origin + local). No-op when origin is absent/[0,0,0].
+      const ox = origin ? origin[0] : 0;
+      const oy = origin ? origin[1] : 0;
+      const oz = origin ? origin[2] : 0;
 
       // Map entity counter to mesh info
       entityMap.set(entityCounter, {
@@ -432,19 +439,19 @@ export class GPUSectionCutter {
         const base = triIdx * 12;
 
         // v0
-        buffer[base + 0] = positions[i0 * 3];
-        buffer[base + 1] = positions[i0 * 3 + 1];
-        buffer[base + 2] = positions[i0 * 3 + 2];
+        buffer[base + 0] = positions[i0 * 3] + ox;
+        buffer[base + 1] = positions[i0 * 3 + 1] + oy;
+        buffer[base + 2] = positions[i0 * 3 + 2] + oz;
         // float 3 = vec3 alignment padding
         // v1
-        buffer[base + 4] = positions[i1 * 3];
-        buffer[base + 5] = positions[i1 * 3 + 1];
-        buffer[base + 6] = positions[i1 * 3 + 2];
+        buffer[base + 4] = positions[i1 * 3] + ox;
+        buffer[base + 5] = positions[i1 * 3 + 1] + oy;
+        buffer[base + 6] = positions[i1 * 3 + 2] + oz;
         // float 7 = vec3 alignment padding
         // v2
-        buffer[base + 8] = positions[i2 * 3];
-        buffer[base + 9] = positions[i2 * 3 + 1];
-        buffer[base + 10] = positions[i2 * 3 + 2];
+        buffer[base + 8] = positions[i2 * 3] + ox;
+        buffer[base + 9] = positions[i2 * 3 + 1] + oy;
+        buffer[base + 10] = positions[i2 * 3 + 2] + oz;
         // entityId (as u32, float slot 11)
         const entityView = new DataView(buffer.buffer, (base + 11) * 4, 4);
         entityView.setUint32(0, entityCounter, true);

--- a/packages/drawing-2d/src/section-cutter.ts
+++ b/packages/drawing-2d/src/section-cutter.ts
@@ -115,7 +115,7 @@ export class SectionCutter {
    */
   cutSingleMesh(mesh: MeshData): MeshCutResult {
     const segments: CutSegment[] = [];
-    const { positions, indices, expressId, ifcType, modelIndex } = mesh;
+    const { positions, indices, expressId, ifcType, modelIndex, origin } = mesh;
 
     const triangleCount = indices.length / 3;
     let intersectedCount = 0;
@@ -125,10 +125,12 @@ export class SectionCutter {
       const i1 = indices[t * 3 + 1];
       const i2 = indices[t * 3 + 2];
 
-      // Get triangle vertices
-      const v0 = this.getVertex(positions, i0);
-      const v1 = this.getVertex(positions, i1);
-      const v2 = this.getVertex(positions, i2);
+      // Get triangle vertices in WORLD space (positions are stored in the
+      // element's local frame; world = origin + local). The section plane is
+      // world-space, so we must lift each vertex by the per-mesh origin.
+      const v0 = this.getVertex(positions, i0, origin);
+      const v1 = this.getVertex(positions, i1, origin);
+      const v2 = this.getVertex(positions, i2, origin);
 
       // Compute signed distances from plane
       const d0 = signedDistanceToPlane(v0, this.planeNormal, this.planeDistance);
@@ -180,9 +182,19 @@ export class SectionCutter {
   /**
    * Get vertex from positions array
    */
-  private getVertex(positions: Float32Array, index: number): Vec3 {
+  private getVertex(
+    positions: Float32Array,
+    index: number,
+    origin?: [number, number, number],
+  ): Vec3 {
     const base = index * 3;
-    return vec3(positions[base], positions[base + 1], positions[base + 2]);
+    return origin
+      ? vec3(
+          positions[base] + origin[0],
+          positions[base + 1] + origin[1],
+          positions[base + 2] + origin[2],
+        )
+      : vec3(positions[base], positions[base + 1], positions[base + 2]);
   }
 
   /**

--- a/packages/drawing-2d/src/storey-bands.ts
+++ b/packages/drawing-2d/src/storey-bands.ts
@@ -25,7 +25,10 @@ import type { ProjectionBandDepths } from './projection-bands.js';
  *  a hard dependency on `@ifc-lite/geometry`'s `MeshData`). */
 export interface StoreyFloorMesh {
   readonly expressId: number;
-  readonly positions: Float32Array; // interleaved [x, y, z, …] in the render frame
+  readonly positions: Float32Array; // interleaved [x, y, z, …] in the element-local frame
+  /** Per-element local-frame origin (world = origin + position). Optional: absent
+   *  on the native/legacy path, in which case positions are already world-space. */
+  readonly origin?: readonly [number, number, number];
 }
 
 /**
@@ -63,9 +66,13 @@ export function storeyFloorsFromMeshes(
     const storeyId = elementToStorey.get(mesh.expressId);
     if (storeyId === undefined) continue;
     const pos = mesh.positions;
+    // Fold the per-element origin so minY is world-Y, matching the section cut
+    // position / axisMin / axisMax (which are world-frame). No-op when absent.
+    const oy = mesh.origin ? mesh.origin[1] : 0;
     let minY = Infinity;
     for (let i = 1; i < pos.length; i += 3) {
-      if (pos[i] < minY) minY = pos[i];
+      const y = pos[i] + oy;
+      if (y < minY) minY = y;
     }
     if (!Number.isFinite(minY)) continue;
     const cur = storeyMinY.get(storeyId);

--- a/packages/export/src/gltf-exporter.ts
+++ b/packages/export/src/gltf-exporter.ts
@@ -22,6 +22,7 @@ interface GLTFScene {
 interface GLTFNode {
     mesh?: number;
     name?: string;
+    translation?: [number, number, number];
     extras?: Record<string, unknown>;
 }
 
@@ -354,6 +355,15 @@ export class GLTFExporter {
             // Node
             const nodeIdx = gltf.nodes.length;
             const node: GLTFNode = { mesh: meshIdx };
+            // Positions/accessor bounds are stored in the element's LOCAL frame
+            // (world = origin + local). Express the per-mesh origin as a glTF
+            // node translation so the buffer keeps small, precise f32 coords
+            // (no fan reintroduction) while the element lands at its world
+            // position. Omitted when origin is absent or all-zero.
+            const mo = mesh.origin;
+            if (mo && (mo[0] !== 0 || mo[1] !== 0 || mo[2] !== 0)) {
+                node.translation = [mo[0], mo[1], mo[2]];
+            }
             if (options.includeMetadata && mesh.expressId !== undefined) {
                 node.extras = mesh.modelIndex !== undefined
                     ? { expressId: mesh.expressId, modelIndex: mesh.modelIndex }

--- a/packages/export/src/ifc5-exporter.ts
+++ b/packages/export/src/ifc5-exporter.ts
@@ -607,13 +607,19 @@ export class Ifc5Exporter {
     let indexOffset = 0;
 
     for (const mesh of meshes) {
+      // Positions are in the element's local frame (world = origin + position);
+      // fold the per-mesh origin to world BEFORE the Y-up→Z-up swap. The IFCX
+      // consumer treats points as absolute, so bake into the points (no per-node
+      // xformop). No-op when origin is absent/[0,0,0].
+      const o = mesh.origin;
+      const ox = o ? o[0] : 0, oy = o ? o[1] : 0, oz = o ? o[2] : 0;
       // Convert positions from Y-up to Z-up
       // Y-up: X=right, Y=up, Z=back
       // Z-up: X=right, Y=forward, Z=up
       for (let i = 0; i < mesh.positions.length; i += 3) {
-        const x = mesh.positions[i];
-        const y = mesh.positions[i + 1];   // Y-up Y = Z-up Z
-        const z = mesh.positions[i + 2];   // Y-up Z = -Z-up Y
+        const x = mesh.positions[i] + ox;
+        const y = mesh.positions[i + 1] + oy;   // Y-up Y = Z-up Z
+        const z = mesh.positions[i + 2] + oz;   // Y-up Z = -Z-up Y
         allPoints.push([x, -z, y]);
       }
 

--- a/packages/export/src/parquet-exporter.ts
+++ b/packages/export/src/parquet-exporter.ts
@@ -182,7 +182,19 @@ export class ParquetExporter {
         const allNormals: number[] = [];
 
         for (const mesh of this.geometryResult.meshes) {
-            allPositions.push(...Array.from(mesh.positions));
+            // Positions are in the element's local frame (world = origin + position).
+            // The BOS columnar layout has no transform column, so bake the per-mesh
+            // origin into the world vertices. Normals are origin-invariant. No-op
+            // when origin is absent/[0,0,0].
+            const o = mesh.origin;
+            if (o && (o[0] !== 0 || o[1] !== 0 || o[2] !== 0)) {
+                const p = mesh.positions;
+                for (let i = 0; i < p.length; i += 3) {
+                    allPositions.push(p[i] + o[0], p[i + 1] + o[1], p[i + 2] + o[2]);
+                }
+            } else {
+                allPositions.push(...Array.from(mesh.positions));
+            }
             allNormals.push(...Array.from(mesh.normals));
         }
 

--- a/packages/geometry/src/coordinate-handler.ts
+++ b/packages/geometry/src/coordinate-handler.ts
@@ -108,10 +108,14 @@ export class CoordinateHandler {
 
         for (const mesh of meshes) {
             const positions = mesh.positions;
+            // world = origin + position (per-element local frame); without folding
+            // the origin, bounds collapse to each element's local frame near 0.
+            const o = mesh.origin;
+            const ox = o ? o[0] : 0, oy = o ? o[1] : 0, oz = o ? o[2] : 0;
             for (let i = 0; i < positions.length; i += 3) {
-                const x = positions[i];
-                const y = positions[i + 1];
-                const z = positions[i + 2];
+                const x = positions[i] + ox;
+                const y = positions[i + 1] + oy;
+                const z = positions[i + 2] + oz;
 
                 // Only include values within threshold (filter out outliers/garbage)
                 const coordsFinite = Number.isFinite(x) && Number.isFinite(y) && Number.isFinite(z);
@@ -154,11 +158,15 @@ export class CoordinateHandler {
             const positions = mesh.positions;
             const len = positions.length;
             if (len < 3) continue;
+            // world = origin + position (per-element local frame); without the
+            // origin every element's sampled verts sit near 0 → bounds collapse.
+            const o = mesh.origin;
+            const ox = o ? o[0] : 0, oy = o ? o[1] : 0, oz = o ? o[2] : 0;
 
             // Sample first vertex
-            const x0 = positions[0];
-            const y0 = positions[1];
-            const z0 = positions[2];
+            const x0 = positions[0] + ox;
+            const y0 = positions[1] + oy;
+            const z0 = positions[2] + oz;
             if (x0 < minX) minX = x0;
             if (y0 < minY) minY = y0;
             if (z0 < minZ) minZ = z0;
@@ -168,9 +176,9 @@ export class CoordinateHandler {
 
             // Sample last vertex (if different from first)
             if (len >= 6) {
-                const x1 = positions[len - 3];
-                const y1 = positions[len - 2];
-                const z1 = positions[len - 1];
+                const x1 = positions[len - 3] + ox;
+                const y1 = positions[len - 2] + oy;
+                const z1 = positions[len - 1] + oz;
                 if (x1 < minX) minX = x1;
                 if (y1 < minY) minY = y1;
                 if (z1 < minZ) minZ = z1;

--- a/packages/geometry/src/geometry-coordinate.ts
+++ b/packages/geometry/src/geometry-coordinate.ts
@@ -75,6 +75,13 @@ export function convertMeshCollectionToBatch(
         // directly would copy a fresh Float32Array out of WASM per access.
         const color = mesh.color;
         const geometryHash = geometryHashes.get(mesh.expressId);
+        // Per-element local-frame origin (world = origin + position); [0,0,0] or
+        // absent getter (older bundle) → absolute positions.
+        const originArr = (mesh as { origin?: ArrayLike<number> }).origin;
+        const origin: [number, number, number] | undefined =
+          originArr && originArr.length === 3 && (originArr[0] || originArr[1] || originArr[2])
+            ? [originArr[0], originArr[1], originArr[2]]
+            : undefined;
         const meshData: MeshData = {
           expressId: mesh.expressId,
           ifcType: mesh.ifcType,
@@ -83,6 +90,7 @@ export function convertMeshCollectionToBatch(
           indices: mesh.indices,
           color: [color[0], color[1], color[2], color[3]],
           ...(shadingColor ? { shadingColor } : {}),
+          ...(origin ? { origin } : {}),
           // #957 follow-up: carry the Model/Types geometry class so the viewer's
           // view-mode filter can show/hide type-library geometry.
           geometryClass: (mesh as { geometryClass?: number }).geometryClass ?? 0,

--- a/packages/geometry/src/geometry-parallel.ts
+++ b/packages/geometry/src/geometry-parallel.ts
@@ -266,6 +266,7 @@ export async function* processParallel(
           texture?: MeshData['texture'];
           geometryHash?: bigint;
           geometryClass?: number;
+          origin?: [number, number, number];
         }) => ({
           expressId: m.expressId,
           ifcType: m.ifcType,
@@ -286,6 +287,9 @@ export async function* processParallel(
           // worker→main re-map (else the viewer's view-mode filter sees only
           // class 0 and the Types view renders nothing).
           ...(m.geometryClass !== undefined ? { geometryClass: m.geometryClass } : {}),
+          // Per-element local-frame origin (world = origin + position); the
+          // renderer reconstructs world via a per-batch model-matrix translate.
+          ...(m.origin ? { origin: m.origin } : {}),
         }));
         if (meshes.length > 0) {
           // Update totalMeshes per batch so consumers see a live

--- a/packages/geometry/src/geometry.worker.ts
+++ b/packages/geometry/src/geometry.worker.ts
@@ -490,12 +490,21 @@ function collectMeshes(
             ? [shadingArray[0], shadingArray[1], shadingArray[2], shadingArray[3]]
             : undefined;
         const geometryHash = geometryHashes.get(mesh.expressId);
+        // Per-element local-frame origin (world = origin + position). Older wasm
+        // bundles lack the getter; [0,0,0] means absolute. Metadata only — the
+        // 3-tuple rides structured-clone, NOT pendingTransfers.
+        const originArr = mesh.origin;
+        const origin: [number, number, number] | undefined =
+          originArr && originArr.length === 3 && (originArr[0] || originArr[1] || originArr[2])
+            ? [originArr[0], originArr[1], originArr[2]]
+            : undefined;
         const meshData: MeshData = {
           expressId: mesh.expressId,
           ifcType: mesh.ifcType,
           positions, normals, indices,
           color: [color[0], color[1], color[2], color[3]],
           ...(shadingColor ? { shadingColor } : {}),
+          ...(origin ? { origin } : {}),
           // Provenance for the Model/Types switch (0=occurrence, 1=orphan type,
           // 2=instanced type). Older wasm bundles lack the getter → default 0.
           geometryClass: mesh.geometryClass ?? 0,

--- a/packages/geometry/src/types.ts
+++ b/packages/geometry/src/types.ts
@@ -47,6 +47,13 @@ export interface MeshData {
    *  occurrence — hidden in Model mode, shown in Types mode). Absent/0 for caches
    *  and non-wasm paths. */
   geometryClass?: number;
+  /** Per-element local-frame origin (WebGL Y-up, metres): world position of
+   *  vertex i = `origin + positions[3i..3i+3]`. Present when the wasm pipeline
+   *  emits a per-element frame (building-scale f32 precision); absent/[0,0,0]
+   *  means `positions` are already absolute world coords (legacy / native /
+   *  caches predating local frame). The renderer reconstructs world via a
+   *  per-batch model-matrix translate. */
+  origin?: [number, number, number];
 }
 
 /** A decoded RGBA8 surface texture attached to a mesh (issue #961). */

--- a/packages/renderer/src/bvh.ts
+++ b/packages/renderer/src/bvh.ts
@@ -55,13 +55,21 @@ export class BVH {
         maxY = Math.max(maxY, y);
         maxZ = Math.max(maxZ, z);
       }
+      // Positions are in the element's local frame (world = origin + position).
+      // The ray traverses world space, so store WORLD-space AABBs by adding the
+      // per-mesh origin to all six extents (a pure translation, so the box stays
+      // valid). No-op when origin is absent/[0,0,0].
+      const orig = meshes[m].origin;
+      const ox = orig ? orig[0] : 0;
+      const oy = orig ? orig[1] : 0;
+      const oz = orig ? orig[2] : 0;
       const o = m * 6;
-      aabbs[o] = minX;
-      aabbs[o + 1] = minY;
-      aabbs[o + 2] = minZ;
-      aabbs[o + 3] = maxX;
-      aabbs[o + 4] = maxY;
-      aabbs[o + 5] = maxZ;
+      aabbs[o] = minX + ox;
+      aabbs[o + 1] = minY + oy;
+      aabbs[o + 2] = minZ + oz;
+      aabbs[o + 3] = maxX + ox;
+      aabbs[o + 4] = maxY + oy;
+      aabbs[o + 5] = maxZ + oz;
     }
     this.meshAABBs = aabbs;
 

--- a/packages/renderer/src/deviation/triangle-bvh.ts
+++ b/packages/renderer/src/deviation/triangle-bvh.ts
@@ -81,14 +81,21 @@ export function buildTriangleBVH(
     const positions = mesh.positions;
     const indices = mesh.indices;
     if (!positions || positions.length === 0) continue;
+    // Positions are in the element's local frame (world = origin + position).
+    // The deviation scan runs in world space, so fold the per-mesh origin into
+    // the triangle buffer / centroids / AABBs. The face normal below uses
+    // differences and is origin-invariant. No-op when origin is absent/[0,0,0].
+    const ox = mesh.origin ? mesh.origin[0] : 0;
+    const oy = mesh.origin ? mesh.origin[1] : 0;
+    const oz = mesh.origin ? mesh.origin[2] : 0;
     const n = indices ? indices.length : positions.length / 3;
     for (let i = 0; i + 2 < n; i += 3) {
       const i0 = indices ? indices[i]     * 3 : (i)     * 3;
       const i1 = indices ? indices[i + 1] * 3 : (i + 1) * 3;
       const i2 = indices ? indices[i + 2] * 3 : (i + 2) * 3;
-      const x0 = positions[i0], y0 = positions[i0 + 1], z0 = positions[i0 + 2];
-      const x1 = positions[i1], y1 = positions[i1 + 1], z1 = positions[i1 + 2];
-      const x2 = positions[i2], y2 = positions[i2 + 1], z2 = positions[i2 + 2];
+      const x0 = positions[i0] + ox, y0 = positions[i0 + 1] + oy, z0 = positions[i0 + 2] + oz;
+      const x1 = positions[i1] + ox, y1 = positions[i1 + 1] + oy, z1 = positions[i1 + 2] + oz;
+      const x2 = positions[i2] + ox, y2 = positions[i2 + 1] + oy, z2 = positions[i2 + 2] + oz;
       const off = triIndex * 12;
       triBuf[off]      = x0; triBuf[off + 1]  = y0; triBuf[off + 2]  = z0;
       triBuf[off + 3]  = x1; triBuf[off + 4]  = y1; triBuf[off + 5]  = z1;

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -857,20 +857,27 @@ export class Renderer {
         const interleaved = new Float32Array(interleavedRaw);
         const interleavedU32 = new Uint32Array(interleavedRaw);
 
-        // Fold the per-element origin back into the VBO so this individual mesh
-        // (selection highlight + GPU object-id picker) stays in ABSOLUTE world
-        // space and renders correctly with an identity model matrix — unlike the
-        // batched path, single meshes aren't worth a per-mesh translate. At
-        // single-element extent f32 is precise even at building scale.
-        const ox = meshData.origin ? meshData.origin[0] : 0;
-        const oy = meshData.origin ? meshData.origin[1] : 0;
-        const oz = meshData.origin ? meshData.origin[2] : 0;
+        // Build this individual mesh (selection highlight + GPU object-id picker)
+        // in ABSOLUTE world space so it renders with an identity model matrix.
+        // CRITICAL: replicate the BATCH's exact two-step f32 path so the highlight
+        // is bit-coincident with its source surface (no z-fight, no depth bias):
+        //   batch stores  s = f32(local + (origin - sharedOrigin))   [merge]
+        //   batch shader  world = f32(f32(sharedOrigin) + s)         [draw]
+        // We compute the same `world` here. When there's no shared origin yet
+        // (legacy / pre-batch), fall back to a plain f64 fold (local + origin).
+        const o = meshData.origin;
+        const so = this.scene.getSharedFrameOrigin();
+        const ox = o ? o[0] : 0, oy = o ? o[1] : 0, oz = o ? o[2] : 0;
+        const fr = Math.fround;
+        const sox = so ? fr(so[0]) : null, soy = so ? fr(so[1]) : 0, soz = so ? fr(so[2]) : 0;
+        const dx = so ? (ox - so[0]) : ox, dy = so ? (oy - so[1]) : oy, dz = so ? (oz - so[2]) : oz;
+        const p = meshData.positions;
         for (let i = 0; i < vertexCount; i++) {
             const base = i * 7;
             const posBase = i * 3;
-            interleaved[base] = meshData.positions[posBase] + ox;
-            interleaved[base + 1] = meshData.positions[posBase + 1] + oy;
-            interleaved[base + 2] = meshData.positions[posBase + 2] + oz;
+            interleaved[base] = so ? fr((sox as number) + fr(p[posBase] + dx)) : (p[posBase] + dx);
+            interleaved[base + 1] = so ? fr(soy + fr(p[posBase + 1] + dy)) : (p[posBase + 1] + dy);
+            interleaved[base + 2] = so ? fr(soz + fr(p[posBase + 2] + dz)) : (p[posBase + 2] + dz);
             const hasNormals = meshData.normals.length > 0;
             interleaved[base + 3] = hasNormals ? meshData.normals[posBase] : 0;
             interleaved[base + 4] = hasNormals ? meshData.normals[posBase + 1] : 0;

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -828,10 +828,15 @@ export class Renderer {
 
         for (const mesh of meshes) {
             const positions = mesh.positions;
+            // Positions are in the element's local frame (world = origin + position).
+            // Model bounds are world-space, so fold the per-mesh origin. No-op when
+            // origin is absent/[0,0,0]. Mirrors coordinate-handler.ts.
+            const o = mesh.origin;
+            const ox = o ? o[0] : 0, oy = o ? o[1] : 0, oz = o ? o[2] : 0;
             for (let i = 0; i < positions.length; i += 3) {
-                const x = positions[i];
-                const y = positions[i + 1];
-                const z = positions[i + 2];
+                const x = positions[i] + ox;
+                const y = positions[i + 1] + oy;
+                const z = positions[i + 2] + oz;
                 if (Number.isFinite(x) && Number.isFinite(y) && Number.isFinite(z)) {
                     this.modelBounds.min.x = Math.min(this.modelBounds.min.x, x);
                     this.modelBounds.min.y = Math.min(this.modelBounds.min.y, y);

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -857,12 +857,20 @@ export class Renderer {
         const interleaved = new Float32Array(interleavedRaw);
         const interleavedU32 = new Uint32Array(interleavedRaw);
 
+        // Fold the per-element origin back into the VBO so this individual mesh
+        // (selection highlight + GPU object-id picker) stays in ABSOLUTE world
+        // space and renders correctly with an identity model matrix — unlike the
+        // batched path, single meshes aren't worth a per-mesh translate. At
+        // single-element extent f32 is precise even at building scale.
+        const ox = meshData.origin ? meshData.origin[0] : 0;
+        const oy = meshData.origin ? meshData.origin[1] : 0;
+        const oz = meshData.origin ? meshData.origin[2] : 0;
         for (let i = 0; i < vertexCount; i++) {
             const base = i * 7;
             const posBase = i * 3;
-            interleaved[base] = meshData.positions[posBase];
-            interleaved[base + 1] = meshData.positions[posBase + 1];
-            interleaved[base + 2] = meshData.positions[posBase + 2];
+            interleaved[base] = meshData.positions[posBase] + ox;
+            interleaved[base + 1] = meshData.positions[posBase + 1] + oy;
+            interleaved[base + 2] = meshData.positions[posBase + 2] + oz;
             const hasNormals = meshData.normals.length > 0;
             interleaved[base + 3] = hasNormals ? meshData.normals[posBase] : 0;
             interleaved[base + 4] = hasNormals ? meshData.normals[posBase + 1] : 0;
@@ -1750,6 +1758,17 @@ export class Renderer {
                     tpl[34] = batch.color[2];
                     tpl[35] = alphaForBatch(batch, batch.color[3]);
 
+                    // Per-batch local frame: the batch's vertices are stored
+                    // RELATIVE to batch.origin (f32-small), so set the model
+                    // matrix translation column to origin (world = origin + pos).
+                    // The 12 rotation/scale floats stay identity from the template;
+                    // the translation lives at column-major indices 12/13/14 →
+                    // tpl[28/29/30]. [0,0,0] for legacy absolute batches.
+                    const o = batch.origin;
+                    tpl[28] = o ? o[0] : 0;
+                    tpl[29] = o ? o[1] : 0;
+                    tpl[30] = o ? o[2] : 0;
+
                     device.queue.writeBuffer(batch.uniformBuffer, 0, tpl);
 
                     // Single draw call for entire batch!
@@ -1772,6 +1791,10 @@ export class Renderer {
                 const texturedMeshes = this.scene.getTexturedMeshes();
                 if (texturedMeshes.length > 0) {
                     pass.setPipeline(this.pipeline.getTexturedPipeline());
+                    // Textured meshes carry absolute (origin-0) positions, so the
+                    // model translation must be identity here — reset the column
+                    // that renderBatch left set to the last opaque batch's origin.
+                    tpl[28] = 0; tpl[29] = 0; tpl[30] = 0;
                     for (const tm of texturedMeshes) {
                         // Honour hide/isolate — textured meshes bypass the batch
                         // visibility filtering above, so apply it per-mesh here or

--- a/packages/renderer/src/pipeline.ts
+++ b/packages/renderer/src/pipeline.ts
@@ -225,17 +225,14 @@ export class RenderPipeline {
                 format: this.depthFormat,
                 depthWriteEnabled: false,  // Don't overwrite depth - selected objects render on top of existing depth
                 depthCompare: 'greater-equal',  // Allow rendering at same depth, but still respect objects in front
-                // Per-element local frame: the highlight mesh is a separate
-                // world-absolute VBO while its source surface renders via a
-                // per-batch (relative + model-translate) path, so at building-
-                // scale world coords (~hundreds of m) the two f32 depth paths
-                // diverge by a few ULP and the coincident highlight loses the
-                // greater-equal test on some facets (fragmented highlight). A
-                // small toward-camera bias (positive in reverse-Z) overwhelms
-                // that sub-mm divergence without x-raying through other elements
-                // (which are cm+ away). slopeScale covers angled/curved facets.
-                depthBias: 256,
-                depthBiasSlopeScale: 8,
+                // No depth bias: the highlight mesh's VBO is built to be
+                // BIT-IDENTICAL to how its source surface renders (same shared
+                // origin + same f32 relativization — see createMeshFromData), so
+                // it sits exactly coincident and 'greater-equal' draws it on top
+                // without a bias. A bias here would x-ray the highlight through
+                // neighbouring geometry and spike at grazing angles.
+                depthBias: 0,
+                depthBiasSlopeScale: 0,
             },
             // MSAA configuration - must match render pass attachment sample count
             multisample: {

--- a/packages/renderer/src/pipeline.ts
+++ b/packages/renderer/src/pipeline.ts
@@ -225,8 +225,17 @@ export class RenderPipeline {
                 format: this.depthFormat,
                 depthWriteEnabled: false,  // Don't overwrite depth - selected objects render on top of existing depth
                 depthCompare: 'greater-equal',  // Allow rendering at same depth, but still respect objects in front
-                depthBias: 0,
-                depthBiasSlopeScale: 0,
+                // Per-element local frame: the highlight mesh is a separate
+                // world-absolute VBO while its source surface renders via a
+                // per-batch (relative + model-translate) path, so at building-
+                // scale world coords (~hundreds of m) the two f32 depth paths
+                // diverge by a few ULP and the coincident highlight loses the
+                // greater-equal test on some facets (fragmented highlight). A
+                // small toward-camera bias (positive in reverse-Z) overwhelms
+                // that sub-mm divergence without x-raying through other elements
+                // (which are cm+ away). slopeScale covers angled/curved facets.
+                depthBias: 256,
+                depthBiasSlopeScale: 8,
             },
             // MSAA configuration - must match render pass attachment sample count
             multisample: {

--- a/packages/renderer/src/raycaster.ts
+++ b/packages/renderer/src/raycaster.ts
@@ -56,6 +56,19 @@ export class Raycaster {
       return null;
     }
 
+    // Positions are in the element's local frame (world = origin + position).
+    // Shift the ray ONCE into that local frame instead of offsetting every
+    // triangle vertex — a pure translation, so ray.direction, the distance t and
+    // the normal are all unaffected. The hit point comes back in the local frame
+    // and is lifted to world below. No-op when origin is absent/[0,0,0].
+    const o = mesh.origin;
+    const localRay: Ray = o
+      ? {
+          origin: { x: ray.origin.x - o[0], y: ray.origin.y - o[1], z: ray.origin.z - o[2] },
+          direction: ray.direction,
+        }
+      : ray;
+
     // Ensure triangle count is valid
     if (indices.length % 3 !== 0) {
       console.warn(`Invalid index count for mesh ${mesh.expressId}: ${indices.length}`);
@@ -106,7 +119,7 @@ export class Raycaster {
         continue;
       }
 
-      const intersection = this.intersectTriangle(ray, v0, v1, v2);
+      const intersection = this.intersectTriangle(localRay, v0, v1, v2);
 
       if (intersection && intersection.distance < closestDistance) {
         closestDistance = intersection.distance;
@@ -114,8 +127,14 @@ export class Raycaster {
         // Calculate normal from triangle
         const normal = this.calculateTriangleNormal(v0, v1, v2);
 
+        // intersection.point is in the local frame (computed from localRay);
+        // lift it back to world space for the caller.
+        const worldPoint: Vec3 = o
+          ? { x: intersection.point.x + o[0], y: intersection.point.y + o[1], z: intersection.point.z + o[2] }
+          : intersection.point;
+
         closestIntersection = {
-          point: intersection.point,
+          point: worldPoint,
           normal,
           distance: intersection.distance,
           meshIndex,

--- a/packages/renderer/src/scene-geometry.ts
+++ b/packages/renderer/src/scene-geometry.ts
@@ -21,14 +21,24 @@ let warnedEntityIdRange = false;
  * Layout per vertex: position (3f) + normal (3f) + entityId (1u32) = 7 × 4 bytes.
  * Bounds are tracked during the merge pass to avoid a second iteration.
  */
-export function mergeGeometry(meshDataArray: MeshData[]): {
+export function mergeGeometry(
+  meshDataArray: MeshData[],
+  // A SHARED scene origin used by EVERY batch. Passing the same origin to all
+  // batches is what kills inter-batch seam z-fighting: a world point shared by
+  // two abutting elements in different colour batches relativizes to the SAME
+  // f32 value (stored = world - sharedOrigin) and draws with the SAME model
+  // matrix (translate(sharedOrigin)), so the two surfaces land bit-coincident
+  // instead of diverging by a few f32 ULP. When omitted (first batch / legacy),
+  // the batch's own world bbox centre is used and returned so the caller can
+  // pin it as the shared origin for all subsequent batches.
+  forcedOrigin?: [number, number, number],
+): {
   vertexData: Float32Array;
   indices: Uint32Array;
   bounds: { min: [number, number, number]; max: [number, number, number] };
-  /** Per-batch local-frame origin (world bbox centre). Stored positions are
-   *  RELATIVE to it; the renderer draws this batch with model = translate(origin)
-   *  so f32 vertex coords stay element-small (no building-scale fan collapse).
-   *  [0,0,0] when no mesh carried an origin (legacy absolute positions). */
+  /** The local-frame origin actually used (forcedOrigin, or this batch's world
+   *  bbox centre). Stored positions are RELATIVE to it; the renderer draws with
+   *  model = translate(origin) so f32 vertex coords stay small. */
   origin: [number, number, number];
 } {
   let totalVertices = 0;
@@ -64,9 +74,12 @@ export function mergeGeometry(meshDataArray: MeshData[]): {
       if (x > maxX) maxX = x; if (y > maxY) maxY = y; if (z > maxZ) maxZ = z;
     }
   }
-  const batchOrigin: [number, number, number] = Number.isFinite(minX)
-    ? [(minX + maxX) / 2, (minY + maxY) / 2, (minZ + maxZ) / 2]
-    : [0, 0, 0];
+  // Prefer the caller's shared scene origin (consistent across all batches → no
+  // seam z-fight); fall back to this batch's own world bbox centre.
+  const batchOrigin: [number, number, number] = forcedOrigin
+    ?? (Number.isFinite(minX)
+      ? [(minX + maxX) / 2, (minY + maxY) / 2, (minZ + maxZ) / 2]
+      : [0, 0, 0]);
 
   let indexOffset = 0;
   let vertexBase = 0;

--- a/packages/renderer/src/scene-geometry.ts
+++ b/packages/renderer/src/scene-geometry.ts
@@ -25,6 +25,11 @@ export function mergeGeometry(meshDataArray: MeshData[]): {
   vertexData: Float32Array;
   indices: Uint32Array;
   bounds: { min: [number, number, number]; max: [number, number, number] };
+  /** Per-batch local-frame origin (world bbox centre). Stored positions are
+   *  RELATIVE to it; the renderer draws this batch with model = translate(origin)
+   *  so f32 vertex coords stay element-small (no building-scale fan collapse).
+   *  [0,0,0] when no mesh carried an origin (legacy absolute positions). */
+  origin: [number, number, number];
 } {
   let totalVertices = 0;
   let totalIndices = 0;
@@ -41,9 +46,27 @@ export function mergeGeometry(meshDataArray: MeshData[]): {
   const vertexDataU32 = new Uint32Array(vertexBufferRaw); // entityId lane
   const indices = new Uint32Array(totalIndices);
 
-  // Track bounds during merge (avoids a second pass)
+  // Pre-pass: WORLD bounding box of the batch (world = mesh.origin + position).
+  // batchOrigin = bbox centre; storing vertices relative to it keeps the f32
+  // magnitudes small (≈ half the batch's spatial spread) regardless of the
+  // model's world placement — which is what prevents f32 fan collapse. A mesh
+  // without an origin contributes its absolute positions (legacy no-op shift).
   let minX = Infinity, minY = Infinity, minZ = Infinity;
   let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+  for (const mesh of meshDataArray) {
+    const p = mesh.positions;
+    const ox = mesh.origin ? mesh.origin[0] : 0;
+    const oy = mesh.origin ? mesh.origin[1] : 0;
+    const oz = mesh.origin ? mesh.origin[2] : 0;
+    for (let i = 0; i < p.length; i += 3) {
+      const x = p[i] + ox, y = p[i + 1] + oy, z = p[i + 2] + oz;
+      if (x < minX) minX = x; if (y < minY) minY = y; if (z < minZ) minZ = z;
+      if (x > maxX) maxX = x; if (y > maxY) maxY = y; if (z > maxZ) maxZ = z;
+    }
+  }
+  const batchOrigin: [number, number, number] = Number.isFinite(minX)
+    ? [(minX + maxX) / 2, (minY + maxY) / 2, (minZ + maxZ) / 2]
+    : [0, 0, 0];
 
   let indexOffset = 0;
   let vertexBase = 0;
@@ -52,6 +75,11 @@ export function mergeGeometry(meshDataArray: MeshData[]): {
     const positions = mesh.positions;
     const normals = mesh.normals;
     const vertexCount = positions.length / 3;
+    // Shift this mesh into the batch-local frame: stored = world - batchOrigin
+    // = (mesh.origin - batchOrigin) + localPosition. f64 fold, f32 store.
+    const dox = (mesh.origin ? mesh.origin[0] : 0) - batchOrigin[0];
+    const doy = (mesh.origin ? mesh.origin[1] : 0) - batchOrigin[1];
+    const doz = (mesh.origin ? mesh.origin[2] : 0) - batchOrigin[2];
 
     // Interleave vertex data (position + normal + entityId)
     let outIdx = vertexBase * 7;
@@ -67,24 +95,13 @@ export function mergeGeometry(meshDataArray: MeshData[]): {
     const hasNormals = normals.length > 0;
     for (let i = 0; i < vertexCount; i++) {
       const srcIdx = i * 3;
-      const px = positions[srcIdx];
-      const py = positions[srcIdx + 1];
-      const pz = positions[srcIdx + 2];
-      vertexData[outIdx++] = px;
-      vertexData[outIdx++] = py;
-      vertexData[outIdx++] = pz;
+      vertexData[outIdx++] = positions[srcIdx] + dox;
+      vertexData[outIdx++] = positions[srcIdx + 1] + doy;
+      vertexData[outIdx++] = positions[srcIdx + 2] + doz;
       vertexData[outIdx++] = hasNormals ? normals[srcIdx] : 0;
       vertexData[outIdx++] = hasNormals ? normals[srcIdx + 1] : 0;
       vertexData[outIdx++] = hasNormals ? normals[srcIdx + 2] : 0;
       vertexDataU32[outIdx++] = perVertexEntityIds ? (perVertexEntityIds[i] >>> 0) : entityId;
-
-      // Update bounds
-      if (px < minX) minX = px;
-      if (py < minY) minY = py;
-      if (pz < minZ) minZ = pz;
-      if (px > maxX) maxX = px;
-      if (py > maxY) maxY = py;
-      if (pz > maxZ) maxZ = pz;
     }
 
     // Copy indices with vertex base offset
@@ -101,10 +118,12 @@ export function mergeGeometry(meshDataArray: MeshData[]): {
   return {
     vertexData,
     indices,
+    // WORLD-space bounds (from the pre-pass) so raycast/fit/section stay world.
     bounds: {
       min: [minX, minY, minZ],
       max: [maxX, maxY, maxZ],
     },
+    origin: batchOrigin,
   };
 }
 

--- a/packages/renderer/src/scene-raycaster.ts
+++ b/packages/renderer/src/scene-raycaster.ts
@@ -224,7 +224,7 @@ export function raycastTriangles(
   rayDir: Vec3,
   rayDirInv: Vec3,
   rayDirSign: [number, number, number],
-  meshDataMap: Map<number, { positions: Float32Array; indices: Uint32Array; entityIds?: Uint32Array; modelIndex?: number }[]>,
+  meshDataMap: Map<number, { positions: Float32Array; indices: Uint32Array; entityIds?: Uint32Array; modelIndex?: number; origin?: [number, number, number] }[]>,
   getEntityBoundingBox: (expressId: number) => BoundingBox | null,
   hiddenIds?: Set<number>,
   isolatedIds?: Set<number> | null,
@@ -257,6 +257,15 @@ export function raycastTriangles(
       const indices = piece.indices;
       const pieceEntityIds = piece.entityIds;
 
+      // Positions are in the element's local frame (world = origin + position).
+      // Rather than offset every triangle vertex, shift the ray origin into the
+      // local frame once (a pure translation; rayDir + the returned distance t
+      // are translation-invariant). No-op when origin is absent/[0,0,0].
+      const o = piece.origin;
+      const localRayOrigin: Vec3 = o
+        ? { x: rayOrigin.x - o[0], y: rayOrigin.y - o[1], z: rayOrigin.z - o[2] }
+        : rayOrigin;
+
       for (let i = 0; i < indices.length; i += 3) {
         // For color-merged meshes, skip triangles that don't belong to
         // this entity.
@@ -273,7 +282,7 @@ export function raycastTriangles(
         const v1: Vec3 = { x: positions[i1], y: positions[i1 + 1], z: positions[i1 + 2] };
         const v2: Vec3 = { x: positions[i2], y: positions[i2 + 1], z: positions[i2 + 2] };
 
-        const t = rayTriangleIntersect(rayOrigin, rayDir, v0, v1, v2);
+        const t = rayTriangleIntersect(localRayOrigin, rayDir, v0, v1, v2);
         if (t !== null && t < closestDistance) {
           closestDistance = t;
           closestHit = { expressId, distance: t, modelIndex: piece.modelIndex };

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -143,6 +143,13 @@ export class Scene {
     return this.batchedMeshes;
   }
 
+  /** The shared local-frame origin all batches relativize against (null until
+   *  the first batch is built). Per-mesh highlight/picker VBOs replicate the
+   *  batch's exact f32 path against this so they render bit-coincident. */
+  getSharedFrameOrigin(): [number, number, number] | null {
+    return this.sharedFrameOrigin;
+  }
+
   /**
    * Store MeshData for lazy GPU buffer creation (used for selection highlighting)
    * This avoids creating 2x GPU buffers during streaming

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -902,6 +902,9 @@ export class Scene {
         normals: new Float32Array(normals),
         indices,
         color: meshData.color,
+        // Fragments are subsets of the same source mesh → same local frame.
+        // Preserve origin so each fragment relativizes/renders in world space.
+        ...(meshData.origin ? { origin: meshData.origin } : {}),
       });
     }
 
@@ -1097,10 +1100,14 @@ export class Scene {
 
       for (const piece of pieces) {
         const positions = piece.positions;
+        // world = origin + position (per-element local frame); bake WORLD bbox.
+        const ox = piece.origin ? piece.origin[0] : 0;
+        const oy = piece.origin ? piece.origin[1] : 0;
+        const oz = piece.origin ? piece.origin[2] : 0;
         for (let i = 0; i < positions.length; i += 3) {
-          const x = positions[i];
-          const y = positions[i + 1];
-          const z = positions[i + 2];
+          const x = positions[i] + ox;
+          const y = positions[i + 1] + oy;
+          const z = positions[i + 2] + oz;
           if (x < minX) minX = x;
           if (y < minY) minY = y;
           if (z < minZ) minZ = z;
@@ -1166,10 +1173,14 @@ export class Scene {
 
       for (const piece of pieces) {
         const positions = piece.positions;
+        // world = origin + position (per-element local frame); bake WORLD bbox.
+        const ox = piece.origin ? piece.origin[0] : 0;
+        const oy = piece.origin ? piece.origin[1] : 0;
+        const oz = piece.origin ? piece.origin[2] : 0;
         for (let i = 0; i < positions.length; i += 3) {
-          const x = positions[i];
-          const y = positions[i + 1];
-          const z = positions[i + 2];
+          const x = positions[i] + ox;
+          const y = positions[i + 1] + oy;
+          const z = positions[i + 2] + oz;
           if (x < minX) minX = x;
           if (y < minY) minY = y;
           if (z < minZ) minZ = z;
@@ -1383,6 +1394,9 @@ export class Scene {
       bindGroup,
       uniformBuffer,
       bounds: merged.bounds,
+      // Per-batch local frame: positions are stored relative to this; the draw
+      // loop applies model = translate(origin) so they land in world space.
+      origin: merged.origin,
     };
   }
 
@@ -1395,6 +1409,7 @@ export class Scene {
     vertexData: Float32Array;
     indices: Uint32Array;
     bounds: { min: [number, number, number]; max: [number, number, number] };
+    origin: [number, number, number];
   } {
     return mergeGeometry(meshDataArray);
   }
@@ -1824,10 +1839,14 @@ export class Scene {
     for (const pieces of this.meshDataMap.values()) {
       for (const piece of pieces) {
         const positions = piece.positions;
+        // world = origin + position (per-element local frame).
+        const ox = piece.origin ? piece.origin[0] : 0;
+        const oy = piece.origin ? piece.origin[1] : 0;
+        const oz = piece.origin ? piece.origin[2] : 0;
         for (let i = 0; i < positions.length; i += 3) {
-          const x = positions[i];
-          const y = positions[i + 1];
-          const z = positions[i + 2];
+          const x = positions[i] + ox;
+          const y = positions[i + 1] + oy;
+          const z = positions[i + 2] + oz;
           if (Number.isFinite(x) && Number.isFinite(y) && Number.isFinite(z)) {
             hasValidData = true;
             if (x < minX) minX = x;
@@ -1880,10 +1899,15 @@ export class Scene {
 
     for (const piece of pieces) {
       const positions = piece.positions;
+      // world = origin + position (per-element local frame); origin absent/[0,0,0]
+      // for legacy absolute meshes.
+      const ox = piece.origin ? piece.origin[0] : 0;
+      const oy = piece.origin ? piece.origin[1] : 0;
+      const oz = piece.origin ? piece.origin[2] : 0;
       for (let i = 0; i < positions.length; i += 3) {
-        const x = positions[i];
-        const y = positions[i + 1];
-        const z = positions[i + 2];
+        const x = positions[i] + ox;
+        const y = positions[i + 1] + oy;
+        const z = positions[i + 2] + oz;
         if (x < minX) minX = x;
         if (y < minY) minY = y;
         if (z < minZ) minZ = z;

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -79,6 +79,11 @@ export class Scene {
   private activeBucketKey: Map<string, string> = new Map(); // base colorKey -> current active bucket key
   private nextSplitId: number = 0; // Monotonic counter for sub-bucket keys
   private nextBatchId: number = 0; // Monotonic counter for unique batch identifiers
+  // Shared local-frame origin for ALL batches (set from the first batch's world
+  // bbox centre). Every batch stores positions relative to it and draws with
+  // model = translate(sharedFrameOrigin), so coincident faces across batches
+  // stay bit-coincident (no seam z-fight) while f32 vertex coords stay small.
+  private sharedFrameOrigin: [number, number, number] | null = null;
   private cachedMaxBufferSize: number = 0; // device.limits.maxBufferSize * safety factor (set on first use)
   private static readonly STREAMING_FRAGMENT_MAX_INDICES = 180_000;
   private static readonly STREAMING_FRAGMENT_MAX_VERTEX_BYTES = 8 * 1024 * 1024;
@@ -1343,7 +1348,16 @@ export class Scene {
     pipeline: RenderPipeline,
     bucketKey?: string
   ): BatchedMesh {
-    const merged = this.mergeGeometry(meshDataArray);
+    // Use ONE shared scene origin for every batch (set from the first batch's
+    // world bbox centre). A per-batch origin would make abutting elements in
+    // different colour batches diverge by a few f32 ULP at building-scale world
+    // coords → seam/end-cap z-fighting. A shared origin makes every coincident
+    // world point relativize identically → no seam z-fight, and the model
+    // sits at most ±(model extent) from it (f32-precise at building scale).
+    const merged = this.mergeGeometry(meshDataArray, this.sharedFrameOrigin ?? undefined);
+    if (!this.sharedFrameOrigin && (merged.origin[0] || merged.origin[1] || merged.origin[2])) {
+      this.sharedFrameOrigin = merged.origin;
+    }
     const expressIds = meshDataArray.map(m => m.expressId);
 
     // Create vertex buffer (interleaved positions + normals)
@@ -1405,13 +1419,13 @@ export class Scene {
    * Merge multiple mesh geometries into single vertex/index buffers.
    * Delegates to the extracted mergeGeometry() utility.
    */
-  private mergeGeometry(meshDataArray: MeshData[]): {
+  private mergeGeometry(meshDataArray: MeshData[], forcedOrigin?: [number, number, number]): {
     vertexData: Float32Array;
     indices: Uint32Array;
     bounds: { min: [number, number, number]; max: [number, number, number] };
     origin: [number, number, number];
   } {
-    return mergeGeometry(meshDataArray);
+    return mergeGeometry(meshDataArray, forcedOrigin);
   }
 
   /**
@@ -1786,6 +1800,8 @@ export class Scene {
     this.streamingFragments = [];
     this.destroyOverrideBatches();
     this.colorOverrides = null;
+    // Reset the shared frame origin so the next model picks its own.
+    this.sharedFrameOrigin = null;
     this.meshes = [];
     this.batchedMeshes = [];
     this.buckets.clear();

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -355,6 +355,10 @@ export class Scene {
       normals: outNorm,
       indices: new Uint32Array(tmpIdx),
       color: merged.color,
+      // Extracted vertices are copied verbatim from the merged mesh's local
+      // frame, so carry its origin forward (world = origin + position) — else
+      // raycast/highlight/snap would treat these local coords as world.
+      origin: merged.origin,
     };
   }
 

--- a/packages/renderer/src/snap-detector.ts
+++ b/packages/renderer/src/snap-detector.ts
@@ -623,9 +623,14 @@ export class SnapDetector {
       metadata: { faceIndex: intersection.triangleIndex },
     });
 
-    // Calculate face center (centroid of triangle)
+    // Calculate face center (centroid of triangle). Positions are in the
+    // element's local frame; the intersection point is world-space, so lift
+    // each vertex by the per-mesh origin (world = origin + local).
     const positions = mesh.positions;
     const indices = mesh.indices;
+    const ox = mesh.origin ? mesh.origin[0] : 0;
+    const oy = mesh.origin ? mesh.origin[1] : 0;
+    const oz = mesh.origin ? mesh.origin[2] : 0;
 
     if (indices) {
       const triIndex = intersection.triangleIndex * 3;
@@ -634,19 +639,19 @@ export class SnapDetector {
       const i2 = indices[triIndex + 2] * 3;
 
       const v0: Vec3 = {
-        x: positions[i0],
-        y: positions[i0 + 1],
-        z: positions[i0 + 2],
+        x: positions[i0] + ox,
+        y: positions[i0 + 1] + oy,
+        z: positions[i0 + 2] + oz,
       };
       const v1: Vec3 = {
-        x: positions[i1],
-        y: positions[i1 + 1],
-        z: positions[i1 + 2],
+        x: positions[i1] + ox,
+        y: positions[i1 + 1] + oy,
+        z: positions[i1 + 2] + oz,
       };
       const v2: Vec3 = {
-        x: positions[i2],
-        y: positions[i2 + 1],
-        z: positions[i2 + 2],
+        x: positions[i2] + ox,
+        y: positions[i2 + 1] + oy,
+        z: positions[i2 + 2] + oz,
       };
 
       const center: Vec3 = {

--- a/packages/renderer/src/snap-geometry-cache.ts
+++ b/packages/renderer/src/snap-geometry-cache.ts
@@ -38,13 +38,22 @@ export function buildGeometryCache(mesh: MeshData): MeshGeometryCache {
     };
   }
 
+  // Positions are stored in the element's local frame (world = origin + local).
+  // Snap targets are compared against world-space raycast hit points, so the
+  // cache is built in WORLD space by lifting every absolute vertex read by the
+  // per-mesh origin. (Triangle-normal math below uses position *differences*,
+  // where the origin cancels — those reads are left untouched.)
+  const ox = mesh.origin ? mesh.origin[0] : 0;
+  const oy = mesh.origin ? mesh.origin[1] : 0;
+  const oz = mesh.origin ? mesh.origin[2] : 0;
+
   const vertexMap = new Map<string, Vec3>();
 
   for (let i = 0; i < positions.length; i += 3) {
     const vertex: Vec3 = {
-      x: positions[i],
-      y: positions[i + 1],
-      z: positions[i + 2],
+      x: positions[i] + ox,
+      y: positions[i + 1] + oy,
+      z: positions[i + 2] + oz,
     };
 
     // Skip invalid vertices
@@ -109,14 +118,14 @@ export function buildGeometryCache(mesh: MeshData): MeshGeometryCache {
         const i1 = idx1 * 3;
 
         const v0: Vec3 = {
-          x: positions[i0],
-          y: positions[i0 + 1],
-          z: positions[i0 + 2],
+          x: positions[i0] + ox,
+          y: positions[i0 + 1] + oy,
+          z: positions[i0 + 2] + oz,
         };
         const v1: Vec3 = {
-          x: positions[i1],
-          y: positions[i1 + 1],
-          z: positions[i1 + 2],
+          x: positions[i1] + ox,
+          y: positions[i1 + 1] + oy,
+          z: positions[i1 + 2] + oz,
         };
 
         // Create canonical edge key (smaller index first)

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -68,8 +68,13 @@ export interface BatchedMesh {
   expressIds: number[];  // For picking - all expressIds in this batch
   bindGroup?: GPUBindGroup;
   uniformBuffer?: GPUBuffer;
-  // Bounding box for frustum culling (optional)
+  // Bounding box for frustum culling (optional) — WORLD space.
   bounds?: { min: [number, number, number]; max: [number, number, number] };
+  /** Per-batch local-frame origin: stored vertex positions are RELATIVE to it,
+   *  so this batch must be drawn with model = translate(origin) to land in world
+   *  space (world = origin + position). Keeps f32 vertex coords element-small at
+   *  building/georef scale (no fan collapse). [0,0,0] = absolute (legacy). */
+  origin?: [number, number, number];
 }
 
 // Section plane for clipping

--- a/packages/spatial/src/spatial-index-builder.ts
+++ b/packages/spatial/src/spatial-index-builder.ts
@@ -109,8 +109,17 @@ function computeMeshBounds(mesh: MeshData): AABB {
     maxZ = Math.max(maxZ, z);
   }
 
+  // Positions are in the element's local frame (world = origin + position). The
+  // spatial index is queried in world space, so lift the AABB by the per-mesh
+  // origin. Origin is constant per mesh, so a single add to the final extents is
+  // exact and cheapest. No-op when origin is absent/[0,0,0].
+  const o = mesh.origin;
+  const ox = o ? o[0] : 0;
+  const oy = o ? o[1] : 0;
+  const oz = o ? o[2] : 0;
+
   return {
-    min: [minX, minY, minZ],
-    max: [maxX, maxY, maxZ],
+    min: [minX + ox, minY + oy, minZ + oz],
+    max: [maxX + ox, maxY + oy, maxZ + oz],
   };
 }

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -424,6 +424,12 @@ export class MeshDataJs {
    */
   readonly color: Float32Array;
   /**
+   * Per-element local-frame origin (Float64Array[3], WebGL Y-up, metres):
+   * world position of vertex i = `origin + positions[3i..3i+3]`. Returns
+   * [0,0,0] when positions are absolute (legacy / local frame off).
+   */
+  readonly origin: Float64Array;
+  /**
    * Get indices as Uint32Array (copy to JS)
    */
   readonly indices: Uint32Array;
@@ -885,6 +891,7 @@ export interface InitOutput {
   readonly meshdatajs_ifcType: (a: number, b: number) => void;
   readonly meshdatajs_indices: (a: number) => number;
   readonly meshdatajs_normals: (a: number) => number;
+  readonly meshdatajs_origin: (a: number) => number;
   readonly meshdatajs_positions: (a: number) => number;
   readonly meshdatajs_shadingColor: (a: number, b: number) => void;
   readonly meshdatajs_textureHeight: (a: number) => number;
@@ -901,7 +908,6 @@ export interface InitOutput {
   readonly meshoutlinejs_contourCount: (a: number) => number;
   readonly profilecollection_get: (a: number, b: number) => number;
   readonly profilecollection_length: (a: number) => number;
-  readonly profileentryjs_expressId: (a: number) => number;
   readonly profileentryjs_extrusionDepth: (a: number) => number;
   readonly profileentryjs_extrusionDir: (a: number) => number;
   readonly profileentryjs_holeCounts: (a: number) => number;
@@ -977,6 +983,7 @@ export interface InitOutput {
   readonly init: () => void;
   readonly symbolicpolyline_pointCount: (a: number) => number;
   readonly get_memory: () => number;
+  readonly profileentryjs_expressId: (a: number) => number;
   readonly symbolicfillarea_expressId: (a: number) => number;
   readonly symbolicpolyline_worldY: (a: number) => number;
   readonly symbolictext_colorB: (a: number) => number;

--- a/packages/wasm/pkg/package.json
+++ b/packages/wasm/pkg/package.json
@@ -5,7 +5,7 @@
     "IFC-Lite Contributors"
   ],
   "description": "WebAssembly bindings for IFC-Lite",
-  "version": "3.1.3",
+  "version": "4.0.0",
   "license": "MPL-2.0",
   "repository": {
     "type": "git",

--- a/rust/geometry/src/geom_hash.rs
+++ b/rust/geometry/src/geom_hash.rs
@@ -96,13 +96,15 @@ impl GeometryHasher {
     }
 
     /// Hash the quantized world position of one vertex into a per-corner value.
+    /// `origin` is the per-mesh local-frame origin (`world = origin + position`);
+    /// pass `[0.0; 3]` for absolute-coordinate positions.
     #[inline]
-    fn corner(&self, positions: &[f32], vi: usize) -> [i64; 3] {
+    fn corner(&self, positions: &[f32], vi: usize, origin: &[f64; 3]) -> [i64; 3] {
         let base = vi * 3;
         [
-            quantize(positions[base] as f64 + self.rtc[0], self.inv_tol),
-            quantize(positions[base + 1] as f64 + self.rtc[1], self.inv_tol),
-            quantize(positions[base + 2] as f64 + self.rtc[2], self.inv_tol),
+            quantize(positions[base] as f64 + origin[0] + self.rtc[0], self.inv_tol),
+            quantize(positions[base + 1] as f64 + origin[1] + self.rtc[1], self.inv_tol),
+            quantize(positions[base + 2] as f64 + origin[2] + self.rtc[2], self.inv_tol),
         ]
     }
 
@@ -110,6 +112,15 @@ impl GeometryHasher {
     /// triangle index buffer). Indices that run past the position buffer or
     /// trailing non-triangle remainder are skipped defensively.
     pub fn add_mesh(&mut self, positions: &[f32], indices: &[u32]) {
+        self.add_mesh_with_origin(positions, indices, [0.0; 3]);
+    }
+
+    /// Like [`add_mesh`] but for positions stored in a per-element LOCAL frame:
+    /// `origin` (the per-mesh AABB-centre origin) is folded back so the hash is
+    /// over absolute world coordinates. This keeps the fingerprint identical
+    /// whether the producer emitted absolute positions (native) or local +
+    /// origin (the wasm local-frame path), and still detects element MOVES.
+    pub fn add_mesh_with_origin(&mut self, positions: &[f32], indices: &[u32], origin: [f64; 3]) {
         let vertex_limit = positions.len() / 3;
         let triangle_end = indices.len() - (indices.len() % 3);
         let mut i = 0;
@@ -126,9 +137,9 @@ impl GeometryHasher {
             // starting vertex don't affect the hash — only the (multiset of)
             // positions and their adjacency as a triangle.
             let mut tri = [
-                self.corner(positions, i0),
-                self.corner(positions, i1),
-                self.corner(positions, i2),
+                self.corner(positions, i0, &origin),
+                self.corner(positions, i1, &origin),
+                self.corner(positions, i2, &origin),
             ];
             tri.sort_unstable();
 

--- a/rust/geometry/src/mesh.rs
+++ b/rust/geometry/src/mesh.rs
@@ -426,6 +426,85 @@ impl Mesh {
         self.indices = valid;
     }
 
+    /// Drop triangles that collapsed into degenerate needles when the mesh was
+    /// stored at f32 precision.
+    ///
+    /// At building-scale world coordinates (e.g. ~220 m) an f32 mantissa only
+    /// resolves ~15 µm, so two genuinely-distinct vertices less than one ULP
+    /// apart round to the *same* (or near-same) f32 value. The triangle that
+    /// joined them becomes a zero-area sliver — and when its third vertex is far
+    /// away, a long thin "fan" that visibly spans the model (the gross
+    /// corruption seen on large georeferenced buildings).
+    ///
+    /// These slivers carry effectively no area, so the neighbouring triangles of
+    /// the same face already cover the surface; removing them is visually
+    /// lossless while eliminating the fans. The proper fix (local-frame / tiled
+    /// vertex storage) keeps the vertices distinct in the first place; this is
+    /// the backstop for meshes that still arrive degenerate.
+    ///
+    /// Conservative by design — only drops triangles that are *unambiguously*
+    /// garbage: a bit-identical f32 vertex pair (exact zero area) or an aspect
+    /// ratio (longest edge / shortest edge) above 1e5. Legitimate thin members
+    /// (mullions, braces) sit far below that. Only `indices` change; the vertex
+    /// buffer and per-vertex data are left intact, so the operation is
+    /// deterministic and keeps vertex indices stable.
+    pub fn drop_degenerate_triangles(&mut self) {
+        if self.indices.len() < 3 {
+            return;
+        }
+        const MAX_ASPECT: f64 = 1.0e5;
+        let vertex_count = self.positions.len() / 3;
+        let vert = |i: u32| -> Option<[f64; 3]> {
+            let i = i as usize;
+            if i >= vertex_count {
+                return None;
+            }
+            Some([
+                self.positions[i * 3] as f64,
+                self.positions[i * 3 + 1] as f64,
+                self.positions[i * 3 + 2] as f64,
+            ])
+        };
+        let bits = |i: u32| -> [u32; 3] {
+            let i = i as usize;
+            [
+                self.positions[i * 3].to_bits(),
+                self.positions[i * 3 + 1].to_bits(),
+                self.positions[i * 3 + 2].to_bits(),
+            ]
+        };
+        let dist = |a: [f64; 3], b: [f64; 3]| -> f64 {
+            ((a[0] - b[0]).powi(2) + (a[1] - b[1]).powi(2) + (a[2] - b[2]).powi(2)).sqrt()
+        };
+
+        let mut kept = Vec::with_capacity(self.indices.len());
+        for tri in self.indices.chunks_exact(3) {
+            let (ia, ib, ic) = (tri[0], tri[1], tri[2]);
+            // Bit-identical f32 vertex pair → exact zero-area collapse.
+            let (ba, bb, bc) = (bits(ia), bits(ib), bits(ic));
+            if ba == bb || bb == bc || ba == bc {
+                continue;
+            }
+            let (va, vb, vc) = match (vert(ia), vert(ib), vert(ic)) {
+                (Some(a), Some(b), Some(c)) => (a, b, c),
+                _ => continue, // out-of-range index: drop (matches validate_indices)
+            };
+            let e0 = dist(va, vb);
+            let e1 = dist(vb, vc);
+            let e2 = dist(vc, va);
+            let min_edge = e0.min(e1).min(e2);
+            let max_edge = e0.max(e1).max(e2);
+            // Catastrophic needle: a sliver whose longest edge dwarfs its
+            // shortest by >1e5. min_edge==0 is already handled by the bit check
+            // above, so a finite ratio here means near-but-not-identical f32.
+            if min_edge > 0.0 && max_edge / min_edge > MAX_ASPECT {
+                continue;
+            }
+            kept.extend_from_slice(tri);
+        }
+        self.indices = kept;
+    }
+
     /// Check if mesh is empty
     #[inline]
     pub fn is_empty(&self) -> bool {

--- a/rust/geometry/src/mesh.rs
+++ b/rust/geometry/src/mesh.rs
@@ -1305,6 +1305,7 @@ mod tests {
             normals: vec![],
             indices: vec![0, 1, 2, 3, 4, 5],
             rtc_applied: false,
+            origin: [0.0; 3],
         };
         mesh.drop_thin_triangles(GRID);
         assert_eq!(mesh.indices, vec![3, 4, 5], "sliver dropped, real kept");
@@ -1320,6 +1321,7 @@ mod tests {
             normals: vec![],
             indices: vec![0, 1, 2],
             rtc_applied: false,
+            origin: [0.0; 3],
         };
         mesh.drop_thin_triangles(GRID);
         assert!(mesh.indices.is_empty(), "coincident-pair needle dropped");
@@ -1333,6 +1335,7 @@ mod tests {
             normals: vec![],
             indices: vec![0, 1, 2],
             rtc_applied: false,
+            origin: [0.0; 3],
         };
         mesh.drop_thin_triangles(GRID);
         assert_eq!(mesh.indices, vec![0, 1, 2], "above-grid triangle kept");
@@ -1363,6 +1366,7 @@ mod tests {
                 0, 1, 4, // the degenerate sliver along edge 0→1
             ],
             rtc_applied: false,
+            origin: [0.0; 3],
         };
         mesh.drop_thin_triangles(GRID);
         assert_eq!(
@@ -1383,6 +1387,7 @@ mod tests {
                 0, 0, 0, // fully collapsed (longest == 0) → skipped
             ],
             rtc_applied: false,
+            origin: [0.0; 3],
         };
         mesh.drop_thin_triangles(GRID);
         assert_eq!(mesh.indices, vec![0, 1, 2]);
@@ -1398,6 +1403,7 @@ mod tests {
             normals: vec![],
             indices: vec![0, 1, 2, 3, 4, 5],
             rtc_applied: false,
+            origin: [0.0; 3],
         };
         mesh.drop_thin_triangles(GRID);
         let once = mesh.indices.clone();
@@ -1417,6 +1423,7 @@ mod tests {
             normals: vec![],
             indices: vec![0, 1, 2, 3, 4, 5],
             rtc_applied: false,
+            origin: [0.0; 3],
         };
         mesh.clean_degenerate();
         assert_eq!(mesh.indices, vec![3, 4, 5]);

--- a/rust/geometry/src/mesh.rs
+++ b/rust/geometry/src/mesh.rs
@@ -634,6 +634,101 @@ impl Mesh {
         weld_impl(self, position_eps, None, /*average_normals=*/ true)
     }
 
+    /// Drop triangles whose perpendicular height (= 2·area / longest edge) is
+    /// below `h_eps` metres — i.e. genuinely-degenerate **collinear** slivers
+    /// (three distinct but near-collinear vertices, zero area). These come from
+    /// redundant collinear vertices in source brep faces / extrusion profiles
+    /// triangulated as-is; vertex welding can't merge them (the vertices are
+    /// distinct), so this catches them. At `h_eps` ≈ 15 µm — far below any real
+    /// architectural feature — the dropped triangles carry no area, so the
+    /// surrounding triangulation still covers the face (visually lossless,
+    /// watertight-preserving). Only `indices` change.
+    pub fn drop_thin_triangles(&mut self, h_eps: f64) {
+        if self.indices.len() < 3 {
+            return;
+        }
+        let vertex_count = self.positions.len() / 3;
+        let p = |i: u32| -> [f64; 3] {
+            let i = i as usize;
+            [
+                self.positions[i * 3] as f64,
+                self.positions[i * 3 + 1] as f64,
+                self.positions[i * 3 + 2] as f64,
+            ]
+        };
+        let mut kept = Vec::with_capacity(self.indices.len());
+        for tri in self.indices.chunks_exact(3) {
+            if (tri[0] as usize) >= vertex_count
+                || (tri[1] as usize) >= vertex_count
+                || (tri[2] as usize) >= vertex_count
+            {
+                continue;
+            }
+            let (a, b, c) = (p(tri[0]), p(tri[1]), p(tri[2]));
+            let d = |u: [f64; 3], v: [f64; 3]| {
+                ((u[0] - v[0]).powi(2) + (u[1] - v[1]).powi(2) + (u[2] - v[2]).powi(2)).sqrt()
+            };
+            let longest = d(a, b).max(d(b, c)).max(d(c, a));
+            if longest <= 0.0 {
+                continue; // fully collapsed
+            }
+            let ux = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+            let vx = [c[0] - a[0], c[1] - a[1], c[2] - a[2]];
+            let cr = [
+                ux[1] * vx[2] - ux[2] * vx[1],
+                ux[2] * vx[0] - ux[0] * vx[2],
+                ux[0] * vx[1] - ux[1] * vx[0],
+            ];
+            let area = 0.5 * (cr[0] * cr[0] + cr[1] * cr[1] + cr[2] * cr[2]).sqrt();
+            let height = 2.0 * area / longest;
+            if height < h_eps {
+                continue; // collinear / zero-area sliver
+            }
+            kept.extend_from_slice(tri);
+        }
+        self.indices = kept;
+    }
+
+    /// Mesh hygiene applied to every element mesh before it leaves the router.
+    ///
+    /// Restores the cleanup the pure-Rust pipeline lost when #1024 removed
+    /// Manifold (which implicitly dropped degenerate output). Without it,
+    /// redundant/near-collinear source vertices in faceted breps and extrusion
+    /// profiles get triangulated into visible needle "spikes" and jagged
+    /// silhouettes (the regression reported on large breps); BIMcollab and
+    /// other viewers don't show them because they clean degenerates on import.
+    ///
+    /// Deliberately **does not weld vertices**. The pipeline emits per-face
+    /// flat-shaded facet soup on purpose (each facet keeps its own vertices +
+    /// normal so creases stay sharp — see issue #846); welding would share
+    /// vertices across facets and re-smooth every crease. Instead we drop only
+    /// the genuinely-degenerate triangles via
+    /// [`drop_thin_triangles`](Self::drop_thin_triangles) below the kernel's
+    /// reconcile grid (`1/65536 ≈ 15.3 µm`): coincident-pair needles (area 0)
+    /// and collinear slivers (three distinct near-collinear vertices). The grid
+    /// is the kernel's own representable resolution, so sub-grid triangles are
+    /// degenerate by definition; measured triangle counts are flat from
+    /// 10–50 µm and only start touching real geometry at ~100 µm (6.5× higher),
+    /// confirming nothing real lives in that band. Positions/normals are left
+    /// untouched, so it is visually lossless and bit-deterministic.
+    ///
+    /// The 15.3 µm threshold is most precise when applied in a small-magnitude
+    /// (element-local) frame, where f32 positions resolve well below it — which
+    /// the tessellation chokepoints honour (they clean *before* world
+    /// placement). The void-cut output is cleaned in world coordinates (the cut
+    /// runs there), so on a model georeferenced a few hundred metres to ~10 km
+    /// from origin — below the RTC re-basing threshold — the f32 grid at that
+    /// magnitude approaches the threshold and the margin near opening seams
+    /// erodes slightly; the `longest <= 0` guard still catches full collapse at
+    /// extreme scale. NaN/Inf triangles are kept (the comparison is false),
+    /// i.e. non-finite geometry is left for upstream to handle, never dropped.
+    pub fn clean_degenerate(&mut self) {
+        // 1/65536 m — matches kernel::mesh_bridge::SNAP_GRID (power-of-two for
+        // bit-determinism). Sub-grid triangles are below kernel resolution.
+        const RECONCILE_GRID: f64 = 1.0 / 65536.0;
+        self.drop_thin_triangles(RECONCILE_GRID);
+    }
+
     /// Filter out triangles with edges exceeding the threshold
     /// This removes "stretched" triangles that span unreasonably large distances,
     /// which can occur when disconnected geometry is incorrectly merged.
@@ -1187,5 +1282,143 @@ mod tests {
             origin: [0.0; 3],        };
         mesh.validate_indices();
         assert_eq!(mesh.indices, vec![0, 1, 2, 1, 2, 3]);
+    }
+
+    // ── drop_thin_triangles / clean_degenerate ───────────────────────────
+
+    const GRID: f64 = 1.0 / 65536.0; // ≈ 15.26 µm, the kernel reconcile grid
+
+    #[test]
+    fn drop_thin_removes_collinear_sliver_keeps_real_triangle() {
+        // v0,v1,v2 are near-collinear: v2 sits 5 µm off the v0→v1 line over a
+        // 1 m span — a zero-area sliver. A second, well-formed triangle
+        // (v3,v4,v5, height 0.5 m) must survive.
+        let mut mesh = Mesh {
+            positions: vec![
+                0.0, 0.0, 0.0, // v0
+                1.0, 0.0, 0.0, // v1
+                0.5, 5.0e-6, 0.0, // v2  (5 µm off the line → sliver)
+                0.0, 0.0, 0.0, // v3
+                1.0, 0.0, 0.0, // v4
+                0.5, 0.5, 0.0, // v5  (real, 0.5 m tall)
+            ],
+            normals: vec![],
+            indices: vec![0, 1, 2, 3, 4, 5],
+            rtc_applied: false,
+        };
+        mesh.drop_thin_triangles(GRID);
+        assert_eq!(mesh.indices, vec![3, 4, 5], "sliver dropped, real kept");
+        // Positions/normals are never touched (orphan vertices are fine).
+        assert_eq!(mesh.positions.len(), 18);
+    }
+
+    #[test]
+    fn drop_thin_removes_coincident_pair_needle() {
+        // Two vertices identical → zero area regardless of the third.
+        let mut mesh = Mesh {
+            positions: vec![0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+            normals: vec![],
+            indices: vec![0, 1, 2],
+            rtc_applied: false,
+        };
+        mesh.drop_thin_triangles(GRID);
+        assert!(mesh.indices.is_empty(), "coincident-pair needle dropped");
+    }
+
+    #[test]
+    fn drop_thin_keeps_thin_but_real_triangle_just_above_grid() {
+        // Height 30 µm (> 15.26 µm grid) over a 1 m base — thin but real.
+        let mut mesh = Mesh {
+            positions: vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.5, 30.0e-6, 0.0],
+            normals: vec![],
+            indices: vec![0, 1, 2],
+            rtc_applied: false,
+        };
+        mesh.drop_thin_triangles(GRID);
+        assert_eq!(mesh.indices, vec![0, 1, 2], "above-grid triangle kept");
+    }
+
+    #[test]
+    fn drop_thin_does_not_open_a_crack_in_a_closed_solid() {
+        // A closed tetrahedron with ONE extra degenerate sliver triangle glued
+        // along an existing edge. Dropping the sliver must leave exactly the 4
+        // real faces — i.e. it removes the sliver and nothing else, so the
+        // watertight surface is unchanged (no real face is collateral-dropped).
+        let a = [0.0f32, 0.0, 0.0];
+        let b = [1.0f32, 0.0, 0.0];
+        let c = [0.0f32, 1.0, 0.0];
+        let d = [0.0f32, 0.0, 1.0];
+        let mut pos = vec![];
+        for v in [a, b, c, d] {
+            pos.extend_from_slice(&v);
+        }
+        // sliver vertex on edge a→b, 5 µm off-line
+        pos.extend_from_slice(&[0.5, 5.0e-6, 0.0]); // index 4
+        let mut mesh = Mesh {
+            positions: pos,
+            normals: vec![],
+            indices: vec![
+                0, 1, 2, // 4 tetra faces
+                0, 1, 3, 0, 2, 3, 1, 2, 3, // (winding irrelevant for this test)
+                0, 1, 4, // the degenerate sliver along edge 0→1
+            ],
+            rtc_applied: false,
+        };
+        mesh.drop_thin_triangles(GRID);
+        assert_eq!(
+            mesh.indices,
+            vec![0, 1, 2, 0, 1, 3, 0, 2, 3, 1, 2, 3],
+            "only the sliver dropped; the 4 closed faces are intact"
+        );
+    }
+
+    #[test]
+    fn drop_thin_skips_oob_and_fully_collapsed_without_panic() {
+        let mut mesh = Mesh {
+            positions: vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+            normals: vec![],
+            indices: vec![
+                0, 1, 2, // valid, real
+                0, 1, 9, // out-of-bounds index → skipped
+                0, 0, 0, // fully collapsed (longest == 0) → skipped
+            ],
+            rtc_applied: false,
+        };
+        mesh.drop_thin_triangles(GRID);
+        assert_eq!(mesh.indices, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn drop_thin_is_idempotent() {
+        let mut mesh = Mesh {
+            positions: vec![
+                0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.5, 5.0e-6, 0.0, // sliver
+                0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.5, 0.5, 0.0, // real
+            ],
+            normals: vec![],
+            indices: vec![0, 1, 2, 3, 4, 5],
+            rtc_applied: false,
+        };
+        mesh.drop_thin_triangles(GRID);
+        let once = mesh.indices.clone();
+        mesh.drop_thin_triangles(GRID);
+        assert_eq!(mesh.indices, once, "second pass is a no-op");
+    }
+
+    #[test]
+    fn clean_degenerate_uses_the_reconcile_grid() {
+        // clean_degenerate must drop a 10 µm sliver (below grid) and keep a
+        // 30 µm one (above grid).
+        let mut mesh = Mesh {
+            positions: vec![
+                0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.5, 10.0e-6, 0.0, // below grid
+                0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.5, 30.0e-6, 0.0, // above grid
+            ],
+            normals: vec![],
+            indices: vec![0, 1, 2, 3, 4, 5],
+            rtc_applied: false,
+        };
+        mesh.clean_degenerate();
+        assert_eq!(mesh.indices, vec![3, 4, 5]);
     }
 }

--- a/rust/geometry/src/mesh.rs
+++ b/rust/geometry/src/mesh.rs
@@ -62,6 +62,14 @@ pub struct Mesh {
     /// Set by `FacetedBrepProcessor::process_with_rtc` to prevent
     /// `transform_mesh` from double-subtracting RTC.
     pub rtc_applied: bool,
+    /// Per-mesh local origin (f64), in the RTC/world frame. When non-zero,
+    /// `positions` are stored RELATIVE to this origin (so they stay small and
+    /// f32-precise regardless of the element's world placement), and the world
+    /// position of a vertex is `origin + position`. Set by `transform_mesh_world`
+    /// to the element's centroid so building-scale coordinates (~hundreds of
+    /// metres) never collapse adjacent vertices to bit-identical f32. Default
+    /// `[0, 0, 0]` means positions are already absolute (legacy/local meshes).
+    pub origin: [f64; 3],
 }
 
 /// A sub-mesh with its source geometry item ID.
@@ -135,8 +143,8 @@ impl Mesh {
             positions: Vec::new(),
             normals: Vec::new(),
             indices: Vec::new(),
-            rtc_applied: false,
-        }
+            rtc_applied: false, 
+            origin: [0.0; 3],        }
     }
 
     /// Create a mesh with capacity
@@ -145,8 +153,8 @@ impl Mesh {
             positions: Vec::with_capacity(vertex_count * 3),
             normals: Vec::with_capacity(vertex_count * 3),
             indices: Vec::with_capacity(index_count),
-            rtc_applied: false,
-        }
+            rtc_applied: false, 
+            origin: [0.0; 3],        }
     }
 
     /// Create a mesh from a single triangle
@@ -253,12 +261,27 @@ impl Mesh {
         self.indices.push(i2);
     }
 
-    /// Merge another mesh into this one
+    /// Merge another mesh into this one.
+    ///
+    /// Positions are stored relative to `origin`. The common case is merging
+    /// local/origin-zero meshes (sub-meshes combined BEFORE the world transform),
+    /// where origins match and concatenation is exact. If the two meshes carry
+    /// different non-zero origins, `other` is rebased into self's frame so the
+    /// merged positions stay consistent (correct, though large-coordinate if the
+    /// origins are far apart — which the pre-transform merge order avoids).
     #[inline]
     pub fn merge(&mut self, other: &Mesh) {
         if other.is_empty() {
             return;
         }
+        if self.positions.is_empty() {
+            self.origin = other.origin;
+        }
+        let d = [
+            other.origin[0] - self.origin[0],
+            other.origin[1] - self.origin[1],
+            other.origin[2] - self.origin[2],
+        ];
 
         let vertex_offset = (self.positions.len() / 3) as u32;
 
@@ -267,7 +290,15 @@ impl Mesh {
         self.normals.reserve(other.normals.len());
         self.indices.reserve(other.indices.len());
 
-        self.positions.extend_from_slice(&other.positions);
+        if d == [0.0, 0.0, 0.0] {
+            self.positions.extend_from_slice(&other.positions);
+        } else {
+            for chunk in other.positions.chunks_exact(3) {
+                self.positions.push((chunk[0] as f64 + d[0]) as f32);
+                self.positions.push((chunk[1] as f64 + d[1]) as f32);
+                self.positions.push((chunk[2] as f64 + d[2]) as f32);
+            }
+        }
         self.normals.extend_from_slice(&other.normals);
 
         // Vectorized index offset - more cache-friendly than loop
@@ -292,20 +323,11 @@ impl Mesh {
         self.normals.reserve(total_positions);
         self.indices.reserve(total_indices);
 
-        // Merge all meshes
+        // Delegate to `merge` for origin reconciliation (positions are stored
+        // relative to `origin`; a naive concat would be wrong across differing
+        // origins).
         for mesh in meshes {
-            if !mesh.is_empty() {
-                let vertex_offset = (self.positions.len() / 3) as u32;
-                self.positions.extend_from_slice(&mesh.positions);
-                self.normals.extend_from_slice(&mesh.normals);
-                self.indices
-                    .extend(mesh.indices.iter().map(|&i| i + vertex_offset));
-
-                // Preserve RTC state: if any mesh has RTC applied, the merged result does too
-                if mesh.rtc_applied {
-                    self.rtc_applied = true;
-                }
-            }
+            self.merge(mesh);
         }
     }
 
@@ -401,6 +423,7 @@ impl Mesh {
             normals,
             indices,
             rtc_applied: self.rtc_applied,
+            origin: self.origin,
         }
     }
 
@@ -761,6 +784,7 @@ fn weld_impl(
         normals: new_normals,
         indices: new_indices,
         rtc_applied: mesh.rtc_applied,
+        origin: mesh.origin,
     }
 }
 
@@ -919,8 +943,8 @@ mod tests {
                 0, 1, 5, // invalid: vertex 5 out of bounds
                 3, 4, 5, // invalid: all out of bounds
             ],
-            rtc_applied: false,
-        };
+            rtc_applied: false, 
+            origin: [0.0; 3],        };
         mesh.validate_indices();
         assert_eq!(mesh.indices, vec![0, 1, 2]);
     }
@@ -931,8 +955,8 @@ mod tests {
             positions: vec![],
             normals: vec![],
             indices: vec![0, 1, 2],
-            rtc_applied: false,
-        };
+            rtc_applied: false, 
+            origin: [0.0; 3],        };
         mesh.validate_indices();
         assert!(mesh.indices.is_empty());
     }
@@ -943,8 +967,8 @@ mod tests {
             positions: vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
             normals: vec![],
             indices: vec![0, 1, 2, 0, 1], // trailing incomplete triangle
-            rtc_applied: false,
-        };
+            rtc_applied: false, 
+            origin: [0.0; 3],        };
         mesh.validate_indices();
         assert_eq!(mesh.indices, vec![0, 1, 2]);
     }
@@ -1080,8 +1104,8 @@ mod tests {
             positions: vec![0.0; 12], // 4 vertices
             normals: vec![],
             indices: vec![0, 1, 2, 1, 2, 3],
-            rtc_applied: false,
-        };
+            rtc_applied: false, 
+            origin: [0.0; 3],        };
         mesh.validate_indices();
         assert_eq!(mesh.indices, vec![0, 1, 2, 1, 2, 3]);
     }

--- a/rust/geometry/src/processors/advanced.rs
+++ b/rust/geometry/src/processors/advanced.rs
@@ -101,8 +101,8 @@ impl GeometryProcessor for AdvancedBrepProcessor {
             positions: all_positions,
             normals: Vec::new(),
             indices: all_indices,
-            rtc_applied: false,
-        })
+            rtc_applied: false, 
+            origin: [0.0; 3],        })
     }
 
     fn supported_types(&self) -> Vec<IfcType> {
@@ -156,8 +156,8 @@ impl GeometryProcessor for BSplineSurfaceProcessor {
             positions,
             normals: Vec::new(),
             indices,
-            rtc_applied: false,
-        })
+            rtc_applied: false, 
+            origin: [0.0; 3],        })
     }
 
     fn supported_types(&self) -> Vec<IfcType> {

--- a/rust/geometry/src/processors/brep.rs
+++ b/rust/geometry/src/processors/brep.rs
@@ -337,6 +337,7 @@ impl FacetedBrepProcessor {
             normals: Vec::new(),
             indices,
             rtc_applied: true, // RTC already subtracted during f64→f32 conversion
+            origin: [0.0; 3],
         })
     }
 }
@@ -451,8 +452,8 @@ impl GeometryProcessor for FacetedBrepProcessor {
             positions,
             normals: Vec::new(),
             indices,
-            rtc_applied: false,
-        })
+            rtc_applied: false, 
+            origin: [0.0; 3],        })
     }
 
     fn supported_types(&self) -> Vec<IfcType> {
@@ -613,8 +614,8 @@ impl GeometryProcessor for FaceBasedSurfaceModelProcessor {
             positions: all_positions,
             normals: Vec::new(),
             indices: all_indices,
-            rtc_applied: false,
-        })
+            rtc_applied: false, 
+            origin: [0.0; 3],        })
     }
 
     fn supported_types(&self) -> Vec<IfcType> {
@@ -776,8 +777,8 @@ impl GeometryProcessor for ShellBasedSurfaceModelProcessor {
             positions: all_positions,
             normals: Vec::new(),
             indices: all_indices,
-            rtc_applied: false,
-        })
+            rtc_applied: false, 
+            origin: [0.0; 3],        })
     }
 
     fn supported_types(&self) -> Vec<IfcType> {

--- a/rust/geometry/src/processors/surface.rs
+++ b/rust/geometry/src/processors/surface.rs
@@ -124,8 +124,8 @@ impl GeometryProcessor for SurfaceOfLinearExtrusionProcessor {
             positions,
             normals: Vec::new(),
             indices,
-            rtc_applied: false,
-        })
+            rtc_applied: false, 
+            origin: [0.0; 3],        })
     }
 
     fn supported_types(&self) -> Vec<IfcType> {

--- a/rust/geometry/src/processors/swept.rs
+++ b/rust/geometry/src/processors/swept.rs
@@ -258,8 +258,8 @@ impl GeometryProcessor for SweptDiskSolidProcessor {
             positions,
             normals: Vec::new(),
             indices,
-            rtc_applied: false,
-        })
+            rtc_applied: false, 
+            origin: [0.0; 3],        })
     }
 
     fn supported_types(&self) -> Vec<IfcType> {
@@ -507,8 +507,8 @@ impl GeometryProcessor for RevolvedAreaSolidProcessor {
             positions,
             normals: Vec::new(),
             indices,
-            rtc_applied: false,
-        };
+            rtc_applied: false, 
+            origin: [0.0; 3],        };
 
         // Apply Position to lift Position-local coords into object coords.
         apply_transform(&mut mesh, &position_transform);

--- a/rust/geometry/src/processors/tessellated.rs
+++ b/rust/geometry/src/processors/tessellated.rs
@@ -614,8 +614,8 @@ impl PolygonalFaceSetProcessor {
             positions: flat_positions,
             normals: flat_normals,
             indices: flat_indices,
-            rtc_applied: false,
-        }
+            rtc_applied: false, 
+            origin: [0.0; 3],        }
     }
 
     /// Like [`Self::build_flat_shaded_mesh`] but also emits a per-vertex UV
@@ -701,8 +701,8 @@ impl PolygonalFaceSetProcessor {
                 positions: flat_positions,
                 normals: flat_normals,
                 indices: flat_indices,
-                rtc_applied: false,
-            },
+                rtc_applied: false, 
+                origin: [0.0; 3],            },
             uvs,
         )
     }

--- a/rust/geometry/src/router/layers.rs
+++ b/rust/geometry/src/router/layers.rs
@@ -64,6 +64,15 @@ impl GeometryRouter {
         if collection.sub_meshes.len() < 2 {
             return None;
         }
+        // Mesh hygiene: slicing the base mesh by layer-interface planes can
+        // introduce zero-area/collinear slivers at the cut, and this layered
+        // path early-returns to its callers (process_element_with_submeshes /
+        // _and_voids) BEFORE their own cleanup loop runs — so clean here, the
+        // single gateway both layered call sites share. See clean_degenerate.
+        let mut collection = collection;
+        for sub in &mut collection.sub_meshes {
+            sub.mesh.clean_degenerate();
+        }
         Some(collection)
     }
 

--- a/rust/geometry/src/router/processing.rs
+++ b/rust/geometry/src/router/processing.rs
@@ -521,6 +521,14 @@ impl GeometryRouter {
             }
         }
 
+        // Mesh hygiene before placement (rigid transform preserves geometry, so
+        // welding/dropping in local coords is identical and uses smaller f32
+        // magnitudes). Single chokepoint downstream of every per-item branch,
+        // incl. CSG output — restores the cleanup #1024 lost with Manifold:
+        // redundant/coincident source vertices that otherwise triangulate into
+        // visible needle spikes and jagged silhouettes. See clean_degenerate.
+        combined_mesh.clean_degenerate();
+
         // Apply placement transformation
         self.apply_placement(element, decoder, &mut combined_mesh)?;
 
@@ -651,6 +659,15 @@ impl GeometryRouter {
             for item in items {
                 self.collect_submeshes_from_item(&item, decoder, &mut sub_meshes)?;
             }
+        }
+
+        // Mesh hygiene before placement — same chokepoint as process_element,
+        // applied per sub-mesh for the multi-item (per-style) channel. Rigid
+        // placement preserves geometry, so order is immaterial. (The layered
+        // and textured channels are cleaned at their own sites:
+        // try_layered_sub_meshes and process_representation_map_with_texture.)
+        for sub in &mut sub_meshes.sub_meshes {
+            sub.mesh.clean_degenerate();
         }
 
         // Apply placement transformation to all sub-meshes
@@ -1118,12 +1135,18 @@ impl GeometryRouter {
             if let Some(t) = &origin_transform {
                 self.transform_mesh_local(&mut mesh, t);
             }
+            // Same sliver hygiene as the other mesh-output chokepoints. This is
+            // the type-geometry (RepresentationMap) channel and the only one
+            // carrying a parallel per-vertex UV array; clean_degenerate edits
+            // only indices (vertices/UVs untouched), so the UVs stay in sync.
+            mesh.clean_degenerate();
             out.push((mesh, uvs, Some(texture)));
         }
         if !untextured.is_empty() {
             if let Some(t) = &origin_transform {
                 self.transform_mesh_local(&mut untextured, t);
             }
+            untextured.clean_degenerate();
             out.push((untextured, Vec::new(), None));
         }
 

--- a/rust/geometry/src/router/transforms.rs
+++ b/rust/geometry/src/router/transforms.rs
@@ -766,24 +766,61 @@ impl GeometryRouter {
     pub(super) fn transform_mesh_world(&self, mesh: &mut Mesh, transform: &Matrix4<f64>) {
         let rtc = self.rtc_offset;
         let needs_rtc = self.has_rtc_offset() && !mesh.rtc_applied;
-
-        if needs_rtc {
-            mesh.positions.chunks_exact_mut(3).for_each(|chunk| {
-                let point = Point3::new(chunk[0] as f64, chunk[1] as f64, chunk[2] as f64);
-                let t = transform.transform_point(&point);
-                chunk[0] = (t.x - rtc.0) as f32;
-                chunk[1] = (t.y - rtc.1) as f32;
-                chunk[2] = (t.z - rtc.2) as f32;
-            });
-            mesh.rtc_applied = true;
+        let (rx, ry, rz) = if needs_rtc {
+            (rtc.0, rtc.1, rtc.2)
         } else {
-            mesh.positions.chunks_exact_mut(3).for_each(|chunk| {
+            (0.0, 0.0, 0.0)
+        };
+
+        // Pass 1 — transform every vertex into the world/RTC frame in f64 and track
+        // the AABB. The exact kernel built `positions` in a small local frame, so the
+        // f32 input is precise here; the precision is only lost if we store the
+        // world-magnitude result (building placement ~hundreds of metres) back to f32,
+        // where one ULP (~15 µm at 220 m) collapses adjacent vertices into degenerate
+        // needles. So we defer the world magnitude into a per-mesh `origin`.
+        let mut min = [f64::INFINITY; 3];
+        let mut max = [f64::NEG_INFINITY; 3];
+        let world: Vec<[f64; 3]> = mesh
+            .positions
+            .chunks_exact(3)
+            .map(|chunk| {
                 let point = Point3::new(chunk[0] as f64, chunk[1] as f64, chunk[2] as f64);
                 let t = transform.transform_point(&point);
-                chunk[0] = t.x as f32;
-                chunk[1] = t.y as f32;
-                chunk[2] = t.z as f32;
-            });
+                let w = [t.x - rx, t.y - ry, t.z - rz];
+                for k in 0..3 {
+                    if w[k] < min[k] {
+                        min[k] = w[k];
+                    }
+                    if w[k] > max[k] {
+                        max[k] = w[k];
+                    }
+                }
+                w
+            })
+            .collect();
+
+        // Per-element local origin = AABB centre (f64), deterministic (not a running
+        // mean). Vertices are stored RELATIVE to it, so they stay element-small and
+        // f32-exact at any building/georef scale; the world position is `origin + p`.
+        let origin = if world.is_empty() {
+            [0.0; 3]
+        } else {
+            [
+                (min[0] + max[0]) * 0.5,
+                (min[1] + max[1]) * 0.5,
+                (min[2] + max[2]) * 0.5,
+            ]
+        };
+
+        // Pass 2 — store (world - origin) as f32: small, exact, collapse-free.
+        for (chunk, w) in mesh.positions.chunks_exact_mut(3).zip(world.iter()) {
+            chunk[0] = (w[0] - origin[0]) as f32;
+            chunk[1] = (w[1] - origin[1]) as f32;
+            chunk[2] = (w[2] - origin[2]) as f32;
+        }
+        mesh.origin = origin;
+        if needs_rtc {
+            mesh.rtc_applied = true;
         }
 
         self.transform_normals(mesh, transform);

--- a/rust/geometry/src/router/transforms.rs
+++ b/rust/geometry/src/router/transforms.rs
@@ -764,6 +764,29 @@ impl GeometryRouter {
     /// during raw world-coordinate triangulation are guarded by `rtc_applied`.
     #[inline]
     pub(super) fn transform_mesh_world(&self, mesh: &mut Mesh, transform: &Matrix4<f64>) {
+        // DIAGNOSTIC: temporarily false to isolate the geometry-loss source.
+        self.transform_mesh_world_framed(mesh, transform, false);
+    }
+
+    /// World placement with an explicit choice of whether to relativize positions
+    /// into a per-mesh local `origin`.
+    ///
+    /// `relativize = true` defers the building/georef-scale world magnitude into
+    /// `mesh.origin` (the AABB centre) and stores positions RELATIVE to it, so f32
+    /// can't collapse adjacent vertices into degenerate needles (the gross-fan bug).
+    ///
+    /// `relativize = false` keeps absolute world/RTC coordinates in `positions`.
+    /// The void-cut path needs this: `apply_void_context` matches the host against
+    /// world-coordinate opening cutters, so the host must stay in the world frame
+    /// for the CSG (relativizing only the host silently breaks every cut). The
+    /// void path applies its own shared-origin relativization to the CSG OUTPUT.
+    #[inline]
+    pub(super) fn transform_mesh_world_framed(
+        &self,
+        mesh: &mut Mesh,
+        transform: &Matrix4<f64>,
+        relativize: bool,
+    ) {
         let rtc = self.rtc_offset;
         let needs_rtc = self.has_rtc_offset() && !mesh.rtc_applied;
         let (rx, ry, rz) = if needs_rtc {
@@ -802,7 +825,7 @@ impl GeometryRouter {
         // Per-element local origin = AABB centre (f64), deterministic (not a running
         // mean). Vertices are stored RELATIVE to it, so they stay element-small and
         // f32-exact at any building/georef scale; the world position is `origin + p`.
-        let origin = if world.is_empty() {
+        let origin = if !relativize || world.is_empty() {
             [0.0; 3]
         } else {
             [
@@ -812,7 +835,8 @@ impl GeometryRouter {
             ]
         };
 
-        // Pass 2 — store (world - origin) as f32: small, exact, collapse-free.
+        // Pass 2 — store (world - origin) as f32. When relativized, small + exact +
+        // collapse-free; otherwise absolute world/RTC (origin == 0).
         for (chunk, w) in mesh.positions.chunks_exact_mut(3).zip(world.iter()) {
             chunk[0] = (w[0] - origin[0]) as f32;
             chunk[1] = (w[1] - origin[1]) as f32;

--- a/rust/geometry/src/router/transforms.rs
+++ b/rust/geometry/src/router/transforms.rs
@@ -821,6 +821,28 @@ impl GeometryRouter {
             (0.0, 0.0, 0.0)
         };
 
+        // Fast path — absolute world/RTC coordinates (origin == 0). Used by the
+        // native/server default and the void-cut host (see the doc comment), and
+        // bit-identical to the framed path with origin [0,0,0]
+        // (`(w - 0) as f32 == w as f32`), so determinism snapshots are unaffected.
+        // Avoids the per-element `Vec<[f64;3]>` allocation + second pass the AABB
+        // framing below needs, keeping the absolute path at its original cost.
+        if !relativize {
+            for chunk in mesh.positions.chunks_exact_mut(3) {
+                let point = Point3::new(chunk[0] as f64, chunk[1] as f64, chunk[2] as f64);
+                let t = transform.transform_point(&point);
+                chunk[0] = (t.x - rx) as f32;
+                chunk[1] = (t.y - ry) as f32;
+                chunk[2] = (t.z - rz) as f32;
+            }
+            mesh.origin = [0.0; 3];
+            if needs_rtc {
+                mesh.rtc_applied = true;
+            }
+            self.transform_normals(mesh, transform);
+            return;
+        }
+
         // Pass 1 — transform every vertex into the world/RTC frame in f64 and track
         // the AABB. The exact kernel built `positions` in a small local frame, so the
         // f32 input is precise here; the precision is only lost if we store the

--- a/rust/geometry/src/router/transforms.rs
+++ b/rust/geometry/src/router/transforms.rs
@@ -21,7 +21,20 @@ use nalgebra::Matrix4;
 /// enables it for native verification meanwhile. Read once and cached.
 pub(crate) fn local_frame_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| std::env::var("IFC_LITE_LOCAL_FRAME").is_ok())
+    *ENABLED.get_or_init(|| {
+        // The viewer (wasm) is the precision-critical target: building-scale f32
+        // vertex storage collapses near-edges into fans, fixed by storing each
+        // element relative to its AABB-centre origin (the renderer reconstructs
+        // world = origin + position). Default ON for wasm. Native stays opt-in
+        // (env) so server output + the cross-arch determinism snapshots remain
+        // absolute-coord byte-identical; native consumers reconstruct from
+        // MeshData.origin when they want the local frame.
+        if cfg!(target_arch = "wasm32") {
+            true
+        } else {
+            std::env::var("IFC_LITE_LOCAL_FRAME").is_ok()
+        }
+    })
 }
 
 impl GeometryRouter {
@@ -841,10 +854,18 @@ impl GeometryRouter {
         let origin = if !relativize || world.is_empty() {
             [0.0; 3]
         } else {
+            // Snap the AABB-centre origin to the kernel reconcile grid. The void
+            // CSG relativizes its operands by this origin (subtract it) and then
+            // snaps to SNAP_GRID; `round((x-o)/G) == round(x/G) - o/G` holds ONLY
+            // when `o` is itself a grid multiple. An off-grid origin shifts every
+            // operand off the snap lattice → the cut emits slivers / zero-area
+            // tris (the ~1.4% void loss). Must use the SAME grid as the kernel.
+            const G: f64 = crate::kernel::mesh_bridge::SNAP_GRID;
+            let snap = |lo: f64, hi: f64| (((lo + hi) * 0.5) / G).round() * G;
             [
-                (min[0] + max[0]) * 0.5,
-                (min[1] + max[1]) * 0.5,
-                (min[2] + max[2]) * 0.5,
+                snap(min[0], max[0]),
+                snap(min[1], max[1]),
+                snap(min[2], max[2]),
             ]
         };
 

--- a/rust/geometry/src/router/transforms.rs
+++ b/rust/geometry/src/router/transforms.rs
@@ -10,6 +10,20 @@ use crate::{Error, Mesh, Point2, Point3, Result, TessellationQuality, Vector2, V
 use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcSchema, IfcType};
 use nalgebra::Matrix4;
 
+/// Whether per-element local-frame vertex precision is enabled.
+///
+/// When ON, `transform_mesh_world` stores positions relative to a per-element
+/// f64 `origin` (so f32 coords stay element-small and never collapse to
+/// degenerate fans at building/georef scale), and the void CSG runs in that same
+/// local frame. The renderer + WASM + cache must all consume `MeshData.origin`
+/// (world = origin + position) for this to render correctly — so it stays OFF by
+/// default until that whole stack ships, then flips on. `IFC_LITE_LOCAL_FRAME=1`
+/// enables it for native verification meanwhile. Read once and cached.
+pub(crate) fn local_frame_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var("IFC_LITE_LOCAL_FRAME").is_ok())
+}
+
 impl GeometryRouter {
     /// Apply local placement transformation to mesh
     pub(super) fn apply_placement(
@@ -764,8 +778,7 @@ impl GeometryRouter {
     /// during raw world-coordinate triangulation are guarded by `rtc_applied`.
     #[inline]
     pub(super) fn transform_mesh_world(&self, mesh: &mut Mesh, transform: &Matrix4<f64>) {
-        // DIAGNOSTIC: temporarily false to isolate the geometry-loss source.
-        self.transform_mesh_world_framed(mesh, transform, false);
+        self.transform_mesh_world_framed(mesh, transform, local_frame_enabled());
     }
 
     /// World placement with an explicit choice of whether to relativize positions

--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -989,7 +989,11 @@ impl GeometryRouter {
             }
         };
 
-        Ok(self.apply_voids_to_mesh(wall_mesh, element, opening_ids, decoder))
+        let mut voided = self.apply_voids_to_mesh(wall_mesh, element, opening_ids, decoder);
+        // Clean slivers the CSG cut can introduce at opening seams — same
+        // hygiene as the tessellation chokepoints (Mesh::clean_degenerate).
+        voided.clean_degenerate();
+        Ok(voided)
     }
 
     /// Apply opening subtraction and clipping planes to an already-built mesh.
@@ -1772,7 +1776,9 @@ impl GeometryRouter {
         let mut voided = SubMeshCollection::new();
         for sub in sub_meshes.sub_meshes {
             let geometry_id = sub.geometry_id;
-            let voided_mesh = self.apply_void_context(sub.mesh, &ctx, element.id);
+            let mut voided_mesh = self.apply_void_context(sub.mesh, &ctx, element.id);
+            // Same CSG-seam hygiene as the single-mesh void path.
+            voided_mesh.clean_degenerate();
             if !voided_mesh.is_empty() {
                 voided
                     .sub_meshes

--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -545,6 +545,61 @@ impl VoidContext {
     fn is_noop(&self) -> bool {
         self.openings.is_empty()
     }
+
+    /// Return a copy of this context with every opening (raw + merged)
+    /// translated by `-origin`, i.e. moved from the world frame into the host's
+    /// per-element local frame. Used by [`GeometryRouter::apply_void_context`]
+    /// so the cutters share the host's local frame for the CSG — the missing
+    /// piece that previously made relativizing only the host silently drop cuts.
+    fn relativized_by(&self, origin: [f64; 3]) -> VoidContext {
+        VoidContext {
+            openings: self.openings.iter().map(|o| o.translated(origin)).collect(),
+            merged_openings: self
+                .merged_openings
+                .iter()
+                .map(|o| o.translated(origin))
+                .collect(),
+        }
+    }
+}
+
+/// Translate a cutter mesh's positions by `-origin` in f64 before the f32 store,
+/// moving it into the host's local frame. `origin` is carried on the result as
+/// zero (the mesh is now expressed in the shared local frame).
+fn translate_cutter_mesh(mesh: &Mesh, origin: [f64; 3]) -> Mesh {
+    let mut positions = Vec::with_capacity(mesh.positions.len());
+    for c in mesh.positions.chunks_exact(3) {
+        positions.push((c[0] as f64 - origin[0]) as f32);
+        positions.push((c[1] as f64 - origin[1]) as f32);
+        positions.push((c[2] as f64 - origin[2]) as f32);
+    }
+    Mesh {
+        positions,
+        normals: mesh.normals.clone(),
+        indices: mesh.indices.clone(),
+        rtc_applied: mesh.rtc_applied,
+        origin: [0.0; 3],
+    }
+}
+
+impl OpeningType {
+    /// Return a copy translated by `-origin` (world → host-local frame). Bounds
+    /// (`Point3`) shift; direction vectors and the oriented `OpeningFrame` are
+    /// translation-invariant and pass through unchanged.
+    fn translated(&self, origin: [f64; 3]) -> OpeningType {
+        let sub = |p: &Point3<f64>| Point3::new(p.x - origin[0], p.y - origin[1], p.z - origin[2]);
+        match self {
+            OpeningType::Rectangular(min, max, dir) => {
+                OpeningType::Rectangular(sub(min), sub(max), *dir)
+            }
+            OpeningType::DiagonalRectangular(mesh, frame) => {
+                OpeningType::DiagonalRectangular(translate_cutter_mesh(mesh, origin), *frame)
+            }
+            OpeningType::NonRectangular(mesh, min, max, dir) => {
+                OpeningType::NonRectangular(translate_cutter_mesh(mesh, origin), sub(min), sub(max), *dir)
+            }
+        }
+    }
 }
 
 impl GeometryRouter {
@@ -1004,7 +1059,38 @@ impl GeometryRouter {
     /// [`GeometryRouter::take_csg_failures`]). The router's failure log is
     /// the only path failures reach the caller; `apply_void_context` itself
     /// always returns the (possibly un-cut) mesh.
-    pub(super) fn apply_void_context(&self, mesh: Mesh, ctx: &VoidContext, element_id: u32) -> Mesh {
+    /// Apply a pre-built `VoidContext`, honouring the host's per-element local
+    /// frame.
+    ///
+    /// When local-frame precision is on, the host mesh arrives stored relative
+    /// to `mesh.origin` (small, f32-exact). The CSG must run with host AND
+    /// cutters in that SAME frame, or the cutters (resolved in world coords)
+    /// won't overlap the local host and every cut silently drops — the
+    /// 222692→190201 regression from the first attempt. This wrapper strips the
+    /// origin off the host (so the inner body works in a pure origin-0 local
+    /// frame with no origin-aware-merge surprises), relativizes the cutters by
+    /// the same origin, runs the CSG, then re-stamps the origin on the result so
+    /// `world = origin + position` holds for the renderer.
+    pub(super) fn apply_void_context(
+        &self,
+        mut mesh: Mesh,
+        ctx: &VoidContext,
+        element_id: u32,
+    ) -> Mesh {
+        let origin = mesh.origin;
+        if origin == [0.0, 0.0, 0.0] {
+            // Legacy/world frame: no relativization needed.
+            return self.apply_void_context_inner(mesh, ctx, element_id);
+        }
+        // Work entirely in the host's local frame (origin 0 on every operand).
+        mesh.origin = [0.0, 0.0, 0.0];
+        let local_ctx = ctx.relativized_by(origin);
+        let mut result = self.apply_void_context_inner(mesh, &local_ctx, element_id);
+        result.origin = origin;
+        result
+    }
+
+    fn apply_void_context_inner(&self, mesh: Mesh, ctx: &VoidContext, element_id: u32) -> Mesh {
         // Capture the input triangle count + bounds so the per-host
         // diagnostic can flag the "cuts attempted but produced no
         // change" case — the silent-no-op signature when an opening

--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -713,9 +713,12 @@ impl GeometryRouter {
                     _ => continue,
                 };
 
-                // Use the same transform_mesh as process_element → apply_placement
-                // This handles ObjectPlacement, unit scaling, and conditional RTC
-                self.transform_mesh_world(&mut mesh, &placement_transform);
+                // Keep the host in absolute world/RTC coordinates here: the void cut
+                // (`apply_void_context`) matches it against world-coordinate opening
+                // cutters, so relativizing the host now would silently break every
+                // cut. The per-element local-origin relativization is applied to the
+                // CSG OUTPUT instead (shared host+cutter frame).
+                self.transform_mesh_world_framed(&mut mesh, &placement_transform, false);
 
                 item_meshes.push(mesh);
             }

--- a/rust/geometry/tests/snapshots/issue_218_window_rendering.snap
+++ b/rust/geometry/tests/snapshots/issue_218_window_rendering.snap
@@ -6,9 +6,9 @@ parse_ok: true
 products_attempted: 105
 products_non_empty: 3
 process_errors: 98
-total_triangles: 3350
+total_triangles: 3340
 total_vertices: 10050
-spike_triangles: 20
+spike_triangles: 19
 total_surface_area: 206.535
 bbox_min: [-4.461, -2.405, -0.200]
 bbox_max: [7.339, 2.155, 2.520]

--- a/rust/geometry/tests/snapshots/issue_472_SurfaceModel_support.snap
+++ b/rust/geometry/tests/snapshots/issue_472_SurfaceModel_support.snap
@@ -6,10 +6,10 @@ parse_ok: true
 products_attempted: 3349
 products_non_empty: 13
 process_errors: 3335
-total_triangles: 51712
+total_triangles: 51588
 total_vertices: 30673
-spike_triangles: 1482
-total_surface_area: 76478.999
+spike_triangles: 1359
+total_surface_area: 76478.998
 bbox_min: [7.803, -55.407, -8.345]
 bbox_max: [210.141, 201.399, 2.900]
 types_seen:

--- a/rust/processing/src/element.rs
+++ b/rust/processing/src/element.rs
@@ -486,6 +486,16 @@ fn produce_type_geometry(
     out
 }
 
+/// Whether the f32-collapse degenerate-triangle backstop is disabled.
+///
+/// On by default. Set `IFC_LITE_DISABLE_DEGENERATE_BACKSTOP=1` to keep the raw
+/// (possibly fan-corrupted) triangles — an escape hatch for debugging the
+/// heuristic or measuring exactly what it removes. Read once and cached.
+fn degenerate_backstop_disabled() -> bool {
+    static DISABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *DISABLED.get_or_init(|| std::env::var("IFC_LITE_DISABLE_DEGENERATE_BACKSTOP").is_ok())
+}
+
 /// Construct the final [`MeshData`]: metadata stamp, style metadata,
 /// geometry-class tag, and the optional site-local rotation. ALWAYS the last
 /// step — geometry hashing happens before this (native IFC frame).
@@ -504,7 +514,9 @@ fn build_mesh_data(
     // span large georeferenced models. Drop the unambiguously-degenerate ones
     // here — the single funnel for every element MeshData. (Proper fix is
     // local-frame / tiled vertex storage; this keeps the viewer clean meanwhile.)
-    mesh.drop_degenerate_triangles();
+    if !degenerate_backstop_disabled() {
+        mesh.drop_degenerate_triangles();
+    }
     let mut mesh_data = MeshData::new(
         job.id,
         job.ifc_type.name().to_string(),

--- a/rust/processing/src/element.rs
+++ b/rust/processing/src/element.rs
@@ -311,7 +311,7 @@ fn produce_inner(
             let geometry_id = full.geometry_id;
             if let Some(groups) = crate::style::split_mesh_by_indexed_colour(&mesh, full) {
                 if let Some(h) = hasher.as_mut() {
-                    h.add_mesh(&mesh.positions, &mesh.indices);
+                    h.add_mesh_with_origin(&mesh.positions, &mesh.indices, mesh.origin);
                 }
                 let mut out: Vec<MeshData> = Vec::with_capacity(groups.len());
                 for (color, mut part) in groups {
@@ -339,7 +339,7 @@ fn produce_inner(
         calculate_normals(&mut mesh);
     }
     if let Some(h) = hasher.as_mut() {
-        h.add_mesh(&mesh.positions, &mesh.indices);
+        h.add_mesh_with_origin(&mesh.positions, &mesh.indices, mesh.origin);
     }
     vec![build_mesh_data(job, mesh, element_color, None, None, 0, ctx)]
 }
@@ -389,7 +389,7 @@ fn emit_sub_meshes(
             .or_else(|| infer_opening_subpart_material_name(&job.ifc_type, color, sub.geometry_id));
 
         if let Some(h) = hasher.as_mut() {
-            h.add_mesh(&sub_mesh.positions, &sub_mesh.indices);
+            h.add_mesh_with_origin(&sub_mesh.positions, &sub_mesh.indices, sub_mesh.origin);
         }
 
         // #858: a face set with a per-triangle colour map splits into one

--- a/rust/processing/src/element.rs
+++ b/rust/processing/src/element.rs
@@ -491,13 +491,20 @@ fn produce_type_geometry(
 /// step — geometry hashing happens before this (native IFC frame).
 fn build_mesh_data(
     job: &ElementMeshJob<'_>,
-    mesh: Mesh,
+    mut mesh: Mesh,
     color: [f32; 4],
     material_name: Option<String>,
     geometry_item_id: Option<u32>,
     geometry_class: u8,
     ctx: &MeshProductionContext<'_>,
 ) -> MeshData {
+    // Backstop for f32 vertex-storage collapse: at building-scale world
+    // coordinates an f32 mantissa can't separate sub-15µm-apart vertices, so
+    // triangles collapse into zero-area / long-thin "fan" slivers that visibly
+    // span large georeferenced models. Drop the unambiguously-degenerate ones
+    // here — the single funnel for every element MeshData. (Proper fix is
+    // local-frame / tiled vertex storage; this keeps the viewer clean meanwhile.)
+    mesh.drop_degenerate_triangles();
     let mut mesh_data = MeshData::new(
         job.id,
         job.ifc_type.name().to_string(),

--- a/rust/processing/src/element.rs
+++ b/rust/processing/src/element.rs
@@ -498,6 +498,7 @@ fn build_mesh_data(
     geometry_class: u8,
     ctx: &MeshProductionContext<'_>,
 ) -> MeshData {
+    let mesh_origin = mesh.origin;
     let mut mesh_data = MeshData::new(
         job.id,
         job.ifc_type.name().to_string(),
@@ -505,7 +506,8 @@ fn build_mesh_data(
         mesh.normals,
         mesh.indices,
         color,
-    );
+    )
+    .with_origin(mesh_origin);
     if let Some(meta) = job.metadata {
         mesh_data = mesh_data
             .with_element_metadata(

--- a/rust/processing/src/processor.rs
+++ b/rust/processing/src/processor.rs
@@ -172,6 +172,38 @@ pub fn convert_mesh_to_site_local(mesh: &mut MeshData, site_transform: Option<&V
 
     apply_inverse_rotation_in_place(&mut mesh.positions, site_transform);
     apply_inverse_rotation_in_place(&mut mesh.normals, site_transform);
+    // Positions are stored RELATIVE to `mesh.origin`, so the world point is
+    // `origin + position`. The site-local inverse rotation acts on the world
+    // point, so the origin must be rotated by the SAME inverse rotation (in f64)
+    // — otherwise the element would be rotated about the wrong centre.
+    apply_inverse_rotation_point_f64(&mut mesh.origin, site_transform);
+}
+
+/// Inverse-rotate a single f64 point in place by `column_major_matrix` (the same
+/// Rᵀ used by `apply_inverse_rotation_in_place`). Used for the per-mesh origin.
+fn apply_inverse_rotation_point_f64(p: &mut [f64; 3], column_major_matrix: &[f64]) {
+    if column_major_matrix.len() < 16 || (p[0] == 0.0 && p[1] == 0.0 && p[2] == 0.0) {
+        return;
+    }
+    let (r00, r10, r20) = (
+        column_major_matrix[0],
+        column_major_matrix[1],
+        column_major_matrix[2],
+    );
+    let (r01, r11, r21) = (
+        column_major_matrix[4],
+        column_major_matrix[5],
+        column_major_matrix[6],
+    );
+    let (r02, r12, r22) = (
+        column_major_matrix[8],
+        column_major_matrix[9],
+        column_major_matrix[10],
+    );
+    let (x, y, z) = (p[0], p[1], p[2]);
+    p[0] = r00 * x + r10 * y + r20 * z;
+    p[1] = r01 * x + r11 * y + r21 * z;
+    p[2] = r02 * x + r12 * y + r22 * z;
 }
 
 /// Job for processing a single entity.

--- a/rust/processing/src/style/indexed_colour.rs
+++ b/rust/processing/src/style/indexed_colour.rs
@@ -137,6 +137,7 @@ pub fn split_mesh_by_indexed_colour(
 
     let has_normals = mesh.normals.len() == mesh.positions.len();
     let rtc_applied = mesh.rtc_applied;
+    let origin = mesh.origin;
 
     // One accumulator per palette entry; built lazily so empty groups vanish.
     #[derive(Default)]
@@ -189,6 +190,7 @@ pub fn split_mesh_by_indexed_colour(
                 normals: group.normals,
                 indices: group.indices,
                 rtc_applied,
+                origin,
             };
             Some((map.colours[palette], mesh))
         })
@@ -213,8 +215,8 @@ mod tests {
             positions,
             normals: Vec::new(),
             indices: vec![0, 1, 2, 3, 4, 5, 0, 1, 99],
-            rtc_applied: false,
-        };
+            rtc_applied: false, 
+            origin: [0.0; 3],        };
         let map = FullIndexedColourMap {
             geometry_id: 1,
             colours: vec![Rgba::new(1.0, 0.0, 0.0, 1.0), Rgba::new(0.0, 1.0, 0.0, 1.0)],

--- a/rust/processing/src/types/mesh.rs
+++ b/rust/processing/src/types/mesh.rs
@@ -70,10 +70,23 @@ pub struct MeshData {
     /// skipped when 0 so ordinary meshes serialize byte-identically.
     #[serde(default, skip_serializing_if = "geometry_class_is_occurrence")]
     pub geometry_class: u8,
+    /// Per-mesh local origin (world/RTC frame, f64). `positions` are stored
+    /// RELATIVE to this — the world position of a vertex is `origin + position` —
+    /// so building/georef-scale placement never collapses adjacent vertices to
+    /// bit-identical f32. The renderer applies it as a per-mesh translation
+    /// (camera-relative). `[0, 0, 0]` ⇒ positions are absolute (legacy/local).
+    /// Serde-default + skip-when-zero so existing payloads/caches stay readable
+    /// and local meshes serialize byte-identically.
+    #[serde(default, skip_serializing_if = "origin_is_zero")]
+    pub origin: [f64; 3],
 }
 
 fn geometry_class_is_occurrence(class: &u8) -> bool {
     *class == 0
+}
+
+fn origin_is_zero(origin: &[f64; 3]) -> bool {
+    origin[0] == 0.0 && origin[1] == 0.0 && origin[2] == 0.0
 }
 
 impl MeshData {
@@ -102,12 +115,19 @@ impl MeshData {
             uvs: None,
             texture: None,
             geometry_class: 0,
+            origin: [0.0; 3],
         }
     }
 
     /// Tag the geometry's provenance for the Model/Types view switch (#957).
     pub fn with_geometry_class(mut self, geometry_class: u8) -> Self {
         self.geometry_class = geometry_class;
+        self
+    }
+
+    /// Set the per-mesh local origin (positions are relative to it).
+    pub fn with_origin(mut self, origin: [f64; 3]) -> Self {
+        self.origin = origin;
         self
     }
 

--- a/rust/wasm-bindings/src/api/gpu_meshes.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes.rs
@@ -349,6 +349,15 @@ impl IfcAPI {
                 };
                 let detected_rtc = router.detect_rtc_offset_from_jobs(&buffered_jobs, &mut decoder);
                 let mut rtc_offset = detected_rtc.unwrap_or((0.0, 0.0, 0.0));
+                // True once ANY detection (partial OR the full re-detect below)
+                // resolved usable placement samples — even if it concluded "no
+                // shift" (0,0,0). The placement-bounds fallback must NOT override
+                // a successful "no shift": that scan averages ALL placement
+                // points incl. a far georef anchor (e.g. IfcSite/MapConversion at
+                // national grid), so on a building whose geometry sits near origin
+                // but carries a georef datum it returns a bogus ~-792 km offset,
+                // pushing the whole model off-screen.
+                let mut detection_succeeded = detected_rtc.is_some();
 
                 // Streaming emits this meta as soon as RTC_SAMPLE_THRESHOLD geometry
                 // jobs are buffered (~the 50th element, near the top of the file), so
@@ -371,18 +380,25 @@ impl IfcAPI {
                     if let Some(full_rtc) =
                         router.detect_rtc_offset_from_jobs(&buffered_jobs, &mut full_decoder)
                     {
+                        // The full index resolved the placement chain — this is a
+                        // successful detection whether it shifts (large) or not.
+                        detection_succeeded = true;
                         if is_large(full_rtc) {
                             rtc_offset = full_rtc;
                         }
                     }
                 }
-                // Server parity: when sampling produced no usable translations
-                // at all, fall back to the full placement-bounds scan exactly
-                // like `process_geometry` does — otherwise a model whose
-                // sampled placements fail to decode renders re-based on the
-                // server but jittery (raw >10 km f32 coords) in the browser.
-                if detected_rtc.is_none() && !is_large(rtc_offset) {
-                    rtc_offset = ifc_lite_core::scan_placement_bounds(content).rtc_offset();
+                // Server parity LAST RESORT: only when NO detection (partial or
+                // full) found any usable placement translations do we scan the
+                // placement bounds (a model whose placements truly can't decode
+                // from this index, e.g. a genuine >10 km georef whose chain is
+                // unresolved). A successful "no shift" must NOT reach here, or the
+                // georef-anchor-skewed scan would re-base an origin-local model.
+                if !detection_succeeded && !is_large(rtc_offset) {
+                    let raw = ifc_lite_core::scan_placement_bounds(content).rtc_offset();
+                    // scan_placement_bounds reads raw IfcCartesianPoint values
+                    // (FILE units); the detection path is unit-scaled to metres.
+                    rtc_offset = (raw.0 * unit_scale, raw.1 * unit_scale, raw.2 * unit_scale);
                 }
                 let needs_shift = is_large(rtc_offset);
 

--- a/rust/wasm-bindings/src/zero_copy.rs
+++ b/rust/wasm-bindings/src/zero_copy.rs
@@ -43,6 +43,12 @@ pub struct MeshDataJs {
     /// via IfcRelDefinesByType — the type-library shape, hidden in Model mode to
     /// avoid double-rendering, shown in Types mode). See #957 follow-up.
     geometry_class: u8,
+    /// Per-element local-frame origin (f64), in the SAME (WebGL Y-up) frame as
+    /// `positions`: world position of vertex i = `origin + positions[3i..]`.
+    /// Default `[0,0,0]` means positions are absolute (legacy). Carries the
+    /// per-element AABB-centre relativization so building-scale coordinates stay
+    /// f32-precise (no fan collapse). See `Mesh::origin`/transform_mesh_world_framed.
+    origin: [f64; 3],
 }
 
 #[wasm_bindgen]
@@ -151,6 +157,14 @@ impl MeshDataJs {
     pub fn geometry_class(&self) -> u8 {
         self.geometry_class
     }
+
+    /// Per-element local-frame origin (Float64Array[3], WebGL Y-up, metres):
+    /// world position of vertex i = `origin + positions[3i..3i+3]`. Returns
+    /// [0,0,0] when positions are absolute (legacy / local frame off).
+    #[wasm_bindgen(getter)]
+    pub fn origin(&self) -> js_sys::Float64Array {
+        js_sys::Float64Array::from(&self.origin[..])
+    }
 }
 
 impl MeshDataJs {
@@ -184,6 +198,12 @@ impl MeshDataJs {
             mesh.indices.swap(i + 1, i + 2);
         }
 
+        // The per-element origin is a world-frame point and MUST undergo the
+        // identical IFC Z-up → WebGL Y-up swap as the positions above, or
+        // `world = origin + position` would mix axes (element renders mirrored
+        // / displaced). Default [0,0,0] swaps to [0,0,0] (no-op for legacy).
+        let origin = [mesh.origin[0], mesh.origin[2], -mesh.origin[1]];
+
         Self {
             express_id,
             ifc_type,
@@ -199,6 +219,7 @@ impl MeshDataJs {
             texture_repeat_s: true,
             texture_repeat_t: true,
             geometry_class: 0,
+            origin,
         }
     }
 
@@ -250,6 +271,9 @@ impl MeshDataJs {
             // Positions are final here (the canonical producer already applied
             // placement/RTC); the flag only guards upstream double-subtraction.
             rtc_applied: true,
+            // Per-element local-frame origin from the producer (IFC frame); the
+            // Z-up→Y-up swap is applied in `new`. [0,0,0] when local frame off.
+            origin: m.origin,
         };
         let mut js = Self::new(m.express_id, m.ifc_type, mesh, m.color);
         js.set_geometry_class(m.geometry_class);
@@ -314,6 +338,7 @@ impl MeshCollection {
             texture_repeat_s: m.texture_repeat_s,
             texture_repeat_t: m.texture_repeat_t,
             geometry_class: m.geometry_class,
+            origin: m.origin,
         })
     }
 
@@ -340,6 +365,7 @@ impl MeshCollection {
             texture_repeat_s: m.texture_repeat_s,
             texture_repeat_t: m.texture_repeat_t,
             geometry_class: m.geometry_class,
+            origin: m.origin,
         })
     }
 
@@ -526,6 +552,7 @@ impl Clone for MeshCollection {
                     texture_repeat_s: m.texture_repeat_s,
                     texture_repeat_t: m.texture_repeat_t,
                     geometry_class: m.geometry_class,
+                    origin: m.origin,
                 })
                 .collect(),
             rtc_offset_x: self.rtc_offset_x,

--- a/scripts/lib/mesh-via-prepass.mjs
+++ b/scripts/lib/mesh-via-prepass.mjs
@@ -53,6 +53,9 @@ export function parseMeshesViaPrePass(api, content) {
             vertexCount: m.vertexCount,
             triangleCount: m.triangleCount,
             geometryClass: m.geometryClass,
+            // Per-element local-frame origin (world = origin + position). Present
+            // on the wasm local-frame path; consumers fold it to recover world.
+            origin: m.origin ? Array.from(m.origin) : undefined,
             free: () => {},
           });
           totalVertices += m.vertexCount;

--- a/scripts/test-wasm-contract.mjs
+++ b/scripts/test-wasm-contract.mjs
@@ -429,19 +429,24 @@ test('coordinates just under the 10km threshold should NOT trigger the shift', (
   assert.equal(collection.rtcOffsetY, 0, 'rtcOffset must stay [0,0,0] under threshold');
   assert.equal(collection.rtcOffsetZ, 0, 'rtcOffset must stay [0,0,0] under threshold');
 
-  // No rebase ⇒ geometry stays at its (large-ish) world position.
+  // No rebase ⇒ geometry stays at its (large-ish) world position. Positions are
+  // stored in the per-element local frame (world = origin + position) on the
+  // wasm path, so fold the origin back before checking the world magnitude
+  // (origin is [0,0,0] / absent on an absolute-coordinate build → unchanged).
   assert.ok(collection.length > 0, 'Moved column should still mesh');
   let maxAbs = 0;
   for (let i = 0; i < collection.length; i++) {
     const mesh = collection.get(i);
+    const o = mesh.origin;
     for (let j = 0; j < mesh.positions.length; j++) {
-      maxAbs = Math.max(maxAbs, Math.abs(mesh.positions[j]));
+      const world = mesh.positions[j] + (o ? o[j % 3] : 0);
+      maxAbs = Math.max(maxAbs, Math.abs(world));
     }
     mesh.free();
   }
   assert.ok(
     maxAbs > 9000,
-    `Unshifted geometry should stay near its 9.95km placement, got max |p| = ${maxAbs}`,
+    `Unshifted geometry should stay near its 9.95km placement, got max |world| = ${maxAbs}`,
   );
 
   collection.free();

--- a/scripts/wasm-fan-check.mjs
+++ b/scripts/wasm-fan-check.mjs
@@ -1,0 +1,79 @@
+// Decisive test: run the EXACT viewer path (buildPrePassOnce + processGeometryBatch)
+// against the BUILT wasm and count visible fan/sliver triangles. If >0, the built
+// wasm's geometry is NOT clean (despite source having clean_degenerate).
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = join(here, '..');
+const wasmJs = join(root, 'packages/wasm/pkg/ifc-lite.js');
+const wasmBin = join(root, 'packages/wasm/pkg/ifc-lite_bg.wasm');
+const model = process.argv[2];
+if (!model) { console.error('usage: node wasm-fan-check.mjs <model.ifc>'); process.exit(2); }
+
+const { initSync, IfcAPI } = await import(pathToFileURL(wasmJs).href);
+const { parseMeshesViaPrePass } = await import(pathToFileURL(join(root, 'scripts/lib/mesh-via-prepass.mjs')).href);
+initSync(readFileSync(wasmBin));
+
+const content = readFileSync(model); // Uint8Array; helper handles bytes/string
+const api = new IfcAPI();
+const meshes = parseMeshesViaPrePass(api, content);
+
+const ulp32 = (v) => { const a = Math.max(Math.fround(Math.abs(v)), 1.2e-38); const b = new Float32Array([a]); const u = new Uint32Array(b.buffer); u[0] += 1; return new Float32Array(u.buffer)[0] - a; };
+const d = (p, i, j) => Math.hypot(p[i*3]-p[j*3], p[i*3+1]-p[j*3+1], p[i*3+2]-p[j*3+2]);
+
+const n = meshes.length ?? meshes.size ?? 0;
+const get = (k) => (meshes.get ? meshes.get(k) : meshes[k]);
+// GLOBAL bbox center over ALL meshes — simulates a PERFECT single global RTC.
+let gmin=[Infinity,Infinity,Infinity], gmax=[-Infinity,-Infinity,-Infinity];
+for (let k=0;k<n;k++){ const m=get(k); if(!m||!m.positions) continue; const p=m.positions;
+  for(let i=0;i<p.length;i+=3){ for(let q=0;q<3;q++){ const v=p[i+q]; if(v<gmin[q])gmin[q]=v; if(v>gmax[q])gmax[q]=v; } } }
+const gctr=[(gmin[0]+gmax[0])/2,(gmin[1]+gmax[1])/2,(gmin[2]+gmax[2])/2];
+const gspan=[gmax[0]-gmin[0],gmax[1]-gmin[1],gmax[2]-gmin[2]];
+
+let tris = 0, zeroArea = 0, visibleFan = 0, subGrid = 0, visibleFanLocal = 0, visibleFanGlobal = 0, maxWorld = 0;
+const GRID = 1/65536;
+for (let k = 0; k < n; k++) {
+  const m = get(k);
+  if (!m || !m.positions || !m.indices) continue;
+  const p = m.positions, idx = m.indices;
+  // per-mesh centroid for the local-frame control
+  let cx0=0, cy0=0, cz0=0; const nv = p.length/3;
+  for (let i=0;i<p.length;i+=3){ cx0+=p[i]; cy0+=p[i+1]; cz0+=p[i+2]; }
+  cx0/=nv||1; cy0/=nv||1; cz0/=nv||1;
+  for (let t = 0; t + 2 < idx.length; t += 3) {
+    const a = idx[t], b = idx[t+1], c = idx[t+2];
+    tris++;
+    const ab = d(p,a,b), bc = d(p,b,c), ca = d(p,c,a);
+    const longest = Math.max(ab, bc, ca);
+    if (longest <= 0) { zeroArea++; continue; }
+    const ux=p[b*3]-p[a*3], uy=p[b*3+1]-p[a*3+1], uz=p[b*3+2]-p[a*3+2];
+    const vx=p[c*3]-p[a*3], vy=p[c*3+1]-p[a*3+1], vz=p[c*3+2]-p[a*3+2];
+    const cxp=uy*vz-uz*vy, cyp=uz*vx-ux*vz, czp=ux*vy-uy*vx;
+    const area = 0.5*Math.hypot(cxp,cyp,czp);
+    const h = 2*area/longest;
+    if (area === 0) zeroArea++;
+    if (h < GRID) subGrid++;
+    let maxc = 0, maxcl = 0;
+    for (const vi of [a,b,c]) {
+      maxc = Math.max(maxc, Math.abs(p[vi*3]), Math.abs(p[vi*3+1]), Math.abs(p[vi*3+2]));
+      maxcl = Math.max(maxcl, Math.abs(p[vi*3]-cx0), Math.abs(p[vi*3+1]-cy0), Math.abs(p[vi*3+2]-cz0));
+    }
+    // global-recenter: max coord after subtracting the global bbox center
+    let maxcg = 0;
+    for (const vi of [a,b,c]) for (let q=0;q<3;q++) maxcg = Math.max(maxcg, Math.abs(p[vi*3+q]-gctr[q]));
+    maxWorld = Math.max(maxWorld, maxc);
+    if (longest > 0.1 && h < ulp32(maxc)) visibleFan++;
+    if (longest > 0.1 && h < ulp32(maxcl)) visibleFanLocal++;
+    if (longest > 0.1 && h < ulp32(maxcg)) visibleFanGlobal++;
+  }
+}
+console.log(JSON.stringify({ meshes: n, triangles: tris, zeroArea, subGrid_h_lt_15us: subGrid,
+  visibleFan_world: visibleFan,
+  visibleFan_GLOBALrecenter: visibleFanGlobal,
+  visibleFan_LOCALframe: visibleFanLocal,
+  maxWorldCoord_m: Math.round(maxWorld),
+  globalSpan_m: gspan.map(v=>Math.round(v)),
+  globalCenter_m: gctr.map(v=>Math.round(v)) }, null, 2));
+api.free?.();


### PR DESCRIPTION
## Problem

On building-scale and georeferenced models, faceted geometry rendered gross **"fan" needles** across the model. Root cause: vertices are stored at **f32** precision while their world coordinates sit ~100–200 m from the origin, where one f32 ULP is ~15–25 µm. Near-edges collapse to the same value and the triangles joining them fan out. This is distinct from tessellation slivers, and global RTC is the wrong lever (it is reserved for >10 km federation re-basing, and a single recentre still leaves the model genuinely spanning ~200 m).

## Solution — per-element local frame

Each element's vertices are stored **relative to a per-element `MeshData.origin`** (the f64 AABB centre, snapped to the kernel reconcile grid `1/65536 m`), so the f32 coordinates stay element-small and collapse-free at any scale. World = `origin + position`.

- **Rust → wasm:** `transform_mesh_world_framed` defers the world magnitude into `origin`; the boundary threads `origin` across with the same IFC Z-up→WebGL Y-up swap as positions. ON for the wasm (viewer) path, env opt-in for native/server so determinism snapshots + server output stay absolute-coordinate byte-identical.
- **Renderer:** one **shared scene origin** for all batches (abutting elements in different colour batches stay bit-coincident → no seam z-fighting); per-batch model-matrix translate reconstructs world; the selection-highlight / GPU-picker buffers replicate the batch's exact f32 path (bit-coincident, no depth bias).
- **Cache:** `origin` serialized (format version 6, auto-heals stale entries).

## Exhaustive consumer audit

A triage→verify pass over every world-space reader of element geometry found and fixed each one that still treated positions as absolute (would mis-place geometry when `origin` is set):

- **Renderer:** CPU raycast narrow phase + broad-phase BVH, colour-merged pick extraction, BIM↔scan deviation BVH, model-bounds union, snap detection, section cutters (CPU + GPU).
- **Clash:** adapter folds `origin` into world-frame triangles fed to **both** the TS and Rust kernels (bounds + geometry agree; differential parity preserved).
- **Export:** glTF (node translation — keeps buffers precise), IFC5 (points pre-swap), Parquet (baked verts).
- **Drawing-2D:** construction-projection outline, storey-band derivation.
- **Spatial:** world-space mesh AABBs.
- **Viewer:** properties bbox, Cesium GLB overlay, MCP playground mesh transform, mesh-duplicate (offset → origin), federation alignment (fold in, write absolute, clear stale origin — proj4 reprojection is nonlinear).

Position **differences** (normals, edge vectors, areas) are origin-invariant and untouched.

## Compare-models parity

The diff geometry hash now folds `origin` so the fingerprint is over absolute world coords — identical whether the producer emitted absolute (native) or local+origin (wasm), and a moved element still changes the hash. The cache-dedup hash is unchanged (it runs pre-placement on origin-free kernel geometry).

## Mesh hygiene (bundles #1113)

This PR **supersedes #1113**: the per-element local frame and `Mesh::clean_degenerate` (drop sub-grid sliver triangles at every mesh-output chokepoint) are complementary and only **together** remove all the fans the viewer actually showed — the local frame kills the f32-storage fans, hygiene removes the sub-grid slivers the finer-grained CSG host then emits. Both verified together.

## Performance

- `transform_mesh_world_framed` gains a fast path for the absolute path (native/server default + void-cut host): bit-identical to the framed path with `origin [0,0,0]`, but skips the per-element `Vec` + second pass.
- Load remains decode/CSG-bound (per the #1097 profiling); the framed-path overhead on the wasm path is below measurement noise. The Manifold-class CSG kernel work continues separately (#1105/#1106).

## Testing

- Rust geometry suite (incl. determinism snapshots): green; native output byte-identical.
- TS: clash 93, drawing-2d 41, export 126, renderer 105 — all green; 8 packages + viewer app typecheck clean.
- wasm rebuilds clean; visually verified end-to-end in the viewer (fans gone, correct placement, openings cut, selection highlight, on all models).

Changesets: `per-element-local-frame` + the bundled hygiene/backstop/load-cost entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-element local coordinate frame support for more accurate world positioning in large and georeferenced models.

* **Bug Fixes**
  * Fixed geometry “fan” corruption that could appear in large models.
  * Improved degenerate/sliver triangle cleanup to prevent needle-like spikes and jagged silhouettes.
  * Updated bounds, raycasting, snapping, section cutting, clash, outlines/derivations, and export outputs to be origin-aware.

* **Chores / Tests**
  * Updated binary cache format so restored geometry keeps correct placement; added a deterministic WASM fan-check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->