### PR TITLE
fix(search): guard undefined type name to stop toLowerCase crash (#1195)

### DIFF
--- a/apps/viewer/src/lib/search/filter-rules.test.ts
+++ b/apps/viewer/src/lib/search/filter-rules.test.ts
@@ -16,6 +16,26 @@ import {
   Rule,
 } from './filter-rules.js';
 
+describe('op helpers tolerate an undefined candidate (#1195)', () => {
+  // getTypeName / property accessors are typed `string` but return undefined
+  // for untyped entities at runtime; the helpers must not throw on it.
+  const undef = undefined as unknown as string;
+  it('setOpMatches treats undefined as "not one of the values"', () => {
+    assert.doesNotThrow(() => setOpMatches('in', undef, ['IfcWall']));
+    assert.strictEqual(setOpMatches('in', undef, ['IfcWall']), false);
+    assert.strictEqual(setOpMatches('notIn', undef, ['IfcWall']), true);
+  });
+  it('stringOpMatches does not throw on an undefined candidate', () => {
+    assert.doesNotThrow(() => stringOpMatches('contains', undef, 'wall'));
+    assert.strictEqual(stringOpMatches('contains', undef, 'wall'), false);
+  });
+  it('valueOpMatches treats undefined as not set', () => {
+    assert.strictEqual(valueOpMatches('isNotSet', undef, ''), true);
+    assert.strictEqual(valueOpMatches('isSet', undef, ''), false);
+    assert.doesNotThrow(() => valueOpMatches('eq', undef, 'x'));
+  });
+});
+
 describe('setOpMatches', () => {
   it('matches case-insensitively for "in"', () => {
     assert.strictEqual(setOpMatches('in', 'IfcWall', ['ifcwall', 'IfcDoor']), true);

--- a/apps/viewer/src/lib/search/filter-rules.ts
+++ b/apps/viewer/src/lib/search/filter-rules.ts
@@ -132,14 +132,22 @@ export type FilterRule =
 
 // ── Pure op helpers (ported verbatim from filter.rs) ──────────────────────────
 
+/** Lower-case a candidate that may be undefined at runtime (e.g. an untyped
+ *  entity's `getTypeName`) — calling `.toLowerCase()` on that crashed filtering
+ *  by type/name (#1195). Coercing nullish to '' is a no-op for real strings. */
+function lower(s: string | null | undefined): string {
+  return (s ?? '').toLowerCase();
+}
+
 export function setOpMatches(op: SetOp, candidate: string, values: readonly string[]): boolean {
-  const hit = values.some((v) => v.toLowerCase() === candidate.toLowerCase());
+  const c = lower(candidate);
+  const hit = values.some((v) => lower(v) === c);
   return op === 'in' ? hit : !hit;
 }
 
 export function stringOpMatches(op: StringOp, candidate: string, value: string): boolean {
-  const a = candidate.toLowerCase();
-  const b = value.toLowerCase();
+  const a = lower(candidate);
+  const b = lower(value);
   switch (op) {
     case 'eq':          return a === b;
     case 'ne':          return a !== b;
@@ -199,12 +207,12 @@ export function numericOpMatches(op: NumericOp, candidate: number, value: number
  */
 export function valueOpMatches(op: ValueOp, psetVal: string, ruleVal: string): boolean {
   switch (op) {
-    case 'isSet':       return psetVal.length > 0;
-    case 'isNotSet':    return psetVal.length === 0;
-    case 'eq':          return psetVal.toLowerCase() === ruleVal.toLowerCase();
-    case 'ne':          return psetVal.toLowerCase() !== ruleVal.toLowerCase();
-    case 'contains':    return psetVal.toLowerCase().includes(ruleVal.toLowerCase());
-    case 'notContains': return !psetVal.toLowerCase().includes(ruleVal.toLowerCase());
+    case 'isSet':       return (psetVal ?? '').length > 0;
+    case 'isNotSet':    return (psetVal ?? '').length === 0;
+    case 'eq':          return lower(psetVal) === lower(ruleVal);
+    case 'ne':          return lower(psetVal) !== lower(ruleVal);
+    case 'contains':    return lower(psetVal).includes(lower(ruleVal));
+    case 'notContains': return !lower(psetVal).includes(lower(ruleVal));
     case 'gt':
     case 'gte':
     case 'lt':

--- a/apps/viewer/src/lib/search/tier0-scan.ts
+++ b/apps/viewer/src/lib/search/tier0-scan.ts
@@ -101,7 +101,7 @@ export function runTier0Scan(
         collected.push({
           modelId: model.id,
           expressId: exactExpressId,
-          typeName: table.getTypeName(exactExpressId),
+          typeName: table.getTypeName(exactExpressId) ?? '',
           name: table.getName(exactExpressId),
           globalId: trimmed,
           description: table.getDescription(exactExpressId),
@@ -196,10 +196,15 @@ function scanModel(
       // Type lookup uses the resolved type-name accessor (handles enum
       // → PascalCase conversion). Cheap but a method call, so it stays
       // inside the per-row loop only because it can outrank NAME_SUBSTR.
+      // getTypeName returns undefined for entities the parser never typed
+      // (e.g. CAT_SKIP/non-product rows); guard it — calling .toLowerCase()
+      // on that undefined crashed the whole search on every keystroke (#1195).
       const typeName = table.getTypeName(expressId[i]);
-      const typeLower = typeName.toLowerCase();
-      if (typeLower === needle) bump(SCORE.TYPE_EXACT, 'type');
-      else if (typeLower.startsWith(needle)) bump(SCORE.TYPE_PREFIX, 'type');
+      if (typeName) {
+        const typeLower = typeName.toLowerCase();
+        if (typeLower === needle) bump(SCORE.TYPE_EXACT, 'type');
+        else if (typeLower.startsWith(needle)) bump(SCORE.TYPE_PREFIX, 'type');
+      }
     }
 
     let objectType = '';
@@ -225,7 +230,7 @@ function scanModel(
     out.push({
       modelId,
       expressId: id,
-      typeName: table.getTypeName(id),
+      typeName: table.getTypeName(id) ?? '',
       name,
       globalId,
       description: description || (dIdx !== 0 ? strings.get(dIdx) : ''),

--- a/apps/viewer/src/lib/search/tier1-index.ts
+++ b/apps/viewer/src/lib/search/tier1-index.ts
@@ -186,7 +186,9 @@ export async function buildTier1Index(
       const globalId = gIdx !== 0 ? strings.get(gIdx) : '';
       const description = dIdx !== 0 ? strings.get(dIdx) : '';
       const objectType = oIdx !== 0 ? strings.get(oIdx) : '';
-      const typeName = table.getTypeName(expressId);
+      // getTypeName is undefined for untyped (CAT_SKIP / non-product) rows;
+      // coerce to '' so the typeNameLower toLowerCase below can't crash (#1195).
+      const typeName = table.getTypeName(expressId) ?? '';
 
       const entryIndex = entries.length;
       entries.push({


### PR DESCRIPTION
Closes #1195.

`EntityTable.getTypeName()` returns `undefined` for untyped entities (CAT_SKIP / non-product rows), but the tier-0 search scan, the tier-1 index build and the ifcType/name filter ops called `.toLowerCase()` on it **unguarded** — an unhandled `TypeError: Cannot read properties of undefined (reading 'toLowerCase')` that fired on every keystroke in search whenever such a row existed (the telemetry crash).

- `tier0-scan` / `tier1-index`: coerce `getTypeName` to `''` before lowercasing.
- `filter-rules`: route `setOpMatches` / `stringOpMatches` / `valueOpMatches` through a nullish-safe `lower()` and guard the `isSet`/`isNotSet` length checks — defense in depth for every type / name / value comparison, behaviour-preserving for real strings.

### Tests
Regression cases that the op helpers tolerate an undefined candidate; full search suite (130 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search stability by properly handling missing or undefined data during filtering and scanning operations.
  * Fixed potential crashes when searching items without type information.

* **Tests**
  * Added test coverage ensuring search operators correctly handle edge cases with missing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->