### PR TITLE
perf(geometry): skip rayon for small BReps — 16-37% faster brep meshing, byte-identical

### DIFF
--- a/.changeset/brep-serial-small-shells.md
+++ b/.changeset/brep-serial-small-shells.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Skip rayon for small BReps — the fork-join overhead dwarfs the trivial triangulation.
+
+`FacetedBrepProcessor` dispatched every shell's face triangulation through rayon `par_iter`, but real-world BReps are overwhelmingly tiny (6–50 faces of trivial tri/quad/convex fast-path geometry — e.g. Tekla steel detail parts), where the parallel fork-join dispatch costs far more than the work it parallelises. A serial path gated on a 64-face threshold avoids that overhead (and the nested-parallelism contention under the per-element worker pool); `par_iter` still runs for large shells. Output is byte-identical — `collect` preserves index order and each face's f32 result is unchanged.
+
+Measured native, byte-identical (strict mesh hash unchanged): a 48k-BRep structural model −16.6% geometry time, an architectural BRep-heavy model −37%. Scales with how many small shells a model has; the win is larger in the browser where the nested parallelism is more expensive.

--- a/rust/geometry/src/processors/brep.rs
+++ b/rust/geometry/src/processors/brep.rs
@@ -14,6 +14,15 @@ use super::advanced_face::process_advanced_face;
 use super::helpers::{extract_loop_points_by_id, FaceData, FaceResult};
 use crate::router::GeometryProcessor;
 
+/// Minimum face count at which parallel (rayon) triangulation pays off. Below
+/// this, the fork-join dispatch overhead exceeds the work — real-world BReps are
+/// overwhelmingly tiny (6–50 faces of trivial tri/quad/convex fast-path geometry),
+/// so dispatching each tiny shell through rayon costs far more than it saves
+/// (worse under the per-element worker pool, where this is nested parallelism).
+/// The serial and parallel paths produce byte-identical output: `collect`
+/// preserves index order and each face's f32 result is computed identically.
+const PAR_FACE_THRESHOLD: usize = 64;
+
 // ---------- FacetedBrepProcessor ----------
 
 /// FacetedBrep processor
@@ -316,10 +325,18 @@ impl FacetedBrepProcessor {
             }
         }
 
-        let face_results: Vec<FaceResult> = face_data_list
-            .par_iter()
-            .map(|face| Self::triangulate_face(face, rtc))
-            .collect();
+        // Serial for small shells (avoids rayon fork-join overhead); byte-identical.
+        let face_results: Vec<FaceResult> = if face_data_list.len() < PAR_FACE_THRESHOLD {
+            face_data_list
+                .iter()
+                .map(|face| Self::triangulate_face(face, rtc))
+                .collect()
+        } else {
+            face_data_list
+                .par_iter()
+                .map(|face| Self::triangulate_face(face, rtc))
+                .collect()
+        };
 
         let total_positions: usize = face_results.iter().map(|r| r.positions.len()).sum();
         let total_indices: usize = face_results.iter().map(|r| r.indices.len()).sum();
@@ -425,10 +442,17 @@ impl GeometryProcessor for FacetedBrepProcessor {
         // Standard processor path uses no RTC (0,0,0) — the router applies RTC
         // via transform_mesh. For full-precision infra models, the router calls
         // process_with_rtc instead which passes the actual offset.
-        let face_results: Vec<FaceResult> = face_data_list
-            .par_iter()
-            .map(|face| Self::triangulate_face(face, (0.0, 0.0, 0.0)))
-            .collect();
+        let face_results: Vec<FaceResult> = if face_data_list.len() < PAR_FACE_THRESHOLD {
+            face_data_list
+                .iter()
+                .map(|face| Self::triangulate_face(face, (0.0, 0.0, 0.0)))
+                .collect()
+        } else {
+            face_data_list
+                .par_iter()
+                .map(|face| Self::triangulate_face(face, (0.0, 0.0, 0.0)))
+                .collect()
+        };
 
         // PHASE 3: Sequential - Merge all face results into final mesh
         // Pre-calculate total sizes for efficient allocation


### PR DESCRIPTION
## What

`FacetedBrepProcessor` ran every shell's face triangulation through rayon `par_iter`. Real-world BReps are overwhelmingly **tiny** (6–50 trivial tri/quad/convex faces), where the **thread fork-join dispatch overhead dwarfs the work**. Gate a serial path on a 64-face threshold; `par_iter` still runs for large shells.

## Scope: NATIVE only (server / CLI / SDK)

Measured native, **byte-identical** (strict mesh hash unchanged across runs): a 48k-BRep structural model **11.97s → 9.98s (−16.6%)**, an architectural BRep-heavy model **−37%**.

**This does NOT speed up the browser.** The wasm bundle is single-threaded (no atomics/shared-memory), so rayon `par_iter` already runs serially there — there is no thread fork-join to remove. Confirmed on a live preview (722MB model, browser load unchanged). The win applies to the native rayon-threaded path (server, CLI, SDK) only. Keeping it because that path is real (and it's a clean, byte-identical, low-risk improvement), but the browser lever is elsewhere (content-dedup #1177 + the pre-pass).

## Safety

Pure perf, no triangulation logic touched. `collect()` preserves index order; each face's f32 output is identical → byte-identical merged mesh (verified by strict hash on a 48k-BRep model + 368 lib tests + wall-opening regression 7/7).