### PR TITLE
fix(viewer): clear stuck highlight when isolating group members

### DIFF
--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -136,9 +136,14 @@ export function Viewport({
   // IMPORTANT: pickResult.expressId is now a globalId (transformed at load time)
   // resolveEntityRef is the single source of truth for globalId → EntityRef
   const handlePickForSelection = useCallback((pickResult: import('@ifc-lite/renderer').PickResult | null) => {
-    // Normal click clears multi-select set (fresh single-selection)
+    // Normal click clears any lingering multi-highlight (fresh single-selection).
+    // Gate on EITHER set: `selectedEntityIds` is the legacy global-id set that
+    // drives the renderer highlight, and some features populate it WITHOUT the
+    // multi-model `selectedEntitiesSet` — e.g. "isolate group members" (#1075)
+    // and clash-pair highlight. Checking only `selectedEntitiesSet` left those
+    // highlights stuck on with no way to clear them by clicking away.
     const currentState = useViewerStore.getState();
-    if (currentState.selectedEntitiesSet.size > 0) {
+    if (currentState.selectedEntitiesSet.size > 0 || currentState.selectedEntityIds.size > 0) {
       useViewerStore.setState({ selectedEntitiesSet: new Set(), selectedEntityIds: new Set() });
     }
 


### PR DESCRIPTION
## Problem

The recently-merged **"isolate group members"** feature (#1075) leaves the isolated members **highlight-colored with no way to undo it** — clicking elements or empty space won't drop the highlight.

## Root cause

The viewer has two selection state channels:
- `selectedEntityIds` (legacy global-id `Set`) → **drives the renderer highlight** (fed to `renderer.render({ selectedIds })` in `useAnimationLoop.ts`)
- `selectedEntitiesSet` (multi-model `EntityRef` `Set`) → property-panel / multi-model awareness

`handleIsolateGroupMembers` (`PropertiesPanel.tsx`) calls `setSelectedEntityIds(globalIds)` to highlight + frame the members. It populates **only** the legacy `selectedEntityIds` set (the group/zone itself is non-geometric, so `frameSelection` needs the member ids to enclose them), leaving `selectedEntitiesSet` empty.

But the only auto-clear-on-click path — `handlePickForSelection` in `Viewport.tsx` — gated its reset on the *wrong* set:

```ts
if (currentState.selectedEntitiesSet.size > 0) {   // ← empty after isolate-group-members
  useViewerStore.setState({ selectedEntitiesSet: new Set(), selectedEntityIds: new Set() });
}
```

Because `selectedEntitiesSet` was empty, the guard never fired, the stale `selectedEntityIds` highlight set was never cleared, and there was no way to deselect → "highlighted with no possibility to undo it."

## Fix

Gate the reset on **either** set being non-empty, so a plain (non-Ctrl) click always clears a lingering multi-highlight regardless of which feature populated it:

```ts
if (currentState.selectedEntitiesSet.size > 0 || currentState.selectedEntityIds.size > 0) {
  useViewerStore.setState({ selectedEntitiesSet: new Set(), selectedEntityIds: new Set() });
}
```

This fixes the true invariant: *a plain click starts a fresh single selection and clears any prior multi-highlight*. The old guard assumed `selectedEntityIds` could only be populated alongside `selectedEntitiesSet` (the Ctrl+click path), but several features populate the highlight set directly.

### Verified consistent across every `selectedEntityIds` producer
- **isolate group members** — fixed.
- **clash-pair highlight** (`useClash.ts`) — had the same latent stuck-highlight bug; now also clearable.
- **box-select**, **context-menu "select same type / storey"** — clearing on a fresh click is the expected behavior.
- **4D Gantt highlight** (`useGanttSelection3DHighlight`) — already has an ownership model that anticipates a user 3D-click taking over (`weStillOwn`); it now relinquishes gracefully and only re-applies when the Gantt selection itself changes.

## Scope notes
- Deliberately **not** coupling highlight-clearing into `clearIsolation()` (the X button) — that's a generic function used by IDS, basket, and hierarchy filters, and isolation/selection are intentionally independent channels.
- Single isolated condition referencing existing always-initialized state — type-safe, no behavioral change for the normal single-select path (which never populates `selectedEntityIds`).

## Test
- Manual: open a model with an `IfcZone`/group, Focus its members from the Relationships card (members isolate + highlight + frame), then click any element or empty space → highlight clears. Repeat after clearing isolation.
