### PR TITLE
fix(renderer): colour overlays (lens/IDS/compare/4D) silently failed to paint

### DIFF
--- a/.changeset/fix-overlay-coloring-zhash.md
+++ b/.changeset/fix-overlay-coloring-zhash.md
@@ -1,0 +1,19 @@
+---
+"@ifc-lite/renderer": patch
+---
+
+Fix lens/IDS/compare/4D colour overlays silently failing to paint. The
+anti-z-fight depth nudge in the vertex shader folded the per-draw `baseColor`
+into its hash, so the colour-override overlay (drawn over the base geometry
+with `depthCompare: 'equal'`) computed a different nudged depth than the base
+pass — material colour vs. override colour — and every overlay fragment was
+rejected. Symptom: the lens panel reported "N coloured" but the 3D model stayed
+its default colour.
+
+The depth nudge now reads an 8-bit material-colour salt baked into the high 8
+bits of the per-vertex entity-id lane (low 24 bits remain the picking id, which
+`encodeId24` masks the salt off of), instead of the draw-time `baseColor`. The
+base and overlay passes therefore compute an identical nudge — so the overlay's
+`equal` depth test matches and colour paints — while distinct material layers
+still receive distinct depths, preserving the coplanar-layer separation. Picking
+is unaffected.

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -114,6 +114,7 @@ import { SkyPass } from './sky-pass.js';
 import { skyShaderSource } from './shaders/sky.wgsl.js';
 import { resolveEnvironment } from './environment.js';
 import { shouldRouteMeshTransparent, shouldRouteBatchTransparent, splitVisibleIdsByPromotion } from './overlay-routing.js';
+import { colorSaltByte, packEntityLane } from './scene-geometry.js';
 import { PointCloudRenderer } from './pointcloud/point-cloud-renderer.js';
 import type { PointCloudAsset } from '@ifc-lite/geometry';
 import { DeviationPipeline } from './deviation/deviation-pipeline.js';
@@ -895,7 +896,12 @@ export class Renderer {
                 }
                 encodedId = encodedId & MAX_ENCODED_ENTITY_ID;
             }
-            interleavedU32[base + 6] = encodedId;
+            // Stamp the SAME high-byte material-colour salt as the batch path
+            // (mergeGeometry) so this individual/selection mesh computes the
+            // identical depth nudge as its source batch — otherwise the highlight
+            // (selection pipeline, reverse-Z 'greater-equal') would z-fight or drop
+            // out against the salted base depth. Low 24 bits stay the picking id.
+            interleavedU32[base + 6] = packEntityLane(encodedId, colorSaltByte(meshData.color));
         }
 
         const vertexBuffer = device.createBuffer({

--- a/packages/renderer/src/scene-geometry.test.ts
+++ b/packages/renderer/src/scene-geometry.test.ts
@@ -1,0 +1,130 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { colorSaltByte, packEntityLane } from './scene-geometry.ts';
+
+/**
+ * Mirror the WGSL depth-nudge hash from `main.wgsl.ts` (`vs_main`) so the test
+ * pins the actual cross-pass contract: the nudge depends ONLY on the packed
+ * entity-id lane, so the base opaque pass and the colour-override OVERLAY pass
+ * (which redraw the same geometry in a different draw colour) must produce the
+ * SAME nudge for the overlay's `depthCompare: 'equal'` to match.
+ *
+ * u32 multiply wraps mod 2^32; `Math.imul(a, b) >>> 0` reproduces that exactly.
+ */
+function shaderZHash(lane: number): number {
+  const colorSalt = Math.imul(lane >>> 24, 2654435761) >>> 0;
+  const mixed = ((lane & 0x00ffffff) ^ colorSalt) >>> 0;
+  return (Math.imul(mixed, 2654435761) >>> 0) & 255;
+}
+
+describe('colorSaltByte', () => {
+  it('returns 0 for null / undefined colour', () => {
+    assert.strictEqual(colorSaltByte(null), 0);
+    assert.strictEqual(colorSaltByte(undefined), 0);
+  });
+
+  it('is deterministic for the same colour', () => {
+    const c: [number, number, number, number] = [0.2, 0.4, 0.6, 1];
+    assert.strictEqual(colorSaltByte(c), colorSaltByte([...c]));
+  });
+
+  it('always returns a byte in [0, 255]', () => {
+    for (const c of [
+      [0, 0, 0, 1],
+      [1, 1, 1, 1],
+      [0.5, 0.5, 0.5, 1],
+      [0.999, 0.001, 0.499, 1],
+      [1, 0, 0, 0.15], // ghost alpha — must not affect the salt
+    ] as [number, number, number, number][]) {
+      const s = colorSaltByte(c);
+      assert.ok(Number.isInteger(s) && s >= 0 && s <= 255, `salt out of range: ${s}`);
+    }
+  });
+
+  it('ignores the alpha channel', () => {
+    assert.strictEqual(colorSaltByte([0.3, 0.6, 0.9, 1]), colorSaltByte([0.3, 0.6, 0.9, 0.15]));
+  });
+
+  it('separates the common material colours seen in practice', () => {
+    // A small palette of distinct materials should map to distinct salts so
+    // coincident coplanar layers get distinct depth nudges.
+    const palette: [number, number, number, number][] = [
+      [0.8, 0.8, 0.8, 1], // concrete grey
+      [0.86, 0.65, 0.4, 1], // brick
+      [0.6, 0.6, 0.6, 1], // steel
+      [0.2, 0.4, 0.7, 1], // glass-ish
+      [0.95, 0.95, 0.9, 1], // plaster
+    ];
+    const salts = new Set(palette.map(colorSaltByte));
+    assert.strictEqual(salts.size, palette.length, 'expected distinct salts for distinct materials');
+  });
+});
+
+describe('packEntityLane', () => {
+  it('preserves the picking id in the low 24 bits (encodeId24 contract)', () => {
+    for (const id of [0, 1, 101, 43810, 1_664_394, 0x00ffffff]) {
+      for (const salt of [0, 1, 127, 255]) {
+        assert.strictEqual(packEntityLane(id, salt) & 0x00ffffff, id, `id ${id} salt ${salt}`);
+      }
+    }
+  });
+
+  it('places the salt in the high 8 bits', () => {
+    for (const salt of [0, 1, 73, 200, 255]) {
+      assert.strictEqual(packEntityLane(12345, salt) >>> 24, salt);
+    }
+  });
+
+  it('masks ids beyond 24 bits down to the low 24 (matches pre-existing picking limit)', () => {
+    const big = 0x01_234567; // > 2^24
+    assert.strictEqual(packEntityLane(big, 99) & 0x00ffffff, big & 0x00ffffff);
+  });
+
+  it('returns an unsigned 32-bit value even when the high bit is set', () => {
+    const lane = packEntityLane(0x00ffffff, 255); // 0xFFFFFFFF
+    assert.ok(lane >= 0 && lane <= 0xffffffff);
+    assert.strictEqual(lane >>> 0, lane);
+  });
+
+  it('only the salt byte clamps in — saltByte values above 255 are masked', () => {
+    assert.strictEqual(packEntityLane(7, 0x1ff) >>> 24, 0xff);
+  });
+});
+
+describe('depth-nudge cross-pass contract (the lens/overlay fix)', () => {
+  it('base and overlay passes compute the SAME nudge for one mesh', () => {
+    // The base batch and the override OVERLAY batch are both built from the same
+    // MeshData (same expressId, same MeshData.color), so they stamp the same
+    // lane and MUST hash to the same nudge — regardless of the draw-time colour.
+    const expressId = 43810;
+    const meshColor: [number, number, number, number] = [0.86, 0.65, 0.4, 1];
+    const baseLane = packEntityLane(expressId, colorSaltByte(meshColor));
+    const overlayLane = packEntityLane(expressId, colorSaltByte(meshColor));
+    assert.strictEqual(baseLane, overlayLane);
+    assert.strictEqual(shaderZHash(baseLane), shaderZHash(overlayLane));
+  });
+
+  it('separates two material layers that share a parent expressId', () => {
+    // Material-layer slices share the PARENT id; distinct material colours must
+    // still yield distinct nudges so their coincident caps do not z-fight.
+    const parentId = 52001;
+    const layerA: [number, number, number, number] = [0.8, 0.8, 0.8, 1];
+    const layerB: [number, number, number, number] = [0.86, 0.65, 0.4, 1];
+    const laneA = packEntityLane(parentId, colorSaltByte(layerA));
+    const laneB = packEntityLane(parentId, colorSaltByte(layerB));
+    assert.notStrictEqual(laneA, laneB);
+    assert.notStrictEqual(shaderZHash(laneA), shaderZHash(laneB));
+  });
+
+  it('nudge does NOT depend on the draw colour (only the baked lane)', () => {
+    // Two different draw colours over the same lane => identical nudge. This is
+    // the property that was broken when the salt came from `uniforms.baseColor`.
+    const lane = packEntityLane(123, colorSaltByte([0.5, 0.2, 0.1, 1]));
+    assert.strictEqual(shaderZHash(lane), shaderZHash(lane));
+  });
+});

--- a/packages/renderer/src/scene-geometry.ts
+++ b/packages/renderer/src/scene-geometry.ts
@@ -16,6 +16,40 @@ const MAX_ENCODED_ENTITY_ID = 0xFFFFFF;
 let warnedEntityIdRange = false;
 
 /**
+ * Per-vertex z-nudge salt (issue: lens/overlay colouring).
+ *
+ * The anti-z-fight depth nudge in `main.wgsl.ts` must produce the SAME depth for
+ * a given surface in BOTH the base opaque pass and the lens/IDS/compare/4D
+ * OVERLAY pass (the overlay pipeline uses `depthCompare: 'equal'`, so any depth
+ * difference rejects every overlay fragment — colour silently fails to paint).
+ *
+ * Material-layer slices share their parent's expressId, so the nudge can't
+ * separate their coincident coplanar caps from the id alone — it needs the
+ * material colour. We bake an 8-bit hash of `MeshData.color` into the HIGH 8
+ * bits of the per-vertex entityId lane (the low 24 bits stay the picking id;
+ * `encodeId24` masks the salt off). Because the salt comes from the geometry's
+ * OWN colour — not the per-draw `baseColor` uniform — the base and overlay
+ * passes compute an identical nudge, while distinct layers still separate.
+ *
+ * Returns a byte in [0,255]. Stamp it as `(id & 0x00FFFFFF) | (salt << 24)`.
+ */
+export function colorSaltByte(color?: readonly number[] | null): number {
+  if (!color) return 0;
+  const r = (Math.round((color[0] ?? 0) * 255) & 0xFF) >>> 0;
+  const g = (Math.round((color[1] ?? 0) * 255) & 0xFF) >>> 0;
+  const b = (Math.round((color[2] ?? 0) * 255) & 0xFF) >>> 0;
+  // Same Knuth-style mix #1160 used (folded to 8 bits — the zHash is `& 255`
+  // anyway, so a byte carries all the entropy that survives downstream).
+  const h = (Math.imul(r, 73856093) ^ Math.imul(g, 19349663) ^ Math.imul(b, 83492791)) >>> 0;
+  return h & 0xFF;
+}
+
+/** Stamp the colour salt into the high 8 bits, picking id into the low 24. */
+export function packEntityLane(rawId: number, saltByte: number): number {
+  return (((rawId >>> 0) & 0x00FFFFFF) | ((saltByte & 0xFF) << 24)) >>> 0;
+}
+
+/**
  * Merge multiple mesh geometries into single interleaved vertex/index buffers.
  *
  * Layout per vertex: position (3f) + normal (3f) + entityId (1u32) = 7 × 4 bytes.
@@ -105,6 +139,10 @@ export function mergeGeometry(
       }
       entityId = entityId & MAX_ENCODED_ENTITY_ID;
     }
+    // High-8-bit material-colour salt → identical nudge in base & overlay passes
+    // (so the lens/IDS/compare/4D overlay's depthCompare:'equal' matches). See
+    // colorSaltByte() above.
+    const saltByte = colorSaltByte(mesh.color);
     const hasNormals = normals.length > 0;
     for (let i = 0; i < vertexCount; i++) {
       const srcIdx = i * 3;
@@ -114,7 +152,7 @@ export function mergeGeometry(
       vertexData[outIdx++] = hasNormals ? normals[srcIdx] : 0;
       vertexData[outIdx++] = hasNormals ? normals[srcIdx + 1] : 0;
       vertexData[outIdx++] = hasNormals ? normals[srcIdx + 2] : 0;
-      vertexDataU32[outIdx++] = perVertexEntityIds ? (perVertexEntityIds[i] >>> 0) : entityId;
+      vertexDataU32[outIdx++] = packEntityLane(perVertexEntityIds ? perVertexEntityIds[i] : entityId, saltByte);
     }
 
     // Copy indices with vertex base offset

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -17,7 +17,7 @@ import {
   raycastBoundingBoxes,
   raycastTriangles,
 } from './scene-raycaster.js';
-import { mergeGeometry, splitMeshDataForBufferLimit } from './scene-geometry.js';
+import { mergeGeometry, splitMeshDataForBufferLimit, colorSaltByte, packEntityLane } from './scene-geometry.js';
 
 /** Consolidated per-bucket state — replaces six separate tracking maps. */
 interface BatchBucket {
@@ -1782,6 +1782,10 @@ export class Scene {
     const f = new Float32Array(interleaved);
     const u = new Uint32Array(interleaved);
     const entityIds = meshData.entityIds;
+    // Match mergeGeometry's entityId-lane packing so an overlay (lens/IDS/...)
+    // drawn over a textured mesh computes the same z-nudge → depthCompare:'equal'
+    // matches. High 8 bits = colour salt, low 24 = picking id.
+    const saltByte = colorSaltByte(meshData.color);
     for (let i = 0; i < vertexCount; i++) {
       const o = i * 9;
       f[o] = positions[i * 3];
@@ -1790,7 +1794,7 @@ export class Scene {
       f[o + 3] = normals[i * 3] ?? 0;
       f[o + 4] = normals[i * 3 + 1] ?? 0;
       f[o + 5] = normals[i * 3 + 2] ?? 0;
-      u[o + 6] = entityIds ? entityIds[i] : meshData.expressId;
+      u[o + 6] = packEntityLane(entityIds ? entityIds[i] : meshData.expressId, saltByte);
       f[o + 7] = uvs[i * 2] ?? 0;
       f[o + 8] = uvs[i * 2 + 1] ?? 0;
     }

--- a/packages/renderer/src/shaders/main.wgsl.ts
+++ b/packages/renderer/src/shaders/main.wgsl.ts
@@ -60,19 +60,21 @@ export const mainShaderSource = `
           // Anti z-fighting: deterministic depth nudge.
           // Knuth multiplicative hash spreads sequential IDs across 0-255 so
           // coplanar faces from different entities always get distinct depths.
-          // We also fold in the per-draw baseColor: a material-layer wall slices
-          // into one closed solid per layer, all sharing the PARENT wall's
-          // expressId, so adjacent layers' coincident interface caps would get
-          // the same entity nudge and z-fight into a flickering comb (you appear
-          // to "see inside" the wall). Batches are keyed by colour, so baseColor
-          // is constant per draw and distinct per layer — XOR-ing it in pushes
-          // abutting layers onto different depths. Constant per draw, so flat
-          // faces stay flat and curved surfaces are unaffected. At 1e-6 per step
-          // the max world-space offset is <3mm at 10m — invisible.
-          let colorSalt = (u32(uniforms.baseColor.r * 255.0) * 73856093u)
-                        ^ (u32(uniforms.baseColor.g * 255.0) * 19349663u)
-                        ^ (u32(uniforms.baseColor.b * 255.0) * 83492791u);
-          let zHash = ((input.entityId ^ colorSalt) * 2654435761u) & 255u;
+          // Material-layer walls slice into one closed solid per layer, all
+          // sharing the PARENT wall's expressId, so adjacent layers' coincident
+          // interface caps would get the same entity nudge and z-fight into a
+          // flickering comb ("see inside the wall"). To separate them we fold in
+          // an 8-bit MATERIAL-COLOUR salt that mergeGeometry/interleaveTextured
+          // baked into the HIGH 8 bits of the entityId lane (low 24 = picking id,
+          // masked off by encodeId24). Crucially the salt comes from the mesh's
+          // OWN colour, NOT the per-draw baseColor uniform — so the base opaque
+          // pass and the lens/IDS/compare/4D OVERLAY pass (which redraws the same
+          // geometry with a DIFFERENT draw colour) compute the SAME nudge, and
+          // the overlay pipeline's depthCompare:'equal' matches instead of
+          // rejecting every fragment. At 1e-6 per step the max world-space offset
+          // is <3mm at 10m — invisible.
+          let colorSalt = (input.entityId >> 24u) * 2654435761u;
+          let zHash = (((input.entityId & 0x00FFFFFFu) ^ colorSalt) * 2654435761u) & 255u;
           output.position.z *= 1.0 + f32(zHash) * 1e-6;
           output.worldPos = worldPos.xyz;
           output.normal = normalize((uniforms.model * vec4<f32>(input.normal, 0.0)).xyz);


### PR DESCRIPTION
## Problem

Lens / IDS-validation / compare / schedule-4D colour overlays silently stopped painting on `main`. The lens panel reports "N coloured" but the 3D model keeps its default material colours (and ghosting is dead too).

## Root cause

PR #1160's anti-z-fight depth nudge in `main.wgsl.ts` folded the **per-draw `baseColor`** into its hash:

```wgsl
let colorSalt = hash(uniforms.baseColor.rgb);
let zHash = ((input.entityId ^ colorSalt) * K) & 255u;
output.position.z *= 1.0 + f32(zHash) * 1e-6;
```

Colour overrides are drawn as **overlay batches over the base geometry** with the overlay pipeline's `depthCompare: 'equal'` (paints only where the base wrote the exact same depth). The base pass draws each entity in its **material** colour; the overlay redraws the *same geometry* in the **override** colour → different `colorSalt` → different nudged `position.z` → the depths never bit-match → every overlay fragment is rejected → nothing paints. The mismatch is colour-dependent and systematic (proven: flipping the overlay to `depthCompare: 'always'` paints everything; base vs. overlay batch origins are bit-identical, ruling out a geometry/origin cause).

This affects **every** consumer of the colour-override channel: lens (auto-color + rules), IDS validation colouring, compare overlay, schedule/4D (`useOverlayCompositor`), and the SDK adapter.

## Fix

Make the nudge **draw-colour-independent** by baking an 8-bit `colorSaltByte(MeshData.color)` into the **high 8 bits** of the per-vertex entity-id lane (low 24 bits stay the picking id; `encodeId24` masks the salt off). The shader hashes the baked salt instead of `baseColor`:

```wgsl
let colorSalt = (input.entityId >> 24u) * K;
let zHash = (((input.entityId & 0x00FFFFFFu) ^ colorSalt) * K) & 255u;
```

Because the salt comes from the mesh's own colour, the base and overlay passes compute an **identical** nudge — so `equal` matches — while distinct material layers still get distinct depths, **preserving #1160's coplanar-layer separation** ("see inside the wall" comb stays fixed). Stamped in both `mergeGeometry` and `interleaveTexturedVertices`. (Note: `(lane*K)&255` ignores the high byte, so the salt is XOR-mixed into the low bits, not merely packed.)

## Verification

Reproduced and verified in the browser on a georeferenced building (`ISSUE_068`), with the proper `depthCompare: 'equal'`:

- ✅ Lens paints, crisp, **no z-fight comb** up close
- ✅ Raw `setPendingColorUpdates` channel paints (IDS / compare / schedule-4D / SDK)
- ✅ Selection highlight solid; base material colours intact
- ✅ Picking unaffected (low-24 id preserved; `encodeId24` masks the salt)
- ✅ 110/110 renderer unit tests pass

Picking note: ids in practice are ≪ 2²⁴, so the high-byte salt never collides with the picking id; models with expressId ≥ 2²⁴ already had truncated picking before this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved silent rendering failures that prevented color overlays from displaying in lens visualizations, IDS mode, comparison tools, and 4D rendering. Overlays now render consistently and correctly across all rendering passes, materials, and layer configurations. This restoration ensures visual accuracy without affecting selection, picking, or other core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->