### PR TITLE
perf(geometry): default content-dedup OFF — it became a net loss after rect_fast

### DIFF
--- a/.changeset/content-dedup-default-off.md
+++ b/.changeset/content-dedup-default-off.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Default content-dedup OFF on the production geometry paths — it was making large-model loads slower, not faster.
+
+The item-level content-dedup (skip re-meshing structurally-identical representation items) builds its 128-bit structural key by recursively decoding the *entire* item subtree (every face, loop, and point entity) with the general decoder — roughly 3.5× more work than the mesher's cached decode of the same item. On real models the hash therefore costs more than the meshing it skips: measured on two large structural models, loads were **20–30% slower** with dedup on (it only paid off at near-100% duplicate hit-rate). Gated both production batch paths (native rayon pool + wasm) behind `GeometryRouter::content_dedup_enabled()` (default `false`); geometry output is byte-identical. The separate `IfcMappedItem` instancing cache is unaffected. A follow-up will make the structural hash walk the cached fast paths so dedup can be re-enabled as a net win.

--- a/rust/geometry/src/router/mod.rs
+++ b/rust/geometry/src/router/mod.rs
@@ -352,6 +352,19 @@ impl GeometryRouter {
         Arc::new(Mutex::new(FxHashMap::default()))
     }
 
+    /// Whether content-dedup is enabled on the PRODUCTION batch paths (native
+    /// rayon pool + wasm). Default OFF: `content_hash::item_signature` builds the
+    /// structural key by recursively `decode_by_id`-ing the ENTIRE item subtree
+    /// (every face/loop/point) with the slow general decoder — ~3.5x MORE work
+    /// than the mesher's cached decode of the same item. Measured on two large
+    /// real models the hash costs more than the meshing it skips, so dedup made
+    /// load 20-30% SLOWER (it was a net win only at near-100% duplicate hit-rate).
+    /// Flip back to `true` once `item_signature` walks via the cached fast paths.
+    /// The separate `IfcMappedItem` instancing cache is always on regardless.
+    pub fn content_dedup_enabled() -> bool {
+        false
+    }
+
     /// Inject a shared item-dedup cache (see [`Self::new_dedup_cache`]) into this
     /// router. All routers given the SAME `Arc` dedup against one cache, so
     /// byte-identical geometry is meshed once across the whole model regardless of

--- a/rust/processing/src/processor.rs
+++ b/rust/processing/src/processor.rs
@@ -1755,7 +1755,11 @@ fn process_entity_job(
 
     let mut local_router = GeometryRouter::with_scale_and_quality(unit_scale, tessellation_quality);
     local_router.set_rtc_offset(rtc_offset);
-    local_router.enable_content_dedup_shared(item_dedup_cache.clone());
+    // content-dedup default OFF: its structural hash costs more than the meshing
+    // it skips on real models (see GeometryRouter::content_dedup_enabled).
+    if GeometryRouter::content_dedup_enabled() {
+        local_router.enable_content_dedup_shared(item_dedup_cache.clone());
+    }
     let local_router = local_router;
 
     let metadata = crate::element::ElementMeshMetadata {

--- a/rust/wasm-bindings/src/api/gpu_meshes.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes.rs
@@ -804,7 +804,9 @@ impl IfcAPI {
         // Arm content-dedup against the per-worker shared cache so byte-identical
         // geometry (e.g. Tekla parts the exporter failed to share via
         // IfcMappedItem) is meshed ONCE across batches, not once per batch.
-        {
+        // content-dedup default OFF: its structural hash costs more than the
+        // meshing it skips on real models (see GeometryRouter::content_dedup_enabled).
+        if GeometryRouter::content_dedup_enabled() {
             let mut slot = self
                 .cached_item_dedup
                 .lock()


### PR DESCRIPTION
## What

Default the item-level content-dedup **off** on both production geometry batch paths (native rayon pool + wasm), behind `GeometryRouter::content_dedup_enabled()` (currently `false`). Geometry output is byte-identical; the separate `IfcMappedItem` instancing cache is unaffected; `with_units` and the `dedup_validate` tests still arm dedup explicitly.

## Why — measured

Profiling large-model load to find the real bottleneck (CSG is no longer it — rect_fast reduced it to <10% of load; meshing dominates), content-dedup turned out to be a **net loss**:

| model | dedup ON | dedup OFF | result |
|---|---|---|---|
| ~722 MB structural | 14.9 s | 12.0 s | **+20% slower with dedup** |
| ~1 GB structural | 9.8 s | 6.9 s | **+30% slower with dedup** |

`content_hash::item_signature` builds the 128-bit structural key by recursively `decode_by_id`-ing the **entire** item subtree (every face, loop, and point entity) with the general decoder — instrumented at **6.5 s of hashing vs 1.9 s of meshing** on the larger model (hit-rate 47%). The "shortcut to skip meshing" decodes ~3.5× more than the meshing it skips.

The root cause is a shifted baseline: dedup was introduced when the exact CSG kernel was 20–40× slower per cut and re-CSG'ing duplicate Tekla parts dominated load. **rect_fast (#1163) made that CSG cheap**, so the hash now dominates and dedup only pays off at near-100% duplicate hit-rate with expensive per-item compute — not the common case.

## Follow-up

A cheap-hash rewrite (walk the cached fast paths instead of `decode_by_id`) was prototyped; it only flips dedup back to a **marginal ~1 s win** here because the meshing it saves is itself cheap, so it isn't worth the hash-vs-mesher sync risk yet. Left as a documented follow-up (the `content_dedup_enabled()` gate flips back on once the hash is cheap) for if an expensive-per-item + high-duplicate model appears.

Byte-identical geometry; pure load-time win.