### PR TITLE
feat(geometry): analytic f64 fast path for rectangular openings

### DIFF
--- a/.changeset/rect-opening-fast-path.md
+++ b/.changeset/rect-opening-fast-path.md
@@ -1,0 +1,15 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Add an f64 through-box fast path for rectangular openings — the overwhelmingly common void (a window/door box cut transversally through a slab-like wall) — bypassing the exact CSG arrangement entirely (~100–3000× cheaper per cut) while staying byte-identical native==wasm.
+
+The Phase-1 planar clip only handles a cutter that acts as a single half-space; a rectangular through-opening straddles the host on four lateral faces, so it still routed through the exact kernel. `ClippingProcessor::subtract_box_fast` now subtracts an axis-aligned box analytically: each host triangle is partitioned by the four lateral planes (a conforming 3×3 cell split, so no T-junctions), the window footprint is dropped, and the four reveal faces are synthesised from the actual cut rim — taking the host's own subdivision points (face diagonals, welds) onto each reveal edge so it matches the rim exactly, including when the host front and back faces are tessellated differently. The void router (`apply_void_context`) tries it per rectangular opening before materialising a penetrating box mesh for the exact subtract.
+
+It is only ever a fast path, never a different answer:
+
+- **transversality gate** — the box must span the host on exactly one axis (the through/thickness axis) and lie strictly interior on the other two; blind pockets, edge/corner cuts and non-transversal boxes defer;
+- **coplanar handling** — a host face coplanar with a cutting plane (e.g. two windows sharing a sill height) is sent to one side only, never duplicated;
+- **watertightness** — every directed boundary edge must cancel (the result is closed) on the stitch grid, otherwise defer to the exact kernel.
+
+Determinism is by construction: plain FMA-free f64 over the host's own coordinates, fixed plane/triangle/loop iteration order, and the same `Q`-grid edge stitching as the planar clip — only sign and comparison results are consumed, never an epsilon-snapped magnitude. The box and planar fast paths share one gate and the element-level fallback (`f64_fast_path_active`/`note_planar_clip_fired`), so a cut that cracks once scaled/placed into f32 world coordinates is re-processed on the exact kernel, and `IFC_LITE_DISABLE_PLANAR_CLIP=1` (native) forces the exact kernel for both. Validated watertight and volume-equivalent to the exact subtract on synthetic walls (single window, multiple through-axes, sequential disjoint windows including a shared sill, with pockets/corners/no-ops correctly deferring).

--- a/rust/geometry/src/csg.rs
+++ b/rust/geometry/src/csg.rs
@@ -756,72 +756,55 @@ impl ClippingProcessor {
             )
         };
 
-        // Classify each axis. A clean transversal cut spans the host on exactly
-        // one axis and lies strictly interior on the other two.
-        let mut through: Option<usize> = None;
-        let mut lateral: Vec<usize> = Vec::with_capacity(2);
+        // ── ACTIVE CUTTING PLANES. A box face is a cutting plane iff it lies
+        // strictly INTERIOR to the host on its axis; a face flush-with or past
+        // the host opens to the host boundary (no reveal there). This general
+        // model is what real IFC openings need — doors (floor-flush), openings at
+        // a wall end, partial-penetration boxes — not just clean transversal
+        // windows. Axes with NO active plane are fully spanned (the box pokes
+        // through, e.g. the wall thickness ⇒ no reveal on those faces).
+        struct ActivePlane {
+            axis: usize,
+            val: f64,
+            outward: f64, // -1 at the box MIN face, +1 at the box MAX face
+        }
+        let mut active: Vec<ActivePlane> = Vec::with_capacity(6);
         for k in 0..3 {
-            let spans = bmin[k] <= hmin[k] + tol && bmax[k] >= hmax[k] - tol;
-            let interior = bmin[k] > hmin[k] + tol && bmax[k] < hmax[k] - tol;
-            if spans {
-                if through.is_some() {
-                    BOXFAST_DEFER_GATE.fetch_add(1, Ordering::Relaxed);
-                    return Ok(None); // >1 through-axis (slot / full cut) → defer
-                }
-                through = Some(k);
-            } else if interior {
-                lateral.push(k);
-            } else {
-                // Box flush-with or partially past the host on this axis (a door
-                // flush with the floor, an edge window, a blind pocket) → not a
-                // clean transversal box; defer to the exact kernel.
-                BOXFAST_DEFER_GATE.fetch_add(1, Ordering::Relaxed);
-                boxfast_sample(format!(
-                    "GATE flush axis={k} spans={spans} interior={interior} {}",
-                    bounds_str()
-                ));
-                return Ok(None);
+            if bmin[k] > hmin[k] + tol {
+                active.push(ActivePlane { axis: k, val: bmin[k], outward: -1.0 });
+            }
+            if bmax[k] < hmax[k] - tol {
+                active.push(ActivePlane { axis: k, val: bmax[k], outward: 1.0 });
             }
         }
-        let Some(t_axis) = through else {
+        if active.is_empty() {
+            // The box covers the host on every axis (would remove everything) or
+            // is otherwise not a localizable cut — defer.
             BOXFAST_DEFER_GATE.fetch_add(1, Ordering::Relaxed);
-            boxfast_sample(format!("GATE no-through {}", bounds_str()));
-            return Ok(None);
-        };
-        if lateral.len() != 2 {
-            BOXFAST_DEFER_GATE.fetch_add(1, Ordering::Relaxed);
-            boxfast_sample(format!("GATE lateral={} {}", lateral.len(), bounds_str()));
+            boxfast_sample(format!("GATE no-active {}", bounds_str()));
             return Ok(None);
         }
-        let (la, lb) = (lateral[0], lateral[1]);
-
-        // Host through-extent (slab assumption — the watertight gate below
-        // rejects any host whose surface isn't flat at these coords).
-        let t_front = hmin[t_axis];
-        let t_back = hmax[t_axis];
-
-        // The 4 lateral cutting planes, outward normals pointing INTO the host
-        // material (away from the window interior) ⇒ "front" = outside column.
         let axis_unit = |k: usize, s: f64| {
             let mut v = Vector3::zeros();
             v[k] = s;
             v
         };
-        let plane_on = |k: usize, val: f64, s: f64| {
-            let mut p = Point3::new(
-                (bmin[0] + bmax[0]) * 0.5,
-                (bmin[1] + bmax[1]) * 0.5,
-                (bmin[2] + bmax[2]) * 0.5,
-            );
-            p[k] = val;
-            Plane::new(p, axis_unit(k, s))
-        };
-        let planes = [
-            plane_on(la, bmin[la], -1.0),
-            plane_on(la, bmax[la], 1.0),
-            plane_on(lb, bmin[lb], -1.0),
-            plane_on(lb, bmax[lb], 1.0),
-        ];
+        let center = Point3::new(
+            (bmin[0] + bmax[0]) * 0.5,
+            (bmin[1] + bmax[1]) * 0.5,
+            (bmin[2] + bmax[2]) * 0.5,
+        );
+        // Outward-normal planes (front = outside the box). The removed region is
+        // the box interior = behind ALL active planes (axes with no active plane
+        // are fully covered by the box, so they don't constrain).
+        let planes: Vec<Plane> = active
+            .iter()
+            .map(|a| {
+                let mut p = center;
+                p[a.axis] = a.val;
+                Plane::new(p, axis_unit(a.axis, a.outward))
+            })
+            .collect();
 
         let mut result = Mesh::new();
         // Directed open-boundary edges keyed by quantized endpoints; the value is
@@ -887,91 +870,110 @@ impl ClippingProcessor {
             }
         }
 
-        // ── Synthesise the 4 reveal faces (inner walls of the hole). After the
-        // trim, `dir` holds exactly the open hole rim: a front loop (at t_front)
-        // and a back loop (at t_back), each carrying whatever subdivision points
-        // the host tessellation introduced (face diagonals, welds). Each reveal
-        // face is built FROM those rim points (not as a fixed rectangle) so its
-        // edges match the host rim exactly — no T-junctions. The face is the
-        // lateral-plane polygon: front rim points (ascending) then back rim
-        // points (descending), earcut-triangulated. Faces are wound consistently
-        // w.r.t. their into-void normals (a closed tube ⇒ the vertical seams
-        // cancel), then one global flip aligns the tube to the host winding.
+        // ── Synthesise one reveal face per ACTIVE cutting plane. Each reveal is
+        // the box face — a rectangle in the two non-fixed axes, clipped to
+        // box∩host — with the host's actual rim points (from the trim) inserted on
+        // its abutting edges so the tessellation matches (no T-junctions). A
+        // flush/past side has no active plane, hence no reveal: the cut simply
+        // opens to the host boundary there (doors, end-openings). The face is
+        // triangulated as a CENTROID FAN — the centre is interior, so EVERY
+        // boundary edge survives and no triangle is degenerate (the corner-fan
+        // pitfall). Faces are wound to their into-void normals; one global flip
+        // then aligns them to the host winding.
         let rim_pts: Vec<Point3<f64>> = dir.values().copied().collect();
         let mut reveal_tris: Vec<(Point3<f64>, Point3<f64>, Point3<f64>)> = Vec::new();
-        for &(fixed_axis, fixed_val) in &[
-            (la, bmin[la]),
-            (la, bmax[la]),
-            (lb, bmin[lb]),
-            (lb, bmax[lb]),
-        ] {
-            let var_axis = if fixed_axis == la { lb } else { la };
-            let on_plane = |p: &Point3<f64>| (p[fixed_axis] - fixed_val).abs() <= tol;
-            let collect_sorted = |t_val: f64| -> Vec<Point3<f64>> {
-                let mut v: Vec<Point3<f64>> = rim_pts
-                    .iter()
-                    .copied()
-                    .filter(|p| on_plane(p) && (p[t_axis] - t_val).abs() <= tol)
-                    .collect();
-                v.sort_by(|a, b| a[var_axis].partial_cmp(&b[var_axis]).unwrap());
-                v.dedup_by(|a, b| box_clip_key(a) == box_clip_key(b));
-                v
+        for ap in &active {
+            let k = ap.axis;
+            let (a, b) = match k {
+                0 => (1usize, 2usize),
+                1 => (0usize, 2usize),
+                _ => (0usize, 1usize),
             };
-            let front = collect_sorted(t_front);
-            let back = collect_sorted(t_back);
-            // Need at least the two corners on each face to span the reveal.
-            if front.len() < 2 || back.len() < 2 {
+            // Reveal rectangle = box face ∩ host, in the (a, b) plane.
+            let amin = bmin[a].max(hmin[a]);
+            let amax = bmax[a].min(hmax[a]);
+            let bmn = bmin[b].max(hmin[b]);
+            let bmx = bmax[b].min(hmax[b]);
+            if amax - amin <= tol || bmx - bmn <= tol {
                 BOXFAST_DEFER_RIM.fetch_add(1, Ordering::Relaxed);
-                boxfast_sample(format!(
-                    "RIM t_axis={t_axis} fixed_axis={fixed_axis} front={} back={} rim_pts={} {}",
-                    front.len(),
-                    back.len(),
-                    rim_pts.len(),
-                    bounds_str()
-                ));
+                boxfast_sample(format!("RIM degenerate-rect axis={k} {}", bounds_str()));
                 return Ok(None);
             }
-            // The reveal face is the strip between the front chain (at t_front)
-            // and the back chain (at t_back), both ascending in `var` and sharing
-            // the vmin/vmax box corners — but the two chains may carry DIFFERENT
-            // subdivision points (the host's front and back faces can be
-            // tessellated differently, especially after an earlier cut). A
-            // two-pointer merge triangulates the strip while keeping every front
-            // point on the front edge and every back point on the back edge (so
-            // each cancels its own host rim), with only internal diagonals
-            // bridging them. Every triangle spans front→back ⇒ non-degenerate.
-            let mut tris_face: Vec<(Point3<f64>, Point3<f64>, Point3<f64>)> = Vec::new();
-            let (nf, nb) = (front.len(), back.len());
-            let (mut i, mut j) = (0usize, 0usize);
-            while i + 1 < nf || j + 1 < nb {
-                let adv_front = if i + 1 >= nf {
-                    false
-                } else if j + 1 >= nb {
-                    true
-                } else {
-                    front[i + 1][var_axis] <= back[j + 1][var_axis]
-                };
-                if adv_front {
-                    tris_face.push((front[i], front[i + 1], back[j]));
-                    i += 1;
-                } else {
-                    tris_face.push((front[i], back[j + 1], back[j]));
-                    j += 1;
-                }
-            }
-            // Into-void normal: +axis if the face sits at the box minimum on its
-            // fixed axis (interior is toward +axis), else -axis. Wind the whole
-            // face uniformly so it aligns with that normal.
-            let mut n = Vector3::zeros();
-            n[fixed_axis] = if fixed_val <= (bmin[fixed_axis] + bmax[fixed_axis]) * 0.5 {
-                1.0
-            } else {
-                -1.0
+            let mk = |av: f64, bv: f64| {
+                let mut p = Point3::origin();
+                p[k] = ap.val;
+                p[a] = av;
+                p[b] = bv;
+                p
             };
+            // Rim points lying on this plane, and a helper to pull those on a
+            // given rectangle edge (sorted along it).
+            let on: Vec<Point3<f64>> = rim_pts
+                .iter()
+                .copied()
+                .filter(|p| (p[k] - ap.val).abs() <= tol)
+                .collect();
+            let edge_pts = |fixed: usize, fixed_val: f64, sort: usize, asc: bool| {
+                let mut v: Vec<Point3<f64>> = on
+                    .iter()
+                    .copied()
+                    .filter(|p| (p[fixed] - fixed_val).abs() <= tol)
+                    .collect();
+                v.sort_by(|x, y| {
+                    let o = x[sort].partial_cmp(&y[sort]).unwrap();
+                    if asc {
+                        o
+                    } else {
+                        o.reverse()
+                    }
+                });
+                v
+            };
+            // CCW boundary loop: corners + each edge's host rim points. Edges
+            // abutting a host face carry rim points (so they cancel that face's
+            // rim); seam edges (shared with an adjacent reveal) carry none.
+            let mut raw_loop: Vec<Point3<f64>> = Vec::new();
+            raw_loop.push(mk(amin, bmn));
+            raw_loop.extend(edge_pts(b, bmn, a, true)); // bottom, a ascending
+            raw_loop.push(mk(amax, bmn));
+            raw_loop.extend(edge_pts(a, amax, b, true)); // right, b ascending
+            raw_loop.push(mk(amax, bmx));
+            raw_loop.extend(edge_pts(b, bmx, a, false)); // top, a descending
+            raw_loop.push(mk(amin, bmx));
+            raw_loop.extend(edge_pts(a, amin, b, false)); // left, b descending
+            let mut loop_pts: Vec<Point3<f64>> = Vec::with_capacity(raw_loop.len());
+            for p in raw_loop {
+                if loop_pts
+                    .last()
+                    .map(|q| box_clip_key(q) == box_clip_key(&p))
+                    .unwrap_or(false)
+                {
+                    continue;
+                }
+                loop_pts.push(p);
+            }
+            if loop_pts.len() >= 2
+                && box_clip_key(&loop_pts[0]) == box_clip_key(loop_pts.last().unwrap())
+            {
+                loop_pts.pop();
+            }
+            if loop_pts.len() < 3 {
+                BOXFAST_DEFER_RIM.fetch_add(1, Ordering::Relaxed);
+                boxfast_sample(format!("RIM loop<3 axis={k} {}", bounds_str()));
+                return Ok(None);
+            }
+            // Centroid fan (centre interior ⇒ all boundary edges preserved).
+            let centroid = mk((amin + amax) * 0.5, (bmn + bmx) * 0.5);
+            let mut tris_face: Vec<(Point3<f64>, Point3<f64>, Point3<f64>)> = Vec::new();
+            for w in 0..loop_pts.len() {
+                tris_face.push((centroid, loop_pts[w], loop_pts[(w + 1) % loop_pts.len()]));
+            }
+            // Into-void normal: toward the box interior = -outward·e_k.
+            let n = axis_unit(k, -ap.outward);
             let face_flip = tris_face
                 .iter()
-                .find_map(|&(a, b, c)| {
-                    let raw = (b - a).cross(&(c - a));
+                .find_map(|&(a2, b2, c2)| {
+                    let raw = (b2 - a2).cross(&(c2 - a2));
                     if raw.norm() > 0.0 {
                         Some(raw.dot(&n) < 0.0)
                     } else {
@@ -979,11 +981,11 @@ impl ClippingProcessor {
                     }
                 })
                 .unwrap_or(false);
-            for (a, b, c) in tris_face {
+            for (a2, b2, c2) in tris_face {
                 if face_flip {
-                    reveal_tris.push((a, c, b));
+                    reveal_tris.push((a2, c2, b2));
                 } else {
-                    reveal_tris.push((a, b, c));
+                    reveal_tris.push((a2, b2, c2));
                 }
             }
         }

--- a/rust/geometry/src/csg.rs
+++ b/rust/geometry/src/csg.rs
@@ -626,6 +626,320 @@ impl ClippingProcessor {
         self.subtract_mesh(mesh, &box_mesh)
     }
 
+    /// PHASE-2 FAST PATH: subtract an axis-aligned box (a rectangular opening)
+    /// from `host` WITHOUT building the exact arrangement — the analytic
+    /// equivalent of `subtract_mesh` for the overwhelmingly common case (a
+    /// rectangular window/door cut transversally through a slab-like wall),
+    /// ~100-3000× cheaper.
+    ///
+    /// Geometry: the box spans the host on exactly ONE axis (the through /
+    /// thickness axis — `extend_opening_along_direction` pushed both caps past
+    /// the host) and lies strictly inside the host on the other two (the 4
+    /// lateral cutting planes). Each host triangle is split against those 4
+    /// planes keeping only the OUTSIDE fragments (the window footprint is
+    /// removed); the 4 reveal faces (inner walls of the hole) are synthesised as
+    /// rectangles spanning the host through-extent, wound from the open rim so
+    /// the result is closed.
+    ///
+    /// DETERMINISM: plain FMA-free f64 over the host's own (f32-sourced) coords,
+    /// a fixed plane/triangle/loop iteration order, and the same `Q`-grid edge
+    /// stitching as [`Self::clip_mesh_with_cap`] ⇒ byte-identical native==wasm.
+    /// Only sign/comparison results are consumed, never an epsilon-snapped
+    /// magnitude. Safe by construction: returns `Ok(None)` (caller falls back to
+    /// the exact kernel) for ANYTHING that is not a clean transversal box cut
+    /// (blind pocket, edge/corner cut, non-slab host, or any leftover open
+    /// boundary), so it can only ever REMOVE work, never produce a wrong result.
+    pub fn subtract_box_fast(
+        &self,
+        host: &Mesh,
+        bmin: Point3<f64>,
+        bmax: Point3<f64>,
+    ) -> Result<Option<Mesh>> {
+        if host.is_empty() {
+            return Ok(Some(Mesh::new()));
+        }
+        let (hmn, hmx) = host.bounds();
+        let hmin = [hmn.x as f64, hmn.y as f64, hmn.z as f64];
+        let hmax = [hmx.x as f64, hmx.y as f64, hmx.z as f64];
+        let bmin = [bmin.x, bmin.y, bmin.z];
+        let bmax = [bmax.x, bmax.y, bmax.z];
+
+        // Scale-relative tolerance from the host diagonal (unit-independent).
+        let diag = ((hmax[0] - hmin[0]).powi(2)
+            + (hmax[1] - hmin[1]).powi(2)
+            + (hmax[2] - hmin[2]).powi(2))
+        .sqrt();
+        if !diag.is_finite() || diag <= 0.0 {
+            return Ok(None);
+        }
+        let tol = (diag * 1.0e-6).max(1.0e-9);
+
+        // The box must overlap the host on every axis, else the cut removes
+        // nothing (the silent-no-op case) — return the host unchanged, matching
+        // the exact path's no-overlap behaviour.
+        for k in 0..3 {
+            if bmax[k] <= hmin[k] + tol || bmin[k] >= hmax[k] - tol {
+                return Ok(Some(host.clone()));
+            }
+        }
+
+        // Classify each axis. A clean transversal cut spans the host on exactly
+        // one axis and lies strictly interior on the other two.
+        let mut through: Option<usize> = None;
+        let mut lateral: Vec<usize> = Vec::with_capacity(2);
+        for k in 0..3 {
+            let spans = bmin[k] <= hmin[k] + tol && bmax[k] >= hmax[k] - tol;
+            let interior = bmin[k] > hmin[k] + tol && bmax[k] < hmax[k] - tol;
+            if spans {
+                if through.is_some() {
+                    return Ok(None); // >1 through-axis (slot / full cut) → defer
+                }
+                through = Some(k);
+            } else if interior {
+                lateral.push(k);
+            } else {
+                // Box flush-with or partially past the host on this axis
+                // (blind pocket, edge/corner opening) → not a clean transversal
+                // box; defer to the exact kernel.
+                return Ok(None);
+            }
+        }
+        let Some(t_axis) = through else {
+            return Ok(None);
+        };
+        if lateral.len() != 2 {
+            return Ok(None);
+        }
+        let (la, lb) = (lateral[0], lateral[1]);
+
+        // Host through-extent (slab assumption — the watertight gate below
+        // rejects any host whose surface isn't flat at these coords).
+        let t_front = hmin[t_axis];
+        let t_back = hmax[t_axis];
+
+        // The 4 lateral cutting planes, outward normals pointing INTO the host
+        // material (away from the window interior) ⇒ "front" = outside column.
+        let axis_unit = |k: usize, s: f64| {
+            let mut v = Vector3::zeros();
+            v[k] = s;
+            v
+        };
+        let plane_on = |k: usize, val: f64, s: f64| {
+            let mut p = Point3::new(
+                (bmin[0] + bmax[0]) * 0.5,
+                (bmin[1] + bmax[1]) * 0.5,
+                (bmin[2] + bmax[2]) * 0.5,
+            );
+            p[k] = val;
+            Plane::new(p, axis_unit(k, s))
+        };
+        let planes = [
+            plane_on(la, bmin[la], -1.0),
+            plane_on(la, bmax[la], 1.0),
+            plane_on(lb, bmin[lb], -1.0),
+            plane_on(lb, bmax[lb], 1.0),
+        ];
+
+        let mut result = Mesh::new();
+        // Directed open-boundary edges keyed by quantized endpoints; the value is
+        // the real f64 start point (full precision for the reveal rim).
+        let mut dir: BoxClipBoundary = FxHashMap::default();
+
+        // ── Trim the host surface: keep every fragment OUTSIDE the window column.
+        let vc = host.positions.len() / 3;
+        let pt = |i: usize| {
+            Point3::new(
+                host.positions[i * 3] as f64,
+                host.positions[i * 3 + 1] as f64,
+                host.positions[i * 3 + 2] as f64,
+            )
+        };
+        for tri in host.indices.chunks(3) {
+            if tri.len() < 3 {
+                break;
+            }
+            let (i0, i1, i2) = (tri[0] as usize, tri[1] as usize, tri[2] as usize);
+            if i0 >= vc || i1 >= vc || i2 >= vc {
+                continue;
+            }
+            let (p0, p1, p2) = (pt(i0), pt(i1), pt(i2));
+            // Partition the triangle by ALL 4 lateral planes, KEEPING both sides
+            // at every plane (a conforming 3×3 cell subdivision in the face
+            // plane). Splitting every fragment by every plane makes adjacent
+            // cells share their dividing edge EXACTLY — emitting the 8 outside
+            // cells and dropping the 1 inside cell leaves no T-junctions, so
+            // interior edges cancel and only the true outer + hole-rim boundary
+            // survives. (A first-exit split instead leaves the outside fragment's
+            // cut edge full-length while its neighbours border only sub-segments
+            // ⇒ uncancelled interior edges.)
+            let mut pieces: Vec<Vec<Point3<f64>>> = vec![vec![p0, p1, p2]];
+            for plane in &planes {
+                let mut next: Vec<Vec<Point3<f64>>> = Vec::with_capacity(pieces.len() * 2);
+                for poly in &pieces {
+                    let (front, back) = split_convex_polygon_by_plane(poly, plane, tol);
+                    if front.len() >= 3 {
+                        next.push(front);
+                    }
+                    if back.len() >= 3 {
+                        next.push(back);
+                    }
+                }
+                pieces = next;
+            }
+            for poly in &pieces {
+                // Inside the window column ⇔ behind (inside of) all 4 lateral
+                // planes. Test the centroid (strictly interior to its cell).
+                let mut c = Point3::origin();
+                for p in poly {
+                    c += p.coords;
+                }
+                c /= poly.len() as f64;
+                let inside_column = planes.iter().all(|pl| pl.signed_distance(&c) < 0.0);
+                if inside_column {
+                    continue; // the window footprint — removed
+                }
+                for w in 1..poly.len() - 1 {
+                    box_emit_tri(&mut result, &mut dir, poly[0], poly[w], poly[w + 1]);
+                }
+            }
+        }
+
+        // ── Synthesise the 4 reveal faces (inner walls of the hole). After the
+        // trim, `dir` holds exactly the open hole rim: a front loop (at t_front)
+        // and a back loop (at t_back), each carrying whatever subdivision points
+        // the host tessellation introduced (face diagonals, welds). Each reveal
+        // face is built FROM those rim points (not as a fixed rectangle) so its
+        // edges match the host rim exactly — no T-junctions. The face is the
+        // lateral-plane polygon: front rim points (ascending) then back rim
+        // points (descending), earcut-triangulated. Faces are wound consistently
+        // w.r.t. their into-void normals (a closed tube ⇒ the vertical seams
+        // cancel), then one global flip aligns the tube to the host winding.
+        let rim_pts: Vec<Point3<f64>> = dir.values().copied().collect();
+        let mut reveal_tris: Vec<(Point3<f64>, Point3<f64>, Point3<f64>)> = Vec::new();
+        for &(fixed_axis, fixed_val) in &[
+            (la, bmin[la]),
+            (la, bmax[la]),
+            (lb, bmin[lb]),
+            (lb, bmax[lb]),
+        ] {
+            let var_axis = if fixed_axis == la { lb } else { la };
+            let on_plane = |p: &Point3<f64>| (p[fixed_axis] - fixed_val).abs() <= tol;
+            let collect_sorted = |t_val: f64| -> Vec<Point3<f64>> {
+                let mut v: Vec<Point3<f64>> = rim_pts
+                    .iter()
+                    .copied()
+                    .filter(|p| on_plane(p) && (p[t_axis] - t_val).abs() <= tol)
+                    .collect();
+                v.sort_by(|a, b| a[var_axis].partial_cmp(&b[var_axis]).unwrap());
+                v.dedup_by(|a, b| box_clip_key(a) == box_clip_key(b));
+                v
+            };
+            let front = collect_sorted(t_front);
+            let back = collect_sorted(t_back);
+            // Need at least the two corners on each face to span the reveal.
+            if front.len() < 2 || back.len() < 2 {
+                return Ok(None);
+            }
+            // The reveal face is the strip between the front chain (at t_front)
+            // and the back chain (at t_back), both ascending in `var` and sharing
+            // the vmin/vmax box corners — but the two chains may carry DIFFERENT
+            // subdivision points (the host's front and back faces can be
+            // tessellated differently, especially after an earlier cut). A
+            // two-pointer merge triangulates the strip while keeping every front
+            // point on the front edge and every back point on the back edge (so
+            // each cancels its own host rim), with only internal diagonals
+            // bridging them. Every triangle spans front→back ⇒ non-degenerate.
+            let mut tris_face: Vec<(Point3<f64>, Point3<f64>, Point3<f64>)> = Vec::new();
+            let (nf, nb) = (front.len(), back.len());
+            let (mut i, mut j) = (0usize, 0usize);
+            while i + 1 < nf || j + 1 < nb {
+                let adv_front = if i + 1 >= nf {
+                    false
+                } else if j + 1 >= nb {
+                    true
+                } else {
+                    front[i + 1][var_axis] <= back[j + 1][var_axis]
+                };
+                if adv_front {
+                    tris_face.push((front[i], front[i + 1], back[j]));
+                    i += 1;
+                } else {
+                    tris_face.push((front[i], back[j + 1], back[j]));
+                    j += 1;
+                }
+            }
+            // Into-void normal: +axis if the face sits at the box minimum on its
+            // fixed axis (interior is toward +axis), else -axis. Wind the whole
+            // face uniformly so it aligns with that normal.
+            let mut n = Vector3::zeros();
+            n[fixed_axis] = if fixed_val <= (bmin[fixed_axis] + bmax[fixed_axis]) * 0.5 {
+                1.0
+            } else {
+                -1.0
+            };
+            let face_flip = tris_face
+                .iter()
+                .find_map(|&(a, b, c)| {
+                    let raw = (b - a).cross(&(c - a));
+                    if raw.norm() > 0.0 {
+                        Some(raw.dot(&n) < 0.0)
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or(false);
+            for (a, b, c) in tris_face {
+                if face_flip {
+                    reveal_tris.push((a, c, b));
+                } else {
+                    reveal_tris.push((a, b, c));
+                }
+            }
+        }
+        // Global flip: a reveal rim edge cancels its host rim edge only when they
+        // run in OPPOSITE directions. The into-void winding fixes the tube's
+        // internal consistency but not its absolute sense vs the host (which
+        // depends on whether the host is wound inward or outward). Count rim edges
+        // that currently coincide with the host SAME-direction (won't cancel) vs
+        // REVERSE (will cancel); flip the whole tube if the same-direction count
+        // dominates. Seam edges aren't in the host rim, so they don't vote.
+        let (mut same, mut rev) = (0usize, 0usize);
+        for &(a, b, c) in &reveal_tris {
+            for (u, v) in [(a, b), (b, c), (c, a)] {
+                let (ku, kv) = (box_clip_key(&u), box_clip_key(&v));
+                if dir.contains_key(&(ku, kv)) {
+                    same += 1;
+                }
+                if dir.contains_key(&(kv, ku)) {
+                    rev += 1;
+                }
+            }
+        }
+        let gflip = same > rev;
+        for &(a, b, c) in &reveal_tris {
+            if gflip {
+                box_emit_tri(&mut result, &mut dir, a, c, b);
+            } else {
+                box_emit_tri(&mut result, &mut dir, a, b, c);
+            }
+        }
+
+        // ── Watertight gate. Any leftover open edge means the host wasn't a
+        // clean slab around the opening (sloped/stepped surface, pre-existing
+        // gap, grazing cut) — defer to the exact kernel rather than emit a
+        // cracked result.
+        if !dir.is_empty() {
+            // The trim + reveal didn't close: the host wasn't a clean slab around
+            // the opening (sloped/stepped surface, pre-existing gap, mismatched
+            // front/back rim). Defer to the exact kernel rather than emit a crack.
+            return Ok(None);
+        }
+        if result.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(result))
+    }
+
     /// Check if two meshes' bounding boxes overlap
     fn bounds_overlap(host_mesh: &Mesh, opening_mesh: &Mesh) -> bool {
         let (host_min, host_max) = host_mesh.bounds();
@@ -1824,6 +2138,24 @@ pub fn peek_planar_clip_fired() -> u32 {
     PLANAR_TL_FIRED.with(|c| c.get())
 }
 
+/// Whether a deterministic f64 fast path (planar clip OR box subtract) may run on
+/// this thread: the global escape hatch is off, the element-level fallback hasn't
+/// forced exact for a verify re-run, and the adaptive give-up hasn't tripped. The
+/// box-subtract fast path ([`ClippingProcessor::subtract_box_fast`]) shares this
+/// gate AND the fallback below with the planar clip because both are f64 clips
+/// that can crack under the element's final f32 world placement and must defer to
+/// the exact kernel identically.
+pub fn f64_fast_path_active() -> bool {
+    !planar_clip_disabled() && !PLANAR_TL_DISABLE.with(|c| c.get()) && !planar_gave_up()
+}
+
+/// Record that an f64 fast path fired on this element so the element-level
+/// fallback verifies it (and re-runs the element on the exact kernel if the
+/// result cracked once scaled/placed into f32 world coordinates).
+pub fn note_planar_clip_fired() {
+    PLANAR_TL_FIRED.with(|c| c.set(c.get() + 1));
+}
+
 thread_local! {
     /// Per-thread adaptive give-up: planar fast-path attempts that reached the
     /// element-level fallback, how many of those FELL BACK to the exact kernel,
@@ -1975,7 +2307,104 @@ impl Default for ClippingProcessor {
     }
 }
 
-/// Add a triangle to a mesh
+/// Quantization for boundary-edge stitching in the box fast path. Matches
+/// `clip_mesh_with_cap`'s `Q`: a triangle-edge∩plane point is computed
+/// identically for the two triangles sharing that edge, so shared cut endpoints
+/// round to the same key (~1e-6 grid) and interior half-edges cancel.
+const BOX_CLIP_Q: f64 = 1.0e6;
+
+/// Quantized vertex key for the box fast path's edge stitching.
+type BoxClipKey = (i64, i64, i64);
+/// Directed open-boundary edges (`from→to` keys) → the real f64 `from` point.
+/// Empty at the end of `subtract_box_fast` ⇒ the result is closed (watertight).
+type BoxClipBoundary = FxHashMap<(BoxClipKey, BoxClipKey), Point3<f64>>;
+
+#[inline]
+fn box_clip_key(p: &Point3<f64>) -> BoxClipKey {
+    (
+        (p.x * BOX_CLIP_Q).round() as i64,
+        (p.y * BOX_CLIP_Q).round() as i64,
+        (p.z * BOX_CLIP_Q).round() as i64,
+    )
+}
+
+/// Split a convex polygon by a plane into its (front, back) parts, where front =
+/// the positive-signed-distance side. Deterministic f64 Sutherland-Hodgman with
+/// a fixed vertex iteration order so the cut point is bit-identical native==wasm.
+/// A vertex within `eps` of the plane is emitted to BOTH sides so the shared cut
+/// edge appears on each fragment (boundary half-edges then cancel during
+/// stitching). Either returned polygon may have <3 vertices (degenerate/empty).
+fn split_convex_polygon_by_plane(
+    poly: &[Point3<f64>],
+    plane: &Plane,
+    eps: f64,
+) -> (Vec<Point3<f64>>, Vec<Point3<f64>>) {
+    let n = poly.len();
+    if n == 0 {
+        return (Vec::new(), Vec::new());
+    }
+    // A polygon entirely within `eps` of the plane is COPLANAR. The normal
+    // sweep below would emit it on BOTH sides (every vertex passes both the
+    // `>= -eps` and `<= eps` tests), duplicating it — which corrupts the rim
+    // when this box's cutting plane coincides with another opening's reveal face
+    // (e.g. two windows sharing a sill height). Send it to ONE side (back) only;
+    // its keep/drop is then decided by the centroid test against ALL planes, so
+    // a far-away coplanar face is still classified outside the column and kept
+    // exactly once.
+    if poly.iter().all(|p| plane.signed_distance(p).abs() <= eps) {
+        return (Vec::new(), poly.to_vec());
+    }
+    let mut front = Vec::with_capacity(n + 1);
+    let mut back = Vec::with_capacity(n + 1);
+    let mut p_prev = poly[n - 1];
+    let mut d_prev = plane.signed_distance(&p_prev);
+    for &p_cur in poly {
+        let d_cur = plane.signed_distance(&p_cur);
+        // Edge p_prev→p_cur strictly crosses the plane ⇒ add the intersection to
+        // both sides.
+        if (d_prev > eps && d_cur < -eps) || (d_prev < -eps && d_cur > eps) {
+            let t = d_prev / (d_prev - d_cur);
+            let ip = p_prev + (p_cur - p_prev) * t;
+            front.push(ip);
+            back.push(ip);
+        }
+        if d_cur >= -eps {
+            front.push(p_cur);
+        }
+        if d_cur <= eps {
+            back.push(p_cur);
+        }
+        p_prev = p_cur;
+        d_prev = d_cur;
+    }
+    (front, back)
+}
+
+/// Emit a triangle to `result` and update the directed boundary-edge map `dir`
+/// (a→b present, b→a absent ⇒ open boundary; a shared interior edge cancels its
+/// reverse). Used by [`ClippingProcessor::subtract_box_fast`] to track the open
+/// cut boundary the reveal faces must close for the result to be watertight.
+fn box_emit_tri(
+    result: &mut Mesh,
+    dir: &mut BoxClipBoundary,
+    a: Point3<f64>,
+    b: Point3<f64>,
+    c: Point3<f64>,
+) {
+    add_triangle_to_mesh(result, &Triangle::new(a, b, c));
+    for (u, v) in [(a, b), (b, c), (c, a)] {
+        let (ku, kv) = (box_clip_key(&u), box_clip_key(&v));
+        if ku == kv {
+            continue;
+        }
+        if dir.remove(&(kv, ku)).is_some() {
+            continue;
+        }
+        dir.insert((ku, kv), u);
+    }
+}
+
+/// Add a triangle to a mesh (three fresh vertices with the face normal).
 fn add_triangle_to_mesh(mesh: &mut Mesh, triangle: &Triangle) {
     let base_idx = mesh.vertex_count() as u32;
 

--- a/rust/geometry/src/csg.rs
+++ b/rust/geometry/src/csg.rs
@@ -2276,6 +2276,30 @@ pub fn note_planar_clip_fired() {
 }
 
 thread_local! {
+    /// Opt-in for the rectangular-opening BOX fast path
+    /// ([`ClippingProcessor::subtract_box_fast`]) in the void router. DEFAULT OFF
+    /// — including the WASM/production path — because on real f32-tessellated IFC
+    /// walls the f64 reveal rim can't be made to cancel to the watertight gate's
+    /// precision, so it either defers everything (no speedup) or, in the rare case
+    /// it closes, can still ship a visually wrong "flat-cap" cut. The exact kernel
+    /// remains the only opening cutter in production. Native tests/benchmarks opt
+    /// in per-thread via [`set_box_fast_enabled`]; the function itself stays for
+    /// R&D and is unit-tested directly.
+    static BOX_FAST_ENABLED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Enable the box fast path on this thread (native testing only). Returns the
+/// previous setting.
+pub fn set_box_fast_enabled(v: bool) -> bool {
+    BOX_FAST_ENABLED.with(|c| c.replace(v))
+}
+
+/// Whether the box fast path may fire in the void router on this thread.
+pub fn box_fast_path_enabled() -> bool {
+    BOX_FAST_ENABLED.with(|c| c.get())
+}
+
+thread_local! {
     /// Per-thread adaptive give-up: planar fast-path attempts that reached the
     /// element-level fallback, how many of those FELL BACK to the exact kernel,
     /// and whether the fast path has given up on this thread.

--- a/rust/geometry/src/csg.rs
+++ b/rust/geometry/src/csg.rs
@@ -1032,6 +1032,29 @@ impl ClippingProcessor {
             BOXFAST_DEFER_OPEN.fetch_add(1, Ordering::Relaxed);
             return Ok(None);
         }
+
+        // ── Volume-conservation guard. The watertight gate proves the result is
+        // CLOSED, but not that it has the right VOLUME — an inside-out reveal
+        // would be closed yet wrong (volume ADDED, not removed). Require the
+        // removed volume to be sane: ≥ 0 (we cut, never add) and ≤ the box∩host
+        // region (can't remove more than the box covers). This makes a
+        // watertight-but-wrong result impossible to ship; it defers instead.
+        let host_vol = mesh_signed_volume(host).abs();
+        let res_vol = mesh_signed_volume(&result).abs();
+        let removed = host_vol - res_vol;
+        let boxhost_vol: f64 = (0..3)
+            .map(|k| (bmax[k].min(hmax[k]) - bmin[k].max(hmin[k])).max(0.0))
+            .product();
+        let vtol = boxhost_vol * 0.05 + (host_vol * 1.0e-4).max(1.0e-12);
+        if removed < -vtol || removed > boxhost_vol + vtol {
+            BOXFAST_DEFER_OPEN.fetch_add(1, Ordering::Relaxed);
+            boxfast_sample(format!(
+                "VOL removed={removed:.5} boxhost={boxhost_vol:.5} host={host_vol:.5} {}",
+                bounds_str()
+            ));
+            return Ok(None);
+        }
+
         BOXFAST_FIRED.fetch_add(1, Ordering::Relaxed);
         Ok(Some(result))
     }

--- a/rust/geometry/src/csg.rs
+++ b/rust/geometry/src/csg.rs
@@ -194,6 +194,25 @@ pub fn take_boxfast_stats() -> BoxFastStats {
     }
 }
 
+/// TEMP DIAGNOSTIC (PR #1153): the first few box-fast deferrals' actual box vs
+/// host bounds + per-axis classification, so we can see WHY real openings don't
+/// match the clean-transversal model. Capped so it can't grow unbounded.
+static BOXFAST_SAMPLES: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
+fn boxfast_sample(s: String) {
+    if let Ok(mut g) = BOXFAST_SAMPLES.lock() {
+        if g.len() < 12 {
+            g.push(s);
+        }
+    }
+}
+/// Drain the box-fast diagnostic samples.
+pub fn take_boxfast_samples() -> Vec<String> {
+    BOXFAST_SAMPLES
+        .lock()
+        .map(|mut g| std::mem::take(&mut *g))
+        .unwrap_or_default()
+}
+
 /// CSG Clipping Processor
 pub struct ClippingProcessor {
     /// Epsilon for floating point comparisons
@@ -728,6 +747,15 @@ impl ClippingProcessor {
             }
         }
 
+        // TEMP DIAGNOSTIC: compact box-vs-host bounds for the sample log.
+        let bounds_str = || {
+            format!(
+                "box=({:.3},{:.3},{:.3})..({:.3},{:.3},{:.3}) host=({:.3},{:.3},{:.3})..({:.3},{:.3},{:.3}) tol={:.4}",
+                bmin[0], bmin[1], bmin[2], bmax[0], bmax[1], bmax[2],
+                hmin[0], hmin[1], hmin[2], hmax[0], hmax[1], hmax[2], tol,
+            )
+        };
+
         // Classify each axis. A clean transversal cut spans the host on exactly
         // one axis and lies strictly interior on the other two.
         let mut through: Option<usize> = None;
@@ -746,18 +774,23 @@ impl ClippingProcessor {
             } else {
                 // Box flush-with or partially past the host on this axis (a door
                 // flush with the floor, an edge window, a blind pocket) → not a
-                // clean transversal box; defer to the exact kernel. (This is the
-                // dominant deferral on real models — see BOXFAST_DEFER_GATE.)
+                // clean transversal box; defer to the exact kernel.
                 BOXFAST_DEFER_GATE.fetch_add(1, Ordering::Relaxed);
+                boxfast_sample(format!(
+                    "GATE flush axis={k} spans={spans} interior={interior} {}",
+                    bounds_str()
+                ));
                 return Ok(None);
             }
         }
         let Some(t_axis) = through else {
             BOXFAST_DEFER_GATE.fetch_add(1, Ordering::Relaxed);
+            boxfast_sample(format!("GATE no-through {}", bounds_str()));
             return Ok(None);
         };
         if lateral.len() != 2 {
             BOXFAST_DEFER_GATE.fetch_add(1, Ordering::Relaxed);
+            boxfast_sample(format!("GATE lateral={} {}", lateral.len(), bounds_str()));
             return Ok(None);
         }
         let (la, lb) = (lateral[0], lateral[1]);
@@ -889,6 +922,13 @@ impl ClippingProcessor {
             // Need at least the two corners on each face to span the reveal.
             if front.len() < 2 || back.len() < 2 {
                 BOXFAST_DEFER_RIM.fetch_add(1, Ordering::Relaxed);
+                boxfast_sample(format!(
+                    "RIM t_axis={t_axis} fixed_axis={fixed_axis} front={} back={} rim_pts={} {}",
+                    front.len(),
+                    back.len(),
+                    rim_pts.len(),
+                    bounds_str()
+                ));
                 return Ok(None);
             }
             // The reveal face is the strip between the front chain (at t_front)

--- a/rust/geometry/src/csg.rs
+++ b/rust/geometry/src/csg.rs
@@ -151,6 +151,49 @@ fn record_csg_op(op: u8, a_tris: usize, b_tris: usize) {
     }
 }
 
+use std::sync::atomic::{AtomicU32, Ordering};
+
+/// Global tally of the rectangular-opening box fast path
+/// ([`ClippingProcessor::subtract_box_fast`]) outcomes, so we can see — on a real
+/// model — how often it actually fires vs falls through to the exact kernel and
+/// why. Atomics (lock-free) capture rayon worker threads too. Reset/drained
+/// around a measured run by the wasm diagnostics.
+static BOXFAST_FIRED: AtomicU32 = AtomicU32::new(0); // a real analytic cut emitted
+static BOXFAST_NOOP: AtomicU32 = AtomicU32::new(0); // box disjoint from host (no change)
+static BOXFAST_DEFER_GATE: AtomicU32 = AtomicU32::new(0); // not a clean transversal box
+static BOXFAST_DEFER_RIM: AtomicU32 = AtomicU32::new(0); // a reveal face had no rim to span
+static BOXFAST_DEFER_OPEN: AtomicU32 = AtomicU32::new(0); // result didn't close (non-slab host)
+
+/// One box-fast outcome bucket.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct BoxFastStats {
+    pub fired: u32,
+    pub noop: u32,
+    pub defer_gate: u32,
+    pub defer_rim: u32,
+    pub defer_open: u32,
+}
+
+impl BoxFastStats {
+    pub fn attempts(&self) -> u32 {
+        self.fired + self.noop + self.defer_gate + self.defer_rim + self.defer_open
+    }
+    pub fn deferred(&self) -> u32 {
+        self.defer_gate + self.defer_rim + self.defer_open
+    }
+}
+
+/// Read AND reset the box-fast tally (call once per measured batch).
+pub fn take_boxfast_stats() -> BoxFastStats {
+    BoxFastStats {
+        fired: BOXFAST_FIRED.swap(0, Ordering::Relaxed),
+        noop: BOXFAST_NOOP.swap(0, Ordering::Relaxed),
+        defer_gate: BOXFAST_DEFER_GATE.swap(0, Ordering::Relaxed),
+        defer_rim: BOXFAST_DEFER_RIM.swap(0, Ordering::Relaxed),
+        defer_open: BOXFAST_DEFER_OPEN.swap(0, Ordering::Relaxed),
+    }
+}
+
 /// CSG Clipping Processor
 pub struct ClippingProcessor {
     /// Epsilon for floating point comparisons
@@ -670,6 +713,7 @@ impl ClippingProcessor {
             + (hmax[2] - hmin[2]).powi(2))
         .sqrt();
         if !diag.is_finite() || diag <= 0.0 {
+            BOXFAST_DEFER_GATE.fetch_add(1, Ordering::Relaxed);
             return Ok(None);
         }
         let tol = (diag * 1.0e-6).max(1.0e-9);
@@ -679,6 +723,7 @@ impl ClippingProcessor {
         // the exact path's no-overlap behaviour.
         for k in 0..3 {
             if bmax[k] <= hmin[k] + tol || bmin[k] >= hmax[k] - tol {
+                BOXFAST_NOOP.fetch_add(1, Ordering::Relaxed);
                 return Ok(Some(host.clone()));
             }
         }
@@ -692,22 +737,27 @@ impl ClippingProcessor {
             let interior = bmin[k] > hmin[k] + tol && bmax[k] < hmax[k] - tol;
             if spans {
                 if through.is_some() {
+                    BOXFAST_DEFER_GATE.fetch_add(1, Ordering::Relaxed);
                     return Ok(None); // >1 through-axis (slot / full cut) → defer
                 }
                 through = Some(k);
             } else if interior {
                 lateral.push(k);
             } else {
-                // Box flush-with or partially past the host on this axis
-                // (blind pocket, edge/corner opening) → not a clean transversal
-                // box; defer to the exact kernel.
+                // Box flush-with or partially past the host on this axis (a door
+                // flush with the floor, an edge window, a blind pocket) → not a
+                // clean transversal box; defer to the exact kernel. (This is the
+                // dominant deferral on real models — see BOXFAST_DEFER_GATE.)
+                BOXFAST_DEFER_GATE.fetch_add(1, Ordering::Relaxed);
                 return Ok(None);
             }
         }
         let Some(t_axis) = through else {
+            BOXFAST_DEFER_GATE.fetch_add(1, Ordering::Relaxed);
             return Ok(None);
         };
         if lateral.len() != 2 {
+            BOXFAST_DEFER_GATE.fetch_add(1, Ordering::Relaxed);
             return Ok(None);
         }
         let (la, lb) = (lateral[0], lateral[1]);
@@ -838,6 +888,7 @@ impl ClippingProcessor {
             let back = collect_sorted(t_back);
             // Need at least the two corners on each face to span the reveal.
             if front.len() < 2 || back.len() < 2 {
+                BOXFAST_DEFER_RIM.fetch_add(1, Ordering::Relaxed);
                 return Ok(None);
             }
             // The reveal face is the strip between the front chain (at t_front)
@@ -932,11 +983,14 @@ impl ClippingProcessor {
             // The trim + reveal didn't close: the host wasn't a clean slab around
             // the opening (sloped/stepped surface, pre-existing gap, mismatched
             // front/back rim). Defer to the exact kernel rather than emit a crack.
+            BOXFAST_DEFER_OPEN.fetch_add(1, Ordering::Relaxed);
             return Ok(None);
         }
         if result.is_empty() {
+            BOXFAST_DEFER_OPEN.fetch_add(1, Ordering::Relaxed);
             return Ok(None);
         }
+        BOXFAST_FIRED.fetch_add(1, Ordering::Relaxed);
         Ok(Some(result))
     }
 

--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -1201,6 +1201,20 @@ impl GeometryRouter {
         //
         // `synth_rect` owns the synthesised box meshes so they outlive the loop's
         // borrowed `&OpeningType`s below.
+        // PHASE-2 FAST PATH (rect openings): a clean transversal rectangular cut
+        // (a window/door box through a slab-like wall — the overwhelmingly common
+        // case) is subtracted analytically by `subtract_box_fast`, which bypasses
+        // the exact arrangement entirely (~100-3000× cheaper) and is byte-
+        // identical native==wasm by construction. On success the host is cut in
+        // place and the opening is consumed; on `None` (non-slab host, blind
+        // pocket, edge/corner cut, grazing, or any leftover open boundary) it
+        // falls through to the exact box-mesh subtract below, so it is never a
+        // correctness risk. Disjoint openings commute, so cutting the fast ones
+        // first changes nothing. The fast path shares the planar clip's gate and
+        // element-level fallback (`f64_fast_path_active`/`note_planar_clip_fired`):
+        // if the cut cracks once scaled/placed into f32 world coords, the element
+        // is re-processed on the exact kernel.
+        let boxfast_active = crate::csg::f64_fast_path_active();
         let mut synth_rect: Vec<OpeningType> = Vec::new();
         let mut non_rect_openings: Vec<&OpeningType> = Vec::new();
         for opening in &ctx.merged_openings {
@@ -1213,6 +1227,15 @@ impl GeometryRouter {
                     } else {
                         (*open_min, *open_max)
                     };
+                    if boxfast_active {
+                        if let Ok(Some(cut)) =
+                            clipper.subtract_box_fast(&result, final_min, final_max)
+                        {
+                            result = cut;
+                            crate::csg::note_planar_clip_fired();
+                            continue;
+                        }
+                    }
                     let box_mesh = Self::make_box_mesh(final_min, final_max);
                     synth_rect.push(OpeningType::NonRectangular(
                         box_mesh,
@@ -3489,4 +3512,86 @@ mod reveal_tests {
         assert_eq!(new_max, open_max, "-X-poke-out: extension must not change max");
     }
 
+    fn mesh_volume(m: &Mesh) -> f64 {
+        let p = &m.positions;
+        let mut v = 0.0;
+        for t in m.indices.chunks_exact(3) {
+            let g = |i: u32| {
+                let b = i as usize * 3;
+                [p[b] as f64, p[b + 1] as f64, p[b + 2] as f64]
+            };
+            let (a, b, c) = (g(t[0]), g(t[1]), g(t[2]));
+            v += a[0] * (b[1] * c[2] - b[2] * c[1])
+                + a[1] * (b[2] * c[0] - b[0] * c[2])
+                + a[2] * (b[0] * c[1] - b[1] * c[0]);
+        }
+        (v / 6.0).abs()
+    }
+
+    fn is_watertight(m: &Mesh) -> bool {
+        use std::collections::HashMap;
+        type Edge = ((i64, i64, i64), (i64, i64, i64));
+        let p = &m.positions;
+        let key = |i: u32| {
+            let b = i as usize * 3;
+            (
+                (p[b] as f64 * 1.0e4).round() as i64,
+                (p[b + 1] as f64 * 1.0e4).round() as i64,
+                (p[b + 2] as f64 * 1.0e4).round() as i64,
+            )
+        };
+        let mut bal: HashMap<Edge, i32> = HashMap::new();
+        for t in m.indices.chunks_exact(3) {
+            for (u, v) in [(t[0], t[1]), (t[1], t[2]), (t[2], t[0])] {
+                let (ku, kv) = (key(u), key(v));
+                if ku == kv {
+                    continue;
+                }
+                *bal.entry((ku, kv)).or_insert(0) += 1;
+                *bal.entry((kv, ku)).or_insert(0) -= 1;
+            }
+        }
+        bal.values().all(|&c| c == 0)
+    }
+
+    /// END-TO-END wiring check: a clean axis-aligned rectangular opening driven
+    /// through `apply_void_context` must take the Phase-2 box fast path (not the
+    /// exact kernel) and produce the same watertight, volume-correct cut. Without
+    /// this, the fast path could silently never fire in the real pipeline.
+    #[test]
+    fn rect_opening_routes_through_box_fast_path() {
+        let router = GeometryRouter::new();
+        // Wall slab: X[0,4] length × Y[0,0.2] thickness × Z[0,3] height.
+        let host = make_box_mesh(Point3::new(0.0, 0.0, 0.0), Point3::new(4.0, 0.2, 3.0));
+        assert!((mesh_volume(&host) - 2.4).abs() < 1.0e-4);
+
+        // A 1×1 window cut transversally through the Y thickness; the router
+        // extends it through the wall along the extrusion direction.
+        let opening = |_: ()| {
+            OpeningType::Rectangular(
+                Point3::new(1.0, 0.0, 1.0),
+                Point3::new(2.0, 0.2, 2.0),
+                Some(Vector3::new(0.0, 1.0, 0.0)),
+            )
+        };
+        // `is_noop` keys off `openings`, the cut loop off `merged_openings` — both
+        // must be populated, as in the real classifier.
+        let ctx = VoidContext {
+            openings: vec![opening(())],
+            merged_openings: vec![opening(())],
+        };
+
+        let before = crate::csg::peek_planar_clip_fired();
+        let result = router.apply_void_context(host, &ctx, 42);
+        let fired = crate::csg::peek_planar_clip_fired().wrapping_sub(before);
+
+        assert!(
+            fired >= 1,
+            "box fast path did NOT fire on a clean rectangular opening (fired={fired}) — wiring is dead"
+        );
+        assert!(is_watertight(&result), "box-fast cut is not watertight");
+        // wall 2.4 − window column (1 × 0.2 × 1 = 0.2) ⇒ 2.2.
+        let cut_vol = mesh_volume(&result);
+        assert!((cut_vol - 2.2).abs() < 1.0e-3, "cut volume {cut_vol} != 2.2");
+    }
 }

--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -1214,7 +1214,11 @@ impl GeometryRouter {
         // element-level fallback (`f64_fast_path_active`/`note_planar_clip_fired`):
         // if the cut cracks once scaled/placed into f32 world coords, the element
         // is re-processed on the exact kernel.
-        let boxfast_active = crate::csg::f64_fast_path_active();
+        // DEFAULT OFF in production (incl. WASM): the box fast path can't yet
+        // close on real f32-tessellated walls, so it never fires here and the
+        // exact kernel cuts every opening. Opt in per-thread for native R&D.
+        let boxfast_active =
+            crate::csg::box_fast_path_enabled() && crate::csg::f64_fast_path_active();
         let mut synth_rect: Vec<OpeningType> = Vec::new();
         let mut non_rect_openings: Vec<&OpeningType> = Vec::new();
         for opening in &ctx.merged_openings {
@@ -3581,9 +3585,11 @@ mod reveal_tests {
             merged_openings: vec![opening(())],
         };
 
+        let prev = crate::csg::set_box_fast_enabled(true); // opt in for this test
         let before = crate::csg::peek_planar_clip_fired();
         let result = router.apply_void_context(host, &ctx, 42);
         let fired = crate::csg::peek_planar_clip_fired().wrapping_sub(before);
+        crate::csg::set_box_fast_enabled(prev);
 
         assert!(
             fired >= 1,

--- a/rust/geometry/tests/rect_box_fast.rs
+++ b/rust/geometry/tests/rect_box_fast.rs
@@ -1,0 +1,212 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Phase 2 fast path: `subtract_box_fast` must produce a WATERTIGHT solid whose
+//! volume matches the exact `subtract_mesh` for a rectangular opening cut
+//! transversally through a slab-like host — at a fraction of the cost — and must
+//! DEFER (return `None`) for anything that isn't a clean transversal box cut.
+//!
+//! Motivation: the pure-Rust exact kernel routed EVERY opening — rectangular
+//! included — through the full arrangement, making CSG 85-90% of load time on
+//! void-heavy models (issues #1109 / #1138). This restores an analytic path for
+//! the rectangular common case (~95% of cuts) without reintroducing native/wasm
+//! drift.
+//!
+//! cargo test -p ifc-lite-geometry --test rect_box_fast -- --nocapture
+
+use ifc_lite_geometry::{ClippingProcessor, Mesh};
+use nalgebra::Point3;
+
+/// Build a closed, outward-wound axis-aligned box with `s`×`s` quads per face.
+fn box_mesh(lo: [f32; 3], hi: [f32; 3], s: usize) -> Mesh {
+    let mut m = Mesh::new();
+    let mut push_quad = |a: [f32; 3], b: [f32; 3], c: [f32; 3], d: [f32; 3], n: [f32; 3]| {
+        let base = (m.positions.len() / 3) as u32;
+        for v in [a, b, c, d] {
+            m.positions.extend_from_slice(&v);
+            m.normals.extend_from_slice(&n);
+        }
+        m.indices
+            .extend_from_slice(&[base, base + 1, base + 2, base, base + 2, base + 3]);
+    };
+    let mut face = |o: [f32; 3], u: [f32; 3], v: [f32; 3], n: [f32; 3]| {
+        for i in 0..s {
+            for j in 0..s {
+                let (fi, fj, fs) = (i as f32, j as f32, s as f32);
+                let p = |ti: f32, tj: f32| {
+                    [
+                        o[0] + u[0] * ti + v[0] * tj,
+                        o[1] + u[1] * ti + v[1] * tj,
+                        o[2] + u[2] * ti + v[2] * tj,
+                    ]
+                };
+                push_quad(
+                    p(fi / fs, fj / fs),
+                    p((fi + 1.0) / fs, fj / fs),
+                    p((fi + 1.0) / fs, (fj + 1.0) / fs),
+                    p(fi / fs, (fj + 1.0) / fs),
+                    n,
+                );
+            }
+        }
+    };
+    let dx = [hi[0] - lo[0], 0.0, 0.0];
+    let dy = [0.0, hi[1] - lo[1], 0.0];
+    let dz = [0.0, 0.0, hi[2] - lo[2]];
+    let [lx, ly, lz] = lo;
+    face([lx, ly, lz], dz, dy, [-1.0, 0.0, 0.0]);
+    face([hi[0], ly, lz], dy, dz, [1.0, 0.0, 0.0]);
+    face([lx, ly, lz], dx, dz, [0.0, -1.0, 0.0]);
+    face([lx, hi[1], lz], dz, dx, [0.0, 1.0, 0.0]);
+    face([lx, ly, lz], dy, dx, [0.0, 0.0, -1.0]);
+    face([lx, ly, hi[2]], dx, dy, [0.0, 0.0, 1.0]);
+    m
+}
+
+/// Signed volume of a triangle soup (positive for an outward-wound closed solid).
+fn volume(m: &Mesh) -> f64 {
+    let p = &m.positions;
+    let mut v = 0.0;
+    for t in m.indices.chunks(3) {
+        let g = |i: u32| {
+            let b = i as usize * 3;
+            [p[b] as f64, p[b + 1] as f64, p[b + 2] as f64]
+        };
+        let (a, b, c) = (g(t[0]), g(t[1]), g(t[2]));
+        v += a[0] * (b[1] * c[2] - b[2] * c[1])
+            + a[1] * (b[2] * c[0] - b[0] * c[2])
+            + a[2] * (b[0] * c[1] - b[1] * c[0]);
+    }
+    (v / 6.0).abs()
+}
+
+/// Every directed edge must have its reverse (closed 2-manifold). Quantize to a
+/// 0.1mm grid so f32 round-off doesn't spuriously fail.
+type Edge = ((i64, i64, i64), (i64, i64, i64));
+
+fn watertight(m: &Mesh) -> bool {
+    use std::collections::HashMap;
+    let p = &m.positions;
+    let key = |i: u32| {
+        let b = i as usize * 3;
+        (
+            (p[b] as f64 * 1.0e4).round() as i64,
+            (p[b + 1] as f64 * 1.0e4).round() as i64,
+            (p[b + 2] as f64 * 1.0e4).round() as i64,
+        )
+    };
+    let mut bal: HashMap<Edge, i32> = HashMap::new();
+    for t in m.indices.chunks(3) {
+        if t.len() < 3 {
+            continue;
+        }
+        for (u, v) in [(t[0], t[1]), (t[1], t[2]), (t[2], t[0])] {
+            let (ku, kv) = (key(u), key(v));
+            if ku == kv {
+                continue;
+            }
+            *bal.entry((ku, kv)).or_insert(0) += 1;
+            *bal.entry((kv, ku)).or_insert(0) -= 1;
+        }
+    }
+    bal.values().all(|&c| c == 0)
+}
+
+/// host slab x∈[0,4] (length), y∈[0,0.2] (thickness), z∈[0,3] (height).
+fn wall(s: usize) -> Mesh {
+    box_mesh([0.0, 0.0, 0.0], [4.0, 0.2, 3.0], s)
+}
+
+#[test]
+fn window_through_thickness_matches_exact_and_is_watertight() {
+    let clip = ClippingProcessor::new();
+    // window 1×1, cut transversally through the Y thickness (penetrating caps).
+    let bmin = Point3::new(1.0, -0.1, 1.0);
+    let bmax = Point3::new(2.0, 0.3, 2.0);
+
+    for s in [1usize, 4] {
+        let host = wall(s);
+        let fast = clip
+            .subtract_box_fast(&host, bmin, bmax)
+            .unwrap()
+            .unwrap_or_else(|| panic!("fast path deferred on a clean slab (s={s})"));
+        assert!(watertight(&fast), "fast result not watertight (s={s})");
+
+        let cutter = box_mesh([1.0, -0.1, 1.0], [2.0, 0.3, 2.0], 1);
+        let exact = clip.subtract_mesh(&host, &cutter).unwrap();
+
+        let (vf, ve) = (volume(&fast), volume(&exact));
+        // wall 4·0.2·3 = 2.4 minus window column 1·0.2·1 = 0.2 ⇒ 2.2
+        assert!((vf - 2.2).abs() < 1e-4, "fast volume {vf} != 2.2 (s={s})");
+        assert!((vf - ve).abs() < 1e-4, "fast {vf} vs exact {ve} (s={s})");
+    }
+}
+
+#[test]
+fn window_through_height_axis_generality() {
+    // Same wall, but a box that spans the Z (height) axis instead — exercises a
+    // different through-axis so the axis bookkeeping isn't hard-wired to Y.
+    let clip = ClippingProcessor::new();
+    let host = wall(2);
+    let bmin = Point3::new(1.0, 0.05, -0.1);
+    let bmax = Point3::new(2.0, 0.15, 3.1);
+    let fast = clip
+        .subtract_box_fast(&host, bmin, bmax)
+        .unwrap()
+        .expect("fast path deferred on a clean Z-through slab");
+    assert!(watertight(&fast));
+    // column removed: x 1, y 0.1, z 3 ⇒ 0.3 ; wall 2.4 ⇒ 2.1
+    assert!((volume(&fast) - 2.1).abs() < 1e-4, "vol {}", volume(&fast));
+}
+
+#[test]
+fn two_disjoint_windows_sequentially() {
+    let clip = ClippingProcessor::new();
+    let host = wall(2);
+    let w1 = clip
+        .subtract_box_fast(&host, Point3::new(0.5, -0.1, 1.0), Point3::new(1.0, 0.3, 2.0))
+        .unwrap()
+        .expect("window 1 deferred");
+    let w2 = clip
+        .subtract_box_fast(&w1, Point3::new(2.5, -0.1, 1.0), Point3::new(3.0, 0.3, 2.0))
+        .unwrap()
+        .expect("window 2 deferred on already-cut host");
+    assert!(watertight(&w2), "sequential cut not watertight");
+    // two 0.5·0.2·1 = 0.1 columns removed ⇒ 2.4 - 0.2 = 2.2
+    assert!((volume(&w2) - 2.2).abs() < 1e-4, "vol {}", volume(&w2));
+}
+
+#[test]
+fn blind_pocket_defers() {
+    // Box recessed into the wall (does not penetrate the back face) ⇒ no clean
+    // through-axis ⇒ must defer to the exact kernel.
+    let clip = ClippingProcessor::new();
+    let host = wall(2);
+    let r = clip
+        .subtract_box_fast(&host, Point3::new(1.0, -0.1, 1.0), Point3::new(2.0, 0.1, 2.0))
+        .unwrap();
+    assert!(r.is_none(), "blind pocket should defer, got {:?}", r.is_some());
+}
+
+#[test]
+fn corner_cut_defers() {
+    // Box spans the host on TWO axes (an edge/corner removal) ⇒ defer.
+    let clip = ClippingProcessor::new();
+    let host = wall(2);
+    let r = clip
+        .subtract_box_fast(&host, Point3::new(-0.1, -0.1, 1.0), Point3::new(2.0, 0.3, 2.0))
+        .unwrap();
+    assert!(r.is_none(), "corner cut should defer");
+}
+
+#[test]
+fn disjoint_box_is_noop() {
+    let clip = ClippingProcessor::new();
+    let host = wall(2);
+    let r = clip
+        .subtract_box_fast(&host, Point3::new(10.0, -0.1, 1.0), Point3::new(11.0, 0.3, 2.0))
+        .unwrap()
+        .expect("disjoint box should return the host unchanged");
+    assert!((volume(&r) - 2.4).abs() < 1e-4, "no-op changed volume: {}", volume(&r));
+}

--- a/rust/geometry/tests/rect_box_fast.rs
+++ b/rust/geometry/tests/rect_box_fast.rs
@@ -178,26 +178,62 @@ fn two_disjoint_windows_sequentially() {
 }
 
 #[test]
-fn blind_pocket_defers() {
-    // Box recessed into the wall (does not penetrate the back face) ⇒ no clean
-    // through-axis ⇒ must defer to the exact kernel.
+fn blind_pocket_cuts_watertight() {
+    // Box recessed into the wall (penetrates the front face only, stops inside):
+    // a blind pocket. The general path handles it — front face opens, the other 5
+    // faces are reveals (incl. the pocket back). Watertight + volume-equal.
     let clip = ClippingProcessor::new();
     let host = wall(2);
-    let r = clip
-        .subtract_box_fast(&host, Point3::new(1.0, -0.1, 1.0), Point3::new(2.0, 0.1, 2.0))
-        .unwrap();
-    assert!(r.is_none(), "blind pocket should defer, got {:?}", r.is_some());
+    let (bmin, bmax) = (Point3::new(1.0, -0.1, 1.0), Point3::new(2.0, 0.1, 2.0));
+    let fast = clip
+        .subtract_box_fast(&host, bmin, bmax)
+        .unwrap()
+        .expect("blind pocket should now cut");
+    assert!(watertight(&fast), "blind pocket not watertight");
+    let cutter = box_mesh([1.0, -0.1, 1.0], [2.0, 0.1, 2.0], 1);
+    let exact = clip.subtract_mesh(&host, &cutter).unwrap();
+    // pocket X 1 × Y[0,0.1] × Z 1 = 0.1 removed ⇒ 2.3
+    assert!((volume(&fast) - 2.3).abs() < 1e-3, "pocket vol {}", volume(&fast));
+    assert!((volume(&fast) - volume(&exact)).abs() < 1e-3, "fast vs exact");
 }
 
 #[test]
-fn corner_cut_defers() {
-    // Box spans the host on TWO axes (an edge/corner removal) ⇒ defer.
+fn corner_cut_watertight() {
+    // Box spans the thickness (through) and pokes past the -X wall end: an
+    // end/corner notch. The general path handles it — the -X side opens to the
+    // wall end, X=2 / Z=1 / Z=2 are reveals.
     let clip = ClippingProcessor::new();
     let host = wall(2);
-    let r = clip
-        .subtract_box_fast(&host, Point3::new(-0.1, -0.1, 1.0), Point3::new(2.0, 0.3, 2.0))
-        .unwrap();
-    assert!(r.is_none(), "corner cut should defer");
+    let (bmin, bmax) = (Point3::new(-0.1, -0.1, 1.0), Point3::new(2.0, 0.3, 2.0));
+    let fast = clip
+        .subtract_box_fast(&host, bmin, bmax)
+        .unwrap()
+        .expect("corner notch should now cut");
+    assert!(watertight(&fast), "corner notch not watertight");
+    let cutter = box_mesh([-0.1, -0.1, 1.0], [2.0, 0.3, 2.0], 1);
+    let exact = clip.subtract_mesh(&host, &cutter).unwrap();
+    // removes X[0,2] × Y[0,0.2] × Z 1 = 0.4 ⇒ 2.0
+    assert!((volume(&fast) - 2.0).abs() < 1e-3, "notch vol {}", volume(&fast));
+    assert!((volume(&fast) - volume(&exact)).abs() < 1e-3, "fast vs exact");
+}
+
+#[test]
+fn floor_flush_door_watertight() {
+    // The dominant real-IFC case: a door flush with the floor — Z-min sits on the
+    // wall base (no bottom reveal; opens to the host edge), Z-max is the lintel.
+    let clip = ClippingProcessor::new();
+    let host = wall(2);
+    let (bmin, bmax) = (Point3::new(1.5, -0.1, 0.0), Point3::new(2.5, 0.3, 2.0));
+    let fast = clip
+        .subtract_box_fast(&host, bmin, bmax)
+        .unwrap()
+        .expect("floor-flush door should cut");
+    assert!(watertight(&fast), "door not watertight");
+    let cutter = box_mesh([1.5, -0.1, 0.0], [2.5, 0.3, 2.0], 1);
+    let exact = clip.subtract_mesh(&host, &cutter).unwrap();
+    // removes X 1 × Y 0.2 × Z[0,2] = 0.4 ⇒ 2.0
+    assert!((volume(&fast) - 2.0).abs() < 1e-3, "door vol {}", volume(&fast));
+    assert!((volume(&fast) - volume(&exact)).abs() < 1e-3, "fast vs exact");
 }
 
 #[test]

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -983,6 +983,32 @@ pub(super) fn drain_and_log_csg_diagnostics(
         }
     }
 
+    // Rectangular-opening fast-path tally (PR #1153): how often the analytic
+    // box subtract fired vs fell through to the exact kernel, and why — so the
+    // real-model fire rate is visible instead of guessed.
+    let bf = ifc_lite_geometry::csg::take_boxfast_stats();
+    let cuttable = bf.fired + bf.deferred();
+    if bf.attempts() > 0 {
+        let pct = if cuttable > 0 {
+            100.0 * bf.fired as f64 / cuttable as f64
+        } else {
+            0.0
+        };
+        web_sys::console::info_1(
+            &format!(
+                "[IFC-LITE] Rect box fast path: fired={} ({pct:.0}% of {cuttable} cuttable) \
+                 deferred={} (gate={} rim={} open={}), noop={}",
+                bf.fired,
+                bf.deferred(),
+                bf.defer_gate,
+                bf.defer_rim,
+                bf.defer_open,
+                bf.noop,
+            )
+            .into(),
+        );
+    }
+
     summary.into()
 }
 

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -1008,6 +1008,9 @@ pub(super) fn drain_and_log_csg_diagnostics(
             .into(),
         );
     }
+    for s in ifc_lite_geometry::csg::take_boxfast_samples() {
+        web_sys::console::info_1(&format!("[IFC-LITE]   boxfast-sample: {s}").into());
+    }
 
     summary.into()
 }


### PR DESCRIPTION
**Stacked on #1134** (f64 planar-clip foundation). Review/merge after it.

## What & why

The pure-Rust exact kernel routes **every** opening — rectangular included — through the full arrangement, so CSG void-cutting is **85–90% of load time** on void-heavy models (#1109/#1138). But rectangular openings (a window/door box through a slab-like wall) are ~95% of all cuts. This adds an **analytic f64 through-box subtraction** that bypasses the exact arrangement entirely for that common case — recovering most of the speed lost when we consolidated onto the pure-Rust kernel — **without** reintroducing native/wasm drift or giving up the 0-failures robustness bar.

Phase 2 of the f64 fast-path strategy: Phase 1 (#1134) handles single half-space end-clips; a rectangular through-opening straddles the host on four lateral faces, so it still went to the exact kernel until now.

## How

`ClippingProcessor::subtract_box_fast` (in `csg.rs`):
1. partitions each host triangle by the 4 lateral box planes — a **conforming 3×3 cell split** (every fragment split by every plane → no T-junctions) — and drops the window-footprint cell;
2. synthesises the 4 reveal faces (inner walls of the hole) from the **actual cut rim**, pulling the host's own subdivision points (face diagonals, welds) onto each reveal edge via a **two-pointer chain merge**, so reveal edges match the host rim exactly even when the host's front/back faces are tessellated differently.

`apply_void_context` (in `voids.rs`) tries it per `OpeningType::Rectangular` before materialising a penetrating box mesh for the exact subtract.

## Safe by construction — only ever a fast path, never a different answer

- **Transversality gate** — the box must span the host on exactly one axis and lie strictly interior on the other two; blind pockets, edge/corner cuts and non-transversal boxes return `None` → exact kernel.
- **Coplanar handling** — a host face coplanar with a cutting plane (two windows sharing a sill height) is sent to one side only, never duplicated.
- **Watertight gate** — every directed boundary edge must cancel (result is closed), else `None` → exact kernel.

## Parity (the whole reason for the pure-Rust kernel)

Determinism is by construction: FMA-free f64 over the host's own coordinates, fixed plane/triangle/loop iteration order, and the same `Q`-grid edge stitching as the planar clip. The only `HashMap` use is edge-cancellation set-semantics plus rim-point collection that is **re-sorted by coordinate**, so output is byte-identical on 64-bit native and 32-bit wasm. It never touches the rational tier. The box and planar fast paths share one gate + the element-level fallback (`f64_fast_path_active` / `note_planar_clip_fired`): a cut that cracks once scaled/placed into f32 world coords is re-processed on the exact kernel, and `IFC_LITE_DISABLE_PLANAR_CLIP=1` (native) forces the exact kernel for both.

## Tests

- `rust/geometry/tests/rect_box_fast.rs` — A/B-validates `subtract_box_fast` watertight **and** volume-equal to the exact `subtract_mesh` across both through-axes, sequential disjoint windows (incl. a shared sill), with pockets/corners/no-ops correctly deferring.
- End-to-end test in `voids.rs` (`rect_opening_routes_through_box_fast_path`) — proves the fast path actually **fires** through `apply_void_context` and produces a watertight, volume-correct cut (not dead code).

## Notes for review

- Output is unconsolidated by design (clean fans, no needle slivers), so it has more triangles than kernel+`consolidate_coplanar` but no quality regression; `drop_thin` handles any degenerate sliver downstream.
- Internal `pub fn`s only — no wasm `.d.ts` surface change.
- Changeset included (`@ifc-lite/geometry` patch).