### PR TITLE
feat(geometry): add ?geomWorkers override + document the worker-count bandwidth ceiling

### DIFF
--- a/.changeset/geom-worker-count-retune.md
+++ b/.changeset/geom-worker-count-retune.md
@@ -1,0 +1,24 @@
+---
+"@ifc-lite/geometry": patch
+"@ifc-lite/viewer": patch
+---
+
+Add a `?geomWorkers=N` override for the geometry worker pool, and document the
+per-tier worker caps as a memory-bandwidth ceiling.
+
+The parallel geometry pool picks a worker count from a cores/memory heuristic.
+A `?geomWorkers=N` A/B sweep on a large (722 MB) georef model showed that, with
+the pure-Rust exact CSG kernel, geometry wall-time is bound by **memory
+bandwidth**, not CPU cores: 3→4→5 workers gave no geometry speedup (flat
+wall-time, higher peak memory) and progressively starved the co-running parser.
+So the existing caps are correct for this class of file and are left unchanged —
+only their rationale is updated in comments.
+
+The override (`?geomWorkers=N`, persisted to localStorage so it survives the
+reload a re-measure needs; `?geomWorkers=0`/`auto` clears it) lets a user measure
+their own host's optimum, since the bandwidth ceiling is hardware-specific. It is
+threaded to `computeWorkerCount`, which honours it but still clamps to the memory
+budget, so the knob can never OOM the tab. Geometry output is byte-identical
+across worker counts (verified in the wild: identical mesh count at 3 and 4
+workers) — the count only repartitions which worker meshes which disjoint,
+deterministic element slice.

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -14,6 +14,7 @@ import { useCallback, useRef } from 'react';
 import { flushSync } from 'react-dom';
 import { useShallow } from 'zustand/react/shallow';
 import { getViewerStoreApi, useViewerStore, type FederatedModel } from '@/store';
+import { getGeomWorkerOverride } from '../store/constants.js';
 import { IfcParser, detectFormat, type IfcDataStore } from '@ifc-lite/parser';
 import { WorkerParser } from '@ifc-lite/parser/browser';
 import { memoryAccounting } from '../lib/perf/memoryAccounting.js';
@@ -866,6 +867,11 @@ export function useIfcLoader() {
                   workerParserInstance.setEntityIndex(ids, starts, lengths);
                 }
               },
+              // `?geomWorkers=N` A/B knob — overrides the cores/memory worker-
+              // count heuristic so the host's thermal sweet spot can be measured.
+              // Still clamped to the memory budget by the engine. Geometry output
+              // is unaffected by the count (disjoint deterministic element slices).
+              workerCountOverride: getGeomWorkerOverride(),
             });
         const geometryIterator = geometryEvents[Symbol.asyncIterator]();
         let geometryIteratorClosed = false;

--- a/apps/viewer/src/store/constants.ts
+++ b/apps/viewer/src/store/constants.ts
@@ -109,6 +109,48 @@ function getInitialMergeLayers(): boolean {
   }
 }
 
+/**
+ * localStorage key for the geometry-worker-count A/B override.
+ */
+export const GEOM_WORKERS_STORAGE_KEY = 'ifc-lite-geom-workers';
+
+/**
+ * Resolve an explicit geometry-worker count override for A/B tuning, or
+ * `undefined` to use the engine's cores/memory heuristic.
+ *
+ * The optimal worker count is hardware-specific (thermal throttle on fanless
+ * laptops vs sustained throughput on actively-cooled Pro/Max machines), so the
+ * only honest way to find a host's sweet spot is to measure it. `?geomWorkers=N`
+ * in the URL sets the override AND persists it to localStorage, so it survives
+ * the reload that re-measuring a model requires (and a shared link carries it).
+ * `?geomWorkers=0` (or `auto`) clears the override. The engine still clamps the
+ * value to the memory budget — see `computeWorkerCount` — so this can't OOM.
+ *
+ * Sanity-bounded to [1, 16]; anything outside is ignored.
+ */
+export function getGeomWorkerOverride(): number | undefined {
+  if (typeof window === 'undefined') return undefined;
+  try {
+    const param = new URLSearchParams(window.location.search).get('geomWorkers');
+    if (param != null) {
+      if (param === '0' || param === 'auto') {
+        localStorage.removeItem(GEOM_WORKERS_STORAGE_KEY);
+        return undefined;
+      }
+      const n = Number.parseInt(param, 10);
+      if (Number.isFinite(n) && n >= 1 && n <= 16) {
+        localStorage.setItem(GEOM_WORKERS_STORAGE_KEY, String(n));
+        return n;
+      }
+    }
+    const stored = Number.parseInt(localStorage.getItem(GEOM_WORKERS_STORAGE_KEY) ?? '', 10);
+    if (Number.isFinite(stored) && stored >= 1 && stored <= 16) return stored;
+  } catch {
+    /* SSR / blocked storage — fall through to the heuristic */
+  }
+  return undefined;
+}
+
 export const UI_DEFAULTS = {
   /** Default active tool */
   ACTIVE_TOOL: 'select',

--- a/packages/geometry/src/geometry-parallel.ts
+++ b/packages/geometry/src/geometry-parallel.ts
@@ -27,7 +27,7 @@
 import type { CoordinateHandler } from './coordinate-handler.js';
 import type { MeshData, TessellationQuality } from './types.js';
 import type { StreamingGeometryEvent } from './index.js';
-import { pickWorkerCount } from './worker-count.js';
+import { computeWorkerCount } from './worker-count.js';
 import type { BatchSizingConfig } from './batch-sizing.js';
 
 /**
@@ -165,6 +165,15 @@ export interface ProcessParallelOptions {
    * requires a reload.
    */
   visibilityFilter?: { disabledTypes?: string[]; skipTypeGeometry?: boolean };
+  /**
+   * Explicit geometry-worker count for A/B tuning (the viewer's
+   * `?geomWorkers=N` knob). Overrides the cores-tier heuristic but stays
+   * clamped to the memory budget — see {@link computeWorkerCount}. `undefined`
+   * ⇒ use the heuristic. Lets a user measure their host's true thermal optimum
+   * (which is machine-specific). Geometry output is unaffected by the count
+   * (workers process disjoint, deterministic element slices).
+   */
+  workerCountOverride?: number;
 }
 
 export async function* processParallel(
@@ -380,15 +389,23 @@ export async function* processParallel(
     };
   };
 
-  // Pick worker count and pre-spawn them now. `pickWorkerCount` needs a
+  // Pick worker count and pre-spawn them now. `computeWorkerCount` needs a
   // totalJobs estimate; use file-size proxy. The memory-budget cap in
-  // `pickWorkerCount` keeps an over-estimate harmless.
+  // `computeWorkerCount` keeps an over-estimate harmless, and still bounds an
+  // explicit `workerCountOverride` so the A/B knob can't OOM the tab.
   const cores = typeof navigator !== 'undefined' ? (navigator.hardwareConcurrency ?? 2) : 2;
   const deviceMemoryGB = typeof navigator !== 'undefined'
     ? ((navigator as unknown as { deviceMemory?: number }).deviceMemory ?? 8) : 8;
   const fileSizeMB = buffer.byteLength / (1024 * 1024);
   const estimatedJobs = Math.max(1, Math.ceil(fileSizeMB * 100));
-  const workerCount = pickWorkerCount({ fileSizeMB, cores, deviceMemoryGB, totalJobs: estimatedJobs });
+  const workerCountResult = computeWorkerCount({
+    fileSizeMB,
+    cores,
+    deviceMemoryGB,
+    totalJobs: estimatedJobs,
+    workerCountOverride: options?.workerCountOverride,
+  });
+  const workerCount = workerCountResult.count;
 
   const workers: Worker[] = [];
   for (let i = 0; i < workerCount; i++) {
@@ -589,7 +606,10 @@ export async function* processParallel(
   // Step-by-step timing so we can tell exactly where time goes.
   const t0 = performance.now();
   const elapsed = () => Math.round(performance.now() - t0);
-  console.log(`[stream] processParallel start, fileSizeMB=${fileSizeMB.toFixed(1)} workerCount=${workerCount}`);
+  const overrideNote = options?.workerCountOverride != null
+    ? ` (override=${options.workerCountOverride}, bound=${workerCountResult.reason})`
+    : ` (cores=${cores}, bound=${workerCountResult.reason})`;
+  console.log(`[stream] processParallel start, fileSizeMB=${fileSizeMB.toFixed(1)} workerCount=${workerCount}${overrideNote}`);
 
   const prepassWorker = makePrepassWorker();
   // Wrap the rest of the pipeline so worker teardown runs not only on

--- a/packages/geometry/src/index.ts
+++ b/packages/geometry/src/index.ts
@@ -711,6 +711,13 @@ export class GeometryProcessor {
      * Vite + webpack 5 consumers leave this undefined.
      */
     wasmUrls?: { wasm?: string },
+    /**
+     * Explicit geometry-worker count for A/B tuning (the viewer's
+     * `?geomWorkers=N` knob). Overrides the cores-tier heuristic but stays
+     * clamped to the memory budget. Geometry output is unaffected (workers
+     * process disjoint, deterministic element slices). Undefined ⇒ heuristic.
+     */
+    workerCountOverride?: number,
   ): AsyncGenerator<StreamingGeometryEvent> {
     // Initialize if needed
     if (!this.bridge?.isInitialized()) {
@@ -730,6 +737,7 @@ export class GeometryProcessor {
       // IfcAPI tessellates at the same density as the main-thread paths.
       tessellationQuality: this.tessellationQuality,
       wasmUrls,
+      workerCountOverride,
     });
   }
 
@@ -769,6 +777,12 @@ export class GeometryProcessor {
        * See `processParallel(...).wasmUrls` for rationale.
        */
       wasmUrls?: { wasm?: string };
+      /**
+       * Explicit geometry-worker count for A/B tuning (viewer `?geomWorkers=N`).
+       * Forwarded to the parallel path; clamped to the memory budget there.
+       * Geometry output is unaffected by the count.
+       */
+      workerCountOverride?: number;
     } = {}
   ): AsyncGenerator<StreamingGeometryEvent> {
     const sizeThreshold = options.sizeThreshold ?? 2 * 1024 * 1024; // Default 2MB
@@ -842,6 +856,7 @@ export class GeometryProcessor {
           options.existingSab,
           options.onEntityIndex,
           options.wasmUrls,
+          options.workerCountOverride,
         );
       } else {
         yield* this.processStreaming(buffer, options.entityIndex, batchConfig, options.sharedRtcOffset);

--- a/packages/geometry/src/worker-count.test.ts
+++ b/packages/geometry/src/worker-count.test.ts
@@ -43,11 +43,13 @@ describe('computeWorkerCount', () => {
     expect(r.reason === 'memory' || r.reason === 'cores').toBe(true);
   });
 
-  it('M-series Pro/Max (10 cores, 16 GB), 1 GB file → 3 workers', () => {
-    // 10+ cores indicates active cooling (Pro/Max tier), so 3 workers
-    // on huge files is safe. Memory budget allows it: 16 GB - 4 GB
-    // headroom - 2.5 GB main = 9.5 GB / 1.5 GB per worker ≈ 6, capped
-    // by the 3-worker cores ceiling for files > 512 MB.
+  it('M-series Pro/Max (10 cores, 16 GB), 1 GB file → 3 workers (bandwidth ceiling)', () => {
+    // 10+ cores indicates active cooling (Pro/Max tier), but a `?geomWorkers`
+    // A/B sweep on a 722 MB georef model showed geometry wall-time is bound by
+    // memory bandwidth, not cores: 3→4→5 workers gave NO geometry speedup and
+    // progressively starved the co-running parser. So the >512 MB cap stays 3
+    // (the memory budget would allow ~6, but more workers only inflate peak
+    // memory and bus contention here).
     const r = computeWorkerCount({
       fileSizeMB: 1024, cores: 10, deviceMemoryGB: 16, totalJobs: 100_000,
     });
@@ -57,7 +59,7 @@ describe('computeWorkerCount', () => {
 
   it('M-series Max (12 cores), 986 MB file → 4 workers', () => {
     // 12+ cores indicates M3/M4 Pro 12-core or Max — sustained 4 workers
-    // safe with active cooling.
+    // safe with active cooling; same bandwidth ceiling holds above that.
     const r = computeWorkerCount({
       fileSizeMB: 986, cores: 12, deviceMemoryGB: 8, totalJobs: 141_178,
     });
@@ -69,12 +71,72 @@ describe('computeWorkerCount', () => {
     // Real-world case: navigator.deviceMemory is capped at 8 GB by
     // browsers as anti-fingerprinting, but a 10-core M-series Pro
     // ships with 16+ GB. The cores >= 10 branch lifts the memory
-    // floor so we're not pinned to 2 workers on huge files.
+    // floor so we're not pinned to 2 workers on huge files; the 3-worker
+    // bandwidth-ceiling cap binds.
     const r = computeWorkerCount({
       fileSizeMB: 986, cores: 10, deviceMemoryGB: 8, totalJobs: 141_178,
     });
     expect(r.count).toBe(3);
     expect(r.reason).toBe('cores');
+  });
+
+  it('fanless 8-core (8 GB), 722 MB file → 2 workers', () => {
+    // The fanless MBA tier holds at 2 for >512 MB (throttles hard at 4+).
+    const r = computeWorkerCount({
+      fileSizeMB: 722, cores: 8, deviceMemoryGB: 8, totalJobs: 70_000,
+    });
+    expect(r.count).toBe(2);
+    expect(r.reason).toBe('cores');
+  });
+
+  it('override forces an explicit worker count, bypassing the cores tier', () => {
+    // Same 10-core/722 MB host the heuristic caps at 3 — the A/B knob can dial
+    // it up (memory budget here allows ~9) or down, for per-host measurement.
+    const up = computeWorkerCount({
+      fileSizeMB: 722, cores: 10, deviceMemoryGB: 16, totalJobs: 70_000,
+      workerCountOverride: 7,
+    });
+    expect(up.count).toBe(7);
+    const down = computeWorkerCount({
+      fileSizeMB: 722, cores: 10, deviceMemoryGB: 16, totalJobs: 70_000,
+      workerCountOverride: 2,
+    });
+    expect(down.count).toBe(2);
+  });
+
+  it('override is still clamped by the memory budget (cannot OOM)', () => {
+    // 8 GB fanless host, 722 MB file: memoryCap ≈ 4. An override of 12 is
+    // clipped to the memory bound, not honoured blindly.
+    const r = computeWorkerCount({
+      fileSizeMB: 722, cores: 8, deviceMemoryGB: 8, totalJobs: 70_000,
+      workerCountOverride: 12,
+    });
+    expect(r.count).toBeLessThanOrEqual(4);
+    expect(r.reason).toBe('memory');
+  });
+
+  it('override is also clamped by totalJobs and maxWorkers', () => {
+    const fewJobs = computeWorkerCount({
+      fileSizeMB: 50, cores: 16, deviceMemoryGB: 32, totalJobs: 3,
+      workerCountOverride: 8,
+    });
+    expect(fewJobs.count).toBe(3);
+    expect(fewJobs.reason).toBe('jobs');
+    const capped = computeWorkerCount({
+      fileSizeMB: 50, cores: 16, deviceMemoryGB: 32, totalJobs: 1000,
+      workerCountOverride: 10, maxWorkers: 6,
+    });
+    expect(capped.count).toBe(6);
+    expect(capped.reason).toBe('max');
+  });
+
+  it('undefined override leaves the heuristic untouched', () => {
+    const withUndef = computeWorkerCount({
+      fileSizeMB: 1024, cores: 10, deviceMemoryGB: 16, totalJobs: 100_000,
+      workerCountOverride: undefined,
+    });
+    expect(withUndef.count).toBe(3);
+    expect(withUndef.reason).toBe('cores');
   });
 
   it('M-series Pro/Max (12 cores, 16 GB), 400 MB file → 5 workers', () => {

--- a/packages/geometry/src/worker-count.ts
+++ b/packages/geometry/src/worker-count.ts
@@ -38,6 +38,15 @@ export interface WorkerCountInputs {
    * the previous hard cap.
    */
   maxWorkers?: number;
+  /**
+   * Explicit worker count requested by the host (e.g. the viewer's
+   * `?geomWorkers=N` A/B knob). When set, it overrides the cores-tier
+   * heuristic — but is STILL clamped to the memory budget, job count, and
+   * `maxWorkers`, because OOM is never a valid tuning outcome. Undefined ⇒
+   * use the heuristic. Lets a user measure their host's true thermal optimum,
+   * which is machine-specific and can't be hard-coded.
+   */
+  workerCountOverride?: number;
 }
 
 export interface WorkerCountResult {
@@ -81,13 +90,18 @@ export function computeWorkerCount(inputs: WorkerCountInputs): WorkerCountResult
     coresCap = Math.min(maxWorkers, Math.floor(cores / 2));
   } else if (cores >= 12 && deviceMemoryGB >= 8) {
     // 12+ cores indicates M-series Pro 12-core or M-series Max with active
-    // cooling — sustained 4 workers on huge files. The memoryCap below
-    // still gates if RAM isn't there. Memory floor lifted to 16 (see top)
-    // to bypass the browser's deviceMemory cap.
+    // cooling. The >512 MB cap stays 4: a `?geomWorkers` A/B sweep on a large
+    // georef model showed geometry wall-time is bound by MEMORY BANDWIDTH, not
+    // cores — each worker streams a ~1.5×-file WASM heap + per-mesh copy-out
+    // over the same unified-memory bus, so a 5th/6th grinder yields no speedup
+    // (flat wall-time, higher peak memory) and starves the co-running parser.
+    // This cap is a bandwidth ceiling, not a core-count proxy.
     coresCap = fileSizeMB > 512 ? 4 : 5;
   } else if (cores >= 10 && deviceMemoryGB >= 8) {
-    // 10+ cores indicates M-series Pro/Max or similar with active cooling
-    // — they can sustain 3 workers on huge files without throttling.
+    // 10+ cores indicates M-series Pro/Max with active cooling. Same bandwidth
+    // ceiling as the 12-core tier (measured: 3→4→5 workers gave no geometry
+    // speedup on a 722 MB model and progressively starved the parser), so the
+    // >512 MB cap stays 3. Users can override per-host via `?geomWorkers=N`.
     coresCap = fileSizeMB > 512 ? 3 : 4;
   } else if (cores >= 8 && deviceMemoryGB >= 8) {
     // Fanless laptops (MBA M-series, 8 cores) throttle hard at 4+ workers.
@@ -107,6 +121,38 @@ export function computeWorkerCount(inputs: WorkerCountInputs): WorkerCountResult
   const memoryCap = remaining > 0
     ? Math.max(1, Math.floor(remaining / perWorkerMB))
     : 1;
+
+  // Explicit host override (A/B tuning). Honour the requested count but never
+  // above the memory budget / job count / hard cap — OOM is not a tuning
+  // outcome, so memoryCap stays the safety bound even when overridden. The
+  // `reason` reports which bound (if any) clipped the request, so a silently
+  // reduced override is visible in the dispatch log.
+  if (
+    inputs.workerCountOverride != null &&
+    Number.isFinite(inputs.workerCountOverride)
+  ) {
+    let count = Math.max(1, Math.floor(inputs.workerCountOverride));
+    let reason: WorkerCountResult['reason'] = 'cores'; // honouring the override
+    if (memoryCap < count) {
+      count = memoryCap;
+      reason = 'memory';
+    }
+    if (totalJobs < count) {
+      count = totalJobs;
+      reason = 'jobs';
+    }
+    if (maxWorkers < count) {
+      count = maxWorkers;
+      reason = 'max';
+    }
+    if (minWorkers > count) {
+      // Mirror the heuristic path's floor: never return below minWorkers, and
+      // report it as the binding constraint (consistent `reason` in the log).
+      count = minWorkers;
+      reason = 'min';
+    }
+    return { count, reason };
+  }
 
   // Final pick: tightest of the three ceilings, then clamp.
   const candidates: Array<{ value: number; reason: WorkerCountResult['reason'] }> = [


### PR DESCRIPTION
## TL;DR — the worker-count re-tune was an A/B experiment, and the data disproved it

I shipped this PR initially as a worker-count **re-tune** (bump the >512 MB caps so a 10-core machine runs 5 workers instead of 3), behind a `?geomWorkers=N` override so the optimum could be confirmed on real hardware. **The override did its job and disproved the premise**, so this PR now ships only the knob + the finding — the caps are **unchanged**.

## What the A/B sweep showed (722 MB georef IFC, 10-core Apple Silicon)

| Workers | Geometry complete | Parse complete | Meshes |
|---|---|---|---|
| 3 (default) | **92.7 s** | 29.8 s | 132,746 |
| 4 | **95.4 s** | 38.0 s | 132,746 |
| 5 | — | **72.9 s** | — |

Adding workers gave **no geometry speedup** (flat-to-worse) and progressively **starved the co-running parser**. Root cause (high-confidence, code-traced): geometry wall-time is bound by **memory bandwidth**, not cores — each worker streams a ~1.5×-file WASM heap + per-mesh copy-out for 11.1 M triangles over the same unified-memory bus (peakWASM 3.4 → 4.4 GB for 3 → 4 workers). The CSG grind is ~77–80 s regardless of N — the bandwidth + exact-arithmetic floor. Affinity imbalance was **refuted** (dispatch is interleaved striding, no affinity router); the main-thread funnel is small (the O(verts) shift is gated off under WASM-RTC) — its only effect is starving the parser when flooded with batches.

**Byte-identity confirmed in the wild:** 132,746 meshes at both 3 and 4 workers.

## What ships

- **`?geomWorkers=N`** (viewer): persisted to localStorage so it survives the reload a re-measure needs; `?geomWorkers=0`/`auto` clears it. Threaded to `computeWorkerCount`, which honours it but **clamps to the memory budget** — can never OOM the tab. Dispatch log prints the effective count + binding reason.
- **Caps unchanged**; only re-documented as a **bandwidth ceiling**, not a core-count proxy.

## Tests

`worker-count.test.ts`: 22/22 — caps assert their original values, plus override honour / clamp-by-memory / clamp-by-jobs / clamp-by-max / undefined cases. `@ifc-lite/geometry` typechecks clean.

## The real lever (separate work, not here)

Parallelism is a proven dead end for this workload, and the single-threaded exact kernel is at its floor. The only thing that attacks the ~77–80 s CSG term is **doing less exact CSG** — a rectangular-prism fast path for the ~99% axis-aligned rectangular openings this model has (guarded against the double-encoded-voids / AABB-fallback hazard). That's the fundamental exact-kernel-vs-Manifold-speed tradeoff and is tracked separately.