### PR TITLE
fix(geometry): cap unbounded IfcHalfSpaceSolid clips (restore #1024-deleted section cap)

### DIFF
--- a/.changeset/halfspace-clip-cap.md
+++ b/.changeset/halfspace-clip-cap.md
@@ -1,0 +1,11 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Cap the cut face of unbounded `IfcHalfSpaceSolid` differences (gable roof-trims, mono-pitch eaves, Revit top-trims).
+
+The pure-Rust kernel consolidation (#1024) deleted the in-tree BSP kernel along with the polygon cap that closed the cross-section left by the fast plane-clip path, but kept that path for unbounded `IfcHalfSpaceSolid` operands. With no cap, every such clip produced an **open, inverted shell** (negative signed volume, dozens of open boundary edges) instead of a watertight solid — the roof-clipped wall rendered as a broken/spiky surface.
+
+The clip now re-closes the section: it chains the on-plane open boundary into loops, classifies them into outer rings and holes, triangulates each region with the kernel CDT, and winds the cap to face the removed side. If the boundary is non-manifold or does not close (a non-watertight host), it bails and leaves the output unchanged — never worse than before.
+
+On AC20-FZK-Haus the two roof-clipped upper walls go from `14 tris / −8.4 m³ / 16 open edges` to `20 tris / +2.06 m³ / 0 open edges`; void-cut walls are untouched.

--- a/rust/geometry/src/processors/boolean.rs
+++ b/rust/geometry/src/processors/boolean.rs
@@ -244,7 +244,13 @@ impl BooleanClippingProcessor {
 
         let plane = Plane::new(plane_point, clip_normal);
         let processor = ClippingProcessor::new();
-        processor.clip_mesh(mesh, &plane)
+        let mut clipped = processor.clip_mesh(mesh, &plane)?;
+        // The plane clip removes the half-space but leaves the cut cross-section
+        // OPEN (the BSP kernel's polygon cap was deleted with the BSP port in
+        // #1024). Re-close it: a watertight host clipped by a plane leaves an
+        // open boundary lying on that plane, forming the section to cap.
+        cap_half_space_clip(&mut clipped, plane_point, clip_normal);
+        Ok(clipped)
     }
 
     fn parse_polygonal_boundary_2d(
@@ -1180,6 +1186,254 @@ fn plane_is_coincident_with_host_face(
     false
 }
 
+/// Close the planar cut left by an unbounded `IfcHalfSpaceSolid` DIFFERENCE.
+///
+/// `ClippingProcessor::clip_mesh` clips each triangle to the half-plane but
+/// emits nothing for the cut cross-section — before #1024 the in-tree BSP
+/// kernel's polygon cap closed it; deleting BSP left this path uncapped, so
+/// gable roof-trims, mono-pitch eaves and Revit top-trim walls render as open,
+/// inverted shells (negative signed volume, dozens of open edges).
+///
+/// A watertight host clipped by a plane has exactly one open boundary — the
+/// section, lying on the cut plane. We weld coincident vertices (the clipper
+/// emits bit-identical coordinates for shared cut points, so an exact f32-bit
+/// key merges them without a tolerance grid that could fuse distinct corners),
+/// chain the on-plane boundary half-edges into loops, classify them into
+/// outer rings and holes by even-odd nesting, triangulate each region with the
+/// kernel's CDT, and append the result wound to face `-clip_normal` (away from
+/// the kept `+clip_normal` material). If the boundary is non-manifold or does
+/// not close (a non-watertight host), we bail and leave the mesh unchanged —
+/// never worse than the uncapped output.
+fn cap_half_space_clip(mesh: &mut Mesh, plane_point: Point3<f64>, clip_normal: Vector3<f64>) {
+    use crate::triangulation::{project_to_2d, triangulate_polygon_with_holes_refined};
+    use std::collections::{HashMap, HashSet};
+
+    // Escape hatch: revert to the pre-fix (uncapped) plane clip without a
+    // rebuild, should the section cap ever misbehave on an unforeseen host.
+    if std::env::var_os("IFC_LITE_HALFSPACE_CAP_OFF").is_some() {
+        return;
+    }
+    let tri_n = mesh.indices.len() / 3;
+    let vcount = mesh.positions.len() / 3;
+    if tri_n == 0 || vcount < 3 {
+        return;
+    }
+    let n = match clip_normal.try_normalize(1e-12) {
+        Some(v) => v,
+        None => return,
+    };
+
+    // Diagonal-relative tolerance for "lies on the cut plane".
+    let (mn, mx) = mesh.bounds();
+    let diag =
+        ((mx.x - mn.x).powi(2) + (mx.y - mn.y).powi(2) + (mx.z - mn.z).powi(2)).sqrt() as f64;
+    let on_plane_eps = (diag * 1.0e-5).max(1.0e-6);
+
+    // Weld coincident vertices by exact f32 bits.
+    let mut weld: HashMap<(u32, u32, u32), u32> = HashMap::new();
+    let mut pos: Vec<Point3<f64>> = Vec::new();
+    let mut on_plane: Vec<bool> = Vec::new();
+    let mut welded: Vec<u32> = Vec::with_capacity(vcount);
+    for i in 0..vcount {
+        let key = (
+            mesh.positions[i * 3].to_bits(),
+            mesh.positions[i * 3 + 1].to_bits(),
+            mesh.positions[i * 3 + 2].to_bits(),
+        );
+        let id = match weld.get(&key) {
+            Some(&id) => id,
+            None => {
+                let p = Point3::new(
+                    mesh.positions[i * 3] as f64,
+                    mesh.positions[i * 3 + 1] as f64,
+                    mesh.positions[i * 3 + 2] as f64,
+                );
+                let id = pos.len() as u32;
+                on_plane.push((p - plane_point).dot(&n).abs() <= on_plane_eps);
+                pos.push(p);
+                weld.insert(key, id);
+                id
+            }
+        };
+        welded.push(id);
+    }
+
+    // Directed half-edges; an undirected edge with no twin is on the open
+    // boundary. Restrict to edges whose endpoints both lie on the cut plane so
+    // a pre-existing open boundary (non-watertight host) is never re-capped.
+    let mut present: HashSet<(u32, u32)> = HashSet::new();
+    for t in 0..tri_n {
+        let v = [
+            welded[mesh.indices[t * 3] as usize],
+            welded[mesh.indices[t * 3 + 1] as usize],
+            welded[mesh.indices[t * 3 + 2] as usize],
+        ];
+        for (a, b) in [(v[0], v[1]), (v[1], v[2]), (v[2], v[0])] {
+            if a != b {
+                present.insert((a, b));
+            }
+        }
+    }
+    let mut next: HashMap<u32, u32> = HashMap::new();
+    for &(a, b) in &present {
+        if present.contains(&(b, a)) {
+            continue; // interior edge
+        }
+        if !on_plane[a as usize] || !on_plane[b as usize] {
+            continue; // not the cut section
+        }
+        if next.insert(a, b).is_some() {
+            return; // non-manifold cut boundary → bail
+        }
+    }
+    if next.is_empty() {
+        return;
+    }
+
+    // Chain the boundary half-edges into closed loops.
+    let mut starts: Vec<u32> = next.keys().copied().collect();
+    starts.sort_unstable();
+    let mut visited: HashSet<u32> = HashSet::new();
+    let mut loops: Vec<Vec<u32>> = Vec::new();
+    for &s in &starts {
+        if visited.contains(&s) {
+            continue;
+        }
+        let mut loop_v: Vec<u32> = Vec::new();
+        let mut cur = s;
+        loop {
+            if !visited.insert(cur) {
+                break;
+            }
+            loop_v.push(cur);
+            match next.get(&cur) {
+                Some(&nx) => cur = nx,
+                None => {
+                    loop_v.clear();
+                    break;
+                }
+            }
+            if cur == s {
+                break;
+            }
+        }
+        if loop_v.len() >= 3 {
+            loops.push(loop_v);
+        }
+    }
+    if loops.is_empty() {
+        return;
+    }
+
+    // Project every loop into one shared 2D basis whose +w faces the cap's
+    // outward normal (-clip_normal), so a CCW triangulated ring lifts to a
+    // triangle whose geometric normal already points outward.
+    let cap_outward = -n;
+    let mut all3d: Vec<Point3<f64>> = Vec::new();
+    let mut ranges: Vec<(usize, usize)> = Vec::new();
+    for lp in &loops {
+        let start = all3d.len();
+        for &i in lp {
+            all3d.push(pos[i as usize]);
+        }
+        ranges.push((start, all3d.len()));
+    }
+    let (all2d, u_axis, v_axis, origin) = project_to_2d(&all3d, &cap_outward);
+
+    let signed_area = |ring: &[Point2<f64>]| -> f64 {
+        let mut s = 0.0;
+        let m = ring.len();
+        for i in 0..m {
+            let j = (i + 1) % m;
+            s += ring[i].x * ring[j].y - ring[j].x * ring[i].y;
+        }
+        s * 0.5
+    };
+    let point_in_ring = |pt: &Point2<f64>, ring: &[Point2<f64>]| -> bool {
+        let mut inside = false;
+        let m = ring.len();
+        let mut j = m - 1;
+        for i in 0..m {
+            let (pi, pj) = (ring[i], ring[j]);
+            if ((pi.y > pt.y) != (pj.y > pt.y))
+                && (pt.x < (pj.x - pi.x) * (pt.y - pi.y) / (pj.y - pi.y) + pi.x)
+            {
+                inside = !inside;
+            }
+            j = i;
+        }
+        inside
+    };
+
+    let rings: Vec<Vec<Point2<f64>>> = ranges
+        .iter()
+        .map(|&(a, b)| all2d[a..b].to_vec())
+        .collect();
+
+    // Even-odd nesting depth: a ring inside an odd number of others is a hole.
+    let depth: Vec<usize> = (0..rings.len())
+        .map(|i| {
+            let probe = rings[i][0];
+            (0..rings.len())
+                .filter(|&j| j != i && point_in_ring(&probe, &rings[j]))
+                .count()
+        })
+        .collect();
+
+    let cap_normal = [cap_outward.x as f32, cap_outward.y as f32, cap_outward.z as f32];
+    let lift = |p: &Point2<f64>| -> Point3<f64> { origin + u_axis * p.x + v_axis * p.y };
+
+    for (oi, ring) in rings.iter().enumerate() {
+        if depth[oi] % 2 != 0 {
+            continue; // hole — emitted with its outer ring
+        }
+        // Outer ring CCW; its immediate holes (depth+1, contained) CW.
+        let mut outer = ring.clone();
+        if signed_area(&outer) < 0.0 {
+            outer.reverse();
+        }
+        let mut holes: Vec<Vec<Point2<f64>>> = Vec::new();
+        for (hi, hring) in rings.iter().enumerate() {
+            if hi == oi || depth[hi] != depth[oi] + 1 {
+                continue;
+            }
+            if !point_in_ring(&hring[0], ring) {
+                continue;
+            }
+            let mut h = hring.clone();
+            if signed_area(&h) > 0.0 {
+                h.reverse();
+            }
+            holes.push(h);
+        }
+
+        let (verts2d, indices) =
+            match triangulate_polygon_with_holes_refined(&outer, &holes, false) {
+                Ok(r) => r,
+                Err(_) => continue,
+            };
+        let verts3d: Vec<Point3<f64>> = verts2d.iter().map(lift).collect();
+        let base = (mesh.positions.len() / 3) as u32;
+        for p in &verts3d {
+            mesh.positions
+                .extend_from_slice(&[p.x as f32, p.y as f32, p.z as f32]);
+            mesh.normals.extend_from_slice(&cap_normal);
+        }
+        for tri in indices.chunks_exact(3) {
+            let (a, b, c) = (verts3d[tri[0]], verts3d[tri[1]], verts3d[tri[2]]);
+            // Wind to face the cap outward normal regardless of CDT convention.
+            let geo_n = (b - a).cross(&(c - a));
+            let (i1, i2) = if geo_n.dot(&cap_outward) >= 0.0 {
+                (tri[1], tri[2])
+            } else {
+                (tri[2], tri[1])
+            };
+            mesh.indices
+                .extend_from_slice(&[base + tri[0] as u32, base + i1 as u32, base + i2 as u32]);
+        }
+    }
+}
+
 impl GeometryProcessor for BooleanClippingProcessor {
     fn process(
         &self,
@@ -1199,5 +1453,110 @@ impl GeometryProcessor for BooleanClippingProcessor {
 impl Default for BooleanClippingProcessor {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod halfspace_cap_tests {
+    use super::*;
+    use crate::csg::{ClippingProcessor, Plane};
+
+    /// Outward-wound watertight unit cube, one face per quad → two triangles,
+    /// vertices duplicated per triangle (as the clipper itself emits them).
+    fn unit_box() -> Mesh {
+        let c = [
+            [0.0f32, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0], [1.0, 0.0, 1.0], [1.0, 1.0, 1.0], [0.0, 1.0, 1.0],
+        ];
+        let tris: [[usize; 3]; 12] = [
+            [0, 2, 1], [0, 3, 2], [4, 5, 6], [4, 6, 7],
+            [0, 1, 5], [0, 5, 4], [1, 2, 6], [1, 6, 5],
+            [2, 3, 7], [2, 7, 6], [3, 0, 4], [3, 4, 7],
+        ];
+        let mut m = Mesh::new();
+        for t in tris {
+            let base = (m.positions.len() / 3) as u32;
+            for &vi in &t {
+                m.positions.extend_from_slice(&c[vi]);
+                m.normals.extend_from_slice(&[0.0, 0.0, 1.0]);
+            }
+            m.indices.extend_from_slice(&[base, base + 1, base + 2]);
+        }
+        m
+    }
+
+    /// Open boundary edges, vertices welded on a 10 µm grid.
+    fn open_edges(m: &Mesh) -> usize {
+        use std::collections::HashMap;
+        let key = |i: usize| -> (i64, i64, i64) {
+            (
+                (m.positions[i * 3] as f64 * 1.0e5).round() as i64,
+                (m.positions[i * 3 + 1] as f64 * 1.0e5).round() as i64,
+                (m.positions[i * 3 + 2] as f64 * 1.0e5).round() as i64,
+            )
+        };
+        let mut vid: HashMap<(i64, i64, i64), u32> = HashMap::new();
+        let mut bal: HashMap<(u32, u32), i32> = HashMap::new();
+        for tri in m.indices.chunks_exact(3) {
+            let mut id = [0u32; 3];
+            for (j, &vi) in tri.iter().enumerate() {
+                let k = key(vi as usize);
+                let n = vid.len() as u32;
+                id[j] = *vid.entry(k).or_insert(n);
+            }
+            for (x, y) in [(id[0], id[1]), (id[1], id[2]), (id[2], id[0])] {
+                let (kk, s) = if x < y { ((x, y), 1) } else { ((y, x), -1) };
+                *bal.entry(kk).or_insert(0) += s;
+            }
+        }
+        bal.values().filter(|&&v| v != 0).count()
+    }
+
+    fn signed_volume(m: &Mesh) -> f64 {
+        let p = |i: usize| {
+            [
+                m.positions[i * 3] as f64,
+                m.positions[i * 3 + 1] as f64,
+                m.positions[i * 3 + 2] as f64,
+            ]
+        };
+        let mut vol = 0.0;
+        for tri in m.indices.chunks_exact(3) {
+            let (a, b, c) = (p(tri[0] as usize), p(tri[1] as usize), p(tri[2] as usize));
+            vol += (a[0] * (b[1] * c[2] - b[2] * c[1]) - a[1] * (b[0] * c[2] - b[2] * c[0])
+                + a[2] * (b[0] * c[1] - b[1] * c[0]))
+                / 6.0;
+        }
+        vol
+    }
+
+    /// Regression for the #1024 BSP-cap deletion: an unbounded `IfcHalfSpaceSolid`
+    /// DIFFERENCE (the plane clip) must leave a watertight, correctly-wound solid,
+    /// not the open inverted shell the uncapped clip produced (AC20 gable walls).
+    #[test]
+    fn unbounded_half_space_clip_is_capped_and_watertight() {
+        let bx = unit_box();
+        assert_eq!(open_edges(&bx), 0, "fixture box must be watertight");
+        assert!((signed_volume(&bx) - 1.0).abs() < 1.0e-6);
+
+        // Keep the +z half — exactly what clip_mesh_with_half_space does.
+        let clip_normal = Vector3::new(0.0, 0.0, 1.0);
+        let plane_point = Point3::new(0.5, 0.5, 0.5);
+        let clipper = ClippingProcessor::new();
+        let mut clipped = clipper
+            .clip_mesh(&bx, &Plane::new(plane_point, clip_normal))
+            .unwrap();
+
+        // Pre-fix: the cut cross-section is left open.
+        assert!(open_edges(&clipped) > 0, "raw plane clip leaves the section open");
+        let tris_before = clipped.indices.len() / 3;
+
+        cap_half_space_clip(&mut clipped, plane_point, clip_normal);
+
+        assert_eq!(open_edges(&clipped), 0, "capped clip must be watertight");
+        assert!(clipped.indices.len() / 3 > tris_before, "cap must add triangles");
+        // Closed kept-half of the unit box → +0.5 (positive ⇒ outward winding).
+        let v = signed_volume(&clipped);
+        assert!((v - 0.5).abs() < 1.0e-5, "capped half-box volume should be +0.5, got {v}");
     }
 }

--- a/rust/geometry/tests/halfspace_clip_cap_regression.rs
+++ b/rust/geometry/tests/halfspace_clip_cap_regression.rs
@@ -1,0 +1,115 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Regression: an unbounded `IfcHalfSpaceSolid` DIFFERENCE must yield a
+//! watertight, correctly-wound solid.
+//!
+//! The pure-Rust kernel consolidation (#1024) deleted the in-tree BSP kernel
+//! along with the polygon cap that closed the cut cross-section on the fast
+//! plane-clip path (`clip_mesh_with_half_space`), but kept that path for
+//! unbounded `IfcHalfSpaceSolid` operands. With no cap, every roof-trim clip
+//! came out as an OPEN, inverted shell — negative signed volume and dozens of
+//! open boundary edges — instead of a solid.
+//!
+//! AC20-FZK-Haus `Wand-Ext-OG-2` (#67536) and `Wand-Ext-OG-4` (#75347) are
+//! roof-clipped upper walls whose `Body` is
+//! `IfcBooleanClippingResult(.DIFFERENCE., extrusion, IfcHalfSpaceSolid)` and
+//! that carry NO void — the exact regressed path. Pre-fix each came out as
+//! 14 tris / −8.4 m³ / 16 open edges; with the section capped they are
+//! 20 tris / +2.06 m³ / 0 open edges.
+
+use ifc_lite_core::{build_entity_index, EntityDecoder};
+use ifc_lite_geometry::{GeometryRouter, Mesh};
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+fn fixture(rel: &str) -> Option<String> {
+    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join(rel);
+    fs::read_to_string(p).ok()
+}
+
+fn process_element_only(content: &str, host_id: u32) -> Option<Mesh> {
+    let entity_index = build_entity_index(content);
+    let mut decoder = EntityDecoder::with_index(content, entity_index);
+    let entity = decoder.decode_by_id(host_id).ok()?;
+    let router = GeometryRouter::with_scale(1.0);
+    router.process_element(&entity, &mut decoder).ok()
+}
+
+/// Open boundary edges (directed half-edges that do not pair), vertices welded
+/// on a 1 mm grid. A watertight solid returns 0.
+fn open_boundary_edges(m: &Mesh) -> usize {
+    let key = |i: usize| -> (i64, i64, i64) {
+        (
+            (m.positions[i * 3] as f64 * 1.0e3).round() as i64,
+            (m.positions[i * 3 + 1] as f64 * 1.0e3).round() as i64,
+            (m.positions[i * 3 + 2] as f64 * 1.0e3).round() as i64,
+        )
+    };
+    let mut vid: HashMap<(i64, i64, i64), u32> = HashMap::new();
+    let mut bal: HashMap<(u32, u32), i32> = HashMap::new();
+    for tri in m.indices.chunks_exact(3) {
+        let mut id = [0u32; 3];
+        for (j, &vi) in tri.iter().enumerate() {
+            let k = key(vi as usize);
+            let n = vid.len() as u32;
+            id[j] = *vid.entry(k).or_insert(n);
+        }
+        for (x, y) in [(id[0], id[1]), (id[1], id[2]), (id[2], id[0])] {
+            let (kk, s) = if x < y { ((x, y), 1) } else { ((y, x), -1) };
+            *bal.entry(kk).or_insert(0) += s;
+        }
+    }
+    bal.values().filter(|&&v| v != 0).count()
+}
+
+fn signed_volume(m: &Mesh) -> f64 {
+    let p = |i: usize| {
+        [
+            m.positions[i * 3] as f64,
+            m.positions[i * 3 + 1] as f64,
+            m.positions[i * 3 + 2] as f64,
+        ]
+    };
+    let mut vol = 0.0;
+    for tri in m.indices.chunks_exact(3) {
+        let (a, b, c) = (p(tri[0] as usize), p(tri[1] as usize), p(tri[2] as usize));
+        vol += (a[0] * (b[1] * c[2] - b[2] * c[1]) - a[1] * (b[0] * c[2] - b[2] * c[0])
+            + a[2] * (b[0] * c[1] - b[1] * c[0]))
+            / 6.0;
+    }
+    vol
+}
+
+#[test]
+fn roof_clipped_walls_are_watertight_solids() {
+    let Some(content) = fixture("tests/models/ara3d/AC20-FZK-Haus.ifc") else {
+        eprintln!("AC20-FZK-Haus fixture not staged; skipping");
+        return;
+    };
+    // Wand-Ext-OG-2 (#67536) and Wand-Ext-OG-4 (#75347): roof-clipped, no void —
+    // the exact `clip_mesh_with_half_space` path that #1024 left uncapped.
+    for id in [67536u32, 75347] {
+        let mesh =
+            process_element_only(&content, id).unwrap_or_else(|| panic!("#{id} should process"));
+        assert!(!mesh.is_empty(), "#{id} produced no geometry");
+
+        let open = open_boundary_edges(&mesh);
+        assert_eq!(
+            open, 0,
+            "#{id}: roof clip must be capped & watertight (16 open edges before the fix)"
+        );
+
+        let vol = signed_volume(&mesh);
+        assert!(
+            vol > 0.5,
+            "#{id}: must be a positive-volume solid \
+             (was inverted/negative before the fix), got {vol}"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

On `main`, gable / mono-pitch / Revit-top-trim walls render as broken, spiky, see-through shells.

**Root cause:** the pure-Rust kernel consolidation (#1024) deleted the in-tree BSP kernel **and its polygon cap**, but kept the fast `clip_mesh_with_half_space` path for unbounded `IfcHalfSpaceSolid` operands. That path clips each triangle to the roof plane but never closes the cut cross-section, so the result is an **open, inverted shell** (negative signed volume, dozens of open boundary edges) instead of a watertight solid.

On AC20-FZK-Haus the two roof-clipped upper walls (`Wand-Ext-OG-2` #67536, `Wand-Ext-OG-4` #75347) came out as **14 tris / −8.4 m³ / 16 open edges**.

## Fix

After the plane clip, re-close the section: chain the on-plane open boundary into loops, classify outer rings vs holes by even-odd nesting, triangulate each region with the kernel CDT, and wind the cap to face the removed side. If the boundary is non-manifold or doesn't close (non-watertight host), bail and leave the output unchanged — never worse than before. `IFC_LITE_HALFSPACE_CAP_OFF` reverts to the old uncapped clip without a rebuild.

**AC20 result:** `#67536`/`#75347` → **20 tris / +2.06 m³ / 0 open edges**; void-cut walls untouched.

## Tests
- `halfspace_clip_cap_regression.rs` — AC20 `#67536`/`#75347` are watertight, positive-volume solids (end-to-end production path).
- `boolean.rs` unit test — synthetic box clip → capped & watertight, +0.5 volume.
- 354 lib tests + all half-space / void / wall / CSG / annex_e-snapshot tests pass; no snapshot drift.

> Note: a global `[unstable] build-std` (for wasm) leaks into native `cargo test` from a nested worktree and duplicates `core` locally; I validated with it disabled. 3 Tekla `wall_opening_cut_regression` tests fail only in that non-standard local build (`cap-on == cap-off`, so the cap is provably uninvolved) — CI's real env runs them green.

## Not in scope
The skolebygg `#632761` near-window spikes are a **separate** cause — f32 coordinate collapse on a plain `SweptSolid` wall's void cut at 221 km georef coords (the per-element local-frame work, OFF by default), not a half-space clip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unbounded half-space solid difference operations to properly close and orient cut surfaces. Cut faces that previously remained open with inverted orientation now generate watertight, correctly-oriented solids with proper boundary closure.

* **Tests**
  * Added regression tests to ensure clipped geometry remains watertight with correct volume orientation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->