### PR TITLE
fix(renderer): keep internal edges visible on selected objects

### DIFF
--- a/.changeset/selection-highlight-preserve-edges.md
+++ b/.changeset/selection-highlight-preserve-edges.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/renderer": patch
+---
+
+Keep internal edges/facets visible on selected objects.
+
+The selection highlight painted every fragment a single flat blue (`color = vec3(0.3, 0.6, 1.0)`), discarding all lighting. Because the viewer's "internal lines" are really the per-face shading step of flat-shaded facets, that flat fill collapsed a selected object into one featureless silhouette — creases and bends disappeared the moment it was highlighted (the faint screen-space edge line alone could not stand in for the lost face-shading cue).
+
+The highlight now re-lights a selection-blue albedo with the scene's own lighting term instead of overwriting it. The base material colour never enters the result (no green-site / red-roof bleed-through, the reason the flat override existed), but the per-face brightness variation is preserved, so internal edges read on the highlight exactly as they do unselected. A multiplicative gain on the lighting luminance keeps sunlit faces at full selection-blue, with a floor/ceiling clamp so shadowed faces only dim and bright scenes never wash out.

--- a/packages/renderer/src/shaders/main.wgsl.ts
+++ b/packages/renderer/src/shaders/main.wgsl.ts
@@ -322,7 +322,13 @@ export const mainShaderSource = `
 
           // Saturation boost - stronger for colored surfaces, less for whites
           let gray = dot(color, vec3<f32>(0.299, 0.587, 0.114));
-          let satBoost = mix(1.4, 1.1, isWhiteish);  // More saturation for colored surfaces
+          // More saturation for colored surfaces. isWhiteish is derived from
+          // the base material colour, so for a SELECTED object it would leak a
+          // material dependence into the highlight (breaking the no-bleed-
+          // through contract). The selection blue is a fully-saturated colour,
+          // so force the colored-surface boost (1.4) when selected — keeping
+          // the highlight identical regardless of the underlying material.
+          let satBoost = select(mix(1.4, 1.1, isWhiteish), 1.4, isSelected);
           color = mix(vec3<f32>(gray), color, satBoost);
 
           // ACES filmic tone mapping

--- a/packages/renderer/src/shaders/main.wgsl.ts
+++ b/packages/renderer/src/shaders/main.wgsl.ts
@@ -229,8 +229,11 @@ export const mainShaderSource = `
           // Darken whites/grays more to reduce washed-out appearance
           baseColor = mix(baseColor, baseColor * 0.7, isWhiteish * 0.4);
 
-          // Combine all lighting
-          var color = baseColor * (ambient + env.sunColor * diffuseSun + vec3<f32>(diffuseFill + rim));
+          // Combine all lighting. Keep the lighting term separate so the
+          // selection highlight can reuse it (re-light a blue albedo) without
+          // the base material colour bleeding through.
+          let lightTerm = ambient + env.sunColor * diffuseSun + vec3<f32>(diffuseFill + rim);
+          var color = baseColor * lightTerm;
 
           // flags.x is a bitfield:
           //   bit 0 (value 1) = isSelected  → selection-highlight + force opaque
@@ -244,17 +247,34 @@ export const mainShaderSource = `
           let isSelected = (uniforms.flags.x & 1u) == 1u;
           let isOverlay = (uniforms.flags.x & 2u) == 2u;
 
-          // Selection highlight — a single FLAT selection colour.
+          // Selection highlight — a blue albedo RE-LIT by the scene lighting.
           //
-          // No lighting-dependent (luminance) or view-dependent (fresnel)
-          // term: the selected object must read as one uniform colour, not
-          // a shaded/gradient surface. The previous fresnel-glow mix left
-          // 80 % of the lit object colour visible at face centres (the
-          // green-site / red-roof bleed-through). A constant colour here
-          // also stays flat through the downstream tone-mapping, since
-          // those are per-pixel functions of a now-constant input.
+          // We override the material albedo with selection-blue and re-light
+          // it with the SAME lightTerm used for unselected surfaces, then
+          // discard the view-dependent (fresnel) term below. Two requirements
+          // are in tension and this satisfies both:
+          //
+          //   * No base-material bleed-through. The old fresnel-glow mix left
+          //     ~80 % of the lit object colour visible at face centres (the
+          //     green-site / red-roof wash-out). Here the base colour never
+          //     enters the result — only lightTerm (geometry/light, colour-
+          //     independent) modulates the constant blue albedo.
+          //   * Facet/crease structure must survive. A single FLAT colour
+          //     (the previous fix) collapsed every face to the same blue, so
+          //     internal edges — which read as the per-face shading STEP, not
+          //     just the faint screen-space edge line — disappeared on
+          //     selection. Re-lighting keeps that per-face brightness step, so
+          //     creases read on the highlight exactly as they do unselected.
+          //
+          // The luminance of lightTerm is remapped by a multiplicative gain
+          // (which preserves the per-face brightness RATIOS, so creases read
+          // as strongly as on the unselected surface) calibrated so a sunlit
+          // face hits full selection-blue, with a floor/ceiling clamp so
+          // shadowed faces only dim and bright scenes never wash out.
           if (isSelected) {
-            color = vec3<f32>(0.3, 0.6, 1.0);
+            let shadeLum = dot(lightTerm, vec3<f32>(0.299, 0.587, 0.114));
+            let shade = clamp(shadeLum * 1.55, 0.45, 1.2);
+            color = vec3<f32>(0.3, 0.6, 1.0) * shade;
           }
 
           // Beautiful fresnel effect for transparent materials (glass)


### PR DESCRIPTION
## Problem

Selecting an object flattened it: the internal crease/facet lines that define its shape disappeared the moment it was highlighted blue.

| Unselected | Selected (before) |
|---|---|
| crease/bend lines visible | uniform blue blob, edges gone |

## Root cause

The viewer is **flat-shaded** — face normals come from screen-space derivatives, so each face gets distinct lighting and a crease reads as a **per-face brightness step** (default lighting spans ~0.18→0.75 luminance, a ~4× step that outlines every edge).

The selection highlight in `packages/renderer/src/shaders/main.wgsl.ts` overwrote that with a single flat colour:

```wgsl
if (isSelected) { color = vec3<f32>(0.3, 0.6, 1.0); }  // discards all lighting
```

Every face became the identical blue, so the facet/crease structure collapsed into one silhouette. The screen-space edge-darkening pass is only a faint ~1px line and can't stand in for the lost face-shading cue.

## Fix

Re-light a selection-blue **albedo** with the scene's own lighting term instead of overwriting it:

```wgsl
let shadeLum = dot(lightTerm, vec3<f32>(0.299, 0.587, 0.114));
let shade = clamp(shadeLum * 1.55, 0.45, 1.2);
color = vec3<f32>(0.3, 0.6, 1.0) * shade;
```

- **No base-material bleed-through** — `lightTerm` is colour-independent (geometry + lights only), so the original surface colour never enters the result. Avoiding that bleed-through (green-site / red-roof wash-out) was the whole reason the flat override existed; this preserves it.
- **Edges return** — per-face brightness variation is kept, so creases read on the highlight exactly as they do unselected.
- The multiplicative gain preserves the relative per-face shading ratios (creases as strong as unselected) and is calibrated so a sunlit face hits full selection-blue; the clamp keeps shadowed faces visible and bright scenes from washing out.

The non-selected path is mathematically unchanged (just factors `lightTerm` into a variable).

## Verification

Simulated the exact fragment-shader selection math per face normal (default lighting env):

| Face | Before (flat) | After |
|---|---|---|
| top (sunlit) | rgb(110,207,233) | rgb(111,207,233) |
| front | rgb(110,207,233) | rgb(46,167,211) |

Old: identical on every face (no edges). New: sunlit face stays at the canonical selection blue while the adjacent front face is a **65-level** step in the red channel → a clearly visible facet edge, still unmistakably the blue selection highlight.

Note: not run in a live browser (single-point WGSL change verified numerically + by import; WGSL is a string `tsc` doesn't typecheck). Changeset included for `@ifc-lite/renderer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved selection highlighting to preserve internal edges and facets on selected objects. Visual details like creases and bends now remain visible when selecting, providing a clearer view of object geometry without obscuring structural details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->