### PR TITLE
fix(viewer): number RAW STEP attributes 1-based to match IFC docs

### DIFF
--- a/apps/viewer/src/components/viewer/properties/RawStepCard.tsx
+++ b/apps/viewer/src/components/viewer/properties/RawStepCard.tsx
@@ -298,7 +298,9 @@ export function RawStepCard({
       {/* Rows */}
       <div className="divide-y-0">
         {tokens.map((token, idx) => {
-          const name = attributeNames[idx] || `Arg ${idx}`;
+          // Fallback name uses the 1-based position so it stays aligned with
+          // the bracketed index shown in each row (which is also 1-based).
+          const name = attributeNames[idx] || `Arg ${idx + 1}`;
           return (
             <RawStepRow
               key={idx}

--- a/apps/viewer/src/components/viewer/properties/RawStepRow.tsx
+++ b/apps/viewer/src/components/viewer/properties/RawStepRow.tsx
@@ -111,12 +111,14 @@ export function RawStepRow({
         isMutated ? 'bg-purple-50/40 dark:bg-purple-950/15' : ''
       }`}
     >
-      {/* Positional index */}
+      {/* Positional index — displayed 1-based to match the buildingSMART
+       *  IFC attribute tables and STEP documentation (GlobalId = #1).
+       *  The `index` prop stays 0-based for store/overlay addressing. */}
       <span
         className="text-[10px] font-mono text-zinc-400 dark:text-zinc-500 tabular-nums tracking-wide"
-        aria-label={`positional index ${index}`}
+        aria-label={`positional index ${index + 1}`}
       >
-        [{index}]
+        [{index + 1}]
       </span>
 
       {/* Schema attribute name */}


### PR DESCRIPTION
## Problem

Reported in #1189. The **RAW** STEP attribute panel numbers positional attributes **0-based** — `[0]` for `GlobalId`, `[1]` for `OwnerHistory`, etc. But the buildingSMART IFC attribute tables and the STEP convention number them **starting at 1** (`GlobalId` = #1). Cross-referencing the documentation against the panel was confusing.

| | Before | After |
|---|---|---|
| GlobalId | `[0]` | `[1]` |
| OwnerHistory | `[1]` | `[2]` |
| … | … | … |

## Fix

Display the bracketed index (and the `Arg N` fallback name, kept aligned with it) **1-based**.

The internal `index` prop stays **0-based** — it drives `setPositionalAttribute` and the `mutatedIndices` overlay-override tracking, which address arguments by their true positional offset. Only the user-facing rendering shifted.

Files:
- `apps/viewer/.../properties/RawStepRow.tsx` — `[{index + 1}]` + matching `aria-label`
- `apps/viewer/.../properties/RawStepCard.tsx` — `Arg ${idx + 1}` fallback

## Notes

- Viewer-only display change; no published-package src touched, so no changeset needed.
- No tests/snapshots referenced the 0-based display.

Closes #1189

🤖 Generated with [Claude Code](https://claude.com/claude-code)