### PR TITLE
fix(viewer): readable tooltip text on bSDD/property cards (#1218)

### DIFF
--- a/apps/viewer/src/components/viewer/properties/BsddCard.tsx
+++ b/apps/viewer/src/components/viewer/properties/BsddCard.tsx
@@ -519,9 +519,13 @@ export function BsddCard({
                           </span>
                         </TooltipTrigger>
                         <TooltipContent side="top" className="max-w-xs text-[10px]">
+                          {/* Tooltip surface is bg-primary, so secondary lines must
+                              derive from primary-foreground (opacity tiers) — hardcoded
+                              zinc/sky washed out on the blue/purple bg and inverted in
+                              dark mode where the foreground flips dark (issue #1218). */}
                           <p className="font-medium">{prop.name}</p>
-                          {prop.description && <p className="mt-0.5 text-zinc-400">{prop.description}</p>}
-                          {prop.dataType && <p className="mt-0.5 text-sky-400">{bsddDataTypeLabel(prop.dataType)}</p>}
+                          {prop.description && <p className="mt-0.5 text-primary-foreground/80">{prop.description}</p>}
+                          {prop.dataType && <p className="mt-0.5 text-primary-foreground/70">{bsddDataTypeLabel(prop.dataType)}</p>}
                         </TooltipContent>
                       </Tooltip>
                       {/* Add button - always visible on right. The property is

--- a/apps/viewer/src/components/viewer/properties/PropertySetCard.tsx
+++ b/apps/viewer/src/components/viewer/properties/PropertySetCard.tsx
@@ -136,7 +136,9 @@ export function PropertySetCard({ pset, modelId, entityId, enableEditing, isType
                           </span>
                         </TooltipTrigger>
                         <TooltipContent side="top" className="text-[10px]">
-                          <span className="text-zinc-400">{parsed.ifcType}</span>
+                          {/* bg-primary tooltip: derive from primary-foreground so it
+                              reads on the blue/purple surface and in dark mode (#1218) */}
+                          <span className="text-primary-foreground/80">{parsed.ifcType}</span>
                         </TooltipContent>
                       </Tooltip>
                     ) : (

--- a/apps/viewer/src/components/viewer/properties/QuantitySetCard.tsx
+++ b/apps/viewer/src/components/viewer/properties/QuantitySetCard.tsx
@@ -58,7 +58,9 @@ export function QuantitySetCard({ qset }: { qset: QuantitySet }) {
                       </span>
                     </TooltipTrigger>
                     <TooltipContent side="top" className="text-[10px]">
-                      <span className="text-zinc-400">{typeName}</span>
+                      {/* bg-primary tooltip: derive from primary-foreground so it
+                          reads on the blue/purple surface and in dark mode (#1218) */}
+                      <span className="text-primary-foreground/80">{typeName}</span>
                     </TooltipContent>
                   </Tooltip>
                 ) : (


### PR DESCRIPTION
Closes #1218.

## Problem
The bSDD property tooltip (and the property-name / quantity-name tooltips) rendered secondary text that was nearly impossible to read — faded grey on the blue/purple tooltip background:

<img width="500" alt="before" src="https://github.com/user-attachments/assets/c0cd5056-a3be-4110-a709-85fdf5f31483" />

## Root cause
`TooltipContent` renders on a `bg-primary` surface — **tokyo-blue**, or **cf-purple** in the conference theme — with `text-primary-foreground`. The secondary lines hardcoded `text-zinc-400` / `text-sky-400`, which:
- wash out on the blue/purple background (the reported bug), and
- would invert in **dark mode**, where `--color-primary-foreground` flips to a dark colour (`tokyo-night`) — a hardcoded light grey there is also wrong.

## Fix
Derive the secondary lines from `primary-foreground` with opacity tiers (`/80`, `/70`) so they track the tooltip's own foreground and stay legible in **every theme** (light tokyo, dark tokyo, cf-purple). Visual hierarchy is preserved via opacity instead of hardcoded hues. This is the same token the tooltip's base text already uses.

Same defect fixed in the property-name tooltip (`PropertySetCard`) and the quantity-name tooltip (`QuantitySetCard`).

## Files
- `apps/viewer/src/components/viewer/properties/BsddCard.tsx`
- `apps/viewer/src/components/viewer/properties/PropertySetCard.tsx`
- `apps/viewer/src/components/viewer/properties/QuantitySetCard.tsx`

className-only changes; no logic or type surface touched. Swept all `TooltipContent` blocks to confirm no other hardcoded palette colours remain on the primary surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved tooltip styling in the properties viewer for enhanced readability across light and dark modes. Updated colors for property details, types, and quantity information to ensure consistent visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->