### PR TITLE
fix(wasm): recover from transient WASM engine-load failures + humanise error

### DIFF
--- a/.changeset/wasm-engine-load-resilience.md
+++ b/.changeset/wasm-engine-load-resilience.md
@@ -1,0 +1,15 @@
+---
+"@ifc-lite/geometry": patch
+"@ifc-lite/parser": patch
+"@ifc-lite/viewer": patch
+---
+
+Recover from transient WASM engine-load failures and humanise the error.
+
+When the `ifc-lite_bg.wasm` binary fails to download (non-OK HTTP status, a cold
+CDN edge, a mid-deploy race, or a blocking proxy/antivirus), wasm-bindgen's
+streaming loader rethrows a cryptic `Failed to execute 'compile' on
+'WebAssembly': HTTP status code is not ok`. The geometry and parser workers now
+retry `init()` once on such fetch/HTTP-shaped failures, and the viewer maps the
+failure to actionable guidance ("reload the page") instead of surfacing the raw
+TypeError. Captured exceptions are tagged with a stable `error_kind` for triage.

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -53,6 +53,7 @@ import { getGlobalRenderer } from './useBCF.js';
 import { extractModelGeoref, alignGeometryToReference, findReferenceGeorefModel } from './ingest/federationAlign.js';
 import { toast } from '../components/ui/toast.js';
 import { posthog } from '../lib/analytics.js';
+import { classifyLoadError, formatLoadError } from '../lib/load-errors.js';
 
 /**
  * Where a {@link useIfcLoader.loadFile} call should land the model.
@@ -1136,17 +1137,16 @@ export function useIfcLoader() {
               }).catch(err => {
                 // Data model parsing failed - spatial index and caching skipped
                 console.warn('[useIfc] Skipping spatial index/cache - data model unavailable:', err);
-                const message = err instanceof Error ? err.message : String(err);
                 if (target.kind === 'federated') {
                   // No placeholder model exists for a federated add (it is only
                   // registered on success via finalizeModel→addModel), so
                   // updateModel would no-op and the failure would vanish —
                   // addModel just returns null. Surface it to the user instead.
-                  toast.error(`Failed to load "${file.name}": ${message}`);
+                  toast.error(formatLoadError(err, file.name));
                 } else {
                   updateModel(modelId, {
                     loadState: 'error',
-                    loadError: message,
+                    loadError: formatLoadError(err, file.name),
                   });
                 }
               });
@@ -1166,7 +1166,14 @@ export function useIfcLoader() {
         void dataStorePromise.catch(() => {});
         if (loadSessionRef.current !== currentSession) return;
         console.error('[useIfc] Error in processing:', err);
-        setError(err instanceof Error ? err.message : 'Unknown error during geometry processing');
+        // A WASM engine-load failure (e.g. the geometry binary 404'd) surfaces
+        // here as a cryptic `compile on 'WebAssembly'` TypeError — humanise it
+        // and tag the captured exception so it is filterable in error tracking.
+        const kind = classifyLoadError(err);
+        setError(formatLoadError(err, file.name));
+        posthog.captureException(err, {
+          additional_properties: { context: 'geometry_processing', error_kind: kind },
+        });
         setLoading(false);
         setGeometryStreamingActive(false);
         return;
@@ -1234,12 +1241,16 @@ export function useIfcLoader() {
     } catch (err) {
       console.error(`[useIfc] loadFile THREW (session=${currentSession}, current=${loadSessionRef.current}):`, err);
       if (loadSessionRef.current !== currentSession) return;
+      const kind = classifyLoadError(err);
+      const friendly = formatLoadError(err, file.name);
       updateModel(modelId, {
         loadState: 'error',
-        loadError: err instanceof Error ? err.message : String(err),
+        loadError: friendly,
       });
-      setError(err instanceof Error ? err.message : 'Unknown error');
-      posthog.captureException(err, { additional_properties: { context: 'ifc_model_load' } });
+      setError(friendly);
+      posthog.captureException(err, {
+        additional_properties: { context: 'ifc_model_load', error_kind: kind },
+      });
       setLoading(false);
       setGeometryStreamingActive(false);
     }

--- a/apps/viewer/src/lib/load-errors.test.ts
+++ b/apps/viewer/src/lib/load-errors.test.ts
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { classifyLoadError, formatLoadError } from './load-errors.js';
+
+describe('classifyLoadError', () => {
+  it('classifies the wasm-bindgen non-OK HTTP status as wasm_engine_load', () => {
+    // The exact message captured in PostHog issue 019ed949 (Edge/Windows).
+    const err = new TypeError(
+      "Failed to execute 'compile' on 'WebAssembly': HTTP status code is not ok",
+    );
+    assert.equal(classifyLoadError(err), 'wasm_engine_load');
+  });
+
+  it('classifies streaming-compile/instantiate WebAssembly failures', () => {
+    for (const verb of ['compile', 'compileStreaming', 'instantiate', 'instantiateStreaming']) {
+      const err = new TypeError(`Failed to execute '${verb}' on 'WebAssembly': bad`);
+      assert.equal(classifyLoadError(err), 'wasm_engine_load', verb);
+    }
+  });
+
+  it('classifies a blocked/failed engine-binary fetch', () => {
+    assert.equal(classifyLoadError(new Error('Failed to fetch ifc-lite_bg.wasm')), 'wasm_engine_load');
+    assert.equal(classifyLoadError(new Error('NetworkError when attempting to fetch wasm')), 'wasm_engine_load');
+  });
+
+  it('classifies out-of-memory failures', () => {
+    assert.equal(classifyLoadError(new Error('memory access out of bounds')), 'out_of_memory');
+    assert.equal(classifyLoadError(new Error('Cannot enlarge memory arrays')), 'out_of_memory');
+  });
+
+  it('classifies cancellation', () => {
+    assert.equal(classifyLoadError(new Error('The operation was aborted')), 'cancelled');
+    assert.equal(classifyLoadError('cancelled'), 'cancelled');
+  });
+
+  it('falls back to unknown for unrelated errors', () => {
+    assert.equal(classifyLoadError(new Error('Unexpected token in IFC header')), 'unknown');
+  });
+
+  it('handles non-Error inputs', () => {
+    assert.equal(classifyLoadError(undefined), 'unknown');
+    assert.equal(classifyLoadError({ nope: true }), 'unknown');
+  });
+});
+
+describe('formatLoadError', () => {
+  it('gives actionable reload guidance for engine-load failures', () => {
+    const msg = formatLoadError(
+      new TypeError("Failed to execute 'compile' on 'WebAssembly': HTTP status code is not ok"),
+      'tower.ifc',
+    );
+    assert.match(msg, /geometry engine/i);
+    assert.match(msg, /reload/i);
+    // The cryptic raw message must NOT leak to the user for known failures.
+    assert.doesNotMatch(msg, /HTTP status code is not ok/);
+  });
+
+  it('preserves the raw message for unknown failures', () => {
+    const msg = formatLoadError(new Error('Unexpected token in IFC header'), 'tower.ifc');
+    assert.match(msg, /"tower\.ifc"/);
+    assert.match(msg, /Unexpected token in IFC header/);
+  });
+
+  it('works without a file name', () => {
+    const msg = formatLoadError(new Error('boom'));
+    assert.match(msg, /the model/);
+  });
+});

--- a/apps/viewer/src/lib/load-errors.ts
+++ b/apps/viewer/src/lib/load-errors.ts
@@ -1,0 +1,102 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Classification + humanisation of model-load failures.
+ *
+ * The geometry/parser workers both initialise the same `@ifc-lite/wasm`
+ * binary. wasm-bindgen's streaming loader rethrows on a non-OK HTTP status
+ * (it only falls back for the wrong-MIME case), surfacing as a cryptic
+ * `TypeError: Failed to execute 'compile' on 'WebAssembly': HTTP status code
+ * is not ok`. That message is meaningless to a user and, captured raw, is
+ * hard to triage in error tracking.
+ *
+ * This module maps such failures to a stable `kind` (for analytics
+ * grouping) and a human-readable message (for the toast / model loadError).
+ */
+
+/** Stable, analytics-friendly classification of a load failure. */
+export type LoadErrorKind =
+  /** The WebAssembly geometry engine binary failed to download/compile. */
+  | 'wasm_engine_load'
+  /** Out-of-memory / WASM heap exhaustion during processing. */
+  | 'out_of_memory'
+  /** The user (or a superseding load) cancelled the operation. */
+  | 'cancelled'
+  /** Anything else. */
+  | 'unknown';
+
+function messageOf(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  return String(err);
+}
+
+/**
+ * The geometry engine binary (`ifc-lite_bg.wasm`) failed to load. This is a
+ * download/compile failure of the WASM module itself, not a problem with the
+ * IFC file — the binary 404'd, was served with a non-OK status, or the fetch
+ * was blocked (corporate proxy / antivirus / offline). wasm-bindgen's loader
+ * cannot recover from a non-OK HTTP status, so it rethrows.
+ */
+function isWasmEngineLoadError(message: string): boolean {
+  return (
+    /HTTP status code is not ok/i.test(message) ||
+    // `compile`/`compileStreaming`/`instantiate`/`instantiateStreaming` on `WebAssembly`.
+    /'(compile|compileStreaming|instantiate|instantiateStreaming)' on 'WebAssembly'/i.test(message) ||
+    // Streaming-fetch failure for the engine binary specifically.
+    (/wasm/i.test(message) && /failed to fetch|networkerror|load failed/i.test(message)) ||
+    /ifc-lite_bg\.wasm/i.test(message)
+  );
+}
+
+function isOutOfMemoryError(message: string): boolean {
+  return (
+    /out of memory|oom|memory access out of bounds|cannot enlarge memory|allocation failed|maximum call stack|array buffer allocation failed|rangeerror: (?:invalid array|array buffer)/i.test(
+      message,
+    )
+  );
+}
+
+function isCancelledError(message: string): boolean {
+  return /\bcancel(?:led|ed)?\b|aborterror|the operation was aborted/i.test(message);
+}
+
+/** Classify a load failure into a stable analytics bucket. */
+export function classifyLoadError(err: unknown): LoadErrorKind {
+  const message = messageOf(err);
+  if (isWasmEngineLoadError(message)) return 'wasm_engine_load';
+  if (isOutOfMemoryError(message)) return 'out_of_memory';
+  if (isCancelledError(message)) return 'cancelled';
+  return 'unknown';
+}
+
+/**
+ * Produce a user-facing message for a load failure. Known failure modes get
+ * actionable guidance; everything else falls back to the raw error text so we
+ * never hide useful detail.
+ *
+ * @param fileName Optional file name to attribute the failure to.
+ */
+export function formatLoadError(err: unknown, fileName?: string): string {
+  const kind = classifyLoadError(err);
+  const subject = fileName ? `"${fileName}"` : 'the model';
+  switch (kind) {
+    case 'wasm_engine_load':
+      return (
+        `Couldn't load the 3D geometry engine — a required file failed to download. ` +
+        `This usually means the app updated in the background, or a proxy/antivirus blocked it. ` +
+        `Please reload the page (Ctrl/Cmd+Shift+R). If it persists, check your network or extensions.`
+      );
+    case 'out_of_memory':
+      return (
+        `Ran out of memory while processing ${subject}. ` +
+        `Try closing other tabs, or load fewer/smaller models at once.`
+      );
+    case 'cancelled':
+      return `Loading ${subject} was cancelled.`;
+    default:
+      return `Failed to load ${subject}: ${messageOf(err)}`;
+  }
+}

--- a/packages/geometry/src/geometry.worker.ts
+++ b/packages/geometry/src/geometry.worker.ts
@@ -233,6 +233,32 @@ let api: IfcAPI | null = null;
 let cachedWasmUrl: string | undefined = undefined;
 
 /**
+ * wasm-bindgen's streaming loader rethrows on a non-OK HTTP status or a failed
+ * fetch of `ifc-lite_bg.wasm` (it only falls back for the wrong-MIME case),
+ * surfacing as `TypeError: Failed to execute 'compile' on 'WebAssembly': HTTP
+ * status code is not ok`. A transient blip — a cold CDN edge, a mid-deploy
+ * race, a flaky proxy — can produce a one-off failure that a second attempt
+ * recovers. Retry the init once on a fetch/HTTP-shaped failure before giving
+ * up; a genuine compile/validation error (corrupt module) propagates
+ * immediately so we don't mask real bugs. `__wbg_init` only short-circuits on
+ * `wasm !== undefined`, so a retry after a failed load safely re-fetches.
+ */
+async function initWasmWithRetry(url: string | undefined): Promise<void> {
+  try {
+    await init(url);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    const looksTransient =
+      /HTTP status code is not ok|failed to fetch|networkerror|load failed|streaming/i.test(msg) ||
+      /'(?:compile|compileStreaming|instantiate|instantiateStreaming)' on 'WebAssembly'/i.test(msg);
+    if (!looksTransient) throw err;
+    console.warn(`[Worker] WASM engine load failed (${msg}); retrying once`);
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    await init(url);
+  }
+}
+
+/**
  * Idempotent wasm + IfcAPI initializer. Centralises the
  * `if (!api) { await init(); api = new IfcAPI(); ... }` boilerplate that
  * every message handler used to repeat. Honours `cachedWasmUrl` so the
@@ -242,7 +268,7 @@ let cachedWasmUrl: string | undefined = undefined;
  */
 async function ensureInit(): Promise<IfcAPI> {
   if (api) return api;
-  await init(cachedWasmUrl);
+  await initWasmWithRetry(cachedWasmUrl);
   api = new IfcAPI();
   mergeLayersApplied = false;
   applyMergeLayersToApi();

--- a/packages/geometry/src/geometry.worker.ts
+++ b/packages/geometry/src/geometry.worker.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import init, { initSync, IfcAPI } from '@ifc-lite/wasm';
+import { initWasmWithRetry } from './wasm-init-retry.js';
 import type { MeshData, TessellationQuality } from './types.js';
 import {
   DEFAULT_BATCH_SIZING,
@@ -233,42 +234,21 @@ let api: IfcAPI | null = null;
 let cachedWasmUrl: string | undefined = undefined;
 
 /**
- * wasm-bindgen's streaming loader rethrows on a non-OK HTTP status or a failed
- * fetch of `ifc-lite_bg.wasm` (it only falls back for the wrong-MIME case),
- * surfacing as `TypeError: Failed to execute 'compile' on 'WebAssembly': HTTP
- * status code is not ok`. A transient blip — a cold CDN edge, a mid-deploy
- * race, a flaky proxy — can produce a one-off failure that a second attempt
- * recovers. Retry the init once on a fetch/HTTP-shaped failure before giving
- * up; a genuine compile/validation error (corrupt module) propagates
- * immediately so we don't mask real bugs. `__wbg_init` only short-circuits on
- * `wasm !== undefined`, so a retry after a failed load safely re-fetches.
- */
-async function initWasmWithRetry(url: string | undefined): Promise<void> {
-  try {
-    await init(url);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    const looksTransient =
-      /HTTP status code is not ok|failed to fetch|networkerror|load failed|streaming/i.test(msg) ||
-      /'(?:compile|compileStreaming|instantiate|instantiateStreaming)' on 'WebAssembly'/i.test(msg);
-    if (!looksTransient) throw err;
-    console.warn(`[Worker] WASM engine load failed (${msg}); retrying once`);
-    await new Promise((resolve) => setTimeout(resolve, 300));
-    await init(url);
-  }
-}
-
-/**
  * Idempotent wasm + IfcAPI initializer. Centralises the
  * `if (!api) { await init(); api = new IfcAPI(); ... }` boilerplate that
  * every message handler used to repeat. Honours `cachedWasmUrl` so the
  * explicit-URL plumbing only has to set state in one place. Returns the
  * `IfcAPI` so call sites can use the value directly without a non-null
  * assertion on the module-level `api`.
+ *
+ * `init` is wrapped in {@link initWasmWithRetry} so a transient engine-binary
+ * download failure (a cold CDN edge, mid-deploy race, or flaky proxy) is
+ * retried once before failing. `__wbg_init` only short-circuits on
+ * `wasm !== undefined`, so a retry after a failed load safely re-fetches.
  */
 async function ensureInit(): Promise<IfcAPI> {
   if (api) return api;
-  await initWasmWithRetry(cachedWasmUrl);
+  await initWasmWithRetry(() => init(cachedWasmUrl), { label: 'geometry.worker' });
   api = new IfcAPI();
   mergeLayersApplied = false;
   applyMergeLayersToApi();

--- a/packages/geometry/src/wasm-init-retry.test.ts
+++ b/packages/geometry/src/wasm-init-retry.test.ts
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect, vi } from 'vitest';
+import { initWasmWithRetry, isTransientWasmLoadError } from './wasm-init-retry.js';
+
+const noop = () => {};
+const instantSleep = () => Promise.resolve();
+
+describe('isTransientWasmLoadError', () => {
+  it('flags the wasm-bindgen non-OK HTTP status (PostHog issue 019ed949)', () => {
+    expect(
+      isTransientWasmLoadError(
+        "Failed to execute 'compile' on 'WebAssembly': HTTP status code is not ok",
+      ),
+    ).toBe(true);
+  });
+
+  it('flags streaming compile/instantiate failures and failed fetches', () => {
+    for (const verb of ['compile', 'compileStreaming', 'instantiate', 'instantiateStreaming']) {
+      expect(isTransientWasmLoadError(`Failed to execute '${verb}' on 'WebAssembly': x`)).toBe(true);
+    }
+    expect(isTransientWasmLoadError('Failed to fetch')).toBe(true);
+    expect(isTransientWasmLoadError('NetworkError when attempting to fetch resource')).toBe(true);
+  });
+
+  it('does NOT flag genuine compile/validation errors', () => {
+    expect(isTransientWasmLoadError('CompileError: invalid value type')).toBe(false);
+    expect(isTransientWasmLoadError('unreachable executed')).toBe(false);
+  });
+});
+
+describe('initWasmWithRetry', () => {
+  it('returns after a single successful init (no retry)', async () => {
+    const init = vi.fn().mockResolvedValue(undefined);
+    await initWasmWithRetry(init, { sleep: instantSleep, warn: noop });
+    expect(init).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries once on a transient error and succeeds', async () => {
+    const init = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new TypeError("Failed to execute 'compile' on 'WebAssembly': HTTP status code is not ok"),
+      )
+      .mockResolvedValueOnce(undefined);
+    await initWasmWithRetry(init, { sleep: instantSleep, warn: noop });
+    expect(init).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT retry a non-transient error and rethrows immediately', async () => {
+    const init = vi.fn().mockRejectedValue(new Error('CompileError: invalid value type'));
+    await expect(initWasmWithRetry(init, { sleep: instantSleep, warn: noop })).rejects.toThrow(
+      /CompileError/,
+    );
+    expect(init).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates the second failure after retrying a transient error', async () => {
+    const init = vi.fn().mockRejectedValue(new Error('Failed to fetch'));
+    await expect(initWasmWithRetry(init, { sleep: instantSleep, warn: noop })).rejects.toThrow(
+      /Failed to fetch/,
+    );
+    expect(init).toHaveBeenCalledTimes(2);
+  });
+
+  it('waits the configured delay before retrying', async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const init = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Failed to fetch'))
+      .mockResolvedValueOnce(undefined);
+    await initWasmWithRetry(init, { sleep, warn: noop, retryDelayMs: 500 });
+    expect(sleep).toHaveBeenCalledWith(500);
+  });
+});

--- a/packages/geometry/src/wasm-init-retry.test.ts
+++ b/packages/geometry/src/wasm-init-retry.test.ts
@@ -17,16 +17,20 @@ describe('isTransientWasmLoadError', () => {
     ).toBe(true);
   });
 
-  it('flags streaming compile/instantiate failures and failed fetches', () => {
-    for (const verb of ['compile', 'compileStreaming', 'instantiate', 'instantiateStreaming']) {
-      expect(isTransientWasmLoadError(`Failed to execute '${verb}' on 'WebAssembly': x`)).toBe(true);
-    }
-    expect(isTransientWasmLoadError('Failed to fetch')).toBe(true);
-    expect(isTransientWasmLoadError('NetworkError when attempting to fetch resource')).toBe(true);
+  it('flags transport/network failures (cross-browser)', () => {
+    expect(isTransientWasmLoadError('Failed to fetch')).toBe(true); // Chromium
+    expect(isTransientWasmLoadError('NetworkError when attempting to fetch resource')).toBe(true); // Firefox
+    expect(isTransientWasmLoadError('Load failed')).toBe(true); // Safari
   });
 
-  it('does NOT flag genuine compile/validation errors', () => {
+  it('does NOT flag genuine compile/validation errors (bad bytes never recover on retry)', () => {
     expect(isTransientWasmLoadError('CompileError: invalid value type')).toBe(false);
+    expect(
+      isTransientWasmLoadError(
+        'CompileError: WebAssembly.instantiateStreaming(): expected magic word 00 61 73 6d',
+      ),
+    ).toBe(false);
+    expect(isTransientWasmLoadError('wasm validation error: at offset 0')).toBe(false);
     expect(isTransientWasmLoadError('unreachable executed')).toBe(false);
   });
 });

--- a/packages/geometry/src/wasm-init-retry.ts
+++ b/packages/geometry/src/wasm-init-retry.ts
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Resilient one-shot retry around wasm-bindgen's `init()`.
+ *
+ * wasm-bindgen's streaming loader rethrows on a non-OK HTTP status or a failed
+ * fetch of `ifc-lite_bg.wasm` (it only falls back to `arrayBuffer`+`instantiate`
+ * for the wrong-MIME case), surfacing as `TypeError: Failed to execute
+ * 'compile' on 'WebAssembly': HTTP status code is not ok`. A transient blip — a
+ * cold CDN edge, a mid-deploy race, a flaky proxy/antivirus — can produce a
+ * one-off failure that a second attempt recovers.
+ *
+ * Extracted from the worker so it is unit-testable without a real wasm bundle.
+ */
+
+/**
+ * True when `message` looks like a transient download/compile failure of the
+ * engine binary (worth one retry) rather than a genuine corrupt-module or
+ * validation error (which should propagate immediately so real bugs aren't
+ * masked).
+ */
+export function isTransientWasmLoadError(message: string): boolean {
+  return (
+    /HTTP status code is not ok|failed to fetch|networkerror|load failed|streaming/i.test(message) ||
+    /'(?:compile|compileStreaming|instantiate|instantiateStreaming)' on 'WebAssembly'/i.test(message)
+  );
+}
+
+export interface InitWasmRetryOptions {
+  /** Delay before the single retry. Default 300ms; pass 0 in tests. */
+  retryDelayMs?: number;
+  /** Injected sleep (tests pass an instant resolver). */
+  sleep?: (ms: number) => Promise<void>;
+  /** Injected logger (defaults to `console.warn`). */
+  warn?: (message: string) => void;
+  /** Context label for the log line. */
+  label?: string;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Run `init` once; on a transient-looking failure, wait and retry exactly once.
+ * Non-transient failures propagate without a retry. The second failure (if any)
+ * propagates to the caller.
+ *
+ * @param init Thunk that performs the actual `init(...)` call (so callers can
+ *   bind their own wasm URL / arguments).
+ */
+export async function initWasmWithRetry(
+  init: () => Promise<unknown>,
+  options: InitWasmRetryOptions = {},
+): Promise<void> {
+  const { retryDelayMs = 300, sleep = defaultSleep, warn = console.warn, label = 'wasm' } = options;
+  try {
+    await init();
+    return;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!isTransientWasmLoadError(msg)) throw err;
+    warn(`[${label}] WASM engine load failed (${msg}); retrying once`);
+    await sleep(retryDelayMs);
+    await init();
+  }
+}

--- a/packages/geometry/src/wasm-init-retry.ts
+++ b/packages/geometry/src/wasm-init-retry.ts
@@ -16,16 +16,24 @@
  */
 
 /**
- * True when `message` looks like a transient download/compile failure of the
+ * True when `message` looks like a transient transport/download failure of the
  * engine binary (worth one retry) rather than a genuine corrupt-module or
- * validation error (which should propagate immediately so real bugs aren't
+ * validation error (which must propagate immediately so real bugs aren't
  * masked).
+ *
+ * Per the WebAssembly Web API, the streaming loader validates the HTTP response
+ * (status, MIME, CORS) and rejects with a `TypeError` BEFORE compiling, so only
+ * those transport failures are retry-worthy. Invalid bytes (corrupt module,
+ * wrong magic header) reject with a `CompileError` — retrying just refetches
+ * the same bad bytes, so those fail fast.
  */
 export function isTransientWasmLoadError(message: string): boolean {
-  return (
-    /HTTP status code is not ok|failed to fetch|networkerror|load failed|streaming/i.test(message) ||
-    /'(?:compile|compileStreaming|instantiate|instantiateStreaming)' on 'WebAssembly'/i.test(message)
-  );
+  // Fail fast on genuine module-validation errors even if a transport-ish word
+  // somehow appears in the message.
+  if (/compileerror|validation error|magic (?:word|number)|invalid (?:wasm|module)/i.test(message)) {
+    return false;
+  }
+  return /HTTP status code is not ok|failed to fetch|network ?error|load failed/i.test(message);
 }
 
 export interface InitWasmRetryOptions {

--- a/packages/parser/src/parser.worker.ts
+++ b/packages/parser/src/parser.worker.ts
@@ -125,9 +125,33 @@ function postOutput(message: ParserWorkerOutputMessage, transfers?: Transferable
 let cachedFullScanApi: Pick<WasmScanApi, 'scanEntitiesFastBytes'> | null = null;
 let initPromise: Promise<void> | null = null;
 
+/**
+ * wasm-bindgen's streaming loader rethrows on a non-OK HTTP status or a failed
+ * fetch of `ifc-lite_bg.wasm` (it only falls back for the wrong-MIME case),
+ * surfacing as `TypeError: Failed to execute 'compile' on 'WebAssembly': HTTP
+ * status code is not ok`. A transient blip — a cold CDN edge, a mid-deploy
+ * race, a flaky proxy — can produce a one-off failure that a second attempt
+ * recovers. Retry the init once on a fetch/HTTP-shaped failure; a genuine
+ * compile/validation error propagates immediately so we don't mask real bugs.
+ */
+async function initWasmWithRetry(): Promise<void> {
+  try {
+    await init();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    const looksTransient =
+      /HTTP status code is not ok|failed to fetch|networkerror|load failed|streaming/i.test(msg) ||
+      /'(?:compile|compileStreaming|instantiate|instantiateStreaming)' on 'WebAssembly'/i.test(msg);
+    if (!looksTransient) throw err;
+    console.warn(`[parser.worker] WASM engine load failed (${msg}); retrying once`);
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    await init();
+  }
+}
+
 async function ensureWasmScanApi(): Promise<Pick<WasmScanApi, 'scanEntitiesFastBytes'>> {
   if (cachedFullScanApi) return cachedFullScanApi;
-  if (!initPromise) initPromise = init().then(() => {});
+  if (!initPromise) initPromise = initWasmWithRetry();
   await initPromise;
   const api = new IfcAPI();
   cachedFullScanApi = {

--- a/packages/parser/src/parser.worker.ts
+++ b/packages/parser/src/parser.worker.ts
@@ -16,6 +16,7 @@
  */
 
 import init, { IfcAPI } from '@ifc-lite/wasm';
+import { initWasmWithRetry } from './wasm-init-retry.js';
 import { IfcParser } from './index.js';
 import type { IfcDataStore } from './columnar-parser.js';
 import type { WasmScanApi } from './entity-scanner.js';
@@ -125,33 +126,18 @@ function postOutput(message: ParserWorkerOutputMessage, transfers?: Transferable
 let cachedFullScanApi: Pick<WasmScanApi, 'scanEntitiesFastBytes'> | null = null;
 let initPromise: Promise<void> | null = null;
 
-/**
- * wasm-bindgen's streaming loader rethrows on a non-OK HTTP status or a failed
- * fetch of `ifc-lite_bg.wasm` (it only falls back for the wrong-MIME case),
- * surfacing as `TypeError: Failed to execute 'compile' on 'WebAssembly': HTTP
- * status code is not ok`. A transient blip — a cold CDN edge, a mid-deploy
- * race, a flaky proxy — can produce a one-off failure that a second attempt
- * recovers. Retry the init once on a fetch/HTTP-shaped failure; a genuine
- * compile/validation error propagates immediately so we don't mask real bugs.
- */
-async function initWasmWithRetry(): Promise<void> {
-  try {
-    await init();
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    const looksTransient =
-      /HTTP status code is not ok|failed to fetch|networkerror|load failed|streaming/i.test(msg) ||
-      /'(?:compile|compileStreaming|instantiate|instantiateStreaming)' on 'WebAssembly'/i.test(msg);
-    if (!looksTransient) throw err;
-    console.warn(`[parser.worker] WASM engine load failed (${msg}); retrying once`);
-    await new Promise((resolve) => setTimeout(resolve, 300));
-    await init();
-  }
-}
-
 async function ensureWasmScanApi(): Promise<Pick<WasmScanApi, 'scanEntitiesFastBytes'>> {
   if (cachedFullScanApi) return cachedFullScanApi;
-  if (!initPromise) initPromise = initWasmWithRetry();
+  // `init` is wrapped in `initWasmWithRetry` so a transient engine-binary
+  // download failure is retried once before failing. Clear `initPromise` on
+  // failure so a later call can recover (e.g. the network came back) instead
+  // of memoising the rejection forever.
+  if (!initPromise) {
+    initPromise = initWasmWithRetry(() => init(), { label: 'parser.worker' }).catch((err) => {
+      initPromise = null;
+      throw err;
+    });
+  }
   await initPromise;
   const api = new IfcAPI();
   cachedFullScanApi = {

--- a/packages/parser/src/wasm-init-retry.test.ts
+++ b/packages/parser/src/wasm-init-retry.test.ts
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect, vi } from 'vitest';
+import { initWasmWithRetry, isTransientWasmLoadError } from './wasm-init-retry.js';
+
+const noop = () => {};
+const instantSleep = () => Promise.resolve();
+
+describe('isTransientWasmLoadError', () => {
+  it('flags the wasm-bindgen non-OK HTTP status (PostHog issue 019ed949)', () => {
+    expect(
+      isTransientWasmLoadError(
+        "Failed to execute 'compile' on 'WebAssembly': HTTP status code is not ok",
+      ),
+    ).toBe(true);
+  });
+
+  it('flags streaming compile/instantiate failures and failed fetches', () => {
+    for (const verb of ['compile', 'compileStreaming', 'instantiate', 'instantiateStreaming']) {
+      expect(isTransientWasmLoadError(`Failed to execute '${verb}' on 'WebAssembly': x`)).toBe(true);
+    }
+    expect(isTransientWasmLoadError('Failed to fetch')).toBe(true);
+    expect(isTransientWasmLoadError('NetworkError when attempting to fetch resource')).toBe(true);
+  });
+
+  it('does NOT flag genuine compile/validation errors', () => {
+    expect(isTransientWasmLoadError('CompileError: invalid value type')).toBe(false);
+    expect(isTransientWasmLoadError('unreachable executed')).toBe(false);
+  });
+});
+
+describe('initWasmWithRetry', () => {
+  it('returns after a single successful init (no retry)', async () => {
+    const init = vi.fn().mockResolvedValue(undefined);
+    await initWasmWithRetry(init, { sleep: instantSleep, warn: noop });
+    expect(init).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries once on a transient error and succeeds', async () => {
+    const init = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new TypeError("Failed to execute 'compile' on 'WebAssembly': HTTP status code is not ok"),
+      )
+      .mockResolvedValueOnce(undefined);
+    await initWasmWithRetry(init, { sleep: instantSleep, warn: noop });
+    expect(init).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT retry a non-transient error and rethrows immediately', async () => {
+    const init = vi.fn().mockRejectedValue(new Error('CompileError: invalid value type'));
+    await expect(initWasmWithRetry(init, { sleep: instantSleep, warn: noop })).rejects.toThrow(
+      /CompileError/,
+    );
+    expect(init).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates the second failure after retrying a transient error', async () => {
+    const init = vi.fn().mockRejectedValue(new Error('Failed to fetch'));
+    await expect(initWasmWithRetry(init, { sleep: instantSleep, warn: noop })).rejects.toThrow(
+      /Failed to fetch/,
+    );
+    expect(init).toHaveBeenCalledTimes(2);
+  });
+
+  it('waits the configured delay before retrying', async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const init = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Failed to fetch'))
+      .mockResolvedValueOnce(undefined);
+    await initWasmWithRetry(init, { sleep, warn: noop, retryDelayMs: 500 });
+    expect(sleep).toHaveBeenCalledWith(500);
+  });
+});

--- a/packages/parser/src/wasm-init-retry.test.ts
+++ b/packages/parser/src/wasm-init-retry.test.ts
@@ -17,16 +17,20 @@ describe('isTransientWasmLoadError', () => {
     ).toBe(true);
   });
 
-  it('flags streaming compile/instantiate failures and failed fetches', () => {
-    for (const verb of ['compile', 'compileStreaming', 'instantiate', 'instantiateStreaming']) {
-      expect(isTransientWasmLoadError(`Failed to execute '${verb}' on 'WebAssembly': x`)).toBe(true);
-    }
-    expect(isTransientWasmLoadError('Failed to fetch')).toBe(true);
-    expect(isTransientWasmLoadError('NetworkError when attempting to fetch resource')).toBe(true);
+  it('flags transport/network failures (cross-browser)', () => {
+    expect(isTransientWasmLoadError('Failed to fetch')).toBe(true); // Chromium
+    expect(isTransientWasmLoadError('NetworkError when attempting to fetch resource')).toBe(true); // Firefox
+    expect(isTransientWasmLoadError('Load failed')).toBe(true); // Safari
   });
 
-  it('does NOT flag genuine compile/validation errors', () => {
+  it('does NOT flag genuine compile/validation errors (bad bytes never recover on retry)', () => {
     expect(isTransientWasmLoadError('CompileError: invalid value type')).toBe(false);
+    expect(
+      isTransientWasmLoadError(
+        'CompileError: WebAssembly.instantiateStreaming(): expected magic word 00 61 73 6d',
+      ),
+    ).toBe(false);
+    expect(isTransientWasmLoadError('wasm validation error: at offset 0')).toBe(false);
     expect(isTransientWasmLoadError('unreachable executed')).toBe(false);
   });
 });

--- a/packages/parser/src/wasm-init-retry.ts
+++ b/packages/parser/src/wasm-init-retry.ts
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Resilient one-shot retry around wasm-bindgen's `init()`.
+ *
+ * wasm-bindgen's streaming loader rethrows on a non-OK HTTP status or a failed
+ * fetch of `ifc-lite_bg.wasm` (it only falls back to `arrayBuffer`+`instantiate`
+ * for the wrong-MIME case), surfacing as `TypeError: Failed to execute
+ * 'compile' on 'WebAssembly': HTTP status code is not ok`. A transient blip — a
+ * cold CDN edge, a mid-deploy race, a flaky proxy/antivirus — can produce a
+ * one-off failure that a second attempt recovers.
+ *
+ * Extracted from the worker so it is unit-testable without a real wasm bundle.
+ */
+
+/**
+ * True when `message` looks like a transient download/compile failure of the
+ * engine binary (worth one retry) rather than a genuine corrupt-module or
+ * validation error (which should propagate immediately so real bugs aren't
+ * masked).
+ */
+export function isTransientWasmLoadError(message: string): boolean {
+  return (
+    /HTTP status code is not ok|failed to fetch|networkerror|load failed|streaming/i.test(message) ||
+    /'(?:compile|compileStreaming|instantiate|instantiateStreaming)' on 'WebAssembly'/i.test(message)
+  );
+}
+
+export interface InitWasmRetryOptions {
+  /** Delay before the single retry. Default 300ms; pass 0 in tests. */
+  retryDelayMs?: number;
+  /** Injected sleep (tests pass an instant resolver). */
+  sleep?: (ms: number) => Promise<void>;
+  /** Injected logger (defaults to `console.warn`). */
+  warn?: (message: string) => void;
+  /** Context label for the log line. */
+  label?: string;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Run `init` once; on a transient-looking failure, wait and retry exactly once.
+ * Non-transient failures propagate without a retry. The second failure (if any)
+ * propagates to the caller.
+ *
+ * @param init Thunk that performs the actual `init(...)` call (so callers can
+ *   bind their own wasm URL / arguments).
+ */
+export async function initWasmWithRetry(
+  init: () => Promise<unknown>,
+  options: InitWasmRetryOptions = {},
+): Promise<void> {
+  const { retryDelayMs = 300, sleep = defaultSleep, warn = console.warn, label = 'wasm' } = options;
+  try {
+    await init();
+    return;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!isTransientWasmLoadError(msg)) throw err;
+    warn(`[${label}] WASM engine load failed (${msg}); retrying once`);
+    await sleep(retryDelayMs);
+    await init();
+  }
+}

--- a/packages/parser/src/wasm-init-retry.ts
+++ b/packages/parser/src/wasm-init-retry.ts
@@ -16,16 +16,24 @@
  */
 
 /**
- * True when `message` looks like a transient download/compile failure of the
+ * True when `message` looks like a transient transport/download failure of the
  * engine binary (worth one retry) rather than a genuine corrupt-module or
- * validation error (which should propagate immediately so real bugs aren't
+ * validation error (which must propagate immediately so real bugs aren't
  * masked).
+ *
+ * Per the WebAssembly Web API, the streaming loader validates the HTTP response
+ * (status, MIME, CORS) and rejects with a `TypeError` BEFORE compiling, so only
+ * those transport failures are retry-worthy. Invalid bytes (corrupt module,
+ * wrong magic header) reject with a `CompileError` — retrying just refetches
+ * the same bad bytes, so those fail fast.
  */
 export function isTransientWasmLoadError(message: string): boolean {
-  return (
-    /HTTP status code is not ok|failed to fetch|networkerror|load failed|streaming/i.test(message) ||
-    /'(?:compile|compileStreaming|instantiate|instantiateStreaming)' on 'WebAssembly'/i.test(message)
-  );
+  // Fail fast on genuine module-validation errors even if a transport-ish word
+  // somehow appears in the message.
+  if (/compileerror|validation error|magic (?:word|number)|invalid (?:wasm|module)/i.test(message)) {
+    return false;
+  }
+  return /HTTP status code is not ok|failed to fetch|network ?error|load failed/i.test(message);
 }
 
 export interface InitWasmRetryOptions {


### PR DESCRIPTION
## What

Fixes PostHog error-tracking issue [`019ed949`](https://eu.posthog.com/project/199147/error_tracking/019ed949-8d6b-7a72-b2a5-5c2f7be1d37f): `TypeError: Failed to execute 'compile' on 'WebAssembly': HTTP status code is not ok` (1 occurrence, Edge 149 / Windows 10, handled).

## Root cause

The geometry and parser workers both `init()` the same `ifc-lite_bg.wasm`. wasm-bindgen's streaming loader (`__wbg_load`) **rethrows** on a non-OK HTTP status — it only falls back to `arrayBuffer()`+`instantiate` for the *wrong-MIME* case. So this is a genuine failed download of the engine binary, surfaced as a cryptic `TypeError` and captured at `useIfcLoader`'s outer catch.

With **no service worker** in play and a **single occurrence in 30 days** (the deployed wasm path works for everyone else), this is a transient/environmental failure — a cold CDN edge, a mid-deploy race, or a proxy/antivirus blocking the `.wasm` (plausible on corporate Edge/Windows). The right fix is **resilience + clarity**, not a config change.

## Changes

- **Workers** (`packages/{geometry,parser}/src/*.worker.ts`): `init()` retries **once** (300 ms backoff) on a fetch/HTTP-shaped failure before propagating. Genuine compile/validation errors still throw immediately, so real bugs aren't masked. Safe because `__wbg_init` only short-circuits on `wasm !== undefined`.
- **`apps/viewer/src/lib/load-errors.ts`** (new): `classifyLoadError()` → stable `error_kind` (`wasm_engine_load` / `out_of_memory` / `cancelled` / `unknown`); `formatLoadError()` → actionable message ("Couldn't load the 3D geometry engine… reload the page") instead of the raw TypeError.
- **`useIfcLoader.ts`**: wired the humanizer into all failure surfaces and tagged captured exceptions with `error_kind` so future occurrences are filterable in PostHog.

## Verification

- New unit test `load-errors.test.ts` (10 cases incl. the exact captured message) — passing.
- `tsc --noEmit` clean for all 4 touched files.
- Note: workers not exercised end-to-end (no wasm build in a fresh worktree); retry logic is simple and typechecks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebAssembly engine initialization resilience: geometry and scan workers now retry once when the WASM engine fetch/load fails transiently (e.g., CDN edge races, blocked downloads, proxy/antivirus interference).
  * Updated viewer error handling to show actionable guidance (such as reloading) instead of raw technical errors.
  * Added consistent error categorization to improve monitoring and troubleshooting.
* **Tests**
  * Added coverage for transient WASM retry behavior and for user-facing error classification/formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->