### PR TITLE
feat(geometry): analytic rectangular-opening fast path (~3× on void-heavy buildings)

### DIFF
--- a/.changeset/rect-opening-fast-path.md
+++ b/.changeset/rect-opening-fast-path.md
@@ -1,0 +1,29 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Add an analytic fast path for rectangular openings, skipping the exact CSG kernel
+for the common case.
+
+The pure-Rust exact CSG kernel is at its single-threaded, memory-bandwidth-bound
+floor (it won't parallelise — adding geometry workers gives no speedup), and
+void-cutting is ~85-90% of load. The only remaining lever is doing *less* exact
+CSG. `rect_fast` cuts axis-aligned rectangular openings through an axis-aligned
+box host (the dominant case: windows/doors in a straight wall) with a 3D cellular
+decomposition instead of the mesh-arrangement kernel: split the host box by every
+opening plane on all three axes, mark each cell solid/void, and emit the exposed
+faces. Watertight by construction (shared snapped grid vertices on the kernel's
+own `SNAP_GRID`), deterministic (FMA-free f64 → byte-identical native==wasm), and
+handles windows, doors (flush to an edge), recesses, notches, and overlapping
+openings uniformly.
+
+It is a pure optimization: any case it can't prove safe — non-box host (multi-
+layer / chamfered / diagonal walls), non-rectangular opening, or a near-edge
+feature whose grid lines would collapse at the host's f32 magnitude — defers to
+the exact kernel unchanged. `IFC_LITE_RECT_FAST=0` forces everything back to the
+exact path.
+
+Measured (dental_clinic, a box-wall-dominated building): ~94% of openings cut
+analytically, void-cut geometry time ~0.95 s → ~0.32 s (~3×), with 2% *fewer*
+triangles (no bloat). Models with more multi-layer or diagonal walls fire less
+(those correctly defer).

--- a/rust/geometry/src/lib.rs
+++ b/rust/geometry/src/lib.rs
@@ -92,6 +92,7 @@ pub mod profile;
 pub mod profile_extractor;
 pub mod profiles;
 pub mod projection_outline;
+pub mod rect_fast;
 pub mod router;
 pub mod tessellation;
 pub mod space_dcel;

--- a/rust/geometry/src/rect_fast.rs
+++ b/rust/geometry/src/rect_fast.rs
@@ -175,17 +175,14 @@ fn aligned_box(mesh: &Mesh) -> Option<AlignedBox> {
     }
 }
 
-/// One opening projected onto the host: the through-axis `w` it penetrates, and
-/// its hole rectangle `[lo,hi]` on the two in-face axes `(u, v)`.
-struct Hole {
-    u_lo: f64,
-    u_hi: f64,
-    v_lo: f64,
-    v_hi: f64,
-}
-
 /// Result of the cut: a watertight `Mesh`, or `None` to defer to the exact
-/// kernel. `openings` are world AABBs (min,max) of the rectangular cutters.
+/// kernel. `openings` are world AABBs (min,max) of axis-aligned rectangular
+/// cutters. Handles WINDOWS, DOORS (flush to an edge), recesses, and overlapping
+/// openings uniformly via a 3D CELLULAR decomposition: split the host box by
+/// every opening plane on all three axes, mark each cell solid (in the host,
+/// outside every opening) or void, and emit each cell face that borders a void
+/// cell or the grid boundary. Watertight by construction — adjacent cells share
+/// snapped grid vertices bit-identically, so no T-junctions and no cracks.
 pub fn subtract_rect_openings(
     host: &Mesh,
     openings: &[([f64; 3], [f64; 3])],
@@ -203,142 +200,91 @@ pub fn subtract_rect_openings(
         }
     };
 
-    // Pick the through-axis `w` = the host's thinnest axis (wall thickness); the
-    // in-face axes are the other two. Every opening must penetrate along the SAME
-    // axis (a corner window cutting two axes is rare → defer).
-    let extents = [bx.max[0] - bx.min[0], bx.max[1] - bx.min[1], bx.max[2] - bx.min[2]];
-    let w = (0..3).min_by(|&i, &j| extents[i].partial_cmp(&extents[j]).unwrap()).unwrap();
-    let (u, v) = match w {
-        0 => (1usize, 2usize),
-        1 => (0usize, 2usize),
-        _ => (0usize, 1usize),
-    };
-
     // Scale-aware near-edge epsilon: two grid lines closer than this would
     // collapse into one f32 at the host's world magnitude, cracking the cut.
-    // max(|coord|) · 2^-21 keeps ≥ 4 f32 ULP between distinct lines; floored at
-    // the snap grid so origin-scale hosts stay permissive.
-    let mag = bx.min[u].abs().max(bx.max[u].abs())
-        .max(bx.min[v].abs().max(bx.max[v].abs()))
-        .max(bx.min[w].abs().max(bx.max[w].abs()));
+    // max(|coord|)·2^-21 keeps >= 4 f32 ULP between distinct lines; floored at the
+    // snap grid so origin-scale hosts stay permissive.
+    let mag = (0..3)
+        .map(|k| bx.min[k].abs().max(bx.max[k].abs()))
+        .fold(0.0f64, f64::max);
     let near_eps = (mag * (1.0 / 2_097_152.0)).max(SNAP_GRID);
 
-    // Snapped host face extents on the in-face axes + through extent.
-    let su = [snap(bx.min[u]), snap(bx.max[u])];
-    let sv = [snap(bx.min[v]), snap(bx.max[v])];
-    let sw = [snap(bx.min[w]), snap(bx.max[w])];
-
-    // Project + validate every opening into a Hole in (u,v); defer on any miss.
-    let mut holes: Vec<Hole> = Vec::with_capacity(openings.len());
+    // Clamp every opening to the host shell (a cutter extended through the wall
+    // pokes past) and keep only those that overlap on all 3 axes. A
+    // non-overlapping opening is a no-op (the SILENT NO-OP case) — drop it.
+    let mut clamped: Vec<[[f64; 3]; 2]> = Vec::with_capacity(openings.len());
     for (omn, omx) in openings {
-        // Must penetrate the full thickness along w (a through-cut): the opening
-        // span on w must cover the host on w (caps poke past, the standard
-        // `extend_opening_along_direction` guarantee).
-        if !(omn[w] <= bx.min[w] + near_eps && omx[w] >= bx.max[w] - near_eps) {
-            stats.defer_not_through += 1;
-            return None;
+        let mut cmn = [0.0; 3];
+        let mut cmx = [0.0; 3];
+        let mut overlaps = true;
+        for k in 0..3 {
+            cmn[k] = snap(omn[k].max(bx.min[k]));
+            cmx[k] = snap(omx[k].min(bx.max[k]));
+            if cmx[k] - cmn[k] <= near_eps {
+                overlaps = false;
+            }
         }
-        // Hole rect on the face = opening span clamped to the host face.
-        let u_lo = snap(omn[u].max(bx.min[u]));
-        let u_hi = snap(omx[u].min(bx.max[u]));
-        let v_lo = snap(omn[v].max(bx.min[v]));
-        let v_hi = snap(omx[v].min(bx.max[v]));
-        // Must be a proper interior hole: strictly inside the face with a real
-        // reveal on every side (≥ near_eps), and non-degenerate.
-        if !(u_lo > su[0] + near_eps
-            && u_hi < su[1] - near_eps
-            && v_lo > sv[0] + near_eps
-            && v_hi < sv[1] - near_eps
-            && u_hi - u_lo > near_eps
-            && v_hi - v_lo > near_eps)
-        {
-            stats.defer_off_face += 1;
-            return None;
+        if overlaps {
+            clamped.push([cmn, cmx]);
         }
-        holes.push(Hole { u_lo, u_hi, v_lo, v_hi });
+    }
+    if clamped.is_empty() {
+        // Nothing actually cuts — defer the no-op to the exact path (it owns the
+        // SILENT NO-OP diagnostic) rather than returning an unchanged clone.
+        stats.defer_off_face += 1;
+        return None;
     }
 
-    // Holes must be pairwise non-overlapping on the face (merged openings are
-    // disjoint; touching/overlapping → defer to the exact kernel which composes
-    // them correctly).
-    for i in 0..holes.len() {
-        for j in (i + 1)..holes.len() {
-            let a = &holes[i];
-            let b = &holes[j];
-            let disjoint = a.u_hi <= b.u_lo + near_eps
-                || b.u_hi <= a.u_lo + near_eps
-                || a.v_hi <= b.v_lo + near_eps
-                || b.v_hi <= a.v_lo + near_eps;
-            if !disjoint {
-                stats.defer_off_face += 1;
+    // Per-axis grid lines: host bounds + every clamped opening edge, snapped,
+    // sorted, deduplicated; near-coincident-but-distinct lines (< near_eps) →
+    // defer (f32-collapse risk).
+    let mut grid: [Vec<f64>; 3] = [Vec::new(), Vec::new(), Vec::new()];
+    for k in 0..3 {
+        let mut edges = vec![snap(bx.min[k]), snap(bx.max[k])];
+        for c in &clamped {
+            edges.push(c[0][k]);
+            edges.push(c[1][k]);
+        }
+        match dedup_axis(edges, near_eps) {
+            Some(g) => grid[k] = g,
+            None => {
+                stats.defer_near_edge += 1;
                 return None;
             }
         }
     }
 
-    // Build the conforming grids: every distinct snapped edge on each in-face
-    // axis becomes a grid line. Near-coincident lines (< near_eps) would collapse
-    // at f32 → defer rather than emit a cracked/degenerate cut.
-    let u_lines = match grid_lines(su, holes.iter().flat_map(|h| [h.u_lo, h.u_hi]), near_eps) {
-        Some(g) => g,
-        None => {
-            stats.defer_near_edge += 1;
-            return None;
-        }
-    };
-    let v_lines = match grid_lines(sv, holes.iter().flat_map(|h| [h.v_lo, h.v_hi]), near_eps) {
-        Some(g) => g,
-        None => {
-            stats.defer_near_edge += 1;
-            return None;
-        }
-    };
-
-    let cut = build_cut(&bx, u, v, w, &sw, &u_lines, &v_lines, &holes);
+    let cut = build_cellular(&grid, &clamped);
     stats.fired += 1;
-    stats.openings_cut += holes.len() as u64;
+    stats.openings_cut += clamped.len() as u64;
     Some(cut)
 }
 
-/// Sorted, deduplicated grid lines on one in-face axis: the two host edges plus
-/// every hole edge. Returns `None` if any two distinct lines are closer than
-/// `near_eps` (would collapse at f32 → crack/degenerate).
-fn grid_lines(
-    host: [f64; 2],
-    hole_edges: impl Iterator<Item = f64>,
-    near_eps: f64,
-) -> Option<Vec<f64>> {
-    let mut lines: Vec<f64> = vec![host[0], host[1]];
-    lines.extend(hole_edges);
-    lines.sort_by(|a, b| a.partial_cmp(b).unwrap());
-    let mut out: Vec<f64> = Vec::with_capacity(lines.len());
-    for c in lines {
+/// Sort + dedup grid lines on one axis; `None` if two DISTINCT lines are closer
+/// than `near_eps` (an f32-collapse risk → defer). Identical snapped values
+/// (e.g. a door edge coinciding with the host edge) collapse to one line.
+fn dedup_axis(mut edges: Vec<f64>, near_eps: f64) -> Option<Vec<f64>> {
+    edges.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let mut out: Vec<f64> = Vec::with_capacity(edges.len());
+    for c in edges {
         match out.last() {
-            Some(&last) if (c - last).abs() <= near_eps => {
-                // coincident within the snap → same line; but if they're
-                // distinct-but-too-close (between snap and near_eps) it's a
-                // near-edge collapse risk → defer.
-                if (c - last).abs() > 0.0 && (c - last).abs() < near_eps {
-                    return None;
+            Some(&last) => {
+                let d = (c - last).abs();
+                if d == 0.0 {
+                    // same line — keep one
+                } else if d < near_eps {
+                    return None; // distinct but too close → collapse risk
+                } else {
+                    out.push(c);
                 }
             }
-            _ => out.push(c),
+            None => out.push(c),
         }
     }
     if out.len() < 2 {
         return None;
     }
     Some(out)
-}
-
-/// Map an (u,v,w) coordinate triple (in axis order) back to a world [x,y,z].
-#[inline]
-fn world(u: usize, v: usize, w: usize, uc: f64, vc: f64, wc: f64) -> [f64; 3] {
-    let mut p = [0.0; 3];
-    p[u] = uc;
-    p[v] = vc;
-    p[w] = wc;
-    p
 }
 
 struct Builder {
@@ -378,147 +324,81 @@ impl Builder {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-fn build_cut(
-    bx: &AlignedBox,
-    u: usize,
-    v: usize,
-    w: usize,
-    sw: &[f64; 2],
-    u_lines: &[f64],
-    v_lines: &[f64],
-    holes: &[Hole],
-) -> Mesh {
+/// 3D cellular exposed-face extraction. `grid[axis]` is the sorted snapped grid
+/// lines on that axis. A cell is solid iff its centre lies outside every opening
+/// (it is always inside the host); emit every face of a solid cell that borders
+/// a void cell or the grid boundary, with the outward normal — skipping faces
+/// internal to the solid region. Watertight: a shared face between two solid
+/// cells is emitted by neither; every boundary face is emitted exactly once on
+/// the snapped grid, so reverse edges cancel bit-for-bit.
+fn build_cellular(grid: &[Vec<f64>; 3], openings: &[[[f64; 3]; 2]]) -> Mesh {
+    let nc = [grid[0].len() - 1, grid[1].len() - 1, grid[2].len() - 1];
+    let center = |axis: usize, i: usize| (grid[axis][i] + grid[axis][i + 1]) * 0.5;
+    let solid = |c: [usize; 3]| -> bool {
+        let p = [center(0, c[0]), center(1, c[1]), center(2, c[2])];
+        !openings
+            .iter()
+            .any(|o| (0..3).all(|a| p[a] > o[0][a] && p[a] < o[1][a]))
+    };
     let mut b = Builder {
         positions: Vec::new(),
         normals: Vec::new(),
         indices: Vec::new(),
     };
 
-    // outward unit normals along each axis
-    let nvec = |axis: usize, pos: bool| -> [f32; 3] {
-        let mut n = [0.0f32; 3];
-        n[axis] = if pos { 1.0 } else { -1.0 };
-        n
-    };
-
-    let cell_in_hole = |uc: f64, vc: f64| -> bool {
-        holes.iter().any(|h| uc > h.u_lo && uc < h.u_hi && vc > h.v_lo && vc < h.v_hi)
-    };
-
-    // --- Front (w = min, outward −w) and Back (w = max, outward +w): conforming
-    //     (u×v) grid, omit cells whose centre lies in a hole. ---
-    for (wi, front) in [(0usize, true), (1usize, false)] {
-        let wc = sw[wi];
-        let n = nvec(w, !front); // front face outward = −w
-        for i in 0..u_lines.len() - 1 {
-            for j in 0..v_lines.len() - 1 {
-                let (u0, u1) = (u_lines[i], u_lines[i + 1]);
-                let (v0, v1) = (v_lines[j], v_lines[j + 1]);
-                if cell_in_hole((u0 + u1) * 0.5, (v0 + v1) * 0.5) {
+    for i in 0..nc[0] {
+        for j in 0..nc[1] {
+            for k in 0..nc[2] {
+                let cell = [i, j, k];
+                if !solid(cell) {
                     continue;
                 }
-                let c00 = world(u, v, w, u0, v0, wc);
-                let c10 = world(u, v, w, u1, v0, wc);
-                let c11 = world(u, v, w, u1, v1, wc);
-                let c01 = world(u, v, w, u0, v1, wc);
-                if front {
-                    b.quad([c00, c01, c11, c10], n); // CCW seen from −w (outward)
-                } else {
-                    b.quad([c00, c10, c11, c01], n); // CCW seen from +w
+                for axis in 0..3 {
+                    let (a1, a2) = match axis {
+                        0 => (1usize, 2usize),
+                        1 => (0usize, 2usize),
+                        _ => (0usize, 1usize),
+                    };
+                    for &pos in &[false, true] {
+                        let exposed = if pos {
+                            cell[axis] == nc[axis] - 1 || !solid({
+                                let mut n = cell;
+                                n[axis] += 1;
+                                n
+                            })
+                        } else {
+                            cell[axis] == 0 || !solid({
+                                let mut n = cell;
+                                n[axis] -= 1;
+                                n
+                            })
+                        };
+                        if !exposed {
+                            continue;
+                        }
+                        let coord = grid[axis][cell[axis] + usize::from(pos)];
+                        let (lo1, hi1) = (grid[a1][cell[a1]], grid[a1][cell[a1] + 1]);
+                        let (lo2, hi2) = (grid[a2][cell[a2]], grid[a2][cell[a2] + 1]);
+                        let corner = |x1: f64, x2: f64| {
+                            let mut q = [0.0; 3];
+                            q[axis] = coord;
+                            q[a1] = x1;
+                            q[a2] = x2;
+                            q
+                        };
+                        let mut n = [0.0f32; 3];
+                        n[axis] = if pos { 1.0 } else { -1.0 };
+                        b.quad(
+                            [
+                                corner(lo1, lo2),
+                                corner(hi1, lo2),
+                                corner(hi1, hi2),
+                                corner(lo1, hi2),
+                            ],
+                            n,
+                        );
+                    }
                 }
-            }
-        }
-    }
-
-    // --- Reveal (jamb) faces: the 4 inner walls of every hole, spanning the
-    //     through-depth. CONFORMING-split along the crossing grid lines from
-    //     OTHER holes so the jamb's edge on the front/back face matches the
-    //     annulus sub-edge for sub-edge (no T-junctions). ---
-    // Grid lines strictly inside [lo,hi], plus the endpoints — the breakpoints a
-    // jamb edge must be split at to match the conforming annulus.
-    let sub = |lines: &[f64], lo: f64, hi: f64| -> Vec<f64> {
-        let mut s = vec![lo];
-        for &c in lines {
-            if c > lo && c < hi {
-                s.push(c);
-            }
-        }
-        s.push(hi);
-        s
-    };
-    let (w0, w1) = (sw[0], sw[1]);
-    for h in holes {
-        // low-u and high-u jambs: split along v.
-        let vbreaks = sub(v_lines, h.v_lo, h.v_hi);
-        for (uc, pos) in [(h.u_lo, true), (h.u_hi, false)] {
-            let n = nvec(u, pos);
-            for k in 0..vbreaks.len() - 1 {
-                let (va, vb) = (vbreaks[k], vbreaks[k + 1]);
-                b.quad(
-                    [
-                        world(u, v, w, uc, va, w0),
-                        world(u, v, w, uc, vb, w0),
-                        world(u, v, w, uc, vb, w1),
-                        world(u, v, w, uc, va, w1),
-                    ],
-                    n,
-                );
-            }
-        }
-        // sill and head jambs: split along u.
-        let ubreaks = sub(u_lines, h.u_lo, h.u_hi);
-        for (vc, pos) in [(h.v_lo, true), (h.v_hi, false)] {
-            let n = nvec(v, pos);
-            for k in 0..ubreaks.len() - 1 {
-                let (ua, ub) = (ubreaks[k], ubreaks[k + 1]);
-                b.quad(
-                    [
-                        world(u, v, w, ua, vc, w0),
-                        world(u, v, w, ub, vc, w0),
-                        world(u, v, w, ub, vc, w1),
-                        world(u, v, w, ua, vc, w1),
-                    ],
-                    n,
-                );
-            }
-        }
-    }
-
-    // --- The 4 unchanged side faces (u = min/max, v = min/max), CONFORMING-split
-    //     at the crossing grid lines so they match the annulus sub-edge for
-    //     sub-edge. Side faces at u=const span v×w; at v=const span u×w. ---
-    let su = [snap(bx.min[u]), snap(bx.max[u])];
-    let sv = [snap(bx.min[v]), snap(bx.max[v])];
-    // u = min (outward −u) and u = max (outward +u): split along v_lines.
-    for (uc, pos) in [(su[0], false), (su[1], true)] {
-        let n = nvec(u, pos);
-        for j in 0..v_lines.len() - 1 {
-            let (v0, v1) = (v_lines[j], v_lines[j + 1]);
-            let c0 = world(u, v, w, uc, v0, sw[0]);
-            let c1 = world(u, v, w, uc, v1, sw[0]);
-            let c2 = world(u, v, w, uc, v1, sw[1]);
-            let c3 = world(u, v, w, uc, v0, sw[1]);
-            if pos {
-                b.quad([c0, c1, c2, c3], n);
-            } else {
-                b.quad([c0, c3, c2, c1], n);
-            }
-        }
-    }
-    // v = min (outward −v) and v = max (outward +v): split along u_lines.
-    for (vc, pos) in [(sv[0], false), (sv[1], true)] {
-        let n = nvec(v, pos);
-        for i in 0..u_lines.len() - 1 {
-            let (u0, u1) = (u_lines[i], u_lines[i + 1]);
-            let c0 = world(u, v, w, u0, vc, sw[0]);
-            let c1 = world(u, v, w, u1, vc, sw[0]);
-            let c2 = world(u, v, w, u1, vc, sw[1]);
-            let c3 = world(u, v, w, u0, vc, sw[1]);
-            if pos {
-                b.quad([c0, c3, c2, c1], n);
-            } else {
-                b.quad([c0, c1, c2, c3], n);
             }
         }
     }
@@ -706,23 +586,52 @@ mod tests {
     }
 
     #[test]
-    fn defers_non_through_opening() {
-        // opening that does NOT span the full Y thickness (a recess, not a hole)
+    fn door_flush_to_floor_watertight() {
+        // DOOR: full thickness, z from BELOW the floor up to 2.0 → touches the
+        // wall's bottom edge (no sill reveal); the bottom face gets a hole. The
+        // case the face-based v1 deferred (off_face); cellular cuts it watertight.
         let base = [0.0, 0.0, 0.0];
-        let recess = ([1.5, 0.05, 0.5], [2.5, 0.15, 2.0]); // y inside the wall
-        let mut st = RectFastStats::default();
-        assert!(subtract_rect_openings(&wall(base), &[recess], &mut st).is_none());
-        assert_eq!(st.defer_not_through, 1);
+        let door = (
+            [base[0] + 1.5, base[1] - 0.1, base[2] - 0.5],
+            [base[0] + 2.5, base[1] + 0.3, base[2] + 2.0],
+        );
+        check_watertight(base, &[door], "door-flush-floor");
     }
 
     #[test]
-    fn defers_off_face_opening() {
-        // opening centred off the wall's X extent (touches/exceeds the edge)
+    fn edge_notch_watertight() {
+        // opening that exceeds the wall's X extent → a notch flush with the right
+        // edge (no right jamb). Was an off_face defer; cellular handles it.
         let base = [0.0, 0.0, 0.0];
-        let off = opening(base, 3.8, 4.5, 0.5, 2.0); // u_hi clamps to wall edge → no reveal
+        let notch = (
+            [base[0] + 3.8, base[1] - 0.1, base[2] + 0.5],
+            [base[0] + 4.5, base[1] + 0.3, base[2] + 2.0],
+        );
+        check_watertight(base, &[notch], "edge-notch");
+    }
+
+    #[test]
+    fn recess_cut_watertight() {
+        // RECESS: does NOT span the full thickness (a niche/pocket). Was a
+        // not_through defer; cellular cuts the pocket watertight.
+        let base = [0.0, 0.0, 0.0];
+        let recess = (
+            [base[0] + 1.5, base[1] + 0.05, base[2] + 0.5],
+            [base[0] + 2.5, base[1] + 0.15, base[2] + 2.0],
+        );
+        check_watertight(base, &[recess], "recess");
+    }
+
+    #[test]
+    fn opening_fully_outside_defers() {
+        // genuine no-op: opening entirely outside the host → no overlap → defer.
+        let base = [0.0, 0.0, 0.0];
+        let outside = (
+            [base[0] + 10.0, base[1] - 0.1, base[2] + 0.5],
+            [base[0] + 11.0, base[1] + 0.3, base[2] + 2.0],
+        );
         let mut st = RectFastStats::default();
-        assert!(subtract_rect_openings(&wall(base), &[off], &mut st).is_none());
-        assert_eq!(st.defer_off_face, 1);
+        assert!(subtract_rect_openings(&wall(base), &[outside], &mut st).is_none());
     }
 
     #[test]

--- a/rust/geometry/src/rect_fast.rs
+++ b/rust/geometry/src/rect_fast.rs
@@ -1,0 +1,710 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Analytic fast path for axis-aligned rectangular openings cut through an
+//! axis-aligned box host (the dominant case: rectangular windows/doors in a
+//! straight wall). This sidesteps the exact mesh-arrangement CSG kernel — which
+//! is at its single-threaded, memory-bandwidth-bound floor — for openings that
+//! need no exact arithmetic at all.
+//!
+//! WATERTIGHTNESS RECIPE (the make-or-break the prior `subtract_box_fast`
+//! attempt got wrong by recomputing rim coords on an incommensurate grid):
+//!   - Build the cut on ONE canonical grid whose lines are the host edges plus
+//!     every opening edge, each value SNAPPED to the kernel's own power-of-two
+//!     `SNAP_GRID = 1/65536` (the grid the host operand already lives on).
+//!   - CONFORMING-split every face by the crossing grid lines (no T-junctions):
+//!     the front/back faces become a grid of cells with hole cells omitted; the
+//!     side faces are split at the hole grid lines so their shared edge with the
+//!     annulus matches sub-edge for sub-edge.
+//!   - Every vertex reads its position from the SAME snapped grid value, so two
+//!     faces meeting at a shared line emit BIT-IDENTICAL f32 → watertight by
+//!     construction (value identity, not a numeric hash-match).
+//!   - Per-face flat normals; vertices are NEVER welded across creases (#846).
+//!
+//! GATING: this is a PURE OPTIMIZATION. It returns `None` (→ caller falls back to
+//! the exact kernel) the moment any precondition fails — non-box host, non-
+//! through opening, opening off the face, or a NEAR-EDGE feature whose grid lines
+//! would collapse into each other at the host's f32 magnitude (the robustness
+//! gate that replaces a hard dependency on the per-element local frame).
+
+use crate::mesh::Mesh;
+
+/// The kernel's reconcile grid (mesh_bridge::SNAP_GRID). Power of two ⇒ the snap
+/// is an exact f64 op ⇒ bit-deterministic native==wasm.
+const SNAP_GRID: f64 = 1.0 / 65536.0;
+
+#[inline]
+fn snap(c: f64) -> f64 {
+    (c / SNAP_GRID).round() * SNAP_GRID
+}
+
+/// Telemetry: why the fast path fired or deferred, so the real fire-rate on a
+/// void-heavy model is measurable (the prior attempt shipped at fired=0).
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RectFastStats {
+    pub fired: u64,
+    pub openings_cut: u64,
+    pub defer_host_not_box: u64,
+    pub defer_not_through: u64,
+    pub defer_off_face: u64,
+    pub defer_near_edge: u64,
+    pub defer_no_openings: u64,
+}
+
+/// An axis-aligned box AABB extracted from a host mesh, plus a check that every
+/// face is axis-aligned (the precondition for the world-coord cut).
+struct AlignedBox {
+    min: [f64; 3],
+    max: [f64; 3],
+}
+
+/// Verify `mesh` is an axis-aligned box (every triangle normal ≈ ±X/±Y/±Z, and
+/// the surface spans exactly the AABB on all 6 sides) and return its AABB.
+/// Conservative: any deviation ⇒ `None` ⇒ defer to the exact kernel.
+fn aligned_box(mesh: &Mesh) -> Option<AlignedBox> {
+    if mesh.indices.len() < 36 {
+        // a box is ≥ 12 triangles; fewer can't be a closed box
+        return None;
+    }
+    let p = |i: u32| -> [f64; 3] {
+        let b = i as usize * 3;
+        [
+            mesh.positions[b] as f64,
+            mesh.positions[b + 1] as f64,
+            mesh.positions[b + 2] as f64,
+        ]
+    };
+    let (mn_f, mx_f) = mesh.bounds();
+    let min = [mn_f.x as f64, mn_f.y as f64, mn_f.z as f64];
+    let max = [mx_f.x as f64, mx_f.y as f64, mx_f.z as f64];
+    // Degenerate extent on any axis ⇒ not a 3D box.
+    for k in 0..3 {
+        if max[k] - min[k] <= SNAP_GRID {
+            return None;
+        }
+    }
+    // Every triangle must be axis-aligned (normal along one axis) AND lie on the
+    // corresponding min or max face plane — i.e. the mesh is exactly the AABB
+    // shell, nothing protruding or interior.
+    const PLANE_TOL: f64 = 1e-4;
+    let mut seen_face = [false; 6]; // -x,+x,-y,+y,-z,+z
+    for tri in mesh.indices.chunks_exact(3) {
+        let (a, b, c) = (p(tri[0]), p(tri[1]), p(tri[2]));
+        let e1 = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+        let e2 = [c[0] - a[0], c[1] - a[1], c[2] - a[2]];
+        let n = [
+            e1[1] * e2[2] - e1[2] * e2[1],
+            e1[2] * e2[0] - e1[0] * e2[2],
+            e1[0] * e2[1] - e1[1] * e2[0],
+        ];
+        let len = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt();
+        if len == 0.0 {
+            continue; // degenerate tri — ignore (hygiene drops it anyway)
+        }
+        // which axis is the normal along?
+        let mut axis = usize::MAX;
+        for k in 0..3 {
+            if (n[k].abs() / len) > 0.999 {
+                axis = k;
+            }
+        }
+        if axis == usize::MAX {
+            return None; // a non-axis-aligned face ⇒ not an aligned box
+        }
+        // all 3 verts must sit on the min or max plane of that axis
+        let on_min = a[axis] <= min[axis] + PLANE_TOL
+            && b[axis] <= min[axis] + PLANE_TOL
+            && c[axis] <= min[axis] + PLANE_TOL;
+        let on_max = a[axis] >= max[axis] - PLANE_TOL
+            && b[axis] >= max[axis] - PLANE_TOL
+            && c[axis] >= max[axis] - PLANE_TOL;
+        if on_min {
+            seen_face[axis * 2] = true;
+        } else if on_max {
+            seen_face[axis * 2 + 1] = true;
+        } else {
+            return None; // an interior / protruding triangle ⇒ not a clean box
+        }
+    }
+    if seen_face.iter().all(|&s| s) {
+        Some(AlignedBox { min, max })
+    } else {
+        None
+    }
+}
+
+/// One opening projected onto the host: the through-axis `w` it penetrates, and
+/// its hole rectangle `[lo,hi]` on the two in-face axes `(u, v)`.
+struct Hole {
+    u_lo: f64,
+    u_hi: f64,
+    v_lo: f64,
+    v_hi: f64,
+}
+
+/// Result of the cut: a watertight `Mesh`, or `None` to defer to the exact
+/// kernel. `openings` are world AABBs (min,max) of the rectangular cutters.
+pub fn subtract_rect_openings(
+    host: &Mesh,
+    openings: &[([f64; 3], [f64; 3])],
+    stats: &mut RectFastStats,
+) -> Option<Mesh> {
+    if openings.is_empty() {
+        stats.defer_no_openings += 1;
+        return None;
+    }
+    let bx = match aligned_box(host) {
+        Some(b) => b,
+        None => {
+            stats.defer_host_not_box += 1;
+            return None;
+        }
+    };
+
+    // Pick the through-axis `w` = the host's thinnest axis (wall thickness); the
+    // in-face axes are the other two. Every opening must penetrate along the SAME
+    // axis (a corner window cutting two axes is rare → defer).
+    let extents = [bx.max[0] - bx.min[0], bx.max[1] - bx.min[1], bx.max[2] - bx.min[2]];
+    let w = (0..3).min_by(|&i, &j| extents[i].partial_cmp(&extents[j]).unwrap()).unwrap();
+    let (u, v) = match w {
+        0 => (1usize, 2usize),
+        1 => (0usize, 2usize),
+        _ => (0usize, 1usize),
+    };
+
+    // Scale-aware near-edge epsilon: two grid lines closer than this would
+    // collapse into one f32 at the host's world magnitude, cracking the cut.
+    // max(|coord|) · 2^-21 keeps ≥ 4 f32 ULP between distinct lines; floored at
+    // the snap grid so origin-scale hosts stay permissive.
+    let mag = bx.min[u].abs().max(bx.max[u].abs())
+        .max(bx.min[v].abs().max(bx.max[v].abs()))
+        .max(bx.min[w].abs().max(bx.max[w].abs()));
+    let near_eps = (mag * (1.0 / 2_097_152.0)).max(SNAP_GRID);
+
+    // Snapped host face extents on the in-face axes + through extent.
+    let su = [snap(bx.min[u]), snap(bx.max[u])];
+    let sv = [snap(bx.min[v]), snap(bx.max[v])];
+    let sw = [snap(bx.min[w]), snap(bx.max[w])];
+
+    // Project + validate every opening into a Hole in (u,v); defer on any miss.
+    let mut holes: Vec<Hole> = Vec::with_capacity(openings.len());
+    for (omn, omx) in openings {
+        // Must penetrate the full thickness along w (a through-cut): the opening
+        // span on w must cover the host on w (caps poke past, the standard
+        // `extend_opening_along_direction` guarantee).
+        if !(omn[w] <= bx.min[w] + near_eps && omx[w] >= bx.max[w] - near_eps) {
+            stats.defer_not_through += 1;
+            return None;
+        }
+        // Hole rect on the face = opening span clamped to the host face.
+        let u_lo = snap(omn[u].max(bx.min[u]));
+        let u_hi = snap(omx[u].min(bx.max[u]));
+        let v_lo = snap(omn[v].max(bx.min[v]));
+        let v_hi = snap(omx[v].min(bx.max[v]));
+        // Must be a proper interior hole: strictly inside the face with a real
+        // reveal on every side (≥ near_eps), and non-degenerate.
+        if !(u_lo > su[0] + near_eps
+            && u_hi < su[1] - near_eps
+            && v_lo > sv[0] + near_eps
+            && v_hi < sv[1] - near_eps
+            && u_hi - u_lo > near_eps
+            && v_hi - v_lo > near_eps)
+        {
+            stats.defer_off_face += 1;
+            return None;
+        }
+        holes.push(Hole { u_lo, u_hi, v_lo, v_hi });
+    }
+
+    // Holes must be pairwise non-overlapping on the face (merged openings are
+    // disjoint; touching/overlapping → defer to the exact kernel which composes
+    // them correctly).
+    for i in 0..holes.len() {
+        for j in (i + 1)..holes.len() {
+            let a = &holes[i];
+            let b = &holes[j];
+            let disjoint = a.u_hi <= b.u_lo + near_eps
+                || b.u_hi <= a.u_lo + near_eps
+                || a.v_hi <= b.v_lo + near_eps
+                || b.v_hi <= a.v_lo + near_eps;
+            if !disjoint {
+                stats.defer_off_face += 1;
+                return None;
+            }
+        }
+    }
+
+    // Build the conforming grids: every distinct snapped edge on each in-face
+    // axis becomes a grid line. Near-coincident lines (< near_eps) would collapse
+    // at f32 → defer rather than emit a cracked/degenerate cut.
+    let u_lines = match grid_lines(su, holes.iter().flat_map(|h| [h.u_lo, h.u_hi]), near_eps) {
+        Some(g) => g,
+        None => {
+            stats.defer_near_edge += 1;
+            return None;
+        }
+    };
+    let v_lines = match grid_lines(sv, holes.iter().flat_map(|h| [h.v_lo, h.v_hi]), near_eps) {
+        Some(g) => g,
+        None => {
+            stats.defer_near_edge += 1;
+            return None;
+        }
+    };
+
+    let cut = build_cut(&bx, u, v, w, &sw, &u_lines, &v_lines, &holes);
+    stats.fired += 1;
+    stats.openings_cut += holes.len() as u64;
+    Some(cut)
+}
+
+/// Sorted, deduplicated grid lines on one in-face axis: the two host edges plus
+/// every hole edge. Returns `None` if any two distinct lines are closer than
+/// `near_eps` (would collapse at f32 → crack/degenerate).
+fn grid_lines(
+    host: [f64; 2],
+    hole_edges: impl Iterator<Item = f64>,
+    near_eps: f64,
+) -> Option<Vec<f64>> {
+    let mut lines: Vec<f64> = vec![host[0], host[1]];
+    lines.extend(hole_edges);
+    lines.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let mut out: Vec<f64> = Vec::with_capacity(lines.len());
+    for c in lines {
+        match out.last() {
+            Some(&last) if (c - last).abs() <= near_eps => {
+                // coincident within the snap → same line; but if they're
+                // distinct-but-too-close (between snap and near_eps) it's a
+                // near-edge collapse risk → defer.
+                if (c - last).abs() > 0.0 && (c - last).abs() < near_eps {
+                    return None;
+                }
+            }
+            _ => out.push(c),
+        }
+    }
+    if out.len() < 2 {
+        return None;
+    }
+    Some(out)
+}
+
+/// Map an (u,v,w) coordinate triple (in axis order) back to a world [x,y,z].
+#[inline]
+fn world(u: usize, v: usize, w: usize, uc: f64, vc: f64, wc: f64) -> [f64; 3] {
+    let mut p = [0.0; 3];
+    p[u] = uc;
+    p[v] = vc;
+    p[w] = wc;
+    p
+}
+
+struct Builder {
+    positions: Vec<f32>,
+    normals: Vec<f32>,
+    indices: Vec<u32>,
+}
+
+impl Builder {
+    fn vert(&mut self, p: [f64; 3], n: [f32; 3]) -> u32 {
+        let idx = (self.positions.len() / 3) as u32;
+        self.positions.push(p[0] as f32);
+        self.positions.push(p[1] as f32);
+        self.positions.push(p[2] as f32);
+        self.normals.extend_from_slice(&n);
+        idx
+    }
+    /// A planar quad (4 coplanar world corners in perimeter order) emitted with
+    /// the winding that makes its front face point along `n` — robust to the
+    /// handedness of the (u,v,w) axis assignment (e.g. a Y-through wall is a
+    /// left-handed frame, which would otherwise invert every face).
+    fn quad(&mut self, c: [[f64; 3]; 4], n: [f32; 3]) {
+        let e1 = [c[1][0] - c[0][0], c[1][1] - c[0][1], c[1][2] - c[0][2]];
+        let e2 = [c[2][0] - c[0][0], c[2][1] - c[0][1], c[2][2] - c[0][2]];
+        let cr = [
+            e1[1] * e2[2] - e1[2] * e2[1],
+            e1[2] * e2[0] - e1[0] * e2[2],
+            e1[0] * e2[1] - e1[1] * e2[0],
+        ];
+        let dot = cr[0] * n[0] as f64 + cr[1] * n[1] as f64 + cr[2] * n[2] as f64;
+        let o = if dot >= 0.0 { [0, 1, 2, 3] } else { [0, 3, 2, 1] };
+        let v0 = self.vert(c[o[0]], n);
+        let v1 = self.vert(c[o[1]], n);
+        let v2 = self.vert(c[o[2]], n);
+        let v3 = self.vert(c[o[3]], n);
+        self.indices.extend_from_slice(&[v0, v1, v2, v0, v2, v3]);
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_cut(
+    bx: &AlignedBox,
+    u: usize,
+    v: usize,
+    w: usize,
+    sw: &[f64; 2],
+    u_lines: &[f64],
+    v_lines: &[f64],
+    holes: &[Hole],
+) -> Mesh {
+    let mut b = Builder {
+        positions: Vec::new(),
+        normals: Vec::new(),
+        indices: Vec::new(),
+    };
+
+    // outward unit normals along each axis
+    let nvec = |axis: usize, pos: bool| -> [f32; 3] {
+        let mut n = [0.0f32; 3];
+        n[axis] = if pos { 1.0 } else { -1.0 };
+        n
+    };
+
+    let cell_in_hole = |uc: f64, vc: f64| -> bool {
+        holes.iter().any(|h| uc > h.u_lo && uc < h.u_hi && vc > h.v_lo && vc < h.v_hi)
+    };
+
+    // --- Front (w = min, outward −w) and Back (w = max, outward +w): conforming
+    //     (u×v) grid, omit cells whose centre lies in a hole. ---
+    for (wi, front) in [(0usize, true), (1usize, false)] {
+        let wc = sw[wi];
+        let n = nvec(w, !front); // front face outward = −w
+        for i in 0..u_lines.len() - 1 {
+            for j in 0..v_lines.len() - 1 {
+                let (u0, u1) = (u_lines[i], u_lines[i + 1]);
+                let (v0, v1) = (v_lines[j], v_lines[j + 1]);
+                if cell_in_hole((u0 + u1) * 0.5, (v0 + v1) * 0.5) {
+                    continue;
+                }
+                let c00 = world(u, v, w, u0, v0, wc);
+                let c10 = world(u, v, w, u1, v0, wc);
+                let c11 = world(u, v, w, u1, v1, wc);
+                let c01 = world(u, v, w, u0, v1, wc);
+                if front {
+                    b.quad([c00, c01, c11, c10], n); // CCW seen from −w (outward)
+                } else {
+                    b.quad([c00, c10, c11, c01], n); // CCW seen from +w
+                }
+            }
+        }
+    }
+
+    // --- Reveal (jamb) faces: the 4 inner walls of every hole, spanning the
+    //     through-depth. CONFORMING-split along the crossing grid lines from
+    //     OTHER holes so the jamb's edge on the front/back face matches the
+    //     annulus sub-edge for sub-edge (no T-junctions). ---
+    // Grid lines strictly inside [lo,hi], plus the endpoints — the breakpoints a
+    // jamb edge must be split at to match the conforming annulus.
+    let sub = |lines: &[f64], lo: f64, hi: f64| -> Vec<f64> {
+        let mut s = vec![lo];
+        for &c in lines {
+            if c > lo && c < hi {
+                s.push(c);
+            }
+        }
+        s.push(hi);
+        s
+    };
+    let (w0, w1) = (sw[0], sw[1]);
+    for h in holes {
+        // low-u and high-u jambs: split along v.
+        let vbreaks = sub(v_lines, h.v_lo, h.v_hi);
+        for (uc, pos) in [(h.u_lo, true), (h.u_hi, false)] {
+            let n = nvec(u, pos);
+            for k in 0..vbreaks.len() - 1 {
+                let (va, vb) = (vbreaks[k], vbreaks[k + 1]);
+                b.quad(
+                    [
+                        world(u, v, w, uc, va, w0),
+                        world(u, v, w, uc, vb, w0),
+                        world(u, v, w, uc, vb, w1),
+                        world(u, v, w, uc, va, w1),
+                    ],
+                    n,
+                );
+            }
+        }
+        // sill and head jambs: split along u.
+        let ubreaks = sub(u_lines, h.u_lo, h.u_hi);
+        for (vc, pos) in [(h.v_lo, true), (h.v_hi, false)] {
+            let n = nvec(v, pos);
+            for k in 0..ubreaks.len() - 1 {
+                let (ua, ub) = (ubreaks[k], ubreaks[k + 1]);
+                b.quad(
+                    [
+                        world(u, v, w, ua, vc, w0),
+                        world(u, v, w, ub, vc, w0),
+                        world(u, v, w, ub, vc, w1),
+                        world(u, v, w, ua, vc, w1),
+                    ],
+                    n,
+                );
+            }
+        }
+    }
+
+    // --- The 4 unchanged side faces (u = min/max, v = min/max), CONFORMING-split
+    //     at the crossing grid lines so they match the annulus sub-edge for
+    //     sub-edge. Side faces at u=const span v×w; at v=const span u×w. ---
+    let su = [snap(bx.min[u]), snap(bx.max[u])];
+    let sv = [snap(bx.min[v]), snap(bx.max[v])];
+    // u = min (outward −u) and u = max (outward +u): split along v_lines.
+    for (uc, pos) in [(su[0], false), (su[1], true)] {
+        let n = nvec(u, pos);
+        for j in 0..v_lines.len() - 1 {
+            let (v0, v1) = (v_lines[j], v_lines[j + 1]);
+            let c0 = world(u, v, w, uc, v0, sw[0]);
+            let c1 = world(u, v, w, uc, v1, sw[0]);
+            let c2 = world(u, v, w, uc, v1, sw[1]);
+            let c3 = world(u, v, w, uc, v0, sw[1]);
+            if pos {
+                b.quad([c0, c1, c2, c3], n);
+            } else {
+                b.quad([c0, c3, c2, c1], n);
+            }
+        }
+    }
+    // v = min (outward −v) and v = max (outward +v): split along u_lines.
+    for (vc, pos) in [(sv[0], false), (sv[1], true)] {
+        let n = nvec(v, pos);
+        for i in 0..u_lines.len() - 1 {
+            let (u0, u1) = (u_lines[i], u_lines[i + 1]);
+            let c0 = world(u, v, w, u0, vc, sw[0]);
+            let c1 = world(u, v, w, u1, vc, sw[0]);
+            let c2 = world(u, v, w, u1, vc, sw[1]);
+            let c3 = world(u, v, w, u0, vc, sw[1]);
+            if pos {
+                b.quad([c0, c3, c2, c1], n);
+            } else {
+                b.quad([c0, c1, c2, c3], n);
+            }
+        }
+    }
+
+    let mut m = Mesh::new();
+    m.positions = b.positions;
+    m.normals = b.normals;
+    m.indices = b.indices;
+    m
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Closed axis-aligned box, 12 outward triangles.
+    fn box_mesh(min: [f64; 3], max: [f64; 3]) -> Mesh {
+        let c = [
+            [min[0], min[1], min[2]],
+            [max[0], min[1], min[2]],
+            [max[0], max[1], min[2]],
+            [min[0], max[1], min[2]],
+            [min[0], min[1], max[2]],
+            [max[0], min[1], max[2]],
+            [max[0], max[1], max[2]],
+            [min[0], max[1], max[2]],
+        ];
+        let faces: [([usize; 4], [f32; 3]); 6] = [
+            ([0, 3, 2, 1], [0.0, 0.0, -1.0]),
+            ([4, 5, 6, 7], [0.0, 0.0, 1.0]),
+            ([0, 1, 5, 4], [0.0, -1.0, 0.0]),
+            ([2, 3, 7, 6], [0.0, 1.0, 0.0]),
+            ([0, 4, 7, 3], [-1.0, 0.0, 0.0]),
+            ([1, 2, 6, 5], [1.0, 0.0, 0.0]),
+        ];
+        let mut m = Mesh::new();
+        for (idx, n) in faces {
+            let b = (m.positions.len() / 3) as u32;
+            for &i in &idx {
+                m.positions.extend_from_slice(&[c[i][0] as f32, c[i][1] as f32, c[i][2] as f32]);
+                m.normals.extend_from_slice(&n);
+            }
+            m.indices.extend_from_slice(&[b, b + 1, b + 2, b, b + 2, b + 3]);
+        }
+        m
+    }
+
+    /// DIRECTED exact-f32-bit edge audit (the production crack detector,
+    /// mesh_bridge::exact_open_edges): a watertight oriented surface has every
+    /// directed edge cancelled by its reverse — catches both cracks AND
+    /// inconsistent winding.
+    fn open_edges(m: &Mesh) -> usize {
+        use std::collections::HashMap;
+        let key = |i: u32| {
+            let b = i as usize * 3;
+            (m.positions[b].to_bits(), m.positions[b + 1].to_bits(), m.positions[b + 2].to_bits())
+        };
+        let mut edges: HashMap<_, i64> = HashMap::new();
+        for t in m.indices.chunks_exact(3) {
+            for (a, b) in [(t[0], t[1]), (t[1], t[2]), (t[2], t[0])] {
+                *edges.entry((key(a), key(b))).or_insert(0) += 1;
+                *edges.entry((key(b), key(a))).or_insert(0) -= 1;
+            }
+        }
+        edges.values().filter(|&&c| c != 0).count()
+    }
+
+    fn degenerate(m: &Mesh) -> usize {
+        let v = |i: u32| {
+            let b = i as usize * 3;
+            [m.positions[b], m.positions[b + 1], m.positions[b + 2]]
+        };
+        let mut n = 0;
+        for t in m.indices.chunks_exact(3) {
+            let (a, b, c) = (v(t[0]), v(t[1]), v(t[2]));
+            let e1 = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+            let e2 = [c[0] - a[0], c[1] - a[1], c[2] - a[2]];
+            let cr = [
+                e1[1] * e2[2] - e1[2] * e2[1],
+                e1[2] * e2[0] - e1[0] * e2[2],
+                e1[0] * e2[1] - e1[1] * e2[0],
+            ];
+            if cr[0] * cr[0] + cr[1] * cr[1] + cr[2] * cr[2] == 0.0 {
+                n += 1;
+            }
+        }
+        n
+    }
+
+    /// Signed volume × 6 (divergence), about origin.
+    fn vol6(m: &Mesh) -> f64 {
+        let v = |i: u32| {
+            let b = i as usize * 3;
+            [m.positions[b] as f64, m.positions[b + 1] as f64, m.positions[b + 2] as f64]
+        };
+        let mut s = 0.0;
+        for t in m.indices.chunks_exact(3) {
+            let (a, b, c) = (v(t[0]), v(t[1]), v(t[2]));
+            let cr = [
+                b[1] * c[2] - b[2] * c[1],
+                b[2] * c[0] - b[0] * c[2],
+                b[0] * c[1] - b[1] * c[0],
+            ];
+            s += a[0] * cr[0] + a[1] * cr[1] + a[2] * cr[2];
+        }
+        s
+    }
+
+    // 4m × 0.2m × 3m wall (thin along Y). Opening boxes poke through Y.
+    fn wall(base: [f64; 3]) -> Mesh {
+        box_mesh(base, [base[0] + 4.0, base[1] + 0.2, base[2] + 3.0])
+    }
+    fn opening(base: [f64; 3], u0: f64, u1: f64, z0: f64, z1: f64) -> ([f64; 3], [f64; 3]) {
+        (
+            [base[0] + u0, base[1] - 0.1, base[2] + z0],
+            [base[0] + u1, base[1] + 0.3, base[2] + z1],
+        )
+    }
+
+    fn check_watertight(base: [f64; 3], openings: &[([f64; 3], [f64; 3])], label: &str) {
+        let host = wall(base);
+        let mut st = RectFastStats::default();
+        let cut = subtract_rect_openings(&host, openings, &mut st)
+            .unwrap_or_else(|| panic!("{label}: expected fast path to fire, deferred: {st:?}"));
+        assert_eq!(open_edges(&cut), 0, "{label}: not watertight");
+        assert_eq!(degenerate(&cut), 0, "{label}: degenerate triangles");
+        // Removed volume ≈ Σ opening∩host volume.
+        let removed = (vol6(&host) - vol6(&cut)) / 6.0;
+        let mut expect = 0.0;
+        let (hmn, hmx) = (base, [base[0] + 4.0, base[1] + 0.2, base[2] + 3.0]);
+        for (omn, omx) in openings {
+            let mut vv = 1.0;
+            for k in 0..3 {
+                vv *= (omx[k].min(hmx[k]) - omn[k].max(hmn[k])).max(0.0);
+            }
+            expect += vv;
+        }
+        // Volume tolerance scales with f32 ULP at the host's magnitude (a wall
+        // 220 km from origin carries ~12 mm of inherent f32 error per coordinate
+        // — true of ANY f32 mesh there, exact kernel included; the cut is still
+        // watertight). Relative 2% OR absolute scale-aware, whichever is looser.
+        let mag = base[0].abs().max(base[2].abs()).max(1.0);
+        let vtol = (expect * 0.02).max(mag * 2f64.powi(-23) * 6.0);
+        assert!(
+            (removed - expect).abs() < vtol,
+            "{label}: removed {removed} != expected {expect} (tol {vtol})"
+        );
+    }
+
+    #[test]
+    fn single_opening_watertight_origin() {
+        check_watertight([0.0, 0.0, 0.0], &[opening([0.0, 0.0, 0.0], 1.5, 2.5, 0.5, 2.0)], "single-origin");
+    }
+
+    #[test]
+    fn single_opening_watertight_building_scale() {
+        check_watertight(
+            [221_534.0, 98_210.0, 47_001.0],
+            &[opening([221_534.0, 98_210.0, 47_001.0], 1.5, 2.5, 0.5, 2.0)],
+            "single-building",
+        );
+    }
+
+    #[test]
+    fn multi_opening_watertight() {
+        let base = [10.0, 5.0, 2.0];
+        let ops = [
+            opening(base, 0.4, 1.2, 0.5, 2.4),
+            opening(base, 1.6, 2.4, 0.5, 2.4),
+            opening(base, 2.8, 3.6, 0.5, 1.0),
+        ];
+        check_watertight(base, &ops, "multi-3");
+    }
+
+    #[test]
+    fn defers_non_box_host() {
+        // a tetrahedron-ish non-box host
+        let mut host = Mesh::new();
+        host.positions = vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
+        host.normals = vec![0.0; 12];
+        host.indices = vec![0, 2, 1, 0, 1, 3, 0, 3, 2, 1, 2, 3];
+        let mut st = RectFastStats::default();
+        assert!(subtract_rect_openings(&host, &[opening([0.0, 0.0, 0.0], 1.5, 2.5, 0.5, 2.0)], &mut st).is_none());
+        assert_eq!(st.defer_host_not_box, 1);
+    }
+
+    #[test]
+    fn defers_non_through_opening() {
+        // opening that does NOT span the full Y thickness (a recess, not a hole)
+        let base = [0.0, 0.0, 0.0];
+        let recess = ([1.5, 0.05, 0.5], [2.5, 0.15, 2.0]); // y inside the wall
+        let mut st = RectFastStats::default();
+        assert!(subtract_rect_openings(&wall(base), &[recess], &mut st).is_none());
+        assert_eq!(st.defer_not_through, 1);
+    }
+
+    #[test]
+    fn defers_off_face_opening() {
+        // opening centred off the wall's X extent (touches/exceeds the edge)
+        let base = [0.0, 0.0, 0.0];
+        let off = opening(base, 3.8, 4.5, 0.5, 2.0); // u_hi clamps to wall edge → no reveal
+        let mut st = RectFastStats::default();
+        assert!(subtract_rect_openings(&wall(base), &[off], &mut st).is_none());
+        assert_eq!(st.defer_off_face, 1);
+    }
+
+    #[test]
+    fn defers_near_edge_at_building_scale() {
+        // 8 µm reveal at ~220 km: below f32 ULP → must defer (the robustness gate)
+        let base = [221_534.0, 98_210.0, 47_001.0];
+        let tight = opening(base, 8e-6, 4.0 - 8e-6, 8e-6, 3.0 - 8e-6);
+        let mut st = RectFastStats::default();
+        assert!(
+            subtract_rect_openings(&wall(base), &[tight], &mut st).is_none(),
+            "near-edge at building scale must defer, not crack"
+        );
+    }
+
+    #[test]
+    fn deterministic_output() {
+        let base = [10.0, 5.0, 2.0];
+        let ops = [opening(base, 1.5, 2.5, 0.5, 2.0)];
+        let mut s1 = RectFastStats::default();
+        let mut s2 = RectFastStats::default();
+        let a = subtract_rect_openings(&wall(base), &ops, &mut s1).unwrap();
+        let b = subtract_rect_openings(&wall(base), &ops, &mut s2).unwrap();
+        assert_eq!(a.positions, b.positions);
+        assert_eq!(a.indices, b.indices);
+    }
+}

--- a/rust/geometry/src/rect_fast.rs
+++ b/rust/geometry/src/rect_fast.rs
@@ -52,6 +52,47 @@ pub struct RectFastStats {
     pub defer_no_openings: u64,
 }
 
+/// Escape hatch: `IFC_LITE_RECT_FAST=0` forces every opening back through the
+/// exact kernel (parity debugging / bisection). Default ON — the path is a pure
+/// optimization that defers on any precondition miss.
+pub fn enabled() -> bool {
+    use std::sync::OnceLock;
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| std::env::var("IFC_LITE_RECT_FAST").as_deref() != Ok("0"))
+}
+
+mod telemetry {
+    use super::RectFastStats;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static C: [AtomicU64; 7] = [const { AtomicU64::new(0) }; 7];
+    pub fn record(s: &RectFastStats) {
+        for (a, v) in C.iter().zip([
+            s.fired, s.openings_cut, s.defer_host_not_box, s.defer_not_through,
+            s.defer_off_face, s.defer_near_edge, s.defer_no_openings,
+        ]) {
+            a.fetch_add(v, Ordering::Relaxed);
+        }
+    }
+    pub fn take() -> RectFastStats {
+        let g = |i: usize| C[i].swap(0, Ordering::Relaxed);
+        RectFastStats {
+            fired: g(0), openings_cut: g(1), defer_host_not_box: g(2),
+            defer_not_through: g(3), defer_off_face: g(4), defer_near_edge: g(5),
+            defer_no_openings: g(6),
+        }
+    }
+}
+
+/// Accumulate per-cut stats into the process-global counters (for fire-rate
+/// measurement); `take_global_stats` drains them.
+pub fn record_global(stats: &RectFastStats) {
+    telemetry::record(stats);
+}
+/// Read + reset the global fire/defer counters.
+pub fn take_global_stats() -> RectFastStats {
+    telemetry::take()
+}
+
 /// An axis-aligned box AABB extracted from a host mesh, plus a check that every
 /// face is axis-aligned (the precondition for the world-coord cut).
 struct AlignedBox {

--- a/rust/geometry/src/rect_fast.rs
+++ b/rust/geometry/src/rect_fast.rs
@@ -264,7 +264,12 @@ pub fn subtract_rect_openings(
 /// than `near_eps` (an f32-collapse risk → defer). Identical snapped values
 /// (e.g. a door edge coinciding with the host edge) collapse to one line.
 fn dedup_axis(mut edges: Vec<f64>, near_eps: f64) -> Option<Vec<f64>> {
-    edges.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    // A non-finite coord (NaN/Inf from a corrupt mesh) would panic the sort under
+    // `panic=abort` and crash the whole batch — defer to the exact kernel instead.
+    if edges.iter().any(|v| !v.is_finite()) {
+        return None;
+    }
+    edges.sort_by(|a, b| a.total_cmp(b));
     let mut out: Vec<f64> = Vec::with_capacity(edges.len());
     for c in edges {
         match out.last() {

--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -1094,6 +1094,37 @@ impl GeometryRouter {
         result
     }
 
+    /// Try the analytic rectangular-opening fast path. Returns the watertight
+    /// cut mesh iff EVERY merged opening is an axis-aligned `Rectangular`
+    /// through-cut and the host is a clean axis-aligned box; otherwise `None`
+    /// (→ the exact kernel handles it). A mixed opening set defers the whole
+    /// host rather than composing analytic + exact cuts.
+    fn try_rect_fast(&self, host: &Mesh, ctx: &VoidContext) -> Option<Mesh> {
+        let (wmn, wmx) = host.bounds();
+        let wall_min = Point3::new(wmn.x as f64, wmn.y as f64, wmn.z as f64);
+        let wall_max = Point3::new(wmx.x as f64, wmx.y as f64, wmx.z as f64);
+        let mut boxes: Vec<([f64; 3], [f64; 3])> =
+            Vec::with_capacity(ctx.merged_openings.len());
+        for op in &ctx.merged_openings {
+            match op {
+                OpeningType::Rectangular(omn, omx, dir) => {
+                    let (fmn, fmx) = match dir {
+                        Some(d) => self.extend_opening_along_direction(
+                            *omn, *omx, wall_min, wall_max, *d,
+                        ),
+                        None => (*omn, *omx),
+                    };
+                    boxes.push(([fmn.x, fmn.y, fmn.z], [fmx.x, fmx.y, fmx.z]));
+                }
+                _ => return None,
+            }
+        }
+        let mut stats = crate::rect_fast::RectFastStats::default();
+        let out = crate::rect_fast::subtract_rect_openings(host, &boxes, &mut stats);
+        crate::rect_fast::record_global(&stats);
+        out
+    }
+
     fn apply_void_context_inner(&self, mesh: Mesh, ctx: &VoidContext, element_id: u32) -> Mesh {
         // Capture the input triangle count + bounds so the per-host
         // diagnostic can flag the "cuts attempted but produced no
@@ -1122,6 +1153,20 @@ impl GeometryRouter {
         // gone) with a clean opening hole. Deterministic + watertight + grid-
         // snapped; a no-op for already-planar extrusion hosts.
         let mut result = crate::facet_weld::weld_near_coplanar_facets(&mesh);
+
+        // ANALYTIC FAST PATH: an axis-aligned box host whose openings are ALL
+        // axis-aligned rectangular through-cuts is subtracted analytically
+        // (`rect_fast`), skipping the exact mesh-arrangement kernel — the
+        // ~80 s memory-bandwidth-bound void-cut window's dominant cost. Pure
+        // optimization: any precondition miss (non-box host, mixed/non-rect
+        // openings, near-edge feature) returns `None` and the host falls through
+        // to the exact path below unchanged. Fired BEFORE the dense-host
+        // subdivision (that workaround is only for the exact kernel).
+        if crate::rect_fast::enabled() {
+            if let Some(fast) = self.try_rect_fast(&result, ctx) {
+                return fast;
+            }
+        }
 
         // OPENING-DENSE HOST REFINEMENT: when many openings target the same host
         // (a window wall is usually 2 big face-triangles per side), every cut's

--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -1122,7 +1122,12 @@ impl GeometryRouter {
         let mut stats = crate::rect_fast::RectFastStats::default();
         let out = crate::rect_fast::subtract_rect_openings(host, &boxes, &mut stats);
         crate::rect_fast::record_global(&stats);
-        out
+        // The cellular cut conformingly splits EVERY face by ALL grid lines (so
+        // adjacent cells share edges → watertight), which over-fragments faces an
+        // opening doesn't reach. Run the result through the SAME coplanar merge
+        // the exact path uses (i_overlay union per plane) to collapse those back
+        // to minimal triangles — keeps it watertight and un-bloated.
+        out.map(crate::csg::ClippingProcessor::consolidate_coplanar)
     }
 
     fn apply_void_context_inner(&self, mesh: Mesh, ctx: &VoidContext, element_id: u32) -> Mesh {

--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -1169,6 +1169,15 @@ impl GeometryRouter {
         // subdivision (that workaround is only for the exact kernel).
         if crate::rect_fast::enabled() {
             if let Some(fast) = self.try_rect_fast(&result, ctx) {
+                // Same per-host cut-effect snapshot the exact path records below,
+                // so fast-path hosts aren't missing from the diagnostics.
+                self.record_host_cut_effect(
+                    element_id,
+                    tris_before,
+                    fast.triangle_count(),
+                    ctx.merged_openings.len(),
+                    host_bounds_capture,
+                );
                 return fast;
             }
         }

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -983,6 +983,34 @@ pub(super) fn drain_and_log_csg_diagnostics(
         }
     }
 
+    // rect_fast (analytic rectangular-opening fast path) engagement for this
+    // batch: fire-rate + why it deferred, so the optimization is VISIBLE in the
+    // console. Absence of this line on a build that has it means nothing fired
+    // AND nothing deferred (no rect-opening hosts in the batch); presence with
+    // fired=0 + high host_not_box means the walls aren't clean axis-aligned
+    // boxes (multi-layer / non-box) and correctly fell back to the exact kernel.
+    let rf = ifc_lite_geometry::rect_fast::take_global_stats();
+    if rf.fired > 0
+        || rf.defer_host_not_box > 0
+        || rf.defer_not_through > 0
+        || rf.defer_off_face > 0
+        || rf.defer_near_edge > 0
+    {
+        web_sys::console::info_1(
+            &format!(
+                "[IFC-LITE] rect_fast: fired={} (cut {} openings) | deferred: \
+                 host_not_box={} not_through={} off_face={} near_edge={}",
+                rf.fired,
+                rf.openings_cut,
+                rf.defer_host_not_box,
+                rf.defer_not_through,
+                rf.defer_off_face,
+                rf.defer_near_edge,
+            )
+            .into(),
+        );
+    }
+
     summary.into()
 }
 

--- a/scripts/vercel-ignore-build.sh
+++ b/scripts/vercel-ignore-build.sh
@@ -55,15 +55,31 @@ cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)" || true
 # successful deploy) is the most accurate base, BUT it usually points at a
 # commit that ISN'T in Vercel's shallow clone — `git diff` then dies with
 # "fatal: bad object <sha>", the check fails, and we deploy every time
-# (never skipping). So only use it when it's actually present in the clone;
-# otherwise fall back to HEAD^, which the shallow clone does include.
-BASE="${VERCEL_GIT_PREVIOUS_SHA:-}"
-if [ -z "$BASE" ] || ! git cat-file -e "${BASE}^{commit}" 2>/dev/null; then
-  BASE="HEAD^"
-fi
+# (never skipping). So only use it when it's actually present in the clone.
 HEAD_SHA="${VERCEL_GIT_COMMIT_SHA:-HEAD}"
 # Guard HEAD_SHA too: if Vercel's SHA isn't in the clone, use the literal HEAD.
 git cat-file -e "${HEAD_SHA}^{commit}" 2>/dev/null || HEAD_SHA="HEAD"
+
+BASE="${VERCEL_GIT_PREVIOUS_SHA:-}"
+if [ -z "$BASE" ] || ! git cat-file -e "${BASE}^{commit}" 2>/dev/null; then
+  # No previous-deploy SHA in the shallow clone — typically a branch's FIRST
+  # deploy. The old fallback (`HEAD^`) diffs only the LAST commit, which falsely
+  # SKIPS a multi-commit branch whose final commit doesn't touch a relevant path
+  # (a changeset or docs commit sitting on top of real source changes — the exact
+  # case that skipped a geometry PR's viewer preview). Diff against the merge-base
+  # with the default branch instead, so the WHOLE branch's changes are considered.
+  DEFAULT_BRANCH="${VERCEL_GIT_REPO_DEFAULT_BRANCH:-main}"
+  git fetch --quiet --depth=200 origin "$DEFAULT_BRANCH" 2>/dev/null || true
+  BASE="$(git merge-base FETCH_HEAD "$HEAD_SHA" 2>/dev/null \
+        || git merge-base "origin/${DEFAULT_BRANCH}" "$HEAD_SHA" 2>/dev/null || true)"
+  if [ -z "$BASE" ] || ! git cat-file -e "${BASE}^{commit}" 2>/dev/null; then
+    # Couldn't establish a reliable base in the shallow clone — DEPLOY. A missed
+    # skip wastes one build; a wrong skip ships a stale deploy, so deploy wins.
+    echo "⚠️  No reliable diff base (no previous deploy, no merge-base) — deploying."
+    exit 1
+  fi
+  echo "   (first deploy — diffing against merge-base ${BASE})"
+fi
 
 # Shared inputs every Rust+WASM app (viewer, viewer-embed) depends on.
 # The landing page is static and depends on NONE of these.


### PR DESCRIPTION
## Why

The pure-Rust exact CSG kernel is at its **single-threaded, memory-bandwidth-bound floor** — a `?geomWorkers` A/B sweep (#1159) proved adding geometry workers gives *zero* speedup, and void-cutting is ~85-90% of load. So the only lever left is doing **less exact CSG**.

## What

`rust/geometry/src/rect_fast.rs` — an analytic cut for the dominant case (axis-aligned rectangular openings through an axis-aligned box host: windows/doors in a straight wall), fired at the top of `apply_void_context_inner`, **before** the dense-host subdivision (an exact-kernel-only workaround).

**3D cellular decomposition:** split the host box by every clamped opening plane on all three axes → mark each cell solid (outside every opening) / void → emit each solid-cell face that borders a void cell or the grid boundary, with the outward normal. Watertight by construction: adjacent cells share snapped grid vertices **bit-identically** (no T-junctions), and a face internal to the solid region is emitted by neither neighbour. Handles **windows, doors (flush to an edge → hole in the adjacent face, no sill), recesses, notches, and overlapping openings** uniformly.

**Pure optimization** — never a correctness dependency. Any case it can't prove safe defers to the exact kernel unchanged:
- non-box host (multi-layer / chamfered / diagonal walls — verified these are the legitimate `host_not_box` defers),
- non-rectangular / mixed opening set,
- near-edge feature whose grid lines would collapse at the host's f32 magnitude (scale-aware guard — the robustness backstop that replaces a hard local-frame dependency).

`IFC_LITE_RECT_FAST=0` forces everything back to the exact kernel (parity bisection).

## Determinism

FMA-free f64 + integer SNAP_GRID (1/65536) ops + fixed iteration order → **byte-identical native==wasm**. Output is a *different but equivalent* triangulation vs the exact kernel (watertight, volume-equal), not byte-for-byte — fixtures where it fires get a one-time, correct re-triangulation.

## Measured (dental_clinic, box-wall-dominated)

| | exact | rect-fast |
|---|---|---|
| openings cut analytically | 0 | **316 (~94%)** |
| void-cut geometry time | 0.95 s | **0.32 s (~3×)** |
| total triangles | 188,291 | 184,015 (**2% fewer**) |

duplex ~54%, FZK-Haus ~29% — the difference is multi-layer/diagonal walls, which **correctly defer**.

## Tests

10 unit tests (watertight via the **directed** exact-f32-bit edge audit + correct removed-volume at origin **and** ~220 km; windows / doors / recesses / notches / multi-hole / overlap / all defer gates / deterministic) + `cdt_volume_watertight_verify` + 20 csg lib tests pass **through** the fast path (default-on). No regressions in the geometry suite (the 3 `wall_opening_cut_regression` failures are pre-existing/environmental — stale `advanced_model.ifc`; they fail identically with the fast path off, and need a fresh `pnpm fixtures`).

## Before relying on it

- **Visual spot-check** on a real model that openings render as holes (the math says watertight; a human eyeball is the last 1%).
- Measure fire-rate/speedup on a large real building (dental at 94% is the closest local proxy; infra models like 170_KM have no rect wall openings → 0 fires, expected).

## Follow-ups (not here)
- Multi-layer / non-box host coverage (the legitimate `host_not_box` frontier) — needs care to preserve internal layer boundaries.
- Coplanar-run merge if triangle count ever matters (currently 2% *under* the exact kernel, so not needed yet).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized rectangular opening subtraction with an analytic fast-path approach for improved geometry processing speed while maintaining watertightness.

* **Diagnostics**
  * Added telemetry logging to track fast-path engagement and processing outcomes.

* **Chores**
  * Improved deployment script reliability with better commit validation and fallback logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->