### PR TITLE
fix(export): emit deferred property atoms — kills ~611k dangling #-refs in merged/STEP output (#1110)

### DIFF
--- a/.changeset/export-emit-deferred-property-atoms.md
+++ b/.changeset/export-emit-deferred-property-atoms.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/export": patch
+---
+
+Fix STEP exporters dropping deferred property atoms, which produced hundreds of thousands of dangling `#`-references in merged (and single-model) IFC output.
+
+On large files the parser can move high-cardinality property atoms (`IfcPropertySingleValue`, `IfcQuantity*`, `IfcPropertyEnumeratedValue`, …) out of `entityIndex.byId` into a secondary `deferredEntityIndex` to cap memory (`deferPropertyAtomIndex`). Every other consumer (on-demand property/material extraction) reads through the `byId.get(id) ?? deferredEntityIndex.get(id)` fallback, but `MergedExporter` and `StepExporter` walked `byId` alone. They therefore emitted the `IfcPropertySet` / `IfcElementQuantity` *containers* while silently dropping the atoms those containers reference — leaving the STEP output full of references to entities that are never defined. Strict viewers (e.g. BIM Vision) reject such files, and lenient ones fall geometry back to the origin when a placement / type / material chain resolves to a dropped entity.
+
+Both exporters now iterate the complete entity set via a shared `getCompleteEntityIndex` helper (primary index + deferred atoms), and the merge offset / new-id allocation now spans deferred ids too so remapped ids can't collide with a deferred atom sitting at a higher express id. When nothing was deferred the primary index is returned unchanged, so the common path keeps its existing behaviour and cost.

--- a/.changeset/mutations-overlay-clears-deferred-ids.md
+++ b/.changeset/mutations-overlay-clears-deferred-ids.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/mutations": patch
+---
+
+Seed the overlay express-id watermark above deferred property atoms, not just `entityIndex.byId`.
+
+On huge files the parser defers high-cardinality property atoms out of `byId` into `deferredEntityIndex` (`deferPropertyAtomIndex`). `StoreEditor.computeMaxExistingId()` scanned only `byId`, so a deferred atom sitting above the primary-index maximum could have its express id reused for a newly created overlay entity. With the export fix now emitting deferred atoms, that collision would surface as two `#ID=` definitions in the STEP output. The watermark (and the post-construction "store grew" guard) now span `deferredEntityIndex` too. Surfaced in review of the #1110 export fix.

--- a/packages/export/src/entity-iteration.ts
+++ b/packages/export/src/entity-iteration.ts
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Complete entity iteration for STEP exporters.
+ *
+ * The parser can defer high-cardinality property *atoms*
+ * (IfcPropertySingleValue, IfcQuantity*, IfcPropertyEnumeratedValue, …) out of
+ * `entityIndex.byId` and into a secondary `deferredEntityIndex` to cap memory
+ * on huge files (the `deferPropertyAtomIndex` parse option). Those atoms are
+ * still referenced by the IfcPropertySet / IfcElementQuantity *containers* that
+ * remain in `byId`.
+ *
+ * Any exporter that copies source entities by walking `entityIndex.byId` alone
+ * therefore silently drops every deferred atom while keeping the references to
+ * them — producing STEP output with dangling `#`-references that strict viewers
+ * (e.g. BIM Vision) reject, and that makes lenient viewers fall geometry back to
+ * the origin when a placement/type/material chain resolves to a dropped entity.
+ *
+ * `getCompleteEntityIndex` exposes a single Map-like view over BOTH indexes so
+ * exporters preserve referential integrity regardless of how the source was
+ * parsed. When nothing was deferred it returns the primary index unchanged, so
+ * the common path keeps its existing behaviour and cost.
+ */
+
+import type { IfcDataStore } from '@ifc-lite/parser';
+
+/** The subset of an entity reference the exporters read. */
+export interface ExportEntityRef {
+  type: string;
+  byteOffset: number;
+  byteLength: number;
+}
+
+/**
+ * Map-like view over a set of entities. Matches the slice of the
+ * `Map` / `CompactEntityIndex` surface the exporters depend on.
+ */
+export interface CompleteEntityIndex {
+  get(id: number): ExportEntityRef | undefined;
+  has(id: number): boolean;
+  readonly size: number;
+  [Symbol.iterator](): IterableIterator<[number, ExportEntityRef]>;
+}
+
+/**
+ * Returns a view over the COMPLETE set of source entities — the primary
+ * `entityIndex.byId` plus any `deferredEntityIndex`. The two indexes are
+ * disjoint by construction (deferred atoms are removed from `byId`), so the
+ * merged view never yields a duplicate id.
+ *
+ * Fast path: when there is no deferred index the primary index is returned
+ * directly (no wrapper allocation, identical iteration order and cost).
+ */
+export function getCompleteEntityIndex(dataStore: IfcDataStore): CompleteEntityIndex {
+  const byId = dataStore.entityIndex.byId as unknown as CompleteEntityIndex;
+  const deferred = dataStore.deferredEntityIndex as unknown as CompleteEntityIndex | undefined;
+  if (!deferred || deferred.size === 0) {
+    return byId;
+  }
+
+  return {
+    get: (id: number) => byId.get(id) ?? deferred.get(id),
+    has: (id: number) => byId.has(id) || deferred.has(id),
+    get size() {
+      return byId.size + deferred.size;
+    },
+    *[Symbol.iterator](): IterableIterator<[number, ExportEntityRef]> {
+      yield* byId;
+      yield* deferred;
+    },
+  };
+}
+
+/** Largest EXPRESS id across a (complete) entity index. */
+export function getMaxExpressId(index: CompleteEntityIndex): number {
+  let max = 0;
+  for (const [id] of index) {
+    if (id > max) max = id;
+  }
+  return max;
+}

--- a/packages/export/src/merged-exporter.test.ts
+++ b/packages/export/src/merged-exporter.test.ts
@@ -6,25 +6,40 @@ import { describe, it, expect } from 'vitest';
 import { MergedExporter, type MergeModelInput } from './merged-exporter.js';
 import type { IfcDataStore } from '@ifc-lite/parser';
 
+type MockEntityRef = { expressId: number; type: string; byteOffset: number; byteLength: number; lineNumber: number };
+
 /**
  * Helper: build a minimal IfcDataStore from STEP entity lines.
  * Each entry is [expressId, type, stepText].
+ *
+ * `deferredIds` mirrors the parser's `deferPropertyAtomIndex` mode: those
+ * entities live in the source buffer but are split out of `entityIndex.byId`
+ * (and `byType`) into a separate `deferredEntityIndex`, exactly as the columnar
+ * parser does for property atoms on huge files.
  */
 function buildMockDataStore(
   entries: Array<[number, string, string]>,
+  deferredIds?: Set<number>,
 ): IfcDataStore {
   const encoder = new TextEncoder();
   const parts: Uint8Array[] = [];
-  const byId = new Map<number, { expressId: number; type: string; byteOffset: number; byteLength: number; lineNumber: number }>();
+  const byId = new Map<number, MockEntityRef>();
+  const deferred = new Map<number, MockEntityRef>();
   const byType = new Map<string, number[]>();
   let offset = 0;
 
   for (const [id, type, text] of entries) {
     const encoded = encoder.encode(text);
-    byId.set(id, { expressId: id, type: type.toUpperCase(), byteOffset: offset, byteLength: encoded.byteLength, lineNumber: 0 });
     const upper = type.toUpperCase();
-    if (!byType.has(upper)) byType.set(upper, []);
-    byType.get(upper)!.push(id);
+    const ref: MockEntityRef = { expressId: id, type: upper, byteOffset: offset, byteLength: encoded.byteLength, lineNumber: 0 };
+    if (deferredIds?.has(id)) {
+      // Deferred atoms are NOT in byId or byType (matches real parser behaviour).
+      deferred.set(id, ref);
+    } else {
+      byId.set(id, ref);
+      if (!byType.has(upper)) byType.set(upper, []);
+      byType.get(upper)!.push(id);
+    }
     parts.push(encoded);
     offset += encoded.byteLength;
   }
@@ -43,15 +58,28 @@ function buildMockDataStore(
     parseTime: 0,
     source,
     entityIndex: { byId, byType },
+    ...(deferred.size > 0 ? { deferredEntityIndex: deferred } : {}),
   } as unknown as IfcDataStore;
 }
 
-function buildModel(id: string, name: string, entries: Array<[number, string, string]>): MergeModelInput {
-  return { id, name, dataStore: buildMockDataStore(entries) };
+function buildModel(id: string, name: string, entries: Array<[number, string, string]>, deferredIds?: Set<number>): MergeModelInput {
+  return { id, name, dataStore: buildMockDataStore(entries, deferredIds) };
 }
 
 /** Decode Uint8Array content to string for test assertions */
 const decode = (bytes: Uint8Array) => new TextDecoder().decode(bytes);
+
+/** Count `#N` references in the output that have no `#N=` definition. */
+function findDanglingRefs(content: string): number[] {
+  const defined = new Set<number>();
+  for (const m of content.matchAll(/(^|\n)#(\d+)=/g)) defined.add(+m[2]);
+  const dangling = new Set<number>();
+  for (const m of content.matchAll(/#(\d+)/g)) {
+    const id = +m[1];
+    if (!defined.has(id)) dangling.add(id);
+  }
+  return [...dangling].sort((a, b) => a - b);
+}
 
 describe('MergedExporter', () => {
   it('should export a single model unchanged', () => {
@@ -248,6 +276,87 @@ describe('MergedExporter', () => {
 
   it('should throw if no models provided', () => {
     expect(() => new MergedExporter([])).toThrow('at least one model');
+  });
+
+  // Regression: github.com/LTplus-AG/ifc-lite/issues/1110
+  // When the parser defers property atoms out of byId (deferPropertyAtomIndex
+  // on huge files), the merge must still emit them — otherwise the kept
+  // IfcPropertySet/IfcElementQuantity containers reference dropped entities and
+  // the output is full of dangling #-refs that strict viewers reject.
+  it('should emit deferred property atoms (no dangling refs)', () => {
+    // #5 (single value) and #6 (quantity) live in deferredEntityIndex, but are
+    // referenced by the pset #3 and element-quantity #4 which stay in byId.
+    const entries: Array<[number, string, string]> = [
+      [1, 'IFCPROJECT', "#1=IFCPROJECT('g1',$,'P',$,$,$,$,$,$);"],
+      [2, 'IFCWALL', "#2=IFCWALL('g2',$,'W',$,$,$,$,$);"],
+      [3, 'IFCPROPERTYSET', "#3=IFCPROPERTYSET('g3',$,'Pset_Wall',$,(#5));"],
+      [4, 'IFCELEMENTQUANTITY', "#4=IFCELEMENTQUANTITY('g4',$,'Qto',$,$,(#6));"],
+      [5, 'IFCPROPERTYSINGLEVALUE', "#5=IFCPROPERTYSINGLEVALUE('IsExternal',$,IFCBOOLEAN(.T.),$);"],
+      [6, 'IFCQUANTITYLENGTH', "#6=IFCQUANTITYLENGTH('Length',$,$,2500.,$);"],
+      [7, 'IFCRELDEFINESBYPROPERTIES', "#7=IFCRELDEFINESBYPROPERTIES('g7',$,$,$,(#2),#3);"],
+    ];
+    const deferred = new Set([5, 6]);
+
+    const model1 = buildModel('m1', 'Arch', entries, deferred);
+    const model2 = buildModel('m2', 'Struct', entries, deferred);
+
+    const exporter = new MergedExporter([model1, model2]);
+    const result = exporter.export({ schema: 'IFC4', projectStrategy: 'keep-first' });
+    const content = decode(result.content);
+
+    // The deferred atoms must be present in the output for both models.
+    expect(content).toContain("IFCPROPERTYSINGLEVALUE('IsExternal'");
+    expect(content).toContain("IFCQUANTITYLENGTH('Length'");
+    // Two models → the single-value atom is emitted twice (once per model).
+    expect(content.match(/IFCPROPERTYSINGLEVALUE\('IsExternal'/g)?.length).toBe(2);
+
+    // No dangling references anywhere in the merged file.
+    expect(findDanglingRefs(content)).toEqual([]);
+  });
+
+  it('should emit deferred property atoms via exportAsync too', async () => {
+    const entries: Array<[number, string, string]> = [
+      [1, 'IFCPROJECT', "#1=IFCPROJECT('g1',$,'P',$,$,$,$,$,$);"],
+      [2, 'IFCWALL', "#2=IFCWALL('g2',$,'W',$,$,$,$,$);"],
+      [3, 'IFCPROPERTYSET', "#3=IFCPROPERTYSET('g3',$,'Pset_Wall',$,(#4));"],
+      [4, 'IFCPROPERTYSINGLEVALUE', "#4=IFCPROPERTYSINGLEVALUE('IsExternal',$,IFCBOOLEAN(.T.),$);"],
+      [5, 'IFCRELDEFINESBYPROPERTIES', "#5=IFCRELDEFINESBYPROPERTIES('g5',$,$,$,(#2),#3);"],
+    ];
+    const deferred = new Set([4]);
+
+    const exporter = new MergedExporter([
+      buildModel('m1', 'Arch', entries, deferred),
+      buildModel('m2', 'Struct', entries, deferred),
+    ]);
+    const result = await exporter.exportAsync({ schema: 'IFC4', projectStrategy: 'keep-first' });
+    const content = decode(result.content);
+
+    expect(content.match(/IFCPROPERTYSINGLEVALUE\('IsExternal'/g)?.length).toBe(2);
+    expect(findDanglingRefs(content)).toEqual([]);
+  });
+
+  it('should not collide remapped ids with a deferred atom at the max express id', () => {
+    // Model1's highest id (10) is a DEFERRED atom — the second model's offset
+    // must clear it, or model2's entities overwrite model1's deferred atom.
+    const model1 = buildModel('m1', 'Arch', [
+      [1, 'IFCPROJECT', "#1=IFCPROJECT('g1',$,'P',$,$,$,$,$,$);"],
+      [2, 'IFCWALL', "#2=IFCWALL('g2',$,'W',$,$,$,$,$);"],
+      [3, 'IFCPROPERTYSET', "#3=IFCPROPERTYSET('g3',$,'Pset',$,(#10));"],
+      [10, 'IFCPROPERTYSINGLEVALUE', "#10=IFCPROPERTYSINGLEVALUE('A',$,IFCLABEL('x'),$);"],
+    ], new Set([10]));
+    const model2 = buildModel('m2', 'Struct', [
+      [1, 'IFCPROJECT', "#1=IFCPROJECT('g4',$,'P2',$,$,$,$,$,$);"],
+      [2, 'IFCCOLUMN', "#2=IFCCOLUMN('g5',$,'C',$,$,$,$,$);"],
+    ]);
+
+    const exporter = new MergedExporter([model1, model2]);
+    const result = exporter.export({ schema: 'IFC4', projectStrategy: 'keep-first' });
+    const content = decode(result.content);
+
+    // Model1's deferred atom keeps id #10; model2's column must land beyond it.
+    expect(content).toContain("#10=IFCPROPERTYSINGLEVALUE('A'");
+    expect(content).toContain("#12=IFCCOLUMN('g5'"); // offset = maxId(10) → #2 → #12
+    expect(findDanglingRefs(content)).toEqual([]);
   });
 
   it('should produce valid STEP structure', () => {

--- a/packages/export/src/merged-exporter.ts
+++ b/packages/export/src/merged-exporter.ts
@@ -17,6 +17,7 @@ import { safeUtf8Decode } from '@ifc-lite/data';
 import { collectReferencedEntityIds, getVisibleEntityIds, collectStyleEntities } from './reference-collector.js';
 import { convertStepLine, needsConversion, type IfcSchemaVersion } from './schema-converter.js';
 import { assembleStepBytes } from './step-serialization.js';
+import { getCompleteEntityIndex, getMaxExpressId } from './entity-iteration.js';
 
 /** Entity types forming shared infrastructure (deduplicated across models). */
 const SHARED_INFRASTRUCTURE_TYPES = new Set([
@@ -157,14 +158,12 @@ export class MergedExporter {
     let nextAvailableId = 1;
     const modelOffsets = new Map<string, number>();
 
-    // First pass: determine ID offsets
+    // First pass: determine ID offsets. Span the COMPLETE entity set (incl.
+    // deferred property atoms) so the next model's offset clears every id this
+    // model will emit — otherwise a deferred atom at a high id collides.
     for (const model of this.models) {
       modelOffsets.set(model.id, nextAvailableId - 1); // offset = nextAvailableId - 1 so IDs start at nextAvailableId
-      let maxId = 0;
-      for (const [id] of model.dataStore.entityIndex.byId) {
-        if (id > maxId) maxId = id;
-      }
-      nextAvailableId += maxId;
+      nextAvailableId += getMaxExpressId(getCompleteEntityIndex(model.dataStore));
     }
 
     // Collect first model's info for deduplication
@@ -184,6 +183,10 @@ export class MergedExporter {
       const source = model.dataStore.source;
       if (!source || source.length === 0) continue;
 
+      // Complete view over byId + any deferred property atoms, so the closure
+      // walk and the emit loop both reach every entity the source defines.
+      const completeIndex = getCompleteEntityIndex(model.dataStore);
+
       // Determine which entities to include
       let includedEntityIds: Set<number> | null = null;
 
@@ -194,11 +197,14 @@ export class MergedExporter {
         includedEntityIds = collectReferencedEntityIds(
           roots,
           source,
-          model.dataStore.entityIndex.byId,
+          completeIndex,
           hiddenProductIds,
         );
         // Second pass: collect style entities that reference included geometry
-        collectStyleEntities(includedEntityIds, source, model.dataStore.entityIndex);
+        collectStyleEntities(includedEntityIds, source, {
+          byId: completeIndex,
+          byType: model.dataStore.entityIndex.byType,
+        });
       }
 
       // Build remap table (references to remap) and skip set (entities to omit)
@@ -240,7 +246,7 @@ export class MergedExporter {
       }
 
       // Emit entities for this model
-      for (const [expressId, entityRef] of model.dataStore.entityIndex.byId) {
+      for (const [expressId, entityRef] of completeIndex) {
         // Skip entities outside the visible closure
         if (includedEntityIds !== null && !includedEntityIds.has(expressId)) {
           continue;
@@ -316,7 +322,7 @@ export class MergedExporter {
     // First pass: count total entities for progress
     let totalEntities = 0;
     for (const model of this.models) {
-      totalEntities += model.dataStore.entityIndex.byId.size;
+      totalEntities += getCompleteEntityIndex(model.dataStore).size;
     }
 
     let nextAvailableId = 1;
@@ -324,11 +330,7 @@ export class MergedExporter {
 
     for (const model of this.models) {
       modelOffsets.set(model.id, nextAvailableId - 1);
-      let maxId = 0;
-      for (const [id] of model.dataStore.entityIndex.byId) {
-        if (id > maxId) maxId = id;
-      }
-      nextAvailableId += maxId;
+      nextAvailableId += getMaxExpressId(getCompleteEntityIndex(model.dataStore));
     }
 
     const firstModel = this.models[0];
@@ -358,15 +360,20 @@ export class MergedExporter {
         });
       }
 
+      const completeIndex = getCompleteEntityIndex(model.dataStore);
+
       let includedEntityIds: Set<number> | null = null;
       if (options.visibleOnly) {
         const hiddenIds = options.hiddenEntityIdsByModel?.get(model.id) ?? new Set<number>();
         const isolatedIds = options.isolatedEntityIdsByModel?.get(model.id) ?? null;
         const { roots, hiddenProductIds } = getVisibleEntityIds(model.dataStore, hiddenIds, isolatedIds);
         includedEntityIds = collectReferencedEntityIds(
-          roots, source, model.dataStore.entityIndex.byId, hiddenProductIds,
+          roots, source, completeIndex, hiddenProductIds,
         );
-        collectStyleEntities(includedEntityIds, source, model.dataStore.entityIndex);
+        collectStyleEntities(includedEntityIds, source, {
+          byId: completeIndex,
+          byType: model.dataStore.entityIndex.byType,
+        });
       }
 
       const sharedRemap = new Map<number, number>();
@@ -395,7 +402,7 @@ export class MergedExporter {
       }
 
       let entityCount = 0;
-      for (const [expressId, entityRef] of model.dataStore.entityIndex.byId) {
+      for (const [expressId, entityRef] of completeIndex) {
         if (includedEntityIds !== null && !includedEntityIds.has(expressId)) continue;
         if (skipEntityIds.has(expressId)) continue;
 

--- a/packages/export/src/step-exporter.test.ts
+++ b/packages/export/src/step-exporter.test.ts
@@ -13,20 +13,32 @@ import { StepExporter } from './step-exporter.js';
 /** Decode Uint8Array content to string for test assertions */
 const decode = (bytes: Uint8Array) => new TextDecoder().decode(bytes);
 
-function buildMockDataStore(entries: Array<[number, string, string]>): IfcDataStore {
+type MockEntityRef = { expressId: number; type: string; byteOffset: number; byteLength: number; lineNumber: number };
+
+function buildMockDataStore(
+  entries: Array<[number, string, string]>,
+  deferredIds?: Set<number>,
+): IfcDataStore {
   const encoder = new TextEncoder();
   const parts: Uint8Array[] = [];
-  const byId = new Map<number, { expressId: number; type: string; byteOffset: number; byteLength: number; lineNumber: number }>();
+  const byId = new Map<number, MockEntityRef>();
+  const deferred = new Map<number, MockEntityRef>();
   const byType = new Map<string, number[]>();
   let offset = 0;
 
   for (const [id, type, text] of entries) {
     const encoded = encoder.encode(text);
-    byId.set(id, { expressId: id, type: type.toUpperCase(), byteOffset: offset, byteLength: encoded.byteLength, lineNumber: 0 });
-    if (!byType.has(type.toUpperCase())) {
-      byType.set(type.toUpperCase(), []);
+    const upper = type.toUpperCase();
+    const ref: MockEntityRef = { expressId: id, type: upper, byteOffset: offset, byteLength: encoded.byteLength, lineNumber: 0 };
+    // Deferred property atoms live in the source buffer but are split out of
+    // byId/byType into deferredEntityIndex (mirrors deferPropertyAtomIndex).
+    if (deferredIds?.has(id)) {
+      deferred.set(id, ref);
+    } else {
+      byId.set(id, ref);
+      if (!byType.has(upper)) byType.set(upper, []);
+      byType.get(upper)!.push(id);
     }
-    byType.get(type.toUpperCase())!.push(id);
     parts.push(encoded);
     offset += encoded.byteLength;
   }
@@ -45,7 +57,20 @@ function buildMockDataStore(entries: Array<[number, string, string]>): IfcDataSt
     parseTime: 0,
     source,
     entityIndex: { byId, byType },
+    ...(deferred.size > 0 ? { deferredEntityIndex: deferred } : {}),
   } as unknown as IfcDataStore;
+}
+
+/** Count `#N` references in the output that have no `#N=` definition. */
+function findDanglingRefs(content: string): number[] {
+  const defined = new Set<number>();
+  for (const m of content.matchAll(/(^|\n)#(\d+)=/g)) defined.add(+m[2]);
+  const dangling = new Set<number>();
+  for (const m of content.matchAll(/#(\d+)/g)) {
+    const id = +m[1];
+    if (!defined.has(id)) dangling.add(id);
+  }
+  return [...dangling].sort((a, b) => a - b);
 }
 
 const SIMPLE_TYPE_INHERITANCE_IFC = `ISO-10303-21;
@@ -504,5 +529,29 @@ describe('StepExporter', () => {
     expect(content).toContain('IFCWALL');
     expect(content).toContain("'SAB-Safe Wall'");
     expect(result.stats.entityCount).toBeGreaterThan(0);
+  });
+
+  // Regression: github.com/LTplus-AG/ifc-lite/issues/1110
+  // The parser can defer property atoms (IfcPropertySingleValue, IfcQuantity*)
+  // out of byId on huge files. The exporter must still emit them, or the kept
+  // IfcPropertySet/IfcElementQuantity containers reference dropped entities.
+  it('emits deferred property atoms so the output has no dangling refs', () => {
+    const store = buildMockDataStore([
+      [1, 'IFCPROJECT', "#1=IFCPROJECT('g1',$,'P',$,$,$,$,$,$);"],
+      [2, 'IFCWALL', "#2=IFCWALL('g2',$,'W',$,$,$,$,$);"],
+      [3, 'IFCPROPERTYSET', "#3=IFCPROPERTYSET('g3',$,'Pset_Wall',$,(#5));"],
+      [4, 'IFCELEMENTQUANTITY', "#4=IFCELEMENTQUANTITY('g4',$,'Qto',$,$,(#6));"],
+      [5, 'IFCPROPERTYSINGLEVALUE', "#5=IFCPROPERTYSINGLEVALUE('IsExternal',$,IFCBOOLEAN(.T.),$);"],
+      [6, 'IFCQUANTITYLENGTH', "#6=IFCQUANTITYLENGTH('Length',$,$,2500.,$);"],
+      [7, 'IFCRELDEFINESBYPROPERTIES', "#7=IFCRELDEFINESBYPROPERTIES('g7',$,$,$,(#2),#3);"],
+    ], new Set([5, 6]));
+
+    const exporter = new StepExporter(store);
+    const result = exporter.export({ schema: 'IFC4' });
+    const content = decode(result.content);
+
+    expect(content).toContain("#5=IFCPROPERTYSINGLEVALUE('IsExternal'");
+    expect(content).toContain("#6=IFCQUANTITYLENGTH('Length'");
+    expect(findDanglingRefs(content)).toEqual([]);
   });
 });

--- a/packages/export/src/step-exporter.ts
+++ b/packages/export/src/step-exporter.ts
@@ -25,6 +25,7 @@ import { safeUtf8Decode } from '@ifc-lite/data';
 import { generateIfcGuid } from '@ifc-lite/encoding';
 import { collectReferencedEntityIds, getVisibleEntityIds, collectStyleEntities } from './reference-collector.js';
 import { convertStepLine, needsConversion, type IfcSchemaVersion } from './schema-converter.js';
+import { getCompleteEntityIndex, getMaxExpressId } from './entity-iteration.js';
 import {
   escapeStepString,
   toStepReal,
@@ -468,6 +469,11 @@ export class StepExporter {
       };
     }
 
+    // Complete view over byId + any deferred property atoms. Walking byId alone
+    // drops deferred atoms while keeping the IfcPropertySet/IfcElementQuantity
+    // references to them, producing dangling #-refs in the output.
+    const completeIndex = getCompleteEntityIndex(this.dataStore);
+
     // Build visible-only closure if requested
     let allowedEntityIds: Set<number> | null = null;
     if (options.visibleOnly && this.dataStore.source) {
@@ -479,7 +485,7 @@ export class StepExporter {
       allowedEntityIds = collectReferencedEntityIds(
         roots,
         this.dataStore.source,
-        this.dataStore.entityIndex.byId,
+        completeIndex,
         hiddenProductIds,
       );
       // Second pass: collect IFCSTYLEDITEM entities that reference included
@@ -488,7 +494,7 @@ export class StepExporter {
       collectStyleEntities(
         allowedEntityIds,
         this.dataStore.source,
-        this.dataStore.entityIndex,
+        { byId: completeIndex, byType: this.dataStore.entityIndex.byType },
       );
     }
 
@@ -498,7 +504,7 @@ export class StepExporter {
 
       // Extract existing entities from source
       const overlayActive = !!this.mutationView && (options.applyMutations !== false);
-      for (const [expressId, entityRef] of this.dataStore.entityIndex.byId) {
+      for (const [expressId, entityRef] of completeIndex) {
         // Skip entities deleted via the overlay (only when mutations are applied)
         if (overlayActive && typeof this.mutationView!.isDeleted === 'function' && this.mutationView!.isDeleted(expressId)) {
           continue;
@@ -680,7 +686,7 @@ export class StepExporter {
     const onProgress = options.onProgress;
 
     // Report preparing phase
-    const totalEntities = this.dataStore.entityIndex.byId.size;
+    const totalEntities = getCompleteEntityIndex(this.dataStore).size;
     if (onProgress) onProgress({ phase: 'preparing', percent: 0, entitiesProcessed: 0, entitiesTotal: totalEntities });
     await new Promise(r => setTimeout(r, 0));
 
@@ -998,11 +1004,9 @@ export class StepExporter {
    * Find the maximum EXPRESS ID in the data store
    */
   private findMaxExpressId(): number {
-    let max = 0;
-    for (const [id] of this.dataStore.entityIndex.byId) {
-      if (id > max) max = id;
-    }
-    return max;
+    // Span deferred property atoms too, so newly allocated ids can't collide
+    // with a deferred entity sitting at a higher express id than anything in byId.
+    return getMaxExpressId(getCompleteEntityIndex(this.dataStore));
   }
 
   /**

--- a/packages/mutations/src/store-editor.ts
+++ b/packages/mutations/src/store-editor.ts
@@ -155,7 +155,8 @@ export class StoreEditor {
     // the current source index BEFORE calling createEntity, so we don't
     // emit phantom CREATE_ENTITY / DELETE_ENTITY pairs into the mutation
     // history just to fix our own bookkeeping.
-    if (this.store.entityIndex.byId.has(this.view.peekNextExpressId())) {
+    const nextId = this.view.peekNextExpressId();
+    if (this.store.entityIndex.byId.has(nextId) || this.store.deferredEntityIndex?.has(nextId)) {
       this.refreshWatermark();
     }
     const created = this.view.createEntity(canonical, attributes);
@@ -260,6 +261,15 @@ export class StoreEditor {
     let max = 0;
     for (const id of this.store.entityIndex.byId.keys()) {
       if (id > max) max = id;
+    }
+    // Deferred property atoms occupy express ids too — clear them so a newly
+    // allocated overlay id can never collide with a deferred atom that sits
+    // above the primary-index maximum (which the exporter now emits).
+    const deferred = this.store.deferredEntityIndex;
+    if (deferred) {
+      for (const id of deferred.keys()) {
+        if (id > max) max = id;
+      }
     }
     return max;
   }

--- a/packages/mutations/src/types.ts
+++ b/packages/mutations/src/types.ts
@@ -181,6 +181,15 @@ export interface MutationStoreShape {
   entityIndex: {
     byId: MutationEntityByIdIndex;
   };
+  /**
+   * Secondary index of property atoms the parser deferred out of `byId` on
+   * huge files (`deferPropertyAtomIndex`). These still occupy express ids in
+   * the source, so the overlay id allocator must clear them too — otherwise a
+   * deferred atom sitting above `max(byId)` gets its id reused for a new
+   * overlay entity, producing a duplicate `#ID=` definition once the exporter
+   * emits both. See @ifc-lite/export `getCompleteEntityIndex`.
+   */
+  deferredEntityIndex?: MutationEntityByIdIndex;
 }
 
 /**

--- a/packages/mutations/test/store-editor.test.ts
+++ b/packages/mutations/test/store-editor.test.ts
@@ -11,10 +11,17 @@ import {
   type MutationStoreShape,
 } from '../src/index.js';
 
-function makeStore(maxId: number): MutationStoreShape {
+function makeStore(maxId: number, deferredIds?: number[]): MutationStoreShape {
   const byId = new Map<number, MutationEntityRef>();
   for (let id = 1; id <= maxId; id++) {
     byId.set(id, { expressId: id, type: 'IFCWALL', byteOffset: 0, byteLength: 1, lineNumber: id });
+  }
+  if (deferredIds && deferredIds.length > 0) {
+    const deferred = new Map<number, MutationEntityRef>();
+    for (const id of deferredIds) {
+      deferred.set(id, { expressId: id, type: 'IFCPROPERTYSINGLEVALUE', byteOffset: 0, byteLength: 1, lineNumber: id });
+    }
+    return { entityIndex: { byId }, deferredEntityIndex: deferred };
   }
   return { entityIndex: { byId } };
 }
@@ -34,6 +41,22 @@ describe('StoreEditor', () => {
 
     expect(editor.getNewEntities()).toHaveLength(1);
     expect(editor.getNewEntity(11)?.attributes).toEqual(['.AREA.', null, '#34', 0.6, 0.4]);
+  });
+
+  // Regression: github.com/LTplus-AG/ifc-lite/issues/1110 (PR review)
+  // On huge files the parser defers property atoms out of byId; a deferred atom
+  // can sit ABOVE max(byId). The overlay id watermark must clear it, or a new
+  // entity reuses that id and the exporter emits two #ID= definitions for it.
+  it('addEntity allocates above deferred property atoms sitting beyond max(byId)', () => {
+    // byId max = 10, but a deferred atom occupies #25.
+    const store = makeStore(10, [25]);
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(store, view);
+
+    const ref = editor.addEntity('IFCDIRECTION', [[0, 0, 1]]);
+
+    // Must clear the deferred atom at #25, not collide at #11.
+    expect(ref.expressId).toBe(26);
   });
 
   it('addEntity continues allocating monotonically across calls', () => {


### PR DESCRIPTION
## Problem (#1110)

`MergedExporter` produces STEP files with hundreds of thousands of **dangling `#`-references** (~611k of 15.5M on a real two-model Revit merge). Strict viewers (**BIM Vision**) refuse to open the file; lenient ones open it but render some elements **displaced to the origin** because a placement / type / material chain resolves to a dropped entity.

## Root cause

On large files the parser moves high-cardinality **property atoms** (`IfcPropertySingleValue`, `IfcQuantity*`, `IfcPropertyEnumeratedValue`, …) out of `entityIndex.byId` into a secondary **`deferredEntityIndex`** to cap memory (the `deferPropertyAtomIndex` parse option). Those atoms stay in `source` and are still referenced by the `IfcPropertySet` / `IfcElementQuantity` **containers** that remain in `byId`.

Every other consumer (on-demand property/material extraction, `material-resolver`) reads through the canonical `byId.get(id) ?? deferredEntityIndex.get(id)` fallback — but **`MergedExporter` and `StepExporter` walked `byId` alone**. They emitted the containers while silently dropping the atoms those containers reference → dangling refs. This is exactly why the in-app federated **view** is fine (it uses the fallback) but the merged **export** is broken.

Confirmed empirically: parsing `AB22.ifc` with `deferPropertyAtomIndex: true` and merging it yields **672 dangling refs** (336/model) — the same shape that scales to the reporter's ~611k on two large Revit models.

## Fix

- New shared helper `packages/export/src/entity-iteration.ts` → `getCompleteEntityIndex(dataStore)` returns a Map-like view over `byId` **+** `deferredEntityIndex`. **Fast path:** when nothing was deferred it returns the primary index unchanged, so the common path is byte-identical and zero-overhead.
- `MergedExporter` (`export` + `exportAsync`): emit loop, visible-only closure walk, style collection, progress count, **and the per-model ID-offset / maxId computation** now span the complete set — so a deferred atom at a high express id can't collide with the next model's remapped ids.
- `StepExporter`: same for the main emit loop, visible-only closure/style pass, and `findMaxExpressId` (new-entity id allocation).

## Verification

Real parser, deferral on — all go from hundreds of dangling refs to **0**:
- self-merge, **cross-model partial unification**, single-model STEP, and the real CLI `merge` command end-to-end.
- Default (no-deferral) path is **byte-identical** to before (fast path returns `byId`), so zero regression risk.
- New regression tests (merge sync + async, deferred-atom-at-max-id collision, single-model STEP) assert zero dangling refs.
- Full `@ifc-lite/export` suite green (130 tests); `export` + `cli` + `sdk` typecheck clean.

## Out of scope

The **duplicate-GlobalId** item noted in the issue is explicitly *separate* (the reporter works around it downstream and the merge intentionally does not regenerate GUIDs). Not addressed here.

Fixes #1110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed STEP file export output for large models. Previously, certain property atoms were omitted during export, resulting in incomplete definitions and broken entity references in the final STEP files. The exporter now correctly includes all referenced property atoms, ensuring complete and valid STEP output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->