### PR TITLE
fix(ids): accept merged voids/fills partOf relation (#1205)

### DIFF
--- a/.changeset/ids-partof-voids-fills.md
+++ b/.changeset/ids-partof-voids-fills.md
@@ -1,0 +1,13 @@
+---
+"@ifc-lite/ids": patch
+"@ifc-lite/data": patch
+---
+
+Accept the IDS `partOf` facet's merged voids/fills relation. The IDS XSD
+enumerates `IFCRELVOIDSELEMENT IFCRELFILLSELEMENT` as a single
+space-separated token (the two relations were merged upstream), but it was
+flagged as an invalid relation on import and silently collapsed to
+voids-only. It is now recognised end-to-end: the parser preserves the
+combined relation, the schema auditor accepts it, and the ancestor walk
+follows both the fills and voids edges so an element reaches its host
+building element through the opening. Fixes #1205.

--- a/packages/data/scripts/generate-ifc-schema.ts
+++ b/packages/data/scripts/generate-ifc-schema.ts
@@ -575,6 +575,21 @@ function parsePartOfRelations(): Record<IfcVersion, PartOfRelation[]> {
       });
     }
   }
+  // The upstream Xbim snapshot predates the IDS XSD merge of voids + fills
+  // into a single `IFCRELVOIDSELEMENT IFCRELFILLSELEMENT` enumeration value
+  // (issue #1205). Inject it for every version so the schema auditor accepts
+  // the combined token. `owner`/`member` are both `IFCELEMENT`: the reachable
+  // "whole" is the voided building element (an IfcElement, e.g. a wall) and
+  // the "part" is any element on the chain (a window/door, or the opening —
+  // IfcOpeningElement is itself an IfcElement subtype).
+  for (const version of Object.keys(out) as IfcVersion[]) {
+    if (out[version].length === 0) continue;
+    out[version].push({
+      relation: 'IFCRELVOIDSELEMENT IFCRELFILLSELEMENT',
+      owner: 'IFCELEMENT',
+      member: 'IFCELEMENT',
+    });
+  }
   return out;
 }
 

--- a/packages/data/src/ifc-schema/generated/partof-relations.ts
+++ b/packages/data/src/ifc-schema/generated/partof-relations.ts
@@ -18,6 +18,7 @@ export const PART_OF_RELATIONS_IFC2X3: readonly PartOfRelationInfo[] = [
   { relation: "IFCRELNESTS", owner: "IFCOBJECTDEFINITION", member: "IFCOBJECTDEFINITION" },
   { relation: "IFCRELVOIDSELEMENT", owner: "IFCELEMENT", member: "IFCFEATUREELEMENTSUBTRACTION" },
   { relation: "IFCRELFILLSELEMENT", owner: "IFCOPENINGELEMENT", member: "IFCELEMENT" },
+  { relation: "IFCRELVOIDSELEMENT IFCRELFILLSELEMENT", owner: "IFCELEMENT", member: "IFCELEMENT" },
 ];
 
 export const PART_OF_RELATIONS_IFC4: readonly PartOfRelationInfo[] = [
@@ -27,6 +28,7 @@ export const PART_OF_RELATIONS_IFC4: readonly PartOfRelationInfo[] = [
   { relation: "IFCRELNESTS", owner: "IFCOBJECTDEFINITION", member: "IFCOBJECTDEFINITION" },
   { relation: "IFCRELVOIDSELEMENT", owner: "IFCELEMENT", member: "IFCFEATUREELEMENTSUBTRACTION" },
   { relation: "IFCRELFILLSELEMENT", owner: "IFCOPENINGELEMENT", member: "IFCELEMENT" },
+  { relation: "IFCRELVOIDSELEMENT IFCRELFILLSELEMENT", owner: "IFCELEMENT", member: "IFCELEMENT" },
 ];
 
 export const PART_OF_RELATIONS_IFC4X3: readonly PartOfRelationInfo[] = [
@@ -36,4 +38,5 @@ export const PART_OF_RELATIONS_IFC4X3: readonly PartOfRelationInfo[] = [
   { relation: "IFCRELNESTS", owner: "IFCOBJECTDEFINITION", member: "IFCOBJECTDEFINITION" },
   { relation: "IFCRELVOIDSELEMENT", owner: "IFCELEMENT", member: "IFCFEATUREELEMENTSUBTRACTION" },
   { relation: "IFCRELFILLSELEMENT", owner: "IFCOPENINGELEMENT", member: "IFCELEMENT" },
+  { relation: "IFCRELVOIDSELEMENT IFCRELFILLSELEMENT", owner: "IFCELEMENT", member: "IFCELEMENT" },
 ];

--- a/packages/ids/src/audit/audit.test.ts
+++ b/packages/ids/src/audit/audit.test.ts
@@ -281,6 +281,24 @@ describe('auditIDSDocument — IFC schema cross-checks', () => {
     const r = await auditIDSDocument(xml);
     expect(codes(r.issues)).toContain('E_IFC_PARTOF_RELATION');
   });
+
+  it('accepts the merged voids/fills partOf relation (issue #1205)', async () => {
+    // The IDS XSD enumerates voids + fills as one space-separated token.
+    // It must not be flagged as an invalid relation on import.
+    const xml = wrap(`<specification name="Window in wall" ifcVersion="IFC4">
+      <applicability>
+        <entity><name><simpleValue>IFCWINDOW</simpleValue></name></entity>
+      </applicability>
+      <requirements>
+        <partOf relation="IFCRELVOIDSELEMENT IFCRELFILLSELEMENT"><entity><name><simpleValue>IFCWALL</simpleValue></name></entity></partOf>
+      </requirements>
+    </specification>`);
+    const r = await auditIDSDocument(xml);
+    // Neither the relation token nor the window→wall owner/member subtype
+    // check should flag — a window IS validly part of a wall via the chain.
+    expect(codes(r.issues)).not.toContain('E_IFC_PARTOF_RELATION');
+    expect(codes(r.issues)).not.toContain('E_IFC_PARTOF_ENTITY');
+  });
 });
 
 describe('auditIDSDocument — coherence checks', () => {

--- a/packages/ids/src/bridge/data-accessor.test.ts
+++ b/packages/ids/src/bridge/data-accessor.test.ts
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { RelationshipType } from '@ifc-lite/data';
+import type { IfcDataStore } from '@ifc-lite/parser';
+
+import { createDataAccessor } from './data-accessor.js';
+
+/**
+ * Minimal store stub modelling a window that fills an opening which voids
+ * a wall:
+ *
+ *   IfcWindow(10) --FillsElement--> IfcOpeningElement(20) --VoidsElement--> IfcWall(30)
+ *
+ * `getRelated(..., 'inverse')` returns the relating side given the related
+ * side, matching how the real CSR graph is built (see
+ * `parser/on-demand-extractors.ts`). `entityIndex.byId` is left empty so
+ * the on-demand attribute extractor short-circuits without touching a
+ * source buffer.
+ */
+function makeStore(): IfcDataStore {
+  const types = new Map<number, string>([
+    [10, 'IfcWindow'],
+    [20, 'IfcOpeningElement'],
+    [30, 'IfcWall'],
+  ]);
+  // inverse adjacency: relatedId -> relType -> relatingIds
+  const inverse = new Map<number, Map<RelationshipType, number[]>>([
+    [10, new Map([[RelationshipType.FillsElement, [20]]])],
+    [20, new Map([[RelationshipType.VoidsElement, [30]]])],
+  ]);
+
+  return {
+    schemaVersion: 'IFC4',
+    source: new Uint8Array(),
+    entities: {
+      getTypeName: (id: number) => types.get(id),
+      getObjectType: () => undefined,
+      getName: () => undefined,
+      getGlobalId: () => undefined,
+      getDescription: () => undefined,
+    },
+    entityIndex: { byId: new Map(), byType: new Map() },
+    relationships: {
+      getRelated: (
+        id: number,
+        relType: RelationshipType,
+        direction: 'forward' | 'inverse'
+      ) => (direction === 'inverse' ? inverse.get(id)?.get(relType) ?? [] : []),
+    },
+  } as unknown as IfcDataStore;
+}
+
+describe('createDataAccessor — merged voids/fills partOf relation (issue #1205)', () => {
+  it('walks both Fills and Voids edges so a window reaches its host wall', () => {
+    const accessor = createDataAccessor(makeStore());
+    const ancestors = accessor.getAncestors!(
+      10,
+      'IfcRelVoidsElement IfcRelFillsElement'
+    );
+    const types = ancestors.map((a) => a.entityType);
+    // The window fills an opening (FillsElement) which voids a wall
+    // (VoidsElement); both are reachable through the chained relation.
+    expect(types).toContain('IfcOpeningElement');
+    expect(types).toContain('IfcWall');
+  });
+
+  it('resolves an opening directly to its voided wall', () => {
+    const accessor = createDataAccessor(makeStore());
+    const ancestors = accessor.getAncestors!(
+      20,
+      'IfcRelVoidsElement IfcRelFillsElement'
+    );
+    expect(ancestors.map((a) => a.entityType)).toEqual(['IfcWall']);
+  });
+
+  it('does not reach the host wall via the single FillsElement relation alone', () => {
+    const accessor = createDataAccessor(makeStore());
+    // A plain fills relation only hops window -> opening, never to the wall.
+    const ancestors = accessor.getAncestors!(10, 'IfcRelFillsElement');
+    expect(ancestors.map((a) => a.entityType)).toEqual(['IfcOpeningElement']);
+  });
+});

--- a/packages/ids/src/bridge/data-accessor.ts
+++ b/packages/ids/src/bridge/data-accessor.ts
@@ -32,13 +32,25 @@ import { narrowSchemaVersion } from './schema-version.js';
 // graph keys on. Passing strings here was a long-standing silent bug:
 // `getRelated` matched nothing → every partOf check looked like
 // "no parent" → fail-when-required, pass-when-prohibited.
-const PARTOF_REL_MAP: Record<PartOfRelation, RelationshipType | undefined> = {
-  IfcRelAggregates: RelationshipType.Aggregates,
-  IfcRelAssignsToGroup: RelationshipType.AssignsToGroup,
-  IfcRelContainedInSpatialStructure: RelationshipType.ContainsElements,
-  IfcRelNests: RelationshipType.Aggregates,
-  IfcRelVoidsElement: RelationshipType.VoidsElement,
-  IfcRelFillsElement: RelationshipType.FillsElement,
+//
+// Each relation maps to a LIST of edge types the ancestor walk follows.
+// All but the merged voids/fills token map to a single type; the IDS XSD
+// merged voids + fills into one enumeration value
+// (`IFCRELVOIDSELEMENT IFCRELFILLSELEMENT`) that links an element to its
+// host building element through an opening — a window fills an opening
+// (`FillsElement`) that voids a wall (`VoidsElement`). Walking both edge
+// types inverse-direction reaches the opening and the wall in turn.
+const PARTOF_REL_MAP: Record<PartOfRelation, readonly RelationshipType[]> = {
+  IfcRelAggregates: [RelationshipType.Aggregates],
+  IfcRelAssignsToGroup: [RelationshipType.AssignsToGroup],
+  IfcRelContainedInSpatialStructure: [RelationshipType.ContainsElements],
+  IfcRelNests: [RelationshipType.Aggregates],
+  IfcRelVoidsElement: [RelationshipType.VoidsElement],
+  IfcRelFillsElement: [RelationshipType.FillsElement],
+  'IfcRelVoidsElement IfcRelFillsElement': [
+    RelationshipType.FillsElement,
+    RelationshipType.VoidsElement,
+  ],
 };
 
 /**
@@ -220,26 +232,29 @@ export function createDataAccessor(store: IfcDataStore): IFCDataAccessor {
     ): ParentInfo[] {
       const relationships = store.relationships;
       if (!relationships?.getRelated) return [];
-      const relType = PARTOF_REL_MAP[relationType];
-      if (relType === undefined) return [];
+      const relTypes = PARTOF_REL_MAP[relationType];
+      if (!relTypes || relTypes.length === 0) return [];
 
       // BFS up the graph — IDS partOf is transitive, so any reachable
-      // ancestor counts.
+      // ancestor counts. The merged voids/fills relation walks two edge
+      // types per node, so the queue follows each mapped type in turn.
       const out: ParentInfo[] = [];
       const seen = new Set<number>([expressId]);
       const queue = [expressId];
       while (queue.length > 0) {
         const id = queue.shift()!;
-        const parents = relationships.getRelated(id, relType, 'inverse');
-        for (const parentId of parents || []) {
-          if (seen.has(parentId)) continue;
-          seen.add(parentId);
-          out.push({
-            expressId: parentId,
-            entityType: accessor.getEntityType(parentId) || 'Unknown',
-            predefinedType: accessor.getObjectType(parentId),
-          });
-          queue.push(parentId);
+        for (const relType of relTypes) {
+          const parents = relationships.getRelated(id, relType, 'inverse');
+          for (const parentId of parents || []) {
+            if (seen.has(parentId)) continue;
+            seen.add(parentId);
+            out.push({
+              expressId: parentId,
+              entityType: accessor.getEntityType(parentId) || 'Unknown',
+              predefinedType: accessor.getObjectType(parentId),
+            });
+            queue.push(parentId);
+          }
         }
       }
       return out;

--- a/packages/ids/src/facets/facets.test.ts
+++ b/packages/ids/src/facets/facets.test.ts
@@ -893,6 +893,17 @@ describe('checkPartOfFacet', () => {
         relation: 'IfcRelAggregates',
       },
     },
+    {
+      // Window connected to its host wall through an opening — the IDS
+      // merged voids/fills relation (issue #1205).
+      expressId: 5,
+      type: 'IfcWindow',
+      parent: {
+        expressId: 400,
+        type: 'IfcWall',
+        relation: 'IfcRelVoidsElement IfcRelFillsElement',
+      },
+    },
   ]);
 
   it('passes when parent exists via specified relation', () => {
@@ -991,6 +1002,16 @@ describe('checkPartOfFacet', () => {
     expect(result.passed).toBe(false);
     expect(result.failure?.type).toBe('PARTOF_PREDEFINED_TYPE_MISSING');
     expect(result.failure?.field).toBe('predefinedType');
+  });
+
+  it('passes for the merged voids/fills relation through an opening (issue #1205)', () => {
+    const facet: IDSPartOfFacet = {
+      type: 'partOf',
+      relation: 'IfcRelVoidsElement IfcRelFillsElement',
+      entity: { type: 'entity', name: sv('IfcWall') },
+    };
+    const result = checkPartOfFacet(facet, 5, accessor);
+    expect(result.passed).toBe(true);
   });
 });
 

--- a/packages/ids/src/facets/partof-facet.ts
+++ b/packages/ids/src/facets/partof-facet.ts
@@ -26,6 +26,7 @@ const RELATION_NAMES: Record<PartOfRelation, string> = {
   IfcRelNests: 'nested in',
   IfcRelVoidsElement: 'voiding',
   IfcRelFillsElement: 'filling',
+  'IfcRelVoidsElement IfcRelFillsElement': 'connected through an opening to',
 };
 
 /**

--- a/packages/ids/src/parser/xml-parser.test.ts
+++ b/packages/ids/src/parser/xml-parser.test.ts
@@ -307,6 +307,34 @@ describe('parseIDS — valid documents', () => {
     }
   });
 
+  it('parses the merged voids/fills partOf relation without collapsing it (issue #1205)', () => {
+    const xml = `<ids xmlns="http://standards.buildingsmart.org/IDS">
+  <info><title>T</title></info>
+  <specifications>
+    <specification name="Test" ifcVersion="IFC4">
+      <applicability>
+        <entity><name><simpleValue>IFCWINDOW</simpleValue></name></entity>
+      </applicability>
+      <requirements>
+        <partOf relation="IFCRELVOIDSELEMENT IFCRELFILLSELEMENT">
+          <entity>
+            <name><simpleValue>IFCWALL</simpleValue></name>
+          </entity>
+        </partOf>
+      </requirements>
+    </specification>
+  </specifications>
+</ids>`;
+
+    const doc = parseIDS(xml);
+    const facet = doc.specifications[0].requirements[0].facet;
+    expect(facet.type).toBe('partOf');
+    if (facet.type === 'partOf') {
+      // Must NOT be collapsed to 'IfcRelVoidsElement' (the old bug).
+      expect(facet.relation).toBe('IfcRelVoidsElement IfcRelFillsElement');
+    }
+  });
+
   it('parses XSD restriction with pattern', () => {
     const xml = `<ids xmlns="http://standards.buildingsmart.org/IDS"
      xmlns:xs="http://www.w3.org/2001/XMLSchema">

--- a/packages/ids/src/parser/xml-parser.ts
+++ b/packages/ids/src/parser/xml-parser.ts
@@ -460,6 +460,7 @@ function isRecognisedPartOfRelation(relation: string): boolean {
     case 'IfcRelVoidsElement':
     case 'IfcRelFillsElement':
     case 'IfcRelAssignsToGroup':
+    case 'IfcRelVoidsElement IfcRelFillsElement':
       return true;
     default:
       return false;
@@ -477,6 +478,13 @@ function normalizePartOfRelation(relation: string): PartOfRelation {
   if (upper.includes('CONTAINED') || upper.includes('SPATIAL'))
     return 'IfcRelContainedInSpatialStructure';
   if (upper.includes('NEST')) return 'IfcRelNests';
+  // The IDS XSD merged voids + fills into a single enumeration value
+  // (`IFCRELVOIDSELEMENT IFCRELFILLSELEMENT`). Detect that combined form
+  // BEFORE the individual checks below so it isn't silently collapsed to
+  // voids-only (which would both drop the fills traversal and trip the
+  // schema auditor — see issue #1205).
+  if (upper.includes('VOID') && upper.includes('FILL'))
+    return 'IfcRelVoidsElement IfcRelFillsElement';
   if (upper.includes('VOID')) return 'IfcRelVoidsElement';
   if (upper.includes('FILL')) return 'IfcRelFillsElement';
   return 'IfcRelContainedInSpatialStructure';

--- a/packages/ids/src/translation/locales/de.ts
+++ b/packages/ids/src/translation/locales/de.ts
@@ -43,6 +43,7 @@ export const de = {
     IfcRelNests: 'verschachtelt in',
     IfcRelVoidsElement: 'durchbrechend',
     IfcRelFillsElement: 'ausfüllend',
+    'IfcRelVoidsElement IfcRelFillsElement': 'über eine Öffnung verbunden mit',
   },
 
   // ============================================================================

--- a/packages/ids/src/translation/locales/en.ts
+++ b/packages/ids/src/translation/locales/en.ts
@@ -43,6 +43,7 @@ export const en = {
     IfcRelNests: 'nested in',
     IfcRelVoidsElement: 'voiding',
     IfcRelFillsElement: 'filling',
+    'IfcRelVoidsElement IfcRelFillsElement': 'connected through an opening to',
   },
 
   // ============================================================================

--- a/packages/ids/src/translation/locales/fr.ts
+++ b/packages/ids/src/translation/locales/fr.ts
@@ -43,6 +43,7 @@ export const fr = {
     IfcRelNests: 'imbriqué dans',
     IfcRelVoidsElement: 'perçant',
     IfcRelFillsElement: 'remplissant',
+    'IfcRelVoidsElement IfcRelFillsElement': 'relié via une ouverture à',
   },
 
   // ============================================================================

--- a/packages/ids/src/types.ts
+++ b/packages/ids/src/types.ts
@@ -199,7 +199,13 @@ export type PartOfRelation =
   | 'IfcRelContainedInSpatialStructure'
   | 'IfcRelNests'
   | 'IfcRelVoidsElement'
-  | 'IfcRelFillsElement';
+  | 'IfcRelFillsElement'
+  // The IDS XSD enumerates voids+fills as a SINGLE space-separated token
+  // (`IFCRELVOIDSELEMENT IFCRELFILLSELEMENT`). It models the chained
+  // relationship that links an element to its host building element
+  // *through an opening* — e.g. a window fills an opening that voids a
+  // wall. See https://github.com/buildingSMART/IDS/issues/278.
+  | 'IfcRelVoidsElement IfcRelFillsElement';
 
 // ============================================================================
 // Constraint Types


### PR DESCRIPTION
## Problem

Fixes #1205. Importing an IDS whose `partOf` facet uses the relation `IFCRELVOIDSELEMENT IFCRELFILLSELEMENT` was flagged as an error (`E_IFC_PARTOF_RELATION`).

This is **not** a malformed value — the [official IDS XSD](https://github.com/buildingSMART/IDS/blob/development/Schema/ids.xsd) enumerates voids/fills as a **single space-separated token**; the two relations were deliberately merged upstream ([IDS#278](https://github.com/buildingSMART/IDS/issues/278), [IDS#193](https://github.com/buildingSMART/IDS/issues/193)). It models the chained relationship that links an element to its host building element *through an opening* (a window fills an opening that voids a wall).

## Root cause

ifc-lite had it backwards:

- **Parser** (`normalizePartOfRelation`) matched `.includes('VOID')` first and silently collapsed the combined token to voids-only, dropping the fills hop.
- **Schema auditor** (`auditPartOfFacet`) looked the raw token up in a table that only held the 6 *separate* relations (generated from a stale Xbim snapshot predating the merge), so the merged value was rejected. The XSD/structural audit passes correctly defer relation-value validity to this pass, making it the sole source of the error.

## Fix (end-to-end)

- **`types.ts`** — add `'IfcRelVoidsElement IfcRelFillsElement'` to `PartOfRelation`.
- **`parser/xml-parser.ts`** — detect the combined token *before* the single voids/fills checks so it isn't collapsed.
- **`data` schema table + generator** — inject the merged entry (`owner`/`member` = `IFCELEMENT`) for every IFC version so the auditor accepts it and regeneration preserves it.
- **`bridge/data-accessor.ts`** — `PARTOF_REL_MAP` now maps to a *list* of edge types; the `getAncestors` BFS follows both `FillsElement` + `VoidsElement` so an element reaches its host through the opening (window → opening → wall). Direction verified against `parser/on-demand-extractors.ts`; mirrors ifctester's `get_filled_void` → `get_voided_element`.
- **`facets/partof-facet.ts` + en/de/fr locales** — human-readable label for the new relation.

## Tests

Added coverage at every layer:

- **Parser** — the merged token parses to `'IfcRelVoidsElement IfcRelFillsElement'` (not collapsed).
- **Audit** — no `E_IFC_PARTOF_RELATION` / `E_IFC_PARTOF_ENTITY` for a window→wall spec.
- **Facet checker** — passes via the combined relation.
- **Bridge** — `getAncestors` reaches the wall from a window through the opening, and a plain `IfcRelFillsElement` alone does not.

`@ifc-lite/ids` 270/270 and `@ifc-lite/data` 51/51 pass; both typecheck clean. Changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for merged `voids`/`fills` relations in the `partOf` facet to enable traversal through openings to host elements.

* **Bug Fixes**
  * Fixed parsing and validation of combined void/fill relationships in IDS documents (fixes `#1205`).

* **Documentation**
  * Added translations for the merged relation in English, French, and German.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->