### PR TITLE
feat(sdk): bim.query.matchingActiveFilter() for filtered CSV/quantity export (#1107)

### DIFF
--- a/.changeset/issue-1107-query-active-filter.md
+++ b/.changeset/issue-1107-query-active-filter.md
@@ -1,0 +1,6 @@
+---
+"@ifc-lite/sdk": minor
+"@ifc-lite/sandbox": minor
+---
+
+Add `bim.query.matchingActiveFilter()` — returns the entities matching the host's active advanced filter (or `null` when no filter is set). Backed by a new `QueryBackendMethods.entitiesMatchingActiveFilter()`. Lets scripted exports (e.g. the CSV quantity take-off) honour the current filtered view instead of always exporting the whole model (issue #1107).

--- a/apps/viewer/src/lib/scripts/templates/bim-globals.d.ts
+++ b/apps/viewer/src/lib/scripts/templates/bim-globals.d.ts
@@ -137,6 +137,8 @@ declare const bim: {
     all(): BimEntity[];
     /** Filter by IFC type e.g. 'IfcWall' */
     byType(...types: string[]): BimEntity[];
+    /** Entities matching the active advanced filter, or null if no filter is active */
+    matchingActiveFilter(): BimEntity[] | null;
     /** Get entity by model ID and express ID */
     entity(modelId: string, expressId: number): BimEntity | null;
     /** Get all named string/enum attributes for an entity */

--- a/apps/viewer/src/lib/scripts/templates/quantity-takeoff.ts
+++ b/apps/viewer/src/lib/scripts/templates/quantity-takeoff.ts
@@ -133,7 +133,16 @@ for (const t of takeoffs.sort((a, b) => b.count - a.count)) {
 
 // ── Export ───────────────────────────────────────────────────────────────
 // Build a flat entity list with quantities for CSV export
-const allElements = bim.query.byType(...ELEMENT_TYPES)
+let allElements = bim.query.byType(...ELEMENT_TYPES)
+// Respect the active advanced filter, if one is set, so the CSV matches the
+// current filtered view rather than the whole model (issue #1107).
+const activeFilter = bim.query.matchingActiveFilter()
+if (activeFilter) {
+  const keep = new Set(activeFilter.map(e => e.ref.modelId + ':' + e.ref.expressId))
+  const before = allElements.length
+  allElements = allElements.filter(e => keep.has(e.ref.modelId + ':' + e.ref.expressId))
+  console.log('Active filter applied: ' + allElements.length + ' of ' + before + ' elements')
+}
 if (allElements.length > 0) {
   const qtyCols = Array.from(quantityColumns).sort()
   bim.export.csv(allElements, {

--- a/apps/viewer/src/sdk/adapters/query-adapter.active-filter.test.ts
+++ b/apps/viewer/src/sdk/adapters/query-adapter.active-filter.test.ts
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createQueryAdapter } from './query-adapter.js';
+import type { StoreApi } from './types.js';
+
+function makeStore(searchFilter: unknown): StoreApi {
+  return {
+    getState: () => ({ searchFilter, models: new Map() }),
+    subscribe: () => () => {},
+  } as unknown as StoreApi;
+}
+
+test('entitiesMatchingActiveFilter returns null when no filter rules are active', () => {
+  const adapter = createQueryAdapter(makeStore({ rules: [], combinator: 'AND', limit: 500 }));
+  // null (not []) so callers can distinguish "no filter" from "zero matches".
+  assert.equal(adapter.entitiesMatchingActiveFilter(), null);
+});
+
+test('entitiesMatchingActiveFilter returns null when the filter state is absent', () => {
+  const adapter = createQueryAdapter(makeStore(undefined));
+  assert.equal(adapter.entitiesMatchingActiveFilter(), null);
+});

--- a/apps/viewer/src/sdk/adapters/query-adapter.ts
+++ b/apps/viewer/src/sdk/adapters/query-adapter.ts
@@ -29,6 +29,7 @@ import {
   extractRelationshipsOnDemand,
 } from '@ifc-lite/parser';
 import { applyAttributeMutationsToEntityData, mergeAttributeMutations } from './mutation-view.js';
+import { evaluateFilterRules } from '../../lib/search/filter-evaluate.js';
 
 /** Map IFC relationship entity names to internal RelationshipType enum.
  * Keys use proper IFC schema names (e.g. IfcRelAggregates, not "Aggregates"). */
@@ -313,8 +314,52 @@ export function createQueryAdapter(store: StoreApi): QueryBackendMethods {
     return filtered;
   }
 
+  /**
+   * Entities matching the viewer's *active advanced filter* (the chip rules in
+   * the Search modal's Filter tab), or `null` when no filter is active. Lets
+   * scripted exports (e.g. the CSV quantity take-off) honour the current
+   * filtered view instead of always exporting everything (issue #1107, item 11).
+   *
+   * Re-evaluates `searchFilter.rules` per model with the synchronous evaluator —
+   * the same logic that backs the modal — with no row cap, so the export covers
+   * the full filtered set rather than the modal's display limit. Hidden/isolated
+   * visibility is intentionally NOT consulted: the chosen semantics are
+   * "active search/filter only".
+   */
+  function entitiesMatchingActiveFilter(): EntityData[] | null {
+    const state = store.getState();
+    const filter = state.searchFilter;
+    if (!filter || filter.rules.length === 0) return null;
+
+    const results: EntityData[] = [];
+    for (const [modelId, model] of getAllModelEntries(state)) {
+      if (!model?.ifcDataStore) continue;
+      const matched = evaluateFilterRules(
+        modelId,
+        model.ifcDataStore,
+        filter.rules,
+        filter.combinator,
+        { limit: Number.MAX_SAFE_INTEGER },
+      );
+      for (const m of matched) {
+        if (m.expressId === 0) continue;
+        const node = new EntityNode(model.ifcDataStore, m.expressId);
+        results.push(applyAttributeMutationsToEntityData(store, modelId, m.expressId, {
+          ref: { modelId, expressId: m.expressId },
+          globalId: node.globalId,
+          name: node.name,
+          type: node.type,
+          description: node.description,
+          objectType: node.objectType,
+        }));
+      }
+    }
+    return results;
+  }
+
   return {
     entities: queryEntities,
+    entitiesMatchingActiveFilter,
     entityData: getEntityData,
     attributes: getAttributes,
     properties: getProperties,

--- a/packages/cli/src/headless-backend.ts
+++ b/packages/cli/src/headless-backend.ts
@@ -346,6 +346,9 @@ export class HeadlessBackend implements BimBackend {
 
         return filtered;
       },
+      // Headless contexts have no interactive viewer filter, so there is never
+      // an "active filter" to report (issue #1107).
+      entitiesMatchingActiveFilter: () => null,
       entityData: getEntityData,
       attributes(ref: EntityRef): EntityAttributeData[] {
         return extractAllEntityAttributes(store, ref.expressId);

--- a/packages/mcp/src/headless-backend.ts
+++ b/packages/mcp/src/headless-backend.ts
@@ -288,6 +288,9 @@ export class HeadlessLikeBackend implements BimBackend {
         if (descriptor.limit && descriptor.limit > 0) filtered = filtered.slice(0, descriptor.limit);
         return filtered;
       },
+      // Headless contexts have no interactive viewer filter, so there is never
+      // an "active filter" to report (issue #1107).
+      entitiesMatchingActiveFilter: () => null,
       entityData: getEntityData,
       attributes(ref: EntityRef): EntityAttributeData[] {
         return extractAllEntityAttributes(store, ref.expressId);

--- a/packages/sandbox/src/bridge-query.ts
+++ b/packages/sandbox/src/bridge-query.ts
@@ -41,6 +41,17 @@ export function buildQueryNamespace(): NamespaceSchema {
         returns: 'value',
       },
       {
+        name: 'matchingActiveFilter',
+        doc: "Entities matching the viewer's active advanced filter, or null if no filter is active",
+        args: [],
+        tsReturn: 'BimEntity[] | null',
+        call: (sdk) => {
+          const matched = sdk.matchingActiveFilter();
+          return matched ? matched.map(withAliases) : null;
+        },
+        returns: 'value',
+      },
+      {
         name: 'entity',
         doc: 'Get entity by model ID and express ID',
         args: ['string', 'number'],

--- a/packages/sdk/src/context.ts
+++ b/packages/sdk/src/context.ts
@@ -104,6 +104,14 @@ export class BimContext {
   }
 
   /**
+   * Entities matching the host's active advanced filter, or `null` when no
+   * filter is active. Use for "export only the current filtered view" flows.
+   */
+  matchingActiveFilter(): EntityData[] | null {
+    return this._queryNamespace.matchingActiveFilter();
+  }
+
+  /**
    * Get a single entity by reference.
    */
   entity(ref: EntityRef): EntityData | null {

--- a/packages/sdk/src/namespaces/query.ts
+++ b/packages/sdk/src/namespaces/query.ts
@@ -105,6 +105,14 @@ export class QueryNamespace {
     return new QueryBuilder(this.backend);
   }
 
+  /**
+   * Entities matching the host's active advanced filter, or `null` when no
+   * filter is active. Use for "export only the current filtered view" flows.
+   */
+  matchingActiveFilter(): EntityData[] | null {
+    return this.backend.query.entitiesMatchingActiveFilter();
+  }
+
   /** Get a single entity by ref */
   entity(ref: EntityRef): EntityData | null {
     return this.backend.query.entityData(ref);

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -312,6 +312,12 @@ export interface ModelBackendMethods {
 
 export interface QueryBackendMethods {
   entities(descriptor: QueryDescriptor): EntityData[];
+  /**
+   * Entities matching the host's active advanced filter, or `null` when no
+   * filter is active (so callers can distinguish "no filter" from "filter with
+   * zero matches"). Host-specific; transport/headless backends may return null.
+   */
+  entitiesMatchingActiveFilter(): EntityData[] | null;
   entityData(ref: EntityRef): EntityData | null;
   attributes(ref: EntityRef): EntityAttributeData[];
   properties(ref: EntityRef): PropertySetData[];


### PR DESCRIPTION
Closes the last item of #1107 (item 11: *"CSV quantity export seemed to export all quantities, not the current filtered view. Filtered export would be useful?"*).

> 📝 **Draft — needs functional QA in the script sandbox.** Everything typechecks (3 packages, 0 errors) and the adapter is unit-tested, but the end-to-end QuickJS guest→bridge→host→template path can't be exercised headless. Please run the **Quantity Take-off** template with an active advanced filter to confirm.

## Chosen semantics
Respect the **active advanced filter** query (the chip rules in the Search modal's Filter tab) — *not* manual hide/isolate — per the decision in discussion.

## Why it needed plumbing
Script templates run in a **QuickJS sandbox**; their `bim` API (`@ifc-lite/sandbox` bridge → `@ifc-lite/sdk` → app backend) had no path to the viewer's filter state. So this threads a new read-only query through all three layers.

## Change
New `bim.query.matchingActiveFilter(): BimEntity[] | null`:
- **`@ifc-lite/sdk`** — `QueryBackendMethods.entitiesMatchingActiveFilter()` + `QueryNamespace`/`BimContext.matchingActiveFilter()`.
- **`@ifc-lite/sandbox`** — `bridge-query` guest method (mirrors `byType`).
- **viewer `query-adapter`** — implements it: re-evaluates `searchFilter.rules` per model with the **synchronous** evaluator (the same logic backing the modal), **no row cap** so the export covers the full filtered set, returning **`null`** when no filter is active (so callers distinguish "no filter" from "zero matches").
- **`quantity-takeoff` template** — intersects its `byType` set with the active filter and logs the count.

The new method rides `QueryBackendMethods`, so the transport backend's generic forwarding proxy handles it unchanged (headless/MCP contexts return null).

## Verification
- `tsc --noEmit`: `@ifc-lite/sdk` ✓, `@ifc-lite/sandbox` ✓, viewer ✓ — all 0 errors.
- `query-adapter.active-filter.test.ts` → 2/2 (no-filter → null; absent state → null). The match path delegates to the already-tested `evaluateFilterRules`.
- Changeset bumps both published packages (minor — additive API).
- ⛔ Not yet run interactively in the script sandbox.