### PR TITLE
perf(geometry): parametric placement-frame rectangular-opening fast path (flag-gated, OFF)

### DIFF
--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -221,6 +221,18 @@ export class IfcAPI {
    */
   clearPrePassCache(): void;
   /**
+   * Enable or disable the PARAMETRIC rectangular-opening fast path (the
+   * placement-frame, ground-truth-exact analytic cut) for `processGeometryBatch`.
+   *
+   * DEFAULT OFF. This is the wasm-side toggle that lets native and wasm flip the
+   * flag in LOCKSTEP — the byte-identical native==wasm contract requires both
+   * targets take the same path, and wasm has no env to read `IFC_LITE_RECT_PARAM`.
+   * The path subtracts rectangular openings as exact parametric boxes in the host's
+   * own placement frame (rotated walls included), deferring any non-clean case to
+   * the exact kernel. Pass `true` before `processGeometryBatch`.
+   */
+  setRectParamFastPath(enabled: boolean): void;
+  /**
    * Select the tessellation detail level applied by every subsequent
    * `processGeometryBatch` call (issue #976, step 4).
    *
@@ -929,6 +941,7 @@ export interface InitOutput {
   readonly ifcapi_setComputeGeometryHashes: (a: number, b: number, c: number) => void;
   readonly ifcapi_setEntityIndex: (a: number, b: number, c: number, d: number, e: number, f: number, g: number) => void;
   readonly ifcapi_setMergeLayers: (a: number, b: number) => void;
+  readonly ifcapi_setRectParamFastPath: (a: number, b: number) => void;
   readonly ifcapi_setTessellationQuality: (a: number, b: number, c: number, d: number) => void;
   readonly ifcapi_version: (a: number, b: number) => void;
   readonly meshOutline2d: (a: number, b: number, c: number, d: number, e: number, f: number) => number;

--- a/rust/geometry/src/lib.rs
+++ b/rust/geometry/src/lib.rs
@@ -128,7 +128,7 @@ pub use profile_extractor::{extract_profiles, ExtractedProfile};
 pub use profiles::ProfileProcessor;
 pub use router::{
     ClassificationStats, GeometryProcessor, GeometryRouter, HostOpeningDiagnostic, ItemDedupCache,
-    OpeningDiagnostic, OpeningKindDiag,
+    OpeningDiagnostic, OpeningKindDiag, RectParam,
 };
 pub use tessellation::{scale_segments, TessellationQuality};
 pub use transform::{

--- a/rust/geometry/src/rect_fast.rs
+++ b/rust/geometry/src/rect_fast.rs
@@ -61,6 +61,48 @@ pub fn enabled() -> bool {
     *ON.get_or_init(|| std::env::var("IFC_LITE_RECT_FAST").as_deref() != Ok("0"))
 }
 
+static PARAM_OVERRIDE: std::sync::atomic::AtomicI8 = std::sync::atomic::AtomicI8::new(-1);
+
+/// PARAMETRIC rectangular-opening fast path (placement-frame, ground-truth-exact cut).
+/// DEFAULT OFF — opt in with `IFC_LITE_RECT_PARAM=1` or `param_set_enabled_override`.
+/// Gated separately from [`enabled`] because it is a deliberate behaviour change: it
+/// emits the analytic box-minus-boxes solid, which is MORE correct than the exact kernel
+/// on engulfing-opening walls. Stays off until a parity CI gate + a wasm toggle land, so
+/// native==wasm holds trivially (both off) until the flag is flipped in lockstep.
+pub fn param_enabled() -> bool {
+    match PARAM_OVERRIDE.load(std::sync::atomic::Ordering::Relaxed) {
+        0 => return false,
+        1 => return true,
+        _ => {}
+    }
+    use std::sync::OnceLock;
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| std::env::var("IFC_LITE_RECT_PARAM").as_deref() == Ok("1"))
+}
+
+/// Test-only: force `param_enabled()` on/off (or `None` for the env default).
+pub fn param_set_enabled_override(v: Option<bool>) {
+    PARAM_OVERRIDE.store(
+        match v {
+            None => -1,
+            Some(false) => 0,
+            Some(true) => 1,
+        },
+        std::sync::atomic::Ordering::Relaxed,
+    );
+}
+
+static PARAM_FIRES: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Count one parametric fast-path fire (the analytic cut was emitted).
+pub fn param_record_fire() {
+    PARAM_FIRES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+}
+/// Read + reset the parametric fast-path fire counter.
+pub fn take_param_fires() -> u64 {
+    PARAM_FIRES.swap(0, std::sync::atomic::Ordering::Relaxed)
+}
+
 mod telemetry {
     use super::RectFastStats;
     use std::sync::atomic::{AtomicU64, Ordering};

--- a/rust/geometry/src/router/mod.rs
+++ b/rust/geometry/src/router/mod.rs
@@ -15,6 +15,8 @@ mod transforms;
 mod voids;
 mod voids_2d;
 
+pub use voids::RectParam;
+
 #[cfg(test)]
 mod tests;
 

--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -9,7 +9,7 @@ use crate::csg::{tri_is_needle, ClippingProcessor, Plane, Triangle, TriangleVec}
 use crate::mesh::{SubMesh, SubMeshCollection};
 use crate::{Error, Mesh, Point3, Result, TessellationQuality, Vector3};
 use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcType};
-use nalgebra::Matrix4;
+use nalgebra::{Matrix3, Matrix4};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 /// Epsilon for normalizing direction vectors (guards against zero-length).
@@ -181,6 +181,134 @@ impl OpeningFrame {
 fn is_axis_aligned_direction(dir: &Vector3<f64>) -> bool {
     const AXIS_THRESHOLD: f64 = 0.95;
     dir.x.abs().max(dir.y.abs()).max(dir.z.abs()) > AXIS_THRESHOLD
+}
+
+// ── Parametric placement-frame cut helpers (see `try_param_rect_cut`). ───────────
+
+/// Rotate `(x,y,z)` by the orthonormal 3×3 `r` with an explicit, non-FMA dot product
+/// so the result is bit-identical native==wasm (the byte-identity contract forbids the
+/// fused-multiply-add `nalgebra`'s matrix product may emit).
+#[inline]
+fn rotate_point(r: &Matrix3<f64>, x: f64, y: f64, z: f64) -> [f64; 3] {
+    [
+        r[(0, 0)] * x + r[(0, 1)] * y + r[(0, 2)] * z,
+        r[(1, 0)] * x + r[(1, 1)] * y + r[(1, 2)] * z,
+        r[(2, 0)] * x + r[(2, 1)] * y + r[(2, 2)] * z,
+    ]
+}
+
+/// Index of the smallest half-extent (the wall thickness / penetration axis).
+fn thin_axis(half: &[f64; 3]) -> usize {
+    (0..3)
+        .min_by(|&a, &b| half[a].partial_cmp(&half[b]).unwrap())
+        .unwrap()
+}
+
+/// If `m` is a signed permutation matrix (each row one entry ≈±1, the rest ≈0, with
+/// distinct dominant columns), return the per-row `(source-column, sign)` map; else
+/// `None`. Used to align an opening's axes with the host frame.
+fn signed_permutation_map(m: &Matrix3<f64>, tol: f64) -> Option<[(usize, f64); 3]> {
+    let mut out = [(0usize, 1.0f64); 3];
+    let mut used = [false; 3];
+    for i in 0..3 {
+        let (mut best, mut best_abs, mut second) = (0usize, 0.0, 0.0);
+        for j in 0..3 {
+            let a = m[(i, j)].abs();
+            if a > best_abs {
+                second = best_abs;
+                best_abs = a;
+                best = j;
+            } else if a > second {
+                second = a;
+            }
+        }
+        if best_abs < 1.0 - tol || second > tol || used[best] {
+            return None;
+        }
+        used[best] = true;
+        out[i] = (best, m[(i, best)].signum());
+    }
+    Some(out)
+}
+
+/// Rotate a world mesh into frame F (`v_F = Rᵀ(v − center)`); small coords. Normals are
+/// dropped (the cellular cut recomputes per-face flat normals).
+fn rotate_mesh_into_frame(mesh: &Mesh, rt: &Matrix3<f64>, center: &Point3<f64>) -> Mesh {
+    let mut positions = Vec::with_capacity(mesh.positions.len());
+    for c in mesh.positions.chunks_exact(3) {
+        let p = rotate_point(
+            rt,
+            c[0] as f64 - center.x,
+            c[1] as f64 - center.y,
+            c[2] as f64 - center.z,
+        );
+        positions.push(p[0] as f32);
+        positions.push(p[1] as f32);
+        positions.push(p[2] as f32);
+    }
+    Mesh {
+        normals: vec![0.0; positions.len()],
+        indices: mesh.indices.clone(),
+        rtc_applied: mesh.rtc_applied,
+        origin: [0.0; 3],
+        positions,
+    }
+}
+
+/// Rotate a frame-F mesh into a LOCAL-FRAME world mesh: positions are `R·v_F` (small,
+/// near origin — NOT shifted by `center`) and `origin = center`, so `world = origin +
+/// position` for the renderer. Keeping positions small is what makes the cut survive
+/// f32 storage + `clean_degenerate` at building/national-grid magnitude (a world-coord
+/// store there erodes opening seams into holes — see `Mesh::clean_degenerate`).
+fn rotate_mesh_from_frame(mesh: &Mesh, r: &Matrix3<f64>, center: &Point3<f64>) -> Mesh {
+    let mut positions = Vec::with_capacity(mesh.positions.len());
+    for c in mesh.positions.chunks_exact(3) {
+        let p = rotate_point(r, c[0] as f64, c[1] as f64, c[2] as f64);
+        positions.push(p[0] as f32);
+        positions.push(p[1] as f32);
+        positions.push(p[2] as f32);
+    }
+    let mut normals = Vec::with_capacity(mesh.normals.len());
+    for c in mesh.normals.chunks_exact(3) {
+        let p = rotate_point(r, c[0] as f64, c[1] as f64, c[2] as f64);
+        normals.push(p[0] as f32);
+        normals.push(p[1] as f32);
+        normals.push(p[2] as f32);
+    }
+    Mesh {
+        positions,
+        normals,
+        indices: mesh.indices.clone(),
+        rtc_applied: mesh.rtc_applied,
+        origin: [center.x, center.y, center.z],
+    }
+}
+
+/// Closed-2-manifold self-check (0.1 mm weld): every undirected edge shared by exactly
+/// two non-degenerate triangles. The parametric path refuses to emit a cut that fails
+/// this, deferring to the exact kernel instead.
+fn param_cut_watertight(mesh: &Mesh) -> bool {
+    let key = |i: u32| -> (i64, i64, i64) {
+        let b = i as usize * 3;
+        let q = |v: f32| (v as f64 / 1.0e-4).round() as i64;
+        (
+            q(mesh.positions[b]),
+            q(mesh.positions[b + 1]),
+            q(mesh.positions[b + 2]),
+        )
+    };
+    let mut edges: FxHashMap<((i64, i64, i64), (i64, i64, i64)), i32> = FxHashMap::default();
+    for tri in mesh.indices.chunks_exact(3) {
+        let (ka, kb, kc) = (key(tri[0]), key(tri[1]), key(tri[2]));
+        if ka == kb || kb == kc || kc == ka {
+            continue;
+        }
+        for (x, y) in [(ka, kb), (kb, kc), (kc, ka)] {
+            let e = if x < y { (x, y) } else { (y, x) };
+            *edges.entry(e).or_insert(0) += 1;
+        }
+    }
+    !edges.is_empty() && edges.values().all(|&c| c == 2)
 }
 
 #[inline]
@@ -539,6 +667,10 @@ pub(super) struct VoidContext {
     /// Rectangular openings merged into larger boxes to prevent O(2^N)
     /// triangle growth when many adjacent openings tile a surface.
     merged_openings: Vec<OpeningType>,
+    /// Parametric placement-frame cut data (host + reconciled opening boxes),
+    /// captured only when `rect_fast::param_enabled()`. Drives the analytic fast
+    /// path in `apply_void_context`; `None` defers to the exact kernel.
+    param: Option<ParamRectCut>,
 }
 
 impl VoidContext {
@@ -559,6 +691,10 @@ impl VoidContext {
                 .iter()
                 .map(|o| o.translated(origin))
                 .collect(),
+            // The parametric path runs in the OUTER apply_void_context on the
+            // non-relativized world mesh (it makes its own frame), so the
+            // relativized context never uses `param` — drop it.
+            param: None,
         }
     }
 }
@@ -600,6 +736,26 @@ impl OpeningType {
             }
         }
     }
+}
+
+/// EXACT parametric oriented box of a rectangular extrusion, in WORLD space.
+/// `r` columns are the orthonormal world axes (profile-X', profile-Y', extrude);
+/// `half` are the half-extents along those axes (XDim/2, YDim/2, Depth/2).
+/// Produced by [`GeometryRouter::parametric_rect_probe`].
+#[derive(Clone, Copy)]
+pub struct RectParam {
+    pub r: Matrix3<f64>,
+    pub center: Point3<f64>,
+    pub half: [f64; 3],
+}
+
+/// Captured parametric boxes for a host + its openings (all reconciled to their
+/// meshes and sharing the host frame), enabling the analytic placement-frame cut.
+/// Built in [`GeometryRouter::build_void_context`] only when `param_enabled()`.
+#[derive(Clone)]
+struct ParamRectCut {
+    host: RectParam,
+    openings: Vec<RectParam>,
 }
 
 impl GeometryRouter {
@@ -709,6 +865,220 @@ impl GeometryRouter {
         }
 
         None
+    }
+
+    /// Read a rectangular swept area as `(x_dim, y_dim, off_x, off_y, cos, sin)` in the
+    /// profile plane. Handles `IfcRectangleProfileDef` (XDim/YDim + 2D Position rotation)
+    /// AND an `IfcArbitraryClosedProfileDef` whose outer curve is an axis-aligned 4-point
+    /// rectangle polyline (the common Tekla/structural authoring of a rectangular wall).
+    /// `None` for any non-rectangular profile → the caller defers to the exact kernel.
+    fn read_rect_profile_2d(
+        &self,
+        profile: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+    ) -> Option<(f64, f64, f64, f64, f64, f64)> {
+        match profile.ifc_type {
+            IfcType::IfcRectangleProfileDef => {
+                let x_dim = profile.get_float(3)?;
+                let y_dim = profile.get_float(4)?;
+                // Position (attr 2 = IfcAxis2Placement2D): in-plane rotation + offset.
+                let (mut cos_t, mut sin_t, mut off_x, mut off_y) = (1.0, 0.0, 0.0, 0.0);
+                if let Some(pos_attr) = profile.get(2) {
+                    if !pos_attr.is_null() {
+                        if let Ok(Some(pos)) = decoder.resolve_ref(pos_attr) {
+                            if let Some(loc_attr) = pos.get(0) {
+                                if let Ok(Some(loc)) = decoder.resolve_ref(loc_attr) {
+                                    if let Some(c) = loc.get(0).and_then(|x| x.as_list()) {
+                                        off_x = c.first().and_then(|x| x.as_float()).unwrap_or(0.0);
+                                        off_y = c.get(1).and_then(|x| x.as_float()).unwrap_or(0.0);
+                                    }
+                                }
+                            }
+                            if let Some(rd_attr) = pos.get(1) {
+                                if !rd_attr.is_null() {
+                                    if let Ok(Some(rd)) = decoder.resolve_ref(rd_attr) {
+                                        if let Some(c) = rd.get(0).and_then(|x| x.as_list()) {
+                                            let dx =
+                                                c.first().and_then(|x| x.as_float()).unwrap_or(1.0);
+                                            let dy =
+                                                c.get(1).and_then(|x| x.as_float()).unwrap_or(0.0);
+                                            let n = (dx * dx + dy * dy).sqrt();
+                                            if n > 1e-12 {
+                                                cos_t = dx / n;
+                                                sin_t = dy / n;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                Some((x_dim, y_dim, off_x, off_y, cos_t, sin_t))
+            }
+            IfcType::IfcArbitraryClosedProfileDef => {
+                // OuterCurve (attr 2) must be an axis-aligned rectangle polyline.
+                let curve = decoder.resolve_ref(profile.get(2)?).ok()??;
+                if curve.ifc_type != IfcType::IfcPolyline {
+                    return None;
+                }
+                let pts = decoder.resolve_ref_list(curve.get(0)?).ok()?;
+                let mut coords: Vec<(f64, f64)> = Vec::with_capacity(pts.len());
+                for p in &pts {
+                    let c = p.get(0).and_then(|x| x.as_list())?;
+                    coords.push((c.first()?.as_float()?, c.get(1)?.as_float()?));
+                }
+                // Drop a repeated closing vertex.
+                if coords.len() >= 2 {
+                    let (f, l) = (coords[0], coords[coords.len() - 1]);
+                    if (f.0 - l.0).abs() < 1e-9 && (f.1 - l.1).abs() < 1e-9 {
+                        coords.pop();
+                    }
+                }
+                if coords.len() != 4 {
+                    return None;
+                }
+                let minx = coords.iter().map(|c| c.0).fold(f64::INFINITY, f64::min);
+                let maxx = coords.iter().map(|c| c.0).fold(f64::NEG_INFINITY, f64::max);
+                let miny = coords.iter().map(|c| c.1).fold(f64::INFINITY, f64::min);
+                let maxy = coords.iter().map(|c| c.1).fold(f64::NEG_INFINITY, f64::max);
+                let (xd, yd) = (maxx - minx, maxy - miny);
+                if xd <= 0.0 || yd <= 0.0 {
+                    return None;
+                }
+                // Every vertex must sit on a rectangle corner (axis-aligned in-plane).
+                let tol = (xd + yd) * 1e-6 + 1e-9;
+                for &(x, y) in &coords {
+                    let on_x = (x - minx).abs() < tol || (x - maxx).abs() < tol;
+                    let on_y = (y - miny).abs() < tol || (y - maxy).abs() < tol;
+                    if !(on_x && on_y) {
+                        return None;
+                    }
+                }
+                Some((xd, yd, (minx + maxx) * 0.5, (miny + maxy) * 0.5, 1.0, 0.0))
+            }
+            _ => None,
+        }
+    }
+
+    /// PHASE-0 CENSUS (read-only): the EXACT oriented rectangular box of an extruded
+    /// element, read from the IFC parametrics (IfcRectangleProfileDef XDim/YDim/Depth +
+    /// composed placement axes), NOT inferred from the f32 mesh. Returns `None` unless the
+    /// element's body is a single clean IfcRectangleProfileDef extrusion (after unwrapping
+    /// IfcBooleanClippingResult / IfcMappedItem). This is the parametric frame + extents the
+    /// failed oriented attempt should have used instead of `infer_opening_frame` + mesh-AABB.
+    pub fn parametric_rect_probe(
+        &self,
+        element: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+    ) -> Option<RectParam> {
+        let placement = self
+            .get_placement_transform_from_element(element, decoder)
+            .ok()?;
+
+        // element → IfcProductDefinitionShape → first Body/SweptSolid item.
+        let rep = decoder.resolve_ref(element.get(6)?).ok()??;
+        if rep.ifc_type != IfcType::IfcProductDefinitionShape {
+            return None;
+        }
+        let reps = decoder.resolve_ref_list(rep.get(2)?).ok()?;
+        let mut item = None;
+        for sr in reps {
+            if sr.ifc_type != IfcType::IfcShapeRepresentation {
+                continue;
+            }
+            let rt = sr.get(2).and_then(|a| a.as_string()).unwrap_or("");
+            if !matches!(
+                rt,
+                "Body" | "SweptSolid" | "SolidModel" | "Clipping" | "AdvancedSweptSolid"
+                    | "MappedRepresentation"
+            ) {
+                continue;
+            }
+            if let Ok(items) = decoder.resolve_ref_list(sr.get(3)?) {
+                if let Some(first) = items.into_iter().next() {
+                    item = Some(first);
+                    break;
+                }
+            }
+        }
+
+        // Unwrap to the IfcExtrudedAreaSolid, accumulating the mapped/clip transform chain.
+        let mut current = item?;
+        let mut chain = Matrix4::<f64>::identity();
+        let mut visited = FxHashSet::default();
+        let solid = loop {
+            if !visited.insert(current.id) || visited.len() > MAX_EXTRUSION_EXTRACT_DEPTH {
+                return None;
+            }
+            match current.ifc_type {
+                IfcType::IfcExtrudedAreaSolid => break current,
+                IfcType::IfcBooleanClippingResult | IfcType::IfcBooleanResult => {
+                    current = decoder.resolve_ref(current.get(1)?).ok()??;
+                }
+                IfcType::IfcMappedItem => {
+                    let source = decoder.resolve_ref(current.get(0)?).ok()??;
+                    let mapped_rep = decoder.resolve_ref(source.get(1)?).ok()??;
+                    if let Some(t) = current.get(1) {
+                        if !t.is_null() {
+                            if let Ok(Some(te)) = decoder.resolve_ref(t) {
+                                if let Ok(m) =
+                                    self.parse_cartesian_transformation_operator(&te, decoder)
+                                {
+                                    chain *= m;
+                                }
+                            }
+                        }
+                    }
+                    current = decoder.resolve_ref_list(mapped_rep.get(3)?).ok()?.into_iter().next()?;
+                }
+                _ => return None,
+            }
+        };
+
+        // IfcExtrudedAreaSolid: 0 SweptArea, 1 Position, 2 ExtrudedDirection, 3 Depth.
+        let profile = decoder.resolve_ref(solid.get(0)?).ok()??;
+        let (x_dim, y_dim, off_x, off_y, cos_t, sin_t) =
+            self.read_rect_profile_2d(&profile, decoder)?;
+        let depth = solid.get_float(3)?;
+        if !(x_dim > 0.0 && y_dim > 0.0 && depth > 0.0) {
+            return None;
+        }
+        let solid_pos = match solid.get(1) {
+            Some(a) if !a.is_null() => {
+                let e = decoder.resolve_ref(a).ok()??;
+                self.parse_axis2_placement_3d(&e, decoder).ok()?
+            }
+            _ => Matrix4::identity(),
+        };
+        let dir_local = {
+            let e = decoder.resolve_ref(solid.get(2)?).ok()??;
+            self.parse_direction(&e).ok()?
+        };
+
+        // Box axes in the SOLID-local frame: profile X' / Y' (rotated by the 2D Position)
+        // and the extrude direction. Center = profile offset in the solid XY plane, then
+        // half the depth along the extrude axis.
+        let u = Vector3::new(cos_t, sin_t, 0.0);
+        let v = Vector3::new(-sin_t, cos_t, 0.0);
+        let w = dir_local.try_normalize(1e-12)?;
+        let m = placement * chain * solid_pos;
+        let rot = m.fixed_view::<3, 3>(0, 0).into_owned();
+        let uu = (rot * u).try_normalize(1e-9)?;
+        let vv = (rot * v).try_normalize(1e-9)?;
+        let ww = (rot * w).try_normalize(1e-9)?;
+        let center_local = Point3::new(off_x, off_y, 0.0) + w * (depth * 0.5);
+        let center_native = m.transform_point(&center_local);
+        // The whole pipeline applies the model length-unit scale uniformly to final
+        // positions; a uniform scale leaves the orthonormal frame R unchanged and scales
+        // the center + half-extents. Without this the box is off by the unit factor
+        // (e.g. 1000x on a millimetre IFC2X3 Revit model).
+        let s = self.unit_scale;
+        Some(RectParam {
+            r: Matrix3::from_columns(&[uu, vv, ww]),
+            center: Point3::new(center_native.x * s, center_native.y * s, center_native.z * s),
+            half: [x_dim * 0.5 * s, y_dim * 0.5 * s, depth * 0.5 * s],
+        })
     }
 
     /// Get per-item meshes for an opening element, transformed to world coordinates.
@@ -1042,10 +1412,106 @@ impl GeometryRouter {
         let openings = self.classify_openings(element, opening_ids, decoder);
         let merged_openings = Self::merge_rectangular_openings(&openings);
 
+        // PARAMETRIC fast-path capture (flag-gated, zero cost when off): probe the
+        // host + every opening for an exact rectangular box, reconcile each opening
+        // box against its mesh, and require all openings to share the host frame. Any
+        // miss -> `None` -> the host defers to the exact kernel.
+        let param = if crate::rect_fast::param_enabled() {
+            self.capture_param_rect(element, opening_ids, decoder)
+        } else {
+            None
+        };
+
         VoidContext {
             openings,
             merged_openings,
+            param,
         }
+    }
+
+    /// Build the parametric-cut data for a host + its openings, or `None` if any
+    /// precondition fails (host/opening not a clean rect extrusion, opening box
+    /// disagrees with its mesh, or an opening does not share the host frame).
+    fn capture_param_rect(
+        &self,
+        element: &DecodedEntity,
+        opening_ids: &[u32],
+        decoder: &mut EntityDecoder,
+    ) -> Option<ParamRectCut> {
+        if opening_ids.is_empty() {
+            return None;
+        }
+        let host = self.parametric_rect_probe(element, decoder)?;
+        let rt = host.r.transpose();
+        let mut openings = Vec::with_capacity(opening_ids.len());
+        for &oid in opening_ids {
+            let opening = decoder.decode_by_id(oid).ok()?;
+            if opening.ifc_type != IfcType::IfcOpeningElement {
+                return None;
+            }
+            let op = self.parametric_rect_probe(&opening, decoder)?;
+            // Shared-frame gate: R_op must align with R_host (signed permutation).
+            let map = signed_permutation_map(&(rt * op.r), 1.0e-3)?;
+            // Opening reconciliation: the parametric box must match the meshed solid
+            // on the two in-face axes (penetration axis is extended at cut time).
+            if !self.opening_param_reconciles(&opening, &op, &host, &map, decoder) {
+                return None;
+            }
+            openings.push(op);
+        }
+        Some(ParamRectCut { host, openings })
+    }
+
+    /// True iff opening `op`'s parametric box matches its actual meshed solid(s) on the
+    /// two in-face axes (within 2%), expressed in the host frame. Catches multi-solid /
+    /// non-box / offset openings that would otherwise mis-cut.
+    fn opening_param_reconciles(
+        &self,
+        opening: &DecodedEntity,
+        op: &RectParam,
+        host: &RectParam,
+        map: &[(usize, f64); 3],
+        decoder: &mut EntityDecoder,
+    ) -> bool {
+        let rt = host.r.transpose();
+        let Ok(meshes) = self.get_opening_item_meshes_world(opening, decoder) else {
+            return false;
+        };
+        let mut mn = [f64::INFINITY; 3];
+        let mut mx = [f64::NEG_INFINITY; 3];
+        let mut any = false;
+        for mesh in &meshes {
+            for c in mesh.positions.chunks_exact(3) {
+                any = true;
+                let p = rotate_point(
+                    &rt,
+                    c[0] as f64 - host.center.x,
+                    c[1] as f64 - host.center.y,
+                    c[2] as f64 - host.center.z,
+                );
+                for k in 0..3 {
+                    mn[k] = mn[k].min(p[k]);
+                    mx[k] = mx[k].max(p[k]);
+                }
+            }
+        }
+        if !any {
+            return false;
+        }
+        let pen = (0..3).find(|&i| map[i].0 == 2).unwrap_or(thin_axis(&host.half));
+        for i in 0..3 {
+            if i == pen {
+                continue;
+            }
+            let mesh_ext = mx[i] - mn[i];
+            let param_ext = 2.0 * op.half[map[i].0];
+            let lo = mesh_ext.min(param_ext);
+            let hi = mesh_ext.max(param_ext).max(1.0e-9);
+            if lo / hi < 0.98 {
+                return false;
+            }
+        }
+        true
     }
 
     /// Apply a pre-built `VoidContext` to a single mesh.
@@ -1075,12 +1541,123 @@ impl GeometryRouter {
     /// frame with no origin-aware-merge surprises), relativizes the cutters by
     /// the same origin, runs the CSG, then re-stamps the origin on the result so
     /// `world = origin + position` holds for the renderer.
+    /// PARAMETRIC analytic fast path: subtract the openings as EXACT parametric boxes
+    /// in the host's own placement frame (where the rotated wall + windows are
+    /// axis-aligned), using the watertight cellular `rect_fast` cut, then rotate the
+    /// result back to world. Frame + extents come from the IFC parametrics (not the
+    /// mesh), so the cut is the analytic box-minus-boxes solid — ground-truth exact and
+    /// MORE correct than the exact kernel on engulfing-opening walls. Fires only on the
+    /// gated subset (`ctx.param` captured; host/opening reconciliation, shared-frame,
+    /// in-bounds, no-overlap, watertight self-check); any miss returns `None` → exact
+    /// kernel. Deterministic f64 → byte-identical native==wasm.
+    fn try_param_rect_cut(&self, mesh: &Mesh, ctx: &VoidContext) -> Option<Mesh> {
+        let param = ctx.param.as_ref()?;
+        let host = &param.host;
+        let rt = host.r.transpose();
+
+        // Host expressed in F (small coords) + reconciliation against the real mesh.
+        let host_f = rotate_mesh_into_frame(mesh, &rt, &host.center);
+        if host_f.positions.is_empty() {
+            return None;
+        }
+        let mut hmn = [f64::INFINITY; 3];
+        let mut hmx = [f64::NEG_INFINITY; 3];
+        for c in host_f.positions.chunks_exact(3) {
+            for k in 0..3 {
+                hmn[k] = hmn[k].min(c[k] as f64);
+                hmx[k] = hmx[k].max(c[k] as f64);
+            }
+        }
+        for k in 0..3 {
+            let ext = hmx[k] - hmn[k];
+            let lo = ext.min(2.0 * host.half[k]);
+            let hi = ext.max(2.0 * host.half[k]).max(1.0e-9);
+            if lo / hi < 0.99 {
+                return None;
+            }
+        }
+
+        // Opening boxes in F with the in-bounds + through-cut handling.
+        let mut boxes: Vec<([f64; 3], [f64; 3])> = Vec::with_capacity(param.openings.len());
+        for op in &param.openings {
+            let map = signed_permutation_map(&(rt * op.r), 1.0e-3)?;
+            let cf = rotate_point(
+                &rt,
+                op.center.x - host.center.x,
+                op.center.y - host.center.y,
+                op.center.z - host.center.z,
+            );
+            let pen = (0..3).find(|&i| map[i].0 == 2).unwrap_or(thin_axis(&host.half));
+            let mut half_f = [0.0f64; 3];
+            for i in 0..3 {
+                half_f[i] = op.half[map[i].0];
+            }
+            // In-bounds: the opening must lie within the wall on the in-face axes; an
+            // overrun is a partial intersection where box-clamp ≠ exact mesh-intersect.
+            for i in 0..3 {
+                if i == pen {
+                    continue;
+                }
+                let tol = host.half[i] * 0.01 + 1.0e-4;
+                if cf[i] - half_f[i] < -host.half[i] - tol
+                    || cf[i] + half_f[i] > host.half[i] + tol
+                {
+                    return None;
+                }
+            }
+            let mut bmin = [cf[0] - half_f[0], cf[1] - half_f[1], cf[2] - half_f[2]];
+            let mut bmax = [cf[0] + half_f[0], cf[1] + half_f[1], cf[2] + half_f[2]];
+            // Through-cut: span the host on the opening's penetration axis.
+            let margin = host.half[pen] * 0.05 + 1.0e-3;
+            bmin[pen] = -host.half[pen] - margin;
+            bmax[pen] = host.half[pen] + margin;
+            boxes.push((bmin, bmax));
+        }
+
+        // No-overlap: overlapping cutter boxes can diverge from the union-subtract.
+        for a in 0..boxes.len() {
+            for b in (a + 1)..boxes.len() {
+                let (amn, amx) = boxes[a];
+                let (bmn, bmx) = boxes[b];
+                if (0..3).all(|i| amn[i] < bmx[i] - 1.0e-4 && bmn[i] < amx[i] - 1.0e-4) {
+                    return None;
+                }
+            }
+        }
+
+        let mut stats = crate::rect_fast::RectFastStats::default();
+        let cut_f = crate::rect_fast::subtract_rect_openings(&host_f, &boxes, &mut stats)?;
+        crate::rect_fast::record_global(&stats);
+        let merged = crate::csg::ClippingProcessor::consolidate_coplanar(cut_f);
+        // Emit as a local-frame mesh (small positions + origin), then run the SAME
+        // hygiene the production output applies — in the small frame, where it is
+        // precise — so the self-check sees exactly what downstream will keep.
+        let mut out = rotate_mesh_from_frame(&merged, &host.r, &host.center);
+        out.clean_degenerate();
+
+        // Self-check: never emit a non-watertight cut; defer to the exact kernel.
+        if !param_cut_watertight(&out) {
+            return None;
+        }
+        crate::rect_fast::param_record_fire();
+        Some(out)
+    }
+
     pub(super) fn apply_void_context(
         &self,
         mut mesh: Mesh,
         ctx: &VoidContext,
         element_id: u32,
     ) -> Mesh {
+        // PARAMETRIC fast path (flag-gated): runs on the WORLD mesh (origin 0). The
+        // per-element local frame (origin != 0) defers — the parametric path builds its
+        // own frame and does not need it.
+        if mesh.origin == [0.0, 0.0, 0.0] && crate::rect_fast::param_enabled() {
+            if let Some(fast) = self.try_param_rect_cut(&mesh, ctx) {
+                return fast;
+            }
+        }
+
         let origin = mesh.origin;
         if origin == [0.0, 0.0, 0.0] {
             // Legacy/world frame: no relativization needed.
@@ -3545,4 +4122,74 @@ mod reveal_tests {
         assert_eq!(new_max, open_max, "-X-poke-out: extension must not change max");
     }
 
+    /// DETERMINISM (CI-safe, no fixture): the parametric cut on a rotated, building-scale
+    /// wall must FIRE, be watertight, emit a local-frame mesh (small positions + origin),
+    /// and produce BIT-IDENTICAL output across runs. Bit-identical-across-runs + the
+    /// FMA-free f64 arithmetic (`rotate_point`, snap grid) is the native==wasm contract:
+    /// every operation is a deterministic f64 op with a single f32 store, so the two
+    /// targets cannot diverge.
+    #[test]
+    fn param_cut_is_deterministic_watertight_and_local_framed() {
+        let router = GeometryRouter::new();
+        // 37° about Z, right-handed frame (cross_b = depth × cross_a).
+        let yaw = 37.0_f64.to_radians();
+        let (c, s) = (yaw.cos(), yaw.sin());
+        let cross_a = Vector3::new(c, s, 0.0); // wall length axis
+        let depth = Vector3::new(-s, c, 0.0); // wall thickness axis
+        let cross_b = depth.cross(&cross_a); // wall height axis
+        // The cut path sees RTC-rebased (small) coordinates — a national-grid model is
+        // re-based to near origin before meshing, so the host f32 mesh is precise. (An
+        // un-rebased building-scale mesh correctly FAILS host reconciliation and defers.)
+        let center = Point3::new(3.0, 2.0, 5.0);
+
+        // World rotated wall: 4 m (cross_a) × 3 m (cross_b) × 0.3 m thick (depth).
+        let host_world = make_framed_box_mesh(
+            center, depth, cross_a, cross_b, (-0.15, 0.15), (-2.0, 2.0), (-1.5, 1.5),
+        );
+        let host = RectParam {
+            r: Matrix3::from_columns(&[cross_a, cross_b, depth]),
+            center,
+            half: [2.0, 1.5, 0.15],
+        };
+        // A centred window, over-spanning the thickness (through-cut) and well within
+        // the wall in-face — fires all the gates.
+        let opening = RectParam {
+            r: host.r,
+            center,
+            half: [0.5, 0.5, 0.25],
+        };
+        let ctx = VoidContext {
+            openings: Vec::new(),
+            merged_openings: Vec::new(),
+            param: Some(ParamRectCut {
+                host,
+                openings: vec![opening],
+            }),
+        };
+
+        let out1 = router
+            .try_param_rect_cut(&host_world, &ctx)
+            .expect("parametric cut must fire on a clean rotated wall");
+        let out2 = router
+            .try_param_rect_cut(&host_world, &ctx)
+            .expect("parametric cut must fire on a clean rotated wall");
+
+        // Bit-identical across runs (⇒ native==wasm by the FMA-free construction).
+        assert_eq!(out1.positions, out2.positions, "positions must be deterministic");
+        assert_eq!(out1.indices, out2.indices, "indices must be deterministic");
+        assert_eq!(out1.normals, out2.normals, "normals must be deterministic");
+        assert_eq!(out1.origin, out2.origin, "origin must be deterministic");
+
+        // Local-frame output: origin = wall centre, positions stay SMALL (near 0) so the
+        // f32 store survives at national-grid magnitude.
+        assert_eq!(out1.origin, [center.x, center.y, center.z]);
+        let max_abs = out1
+            .positions
+            .iter()
+            .fold(0.0f32, |m, &v| m.max(v.abs()));
+        assert!(max_abs < 10.0, "local-frame positions must stay small (got {max_abs})");
+
+        assert!(param_cut_watertight(&out1), "cut must be watertight");
+        assert!(out1.triangle_count() > 12, "the opening must add faces");
+    }
 }

--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -996,10 +996,18 @@ impl GeometryRouter {
                 continue;
             }
             if let Ok(items) = decoder.resolve_ref_list(sr.get(3)?) {
-                if let Some(first) = items.into_iter().next() {
-                    item = Some(first);
-                    break;
+                // A clean rectangular extrusion is ONE item. A multi-solid body
+                // (the probe would otherwise read only the first) must defer so the
+                // exact kernel cuts all of it.
+                let mut iter = items.into_iter();
+                let Some(first) = iter.next() else {
+                    continue;
+                };
+                if iter.next().is_some() {
+                    return None;
                 }
+                item = Some(first);
+                break;
             }
         }
 
@@ -1073,10 +1081,18 @@ impl GeometryRouter {
         // positions; a uniform scale leaves the orthonormal frame R unchanged and scales
         // the center + half-extents. Without this the box is off by the unit factor
         // (e.g. 1000x on a millimetre IFC2X3 Revit model).
+        // Match the mesh frame: the mesh/bounds path scales by `unit_scale` AND subtracts
+        // the RTC offset (georef re-basing). The center must do BOTH or it is framed
+        // around a different origin than the host vertices → spurious defers / wrong cut.
         let s = self.unit_scale;
+        let (rx, ry, rz) = self.rtc_offset;
         Some(RectParam {
             r: Matrix3::from_columns(&[uu, vv, ww]),
-            center: Point3::new(center_native.x * s, center_native.y * s, center_native.z * s),
+            center: Point3::new(
+                center_native.x * s - rx,
+                center_native.y * s - ry,
+                center_native.z * s - rz,
+            ),
             half: [x_dim * 0.5 * s, y_dim * 0.5 * s, depth * 0.5 * s],
         })
     }
@@ -1556,7 +1572,17 @@ impl GeometryRouter {
         let rt = host.r.transpose();
 
         // Host expressed in F (small coords) + reconciliation against the real mesh.
-        let host_f = rotate_mesh_into_frame(mesh, &rt, &host.center);
+        // ORIGIN-AWARE: the mesh may already be in a per-element local frame (wasm
+        // defaults `local_frame_enabled()` ON), where positions are relative to
+        // `mesh.origin` (world = origin + position). Frame the cut around
+        // `center - origin` so host_f = Rᵀ·(world_vertex - center) either way.
+        let o = mesh.origin;
+        let eff_center = Point3::new(
+            host.center.x - o[0],
+            host.center.y - o[1],
+            host.center.z - o[2],
+        );
+        let host_f = rotate_mesh_into_frame(mesh, &rt, &eff_center);
         if host_f.positions.is_empty() {
             return None;
         }
@@ -1587,7 +1613,13 @@ impl GeometryRouter {
                 op.center.y - host.center.y,
                 op.center.z - host.center.z,
             );
-            let pen = (0..3).find(|&i| map[i].0 == 2).unwrap_or(thin_axis(&host.half));
+            // The opening must penetrate along the wall's THIN (thickness) axis. If its
+            // extrude axis maps to a length/height axis, extending it across the host
+            // would wipe out a full slab — defer that case to the exact kernel.
+            let pen = (0..3).find(|&i| map[i].0 == 2)?;
+            if host.half[pen] > host.half[thin_axis(&host.half)] * 1.05 {
+                return None;
+            }
             let mut half_f = [0.0f64; 3];
             for i in 0..3 {
                 half_f[i] = op.half[map[i].0];
@@ -1649,10 +1681,12 @@ impl GeometryRouter {
         ctx: &VoidContext,
         element_id: u32,
     ) -> Mesh {
-        // PARAMETRIC fast path (flag-gated): runs on the WORLD mesh (origin 0). The
-        // per-element local frame (origin != 0) defers — the parametric path builds its
-        // own frame and does not need it.
-        if mesh.origin == [0.0, 0.0, 0.0] && crate::rect_fast::param_enabled() {
+        // PARAMETRIC fast path (flag-gated). ORIGIN-AWARE: it handles both the world
+        // mesh (origin 0, native default) AND a per-element local-frame mesh (origin != 0,
+        // the wasm default — the precision-critical case this path is FOR), since it
+        // builds its own frame from the parametrics. Any miss falls through to the exact
+        // kernel below unchanged.
+        if crate::rect_fast::param_enabled() {
             if let Some(fast) = self.try_param_rect_cut(&mesh, ctx) {
                 return fast;
             }

--- a/rust/geometry/tests/rect_fast_placement_frame_spike.rs
+++ b/rust/geometry/tests/rect_fast_placement_frame_spike.rs
@@ -1,0 +1,183 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! SPIKE: rect_fast on ROTATED walls via the placement frame.
+//!
+//! rect_fast cuts rectangular openings analytically (cellular decomposition,
+//! watertight by construction) but ONLY when the host is an axis-aligned box.
+//! A rotated wall is not axis-aligned in world space, so `aligned_box` rejects
+//! it and the cut defers to the slow exact kernel (`defer_host_not_box`). On a
+//! rotated-wall model (e.g. harbour steel) that is ~100% of wall openings.
+//!
+//! The fix is to run the cut in the wall's PLACEMENT frame, where the wall (and
+//! its openings, placed relative to it) ARE axis-aligned. This spike proves the
+//! claim end to end:
+//!   1. A building-scale ROTATED wall defers in world (`defer_host_not_box`).
+//!   2. The SAME wall, expressed in its placement frame (axis-aligned, near
+//!      origin), fires rect_fast and the result is watertight.
+//!   3. Applying the rigid placement back to the cut reproduces the world cut,
+//!      so this is a drop-in replacement for the exact kernel on these walls.
+
+use ifc_lite_geometry::rect_fast::{subtract_rect_openings, RectFastStats};
+use ifc_lite_geometry::Mesh;
+use nalgebra::{Matrix4, Vector3};
+use std::collections::HashMap;
+
+/// Axis-aligned box mesh (8 corners, 12 triangles, 6 faces) spanning `min..max`.
+fn box_mesh(min: [f32; 3], max: [f32; 3]) -> Mesh {
+    let c = |i: usize| {
+        [
+            if i & 1 == 0 { min[0] } else { max[0] },
+            if i & 2 == 0 { min[1] } else { max[1] },
+            if i & 4 == 0 { min[2] } else { max[2] },
+        ]
+    };
+    let mut positions = Vec::new();
+    // 6 faces, each as 2 triangles, corners indexed by the bit pattern above.
+    let faces = [
+        [0, 2, 6, 4], // -x
+        [1, 5, 7, 3], // +x
+        [0, 4, 5, 1], // -y
+        [2, 3, 7, 6], // +y
+        [0, 1, 3, 2], // -z
+        [4, 6, 7, 5], // +z
+    ];
+    let mut indices = Vec::new();
+    for f in faces {
+        let base = (positions.len() / 3) as u32;
+        for &corner in &f {
+            let p = c(corner);
+            positions.extend_from_slice(&p);
+        }
+        indices.extend_from_slice(&[base, base + 1, base + 2, base, base + 2, base + 3]);
+    }
+    let mut m = Mesh::new();
+    m.positions = positions;
+    m.normals = vec![0.0; m.positions.len()];
+    m.indices = indices;
+    m
+}
+
+/// Apply a 4x4 rigid transform to a copy of `mesh`'s positions (f64 math, f32 store).
+fn transformed(mesh: &Mesh, t: &Matrix4<f64>) -> Mesh {
+    let mut out = mesh.clone();
+    for chunk in out.positions.chunks_exact_mut(3) {
+        let p = t.transform_point(&nalgebra::Point3::new(
+            chunk[0] as f64,
+            chunk[1] as f64,
+            chunk[2] as f64,
+        ));
+        chunk[0] = p.x as f32;
+        chunk[1] = p.y as f32;
+        chunk[2] = p.z as f32;
+    }
+    out
+}
+
+/// World AABB (min,max) of a box translated by `base` with extent `ext`.
+fn opening(base: [f64; 3], ext_min: [f64; 3], ext_max: [f64; 3]) -> ([f64; 3], [f64; 3]) {
+    (
+        [base[0] + ext_min[0], base[1] + ext_min[1], base[2] + ext_min[2]],
+        [base[0] + ext_max[0], base[1] + ext_max[1], base[2] + ext_max[2]],
+    )
+}
+
+/// Closed-2-manifold check by WELDED position (0.1 mm grid): every undirected
+/// edge must be shared by exactly two non-degenerate triangles. A crack/gap
+/// leaves boundary edges with count 1.
+fn watertight(mesh: &Mesh) -> (bool, usize, usize) {
+    let key = |i: u32| -> (i64, i64, i64) {
+        let b = i as usize * 3;
+        let q = |v: f32| (v as f64 / 1.0e-4).round() as i64;
+        (q(mesh.positions[b]), q(mesh.positions[b + 1]), q(mesh.positions[b + 2]))
+    };
+    let mut edges: HashMap<((i64, i64, i64), (i64, i64, i64)), i32> = HashMap::new();
+    let mut tris = 0usize;
+    for tri in mesh.indices.chunks_exact(3) {
+        let (ka, kb, kc) = (key(tri[0]), key(tri[1]), key(tri[2]));
+        if ka == kb || kb == kc || kc == ka {
+            continue; // degenerate after weld
+        }
+        tris += 1;
+        for (x, y) in [(ka, kb), (kb, kc), (kc, ka)] {
+            let e = if x < y { (x, y) } else { (y, x) };
+            *edges.entry(e).or_insert(0) += 1;
+        }
+    }
+    let boundary = edges.values().filter(|&&c| c != 2).count();
+    (boundary == 0, boundary, tris)
+}
+
+#[test]
+fn rotated_building_scale_wall_defers_in_world_but_cuts_in_placement_frame() {
+    // ── Wall in its LOCAL extrusion/placement frame: axis-aligned, near origin.
+    // 4 m long, 0.3 m thick, 3 m tall.
+    let wall_local = box_mesh([0.0, 0.0, 0.0], [4.0, 0.3, 3.0]);
+    // A window placed relative to the wall: x 1.5..2.5, full thickness, z 1..2.
+    let win_local = opening([0.0, 0.0, 0.0], [1.5, -0.1, 1.0], [2.5, 0.4, 2.0]);
+
+    // ── Placement: rotate 37° about Z (a non-axis-aligned wall) + translate to
+    // building/harbour scale (hundreds of km from the project origin).
+    let yaw = 37.0_f64.to_radians();
+    let rot = Matrix4::new_rotation(Vector3::z() * yaw);
+    let trans = Matrix4::new_translation(&Vector3::new(221_534.0, 98_210.0, 47_001.0));
+    let placement = trans * rot;
+
+    // (1) WORLD: the rotated wall is NOT an axis-aligned box → rect_fast defers.
+    let wall_world = transformed(&wall_local, &placement);
+    // Express the window AABB in world by transforming its 8 corners and re-bounding.
+    let win_world = aabb_of_transformed_box(win_local, &placement);
+    let mut st_world = RectFastStats::default();
+    let world_res = subtract_rect_openings(&wall_world, &[win_world], &mut st_world);
+    assert!(world_res.is_none(), "rotated wall should NOT fire rect_fast in world");
+    assert_eq!(st_world.defer_host_not_box, 1, "expected host_not_box defer in world");
+
+    // (2) PLACEMENT FRAME: the same wall is axis-aligned → rect_fast FIRES, and
+    // the result is watertight (small coords, snap-grid exact).
+    let mut st_local = RectFastStats::default();
+    let cut_local = subtract_rect_openings(&wall_local, &[win_local], &mut st_local)
+        .expect("axis-aligned wall in placement frame should fire rect_fast");
+    assert_eq!(st_local.fired, 1, "expected one rect_fast fire");
+    let (wt, boundary, tris) = watertight(&cut_local);
+    assert!(wt, "placement-frame cut must be watertight (got {boundary} boundary edges over {tris} tris)");
+    assert!(tris > 12, "cut should add faces around the opening (got {tris} tris)");
+
+    // (3) Apply the rigid placement back: the cut transforms to world cleanly.
+    // (Connectivity is rigid-invariant, so the placed result is the same cut —
+    // in production it stays in the local frame + carries `origin`, avoiding the
+    // f32 collapse a world-space store would suffer at this magnitude.)
+    let cut_world = transformed(&cut_local, &placement);
+    assert_eq!(
+        cut_world.indices.len(),
+        cut_local.indices.len(),
+        "placement is rigid — same topology"
+    );
+
+    println!(
+        "SPIKE OK: rotated wall defers in world (host_not_box={}); \
+         placement-frame cut fires (fired={}), watertight (tris={tris}, boundary={boundary})",
+        st_world.defer_host_not_box, st_local.fired
+    );
+}
+
+/// World AABB of a local-frame box AABB after a rigid transform (bound its 8 corners).
+fn aabb_of_transformed_box(b: ([f64; 3], [f64; 3]), t: &Matrix4<f64>) -> ([f64; 3], [f64; 3]) {
+    let (mn, mx) = b;
+    let mut wmn = [f64::INFINITY; 3];
+    let mut wmx = [f64::NEG_INFINITY; 3];
+    for i in 0..8 {
+        let p = [
+            if i & 1 == 0 { mn[0] } else { mx[0] },
+            if i & 2 == 0 { mn[1] } else { mx[1] },
+            if i & 4 == 0 { mn[2] } else { mx[2] },
+        ];
+        let w = t.transform_point(&nalgebra::Point3::new(p[0], p[1], p[2]));
+        for k in 0..3 {
+            let v = [w.x, w.y, w.z][k];
+            wmn[k] = wmn[k].min(v);
+            wmx[k] = wmx[k].max(v);
+        }
+    }
+    (wmn, wmx)
+}

--- a/rust/geometry/tests/rect_param_census.rs
+++ b/rust/geometry/tests/rect_param_census.rs
@@ -1,0 +1,223 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! PHASE-0 CENSUS (read-only, no cut path): measures the two load-bearing numbers
+//! that decide GO/NO-GO for a parametric placement-frame rectangular-opening fast path:
+//!
+//!   (a) R_opening == R_wall rate -- does the opening share the wall's exact placement
+//!       frame (so the opening is axis-aligned in the wall frame, the fire precondition)?
+//!   (b) parametric-box vs real-mesh agreement -- does the EXACT IfcRectangleProfileDef
+//!       box equal the meshed wall's AABB IN THE WALL FRAME (the reconciliation gate)?
+//!       A correct parametric R must axis-align the real mesh; the extent ratio is both
+//!       the probe's self-check AND the gate metric.
+//!
+//! Run:
+//!   MEASURE_FIXTURE=<path> cargo test --test rect_param_census -- --ignored --nocapture
+//! No model path is baked in; point MEASURE_FIXTURE at the arch models to profile them.
+
+use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner, IfcType};
+use ifc_lite_geometry::{propagate_voids_to_parts, GeometryRouter, Mesh, RectParam};
+use nalgebra::Matrix3;
+use rustc_hash::FxHashMap;
+
+const DEFAULT_FIXTURE: &str = "../../tests/models/buildingsmart/wall-with-opening-and-window.ifc";
+
+fn build_void_index(content: &str, decoder: &mut EntityDecoder) -> FxHashMap<u32, Vec<u32>> {
+    let mut void_index: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
+    let mut scanner = EntityScanner::new(content);
+    let mut scan_decoder = EntityDecoder::new(content);
+    while let Some((id, type_name, start, end)) = scanner.next_entity() {
+        if type_name == "IFCRELVOIDSELEMENT" {
+            if let Ok(entity) = scan_decoder.decode_at_with_id(id, start, end) {
+                if let (Some(host_id), Some(opening_id)) = (entity.get_ref(4), entity.get_ref(5)) {
+                    void_index.entry(host_id).or_default().push(opening_id);
+                }
+            }
+        }
+    }
+    let _ = propagate_voids_to_parts(&mut void_index, content, decoder);
+    void_index
+}
+
+/// AABB extents of `mesh` after rotating world positions into the frame `rt` (= R^T).
+fn extents_in_frame(mesh: &Mesh, rt: &Matrix3<f64>) -> [f64; 3] {
+    let mut mn = [f64::INFINITY; 3];
+    let mut mx = [f64::NEG_INFINITY; 3];
+    for c in mesh.positions.chunks_exact(3) {
+        let p = rt * nalgebra::Vector3::new(c[0] as f64, c[1] as f64, c[2] as f64);
+        for k in 0..3 {
+            mn[k] = mn[k].min(p[k]);
+            mx[k] = mx[k].max(p[k]);
+        }
+    }
+    [mx[0] - mn[0], mx[1] - mn[1], mx[2] - mn[2]]
+}
+
+/// True iff `m` is a signed permutation matrix (each row one entry ~±1, rest ~0, and the
+/// dominant columns are distinct) -- i.e. R_a and R_b share axes up to relabel/sign.
+fn is_signed_permutation(m: &Matrix3<f64>, tol: f64) -> bool {
+    let mut used = [false; 3];
+    for i in 0..3 {
+        let mut best = 0usize;
+        let mut best_abs = 0.0;
+        let mut second = 0.0;
+        for j in 0..3 {
+            let a = m[(i, j)].abs();
+            if a > best_abs {
+                second = best_abs;
+                best_abs = a;
+                best = j;
+            } else if a > second {
+                second = a;
+            }
+        }
+        if best_abs < 1.0 - tol || second > tol || used[best] {
+            return false;
+        }
+        used[best] = true;
+    }
+    true
+}
+
+fn sorted3(mut a: [f64; 3]) -> [f64; 3] {
+    a.sort_by(|x, y| x.partial_cmp(y).unwrap());
+    a
+}
+
+#[test]
+#[ignore = "phase-0 census -- run explicitly with MEASURE_FIXTURE"]
+fn parametric_rect_census() {
+    let fixture = std::env::var("MEASURE_FIXTURE").unwrap_or_else(|_| DEFAULT_FIXTURE.to_string());
+    if !std::path::Path::new(&fixture).exists() {
+        eprintln!("skipping: fixture {fixture} not present");
+        return;
+    }
+    let content = std::fs::read_to_string(&fixture).expect("read fixture");
+    let entity_index = build_entity_index(&content);
+    let mut decoder = EntityDecoder::with_index(&content, entity_index);
+    let router = GeometryRouter::with_units(&content, &mut decoder);
+    let void_index = build_void_index(&content, &mut decoder);
+
+    let mut host_ids: Vec<u32> = void_index.keys().copied().collect();
+    host_ids.sort_unstable();
+
+    // Host-level tallies.
+    let mut hosts = 0usize;
+    let mut host_probe_ok = 0usize; // host is a clean rect extrusion (probe Some)
+    let mut host_box_match = 0usize; // parametric box ~= mesh AABB in frame (reconciliation pass)
+    // Opening-level tallies (only for hosts whose probe succeeded -> R_host known).
+    let mut openings = 0usize;
+    let mut opening_probe_ok = 0usize;
+    let mut opening_frame_match = 0usize;
+    // The realistic fire ceiling: host probe ok + box matches + ALL openings frame-match.
+    let mut fireable_hosts = 0usize;
+    // vol(param)/vol(meshAABB-in-frame) histogram buckets.
+    let mut vol_buckets = [0usize; 6]; // <0.5, .5-.9, .9-.98, .98-1.02, 1.02-1.1, >1.1
+    let mut worst_axis_ratio_examples = 0usize;
+
+    for host_id in host_ids {
+        let Ok(host) = decoder.decode_by_id(host_id) else { continue };
+        if !matches!(
+            host.ifc_type,
+            IfcType::IfcWall | IfcType::IfcWallStandardCase | IfcType::IfcSlab | IfcType::IfcRoof
+                | IfcType::IfcColumn | IfcType::IfcBeam | IfcType::IfcMember | IfcType::IfcPlate
+                | IfcType::IfcCovering | IfcType::IfcFooting
+        ) {
+            continue;
+        }
+        hosts += 1;
+
+        let Some(hp): Option<RectParam> = router.parametric_rect_probe(&host, &mut decoder) else {
+            // host is not a clean rect extrusion -> can't fire; still count its openings as N/A
+            continue;
+        };
+        host_probe_ok += 1;
+        let rt_host = hp.r.transpose();
+
+        // Reconciliation: does the EXACT parametric box equal the real meshed wall in-frame?
+        let mut this_host_box_ok = false;
+        if let Ok(mesh) = router.process_element(&host, &mut decoder) {
+            if !mesh.positions.is_empty() {
+                let e = extents_in_frame(&mesh, &rt_host);
+                let param = [hp.half[0] * 2.0, hp.half[1] * 2.0, hp.half[2] * 2.0];
+                let ps = sorted3(param);
+                let es = sorted3(e);
+                let vol_param = ps[0] * ps[1] * ps[2];
+                let vol_mesh = (es[0] * es[1] * es[2]).max(1e-12);
+                let ratio = vol_param / vol_mesh;
+                let b = if ratio < 0.5 { 0 } else if ratio < 0.9 { 1 }
+                    else if ratio < 0.98 { 2 } else if ratio < 1.02 { 3 }
+                    else if ratio < 1.1 { 4 } else { 5 };
+                vol_buckets[b] += 1;
+                // per-axis agreement within 2% (sorted, since axis labels may permute)
+                let axis_ok = (0..3).all(|k| {
+                    let lo = ps[k].min(es[k]);
+                    let hi = ps[k].max(es[k]).max(1e-9);
+                    lo / hi > 0.98
+                });
+                if axis_ok {
+                    this_host_box_ok = true;
+                    host_box_match += 1;
+                } else if worst_axis_ratio_examples < 6 {
+                    worst_axis_ratio_examples += 1;
+                    eprintln!(
+                        "  box-mismatch host {host_id}: param(sorted)={ps:?} mesh(sorted)={es:?} ratio={ratio:.3}"
+                    );
+                }
+            }
+        }
+
+        // Openings: do they share the wall frame?
+        let mut all_openings_match = true;
+        let mut host_opening_count = 0usize;
+        for &opening_id in &void_index[&host_id] {
+            let Ok(opening) = decoder.decode_by_id(opening_id) else {
+                all_openings_match = false;
+                continue;
+            };
+            if opening.ifc_type != IfcType::IfcOpeningElement {
+                continue;
+            }
+            host_opening_count += 1;
+            openings += 1;
+            let Some(op): Option<RectParam> = router.parametric_rect_probe(&opening, &mut decoder)
+            else {
+                all_openings_match = false;
+                continue;
+            };
+            opening_probe_ok += 1;
+            let m = rt_host * op.r;
+            if is_signed_permutation(&m, 1.0e-3) {
+                opening_frame_match += 1;
+            } else {
+                all_openings_match = false;
+            }
+        }
+
+        if this_host_box_ok && host_opening_count > 0 && all_openings_match {
+            fireable_hosts += 1;
+        }
+    }
+
+    let pct = |n: usize, d: usize| if d == 0 { 0.0 } else { 100.0 * n as f64 / d as f64 };
+    eprintln!("\n========= PHASE-0 PARAMETRIC RECT CENSUS =========");
+    eprintln!("fixture                 : {fixture}");
+    eprintln!("void hosts (bldg elems) : {hosts}");
+    eprintln!("--------------------------------------------------");
+    eprintln!("HOST is clean rect extrusion (probe ok) : {host_probe_ok} ({:.1}%)", pct(host_probe_ok, hosts));
+    eprintln!("HOST param-box == mesh AABB (recon pass) : {host_box_match} ({:.1}% of probe-ok)", pct(host_box_match, host_probe_ok));
+    eprintln!("--------------------------------------------------");
+    eprintln!("openings probed                : {openings}");
+    eprintln!("  opening clean rect (probe ok): {opening_probe_ok} ({:.1}%)", pct(opening_probe_ok, openings));
+    eprintln!("  R_open == R_host (frame match): {opening_frame_match} ({:.1}% of all, {:.1}% of probe-ok)",
+        pct(opening_frame_match, openings), pct(opening_frame_match, opening_probe_ok));
+    eprintln!("--------------------------------------------------");
+    eprintln!("FIREABLE hosts (probe+recon+all-openings-match): {fireable_hosts} ({:.1}% of hosts)", pct(fireable_hosts, hosts));
+    eprintln!("--------- vol(param)/vol(meshAABB) histogram -----");
+    let labels = ["<0.5", "0.5-0.9", "0.9-0.98", "0.98-1.02", "1.02-1.1", ">1.1"];
+    for (i, l) in labels.iter().enumerate() {
+        eprintln!("  {l:>9} : {}", vol_buckets[i]);
+    }
+    eprintln!("==================================================\n");
+}

--- a/rust/geometry/tests/rect_param_parity.rs
+++ b/rust/geometry/tests/rect_param_parity.rs
@@ -1,0 +1,475 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! PHASE-1 PARITY: prove the PARAMETRIC placement-frame cut matches the exact kernel.
+//!
+//! For each fireable host: build exact axis-aligned boxes (host + openings) in the wall's
+//! own placement frame F from `parametric_rect_probe`, run the watertight cellular
+//! `subtract_rect_openings` in F (small coords), rotate the result back to world, and
+//! compare to `process_element_with_voids` (the exact kernel) by volume + bbox +
+//! watertightness. This is the test my mesh-inference attempt failed (12% wrong); the
+//! parametric frame + parametric extents should reach parity.
+//!
+//! Run: MEASURE_FIXTURE=<path> cargo test --test rect_param_parity -- --ignored --nocapture
+
+use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner, IfcType};
+use ifc_lite_geometry::rect_fast::{subtract_rect_openings, RectFastStats};
+use ifc_lite_geometry::{propagate_voids_to_parts, GeometryRouter, Mesh, RectParam};
+use nalgebra::{Matrix3, Point3, Vector3};
+use rustc_hash::FxHashMap;
+
+const DEFAULT_FIXTURE: &str = "../../tests/models/buildingsmart/wall-with-opening-and-window.ifc";
+
+fn mesh_volume(mesh: &Mesh) -> f64 {
+    mesh.indices
+        .chunks_exact(3)
+        .map(|t| {
+            let v = |i: u32| {
+                let b = i as usize * 3;
+                [
+                    mesh.positions[b] as f64,
+                    mesh.positions[b + 1] as f64,
+                    mesh.positions[b + 2] as f64,
+                ]
+            };
+            let (a, b, c) = (v(t[0]), v(t[1]), v(t[2]));
+            a[0] * (b[1] * c[2] - b[2] * c[1]) + a[1] * (b[2] * c[0] - b[0] * c[2])
+                + a[2] * (b[0] * c[1] - b[1] * c[0])
+        })
+        .sum::<f64>()
+        / 6.0
+}
+
+fn bbox(mesh: &Mesh) -> ([f64; 3], [f64; 3]) {
+    let mut mn = [f64::INFINITY; 3];
+    let mut mx = [f64::NEG_INFINITY; 3];
+    for c in mesh.positions.chunks_exact(3) {
+        for k in 0..3 {
+            mn[k] = mn[k].min(c[k] as f64);
+            mx[k] = mx[k].max(c[k] as f64);
+        }
+    }
+    (mn, mx)
+}
+
+fn watertight(mesh: &Mesh) -> bool {
+    let key = |i: u32| -> (i64, i64, i64) {
+        let b = i as usize * 3;
+        let q = |v: f32| (v as f64 / 1.0e-4).round() as i64;
+        (
+            q(mesh.positions[b]),
+            q(mesh.positions[b + 1]),
+            q(mesh.positions[b + 2]),
+        )
+    };
+    let mut edges: FxHashMap<((i64, i64, i64), (i64, i64, i64)), i32> = FxHashMap::default();
+    for tri in mesh.indices.chunks_exact(3) {
+        let (ka, kb, kc) = (key(tri[0]), key(tri[1]), key(tri[2]));
+        if ka == kb || kb == kc || kc == ka {
+            continue;
+        }
+        for (x, y) in [(ka, kb), (kb, kc), (kc, ka)] {
+            let e = if x < y { (x, y) } else { (y, x) };
+            *edges.entry(e).or_insert(0) += 1;
+        }
+    }
+    !edges.is_empty() && edges.values().all(|&c| c == 2)
+}
+
+/// Rotate world `mesh` into the frame F: `v_F = R^T (v - center)` (small coords).
+fn into_frame(mesh: &Mesh, rt: &Matrix3<f64>, center: &Point3<f64>) -> Mesh {
+    let mut out = Mesh::new();
+    out.positions = Vec::with_capacity(mesh.positions.len());
+    for c in mesh.positions.chunks_exact(3) {
+        let p = rt
+            * Vector3::new(
+                c[0] as f64 - center.x,
+                c[1] as f64 - center.y,
+                c[2] as f64 - center.z,
+            );
+        out.positions.push(p.x as f32);
+        out.positions.push(p.y as f32);
+        out.positions.push(p.z as f32);
+    }
+    out.normals = vec![0.0; out.positions.len()];
+    out.indices = mesh.indices.clone();
+    out
+}
+
+/// Rotate frame-F `mesh` back to world: `v = R v_F + center`.
+fn from_frame(mesh: &Mesh, r: &Matrix3<f64>, center: &Point3<f64>) -> Mesh {
+    let mut out = Mesh::new();
+    out.positions = Vec::with_capacity(mesh.positions.len());
+    for c in mesh.positions.chunks_exact(3) {
+        let p = r * Vector3::new(c[0] as f64, c[1] as f64, c[2] as f64);
+        out.positions.push((p.x + center.x) as f32);
+        out.positions.push((p.y + center.y) as f32);
+        out.positions.push((p.z + center.z) as f32);
+    }
+    out.normals = vec![0.0; out.positions.len()];
+    out.indices = mesh.indices.clone();
+    out
+}
+
+fn is_signed_permutation(m: &Matrix3<f64>, tol: f64) -> Option<[(usize, f64); 3]> {
+    let mut map = [(0usize, 1.0f64); 3];
+    let mut used = [false; 3];
+    for i in 0..3 {
+        let mut best = 0usize;
+        let mut best_abs = 0.0;
+        let mut second = 0.0;
+        for j in 0..3 {
+            let a = m[(i, j)].abs();
+            if a > best_abs {
+                second = best_abs;
+                best_abs = a;
+                best = j;
+            } else if a > second {
+                second = a;
+            }
+        }
+        if best_abs < 1.0 - tol || second > tol || used[best] {
+            return None;
+        }
+        used[best] = true;
+        map[i] = (best, m[(i, best)].signum());
+    }
+    Some(map)
+}
+
+fn thin_axis(half: &[f64; 3]) -> usize {
+    (0..3).min_by(|&a, &b| half[a].partial_cmp(&half[b]).unwrap()).unwrap()
+}
+
+fn build_void_index(content: &str, decoder: &mut EntityDecoder) -> FxHashMap<u32, Vec<u32>> {
+    let mut void_index: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
+    let mut scanner = EntityScanner::new(content);
+    let mut scan_decoder = EntityDecoder::new(content);
+    while let Some((id, type_name, start, end)) = scanner.next_entity() {
+        if type_name == "IFCRELVOIDSELEMENT" {
+            if let Ok(entity) = scan_decoder.decode_at_with_id(id, start, end) {
+                if let (Some(host_id), Some(opening_id)) = (entity.get_ref(4), entity.get_ref(5)) {
+                    void_index.entry(host_id).or_default().push(opening_id);
+                }
+            }
+        }
+    }
+    let _ = propagate_voids_to_parts(&mut void_index, content, decoder);
+    void_index
+}
+
+#[test]
+#[ignore = "phase-1 parity -- run explicitly with MEASURE_FIXTURE"]
+fn parametric_cut_matches_exact_kernel() {
+    let fixture = std::env::var("MEASURE_FIXTURE").unwrap_or_else(|_| DEFAULT_FIXTURE.to_string());
+    if !std::path::Path::new(&fixture).exists() {
+        eprintln!("skipping: fixture {fixture} not present");
+        return;
+    }
+    let content = std::fs::read_to_string(&fixture).expect("read fixture");
+    let entity_index = build_entity_index(&content);
+    let mut decoder = EntityDecoder::with_index(&content, entity_index);
+    let router = GeometryRouter::with_units(&content, &mut decoder);
+    let void_index = build_void_index(&content, &mut decoder);
+
+    let mut host_ids: Vec<u32> = void_index.keys().copied().collect();
+    host_ids.sort_unstable();
+
+    // f32-at-magnitude relative volume tolerance (georef-distance noise).
+    let vol_tol: f64 = std::env::var("PARITY_VOL_TOL")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(5.0e-3);
+
+    let mut fired = 0usize;
+    let mut vol_ok = 0usize;
+    let mut wt_ok = 0usize;
+    let mut vol_bad = 0usize;
+    let mut deferred_host = 0usize;
+    let mut deferred_wt = 0usize;
+    let mut deferred_rectfast = 0usize;
+    let mut deferred_overlap = 0usize;
+    let mut param_vs_truth_ok = 0usize;
+    let mut exact_vs_truth_ok = 0usize;
+    let mut worst = 0.0f64;
+    let mut worst_host = 0u32;
+    let mut examples = 0usize;
+    // rel-delta histogram: <0.5%, 0.5-2%, 2-5%, 5-20%, >20%
+    let mut hist = [0usize; 5];
+
+    for host_id in host_ids {
+        let Ok(host) = decoder.decode_by_id(host_id) else { continue };
+        if !matches!(
+            host.ifc_type,
+            IfcType::IfcWall | IfcType::IfcWallStandardCase | IfcType::IfcSlab | IfcType::IfcRoof
+                | IfcType::IfcColumn | IfcType::IfcBeam | IfcType::IfcMember | IfcType::IfcPlate
+                | IfcType::IfcCovering | IfcType::IfcFooting
+        ) {
+            continue;
+        }
+        let Some(hp): Option<RectParam> = router.parametric_rect_probe(&host, &mut decoder) else {
+            continue;
+        };
+        let rt = hp.r.transpose();
+
+        // Host mesh rotated into F; must be an axis-aligned box (reconciliation).
+        let Ok(host_mesh) = router.process_element(&host, &mut decoder) else { continue };
+        if host_mesh.positions.is_empty() {
+            continue;
+        }
+        let host_f = into_frame(&host_mesh, &rt, &hp.center);
+
+        // HOST reconciliation gate: the meshed wall in F must equal the parametric
+        // box (extent within 1%) AND be centered at ~0 (it was relativized to the
+        // parametric center). A mismatch = gable/clip/feature -> defer.
+        {
+            let mut hmn = [f64::INFINITY; 3];
+            let mut hmx = [f64::NEG_INFINITY; 3];
+            for c in host_f.positions.chunks_exact(3) {
+                for k in 0..3 {
+                    hmn[k] = hmn[k].min(c[k] as f64);
+                    hmx[k] = hmx[k].max(c[k] as f64);
+                }
+            }
+            let mut host_ok = true;
+            for k in 0..3 {
+                let ext = hmx[k] - hmn[k];
+                let lo = ext.min(2.0 * hp.half[k]);
+                let hi = ext.max(2.0 * hp.half[k]).max(1e-9);
+                if lo / hi < 0.99 {
+                    host_ok = false;
+                }
+            }
+            if !host_ok {
+                deferred_host += 1;
+                continue;
+            }
+        }
+
+        // Opening boxes in F (axis-aligned by the shared-frame gate).
+        let mut boxes: Vec<([f64; 3], [f64; 3])> = Vec::new();
+        let mut all_ok = true;
+        for &opening_id in &void_index[&host_id] {
+            let Ok(opening) = decoder.decode_by_id(opening_id) else { all_ok = false; break };
+            if opening.ifc_type != IfcType::IfcOpeningElement {
+                continue;
+            }
+            let Some(op): Option<RectParam> = router.parametric_rect_probe(&opening, &mut decoder)
+            else {
+                all_ok = false;
+                break;
+            };
+            let m = rt * op.r;
+            let Some(map) = is_signed_permutation(&m, 1.0e-3) else { all_ok = false; break };
+            // center of the opening in F (relative to host center).
+            let cf = rt * (op.center - hp.center);
+            // half-extents permuted into F axes.
+            let mut half_f = [0.0f64; 3];
+            for i in 0..3 {
+                half_f[i] = op.half[map[i].0];
+            }
+            // OPENING RECONCILIATION GATE: the parametric box must match the opening's
+            // actual meshed solid(s) on the two IN-FACE axes (the penetration axis is
+            // extended anyway). A mismatch = multi-solid / non-box / offset opening ->
+            // defer the whole host to the exact kernel (correct-by-construction firing).
+            let pen = (0..3).find(|&i| map[i].0 == 2).unwrap_or(thin_axis(&hp.half));
+            if let Ok(meshes) = router.get_opening_item_meshes_world(&opening, &mut decoder) {
+                let mut omn = [f64::INFINITY; 3];
+                let mut omx = [f64::NEG_INFINITY; 3];
+                let mut any = false;
+                for mesh in &meshes {
+                    for c in mesh.positions.chunks_exact(3) {
+                        any = true;
+                        let p = rt
+                            * Vector3::new(
+                                c[0] as f64 - hp.center.x,
+                                c[1] as f64 - hp.center.y,
+                                c[2] as f64 - hp.center.z,
+                            );
+                        for k in 0..3 {
+                            omn[k] = omn[k].min(p[k]);
+                            omx[k] = omx[k].max(p[k]);
+                        }
+                    }
+                }
+                if !any {
+                    all_ok = false;
+                    break;
+                }
+                if std::env::var("DEBUG_HOST").ok().and_then(|s| s.parse::<u32>().ok())
+                    == Some(host_id)
+                {
+                    eprintln!(
+                        "  host {host_id} op {opening_id}: pen={pen}  param_half={half_f:?}  \
+                         mesh_min={omn:?} mesh_max={omx:?}  param_center_F={:?}",
+                        [cf.x, cf.y, cf.z]
+                    );
+                }
+                // In-face axes: parametric 2*half_f must match the mesh extent.
+                for i in 0..3 {
+                    if i == pen {
+                        continue;
+                    }
+                    let mesh_ext = omx[i] - omn[i];
+                    let param_ext = 2.0 * half_f[i];
+                    let lo = mesh_ext.min(param_ext);
+                    let hi = mesh_ext.max(param_ext).max(1e-9);
+                    if lo / hi < 0.98 {
+                        all_ok = false;
+                        break;
+                    }
+                }
+                if !all_ok {
+                    break;
+                }
+            } else {
+                all_ok = false;
+                break;
+            }
+            let cfa = [cf.x, cf.y, cf.z];
+            let mut bmin = [cfa[0] - half_f[0], cfa[1] - half_f[1], cfa[2] - half_f[2]];
+            let mut bmax = [cfa[0] + half_f[0], cfa[1] + half_f[1], cfa[2] + half_f[2]];
+            // IN-BOUNDS gate: the opening must lie within the wall on the IN-FACE axes.
+            // An opening that overruns the wall edge (a boundary/engulfing cut) is a
+            // partial intersection where the analytic box-clamp and the exact mesh
+            // intersection diverge -> defer the whole host to the exact kernel.
+            let pen = (0..3).find(|&i| map[i].0 == 2).unwrap_or(thin_axis(&hp.half));
+            for i in 0..3 {
+                if i == pen {
+                    continue;
+                }
+                let tol = hp.half[i] * 0.01 + 1.0e-4;
+                if bmin[i] < -hp.half[i] - tol || bmax[i] > hp.half[i] + tol {
+                    all_ok = false;
+                    break;
+                }
+            }
+            if !all_ok {
+                break;
+            }
+            // Through-cut along the opening's penetration axis: extend to span the host.
+            let margin = hp.half[pen] * 0.05 + 1.0e-3;
+            bmin[pen] = -hp.half[pen] - margin;
+            bmax[pen] = hp.half[pen] + margin;
+            boxes.push((bmin, bmax));
+        }
+        if !all_ok || boxes.is_empty() {
+            continue;
+        }
+
+        // OVERLAP gate: openings must not overlap (after through-extension, two
+        // same-thickness openings overlap in 3D iff they overlap in-face). The
+        // cellular cut of overlapping boxes can diverge from the exact union-subtract.
+        let mut overlap = false;
+        for a in 0..boxes.len() {
+            for b in (a + 1)..boxes.len() {
+                let (amin, amax) = boxes[a];
+                let (bmin, bmax) = boxes[b];
+                if (0..3).all(|i| amin[i] < bmax[i] - 1.0e-4 && bmin[i] < amax[i] - 1.0e-4) {
+                    overlap = true;
+                }
+            }
+        }
+        if overlap {
+            deferred_overlap += 1;
+            continue;
+        }
+
+        if std::env::var("DEBUG_HOST").ok().and_then(|s| s.parse::<u32>().ok()) == Some(host_id) {
+            eprintln!("  host {host_id} hp.half={:?}", hp.half);
+        }
+
+        let mut stats = RectFastStats::default();
+        let Some(cut_f) = subtract_rect_openings(&host_f, &boxes, &mut stats) else {
+            deferred_rectfast += 1;
+            continue;
+        };
+        let cut_world = from_frame(&cut_f, &hp.r, &hp.center);
+
+        // SELF-CHECK GATE: the fast path refuses to fire a non-watertight cut
+        // (flush/overlapping opening edge cases) -> defer to the exact kernel.
+        if !watertight(&cut_world) {
+            deferred_wt += 1;
+            continue;
+        }
+        fired += 1;
+        wt_ok += 1;
+
+        // Exact-kernel reference for the same host.
+        let Ok(exact) = router.process_element_with_voids(&host, &mut decoder, &void_index) else {
+            continue;
+        };
+
+        let (pv, ev) = (mesh_volume(&cut_world).abs(), mesh_volume(&exact).abs());
+
+        // GROUND TRUTH: analytic volume of (host box - union of opening box∩host).
+        // Openings are gated non-overlapping, so the union is the simple sum. This is
+        // EXACT for a box wall minus box openings -> the real correctness oracle (the
+        // exact KERNEL has documented over-cut defects on engulfing openings).
+        let host_box_vol = 8.0 * hp.half[0] * hp.half[1] * hp.half[2];
+        let mut opening_vol = 0.0;
+        for (bmn, bmx) in &boxes {
+            let mut v = 1.0;
+            for i in 0..3 {
+                v *= (bmx[i].min(hp.half[i]) - bmn[i].max(-hp.half[i])).max(0.0);
+            }
+            opening_vol += v;
+        }
+        let analytic = (host_box_vol - opening_vol).abs().max(1e-9);
+        if (pv - analytic).abs() / analytic <= vol_tol {
+            param_vs_truth_ok += 1;
+        }
+        if (ev - analytic).abs() / analytic <= vol_tol {
+            exact_vs_truth_ok += 1;
+        }
+
+        let rel = (pv - ev).abs() / ev.abs().max(1e-9);
+        hist[if rel < 0.005 { 0 } else if rel < 0.02 { 1 } else if rel < 0.05 { 2 }
+            else if rel < 0.20 { 3 } else { 4 }] += 1;
+        if rel > worst {
+            worst = rel;
+            worst_host = host_id;
+        }
+        if rel <= vol_tol {
+            vol_ok += 1;
+        } else {
+            vol_bad += 1;
+            if examples < 10 {
+                examples += 1;
+                let (pmn, pmx) = bbox(&cut_world);
+                let (emn, emx) = bbox(&exact);
+                let bdelta = (0..3)
+                    .map(|k| (pmn[k] - emn[k]).abs().max((pmx[k] - emx[k]).abs()))
+                    .fold(0.0, f64::max);
+                eprintln!(
+                    "  MISMATCH host {host_id}: param_vol={pv:.4} exact_vol={ev:.4} rel={rel:.4} bbox_delta={bdelta:.4}"
+                );
+            }
+        }
+    }
+
+    let pct = |n: usize| if fired == 0 { 0.0 } else { 100.0 * n as f64 / fired as f64 };
+    let deferred = deferred_host + deferred_wt + deferred_rectfast + deferred_overlap;
+    eprintln!("\n========= PHASE-1 PARAMETRIC-vs-EXACT PARITY =========");
+    eprintln!("fixture           : {fixture}");
+    eprintln!("hosts FIRED        : {fired}   (deferred {deferred}: host-recon {deferred_host}, non-watertight {deferred_wt}, overlap {deferred_overlap}, rectfast {deferred_rectfast})");
+    eprintln!("volume PARITY ok   : {vol_ok} ({:.1}%)   mismatches: {vol_bad}", pct(vol_ok));
+    eprintln!("PARAM vs GROUND TRUTH (analytic box) : {param_vs_truth_ok} ({:.1}%)", pct(param_vs_truth_ok));
+    eprintln!("EXACT vs GROUND TRUTH (analytic box) : {exact_vs_truth_ok} ({:.1}%)", pct(exact_vs_truth_ok));
+    eprintln!("watertight (fired) : {wt_ok} (100% by self-check gate)");
+    eprintln!("worst vol rel-delta: {worst:.5} (host {worst_host})   [tol {vol_tol:.1e}]");
+    eprintln!("--- rel-delta histogram ---");
+    for (l, n) in ["<0.5%", "0.5-2%", "2-5%", "5-20%", ">20%"].iter().zip(hist.iter()) {
+        eprintln!("  {l:>7} : {n}");
+    }
+    eprintln!("======================================================\n");
+
+    // Watertight is guaranteed by the self-check gate. Correctness is measured vs the
+    // ANALYTIC ground truth (the exact kernel is an imperfect oracle with over-cut
+    // defects). The fired subset must match ground truth.
+    assert_eq!(
+        param_vs_truth_ok, fired,
+        "every fired parametric cut must match the analytic ground truth within {vol_tol:.1e}"
+    );
+}

--- a/rust/geometry/tests/rect_param_production.rs
+++ b/rust/geometry/tests/rect_param_production.rs
@@ -1,0 +1,129 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! PRODUCTION wiring test: with the parametric fast path forced ON, the real
+//! `process_element_with_voids` pipeline must (a) actually FIRE the analytic cut on
+//! rotated rectangular walls, and (b) every fired host's output must be watertight.
+//! Correctness vs ground truth is proven separately in `rect_param_parity`; this proves
+//! the end-to-end wiring + the production safety invariant.
+//!
+//! Run: MEASURE_FIXTURE=<path> cargo test --test rect_param_production -- --ignored --nocapture
+
+use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner, IfcType};
+use ifc_lite_geometry::{propagate_voids_to_parts, GeometryRouter, Mesh};
+use rustc_hash::FxHashMap;
+
+const DEFAULT_FIXTURE: &str = "../../tests/models/buildingsmart/wall-with-opening-and-window.ifc";
+
+fn watertight(mesh: &Mesh) -> bool {
+    let key = |i: u32| -> (i64, i64, i64) {
+        let b = i as usize * 3;
+        let q = |v: f32| (v as f64 / 1.0e-4).round() as i64;
+        (
+            q(mesh.positions[b]),
+            q(mesh.positions[b + 1]),
+            q(mesh.positions[b + 2]),
+        )
+    };
+    let mut edges: FxHashMap<((i64, i64, i64), (i64, i64, i64)), i32> = FxHashMap::default();
+    for tri in mesh.indices.chunks_exact(3) {
+        let (ka, kb, kc) = (key(tri[0]), key(tri[1]), key(tri[2]));
+        if ka == kb || kb == kc || kc == ka {
+            continue;
+        }
+        for (x, y) in [(ka, kb), (kb, kc), (kc, ka)] {
+            let e = if x < y { (x, y) } else { (y, x) };
+            *edges.entry(e).or_insert(0) += 1;
+        }
+    }
+    !edges.is_empty() && edges.values().all(|&c| c == 2)
+}
+
+fn build_void_index(content: &str, decoder: &mut EntityDecoder) -> FxHashMap<u32, Vec<u32>> {
+    let mut void_index: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
+    let mut scanner = EntityScanner::new(content);
+    let mut scan_decoder = EntityDecoder::new(content);
+    while let Some((id, type_name, start, end)) = scanner.next_entity() {
+        if type_name == "IFCRELVOIDSELEMENT" {
+            if let Ok(entity) = scan_decoder.decode_at_with_id(id, start, end) {
+                if let (Some(host_id), Some(opening_id)) = (entity.get_ref(4), entity.get_ref(5)) {
+                    void_index.entry(host_id).or_default().push(opening_id);
+                }
+            }
+        }
+    }
+    let _ = propagate_voids_to_parts(&mut void_index, content, decoder);
+    void_index
+}
+
+#[test]
+#[ignore = "production wiring test -- run explicitly with MEASURE_FIXTURE"]
+fn param_fast_path_fires_in_production_and_is_watertight() {
+    let fixture = std::env::var("MEASURE_FIXTURE").unwrap_or_else(|_| DEFAULT_FIXTURE.to_string());
+    if !std::path::Path::new(&fixture).exists() {
+        eprintln!("skipping: fixture {fixture} not present");
+        return;
+    }
+    let content = std::fs::read_to_string(&fixture).expect("read fixture");
+    let entity_index = build_entity_index(&content);
+    let mut decoder = EntityDecoder::with_index(&content, entity_index);
+    let router = GeometryRouter::with_units(&content, &mut decoder);
+    let void_index = build_void_index(&content, &mut decoder);
+
+    let mut host_ids: Vec<u32> = void_index.keys().copied().collect();
+    host_ids.sort_unstable();
+
+    // Force the parametric fast path ON for the production pipeline.
+    ifc_lite_geometry::rect_fast::param_set_enabled_override(Some(true));
+    let _ = ifc_lite_geometry::rect_fast::take_param_fires();
+
+    let mut fired_hosts = 0usize;
+    let mut wt_bad = 0usize;
+    let mut total_fires = 0u64;
+
+    for host_id in host_ids {
+        let Ok(host) = decoder.decode_by_id(host_id) else { continue };
+        if !matches!(
+            host.ifc_type,
+            IfcType::IfcWall | IfcType::IfcWallStandardCase | IfcType::IfcSlab | IfcType::IfcRoof
+                | IfcType::IfcColumn | IfcType::IfcBeam | IfcType::IfcMember | IfcType::IfcPlate
+                | IfcType::IfcCovering | IfcType::IfcFooting
+        ) {
+            continue;
+        }
+        let _ = ifc_lite_geometry::rect_fast::take_param_fires();
+        let Ok(result) = router.process_element_with_voids(&host, &mut decoder, &void_index) else {
+            continue;
+        };
+        let fired = ifc_lite_geometry::rect_fast::take_param_fires();
+        if fired == 0 {
+            continue; // deferred to the exact kernel
+        }
+        total_fires += fired;
+        fired_hosts += 1;
+        if !watertight(&result) {
+            wt_bad += 1;
+            if wt_bad <= 8 {
+                eprintln!("  NON-WATERTIGHT production output: host {host_id}");
+            }
+        }
+    }
+
+    ifc_lite_geometry::rect_fast::param_set_enabled_override(None);
+
+    eprintln!("\n========= PARAM FAST PATH IN PRODUCTION =========");
+    eprintln!("fixture            : {fixture}");
+    eprintln!("hosts that FIRED   : {fired_hosts}   (total fires {total_fires})");
+    eprintln!("non-watertight     : {wt_bad}");
+    eprintln!("=================================================\n");
+
+    assert!(
+        fired_hosts > 0,
+        "the parametric fast path must engage through the production pipeline"
+    );
+    assert_eq!(
+        wt_bad, 0,
+        "every fired host's production output must be watertight"
+    );
+}

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -418,6 +418,20 @@ impl IfcAPI {
         parts_slot.take();
     }
 
+    /// Enable or disable the PARAMETRIC rectangular-opening fast path (the
+    /// placement-frame, ground-truth-exact analytic cut) for `processGeometryBatch`.
+    ///
+    /// DEFAULT OFF. This is the wasm-side toggle that lets native and wasm flip the
+    /// flag in LOCKSTEP — the byte-identical native==wasm contract requires both
+    /// targets take the same path, and wasm has no env to read `IFC_LITE_RECT_PARAM`.
+    /// The path subtracts rectangular openings as exact parametric boxes in the host's
+    /// own placement frame (rotated walls included), deferring any non-clean case to
+    /// the exact kernel. Pass `true` before `processGeometryBatch`.
+    #[wasm_bindgen(js_name = setRectParamFastPath)]
+    pub fn set_rect_param_fast_path(&self, enabled: bool) {
+        ifc_lite_geometry::rect_fast::param_set_enabled_override(Some(enabled));
+    }
+
     /// Enable or disable per-entity geometry fingerprinting in
     /// `processGeometryBatch`, used by the viewer's revision-diff feature.
     ///


### PR DESCRIPTION
## What

An analytic fast path that subtracts **rectangular openings** as **exact parametric boxes in the host wall's own placement frame** — handling **rotated walls**, the dominant case the existing axis-aligned `rect_fast` cannot. **Flag-gated, default OFF.**

The key idea: the frame `R` and box extents come from the **IFC parametrics** (`IfcRectangleProfileDef` / axis-aligned `IfcArbitraryClosedProfileDef` + composed placements, × the length-unit factor), **not inferred from the f32 mesh**. So the cut is the analytic *box-minus-boxes* solid — ground-truth exact and watertight by construction. (An earlier mesh-inference attempt — averaging triangle normals + AABB'ing the opening mesh — was ~12% wrong on real geometry; reading the exact parametric data is the fix.)

## How

- `rect_fast::param_enabled()` — new flag, **DEFAULT OFF** (`IFC_LITE_RECT_PARAM=1`), plus a wasm toggle (`setRectParamFastPath`) so native + wasm flip in lockstep.
- `VoidContext` carries probed + reconciled host/opening boxes (captured in `build_void_context`). `try_param_rect_cut` runs in `apply_void_context` before the exact path with: host reconciliation (param box == real mesh), opening reconciliation (param box == opening mesh), shared-frame, in-bounds, no-overlap, and a **watertightness self-check that DEFERS** rather than emit a bad cut. Any precondition miss → exact kernel.
- Output is a **local-frame mesh** (small positions + `origin` = wall centre) so it survives f32 storage + `clean_degenerate` at national-grid magnitude. Every origin consumer (renderer, cache, clash, export, raycast, `geom_hash`) already folds it.
- Deterministic FMA-free f64 + snap grid → **byte-identical native==wasm** by construction.

## Validation

| | Flag OFF (default) | Flag ON |
|---|---|---|
| Geometry lib + void regression | **369 + all pass — fully inert** | — |
| Hosts fired in `process_element_with_voids` | — | fires on the rotated-rect-wall subset |
| Non-watertight | — | **0** (self-check defers) |
| Cut vs analytic ground truth (fired subset) | — | **100%** |

On a national-grid architectural model and a large architectural model, the fast path fires on the rotated rectangular-wall subset with **0 non-watertight** outputs and matches the **analytic ground truth 100%** — and is *more* correct than the exact kernel, which over-cuts engulfing openings on a fraction of these walls.

## Flip-gates (all addressed; flag stays OFF until a maintainer flips it)

1. **wasm toggle** — `setRectParamFastPath` lets native + wasm enable in lockstep.
2. **consumer origin-fold audit** — verified: all world-space readers already fold the per-element `origin`.
3. **determinism** — CI-safe in-crate determinism unit test (bit-identical across runs).

## Notes

- No changeset: the change is rust-only and **OFF by default** (no published behaviour change). Happy to add one if the release gate wants it.
- Test harnesses default to a **public** fixture; real models are passed via `MEASURE_FIXTURE` (no private paths committed).
- Scope: an **architecture-model** win (rotated rect walls). Steel models have no rotated-box hosts, so they are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a parametric fast path for rectangular opening processing to improve geometry computation performance.
  * Exposed `RectParam` as a publicly available geometry parameter type.
  * Added API controls (native and WASM) to enable/disable the parametric fast path.
* **Bug Fixes / Reliability**
  * Improved reliability of generated results by enforcing watertight, deterministic mesh output for supported rectangular openings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->