### PR TITLE
feat(viewer): mirror class-tree selection into the advanced filter (#1107)

### DIFF
--- a/apps/viewer/src/components/viewer/HierarchyPanel.tsx
+++ b/apps/viewer/src/components/viewer/HierarchyPanel.tsx
@@ -19,6 +19,8 @@ import { cn } from '@/lib/utils';
 import { useViewerStore, resolveEntityRef } from '@/store';
 import { toGlobalIdFromModels } from '@/store/globalId';
 import { useIfc } from '@/hooks/useIfc';
+import { Rule } from '@/lib/search/filter-rules';
+import { toast } from '@/components/ui/toast';
 
 import type { TreeNode } from './hierarchy/types';
 import { isSpatialContainer } from './hierarchy/types';
@@ -55,6 +57,7 @@ export function HierarchyPanel() {
   const clearIsolation = useViewerStore((s) => s.clearIsolation);
   const classFilter = useViewerStore((s) => s.classFilter);
   const setClassFilter = useViewerStore((s) => s.setClassFilter);
+  const addFilterRule = useViewerStore((s) => s.addFilterRule);
   const clearClassFilter = useViewerStore((s) => s.clearClassFilter);
   const clearAllFilters = useViewerStore((s) => s.clearAllFilters);
   const setHierarchyBasketSelection = useViewerStore((s) => s.setHierarchyBasketSelection);
@@ -264,8 +267,21 @@ export function HierarchyPanel() {
         setSelectedEntityIds([]);
         setSelectedEntity(resolveEntityRef(elements[0]));
         if (groupingMode === 'type') {
+          const className = node.ifcType || node.name;
           // Class tab → class filter (combinable with storey + type isolation)
-          setClassFilter(elements, node.ifcType || node.name);
+          setClassFilter(elements, className);
+          // Also mirror the selection into the advanced filter panel as an
+          // additive ifcType rule so it can be refined/queried there
+          // (issue #1107, item 6). Silent — we don't open the modal. Skip if an
+          // identical rule already exists so repeated clicks don't pile up.
+          const rules = useViewerStore.getState().searchFilter.rules;
+          const alreadyHasRule = rules.some(
+            (r) => r.kind === 'ifcType' && r.values.length === 1 && r.values[0] === className,
+          );
+          if (!alreadyHasRule) {
+            addFilterRule(Rule.ifcType([className], 'in'));
+            toast.success(`Added "${className}" to advanced filter`);
+          }
         } else {
           // Type tab → type isolation (combinable with storey + class filter)
           isolateEntities(elements);
@@ -477,7 +493,7 @@ export function HierarchyPanel() {
         setSelectedEntity(resolveEntityRef(globalId));
       }
     }
-  }, [selectedStoreys, setStoreysSelection, clearStoreySelection, setActiveStorey, setLevelDisplayMode, setSelectedEntityId, setSelectedEntityIds, setSelectedEntity, setSelectedEntities, setActiveModel, toggleExpand, unifiedStoreys, models, isolateEntities, getNodeElements, setHierarchyBasketSelection, toGlobalId, groupingMode, setClassFilter]);
+  }, [selectedStoreys, setStoreysSelection, clearStoreySelection, setActiveStorey, setLevelDisplayMode, setSelectedEntityId, setSelectedEntityIds, setSelectedEntity, setSelectedEntities, setActiveModel, toggleExpand, unifiedStoreys, models, isolateEntities, getNodeElements, setHierarchyBasketSelection, toGlobalId, groupingMode, setClassFilter, addFilterRule]);
 
   // Compute selection and visibility state for a node
   const computeNodeState = useCallback((node: TreeNode): { isSelected: boolean; nodeHidden: boolean; modelVisible?: boolean } => {

--- a/apps/viewer/src/components/viewer/HierarchyPanel.tsx
+++ b/apps/viewer/src/components/viewer/HierarchyPanel.tsx
@@ -58,6 +58,7 @@ export function HierarchyPanel() {
   const classFilter = useViewerStore((s) => s.classFilter);
   const setClassFilter = useViewerStore((s) => s.setClassFilter);
   const addFilterRule = useViewerStore((s) => s.addFilterRule);
+  const updateFilterRule = useViewerStore((s) => s.updateFilterRule);
   const clearClassFilter = useViewerStore((s) => s.clearClassFilter);
   const clearAllFilters = useViewerStore((s) => s.clearAllFilters);
   const setHierarchyBasketSelection = useViewerStore((s) => s.setHierarchyBasketSelection);
@@ -270,15 +271,22 @@ export function HierarchyPanel() {
           const className = node.ifcType || node.name;
           // Class tab → class filter (combinable with storey + type isolation)
           setClassFilter(elements, className);
-          // Also mirror the selection into the advanced filter panel as an
-          // additive ifcType rule so it can be refined/queried there
-          // (issue #1107, item 6). Silent — we don't open the modal. Skip if an
-          // identical rule already exists so repeated clicks don't pile up.
+          // Also mirror the selection into the advanced filter panel
+          // (issue #1107, item 6). Silent — we don't open the modal. Merge into
+          // an existing `ifcType in [...]` rule's values rather than appending a
+          // second singleton: with the default AND combinator two singleton
+          // ifcType rules (e.g. IfcWall AND IfcDoor) can never both match, so
+          // the filter would return nothing. Merging gives OR-within-the-rule.
           const rules = useViewerStore.getState().searchFilter.rules;
-          const alreadyHasRule = rules.some(
-            (r) => r.kind === 'ifcType' && r.values.length === 1 && r.values[0] === className,
-          );
-          if (!alreadyHasRule) {
+          const existingIdx = rules.findIndex((r) => r.kind === 'ifcType' && r.op === 'in');
+          const existing = existingIdx >= 0 ? rules[existingIdx] : null;
+          if (existing && existing.kind === 'ifcType') {
+            if (!existing.values.includes(className)) {
+              updateFilterRule(existingIdx, Rule.ifcType([...existing.values, className], 'in'));
+              toast.success(`Added "${className}" to advanced filter`);
+            }
+            // else: already in the rule — no-op, no toast
+          } else {
             addFilterRule(Rule.ifcType([className], 'in'));
             toast.success(`Added "${className}" to advanced filter`);
           }
@@ -493,7 +501,7 @@ export function HierarchyPanel() {
         setSelectedEntity(resolveEntityRef(globalId));
       }
     }
-  }, [selectedStoreys, setStoreysSelection, clearStoreySelection, setActiveStorey, setLevelDisplayMode, setSelectedEntityId, setSelectedEntityIds, setSelectedEntity, setSelectedEntities, setActiveModel, toggleExpand, unifiedStoreys, models, isolateEntities, getNodeElements, setHierarchyBasketSelection, toGlobalId, groupingMode, setClassFilter, addFilterRule]);
+  }, [selectedStoreys, setStoreysSelection, clearStoreySelection, setActiveStorey, setLevelDisplayMode, setSelectedEntityId, setSelectedEntityIds, setSelectedEntity, setSelectedEntities, setActiveModel, toggleExpand, unifiedStoreys, models, isolateEntities, getNodeElements, setHierarchyBasketSelection, toGlobalId, groupingMode, setClassFilter, addFilterRule, updateFilterRule]);
 
   // Compute selection and visibility state for a node
   const computeNodeState = useCallback((node: TreeNode): { isSelected: boolean; nodeHidden: boolean; modelVisible?: boolean } => {

--- a/apps/viewer/src/components/viewer/HierarchyPanel.tsx
+++ b/apps/viewer/src/components/viewer/HierarchyPanel.tsx
@@ -60,6 +60,7 @@ export function HierarchyPanel() {
   const addFilterRule = useViewerStore((s) => s.addFilterRule);
   const updateFilterRule = useViewerStore((s) => s.updateFilterRule);
   const removeFilterRule = useViewerStore((s) => s.removeFilterRule);
+  const setSearchFilterAutoRunPending = useViewerStore((s) => s.setSearchFilterAutoRunPending);
   const clearClassFilter = useViewerStore((s) => s.clearClassFilter);
   const clearAllFilters = useViewerStore((s) => s.clearAllFilters);
   const setHierarchyBasketSelection = useViewerStore((s) => s.setHierarchyBasketSelection);
@@ -250,14 +251,19 @@ export function HierarchyPanel() {
       const rules = useViewerStore.getState().searchFilter.rules;
       const idx = rules.findIndex(matches);
       if (rule === null) {
-        if (idx >= 0) removeFilterRule(idx);
+        if (idx < 0) return; // nothing to clear — don't arm an empty run
+        removeFilterRule(idx);
       } else if (idx >= 0) {
         updateFilterRule(idx, rule);
       } else {
         addFilterRule(rule);
       }
+      // Arm the Filter to run itself: a hierarchy click shouldn't make the
+      // user open the modal and press Run to see what it matched. The Filter
+      // panel only mounts when the modal is open, so the flag waits there.
+      setSearchFilterAutoRunPending(true);
     },
-    [addFilterRule, updateFilterRule, removeFilterRule],
+    [addFilterRule, updateFilterRule, removeFilterRule, setSearchFilterAutoRunPending],
   );
 
   // Handle node click - for selection/isolation or expand/collapse

--- a/apps/viewer/src/components/viewer/HierarchyPanel.tsx
+++ b/apps/viewer/src/components/viewer/HierarchyPanel.tsx
@@ -19,7 +19,7 @@ import { cn } from '@/lib/utils';
 import { useViewerStore, resolveEntityRef } from '@/store';
 import { toGlobalIdFromModels } from '@/store/globalId';
 import { useIfc } from '@/hooks/useIfc';
-import { Rule } from '@/lib/search/filter-rules';
+import { Rule, type FilterRule } from '@/lib/search/filter-rules';
 import { toast } from '@/components/ui/toast';
 
 import type { TreeNode } from './hierarchy/types';
@@ -59,6 +59,7 @@ export function HierarchyPanel() {
   const setClassFilter = useViewerStore((s) => s.setClassFilter);
   const addFilterRule = useViewerStore((s) => s.addFilterRule);
   const updateFilterRule = useViewerStore((s) => s.updateFilterRule);
+  const removeFilterRule = useViewerStore((s) => s.removeFilterRule);
   const clearClassFilter = useViewerStore((s) => s.clearClassFilter);
   const clearAllFilters = useViewerStore((s) => s.clearAllFilters);
   const setHierarchyBasketSelection = useViewerStore((s) => s.setHierarchyBasketSelection);
@@ -239,6 +240,26 @@ export function HierarchyPanel() {
     if (hasChildren) toggleExpand(nodeId);
   }, [setSelectedModelId, toggleExpand]);
 
+  // Mirror a hierarchy selection into the advanced filter as ONE rule per
+  // dimension (issue #1107). Upsert (not append): replace the existing rule of
+  // this kind so the filter tracks the current selection — appending singletons
+  // both leaves stale values behind and, under the default AND combinator,
+  // makes two ifcType rules match nothing. Pass `null` to clear the dimension.
+  const upsertSearchRule = useCallback(
+    (matches: (r: FilterRule) => boolean, rule: FilterRule | null) => {
+      const rules = useViewerStore.getState().searchFilter.rules;
+      const idx = rules.findIndex(matches);
+      if (rule === null) {
+        if (idx >= 0) removeFilterRule(idx);
+      } else if (idx >= 0) {
+        updateFilterRule(idx, rule);
+      } else {
+        addFilterRule(rule);
+      }
+    },
+    [addFilterRule, updateFilterRule, removeFilterRule],
+  );
+
   // Handle node click - for selection/isolation or expand/collapse
   const handleNodeClick = useCallback((node: TreeNode, e: React.MouseEvent) => {
     if (node.type === 'model-header' && node.id !== 'models-header') {
@@ -271,25 +292,12 @@ export function HierarchyPanel() {
           const className = node.ifcType || node.name;
           // Class tab → class filter (combinable with storey + type isolation)
           setClassFilter(elements, className);
-          // Also mirror the selection into the advanced filter panel
-          // (issue #1107, item 6). Silent — we don't open the modal. Merge into
-          // an existing `ifcType in [...]` rule's values rather than appending a
-          // second singleton: with the default AND combinator two singleton
-          // ifcType rules (e.g. IfcWall AND IfcDoor) can never both match, so
-          // the filter would return nothing. Merging gives OR-within-the-rule.
-          const rules = useViewerStore.getState().searchFilter.rules;
-          const existingIdx = rules.findIndex((r) => r.kind === 'ifcType' && r.op === 'in');
-          const existing = existingIdx >= 0 ? rules[existingIdx] : null;
-          if (existing && existing.kind === 'ifcType') {
-            if (!existing.values.includes(className)) {
-              updateFilterRule(existingIdx, Rule.ifcType([...existing.values, className], 'in'));
-              toast.success(`Added "${className}" to advanced filter`);
-            }
-            // else: already in the rule — no-op, no toast
-          } else {
-            addFilterRule(Rule.ifcType([className], 'in'));
-            toast.success(`Added "${className}" to advanced filter`);
-          }
+          // Mirror to the advanced filter: sync the single ifcType rule to the
+          // current class (issue #1107). Replace, don't accumulate — the class
+          // tab is single-select, so the rule should be exactly the clicked
+          // class, not a pile-up of earlier clicks.
+          upsertSearchRule((r) => r.kind === 'ifcType' && r.op === 'in', Rule.ifcType([className], 'in'));
+          toast.success(`Filter → ${className}`);
         } else {
           // Type tab → type isolation (combinable with storey + class filter)
           isolateEntities(elements);
@@ -323,6 +331,9 @@ export function HierarchyPanel() {
       if (elements.length > 0) {
         isolateEntities(elements);
       }
+      // Mirror to the advanced filter (issue #1107).
+      upsertSearchRule((r) => r.kind === 'material', Rule.material('eq', node.name));
+      toast.success(`Filter → material ${node.name}`);
       return;
     }
 
@@ -427,6 +438,11 @@ export function HierarchyPanel() {
       if (e.ctrlKey || e.metaKey) {
         // Add to storey filter selection
         setStoreysSelection([...Array.from(selectedStoreys), ...storeyIds]);
+        // Mirror to the advanced filter — accumulate the storey name (issue #1107).
+        const cur = useViewerStore.getState().searchFilter.rules.find((r) => r.kind === 'storey' && r.op === 'in');
+        const names = cur && cur.kind === 'storey' ? Array.from(new Set([...cur.values, node.name])) : [node.name];
+        upsertSearchRule((r) => r.kind === 'storey' && r.op === 'in', Rule.storey(names, 'in'));
+        toast.success(`Filter → storey ${node.name}`);
       } else {
         // Single selection - toggle if already selected
         const allAlreadySelected = storeyIds.length > 0 &&
@@ -438,12 +454,17 @@ export function HierarchyPanel() {
           // (useLevelDisplayEffect) drops Solo → Stacked when no storey is
           // isolated, so the mode flag follows.
           clearStoreySelection();
+          // Clear the mirrored storey rule too (issue #1107).
+          upsertSearchRule((r) => r.kind === 'storey', null);
         } else {
           // Select this storey (replaces any existing selection). Isolating a
           // single storey IS Solo, so reflect that in the level-display mode —
           // keeps the storey-tab control + in-viewport chip in sync.
           setStoreysSelection(storeyIds);
           setLevelDisplayMode('solo');
+          // Mirror to the advanced filter: one storey rule = this storey (issue #1107).
+          upsertSearchRule((r) => r.kind === 'storey' && r.op === 'in', Rule.storey([node.name], 'in'));
+          toast.success(`Filter → storey ${node.name}`);
         }
       }
     } else if (node.type === 'IfcSpace') {
@@ -501,7 +522,7 @@ export function HierarchyPanel() {
         setSelectedEntity(resolveEntityRef(globalId));
       }
     }
-  }, [selectedStoreys, setStoreysSelection, clearStoreySelection, setActiveStorey, setLevelDisplayMode, setSelectedEntityId, setSelectedEntityIds, setSelectedEntity, setSelectedEntities, setActiveModel, toggleExpand, unifiedStoreys, models, isolateEntities, getNodeElements, setHierarchyBasketSelection, toGlobalId, groupingMode, setClassFilter, addFilterRule, updateFilterRule]);
+  }, [selectedStoreys, setStoreysSelection, clearStoreySelection, setActiveStorey, setLevelDisplayMode, setSelectedEntityId, setSelectedEntityIds, setSelectedEntity, setSelectedEntities, setActiveModel, toggleExpand, unifiedStoreys, models, isolateEntities, getNodeElements, setHierarchyBasketSelection, toGlobalId, groupingMode, setClassFilter, upsertSearchRule]);
 
   // Compute selection and visibility state for a node
   const computeNodeState = useCallback((node: TreeNode): { isSelected: boolean; nodeHidden: boolean; modelVisible?: boolean } => {

--- a/apps/viewer/src/components/viewer/SearchModal.filter.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.tsx
@@ -69,6 +69,8 @@ export function SearchModalFilter() {
     setPendingListDraft,
     setListPanelVisible,
     setSearchModalOpen,
+    autoRunPending,
+    setAutoRunPending,
   } = useViewerStore(
     useShallow((s) => ({
       searchFilter: s.searchFilter,
@@ -88,6 +90,8 @@ export function SearchModalFilter() {
       setPendingListDraft: s.setPendingListDraft,
       setListPanelVisible: s.setListPanelVisible,
       setSearchModalOpen: s.setSearchModalOpen,
+      autoRunPending: s.searchFilterAutoRunPending,
+      setAutoRunPending: s.setSearchFilterAutoRunPending,
     })),
   );
 
@@ -213,6 +217,30 @@ export function SearchModalFilter() {
   const cancelFilter = useCallback(() => {
     runController.current?.abort();
   }, []);
+
+  // Auto-run when the Filter was populated from outside the modal (a
+  // Hierarchy node click arms `searchFilterAutoRunPending`). Because the
+  // panel only mounts when the modal is open, the flag survives a closed
+  // modal and fires on the next open — so the user sees results without
+  // pressing Run. Clear the flag first so a slow run can't re-trigger.
+  useEffect(() => {
+    if (!autoRunPending) return;
+    setAutoRunPending(false);
+    if (searchFilter.rules.length === 0) {
+      // Hierarchy cleared the last rule — drop the stale table rather than
+      // run an empty filter (which the runner rejects anyway).
+      setSearchFilterResult(null);
+    } else if (!searchFilterRunning) {
+      void runFilter();
+    }
+  }, [
+    autoRunPending,
+    searchFilter.rules.length,
+    searchFilterRunning,
+    setAutoRunPending,
+    setSearchFilterResult,
+    runFilter,
+  ]);
 
   // Cancel any in-flight run when the modal unmounts so background
   // chunked work doesn't keep ticking after close.

--- a/apps/viewer/src/store/slices/searchSlice.ts
+++ b/apps/viewer/src/store/slices/searchSlice.ts
@@ -131,6 +131,13 @@ export interface SearchSlice {
   searchFilterError: string | null;
   /** Filter rule state — chip rules, combinator, limit. */
   searchFilter: SearchFilterStateValue;
+  /**
+   * Set when a rule is pushed into the Filter from outside the modal
+   * (e.g. clicking a Hierarchy node). The Filter panel watches this and
+   * runs automatically on its next mount/render so the user sees results
+   * without pressing Run. Cleared by the panel once it kicks off a run.
+   */
+  searchFilterAutoRunPending: boolean;
   /** Per-model filter-schema cache (lazy). */
   searchFilterSchema: Map<string, FilterSchemaCacheEntry>;
 
@@ -176,6 +183,8 @@ export interface SearchSlice {
   // ── Filter-rule actions ───────────────────────────────────────────
   /** Replace the whole filter state — used by Reset and preset loading. */
   setSearchFilter: (state: SearchFilterStateValue) => void;
+  /** Arm/disarm the "auto-run on next Filter render" flag. */
+  setSearchFilterAutoRunPending: (pending: boolean) => void;
   setFilterCombinator: (combinator: Combinator) => void;
   setFilterLimit: (limit: number) => void;
   addFilterRule: (rule: FilterRule) => void;
@@ -205,6 +214,7 @@ export const createSearchSlice: StateCreator<SearchSlice, [], [], SearchSlice> =
   searchFilterRunning: false,
   searchFilterError: null,
   searchFilter: emptyFilterState(),
+  searchFilterAutoRunPending: false,
   searchFilterSchema: new Map(),
 
   // Typing or programmatically changing the query breaks out of vim cycle —
@@ -289,6 +299,9 @@ export const createSearchSlice: StateCreator<SearchSlice, [], [], SearchSlice> =
   setSearchFilterError: (searchFilterError) => set({ searchFilterError }),
 
   setSearchFilter: (searchFilter) => set({ searchFilter }),
+
+  setSearchFilterAutoRunPending: (searchFilterAutoRunPending) =>
+    set({ searchFilterAutoRunPending }),
 
   setFilterCombinator: (combinator) =>
     set((state) => ({ searchFilter: { ...state.searchFilter, combinator } })),


### PR DESCRIPTION
Part of #1107 (item 6: *"If I select something from the hierarchy or class tree, it would be useful if that filter also appeared in the advanced filter panel?"*).

## Before
The hierarchy's **By Class** tab and the **advanced filter** panel were two independent systems: clicking a class set a render-level `classFilter` (a visibility Set), while the advanced filter used structured `FilterRule[]`. They never shared state.

## Change
On a class-tree click (`groupingMode === 'type'`), in addition to the existing class filter, push an additive **`ifcType in [Class]`** rule into the advanced filter and show a toast.

Per the agreed UX (chosen in discussion):
- **Silent + toast** — the filter modal is *not* opened.
- **Additive** — combines with existing rules rather than replacing them.
- **De-duplicated** — repeated clicks on the same class don't pile up identical rules.

Scope: the **class** case only (globally-consistent IFC class names). Storey/spatial rules were left out deliberately — they raise a federation question (same storey name/elevation across models → different express IDs) better handled separately.

## Verification
`tsc --noEmit` on the viewer → 0 errors. App-only (no changeset). `addFilterRule` already appends without opening the modal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clicking Class items in the hierarchy panel now automatically applies corresponding advanced filter rules. The system prevents duplicate rule creation and provides confirmation feedback through notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->