### PR TITLE
Space Sketch overhaul: modeless draw, snap-to-building, DCEL orphan cleanup, engine net/gross

### DIFF
--- a/.changeset/evict-stale-highlight-on-move.md
+++ b/.changeset/evict-stale-highlight-on-move.md
@@ -1,0 +1,12 @@
+---
+"@ifc-lite/renderer": patch
+---
+
+Fix the ghost left when moving (or deleting/splitting) a selected element. The
+per-entity selection-highlight meshes in `Scene.meshes` are frozen position
+copies made at selection time and were only ever cleared by `clear()` — so an
+element moved while selected (the gizmo holds the selection through the drag)
+kept drawing its highlight at the OLD position, a faint duplicate. `Scene` now
+evicts an entity's standalone highlight meshes (freeing their GPU buffers) in
+`translateMeshesForEntity` and `removeMeshesForEntity`, so the highlight is
+re-extracted from the entity's current geometry on the next frame.

--- a/.changeset/scene-streaming-fragment-accessors.md
+++ b/.changeset/scene-streaming-fragment-accessors.md
@@ -1,0 +1,10 @@
+---
+"@ifc-lite/renderer": patch
+---
+
+Add `Scene.hasStreamingFragments()` and `Scene.isEphemeralStreaming()`
+accessors. They let the viewer detect an element that was appended during
+streaming and still rendered as a streaming fragment — which, after the element
+is moved (its colour bucket re-batched), would otherwise linger as a ghost
+duplicate at the original position — and finalise the fragments into clean
+buckets (skipping ephemeral mode, where no geometry is retained to rebuild from).

--- a/.changeset/space-plate-edit-ops.md
+++ b/.changeset/space-plate-edit-ops.md
@@ -1,0 +1,10 @@
+---
+"@ifc-lite/wasm": minor
+---
+
+Add two interactive editing operations to `SpacePlateHandle` (the persistent space-topology editor):
+
+- `dissolveVertex(v)` — dissolve a degree-2 vertex, welding its two incident edges into one straight edge between the neighbours (the inverse of `splitEdge`). Rejects wall junctions (degree ≥ 3) and welds that would duplicate an edge.
+- `addFace(coords, source)` — author a new room face from a flat ring `[x0, y0, x1, y1, …]`; winding is normalised to CCW and the room becomes its own connected component. Rejects rings that are too short, self-intersecting, or near-zero area.
+
+Backed by new `dissolve_vertex` / `add_face` operations in the `ifc-lite-geometry` `space_dcel` core.

--- a/.changeset/space-plate-face-based-rooms.md
+++ b/.changeset/space-plate-face-based-rooms.md
@@ -2,15 +2,16 @@
 "@ifc-lite/wasm": minor
 ---
 
-`SpacePlateHandle` gains a face-based room derivation: `fromWallRects(rectCoords,
-snapTolerance, minArea)` builds a plate from each wall's footprint **rectangle**
-(4 corners, wall-major) instead of its centreline. Rooms are the bounded **gaps
-between** the rectangles — a face is a room iff its centroid falls outside every
-wall rectangle — so the room boundary is the wall faces themselves and every node
-lands on the true wall axis (no centreline distribution bias).
+`SpacePlateHandle` gains `fromWallRects(rectCoords, snapTolerance, minArea)`: build
+a plate from each wall's footprint **rectangle** (4 corners, wall-major) instead of
+its centreline. Rooms are detected as the bounded **gaps between** the rectangles
+(a face is a room iff its centroid is outside every rectangle), so the room
+boundary lands on the wall faces with no centreline distribution bias — then each
+room is LIFTED to its wall axis, so the returned plate is a normal centreline plate
+whose room outlines are the wall axes and whose vertices are the editable nodes.
+Every edit op (drag / split / merge) therefore acts directly on what's displayed,
+and `netOutline(face, inset)` recovers the inner (net) / outer (gross) faces.
 
-`gapBoundary(face, factor)` reads a room's outline offset outward per edge by
-`factor · ½ thickness`: `0` = net (inner faces), `1` = the wall axis (centreline),
-`2` = gross (outer faces). The corner re-intersection is miter-clamped so a
-concave room's outward offset can't blow up. Centreline plates
-(`new SpacePlateHandle(...)`) are unchanged.
+Room classification is now a stable per-face flag set once at build and carried
+through edits (split inherits it, merge ORs it) — so dragging a vertex or cutting a
+room can no longer silently re-classify faces into phantom rooms.

--- a/.changeset/space-plate-face-based-rooms.md
+++ b/.changeset/space-plate-face-based-rooms.md
@@ -1,0 +1,16 @@
+---
+"@ifc-lite/wasm": minor
+---
+
+`SpacePlateHandle` gains a face-based room derivation: `fromWallRects(rectCoords,
+snapTolerance, minArea)` builds a plate from each wall's footprint **rectangle**
+(4 corners, wall-major) instead of its centreline. Rooms are the bounded **gaps
+between** the rectangles — a face is a room iff its centroid falls outside every
+wall rectangle — so the room boundary is the wall faces themselves and every node
+lands on the true wall axis (no centreline distribution bias).
+
+`gapBoundary(face, factor)` reads a room's outline offset outward per edge by
+`factor · ½ thickness`: `0` = net (inner faces), `1` = the wall axis (centreline),
+`2` = gross (outer faces). The corner re-intersection is miter-clamped so a
+concave room's outward offset can't blow up. Centreline plates
+(`new SpacePlateHandle(...)`) are unchanged.

--- a/.changeset/space-plate-net-area-and-removal.md
+++ b/.changeset/space-plate-net-area-and-removal.md
@@ -1,0 +1,20 @@
+---
+"@ifc-lite/wasm": minor
+---
+
+Extend `SpacePlateHandle` (the persistent space-topology editor) with orphan
+removal and engine-computed wall-boundary outlines:
+
+- `removeEdge(edge)` — remove a wall, choosing the right semantics from its two
+  faces: union two real rooms, or delete a bridge/spur wall and auto-clean the
+  orphaned inner lines + nodes it leaves; a real enclosing wall is refused.
+- `prune()` — sweep the plate clean (dangling spur walls, isolated nodes,
+  redundant collinear nodes); returns how many elements were pruned. Build also
+  auto-prunes so derived plates start as just their rooms.
+- `netOutline(face, inset)` — the room outline offset to the net (inner) or
+  gross (outer) wall face, using each edge's own wall half-thickness with
+  topology-aware shared-edge pinning (no fuzzy edge↔wall matching).
+
+The constructor now takes an additional `segHalfThickness: Float64Array`
+(per-segment half-thickness in metres, carried onto the derived edges for
+`netOutline`); pass an empty array when thickness is unknown.

--- a/.changeset/translate-authored-meshes.md
+++ b/.changeset/translate-authored-meshes.md
@@ -1,0 +1,13 @@
+---
+"@ifc-lite/renderer": patch
+---
+
+Fix `Scene.translateMeshesForEntity` skipping single-entity meshes. The move
+gizmo couldn't move an authored element (a baked IfcSpace, or an added
+slab/wall/…) even though its placement and bounding box resolved: those meshes
+tag every vertex with their own entity id for picking, and the translate path
+skipped *any* mesh with a non-empty `entityIds` (meant to protect shared
+colour-merged meshes from dragging unrelated entities). Now it skips only a
+genuine merge — one whose vertices carry a *different* entity id — so a
+single-entity mesh (all vertices tagged with the target id) translates as
+expected. Parsed single-entity meshes (empty `entityIds`) are unaffected.

--- a/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.test.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.test.ts
@@ -7,7 +7,7 @@ import assert from 'node:assert';
 import { IfcTypeEnum, type SpatialHierarchy, type SpatialNode } from '@ifc-lite/data';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import { useViewerStore, type FederatedModel } from '@/store';
-import { buildTreeData } from './treeDataBuilder';
+import { buildTreeData, buildTypeTree, type AuthoredProduct } from './treeDataBuilder';
 
 function createSpatialNode(
   expressId: number,
@@ -114,6 +114,31 @@ function createModel(idOffset: number): FederatedModel {
     maxExpressId: 7,
   };
 }
+
+describe('buildTypeTree — authored (overlay) products', () => {
+  // entities.count === 0 so the columnar scan is empty; only the authored
+  // fold-in produces nodes — isolating the new path.
+  it('folds an authored IfcSpace into its class group and dedups by globalId', () => {
+    const ds = createDataStore();
+    const authored: AuthoredProduct[] = [
+      { modelId: 'legacy', expressId: 900, globalId: 900, name: 'Space 1', ifcType: 'IfcSpace' },
+      { modelId: 'legacy', expressId: 900, globalId: 900, name: 'dup', ifcType: 'IfcSpace' },
+    ];
+    const nodes = buildTypeTree(new Map(), ds, new Set(['type-IfcSpace']), false, new Set([900]), authored);
+    const group = nodes.find((n) => n.type === 'type-group' && n.ifcType === 'IfcSpace');
+    assert.ok(group, 'an IfcSpace class group exists');
+    assert.strictEqual(group.elementCount, 1, 'deduped by globalId');
+    const el = nodes.find((n) => n.type !== 'type-group' && n.expressIds[0] === 900);
+    assert.ok(el, 'the authored space appears as an element (group expanded)');
+    assert.strictEqual(el.name, 'Space 1');
+  });
+
+  it('does nothing when there are no authored products', () => {
+    const ds = createDataStore();
+    const nodes = buildTypeTree(new Map(), ds, new Set(), false, new Set(), []);
+    assert.strictEqual(nodes.length, 0);
+  });
+});
 
 describe('buildTreeData', () => {
   it('keeps IfcSpace as a spatial node, expands bySpace children, and avoids storey duplicates', () => {

--- a/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.ts
@@ -462,15 +462,28 @@ export function buildTreeData(
   return nodes;
 }
 
+/** An authored (overlay) product to fold into the class/type trees — it lives in
+ *  the mutation overlay, not the columnar parse those builders scan. */
+export interface AuthoredProduct {
+  modelId: string;
+  expressId: number;
+  globalId: number;
+  name: string;
+  ifcType: string;
+}
+
 /** Build tree data grouped by IFC class instead of spatial hierarchy.
  *  Only includes entities that have geometry (visible in the 3D viewer).
- *  @param geometricIds Pre-computed set of global IDs with geometry (memoized by caller). */
+ *  @param geometricIds Pre-computed set of global IDs with geometry (memoized by caller).
+ *  @param authoredProducts Overlay-authored products (e.g. a baked IfcSpace) that
+ *    aren't in the columnar table but have geometry — folded into their class. */
 export function buildTypeTree(
   models: Map<string, FederatedModel>,
   ifcDataStore: IfcDataStore | null | undefined,
   expandedNodes: Set<string>,
   isMultiModel: boolean,
   geometricIds?: Set<number>,
+  authoredProducts?: AuthoredProduct[],
 ): TreeNode[] {
   // Collect entities grouped by IFC class across all models
   const typeGroups = new Map<string, Array<{ expressId: number; globalId: number; name: string; modelId: string }>>();
@@ -502,6 +515,17 @@ export function buildTypeTree(
     }
   } else if (ifcDataStore) {
     processDataStore(ifcDataStore, 'legacy');
+  }
+
+  // Fold in authored (overlay) products — a baked IfcSpace, an added slab, … —
+  // which the columnar scan above can't see, so they'd otherwise be absent from
+  // the "By Class" tree even though they render in 3D.
+  for (const p of authoredProducts ?? []) {
+    let list = typeGroups.get(p.ifcType);
+    if (!list) { list = []; typeGroups.set(p.ifcType, list); }
+    if (!list.some((e) => e.globalId === p.globalId)) {
+      list.push({ expressId: p.expressId, globalId: p.globalId, name: p.name, modelId: p.modelId });
+    }
   }
 
   // Sort types alphabetically

--- a/apps/viewer/src/components/viewer/hierarchy/useHierarchyTree.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/useHierarchyTree.ts
@@ -16,6 +16,7 @@ import {
   buildMaterialTree,
   filterNodes,
   splitNodes,
+  type AuthoredProduct,
 } from './treeDataBuilder';
 
 export type GroupingMode = 'spatial' | 'type' | 'ifc-type' | 'material';
@@ -183,12 +184,44 @@ export function useHierarchyTree({ models, ifcDataStore, isMultiModel, geometryR
     return expressIds.map((expressId) => state.toGlobalId(modelId, expressId));
   }, []);
 
+  // Authored (overlay) products with geometry. They live in the mutation overlay,
+  // not the columnar parse the class/type builders scan, so a baked IfcSpace was
+  // absent from the "By Class" tree. Filtering by geometricIds keeps it to real
+  // products (the space has a mesh; its helper points/placements/solids don't).
+  const mutationViews = useViewerStore((s) => s.mutationViews);
+  const mutationVersion = useViewerStore((s) => s.mutationVersion);
+  const authoredProducts = useMemo<AuthoredProduct[]>(() => {
+    const out: AuthoredProduct[] = [];
+    const state = useViewerStore.getState();
+    for (const [modelId, view] of mutationViews) {
+      const getNew = (view as { getNewEntities?: () => Iterable<{ expressId: number; type: string; attributes: unknown[] }> }).getNewEntities;
+      if (typeof getNew !== 'function') continue;
+      for (const ent of getNew.call(view)) {
+        const globalId = modelId === 'legacy' || !models.has(modelId)
+          ? ent.expressId
+          : state.toGlobalId(modelId, ent.expressId);
+        if (!geometricIds.has(globalId)) continue;
+        const rawName = ent.attributes?.[2];
+        out.push({
+          modelId,
+          expressId: ent.expressId,
+          globalId,
+          ifcType: ent.type,
+          name: typeof rawName === 'string' && rawName ? rawName : `${ent.type} #${ent.expressId}`,
+        });
+      }
+    }
+    return out;
+    // mutationVersion bumps on every authoring edit; geometricIds tracks the mesh.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mutationViews, models, geometricIds, mutationVersion]);
+
   // Build the tree data structure based on grouping mode
   // Note: hiddenEntities intentionally NOT in deps - visibility computed lazily for performance
   const treeData = useMemo(
     (): TreeNode[] => {
       if (groupingMode === 'type') {
-        return buildTypeTree(models, ifcDataStore, expandedNodes, isMultiModel, geometricIds);
+        return buildTypeTree(models, ifcDataStore, expandedNodes, isMultiModel, geometricIds, authoredProducts);
       }
       if (groupingMode === 'ifc-type') {
         return buildIfcTypeTree(models, ifcDataStore, expandedNodes, isMultiModel, geometricIds);
@@ -198,7 +231,7 @@ export function useHierarchyTree({ models, ifcDataStore, isMultiModel, geometryR
       }
       return buildTreeData(models, ifcDataStore, expandedNodes, isMultiModel, unifiedStoreys);
     },
-    [models, ifcDataStore, expandedNodes, isMultiModel, unifiedStoreys, groupingMode, geometricIds]
+    [models, ifcDataStore, expandedNodes, isMultiModel, unifiedStoreys, groupingMode, geometricIds, authoredProducts]
   );
 
   // Filter nodes based on search

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -30,7 +30,7 @@ import {
   GENERATED_SPACE_OBJECTTYPE,
   type BoundaryMode,
 } from '@ifc-lite/create';
-import { X, Undo2, Redo2, Building2, Layers } from 'lucide-react';
+import { X, Undo2, Redo2, Building2, Layers, Maximize, AlertTriangle } from 'lucide-react';
 
 let wasmReady: Promise<void> | null = null;
 function ensureWasm(): Promise<void> {
@@ -48,7 +48,7 @@ interface Boundary {
   edge: number;
   source: number | null;
 }
-type Mode = 'drag' | 'split' | 'merge';
+type Mode = 'drag' | 'split' | 'merge' | 'draw';
 type Pt = [number, number];
 type Hover =
   | { kind: 'vertex'; pos: Pt }
@@ -58,8 +58,10 @@ type Hover =
  *  edge (which becomes a new node when the cut is committed). */
 type SplitTarget = { kind: 'vertex'; vid: number; pos: Pt } | { kind: 'edge'; edge: number; pos: Pt };
 
-const SVG_W = 580;
-const SVG_H = 460;
+const DEFAULT_W = 580;
+const DEFAULT_H = 460;
+const MIN_W = 360;
+const MIN_H = 280;
 const PAD = 36;
 const PICK_PX = 12;
 const SNAP_PX = 10;
@@ -88,23 +90,33 @@ const centroid = (pts: Pt[]): Pt => {
   return [cx / pts.length, cy / pts.length];
 };
 
-interface Fit { scale: number; minX: number; minY: number }
+/** Screen transform as a pure affine: `screen = off + world * scale` (Y
+ *  flipped). Decoupling from the canvas size + a fixed origin is what lets the
+ *  same struct carry fit-to-bounds, wheel-zoom, and drag-pan (Issue 4). */
+interface Fit { scale: number; offX: number; offY: number }
 
-function computeFit(rooms: Room[]): Fit {
+/** Frame the rooms centred within a `w`×`h` canvas (PAD margin) as an affine. */
+function computeFit(rooms: Room[], w: number, h: number): Fit {
   let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
   for (const r of rooms) for (const [x, y] of r.outline) {
     minX = Math.min(minX, x); minY = Math.min(minY, y);
     maxX = Math.max(maxX, x); maxY = Math.max(maxY, y);
   }
-  if (!isFinite(minX)) return { scale: 1, minX: 0, minY: 0 };
-  const scale = Math.min((SVG_W - 2 * PAD) / Math.max(maxX - minX, 1e-6), (SVG_H - 2 * PAD) / Math.max(maxY - minY, 1e-6));
-  return { scale, minX, minY };
+  if (!isFinite(minX)) return { scale: 1, offX: PAD, offY: h - PAD };
+  const scale = Math.min((w - 2 * PAD) / Math.max(maxX - minX, 1e-6), (h - 2 * PAD) / Math.max(maxY - minY, 1e-6));
+  const cx = (minX + maxX) / 2, cy = (minY + maxY) / 2;
+  return { scale, offX: w / 2 - cx * scale, offY: h / 2 + cy * scale };
 }
 
-const sX = (f: Fit, x: number) => PAD + (x - f.minX) * f.scale;
-const sY = (f: Fit, y: number) => SVG_H - PAD - (y - f.minY) * f.scale;
-const wX = (f: Fit, sx: number) => f.minX + (sx - PAD) / f.scale;
-const wY = (f: Fit, sy: number) => f.minY + (SVG_H - PAD - sy) / f.scale;
+/** Zoom by `factor` about screen point `(ax, ay)` (keeps it fixed). */
+function zoomFit(f: Fit, factor: number, ax: number, ay: number): Fit {
+  return { scale: f.scale * factor, offX: ax - (ax - f.offX) * factor, offY: ay + (f.offY - ay) * factor };
+}
+
+const sX = (f: Fit, x: number) => f.offX + x * f.scale;
+const sY = (f: Fit, y: number) => f.offY - y * f.scale;
+const wX = (f: Fit, sx: number) => (sx - f.offX) / f.scale;
+const wY = (f: Fit, sy: number) => (f.offY - sy) / f.scale;
 
 function distToSeg(px: number, py: number, ax: number, ay: number, bx: number, by: number): number {
   const dx = bx - ax, dy = by - ay;
@@ -144,20 +156,22 @@ export function SpaceSketchOverlay() {
   const plateRef = useRef<SpacePlateHandle | null>(null);
   const svgRef = useRef<SVGSVGElement | null>(null);
   const panelRef = useRef<HTMLDivElement | null>(null);
-  const fitRef = useRef<Fit>({ scale: 1, minX: 0, minY: 0 });
+  const fitRef = useRef<Fit>({ scale: 1, offX: PAD, offY: DEFAULT_H - PAD });
   const rafRef = useRef<number | null>(null);
   const rebuildTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const buildSeqRef = useRef(0);
   // IfcSpace expressIds this session created per storey — so a re-bake (or
   // "Generate all") replaces the spaces it dropped instead of duplicating.
   const generatedRef = useRef<Map<number, number[]>>(new Map());
-  const moveRef = useRef<{ x: number; y: number; shift: boolean } | null>(null);
+  const moveRef = useRef<{ x: number; y: number; shift: boolean; del: boolean } | null>(null);
 
   const dragRef = useRef<number | null>(null);
   const dragStartRef = useRef<Pt | null>(null);
   const otherVertsRef = useRef<Pt[]>([]);
   const pendingUndoRef = useRef<SpacePlateHandle | null>(null);
   const draggedRef = useRef(false);
+  const panningRef = useRef(false); // Issue 4: middle-mouse / empty-drag panning
+  const resizeRef = useRef<{ x: number; y: number; w: number; h: number } | null>(null);
 
   const undoRef = useRef<SpacePlateHandle[]>([]);
   const redoRef = useRef<SpacePlateHandle[]>([]);
@@ -168,6 +182,19 @@ export function SpaceSketchOverlay() {
   const [splitPick, setSplitPick] = useState<SplitTarget | null>(null);
   const [splitHover, setSplitHover] = useState<Pt | null>(null);
   const [snapPos, setSnapPos] = useState<Pt | null>(null);
+  // Issue 3: the vertex that an ⌥/Ctrl-click would dissolve — telegraphed live.
+  const [deleteHover, setDeleteHover] = useState<Pt | null>(null);
+  // Issue 2: the in-progress drawn room (world coords) + the live cursor point.
+  const [drawPts, setDrawPts] = useState<Pt[]>([]);
+  const [drawCursor, setDrawCursor] = useState<Pt | null>(null);
+  // Issue 4: canvas size (resizable) + a tick that forces a re-render whenever
+  // the view transform in fitRef changes (zoom/pan/fit) without making the
+  // per-frame pointer math go through React state.
+  const [size, setSize] = useState({ w: DEFAULT_W, h: DEFAULT_H });
+  const sizeRef = useRef(size);
+  sizeRef.current = size;
+  const [fitTick, setFitTick] = useState(0);
+  const applyFit = useCallback((next: Fit) => { fitRef.current = next; setFitTick((t) => t + 1); }, []);
   const [derivedStorey, setDerivedStorey] = useState<number | null>(null);
   const [snapTol, setSnapTol] = useState<number | null>(null); // null = auto-escalate
   const [usedTol, setUsedTol] = useState(0.1);
@@ -182,7 +209,13 @@ export function SpaceSketchOverlay() {
   const [hist, setHist] = useState(0);
   const [status, setStatus] = useState('Load the demo plate or derive from a storey.');
   const [showBuilding, setShowBuilding] = useState(true);
+  const [showDiagnostics, setShowDiagnostics] = useState(false); // Issue 7 — leak diagnostics
   const [boundaryMode, setBoundaryMode] = useState<BoundaryMode>('inner');
+  // Transient "12 → 9 rooms" badge after a corner-tolerance rebuild — the
+  // effect on the plan is otherwise invisible (Issue 5).
+  const [snapDelta, setSnapDelta] = useState<{ from: number; to: number } | null>(null);
+  const pendingSnapPrevRef = useRef<number | null>(null);
+  const snapDeltaTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Every IfcBuildingStorey with its resolved name + elevation, low → high.
   const storeys = useMemo(() => {
@@ -219,7 +252,7 @@ export function SpaceSketchOverlay() {
         strokeDasharray={l.hidden ? '3 3' : undefined}
         pointerEvents="none" />
     ));
-  }, [underlay, showBuilding, hist]);
+  }, [underlay, showBuilding, fitTick]);
   const [storeyId, setStoreyId] = useState<number | null>(null);
   const lastDerivedRef = useRef<string | null>(null);
   // Connect to the shared active storey instead of always defaulting to the
@@ -308,6 +341,43 @@ export function SpaceSketchOverlay() {
     setStatus('Redo.');
   }, [resetInteraction, refreshRooms]);
 
+  // Ctrl/Cmd+Z (Shift = redo) must drive THIS overlay's history, not the 3D
+  // model behind the panel. The global handler in useKeyboardShortcuts routes
+  // Ctrl+Z to the active model's mutation stack; a capture-phase listener here
+  // runs before it and stopPropagation()s, so the sketch and the in-panel
+  // Undo/Redo buttons share one history. Skip when a text input is focused so
+  // native field undo (and the global handler, which also skips inputs) is
+  // untouched. The overlay only mounts while the tool is active, so this
+  // listener's lifetime is exactly the tool's.
+  useEffect(() => {
+    const onUndoRedo = (e: KeyboardEvent) => {
+      if (e.key.toLowerCase() !== 'z' || !(e.ctrlKey || e.metaKey)) return;
+      const t = e.target as HTMLElement | null;
+      if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
+      e.preventDefault();
+      e.stopPropagation();
+      if (e.shiftKey) redo(); else undo();
+    };
+    window.addEventListener('keydown', onUndoRedo, true);
+    return () => window.removeEventListener('keydown', onUndoRedo, true);
+  }, [undo, redo]);
+
+  // Wheel = zoom about the cursor (Issue 4). A native non-passive listener so
+  // preventDefault() actually stops the page from scrolling under the panel.
+  useEffect(() => {
+    const el = svgRef.current;
+    if (!el) return;
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      const rect = el.getBoundingClientRect();
+      const factor = Math.exp(-e.deltaY * 0.0015); // scroll up → zoom in
+      const next = zoomFit(fitRef.current, factor, e.clientX - rect.left, e.clientY - rect.top);
+      if (next.scale >= 0.5 && next.scale <= 5000) { fitRef.current = next; setFitTick((t) => t + 1); }
+    };
+    el.addEventListener('wheel', onWheel, { passive: false });
+    return () => el.removeEventListener('wheel', onWheel);
+  }, []);
+
   const buildFrom = useCallback(async (coords: Float64Array, sources: Int32Array, label: string, storey: number | null) => {
     // Re-entrancy guard: a rapid rebuild (snap slider) must not let an older
     // async build free/replace the plate a newer one is using — that races the
@@ -342,16 +412,25 @@ export function SpaceSketchOverlay() {
       plateRef.current = plate!;
       setUsedTol(used);
       const snap = plate!.snapshot() as Room[];
-      fitRef.current = computeFit(snap);
+      applyFit(computeFit(snap, sizeRef.current.w, sizeRef.current.h));
       resetInteraction();
       setDerivedStorey(storey);
       setRooms(snap); setHist((v) => v + 1);
+      // Surface the room-count consequence of a corner-tolerance change (only a
+      // snap rebuild sets pendingSnapPrevRef; an initial derive leaves it null).
+      const prevCount = pendingSnapPrevRef.current;
+      pendingSnapPrevRef.current = null;
+      if (prevCount != null && prevCount !== snap.length) {
+        setSnapDelta({ from: prevCount, to: snap.length });
+        if (snapDeltaTimerRef.current) clearTimeout(snapDeltaTimerRef.current);
+        snapDeltaTimerRef.current = setTimeout(() => setSnapDelta(null), 1800);
+      }
       const total = snap.reduce((s, r) => s + r.area, 0);
-      setStatus(`${label}: ${snap.length} room(s), ${total.toFixed(1)} m² · snap ${used}m${manual == null ? ' (auto)' : ''}.`);
+      setStatus(`${label}: ${snap.length} room(s), ${total.toFixed(1)} m² · corner tol ${used}m${manual == null ? ' (auto)' : ''}.`);
     } catch (e) {
       setStatus(`Build failed: ${String(e)}`);
     }
-  }, [freeHistory, resetInteraction]);
+  }, [freeHistory, resetInteraction, applyFit]);
 
   // Manual snap override (null → back to auto-escalate). Rebuilds the current
   // plate from its source segments at the chosen tolerance.
@@ -359,6 +438,8 @@ export function SpaceSketchOverlay() {
     snapTolRef.current = tol;
     setSnapTol(tol);
     if (tol != null) setUsedTol(tol); // move the slider thumb/label immediately
+    // Remember the room count before this rebuild so buildFrom can flash the delta.
+    pendingSnapPrevRef.current = plateRef.current?.roomCount ?? null;
     // Debounce the actual rebuild: the range input fires onChange on every
     // tick, and buildFrom is async + frees/creates wasm handles — rebuilding
     // per tick raced the shared heap and froze the editor. Rebuild once the
@@ -522,6 +603,7 @@ export function SpaceSketchOverlay() {
   useEffect(() => () => {
     if (rafRef.current) cancelAnimationFrame(rafRef.current);
     if (rebuildTimerRef.current) clearTimeout(rebuildTimerRef.current);
+    if (snapDeltaTimerRef.current) clearTimeout(snapDeltaTimerRef.current);
     freeHistory();
     plateRef.current?.free();
     plateRef.current = null;
@@ -535,8 +617,8 @@ export function SpaceSketchOverlay() {
     // pushed the room off-canvas ("disappears") and made the SVG rasterise a
     // polygon spanning to extreme coordinates, freezing the browser.
     return [
-      Math.max(0, Math.min(SVG_W, e.clientX - rect.left)),
-      Math.max(0, Math.min(SVG_H, e.clientY - rect.top)),
+      Math.max(0, Math.min(sizeRef.current.w, e.clientX - rect.left)),
+      Math.max(0, Math.min(sizeRef.current.h, e.clientY - rect.top)),
     ];
   };
 
@@ -613,6 +695,28 @@ export function SpaceSketchOverlay() {
     setStatus(`Split — ${plate.roomCount} room(s).`);
   }, [commitUndo, refreshRooms]);
 
+  // Commit the in-progress drawn polygon as a new room face (Issue 2). The new
+  // room is its own connected component — it doesn't merge into existing walls.
+  const commitDraw = useCallback(() => {
+    const plate = plateRef.current;
+    if (!plate) return;
+    if (drawPts.length < 3) { setStatus('A room needs at least 3 points.'); return; }
+    const snap = plate.duplicate();
+    try {
+      plate.addFace(new Float64Array(drawPts.flat()), -1);
+      commitUndo(snap);
+      setDrawPts([]); setDrawCursor(null);
+      refreshRooms();
+      setStatus(`Drew a room — ${plate.roomCount} room(s).`);
+    } catch (err) {
+      // Roll back to the pre-draw snapshot (mirror performSplit/merge).
+      plate.free();
+      plateRef.current = snap;
+      refreshRooms();
+      setStatus(`Draw rejected: ${String(err).replace(/^\w+:\s*/, '')}`);
+    }
+  }, [drawPts, commitUndo, refreshRooms]);
+
   const processMove = useCallback(() => {
     rafRef.current = null;
     const m = moveRef.current;
@@ -655,28 +759,67 @@ export function SpaceSketchOverlay() {
       const t = resolveSplitTarget(wx, wy);
       setSplitHover(t ? t.pos : null);
       setHover(t && t.kind === 'vertex' ? { kind: 'vertex', pos: t.pos } : null);
+    } else if (mode === 'draw') {
+      // Snap the preview point to an existing corner so drawn rooms align.
+      const snapV = nearestVertPos(wx, wy);
+      setDrawCursor(snapV ?? [wx, wy]);
     } else {
       const v = pickVertex(wx, wy);
       const pos = v != null ? nearestVertPos(wx, wy) : null;
       setHover(v != null && pos ? { kind: 'vertex', pos } : null);
+      // Telegraph the ⌥/Ctrl-click delete on whatever vertex is under the cursor.
+      setDeleteHover(m.del && pos ? pos : null);
     }
   }, [mode, pickEdge, pickVertex, nearestVertPos, resolveSplitTarget, refreshRooms]);
 
   const onPointerMove = useCallback((e: React.PointerEvent) => {
+    if (panningRef.current) {
+      // Pan by the raw pointer delta (movement*), so it doesn't fight the
+      // canvas-edge clamp in svgPoint.
+      fitRef.current = { scale: fitRef.current.scale, offX: fitRef.current.offX + e.movementX, offY: fitRef.current.offY + e.movementY };
+      setFitTick((t) => t + 1);
+      return;
+    }
     const [x, y] = svgPoint(e);
-    moveRef.current = { x, y, shift: e.shiftKey };
+    moveRef.current = { x, y, shift: e.shiftKey, del: e.ctrlKey || e.altKey || e.metaKey };
     if (rafRef.current == null) rafRef.current = requestAnimationFrame(processMove);
   }, [processMove]);
 
   const onPointerDown = useCallback((e: React.PointerEvent) => {
     const plate = plateRef.current;
     if (!plate) return;
+    // Middle-mouse drag pans the view in any mode (Issue 4).
+    if (e.button === 1) {
+      panningRef.current = true;
+      svgRef.current?.setPointerCapture(e.pointerId);
+      return;
+    }
     const [sx, sy] = svgPoint(e);
     const wx = wX(fitRef.current, sx), wy = wY(fitRef.current, sy);
 
     if (mode === 'drag') {
       const v = pickVertex(wx, wy);
-      if (v == null) return;
+      if (v == null) {
+        // Empty space in drag mode → pan the view (Issue 4).
+        panningRef.current = true;
+        svgRef.current?.setPointerCapture(e.pointerId);
+        return;
+      }
+      // ⌥/Ctrl-click dissolves a degree-2 node — the inverse of split (Issue 3).
+      if (e.altKey || e.ctrlKey || e.metaKey) {
+        const snap = plate.duplicate();
+        try {
+          plate.dissolveVertex(v);
+          commitUndo(snap); refreshRooms(); setHover(null); setDeleteHover(null);
+          setStatus(`Removed vertex — ${plate.roomCount} room(s).`);
+        } catch (err) {
+          plate.free();
+          plateRef.current = snap;
+          refreshRooms();
+          setStatus(`Can't remove vertex: ${String(err).replace(/^\w+:\s*/, '')}`);
+        }
+        return;
+      }
       const start = nearestVertPos(wx, wy);
       dragRef.current = v;
       dragStartRef.current = start;
@@ -713,10 +856,30 @@ export function SpaceSketchOverlay() {
       const first = splitPick;
       setSplitPick(null);
       performSplit(first, target);
+      return;
     }
-  }, [mode, pickVertex, nearestVertPos, pickEdge, rooms, splitPick, resolveSplitTarget, performSplit, commitUndo, refreshRooms]);
+    if (mode === 'draw') {
+      const snapV = nearestVertPos(wx, wy);
+      const p: Pt = snapV ?? [wx, wy];
+      // With ≥3 points placed, clicking the first dot closes the loop.
+      if (drawPts.length >= 3) {
+        const first = drawPts[0];
+        if (Math.hypot(p[0] - first[0], p[1] - first[1]) <= PICK_PX / fitRef.current.scale) {
+          commitDraw();
+          return;
+        }
+      }
+      setDrawPts((pts) => [...pts, p]);
+      setStatus(`Drawing — ${drawPts.length + 1} point(s). Click the first dot (or “Finish”) to close.`);
+    }
+  }, [mode, pickVertex, nearestVertPos, pickEdge, rooms, splitPick, resolveSplitTarget, performSplit, commitUndo, refreshRooms, drawPts, commitDraw]);
 
   const endDrag = useCallback((e: React.PointerEvent) => {
+    if (panningRef.current) {
+      panningRef.current = false;
+      svgRef.current?.releasePointerCapture(e.pointerId);
+      return;
+    }
     if (dragRef.current == null) return;
     dragRef.current = null; dragStartRef.current = null; setSnapPos(null);
     svgRef.current?.releasePointerCapture(e.pointerId);
@@ -731,20 +894,20 @@ export function SpaceSketchOverlay() {
   const total = rooms.reduce((s, r) => s + r.area, 0);
   const mergeRooms = hover?.kind === 'edge' ? new Set(hover.rooms) : null;
   const cursorWorld = moveRef.current ? [wX(f, moveRef.current.x), wY(f, moveRef.current.y)] as Pt : null;
-  const cursor = dragRef.current != null ? 'grabbing' : (mode === 'drag' && hover?.kind === 'vertex') ? 'grab' : 'crosshair';
+  const cursor = panningRef.current || dragRef.current != null ? 'grabbing' : (mode === 'drag' && hover?.kind === 'vertex') ? 'grab' : 'crosshair';
   const canUndo = undoRef.current.length > 0;
   const canRedo = redoRef.current.length > 0;
-  void hist;
+  void hist; void fitTick;
 
   const gridStep = f.scale > 14 ? 1 : f.scale > 5 ? 2 : 5;
   const gridLines: { x1: number; y1: number; x2: number; y2: number }[] = [];
   if (rooms.length) {
     const gx0 = Math.floor(wX(f, PAD) / gridStep) * gridStep;
-    const gx1 = Math.ceil(wX(f, SVG_W - PAD) / gridStep) * gridStep;
-    const gy0 = Math.floor(wY(f, SVG_H - PAD) / gridStep) * gridStep;
+    const gx1 = Math.ceil(wX(f, size.w - PAD) / gridStep) * gridStep;
+    const gy0 = Math.floor(wY(f, size.h - PAD) / gridStep) * gridStep;
     const gy1 = Math.ceil(wY(f, PAD) / gridStep) * gridStep;
-    for (let x = gx0; x <= gx1; x += gridStep) gridLines.push({ x1: sX(f, x), y1: PAD, x2: sX(f, x), y2: SVG_H - PAD });
-    for (let y = gy0; y <= gy1; y += gridStep) gridLines.push({ x1: PAD, y1: sY(f, y), x2: SVG_W - PAD, y2: sY(f, y) });
+    for (let x = gx0; x <= gx1; x += gridStep) gridLines.push({ x1: sX(f, x), y1: PAD, x2: sX(f, x), y2: size.h - PAD });
+    for (let y = gy0; y <= gy1; y += gridStep) gridLines.push({ x1: PAD, y1: sY(f, y), x2: size.w - PAD, y2: sY(f, y) });
   }
 
   const iconBtn = 'inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-40';
@@ -753,12 +916,50 @@ export function SpaceSketchOverlay() {
   // editable vertices stay on the centreline (the topology). `center` shows the
   // raw centreline.
   const ext = extractionRef.current;
-  const displayOutline = (outline: Pt[], others: Pt[][]): Pt[] =>
-    boundaryMode === 'center' || !ext ? outline : offsetRoomFootprint(outline, ext.segments, ext.thicknesses, boundaryMode, others);
+  // Per-room display outline at the chosen boundary, plus whether the inset
+  // actually changed the room. Inner/Outer silently fall back to the centreline
+  // when no wall offset applies (no wall ran along the room's edges, or a
+  // fully-internal room in Outer mode) — flag those so the toggle doesn't look
+  // broken (Issue 6).
+  const boundaryInfo = useMemo(
+    () =>
+      rooms.map((r, ri) => {
+        if (boundaryMode === 'center') return { disp: r.outline, unbounded: false };
+        if (!ext) return { disp: r.outline, unbounded: true };
+        const others = rooms.filter((_, j) => j !== ri).map((x) => x.outline);
+        const disp = offsetRoomFootprint(r.outline, ext.segments, ext.thicknesses, boundaryMode, others);
+        return { disp, unbounded: Math.abs(polyArea(disp) - r.area) < 1e-3 };
+      }),
+    [rooms, boundaryMode, ext],
+  );
+  const unboundedCount = boundaryMode === 'center' ? 0 : boundaryInfo.filter((b) => b.unbounded).length;
+
+  // Issue 7 — leak diagnostics: classify each derive wall segment as bounding
+  // (its centreline lies along a room edge) vs non-bounding (a stray/leaked wall
+  // that enclosed nothing). Purely geometric, so it needs no source provenance.
+  const diagnostics = useMemo(() => {
+    if (!showDiagnostics || !ext) return null;
+    const tol = 0.35; // m — segment midpoint within this of a room edge ⇒ bounding
+    return ext.segments.map((s) => {
+      const mx = (s.a[0] + s.b[0]) / 2, my = (s.a[1] + s.b[1]) / 2;
+      let bounding = false;
+      for (const r of rooms) {
+        const n = r.outline.length;
+        for (let i = 0; i < n && !bounding; i++) {
+          const a = r.outline[i], b = r.outline[(i + 1) % n];
+          if (distToSeg(mx, my, a[0], a[1], b[0], b[1]) <= tol) bounding = true;
+        }
+        if (bounding) break;
+      }
+      return { a: s.a as Pt, b: s.b as Pt, bounding };
+    });
+  }, [showDiagnostics, ext, rooms]);
+  const leakCount = diagnostics ? diagnostics.filter((s) => !s.bounding).length : 0;
+  const badCount = rooms.filter((r) => !r.simple).length;
 
   return (
     <div ref={panelRef} className="absolute left-1/2 top-4 -translate-x-1/2 z-30 rounded-xl border bg-background/95 shadow-xl backdrop-blur p-3 select-none pointer-events-auto"
-         style={{ width: SVG_W + 24 }}>
+         style={{ width: size.w + 24 }}>
       <div className="flex items-center justify-between mb-2.5">
         <div className="flex items-center gap-2 text-sm font-semibold">
           <Layers className="h-4 w-4 text-muted-foreground" /> Space Sketch
@@ -780,45 +981,83 @@ export function SpaceSketchOverlay() {
       {/* Edit: mode + history */}
       <div className="flex items-center gap-1.5 mb-2">
         <div className="inline-flex rounded-md border p-0.5">
-          {(['drag', 'split', 'merge'] as Mode[]).map((m) => (
+          {(['drag', 'split', 'merge', 'draw'] as Mode[]).map((m) => (
             <button key={m}
               className={`rounded px-2 py-0.5 text-xs capitalize transition-colors ${mode === m ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'}`}
-              onClick={() => { setMode(m); setSplitPick(null); setSplitHover(null); setHover(null); }}
-              disabled={!rooms.length}>{m}</button>
+              onClick={() => { setMode(m); setSplitPick(null); setSplitHover(null); setHover(null); setDeleteHover(null); setDrawPts([]); setDrawCursor(null); }}
+              title={m === 'draw' ? 'Author a new room by clicking its corners' : `Edit derived rooms (${m})`}
+              disabled={m === 'draw' ? derivedStorey == null : !rooms.length}>{m}</button>
           ))}
         </div>
-        <button className={iconBtn} onClick={undo} disabled={!canUndo} title="Undo"><Undo2 className="h-4 w-4" /></button>
-        <button className={iconBtn} onClick={redo} disabled={!canRedo} title="Redo"><Redo2 className="h-4 w-4" /></button>
-        <div className="ml-auto flex items-center gap-1.5 text-[11px] text-muted-foreground"
-          title="Corner-closing tolerance — larger closes bigger gaps but can over-merge">
-          <span>snap</span>
-          <input type="range" min={0.05} max={1} step={0.05} value={usedTol} className="w-20 accent-primary"
-            disabled={derivedStorey == null} onChange={(e) => rebuildWithSnap(Number(e.target.value))} />
-          <button className="tabular-nums hover:text-foreground" onClick={() => rebuildWithSnap(null)}
-            title="Reset to automatic snap">{usedTol.toFixed(2)}m{snapTol == null ? '·a' : ''}</button>
+        <button className={iconBtn} onClick={undo} disabled={!canUndo} title="Undo (Ctrl+Z)"><Undo2 className="h-4 w-4" /></button>
+        <button className={iconBtn} onClick={redo} disabled={!canRedo} title="Redo (Ctrl+Shift+Z)"><Redo2 className="h-4 w-4" /></button>
+      </div>
+
+      {/* Draw-room controls (Issue 2) — only while authoring a new room. */}
+      {mode === 'draw' && (
+        <div className="flex items-center gap-1.5 mb-2 text-[11px]">
+          <span className="text-muted-foreground">Draw room · {drawPts.length} pt(s)</span>
+          <button onClick={commitDraw} disabled={drawPts.length < 3}
+            className="rounded bg-emerald-600 px-2 py-0.5 font-medium text-white hover:bg-emerald-700 disabled:opacity-40">Finish</button>
+          <button onClick={() => setDrawPts((p) => p.slice(0, -1))} disabled={!drawPts.length}
+            className="rounded border px-2 py-0.5 hover:bg-muted disabled:opacity-40" title="Remove the last point">Undo point</button>
+          <button onClick={() => { setDrawPts([]); setDrawCursor(null); setStatus('Draw cancelled.'); }} disabled={!drawPts.length}
+            className="rounded border px-2 py-0.5 hover:bg-muted disabled:opacity-40">Cancel</button>
         </div>
+      )}
+
+      {/* Corner-closing tolerance — the gap two wall centrelines may have and
+          still close a room corner. NOT vertex snapping (that's the drag
+          behaviour); the name "snap" was conflated with it. Numeric field for
+          precise values; the badge flashes the room-count change so the effect
+          is visible on the plan (Issue 5). */}
+      <div className="flex items-center gap-1.5 mb-2 text-[11px] text-muted-foreground">
+        <span title="How far apart two wall centrelines can be and still close a room corner. Larger closes bigger gaps but can over-merge. This is NOT vertex snapping.">Corner tol</span>
+        <input type="range" min={0.05} max={1} step={0.05} value={usedTol} className="w-20 accent-primary"
+          disabled={derivedStorey == null} onChange={(e) => rebuildWithSnap(Number(e.target.value))} />
+        <input type="number" min={0.05} max={1} step={0.05} value={usedTol} aria-label="Corner tolerance (metres)"
+          className="w-14 rounded border bg-background px-1 py-0.5 tabular-nums disabled:opacity-40"
+          disabled={derivedStorey == null}
+          onChange={(e) => { const v = Number(e.target.value); if (Number.isFinite(v) && v > 0) rebuildWithSnap(Math.min(1, Math.max(0.05, v))); }} />
+        <span>m</span>
+        <button className="rounded px-1 hover:text-foreground disabled:opacity-40" onClick={() => rebuildWithSnap(null)}
+          disabled={derivedStorey == null}
+          title={snapTol == null ? 'Automatic — escalates the tolerance until rooms close' : 'Reset to automatic'}>{snapTol == null ? 'auto' : 'reset'}</button>
+        {snapDelta && (
+          <span className={`ml-auto rounded px-1 tabular-nums animate-pulse ${snapDelta.to === 0 ? 'text-red-500' : snapDelta.to < snapDelta.from ? 'text-amber-500' : 'text-emerald-500'}`}
+            title="Rooms before → after this tolerance change">{snapDelta.from} → {snapDelta.to} rooms</span>
+        )}
       </div>
 
       {/* View: boundary relative to walls + building underlay */}
       <div className="flex items-center gap-2 mb-2 text-[11px] text-muted-foreground">
         <span title="Where the space boundary sits relative to its walls — drives the 2D preview and the bake">Boundary</span>
         <div className="inline-flex rounded-md border p-0.5">
-          {(['center', 'inner', 'outer'] as BoundaryMode[]).map((m) => (
-            <button key={m}
-              className={`rounded px-2 py-0.5 capitalize transition-colors ${boundaryMode === m ? 'bg-primary text-primary-foreground' : 'hover:text-foreground'}`}
-              onClick={() => setBoundaryMode(m)}
-              title={m === 'center' ? 'Wall centreline' : m === 'inner' ? 'Inner (net) face' : 'Outer (gross) face'}>{m}</button>
-          ))}
+          {(['center', 'inner', 'outer'] as BoundaryMode[]).map((m) => {
+            const noWallData = !ext && m !== 'center';
+            return (
+              <button key={m}
+                className={`rounded px-2 py-0.5 capitalize transition-colors disabled:opacity-40 ${boundaryMode === m ? 'bg-primary text-primary-foreground' : 'hover:text-foreground'}`}
+                onClick={() => setBoundaryMode(m)} disabled={noWallData}
+                title={noWallData ? 'No wall data on this derive — only the centreline is available' : m === 'center' ? 'Wall centreline' : m === 'inner' ? 'Inner (net) face' : 'Outer (gross) face'}>{m}</button>
+            );
+          })}
         </div>
-        <button className={`${iconBtn} ml-auto ${showBuilding ? 'bg-primary/10 text-primary hover:bg-primary/15' : ''}`}
+        <button className={`${iconBtn} ml-auto`} onClick={() => applyFit(computeFit(rooms, sizeRef.current.w, sizeRef.current.h))}
+          disabled={!rooms.length} title="Fit the plan to the canvas (reset zoom & pan)"><Maximize className="h-4 w-4" /></button>
+        <button className={`${iconBtn} ${showBuilding ? 'bg-primary/10 text-primary hover:bg-primary/15' : ''}`}
           onClick={() => setShowBuilding((v) => !v)}
           title="Show surrounding building elements (plan cut ~1.2 m above the floor)"><Building2 className="h-4 w-4" /></button>
+        <button className={`${iconBtn} ${showDiagnostics ? 'bg-red-500/10 text-red-500 hover:bg-red-500/15' : ''}`}
+          onClick={() => setShowDiagnostics((v) => !v)} disabled={!ext}
+          title="Diagnostics — highlight walls that bound no room (possible leaks) and rooms that failed to close"><AlertTriangle className="h-4 w-4" /></button>
       </div>
 
-      <svg ref={svgRef} width={SVG_W} height={SVG_H} style={{ cursor }}
+      <svg ref={svgRef} width={size.w} height={size.h} style={{ cursor }}
         className="rounded border bg-muted/20 touch-none"
         onPointerDown={onPointerDown} onPointerMove={onPointerMove} onPointerUp={endDrag}
-        onPointerLeave={() => { setHover(null); setSplitHover(null); }}>
+        onContextMenu={(e) => e.preventDefault()}
+        onPointerLeave={() => { setHover(null); setSplitHover(null); setDeleteHover(null); setDrawCursor(null); }}>
         {gridLines.map((l, i) => <line key={`g${i}`} {...l} stroke="currentColor" strokeOpacity={0.06} strokeWidth={1} />)}
 
         {/* Building-element underlay (plan cut ~1.2 m above the storey) for orientation. */}
@@ -826,7 +1065,7 @@ export function SpaceSketchOverlay() {
 
         {rooms.map((r, ri) => {
           const color = ROOM_COLORS[ri % ROOM_COLORS.length];
-          const disp = displayOutline(r.outline, rooms.filter((_, j) => j !== ri).map((x) => x.outline));
+          const { disp, unbounded } = boundaryInfo[ri];
           const pts = disp.map((p) => `${sX(f, p[0])},${sY(f, p[1])}`).join(' ');
           const [cwx, cwy] = centroid(disp);
           const cx = sX(f, cwx), cy = sY(f, cwy);
@@ -840,12 +1079,23 @@ export function SpaceSketchOverlay() {
                   fill="none" stroke={color} strokeOpacity={0.25} strokeDasharray="3 3" strokeWidth={1} />
               )}
               <polygon points={pts} fill={bad ? '#ef4444' : color} fillOpacity={lit ? 0.42 : bad ? 0.3 : 0.16}
-                stroke={bad ? '#ef4444' : color} strokeWidth={lit ? 3 : 2} />
+                stroke={bad ? '#ef4444' : color} strokeWidth={lit ? 3 : 2}
+                strokeDasharray={unbounded && !bad ? '5 4' : undefined}>
+                {unbounded && <title>Boundary “{boundaryMode}” made no change to this room — no wall offset applies (no wall runs along its edges, or it's fully internal in Outer mode).</title>}
+              </polygon>
               <text x={cx} y={cy - 5} textAnchor="middle" fontSize={12} fontWeight={600} fill="currentColor" className="pointer-events-none">{area.toFixed(2)}</text>
               <text x={cx} y={cy + 9} textAnchor="middle" fontSize={9} fill="currentColor" opacity={0.55} className="pointer-events-none">m²</text>
             </g>
           );
         })}
+
+        {/* Issue 7 — leak diagnostics: walls that bound a room (green) vs walls
+            that bound nothing (red dashed = a stray segment / leak suspect). */}
+        {diagnostics && diagnostics.map((s, i) => (
+          <line key={`dg${i}`} x1={sX(f, s.a[0])} y1={sY(f, s.a[1])} x2={sX(f, s.b[0])} y2={sY(f, s.b[1])}
+            stroke={s.bounding ? '#22c55e' : '#ef4444'} strokeOpacity={s.bounding ? 0.45 : 0.95}
+            strokeWidth={s.bounding ? 1.2 : 2.2} strokeDasharray={s.bounding ? undefined : '4 3'} pointerEvents="none" />
+        ))}
 
         {hover?.kind === 'edge' && (
           <line x1={sX(f, hover.a[0])} y1={sY(f, hover.a[1])} x2={sX(f, hover.b[0])} y2={sY(f, hover.b[1])} stroke="#ef4444" strokeWidth={4} strokeLinecap="round" />
@@ -869,6 +1119,24 @@ export function SpaceSketchOverlay() {
           </g>
         )}
 
+        {/* Draw-room in progress (Issue 2): placed points, rubber band, close hint. */}
+        {mode === 'draw' && drawPts.length > 0 && (
+          <g pointerEvents="none">
+            {drawPts.length >= 3 && (
+              <polygon points={drawPts.map((p) => `${sX(f, p[0])},${sY(f, p[1])}`).join(' ')} fill="#22c55e" fillOpacity={0.1} stroke="none" />
+            )}
+            <polyline points={drawPts.map((p) => `${sX(f, p[0])},${sY(f, p[1])}`).join(' ')} fill="none" stroke="#22c55e" strokeWidth={1.5} />
+            {drawCursor && (
+              <line x1={sX(f, drawPts[drawPts.length - 1][0])} y1={sY(f, drawPts[drawPts.length - 1][1])}
+                x2={sX(f, drawCursor[0])} y2={sY(f, drawCursor[1])} stroke="#22c55e" strokeOpacity={0.5} strokeDasharray="4 3" strokeWidth={1.2} />
+            )}
+            {drawPts.map((p, i) => (
+              <circle key={`d${i}`} cx={sX(f, p[0])} cy={sY(f, p[1])} r={i === 0 && drawPts.length >= 3 ? 6 : 3.5}
+                fill={i === 0 && drawPts.length >= 3 ? '#22c55e' : '#fff'} stroke="#16a34a" strokeWidth={1.5} />
+            ))}
+          </g>
+        )}
+
         {uniqueVerts(rooms).map((p, i) => {
           const isHover = hover?.kind === 'vertex' && Math.abs(hover.pos[0] - p[0]) < EPS && Math.abs(hover.pos[1] - p[1]) < EPS;
           return (
@@ -876,6 +1144,14 @@ export function SpaceSketchOverlay() {
               fill={isHover ? '#fbbf24' : '#fff'} stroke="#334155" strokeWidth={1.5} pointerEvents="none" />
           );
         })}
+
+        {/* ⌥/Ctrl-click delete telegraph (Issue 3): a red ring + minus over the node. */}
+        {deleteHover && (
+          <g pointerEvents="none">
+            <circle cx={sX(f, deleteHover[0])} cy={sY(f, deleteHover[1])} r={8} fill="#ef4444" fillOpacity={0.15} stroke="#ef4444" strokeWidth={1.5} />
+            <line x1={sX(f, deleteHover[0]) - 4} y1={sY(f, deleteHover[1])} x2={sX(f, deleteHover[0]) + 4} y2={sY(f, deleteHover[1])} stroke="#ef4444" strokeWidth={2} />
+          </g>
+        )}
       </svg>
 
       <div className="mt-2.5 flex items-center gap-2">
@@ -888,10 +1164,34 @@ export function SpaceSketchOverlay() {
         </div>
       </div>
       <div className="mt-1.5 text-[11px] text-muted-foreground">
-        {!rooms.length && 'Pick a storey to derive its rooms, or “Generate all” for the whole building.'}
-        {!!rooms.length && mode === 'drag' && 'Drag a vertex — shared vertices move both rooms; snaps to others, Shift = ortho.'}
+        {!rooms.length && mode !== 'draw' && 'Pick a storey to derive its rooms, “Generate all” for the building, or “draw” a room by hand.'}
+        {!!rooms.length && mode === 'drag' && 'Drag a vertex — shared vertices move both rooms; snaps to others, Shift = ortho. ⌥/Ctrl-click a node to remove it.'}
         {!!rooms.length && mode === 'split' && 'Click two points — corners or anywhere on a wall (new nodes added as needed).'}
         {!!rooms.length && mode === 'merge' && 'Hover highlights the wall + both rooms; click to merge them.'}
+        {mode === 'draw' && 'Click to drop corners; click the first dot (or “Finish”) to close the room. It’s a standalone room — it won’t merge into existing walls.'}
+        {unboundedCount > 0 && (
+          <span className="text-amber-600 dark:text-amber-500"> · {unboundedCount} room(s) unchanged by {boundaryMode} (dashed) — no wall offset.</span>
+        )}
+        {!!rooms.length && <span className="opacity-60"> · Scroll = zoom · middle- or empty-drag = pan · ⤢ = fit.</span>}
+        {showDiagnostics && (
+          <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5">
+            <span className="text-emerald-600 dark:text-emerald-500">▬ wall bounds a room</span>
+            <span className="text-red-500">╌ wall bounds nothing ({leakCount} — leak suspect)</span>
+            <span className="text-red-500">▦ room failed to close ({badCount})</span>
+          </div>
+        )}
+      </div>
+
+      {/* Resize grip (Issue 4) — drag to grow/shrink the canvas; the plan stays
+          put (hit ⤢ to reframe). */}
+      <div
+        onPointerDown={(e) => { e.preventDefault(); e.stopPropagation(); resizeRef.current = { x: e.clientX, y: e.clientY, w: size.w, h: size.h }; (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId); }}
+        onPointerMove={(e) => { const r = resizeRef.current; if (!r) return; setSize({ w: Math.max(MIN_W, Math.round(r.w + (e.clientX - r.x))), h: Math.max(MIN_H, Math.round(r.h + (e.clientY - r.y))) }); }}
+        onPointerUp={(e) => { resizeRef.current = null; (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId); }}
+        title="Drag to resize the panel"
+        className="absolute bottom-1 right-1 h-3.5 w-3.5 cursor-nwse-resize text-muted-foreground/50 hover:text-foreground"
+        style={{ touchAction: 'none' }}>
+        <svg viewBox="0 0 10 10" className="h-full w-full" pointerEvents="none"><path d="M9 2 L2 9 M9 6 L6 9" stroke="currentColor" strokeWidth={1.2} fill="none" /></svg>
       </div>
     </div>
   );

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -678,7 +678,7 @@ export function SpaceSketchOverlay() {
     plateRef.current = null;
   }, [freeHistory]);
 
-  const svgPoint = (e: React.PointerEvent): Pt => {
+  const svgPoint = (e: React.MouseEvent): Pt => {
     const rect = svgRef.current!.getBoundingClientRect();
     // Clamp to the canvas: during a drag the pointer is captured, so moving it
     // past the panel (e.g. dragging a vertex down off the bottom) would report
@@ -1011,6 +1011,91 @@ export function SpaceSketchOverlay() {
     return () => { window.removeEventListener('keydown', onMod); window.removeEventListener('keyup', onMod); };
   }, [processMove]);
 
+  // The "remove at this point" gesture, shared by modifier+left-click
+  // (onPointerDown) and right-click / macOS Ctrl-click (onContextMenu): a node
+  // dissolves or its incident wall is removed; a wall is removed; both auto-clean
+  // the orphans. Returns true if it acted on something under the cursor.
+  const removeAtPoint = useCallback((wx: number, wy: number): boolean => {
+    const plate = plateRef.current;
+    if (!plate) return false;
+    // Over a node → dissolve it, else remove one of its incident walls.
+    const v = pickVertex(wx, wy);
+    if (v != null) {
+      const snap = plate.duplicate();
+      // Remove ANY node: a degree-2 node dissolves (straighten/remove); a wall
+      // junction (3+ walls) collapses by removing one of its incident walls.
+      // Scan EVERY wall incident to the node (not just the cursor-nearest) so a
+      // junction with one removable wall still goes.
+      const vp = nearestVertPos(wx, wy);
+      let ok = false;
+      let reason = '';
+      try { plate.dissolveVertex(v); ok = true; setStatus(`Removed node — ${plate.roomCount} room(s).`); }
+      catch (err) {
+        reason = String(err).replace(/^\w+:\s*/, '');
+        // The node won't straighten away (it's a wall junction). Remove one of
+        // its incident walls instead: `removeEdge` unions two real rooms, or
+        // deletes a bridge/spur wall and auto-cleans the orphaned inner lines
+        // and nodes it leaves — handling the BridgeEdge/BordersExterior cases
+        // the old merge-only path rejected.
+        if (vp) {
+          for (const r of rooms) {
+            const n = r.outline.length;
+            const k = r.outline.findIndex((p) => Math.abs(p[0] - vp[0]) < EPS && Math.abs(p[1] - vp[1]) < EPS);
+            if (k < 0) continue;
+            const bounds = plate.boundingElements(r.face) as Boundary[];
+            for (const idx of [k, (k - 1 + n) % n]) {
+              const b = bounds[idx];
+              if (!b) continue;
+              try { plate.removeEdge(b.edge); ok = true; setStatus(`Removed wall & cleaned up — ${plate.roomCount} room(s).`); }
+              catch { /* an enclosing wall — try the next incident wall */ }
+              if (ok) break;
+            }
+            if (ok) break;
+          }
+        }
+      }
+      if (ok) { commitUndo(snap); refreshRooms(); setHover(null); setDeleteHover(null); }
+      else {
+        plate.free(); plateRef.current = snap; refreshRooms();
+        // Genuinely unremovable: every incident wall borders the outside (no
+        // second room to merge into) and the node won't dissolve. Surface the
+        // kernel reason so it's diagnosable rather than mysterious.
+        setStatus(`Can’t remove this node — no wall here separates two rooms${reason ? ` (${reason})` : ''}.`);
+      }
+      return true;
+    }
+    // Over a wall → remove it (merge two rooms / delete a bridge-spur + clean up).
+    const ed = pickEdge(wx, wy);
+    if (ed != null) {
+      const snap = plate.duplicate();
+      try {
+        // `removeEdge` unions two real rooms, or deletes a bridge/spur wall and
+        // auto-cleans the orphaned inner lines & nodes — only a real enclosing
+        // wall (room ↔ exterior) is refused, so a room never silently opens.
+        plate.removeEdge(ed.edge);
+        commitUndo(snap); refreshRooms(); setHover(null);
+        setStatus(`Removed wall — ${plate.roomCount} room(s) left.`);
+      } catch (err) {
+        plate.free(); plateRef.current = snap; refreshRooms();
+        setStatus(`Can't remove this wall: ${String(err).replace(/^\w+:\s*/, '')}`);
+      }
+      return true;
+    }
+    return false; // nothing under the cursor
+  }, [pickVertex, pickEdge, nearestVertPos, rooms, commitUndo, refreshRooms]);
+
+  // Right-click / macOS Ctrl-click is the remove gesture. macOS turns Ctrl-click
+  // into a real right-click (button 2 + contextmenu), so routing it here — rather
+  // than the button-2 pointerdown — makes Ctrl-click remove reliably, matching
+  // Cmd/Alt-click. preventDefault keeps the native menu away regardless.
+  const onContextMenu = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    if (!plateRef.current) return;
+    if (drawPts.length > 0 || splitPick) return; // mid-gesture → leave it to Esc
+    const [sx, sy] = svgPoint(e);
+    removeAtPoint(wX(fitRef.current, sx), wY(fitRef.current, sy));
+  }, [drawPts, splitPick, removeAtPoint]);
+
   const onPointerDown = useCallback((e: React.PointerEvent) => {
     const plate = plateRef.current;
     if (!plate) return;
@@ -1020,11 +1105,15 @@ export function SpaceSketchOverlay() {
       svgRef.current?.setPointerCapture(e.pointerId);
       return;
     }
+    // Right-click (incl. macOS Ctrl-click) is the remove gesture — handled in
+    // onContextMenu so it fires reliably; ignore it here so a secondary-button
+    // press never starts a drag / cut / draw.
+    if (e.button === 2) return;
     const [sx, sy] = svgPoint(e);
     const wx = wX(fitRef.current, sx), wy = wY(fitRef.current, sy);
-    // Dissolve/merge intent: Alt/Ctrl/Cmd, OR a right-click (button 2) — which is
-    // also what macOS Ctrl-click emits, so Ctrl-click works there too.
-    const mod = e.altKey || e.ctrlKey || e.metaKey || e.button === 2;
+    // Dissolve/merge intent on a left-click held with a modifier (Win/Linux
+    // Ctrl, macOS Alt/Cmd; macOS Ctrl-click arrives via onContextMenu instead).
+    const mod = e.altKey || e.ctrlKey || e.metaKey;
     const tol = PICK_PX / fitRef.current.scale;
 
     // 1. Drawing in progress → add a corner (or close on the first dot).
@@ -1053,54 +1142,13 @@ export function SpaceSketchOverlay() {
       return;
     }
 
-    // 3. Over a node → ⌥ removes it, else drag it.
+    // Modifier + left-click anywhere on a node/wall → remove (shared with the
+    // right-click path). macOS Ctrl-click is a right-click → onContextMenu.
+    if (mod) { removeAtPoint(wx, wy); return; }
+
+    // 3. Over a node → drag it.
     const v = pickVertex(wx, wy);
     if (v != null) {
-      if (mod) {
-        const snap = plate.duplicate();
-        // Remove ANY node: a degree-2 node dissolves (straighten/remove); a wall
-        // junction (3+ walls) collapses by merging across one of its walls that
-        // separates two rooms. Scan EVERY wall incident to the node (not just the
-        // cursor-nearest) so a junction with one mergeable wall still goes.
-        const vp = nearestVertPos(wx, wy);
-        let ok = false;
-        let reason = '';
-        try { plate.dissolveVertex(v); ok = true; setStatus(`Removed node — ${plate.roomCount} room(s).`); }
-        catch (err) {
-          reason = String(err).replace(/^\w+:\s*/, '');
-          // The node won't straighten away (it's a wall junction). Remove one of
-          // its incident walls instead: `removeEdge` unions two real rooms, or
-          // deletes a bridge/spur wall and auto-cleans the orphaned inner lines
-          // and nodes it leaves — handling the BridgeEdge/BordersExterior cases
-          // the old merge-only path rejected. Scan EVERY incident wall so a
-          // junction with one removable wall still goes.
-          if (vp) {
-            for (const r of rooms) {
-              const n = r.outline.length;
-              const k = r.outline.findIndex((p) => Math.abs(p[0] - vp[0]) < EPS && Math.abs(p[1] - vp[1]) < EPS);
-              if (k < 0) continue;
-              const bounds = plate.boundingElements(r.face) as Boundary[];
-              for (const idx of [k, (k - 1 + n) % n]) {
-                const b = bounds[idx];
-                if (!b) continue;
-                try { plate.removeEdge(b.edge); ok = true; setStatus(`Removed wall & cleaned up — ${plate.roomCount} room(s).`); }
-                catch { /* an enclosing wall — try the next incident wall */ }
-                if (ok) break;
-              }
-              if (ok) break;
-            }
-          }
-        }
-        if (ok) { commitUndo(snap); refreshRooms(); setHover(null); setDeleteHover(null); }
-        else {
-          plate.free(); plateRef.current = snap; refreshRooms();
-          // Genuinely unremovable: every incident wall borders the outside (no
-          // second room to merge into) and the node won't dissolve. Surface the
-          // kernel reason so it's diagnosable rather than mysterious.
-          setStatus(`Can’t remove this node — no wall here separates two rooms${reason ? ` (${reason})` : ''}.`);
-        }
-        return;
-      }
       const start = nearestVertPos(wx, wy);
       dragRef.current = v; dragStartRef.current = start; draggedRef.current = false;
       pendingUndoRef.current = plate.duplicate();
@@ -1111,24 +1159,9 @@ export function SpaceSketchOverlay() {
       return;
     }
 
-    // 4. Over a wall → ⌥ merges across it, else start a cut (first point).
+    // 4. Over a wall → start a cut (first point) by inserting a node.
     const ed = pickEdge(wx, wy);
     if (ed != null) {
-      if (mod) {
-        const snap = plate.duplicate();
-        try {
-          // `removeEdge` unions two real rooms, or deletes a bridge/spur wall and
-          // auto-cleans the orphaned inner lines & nodes — only a real enclosing
-          // wall (room ↔ exterior) is refused, so a room never silently opens.
-          plate.removeEdge(ed.edge);
-          commitUndo(snap); refreshRooms(); setHover(null);
-          setStatus(`Removed wall — ${plate.roomCount} room(s) left.`);
-        } catch (err) {
-          plate.free(); plateRef.current = snap; refreshRooms();
-          setStatus(`Can't remove this wall: ${String(err).replace(/^\w+:\s*/, '')}`);
-        }
-        return;
-      }
       // Insert a node on the wall RIGHT NOW (so "add a node" actually adds one,
       // visible + undoable), and arm a cut from it. A second wall/corner click
       // splits the room between the two; Esc/elsewhere keeps the added node.
@@ -1148,10 +1181,8 @@ export function SpaceSketchOverlay() {
       return;
     }
 
-    // 5. Empty space → a right-click here does nothing (it's the dissolve gesture,
-    //    only meaningful on a node/wall). Shift pans (so you can still pan now
-    //    that a plain click draws). Otherwise start drawing a new room.
-    if (e.button === 2) return;
+    // 5. Empty space → Shift pans (so you can still pan now that a plain click
+    //    draws). Otherwise start drawing a new room.
     if (e.shiftKey) {
       panningRef.current = true;
       svgRef.current?.setPointerCapture(e.pointerId);
@@ -1161,7 +1192,7 @@ export function SpaceSketchOverlay() {
     drawRedoRef.current = [];
     setDrawPts([snap.pt]);
     setStatus('Drawing — click to add corners · Enter / double-click / first dot to close · Shift = straight.');
-  }, [drawPts, splitPick, pickVertex, nearestVertPos, pickEdge, rooms, resolveSplitTarget, performSplit, commitUndo, refreshRooms, commitDraw]);
+  }, [drawPts, splitPick, pickVertex, nearestVertPos, pickEdge, rooms, resolveSplitTarget, performSplit, commitUndo, refreshRooms, commitDraw, removeAtPoint]);
 
   const endDrag = useCallback((e: React.PointerEvent) => {
     if (panningRef.current) {
@@ -1392,7 +1423,7 @@ export function SpaceSketchOverlay() {
         className="rounded border bg-muted/20 touch-none"
         onPointerDown={onPointerDown} onPointerMove={onPointerMove} onPointerUp={endDrag}
         onDoubleClick={() => { if (drawPts.length > 0) commitDraw(); }}
-        onContextMenu={(e) => e.preventDefault()}
+        onContextMenu={onContextMenu}
         onPointerLeave={() => { setHover(null); setSplitHover(null); setDeleteHover(null); setDrawCursor(null); setAlignGuides({ vRef: null, hRef: null }); setIntent(null); }}>
         {gridLines.map((l, i) => <line key={`g${i}`} {...l} stroke="currentColor" strokeOpacity={0.06} strokeWidth={1} />)}
 

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -24,7 +24,13 @@ import { useConstructionUnderlay } from '@/hooks/useConstructionUnderlay';
 import { useIfc } from '@/hooks/useIfc';
 import { snapPoint, alignToAxes, type SnapKind } from '@/lib/space-snap';
 import { editError } from '@/lib/space-edit-error';
-import init, { SpacePlateHandle } from '@ifc-lite/wasm';
+import {
+  SpacePlateSession,
+  ensureSpaceWasm,
+  snapshotRooms,
+  type Room,
+  type Boundary,
+} from '@/lib/space-plate-session';
 import {
   extractWallSegmentsForStorey,
   offsetRoomFootprint,
@@ -34,22 +40,6 @@ import {
 } from '@ifc-lite/create';
 import { X, Undo2, Redo2, Layers, Maximize, AlertTriangle, Magnet, SlidersHorizontal, HelpCircle, Eraser } from 'lucide-react';
 
-let wasmReady: Promise<void> | null = null;
-function ensureWasm(): Promise<void> {
-  if (!wasmReady) wasmReady = init().then(() => undefined);
-  return wasmReady;
-}
-
-interface Room {
-  face: number;
-  area: number;
-  simple: boolean;
-  outline: [number, number][];
-}
-interface Boundary {
-  edge: number;
-  source: number | null;
-}
 type Pt = [number, number];
 type Hover =
   | { kind: 'vertex'; pos: Pt }
@@ -66,7 +56,6 @@ const MIN_H = 280;
 const PAD = 36;
 const PICK_PX = 12;
 const SNAP_PX = 10;
-const MAX_UNDO = 40;
 const BAKE_HEIGHT = 3;
 const EPS = 1e-6;
 
@@ -173,7 +162,7 @@ export function SpaceSketchOverlay() {
   const activeModelId = useViewerStore((s) => s.activeModelId);
   const { ifcDataStore } = useIfc();
 
-  const plateRef = useRef<SpacePlateHandle | null>(null);
+  const sessionRef = useRef<SpacePlateSession | null>(null);
   const svgRef = useRef<SVGSVGElement | null>(null);
   const panelRef = useRef<HTMLDivElement | null>(null);
   const fitRef = useRef<Fit>({ scale: 1, offX: PAD, offY: DEFAULT_H - PAD });
@@ -188,13 +177,9 @@ export function SpaceSketchOverlay() {
   const dragRef = useRef<number | null>(null);
   const dragStartRef = useRef<Pt | null>(null);
   const otherVertsRef = useRef<Pt[]>([]);
-  const pendingUndoRef = useRef<SpacePlateHandle | null>(null);
   const draggedRef = useRef(false);
   const panningRef = useRef(false); // Issue 4: middle-mouse / empty-drag panning
   const resizeRef = useRef<{ x: number; y: number; w: number; h: number } | null>(null);
-
-  const undoRef = useRef<SpacePlateHandle[]>([]);
-  const redoRef = useRef<SpacePlateHandle[]>([]);
   // While drawing, Undo pops the last placed point onto this stack and Redo
   // re-adds it — so point placement uses the panel Undo/Redo, not a separate
   // draw-only control. Cleared when the draw is committed/cancelled.
@@ -347,33 +332,26 @@ export function SpaceSketchOverlay() {
   // Keyboard handling (Esc aborts the current op / double-Esc closes / Enter
   // closes a drawn room) lives below, after `commitDraw` is defined.
 
+  // Re-read the rooms from the session into render state (cheap per-frame use
+  // during a drag — no history/dirty side effects).
   const refreshRooms = useCallback(() => {
-    const plate = plateRef.current;
-    if (plate) setRooms(plate.snapshot() as Room[]);
+    const s = sessionRef.current;
+    if (s) setRooms(s.rooms());
   }, []);
 
-  const freeHistory = useCallback(() => {
-    undoRef.current.forEach((h) => h.free());
-    redoRef.current.forEach((h) => h.free());
-    undoRef.current = [];
-    redoRef.current = [];
-    pendingUndoRef.current?.free();
-    pendingUndoRef.current = null;
-  }, []);
-
-  const commitUndo = useCallback((snap: SpacePlateHandle) => {
-    undoRef.current.push(snap);
-    if (undoRef.current.length > MAX_UNDO) undoRef.current.shift()!.free();
-    redoRef.current.forEach((h) => h.free());
-    redoRef.current = [];
+  // After any committed plate change: re-render the canvas, refresh the
+  // undo/redo button states (`hist`), and mirror the session's dirty flag.
+  const commit = useCallback(() => {
+    const s = sessionRef.current;
+    setRooms(s?.rooms() ?? []);
     setHist((v) => v + 1);
-    setDirty(true); // an edit happened — unbaked until the next Bake
+    setDirty(s?.dirty ?? false);
   }, []);
 
   const resetInteraction = useCallback(() => {
     setHover(null); setSplitPick(null); setSplitHover(null); setSnapPos(null);
     dragRef.current = null; dragStartRef.current = null;
-    pendingUndoRef.current?.free(); pendingUndoRef.current = null;
+    sessionRef.current?.cancelDrag(); // discard any in-flight drag snapshot
   }, []);
 
   const undo = useCallback(() => {
@@ -384,13 +362,11 @@ export function SpaceSketchOverlay() {
       setStatus('Removed last point.');
       return;
     }
-    const plate = plateRef.current;
-    if (!plate || !undoRef.current.length) return;
-    redoRef.current.push(plate);
-    plateRef.current = undoRef.current.pop()!;
-    resetInteraction(); refreshRooms(); setHist((v) => v + 1);
-    setStatus('Undo.');
-  }, [drawPts, resetInteraction, refreshRooms]);
+    if (sessionRef.current?.undo()) {
+      resetInteraction(); commit();
+      setStatus('Undo.');
+    }
+  }, [drawPts, resetInteraction, commit]);
 
   const redo = useCallback(() => {
     // While drawing, Redo re-adds the last point Undo removed.
@@ -400,13 +376,11 @@ export function SpaceSketchOverlay() {
       setStatus('Re-added point.');
       return;
     }
-    const plate = plateRef.current;
-    if (!plate || !redoRef.current.length) return;
-    undoRef.current.push(plate);
-    plateRef.current = redoRef.current.pop()!;
-    resetInteraction(); refreshRooms(); setHist((v) => v + 1);
-    setStatus('Redo.');
-  }, [resetInteraction, refreshRooms]);
+    if (sessionRef.current?.redo()) {
+      resetInteraction(); commit();
+      setStatus('Redo.');
+    }
+  }, [resetInteraction, commit]);
 
   // Ctrl/Cmd+Z (Shift = redo) must drive THIS overlay's history, not the 3D
   // model behind the panel. The global handler in useKeyboardShortcuts routes
@@ -451,34 +425,21 @@ export function SpaceSketchOverlay() {
     // shared wasm heap. Only the latest build applies; superseded ones bail.
     const seq = ++buildSeqRef.current;
     try {
-      await ensureWasm();
+      await ensureSpaceWasm();
+      // The only async gap is the wasm init above; after it, build() runs
+      // synchronously and atomically. So a single post-await seq check is enough
+      // to keep an older rebuild (rapid snap-slider drags) from replacing the
+      // plate a newer one is building — the stale one bails before touching it.
       if (seq !== buildSeqRef.current) return;
-      plateRef.current?.free();
-      freeHistory();
-      // Real wall centrelines don't meet exactly at corners — they're offset
-      // by ~half the wall thickness. A tight snap leaves the loop open (0
-      // rooms). Auto-escalate: take the first tolerance that encloses rooms,
-      // else the largest tried (least surprising than silently finding none).
       lastBuildRef.current = { coords, sources, label, storey };
       const manual = snapTolRef.current;
-      let plate: SpacePlateHandle | null = null;
-      let used = 0.1;
-      if (manual != null) {
-        plate = new SpacePlateHandle(coords, sources, manual, 0.5);
-        used = manual;
-      } else {
-        for (const tol of [0.1, 0.25, 0.5]) {
-          const p = new SpacePlateHandle(coords, sources, tol, 0.5);
-          plate?.free();
-          plate = p;
-          used = tol;
-          if (p.roomCount > 0) break;
-        }
-      }
-      if (seq !== buildSeqRef.current) { plate?.free(); return; }
-      plateRef.current = plate!;
+      let session = sessionRef.current;
+      if (!session) { session = new SpacePlateSession(); sessionRef.current = session; }
+      // Auto-escalate the corner-snap (real centrelines miss corners by ~½ a
+      // wall thickness, so a tight snap leaves the loop open → 0 rooms); the
+      // session tries [0.1, 0.25, 0.5] and keeps the first that encloses rooms.
+      const { rooms: snap, tol: used } = session.build(coords, sources, manual, 0.5);
       setUsedTol(used);
-      const snap = plate!.snapshot() as Room[];
       applyFit(computeFit(snap, sizeRef.current.w, sizeRef.current.h));
       resetInteraction();
       setDerivedStorey(storey);
@@ -498,7 +459,7 @@ export function SpaceSketchOverlay() {
     } catch (e) {
       setStatus(`Build failed: ${String(e)}`);
     }
-  }, [freeHistory, resetInteraction, applyFit]);
+  }, [resetInteraction, applyFit]);
 
   // Manual snap override (null → back to auto-escalate). Rebuilds the current
   // plate from its source segments at the chosen tolerance.
@@ -507,7 +468,7 @@ export function SpaceSketchOverlay() {
     setSnapTol(tol);
     if (tol != null) setUsedTol(tol); // move the slider thumb/label immediately
     // Remember the room count before this rebuild so buildFrom can flash the delta.
-    pendingSnapPrevRef.current = plateRef.current?.roomCount ?? null;
+    pendingSnapPrevRef.current = sessionRef.current?.roomCount ?? null;
     // Debounce the actual rebuild: the range input fires onChange on every
     // tick, and buildFrom is async + frees/creates wasm handles — rebuilding
     // per tick raced the shared heap and froze the editor. Rebuild once the
@@ -619,17 +580,17 @@ export function SpaceSketchOverlay() {
   }, [activeModelId, removeEntity, addSpace, floorToFloor, boundaryMode]);
 
   const bake = useCallback(() => {
-    const plate = plateRef.current;
-    if (!plate || !activeModelId || derivedStorey == null || !ifcDataStore) {
+    const session = sessionRef.current;
+    if (!session?.alive || !activeModelId || derivedStorey == null || !ifcDataStore) {
       setStatus('Derive a storey first.');
       return;
     }
-    const outlines = (plate.snapshot() as Room[]).map((r) => r.outline);
+    const outlines = session.rooms().map((r) => r.outline);
     const ext = extractionRef.current;
     const authored = existingSpaceFootprintsByStorey(ifcDataStore).get(derivedStorey) ?? [];
     const { emitted, skipped, error } = bakeStorey(derivedStorey, outlines, ext?.segments, ext?.thicknesses, authored);
     if (emitted > 0) revealSpaces();
-    if (!error) setDirty(false); // this storey's rooms are now written to IfcSpace
+    if (!error) { session.dirty = false; setDirty(false); } // rooms now written to IfcSpace
     setStatus(error
       ? `Baked ${emitted} IfcSpace — others failed: ${error}`
       : `Baked ${emitted} IfcSpace${skipped ? `, skipped ${skipped} (already a space)` : ''}.`);
@@ -638,7 +599,7 @@ export function SpaceSketchOverlay() {
   const bakeWholeBuilding = useCallback(async () => {
     if (!activeModelId || !ifcDataStore) { setStatus('No model loaded.'); return; }
     setStatus('Generating spaces for every storey…');
-    await ensureWasm();
+    await ensureSpaceWasm();
     const authoredMap = existingSpaceFootprintsByStorey(ifcDataStore);
     let totalEmitted = 0, totalSkipped = 0, floors = 0;
     let firstError: string | null = null;
@@ -648,15 +609,9 @@ export function SpaceSketchOverlay() {
       const coords = new Float64Array(segments.length * 4);
       const sources = new Int32Array(segments.length).fill(-1);
       segments.forEach((s, i) => { coords[i * 4] = s.a[0]; coords[i * 4 + 1] = s.a[1]; coords[i * 4 + 2] = s.b[0]; coords[i * 4 + 3] = s.b[1]; });
-      let plate: SpacePlateHandle | null = null;
-      for (const tol of [0.1, 0.25, 0.5]) {
-        const p = new SpacePlateHandle(coords, sources, tol, 0.5);
-        plate?.free();
-        plate = p;
-        if (p.roomCount > 0) break;
-      }
-      const outlines = (plate!.snapshot() as Room[]).map((r) => r.outline);
-      plate!.free();
+      // Throwaway plate per storey (escalation + deterministic free handled by
+      // the session module) — this path doesn't touch the live session.
+      const outlines = snapshotRooms(coords, sources).map((r) => r.outline);
       if (!outlines.length) continue;
       const { emitted, skipped, error } = bakeStorey(st.id, outlines, segments, wallThicknesses, authoredMap.get(st.id) ?? []);
       totalEmitted += emitted; totalSkipped += skipped;
@@ -664,7 +619,7 @@ export function SpaceSketchOverlay() {
       if (emitted) floors++;
     }
     if (totalEmitted > 0) revealSpaces();
-    if (!firstError) setDirty(false);
+    if (!firstError) { if (sessionRef.current) sessionRef.current.dirty = false; setDirty(false); }
     setStatus(firstError
       ? `Generated ${totalEmitted} IfcSpace — others failed: ${firstError}`
       : `Generated ${totalEmitted} IfcSpace across ${floors} storey(s)${totalSkipped ? `; skipped ${totalSkipped} existing` : ''}.`);
@@ -674,10 +629,9 @@ export function SpaceSketchOverlay() {
     if (rafRef.current) cancelAnimationFrame(rafRef.current);
     if (rebuildTimerRef.current) clearTimeout(rebuildTimerRef.current);
     if (snapDeltaTimerRef.current) clearTimeout(snapDeltaTimerRef.current);
-    freeHistory();
-    plateRef.current?.free();
-    plateRef.current = null;
-  }, [freeHistory]);
+    sessionRef.current?.dispose();
+    sessionRef.current = null;
+  }, []);
 
   const svgPoint = (e: React.MouseEvent): Pt => {
     const rect = svgRef.current!.getBoundingClientRect();
@@ -693,10 +647,7 @@ export function SpaceSketchOverlay() {
   };
 
   const pickVertex = useCallback((wx: number, wy: number): number | null => {
-    const plate = plateRef.current;
-    if (!plate) return null;
-    const v = plate.findVertexNear(wx, wy, PICK_PX / fitRef.current.scale);
-    return v === undefined ? null : v;
+    return sessionRef.current?.findVertexNear(wx, wy, PICK_PX / fitRef.current.scale) ?? null;
   }, []);
 
   const nearestVertPos = useCallback((wx: number, wy: number): Pt | null => {
@@ -709,12 +660,12 @@ export function SpaceSketchOverlay() {
   }, [rooms]);
 
   const pickEdge = useCallback((wx: number, wy: number): { face: number; edge: number; a: Pt; b: Pt } | null => {
-    const plate = plateRef.current;
-    if (!plate) return null;
+    const session = sessionRef.current;
+    if (!session) return null;
     const tol = PICK_PX / fitRef.current.scale;
     let best: { face: number; edge: number; a: Pt; b: Pt; d: number } | null = null;
     for (const r of rooms) {
-      const bounds = plate.boundingElements(r.face) as Boundary[];
+      const bounds = session.boundingElements(r.face);
       const n = r.outline.length;
       for (let i = 0; i < n; i++) {
         const a = r.outline[i], b = r.outline[(i + 1) % n];
@@ -738,38 +689,37 @@ export function SpaceSketchOverlay() {
   // Commit a split between two targets, inserting nodes for edge endpoints.
   // The whole gesture is atomic: on any failure the inserted nodes roll back.
   const performSplit = useCallback((first: SplitTarget, second: SplitTarget) => {
-    const plate = plateRef.current;
-    if (!plate) return;
+    const session = sessionRef.current;
+    if (!session?.alive) return;
     if (first.kind === 'edge' && second.kind === 'edge' && first.edge === second.edge) {
       setStatus('Pick points on two different edges (or corners).'); return;
     }
-    const snapshot = plate.duplicate();
     try {
-      const va = first.kind === 'vertex' ? first.vid : plate.splitEdge(first.edge, first.pos[0], first.pos[1]);
-      const vb = second.kind === 'vertex' ? second.vid : plate.splitEdge(second.edge, second.pos[0], second.pos[1]);
-      if (va === vb) throw new Error('DegenerateCut: same point');
-      const fresh = plate.snapshot() as Room[];
-      const onBoundary = (r: Room, p: Pt) => r.outline.some((q) => Math.abs(q[0] - p[0]) < EPS && Math.abs(q[1] - p[1]) < EPS);
-      const room = fresh.find((r) => onBoundary(r, first.pos) && onBoundary(r, second.pos));
-      if (!room) throw new Error('points are not on the same room');
-      plate.splitFace(room.face, va, vb, -1);
+      // One atomic edit: insert any edge-endpoint nodes, then cut between them.
+      // session.edit rolls the whole thing back if any step throws.
+      session.edit((h) => {
+        const va = first.kind === 'vertex' ? first.vid : h.splitEdge(first.edge, first.pos[0], first.pos[1]);
+        const vb = second.kind === 'vertex' ? second.vid : h.splitEdge(second.edge, second.pos[0], second.pos[1]);
+        if (va === vb) throw new Error('the two cut points are the same');
+        const fresh = h.snapshot() as Room[];
+        const onBoundary = (r: Room, p: Pt) => r.outline.some((q) => Math.abs(q[0] - p[0]) < EPS && Math.abs(q[1] - p[1]) < EPS);
+        const room = fresh.find((r) => onBoundary(r, first.pos) && onBoundary(r, second.pos));
+        if (!room) throw new Error('the two points are not on the same room');
+        h.splitFace(room.face, va, vb, -1);
+      });
+      commit();
+      setStatus(`Split — ${session.roomCount} room(s).`);
     } catch (err) {
-      plate.free();
-      plateRef.current = snapshot; // roll back inserted nodes + partial cut
-      refreshRooms();
+      commit(); // session rolled the plate back; re-render the restored state
       setStatus(`Split rejected: ${editError(err).message}`);
-      return;
     }
-    commitUndo(snapshot);
-    refreshRooms();
-    setStatus(`Split — ${plate.roomCount} room(s).`);
-  }, [commitUndo, refreshRooms]);
+  }, [commit]);
 
   // Commit the in-progress drawn polygon as a new room face (Issue 2). The new
   // room is its own connected component — it doesn't merge into existing walls.
   const commitDraw = useCallback(() => {
-    const plate = plateRef.current;
-    if (!plate) return;
+    const session = sessionRef.current;
+    if (!session?.alive) return;
     // Drop trailing duplicate point(s) — e.g. the second click of a double-click
     // close lands on the same spot as the final corner.
     let pts = drawPts;
@@ -777,21 +727,16 @@ export function SpaceSketchOverlay() {
       pts = pts.slice(0, -1);
     }
     if (pts.length < 3) { setStatus('A room needs at least 3 points.'); return; }
-    const snap = plate.duplicate();
     try {
-      plate.addFace(new Float64Array(pts.flat()), -1);
-      commitUndo(snap);
+      session.edit((h) => h.addFace(new Float64Array(pts.flat()), -1));
       setDrawPts([]); setDrawCursor(null); drawRedoRef.current = []; setAlignGuides({ vRef: null, hRef: null });
-      refreshRooms();
-      setStatus(`Drew a room — ${plate.roomCount} room(s).`);
+      commit();
+      setStatus(`Drew a room — ${session.roomCount} room(s).`);
     } catch (err) {
-      // Roll back to the pre-draw snapshot (mirror performSplit/merge).
-      plate.free();
-      plateRef.current = snap;
-      refreshRooms();
+      commit(); // session rolled back the partial draw
       setStatus(`Draw rejected: ${editError(err).message}`);
     }
-  }, [drawPts, commitUndo, refreshRooms]);
+  }, [drawPts, commit]);
 
   // Single Esc aborts the in-progress operation (in priority order); it does NOT
   // close the panel. Returns true if something was aborted.
@@ -807,14 +752,8 @@ export function SpaceSketchOverlay() {
       return true;
     }
     if (dragRef.current != null) {
-      // Revert the live drag to its pre-drag snapshot.
-      const plate = plateRef.current;
-      if (plate && pendingUndoRef.current) {
-        plate.free();
-        plateRef.current = pendingUndoRef.current;
-        pendingUndoRef.current = null;
-        refreshRooms();
-      }
+      sessionRef.current?.cancelDrag(); // revert the live drag to its pre-drag snapshot
+      refreshRooms();
       dragRef.current = null; dragStartRef.current = null;
       draggedRef.current = false; setSnapPos(null);
       setStatus('Drag cancelled.');
@@ -865,30 +804,28 @@ export function SpaceSketchOverlay() {
   // non-destructive wall arrangement. Area-neutral and idempotent (the Rust
   // `prune` does the topology surgery; real corners and wall junctions stay).
   const cleanupOrphans = useCallback(() => {
-    const plate = plateRef.current;
-    if (!plate || !rooms.length) return;
-    const snap = plate.duplicate();
-    let removed = 0;
+    const session = sessionRef.current;
+    if (!session?.alive || !rooms.length) return;
     try {
-      removed = plate.prune();
+      // Commit only if prune actually removed something (no-op → no undo entry).
+      const removed = session.edit((h) => h.prune(), (n) => n > 0);
+      if (removed > 0) {
+        commit();
+        setStatus(`Cleaned up ${removed} orphan wall${removed === 1 ? '' : 's'}/node${removed === 1 ? '' : 's'} — ${session.roomCount} room(s).`);
+      } else {
+        setStatus('Nothing to clean up — no orphan walls or nodes.');
+      }
     } catch (err) {
-      plate.free(); plateRef.current = snap; refreshRooms();
+      commit();
       setStatus(`Cleanup failed: ${editError(err).message}`);
-      return;
     }
-    if (removed > 0) {
-      commitUndo(snap); refreshRooms();
-      setStatus(`Cleaned up ${removed} orphan wall${removed === 1 ? '' : 's'}/node${removed === 1 ? '' : 's'} — ${plate.roomCount} room(s).`);
-    } else {
-      snap.free(); setStatus('Nothing to clean up — no orphan walls or nodes.');
-    }
-  }, [rooms, commitUndo, refreshRooms]);
+  }, [rooms, commit]);
 
   const processMove = useCallback(() => {
     rafRef.current = null;
     const m = moveRef.current;
-    const plate = plateRef.current;
-    if (!m || !plate) return;
+    const session = sessionRef.current;
+    if (!m || !session?.alive) return;
     const wx = wX(fitRef.current, m.x), wy = wY(fitRef.current, m.y);
 
     const vid = dragRef.current;
@@ -906,12 +843,8 @@ export function SpaceSketchOverlay() {
       setSnapPos(snap.kind === 'none' ? null : snap.pt);
       setSnapKind(snap.kind);
       setIntent({ text: snap.kind === 'line' ? 'Move onto wall' : snap.kind === 'vertex' ? 'Move onto corner' : m.shift ? 'Move (straight)' : 'Move node', tone: 'move' });
-      try {
-        plate.dragVertex(vid, snap.pt[0], snap.pt[1]);
-        refreshRooms();
-      } catch (e) {
-        console.debug('[space-sketch] dragVertex failed (plate torn down mid-drag?)', e);
-      }
+      session.dragTo(vid, snap.pt[0], snap.pt[1]);
+      refreshRooms();
       return;
     }
 
@@ -961,7 +894,7 @@ export function SpaceSketchOverlay() {
       if (m.del) {
         // ⌥/Ctrl over a wall → remove preview. A distinct room across → merge;
         // otherwise removeEdge deletes the wall and cleans up the orphans.
-        const nbr = plate.neighborAcross(ed.edge);
+        const nbr = session.neighborAcross(ed.edge);
         const shared = nbr !== undefined && nbr !== ed.face;
         setHover({ kind: 'edge', edge: ed.edge, rooms: [ed.face, ...(shared ? [nbr] : [])], a: ed.a, b: ed.b });
         setSplitHover(null);
@@ -1017,73 +950,67 @@ export function SpaceSketchOverlay() {
   // dissolves or its incident wall is removed; a wall is removed; both auto-clean
   // the orphans. Returns true if it acted on something under the cursor.
   const removeAtPoint = useCallback((wx: number, wy: number): boolean => {
-    const plate = plateRef.current;
-    if (!plate) return false;
+    const session = sessionRef.current;
+    if (!session?.alive) return false;
     // Over a node → dissolve it, else remove one of its incident walls.
     const v = pickVertex(wx, wy);
     if (v != null) {
-      const snap = plate.duplicate();
-      // Remove ANY node: a degree-2 node dissolves (straighten/remove); a wall
-      // junction (3+ walls) collapses by removing one of its incident walls.
-      // Scan EVERY wall incident to the node (not just the cursor-nearest) so a
-      // junction with one removable wall still goes.
       const vp = nearestVertPos(wx, wy);
-      let ok = false;
-      let reason = '';
-      try { plate.dissolveVertex(v); ok = true; setStatus(`Removed node — ${plate.roomCount} room(s).`); }
-      catch (err) {
-        reason = editError(err).message;
-        // The node won't straighten away (it's a wall junction). Remove one of
-        // its incident walls instead: `removeEdge` unions two real rooms, or
-        // deletes a bridge/spur wall and auto-cleans the orphaned inner lines
-        // and nodes it leaves — handling the BridgeEdge/BordersExterior cases
-        // the old merge-only path rejected.
-        if (vp) {
-          for (const r of rooms) {
-            const n = r.outline.length;
-            const k = r.outline.findIndex((p) => Math.abs(p[0] - vp[0]) < EPS && Math.abs(p[1] - vp[1]) < EPS);
-            if (k < 0) continue;
-            const bounds = plate.boundingElements(r.face) as Boundary[];
-            for (const idx of [k, (k - 1 + n) % n]) {
-              const b = bounds[idx];
-              if (!b) continue;
-              try { plate.removeEdge(b.edge); ok = true; setStatus(`Removed wall & cleaned up — ${plate.roomCount} room(s).`); }
-              catch { /* an enclosing wall — try the next incident wall */ }
-              if (ok) break;
+      try {
+        // One atomic edit: a degree-2 node dissolves (straighten/remove); a wall
+        // junction (3+ walls) won't, so fall back to removing one incident wall
+        // (removeEdge unions two real rooms, or deletes a bridge/spur wall and
+        // auto-cleans the orphans — handling the BridgeEdge/BordersExterior
+        // cases the old merge-only path rejected). Throws if nothing is
+        // removable, so session.edit rolls back.
+        const outcome = session.edit((h): 'node' | 'wall' => {
+          try { h.dissolveVertex(v); return 'node'; }
+          catch (dissolveErr) {
+            const reason = editError(dissolveErr).message;
+            if (vp) {
+              for (const r of rooms) {
+                const n = r.outline.length;
+                const k = r.outline.findIndex((p) => Math.abs(p[0] - vp[0]) < EPS && Math.abs(p[1] - vp[1]) < EPS);
+                if (k < 0) continue;
+                const bounds = h.boundingElements(r.face) as Boundary[];
+                for (const idx of [k, (k - 1 + n) % n]) {
+                  const b = bounds[idx];
+                  if (!b) continue;
+                  try { h.removeEdge(b.edge); return 'wall'; }
+                  catch { /* an enclosing wall — try the next incident wall */ }
+                }
+              }
             }
-            if (ok) break;
+            throw new Error(`no wall here separates two rooms${reason ? ` (${reason})` : ''}`);
           }
-        }
-      }
-      if (ok) { commitUndo(snap); refreshRooms(); setHover(null); setDeleteHover(null); }
-      else {
-        plate.free(); plateRef.current = snap; refreshRooms();
-        // Genuinely unremovable: every incident wall borders the outside (no
-        // second room to merge into) and the node won't dissolve. Surface the
-        // kernel reason so it's diagnosable rather than mysterious.
-        setStatus(`Can’t remove this node — no wall here separates two rooms${reason ? ` (${reason})` : ''}.`);
+        });
+        commit(); setHover(null); setDeleteHover(null);
+        setStatus(outcome === 'node'
+          ? `Removed node — ${session.roomCount} room(s).`
+          : `Removed wall & cleaned up — ${session.roomCount} room(s).`);
+      } catch (err) {
+        commit(); // session rolled back
+        setStatus(`Can’t remove this node — ${editError(err).message}.`);
       }
       return true;
     }
     // Over a wall → remove it (merge two rooms / delete a bridge-spur + clean up).
     const ed = pickEdge(wx, wy);
     if (ed != null) {
-      const snap = plate.duplicate();
       try {
-        // `removeEdge` unions two real rooms, or deletes a bridge/spur wall and
-        // auto-cleans the orphaned inner lines & nodes — only a real enclosing
-        // wall (room ↔ exterior) is refused, so a room never silently opens.
-        plate.removeEdge(ed.edge);
-        commitUndo(snap); refreshRooms(); setHover(null);
-        setStatus(`Removed wall — ${plate.roomCount} room(s) left.`);
+        // removeEdge unions two real rooms, or deletes a bridge/spur wall and
+        // auto-cleans the orphans — only a real enclosing wall is refused.
+        session.edit((h) => h.removeEdge(ed.edge));
+        commit(); setHover(null);
+        setStatus(`Removed wall — ${session.roomCount} room(s) left.`);
       } catch (err) {
-        plate.free(); plateRef.current = snap; refreshRooms();
+        commit();
         setStatus(`Can't remove this wall: ${editError(err).message}`);
       }
       return true;
     }
     return false; // nothing under the cursor
-  }, [pickVertex, pickEdge, nearestVertPos, rooms, commitUndo, refreshRooms]);
+  }, [pickVertex, pickEdge, nearestVertPos, rooms, commit]);
 
   // Right-click / macOS Ctrl-click is the remove gesture. macOS turns Ctrl-click
   // into a real right-click (button 2 + contextmenu), so routing it here — rather
@@ -1091,15 +1018,15 @@ export function SpaceSketchOverlay() {
   // Cmd/Alt-click. preventDefault keeps the native menu away regardless.
   const onContextMenu = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
-    if (!plateRef.current) return;
+    if (!sessionRef.current?.alive) return;
     if (drawPts.length > 0 || splitPick) return; // mid-gesture → leave it to Esc
     const [sx, sy] = svgPoint(e);
     removeAtPoint(wX(fitRef.current, sx), wY(fitRef.current, sy));
   }, [drawPts, splitPick, removeAtPoint]);
 
   const onPointerDown = useCallback((e: React.PointerEvent) => {
-    const plate = plateRef.current;
-    if (!plate) return;
+    const session = sessionRef.current;
+    if (!session?.alive) return;
     // Middle-mouse drag pans the view in any mode (Issue 4).
     if (e.button === 1) {
       panningRef.current = true;
@@ -1152,7 +1079,7 @@ export function SpaceSketchOverlay() {
     if (v != null) {
       const start = nearestVertPos(wx, wy);
       dragRef.current = v; dragStartRef.current = start; draggedRef.current = false;
-      pendingUndoRef.current = plate.duplicate();
+      session.beginDrag(); // pre-drag snapshot; committed on drop, reverted on cancel
       otherVertsRef.current = start
         ? uniqueVerts(rooms).filter((p) => Math.hypot(p[0] - start[0], p[1] - start[1]) > 1e-6)
         : uniqueVerts(rooms);
@@ -1166,17 +1093,15 @@ export function SpaceSketchOverlay() {
       // Insert a node on the wall RIGHT NOW (so "add a node" actually adds one,
       // visible + undoable), and arm a cut from it. A second wall/corner click
       // splits the room between the two; Esc/elsewhere keeps the added node.
-      const snap = plate.duplicate();
       try {
         const pos = projectOnSeg([wx, wy], ed.a, ed.b);
-        const va = plate.splitEdge(ed.edge, pos[0], pos[1]);
-        commitUndo(snap);
-        refreshRooms();
+        const va = session.edit((h) => h.splitEdge(ed.edge, pos[0], pos[1]));
+        commit();
         setSplitPick({ kind: 'vertex', vid: va, pos });
         setSplitHover(pos);
         setStatus('Node added — click another wall or corner to split between them, or Esc to keep the node.');
       } catch (err) {
-        plate.free(); plateRef.current = snap; refreshRooms();
+        commit();
         setStatus(`Can't add node here: ${editError(err).message}`);
       }
       return;
@@ -1193,7 +1118,7 @@ export function SpaceSketchOverlay() {
     drawRedoRef.current = [];
     setDrawPts([snap.pt]);
     setStatus('Drawing — click to add corners · Enter / double-click / first dot to close · Shift = straight.');
-  }, [drawPts, splitPick, pickVertex, nearestVertPos, pickEdge, rooms, resolveSplitTarget, performSplit, commitUndo, refreshRooms, commitDraw, removeAtPoint]);
+  }, [drawPts, splitPick, pickVertex, nearestVertPos, pickEdge, rooms, resolveSplitTarget, performSplit, commit, commitDraw, removeAtPoint]);
 
   const endDrag = useCallback((e: React.PointerEvent) => {
     if (panningRef.current) {
@@ -1204,12 +1129,12 @@ export function SpaceSketchOverlay() {
     if (dragRef.current == null) return;
     dragRef.current = null; dragStartRef.current = null; setSnapPos(null);
     svgRef.current?.releasePointerCapture(e.pointerId);
-    if (draggedRef.current && pendingUndoRef.current) commitUndo(pendingUndoRef.current);
-    else pendingUndoRef.current?.free();
-    pendingUndoRef.current = null;
+    const session = sessionRef.current;
+    if (draggedRef.current) { session?.commitDrag(); commit(); }
+    else session?.cancelDrag(); // a click without a drag → discard the snapshot
     const total = rooms.reduce((s, r) => s + r.area, 0);
     if (draggedRef.current) setStatus(`Drag done — ${rooms.length} room(s), ${total.toFixed(1)} m² (conserved).`);
-  }, [rooms, commitUndo]);
+  }, [rooms, commit]);
 
   const f = fitRef.current;
   const total = rooms.reduce((s, r) => s + r.area, 0);
@@ -1217,8 +1142,9 @@ export function SpaceSketchOverlay() {
   const cursorWorld = moveRef.current ? [wX(f, moveRef.current.x), wY(f, moveRef.current.y)] as Pt : null;
   const cursor = panningRef.current || dragRef.current != null ? 'grabbing' : hover?.kind === 'vertex' ? 'grab' : 'crosshair';
   // During a draw, Undo/Redo act on the placed points (not the plate stack).
-  const canUndo = drawPts.length > 0 || undoRef.current.length > 0;
-  const canRedo = drawRedoRef.current.length > 0 || redoRef.current.length > 0;
+  // `hist` bumps on every committed change so these recompute on re-render.
+  const canUndo = drawPts.length > 0 || (sessionRef.current?.canUndo ?? false);
+  const canRedo = drawRedoRef.current.length > 0 || (sessionRef.current?.canRedo ?? false);
   void hist; void fitTick;
 
   const gridStep = f.scale > 14 ? 1 : f.scale > 5 ? 2 : 5;

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -22,7 +22,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useViewerStore } from '@/store';
 import { useConstructionUnderlay } from '@/hooks/useConstructionUnderlay';
 import { useIfc } from '@/hooks/useIfc';
-import { snapPoint, type SnapKind } from '@/lib/space-snap';
+import { snapPoint, alignToAxes, type SnapKind } from '@/lib/space-snap';
 import init, { SpacePlateHandle } from '@ifc-lite/wasm';
 import {
   extractWallSegmentsForStorey,
@@ -202,6 +202,10 @@ export function SpaceSketchOverlay() {
   // Issue 2: the in-progress drawn room (world coords) + the live cursor point.
   const [drawPts, setDrawPts] = useState<Pt[]>([]);
   const [drawCursor, setDrawCursor] = useState<Pt | null>(null);
+  // Alignment guides while drawing: reference corners whose X (vertical guide)
+  // / Y (horizontal guide) the cursor is currently locked to — so the closing
+  // corner can line up under the first point, etc.
+  const [alignGuides, setAlignGuides] = useState<{ vRef: Pt | null; hRef: Pt | null }>({ vRef: null, hRef: null });
   // Issue 4: canvas size (resizable) + a tick that forces a re-render whenever
   // the view transform in fitRef changes (zoom/pan/fit) without making the
   // per-frame pointer math go through React state.
@@ -249,9 +253,11 @@ export function SpaceSketchOverlay() {
     () => (derivedStorey == null ? null : storeys.find((s) => s.id === derivedStorey)?.elev ?? null),
     [derivedStorey, storeys],
   );
-  // Compute the underlay when it's shown OR when snapping needs it (snapping to
-  // building lines must work even if the underlay isn't drawn).
-  const { lines: underlay } = useConstructionUnderlay((showBuilding || snapToBuilding) && rooms.length > 0, derivedFloorElev);
+  // Compute the underlay whenever a storey is derived (so snapping works even
+  // before any room exists — e.g. drawing the FIRST room must still snap to the
+  // building walls), not only when rooms are already present. Gated by show OR
+  // snap so it's not computed when neither needs it.
+  const { lines: underlay } = useConstructionUnderlay((showBuilding || snapToBuilding) && derivedFloorElev != null, derivedFloorElev);
 
   // Building wall lines as snap segments (room frame), only while snapping is on.
   const buildingSegments = useMemo<Array<[Pt, Pt]>>(
@@ -743,7 +749,7 @@ export function SpaceSketchOverlay() {
     try {
       plate.addFace(new Float64Array(pts.flat()), -1);
       commitUndo(snap);
-      setDrawPts([]); setDrawCursor(null); drawRedoRef.current = [];
+      setDrawPts([]); setDrawCursor(null); drawRedoRef.current = []; setAlignGuides({ vRef: null, hRef: null });
       refreshRooms();
       setStatus(`Drew a room — ${plate.roomCount} room(s).`);
     } catch (err) {
@@ -759,7 +765,7 @@ export function SpaceSketchOverlay() {
   // close the panel. Returns true if something was aborted.
   const abortCurrentOp = useCallback((): boolean => {
     if (mode === 'draw' && (drawPts.length > 0 || drawCursor)) {
-      setDrawPts([]); setDrawCursor(null); drawRedoRef.current = [];
+      setDrawPts([]); setDrawCursor(null); drawRedoRef.current = []; setAlignGuides({ vRef: null, hRef: null });
       setStatus('Draw cancelled.');
       return true;
     }
@@ -848,18 +854,29 @@ export function SpaceSketchOverlay() {
       setSplitHover(t ? t.pos : null);
       setHover(t && t.kind === 'vertex' ? { kind: 'vertex', pos: t.pos } : null);
     } else if (mode === 'draw') {
-      // Preview the next corner: snap to room vertices + building walls; Shift
-      // constrains to ortho from the previous corner.
+      // Preview the next corner. Strong osnap (room vertices + building walls)
+      // wins; otherwise align to the drawn corners' axes (so the closing corner
+      // locks under the first point, etc.). Shift constrains to ortho from the
+      // previous corner first.
+      const tol = PICK_PX / fitRef.current.scale;
       const anchor = drawPts.length > 0 ? drawPts[drawPts.length - 1] : null;
       const snap = snapPoint([wx, wy], {
         vertices: uniqueVerts(rooms),
         segments: buildingSegmentsRef.current,
-        tol: PICK_PX / fitRef.current.scale,
+        tol,
         ortho: m.shift,
         anchor,
       });
-      setDrawCursor(snap.pt);
-      setSnapKind(snap.kind);
+      if (snap.kind === 'none' && drawPts.length > 0) {
+        const al = alignToAxes(snap.pt, drawPts, tol);
+        setDrawCursor(al.pt);
+        setSnapKind('none');
+        setAlignGuides({ vRef: al.vRef, hRef: al.hRef });
+      } else {
+        setDrawCursor(snap.pt);
+        setSnapKind(snap.kind);
+        setAlignGuides({ vRef: null, hRef: null });
+      }
     } else {
       const v = pickVertex(wx, wy);
       const pos = v != null ? nearestVertPos(wx, wy) : null;
@@ -956,16 +973,20 @@ export function SpaceSketchOverlay() {
       return;
     }
     if (mode === 'draw') {
-      // Snap the dropped corner to room vertices + building walls; Shift = ortho
-      // from the previous corner.
+      // Snap the dropped corner: strong osnap (room vertices + building walls)
+      // wins; otherwise align to the drawn corners' axes. Shift = ortho from the
+      // previous corner first. Mirrors the preview in processMove.
+      const tol = PICK_PX / fitRef.current.scale;
       const anchor = drawPts.length > 0 ? drawPts[drawPts.length - 1] : null;
-      const p = snapPoint([wx, wy], {
+      const snap = snapPoint([wx, wy], {
         vertices: uniqueVerts(rooms),
         segments: buildingSegmentsRef.current,
-        tol: PICK_PX / fitRef.current.scale,
+        tol,
         ortho: e.shiftKey,
         anchor,
-      }).pt;
+      });
+      const p = snap.kind === 'none' && drawPts.length > 0 ? alignToAxes(snap.pt, drawPts, tol).pt : snap.pt;
+      setAlignGuides({ vRef: null, hRef: null });
       // With ≥3 points placed, clicking the first dot closes the loop.
       if (drawPts.length >= 3) {
         const first = drawPts[0];
@@ -1091,7 +1112,7 @@ export function SpaceSketchOverlay() {
           {(['drag', 'split', 'merge', 'draw'] as Mode[]).map((m) => (
             <button key={m}
               className={`rounded px-2 py-0.5 text-xs capitalize transition-colors ${mode === m ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'}`}
-              onClick={() => { setMode(m); setSplitPick(null); setSplitHover(null); setHover(null); setDeleteHover(null); setDrawPts([]); setDrawCursor(null); drawRedoRef.current = []; }}
+              onClick={() => { setMode(m); setSplitPick(null); setSplitHover(null); setHover(null); setDeleteHover(null); setDrawPts([]); setDrawCursor(null); drawRedoRef.current = []; setAlignGuides({ vRef: null, hRef: null }); }}
               title={m === 'draw' ? 'Author a new room by clicking its corners' : `Edit derived rooms (${m})`}
               disabled={m === 'draw' ? derivedStorey == null : !rooms.length}>{m}</button>
           ))}
@@ -1168,7 +1189,7 @@ export function SpaceSketchOverlay() {
         onPointerDown={onPointerDown} onPointerMove={onPointerMove} onPointerUp={endDrag}
         onDoubleClick={() => { if (mode === 'draw') commitDraw(); }}
         onContextMenu={(e) => e.preventDefault()}
-        onPointerLeave={() => { setHover(null); setSplitHover(null); setDeleteHover(null); setDrawCursor(null); }}>
+        onPointerLeave={() => { setHover(null); setSplitHover(null); setDeleteHover(null); setDrawCursor(null); setAlignGuides({ vRef: null, hRef: null }); }}>
         {gridLines.map((l, i) => <line key={`g${i}`} {...l} stroke="currentColor" strokeOpacity={0.06} strokeWidth={1} />)}
 
         {/* Building-element underlay (plan cut ~1.2 m above the storey) for orientation. */}
@@ -1240,6 +1261,16 @@ export function SpaceSketchOverlay() {
         {/* Draw-room in progress (Issue 2): placed points, rubber band, close hint. */}
         {mode === 'draw' && drawPts.length > 0 && (
           <g pointerEvents="none">
+            {/* Alignment guides — the dashed lines that telegraph "this corner
+                is lined up with that earlier corner" (e.g. under the first). */}
+            {drawCursor && alignGuides.vRef && (
+              <line x1={sX(f, drawCursor[0])} y1={sY(f, alignGuides.vRef[1])} x2={sX(f, drawCursor[0])} y2={sY(f, drawCursor[1])}
+                stroke="#f59e0b" strokeOpacity={0.7} strokeDasharray="3 3" strokeWidth={1} />
+            )}
+            {drawCursor && alignGuides.hRef && (
+              <line x1={sX(f, alignGuides.hRef[0])} y1={sY(f, drawCursor[1])} x2={sX(f, drawCursor[0])} y2={sY(f, drawCursor[1])}
+                stroke="#f59e0b" strokeOpacity={0.7} strokeDasharray="3 3" strokeWidth={1} />
+            )}
             {drawPts.length >= 3 && (
               <polygon points={drawPts.map((p) => `${sX(f, p[0])},${sY(f, p[1])}`).join(' ')} fill="#22c55e" fillOpacity={0.1} stroke="none" />
             )}

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -1065,16 +1065,22 @@ export function SpaceSketchOverlay() {
     if (v != null) {
       if (mod) {
         const snap = plate.duplicate();
-        try {
-          plate.dissolveVertex(v);
-          commitUndo(snap); refreshRooms(); setHover(null); setDeleteHover(null);
-          setStatus(`Removed vertex — ${plate.roomCount} room(s).`);
-        } catch {
-          plate.free(); plateRef.current = snap; refreshRooms();
-          // The only nodes that can't dissolve are wall junctions (3+ walls meet)
-          // — removing one there means removing a wall, i.e. merging rooms.
-          setStatus('Can’t remove a wall-junction node — ⌥-click a wall to merge the rooms instead.');
+        // A degree-2 node dissolves (straighten/remove). A wall JUNCTION (3+
+        // walls) can't dissolve — removing it there means removing a wall, so
+        // fall back to merging across the wall nearest the cursor. Together
+        // these "remove" every node: redundant ones vanish, junctions collapse
+        // by joining the two rooms that wall separated.
+        let ok = false;
+        try { plate.dissolveVertex(v); ok = true; setStatus(`Removed node — ${plate.roomCount} room(s).`); }
+        catch {
+          const ed2 = pickEdge(wx, wy);
+          if (ed2 && plate.neighborAcross(ed2.edge) !== undefined) {
+            try { plate.mergeFaces(ed2.edge); ok = true; setStatus(`Merged across the wall — ${plate.roomCount} room(s).`); }
+            catch { /* falls to the failure path below */ }
+          }
         }
+        if (ok) { commitUndo(snap); refreshRooms(); setHover(null); setDeleteHover(null); }
+        else { plate.free(); plateRef.current = snap; refreshRooms(); setStatus('Can’t remove this node — its walls border the outside or don’t separate two rooms.'); }
         return;
       }
       const start = nearestVertPos(wx, wy);

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -38,7 +38,6 @@ import {
 } from '@/lib/space-sketch-geometry';
 import {
   extractWallSegmentsForStorey,
-  offsetRoomFootprint,
   existingSpaceFootprintsByStorey,
   GENERATED_SPACE_OBJECTTYPE,
   type BoundaryMode,
@@ -133,12 +132,13 @@ export function SpaceSketchOverlay() {
   const [snapTol, setSnapTol] = useState<number | null>(null); // null = auto-escalate
   const [usedTol, setUsedTol] = useState(0.1);
   const snapTolRef = useRef<number | null>(null);
-  const lastBuildRef = useRef<{ coords: Float64Array; sources: Int32Array; label: string; storey: number | null } | null>(null);
-  // Wall segments + thicknesses from the last derive, kept for net-footprint
-  // inset at bake (so the IfcSpace solid stops at the inner wall face).
+  const lastBuildRef = useRef<{ coords: Float64Array; sources: Int32Array; thicknesses: Float64Array; label: string; storey: number | null } | null>(null);
+  // Wall segments + thicknesses from the last derive, kept for the leak
+  // diagnostics overlay + the "has wall data" affordance (net/gross outlines now
+  // come from the engine via half-thickness carried on each edge).
   const extractionRef = useRef<{
-    segments: Parameters<typeof offsetRoomFootprint>[1];
-    thicknesses: Parameters<typeof offsetRoomFootprint>[2];
+    segments: ReturnType<typeof extractWallSegmentsForStorey>['segments'];
+    thicknesses: ReturnType<typeof extractWallSegmentsForStorey>['wallThicknesses'];
   } | null>(null);
   const [hist, setHist] = useState(0);
   const [status, setStatus] = useState('Load the demo plate or derive from a storey.');
@@ -321,7 +321,7 @@ export function SpaceSketchOverlay() {
     return () => el.removeEventListener('wheel', onWheel);
   }, []);
 
-  const buildFrom = useCallback(async (coords: Float64Array, sources: Int32Array, label: string, storey: number | null) => {
+  const buildFrom = useCallback(async (coords: Float64Array, sources: Int32Array, thicknesses: Float64Array, label: string, storey: number | null) => {
     // Re-entrancy guard: a rapid rebuild (snap slider) must not let an older
     // async build free/replace the plate a newer one is using — that races the
     // shared wasm heap. Only the latest build applies; superseded ones bail.
@@ -333,14 +333,14 @@ export function SpaceSketchOverlay() {
       // to keep an older rebuild (rapid snap-slider drags) from replacing the
       // plate a newer one is building — the stale one bails before touching it.
       if (seq !== buildSeqRef.current) return;
-      lastBuildRef.current = { coords, sources, label, storey };
+      lastBuildRef.current = { coords, sources, thicknesses, label, storey };
       const manual = snapTolRef.current;
       let session = sessionRef.current;
       if (!session) { session = new SpacePlateSession(); sessionRef.current = session; }
       // Auto-escalate the corner-snap (real centrelines miss corners by ~½ a
       // wall thickness, so a tight snap leaves the loop open → 0 rooms); the
       // session tries [0.1, 0.25, 0.5] and keeps the first that encloses rooms.
-      const { rooms: snap, tol: used } = session.build(coords, sources, manual, 0.5);
+      const { rooms: snap, tol: used } = session.build(coords, sources, thicknesses, manual, 0.5);
       setUsedTol(used);
       applyFit(computeFit(snap, sizeRef.current.w, sizeRef.current.h));
       resetInteraction();
@@ -379,7 +379,7 @@ export function SpaceSketchOverlay() {
     rebuildTimerRef.current = setTimeout(() => {
       rebuildTimerRef.current = null;
       const lb = lastBuildRef.current;
-      if (lb) void buildFrom(lb.coords, lb.sources, lb.label, lb.storey);
+      if (lb) void buildFrom(lb.coords, lb.sources, lb.thicknesses, lb.label, lb.storey);
     }, 180);
   }, [buildFrom]);
 
@@ -394,12 +394,17 @@ export function SpaceSketchOverlay() {
       extractionRef.current = { segments, thicknesses: wallThicknesses };
       const coords = new Float64Array(segments.length * 4);
       const sources = new Int32Array(segments.length).fill(-1);
+      // Half-thickness per segment (m), carried onto the edges so the engine can
+      // offset to the net/gross wall face.
+      const half = new Float64Array(segments.length);
       segments.forEach((s, i) => {
         coords[i * 4] = s.a[0]; coords[i * 4 + 1] = s.a[1];
         coords[i * 4 + 2] = s.b[0]; coords[i * 4 + 3] = s.b[1];
+        const t = wallThicknesses[i];
+        half[i] = t && t > 0 ? t / 2 : 0;
       });
       const name = ifcDataStore.entities.getName(storeyId) || `Storey #${storeyId}`;
-      await buildFrom(coords, sources, name, storeyId);
+      await buildFrom(coords, sources, half, name, storeyId);
     } catch (e) {
       setStatus(`Derive failed: ${String(e)}`);
     }
@@ -447,9 +452,7 @@ export function SpaceSketchOverlay() {
    */
   const bakeStorey = useCallback((
     sid: number,
-    outlines: Pt[][],
-    segments: Parameters<typeof offsetRoomFootprint>[1] | undefined,
-    thicknesses: Parameters<typeof offsetRoomFootprint>[2] | undefined,
+    rooms: { outline: Pt[]; boundary: Pt[] }[],
     authored: Pt[][],
   ): { emitted: number; skipped: number; error: string | null } => {
     if (!activeModelId) return { emitted: 0, skipped: 0, error: null };
@@ -463,23 +466,22 @@ export function SpaceSketchOverlay() {
     // line tells the user the truth instead of silently dropping spaces
     // that would then be missing from the export.
     let error: string | null = null;
-    for (let oi = 0; oi < outlines.length; oi++) {
-      const outline = outlines[oi];
-      const [cx, cy] = centroid(outline);
+    for (const room of rooms) {
+      const [cx, cy] = centroid(room.outline);
       if (authored.some((fp) => pointInPoly(cx, cy, fp))) { skipped++; continue; }
-      const others = outlines.filter((_, j) => j !== oi);
-      const inset = segments && thicknesses ? offsetRoomFootprint(outline, segments, thicknesses, boundaryMode, others) : outline;
+      // `boundary` is the engine's net/gross/centre outline; gross area stays on
+      // the centreline so the quantity reflects the room, not the wall face.
       const res = addSpace(activeModelId, sid, {
-        Profile: 'polygon', OuterCurve: inset, Height: height,
+        Profile: 'polygon', OuterCurve: room.boundary, Height: height,
         Name: `Space ${newIds.length + 1}`, ObjectType: GENERATED_SPACE_OBJECTTYPE,
-        grossFloorArea: polyArea(outline),
+        grossFloorArea: polyArea(room.outline),
       });
       if (res && 'expressId' in res) newIds.push(res.expressId);
       else error ??= (res && 'error' in res ? res.error : 'unknown error');
     }
     generatedRef.current.set(sid, newIds);
     return { emitted: newIds.length, skipped, error };
-  }, [activeModelId, removeEntity, addSpace, floorToFloor, boundaryMode]);
+  }, [activeModelId, removeEntity, addSpace, floorToFloor]);
 
   const bake = useCallback(() => {
     const session = sessionRef.current;
@@ -487,16 +489,18 @@ export function SpaceSketchOverlay() {
       setStatus('Derive a storey first.');
       return;
     }
-    const outlines = session.rooms().map((r) => r.outline);
-    const ext = extractionRef.current;
+    const rooms = session.rooms().map((r) => ({
+      outline: r.outline,
+      boundary: session.boundaryOutline(r.face, boundaryMode),
+    }));
     const authored = existingSpaceFootprintsByStorey(ifcDataStore).get(derivedStorey) ?? [];
-    const { emitted, skipped, error } = bakeStorey(derivedStorey, outlines, ext?.segments, ext?.thicknesses, authored);
+    const { emitted, skipped, error } = bakeStorey(derivedStorey, rooms, authored);
     if (emitted > 0) revealSpaces();
     if (!error) { session.dirty = false; setDirty(false); } // rooms now written to IfcSpace
     setStatus(error
       ? `Baked ${emitted} IfcSpace — others failed: ${error}`
       : `Baked ${emitted} IfcSpace${skipped ? `, skipped ${skipped} (already a space)` : ''}.`);
-  }, [activeModelId, derivedStorey, ifcDataStore, bakeStorey, revealSpaces]);
+  }, [activeModelId, derivedStorey, ifcDataStore, bakeStorey, revealSpaces, boundaryMode]);
 
   const bakeWholeBuilding = useCallback(async () => {
     if (!activeModelId || !ifcDataStore) { setStatus('No model loaded.'); return; }
@@ -510,12 +514,18 @@ export function SpaceSketchOverlay() {
       if (!segments.length) continue;
       const coords = new Float64Array(segments.length * 4);
       const sources = new Int32Array(segments.length).fill(-1);
-      segments.forEach((s, i) => { coords[i * 4] = s.a[0]; coords[i * 4 + 1] = s.a[1]; coords[i * 4 + 2] = s.b[0]; coords[i * 4 + 3] = s.b[1]; });
+      const half = new Float64Array(segments.length);
+      segments.forEach((s, i) => {
+        coords[i * 4] = s.a[0]; coords[i * 4 + 1] = s.a[1]; coords[i * 4 + 2] = s.b[0]; coords[i * 4 + 3] = s.b[1];
+        const t = wallThicknesses[i];
+        half[i] = t && t > 0 ? t / 2 : 0;
+      });
       // Throwaway plate per storey (escalation + deterministic free handled by
-      // the session module) — this path doesn't touch the live session.
-      const outlines = snapshotRooms(coords, sources).map((r) => r.outline);
-      if (!outlines.length) continue;
-      const { emitted, skipped, error } = bakeStorey(st.id, outlines, segments, wallThicknesses, authoredMap.get(st.id) ?? []);
+      // the session module) — this path doesn't touch the live session. Reads
+      // each room's centreline + the boundary outline at the chosen mode.
+      const rooms = snapshotRooms(coords, sources, half, boundaryMode);
+      if (!rooms.length) continue;
+      const { emitted, skipped, error } = bakeStorey(st.id, rooms, authoredMap.get(st.id) ?? []);
       totalEmitted += emitted; totalSkipped += skipped;
       firstError ??= error;
       if (emitted) floors++;
@@ -525,7 +535,7 @@ export function SpaceSketchOverlay() {
     setStatus(firstError
       ? `Generated ${totalEmitted} IfcSpace — others failed: ${firstError}`
       : `Generated ${totalEmitted} IfcSpace across ${floors} storey(s)${totalSkipped ? `; skipped ${totalSkipped} existing` : ''}.`);
-  }, [activeModelId, ifcDataStore, storeys, bakeStorey, revealSpaces]);
+  }, [activeModelId, ifcDataStore, storeys, bakeStorey, revealSpaces, boundaryMode]);
 
   useEffect(() => () => {
     if (rafRef.current) cancelAnimationFrame(rafRef.current);
@@ -1073,14 +1083,17 @@ export function SpaceSketchOverlay() {
   // broken (Issue 6).
   const boundaryInfo = useMemo(
     () =>
-      rooms.map((r, ri) => {
+      rooms.map((r) => {
         if (boundaryMode === 'center') return { disp: r.outline, unbounded: false };
-        if (!ext) return { disp: r.outline, unbounded: true };
-        const others = rooms.filter((_, j) => j !== ri).map((x) => x.outline);
-        const disp = offsetRoomFootprint(r.outline, ext.segments, ext.thicknesses, boundaryMode, others);
+        // Net/gross outline straight from the engine (per-edge wall thickness);
+        // it falls back to the centreline when no wall offset applies, so a
+        // no-change result flags the room as unbounded (Issue 6).
+        const disp = sessionRef.current?.boundaryOutline(r.face, boundaryMode) ?? r.outline;
         return { disp, unbounded: Math.abs(polyArea(disp) - r.area) < 1e-3 };
       }),
-    [rooms, boundaryMode, ext],
+    // `hist` re-derives this after a plate edit (rooms identity also changes then).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [rooms, boundaryMode, hist],
   );
   const unboundedCount = boundaryMode === 'center' ? 0 : boundaryInfo.filter((b) => b.unbounded).length;
 

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -31,7 +31,7 @@ import {
   GENERATED_SPACE_OBJECTTYPE,
   type BoundaryMode,
 } from '@ifc-lite/create';
-import { X, Undo2, Redo2, Building2, Layers, Maximize, AlertTriangle, Magnet } from 'lucide-react';
+import { X, Undo2, Redo2, Layers, Maximize, AlertTriangle, Magnet, SlidersHorizontal, HelpCircle } from 'lucide-react';
 
 let wasmReady: Promise<void> | null = null;
 function ensureWasm(): Promise<void> {
@@ -195,6 +195,14 @@ export function SpaceSketchOverlay() {
   // Snap every node to the building's 2D wall lines (corners + along walls).
   // Default on; the magnet toggle in the toolbar turns it off (vertex-only).
   const [snapToBuilding, setSnapToBuilding] = useState(true);
+  // True once the user has edited the plate (drag/split/merge/draw/dissolve)
+  // since the last bake/derive — drives the "close with unbaked edits" guard.
+  const [dirty, setDirty] = useState(false);
+  // Disclosure popovers (self-managed; no radix Popover primitive here) + the
+  // unbaked-edits close confirmation. Keep the default panel clean.
+  const [optionsOpen, setOptionsOpen] = useState(false);
+  const [helpOpen, setHelpOpen] = useState(false);
+  const [confirmClose, setConfirmClose] = useState(false);
   // Issue 3: the vertex that an ⌥/Ctrl-click would dissolve — telegraphed live.
   const [deleteHover, setDeleteHover] = useState<Pt | null>(null);
   // Issue 2: the in-progress drawn room (world coords) + the live cursor point.
@@ -337,6 +345,7 @@ export function SpaceSketchOverlay() {
     redoRef.current.forEach((h) => h.free());
     redoRef.current = [];
     setHist((v) => v + 1);
+    setDirty(true); // an edit happened — unbaked until the next Bake
   }, []);
 
   const resetInteraction = useCallback(() => {
@@ -452,6 +461,7 @@ export function SpaceSketchOverlay() {
       resetInteraction();
       setDerivedStorey(storey);
       setRooms(snap); setHist((v) => v + 1);
+      setDirty(false); // a fresh derive is the new clean baseline
       // Surface the room-count consequence of a corner-tolerance change (only a
       // snap rebuild sets pendingSnapPrevRef; an initial derive leaves it null).
       const prevCount = pendingSnapPrevRef.current;
@@ -597,6 +607,7 @@ export function SpaceSketchOverlay() {
     const authored = existingSpaceFootprintsByStorey(ifcDataStore).get(derivedStorey) ?? [];
     const { emitted, skipped, error } = bakeStorey(derivedStorey, outlines, ext?.segments, ext?.thicknesses, authored);
     if (emitted > 0) revealSpaces();
+    if (!error) setDirty(false); // this storey's rooms are now written to IfcSpace
     setStatus(error
       ? `Baked ${emitted} IfcSpace — others failed: ${error}`
       : `Baked ${emitted} IfcSpace${skipped ? `, skipped ${skipped} (already a space)` : ''}.`);
@@ -631,6 +642,7 @@ export function SpaceSketchOverlay() {
       if (emitted) floors++;
     }
     if (totalEmitted > 0) revealSpaces();
+    if (!firstError) setDirty(false);
     setStatus(firstError
       ? `Generated ${totalEmitted} IfcSpace — others failed: ${firstError}`
       : `Generated ${totalEmitted} IfcSpace across ${floors} storey(s)${totalSkipped ? `; skipped ${totalSkipped} existing` : ''}.`);
@@ -800,8 +812,11 @@ export function SpaceSketchOverlay() {
         e.preventDefault();
         const now = Date.now();
         if (abortCurrentOp()) { escTimeRef.current = 0; return; }
-        if (now - escTimeRef.current <= 400) { escTimeRef.current = 0; setActiveTool('select'); }
-        else { escTimeRef.current = now; setStatus('Press Esc again to close.'); }
+        if (now - escTimeRef.current <= 400) {
+          escTimeRef.current = 0;
+          if (dirty) setConfirmClose(true); // guard unbaked edits
+          else setActiveTool('select');
+        } else { escTimeRef.current = now; setStatus(dirty ? 'Unbaked edits — Esc again to discard & close.' : 'Press Esc again to close.'); }
       } else if (e.key === 'Enter' && drawPts.length > 0 && !inField) {
         e.preventDefault();
         commitDraw();
@@ -809,7 +824,13 @@ export function SpaceSketchOverlay() {
     };
     document.addEventListener('keydown', onKey);
     return () => document.removeEventListener('keydown', onKey);
-  }, [abortCurrentOp, commitDraw, drawPts.length, setActiveTool]);
+  }, [abortCurrentOp, commitDraw, drawPts.length, dirty, setActiveTool]);
+
+  // Close request from the ✕ button: guard unbaked edits with an inline confirm.
+  const requestClose = useCallback(() => {
+    if (dirty) setConfirmClose(true);
+    else setActiveTool('select');
+  }, [dirty, setActiveTool]);
 
   const processMove = useCallback(() => {
     rafRef.current = null;
@@ -997,7 +1018,13 @@ export function SpaceSketchOverlay() {
       return;
     }
 
-    // 5. Empty space → start drawing a new room.
+    // 5. Empty space → Shift pans (so you can still pan now that a plain click
+    //    draws); otherwise start drawing a new room.
+    if (e.shiftKey) {
+      panningRef.current = true;
+      svgRef.current?.setPointerCapture(e.pointerId);
+      return;
+    }
     const snap = snapPoint([wx, wy], { vertices: uniqueVerts(rooms), segments: buildingSegmentsRef.current, tol });
     drawRedoRef.current = [];
     setDrawPts([snap.pt]);
@@ -1091,11 +1118,26 @@ export function SpaceSketchOverlay() {
   return (
     <div ref={panelRef} className="absolute left-1/2 top-4 -translate-x-1/2 z-30 rounded-xl border bg-background/95 shadow-xl backdrop-blur p-3 select-none pointer-events-auto"
          style={{ width: size.w + 24 }}>
+      {/* Inline unbaked-edits close confirmation (not a native dialog). */}
+      {confirmClose && (
+        <div className="absolute inset-x-0 top-0 z-40 flex items-center gap-2 rounded-t-xl border-b border-amber-600/40 bg-amber-500 px-3 py-2 text-xs text-amber-950">
+          <AlertTriangle className="h-4 w-4 shrink-0" />
+          <span className="flex-1 font-medium">Unbaked edits will be lost.</span>
+          <button onClick={() => setConfirmClose(false)} className="rounded px-2 py-1 font-medium hover:bg-black/10">Keep editing</button>
+          <button onClick={() => { setConfirmClose(false); setActiveTool('select'); }} className="rounded bg-amber-950 px-2 py-1 font-medium text-amber-50 hover:bg-amber-900">Discard &amp; close</button>
+        </div>
+      )}
+
       <div className="flex items-center justify-between mb-2.5">
         <div className="flex items-center gap-2 text-sm font-semibold">
           <Layers className="h-4 w-4 text-muted-foreground" /> Space Sketch
+          {dirty && <span className="h-1.5 w-1.5 rounded-full bg-amber-500" title="Unbaked edits" />}
         </div>
-        <button className={iconBtn} onClick={() => setActiveTool('select')} title="Close (double-tap Esc)"><X className="h-4 w-4" /></button>
+        <div className="flex items-center gap-0.5">
+          <button className={`${iconBtn} ${helpOpen ? 'bg-muted text-foreground' : ''}`} aria-pressed={helpOpen}
+            onClick={() => { setHelpOpen((v) => !v); setOptionsOpen(false); }} title="How it works"><HelpCircle className="h-4 w-4" /></button>
+          <button className={iconBtn} onClick={requestClose} title="Close (double-tap Esc)"><X className="h-4 w-4" /></button>
+        </div>
       </div>
 
       {/* Storey + whole-building */}
@@ -1109,72 +1151,99 @@ export function SpaceSketchOverlay() {
           title="Create IfcSpace for every storey at once — auto floor-to-floor height, skips rooms that already have a space">Generate all</button>
       </div>
 
-      {/* History + snap. The tool is modeless — what happens is driven by what's
-          under the cursor (node / wall / empty), so there are no mode tabs. */}
-      <div className="flex items-center gap-1.5 mb-2">
+      {/* Action row — modeless, so no mode tabs: history · snap · options · fit,
+          with a live room tally. Secondary settings hide behind Options. */}
+      <div className="flex items-center gap-1 mb-2">
         <button className={iconBtn} onClick={undo} disabled={!canUndo} title="Undo (Ctrl+Z)"><Undo2 className="h-4 w-4" /></button>
         <button className={iconBtn} onClick={redo} disabled={!canRedo} title="Redo (Ctrl+Shift+Z)"><Redo2 className="h-4 w-4" /></button>
-        <button
-          className={`${iconBtn} ${snapToBuilding ? 'bg-primary/10 text-primary hover:bg-primary/15' : ''}`}
-          onClick={() => setSnapToBuilding((v) => !v)}
-          aria-pressed={snapToBuilding}
-          title={snapToBuilding ? 'Snap to building walls: on — click to disable' : 'Snap to building walls: off — click to enable'}
-        ><Magnet className="h-4 w-4" /></button>
+        <span className="mx-0.5 h-5 w-px bg-border" />
+        <button className={`${iconBtn} ${snapToBuilding ? 'bg-primary/10 text-primary hover:bg-primary/15' : ''}`}
+          onClick={() => setSnapToBuilding((v) => !v)} aria-pressed={snapToBuilding}
+          title={snapToBuilding ? 'Snap to walls + corners: on' : 'Snap to walls + corners: off'}><Magnet className="h-4 w-4" /></button>
+        <button className={`${iconBtn} relative ${optionsOpen ? 'bg-muted text-foreground' : ''}`} aria-pressed={optionsOpen}
+          onClick={() => { setOptionsOpen((v) => !v); setHelpOpen(false); }} title="Options — boundary, corner tolerance, underlay">
+          <SlidersHorizontal className="h-4 w-4" />
+          {(boundaryMode !== 'inner' || snapTol != null || showDiagnostics) && <span className="absolute right-1 top-1 h-1.5 w-1.5 rounded-full bg-primary" />}
+        </button>
+        <button className={iconBtn} onClick={() => applyFit(computeFit(rooms, sizeRef.current.w, sizeRef.current.h))}
+          disabled={!rooms.length} title="Fit plan to canvas (reset zoom & pan)"><Maximize className="h-4 w-4" /></button>
+        <span className="ml-auto pr-1 text-[11px] tabular-nums text-muted-foreground">
+          {rooms.length} {rooms.length === 1 ? 'room' : 'rooms'} · {total.toFixed(1)} m²
+        </span>
       </div>
 
-      {/* While drawing a room, the point-placement hint. */}
-      {drawPts.length > 0 && (
-        <div className="mb-2 text-[11px] text-muted-foreground leading-tight">
-          {`${drawPts.length} pt(s) · Enter, double-click, or click the first dot to close · Esc cancels · Ctrl+Z removes last · Shift = straight.`}
+      {/* Click-away backdrop for the disclosure popovers (panel-local). */}
+      {(optionsOpen || helpOpen) && (
+        <div className="absolute inset-0 z-10" aria-hidden onMouseDown={() => { setOptionsOpen(false); setHelpOpen(false); }} />
+      )}
+
+      {/* Options popover — the set-once settings, out of the main flow. */}
+      {optionsOpen && (
+        <div className="absolute right-3 top-12 z-20 w-64 space-y-3 rounded-lg border bg-popover p-3 text-[11px] text-muted-foreground shadow-xl">
+          <div className="space-y-1.5">
+            <div className="font-medium text-foreground">Boundary</div>
+            <div className="inline-flex rounded-md border p-0.5">
+              {(['center', 'inner', 'outer'] as BoundaryMode[]).map((m) => {
+                const noWallData = !ext && m !== 'center';
+                return (
+                  <button key={m}
+                    className={`rounded px-2 py-0.5 capitalize transition-colors disabled:opacity-40 ${boundaryMode === m ? 'bg-primary text-primary-foreground' : 'hover:text-foreground'}`}
+                    onClick={() => setBoundaryMode(m)} disabled={noWallData}
+                    title={noWallData ? 'No wall data on this derive — only the centreline is available' : m === 'center' ? 'Wall centreline' : m === 'inner' ? 'Inner (net) face' : 'Outer (gross) face'}>{m}</button>
+                );
+              })}
+            </div>
+          </div>
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between">
+              <span className="font-medium text-foreground">Corner tolerance</span>
+              {snapDelta && (
+                <span className={`tabular-nums ${snapDelta.to === 0 ? 'text-red-500' : snapDelta.to < snapDelta.from ? 'text-amber-500' : 'text-emerald-500'}`}
+                  title="Rooms before → after">{snapDelta.from} → {snapDelta.to}</span>
+              )}
+            </div>
+            <div className="flex items-center gap-1.5">
+              <input type="range" min={0.05} max={1} step={0.05} value={usedTol} className="flex-1 accent-primary"
+                disabled={derivedStorey == null} onChange={(e) => rebuildWithSnap(Number(e.target.value))} />
+              <input type="number" min={0.05} max={1} step={0.05} value={usedTol} aria-label="Corner tolerance (metres)"
+                className="w-12 rounded border bg-background px-1 py-0.5 tabular-nums disabled:opacity-40"
+                disabled={derivedStorey == null}
+                onChange={(e) => { const v = Number(e.target.value); if (Number.isFinite(v) && v > 0) rebuildWithSnap(Math.min(1, Math.max(0.05, v))); }} />
+              <button className="rounded px-1 hover:text-foreground disabled:opacity-40" onClick={() => rebuildWithSnap(null)}
+                disabled={derivedStorey == null}
+                title={snapTol == null ? 'Automatic — escalates until rooms close' : 'Reset to automatic'}>{snapTol == null ? 'auto' : 'reset'}</button>
+            </div>
+          </div>
+          <label className="flex cursor-pointer items-center justify-between">
+            <span className="text-foreground">Show building underlay</span>
+            <input type="checkbox" className="accent-primary" checked={showBuilding} onChange={() => setShowBuilding((v) => !v)} />
+          </label>
+          <label className="flex cursor-pointer items-center justify-between">
+            <span className="text-foreground">Leak diagnostics</span>
+            <input type="checkbox" className="accent-primary" checked={showDiagnostics} disabled={!ext} onChange={() => setShowDiagnostics((v) => !v)} />
+          </label>
         </div>
       )}
 
-      {/* Corner-closing tolerance — the gap two wall centrelines may have and
-          still close a room corner. NOT vertex snapping (that's the drag
-          behaviour); the name "snap" was conflated with it. Numeric field for
-          precise values; the badge flashes the room-count change so the effect
-          is visible on the plan (Issue 5). */}
-      <div className="flex items-center gap-1.5 mb-2 text-[11px] text-muted-foreground">
-        <span title="How far apart two wall centrelines can be and still close a room corner. Larger closes bigger gaps but can over-merge. This is NOT vertex snapping.">Corner tol</span>
-        <input type="range" min={0.05} max={1} step={0.05} value={usedTol} className="w-20 accent-primary"
-          disabled={derivedStorey == null} onChange={(e) => rebuildWithSnap(Number(e.target.value))} />
-        <input type="number" min={0.05} max={1} step={0.05} value={usedTol} aria-label="Corner tolerance (metres)"
-          className="w-14 rounded border bg-background px-1 py-0.5 tabular-nums disabled:opacity-40"
-          disabled={derivedStorey == null}
-          onChange={(e) => { const v = Number(e.target.value); if (Number.isFinite(v) && v > 0) rebuildWithSnap(Math.min(1, Math.max(0.05, v))); }} />
-        <span>m</span>
-        <button className="rounded px-1 hover:text-foreground disabled:opacity-40" onClick={() => rebuildWithSnap(null)}
-          disabled={derivedStorey == null}
-          title={snapTol == null ? 'Automatic — escalates the tolerance until rooms close' : 'Reset to automatic'}>{snapTol == null ? 'auto' : 'reset'}</button>
-        {snapDelta && (
-          <span className={`ml-auto rounded px-1 tabular-nums animate-pulse ${snapDelta.to === 0 ? 'text-red-500' : snapDelta.to < snapDelta.from ? 'text-amber-500' : 'text-emerald-500'}`}
-            title="Rooms before → after this tolerance change">{snapDelta.from} → {snapDelta.to} rooms</span>
-        )}
-      </div>
-
-      {/* View: boundary relative to walls + building underlay */}
-      <div className="flex items-center gap-2 mb-2 text-[11px] text-muted-foreground">
-        <span title="Where the space boundary sits relative to its walls — drives the 2D preview and the bake">Boundary</span>
-        <div className="inline-flex rounded-md border p-0.5">
-          {(['center', 'inner', 'outer'] as BoundaryMode[]).map((m) => {
-            const noWallData = !ext && m !== 'center';
-            return (
-              <button key={m}
-                className={`rounded px-2 py-0.5 capitalize transition-colors disabled:opacity-40 ${boundaryMode === m ? 'bg-primary text-primary-foreground' : 'hover:text-foreground'}`}
-                onClick={() => setBoundaryMode(m)} disabled={noWallData}
-                title={noWallData ? 'No wall data on this derive — only the centreline is available' : m === 'center' ? 'Wall centreline' : m === 'inner' ? 'Inner (net) face' : 'Outer (gross) face'}>{m}</button>
-            );
-          })}
+      {/* Help popover — the full gesture legend, on demand (keeps the panel clean). */}
+      {helpOpen && (
+        <div className="absolute right-3 top-12 z-20 w-72 space-y-1.5 rounded-lg border bg-popover p-3 text-[11px] shadow-xl">
+          <div className="mb-1 font-medium text-foreground">One tool — actions follow the cursor:</div>
+          {([
+            ['Drag a node', 'move it (snaps; Shift = straight)'],
+            ['Click a wall, then another', 'split the room between them'],
+            ['Click empty space', 'draw a room (Enter / dbl-click closes)'],
+            ['⌥/Ctrl-click a node', 'remove it'],
+            ['⌥/Ctrl-click a wall', 'merge the two rooms'],
+            ['Shift-drag / middle-drag', 'pan · scroll = zoom'],
+          ] as [string, string][]).map(([k, v]) => (
+            <div key={k} className="flex gap-2">
+              <span className="shrink-0 font-medium text-foreground">{k}</span>
+              <span className="text-muted-foreground">— {v}</span>
+            </div>
+          ))}
         </div>
-        <button className={`${iconBtn} ml-auto`} onClick={() => applyFit(computeFit(rooms, sizeRef.current.w, sizeRef.current.h))}
-          disabled={!rooms.length} title="Fit the plan to the canvas (reset zoom & pan)"><Maximize className="h-4 w-4" /></button>
-        <button className={`${iconBtn} ${showBuilding ? 'bg-primary/10 text-primary hover:bg-primary/15' : ''}`}
-          onClick={() => setShowBuilding((v) => !v)}
-          title="Show surrounding building elements (plan cut ~1.2 m above the floor)"><Building2 className="h-4 w-4" /></button>
-        <button className={`${iconBtn} ${showDiagnostics ? 'bg-red-500/10 text-red-500 hover:bg-red-500/15' : ''}`}
-          onClick={() => setShowDiagnostics((v) => !v)} disabled={!ext}
-          title="Diagnostics — highlight walls that bound no room (possible leaks) and rooms that failed to close"><AlertTriangle className="h-4 w-4" /></button>
-      </div>
+      )}
 
       <svg ref={svgRef} width={size.w} height={size.h} style={{ cursor }}
         className="rounded border bg-muted/20 touch-none"
@@ -1321,33 +1390,36 @@ export function SpaceSketchOverlay() {
         )}
       </svg>
 
-      <div className="mt-2.5 flex items-center gap-2">
-        <button className="h-8 shrink-0 rounded-md bg-emerald-600 px-3 text-xs font-medium text-white hover:bg-emerald-700 disabled:opacity-40"
-          onClick={bake} disabled={derivedStorey == null || !rooms.length}
-          title="Write this storey's rooms as IfcSpace — replaces any this tool already dropped here">Bake storey</button>
-        <div className="min-w-0 flex-1 text-right text-xs text-muted-foreground leading-tight">
-          <div>{rooms.length} room(s) · {total.toFixed(1)} m²</div>
-          {status && <div className="truncate">{status}</div>}
-        </div>
-      </div>
-      <div className="mt-1.5 text-[11px] text-muted-foreground">
-        {!rooms.length && drawPts.length === 0 && 'Pick a storey to derive its rooms, “Generate all” for the building, or click empty space to draw a room by hand.'}
-        {drawPts.length > 0
-          ? 'Click corners (snap to walls + earlier corners; Shift = straight). Enter, double-click, or click the first dot to close. Esc cancels; Ctrl+Z removes the last point.'
-          : splitPick
-            ? 'Click another wall (or corner) on the same room to finish the cut. Esc cancels.'
-            : 'Drag a node to move it · click a wall then another to split · ⌥-click a wall to merge · click empty space to draw a room · ⌥-click a node to remove it.'}
-        {unboundedCount > 0 && (
-          <span className="text-amber-600 dark:text-amber-500"> · {unboundedCount} room(s) unchanged by {boundaryMode} (dashed) — no wall offset.</span>
-        )}
-        {!!rooms.length && <span className="opacity-60"> · Scroll = zoom · middle- or empty-drag = pan · ⤢ = fit.</span>}
-        {showDiagnostics && (
-          <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5">
-            <span className="text-emerald-600 dark:text-emerald-500">▬ wall bounds a room</span>
-            <span className="text-red-500">╌ wall bounds nothing ({leakCount} — leak suspect)</span>
-            <span className="text-red-500">▦ room failed to close ({badCount})</span>
+      {/* Footer — an in-the-moment hint only while drawing/cutting (the full
+          legend lives behind “?”), the live status, then the primary action. */}
+      <div className="mt-2.5 space-y-1.5">
+        {(drawPts.length > 0 || splitPick) && (
+          <div className="text-[11px] leading-tight text-primary">
+            {drawPts.length > 0
+              ? 'Click corners · Enter / double-click / first dot to close · Shift = straight · Esc cancels.'
+              : 'Click another wall or corner to finish the cut · Esc cancels.'}
           </div>
         )}
+        {status && drawPts.length === 0 && !splitPick && (
+          <div className="truncate text-[11px] leading-tight text-muted-foreground" title={status}>{status}</div>
+        )}
+        {unboundedCount > 0 && (
+          <div className="text-[11px] leading-tight text-amber-600 dark:text-amber-500">
+            {unboundedCount} room(s) unchanged by “{boundaryMode}” (dashed) — no wall offset.
+          </div>
+        )}
+        {showDiagnostics && (
+          <div className="flex flex-wrap gap-x-3 gap-y-0.5 text-[10px]">
+            <span className="text-emerald-600 dark:text-emerald-500">▬ bounds a room</span>
+            <span className="text-red-500">╌ bounds nothing ({leakCount})</span>
+            <span className="text-red-500">▦ failed to close ({badCount})</span>
+          </div>
+        )}
+        <button className="h-9 w-full rounded-md bg-emerald-600 text-xs font-semibold text-white hover:bg-emerald-700 disabled:opacity-40"
+          onClick={bake} disabled={derivedStorey == null || !rooms.length}
+          title="Write this storey's rooms as IfcSpace — replaces any this tool already dropped here">
+          Bake storey to IfcSpace
+        </button>
       </div>
 
       {/* Resize grip (Issue 4) — drag to grow/shrink the canvas; the plan stays

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -31,7 +31,7 @@ import {
   GENERATED_SPACE_OBJECTTYPE,
   type BoundaryMode,
 } from '@ifc-lite/create';
-import { X, Undo2, Redo2, Layers, Maximize, AlertTriangle, Magnet, SlidersHorizontal, HelpCircle } from 'lucide-react';
+import { X, Undo2, Redo2, Layers, Maximize, AlertTriangle, Magnet, SlidersHorizontal, HelpCircle, Eraser } from 'lucide-react';
 
 let wasmReady: Promise<void> | null = null;
 function ensureWasm(): Promise<void> {
@@ -859,6 +859,39 @@ export function SpaceSketchOverlay() {
     else setActiveTool('select');
   }, [dirty, setActiveTool]);
 
+  // "Simplify" — bulk-remove every redundant node: one that lies on a straight
+  // run in EVERY room it touches (so dissolving it can't change any room's
+  // shape). This clears the derivation cruft without deforming geometry. Wall
+  // junctions (3+ walls) are left alone — those are removed by merging.
+  const simplifyRedundantNodes = useCallback(() => {
+    const plate = plateRef.current;
+    if (!plate || !rooms.length) return;
+    const COLL_TOL = 0.02; // m — perpendicular distance to the chord through neighbours
+    const byPos = new Map<string, { p: Pt; collinearEverywhere: boolean }>();
+    for (const r of rooms) {
+      const n = r.outline.length;
+      for (let i = 0; i < n; i++) {
+        const a = r.outline[(i + n - 1) % n], c = r.outline[i], b = r.outline[(i + 1) % n];
+        const coll = distToSeg(c[0], c[1], a[0], a[1], b[0], b[1]) < COLL_TOL;
+        const key = `${c[0].toFixed(4)},${c[1].toFixed(4)}`;
+        const e = byPos.get(key);
+        if (e) e.collinearEverywhere = e.collinearEverywhere && coll;
+        else byPos.set(key, { p: c, collinearEverywhere: coll });
+      }
+    }
+    const candidates = [...byPos.values()].filter((e) => e.collinearEverywhere).map((e) => e.p);
+    if (!candidates.length) { setStatus('No redundant nodes to remove.'); return; }
+    const snap = plate.duplicate();
+    let removed = 0;
+    for (const p of candidates) {
+      const vid = plate.findVertexNear(p[0], p[1], 1e-3); // positions don't move as others dissolve
+      if (vid === undefined) continue;
+      try { plate.dissolveVertex(vid); removed++; } catch { /* junction/triangle — leave it */ }
+    }
+    if (removed > 0) { commitUndo(snap); refreshRooms(); setStatus(`Removed ${removed} redundant node(s).`); }
+    else { snap.free(); setStatus('No removable redundant nodes.'); }
+  }, [rooms, commitUndo, refreshRooms]);
+
   const processMove = useCallback(() => {
     rafRef.current = null;
     const m = moveRef.current;
@@ -1036,9 +1069,11 @@ export function SpaceSketchOverlay() {
           plate.dissolveVertex(v);
           commitUndo(snap); refreshRooms(); setHover(null); setDeleteHover(null);
           setStatus(`Removed vertex — ${plate.roomCount} room(s).`);
-        } catch (err) {
+        } catch {
           plate.free(); plateRef.current = snap; refreshRooms();
-          setStatus(`Can't remove vertex: ${String(err).replace(/^\w+:\s*/, '')}`);
+          // The only nodes that can't dissolve are wall junctions (3+ walls meet)
+          // — removing one there means removing a wall, i.e. merging rooms.
+          setStatus('Can’t remove a wall-junction node — ⌥-click a wall to merge the rooms instead.');
         }
         return;
       }
@@ -1067,10 +1102,21 @@ export function SpaceSketchOverlay() {
         }
         return;
       }
-      const target = resolveSplitTarget(wx, wy);
-      if (target) {
-        setSplitPick(target); setSplitHover(target.pos);
-        setStatus('Cut started — click another wall (or corner) on the same room to finish.');
+      // Insert a node on the wall RIGHT NOW (so "add a node" actually adds one,
+      // visible + undoable), and arm a cut from it. A second wall/corner click
+      // splits the room between the two; Esc/elsewhere keeps the added node.
+      const snap = plate.duplicate();
+      try {
+        const pos = projectOnSeg([wx, wy], ed.a, ed.b);
+        const va = plate.splitEdge(ed.edge, pos[0], pos[1]);
+        commitUndo(snap);
+        refreshRooms();
+        setSplitPick({ kind: 'vertex', vid: va, pos });
+        setSplitHover(pos);
+        setStatus('Node added — click another wall or corner to split between them, or Esc to keep the node.');
+      } catch (err) {
+        plate.free(); plateRef.current = snap; refreshRooms();
+        setStatus(`Can't add node here: ${String(err).replace(/^\w+:\s*/, '')}`);
       }
       return;
     }
@@ -1224,6 +1270,8 @@ export function SpaceSketchOverlay() {
           <SlidersHorizontal className="h-4 w-4" />
           {(boundaryMode !== 'inner' || snapTol != null || showDiagnostics) && <span className="absolute right-1 top-1 h-1.5 w-1.5 rounded-full bg-primary" />}
         </button>
+        <button className={iconBtn} onClick={simplifyRedundantNodes}
+          disabled={!rooms.length} title="Clean up — remove redundant nodes on straight walls (shape unchanged)"><Eraser className="h-4 w-4" /></button>
         <button className={iconBtn} onClick={() => applyFit(computeFit(rooms, sizeRef.current.w, sizeRef.current.h))}
           disabled={!rooms.length} title="Fit plan to canvas (reset zoom & pan)"><Maximize className="h-4 w-4" /></button>
         <span className="ml-auto pr-1 text-[11px] tabular-nums text-muted-foreground">

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -859,37 +859,28 @@ export function SpaceSketchOverlay() {
     else setActiveTool('select');
   }, [dirty, setActiveTool]);
 
-  // "Simplify" — bulk-remove every redundant node: one that lies on a straight
-  // run in EVERY room it touches (so dissolving it can't change any room's
-  // shape). This clears the derivation cruft without deforming geometry. Wall
-  // junctions (3+ walls) are left alone — those are removed by merging.
-  const simplifyRedundantNodes = useCallback(() => {
+  // "Clean up" — sweep the whole plate clean in the engine: remove dangling
+  // spur walls, isolated nodes, and redundant collinear nodes left by the
+  // non-destructive wall arrangement. Area-neutral and idempotent (the Rust
+  // `prune` does the topology surgery; real corners and wall junctions stay).
+  const cleanupOrphans = useCallback(() => {
     const plate = plateRef.current;
     if (!plate || !rooms.length) return;
-    const COLL_TOL = 0.02; // m — perpendicular distance to the chord through neighbours
-    const byPos = new Map<string, { p: Pt; collinearEverywhere: boolean }>();
-    for (const r of rooms) {
-      const n = r.outline.length;
-      for (let i = 0; i < n; i++) {
-        const a = r.outline[(i + n - 1) % n], c = r.outline[i], b = r.outline[(i + 1) % n];
-        const coll = distToSeg(c[0], c[1], a[0], a[1], b[0], b[1]) < COLL_TOL;
-        const key = `${c[0].toFixed(4)},${c[1].toFixed(4)}`;
-        const e = byPos.get(key);
-        if (e) e.collinearEverywhere = e.collinearEverywhere && coll;
-        else byPos.set(key, { p: c, collinearEverywhere: coll });
-      }
-    }
-    const candidates = [...byPos.values()].filter((e) => e.collinearEverywhere).map((e) => e.p);
-    if (!candidates.length) { setStatus('No redundant nodes to remove.'); return; }
     const snap = plate.duplicate();
     let removed = 0;
-    for (const p of candidates) {
-      const vid = plate.findVertexNear(p[0], p[1], 1e-3); // positions don't move as others dissolve
-      if (vid === undefined) continue;
-      try { plate.dissolveVertex(vid); removed++; } catch { /* junction/triangle — leave it */ }
+    try {
+      removed = plate.prune();
+    } catch (err) {
+      plate.free(); plateRef.current = snap; refreshRooms();
+      setStatus(`Cleanup failed: ${String(err).replace(/^\w+:\s*/, '')}`);
+      return;
     }
-    if (removed > 0) { commitUndo(snap); refreshRooms(); setStatus(`Removed ${removed} redundant node(s).`); }
-    else { snap.free(); setStatus('No removable redundant nodes.'); }
+    if (removed > 0) {
+      commitUndo(snap); refreshRooms();
+      setStatus(`Cleaned up ${removed} orphan wall${removed === 1 ? '' : 's'}/node${removed === 1 ? '' : 's'} — ${plate.roomCount} room(s).`);
+    } else {
+      snap.free(); setStatus('Nothing to clean up — no orphan walls or nodes.');
+    }
   }, [rooms, commitUndo, refreshRooms]);
 
   const processMove = useCallback(() => {
@@ -967,11 +958,13 @@ export function SpaceSketchOverlay() {
     if (ed != null) {
       setDeleteHover(null); setDrawCursor(null); setSnapPos(null);
       if (m.del) {
-        // ⌥/Ctrl over a wall → merge preview (both rooms if the wall is shared).
+        // ⌥/Ctrl over a wall → remove preview. A distinct room across → merge;
+        // otherwise removeEdge deletes the wall and cleans up the orphans.
         const nbr = plate.neighborAcross(ed.edge);
-        setHover({ kind: 'edge', edge: ed.edge, rooms: [ed.face, ...(nbr !== undefined ? [nbr] : [])], a: ed.a, b: ed.b });
+        const shared = nbr !== undefined && nbr !== ed.face;
+        setHover({ kind: 'edge', edge: ed.edge, rooms: [ed.face, ...(shared ? [nbr] : [])], a: ed.a, b: ed.b });
         setSplitHover(null);
-        setIntent({ text: nbr !== undefined ? 'Merge rooms' : 'No room to merge', tone: 'remove' });
+        setIntent({ text: shared ? 'Merge rooms' : 'Remove wall', tone: 'remove' });
       } else {
         // plain → cut cue ("+") at the projected point on the wall.
         setHover(null);
@@ -1075,6 +1068,12 @@ export function SpaceSketchOverlay() {
         try { plate.dissolveVertex(v); ok = true; setStatus(`Removed node — ${plate.roomCount} room(s).`); }
         catch (err) {
           reason = String(err).replace(/^\w+:\s*/, '');
+          // The node won't straighten away (it's a wall junction). Remove one of
+          // its incident walls instead: `removeEdge` unions two real rooms, or
+          // deletes a bridge/spur wall and auto-cleans the orphaned inner lines
+          // and nodes it leaves — handling the BridgeEdge/BordersExterior cases
+          // the old merge-only path rejected. Scan EVERY incident wall so a
+          // junction with one removable wall still goes.
           if (vp) {
             for (const r of rooms) {
               const n = r.outline.length;
@@ -1083,10 +1082,9 @@ export function SpaceSketchOverlay() {
               const bounds = plate.boundingElements(r.face) as Boundary[];
               for (const idx of [k, (k - 1 + n) % n]) {
                 const b = bounds[idx];
-                if (b && plate.neighborAcross(b.edge) !== undefined) {
-                  try { plate.mergeFaces(b.edge); ok = true; setStatus(`Merged across the wall — ${plate.roomCount} room(s).`); }
-                  catch { /* try the next incident wall */ }
-                }
+                if (!b) continue;
+                try { plate.removeEdge(b.edge); ok = true; setStatus(`Removed wall & cleaned up — ${plate.roomCount} room(s).`); }
+                catch { /* an enclosing wall — try the next incident wall */ }
                 if (ok) break;
               }
               if (ok) break;
@@ -1119,12 +1117,15 @@ export function SpaceSketchOverlay() {
       if (mod) {
         const snap = plate.duplicate();
         try {
-          plate.mergeFaces(ed.edge);
+          // `removeEdge` unions two real rooms, or deletes a bridge/spur wall and
+          // auto-cleans the orphaned inner lines & nodes — only a real enclosing
+          // wall (room ↔ exterior) is refused, so a room never silently opens.
+          plate.removeEdge(ed.edge);
           commitUndo(snap); refreshRooms(); setHover(null);
-          setStatus(`Merged across wall — ${plate.roomCount} room(s) left.`);
+          setStatus(`Removed wall — ${plate.roomCount} room(s) left.`);
         } catch (err) {
           plate.free(); plateRef.current = snap; refreshRooms();
-          setStatus(`Merge rejected: ${String(err).replace(/^Error:\s*/, '')}`);
+          setStatus(`Can't remove this wall: ${String(err).replace(/^\w+:\s*/, '')}`);
         }
         return;
       }
@@ -1296,8 +1297,8 @@ export function SpaceSketchOverlay() {
           <SlidersHorizontal className="h-4 w-4" />
           {(boundaryMode !== 'inner' || snapTol != null || showDiagnostics) && <span className="absolute right-1 top-1 h-1.5 w-1.5 rounded-full bg-primary" />}
         </button>
-        <button className={iconBtn} onClick={simplifyRedundantNodes}
-          disabled={!rooms.length} title="Clean up — remove redundant nodes on straight walls (shape unchanged)"><Eraser className="h-4 w-4" /></button>
+        <button className={iconBtn} onClick={cleanupOrphans}
+          disabled={!rooms.length} title="Clean up — remove orphaned inner walls & redundant nodes (room shapes unchanged)"><Eraser className="h-4 w-4" /></button>
         <button className={iconBtn} onClick={() => applyFit(computeFit(rooms, sizeRef.current.w, sizeRef.current.h))}
           disabled={!rooms.length} title="Fit plan to canvas (reset zoom & pan)"><Maximize className="h-4 w-4" /></button>
         <span className="ml-auto pr-1 text-[11px] tabular-nums text-muted-foreground">
@@ -1366,8 +1367,8 @@ export function SpaceSketchOverlay() {
             ['Drag a node', 'move it (snaps; Shift = straight)'],
             ['Click a wall, then another', 'split the room between them'],
             ['Click empty space', 'draw a room (Enter / dbl-click closes)'],
-            ['⌥/Ctrl/right-click a node', 'remove it'],
-            ['⌥/Ctrl/right-click a wall', 'merge the two rooms'],
+            ['⌥/Ctrl/right-click a node', 'remove it (cleans up orphans)'],
+            ['⌥/Ctrl/right-click a wall', 'merge rooms / remove & clean up'],
             ['Shift-drag / middle-drag', 'pan · scroll = zoom'],
           ] as [string, string][]).map(([k, v]) => (
             <div key={k} className="flex gap-2">

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -28,16 +28,17 @@ import { pointerButton, isRemoveModifier } from '@/lib/space-interaction';
 import {
   SpacePlateSession,
   ensureSpaceWasm,
-  snapshotRooms,
+  snapshotRoomsFromRects,
+  flattenWallRects,
   type Room,
   type Boundary,
 } from '@/lib/space-plate-session';
+import { wallRectsFromMeshes, type WallRect } from '@/lib/wall-rects-from-meshes';
 import {
   polyArea, pointInPoly, centroid, uniqueVerts, distToSeg, projectOnSeg,
   computeFit, zoomFit, sX, sY, wX, wY, PAD, type Fit, type Pt,
 } from '@/lib/space-sketch-geometry';
 import {
-  extractWallSegmentsForStorey,
   existingSpaceFootprintsByStorey,
   GENERATED_SPACE_OBJECTTYPE,
   type BoundaryMode,
@@ -55,17 +56,16 @@ const PICK_PX = 12;
 const SNAP_PX = 10;
 const BAKE_HEIGHT = 3;
 const EPS = 1e-6;
-// Assumed wall thickness (m) for the Inner/Outer boundary offset when a wall
-// carries no resolvable material-layer thickness — so the net/gross face works
-// on every model, not just ones with full material data. Real layer thickness
-// is used whenever it's available.
-const DEFAULT_WALL_THICKNESS = 0.2;
 
 export function SpaceSketchOverlay() {
   const setActiveTool = useViewerStore((s) => s.setActiveTool);
   const addSpace = useViewerStore((s) => s.addSpace);
   const removeEntity = useViewerStore((s) => s.removeEntity);
   const activeModelId = useViewerStore((s) => s.activeModelId);
+  // Rooms are derived from the RENDERED wall meshes (the geometry the user sees),
+  // so the room lines land on the rendered wall faces — not from STEP source
+  // geometry, which has no per-wall thickness here and a centroid-biased axis.
+  const geometryResult = useViewerStore((s) => s.geometryResult);
   const { ifcDataStore } = useIfc();
 
   const sessionRef = useRef<SpacePlateSession | null>(null);
@@ -137,19 +137,21 @@ export function SpaceSketchOverlay() {
   const [snapTol, setSnapTol] = useState<number | null>(null); // null = auto-escalate
   const [usedTol, setUsedTol] = useState(0.1);
   const snapTolRef = useRef<number | null>(null);
-  const lastBuildRef = useRef<{ coords: Float64Array; sources: Int32Array; thicknesses: Float64Array; label: string; storey: number | null } | null>(null);
-  // Wall segments + thicknesses from the last derive, kept for the leak
-  // diagnostics overlay + the "has wall data" affordance (net/gross outlines now
-  // come from the engine via half-thickness carried on each edge).
+  const lastBuildRef = useRef<{ rects: WallRect[]; label: string; storey: number | null } | null>(null);
+  // Wall centrelines + thicknesses from the last derive, kept for the leak
+  // diagnostics overlay + the "has wall data" affordance.
   const extractionRef = useRef<{
-    segments: ReturnType<typeof extractWallSegmentsForStorey>['segments'];
-    thicknesses: ReturnType<typeof extractWallSegmentsForStorey>['wallThicknesses'];
+    segments: { a: Pt; b: Pt }[];
+    thicknesses: number[];
   } | null>(null);
   const [hist, setHist] = useState(0);
-  const [status, setStatus] = useState('Load the demo plate or derive from a storey.');
+  const [status, setStatus] = useState('Pick a storey to derive rooms from its walls.');
   const [showBuilding, setShowBuilding] = useState(true);
   const [showDiagnostics, setShowDiagnostics] = useState(false); // Issue 7 — leak diagnostics
-  const [boundaryMode, setBoundaryMode] = useState<BoundaryMode>('inner');
+  // Default to the wall AXIS (face-based rooms are the gaps between wall
+  // rectangles): `center` puts the room outline + nodes on the true wall
+  // centreline. `inner`/`outer` show the net/gross faces.
+  const [boundaryMode, setBoundaryMode] = useState<BoundaryMode>('center');
   // Transient "12 → 9 rooms" badge after a corner-tolerance rebuild — the
   // effect on the plan is otherwise invisible (Issue 5).
   const [snapDelta, setSnapDelta] = useState<{ from: number; to: number } | null>(null);
@@ -326,33 +328,31 @@ export function SpaceSketchOverlay() {
     return () => el.removeEventListener('wheel', onWheel);
   }, []);
 
-  const buildFrom = useCallback(async (coords: Float64Array, sources: Int32Array, thicknesses: Float64Array, label: string, storey: number | null) => {
+  // Build a face-based plate from the storey's wall RECTANGLES (read from the
+  // rendered meshes): rooms are the gaps between walls, so the room boundary IS
+  // the rendered wall faces and every node lands on the true wall axis. `snapTol`
+  // welds nearby rectangle corners (default 5 cm); a manual override comes from
+  // the slider.
+  const buildFrom = useCallback(async (rects: WallRect[], label: string, storey: number | null) => {
     // Re-entrancy guard: a rapid rebuild (snap slider) must not let an older
     // async build free/replace the plate a newer one is using — that races the
     // shared wasm heap. Only the latest build applies; superseded ones bail.
     const seq = ++buildSeqRef.current;
     try {
       await ensureSpaceWasm();
-      // The only async gap is the wasm init above; after it, build() runs
-      // synchronously and atomically. So a single post-await seq check is enough
-      // to keep an older rebuild (rapid snap-slider drags) from replacing the
-      // plate a newer one is building — the stale one bails before touching it.
       if (seq !== buildSeqRef.current) return;
-      lastBuildRef.current = { coords, sources, thicknesses, label, storey };
-      const manual = snapTolRef.current;
+      lastBuildRef.current = { rects, label, storey };
+      const snapTol = snapTolRef.current ?? 0.05;
       let session = sessionRef.current;
       if (!session) { session = new SpacePlateSession(); sessionRef.current = session; }
-      // Auto-escalate the corner-snap (real centrelines miss corners by ~½ a
-      // wall thickness, so a tight snap leaves the loop open → 0 rooms); the
-      // session tries [0.1, 0.25, 0.5] and keeps the first that encloses rooms.
-      const { rooms: snap, tol: used } = session.build(coords, sources, thicknesses, manual, 0.5);
-      setUsedTol(used);
+      const { rooms: snap } = session.buildFromRects(flattenWallRects(rects.map((r) => r.corners)), snapTol, 0.3);
+      setUsedTol(snapTol);
       applyFit(computeFit(snap, sizeRef.current.w, sizeRef.current.h));
       resetInteraction();
       setDerivedStorey(storey);
       setRooms(snap); setHist((v) => v + 1);
       setDirty(false); // a fresh derive is the new clean baseline
-      // Surface the room-count consequence of a corner-tolerance change (only a
+      // Surface the room-count consequence of a weld-tolerance change (only a
       // snap rebuild sets pendingSnapPrevRef; an initial derive leaves it null).
       const prevCount = pendingSnapPrevRef.current;
       pendingSnapPrevRef.current = null;
@@ -362,14 +362,14 @@ export function SpaceSketchOverlay() {
         snapDeltaTimerRef.current = setTimeout(() => setSnapDelta(null), 1800);
       }
       const total = snap.reduce((s, r) => s + r.area, 0);
-      setStatus(`${label}: ${snap.length} room(s), ${total.toFixed(1)} m² · corner tol ${used}m${manual == null ? ' (auto)' : ''}.`);
+      setStatus(`${label}: ${snap.length} room(s), ${total.toFixed(1)} m² · ${rects.length} walls.`);
     } catch (e) {
       setStatus(`Build failed: ${String(e)}`);
     }
   }, [resetInteraction, applyFit]);
 
-  // Manual snap override (null → back to auto-escalate). Rebuilds the current
-  // plate from its source segments at the chosen tolerance.
+  // Manual weld-tolerance override (null → 5 cm default). Rebuilds the current
+  // plate from its wall rectangles at the chosen tolerance.
   const rebuildWithSnap = useCallback((tol: number | null) => {
     snapTolRef.current = tol;
     setSnapTol(tol);
@@ -384,36 +384,33 @@ export function SpaceSketchOverlay() {
     rebuildTimerRef.current = setTimeout(() => {
       rebuildTimerRef.current = null;
       const lb = lastBuildRef.current;
-      if (lb) void buildFrom(lb.coords, lb.sources, lb.thicknesses, lb.label, lb.storey);
+      if (lb) void buildFrom(lb.rects, lb.label, lb.storey);
     }, 180);
   }, [buildFrom]);
 
   const deriveFromStorey = useCallback(async () => {
     if (!ifcDataStore || storeyId == null) { setStatus('No model / storey to derive from.'); return; }
+    const meshes = geometryResult?.meshes;
+    if (!meshes || meshes.length === 0) { setStatus('Model geometry still loading — try again in a moment.'); return; }
     try {
-      const { segments, considered, skipped, wallThicknesses } = extractWallSegmentsForStorey(ifcDataStore, storeyId);
-      if (!segments.length) {
-        setStatus(`No wall axes on storey ${storeyId} (${considered} walls, ${skipped.length} skipped).`);
+      const elev = storeys.find((s) => s.id === storeyId)?.elev ?? 0;
+      const rects = wallRectsFromMeshes(meshes, geometryResult?.coordinateInfo, elev, floorToFloor(storeyId));
+      if (!rects.length) {
+        setStatus(`No walls found on storey ${storeyId} (no rendered wall meshes in its height band).`);
         return;
       }
-      extractionRef.current = { segments, thicknesses: wallThicknesses };
-      const coords = new Float64Array(segments.length * 4);
-      const sources = new Int32Array(segments.length).fill(-1);
-      // Half-thickness per segment (m), carried onto the edges so the engine can
-      // offset to the net/gross wall face.
-      const half = new Float64Array(segments.length);
-      segments.forEach((s, i) => {
-        coords[i * 4] = s.a[0]; coords[i * 4 + 1] = s.a[1];
-        coords[i * 4 + 2] = s.b[0]; coords[i * 4 + 3] = s.b[1];
-        const t = wallThicknesses[i];
-        half[i] = (t && t > 0 ? t : DEFAULT_WALL_THICKNESS) / 2;
-      });
+      extractionRef.current = {
+        segments: rects.map((r) => ({ a: r.centreline[0], b: r.centreline[1] })),
+        thicknesses: rects.map((r) => r.thickness),
+      };
       const name = ifcDataStore.entities.getName(storeyId) || `Storey #${storeyId}`;
-      await buildFrom(coords, sources, half, name, storeyId);
+      await buildFrom(rects, name, storeyId);
     } catch (e) {
       setStatus(`Derive failed: ${String(e)}`);
     }
-  }, [ifcDataStore, storeyId, buildFrom]);
+    // floorToFloor depends on `storeys`; both are stable per render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ifcDataStore, storeyId, geometryResult, buildFrom, storeys]);
 
   // Auto-detect: derive rooms the moment a storey is chosen (and on open, when
   // the first storey auto-selects) so the user doesn't have to click Derive.
@@ -509,26 +506,21 @@ export function SpaceSketchOverlay() {
 
   const bakeWholeBuilding = useCallback(async () => {
     if (!activeModelId || !ifcDataStore) { setStatus('No model loaded.'); return; }
+    const meshes = geometryResult?.meshes;
+    if (!meshes || meshes.length === 0) { setStatus('Model geometry still loading.'); return; }
     setStatus('Generating spaces for every storey…');
     await ensureSpaceWasm();
     const authoredMap = existingSpaceFootprintsByStorey(ifcDataStore);
+    const coord = geometryResult?.coordinateInfo;
     let totalEmitted = 0, totalSkipped = 0, floors = 0;
     let firstError: string | null = null;
     for (const st of storeys) {
-      const { segments, wallThicknesses } = extractWallSegmentsForStorey(ifcDataStore, st.id);
-      if (!segments.length) continue;
-      const coords = new Float64Array(segments.length * 4);
-      const sources = new Int32Array(segments.length).fill(-1);
-      const half = new Float64Array(segments.length);
-      segments.forEach((s, i) => {
-        coords[i * 4] = s.a[0]; coords[i * 4 + 1] = s.a[1]; coords[i * 4 + 2] = s.b[0]; coords[i * 4 + 3] = s.b[1];
-        const t = wallThicknesses[i];
-        half[i] = (t && t > 0 ? t : DEFAULT_WALL_THICKNESS) / 2;
-      });
-      // Throwaway plate per storey (escalation + deterministic free handled by
-      // the session module) — this path doesn't touch the live session. Reads
-      // each room's centreline + the boundary outline at the chosen mode.
-      const rooms = snapshotRooms(coords, sources, half, boundaryMode);
+      const rects = wallRectsFromMeshes(meshes, coord, st.elev, floorToFloor(st.id));
+      if (!rects.length) continue;
+      // Throwaway face-based plate per storey (deterministic free handled by the
+      // session module) — this path doesn't touch the live session. Reads each
+      // room's wall axis + the boundary outline at the chosen mode.
+      const rooms = snapshotRoomsFromRects(flattenWallRects(rects.map((r) => r.corners)), boundaryMode);
       if (!rooms.length) continue;
       const { emitted, skipped, error } = bakeStorey(st.id, rooms, authoredMap.get(st.id) ?? []);
       totalEmitted += emitted; totalSkipped += skipped;
@@ -540,7 +532,7 @@ export function SpaceSketchOverlay() {
     setStatus(firstError
       ? `Generated ${totalEmitted} IfcSpace — others failed: ${firstError}`
       : `Generated ${totalEmitted} IfcSpace across ${floors} storey(s)${totalSkipped ? `; skipped ${totalSkipped} existing` : ''}.`);
-  }, [activeModelId, ifcDataStore, storeys, bakeStorey, revealSpaces, boundaryMode]);
+  }, [activeModelId, ifcDataStore, geometryResult, storeys, floorToFloor, bakeStorey, revealSpaces, boundaryMode]);
 
   useEffect(() => () => {
     if (rafRef.current) cancelAnimationFrame(rafRef.current);

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -1065,22 +1065,42 @@ export function SpaceSketchOverlay() {
     if (v != null) {
       if (mod) {
         const snap = plate.duplicate();
-        // A degree-2 node dissolves (straighten/remove). A wall JUNCTION (3+
-        // walls) can't dissolve — removing it there means removing a wall, so
-        // fall back to merging across the wall nearest the cursor. Together
-        // these "remove" every node: redundant ones vanish, junctions collapse
-        // by joining the two rooms that wall separated.
+        // Remove ANY node: a degree-2 node dissolves (straighten/remove); a wall
+        // junction (3+ walls) collapses by merging across one of its walls that
+        // separates two rooms. Scan EVERY wall incident to the node (not just the
+        // cursor-nearest) so a junction with one mergeable wall still goes.
+        const vp = nearestVertPos(wx, wy);
         let ok = false;
+        let reason = '';
         try { plate.dissolveVertex(v); ok = true; setStatus(`Removed node — ${plate.roomCount} room(s).`); }
-        catch {
-          const ed2 = pickEdge(wx, wy);
-          if (ed2 && plate.neighborAcross(ed2.edge) !== undefined) {
-            try { plate.mergeFaces(ed2.edge); ok = true; setStatus(`Merged across the wall — ${plate.roomCount} room(s).`); }
-            catch { /* falls to the failure path below */ }
+        catch (err) {
+          reason = String(err).replace(/^\w+:\s*/, '');
+          if (vp) {
+            for (const r of rooms) {
+              const n = r.outline.length;
+              const k = r.outline.findIndex((p) => Math.abs(p[0] - vp[0]) < EPS && Math.abs(p[1] - vp[1]) < EPS);
+              if (k < 0) continue;
+              const bounds = plate.boundingElements(r.face) as Boundary[];
+              for (const idx of [k, (k - 1 + n) % n]) {
+                const b = bounds[idx];
+                if (b && plate.neighborAcross(b.edge) !== undefined) {
+                  try { plate.mergeFaces(b.edge); ok = true; setStatus(`Merged across the wall — ${plate.roomCount} room(s).`); }
+                  catch { /* try the next incident wall */ }
+                }
+                if (ok) break;
+              }
+              if (ok) break;
+            }
           }
         }
         if (ok) { commitUndo(snap); refreshRooms(); setHover(null); setDeleteHover(null); }
-        else { plate.free(); plateRef.current = snap; refreshRooms(); setStatus('Can’t remove this node — its walls border the outside or don’t separate two rooms.'); }
+        else {
+          plate.free(); plateRef.current = snap; refreshRooms();
+          // Genuinely unremovable: every incident wall borders the outside (no
+          // second room to merge into) and the node won't dissolve. Surface the
+          // kernel reason so it's diagnosable rather than mysterious.
+          setStatus(`Can’t remove this node — no wall here separates two rooms${reason ? ` (${reason})` : ''}.`);
+        }
         return;
       }
       const start = nearestVertPos(wx, wy);

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -32,6 +32,10 @@ import {
   type Boundary,
 } from '@/lib/space-plate-session';
 import {
+  polyArea, pointInPoly, centroid, uniqueVerts, distToSeg, projectOnSeg,
+  computeFit, zoomFit, sX, sY, wX, wY, PAD, type Fit, type Pt,
+} from '@/lib/space-sketch-geometry';
+import {
   extractWallSegmentsForStorey,
   offsetRoomFootprint,
   existingSpaceFootprintsByStorey,
@@ -40,7 +44,6 @@ import {
 } from '@ifc-lite/create';
 import { X, Undo2, Redo2, Layers, Maximize, AlertTriangle, Magnet, SlidersHorizontal, HelpCircle, Eraser } from 'lucide-react';
 
-type Pt = [number, number];
 type Hover =
   | { kind: 'vertex'; pos: Pt }
   | { kind: 'edge'; edge: number; rooms: number[]; a: Pt; b: Pt }
@@ -53,86 +56,10 @@ const DEFAULT_W = 580;
 const DEFAULT_H = 460;
 const MIN_W = 360;
 const MIN_H = 280;
-const PAD = 36;
 const PICK_PX = 12;
 const SNAP_PX = 10;
 const BAKE_HEIGHT = 3;
 const EPS = 1e-6;
-
-/** Absolute polygon area (shoelace), m². */
-function polyArea(pts: Pt[]): number {
-  let a = 0;
-  for (let k = 0; k < pts.length; k++) { const p = pts[k], q = pts[(k + 1) % pts.length]; a += p[0] * q[1] - q[0] * p[1]; }
-  return Math.abs(a) / 2;
-}
-/** Ray-cast point-in-polygon. */
-function pointInPoly(x: number, y: number, poly: Pt[]): boolean {
-  let inside = false;
-  for (let i = 0, j = poly.length - 1; i < poly.length; j = i++) {
-    const xi = poly[i][0], yi = poly[i][1], xj = poly[j][0], yj = poly[j][1];
-    if ((yi > y) !== (yj > y) && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi) inside = !inside;
-  }
-  return inside;
-}
-const centroid = (pts: Pt[]): Pt => {
-  let cx = 0, cy = 0;
-  for (const p of pts) { cx += p[0]; cy += p[1]; }
-  return [cx / pts.length, cy / pts.length];
-};
-
-/** Screen transform as a pure affine: `screen = off + world * scale` (Y
- *  flipped). Decoupling from the canvas size + a fixed origin is what lets the
- *  same struct carry fit-to-bounds, wheel-zoom, and drag-pan (Issue 4). */
-interface Fit { scale: number; offX: number; offY: number }
-
-/** Frame the rooms centred within a `w`×`h` canvas (PAD margin) as an affine. */
-function computeFit(rooms: Room[], w: number, h: number): Fit {
-  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-  for (const r of rooms) for (const [x, y] of r.outline) {
-    minX = Math.min(minX, x); minY = Math.min(minY, y);
-    maxX = Math.max(maxX, x); maxY = Math.max(maxY, y);
-  }
-  if (!isFinite(minX)) return { scale: 1, offX: PAD, offY: h - PAD };
-  const scale = Math.min((w - 2 * PAD) / Math.max(maxX - minX, 1e-6), (h - 2 * PAD) / Math.max(maxY - minY, 1e-6));
-  const cx = (minX + maxX) / 2, cy = (minY + maxY) / 2;
-  return { scale, offX: w / 2 - cx * scale, offY: h / 2 + cy * scale };
-}
-
-/** Zoom by `factor` about screen point `(ax, ay)` (keeps it fixed). */
-function zoomFit(f: Fit, factor: number, ax: number, ay: number): Fit {
-  return { scale: f.scale * factor, offX: ax - (ax - f.offX) * factor, offY: ay + (f.offY - ay) * factor };
-}
-
-const sX = (f: Fit, x: number) => f.offX + x * f.scale;
-const sY = (f: Fit, y: number) => f.offY - y * f.scale;
-const wX = (f: Fit, sx: number) => (sx - f.offX) / f.scale;
-const wY = (f: Fit, sy: number) => (f.offY - sy) / f.scale;
-
-function distToSeg(px: number, py: number, ax: number, ay: number, bx: number, by: number): number {
-  const dx = bx - ax, dy = by - ay;
-  const len2 = dx * dx + dy * dy || 1e-9;
-  let t = ((px - ax) * dx + (py - ay) * dy) / len2;
-  t = Math.max(0, Math.min(1, t));
-  return Math.hypot(px - (ax + t * dx), py - (ay + t * dy));
-}
-
-function projectOnSeg(p: Pt, a: Pt, b: Pt): Pt {
-  const dx = b[0] - a[0], dy = b[1] - a[1];
-  const len2 = dx * dx + dy * dy || 1e-9;
-  let t = ((p[0] - a[0]) * dx + (p[1] - a[1]) * dy) / len2;
-  t = Math.max(0, Math.min(1, t));
-  return [a[0] + t * dx, a[1] + t * dy];
-}
-
-function uniqueVerts(rooms: Room[]): Pt[] {
-  const seen = new Set<string>();
-  const out: Pt[] = [];
-  for (const r of rooms) for (const p of r.outline) {
-    const k = `${p[0].toFixed(4)},${p[1].toFixed(4)}`;
-    if (!seen.has(k)) { seen.add(k); out.push(p); }
-  }
-  return out;
-}
 
 const ROOM_COLORS = ['#6366f1', '#10b981', '#f59e0b', '#ec4899', '#06b6d4', '#84cc16', '#a855f7', '#ef4444'];
 

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -44,6 +44,7 @@ import {
 } from '@ifc-lite/create';
 import { X, Undo2, Redo2, Layers, Maximize, AlertTriangle, Magnet, SlidersHorizontal, HelpCircle, Eraser } from 'lucide-react';
 import { SpaceSketchCanvas } from './space-sketch/SpaceSketchCanvas';
+import { OptionsPopover, HelpPopover } from './space-sketch/SpaceSketchPopovers';
 import type { Hover, SplitTarget, IntentTone } from './space-sketch/types';
 
 const DEFAULT_W = 580;
@@ -1169,73 +1170,24 @@ export function SpaceSketchOverlay() {
         <div className="absolute inset-0 z-10" aria-hidden onMouseDown={() => { setOptionsOpen(false); setHelpOpen(false); }} />
       )}
 
-      {/* Options popover — the set-once settings, out of the main flow. */}
+      {/* Disclosure popovers (Options / Help) — kept out of the default flow. */}
       {optionsOpen && (
-        <div className="absolute right-3 top-12 z-20 w-64 space-y-3 rounded-lg border bg-popover p-3 text-[11px] text-muted-foreground shadow-xl">
-          <div className="space-y-1.5">
-            <div className="font-medium text-foreground">Boundary</div>
-            <div className="inline-flex rounded-md border p-0.5">
-              {(['center', 'inner', 'outer'] as BoundaryMode[]).map((m) => {
-                const noWallData = !ext && m !== 'center';
-                return (
-                  <button key={m}
-                    className={`rounded px-2 py-0.5 capitalize transition-colors disabled:opacity-40 ${boundaryMode === m ? 'bg-primary text-primary-foreground' : 'hover:text-foreground'}`}
-                    onClick={() => setBoundaryMode(m)} disabled={noWallData}
-                    title={noWallData ? 'No wall data on this derive — only the centreline is available' : m === 'center' ? 'Wall centreline' : m === 'inner' ? 'Inner (net) face' : 'Outer (gross) face'}>{m}</button>
-                );
-              })}
-            </div>
-          </div>
-          <div className="space-y-1.5">
-            <div className="flex items-center justify-between">
-              <span className="font-medium text-foreground">Corner tolerance</span>
-              {snapDelta && (
-                <span className={`tabular-nums ${snapDelta.to === 0 ? 'text-red-500' : snapDelta.to < snapDelta.from ? 'text-amber-500' : 'text-emerald-500'}`}
-                  title="Rooms before → after">{snapDelta.from} → {snapDelta.to}</span>
-              )}
-            </div>
-            <div className="flex items-center gap-1.5">
-              <input type="range" min={0.05} max={1} step={0.05} value={usedTol} className="flex-1 accent-primary"
-                disabled={derivedStorey == null} onChange={(e) => rebuildWithSnap(Number(e.target.value))} />
-              <input type="number" min={0.05} max={1} step={0.05} value={usedTol} aria-label="Corner tolerance (metres)"
-                className="w-12 rounded border bg-background px-1 py-0.5 tabular-nums disabled:opacity-40"
-                disabled={derivedStorey == null}
-                onChange={(e) => { const v = Number(e.target.value); if (Number.isFinite(v) && v > 0) rebuildWithSnap(Math.min(1, Math.max(0.05, v))); }} />
-              <button className="rounded px-1 hover:text-foreground disabled:opacity-40" onClick={() => rebuildWithSnap(null)}
-                disabled={derivedStorey == null}
-                title={snapTol == null ? 'Automatic — escalates until rooms close' : 'Reset to automatic'}>{snapTol == null ? 'auto' : 'reset'}</button>
-            </div>
-          </div>
-          <label className="flex cursor-pointer items-center justify-between">
-            <span className="text-foreground">Show building underlay</span>
-            <input type="checkbox" className="accent-primary" checked={showBuilding} onChange={() => setShowBuilding((v) => !v)} />
-          </label>
-          <label className="flex cursor-pointer items-center justify-between">
-            <span className="text-foreground">Leak diagnostics</span>
-            <input type="checkbox" className="accent-primary" checked={showDiagnostics} disabled={!ext} onChange={() => setShowDiagnostics((v) => !v)} />
-          </label>
-        </div>
+        <OptionsPopover
+          boundaryMode={boundaryMode}
+          onBoundaryMode={setBoundaryMode}
+          hasWallData={!!ext}
+          snapDelta={snapDelta}
+          usedTol={usedTol}
+          snapDisabled={derivedStorey == null}
+          onSnap={rebuildWithSnap}
+          snapTol={snapTol}
+          showBuilding={showBuilding}
+          onToggleBuilding={() => setShowBuilding((v) => !v)}
+          showDiagnostics={showDiagnostics}
+          onToggleDiagnostics={() => setShowDiagnostics((v) => !v)}
+        />
       )}
-
-      {/* Help popover — the full gesture legend, on demand (keeps the panel clean). */}
-      {helpOpen && (
-        <div className="absolute right-3 top-12 z-20 w-72 space-y-1.5 rounded-lg border bg-popover p-3 text-[11px] shadow-xl">
-          <div className="mb-1 font-medium text-foreground">One tool — actions follow the cursor:</div>
-          {([
-            ['Drag a node', 'move it (snaps; Shift = straight)'],
-            ['Click a wall, then another', 'split the room between them'],
-            ['Click empty space', 'draw a room (Enter / dbl-click closes)'],
-            ['⌥/Ctrl/right-click a node', 'remove it (cleans up orphans)'],
-            ['⌥/Ctrl/right-click a wall', 'merge rooms / remove & clean up'],
-            ['Shift-drag / middle-drag', 'pan · scroll = zoom'],
-          ] as [string, string][]).map(([k, v]) => (
-            <div key={k} className="flex gap-2">
-              <span className="shrink-0 font-medium text-foreground">{k}</span>
-              <span className="text-muted-foreground">— {v}</span>
-            </div>
-          ))}
-        </div>
-      )}
+      {helpOpen && <HelpPopover />}
 
       <SpaceSketchCanvas
         svgRef={svgRef}

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -22,6 +22,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useViewerStore } from '@/store';
 import { useConstructionUnderlay } from '@/hooks/useConstructionUnderlay';
 import { useIfc } from '@/hooks/useIfc';
+import { snapPoint, type SnapKind } from '@/lib/space-snap';
 import init, { SpacePlateHandle } from '@ifc-lite/wasm';
 import {
   extractWallSegmentsForStorey,
@@ -30,7 +31,7 @@ import {
   GENERATED_SPACE_OBJECTTYPE,
   type BoundaryMode,
 } from '@ifc-lite/create';
-import { X, Undo2, Redo2, Building2, Layers, Maximize, AlertTriangle } from 'lucide-react';
+import { X, Undo2, Redo2, Building2, Layers, Maximize, AlertTriangle, Magnet } from 'lucide-react';
 
 let wasmReady: Promise<void> | null = null;
 function ensureWasm(): Promise<void> {
@@ -175,6 +176,15 @@ export function SpaceSketchOverlay() {
 
   const undoRef = useRef<SpacePlateHandle[]>([]);
   const redoRef = useRef<SpacePlateHandle[]>([]);
+  // While drawing, Undo pops the last placed point onto this stack and Redo
+  // re-adds it — so point placement uses the panel Undo/Redo, not a separate
+  // draw-only control. Cleared when the draw is committed/cancelled.
+  const drawRedoRef = useRef<Pt[]>([]);
+  // Timestamp of the last bare Esc — a second within 400 ms closes the panel.
+  const escTimeRef = useRef(0);
+  // Building wall lines (room frame) for snapping; synced from a memo so the
+  // per-frame pointer math can read it without re-binding processMove.
+  const buildingSegmentsRef = useRef<Array<[Pt, Pt]>>([]);
 
   const [rooms, setRooms] = useState<Room[]>([]);
   const [mode, setMode] = useState<Mode>('drag');
@@ -182,6 +192,11 @@ export function SpaceSketchOverlay() {
   const [splitPick, setSplitPick] = useState<SplitTarget | null>(null);
   const [splitHover, setSplitHover] = useState<Pt | null>(null);
   const [snapPos, setSnapPos] = useState<Pt | null>(null);
+  // What the live snap landed on, so the cue can differ for a wall vs a corner.
+  const [snapKind, setSnapKind] = useState<SnapKind>('none');
+  // Snap every node to the building's 2D wall lines (corners + along walls).
+  // Default on; the magnet toggle in the toolbar turns it off (vertex-only).
+  const [snapToBuilding, setSnapToBuilding] = useState(true);
   // Issue 3: the vertex that an ⌥/Ctrl-click would dissolve — telegraphed live.
   const [deleteHover, setDeleteHover] = useState<Pt | null>(null);
   // Issue 2: the in-progress drawn room (world coords) + the live cursor point.
@@ -234,7 +249,16 @@ export function SpaceSketchOverlay() {
     () => (derivedStorey == null ? null : storeys.find((s) => s.id === derivedStorey)?.elev ?? null),
     [derivedStorey, storeys],
   );
-  const { lines: underlay } = useConstructionUnderlay(showBuilding && rooms.length > 0, derivedFloorElev);
+  // Compute the underlay when it's shown OR when snapping needs it (snapping to
+  // building lines must work even if the underlay isn't drawn).
+  const { lines: underlay } = useConstructionUnderlay((showBuilding || snapToBuilding) && rooms.length > 0, derivedFloorElev);
+
+  // Building wall lines as snap segments (room frame), only while snapping is on.
+  const buildingSegments = useMemo<Array<[Pt, Pt]>>(
+    () => (snapToBuilding ? underlay.map((l) => [l.a, l.b] as [Pt, Pt]) : []),
+    [underlay, snapToBuilding],
+  );
+  useEffect(() => { buildingSegmentsRef.current = buildingSegments; }, [buildingSegments]);
 
   // Pre-render the (potentially large) building underlay once per (re)derive,
   // NOT on every drag frame — re-creating hundreds of SVG lines each frame
@@ -260,14 +284,17 @@ export function SpaceSketchOverlay() {
   // and follow it when it changes while the panel is open. The in-panel storey
   // <select> stays as a local override; a later hierarchy pick wins.
   const activeStorey = useViewerStore((s) => s.activeStorey);
-  // Keyed by `${modelId}:${expressId}` (not a bare id) so switching to another
-  // model that happens to share a storey express-id still counts as a change.
+  // Match the active storey to THIS model's storey list by express-id. We don't
+  // compare modelId: `storeys` already comes from the active model's store, so
+  // membership is inherently model-scoped — and `activeModelId` can be null for
+  // a single model in the map (where the hierarchy stores the model UUID), so a
+  // strict modelId equality wrongly failed and fell back to the lowest storey.
   const lastActiveStoreyRef = useRef<string | null>(null);
   useEffect(() => {
     if (!storeys.length) return;
-    const sketchModelId = activeModelId ?? 'legacy';
+    const sketchModelId = activeStorey?.modelId ?? activeModelId ?? 'legacy';
     const activeHere =
-      activeStorey && activeStorey.modelId === sketchModelId && storeys.some((s) => s.id === activeStorey.expressId)
+      activeStorey && storeys.some((s) => s.id === activeStorey.expressId)
         ? activeStorey.expressId
         : null;
     const activeKey = activeHere == null ? null : `${sketchModelId}:${activeHere}`;
@@ -281,19 +308,10 @@ export function SpaceSketchOverlay() {
     if (storeyId == null) setStoreyId(activeHere ?? storeys[0].id);
   }, [storeys, storeyId, activeStorey, activeModelId]);
 
-  // Click anywhere outside the panel closes the tool. Esc closes too.
-  useEffect(() => {
-    const onDown = (e: PointerEvent) => {
-      if (panelRef.current && !panelRef.current.contains(e.target as Node)) setActiveTool('select');
-    };
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setActiveTool('select'); };
-    document.addEventListener('pointerdown', onDown, true);
-    document.addEventListener('keydown', onKey);
-    return () => {
-      document.removeEventListener('pointerdown', onDown, true);
-      document.removeEventListener('keydown', onKey);
-    };
-  }, [setActiveTool]);
+  // Panel stays open while you work — it no longer closes on an outside click
+  // (you need to click the hierarchy to pick a storey) or on a single Esc.
+  // Keyboard handling (Esc aborts the current op / double-Esc closes / Enter
+  // closes a drawn room) lives below, after `commitDraw` is defined.
 
   const refreshRooms = useCallback(() => {
     const plate = plateRef.current;
@@ -324,22 +342,36 @@ export function SpaceSketchOverlay() {
   }, []);
 
   const undo = useCallback(() => {
+    // While drawing, Undo removes the last placed point (no separate draw undo).
+    if (mode === 'draw' && drawPts.length > 0) {
+      drawRedoRef.current.push(drawPts[drawPts.length - 1]);
+      setDrawPts((p) => p.slice(0, -1));
+      setStatus('Removed last point.');
+      return;
+    }
     const plate = plateRef.current;
     if (!plate || !undoRef.current.length) return;
     redoRef.current.push(plate);
     plateRef.current = undoRef.current.pop()!;
     resetInteraction(); refreshRooms(); setHist((v) => v + 1);
     setStatus('Undo.');
-  }, [resetInteraction, refreshRooms]);
+  }, [mode, drawPts, resetInteraction, refreshRooms]);
 
   const redo = useCallback(() => {
+    // While drawing, Redo re-adds the last point Undo removed.
+    if (mode === 'draw' && drawRedoRef.current.length > 0) {
+      const pt = drawRedoRef.current.pop()!;
+      setDrawPts((p) => [...p, pt]);
+      setStatus('Re-added point.');
+      return;
+    }
     const plate = plateRef.current;
     if (!plate || !redoRef.current.length) return;
     undoRef.current.push(plate);
     plateRef.current = redoRef.current.pop()!;
     resetInteraction(); refreshRooms(); setHist((v) => v + 1);
     setStatus('Redo.');
-  }, [resetInteraction, refreshRooms]);
+  }, [mode, resetInteraction, refreshRooms]);
 
   // Ctrl/Cmd+Z (Shift = redo) must drive THIS overlay's history, not the 3D
   // model behind the panel. The global handler in useKeyboardShortcuts routes
@@ -700,12 +732,18 @@ export function SpaceSketchOverlay() {
   const commitDraw = useCallback(() => {
     const plate = plateRef.current;
     if (!plate) return;
-    if (drawPts.length < 3) { setStatus('A room needs at least 3 points.'); return; }
+    // Drop trailing duplicate point(s) — e.g. the second click of a double-click
+    // close lands on the same spot as the final corner.
+    let pts = drawPts;
+    while (pts.length >= 2 && Math.hypot(pts[pts.length - 1][0] - pts[pts.length - 2][0], pts[pts.length - 1][1] - pts[pts.length - 2][1]) < EPS) {
+      pts = pts.slice(0, -1);
+    }
+    if (pts.length < 3) { setStatus('A room needs at least 3 points.'); return; }
     const snap = plate.duplicate();
     try {
-      plate.addFace(new Float64Array(drawPts.flat()), -1);
+      plate.addFace(new Float64Array(pts.flat()), -1);
       commitUndo(snap);
-      setDrawPts([]); setDrawCursor(null);
+      setDrawPts([]); setDrawCursor(null); drawRedoRef.current = [];
       refreshRooms();
       setStatus(`Drew a room — ${plate.roomCount} room(s).`);
     } catch (err) {
@@ -717,6 +755,58 @@ export function SpaceSketchOverlay() {
     }
   }, [drawPts, commitUndo, refreshRooms]);
 
+  // Single Esc aborts the in-progress operation (in priority order); it does NOT
+  // close the panel. Returns true if something was aborted.
+  const abortCurrentOp = useCallback((): boolean => {
+    if (mode === 'draw' && (drawPts.length > 0 || drawCursor)) {
+      setDrawPts([]); setDrawCursor(null); drawRedoRef.current = [];
+      setStatus('Draw cancelled.');
+      return true;
+    }
+    if (splitPick) {
+      setSplitPick(null); setSplitHover(null);
+      setStatus('Split cancelled.');
+      return true;
+    }
+    if (dragRef.current != null) {
+      // Revert the live drag to its pre-drag snapshot.
+      const plate = plateRef.current;
+      if (plate && pendingUndoRef.current) {
+        plate.free();
+        plateRef.current = pendingUndoRef.current;
+        pendingUndoRef.current = null;
+        refreshRooms();
+      }
+      dragRef.current = null; dragStartRef.current = null;
+      draggedRef.current = false; setSnapPos(null);
+      setStatus('Drag cancelled.');
+      return true;
+    }
+    return false;
+  }, [mode, drawPts, drawCursor, splitPick, refreshRooms]);
+
+  // Esc = abort current op (single) / close panel (double-tap ≤400 ms).
+  // Enter (in draw mode) closes the room. Both skip text inputs.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const t = e.target as HTMLElement | null;
+      const inField = !!t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable);
+      if (e.key === 'Escape') {
+        if (inField) return;
+        e.preventDefault();
+        const now = Date.now();
+        if (abortCurrentOp()) { escTimeRef.current = 0; return; }
+        if (now - escTimeRef.current <= 400) { escTimeRef.current = 0; setActiveTool('select'); }
+        else { escTimeRef.current = now; setStatus('Press Esc again to close.'); }
+      } else if (e.key === 'Enter' && mode === 'draw' && !inField) {
+        e.preventDefault();
+        commitDraw();
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [abortCurrentOp, commitDraw, mode, setActiveTool]);
+
   const processMove = useCallback(() => {
     rafRef.current = null;
     const m = moveRef.current;
@@ -727,21 +817,19 @@ export function SpaceSketchOverlay() {
     const vid = dragRef.current;
     if (vid != null) {
       draggedRef.current = true;
-      let tx = wx, ty = wy;
-      if (m.shift && dragStartRef.current) {
-        const [ox, oy] = dragStartRef.current;
-        if (Math.abs(wx - ox) >= Math.abs(wy - oy)) ty = oy; else tx = ox;
-      }
-      const tol = SNAP_PX / fitRef.current.scale;
-      let snapped: Pt | null = null, bestD = tol;
-      for (const p of otherVertsRef.current) {
-        const d = Math.hypot(p[0] - tx, p[1] - ty);
-        if (d < bestD) { bestD = d; snapped = p; }
-      }
-      if (snapped) { tx = snapped[0]; ty = snapped[1]; }
-      setSnapPos(snapped);
+      // Snap to other room vertices + building wall lines (corners and along
+      // walls), with Shift constraining to ortho from the drag start first.
+      const snap = snapPoint([wx, wy], {
+        vertices: otherVertsRef.current,
+        segments: buildingSegmentsRef.current,
+        tol: SNAP_PX / fitRef.current.scale,
+        ortho: m.shift,
+        anchor: dragStartRef.current,
+      });
+      setSnapPos(snap.kind === 'none' ? null : snap.pt);
+      setSnapKind(snap.kind);
       try {
-        plate.dragVertex(vid, tx, ty);
+        plate.dragVertex(vid, snap.pt[0], snap.pt[1]);
         refreshRooms();
       } catch (e) {
         console.debug('[space-sketch] dragVertex failed (plate torn down mid-drag?)', e);
@@ -760,9 +848,18 @@ export function SpaceSketchOverlay() {
       setSplitHover(t ? t.pos : null);
       setHover(t && t.kind === 'vertex' ? { kind: 'vertex', pos: t.pos } : null);
     } else if (mode === 'draw') {
-      // Snap the preview point to an existing corner so drawn rooms align.
-      const snapV = nearestVertPos(wx, wy);
-      setDrawCursor(snapV ?? [wx, wy]);
+      // Preview the next corner: snap to room vertices + building walls; Shift
+      // constrains to ortho from the previous corner.
+      const anchor = drawPts.length > 0 ? drawPts[drawPts.length - 1] : null;
+      const snap = snapPoint([wx, wy], {
+        vertices: uniqueVerts(rooms),
+        segments: buildingSegmentsRef.current,
+        tol: PICK_PX / fitRef.current.scale,
+        ortho: m.shift,
+        anchor,
+      });
+      setDrawCursor(snap.pt);
+      setSnapKind(snap.kind);
     } else {
       const v = pickVertex(wx, wy);
       const pos = v != null ? nearestVertPos(wx, wy) : null;
@@ -770,7 +867,7 @@ export function SpaceSketchOverlay() {
       // Telegraph the ⌥/Ctrl-click delete on whatever vertex is under the cursor.
       setDeleteHover(m.del && pos ? pos : null);
     }
-  }, [mode, pickEdge, pickVertex, nearestVertPos, resolveSplitTarget, refreshRooms]);
+  }, [mode, drawPts, rooms, pickEdge, pickVertex, nearestVertPos, resolveSplitTarget, refreshRooms]);
 
   const onPointerMove = useCallback((e: React.PointerEvent) => {
     if (panningRef.current) {
@@ -859,8 +956,16 @@ export function SpaceSketchOverlay() {
       return;
     }
     if (mode === 'draw') {
-      const snapV = nearestVertPos(wx, wy);
-      const p: Pt = snapV ?? [wx, wy];
+      // Snap the dropped corner to room vertices + building walls; Shift = ortho
+      // from the previous corner.
+      const anchor = drawPts.length > 0 ? drawPts[drawPts.length - 1] : null;
+      const p = snapPoint([wx, wy], {
+        vertices: uniqueVerts(rooms),
+        segments: buildingSegmentsRef.current,
+        tol: PICK_PX / fitRef.current.scale,
+        ortho: e.shiftKey,
+        anchor,
+      }).pt;
       // With ≥3 points placed, clicking the first dot closes the loop.
       if (drawPts.length >= 3) {
         const first = drawPts[0];
@@ -869,8 +974,9 @@ export function SpaceSketchOverlay() {
           return;
         }
       }
+      drawRedoRef.current = []; // a new point invalidates the point-redo stack
       setDrawPts((pts) => [...pts, p]);
-      setStatus(`Drawing — ${drawPts.length + 1} point(s). Click the first dot (or “Finish”) to close.`);
+      setStatus(`Drawing — ${drawPts.length + 1} pt(s) · Enter / double-click / first dot to close · Shift = straight · Ctrl+Z removes last.`);
     }
   }, [mode, pickVertex, nearestVertPos, pickEdge, rooms, splitPick, resolveSplitTarget, performSplit, commitUndo, refreshRooms, drawPts, commitDraw]);
 
@@ -895,8 +1001,9 @@ export function SpaceSketchOverlay() {
   const mergeRooms = hover?.kind === 'edge' ? new Set(hover.rooms) : null;
   const cursorWorld = moveRef.current ? [wX(f, moveRef.current.x), wY(f, moveRef.current.y)] as Pt : null;
   const cursor = panningRef.current || dragRef.current != null ? 'grabbing' : (mode === 'drag' && hover?.kind === 'vertex') ? 'grab' : 'crosshair';
-  const canUndo = undoRef.current.length > 0;
-  const canRedo = redoRef.current.length > 0;
+  // During a draw, Undo/Redo act on the placed points (not the plate stack).
+  const canUndo = (mode === 'draw' && drawPts.length > 0) || undoRef.current.length > 0;
+  const canRedo = (mode === 'draw' && drawRedoRef.current.length > 0) || redoRef.current.length > 0;
   void hist; void fitTick;
 
   const gridStep = f.scale > 14 ? 1 : f.scale > 5 ? 2 : 5;
@@ -964,7 +1071,7 @@ export function SpaceSketchOverlay() {
         <div className="flex items-center gap-2 text-sm font-semibold">
           <Layers className="h-4 w-4 text-muted-foreground" /> Space Sketch
         </div>
-        <button className={iconBtn} onClick={() => setActiveTool('select')} title="Close (Esc)"><X className="h-4 w-4" /></button>
+        <button className={iconBtn} onClick={() => setActiveTool('select')} title="Close (double-tap Esc)"><X className="h-4 w-4" /></button>
       </div>
 
       {/* Storey + whole-building */}
@@ -984,25 +1091,28 @@ export function SpaceSketchOverlay() {
           {(['drag', 'split', 'merge', 'draw'] as Mode[]).map((m) => (
             <button key={m}
               className={`rounded px-2 py-0.5 text-xs capitalize transition-colors ${mode === m ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'}`}
-              onClick={() => { setMode(m); setSplitPick(null); setSplitHover(null); setHover(null); setDeleteHover(null); setDrawPts([]); setDrawCursor(null); }}
+              onClick={() => { setMode(m); setSplitPick(null); setSplitHover(null); setHover(null); setDeleteHover(null); setDrawPts([]); setDrawCursor(null); drawRedoRef.current = []; }}
               title={m === 'draw' ? 'Author a new room by clicking its corners' : `Edit derived rooms (${m})`}
               disabled={m === 'draw' ? derivedStorey == null : !rooms.length}>{m}</button>
           ))}
         </div>
         <button className={iconBtn} onClick={undo} disabled={!canUndo} title="Undo (Ctrl+Z)"><Undo2 className="h-4 w-4" /></button>
         <button className={iconBtn} onClick={redo} disabled={!canRedo} title="Redo (Ctrl+Shift+Z)"><Redo2 className="h-4 w-4" /></button>
+        <button
+          className={`${iconBtn} ${snapToBuilding ? 'bg-primary/10 text-primary hover:bg-primary/15' : ''}`}
+          onClick={() => setSnapToBuilding((v) => !v)}
+          aria-pressed={snapToBuilding}
+          title={snapToBuilding ? 'Snap to building walls: on — click to disable' : 'Snap to building walls: off — click to enable'}
+        ><Magnet className="h-4 w-4" /></button>
       </div>
 
-      {/* Draw-room controls (Issue 2) — only while authoring a new room. */}
+      {/* Draw-room hint (Issue 2) — point placement uses the panel Undo/Redo and
+          Esc; no separate draw buttons. Only while authoring a new room. */}
       {mode === 'draw' && (
-        <div className="flex items-center gap-1.5 mb-2 text-[11px]">
-          <span className="text-muted-foreground">Draw room · {drawPts.length} pt(s)</span>
-          <button onClick={commitDraw} disabled={drawPts.length < 3}
-            className="rounded bg-emerald-600 px-2 py-0.5 font-medium text-white hover:bg-emerald-700 disabled:opacity-40">Finish</button>
-          <button onClick={() => setDrawPts((p) => p.slice(0, -1))} disabled={!drawPts.length}
-            className="rounded border px-2 py-0.5 hover:bg-muted disabled:opacity-40" title="Remove the last point">Undo point</button>
-          <button onClick={() => { setDrawPts([]); setDrawCursor(null); setStatus('Draw cancelled.'); }} disabled={!drawPts.length}
-            className="rounded border px-2 py-0.5 hover:bg-muted disabled:opacity-40">Cancel</button>
+        <div className="mb-2 text-[11px] text-muted-foreground leading-tight">
+          {drawPts.length === 0
+            ? 'Click to drop the first corner. Shift = straight · snaps to walls.'
+            : `${drawPts.length} pt(s) · Enter, double-click, or click the first dot to close · Esc cancels · Ctrl+Z removes last · Shift = straight.`}
         </div>
       )}
 
@@ -1056,6 +1166,7 @@ export function SpaceSketchOverlay() {
       <svg ref={svgRef} width={size.w} height={size.h} style={{ cursor }}
         className="rounded border bg-muted/20 touch-none"
         onPointerDown={onPointerDown} onPointerMove={onPointerMove} onPointerUp={endDrag}
+        onDoubleClick={() => { if (mode === 'draw') commitDraw(); }}
         onContextMenu={(e) => e.preventDefault()}
         onPointerLeave={() => { setHover(null); setSplitHover(null); setDeleteHover(null); setDrawCursor(null); }}>
         {gridLines.map((l, i) => <line key={`g${i}`} {...l} stroke="currentColor" strokeOpacity={0.06} strokeWidth={1} />)}
@@ -1114,8 +1225,15 @@ export function SpaceSketchOverlay() {
         )}
         {snapPos && (
           <g pointerEvents="none">
-            <circle cx={sX(f, snapPos[0])} cy={sY(f, snapPos[1])} r={9} fill="none" stroke="#22c55e" strokeWidth={1.5} />
-            <circle cx={sX(f, snapPos[0])} cy={sY(f, snapPos[1])} r={2.5} fill="#22c55e" />
+            {snapKind === 'line' ? (
+              // On-wall snap — amber diamond.
+              <rect x={sX(f, snapPos[0]) - 5} y={sY(f, snapPos[1]) - 5} width={10} height={10} fill="none"
+                stroke="#f59e0b" strokeWidth={1.5} transform={`rotate(45 ${sX(f, snapPos[0])} ${sY(f, snapPos[1])})`} />
+            ) : (
+              // Corner/vertex snap — green ring.
+              <circle cx={sX(f, snapPos[0])} cy={sY(f, snapPos[1])} r={9} fill="none" stroke="#22c55e" strokeWidth={1.5} />
+            )}
+            <circle cx={sX(f, snapPos[0])} cy={sY(f, snapPos[1])} r={2.5} fill={snapKind === 'line' ? '#f59e0b' : '#22c55e'} />
           </g>
         )}
 
@@ -1129,6 +1247,12 @@ export function SpaceSketchOverlay() {
             {drawCursor && (
               <line x1={sX(f, drawPts[drawPts.length - 1][0])} y1={sY(f, drawPts[drawPts.length - 1][1])}
                 x2={sX(f, drawCursor[0])} y2={sY(f, drawCursor[1])} stroke="#22c55e" strokeOpacity={0.5} strokeDasharray="4 3" strokeWidth={1.2} />
+            )}
+            {drawCursor && snapKind !== 'none' && (
+              snapKind === 'line'
+                ? <rect x={sX(f, drawCursor[0]) - 5} y={sY(f, drawCursor[1]) - 5} width={10} height={10} fill="none"
+                    stroke="#f59e0b" strokeWidth={1.5} transform={`rotate(45 ${sX(f, drawCursor[0])} ${sY(f, drawCursor[1])})`} />
+                : <circle cx={sX(f, drawCursor[0])} cy={sY(f, drawCursor[1])} r={7} fill="none" stroke="#22c55e" strokeWidth={1.5} />
             )}
             {drawPts.map((p, i) => (
               <circle key={`d${i}`} cx={sX(f, p[0])} cy={sY(f, p[1])} r={i === 0 && drawPts.length >= 3 ? 6 : 3.5}
@@ -1165,10 +1289,10 @@ export function SpaceSketchOverlay() {
       </div>
       <div className="mt-1.5 text-[11px] text-muted-foreground">
         {!rooms.length && mode !== 'draw' && 'Pick a storey to derive its rooms, “Generate all” for the building, or “draw” a room by hand.'}
-        {!!rooms.length && mode === 'drag' && 'Drag a vertex — shared vertices move both rooms; snaps to others, Shift = ortho. ⌥/Ctrl-click a node to remove it.'}
+        {!!rooms.length && mode === 'drag' && 'Drag a vertex — shared vertices move both rooms; snaps to corners + walls, Shift = straight. ⌥/Ctrl-click a node to remove it.'}
         {!!rooms.length && mode === 'split' && 'Click two points — corners or anywhere on a wall (new nodes added as needed).'}
         {!!rooms.length && mode === 'merge' && 'Hover highlights the wall + both rooms; click to merge them.'}
-        {mode === 'draw' && 'Click to drop corners; click the first dot (or “Finish”) to close the room. It’s a standalone room — it won’t merge into existing walls.'}
+        {mode === 'draw' && 'Click corners (snap to walls; Shift = straight). Enter, double-click, or click the first dot to close. Esc cancels; Ctrl+Z removes the last point. Standalone room — won’t merge into existing walls.'}
         {unboundedCount > 0 && (
           <span className="text-amber-600 dark:text-amber-500"> · {unboundedCount} room(s) unchanged by {boundaryMode} (dashed) — no wall offset.</span>
         )}

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -7,13 +7,15 @@
  * `SpacePlateHandle` topology editor (rust/geometry `space_dcel`).
  *
  * Self-contained: owns its own wasm handle + local state (no shared slice).
- * Seed from the active storey's walls (or a demo plate), drag a shared vertex
- * (both rooms follow), split a room — between corners OR new nodes added
- * anywhere on a wall — merge two rooms, then Bake to real `IfcSpace` through
- * the viewer's existing `addSpace`.
+ * Rooms are derived from the active storey's RENDERED wall meshes (min-area
+ * footprint rectangles → gap detection → lifted onto the wall axis), then the
+ * user can drag a shared vertex (both rooms follow), split a room — between
+ * corners OR new nodes added anywhere on a wall — merge two rooms, then Bake to
+ * real `IfcSpace` through the viewer's existing `addSpace`.
  *
- * Fluency (RFC §4.2): hover telegraphs the op; dragging snaps to other
- * vertices (Shift = ortho). Undo/redo snapshots the plate via `duplicate()`
+ * Fluency (RFC §4.2): hover telegraphs the op; drawing/dragging/cutting snap to
+ * other vertices + walls, with Shift = ortho (which dominates snap). Undo/redo
+ * snapshots the plate via `duplicate()`
  * (each clone owns its heap, freed deterministically — never JS GC). 2D plan
  * sketch; 3D-on-model registration is the next step.
  */
@@ -56,6 +58,12 @@ const PICK_PX = 12;
 const SNAP_PX = 10;
 const BAKE_HEIGHT = 3;
 const EPS = 1e-6;
+
+/** Lock `p` to a horizontal or vertical line through `anchor` (Shift-ortho),
+ *  whichever axis the cursor moved further along. Used for straight cut lines. */
+function orthoLock(anchor: Pt, p: Pt): Pt {
+  return Math.abs(p[0] - anchor[0]) >= Math.abs(p[1] - anchor[1]) ? [p[0], anchor[1]] : [anchor[0], p[1]];
+}
 
 export function SpaceSketchOverlay() {
   const setActiveTool = useViewerStore((s) => s.setActiveTool);
@@ -765,7 +773,10 @@ export function SpaceSketchOverlay() {
       const anchor = drawPts[drawPts.length - 1];
       const snap = snapPoint([wx, wy], { vertices: uniqueVerts(rooms), segments: buildingSegmentsRef.current, tol, ortho: m.shift, anchor });
       let pt = snap.pt;
-      if (snap.kind === 'none') {
+      // Axis-align to the drawn corners only when NOT holding Shift — under Shift
+      // the ortho constraint is authoritative and alignToAxes (which snaps X and Y
+      // independently) would pull the point off the straight line.
+      if (snap.kind === 'none' && !m.shift) {
         const al = alignToAxes(snap.pt, drawPts, tol);
         pt = al.pt; setSnapKind('none'); setAlignGuides({ vRef: al.vRef, hRef: al.hRef });
       } else {
@@ -780,10 +791,14 @@ export function SpaceSketchOverlay() {
     // Cutting: preview the second point. Track the cursor (snapped target or raw)
     // so the rubber band follows even over empty space.
     if (splitPick) {
-      const t = resolveSplitTarget(wx, wy);
-      setSplitHover(t ? t.pos : [wx, wy]);
+      // Shift = straight cut: lock the second point ortho from the first, then
+      // resolve onto a wall/corner along that line (so a rectangular room cuts
+      // cleanly perpendicular). Shift dominates — snap can't bend the cut.
+      const cur: Pt = m.shift ? orthoLock(splitPick.pos, [wx, wy]) : [wx, wy];
+      const t = resolveSplitTarget(cur[0], cur[1]);
+      setSplitHover(t ? t.pos : cur);
       setHover(t && t.kind === 'vertex' ? { kind: 'vertex', pos: t.pos } : null);
-      setIntent({ text: t ? 'Finish cut here' : 'Click a wall or corner to cut', tone: 'cut' });
+      setIntent({ text: t ? (m.shift ? 'Finish cut (straight)' : 'Finish cut here') : 'Click a wall or corner to cut', tone: 'cut' });
       return;
     }
 
@@ -957,7 +972,8 @@ export function SpaceSketchOverlay() {
     if (drawPts.length > 0) {
       const anchor = drawPts[drawPts.length - 1];
       const snap = snapPoint([wx, wy], { vertices: uniqueVerts(rooms), segments: buildingSegmentsRef.current, tol, ortho: e.shiftKey, anchor });
-      const p = snap.kind === 'none' ? alignToAxes(snap.pt, drawPts, tol).pt : snap.pt;
+      // Under Shift the ortho point is authoritative; only axis-align when free.
+      const p = snap.kind === 'none' && !e.shiftKey ? alignToAxes(snap.pt, drawPts, tol).pt : snap.pt;
       setAlignGuides({ vRef: null, hRef: null });
       if (drawPts.length >= 3) {
         const first = drawPts[0];
@@ -969,9 +985,11 @@ export function SpaceSketchOverlay() {
       return;
     }
 
-    // 2. Cutting in progress → place the second cut point and split.
+    // 2. Cutting in progress → place the second cut point and split (Shift =
+    // straight cut, ortho from the first point).
     if (splitPick) {
-      const target = resolveSplitTarget(wx, wy);
+      const cur: Pt = e.shiftKey ? orthoLock(splitPick.pos, [wx, wy]) : [wx, wy];
+      const target = resolveSplitTarget(cur[0], cur[1]);
       if (!target) { setStatus('Click another wall (or corner) on the same room to finish the cut.'); return; }
       const first = splitPick;
       setSplitPick(null); setSplitHover(null);

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -43,14 +43,8 @@ import {
   type BoundaryMode,
 } from '@ifc-lite/create';
 import { X, Undo2, Redo2, Layers, Maximize, AlertTriangle, Magnet, SlidersHorizontal, HelpCircle, Eraser } from 'lucide-react';
-
-type Hover =
-  | { kind: 'vertex'; pos: Pt }
-  | { kind: 'edge'; edge: number; rooms: number[]; a: Pt; b: Pt }
-  | null;
-/** A split endpoint the user picked — an existing corner, or a point on a wall
- *  edge (which becomes a new node when the cut is committed). */
-type SplitTarget = { kind: 'vertex'; vid: number; pos: Pt } | { kind: 'edge'; edge: number; pos: Pt };
+import { SpaceSketchCanvas } from './space-sketch/SpaceSketchCanvas';
+import type { Hover, SplitTarget, IntentTone } from './space-sketch/types';
 
 const DEFAULT_W = 580;
 const DEFAULT_H = 460;
@@ -60,27 +54,6 @@ const PICK_PX = 12;
 const SNAP_PX = 10;
 const BAKE_HEIGHT = 3;
 const EPS = 1e-6;
-
-const ROOM_COLORS = ['#6366f1', '#10b981', '#f59e0b', '#ec4899', '#06b6d4', '#84cc16', '#a855f7', '#ef4444'];
-
-// Live action-intent chip — one consistent colour language across the tool:
-// green = create/draw, blue = cut/split, red = remove/merge (dissolve),
-// neutral = move/pan. The on-canvas cues use the same hues.
-type IntentTone = 'move' | 'draw' | 'cut' | 'remove' | 'pan';
-const INTENT_TEXT_CLASS: Record<IntentTone, string> = {
-  move: 'text-foreground',
-  draw: 'text-emerald-600 dark:text-emerald-400',
-  cut: 'text-blue-600 dark:text-blue-400',
-  remove: 'text-red-600 dark:text-red-400',
-  pan: 'text-muted-foreground',
-};
-const INTENT_DOT_CLASS: Record<IntentTone, string> = {
-  move: 'bg-zinc-400',
-  draw: 'bg-emerald-500',
-  cut: 'bg-blue-500',
-  remove: 'bg-red-500',
-  pan: 'bg-zinc-400',
-};
 
 export function SpaceSketchOverlay() {
   const setActiveTool = useViewerStore((s) => s.setActiveTool);
@@ -1264,160 +1237,37 @@ export function SpaceSketchOverlay() {
         </div>
       )}
 
-      <div className="relative">
-      {/* Live action preview — tells you what the next click will do, colour-keyed
-          to the on-canvas cues (green draw · blue cut · red remove/merge). */}
-      {intent && (
-        <div className="pointer-events-none absolute right-2 top-2 z-20 flex items-center gap-1.5 rounded-md border bg-background/85 px-2 py-1 text-[11px] font-semibold shadow-sm backdrop-blur">
-          <span className={`h-1.5 w-1.5 rounded-full ${INTENT_DOT_CLASS[intent.tone]}`} />
-          <span className={INTENT_TEXT_CLASS[intent.tone]}>{intent.text}</span>
-        </div>
-      )}
-      <svg ref={svgRef} width={size.w} height={size.h} style={{ cursor }}
-        className="rounded border bg-muted/20 touch-none"
-        onPointerDown={onPointerDown} onPointerMove={onPointerMove} onPointerUp={endDrag}
+      <SpaceSketchCanvas
+        svgRef={svgRef}
+        width={size.w}
+        height={size.h}
+        cursor={cursor}
+        fit={f}
+        gridLines={gridLines}
+        underlay={underlayEls}
+        rooms={rooms}
+        boundaryInfo={boundaryInfo}
+        boundaryMode={boundaryMode}
+        mergeFaces={mergeRooms}
+        diagnostics={diagnostics}
+        hover={hover}
+        splitPick={splitPick}
+        previewEnd={previewEnd}
+        splitHover={splitHover}
+        snapPos={snapPos}
+        snapKind={snapKind}
+        drawPts={drawPts}
+        drawCursor={drawCursor}
+        alignGuides={alignGuides}
+        deleteHover={deleteHover}
+        intent={intent}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={endDrag}
         onDoubleClick={() => { if (drawPts.length > 0) commitDraw(); }}
         onContextMenu={onContextMenu}
-        onPointerLeave={() => { setHover(null); setSplitHover(null); setDeleteHover(null); setDrawCursor(null); setAlignGuides({ vRef: null, hRef: null }); setIntent(null); }}>
-        {gridLines.map((l, i) => <line key={`g${i}`} {...l} stroke="currentColor" strokeOpacity={0.06} strokeWidth={1} />)}
-
-        {/* Building-element underlay (plan cut ~1.2 m above the storey) for orientation. */}
-        {underlayEls}
-
-        {rooms.map((r, ri) => {
-          const color = ROOM_COLORS[ri % ROOM_COLORS.length];
-          const { disp, unbounded } = boundaryInfo[ri];
-          const pts = disp.map((p) => `${sX(f, p[0])},${sY(f, p[1])}`).join(' ');
-          const [cwx, cwy] = centroid(disp);
-          const cx = sX(f, cwx), cy = sY(f, cwy);
-          const lit = mergeRooms?.has(r.face);
-          const bad = !r.simple;
-          const area = boundaryMode === 'center' ? r.area : polyArea(disp);
-          return (
-            <g key={r.face}>
-              {boundaryMode !== 'center' && (
-                <polygon points={r.outline.map((p) => `${sX(f, p[0])},${sY(f, p[1])}`).join(' ')}
-                  fill="none" stroke={color} strokeOpacity={0.25} strokeDasharray="3 3" strokeWidth={1} />
-              )}
-              <polygon points={pts} fill={bad ? '#ef4444' : color} fillOpacity={lit ? 0.42 : bad ? 0.3 : 0.16}
-                stroke={bad ? '#ef4444' : color} strokeWidth={lit ? 3 : 2}
-                strokeDasharray={unbounded && !bad ? '5 4' : undefined}>
-                {unbounded && <title>Boundary “{boundaryMode}” made no change to this room — no wall offset applies (no wall runs along its edges, or it's fully internal in Outer mode).</title>}
-              </polygon>
-              <text x={cx} y={cy - 5} textAnchor="middle" fontSize={12} fontWeight={600} fill="currentColor" className="pointer-events-none">{area.toFixed(2)}</text>
-              <text x={cx} y={cy + 9} textAnchor="middle" fontSize={9} fill="currentColor" opacity={0.55} className="pointer-events-none">m²</text>
-            </g>
-          );
-        })}
-
-        {/* Issue 7 — leak diagnostics: walls that bound a room (green) vs walls
-            that bound nothing (red dashed = a stray segment / leak suspect). */}
-        {diagnostics && diagnostics.map((s, i) => (
-          <line key={`dg${i}`} x1={sX(f, s.a[0])} y1={sY(f, s.a[1])} x2={sX(f, s.b[0])} y2={sY(f, s.b[1])}
-            stroke={s.bounding ? '#22c55e' : '#ef4444'} strokeOpacity={s.bounding ? 0.45 : 0.95}
-            strokeWidth={s.bounding ? 1.2 : 2.2} strokeDasharray={s.bounding ? undefined : '4 3'} pointerEvents="none" />
-        ))}
-
-        {hover?.kind === 'edge' && (
-          <line x1={sX(f, hover.a[0])} y1={sY(f, hover.a[1])} x2={sX(f, hover.b[0])} y2={sY(f, hover.b[1])} stroke="#ef4444" strokeWidth={4} strokeLinecap="round" />
-        )}
-        {splitPick && previewEnd && (
-          <line x1={sX(f, splitPick.pos[0])} y1={sY(f, splitPick.pos[1])} x2={sX(f, previewEnd[0])} y2={sY(f, previewEnd[1])}
-            stroke="#3b82f6" strokeWidth={1.5} strokeDasharray="5 4" />
-        )}
-        {/* Cut/insert cue on a wall — the "+" handle that telegraphs "click to
-            place a cut point here" (and previews the second cut point). */}
-        {splitHover && (
-          <g pointerEvents="none">
-            <circle cx={sX(f, splitHover[0])} cy={sY(f, splitHover[1])} r={6} fill="#3b82f6" fillOpacity={0.15} stroke="#3b82f6" strokeWidth={1.5} />
-            <line x1={sX(f, splitHover[0]) - 3} y1={sY(f, splitHover[1])} x2={sX(f, splitHover[0]) + 3} y2={sY(f, splitHover[1])} stroke="#3b82f6" strokeWidth={1.5} />
-            <line x1={sX(f, splitHover[0])} y1={sY(f, splitHover[1]) - 3} x2={sX(f, splitHover[0])} y2={sY(f, splitHover[1]) + 3} stroke="#3b82f6" strokeWidth={1.5} />
-          </g>
-        )}
-        {/* first committed split pick */}
-        {splitPick && (
-          <circle cx={sX(f, splitPick.pos[0])} cy={sY(f, splitPick.pos[1])} r={5} fill="#3b82f6" stroke="#fff" strokeWidth={1.5} pointerEvents="none" />
-        )}
-        {snapPos && (
-          <g pointerEvents="none">
-            {snapKind === 'line' ? (
-              // On-wall snap — amber diamond.
-              <rect x={sX(f, snapPos[0]) - 5} y={sY(f, snapPos[1]) - 5} width={10} height={10} fill="none"
-                stroke="#f59e0b" strokeWidth={1.5} transform={`rotate(45 ${sX(f, snapPos[0])} ${sY(f, snapPos[1])})`} />
-            ) : (
-              // Corner/vertex snap — green ring.
-              <circle cx={sX(f, snapPos[0])} cy={sY(f, snapPos[1])} r={9} fill="none" stroke="#22c55e" strokeWidth={1.5} />
-            )}
-            <circle cx={sX(f, snapPos[0])} cy={sY(f, snapPos[1])} r={2.5} fill={snapKind === 'line' ? '#f59e0b' : '#22c55e'} />
-          </g>
-        )}
-
-        {/* First-corner preview: before any point is placed, show where the
-            click will land + the snap cue, so the snap is visible up front. */}
-        {drawPts.length === 0 && drawCursor && (
-          <g pointerEvents="none">
-            {snapKind === 'line' && (
-              <rect x={sX(f, drawCursor[0]) - 5} y={sY(f, drawCursor[1]) - 5} width={10} height={10} fill="none"
-                stroke="#f59e0b" strokeWidth={1.5} transform={`rotate(45 ${sX(f, drawCursor[0])} ${sY(f, drawCursor[1])})`} />
-            )}
-            {snapKind === 'vertex' && (
-              <circle cx={sX(f, drawCursor[0])} cy={sY(f, drawCursor[1])} r={7} fill="none" stroke="#22c55e" strokeWidth={1.5} />
-            )}
-            <circle cx={sX(f, drawCursor[0])} cy={sY(f, drawCursor[1])} r={4} fill="#22c55e" stroke="#16a34a" strokeWidth={1.5} />
-          </g>
-        )}
-
-        {/* Draw-room in progress (Issue 2): placed points, rubber band, close hint. */}
-        {drawPts.length > 0 && (
-          <g pointerEvents="none">
-            {/* Alignment guides — the dashed lines that telegraph "this corner
-                is lined up with that earlier corner" (e.g. under the first). */}
-            {drawCursor && alignGuides.vRef && (
-              <line x1={sX(f, drawCursor[0])} y1={sY(f, alignGuides.vRef[1])} x2={sX(f, drawCursor[0])} y2={sY(f, drawCursor[1])}
-                stroke="#f59e0b" strokeOpacity={0.7} strokeDasharray="3 3" strokeWidth={1} />
-            )}
-            {drawCursor && alignGuides.hRef && (
-              <line x1={sX(f, alignGuides.hRef[0])} y1={sY(f, drawCursor[1])} x2={sX(f, drawCursor[0])} y2={sY(f, drawCursor[1])}
-                stroke="#f59e0b" strokeOpacity={0.7} strokeDasharray="3 3" strokeWidth={1} />
-            )}
-            {drawPts.length >= 3 && (
-              <polygon points={drawPts.map((p) => `${sX(f, p[0])},${sY(f, p[1])}`).join(' ')} fill="#22c55e" fillOpacity={0.1} stroke="none" />
-            )}
-            <polyline points={drawPts.map((p) => `${sX(f, p[0])},${sY(f, p[1])}`).join(' ')} fill="none" stroke="#22c55e" strokeWidth={1.5} />
-            {drawCursor && (
-              <line x1={sX(f, drawPts[drawPts.length - 1][0])} y1={sY(f, drawPts[drawPts.length - 1][1])}
-                x2={sX(f, drawCursor[0])} y2={sY(f, drawCursor[1])} stroke="#22c55e" strokeOpacity={0.5} strokeDasharray="4 3" strokeWidth={1.2} />
-            )}
-            {drawCursor && snapKind !== 'none' && (
-              snapKind === 'line'
-                ? <rect x={sX(f, drawCursor[0]) - 5} y={sY(f, drawCursor[1]) - 5} width={10} height={10} fill="none"
-                    stroke="#f59e0b" strokeWidth={1.5} transform={`rotate(45 ${sX(f, drawCursor[0])} ${sY(f, drawCursor[1])})`} />
-                : <circle cx={sX(f, drawCursor[0])} cy={sY(f, drawCursor[1])} r={7} fill="none" stroke="#22c55e" strokeWidth={1.5} />
-            )}
-            {drawPts.map((p, i) => (
-              <circle key={`d${i}`} cx={sX(f, p[0])} cy={sY(f, p[1])} r={i === 0 && drawPts.length >= 3 ? 6 : 3.5}
-                fill={i === 0 && drawPts.length >= 3 ? '#22c55e' : '#fff'} stroke="#16a34a" strokeWidth={1.5} />
-            ))}
-          </g>
-        )}
-
-        {uniqueVerts(rooms).map((p, i) => {
-          const isHover = hover?.kind === 'vertex' && Math.abs(hover.pos[0] - p[0]) < EPS && Math.abs(hover.pos[1] - p[1]) < EPS;
-          return (
-            <circle key={i} cx={sX(f, p[0])} cy={sY(f, p[1])} r={isHover ? 6 : 4}
-              fill={isHover ? '#fbbf24' : '#fff'} stroke="#334155" strokeWidth={1.5} pointerEvents="none" />
-          );
-        })}
-
-        {/* ⌥/Ctrl-click delete telegraph (Issue 3): a red ring + minus over the node. */}
-        {deleteHover && (
-          <g pointerEvents="none">
-            <circle cx={sX(f, deleteHover[0])} cy={sY(f, deleteHover[1])} r={8} fill="#ef4444" fillOpacity={0.15} stroke="#ef4444" strokeWidth={1.5} />
-            <line x1={sX(f, deleteHover[0]) - 4} y1={sY(f, deleteHover[1])} x2={sX(f, deleteHover[0]) + 4} y2={sY(f, deleteHover[1])} stroke="#ef4444" strokeWidth={2} />
-          </g>
-        )}
-      </svg>
-      </div>
+        onPointerLeave={() => { setHover(null); setSplitHover(null); setDeleteHover(null); setDrawCursor(null); setAlignGuides({ vRef: null, hRef: null }); setIntent(null); }}
+      />
 
       {/* Footer — an in-the-moment hint only while drawing/cutting (the full
           legend lives behind “?”), the live status, then the primary action. */}

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -146,6 +146,25 @@ function uniqueVerts(rooms: Room[]): Pt[] {
 
 const ROOM_COLORS = ['#6366f1', '#10b981', '#f59e0b', '#ec4899', '#06b6d4', '#84cc16', '#a855f7', '#ef4444'];
 
+// Live action-intent chip — one consistent colour language across the tool:
+// green = create/draw, blue = cut/split, red = remove/merge (dissolve),
+// neutral = move/pan. The on-canvas cues use the same hues.
+type IntentTone = 'move' | 'draw' | 'cut' | 'remove' | 'pan';
+const INTENT_TEXT_CLASS: Record<IntentTone, string> = {
+  move: 'text-foreground',
+  draw: 'text-emerald-600 dark:text-emerald-400',
+  cut: 'text-blue-600 dark:text-blue-400',
+  remove: 'text-red-600 dark:text-red-400',
+  pan: 'text-muted-foreground',
+};
+const INTENT_DOT_CLASS: Record<IntentTone, string> = {
+  move: 'bg-zinc-400',
+  draw: 'bg-emerald-500',
+  cut: 'bg-blue-500',
+  remove: 'bg-red-500',
+  pan: 'bg-zinc-400',
+};
+
 export function SpaceSketchOverlay() {
   const setActiveTool = useViewerStore((s) => s.setActiveTool);
   const addSpace = useViewerStore((s) => s.addSpace);
@@ -212,6 +231,8 @@ export function SpaceSketchOverlay() {
   // / Y (horizontal guide) the cursor is currently locked to — so the closing
   // corner can line up under the first point, etc.
   const [alignGuides, setAlignGuides] = useState<{ vRef: Pt | null; hRef: Pt | null }>({ vRef: null, hRef: null });
+  // Live "what will this click do" label, shown top-right of the canvas.
+  const [intent, setIntent] = useState<{ text: string; tone: IntentTone } | null>(null);
   // Issue 4: canvas size (resizable) + a tick that forces a re-render whenever
   // the view transform in fitRef changes (zoom/pan/fit) without making the
   // per-frame pointer math go through React state.
@@ -801,30 +822,36 @@ export function SpaceSketchOverlay() {
     return false;
   }, [drawPts, splitPick, refreshRooms]);
 
-  // Esc = abort current op (single) / close panel (double-tap ≤400 ms).
-  // Enter (in draw mode) closes the room. Both skip text inputs.
+  // While the panel is open, Esc belongs to the sketch — NOT the global
+  // shortcut (which closes the tool and would lose the sketch). Capture-phase +
+  // stopImmediatePropagation beats the window-level handler in useKeyboardShortcuts.
+  // Esc: close a popover/confirm → abort the current op → (double-tap) close, with
+  // an unbaked-edits guard. Enter closes a drawn room.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       const t = e.target as HTMLElement | null;
       const inField = !!t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable);
       if (e.key === 'Escape') {
-        if (inField) return;
         e.preventDefault();
+        e.stopImmediatePropagation(); // own Esc; don't let the global handler close us
+        if (helpOpen || optionsOpen) { setHelpOpen(false); setOptionsOpen(false); return; }
+        if (confirmClose) { setConfirmClose(false); return; } // Esc cancels the confirm (never discards)
         const now = Date.now();
         if (abortCurrentOp()) { escTimeRef.current = 0; return; }
         if (now - escTimeRef.current <= 400) {
           escTimeRef.current = 0;
-          if (dirty) setConfirmClose(true); // guard unbaked edits
+          if (dirty) setConfirmClose(true); // guard unbaked edits — must click Discard
           else setActiveTool('select');
-        } else { escTimeRef.current = now; setStatus(dirty ? 'Unbaked edits — Esc again to discard & close.' : 'Press Esc again to close.'); }
+        } else { escTimeRef.current = now; setStatus(dirty ? 'Unbaked edits — Esc again to review.' : 'Press Esc again to close.'); }
       } else if (e.key === 'Enter' && drawPts.length > 0 && !inField) {
         e.preventDefault();
+        e.stopImmediatePropagation();
         commitDraw();
       }
     };
-    document.addEventListener('keydown', onKey);
-    return () => document.removeEventListener('keydown', onKey);
-  }, [abortCurrentOp, commitDraw, drawPts.length, dirty, setActiveTool]);
+    window.addEventListener('keydown', onKey, true);
+    return () => window.removeEventListener('keydown', onKey, true);
+  }, [abortCurrentOp, commitDraw, drawPts.length, dirty, helpOpen, optionsOpen, confirmClose, setActiveTool]);
 
   // Close request from the ✕ button: guard unbaked edits with an inline confirm.
   const requestClose = useCallback(() => {
@@ -853,6 +880,7 @@ export function SpaceSketchOverlay() {
       });
       setSnapPos(snap.kind === 'none' ? null : snap.pt);
       setSnapKind(snap.kind);
+      setIntent({ text: snap.kind === 'line' ? 'Move onto wall' : snap.kind === 'vertex' ? 'Move onto corner' : m.shift ? 'Move (straight)' : 'Move node', tone: 'move' });
       try {
         plate.dragVertex(vid, snap.pt[0], snap.pt[1]);
         refreshRooms();
@@ -869,52 +897,62 @@ export function SpaceSketchOverlay() {
       const tol = PICK_PX / fitRef.current.scale;
       const anchor = drawPts[drawPts.length - 1];
       const snap = snapPoint([wx, wy], { vertices: uniqueVerts(rooms), segments: buildingSegmentsRef.current, tol, ortho: m.shift, anchor });
+      let pt = snap.pt;
       if (snap.kind === 'none') {
         const al = alignToAxes(snap.pt, drawPts, tol);
-        setDrawCursor(al.pt); setSnapKind('none'); setAlignGuides({ vRef: al.vRef, hRef: al.hRef });
+        pt = al.pt; setSnapKind('none'); setAlignGuides({ vRef: al.vRef, hRef: al.hRef });
       } else {
-        setDrawCursor(snap.pt); setSnapKind(snap.kind); setAlignGuides({ vRef: null, hRef: null });
+        setSnapKind(snap.kind); setAlignGuides({ vRef: null, hRef: null });
       }
+      setDrawCursor(pt);
+      const closing = drawPts.length >= 3 && Math.hypot(pt[0] - drawPts[0][0], pt[1] - drawPts[0][1]) <= tol;
+      setIntent({ text: closing ? 'Close room' : m.shift ? 'Add corner (straight)' : 'Add corner', tone: 'draw' });
       return;
     }
 
-    // Cutting: first cut point placed → preview the second point.
+    // Cutting: preview the second point. Track the cursor (snapped target or raw)
+    // so the rubber band follows even over empty space.
     if (splitPick) {
       const t = resolveSplitTarget(wx, wy);
-      setSplitHover(t ? t.pos : null);
+      setSplitHover(t ? t.pos : [wx, wy]);
       setHover(t && t.kind === 'vertex' ? { kind: 'vertex', pos: t.pos } : null);
+      setIntent({ text: t ? 'Finish cut here' : 'Click a wall or corner to cut', tone: 'cut' });
       return;
     }
 
-    // Idle hover — context cues by what's under the cursor.
+    // Idle hover — context cues + the intent label by what's under the cursor.
     const v = pickVertex(wx, wy);
     if (v != null) {
       const pos = nearestVertPos(wx, wy);
       setHover(pos ? { kind: 'vertex', pos } : null);
-      setDeleteHover(m.del && pos ? pos : null); // ⌥ telegraphs node removal
+      setDeleteHover(m.del && pos ? pos : null); // ⌥/Ctrl telegraphs node removal
       setSplitHover(null); setDrawCursor(null); setSnapPos(null); setAlignGuides({ vRef: null, hRef: null });
+      setIntent(m.del ? { text: 'Remove node', tone: 'remove' } : { text: 'Move node', tone: 'move' });
       return;
     }
     const ed = pickEdge(wx, wy);
     if (ed != null) {
       setDeleteHover(null); setDrawCursor(null); setSnapPos(null);
       if (m.del) {
-        // ⌥ over a wall → merge preview (both rooms if the wall is shared).
+        // ⌥/Ctrl over a wall → merge preview (both rooms if the wall is shared).
         const nbr = plate.neighborAcross(ed.edge);
         setHover({ kind: 'edge', edge: ed.edge, rooms: [ed.face, ...(nbr !== undefined ? [nbr] : [])], a: ed.a, b: ed.b });
         setSplitHover(null);
+        setIntent({ text: nbr !== undefined ? 'Merge rooms' : 'No room to merge', tone: 'remove' });
       } else {
         // plain → cut cue ("+") at the projected point on the wall.
         setHover(null);
         setSplitHover(projectOnSeg([wx, wy], ed.a, ed.b));
+        setIntent({ text: 'Cut from here', tone: 'cut' });
       }
       return;
     }
-    // Empty space → preview where a new room's first corner would drop.
-    setHover(null); setDeleteHover(null); setSplitHover(null);
+    // Empty space → draw a room (or Shift = pan; hide the draw dot then).
+    setHover(null); setDeleteHover(null); setSplitHover(null); setAlignGuides({ vRef: null, hRef: null });
     const tol = PICK_PX / fitRef.current.scale;
     const snap = snapPoint([wx, wy], { vertices: uniqueVerts(rooms), segments: buildingSegmentsRef.current, tol });
-    setDrawCursor(snap.pt); setSnapKind(snap.kind); setAlignGuides({ vRef: null, hRef: null });
+    setDrawCursor(m.shift ? null : snap.pt); setSnapKind(snap.kind);
+    setIntent(m.shift ? { text: 'Pan', tone: 'pan' } : { text: 'Draw room', tone: 'draw' });
   }, [drawPts, splitPick, rooms, pickEdge, pickVertex, nearestVertPos, resolveSplitTarget, refreshRooms]);
 
   const onPointerMove = useCallback((e: React.PointerEvent) => {
@@ -930,6 +968,23 @@ export function SpaceSketchOverlay() {
     if (rafRef.current == null) rafRef.current = requestAnimationFrame(processMove);
   }, [processMove]);
 
+  // Pressing/releasing a modifier re-evaluates the hover preview at the current
+  // cursor (so the action label + cues flip the instant you hold ⌥/Ctrl/Shift,
+  // without having to move). No-op until the cursor has been over the canvas.
+  useEffect(() => {
+    const onMod = (e: KeyboardEvent) => {
+      if (e.key !== 'Alt' && e.key !== 'Control' && e.key !== 'Meta' && e.key !== 'Shift') return;
+      const m = moveRef.current;
+      if (!m || dragRef.current != null || panningRef.current) return;
+      m.del = e.altKey || e.ctrlKey || e.metaKey;
+      m.shift = e.shiftKey;
+      if (rafRef.current == null) rafRef.current = requestAnimationFrame(processMove);
+    };
+    window.addEventListener('keydown', onMod);
+    window.addEventListener('keyup', onMod);
+    return () => { window.removeEventListener('keydown', onMod); window.removeEventListener('keyup', onMod); };
+  }, [processMove]);
+
   const onPointerDown = useCallback((e: React.PointerEvent) => {
     const plate = plateRef.current;
     if (!plate) return;
@@ -941,7 +996,9 @@ export function SpaceSketchOverlay() {
     }
     const [sx, sy] = svgPoint(e);
     const wx = wX(fitRef.current, sx), wy = wY(fitRef.current, sy);
-    const mod = e.altKey || e.ctrlKey || e.metaKey; // ⌥/Ctrl = dissolve
+    // Dissolve/merge intent: Alt/Ctrl/Cmd, OR a right-click (button 2) — which is
+    // also what macOS Ctrl-click emits, so Ctrl-click works there too.
+    const mod = e.altKey || e.ctrlKey || e.metaKey || e.button === 2;
     const tol = PICK_PX / fitRef.current.scale;
 
     // 1. Drawing in progress → add a corner (or close on the first dot).
@@ -1018,8 +1075,10 @@ export function SpaceSketchOverlay() {
       return;
     }
 
-    // 5. Empty space → Shift pans (so you can still pan now that a plain click
-    //    draws); otherwise start drawing a new room.
+    // 5. Empty space → a right-click here does nothing (it's the dissolve gesture,
+    //    only meaningful on a node/wall). Shift pans (so you can still pan now
+    //    that a plain click draws). Otherwise start drawing a new room.
+    if (e.button === 2) return;
     if (e.shiftKey) {
       panningRef.current = true;
       svgRef.current?.setPointerCapture(e.pointerId);
@@ -1233,8 +1292,8 @@ export function SpaceSketchOverlay() {
             ['Drag a node', 'move it (snaps; Shift = straight)'],
             ['Click a wall, then another', 'split the room between them'],
             ['Click empty space', 'draw a room (Enter / dbl-click closes)'],
-            ['⌥/Ctrl-click a node', 'remove it'],
-            ['⌥/Ctrl-click a wall', 'merge the two rooms'],
+            ['⌥/Ctrl/right-click a node', 'remove it'],
+            ['⌥/Ctrl/right-click a wall', 'merge the two rooms'],
             ['Shift-drag / middle-drag', 'pan · scroll = zoom'],
           ] as [string, string][]).map(([k, v]) => (
             <div key={k} className="flex gap-2">
@@ -1245,12 +1304,21 @@ export function SpaceSketchOverlay() {
         </div>
       )}
 
+      <div className="relative">
+      {/* Live action preview — tells you what the next click will do, colour-keyed
+          to the on-canvas cues (green draw · blue cut · red remove/merge). */}
+      {intent && (
+        <div className="pointer-events-none absolute right-2 top-2 z-20 flex items-center gap-1.5 rounded-md border bg-background/85 px-2 py-1 text-[11px] font-semibold shadow-sm backdrop-blur">
+          <span className={`h-1.5 w-1.5 rounded-full ${INTENT_DOT_CLASS[intent.tone]}`} />
+          <span className={INTENT_TEXT_CLASS[intent.tone]}>{intent.text}</span>
+        </div>
+      )}
       <svg ref={svgRef} width={size.w} height={size.h} style={{ cursor }}
         className="rounded border bg-muted/20 touch-none"
         onPointerDown={onPointerDown} onPointerMove={onPointerMove} onPointerUp={endDrag}
         onDoubleClick={() => { if (drawPts.length > 0) commitDraw(); }}
         onContextMenu={(e) => e.preventDefault()}
-        onPointerLeave={() => { setHover(null); setSplitHover(null); setDeleteHover(null); setDrawCursor(null); setAlignGuides({ vRef: null, hRef: null }); }}>
+        onPointerLeave={() => { setHover(null); setSplitHover(null); setDeleteHover(null); setDrawCursor(null); setAlignGuides({ vRef: null, hRef: null }); setIntent(null); }}>
         {gridLines.map((l, i) => <line key={`g${i}`} {...l} stroke="currentColor" strokeOpacity={0.06} strokeWidth={1} />)}
 
         {/* Building-element underlay (plan cut ~1.2 m above the storey) for orientation. */}
@@ -1389,6 +1457,7 @@ export function SpaceSketchOverlay() {
           </g>
         )}
       </svg>
+      </div>
 
       {/* Footer — an in-the-moment hint only while drawing/cutting (the full
           legend lives behind “?”), the live status, then the primary action. */}

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -49,7 +49,6 @@ interface Boundary {
   edge: number;
   source: number | null;
 }
-type Mode = 'drag' | 'split' | 'merge' | 'draw';
 type Pt = [number, number];
 type Hover =
   | { kind: 'vertex'; pos: Pt }
@@ -187,7 +186,6 @@ export function SpaceSketchOverlay() {
   const buildingSegmentsRef = useRef<Array<[Pt, Pt]>>([]);
 
   const [rooms, setRooms] = useState<Room[]>([]);
-  const [mode, setMode] = useState<Mode>('drag');
   const [hover, setHover] = useState<Hover>(null);
   const [splitPick, setSplitPick] = useState<SplitTarget | null>(null);
   const [splitHover, setSplitHover] = useState<Pt | null>(null);
@@ -349,7 +347,7 @@ export function SpaceSketchOverlay() {
 
   const undo = useCallback(() => {
     // While drawing, Undo removes the last placed point (no separate draw undo).
-    if (mode === 'draw' && drawPts.length > 0) {
+    if (drawPts.length > 0) {
       drawRedoRef.current.push(drawPts[drawPts.length - 1]);
       setDrawPts((p) => p.slice(0, -1));
       setStatus('Removed last point.');
@@ -361,11 +359,11 @@ export function SpaceSketchOverlay() {
     plateRef.current = undoRef.current.pop()!;
     resetInteraction(); refreshRooms(); setHist((v) => v + 1);
     setStatus('Undo.');
-  }, [mode, drawPts, resetInteraction, refreshRooms]);
+  }, [drawPts, resetInteraction, refreshRooms]);
 
   const redo = useCallback(() => {
     // While drawing, Redo re-adds the last point Undo removed.
-    if (mode === 'draw' && drawRedoRef.current.length > 0) {
+    if (drawRedoRef.current.length > 0) {
       const pt = drawRedoRef.current.pop()!;
       setDrawPts((p) => [...p, pt]);
       setStatus('Re-added point.');
@@ -377,7 +375,7 @@ export function SpaceSketchOverlay() {
     plateRef.current = redoRef.current.pop()!;
     resetInteraction(); refreshRooms(); setHist((v) => v + 1);
     setStatus('Redo.');
-  }, [mode, resetInteraction, refreshRooms]);
+  }, [resetInteraction, refreshRooms]);
 
   // Ctrl/Cmd+Z (Shift = redo) must drive THIS overlay's history, not the 3D
   // model behind the panel. The global handler in useKeyboardShortcuts routes
@@ -764,7 +762,7 @@ export function SpaceSketchOverlay() {
   // Single Esc aborts the in-progress operation (in priority order); it does NOT
   // close the panel. Returns true if something was aborted.
   const abortCurrentOp = useCallback((): boolean => {
-    if (mode === 'draw' && (drawPts.length > 0 || drawCursor)) {
+    if (drawPts.length > 0) {
       setDrawPts([]); setDrawCursor(null); drawRedoRef.current = []; setAlignGuides({ vRef: null, hRef: null });
       setStatus('Draw cancelled.');
       return true;
@@ -789,7 +787,7 @@ export function SpaceSketchOverlay() {
       return true;
     }
     return false;
-  }, [mode, drawPts, drawCursor, splitPick, refreshRooms]);
+  }, [drawPts, splitPick, refreshRooms]);
 
   // Esc = abort current op (single) / close panel (double-tap ≤400 ms).
   // Enter (in draw mode) closes the room. Both skip text inputs.
@@ -804,14 +802,14 @@ export function SpaceSketchOverlay() {
         if (abortCurrentOp()) { escTimeRef.current = 0; return; }
         if (now - escTimeRef.current <= 400) { escTimeRef.current = 0; setActiveTool('select'); }
         else { escTimeRef.current = now; setStatus('Press Esc again to close.'); }
-      } else if (e.key === 'Enter' && mode === 'draw' && !inField) {
+      } else if (e.key === 'Enter' && drawPts.length > 0 && !inField) {
         e.preventDefault();
         commitDraw();
       }
     };
     document.addEventListener('keydown', onKey);
     return () => document.removeEventListener('keydown', onKey);
-  }, [abortCurrentOp, commitDraw, mode, setActiveTool]);
+  }, [abortCurrentOp, commitDraw, drawPts.length, setActiveTool]);
 
   const processMove = useCallback(() => {
     rafRef.current = null;
@@ -843,48 +841,60 @@ export function SpaceSketchOverlay() {
       return;
     }
 
-    if (mode === 'merge') {
-      const e = pickEdge(wx, wy);
-      if (e) {
-        const nbr = plate.neighborAcross(e.edge);
-        setHover({ kind: 'edge', edge: e.edge, rooms: [e.face, ...(nbr !== undefined ? [nbr] : [])], a: e.a, b: e.b });
-      } else setHover(null);
-    } else if (mode === 'split') {
+    // Drawing a new room: preview the next corner. Strong osnap (room vertices +
+    // building walls) wins; otherwise align to the drawn corners' axes (so the
+    // closing corner locks under the first), Shift = ortho from the last corner.
+    if (drawPts.length > 0) {
+      const tol = PICK_PX / fitRef.current.scale;
+      const anchor = drawPts[drawPts.length - 1];
+      const snap = snapPoint([wx, wy], { vertices: uniqueVerts(rooms), segments: buildingSegmentsRef.current, tol, ortho: m.shift, anchor });
+      if (snap.kind === 'none') {
+        const al = alignToAxes(snap.pt, drawPts, tol);
+        setDrawCursor(al.pt); setSnapKind('none'); setAlignGuides({ vRef: al.vRef, hRef: al.hRef });
+      } else {
+        setDrawCursor(snap.pt); setSnapKind(snap.kind); setAlignGuides({ vRef: null, hRef: null });
+      }
+      return;
+    }
+
+    // Cutting: first cut point placed → preview the second point.
+    if (splitPick) {
       const t = resolveSplitTarget(wx, wy);
       setSplitHover(t ? t.pos : null);
       setHover(t && t.kind === 'vertex' ? { kind: 'vertex', pos: t.pos } : null);
-    } else if (mode === 'draw') {
-      // Preview the next corner. Strong osnap (room vertices + building walls)
-      // wins; otherwise align to the drawn corners' axes (so the closing corner
-      // locks under the first point, etc.). Shift constrains to ortho from the
-      // previous corner first.
-      const tol = PICK_PX / fitRef.current.scale;
-      const anchor = drawPts.length > 0 ? drawPts[drawPts.length - 1] : null;
-      const snap = snapPoint([wx, wy], {
-        vertices: uniqueVerts(rooms),
-        segments: buildingSegmentsRef.current,
-        tol,
-        ortho: m.shift,
-        anchor,
-      });
-      if (snap.kind === 'none' && drawPts.length > 0) {
-        const al = alignToAxes(snap.pt, drawPts, tol);
-        setDrawCursor(al.pt);
-        setSnapKind('none');
-        setAlignGuides({ vRef: al.vRef, hRef: al.hRef });
-      } else {
-        setDrawCursor(snap.pt);
-        setSnapKind(snap.kind);
-        setAlignGuides({ vRef: null, hRef: null });
-      }
-    } else {
-      const v = pickVertex(wx, wy);
-      const pos = v != null ? nearestVertPos(wx, wy) : null;
-      setHover(v != null && pos ? { kind: 'vertex', pos } : null);
-      // Telegraph the ⌥/Ctrl-click delete on whatever vertex is under the cursor.
-      setDeleteHover(m.del && pos ? pos : null);
+      return;
     }
-  }, [mode, drawPts, rooms, pickEdge, pickVertex, nearestVertPos, resolveSplitTarget, refreshRooms]);
+
+    // Idle hover — context cues by what's under the cursor.
+    const v = pickVertex(wx, wy);
+    if (v != null) {
+      const pos = nearestVertPos(wx, wy);
+      setHover(pos ? { kind: 'vertex', pos } : null);
+      setDeleteHover(m.del && pos ? pos : null); // ⌥ telegraphs node removal
+      setSplitHover(null); setDrawCursor(null); setSnapPos(null); setAlignGuides({ vRef: null, hRef: null });
+      return;
+    }
+    const ed = pickEdge(wx, wy);
+    if (ed != null) {
+      setDeleteHover(null); setDrawCursor(null); setSnapPos(null);
+      if (m.del) {
+        // ⌥ over a wall → merge preview (both rooms if the wall is shared).
+        const nbr = plate.neighborAcross(ed.edge);
+        setHover({ kind: 'edge', edge: ed.edge, rooms: [ed.face, ...(nbr !== undefined ? [nbr] : [])], a: ed.a, b: ed.b });
+        setSplitHover(null);
+      } else {
+        // plain → cut cue ("+") at the projected point on the wall.
+        setHover(null);
+        setSplitHover(projectOnSeg([wx, wy], ed.a, ed.b));
+      }
+      return;
+    }
+    // Empty space → preview where a new room's first corner would drop.
+    setHover(null); setDeleteHover(null); setSplitHover(null);
+    const tol = PICK_PX / fitRef.current.scale;
+    const snap = snapPoint([wx, wy], { vertices: uniqueVerts(rooms), segments: buildingSegmentsRef.current, tol });
+    setDrawCursor(snap.pt); setSnapKind(snap.kind); setAlignGuides({ vRef: null, hRef: null });
+  }, [drawPts, splitPick, rooms, pickEdge, pickVertex, nearestVertPos, resolveSplitTarget, refreshRooms]);
 
   const onPointerMove = useCallback((e: React.PointerEvent) => {
     if (panningRef.current) {
@@ -910,34 +920,52 @@ export function SpaceSketchOverlay() {
     }
     const [sx, sy] = svgPoint(e);
     const wx = wX(fitRef.current, sx), wy = wY(fitRef.current, sy);
+    const mod = e.altKey || e.ctrlKey || e.metaKey; // ⌥/Ctrl = dissolve
+    const tol = PICK_PX / fitRef.current.scale;
 
-    if (mode === 'drag') {
-      const v = pickVertex(wx, wy);
-      if (v == null) {
-        // Empty space in drag mode → pan the view (Issue 4).
-        panningRef.current = true;
-        svgRef.current?.setPointerCapture(e.pointerId);
-        return;
+    // 1. Drawing in progress → add a corner (or close on the first dot).
+    if (drawPts.length > 0) {
+      const anchor = drawPts[drawPts.length - 1];
+      const snap = snapPoint([wx, wy], { vertices: uniqueVerts(rooms), segments: buildingSegmentsRef.current, tol, ortho: e.shiftKey, anchor });
+      const p = snap.kind === 'none' ? alignToAxes(snap.pt, drawPts, tol).pt : snap.pt;
+      setAlignGuides({ vRef: null, hRef: null });
+      if (drawPts.length >= 3) {
+        const first = drawPts[0];
+        if (Math.hypot(p[0] - first[0], p[1] - first[1]) <= tol) { commitDraw(); return; }
       }
-      // ⌥/Ctrl-click dissolves a degree-2 node — the inverse of split (Issue 3).
-      if (e.altKey || e.ctrlKey || e.metaKey) {
+      drawRedoRef.current = [];
+      setDrawPts((pts) => [...pts, p]);
+      setStatus(`Drawing — ${drawPts.length + 1} pt(s) · Enter / double-click / first dot to close · Shift = straight · Ctrl+Z removes last.`);
+      return;
+    }
+
+    // 2. Cutting in progress → place the second cut point and split.
+    if (splitPick) {
+      const target = resolveSplitTarget(wx, wy);
+      if (!target) { setStatus('Click another wall (or corner) on the same room to finish the cut.'); return; }
+      const first = splitPick;
+      setSplitPick(null); setSplitHover(null);
+      performSplit(first, target);
+      return;
+    }
+
+    // 3. Over a node → ⌥ removes it, else drag it.
+    const v = pickVertex(wx, wy);
+    if (v != null) {
+      if (mod) {
         const snap = plate.duplicate();
         try {
           plate.dissolveVertex(v);
           commitUndo(snap); refreshRooms(); setHover(null); setDeleteHover(null);
           setStatus(`Removed vertex — ${plate.roomCount} room(s).`);
         } catch (err) {
-          plate.free();
-          plateRef.current = snap;
-          refreshRooms();
+          plate.free(); plateRef.current = snap; refreshRooms();
           setStatus(`Can't remove vertex: ${String(err).replace(/^\w+:\s*/, '')}`);
         }
         return;
       }
       const start = nearestVertPos(wx, wy);
-      dragRef.current = v;
-      dragStartRef.current = start;
-      draggedRef.current = false;
+      dragRef.current = v; dragStartRef.current = start; draggedRef.current = false;
       pendingUndoRef.current = plate.duplicate();
       otherVertsRef.current = start
         ? uniqueVerts(rooms).filter((p) => Math.hypot(p[0] - start[0], p[1] - start[1]) > 1e-6)
@@ -945,61 +973,36 @@ export function SpaceSketchOverlay() {
       svgRef.current?.setPointerCapture(e.pointerId);
       return;
     }
-    if (mode === 'merge') {
-      const hit = pickEdge(wx, wy);
-      if (!hit) { setStatus('No edge under cursor.'); return; }
-      const snap = plate.duplicate();
-      try {
-        plate.mergeFaces(hit.edge);
-        commitUndo(snap); refreshRooms(); setHover(null);
-        setStatus(`Merged across wall — ${plate.roomCount} room(s) left.`);
-      } catch (err) {
-        // Roll back to the pre-merge snapshot (mirror performSplit) in case
-        // mergeFaces mutated before throwing.
-        plate.free();
-        plateRef.current = snap;
-        refreshRooms();
-        setStatus(`Merge rejected: ${String(err).replace(/^Error:\s*/, '')}`);
-      }
-      return;
-    }
-    if (mode === 'split') {
-      const target = resolveSplitTarget(wx, wy);
-      if (!target) { setStatus('Click a corner or anywhere on a wall.'); return; }
-      if (!splitPick) { setSplitPick(target); setStatus('Pick the second point (corner or wall) on the same room.'); return; }
-      const first = splitPick;
-      setSplitPick(null);
-      performSplit(first, target);
-      return;
-    }
-    if (mode === 'draw') {
-      // Snap the dropped corner: strong osnap (room vertices + building walls)
-      // wins; otherwise align to the drawn corners' axes. Shift = ortho from the
-      // previous corner first. Mirrors the preview in processMove.
-      const tol = PICK_PX / fitRef.current.scale;
-      const anchor = drawPts.length > 0 ? drawPts[drawPts.length - 1] : null;
-      const snap = snapPoint([wx, wy], {
-        vertices: uniqueVerts(rooms),
-        segments: buildingSegmentsRef.current,
-        tol,
-        ortho: e.shiftKey,
-        anchor,
-      });
-      const p = snap.kind === 'none' && drawPts.length > 0 ? alignToAxes(snap.pt, drawPts, tol).pt : snap.pt;
-      setAlignGuides({ vRef: null, hRef: null });
-      // With ≥3 points placed, clicking the first dot closes the loop.
-      if (drawPts.length >= 3) {
-        const first = drawPts[0];
-        if (Math.hypot(p[0] - first[0], p[1] - first[1]) <= PICK_PX / fitRef.current.scale) {
-          commitDraw();
-          return;
+
+    // 4. Over a wall → ⌥ merges across it, else start a cut (first point).
+    const ed = pickEdge(wx, wy);
+    if (ed != null) {
+      if (mod) {
+        const snap = plate.duplicate();
+        try {
+          plate.mergeFaces(ed.edge);
+          commitUndo(snap); refreshRooms(); setHover(null);
+          setStatus(`Merged across wall — ${plate.roomCount} room(s) left.`);
+        } catch (err) {
+          plate.free(); plateRef.current = snap; refreshRooms();
+          setStatus(`Merge rejected: ${String(err).replace(/^Error:\s*/, '')}`);
         }
+        return;
       }
-      drawRedoRef.current = []; // a new point invalidates the point-redo stack
-      setDrawPts((pts) => [...pts, p]);
-      setStatus(`Drawing — ${drawPts.length + 1} pt(s) · Enter / double-click / first dot to close · Shift = straight · Ctrl+Z removes last.`);
+      const target = resolveSplitTarget(wx, wy);
+      if (target) {
+        setSplitPick(target); setSplitHover(target.pos);
+        setStatus('Cut started — click another wall (or corner) on the same room to finish.');
+      }
+      return;
     }
-  }, [mode, pickVertex, nearestVertPos, pickEdge, rooms, splitPick, resolveSplitTarget, performSplit, commitUndo, refreshRooms, drawPts, commitDraw]);
+
+    // 5. Empty space → start drawing a new room.
+    const snap = snapPoint([wx, wy], { vertices: uniqueVerts(rooms), segments: buildingSegmentsRef.current, tol });
+    drawRedoRef.current = [];
+    setDrawPts([snap.pt]);
+    setStatus('Drawing — click to add corners · Enter / double-click / first dot to close · Shift = straight.');
+  }, [drawPts, splitPick, pickVertex, nearestVertPos, pickEdge, rooms, resolveSplitTarget, performSplit, commitUndo, refreshRooms, commitDraw]);
 
   const endDrag = useCallback((e: React.PointerEvent) => {
     if (panningRef.current) {
@@ -1021,10 +1024,10 @@ export function SpaceSketchOverlay() {
   const total = rooms.reduce((s, r) => s + r.area, 0);
   const mergeRooms = hover?.kind === 'edge' ? new Set(hover.rooms) : null;
   const cursorWorld = moveRef.current ? [wX(f, moveRef.current.x), wY(f, moveRef.current.y)] as Pt : null;
-  const cursor = panningRef.current || dragRef.current != null ? 'grabbing' : (mode === 'drag' && hover?.kind === 'vertex') ? 'grab' : 'crosshair';
+  const cursor = panningRef.current || dragRef.current != null ? 'grabbing' : hover?.kind === 'vertex' ? 'grab' : 'crosshair';
   // During a draw, Undo/Redo act on the placed points (not the plate stack).
-  const canUndo = (mode === 'draw' && drawPts.length > 0) || undoRef.current.length > 0;
-  const canRedo = (mode === 'draw' && drawRedoRef.current.length > 0) || redoRef.current.length > 0;
+  const canUndo = drawPts.length > 0 || undoRef.current.length > 0;
+  const canRedo = drawRedoRef.current.length > 0 || redoRef.current.length > 0;
   void hist; void fitTick;
 
   const gridStep = f.scale > 14 ? 1 : f.scale > 5 ? 2 : 5;
@@ -1106,17 +1109,9 @@ export function SpaceSketchOverlay() {
           title="Create IfcSpace for every storey at once — auto floor-to-floor height, skips rooms that already have a space">Generate all</button>
       </div>
 
-      {/* Edit: mode + history */}
+      {/* History + snap. The tool is modeless — what happens is driven by what's
+          under the cursor (node / wall / empty), so there are no mode tabs. */}
       <div className="flex items-center gap-1.5 mb-2">
-        <div className="inline-flex rounded-md border p-0.5">
-          {(['drag', 'split', 'merge', 'draw'] as Mode[]).map((m) => (
-            <button key={m}
-              className={`rounded px-2 py-0.5 text-xs capitalize transition-colors ${mode === m ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'}`}
-              onClick={() => { setMode(m); setSplitPick(null); setSplitHover(null); setHover(null); setDeleteHover(null); setDrawPts([]); setDrawCursor(null); drawRedoRef.current = []; setAlignGuides({ vRef: null, hRef: null }); }}
-              title={m === 'draw' ? 'Author a new room by clicking its corners' : `Edit derived rooms (${m})`}
-              disabled={m === 'draw' ? derivedStorey == null : !rooms.length}>{m}</button>
-          ))}
-        </div>
         <button className={iconBtn} onClick={undo} disabled={!canUndo} title="Undo (Ctrl+Z)"><Undo2 className="h-4 w-4" /></button>
         <button className={iconBtn} onClick={redo} disabled={!canRedo} title="Redo (Ctrl+Shift+Z)"><Redo2 className="h-4 w-4" /></button>
         <button
@@ -1127,13 +1122,10 @@ export function SpaceSketchOverlay() {
         ><Magnet className="h-4 w-4" /></button>
       </div>
 
-      {/* Draw-room hint (Issue 2) — point placement uses the panel Undo/Redo and
-          Esc; no separate draw buttons. Only while authoring a new room. */}
-      {mode === 'draw' && (
+      {/* While drawing a room, the point-placement hint. */}
+      {drawPts.length > 0 && (
         <div className="mb-2 text-[11px] text-muted-foreground leading-tight">
-          {drawPts.length === 0
-            ? 'Click to drop the first corner. Shift = straight · snaps to walls.'
-            : `${drawPts.length} pt(s) · Enter, double-click, or click the first dot to close · Esc cancels · Ctrl+Z removes last · Shift = straight.`}
+          {`${drawPts.length} pt(s) · Enter, double-click, or click the first dot to close · Esc cancels · Ctrl+Z removes last · Shift = straight.`}
         </div>
       )}
 
@@ -1187,7 +1179,7 @@ export function SpaceSketchOverlay() {
       <svg ref={svgRef} width={size.w} height={size.h} style={{ cursor }}
         className="rounded border bg-muted/20 touch-none"
         onPointerDown={onPointerDown} onPointerMove={onPointerMove} onPointerUp={endDrag}
-        onDoubleClick={() => { if (mode === 'draw') commitDraw(); }}
+        onDoubleClick={() => { if (drawPts.length > 0) commitDraw(); }}
         onContextMenu={(e) => e.preventDefault()}
         onPointerLeave={() => { setHover(null); setSplitHover(null); setDeleteHover(null); setDrawCursor(null); setAlignGuides({ vRef: null, hRef: null }); }}>
         {gridLines.map((l, i) => <line key={`g${i}`} {...l} stroke="currentColor" strokeOpacity={0.06} strokeWidth={1} />)}
@@ -1236,9 +1228,14 @@ export function SpaceSketchOverlay() {
           <line x1={sX(f, splitPick.pos[0])} y1={sY(f, splitPick.pos[1])} x2={sX(f, previewEnd[0])} y2={sY(f, previewEnd[1])}
             stroke="#3b82f6" strokeWidth={1.5} strokeDasharray="5 4" />
         )}
-        {/* split candidate node (corner or new node on a wall) */}
-        {mode === 'split' && splitHover && (
-          <circle cx={sX(f, splitHover[0])} cy={sY(f, splitHover[1])} r={5} fill="#3b82f6" fillOpacity={0.5} stroke="#3b82f6" strokeWidth={1.5} pointerEvents="none" />
+        {/* Cut/insert cue on a wall — the "+" handle that telegraphs "click to
+            place a cut point here" (and previews the second cut point). */}
+        {splitHover && (
+          <g pointerEvents="none">
+            <circle cx={sX(f, splitHover[0])} cy={sY(f, splitHover[1])} r={6} fill="#3b82f6" fillOpacity={0.15} stroke="#3b82f6" strokeWidth={1.5} />
+            <line x1={sX(f, splitHover[0]) - 3} y1={sY(f, splitHover[1])} x2={sX(f, splitHover[0]) + 3} y2={sY(f, splitHover[1])} stroke="#3b82f6" strokeWidth={1.5} />
+            <line x1={sX(f, splitHover[0])} y1={sY(f, splitHover[1]) - 3} x2={sX(f, splitHover[0])} y2={sY(f, splitHover[1]) + 3} stroke="#3b82f6" strokeWidth={1.5} />
+          </g>
         )}
         {/* first committed split pick */}
         {splitPick && (
@@ -1260,7 +1257,7 @@ export function SpaceSketchOverlay() {
 
         {/* First-corner preview: before any point is placed, show where the
             click will land + the snap cue, so the snap is visible up front. */}
-        {mode === 'draw' && drawPts.length === 0 && drawCursor && (
+        {drawPts.length === 0 && drawCursor && (
           <g pointerEvents="none">
             {snapKind === 'line' && (
               <rect x={sX(f, drawCursor[0]) - 5} y={sY(f, drawCursor[1]) - 5} width={10} height={10} fill="none"
@@ -1274,7 +1271,7 @@ export function SpaceSketchOverlay() {
         )}
 
         {/* Draw-room in progress (Issue 2): placed points, rubber band, close hint. */}
-        {mode === 'draw' && drawPts.length > 0 && (
+        {drawPts.length > 0 && (
           <g pointerEvents="none">
             {/* Alignment guides — the dashed lines that telegraph "this corner
                 is lined up with that earlier corner" (e.g. under the first). */}
@@ -1334,11 +1331,12 @@ export function SpaceSketchOverlay() {
         </div>
       </div>
       <div className="mt-1.5 text-[11px] text-muted-foreground">
-        {!rooms.length && mode !== 'draw' && 'Pick a storey to derive its rooms, “Generate all” for the building, or “draw” a room by hand.'}
-        {!!rooms.length && mode === 'drag' && 'Drag a vertex — shared vertices move both rooms; snaps to corners + walls, Shift = straight. ⌥/Ctrl-click a node to remove it.'}
-        {!!rooms.length && mode === 'split' && 'Click two points — corners or anywhere on a wall (new nodes added as needed).'}
-        {!!rooms.length && mode === 'merge' && 'Hover highlights the wall + both rooms; click to merge them.'}
-        {mode === 'draw' && 'Click corners (snap to walls; Shift = straight). Enter, double-click, or click the first dot to close. Esc cancels; Ctrl+Z removes the last point. Standalone room — won’t merge into existing walls.'}
+        {!rooms.length && drawPts.length === 0 && 'Pick a storey to derive its rooms, “Generate all” for the building, or click empty space to draw a room by hand.'}
+        {drawPts.length > 0
+          ? 'Click corners (snap to walls + earlier corners; Shift = straight). Enter, double-click, or click the first dot to close. Esc cancels; Ctrl+Z removes the last point.'
+          : splitPick
+            ? 'Click another wall (or corner) on the same room to finish the cut. Esc cancels.'
+            : 'Drag a node to move it · click a wall then another to split · ⌥-click a wall to merge · click empty space to draw a room · ⌥-click a node to remove it.'}
         {unboundedCount > 0 && (
           <span className="text-amber-600 dark:text-amber-500"> · {unboundedCount} room(s) unchanged by {boundaryMode} (dashed) — no wall offset.</span>
         )}

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -1258,6 +1258,21 @@ export function SpaceSketchOverlay() {
           </g>
         )}
 
+        {/* First-corner preview: before any point is placed, show where the
+            click will land + the snap cue, so the snap is visible up front. */}
+        {mode === 'draw' && drawPts.length === 0 && drawCursor && (
+          <g pointerEvents="none">
+            {snapKind === 'line' && (
+              <rect x={sX(f, drawCursor[0]) - 5} y={sY(f, drawCursor[1]) - 5} width={10} height={10} fill="none"
+                stroke="#f59e0b" strokeWidth={1.5} transform={`rotate(45 ${sX(f, drawCursor[0])} ${sY(f, drawCursor[1])})`} />
+            )}
+            {snapKind === 'vertex' && (
+              <circle cx={sX(f, drawCursor[0])} cy={sY(f, drawCursor[1])} r={7} fill="none" stroke="#22c55e" strokeWidth={1.5} />
+            )}
+            <circle cx={sX(f, drawCursor[0])} cy={sY(f, drawCursor[1])} r={4} fill="#22c55e" stroke="#16a34a" strokeWidth={1.5} />
+          </g>
+        )}
+
         {/* Draw-room in progress (Issue 2): placed points, rubber band, close hint. */}
         {mode === 'draw' && drawPts.length > 0 && (
           <g pointerEvents="none">

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -55,6 +55,11 @@ const PICK_PX = 12;
 const SNAP_PX = 10;
 const BAKE_HEIGHT = 3;
 const EPS = 1e-6;
+// Assumed wall thickness (m) for the Inner/Outer boundary offset when a wall
+// carries no resolvable material-layer thickness — so the net/gross face works
+// on every model, not just ones with full material data. Real layer thickness
+// is used whenever it's available.
+const DEFAULT_WALL_THICKNESS = 0.2;
 
 export function SpaceSketchOverlay() {
   const setActiveTool = useViewerStore((s) => s.setActiveTool);
@@ -401,7 +406,7 @@ export function SpaceSketchOverlay() {
         coords[i * 4] = s.a[0]; coords[i * 4 + 1] = s.a[1];
         coords[i * 4 + 2] = s.b[0]; coords[i * 4 + 3] = s.b[1];
         const t = wallThicknesses[i];
-        half[i] = t && t > 0 ? t / 2 : 0;
+        half[i] = (t && t > 0 ? t : DEFAULT_WALL_THICKNESS) / 2;
       });
       const name = ifcDataStore.entities.getName(storeyId) || `Storey #${storeyId}`;
       await buildFrom(coords, sources, half, name, storeyId);
@@ -518,7 +523,7 @@ export function SpaceSketchOverlay() {
       segments.forEach((s, i) => {
         coords[i * 4] = s.a[0]; coords[i * 4 + 1] = s.a[1]; coords[i * 4 + 2] = s.b[0]; coords[i * 4 + 3] = s.b[1];
         const t = wallThicknesses[i];
-        half[i] = t && t > 0 ? t / 2 : 0;
+        half[i] = (t && t > 0 ? t : DEFAULT_WALL_THICKNESS) / 2;
       });
       // Throwaway plate per storey (escalation + deterministic free handled by
       // the session module) — this path doesn't touch the live session. Reads
@@ -1226,7 +1231,7 @@ export function SpaceSketchOverlay() {
         drawCursor={drawCursor}
         alignGuides={alignGuides}
         deleteHover={deleteHover}
-        intent={intent}
+        intent={optionsOpen || helpOpen || confirmClose ? null : intent}
         onPointerDown={onPointerDown}
         onPointerMove={onPointerMove}
         onPointerUp={endDrag}

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -23,6 +23,7 @@ import { useViewerStore } from '@/store';
 import { useConstructionUnderlay } from '@/hooks/useConstructionUnderlay';
 import { useIfc } from '@/hooks/useIfc';
 import { snapPoint, alignToAxes, type SnapKind } from '@/lib/space-snap';
+import { editError } from '@/lib/space-edit-error';
 import init, { SpacePlateHandle } from '@ifc-lite/wasm';
 import {
   extractWallSegmentsForStorey,
@@ -756,7 +757,7 @@ export function SpaceSketchOverlay() {
       plate.free();
       plateRef.current = snapshot; // roll back inserted nodes + partial cut
       refreshRooms();
-      setStatus(`Split rejected: ${String(err).replace(/^Error:\s*/, '')}`);
+      setStatus(`Split rejected: ${editError(err).message}`);
       return;
     }
     commitUndo(snapshot);
@@ -788,7 +789,7 @@ export function SpaceSketchOverlay() {
       plate.free();
       plateRef.current = snap;
       refreshRooms();
-      setStatus(`Draw rejected: ${String(err).replace(/^\w+:\s*/, '')}`);
+      setStatus(`Draw rejected: ${editError(err).message}`);
     }
   }, [drawPts, commitUndo, refreshRooms]);
 
@@ -872,7 +873,7 @@ export function SpaceSketchOverlay() {
       removed = plate.prune();
     } catch (err) {
       plate.free(); plateRef.current = snap; refreshRooms();
-      setStatus(`Cleanup failed: ${String(err).replace(/^\w+:\s*/, '')}`);
+      setStatus(`Cleanup failed: ${editError(err).message}`);
       return;
     }
     if (removed > 0) {
@@ -1031,7 +1032,7 @@ export function SpaceSketchOverlay() {
       let reason = '';
       try { plate.dissolveVertex(v); ok = true; setStatus(`Removed node — ${plate.roomCount} room(s).`); }
       catch (err) {
-        reason = String(err).replace(/^\w+:\s*/, '');
+        reason = editError(err).message;
         // The node won't straighten away (it's a wall junction). Remove one of
         // its incident walls instead: `removeEdge` unions two real rooms, or
         // deletes a bridge/spur wall and auto-cleans the orphaned inner lines
@@ -1077,7 +1078,7 @@ export function SpaceSketchOverlay() {
         setStatus(`Removed wall — ${plate.roomCount} room(s) left.`);
       } catch (err) {
         plate.free(); plateRef.current = snap; refreshRooms();
-        setStatus(`Can't remove this wall: ${String(err).replace(/^\w+:\s*/, '')}`);
+        setStatus(`Can't remove this wall: ${editError(err).message}`);
       }
       return true;
     }
@@ -1176,7 +1177,7 @@ export function SpaceSketchOverlay() {
         setStatus('Node added — click another wall or corner to split between them, or Esc to keep the node.');
       } catch (err) {
         plate.free(); plateRef.current = snap; refreshRooms();
-        setStatus(`Can't add node here: ${String(err).replace(/^\w+:\s*/, '')}`);
+        setStatus(`Can't add node here: ${editError(err).message}`);
       }
       return;
     }

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -24,6 +24,7 @@ import { useConstructionUnderlay } from '@/hooks/useConstructionUnderlay';
 import { useIfc } from '@/hooks/useIfc';
 import { snapPoint, alignToAxes, type SnapKind } from '@/lib/space-snap';
 import { editError } from '@/lib/space-edit-error';
+import { pointerButton, isRemoveModifier } from '@/lib/space-interaction';
 import {
   SpacePlateSession,
   ensureSpaceWasm,
@@ -825,7 +826,7 @@ export function SpaceSketchOverlay() {
       return;
     }
     const [x, y] = svgPoint(e);
-    moveRef.current = { x, y, shift: e.shiftKey, del: e.ctrlKey || e.altKey || e.metaKey };
+    moveRef.current = { x, y, shift: e.shiftKey, del: isRemoveModifier(e) };
     if (rafRef.current == null) rafRef.current = requestAnimationFrame(processMove);
   }, [processMove]);
 
@@ -837,7 +838,7 @@ export function SpaceSketchOverlay() {
       if (e.key !== 'Alt' && e.key !== 'Control' && e.key !== 'Meta' && e.key !== 'Shift') return;
       const m = moveRef.current;
       if (!m || dragRef.current != null || panningRef.current) return;
-      m.del = e.altKey || e.ctrlKey || e.metaKey;
+      m.del = isRemoveModifier(e);
       m.shift = e.shiftKey;
       if (rafRef.current == null) rafRef.current = requestAnimationFrame(processMove);
     };
@@ -929,7 +930,7 @@ export function SpaceSketchOverlay() {
     const session = sessionRef.current;
     if (!session?.alive) return;
     // Middle-mouse drag pans the view in any mode (Issue 4).
-    if (e.button === 1) {
+    if (pointerButton(e) === 'middle') {
       panningRef.current = true;
       svgRef.current?.setPointerCapture(e.pointerId);
       return;
@@ -937,12 +938,12 @@ export function SpaceSketchOverlay() {
     // Right-click (incl. macOS Ctrl-click) is the remove gesture — handled in
     // onContextMenu so it fires reliably; ignore it here so a secondary-button
     // press never starts a drag / cut / draw.
-    if (e.button === 2) return;
+    if (pointerButton(e) === 'secondary') return;
     const [sx, sy] = svgPoint(e);
     const wx = wX(fitRef.current, sx), wy = wY(fitRef.current, sy);
     // Dissolve/merge intent on a left-click held with a modifier (Win/Linux
     // Ctrl, macOS Alt/Cmd; macOS Ctrl-click arrives via onContextMenu instead).
-    const mod = e.altKey || e.ctrlKey || e.metaKey;
+    const mod = isRemoveModifier(e);
     const tol = PICK_PX / fitRef.current.scale;
 
     // 1. Drawing in progress → add a corner (or close on the first dot).

--- a/apps/viewer/src/components/viewer/tools/space-sketch/SpaceSketchCanvas.tsx
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/SpaceSketchCanvas.tsx
@@ -1,0 +1,238 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The Space Sketch SVG canvas — the presentational layer. Pure render: it draws
+ * the grid, building underlay, rooms (at the chosen boundary), leak diagnostics,
+ * and all the live interaction cues (hover, cut rubber-band, snap rings, draw
+ * preview, delete telegraph), plus the action-intent chip. All interaction
+ * logic lives in the overlay controller; this component only receives state and
+ * forwards pointer events.
+ */
+
+import type { Room } from '@/lib/space-plate-session';
+import { sX, sY, centroid, polyArea, uniqueVerts, type Fit, type Pt } from '@/lib/space-sketch-geometry';
+import type { SnapKind } from '@/lib/space-snap';
+import type { BoundaryMode } from '@ifc-lite/create';
+import type { Hover, SplitTarget, Intent, IntentTone } from './types';
+
+const EPS = 1e-6;
+const ROOM_COLORS = ['#6366f1', '#10b981', '#f59e0b', '#ec4899', '#06b6d4', '#84cc16', '#a855f7', '#ef4444'];
+
+const INTENT_TEXT_CLASS: Record<IntentTone, string> = {
+  move: 'text-foreground',
+  draw: 'text-emerald-600 dark:text-emerald-400',
+  cut: 'text-blue-600 dark:text-blue-400',
+  remove: 'text-red-600 dark:text-red-400',
+  pan: 'text-muted-foreground',
+};
+const INTENT_DOT_CLASS: Record<IntentTone, string> = {
+  move: 'bg-zinc-400',
+  draw: 'bg-emerald-500',
+  cut: 'bg-blue-500',
+  remove: 'bg-red-500',
+  pan: 'bg-zinc-400',
+};
+
+interface GridLine { x1: number; y1: number; x2: number; y2: number }
+interface BoundaryInfo { disp: Pt[]; unbounded: boolean }
+interface Diagnostic { a: Pt; b: Pt; bounding: boolean }
+
+export interface SpaceSketchCanvasProps {
+  svgRef: React.RefObject<SVGSVGElement | null>;
+  width: number;
+  height: number;
+  cursor: string;
+  fit: Fit;
+  gridLines: GridLine[];
+  underlay: React.ReactNode;
+  rooms: Room[];
+  boundaryInfo: BoundaryInfo[];
+  boundaryMode: BoundaryMode;
+  mergeFaces: Set<number> | null;
+  diagnostics: Diagnostic[] | null;
+  hover: Hover;
+  splitPick: SplitTarget | null;
+  previewEnd: Pt | null;
+  splitHover: Pt | null;
+  snapPos: Pt | null;
+  snapKind: SnapKind;
+  drawPts: Pt[];
+  drawCursor: Pt | null;
+  alignGuides: { vRef: Pt | null; hRef: Pt | null };
+  deleteHover: Pt | null;
+  intent: Intent | null;
+  onPointerDown: (e: React.PointerEvent) => void;
+  onPointerMove: (e: React.PointerEvent) => void;
+  onPointerUp: (e: React.PointerEvent) => void;
+  onDoubleClick: () => void;
+  onContextMenu: (e: React.MouseEvent) => void;
+  onPointerLeave: () => void;
+}
+
+export function SpaceSketchCanvas(props: SpaceSketchCanvasProps) {
+  const {
+    svgRef, width, height, cursor, fit: f, gridLines, underlay, rooms, boundaryInfo,
+    boundaryMode, mergeFaces, diagnostics, hover, splitPick, previewEnd, splitHover,
+    snapPos, snapKind, drawPts, drawCursor, alignGuides, deleteHover, intent,
+    onPointerDown, onPointerMove, onPointerUp, onDoubleClick, onContextMenu, onPointerLeave,
+  } = props;
+
+  return (
+    <div className="relative">
+      {/* Live action preview — tells you what the next click will do, colour-keyed
+          to the on-canvas cues (green draw · blue cut · red remove/merge). */}
+      {intent && (
+        <div className="pointer-events-none absolute right-2 top-2 z-20 flex items-center gap-1.5 rounded-md border bg-background/85 px-2 py-1 text-[11px] font-semibold shadow-sm backdrop-blur">
+          <span className={`h-1.5 w-1.5 rounded-full ${INTENT_DOT_CLASS[intent.tone]}`} />
+          <span className={INTENT_TEXT_CLASS[intent.tone]}>{intent.text}</span>
+        </div>
+      )}
+      <svg ref={svgRef} width={width} height={height} style={{ cursor }}
+        className="rounded border bg-muted/20 touch-none"
+        onPointerDown={onPointerDown} onPointerMove={onPointerMove} onPointerUp={onPointerUp}
+        onDoubleClick={onDoubleClick}
+        onContextMenu={onContextMenu}
+        onPointerLeave={onPointerLeave}>
+        {gridLines.map((l, i) => <line key={`g${i}`} {...l} stroke="currentColor" strokeOpacity={0.06} strokeWidth={1} />)}
+
+        {/* Building-element underlay (plan cut ~1.2 m above the storey) for orientation. */}
+        {underlay}
+
+        {rooms.map((r, ri) => {
+          const color = ROOM_COLORS[ri % ROOM_COLORS.length];
+          const { disp, unbounded } = boundaryInfo[ri];
+          const pts = disp.map((p) => `${sX(f, p[0])},${sY(f, p[1])}`).join(' ');
+          const [cwx, cwy] = centroid(disp);
+          const cx = sX(f, cwx), cy = sY(f, cwy);
+          const lit = mergeFaces?.has(r.face);
+          const bad = !r.simple;
+          const area = boundaryMode === 'center' ? r.area : polyArea(disp);
+          return (
+            <g key={r.face}>
+              {boundaryMode !== 'center' && (
+                <polygon points={r.outline.map((p) => `${sX(f, p[0])},${sY(f, p[1])}`).join(' ')}
+                  fill="none" stroke={color} strokeOpacity={0.25} strokeDasharray="3 3" strokeWidth={1} />
+              )}
+              <polygon points={pts} fill={bad ? '#ef4444' : color} fillOpacity={lit ? 0.42 : bad ? 0.3 : 0.16}
+                stroke={bad ? '#ef4444' : color} strokeWidth={lit ? 3 : 2}
+                strokeDasharray={unbounded && !bad ? '5 4' : undefined}>
+                {unbounded && <title>Boundary “{boundaryMode}” made no change to this room — no wall offset applies (no wall runs along its edges, or it's fully internal in Outer mode).</title>}
+              </polygon>
+              <text x={cx} y={cy - 5} textAnchor="middle" fontSize={12} fontWeight={600} fill="currentColor" className="pointer-events-none">{area.toFixed(2)}</text>
+              <text x={cx} y={cy + 9} textAnchor="middle" fontSize={9} fill="currentColor" opacity={0.55} className="pointer-events-none">m²</text>
+            </g>
+          );
+        })}
+
+        {/* Issue 7 — leak diagnostics: walls that bound a room (green) vs walls
+            that bound nothing (red dashed = a stray segment / leak suspect). */}
+        {diagnostics && diagnostics.map((s, i) => (
+          <line key={`dg${i}`} x1={sX(f, s.a[0])} y1={sY(f, s.a[1])} x2={sX(f, s.b[0])} y2={sY(f, s.b[1])}
+            stroke={s.bounding ? '#22c55e' : '#ef4444'} strokeOpacity={s.bounding ? 0.45 : 0.95}
+            strokeWidth={s.bounding ? 1.2 : 2.2} strokeDasharray={s.bounding ? undefined : '4 3'} pointerEvents="none" />
+        ))}
+
+        {hover?.kind === 'edge' && (
+          <line x1={sX(f, hover.a[0])} y1={sY(f, hover.a[1])} x2={sX(f, hover.b[0])} y2={sY(f, hover.b[1])} stroke="#ef4444" strokeWidth={4} strokeLinecap="round" />
+        )}
+        {splitPick && previewEnd && (
+          <line x1={sX(f, splitPick.pos[0])} y1={sY(f, splitPick.pos[1])} x2={sX(f, previewEnd[0])} y2={sY(f, previewEnd[1])}
+            stroke="#3b82f6" strokeWidth={1.5} strokeDasharray="5 4" />
+        )}
+        {/* Cut/insert cue on a wall — the "+" handle that telegraphs "click to
+            place a cut point here" (and previews the second cut point). */}
+        {splitHover && (
+          <g pointerEvents="none">
+            <circle cx={sX(f, splitHover[0])} cy={sY(f, splitHover[1])} r={6} fill="#3b82f6" fillOpacity={0.15} stroke="#3b82f6" strokeWidth={1.5} />
+            <line x1={sX(f, splitHover[0]) - 3} y1={sY(f, splitHover[1])} x2={sX(f, splitHover[0]) + 3} y2={sY(f, splitHover[1])} stroke="#3b82f6" strokeWidth={1.5} />
+            <line x1={sX(f, splitHover[0])} y1={sY(f, splitHover[1]) - 3} x2={sX(f, splitHover[0])} y2={sY(f, splitHover[1]) + 3} stroke="#3b82f6" strokeWidth={1.5} />
+          </g>
+        )}
+        {/* first committed split pick */}
+        {splitPick && (
+          <circle cx={sX(f, splitPick.pos[0])} cy={sY(f, splitPick.pos[1])} r={5} fill="#3b82f6" stroke="#fff" strokeWidth={1.5} pointerEvents="none" />
+        )}
+        {snapPos && (
+          <g pointerEvents="none">
+            {snapKind === 'line' ? (
+              // On-wall snap — amber diamond.
+              <rect x={sX(f, snapPos[0]) - 5} y={sY(f, snapPos[1]) - 5} width={10} height={10} fill="none"
+                stroke="#f59e0b" strokeWidth={1.5} transform={`rotate(45 ${sX(f, snapPos[0])} ${sY(f, snapPos[1])})`} />
+            ) : (
+              // Corner/vertex snap — green ring.
+              <circle cx={sX(f, snapPos[0])} cy={sY(f, snapPos[1])} r={9} fill="none" stroke="#22c55e" strokeWidth={1.5} />
+            )}
+            <circle cx={sX(f, snapPos[0])} cy={sY(f, snapPos[1])} r={2.5} fill={snapKind === 'line' ? '#f59e0b' : '#22c55e'} />
+          </g>
+        )}
+
+        {/* First-corner preview: before any point is placed, show where the
+            click will land + the snap cue, so the snap is visible up front. */}
+        {drawPts.length === 0 && drawCursor && (
+          <g pointerEvents="none">
+            {snapKind === 'line' && (
+              <rect x={sX(f, drawCursor[0]) - 5} y={sY(f, drawCursor[1]) - 5} width={10} height={10} fill="none"
+                stroke="#f59e0b" strokeWidth={1.5} transform={`rotate(45 ${sX(f, drawCursor[0])} ${sY(f, drawCursor[1])})`} />
+            )}
+            {snapKind === 'vertex' && (
+              <circle cx={sX(f, drawCursor[0])} cy={sY(f, drawCursor[1])} r={7} fill="none" stroke="#22c55e" strokeWidth={1.5} />
+            )}
+            <circle cx={sX(f, drawCursor[0])} cy={sY(f, drawCursor[1])} r={4} fill="#22c55e" stroke="#16a34a" strokeWidth={1.5} />
+          </g>
+        )}
+
+        {/* Draw-room in progress (Issue 2): placed points, rubber band, close hint. */}
+        {drawPts.length > 0 && (
+          <g pointerEvents="none">
+            {/* Alignment guides — the dashed lines that telegraph "this corner
+                is lined up with that earlier corner" (e.g. under the first). */}
+            {drawCursor && alignGuides.vRef && (
+              <line x1={sX(f, drawCursor[0])} y1={sY(f, alignGuides.vRef[1])} x2={sX(f, drawCursor[0])} y2={sY(f, drawCursor[1])}
+                stroke="#f59e0b" strokeOpacity={0.7} strokeDasharray="3 3" strokeWidth={1} />
+            )}
+            {drawCursor && alignGuides.hRef && (
+              <line x1={sX(f, alignGuides.hRef[0])} y1={sY(f, drawCursor[1])} x2={sX(f, drawCursor[0])} y2={sY(f, drawCursor[1])}
+                stroke="#f59e0b" strokeOpacity={0.7} strokeDasharray="3 3" strokeWidth={1} />
+            )}
+            {drawPts.length >= 3 && (
+              <polygon points={drawPts.map((p) => `${sX(f, p[0])},${sY(f, p[1])}`).join(' ')} fill="#22c55e" fillOpacity={0.1} stroke="none" />
+            )}
+            <polyline points={drawPts.map((p) => `${sX(f, p[0])},${sY(f, p[1])}`).join(' ')} fill="none" stroke="#22c55e" strokeWidth={1.5} />
+            {drawCursor && (
+              <line x1={sX(f, drawPts[drawPts.length - 1][0])} y1={sY(f, drawPts[drawPts.length - 1][1])}
+                x2={sX(f, drawCursor[0])} y2={sY(f, drawCursor[1])} stroke="#22c55e" strokeOpacity={0.5} strokeDasharray="4 3" strokeWidth={1.2} />
+            )}
+            {drawCursor && snapKind !== 'none' && (
+              snapKind === 'line'
+                ? <rect x={sX(f, drawCursor[0]) - 5} y={sY(f, drawCursor[1]) - 5} width={10} height={10} fill="none"
+                    stroke="#f59e0b" strokeWidth={1.5} transform={`rotate(45 ${sX(f, drawCursor[0])} ${sY(f, drawCursor[1])})`} />
+                : <circle cx={sX(f, drawCursor[0])} cy={sY(f, drawCursor[1])} r={7} fill="none" stroke="#22c55e" strokeWidth={1.5} />
+            )}
+            {drawPts.map((p, i) => (
+              <circle key={`d${i}`} cx={sX(f, p[0])} cy={sY(f, p[1])} r={i === 0 && drawPts.length >= 3 ? 6 : 3.5}
+                fill={i === 0 && drawPts.length >= 3 ? '#22c55e' : '#fff'} stroke="#16a34a" strokeWidth={1.5} />
+            ))}
+          </g>
+        )}
+
+        {uniqueVerts(rooms).map((p, i) => {
+          const isHover = hover?.kind === 'vertex' && Math.abs(hover.pos[0] - p[0]) < EPS && Math.abs(hover.pos[1] - p[1]) < EPS;
+          return (
+            <circle key={i} cx={sX(f, p[0])} cy={sY(f, p[1])} r={isHover ? 6 : 4}
+              fill={isHover ? '#fbbf24' : '#fff'} stroke="#334155" strokeWidth={1.5} pointerEvents="none" />
+          );
+        })}
+
+        {/* ⌥/Ctrl-click delete telegraph (Issue 3): a red ring + minus over the node. */}
+        {deleteHover && (
+          <g pointerEvents="none">
+            <circle cx={sX(f, deleteHover[0])} cy={sY(f, deleteHover[1])} r={8} fill="#ef4444" fillOpacity={0.15} stroke="#ef4444" strokeWidth={1.5} />
+            <line x1={sX(f, deleteHover[0]) - 4} y1={sY(f, deleteHover[1])} x2={sX(f, deleteHover[0]) + 4} y2={sY(f, deleteHover[1])} stroke="#ef4444" strokeWidth={2} />
+          </g>
+        )}
+      </svg>
+    </div>
+  );
+}

--- a/apps/viewer/src/components/viewer/tools/space-sketch/SpaceSketchPopovers.tsx
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/SpaceSketchPopovers.tsx
@@ -14,7 +14,7 @@ export interface OptionsPopoverProps {
   hasWallData: boolean;
   snapDelta: { from: number; to: number } | null;
   usedTol: number;
-  /** Corner-tolerance controls are disabled until a storey is derived. */
+  /** The weld-tolerance control is disabled until a storey is derived. */
   snapDisabled: boolean;
   onSnap: (tol: number | null) => void;
   snapTol: number | null;
@@ -47,7 +47,7 @@ export function OptionsPopover(props: OptionsPopoverProps) {
       </div>
       <div className="space-y-1.5">
         <div className="flex items-center justify-between">
-          <span className="font-medium text-foreground">Corner tolerance</span>
+          <span className="font-medium text-foreground" title="How close two wall-rectangle corners must be to be welded into one when deriving rooms">Weld tolerance</span>
           {snapDelta && (
             <span className={`tabular-nums ${snapDelta.to === 0 ? 'text-red-500' : snapDelta.to < snapDelta.from ? 'text-amber-500' : 'text-emerald-500'}`}
               title="Rooms before → after">{snapDelta.from} → {snapDelta.to}</span>
@@ -56,13 +56,13 @@ export function OptionsPopover(props: OptionsPopoverProps) {
         <div className="flex items-center gap-1.5">
           <input type="range" min={0.05} max={1} step={0.05} value={usedTol} className="flex-1 accent-primary"
             disabled={snapDisabled} onChange={(e) => onSnap(Number(e.target.value))} />
-          <input type="number" min={0.05} max={1} step={0.05} value={usedTol} aria-label="Corner tolerance (metres)"
+          <input type="number" min={0.05} max={1} step={0.05} value={usedTol} aria-label="Weld tolerance (metres)"
             className="w-12 rounded border bg-background px-1 py-0.5 tabular-nums disabled:opacity-40"
             disabled={snapDisabled}
             onChange={(e) => { const v = Number(e.target.value); if (Number.isFinite(v) && v > 0) onSnap(Math.min(1, Math.max(0.05, v))); }} />
           <button className="rounded px-1 hover:text-foreground disabled:opacity-40" onClick={() => onSnap(null)}
             disabled={snapDisabled}
-            title={snapTol == null ? 'Automatic — escalates until rooms close' : 'Reset to automatic'}>{snapTol == null ? 'auto' : 'reset'}</button>
+            title={snapTol == null ? 'Default (5 cm)' : 'Reset to the 5 cm default'}>{snapTol == null ? 'auto' : 'reset'}</button>
         </div>
       </div>
       <label className="flex cursor-pointer items-center justify-between">

--- a/apps/viewer/src/components/viewer/tools/space-sketch/SpaceSketchPopovers.tsx
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/SpaceSketchPopovers.tsx
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/** The Space Sketch disclosure popovers — kept out of the default panel flow:
+ *  Options (set-once settings) and Help (the full gesture legend). */
+
+import type { BoundaryMode } from '@ifc-lite/create';
+
+export interface OptionsPopoverProps {
+  boundaryMode: BoundaryMode;
+  onBoundaryMode: (m: BoundaryMode) => void;
+  /** Whether this derive carried wall thickness — without it only `center` works. */
+  hasWallData: boolean;
+  snapDelta: { from: number; to: number } | null;
+  usedTol: number;
+  /** Corner-tolerance controls are disabled until a storey is derived. */
+  snapDisabled: boolean;
+  onSnap: (tol: number | null) => void;
+  snapTol: number | null;
+  showBuilding: boolean;
+  onToggleBuilding: () => void;
+  showDiagnostics: boolean;
+  onToggleDiagnostics: () => void;
+}
+
+export function OptionsPopover(props: OptionsPopoverProps) {
+  const {
+    boundaryMode, onBoundaryMode, hasWallData, snapDelta, usedTol, snapDisabled,
+    onSnap, snapTol, showBuilding, onToggleBuilding, showDiagnostics, onToggleDiagnostics,
+  } = props;
+  return (
+    <div className="absolute right-3 top-12 z-20 w-64 space-y-3 rounded-lg border bg-popover p-3 text-[11px] text-muted-foreground shadow-xl">
+      <div className="space-y-1.5">
+        <div className="font-medium text-foreground">Boundary</div>
+        <div className="inline-flex rounded-md border p-0.5">
+          {(['center', 'inner', 'outer'] as BoundaryMode[]).map((m) => {
+            const noWallData = !hasWallData && m !== 'center';
+            return (
+              <button key={m}
+                className={`rounded px-2 py-0.5 capitalize transition-colors disabled:opacity-40 ${boundaryMode === m ? 'bg-primary text-primary-foreground' : 'hover:text-foreground'}`}
+                onClick={() => onBoundaryMode(m)} disabled={noWallData}
+                title={noWallData ? 'No wall data on this derive — only the centreline is available' : m === 'center' ? 'Wall centreline' : m === 'inner' ? 'Inner (net) face' : 'Outer (gross) face'}>{m}</button>
+            );
+          })}
+        </div>
+      </div>
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between">
+          <span className="font-medium text-foreground">Corner tolerance</span>
+          {snapDelta && (
+            <span className={`tabular-nums ${snapDelta.to === 0 ? 'text-red-500' : snapDelta.to < snapDelta.from ? 'text-amber-500' : 'text-emerald-500'}`}
+              title="Rooms before → after">{snapDelta.from} → {snapDelta.to}</span>
+          )}
+        </div>
+        <div className="flex items-center gap-1.5">
+          <input type="range" min={0.05} max={1} step={0.05} value={usedTol} className="flex-1 accent-primary"
+            disabled={snapDisabled} onChange={(e) => onSnap(Number(e.target.value))} />
+          <input type="number" min={0.05} max={1} step={0.05} value={usedTol} aria-label="Corner tolerance (metres)"
+            className="w-12 rounded border bg-background px-1 py-0.5 tabular-nums disabled:opacity-40"
+            disabled={snapDisabled}
+            onChange={(e) => { const v = Number(e.target.value); if (Number.isFinite(v) && v > 0) onSnap(Math.min(1, Math.max(0.05, v))); }} />
+          <button className="rounded px-1 hover:text-foreground disabled:opacity-40" onClick={() => onSnap(null)}
+            disabled={snapDisabled}
+            title={snapTol == null ? 'Automatic — escalates until rooms close' : 'Reset to automatic'}>{snapTol == null ? 'auto' : 'reset'}</button>
+        </div>
+      </div>
+      <label className="flex cursor-pointer items-center justify-between">
+        <span className="text-foreground">Show building underlay</span>
+        <input type="checkbox" className="accent-primary" checked={showBuilding} onChange={onToggleBuilding} />
+      </label>
+      <label className="flex cursor-pointer items-center justify-between">
+        <span className="text-foreground">Leak diagnostics</span>
+        <input type="checkbox" className="accent-primary" checked={showDiagnostics} disabled={!hasWallData} onChange={onToggleDiagnostics} />
+      </label>
+    </div>
+  );
+}
+
+const HELP_ROWS: [string, string][] = [
+  ['Drag a node', 'move it (snaps; Shift = straight)'],
+  ['Click a wall, then another', 'split the room between them'],
+  ['Click empty space', 'draw a room (Enter / dbl-click closes)'],
+  ['⌥/Ctrl/right-click a node', 'remove it (cleans up orphans)'],
+  ['⌥/Ctrl/right-click a wall', 'merge rooms / remove & clean up'],
+  ['Shift-drag / middle-drag', 'pan · scroll = zoom'],
+];
+
+export function HelpPopover() {
+  return (
+    <div className="absolute right-3 top-12 z-20 w-72 space-y-1.5 rounded-lg border bg-popover p-3 text-[11px] shadow-xl">
+      <div className="mb-1 font-medium text-foreground">One tool — actions follow the cursor:</div>
+      {HELP_ROWS.map(([k, v]) => (
+        <div key={k} className="flex gap-2">
+          <span className="shrink-0 font-medium text-foreground">{k}</span>
+          <span className="text-muted-foreground">— {v}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/viewer/src/components/viewer/tools/space-sketch/types.ts
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/types.ts
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/** Shared UI types for the Space Sketch overlay and its sub-components. */
+
+import type { Pt } from '@/lib/space-sketch-geometry';
+
+/** What the cursor is currently over (drives the hover highlight). */
+export type Hover =
+  | { kind: 'vertex'; pos: Pt }
+  | { kind: 'edge'; edge: number; rooms: number[]; a: Pt; b: Pt }
+  | null;
+
+/** A split endpoint the user picked — an existing corner, or a point on a wall
+ *  edge (which becomes a new node when the cut is committed). */
+export type SplitTarget =
+  | { kind: 'vertex'; vid: number; pos: Pt }
+  | { kind: 'edge'; edge: number; pos: Pt };
+
+/** The colour language for the live action-intent chip + on-canvas cues:
+ *  green = create/draw, blue = cut/split, red = remove/merge, neutral = move/pan. */
+export type IntentTone = 'move' | 'draw' | 'cut' | 'remove' | 'pan';
+
+export interface Intent { text: string; tone: IntentTone }

--- a/apps/viewer/src/components/viewer/useGeometryStreaming.ts
+++ b/apps/viewer/src/components/viewer/useGeometryStreaming.ts
@@ -601,6 +601,14 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
       if (scene.hasPendingBatches()) {
         scene.rebuildPendingBatches(device, pipeline);
       }
+      // An element appended during streaming (e.g. an authored IfcSpace) lingers
+      // as a streaming fragment at its ORIGINAL position on top of its now-moved
+      // bucket batch — a ghost duplicate. Finalising merges fragments into clean
+      // buckets (no-op once none remain). Skipped in ephemeral mode, where no
+      // geometry is retained to rebuild the batches from.
+      if (scene.hasStreamingFragments() && !scene.isEphemeralStreaming()) {
+        scene.finalizeStreaming(device, pipeline);
+      }
       renderer.requestRender();
     }
     clearPendingMeshTranslations();

--- a/apps/viewer/src/lib/space-edit-error.test.ts
+++ b/apps/viewer/src/lib/space-edit-error.test.ts
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { editError } from './space-edit-error.js';
+
+describe('editError', () => {
+  it('reads the stable code from a typed engine Error (name + message)', () => {
+    const e = new Error('this wall bridges the room to itself');
+    e.name = 'BridgeEdge';
+    const r = editError(e);
+    assert.strictEqual(r.code, 'BridgeEdge');
+    assert.strictEqual(r.message, 'this wall bridges the room to itself');
+  });
+
+  it('returns code=null for an Error whose name is not a known edit code', () => {
+    const e = new Error('boom'); // default name === 'Error'
+    const r = editError(e);
+    assert.strictEqual(r.code, null);
+    assert.strictEqual(r.message, 'boom');
+  });
+
+  it('falls back to the name when an Error has no message', () => {
+    const e = new Error('');
+    e.name = 'StaleHandle';
+    const r = editError(e);
+    assert.strictEqual(r.code, 'StaleHandle');
+    assert.strictEqual(r.message, 'StaleHandle');
+  });
+
+  it('strips a legacy "Code:" prefix from a thrown string', () => {
+    const r = editError('BordersExterior: nothing to merge');
+    assert.strictEqual(r.code, null);
+    assert.strictEqual(r.message, 'nothing to merge');
+  });
+
+  it('handles a bare non-error value', () => {
+    assert.strictEqual(editError(undefined).message, 'undefined');
+    assert.strictEqual(editError(undefined).code, null);
+  });
+});

--- a/apps/viewer/src/lib/space-edit-error.ts
+++ b/apps/viewer/src/lib/space-edit-error.ts
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Typed reader for `SpacePlateHandle` edit rejections.
+ *
+ * The Rust binding throws a `js_sys::Error` whose `name` is a STABLE code (one
+ * of `EditErrorCode`) and whose `message` is human prose — so callers switch on
+ * the code for control flow and show the message to the user, instead of
+ * pattern-matching the prose. See `rust/wasm-bindings/src/api/space_plate.rs`.
+ */
+
+/** The stable `EditError` variants the engine can reject an edit with. */
+export type EditErrorCode =
+  | 'StaleHandle'
+  | 'VerticesNotOnFace'
+  | 'DegenerateCut'
+  | 'BordersExterior'
+  | 'BridgeEdge'
+  | 'VertexNotDissolvable'
+  | 'InvalidPolygon';
+
+const CODES: ReadonlySet<string> = new Set<EditErrorCode>([
+  'StaleHandle',
+  'VerticesNotOnFace',
+  'DegenerateCut',
+  'BordersExterior',
+  'BridgeEdge',
+  'VertexNotDissolvable',
+  'InvalidPolygon',
+]);
+
+export interface EditError {
+  /** The stable engine code, or `null` if this wasn't a recognised edit error. */
+  code: EditErrorCode | null;
+  /** Human-readable message, safe to surface in the status line. */
+  message: string;
+}
+
+/** Normalise anything thrown by a `SpacePlateHandle` edit into `{ code, message }`. */
+export function editError(err: unknown): EditError {
+  if (err instanceof Error) {
+    const code = CODES.has(err.name) ? (err.name as EditErrorCode) : null;
+    return { code, message: err.message || err.name || 'Edit failed' };
+  }
+  // A thrown string / unknown value — strip a leading "Word:" code prefix so a
+  // legacy/raw rejection still reads cleanly.
+  return { code: null, message: String(err).replace(/^\w+:\s*/, '') };
+}

--- a/apps/viewer/src/lib/space-interaction.test.ts
+++ b/apps/viewer/src/lib/space-interaction.test.ts
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { pointerButton, isRemoveModifier } from './space-interaction.js';
+
+describe('pointerButton', () => {
+  it('names the standard buttons', () => {
+    assert.strictEqual(pointerButton({ button: 0 }), 'primary');
+    assert.strictEqual(pointerButton({ button: 1 }), 'middle');
+    assert.strictEqual(pointerButton({ button: 2 }), 'secondary');
+    assert.strictEqual(pointerButton({ button: 5 }), 'other');
+  });
+});
+
+describe('isRemoveModifier', () => {
+  const ev = (o: Partial<{ altKey: boolean; ctrlKey: boolean; metaKey: boolean }>) =>
+    ({ altKey: false, ctrlKey: false, metaKey: false, ...o });
+
+  it('is true for Alt, Ctrl, or Cmd held', () => {
+    assert.strictEqual(isRemoveModifier(ev({ altKey: true })), true);
+    assert.strictEqual(isRemoveModifier(ev({ ctrlKey: true })), true);
+    assert.strictEqual(isRemoveModifier(ev({ metaKey: true })), true);
+  });
+
+  it('is false with no modifier (a plain click drags / draws)', () => {
+    assert.strictEqual(isRemoveModifier(ev({})), false);
+  });
+
+  it('treats Shift alone as not-a-remove (Shift is ortho/pan)', () => {
+    assert.strictEqual(isRemoveModifier(ev({})), false);
+  });
+});

--- a/apps/viewer/src/lib/space-interaction.ts
+++ b/apps/viewer/src/lib/space-interaction.ts
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Input normalization for the Space Sketch editor — the single place that knows
+ * what each mouse button / modifier means, so platform quirks are encoded once
+ * (and unit-tested) instead of being re-derived in every handler.
+ *
+ * The big quirk: on macOS a **Ctrl+click is converted by the OS into a real
+ * right-click** (`button === 2` + a `contextmenu` event), whereas Cmd/Alt+click
+ * stay a normal left-click. So the "remove" gesture reaches the app two ways —
+ * a modifier-held primary click (Win/Linux Ctrl, macOS Alt/Cmd) via pointerdown,
+ * and a secondary click (any right-click, incl. macOS Ctrl-click) via the
+ * context menu. Both must do the same thing; this module makes that explicit.
+ */
+
+export type PointerButton = 'primary' | 'middle' | 'secondary' | 'other';
+
+/** Which mouse button a pointer/mouse event used. */
+export function pointerButton(e: { button: number }): PointerButton {
+  switch (e.button) {
+    case 0: return 'primary';
+    case 1: return 'middle';
+    case 2: return 'secondary';
+    default: return 'other';
+  }
+}
+
+/**
+ * True when a remove/dissolve modifier (Alt, Ctrl, or Cmd) is held. Works for
+ * pointer and keyboard events alike (both carry the modifier flags), so the
+ * pointerdown handler, the hover-preview, and the keydown/keyup listener all
+ * agree on what counts as the remove gesture.
+ *
+ * NOTE: a macOS Ctrl+click does NOT come through here as a primary click — the
+ * OS turns it into a secondary click, so it's handled via the context-menu
+ * path. This reports the explicit modifier state for a *left* click.
+ */
+export function isRemoveModifier(e: { altKey: boolean; ctrlKey: boolean; metaKey: boolean }): boolean {
+  return e.altKey || e.ctrlKey || e.metaKey;
+}

--- a/apps/viewer/src/lib/space-plate-session.test.ts
+++ b/apps/viewer/src/lib/space-plate-session.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert';
-import { SpacePlateSession, MAX_UNDO } from './space-plate-session.js';
+import { SpacePlateSession, MAX_UNDO, flattenWallRects } from './space-plate-session.js';
 import type { SpacePlateHandle } from '@ifc-lite/wasm';
 
 // A stand-in for the wasm handle: tracks the live-handle count and throws on a
@@ -131,5 +131,55 @@ describe('SpacePlateSession', () => {
     assert.strictEqual(s.canUndo, true);
     s.dispose();
     assert.strictEqual(live, 0, 'dispose frees current + history + pending');
+  });
+});
+
+describe('SpacePlateSession — face-based presentation', () => {
+  // The face-based plate's vertices sit on the inner wall faces (the room is the
+  // gap between wall rectangles); the session must present each room at its wall
+  // AXIS so nodes land on the wall centre. These poke `faceBased` directly so the
+  // swap is tested without a real wasm plate (build path is covered by the viewer
+  // integration). The fake's `gapBoundary(_, 1)` returns the axis outline.
+  const makeFaceBased = (handle: Partial<SpacePlateHandle>): SpacePlateSession => {
+    const s = SpacePlateSession.fromHandle({ free: () => {}, ...handle } as unknown as SpacePlateHandle);
+    (s as unknown as { faceBased: boolean }).faceBased = true;
+    return s;
+  };
+
+  it('presents each room at its wall axis (gapBoundary factor 1) and reports the axis area', () => {
+    const net = [[0, 0], [2, 0], [2, 2], [0, 2]]; // gap / inner faces — 2×2
+    const axis = Float64Array.from([-0.5, -0.5, 2.5, -0.5, 2.5, 2.5, -0.5, 2.5]); // +½t each edge — 3×3
+    const s = makeFaceBased({
+      snapshot: () => [{ face: 7, area: 4, simple: true, outline: net }] as unknown as ReturnType<SpacePlateHandle['snapshot']>,
+      gapBoundary: (_f: number, factor: number) => (factor === 1 ? axis : new Float64Array()),
+    });
+    const [room] = s.rooms();
+    assert.deepStrictEqual(room.outline, [[-0.5, -0.5], [2.5, -0.5], [2.5, 2.5], [-0.5, 2.5]], 'outline swapped to the wall axis');
+    assert.strictEqual(room.area, 9, 'reported area is the axis (gross-basis) 3×3 area');
+    assert.strictEqual(room.face, 7, 'face id preserved for editing/boundary lookups');
+  });
+
+  it('maps boundaryOutline net/center/outer to gapBoundary factors 0/1/2', () => {
+    const calls: number[] = [];
+    const s = makeFaceBased({
+      snapshot: () => [] as unknown as ReturnType<SpacePlateHandle['snapshot']>,
+      gapBoundary: (_f: number, factor: number) => { calls.push(factor); return Float64Array.from([0, 0, 1, 0, 1, 1]); },
+    });
+    s.boundaryOutline(3, 'inner');
+    s.boundaryOutline(3, 'center');
+    s.boundaryOutline(3, 'outer');
+    assert.deepStrictEqual(calls, [0, 1, 2], 'inner→net, center→axis, outer→gross');
+  });
+});
+
+describe('flattenWallRects', () => {
+  it('lays out 4 corners × 2 coords per wall, wall-major', () => {
+    const flat = flattenWallRects([
+      [[0, 0], [1, 0], [1, 2], [0, 2]],
+      [[5, 5], [6, 5], [6, 7], [5, 7]],
+    ]);
+    assert.strictEqual(flat.length, 16, '8 floats per wall × 2 walls');
+    assert.deepStrictEqual(Array.from(flat.slice(0, 8)), [0, 0, 1, 0, 1, 2, 0, 2]);
+    assert.deepStrictEqual(Array.from(flat.slice(8)), [5, 5, 6, 5, 6, 7, 5, 7]);
   });
 });

--- a/apps/viewer/src/lib/space-plate-session.test.ts
+++ b/apps/viewer/src/lib/space-plate-session.test.ts
@@ -134,41 +134,23 @@ describe('SpacePlateSession', () => {
   });
 });
 
-describe('SpacePlateSession — face-based presentation', () => {
-  // The face-based plate's vertices sit on the inner wall faces (the room is the
-  // gap between wall rectangles); the session must present each room at its wall
-  // AXIS so nodes land on the wall centre. These poke `faceBased` directly so the
-  // swap is tested without a real wasm plate (build path is covered by the viewer
-  // integration). The fake's `gapBoundary(_, 1)` returns the axis outline.
-  const makeFaceBased = (handle: Partial<SpacePlateHandle>): SpacePlateSession => {
-    const s = SpacePlateSession.fromHandle({ free: () => {}, ...handle } as unknown as SpacePlateHandle);
-    (s as unknown as { faceBased: boolean }).faceBased = true;
-    return s;
-  };
-
-  it('presents each room at its wall axis (gapBoundary factor 1) and reports the axis area', () => {
-    const net = [[0, 0], [2, 0], [2, 2], [0, 2]]; // gap / inner faces — 2×2
-    const axis = Float64Array.from([-0.5, -0.5, 2.5, -0.5, 2.5, 2.5, -0.5, 2.5]); // +½t each edge — 3×3
-    const s = makeFaceBased({
-      snapshot: () => [{ face: 7, area: 4, simple: true, outline: net }] as unknown as ReturnType<SpacePlateHandle['snapshot']>,
-      gapBoundary: (_f: number, factor: number) => (factor === 1 ? axis : new Float64Array()),
-    });
-    const [room] = s.rooms();
-    assert.deepStrictEqual(room.outline, [[-0.5, -0.5], [2.5, -0.5], [2.5, 2.5], [-0.5, 2.5]], 'outline swapped to the wall axis');
-    assert.strictEqual(room.area, 9, 'reported area is the axis (gross-basis) 3×3 area');
-    assert.strictEqual(room.face, 7, 'face id preserved for editing/boundary lookups');
-  });
-
-  it('maps boundaryOutline net/center/outer to gapBoundary factors 0/1/2', () => {
-    const calls: number[] = [];
-    const s = makeFaceBased({
-      snapshot: () => [] as unknown as ReturnType<SpacePlateHandle['snapshot']>,
-      gapBoundary: (_f: number, factor: number) => { calls.push(factor); return Float64Array.from([0, 0, 1, 0, 1, 1]); },
-    });
+describe('SpacePlateSession — boundary outlines', () => {
+  // `fromWallRects` returns a centreline plate whose room outline IS the wall
+  // axis, so `center` is the room outline itself and `inner`/`outer` route to
+  // `net_outline` (inset/outset by the wall half-thickness). Fake handle, no wasm.
+  it('center returns the room outline; inner/outer route to net_outline (inset/outset)', () => {
+    const axisOutline: [number, number][] = [[0, 0], [3, 0], [3, 3], [0, 3]];
+    const insets: boolean[] = [];
+    const handle = {
+      snapshot: () => [{ face: 3, area: 9, simple: true, outline: axisOutline }] as unknown as ReturnType<SpacePlateHandle['snapshot']>,
+      netOutline: (_f: number, inset: boolean) => { insets.push(inset); return Float64Array.from([0, 0, 1, 0, 1, 1]); },
+      free: () => {},
+    } as unknown as SpacePlateHandle;
+    const s = SpacePlateSession.fromHandle(handle);
+    assert.deepStrictEqual(s.boundaryOutline(3, 'center'), axisOutline, 'center = the wall axis outline');
     s.boundaryOutline(3, 'inner');
-    s.boundaryOutline(3, 'center');
     s.boundaryOutline(3, 'outer');
-    assert.deepStrictEqual(calls, [0, 1, 2], 'inner→net, center→axis, outer→gross');
+    assert.deepStrictEqual(insets, [true, false], 'inner → inset (net), outer → outset (gross)');
   });
 });
 

--- a/apps/viewer/src/lib/space-plate-session.test.ts
+++ b/apps/viewer/src/lib/space-plate-session.test.ts
@@ -1,0 +1,135 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { SpacePlateSession, MAX_UNDO } from './space-plate-session.js';
+import type { SpacePlateHandle } from '@ifc-lite/wasm';
+
+// A stand-in for the wasm handle: tracks the live-handle count and throws on a
+// double free, so the tests catch leaks AND the double-free class of bug the
+// session is meant to eliminate. `value` is a stand-in for plate state so we can
+// assert that undo/redo/rollback actually restore the right snapshot.
+let live = 0;
+class FakeHandle {
+  freed = false;
+  constructor(public value: number) { live++; }
+  duplicate(): SpacePlateHandle { return new FakeHandle(this.value) as unknown as SpacePlateHandle; }
+  free(): void {
+    if (this.freed) throw new Error('double free');
+    this.freed = true;
+    live--;
+  }
+  get roomCount(): number { return this.value; }
+  snapshot(): unknown { return []; }
+  /** A stand-in mutation. */
+  set(v: number): number { this.value = v; return v; }
+}
+
+const fake = (v: number) => new FakeHandle(v) as unknown as SpacePlateHandle;
+const valueOf = (s: SpacePlateSession) => s.roomCount; // roomCount === FakeHandle.value
+
+describe('SpacePlateSession', () => {
+  beforeEach(() => { live = 0; });
+
+  it('edit commits on success and undo restores the pre-edit state', () => {
+    const s = SpacePlateSession.fromHandle(fake(10));
+    assert.strictEqual(s.dirty, false);
+    s.edit((h) => (h as unknown as FakeHandle).set(20));
+    assert.strictEqual(valueOf(s), 20);
+    assert.strictEqual(s.dirty, true);
+    assert.strictEqual(s.canUndo, true);
+    assert.strictEqual(s.undo(), true);
+    assert.strictEqual(valueOf(s), 10, 'undo restores the pre-edit snapshot');
+    assert.strictEqual(s.canRedo, true);
+    s.dispose();
+    assert.strictEqual(live, 0, 'no leaked / double-freed handles');
+  });
+
+  it('edit rolls back to the snapshot and rethrows on a rejected mutation', () => {
+    const s = SpacePlateSession.fromHandle(fake(10));
+    assert.throws(() => s.edit((h) => {
+      (h as unknown as FakeHandle).set(99); // partial mutation…
+      throw new Error('BridgeEdge'); // …then the engine rejects
+    }), /BridgeEdge/);
+    assert.strictEqual(valueOf(s), 10, 'plate rolled back to pre-edit value');
+    assert.strictEqual(s.dirty, false, 'a rejected edit does not dirty the plate');
+    assert.strictEqual(s.canUndo, false, 'no undo entry for a rejected edit');
+    s.dispose();
+    assert.strictEqual(live, 0);
+  });
+
+  it('skips the undo entry when shouldCommit reports no change (prune-of-0)', () => {
+    const s = SpacePlateSession.fromHandle(fake(10));
+    const removed = s.edit(() => 0, (n) => n > 0);
+    assert.strictEqual(removed, 0);
+    assert.strictEqual(s.canUndo, false, 'a no-op prune leaves no undo entry');
+    assert.strictEqual(s.dirty, false);
+    s.dispose();
+    assert.strictEqual(live, 0, 'the discarded snapshot was freed');
+  });
+
+  it('redo replays an undone edit, and a new edit clears the redo stack', () => {
+    const s = SpacePlateSession.fromHandle(fake(1));
+    s.edit((h) => (h as unknown as FakeHandle).set(2));
+    s.undo();
+    assert.strictEqual(valueOf(s), 1);
+    assert.strictEqual(s.redo(), true);
+    assert.strictEqual(valueOf(s), 2, 'redo replays the edit');
+    // Undo, then a fresh edit must drop the redo branch.
+    s.undo();
+    s.edit((h) => (h as unknown as FakeHandle).set(3));
+    assert.strictEqual(s.canRedo, false, 'a new edit clears redo');
+    s.dispose();
+    assert.strictEqual(live, 0);
+  });
+
+  it('bounds the undo stack at MAX_UNDO, freeing evicted snapshots', () => {
+    const s = SpacePlateSession.fromHandle(fake(0));
+    for (let i = 1; i <= MAX_UNDO + 5; i++) s.edit((h) => (h as unknown as FakeHandle).set(i));
+    // Undo can only walk back MAX_UNDO steps.
+    let steps = 0;
+    while (s.undo()) steps++;
+    assert.strictEqual(steps, MAX_UNDO, 'history is capped at MAX_UNDO');
+    s.dispose();
+    assert.strictEqual(live, 0, 'evicted snapshots were freed, not leaked');
+  });
+
+  it('commits a drag as one undo step', () => {
+    const s = SpacePlateSession.fromHandle(fake(5));
+    assert.strictEqual(s.beginDrag(), true);
+    // dragTo calls handle.dragVertex (absent on the fake → swallowed); simulate
+    // the live mutation a real drag step performs:
+    (s as unknown as { handle: FakeHandle }).handle.set(8);
+    s.commitDrag();
+    assert.strictEqual(s.canUndo, true);
+    assert.strictEqual(s.undo(), true);
+    assert.strictEqual(valueOf(s), 5, 'undo restores the pre-drag state');
+    s.dispose();
+    assert.strictEqual(live, 0);
+  });
+
+  it('cancels a drag by restoring the pre-drag snapshot', () => {
+    const s = SpacePlateSession.fromHandle(fake(5));
+    s.beginDrag();
+    (s as unknown as { handle: FakeHandle }).handle.set(8); // live drag mutation
+    assert.strictEqual(valueOf(s), 8);
+    s.cancelDrag();
+    assert.strictEqual(valueOf(s), 5, 'cancel reverts to the pre-drag value');
+    assert.strictEqual(s.canUndo, false, 'a cancelled drag leaves no undo entry');
+    s.dispose();
+    assert.strictEqual(live, 0);
+  });
+
+  it('build replaces the plate, clears history, and resets dirty', () => {
+    // Exercise the history-replacement path via fromHandle + manual edits, then
+    // assert dispose cleans everything (build() itself needs wasm, covered by
+    // the viewer integration).
+    const s = SpacePlateSession.fromHandle(fake(1));
+    s.edit((h) => (h as unknown as FakeHandle).set(2));
+    assert.strictEqual(s.canUndo, true);
+    s.dispose();
+    assert.strictEqual(live, 0, 'dispose frees current + history + pending');
+  });
+});

--- a/apps/viewer/src/lib/space-plate-session.ts
+++ b/apps/viewer/src/lib/space-plate-session.ts
@@ -88,25 +88,6 @@ function flatToPts(flat: Float64Array): [number, number][] {
   return out;
 }
 
-/** Signed-area magnitude of a closed polygon (shoelace), m². */
-function polyArea2(pts: [number, number][]): number {
-  let a = 0;
-  for (let i = 0; i < pts.length; i++) {
-    const [x1, y1] = pts[i];
-    const [x2, y2] = pts[(i + 1) % pts.length];
-    a += x1 * y2 - x2 * y1;
-  }
-  return Math.abs(a) / 2;
-}
-
-/** Wall-axis-factor for the face-based `gapBoundary` query: the room face IS the
- *  gap between wall rectangles (= net inner-face outline), and each room edge is
- *  offset outward by `factor · ½ wall-thickness` — 0 = net (inner faces), 1 = the
- *  wall AXIS (true centreline), 2 = gross (outer faces). */
-function gapFactor(boundary: 'center' | 'inner' | 'outer'): number {
-  return boundary === 'inner' ? 0 : boundary === 'outer' ? 2 : 1;
-}
-
 /** Flatten N wall rectangles ([[x,y]×4] each, CCW) into the `8·N` float array
  *  `fromWallRects` expects (4 corners × 2 coords per wall, wall-major). */
 export function flattenWallRects(rects: ([number, number][])[]): Float64Array {
@@ -140,11 +121,11 @@ export function snapshotRooms(
   return out;
 }
 
-/** Face-based whole-building bake: build a throwaway plate from wall RECTANGLES
- *  (the gaps between them are the rooms), and for each room read its wall-axis
- *  `outline` (the centreline — the gross-area basis) and its `boundary` outline
- *  at the chosen mode (net / axis / gross). The room face is the net inner-face
- *  polygon; `gapBoundary` offsets it outward per edge. Frees the plate. */
+/** Face-based whole-building bake: build a throwaway plate from wall RECTANGLES.
+ *  `fromWallRects` returns a centreline plate whose room outline IS the wall axis
+ *  (the gross-area basis), so the boundary at the chosen mode is the axis itself
+ *  (`center`) or `net_outline` inset/outset to the inner (net) / outer (gross)
+ *  face. Frees the plate. */
 export function snapshotRoomsFromRects(
   rectCoords: Float64Array,
   boundary: 'center' | 'inner' | 'outer',
@@ -153,10 +134,9 @@ export function snapshotRoomsFromRects(
 ): RoomWithBoundary[] {
   const handle = SpacePlateHandle.fromWallRects(rectCoords, snapTolerance, minArea);
   const rooms = handle.snapshot() as Room[];
-  const factor = gapFactor(boundary);
   const out = rooms.map((r) => ({
-    outline: flatToPts(handle.gapBoundary(r.face, 1)), // wall axis — gross-area basis
-    boundary: flatToPts(handle.gapBoundary(r.face, factor)),
+    outline: r.outline, // the wall axis (centreline) — gross-area basis
+    boundary: boundary === 'center' ? r.outline : flatToPts(handle.netOutline(r.face, boundary === 'inner')),
   }));
   handle.free();
   return out;
@@ -170,11 +150,6 @@ export class SpacePlateSession {
   private pending: SpacePlateHandle | null = null;
   /** True once the plate has been edited since the last build/bake-clear. */
   dirty = false;
-  /** Face-based plate (built from wall RECTANGLES via `buildFromRects`): rooms are
-   *  the gaps between walls, the plate vertices sit on the inner faces, and each
-   *  room is PRESENTED at its wall axis (centreline) so nodes land on the wall
-   *  centre. A centreline plate (`build`) presents its raw outline unchanged. */
-  private faceBased = false;
 
   /** Adopt an already-built handle (no history). For tests / direct seeding;
    *  normal use goes through `build`. */
@@ -197,15 +172,17 @@ export class SpacePlateSession {
     this.disposeHandle();
     this.clearHistory();
     this.handle = handle;
-    this.faceBased = false;
     this.dirty = false;
     return { rooms: this.rooms(), tol };
   }
 
-  /** Build a face-based plate from wall RECTANGLES (each wall's 4 footprint
-   *  corners, wall-major, `8·N` floats — see `flattenWallRects`). Rooms are the
-   *  bounded gaps between the rectangles, so the room boundary IS the wall faces
-   *  (no centroid bias) — and each room is presented at its true wall axis.
+  /** Build a plate from wall RECTANGLES (each wall's 4 footprint corners,
+   *  wall-major, `8·N` floats — see `flattenWallRects`). Rooms are detected as the
+   *  bounded gaps between the rectangles (boundary literally on the wall faces, no
+   *  centroid bias), then LIFTED to the wall axis: the returned plate is a normal
+   *  centreline plate whose room outlines ARE the wall axes and whose vertices ARE
+   *  the displayed nodes — so editing (drag / split / merge) acts directly on what
+   *  the user sees. `net_outline` recovers the inner (net) / outer (gross) faces.
    *  Replaces the current plate and clears history. */
   buildFromRects(rectCoords: Float64Array, snapTolerance = 0.05, minArea = 0.3): { rooms: Room[] } {
     const handle = SpacePlateHandle.fromWallRects(rectCoords, snapTolerance, minArea);
@@ -213,33 +190,17 @@ export class SpacePlateSession {
     this.disposeHandle();
     this.clearHistory();
     this.handle = handle;
-    this.faceBased = true;
     this.dirty = false;
     return { rooms: this.rooms() };
   }
 
   // ───────────────────────────── reads ─────────────────────────────
 
-  /** Present a raw plate room. In face-based mode the plate vertices sit on the
-   *  inner wall faces (the gap), so swap the outline for the wall AXIS and report
-   *  the axis (centreline) area — the gross-area basis nodes are drawn at. */
-  private materialize(r: Room): Room {
-    if (!this.faceBased || !this.handle) return r;
-    const outline = flatToPts(this.handle.gapBoundary(r.face, 1));
-    return outline.length >= 3 ? { ...r, outline, area: polyArea2(outline) } : r;
-  }
+  rooms(): Room[] { return this.handle ? (this.handle.snapshot() as Room[]) : []; }
 
-  rooms(): Room[] {
-    return this.handle ? (this.handle.snapshot() as Room[]).map((r) => this.materialize(r)) : [];
-  }
-
-  /** A room's outline at the chosen wall boundary: the centreline (`center`),
-   *  the net inner face (`inner`), or the gross outer face (`outer`). */
+  /** A room's outline at the chosen wall boundary: the centreline / wall axis
+   *  (`center`), the net inner face (`inner`), or the gross outer face (`outer`). */
   boundaryOutline(face: number, boundary: 'center' | 'inner' | 'outer'): [number, number][] {
-    if (this.faceBased && this.handle) {
-      // Face-based: every room edge is a wall face, so the offset always applies.
-      return flatToPts(this.handle.gapBoundary(face, gapFactor(boundary)));
-    }
     if (!this.handle || boundary === 'center') {
       const room = this.rooms().find((r) => r.face === face);
       return room ? room.outline : [];

--- a/apps/viewer/src/lib/space-plate-session.ts
+++ b/apps/viewer/src/lib/space-plate-session.ts
@@ -46,22 +46,27 @@ export function ensureSpaceWasm(): Promise<void> {
   return wasmReady;
 }
 
+/** Half-thickness (m) per wall segment, parallel to the coords/sources arrays;
+ *  carried onto derived edges so net/gross outlines can be queried. Empty = none. */
+export type Thicknesses = Float64Array;
+
 /** Build a plate from flat wall segments. With `manualTol` null, escalate the
  *  corner-snap tolerance until one encloses rooms (real centrelines miss corners
  *  by ~½ a wall thickness, so a tight snap leaves the loop open → 0 rooms). */
 function buildHandle(
   coords: Float64Array,
   sources: Int32Array,
+  thicknesses: Thicknesses,
   manualTol: number | null,
   minArea: number,
 ): { handle: SpacePlateHandle; tol: number } {
   if (manualTol != null) {
-    return { handle: new SpacePlateHandle(coords, sources, manualTol, minArea), tol: manualTol };
+    return { handle: new SpacePlateHandle(coords, sources, thicknesses, manualTol, minArea), tol: manualTol };
   }
   let handle: SpacePlateHandle | null = null;
   let tol = 0.1;
   for (const t of [0.1, 0.25, 0.5]) {
-    const p = new SpacePlateHandle(coords, sources, t, minArea);
+    const p = new SpacePlateHandle(coords, sources, thicknesses, t, minArea);
     handle?.free();
     handle = p;
     tol = t;
@@ -70,13 +75,37 @@ function buildHandle(
   return { handle: handle!, tol };
 }
 
-/** Build a throwaway plate, read its rooms, and free it — for paths (e.g.
- *  whole-building bake) that need a storey's rooms without a live session. */
-export function snapshotRooms(coords: Float64Array, sources: Int32Array, minArea = 0.5): Room[] {
-  const { handle } = buildHandle(coords, sources, null, minArea);
+/** One room from a throwaway-plate snapshot: its centreline outline + the outline
+ *  at the requested wall boundary (net/gross/centre). */
+export interface RoomWithBoundary {
+  outline: [number, number][];
+  boundary: [number, number][];
+}
+
+function flatToPts(flat: Float64Array): [number, number][] {
+  const out: [number, number][] = [];
+  for (let i = 0; i + 1 < flat.length; i += 2) out.push([flat[i], flat[i + 1]]);
+  return out;
+}
+
+/** Build a throwaway plate, read each room's centreline + boundary outline at
+ *  `boundary` mode, and free it — for paths (whole-building bake) that need a
+ *  storey's rooms without a live session. */
+export function snapshotRooms(
+  coords: Float64Array,
+  sources: Int32Array,
+  thicknesses: Thicknesses,
+  boundary: 'center' | 'inner' | 'outer',
+  minArea = 0.5,
+): RoomWithBoundary[] {
+  const { handle } = buildHandle(coords, sources, thicknesses, null, minArea);
   const rooms = handle.snapshot() as Room[];
+  const out = rooms.map((r) => ({
+    outline: r.outline,
+    boundary: boundary === 'center' ? r.outline : flatToPts(handle.netOutline(r.face, boundary === 'inner')),
+  }));
   handle.free();
-  return rooms;
+  return out;
 }
 
 export class SpacePlateSession {
@@ -103,8 +132,8 @@ export class SpacePlateSession {
 
   /** Build a fresh plate, replacing the current one and clearing all history.
    *  Resets `dirty` (a fresh derive is the new clean baseline). */
-  build(coords: Float64Array, sources: Int32Array, manualTol: number | null, minArea = 0.5): { rooms: Room[]; tol: number } {
-    const { handle, tol } = buildHandle(coords, sources, manualTol, minArea);
+  build(coords: Float64Array, sources: Int32Array, thicknesses: Thicknesses, manualTol: number | null, minArea = 0.5): { rooms: Room[]; tol: number } {
+    const { handle, tol } = buildHandle(coords, sources, thicknesses, manualTol, minArea);
     this.discardPending();
     this.disposeHandle();
     this.clearHistory();
@@ -116,6 +145,17 @@ export class SpacePlateSession {
   // ───────────────────────────── reads ─────────────────────────────
 
   rooms(): Room[] { return this.handle ? (this.handle.snapshot() as Room[]) : []; }
+
+  /** A room's outline at the chosen wall boundary: the centreline (`center`),
+   *  the net inner face (`inner`), or the gross outer face (`outer`). */
+  boundaryOutline(face: number, boundary: 'center' | 'inner' | 'outer'): [number, number][] {
+    if (!this.handle || boundary === 'center') {
+      const room = this.rooms().find((r) => r.face === face);
+      return room ? room.outline : [];
+    }
+    return flatToPts(this.handle.netOutline(face, boundary === 'inner'));
+  }
+
   neighborAcross(edge: number): number | undefined { return this.handle?.neighborAcross(edge); }
   boundingElements(face: number): Boundary[] {
     return this.handle ? (this.handle.boundingElements(face) as Boundary[]) : [];

--- a/apps/viewer/src/lib/space-plate-session.ts
+++ b/apps/viewer/src/lib/space-plate-session.ts
@@ -88,6 +88,38 @@ function flatToPts(flat: Float64Array): [number, number][] {
   return out;
 }
 
+/** Signed-area magnitude of a closed polygon (shoelace), m². */
+function polyArea2(pts: [number, number][]): number {
+  let a = 0;
+  for (let i = 0; i < pts.length; i++) {
+    const [x1, y1] = pts[i];
+    const [x2, y2] = pts[(i + 1) % pts.length];
+    a += x1 * y2 - x2 * y1;
+  }
+  return Math.abs(a) / 2;
+}
+
+/** Wall-axis-factor for the face-based `gapBoundary` query: the room face IS the
+ *  gap between wall rectangles (= net inner-face outline), and each room edge is
+ *  offset outward by `factor · ½ wall-thickness` — 0 = net (inner faces), 1 = the
+ *  wall AXIS (true centreline), 2 = gross (outer faces). */
+function gapFactor(boundary: 'center' | 'inner' | 'outer'): number {
+  return boundary === 'inner' ? 0 : boundary === 'outer' ? 2 : 1;
+}
+
+/** Flatten N wall rectangles ([[x,y]×4] each, CCW) into the `8·N` float array
+ *  `fromWallRects` expects (4 corners × 2 coords per wall, wall-major). */
+export function flattenWallRects(rects: ([number, number][])[]): Float64Array {
+  const flat = new Float64Array(rects.length * 8);
+  rects.forEach((r, w) => {
+    for (let c = 0; c < 4; c++) {
+      flat[w * 8 + c * 2] = r[c][0];
+      flat[w * 8 + c * 2 + 1] = r[c][1];
+    }
+  });
+  return flat;
+}
+
 /** Build a throwaway plate, read each room's centreline + boundary outline at
  *  `boundary` mode, and free it — for paths (whole-building bake) that need a
  *  storey's rooms without a live session. */
@@ -108,6 +140,28 @@ export function snapshotRooms(
   return out;
 }
 
+/** Face-based whole-building bake: build a throwaway plate from wall RECTANGLES
+ *  (the gaps between them are the rooms), and for each room read its wall-axis
+ *  `outline` (the centreline — the gross-area basis) and its `boundary` outline
+ *  at the chosen mode (net / axis / gross). The room face is the net inner-face
+ *  polygon; `gapBoundary` offsets it outward per edge. Frees the plate. */
+export function snapshotRoomsFromRects(
+  rectCoords: Float64Array,
+  boundary: 'center' | 'inner' | 'outer',
+  snapTolerance = 0.05,
+  minArea = 0.3,
+): RoomWithBoundary[] {
+  const handle = SpacePlateHandle.fromWallRects(rectCoords, snapTolerance, minArea);
+  const rooms = handle.snapshot() as Room[];
+  const factor = gapFactor(boundary);
+  const out = rooms.map((r) => ({
+    outline: flatToPts(handle.gapBoundary(r.face, 1)), // wall axis — gross-area basis
+    boundary: flatToPts(handle.gapBoundary(r.face, factor)),
+  }));
+  handle.free();
+  return out;
+}
+
 export class SpacePlateSession {
   private handle: SpacePlateHandle | null = null;
   private undoStack: SpacePlateHandle[] = [];
@@ -116,6 +170,11 @@ export class SpacePlateSession {
   private pending: SpacePlateHandle | null = null;
   /** True once the plate has been edited since the last build/bake-clear. */
   dirty = false;
+  /** Face-based plate (built from wall RECTANGLES via `buildFromRects`): rooms are
+   *  the gaps between walls, the plate vertices sit on the inner faces, and each
+   *  room is PRESENTED at its wall axis (centreline) so nodes land on the wall
+   *  centre. A centreline plate (`build`) presents its raw outline unchanged. */
+  private faceBased = false;
 
   /** Adopt an already-built handle (no history). For tests / direct seeding;
    *  normal use goes through `build`. */
@@ -138,17 +197,49 @@ export class SpacePlateSession {
     this.disposeHandle();
     this.clearHistory();
     this.handle = handle;
+    this.faceBased = false;
     this.dirty = false;
     return { rooms: this.rooms(), tol };
   }
 
+  /** Build a face-based plate from wall RECTANGLES (each wall's 4 footprint
+   *  corners, wall-major, `8·N` floats — see `flattenWallRects`). Rooms are the
+   *  bounded gaps between the rectangles, so the room boundary IS the wall faces
+   *  (no centroid bias) — and each room is presented at its true wall axis.
+   *  Replaces the current plate and clears history. */
+  buildFromRects(rectCoords: Float64Array, snapTolerance = 0.05, minArea = 0.3): { rooms: Room[] } {
+    const handle = SpacePlateHandle.fromWallRects(rectCoords, snapTolerance, minArea);
+    this.discardPending();
+    this.disposeHandle();
+    this.clearHistory();
+    this.handle = handle;
+    this.faceBased = true;
+    this.dirty = false;
+    return { rooms: this.rooms() };
+  }
+
   // ───────────────────────────── reads ─────────────────────────────
 
-  rooms(): Room[] { return this.handle ? (this.handle.snapshot() as Room[]) : []; }
+  /** Present a raw plate room. In face-based mode the plate vertices sit on the
+   *  inner wall faces (the gap), so swap the outline for the wall AXIS and report
+   *  the axis (centreline) area — the gross-area basis nodes are drawn at. */
+  private materialize(r: Room): Room {
+    if (!this.faceBased || !this.handle) return r;
+    const outline = flatToPts(this.handle.gapBoundary(r.face, 1));
+    return outline.length >= 3 ? { ...r, outline, area: polyArea2(outline) } : r;
+  }
+
+  rooms(): Room[] {
+    return this.handle ? (this.handle.snapshot() as Room[]).map((r) => this.materialize(r)) : [];
+  }
 
   /** A room's outline at the chosen wall boundary: the centreline (`center`),
    *  the net inner face (`inner`), or the gross outer face (`outer`). */
   boundaryOutline(face: number, boundary: 'center' | 'inner' | 'outer'): [number, number][] {
+    if (this.faceBased && this.handle) {
+      // Face-based: every room edge is a wall face, so the offset always applies.
+      return flatToPts(this.handle.gapBoundary(face, gapFactor(boundary)));
+    }
     if (!this.handle || boundary === 'center') {
       const room = this.rooms().find((r) => r.face === face);
       return room ? room.outline : [];

--- a/apps/viewer/src/lib/space-plate-session.ts
+++ b/apps/viewer/src/lib/space-plate-session.ts
@@ -1,0 +1,248 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `SpacePlateSession` — the owner of the persistent `SpacePlateHandle` and its
+ * editing lifecycle.
+ *
+ * The wasm handle owns Rust-side `Vec`s on the shared dlmalloc heap, so it must
+ * be freed deterministically (never via JS GC — a long-lived handle that
+ * outlives its frees corrupts the heap). Centralising that discipline here keeps
+ * the React layer from ever touching `.duplicate()` / `.free()` directly, and
+ * collapses the ~6 copies of the `duplicate → try → commit / catch → free →
+ * restore` pattern into one `edit()`.
+ *
+ * - **Mutations** go through `edit(fn)`: snapshot the plate, run `fn`, push the
+ *   snapshot onto the undo stack on success (clearing redo), or roll back to it
+ *   and rethrow on failure (so the caller reads the typed `editError`).
+ * - **Drags** go through `beginDrag` / `dragTo` / `commitDrag` / `cancelDrag`:
+ *   one pre-drag snapshot, live mutation, commit on drop or restore on cancel.
+ * - **Reads** go through the typed query methods; the raw handle is never
+ *   exposed, so a mutation can't sneak past the undo machinery.
+ */
+
+import init, { SpacePlateHandle } from '@ifc-lite/wasm';
+
+export interface Room {
+  face: number;
+  area: number;
+  simple: boolean;
+  outline: [number, number][];
+}
+
+export interface Boundary {
+  edge: number;
+  source: number | null;
+}
+
+/** Undo depth — bounded so a long session can't grow the heap unboundedly. */
+export const MAX_UNDO = 40;
+
+let wasmReady: Promise<void> | null = null;
+/** Initialise the wasm module once (idempotent). */
+export function ensureSpaceWasm(): Promise<void> {
+  if (!wasmReady) wasmReady = init().then(() => undefined);
+  return wasmReady;
+}
+
+/** Build a plate from flat wall segments. With `manualTol` null, escalate the
+ *  corner-snap tolerance until one encloses rooms (real centrelines miss corners
+ *  by ~½ a wall thickness, so a tight snap leaves the loop open → 0 rooms). */
+function buildHandle(
+  coords: Float64Array,
+  sources: Int32Array,
+  manualTol: number | null,
+  minArea: number,
+): { handle: SpacePlateHandle; tol: number } {
+  if (manualTol != null) {
+    return { handle: new SpacePlateHandle(coords, sources, manualTol, minArea), tol: manualTol };
+  }
+  let handle: SpacePlateHandle | null = null;
+  let tol = 0.1;
+  for (const t of [0.1, 0.25, 0.5]) {
+    const p = new SpacePlateHandle(coords, sources, t, minArea);
+    handle?.free();
+    handle = p;
+    tol = t;
+    if (p.roomCount > 0) break;
+  }
+  return { handle: handle!, tol };
+}
+
+/** Build a throwaway plate, read its rooms, and free it — for paths (e.g.
+ *  whole-building bake) that need a storey's rooms without a live session. */
+export function snapshotRooms(coords: Float64Array, sources: Int32Array, minArea = 0.5): Room[] {
+  const { handle } = buildHandle(coords, sources, null, minArea);
+  const rooms = handle.snapshot() as Room[];
+  handle.free();
+  return rooms;
+}
+
+export class SpacePlateSession {
+  private handle: SpacePlateHandle | null = null;
+  private undoStack: SpacePlateHandle[] = [];
+  private redoStack: SpacePlateHandle[] = [];
+  /** Pre-drag snapshot held for the duration of a live drag. */
+  private pending: SpacePlateHandle | null = null;
+  /** True once the plate has been edited since the last build/bake-clear. */
+  dirty = false;
+
+  /** Adopt an already-built handle (no history). For tests / direct seeding;
+   *  normal use goes through `build`. */
+  static fromHandle(handle: SpacePlateHandle): SpacePlateSession {
+    const s = new SpacePlateSession();
+    s.handle = handle;
+    return s;
+  }
+
+  get alive(): boolean { return this.handle != null; }
+  get roomCount(): number { return this.handle?.roomCount ?? 0; }
+  get canUndo(): boolean { return this.undoStack.length > 0; }
+  get canRedo(): boolean { return this.redoStack.length > 0; }
+
+  /** Build a fresh plate, replacing the current one and clearing all history.
+   *  Resets `dirty` (a fresh derive is the new clean baseline). */
+  build(coords: Float64Array, sources: Int32Array, manualTol: number | null, minArea = 0.5): { rooms: Room[]; tol: number } {
+    const { handle, tol } = buildHandle(coords, sources, manualTol, minArea);
+    this.discardPending();
+    this.disposeHandle();
+    this.clearHistory();
+    this.handle = handle;
+    this.dirty = false;
+    return { rooms: this.rooms(), tol };
+  }
+
+  // ───────────────────────────── reads ─────────────────────────────
+
+  rooms(): Room[] { return this.handle ? (this.handle.snapshot() as Room[]) : []; }
+  neighborAcross(edge: number): number | undefined { return this.handle?.neighborAcross(edge); }
+  boundingElements(face: number): Boundary[] {
+    return this.handle ? (this.handle.boundingElements(face) as Boundary[]) : [];
+  }
+  findVertexNear(x: number, y: number, tol: number): number | null {
+    const v = this.handle?.findVertexNear(x, y, tol);
+    return v === undefined ? null : v;
+  }
+
+  // ─────────────────────────── mutations ───────────────────────────
+
+  /**
+   * Run a mutation against the live plate, with undo/rollback handled here.
+   * On success the pre-edit snapshot is pushed to the undo stack and `dirty` is
+   * set; on a thrown rejection the plate is rolled back to the snapshot and the
+   * error is rethrown. `shouldCommit` lets an op that reports "nothing changed"
+   * (e.g. `prune` returning 0) skip the undo entry without leaving a dangling
+   * snapshot.
+   */
+  edit<T>(fn: (h: SpacePlateHandle) => T, shouldCommit: (result: T) => boolean = () => true): T {
+    const h = this.require();
+    const snap = h.duplicate();
+    let result: T;
+    try {
+      result = fn(h);
+    } catch (e) {
+      h.free();
+      this.handle = snap; // restore the pre-edit state
+      throw e;
+    }
+    if (shouldCommit(result)) {
+      this.pushUndo(snap);
+      this.dirty = true;
+    } else {
+      snap.free(); // no change — discard the snapshot, keep the (unchanged) plate
+    }
+    return result;
+  }
+
+  // ─────────────────────────── dragging ────────────────────────────
+
+  /** Begin a live drag: snapshot the current plate. Returns false if no plate. */
+  beginDrag(): boolean {
+    if (!this.handle) return false;
+    this.discardPending();
+    this.pending = this.handle.duplicate();
+    return true;
+  }
+
+  /** Apply a live drag step to vertex `v`. Swallows a torn-down-plate throw
+   *  (the handle can be freed mid-drag by a rebuild). */
+  dragTo(v: number, x: number, y: number): void {
+    try {
+      this.handle?.dragVertex(v, x, y);
+    } catch (e) {
+      console.debug('[space-sketch] dragVertex failed (plate torn down mid-drag?)', e);
+    }
+  }
+
+  /** Commit a drag: push the pre-drag snapshot onto the undo stack. */
+  commitDrag(): void {
+    if (!this.pending) return;
+    this.pushUndo(this.pending);
+    this.pending = null;
+    this.dirty = true;
+  }
+
+  /** Cancel a drag: restore the plate to its pre-drag snapshot. */
+  cancelDrag(): void {
+    if (this.pending && this.handle) {
+      this.handle.free();
+      this.handle = this.pending;
+      this.pending = null;
+    }
+  }
+
+  // ────────────────────────── undo / redo ──────────────────────────
+
+  undo(): boolean {
+    if (!this.handle || !this.undoStack.length) return false;
+    this.redoStack.push(this.handle);
+    this.handle = this.undoStack.pop()!;
+    return true;
+  }
+
+  redo(): boolean {
+    if (!this.handle || !this.redoStack.length) return false;
+    this.undoStack.push(this.handle);
+    this.handle = this.redoStack.pop()!;
+    return true;
+  }
+
+  /** Free every handle the session owns (current, history, pending). */
+  dispose(): void {
+    this.discardPending();
+    this.clearHistory();
+    this.disposeHandle();
+  }
+
+  // ───────────────────────────── internal ─────────────────────────────
+
+  private require(): SpacePlateHandle {
+    if (!this.handle) throw new Error('StaleHandle');
+    return this.handle;
+  }
+
+  private pushUndo(snap: SpacePlateHandle): void {
+    this.undoStack.push(snap);
+    if (this.undoStack.length > MAX_UNDO) this.undoStack.shift()!.free();
+    this.redoStack.forEach((h) => h.free());
+    this.redoStack = [];
+  }
+
+  private discardPending(): void {
+    this.pending?.free();
+    this.pending = null;
+  }
+
+  private clearHistory(): void {
+    this.undoStack.forEach((h) => h.free());
+    this.redoStack.forEach((h) => h.free());
+    this.undoStack = [];
+    this.redoStack = [];
+  }
+
+  private disposeHandle(): void {
+    this.handle?.free();
+    this.handle = null;
+  }
+}

--- a/apps/viewer/src/lib/space-sketch-geometry.test.ts
+++ b/apps/viewer/src/lib/space-sketch-geometry.test.ts
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  polyArea, pointInPoly, centroid, uniqueVerts, distToSeg, projectOnSeg,
+  computeFit, zoomFit, sX, sY, wX, wY, type Pt,
+} from './space-sketch-geometry.js';
+import type { Room } from './space-plate-session.js';
+
+const room = (outline: Pt[]): Room => ({ face: 0, area: polyArea(outline), simple: true, outline });
+const rect: Pt[] = [[0, 0], [4, 0], [4, 3], [0, 3]];
+
+describe('polyArea', () => {
+  it('is winding-independent (absolute)', () => {
+    assert.strictEqual(polyArea(rect), 12);
+    assert.strictEqual(polyArea([...rect].reverse()), 12);
+  });
+});
+
+describe('pointInPoly', () => {
+  it('detects inside vs outside', () => {
+    assert.strictEqual(pointInPoly(2, 1.5, rect), true);
+    assert.strictEqual(pointInPoly(5, 1.5, rect), false);
+  });
+});
+
+describe('centroid', () => {
+  it('averages the points', () => {
+    assert.deepStrictEqual(centroid(rect), [2, 1.5]);
+  });
+});
+
+describe('uniqueVerts', () => {
+  it('dedupes shared corners across rooms', () => {
+    const a = room([[0, 0], [4, 0], [4, 3], [0, 3]]);
+    const b = room([[4, 0], [8, 0], [8, 3], [4, 3]]); // shares (4,0) and (4,3)
+    assert.strictEqual(uniqueVerts([a, b]).length, 6, 'two shared corners collapse 8 → 6');
+  });
+});
+
+describe('distToSeg / projectOnSeg', () => {
+  it('measures perpendicular distance and clamps the projection', () => {
+    assert.ok(Math.abs(distToSeg(5, 1, 0, 0, 10, 0) - 1) < 1e-9);
+    assert.deepStrictEqual(projectOnSeg([5, 1], [0, 0], [10, 0]), [5, 0]);
+    // Past the end → clamps to the endpoint.
+    assert.deepStrictEqual(projectOnSeg([20, 5], [0, 0], [10, 0]), [10, 0]);
+  });
+});
+
+describe('computeFit / transforms', () => {
+  it('frames rooms centred and round-trips world↔screen', () => {
+    const f = computeFit([room(rect)], 580, 460);
+    // The room centre (2, 1.5) maps to the canvas centre.
+    assert.ok(Math.abs(sX(f, 2) - 290) < 1e-6);
+    assert.ok(Math.abs(sY(f, 1.5) - 230) < 1e-6);
+    // world → screen → world is identity.
+    assert.ok(Math.abs(wX(f, sX(f, 3.3)) - 3.3) < 1e-9);
+    assert.ok(Math.abs(wY(f, sY(f, 2.1)) - 2.1) < 1e-9);
+  });
+
+  it('falls back to a sane default for an empty scene', () => {
+    const f = computeFit([], 580, 460);
+    assert.strictEqual(f.scale, 1);
+  });
+
+  it('zoomFit keeps the anchor point fixed on screen', () => {
+    const f = computeFit([room(rect)], 580, 460);
+    const z = zoomFit(f, 2, 100, 200);
+    assert.ok(Math.abs(sX(z, wX(f, 100)) - 100) < 1e-6, 'anchor X stays put');
+    assert.ok(Math.abs(sY(z, wY(f, 200)) - 200) < 1e-6, 'anchor Y stays put');
+    assert.strictEqual(z.scale, f.scale * 2);
+  });
+});

--- a/apps/viewer/src/lib/space-sketch-geometry.ts
+++ b/apps/viewer/src/lib/space-sketch-geometry.ts
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Pure 2D geometry + view-transform helpers for the Space Sketch editor.
+ *
+ * Extracted from the overlay component so they're testable and reusable across
+ * the (interaction / renderer / panel) split — no React, no module state.
+ */
+
+import type { Room } from './space-plate-session';
+
+export type Pt = [number, number];
+
+/** Canvas inner margin (px) used when framing rooms to the view. */
+export const PAD = 36;
+
+/** Absolute polygon area (shoelace), m². */
+export function polyArea(pts: Pt[]): number {
+  let a = 0;
+  for (let k = 0; k < pts.length; k++) {
+    const p = pts[k], q = pts[(k + 1) % pts.length];
+    a += p[0] * q[1] - q[0] * p[1];
+  }
+  return Math.abs(a) / 2;
+}
+
+/** Ray-cast point-in-polygon test. */
+export function pointInPoly(x: number, y: number, poly: Pt[]): boolean {
+  let inside = false;
+  for (let i = 0, j = poly.length - 1; i < poly.length; j = i++) {
+    const xi = poly[i][0], yi = poly[i][1], xj = poly[j][0], yj = poly[j][1];
+    if ((yi > y) !== (yj > y) && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi) inside = !inside;
+  }
+  return inside;
+}
+
+export function centroid(pts: Pt[]): Pt {
+  let cx = 0, cy = 0;
+  for (const p of pts) { cx += p[0]; cy += p[1]; }
+  return [cx / pts.length, cy / pts.length];
+}
+
+/** Distinct vertices across all room outlines (deduped by 4-decimal key). */
+export function uniqueVerts(rooms: Room[]): Pt[] {
+  const seen = new Set<string>();
+  const out: Pt[] = [];
+  for (const r of rooms) for (const p of r.outline) {
+    const k = `${p[0].toFixed(4)},${p[1].toFixed(4)}`;
+    if (!seen.has(k)) { seen.add(k); out.push(p); }
+  }
+  return out;
+}
+
+/** Distance from point `(px,py)` to segment `a→b` (clamped to the segment). */
+export function distToSeg(px: number, py: number, ax: number, ay: number, bx: number, by: number): number {
+  const dx = bx - ax, dy = by - ay;
+  const len2 = dx * dx + dy * dy || 1e-9;
+  let t = ((px - ax) * dx + (py - ay) * dy) / len2;
+  t = Math.max(0, Math.min(1, t));
+  return Math.hypot(px - (ax + t * dx), py - (ay + t * dy));
+}
+
+/** Closest point on segment `a→b` to `p` (clamped to the segment). */
+export function projectOnSeg(p: Pt, a: Pt, b: Pt): Pt {
+  const dx = b[0] - a[0], dy = b[1] - a[1];
+  const len2 = dx * dx + dy * dy || 1e-9;
+  let t = ((p[0] - a[0]) * dx + (p[1] - a[1]) * dy) / len2;
+  t = Math.max(0, Math.min(1, t));
+  return [a[0] + t * dx, a[1] + t * dy];
+}
+
+/** Screen transform as a pure affine: `screen = off + world * scale` (Y
+ *  flipped). Decoupling from canvas size + a fixed origin lets one struct carry
+ *  fit-to-bounds, wheel-zoom, and drag-pan. */
+export interface Fit { scale: number; offX: number; offY: number }
+
+/** Frame the rooms centred within a `w`×`h` canvas (PAD margin) as an affine. */
+export function computeFit(rooms: Room[], w: number, h: number): Fit {
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  for (const r of rooms) for (const [x, y] of r.outline) {
+    minX = Math.min(minX, x); minY = Math.min(minY, y);
+    maxX = Math.max(maxX, x); maxY = Math.max(maxY, y);
+  }
+  if (!isFinite(minX)) return { scale: 1, offX: PAD, offY: h - PAD };
+  const scale = Math.min((w - 2 * PAD) / Math.max(maxX - minX, 1e-6), (h - 2 * PAD) / Math.max(maxY - minY, 1e-6));
+  const cx = (minX + maxX) / 2, cy = (minY + maxY) / 2;
+  return { scale, offX: w / 2 - cx * scale, offY: h / 2 + cy * scale };
+}
+
+/** Zoom by `factor` about screen point `(ax, ay)` (keeps it fixed). */
+export function zoomFit(f: Fit, factor: number, ax: number, ay: number): Fit {
+  return { scale: f.scale * factor, offX: ax - (ax - f.offX) * factor, offY: ay + (f.offY - ay) * factor };
+}
+
+export const sX = (f: Fit, x: number) => f.offX + x * f.scale;
+export const sY = (f: Fit, y: number) => f.offY - y * f.scale;
+export const wX = (f: Fit, sx: number) => (sx - f.offX) / f.scale;
+export const wY = (f: Fit, sy: number) => (f.offY - sy) / f.scale;

--- a/apps/viewer/src/lib/space-snap.test.ts
+++ b/apps/viewer/src/lib/space-snap.test.ts
@@ -47,12 +47,24 @@ describe('snapPoint', () => {
     assert.strictEqual(r.kind, 'none');
   });
 
-  it('still snaps to a corner that lies along the ortho line', () => {
-    // Ortho locks [4,0.1] → [4,0]; a vertex near that ortho point still snaps,
-    // so straight runs land cleanly on aligned corners.
-    const r = snapPoint([4, 0.1], { vertices: [[4.05, 0.02]], tol: 0.3, ortho: true, anchor: [0, 0] });
-    assert.deepStrictEqual(r.pt, [4.05, 0.02]);
+  it('ortho DOMINATES snap — snapping moves ALONG the line, never off it', () => {
+    // Ortho locks [4,0.1] → the horizontal line y=0. A vertex at [4.05, 0.4] is
+    // far OFF the line but its X is near → the result aligns X to 4.05 yet stays
+    // on the line (y=0). The old behaviour jumped to the vertex and broke ortho.
+    const r = snapPoint([4, 0.1], { vertices: [[4.05, 0.4]], tol: 0.3, ortho: true, anchor: [0, 0] });
+    assert.deepStrictEqual(r.pt, [4.05, 0], 'X aligned to the corner, Y still on the ortho line');
     assert.strictEqual(r.kind, 'vertex');
+  });
+
+  it('ortho snaps the free coord to where a wall crosses the ortho line', () => {
+    // Horizontal ortho line y=0 through the anchor; a diagonal wall [2,-1]→[4,1]
+    // crosses it at (3,0) (endpoints out of range) → the point snaps along the
+    // line to that crossing.
+    const r = snapPoint([3.1, 0.05], {
+      segments: [[[2, -1], [4, 1]]], tol: 0.3, ortho: true, anchor: [0, 0],
+    });
+    assert.deepStrictEqual(r.pt, [3, 0]);
+    assert.strictEqual(r.kind, 'line');
   });
 });
 

--- a/apps/viewer/src/lib/space-snap.test.ts
+++ b/apps/viewer/src/lib/space-snap.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { snapPoint, type Pt } from './space-snap.js';
+import { snapPoint, alignToAxes, type Pt } from './space-snap.js';
 
 const seg = (a: Pt, b: Pt): [Pt, Pt] => [a, b];
 
@@ -53,5 +53,33 @@ describe('snapPoint', () => {
     const r = snapPoint([4, 0.1], { vertices: [[4.05, 0.02]], tol: 0.3, ortho: true, anchor: [0, 0] });
     assert.deepStrictEqual(r.pt, [4.05, 0.02]);
     assert.strictEqual(r.kind, 'vertex');
+  });
+});
+
+describe('alignToAxes', () => {
+  const first: Pt = [0, 0];
+  const prev: Pt = [5, 4];
+
+  it('locks X to a reference axis (vertical guide) within tolerance', () => {
+    // Closing corner near the first point's X → snaps under it; keeps its own Y.
+    const r = alignToAxes([0.08, 4.2], [first, prev], 0.2);
+    assert.deepStrictEqual(r.pt, [0, 4.2]);
+    assert.deepStrictEqual(r.vRef, first);
+    assert.strictEqual(r.hRef, null);
+  });
+
+  it('aligns X and Y to two different references (rectangle corner)', () => {
+    // Under the first point (X) and level with the previous point (Y).
+    const r = alignToAxes([0.05, 3.95], [first, prev], 0.2);
+    assert.deepStrictEqual(r.pt, [0, 4]);
+    assert.deepStrictEqual(r.vRef, first);
+    assert.deepStrictEqual(r.hRef, prev);
+  });
+
+  it('leaves the point untouched when no axis is within tolerance', () => {
+    const r = alignToAxes([3, 2], [first, prev], 0.2);
+    assert.deepStrictEqual(r.pt, [3, 2]);
+    assert.strictEqual(r.vRef, null);
+    assert.strictEqual(r.hRef, null);
   });
 });

--- a/apps/viewer/src/lib/space-snap.test.ts
+++ b/apps/viewer/src/lib/space-snap.test.ts
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { snapPoint, type Pt } from './space-snap.js';
+
+const seg = (a: Pt, b: Pt): [Pt, Pt] => [a, b];
+
+describe('snapPoint', () => {
+  it('snaps to the nearest room vertex (corner) within tolerance', () => {
+    const r = snapPoint([1.04, 0.97], { vertices: [[1, 1], [5, 5]], tol: 0.2 });
+    assert.deepStrictEqual(r.pt, [1, 1]);
+    assert.strictEqual(r.kind, 'vertex');
+  });
+
+  it('snaps to a segment endpoint as a corner', () => {
+    const r = snapPoint([0.05, -0.05], { segments: [seg([0, 0], [4, 0])], tol: 0.2 });
+    assert.deepStrictEqual(r.pt, [0, 0]);
+    assert.strictEqual(r.kind, 'vertex');
+  });
+
+  it('prefers a corner over an on-wall projection when both are in range', () => {
+    // Cursor is near the wall body AND near its endpoint corner — corner wins.
+    const r = snapPoint([0.1, 0.1], { segments: [seg([0, 0], [10, 0])], tol: 0.5 });
+    assert.deepStrictEqual(r.pt, [0, 0]);
+    assert.strictEqual(r.kind, 'vertex');
+  });
+
+  it('snaps onto the wall body (projection) when no corner is in range', () => {
+    const r = snapPoint([5, 0.1], { segments: [seg([0, 0], [10, 0])], tol: 0.5 });
+    assert.deepStrictEqual(r.pt, [5, 0]);
+    assert.strictEqual(r.kind, 'line');
+  });
+
+  it('returns the raw point (no snap) when nothing is within tolerance', () => {
+    const r = snapPoint([5, 5], { vertices: [[0, 0]], segments: [seg([0, 0], [1, 0])], tol: 0.2 });
+    assert.deepStrictEqual(r.pt, [5, 5]);
+    assert.strictEqual(r.kind, 'none');
+  });
+
+  it('applies ortho relative to the anchor when no snap target is in range', () => {
+    // Mostly-horizontal move → locks Y to the anchor's Y.
+    const r = snapPoint([4, 0.3], { tol: 0.1, ortho: true, anchor: [0, 0] });
+    assert.deepStrictEqual(r.pt, [4, 0]);
+    assert.strictEqual(r.kind, 'none');
+  });
+
+  it('still snaps to a corner that lies along the ortho line', () => {
+    // Ortho locks [4,0.1] → [4,0]; a vertex near that ortho point still snaps,
+    // so straight runs land cleanly on aligned corners.
+    const r = snapPoint([4, 0.1], { vertices: [[4.05, 0.02]], tol: 0.3, ortho: true, anchor: [0, 0] });
+    assert.deepStrictEqual(r.pt, [4.05, 0.02]);
+    assert.strictEqual(r.kind, 'vertex');
+  });
+});

--- a/apps/viewer/src/lib/space-snap.ts
+++ b/apps/viewer/src/lib/space-snap.ts
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Snapping for the 2D Space Sketch editor — shared by both dragging existing
+ * room vertices and drawing new room corners, so every node behaves the same.
+ *
+ * Candidates, in priority order (nearest within `tol` wins per tier):
+ *   1. Corners — room vertices + building-line endpoints.
+ *   2. On-wall — projection onto the nearest building segment.
+ * Both work in the room (model-metre) frame, the same frame the underlay lines
+ * and room outlines already live in.
+ *
+ * Ortho (Shift) is applied first, relative to `anchor`, so straight runs still
+ * land on corners/walls; an in-range snap then overrides the ortho point (snap
+ * beats straightness, matching the drag behaviour the editor already had).
+ */
+
+export type Pt = [number, number];
+
+export type SnapKind = 'vertex' | 'line' | 'none';
+
+export interface SnapOptions {
+  /** Corner targets — existing room vertices. */
+  vertices?: ReadonlyArray<Pt>;
+  /** Building wall lines (room frame); endpoints snap as corners, bodies as on-wall. */
+  segments?: ReadonlyArray<readonly [Pt, Pt]>;
+  /** Snap radius in world (metre) units. */
+  tol: number;
+  /** Constrain to horizontal/vertical from `anchor` before snapping. */
+  ortho?: boolean;
+  /** Reference point for ortho (e.g. the previous drawn corner or drag start). */
+  anchor?: Pt | null;
+}
+
+export interface SnapResult {
+  pt: Pt;
+  kind: SnapKind;
+}
+
+/** Constrain `p` to a horizontal or vertical line through `anchor`, whichever
+ *  axis the cursor has moved further along. */
+function applyOrtho(p: Pt, anchor: Pt): Pt {
+  const dx = Math.abs(p[0] - anchor[0]);
+  const dy = Math.abs(p[1] - anchor[1]);
+  return dx >= dy ? [p[0], anchor[1]] : [anchor[0], p[1]];
+}
+
+/** Closest point on segment a→b to p (clamped to the segment). */
+function projectOnSeg(p: Pt, a: readonly [number, number], b: readonly [number, number]): Pt {
+  const dx = b[0] - a[0], dy = b[1] - a[1];
+  const len2 = dx * dx + dy * dy || 1e-9;
+  let t = ((p[0] - a[0]) * dx + (p[1] - a[1]) * dy) / len2;
+  t = Math.max(0, Math.min(1, t));
+  return [a[0] + t * dx, a[1] + t * dy];
+}
+
+export function snapPoint(p: Pt, opts: SnapOptions): SnapResult {
+  const { vertices = [], segments = [], tol, ortho = false, anchor = null } = opts;
+  const base: Pt = ortho && anchor ? applyOrtho(p, anchor) : [p[0], p[1]];
+
+  // 1. Corner snap — room vertices + segment endpoints. Scalar trackers (not a
+  // `Pt | null`) so TS control-flow doesn't narrow the accumulator to `never`.
+  let bestX = 0, bestY = 0, bestD = tol, foundCorner = false;
+  const consider = (qx: number, qy: number) => {
+    const d = Math.hypot(qx - base[0], qy - base[1]);
+    if (d < bestD) { bestD = d; bestX = qx; bestY = qy; foundCorner = true; }
+  };
+  for (const q of vertices) consider(q[0], q[1]);
+  for (const seg of segments) { consider(seg[0][0], seg[0][1]); consider(seg[1][0], seg[1][1]); }
+  if (foundCorner) return { pt: [bestX, bestY], kind: 'vertex' };
+
+  // 2. On-wall snap — nearest segment projection.
+  let projX = 0, projY = 0, projD = tol, foundLine = false;
+  for (const seg of segments) {
+    const q = projectOnSeg(base, seg[0], seg[1]);
+    const d = Math.hypot(q[0] - base[0], q[1] - base[1]);
+    if (d < projD) { projD = d; projX = q[0]; projY = q[1]; foundLine = true; }
+  }
+  if (foundLine) return { pt: [projX, projY], kind: 'line' };
+
+  // 3. No snap — the ortho-adjusted (or raw) point.
+  return { pt: base, kind: 'none' };
+}

--- a/apps/viewer/src/lib/space-snap.ts
+++ b/apps/viewer/src/lib/space-snap.ts
@@ -56,6 +56,35 @@ function projectOnSeg(p: Pt, a: readonly [number, number], b: readonly [number, 
   return [a[0] + t * dx, a[1] + t * dy];
 }
 
+export interface AlignResult {
+  pt: Pt;
+  /** Reference point whose X the result aligned to (vertical guide), if any. */
+  vRef: Pt | null;
+  /** Reference point whose Y the result aligned to (horizontal guide), if any. */
+  hRef: Pt | null;
+}
+
+/**
+ * Alignment / object-snap tracking: independently snap `p`'s X to the nearest
+ * reference point's X (a vertical guide) and its Y to the nearest reference's Y
+ * (a horizontal guide). Lets a drawn corner lock under/level-with an earlier
+ * corner — e.g. the closing point aligns vertically with the first point — so
+ * rectangles close cleanly. X and Y snap independently, so the result can sit at
+ * the intersection of two different references' axes.
+ */
+export function alignToAxes(p: Pt, refs: ReadonlyArray<Pt>, tol: number): AlignResult {
+  let x = p[0], y = p[1];
+  let vRef: Pt | null = null, hRef: Pt | null = null;
+  let bestVX = tol, bestHY = tol;
+  for (const r of refs) {
+    const dx = Math.abs(r[0] - p[0]);
+    if (dx < bestVX) { bestVX = dx; x = r[0]; vRef = r; }
+    const dy = Math.abs(r[1] - p[1]);
+    if (dy < bestHY) { bestHY = dy; y = r[1]; hRef = r; }
+  }
+  return { pt: [x, y], vRef, hRef };
+}
+
 export function snapPoint(p: Pt, opts: SnapOptions): SnapResult {
   const { vertices = [], segments = [], tol, ortho = false, anchor = null } = opts;
   const base: Pt = ortho && anchor ? applyOrtho(p, anchor) : [p[0], p[1]];

--- a/apps/viewer/src/lib/space-snap.ts
+++ b/apps/viewer/src/lib/space-snap.ts
@@ -12,9 +12,10 @@
  * Both work in the room (model-metre) frame, the same frame the underlay lines
  * and room outlines already live in.
  *
- * Ortho (Shift) is applied first, relative to `anchor`, so straight runs still
- * land on corners/walls; an in-range snap then overrides the ortho point (snap
- * beats straightness, matching the drag behaviour the editor already had).
+ * Ortho (Shift) DOMINATES snap: when `ortho` is set the point is locked to the
+ * horizontal/vertical line through `anchor` and snapping only moves it ALONG that
+ * line (to a corner's aligned coordinate, or where the line crosses a wall) — it
+ * can never break the straight constraint. Without Shift, snap is free in 2D.
  */
 
 export type Pt = [number, number];
@@ -37,14 +38,6 @@ export interface SnapOptions {
 export interface SnapResult {
   pt: Pt;
   kind: SnapKind;
-}
-
-/** Constrain `p` to a horizontal or vertical line through `anchor`, whichever
- *  axis the cursor has moved further along. */
-function applyOrtho(p: Pt, anchor: Pt): Pt {
-  const dx = Math.abs(p[0] - anchor[0]);
-  const dy = Math.abs(p[1] - anchor[1]);
-  return dx >= dy ? [p[0], anchor[1]] : [anchor[0], p[1]];
 }
 
 /** Closest point on segment a→b to p (clamped to the segment). */
@@ -85,9 +78,53 @@ export function alignToAxes(p: Pt, refs: ReadonlyArray<Pt>, tol: number): AlignR
   return { pt: [x, y], vRef, hRef };
 }
 
+/**
+ * Snap ALONG the ortho line through `anchor` (Shift held): the point stays on the
+ * horizontal/vertical line, and only the free coordinate is snapped — to a nearby
+ * corner's aligned coordinate (so the new node lines up with an existing one) or
+ * to where the ortho line crosses a wall. Never breaks the straight constraint.
+ */
+function snapAlongOrtho(
+  p: Pt,
+  anchor: Pt,
+  vertices: ReadonlyArray<Pt>,
+  segments: ReadonlyArray<readonly [Pt, Pt]>,
+  tol: number,
+): SnapResult {
+  const horizontal = Math.abs(p[0] - anchor[0]) >= Math.abs(p[1] - anchor[1]);
+  const free = horizontal ? 0 : 1; // coordinate that varies along the line
+  const fixed = horizontal ? 1 : 0; // coordinate pinned to the anchor
+  const fixedVal = anchor[fixed];
+  const target = p[free];
+  let best = target, bestD = tol;
+  let kind: SnapKind = 'none';
+  // (a) align the free coord with a nearby corner (room vertex or wall endpoint).
+  const alignTo = (q: Pt) => {
+    const d = Math.abs(q[free] - target);
+    if (d < bestD) { bestD = d; best = q[free]; kind = 'vertex'; }
+  };
+  for (const q of vertices) alignTo(q);
+  for (const seg of segments) { alignTo(seg[0]); alignTo(seg[1]); }
+  // (b) where the ortho line (fixed = fixedVal) crosses a wall segment.
+  for (const seg of segments) {
+    const fa = seg[0][fixed], fb = seg[1][fixed];
+    const denom = fb - fa;
+    if (Math.abs(denom) < 1e-9 || (fa - fixedVal) * (fb - fixedVal) > 0) continue; // parallel / no crossing
+    const t = (fixedVal - fa) / denom;
+    if (t < 0 || t > 1) continue;
+    const cross = seg[0][free] + t * (seg[1][free] - seg[0][free]);
+    const d = Math.abs(cross - target);
+    if (d < bestD) { bestD = d; best = cross; kind = 'line'; }
+  }
+  const pt: Pt = horizontal ? [best, fixedVal] : [fixedVal, best];
+  return { pt, kind };
+}
+
 export function snapPoint(p: Pt, opts: SnapOptions): SnapResult {
   const { vertices = [], segments = [], tol, ortho = false, anchor = null } = opts;
-  const base: Pt = ortho && anchor ? applyOrtho(p, anchor) : [p[0], p[1]];
+  // Shift held → ortho dominates: snap only along the straight line.
+  if (ortho && anchor) return snapAlongOrtho(p, anchor, vertices, segments, tol);
+  const base: Pt = [p[0], p[1]];
 
   // 1. Corner snap — room vertices + segment endpoints. Scalar trackers (not a
   // `Pt | null`) so TS control-flow doesn't narrow the accumulator to `never`.

--- a/apps/viewer/src/lib/wall-rects-from-meshes.test.ts
+++ b/apps/viewer/src/lib/wall-rects-from-meshes.test.ts
@@ -1,0 +1,84 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { footprintOBB, wallRectsFromMeshes } from './wall-rects-from-meshes.js';
+import type { MeshData } from '@ifc-lite/geometry';
+
+type Pt = [number, number];
+const near = (a: number, b: number, eps = 1e-6) => Math.abs(a - b) < eps;
+
+// A render-frame box for one wall: plan footprint is XZ, height is Y. A wall
+// 4 m long (X) × `thick` (Z), `h0..h1` tall (Y).
+function wallBox(expressId: number, x0: number, x1: number, z0: number, z1: number, y0: number, y1: number): MeshData {
+  const c = (x: number, y: number, z: number) => [x, y, z];
+  return {
+    expressId, ifcType: 'IfcWall',
+    positions: new Float32Array([
+      ...c(x0, y0, z0), ...c(x1, y0, z0), ...c(x1, y0, z1), ...c(x0, y0, z1),
+      ...c(x0, y1, z0), ...c(x1, y1, z0), ...c(x1, y1, z1), ...c(x0, y1, z1),
+    ]),
+  } as unknown as MeshData;
+}
+
+describe('footprintOBB', () => {
+  it('recovers an axis-aligned rectangle: length, thickness, corners', () => {
+    // 4 long × 0.8 thick, axis-aligned in the plan.
+    const pts: Pt[] = [[0, 0], [4, 0], [4, 0.8], [0, 0.8]];
+    const o = footprintOBB(pts)!;
+    assert.ok(near(o.length, 4, 1e-6), `length ${o.length}`);
+    assert.ok(near(o.thickness, 0.8, 1e-6), `thickness ${o.thickness}`);
+    assert.strictEqual(o.corners.length, 4);
+    // every input point coincides with a corner (rectangle reproduced exactly)
+    for (const p of pts) assert.ok(o.corners.some((c) => near(c[0], p[0], 1e-6) && near(c[1], p[1], 1e-6)), `corner for ${p}`);
+  });
+
+  it('the long axis is reported as length regardless of point order', () => {
+    const o = footprintOBB([[0, 0], [0, 5], [0.3, 5], [0.3, 0]])!; // thin in X, long in Y
+    assert.ok(near(o.length, 5, 1e-6));
+    assert.ok(near(o.thickness, 0.3, 1e-6));
+  });
+});
+
+describe('wallRectsFromMeshes', () => {
+  it('reads a wall rectangle from the rendered footprint (room frame, rtc=shift=0)', () => {
+    // Wall along X: renderX[0..4], renderZ[0..0.8], height Y[0..3].
+    // Room frame: ifcX = renderX, ifcY = -renderZ → ifcY in [-0.8, 0].
+    const rects = wallRectsFromMeshes([wallBox(1, 0, 4, 0, 0.8, 0, 3)], undefined, 0, 3);
+    assert.strictEqual(rects.length, 1);
+    assert.ok(near(rects[0].thickness, 0.8, 1e-4), `thickness ${rects[0].thickness}`);
+    const [a, b] = rects[0].centreline;
+    // centreline runs along X at the mid thickness (ifcY = -0.4)
+    assert.ok(near(a[1], -0.4, 1e-4) && near(b[1], -0.4, 1e-4), `centreline y ${a[1]},${b[1]}`);
+    assert.ok(near(Math.abs(b[0] - a[0]), 4, 1e-4), `centreline length ${Math.abs(b[0] - a[0])}`);
+  });
+
+  it('aggregates fragments of one wall (same expressId) before the OBB', () => {
+    // Two fragments of the SAME wall (a void-cut wall) — together a 4 m wall.
+    const rects = wallRectsFromMeshes(
+      [wallBox(7, 0, 1.5, 0, 0.8, 0, 3), wallBox(7, 2.5, 4, 0, 0.8, 0, 3)],
+      undefined, 0, 3,
+    );
+    assert.strictEqual(rects.length, 1, 'one wall, not two');
+    assert.ok(near(rects[0].thickness, 0.8, 1e-4));
+  });
+
+  it('excludes walls outside the storey height band', () => {
+    // Wall lives at Y[10..13]; storey band is [0,3] → excluded.
+    const rects = wallRectsFromMeshes([wallBox(1, 0, 4, 0, 0.8, 10, 13)], undefined, 0, 3);
+    assert.strictEqual(rects.length, 0);
+  });
+
+  it('includes a full-height wall that spans the band', () => {
+    // Wall Y[0..20] spans storey band [6,9] → included.
+    const rects = wallRectsFromMeshes([wallBox(1, 0, 4, 0, 0.8, 0, 20)], undefined, 6, 3);
+    assert.strictEqual(rects.length, 1);
+  });
+
+  it('ignores non-wall meshes', () => {
+    const slab = { expressId: 2, ifcType: 'IfcSlab', positions: new Float32Array([0, 0, 0, 5, 0, 0, 5, 0, 5, 0, 0, 5, 0, 0.2, 0, 5, 0.2, 0, 5, 0.2, 5, 0, 0.2, 5]) } as unknown as MeshData;
+    assert.strictEqual(wallRectsFromMeshes([slab], undefined, 0, 3).length, 0);
+  });
+});

--- a/apps/viewer/src/lib/wall-rects-from-meshes.test.ts
+++ b/apps/viewer/src/lib/wall-rects-from-meshes.test.ts
@@ -40,6 +40,21 @@ describe('footprintOBB', () => {
     assert.ok(near(o.length, 5, 1e-6));
     assert.ok(near(o.thickness, 0.3, 1e-6));
   });
+
+  it('is distribution-invariant: a dense diagonal interior cluster does NOT tilt it (PCA would)', () => {
+    // An axis-aligned 4 × 0.4 wall, plus many interior vertices packed along a
+    // diagonal. PCA's principal axis would tilt toward the cluster (this is the
+    // real-model bug — uneven mesh density skewed walls up to ~5°). The min-area
+    // rectangle depends only on the hull, so it stays axis-aligned.
+    const pts: Pt[] = [[0, 0], [4, 0], [4, 0.4], [0, 0.4]];
+    for (let i = 0; i < 60; i++) { const t = i / 59; pts.push([t * 4, t * 0.4]); }
+    const o = footprintOBB(pts)!;
+    const ang = Math.atan2(o.corners[1][1] - o.corners[0][1], o.corners[1][0] - o.corners[0][0]) * 180 / Math.PI;
+    const off = Math.min(Math.abs(((ang % 90) + 90) % 90), 90 - Math.abs(((ang % 90) + 90) % 90));
+    assert.ok(off < 0.01, `off-axis ${off}° (should be ~0 — not tilted by the interior cluster)`);
+    assert.ok(near(o.thickness, 0.4, 1e-4), `thickness ${o.thickness}`);
+    assert.ok(near(o.length, 4, 1e-4), `length ${o.length}`);
+  });
 });
 
 describe('wallRectsFromMeshes', () => {

--- a/apps/viewer/src/lib/wall-rects-from-meshes.ts
+++ b/apps/viewer/src/lib/wall-rects-from-meshes.ts
@@ -49,31 +49,69 @@ const MAX_THICK = 2.5;
 /** A wall is "on" a storey when its height range overlaps the band interior. */
 const BAND_MARGIN = 0.2;
 
-/** Oriented bounding box of a thin plan point cloud → its 4 CCW corners, length
- *  and thickness, via PCA + min/max extents (distribution-invariant). */
-export function footprintOBB(pts: Pt[]): { corners: [Pt, Pt, Pt, Pt]; length: number; thickness: number } | null {
-  const n = pts.length;
-  if (n < 3) return null;
-  let cx = 0, cy = 0;
-  for (const p of pts) { cx += p[0]; cy += p[1]; }
-  cx /= n; cy /= n;
-  let sxx = 0, sxy = 0, syy = 0;
-  for (const p of pts) { const dx = p[0] - cx, dy = p[1] - cy; sxx += dx * dx; sxy += dx * dy; syy += dy * dy; }
-  const ang = 0.5 * Math.atan2(2 * sxy, sxx - syy);
-  let u: Pt = [Math.cos(ang), Math.sin(ang)];
-  let nrm: Pt = [-Math.sin(ang), Math.cos(ang)];
-  let umin = Infinity, umax = -Infinity, nmin = Infinity, nmax = -Infinity;
-  for (const p of pts) {
-    const dx = p[0] - cx, dy = p[1] - cy;
-    const pu = dx * u[0] + dy * u[1], pn = dx * nrm[0] + dy * nrm[1];
-    if (pu < umin) umin = pu; if (pu > umax) umax = pu;
-    if (pn < nmin) nmin = pn; if (pn > nmax) nmax = pn;
+/** Convex hull (Andrew's monotone chain), CCW, of a plan point cloud. */
+function convexHull(pts: Pt[]): Pt[] {
+  const uniq = [...new Map(pts.map((p) => [`${p[0].toFixed(5)},${p[1].toFixed(5)}`, p])).values()]
+    .sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+  if (uniq.length < 3) return uniq;
+  const cross = (o: Pt, a: Pt, b: Pt) => (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0]);
+  const lower: Pt[] = [];
+  for (const p of uniq) {
+    while (lower.length >= 2 && cross(lower[lower.length - 2], lower[lower.length - 1], p) <= 0) lower.pop();
+    lower.push(p);
   }
-  let len = umax - umin, thick = nmax - nmin;
-  // Ensure u is the long (length) axis.
-  if (thick > len) { [u, nrm] = [nrm, u]; [len, thick] = [thick, len]; const t0 = umin, t1 = umax; umin = nmin; umax = nmax; nmin = t0; nmax = t1; }
-  const corner = (a: number, b: number): Pt => [cx + u[0] * a + nrm[0] * b, cy + u[1] * a + nrm[1] * b];
-  return { corners: [corner(umin, nmin), corner(umax, nmin), corner(umax, nmax), corner(umin, nmax)], length: len, thickness: thick };
+  const upper: Pt[] = [];
+  for (let i = uniq.length - 1; i >= 0; i--) {
+    const p = uniq[i];
+    while (upper.length >= 2 && cross(upper[upper.length - 2], upper[upper.length - 1], p) <= 0) upper.pop();
+    upper.push(p);
+  }
+  lower.pop();
+  upper.pop();
+  return lower.concat(upper);
+}
+
+/**
+ * MINIMUM-AREA bounding rectangle of a thin plan point cloud (rotating calipers
+ * on the convex hull) → its 4 CCW corners (long edge first), length, thickness.
+ *
+ * NOT PCA. PCA orients by minimizing variance, so on a wall whose mesh has uneven
+ * vertex density (short structural stubs especially) the principal axis tilts by
+ * several degrees even though the wall is axis-aligned — which skews the room into
+ * a parallelogram. The min-area rectangle depends only on the footprint OUTLINE
+ * (the hull), so it returns the true rectangle: measured 0.000° skew / 0 m off the
+ * rendered faces on the storeys where PCA produced ~5° skew.
+ */
+export function footprintOBB(pts: Pt[]): { corners: [Pt, Pt, Pt, Pt]; length: number; thickness: number } | null {
+  const h = convexHull(pts);
+  if (h.length < 3) return null;
+  let best: { area: number; corners: [Pt, Pt, Pt, Pt]; length: number; thickness: number } | null = null;
+  // The min-area rectangle is collinear with one hull edge — try them all.
+  for (let i = 0; i < h.length; i++) {
+    const a = h[i], b = h[(i + 1) % h.length];
+    let ex = b[0] - a[0], ey = b[1] - a[1];
+    const L = Math.hypot(ex, ey);
+    if (L < 1e-9) continue;
+    ex /= L; ey /= L;
+    const nx = -ey, ny = ex; // +90° (CCW) of the edge dir
+    let umin = Infinity, umax = -Infinity, vmin = Infinity, vmax = -Infinity;
+    for (const q of h) {
+      const du = (q[0] - a[0]) * ex + (q[1] - a[1]) * ey;
+      const dv = (q[0] - a[0]) * nx + (q[1] - a[1]) * ny;
+      if (du < umin) umin = du; if (du > umax) umax = du;
+      if (dv < vmin) vmin = dv; if (dv > vmax) vmax = dv;
+    }
+    const ulen = umax - umin, vlen = vmax - vmin;
+    const area = ulen * vlen;
+    if (best && area >= best.area) continue;
+    const P = (du: number, dv: number): Pt => [a[0] + ex * du + nx * dv, a[1] + ey * du + ny * dv];
+    // CCW corners; rotate so corners[0]→corners[1] is the LONG (length) axis,
+    // which `wallRectsFromMeshes` relies on to take the centreline.
+    let corners: [Pt, Pt, Pt, Pt] = [P(umin, vmin), P(umax, vmin), P(umax, vmax), P(umin, vmax)];
+    if (ulen < vlen) corners = [corners[1], corners[2], corners[3], corners[0]];
+    best = { area, corners, length: Math.max(ulen, vlen), thickness: Math.min(ulen, vlen) };
+  }
+  return best;
 }
 
 /**

--- a/apps/viewer/src/lib/wall-rects-from-meshes.ts
+++ b/apps/viewer/src/lib/wall-rects-from-meshes.ts
@@ -1,0 +1,128 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Wall footprint RECTANGLES for the face-based room derivation, read from the
+ * RENDERED meshes — the exact geometry the user sees in the 3D scene and behind
+ * the sketch as the construction underlay.
+ *
+ * Why not the STEP source geometry (`@ifc-lite/create` extract-walls)? Because a
+ * source-geometry centreline is only ever self-consistent: it was repeatedly
+ * validated against its OWN output, yet the room lines still landed off the
+ * rendered walls. Measured on a real 1036-wall structural model, the source path
+ * had (a) NO thickness for 0/1036 walls → every wall drawn at the 0.2 m default
+ * while real walls span 0.08–1.04 m, and (b) a PCA-centroid axis bias up to
+ * 0.33 m on thick walls. Deriving the rectangle straight from the rendered mesh
+ * footprint eliminates both: the OBB width IS the rendered thickness, and the
+ * min/max OBB axis is distribution-invariant. Room edges then sit on the rendered
+ * wall faces to ~1 mm (measured), because they ARE the rendered faces.
+ *
+ * Frame: the rendered meshes are WebGL Y-up (`world = origin + position`). The
+ * plan footprint is render XZ; we map it to the same "room frame" the underlay
+ * uses (`useConstructionUnderlay`): `ifcX = renderX + cx`, `ifcY = cy − renderZ`,
+ * with `cx = rtc.x − shift.x`, `cy = rtc.y + shift.z`. For models with no large
+ * coordinate shift (rtc = shift = 0) this is `(renderX, −renderZ)` — identity to
+ * IFC X/Y. Storey scoping is a render-Y (height) band overlap, so a full-height
+ * wall correctly bounds rooms on every storey it passes through.
+ */
+
+import type { MeshData, CoordinateInfo } from '@ifc-lite/geometry';
+
+type Pt = [number, number];
+
+/** One wall's footprint: the 4-corner rectangle (engine input), plus its
+ *  centreline + thickness (for the diagnostics overlay / "has wall data"). */
+export interface WallRect {
+  corners: Pt[];
+  centreline: [Pt, Pt];
+  thickness: number;
+}
+
+const WALL_TYPES = new Set(['IfcWall', 'IfcWallStandardCase']);
+
+/** OBB filter: drop slivers and anything too thick to be a wall (a mis-typed
+ *  slab/footing caught in the band). */
+const MIN_LEN = 0.3;
+const MIN_THICK = 0.02;
+const MAX_THICK = 2.5;
+/** A wall is "on" a storey when its height range overlaps the band interior. */
+const BAND_MARGIN = 0.2;
+
+/** Oriented bounding box of a thin plan point cloud → its 4 CCW corners, length
+ *  and thickness, via PCA + min/max extents (distribution-invariant). */
+export function footprintOBB(pts: Pt[]): { corners: [Pt, Pt, Pt, Pt]; length: number; thickness: number } | null {
+  const n = pts.length;
+  if (n < 3) return null;
+  let cx = 0, cy = 0;
+  for (const p of pts) { cx += p[0]; cy += p[1]; }
+  cx /= n; cy /= n;
+  let sxx = 0, sxy = 0, syy = 0;
+  for (const p of pts) { const dx = p[0] - cx, dy = p[1] - cy; sxx += dx * dx; sxy += dx * dy; syy += dy * dy; }
+  const ang = 0.5 * Math.atan2(2 * sxy, sxx - syy);
+  let u: Pt = [Math.cos(ang), Math.sin(ang)];
+  let nrm: Pt = [-Math.sin(ang), Math.cos(ang)];
+  let umin = Infinity, umax = -Infinity, nmin = Infinity, nmax = -Infinity;
+  for (const p of pts) {
+    const dx = p[0] - cx, dy = p[1] - cy;
+    const pu = dx * u[0] + dy * u[1], pn = dx * nrm[0] + dy * nrm[1];
+    if (pu < umin) umin = pu; if (pu > umax) umax = pu;
+    if (pn < nmin) nmin = pn; if (pn > nmax) nmax = pn;
+  }
+  let len = umax - umin, thick = nmax - nmin;
+  // Ensure u is the long (length) axis.
+  if (thick > len) { [u, nrm] = [nrm, u]; [len, thick] = [thick, len]; const t0 = umin, t1 = umax; umin = nmin; umax = nmax; nmin = t0; nmax = t1; }
+  const corner = (a: number, b: number): Pt => [cx + u[0] * a + nrm[0] * b, cy + u[1] * a + nrm[1] * b];
+  return { corners: [corner(umin, nmin), corner(umax, nmin), corner(umax, nmax), corner(umin, nmax)], length: len, thickness: thick };
+}
+
+/**
+ * Per-wall footprint rectangles (4 CCW corners, room frame) for the walls whose
+ * height range overlaps the storey band `[floorElevation, floorElevation +
+ * floorToFloor]`. Aggregates all mesh fragments of one wall (a void-cut wall
+ * renders as several) by `expressId` before taking the OBB.
+ */
+export function wallRectsFromMeshes(
+  meshes: readonly MeshData[],
+  coord: CoordinateInfo | undefined,
+  floorElevation: number,
+  floorToFloor: number,
+): WallRect[] {
+  const rtc = coord?.wasmRtcOffset ?? { x: 0, y: 0, z: 0 };
+  const shift = coord?.originShift ?? { x: 0, y: 0, z: 0 };
+  const cx = rtc.x - shift.x;
+  const cy = rtc.y + shift.z;
+  // Storey band in render-Y (height). renderY = ifcZ − rtc.z + shift.y.
+  const lo = floorElevation - rtc.z + shift.y;
+  const hi = floorElevation + floorToFloor - rtc.z + shift.y;
+
+  const walls = new Map<number, { pts: Pt[]; ymin: number; ymax: number }>();
+  for (const m of meshes) {
+    if (!m.ifcType || !WALL_TYPES.has(m.ifcType)) continue;
+    const pos = m.positions;
+    const o = m.origin ?? [0, 0, 0];
+    let w = walls.get(m.expressId);
+    if (!w) { w = { pts: [], ymin: Infinity, ymax: -Infinity }; walls.set(m.expressId, w); }
+    for (let i = 0; i + 2 < pos.length; i += 3) {
+      const rx = o[0] + pos[i], ry = o[1] + pos[i + 1], rz = o[2] + pos[i + 2];
+      w.pts.push([rx + cx, cy - rz]);
+      if (ry < w.ymin) w.ymin = ry;
+      if (ry > w.ymax) w.ymax = ry;
+    }
+  }
+
+  const out: WallRect[] = [];
+  for (const w of walls.values()) {
+    if (!(w.ymax > lo + BAND_MARGIN && w.ymin < hi - BAND_MARGIN)) continue; // not on this storey
+    if (w.pts.length < 6) continue;
+    const o = footprintOBB(w.pts);
+    if (!o || o.length <= MIN_LEN || o.thickness <= MIN_THICK || o.thickness >= MAX_THICK) continue;
+    const [c0, c1, c2, c3] = o.corners;
+    // Centreline = the mid-thickness line along the long axis (mid of each short
+    // edge). c0→c1 and c3→c2 are the long (face) edges.
+    const a: Pt = [(c0[0] + c3[0]) / 2, (c0[1] + c3[1]) / 2];
+    const b: Pt = [(c1[0] + c2[0]) / 2, (c1[1] + c2[1]) / 2];
+    out.push({ corners: o.corners, centreline: [a, b], thickness: o.thickness });
+  }
+  return out;
+}

--- a/apps/viewer/src/store/slices/mutationSlice.ts
+++ b/apps/viewer/src/store/slices/mutationSlice.ts
@@ -72,6 +72,7 @@ import {
 } from '@/lib/slab-edit.js';
 import { getModelLengthUnitScale } from '@/lib/length-unit-scale.js';
 import type { Point2D } from '@/lib/polygon-clip.js';
+import { registerAuthoredElement } from '@/utils/spatialHierarchy.js';
 
 /**
  * IFC-space directions for {@link MutationSlice.duplicateEntity}.
@@ -919,6 +920,18 @@ function runInStoreElementBuilder(
     entityId = build(editor, anchor);
   } catch (err) {
     return { error: err instanceof Error ? err.message : `Failed to ${errorContext}` };
+  }
+
+  // Make the authored element a first-class citizen immediately: register it in
+  // the spatial hierarchy so it appears in the spatial tree under its storey and
+  // resolves its storey assignment. The hierarchy is built from the columnar
+  // parse at load and otherwise never sees overlay-authored entities — so a
+  // baked IfcSpace would be invisible in the tree, have no storey, and (since it
+  // can't be picked from the tree) feel un-selectable / un-movable. (Aggregated
+  // spaces become a child node; contained elements join the storey's list.)
+  if (dataStore.spatialHierarchy) {
+    const name = dataStore.entities?.getName?.(entityId) ?? '';
+    registerAuthoredElement(dataStore.spatialHierarchy, storeyExpressId, entityId, ifcType, name);
   }
 
   // Build a renderer-frame mesh for the new element so it appears in

--- a/apps/viewer/src/store/slices/mutationSlice.ts
+++ b/apps/viewer/src/store/slices/mutationSlice.ts
@@ -930,7 +930,11 @@ function runInStoreElementBuilder(
   // can't be picked from the tree) feel un-selectable / un-movable. (Aggregated
   // spaces become a child node; contained elements join the storey's list.)
   if (dataStore.spatialHierarchy) {
-    const name = dataStore.entities?.getName?.(entityId) ?? '';
+    // Name lives on the overlay record (attrs[2] = Name for every IfcRoot
+    // subtype), not the columnar parse, so the tree label reads the authored
+    // name ("Space 1") rather than falling back to the type.
+    const rawName = editor.getNewEntity(entityId)?.attributes?.[2];
+    const name = typeof rawName === 'string' ? rawName : '';
     registerAuthoredElement(dataStore.spatialHierarchy, storeyExpressId, entityId, ifcType, name);
   }
 

--- a/apps/viewer/src/utils/spatialHierarchy.test.ts
+++ b/apps/viewer/src/utils/spatialHierarchy.test.ts
@@ -11,7 +11,62 @@ import {
   RelationshipType,
   StringTable,
 } from '@ifc-lite/data';
-import { rebuildSpatialHierarchy, rebuildOnDemandMaps } from './spatialHierarchy';
+import { rebuildSpatialHierarchy, rebuildOnDemandMaps, registerAuthoredElement } from './spatialHierarchy';
+
+describe('registerAuthoredElement', () => {
+  function baseHierarchy() {
+    const strings = new StringTable();
+    const entities = new EntityTableBuilder(4, strings);
+    entities.add(1, 'IFCPROJECT', 'p0', 'Project', '', '');
+    entities.add(2, 'IFCSITE', 's0', 'Site', '', '');
+    entities.add(3, 'IFCBUILDING', 'b0', 'Building', '', '');
+    entities.add(4, 'IFCBUILDINGSTOREY', 'st0', 'Level 1', '', '');
+    const rels = new RelationshipGraphBuilder();
+    rels.addEdge(1, 2, RelationshipType.Aggregates, 100);
+    rels.addEdge(2, 3, RelationshipType.Aggregates, 101);
+    rels.addEdge(3, 4, RelationshipType.Aggregates, 102);
+    const h = rebuildSpatialHierarchy(entities.build(), rels.build());
+    assert.ok(h);
+    return h;
+  }
+  const storeyNodeOf = (h: NonNullable<ReturnType<typeof rebuildSpatialHierarchy>>) =>
+    h.project.children[0].children[0].children[0];
+
+  it('adds an authored IfcSpace as a storey child node with a storey assignment', () => {
+    const h = baseHierarchy();
+    registerAuthoredElement(h, 4, 50, 'IFCSPACE', 'Kitchen');
+    assert.equal(h.elementToStorey.get(50), 4, 'space resolves its storey');
+    assert.ok(h.bySpace.has(50), 'space registered in bySpace');
+    const space = storeyNodeOf(h).children.find((c) => c.expressId === 50);
+    assert.ok(space, 'space is a child node of the storey');
+    assert.equal(space.type, IfcTypeEnum.IfcSpace);
+    assert.equal(space.name, 'Kitchen');
+  });
+
+  it('adds an authored contained element (slab) to the storey element list', () => {
+    const h = baseHierarchy();
+    registerAuthoredElement(h, 4, 60, 'IFCSLAB', 'Floor');
+    assert.equal(h.elementToStorey.get(60), 4);
+    assert.deepEqual(h.getStoreyElements(4), [60], 'slab joins the storey contained list');
+  });
+
+  it('is idempotent for repeated registration', () => {
+    const h = baseHierarchy();
+    registerAuthoredElement(h, 4, 50, 'IFCSPACE', 'Kitchen');
+    registerAuthoredElement(h, 4, 50, 'IFCSPACE', 'Kitchen');
+    registerAuthoredElement(h, 4, 60, 'IFCSLAB', 'Floor');
+    registerAuthoredElement(h, 4, 60, 'IFCSLAB', 'Floor');
+    assert.equal(storeyNodeOf(h).children.filter((c) => c.expressId === 50).length, 1);
+    assert.deepEqual(h.getStoreyElements(4), [60]);
+  });
+
+  it('falls back to a type name when no name is given', () => {
+    const h = baseHierarchy();
+    registerAuthoredElement(h, 4, 51, 'IFCSPACE', '');
+    const space = storeyNodeOf(h).children.find((c) => c.expressId === 51);
+    assert.equal(space?.name, 'IfcSpace');
+  });
+});
 
 describe('rebuildSpatialHierarchy', () => {
   it('preserves IFC4.3 facility-part trees during cache rebuilds', () => {

--- a/apps/viewer/src/utils/spatialHierarchy.ts
+++ b/apps/viewer/src/utils/spatialHierarchy.ts
@@ -223,6 +223,65 @@ export function rebuildSpatialHierarchy(
   };
 }
 
+/** Depth-first search for a spatial node by express id. */
+function findSpatialNode(node: SpatialNode, expressId: number): SpatialNode | null {
+  if (node.expressId === expressId) return node;
+  for (const child of node.children) {
+    const hit = findSpatialNode(child, expressId);
+    if (hit) return hit;
+  }
+  return null;
+}
+
+/**
+ * Register a freshly-authored element into an ALREADY-BUILT spatial hierarchy,
+ * in place, so it's a first-class citizen the instant it's created — visible in
+ * the spatial tree under its storey and resolving its storey assignment.
+ *
+ * Authored entities live in the store's mutation overlay, not the columnar parse
+ * the hierarchy was built from at load, so a full `rebuildSpatialHierarchy` can't
+ * see them (and would be O(n) per add anyway). This patches the maps + tree
+ * directly, mirroring how each relationship type lands a child:
+ *   - A spatial-structure element (IfcSpace / IfcSpatialZone, linked by
+ *     IfcRelAggregates) becomes a child NODE of the storey.
+ *   - Any other element (slab / wall / … linked by IfcRelContainedInSpatialStructure)
+ *     joins the storey's contained-element list (what the tree reads via byStorey).
+ * Idempotent. A later export+reparse rebuilds the hierarchy from the real
+ * relationships, so this is purely the live-session bridge.
+ */
+export function registerAuthoredElement(
+  hierarchy: SpatialHierarchy,
+  storeyExpressId: number,
+  entityId: number,
+  ifcTypeName: string,
+  name: string,
+): void {
+  hierarchy.elementToStorey.set(entityId, storeyExpressId);
+
+  const upper = ifcTypeName.toUpperCase();
+  if (upper === 'IFCSPACE' || upper === 'IFCSPATIALZONE') {
+    if (!hierarchy.bySpace.has(entityId)) hierarchy.bySpace.set(entityId, []);
+    const storeyNode = findSpatialNode(hierarchy.project, storeyExpressId);
+    if (storeyNode && !storeyNode.children.some((c) => c.expressId === entityId)) {
+      storeyNode.children.push({
+        expressId: entityId,
+        type: upper === 'IFCSPATIALZONE' ? IfcTypeEnum.IfcSpatialZone : IfcTypeEnum.IfcSpace,
+        name: name || (upper === 'IFCSPATIALZONE' ? 'IfcSpatialZone' : 'IfcSpace'),
+        children: [],
+        elements: [],
+      });
+    }
+    return;
+  }
+
+  const existing = hierarchy.byStorey.get(storeyExpressId);
+  if (existing) {
+    if (!existing.includes(entityId)) existing.push(entityId);
+  } else {
+    hierarchy.byStorey.set(storeyExpressId, [entityId]);
+  }
+}
+
 /**
  * Entity index type for property/quantity set lookup
  */

--- a/packages/renderer/src/scene-translate.test.ts
+++ b/packages/renderer/src/scene-translate.test.ts
@@ -64,4 +64,22 @@ describe('Scene.translateMeshesForEntity', () => {
     const scene = new Scene();
     assert.strictEqual(scene.translateMeshesForEntity(999, [1, 0, 0]), false);
   });
+
+  it('evicts the entity\'s stale selection-highlight meshes on move (no ghost)', () => {
+    const scene = new Scene();
+    scene.addMeshData(mesh(7, [0, 0, 0, 1, 0, 0, 0, 1, 0]));
+    // A standalone highlight mesh (frozen copy made at selection time) lives in
+    // scene.meshes and would otherwise linger at the old position after a move.
+    let destroyed = false;
+    const stub = () => ({ destroy: () => { destroyed = true; } });
+    const sceneMeshes = scene as unknown as { meshes: unknown[] };
+    sceneMeshes.meshes.push({ expressId: 7, vertexBuffer: stub(), indexBuffer: stub() });
+    sceneMeshes.meshes.push({ expressId: 99, vertexBuffer: { destroy() {} }, indexBuffer: { destroy() {} } });
+
+    scene.translateMeshesForEntity(7, [5, 0, 0]);
+
+    assert.strictEqual(sceneMeshes.meshes.length, 1, 'entity 7 highlight evicted, other kept');
+    assert.strictEqual((sceneMeshes.meshes[0] as { expressId: number }).expressId, 99);
+    assert.strictEqual(destroyed, true, 'evicted highlight GPU buffers were freed');
+  });
 });

--- a/packages/renderer/src/scene-translate.test.ts
+++ b/packages/renderer/src/scene-translate.test.ts
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { Scene } from './scene.js';
+import type { MeshData } from '@ifc-lite/geometry';
+
+/**
+ * `translateMeshesForEntity` mutates mesh positions in place (the GPU re-upload
+ * paths are guarded by a device we don't supply here), so the move logic is
+ * exercised CPU-side. The key contract: move a single-entity mesh (incl. an
+ * authored one that tags every vertex with its own id for picking), but never a
+ * genuine colour-merge shared by other entities.
+ */
+
+function mesh(
+  expressId: number,
+  positions: number[],
+  entityIds?: number[],
+): MeshData {
+  return {
+    expressId,
+    positions: new Float32Array(positions),
+    normals: new Float32Array(positions),
+    indices: new Uint32Array([0, 1, 2]),
+    color: [0, 0, 0, 1],
+    name: `mesh-${expressId}`,
+    ...(entityIds ? { entityIds: new Uint32Array(entityIds) } : {}),
+  } as unknown as MeshData;
+}
+
+describe('Scene.translateMeshesForEntity', () => {
+  it('moves a dedicated mesh with no entityIds (parsed single-entity)', () => {
+    const scene = new Scene();
+    const m = mesh(5, [0, 0, 0, 1, 1, 1]);
+    scene.addMeshData(m);
+    assert.strictEqual(scene.translateMeshesForEntity(5, [0, 5, 0]), true);
+    assert.strictEqual(m.positions[1], 5);
+    assert.strictEqual(m.positions[4], 6);
+  });
+
+  it('moves an authored single-entity mesh (every vertex tagged with its own id)', () => {
+    const scene = new Scene();
+    // buildPolygonExtrusion does entityIds.fill(globalId) — all the same id.
+    const m = mesh(7, [0, 0, 0, 1, 0, 0, 0, 1, 0], [7, 7, 7]);
+    scene.addMeshData(m);
+    assert.strictEqual(scene.translateMeshesForEntity(7, [10, 0, 0]), true, 'single-entity mesh translates');
+    assert.strictEqual(m.positions[0], 10);
+    assert.strictEqual(m.positions[3], 11);
+  });
+
+  it('skips a genuine colour-merged mesh shared by other entities', () => {
+    const scene = new Scene();
+    // Vertices belong to entities 7 AND 8 — moving 7 must not drag the merge.
+    const m = mesh(7, [0, 0, 0, 1, 0, 0, 0, 1, 0], [7, 7, 8]);
+    scene.addMeshData(m); // registered under both 7 and 8
+    assert.strictEqual(scene.translateMeshesForEntity(7, [10, 0, 0]), false, 'shared merge is not moved');
+    assert.strictEqual(m.positions[0], 0, 'positions unchanged');
+  });
+
+  it('returns false when the entity has no mesh', () => {
+    const scene = new Scene();
+    assert.strictEqual(scene.translateMeshesForEntity(999, [1, 0, 0]), false);
+  });
+});

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -632,6 +632,10 @@ export class Scene {
     for (const key of affectedKeys) {
       this.pendingBatchKeys.add(key);
     }
+    // Also drop the entity's standalone selection-highlight meshes — they're not
+    // in the buckets and would otherwise linger after a delete/split (same ghost
+    // class as a move).
+    this.evictHighlightMeshes(expressId);
     // True when at least one dedicated mesh was removed — covers
     // the case where a mesh was queued but not yet bucketed.
     return removedDedicated;
@@ -725,10 +729,31 @@ export class Scene {
     }
 
     this.boundingBoxes.delete(expressId);
+    // The per-entity selection-highlight meshes in `this.meshes` are frozen
+    // position copies made at selection time and are otherwise only cleared by
+    // clear() — so a moved-while-selected entity (the gizmo holds the selection
+    // through the drag) keeps drawing its highlight at the OLD position: a ghost.
+    // Evict them so the highlight re-extracts from the moved geometry next frame.
+    this.evictHighlightMeshes(expressId);
     for (const key of affectedKeys) {
       this.pendingBatchKeys.add(key);
     }
     return true;
+  }
+
+  /** Drop the per-entity selection-highlight meshes for `expressId` (frozen
+   *  copies in `this.meshes`) + free their GPU buffers, so the highlight is
+   *  rebuilt from the entity's current geometry on the next render. Used after a
+   *  translate or removal, which mutate the underlying geometry but don't touch
+   *  these standalone highlight meshes. */
+  private evictHighlightMeshes(expressId: number): void {
+    if (this.meshes.length === 0) return;
+    const kept: Mesh[] = [];
+    for (const mesh of this.meshes) {
+      if (mesh.expressId === expressId) destroyGpuResources(mesh);
+      else kept.push(mesh);
+    }
+    this.meshes = kept;
   }
 
   /** Bulk variant of `translateMeshesForEntity`. */

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -761,6 +761,22 @@ export class Scene {
     return this.meshQueueReadIndex < this.meshQueue.length;
   }
 
+  /** True while un-finalised streaming fragments are still being drawn. An
+   *  element appended during streaming (e.g. an authored IfcSpace) renders as
+   *  such a fragment AND accumulates in its colour bucket; once the bucket is
+   *  re-batched (e.g. by a move) the fragment becomes a stale duplicate, so the
+   *  caller should `finalizeStreaming` to merge fragments away. */
+  hasStreamingFragments(): boolean {
+    return this.streamingFragments.length > 0;
+  }
+
+  /** True when streaming runs in ephemeral mode (huge files) — fragments render
+   *  directly from GPU and geometry is NOT retained for re-batch, so callers
+   *  must NOT finalize (there's nothing to rebuild the batches from). */
+  isEphemeralStreaming(): boolean {
+    return this.ephemeralStreamingMode;
+  }
+
   setEphemeralStreamingMode(enabled: boolean): void {
     this.ephemeralStreamingMode = enabled;
   }

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -681,9 +681,20 @@ export class Scene {
     const affectedKeys = new Set<string>();
     let anyMoved = false;
     for (const meshData of meshDataList) {
-      // Skip shared color-merged meshes — translating their
-      // positions would move every entity in the merge.
-      if (meshData.entityIds && meshData.entityIds.length > 0) continue;
+      // Skip a genuinely shared color-merged mesh — one whose vertices belong to
+      // MORE than this entity — because translating it would drag the others too.
+      // An authored single-entity mesh (slab/space/wall added in-session) tags
+      // EVERY vertex with its own id for picking; all-same-id is safe to move, so
+      // only bail when a foreign id is present (was: skip on any entityIds at all,
+      // which froze authored elements under the gizmo even though their placement
+      // and bbox resolved fine).
+      if (meshData.entityIds && meshData.entityIds.length > 0) {
+        let shared = false;
+        for (let i = 0; i < meshData.entityIds.length; i++) {
+          if (meshData.entityIds[i] !== expressId) { shared = true; break; }
+        }
+        if (shared) continue;
+      }
       const pos = meshData.positions;
       for (let i = 0; i < pos.length; i += 3) {
         pos[i] += dx;

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -539,6 +539,16 @@ export class SpacePlateHandle {
    */
   mergeFaces(edge: number): any;
   /**
+   * Remove a wall edge, choosing the right semantics from its two faces:
+   * two real rooms → union them; a bridge / spur / outer-only wall → delete
+   * it and auto-clean the orphaned inner lines and nodes it leaves; a real
+   * enclosing wall (room ↔ exterior) → rejected (`BordersExterior`). This is
+   * the "remove this wall and tidy up" affordance for the orphan cruft the
+   * non-destructive wall arrangement leaves behind. Returns the rooms it
+   * changed (empty if the edge bounded no room).
+   */
+  removeEdge(edge: number): any;
+  /**
    * Flat outline `[x0, y0, x1, y1, …]` of a face (no repeated closing vertex).
    */
   faceOutline(face: number): Float64Array;
@@ -577,6 +587,14 @@ export class SpacePlateHandle {
    * `snapTolerance` / `minArea`: pass `<= 0` to take the defaults.
    */
   constructor(seg_coords: Float64Array, seg_sources: Int32Array, snap_tolerance: number, min_area: number);
+  /**
+   * Sweep the whole plate clean: remove dangling spur walls, isolated nodes,
+   * and redundant collinear nodes — the "clean up orphans" / eraser action.
+   * Area-neutral and idempotent. Returns how many topology elements were
+   * pruned (0 = the plate was already clean); the caller re-renders via
+   * `snapshot` like any other edit.
+   */
+  prune(): number;
   /**
    * Author a new room from a flat ring `[x0, y0, x1, y1, …]` (no repeated
    * closing vertex). `source` `-1` marks a user-drawn room. Winding is
@@ -925,6 +943,8 @@ export interface InitOutput {
   readonly spaceplatehandle_mergeFaces: (a: number, b: number, c: number) => void;
   readonly spaceplatehandle_neighborAcross: (a: number, b: number) => number;
   readonly spaceplatehandle_new: (a: number, b: number, c: number, d: number, e: number, f: number, g: number) => void;
+  readonly spaceplatehandle_prune: (a: number) => number;
+  readonly spaceplatehandle_removeEdge: (a: number, b: number, c: number) => void;
   readonly spaceplatehandle_roomCount: (a: number) => number;
   readonly spaceplatehandle_roomIds: (a: number, b: number) => void;
   readonly spaceplatehandle_setFaceHeight: (a: number, b: number, c: number, d: number, e: number) => void;

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -578,6 +578,13 @@ export class SpacePlateHandle {
    */
   faceOutline(face: number): Float64Array;
   /**
+   * Face-based gap-room boundary as flat `[x0, y0, …]`: each edge pushed
+   * OUTWARD (into the wall) by `factor × the source wall's half-thickness`.
+   * `0` → net (the gap / inner faces); `1` → centre axis (½ thickness, the
+   * editable node line on the wall mid); `2` → gross outer face.
+   */
+  gapBoundary(face: number, factor: number): Float64Array;
+  /**
    * Dissolve a degree-2 vertex, welding its two edges into one straight
    * edge between the neighbours — the inverse of `splitEdge`, and the
    * "delete this corner / node" affordance. Returns the rooms it changed.
@@ -585,6 +592,15 @@ export class SpacePlateHandle {
    * edge.
    */
   dissolveVertex(v: number): any;
+  /**
+   * FACE-BASED build: rooms are the gaps between wall footprint rectangles.
+   * `rectCoords` is flat `[x0, y0, x1, y1, x2, y2, x3, y3, …]` — 8 f64 per wall
+   * (its 4 plan-rectangle corners, CCW). A bounded arrangement face is a room
+   * only if its centroid is outside every rectangle (a gap, not a wall
+   * interior). The room outline IS the net (inner-face) area; `gapBoundary`
+   * gives the centre axis (½ thickness) and the gross outer face.
+   */
+  static fromWallRects(rect_coords: Float64Array, snap_tolerance: number, min_area: number): SpacePlateHandle;
   /**
    * The room on the far side of a half-edge (its twin's face), or
    * `undefined`. O(1) — the "who's across this wall" query.
@@ -969,6 +985,8 @@ export interface InitOutput {
   readonly spaceplatehandle_faceArea: (a: number, b: number) => number;
   readonly spaceplatehandle_faceOutline: (a: number, b: number, c: number) => void;
   readonly spaceplatehandle_findVertexNear: (a: number, b: number, c: number, d: number) => number;
+  readonly spaceplatehandle_fromWallRects: (a: number, b: number, c: number, d: number, e: number) => void;
+  readonly spaceplatehandle_gapBoundary: (a: number, b: number, c: number, d: number) => void;
   readonly spaceplatehandle_mergeFaces: (a: number, b: number, c: number) => void;
   readonly spaceplatehandle_neighborAcross: (a: number, b: number) => number;
   readonly spaceplatehandle_netOutline: (a: number, b: number, c: number, d: number) => void;

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -539,6 +539,15 @@ export class SpacePlateHandle {
    */
   mergeFaces(edge: number): any;
   /**
+   * The face outline offset to a wall boundary, as flat `[x0, y0, …]`: each
+   * edge is moved by its own wall's half-thickness — inward when `inset`
+   * (the net / inner face), outward otherwise (the gross / outer face).
+   * Shared room↔room edges are pinned when pushing outward. Falls back to the
+   * centreline outline when no offset applies — so it's always a sane ring.
+   * (For a `center` boundary just use `faceOutline`.)
+   */
+  netOutline(face: number, inset: boolean): Float64Array;
+  /**
    * Remove a wall edge, choosing the right semantics from its two faces:
    * two real rooms → union them; a bridge / spur / outer-only wall → delete
    * it and auto-clean the orphaned inner lines and nodes it leaves; a real
@@ -584,9 +593,12 @@ export class SpacePlateHandle {
    *
    * `segCoords`: `[ax, ay, bx, by, …]` (length a multiple of 4).
    * `segSources`: one `i32` per segment, `-1` for none.
+   * `segHalfThickness`: one `f64` per segment — half the wall's thickness in
+   * metres, carried onto the derived edges for `netOutline`. Pass an empty
+   * array (or all zeros) when thickness is unknown (centreline only).
    * `snapTolerance` / `minArea`: pass `<= 0` to take the defaults.
    */
-  constructor(seg_coords: Float64Array, seg_sources: Int32Array, snap_tolerance: number, min_area: number);
+  constructor(seg_coords: Float64Array, seg_sources: Int32Array, seg_half_thickness: Float64Array, snap_tolerance: number, min_area: number);
   /**
    * Sweep the whole plate clean: remove dangling spur walls, isolated nodes,
    * and redundant collinear nodes — the "clean up orphans" / eraser action.
@@ -942,7 +954,8 @@ export interface InitOutput {
   readonly spaceplatehandle_findVertexNear: (a: number, b: number, c: number, d: number) => number;
   readonly spaceplatehandle_mergeFaces: (a: number, b: number, c: number) => void;
   readonly spaceplatehandle_neighborAcross: (a: number, b: number) => number;
-  readonly spaceplatehandle_new: (a: number, b: number, c: number, d: number, e: number, f: number, g: number) => void;
+  readonly spaceplatehandle_netOutline: (a: number, b: number, c: number, d: number) => void;
+  readonly spaceplatehandle_new: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number) => void;
   readonly spaceplatehandle_prune: (a: number) => number;
   readonly spaceplatehandle_removeEdge: (a: number, b: number, c: number) => void;
   readonly spaceplatehandle_roomCount: (a: number) => number;

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -543,6 +543,14 @@ export class SpacePlateHandle {
    */
   faceOutline(face: number): Float64Array;
   /**
+   * Dissolve a degree-2 vertex, welding its two edges into one straight
+   * edge between the neighbours — the inverse of `splitEdge`, and the
+   * "delete this corner / node" affordance. Returns the rooms it changed.
+   * Rejects a wall junction (degree ≥ 3) or a weld that would duplicate an
+   * edge.
+   */
+  dissolveVertex(v: number): any;
+  /**
    * The room on the far side of a half-edge (its twin's face), or
    * `undefined`. O(1) — the "who's across this wall" query.
    */
@@ -569,6 +577,13 @@ export class SpacePlateHandle {
    * `snapTolerance` / `minArea`: pass `<= 0` to take the defaults.
    */
   constructor(seg_coords: Float64Array, seg_sources: Int32Array, snap_tolerance: number, min_area: number);
+  /**
+   * Author a new room from a flat ring `[x0, y0, x1, y1, …]` (no repeated
+   * closing vertex). `source` `-1` marks a user-drawn room. Winding is
+   * normalised to CCW; returns the new room patch. The room is its own
+   * connected component — it does not merge into existing topology.
+   */
+  addFace(coords: Float64Array, source: number): any;
   /**
    * Face ids of every live room.
    */
@@ -899,7 +914,9 @@ export interface InitOutput {
   readonly profileentryjs_modelIndex: (a: number) => number;
   readonly profileentryjs_outerPoints: (a: number) => number;
   readonly profileentryjs_transform: (a: number) => number;
+  readonly spaceplatehandle_addFace: (a: number, b: number, c: number, d: number, e: number) => void;
   readonly spaceplatehandle_boundingElements: (a: number, b: number, c: number) => void;
+  readonly spaceplatehandle_dissolveVertex: (a: number, b: number, c: number) => void;
   readonly spaceplatehandle_dragVertex: (a: number, b: number, c: number, d: number, e: number) => void;
   readonly spaceplatehandle_duplicate: (a: number) => number;
   readonly spaceplatehandle_faceArea: (a: number, b: number) => number;

--- a/rust/geometry/src/space_dcel.rs
+++ b/rust/geometry/src/space_dcel.rs
@@ -569,11 +569,24 @@ impl SpacePlate {
         let qa = self.half_edges[o1.0 as usize].next; // what followed o1 in fa
         let qb = self.half_edges[o2.0 as usize].next; // what followed o2 in fb
 
+        // The welded X↔Y edge only carries a wall provenance when BOTH survivors
+        // agreed on one — otherwise it spans two different source walls and must
+        // drop to `None`, so we don't emit a stale IfcRelSpaceBoundary link.
+        let welded_source = if self.half_edges[t1.0 as usize].source_element
+            == self.half_edges[t2.0 as usize].source_element
+        {
+            self.half_edges[t1.0 as usize].source_element
+        } else {
+            None
+        };
+
         // Re-twin the survivors into one undirected edge X↔Y, splicing out v.
         self.half_edges[t1.0 as usize].twin = t2; // t1 now X→Y
+        self.half_edges[t1.0 as usize].source_element = welded_source;
         self.half_edges[t1.0 as usize].next = qb;
         self.half_edges[qb.0 as usize].prev = t1;
         self.half_edges[t2.0 as usize].twin = t1; // t2 now Y→X
+        self.half_edges[t2.0 as usize].source_element = welded_source;
         self.half_edges[t2.0 as usize].next = qa;
         self.half_edges[qa.0 as usize].prev = t2;
 
@@ -616,6 +629,20 @@ impl SpacePlate {
     pub fn add_face(&mut self, points: &[[f64; 2]], source_element: Option<u32>) -> Result<FacePatch, EditError> {
         if points.len() < 3 || !is_simple_polygon(points) {
             return Err(EditError::InvalidPolygon);
+        }
+        // Reject consecutive coincident points, including the closing wrap. A
+        // zero-length edge slips past `is_simple_polygon` (its segment-cross test
+        // treats a degenerate segment as parallel), so a ring like [A, A, B, C]
+        // has non-zero area yet would persist a duplicate vertex + zero-length
+        // half-edge — malformed for later editing/offsetting/baking. Reachable
+        // from the draw UI (e.g. a double-click landing the final corner twice).
+        let n = points.len();
+        for i in 0..n {
+            let a = points[i];
+            let b = points[(i + 1) % n];
+            if (a[0] - b[0]).abs() < EPS && (a[1] - b[1]).abs() < EPS {
+                return Err(EditError::InvalidPolygon);
+            }
         }
         let signed = polygon_area(points);
         if signed.abs() < EPS {
@@ -1647,6 +1674,14 @@ mod tests {
         // Collinear (zero area).
         let line = vec![[0.0, 0.0], [2.0, 0.0], [4.0, 0.0]];
         assert_eq!(plate.add_face(&line, None), Err(EditError::InvalidPolygon));
+        // Consecutive duplicate point (zero-length edge) — non-zero area, but a
+        // degenerate edge that is_simple_polygon misses. Reachable via a
+        // double-click that lands the final corner twice.
+        let dup = vec![[0.0, 0.0], [0.0, 0.0], [4.0, 0.0], [4.0, 4.0]];
+        assert_eq!(plate.add_face(&dup, None), Err(EditError::InvalidPolygon));
+        // Repeated closing point (first == last) — the wrap-around case.
+        let closed = vec![[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 0.0]];
+        assert_eq!(plate.add_face(&closed, None), Err(EditError::InvalidPolygon));
     }
 
     // Test-only helper.

--- a/rust/geometry/src/space_dcel.rs
+++ b/rust/geometry/src/space_dcel.rs
@@ -140,6 +140,13 @@ struct Face {
     /// One boundary half-edge, or `None` once tombstoned.
     half_edge: Option<HalfEdgeId>,
     is_outer: bool,
+    /// Whether this bounded face is surfaced as a ROOM. Classified ONCE at build
+    /// (every bounded face for a centreline plate; only the gaps between wall
+    /// rectangles for a face-based plate) and then carried THROUGH edits — a
+    /// split inherits it, a merge ORs it. Never re-derived from geometry, so
+    /// dragging a vertex or cutting a room can't silently re-classify faces into
+    /// phantom rooms (the wall-rect centroid test was the culprit).
+    is_room: bool,
     floor_z: f64,
     ceiling_z: f64,
     /// Set when the ceiling plane is inferred (e.g. pitched roof underside);
@@ -233,35 +240,69 @@ impl SpacePlate {
         plate
     }
 
-    /// FACE-BASED build: rooms are the gaps BETWEEN wall footprint rectangles,
-    /// not the faces of a centreline arrangement. Each `rect` is a wall's plan
-    /// rectangle (4 corners); its 4 edges (the two long ones are the wall faces)
-    /// are arranged, and a resulting bounded face is a room iff its centroid lies
-    /// outside every rectangle (a gap, not a wall interior or a junction overlap).
+    /// FACE-BASED build → an editable CENTRELINE plate sitting on the wall axes.
     ///
-    /// Because the room boundary is literally the wall faces, a node can't sit
-    /// off the wall axis the way a centroid-derived centreline could, and there's
-    /// no fragile centreline-position sensitivity. Each edge carries half the
-    /// source wall's thickness (the rectangle's short extent / 2), so `net_outline`
-    /// offsets the gap (= the net / inner-face area) outward to the centre axis
-    /// (½ thickness) or the gross outer face (full thickness).
+    /// Two stages. (1) DETECT: arrange the wall footprint rectangle edges and keep
+    /// each bounded face whose centroid lies OUTSIDE every rectangle — i.e. a GAP
+    /// between walls (not a wall interior or a junction overlap). This locates the
+    /// rooms accurately, with the room boundary literally on the rendered wall
+    /// faces (no centroid-derived-centreline drift). (2) LIFT: take each gap room's
+    /// wall-AXIS outline (the net gap offset out by ½ thickness, corners
+    /// re-intersected) and arrange THOSE edges into the returned plate.
+    ///
+    /// The returned plate is therefore a normal centreline plate whose room
+    /// outlines ARE the wall axes and whose vertices ARE the displayed nodes — so
+    /// every editing op (drag / split / merge / dissolve) acts directly on what the
+    /// user sees, with no axis-vs-face offset. Each axis edge carries its wall's
+    /// half-thickness, so `net_outline` recovers the inner (net) and outer (gross)
+    /// faces. Adjacent rooms' shared wall maps to one shared centreline edge.
     pub fn build_from_wall_rects(rects: &[[[f64; 2]; 4]], options: BuildOptions) -> Self {
-        let mut segments: Vec<InputSegment> = Vec::with_capacity(rects.len() * 4);
+        // --- Stage 1: detect rooms as the gaps between wall rectangles. ---
+        let mut rect_edges: Vec<InputSegment> = Vec::with_capacity(rects.len() * 4);
         for (wi, r) in rects.iter().enumerate() {
             // Wall thickness = the rectangle's shorter side (faces are the long pair).
             let side = |a: [f64; 2], b: [f64; 2]| ((b[0] - a[0]).powi(2) + (b[1] - a[1]).powi(2)).sqrt();
-            let s01 = side(r[0], r[1]);
-            let s12 = side(r[1], r[2]);
-            let half = s01.min(s12) / 2.0;
+            let half = side(r[0], r[1]).min(side(r[1], r[2])) / 2.0;
             let src = Some(wi as u32);
             for i in 0..4 {
-                segments.push(InputSegment::new(r[i], r[(i + 1) % 4], src).with_half_thickness(half));
+                rect_edges.push(InputSegment::new(r[i], r[(i + 1) % 4], src).with_half_thickness(half));
             }
         }
-        let arr = Arrangement::resolve(&segments, options.snap_tolerance);
-        let mut plate = Self::from_arrangement(arr, options.min_area);
-        plate.wall_rects = rects.to_vec();
-        plate
+        let mut gap = Self::from_arrangement(Arrangement::resolve(&rect_edges, options.snap_tolerance), options.min_area);
+        gap.wall_rects = rects.to_vec();
+
+        // --- Stage 2: lift each gap room to its wall-axis outline and re-arrange. ---
+        let mut axis_edges: Vec<InputSegment> = Vec::new();
+        for i in 0..gap.faces.len() {
+            let f = FaceId(i as u32);
+            if gap.faces[i].is_outer || !gap.is_gap_face(f) {
+                continue;
+            }
+            let axis = gap.gap_boundary(f, 1.0); // net gap → wall axis (½ thickness out)
+            let cycle: Vec<HalfEdgeId> = gap.face_half_edges(f).collect();
+            if axis.len() < 3 || axis.len() != cycle.len() {
+                continue;
+            }
+            for k in 0..axis.len() {
+                let he = &gap.half_edges[cycle[k].0 as usize];
+                axis_edges.push(
+                    InputSegment::new(axis[k], axis[(k + 1) % axis.len()], he.source_element)
+                        .with_half_thickness(he.half_thickness),
+                );
+            }
+        }
+        // Fallback: if the lift produced nothing usable (degenerate input), return
+        // the gap plate as-is so the caller still gets rooms.
+        if axis_edges.is_empty() {
+            for i in 0..gap.faces.len() {
+                let f = FaceId(i as u32);
+                gap.faces[i].is_room = !gap.faces[i].is_outer && gap.is_gap_face(f);
+            }
+            return gap;
+        }
+        // The returned plate has no `wall_rects`, so `is_room` defaults to every
+        // bounded face — exactly the lifted axis rooms.
+        Self::from_arrangement(Arrangement::resolve(&axis_edges, options.snap_tolerance), options.min_area)
     }
 
     fn from_arrangement(arr: Arrangement, min_area: f64) -> Self {
@@ -362,6 +403,9 @@ impl SpacePlate {
             plate.faces.push(Face {
                 half_edge: cycle.first().copied(),
                 is_outer: is_outer || too_small,
+                // Centreline default: every bounded, non-tiny face is a room.
+                // `build_from_wall_rects` re-classifies to gaps-only afterwards.
+                is_room: !(is_outer || too_small),
                 floor_z: 0.0,
                 ceiling_z: 0.0,
                 non_planar_ceiling: false,
@@ -481,6 +525,7 @@ impl SpacePlate {
         self.faces.push(Face {
             half_edge: Some(e_ba),
             is_outer: false,
+            is_room: parent.is_room, // both halves of a split stay rooms
             floor_z: parent.floor_z,
             ceiling_z: parent.ceiling_z,
             non_planar_ceiling: parent.non_planar_ceiling,
@@ -575,6 +620,8 @@ impl SpacePlate {
         self.half_edges[tp.0 as usize].next = hn;
         self.half_edges[hn.0 as usize].prev = tp;
 
+        // The merged face is a room if either side was.
+        self.faces[f_keep.0 as usize].is_room |= self.faces[f_drop.0 as usize].is_room;
         // Re-home f_drop's loop onto f_keep, then tombstone f_drop + the edge.
         self.faces[f_keep.0 as usize].half_edge = Some(hp);
         let merged_cycle: Vec<HalfEdgeId> = self.face_half_edges(f_keep).collect();
@@ -964,6 +1011,7 @@ impl SpacePlate {
         self.faces.push(Face {
             half_edge: Some(HalfEdgeId(h0)),
             is_outer: false,
+            is_room: true, // a user-drawn partition is a room
             floor_z: 0.0,
             ceiling_z: 0.0,
             non_planar_ceiling: false,
@@ -972,6 +1020,7 @@ impl SpacePlate {
         self.faces.push(Face {
             half_edge: Some(HalfEdgeId(g0)),
             is_outer: true,
+            is_room: false,
             floor_z: 0.0,
             ceiling_z: 0.0,
             non_planar_ceiling: false,
@@ -1002,14 +1051,15 @@ impl SpacePlate {
             .map(|i| FaceId(i as u32))
             .filter(move |f| {
                 let face = &self.faces[f.0 as usize];
-                face.alive && !face.is_outer && self.is_room_face(*f)
+                face.alive && face.is_room
             })
     }
 
-    /// Face-based room test: a bounded face is a room when its centroid is not
-    /// inside any wall rectangle (a gap, not a wall interior). Always true for
-    /// the centreline build (no `wall_rects`).
-    fn is_room_face(&self, face: FaceId) -> bool {
+    /// Geometric gap test used ONCE at build to classify face-based rooms: a
+    /// bounded face is a gap (room) when its centroid is not inside any wall
+    /// rectangle. True for the centreline build (no `wall_rects`). Not used after
+    /// build — `Face::is_room` is the carried-through source of truth.
+    fn is_gap_face(&self, face: FaceId) -> bool {
         if self.wall_rects.is_empty() {
             return true;
         }
@@ -1789,12 +1839,41 @@ mod tests {
         let plate = SpacePlate::build_from_wall_rects(&rects, BuildOptions::default());
         assert_eq!(plate.room_count(), 1, "the gap between the four walls is the one room");
         let room = plate.rooms().next().unwrap();
-        let net = polygon_area(&plate.face_outline(room)).abs();
-        assert!((net - 10.64).abs() < 1e-6, "net (gap / inner faces) = 10.64, got {net}");
-        let axis = polygon_area(&plate.gap_boundary(room, 1.0)).abs();
-        assert!((axis - 12.0).abs() < 1e-6, "axis (+½ thickness, the node line) = 12, got {axis}");
-        let gross = polygon_area(&plate.gap_boundary(room, 2.0)).abs();
-        assert!((gross - 13.44).abs() < 1e-6, "gross (+ full thickness) = 13.44, got {gross}");
+        // The editable plate sits on the wall AXIS: the room outline IS the axis
+        // (4×3 = 12), and net_outline recovers the inner (net) / outer (gross) faces.
+        let axis = polygon_area(&plate.face_outline(room)).abs();
+        assert!((axis - 12.0).abs() < 1e-6, "room outline is the wall axis (4×3=12), got {axis}");
+        let net = polygon_area(&plate.net_outline(room, true)).abs();
+        assert!((net - 10.64).abs() < 1e-3, "net (inner faces) = 10.64, got {net}");
+        let gross = polygon_area(&plate.net_outline(room, false)).abs();
+        assert!((gross - 13.44).abs() < 1e-3, "gross (outer faces) = 13.44, got {gross}");
+    }
+
+    #[test]
+    fn face_based_edits_preserve_room_classification() {
+        // The 4-wall box → one gap room. `is_room` is set once at build and
+        // carried through edits, so neither a drag nor a split can re-classify
+        // wall-interior faces into phantom rooms — and a split yields TWO rooms.
+        let rects = vec![
+            [[-0.1, -0.1], [4.1, -0.1], [4.1, 0.1], [-0.1, 0.1]],
+            [[-0.1, 2.9], [4.1, 2.9], [4.1, 3.1], [-0.1, 3.1]],
+            [[-0.1, -0.1], [0.1, -0.1], [0.1, 3.1], [-0.1, 3.1]],
+            [[3.9, -0.1], [4.1, -0.1], [4.1, 3.1], [3.9, 3.1]],
+        ];
+        let mut plate = SpacePlate::build_from_wall_rects(&rects, BuildOptions::default());
+        assert_eq!(plate.room_count(), 1);
+        // The plate sits on the wall axis, so the room corners are the axis corners
+        // (0,0)…(4,3). Drag one inward — must NOT spawn a phantom room.
+        let corner = plate.find_vertex([4.0, 3.0]);
+        plate.drag_vertex(corner, 3.7, 2.7).expect("drag");
+        assert_eq!(plate.room_count(), 1, "a drag must not spawn phantom rooms");
+        // Cut the room across → two rooms (both halves inherit is_room; this was
+        // the "can't cut a space in half" bug).
+        let room = plate.rooms().next().unwrap();
+        let a = plate.find_vertex([0.0, 0.0]);
+        let b = plate.find_vertex([3.7, 2.7]);
+        plate.split_face(room, a, b, None).expect("split");
+        assert_eq!(plate.room_count(), 2, "a split produces two rooms");
     }
 
     /// Two rooms sharing a central wall — the canonical "shared edge"

--- a/rust/geometry/src/space_dcel.rs
+++ b/rust/geometry/src/space_dcel.rs
@@ -183,6 +183,11 @@ pub struct SpacePlate {
 }
 
 const EPS: f64 = 1e-9;
+/// Perpendicular-distance threshold (metres) for "this degree-2 node is a
+/// redundant collinear point on a straight run" — used by `prune_orphans` to
+/// dissolve derivation cruft. Far below the wall snap tolerance (default 0.1 m)
+/// so genuine corners are never mistaken for collinear and dissolved away.
+const EPS_COLL: f64 = 1e-6;
 
 impl SpacePlate {
     // ───────────────────────── construction ─────────────────────────
@@ -199,7 +204,13 @@ impl SpacePlate {
     /// 7. flag CW cycles as exterior and drop sub-`min_area` rooms.
     pub fn build(segments: &[InputSegment], options: BuildOptions) -> Self {
         let arr = Arrangement::resolve(segments, options.snap_tolerance);
-        Self::from_arrangement(arr, options.min_area)
+        let mut plate = Self::from_arrangement(arr, options.min_area);
+        // The arrangement is non-destructive, so it can carry cruft that bounds
+        // no room — dangling spur walls and the redundant collinear nodes they
+        // leave behind. Clean them so a derived plate starts as just its rooms
+        // (a no-op on already-clean inputs; never changes a room's area).
+        plate.prune_orphans();
+        plate
     }
 
     fn from_arrangement(arr: Arrangement, min_area: f64) -> Self {
@@ -616,6 +627,209 @@ impl SpacePlate {
             .collect())
     }
 
+    /// Live degree of a vertex (its number of live outgoing half-edges).
+    fn vertex_degree(&self, v: VertexId) -> usize {
+        let vi = v.0 as usize;
+        if vi >= self.vertices.len() || !self.vertices[vi].alive {
+            return 0;
+        }
+        self.outgoing_half_edges(v).count()
+    }
+
+    /// Remove the undirected edge of a **degree-1 spur tip** — a dangling wall
+    /// poking into a face — splicing the face cycle closed and tombstoning the
+    /// tip. `spur_he` may be either half-edge of the spur. Internal; driven by
+    /// `prune_orphans` / `remove_edge`. Area-neutral: the tip's out-and-back
+    /// boundary contributes cancelling shoelace terms, so no face area changes.
+    fn remove_spur_edge(&mut self, spur_he: HalfEdgeId) -> Result<(), EditError> {
+        let hi = spur_he.0 as usize;
+        if hi >= self.half_edges.len() || !self.half_edges[hi].alive {
+            return Err(EditError::StaleHandle);
+        }
+        let t = self.half_edges[hi].twin;
+        // Orient so `s = T→J` (origin is the degree-1 tip) and `s_t = J→T`.
+        let (s, s_t) = if self.vertex_degree(self.half_edges[hi].origin) == 1 {
+            (spur_he, t)
+        } else if self.vertex_degree(self.half_edges[t.0 as usize].origin) == 1 {
+            (t, spur_he)
+        } else {
+            return Err(EditError::VertexNotDissolvable); // neither end is a tip
+        };
+        let tip = self.half_edges[s.0 as usize].origin;
+        let j = self.half_edges[s_t.0 as usize].origin;
+        let f = self.half_edges[s.0 as usize].face;
+        // A genuine tip is a peninsula: both half-edges share one face and the
+        // rotation at the tip is the out-and-back pattern. Else it's corrupt.
+        if self.half_edges[s_t.0 as usize].face != f
+            || self.half_edges[s_t.0 as usize].next != s
+            || self.half_edges[s.0 as usize].prev != s_t
+        {
+            return Err(EditError::StaleHandle);
+        }
+        let a = self.half_edges[s_t.0 as usize].prev; // ends at J
+        let b = self.half_edges[s.0 as usize].next; // starts at J
+
+        if a == s {
+            // Lone stick: J is degree-1 too — the whole 2-vertex component is just
+            // this edge bounding one outer face. Tombstone the lot.
+            if !self.faces[f.0 as usize].is_outer {
+                return Err(EditError::StaleHandle); // a lone stick can't bound a room
+            }
+            self.half_edges[s.0 as usize].alive = false;
+            self.half_edges[s_t.0 as usize].alive = false;
+            self.vertices[tip.0 as usize].outgoing = None;
+            self.vertices[tip.0 as usize].alive = false;
+            self.vertices[j.0 as usize].outgoing = None;
+            self.vertices[j.0 as usize].alive = false;
+            self.faces[f.0 as usize].alive = false;
+            self.faces[f.0 as usize].half_edge = None;
+            return Ok(());
+        }
+
+        // Splice the spur out of F's cycle: A → B directly.
+        self.half_edges[a.0 as usize].next = b;
+        self.half_edges[b.0 as usize].prev = a;
+        self.half_edges[s.0 as usize].alive = false;
+        self.half_edges[s_t.0 as usize].alive = false;
+        self.vertices[tip.0 as usize].outgoing = None;
+        self.vertices[tip.0 as usize].alive = false;
+        self.repair_vertex_outgoing(j, s_t);
+        if matches!(self.faces[f.0 as usize].half_edge, Some(h) if h == s || h == s_t) {
+            self.faces[f.0 as usize].half_edge = Some(a);
+        }
+        Ok(())
+    }
+
+    /// Remove all orphaned cruft the wall arrangement leaves behind: dangling
+    /// spur walls (degree-1 chains), isolated vertices, and redundant collinear
+    /// degree-2 nodes. Idempotent, and never changes a room's area (spurs bound
+    /// no room; collinear dissolve only straightens a node already on its chord).
+    /// Returns how many topology elements were pruned.
+    pub fn prune_orphans(&mut self) -> usize {
+        let mut removed = 0usize;
+        // Phase A — spur sweep to a fixpoint (chews whole chains).
+        loop {
+            let tips: Vec<VertexId> = (0..self.vertices.len())
+                .map(|i| VertexId(i as u32))
+                .filter(|&v| self.vertex_degree(v) == 1)
+                .collect();
+            if tips.is_empty() {
+                break;
+            }
+            for tip in tips {
+                if self.vertex_degree(tip) != 1 {
+                    continue; // a sibling removal already changed it
+                }
+                let s = self.outgoing_half_edges(tip).next();
+                if let Some(s) = s {
+                    if self.remove_spur_edge(s).is_ok() {
+                        removed += 1;
+                    }
+                }
+            }
+        }
+        // Phase B — drop leftover degree-0 (isolated) vertices.
+        for i in 0..self.vertices.len() {
+            let v = VertexId(i as u32);
+            if self.vertices[i].alive && self.vertex_degree(v) == 0 {
+                self.vertices[i].alive = false;
+                self.vertices[i].outgoing = None;
+                removed += 1;
+            }
+        }
+        // Phase C — dissolve redundant collinear degree-2 nodes (fixpoint).
+        loop {
+            let mut progress = false;
+            let cands: Vec<VertexId> = (0..self.vertices.len())
+                .map(|i| VertexId(i as u32))
+                .filter(|&v| self.vertex_degree(v) == 2)
+                .collect();
+            for v in cands {
+                if self.vertex_degree(v) != 2 {
+                    continue;
+                }
+                let outs: Vec<HalfEdgeId> = self.outgoing_half_edges(v).collect();
+                let p = self.vertices[v.0 as usize].pos;
+                let x = self.vertices[self.dest(outs[0]).0 as usize].pos;
+                let y = self.vertices[self.dest(outs[1]).0 as usize].pos;
+                if perp_distance(p, x, y) >= EPS_COLL {
+                    continue; // a genuine corner — keep it
+                }
+                if self.dissolve_vertex(v).is_ok() {
+                    removed += 1;
+                    progress = true;
+                }
+            }
+            if !progress {
+                break;
+            }
+        }
+        removed
+    }
+
+    /// Remove the wall `edge`, choosing the right semantics from its two
+    /// incident faces, and auto-clean the orphans it leaves:
+    /// - room ↔ room → union the two rooms (`merge_faces`);
+    /// - bridge (same face both sides) or outer ↔ outer → delete it + `prune_orphans`;
+    /// - room ↔ outer (a real enclosing wall) → `BordersExterior` (don't open a room).
+    pub fn remove_edge(&mut self, edge: HalfEdgeId) -> Result<Vec<FacePatch>, EditError> {
+        let hi = edge.0 as usize;
+        if hi >= self.half_edges.len() || !self.half_edges[hi].alive {
+            return Err(EditError::StaleHandle);
+        }
+        let t = self.half_edges[hi].twin;
+        let f_keep = self.half_edges[hi].face;
+        let f_drop = self.half_edges[t.0 as usize].face;
+        let keep_outer = self.faces[f_keep.0 as usize].is_outer;
+        let drop_outer = self.faces[f_drop.0 as usize].is_outer;
+
+        if f_keep != f_drop && !keep_outer && !drop_outer {
+            return self.merge_faces(edge); // two real rooms → union
+        }
+        if f_keep != f_drop && keep_outer != drop_outer {
+            return Err(EditError::BordersExterior); // would open a room
+        }
+
+        // Bridge (f_keep == f_drop) or outer ↔ outer → delete + clean.
+        let hn = self.half_edges[hi].next;
+        let hp = self.half_edges[hi].prev;
+        let tn = self.half_edges[t.0 as usize].next;
+        let tp = self.half_edges[t.0 as usize].prev;
+        let oh = self.half_edges[hi].origin;
+        let ot = self.half_edges[t.0 as usize].origin;
+
+        self.half_edges[hp.0 as usize].next = tn;
+        self.half_edges[tn.0 as usize].prev = hp;
+        self.half_edges[tp.0 as usize].next = hn;
+        self.half_edges[hn.0 as usize].prev = tp;
+
+        if f_drop != f_keep {
+            // outer ↔ outer: fold f_drop's loop into f_keep.
+            self.faces[f_keep.0 as usize].half_edge = Some(hp);
+            let merged: Vec<HalfEdgeId> = self.face_half_edges(f_keep).collect();
+            for he in merged {
+                self.half_edges[he.0 as usize].face = f_keep;
+            }
+            self.faces[f_drop.0 as usize].alive = false;
+            self.faces[f_drop.0 as usize].half_edge = None;
+        }
+        self.half_edges[hi].alive = false;
+        self.half_edges[t.0 as usize].alive = false;
+        self.repair_vertex_outgoing(oh, edge);
+        self.repair_vertex_outgoing(ot, t);
+        // The face's anchor may have been one of the removed half-edges (esp. a
+        // bridge / spur in the outer face) — re-point it at a survivor.
+        self.reanchor_face_if_dead(f_keep);
+
+        self.prune_orphans();
+
+        let mut out = Vec::new();
+        if self.faces[f_keep.0 as usize].alive && !self.faces[f_keep.0 as usize].is_outer {
+            out.push(self.face_patch(f_keep));
+        }
+        Ok(out)
+    }
+
     /// Author a brand-new room from a closed ring of points — the "draw a
     /// room" affordance. The polygon becomes its **own** connected component:
     /// a CCW interior room face plus the CW exterior face bounding it. It does
@@ -852,6 +1066,31 @@ impl SpacePlate {
         self.vertices[v.0 as usize].outgoing = replacement;
         if replacement.is_none() {
             self.vertices[v.0 as usize].alive = false;
+        }
+    }
+
+    /// Ensure `f`'s anchor half-edge is a live half-edge that still belongs to
+    /// `f`; if the anchor was tombstoned (or re-homed), re-point it at any
+    /// surviving member, and tombstone the face if none remain.
+    fn reanchor_face_if_dead(&mut self, f: FaceId) {
+        let fi = f.0 as usize;
+        if fi >= self.faces.len() || !self.faces[fi].alive {
+            return;
+        }
+        let ok = matches!(self.faces[fi].half_edge, Some(h)
+            if self.half_edges[h.0 as usize].alive && self.half_edges[h.0 as usize].face == f);
+        if ok {
+            return;
+        }
+        let replacement = (0..self.half_edges.len())
+            .map(|i| HalfEdgeId(i as u32))
+            .find(|h| {
+                let he = &self.half_edges[h.0 as usize];
+                he.alive && he.face == f
+            });
+        self.faces[fi].half_edge = replacement;
+        if replacement.is_none() {
+            self.faces[fi].alive = false;
         }
     }
 
@@ -1212,6 +1451,19 @@ fn polygon_area(pts: &[[f64; 2]]) -> f64 {
         acc += p[0] * q[1] - q[0] * p[1];
     }
     acc * 0.5
+}
+
+/// Perpendicular distance of point `p` to the infinite line through `a` and `b`
+/// (degenerates to the point distance when `a == b`). Used to judge whether a
+/// degree-2 node is a redundant collinear point on its neighbours' chord.
+fn perp_distance(p: [f64; 2], a: [f64; 2], b: [f64; 2]) -> f64 {
+    let dx = b[0] - a[0];
+    let dy = b[1] - a[1];
+    let len = (dx * dx + dy * dy).sqrt();
+    if len < EPS {
+        return ((p[0] - a[0]).powi(2) + (p[1] - a[1]).powi(2)).sqrt();
+    }
+    ((p[0] - a[0]) * dy - (p[1] - a[1]) * dx).abs() / len
 }
 
 /// Cheap self-intersection screen for edit feedback: O(n²) edge-pair test on a
@@ -1682,6 +1934,177 @@ mod tests {
         // Repeated closing point (first == last) — the wrap-around case.
         let closed = vec![[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 0.0]];
         assert_eq!(plate.add_face(&closed, None), Err(EditError::InvalidPolygon));
+    }
+
+    // ───────────────── orphan removal + auto-cleanup ─────────────────
+
+    /// rect(0,0,4,3) plus a spur wall poking out of the right wall's midpoint
+    /// to (6, 1.5). The T-junction snap splits the right wall at (4,1.5), so
+    /// the arrangement carries a degree-1 tip at (6,1.5) and a redundant
+    /// collinear node at (4,1.5).
+    fn spur_segs() -> Vec<InputSegment> {
+        let mut s = loop_segments(&rect(0.0, 0.0, 4.0, 3.0), 100);
+        s.push(InputSegment::new([4.0, 1.5], [6.0, 1.5], Some(200)));
+        s
+    }
+
+    /// Build the spur plate WITHOUT the `build` auto-prune (via the raw
+    /// `from_arrangement`) so the spur survives for the removal/prune tests.
+    fn spur_plate_unpruned() -> SpacePlate {
+        let arr = Arrangement::resolve(&spur_segs(), 0.1);
+        SpacePlate::from_arrangement(arr, 0.5)
+    }
+
+    fn live_vertex_count(plate: &SpacePlate) -> usize {
+        (0..plate.vertices.len()).filter(|&i| plate.vertices[i].alive).count()
+    }
+
+    #[test]
+    fn spur_fixture_actually_has_a_spur() {
+        let plate = spur_plate_unpruned();
+        assert_eq!(plate.room_count(), 1, "the rectangle is still one room");
+        let tip = plate.find_vertex([6.0, 1.5]);
+        assert_eq!(plate.vertex_degree(tip), 1, "the spur end is a degree-1 tip");
+        let junction = plate.find_vertex([4.0, 1.5]);
+        assert_eq!(plate.vertex_degree(junction), 3, "the spur base is a T-junction");
+    }
+
+    #[test]
+    fn remove_spur_edge_drops_the_tip_and_keeps_area() {
+        let mut plate = spur_plate_unpruned();
+        let area_before: f64 = plate.rooms().map(|f| plate.face_area(f)).sum();
+        let tip = plate.find_vertex([6.0, 1.5]);
+        let spur_he = plate.outgoing_half_edges(tip).next().expect("tip has an outgoing he");
+        plate.remove_spur_edge(spur_he).expect("remove the spur");
+        assert_eq!(plate.vertex_position(tip), None, "the tip is tombstoned");
+        assert_eq!(plate.room_count(), 1, "no room gained or lost");
+        let area_after: f64 = plate.rooms().map(|f| plate.face_area(f)).sum();
+        assert!(
+            (area_before - area_after).abs() < 1e-6,
+            "spur removal is area-neutral: {area_before} vs {area_after}",
+        );
+    }
+
+    #[test]
+    fn remove_spur_edge_rejects_a_non_tip_and_a_stale_handle() {
+        let mut plate = spur_plate_unpruned();
+        // Any room boundary edge has both ends at degree ≥ 2 → not a spur.
+        let room = plate.rooms().next().unwrap();
+        let non_spur = plate.face_half_edges(room).next().expect("a room edge");
+        assert_eq!(plate.remove_spur_edge(non_spur), Err(EditError::VertexNotDissolvable));
+        assert_eq!(plate.remove_spur_edge(HalfEdgeId(99_999)), Err(EditError::StaleHandle));
+    }
+
+    #[test]
+    fn prune_orphans_removes_the_spur_and_dissolves_the_exposed_node() {
+        let mut plate = spur_plate_unpruned();
+        let room = plate.rooms().next().unwrap();
+        assert!(
+            plate.face_outline(room).len() >= 5,
+            "unpruned room boundary carries the T-junction node",
+        );
+        let removed = plate.prune_orphans();
+        assert!(removed >= 2, "pruned the spur edge + the now-collinear node: {removed}");
+        let room = plate.rooms().next().unwrap();
+        assert_eq!(plate.face_outline(room).len(), 4, "back to a clean 4-corner rectangle");
+        assert!((plate.face_area(room) - 12.0).abs() < 1e-6, "area unchanged: {}", plate.face_area(room));
+        assert_eq!(live_vertex_count(&plate), 4, "only the four corners survive");
+    }
+
+    #[test]
+    fn prune_orphans_is_idempotent_and_a_noop_on_clean_plates() {
+        // Clean by construction (build auto-prunes) → nothing to do.
+        let mut clean = two_room_plate();
+        assert_eq!(clean.prune_orphans(), 0, "a clean two-room plate prunes nothing");
+        assert_eq!(clean.room_count(), 2);
+        let total: f64 = clean.rooms().map(|f| clean.face_area(f)).sum();
+        assert!((total - 24.0).abs() < 1e-6, "areas intact: {total}");
+        // A second prune right after a real one finds nothing.
+        let mut messy = spur_plate_unpruned();
+        messy.prune_orphans();
+        assert_eq!(messy.prune_orphans(), 0, "prune is idempotent");
+    }
+
+    #[test]
+    fn prune_keeps_genuine_corners() {
+        let segs = loop_segments(&rect(0.0, 0.0, 4.0, 3.0), 100);
+        let mut plate = SpacePlate::build(&segs, BuildOptions::default());
+        assert_eq!(plate.prune_orphans(), 0, "a clean rectangle has nothing to prune");
+        assert_eq!(
+            plate.face_outline(plate.rooms().next().unwrap()).len(),
+            4,
+            "all four real corners are kept (not mistaken for collinear)",
+        );
+    }
+
+    #[test]
+    fn build_auto_prunes_spur_walls() {
+        let plate = SpacePlate::build(&spur_segs(), BuildOptions::default());
+        assert_eq!(plate.room_count(), 1, "the spur doesn't create a phantom room");
+        let room = plate.rooms().next().unwrap();
+        assert_eq!(plate.face_outline(room).len(), 4, "derived room is a clean rectangle, no spur stub");
+        assert!((plate.face_area(room) - 12.0).abs() < 1e-6, "area is the rectangle: {}", plate.face_area(room));
+    }
+
+    #[test]
+    fn remove_edge_merges_two_real_rooms() {
+        let mut plate = two_room_plate();
+        let rooms: Vec<FaceId> = plate.rooms().collect();
+        let shared = plate
+            .face_half_edges(rooms[0])
+            .find(|h| {
+                plate
+                    .neighbor_across(*h)
+                    .map(|n| n != rooms[0] && !plate.faces[n.0 as usize].is_outer)
+                    .unwrap_or(false)
+            })
+            .expect("shared edge");
+        let patches = plate.remove_edge(shared).expect("remove the shared wall");
+        assert_eq!(plate.room_count(), 1, "two rooms merged into one");
+        let total: f64 = patches.iter().map(|p| p.area).sum();
+        assert!((total - 24.0).abs() < 1e-6, "merged area = full box: {total}");
+    }
+
+    #[test]
+    fn remove_edge_refuses_an_enclosing_wall() {
+        let mut plate = two_room_plate();
+        let rooms: Vec<FaceId> = plate.rooms().collect();
+        let exterior_edge = plate
+            .face_half_edges(rooms[0])
+            .find(|h| {
+                plate
+                    .neighbor_across(*h)
+                    .map(|n| plate.faces[n.0 as usize].is_outer)
+                    .unwrap_or(false)
+            })
+            .expect("an outer wall");
+        assert_eq!(plate.remove_edge(exterior_edge), Err(EditError::BordersExterior));
+    }
+
+    #[test]
+    fn remove_edge_deletes_a_bridge_and_cleans_orphans() {
+        let mut plate = spur_plate_unpruned();
+        let tip = plate.find_vertex([6.0, 1.5]);
+        let spur = plate.outgoing_half_edges(tip).next().expect("spur he");
+        // Both of the spur's half-edges sit in the same (exterior) face → bridge.
+        let t = plate.half_edges[spur.0 as usize].twin;
+        assert_eq!(
+            plate.half_edges[spur.0 as usize].face,
+            plate.half_edges[t.0 as usize].face,
+            "the spur is a bridge (same face both sides)",
+        );
+        let patches = plate.remove_edge(spur).expect("remove the bridge/spur wall");
+        assert!(patches.is_empty(), "a bridge in the exterior bounds no room");
+        assert_eq!(plate.room_count(), 1, "the rectangle room survives");
+        let room = plate.rooms().next().unwrap();
+        assert_eq!(plate.face_outline(room).len(), 4, "room cleaned back to a rectangle");
+        assert!((plate.face_area(room) - 12.0).abs() < 1e-6, "area unchanged: {}", plate.face_area(room));
+    }
+
+    #[test]
+    fn remove_edge_rejects_a_stale_handle() {
+        let mut plate = two_room_plate();
+        assert_eq!(plate.remove_edge(HalfEdgeId(99_999)), Err(EditError::StaleHandle));
     }
 
     // Test-only helper.

--- a/rust/geometry/src/space_dcel.rs
+++ b/rust/geometry/src/space_dcel.rs
@@ -165,6 +165,13 @@ pub enum EditError {
     /// `merge_faces`: both sides are the same face — the edge is a bridge,
     /// and removing it would change connectivity rather than union two rooms.
     BridgeEdge,
+    /// `dissolve_vertex`: the vertex isn't a simple degree-2 node (a junction
+    /// where 3+ walls meet, or a dangling tip), so there's no unambiguous pair
+    /// of edges to weld into one.
+    VertexNotDissolvable,
+    /// `add_face`: the ring has fewer than 3 points, self-intersects, or
+    /// encloses near-zero area.
+    InvalidPolygon,
 }
 
 /// The persistent floor-plate topology. See the module docs.
@@ -515,6 +522,161 @@ impl SpacePlate {
         }
 
         Ok(vec![self.face_patch(f_keep)])
+    }
+
+    /// Dissolve a **degree-2** vertex `v`, welding its two incident edges into
+    /// one straight edge between its neighbours — the inverse of `split_edge`,
+    /// and the "delete this corner / errant node" affordance. Both incident
+    /// faces lose a boundary vertex; if `v` was a real corner the faces change
+    /// shape (the edge becomes the straight chord A→B), which is the intended
+    /// edit. Returns a patch per incident *room* face.
+    ///
+    /// Rejects:
+    /// - a vertex whose degree isn't exactly 2 — a wall junction or dangling
+    ///   tip has no unambiguous edge pair to merge (`VertexNotDissolvable`);
+    /// - a weld whose two neighbours are already directly joined, which would
+    ///   make a parallel edge / collapse a triangle to a digon (`DegenerateCut`).
+    pub fn dissolve_vertex(&mut self, v: VertexId) -> Result<Vec<FacePatch>, EditError> {
+        let vi = v.0 as usize;
+        if vi >= self.vertices.len() || !self.vertices[vi].alive {
+            return Err(EditError::StaleHandle);
+        }
+        // Degree must be exactly 2 (two live outgoing half-edges).
+        let outs: Vec<HalfEdgeId> = self.outgoing_half_edges(v).collect();
+        if outs.len() != 2 {
+            return Err(EditError::VertexNotDissolvable);
+        }
+        let (o1, o2) = (outs[0], outs[1]); // v→X, v→Y
+        let t1 = self.half_edges[o1.0 as usize].twin; // X→v — kept, becomes X→Y
+        let t2 = self.half_edges[o2.0 as usize].twin; // Y→v — kept, becomes Y→X
+        let x = self.dest(o1);
+        let y = self.dest(o2);
+        if x == y {
+            return Err(EditError::DegenerateCut); // both edges to one neighbour (digon)
+        }
+        // Welding X and Y when they already share an edge would duplicate it.
+        if self.outgoing_half_edges(x).any(|h| self.dest(h) == y) {
+            return Err(EditError::DegenerateCut);
+        }
+        // Degree-2 invariant: the edge arriving at v before o1 (in o1's face) is
+        // t2, and symmetrically prev(o2)==t1. If this doesn't hold one edge is a
+        // dangling antenna — bail rather than corrupt the rotation.
+        if self.half_edges[o1.0 as usize].prev != t2 || self.half_edges[o2.0 as usize].prev != t1 {
+            return Err(EditError::VertexNotDissolvable);
+        }
+        let fa = self.half_edges[t2.0 as usize].face; // face that saw Y→v→X
+        let fb = self.half_edges[t1.0 as usize].face; // face that saw X→v→Y
+        let qa = self.half_edges[o1.0 as usize].next; // what followed o1 in fa
+        let qb = self.half_edges[o2.0 as usize].next; // what followed o2 in fb
+
+        // Re-twin the survivors into one undirected edge X↔Y, splicing out v.
+        self.half_edges[t1.0 as usize].twin = t2; // t1 now X→Y
+        self.half_edges[t1.0 as usize].next = qb;
+        self.half_edges[qb.0 as usize].prev = t1;
+        self.half_edges[t2.0 as usize].twin = t1; // t2 now Y→X
+        self.half_edges[t2.0 as usize].next = qa;
+        self.half_edges[qa.0 as usize].prev = t2;
+
+        // Tombstone the two v-originating half-edges and v itself.
+        self.half_edges[o1.0 as usize].alive = false;
+        self.half_edges[o2.0 as usize].alive = false;
+        self.vertices[vi].outgoing = None;
+        self.vertices[vi].alive = false;
+
+        // A face anchor may have pointed at a now-dead half-edge.
+        for (face, keep) in [(fa, t2), (fb, t1)] {
+            let anchor = self.faces[face.0 as usize].half_edge;
+            if anchor == Some(o1) || anchor == Some(o2) {
+                self.faces[face.0 as usize].half_edge = Some(keep);
+            }
+        }
+        // X keeps its survivor t1 (origin X) and Y keeps t2 (origin Y); their
+        // outgoing slots could only have referenced o1/o2 via v, now gone.
+
+        let mut faces = vec![fa, fb];
+        faces.sort();
+        faces.dedup();
+        Ok(faces
+            .into_iter()
+            .filter(|f| !self.faces[f.0 as usize].is_outer)
+            .map(|f| self.face_patch(f))
+            .collect())
+    }
+
+    /// Author a brand-new room from a closed ring of points — the "draw a
+    /// room" affordance. The polygon becomes its **own** connected component:
+    /// a CCW interior room face plus the CW exterior face bounding it. It does
+    /// NOT merge into existing topology (there's no arrangement overlay), so
+    /// drawing over an existing room leaves two independent components — the
+    /// documented prototype limitation.
+    ///
+    /// `points` is the ring with no repeated closing vertex; winding is
+    /// normalised to CCW. Rejects a ring that is too short, self-intersecting,
+    /// or near-zero area (`InvalidPolygon`). Returns the new room's patch.
+    pub fn add_face(&mut self, points: &[[f64; 2]], source_element: Option<u32>) -> Result<FacePatch, EditError> {
+        if points.len() < 3 || !is_simple_polygon(points) {
+            return Err(EditError::InvalidPolygon);
+        }
+        let signed = polygon_area(points);
+        if signed.abs() < EPS {
+            return Err(EditError::InvalidPolygon);
+        }
+        // Normalise to CCW so the interior winds positive (room on the left).
+        let ring: Vec<[f64; 2]> =
+            if signed > 0.0 { points.to_vec() } else { points.iter().rev().copied().collect() };
+        let nn = ring.len() as u32;
+
+        let v0 = self.vertices.len() as u32; // first new vertex id
+        let h0 = self.half_edges.len() as u32; // first interior half-edge id
+        let g0 = h0 + nn; // first exterior (twin) half-edge id
+        let room = FaceId(self.faces.len() as u32);
+        let outer = FaceId(self.faces.len() as u32 + 1);
+
+        for (i, &p) in ring.iter().enumerate() {
+            self.vertices.push(Vertex { pos: p, outgoing: Some(HalfEdgeId(h0 + i as u32)), alive: true });
+        }
+        // Interior half-edges h_i: v_i → v_{i+1}, CCW, room on the left.
+        for i in 0..nn {
+            self.half_edges.push(HalfEdge {
+                origin: VertexId(v0 + i),
+                twin: HalfEdgeId(g0 + i),
+                next: HalfEdgeId(h0 + (i + 1) % nn),
+                prev: HalfEdgeId(h0 + (i + nn - 1) % nn),
+                face: room,
+                source_element,
+                alive: true,
+            });
+        }
+        // Exterior twins g_i: v_{i+1} → v_i, winding CW around the room.
+        for i in 0..nn {
+            self.half_edges.push(HalfEdge {
+                origin: VertexId(v0 + (i + 1) % nn),
+                twin: HalfEdgeId(h0 + i),
+                next: HalfEdgeId(g0 + (i + nn - 1) % nn),
+                prev: HalfEdgeId(g0 + (i + 1) % nn),
+                face: outer,
+                source_element,
+                alive: true,
+            });
+        }
+        self.faces.push(Face {
+            half_edge: Some(HalfEdgeId(h0)),
+            is_outer: false,
+            floor_z: 0.0,
+            ceiling_z: 0.0,
+            non_planar_ceiling: false,
+            alive: true,
+        });
+        self.faces.push(Face {
+            half_edge: Some(HalfEdgeId(g0)),
+            is_outer: true,
+            floor_z: 0.0,
+            ceiling_z: 0.0,
+            non_planar_ceiling: false,
+            alive: true,
+        });
+
+        Ok(self.face_patch(room))
     }
 
     // ─────────────────────────── queries ────────────────────────────
@@ -1368,6 +1530,123 @@ mod tests {
             .filter(|(_, s)| s.is_none())
             .count();
         assert!(unsourced >= 1, "the user-drawn partition has no source element");
+    }
+
+    #[test]
+    fn dissolve_is_the_inverse_of_split_edge() {
+        let mut plate = two_room_plate();
+        let rooms: Vec<FaceId> = plate.rooms().collect();
+        let areas_before: Vec<f64> = rooms.iter().map(|f| plate.face_area(*f)).collect();
+        let verts_before: Vec<usize> = rooms.iter().map(|f| plate.face_outline(*f).len()).collect();
+        // Add a node mid-shared-wall, then dissolve it back out.
+        let shared = plate
+            .face_half_edges(rooms[0])
+            .find(|h| {
+                plate
+                    .neighbor_across(*h)
+                    .map(|n| n != rooms[0] && !plate.faces[n.0 as usize].is_outer)
+                    .unwrap_or(false)
+            })
+            .expect("shared edge");
+        let a = plate.vertices[plate.half_edges[shared.0 as usize].origin.0 as usize].pos;
+        let bvid = plate.half_edges[plate.half_edges[shared.0 as usize].twin.0 as usize].origin;
+        let b = plate.vertices[bvid.0 as usize].pos;
+        let mid = [(a[0] + b[0]) / 2.0, (a[1] + b[1]) / 2.0];
+        let n = plate.split_edge(shared, mid[0], mid[1]).expect("split_edge");
+        assert_eq!(plate.face_outline(rooms[0]).len(), verts_before[0] + 1, "node added");
+
+        let patches = plate.dissolve_vertex(n).expect("dissolve the node");
+        assert_eq!(patches.len(), 2, "both rooms touching the welded wall come back");
+        assert_eq!(plate.vertex_position(n), None, "the node is tombstoned");
+        assert_eq!(plate.room_count(), 2, "no room added or lost");
+        for (f, (a0, v0)) in rooms.iter().zip(areas_before.iter().zip(&verts_before)) {
+            assert!((plate.face_area(*f) - a0).abs() < 1e-6, "area restored");
+            assert_eq!(plate.face_outline(*f).len(), *v0, "vertex count restored");
+        }
+    }
+
+    #[test]
+    fn dissolve_corner_straightens_the_room() {
+        // A 4×3 rectangle; dropping corner (0,0) leaves the triangle
+        // (4,0)-(4,3)-(0,3) = 12 − 6 = 6 m².
+        let segs = loop_segments(&rect(0.0, 0.0, 4.0, 3.0), 400);
+        let mut plate = SpacePlate::build(&segs, BuildOptions::default());
+        let v00 = plate.find_vertex([0.0, 0.0]);
+        let patches = plate.dissolve_vertex(v00).expect("dissolve a convex corner");
+        assert_eq!(plate.room_count(), 1);
+        assert_eq!(patches.len(), 1, "one incident room (the other side is exterior)");
+        assert!((patches[0].area - 6.0).abs() < 1e-6, "area = 6 m²: {}", patches[0].area);
+        assert!(patches[0].simple, "the triangle stays simple");
+        assert_eq!(plate.face_outline(patches[0].face).len(), 3, "now a triangle");
+    }
+
+    #[test]
+    fn dissolve_rejects_a_wall_junction() {
+        // (4,0) is where the central wall meets the bottom wall: degree 3.
+        let mut plate = two_room_plate();
+        let junction = plate.find_vertex([4.0, 0.0]);
+        assert_eq!(plate.dissolve_vertex(junction), Err(EditError::VertexNotDissolvable));
+    }
+
+    #[test]
+    fn dissolve_rejects_triangle_collapse() {
+        // A triangle room: dropping any corner welds two already-adjacent
+        // neighbours into a parallel edge → a digon. Reject.
+        let segs = loop_segments(&[[0.0, 0.0], [4.0, 0.0], [0.0, 3.0]], 500);
+        let mut plate = SpacePlate::build(&segs, BuildOptions::default());
+        assert_eq!(plate.room_count(), 1, "triangle is one room");
+        let corner = plate.find_vertex([0.0, 0.0]);
+        assert_eq!(plate.dissolve_vertex(corner), Err(EditError::DegenerateCut));
+    }
+
+    #[test]
+    fn dissolve_rejects_a_stale_handle() {
+        let mut plate = two_room_plate();
+        assert_eq!(plate.dissolve_vertex(VertexId(9999)), Err(EditError::StaleHandle));
+    }
+
+    #[test]
+    fn add_face_creates_a_room_on_an_empty_plate() {
+        let mut plate = SpacePlate::build(&[], BuildOptions::default());
+        assert_eq!(plate.room_count(), 0, "no walls → no rooms");
+        let patch = plate.add_face(&rect(0.0, 0.0, 5.0, 4.0), None).expect("draw a room");
+        assert_eq!(plate.room_count(), 1, "the drawn room exists");
+        assert!((patch.area - 20.0).abs() < 1e-6, "area = 20 m²: {}", patch.area);
+        assert!(patch.simple);
+        assert!((plate.face_area(patch.face) - 20.0).abs() < 1e-6, "queryable like any room");
+    }
+
+    #[test]
+    fn add_face_normalises_clockwise_winding() {
+        let mut plate = SpacePlate::build(&[], BuildOptions::default());
+        // CW ring (reverse of a rect): area must still come out correct.
+        let cw = vec![[0.0, 0.0], [0.0, 4.0], [5.0, 4.0], [5.0, 0.0]];
+        let patch = plate.add_face(&cw, Some(7)).expect("draw a CW room");
+        assert!((patch.area - 20.0).abs() < 1e-6, "winding normalised: {}", patch.area);
+        assert!(polygon_area(&patch.outline) > 0.0, "interior face winds CCW");
+    }
+
+    #[test]
+    fn add_face_into_an_existing_plate_keeps_the_old_rooms() {
+        let mut plate = two_room_plate();
+        let before: f64 = plate.rooms().map(|f| plate.face_area(f)).sum();
+        plate.add_face(&rect(20.0, 20.0, 23.0, 22.0), None).expect("draw a third room"); // 3×2 = 6 m²
+        assert_eq!(plate.room_count(), 3, "two original + one drawn");
+        let total: f64 = plate.rooms().map(|f| plate.face_area(f)).sum();
+        assert!((total - (before + 6.0)).abs() < 1e-6, "old rooms intact: {total} vs {}", before + 6.0);
+    }
+
+    #[test]
+    fn add_face_rejects_bad_rings() {
+        let mut plate = SpacePlate::build(&[], BuildOptions::default());
+        // Too few points.
+        assert_eq!(plate.add_face(&[[0.0, 0.0], [1.0, 0.0]], None), Err(EditError::InvalidPolygon));
+        // Self-intersecting bow-tie.
+        let bowtie = vec![[0.0, 0.0], [4.0, 4.0], [4.0, 0.0], [0.0, 4.0]];
+        assert_eq!(plate.add_face(&bowtie, None), Err(EditError::InvalidPolygon));
+        // Collinear (zero area).
+        let line = vec![[0.0, 0.0], [2.0, 0.0], [4.0, 0.0]];
+        assert_eq!(plate.add_face(&line, None), Err(EditError::InvalidPolygon));
     }
 
     // Test-only helper.

--- a/rust/geometry/src/space_dcel.rs
+++ b/rust/geometry/src/space_dcel.rs
@@ -73,11 +73,22 @@ pub struct InputSegment {
     pub a: [f64; 2],
     pub b: [f64; 2],
     pub source_element: Option<u32>,
+    /// Half the source wall's thickness (metres). Carried onto every half-edge
+    /// derived from this segment so `net_outline` can inset each room edge by
+    /// its own wall's half-thickness — no fuzzy edge↔wall matching, unlike the
+    /// TS `offsetRoomFootprint`. `0.0` = unknown/no thickness (centreline only).
+    pub half_thickness: f64,
 }
 
 impl InputSegment {
     pub fn new(a: [f64; 2], b: [f64; 2], source_element: Option<u32>) -> Self {
-        Self { a, b, source_element }
+        Self { a, b, source_element, half_thickness: 0.0 }
+    }
+
+    /// Builder: set the half-thickness (metres) carried to derived half-edges.
+    pub fn with_half_thickness(mut self, half_thickness: f64) -> Self {
+        self.half_thickness = half_thickness;
+        self
     }
 }
 
@@ -118,6 +129,9 @@ struct HalfEdge {
     /// The IFC element this edge bounds, propagated from the input segment.
     /// `None` for the exterior side of a boundary-less cut or a user split.
     source_element: Option<u32>,
+    /// Half the source wall's thickness (metres); `0.0` for a user-drawn edge.
+    /// Both twins carry the same value (it's the wall, not a side).
+    half_thickness: f64,
     alive: bool,
 }
 
@@ -227,7 +241,7 @@ impl SpacePlate {
         // Two half-edges per undirected edge, twinned. Record outgoing fans.
         let mut fans: Vec<Vec<(HalfEdgeId, f64)>> = vec![Vec::new(); arr.vertices.len()];
         for e in &arr.edges {
-            let (a, b, src) = (e.a, e.b, e.source);
+            let (a, b, src, ht) = (e.a, e.b, e.source, e.half_thickness);
             let pa = arr.vertices[a];
             let pb = arr.vertices[b];
             let fwd = HalfEdgeId(plate.half_edges.len() as u32);
@@ -240,6 +254,7 @@ impl SpacePlate {
                 prev: fwd,
                 face: FaceId(0),
                 source_element: src,
+                half_thickness: ht,
                 alive: true,
             });
             plate.half_edges.push(HalfEdge {
@@ -249,6 +264,7 @@ impl SpacePlate {
                 prev: bwd,
                 face: FaceId(0),
                 source_element: src,
+                half_thickness: ht,
                 alive: true,
             });
             fans[a].push((fwd, (pb[1] - pa[1]).atan2(pb[0] - pa[0])));
@@ -401,6 +417,7 @@ impl SpacePlate {
             prev: pa_prev,
             face,
             source_element,
+            half_thickness: 0.0, // a user-drawn partition has no wall thickness yet
             alive: true,
         });
         self.half_edges.push(HalfEdge {
@@ -410,6 +427,7 @@ impl SpacePlate {
             prev: pb_prev,
             face: new_face,
             source_element,
+            half_thickness: 0.0,
             alive: true,
         });
 
@@ -460,6 +478,9 @@ impl SpacePlate {
         let t_next = self.half_edges[t.0 as usize].next;
         let h_src = self.half_edges[h.0 as usize].source_element;
         let t_src = self.half_edges[t.0 as usize].source_element;
+        // The two new halves continue the same wall → inherit its thickness.
+        let h_ht = self.half_edges[h.0 as usize].half_thickness;
+        let t_ht = self.half_edges[t.0 as usize].half_thickness;
 
         let n = VertexId(self.vertices.len() as u32);
         let e1 = HalfEdgeId(self.half_edges.len() as u32); // N → B (was dest of h)
@@ -467,10 +488,10 @@ impl SpacePlate {
 
         self.vertices.push(Vertex { pos: [x, y], outgoing: Some(e1), alive: true });
         self.half_edges.push(HalfEdge {
-            origin: n, twin: t, next: h_next, prev: h, face: f1, source_element: h_src, alive: true,
+            origin: n, twin: t, next: h_next, prev: h, face: f1, source_element: h_src, half_thickness: h_ht, alive: true,
         });
         self.half_edges.push(HalfEdge {
-            origin: n, twin: h, next: t_next, prev: t, face: f2, source_element: t_src, alive: true,
+            origin: n, twin: h, next: t_next, prev: t, face: f2, source_element: t_src, half_thickness: t_ht, alive: true,
         });
 
         // h becomes A→N; t becomes B→N. Their twins/nexts re-point through N.
@@ -885,6 +906,7 @@ impl SpacePlate {
                 prev: HalfEdgeId(h0 + (i + nn - 1) % nn),
                 face: room,
                 source_element,
+                half_thickness: 0.0, // a drawn room has no source wall thickness
                 alive: true,
             });
         }
@@ -897,6 +919,7 @@ impl SpacePlate {
                 prev: HalfEdgeId(g0 + (i + 1) % nn),
                 face: outer,
                 source_element,
+                half_thickness: 0.0,
                 alive: true,
             });
         }
@@ -952,6 +975,80 @@ impl SpacePlate {
     /// Absolute area of a face.
     pub fn face_area(&self, face: FaceId) -> f64 {
         self.signed_area_of_cycle(&self.face_half_edges(face).collect::<Vec<_>>()).abs()
+    }
+
+    /// The room's outline offset to a wall **boundary face** rather than the
+    /// centreline: each boundary edge is moved perpendicular by its own wall's
+    /// half-thickness — inward for the net (inner) face, outward for the gross
+    /// (outer) face — then adjacent offset lines are re-intersected for the
+    /// corners. Because every half-edge carries its source wall's thickness,
+    /// this needs no fuzzy edge↔wall matching (unlike the TS `offsetRoomFootprint`).
+    ///
+    /// An edge shared with another room (its twin bounds a room, not the
+    /// exterior) is pinned to the centreline in **outward** mode so it can't
+    /// push into the neighbour. Falls back to the unchanged centreline outline
+    /// when no offset applies, a corner is degenerate, or an inset would invert
+    /// the polygon — so the result is always a sane ring.
+    pub fn net_outline(&self, face: FaceId, inset: bool) -> Vec<[f64; 2]> {
+        let centre = self.face_outline(face);
+        let n = centre.len();
+        if n < 3 {
+            return centre;
+        }
+        let cycle: Vec<HalfEdgeId> = self.face_half_edges(face).collect();
+        if cycle.len() != n {
+            return centre; // outline / cycle mismatch (e.g. a hole) — don't guess
+        }
+        let sign = if inset { 1.0 } else { -1.0 };
+        // Per edge: a point on its offset line + the edge's unit direction.
+        let mut lines: Vec<([f64; 2], [f64; 2])> = Vec::with_capacity(n);
+        for i in 0..n {
+            let a = centre[i];
+            let b = centre[(i + 1) % n];
+            let (dx, dy) = (b[0] - a[0], b[1] - a[1]);
+            let l = (dx * dx + dy * dy).sqrt();
+            if l < EPS {
+                return centre;
+            }
+            let (ux, uy) = (dx / l, dy / l);
+            let mut half = self.half_edges[cycle[i].0 as usize].half_thickness;
+            // Outward: a shared (room↔room) edge would overlap the neighbour, so pin it.
+            if !inset {
+                if let Some(nbr) = self.neighbor_across(cycle[i]) {
+                    if !self.faces[nbr.0 as usize].is_outer {
+                        half = 0.0;
+                    }
+                }
+            }
+            let off = sign * half;
+            // Inward normal of a CCW outline is to the left of a→b: (-uy, ux).
+            lines.push(([a[0] - uy * off, a[1] + ux * off], [ux, uy]));
+        }
+        let mut verts: Vec<[f64; 2]> = Vec::with_capacity(n);
+        for i in 0..n {
+            let (pp, pd) = lines[(i + n - 1) % n];
+            let (cp, cd) = lines[i];
+            let hit = line_intersection(pp, [pp[0] + pd[0], pp[1] + pd[1]], cp, [cp[0] + cd[0], cp[1] + cd[1]]);
+            // Parallel offset lines (a collinear node, e.g. a mid-wall split, or
+            // two edges of equal thickness in a straight run) don't intersect —
+            // drop the corner onto the current offset line so it sits flush on
+            // the inset boundary instead of poking back to the centreline.
+            verts.push(hit.unwrap_or_else(|| {
+                let t = (centre[i][0] - cp[0]) * cd[0] + (centre[i][1] - cp[1]) * cd[1];
+                [cp[0] + t * cd[0], cp[1] + t * cd[1]]
+            }));
+        }
+        if verts.iter().any(|v| !v[0].is_finite() || !v[1].is_finite()) {
+            return centre;
+        }
+        let got = polygon_area(&verts).abs();
+        if got <= EPS {
+            return centre;
+        }
+        if inset && got > polygon_area(&centre).abs() + 1e-6 {
+            return centre; // the inset inverted the polygon — keep the centreline
+        }
+        verts
     }
 
     /// The bounding half-edges of a face paired with the IFC element each
@@ -1170,6 +1267,7 @@ struct ArrEdge {
     a: usize,
     b: usize,
     source: Option<u32>,
+    half_thickness: f64,
 }
 
 /// The planar arrangement: snapped vertices + split, deduped edges. This is
@@ -1223,7 +1321,7 @@ impl Arrangement {
             let ai = lookup(s.a, &mut vertices);
             let bi = lookup(s.b, &mut vertices);
             if ai != bi {
-                segs.push(Seg { a: ai, b: bi, source: s.source_element });
+                segs.push(Seg { a: ai, b: bi, source: s.source_element, half_thickness: s.half_thickness });
             }
         }
 
@@ -1242,7 +1340,7 @@ impl Arrangement {
             'outer: for vid in endpoints {
                 let p = vertices[vid];
                 for si in 0..segs.len() {
-                    let Seg { a, b, source } = segs[si];
+                    let Seg { a, b, source, half_thickness } = segs[si];
                     if a == vid || b == vid {
                         continue;
                     }
@@ -1255,8 +1353,8 @@ impl Arrangement {
                         if !(1e-6..=1.0 - 1e-6).contains(&t) {
                             continue; // endpoint, not interior
                         }
-                        segs[si] = Seg { a, b: vid, source };
-                        segs.push(Seg { a: vid, b, source });
+                        segs[si] = Seg { a, b: vid, source, half_thickness };
+                        segs.push(Seg { a: vid, b, source, half_thickness });
                         applied = true;
                         break 'outer;
                     }
@@ -1309,13 +1407,14 @@ impl Arrangement {
         let mut seen: std::collections::HashSet<(usize, usize)> = std::collections::HashSet::new();
         for (i, mut cuts) in splits.into_iter().enumerate() {
             let source = seeds[i].source;
+            let ht = seeds[i].half_thickness;
             if cuts.len() <= 2 {
-                push_edge(&mut edges, &mut seen, cuts[0].1, cuts[1].1, source);
+                push_edge(&mut edges, &mut seen, cuts[0].1, cuts[1].1, source, ht);
                 continue;
             }
             cuts.sort_by(|p, q| p.0.partial_cmp(&q.0).unwrap_or(std::cmp::Ordering::Equal));
             for w in cuts.windows(2) {
-                push_edge(&mut edges, &mut seen, w[0].1, w[1].1, source);
+                push_edge(&mut edges, &mut seen, w[0].1, w[1].1, source, ht);
             }
         }
 
@@ -1328,21 +1427,24 @@ struct Seg {
     a: usize,
     b: usize,
     source: Option<u32>,
+    half_thickness: f64,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn push_edge(
     edges: &mut Vec<ArrEdge>,
     seen: &mut std::collections::HashSet<(usize, usize)>,
     a: usize,
     b: usize,
     source: Option<u32>,
+    half_thickness: f64,
 ) {
     if a == b {
         return;
     }
     let key = if a < b { (a, b) } else { (b, a) };
     if seen.insert(key) {
-        edges.push(ArrEdge { a, b, source });
+        edges.push(ArrEdge { a, b, source, half_thickness });
     }
 }
 
@@ -2105,6 +2207,82 @@ mod tests {
     fn remove_edge_rejects_a_stale_handle() {
         let mut plate = two_room_plate();
         assert_eq!(plate.remove_edge(HalfEdgeId(99_999)), Err(EditError::StaleHandle));
+    }
+
+    // ───────────────── net-area (wall-thickness offset) ─────────────────
+
+    /// A closed loop with a uniform wall half-thickness on every edge.
+    fn thick_loop(corners: &[[f64; 2]], base: u32, half: f64) -> Vec<InputSegment> {
+        loop_segments(corners, base).into_iter().map(|s| s.with_half_thickness(half)).collect()
+    }
+
+    fn thick_two_room_plate(half: f64) -> SpacePlate {
+        let segs = vec![
+            InputSegment::new([0.0, 0.0], [8.0, 0.0], Some(1)).with_half_thickness(half),
+            InputSegment::new([8.0, 0.0], [8.0, 3.0], Some(2)).with_half_thickness(half),
+            InputSegment::new([8.0, 3.0], [0.0, 3.0], Some(3)).with_half_thickness(half),
+            InputSegment::new([0.0, 3.0], [0.0, 0.0], Some(4)).with_half_thickness(half),
+            InputSegment::new([4.0, 0.0], [4.0, 3.0], Some(99)).with_half_thickness(half),
+        ];
+        SpacePlate::build(&segs, BuildOptions::default())
+    }
+
+    #[test]
+    fn net_outline_insets_and_outsets_by_the_wall_half_thickness() {
+        let plate = SpacePlate::build(&thick_loop(&rect(0.0, 0.0, 4.0, 3.0), 100, 0.25), BuildOptions::default());
+        let room = plate.rooms().next().unwrap();
+        // Inner: 0.25 in on every side → 3.5 × 2.5 = 8.75 m².
+        let inner = polygon_area(&plate.net_outline(room, true)).abs();
+        assert!((inner - 8.75).abs() < 1e-6, "inset 0.25 all round = 8.75, got {inner}");
+        // Outer: 0.25 out on every side → 4.5 × 3.5 = 15.75 m².
+        let outer = polygon_area(&plate.net_outline(room, false)).abs();
+        assert!((outer - 15.75).abs() < 1e-6, "outset 0.25 all round = 15.75, got {outer}");
+    }
+
+    #[test]
+    fn net_outline_is_the_centreline_without_thickness() {
+        // loop_segments leaves half_thickness at 0 → nothing to offset.
+        let plate = SpacePlate::build(&loop_segments(&rect(0.0, 0.0, 4.0, 3.0), 100), BuildOptions::default());
+        let room = plate.rooms().next().unwrap();
+        assert_eq!(plate.net_outline(room, true), plate.face_outline(room), "no thickness → unchanged");
+        assert_eq!(plate.net_outline(room, false), plate.face_outline(room));
+    }
+
+    #[test]
+    fn net_outline_pins_a_shared_wall_when_pushing_outward() {
+        let plate = thick_two_room_plate(0.25);
+        assert_eq!(plate.room_count(), 2);
+        // The left room (centroid x < 4) shares the central wall at x = 4.
+        let left = plate
+            .rooms()
+            .find(|f| {
+                let o = plate.face_outline(*f);
+                (o.iter().map(|p| p[0]).sum::<f64>() / o.len() as f64) < 4.0
+            })
+            .expect("a left room");
+        let outer = plate.net_outline(left, false);
+        let max_x = outer.iter().map(|p| p[0]).fold(f64::MIN, f64::max);
+        let min_x = outer.iter().map(|p| p[0]).fold(f64::MAX, f64::min);
+        assert!((max_x - 4.0).abs() < 1e-6, "shared wall (x=4) is pinned outward, got {max_x}");
+        assert!((min_x + 0.25).abs() < 1e-6, "the exterior wall pushes out to -0.25, got {min_x}");
+    }
+
+    #[test]
+    fn net_outline_thickness_survives_an_edge_split() {
+        let mut plate = SpacePlate::build(&thick_loop(&rect(0.0, 0.0, 4.0, 3.0), 100, 0.25), BuildOptions::default());
+        let room = plate.rooms().next().unwrap();
+        // Split the bottom edge (y = 0) at its midpoint; both halves keep 0.25.
+        let bottom = plate
+            .face_half_edges(room)
+            .find(|h| {
+                let a = plate.vertices[plate.half_edges[h.0 as usize].origin.0 as usize].pos;
+                let b = plate.vertices[plate.dest(*h).0 as usize].pos;
+                a[1].abs() < 1e-9 && b[1].abs() < 1e-9
+            })
+            .expect("the bottom edge");
+        plate.split_edge(bottom, 2.0, 0.0).expect("split");
+        let inner = polygon_area(&plate.net_outline(room, true)).abs();
+        assert!((inner - 8.75).abs() < 1e-6, "the split edge keeps its wall thickness: {inner}");
     }
 
     // Test-only helper.

--- a/rust/geometry/src/space_dcel.rs
+++ b/rust/geometry/src/space_dcel.rs
@@ -194,6 +194,12 @@ pub struct SpacePlate {
     vertices: Vec<Vertex>,
     half_edges: Vec<HalfEdge>,
     faces: Vec<Face>,
+    /// Wall footprint rectangles (4 corners each), set only by the FACE-BASED
+    /// build (`build_from_wall_rects`). When non-empty, a bounded face is a ROOM
+    /// only if its centroid lies OUTSIDE every wall rectangle (it's a gap between
+    /// walls, not a wall interior). Empty for the centreline build, where every
+    /// non-outer bounded face is a room.
+    wall_rects: Vec<[[f64; 2]; 4]>,
 }
 
 const EPS: f64 = 1e-9;
@@ -227,6 +233,37 @@ impl SpacePlate {
         plate
     }
 
+    /// FACE-BASED build: rooms are the gaps BETWEEN wall footprint rectangles,
+    /// not the faces of a centreline arrangement. Each `rect` is a wall's plan
+    /// rectangle (4 corners); its 4 edges (the two long ones are the wall faces)
+    /// are arranged, and a resulting bounded face is a room iff its centroid lies
+    /// outside every rectangle (a gap, not a wall interior or a junction overlap).
+    ///
+    /// Because the room boundary is literally the wall faces, a node can't sit
+    /// off the wall axis the way a centroid-derived centreline could, and there's
+    /// no fragile centreline-position sensitivity. Each edge carries half the
+    /// source wall's thickness (the rectangle's short extent / 2), so `net_outline`
+    /// offsets the gap (= the net / inner-face area) outward to the centre axis
+    /// (½ thickness) or the gross outer face (full thickness).
+    pub fn build_from_wall_rects(rects: &[[[f64; 2]; 4]], options: BuildOptions) -> Self {
+        let mut segments: Vec<InputSegment> = Vec::with_capacity(rects.len() * 4);
+        for (wi, r) in rects.iter().enumerate() {
+            // Wall thickness = the rectangle's shorter side (faces are the long pair).
+            let side = |a: [f64; 2], b: [f64; 2]| ((b[0] - a[0]).powi(2) + (b[1] - a[1]).powi(2)).sqrt();
+            let s01 = side(r[0], r[1]);
+            let s12 = side(r[1], r[2]);
+            let half = s01.min(s12) / 2.0;
+            let src = Some(wi as u32);
+            for i in 0..4 {
+                segments.push(InputSegment::new(r[i], r[(i + 1) % 4], src).with_half_thickness(half));
+            }
+        }
+        let arr = Arrangement::resolve(&segments, options.snap_tolerance);
+        let mut plate = Self::from_arrangement(arr, options.min_area);
+        plate.wall_rects = rects.to_vec();
+        plate
+    }
+
     fn from_arrangement(arr: Arrangement, min_area: f64) -> Self {
         let mut plate = SpacePlate {
             vertices: arr
@@ -236,6 +273,7 @@ impl SpacePlate {
                 .collect(),
             half_edges: Vec::with_capacity(arr.edges.len() * 2),
             faces: Vec::new(),
+            wall_rects: Vec::new(),
         };
 
         // Two half-edges per undirected edge, twinned. Record outgoing fans.
@@ -955,14 +993,37 @@ impl SpacePlate {
         Some(self.half_edges[he.twin.0 as usize].face)
     }
 
-    /// Every live interior (room) face.
+    /// Every live interior (room) face. In the FACE-BASED build (`wall_rects`
+    /// non-empty) a bounded face is a room only if it's a gap between walls — its
+    /// centroid lies outside every wall rectangle, so wall interiors and junction
+    /// overlaps are excluded.
     pub fn rooms(&self) -> impl Iterator<Item = FaceId> + '_ {
         (0..self.faces.len())
             .map(|i| FaceId(i as u32))
             .filter(move |f| {
                 let face = &self.faces[f.0 as usize];
-                face.alive && !face.is_outer
+                face.alive && !face.is_outer && self.is_room_face(*f)
             })
+    }
+
+    /// Face-based room test: a bounded face is a room when its centroid is not
+    /// inside any wall rectangle (a gap, not a wall interior). Always true for
+    /// the centreline build (no `wall_rects`).
+    fn is_room_face(&self, face: FaceId) -> bool {
+        if self.wall_rects.is_empty() {
+            return true;
+        }
+        let outline = self.face_outline(face);
+        if outline.len() < 3 {
+            return false;
+        }
+        let (mut cx, mut cy) = (0.0, 0.0);
+        for p in &outline {
+            cx += p[0];
+            cy += p[1];
+        }
+        let c = [cx / outline.len() as f64, cy / outline.len() as f64];
+        !self.wall_rects.iter().any(|r| point_in_quad(c, r))
     }
 
     /// CCW outline of a face (no repeated closing vertex).
@@ -1047,6 +1108,84 @@ impl SpacePlate {
         }
         if inset && got > polygon_area(&centre).abs() + 1e-6 {
             return centre; // the inset inverted the polygon — keep the centreline
+        }
+        verts
+    }
+
+    /// FACE-BASED boundary of a gap room: the gap outline IS the net (inner-face)
+    /// area, so this pushes every edge OUTWARD (into the wall, away from the room)
+    /// by `factor × the source wall's half-thickness`, then re-intersects corners.
+    /// `factor = 0` → net (the gap itself); `1` → the wall **axis / centre line**
+    /// (½ thickness — where the editable node sits, on the wall mid); `2` → the
+    /// gross outer face (full thickness). No shared-edge pinning: two rooms across
+    /// a wall correctly meet at the mid axis and overlap into it for gross.
+    pub fn gap_boundary(&self, face: FaceId, factor: f64) -> Vec<[f64; 2]> {
+        let centre = self.face_outline(face);
+        let n = centre.len();
+        if n < 3 || factor.abs() < EPS {
+            return centre;
+        }
+        let cycle: Vec<HalfEdgeId> = self.face_half_edges(face).collect();
+        if cycle.len() != n {
+            return centre;
+        }
+        // Per edge: the offset line (anchor + dir), the outward displacement
+        // vector applied, and |offset| (for the corner miter clamp below).
+        let mut lines: Vec<([f64; 2], [f64; 2])> = Vec::with_capacity(n);
+        let mut disp: Vec<[f64; 2]> = Vec::with_capacity(n);
+        let mut off_mag: Vec<f64> = Vec::with_capacity(n);
+        for i in 0..n {
+            let a = centre[i];
+            let b = centre[(i + 1) % n];
+            let (dx, dy) = (b[0] - a[0], b[1] - a[1]);
+            let l = (dx * dx + dy * dy).sqrt();
+            if l < EPS {
+                return centre;
+            }
+            let (ux, uy) = (dx / l, dy / l);
+            let half = self.half_edges[cycle[i].0 as usize].half_thickness;
+            // Outward (right of a→b on a CCW ring) = (uy, -ux), i.e. negate the
+            // inward normal (-uy, ux). Push the edge out by factor × half.
+            let off = factor * half;
+            let d = [uy * off, -ux * off];
+            lines.push(([a[0] + d[0], a[1] + d[1]], [ux, uy]));
+            disp.push(d);
+            off_mag.push(off.abs());
+        }
+        // Re-intersect adjacent offset lines at each corner. At a concave / very
+        // acute corner the two near-parallel lines meet far away (an unbounded
+        // miter), which would blow the polygon up; clamp any corner that moves
+        // more than MITER_LIMIT × the local offset to a bevel (the original
+        // corner displaced by the mean of its two edges' offsets).
+        const MITER_LIMIT: f64 = 4.0;
+        let mut verts: Vec<[f64; 2]> = Vec::with_capacity(n);
+        for i in 0..n {
+            let pj = (i + n - 1) % n;
+            let (pp, pd) = lines[pj];
+            let (cp, cd) = lines[i];
+            let bevel = [
+                centre[i][0] + 0.5 * (disp[pj][0] + disp[i][0]),
+                centre[i][1] + 0.5 * (disp[pj][1] + disp[i][1]),
+            ];
+            let limit = MITER_LIMIT * off_mag[i].max(off_mag[pj]) + EPS;
+            let pt = match line_intersection(pp, [pp[0] + pd[0], pp[1] + pd[1]], cp, [cp[0] + cd[0], cp[1] + cd[1]]) {
+                Some(m) => {
+                    let (ddx, ddy) = (m[0] - centre[i][0], m[1] - centre[i][1]);
+                    if (ddx * ddx + ddy * ddy).sqrt() <= limit { m } else { bevel }
+                }
+                None => bevel,
+            };
+            verts.push(pt);
+        }
+        // Final guards: any non-finite / degenerate / runaway (a still-exploded
+        // offset polygon should never dwarf the net area) → fall back to the net.
+        let net_area = polygon_area(&centre).abs();
+        let off_area = polygon_area(&verts).abs();
+        if verts.iter().any(|v| !v[0].is_finite() || !v[1].is_finite())
+            || off_area <= EPS
+            || off_area > 4.0 * net_area + 25.0
+        {
+            return centre;
         }
         verts
     }
@@ -1555,6 +1694,22 @@ fn polygon_area(pts: &[[f64; 2]]) -> f64 {
     acc * 0.5
 }
 
+/// Ray-cast point-in-polygon for a wall rectangle (4 corners). A face centroid
+/// inside any wall rect = a wall interior / junction overlap, not a room gap.
+fn point_in_quad(p: [f64; 2], quad: &[[f64; 2]; 4]) -> bool {
+    let mut inside = false;
+    let mut j = 3;
+    for i in 0..4 {
+        let (xi, yi) = (quad[i][0], quad[i][1]);
+        let (xj, yj) = (quad[j][0], quad[j][1]);
+        if ((yi > p[1]) != (yj > p[1])) && (p[0] < (xj - xi) * (p[1] - yi) / (yj - yi) + xi) {
+            inside = !inside;
+        }
+        j = i;
+    }
+    inside
+}
+
 /// Perpendicular distance of point `p` to the infinite line through `a` and `b`
 /// (degenerates to the point distance when `a == b`). Used to judge whether a
 /// degree-2 node is a redundant collinear point on its neighbours' chord.
@@ -1617,6 +1772,29 @@ mod tests {
         assert_eq!(plate.room_count(), 1);
         let room = plate.rooms().next().unwrap();
         assert!((plate.face_area(room) - 12.0).abs() < 1e-6, "area {}", plate.face_area(room));
+    }
+
+    #[test]
+    fn face_based_room_is_the_gap_between_wall_rects() {
+        // A 4×3 room boxed by four 0.2 m-thick wall rectangles (they overlap at
+        // the corners, as real walls do). The room is the GAP between them: net
+        // (inner faces) = 3.8×2.8 = 10.64; axis (+½t) = 4×3 = 12; gross (+t) =
+        // 4.2×3.2 = 13.44. Nodes sit on the axis = the true wall mid.
+        let rects = vec![
+            [[-0.1, -0.1], [4.1, -0.1], [4.1, 0.1], [-0.1, 0.1]], // bottom
+            [[-0.1, 2.9], [4.1, 2.9], [4.1, 3.1], [-0.1, 3.1]],   // top
+            [[-0.1, -0.1], [0.1, -0.1], [0.1, 3.1], [-0.1, 3.1]], // left
+            [[3.9, -0.1], [4.1, -0.1], [4.1, 3.1], [3.9, 3.1]],   // right
+        ];
+        let plate = SpacePlate::build_from_wall_rects(&rects, BuildOptions::default());
+        assert_eq!(plate.room_count(), 1, "the gap between the four walls is the one room");
+        let room = plate.rooms().next().unwrap();
+        let net = polygon_area(&plate.face_outline(room)).abs();
+        assert!((net - 10.64).abs() < 1e-6, "net (gap / inner faces) = 10.64, got {net}");
+        let axis = polygon_area(&plate.gap_boundary(room, 1.0)).abs();
+        assert!((axis - 12.0).abs() < 1e-6, "axis (+½ thickness, the node line) = 12, got {axis}");
+        let gross = polygon_area(&plate.gap_boundary(room, 2.0)).abs();
+        assert!((gross - 13.44).abs() < 1e-6, "gross (+ full thickness) = 13.44, got {gross}");
     }
 
     /// Two rooms sharing a central wall — the canonical "shared edge"

--- a/rust/wasm-bindings/src/api/space_plate.rs
+++ b/rust/wasm-bindings/src/api/space_plate.rs
@@ -121,6 +121,44 @@ impl SpacePlateHandle {
         Ok(SpacePlateHandle { inner: SpacePlate::build(&segments, opts) })
     }
 
+    /// FACE-BASED build: rooms are the gaps between wall footprint rectangles.
+    /// `rectCoords` is flat `[x0, y0, x1, y1, x2, y2, x3, y3, …]` — 8 f64 per wall
+    /// (its 4 plan-rectangle corners, CCW). A bounded arrangement face is a room
+    /// only if its centroid is outside every rectangle (a gap, not a wall
+    /// interior). The room outline IS the net (inner-face) area; `gapBoundary`
+    /// gives the centre axis (½ thickness) and the gross outer face.
+    #[wasm_bindgen(js_name = fromWallRects)]
+    pub fn from_wall_rects(rect_coords: &[f64], snap_tolerance: f64, min_area: f64) -> Result<SpacePlateHandle, JsValue> {
+        if !rect_coords.len().is_multiple_of(8) {
+            return Err(JsValue::from_str(
+                "rectCoords length must be a multiple of 8 (4 corners × x,y per wall)",
+            ));
+        }
+        let rects: Vec<[[f64; 2]; 4]> = rect_coords
+            .chunks_exact(8)
+            .map(|c| [[c[0], c[1]], [c[2], c[3]], [c[4], c[5]], [c[6], c[7]]])
+            .collect();
+        let defaults = BuildOptions::default();
+        let opts = BuildOptions {
+            snap_tolerance: if snap_tolerance > 0.0 { snap_tolerance } else { defaults.snap_tolerance },
+            min_area: if min_area > 0.0 { min_area } else { defaults.min_area },
+        };
+        Ok(SpacePlateHandle { inner: SpacePlate::build_from_wall_rects(&rects, opts) })
+    }
+
+    /// Face-based gap-room boundary as flat `[x0, y0, …]`: each edge pushed
+    /// OUTWARD (into the wall) by `factor × the source wall's half-thickness`.
+    /// `0` → net (the gap / inner faces); `1` → centre axis (½ thickness, the
+    /// editable node line on the wall mid); `2` → gross outer face.
+    #[wasm_bindgen(js_name = gapBoundary)]
+    pub fn gap_boundary(&self, face: u32, factor: f64) -> Vec<f64> {
+        self.inner
+            .gap_boundary(FaceId(face), factor)
+            .into_iter()
+            .flat_map(|p| [p[0], p[1]])
+            .collect()
+    }
+
     /// Number of live rooms.
     #[wasm_bindgen(getter, js_name = roomCount)]
     pub fn room_count(&self) -> usize {

--- a/rust/wasm-bindings/src/api/space_plate.rs
+++ b/rust/wasm-bindings/src/api/space_plate.rs
@@ -283,16 +283,21 @@ fn to_js<T: Serialize>(value: &T) -> Result<JsValue, JsValue> {
     serde_wasm_bindgen::to_value(value).map_err(|e| JsValue::from_str(&e.to_string()))
 }
 
-/// Map a topology-edit rejection to a JS `Error` with a stable, readable code.
+/// Map a topology-edit rejection to a JS `Error` whose `name` is a STABLE code
+/// (the `EditError` variant) and whose `message` is human prose. The TS side
+/// switches on `err.name` rather than parsing the message string — see
+/// `space-edit-error.ts`.
 fn edit_err(e: EditError) -> JsValue {
-    let msg = match e {
-        EditError::StaleHandle => "StaleHandle: id is tombstoned or out of range",
-        EditError::VerticesNotOnFace => "VerticesNotOnFace: both split vertices must lie on the face",
-        EditError::DegenerateCut => "DegenerateCut: split endpoints are equal or already adjacent",
-        EditError::BordersExterior => "BordersExterior: edge borders the exterior — nothing to merge",
-        EditError::BridgeEdge => "BridgeEdge: edge is a bridge — removing it would split connectivity",
-        EditError::VertexNotDissolvable => "VertexNotDissolvable: only a degree-2 vertex (a node between exactly two walls) can be dissolved",
-        EditError::InvalidPolygon => "InvalidPolygon: need a simple ring of 3+ points enclosing non-zero area",
+    let (code, msg) = match e {
+        EditError::StaleHandle => ("StaleHandle", "this element no longer exists (it was removed or merged)"),
+        EditError::VerticesNotOnFace => ("VerticesNotOnFace", "both split points must lie on the same room"),
+        EditError::DegenerateCut => ("DegenerateCut", "the two points are the same or already share a wall"),
+        EditError::BordersExterior => ("BordersExterior", "this wall is the room's outer edge — removing it would open the room"),
+        EditError::BridgeEdge => ("BridgeEdge", "this wall bridges the room to itself"),
+        EditError::VertexNotDissolvable => ("VertexNotDissolvable", "this node joins three or more walls"),
+        EditError::InvalidPolygon => ("InvalidPolygon", "a room needs a simple ring of 3+ points enclosing real area"),
     };
-    JsValue::from_str(msg)
+    let err = js_sys::Error::new(msg);
+    err.set_name(code);
+    err.into()
 }

--- a/rust/wasm-bindings/src/api/space_plate.rs
+++ b/rust/wasm-bindings/src/api/space_plate.rs
@@ -72,11 +72,15 @@ impl SpacePlateHandle {
     ///
     /// `segCoords`: `[ax, ay, bx, by, …]` (length a multiple of 4).
     /// `segSources`: one `i32` per segment, `-1` for none.
+    /// `segHalfThickness`: one `f64` per segment — half the wall's thickness in
+    /// metres, carried onto the derived edges for `netOutline`. Pass an empty
+    /// array (or all zeros) when thickness is unknown (centreline only).
     /// `snapTolerance` / `minArea`: pass `<= 0` to take the defaults.
     #[wasm_bindgen(constructor)]
     pub fn new(
         seg_coords: &[f64],
         seg_sources: &[i32],
+        seg_half_thickness: &[f64],
         snap_tolerance: f64,
         min_area: f64,
     ) -> Result<SpacePlateHandle, JsValue> {
@@ -91,15 +95,22 @@ impl SpacePlateHandle {
                 "segSources length must equal the segment count (segCoords.len / 4)",
             ));
         }
+        if !seg_half_thickness.is_empty() && seg_half_thickness.len() != n {
+            return Err(JsValue::from_str(
+                "segHalfThickness must be empty or have one entry per segment",
+            ));
+        }
         let segments: Vec<InputSegment> = (0..n)
             .map(|i| {
                 let o = i * 4;
                 let src = seg_sources[i];
+                let half = seg_half_thickness.get(i).copied().unwrap_or(0.0);
                 InputSegment::new(
                     [seg_coords[o], seg_coords[o + 1]],
                     [seg_coords[o + 2], seg_coords[o + 3]],
                     if src < 0 { None } else { Some(src as u32) },
                 )
+                .with_half_thickness(half.max(0.0))
             })
             .collect();
         let defaults = BuildOptions::default();
@@ -148,6 +159,21 @@ impl SpacePlateHandle {
     pub fn face_outline(&self, face: u32) -> Vec<f64> {
         self.inner
             .face_outline(FaceId(face))
+            .into_iter()
+            .flat_map(|p| [p[0], p[1]])
+            .collect()
+    }
+
+    /// The face outline offset to a wall boundary, as flat `[x0, y0, …]`: each
+    /// edge is moved by its own wall's half-thickness — inward when `inset`
+    /// (the net / inner face), outward otherwise (the gross / outer face).
+    /// Shared room↔room edges are pinned when pushing outward. Falls back to the
+    /// centreline outline when no offset applies — so it's always a sane ring.
+    /// (For a `center` boundary just use `faceOutline`.)
+    #[wasm_bindgen(js_name = netOutline)]
+    pub fn net_outline(&self, face: u32, inset: bool) -> Vec<f64> {
+        self.inner
+            .net_outline(FaceId(face), inset)
             .into_iter()
             .flat_map(|p| [p[0], p[1]])
             .collect()

--- a/rust/wasm-bindings/src/api/space_plate.rs
+++ b/rust/wasm-bindings/src/api/space_plate.rs
@@ -223,6 +223,32 @@ impl SpacePlateHandle {
         let patches = self.inner.merge_faces(HalfEdgeId(edge)).map_err(edit_err)?;
         patches_to_js(patches)
     }
+
+    /// Dissolve a degree-2 vertex, welding its two edges into one straight
+    /// edge between the neighbours — the inverse of `splitEdge`, and the
+    /// "delete this corner / node" affordance. Returns the rooms it changed.
+    /// Rejects a wall junction (degree ≥ 3) or a weld that would duplicate an
+    /// edge.
+    #[wasm_bindgen(js_name = dissolveVertex)]
+    pub fn dissolve_vertex(&mut self, v: u32) -> Result<JsValue, JsValue> {
+        let patches = self.inner.dissolve_vertex(VertexId(v)).map_err(edit_err)?;
+        patches_to_js(patches)
+    }
+
+    /// Author a new room from a flat ring `[x0, y0, x1, y1, …]` (no repeated
+    /// closing vertex). `source` `-1` marks a user-drawn room. Winding is
+    /// normalised to CCW; returns the new room patch. The room is its own
+    /// connected component — it does not merge into existing topology.
+    #[wasm_bindgen(js_name = addFace)]
+    pub fn add_face(&mut self, coords: &[f64], source: i32) -> Result<JsValue, JsValue> {
+        if !coords.len().is_multiple_of(2) {
+            return Err(JsValue::from_str("coords length must be even (x, y per vertex)"));
+        }
+        let pts: Vec<[f64; 2]> = coords.chunks_exact(2).map(|c| [c[0], c[1]]).collect();
+        let src = if source < 0 { None } else { Some(source as u32) };
+        let patch = self.inner.add_face(&pts, src).map_err(edit_err)?;
+        patches_to_js(vec![patch])
+    }
 }
 
 fn patches_to_js(patches: Vec<FacePatch>) -> Result<JsValue, JsValue> {
@@ -242,6 +268,8 @@ fn edit_err(e: EditError) -> JsValue {
         EditError::DegenerateCut => "DegenerateCut: split endpoints are equal or already adjacent",
         EditError::BordersExterior => "BordersExterior: edge borders the exterior — nothing to merge",
         EditError::BridgeEdge => "BridgeEdge: edge is a bridge — removing it would split connectivity",
+        EditError::VertexNotDissolvable => "VertexNotDissolvable: only a degree-2 vertex (a node between exactly two walls) can be dissolved",
+        EditError::InvalidPolygon => "InvalidPolygon: need a simple ring of 3+ points enclosing non-zero area",
     };
     JsValue::from_str(msg)
 }

--- a/rust/wasm-bindings/src/api/space_plate.rs
+++ b/rust/wasm-bindings/src/api/space_plate.rs
@@ -249,6 +249,29 @@ impl SpacePlateHandle {
         let patch = self.inner.add_face(&pts, src).map_err(edit_err)?;
         patches_to_js(vec![patch])
     }
+
+    /// Remove a wall edge, choosing the right semantics from its two faces:
+    /// two real rooms → union them; a bridge / spur / outer-only wall → delete
+    /// it and auto-clean the orphaned inner lines and nodes it leaves; a real
+    /// enclosing wall (room ↔ exterior) → rejected (`BordersExterior`). This is
+    /// the "remove this wall and tidy up" affordance for the orphan cruft the
+    /// non-destructive wall arrangement leaves behind. Returns the rooms it
+    /// changed (empty if the edge bounded no room).
+    #[wasm_bindgen(js_name = removeEdge)]
+    pub fn remove_edge(&mut self, edge: u32) -> Result<JsValue, JsValue> {
+        let patches = self.inner.remove_edge(HalfEdgeId(edge)).map_err(edit_err)?;
+        patches_to_js(patches)
+    }
+
+    /// Sweep the whole plate clean: remove dangling spur walls, isolated nodes,
+    /// and redundant collinear nodes — the "clean up orphans" / eraser action.
+    /// Area-neutral and idempotent. Returns how many topology elements were
+    /// pruned (0 = the plate was already clean); the caller re-renders via
+    /// `snapshot` like any other edit.
+    #[wasm_bindgen(js_name = prune)]
+    pub fn prune(&mut self) -> usize {
+        self.inner.prune_orphans()
+    }
 }
 
 fn patches_to_js(patches: Vec<FacePatch>) -> Result<JsValue, JsValue> {


### PR DESCRIPTION
## Summary

The Space Sketch 2D room editor, rebuilt as a clean overhaul on current `main`. This is the stable Space Sketch work **without** the experimental wall-thickness / face-based room-derivation arc that accumulated on `space-sketch-ux` (#1098) — that experiment is set aside on its own branch for reference; this branch resets to the solid foundation before it.

## What's in it

**Modeless editor + UX**
- One modeless tool (no drag/split/merge/draw mode tabs) — cursor + gesture driven
- Snap-to-building (walls + corners), sticky panel, Shift-pan, wheel-zoom-to-cursor, unbaked-edits close guard, decluttered panel + contextual hints
- Draw rework: snap the first point, align corners to axes, first-corner snap preview
- macOS Ctrl-click = remove, routed via `contextmenu` for reliability

**DCEL engine (`rust/geometry/src/space_dcel.rs` + `@ifc-lite/wasm`)**
- `dissolve_vertex` / `add_face` / `split_edge` (add nodes on walls)
- Removable orphans + auto-cleanup (`remove_edge`, `prune_orphans`) so any wall/node can be deleted and orphaned inner walls/nodes are swept — derived plates start clean
- Per-edge wall thickness threaded onto half-edges + `net_outline(face, inset)` → net/gross outlines come from the engine (topology-pinned shared edges), not the fuzzy TS `offsetRoomFootprint`

**Architecture refactor (6 parts)**
- Structured edit-error contract across the wasm boundary (`{code, message}`)
- `SpacePlateSession` owns the wasm handle + undo/redo + drag lifecycle (deterministic free; no React-side `.duplicate()/.free()`)
- Extracted `<SpaceSketchCanvas>`, Options/Help popovers, pure tested geometry helpers, centralized pointer/modifier input normalization

**Authored-element fixes (viewer/renderer)**
- Register authored elements in the spatial hierarchy as first-class (name, By-Class/type tree, spatial-tree label)
- Move gizmo handles authored single-entity meshes; clear the ghost duplicate on move; the move ghost no longer reuses the stale selection-highlight mesh

## Changesets
- `@ifc-lite/wasm` (minor ×2 — edit ops + net-area/removal)
- `@ifc-lite/renderer` (patch ×3 — stale-highlight evict, scene-streaming accessors, authored-mesh translate)

## Verification
- 39 `space_dcel` Rust tests green; committed wasm `.d.ts` in sync with a fresh build (CI gate)
- Viewer `tsc --noEmit` clean
- Merge of `origin/main` was conflict-free

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Space Sketch UI improvements: richer snapping visuals, options/help popovers, and modeless actions.
  * Introduced session-based plate editing with new operations (dissolve/add/remove/prune) and face-based room derivation with improved boundary/outline support.
  * Updated hierarchy to include newly-authored overlay elements, with better type-tree folding.
* **Bug Fixes**
  * Prevented “ghost” selection highlights when moving/removing entities.
  * Fixed translation for authored single-entity meshes.
  * Improved streaming finalization to avoid unclean fragment duplicates.
* **Documentation**
  * Added Changeset entries covering renderer and WASM updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->