### PR TITLE
fix(deps): repair broken pnpm-lock.yaml (dompurify) — unbreak main deploy

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8160,7 +8160,7 @@ snapshots:
       '@posthog/core': 1.32.1
       '@posthog/types': 1.386.1
       core-js: 3.49.0
-      dompurify: 3.4.8
+      dompurify: 3.4.11
       fflate: 0.4.8
       preact: 10.29.2
       query-selector-shadow-dom: 1.0.1


### PR DESCRIPTION
**Hotfix — main's Vercel deploy is currently failing.**

#1058 (posthog-js) was merged with a stale lockfile: its `posthog-js@1.386.1` snapshot still referenced `dompurify@3.4.8`, but #1162's Dependabot security bump had already removed that package entry (everything else resolves `dompurify@3.4.11`). The dangling reference broke `pnpm install --frozen-lockfile`:

```
ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY  Broken lockfile: no entry for 'dompurify@3.4.8'
```

posthog-js accepts `dompurify@^3.3.2`, so `pnpm install --fix-lockfile` deduped the snapshot to the already-present `3.4.11`. **One-line change.** Verified locally: `pnpm install --frozen-lockfile` now completes (exit 0).

Root cause was merging a lockfile-touching PR whose branch predated the dompurify bump — will rebase lockfile-touching PRs before merging going forward.