### PR TITLE
feat(geometry): content-dedup identical representation items (skip re-meshing)

### DIFF
--- a/rust/geometry/src/lib.rs
+++ b/rust/geometry/src/lib.rs
@@ -126,7 +126,7 @@ pub use profile::{Profile2D, Profile2DWithVoids, ProfileType, VoidInfo};
 pub use profile_extractor::{extract_profiles, ExtractedProfile};
 pub use profiles::ProfileProcessor;
 pub use router::{
-    ClassificationStats, GeometryProcessor, GeometryRouter, HostOpeningDiagnostic,
+    ClassificationStats, GeometryProcessor, GeometryRouter, HostOpeningDiagnostic, ItemDedupCache,
     OpeningDiagnostic, OpeningKindDiag,
 };
 pub use tessellation::{scale_segments, TessellationQuality};

--- a/rust/geometry/src/router/content_hash.rs
+++ b/rust/geometry/src/router/content_hash.rs
@@ -31,9 +31,11 @@ use ifc_lite_core::{AttributeValue, EntityDecoder};
 use rustc_hash::FxHashMap;
 
 /// Defensive recursion bound. IFC geometry is a DAG (item → solids → profiles →
-/// points), so this is never hit by well-formed files; it bounds a malformed
-/// cyclic one.
-const MAX_DEPTH: u32 = 96;
+/// points); deeply NESTED `IfcBooleanResult` chains are the realistic deep case,
+/// so this is set well above any plausible cut chain. Beyond it the hash falls
+/// back to an entity-id-distinct value (see `sig_entity`) so over-depth subtrees
+/// can never COLLIDE — they simply stop deduping rather than risk a false merge.
+const MAX_DEPTH: u32 = 256;
 
 /// Sentinel written into the memo while an entity's hash is being computed, so a
 /// (malformed) cycle resolves to a fixed value instead of recursing forever.
@@ -104,7 +106,11 @@ fn sig_entity(decoder: &mut EntityDecoder, id: u32, memo: &mut FxHashMap<u32, u1
         return s;
     }
     if depth > MAX_DEPTH {
-        return fold(0, 0xDEAD_BEEF_DEAD_BEEF);
+        // Fold the entity id so two DIFFERENT over-depth subtrees get DIFFERENT
+        // values — they stop deduping (id breaks renumbering-invariance) but can
+        // never false-merge, which matters far more than deduping a pathological
+        // boolean chain.
+        return fold(0xDEAD_BEEF_DEAD_BEEF, id as u64);
     }
     memo.insert(id, CYCLE_SENTINEL); // break cycles (DAG ⇒ unreachable in practice)
     let entity = match decoder.decode_by_id(id) {

--- a/rust/geometry/src/router/content_hash.rs
+++ b/rust/geometry/src/router/content_hash.rs
@@ -84,6 +84,21 @@ pub fn item_signature(decoder: &mut EntityDecoder, root_id: u32, memo: &mut FxHa
     sig_entity(decoder, root_id, memo, 0)
 }
 
+/// Combine the pure structural item hash with the router parameters that change
+/// the MESHED output but live outside the IFC structure — tessellation quality
+/// (curved profiles tessellate finer at higher quality), unit scale, and RTC
+/// offset. Without this, a cache shared across routers — or one that outlives a
+/// `setTessellationQuality` change on the same worker — would serve a mesh built
+/// under different parameters (e.g. #976: every quality level returns the
+/// first-cached triangle count).
+pub fn key_with_params(structural: u128, quality_index: u8, unit_scale: f64, rtc: (f64, f64, f64)) -> u128 {
+    let mut s = fold(structural, quality_index as u64);
+    s = fold(s, unit_scale.to_bits());
+    s = fold(s, rtc.0.to_bits());
+    s = fold(s, rtc.1.to_bits());
+    fold(s, rtc.2.to_bits())
+}
+
 fn sig_entity(decoder: &mut EntityDecoder, id: u32, memo: &mut FxHashMap<u32, u128>, depth: u32) -> u128 {
     if let Some(&s) = memo.get(&id) {
         return s;

--- a/rust/geometry/src/router/content_hash.rs
+++ b/rust/geometry/src/router/content_hash.rs
@@ -1,0 +1,141 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Structural content hash of an IFC representation ITEM subtree, for geometry
+//! deduplication of the meshing + CSG compute.
+//!
+//! Tekla (and other steel detailers) export thousands of geometrically identical
+//! parts — connection plates, bolts — each with its OWN representation item
+//! rather than sharing one via `IfcMappedItem`. The Manifold kernel chewed
+//! through the redundant booleans fast; the exact pure-Rust kernel (#1024) is
+//! ~20-40× slower per cut, so re-meshing+re-CSG'ing the duplicates dominates load
+//! time (a 19.5 MB Tekla model: 83% of 15k items are byte-duplicates).
+//!
+//! This hashes the FULLY RESOLVED item subtree (entity references followed to
+//! their values), so two geometrically identical items with different entity
+//! numbers map to the SAME key. It deliberately covers ONLY geometry-defining
+//! structure: colour/style (`IfcStyledItem` points INTO the item from outside,
+//! so it is never in the closure), the per-instance `geometry_id`, voids and
+//! placement all live OUTSIDE the item and stay per-instance — the cache holds a
+//! colour-free local mesh that every instance reuses with its own attributes.
+//!
+//! The hash is 128-bit over the COMPLETE structure (every attribute value,
+//! recursively), unlike the sampled 64-bit mesh hash that collided in #833. The
+//! collision probability across a model's items is ~1e-30, so no post-mesh
+//! equality fallback is needed. Deterministic (integer splitmix64, no float
+//! ordering beyond the bit pattern), so native x86_64/aarch64 and wasm32 produce
+//! identical keys.
+
+use ifc_lite_core::{AttributeValue, EntityDecoder};
+use rustc_hash::FxHashMap;
+
+/// Defensive recursion bound. IFC geometry is a DAG (item → solids → profiles →
+/// points), so this is never hit by well-formed files; it bounds a malformed
+/// cyclic one.
+const MAX_DEPTH: u32 = 96;
+
+/// Sentinel written into the memo while an entity's hash is being computed, so a
+/// (malformed) cycle resolves to a fixed value instead of recursing forever.
+const CYCLE_SENTINEL: u128 = 0xC1C1_C1C1_C1C1_C1C1_C1C1_C1C1_C1C1_C1C1;
+
+#[inline]
+fn mix64(mut x: u64) -> u64 {
+    // splitmix64 finalizer — strong avalanche, same as `geom_hash::mix64`.
+    x = (x ^ (x >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    x = (x ^ (x >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    x ^ (x >> 31)
+}
+
+/// Fold a 64-bit value into a 128-bit running state across two independent lanes.
+#[inline]
+fn fold(state: u128, v: u64) -> u128 {
+    let lo = state as u64;
+    let hi = (state >> 64) as u64;
+    let lo2 = mix64(lo.wrapping_add(v).wrapping_mul(0x9E37_79B9_7F4A_7C15));
+    let hi2 = mix64(
+        hi.rotate_left(23) ^ v.wrapping_mul(0xC2B2_AE3D_27D4_EB4F).wrapping_add(0x1656_67B1),
+    );
+    ((hi2 as u128) << 64) | (lo2 as u128)
+}
+
+#[inline]
+fn fold_bytes(mut state: u128, bytes: &[u8]) -> u128 {
+    state = fold(state, bytes.len() as u64);
+    let mut chunks = bytes.chunks_exact(8);
+    for c in &mut chunks {
+        state = fold(state, u64::from_le_bytes(c.try_into().unwrap()));
+    }
+    let rem = chunks.remainder();
+    if !rem.is_empty() {
+        let mut buf = [0u8; 8];
+        buf[..rem.len()].copy_from_slice(rem);
+        state = fold(state, u64::from_le_bytes(buf));
+    }
+    state
+}
+
+/// 128-bit structural hash of the representation item rooted at `root_id`. `memo`
+/// caches per-entity hashes so shared sub-entities (a profile reused by many
+/// solids, the representation context) are visited once; it keys on entity ids,
+/// so it must belong to ONE model (the `GeometryRouter` owns one per loaded
+/// file).
+pub fn item_signature(decoder: &mut EntityDecoder, root_id: u32, memo: &mut FxHashMap<u32, u128>) -> u128 {
+    sig_entity(decoder, root_id, memo, 0)
+}
+
+fn sig_entity(decoder: &mut EntityDecoder, id: u32, memo: &mut FxHashMap<u32, u128>, depth: u32) -> u128 {
+    if let Some(&s) = memo.get(&id) {
+        return s;
+    }
+    if depth > MAX_DEPTH {
+        return fold(0, 0xDEAD_BEEF_DEAD_BEEF);
+    }
+    memo.insert(id, CYCLE_SENTINEL); // break cycles (DAG ⇒ unreachable in practice)
+    let entity = match decoder.decode_by_id(id) {
+        Ok(e) => e,
+        Err(_) => {
+            // Unresolvable reference: a fixed sentinel (NOT the id, so structurally
+            // identical-but-renumbered files still collide).
+            let s = fold(0, 0x00BA_D0BA_D0BA_D000);
+            memo.insert(id, s);
+            return s;
+        }
+    };
+    // Hash the stable type NAME (IfcType isn't a primitive-castable enum).
+    let mut acc = fold_bytes(fold(0, 0x5EED_5EED), entity.ifc_type.as_str().as_bytes());
+    for attr in &entity.attributes {
+        acc = hash_attr(decoder, attr, acc, memo, depth);
+    }
+    memo.insert(id, acc);
+    acc
+}
+
+fn hash_attr(
+    decoder: &mut EntityDecoder,
+    attr: &AttributeValue,
+    acc: u128,
+    memo: &mut FxHashMap<u32, u128>,
+    depth: u32,
+) -> u128 {
+    match attr {
+        AttributeValue::EntityRef(r) => {
+            let child = sig_entity(decoder, *r, memo, depth + 1);
+            // Fold both lanes of the child hash, tagged.
+            fold(fold(fold(acc, 1), child as u64), (child >> 64) as u64)
+        }
+        AttributeValue::String(s) => fold_bytes(fold(acc, 2), s.as_bytes()),
+        AttributeValue::Integer(i) => fold(fold(acc, 3), *i as u64),
+        AttributeValue::Float(f) => fold(fold(acc, 4), f.to_bits()),
+        AttributeValue::Enum(e) => fold_bytes(fold(acc, 5), e.as_bytes()),
+        AttributeValue::List(items) => {
+            let mut a = fold(fold(acc, 6), items.len() as u64);
+            for it in items {
+                a = hash_attr(decoder, it, a, memo, depth);
+            }
+            a
+        }
+        AttributeValue::Null => fold(acc, 8),
+        AttributeValue::Derived => fold(acc, 9),
+    }
+}

--- a/rust/geometry/src/router/mod.rs
+++ b/rust/geometry/src/router/mod.rs
@@ -8,6 +8,7 @@
 
 mod caching;
 mod clipping;
+mod content_hash;
 mod layers;
 mod processing;
 mod transforms;
@@ -33,7 +34,7 @@ use nalgebra::Matrix4;
 use rustc_hash::FxHashMap;
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 /// Geometry processor trait
 /// Each processor handles one type of IFC representation
@@ -57,6 +58,14 @@ pub trait GeometryProcessor {
     fn supported_types(&self) -> Vec<IfcType>;
 }
 
+/// Shared content-dedup cache: maps a 128-bit structural item hash to the
+/// LOCAL (pre-placement, void-free, colour-free) item mesh. Build ONE per loaded
+/// model with [`GeometryRouter::new_dedup_cache`] and inject it into every
+/// per-element / per-batch router via
+/// [`GeometryRouter::enable_content_dedup_shared`] so byte-identical geometry is
+/// meshed once regardless of how the work is partitioned across threads/batches.
+pub type ItemDedupCache = Arc<Mutex<FxHashMap<u128, Arc<Mesh>>>>;
+
 /// Geometry router - routes entities to processors
 pub struct GeometryRouter {
     schema: IfcSchema,
@@ -68,6 +77,25 @@ pub struct GeometryRouter {
     /// Buildings with repeated floors have 99% identical geometry
     /// Key: Hash of mesh content, Value: Processed mesh
     geometry_hash_cache: RefCell<FxHashMap<u64, Arc<Mesh>>>,
+    /// SHARED content-dedup of LOCAL (pre-placement, void-free) representation-ITEM
+    /// meshes, keyed by a 128-bit structural hash of the item subtree
+    /// (`content_hash::item_signature`). Skips the meshing + CSG for byte-identical
+    /// geometry the exporter failed to share via `IfcMappedItem` (Tekla connection
+    /// plates/bolts). The cached mesh is COLOUR-FREE; the per-instance
+    /// `geometry_id` (colour/palette/texture), voids and placement are applied by
+    /// the caller, so reuse never changes an instance's appearance.
+    ///
+    /// `Arc<Mutex<_>>` so ONE cache outlives any single router and is shared across
+    /// the native rayon pool's per-element routers AND a wasm worker's per-batch
+    /// routers (re-injected each batch). A hit skips the expensive build entirely,
+    /// so the lock is held only for a map get/clone (hit) or insert (miss); the
+    /// build runs outside it. `None` ⇒ dedup disabled (e.g. `new()` in tests).
+    item_dedup_cache: Option<ItemDedupCache>,
+    /// Per-router memo for the per-item structural hash (shared sub-entities hashed
+    /// once). Keyed by entity id ⇒ valid for one loaded model. Kept LOCAL (not
+    /// shared) so the recursive DAG walk never contends the shared cache's lock;
+    /// recomputing it per router is cheap next to meshing.
+    content_sig_memo: RefCell<FxHashMap<u32, u128>>,
     /// Unit scale factor (e.g., 0.001 for millimeters -> meters)
     /// Applied to all mesh positions after processing
     unit_scale: f64,
@@ -204,6 +232,8 @@ impl GeometryRouter {
             processors: HashMap::new(),
             mapped_item_cache: RefCell::new(FxHashMap::default()),
             geometry_hash_cache: RefCell::new(FxHashMap::default()),
+            item_dedup_cache: None, // armed by `with_units` / `enable_content_dedup_shared`
+            content_sig_memo: RefCell::new(FxHashMap::default()),
             unit_scale: 1.0,             // Default to base meters
             rtc_offset: (0.0, 0.0, 0.0), // Default to no offset
             material_layer_index: None,
@@ -250,21 +280,25 @@ impl GeometryRouter {
     where
         T: AsRef<[u8]> + ?Sized,
     {
-        let content = content.as_ref();
-        let mut scanner = ifc_lite_core::EntityScanner::new(content);
-        let mut scale = 1.0;
+        let scale = Self::scan_unit_scale(content.as_ref(), decoder);
+        let mut router = Self::with_scale(scale);
+        router.arm_content_dedup();
+        router
+    }
 
-        // Scan through file to find IFCPROJECT
+    /// Scan to the first `IFCPROJECT` and extract its length-unit scale (e.g.
+    /// `0.001` for millimetres → metres); `1.0` if none is found.
+    fn scan_unit_scale(content: &[u8], decoder: &mut EntityDecoder) -> f64 {
+        let mut scanner = ifc_lite_core::EntityScanner::new(content);
         while let Some((id, type_name, _, _)) = scanner.next_entity() {
             if type_name == "IFCPROJECT" {
                 if let Ok(s) = ifc_lite_core::extract_length_unit_scale(decoder, id) {
-                    scale = s;
+                    return s;
                 }
                 break;
             }
         }
-
-        Self::with_scale(scale)
+        1.0
     }
 
     /// Create router with unit scale extracted from IFC file AND RTC offset for large coordinates
@@ -282,21 +316,10 @@ impl GeometryRouter {
     where
         T: AsRef<[u8]> + ?Sized,
     {
-        let content = content.as_ref();
-        let mut scanner = ifc_lite_core::EntityScanner::new(content);
-        let mut scale = 1.0;
-
-        // Scan through file to find IFCPROJECT
-        while let Some((id, type_name, _, _)) = scanner.next_entity() {
-            if type_name == "IFCPROJECT" {
-                if let Ok(s) = ifc_lite_core::extract_length_unit_scale(decoder, id) {
-                    scale = s;
-                }
-                break;
-            }
-        }
-
-        Self::with_scale_and_rtc(scale, rtc_offset)
+        let scale = Self::scan_unit_scale(content.as_ref(), decoder);
+        let mut router = Self::with_scale_and_rtc(scale, rtc_offset);
+        router.arm_content_dedup();
+        router
     }
 
     /// Create router with pre-calculated unit scale
@@ -304,6 +327,47 @@ impl GeometryRouter {
         let mut router = Self::new();
         router.unit_scale = unit_scale;
         router
+    }
+
+    /// Arm content-dedup with a NEW empty cache. Used by the model constructors
+    /// (`with_units*`) where this router owns the only reference; multi-router
+    /// callers (native pool, wasm batches) should build ONE shared cache via
+    /// [`Self::new_dedup_cache`] and inject it into every router with
+    /// [`Self::enable_content_dedup_shared`] so the cache persists across them.
+    fn arm_content_dedup(&mut self) {
+        self.item_dedup_cache = Some(Self::new_dedup_cache());
+    }
+
+    /// A fresh empty shared item-dedup cache, to be cloned into every per-element /
+    /// per-batch router of ONE loaded model so they all dedup against it. Keep one
+    /// per model: the key is a per-model entity-structure hash, and the cached
+    /// meshes bake in this model's unit scale / tessellation quality.
+    pub fn new_dedup_cache() -> ItemDedupCache {
+        Arc::new(Mutex::new(FxHashMap::default()))
+    }
+
+    /// Inject a shared item-dedup cache (see [`Self::new_dedup_cache`]) into this
+    /// router. All routers given the SAME `Arc` dedup against one cache, so
+    /// byte-identical geometry is meshed once across the whole model regardless of
+    /// how elements are partitioned across threads or batches.
+    pub fn enable_content_dedup_shared(&mut self, cache: ItemDedupCache) {
+        self.item_dedup_cache = Some(cache);
+    }
+
+    /// Disable content-dedup (drops the cache reference so `item_dedup_key`
+    /// returns `None` and meshing is never skipped). Test/bench helper for an A/B
+    /// against the deduped path.
+    pub fn disable_content_dedup(&mut self) {
+        self.item_dedup_cache = None;
+    }
+
+    /// Number of unique item meshes cached by content-dedup so far — the reuse the
+    /// pipeline recovered (vs. the meshed-item count). Diagnostics.
+    pub fn dedup_unique_count(&self) -> usize {
+        self.item_dedup_cache
+            .as_ref()
+            .map(|c| c.lock().expect("dedup cache poisoned").len())
+            .unwrap_or(0)
     }
 
     /// Create router with RTC offset for large coordinate handling

--- a/rust/geometry/src/router/processing.rs
+++ b/rust/geometry/src/router/processing.rs
@@ -867,13 +867,23 @@ impl GeometryRouter {
         Ok(mesh)
     }
 
-    /// Structural-hash key for an item, or `None` when dedup is disabled (skips
-    /// the hash walk entirely so disabled = zero overhead).
+    /// Cache key for an item: its structural hash combined with the router params
+    /// that change the meshed output (tessellation quality / unit scale / RTC), or
+    /// `None` when dedup is disabled (skips the hash walk so disabled = zero
+    /// overhead). The quality fold is what keeps `setTessellationQuality` correct —
+    /// the shared cache persists across quality changes on a worker, so the key
+    /// must distinguish them (#976).
     fn item_dedup_key(&self, item: &DecodedEntity, decoder: &mut EntityDecoder) -> Option<u128> {
         self.item_dedup_cache.as_ref()?;
-        let mut memo = self.content_sig_memo.borrow_mut();
-        Some(super::content_hash::item_signature(
-            decoder, item.id, &mut memo,
+        let structural = {
+            let mut memo = self.content_sig_memo.borrow_mut();
+            super::content_hash::item_signature(decoder, item.id, &mut memo)
+        };
+        Some(super::content_hash::key_with_params(
+            structural,
+            self.tessellation_quality.to_index(),
+            self.unit_scale,
+            self.rtc_offset,
         ))
     }
 

--- a/rust/geometry/src/router/processing.rs
+++ b/rust/geometry/src/router/processing.rs
@@ -670,9 +670,21 @@ impl GeometryRouter {
             sub.mesh.clean_degenerate();
         }
 
-        // Apply placement transformation to all sub-meshes
-        // ObjectPlacement translation is in file units (e.g., mm) but geometry is scaled to meters,
-        // so we MUST scale the transform to match. Same as apply_placement does.
+        self.apply_submesh_placement(&mut sub_meshes, element, decoder)?;
+        Ok(sub_meshes)
+    }
+
+    /// Apply the element's `ObjectPlacement` (scaled to metres) to every sub-mesh.
+    /// Placement is a rigid per-instance transform, kept OUT of the dedup cache so
+    /// instances of one shared geometry land at their own positions.
+    fn apply_submesh_placement(
+        &self,
+        sub_meshes: &mut SubMeshCollection,
+        element: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+    ) -> Result<()> {
+        // ObjectPlacement translation is in file units (e.g. mm) but geometry is
+        // scaled to metres, so the transform MUST be scaled to match.
         if let Some(placement_attr) = element.get(5) {
             if !placement_attr.is_null() {
                 if let Some(placement) = decoder.resolve_ref(placement_attr)? {
@@ -684,8 +696,7 @@ impl GeometryRouter {
                 }
             }
         }
-
-        Ok(sub_meshes)
+        Ok(())
     }
 
     /// Collect sub-meshes from a representation item, following MappedItem references.
@@ -810,19 +821,69 @@ impl GeometryRouter {
         Ok(())
     }
 
-    /// Process a single representation item (IfcExtrudedAreaSolid, etc.)
-    /// Uses hash-based caching for geometry deduplication across repeated floors
+    /// Process a single representation item (IfcExtrudedAreaSolid, etc.), with
+    /// content-dedup: a 128-bit structural hash of the item subtree skips the
+    /// meshing + CSG for geometry byte-identical to an item meshed earlier (e.g.
+    /// the thousands of Tekla connection plates/bolts an exporter failed to share
+    /// via `IfcMappedItem`). The cached mesh is colour-free and pre-placement; the
+    /// caller keeps this item's own `geometry_id` (so colour/palette/texture stay
+    /// per-instance) and applies voids + placement afterwards, so a cache hit is
+    /// indistinguishable from a fresh build.
     #[inline]
     pub fn process_representation_item(
         &self,
         item: &DecodedEntity,
         decoder: &mut EntityDecoder,
     ) -> Result<Mesh> {
-        // Special handling for MappedItem with caching
+        // MappedItem has its own instancing cache (the source representation is
+        // already shared), so it never enters the structural-hash path.
         if item.ifc_type == IfcType::IfcMappedItem {
             return self.process_mapped_item_cached(item, decoder);
         }
 
+        // `None` ⇒ dedup disabled (no hash overhead). On a hit, return a clone of
+        // the cached item mesh; meshing is skipped entirely.
+        let dedup_key = self.item_dedup_key(item, decoder);
+        if let (Some(key), Some(cache)) = (dedup_key, self.item_dedup_cache.as_ref()) {
+            let hit = cache.lock().expect("dedup cache poisoned").get(&key).cloned();
+            if let Some(mesh) = hit {
+                return Ok((*mesh).clone());
+            }
+        }
+
+        let mesh = self.process_representation_item_uncached(item, decoder)?;
+
+        // Cache the freshly-meshed item under its structural hash. Empty meshes
+        // (unsupported/degenerate geometry) are never cached.
+        if let (Some(key), Some(cache)) = (dedup_key, self.item_dedup_cache.as_ref()) {
+            if !mesh.positions.is_empty() {
+                cache
+                    .lock()
+                    .expect("dedup cache poisoned")
+                    .insert(key, Arc::new(mesh.clone()));
+            }
+        }
+
+        Ok(mesh)
+    }
+
+    /// Structural-hash key for an item, or `None` when dedup is disabled (skips
+    /// the hash walk entirely so disabled = zero overhead).
+    fn item_dedup_key(&self, item: &DecodedEntity, decoder: &mut EntityDecoder) -> Option<u128> {
+        self.item_dedup_cache.as_ref()?;
+        let mut memo = self.content_sig_memo.borrow_mut();
+        Some(super::content_hash::item_signature(
+            decoder, item.id, &mut memo,
+        ))
+    }
+
+    /// The meshing body of [`Self::process_representation_item`] (everything except
+    /// the MappedItem path and the content-dedup wrapper).
+    fn process_representation_item_uncached(
+        &self,
+        item: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+    ) -> Result<Mesh> {
         // For raw world-coordinate FacetedBrep with RTC: subtract RTC from f64
         // coordinates BEFORE f32 conversion. Do not use this path for ordinary
         // local Breps whose large position comes from IfcObjectPlacement; those

--- a/rust/geometry/tests/dedup_validate.rs
+++ b/rust/geometry/tests/dedup_validate.rs
@@ -182,6 +182,72 @@ END-ISO-10303-21;
     .to_string()
 }
 
+/// A single cylinder (circle-profile extrusion) — curved, so its triangle count
+/// scales with tessellation quality.
+fn curved_extrusion_ifc() -> String {
+    r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('curve.ifc','2025-01-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('proj',$,'P','',$,$,$,(#12),#7);
+#7=IFCUNITASSIGNMENT((#8));
+#8=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#12=IFCGEOMETRICREPRESENTATIONCONTEXT('3D','Model',3,1.E-6,#14,$);
+#14=IFCAXIS2PLACEMENT3D(#15,$,$);
+#15=IFCCARTESIANPOINT((0.,0.,0.));
+#40=IFCLOCALPLACEMENT($,#41);
+#41=IFCAXIS2PLACEMENT3D(#42,$,$);
+#42=IFCCARTESIANPOINT((0.,0.,0.));
+#50=IFCBUILDINGELEMENTPROXY('c',$,'C','',$,#40,#51,$,$);
+#51=IFCPRODUCTDEFINITIONSHAPE($,$,(#52));
+#52=IFCSHAPEREPRESENTATION(#12,'Body','SweptSolid',(#53));
+#53=IFCEXTRUDEDAREASOLID(#54,#57,#60,1.);
+#54=IFCCIRCLEPROFILEDEF(.AREA.,$,#55,0.5);
+#55=IFCAXIS2PLACEMENT2D(#56,$);
+#56=IFCCARTESIANPOINT((0.,0.));
+#57=IFCAXIS2PLACEMENT3D(#58,$,$);
+#58=IFCCARTESIANPOINT((0.,0.,0.));
+#60=IFCDIRECTION((0.,0.,1.));
+ENDSEC;
+END-ISO-10303-21;
+"#
+    .to_string()
+}
+
+/// CI guard for #976 × dedup: the shared cache persists across
+/// `setTessellationQuality` changes, so the cache KEY must fold in the quality —
+/// otherwise the first-meshed quality is served for every later one. Two routers
+/// sharing ONE cache at different qualities must still tessellate the curve
+/// differently.
+#[test]
+fn content_dedup_keys_on_tessellation_quality() {
+    use ifc_lite_geometry::TessellationQuality;
+    let content = curved_extrusion_ifc();
+    let cache = GeometryRouter::new_dedup_cache();
+
+    let tris = |quality: TessellationQuality| -> usize {
+        let mut d = EntityDecoder::with_index(&content, build_entity_index(&content));
+        let mut r = GeometryRouter::with_scale_and_quality(1.0, quality);
+        r.enable_content_dedup_shared(cache.clone()); // SAME cache across qualities
+        let e = d.decode_by_id(50).expect("decode element");
+        let sm = r
+            .process_element_with_submeshes(&e, &mut d)
+            .expect("mesh element");
+        sm.sub_meshes.iter().map(|s| s.mesh.indices.len() / 3).sum()
+    };
+
+    let low = tris(TessellationQuality::Lowest);
+    let high = tris(TessellationQuality::Highest);
+    assert!(low > 0 && high > 0, "curved extrusion produced no geometry");
+    assert!(
+        high > low,
+        "higher quality must tessellate finer despite the shared dedup cache (low={low}, high={high})"
+    );
+}
+
 /// CI guard (no external fixture): content-dedup must produce BYTE-IDENTICAL
 /// geometry to the non-deduped path, collapse structurally-identical items to one
 /// cached mesh, and keep placement per-instance.

--- a/rust/geometry/tests/dedup_validate.rs
+++ b/rust/geometry/tests/dedup_validate.rs
@@ -93,6 +93,13 @@ fn run(
     content: &str,
     index: FxHashMap<u32, (usize, usize)>,
 ) -> (Vec<(u32, u64)>, usize, f64) {
+    // Sentinel fingerprints for the non-mesh outcomes, so EVERY product yields an
+    // entry — ON and OFF stay 1:1 aligned and a config-dependent decode/mesh
+    // divergence surfaces as a fingerprint mismatch instead of silently shrinking
+    // the compared set.
+    const FP_DECODE_ERR: u64 = u64::MAX;
+    const FP_MESH_ERR: u64 = u64::MAX - 1;
+
     let mut decoder = EntityDecoder::with_index(content, index);
     let mut fps: Vec<(u32, u64)> = Vec::with_capacity(products.len());
     let mut tris = 0usize;
@@ -100,7 +107,10 @@ fn run(
     for (id, _ty) in products {
         let entity = match decoder.decode_by_id(*id) {
             Ok(e) => e,
-            Err(_) => continue,
+            Err(_) => {
+                fps.push((*id, FP_DECODE_ERR));
+                continue;
+            }
         };
         let openings = void_idx.get(id).map(|v| v.len()).unwrap_or(0);
         let sm = if openings > 0 {
@@ -108,9 +118,12 @@ fn run(
         } else {
             router.process_element_with_submeshes(&entity, &mut decoder)
         };
-        if let Ok(sm) = sm {
-            tris += sm.sub_meshes.iter().map(|s| s.mesh.indices.len() / 3).sum::<usize>();
-            fps.push((*id, fingerprint(&sm)));
+        match sm {
+            Ok(sm) => {
+                tris += sm.sub_meshes.iter().map(|s| s.mesh.indices.len() / 3).sum::<usize>();
+                fps.push((*id, fingerprint(&sm)));
+            }
+            Err(_) => fps.push((*id, FP_MESH_ERR)),
         }
     }
     (fps, tris, t.elapsed().as_secs_f64() * 1000.0)

--- a/rust/geometry/tests/dedup_validate.rs
+++ b/rust/geometry/tests/dedup_validate.rs
@@ -1,0 +1,294 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Content-dedup A/B validation on a real model: drives the SUBMESH path (the
+//! production `produce_element_meshes` entry, where the dedup lives — NOT the
+//! `process_element` path the calibration harness uses) with dedup ON and OFF,
+//! asserts the per-element geometry is BYTE-IDENTICAL between the two, and prints
+//! the wall-time of each so the speedup is measurable.
+//!
+//! Two independent routers each start cold, so the timings are a fair cold-cache
+//! comparison and a content-hash false-merge would surface as a fingerprint
+//! mismatch (the OFF run is the ground truth — it rebuilds every element).
+//!
+//! IFCLT_MODEL=/abs/path.ifc cargo test -p ifc-lite-geometry --release \
+//!   --test dedup_validate -- --ignored --nocapture
+
+use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner};
+use ifc_lite_geometry::{propagate_voids_to_parts, GeometryRouter, SubMeshCollection};
+use rustc_hash::FxHashMap;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::time::Instant;
+
+fn build_void_index(content: &str) -> FxHashMap<u32, Vec<u32>> {
+    let mut idx: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
+    let mut scanner = EntityScanner::new(content);
+    let mut decoder = EntityDecoder::new(content);
+    while let Some((id, name, start, end)) = scanner.next_entity() {
+        if name == "IFCRELVOIDSELEMENT" {
+            if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
+                if let (Some(host), Some(opening)) = (entity.get_ref(4), entity.get_ref(5)) {
+                    idx.entry(host).or_default().push(opening);
+                }
+            }
+        }
+    }
+    let _ = propagate_voids_to_parts(&mut idx, content, &mut decoder);
+    idx
+}
+
+fn list_products(content: &str) -> Vec<(u32, String)> {
+    let mut products = Vec::new();
+    let mut scanner = EntityScanner::new(content);
+    while let Some((id, name, _, _)) = scanner.next_entity() {
+        let n = name;
+        if n.starts_with("IFC")
+            && (n.contains("WALL") || n.contains("BEAM") || n.contains("COLUMN")
+                || n.contains("MEMBER") || n.contains("PLATE") || n.contains("SLAB")
+                || n.contains("FOOTING") || n.contains("PILE") || n.contains("RAILING")
+                || n.contains("STAIR") || n.contains("ROOF") || n.contains("COVERING")
+                || n.contains("BUILDINGELEMENT") || n.contains("PROXY") || n.contains("FLOW")
+                || n.contains("DISCRETE") || n.contains("FURNISH")
+                || n == "IFCDOOR" || n == "IFCWINDOW")
+        {
+            products.push((id, n.to_string()));
+        }
+    }
+    products
+}
+
+/// Deterministic content fingerprint of a placed sub-mesh collection — every bit
+/// that the renderer consumes (geometry id, f32 positions/normals, indices, and
+/// the f64 local-frame origin), in submesh order.
+fn fingerprint(sm: &SubMeshCollection) -> u64 {
+    let mut h = DefaultHasher::new();
+    sm.sub_meshes.len().hash(&mut h);
+    for s in &sm.sub_meshes {
+        s.geometry_id.hash(&mut h);
+        s.mesh.positions.len().hash(&mut h);
+        for &p in &s.mesh.positions {
+            p.to_bits().hash(&mut h);
+        }
+        for &n in &s.mesh.normals {
+            n.to_bits().hash(&mut h);
+        }
+        for &i in &s.mesh.indices {
+            i.hash(&mut h);
+        }
+        for &o in &s.mesh.origin {
+            o.to_bits().hash(&mut h);
+        }
+    }
+    h.finish()
+}
+
+/// Process every product through the submesh path, returning (per-element
+/// fingerprint, total triangles) and the wall-time.
+fn run(
+    router: &GeometryRouter,
+    products: &[(u32, String)],
+    void_idx: &FxHashMap<u32, Vec<u32>>,
+    content: &str,
+    index: FxHashMap<u32, (usize, usize)>,
+) -> (Vec<(u32, u64)>, usize, f64) {
+    let mut decoder = EntityDecoder::with_index(content, index);
+    let mut fps: Vec<(u32, u64)> = Vec::with_capacity(products.len());
+    let mut tris = 0usize;
+    let t = Instant::now();
+    for (id, _ty) in products {
+        let entity = match decoder.decode_by_id(*id) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let openings = void_idx.get(id).map(|v| v.len()).unwrap_or(0);
+        let sm = if openings > 0 {
+            router.process_element_with_submeshes_and_voids(&entity, &mut decoder, void_idx)
+        } else {
+            router.process_element_with_submeshes(&entity, &mut decoder)
+        };
+        if let Ok(sm) = sm {
+            tris += sm.sub_meshes.iter().map(|s| s.mesh.indices.len() / 3).sum::<usize>();
+            fps.push((*id, fingerprint(&sm)));
+        }
+    }
+    (fps, tris, t.elapsed().as_secs_f64() * 1000.0)
+}
+
+/// Two `IfcBuildingElementProxy` with byte-identical FacetedBrep geometry (a
+/// triangle, renumbered) at DIFFERENT placements, plus a third with a larger,
+/// distinct triangle. The two duplicates must collapse to ONE cached item mesh;
+/// the third stays separate.
+fn synthetic_duplicates_ifc() -> String {
+    r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('dedup.ifc','2025-01-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('proj',$,'P','',$,$,$,(#12),#7);
+#7=IFCUNITASSIGNMENT((#8));
+#8=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#12=IFCGEOMETRICREPRESENTATIONCONTEXT('3D','Model',3,1.E-6,#14,$);
+#14=IFCAXIS2PLACEMENT3D(#15,$,$);
+#15=IFCCARTESIANPOINT((0.,0.,0.));
+#40=IFCLOCALPLACEMENT($,#41);
+#41=IFCAXIS2PLACEMENT3D(#42,$,$);
+#42=IFCCARTESIANPOINT((0.,0.,0.));
+#50=IFCBUILDINGELEMENTPROXY('a1',$,'A1','',$,#40,#51,$,$);
+#51=IFCPRODUCTDEFINITIONSHAPE($,$,(#52));
+#52=IFCSHAPEREPRESENTATION(#12,'Body','Brep',(#53));
+#53=IFCFACETEDBREP(#54);
+#54=IFCCLOSEDSHELL((#55));
+#55=IFCFACE((#56));
+#56=IFCFACEOUTERBOUND(#57,.T.);
+#57=IFCPOLYLOOP((#58,#59,#60));
+#58=IFCCARTESIANPOINT((0.,0.,0.));
+#59=IFCCARTESIANPOINT((1.,0.,0.));
+#60=IFCCARTESIANPOINT((0.,1.,0.));
+#70=IFCLOCALPLACEMENT($,#71);
+#71=IFCAXIS2PLACEMENT3D(#72,$,$);
+#72=IFCCARTESIANPOINT((10.,0.,0.));
+#80=IFCBUILDINGELEMENTPROXY('a2',$,'A2','',$,#70,#81,$,$);
+#81=IFCPRODUCTDEFINITIONSHAPE($,$,(#82));
+#82=IFCSHAPEREPRESENTATION(#12,'Body','Brep',(#83));
+#83=IFCFACETEDBREP(#84);
+#84=IFCCLOSEDSHELL((#85));
+#85=IFCFACE((#86));
+#86=IFCFACEOUTERBOUND(#87,.T.);
+#87=IFCPOLYLOOP((#88,#89,#90));
+#88=IFCCARTESIANPOINT((0.,0.,0.));
+#89=IFCCARTESIANPOINT((1.,0.,0.));
+#90=IFCCARTESIANPOINT((0.,1.,0.));
+#100=IFCLOCALPLACEMENT($,#101);
+#101=IFCAXIS2PLACEMENT3D(#102,$,$);
+#102=IFCCARTESIANPOINT((0.,10.,0.));
+#110=IFCBUILDINGELEMENTPROXY('b',$,'B','',$,#100,#111,$,$);
+#111=IFCPRODUCTDEFINITIONSHAPE($,$,(#112));
+#112=IFCSHAPEREPRESENTATION(#12,'Body','Brep',(#113));
+#113=IFCFACETEDBREP(#114);
+#114=IFCCLOSEDSHELL((#115));
+#115=IFCFACE((#116));
+#116=IFCFACEOUTERBOUND(#117,.T.);
+#117=IFCPOLYLOOP((#118,#119,#120));
+#118=IFCCARTESIANPOINT((0.,0.,0.));
+#119=IFCCARTESIANPOINT((2.,0.,0.));
+#120=IFCCARTESIANPOINT((0.,2.,0.));
+ENDSEC;
+END-ISO-10303-21;
+"#
+    .to_string()
+}
+
+/// CI guard (no external fixture): content-dedup must produce BYTE-IDENTICAL
+/// geometry to the non-deduped path, collapse structurally-identical items to one
+/// cached mesh, and keep placement per-instance.
+#[test]
+fn content_dedup_byte_identical_on_synthetic_duplicates() {
+    let content = synthetic_duplicates_ifc();
+    let ids = [50u32, 80, 110];
+
+    // ON: content-dedup armed via with_units.
+    let mut d_on = EntityDecoder::with_index(&content, build_entity_index(&content));
+    let on_router = GeometryRouter::with_units(&content, &mut d_on);
+    let mut on = Vec::new();
+    for &id in &ids {
+        let e = d_on.decode_by_id(id).expect("decode element");
+        let sm = on_router
+            .process_element_with_submeshes(&e, &mut d_on)
+            .expect("mesh element");
+        assert!(!sm.sub_meshes.is_empty(), "element #{id} produced no geometry");
+        on.push(fingerprint(&sm));
+    }
+    // #50 and #80 share one structural hash; #110 is distinct ⇒ 2 unique meshes.
+    assert_eq!(
+        on_router.dedup_unique_count(),
+        2,
+        "expected exactly 2 unique item meshes (2 duplicates collapse to 1)"
+    );
+
+    // OFF: same router family, dedup disabled ⇒ every element rebuilt.
+    let mut d_off = EntityDecoder::with_index(&content, build_entity_index(&content));
+    let mut off_router = GeometryRouter::with_units(&content, &mut d_off);
+    off_router.disable_content_dedup();
+    let mut off = Vec::new();
+    for &id in &ids {
+        let e = d_off.decode_by_id(id).expect("decode element");
+        let sm = off_router
+            .process_element_with_submeshes(&e, &mut d_off)
+            .expect("mesh element");
+        off.push(fingerprint(&sm));
+    }
+
+    assert_eq!(on, off, "deduped geometry differs from the freshly-built geometry");
+    // The two duplicate instances are at different placements, so their world
+    // meshes — and thus fingerprints — must differ: placement stays per-instance.
+    assert_ne!(on[0], on[1], "per-instance placement was lost to the shared cache");
+}
+
+#[test]
+#[ignore = "manual; needs IFCLT_MODEL"]
+fn dedup_byte_identical_and_faster() {
+    let path = match std::env::var("IFCLT_MODEL") {
+        Ok(p) => p,
+        Err(_) => {
+            println!("set IFCLT_MODEL=/abs/path.ifc");
+            return;
+        }
+    };
+    let content = std::fs::read_to_string(&path).expect("read model");
+    println!("\n=== content-dedup A/B (submesh path) ===");
+    println!("model: {path}  ({} bytes)", content.len());
+
+    let void_idx = build_void_index(&content);
+    let products = list_products(&content);
+    println!("products: {}  (voided hosts: {})\n", products.len(), void_idx.len());
+
+    // --- OFF: ground truth, rebuilds every element ---
+    let off_router = {
+        let mut d = EntityDecoder::with_index(&content, build_entity_index(&content));
+        let mut r = GeometryRouter::with_units(&content, &mut d);
+        r.disable_content_dedup();
+        r
+    };
+    let (off_fps, off_tris, off_ms) =
+        run(&off_router, &products, &void_idx, &content, build_entity_index(&content));
+    println!("OFF (no dedup): {off_ms:.0}ms  tris={off_tris}");
+
+    // --- ON: content-dedup armed ---
+    let on_router = {
+        let mut d = EntityDecoder::with_index(&content, build_entity_index(&content));
+        GeometryRouter::with_units(&content, &mut d)
+    };
+    let (on_fps, on_tris, on_ms) =
+        run(&on_router, &products, &void_idx, &content, build_entity_index(&content));
+    println!(
+        "ON  (dedup):    {on_ms:.0}ms  tris={on_tris}  unique-geometries={}",
+        on_router.dedup_unique_count()
+    );
+
+    let speedup = if on_ms > 0.0 { off_ms / on_ms } else { 0.0 };
+    println!("\nspeedup: {speedup:.1}x   ({off_ms:.0}ms → {on_ms:.0}ms)");
+
+    // --- correctness: per-element fingerprints must be byte-identical ---
+    assert_eq!(off_fps.len(), on_fps.len(), "element count diverged ON vs OFF");
+    let mut mismatches = 0usize;
+    for ((off_id, off_fp), (on_id, on_fp)) in off_fps.iter().zip(on_fps.iter()) {
+        assert_eq!(off_id, on_id, "element order diverged");
+        if off_fp != on_fp {
+            if mismatches < 10 {
+                println!("  MISMATCH element #{off_id}: off={off_fp:x} on={on_fp:x}");
+            }
+            mismatches += 1;
+        }
+    }
+    println!(
+        "fingerprint mismatches: {mismatches} / {} elements",
+        off_fps.len()
+    );
+    assert_eq!(on_tris, off_tris, "triangle totals diverged ON vs OFF");
+    assert_eq!(mismatches, 0, "content-dedup produced different geometry");
+    println!("✓ dedup is byte-identical to the non-deduped path");
+}

--- a/rust/processing/src/processor.rs
+++ b/rust/processing/src/processor.rs
@@ -1464,6 +1464,13 @@ pub fn process_geometry_streaming_filtered_with_options(
     let csg_failure_collector: std::sync::Mutex<FxHashMap<u32, Vec<ifc_lite_geometry::BoolFailure>>> =
         std::sync::Mutex::new(FxHashMap::default());
 
+    // Shared content-dedup cache for the whole model: every per-job router (built
+    // fresh per element below) dedups against it, so byte-identical geometry the
+    // exporter failed to share via IfcMappedItem (Tekla parts) is meshed once
+    // across the rayon pool instead of once per element. The lock is held only for
+    // a hash get/insert; meshing runs outside it.
+    let item_dedup_cache = GeometryRouter::new_dedup_cache();
+
     while chunk_start < total_jobs {
         let chunk_end = (chunk_start + current_chunk_size).min(total_jobs);
         let jobs_chunk = &mut entity_jobs[chunk_start..chunk_end];
@@ -1569,6 +1576,7 @@ pub fn process_geometry_streaming_filtered_with_options(
                     texture_index.as_ref(),
                     site_local_rotation,
                     &csg_failure_collector,
+                    &item_dedup_cache,
                 )
             })
             .collect();
@@ -1719,6 +1727,9 @@ fn process_entity_job(
     // Shared sink for per-job router CSG diagnostics (parity with the wasm
     // path's `drain_and_log_csg_diagnostics`).
     csg_failure_collector: &std::sync::Mutex<FxHashMap<u32, Vec<ifc_lite_geometry::BoolFailure>>>,
+    // Model-wide content-dedup cache shared by every per-job router so identical
+    // geometry is meshed once across the rayon pool (#1109 follow-up).
+    item_dedup_cache: &ifc_lite_geometry::ItemDedupCache,
 ) -> Vec<MeshData> {
     if skipped_entity_ids.contains(&job.id) {
         return Vec::new();
@@ -1736,6 +1747,7 @@ fn process_entity_job(
 
     let mut local_router = GeometryRouter::with_scale_and_quality(unit_scale, tessellation_quality);
     local_router.set_rtc_offset(rtc_offset);
+    local_router.enable_content_dedup_shared(item_dedup_cache.clone());
     let local_router = local_router;
 
     let metadata = crate::element::ElementMeshMetadata {

--- a/rust/wasm-bindings/src/api/gpu_meshes.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes.rs
@@ -751,6 +751,20 @@ impl IfcAPI {
         let mut router =
             GeometryRouter::with_scale_and_quality(unit_scale, self.tessellation_quality());
 
+        // Arm content-dedup against the per-worker shared cache so byte-identical
+        // geometry (e.g. Tekla parts the exporter failed to share via
+        // IfcMappedItem) is meshed ONCE across batches, not once per batch.
+        {
+            let mut slot = self
+                .cached_item_dedup
+                .lock()
+                .expect("ifc-lite cached_item_dedup Mutex poisoned");
+            let cache = slot
+                .get_or_insert_with(GeometryRouter::new_dedup_cache)
+                .clone();
+            router.enable_content_dedup_shared(cache);
+        }
+
         // Set RTC offset if needed
         if needs_shift {
             router.set_rtc_offset((rtc_x, rtc_y, rtc_z));

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -50,6 +50,16 @@ pub struct IfcAPI {
     /// under concurrent `&self` access.
     cached_entity_index: std::sync::Mutex<Option<std::sync::Arc<EntityIndex>>>,
 
+    /// Per-worker shared content-dedup cache (#1109 follow-up). The
+    /// `GeometryRouter` is rebuilt every `processGeometryBatch`, so its item-mesh
+    /// dedup cache would reset each batch. Holding ONE cache here and injecting it
+    /// into every batch router lets byte-identical geometry mesh once across the
+    /// whole worker's workload — e.g. Tekla connection plates/bolts the exporter
+    /// emitted as thousands of separate items instead of one `IfcMappedItem`.
+    /// Built lazily on first batch; one model per `IfcApi` instance, exactly like
+    /// `cached_entity_index`.
+    cached_item_dedup: std::sync::Mutex<Option<ifc_lite_geometry::ItemDedupCache>>,
+
     /// When `true`, `processGeometryBatch` suppresses geometry emission for
     /// every `IfcBuildingElementPart` whose `IfcRelAggregates` parent (a) has
     /// its own `Representation` and (b) is marked `Sliceable` in
@@ -176,6 +186,7 @@ impl IfcAPI {
         Self {
             initialized: true,
             cached_entity_index: std::sync::Mutex::new(None),
+            cached_item_dedup: std::sync::Mutex::new(None),
             merge_layers: std::sync::atomic::AtomicBool::new(false),
             cached_parts_to_skip: std::sync::Mutex::new(None),
             cached_referenced_repmaps: std::sync::Mutex::new(None),

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -268,6 +268,14 @@ impl IfcAPI {
             .lock()
             .expect("ifc-lite cached_geometry_styles Mutex poisoned")
             .take();
+        // The content-dedup cache holds the previous model's item meshes, keyed by
+        // a content hash of that model's entities. Drop it so a new file on the
+        // same reused IfcAPI starts with an empty cache (bounds memory across
+        // loads; defensive even though the key is content- not id-based).
+        self.cached_item_dedup
+            .lock()
+            .expect("ifc-lite cached_item_dedup Mutex poisoned")
+            .take();
     }
 
     /// Populate `cached_entity_index` from pre-extracted column arrays.
@@ -344,6 +352,13 @@ impl IfcAPI {
         self.cached_geometry_styles
             .lock()
             .expect("ifc-lite cached_geometry_styles Mutex poisoned")
+            .take();
+        // The content-dedup cache holds the previous model's item meshes — drop it
+        // on content swap so a reused IfcAPI starts the new file with an empty
+        // cache (bounds memory across loads).
+        self.cached_item_dedup
+            .lock()
+            .expect("ifc-lite cached_item_dedup Mutex poisoned")
             .take();
     }
 


### PR DESCRIPTION
## Problem

Boolean-heavy models exported **without** `IfcMappedItem` — e.g. structural-steel detailers that emit every connection plate/bolt as its own representation item — re-mesh and re-CSG thousands of byte-identical solids. With the exact pure-Rust kernel (#1024, ~20–40× slower per cut than the old Manifold path), this dominates load time. A 19.5 MB steel model spent ~85% of geometry time re-computing duplicates — a regression from the Manifold era, where cheap booleans hid the waste. This is the root cause behind the #1109 "hangs at 95%, used to load in seconds" reports for that class of model.

A spike measured the floor: **2562 unique geometries / 15291 elements (83% duplicates)** → re-computing the duplicates cost ~159 s of the ~182 s total.

## Fix

A content-dedup layer in `process_representation_item`: a **128-bit structural hash** of the fully-resolved item subtree (`content_hash::item_signature`) keys a shared cache of the **LOCAL, void-free, colour-free** item mesh. A cache hit skips meshing + CSG entirely.

The per-instance attributes stay out of the cache and are applied by the caller exactly as before:
- **`geometry_id`** → colour / per-triangle palette / texture (so two identical-geometry parts with different colours both render correctly — no styled-item gate needed, because colour rides `geometry_id`, not the mesh)
- **voids** (per-element opening cuts) and **placement** (per-instance rigid transform + local-frame origin)

So a cache hit is **byte-identical** to a fresh build. The 128-bit full-structure hash (vs the sampled 64-bit mesh hash that collided in #833) makes a false merge ~1e-30, and it's deterministic integer splitmix64 → native and wasm produce identical keys.

The cache is `Arc<Mutex<_>>`, shared across one model's routers so it outlives any single router:
- **native:** one cache for the whole rayon pool (`processor.rs`)
- **wasm:** one cache per worker, injected into every per-batch router and held on `IfcAPI` so it persists **across batches**, not just within one (`gpu_meshes.rs`) — the router is rebuilt per batch, so without this the cache would reset ~30× on a large model

## Why item-level (not representation-level)

An earlier representation-level attempt had to skip every per-item-styled element to stay colour-correct — and this Tekla file styles ~98% of elements, so dedup never fired. Moving dedup down to the item level (where `geometry_id` is already assigned per-instance by the caller) makes it colour-correct *by construction* and removes the gate. Aligns with the existing per-item `geometry_hash_cache`, except this skips the **compute**, not just storage.

## Measured (serial, exact kernel)

| Model | Before | After | Mismatches |
|---|---|---|---|
| 19.5 MB steel (no IfcMappedItem) | 182 s | **24 s (7.6×)** | 0 / 15291 |
| 35 MB architectural (82 voided hosts) | 4.78 s | 4.49 s | 0 / 6574 |

The second row is the corpus check: a totally different model where ~46% of items are unique — the hash overhead is **negligible** (slightly net-faster), confirming no regression on ordinary models. 24 s serial → ~6 s across the viewer's 4 workers, restoring the pre-kernel-swap load time.

## Tests

- **Committed CI guard** `content_dedup_byte_identical_on_synthetic_duplicates` (no external fixture): asserts ON==OFF byte-for-byte, correct collapse (2 duplicates → 1 cached mesh), and that placement stays per-instance.
- **Gated A/B harness** `dedup_validate` (`IFCLT_MODEL=…`): drives the production submesh path with dedup ON vs OFF, fingerprints every element, reports speedup. Source of the numbers above.
- Geometry suite **477 ✓**, processing suite **62 ✓**, clippy clean.

## Follow-up (not in this PR)

WASM workers are separate realms, so the cache is **per-worker** — each worker dedups its own assigned elements. The reported regression is resolved by that alone (7.6× less total work). Routing identical geometry to the same worker (content-affinity) could squeeze the cross-worker case further, but needs a JS-side hash pre-pass + scheduler change and browser measurement; deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structural, content-based deduplication so repeated, byte-identical representation-item geometry is meshed once and reused.
  * Introduced shared dedup caches for parallel geometry processing and for consecutive WASM geometry batches, with proper cache reset between loads.
* **Tests**
  * Added tests that verify identical results and expected cache reduction on synthetic duplicates.
  * Added a regression test ensuring dedup keys account for tessellation quality.
  * Added an ignored, performance-focused comparison test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->