### PR TITLE
fix(viewer): raise dark-theme muted/tab text contrast to WCAG AA (#1107)

### DIFF
--- a/apps/viewer/src/index.css
+++ b/apps/viewer/src/index.css
@@ -62,6 +62,9 @@
   --tab-text: #71717a;
   --tab-active-bg: #ffffff;
   --tab-active-text: #18181b;
+  /* Slightly-raised inactive tab (properties strip). Light mode lifts toward
+     white; dark mode overrides this to skip the lift (see below). */
+  --tab-inactive-bg: color-mix(in srgb, var(--tabs-bg) 82%, white 18%);
 }
 
 .dark {
@@ -79,6 +82,11 @@
   --tab-text: #828bb8;
   --tab-active-bg: #16161e;
   --tab-active-text: #a9b1d6;
+  /* No white-lift on the inactive trigger in dark mode: even an 18% lift takes
+     the bg to ~#474b59 where --tab-text (#828bb8) drops to 2.6:1. Keep it flat
+     on --tabs-bg so the muted label stays at 4.69:1 AA; the active tab is still
+     distinct via its darker bg + accent border (issue #1107, item 1 review). */
+  --tab-inactive-bg: var(--tabs-bg);
 }
 
 /* Custom theme configuration */
@@ -354,7 +362,7 @@ body {
   border-bottom: 0;
   border-left: 0;
   border-radius: 0 !important;
-  background-color: color-mix(in srgb, var(--tabs-bg) 82%, white 18%) !important;
+  background-color: var(--tab-inactive-bg) !important;
   color: var(--tab-text) !important;
   font-weight: 600;
   line-height: 1;

--- a/apps/viewer/src/index.css
+++ b/apps/viewer/src/index.css
@@ -74,7 +74,9 @@
   /* Tabs - Dark mode */
   --tabs-bg: #1f2335;
   --tabs-border: #3b4261;
-  --tab-text: #565f89;
+  /* #565f89 (tokyo comment) was only 2.51:1 on --tabs-bg — below WCAG AA.
+     #828bb8 keeps the Tokyo Night hue at 4.69:1 (issue #1107, item 1). */
+  --tab-text: #828bb8;
   --tab-active-bg: #16161e;
   --tab-active-text: #a9b1d6;
 }
@@ -121,7 +123,11 @@
   --color-secondary: var(--tokyo-bg-highlight);
   --color-secondary-foreground: var(--tokyo-fg);
   --color-muted: var(--tokyo-bg-highlight);
-  --color-muted-foreground: var(--tokyo-comment);
+  /* --tokyo-comment (#565f89) is ~2.5-2.9:1 on the dark surfaces this maps
+     onto (storm/night/highlight) — below WCAG AA. #828bb8 holds the Tokyo
+     Night hue at >=4.69:1. Kept separate from --tokyo-comment so the latter
+     stays usable for decorative fills (issue #1107, item 1). */
+  --color-muted-foreground: #828bb8;
   --color-accent: var(--tokyo-bg-highlight);
   --color-accent-foreground: var(--tokyo-fg);
   --color-destructive: var(--tokyo-red);
@@ -190,7 +196,10 @@ body {
 .dark .text-zinc-500,
 .dark .text-zinc-400,
 .dark .text-zinc-600 {
-  color: var(--tokyo-comment) !important;
+  /* Route muted utility text through the accessible muted-foreground token
+     (#828bb8) instead of raw --tokyo-comment (#565f89, ~2.5:1, fails WCAG AA).
+     issue #1107, item 1. */
+  color: var(--color-muted-foreground) !important;
 }
 
 .dark .text-zinc-200,


### PR DESCRIPTION
Part of #1107 (item 1: *"Dark theme contrast feels too low. The text and UI are hard to read against the dark background."*).

## Problem
The Tokyo Night dark theme used `--tokyo-comment` (`#565f89`) for secondary text. Measured contrast against the dark surfaces it renders on:

| Token / usage | Background | Contrast | WCAG AA (4.5:1) |
|---|---|---|---|
| `--tab-text` (inactive tabs) | `--tabs-bg #1f2335` | **2.51:1** | ❌ |
| `--color-muted-foreground` | storm/night/highlight | **2.76–2.91:1** | ❌ |
| `.text-zinc-400/500/600` (muted utility text, used everywhere) | dark surfaces | **2.5–2.9:1** | ❌ |

Main body text (`#a9b1d6`, ~8:1) was already fine — the problem was specifically secondary/muted text and tab chrome.

## Fix
Move those three to **`#828bb8`**, which keeps the Tokyo Night hue but reaches **4.69–5.42:1**:

- `--tab-text` → `#828bb8`
- `--color-muted-foreground` → `#828bb8` (single accessible definition)
- `.dark .text-zinc-400/500/600` now route through `var(--color-muted-foreground)` instead of raw `--tokyo-comment`

`--tokyo-comment` itself is **left unchanged** so it stays usable for decorative fills (e.g. the scrollbar thumb, line 247). `--hierarchy-text` (#7982a9) was left as-is: it reaches 4.54:1 on the panel background where it's actually used (selected rows use the separate, compliant `--hierarchy-selected-text`).

## Verification
Contrast ratios computed with the WCAG 2.x relative-luminance formula. CSS-only; no component or store changes. No changeset (app-only).