### PR TITLE
chore(geometry): flip the parametric rect-opening fast path ON by default

### DIFF
--- a/rust/geometry/src/rect_fast.rs
+++ b/rust/geometry/src/rect_fast.rs
@@ -64,11 +64,16 @@ pub fn enabled() -> bool {
 static PARAM_OVERRIDE: std::sync::atomic::AtomicI8 = std::sync::atomic::AtomicI8::new(-1);
 
 /// PARAMETRIC rectangular-opening fast path (placement-frame, ground-truth-exact cut).
-/// DEFAULT OFF — opt in with `IFC_LITE_RECT_PARAM=1` or `param_set_enabled_override`.
-/// Gated separately from [`enabled`] because it is a deliberate behaviour change: it
-/// emits the analytic box-minus-boxes solid, which is MORE correct than the exact kernel
-/// on engulfing-opening walls. Stays off until a parity CI gate + a wasm toggle land, so
-/// native==wasm holds trivially (both off) until the flag is flipped in lockstep.
+/// DEFAULT ON (set `IFC_LITE_RECT_PARAM=0` to force the exact kernel for bisection).
+/// LOCKSTEP native+wasm so the byte-identical contract holds: both targets take the same
+/// (deterministic, FMA-free) path. It emits the analytic box-minus-boxes solid — proven
+/// 100% vs ground truth + watertight on the firing subset, and MORE correct than the
+/// exact kernel on engulfing-opening walls (which it deliberately replaces). Any non-clean
+/// case defers to the exact kernel, so the change is confined to clean box-host /
+/// rectangular-prism-opening walls. NOTE: a firing element emits a local-frame mesh
+/// (small positions + `origin`); native server output is no longer pure absolute-coord for
+/// those elements (every origin consumer already folds it). The frozen determinism corpus
+/// is unaffected — no snapshot/regression model is a clean rect-opening box wall.
 pub fn param_enabled() -> bool {
     match PARAM_OVERRIDE.load(std::sync::atomic::Ordering::Relaxed) {
         0 => return false,
@@ -77,7 +82,7 @@ pub fn param_enabled() -> bool {
     }
     use std::sync::OnceLock;
     static ON: OnceLock<bool> = OnceLock::new();
-    *ON.get_or_init(|| std::env::var("IFC_LITE_RECT_PARAM").as_deref() == Ok("1"))
+    *ON.get_or_init(|| std::env::var("IFC_LITE_RECT_PARAM").as_deref() != Ok("0"))
 }
 
 /// Test-only: force `param_enabled()` on/off (or `None` for the env default).


### PR DESCRIPTION
## What

Flips `rect_fast::param_enabled()` default **OFF → ON** (lockstep native+wasm). `IFC_LITE_RECT_PARAM=0` still forces the exact kernel for bisection. Builds on #1193 + #1209.

**Draft** — this changes production geometry on real models and carries a tradeoff (below). It should land only after a live-viewer validation + a deliberate team call.

## Why it's safe to consider

- **Correctness**: proven 100% within 0.5% of the analytic box-minus-boxes ground truth, 0 non-watertight, on a large steel/harbour model (176 walls fire) and a large arch model (294 walls). Any non-clean case (gable host, non-rect opening, multi-overlap, etc.) defers to the exact kernel.
- **CI-safe**: 369 lib + the geometry snapshot / dedup / void-regression corpus pass with param default ON, **zero snapshot drift** — no frozen-corpus model is a clean box-host rect-opening wall, so the flip is invisible to CI.
- **Determinism / byte-identity**: lockstep + the same FMA-free f64 path → native==wasm holds.

## The win

Targets the **wall void-cutting that now dominates steel-model geometry time** (the faceted-brep mesher was already fixed by #1181/#1184). On the steel/harbour model it fires on 176 walls that previously went through the exact kernel; it's also more correct than the exact kernel on engulfing-opening walls.

## Tradeoff to weigh before merge

A *firing* element emits a **local-frame mesh** (small positions + `origin`), so native server output is no longer pure absolute-coord for those elements. Every origin consumer (renderer / cache / clash / export / raycast / `geom_hash`) already folds it, and the frozen determinism corpus is unaffected — but this is a deliberate change to the "native stays absolute-coord" choice.

## Before merge

- [ ] Live-viewer validation on a real georeferenced model (wasm + RTC + renderer origin-fold render correctly — no scatter/holes).
- [ ] Confirm the team accepts the native-absolute-coord tradeoff for firing elements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)