### PR TITLE
feat(geometry): Step-0 kernel timing instrumentation (feature-gated)

### DIFF
--- a/.changeset/kernel-timing-instrumentation.md
+++ b/.changeset/kernel-timing-instrumentation.md
@@ -1,0 +1,10 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Add opt-in, feature-gated CSG kernel timing instrumentation (`kernel-timing`).
+
+Behind the off-by-default `kernel-timing` cargo feature: per-phase wall-clock,
+per-phase op counts, and predicate-tier escalation counts on both native and
+WASM, to profile where boolean CSG time goes. Default builds compile it out
+entirely — no shipped-artifact or runtime change.

--- a/rust/geometry/Cargo.toml
+++ b/rust/geometry/Cargo.toml
@@ -18,6 +18,10 @@ readme = "../../README.md"
 # (docs/architecture/geometry-pipeline.md).
 default = []
 debug_geometry = []
+# Step-0 kernel instrumentation: per-phase timers + per-predicate-tier
+# escalation counters (src/kernel/timing.rs). OFF in production (zero cost);
+# enable for a measured run (`--features kernel-timing`, incl. build-wasm.sh).
+kernel-timing = []
 
 [dependencies]
 

--- a/rust/geometry/src/csg.rs
+++ b/rust/geometry/src/csg.rs
@@ -794,6 +794,7 @@ impl ClippingProcessor {
     /// Returns the input mesh unchanged if the consolidate fails or yields
     /// nothing — never worse than the raw kernel output.
     pub(crate) fn consolidate_coplanar(mesh: Mesh) -> Mesh {
+        let _t = crate::kernel::timing::timer(crate::kernel::timing::Phase::Consolidate);
         use crate::triangulation::{
             project_to_2d_with_basis, triangulate_polygon_with_holes_refined,
         };

--- a/rust/geometry/src/kernel/arrangement.rs
+++ b/rust/geometry/src/kernel/arrangement.rs
@@ -173,7 +173,11 @@ pub fn arrange(a: &[Tri], b: &[Tri]) -> Arrangement {
     let mut cop_b: Vec<Vec<Constraint>> = (0..b.len()).map(|_| Vec::new()).collect();
     let mut pt_a: Vec<Vec<ImplicitPoint>> = (0..a.len()).map(|_| Vec::new()).collect();
     let mut pt_b: Vec<Vec<ImplicitPoint>> = (0..b.len()).map(|_| Vec::new()).collect();
-    let pairs = super::broadphase::candidate_pairs(a, b);
+    let pairs = {
+        let _t = crate::kernel::timing::timer(crate::kernel::timing::Phase::Broadphase);
+        super::broadphase::candidate_pairs(a, b)
+    };
+    let _tt = crate::kernel::timing::timer(crate::kernel::timing::Phase::TriTri);
     for (i, j) in pairs {
         // Deterministic escalation guardrail (#1109): stop accumulating
         // intersections once this boolean has blown its BigRational budget. The
@@ -206,6 +210,7 @@ pub fn arrange(a: &[Tri], b: &[Tri]) -> Arrangement {
             TriTri::None => {}
         }
     }
+    drop(_tt);
     // 2. seg×seg pre-pass on the segment constraints, then append the coplanar ones
     let build = |tris: &[Tri], raw: &[Vec<RawSeg>], cop: &mut [Vec<Constraint>]| -> Vec<Vec<Constraint>> {
         (0..tris.len())
@@ -220,15 +225,19 @@ pub fn arrange(a: &[Tri], b: &[Tri]) -> Arrangement {
     // captured BEFORE `build` drains the coplanar-constraint accumulators.
     let cop_parent_a: Vec<bool> = cop_a.iter().map(|c| !c.is_empty()).collect();
     let cop_parent_b: Vec<bool> = cop_b.iter().map(|c| !c.is_empty()).collect();
-    let ca = build(a, &raw_a, &mut cop_a);
-    let cb = build(b, &raw_b, &mut cop_b);
+    let (ca, cb) = {
+        let _t = crate::kernel::timing::timer(crate::kernel::timing::Phase::SplitCrossings);
+        (build(a, &raw_a, &mut cop_a), build(b, &raw_b, &mut cop_b))
+    };
     // 3. re-triangulate each operand over the SHARED interner ⇒ conforming surfaces
     let mut interner = Interner::new();
     let mut unrecovered = 0usize;
+    let _tr = crate::kernel::timing::timer(crate::kernel::timing::Phase::Retriangulate);
     let (tris_a, coplanar_a) =
         retriangulate_each(a, &ca, &pt_a, &cop_parent_a, &mut interner, &mut unrecovered);
     let (tris_b, coplanar_b) =
         retriangulate_each(b, &cb, &pt_b, &cop_parent_b, &mut interner, &mut unrecovered);
+    drop(_tr);
     let n_pts = interner.len();
     Arrangement {
         interner,
@@ -997,6 +1006,7 @@ fn on_interface_keep(
 /// interface shares the unordered vertex set but has OPPOSITE winding, so it never
 /// collides; both its copies are dissolved by regime 2.)
 fn boolean_vids(arr: &Arrangement, a: &[Tri], b: &[Tri], op: BoolOp) -> Vec<[Vid; 3]> {
+    let _t = crate::kernel::timing::timer(crate::kernel::timing::Phase::Classify);
     boolean_vids_components(arr, a, &BComponents::new(&[b]), op)
 }
 

--- a/rust/geometry/src/kernel/budget.rs
+++ b/rust/geometry/src/kernel/budget.rs
@@ -238,6 +238,7 @@ pub fn reset_peak() {
 /// expensive fixed-width / BigRational path.
 #[inline]
 pub fn note_escalation() {
+    crate::kernel::timing::tier(crate::kernel::timing::Tier::Escalation);
     COUNT.with(|c| c.set(c.get().saturating_add(1)));
     ELEM_COUNT.with(|c| c.set(c.get().saturating_add(1)));
 }

--- a/rust/geometry/src/kernel/mesh_bridge.rs
+++ b/rust/geometry/src/kernel/mesh_bridge.rs
@@ -33,6 +33,7 @@ fn snap(c: f64) -> f64 {
 /// `BigRational::from_float` deep in the predicates (the two empirically-found
 /// reachable panic sites).
 pub fn mesh_to_tris(m: &Mesh) -> Vec<Tri> {
+    let _t = crate::kernel::timing::timer(crate::kernel::timing::Phase::MeshToTris);
     let vertex = |i: u32| -> Option<[f64; 3]> {
         let b = (i as usize) * 3;
         let c = [
@@ -69,6 +70,7 @@ fn face_normal(t: &Tri) -> [f32; 3] {
 
 /// The kernel's triangle list → a `Mesh` (per-face flat normals, f64 → f32).
 pub fn tris_to_mesh(tris: &[Tri]) -> Mesh {
+    let _t = crate::kernel::timing::timer(crate::kernel::timing::Phase::TrisToMesh);
     let mut m = Mesh::with_capacity(tris.len() * 3, tris.len() * 3);
     for t in tris {
         let n = face_normal(t);

--- a/rust/geometry/src/kernel/mod.rs
+++ b/rust/geometry/src/kernel/mod.rs
@@ -26,6 +26,7 @@ pub mod mesh_bridge;
 pub mod predicates;
 pub mod rational;
 pub mod retriangulate;
+pub mod timing;
 pub mod tritri;
 
 /// Three-valued exact sign.

--- a/rust/geometry/src/kernel/predicates.rs
+++ b/rust/geometry/src/kernel/predicates.rs
@@ -19,7 +19,9 @@ use super::{DropAxis, ImplicitPoint, Sign};
 /// escalate to the exact (BigRational) tier only on a straddle. Every tier
 /// returns the SAME sign — verified against the oracle in tests.
 pub fn orient3d(a: &ImplicitPoint, b: &ImplicitPoint, c: &ImplicitPoint, d: &ImplicitPoint) -> Sign {
+    use crate::kernel::timing::{tier, Tier};
     use ImplicitPoint::{Explicit, Lpi, Tpi};
+    tier(Tier::PredCall);
     match (a, b, c, d) {
         (Explicit(a), Explicit(b), Explicit(c), Explicit(d)) => {
             Sign::from_f64(geometry_predicates::orient3d(*a, *b, *c, *d))
@@ -29,13 +31,19 @@ pub fn orient3d(a: &ImplicitPoint, b: &ImplicitPoint, c: &ImplicitPoint, d: &Imp
                 crate::kernel::budget::note_escalation();
                 fixed::indirect_orient3d(a, *b, *c, *d)
             })
-            .unwrap_or_else(|| rational::lpi_orient3d(l, *b, *c, *d)),
+            .unwrap_or_else(|| {
+                tier(Tier::Rational);
+                rational::lpi_orient3d(l, *b, *c, *d)
+            }),
         (Tpi(t), Explicit(b), Explicit(c), Explicit(d)) => interval::tpi_orient3d(t, *b, *c, *d)
             .or_else(|| {
                 crate::kernel::budget::note_escalation();
                 fixed::indirect_orient3d(a, *b, *c, *d)
             })
-            .unwrap_or_else(|| rational::tpi_orient3d(t, *b, *c, *d)),
+            .unwrap_or_else(|| {
+                tier(Tier::Rational);
+                rational::tpi_orient3d(t, *b, *c, *d)
+            }),
         // By-construction unreachable: kernel callers only ever build the configurations above.
         _ => unimplemented!(
             "kernel::orient3d: implicit-point configuration never produced by the arrangement pipeline"
@@ -53,6 +61,7 @@ pub fn orient2d(a: &ImplicitPoint, b: &ImplicitPoint, c: &ImplicitPoint, axis: D
         DropAxis::Y => (0, 2),
         DropAxis::Z => (0, 1),
     };
+    crate::kernel::timing::tier(crate::kernel::timing::Tier::PredCall);
     match (a, b, c) {
         (Explicit(a), Explicit(b), Explicit(c)) => {
             Sign::from_f64(geometry_predicates::orient2d([a[i], a[j]], [b[i], b[j]], [c[i], c[j]]))
@@ -62,13 +71,19 @@ pub fn orient2d(a: &ImplicitPoint, b: &ImplicitPoint, c: &ImplicitPoint, axis: D
                 crate::kernel::budget::note_escalation();
                 fixed::indirect_orient2d(a, *b, *c, axis)
             })
-            .unwrap_or_else(|| rational::lpi_orient2d(l, *b, *c, axis)),
+            .unwrap_or_else(|| {
+                crate::kernel::timing::tier(crate::kernel::timing::Tier::Rational);
+                rational::lpi_orient2d(l, *b, *c, axis)
+            }),
         (Tpi(t), Explicit(b), Explicit(c)) => interval::tpi_orient2d(t, *b, *c, axis)
             .or_else(|| {
                 crate::kernel::budget::note_escalation();
                 fixed::indirect_orient2d(a, *b, *c, axis)
             })
-            .unwrap_or_else(|| rational::tpi_orient2d(t, *b, *c, axis)),
+            .unwrap_or_else(|| {
+                crate::kernel::timing::tier(crate::kernel::timing::Tier::Rational);
+                rational::tpi_orient2d(t, *b, *c, axis)
+            }),
         // By-construction unreachable: kernel callers only ever build the configurations above.
         _ => unimplemented!(
             "kernel::orient2d: implicit-point configuration never produced by the arrangement pipeline"
@@ -78,33 +93,48 @@ pub fn orient2d(a: &ImplicitPoint, b: &ImplicitPoint, c: &ImplicitPoint, axis: D
 
 /// orient2d with two implicit points (a,b) + one explicit (c) — cascade.
 pub fn orient2d_2i(a: &ImplicitPoint, b: &ImplicitPoint, c: [f64; 3], axis: DropAxis) -> Sign {
+    use crate::kernel::timing::{tier, Tier};
+    tier(Tier::PredCall);
     // cascade: interval filter → fixed-width exact (fast) → BigRational (off-grid / overflow)
     interval::orient2d_2i(a, b, c, axis)
         .or_else(|| {
             crate::kernel::budget::note_escalation();
             fixed::orient2d_2i(a, b, c, axis)
         })
-        .unwrap_or_else(|| rational::orient2d_2i(a, b, c, axis))
+        .unwrap_or_else(|| {
+            tier(Tier::Rational);
+            rational::orient2d_2i(a, b, c, axis)
+        })
 }
 
 /// orient2d with three implicit points (a,b,c) — cascade.
 pub fn orient2d_3i(a: &ImplicitPoint, b: &ImplicitPoint, c: &ImplicitPoint, axis: DropAxis) -> Sign {
+    use crate::kernel::timing::{tier, Tier};
+    tier(Tier::PredCall);
     interval::orient2d_3i(a, b, c, axis)
         .or_else(|| {
             crate::kernel::budget::note_escalation();
             fixed::orient2d_3i(a, b, c, axis)
         })
-        .unwrap_or_else(|| rational::orient2d_3i(a, b, c, axis))
+        .unwrap_or_else(|| {
+            tier(Tier::Rational);
+            rational::orient2d_3i(a, b, c, axis)
+        })
 }
 
 /// Exact lexicographic total order on points — the interner's comparison (cascade).
 pub fn cmp_lex(a: &ImplicitPoint, b: &ImplicitPoint) -> Sign {
+    use crate::kernel::timing::{tier, Tier};
+    tier(Tier::PredCall);
     interval::cmp_lex(a, b)
         .or_else(|| {
             crate::kernel::budget::note_escalation();
             fixed::cmp_lex(a, b)
         })
-        .unwrap_or_else(|| rational::cmp_lex(a, b))
+        .unwrap_or_else(|| {
+            tier(Tier::Rational);
+            rational::cmp_lex(a, b)
+        })
 }
 
 #[inline]

--- a/rust/geometry/src/kernel/timing.rs
+++ b/rust/geometry/src/kernel/timing.rs
@@ -1,0 +1,209 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Step 0 of the kernel-speed roadmap: per-phase wall-clock timers + per-phase
+//! invocation counts + per-predicate-tier escalation counters, so we stop flying
+//! blind on where a CSG boolean's time actually goes — on BOTH native and wasm.
+//!
+//! - **Phase timers** use `std::time::Instant` on native (server/CLI). On wasm32
+//!   `Instant` is unavailable, so the wall-clock is skipped there and the
+//!   **op counts + tier counters** (clock-free) carry the structural breakdown —
+//!   which is exactly the data that answers "which phase dominates" and "what
+//!   fraction of predicates escalate to the wasm-expensive wide-int / rational
+//!   tier".
+//! - Everything is behind the `kernel-timing` cargo feature and compiles to
+//!   **nothing** when off (the entry points are `#[inline(always)]` no-ops over
+//!   a zero-sized guard), so production native and wasm pay zero cost. Enable for
+//!   a measured run: `cargo … --features kernel-timing`, or pass
+//!   `--features kernel-timing` to `build-wasm.sh` for a wasm profiling bundle.
+
+/// A phase of one CSG boolean (`mesh_bridge::subtract` → `arrange` → classify →
+/// `tris_to_mesh` → `consolidate_coplanar`).
+#[derive(Clone, Copy)]
+pub enum Phase {
+    MeshToTris = 0,
+    Broadphase = 1,
+    TriTri = 2,
+    SplitCrossings = 3,
+    Retriangulate = 4,
+    Classify = 5,
+    TrisToMesh = 6,
+    Consolidate = 7,
+}
+pub const N_PHASES: usize = 8;
+const PHASE_NAMES: [&str; N_PHASES] = [
+    "mesh_to_tris",
+    "broadphase",
+    "tri_tri",
+    "split_crossings",
+    "retriangulate",
+    "classify",
+    "tris_to_mesh",
+    "consolidate",
+];
+
+/// A predicate evaluation tier. `PredCall` is every exact predicate evaluation
+/// (the denominator); `Escalation` is those that fell past the cheap f64
+/// interval filter into the fixed-point tier (the wide-int work wasm32 emulates
+/// as multi-limb); `Rational` is the `BigRational` heap tier (~3 ms/call).
+#[derive(Clone, Copy)]
+pub enum Tier {
+    PredCall = 0,
+    Escalation = 1,
+    Rational = 2,
+}
+pub const N_TIERS: usize = 3;
+
+#[cfg(feature = "kernel-timing")]
+mod inner {
+    use super::{Phase, Tier, N_PHASES, N_TIERS};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    pub(super) static PHASE_NS: [AtomicU64; N_PHASES] = [const { AtomicU64::new(0) }; N_PHASES];
+    pub(super) static PHASE_OPS: [AtomicU64; N_PHASES] = [const { AtomicU64::new(0) }; N_PHASES];
+    pub(super) static TIERS: [AtomicU64; N_TIERS] = [const { AtomicU64::new(0) }; N_TIERS];
+
+    // Monotonic nanosecond clock. Native uses `Instant` (lazy epoch). wasm32 has
+    // no `Instant`, so the host injects a millisecond clock (`performance.now`)
+    // via `set_wasm_clock`; until it does, wasm wall-clock reads 0 (the op/tier
+    // counts still work). Keeping the host clock OUT of the geometry crate (which
+    // must stay web-free) — it's a plain `fn() -> f64` pointer set by wasm-bindings.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn now_ns() -> u64 {
+        static EPOCH: std::sync::OnceLock<std::time::Instant> = std::sync::OnceLock::new();
+        EPOCH.get_or_init(std::time::Instant::now).elapsed().as_nanos() as u64
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    static WASM_CLOCK: std::sync::OnceLock<fn() -> f64> = std::sync::OnceLock::new();
+
+    #[cfg(target_arch = "wasm32")]
+    pub fn set_wasm_clock(f: fn() -> f64) {
+        let _ = WASM_CLOCK.set(f);
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn now_ns() -> u64 {
+        WASM_CLOCK
+            .get()
+            .map(|f| (f() * 1.0e6) as u64)
+            .unwrap_or(0)
+    }
+
+    /// RAII phase guard: bumps the phase invocation count, and on drop adds the
+    /// elapsed wall-clock.
+    pub struct PhaseTimer {
+        phase: usize,
+        start: u64,
+    }
+
+    impl Drop for PhaseTimer {
+        #[inline]
+        fn drop(&mut self) {
+            PHASE_OPS[self.phase].fetch_add(1, Ordering::Relaxed);
+            PHASE_NS[self.phase].fetch_add(now_ns().saturating_sub(self.start), Ordering::Relaxed);
+        }
+    }
+
+    #[inline]
+    pub fn timer(p: Phase) -> PhaseTimer {
+        PhaseTimer {
+            phase: p as usize,
+            start: now_ns(),
+        }
+    }
+
+    #[inline]
+    pub fn tier(t: Tier) {
+        TIERS[t as usize].fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Inject a millisecond wall-clock for wasm phase timing (e.g. `performance.now`).
+/// No-op on native (uses `Instant`) and when the feature is off.
+#[cfg(all(feature = "kernel-timing", target_arch = "wasm32"))]
+pub fn set_wasm_clock(f: fn() -> f64) {
+    inner::set_wasm_clock(f);
+}
+#[cfg(not(all(feature = "kernel-timing", target_arch = "wasm32")))]
+#[inline(always)]
+pub fn set_wasm_clock(_f: fn() -> f64) {}
+
+#[cfg(not(feature = "kernel-timing"))]
+mod inner {
+    use super::{Phase, Tier};
+    /// Zero-sized no-op guard — drops to nothing.
+    pub struct PhaseTimer;
+    #[inline(always)]
+    pub fn timer(_: Phase) -> PhaseTimer {
+        PhaseTimer
+    }
+    #[inline(always)]
+    pub fn tier(_: Tier) {}
+}
+
+pub use inner::{tier, timer, PhaseTimer};
+
+/// A drained snapshot of the kernel timing/counters.
+#[derive(Default, Clone)]
+pub struct KernelTiming {
+    pub phase_ns: [u64; N_PHASES],
+    pub phase_ops: [u64; N_PHASES],
+    pub tiers: [u64; N_TIERS],
+}
+
+/// Read AND reset the global timing/counters (call once per measured batch).
+#[cfg(feature = "kernel-timing")]
+pub fn take() -> KernelTiming {
+    use std::sync::atomic::Ordering;
+    let mut t = KernelTiming::default();
+    for i in 0..N_PHASES {
+        t.phase_ns[i] = inner::PHASE_NS[i].swap(0, Ordering::Relaxed);
+        t.phase_ops[i] = inner::PHASE_OPS[i].swap(0, Ordering::Relaxed);
+    }
+    for i in 0..N_TIERS {
+        t.tiers[i] = inner::TIERS[i].swap(0, Ordering::Relaxed);
+    }
+    t
+}
+
+#[cfg(not(feature = "kernel-timing"))]
+pub fn take() -> KernelTiming {
+    KernelTiming::default()
+}
+
+impl KernelTiming {
+    pub fn is_empty(&self) -> bool {
+        self.phase_ops.iter().all(|&x| x == 0) && self.tiers.iter().all(|&x| x == 0)
+    }
+
+    /// One-line summary: per-phase ms (and % of measured wall-clock, 0 on wasm
+    /// where there is no clock) + invocation counts, then the predicate-tier
+    /// escalation fractions (the wasm-cost signal).
+    pub fn format(&self) -> String {
+        let total_ns: u64 = self.phase_ns.iter().sum();
+        let mut s = String::new();
+        for i in 0..N_PHASES {
+            let pct = if total_ns > 0 {
+                100.0 * self.phase_ns[i] as f64 / total_ns as f64
+            } else {
+                0.0
+            };
+            s.push_str(&format!(
+                "{}={:.0}ms/{:.0}%/{}ops ",
+                PHASE_NAMES[i],
+                self.phase_ns[i] as f64 / 1.0e6,
+                pct,
+                self.phase_ops[i],
+            ));
+        }
+        let (calls, esc, rat) = (self.tiers[0], self.tiers[1], self.tiers[2]);
+        let esc_pct = if calls > 0 { 100.0 * esc as f64 / calls as f64 } else { 0.0 };
+        let rat_pct = if calls > 0 { 100.0 * rat as f64 / calls as f64 } else { 0.0 };
+        s.push_str(&format!(
+            "| predicates={calls} escalated={esc}({esc_pct:.1}%) rational={rat}({rat_pct:.3}%)"
+        ));
+        s
+    }
+}

--- a/rust/geometry/tests/kernel_timing_smoke.rs
+++ b/rust/geometry/tests/kernel_timing_smoke.rs
@@ -1,0 +1,78 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Smoke test for the Step-0 kernel timing instrumentation: a real exact-kernel
+//! boolean must populate the per-phase timers + predicate-tier counters when
+//! built with `--features kernel-timing`, and record NOTHING (zero overhead)
+//! otherwise.
+//!
+//! cargo test -p ifc-lite-geometry --features kernel-timing --test kernel_timing_smoke -- --nocapture
+
+use ifc_lite_geometry::kernel::timing;
+use ifc_lite_geometry::{ClippingProcessor, Mesh};
+use nalgebra::Point3;
+
+/// Closed axis-aligned box (12 triangles), outward-wound.
+fn box_mesh(min: [f32; 3], max: [f32; 3]) -> Mesh {
+    let mut m = Mesh::new();
+    let c = [
+        [min[0], min[1], min[2]],
+        [max[0], min[1], min[2]],
+        [max[0], max[1], min[2]],
+        [min[0], max[1], min[2]],
+        [min[0], min[1], max[2]],
+        [max[0], min[1], max[2]],
+        [max[0], max[1], max[2]],
+        [min[0], max[1], max[2]],
+    ];
+    let faces: [([usize; 4], [f32; 3]); 6] = [
+        ([0, 3, 2, 1], [0.0, 0.0, -1.0]),
+        ([4, 5, 6, 7], [0.0, 0.0, 1.0]),
+        ([0, 1, 5, 4], [0.0, -1.0, 0.0]),
+        ([2, 3, 7, 6], [0.0, 1.0, 0.0]),
+        ([0, 4, 7, 3], [-1.0, 0.0, 0.0]),
+        ([1, 2, 6, 5], [1.0, 0.0, 0.0]),
+    ];
+    for (idx, n) in faces {
+        let b = (m.positions.len() / 3) as u32;
+        for &i in &idx {
+            m.positions.extend_from_slice(&c[i]);
+            m.normals.extend_from_slice(&n);
+        }
+        m.indices
+            .extend_from_slice(&[b, b + 1, b + 2, b, b + 2, b + 3]);
+    }
+    m
+}
+
+#[test]
+fn boolean_populates_kernel_timing() {
+    let _ = timing::take(); // clear any cross-test residue
+    let clip = ClippingProcessor::new();
+    // A window-ish box cut through a wall slab → a real arrangement boolean.
+    let host = box_mesh([0.0, 0.0, 0.0], [4.0, 0.2, 3.0]);
+    let cutter = box_mesh([1.0, -0.1, 1.0], [2.0, 0.3, 2.0]);
+    let out = clip.subtract_box(&host, Point3::new(1.0, -0.1, 1.0), Point3::new(2.0, 0.3, 2.0));
+    assert!(out.is_ok(), "subtract should succeed");
+    let _ = cutter; // host/cutter both exercise mesh_to_tris
+
+    let kt = timing::take();
+    eprintln!("[kernel-timing smoke] {}", kt.format());
+
+    if cfg!(feature = "kernel-timing") {
+        assert!(
+            !kt.is_empty(),
+            "kernel-timing feature ON but nothing was recorded"
+        );
+        // A box−box arrangement must exercise the predicate cascade and the
+        // mesh-conversion phases at minimum.
+        assert!(kt.tiers[0] > 0, "no predicate evaluations recorded");
+        assert!(
+            kt.phase_ops.iter().any(|&o| o > 0),
+            "no phase invocations recorded"
+        );
+    } else {
+        assert!(kt.is_empty(), "kernel-timing OFF must record nothing");
+    }
+}

--- a/rust/wasm-bindings/Cargo.toml
+++ b/rust/wasm-bindings/Cargo.toml
@@ -19,6 +19,9 @@ crate-type = ["cdylib", "rlib"]
 [features]
 default = ["console_error_panic_hook"]
 debug_geometry = ["ifc-lite-geometry/debug_geometry"]
+# Step-0 kernel instrumentation — logs per-phase/per-tier CSG timing to the
+# browser console. Build a profiling bundle: `build-wasm.sh --features kernel-timing`.
+kernel-timing = ["ifc-lite-geometry/kernel-timing"]
 
 [dependencies]
 console_error_panic_hook = { version = "0.1", optional = true }
@@ -51,7 +54,7 @@ serde-wasm-bindgen = "=0.6.5"
 thiserror = "2.0"
 wasm-bindgen = "=0.2.106"
 wasm-bindgen-futures = "=0.4.56"
-web-sys = { version = "=0.3.83", features = ["console", "Performance", "Window"] }
+web-sys = { version = "=0.3.83", features = ["console", "Performance", "Window", "WorkerGlobalScope"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "=0.3.56"

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -1011,7 +1011,34 @@ pub(super) fn drain_and_log_csg_diagnostics(
         );
     }
 
+    // Step-0 kernel instrumentation (perf/kernel-timing): per-phase wall-clock +
+    // per-phase op counts + predicate-tier escalation counts. Empty unless built
+    // with `--features kernel-timing`, so production logs nothing.
+    #[cfg(feature = "kernel-timing")]
+    ifc_lite_geometry::kernel::timing::set_wasm_clock(perf_now);
+    let kt = ifc_lite_geometry::kernel::timing::take();
+    if !kt.is_empty() {
+        web_sys::console::info_1(&format!("[IFC-LITE] kernel-timing: {}", kt.format()).into());
+    }
+
     summary.into()
+}
+
+/// A millisecond wall-clock that works in both the window and worker scopes —
+/// injected into the geometry kernel's timing so wasm phase timing is real
+/// `performance.now()` deltas, not zeros.
+#[cfg(feature = "kernel-timing")]
+fn perf_now() -> f64 {
+    use wasm_bindgen::JsCast;
+    if let Ok(w) = js_sys::global().dyn_into::<web_sys::WorkerGlobalScope>() {
+        if let Some(p) = w.performance() {
+            return p.now();
+        }
+    }
+    web_sys::window()
+        .and_then(|w| w.performance())
+        .map(|p| p.now())
+        .unwrap_or(0.0)
 }
 
 /// Convert entity counts map to JavaScript object

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -63,12 +63,20 @@ if ! command -v wasm-pack &> /dev/null; then
   fi
 fi
 
-# Check if debug_geometry feature should be enabled
-FEATURES=""
+# Optional build features (combined into one comma list).
+FEATURE_LIST=""
 if [ "${DEBUG_GEOMETRY:-}" = "1" ]; then
-  FEATURES="--features debug_geometry"
+  FEATURE_LIST="debug_geometry"
   echo "🔍 Building with debug_geometry feature enabled"
 fi
+# KERNEL_TIMING=1 → log per-phase / per-predicate-tier CSG timing to the console
+# (perf/kernel-timing Step 0). Profiling builds only; never the default.
+if [ "${KERNEL_TIMING:-}" = "1" ]; then
+  FEATURE_LIST="${FEATURE_LIST:+$FEATURE_LIST,}kernel-timing"
+  echo "⏱  Building with kernel-timing feature enabled (profiling bundle)"
+fi
+FEATURES=""
+[ -n "$FEATURE_LIST" ] && FEATURES="--features $FEATURE_LIST"
 
 OUT_DIR="../../packages/wasm/pkg"
 echo "🟢 Building single-thread bundle → $OUT_DIR"


### PR DESCRIPTION
**Step 0 of the kernel-speed roadmap.** We've been flying blind on where a CSG boolean's ~84.6s (722MB model) actually goes — there was no `Instant` anywhere in the kernel, only an op-count census. This adds **per-phase wall-clock + per-phase op counts + per-predicate-tier escalation counters**, on **both native and WASM**, so the next moves (parallelism / consolidate-gating / on-grid starvation / the adaptive-f64 spike) are chosen from data, not estimates.

## What it measures

- **8 phases**: `mesh_to_tris, broadphase, tri_tri, split_crossings, retriangulate, classify, tris_to_mesh, consolidate`.
- **3 predicate tiers**: total predicate evaluations, escalations past the cheap f64 interval filter (the wide-int work wasm32 emulates as multi-limb), and the `BigRational` tier (~3 ms/call).

Sample, single box−box cut (native):
```
split_crossings=…/36% retriangulate=…/40% consolidate=…/16% | predicates=1822 escalated=116(6.4%) rational=0(0.000%)
```

## Design

- `kernel/timing.rs`: lock-free atomics (captures rayon workers). Native wall-clock via `Instant`; wasm32 has no `Instant`, so the host injects `performance.now()` via `set_wasm_clock` (kept out of the web-free geometry crate as a plain `fn() -> f64` pointer; needs `WorkerGlobalScope` for the worker scope).
- **Zero production cost**: behind the `kernel-timing` cargo feature. OFF ⇒ every entry point is an `#[inline(always)]` no-op over a zero-sized guard. Determinism untouched — counters/timers never feed a sign or a coordinate.
- Reuses the existing `budget::note_escalation()` hook as the escalation counter.

## How to run a measurement

- **WASM** (viewer): `KERNEL_TIMING=1 scripts/build-wasm.sh`, reload the model, read `[IFC-LITE] kernel-timing: …` per batch in the console.
- **Native** (server/CLI/test): build with `--features kernel-timing` and drain `ifc_lite_geometry::kernel::timing::take()`. The smoke test prints it: `cargo test -p ifc-lite-geometry --features kernel-timing --test kernel_timing_smoke -- --nocapture`.

## Tests

`kernel_timing_smoke.rs` asserts a real boolean populates the timers/counters with the feature ON and records **nothing** with it OFF. Full geometry suite green (the 3 `wall_opening` failures are a pre-existing stale-local-fixture issue — `advanced_model.ifc` — unrelated to this change; CI fetches the fresh fixture).

Next: run this on the 722MB model native + wasm to decide whether the model is retriangulate-bound or consolidate-bound, and how hot the wide-int tier actually is on wasm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional kernel timing instrumentation for CSG operations to measure performance by phase and predicate evaluation tier. Enable with `--features kernel-timing`. Timing metrics are automatically included in CSG diagnostics output and logged to console in WASM builds.

* **Chores**
  * Updated build scripts to support kernel-timing feature configuration via environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->