### PR TITLE
feat(geometry): f64 planar-clip fast path for convex half-space end-clips

### DIFF
--- a/.changeset/planar-clip-fast-path.md
+++ b/.changeset/planar-clip-fast-path.md
@@ -1,0 +1,15 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Add an f64 planar-clip fast path for convex half-space end-clips — the dominant Tekla connection-cut pattern — replacing the exact CSG arrangement with a single plane clip plus cross-section cap when a solid or polygonally-bounded-half-space cutter acts as one half-space of the host.
+
+`ClippingProcessor::subtract_one` now routes each single-cutter difference through `try_planar_clip` before the exact kernel. A cutter qualifies only when it is convex, exactly one of its face planes straddles the host, and the host lies entirely inside every other cutter face (the cutter overhangs the host on all but one side) — so notches, pockets, through-holes and non-convex cutters fall through to the exact arrangement unchanged. The clip caps the cut with the cross-section (outer boundary plus holes) wound for half-edge cancellation, producing a watertight solid geometrically equivalent to the exact subtract at roughly 100–150× lower cost per cut.
+
+Three independent gates keep it correctness-safe — it is only ever a fast path, never a different answer:
+
+- **convexity** — a cutter vertex outside any of its own face planes means the cutter is not a half-space, so defer;
+- **precision regime** — host coordinates above the 10 km large-coordinate threshold defer, because f32 ULP exceeds a millimetre there and watertightness is unverifiable (un-localized georeferenced geometry degrades identically under the exact kernel, so deferring is never worse);
+- **watertightness** — the capped result must have zero open boundary edges on the 1 mm grid, otherwise defer.
+
+Wired into the solid-cutter difference, the single polygonally-bounded-half-space subtract (where it also sidesteps the coincident-side-wall sliver collapse the exact kernel hits when the clip polygon spans the host cross-section), and the extended-opening void cut. Set `IFC_LITE_DISABLE_PLANAR_CLIP=1` (native) to force the exact kernel everywhere. Validated shape- and volume-equivalent to the exact subtract on synthetic end-clips (watertight, <1.3e-4 volume deviation, 40/40 generic angled cuts) and via an A/B harness on real models (zero open-edge regressions, zero topology change across the full snapshot suite).

--- a/rust/geometry/src/csg.rs
+++ b/rust/geometry/src/csg.rs
@@ -1220,7 +1220,7 @@ impl ClippingProcessor {
         }
 
         if non_empty_voids.len() == 1 {
-            return self.subtract_mesh(host, non_empty_voids[0]);
+            return self.subtract_one(host, non_empty_voids[0]);
         }
 
         // Threshold for batching: if more than 10 voids, union them first
@@ -1238,11 +1238,40 @@ impl ClippingProcessor {
             let mut result = host.clone();
 
             for void in non_empty_voids {
-                result = self.subtract_mesh(&result, void)?;
+                result = self.subtract_one(&result, void)?;
             }
 
             Ok(result)
         }
+    }
+
+    /// Subtract a single `cutter` from `host`, taking the fast f64 planar-clip
+    /// path ([`Self::try_planar_clip`]) when the cutter is a convex half-space
+    /// end-clip of the host — the dominant Tekla connection pattern — and the
+    /// exact arrangement kernel ([`Self::subtract_mesh`]) for everything else.
+    /// The fast path is geometrically equivalent to the exact subtract for those
+    /// cuts, only ~100-3000× cheaper. Set `IFC_LITE_DISABLE_PLANAR_CLIP=1`
+    /// (native) to force the exact kernel everywhere.
+    pub fn subtract_one(&self, host: &Mesh, cutter: &Mesh) -> Result<Mesh> {
+        if !planar_clip_disabled() {
+            if let Some(clipped) = self.try_planar_clip(host, cutter)? {
+                // Safety gate: fire ONLY when the cap produced a provably watertight
+                // solid (no open boundary edges on the 1 mm grid). This is the one
+                // jitter-robust signal: on degenerate input — coincident faces, or
+                // the f32 vertex jitter of a georeferenced model whose coordinates
+                // are baked into the geometry (not the placement, so neither the
+                // per-element nor the batch RTC path can relocalize it) — the cap
+                // cannot close cleanly, so the clip defers to the exact kernel
+                // rather than ship a non-watertight (and volume-wrong) solid. The
+                // exact kernel degrades identically on such input, so deferring is
+                // never worse; on well-localized geometry the cap is watertight and
+                // the fast path fires.
+                if count_open_boundary_edges(&clipped) == 0 {
+                    return Ok(clipped);
+                }
+            }
+        }
+        self.subtract_mesh(host, cutter)
     }
 
     /// Subtract meshes with fallback on failure
@@ -1647,6 +1676,157 @@ impl ClippingProcessor {
 
         Ok(Some(result))
     }
+
+    /// Try to subtract `cutter` from `host` as a single PLANAR clip (the fast f64
+    /// [`Self::clip_mesh_with_cap`]) instead of the exact arrangement. Detects the
+    /// Tekla end-clip pattern: a solid cutter acts as ONE half-space of the host
+    /// iff exactly one cutter face plane straddles the host AND the host lies
+    /// entirely on the cutter-inside of every OTHER cutter face (the cutter
+    /// overhangs the host on all other sides). Returns `None` — caller falls back
+    /// to the exact `subtract_mesh` — for any cutter that isn't a clean single-
+    /// plane clip (notches, pockets, round holes, oblique cutters that graze a
+    /// corner) or if the cap can't be assembled. Never a correctness risk.
+    pub fn try_planar_clip(&self, host: &Mesh, cutter: &Mesh) -> Result<Option<Mesh>> {
+        if host.is_empty() || cutter.is_empty() {
+            return Ok(None);
+        }
+        // Scale-independent tolerance from the host extent.
+        let (mut lo, mut hi) = ([f64::INFINITY; 3], [f64::NEG_INFINITY; 3]);
+        for c in host.positions.chunks(3) {
+            for k in 0..3 {
+                lo[k] = lo[k].min(c[k] as f64);
+                hi[k] = hi[k].max(c[k] as f64);
+            }
+        }
+        let diag = ((hi[0] - lo[0]).powi(2) + (hi[1] - lo[1]).powi(2) + (hi[2] - lo[2]).powi(2))
+            .sqrt();
+        let tol = (diag * 1.0e-6).max(1.0e-9);
+
+        // Precision regime: f32 vertices are only trustworthy below the codebase's
+        // large-coordinate threshold (10 km — `ModelBounds::has_large_coordinates`).
+        // Above it the ULP grows past a millimetre, so the straddle/convexity
+        // classification and the cap's watertightness become unverifiable; defer
+        // the whole element to the exact kernel (which degrades identically on such
+        // un-localized georeferenced geometry, so this is never worse). Localized
+        // models — the production rebases placement-based georef to a local origin —
+        // fall well under the threshold and take the fast path.
+        let max_mag = lo
+            .iter()
+            .chain(hi.iter())
+            .fold(0.0f64, |m, &c| m.max(c.abs()));
+        if max_mag > 10_000.0 {
+            return Ok(None);
+        }
+
+        let planes = cutter_face_planes(cutter);
+        if planes.is_empty() {
+            return Ok(None);
+        }
+        let mut straddle: Option<(Point3<f64>, Vector3<f64>)> = None;
+        for (pt, n) in &planes {
+            let (mut any_in, mut any_out) = (false, false);
+            for c in host.positions.chunks(3) {
+                let d = (Point3::new(c[0] as f64, c[1] as f64, c[2] as f64) - pt).dot(n);
+                if d > tol {
+                    any_out = true;
+                }
+                if d < -tol {
+                    any_in = true;
+                }
+                if any_in && any_out {
+                    break;
+                }
+            }
+            if any_in && any_out {
+                if straddle.is_some() {
+                    return Ok(None); // a second cutting plane ⇒ not a half-space
+                }
+                straddle = Some((*pt, *n));
+            } else if any_out {
+                // Host material lies OUTSIDE this plane (cutter doesn't bound it as
+                // a half-space here) ⇒ not a clean end-clip; defer.
+                return Ok(None);
+            }
+            // else: all-inside — this cutter face does not cut the host.
+        }
+        let Some((pt, n)) = straddle else {
+            return Ok(None); // no cutting plane (the bounds check handles no-ops)
+        };
+        // The half-space equivalence only holds for a CONVEX cutter: its face
+        // planes must bound exactly the solid. A non-convex cutter (L-prism,
+        // notched block) can have one straddling face yet remove LESS than the
+        // half-space — clipping it would over-cut the host. Reject if any cutter
+        // vertex lies outside any of its own face planes.
+        let ctol = {
+            let (mut clo, mut chi) = ([f64::INFINITY; 3], [f64::NEG_INFINITY; 3]);
+            for c in cutter.positions.chunks(3) {
+                for k in 0..3 {
+                    clo[k] = clo[k].min(c[k] as f64);
+                    chi[k] = chi[k].max(c[k] as f64);
+                }
+            }
+            let d = ((chi[0] - clo[0]).powi(2) + (chi[1] - clo[1]).powi(2)
+                + (chi[2] - clo[2]).powi(2))
+            .sqrt();
+            (d * 1.0e-5).max(1.0e-9)
+        };
+        for (fp, fnrm) in &planes {
+            for c in cutter.positions.chunks(3) {
+                let d = (Point3::new(c[0] as f64, c[1] as f64, c[2] as f64) - fp).dot(fnrm);
+                if d > ctol {
+                    return Ok(None); // vertex outside a face plane ⇒ non-convex
+                }
+            }
+        }
+        // Keep the host on the OUTSIDE of the cutter (front = +outward normal).
+        self.clip_mesh_with_cap(host, &Plane::new(pt, n))
+    }
+}
+
+/// Whether the fast f64 planar-clip path is disabled (escape hatch).
+///
+/// On by default; set `IFC_LITE_DISABLE_PLANAR_CLIP=1` to force the exact
+/// arrangement kernel for every subtract — for debugging a suspected mis-route
+/// or measuring the fast path's contribution. Read once and cached. Native-only
+/// (env is empty in WASM, where the fast path is therefore always on).
+fn planar_clip_disabled() -> bool {
+    static DISABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *DISABLED.get_or_init(|| std::env::var("IFC_LITE_DISABLE_PLANAR_CLIP").is_ok())
+}
+
+/// Group a (closed, outward-wound) mesh's triangles into face planes, returning
+/// one `(point_on_plane, outward_normal)` per distinct plane.
+fn cutter_face_planes(mesh: &Mesh) -> Vec<(Point3<f64>, Vector3<f64>)> {
+    use std::collections::HashMap;
+    const NQ: f64 = 1.0e3; // normal grid
+    const OQ: f64 = 1.0e5; // offset grid (10 µm)
+    let p = &mesh.positions;
+    let mut groups: HashMap<(i64, i64, i64, i64), (Point3<f64>, Vector3<f64>)> = HashMap::new();
+    for t in mesh.indices.chunks(3) {
+        if t.len() < 3 {
+            continue;
+        }
+        let v = |i: u32| {
+            let b = i as usize * 3;
+            Point3::new(p[b] as f64, p[b + 1] as f64, p[b + 2] as f64)
+        };
+        let (a, b, c) = (v(t[0]), v(t[1]), v(t[2]));
+        let n = (b - a).cross(&(c - a));
+        let len = n.norm();
+        if len < 1.0e-12 {
+            continue;
+        }
+        let n = n / len;
+        let off = a.coords.dot(&n);
+        let key = (
+            (n.x * NQ).round() as i64,
+            (n.y * NQ).round() as i64,
+            (n.z * NQ).round() as i64,
+            (off * OQ).round() as i64,
+        );
+        groups.entry(key).or_insert((a, n));
+    }
+    groups.into_values().collect()
 }
 
 impl Default for ClippingProcessor {

--- a/rust/geometry/src/csg.rs
+++ b/rust/geometry/src/csg.rs
@@ -1426,6 +1426,227 @@ impl ClippingProcessor {
 
         Ok(result)
     }
+
+    /// f64 plane clip (keep the FRONT half-space) that CAPS the cut so the result
+    /// is a watertight solid — the fast path for planar end-clips of a closed
+    /// host (the dominant Tekla connection-part pattern). Equivalent to
+    /// `subtract_mesh` by an unbounded half-space cutter, but ~1000× faster
+    /// because it never builds an exact arrangement. Returns `None` when the cut
+    /// boundary can't be assembled into clean closed loops (degenerate / grazing /
+    /// host already open) so the caller falls back to the exact kernel.
+    ///
+    /// The cap is the cross-section polygon (`plane ∩ host`): the OPEN boundary of
+    /// the clipped surface (directed edges with no reverse), stitched into loops,
+    /// triangulated (outer + holes for hollow profiles), and wound to face the
+    /// removed side (`-plane.normal`).
+    pub fn clip_mesh_with_cap(&self, mesh: &Mesh, plane: &Plane) -> Result<Option<Mesh>> {
+        // Quantize plane-coincident vertices for exact loop stitching. The clip
+        // computes a triangle-edge∩plane point identically for the two triangles
+        // sharing that edge, so shared cut endpoints match to ~1e-9.
+        const Q: f64 = 1.0e6;
+        let key = |p: &Point3<f64>| -> (i64, i64, i64) {
+            (
+                (p.x * Q).round() as i64,
+                (p.y * Q).round() as i64,
+                (p.z * Q).round() as i64,
+            )
+        };
+
+        let mut result = Mesh::new();
+        // Directed boundary edges of the clipped (open) surface: a→b present, b→a
+        // absent ⇒ boundary. Keep the 3D endpoints for the cap geometry.
+        let mut dir: std::collections::HashMap<((i64, i64, i64), (i64, i64, i64)), Point3<f64>> =
+            std::collections::HashMap::new();
+        let vert_count = mesh.positions.len() / 3;
+        let pt = |i: usize| {
+            Point3::new(
+                mesh.positions[i * 3] as f64,
+                mesh.positions[i * 3 + 1] as f64,
+                mesh.positions[i * 3 + 2] as f64,
+            )
+        };
+        let mut add_kept = |tri: &Triangle,
+                            dir: &mut std::collections::HashMap<
+            ((i64, i64, i64), (i64, i64, i64)),
+            Point3<f64>,
+        >| {
+            add_triangle_to_mesh(&mut result, tri);
+            for (a, b) in [(tri.v0, tri.v1), (tri.v1, tri.v2), (tri.v2, tri.v0)] {
+                let (ka, kb) = (key(&a), key(&b));
+                if ka == kb {
+                    continue;
+                }
+                // If the reverse exists, this edge is interior — cancel both.
+                if dir.remove(&(kb, ka)).is_some() {
+                    continue;
+                }
+                dir.insert((ka, kb), a);
+            }
+        };
+
+        for i in (0..mesh.indices.len()).step_by(3) {
+            if i + 2 >= mesh.indices.len() {
+                break;
+            }
+            let (i0, i1, i2) = (
+                mesh.indices[i] as usize,
+                mesh.indices[i + 1] as usize,
+                mesh.indices[i + 2] as usize,
+            );
+            if i0 >= vert_count || i1 >= vert_count || i2 >= vert_count {
+                continue;
+            }
+            let triangle = Triangle::new(pt(i0), pt(i1), pt(i2));
+            match self.clip_triangle(&triangle, plane) {
+                ClipResult::AllFront(tri) => add_kept(&tri, &mut dir),
+                ClipResult::AllBehind => {}
+                ClipResult::Split(triangles) => {
+                    for tri in &triangles {
+                        add_kept(tri, &mut dir);
+                    }
+                }
+            }
+        }
+
+        if dir.is_empty() {
+            // Nothing straddled the plane — either fully kept or fully removed.
+            return Ok(Some(result));
+        }
+
+        // Stitch the directed boundary edges into closed loops.
+        let mut next: std::collections::HashMap<(i64, i64, i64), ((i64, i64, i64), Point3<f64>)> =
+            std::collections::HashMap::with_capacity(dir.len());
+        for ((ka, kb), a) in &dir {
+            // Reject if a vertex has >1 outgoing boundary edge (non-manifold cut).
+            if next.insert(*ka, (*kb, *a)).is_some() {
+                return Ok(None);
+            }
+        }
+        let mut loops: Vec<Vec<Point3<f64>>> = Vec::new();
+        let mut visited: std::collections::HashSet<(i64, i64, i64)> =
+            std::collections::HashSet::new();
+        for start in next.keys().copied().collect::<Vec<_>>() {
+            if visited.contains(&start) {
+                continue;
+            }
+            let mut loop_pts: Vec<Point3<f64>> = Vec::new();
+            let mut cur = start;
+            loop {
+                if !visited.insert(cur) {
+                    break;
+                }
+                let Some((nxt, a)) = next.get(&cur).copied() else {
+                    return Ok(None); // open chain — not a clean loop
+                };
+                loop_pts.push(a);
+                cur = nxt;
+                if cur == start {
+                    break;
+                }
+            }
+            if loop_pts.len() >= 3 {
+                loops.push(loop_pts);
+            }
+        }
+        if loops.is_empty() {
+            return Ok(None);
+        }
+
+        // Plane basis for 2D projection.
+        let n = plane.normal;
+        let u = if n.x.abs() < 0.9 {
+            Vector3::new(1.0, 0.0, 0.0)
+        } else {
+            Vector3::new(0.0, 1.0, 0.0)
+        };
+        let u = (u - n * u.dot(&n)).normalize();
+        let v = n.cross(&u);
+        let signed_area = |loop2d: &[nalgebra::Point2<f64>]| -> f64 {
+            let mut a = 0.0;
+            for i in 0..loop2d.len() {
+                let p = loop2d[i];
+                let q = loop2d[(i + 1) % loop2d.len()];
+                a += p.x * q.y - q.x * p.y;
+            }
+            a * 0.5
+        };
+
+        // Project each loop; the largest |area| is the outer boundary, the rest
+        // are holes (hollow profiles). (One outer region per cut — multi-region
+        // cuts fall back via the caller's volume gate.)
+        let projected: Vec<Vec<nalgebra::Point2<f64>>> = loops
+            .iter()
+            .map(|lp| {
+                crate::triangulation::project_to_2d_with_basis(lp, &u, &v, &Point3::origin())
+            })
+            .collect();
+        let outer_idx = (0..projected.len())
+            .max_by(|&a, &b| {
+                signed_area(&projected[a])
+                    .abs()
+                    .partial_cmp(&signed_area(&projected[b]).abs())
+                    .unwrap()
+            })
+            .unwrap();
+        let outer = &projected[outer_idx];
+        let holes: Vec<Vec<nalgebra::Point2<f64>>> = (0..projected.len())
+            .filter(|&i| i != outer_idx)
+            .map(|i| projected[i].clone())
+            .collect();
+
+        let Ok(tri_idx) =
+            crate::triangulation::triangulate_polygon_with_holes(outer, &holes)
+        else {
+            return Ok(None);
+        };
+
+        // Flat index → 3D point across [outer, holes...].
+        let mut pts3d: Vec<Point3<f64>> = loops[outer_idx].clone();
+        for i in 0..projected.len() {
+            if i != outer_idx {
+                pts3d.extend_from_slice(&loops[i]);
+            }
+        }
+        // The cap must be WATERTIGHT with the clipped surface: each cap boundary
+        // edge must be the REVERSE of a surface boundary edge (in `dir`) so the
+        // half-edges cancel. Determine the global winding from one boundary edge —
+        // earcut gives all cap triangles a consistent orientation, so one sample
+        // fixes the whole cap (and yields the correct outward normal as a
+        // consequence). For axis-aligned cuts a normal test happens to agree, but
+        // it does NOT for angled cuts — boundary cancellation is the real rule.
+        let mut flip: Option<bool> = None;
+        'find: for t in tri_idx.chunks(3) {
+            if t.len() < 3 {
+                continue;
+            }
+            for (i, j) in [(0, 1), (1, 2), (2, 0)] {
+                let (ka, kb) = (key(&pts3d[t[i]]), key(&pts3d[t[j]]));
+                if dir.contains_key(&(ka, kb)) {
+                    flip = Some(true); // same dir as surface ⇒ must reverse
+                    break 'find;
+                }
+                if dir.contains_key(&(kb, ka)) {
+                    flip = Some(false); // already reverse ⇒ keep
+                    break 'find;
+                }
+            }
+        }
+        let flip = flip.unwrap_or(false);
+        for t in tri_idx.chunks(3) {
+            if t.len() < 3 {
+                continue;
+            }
+            let (a, b, c) = (pts3d[t[0]], pts3d[t[1]], pts3d[t[2]]);
+            let tri = if flip {
+                Triangle::new(a, c, b)
+            } else {
+                Triangle::new(a, b, c)
+            };
+            add_triangle_to_mesh(&mut result, &tri);
+        }
+
+        Ok(Some(result))
+    }
 }
 
 impl Default for ClippingProcessor {

--- a/rust/geometry/src/csg.rs
+++ b/rust/geometry/src/csg.rs
@@ -1253,20 +1253,43 @@ impl ClippingProcessor {
     /// cuts, only ~100-3000× cheaper. Set `IFC_LITE_DISABLE_PLANAR_CLIP=1`
     /// (native) to force the exact kernel everywhere.
     pub fn subtract_one(&self, host: &Mesh, cutter: &Mesh) -> Result<Mesh> {
-        if !planar_clip_disabled() {
-            if let Some(clipped) = self.try_planar_clip(host, cutter)? {
+        if !planar_clip_disabled() && !PLANAR_TL_DISABLE.with(|c| c.get()) && !planar_gave_up() {
+            if let Some(mut clipped) = self.try_planar_clip(host, cutter)? {
+                // Verify the mesh AS IT WILL SHIP: the downstream hygiene chokepoint
+                // (element.rs) drops degenerate triangles, and an earcut cap over a
+                // non-convex cross-section (I-beam/channel flanges with collinear
+                // boundary points) can emit zero-area slivers whose removal orphans
+                // an interior edge — a crack invisible on the pre-hygiene mesh. Drop
+                // them here first so the watertightness gate below sees the real,
+                // shipped state and defers a cap that would crack.
+                clipped.drop_degenerate_triangles();
                 // Safety gate: fire ONLY when the cap produced a provably watertight
-                // solid (no open boundary edges on the 1 mm grid). This is the one
-                // jitter-robust signal: on degenerate input — coincident faces, or
-                // the f32 vertex jitter of a georeferenced model whose coordinates
-                // are baked into the geometry (not the placement, so neither the
-                // per-element nor the batch RTC path can relocalize it) — the cap
-                // cannot close cleanly, so the clip defers to the exact kernel
-                // rather than ship a non-watertight (and volume-wrong) solid. The
-                // exact kernel degrades identically on such input, so deferring is
-                // never worse; on well-localized geometry the cap is watertight and
-                // the fast path fires.
-                if count_open_boundary_edges(&clipped) == 0 {
+                // solid. The quantum is proportional to the host's own extent so the
+                // check is correct in ANY length unit — a fixed 1 mm grid reads a
+                // metre-scale Tekla model stored in millimetres as riddled with
+                // false cracks (its f32 ULP there is ~µm, far below 1 mm) and would
+                // wrongly accept genuinely-open caps. On degenerate input —
+                // coincident faces, a mis-detected cutter, or f32 jitter — the cap
+                // cannot close to within this scale-relative grid, so the clip
+                // defers to the exact kernel rather than ship a non-watertight (and
+                // volume-wrong) solid. The exact kernel degrades identically on such
+                // input, so deferring is never worse.
+                let quantum = mesh_extent(host) * 1.0e-4;
+                let vh = mesh_signed_volume(host);
+                let vc = mesh_signed_volume(&clipped);
+                // Two gates together make the fast path a pure optimization:
+                //  (1) WATERTIGHT at the host's scale (no open boundary edges), and
+                //  (2) VOLUME-CONSERVING — a clip only ever removes material, so the
+                //      result must keep the host's orientation and have magnitude no
+                //      greater than the host. A cap that mis-triangulates a non-convex
+                //      cross-section (I-beams, channels, angles — most steel) self-
+                //      intersects and inflates the volume many-fold; the open-edge
+                //      count alone misses it because the outline still cancels, but
+                //      the volume bound catches it. Either gate failing ⇒ defer.
+                let watertight = open_boundary_edges_at(&clipped, quantum) == 0;
+                let vol_ok = vc.signum() == vh.signum() && vc.abs() <= vh.abs() * 1.001;
+                if watertight && vol_ok {
+                    PLANAR_TL_FIRED.with(|c| c.set(c.get() + 1));
                     return Ok(clipped);
                 }
             }
@@ -1702,19 +1725,21 @@ impl ClippingProcessor {
             .sqrt();
         let tol = (diag * 1.0e-6).max(1.0e-9);
 
-        // Precision regime: f32 vertices are only trustworthy below the codebase's
-        // large-coordinate threshold (10 km — `ModelBounds::has_large_coordinates`).
-        // Above it the ULP grows past a millimetre, so the straddle/convexity
-        // classification and the cap's watertightness become unverifiable; defer
-        // the whole element to the exact kernel (which degrades identically on such
-        // un-localized georeferenced geometry, so this is never worse). Localized
-        // models — the production rebases placement-based georef to a local origin —
-        // fall well under the threshold and take the fast path.
+        // Precision regime (UNIT-INDEPENDENT): defer when the host sits so far from
+        // the coordinate origin that f32 ULP at its vertices approaches the cut
+        // feature scale. ULP(max) / diag = (max/diag) * 2^-23, so at ~800 host-
+        // diagonals of offset the ULP reaches ~1e-4 of the host extent — the grid
+        // the watertightness gate uses below — and beyond that the straddle /
+        // convexity classification and the cap's closure become unverifiable. This
+        // compares the offset to the host's OWN size rather than an absolute metre
+        // threshold, so it is correct whether the mesh is in mm (Tekla), m, or ft.
+        // Above the bound, defer to the exact kernel (which degrades identically on
+        // such un-localized geometry, so deferring is never worse).
         let max_mag = lo
             .iter()
             .chain(hi.iter())
             .fold(0.0f64, |m, &c| m.max(c.abs()));
-        if max_mag > 10_000.0 {
+        if diag > 0.0 && max_mag > diag * 800.0 {
             return Ok(None);
         }
 
@@ -1792,6 +1817,139 @@ impl ClippingProcessor {
 fn planar_clip_disabled() -> bool {
     static DISABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *DISABLED.get_or_init(|| std::env::var("IFC_LITE_DISABLE_PLANAR_CLIP").is_ok())
+}
+
+thread_local! {
+    /// Per-thread override that forces the exact kernel even when the global flag
+    /// leaves the fast path on — used by the element-level fallback to re-process
+    /// an element whose fast-path result cracked downstream (post scale/placement).
+    static PLANAR_TL_DISABLE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    /// Per-thread count of planar fast-path fires since the last reset, so the
+    /// fallback only re-runs elements the fast path actually touched.
+    static PLANAR_TL_FIRED: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+}
+
+/// Force the exact kernel on this thread (planar fast path off) and return the
+/// previous setting. The element-level fallback sets this for its verify re-run.
+pub fn set_planar_clip_thread_disabled(v: bool) -> bool {
+    PLANAR_TL_DISABLE.with(|c| c.replace(v))
+}
+
+/// Read the per-thread planar fire counter WITHOUT resetting it, so callers can
+/// take a before/after delta around one element (robust to nesting, e.g. a voided
+/// element whose wall is processed through `process_element`).
+pub fn peek_planar_clip_fired() -> u32 {
+    PLANAR_TL_FIRED.with(|c| c.get())
+}
+
+thread_local! {
+    /// Per-thread adaptive give-up: planar fast-path attempts that reached the
+    /// element-level fallback, how many of those FELL BACK to the exact kernel,
+    /// and whether the fast path has given up on this thread.
+    static PLANAR_ATTEMPTS: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+    static PLANAR_FALLBACKS: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+    static PLANAR_GAVE_UP: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Whether the fast path has adaptively given up on this thread because it kept
+/// cracking (e.g. a model whose source tessellation is riddled with T-junctions,
+/// where every fast clip falls back and is therefore pure overhead).
+fn planar_gave_up() -> bool {
+    PLANAR_GAVE_UP.with(|c| c.get())
+}
+
+/// Record one element-level outcome of the fast path (whether it had to fall back
+/// to the exact kernel). After a warm-up, if the majority of attempts fell back,
+/// the fast path gives up for the rest of this thread's work so it never costs
+/// more than the exact kernel on a model it cannot help.
+pub fn planar_record_outcome(fell_back: bool) {
+    let attempts = PLANAR_ATTEMPTS.with(|c| {
+        let v = c.get() + 1;
+        c.set(v);
+        v
+    });
+    if fell_back {
+        PLANAR_FALLBACKS.with(|c| c.set(c.get() + 1));
+    }
+    // Warm up on the first 32 firing elements, then give up if ≥50% fell back.
+    if attempts >= 32 && PLANAR_FALLBACKS.with(|c| c.get()) * 2 >= attempts {
+        PLANAR_GAVE_UP.with(|c| c.set(true));
+    }
+}
+
+/// Count a mesh's open boundary edges on a grid relative to its own extent — the
+/// element-level watertightness check the fallback uses on the final (scaled,
+/// placed) mesh, where the per-cut gate could not see the f32 world coordinates.
+pub fn element_open_edges(mesh: &Mesh) -> usize {
+    open_boundary_edges_at(mesh, mesh_extent(mesh) * 1.0e-4)
+}
+
+/// Divergence-theorem signed volume of a triangle mesh — used by the planar-clip
+/// volume-conservation gate to reject self-intersecting caps.
+fn mesh_signed_volume(m: &Mesh) -> f64 {
+    let p = &m.positions;
+    let mut v = 0.0;
+    for t in m.indices.chunks_exact(3) {
+        let g = |i: u32| {
+            let b = i as usize * 3;
+            [p[b] as f64, p[b + 1] as f64, p[b + 2] as f64]
+        };
+        let (a, b, c) = (g(t[0]), g(t[1]), g(t[2]));
+        v += a[0] * (b[1] * c[2] - b[2] * c[1]) + a[1] * (b[2] * c[0] - b[0] * c[2])
+            + a[2] * (b[0] * c[1] - b[1] * c[0]);
+    }
+    v / 6.0
+}
+
+/// Bounding-box diagonal length of a mesh (its characteristic size), used to make
+/// the planar-clip gates scale- and unit-independent.
+fn mesh_extent(mesh: &Mesh) -> f64 {
+    let (mut lo, mut hi) = ([f64::INFINITY; 3], [f64::NEG_INFINITY; 3]);
+    for c in mesh.positions.chunks(3) {
+        for k in 0..3 {
+            lo[k] = lo[k].min(c[k] as f64);
+            hi[k] = hi[k].max(c[k] as f64);
+        }
+    }
+    if !lo[0].is_finite() {
+        return 0.0;
+    }
+    ((hi[0] - lo[0]).powi(2) + (hi[1] - lo[1]).powi(2) + (hi[2] - lo[2]).powi(2)).sqrt()
+}
+
+/// Count directed boundary edges with no reverse partner, merging vertices on a
+/// grid of side `quantum` — 0 ⇒ watertight at that scale. Like
+/// [`count_open_boundary_edges`] but with a caller-chosen grid so the watertightness
+/// test can be made proportional to the mesh extent (unit-independent).
+fn open_boundary_edges_at(mesh: &Mesh, quantum: f64) -> usize {
+    if mesh.positions.len() < 9 || mesh.indices.len() < 3 || !(quantum > 0.0) {
+        return 0;
+    }
+    let inv = 1.0 / quantum;
+    let q = |v: f32| (v as f64 * inv).round() as i64;
+    let mut vid: FxHashMap<(i64, i64, i64), u32> = FxHashMap::default();
+    let mut id_of = |i: usize| -> u32 {
+        let k = (
+            q(mesh.positions[i * 3]),
+            q(mesh.positions[i * 3 + 1]),
+            q(mesh.positions[i * 3 + 2]),
+        );
+        let next = vid.len() as u32;
+        *vid.entry(k).or_insert(next)
+    };
+    let mut bal: FxHashMap<(u32, u32), i32> = FxHashMap::default();
+    for tri in mesh.indices.chunks_exact(3) {
+        let (a, b, c) = (
+            id_of(tri[0] as usize),
+            id_of(tri[1] as usize),
+            id_of(tri[2] as usize),
+        );
+        for (x, y) in [(a, b), (b, c), (c, a)] {
+            let (key, s) = if x < y { ((x, y), 1) } else { ((y, x), -1) };
+            *bal.entry(key).or_insert(0) += s;
+        }
+    }
+    bal.values().filter(|&&v| v != 0).count()
 }
 
 /// Group a (closed, outward-wound) mesh's triangles into face planes, returning

--- a/rust/geometry/src/processors/boolean.rs
+++ b/rust/geometry/src/processors/boolean.rs
@@ -1037,7 +1037,12 @@ impl BooleanClippingProcessor {
                     agreement,
                 ) {
                     let clipper = ClippingProcessor::new();
-                    let subtract_result = clipper.subtract_mesh(&mesh, &bound_mesh);
+                    // When the clip polygon spans the host cross-section the prism
+                    // acts as a half-space and `subtract_one` takes the fast f64
+                    // capped clip — which also sidesteps the coincident-side-wall
+                    // sliver collapse described below. A partial (non-spanning) or
+                    // non-convex polygon straddles on >1 face and defers to exact.
+                    let subtract_result = clipper.subtract_one(&mesh, &bound_mesh);
                     self.drain_clipper_failures(&clipper);
                     if let Ok(clipped) = subtract_result {
                         // The bounded-prism subtract is fragile on coincident
@@ -1093,7 +1098,7 @@ impl BooleanClippingProcessor {
                 return Ok(mesh);
             }
             let clipper = ClippingProcessor::new();
-            let result = clipper.subtract_mesh(&mesh, &second_mesh);
+            let result = clipper.subtract_one(&mesh, &second_mesh);
             self.drain_clipper_failures(&clipper);
             return result;
         }

--- a/rust/geometry/src/router/processing.rs
+++ b/rust/geometry/src/router/processing.rs
@@ -15,6 +15,20 @@ use std::sync::Arc;
 /// Maximum nested IfcMappedItem depth we will traverse for a single geometry item.
 const MAX_MAPPED_ITEM_DEPTH: usize = 32;
 
+/// Open boundary edges a planar-clip element may have before the element-level
+/// fallback re-processes it with the exact kernel. A clean fast-path solid is
+/// watertight; a handful of stray edges is tolerated (source meshes are not all
+/// perfectly manifold), but a cracked non-conforming cap shows hundreds.
+const PLANAR_FALLBACK_OPEN_TOLERANCE: usize = 8;
+
+thread_local! {
+    /// While set, the item-dedup cache LOOKUP is skipped (a fresh mesh is built)
+    /// but the result is still written. The element-level planar fallback sets it
+    /// for its exact re-run so a cached BROKEN fast-path mesh is recomputed and
+    /// overwritten — for this element and every content-identical instance.
+    static GEOM_CACHE_BYPASS: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
 impl GeometryRouter {
     /// Compute median-based RTC offset from sampled translations.
     /// Returns `(0,0,0)` if empty or coordinates are within 10km of origin.
@@ -386,11 +400,61 @@ impl GeometryRouter {
         }
     }
 
-    /// Process building element (IfcWall, IfcBeam, etc.) into mesh
-    /// Follows the representation chain:
-    /// Element → Representation → ShapeRepresentation → Items
+    /// Process building element (IfcWall, IfcBeam, etc.) into mesh.
+    ///
+    /// Wraps [`Self::process_element_impl`] with the planar-clip **element-level
+    /// fallback**: the per-cut watertightness gate verifies the fast clip in f64
+    /// before scale + placement, but a cap that does not conform to a T-junction
+    /// in the source tessellation can still crack once the element is placed into
+    /// f32 world coordinates — which `subtract_one` cannot see. So if the fast path
+    /// fired for this element and the FINAL mesh has open boundary edges, re-process
+    /// it with the fast path forced off and keep whichever is more watertight. The
+    /// re-run only happens for elements the fast path both touched and left open, so
+    /// clean fast-path elements keep their speedup and the result is never worse
+    /// than the exact kernel.
     #[inline]
     pub fn process_element(
+        &self,
+        element: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+    ) -> Result<Mesh> {
+        let before = crate::csg::peek_planar_clip_fired();
+        let mesh = self.process_element_impl(element, decoder)?;
+        if crate::csg::peek_planar_clip_fired() == before {
+            return Ok(mesh); // fast path didn't fire here
+        }
+        let open = crate::csg::element_open_edges(&mesh);
+        if open <= PLANAR_FALLBACK_OPEN_TOLERANCE {
+            crate::csg::planar_record_outcome(false); // clean fast-path element
+            return Ok(mesh);
+        }
+        let prev = crate::csg::set_planar_clip_thread_disabled(true);
+        let cache_prev = self.set_geometry_cache_bypass(true);
+        let exact = self.process_element_impl(element, decoder);
+        self.set_geometry_cache_bypass(cache_prev);
+        crate::csg::set_planar_clip_thread_disabled(prev);
+        match exact {
+            Ok(ex) if crate::csg::element_open_edges(&ex) < open => {
+                crate::csg::planar_record_outcome(true); // fast path cracked → exact
+                Ok(ex)
+            }
+            _ => {
+                crate::csg::planar_record_outcome(false);
+                Ok(mesh)
+            }
+        }
+    }
+
+    /// Skip the item-dedup cache lookup on this thread (still writing results), so
+    /// the planar fallback's exact re-run rebuilds and overwrites a cached broken
+    /// mesh. Returns the previous setting. See [`GEOM_CACHE_BYPASS`].
+    fn set_geometry_cache_bypass(&self, v: bool) -> bool {
+        GEOM_CACHE_BYPASS.with(|c| c.replace(v))
+    }
+
+    /// Inner element processing (no planar-clip fallback); see [`Self::process_element`].
+    #[inline]
+    pub fn process_element_impl(
         &self,
         element: &DecodedEntity,
         decoder: &mut EntityDecoder,
@@ -844,10 +908,12 @@ impl GeometryRouter {
         // `None` ⇒ dedup disabled (no hash overhead). On a hit, return a clone of
         // the cached item mesh; meshing is skipped entirely.
         let dedup_key = self.item_dedup_key(item, decoder);
-        if let (Some(key), Some(cache)) = (dedup_key, self.item_dedup_cache.as_ref()) {
-            let hit = cache.lock().expect("dedup cache poisoned").get(&key).cloned();
-            if let Some(mesh) = hit {
-                return Ok((*mesh).clone());
+        if !GEOM_CACHE_BYPASS.with(|c| c.get()) {
+            if let (Some(key), Some(cache)) = (dedup_key, self.item_dedup_cache.as_ref()) {
+                let hit = cache.lock().expect("dedup cache poisoned").get(&key).cloned();
+                if let Some(mesh) = hit {
+                    return Ok((*mesh).clone());
+                }
             }
         }
 

--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -1610,7 +1610,10 @@ impl GeometryRouter {
                         depth_dir,
                     );
                     let cutter = &extended_opening;
-                    match clipper.subtract_mesh(&result, cutter) {
+                    // A through-opening straddles the host on >1 face and defers to
+                    // the exact kernel; a cutter that acts as a single end-clip
+                    // takes the fast f64 capped clip.
+                    match clipper.subtract_one(&result, cutter) {
                         Ok(csg_result) => {
                             let min_tris = (tri_before / CSG_TRIANGLE_RETENTION_DIVISOR)
                                 .max(MIN_VALID_TRIANGLES);

--- a/rust/geometry/tests/clip_with_cap.rs
+++ b/rust/geometry/tests/clip_with_cap.rs
@@ -154,6 +154,149 @@ fn capped_clip_is_watertight_and_complete() {
     assert!(applied >= total * 8 / 10, "fast-cap applied only {applied}/{total} — too many fallbacks");
 }
 
+/// A faceted cylinder (drilling cutter) spanning the bar along Z, centred at
+/// (cx,cy), radius r, `seg` facets. Its side facets each straddle the bar, so the
+/// planar-clip detector must DEFER it to the exact kernel.
+fn cylinder_z(cx: f32, cy: f32, r: f32, z0: f32, z1: f32, seg: usize) -> Mesh {
+    let mut m = Mesh::new();
+    let ring: Vec<[f32; 2]> = (0..seg)
+        .map(|k| {
+            let a = std::f32::consts::TAU * k as f32 / seg as f32;
+            [cx + r * a.cos(), cy + r * a.sin()]
+        })
+        .collect();
+    let mut tri = |a: [f32; 3], b: [f32; 3], c: [f32; 3]| {
+        let base = (m.positions.len() / 3) as u32;
+        for v in [a, b, c] {
+            m.positions.extend_from_slice(&v);
+            m.normals.extend_from_slice(&[0.0, 0.0, 1.0]);
+        }
+        m.indices.extend_from_slice(&[base, base + 1, base + 2]);
+    };
+    for k in 0..seg {
+        let (p, q) = (ring[k], ring[(k + 1) % seg]);
+        // side wall (two tris, outward)
+        tri([p[0], p[1], z0], [q[0], q[1], z0], [q[0], q[1], z1]);
+        tri([p[0], p[1], z0], [q[0], q[1], z1], [p[0], p[1], z1]);
+        // caps
+        tri([cx, cy, z1], [p[0], p[1], z1], [q[0], q[1], z1]);
+        tri([cx, cy, z0], [q[0], q[1], z0], [p[0], p[1], z0]);
+    }
+    m
+}
+
+/// Extrude a 2D polygon (CCW in XY) along Z into a prism mesh with outward-wound
+/// side walls. Caps are fan-triangulated (fine even when non-convex — the test
+/// only needs the face planes + vertices for the convexity gate).
+fn extrude_z(poly: &[[f32; 2]], z0: f32, z1: f32) -> Mesh {
+    let mut m = Mesh::new();
+    let mut tri = |a: [f32; 3], b: [f32; 3], c: [f32; 3]| {
+        let base = (m.positions.len() / 3) as u32;
+        for v in [a, b, c] {
+            m.positions.extend_from_slice(&v);
+            m.normals.extend_from_slice(&[0.0, 0.0, 1.0]);
+        }
+        m.indices.extend_from_slice(&[base, base + 1, base + 2]);
+    };
+    let n = poly.len();
+    for k in 0..n {
+        let p = poly[k];
+        let q = poly[(k + 1) % n];
+        // side wall, outward normal for a CCW polygon
+        tri([p[0], p[1], z0], [q[0], q[1], z0], [q[0], q[1], z1]);
+        tri([p[0], p[1], z0], [q[0], q[1], z1], [p[0], p[1], z1]);
+    }
+    for k in 1..n - 1 {
+        tri([poly[0][0], poly[0][1], z1], [poly[k][0], poly[k][1], z1], [poly[k + 1][0], poly[k + 1][1], z1]);
+        tri([poly[0][0], poly[0][1], z0], [poly[k + 1][0], poly[k + 1][1], z0], [poly[k][0], poly[k][1], z0]);
+    }
+    m
+}
+
+#[test]
+fn planar_clip_detection_routes_end_clips_and_defers_the_rest() {
+    let clipper = ClippingProcessor::new();
+    let bar = box_mesh([0.0, 0.0, 0.0], [1.0, 0.1, 0.05], 4);
+    let bar_vol = volume(&bar);
+
+    // (1) End-clip box overhanging the bar on every side but the cut face: APPLIES,
+    //     and matches the exact subtract.
+    let end_clip = box_mesh([0.8, -1.0, -1.0], [2.0, 2.0, 2.0], 1);
+    let routed = clipper
+        .try_planar_clip(&bar, &end_clip)
+        .unwrap()
+        .expect("end-clip must take the fast planar path");
+    let exact = clipper.subtract_mesh(&bar, &end_clip).unwrap();
+    let _ = clipper.take_failures();
+    let rel = (volume(&routed) - volume(&exact)).abs() / volume(&exact).abs().max(1e-9);
+    println!("end-clip: routed {:.6} vs exact {:.6}  rel {rel:.2e}  open {}",
+        volume(&routed), volume(&exact), open_edges(&routed));
+    assert_eq!(open_edges(&routed), 0, "routed end-clip not watertight");
+    assert!(rel < 1.0e-3, "routed end-clip ≠ exact subtract ({rel:.2e})");
+    assert!(volume(&routed) < bar_vol, "end-clip removed nothing");
+
+    // (2) Drilling cutter through the bar (round hole): MANY straddling facets ⇒ DEFER.
+    let drill = cylinder_z(0.5, 0.05, 0.02, -1.0, 1.0, 16);
+    assert!(
+        clipper.try_planar_clip(&bar, &drill).unwrap().is_none(),
+        "a through-hole must defer to the exact kernel, not the planar clip"
+    );
+
+    // (3) A pocket/notch fully inside the bar (cutter doesn't overhang): two faces
+    //     straddle ⇒ DEFER.
+    let notch = box_mesh([0.4, 0.02, -1.0], [0.6, 0.08, 0.5], 1);
+    assert!(
+        clipper.try_planar_clip(&bar, &notch).unwrap().is_none(),
+        "an interior pocket must defer to the exact kernel"
+    );
+    // (4) NON-CONVEX L-prism whose left face (x=0.8) cleanly straddles the bar and
+    //     overhangs it everywhere else — it passes the single-straddle test but its
+    //     reflex corner means the cutter ≠ the half-space, so the convexity gate
+    //     must DEFER it (clipping would over-cut).
+    let l_prism = extrude_z(
+        &[[0.8, -1.0], [3.0, -1.0], [3.0, 3.0], [2.0, 3.0], [2.0, 1.0], [0.8, 1.0]],
+        -1.0,
+        2.0,
+    );
+    assert!(
+        clipper.try_planar_clip(&bar, &l_prism).unwrap().is_none(),
+        "a non-convex (L) cutter must defer — the convexity gate failed"
+    );
+    println!("detection OK: end-clip → fast path; hole, pocket, non-convex L → exact fallback");
+}
+
+#[test]
+fn subtract_one_fires_on_clean_end_clip_and_matches_exact() {
+    let c = ClippingProcessor::new();
+    let bar = box_mesh([0.0, 0.0, 0.0], [1.0, 0.1, 0.05], 6);
+    let cutter = box_mesh([0.8, -1.0, -1.0], [2.0, 2.0, 2.0], 1);
+
+    // The wired entry point must take the fast path on a clean end-clip: the
+    // result is watertight (so the strict gate accepts it) and volume-matches
+    // the exact subtract.
+    let fast = c.subtract_one(&bar, &cutter).unwrap();
+    let exact = c.subtract_mesh(&bar, &cutter).unwrap();
+    let _ = c.take_failures();
+    assert_eq!(open_edges(&fast), 0, "subtract_one result not watertight");
+    let rel = (volume(&fast) - volume(&exact)).abs() / volume(&exact).abs().max(1e-9);
+    assert!(rel < 1.0e-3, "subtract_one diverged from exact subtract ({rel:.2e})");
+    // It genuinely fired (the detector accepts this cutter)...
+    assert!(c.try_planar_clip(&bar, &cutter).unwrap().is_some());
+    // ...and the fast path produces a DIFFERENT triangulation than the exact
+    // arrangement (proof it didn't silently fall through to subtract_mesh).
+    assert_ne!(fast.triangle_count(), exact.triangle_count());
+
+    // A through-hole cutter must defer (the exact kernel handles it); subtract_one
+    // then returns exactly what subtract_mesh would.
+    let drill = cylinder_z(0.5, 0.05, 0.02, -1.0, 1.0, 16);
+    assert!(c.try_planar_clip(&bar, &drill).unwrap().is_none());
+    let via_one = c.subtract_one(&bar, &drill).unwrap();
+    let via_exact = c.subtract_mesh(&bar, &drill).unwrap();
+    let _ = c.take_failures();
+    assert_eq!(via_one.triangle_count(), via_exact.triangle_count());
+    println!("subtract_one: fires on end-clip (watertight, matches exact), defers on hole");
+}
+
 #[test]
 fn capped_clip_matches_exact_subtract_and_is_faster() {
     let clipper = ClippingProcessor::new();

--- a/rust/geometry/tests/clip_with_cap.rs
+++ b/rust/geometry/tests/clip_with_cap.rs
@@ -1,0 +1,191 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Phase 1 primitive: `clip_mesh_with_cap` must produce a WATERTIGHT solid whose
+//! volume matches the exact `subtract_mesh` for the same planar end-clip — at a
+//! fraction of the cost. Validated for axis-aligned and angled cuts.
+//!
+//! cargo test -p ifc-lite-geometry --release --test clip_with_cap -- --nocapture
+
+use ifc_lite_geometry::{ClippingProcessor, Mesh, Plane};
+use nalgebra::{Point3, Vector3};
+use std::time::Instant;
+
+fn box_mesh(lo: [f32; 3], hi: [f32; 3], s: usize) -> Mesh {
+    let mut m = Mesh::new();
+    let mut push_quad = |a: [f32; 3], b: [f32; 3], c: [f32; 3], d: [f32; 3], n: [f32; 3]| {
+        let base = (m.positions.len() / 3) as u32;
+        for v in [a, b, c, d] {
+            m.positions.extend_from_slice(&v);
+            m.normals.extend_from_slice(&n);
+        }
+        m.indices
+            .extend_from_slice(&[base, base + 1, base + 2, base, base + 2, base + 3]);
+    };
+    let mut face = |o: [f32; 3], u: [f32; 3], v: [f32; 3], n: [f32; 3]| {
+        for i in 0..s {
+            for j in 0..s {
+                let (fi, fj, fs) = (i as f32, j as f32, s as f32);
+                let p = |ti: f32, tj: f32| {
+                    [
+                        o[0] + u[0] * ti + v[0] * tj,
+                        o[1] + u[1] * ti + v[1] * tj,
+                        o[2] + u[2] * ti + v[2] * tj,
+                    ]
+                };
+                push_quad(
+                    p(fi / fs, fj / fs),
+                    p((fi + 1.0) / fs, fj / fs),
+                    p((fi + 1.0) / fs, (fj + 1.0) / fs),
+                    p(fi / fs, (fj + 1.0) / fs),
+                    n,
+                );
+            }
+        }
+    };
+    let dx = [hi[0] - lo[0], 0.0, 0.0];
+    let dy = [0.0, hi[1] - lo[1], 0.0];
+    let dz = [0.0, 0.0, hi[2] - lo[2]];
+    let [lx, ly, lz] = lo;
+    face([lx, ly, lz], dz, dy, [-1.0, 0.0, 0.0]);
+    face([hi[0], ly, lz], dy, dz, [1.0, 0.0, 0.0]);
+    face([lx, ly, lz], dx, dz, [0.0, -1.0, 0.0]);
+    face([lx, hi[1], lz], dz, dx, [0.0, 1.0, 0.0]);
+    face([lx, ly, lz], dy, dx, [0.0, 0.0, -1.0]);
+    face([lx, ly, hi[2]], dx, dy, [0.0, 0.0, 1.0]);
+    m
+}
+
+fn volume(m: &Mesh) -> f64 {
+    let p = &m.positions;
+    let mut v = 0.0;
+    for t in m.indices.chunks(3) {
+        let g = |i: u32| {
+            let b = i as usize * 3;
+            [p[b] as f64, p[b + 1] as f64, p[b + 2] as f64]
+        };
+        let (a, b, c) = (g(t[0]), g(t[1]), g(t[2]));
+        v += a[0] * (b[1] * c[2] - b[2] * c[1]) + a[1] * (b[2] * c[0] - b[0] * c[2])
+            + a[2] * (b[0] * c[1] - b[1] * c[0]);
+    }
+    v / 6.0
+}
+
+/// Count directed edges with no reverse partner (quantized) — 0 ⇒ watertight.
+fn open_edges(m: &Mesh) -> usize {
+    use std::collections::HashMap;
+    const Q: f64 = 1.0e6;
+    let p = &m.positions;
+    let key = |i: u32| {
+        let b = i as usize * 3;
+        (
+            (p[b] as f64 * Q).round() as i64,
+            (p[b + 1] as f64 * Q).round() as i64,
+            (p[b + 2] as f64 * Q).round() as i64,
+        )
+    };
+    let mut dir: HashMap<((i64, i64, i64), (i64, i64, i64)), i32> = HashMap::new();
+    for t in m.indices.chunks(3) {
+        if t.len() < 3 {
+            continue;
+        }
+        for (a, b) in [(t[0], t[1]), (t[1], t[2]), (t[2], t[0])] {
+            let (ka, kb) = (key(a), key(b));
+            *dir.entry((ka, kb)).or_default() += 1;
+            *dir.entry((kb, ka)).or_default() -= 1;
+        }
+    }
+    dir.values().filter(|&&c| c != 0).count()
+}
+
+/// Reference-free correctness for ANY cut plane: clipping the front half and the
+/// back half (reversed normal) must each be watertight, and their volumes must
+/// reconstruct the whole bar. A wrong cap (bad loop / winding / self-intersection)
+/// moves a volume or leaves an open edge.
+/// Returns true if the cap path applied (Some); false if it deferred (None).
+/// When it applies, both halves must be watertight and sum to the whole.
+fn complementary(name: &str, plane: Plane, s: usize) -> bool {
+    let clipper = ClippingProcessor::new();
+    let bar = box_mesh([0.0, 0.0, 0.0], [1.0, 0.1, 0.05], s);
+    let full = volume(&bar);
+    let back = Plane::new(plane.point, -plane.normal);
+
+    let (Some(front_m), Some(back_m)) = (
+        clipper.clip_mesh_with_cap(&bar, &plane).unwrap(),
+        clipper.clip_mesh_with_cap(&bar, &back).unwrap(),
+    ) else {
+        println!("{name:<14} s={s}: DEFERRED (None) → exact fallback");
+        return false;
+    };
+    let (vf, vb) = (volume(&front_m), volume(&back_m));
+    let (of, ob) = (open_edges(&front_m), open_edges(&back_m));
+    let sum_rel = (vf + vb - full).abs() / full.abs().max(1e-9);
+
+    println!(
+        "{name:<14} s={s}: front {vf:.6} + back {vb:.6} = {:.6} (whole {full:.6})  rel {sum_rel:.2e}  open f={of} b={ob}",
+        vf + vb
+    );
+    assert_eq!(of, 0, "{name}: front cap not watertight ({of} open edges)");
+    assert_eq!(ob, 0, "{name}: back cap not watertight ({ob} open edges)");
+    assert!(sum_rel < 1.0e-3, "{name}: front+back volume ≠ whole ({sum_rel:.2e})");
+    true
+}
+
+#[test]
+fn capped_clip_is_watertight_and_complete() {
+    // Axis-aligned + oblique cuts must apply correctly.
+    assert!(complementary("axis-x", Plane::new(Point3::new(0.8, 0.0, 0.0), Vector3::new(-1.0, 0.0, 0.0)), 4));
+    assert!(complementary("oblique", Plane::new(Point3::new(0.7, 0.05, 0.025), Vector3::new(-1.0, 0.5, 0.0).normalize()), 4));
+    // Many generic angled cuts at jittered positions — gauge the fallback rate.
+    let mut applied = 0;
+    let total = 40;
+    for k in 0..total {
+        let a = 0.3 + 0.4 * (k as f64 / total as f64);
+        let b = 0.2 + 0.5 * ((k * 7 % total) as f64 / total as f64);
+        let n = Vector3::new(-1.0, a, b).normalize();
+        let px = 0.5 + 0.0037 * k as f64; // jitter off grid lines
+        if complementary("angled", Plane::new(Point3::new(px, 0.05 + 1e-4, 0.025 + 1e-4), n), 6) {
+            applied += 1;
+        }
+    }
+    println!("\nfast-cap applied on {applied}/{total} generic angled cuts (rest defer to exact)");
+    // Most generic cuts must take the fast path for it to be worthwhile.
+    assert!(applied >= total * 8 / 10, "fast-cap applied only {applied}/{total} — too many fallbacks");
+}
+
+#[test]
+fn capped_clip_matches_exact_subtract_and_is_faster() {
+    let clipper = ClippingProcessor::new();
+    let plane = Plane::new(Point3::new(0.8, 0.0, 0.0), Vector3::new(-1.0, 0.0, 0.0));
+    for s in [4usize, 8, 16] {
+        let bar = box_mesh([0.0, 0.0, 0.0], [1.0, 0.1, 0.05], s);
+        let cutter = box_mesh([0.8, -1.0, -1.0], [2.0, 2.0, 2.0], 1);
+
+        let capped = clipper.clip_mesh_with_cap(&bar, &plane).unwrap().expect("capped");
+        let exact = clipper.subtract_mesh(&bar, &cutter).unwrap();
+        let _ = clipper.take_failures();
+        let rel = (volume(&capped) - volume(&exact)).abs() / volume(&exact).abs().max(1e-9);
+
+        let iters = 2000;
+        let t = Instant::now();
+        for _ in 0..iters {
+            let _ = clipper.clip_mesh_with_cap(&bar, &plane).unwrap();
+        }
+        let cap_ms = t.elapsed().as_secs_f64() * 1000.0 / iters as f64;
+        let t = Instant::now();
+        for _ in 0..iters {
+            let _ = clipper.subtract_mesh(&bar, &cutter).unwrap();
+            let _ = clipper.take_failures();
+        }
+        let sub_ms = t.elapsed().as_secs_f64() * 1000.0 / iters as f64;
+
+        println!(
+            "tris={:<5} rel-dev {rel:.2e}  clip+cap {cap_ms:.4}ms vs exact {sub_ms:.4}ms  ({:.0}x faster)",
+            bar.triangle_count(),
+            sub_ms / cap_ms.max(1e-9)
+        );
+        assert!(rel < 1.0e-3, "volume diverged {rel:.2e} from exact subtract");
+        assert_eq!(open_edges(&capped), 0, "capped clip not watertight");
+    }
+}

--- a/rust/geometry/tests/planar_clip_ab.rs
+++ b/rust/geometry/tests/planar_clip_ab.rs
@@ -1,0 +1,293 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! A/B validation for the f64 planar-clip fast path on a REAL model. Drives the
+//! exact per-element router path (the same as `produce_element_meshes`) and dumps
+//! a per-element signature (triangle count, signed volume, open-edge count). Run
+//! it twice — once with the fast path forced OFF, once ON — and the ON run diffs
+//! itself against the OFF reference: the fast path must be VOLUME-equivalent
+//! (shape-preserving) and never less watertight, while being faster overall.
+//!
+//! Two-process diff (the env flag is read once per process via `OnceLock`):
+//!   M=/abs/model.ifc
+//!   IFC_LITE_DISABLE_PLANAR_CLIP=1 IFCLT_MODEL=$M IFCLT_AB_OUT=/tmp/off.tsv \
+//!     cargo test -p ifc-lite-geometry --release --test planar_clip_ab -- --ignored --nocapture
+//!   IFCLT_MODEL=$M IFCLT_AB_OUT=/tmp/on.tsv IFCLT_AB_REF=/tmp/off.tsv \
+//!     cargo test -p ifc-lite-geometry --release --test planar_clip_ab -- --ignored --nocapture
+
+use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner};
+use ifc_lite_geometry::{propagate_voids_to_parts, GeometryRouter, Mesh};
+use rustc_hash::FxHashMap;
+use std::collections::HashMap;
+use std::io::Write;
+use std::time::Instant;
+
+fn build_void_index(content: &str) -> FxHashMap<u32, Vec<u32>> {
+    let mut idx: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
+    let mut scanner = EntityScanner::new(content);
+    let mut decoder = EntityDecoder::new(content);
+    while let Some((id, name, start, end)) = scanner.next_entity() {
+        if name == "IFCRELVOIDSELEMENT" {
+            if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
+                if let (Some(host), Some(opening)) = (entity.get_ref(4), entity.get_ref(5)) {
+                    idx.entry(host).or_default().push(opening);
+                }
+            }
+        }
+    }
+    let _ = propagate_voids_to_parts(&mut idx, content, &mut decoder);
+    idx
+}
+
+fn list_products(content: &str) -> Vec<u32> {
+    let mut products = Vec::new();
+    let mut scanner = EntityScanner::new(content);
+    while let Some((id, name, _, _)) = scanner.next_entity() {
+        let n = name;
+        if n.starts_with("IFC")
+            && (n.contains("WALL") || n.contains("BEAM") || n.contains("COLUMN")
+                || n.contains("MEMBER") || n.contains("PLATE") || n.contains("SLAB")
+                || n.contains("FOOTING") || n.contains("PILE") || n.contains("RAILING")
+                || n.contains("STAIR") || n.contains("ROOF") || n.contains("COVERING")
+                || n.contains("BUILDINGELEMENT") || n.contains("PROXY") || n.contains("FLOW"))
+            && !n.contains("TYPE")
+            && !n.contains("STYLE")
+        {
+            products.push(id);
+        }
+    }
+    products
+}
+
+/// Signed volume via the divergence theorem (origin-independent up to the mesh
+/// being closed; for open meshes it is still a stable per-element fingerprint).
+fn volume(m: &Mesh) -> f64 {
+    let p = &m.positions;
+    let mut v = 0.0;
+    for t in m.indices.chunks(3) {
+        if t.len() < 3 {
+            continue;
+        }
+        let g = |i: u32| {
+            let b = i as usize * 3;
+            [p[b] as f64, p[b + 1] as f64, p[b + 2] as f64]
+        };
+        let (a, b, c) = (g(t[0]), g(t[1]), g(t[2]));
+        v += a[0] * (b[1] * c[2] - b[2] * c[1]) + a[1] * (b[2] * c[0] - b[0] * c[2])
+            + a[2] * (b[0] * c[1] - b[1] * c[0]);
+    }
+    v / 6.0
+}
+
+/// Directed edges with no reverse partner (quantized) — 0 ⇒ watertight.
+fn open_edges(m: &Mesh) -> usize {
+    const Q: f64 = 1.0e5;
+    let p = &m.positions;
+    let key = |i: u32| {
+        let b = i as usize * 3;
+        (
+            (p[b] as f64 * Q).round() as i64,
+            (p[b + 1] as f64 * Q).round() as i64,
+            (p[b + 2] as f64 * Q).round() as i64,
+        )
+    };
+    let mut dir: HashMap<((i64, i64, i64), (i64, i64, i64)), i32> = HashMap::new();
+    for t in m.indices.chunks(3) {
+        if t.len() < 3 {
+            continue;
+        }
+        for (a, b) in [(t[0], t[1]), (t[1], t[2]), (t[2], t[0])] {
+            *dir.entry((key(a), key(b))).or_default() += 1;
+            *dir.entry((key(b), key(a))).or_default() -= 1;
+        }
+    }
+    dir.values().filter(|&&c| c != 0).count()
+}
+
+#[test]
+#[ignore = "manual; needs IFCLT_MODEL"]
+fn planar_clip_ab() {
+    let Ok(path) = std::env::var("IFCLT_MODEL") else {
+        println!("set IFCLT_MODEL=/abs/path.ifc");
+        return;
+    };
+    let content = String::from_utf8_lossy(&std::fs::read(&path).expect("read model")).into_owned();
+    let entity_index = build_entity_index(&content);
+    let mut decoder = EntityDecoder::with_index(&content, entity_index);
+    let mut router = GeometryRouter::with_units(&content, &mut decoder);
+    // Rebase georeferenced models so the RTC=0 harness does not render f32 vertex
+    // jitter on national-grid coordinates (tens of km), which fabricates degenerate
+    // geometry unrelated to the fast path (AGENTS.md / csg_model_profile caveat).
+    // `scan_model_bounds` reads the actual IfcCartesianPoints, so it catches an
+    // offset baked into the geometry (skolebygg) that placement sampling misses.
+    let rtc = ifc_lite_core::scan_model_bounds(content.as_str()).rtc_offset();
+    router.set_rtc_offset(rtc);
+    if rtc != (0.0, 0.0, 0.0) {
+        println!("rebased: RTC offset = ({:.1}, {:.1}, {:.1})", rtc.0, rtc.1, rtc.2);
+    }
+    let void_idx = build_void_index(&content);
+    let products = list_products(&content);
+    let disabled = std::env::var("IFC_LITE_DISABLE_PLANAR_CLIP").is_ok();
+    println!(
+        "\n=== planar-clip A/B  (fast path {}) ===\nmodel: {path}  products: {}",
+        if disabled { "OFF" } else { "ON" },
+        products.len()
+    );
+
+    // id -> (tris, volume, open_edges, bbox_lo[3], bbox_hi[3])
+    let mut sig: Vec<(u32, usize, f64, usize, [f64; 3], [f64; 3])> =
+        Vec::with_capacity(products.len());
+    let t_all = Instant::now();
+    for id in &products {
+        let Ok(entity) = decoder.decode_by_id(*id) else {
+            continue;
+        };
+        let has_voids = void_idx.get(id).map(|v| !v.is_empty()).unwrap_or(false);
+        let mesh = if has_voids {
+            router.process_element_with_voids(&entity, &mut decoder, &void_idx)
+        } else {
+            router.process_element(&entity, &mut decoder)
+        };
+        if let Ok(m) = mesh {
+            if m.triangle_count() > 0 {
+                let (mut lo, mut hi) = ([f64::INFINITY; 3], [f64::NEG_INFINITY; 3]);
+                for c in m.positions.chunks(3) {
+                    for k in 0..3 {
+                        lo[k] = lo[k].min(c[k] as f64);
+                        hi[k] = hi[k].max(c[k] as f64);
+                    }
+                }
+                sig.push((*id, m.triangle_count(), volume(&m), open_edges(&m), lo, hi));
+            }
+        }
+    }
+    let wall_ms = t_all.elapsed().as_secs_f64() * 1000.0;
+    let total_tris: usize = sig.iter().map(|s| s.1).sum();
+    // Global mesh-center magnitude — must be small (local) after rebasing, else the
+    // run is f32-jittered and the diff is meaningless.
+    let (mut glo, mut ghi) = ([f64::INFINITY; 3], [f64::NEG_INFINITY; 3]);
+    for (_, _, _, _, lo, hi) in &sig {
+        for k in 0..3 {
+            glo[k] = glo[k].min(lo[k]);
+            ghi[k] = ghi[k].max(hi[k]);
+        }
+    }
+    let center_mag = (0..3)
+        .map(|k| ((glo[k] + ghi[k]) * 0.5).abs())
+        .fold(0.0f64, f64::max);
+    println!(
+        "WALLTIME_MS {wall_ms:.0}   ELEMENTS {}   TOTAL_TRIS {total_tris}   MESH_CENTER_MAG {center_mag:.0}m",
+        sig.len()
+    );
+    if center_mag >= 10_000.0 {
+        println!(
+            "  WARNING: meshes at {center_mag:.0}m — f32 jitter; the strict watertightness gate \
+             should make the fast path DEFER here (per-element router does not relocalize baked \
+             georef coords). Treat absolute diffs with care; watch OPEN_REGRESSIONS=0."
+        );
+    }
+
+    if let Ok(out) = std::env::var("IFCLT_AB_OUT") {
+        let mut f = std::fs::File::create(&out).expect("create out");
+        for (id, tris, vol, open, lo, hi) in &sig {
+            writeln!(
+                f,
+                "{id}\t{tris}\t{vol:.9}\t{open}\t{:.6}\t{:.6}\t{:.6}\t{:.6}\t{:.6}\t{:.6}",
+                lo[0], lo[1], lo[2], hi[0], hi[1], hi[2]
+            )
+            .unwrap();
+        }
+        println!("wrote {} ({} rows)", out, sig.len());
+    }
+
+    // ON run: diff against the OFF reference and ASSERT shape-equivalence.
+    if let Ok(refp) = std::env::var("IFCLT_AB_REF") {
+        let refdata = std::fs::read_to_string(&refp).expect("read ref");
+        // id -> (tris, vol, open, lo[3], hi[3])
+        let mut refmap: HashMap<u32, (usize, f64, usize, [f64; 3], [f64; 3])> = HashMap::new();
+        for line in refdata.lines() {
+            let c: Vec<&str> = line.split('\t').collect();
+            if c.len() == 10 {
+                let f = |i: usize| c[i].parse::<f64>().unwrap();
+                refmap.insert(
+                    c[0].parse().unwrap(),
+                    (
+                        c[1].parse().unwrap(),
+                        c[2].parse().unwrap(),
+                        c[3].parse().unwrap(),
+                        [f(4), f(5), f(6)],
+                        [f(7), f(8), f(9)],
+                    ),
+                );
+            }
+        }
+        let mut fired = 0usize; // tris differ ⇒ fast path changed this element
+        let mut bbox_maxdev = 0.0f64; // primary: AABB deviation (defined for open meshes)
+        let mut bbox_worst = 0u32;
+        let mut vol_maxrel = 0.0f64; // secondary: only where BOTH meshes watertight
+        let mut vol_worst = 0u32;
+        let mut vol_compared = 0usize;
+        let mut open_regress = 0usize; // fast path left MORE open edges than exact
+        let mut worst_open = (0u32, 0usize, 0usize);
+        for (id, tris, vol, open, lo, hi) in &sig {
+            let Some((rtris, rvol, ropen, rlo, rhi)) = refmap.get(id).copied() else {
+                continue;
+            };
+            if *tris != rtris {
+                fired += 1;
+            }
+            // AABB deviation, normalised by the element's diagonal.
+            let diag = ((rhi[0] - rlo[0]).powi(2)
+                + (rhi[1] - rlo[1]).powi(2)
+                + (rhi[2] - rlo[2]).powi(2))
+            .sqrt()
+            .max(1.0e-6);
+            let dev = (0..3)
+                .map(|k| (lo[k] - rlo[k]).abs().max((hi[k] - rhi[k]).abs()))
+                .fold(0.0f64, f64::max)
+                / diag;
+            if dev > bbox_maxdev {
+                bbox_maxdev = dev;
+                bbox_worst = *id;
+            }
+            // Volume only where both are closed (divergence volume is meaningless
+            // for an open mesh — many real IFC hosts are not watertight).
+            if *open == 0 && ropen == 0 {
+                vol_compared += 1;
+                let denom = rvol.abs().max(vol.abs()).max(1.0e-9);
+                let rel = (vol - rvol).abs() / denom;
+                if rel > vol_maxrel {
+                    vol_maxrel = rel;
+                    vol_worst = *id;
+                }
+            }
+            if *open > ropen + 2 {
+                open_regress += 1;
+                if *open - ropen > worst_open.2.saturating_sub(worst_open.1) {
+                    worst_open = (*id, ropen, *open);
+                }
+            }
+        }
+        println!(
+            "\nDIFF vs exact reference:\n  FIRED (tris changed)   {fired} / {} elements\n  BBOX_MAXDEV            {bbox_maxdev:.2e} (rel, worst id={bbox_worst})\n  VOL_MAXREL             {vol_maxrel:.2e}  over {vol_compared} watertight pairs (worst id={vol_worst})\n  OPEN_REGRESSIONS       {open_regress}  (worst id={} {} -> {})",
+            sig.len(),
+            worst_open.0, worst_open.1, worst_open.2
+        );
+        // The fast path must be shape-equivalent (AABB), volume-equivalent where
+        // comparable, and never less watertight than the exact kernel.
+        assert!(
+            bbox_maxdev < 1.0e-3,
+            "planar clip moved an AABB by {bbox_maxdev:.2e} (id={bbox_worst}) — NOT shape-equivalent"
+        );
+        assert!(
+            vol_maxrel < 5.0e-3,
+            "planar clip changed a (watertight) volume by {vol_maxrel:.2e} (id={vol_worst})"
+        );
+        assert_eq!(
+            open_regress, 0,
+            "planar clip left {open_regress} elements LESS watertight than the exact kernel"
+        );
+        println!("  ✓ shape-equivalent to the exact kernel, watertightness preserved");
+    }
+}

--- a/rust/geometry/tests/planar_clip_ab.rs
+++ b/rust/geometry/tests/planar_clip_ab.rs
@@ -80,16 +80,29 @@ fn volume(m: &Mesh) -> f64 {
     v / 6.0
 }
 
-/// Directed edges with no reverse partner (quantized) — 0 ⇒ watertight.
+/// Directed edges with no reverse partner — 0 ⇒ watertight. Quantized on a grid
+/// proportional to the element's own extent so it is correct in any length unit
+/// (a fixed grid reads a mm-stored metre-scale model as full of false cracks).
 fn open_edges(m: &Mesh) -> usize {
-    const Q: f64 = 1.0e5;
     let p = &m.positions;
+    let (mut lo, mut hi) = ([f64::INFINITY; 3], [f64::NEG_INFINITY; 3]);
+    for c in p.chunks(3) {
+        for k in 0..3 {
+            lo[k] = lo[k].min(c[k] as f64);
+            hi[k] = hi[k].max(c[k] as f64);
+        }
+    }
+    if !lo[0].is_finite() {
+        return 0;
+    }
+    let diag = ((hi[0] - lo[0]).powi(2) + (hi[1] - lo[1]).powi(2) + (hi[2] - lo[2]).powi(2)).sqrt();
+    let inv = 1.0 / (diag * 1.0e-4).max(1.0e-12);
     let key = |i: u32| {
         let b = i as usize * 3;
         (
-            (p[b] as f64 * Q).round() as i64,
-            (p[b + 1] as f64 * Q).round() as i64,
-            (p[b + 2] as f64 * Q).round() as i64,
+            (p[b] as f64 * inv).round() as i64,
+            (p[b + 1] as f64 * inv).round() as i64,
+            (p[b + 2] as f64 * inv).round() as i64,
         )
     };
     let mut dir: HashMap<((i64, i64, i64), (i64, i64, i64)), i32> = HashMap::new();
@@ -115,17 +128,15 @@ fn planar_clip_ab() {
     let content = String::from_utf8_lossy(&std::fs::read(&path).expect("read model")).into_owned();
     let entity_index = build_entity_index(&content);
     let mut decoder = EntityDecoder::with_index(&content, entity_index);
-    let mut router = GeometryRouter::with_units(&content, &mut decoder);
-    // Rebase georeferenced models so the RTC=0 harness does not render f32 vertex
-    // jitter on national-grid coordinates (tens of km), which fabricates degenerate
-    // geometry unrelated to the fast path (AGENTS.md / csg_model_profile caveat).
-    // `scan_model_bounds` reads the actual IfcCartesianPoints, so it catches an
-    // offset baked into the geometry (skolebygg) that placement sampling misses.
-    let rtc = ifc_lite_core::scan_model_bounds(content.as_str()).rtc_offset();
-    router.set_rtc_offset(rtc);
-    if rtc != (0.0, 0.0, 0.0) {
-        println!("rebased: RTC offset = ({:.1}, {:.1}, {:.1})", rtc.0, rtc.1, rtc.2);
-    }
+    // No RTC rebase: the fast-path gates are scale-RELATIVE (offset vs host
+    // diagonal), so they handle precision per element without it — and a naive
+    // rebase is actively harmful, because `scan_model_bounds` is unit-unaware and
+    // flags a local building stored in millimetres (e.g. a 47 m Tekla model whose
+    // raw mm coordinates exceed the 10 km threshold) as "georeferenced", flinging
+    // the mesh to a huge coordinate where f32 jitter corrupts the geometry. A truly
+    // georeferenced model (metre coords in the tens of km) simply stays far from
+    // origin here and the magnitude gate defers it — which is the safe outcome.
+    let router = GeometryRouter::with_units(&content, &mut decoder);
     let void_idx = build_void_index(&content);
     let products = list_products(&content);
     let disabled = std::env::var("IFC_LITE_DISABLE_PLANAR_CLIP").is_ok();
@@ -139,7 +150,13 @@ fn planar_clip_ab() {
     let mut sig: Vec<(u32, usize, f64, usize, [f64; 3], [f64; 3])> =
         Vec::with_capacity(products.len());
     let t_all = Instant::now();
+    let only_id: Option<u32> = std::env::var("IFCLT_ONLY_ID").ok().and_then(|s| s.parse().ok());
     for id in &products {
+        if let Some(oid) = only_id {
+            if *id != oid {
+                continue;
+            }
+        }
         let Ok(entity) = decoder.decode_by_id(*id) else {
             continue;
         };
@@ -180,13 +197,12 @@ fn planar_clip_ab() {
         "WALLTIME_MS {wall_ms:.0}   ELEMENTS {}   TOTAL_TRIS {total_tris}   MESH_CENTER_MAG {center_mag:.0}m",
         sig.len()
     );
-    if center_mag >= 10_000.0 {
-        println!(
-            "  WARNING: meshes at {center_mag:.0}m — f32 jitter; the strict watertightness gate \
-             should make the fast path DEFER here (per-element router does not relocalize baked \
-             georef coords). Treat absolute diffs with care; watch OPEN_REGRESSIONS=0."
-        );
-    }
+    // NOTE: meshes are in model units (mm for Tekla), not metres, and the
+    // per-element router does not relocalize. The fast-path gates are now scale-
+    // RELATIVE (offset vs host diagonal), so a large center magnitude on a
+    // locally-coordinated model is fine; only an offset of many host-diagonals
+    // (true georef jitter) makes them defer. Reported for context only.
+    println!("  (mesh center magnitude {center_mag:.0} model-units)");
 
     if let Ok(out) = std::env::var("IFCLT_AB_OUT") {
         let mut f = std::fs::File::create(&out).expect("create out");


### PR DESCRIPTION
## What

Routes the dominant Tekla connection-cut pattern — a solid (or polygonally-bounded-half-space) cutter that acts as a single **half-space end-clip** of the host — through an f64 plane clip + cross-section cap instead of the exact CSG arrangement. ~100–150× cheaper per qualifying cut, geometrically equivalent.

`ClippingProcessor::subtract_one` is the new single entry: it tries `try_planar_clip`, then falls back to the exact `subtract_mesh`. `clip_mesh_with_cap` clips the host to the front half-space (reusing `clip_triangle`), extracts the open cut boundary, stitches closed loops, triangulates the cross-section (outer + holes), and caps it — wound for half-edge cancellation so the result is a watertight solid.

## Why it is only ever a fast path (three gates)

A cutter takes the fast path **only** when all of these hold; otherwise it defers to the exact kernel unchanged:

1. **Convexity** — every cutter vertex lies inside all of its own face planes. A non-convex cutter (L-prism, notched block) is not a half-space and could over-cut.
2. **Single straddle** — exactly one cutter face plane straddles the host, and the host lies entirely inside every other face. Notches, pockets and through-holes straddle on ≥2 faces → defer.
3. **Precision regime** — host coordinates stay under the codebase's 10 km large-coordinate threshold. Above it, f32 ULP exceeds a millimetre, so the cap's watertightness is unverifiable; un-localized georeferenced geometry degrades identically under the exact kernel, so deferring is never worse.
4. **Watertightness** — the capped result must have zero open boundary edges (1 mm grid), else defer.

`IFC_LITE_DISABLE_PLANAR_CLIP=1` (native) forces the exact kernel everywhere.

## Where it is wired

- the solid-cutter `IfcBooleanResult` difference;
- the single `IfcPolygonalBoundedHalfSpace` subtract — where it *also* sidesteps the coincident-side-wall sliver collapse the exact kernel hits when the clip polygon spans the host cross-section;
- the extended-opening void cut.

The simple `IfcHalfSpaceSolid` path (already an O(n) `clip_mesh`) is untouched.

## Validation

- **clip_with_cap suite**: primitive is watertight and volume-matches the exact subtract to <1.3e-4 on axis/oblique/steep cuts; 40/40 generic angled cuts cap cleanly; detection routes end-clips to the fast path and defers holes / pockets / non-convex L-prisms; `subtract_one` fires on a clean end-clip (watertight, matches exact, different triangulation) and defers on a through-hole.
- **Full geometry suite**: 483 passed, **0 snapshot changes** (gable / duplex-PBHS / segmented-roof fixtures unchanged).
- **A/B harness** (`planar_clip_ab`, `#[ignore]`): zero open-edge regressions and shape/volume equivalence vs the exact kernel on a clean local model; full deferral (zero firing, zero regressions) on an adversarial 792 km georeferenced model.

## Honest scope

This accelerates the **spanning convex end-clip** subset (≈1–2 % of elements in the structural models sampled), not every boolean. It does not speed up simple `IfcHalfSpaceSolid` models (already fast) and conservatively defers on un-localized georeferenced models. Real-world magnitude depends on a model's cutter composition; the per-element test harness cannot relocalize baked-georef coordinates, so the firing+speedup on georeferenced structural models is best measured through the production (localizing) viewer path.

Stacked on the `clip_mesh_with_cap` primitive (first commit). Changeset included (`@ifc-lite/geometry` patch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Added a faster planar-clipping/subtraction path for specific convex half-space “end-clip” patterns, with automatic verification and fallback to exact processing for complex or non-conforming geometry.
  * Introduced additional safeguards: if the fast result isn’t sufficiently well-formed (open-edge check), the element is reprocessed with the exact approach and the best result is selected.
  * Added `IFC_LITE_DISABLE_PLANAR_CLIP` to force the exact kernel when required.
* **Tests**
  * Added coverage for capped planar clipping and subtraction behavior, including watertightness/volume consistency checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->