### PR TITLE
fix(viewer): drop Cesium RequestErrorEvent tile failures from PostHog error tracking

### DIFF
--- a/apps/viewer/src/lib/analytics.ts
+++ b/apps/viewer/src/lib/analytics.ts
@@ -68,11 +68,46 @@ const scrubProperties = (props: Record<string, unknown> | undefined): void => {
   }
 };
 
-// `before_send` shape: (event | null) => (event | null). Mutating properties in
-// place keeps PostHog's event intact; returning null would drop it entirely.
-// Generic so it satisfies posthog-js's BeforeSendFn (CaptureResult) signature.
-const scrubEvent = <T extends { properties?: Record<string, unknown> } | null>(event: T): T => {
-  if (event) scrubProperties(event.properties);
+// ── Noise filter ───────────────────────────────────────────────────────────
+// Cesium rejects failed tile / terrain / imagery / ion-asset requests with a
+// `RequestErrorEvent` — a plain `{ statusCode, response, responseHeaders }`
+// object, not an Error. During continuous globe rendering these fire from deep
+// inside Cesium's request scheduler (a tile 403/404/429/timeout), so the geo
+// call sites we own (all `try/catch`-wrapped) can't intercept them, and they
+// surface as unhandled rejections that PostHog's exception autocapture records.
+// They are unactionable third-party network failures, not ifc-lite bugs, so we
+// drop the `$exception` event entirely. Match on Cesium's stable property-name
+// shape (those three keys), NOT the minified class name (`D_`), which changes
+// every build. posthog-js stringifies a non-Error throwable as
+// "'<ctor>' captured as exception with keys: <comma-separated own keys>".
+const CESIUM_REQUEST_ERROR =
+  /captured as exception with keys:(?=[^]*\bstatusCode\b)(?=[^]*\bresponse\b)(?=[^]*\bresponseHeaders\b)/;
+
+const isUnactionableThirdPartyException = (
+  event: { event?: string; properties?: Record<string, unknown> },
+): boolean => {
+  if (event.event !== '$exception') return false;
+  const list = event.properties?.$exception_list;
+  if (!Array.isArray(list)) return false;
+  return list.some(
+    (e) =>
+      typeof (e as { value?: unknown })?.value === 'string' &&
+      CESIUM_REQUEST_ERROR.test((e as { value: string }).value),
+  );
+};
+
+// `before_send` shape: (event | null) => (event | null). Returning null drops
+// the event (noise filter above); otherwise we mutate properties in place,
+// which keeps PostHog's event intact. Generic so it satisfies posthog-js's
+// BeforeSendFn (CaptureResult) signature.
+const scrubEvent = <
+  T extends { event?: string; properties?: Record<string, unknown> } | null,
+>(
+  event: T,
+): T | null => {
+  if (!event) return event;
+  if (isUnactionableThirdPartyException(event)) return null;
+  scrubProperties(event.properties);
   return event;
 };
 


### PR DESCRIPTION
## What

Closes #1175 — the PostHog error `'D_' captured as exception with keys: response, responseHeaders, statusCode`.

## Diagnosis

The captured exception is a **Cesium `RequestErrorEvent`**, not an app bug:

- Cesium `reject()`s a failed tile / terrain / imagery / ion-asset request with a `RequestErrorEvent` — a plain `{ statusCode, response, responseHeaders }` object (those three keys are an exact match), **not** an `Error`.
- The mechanism in PostHog is `handled: false, synthetic: true` with **no app stack frames** — i.e. an unhandled promise rejection that PostHog's exception autocapture coerced into a synthetic `Error`. `D_` is the minified class name (`RequestErrorEvent`).
- These fire from **deep inside Cesium's request scheduler** during continuous globe rendering (a tile `403`/`404`/`429`/timeout). Every geo call site we own (`createWorldImageryAsync`, `CesiumTerrainProvider.fromIonAssetId`, `createOsmBuildingsAsync`, `createGooglePhotorealistic3DTileset`, …) is already `await`-ed inside `try/catch`, so there is no app-level catch we can add — the rejection originates below our code.

They are unactionable third-party network failures, so they should not pollute error tracking.

## Fix

Drop the `$exception` event in the existing `before_send` privacy/quality guard in `apps/viewer/src/lib/analytics.ts` — the natural home for this telemetry policy. The matcher keys on Cesium's **stable property-name shape** (`response` + `responseHeaders` + `statusCode` in PostHog's "captured as exception with keys: …" string) rather than the minified class name `D_`, which changes every build. A real app `Error` (normal stack, not a non-Error throwable with those three keys) is unaffected.

## Verification

Isolated typecheck + runtime check against the real `@posthog/types`:

- `before_send: scrubEvent` type-checks against `BeforeSendFn` (`(cr: CaptureResult | null) => CaptureResult | null`).
- The Cesium `RequestErrorEvent` sample event → **dropped** (`null`).
- A real `TypeError` sample event → **kept** (no false positives).

No changeset: `@ifc-lite/viewer` is the deployed app, not a release-managed library (matching PR #1174, which edited this same file without one).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analytics quality by filtering out non-actionable request failure events, reducing noise in error tracking and enabling better issue prioritization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->