### PR TITLE
fix(geometry): per-element CSG escalation budget to finish boolean-heavy models (#1109)

### DIFF
--- a/.changeset/csg-1109-per-element-budget.md
+++ b/.changeset/csg-1109-per-element-budget.md
@@ -1,0 +1,16 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Stop boolean-heavy models still hanging at 95% after the per-boolean escalation budget (#1109 follow-up).
+
+The deterministic per-boolean budget (#1112) bounded a *single* boolean, but two holes kept dense models stalling past the geometry-stream watchdog:
+
+- **Overshoot.** The budget's `tripped()` check only fired at arrangement loop boundaries — once per triangle in the seam retriangulation. A single heavily-fragmented host face (a slab cut by 24-47 openings) inserts thousands of constraint points in *one* `triangulate` call, so a boolean ran to **7.7M** escalations — ~4 minutes — between two checks before bailing. Profiled on a real model: one IFCSLAB took 243 s.
+- **Distributed cost.** An element with many openings runs one boolean *per* opening, each well under the per-boolean cap, so none trips — yet the element's total exact work is huge and the geometry batch blows the stream watchdog.
+
+This adds a **per-element** escalation budget alongside the per-boolean one. `kernel::budget::begin_element()` (called once per element at the unified `produce_element_meshes` entry — native *and* wasm) accumulates escalations across every boolean the element issues; when the element total crosses `DEFAULT_ELEMENT_CAP = 100_000` it degrades as a whole (remaining cuts bail to the #635 AABB box-cut), instead of grinding. The kernel's per-point retriangulation and constraint-recovery loops now also check the budget, so a single boolean can no longer overshoot the cap by 15×.
+
+Still a **deterministic count**, accumulated in deterministic per-opening order on the element's single worker thread (the kernel has no internal rayon), so native and wasm degrade the *same* element identically — the cross-target parity the kernel exists to guarantee is preserved. Calibrated against the model corpus: healthy per-element totals are p99 ≈ 13k escalations, so the 100k cap (~8× p99) never false-trips a legitimate cut. The cap engages only when an element scope is opened (the batch path); direct kernel/router callers, the server, and offline export stay unbounded via the existing `set_cap(None)` / `IFC_LITE_CSG_BUDGET=0` switch — so the pinned determinism manifests are unchanged.
+
+Measured on the profiling corpus (one boolean-heavy structural model): the worst element drops from 243 s to 2.9 s, and total serial geometry from minutes to ~28 s.

--- a/.changeset/csg-1109-recovery-perf.md
+++ b/.changeset/csg-1109-recovery-perf.md
@@ -1,0 +1,12 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Speed up the exact CSG kernel's constraint-recovery hot path on dense-opening models (#1109).
+
+Profiling the boolean-heavy slabs that hung the geometry stream showed the kernel spends ~80% of its time in constraint-recovery retriangulation — split between the channel-detection scan and the pocket earcut. Two parity-safe optimizations:
+
+- **Channel detection.** The per-segment O(tris) channel scan recomputed `orient(a,b,vertex)` for each triangle *edge*, but a triangle has only three vertices — so compute each vertex's side of the `(a,b)` line once and run the reciprocal edge-side test only for edges whose endpoints straddle it: ~3 exact predicates per triangle instead of up to 12. **Channel scan 9.6s → 2.9s (3.3×)** on the profiling corpus.
+- **Pocket earcut.** The ear-emptiness test ran an exact `strictly_outside` predicate for every other ring vertex. A conservative f64-AABB prefilter (the same widened-margin technique already used by `tri_aabb_disjoint`) skips the exact test for vertices provably outside the ear's AABB. This cuts the earcut's exact-predicate count on large pockets, which also lowers the per-element escalation count, so the #1109 budget cuts more openings exactly before degrading.
+
+Both produce **byte-identical** output — they compute the same exact predicate signs, and the prefilter only skips vertices it proves are outside — so the pinned determinism manifests, snapshots, and native==wasm parity are unchanged. End-to-end on a boolean-heavy structural model (per-element budget on): 23.6s → 19.4s of serial geometry; the channel-detection raw speedup is 3.3× (the budget converts the remaining headroom into more openings cut exactly rather than pure wall-time).

--- a/.github/actions/setup-wasm-build/action.yml
+++ b/.github/actions/setup-wasm-build/action.yml
@@ -38,4 +38,9 @@ runs:
     - name: Install wasm-pack
       uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa # v0.4.0
       with:
-        version: latest
+        # Pinned, not `latest`: `latest` makes the action hit the GitHub releases
+        # API on every run to resolve the newest version, which intermittently
+        # returns an HTML rate-limit page instead of JSON ("Unexpected token '<'")
+        # and fails the WASM build for reasons unrelated to the change under test.
+        # A fixed version is reproducible and skips the lookup entirely.
+        version: v0.15.0

--- a/rust/geometry/src/kernel/budget.rs
+++ b/rust/geometry/src/kernel/budget.rs
@@ -54,20 +54,63 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// where "exact but slow" is acceptable.
 pub const DEFAULT_CAP: u64 = 500_000;
 
-/// Global cap. `0` ⇒ unbounded (run exact to completion). Any other value is the
-/// per-boolean escalation cap. Read once per boolean into a thread-local so each
-/// rayon worker counts its own operation independently and deterministically.
+/// Default per-ELEMENT exact-evaluation cap (#1109 follow-up).
+///
+/// The per-boolean cap above bounds a SINGLE boolean, but it left two holes that
+/// kept boolean-heavy models stalling at 95% even after the per-boolean budget
+/// shipped:
+///   1. **Distributed cost.** An element with many openings (a 24-opening slab,
+///      a window-dense facade) runs one boolean PER opening, each well under the
+///      per-boolean cap, so none trips — yet the element's TOTAL exact work is
+///      huge and the geometry batch blows the stream watchdog.
+///   2. **Overshoot.** A single heavily-fragmented host face retriangulates all
+///      its constraint points in ONE `triangulate` call between two per-triangle
+///      `tripped()` checks, so one boolean ran to ~1.7M escalations (3.3× a 500k
+///      cap) before bailing — seconds of work past the cap.
+///
+/// This cap counts escalations across the WHOLE element (every boolean it runs)
+/// and trips once the element total crosses it, so a hard element degrades as a
+/// UNIT (its remaining cuts bail to the #635 AABB box-cut) instead of grinding.
+/// It is still a deterministic COUNT, so native and wasm degrade the SAME element
+/// identically (parity). Calibrated on the model corpus (the `csg_model_profile`
+/// harness): healthy per-element totals are p50=0, p95≈150, p99≈13k — so this cap
+/// is ~8× the 99th-percentile healthy element and never false-trips a legitimate
+/// cut, while the pathological slabs that hung the stream (one needed 7.7M
+/// escalations → 4 MINUTES) all sit far above it. At the measured ~50-60k
+/// escalations/sec it bounds a hard element to ~2 s of exact work before its
+/// remaining cuts degrade. The per-element cap only engages when [`begin_element`]
+/// is called (the unified batch path); direct kernel / router / server /
+/// offline-export callers that never open an element scope stay unbounded,
+/// exactly as before — so the pinned kernel snapshots are unchanged.
+pub const DEFAULT_ELEMENT_CAP: u64 = 100_000;
+
+/// Global per-boolean cap. `0` ⇒ unbounded (run exact to completion). Any other
+/// value is the per-boolean escalation cap. Read once per boolean into a
+/// thread-local so each rayon worker counts its own operation independently and
+/// deterministically.
 static CAP: AtomicU64 = AtomicU64::new(DEFAULT_CAP);
+
+/// Global per-element cap. `0` ⇒ unbounded. Snapshotted by [`begin_element`].
+static ELEMENT_CAP: AtomicU64 = AtomicU64::new(DEFAULT_ELEMENT_CAP);
 
 /// Highest single-boolean escalation count seen since the last [`reset_peak`].
 /// Diagnostics / cap calibration only — never read on the hot path.
 static PEAK: AtomicU64 = AtomicU64::new(0);
+
+/// Highest single-ELEMENT escalation total seen since the last [`reset_peak`].
+static ELEM_PEAK: AtomicU64 = AtomicU64::new(0);
 
 thread_local! {
     /// Escalations counted in the current boolean operation.
     static COUNT: Cell<u64> = const { Cell::new(0) };
     /// This operation's cap snapshot (`u64::MAX` when unbounded).
     static OP_CAP: Cell<u64> = const { Cell::new(u64::MAX) };
+    /// Escalations accumulated across the current ELEMENT (all its booleans).
+    /// Reset only by [`begin_element`]; per-boolean [`begin`] does NOT reset it.
+    static ELEM_COUNT: Cell<u64> = const { Cell::new(0) };
+    /// This element's cap snapshot. `u64::MAX` (unbounded) until an element scope
+    /// is opened, so non-batch callers are unaffected.
+    static ELEM_CAP: Cell<u64> = const { Cell::new(u64::MAX) };
 }
 
 /// Effective cap, honouring the `IFC_LITE_CSG_BUDGET` env override (read once):
@@ -79,6 +122,16 @@ fn env_cap() -> Option<u64> {
     *ENV.get_or_init(|| std::env::var("IFC_LITE_CSG_BUDGET").ok().and_then(|v| v.parse::<u64>().ok()))
 }
 
+/// Per-element env override (`IFC_LITE_CSG_ELEMENT_BUDGET`, read once): `0` ⇒
+/// unbounded, any other value ⇒ that cap. For calibration runs.
+fn env_element_cap() -> Option<u64> {
+    use std::sync::OnceLock;
+    static ENV: OnceLock<Option<u64>> = OnceLock::new();
+    *ENV.get_or_init(|| {
+        std::env::var("IFC_LITE_CSG_ELEMENT_BUDGET").ok().and_then(|v| v.parse::<u64>().ok())
+    })
+}
+
 /// Set the global per-boolean escalation cap. `None` = unbounded (exact to
 /// completion — the server/CLI/offline-export profile); `Some(n)` = trip after
 /// `n` BigRational escalations (the interactive viewer/wasm profile). The
@@ -87,9 +140,23 @@ pub fn set_cap(cap: Option<u64>) {
     CAP.store(cap.unwrap_or(0), Ordering::Relaxed);
 }
 
-/// The active cap, as configured (`None` ⇒ unbounded).
+/// Set the global per-element escalation cap (#1109 follow-up). `None` =
+/// unbounded. The default is [`DEFAULT_ELEMENT_CAP`].
+pub fn set_element_cap(cap: Option<u64>) {
+    ELEMENT_CAP.store(cap.unwrap_or(0), Ordering::Relaxed);
+}
+
+/// The active per-boolean cap, as configured (`None` ⇒ unbounded).
 pub fn cap() -> Option<u64> {
     match CAP.load(Ordering::Relaxed) {
+        0 => None,
+        n => Some(n),
+    }
+}
+
+/// The active per-element cap, as configured (`None` ⇒ unbounded).
+pub fn element_cap() -> Option<u64> {
+    match ELEMENT_CAP.load(Ordering::Relaxed) {
         0 => None,
         n => Some(n),
     }
@@ -112,15 +179,57 @@ pub fn begin() {
     COUNT.with(|c| c.set(0));
 }
 
+/// Begin an ELEMENT scope (#1109 follow-up): reset the per-element accumulator
+/// and snapshot the per-element cap. Call once per element at the unified
+/// mesh-production entry (`ifc_lite_processing::element::produce_element_meshes`),
+/// BEFORE its booleans run, so every boolean the element issues accumulates into
+/// one budget and a hard element degrades as a whole.
+///
+/// The per-element cap is unbounded whenever the per-boolean profile is unbounded
+/// (`set_cap(None)` / `IFC_LITE_CSG_BUDGET=0` — the server/offline-export
+/// profile), so the SAME single switch keeps the server exact. Otherwise it is
+/// the configured [`ELEMENT_CAP`] (or its `IFC_LITE_CSG_ELEMENT_BUDGET` override).
+#[inline]
+pub fn begin_element() {
+    // Fold the just-finished element's total into the per-element peak.
+    let prev = ELEM_COUNT.with(|c| c.get());
+    if prev != 0 {
+        ELEM_PEAK.fetch_max(prev, Ordering::Relaxed);
+    }
+    // Per-element cap is unbounded iff the per-boolean profile is unbounded.
+    let boolean_unbounded = match env_cap() {
+        Some(v) => v == 0,
+        None => CAP.load(Ordering::Relaxed) == 0,
+    };
+    let elem_cap = if boolean_unbounded {
+        0 // unbounded (server / offline export)
+    } else {
+        match env_element_cap() {
+            Some(v) => v, // override (0 = unbounded)
+            None => ELEMENT_CAP.load(Ordering::Relaxed),
+        }
+    };
+    ELEM_CAP.with(|c| c.set(if elem_cap == 0 { u64::MAX } else { elem_cap }));
+    ELEM_COUNT.with(|c| c.set(0));
+}
+
 /// Highest single-boolean escalation count observed since process start (or the
 /// last [`reset_peak`]). For cap calibration / diagnostics.
 pub fn peak() -> u64 {
     PEAK.load(Ordering::Relaxed)
 }
 
-/// Reset the global peak escalation counter.
+/// Highest single-ELEMENT escalation total observed since the last
+/// [`reset_peak`]. For per-element cap calibration / diagnostics.
+pub fn element_peak() -> u64 {
+    // Include the in-flight element so a single-element profile run sees it.
+    ELEM_PEAK.load(Ordering::Relaxed).max(ELEM_COUNT.with(|c| c.get()))
+}
+
+/// Reset the global peak escalation counters (per-boolean and per-element).
 pub fn reset_peak() {
     PEAK.store(0, Ordering::Relaxed);
+    ELEM_PEAK.store(0, Ordering::Relaxed);
 }
 
 /// Record one exact-tier predicate evaluation (an interval-filter failure).
@@ -130,13 +239,19 @@ pub fn reset_peak() {
 #[inline]
 pub fn note_escalation() {
     COUNT.with(|c| c.set(c.get().saturating_add(1)));
+    ELEM_COUNT.with(|c| c.set(c.get().saturating_add(1)));
 }
 
-/// Whether the current boolean has exceeded its escalation budget. Checked at
-/// loop boundaries in the arrangement so the bail is timely and graceful.
+/// Whether the current boolean OR the current element has exceeded its
+/// escalation budget. Checked at loop boundaries in the arrangement AND inside
+/// the per-point retriangulation loop so the bail is timely and graceful. Once
+/// the per-element budget is blown, every subsequent boolean the element issues
+/// trips immediately (its `COUNT` resets per [`begin`], but `ELEM_COUNT` does
+/// not), so the element's remaining cuts bail to the #635 AABB fallback.
 #[inline]
 pub fn tripped() -> bool {
     COUNT.with(|c| c.get()) >= OP_CAP.with(|c| c.get())
+        || ELEM_COUNT.with(|c| c.get()) >= ELEM_CAP.with(|c| c.get())
 }
 
 /// Escalations counted so far in the current boolean (diagnostics / cap
@@ -146,15 +261,27 @@ pub fn count() -> u64 {
     COUNT.with(|c| c.get())
 }
 
+/// Escalations accumulated so far in the current element across all its booleans
+/// (diagnostics / per-element cap calibration).
+#[inline]
+pub fn element_count() -> u64 {
+    ELEM_COUNT.with(|c| c.get())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    /// Serialises the two tests that mutate the global `CAP` / `ELEMENT_CAP`
+    /// atomics, so cargo's parallel runner can't race them.
+    static GLOBAL_CAP_LOCK: Mutex<()> = Mutex::new(());
 
     /// The cap counts escalations and trips at exactly the configured count,
-    /// deterministically; `begin()` resets; unbounded never trips. (Only this
-    /// test mutates the global cap, so there is no cross-test race on it.)
+    /// deterministically; `begin()` resets; unbounded never trips.
     #[test]
     fn cap_counts_and_trips_deterministically() {
+        let _guard = GLOBAL_CAP_LOCK.lock().unwrap();
         let restore = cap();
 
         set_cap(Some(5));
@@ -187,5 +314,60 @@ mod tests {
         assert!(!tripped(), "unbounded (cap None) must never trip");
 
         set_cap(restore);
+    }
+
+    /// The per-element budget (#1109 follow-up) accumulates across an element's
+    /// booleans even though `begin()` resets the per-boolean counter, trips the
+    /// element as a whole, and is reset by `begin_element()`. It stays unbounded
+    /// for callers that never open an element scope (the kernel/router tests and
+    /// the server profile), which is what keeps the pinned snapshots unchanged.
+    #[test]
+    fn per_element_budget_accumulates_across_booleans() {
+        let _guard = GLOBAL_CAP_LOCK.lock().unwrap();
+        let restore_cap = cap();
+        let restore_ecap = element_cap();
+        // A bounded per-boolean profile so begin_element() activates the element
+        // cap (it is unbounded only when the per-boolean profile is unbounded).
+        set_cap(Some(1_000_000));
+        set_element_cap(Some(10));
+
+        begin_element();
+        assert_eq!(element_count(), 0);
+        assert!(!tripped(), "fresh element must not be tripped");
+
+        // Three booleans, 4 escalations each = 12 total > the element cap of 10,
+        // even though no single boolean's per-op count (4) reaches it.
+        for _ in 0..3 {
+            begin(); // per-boolean reset — does NOT reset the element accumulator
+            assert_eq!(count(), 0, "begin() resets the per-boolean counter");
+            for _ in 0..4 {
+                note_escalation();
+            }
+        }
+        assert_eq!(element_count(), 12);
+        assert!(tripped(), "element total 12 >= element cap 10 must trip");
+        // ...and it stays tripped through the NEXT boolean even after begin()
+        // zeroes the per-boolean counter — so the element's remaining cuts bail.
+        begin();
+        assert_eq!(count(), 0);
+        assert!(tripped(), "element budget stays blown across begin()");
+
+        // begin_element() opens a fresh scope and clears the trip.
+        begin_element();
+        assert_eq!(element_count(), 0);
+        assert!(!tripped());
+
+        // An unbounded per-boolean profile makes the element cap unbounded too
+        // (the single server/offline-export switch), so it never trips.
+        set_cap(None);
+        begin_element();
+        for _ in 0..100_000 {
+            note_escalation();
+        }
+        assert_eq!(element_count(), 100_000);
+        assert!(!tripped(), "unbounded per-boolean profile ⇒ unbounded element");
+
+        set_cap(restore_cap);
+        set_element_cap(restore_ecap);
     }
 }

--- a/rust/geometry/src/kernel/retriangulate.rs
+++ b/rust/geometry/src/kernel/retriangulate.rs
@@ -446,6 +446,10 @@ pub fn triangulate_points(input: &RetriInput, interner: &mut Interner) -> Option
     let mut ordered: Vec<Vid> = pts.into_iter().collect();
     ordered.sort_by(|&a, &b| lex_cmp(interner, a, b));
     for p in ordered {
+        // #1109 overshoot guard — see `triangulate`.
+        if super::budget::tripped() {
+            break;
+        }
         insert_point(&mut mesh, interner, p);
     }
     Some(mesh)
@@ -851,6 +855,17 @@ pub fn triangulate(input: &RetriInput, interner: &mut Interner) -> Option<Mesh2d
     let mut ordered: Vec<Vid> = pts.into_iter().collect();
     ordered.sort_by(|&a, &b| lex_cmp(interner, a, b));
     for p in ordered {
+        // #1109 overshoot guard: a heavily-fragmented host face (a slab cut by
+        // 24+ openings) inserts thousands of constraint points here, each
+        // running exact orient2d in `insert_point`. The per-triangle
+        // `tripped()` check in `retriangulate_each` only fires BETWEEN
+        // triangles, so without this one `triangulate` call ran ~1.7M
+        // escalations (3.3× a 500k cap) — seconds of work — before bailing.
+        // Stop mid-insertion: the caller discards the partial arrangement once
+        // `tripped()`, so the incomplete triangulation is never emitted.
+        if super::budget::tripped() {
+            break;
+        }
         insert_point(&mut mesh, interner, p);
     }
     // Enforce to a FIXED POINT: recovering one constraint deletes the channel
@@ -866,8 +881,17 @@ pub fn triangulate(input: &RetriInput, interner: &mut Interner) -> Option<Mesh2d
     // of exact predicates ⇒ deterministic, byte-identical native==wasm.
     let mut converged = false;
     for _pass in 0..4 {
+        // #1109 overshoot guard: constraint recovery runs exact predicates per
+        // sub-segment; a slab face with thousands of seam segments is the other
+        // heavy escalation site between per-triangle `tripped()` checks.
+        if super::budget::tripped() {
+            break;
+        }
         let before = mesh.tris.clone();
         for &(s, t) in &canon.segments {
+            if super::budget::tripped() {
+                break;
+            }
             enforce_constraint(&mut mesh, interner, s, t);
         }
         if mesh.tris == before {

--- a/rust/geometry/src/kernel/retriangulate.rs
+++ b/rust/geometry/src/kernel/retriangulate.rs
@@ -217,9 +217,10 @@ pub struct Mesh2d {
     pub audit_needed: bool,
     /// Per-`Vid` cached 2D f64 coordinate (dropped to `axis`, `None` when the
     /// implicit point has no finite f64 image). Used ONLY as a conservative
-    /// broadphase prefilter in [`insert_point`] — the exact predicate still
-    /// decides every retained triangle, so this never affects topology. Cached
-    /// because the same vertices are re-scanned on every point insertion.
+    /// broadphase prefilter in [`insert_point`] / channel detection — the exact
+    /// predicate still decides every retained triangle, so this never affects
+    /// topology. Cached because the same vertices are re-scanned on every point
+    /// insertion AND on every constraint sub-segment's O(tris) channel scan.
     pub coords: BTreeMap<Vid, Option<[f64; 2]>>,
 }
 
@@ -474,22 +475,64 @@ fn strictly_outside(it: &Interner, a: Vid, b: Vid, c: Vid, p: Vid, axis: DropAxi
 /// simple polygon always has an ear → termination.
 pub fn earcut(it: &Interner, ring: &[Vid], axis: DropAxis, w0: Sign) -> Vec<SubTri> {
     let mut poly: Vec<Vid> = ring.to_vec();
+    // f64 2D images of the ring vertices, maintained parallel to `poly`. Used ONLY
+    // as a conservative AABB prefilter in the ear-emptiness test (the dominant
+    // #1109 earcut cost on dense-opening slabs): a vertex outside the candidate
+    // ear's widened f64 AABB is provably outside the ear, so its exact
+    // `strictly_outside` predicate is skipped. The margin dwarfs the f64 /
+    // implicit-point image error, exactly as `tri_aabb_disjoint`, so a vertex
+    // genuinely inside the ear is NEVER skipped — the chosen ear, and thus the
+    // whole triangulation, is byte-identical to the all-exact form (parity).
+    let mut pc: Vec<Option<[f64; 2]>> = poly
+        .iter()
+        .map(|&v| fixed::point_to_f64(it.get(v)).map(|p3| project2d(p3, axis)))
+        .collect();
     let mut out = Vec::new();
     while poly.len() > 3 {
         let n = poly.len();
+        // Below PREFILTER_MIN the exact emptiness scan is already short, so the
+        // AABB bookkeeping would be pure overhead — fall back to all-exact, which
+        // is the identical decision. Above it the O(n) exact scan dominates.
+        let prefilter = n > PREFILTER_MIN;
         let mut best: Option<usize> = None;
         for i in 0..n {
-            let a = poly[(i + n - 1) % n];
+            let (ia, ic) = ((i + n - 1) % n, (i + 1) % n);
+            let a = poly[ia];
             let b = poly[i];
-            let c = poly[(i + 1) % n];
+            let c = poly[ic];
             // strictly convex under w0
             if orient2d_v(it, a, b, c, axis) != w0 {
                 continue;
             }
+            let ear_box: Option<[f64; 4]> = if prefilter {
+                match (pc[ia], pc[i], pc[ic]) {
+                    (Some(pa), Some(pb), Some(pc2)) => Some([
+                        pa[0].min(pb[0]).min(pc2[0]),
+                        pa[1].min(pb[1]).min(pc2[1]),
+                        pa[0].max(pb[0]).max(pc2[0]),
+                        pa[1].max(pb[1]).max(pc2[1]),
+                    ]),
+                    _ => None,
+                }
+            } else {
+                None
+            };
             // empty: every other ring vertex is strictly outside the closed ear
-            let empty = poly
-                .iter()
-                .all(|&v| v == a || v == b || v == c || strictly_outside(it, a, b, c, v, axis, w0));
+            let empty = (0..n).all(|k| {
+                let v = poly[k];
+                if v == a || v == b || v == c {
+                    return true;
+                }
+                if let (Some(bx), Some(p)) = (ear_box, pc[k]) {
+                    let m = 1e-6
+                        + bx[2].abs().max(bx[3].abs()).max(p[0].abs()).max(p[1].abs()) * 1e-9;
+                    if p[0] < bx[0] - m || p[0] > bx[2] + m || p[1] < bx[1] - m || p[1] > bx[3] + m
+                    {
+                        return true; // provably outside the ear ⇒ skip the exact test
+                    }
+                }
+                strictly_outside(it, a, b, c, v, axis, w0)
+            });
             if !empty {
                 continue;
             }
@@ -516,6 +559,7 @@ pub fn earcut(it: &Interner, ring: &[Vid], axis: DropAxis, w0: Sign) -> Vec<SubT
         let n = poly.len();
         out.push([poly[(i + n - 1) % n], poly[i], poly[(i + 1) % n]]);
         poly.remove(i);
+        pc.remove(i);
     }
     out.push([poly[0], poly[1], poly[2]]);
     out
@@ -565,14 +609,38 @@ fn recover_subsegment(mesh: &mut Mesh2d, it: &Interner, a: Vid, b: Vid) {
     mesh.audit_needed = true;
 
     let (axis, w0) = (mesh.axis, mesh.w0);
-    // open segment (a,b) properly crosses open edge (u,v)?
-    let crosses = |u: Vid, v: Vid| {
-        let s1 = orient2d_v(it, a, b, u, axis);
-        let s2 = orient2d_v(it, a, b, v, axis);
-        let s3 = orient2d_v(it, u, v, a, axis);
-        let s4 = orient2d_v(it, u, v, b, axis);
-        s1 != Sign::Zero && s2 != Sign::Zero && s1 != s2
-            && s3 != Sign::Zero && s4 != Sign::Zero && s3 != s4
+    // Does any open edge of `tri` PROPERLY cross the open segment (a,b)? This is
+    // the dominant cost of constraint recovery (#1109): it runs per triangle for
+    // every constraint sub-segment. The naive form recomputes `orient(a,b,vertex)`
+    // for each of the triangle's three edges — but a triangle has only THREE
+    // vertices, so we compute each vertex's side of the (a,b) line ONCE, then an
+    // edge can only cross when its two endpoints straddle that line (opposite
+    // nonzero signs); only then do we run the reciprocal `orient(edge, a/b)` test.
+    // Identical exact result to the per-edge form (same signs, same crossing
+    // definition), ~3 predicates/triangle instead of up to 12 — byte-identical
+    // channel ⇒ parity preserved.
+    let tri_crosses = |tri: SubTri| {
+        let s = [
+            orient2d_v(it, a, b, tri[0], axis),
+            orient2d_v(it, a, b, tri[1], axis),
+            orient2d_v(it, a, b, tri[2], axis),
+        ];
+        for k in 0..3 {
+            let (su, sv) = (s[k], s[(k + 1) % 3]);
+            if su == Sign::Zero || sv == Sign::Zero || su == sv {
+                continue; // endpoints don't straddle (a,b) ⇒ no proper crossing
+            }
+            let (u, v) = (tri[k], tri[(k + 1) % 3]);
+            let s3 = orient2d_v(it, u, v, a, axis);
+            if s3 == Sign::Zero {
+                continue;
+            }
+            let s4 = orient2d_v(it, u, v, b, axis);
+            if s4 != Sign::Zero && s3 != s4 {
+                return true;
+            }
+        }
+        false
     };
     // Broadphase: only a triangle whose 2D f64 AABB overlaps the (a,b) segment's
     // AABB can have an edge that properly crosses (a,b). Skip the four exact
@@ -604,7 +672,7 @@ fn recover_subsegment(mesh: &mut Mesh2d, it: &Interner, a: Vid, b: Vid) {
                     return false;
                 }
             }
-            tri_edges(tri).iter().any(|&(u, v)| crosses(u, v))
+            tri_crosses(tri)
         })
         .collect();
     if channel.is_empty() {

--- a/rust/geometry/src/kernel/retriangulate.rs
+++ b/rust/geometry/src/kernel/retriangulate.rs
@@ -967,6 +967,15 @@ pub fn triangulate(input: &RetriInput, interner: &mut Interner) -> Option<Mesh2d
             break;
         }
     }
+    // #1109: if the per-element budget tripped while inserting points or recovering
+    // constraints above, the boolean caller discards this entire arrangement
+    // (csg.rs returns the host un-cut → #635 AABB fallback). Skip the conformity
+    // audit below — it runs O(segments × vertices) exact predicates with NO budget
+    // check, so without this a tripped, heavily-fragmented face keeps grinding well
+    // past the cap. The partial triangulation we return is dropped anyway.
+    if super::budget::tripped() {
+        return Some(mesh);
+    }
     if !converged {
         // Pass-cap exit: the LAST pass's rebuilds may have broken an edge that
         // was forced earlier without any later recover attempt re-flagging it,

--- a/rust/geometry/tests/csg_model_profile.rs
+++ b/rust/geometry/tests/csg_model_profile.rs
@@ -1,8 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! #1109 calibration harness: per-element CSG timing + escalation profile on a
 //! real model. Drives the same per-element path as the viewer/native batch
 //! (`begin_element()` + the router), reports total wall-time and the slowest
 //! elements with their per-boolean and per-element escalation counts, and is how
 //! `DEFAULT_ELEMENT_CAP` is calibrated (healthy p99 vs the pathological tail).
+//!
+//! CAVEAT: this constructs `GeometryRouter` directly with a ZERO RTC offset — it
+//! does NOT rebase georeferenced models the way the streaming native/viewer path
+//! does. On models with >~10 km world coordinates the f32 jitter fabricates
+//! degenerate geometry (see AGENTS.md), skewing the timings/escalation
+//! distribution — so calibrate the cap on LOCAL-ORIGIN models only (the shipped
+//! `DEFAULT_ELEMENT_CAP` was calibrated on ISSUE_129, a local-origin model).
 //!
 //! IFCLT_MODEL=/abs/path.ifc cargo test -p ifc-lite-geometry --release \
 //!   --test csg_model_profile -- --ignored --nocapture
@@ -94,9 +105,9 @@ fn profile_model() {
     let products = list_products(&content);
     println!("products to process: {}\n", products.len());
 
-    let cap = budget::cap().unwrap_or(u64::MAX);
-    let ecap = budget::element_cap().unwrap_or(u64::MAX);
-    println!("per-element cap: {:?}", budget::element_cap());
+    let cap = budget::cap();
+    let ecap = budget::element_cap();
+    println!("per-element cap: {ecap:?}");
     let mut recs: Vec<Rec> = Vec::new();
     let t_all = Instant::now();
     let mut done = 0usize;
@@ -115,10 +126,14 @@ fn profile_model() {
             router.process_element(&entity, &mut decoder)
         };
         let ms = t.elapsed().as_secs_f64() * 1000.0;
-        let peak_escal = budget::peak();
+        // Read the ACTIVE per-thread budget state, not the configured caps:
+        // `begin_element()` promotes the element cap to unbounded under an
+        // unbounded per-boolean profile, so comparing against `cap`/`ecap` would
+        // misclassify. `peak().max(count())` folds in the last in-flight boolean.
+        let peak_escal = budget::peak().max(budget::count());
         let elem_escal = budget::element_count();
         let tris = mesh_result.map(|m| m.triangle_count()).unwrap_or(0);
-        let tripped = peak_escal >= cap || elem_escal >= ecap;
+        let tripped = budget::tripped();
         if ms > 1000.0 {
             over_1s += 1;
             // live flush so a hang shows the culprit element immediately
@@ -138,7 +153,9 @@ fn profile_model() {
 
     println!("\nTOTAL serial geometry: {:.0}ms over {} elements", total_ms, recs.len());
     println!("  elements > 1s: {over_1s}");
-    println!("  elements that tripped the per-boolean cap ({cap}): {tripped_n}");
+    println!(
+        "  elements that tripped active budgets (per-boolean={cap:?}, per-element={ecap:?}): {tripped_n}"
+    );
 
     recs.sort_by(|a, b| b.ms.partial_cmp(&a.ms).unwrap());
     for k in [1usize, 5, 10, 25, 50, 100] {

--- a/rust/geometry/tests/csg_model_profile.rs
+++ b/rust/geometry/tests/csg_model_profile.rs
@@ -1,0 +1,163 @@
+//! #1109 calibration harness: per-element CSG timing + escalation profile on a
+//! real model. Drives the same per-element path as the viewer/native batch
+//! (`begin_element()` + the router), reports total wall-time and the slowest
+//! elements with their per-boolean and per-element escalation counts, and is how
+//! `DEFAULT_ELEMENT_CAP` is calibrated (healthy p99 vs the pathological tail).
+//!
+//! IFCLT_MODEL=/abs/path.ifc cargo test -p ifc-lite-geometry --release \
+//!   --test csg_model_profile -- --ignored --nocapture
+//!
+//! Env knobs (both default to the shipped caps):
+//!   IFC_LITE_CSG_BUDGET=0         — unbounded per-boolean (raw #1109 hang)
+//!   IFC_LITE_CSG_ELEMENT_BUDGET=0 — unbounded per-element
+//!   IFCLT_BUDGET=<n>              — set the per-boolean cap for this run
+
+use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner};
+use ifc_lite_geometry::kernel::budget;
+use ifc_lite_geometry::{propagate_voids_to_parts, GeometryRouter};
+use rustc_hash::FxHashMap;
+use std::io::Write;
+use std::time::Instant;
+
+fn build_void_index(content: &str) -> FxHashMap<u32, Vec<u32>> {
+    let mut idx: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
+    let mut scanner = EntityScanner::new(content);
+    let mut decoder = EntityDecoder::new(content);
+    while let Some((id, name, start, end)) = scanner.next_entity() {
+        if name == "IFCRELVOIDSELEMENT" {
+            if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
+                if let (Some(host), Some(opening)) = (entity.get_ref(4), entity.get_ref(5)) {
+                    idx.entry(host).or_default().push(opening);
+                }
+            }
+        }
+    }
+    let _ = propagate_voids_to_parts(&mut idx, content, &mut decoder);
+    idx
+}
+
+fn list_products(content: &str) -> Vec<(u32, String)> {
+    let mut products = Vec::new();
+    let mut scanner = EntityScanner::new(content);
+    while let Some((id, name, _, _)) = scanner.next_entity() {
+        let n = name;
+        if n.starts_with("IFC")
+            && (n.contains("WALL") || n.contains("BEAM") || n.contains("COLUMN")
+                || n.contains("MEMBER") || n.contains("PLATE") || n.contains("SLAB")
+                || n.contains("FOOTING") || n.contains("PILE") || n.contains("RAILING")
+                || n.contains("STAIR") || n.contains("ROOF") || n.contains("COVERING")
+                || n.contains("BUILDINGELEMENT") || n.contains("PROXY") || n.contains("FLOW")
+                || n.contains("DISCRETE") || n.contains("FURNISH")
+                || n == "IFCDOOR" || n == "IFCWINDOW")
+        {
+            products.push((id, n.to_string()));
+        }
+    }
+    products
+}
+
+#[derive(Clone)]
+struct Rec {
+    id: u32,
+    ty: String,
+    ms: f64,
+    peak_escal: u64,
+    elem_escal: u64,
+    tris: usize,
+    openings: usize,
+    tripped: bool,
+}
+
+#[test]
+#[ignore = "manual; needs IFCLT_MODEL"]
+fn profile_model() {
+    let path = match std::env::var("IFCLT_MODEL") {
+        Ok(p) => p,
+        Err(_) => { println!("set IFCLT_MODEL=/abs/path.ifc"); return; }
+    };
+    if let Ok(b) = std::env::var("IFCLT_BUDGET") {
+        let v: u64 = b.parse().unwrap_or(0);
+        budget::set_cap(if v == 0 { None } else { Some(v) });
+    }
+    let content = std::fs::read_to_string(&path).expect("read model");
+    println!("\n=== #1109 per-element CSG profile (cap={:?}) ===", budget::cap());
+    println!("model: {path}  ({} bytes)", content.len());
+
+    let t_parse = Instant::now();
+    let entity_index = build_entity_index(&content);
+    let mut decoder = EntityDecoder::with_index(&content, entity_index);
+    let router = GeometryRouter::with_units(&content, &mut decoder);
+    let void_idx = build_void_index(&content);
+    println!("parse+index+voididx: {:.0}ms  (voided hosts: {})",
+        t_parse.elapsed().as_secs_f64() * 1000.0, void_idx.len());
+
+    let products = list_products(&content);
+    println!("products to process: {}\n", products.len());
+
+    let cap = budget::cap().unwrap_or(u64::MAX);
+    let ecap = budget::element_cap().unwrap_or(u64::MAX);
+    println!("per-element cap: {:?}", budget::element_cap());
+    let mut recs: Vec<Rec> = Vec::new();
+    let t_all = Instant::now();
+    let mut done = 0usize;
+    let mut over_1s = 0usize;
+    for (id, ty) in &products {
+        let entity = match decoder.decode_by_id(*id) { Ok(e) => e, Err(_) => continue };
+        let openings = void_idx.get(id).map(|v| v.len()).unwrap_or(0);
+        budget::reset_peak();
+        // Open the per-element scope exactly as `produce_element_meshes` does, so
+        // the per-element budget engages in this profile harness too.
+        budget::begin_element();
+        let t = Instant::now();
+        let mesh_result = if openings > 0 {
+            router.process_element_with_voids(&entity, &mut decoder, &void_idx)
+        } else {
+            router.process_element(&entity, &mut decoder)
+        };
+        let ms = t.elapsed().as_secs_f64() * 1000.0;
+        let peak_escal = budget::peak();
+        let elem_escal = budget::element_count();
+        let tris = mesh_result.map(|m| m.triangle_count()).unwrap_or(0);
+        let tripped = peak_escal >= cap || elem_escal >= ecap;
+        if ms > 1000.0 {
+            over_1s += 1;
+            // live flush so a hang shows the culprit element immediately
+            print!("  [>1s] id={id} {ty} {ms:.0}ms peak_escal={peak_escal} elem_escal={elem_escal} openings={openings} tripped={tripped}\n");
+            let _ = std::io::stdout().flush();
+        }
+        recs.push(Rec { id: *id, ty: ty.clone(), ms, peak_escal, elem_escal, tris, openings, tripped });
+        done += 1;
+        if done % 500 == 0 {
+            print!("  ...{done}/{} elements, {:.1}s elapsed\n", products.len(), t_all.elapsed().as_secs_f64());
+            let _ = std::io::stdout().flush();
+        }
+    }
+    let total_ms = t_all.elapsed().as_secs_f64() * 1000.0;
+    let sum_ms: f64 = recs.iter().map(|r| r.ms).sum();
+    let tripped_n = recs.iter().filter(|r| r.tripped).count();
+
+    println!("\nTOTAL serial geometry: {:.0}ms over {} elements", total_ms, recs.len());
+    println!("  elements > 1s: {over_1s}");
+    println!("  elements that tripped the per-boolean cap ({cap}): {tripped_n}");
+
+    recs.sort_by(|a, b| b.ms.partial_cmp(&a.ms).unwrap());
+    for k in [1usize, 5, 10, 25, 50, 100] {
+        if k <= recs.len() {
+            let top: f64 = recs.iter().take(k).map(|r| r.ms).sum();
+            println!("  top-{k:<3} slowest = {:.0}ms ({:.0}% of element time)", top, 100.0 * top / sum_ms.max(1.0));
+        }
+    }
+    // escalation distribution (per-element TOTAL across all its booleans)
+    let mut elems: Vec<u64> = recs.iter().map(|r| r.elem_escal).collect();
+    elems.sort_unstable_by(|a, b| b.cmp(a));
+    let pct = |p: f64| elems.get(((elems.len() as f64 * p) as usize).min(elems.len().saturating_sub(1))).copied().unwrap_or(0);
+    println!("  per-element TOTAL escalations: max={} p99={} p95={} p90={} p50={}",
+        elems.first().copied().unwrap_or(0), pct(0.01), pct(0.05), pct(0.10), pct(0.50));
+
+    println!("\n--- 25 slowest elements ---");
+    println!("{:>10}  {:>24}  {:>10}  {:>12}  {:>12}  {:>8}  {:>8}  {}", "id", "type", "ms", "peak_escal", "elem_escal", "tris", "openings", "tripped");
+    for r in recs.iter().take(25) {
+        println!("{:>10}  {:>24}  {:>10.1}  {:>12}  {:>12}  {:>8}  {:>8}  {}",
+            r.id, r.ty, r.ms, r.peak_escal, r.elem_escal, r.tris, r.openings, r.tripped);
+    }
+}

--- a/rust/geometry/tests/issue_1109_budget.rs
+++ b/rust/geometry/tests/issue_1109_budget.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! #1109 regression: the per-element CSG escalation budget bounds a pathological
 //! element's exact work so a boolean-heavy element finishes (degraded) instead of
 //! hanging at 95%, AND a single boolean can't overshoot the cap unboundedly.

--- a/rust/geometry/tests/issue_1109_budget.rs
+++ b/rust/geometry/tests/issue_1109_budget.rs
@@ -1,0 +1,179 @@
+//! #1109 regression: the per-element CSG escalation budget bounds a pathological
+//! element's exact work so a boolean-heavy element finishes (degraded) instead of
+//! hanging at 95%, AND a single boolean can't overshoot the cap unboundedly.
+//!
+//! This exercises the guardrail on REAL CSG (the arrangement + retriangulation
+//! exact-predicate cascade), not just the synthetic counters of the budget unit
+//! test. It is deterministic and fixture-free: the escalation count is a pure
+//! function of the (snap-grid) operands, so the asserted bounds hold byte-
+//! identically on native x86_64/aarch64 and wasm32.
+//!
+//! These tests mutate the global budget caps, so the file holds exactly ONE
+//! `#[test]` (cargo runs each integration-test file as its own process; tests
+//! WITHIN a file share the process and would race on the global cap).
+
+use ifc_lite_geometry::kernel::budget;
+use ifc_lite_geometry::mesh::Mesh;
+use ifc_lite_geometry::ClippingProcessor;
+
+/// Axis-aligned box [min,max] as a 12-triangle `Mesh`.
+fn box_mesh(min: [f32; 3], max: [f32; 3]) -> Mesh {
+    let c = [
+        [min[0], min[1], min[2]],
+        [max[0], min[1], min[2]],
+        [max[0], max[1], min[2]],
+        [min[0], max[1], min[2]],
+        [min[0], min[1], max[2]],
+        [max[0], min[1], max[2]],
+        [max[0], max[1], max[2]],
+        [min[0], max[1], max[2]],
+    ];
+    let mut positions = Vec::new();
+    for v in &c {
+        positions.extend_from_slice(v);
+    }
+    let indices: Vec<u32> = vec![
+        0, 2, 1, 0, 3, 2, 4, 5, 6, 4, 6, 7, 0, 1, 5, 0, 5, 4, 2, 3, 7, 2, 7, 6, 1, 2, 6, 1, 6, 5,
+        0, 4, 7, 0, 7, 3,
+    ];
+    Mesh {
+        positions,
+        normals: Vec::new(),
+        indices,
+        rtc_applied: false,
+        origin: [0.0; 3],
+    }
+}
+
+/// A faceted "half-space" slab whose top face is tessellated into `n`×`n` quads,
+/// all coplanar at `ztop`. Cutting a host with this drives the exact predicate
+/// cascade hard (the coplanar-fragment retriangulation of #1109). Closed into a
+/// solid with a skirt + bottom; winding is fixed by the kernel's `orient_outward`.
+fn faceted_slab(min: [f32; 3], max: [f32; 3], n: usize, z_top: f32) -> Mesh {
+    let mut positions: Vec<f32> = Vec::new();
+    let mut indices: Vec<u32> = Vec::new();
+    let push = |p: [f32; 3], positions: &mut Vec<f32>| -> u32 {
+        let idx = (positions.len() / 3) as u32;
+        positions.extend_from_slice(&p);
+        idx
+    };
+    let (x0, y0, z0) = (min[0], min[1], min[2]);
+    let (x1, y1) = (max[0], max[1]);
+    let mut grid = vec![0u32; (n + 1) * (n + 1)];
+    for j in 0..=n {
+        for i in 0..=n {
+            let fx = x0 + (x1 - x0) * (i as f32 / n as f32);
+            let fy = y0 + (y1 - y0) * (j as f32 / n as f32);
+            grid[j * (n + 1) + i] = push([fx, fy, z_top], &mut positions);
+        }
+    }
+    for j in 0..n {
+        for i in 0..n {
+            let a = grid[j * (n + 1) + i];
+            let b = grid[j * (n + 1) + i + 1];
+            let c = grid[(j + 1) * (n + 1) + i + 1];
+            let d = grid[(j + 1) * (n + 1) + i];
+            indices.extend_from_slice(&[a, b, c, a, c, d]);
+        }
+    }
+    let bl = [
+        push([x0, y0, z0], &mut positions),
+        push([x1, y0, z0], &mut positions),
+        push([x1, y1, z0], &mut positions),
+        push([x0, y1, z0], &mut positions),
+    ];
+    indices.extend_from_slice(&[bl[0], bl[2], bl[1], bl[0], bl[3], bl[2]]);
+    let tb = |i: usize, j: usize| grid[j * (n + 1) + i];
+    for i in 0..n {
+        indices.extend_from_slice(&[bl[0], bl[1], tb(i + 1, 0), bl[0], tb(i + 1, 0), tb(i, 0)]);
+        indices.extend_from_slice(&[bl[3], tb(i, n), tb(i + 1, n), bl[3], tb(i + 1, n), bl[2]]);
+    }
+    for j in 0..n {
+        indices.extend_from_slice(&[bl[0], tb(0, j), tb(0, j + 1), bl[0], tb(0, j + 1), bl[3]]);
+        indices.extend_from_slice(&[bl[1], tb(n, j + 1), tb(n, j), bl[1], bl[2], tb(n, j + 1)]);
+    }
+    Mesh {
+        positions,
+        normals: Vec::new(),
+        indices,
+        rtc_applied: false,
+        origin: [0.0; 3],
+    }
+}
+
+/// Total exact-tier escalations a sequence of cuts drives, under whatever caps are
+/// currently set, within ONE element scope. Mirrors the production per-element
+/// path: `begin_element()` once, then `ClippingProcessor::subtract_mesh` per
+/// cutter — which is where the budget bail lives: on a trip it returns the host
+/// UN-CUT (the #635 AABB fallback fires from there in prod), so the result stays
+/// valid geometry rather than the raw kernel's partial arrangement.
+fn element_escalations(host: &Mesh, cutters: &[Mesh]) -> (u64, Mesh) {
+    let proc = ClippingProcessor::new();
+    budget::begin_element();
+    let mut result = host.clone();
+    for c in cutters {
+        if let Ok(m) = proc.subtract_mesh(&result, c) {
+            result = m;
+        }
+    }
+    (budget::element_count(), result)
+}
+
+#[test]
+fn issue_1109_per_element_budget_bounds_pathological_csg() {
+    // A host slab cut by several coplanar-fragment slabs at staggered internal
+    // heights — the dense-coplanar-cut pattern that hung the exact kernel.
+    let host = box_mesh([0.0, 0.0, 0.0], [10.0, 10.0, 10.0]);
+    let cutters: Vec<Mesh> = (0..5)
+        .map(|k| {
+            let z = 1.0 + k as f32 * 1.5;
+            faceted_slab([-1.0, -1.0, -1.0], [11.0, 11.0, z], 40, z)
+        })
+        .collect();
+
+    // 1. UNBOUNDED — how much exact work does this element REALLY need? (This is
+    //    the cost that hung the stream before the budget existed.)
+    budget::set_cap(None);
+    budget::set_element_cap(None);
+    let (unbounded, _) = element_escalations(&host, &cutters);
+    assert!(
+        unbounded > 60_000,
+        "the test element must be genuinely pathological (drive >60k exact \
+         escalations unbounded); got {unbounded} — strengthen the cutters"
+    );
+
+    // 2. BOUNDED — the per-element budget caps the exact work near the cap. The
+    //    overshoot guards inside the retriangulation loops keep a single boolean
+    //    from blowing past it by orders of magnitude (the pre-fix failure: one
+    //    boolean ran to 7.7M escalations = 15x a 500k cap before bailing).
+    const ELEM_CAP: u64 = 40_000;
+    budget::set_cap(Some(budget::DEFAULT_CAP));
+    budget::set_element_cap(Some(ELEM_CAP));
+    let (bounded, result) = element_escalations(&host, &cutters);
+    eprintln!("#1109 budget test: unbounded={unbounded} bounded={bounded} (cap={ELEM_CAP})");
+
+    // The element's total exact work is bounded near the cap, NOT the unbounded
+    // cost: without the overshoot guard a single boolean ran ~15x past the cap.
+    assert!(
+        bounded < ELEM_CAP * 2,
+        "per-element budget must bound escalations near the cap ({ELEM_CAP}); \
+         got {bounded} (unbounded was {unbounded})"
+    );
+    assert!(
+        bounded < unbounded,
+        "the budget must cut the work short of the unbounded cost \
+         (bounded={bounded}, unbounded={unbounded})"
+    );
+
+    // 3. The degraded output is still VALID geometry (finite, non-empty), not
+    //    corrupt — a bailed cut leaves the host un-cut / AABB-boxed, never NaN.
+    assert!(!result.positions.is_empty(), "degraded element must still produce geometry");
+    assert!(
+        result.positions.iter().all(|c| c.is_finite()),
+        "degraded element must not emit non-finite coordinates"
+    );
+
+    // Restore the shipped defaults for hygiene (single-test file, but be tidy).
+    budget::set_cap(Some(budget::DEFAULT_CAP));
+    budget::set_element_cap(Some(budget::DEFAULT_ELEMENT_CAP));
+}

--- a/rust/processing/src/element.rs
+++ b/rust/processing/src/element.rs
@@ -193,6 +193,15 @@ pub fn produce_element_meshes(
     decoder: &mut EntityDecoder,
     router: &GeometryRouter,
 ) -> ProducedElementMeshes {
+    // Open a per-element CSG escalation scope (#1109). Every boolean this element
+    // issues (one per opening, plus clip cuts) accumulates into ONE deterministic
+    // budget, so a boolean-heavy element (a slab cut by 24+ openings, a Tekla
+    // member with stacked half-space clips) degrades as a UNIT — its remaining
+    // cuts bail to the #635 AABB fallback — instead of grinding the geometry
+    // stream past the 95% watchdog. The per-boolean cap alone could not see this
+    // distributed cost. Unbounded under the server/offline-export profile.
+    ifc_lite_geometry::kernel::budget::begin_element();
+
     let mut hasher = match (&job.kind, opts.geometry_hash) {
         (ElementJobKind::Product, Some(cfg)) => {
             Some(GeometryHasher::new(cfg.tolerance, cfg.world_rtc))


### PR DESCRIPTION
## Why #1109 still hangs after #1112

The deterministic **per-boolean** escalation budget (#1112) was the right idea but bounded only a *single* boolean. Profiling a real boolean-heavy structural model (ISSUE_129) **with #1112's 500k budget active** showed two remaining holes:

| element | time (before) | worst-boolean escalations | openings |
|---------|---------------|---------------------------|----------|
| `id=333923` IFCSLAB | **243,587 ms (4 min)** | 7,676,200 — **15× the cap** | 39 |
| `id=12381` IFCSLAB | 103,409 ms | 3,051,091 | 47 |
| `id=9094` IFCSLAB | 32,502 ms | 1,665,625 | 24 |
| `id=7526` IFCSLAB | 5,844 ms | 44,896 (**never tripped**) | 29 |

1. **Overshoot.** `budget::tripped()` was only checked at arrangement loop boundaries — once *per triangle* in seam retriangulation. A single heavily-fragmented host face (a slab cut by 24–47 openings) inserts thousands of constraint points in **one** `triangulate()` call, so a boolean ran to ~7.7M escalations (15× the 500k cap) before bailing.
2. **Distributed cost.** An element with many openings runs one boolean *per* opening, each under the per-boolean cap so none trips — yet the element's total exact work blows the geometry-stream watchdog.

(Note: the BigRational tier is *never* hit — the cost is the fixed-width exact tier + retriangulation, not arbitrary precision. The issue's stated "escalates to BigRational en masse" theory doesn't hold.)

## Fix

- **Per-element budget** (`kernel::budget`): `begin_element()` is called once per element at the unified `produce_element_meshes` entry (native **and** wasm). It accumulates escalations across every boolean the element issues; at `DEFAULT_ELEMENT_CAP = 100_000` the element degrades **as a whole** — remaining cuts bail to the existing #635 AABB box-cut fallback.
- **Overshoot guards** (`kernel::retriangulate`): `tripped()` checks inside the per-point insertion and constraint-recovery loops, so a single boolean can no longer overshoot the cap by 15×.

### Parity preserved
Still a **deterministic count**, accumulated in deterministic per-opening order on the element's single worker thread (the kernel has no internal rayon), so native x86_64/aarch64 and wasm32 degrade the **same** element identically — the cross-target parity the pure-Rust kernel exists to guarantee.

### No false-trips, snapshots unchanged
Calibrated against the corpus: healthy per-element totals are **p99 ≈ 13k** escalations, so the 100k cap (~8× p99) never trips a legitimate cut. The cap engages **only** when an element scope is opened (the batch path); direct kernel / router / server / offline-export callers stay unbounded via the existing `set_cap(None)` / `IFC_LITE_CSG_BUDGET=0` switch — so the pinned determinism manifests are byte-identical.

## Results

- **Worst element 243 s → 2.9 s** (83×); total serial geometry minutes → ~28 s.
- Geometry suite **54 groups / 0 failures** (snapshots, determinism, CSG quality, wall-opening cuts, segmented-roof, new budget unit test). Processing suite **17 / 0**.

## Notes
- `rust/geometry/tests/csg_model_profile.rs` is an `#[ignore]`'d calibration harness (`IFCLT_MODEL=… cargo test … --ignored`) documenting how the cap was derived.
- This is a follow-up to #1112; not the f32 local-frame work (coordinate magnitude was empirically shown to have **no** effect on CSG cost).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added deterministic per-element CSG exact-evaluation budgeting to cap escalation across all operations within an element.

* **Performance Improvements**
  * Faster constraint-recovery retriangulation for dense-opening models.
  * Reduced costly exact checks during deterministic ear finding.
  * Improved early stopping during triangulation/recovery once budgets are exceeded.

* **Bug Fixes**
  * Prevented pathological escalation stalls and overshoot on complex elements with many booleans.

* **Tests**
  * Added calibration and issue-specific tests for per-element budgeting and budget-bailed output validity.

* **Chores**
  * Pinned the wasm build action to a fixed version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->