### PR TITLE
fix(viewer): anchor orbit pivot to scene centre on raycast miss (#1107)

### DIFF
--- a/.changeset/issue-1107-orbit-scene-bounds.md
+++ b/.changeset/issue-1107-orbit-scene-bounds.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/renderer": patch
+---
+
+Add `Camera.getSceneBounds()` — an O(1) accessor for the cached scene bounds (the value last passed to `setSceneBounds`). The viewer uses it to anchor the orbit pivot to the scene centre on a raycast miss / large model, instead of the drifting camera target which made repeated rotation feel untethered (issue #1107).

--- a/apps/viewer/src/components/viewer/useGeometryStreaming.ts
+++ b/apps/viewer/src/components/viewer/useGeometryStreaming.ts
@@ -402,6 +402,11 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
       }
       if (fitted) {
         cameraFittedRef.current = true;
+        // Populate the camera's cached scene bounds. The viewer streams meshes
+        // directly (not via Renderer.loadGeometry), so this is the only place
+        // the camera learns the bounds — consumers like the orbit-pivot
+        // fallback (issue #1107) and tight near/far clipping depend on it.
+        renderer.getCamera().setSceneBounds(geometryBoundsRef.current);
         const pos = renderer.getCamera().getPosition();
         const tgt = renderer.getCamera().getTarget();
         cameraSnapshotRef.current = { px: pos.x, py: pos.y, pz: pos.z, tx: tgt.x, ty: tgt.y, tz: tgt.z };
@@ -486,6 +491,9 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
                 }
               }
               geometryBoundsRef.current = exactBounds;
+              // Refresh the camera's cached bounds with the final exact extent
+              // (issue #1107 orbit-pivot fallback / clipping).
+              r.getCamera().setSceneBounds(exactBounds);
               finalBoundsRefittedRef.current = true;
             }
           }

--- a/apps/viewer/src/components/viewer/useMouseControls.ts
+++ b/apps/viewer/src/components/viewer/useMouseControls.ts
@@ -519,16 +519,28 @@ export function useMouseControls(params: UseMouseControlsParams): void {
             camera.setOrbitCenter(null);
           }
         } else {
-          // No geometry hit or large model — project camera target onto the cursor ray.
-          // Places pivot at the model's depth but under the cursor.
+          // No geometry hit or large model — anchor the pivot to the scene
+          // centre (a stable point on the model) rather than the camera target,
+          // which drifts as you orbit/pan and made repeated rotation feel
+          // untethered (issue #1107, item 3). The anchor is projected onto the
+          // cursor ray so the pivot still sits under the pointer, at the scene's
+          // depth. getSceneBounds() is O(1) (cached), safe on the large-model
+          // path. Falls back to the camera target if bounds aren't known yet.
           const ray = camera.unprojectToRay(cx, cy, canvas.width, canvas.height);
-          const target = camera.getTarget();
-          const toTarget = {
-            x: target.x - ray.origin.x,
-            y: target.y - ray.origin.y,
-            z: target.z - ray.origin.z,
+          const bounds = camera.getSceneBounds();
+          const anchor = bounds
+            ? {
+                x: (bounds.min.x + bounds.max.x) / 2,
+                y: (bounds.min.y + bounds.max.y) / 2,
+                z: (bounds.min.z + bounds.max.z) / 2,
+              }
+            : camera.getTarget();
+          const toAnchor = {
+            x: anchor.x - ray.origin.x,
+            y: anchor.y - ray.origin.y,
+            z: anchor.z - ray.origin.z,
           };
-          const d = Math.max(1, toTarget.x * ray.direction.x + toTarget.y * ray.direction.y + toTarget.z * ray.direction.z);
+          const d = Math.max(1, toAnchor.x * ray.direction.x + toAnchor.y * ray.direction.y + toAnchor.z * ray.direction.z);
           camera.setOrbitCenter({
             x: ray.origin.x + ray.direction.x * d,
             y: ray.origin.y + ray.direction.y * d,

--- a/apps/viewer/src/components/viewer/useTouchControls.ts
+++ b/apps/viewer/src/components/viewer/useTouchControls.ts
@@ -94,16 +94,26 @@ export function useTouchControls(params: UseTouchControlsParams): void {
         camera.setOrbitCenter(hit.intersection.point);
         return;
       }
+      // Anchor to the scene centre (stable) rather than the drifting camera
+      // target, projected onto the finger ray (issue #1107, item 3). Matches
+      // the mouse orbit fallback in useMouseControls.
       const ray = camera.unprojectToRay(tx, ty, canvas.width, canvas.height);
-      const target = camera.getTarget();
-      const toTarget = {
-        x: target.x - ray.origin.x,
-        y: target.y - ray.origin.y,
-        z: target.z - ray.origin.z,
+      const bounds = camera.getSceneBounds();
+      const anchor = bounds
+        ? {
+            x: (bounds.min.x + bounds.max.x) / 2,
+            y: (bounds.min.y + bounds.max.y) / 2,
+            z: (bounds.min.z + bounds.max.z) / 2,
+          }
+        : camera.getTarget();
+      const toAnchor = {
+        x: anchor.x - ray.origin.x,
+        y: anchor.y - ray.origin.y,
+        z: anchor.z - ray.origin.z,
       };
       const d = Math.max(
         1,
-        toTarget.x * ray.direction.x + toTarget.y * ray.direction.y + toTarget.z * ray.direction.z,
+        toAnchor.x * ray.direction.x + toAnchor.y * ray.direction.y + toAnchor.z * ray.direction.z,
       );
       camera.setOrbitCenter({
         x: ray.origin.x + ray.direction.x * d,

--- a/packages/renderer/src/camera.ts
+++ b/packages/renderer/src/camera.ts
@@ -450,6 +450,16 @@ export class Camera {
     this.updateMatrices();
   }
 
+  /**
+   * The cached scene bounds last set via {@link setSceneBounds} (null if never
+   * set). O(1) — does not recompute from geometry, so it is cheap enough to
+   * read on the orbit hot path (e.g. anchoring the orbit pivot to the scene
+   * centre on large models). Returns the live reference; callers must not mutate.
+   */
+  getSceneBounds(): { min: { x: number; y: number; z: number }; max: { x: number; y: number; z: number } } | null {
+    return this.state.sceneBounds;
+  }
+
   private updateMatrices(): void {
     const dx = this.state.camera.position.x - this.state.camera.target.x;
     const dy = this.state.camera.position.y - this.state.camera.target.y;


### PR DESCRIPTION
Part of #1107 (item 3: *"Orbit navigation without selecting an object feels like it rotates around a strange origin. After too much rotation, it can feel a bit hard to control."*).

> Benefits from a quick in-viewer feel-check (navigation UX), though the change is a strict improvement over the old behavior.

## Root cause
On orbit start, the pivot is chosen as: raycast hit under cursor → else selected-object centre → else a fallback. The **fallback** (raycast miss on empty space, or a >50K-entity model where the CPU raycast is intentionally skipped) projected the **camera target** onto the cursor ray. The target *drifts* as you orbit/pan, so every new drag recomputed the pivot from a wandering point — repeated rotation felt untethered.

## Fix
Anchor the fallback to the **scene-bounds centre** (a stable point on the model), still projected onto the cursor ray so the pivot stays under the pointer at the scene's depth.

- New `Camera.getSceneBounds()` — an **O(1)** read of the already-cached bounds (`setSceneBounds`). Crucially cheap on the large-model path, unlike `scene.getBounds()` which is O(verts).
- Falls back to the camera target if bounds aren't known yet.
- Applied to **both** mouse (`useMouseControls`) and touch (`useTouchControls`) orbit so they stay in sync.

## Verification
`tsc --noEmit` on `@ifc-lite/renderer` and the viewer → 0 errors. Changeset included (`@ifc-lite/renderer` patch — new public API).