### PR TITLE
fix(geometry): rect-fast erases whole walls on redundant voids (#1167)

### DIFF
--- a/.changeset/rect-fast-redundant-void-guard.md
+++ b/.changeset/rect-fast-redundant-void-guard.md
@@ -1,0 +1,20 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Fix the rectangular-opening fast path erasing whole walls on redundant voids.
+
+Some authoring tools bake an opening into the wall profile AND re-add it as a
+separate opening element whose box spans the entire wall (a double-encoded /
+redundant void). The exact CSG kernel treats such a cutter as a no-op (its faces
+are coplanar with the host, so the host is returned unchanged), but the analytic
+`rect_fast` path was cutting it literally — removing the entire wall and leaving
+the window floating in a giant void (#1167).
+
+`rect_fast` now detects any opening whose clamped box contains the whole host on
+all three axes and defers the element to the exact kernel, matching its
+behaviour. Genuine interior openings (a margin on any in-face axis) are
+unaffected and still cut analytically. Verified against ~1,500 void elements
+across 13 architectural models: the only fast-vs-exact divergence was this
+whole-wall case, now gone; every normal window already removed identical volume
+on both paths.

--- a/rust/geometry/src/rect_fast.rs
+++ b/rust/geometry/src/rect_fast.rs
@@ -212,17 +212,35 @@ pub fn subtract_rect_openings(
     // Clamp every opening to the host shell (a cutter extended through the wall
     // pokes past) and keep only those that overlap on all 3 axes. A
     // non-overlapping opening is a no-op (the SILENT NO-OP case) — drop it.
+    let smin = [snap(bx.min[0]), snap(bx.min[1]), snap(bx.min[2])];
+    let smax = [snap(bx.max[0]), snap(bx.max[1]), snap(bx.max[2])];
     let mut clamped: Vec<[[f64; 3]; 2]> = Vec::with_capacity(openings.len());
     for (omn, omx) in openings {
         let mut cmn = [0.0; 3];
         let mut cmx = [0.0; 3];
         let mut overlaps = true;
+        let mut covers_full = true;
         for k in 0..3 {
             cmn[k] = snap(omn[k].max(bx.min[k]));
             cmx[k] = snap(omx[k].min(bx.max[k]));
             if cmx[k] - cmn[k] <= near_eps {
                 overlaps = false;
             }
+            // Does the clamped opening reach the host edge-to-edge on this axis?
+            if cmn[k] > smin[k] + near_eps || cmx[k] < smax[k] - near_eps {
+                covers_full = false;
+            }
+        }
+        // An opening that CONTAINS the whole host on all three axes is a
+        // degenerate / double-encoded redundant void: the void is already baked
+        // into the wall profile and re-added as an opening element (#964). The
+        // exact kernel treats it as a no-op (coplanar cutter faces → host left
+        // unchanged), so the fast path MUST NOT cut it — doing so erases the
+        // entire wall and leaves the window floating in a giant void (#1167).
+        // Defer the whole host to the exact path to match its behaviour.
+        if covers_full {
+            stats.defer_off_face += 1;
+            return None;
         }
         if overlaps {
             clamped.push([cmn, cmx]);
@@ -661,5 +679,45 @@ mod tests {
         let b = subtract_rect_openings(&wall(base), &ops, &mut s2).unwrap();
         assert_eq!(a.positions, b.positions);
         assert_eq!(a.indices, b.indices);
+    }
+
+    #[test]
+    fn redundant_whole_wall_opening_defers() {
+        // #1167: a double-encoded void (#964) whose box CONTAINS the whole wall
+        // — full width × full height, through the thickness. The exact kernel
+        // treats this as a no-op (coplanar cutter → host unchanged), so the fast
+        // path MUST defer; cutting it would erase the entire wall and leave the
+        // window floating in a giant void.
+        let base = [10.0, 5.0, 2.0];
+        let whole = opening(base, 0.0, 4.0, 0.0, 3.0); // spans the full 4 m × 3 m face
+        let mut st = RectFastStats::default();
+        assert!(
+            subtract_rect_openings(&wall(base), &[whole], &mut st).is_none(),
+            "opening that contains the whole host must defer, not erase the wall"
+        );
+        assert_eq!(st.defer_off_face, 1);
+
+        // A whole-wall opening MIXED with a genuine window still defers the host
+        // (the redundant void poisons the batch → hand the whole element to the
+        // exact path, which cuts the real window and no-ops the redundant one).
+        let mut st_mix = RectFastStats::default();
+        assert!(
+            subtract_rect_openings(
+                &wall(base),
+                &[whole, opening(base, 0.5, 1.5, 0.4, 2.6)],
+                &mut st_mix
+            )
+            .is_none(),
+            "a redundant whole-wall opening must defer the whole host"
+        );
+
+        // Sanity: a genuine interior window (margin on every in-face axis) still
+        // fires the fast path — the guard is not over-broad.
+        let mut st_ok = RectFastStats::default();
+        assert!(
+            subtract_rect_openings(&wall(base), &[opening(base, 0.5, 3.5, 0.4, 2.6)], &mut st_ok)
+                .is_some(),
+            "an interior window must still fire the fast path"
+        );
     }
 }


### PR DESCRIPTION
## Problem (#1167)

The rectangular-opening analytic fast path (`rect_fast`, shipped in #1163) was cutting **double-encoded / redundant voids** — opening elements whose box spans the *entire* wall. Some authoring tools bake a void into the wall profile **and** re-add it as a separate opening element covering the whole wall.

The exact CSG kernel treats such a cutter as a **no-op** (its faces are coplanar with the host → wall returned unchanged). The fast path cut it literally — **removing the entire wall and leaving the window floating in a giant void**.

## Fix

`subtract_rect_openings` now detects any opening whose clamped box contains the host on **all three axes** and defers the whole element to the exact kernel, matching its behaviour. A redundant whole-wall opening mixed with real windows defers the element too (the exact path then cuts the real windows and no-ops the redundant one). Genuine interior openings — a margin on any in-face axis — are unaffected and still cut analytically.

## Verification

- Swept the **fast-path vs. exact-kernel removed void volume per element** across **~1,500 void elements in 13 architectural models** (AC20-FZK, Smiley-West, duplex, schependomlaan, Office, FM_ARC_DigitalHub, S_Office, dental_clinic, two large real exports, …). The **only** divergence anywhere was this whole-wall case. After the guard: **0 over-cuts**; every normal window already removed identical volume on both paths.
- 11 `rect_fast` unit tests pass, including a new `redundant_whole_wall_opening_defers` (whole-wall defers; mixed-with-window defers; interior window still fires).

## Scope / caveat

This fixes the reproducible fast-path over-cut (erased walls). If the reported screenshot shows **normal windows in intact walls** with a too-wide reveal, that is a *separate, pre-existing* opening-larger-than-window case (loose axis-aligned box on a slightly angled wall) present in both the old and new builds — tracked separately. Asked the reporter to confirm on the issue.

Pure optimization guard — no behaviour change for any case the fast path already handled correctly. Deterministic, watertight, byte-identical native==wasm preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where certain redundant openings could incorrectly erase entire walls. The system now properly detects these cases and routes them to exact computation, while genuine interior openings continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->