### PR TITLE
feat(viewer): PostHog — feature events, privacy guard, export + load-perf telemetry

### DIFF
--- a/apps/viewer/src/components/viewer/BCFPanel.tsx
+++ b/apps/viewer/src/components/viewer/BCFPanel.tsx
@@ -26,6 +26,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { useViewerStore } from '@/store';
+import { posthog } from '@/lib/analytics';
 import type { BCFTopic, BCFViewpoint } from '@ifc-lite/bcf';
 import {
   readBCF,
@@ -196,6 +197,7 @@ export function BCFPanel({ onClose }: BCFPanelProps) {
       a.click();
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
+      posthog.capture('bcf_exported', { topic_count: bcfProject.topics.size });
     } catch (error) {
       console.error('Failed to export BCF:', error);
       setBcfError(error instanceof Error ? error.message : 'Failed to export BCF file');
@@ -217,6 +219,11 @@ export function BCFPanel({ onClose }: BCFPanelProps) {
         priority: data.priority,
       });
       addTopic(topic);
+      posthog.capture('bcf_topic_created', {
+        topic_type: topic.topicType,
+        priority: topic.priority,
+        has_description: Boolean(topic.description),
+      });
       setShowCreateForm(false);
     },
     [ensureProject, bcfAuthor, addTopic]

--- a/apps/viewer/src/components/viewer/ExportDialog.tsx
+++ b/apps/viewer/src/components/viewer/ExportDialog.tsx
@@ -50,6 +50,7 @@ import {
 } from '@/components/ui/alert';
 import { Progress } from '@/components/ui/progress';
 import { useViewerStore } from '@/store';
+import { posthog } from '@/lib/analytics';
 import { useOptionalExtensionHost } from '@/sdk/ExtensionHostProvider';
 import { configureMutationView } from '@/utils/configureMutationView';
 import { toast } from '@/components/ui/toast';
@@ -327,6 +328,10 @@ export function ExportDialog({ trigger }: ExportDialogProps) {
     setExportResult(null);
     setExportProgress(null);
 
+    // Set per success branch; captured once in `finally` so a thrown export
+    // never counts. Format reflects what was actually written (the IFC5 vs
+    // STEP vs changes-JSON branch), not just the schema-derived extension.
+    let exportedFormat: string | null = null;
     try {
       // Handle merged export of all models (STEP only, not IFC5)
       if (!isIfc5 && exportScope === 'merged' && !changesOnly) {
@@ -392,6 +397,7 @@ export function ExportDialog({ trigger }: ExportDialogProps) {
         const msg = `Merged ${result.stats.modelCount} models, ${result.stats.totalEntityCount.toLocaleString()} entities`;
         setExportResult({ success: true, message: msg });
         toast.success(msg);
+        exportedFormat = 'ifc';
         return;
       }
 
@@ -465,6 +471,7 @@ export function ExportDialog({ trigger }: ExportDialogProps) {
         const ifcxMsg = `Exported IFCX: ${result.stats.nodeCount} nodes, ${result.stats.meshCount} meshes, ${result.stats.propertyCount} properties`;
         setExportResult({ success: true, message: ifcxMsg });
         toast.success(ifcxMsg);
+        exportedFormat = 'ifcx';
 
       // ── Changes only (pre-IFC5) → JSON ───────────────────────────────
       } else if (changesOnly) {
@@ -490,6 +497,7 @@ export function ExportDialog({ trigger }: ExportDialogProps) {
         const jsonMsg = `Exported ${mutations.length} changes as JSON`;
         setExportResult({ success: true, message: jsonMsg });
         toast.success(jsonMsg);
+        exportedFormat = 'json';
 
       // ── Pre-IFC5 full export → STEP ──────────────────────────────────
       } else {
@@ -555,6 +563,7 @@ export function ExportDialog({ trigger }: ExportDialogProps) {
         const stepMsg = `Exported ${result.stats.entityCount} entities (${result.stats.modifiedEntityCount} modified)`;
         setExportResult({ success: true, message: stepMsg });
         toast.success(stepMsg);
+        exportedFormat = 'ifc';
       }
     } catch (error) {
       console.error('Export failed:', error);
@@ -563,6 +572,15 @@ export function ExportDialog({ trigger }: ExportDialogProps) {
       toast.error(errMsg);
     } finally {
       setIsExporting(false);
+      if (exportedFormat) {
+        posthog.capture('export_completed', {
+          format: exportedFormat,
+          scope: exportScope,
+          changes_only: changesOnly,
+          visible_only: visibleOnly,
+          include_geometry: includeGeometry,
+        });
+      }
     }
   }, [selectedModel, selectedModelId, schema, isIfc5, exportScope, includeGeometry, applyMutations, changesOnly, visibleOnly, onlyKnownProperties, getMutationView, getLocalHiddenIds, getLocalIsolatedIds, modifiedCount, models, extensionHost, outputInfo]);
 

--- a/apps/viewer/src/components/viewer/GLBExportDialog.tsx
+++ b/apps/viewer/src/components/viewer/GLBExportDialog.tsx
@@ -40,6 +40,7 @@ import {
   AlertTitle,
 } from '@/components/ui/alert';
 import { useViewerStore } from '@/store';
+import { posthog } from '@/lib/analytics';
 import { toast } from '@/components/ui/toast';
 import { GLTFExporter } from '@ifc-lite/export';
 
@@ -232,6 +233,13 @@ export function GLBExportDialog({ trigger }: GLBExportDialogProps) {
       const msg = `Exported GLB (${(blob.size / 1024).toFixed(0)} KB)`;
       setExportResult({ success: true, message: msg });
       toast.success(msg);
+      posthog.capture('export_completed', {
+        format: 'glb',
+        visible_only: visibleOnly,
+        include_metadata: includeMetadata,
+        color_source: colorSource,
+        size_kb: Math.round(blob.size / 1024),
+      });
     } catch (err) {
       console.error('Export failed:', err);
       const errMsg = `GLB export failed: ${err instanceof Error ? err.message : 'Unknown error'}`;

--- a/apps/viewer/src/components/viewer/ScriptPanel.tsx
+++ b/apps/viewer/src/components/viewer/ScriptPanel.tsx
@@ -51,6 +51,7 @@ import {
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { cn, formatDuration } from '@/lib/utils';
 import { useViewerStore } from '@/store';
+import { posthog } from '@/lib/analytics';
 import { useSandbox } from '@/hooks/useSandbox';
 import { SCRIPT_TEMPLATES } from '@/lib/scripts/templates';
 import { CodeEditor } from './CodeEditor';
@@ -212,9 +213,16 @@ export function ScriptPanel({ onClose }: ScriptPanelProps) {
     if (executionState === 'running') return;
     const startedAt = performance.now();
     await execute(editorContent);
+    const durationMs = Math.round(performance.now() - startedAt);
     extensionHost?.emitAction('script.execute', {
       templateId: activeScriptId ?? undefined,
-      durationMs: Math.round(performance.now() - startedAt),
+      durationMs,
+    });
+    posthog.capture('script_run', {
+      from_template: activeScriptId != null,
+      template_id: activeScriptId ?? undefined,
+      duration_ms: durationMs,
+      success: useViewerStore.getState().scriptLastError == null,
     });
   }, [execute, editorContent, executionState, extensionHost, activeScriptId]);
 

--- a/apps/viewer/src/components/viewer/SunSkyPanel.tsx
+++ b/apps/viewer/src/components/viewer/SunSkyPanel.tsx
@@ -26,6 +26,7 @@ import { cn } from '@/lib/utils';
 import type { CesiumDataSource } from '@/store/slices/cesiumSlice';
 import type { SolarSweepMode } from '@/store/slices/solarSlice';
 import { LIGHTING_PRESETS, LIGHTING_PRESET_ORDER, isLightingPresetId } from '@/lib/lighting-presets';
+import { posthog } from '@/lib/analytics';
 import {
   solarDisplayOffsetMinutes,
   toSolarDateInputValue,
@@ -194,7 +195,19 @@ export function SunSkyPanel() {
                 <button
                   type="button"
                   aria-pressed={solarEnabled}
-                  onClick={() => setSolarEnabled(!solarEnabled)}
+                  onClick={() => {
+                    const next = !solarEnabled;
+                    setSolarEnabled(next);
+                    // Fire only on enable — the sun study is a live analysis,
+                    // so "turned on" is the run signal (no discrete compute step).
+                    if (next) {
+                      posthog.capture('solar_analysis_run', {
+                        sweep_mode: sweepMode,
+                        use_local_time: useLocalTime,
+                        data_source: dataSource,
+                      });
+                    }
+                  }}
                   className={cn(
                     'px-2 py-0.5 rounded text-[10px] font-semibold uppercase transition-colors',
                     solarEnabled ? 'bg-amber-500 text-zinc-950' : 'text-muted-foreground hover:bg-muted hover:text-foreground',

--- a/apps/viewer/src/components/viewer/lists/ListResultsTable.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListResultsTable.tsx
@@ -23,6 +23,7 @@ import { useViewerStore } from '@/store';
 import { getVisibleBasketEntityRefsFromStore } from '@/store/basketVisibleSet';
 import type { ListResult, ListRow, ColumnDefinition, ListGrouping } from '@ifc-lite/lists';
 import { exportList, buildExportModel, EXPORT_LABELS, type ExportFormat } from '@/lib/lists/export';
+import { posthog } from '@/lib/analytics';
 import { cn } from '@/lib/utils';
 import { columnToAutoColor } from '@/lib/lists/columnToAutoColor';
 import { AUTO_COLOR_FROM_LIST_ID } from '@/store/slices/lensSlice';
@@ -206,6 +207,13 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange 
       generatedAt: new Date().toLocaleString(),
     });
     void exportList(format, model);
+    // Counts only — never the list title or column/property names (confidential).
+    posthog.capture('export_completed', {
+      format,
+      surface: 'list_results',
+      row_count: sortedRows.length,
+      column_count: columns.length,
+    });
   }, [listName, columns, sortedRows, grouping, numericCols, columnWidths]);
 
   const handleRowClick = useCallback((row: ListRow) => {

--- a/apps/viewer/src/components/viewer/properties/GeoreferencingPanel.tsx
+++ b/apps/viewer/src/components/viewer/properties/GeoreferencingPanel.tsx
@@ -13,6 +13,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { Badge } from '@/components/ui/badge';
 import { computeAngleToGridNorth, type GeoreferenceInfo, type MapConversion, type ProjectedCRS } from '@ifc-lite/parser';
 import { useViewerStore } from '@/store';
+import { posthog } from '@/lib/analytics';
 import type { CoordinateInfo, GeometryResult } from '@ifc-lite/geometry';
 import { EpsgLookupDialog, type EpsgResult } from './EpsgLookupDialog';
 import { FederationAlignmentControls } from './FederationAlignmentControls';
@@ -467,6 +468,7 @@ export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVers
       ? mergedCRS?.[field as keyof ProjectedCRS]
       : mergedConversion?.[field as keyof MapConversion];
     setGeorefField(modelId, entity, field, value, oldValue as string | number | undefined);
+    posthog.capture('georeference_set', { method: 'crs_field', entity, field });
     requestAlignmentReload();
   }, [modelId, setGeorefField, mergedCRS, mergedConversion, requestAlignmentReload]);
 
@@ -477,6 +479,7 @@ export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVers
       { field: 'xAxisAbscissa', value: abscissa, oldValue: mergedConversion?.xAxisAbscissa },
       { field: 'xAxisOrdinate', value: ordinate, oldValue: mergedConversion?.xAxisOrdinate },
     ]);
+    posthog.capture('georeference_set', { method: 'true_north' });
     requestAlignmentReload();
   }, [modelId, setGeorefFields, mergedConversion, requestAlignmentReload]);
 
@@ -498,6 +501,10 @@ export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVers
       });
     }
     setGeorefFields(modelId, 'mapConversion', fields);
+    posthog.capture('georeference_set', {
+      method: 'map_pick',
+      has_terrain_height: position.terrainHeight !== null,
+    });
     setConversionOpen(true);
     requestAlignmentReload();
   }, [modelId, setGeorefFields, mergedConversion, requestAlignmentReload, oHeightForBaseAltitude]);

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -492,7 +492,7 @@ export function useIfcLoader() {
           pointCloudHandleId: ingest.rendererHandle.id,
         });
         setProgress({ phase: 'Complete', percent: 100 });
-        posthog.capture('ifc_model_loaded', { format, file_size_mb: Math.round(fileSizeMB * 100) / 100, load_target: target.kind, load_path: 'point-cloud' });
+        posthog.capture('ifc_model_loaded', { format, file_size_mb: Math.round(fileSizeMB * 100) / 100, load_target: target.kind, load_path: 'point-cloud', total_elapsed_ms: Math.round(performance.now() - totalStartTime) });
         setLoading(false);
         return;
       }
@@ -511,7 +511,7 @@ export function useIfcLoader() {
           await finalizeModel(result.dataStore, result.geometryResult, result.schemaVersion);
 
           setProgress({ phase: 'Complete', percent: 100 });
-          posthog.capture('ifc_model_loaded', { format: 'ifcx', file_size_mb: Math.round(fileSizeMB * 100) / 100, load_target: target.kind, load_path: 'wasm' });
+          posthog.capture('ifc_model_loaded', { format: 'ifcx', file_size_mb: Math.round(fileSizeMB * 100) / 100, load_target: target.kind, load_path: 'wasm', total_elapsed_ms: Math.round(performance.now() - totalStartTime) });
           setLoading(false);
           return;
         } catch (err: unknown) {
@@ -553,7 +553,7 @@ export function useIfcLoader() {
           );
 
           setProgress({ phase: 'Complete', percent: 100 });
-          posthog.capture('ifc_model_loaded', { format: 'glb', file_size_mb: Math.round(fileSizeMB * 100) / 100, load_target: target.kind, load_path: 'wasm' });
+          posthog.capture('ifc_model_loaded', { format: 'glb', file_size_mb: Math.round(fileSizeMB * 100) / 100, load_target: target.kind, load_path: 'wasm', total_elapsed_ms: Math.round(performance.now() - totalStartTime) });
           setLoading(false);
           return;
         } catch (err: unknown) {
@@ -598,7 +598,7 @@ export function useIfcLoader() {
               cacheState: 'hit',
             });
             console.log(`[useIfc] TOTAL LOAD TIME (from cache): ${(performance.now() - totalStartTime).toFixed(0)}ms`);
-            posthog.capture('ifc_model_loaded', { format, file_size_mb: Math.round(fileSizeMB * 100) / 100, load_target: target.kind, load_path: 'cache' });
+            posthog.capture('ifc_model_loaded', { format, file_size_mb: Math.round(fileSizeMB * 100) / 100, load_target: target.kind, load_path: 'cache', total_elapsed_ms: Math.round(performance.now() - totalStartTime) });
             setLoading(false);
             return;
           }
@@ -621,7 +621,7 @@ export function useIfcLoader() {
           const state = useViewerStore.getState();
           await finalizeModel(state.ifcDataStore, state.geometryResult, getSchemaVersion(state.ifcDataStore));
           console.log(`[useIfc] TOTAL LOAD TIME (server): ${(performance.now() - totalStartTime).toFixed(0)}ms`);
-          posthog.capture('ifc_model_loaded', { format, file_size_mb: Math.round(fileSizeMB * 100) / 100, load_target: target.kind, load_path: 'server' });
+          posthog.capture('ifc_model_loaded', { format, file_size_mb: Math.round(fileSizeMB * 100) / 100, load_target: target.kind, load_path: 'server', total_elapsed_ms: Math.round(performance.now() - totalStartTime) });
           setLoading(false);
           return;
         }
@@ -1209,6 +1209,17 @@ export function useIfcLoader() {
         load_path: 'wasm',
         mesh_count: allMeshes.length,
         total_elapsed_ms: Math.round(totalElapsedMs),
+        // Field perf telemetry: vertices/triangles size the model, and the
+        // milestones (read → metadata → first batch → first paint → stream
+        // done) let us spot where real-world loads regress. CSG itself runs
+        // in the geometry workers, so the stream window is its best proxy.
+        total_vertices: totalVertices,
+        total_triangles: allMeshes.reduce((sum, m) => sum + m.indices.length / 3, 0),
+        file_read_ms: Math.round(fileReadMs),
+        metadata_complete_ms: metadataCompleteMs != null ? Math.round(metadataCompleteMs) : undefined,
+        first_geometry_batch_ms: firstAppendGeometryBatchMs != null ? Math.round(firstAppendGeometryBatchMs) : undefined,
+        first_visible_geometry_ms: firstVisibleGeometryMs != null ? Math.round(firstVisibleGeometryMs) : undefined,
+        stream_complete_ms: streamCompleteMs != null ? Math.round(streamCompleteMs) : undefined,
       });
       setLoading(false);
       setGeometryStreamingActive(false);

--- a/apps/viewer/src/hooks/useLens.ts
+++ b/apps/viewer/src/hooks/useLens.ts
@@ -26,6 +26,7 @@ import { useEffect, useRef, useMemo } from 'react';
 import { evaluateLens, evaluateAutoColorLens, rgbaToHex, isGhostColor } from '@ifc-lite/lens';
 import type { AutoColorEvaluationResult } from '@ifc-lite/lens';
 import { useViewerStore } from '@/store';
+import { posthog } from '@/lib/analytics';
 import { createLensDataProvider } from '@/lib/lens';
 import { useLensDiscovery } from './useLensDiscovery';
 
@@ -109,6 +110,14 @@ export function useLens() {
     if (colorMap.size > 0) {
       useViewerStore.getState().setPendingColorUpdates(colorMap);
     }
+
+    posthog.capture('lens_applied', {
+      mode: isAutoColor ? 'auto_color' : 'rules',
+      rule_count: activeLens.rules.length,
+      auto_color_source: isAutoColor ? activeLens.autoColor?.source : undefined,
+      matched_entity_count: colorMap.size,
+      hidden_entity_count: hiddenIds.size,
+    });
   }, [activeLensId, activeLens]);
 
   return {

--- a/apps/viewer/src/lib/analytics.ts
+++ b/apps/viewer/src/lib/analytics.ts
@@ -22,6 +22,60 @@ const enabled = Boolean(key && host) && typeof posthogClient?.init === 'function
 // narrow type is what keeps keyless/Node environments crash-free.
 type AnalyticsClient = Pick<typeof posthogClient, 'capture' | 'captureException'>;
 
+// ── Privacy guard ──────────────────────────────────────────────────────────
+// ifc-lite opens confidential client building models, so the rule that keeps
+// file / pset / property names out of git applies to analytics too: NO event
+// may carry a file name, model name, BCF title, free text, or a filesystem
+// path — even accidentally from a future call site. `scrubEvent` runs on every
+// captured event (including PostHog's own $pageleave / $exception) as a safety
+// net on top of the deliberately lean explicit properties.
+
+// Keys whose values tend to be PII / free text / confidential identifiers.
+// Matches whole `_`-delimited words, so analytics keys like `data_source`,
+// `auto_color_source`, `template_id` or `field` are deliberately left intact.
+const SENSITIVE_KEY =
+  /(?:^|_)(?:name|filename|model|title|label|path|url|uri|href|email|author|comment|description|message|content|query|sql|expression|psetname|propertyname)(?:$|_)/i;
+
+// PostHog auto-properties that are URLs — keep the route, drop query + hash
+// (a share link can encode a model id or token).
+const URL_KEYS = new Set<string>([
+  '$current_url', '$referrer', '$referring_domain', '$pathname',
+  '$initial_current_url', '$initial_referrer', '$initial_referring_domain',
+  '$prev_pageview_pathname',
+]);
+
+// String values that look like a filesystem path or a building-model file name.
+const PATHISH =
+  /[\\/][^\\/]*\.(?:ifc|ifcx|ifczip|bcf|bcfzip|glb|gltf|obj|csv|xlsx|pdf|json|step|stp|las|laz)\b|^(?:file|blob):|^[A-Za-z]:\\|\/Users\/|\/home\//i;
+
+const stripQueryAndHash = (value: string): string => {
+  const cut = value.search(/[?#]/);
+  return cut === -1 ? value : value.slice(0, cut);
+};
+
+const scrubProperties = (props: Record<string, unknown> | undefined): void => {
+  if (!props) return;
+  for (const k of Object.keys(props)) {
+    if (SENSITIVE_KEY.test(k)) {
+      delete props[k];
+      continue;
+    }
+    const v = props[k];
+    if (typeof v === 'string') {
+      if (URL_KEYS.has(k)) props[k] = stripQueryAndHash(v);
+      else if (PATHISH.test(v)) props[k] = '[redacted]';
+    }
+  }
+};
+
+// `before_send` shape: (event | null) => (event | null). Mutating properties in
+// place keeps PostHog's event intact; returning null would drop it entirely.
+// Generic so it satisfies posthog-js's BeforeSendFn (CaptureResult) signature.
+const scrubEvent = <T extends { properties?: Record<string, unknown> } | null>(event: T): T => {
+  if (event) scrubProperties(event.properties);
+  return event;
+};
+
 let client: AnalyticsClient | null = null;
 if (enabled) {
   try {
@@ -34,6 +88,9 @@ if (enabled) {
       capture_pageview: false,
       capture_pageleave: true,
       autocapture: false,
+      // Strip any file name / model name / path / free text from every event
+      // (current + future) before it leaves the browser. See scrubEvent above.
+      before_send: scrubEvent,
     });
     client = posthogClient;
   } catch (err) {


### PR DESCRIPTION
## What

Brings PostHog to full coverage across the viewer: the remaining feature events, plus three cross-cutting analytics improvements (privacy guard, export funnel, load-perf telemetry).

### 1. Feature events (commit 1)
| Event | Where | Properties |
|---|---|---|
| `bcf_topic_created` | `BCFPanel.handleCreateTopic` | `topic_type`, `priority`, `has_description` |
| `bcf_exported` | `BCFPanel.handleExport` | `topic_count` |
| `script_run` | `ScriptPanel.handleRun` | `from_template`, `template_id`, `duration_ms`, `success` |
| `lens_applied` | `useLens` (on evaluation) | `mode`, `rule_count`, `auto_color_source`, `matched_entity_count`, `hidden_entity_count` |
| `georeference_set` | `GeoreferencingPanel` (3 paths) | `method` = `crs_field` \| `true_north` \| `map_pick` |
| `solar_analysis_run` | `SunSkyPanel` (sun-study toggle) | `sweep_mode`, `use_local_time`, `data_source` |

Already wired on `main` (unchanged): `ids_validation_completed`, `clash_detection_run`, `model_compare_run`, `drawing_exported`, `ifc_model_loaded`, `ids_report_exported`, `ai_chat_message_sent`, `byok_key_saved`.

### 2. Privacy guard (commit 2)
`analytics.ts` now installs a `before_send` sanitizer that runs on **every** event (including PostHog's own `$pageleave` / `$exception`):
- deletes sensitive property keys (`name`/`file`/`model`/`title`/`path`/`url`/`author`/`comment`/`description`/pset+property names) — whole-`_`-word matching, so `data_source`/`template_id`/`field` survive
- strips query + hash from URL auto-properties (a share link can encode a model id/token)
- redacts string values that look like a filesystem path or model file name

Rationale: ifc-lite opens confidential client building models, so the "nothing private in git" rule extends to analytics — this is a safety net on top of the already-lean explicit properties, covering future call sites too.

### 3. export_completed (commit 2)
Instruments the export surfaces that weren't tracked, complementing `drawing_exported` / `ids_report_exported`:
- **ExportDialog** → `ifc` / `ifcx` / `json` (changes) — captured in `finally`, gated on a per-branch success flag, so a thrown export never counts
- **GLBExportDialog** → `glb`
- **List/query results table** → `csv` / `xlsx` / `pdf` (counts only, never the list title or column/property names)

### 4. Load-perf telemetry (commit 2)
Extends `ifc_model_loaded` (you're perf-focused — CSG bottleneck, watchdog, benchmark):
- WASM path: `total_vertices`, `total_triangles`, and milestones `file_read_ms` / `metadata_complete_ms` / `first_geometry_batch_ms` / `first_visible_geometry_ms` / `stream_complete_ms` (CSG runs in the geometry workers, so the stream window is its best proxy)
- `total_elapsed_ms` added to the point-cloud / ifcx / glb / cache / server paths for a uniform core metric

## Design notes
- **Solar** has no discrete "run" — the sun study is live, so the event fires on enable.
- **Georeference** has no single funnel, so all three user edit paths are tagged with a `method` discriminator.
- All calls route through the noop-safe `@/lib/analytics` helper → keyless / Node-test builds stay crash-free.

## Verification
- `tsc --noEmit` on the viewer: **zero errors in any edited file**. Remaining errors in this checkout are environmental (uninstalled `posthog-js`/`jszip`/`@ifc-lite/wasm`, all CI-built) plus pre-existing SpacePlate errors on `main`.
- Only `apps/viewer` is touched (no `@ifc-lite/*` package) → no changeset needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added PostHog analytics instrumentation for BCF export, script runs, solar (sun study) analysis, georeferencing edits, lens overlay application, and list/GLB export completion.
  * Enhanced IFC loading telemetry with additional performance/geometry metrics.
  * Improved export analytics accuracy by reporting the actual output format when downloads succeed.
  * Introduced a client-side privacy scrubbing layer to redact sensitive event properties before analytics are sent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->