### PR TITLE
fix(viewer): copy Cesium runtime assets to /cesium so the map renders (#1139)

### DIFF
--- a/apps/viewer/vite-plugins/cesium-assets.ts
+++ b/apps/viewer/vite-plugins/cesium-assets.ts
@@ -1,0 +1,91 @@
+import path from 'node:path';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import type { Plugin } from 'vite';
+
+const require = createRequire(import.meta.url);
+
+// CesiumJS loads its prebuilt Workers / Assets / Widgets / ThirdParty at runtime
+// from CESIUM_BASE_URL (= '/cesium', set in vite.config's `define`), so they must
+// sit at  <outDir>/cesium/<Subdir>/…  and be served at  /cesium/<Subdir>/…  in dev.
+//
+// We copy them ourselves rather than via vite-plugin-static-copy: in its v4 line
+// the plugin rebuilds each destination from the file's path *relative to the Vite
+// root*, so an absolute node_modules source lands every file under
+//   <outDir>/cesium/node_modules/.pnpm/cesium@<v>/node_modules/cesium/Build/Cesium/…
+// instead of <outDir>/cesium/…  → every /cesium/Assets|Workers/… request 404'd in
+// production and the Cesium globe never rendered (#1139). Its stripBase escape
+// hatch is static and would flatten Cesium's nested Assets/Textures tree. A plain
+// recursive copy is deterministic and package-manager-agnostic.
+const CESIUM_SUBDIRS = ['Workers', 'ThirdParty', 'Assets', 'Widgets'] as const;
+
+const CESIUM_DEV_MIME: Record<string, string> = {
+  '.js': 'text/javascript', '.mjs': 'text/javascript', '.css': 'text/css',
+  '.json': 'application/json', '.wasm': 'application/wasm', '.png': 'image/png',
+  '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg', '.gif': 'image/gif',
+  '.svg': 'image/svg+xml', '.xml': 'application/xml',
+};
+
+export function cesiumStaticAssets(): Plugin {
+  const cesiumBuild = path.join(
+    path.dirname(require.resolve('cesium/package.json')),
+    'Build',
+    'Cesium',
+  );
+  // Fail loud at config time if the prebuilt assets aren't where we expect —
+  // a silent miss here is exactly how #1139 shipped a broken map.
+  for (const sub of CESIUM_SUBDIRS) {
+    if (!fs.existsSync(path.join(cesiumBuild, sub))) {
+      throw new Error(`[cesium-assets] missing ${sub} under ${cesiumBuild}`);
+    }
+  }
+
+  let resolvedOutDir = 'dist';
+  return {
+    name: 'ifc-lite:cesium-static-assets',
+    configResolved(config) {
+      resolvedOutDir = path.resolve(config.root, config.build.outDir);
+    },
+    // Build: recursive-copy the subdirs flat under <outDir>/cesium.
+    async closeBundle() {
+      const dest = path.join(resolvedOutDir, 'cesium');
+      await Promise.all(
+        CESIUM_SUBDIRS.map((sub) =>
+          fs.promises.cp(path.join(cesiumBuild, sub), path.join(dest, sub), {
+            recursive: true,
+          }),
+        ),
+      );
+    },
+    // Dev: serve /cesium/* straight from the Cesium package (connect strips the
+    // '/cesium' mount prefix, so req.url is already the in-package path).
+    configureServer(server) {
+      server.middlewares.use('/cesium', (req, res, next) => {
+        if (req.method !== 'GET' && req.method !== 'HEAD') return next();
+        const rel = decodeURIComponent((req.url ?? '/').split('?')[0]);
+        const filePath = path.normalize(path.join(cesiumBuild, rel));
+        // Contain to the build dir — compare on a path-separator boundary so a
+        // sibling like `…/Cesium-backup` can't satisfy a bare prefix match.
+        const insideBuild =
+          filePath === cesiumBuild || filePath.startsWith(cesiumBuild + path.sep);
+        if (!insideBuild || !fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
+          return next();
+        }
+        res.setHeader(
+          'Content-Type',
+          CESIUM_DEV_MIME[path.extname(filePath).toLowerCase()] ??
+            'application/octet-stream',
+        );
+        if (req.method === 'HEAD') return res.end();
+        // Guard the TOCTOU window between existsSync and the stream open: an
+        // unhandled 'error' would otherwise crash the dev server.
+        fs.createReadStream(filePath)
+          .on('error', () => {
+            if (!res.headersSent) res.writeHead(500);
+            res.end();
+          })
+          .pipe(res);
+      });
+    },
+  };
+}

--- a/apps/viewer/vite.config.ts
+++ b/apps/viewer/vite.config.ts
@@ -1,12 +1,10 @@
-import { defineConfig, type PluginOption } from 'vite';
+import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import wasm from 'vite-plugin-wasm';
 import topLevelAwait from 'vite-plugin-top-level-await';
-import { createRequire } from 'node:module';
 import path from 'path';
 import fs from 'fs';
-
-const require = createRequire(import.meta.url);
+import { cesiumStaticAssets } from './vite-plugins/cesium-assets';
 
 // --- Build-time changelog parser ---
 
@@ -210,83 +208,6 @@ const rootPkg = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, '../../package.json'), 'utf-8')
 );
 const appVersion = viewerPkg.version || rootPkg.version;
-
-// CesiumJS loads its prebuilt Workers / Assets / Widgets / ThirdParty at
-// runtime from CESIUM_BASE_URL (= '/cesium', set in `define` below), so they
-// must sit at  dist/cesium/<Subdir>/…  and be served at  /cesium/<Subdir>/…
-// in dev.
-//
-// We copy them ourselves rather than via vite-plugin-static-copy: in its v4
-// line the plugin rebuilds each destination from the file's path *relative to
-// the Vite root*, so an absolute node_modules source lands every file under
-//   dist/cesium/node_modules/.pnpm/cesium@<v>/node_modules/cesium/Build/Cesium/…
-// instead of dist/cesium/…  → every /cesium/Assets|Workers/… request 404'd in
-// production and the Cesium globe never rendered (#1139). Its stripBase escape
-// hatch is static and would flatten Cesium's nested Assets/Textures tree. A
-// plain recursive copy is deterministic and package-manager-agnostic.
-const CESIUM_SUBDIRS = ['Workers', 'ThirdParty', 'Assets', 'Widgets'] as const;
-const CESIUM_DEV_MIME: Record<string, string> = {
-  '.js': 'text/javascript', '.mjs': 'text/javascript', '.css': 'text/css',
-  '.json': 'application/json', '.wasm': 'application/wasm', '.png': 'image/png',
-  '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg', '.gif': 'image/gif',
-  '.svg': 'image/svg+xml', '.xml': 'application/xml',
-};
-
-function cesiumStaticAssets(): PluginOption {
-  const cesiumBuild = path.join(
-    path.dirname(require.resolve('cesium/package.json')),
-    'Build',
-    'Cesium',
-  );
-  // Fail loud at config time if the prebuilt assets aren't where we expect —
-  // a silent miss here is exactly how #1139 shipped a broken map.
-  for (const sub of CESIUM_SUBDIRS) {
-    if (!fs.existsSync(path.join(cesiumBuild, sub))) {
-      throw new Error(`[cesium-assets] missing ${sub} under ${cesiumBuild}`);
-    }
-  }
-  let outDir = 'dist';
-  return {
-    name: 'ifc-lite:cesium-static-assets',
-    configResolved(config) {
-      outDir = config.build.outDir;
-    },
-    // Build: recursive-copy the subdirs flat under <outDir>/cesium.
-    async closeBundle() {
-      const dest = path.resolve(__dirname, outDir, 'cesium');
-      await Promise.all(
-        CESIUM_SUBDIRS.map((sub) =>
-          fs.promises.cp(path.join(cesiumBuild, sub), path.join(dest, sub), {
-            recursive: true,
-          }),
-        ),
-      );
-    },
-    // Dev: serve /cesium/* straight from the Cesium package (connect strips the
-    // '/cesium' mount prefix, so req.url is already the in-package path).
-    configureServer(server) {
-      server.middlewares.use('/cesium', (req, res, next) => {
-        if (req.method !== 'GET' && req.method !== 'HEAD') return next();
-        const rel = decodeURIComponent((req.url ?? '/').split('?')[0]);
-        const filePath = path.normalize(path.join(cesiumBuild, rel));
-        if (
-          !filePath.startsWith(cesiumBuild) || // contain to the build dir
-          !fs.existsSync(filePath) ||
-          !fs.statSync(filePath).isFile()
-        ) {
-          return next();
-        }
-        res.setHeader(
-          'Content-Type',
-          CESIUM_DEV_MIME[path.extname(filePath).toLowerCase()] ??
-            'application/octet-stream',
-        );
-        if (req.method === 'HEAD') return res.end();
-        fs.createReadStream(filePath).pipe(res);
-      });
-    },
-  };
-}
 
 export default defineConfig({
   plugins: [

--- a/apps/viewer/vite.config.ts
+++ b/apps/viewer/vite.config.ts
@@ -1,8 +1,7 @@
-import { defineConfig, normalizePath } from 'vite';
+import { defineConfig, type PluginOption } from 'vite';
 import react from '@vitejs/plugin-react';
 import wasm from 'vite-plugin-wasm';
 import topLevelAwait from 'vite-plugin-top-level-await';
-import { viteStaticCopy } from 'vite-plugin-static-copy';
 import { createRequire } from 'node:module';
 import path from 'path';
 import fs from 'fs';
@@ -212,30 +211,89 @@ const rootPkg = JSON.parse(
 );
 const appVersion = viewerPkg.version || rootPkg.version;
 
+// CesiumJS loads its prebuilt Workers / Assets / Widgets / ThirdParty at
+// runtime from CESIUM_BASE_URL (= '/cesium', set in `define` below), so they
+// must sit at  dist/cesium/<Subdir>/…  and be served at  /cesium/<Subdir>/…
+// in dev.
+//
+// We copy them ourselves rather than via vite-plugin-static-copy: in its v4
+// line the plugin rebuilds each destination from the file's path *relative to
+// the Vite root*, so an absolute node_modules source lands every file under
+//   dist/cesium/node_modules/.pnpm/cesium@<v>/node_modules/cesium/Build/Cesium/…
+// instead of dist/cesium/…  → every /cesium/Assets|Workers/… request 404'd in
+// production and the Cesium globe never rendered (#1139). Its stripBase escape
+// hatch is static and would flatten Cesium's nested Assets/Textures tree. A
+// plain recursive copy is deterministic and package-manager-agnostic.
+const CESIUM_SUBDIRS = ['Workers', 'ThirdParty', 'Assets', 'Widgets'] as const;
+const CESIUM_DEV_MIME: Record<string, string> = {
+  '.js': 'text/javascript', '.mjs': 'text/javascript', '.css': 'text/css',
+  '.json': 'application/json', '.wasm': 'application/wasm', '.png': 'image/png',
+  '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg', '.gif': 'image/gif',
+  '.svg': 'image/svg+xml', '.xml': 'application/xml',
+};
+
+function cesiumStaticAssets(): PluginOption {
+  const cesiumBuild = path.join(
+    path.dirname(require.resolve('cesium/package.json')),
+    'Build',
+    'Cesium',
+  );
+  // Fail loud at config time if the prebuilt assets aren't where we expect —
+  // a silent miss here is exactly how #1139 shipped a broken map.
+  for (const sub of CESIUM_SUBDIRS) {
+    if (!fs.existsSync(path.join(cesiumBuild, sub))) {
+      throw new Error(`[cesium-assets] missing ${sub} under ${cesiumBuild}`);
+    }
+  }
+  let outDir = 'dist';
+  return {
+    name: 'ifc-lite:cesium-static-assets',
+    configResolved(config) {
+      outDir = config.build.outDir;
+    },
+    // Build: recursive-copy the subdirs flat under <outDir>/cesium.
+    async closeBundle() {
+      const dest = path.resolve(__dirname, outDir, 'cesium');
+      await Promise.all(
+        CESIUM_SUBDIRS.map((sub) =>
+          fs.promises.cp(path.join(cesiumBuild, sub), path.join(dest, sub), {
+            recursive: true,
+          }),
+        ),
+      );
+    },
+    // Dev: serve /cesium/* straight from the Cesium package (connect strips the
+    // '/cesium' mount prefix, so req.url is already the in-package path).
+    configureServer(server) {
+      server.middlewares.use('/cesium', (req, res, next) => {
+        if (req.method !== 'GET' && req.method !== 'HEAD') return next();
+        const rel = decodeURIComponent((req.url ?? '/').split('?')[0]);
+        const filePath = path.normalize(path.join(cesiumBuild, rel));
+        if (
+          !filePath.startsWith(cesiumBuild) || // contain to the build dir
+          !fs.existsSync(filePath) ||
+          !fs.statSync(filePath).isFile()
+        ) {
+          return next();
+        }
+        res.setHeader(
+          'Content-Type',
+          CESIUM_DEV_MIME[path.extname(filePath).toLowerCase()] ??
+            'application/octet-stream',
+        );
+        if (req.method === 'HEAD') return res.end();
+        fs.createReadStream(filePath).pipe(res);
+      });
+    },
+  };
+}
+
 export default defineConfig({
   plugins: [
     react(),
     wasm(),
     topLevelAwait(),
-    // Copy Cesium static assets (Workers, ThirdParty, Assets) to public path
-    // so CesiumJS can load them at runtime via CESIUM_BASE_URL.
-    // Use require.resolve to handle pnpm's .pnpm store structure.
-    (() => {
-      const cesiumPkg = path.dirname(require.resolve('cesium/package.json'));
-      const cesiumBuild = path.join(cesiumPkg, 'Build', 'Cesium');
-      // vite-plugin-static-copy globs `src` with tinyglobby, which treats `\` as
-      // an escape char — so the raw Windows paths from path.join match nothing
-      // ("No file was found to copy"). normalizePath -> forward slashes fixes it
-      // cross-platform (no-op on POSIX).
-      return viteStaticCopy({
-        targets: [
-          { src: normalizePath(path.join(cesiumBuild, 'Workers')), dest: 'cesium' },
-          { src: normalizePath(path.join(cesiumBuild, 'ThirdParty')), dest: 'cesium' },
-          { src: normalizePath(path.join(cesiumBuild, 'Assets')), dest: 'cesium' },
-          { src: normalizePath(path.join(cesiumBuild, 'Widgets')), dest: 'cesium' },
-        ],
-      });
-    })(),
+    cesiumStaticAssets(),
   ],
   define: {
     __APP_VERSION__: JSON.stringify(appVersion),


### PR DESCRIPTION
## What

Closes #1139 — *"The map on cesium does not show up anymore."*

## Diagnosis

Production (`www.ifclite.com`) returns **`x-vercel-error: NOT_FOUND` for the entire `/cesium/` asset tree** — Workers, Assets/Textures, Widgets, and credit images all 404. The Cesium engine JS bundles fine (the overlay mounts and *requests* credits), but it can't fetch the runtime Workers/imagery from `CESIUM_BASE_URL` (`/cesium`), so the globe/terrain never render and the map is black.

Root cause is in `apps/viewer/vite.config.ts`. The `vite-plugin-static-copy` **v4** line rebuilds each file's destination from its path *relative to the Vite root*, so an absolute `node_modules` source landed every file at:

```
dist/cesium/node_modules/.pnpm/cesium@1.142.0/node_modules/cesium/Build/Cesium/Assets/Images/ion-credit.png
```

instead of `dist/cesium/Assets/Images/ion-credit.png`. So `/cesium/Assets/…` 404s. Confirmed locally: the built `dist/cesium/` contained **only** a `node_modules/…` subtree.

Why it looked browser-specific ("works in Firefox / works for me"): it's actually broken for **everyone** on a fresh cache — the reporters who saw a working map had an *earlier, correctly-pathed* deploy still in their HTTP cache. The `$lib:web` Edge user in #1175 hit the same thing (the unhandled Cesium `RequestErrorEvent`s are these failed worker/tile fetches).

This regressed with the vite 7 / `vite-plugin-static-copy` v4 bump (the "core update" the reporter suspected). The plugin's `stripBase` escape hatch is static and would flatten Cesium's nested `Assets/Textures/NaturalEarthII/z/x/y.jpg` tree, so it isn't a clean fix.

## Fix

Replace the static-copy block with a small inline Vite plugin (`cesiumStaticAssets`) that:

- **build** — recursively `fs.cp`s `Workers / ThirdParty / Assets / Widgets` into `<outDir>/cesium/<Subdir>/…`. Deterministic, package-manager-agnostic, structure-preserving.
- **dev** — serves `/cesium/*` straight from the Cesium package (dev was broken the same way — the plugin's dev fileMap keys off the same nested dest).
- **fails loud** at config time if the prebuilt subdirs are missing, so a silent miss can't ship a broken map again.

Single-file change. `CESIUM_BASE_URL` stays `/cesium`. Turbo self-heals: the `vite.config.ts` change busts the viewer build cache key, so the next build re-copies the assets to the correct paths.

## Verification

- `tsc --noEmit` on the new config: clean.
- Replayed the exact `closeBundle` copy against the installed `cesium@1.142.0`: `ion-credit.png`, `bing_maps_credit.png`, `approximateTerrainHeights.json`, the nested `Textures/NaturalEarthII/0/0/0.jpg`, and `Widgets/widgets.css` all land flat under `dist/cesium/…`; **no `node_modules` nesting**; Workers = 110 files.

## Notes

- `vite-plugin-static-copy` is now unused in code (still declared in `apps/viewer/package.json`). Left in place to avoid lockfile churn — can be pruned in a separate dependency-hygiene pass.
- No changeset: `@ifc-lite/viewer` is the deployed app, not a release-managed library (same as #1174/#1178).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the viewer application's build infrastructure by optimizing how Cesium assets are validated, compiled, and served during development and production builds. This enhancement streamlines asset handling and delivery across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->