### PR TITLE
fix(viewer): include mergeLayers in geometry cache key (#1107)

### DIFF
--- a/apps/viewer/src/hooks/geometryCacheKey.test.ts
+++ b/apps/viewer/src/hooks/geometryCacheKey.test.ts
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { buildGeometryCacheKey } from './geometryCacheKey.js';
+
+describe('buildGeometryCacheKey', () => {
+  it('folds size, fingerprint and format version into the key', () => {
+    const key = buildGeometryCacheKey(1024, 'abc123', false, 7);
+    assert.strictEqual(key, 'ifc-1024-abc123-v7');
+  });
+
+  it('omits the merge-layers discriminator when merging is off (preserves legacy default-off entries)', () => {
+    const key = buildGeometryCacheKey(2048, 'deadbeef', false, 5);
+    assert.ok(!key.includes('-ml'), `expected no merge suffix, got ${key}`);
+  });
+
+  it('appends a merge-layers discriminator when merging is on', () => {
+    const key = buildGeometryCacheKey(2048, 'deadbeef', true, 5);
+    assert.strictEqual(key, 'ifc-2048-deadbeef-v5-ml');
+  });
+
+  it('produces distinct keys for the two merge-layers states (issue #1107: toggle+reload must miss)', () => {
+    const off = buildGeometryCacheKey(4096, 'feed', false, 5);
+    const on = buildGeometryCacheKey(4096, 'feed', true, 5);
+    assert.notStrictEqual(off, on);
+  });
+
+  it('keeps the key filename-safe for the desktop Tauri cache backend ([A-Za-z0-9_-])', () => {
+    const key = buildGeometryCacheKey(99, 'a1b2c3', true, 5);
+    assert.match(key, /^[A-Za-z0-9_-]+$/);
+  });
+});

--- a/apps/viewer/src/hooks/geometryCacheKey.ts
+++ b/apps/viewer/src/hooks/geometryCacheKey.ts
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { FORMAT_VERSION } from '@ifc-lite/cache';
+
+/**
+ * Build the persisted geometry cache key for a loaded model.
+ *
+ * The key folds together everything that changes the *bytes* of the cached
+ * geometry so a stale entry can never be served for a different input:
+ *   - `byteLength` + `fingerprint`: identify the source file content
+ *   - `FORMAT_VERSION`: a format bump invalidates incompatible entries
+ *   - `mergeLayers`: the multi-layer-wall merge flag is a load-time WASM
+ *     tessellation input (issue #540). It was previously absent from the key,
+ *     so toggling it and reloading served geometry built with the *previous*
+ *     flag — the toggle silently no-op'd until the model was re-imported
+ *     (issue #1107). Including it makes a toggle+reload a cache miss that
+ *     re-tessellates with the new flag.
+ *
+ * The `mergeLayers` discriminator is omitted when false so pre-existing
+ * cache entries (the default is off) stay valid — only the opt-in `true`
+ * path gets a distinct key.
+ *
+ * The desktop (Tauri) cache backend only accepts `[A-Za-z0-9_-]`, so the key
+ * stays filename-safe and independent of the original filename.
+ */
+export function buildGeometryCacheKey(
+  byteLength: number,
+  fingerprint: string,
+  mergeLayers: boolean,
+  formatVersion: number | string = FORMAT_VERSION
+): string {
+  return `ifc-${byteLength}-${fingerprint}-v${formatVersion}${mergeLayers ? '-ml' : ''}`;
+}

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -27,7 +27,8 @@ import {
 } from '@ifc-lite/geometry';
 import { acquireFileBuffer, type AcquiredBuffer } from '../utils/acquireFileBuffer.js';
 import { buildSpatialIndexGuarded, buildSpatialIndexForModel } from '../utils/loadingUtils.js';
-import { type GeometryData, FORMAT_VERSION } from '@ifc-lite/cache';
+import { buildGeometryCacheKey } from './geometryCacheKey.js';
+import { type GeometryData } from '@ifc-lite/cache';
 
 import { SERVER_URL, USE_SERVER, CACHE_SIZE_THRESHOLD, CACHE_MAX_SOURCE_SIZE, getDynamicBatchConfig } from '../utils/ifcConfig.js';
 import {
@@ -564,12 +565,17 @@ export function useIfcLoader() {
       // Cache key uses filename + size + content fingerprint + format version
       // Fingerprint prevents collisions for different files with the same name and size
       const fingerprint = computeFastFingerprint(buffer);
-      // Desktop Tauri cache commands only accept [A-Za-z0-9_-], so keep the
-      // persisted key filename-safe and independent of the original filename.
-      // Pin to the cache FORMAT_VERSION so a format bump invalidates stale
-      // entries (e.g. v5 added the geometryClass tag the Model/Types switch
-      // needs); a manual literal here silently kept serving incompatible data.
-      const cacheKey = `ifc-${buffer.byteLength}-${fingerprint}-v${FORMAT_VERSION}`;
+      // Snapshot the merge-layers flag *before* the cache lookup: it is a
+      // load-time WASM tessellation input (issue #540) and must discriminate
+      // the cache key, otherwise toggling it + reloading serves geometry built
+      // with the previous flag (issue #1107). Reused below for the
+      // GeometryProcessor so the key and the actual tessellation agree.
+      const mergeLayersAtLoad = useViewerStore.getState().mergeLayers;
+      // Desktop Tauri cache commands only accept [A-Za-z0-9_-], so the key
+      // stays filename-safe and independent of the original filename. Pinned
+      // to FORMAT_VERSION so a format bump invalidates stale entries (e.g. v5
+      // added the geometryClass tag the Model/Types switch needs).
+      const cacheKey = buildGeometryCacheKey(buffer.byteLength, fingerprint, mergeLayersAtLoad);
 
       // Cache + server are PRIMARY-ONLY: a federated add is WASM-only with no
       // cache/server round-trip (matches the former parseStepBufferViewerModel).
@@ -621,7 +627,8 @@ export function useIfcLoader() {
       }
 
       // Initialize geometry processor first (WASM init is fast if already loaded)
-      const mergeLayersAtLoad = useViewerStore.getState().mergeLayers;
+      // Reuses the merge-layers snapshot taken above for the cache key so the
+      // key and the WASM tessellation always agree (issues #540, #1107).
       const geometryProcessor = new GeometryProcessor({
         quality: GeometryQuality.Balanced,
         preferNative: false,

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -604,7 +604,12 @@ export function useIfcLoader() {
       // Only for IFC4 STEP files (server doesn't support IFCX). Native
       // file handles (Tauri) don't have an HTTP-uploadable body, so skip
       // the server path and fall through to the WASM loader.
-      if (target.kind === 'primary' && format === 'ifc' && USE_SERVER && SERVER_URL && SERVER_URL !== '') {
+      // Also skip it when merge-layers is on: the server tessellates without
+      // the flag and its cache key ignores it, so a toggle+reload would still
+      // return non-merged geometry. The local WASM path honours the flag, so
+      // route through it instead (issue #1107). Merge-layers is opt-in, so the
+      // common (flag-off) load keeps the server fast path.
+      if (target.kind === 'primary' && format === 'ifc' && !mergeLayersAtLoad && USE_SERVER && SERVER_URL && SERVER_URL !== '') {
         // Pass buffer directly - server uses File object for parsing, buffer is only for size checks
         const serverSuccess = await loadFromServer(file, buffer, () => loadSessionRef.current !== currentSession);
         if (serverSuccess) {


### PR DESCRIPTION
Part of #1107 (item 4: *"Wall display mode reload did not seem to apply. I had to reopen the model."*).

## Root cause
The "Merge Multilayer Walls" flag (`mergeLayers`) is a **load-time WASM tessellation input** (#540), but it was **absent from the persisted geometry cache key**:

```
ifc-${byteLength}-${fingerprint}-v${FORMAT_VERSION}   // no mergeLayers
```

For any model ≥10 MB (the cache threshold), the cache-hit path in `useIfcLoader.ts` returns early and **never constructs the `GeometryProcessor`** with the new flag. So toggling the setting + reloading restored geometry built with the *previous* flag — the toggle silently no-op'd until the model was re-imported.

## Fix
- New pure, unit-tested helper `buildGeometryCacheKey(byteLength, fingerprint, mergeLayers)` that folds `mergeLayers` into the key.
- The discriminator (`-ml`) is **omitted when false**, so existing default-off cache entries stay valid — only the opt-in `true` path gets a distinct key. A toggle+reload is now a cache **miss** that re-tessellates with the new flag.
- The `mergeLayers` snapshot is read **once** (before the cache lookup) and reused for the `GeometryProcessor`, so the key and the actual tessellation always agree.

This fixes correctness on **reload**; live in-place re-mesh *without* reload (the `MergeLayersBanner` future improvement) remains a separate enhancement.

## Verification
- `npx tsx --test src/hooks/geometryCacheKey.test.ts` → 5/5 pass
- `tsc --noEmit` on the viewer → 0 errors

No changeset (app-only, `@ifc-lite/*` packages untouched). The key-format change is self-healing (mismatched keys simply re-process once).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for geometry cache key composition and edge cases.

* **Refactor**
  * Improved cache key generation logic to properly handle merge-layers setting, ensuring consistent behavior and cache validity across different configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->