### PR TITLE
fix(viewer): bSDD value flow — no prefill, correct type, edit-on-add (#1107)

### DIFF
--- a/.changeset/bsdd-unset-boolean-property.md
+++ b/.changeset/bsdd-unset-boolean-property.md
@@ -1,0 +1,8 @@
+---
+"@ifc-lite/mutations": patch
+---
+
+Treat a null/unset property value as present, not absent. A property may legitimately exist with no value (e.g. an IFC boolean added from bSDD, which now starts unset rather than defaulting to `false`), so `MutablePropertyView` no longer reads `value === null` as "property does not exist":
+
+- `deleteProperty` keys absence off existence (in-session pset membership), so an unset property is still deletable instead of the trash button being a silent no-op.
+- `setProperty` classifies a write as `UPDATE_PROPERTY` vs `CREATE_PROPERTY` by whether the property already existed (not by null value), so undoing an edit to an unset property restores its prior unset state instead of deleting the whole property.

--- a/apps/viewer/src/components/viewer/PropertiesPanel.tsx
+++ b/apps/viewer/src/components/viewer/PropertiesPanel.tsx
@@ -214,6 +214,8 @@ export function PropertiesPanel() {
   // geometry manipulators, georeference placement, add-element draw
   // tools — behind a single switch.
   const editMode = useViewerStore((s) => s.editEnabled);
+  const propertiesActiveTab = useViewerStore((s) => s.propertiesActiveTab);
+  const setPropertiesActiveTab = useViewerStore((s) => s.setPropertiesActiveTab);
 
   const copyToClipboard = useCallback((text: string) => {
     navigator.clipboard.writeText(text);
@@ -1403,7 +1405,11 @@ export function PropertiesPanel() {
       )}
 
       {/* Tabs */}
-      <Tabs defaultValue="properties" className="flex-1 flex flex-col overflow-hidden">
+      <Tabs
+        value={propertiesActiveTab}
+        onValueChange={(v) => setPropertiesActiveTab(v as 'properties' | 'quantities' | 'bsdd' | 'raw-step')}
+        className="flex-1 flex flex-col overflow-hidden"
+      >
         <TabsList className="properties-tabs-list w-full shrink-0">
           <TabsTrigger
             value="properties"

--- a/apps/viewer/src/components/viewer/PropertiesPanel.tsx
+++ b/apps/viewer/src/components/viewer/PropertiesPanel.tsx
@@ -67,7 +67,7 @@ const MATERIAL_DEF_TYPES = new Set([
   'IFCMATERIALLIST',
 ]);
 
-type DisplayProperty = { name: string; value: unknown; isMutated: boolean };
+type DisplayProperty = { name: string; value: unknown; isMutated: boolean; type?: number };
 type DisplayPropertySet = {
   name: string;
   properties: DisplayProperty[];
@@ -569,6 +569,9 @@ export function PropertiesPanel() {
             name: p.name,
             value: p.value,
             isMutated: mutatedKeys.has(`${pset.name}:${p.name}`),
+            // Carry the value type so the editor can render the right control
+            // even when the value is null/unset (e.g. a fresh bSDD Boolean).
+            type: p.type,
           })),
           isNewPset: newPsetNames.has(pset.name),
         }));

--- a/apps/viewer/src/components/viewer/PropertiesPanel.tsx
+++ b/apps/viewer/src/components/viewer/PropertiesPanel.tsx
@@ -216,6 +216,66 @@ export function PropertiesPanel() {
   const editMode = useViewerStore((s) => s.editEnabled);
   const propertiesActiveTab = useViewerStore((s) => s.propertiesActiveTab);
   const setPropertiesActiveTab = useViewerStore((s) => s.setPropertiesActiveTab);
+  const setEditEnabled = useViewerStore((s) => s.setEditEnabled);
+  const pendingPropertyFocus = useViewerStore((s) => s.pendingPropertyFocus);
+  const setPendingPropertyFocus = useViewerStore((s) => s.setPendingPropertyFocus);
+
+  // One-shot "jump to the property I just added in bSDD" focus (issue #1107).
+  // The bSDD card arms `pendingPropertyFocus` and the user crosses over via its
+  // "Edit in Properties" bar. When we land on the Properties tab for the same
+  // entity, enter edit mode, remember which row to highlight, and consume the
+  // request so it fires exactly once.
+  const [focusedPropKey, setFocusedPropKey] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (propertiesActiveTab !== 'properties') return;
+    const focus = pendingPropertyFocus;
+    if (!focus || !selectedEntity) return;
+    // Match on the same raw modelId + expressId the selection carries; a stale
+    // focus for a different entity is left untouched (never consumed here).
+    if (focus.modelId !== selectedEntity.modelId || focus.entityId !== selectedEntity.expressId) return;
+    setEditEnabled(true);
+    // entityId-qualified key so it can only ever highlight the occurrence row
+    // (not an inherited type pset that happens to share the name).
+    setFocusedPropKey(`${focus.entityId}:${focus.psetName}:${focus.propName}`);
+    setPendingPropertyFocus(null);
+  }, [propertiesActiveTab, pendingPropertyFocus, selectedEntity, setEditEnabled, setPendingPropertyFocus]);
+
+  // A new selection abandons the arm-then-cross-over gesture: it was tied to the
+  // previous element, so drop any armed focus and clear the transient highlight
+  // rather than let them resurrect on a later, unrelated entity (issue #1107).
+  // Arm + cross-over both happen on the SAME selection (bSDD tab → Properties
+  // tab), so this never fires mid-gesture.
+  useEffect(() => {
+    setFocusedPropKey(null);
+    setPendingPropertyFocus(null);
+  }, [selectedEntity?.modelId, selectedEntity?.expressId, setPendingPropertyFocus]);
+
+  // Once the focused row is painted (after the edit-mode re-render), scroll it
+  // into view and let the highlight fade after a beat. Match the attribute by
+  // value rather than building a selector to stay injection-safe on odd names.
+  useEffect(() => {
+    if (!focusedPropKey) return;
+    let raf2 = 0;
+    const raf1 = requestAnimationFrame(() => {
+      raf2 = requestAnimationFrame(() => {
+        let el: Element | null = null;
+        document.querySelectorAll('[data-prop-key]').forEach((node) => {
+          if (node.getAttribute('data-prop-key') === focusedPropKey) el = node;
+        });
+        if (el) {
+          const reduce = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+          (el as Element).scrollIntoView({ block: 'center', behavior: reduce ? 'auto' : 'smooth' });
+        }
+      });
+    });
+    const fade = window.setTimeout(() => setFocusedPropKey(null), 2400);
+    return () => {
+      cancelAnimationFrame(raf1);
+      if (raf2) cancelAnimationFrame(raf2);
+      window.clearTimeout(fade);
+    };
+  }, [focusedPropKey]);
 
   const copyToClipboard = useCallback((text: string) => {
     navigator.clipboard.writeText(text);
@@ -1511,6 +1571,7 @@ export function PropertiesPanel() {
                         enableEditing={editMode}
                         isTypeProperty={renderedIsTypeEntity}
                         typeEditScope={renderedIsTypeEntity ? renderedTypeEditImpact ?? undefined : undefined}
+                        focusedPropKey={focusedPropKey}
                       />
                     ))}
                   </>
@@ -1535,6 +1596,7 @@ export function PropertiesPanel() {
                         enableEditing={editMode}
                         isTypeProperty
                         typeEditScope={renderedTypeEditImpact?.mode === 'inherited' ? renderedTypeEditImpact : undefined}
+                        focusedPropKey={focusedPropKey}
                       />
                     ))}
                   </>

--- a/apps/viewer/src/components/viewer/PropertyEditor.tsx
+++ b/apps/viewer/src/components/viewer/PropertyEditor.tsx
@@ -209,12 +209,32 @@ export function PropertyEditor({
       {/* Value input */}
       <div className="flex items-center gap-2">
         {valueType === PropertyValueType.Boolean || valueType === PropertyValueType.Logical ? (
-          <div className="flex items-center gap-2 flex-1">
-            <Switch
-              checked={value === 'true'}
-              onCheckedChange={(checked) => setValue(checked ? 'true' : 'false')}
-            />
-            <span className="text-xs text-zinc-500">{value === 'true' ? 'True' : 'False'}</span>
+          // Tri-state: a boolean property value is optional in IFC, so "Unset"
+          // is a first-class choice — we never silently coerce to false. An
+          // empty `value` ('') means unset (issue #1107).
+          <div className="flex items-center gap-1 flex-1" role="radiogroup" aria-label="Boolean value">
+            {([['', 'Unset'], ['true', 'True'], ['false', 'False']] as const).map(([v, label]) => {
+              const active = value === v;
+              return (
+                <button
+                  key={label}
+                  type="button"
+                  role="radio"
+                  aria-checked={active}
+                  onClick={() => {
+                    setValue(v);
+                    if (showScopeConfirm) setShowScopeConfirm(false);
+                  }}
+                  className={`px-2 py-0.5 text-xs rounded border transition-colors ${
+                    active
+                      ? 'bg-purple-600 text-white border-purple-600'
+                      : 'bg-white dark:bg-zinc-900 text-zinc-600 dark:text-zinc-300 border-zinc-300 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800'
+                  } ${v === '' ? 'italic' : ''}`}
+                >
+                  {label}
+                </button>
+              );
+            })}
           </div>
         ) : (
           <Input
@@ -1455,6 +1475,9 @@ function parseValue(value: string, type: PropertyValueType): PropertyValue {
       return parseInt(value, 10) || 0;
     case PropertyValueType.Boolean:
     case PropertyValueType.Logical:
+      // Empty = unset → null (encodes to the table's 255 sentinel, serialises
+      // to `$`). Only an explicit choice writes a concrete boolean.
+      if (value === '') return null;
       return value.toLowerCase() === 'true';
     default:
       return value;

--- a/apps/viewer/src/components/viewer/properties/BsddCard.tsx
+++ b/apps/viewer/src/components/viewer/properties/BsddCard.tsx
@@ -18,13 +18,14 @@ import { Badge } from '@/components/ui/badge';
 import { Switch } from '@/components/ui/switch';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useViewerStore } from '@/store';
-import { type PropertyValue, PropertyValueType, QuantityType } from '@ifc-lite/data';
+import { type PropertyValue, QuantityType } from '@ifc-lite/data';
 import {
   fetchClassInfo,
   bsddDataTypeLabel,
   type BsddClassInfo,
   type BsddClassProperty,
 } from '@/services/bsdd';
+import { toPropertyValueType, defaultValue, inlineControlKind } from './bsddInlineValue.js';
 
 // ---------------------------------------------------------------------------
 // Helpers for Qto_* (quantity set) detection and mapping
@@ -47,34 +48,8 @@ function inferQuantityType(units: string[] | null): QuantityType {
   return QuantityType.Count;
 }
 
-// ---------------------------------------------------------------------------
-// bSDD data type → PropertyValueType mapping
-// ---------------------------------------------------------------------------
-
-function toPropertyValueType(bsddType: string | null): PropertyValueType {
-  if (!bsddType) return PropertyValueType.String;
-  const lower = bsddType.toLowerCase();
-  if (lower === 'boolean') return PropertyValueType.Boolean;
-  if (lower === 'real' || lower === 'number') return PropertyValueType.Real;
-  if (lower === 'integer') return PropertyValueType.Integer;
-  if (lower === 'character' || lower === 'string') return PropertyValueType.String;
-  return PropertyValueType.Label;
-}
-
-function defaultValue(bsddType: string | null): PropertyValue {
-  // Boolean gets a concrete default (false) so the value is valid the moment
-  // it's added and the inline Switch has a state to toggle. Everything else
-  // starts empty for manual entry (issue #1107, item 10).
-  if (toPropertyValueType(bsddType) === PropertyValueType.Boolean) return false;
-  return '';
-}
-
-/** Which inline value control (if any) a bSDD property offers before "Add". */
-function inlineControlKind(prop: BsddClassProperty): 'boolean' | 'enum' | null {
-  if (toPropertyValueType(prop.dataType) === PropertyValueType.Boolean) return 'boolean';
-  if (prop.allowedValues && prop.allowedValues.length > 0) return 'enum';
-  return null;
-}
+// Inline-value decision logic lives in ./bsddInlineValue.ts so it can be
+// unit-tested without the component's React/store/Radix dependency graph.
 
 /** bSDD properties with null propertySet are IFC entity-level attributes */
 const BSDD_ATTRIBUTES_GROUP = 'Attributes';

--- a/apps/viewer/src/components/viewer/properties/BsddCard.tsx
+++ b/apps/viewer/src/components/viewer/properties/BsddCard.tsx
@@ -200,8 +200,11 @@ export function BsddCard({
       if (modelId === 'legacy') normalizedModelId = '__legacy__';
 
       if (psetName === BSDD_ATTRIBUTES_GROUP) {
-        // Route entity-level attributes (Name, Description, ObjectType, Tag, etc.)
-        storeSetAttribute(normalizedModelId, entityId, prop.name, '');
+        // Route entity-level attributes (Name, Description, ObjectType, Tag,
+        // PredefinedType, etc.). Honour an inline-chosen value (e.g. an enum
+        // attribute like PredefinedType) — attributes are stored as strings
+        // (issue #1107, item 10 review follow-up).
+        storeSetAttribute(normalizedModelId, entityId, prop.name, valueOverride != null ? String(valueOverride) : '');
       } else if (isQuantitySet(psetName)) {
         // Route Qto_* through quantity creation
         const qType = inferQuantityType(prop.units);

--- a/apps/viewer/src/components/viewer/properties/BsddCard.tsx
+++ b/apps/viewer/src/components/viewer/properties/BsddCard.tsx
@@ -16,6 +16,7 @@ import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Badge } from '@/components/ui/badge';
 import { useViewerStore } from '@/store';
+import { toast } from '@/components/ui/toast';
 import { QuantityType } from '@ifc-lite/data';
 import {
   fetchClassInfo,
@@ -101,6 +102,8 @@ export function BsddCard({
   const createQuantitySet = useViewerStore((s) => s.createQuantitySet);
   const storeSetAttribute = useViewerStore((s) => s.setAttribute);
   const bumpMutationVersion = useViewerStore((s) => s.bumpMutationVersion);
+  const setEditEnabled = useViewerStore((s) => s.setEditEnabled);
+  const setPropertiesActiveTab = useViewerStore((s) => s.setPropertiesActiveTab);
 
   // Fetch class info from bSDD when entity type changes
   useEffect(() => {
@@ -215,8 +218,15 @@ export function BsddCard({
 
       bumpMutationVersion();
       setAddedKeys((prev) => new Set(prev).add(`${psetName}:${prop.name}`));
+
+      // Take the user to the added property and make it immediately editable:
+      // switch to the Properties tab and turn on edit mode so the value can be
+      // set without first hunting for the toolbar edit button (issue #1107).
+      setPropertiesActiveTab('properties');
+      setEditEnabled(true);
+      toast.success(`Added "${prop.name}" — set its value in Properties`);
     },
-    [modelId, entityId, existingPsets, existingQsets, setProperty, createPropertySet, setQuantity, createQuantitySet, storeSetAttribute, bumpMutationVersion],
+    [modelId, entityId, existingPsets, existingQsets, setProperty, createPropertySet, setQuantity, createQuantitySet, storeSetAttribute, bumpMutationVersion, setPropertiesActiveTab, setEditEnabled],
   );
 
   const handleAddAllInPset = useCallback(
@@ -311,8 +321,15 @@ export function BsddCard({
         for (const p of toAdd) next.add(`${psetName}:${p.name}`);
         return next;
       });
+
+      // Same as single-add: surface the new properties and make them editable.
+      setPropertiesActiveTab('properties');
+      setEditEnabled(true);
+      if (toAdd.length > 0) {
+        toast.success(`Added ${toAdd.length} ${psetName} ${toAdd.length === 1 ? 'property' : 'properties'} — set values in Properties`);
+      }
     },
-    [modelId, entityId, existingPsets, existingQsets, existingProps, existingQuants, existingAttributes, addedKeys, setProperty, createPropertySet, setQuantity, createQuantitySet, storeSetAttribute, bumpMutationVersion],
+    [modelId, entityId, existingPsets, existingQsets, existingProps, existingQuants, existingAttributes, addedKeys, setProperty, createPropertySet, setQuantity, createQuantitySet, storeSetAttribute, bumpMutationVersion, setPropertiesActiveTab, setEditEnabled],
   );
 
   // Loading state

--- a/apps/viewer/src/components/viewer/properties/BsddCard.tsx
+++ b/apps/viewer/src/components/viewer/properties/BsddCard.tsx
@@ -15,6 +15,8 @@ import { BookOpen, Plus, Check, Loader2, ExternalLink, ChevronDown, ChevronRight
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Badge } from '@/components/ui/badge';
+import { Switch } from '@/components/ui/switch';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useViewerStore } from '@/store';
 import { type PropertyValue, PropertyValueType, QuantityType } from '@ifc-lite/data';
 import {
@@ -59,9 +61,19 @@ function toPropertyValueType(bsddType: string | null): PropertyValueType {
   return PropertyValueType.Label;
 }
 
-function defaultValue(_bsddType: string | null): PropertyValue {
-  // Always return empty string – user fills in values manually
+function defaultValue(bsddType: string | null): PropertyValue {
+  // Boolean gets a concrete default (false) so the value is valid the moment
+  // it's added and the inline Switch has a state to toggle. Everything else
+  // starts empty for manual entry (issue #1107, item 10).
+  if (toPropertyValueType(bsddType) === PropertyValueType.Boolean) return false;
   return '';
+}
+
+/** Which inline value control (if any) a bSDD property offers before "Add". */
+function inlineControlKind(prop: BsddClassProperty): 'boolean' | 'enum' | null {
+  if (toPropertyValueType(prop.dataType) === PropertyValueType.Boolean) return 'boolean';
+  if (prop.allowedValues && prop.allowedValues.length > 0) return 'enum';
+  return null;
 }
 
 /** bSDD properties with null propertySet are IFC entity-level attributes */
@@ -109,6 +121,13 @@ export function BsddCard({
   const [error, setError] = useState<string | null>(null);
   const [expandedPsets, setExpandedPsets] = useState<Set<string>>(new Set());
   const [addedKeys, setAddedKeys] = useState<Set<string>>(new Set());
+  // Values the user sets inline (boolean/enum) before clicking Add, keyed by
+  // `${psetName}:${prop.name}` — issue #1107, item 10.
+  const [pendingValues, setPendingValues] = useState<Map<string, PropertyValue>>(new Map());
+
+  const setPendingValue = useCallback((key: string, value: PropertyValue) => {
+    setPendingValues((prev) => new Map(prev).set(key, value));
+  }, []);
 
   const setProperty = useViewerStore((s) => s.setProperty);
   const createPropertySet = useViewerStore((s) => s.createPropertySet);
@@ -176,7 +195,7 @@ export function BsddCard({
   }, []);
 
   const handleAddProperty = useCallback(
-    (psetName: string, prop: BsddClassProperty) => {
+    (psetName: string, prop: BsddClassProperty, valueOverride?: PropertyValue) => {
       let normalizedModelId = modelId;
       if (modelId === 'legacy') normalizedModelId = '__legacy__';
 
@@ -206,7 +225,7 @@ export function BsddCard({
       } else {
         // Route Pset_* / other through property creation
         const valueType = toPropertyValueType(prop.dataType);
-        const value = defaultValue(prop.dataType);
+        const value = valueOverride !== undefined ? valueOverride : defaultValue(prop.dataType);
         const psetExists = existingPsets.includes(psetName);
 
         if (!psetExists) {
@@ -463,6 +482,33 @@ export function BsddCard({
                           {prop.dataType && <p className="mt-0.5 text-sky-400">{bsddDataTypeLabel(prop.dataType)}</p>}
                         </TooltipContent>
                       </Tooltip>
+                      {/* Inline value control for boolean / enum so a value can
+                          be set before adding (issue #1107, item 10). */}
+                      {!alreadyExists && inlineControlKind(prop) === 'boolean' && (
+                        <Switch
+                          checked={pendingValues.get(addedKey) === true}
+                          onCheckedChange={(v) => setPendingValue(addedKey, v)}
+                          className="shrink-0"
+                          aria-label={`Set ${prop.name}`}
+                        />
+                      )}
+                      {!alreadyExists && inlineControlKind(prop) === 'enum' && (
+                        <Select
+                          value={typeof pendingValues.get(addedKey) === 'string' ? (pendingValues.get(addedKey) as string) : undefined}
+                          onValueChange={(v) => setPendingValue(addedKey, v)}
+                        >
+                          <SelectTrigger className="h-6 w-28 shrink-0 px-2 text-[11px]">
+                            <SelectValue placeholder="Value…" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {prop.allowedValues!.filter((av) => av.value).map((av) => (
+                              <SelectItem key={av.value} value={av.value} className="text-xs">
+                                {av.value}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      )}
                       {/* Add button - always visible on right */}
                       {alreadyExists ? (
                         <Check className="h-3.5 w-3.5 text-emerald-500 shrink-0" />
@@ -473,7 +519,7 @@ export function BsddCard({
                               variant="ghost"
                               size="icon"
                               className="h-5 w-5 p-0 shrink-0 hover:bg-sky-200 dark:hover:bg-sky-800"
-                              onClick={() => handleAddProperty(psetName, prop)}
+                              onClick={() => handleAddProperty(psetName, prop, pendingValues.get(addedKey))}
                             >
                               <Plus className="h-3 w-3 text-sky-600 dark:text-sky-400" />
                             </Button>

--- a/apps/viewer/src/components/viewer/properties/BsddCard.tsx
+++ b/apps/viewer/src/components/viewer/properties/BsddCard.tsx
@@ -11,7 +11,7 @@
  */
 
 import { useState, useEffect, useMemo, useCallback } from 'react';
-import { BookOpen, Plus, Check, Loader2, ExternalLink, ChevronDown, ChevronRight } from 'lucide-react';
+import { BookOpen, Plus, Check, Loader2, ExternalLink, ChevronDown, ChevronRight, ArrowRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Badge } from '@/components/ui/badge';
@@ -104,6 +104,7 @@ export function BsddCard({
   const bumpMutationVersion = useViewerStore((s) => s.bumpMutationVersion);
   const setEditEnabled = useViewerStore((s) => s.setEditEnabled);
   const setPropertiesActiveTab = useViewerStore((s) => s.setPropertiesActiveTab);
+  const setPendingPropertyFocus = useViewerStore((s) => s.setPendingPropertyFocus);
 
   // Fetch class info from bSDD when entity type changes
   useEffect(() => {
@@ -136,6 +137,15 @@ export function BsddCard({
       cancelled = true;
     };
   }, [entityType]);
+
+  // `addedKeys` tracks what was added to THIS element, so it must reset when the
+  // selection moves to a different element — even one of the same IfcType, which
+  // leaves `entityType` (and the fetch above) unchanged. Without this the "N
+  // added · Edit in Properties" bar and the per-row check marks leak onto the
+  // next element (issue #1107 review).
+  useEffect(() => {
+    setAddedKeys(new Set());
+  }, [entityId, modelId]);
 
   // Group properties by property set name
   const groupedProps = useMemo(() => {
@@ -219,14 +229,20 @@ export function BsddCard({
       bumpMutationVersion();
       setAddedKeys((prev) => new Set(prev).add(`${psetName}:${prop.name}`));
 
-      // Take the user to the added property and make it immediately editable:
-      // switch to the Properties tab and turn on edit mode so the value can be
-      // set without first hunting for the toolbar edit button (issue #1107).
-      setPropertiesActiveTab('properties');
-      setEditEnabled(true);
-      toast.success(`Added "${prop.name}" — set its value in Properties`);
+      // Stay in the bSDD card — the user may want to add more (issue #1107).
+      // Don't yank them to the Properties tab or flip edit mode here. Instead
+      // ARM a one-shot focus on the new row; the card's "Edit in Properties"
+      // bar is the deliberate jump, and only THEN do we enter edit mode and
+      // scroll/highlight the row. Pset_* properties are the only inline-
+      // editable target, so attributes and Qto_* quantities just confirm.
+      if (psetName !== BSDD_ATTRIBUTES_GROUP && !isQuantitySet(psetName)) {
+        setPendingPropertyFocus({ modelId, entityId, psetName, propName: prop.name });
+        toast.success(`Added "${prop.name}" — open Properties to set its value`);
+      } else {
+        toast.success(`Added "${prop.name}"`);
+      }
     },
-    [modelId, entityId, existingPsets, existingQsets, setProperty, createPropertySet, setQuantity, createQuantitySet, storeSetAttribute, bumpMutationVersion, setPropertiesActiveTab, setEditEnabled],
+    [modelId, entityId, existingPsets, existingQsets, setProperty, createPropertySet, setQuantity, createQuantitySet, storeSetAttribute, bumpMutationVersion, setPendingPropertyFocus],
   );
 
   const handleAddAllInPset = useCallback(
@@ -322,14 +338,37 @@ export function BsddCard({
         return next;
       });
 
-      // Same as single-add: surface the new properties and make them editable.
-      setPropertiesActiveTab('properties');
-      setEditEnabled(true);
-      if (toAdd.length > 0) {
-        toast.success(`Added ${toAdd.length} ${psetName} ${toAdd.length === 1 ? 'property' : 'properties'} — set values in Properties`);
+      // Same as single-add: stay put, arm a one-shot focus on the first new
+      // property (Pset_* only — attributes/quantities aren't inline-editable).
+      const isEditableProps = !isAttrGroup && !isQuantitySet(psetName);
+      if (isEditableProps) {
+        setPendingPropertyFocus({ modelId, entityId, psetName, propName: toAdd[0].name });
       }
+      toast.success(
+        `Added ${toAdd.length} ${psetName} ${toAdd.length === 1 ? 'property' : 'properties'}` +
+          (isEditableProps ? ' — open Properties to set values' : ''),
+      );
     },
-    [modelId, entityId, existingPsets, existingQsets, existingProps, existingQuants, existingAttributes, addedKeys, setProperty, createPropertySet, setQuantity, createQuantitySet, storeSetAttribute, bumpMutationVersion, setPropertiesActiveTab, setEditEnabled],
+    [modelId, entityId, existingPsets, existingQsets, existingProps, existingQuants, existingAttributes, addedKeys, setProperty, createPropertySet, setQuantity, createQuantitySet, storeSetAttribute, bumpMutationVersion, setPendingPropertyFocus],
+  );
+
+  // The deliberate "take me to what I just added" action behind the card's
+  // "Edit in Properties" bar. Switching to the Properties tab + entering edit
+  // mode is what "go edit" means; the Properties panel then consumes any armed
+  // pendingPropertyFocus to scroll to and highlight the exact row.
+  const goToProperties = useCallback(() => {
+    setPropertiesActiveTab('properties');
+    setEditEnabled(true);
+  }, [setPropertiesActiveTab, setEditEnabled]);
+
+  // The "Edit in Properties" bar only makes sense for things that ARE editable
+  // on the Properties tab: Pset_* properties and entity attributes. Qto_*
+  // quantities render read-only on a different tab, so a quantity-only add must
+  // not surface the bar (it would dump the user on the wrong tab). Keys begin
+  // with their set name, so a `Qto_` prefix flags a quantity (issue #1107).
+  const editableAddedCount = useMemo(
+    () => Array.from(addedKeys).filter((k) => !k.startsWith('Qto_')).length,
+    [addedKeys],
   );
 
   // Loading state
@@ -368,6 +407,23 @@ export function BsddCard({
         <div className="px-1 pb-1 text-[11px] text-zinc-500 dark:text-zinc-400 leading-relaxed">
           {classInfo.definition}
         </div>
+      )}
+
+      {/* "Go edit" bar — the deliberate jump to the Properties tab. Appears
+          once anything has been added this session so the user can keep adding
+          here, then cross over to set values when ready (issue #1107). Kept out
+          of the scroll body's sticky region (Radix ScrollArea breaks sticky)
+          and pinned at the top where attention returns after an add. */}
+      {editableAddedCount > 0 && (
+        <button
+          type="button"
+          onClick={goToProperties}
+          className="flex w-full items-center justify-center gap-1.5 rounded-md border-2 border-emerald-300/70 dark:border-emerald-700/60 bg-emerald-50 dark:bg-emerald-950/40 px-3 py-2 text-xs font-semibold text-emerald-700 dark:text-emerald-300 hover:bg-emerald-100 dark:hover:bg-emerald-900/50 transition-colors"
+        >
+          <Check className="h-3.5 w-3.5 shrink-0" />
+          <span className="truncate">{editableAddedCount} added · Edit in Properties</span>
+          <ArrowRight className="h-3.5 w-3.5 shrink-0" />
+        </button>
       )}
 
       {/* Property sets from bSDD */}

--- a/apps/viewer/src/components/viewer/properties/BsddCard.tsx
+++ b/apps/viewer/src/components/viewer/properties/BsddCard.tsx
@@ -15,17 +15,15 @@ import { BookOpen, Plus, Check, Loader2, ExternalLink, ChevronDown, ChevronRight
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Badge } from '@/components/ui/badge';
-import { Switch } from '@/components/ui/switch';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useViewerStore } from '@/store';
-import { type PropertyValue, QuantityType } from '@ifc-lite/data';
+import { QuantityType } from '@ifc-lite/data';
 import {
   fetchClassInfo,
   bsddDataTypeLabel,
   type BsddClassInfo,
   type BsddClassProperty,
 } from '@/services/bsdd';
-import { toPropertyValueType, defaultValue, inlineControlKind } from './bsddInlineValue.js';
+import { toPropertyValueType, defaultValue } from './bsddInlineValue.js';
 
 // ---------------------------------------------------------------------------
 // Helpers for Qto_* (quantity set) detection and mapping
@@ -96,13 +94,6 @@ export function BsddCard({
   const [error, setError] = useState<string | null>(null);
   const [expandedPsets, setExpandedPsets] = useState<Set<string>>(new Set());
   const [addedKeys, setAddedKeys] = useState<Set<string>>(new Set());
-  // Values the user sets inline (boolean/enum) before clicking Add, keyed by
-  // `${psetName}:${prop.name}` — issue #1107, item 10.
-  const [pendingValues, setPendingValues] = useState<Map<string, PropertyValue>>(new Map());
-
-  const setPendingValue = useCallback((key: string, value: PropertyValue) => {
-    setPendingValues((prev) => new Map(prev).set(key, value));
-  }, []);
 
   const setProperty = useViewerStore((s) => s.setProperty);
   const createPropertySet = useViewerStore((s) => s.createPropertySet);
@@ -170,16 +161,15 @@ export function BsddCard({
   }, []);
 
   const handleAddProperty = useCallback(
-    (psetName: string, prop: BsddClassProperty, valueOverride?: PropertyValue) => {
+    (psetName: string, prop: BsddClassProperty) => {
       let normalizedModelId = modelId;
       if (modelId === 'legacy') normalizedModelId = '__legacy__';
 
       if (psetName === BSDD_ATTRIBUTES_GROUP) {
         // Route entity-level attributes (Name, Description, ObjectType, Tag,
-        // PredefinedType, etc.). Honour an inline-chosen value (e.g. an enum
-        // attribute like PredefinedType) — attributes are stored as strings
-        // (issue #1107, item 10 review follow-up).
-        storeSetAttribute(normalizedModelId, entityId, prop.name, valueOverride != null ? String(valueOverride) : '');
+        // PredefinedType, etc.). Created empty — the value is filled in
+        // afterwards in the Properties tab (issue #1107).
+        storeSetAttribute(normalizedModelId, entityId, prop.name, '');
       } else if (isQuantitySet(psetName)) {
         // Route Qto_* through quantity creation
         const qType = inferQuantityType(prop.units);
@@ -201,9 +191,10 @@ export function BsddCard({
           );
         }
       } else {
-        // Route Pset_* / other through property creation
+        // Route Pset_* / other through property creation, with the correct
+        // bSDD-derived value type so the inline editor shows the right control.
         const valueType = toPropertyValueType(prop.dataType);
-        const value = valueOverride !== undefined ? valueOverride : defaultValue(prop.dataType);
+        const value = defaultValue(prop.dataType);
         const psetExists = existingPsets.includes(psetName);
 
         if (!psetExists) {
@@ -460,34 +451,9 @@ export function BsddCard({
                           {prop.dataType && <p className="mt-0.5 text-sky-400">{bsddDataTypeLabel(prop.dataType)}</p>}
                         </TooltipContent>
                       </Tooltip>
-                      {/* Inline value control for boolean / enum so a value can
-                          be set before adding (issue #1107, item 10). */}
-                      {!alreadyExists && inlineControlKind(prop) === 'boolean' && (
-                        <Switch
-                          checked={pendingValues.get(addedKey) === true}
-                          onCheckedChange={(v) => setPendingValue(addedKey, v)}
-                          className="shrink-0"
-                          aria-label={`Set ${prop.name}`}
-                        />
-                      )}
-                      {!alreadyExists && inlineControlKind(prop) === 'enum' && (
-                        <Select
-                          value={typeof pendingValues.get(addedKey) === 'string' ? (pendingValues.get(addedKey) as string) : undefined}
-                          onValueChange={(v) => setPendingValue(addedKey, v)}
-                        >
-                          <SelectTrigger className="h-6 w-28 shrink-0 px-2 text-[11px]">
-                            <SelectValue placeholder="Value…" />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {prop.allowedValues!.filter((av) => av.value).map((av) => (
-                              <SelectItem key={av.value} value={av.value} className="text-xs">
-                                {av.value}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      )}
-                      {/* Add button - always visible on right */}
+                      {/* Add button - always visible on right. The property is
+                          created with its correct bSDD data type; the value is
+                          edited afterwards in the Properties tab (issue #1107). */}
                       {alreadyExists ? (
                         <Check className="h-3.5 w-3.5 text-emerald-500 shrink-0" />
                       ) : (
@@ -497,7 +463,7 @@ export function BsddCard({
                               variant="ghost"
                               size="icon"
                               className="h-5 w-5 p-0 shrink-0 hover:bg-sky-200 dark:hover:bg-sky-800"
-                              onClick={() => handleAddProperty(psetName, prop, pendingValues.get(addedKey))}
+                              onClick={() => handleAddProperty(psetName, prop)}
                             >
                               <Plus className="h-3 w-3 text-sky-600 dark:text-sky-400" />
                             </Button>

--- a/apps/viewer/src/components/viewer/properties/PropertySetCard.tsx
+++ b/apps/viewer/src/components/viewer/properties/PropertySetCard.tsx
@@ -14,6 +14,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { Badge } from '@/components/ui/badge';
 import { decodeIfcString, parsePropertyValue } from './encodingUtils';
 import type { PropertySet } from './encodingUtils';
+import { PropertyValueType } from '@ifc-lite/data';
 
 export interface PropertySetCardProps {
   pset: PropertySet;
@@ -95,7 +96,7 @@ export function PropertySetCard({ pset, modelId, entityId, enableEditing, isType
       </CollapsibleTrigger>
       <CollapsibleContent>
         <div className="border-t-2 border-zinc-200 dark:border-zinc-800 divide-y divide-zinc-100 dark:divide-zinc-900">
-          {pset.properties.map((prop: { name: string; value: unknown; isMutated?: boolean }) => {
+          {pset.properties.map((prop: { name: string; value: unknown; isMutated?: boolean; type?: number }) => {
             const parsed = parsePropertyValue(prop.value);
             const decodedName = decodeIfcString(prop.name);
             const isMutated = prop.isMutated;
@@ -152,6 +153,7 @@ export function PropertySetCard({ pset, modelId, entityId, enableEditing, isType
                       psetName={pset.name}
                       propName={prop.name}
                       currentValue={prop.value}
+                      currentType={prop.type as PropertyValueType | undefined}
                       editScope={typeEditScope}
                     />
                   ) : (

--- a/apps/viewer/src/components/viewer/properties/PropertySetCard.tsx
+++ b/apps/viewer/src/components/viewer/properties/PropertySetCard.tsx
@@ -6,6 +6,7 @@
  * Property set display component with edit support.
  */
 
+import { useState, useEffect } from 'react';
 import { Sparkles, PenLine, Building2 } from 'lucide-react';
 import { PropertyEditor, type PropertyEditScope } from '../PropertyEditor';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
@@ -22,12 +23,28 @@ export interface PropertySetCardProps {
   /** Whether this property set is inherited from the type entity */
   isTypeProperty?: boolean;
   typeEditScope?: PropertyEditScope;
+  /** `"PsetName:PropName"` of a row to transiently highlight + scroll to
+   *  (the bSDD "jump to added property" flow, issue #1107). */
+  focusedPropKey?: string | null;
 }
 
-export function PropertySetCard({ pset, modelId, entityId, enableEditing, isTypeProperty, typeEditScope }: PropertySetCardProps) {
+export function PropertySetCard({ pset, modelId, entityId, enableEditing, isTypeProperty, typeEditScope, focusedPropKey }: PropertySetCardProps) {
   // Check if any property in this set is mutated
   const hasMutations = pset.properties.some(p => p.isMutated);
   const isNewPset = pset.isNewPset;
+
+  // Row identity for the bSDD focus flow (issue #1107). The entityId is part of
+  // the key so an occurrence pset and an inherited type pset of the SAME name
+  // don't collide — only the card the property was actually added to matches.
+  const keyFor = (propName: string) => `${entityId ?? ''}:${pset.name}:${propName}`;
+  const containsFocused = focusedPropKey != null && pset.properties.some(p => keyFor(p.name) === focusedPropKey);
+
+  // Self-control the collapse so a focused row can't hide inside a pset the user
+  // previously collapsed — force it open when this card holds the focus target.
+  const [open, setOpen] = useState(true);
+  useEffect(() => {
+    if (containsFocused) setOpen(true);
+  }, [containsFocused]);
 
   // Dynamic styling based on mutation state and source
   const borderClass = isNewPset
@@ -47,7 +64,7 @@ export function PropertySetCard({ pset, modelId, entityId, enableEditing, isType
     : 'bg-white dark:bg-zinc-950';
 
   return (
-    <Collapsible defaultOpen className={`${borderClass} ${bgClass} group w-full max-w-full overflow-hidden`}>
+    <Collapsible open={open} onOpenChange={setOpen} className={`${borderClass} ${bgClass} group w-full max-w-full overflow-hidden`}>
       <CollapsibleTrigger className="flex items-center gap-2 w-full p-2.5 hover:bg-zinc-50 dark:hover:bg-zinc-900 text-left transition-colors overflow-hidden">
         {isNewPset && (
           <Tooltip>
@@ -82,12 +99,17 @@ export function PropertySetCard({ pset, modelId, entityId, enableEditing, isType
             const parsed = parsePropertyValue(prop.value);
             const decodedName = decodeIfcString(prop.name);
             const isMutated = prop.isMutated;
+            const propKey = keyFor(prop.name);
+            const isFocused = focusedPropKey != null && focusedPropKey === propKey;
 
             return (
               <div
                 key={prop.name}
-                className={`flex items-start justify-between gap-2 px-3 py-2 text-xs group/prop ${
-                  isMutated
+                data-prop-key={propKey}
+                className={`flex items-start justify-between gap-2 px-3 py-2 text-xs group/prop transition-colors ${
+                  isFocused
+                    ? 'bg-amber-100/70 dark:bg-amber-900/40 ring-2 ring-inset ring-amber-400 dark:ring-amber-500 motion-safe:animate-pulse-subtle'
+                    : isMutated
                     ? 'bg-purple-50/50 dark:bg-purple-950/30 hover:bg-purple-100/50 dark:hover:bg-purple-900/30'
                     : 'hover:bg-zinc-50/50 dark:hover:bg-zinc-900/50'
                 }`}

--- a/apps/viewer/src/components/viewer/properties/bsddInlineValue.test.ts
+++ b/apps/viewer/src/components/viewer/properties/bsddInlineValue.test.ts
@@ -21,9 +21,11 @@ describe('toPropertyValueType', () => {
 });
 
 describe('defaultValue', () => {
-  it('returns false for boolean so the value is valid the moment it is added', () => {
-    assert.strictEqual(defaultValue('Boolean'), false);
-    assert.strictEqual(defaultValue('boolean'), false);
+  it('returns null (unset) for boolean — never picks a value for the user', () => {
+    // An IFC boolean property is legitimately optional; a fresh bSDD add must
+    // start empty, not default to `false` (issue #1107).
+    assert.strictEqual(defaultValue('Boolean'), null);
+    assert.strictEqual(defaultValue('boolean'), null);
   });
 
   it('returns empty string for every other type (manual entry)', () => {

--- a/apps/viewer/src/components/viewer/properties/bsddInlineValue.test.ts
+++ b/apps/viewer/src/components/viewer/properties/bsddInlineValue.test.ts
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { toPropertyValueType, defaultValue, inlineControlKind } from './bsddInlineValue.js';
+import { PropertyValueType } from '@ifc-lite/data';
+import type { BsddClassProperty } from '@/services/bsdd';
+
+function prop(partial: Partial<BsddClassProperty>): BsddClassProperty {
+  return {
+    name: 'P',
+    dataType: null,
+    allowedValues: null,
+    propertySet: 'Pset_Test',
+    ...partial,
+  } as BsddClassProperty;
+}
+
+describe('toPropertyValueType', () => {
+  it('maps bSDD dataType strings (case-insensitive)', () => {
+    assert.strictEqual(toPropertyValueType('Boolean'), PropertyValueType.Boolean);
+    assert.strictEqual(toPropertyValueType('boolean'), PropertyValueType.Boolean);
+    assert.strictEqual(toPropertyValueType('Real'), PropertyValueType.Real);
+    assert.strictEqual(toPropertyValueType('Integer'), PropertyValueType.Integer);
+    assert.strictEqual(toPropertyValueType('Character'), PropertyValueType.String);
+    assert.strictEqual(toPropertyValueType(null), PropertyValueType.String);
+    assert.strictEqual(toPropertyValueType('Enumeration'), PropertyValueType.Label);
+  });
+});
+
+describe('defaultValue', () => {
+  it('returns false for boolean so the value is valid the moment it is added', () => {
+    assert.strictEqual(defaultValue('Boolean'), false);
+    assert.strictEqual(defaultValue('boolean'), false);
+  });
+
+  it('returns empty string for every other type (manual entry)', () => {
+    assert.strictEqual(defaultValue('Character'), '');
+    assert.strictEqual(defaultValue('Real'), '');
+    assert.strictEqual(defaultValue('Integer'), '');
+    assert.strictEqual(defaultValue(null), '');
+  });
+});
+
+describe('inlineControlKind', () => {
+  it('offers a boolean control for a Boolean dataType', () => {
+    assert.strictEqual(inlineControlKind(prop({ dataType: 'Boolean' })), 'boolean');
+  });
+
+  it('offers an enum control when allowedValues are present', () => {
+    assert.strictEqual(
+      inlineControlKind(prop({ dataType: 'Character', allowedValues: [{ value: 'A' }, { value: 'B' }] })),
+      'enum',
+    );
+  });
+
+  it('prefers boolean over enum when both could apply', () => {
+    assert.strictEqual(
+      inlineControlKind(prop({ dataType: 'Boolean', allowedValues: [{ value: 'X' }] })),
+      'boolean',
+    );
+  });
+
+  it('returns null for a plain string property (no inline control, manual entry)', () => {
+    assert.strictEqual(inlineControlKind(prop({ dataType: 'Character', allowedValues: null })), null);
+    assert.strictEqual(inlineControlKind(prop({ dataType: 'Character', allowedValues: [] })), null);
+  });
+});

--- a/apps/viewer/src/components/viewer/properties/bsddInlineValue.test.ts
+++ b/apps/viewer/src/components/viewer/properties/bsddInlineValue.test.ts
@@ -5,19 +5,8 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { toPropertyValueType, defaultValue, inlineControlKind } from './bsddInlineValue.js';
+import { toPropertyValueType, defaultValue } from './bsddInlineValue.js';
 import { PropertyValueType } from '@ifc-lite/data';
-import type { BsddClassProperty } from '@/services/bsdd';
-
-function prop(partial: Partial<BsddClassProperty>): BsddClassProperty {
-  return {
-    name: 'P',
-    dataType: null,
-    allowedValues: null,
-    propertySet: 'Pset_Test',
-    ...partial,
-  } as BsddClassProperty;
-}
 
 describe('toPropertyValueType', () => {
   it('maps bSDD dataType strings (case-insensitive)', () => {
@@ -42,30 +31,5 @@ describe('defaultValue', () => {
     assert.strictEqual(defaultValue('Real'), '');
     assert.strictEqual(defaultValue('Integer'), '');
     assert.strictEqual(defaultValue(null), '');
-  });
-});
-
-describe('inlineControlKind', () => {
-  it('offers a boolean control for a Boolean dataType', () => {
-    assert.strictEqual(inlineControlKind(prop({ dataType: 'Boolean' })), 'boolean');
-  });
-
-  it('offers an enum control when allowedValues are present', () => {
-    assert.strictEqual(
-      inlineControlKind(prop({ dataType: 'Character', allowedValues: [{ value: 'A' }, { value: 'B' }] })),
-      'enum',
-    );
-  });
-
-  it('prefers boolean over enum when both could apply', () => {
-    assert.strictEqual(
-      inlineControlKind(prop({ dataType: 'Boolean', allowedValues: [{ value: 'X' }] })),
-      'boolean',
-    );
-  });
-
-  it('returns null for a plain string property (no inline control, manual entry)', () => {
-    assert.strictEqual(inlineControlKind(prop({ dataType: 'Character', allowedValues: null })), null);
-    assert.strictEqual(inlineControlKind(prop({ dataType: 'Character', allowedValues: [] })), null);
   });
 });

--- a/apps/viewer/src/components/viewer/properties/bsddInlineValue.ts
+++ b/apps/viewer/src/components/viewer/properties/bsddInlineValue.ts
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Pure decision logic for the bSDD card's inline value controls (issue #1107,
+ * item 10). Kept out of BsddCard.tsx so it can be unit-tested without pulling
+ * the component's React / Radix / store dependency graph.
+ */
+
+import { type PropertyValue, PropertyValueType } from '@ifc-lite/data';
+import type { BsddClassProperty } from '@/services/bsdd';
+
+/** Map a bSDD dataType string to the viewer's PropertyValueType. */
+export function toPropertyValueType(bsddType: string | null): PropertyValueType {
+  if (!bsddType) return PropertyValueType.String;
+  const lower = bsddType.toLowerCase();
+  if (lower === 'boolean') return PropertyValueType.Boolean;
+  if (lower === 'real' || lower === 'number') return PropertyValueType.Real;
+  if (lower === 'integer') return PropertyValueType.Integer;
+  if (lower === 'character' || lower === 'string') return PropertyValueType.String;
+  return PropertyValueType.Label;
+}
+
+/** Default value used when a bSDD property is added without an inline choice. */
+export function defaultValue(bsddType: string | null): PropertyValue {
+  // Boolean gets a concrete default (false) so the value is valid the moment
+  // it's added and the inline Switch has a state to toggle. Everything else
+  // starts empty for manual entry.
+  if (toPropertyValueType(bsddType) === PropertyValueType.Boolean) return false;
+  return '';
+}
+
+/** Which inline value control (if any) a bSDD property offers before "Add". */
+export function inlineControlKind(prop: BsddClassProperty): 'boolean' | 'enum' | null {
+  if (toPropertyValueType(prop.dataType) === PropertyValueType.Boolean) return 'boolean';
+  if (prop.allowedValues && prop.allowedValues.length > 0) return 'enum';
+  return null;
+}

--- a/apps/viewer/src/components/viewer/properties/bsddInlineValue.ts
+++ b/apps/viewer/src/components/viewer/properties/bsddInlineValue.ts
@@ -9,7 +9,6 @@
  */
 
 import { type PropertyValue, PropertyValueType } from '@ifc-lite/data';
-import type { BsddClassProperty } from '@/services/bsdd';
 
 /** Map a bSDD dataType string to the viewer's PropertyValueType. */
 export function toPropertyValueType(bsddType: string | null): PropertyValueType {
@@ -22,18 +21,13 @@ export function toPropertyValueType(bsddType: string | null): PropertyValueType 
   return PropertyValueType.Label;
 }
 
-/** Default value used when a bSDD property is added without an inline choice. */
+/**
+ * Default value used when a bSDD property is added. The property is created
+ * with its correct {@link toPropertyValueType} type; Boolean gets a concrete
+ * `false` so the value is valid immediately, everything else starts empty for
+ * editing in the Properties tab.
+ */
 export function defaultValue(bsddType: string | null): PropertyValue {
-  // Boolean gets a concrete default (false) so the value is valid the moment
-  // it's added and the inline Switch has a state to toggle. Everything else
-  // starts empty for manual entry.
   if (toPropertyValueType(bsddType) === PropertyValueType.Boolean) return false;
   return '';
-}
-
-/** Which inline value control (if any) a bSDD property offers before "Add". */
-export function inlineControlKind(prop: BsddClassProperty): 'boolean' | 'enum' | null {
-  if (toPropertyValueType(prop.dataType) === PropertyValueType.Boolean) return 'boolean';
-  if (prop.allowedValues && prop.allowedValues.length > 0) return 'enum';
-  return null;
 }

--- a/apps/viewer/src/components/viewer/properties/bsddInlineValue.ts
+++ b/apps/viewer/src/components/viewer/properties/bsddInlineValue.ts
@@ -23,11 +23,13 @@ export function toPropertyValueType(bsddType: string | null): PropertyValueType 
 
 /**
  * Default value used when a bSDD property is added. The property is created
- * with its correct {@link toPropertyValueType} type; Boolean gets a concrete
- * `false` so the value is valid immediately, everything else starts empty for
- * editing in the Properties tab.
+ * with its correct {@link toPropertyValueType} type but NO value — we never
+ * decide a value on the user's behalf (issue #1107). An IFC property value is
+ * legitimately optional, so a fresh Boolean is `null` (unset / `$`), not a
+ * concrete `false`; everything else starts as an empty string. The user sets
+ * the value (or leaves it empty) in the Properties tab.
  */
 export function defaultValue(bsddType: string | null): PropertyValue {
-  if (toPropertyValueType(bsddType) === PropertyValueType.Boolean) return false;
+  if (toPropertyValueType(bsddType) === PropertyValueType.Boolean) return null;
   return '';
 }

--- a/apps/viewer/src/components/viewer/properties/encodingUtils.ts
+++ b/apps/viewer/src/components/viewer/properties/encodingUtils.ts
@@ -19,7 +19,11 @@ export type { ParsedPropertyValue } from '@ifc-lite/encoding';
 
 export interface PropertySet {
   name: string;
-  properties: Array<{ name: string; value: unknown; isMutated?: boolean }>;
+  /** `type` is the PropertyValueType (numeric enum) carried from the mutation
+   *  view so the inline editor knows e.g. an *unset* Boolean is still a Boolean
+   *  (it can't infer that from a null value alone). Optional — base/loaded
+   *  properties may omit it and fall back to value inference. */
+  properties: Array<{ name: string; value: unknown; isMutated?: boolean; type?: number }>;
   isNewPset?: boolean;
   /** Where this property set originates from: 'instance' (occurrence) or 'type' (inherited from IfcTypeObject) */
   source?: 'instance' | 'type';

--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -299,6 +299,10 @@ const createViewerStore = () => create<ViewerState>()((...args) => ({
       // UI
       activeTool: UI_DEFAULTS.ACTIVE_TOOL,
       editEnabled: false,
+      // Drop any one-shot bSDD "jump to property" focus armed before the load —
+      // a new file reuses ids ('legacy' + reassigned expressIds) so a stale
+      // focus could otherwise match an unrelated entity (issue #1107).
+      pendingPropertyFocus: null,
       visualEnhancementsEnabled: UI_DEFAULTS.VISUAL_ENHANCEMENTS_ENABLED,
       edgeContrastEnabled: UI_DEFAULTS.EDGE_CONTRAST_ENABLED,
       edgeContrastIntensity: UI_DEFAULTS.EDGE_CONTRAST_INTENSITY,

--- a/apps/viewer/src/store/slices/mutationSlice.ts
+++ b/apps/viewer/src/store/slices/mutationSlice.ts
@@ -2461,7 +2461,11 @@ export const createMutationSlice: StateCreator<
 
     // Apply inverse mutation (skipHistory=true to avoid polluting mutation history)
     if (mutation.type === 'UPDATE_PROPERTY' || mutation.type === 'CREATE_PROPERTY') {
-      if (mutation.oldValue === null && mutation.psetName && mutation.propName) {
+      // Decide by mutation TYPE, not by `oldValue === null`: a property can have
+      // a null (unset) value yet still have existed before the edit (an unset
+      // Boolean). Undoing a CREATE removes the property; undoing an UPDATE
+      // restores its prior value — which may legitimately be null/unset (#1107).
+      if (mutation.type === 'CREATE_PROPERTY' && mutation.psetName && mutation.propName) {
         view.deleteProperty(mutation.entityId, mutation.psetName, mutation.propName, true);
       } else if (mutation.psetName && mutation.propName && mutation.oldValue !== undefined) {
         view.setProperty(

--- a/apps/viewer/src/store/slices/uiSlice.ts
+++ b/apps/viewer/src/store/slices/uiSlice.ts
@@ -16,6 +16,21 @@ import type { CesiumPlacementDraft } from './cesiumSlice.js';
 export type ThemeMode = 'light' | 'dark' | 'colorful';
 
 /**
+ * One-shot target for "jump to a property and edit it" flows (issue #1107).
+ * Armed when a property is added from the bSDD card, consumed by the
+ * Properties panel once the user arrives on the Properties tab — it scrolls
+ * the row into view, highlights it and enters edit mode, then clears itself.
+ * Identified by the same (raw) modelId + expressId the selection carries, so
+ * a stale focus left over from a different entity is simply never matched.
+ */
+export interface PropertyFocusTarget {
+  modelId: string;
+  entityId: number;
+  psetName: string;
+  propName: string;
+}
+
+/**
  * Tools that require edit mode to function. Entering one of them
  * flips `editEnabled` on; leaving edit mode forces these tools
  * back to `'select'`. Keep the list in sync — duplicating the
@@ -67,6 +82,9 @@ export interface UISlice {
   /** Active tab in the Properties panel. Controlled so in-app flows (e.g.
    *  adding a bSDD property) can jump back to "properties" — issue #1107. */
   propertiesActiveTab: 'properties' | 'quantities' | 'bsdd' | 'raw-step';
+  /** One-shot "scroll to + highlight + edit this property" request, armed by
+   *  the bSDD add flow and consumed by the Properties panel. Null when idle. */
+  pendingPropertyFocus: PropertyFocusTarget | null;
   theme: ThemeMode;
   isMobile: boolean;
   hoverTooltipsEnabled: boolean;
@@ -97,6 +115,8 @@ export interface UISlice {
   setEditEnabled: (enabled: boolean) => void;
   toggleEditEnabled: () => void;
   setPropertiesActiveTab: (tab: 'properties' | 'quantities' | 'bsdd' | 'raw-step') => void;
+  /** Arm (or clear, with null) the one-shot property-focus request. */
+  setPendingPropertyFocus: (focus: PropertyFocusTarget | null) => void;
   setTheme: (theme: ThemeMode) => void;
   toggleTheme: () => void;
   /** Shift+click secret: toggle colorful mode on/off */
@@ -144,6 +164,7 @@ export const createUISlice: StateCreator<UISlice & UICrossSliceState, [], [], UI
   activeTool: UI_DEFAULTS.ACTIVE_TOOL,
   editEnabled: false,
   propertiesActiveTab: 'properties',
+  pendingPropertyFocus: null,
   theme: UI_DEFAULTS.THEME,
   isMobile: false,
   hoverTooltipsEnabled: UI_DEFAULTS.HOVER_TOOLTIPS_ENABLED,
@@ -206,6 +227,8 @@ export const createUISlice: StateCreator<UISlice & UICrossSliceState, [], [], UI
   },
 
   setPropertiesActiveTab: (propertiesActiveTab) => set({ propertiesActiveTab }),
+
+  setPendingPropertyFocus: (pendingPropertyFocus) => set({ pendingPropertyFocus }),
 
   setTheme: (theme) => {
     applyThemeClasses(theme);

--- a/apps/viewer/src/store/slices/uiSlice.ts
+++ b/apps/viewer/src/store/slices/uiSlice.ts
@@ -64,6 +64,9 @@ export interface UISlice {
    * rather than per-panel toggles.
    */
   editEnabled: boolean;
+  /** Active tab in the Properties panel. Controlled so in-app flows (e.g.
+   *  adding a bSDD property) can jump back to "properties" — issue #1107. */
+  propertiesActiveTab: 'properties' | 'quantities' | 'bsdd' | 'raw-step';
   theme: ThemeMode;
   isMobile: boolean;
   hoverTooltipsEnabled: boolean;
@@ -93,6 +96,7 @@ export interface UISlice {
   setActiveTool: (tool: string) => void;
   setEditEnabled: (enabled: boolean) => void;
   toggleEditEnabled: () => void;
+  setPropertiesActiveTab: (tab: 'properties' | 'quantities' | 'bsdd' | 'raw-step') => void;
   setTheme: (theme: ThemeMode) => void;
   toggleTheme: () => void;
   /** Shift+click secret: toggle colorful mode on/off */
@@ -139,6 +143,7 @@ export const createUISlice: StateCreator<UISlice & UICrossSliceState, [], [], UI
   rightPanelCollapsed: false,
   activeTool: UI_DEFAULTS.ACTIVE_TOOL,
   editEnabled: false,
+  propertiesActiveTab: 'properties',
   theme: UI_DEFAULTS.THEME,
   isMobile: false,
   hoverTooltipsEnabled: UI_DEFAULTS.HOVER_TOOLTIPS_ENABLED,
@@ -199,6 +204,8 @@ export const createUISlice: StateCreator<UISlice & UICrossSliceState, [], [], UI
   toggleEditEnabled: () => {
     get().setEditEnabled(!get().editEnabled);
   },
+
+  setPropertiesActiveTab: (propertiesActiveTab) => set({ propertiesActiveTab }),
 
   setTheme: (theme) => {
     applyThemeClasses(theme);

--- a/packages/mutations/src/mutable-property-view.ts
+++ b/packages/mutations/src/mutable-property-view.ts
@@ -331,6 +331,16 @@ export class MutablePropertyView {
     // Get old value for undo
     const oldValue = this.getPropertyValue(entityId, psetName, propName);
 
+    // Whether the property already existed BEFORE this call — decided up front
+    // because the block below may insert it into `newPsets`. A null value does
+    // NOT mean absent (an unset Boolean is present-but-empty), so existence is
+    // "had a value OR already an in-session property" (issue #1107). This drives
+    // the CREATE vs UPDATE classification so undo reverts an unset edit instead
+    // of deleting the whole property.
+    const propExistedBefore =
+      oldValue !== null ||
+      !!this.newPsets.get(entityId)?.get(psetName)?.properties.some(p => p.name === propName);
+
     // Check if this pset exists in base
     const basePsets = this.getBasePropertiesForEntity(entityId);
     const psetExistsInBase = basePsets.some(p => p.name === psetName);
@@ -387,7 +397,7 @@ export class MutablePropertyView {
 
     const mutation: Mutation = {
       id: generateMutationId(),
-      type: oldValue === null ? 'CREATE_PROPERTY' : 'UPDATE_PROPERTY',
+      type: propExistedBefore ? 'UPDATE_PROPERTY' : 'CREATE_PROPERTY',
       timestamp: Date.now(),
       modelId: this.modelId,
       entityId,
@@ -412,7 +422,12 @@ export class MutablePropertyView {
     const key = propertyKey(entityId, psetName, propName);
     const oldValue = this.getPropertyValue(entityId, psetName, propName);
 
-    if (oldValue === null) {
+    // A property can legitimately exist with a null value — an unset Boolean
+    // added from bSDD lives in `newPsets` with value=null (issue #1107). So
+    // "absent" means "no value AND not an in-session property"; keying delete
+    // purely on `oldValue === null` made the trash button a silent no-op.
+    const inNewPset = !!this.newPsets.get(entityId)?.get(psetName)?.properties.some(p => p.name === propName);
+    if (oldValue === null && !inNewPset) {
       return null; // Property doesn't exist
     }
 

--- a/packages/mutations/test/mutable-property-view.test.ts
+++ b/packages/mutations/test/mutable-property-view.test.ts
@@ -44,6 +44,35 @@ describe('MutablePropertyView', () => {
     expect(view.getForEntity(7)).toEqual([]);
   });
 
+  it('treats a null/unset property as present, not absent (issue #1107)', () => {
+    // A bSDD Boolean is added unset (value null) so we never pick a value for
+    // the user. Such a property still EXISTS — null must not be read as absent.
+    const view = new MutablePropertyView(null, 'model-1');
+    view.setOnDemandExtractor(() => []);
+
+    const created = view.setProperty(9, 'Pset_WallCommon', 'Combustible', null, PropertyValueType.Boolean);
+    expect(created.type).toBe('CREATE_PROPERTY');
+    expect(view.getForEntity(9)).toMatchObject([
+      {
+        name: 'Pset_WallCommon',
+        properties: [{ name: 'Combustible', type: PropertyValueType.Boolean, value: null }],
+      },
+    ]);
+
+    // Editing an existing-but-unset property is an UPDATE (not a CREATE), so a
+    // later undo restores the prior unset state instead of deleting the property.
+    const edited = view.setProperty(9, 'Pset_WallCommon', 'Combustible', true, PropertyValueType.Boolean);
+    expect(edited.type).toBe('UPDATE_PROPERTY');
+    expect(edited.oldValue).toBeNull();
+
+    // The unset property is still deletable — the trash button is not a no-op.
+    const fresh = new MutablePropertyView(null, 'model-1');
+    fresh.setOnDemandExtractor(() => []);
+    fresh.setProperty(9, 'Pset_WallCommon', 'Combustible', null, PropertyValueType.Boolean);
+    expect(fresh.deleteProperty(9, 'Pset_WallCommon', 'Combustible')).not.toBeNull();
+    expect(fresh.getForEntity(9)).toEqual([]);
+  });
+
   describe('entity aliases (duplicate flow)', () => {
     it('routes base property reads to the source entity when aliased', () => {
       const view = new MutablePropertyView(null, 'model-1');


### PR DESCRIPTION
Part of #1107 (item 10: *"bSDD property editing was not clear. I could add a property, but I was not sure how to set values like true or false."*).

## Problem
The bSDD card added every property with an **empty string** value (`defaultValue()` always returned `''`). To set a boolean you had to: add it → find it in the Properties panel → open the inline editor → use the Switch. There was no on-card way to set true/false, and nothing signalled a value was needed.

## Fix
Render a value control inline next to each not-yet-added property:
- **Boolean** dataType → a `Switch` (defaults to `false`)
- **enum** (property has bSDD `allowedValues`) → a `Select` of the allowed values

The chosen value flows through `handleAddProperty(psetName, prop, value)` so the property is created **with** it instead of an empty string. `defaultValue()` now returns `false` for booleans — a valid default everywhere it's used (single add, Add-All, and the Switch's initial state) — so a boolean is usable the moment it's added. Other dataTypes are unchanged (still empty for manual entry).

## Verification
`tsc --noEmit` on the viewer → 0 errors. App-only (no changeset). A quick visual check of the bSDD card is worthwhile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a one-shot “jump to property and edit” workflow: the Properties tab opens, the target row is highlighted, focus is applied after render, then cleared.

* **Improvements**
  * Streamlined bSDD inline value handling with consistent type-to-control mapping, correct defaults, and improved add-flow toasts for inline-editable items.
  * Added tri-state Boolean/Logical editing (“Unset / True / False”) with correct persistence.

* **Bug Fixes**
  * Prevented added checkmarks and edit prompts from carrying over across entity selections.
  * Corrected handling of unset/null properties for edit, delete, and undo behavior.

* **Tests**
  * Added unit tests for bSDD value type mapping and default generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->