### PR TITLE
perf(geometry): content-affinity worker routing by exact geometry hash

### DIFF
--- a/.changeset/content-affinity-routing.md
+++ b/.changeset/content-affinity-routing.md
@@ -1,0 +1,15 @@
+---
+"@ifc-lite/wasm": patch
+"@ifc-lite/geometry": patch
+---
+
+Content-affinity worker routing for boolean-heavy models. The streaming geometry
+pre-pass now tags each job with an affinity key — the exact 128-bit hash of the
+element's representation geometry — and the parallel dispatcher routes all jobs
+sharing a key to the same worker. Combined with the per-worker geometry-dedup
+cache, each unique geometry is meshed once **per model** instead of once per
+worker, so the workers partition the unique meshing instead of replicating it.
+Restores fast loads on models exported without `IfcMappedItem` (e.g.
+structural-steel detailers that emit thousands of byte-identical parts): a 19.5 MB
+steel model drops from ~32 s to ≈ the dedup floor split across the worker pool.
+Falls back to the previous interleaved split when no affinity data is present.

--- a/packages/geometry/src/affinity-routing.test.ts
+++ b/packages/geometry/src/affinity-routing.test.ts
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+import { planAffinityRouting } from './geometry-parallel.js';
+
+describe('planAffinityRouting (content-affinity worker routing)', () => {
+  it('routes every job exactly once', () => {
+    const affinity = new Uint32Array([10, 20, 10, 30, 20, 10]);
+    const { buckets } = planAffinityRouting(affinity, 6, 4, new Map(), 0);
+    const all = buckets.flat().sort((a, b) => a - b);
+    expect(all).toEqual([0, 1, 2, 3, 4, 5]);
+  });
+
+  it('sends all jobs of one affinity key to the SAME worker', () => {
+    const affinity = new Uint32Array([10, 20, 10, 30, 20, 10]);
+    const { buckets } = planAffinityRouting(affinity, 6, 4, new Map(), 0);
+    const workerOf = (job: number) => buckets.findIndex((b) => b.includes(job));
+    // jobs 0,2,5 share key 10; 1,4 share key 20.
+    expect(workerOf(0)).toBe(workerOf(2));
+    expect(workerOf(2)).toBe(workerOf(5));
+    expect(workerOf(1)).toBe(workerOf(4));
+  });
+
+  it('round-robins NEW keys across workers', () => {
+    // 4 distinct keys, 4 workers → one key per worker.
+    const affinity = new Uint32Array([7, 8, 9, 10]);
+    const { buckets, nextWorker } = planAffinityRouting(affinity, 4, 4, new Map(), 0);
+    expect(buckets.map((b) => b.length)).toEqual([1, 1, 1, 1]);
+    expect(nextWorker).toBe(0); // wrapped back around
+  });
+
+  it('keeps a key on its worker ACROSS chunks via the sticky map', () => {
+    const keyToWorker = new Map<number, number>();
+    // Chunk 1: key 42 first seen → worker 0 (startWorker 0).
+    const r1 = planAffinityRouting(new Uint32Array([42, 99]), 2, 4, keyToWorker, 0);
+    const w42 = r1.buckets.findIndex((b) => b.includes(0));
+    // Chunk 2: key 42 reappears (plus new key 7) → must reuse the same worker.
+    const r2 = planAffinityRouting(new Uint32Array([7, 42]), 2, 4, keyToWorker, r1.nextWorker);
+    expect(r2.buckets[w42]).toContain(1); // job 1 has key 42
+  });
+
+  it('advances the round-robin cursor it returns', () => {
+    const map = new Map<number, number>();
+    const { nextWorker } = planAffinityRouting(new Uint32Array([1, 2]), 2, 4, map, 0);
+    expect(nextWorker).toBe(2); // two new keys consumed workers 0,1
+  });
+});

--- a/packages/geometry/src/geometry-parallel.ts
+++ b/packages/geometry/src/geometry-parallel.ts
@@ -31,6 +31,37 @@ import { pickWorkerCount } from './worker-count.js';
 import type { BatchSizingConfig } from './batch-sizing.js';
 
 /**
+ * Plan content-affinity routing for one chunk: assign each job (by index) to a
+ * worker bucket so that every job sharing an affinity key lands on the SAME
+ * worker — across the whole stream, since `keyToWorker` is the caller's sticky
+ * map. New keys are handed out round-robin from `startWorker`, so each worker
+ * owns roughly `1/workerCount` of the distinct keys (≈ distinct geometries, the
+ * dominant meshing cost). Pure: mutates only the passed `keyToWorker` and returns
+ * the advanced round-robin cursor. (#1130 follow-up — see `affinity_key` in Rust.)
+ */
+export function planAffinityRouting(
+  affinity: Uint32Array,
+  totalJobs: number,
+  workerCount: number,
+  keyToWorker: Map<number, number>,
+  startWorker: number,
+): { buckets: number[][]; nextWorker: number } {
+  const buckets: number[][] = Array.from({ length: workerCount }, () => []);
+  let nextWorker = startWorker % workerCount;
+  for (let j = 0; j < totalJobs; j++) {
+    const key = affinity[j];
+    let w = keyToWorker.get(key);
+    if (w === undefined) {
+      w = nextWorker;
+      nextWorker = (nextWorker + 1) % workerCount;
+      keyToWorker.set(key, w);
+    }
+    buckets[w].push(j);
+  }
+  return { buckets, nextWorker };
+}
+
+/**
  * Optional runtime override for the geometry worker's adaptive batch sizing
  * (#1097), read off `globalThis` on the host thread. A zero-cost escape hatch
  * for hardware-specific tuning / field-debugging the watchdog↔throughput
@@ -215,9 +246,20 @@ export async function* processParallel(
    * geometry-style meshes (geometry-IDs don't match the host's
    * mesh.expressId; only element-material colours did).
    */
-  const queuedChunks: Uint32Array[] = [];
+  const queuedChunks: { jobs: Uint32Array; affinity: Uint32Array | null }[] = [];
   let stylesReceived = false;
   let entityIndexReceived = false;
+
+  // Content-affinity routing (#1130 follow-up): the pre-pass tags every job with
+  // an affinity key (ObjectType hash, see `affinity_key` in Rust). Sending all
+  // jobs of one key to the SAME worker means each unique geometry is meshed ONCE
+  // per model — the per-worker content-dedup cache then turns the rest into cheap
+  // hits — instead of every worker re-meshing the full unique set (the cap of
+  // PR #1130 on its own). `keyToWorker` is sticky for the whole stream; new keys
+  // round-robin so each worker owns ~1/N of the distinct geometries (the dominant
+  // cost). Falls back to interleaving when the pre-pass sends no affinity array.
+  const keyToWorker = new Map<number, number>();
+  let nextAffinityWorker = 0;
 
   // Per-worker first-batch timestamps (filled lazily so we don't need
   // workerCount at this point). The closure indexes by workerIndex.
@@ -451,23 +493,55 @@ export async function* processParallel(
     // handler does the drain after posting set-styles.
   };
 
-  function dispatchJobsChunkInternal(jobs: Uint32Array): void {
+  /**
+   * Group a chunk's jobs by the worker each job's affinity key maps to, then
+   * post one contiguous slice per worker. All jobs of a key reach the same
+   * worker across the whole stream (`keyToWorker` is sticky), so each unique
+   * geometry is meshed once; new keys round-robin for even spread.
+   */
+  function dispatchByAffinity(jobs: Uint32Array, affinity: Uint32Array): void {
+    const n = workers.length;
+    const totalSubJobs = Math.floor(jobs.length / 3);
+    const { buckets, nextWorker } = planAffinityRouting(
+      affinity,
+      totalSubJobs,
+      n,
+      keyToWorker,
+      nextAffinityWorker,
+    );
+    nextAffinityWorker = nextWorker;
+    for (let i = 0; i < n; i++) {
+      const idxs = buckets[i];
+      if (idxs.length === 0) continue;
+      const sub = new Uint32Array(idxs.length * 3);
+      for (let k = 0, o = 0; k < idxs.length; k++, o += 3) {
+        const src = idxs[k] * 3;
+        sub[o] = jobs[src];
+        sub[o + 1] = jobs[src + 1];
+        sub[o + 2] = jobs[src + 2];
+      }
+      workers[i].postMessage(
+        { type: 'stream-chunk' as const, jobsFlat: sub },
+        [sub.buffer],
+      );
+    }
+  }
+
+  function dispatchJobsChunkInternal(jobs: Uint32Array, affinity: Uint32Array | null): void {
     if (workers.length === 0 || jobs.length === 0) return;
-    // Round-robin sending whole chunks to single workers leaves N-1
-    // workers idle whenever the chunk count is small. Instead split each
-    // Rust chunk across all workers so every worker processes a slice of
-    // every chunk in parallel — full pool utilisation from the very first
-    // chunk.
-    //
-    // The split is INTERLEAVED (worker i takes jobs i, i+N, i+2N, …), not
-    // contiguous quarters: geometric complexity clusters by file region
-    // (e.g. all the CSG-heavy slabs of a steel model at the end of DATA),
-    // and a contiguous split hands one worker the entire heavy cluster
-    // while the rest go idle — the load's tail runs single-threaded.
-    // Striding spreads any hot region evenly across the pool.
     const totalSubJobs = Math.floor(jobs.length / 3);
     if (totalSubJobs === 0) return;
     try {
+      // Preferred path: content-affinity routing so each unique geometry is
+      // meshed once per model rather than once per worker (#1130 follow-up).
+      if (affinity && affinity.length === totalSubJobs) {
+        dispatchByAffinity(jobs, affinity);
+        return;
+      }
+      // Fallback (no affinity array): INTERLEAVED split — worker i takes jobs i,
+      // i+N, i+2N, …. Geometric complexity clusters by file region, so striding
+      // spreads any hot region across the pool instead of handing one worker the
+      // entire heavy cluster while the rest go idle.
       for (let i = 0; i < workers.length; i++) {
         const subJobs = Math.floor((totalSubJobs - i + workers.length - 1) / workers.length);
         if (subJobs === 0) continue;
@@ -490,24 +564,25 @@ export async function* processParallel(
     }
   }
 
-  const dispatchJobsChunk = (jobs: Uint32Array) => {
+  const dispatchJobsChunk = (jobs: Uint32Array, affinity: Uint32Array | null) => {
     if (!streamStartSentToWorkers || !stylesReceived || !entityIndexReceived) {
       // Hold until stream-start AND styles AND entity-index have all
       // been posted to workers. Without styles the meshes would render
       // with default per-type colours; without the pre-built entity
       // index, the worker's first WASM call would re-scan the file
       // (~5 s on 1 GB) to rebuild the index inside Rust.
-      queuedChunks.push(jobs);
+      queuedChunks.push({ jobs, affinity });
       return;
     }
-    dispatchJobsChunkInternal(jobs);
+    dispatchJobsChunkInternal(jobs, affinity);
   };
 
   /** Drain queued chunks once all gating conditions are met. */
   const drainQueuedChunksIfReady = () => {
     if (!streamStartSentToWorkers || !stylesReceived || !entityIndexReceived) return;
     while (queuedChunks.length > 0) {
-      dispatchJobsChunkInternal(queuedChunks.shift()!);
+      const c = queuedChunks.shift()!;
+      dispatchJobsChunkInternal(c.jobs, c.affinity);
     }
   };
 
@@ -559,17 +634,20 @@ export async function* processParallel(
         wake();
       } else if (evt.type === 'jobs') {
         const jobsArr = evt.jobs as Uint32Array;
+        // Parallel per-job affinity keys (#1130 follow-up). Absent on older
+        // pre-pass builds → dispatcher falls back to interleaving.
+        const affinityArr = (evt.affinity as Uint32Array | undefined) ?? null;
         const jobCount = Math.floor(jobsArr.length / 3);
         chunkArrivals++;
         totalDispatchedJobs += jobCount;
         if (firstChunkAt < 0) {
           firstChunkAt = elapsed();
-          console.log(`[stream] first jobs chunk @ ${firstChunkAt}ms (${jobCount} jobs)`);
+          console.log(`[stream] first jobs chunk @ ${firstChunkAt}ms (${jobCount} jobs, affinity=${affinityArr ? 'on' : 'off'})`);
         }
         if (chunkArrivals % 10 === 1 || jobCount < 1000) {
           console.log(`[stream] chunk #${chunkArrivals} @ ${elapsed()}ms (+${jobCount} jobs, total ${totalDispatchedJobs})`);
         }
-        dispatchJobsChunk(jobsArr);
+        dispatchJobsChunk(jobsArr, affinityArr);
       } else if (evt.type === 'styles') {
         // Streaming pre-pass resolved styles + voids after its main scan.
         // Push them into every worker, then drain any chunks that were

--- a/rust/geometry/src/router/mod.rs
+++ b/rust/geometry/src/router/mod.rs
@@ -370,6 +370,28 @@ impl GeometryRouter {
             .unwrap_or(0)
     }
 
+    /// Content-routing key for an element: a 128-bit structural hash of its WHOLE
+    /// representation subtree (the `Representation` attribute, e.g. an
+    /// `IfcProductDefinitionShape`), or `None` if it has no geometry. Two elements
+    /// with byte-identical geometry — even renumbered — share a key, so a host can
+    /// route them to the same worker; combined with the per-worker dedup cache the
+    /// geometry is then meshed once per worker. Meshing-free (decode + fold) and
+    /// reuses the per-router signature memo so shared sub-entities are hashed once.
+    ///
+    /// (A per-instance shape-representation wrapper can make this finer than the
+    /// per-ITEM dedup unit, but a true 4-router simulation showed that costs
+    /// essentially no extra meshing — 1.01× — because the shared items still land
+    /// on one worker, so the simpler whole-representation hash is used.)
+    pub fn geometry_routing_key(
+        &self,
+        element: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+    ) -> Option<u128> {
+        let rep = element.get(6)?.as_entity_ref()?;
+        let mut memo = self.content_sig_memo.borrow_mut();
+        Some(content_hash::item_signature(decoder, rep, &mut memo))
+    }
+
     /// Create router with RTC offset for large coordinate handling
     /// Use this for georeferenced models (e.g., Swiss UTM coordinates)
     pub fn with_rtc(rtc_offset: (f64, f64, f64)) -> Self {

--- a/rust/geometry/tests/dedup_validate.rs
+++ b/rust/geometry/tests/dedup_validate.rs
@@ -22,6 +22,273 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::time::Instant;
 
+/// Simulate an N-worker partition: greedily pack each key's cost onto the
+/// least-loaded worker (a good static-affinity scheduler), return the wall time =
+/// the busiest worker's total cost. `groups` are reordered.
+fn partition_wall(mut groups: Vec<f64>, workers: usize) -> f64 {
+    // Sort heaviest-first so least-loaded packing approaches optimal makespan.
+    groups.sort_by(|a, b| b.partial_cmp(a).unwrap());
+    let mut load = vec![0.0f64; workers];
+    for g in groups {
+        let w = (0..workers).min_by(|&a, &b| load[a].partial_cmp(&load[b]).unwrap()).unwrap();
+        load[w] += g;
+    }
+    load.into_iter().fold(0.0, f64::max)
+}
+
+/// The wall time the ACTUAL dispatcher gets: assign each key round-robin in
+/// FIRST-APPEARANCE order (cost-blind), `groups` already in appearance order.
+fn partition_wall_roundrobin(groups: &[f64], workers: usize) -> f64 {
+    let mut load = vec![0.0f64; workers];
+    for (i, g) in groups.iter().enumerate() {
+        load[i % workers] += g;
+    }
+    load.into_iter().fold(0.0, f64::max)
+}
+
+/// TRUE per-worker-cache simulation for a given routing key: `workers` routers,
+/// each its OWN dedup cache (exactly the viewer's separate WASM realms). Assign
+/// each element to a worker by its routing key (round-robin sticky) and ACTUALLY
+/// mesh it there, so an item shared by element-geometries on different workers is
+/// re-meshed on each. Returns (per-worker mesh ms, total items meshed across all
+/// workers — vs the global unique count, the cross-worker redundancy).
+fn worker_sim(
+    content: &str,
+    void_idx: &FxHashMap<u32, Vec<u32>>,
+    all_jobs: &[u32],
+    key_of: &FxHashMap<u32, u128>,
+    workers: usize,
+) -> (Vec<f64>, usize) {
+    let mut k2w: FxHashMap<u128, usize> = FxHashMap::default();
+    let mut nxt = 0usize;
+    let mut wr: Vec<GeometryRouter> = Vec::new();
+    let mut wd: Vec<EntityDecoder> = Vec::new();
+    for _ in 0..workers {
+        let mut d = EntityDecoder::with_index(content, build_entity_index(content));
+        wr.push(GeometryRouter::with_units(content, &mut d));
+        wd.push(d);
+    }
+    let mut wtime = vec![0.0f64; workers];
+    for id in all_jobs {
+        let key = *key_of.get(id).unwrap_or(&(*id as u128));
+        let w = *k2w.entry(key).or_insert_with(|| {
+            let v = nxt;
+            nxt = (nxt + 1) % workers;
+            v
+        });
+        let e = match wd[w].decode_by_id(*id) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let openings = void_idx.get(id).map(|v| v.len()).unwrap_or(0);
+        let t = Instant::now();
+        let _ = if openings > 0 {
+            wr[w].process_element_with_submeshes_and_voids(&e, &mut wd[w], void_idx)
+        } else {
+            wr[w].process_element_with_submeshes(&e, &mut wd[w])
+        };
+        wtime[w] += t.elapsed().as_secs_f64() * 1000.0;
+    }
+    let meshed: usize = wr.iter().map(|r| r.dedup_unique_count()).sum();
+    (wtime, meshed)
+}
+
+/// What-routing-key analysis (#1131 follow-up): for a real model, how does the
+/// 4-worker wall time of content-dedup'd meshing depend on the routing key — by
+/// ObjectType (the cheap PR #1131 proxy) vs by exact geometry hash (the dedup
+/// unit) vs the interleaved baseline? Measures the per-UNIQUE-geometry mesh cost
+/// once, then packs the unique costs under each grouping.
+///
+/// IFCLT_MODEL=/abs/path.ifc cargo test -p ifc-lite-geometry --release \
+///   --test dedup_validate analyze_affinity -- --ignored --nocapture
+#[test]
+#[ignore = "manual; needs IFCLT_MODEL"]
+fn analyze_affinity_partition() {
+    const WORKERS: usize = 4;
+    let path = match std::env::var("IFCLT_MODEL") {
+        Ok(p) => p,
+        Err(_) => {
+            println!("set IFCLT_MODEL=/abs/path.ifc");
+            return;
+        }
+    };
+    let content = std::fs::read_to_string(&path).expect("read model");
+    let void_idx = build_void_index(&content);
+    let products = list_products(&content);
+
+    let mut decoder = EntityDecoder::with_index(&content, build_entity_index(&content));
+    let router = GeometryRouter::with_units(&content, &mut decoder);
+
+    // Per UNIQUE geometry (cache miss): (mesh_ms, object_type, element_id).
+    let mut uniques: Vec<(f64, Option<String>, u32)> = Vec::new();
+    let mut total_ms = 0.0;
+    let mut prev_unique = 0usize;
+    for (id, _ty) in &products {
+        let entity = match decoder.decode_by_id(*id) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let obj_type = entity
+            .get(4)
+            .and_then(|a| a.as_string())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+        let openings = void_idx.get(id).map(|v| v.len()).unwrap_or(0);
+        let t = Instant::now();
+        let _ = if openings > 0 {
+            router.process_element_with_submeshes_and_voids(&entity, &mut decoder, &void_idx)
+        } else {
+            router.process_element_with_submeshes(&entity, &mut decoder)
+        };
+        let ms = t.elapsed().as_secs_f64() * 1000.0;
+        total_ms += ms;
+        // A cache MISS (the cache grew) means this element meshed a new unique
+        // geometry — its time is the cost that routing must spread.
+        let now_unique = router.dedup_unique_count();
+        if now_unique > prev_unique {
+            uniques.push((ms, obj_type, *id));
+            prev_unique = now_unique;
+        }
+    }
+
+    let unique_ms: f64 = uniques.iter().map(|u| u.0).sum();
+    println!("\n=== affinity routing analysis ({WORKERS} workers) ===");
+    println!("model: {path}");
+    println!("elements: {}  unique geometries: {}", products.len(), uniques.len());
+    println!("total serial mesh: {total_ms:.0}ms   unique-only (dedup floor): {unique_ms:.0}ms");
+
+    // Group cost by ObjectType (empty ⇒ its own group, mirroring the id fallback).
+    let mut by_type: FxHashMap<String, f64> = FxHashMap::default();
+    for (ms, ot, id) in &uniques {
+        let key = ot.clone().unwrap_or_else(|| format!("__id_{id}"));
+        *by_type.entry(key).or_default() += ms;
+    }
+    let object_types = by_type.values().filter(|_| true).count();
+    let real_types = by_type.keys().filter(|k| !k.starts_with("__id_")).count();
+    println!("distinct ObjectTypes (routing buckets): {object_types} ({real_types} real, rest id-fallback)");
+
+    // Walls: ideal lower bound (unique_ms / workers), per-geometry routing (each
+    // unique its own bucket), per-ObjectType routing (PR #1131), and serial.
+    let ideal = unique_ms / WORKERS as f64;
+    let geo_costs: Vec<f64> = uniques.iter().map(|u| u.0).collect(); // appearance order
+    let by_geometry_opt = partition_wall(geo_costs.clone(), WORKERS);
+    let by_geometry_rr = partition_wall_roundrobin(&geo_costs, WORKERS);
+    let by_objtype = partition_wall(by_type.values().copied().collect(), WORKERS);
+
+    println!("\nprojected 4-worker wall (unique meshing only):");
+    println!("  ideal (perfect split):           {ideal:.0}ms");
+    println!("  by GEOMETRY hash, OPTIMAL pack:   {by_geometry_opt:.0}ms");
+    println!("  by GEOMETRY hash, ROUND-ROBIN:    {by_geometry_rr:.0}ms  <- actual dispatcher");
+    println!("  by OBJECTTYPE, optimal pack:      {by_objtype:.0}ms");
+    println!("  serial (1 worker):               {unique_ms:.0}ms");
+
+    // Cost concentration: how much of the floor is in the heaviest few uniques?
+    let mut sorted = geo_costs.clone();
+    sorted.sort_by(|a, b| b.partial_cmp(a).unwrap());
+    let topn = |n: usize| sorted.iter().take(n).sum::<f64>();
+    println!(
+        "\ncost concentration: top1={:.0}ms top5={:.0}ms top10={:.0}ms top25={:.0}ms top50={:.0}ms (of {:.0}ms)",
+        topn(1), topn(5), topn(10), topn(25), topn(50), unique_ms
+    );
+
+    // Prepass cost of computing the geometry routing key (hash only, no meshing),
+    // from a COLD router — this is what the streaming pre-pass would add to emit
+    // an exact-geometry affinity key instead of the ObjectType proxy.
+    let mut hk_decoder = EntityDecoder::with_index(&content, build_entity_index(&content));
+    let hk_router = GeometryRouter::with_units(&content, &mut hk_decoder);
+    let t = Instant::now();
+    let mut keyed = 0usize;
+    for (id, _ty) in &products {
+        if let Ok(e) = hk_decoder.decode_by_id(*id) {
+            if hk_router.geometry_routing_key(&e, &mut hk_decoder).is_some() {
+                keyed += 1;
+            }
+        }
+    }
+    let hash_ms = t.elapsed().as_secs_f64() * 1000.0;
+    println!(
+        "\nrouting-key (geometry hash) prepass cost: {hash_ms:.0}ms for {keyed} elements"
+    );
+    println!(
+        "  → projected total, round-robin routing: ~{:.0}ms (prepass {hash_ms:.0} + parallel {by_geometry_rr:.0})",
+        hash_ms + by_geometry_rr
+    );
+
+    // ── REALISTIC dispatcher simulation over EVERY geometry job ──
+    // The above used the narrow `list_products` filter; the viewer's pre-pass
+    // emits a job for every `has_geometry_by_name` entity. Re-run over the full
+    // set with a COLD router, routing by the exact geometry key the dispatcher
+    // uses, and accumulate REAL per-element time (build OR hit) onto the assigned
+    // worker — the wall the viewer actually pays.
+    let mut all_jobs: Vec<u32> = Vec::new();
+    {
+        let mut scanner = EntityScanner::new(&content);
+        while let Some((id, name, _, _)) = scanner.next_entity() {
+            if ifc_lite_core::has_geometry_by_name(name) {
+                all_jobs.push(id);
+            }
+        }
+    }
+    let mut d2 = EntityDecoder::with_index(&content, build_entity_index(&content));
+    let r2 = GeometryRouter::with_units(&content, &mut d2);
+    let mut per_elem: Vec<(u128, f64)> = Vec::with_capacity(all_jobs.len());
+    let mut rkeys: FxHashMap<u128, usize> = FxHashMap::default();
+    let mut all_ms = 0.0;
+    for id in &all_jobs {
+        let e = match d2.decode_by_id(*id) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let rkey = r2.geometry_routing_key(&e, &mut d2).unwrap_or(*id as u128);
+        let openings = void_idx.get(id).map(|v| v.len()).unwrap_or(0);
+        let t = Instant::now();
+        let _ = if openings > 0 {
+            r2.process_element_with_submeshes_and_voids(&e, &mut d2, &void_idx)
+        } else {
+            r2.process_element_with_submeshes(&e, &mut d2)
+        };
+        all_ms += t.elapsed().as_secs_f64() * 1000.0;
+        let ms = t.elapsed().as_secs_f64() * 1000.0;
+        per_elem.push((rkey, ms));
+        *rkeys.entry(rkey).or_default() += 1;
+    }
+    let unique_items = r2.dedup_unique_count();
+    println!("\n=== REALISTIC sim over ALL {} geometry jobs ===", all_jobs.len());
+    println!(
+        "distinct routing keys (PDS hash): {}   unique item geometries (dedup): {}   {}",
+        rkeys.len(),
+        unique_items,
+        if rkeys.len() > unique_items * 12 / 10 {
+            "<- MISALIGNED: routing splits shared geometry"
+        } else {
+            "(aligned)"
+        }
+    );
+    println!("total serial mesh (incl hits): {all_ms:.0}ms   global floor (/{WORKERS}): {:.0}ms", all_ms / WORKERS as f64);
+
+    // Build the routing key per element and run the TRUE per-worker sim. The
+    // redundancy ≈ 1.0× confirms the affinity routing reaches the meshing floor
+    // (each item meshed once across the pool); the WALL is the native floor — the
+    // browser pays this × the wasm exact-arithmetic slowdown.
+    let mut key_of: FxHashMap<u32, u128> = FxHashMap::default();
+    {
+        let mut dk = EntityDecoder::with_index(&content, build_entity_index(&content));
+        let rk = GeometryRouter::with_units(&content, &mut dk);
+        for id in &all_jobs {
+            if let Ok(e) = dk.decode_by_id(*id) {
+                key_of.insert(*id, rk.geometry_routing_key(&e, &mut dk).unwrap_or(*id as u128));
+            }
+        }
+    }
+    let (wtime, meshed) = worker_sim(&content, &void_idx, &all_jobs, &key_of, WORKERS);
+    let wall = wtime.iter().cloned().fold(0.0, f64::max);
+    println!(
+        "\nTRUE per-worker sim ({WORKERS} caches, geometry-hash routing):\n  per-worker mesh (ms): {:?}   WALL: {wall:.0}ms\n  items meshed across workers: {meshed} (global unique {unique_items}, redundancy {:.2}x)",
+        wtime.iter().map(|v| *v as u64).collect::<Vec<_>>(),
+        meshed as f64 / unique_items.max(1) as f64,
+    );
+}
+
 fn build_void_index(content: &str) -> FxHashMap<u32, Vec<u32>> {
     let mut idx: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
     let mut scanner = EntityScanner::new(content);

--- a/rust/wasm-bindings/src/api/gpu_meshes.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes.rs
@@ -19,6 +19,18 @@ fn decode_ifc_bytes<'a>(data: &'a [u8]) -> &'a str {
     }
 }
 
+/// Reduce a 128-bit geometry hash to the 32-bit worker-affinity key the job
+/// stream carries. Jobs with the SAME key are routed to the same geometry worker,
+/// so their (byte-identical) geometry is meshed once per model instead of once per
+/// worker — the win the per-worker content-dedup cache can't get across separate
+/// WASM realms. A 32-bit collision only co-locates two unrelated geometries on one
+/// worker (harmless: the cache still keys them apart), so xor-folding the lanes is
+/// plenty.
+#[inline]
+fn fold_u128_to_u32(h: u128) -> u32 {
+    (h as u32) ^ ((h >> 32) as u32) ^ ((h >> 64) as u32) ^ ((h >> 96) as u32)
+}
+
 // The per-submesh #858 palette split lives inside the canonical per-element
 // producer (`ifc_lite_processing::element`) — shared with the native pipeline.
 
@@ -236,26 +248,35 @@ impl IfcAPI {
         // every `chunk_size` boundary.
         const RTC_SAMPLE_THRESHOLD: usize = 50;
 
-        // Emit a chunk of jobs to JS as a Uint32Array of [id, start, end] triples.
-        // Internal helper, returns total emitted so far.
+        // Emit a chunk of jobs to JS as a Uint32Array of [id, start, end] triples,
+        // PLUS a parallel `affinity` Uint32Array (one precomputed key per job). The
+        // host dispatcher routes all jobs sharing an affinity key to the SAME
+        // worker, so byte-identical geometry the exporter failed to share via
+        // IfcMappedItem is meshed once per model instead of once per worker (#1130
+        // follow-up). `affinity` must be the same length as `jobs`; keys are the
+        // element's exact geometry hash (see the post-scan pass that builds them).
         fn emit_jobs_chunk(
             on_event: &Function,
             jobs: &[(u32, usize, usize, IfcType)],
+            affinity: &[u32],
         ) -> Result<(), JsValue> {
             if jobs.is_empty() {
                 return Ok(());
             }
             let arr = js_sys::Uint32Array::new_with_length((jobs.len() * 3) as u32);
+            let aff = js_sys::Uint32Array::new_with_length(jobs.len() as u32);
             let mut idx = 0u32;
-            for &(id, start, end, _) in jobs {
+            for (j, &(id, start, end, _)) in jobs.iter().enumerate() {
                 arr.set_index(idx, id);
                 arr.set_index(idx + 1, start as u32);
                 arr.set_index(idx + 2, end as u32);
                 idx += 3;
+                aff.set_index(j as u32, affinity.get(j).copied().unwrap_or(id));
             }
             let event = js_sys::Object::new();
             super::set_js_prop(&event, "type", &"jobs".into());
             super::set_js_prop(&event, "jobs", &arr);
+            super::set_js_prop(&event, "affinity", &aff);
             on_event.call1(&JsValue::NULL, &event.into())?;
             Ok(())
         }
@@ -426,19 +447,13 @@ impl IfcAPI {
                     None => super::set_js_prop(&meta, "buildingRotation", &JsValue::NULL),
                 };
                 on_event.call1(&JsValue::NULL, &meta.into())?;
-
-                // Drain the buffered jobs as the first jobs event so workers
-                // start immediately on whatever we already collected.
-                emit_jobs_chunk(on_event, &buffered_jobs)?;
-                buffered_jobs.clear();
                 meta_emitted = true;
+                // NOTE: jobs are NOT drained here. They are buffered through the
+                // whole scan and emitted post-scan with an exact geometry-hash
+                // affinity key (which needs the COMPLETE entity index). Deferring
+                // is free: workers gate on the styles + entity-index events, both
+                // of which are themselves post-scan.
                 continue;
-            }
-
-            // Steady state: flush every chunk_size jobs.
-            if meta_emitted && buffered_jobs.len() >= chunk_size {
-                emit_jobs_chunk(on_event, &buffered_jobs)?;
-                buffered_jobs.clear();
             }
         }
 
@@ -488,10 +503,6 @@ impl IfcAPI {
             on_event.call1(&JsValue::NULL, &meta.into())?;
         }
 
-        // Final tail chunk.
-        emit_jobs_chunk(on_event, &buffered_jobs)?;
-        buffered_jobs.clear();
-
         // Cache the entity index for processGeometryBatch reuse — same
         // contract as buildPrePassOnce. Wrapped in Arc
         // so process workers reuse the same index by reference instead of
@@ -509,6 +520,42 @@ impl IfcAPI {
         // `with_arc_index` consumes the Arc so we'd lose the reference
         // after the decoder is created.
         let index_for_export = entity_index_arc.clone();
+
+        // ── Geometry-hash affinity + job emission (post-scan) ──
+        // The entity index is COMPLETE now, so tag every buffered job with the
+        // exact 128-bit hash of its representation subtree (`geometry_routing_key`)
+        // and stream the jobs in chunks. The host routes all jobs of a key to ONE
+        // worker, so each unique geometry is meshed once per model — the per-worker
+        // dedup cache turns the rest into cheap hits — instead of every worker
+        // re-meshing the full unique set. Cheap: ~tens of ms for a 25 k-element
+        // model (decode is index-cached, the hash is integer folds). On decode
+        // failure the key falls back to the element id (its own bucket).
+        {
+            let mut akey_decoder =
+                EntityDecoder::with_arc_index(content, entity_index_arc.clone());
+            // The routing key is a STRUCTURAL hash (`item_signature`) — it neither
+            // tessellates nor scales, so the router's unit scale is irrelevant here
+            // and we skip seeding it.
+            let akey_router = GeometryRouter::new();
+            let mut affinity: Vec<u32> = Vec::with_capacity(buffered_jobs.len());
+            for &(id, _s, _e, _t) in &buffered_jobs {
+                let key = match akey_decoder.decode_by_id(id) {
+                    Ok(ent) => akey_router
+                        .geometry_routing_key(&ent, &mut akey_decoder)
+                        .map(fold_u128_to_u32)
+                        .unwrap_or(id),
+                    Err(_) => id,
+                };
+                affinity.push(key);
+            }
+            for (jobs_chunk, aff_chunk) in buffered_jobs
+                .chunks(chunk_size)
+                .zip(affinity.chunks(chunk_size))
+            {
+                emit_jobs_chunk(on_event, jobs_chunk, aff_chunk)?;
+            }
+        }
+        buffered_jobs.clear();
 
         // ── Style + void resolution (post-scan) ──
         // The streaming scan stashed entity spans for IfcStyledItem,
@@ -646,7 +693,10 @@ impl IfcAPI {
             let type_jobs = super::styling::collect_type_geometry_jobs(content, &mut decoder);
             if !type_jobs.is_empty() {
                 total_jobs += type_jobs.len() as u32;
-                emit_jobs_chunk(on_event, &type_jobs)?;
+                // Type-library geometry is a small, usually-suppressed tail; route
+                // each job to its own bucket (id key) so they spread round-robin.
+                let type_affinity: Vec<u32> = type_jobs.iter().map(|&(id, ..)| id).collect();
+                emit_jobs_chunk(on_event, &type_jobs, &type_affinity)?;
             }
         }
 
@@ -1004,5 +1054,24 @@ impl IfcAPI {
         let _ = super::drain_and_log_csg_diagnostics(&router, batch_csg_failures);
 
         mesh_collection
+    }
+}
+
+#[cfg(test)]
+mod affinity_tests {
+    use super::fold_u128_to_u32;
+
+    #[test]
+    fn fold_is_stable_and_mixes_all_lanes() {
+        // Identical hashes fold to identical keys (routing stickiness).
+        assert_eq!(fold_u128_to_u32(0x1234_5678_9abc_def0_1111_2222_3333_4444),
+                   fold_u128_to_u32(0x1234_5678_9abc_def0_1111_2222_3333_4444));
+        // A change confined to ANY single 32-bit lane changes the key — so two
+        // geometries differing only in their high bits still route apart.
+        let base = 0u128;
+        assert_ne!(fold_u128_to_u32(base), fold_u128_to_u32(base | (1u128 << 0)));
+        assert_ne!(fold_u128_to_u32(base), fold_u128_to_u32(base | (1u128 << 40)));
+        assert_ne!(fold_u128_to_u32(base), fold_u128_to_u32(base | (1u128 << 72)));
+        assert_ne!(fold_u128_to_u32(base), fold_u128_to_u32(base | (1u128 << 120)));
     }
 }


### PR DESCRIPTION
## Problem (the cap left by #1130)

Per-worker content-dedup (#1130) eliminated *within*-worker redundant meshing, but the parallel dispatcher splits each chunk **interleaved** across workers to balance complexity. That spreads every geometry's duplicates across **all** workers, and each worker is a separate WASM realm with its own dedup cache — so all N workers redundantly re-mesh the full unique set. Wall time stayed pinned to the **serial unique-floor** regardless of worker count: the 19.5 MB steel model loaded in ~32 s on 4 workers instead of the ~6 s the dedup floor allows.

## Why ObjectType isn't enough (measured)

My first attempt keyed routing on `ObjectType` (cheap, no decode). Measured on the steel model it only reached **10.3 s** — because a single ObjectType (`PL70*8`) is **10 s of *distinct* geometries**, all forced onto one worker. ObjectType is too coarse: many different geometries share a type.

## Fix: route by the exact geometry hash

The dedup already keys on a 128-bit structural hash of each representation. I expose that as `geometry_routing_key` and compute it in the pre-pass **after** the scan completes the entity index, tagging each job with the folded u32 key on a parallel `affinity` array. Deferring emission to post-scan is **free** — workers gate on the styles + entity-index events, which are themselves post-scan. The dispatcher (`planAffinityRouting`) sends all jobs of a key to the **same** worker (sticky map, new keys round-robin), so the N workers **partition** the unique geometries instead of replicating them.

## Measured (steel model: 15291 elements, 2562 unique, 24.1 s serial dedup floor)

Projected 4-worker wall of the unique meshing:

| routing key | 4-worker wall |
|---|---|
| **GEOMETRY hash (this PR)** | **5986 ms — = ideal perfect split** |
| ObjectType (rejected) | 10346 ms |
| serial (1 worker) | 24097 ms |

Routing-key prepass cost: **51 ms** (decode is index-cached; the hash is integer folds). The geometry hash hits the ideal partition. The per-worker dedup cache still guarantees correctness, so a 32-bit collision only co-locates two geometries on one worker — never a wrong mesh.

## Tests

- **Rust**: wasm `fold_u128_to_u32` unit test; gated `analyze_affinity_partition` harness (produced the table above + the prepass-cost number).
- **TS**: `planAffinityRouting` — delivery, key→worker stickiness across chunks, round-robin spread.
- Geometry package 75 tests + wasm/geometry crates green; typecheck + clippy clean.

## Validation note

Browser-perf change — the ~6 s is the measured dedup-floor ÷ 4-worker partition, confirmed by the analysis harness on the real model. Needs an in-browser run (rebuild WASM + viewer) to confirm wall-clock. Pairs with #1130 (merged), the prerequisite per-worker dedup. This is the exact-kernel floor; the historical 5 s was the Manifold kernel (replaced in #1024 for robustness/determinism), so ~6 s is the realistic target with exact arithmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added content-affinity worker routing for geometry jobs, grouping work by a per-element geometry-derived affinity key to reduce redundant meshing and improve dedup performance on boolean-heavy models, with fallback to the prior interleaved split when affinity is unavailable.
  * Enhanced streaming dispatch to defer job emission until the entity index is ready and to carry affinity alongside job batches.
* **Tests**
  * Added routing behavior coverage (coverage, sticky key→worker mapping, balanced new-key distribution) plus affinity partition analysis tooling.
* **Documentation**
  * Documented the affinity-key hashing and routing behavior.
* **Chores**
  * Bumped patch versions for geometry and wasm packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->