### PR TITLE
fix(release): publish ifc-lite-ffi to crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,9 +139,13 @@ jobs:
         run: pnpm build
 
       # Exchange the workflow's OIDC ID-token for a short-lived (30-minute)
-      # crates.io access token. Trusted Publisher must be configured on
-      # crates.io for each of ifc-lite-core, ifc-lite-geometry, ifc-lite-wasm
-      # pointing at this repo + this workflow before the first run.
+      # crates.io access token. A Trusted Publisher must be configured on
+      # crates.io for EACH published crate (ifc-lite-core, -geometry, -clash,
+      # -processing, -ffi, -wasm) pointing at this repo + this workflow
+      # before its first automated publish. A brand-new crate name (e.g.
+      # ifc-lite-ffi) must additionally be bootstrapped once with a personal
+      # API token — `cargo publish -p <crate> --token …` — to claim the name,
+      # since a Trusted Publisher can only be configured on an existing crate.
       - name: Authenticate to crates.io (OIDC)
         id: crates-auth
         uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4

--- a/rust/ffi/Cargo.toml
+++ b/rust/ffi/Cargo.toml
@@ -15,6 +15,11 @@ description = "C FFI bindings for ifc-lite — native DLL for in-process IFC par
 crate-type = ["cdylib"]
 
 [dependencies]
-ifc-lite-processing = { path = "../processing" }
+# Carry an explicit `version` alongside `path` so the crate is publishable to
+# crates.io: `cargo publish` strips the path and keeps the version requirement.
+# A path-only dep fails publish ("dependency does not specify a version").
+# `scripts/sync-versions.js` keeps this literal aligned with the workspace
+# version on every `changeset version` bump.
+ifc-lite-processing = { version = "4.1.0", path = "../processing" }
 rayon = "1.10"
 serde_json = "1.0"

--- a/scripts/release-crates.mjs
+++ b/scripts/release-crates.mjs
@@ -26,12 +26,14 @@ import { dirname, join } from 'path';
 const rootDir = join(dirname(fileURLToPath(import.meta.url)), '..');
 
 // Dependency order: geometry depends on core; clash is dependency-free;
-// processing depends on core+geometry; wasm depends on all four.
+// processing depends on core+geometry; ffi (cdylib C bindings) depends on
+// processing; wasm depends on core+geometry+clash+processing.
 const CRATES = [
   'ifc-lite-core',
   'ifc-lite-geometry',
   'ifc-lite-clash',
   'ifc-lite-processing',
+  'ifc-lite-ffi',
   'ifc-lite-wasm',
 ];
 

--- a/scripts/sync-versions.js
+++ b/scripts/sync-versions.js
@@ -94,7 +94,7 @@ function syncVersions() {
   // path and keeps the version requirement on publish). Those literals
   // must track the workspace version or every workspace build breaks with
   // a version/path mismatch after a bump.
-  for (const member of ['core', 'geometry', 'processing', 'clash', 'wasm-bindings']) {
+  for (const member of ['core', 'geometry', 'processing', 'clash', 'ffi', 'wasm-bindings']) {
     const memberTomlPath = join(rootDir, 'rust', member, 'Cargo.toml');
     let memberToml;
     try {


### PR DESCRIPTION
## Problem

The `ifc-lite-ffi` crate (added in #1182) is wired into the Cargo workspace but is **absent from crates.io** — the name is unclaimed, while the other 5 crates are live at 4.1.0. It missed **three** independent layers of the crate-release machinery, each fatal on its own.

## Root cause

1. **`scripts/release-crates.mjs`** — the publish loop iterates a hardcoded `CRATES` list that never included `ifc-lite-ffi`. It was never attempted.
2. **`rust/ffi/Cargo.toml`** — internal dep was `ifc-lite-processing = { path = "../processing" }` with **no `version`**. `cargo publish` rejects path-only deps (*"dependency does not specify a version"*), so packaging fails even if listed. Every sibling crate uses `{ version = "4.1.0", path = … }`.
3. **`scripts/sync-versions.js`** — the member loop that keeps those `version` literals aligned on each `changeset version` bump was hardcoded to `core/geometry/processing/clash/wasm-bindings`, so `ffi` would drift after the next bump.

## Changes

- Add `ifc-lite-ffi` to the publish list, in dependency order (after `processing`, which it depends on).
- Pin `ifc-lite-processing` to `{ version = "4.1.0", path = … }` in the FFI manifest.
- Add `ffi` to the `sync-versions.js` member loop.
- Correct the stale `release.yml` comment to list all six published crates and document the one-time new-crate bootstrap.

## Verification

- `cargo publish -p ifc-lite-ffi --dry-run` now packages cleanly (was failing on the missing dep version).
- `sync-versions.js` runs idempotently at 4.1.0; its regex confirms it will bump the ffi dep on future releases.

## ⚠️ Required one-time human step (not in this PR)

OIDC trusted publishing cannot create a brand-new crate name. Before the automated release can publish `ifc-lite-ffi`:

1. Claim the name with a personal token: `cargo publish -p ifc-lite-ffi --token <crates.io token>`
2. crates.io → `ifc-lite-ffi` → Settings → **Trusted Publishing** → add GitHub repo `LTplus-AG/ifc-lite`, workflow `release.yml`, environment `release-publish`.

After that, every `changeset version` bump publishes ffi via OIDC alongside the other crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)