### PR TITLE
fix(release): advance workspace anchor to 4.1.0 + rebuild server-bin

### DIFF
--- a/.changeset/server-bin-native-geometry.md
+++ b/.changeset/server-bin-native-geometry.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/server-bin": patch
+---
+
+Rebuild the prebuilt native server binary to ship the latest Rust geometry/processing changes.
+
+`@ifc-lite/server-bin` downloads its per-platform native archive from a GitHub release tagged at its own version, and the release workflow skips rebuilding assets when that tag already exists. Bump the patch version so a fresh `v<server-bin>` release fires and the prebuilt binary carries the merged native-side geometry work — the per-element local frame, the deterministic CSG escalation budget (the #1109 95% hang fix), the f64 interval-lambda / cmp_along predicate filters, and the curved-wall watertightness guard.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1464,11 +1464,11 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ifc-lite-clash"
-version = "4.0.0"
+version = "4.1.0"
 
 [[package]]
 name = "ifc-lite-core"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "fast-float2",
  "futures-core",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-geometry"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "approx",
  "bnum",
@@ -1510,7 +1510,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-processing"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "ifc-lite-core",
  "ifc-lite-geometry",
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-server"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-wasm"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "console_error_panic_hook",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,18 +3,18 @@ members = ["rust/core", "rust/geometry", "rust/processing", "rust/clash", "rust/
 resolver = "2"
 
 [workspace.package]
-version = "4.0.0"
+version = "4.1.0"
 edition = "2021"
 authors = ["IFC-Lite Contributors"]
 license = "MPL-2.0"
 repository = "https://github.com/LTplus-AG/ifc-lite"
 
 [workspace.dependencies]
-ifc-lite-core = { version = "4.0.0", path = "rust/core" }
-ifc-lite-geometry = { version = "4.0.0", path = "rust/geometry" }
-ifc-lite-processing = { version = "4.0.0", path = "rust/processing" }
-ifc-lite-clash = { version = "4.0.0", path = "rust/clash" }
-ifc-lite-wasm = { version = "4.0.0", path = "rust/wasm-bindings" }
+ifc-lite-core = { version = "4.1.0", path = "rust/core" }
+ifc-lite-geometry = { version = "4.1.0", path = "rust/geometry" }
+ifc-lite-processing = { version = "4.1.0", path = "rust/processing" }
+ifc-lite-clash = { version = "4.1.0", path = "rust/clash" }
+ifc-lite-wasm = { version = "4.1.0", path = "rust/wasm-bindings" }
 
 [profile.release]
 opt-level = 3           # Optimize for speed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ifc-lite",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "High-performance browser IFC parser & renderer",
   "private": true,
   "type": "module",

--- a/rust/processing/Cargo.toml
+++ b/rust/processing/Cargo.toml
@@ -15,11 +15,11 @@ categories = ["parsing", "algorithms"]
 readme = "../../README.md"
 
 [dependencies]
-ifc-lite-core = { version = "4.0.0", path = "../core" }
+ifc-lite-core = { version = "4.1.0", path = "../core" }
 # CSG runs on the pure-Rust exact kernel inside ifc-lite-geometry on every
 # target (the Manifold C++ kernel was removed in the kernel consolidation —
 # see docs/architecture/geometry-pipeline.md).
-ifc-lite-geometry = { version = "4.0.0", path = "../geometry", default-features = false }
+ifc-lite-geometry = { version = "4.1.0", path = "../geometry", default-features = false }
 rayon = "1.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/rust/wasm-bindings/Cargo.toml
+++ b/rust/wasm-bindings/Cargo.toml
@@ -29,12 +29,12 @@ ifc-lite-core.workspace = true
 # same kernel on wasm32 and native. The Manifold C++ kernel and its
 # LLVM/emsdk build prerequisites were removed in the kernel
 # consolidation (docs/architecture/geometry-pipeline.md).
-ifc-lite-geometry = { version = "4.0.0", path = "../geometry", default-features = false, features = [] }
+ifc-lite-geometry = { version = "4.1.0", path = "../geometry", default-features = false, features = [] }
 # Canonical 2D-symbol extractor lives here; the wasm bindings just
 # delegate (issue #843 follow-up — full parity, one implementation).
-ifc-lite-processing = { version = "4.0.0", path = "../processing" }
+ifc-lite-processing = { version = "4.1.0", path = "../processing" }
 # Pure-geometry clash kernel (BVH broad phase + exact triangle narrow phase).
-ifc-lite-clash = { version = "4.0.0", path = "../clash" }
+ifc-lite-clash = { version = "4.1.0", path = "../clash" }
 js-sys = "=0.3.83"
 rayon = "1.10"
 # `ifc-lite-geometry` uses rayon `par_iter` (e.g. FacetedBrep


### PR DESCRIPTION
Ensures the merged native geometry work reaches **crates.io** and the **prebuilt native server binary**, not just npm. Addresses the Codex review on #1104 (P1 + P2).

## Why
The changesets bot bumps npm package versions but never the Cargo/root anchor. With the anchor stuck at the already-published `4.0.0`, `scripts/release-crates.mjs` skips every Rust crate as already-published, and `@ifc-lite/server-bin` keeps its existing tag so its binary-release step is skipped. So crates.io + prebuilt-server users would NOT receive:
- per-element local frame (#1114)
- deterministic CSG escalation budget — the #1109 95% hang fix (#1112)
- f64 interval-lambda + `cmp_along` predicate filters (#1105/#1106)
- curved-wall watertightness guard (#1108)

## What
- Bump root `package.json` → `4.1.0` (the `sync-versions.js` anchor) and run `sync-versions` so `Cargo [workspace.package]`, the internal rust dep pins, and `Cargo.lock` all track `4.1.0`. `release-crates.mjs` then republishes `ifc-lite-core/geometry/processing/clash/wasm` at `4.1.0`.
- Add a `@ifc-lite/server-bin` patch changeset → a fresh `v<server-bin>` release fires and the per-platform native binaries rebuild with the new geometry.

Mirrors #1082. npm packages version independently via their own changesets and are unaffected. After this merges, the changesets bot regenerates #1104 with `Cargo 4.1.0` + `server-bin 1.16.3`; merging #1104 then releases everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)