### PR TITLE
fix(viewer): classify the heavy-model OOM error family + stop the watchdog filename leak

### DIFF
--- a/.changeset/geometry-worker-crash-message.md
+++ b/.changeset/geometry-worker-crash-message.md
@@ -1,0 +1,12 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Emit a meaningful message when a geometry worker crashes. A hard worker crash
+(e.g. the wasm thread aborting under memory pressure) fires an `ErrorEvent`
+with an empty `message`, so the pool reported the cryptic, unclassifiable
+"Geometry worker failed: undefined". It now synthesises a message from
+whatever the `ErrorEvent` carries (`filename:lineno`, or
+"worker terminated unexpectedly"), so the failure is human-readable and the
+viewer's load-error classifier can bucket it instead of filing it as a raw
+one-off error.

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -914,8 +914,12 @@ export function useIfcLoader() {
             geometryIterator.next(),
             new Promise<never>((_, reject) => {
               watchdogId = globalThis.setTimeout(() => {
+                // Do NOT embed `file.name` here — this Error is captured by
+                // error tracking (and auto-filed as a public GitHub issue), so
+                // a confidential model name would leak. The file name is added
+                // back for the user only, via formatLoadError(err, file.name).
                 reject(new Error(
-                  `Geometry stream stalled after ${watchdogMs}ms while loading ${file.name}. ` +
+                  `Geometry stream stalled after ${watchdogMs}ms. ` +
                   `Last rendered meshes: ${lastTotalMeshes}.`
                 ));
               }, watchdogMs);

--- a/apps/viewer/src/lib/analytics-scrub.ts
+++ b/apps/viewer/src/lib/analytics-scrub.ts
@@ -43,15 +43,20 @@ const stripQueryAndHash = (value: string): string => {
 const scrubProperties = (props: Record<string, unknown> | undefined): void => {
   if (!props) return;
   for (const k of Object.keys(props)) {
+    const v = props[k];
+    // URL_KEYS must be checked BEFORE SENSITIVE_KEY: keys like `$current_url`
+    // match SENSITIVE_KEY's `url` word, so without this they'd be deleted
+    // outright instead of having their query/hash stripped — losing the route
+    // we intend to keep (see the URL_KEYS comment above).
+    if (URL_KEYS.has(k)) {
+      if (typeof v === 'string') props[k] = stripQueryAndHash(v);
+      continue;
+    }
     if (SENSITIVE_KEY.test(k)) {
       delete props[k];
       continue;
     }
-    const v = props[k];
-    if (typeof v === 'string') {
-      if (URL_KEYS.has(k)) props[k] = stripQueryAndHash(v);
-      else if (PATHISH.test(v)) props[k] = '[redacted]';
-    }
+    if (typeof v === 'string' && PATHISH.test(v)) props[k] = '[redacted]';
   }
 };
 
@@ -85,14 +90,15 @@ const isUnactionableThirdPartyException = (
 
 // ── Error-family tagging ─────────────────────────────────────────────────────
 // The geometry pipeline surfaces a recurring family of resource-exhaustion
-// failures on heavy models (WASM OOM, worker crashes, the stream watchdog) plus
-// transient engine-load failures. Most reach error tracking RAW — either as
-// uncaught exceptions PostHog autocaptures (e.g. a wasm "unreachable" trap in
-// the worker-message handler) or via explicit captureException — so each new
-// minified message spawns its own one-off error group (and a public GitHub
-// issue). Stamping a stable `error_kind` from the exception's message lets these
-// be filtered, grouped, and suppressed centrally instead of triaged one by one.
-// See ./load-errors.ts for the taxonomy.
+// failures on heavy models (WASM OOM, the worker pool's "Geometry worker …"
+// crashes, the stream watchdog) plus transient engine-load failures. Many reach
+// error tracking RAW — either as uncaught exceptions PostHog autocaptures or via
+// explicit captureException — so each new minified message spawns its own
+// one-off error group (and a public GitHub issue). Stamping a stable
+// `error_kind` from the exception's message lets the *recognised* family be
+// filtered, grouped, and suppressed centrally instead of triaged one by one.
+// Unrecognised exceptions (`unknown`) are left untagged so an unrelated app
+// failure is never mislabelled as a geometry/load error. See ./load-errors.ts.
 const exceptionMessage = (
   props: Record<string, unknown> | undefined,
 ): string | undefined => {
@@ -117,7 +123,11 @@ const tagErrorKind = (
   if (typeof event.properties.error_kind === 'string') return;
   const message = exceptionMessage(event.properties);
   if (message === undefined) return;
-  event.properties.error_kind = classifyLoadError(message);
+  const kind = classifyLoadError(message);
+  // Only tag recognised families — never stamp `unknown` onto an unrelated
+  // exception (that would mislabel it as a triaged load error).
+  if (kind === 'unknown') return;
+  event.properties.error_kind = kind;
 };
 
 // `before_send` shape: (event | null) => (event | null). Returning null drops

--- a/apps/viewer/src/lib/analytics-scrub.ts
+++ b/apps/viewer/src/lib/analytics-scrub.ts
@@ -1,0 +1,137 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { classifyLoadError } from './load-errors.js';
+
+// PostHog `before_send` pipeline: the single gate every captured event passes
+// through before it leaves the browser. Kept dependency-free (no posthog-js) so
+// the privacy + tagging contract is unit-testable without the browser SDK; the
+// client wiring lives in analytics.ts.
+
+// ── Privacy guard ──────────────────────────────────────────────────────────
+// ifc-lite opens confidential client building models, so the rule that keeps
+// file / pset / property names out of git applies to analytics too: NO event
+// may carry a file name, model name, BCF title, free text, or a filesystem
+// path — even accidentally from a future call site. `scrubEvent` runs on every
+// captured event (including PostHog's own $pageleave / $exception) as a safety
+// net on top of the deliberately lean explicit properties.
+
+// Keys whose values tend to be PII / free text / confidential identifiers.
+// Matches whole `_`-delimited words, so analytics keys like `data_source`,
+// `auto_color_source`, `template_id` or `field` are deliberately left intact.
+const SENSITIVE_KEY =
+  /(?:^|_)(?:name|filename|model|title|label|path|url|uri|href|email|author|comment|description|message|content|query|sql|expression|psetname|propertyname)(?:$|_)/i;
+
+// PostHog auto-properties that are URLs — keep the route, drop query + hash
+// (a share link can encode a model id or token).
+const URL_KEYS = new Set<string>([
+  '$current_url', '$referrer', '$referring_domain', '$pathname',
+  '$initial_current_url', '$initial_referrer', '$initial_referring_domain',
+  '$prev_pageview_pathname',
+]);
+
+// String values that look like a filesystem path or a building-model file name.
+const PATHISH =
+  /[\\/][^\\/]*\.(?:ifc|ifcx|ifczip|bcf|bcfzip|glb|gltf|obj|csv|xlsx|pdf|json|step|stp|las|laz)\b|^(?:file|blob):|^[A-Za-z]:\\|\/Users\/|\/home\//i;
+
+const stripQueryAndHash = (value: string): string => {
+  const cut = value.search(/[?#]/);
+  return cut === -1 ? value : value.slice(0, cut);
+};
+
+const scrubProperties = (props: Record<string, unknown> | undefined): void => {
+  if (!props) return;
+  for (const k of Object.keys(props)) {
+    if (SENSITIVE_KEY.test(k)) {
+      delete props[k];
+      continue;
+    }
+    const v = props[k];
+    if (typeof v === 'string') {
+      if (URL_KEYS.has(k)) props[k] = stripQueryAndHash(v);
+      else if (PATHISH.test(v)) props[k] = '[redacted]';
+    }
+  }
+};
+
+// ── Noise filter ───────────────────────────────────────────────────────────
+// Cesium rejects failed tile / terrain / imagery / ion-asset requests with a
+// `RequestErrorEvent` — a plain `{ statusCode, response, responseHeaders }`
+// object, not an Error. During continuous globe rendering these fire from deep
+// inside Cesium's request scheduler (a tile 403/404/429/timeout), so the geo
+// call sites we own (all `try/catch`-wrapped) can't intercept them, and they
+// surface as unhandled rejections that PostHog's exception autocapture records.
+// They are unactionable third-party network failures, not ifc-lite bugs, so we
+// drop the `$exception` event entirely. Match on Cesium's stable property-name
+// shape (those three keys), NOT the minified class name (`D_`), which changes
+// every build. posthog-js stringifies a non-Error throwable as
+// "'<ctor>' captured as exception with keys: <comma-separated own keys>".
+const CESIUM_REQUEST_ERROR =
+  /captured as exception with keys:(?=[^]*\bstatusCode\b)(?=[^]*\bresponse\b)(?=[^]*\bresponseHeaders\b)/;
+
+const isUnactionableThirdPartyException = (
+  event: { event?: string; properties?: Record<string, unknown> },
+): boolean => {
+  if (event.event !== '$exception') return false;
+  const list = event.properties?.$exception_list;
+  if (!Array.isArray(list)) return false;
+  return list.some(
+    (e) =>
+      typeof (e as { value?: unknown })?.value === 'string' &&
+      CESIUM_REQUEST_ERROR.test((e as { value: string }).value),
+  );
+};
+
+// ── Error-family tagging ─────────────────────────────────────────────────────
+// The geometry pipeline surfaces a recurring family of resource-exhaustion
+// failures on heavy models (WASM OOM, worker crashes, the stream watchdog) plus
+// transient engine-load failures. Most reach error tracking RAW — either as
+// uncaught exceptions PostHog autocaptures (e.g. a wasm "unreachable" trap in
+// the worker-message handler) or via explicit captureException — so each new
+// minified message spawns its own one-off error group (and a public GitHub
+// issue). Stamping a stable `error_kind` from the exception's message lets these
+// be filtered, grouped, and suppressed centrally instead of triaged one by one.
+// See ./load-errors.ts for the taxonomy.
+const exceptionMessage = (
+  props: Record<string, unknown> | undefined,
+): string | undefined => {
+  if (!props) return undefined;
+  const list = props.$exception_list;
+  if (Array.isArray(list)) {
+    for (const e of list) {
+      const v = (e as { value?: unknown })?.value;
+      if (typeof v === 'string' && v) return v;
+    }
+  }
+  const values = props.$exception_values;
+  if (Array.isArray(values) && typeof values[0] === 'string') return values[0] as string;
+  return undefined;
+};
+
+const tagErrorKind = (
+  event: { event?: string; properties?: Record<string, unknown> },
+): void => {
+  if (event.event !== '$exception' || !event.properties) return;
+  // Don't clobber an explicit kind set at the capture site.
+  if (typeof event.properties.error_kind === 'string') return;
+  const message = exceptionMessage(event.properties);
+  if (message === undefined) return;
+  event.properties.error_kind = classifyLoadError(message);
+};
+
+// `before_send` shape: (event | null) => (event | null). Returning null drops
+// the event (noise filter above); otherwise we mutate properties in place,
+// which keeps PostHog's event intact. Generic so it satisfies posthog-js's
+// BeforeSendFn (CaptureResult) signature.
+export const scrubEvent = <
+  T extends { event?: string; properties?: Record<string, unknown> } | null,
+>(
+  event: T,
+): T | null => {
+  if (!event) return event;
+  if (isUnactionableThirdPartyException(event)) return null;
+  tagErrorKind(event);
+  scrubProperties(event.properties);
+  return event;
+};

--- a/apps/viewer/src/lib/analytics.test.ts
+++ b/apps/viewer/src/lib/analytics.test.ts
@@ -22,9 +22,14 @@ const exceptionEvent = (value: string, extraProps: Record<string, unknown> = {})
 });
 
 describe('scrubEvent — error_kind tagging', () => {
-  it('tags a raw wasm "unreachable" trap (autocaptured, issue #1196)', () => {
-    const out = scrubEvent(exceptionEvent('unreachable'));
-    assert.equal(out?.properties?.error_kind, 'geometry_worker_crash');
+  it('tags a wrapped worker trap but NOT a bare one (issue #1196)', () => {
+    // The worker pool wraps failures, so the attributable form is tagged…
+    const wrapped = scrubEvent(exceptionEvent('Geometry worker error: unreachable'));
+    assert.equal(wrapped?.properties?.error_kind, 'geometry_worker_crash');
+    // …but a bare wasm trap stays untagged (could be any viewer wasm, not just
+    // geometry), so it is neither mislabelled nor suppressed as the family.
+    const bare = scrubEvent(exceptionEvent('unreachable'));
+    assert.equal(bare?.properties?.error_kind, undefined);
   });
 
   it('tags the main-thread RangeError OOM (issue #1215)', () => {
@@ -79,6 +84,22 @@ describe('scrubEvent — noise filter + PII guard (regression)', () => {
     assert.equal(out?.properties?.file_name, undefined);
     assert.equal(out?.properties?.detail, '[redacted]');
     assert.equal(out?.properties?.count, 3);
+  });
+
+  it('strips query + hash from URL auto-properties instead of deleting them', () => {
+    // Regression: `$current_url` matches SENSITIVE_KEY's `url` word, so without
+    // URL_KEYS being checked first it would be deleted outright, losing the
+    // route. We keep the route, drop the query/hash (which can encode a model
+    // id or token).
+    const out = scrubEvent({
+      event: '$pageview',
+      properties: {
+        $current_url: 'https://app.example.com/viewer?model=secret#section',
+        $referrer: 'https://other.com/page?utm_source=x',
+      },
+    } as CaptureEvent);
+    assert.equal(out?.properties?.$current_url, 'https://app.example.com/viewer');
+    assert.equal(out?.properties?.$referrer, 'https://other.com/page');
   });
 
   it('passes a null event through untouched', () => {

--- a/apps/viewer/src/lib/analytics.test.ts
+++ b/apps/viewer/src/lib/analytics.test.ts
@@ -1,0 +1,87 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { scrubEvent } from './analytics-scrub.js';
+
+// `scrubEvent` is the single `before_send` gate every captured event passes
+// through: it drops unactionable third-party noise, tags the geometry
+// error family with a stable `error_kind`, and scrubs PII / confidential
+// model identifiers. These tests pin that contract.
+
+type CaptureEvent = { event?: string; properties?: Record<string, unknown> };
+
+const exceptionEvent = (value: string, extraProps: Record<string, unknown> = {}): CaptureEvent => ({
+  event: '$exception',
+  properties: {
+    $exception_list: [{ type: 'Error', value }],
+    ...extraProps,
+  },
+});
+
+describe('scrubEvent — error_kind tagging', () => {
+  it('tags a raw wasm "unreachable" trap (autocaptured, issue #1196)', () => {
+    const out = scrubEvent(exceptionEvent('unreachable'));
+    assert.equal(out?.properties?.error_kind, 'geometry_worker_crash');
+  });
+
+  it('tags the main-thread RangeError OOM (issue #1215)', () => {
+    const out = scrubEvent(exceptionEvent('Array buffer allocation failed'));
+    assert.equal(out?.properties?.error_kind, 'out_of_memory');
+  });
+
+  it('tags the geometry stream watchdog timeout (issues #1194/#1204)', () => {
+    const out = scrubEvent(exceptionEvent('Geometry stream stalled after 40000ms. Last rendered meshes: 0.'));
+    assert.equal(out?.properties?.error_kind, 'geometry_stream_stalled');
+  });
+
+  it('reads the message from $exception_values when no $exception_list is present', () => {
+    const out = scrubEvent({
+      event: '$exception',
+      properties: { $exception_values: ['Geometry worker failed: undefined'] },
+    } as CaptureEvent);
+    assert.equal(out?.properties?.error_kind, 'geometry_worker_crash');
+  });
+
+  it('does not clobber an error_kind set explicitly at the capture site', () => {
+    const out = scrubEvent(exceptionEvent('unreachable', { error_kind: 'out_of_memory' }));
+    assert.equal(out?.properties?.error_kind, 'out_of_memory');
+  });
+
+  it('leaves non-exception events untagged', () => {
+    const out = scrubEvent({ event: 'ifc_model_loaded', properties: { file_size_mb: 12 } } as CaptureEvent);
+    assert.equal(out?.properties?.error_kind, undefined);
+  });
+});
+
+describe('scrubEvent — noise filter + PII guard (regression)', () => {
+  it('drops the Cesium RequestErrorEvent noise (issue #1175)', () => {
+    const out = scrubEvent({
+      event: '$exception',
+      properties: {
+        $exception_list: [
+          { type: 'Error', value: "'D_' captured as exception with keys: response, responseHeaders, statusCode" },
+        ],
+      },
+    });
+    assert.equal(out, null);
+  });
+
+  it('strips a confidential file name and path from event properties', () => {
+    const out = scrubEvent({
+      event: 'custom',
+      // `file_name` is a sensitive key → deleted; `detail` is not sensitive but
+      // its value is path-ish → redacted; `count` is plain → untouched.
+      properties: { file_name: 'Confidential-Tower.ifc', detail: '/Users/me/Confidential-Tower.ifc', count: 3 },
+    });
+    assert.equal(out?.properties?.file_name, undefined);
+    assert.equal(out?.properties?.detail, '[redacted]');
+    assert.equal(out?.properties?.count, 3);
+  });
+
+  it('passes a null event through untouched', () => {
+    assert.equal(scrubEvent(null), null);
+  });
+});

--- a/apps/viewer/src/lib/analytics.ts
+++ b/apps/viewer/src/lib/analytics.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import posthogClient from 'posthog-js';
+import { scrubEvent } from './analytics-scrub.js';
 
 // `import.meta.env` is undefined under the Node test runner (no Vite define
 // plugin), and this module is loaded transitively by most viewer tests. The
@@ -22,95 +23,6 @@ const enabled = Boolean(key && host) && typeof posthogClient?.init === 'function
 // narrow type is what keeps keyless/Node environments crash-free.
 type AnalyticsClient = Pick<typeof posthogClient, 'capture' | 'captureException'>;
 
-// ── Privacy guard ──────────────────────────────────────────────────────────
-// ifc-lite opens confidential client building models, so the rule that keeps
-// file / pset / property names out of git applies to analytics too: NO event
-// may carry a file name, model name, BCF title, free text, or a filesystem
-// path — even accidentally from a future call site. `scrubEvent` runs on every
-// captured event (including PostHog's own $pageleave / $exception) as a safety
-// net on top of the deliberately lean explicit properties.
-
-// Keys whose values tend to be PII / free text / confidential identifiers.
-// Matches whole `_`-delimited words, so analytics keys like `data_source`,
-// `auto_color_source`, `template_id` or `field` are deliberately left intact.
-const SENSITIVE_KEY =
-  /(?:^|_)(?:name|filename|model|title|label|path|url|uri|href|email|author|comment|description|message|content|query|sql|expression|psetname|propertyname)(?:$|_)/i;
-
-// PostHog auto-properties that are URLs — keep the route, drop query + hash
-// (a share link can encode a model id or token).
-const URL_KEYS = new Set<string>([
-  '$current_url', '$referrer', '$referring_domain', '$pathname',
-  '$initial_current_url', '$initial_referrer', '$initial_referring_domain',
-  '$prev_pageview_pathname',
-]);
-
-// String values that look like a filesystem path or a building-model file name.
-const PATHISH =
-  /[\\/][^\\/]*\.(?:ifc|ifcx|ifczip|bcf|bcfzip|glb|gltf|obj|csv|xlsx|pdf|json|step|stp|las|laz)\b|^(?:file|blob):|^[A-Za-z]:\\|\/Users\/|\/home\//i;
-
-const stripQueryAndHash = (value: string): string => {
-  const cut = value.search(/[?#]/);
-  return cut === -1 ? value : value.slice(0, cut);
-};
-
-const scrubProperties = (props: Record<string, unknown> | undefined): void => {
-  if (!props) return;
-  for (const k of Object.keys(props)) {
-    if (SENSITIVE_KEY.test(k)) {
-      delete props[k];
-      continue;
-    }
-    const v = props[k];
-    if (typeof v === 'string') {
-      if (URL_KEYS.has(k)) props[k] = stripQueryAndHash(v);
-      else if (PATHISH.test(v)) props[k] = '[redacted]';
-    }
-  }
-};
-
-// ── Noise filter ───────────────────────────────────────────────────────────
-// Cesium rejects failed tile / terrain / imagery / ion-asset requests with a
-// `RequestErrorEvent` — a plain `{ statusCode, response, responseHeaders }`
-// object, not an Error. During continuous globe rendering these fire from deep
-// inside Cesium's request scheduler (a tile 403/404/429/timeout), so the geo
-// call sites we own (all `try/catch`-wrapped) can't intercept them, and they
-// surface as unhandled rejections that PostHog's exception autocapture records.
-// They are unactionable third-party network failures, not ifc-lite bugs, so we
-// drop the `$exception` event entirely. Match on Cesium's stable property-name
-// shape (those three keys), NOT the minified class name (`D_`), which changes
-// every build. posthog-js stringifies a non-Error throwable as
-// "'<ctor>' captured as exception with keys: <comma-separated own keys>".
-const CESIUM_REQUEST_ERROR =
-  /captured as exception with keys:(?=[^]*\bstatusCode\b)(?=[^]*\bresponse\b)(?=[^]*\bresponseHeaders\b)/;
-
-const isUnactionableThirdPartyException = (
-  event: { event?: string; properties?: Record<string, unknown> },
-): boolean => {
-  if (event.event !== '$exception') return false;
-  const list = event.properties?.$exception_list;
-  if (!Array.isArray(list)) return false;
-  return list.some(
-    (e) =>
-      typeof (e as { value?: unknown })?.value === 'string' &&
-      CESIUM_REQUEST_ERROR.test((e as { value: string }).value),
-  );
-};
-
-// `before_send` shape: (event | null) => (event | null). Returning null drops
-// the event (noise filter above); otherwise we mutate properties in place,
-// which keeps PostHog's event intact. Generic so it satisfies posthog-js's
-// BeforeSendFn (CaptureResult) signature.
-const scrubEvent = <
-  T extends { event?: string; properties?: Record<string, unknown> } | null,
->(
-  event: T,
-): T | null => {
-  if (!event) return event;
-  if (isUnactionableThirdPartyException(event)) return null;
-  scrubProperties(event.properties);
-  return event;
-};
-
 let client: AnalyticsClient | null = null;
 if (enabled) {
   try {
@@ -124,7 +36,9 @@ if (enabled) {
       capture_pageleave: true,
       autocapture: false,
       // Strip any file name / model name / path / free text from every event
-      // (current + future) before it leaves the browser. See scrubEvent above.
+      // (current + future) before it leaves the browser, drop unactionable
+      // third-party noise, and tag the geometry error family. See scrubEvent
+      // in ./analytics-scrub.ts.
       before_send: scrubEvent,
     });
     client = posthogClient;

--- a/apps/viewer/src/lib/load-errors.test.ts
+++ b/apps/viewer/src/lib/load-errors.test.ts
@@ -32,6 +32,50 @@ describe('classifyLoadError', () => {
     assert.equal(classifyLoadError(new Error('Cannot enlarge memory arrays')), 'out_of_memory');
   });
 
+  it('classifies the main-thread RangeError OOM (issue #1215)', () => {
+    // The exact message captured in PostHog issue 019edcc2 (Chrome/Windows).
+    assert.equal(classifyLoadError(new RangeError('Array buffer allocation failed')), 'out_of_memory');
+  });
+
+  it('classifies a hard geometry-worker crash (issue #1203)', () => {
+    // worker.onerror with an empty ErrorEvent used to read "undefined"; it now
+    // synthesises a message, and either form must bucket as a worker crash.
+    assert.equal(classifyLoadError(new Error('Geometry worker failed: undefined')), 'geometry_worker_crash');
+    assert.equal(
+      classifyLoadError(new Error('Geometry worker failed: worker terminated unexpectedly')),
+      'geometry_worker_crash',
+    );
+  });
+
+  it('classifies a wasm runtime trap surfaced through the worker (issue #1196)', () => {
+    // The exact message captured in PostHog issue 019eda71.
+    assert.equal(classifyLoadError(new Error('unreachable')), 'geometry_worker_crash');
+    assert.equal(classifyLoadError(new Error('Geometry worker error: unreachable')), 'geometry_worker_crash');
+  });
+
+  it('prefers out_of_memory over worker_crash when the worker died with a clear OOM', () => {
+    assert.equal(
+      classifyLoadError(new Error('Geometry worker error: Cannot enlarge memory arrays')),
+      'out_of_memory',
+    );
+  });
+
+  it('classifies the geometry stream watchdog timeout (issues #1194/#1204)', () => {
+    assert.equal(
+      classifyLoadError(new Error('Geometry stream stalled after 40000ms. Last rendered meshes: 0.')),
+      'geometry_stream_stalled',
+    );
+  });
+
+  it('does not depend on a file name in the stall message (privacy)', () => {
+    // The watchdog Error must never carry the model name; classification keys
+    // only on the stable prefix.
+    assert.equal(
+      classifyLoadError(new Error('Geometry stream stalled after 90000ms. Last rendered meshes: 3473.')),
+      'geometry_stream_stalled',
+    );
+  });
+
   it('classifies cancellation', () => {
     assert.equal(classifyLoadError(new Error('The operation was aborted')), 'cancelled');
     assert.equal(classifyLoadError('cancelled'), 'cancelled');
@@ -57,6 +101,22 @@ describe('formatLoadError', () => {
     assert.match(msg, /reload/i);
     // The cryptic raw message must NOT leak to the user for known failures.
     assert.doesNotMatch(msg, /HTTP status code is not ok/);
+  });
+
+  it('gives actionable memory guidance for a worker crash without leaking the raw message', () => {
+    const msg = formatLoadError(new Error('Geometry worker failed: undefined'), 'tower.ifc');
+    assert.match(msg, /"tower\.ifc"/);
+    assert.match(msg, /memory/i);
+    assert.doesNotMatch(msg, /undefined/);
+  });
+
+  it('gives actionable guidance for a stream stall and re-attaches the file name for the user', () => {
+    const msg = formatLoadError(
+      new Error('Geometry stream stalled after 40000ms. Last rendered meshes: 0.'),
+      'tower.ifc',
+    );
+    assert.match(msg, /"tower\.ifc"/);
+    assert.match(msg, /stalled/i);
   });
 
   it('preserves the raw message for unknown failures', () => {

--- a/apps/viewer/src/lib/load-errors.test.ts
+++ b/apps/viewer/src/lib/load-errors.test.ts
@@ -47,10 +47,15 @@ describe('classifyLoadError', () => {
     );
   });
 
-  it('classifies a wasm runtime trap surfaced through the worker (issue #1196)', () => {
-    // The exact message captured in PostHog issue 019eda71.
-    assert.equal(classifyLoadError(new Error('unreachable')), 'geometry_worker_crash');
+  it('classifies a wasm trap only when the worker marker is present (issue #1196)', () => {
+    // The worker pool wraps its failures, so a real geometry trap arrives with
+    // the "Geometry worker error:" prefix and is attributable.
     assert.equal(classifyLoadError(new Error('Geometry worker error: unreachable')), 'geometry_worker_crash');
+    // A BARE wasm trap is NOT attributed to geometry — other viewer wasm
+    // (space-plate, parquet) can trap too, so it stays unknown and surfaces on
+    // its own instead of being mis-bucketed/suppressed as the geometry family.
+    assert.equal(classifyLoadError(new Error('unreachable')), 'unknown');
+    assert.equal(classifyLoadError(new Error('RuntimeError: unreachable executed')), 'unknown');
   });
 
   it('prefers out_of_memory over worker_crash when the worker died with a clear OOM', () => {

--- a/apps/viewer/src/lib/load-errors.ts
+++ b/apps/viewer/src/lib/load-errors.ts
@@ -22,6 +22,21 @@ export type LoadErrorKind =
   | 'wasm_engine_load'
   /** Out-of-memory / WASM heap exhaustion during processing. */
   | 'out_of_memory'
+  /**
+   * A geometry worker (or the wasm mesher running in it) stopped unexpectedly
+   * — a hard worker crash (`worker.onerror`, no message) or a wasm runtime
+   * trap (`unreachable`, `RuntimeError`) surfaced during processing. On heavy
+   * models this is almost always memory pressure that didn't reach the JS heap
+   * as a clean OOM, so it is grouped separately from `out_of_memory` only for
+   * triage — the user guidance is the same.
+   */
+  | 'geometry_worker_crash'
+  /**
+   * The geometry stream watchdog fired: no batch arrived within the grace
+   * window. A derived symptom — usually downstream of a worker crash/OOM, or a
+   * genuinely too-large/complex model that never streams on this device.
+   */
+  | 'geometry_stream_stalled'
   /** The user (or a superseding load) cancelled the operation. */
   | 'cancelled'
   /** Anything else. */
@@ -59,6 +74,31 @@ function isOutOfMemoryError(message: string): boolean {
   );
 }
 
+/**
+ * The geometry stream watchdog timed out (see `useIfcLoader`'s `Promise.race`).
+ * Matched on the stable prefix only — the message must NOT carry the file name
+ * (it would leak a confidential model name into error tracking), so we never
+ * rely on anything past "stalled".
+ */
+function isStreamStalledError(message: string): boolean {
+  return /geometry stream stalled/i.test(message);
+}
+
+/**
+ * A geometry worker died or the wasm mesher trapped during processing. Covers:
+ *  - `worker.onerror` wrapped as "Geometry worker failed: …" (an empty
+ *    `ErrorEvent` from a hard crash — classic OOM kill of the worker thread),
+ *  - "Geometry worker error: …" (the worker posted a `{type:'error'}` message),
+ *  - a raw wasm runtime trap (`unreachable`, `RuntimeError`) that escaped as an
+ *    uncaught exception in the worker-message handler.
+ */
+function isGeometryWorkerCrashError(message: string): boolean {
+  return (
+    /geometry worker (?:failed|error|crashed|terminated)/i.test(message) ||
+    /\bunreachable\b|runtimeerror|wasm trap|trap: |rust_begin_unwind/i.test(message)
+  );
+}
+
 function isCancelledError(message: string): boolean {
   return /\bcancel(?:led|ed)?\b|aborterror|the operation was aborted/i.test(message);
 }
@@ -67,7 +107,11 @@ function isCancelledError(message: string): boolean {
 export function classifyLoadError(err: unknown): LoadErrorKind {
   const message = messageOf(err);
   if (isWasmEngineLoadError(message)) return 'wasm_engine_load';
+  // Explicit memory-exhaustion signals win over the worker-crash bucket so a
+  // worker that died with a clear OOM message is grouped as out_of_memory.
   if (isOutOfMemoryError(message)) return 'out_of_memory';
+  if (isStreamStalledError(message)) return 'geometry_stream_stalled';
+  if (isGeometryWorkerCrashError(message)) return 'geometry_worker_crash';
   if (isCancelledError(message)) return 'cancelled';
   return 'unknown';
 }
@@ -92,6 +136,18 @@ export function formatLoadError(err: unknown, fileName?: string): string {
     case 'out_of_memory':
       return (
         `Ran out of memory while processing ${subject}. ` +
+        `Try closing other tabs, or load fewer/smaller models at once.`
+      );
+    case 'geometry_worker_crash':
+      return (
+        `A geometry worker stopped unexpectedly while processing ${subject}. ` +
+        `This usually means the model is too large for this device's available memory. ` +
+        `Try closing other tabs, or load fewer/smaller models at once.`
+      );
+    case 'geometry_stream_stalled':
+      return (
+        `Processing ${subject} stalled and was stopped. ` +
+        `The model may be too large or complex for this device. ` +
         `Try closing other tabs, or load fewer/smaller models at once.`
       );
     case 'cancelled':

--- a/apps/viewer/src/lib/load-errors.ts
+++ b/apps/viewer/src/lib/load-errors.ts
@@ -85,18 +85,23 @@ function isStreamStalledError(message: string): boolean {
 }
 
 /**
- * A geometry worker died or the wasm mesher trapped during processing. Covers:
+ * A geometry worker explicitly reported a failure. Covers the messages the
+ * worker pool produces:
  *  - `worker.onerror` wrapped as "Geometry worker failed: …" (an empty
  *    `ErrorEvent` from a hard crash — classic OOM kill of the worker thread),
- *  - "Geometry worker error: …" (the worker posted a `{type:'error'}` message),
- *  - a raw wasm runtime trap (`unreachable`, `RuntimeError`) that escaped as an
- *    uncaught exception in the worker-message handler.
+ *  - "Geometry worker error: …" (the worker posted a `{type:'error'}` message,
+ *    e.g. "Geometry worker error: unreachable").
+ *
+ * Deliberately keyed on the "geometry worker" marker only. A *bare* wasm trap
+ * (`unreachable`, `RuntimeError`) is NOT attributed here: the viewer runs other
+ * wasm (space-plate, parquet) whose traps would otherwise be mis-bucketed as the
+ * geometry family and wrongly suppressed. Those stay `unknown` and surface on
+ * their own. (The worker pool always wraps its failures with the marker, so a
+ * genuine geometry-worker trap still lands here via the "Geometry worker …"
+ * prefix.)
  */
 function isGeometryWorkerCrashError(message: string): boolean {
-  return (
-    /geometry worker (?:failed|error|crashed|terminated)/i.test(message) ||
-    /\bunreachable\b|runtimeerror|wasm trap|trap: |rust_begin_unwind/i.test(message)
-  );
+  return /geometry worker (?:failed|error|crashed|terminated)/i.test(message);
 }
 
 function isCancelledError(message: string): boolean {

--- a/packages/geometry/src/geometry-parallel.ts
+++ b/packages/geometry/src/geometry-parallel.ts
@@ -382,7 +382,17 @@ export async function* processParallel(
       }
     };
     worker.onerror = (err) => {
-      workerError = new Error(`Geometry worker failed: ${err.message}`);
+      // A hard worker crash (e.g. the wasm thread aborting under memory
+      // pressure) fires an ErrorEvent with an empty `message`. Emitting the
+      // literal "undefined" produced a cryptic, unclassifiable error in tracking
+      // ("Geometry worker failed: undefined"). Synthesise a meaningful message
+      // from whatever the ErrorEvent carries, defaulting to the most common
+      // cause so the error classifier can bucket it.
+      const detail =
+        (err?.message && String(err.message)) ||
+        (err?.filename ? `at ${err.filename}:${err.lineno ?? 0}` : '') ||
+        'worker terminated unexpectedly';
+      workerError = new Error(`Geometry worker failed: ${detail}`);
       workersCompleted++;
       worker.terminate();
       wake();


### PR DESCRIPTION
## What

The auto-filed PostHog → GitHub error issues #1194, #1196, #1203, #1204 and #1215 are **one family** — resource exhaustion on large models — not distinct bugs:

| Issue | Surface | Root |
|---|---|---|
| #1196 `unreachable` | wasm trap during meshing, autocaptured raw | OOM/abort |
| #1203 `Geometry worker failed: undefined` | `worker.onerror` with an empty `ErrorEvent` | worker hard-crash |
| #1194 / #1204 `Geometry stream stalled` | the 40s watchdog (0/N meshes) | downstream of the above |
| #1215 `RangeError: Array buffer allocation failed` | main-thread allocation | OOM |

PR #1190 only hardened the wasm **engine-load** path (init download/compile + retry) and an OOM classifier, so these **runtime** paths kept recurring after it (e.g. #1196 fired ~3.5h after #1190 merged).

## Changes

- **`packages/geometry/src/geometry-parallel.ts`** — `worker.onerror` synthesises a meaningful message from the `ErrorEvent` instead of `"Geometry worker failed: undefined"` (a hard crash fires an empty event), so the failure is human-readable and classifiable.
- **`apps/viewer/src/hooks/useIfcLoader.ts`** — the stream-watchdog `Error` **no longer embeds the model file name**. It was captured into error tracking and auto-filed into a **public** GitHub issue (a confidential-name leak only partly caught by the `redactPii` Hog guard). The name is re-attached for the user only, via `formatLoadError(err, file.name)`.
- **`apps/viewer/src/lib/load-errors.ts`** — `LoadErrorKind` gains `geometry_worker_crash` + `geometry_stream_stalled`; classifies `unreachable`, worker crashes, stalls, and the main-thread `RangeError`, each with actionable user guidance.
- **`apps/viewer/src/lib/analytics-scrub.ts`** (new) — the `before_send` guard is extracted out of `analytics.ts` (dependency-free, so it's unit-testable without the browser SDK) and now stamps a stable top-level `error_kind` on every `$exception` — including raw autocaptured ones — so the whole family is filterable/groupable.
- Tests: the load-error taxonomy (the exact captured strings from each issue) and the `before_send` scrub/tag/PII contract (previously untested).

## Follow-up (telemetry, applied separately)
A filter on the "GitHub issue on issue created" Hog destination to stop auto-filing this family as public issues (keeps full PostHog data). This PR makes the family classifiable; the destination filter is the noise switch.

## Verification
- `tsx --test` load-errors + analytics-scrub: 27/27 pass.
- `tsc --noEmit` clean for all touched files (remaining errors are unbuilt-workspace noise in a fresh worktree).
- Changeset added for `@ifc-lite/geometry`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved load-error classification to distinguish geometry worker crashes and stream stalls from other failures.
  * Enhanced error messages for geometry-related failures with clearer user guidance.

* **Bug Fixes**
  * Improved crash error reporting with synthesized details when worker messages are empty.
  * Enhanced analytics privacy by scrubbing sensitive data and PII from events.
  * Better error message formatting to prevent leaking internal file paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->