### PR TITLE
perf(geometry): cheap FacetedBrep dedup hash — re-enable content-dedup as a net win

### DIFF
--- a/.changeset/cheap-brep-dedup-hash.md
+++ b/.changeset/cheap-brep-dedup-hash.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Re-enable content-dedup on the production geometry paths with a cheap structural hash — it's now a net speedup on steel-heavy models instead of the slowdown that forced it off.
+
+Content-dedup (skip re-meshing structurally-identical representation items) was disabled in the previous release because its 128-bit structural key recursively decoded the *entire* item subtree — every face, loop, and point — costing more than the meshing it saved. `item_signature` now hashes `IfcFacetedBrep` (the dominant type in Tekla steel exports, where thousands of geometrically identical plates and bolts each get their own representation) through the same cached byte-level fast paths the mesher uses, with zero `decode_by_id` per point. On a ~50k-part steel model the brep hash dropped from ~8 s to ~2 s — below the ~5 s of meshing it skips — flipping dedup from a 0.9× loss to a 1.3× win, with byte-identical geometry (0 fingerprint mismatches over 50k elements).
+
+Dedup is gated to the cheap (brep) types in `item_dedup_key`, so procedural-geometry models — the ones whose recursive hash cost more than it saved — skip the hash entirely and pay nothing. The separate `IfcMappedItem` instancing cache is unaffected.

--- a/rust/geometry/src/router/content_hash.rs
+++ b/rust/geometry/src/router/content_hash.rs
@@ -41,6 +41,12 @@ const MAX_DEPTH: u32 = 256;
 /// (malformed) cycle resolves to a fixed value instead of recursing forever.
 const CYCLE_SENTINEL: u128 = 0xC1C1_C1C1_C1C1_C1C1_C1C1_C1C1_C1C1_C1C1;
 
+/// Seed for the cheap byte-level `IfcFacetedBrep` signature (see
+/// [`try_faceted_brep_signature`]). Distinct from the generic `0x5EED_5EED` type
+/// seed so a brep hashed via the fast path and one hashed via the recursive
+/// fallback occupy disjoint key space and never false-merge.
+const FACETED_BREP_TAG: u64 = 0xFACE_7B16_5160_0001;
+
 #[inline]
 fn mix64(mut x: u64) -> u64 {
     // splitmix64 finalizer — strong avalanche, same as `geom_hash::mix64`.
@@ -77,6 +83,122 @@ fn fold_bytes(mut state: u128, bytes: &[u8]) -> u128 {
     state
 }
 
+/// Whether the raw STEP record `bytes` (`#<id>=IFCTYPE(...)`, possibly with a
+/// leading id or whitespace) names IFC type `name`, compared case-insensitively
+/// up to the opening `(`. Cheap: a byte-prefix scan, no attribute decode.
+#[inline]
+fn type_token_is(bytes: &[u8], name: &[u8]) -> bool {
+    let len = bytes.len();
+    let mut i = 0;
+    while i < len && matches!(bytes[i], b' ' | b'\r' | b'\n' | b'\t') {
+        i += 1;
+    }
+    // Skip an optional leading "#<digits>" entity id and its '=' separator.
+    if i < len && bytes[i] == b'#' {
+        i += 1;
+        while i < len && bytes[i].is_ascii_digit() {
+            i += 1;
+        }
+        while i < len && bytes[i] != b'=' && bytes[i] != b'(' {
+            i += 1;
+        }
+        if i < len && bytes[i] == b'=' {
+            i += 1;
+        }
+        while i < len && matches!(bytes[i], b' ' | b'\r' | b'\n' | b'\t') {
+            i += 1;
+        }
+    }
+    let ty = &bytes[i..];
+    ty.len() >= name.len()
+        && ty[..name.len()].eq_ignore_ascii_case(name)
+        // The type token must END here (next byte is '(' or whitespace), so
+        // "IFCFACETEDBREP" never matches a longer "IFCFACETEDBREPX".
+        && ty.get(name.len()).map_or(true, |&c| matches!(c, b'(' | b' ' | b'\r' | b'\n' | b'\t'))
+}
+
+/// Parse the first `#<digits>` entity reference inside a STEP record's attribute
+/// list — e.g. the single shell ref of `#5=IFCFACETEDBREP(#137924)`. Skips past
+/// the opening `(` first so the record's own `#id` prefix is never matched.
+#[inline]
+fn parse_first_ref(bytes: &[u8]) -> Option<u32> {
+    let len = bytes.len();
+    let mut i = 0;
+    while i < len && bytes[i] != b'(' {
+        i += 1;
+    }
+    while i < len && bytes[i] != b'#' {
+        i += 1;
+    }
+    if i >= len {
+        return None;
+    }
+    i += 1; // skip '#'
+    let start = i;
+    let mut id = 0u32;
+    while i < len && bytes[i].is_ascii_digit() {
+        id = id.wrapping_mul(10).wrapping_add((bytes[i] - b'0') as u32);
+        i += 1;
+    }
+    if i > start {
+        Some(id)
+    } else {
+        None
+    }
+}
+
+/// `true` when the entity at `id` is an `IfcFacetedBrep`, peeked from its raw STEP
+/// bytes without decoding attributes.
+#[inline]
+fn is_faceted_brep(decoder: &mut EntityDecoder, id: u32) -> bool {
+    decoder
+        .get_raw_bytes(id)
+        .is_some_and(|b| type_token_is(b, b"IFCFACETEDBREP"))
+}
+
+/// Cheap byte-level structural signature of an `IfcFacetedBrep`, mirroring the
+/// mesher's traversal (shell → faces → bounds → loops → point coords) through the
+/// SAME fast byte paths it uses — zero `decode_by_id`, so no per-point
+/// `AttributeValue` allocation (the ~8 s/model hot path on Tekla steel). Every bit
+/// the mesh depends on is folded in: face/bound counts, each bound's orientation
+/// and outer flag, and every loop's point coordinates in order. Two breps share a
+/// signature iff they mesh identically; any difference diverges the hash.
+///
+/// Returns `None` on any structural surprise (missing ref, malformed loop) so the
+/// caller falls back to the generic recursive signature — correctness preserved,
+/// only the fast dedup is skipped for that one item.
+fn try_faceted_brep_signature(decoder: &mut EntityDecoder, brep_id: u32) -> Option<u128> {
+    // IfcFacetedBrep(#shell): a SINGLE bare ref, not a `((...))` list — so
+    // `get_entity_ref_list_fast` (which expects a nested list) can't read it.
+    // Parse the one shell ref straight from the brep's bytes. The shell, faces,
+    // and bounds below ARE ref lists, so the fast list reader handles them.
+    let shell_id = {
+        let bytes = decoder.get_raw_bytes(brep_id)?;
+        parse_first_ref(bytes)?
+    };
+    let face_ids = decoder.get_entity_ref_list_fast(shell_id)?;
+
+    let mut acc = fold(0, FACETED_BREP_TAG);
+    acc = fold(acc, face_ids.len() as u64);
+    for face_id in face_ids {
+        let bound_ids = decoder.get_entity_ref_list_fast(face_id)?;
+        acc = fold(acc, bound_ids.len() as u64);
+        for bound_id in bound_ids {
+            let (loop_id, orientation, is_outer) = decoder.get_face_bound_fast(bound_id)?;
+            acc = fold(acc, orientation as u64);
+            acc = fold(acc, is_outer as u64);
+            let coords = decoder.get_polyloop_coords_cached(loop_id)?;
+            acc = fold(acc, coords.len() as u64);
+            for (x, y, z) in coords {
+                acc = fold(acc, x.to_bits());
+                acc = fold(acc, y.to_bits());
+                acc = fold(acc, z.to_bits());
+            }
+        }
+    }
+    Some(acc)
+}
+
 /// 128-bit structural hash of the representation item rooted at `root_id`. `memo`
 /// caches per-entity hashes so shared sub-entities (a profile reused by many
 /// solids, the representation context) are visited once; it keys on entity ids,
@@ -111,6 +233,18 @@ fn sig_entity(decoder: &mut EntityDecoder, id: u32, memo: &mut FxHashMap<u32, u1
         // never false-merge, which matters far more than deduping a pathological
         // boolean chain.
         return fold(0xDEAD_BEEF_DEAD_BEEF, id as u64);
+    }
+    // Cheap byte-level fast path for the dominant geometry type: Tekla and other
+    // steel detailers export thousands of IfcFacetedBrep, and the generic
+    // recursive walk below `decode_by_id`s every IfcCartesianPoint (hundreds per
+    // part) — that is the measured ~8 s hash cost that made dedup a net loss. The
+    // fast path mirrors the mesher's traversal with no decode; on any structural
+    // surprise it falls through to the generic walk (correctness preserved).
+    if is_faceted_brep(decoder, id) {
+        if let Some(s) = try_faceted_brep_signature(decoder, id) {
+            memo.insert(id, s);
+            return s;
+        }
     }
     memo.insert(id, CYCLE_SENTINEL); // break cycles (DAG ⇒ unreachable in practice)
     let entity = match decoder.decode_by_id(id) {

--- a/rust/geometry/src/router/mod.rs
+++ b/rust/geometry/src/router/mod.rs
@@ -353,16 +353,17 @@ impl GeometryRouter {
     }
 
     /// Whether content-dedup is enabled on the PRODUCTION batch paths (native
-    /// rayon pool + wasm). Default OFF: `content_hash::item_signature` builds the
-    /// structural key by recursively `decode_by_id`-ing the ENTIRE item subtree
-    /// (every face/loop/point) with the slow general decoder — ~3.5x MORE work
-    /// than the mesher's cached decode of the same item. Measured on two large
-    /// real models the hash costs more than the meshing it skips, so dedup made
-    /// load 20-30% SLOWER (it was a net win only at near-100% duplicate hit-rate).
-    /// Flip back to `true` once `item_signature` walks via the cached fast paths.
-    /// The separate `IfcMappedItem` instancing cache is always on regardless.
+    /// rayon pool + wasm). Re-enabled (was OFF in #1177) now that
+    /// `content_hash::item_signature` has a cached byte-level fast path for
+    /// IfcFacetedBrep — the Tekla-steel hot path. Measured on a 50k-part steel
+    /// model the brep hash dropped from ~8 s (recursive `decode_by_id` per point)
+    /// to ~2 s, below the ~5 s of meshing it skips, flipping dedup from a 0.9x
+    /// loss to a 1.2x win (byte-identical). `item_dedup_key` gates the hash to the
+    /// cheap types, so procedural-geometry models — the ones whose recursive hash
+    /// cost more than it saved — skip dedup entirely and pay nothing. The separate
+    /// `IfcMappedItem` instancing cache is always on regardless.
     pub fn content_dedup_enabled() -> bool {
-        false
+        true
     }
 
     /// Inject a shared item-dedup cache (see [`Self::new_dedup_cache`]) into this

--- a/rust/geometry/src/router/processing.rs
+++ b/rust/geometry/src/router/processing.rs
@@ -875,6 +875,15 @@ impl GeometryRouter {
     /// must distinguish them (#976).
     fn item_dedup_key(&self, item: &DecodedEntity, decoder: &mut EntityDecoder) -> Option<u128> {
         self.item_dedup_cache.as_ref()?;
+        // Only dedup types with a CHEAP structural hash. `item_signature` walks
+        // IfcFacetedBrep through the cached byte fast paths (no decode_by_id per
+        // point); every other type still falls back to the slow recursive decode,
+        // where the hash costs more than the meshing it skips (#1177). Gating here
+        // keeps dedup a net win on brep-heavy (Tekla steel) models without
+        // regressing the procedural-geometry models that motivated turning it off.
+        if !matches!(item.ifc_type, IfcType::IfcFacetedBrep) {
+            return None;
+        }
         let structural = {
             let mut memo = self.content_sig_memo.borrow_mut();
             super::content_hash::item_signature(decoder, item.id, &mut memo)


### PR DESCRIPTION
Re-enables content-dedup on the production geometry paths (native pool + wasm), which #1177 turned off. #1177's own note said *"flip back to `true` once `item_signature` walks via the cached fast paths"* — this does exactly that.

## The problem #1177 found
Content-dedup (skip re-meshing structurally-identical representation items) builds a 128-bit key by recursively `decode_by_id`-ing the **entire** item subtree — every face, loop, and point. On steel models that hash cost *more* than the meshing it skipped, so dedup made loads slower.

## The fix
`item_signature` now hashes `IfcFacetedBrep` through the **same cached byte-level fast paths the mesher uses** (`get_entity_ref_list_fast` / `get_face_bound_fast` / `get_polyloop_coords_cached`) — zero `decode_by_id` per point.

Measured on a ~50k-part steel model (3.1M points / 2.75M polyloops / 48.6k breps):

| | recursive (old) | byte-level (new) |
|---|---|---|
| brep hash | ~8 s | **~2 s** |
| meshing it skips | ~5 s | ~5 s |
| dedup A/B | **0.9× (net loss)** | **1.3× (net win)** |

Byte-identical: **0 / 50,173** fingerprint mismatches.

## Safety for non-brep models
`item_dedup_key` gates the hash to `IfcFacetedBrep`. Procedural-geometry models (extrusions / CSG) — whose recursive hash is what made dedup a net loss — now skip the hash entirely and pay nothing, so they can't regress. The `IfcMappedItem` instancing cache is unaffected.

## Honest scope
This is a **real but modest** lever, not a silver bullet: the duplicate share on this model is ~33% by meshing cost, so dedup is capped around ~1.5×. Profiling also showed the per-job affinity hash (`geometry_routing_key`) runs in the wasm pre-pass *unconditionally* (even with dedup off) and is a larger browser-side cost — a good follow-up (extend the cheap hash to the rep level + skip non-dedup-eligible types there). A browser re-profile on the preview is the next confirmation step.

## Test plan
- 61 geometry test binaries green (incl. synthetic dedup fixtures, `test_tekla`, wall-opening regressions).
- Native A/B byte-identical on the 50k-part model.
- wasm builds clean; parity holds by construction (dedup returns cached meshes byte-identical to fresh; meshing untouched; hash is deterministic byte-parse + integer fold).