### PR TITLE
fix(viewer): nest IfcElementAssembly/IfcStair parts in the spatial tree + make assemblies selectable (#1133)

### DIFF
--- a/.changeset/assembly-tree-nesting.md
+++ b/.changeset/assembly-tree-nesting.md
@@ -1,0 +1,15 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Show IfcElementAssembly / IfcStair parts in the spatial tree and make assemblies
+selectable (#1133). A decomposing assembly carries no geometry of its own — its
+stair flights, railings, landing slabs and virtual clearance volumes hang off it
+via `IfcRelAggregates` and hold the meshes — so the spatial panel previously
+listed the assembly as a childless leaf, the parts were unreachable, and
+clicking the assembly highlighted nothing. The hierarchy now nests an
+assembly's aggregated parts beneath it (recursively, cycle-guarded), clicking
+the assembly highlights and frames the whole thing, soloing a storey keeps the
+parts (they inherit the storey through the assembly), and `IfcVirtualElement`
+clearance volumes are hidden by default with a new "Virtual Elements"
+visibility toggle.

--- a/apps/viewer/src/components/viewer/GLBExportDialog.tsx
+++ b/apps/viewer/src/components/viewer/GLBExportDialog.tsx
@@ -52,12 +52,13 @@ type ColorSource = 'rendering' | 'shading';
  * matches what the user sees in the viewport.
  */
 function buildHiddenIfcTypes(
-  typeVisibility: { spaces: boolean; spatialZones: boolean; openings: boolean; site: boolean },
+  typeVisibility: { spaces: boolean; spatialZones: boolean; openings: boolean; virtualElements: boolean; site: boolean },
 ): Set<string> {
   const out = new Set<string>();
   if (!typeVisibility.spaces) out.add('IfcSpace');
   if (!typeVisibility.spatialZones) out.add('IfcSpatialZone');
   if (!typeVisibility.openings) out.add('IfcOpeningElement');
+  if (!typeVisibility.virtualElements) out.add('IfcVirtualElement');
   if (!typeVisibility.site) out.add('IfcSite');
   return out;
 }

--- a/apps/viewer/src/components/viewer/HierarchyPanel.tsx
+++ b/apps/viewer/src/components/viewer/HierarchyPanel.tsx
@@ -446,6 +446,23 @@ export function HierarchyPanel() {
       const elementId = node.expressIds[0];
       const modelId = node.modelIds[0];
       const globalId = node.globalIds[0] ?? elementId;
+      const parts = node.assemblyChildGlobalIds;
+
+      if (parts && parts.length > 0) {
+        // A decomposing assembly (IfcElementAssembly, IfcStair-as-container, …)
+        // carries no geometry of its own — highlight + frame all its parts in
+        // one click. The assembly goes last so it becomes the primary selection
+        // (setSelectedEntityIds keys selectedEntityId off the final id), which
+        // keeps the assembly row highlighted in the tree (#1133).
+        setSelectedEntityIds([...parts, globalId]);
+        if (modelId !== 'legacy') {
+          setSelectedEntity({ modelId, expressId: elementId });
+          setActiveModel(modelId);
+        } else {
+          setSelectedEntity(resolveEntityRef(globalId));
+        }
+        return;
+      }
 
       // Clear multi-selection (e.g. from a prior type-group click) so only
       // this single element is highlighted, matching Viewport pick behavior
@@ -487,7 +504,14 @@ export function HierarchyPanel() {
     // Compute visibility inline - for elements check directly, for storeys use getNodeElements
     let nodeHidden = false;
     if (node.type === 'element') {
-      nodeHidden = hiddenEntities.has(node.globalIds[0] ?? node.expressIds[0]);
+      const parts = node.assemblyChildGlobalIds;
+      if (parts && parts.length > 0) {
+        // An assembly reads as hidden only when every part it owns is hidden
+        // (its own geometry-less id never enters hiddenEntities) (#1133).
+        nodeHidden = parts.every((id) => hiddenEntities.has(id));
+      } else {
+        nodeHidden = hiddenEntities.has(node.globalIds[0] ?? node.expressIds[0]);
+      }
     } else if (node.type === 'IfcBuildingStorey' || node.type === 'IfcSpace' || node.type === 'unified-storey' ||
                node.type === 'type-group' || node.type === 'ifc-type' || node.type === 'material-group' ||
                (node.type === 'model-header' && node.id.startsWith('contrib-'))) {

--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -30,6 +30,7 @@ import {
   Info,
   Layers2,
   SquareX,
+  BoxSelect,
   Building2,
   Plus,
   PackagePlus,
@@ -344,6 +345,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
     typeVisibility.spaces,
     typeVisibility.spatialZones,
     typeVisibility.openings,
+    typeVisibility.virtualElements,
     typeVisibility.site,
     typeVisibility.ifcAnnotations,
     typeVisibility.ifcGrid,
@@ -1373,6 +1375,13 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
             description="Door & window voids"
             checked={typeVisibility.openings}
             onChange={() => toggleTypeVisibility('openings')}
+          />
+          <ClassVisibilityRow
+            icon={<BoxSelect className="h-4 w-4 shrink-0" style={{ color: '#9aa0a6' }} />}
+            label="Virtual Elements"
+            description="Non-physical boundaries & clearance volumes"
+            checked={typeVisibility.virtualElements}
+            onChange={() => toggleTypeVisibility('virtualElements')}
           />
           <ClassVisibilityRow
             icon={<Building2 className="h-4 w-4 shrink-0" style={{ color: '#66cc4d' }} />}

--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -21,6 +21,7 @@ import { useSolarSweep } from '@/hooks/useSolarSweep';
 import { getViewerStoreApi, useViewerStore } from '@/store';
 import { toGlobalIdFromModels } from '@/store/globalId';
 import { collectIfcBuildingStoreyElementsWithIfcSpace } from '@/store/basketVisibleSet';
+import type { AggregationRelationships } from '@/utils/aggregation';
 import { useIfc } from '@/hooks/useIfc';
 import { useWebGPU } from '@/hooks/useWebGPU';
 import { cacheFileBlobs, formatFileSize, getCachedFile, getRecentFiles, recordRecentFiles, type RecentFileEntry } from '@/lib/recent-files';
@@ -592,6 +593,7 @@ export function ViewportContainer() {
       prevVis.spaces !== typeVisibility.spaces ||
       prevVis.spatialZones !== typeVisibility.spatialZones ||
       prevVis.openings !== typeVisibility.openings ||
+      prevVis.virtualElements !== typeVisibility.virtualElements ||
       prevVis.site !== typeVisibility.site ||
       filteredTypeModeRef.current !== effectiveViewMode;
     const sourceChanged = filteredSourceRef.current !== allMeshes;
@@ -603,7 +605,7 @@ export function ViewportContainer() {
       filteredTypeModeRef.current = effectiveViewMode;
     }
 
-    const needsFilter = !typeVisibility.spaces || !typeVisibility.spatialZones || !typeVisibility.openings || !typeVisibility.site;
+    const needsFilter = !typeVisibility.spaces || !typeVisibility.spatialZones || !typeVisibility.openings || !typeVisibility.virtualElements || !typeVisibility.site;
     const prevCacheLen = cache.length;
 
     // Only process NEW meshes since last run — O(batch_size) not O(total)
@@ -627,6 +629,7 @@ export function ViewportContainer() {
         if (ifcType === 'IfcSpace' && !typeVisibility.spaces) continue;
         if (ifcType === 'IfcSpatialZone' && !typeVisibility.spatialZones) continue;
         if (ifcType === 'IfcOpeningElement' && !typeVisibility.openings) continue;
+        if (ifcType === 'IfcVirtualElement' && !typeVisibility.virtualElements) continue;
         if (ifcType === 'IfcSite' && !typeVisibility.site) continue;
       }
 
@@ -670,12 +673,16 @@ export function ViewportContainer() {
       for (const [, model] of storeModels) {
         const hierarchy = model.ifcDataStore?.spatialHierarchy;
         if (!hierarchy) continue;
+        // Pass the relationship graph so storey isolation pulls in the parts of
+        // any decomposing assembly (stair flights, railings, …) — they live off
+        // the spatial tree via IfcRelAggregates and would otherwise vanish (#1133).
+        const relationships = model.ifcDataStore?.relationships as AggregationRelationships | undefined;
 
         for (const storeyId of selectedStoreys) {
           const localStoreyId = hierarchy.byStorey.has(storeyId)
             ? storeyId
             : storeyId - (model.idOffset ?? 0);
-          const storeyElementIds = collectIfcBuildingStoreyElementsWithIfcSpace(hierarchy, localStoreyId);
+          const storeyElementIds = collectIfcBuildingStoreyElementsWithIfcSpace(hierarchy, localStoreyId, relationships);
           if (storeyElementIds) {
             for (const originalExpressId of storeyElementIds) {
               combinedGlobalIds.add(toGlobalIdFromModels(storeModels, model.id, originalExpressId));
@@ -687,8 +694,9 @@ export function ViewportContainer() {
       // Legacy single-model mode (offset = 0)
       if (ifcDataStore?.spatialHierarchy && storeModels.size === 0) {
         const hierarchy = ifcDataStore.spatialHierarchy;
+        const relationships = ifcDataStore.relationships as AggregationRelationships | undefined;
         for (const storeyId of selectedStoreys) {
-          const storeyElementIds = collectIfcBuildingStoreyElementsWithIfcSpace(hierarchy, storeyId);
+          const storeyElementIds = collectIfcBuildingStoreyElementsWithIfcSpace(hierarchy, storeyId, relationships);
           if (storeyElementIds) {
             for (const id of storeyElementIds) {
               combinedGlobalIds.add(id);

--- a/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.test.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { IfcTypeEnum, type SpatialHierarchy, type SpatialNode } from '@ifc-lite/data';
+import { IfcTypeEnum, RelationshipType, type SpatialHierarchy, type SpatialNode } from '@ifc-lite/data';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import { useViewerStore, type FederatedModel } from '@/store';
 import { buildTreeData, buildTypeTree, type AuthoredProduct } from './treeDataBuilder';
@@ -94,6 +94,55 @@ function createFacilityDataStore(): IfcDataStore {
       getTypeName: (id: number) => {
         if (id === 4) return 'IfcWall';
         return 'Unknown';
+      },
+    },
+  } as unknown as IfcDataStore;
+}
+
+/** Storey #4 contains an IfcStair #10 that decomposes (IfcRelAggregates) into a
+ *  stair flight #11 and a railing #12 — neither part is directly contained in
+ *  the storey. Mirrors the issue #1133 file. Legacy mode → globalId === expressId. */
+function createAssemblyDataStore(): IfcDataStore {
+  const storeyNode = createSpatialNode(4, IfcTypeEnum.IfcBuildingStorey, 'GROUND');
+  const buildingNode = createSpatialNode(3, IfcTypeEnum.IfcBuilding, 'MY_BUILDING', [storeyNode]);
+  const siteNode = createSpatialNode(2, IfcTypeEnum.IfcSite, 'MY_SITE', [buildingNode]);
+  const projectNode = createSpatialNode(1, IfcTypeEnum.IfcProject, 'MY_PROJECT', [siteNode]);
+
+  const spatialHierarchy: SpatialHierarchy = {
+    project: projectNode,
+    byStorey: new Map([[4, [10]]]), // only the stair is contained, not its parts
+    byBuilding: new Map(),
+    bySite: new Map(),
+    bySpace: new Map(),
+    storeyElevations: new Map(),
+    storeyHeights: new Map(),
+    elementToStorey: new Map([[10, 4]]),
+    getStoreyElements: () => [],
+    getStoreyByElevation: () => null,
+    getContainingSpace: () => null,
+    getPath: () => [],
+  };
+
+  const names: Record<number, string> = {
+    10: 'Stair', 11: 'Flight', 12: 'Railing',
+  };
+  const types: Record<number, string> = {
+    10: 'IfcStair', 11: 'IfcStairFlight', 12: 'IfcRailing',
+  };
+
+  return {
+    spatialHierarchy,
+    entities: {
+      count: 0,
+      getName: (id: number) => names[id] ?? '',
+      getTypeName: (id: number) => types[id] ?? 'Unknown',
+    },
+    relationships: {
+      getRelated: (id: number, relType: RelationshipType, direction: 'forward' | 'inverse') => {
+        if (relType === RelationshipType.Aggregates && direction === 'forward' && id === 10) {
+          return [11, 12];
+        }
+        return [];
       },
     },
   } as unknown as IfcDataStore;
@@ -217,5 +266,38 @@ describe('buildTreeData', () => {
     assert.ok(barrierNode);
     assert.strictEqual(barrierNode.type, 'element');
     assert.strictEqual(barrierNode.ifcType, 'IfcWall');
+  });
+
+  it('nests an assembly stair under the storey and exposes its parts (issue #1133)', () => {
+    useViewerStore.setState({ models: new Map() });
+    const ds = createAssemblyDataStore();
+
+    // Storey expanded but the stair collapsed: it must still advertise children
+    // and carry its parts for one-click highlight/isolate.
+    const collapsed = buildTreeData(new Map(), ds, new Set(['root-1', 'root-1-2', 'root-1-2-3', 'root-1-2-3-4']), false, []);
+    const stair = collapsed.find((n) => n.id === 'element-legacy-10');
+    assert.ok(stair, 'stair appears under the storey');
+    assert.strictEqual(stair.ifcType, 'IfcStair');
+    assert.strictEqual(stair.hasChildren, true, 'assembly is expandable');
+    assert.strictEqual(stair.elementCount, 2, 'badge shows direct part count');
+    assert.deepStrictEqual(stair.assemblyChildGlobalIds, [11, 12], 'parts carried for highlight/isolate');
+    // Parts are hidden until the stair row itself is expanded.
+    assert.strictEqual(collapsed.some((n) => n.id === 'element-legacy-11'), false);
+
+    // Expand the stair → its parts become nested rows one level deeper.
+    const expanded = buildTreeData(
+      new Map(),
+      ds,
+      new Set(['root-1', 'root-1-2', 'root-1-2-3', 'root-1-2-3-4', 'element-legacy-10']),
+      false,
+      [],
+    );
+    const flight = expanded.find((n) => n.id === 'element-legacy-11');
+    const railing = expanded.find((n) => n.id === 'element-legacy-12');
+    assert.ok(flight && railing, 'both parts render when the assembly is expanded');
+    assert.strictEqual(flight.ifcType, 'IfcStairFlight');
+    assert.strictEqual(railing.ifcType, 'IfcRailing');
+    assert.strictEqual(flight.depth, stair.depth + 1, 'parts nest one level under the assembly');
+    assert.strictEqual(flight.hasChildren, false, 'leaf parts are not expandable');
   });
 });

--- a/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.ts
@@ -15,6 +15,11 @@ import type { IfcDataStore } from '@ifc-lite/parser';
 import { buildMaterialUsageIndex } from '@ifc-lite/parser';
 import { useViewerStore, type FederatedModel } from '@/store';
 import { toGlobalIdFromModels } from '@/store/globalId';
+import {
+  collectAggregatedDescendants,
+  getAggregatedChildren,
+  type AggregationRelationships,
+} from '@/utils/aggregation';
 import type { TreeNode, NodeType, StoreyData, UnifiedStorey } from './types';
 
 /** Helper to create elevation key (with 0.5m tolerance for matching) */
@@ -182,6 +187,74 @@ export function getUnifiedStoreyElements(
   return allElements;
 }
 
+/**
+ * Emit one element row and, if it decomposes via `IfcRelAggregates`, its parts
+ * nested underneath (recursively). A decomposing assembly — an
+ * `IfcElementAssembly`, or an `IfcStair`/`IfcRoof`/`IfcRamp` used as a container
+ * — appears in the spatial tree as a leaf contained in its storey, while its
+ * stair flights / railings / landing slabs / virtual clearance volumes hang off
+ * it via aggregation and hold the actual geometry. Without nesting, those parts
+ * were absent from the spatial panel and the assembly was unselectable
+ * (issue #1133).
+ *
+ * `ancestors` is the aggregation path from the storey-level element down to
+ * here, used to break malformed `IfcRelAggregates` cycles.
+ */
+function emitElementSubtree(
+  elementId: number,
+  modelId: string,
+  models: Map<string, FederatedModel>,
+  dataStore: IfcDataStore,
+  depth: number,
+  expandedNodes: Set<string>,
+  nodes: TreeNode[],
+  ancestors: Set<number>,
+): void {
+  const relationships = dataStore.relationships as AggregationRelationships | undefined;
+  const globalId = resolveTreeGlobalId(modelId, elementId, models);
+  const entityType = dataStore.entities?.getTypeName(elementId) || 'Unknown';
+  const entityName = dataStore.entities?.getName(elementId) || `${entityType} #${elementId}`;
+
+  // Direct decomposition children, minus anything already on the path (cycle guard).
+  const childIds = getAggregatedChildren(relationships, elementId)
+    .filter((id) => id !== elementId && !ancestors.has(id));
+  const hasChildren = childIds.length > 0;
+  const nodeId = `element-${modelId}-${elementId}`;
+  const isExpanded = hasChildren && expandedNodes.has(nodeId);
+
+  // All descendant parts carry the geometry — stash their global IDs so a click
+  // on the (geometry-less) assembly can highlight / frame / isolate the whole
+  // thing at once, even while the row is collapsed.
+  const assemblyChildGlobalIds = hasChildren
+    ? collectAggregatedDescendants(relationships, elementId).map((id) =>
+        resolveTreeGlobalId(modelId, id, models),
+      )
+    : undefined;
+
+  nodes.push({
+    id: nodeId,
+    expressIds: [elementId],
+    globalIds: [globalId],
+    modelIds: [modelId],
+    name: entityName,
+    type: 'element',
+    ifcType: entityType,
+    depth,
+    hasChildren,
+    isExpanded,
+    isVisible: true, // Computed lazily during render
+    elementCount: hasChildren ? childIds.length : undefined,
+    assemblyChildGlobalIds,
+  });
+
+  if (isExpanded) {
+    const nextAncestors = new Set(ancestors).add(elementId);
+    for (const childId of childIds) {
+      emitElementSubtree(childId, modelId, models, dataStore, depth + 1, expandedNodes, nodes, nextAncestors);
+    }
+  }
+}
+
 /** Recursively build spatial nodes (Project -> Site -> Building) */
 function buildSpatialNodes(
   spatialNode: SpatialNode,
@@ -259,26 +332,11 @@ function buildSpatialNodes(
       );
     }
 
-    // Add direct spatial children elements for expanded nodes.
+    // Add direct spatial children elements for expanded nodes — each may itself
+    // decompose into nested parts via IfcRelAggregates (issue #1133).
     if (hasDirectElements) {
       for (const elementId of elements) {
-        const globalId = resolveTreeGlobalId(modelId, elementId, models);
-        const entityType = dataStore.entities?.getTypeName(elementId) || 'Unknown';
-        const entityName = dataStore.entities?.getName(elementId) || `${entityType} #${elementId}`;
-
-        nodes.push({
-          id: `element-${modelId}-${elementId}`,
-          expressIds: [elementId],
-          globalIds: [globalId],
-          modelIds: [modelId],
-          name: entityName,
-          type: 'element',
-          ifcType: entityType,
-          depth: depth + 1,
-          hasChildren: false,
-          isExpanded: false,
-          isVisible: true, // Computed lazily during render
-        });
+        emitElementSubtree(elementId, modelId, models, dataStore, depth + 1, expandedNodes, nodes, new Set());
       }
     }
   }
@@ -343,27 +401,11 @@ export function buildTreeData(
             _idOffset: offset,
           });
 
-          // If contribution expanded, show elements
-          if (contribExpanded) {
-            const dataStore = model?.ifcDataStore;
+          // If contribution expanded, show elements (assemblies nest their
+          // IfcRelAggregates parts — issue #1133).
+          if (contribExpanded && model?.ifcDataStore) {
             for (const elementId of storey.elements) {
-              const globalId = resolveTreeGlobalId(storey.modelId, elementId, models);
-              const entityType = dataStore?.entities?.getTypeName(elementId) || 'Unknown';
-              const entityName = dataStore?.entities?.getName(elementId) || `${entityType} #${elementId}`;
-
-              nodes.push({
-                id: `element-${storey.modelId}-${elementId}`,
-                expressIds: [elementId],
-                globalIds: [globalId],
-                modelIds: [storey.modelId],
-                name: entityName,
-                type: 'element',
-                ifcType: entityType,
-                depth: 2,
-                hasChildren: false,
-                isExpanded: false,
-                isVisible: true, // Computed lazily during render
-              });
+              emitElementSubtree(elementId, storey.modelId, models, model.ifcDataStore, 2, expandedNodes, nodes, new Set());
             }
           }
         }

--- a/apps/viewer/src/components/viewer/hierarchy/types.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/types.ts
@@ -48,6 +48,15 @@ export interface TreeNode {
   storeyElevation?: number;
   /** Internal: ID offset for lazy visibility computation */
   _idOffset?: number;
+  /**
+   * For a decomposing assembly element (IfcElementAssembly, an IfcStair used as
+   * a container, …): the federated global IDs of every `IfcRelAggregates`
+   * descendant part. Present only when the element actually aggregates parts.
+   * `globalIds[0]` stays the assembly itself (so tree selection + hidden-state
+   * keep working); these parts carry the geometry and are used to highlight /
+   * frame / isolate the whole assembly at once (issue #1133).
+   */
+  assemblyChildGlobalIds?: number[];
 }
 
 /** Data for a storey from a single model */

--- a/apps/viewer/src/components/viewer/hierarchy/useHierarchyTree.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/useHierarchyTree.ts
@@ -309,7 +309,11 @@ export function useHierarchyTree({ models, ifcDataStore, isMultiModel, geometryR
         return [...node.globalIds, ...toGlobalIdsForModel(modelId, localIds)];
       }
     } else if (node.type === 'element') {
-      return node.globalIds;
+      // A decomposing assembly folds in its IfcRelAggregates parts so the eye
+      // toggle / isolate / basket act on the whole assembly at once (#1133).
+      return node.assemblyChildGlobalIds && node.assemblyChildGlobalIds.length > 0
+        ? [...node.globalIds, ...node.assemblyChildGlobalIds]
+        : node.globalIds;
     }
     // Spatial containers (Project, Site, Building) and top-level models don't have direct element visibility toggle
     return [];

--- a/apps/viewer/src/sdk/adapters/visibility-adapter.ts
+++ b/apps/viewer/src/sdk/adapters/visibility-adapter.ts
@@ -7,6 +7,7 @@ import type { StoreApi } from './types.js';
 import { getModelForRef, type ModelLike } from './model-compat.js';
 import { collectSpatialSubtreeElementsWithIfcSpace } from '../../store/basketVisibleSet.js';
 import { toGlobalIdForRef, toGlobalIdFromModels } from '../../store/globalId.js';
+import type { AggregationRelationships } from '../../utils/aggregation.js';
 import { isSpaceLikeSpatialTypeName, isSpatialStructureTypeName, type SpatialNode } from '@ifc-lite/data';
 
 function findDescendantNode(root: SpatialNode, expressId: number): SpatialNode | null {
@@ -41,7 +42,11 @@ function expandSpatialRef(ref: EntityRef, model: ModelLike): number[] {
   const startNode = findDescendantNode(hierarchy.project, ref.expressId);
   if (!startNode) return [ref.expressId];
 
-  const ids = collectSpatialSubtreeElementsWithIfcSpace(hierarchy, ref.expressId);
+  const ids = collectSpatialSubtreeElementsWithIfcSpace(
+    hierarchy,
+    ref.expressId,
+    dataStore.relationships as AggregationRelationships | undefined,
+  );
   return ids && ids.length > 0 ? ids : [ref.expressId];
 }
 

--- a/apps/viewer/src/store/basketVisibleSet.test.ts
+++ b/apps/viewer/src/store/basketVisibleSet.test.ts
@@ -4,7 +4,8 @@
 
 import assert from 'node:assert/strict';
 import { beforeEach, describe, it } from 'node:test';
-import { IfcTypeEnum, type SpatialHierarchy, type SpatialNode } from '@ifc-lite/data';
+import { IfcTypeEnum, RelationshipType, type SpatialHierarchy, type SpatialNode } from '@ifc-lite/data';
+import type { AggregationRelationships } from '../utils/aggregation.js';
 import {
   collectSpatialSubtreeElementsWithIfcSpace,
   getSmartBasketInputFromStore,
@@ -48,6 +49,44 @@ describe('collectSpatialSubtreeElementsWithIfcSpace', () => {
     };
 
     assert.deepEqual(collectSpatialSubtreeElementsWithIfcSpace(hierarchy, 2), [4]);
+  });
+
+  it('pulls aggregated assembly parts into a storey when relationships are supplied (issue #1133)', () => {
+    // Storey #4 contains an IfcStair #10 whose parts (#11, #12, #13) hang off it
+    // via IfcRelAggregates and are NOT directly contained in the storey.
+    const storeyNode = createNode(4, IfcTypeEnum.IfcBuildingStorey, [], [10]);
+    const buildingNode = createNode(3, IfcTypeEnum.IfcBuilding, [storeyNode], []);
+    const projectNode = createNode(1, IfcTypeEnum.IfcProject, [buildingNode], []);
+
+    const hierarchy: SpatialHierarchy = {
+      project: projectNode,
+      byStorey: new Map([[4, [10]]]),
+      byBuilding: new Map(),
+      bySite: new Map(),
+      bySpace: new Map(),
+      storeyElevations: new Map(),
+      storeyHeights: new Map(),
+      elementToStorey: new Map([[10, 4]]),
+      getStoreyElements: () => [],
+      getStoreyByElevation: () => null,
+      getContainingSpace: () => null,
+      getPath: () => [],
+    };
+
+    const relationships: AggregationRelationships = {
+      getRelated: (id, relType, direction) =>
+        relType === RelationshipType.Aggregates && direction === 'forward' && id === 10
+          ? [11, 12, 13]
+          : [],
+    };
+
+    // Without the graph (back-compat): only the stair, parts vanish.
+    assert.deepEqual(collectSpatialSubtreeElementsWithIfcSpace(hierarchy, 4), [10]);
+    // With the graph: the whole assembly travels with the storey.
+    assert.deepEqual(
+      collectSpatialSubtreeElementsWithIfcSpace(hierarchy, 4, relationships),
+      [10, 11, 12, 13],
+    );
   });
 
   it('keeps the selected container when the spatial subtree has no descendant elements', () => {

--- a/apps/viewer/src/store/basketVisibleSet.ts
+++ b/apps/viewer/src/store/basketVisibleSet.ts
@@ -15,6 +15,7 @@ import type { EntityRef } from './types.js';
 import { entityRefToString, stringToEntityRef } from './types.js';
 import { useViewerStore } from './index.js';
 import { toGlobalIdFromModels } from './globalId.js';
+import { collectAggregatedDescendants, type AggregationRelationships } from '../utils/aggregation.js';
 
 type ViewerStateSnapshot = ReturnType<typeof useViewerStore.getState>;
 
@@ -81,6 +82,7 @@ function visibilityFingerprint(state: ViewerStateSnapshot): string {
     digestNumberSet(state.selectedStoreys),
     tv.spaces ? 1 : 0,
     tv.openings ? 1 : 0,
+    tv.virtualElements ? 1 : 0,
     tv.site ? 1 : 0,
     state.models.size,
     modelParts.join(';'),
@@ -109,6 +111,7 @@ function matchesTypeVisibility(ifcType: string | undefined, typeVisibility: View
   if (ifcType === 'IfcSpace' && !typeVisibility.spaces) return false;
   if (ifcType === 'IfcSpatialZone' && !typeVisibility.spatialZones) return false;
   if (ifcType === 'IfcOpeningElement' && !typeVisibility.openings) return false;
+  if (ifcType === 'IfcVirtualElement' && !typeVisibility.virtualElements) return false;
   if (ifcType === 'IfcSite' && !typeVisibility.site) return false;
   return true;
 }
@@ -141,7 +144,11 @@ function findSpatialNode(root: SpatialNode, expressId: number): SpatialNode | nu
 }
 
 function getContainerElementIds(dataStore: IfcDataStore, containerExpressId: number): number[] {
-  return collectSpatialSubtreeElementsWithIfcSpace(dataStore.spatialHierarchy, containerExpressId) ?? [];
+  return collectSpatialSubtreeElementsWithIfcSpace(
+    dataStore.spatialHierarchy,
+    containerExpressId,
+    dataStore.relationships as AggregationRelationships | undefined
+  ) ?? [];
 }
 
 function expandRefToElements(state: ViewerStateSnapshot, ref: EntityRef): EntityRef[] {
@@ -265,15 +272,17 @@ function getExpandedSelectionRefs(state: ViewerStateSnapshot): EntityRef[] {
  */
 export function collectIfcBuildingStoreyElementsWithIfcSpace(
   hierarchy: SpatialHierarchy,
-  storeyId: number
+  storeyId: number,
+  relationships?: AggregationRelationships
 ): number[] | null {
   if (!hierarchy.byStorey.has(storeyId)) return null;
-  return collectSpatialSubtreeElementsWithIfcSpace(hierarchy, storeyId);
+  return collectSpatialSubtreeElementsWithIfcSpace(hierarchy, storeyId, relationships);
 }
 
 export function collectSpatialSubtreeElementsWithIfcSpace(
   hierarchy: SpatialHierarchy | undefined,
-  expressId: number
+  expressId: number,
+  relationships?: AggregationRelationships
 ): number[] | null {
   if (!hierarchy?.project) return null;
 
@@ -282,18 +291,29 @@ export function collectSpatialSubtreeElementsWithIfcSpace(
 
   const combined: number[] = [];
   const seen = new Set<number>();
+  const add = (id: number) => {
+    if (seen.has(id)) return;
+    seen.add(id);
+    combined.push(id);
+  };
   const stack: SpatialNode[] = [startNode];
 
   while (stack.length > 0) {
     const current = stack.pop()!;
-    if (current.type === IfcTypeEnum.IfcSpace && !seen.has(current.expressId)) {
-      seen.add(current.expressId);
-      combined.push(current.expressId);
+    if (current.type === IfcTypeEnum.IfcSpace) {
+      add(current.expressId);
     }
     for (const elementId of current.elements || []) {
-      if (seen.has(elementId)) continue;
-      seen.add(elementId);
-      combined.push(elementId);
+      add(elementId);
+      // A decomposing assembly (IfcElementAssembly, IfcStair-as-container, …)
+      // keeps its parts off the spatial tree, so without this they have no
+      // storey assignment and storey isolation would drop the stair flights /
+      // railings / landing slabs / virtual clearance volumes (#1133).
+      if (relationships) {
+        for (const descId of collectAggregatedDescendants(relationships, elementId)) {
+          add(descId);
+        }
+      }
     }
     for (const child of current.children || []) {
       stack.push(child);
@@ -312,10 +332,11 @@ function computeStoreyIsolation(state: ViewerStateSnapshot): Set<number> | null 
     for (const [, model] of state.models) {
       const hierarchy = model.ifcDataStore?.spatialHierarchy;
       if (!hierarchy) continue;
+      const relationships = model.ifcDataStore?.relationships as AggregationRelationships | undefined;
       const offset = model.idOffset ?? 0;
       for (const storeyId of state.selectedStoreys) {
         const localStoreyId = hierarchy.byStorey.has(storeyId) ? storeyId : storeyId - offset;
-        const storeyElementIds = collectIfcBuildingStoreyElementsWithIfcSpace(hierarchy, localStoreyId);
+        const storeyElementIds = collectIfcBuildingStoreyElementsWithIfcSpace(hierarchy, localStoreyId, relationships);
         if (!storeyElementIds) continue;
         for (const localId of storeyElementIds) {
           ids.add(toGlobalIdFromModels(state.models, model.id, localId));
@@ -324,8 +345,9 @@ function computeStoreyIsolation(state: ViewerStateSnapshot): Set<number> | null 
     }
   } else if (state.ifcDataStore?.spatialHierarchy) {
     const hierarchy = state.ifcDataStore.spatialHierarchy;
+    const relationships = state.ifcDataStore.relationships as AggregationRelationships | undefined;
     for (const storeyId of state.selectedStoreys) {
-      const storeyElementIds = collectIfcBuildingStoreyElementsWithIfcSpace(hierarchy, storeyId);
+      const storeyElementIds = collectIfcBuildingStoreyElementsWithIfcSpace(hierarchy, storeyId, relationships);
       if (!storeyElementIds) continue;
       for (const id of storeyElementIds) {
         ids.add(id);

--- a/apps/viewer/src/store/constants.ts
+++ b/apps/viewer/src/store/constants.ts
@@ -157,12 +157,13 @@ export const UI_DEFAULTS = {
  * user can clear an individual preference without nuking the rest.
  */
 export const TYPE_VISIBILITY_STORAGE_KEYS = {
-  spaces:         'ifc-lite-ifc-spaces-visible',
-  spatialZones:   'ifc-lite-ifc-spatial-zones-visible',
-  openings:       'ifc-lite-ifc-openings-visible',
-  site:           'ifc-lite-ifc-site-visible',
-  ifcAnnotations: 'ifc-lite-ifc-annotations-visible',
-  ifcGrid:        'ifc-lite-ifc-grid-visible',
+  spaces:          'ifc-lite-ifc-spaces-visible',
+  spatialZones:    'ifc-lite-ifc-spatial-zones-visible',
+  openings:        'ifc-lite-ifc-openings-visible',
+  virtualElements: 'ifc-lite-ifc-virtual-elements-visible',
+  site:            'ifc-lite-ifc-site-visible',
+  ifcAnnotations:  'ifc-lite-ifc-annotations-visible',
+  ifcGrid:         'ifc-lite-ifc-grid-visible',
 } as const;
 
 /** Legacy alias — kept until external callers migrate. */
@@ -191,6 +192,9 @@ export const TYPE_VISIBILITY_SEMANTIC_DEFAULTS: TypeVisibility = {
   spaces: false,
   spatialZones: false,
   openings: false,
+  // IfcVirtualElement off — non-physical clearance/boundary volumes that
+  // obscure real geometry when present (issue #1133).
+  virtualElements: false,
   site: true,
   ifcAnnotations: true,
   ifcGrid: true,
@@ -209,10 +213,11 @@ export const TYPE_VISIBILITY_SEMANTIC_DEFAULTS: TypeVisibility = {
  */
 export function getPersistedTypeVisibility(): TypeVisibility {
   return {
-    spaces:         readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.spaces, TYPE_VISIBILITY_SEMANTIC_DEFAULTS.spaces),
-    spatialZones:   readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.spatialZones, TYPE_VISIBILITY_SEMANTIC_DEFAULTS.spatialZones),
-    openings:       readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.openings, TYPE_VISIBILITY_SEMANTIC_DEFAULTS.openings),
-    site:           readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.site, TYPE_VISIBILITY_SEMANTIC_DEFAULTS.site),
+    spaces:          readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.spaces, TYPE_VISIBILITY_SEMANTIC_DEFAULTS.spaces),
+    spatialZones:    readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.spatialZones, TYPE_VISIBILITY_SEMANTIC_DEFAULTS.spatialZones),
+    openings:        readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.openings, TYPE_VISIBILITY_SEMANTIC_DEFAULTS.openings),
+    virtualElements: readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.virtualElements, TYPE_VISIBILITY_SEMANTIC_DEFAULTS.virtualElements),
+    site:            readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.site, TYPE_VISIBILITY_SEMANTIC_DEFAULTS.site),
     ifcAnnotations: readPersistedBool(TYPE_VISIBILITY_STORAGE_KEYS.ifcAnnotations, TYPE_VISIBILITY_SEMANTIC_DEFAULTS.ifcAnnotations),
     // Issue #862. Migration: if the new grid key isn't set yet, fall back to
     // the legacy combined `ifcAnnotations` preference so a user who turned

--- a/apps/viewer/src/store/slices/visibilitySlice.test.ts
+++ b/apps/viewer/src/store/slices/visibilitySlice.test.ts
@@ -290,6 +290,7 @@ describe('VisibilitySlice', () => {
         spaces: false,
         spatialZones: false,
         openings: false,
+        virtualElements: false,
         site: true,
         ifcAnnotations: true,
         ifcGrid: true,

--- a/apps/viewer/src/store/slices/visibilitySlice.ts
+++ b/apps/viewer/src/store/slices/visibilitySlice.ts
@@ -59,7 +59,7 @@ export interface VisibilitySlice {
   clearAllFilters: () => void;
   showAll: () => void;
   isEntityVisible: (id: number) => boolean;
-  toggleTypeVisibility: (type: 'spaces' | 'spatialZones' | 'openings' | 'site' | 'ifcAnnotations' | 'ifcGrid') => void;
+  toggleTypeVisibility: (type: 'spaces' | 'spatialZones' | 'openings' | 'virtualElements' | 'site' | 'ifcAnnotations' | 'ifcGrid') => void;
   /** Restore every type-visibility toggle to its semantic default (and persist). */
   resetTypeVisibility: () => void;
   /** Set the Model/Types 3D view mode (and persist). */

--- a/apps/viewer/src/store/types.ts
+++ b/apps/viewer/src/store/types.ts
@@ -201,6 +201,13 @@ export interface TypeVisibility {
   spatialZones: boolean;
   /** IfcOpeningElement - off by default */
   openings: boolean;
+  /**
+   * IfcVirtualElement - off by default. Non-physical placeholders (space
+   * boundaries, "free space"/clearance volumes around stairs) that carry
+   * geometry in some exports but aren't real building elements; rendering them
+   * clutters the view with translucent boxes (issue #1133).
+   */
+  virtualElements: boolean;
   /** IfcSite - on by default (when has geometry) */
   site: boolean;
   /** IfcAnnotation (2D symbolic curves) - on by default when present */

--- a/apps/viewer/src/utils/aggregation.test.ts
+++ b/apps/viewer/src/utils/aggregation.test.ts
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { RelationshipType } from '@ifc-lite/data';
+import {
+  collectAggregatedDescendants,
+  getAggregatedChildren,
+  type AggregationRelationships,
+} from './aggregation';
+
+/** Minimal forward-only IfcRelAggregates graph from an adjacency map. */
+function makeRelationships(adjacency: Record<number, number[]>): AggregationRelationships {
+  return {
+    getRelated(entityId, relType, direction) {
+      if (relType !== RelationshipType.Aggregates || direction !== 'forward') return [];
+      return adjacency[entityId] ?? [];
+    },
+  };
+}
+
+describe('aggregation helpers', () => {
+  it('getAggregatedChildren returns direct children only', () => {
+    const rel = makeRelationships({ 1: [2, 3], 2: [4] });
+    assert.deepStrictEqual(getAggregatedChildren(rel, 1), [2, 3]);
+    assert.deepStrictEqual(getAggregatedChildren(rel, 2), [4]);
+    assert.deepStrictEqual(getAggregatedChildren(rel, 4), []);
+    assert.deepStrictEqual(getAggregatedChildren(undefined, 1), []);
+  });
+
+  it('collectAggregatedDescendants walks the whole subtree in pre-order, excluding the root', () => {
+    // 1 ─┬ 2 ─ 4
+    //    └ 3 ─┬ 5
+    //         └ 6
+    const rel = makeRelationships({ 1: [2, 3], 2: [4], 3: [5, 6] });
+    assert.deepStrictEqual(collectAggregatedDescendants(rel, 1), [2, 4, 3, 5, 6]);
+  });
+
+  it('flat assembly (stair → 13 parts) returns every part', () => {
+    const parts = [351, 561, 684, 757, 794, 821, 864, 879, 3111, 3140, 5276, 5302, 11299];
+    const rel = makeRelationships({ 1124: parts });
+    assert.deepStrictEqual(collectAggregatedDescendants(rel, 1124), parts);
+  });
+
+  it('terminates on a malformed aggregation cycle', () => {
+    // A aggregates B, B aggregates A — must not loop forever.
+    const rel = makeRelationships({ 1: [2], 2: [1] });
+    assert.deepStrictEqual(collectAggregatedDescendants(rel, 1), [2]);
+  });
+
+  it('returns nothing for a leaf or a missing relationship graph', () => {
+    const rel = makeRelationships({ 1: [2] });
+    assert.deepStrictEqual(collectAggregatedDescendants(rel, 2), []);
+    assert.deepStrictEqual(collectAggregatedDescendants(undefined, 1), []);
+  });
+});

--- a/apps/viewer/src/utils/aggregation.ts
+++ b/apps/viewer/src/utils/aggregation.ts
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Helpers for IFC decomposition (`IfcRelAggregates`).
+ *
+ * An assembly — `IfcElementAssembly`, an `IfcStair`/`IfcRoof`/`IfcRamp` used as
+ * a container, a wall with `IfcBuildingElementPart`s — carries no geometry of
+ * its own; its parts (stair flights, railings, landing slabs, virtual clearance
+ * volumes, …) hang off it via `IfcRelAggregates` and hold the actual meshes.
+ * The spatial hierarchy only records the assembly as a leaf contained in its
+ * storey, so the parts are invisible to anything that walks the tree (the
+ * spatial panel, storey isolation, assembly selection). These helpers recover
+ * the parts straight from the relationship graph, which both fresh parses and
+ * cache loads retain (issue #1133).
+ */
+
+import { RelationshipType } from '@ifc-lite/data';
+
+/** Structural view of the relationship graph — both the parser's
+ *  `RelationshipGraph` and the cache-rebuilt graph satisfy it. */
+export interface AggregationRelationships {
+  getRelated(
+    entityId: number,
+    relType: RelationshipType,
+    direction: 'forward' | 'inverse'
+  ): number[];
+}
+
+/** Direct `IfcRelAggregates` children of `expressId` (one level down). */
+export function getAggregatedChildren(
+  relationships: AggregationRelationships | undefined,
+  expressId: number
+): number[] {
+  if (!relationships) return [];
+  return relationships.getRelated(expressId, RelationshipType.Aggregates, 'forward');
+}
+
+/**
+ * All decomposition descendants of `rootId` via `IfcRelAggregates`, depth-first
+ * and excluding `rootId` itself. Cycle-guarded against malformed files
+ * (A aggregates B, B aggregates A) so it always terminates. Order is a stable
+ * pre-order so callers can rely on it for display.
+ */
+export function collectAggregatedDescendants(
+  relationships: AggregationRelationships | undefined,
+  rootId: number
+): number[] {
+  if (!relationships) return [];
+  const out: number[] = [];
+  const seen = new Set<number>([rootId]);
+  // DFS with an explicit stack; push children in reverse so siblings keep
+  // their authored order in the pre-order output.
+  const stack: number[] = [];
+  const pushChildren = (parentId: number) => {
+    const kids = relationships.getRelated(parentId, RelationshipType.Aggregates, 'forward');
+    for (let i = kids.length - 1; i >= 0; i--) stack.push(kids[i]);
+  };
+  pushChildren(rootId);
+  while (stack.length > 0) {
+    const id = stack.pop()!;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+    pushChildren(id);
+  }
+  return out;
+}


### PR DESCRIPTION
Closes #1133.

## Diagnosis

The geometry library is fine — the reporter's own library-based app renders the assembly parts correctly (its tree shows the `IfcStair` expanded to all 13 parts, and selecting the landing slab highlights it). The bug is entirely in **`@ifc-lite/viewer`'s spatial tree + selection**.

A decomposing assembly — `IfcElementAssembly`, or an `IfcStair`/`IfcRoof`/`IfcRamp` used as a container — carries **no geometry of its own** (`Representation = $`). Its stair flights, railings, landing slabs and virtual clearance volumes hang off it via `IfcRelAggregates` and hold the meshes. The spatial hierarchy only records the assembly as a leaf contained in its storey, so:

- the spatial panel listed the assembly as a **childless leaf** — the parts were absent and unreachable;
- clicking the assembly **highlighted nothing** (it has no own mesh, and the tree node carried only its own id);
- soloing a storey **dropped the parts** (they have no storey assignment — only aggregation links them to the assembly).

In the issue file the stair geometry *does* render in 3D; the complaint is the tree + selectability (plus the `IfcVirtualElement` clearance boxes cluttering the view).

## Fix

- **Nest parts in the tree** (`treeDataBuilder.ts`): an element that decomposes via `IfcRelAggregates` becomes an expandable node with its parts nested recursively (cycle-guarded). Read straight from the relationship graph, which both fresh parses and cache loads retain.
- **Selectable assembly** (`HierarchyPanel.tsx` / `useHierarchyTree.ts`): clicking the assembly highlights + frames all its parts at once; parts stay individually selectable once expanded; the eye toggle / isolate / basket act on the whole assembly.
- **Storey isolation** (`basketVisibleSet.ts`): the storey-subtree collector now folds in each contained element's aggregated descendants, so soloing a storey keeps the assembly parts.
- **Hide `IfcVirtualElement` by default**: new "Virtual Elements" toggle in the visibility menu (off by default like openings/spaces) — non-physical boundary/clearance volumes that otherwise clutter the view. Mirrored in the GLB export filter.

## Tests

- `utils/aggregation.test.ts` — descendant walk, pre-order, the 13-part flat-stair case, cycle termination, missing-graph fallback.
- `treeDataBuilder.test.ts` — assembly nests under its storey, advertises children + part count while collapsed, carries parts for highlight, and expands to nested part rows.
- `basketVisibleSet.test.ts` — storey collection pulls in aggregated parts when the relationship graph is supplied (and stays back-compatible without it).
- `visibilitySlice.test.ts` — default-shape updated for the new toggle.

`tsc --noEmit` clean; 53 viewer unit tests pass.

## Notes / follow-ups

- Parts render in 3D today; this PR makes them browsable, selectable, and storey-isolation-safe — and stops virtual clearance volumes from obscuring real geometry.
- A full in-browser pass wasn't run here (needs the wasm dev pipeline); verification is via the unit suite + typecheck + the reporter's screenshots. Worth a quick manual look at the linked file before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Assembly elements (e.g., stairs) now display component parts nested in the hierarchy.
  * Assembly selection now highlights the complete assembly with all aggregated parts.
  * Added "Virtual Elements" visibility toggle (hidden by default).
  * Storey isolation now preserves assembly parts.

* **Bug Fixes**
  * Virtual elements are hidden by default in exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->