### PR TITLE
fix(viewer): stop drop-zone overlay flickering during drag

### DIFF
--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -405,24 +405,42 @@ export function ViewportContainer() {
     setCesiumSourceModelId(georef?.sourceModelId ?? null);
   }, [georef?.sourceModelId, setCesiumSourceModelId]);
 
-  const handleDragOver = useCallback((e: React.DragEvent) => {
+  // Track drag enter/leave depth so the overlay doesn't flicker when the
+  // cursor moves between child elements (each child boundary fires its own
+  // dragenter/dragleave that bubbles to the container).
+  const dragDepthRef = useRef(0);
+
+  const handleDragEnter = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
+    dragDepthRef.current += 1;
     // Only show drag state if WebGPU is supported
     if (webgpu.supported) {
       setIsDragging(true);
     }
   }, [webgpu.supported]);
 
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    // Needed to allow the drop, but does not toggle drag state (avoids flicker)
+    e.preventDefault();
+    e.stopPropagation();
+  }, []);
+
   const handleDragLeave = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    setIsDragging(false);
+    dragDepthRef.current -= 1;
+    // Only hide once we've actually left the container (depth back to zero)
+    if (dragDepthRef.current <= 0) {
+      dragDepthRef.current = 0;
+      setIsDragging(false);
+    }
   }, []);
 
   const handleDrop = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
+    dragDepthRef.current = 0;
     setIsDragging(false);
 
     // Block file loading if WebGPU not supported
@@ -753,6 +771,7 @@ export function ViewportContainer() {
       <div
         className="relative h-full w-full bg-white dark:bg-black text-zinc-900 dark:text-zinc-50 overflow-hidden"
         data-viewport
+        onDragEnter={handleDragEnter}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
@@ -770,7 +789,7 @@ export function ViewportContainer() {
 
         {/* Drop overlay */}
         {isDragging && (
-          <div className="absolute inset-0 z-50 bg-primary/10 backdrop-blur-[2px] flex items-center justify-center p-8">
+          <div className="pointer-events-none absolute inset-0 z-50 bg-primary/10 backdrop-blur-[2px] flex items-center justify-center p-8">
             <div className="border-4 border-dashed border-primary bg-white/90 dark:bg-black/90 p-12 max-w-2xl w-full text-center shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] dark:shadow-[8px_8px_0px_0px_rgba(255,255,255,1)] transition-all">
               <Upload className="h-20 w-20 mx-auto text-primary mb-6" />
               <p className="text-3xl font-black uppercase tracking-tight text-primary">Drop File to Load</p>
@@ -1089,13 +1108,14 @@ export function ViewportContainer() {
     <div
       className="relative h-full w-full bg-zinc-50 dark:bg-black overflow-hidden"
       data-viewport
+      onDragEnter={handleDragEnter}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
     >
       {/* Drop overlay for when a file is already loaded - shows "Add Model" */}
       {isDragging && (
-        <div className="absolute inset-0 z-50 bg-[#9ece6a]/10 backdrop-blur-[2px] flex items-center justify-center">
+        <div className="pointer-events-none absolute inset-0 z-50 bg-[#9ece6a]/10 backdrop-blur-[2px] flex items-center justify-center">
           <div className="bg-white dark:bg-[#1a1b26] border-4 border-dashed border-[#9ece6a] p-8 shadow-2xl">
             <div className="text-center">
               <Plus className="h-12 w-12 mx-auto text-[#9ece6a] mb-4" />

--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -5,6 +5,12 @@
 import { useMemo, useRef, useState, useCallback, useEffect, useSyncExternalStore } from 'react';
 import { useLevelDisplayEffect } from '@/hooks/useLevelDisplayEffect';
 import { Viewport } from './Viewport';
+import {
+  initialDragOverlayState,
+  reduceDragOverlay,
+  type DragOverlayEvent,
+  type DragOverlayState,
+} from './dragOverlayState';
 import { ViewportOverlays } from './ViewportOverlays';
 import { MergeLayersBanner } from './MergeLayersBanner';
 import { LevelDisplayIndicator } from './LevelDisplayIndicator';
@@ -407,18 +413,19 @@ export function ViewportContainer() {
 
   // Track drag enter/leave depth so the overlay doesn't flicker when the
   // cursor moves between child elements (each child boundary fires its own
-  // dragenter/dragleave that bubbles to the container).
-  const dragDepthRef = useRef(0);
+  // dragenter/dragleave that bubbles to the container). See dragOverlayState.ts.
+  const dragStateRef = useRef<DragOverlayState>(initialDragOverlayState);
+
+  const applyDragEvent = useCallback((event: DragOverlayEvent) => {
+    dragStateRef.current = reduceDragOverlay(dragStateRef.current, event, webgpu.supported);
+    setIsDragging(dragStateRef.current.dragging);
+  }, [webgpu.supported]);
 
   const handleDragEnter = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    dragDepthRef.current += 1;
-    // Only show drag state if WebGPU is supported
-    if (webgpu.supported) {
-      setIsDragging(true);
-    }
-  }, [webgpu.supported]);
+    applyDragEvent('enter');
+  }, [applyDragEvent]);
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
     // Needed to allow the drop, but does not toggle drag state (avoids flicker)
@@ -429,19 +436,13 @@ export function ViewportContainer() {
   const handleDragLeave = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    dragDepthRef.current -= 1;
-    // Only hide once we've actually left the container (depth back to zero)
-    if (dragDepthRef.current <= 0) {
-      dragDepthRef.current = 0;
-      setIsDragging(false);
-    }
-  }, []);
+    applyDragEvent('leave');
+  }, [applyDragEvent]);
 
   const handleDrop = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    dragDepthRef.current = 0;
-    setIsDragging(false);
+    applyDragEvent('drop');
 
     // Block file loading if WebGPU not supported
     if (!webgpu.supported) {

--- a/apps/viewer/src/components/viewer/dragOverlayState.test.ts
+++ b/apps/viewer/src/components/viewer/dragOverlayState.test.ts
@@ -1,0 +1,58 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  initialDragOverlayState,
+  reduceDragOverlay,
+  type DragOverlayState,
+} from './dragOverlayState';
+
+test('enter shows overlay and increments depth when WebGPU supported', () => {
+  const next = reduceDragOverlay(initialDragOverlayState, 'enter', true);
+  assert.deepEqual(next, { depth: 1, dragging: true });
+});
+
+test('enter increments depth but keeps overlay hidden when WebGPU unsupported', () => {
+  const next = reduceDragOverlay(initialDragOverlayState, 'enter', false);
+  assert.deepEqual(next, { depth: 1, dragging: false });
+});
+
+test('overlay stays visible across nested child boundary crossings (no flicker)', () => {
+  // Cursor enters the container, then crosses into a nested child:
+  // child dragenter (depth 2) fires before the container dragleave (depth 1).
+  let state: DragOverlayState = initialDragOverlayState;
+  state = reduceDragOverlay(state, 'enter', true); // enter container
+  assert.equal(state.dragging, true);
+
+  state = reduceDragOverlay(state, 'enter', true); // enter child
+  assert.equal(state.depth, 2);
+  assert.equal(state.dragging, true);
+
+  state = reduceDragOverlay(state, 'leave', true); // leave previous element
+  assert.equal(state.depth, 1);
+  assert.equal(state.dragging, true, 'overlay must remain visible mid-traversal');
+});
+
+test('overlay hides only once depth returns to zero', () => {
+  let state: DragOverlayState = { depth: 2, dragging: true };
+  state = reduceDragOverlay(state, 'leave', true);
+  assert.deepEqual(state, { depth: 1, dragging: true });
+
+  state = reduceDragOverlay(state, 'leave', true);
+  assert.deepEqual(state, { depth: 0, dragging: false });
+});
+
+test('leave clamps depth at zero and hides overlay even if it goes negative', () => {
+  // Some browsers can fire an unbalanced dragleave; depth must never go negative.
+  const state = reduceDragOverlay(initialDragOverlayState, 'leave', true);
+  assert.deepEqual(state, { depth: 0, dragging: false });
+});
+
+test('drop resets depth to zero and hides overlay', () => {
+  const state = reduceDragOverlay({ depth: 3, dragging: true }, 'drop', true);
+  assert.deepEqual(state, { depth: 0, dragging: false });
+});
+
+test('drop resets even when WebGPU unsupported', () => {
+  const state = reduceDragOverlay({ depth: 1, dragging: false }, 'drop', false);
+  assert.deepEqual(state, { depth: 0, dragging: false });
+});

--- a/apps/viewer/src/components/viewer/dragOverlayState.ts
+++ b/apps/viewer/src/components/viewer/dragOverlayState.ts
@@ -1,0 +1,47 @@
+/**
+ * Pure state machine for the file drop-zone overlay.
+ *
+ * The overlay flickered when the cursor moved between child elements because
+ * each child boundary fires its own `dragenter`/`dragleave` that bubbles up to
+ * the container. We track a depth counter so the overlay only hides once the
+ * cursor has truly left the container (depth back to zero), not when it merely
+ * crosses into a nested child.
+ */
+export interface DragOverlayState {
+  /** Net dragenter-minus-dragleave depth over the container subtree. */
+  depth: number;
+  /** Whether the drop overlay should be visible. */
+  dragging: boolean;
+}
+
+export type DragOverlayEvent = 'enter' | 'leave' | 'drop';
+
+export const initialDragOverlayState: DragOverlayState = { depth: 0, dragging: false };
+
+/**
+ * Compute the next overlay state for a drag event.
+ *
+ * - `enter`: increments depth; shows the overlay only when WebGPU is supported.
+ * - `leave`: decrements depth; hides the overlay only once depth returns to zero.
+ * - `drop`: resets depth and hides the overlay.
+ */
+export function reduceDragOverlay(
+  state: DragOverlayState,
+  event: DragOverlayEvent,
+  webgpuSupported: boolean,
+): DragOverlayState {
+  switch (event) {
+    case 'enter': {
+      const depth = state.depth + 1;
+      // Preserve prior `dragging` when WebGPU is unsupported (overlay stays hidden).
+      return { depth, dragging: webgpuSupported ? true : state.dragging };
+    }
+    case 'leave': {
+      const depth = state.depth - 1;
+      if (depth <= 0) return { depth: 0, dragging: false };
+      return { depth, dragging: state.dragging };
+    }
+    case 'drop':
+      return { depth: 0, dragging: false };
+  }
+}


### PR DESCRIPTION
## Problem

When dragging a file onto the viewer, the drop-zone overlay flickered. `onDragOver` set `isDragging` true and `onDragLeave` set it false; as the cursor crossed child-element boundaries (the overlay itself, `GridPattern`, etc.) each child fired a `dragleave` that bubbled to the container, hiding the overlay, then immediately re-showing it — rapid flicker.

## Fix

- Introduce a **drag-depth counter** (`dragDepthRef`): `onDragEnter` increments, `onDragLeave` decrements; the overlay hides only when depth returns to 0 (cursor truly left the container). Moving into a child nets to zero, so the overlay stays stable.
- `onDragOver` now only `preventDefault()`s (to keep drop enabled) and no longer toggles state.
- Mark both drop overlays `pointer-events-none` so they don't emit their own drag events.
- `onDrop` resets the counter.

Applied to both container variants (empty state and models-loaded).

## Testing

- Typecheck: clean
- Viewer test suite: 1002 pass / 0 fail / 2 skipped
- Manual drag-and-drop flicker check: to be verified in the viewer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag-and-drop handling in the viewer so the drop overlay no longer flickers when dragging over nested elements.
  * Updated overlay interaction behavior so the overlay doesn’t intercept drag/pointer interactions during drag-over.
  * Ensured the overlay reliably resets when dropping files, including cases where WebGPU isn’t supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->