### PR TITLE
feat(viewer): choose the bSDD source dictionary in the properties card

### DIFF
--- a/.changeset/bsdd-select-dictionary.md
+++ b/.changeset/bsdd-select-dictionary.md
@@ -2,16 +2,16 @@
 "@ifc-lite/viewer": minor
 ---
 
-Let the Properties → bSDD card read from dictionaries other than IFC. Two
-searchable pickers now sit at the top of the card:
+Let the Properties → bSDD card read from dictionaries other than IFC.
 
-- **Dictionary search** — a searchable field over the *entire* bSDD catalogue
-  (IFC 4.3 pinned first, every other published dictionary below), not a
-  hardcoded shortlist.
-- **Class search** (for non-IFC dictionaries) — search that dictionary's
-  classes directly (server-side), seeded with classes related to the current
-  IFC entity type as suggestions. Picking a class surfaces its property sets
-  through the existing one-click add-to-element flow.
+- **Dictionary picker** — a searchable field over the entire bSDD catalogue
+  (IFC 4.3 pinned first, ~400 dictionaries), browsable by scrolling.
+- **Class browser** (for non-IFC dictionaries) — a scrollable, paginated list
+  of the dictionary's classes that loads more as you scroll (infinite scroll
+  via the bSDD `Dictionary/Classes` `Offset`/`Limit` endpoint, so a 5,000-class
+  dictionary is never fetched at once). A filter box narrows the list. Picking
+  a class surfaces its property sets through the existing one-click
+  add-to-element flow.
 
-The chosen dictionary persists to `localStorage`. Empty/missing states are
-handled with a one-click "Back to IFC 4.3". Closes #1219.
+The chosen dictionary persists to `localStorage`; IFC behaviour is unchanged
+(resolved by entity-type name). Closes #1219.

--- a/.changeset/bsdd-select-dictionary.md
+++ b/.changeset/bsdd-select-dictionary.md
@@ -1,0 +1,13 @@
+---
+"@ifc-lite/viewer": minor
+---
+
+Let the Properties → bSDD card read from dictionaries other than IFC. A
+source-dictionary picker now sits at the top of the card: it offers IFC 4.3
+(the default) plus every other bSDD that maps classes to the selected entity
+type — Uniclass, ETIM, NL-SfB, or an organisation's own published dictionary.
+Picking a non-IFC dictionary fetches that dictionary's related class(es),
+merges their property sets (deduped by `propertySet:name`), and exposes them
+through the existing one-click add-to-element flow. The choice persists to
+`localStorage`, and a dictionary with no definitions for the current type
+shows a clear empty state with a one-click "Back to IFC 4.3". Closes #1219.

--- a/.changeset/bsdd-select-dictionary.md
+++ b/.changeset/bsdd-select-dictionary.md
@@ -2,12 +2,16 @@
 "@ifc-lite/viewer": minor
 ---
 
-Let the Properties → bSDD card read from dictionaries other than IFC. A
-source-dictionary picker now sits at the top of the card: it offers IFC 4.3
-(the default) plus every other bSDD that maps classes to the selected entity
-type — Uniclass, ETIM, NL-SfB, or an organisation's own published dictionary.
-Picking a non-IFC dictionary fetches that dictionary's related class(es),
-merges their property sets (deduped by `propertySet:name`), and exposes them
-through the existing one-click add-to-element flow. The choice persists to
-`localStorage`, and a dictionary with no definitions for the current type
-shows a clear empty state with a one-click "Back to IFC 4.3". Closes #1219.
+Let the Properties → bSDD card read from dictionaries other than IFC. Two
+searchable pickers now sit at the top of the card:
+
+- **Dictionary search** — a searchable field over the *entire* bSDD catalogue
+  (IFC 4.3 pinned first, every other published dictionary below), not a
+  hardcoded shortlist.
+- **Class search** (for non-IFC dictionaries) — search that dictionary's
+  classes directly (server-side), seeded with classes related to the current
+  IFC entity type as suggestions. Picking a class surfaces its property sets
+  through the existing one-click add-to-element flow.
+
+The chosen dictionary persists to `localStorage`. Empty/missing states are
+handled with a one-click "Back to IFC 4.3". Closes #1219.

--- a/apps/viewer/src/components/ui/combo-input.tsx
+++ b/apps/viewer/src/components/ui/combo-input.tsx
@@ -27,6 +27,13 @@ export interface ComboInputProps {
   className?: string;
   /** Cap rendered suggestions (filtering still scans all options). */
   maxRendered?: number;
+  /**
+   * Skip the built-in substring filtering and render `options` as-is. Use when
+   * the options are already filtered upstream (e.g. a server-side search keyed
+   * on the typed value), so results whose label doesn't literally contain the
+   * query aren't hidden.
+   */
+  disableFilter?: boolean;
   'aria-label'?: string;
 }
 
@@ -39,6 +46,7 @@ export function ComboInput({
   placeholder,
   className,
   maxRendered = 50,
+  disableFilter = false,
   'aria-label': ariaLabel,
 }: ComboInputProps) {
   const [open, setOpen] = useState(false);
@@ -48,10 +56,11 @@ export function ComboInput({
   const listRef = useRef<HTMLDivElement>(null);
 
   const filtered = useMemo(() => {
+    if (disableFilter) return options.slice(0, maxRendered);
     const q = value.trim().toLowerCase();
     const matches = q ? options.filter((o) => o.toLowerCase().includes(q)) : options;
     return matches.slice(0, maxRendered);
-  }, [options, value, maxRendered]);
+  }, [options, value, maxRendered, disableFilter]);
 
   useEffect(() => { setHighlight(0); }, [filtered]);
 

--- a/apps/viewer/src/components/ui/combo-input.tsx
+++ b/apps/viewer/src/components/ui/combo-input.tsx
@@ -27,13 +27,6 @@ export interface ComboInputProps {
   className?: string;
   /** Cap rendered suggestions (filtering still scans all options). */
   maxRendered?: number;
-  /**
-   * Skip the built-in substring filtering and render `options` as-is. Use when
-   * the options are already filtered upstream (e.g. a server-side search keyed
-   * on the typed value), so results whose label doesn't literally contain the
-   * query aren't hidden.
-   */
-  disableFilter?: boolean;
   'aria-label'?: string;
 }
 
@@ -46,7 +39,6 @@ export function ComboInput({
   placeholder,
   className,
   maxRendered = 50,
-  disableFilter = false,
   'aria-label': ariaLabel,
 }: ComboInputProps) {
   const [open, setOpen] = useState(false);
@@ -56,11 +48,10 @@ export function ComboInput({
   const listRef = useRef<HTMLDivElement>(null);
 
   const filtered = useMemo(() => {
-    if (disableFilter) return options.slice(0, maxRendered);
     const q = value.trim().toLowerCase();
     const matches = q ? options.filter((o) => o.toLowerCase().includes(q)) : options;
     return matches.slice(0, maxRendered);
-  }, [options, value, maxRendered, disableFilter]);
+  }, [options, value, maxRendered]);
 
   useEffect(() => { setHighlight(0); }, [filtered]);
 

--- a/apps/viewer/src/components/viewer/properties/BsddCard.tsx
+++ b/apps/viewer/src/components/viewer/properties/BsddCard.tsx
@@ -10,7 +10,7 @@
  * properties to the element in one click.
  */
 
-import { useState, useEffect, useMemo, useCallback, useRef, type UIEvent } from 'react';
+import { useState, useEffect, useLayoutEffect, useMemo, useCallback, useRef, type UIEvent } from 'react';
 import { BookOpen, Plus, Check, Loader2, ExternalLink, ChevronDown, ChevronRight, ArrowRight, Library, Search } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -126,6 +126,12 @@ export function BsddCard({
   // Monotonic token: every reset/filter bumps it so a slow in-flight page that
   // resolves after the dictionary/filter changed is discarded, not appended.
   const classReqRef = useRef(0);
+  // The class list grows to fill the panel's remaining height (the Radix
+  // ScrollArea wraps content in a `display:table` div, so flexbox can't size it
+  // — we measure instead). Browse mode only; a picked class uses a compact list
+  // so its properties get room below.
+  const classListRef = useRef<HTMLDivElement | null>(null);
+  const [classListMaxH, setClassListMaxH] = useState<number | undefined>(undefined);
 
   const bsddDictionary = useViewerStore((s) => s.bsddDictionary);
   const setBsddDictionary = useViewerStore((s) => s.setBsddDictionary);
@@ -286,6 +292,33 @@ export function BsddCard({
   useEffect(() => () => {
     if (classSearchTimer.current) clearTimeout(classSearchTimer.current);
   }, []);
+
+  // Size the browse list to the space between its top and the bottom of the
+  // scroll viewport (falling back to the window), so it fills the panel instead
+  // of being a short fixed box. Re-measures on panel/window resize.
+  useLayoutEffect(() => {
+    if (isIfcDict || selectedClass) {
+      setClassListMaxH(undefined);
+      return;
+    }
+    const el = classListRef.current;
+    if (!el) return;
+    const viewport = el.closest('[data-radix-scroll-area-viewport]') as HTMLElement | null;
+    const measure = () => {
+      const top = el.getBoundingClientRect().top;
+      const bottom = viewport ? viewport.getBoundingClientRect().bottom : window.innerHeight;
+      // Leave room for the "Showing N of M" status line + a little breathing room.
+      setClassListMaxH(Math.max(160, Math.floor(bottom - top - 28)));
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    if (viewport) ro.observe(viewport);
+    window.addEventListener('resize', measure);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener('resize', measure);
+    };
+  }, [isIfcDict, selectedClass]);
 
   // `addedKeys` tracks what was added to THIS element, so it must reset when the
   // selection moves to a different element — even one of the same IfcType, which
@@ -576,8 +609,12 @@ export function BsddCard({
         />
       </div>
       <div
+        ref={classListRef}
         onScroll={onClassListScroll}
-        className="max-h-52 overflow-y-auto rounded-md border border-sky-200/60 dark:border-sky-800/40 divide-y divide-sky-100/70 dark:divide-sky-900/30"
+        style={selectedClass ? undefined : { maxHeight: classListMaxH }}
+        className={`overflow-y-auto rounded-md border border-sky-200/60 dark:border-sky-800/40 divide-y divide-sky-100/70 dark:divide-sky-900/30 ${
+          selectedClass ? 'max-h-44' : ''
+        }`}
       >
         {classItems.map((c) => {
           const isSel = selectedClass?.uri === c.uri;

--- a/apps/viewer/src/components/viewer/properties/BsddCard.tsx
+++ b/apps/viewer/src/components/viewer/properties/BsddCard.tsx
@@ -10,29 +10,27 @@
  * properties to the element in one click.
  */
 
-import { useState, useEffect, useMemo, useCallback } from 'react';
-import { BookOpen, Plus, Check, Loader2, ExternalLink, ChevronDown, ChevronRight, ArrowRight, Library } from 'lucide-react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { BookOpen, Plus, Check, Loader2, ExternalLink, ChevronDown, ChevronRight, ArrowRight, Library, Search } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Badge } from '@/components/ui/badge';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { ComboInput } from '@/components/ui/combo-input';
 import { useViewerStore } from '@/store';
 import { toast } from '@/components/ui/toast';
 import { QuantityType } from '@ifc-lite/data';
 import {
-  fetchClassInfoForDictionary,
-  discoverDictionaries,
+  fetchClassInfo,
+  fetchClassByUri,
+  fetchAllDictionaries,
+  searchDictionaryClasses,
+  searchRelatedClasses,
   bsddDataTypeLabel,
   IFC_DICTIONARY,
   type BsddClassInfo,
   type BsddClassProperty,
   type BsddDictionary,
+  type BsddSearchResult,
 } from '@/services/bsdd';
 import { toPropertyValueType, defaultValue } from './bsddInlineValue.js';
 
@@ -55,6 +53,11 @@ function inferQuantityType(units: string[] | null): QuantityType {
   if (u === 'kg' || u === 'g' || u === 't') return QuantityType.Weight;
   if (u === 's' || u === 'h' || u === 'min') return QuantityType.Time;
   return QuantityType.Count;
+}
+
+/** Display label for a bSDD class in the searchable class picker. */
+function classLabel(c: BsddSearchResult): string {
+  return c.code ? `${c.code} · ${c.name}` : c.name;
 }
 
 // Inline-value decision logic lives in ./bsddInlineValue.ts so it can be
@@ -105,9 +108,19 @@ export function BsddCard({
   const [error, setError] = useState<string | null>(null);
   const [expandedPsets, setExpandedPsets] = useState<Set<string>>(new Set());
   const [addedKeys, setAddedKeys] = useState<Set<string>>(new Set());
-  // Dictionaries that hold classes related to this IFC type (IFC first), used
-  // to populate the source-dictionary picker (issue #1219).
-  const [dictionaries, setDictionaries] = useState<BsddDictionary[]>([IFC_DICTIONARY]);
+
+  // Source-dictionary picker: the whole bSDD catalogue (searchable), and the
+  // current search text. The committed choice lives in the store (issue #1219).
+  const [allDictionaries, setAllDictionaries] = useState<BsddDictionary[]>([IFC_DICTIONARY]);
+  const [dictQuery, setDictQuery] = useState('');
+
+  // Non-IFC class picker: which class in the selected dictionary to read
+  // properties from. `classResults` are the current suggestions (seeded with
+  // classes related to this IFC type, then driven by the search query).
+  const [classQuery, setClassQuery] = useState('');
+  const [classResults, setClassResults] = useState<BsddSearchResult[]>([]);
+  const [selectedClass, setSelectedClass] = useState<BsddSearchResult | null>(null);
+  const classSearchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const bsddDictionary = useViewerStore((s) => s.bsddDictionary);
   const setBsddDictionary = useViewerStore((s) => s.setBsddDictionary);
@@ -121,31 +134,49 @@ export function BsddCard({
   const setPropertiesActiveTab = useViewerStore((s) => s.setPropertiesActiveTab);
   const setPendingPropertyFocus = useViewerStore((s) => s.setPendingPropertyFocus);
 
-  // Discover which dictionaries have classes related to this IFC type, so the
-  // picker can offer non-IFC bSDDs (Uniclass, ETIM, a company's own, …). Always
-  // keeps IFC as the first option even if discovery fails (issue #1219).
+  const isIfcDict = bsddDictionary.uri === IFC_DICTIONARY.uri;
+
+  // Load the full dictionary catalogue once (cached in the service) so the
+  // picker can search every bSDD, not just the few related to this entity.
   useEffect(() => {
     let cancelled = false;
-    setDictionaries([IFC_DICTIONARY]);
-    if (!entityType) return;
-
-    discoverDictionaries(entityType).then(
+    fetchAllDictionaries().then(
       (dicts) => {
-        if (cancelled) return;
-        setDictionaries(dicts.length > 0 ? dicts : [IFC_DICTIONARY]);
+        if (!cancelled) setAllDictionaries(dicts.length > 0 ? dicts : [IFC_DICTIONARY]);
       },
       () => {
-        if (!cancelled) setDictionaries([IFC_DICTIONARY]);
+        if (!cancelled) setAllDictionaries([IFC_DICTIONARY]);
       },
     );
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // When the dictionary or entity type changes, reset the class picker and (for
+  // non-IFC dictionaries) seed suggestions with classes related to this IFC
+  // type — a useful starting point the user can search past.
+  useEffect(() => {
+    let cancelled = false;
+    setSelectedClass(null);
+    setClassQuery('');
+    setClassResults([]);
+
+    if (isIfcDict || !entityType) return;
+
+    searchRelatedClasses(entityType).then((related) => {
+      if (cancelled) return;
+      setClassResults(related.filter((c) => c.dictionaryUri === bsddDictionary.uri && c.uri));
+    });
 
     return () => {
       cancelled = true;
     };
-  }, [entityType]);
+  }, [entityType, bsddDictionary.uri, isIfcDict]);
 
-  // Fetch class info from the selected dictionary when the entity type or the
-  // chosen dictionary changes.
+  // Load the property definitions to display:
+  //  - IFC dictionary → resolve by entity type name (the standard path).
+  //  - other dictionary → whichever class the user has picked.
   useEffect(() => {
     let cancelled = false;
     setClassInfo(null);
@@ -153,17 +184,18 @@ export function BsddCard({
     setAddedKeys(new Set());
 
     if (!entityType) return;
+    if (!isIfcDict && !selectedClass) return; // waiting for a class pick
 
     setLoading(true);
-    fetchClassInfoForDictionary(entityType, bsddDictionary.uri).then(
+    const promise = isIfcDict
+      ? fetchClassInfo(entityType)
+      : fetchClassByUri(selectedClass!.uri, false);
+
+    promise.then(
       (info) => {
         if (cancelled) return;
         setLoading(false);
-        if (info && info.classProperties.length > 0) {
-          setClassInfo(info);
-        } else {
-          setClassInfo(null);
-        }
+        setClassInfo(info && info.classProperties.length > 0 ? info : null);
       },
       (err) => {
         if (cancelled) return;
@@ -175,7 +207,12 @@ export function BsddCard({
     return () => {
       cancelled = true;
     };
-  }, [entityType, bsddDictionary.uri]);
+  }, [entityType, isIfcDict, selectedClass]);
+
+  // Clear any pending class-search debounce on unmount.
+  useEffect(() => () => {
+    if (classSearchTimer.current) clearTimeout(classSearchTimer.current);
+  }, []);
 
   // `addedKeys` tracks what was added to THIS element, so it must reset when the
   // selection moves to a different element — even one of the same IfcType, which
@@ -410,44 +447,95 @@ export function BsddCard({
     [addedKeys],
   );
 
-  const isIfcDict = bsddDictionary.uri === IFC_DICTIONARY.uri;
+  // ---- Source-dictionary picker (searchable over the whole bSDD catalogue) ----
+  const dictByLabel = useMemo(() => {
+    const m = new Map<string, BsddDictionary>();
+    for (const d of allDictionaries) m.set(d.name, d);
+    return m;
+  }, [allDictionaries]);
+  const dictLabels = useMemo(() => allDictionaries.map((d) => d.name), [allDictionaries]);
 
-  // The picker offers every discovered dictionary, plus the currently-selected
-  // one if it isn't related to *this* entity type (so the dropdown still shows
-  // the active choice rather than silently snapping to IFC).
-  const dictionaryOptions = useMemo(() => {
-    const opts = [...dictionaries];
-    if (!opts.some((d) => d.uri === bsddDictionary.uri)) {
-      opts.push(bsddDictionary);
-    }
-    return opts;
-  }, [dictionaries, bsddDictionary]);
-
-  const handleDictChange = useCallback(
-    (uri: string) => {
-      const next = dictionaryOptions.find((d) => d.uri === uri);
-      if (next) setBsddDictionary(next);
+  const handleDictQuery = useCallback(
+    (next: string) => {
+      const match = dictByLabel.get(next);
+      if (match) {
+        // A real dictionary was chosen — commit it and clear the query so the
+        // input's placeholder shows the selection (rather than the typed text).
+        if (match.uri !== bsddDictionary.uri) setBsddDictionary(match);
+        setDictQuery('');
+      } else {
+        setDictQuery(next);
+      }
     },
-    [dictionaryOptions, setBsddDictionary],
+    [dictByLabel, bsddDictionary.uri, setBsddDictionary],
   );
 
-  // Source-dictionary picker — always rendered above the body so users can
-  // switch bSDDs in any state (loading / error / empty / populated). Issue #1219.
-  const dictionarySelector = (
-    <div className="flex items-center gap-1.5 px-1 pb-2">
-      <Library className="h-3.5 w-3.5 text-sky-500 shrink-0" />
-      <Select value={bsddDictionary.uri} onValueChange={handleDictChange}>
-        <SelectTrigger className="h-7 text-xs flex-1 min-w-0" aria-label="bSDD source dictionary">
-          <SelectValue placeholder="Select dictionary" />
-        </SelectTrigger>
-        <SelectContent>
-          {dictionaryOptions.map((d) => (
-            <SelectItem key={d.uri} value={d.uri} className="text-xs">
-              {d.name}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+  // ---- Class picker (server-searched within the selected non-IFC dictionary) ----
+  const classByLabel = useMemo(() => {
+    const m = new Map<string, BsddSearchResult>();
+    for (const c of classResults) m.set(classLabel(c), c);
+    return m;
+  }, [classResults]);
+  const classLabels = useMemo(() => classResults.map(classLabel), [classResults]);
+
+  const seedRelatedClasses = useCallback(() => {
+    searchRelatedClasses(entityType).then((related) =>
+      setClassResults(related.filter((c) => c.dictionaryUri === bsddDictionary.uri && c.uri)),
+    );
+  }, [entityType, bsddDictionary.uri]);
+
+  const handleClassQuery = useCallback(
+    (next: string) => {
+      const match = classByLabel.get(next);
+      if (match) {
+        setSelectedClass(match);
+        setClassQuery('');
+        return;
+      }
+      setClassQuery(next);
+      if (classSearchTimer.current) clearTimeout(classSearchTimer.current);
+      const q = next.trim();
+      if (!q) {
+        seedRelatedClasses();
+        return;
+      }
+      // Debounce the live search so each keystroke doesn't hit the bSDD API.
+      classSearchTimer.current = setTimeout(() => {
+        searchDictionaryClasses(bsddDictionary.uri, q).then(setClassResults);
+      }, 250);
+    },
+    [classByLabel, bsddDictionary.uri, seedRelatedClasses],
+  );
+
+  // Pickers — always rendered above the body so users can switch bSDDs / classes
+  // in any state (loading / error / empty / populated). Issue #1219.
+  const pickers = (
+    <div className="space-y-1.5 px-1 pb-2">
+      <div className="flex items-center gap-1.5">
+        <Library className="h-3.5 w-3.5 text-sky-500 shrink-0" />
+        <ComboInput
+          value={dictQuery}
+          onChange={handleDictQuery}
+          options={dictLabels}
+          placeholder={bsddDictionary.name}
+          aria-label="bSDD source dictionary"
+          className="h-7 text-xs"
+        />
+      </div>
+      {!isIfcDict && (
+        <div className="flex items-center gap-1.5">
+          <Search className="h-3.5 w-3.5 text-sky-500 shrink-0" />
+          <ComboInput
+            value={classQuery}
+            onChange={handleClassQuery}
+            options={classLabels}
+            disableFilter
+            placeholder={selectedClass ? classLabel(selectedClass) : `Search ${bsddDictionary.name} classes…`}
+            aria-label="bSDD class"
+            className="h-7 text-xs"
+          />
+        </div>
+      )}
     </div>
   );
 
@@ -455,10 +543,10 @@ export function BsddCard({
   if (loading) {
     return (
       <div className="w-full min-w-0 overflow-hidden">
-        {dictionarySelector}
+        {pickers}
         <div className="flex items-center gap-2 px-3 py-6 text-xs text-zinc-400">
           <Loader2 className="h-3.5 w-3.5 animate-spin" />
-          <span>Loading {bsddDictionary.name} data for {entityType}...</span>
+          <span>Loading {isIfcDict ? bsddDictionary.name : selectedClass?.name} data…</span>
         </div>
       </div>
     );
@@ -468,9 +556,32 @@ export function BsddCard({
   if (error) {
     return (
       <div className="w-full min-w-0 overflow-hidden">
-        {dictionarySelector}
+        {pickers}
         <div className="px-3 py-4 text-xs text-red-500/70">
           <p>Could not load bSDD data: {error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Non-IFC dictionary with no class picked yet — prompt the user to search.
+  if (!isIfcDict && !selectedClass) {
+    return (
+      <div className="w-full min-w-0 overflow-hidden">
+        {pickers}
+        <div className="flex flex-col items-center justify-center text-center px-4 py-8 text-xs text-zinc-400 gap-2">
+          <Search className="h-6 w-6 text-zinc-300 dark:text-zinc-600" />
+          <p>
+            Search <span className="font-medium">{bsddDictionary.name}</span> for a class to add
+            its properties to <span className="font-mono font-medium">{entityType}</span>.
+          </p>
+          <button
+            type="button"
+            onClick={() => setBsddDictionary(IFC_DICTIONARY)}
+            className="mt-1 text-sky-500 hover:text-sky-600 underline underline-offset-2"
+          >
+            Back to {IFC_DICTIONARY.name}
+          </button>
         </div>
       </div>
     );
@@ -480,12 +591,21 @@ export function BsddCard({
   if (!classInfo || groupedProps.size === 0) {
     return (
       <div className="w-full min-w-0 overflow-hidden">
-        {dictionarySelector}
+        {pickers}
         <div className="flex flex-col items-center justify-center text-center px-4 py-8 text-xs text-zinc-400 gap-2">
           <BookOpen className="h-6 w-6 text-zinc-300 dark:text-zinc-600" />
           <p>
-            No <span className="font-medium">{bsddDictionary.name}</span> properties for{' '}
-            <span className="font-mono font-medium">{entityType}</span>
+            {isIfcDict ? (
+              <>
+                No <span className="font-medium">{bsddDictionary.name}</span> properties for{' '}
+                <span className="font-mono font-medium">{entityType}</span>
+              </>
+            ) : (
+              <>
+                No properties defined on{' '}
+                <span className="font-medium">{selectedClass?.name}</span>
+              </>
+            )}
           </p>
           {!isIfcDict && (
             <button
@@ -503,7 +623,7 @@ export function BsddCard({
 
   return (
     <div className="space-y-2 w-full min-w-0 overflow-hidden">
-      {dictionarySelector}
+      {pickers}
       {/* Header with class description */}
       {classInfo.definition && (
         <div className="px-1 pb-1 text-[11px] text-zinc-500 dark:text-zinc-400 leading-relaxed">

--- a/apps/viewer/src/components/viewer/properties/BsddCard.tsx
+++ b/apps/viewer/src/components/viewer/properties/BsddCard.tsx
@@ -10,12 +10,13 @@
  * properties to the element in one click.
  */
 
-import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef, type UIEvent } from 'react';
 import { BookOpen, Plus, Check, Loader2, ExternalLink, ChevronDown, ChevronRight, ArrowRight, Library, Search } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Badge } from '@/components/ui/badge';
 import { ComboInput } from '@/components/ui/combo-input';
+import { Input } from '@/components/ui/input';
 import { useViewerStore } from '@/store';
 import { toast } from '@/components/ui/toast';
 import { QuantityType } from '@ifc-lite/data';
@@ -23,8 +24,8 @@ import {
   fetchClassInfo,
   fetchClassByUri,
   fetchAllDictionaries,
+  listDictionaryClasses,
   searchDictionaryClasses,
-  searchRelatedClasses,
   bsddDataTypeLabel,
   IFC_DICTIONARY,
   type BsddClassInfo,
@@ -32,6 +33,9 @@ import {
   type BsddDictionary,
   type BsddSearchResult,
 } from '@/services/bsdd';
+
+/** How many classes to fetch per page when browsing a non-IFC dictionary. */
+const CLASS_PAGE_SIZE = 50;
 import { toPropertyValueType, defaultValue } from './bsddInlineValue.js';
 
 // ---------------------------------------------------------------------------
@@ -53,11 +57,6 @@ function inferQuantityType(units: string[] | null): QuantityType {
   if (u === 'kg' || u === 'g' || u === 't') return QuantityType.Weight;
   if (u === 's' || u === 'h' || u === 'min') return QuantityType.Time;
   return QuantityType.Count;
-}
-
-/** Display label for a bSDD class in the searchable class picker. */
-function classLabel(c: BsddSearchResult): string {
-  return c.code ? `${c.code} · ${c.name}` : c.name;
 }
 
 // Inline-value decision logic lives in ./bsddInlineValue.ts so it can be
@@ -114,13 +113,19 @@ export function BsddCard({
   const [allDictionaries, setAllDictionaries] = useState<BsddDictionary[]>([IFC_DICTIONARY]);
   const [dictQuery, setDictQuery] = useState('');
 
-  // Non-IFC class picker: which class in the selected dictionary to read
-  // properties from. `classResults` are the current suggestions (seeded with
-  // classes related to this IFC type, then driven by the search query).
+  // Non-IFC class picker: the user browses the dictionary's classes in a
+  // paginated, scrollable list (a dictionary can hold thousands), optionally
+  // narrowed by a text filter, then picks one to read its properties.
   const [classQuery, setClassQuery] = useState('');
-  const [classResults, setClassResults] = useState<BsddSearchResult[]>([]);
+  const [classItems, setClassItems] = useState<BsddSearchResult[]>([]);
+  const [classTotal, setClassTotal] = useState(0);
+  const [classOffset, setClassOffset] = useState(0);
+  const [classLoading, setClassLoading] = useState(false);
   const [selectedClass, setSelectedClass] = useState<BsddSearchResult | null>(null);
   const classSearchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Monotonic token: every reset/filter bumps it so a slow in-flight page that
+  // resolves after the dictionary/filter changed is discarded, not appended.
+  const classReqRef = useRef(0);
 
   const bsddDictionary = useViewerStore((s) => s.bsddDictionary);
   const setBsddDictionary = useViewerStore((s) => s.setBsddDictionary);
@@ -153,26 +158,94 @@ export function BsddCard({
     };
   }, []);
 
-  // When the dictionary or entity type changes, reset the class picker and (for
-  // non-IFC dictionaries) seed suggestions with classes related to this IFC
-  // type — a useful starting point the user can search past.
+  // When the dictionary changes, reset the class browser and load its first
+  // page. For a non-IFC dictionary the user browses this list to pick a class.
   useEffect(() => {
-    let cancelled = false;
     setSelectedClass(null);
     setClassQuery('');
-    setClassResults([]);
+    setClassItems([]);
+    setClassTotal(0);
+    setClassOffset(0);
 
-    if (isIfcDict || !entityType) return;
+    if (isIfcDict) return;
 
-    searchRelatedClasses(entityType).then((related) => {
-      if (cancelled) return;
-      setClassResults(related.filter((c) => c.dictionaryUri === bsddDictionary.uri && c.uri));
-    });
+    const token = ++classReqRef.current;
+    setClassLoading(true);
+    listDictionaryClasses(bsddDictionary.uri, 0, CLASS_PAGE_SIZE).then(
+      (page) => {
+        if (token !== classReqRef.current) return;
+        setClassItems(page.classes);
+        setClassTotal(page.total);
+        setClassOffset(page.classes.length);
+        setClassLoading(false);
+      },
+      () => {
+        if (token === classReqRef.current) setClassLoading(false);
+      },
+    );
+  }, [bsddDictionary.uri, isIfcDict]);
 
-    return () => {
-      cancelled = true;
-    };
-  }, [entityType, bsddDictionary.uri, isIfcDict]);
+  // Append the next page when the list is scrolled near the bottom (browse mode
+  // only — text-filtered results come back in a single page).
+  const loadMoreClasses = useCallback(() => {
+    if (classLoading || classQuery.trim() || classItems.length >= classTotal) return;
+    const token = classReqRef.current;
+    setClassLoading(true);
+    listDictionaryClasses(bsddDictionary.uri, classOffset, CLASS_PAGE_SIZE).then(
+      (page) => {
+        if (token !== classReqRef.current) return;
+        setClassItems((prev) => [...prev, ...page.classes]);
+        setClassOffset((o) => o + page.classes.length);
+        setClassLoading(false);
+      },
+      () => {
+        if (token === classReqRef.current) setClassLoading(false);
+      },
+    );
+  }, [classLoading, classQuery, classItems.length, classTotal, classOffset, bsddDictionary.uri]);
+
+  // Debounced filter: empty → browse the full paginated list; text → search the
+  // dictionary (single page). A bumped token discards any in-flight load.
+  const handleClassFilter = useCallback(
+    (q: string) => {
+      setClassQuery(q);
+      if (classSearchTimer.current) clearTimeout(classSearchTimer.current);
+      const trimmed = q.trim();
+      const token = ++classReqRef.current;
+      setClassItems([]);
+      setClassOffset(0);
+      setClassLoading(true);
+      classSearchTimer.current = setTimeout(() => {
+        const req = trimmed
+          ? searchDictionaryClasses(bsddDictionary.uri, trimmed).then((res) => ({
+              classes: res,
+              total: res.length,
+            }))
+          : listDictionaryClasses(bsddDictionary.uri, 0, CLASS_PAGE_SIZE);
+        req.then(
+          (page) => {
+            if (token !== classReqRef.current) return;
+            setClassItems(page.classes);
+            setClassTotal(page.total);
+            setClassOffset(page.classes.length);
+            setClassLoading(false);
+          },
+          () => {
+            if (token === classReqRef.current) setClassLoading(false);
+          },
+        );
+      }, 250);
+    },
+    [bsddDictionary.uri],
+  );
+
+  const onClassListScroll = useCallback(
+    (e: UIEvent<HTMLDivElement>) => {
+      const el = e.currentTarget;
+      if (el.scrollHeight - el.scrollTop - el.clientHeight < 80) loadMoreClasses();
+    },
+    [loadMoreClasses],
+  );
 
   // Load the property definitions to display:
   //  - IFC dictionary → resolve by entity type name (the standard path).
@@ -470,129 +543,104 @@ export function BsddCard({
     [dictByLabel, bsddDictionary.uri, setBsddDictionary],
   );
 
-  // ---- Class picker (server-searched within the selected non-IFC dictionary) ----
-  const classByLabel = useMemo(() => {
-    const m = new Map<string, BsddSearchResult>();
-    for (const c of classResults) m.set(classLabel(c), c);
-    return m;
-  }, [classResults]);
-  const classLabels = useMemo(() => classResults.map(classLabel), [classResults]);
-
-  const seedRelatedClasses = useCallback(() => {
-    searchRelatedClasses(entityType).then((related) =>
-      setClassResults(related.filter((c) => c.dictionaryUri === bsddDictionary.uri && c.uri)),
-    );
-  }, [entityType, bsddDictionary.uri]);
-
-  const handleClassQuery = useCallback(
-    (next: string) => {
-      const match = classByLabel.get(next);
-      if (match) {
-        setSelectedClass(match);
-        setClassQuery('');
-        return;
-      }
-      setClassQuery(next);
-      if (classSearchTimer.current) clearTimeout(classSearchTimer.current);
-      const q = next.trim();
-      if (!q) {
-        seedRelatedClasses();
-        return;
-      }
-      // Debounce the live search so each keystroke doesn't hit the bSDD API.
-      classSearchTimer.current = setTimeout(() => {
-        searchDictionaryClasses(bsddDictionary.uri, q).then(setClassResults);
-      }, 250);
-    },
-    [classByLabel, bsddDictionary.uri, seedRelatedClasses],
+  // ---- Source-dictionary picker (searchable over the whole bSDD catalogue) ----
+  const dictionaryCombo = (
+    <div className="flex items-center gap-1.5 px-1">
+      <Library className="h-3.5 w-3.5 text-sky-500 shrink-0" />
+      <ComboInput
+        value={dictQuery}
+        onChange={handleDictQuery}
+        options={dictLabels}
+        // Render the full catalogue so it can be browsed by scrolling, not just
+        // filtered by typing.
+        maxRendered={1000}
+        placeholder={bsddDictionary.name}
+        aria-label="bSDD source dictionary"
+        className="h-7 text-xs"
+      />
+    </div>
   );
 
-  // Pickers — always rendered above the body so users can switch bSDDs / classes
-  // in any state (loading / error / empty / populated). Issue #1219.
-  const pickers = (
-    <div className="space-y-1.5 px-1 pb-2">
+  // ---- Class browser (paginated, scrollable list of the dictionary's classes) ----
+  const browseExhausted = !classQuery.trim() && classItems.length >= classTotal;
+  const classBrowser = (
+    <div className="space-y-1 px-1">
       <div className="flex items-center gap-1.5">
-        <Library className="h-3.5 w-3.5 text-sky-500 shrink-0" />
-        <ComboInput
-          value={dictQuery}
-          onChange={handleDictQuery}
-          options={dictLabels}
-          placeholder={bsddDictionary.name}
-          aria-label="bSDD source dictionary"
+        <Search className="h-3.5 w-3.5 text-sky-500 shrink-0" />
+        <Input
+          value={classQuery}
+          onChange={(e) => handleClassFilter(e.target.value)}
+          placeholder={`Filter ${bsddDictionary.name} classes…`}
+          aria-label="Filter bSDD classes"
           className="h-7 text-xs"
         />
       </div>
-      {!isIfcDict && (
-        <div className="flex items-center gap-1.5">
-          <Search className="h-3.5 w-3.5 text-sky-500 shrink-0" />
-          <ComboInput
-            value={classQuery}
-            onChange={handleClassQuery}
-            options={classLabels}
-            disableFilter
-            placeholder={selectedClass ? classLabel(selectedClass) : `Search ${bsddDictionary.name} classes…`}
-            aria-label="bSDD class"
-            className="h-7 text-xs"
-          />
+      <div
+        onScroll={onClassListScroll}
+        className="max-h-52 overflow-y-auto rounded-md border border-sky-200/60 dark:border-sky-800/40 divide-y divide-sky-100/70 dark:divide-sky-900/30"
+      >
+        {classItems.map((c) => {
+          const isSel = selectedClass?.uri === c.uri;
+          return (
+            <button
+              key={c.uri}
+              type="button"
+              onClick={() => setSelectedClass(c)}
+              title={`${c.code} · ${c.name}`}
+              className={`flex w-full items-baseline gap-1.5 px-2 py-1 text-left text-xs overflow-hidden transition-colors ${
+                isSel
+                  ? 'bg-sky-100 dark:bg-sky-900/40'
+                  : 'hover:bg-sky-50/60 dark:hover:bg-sky-900/20'
+              }`}
+            >
+              <span className="font-mono text-[10px] text-sky-600 dark:text-sky-400 shrink-0">{c.code}</span>
+              <span className="truncate text-zinc-600 dark:text-zinc-300">{c.name}</span>
+            </button>
+          );
+        })}
+        {classLoading && (
+          <div className="flex items-center justify-center gap-1.5 px-2 py-2 text-[10px] text-zinc-400">
+            <Loader2 className="h-3 w-3 animate-spin" /> Loading…
+          </div>
+        )}
+        {!classLoading && classItems.length === 0 && (
+          <div className="px-2 py-3 text-center text-[10px] text-zinc-400">No classes found</div>
+        )}
+      </div>
+      {classItems.length > 0 && (
+        <div className="px-1 text-[10px] text-zinc-400">
+          {classQuery.trim()
+            ? `${classItems.length} match${classItems.length === 1 ? '' : 'es'}`
+            : `Showing ${classItems.length} of ${classTotal}${browseExhausted ? '' : ' · scroll for more'}`}
         </div>
       )}
     </div>
   );
 
-  // Loading state
-  if (loading) {
-    return (
-      <div className="w-full min-w-0 overflow-hidden">
-        {pickers}
+  // The property body for whatever is resolved (IFC type, or the picked class).
+  const showProperties = !!classInfo && groupedProps.size > 0;
+  const propertyEmpty = !loading && !error && !showProperties && (isIfcDict || !!selectedClass);
+
+  return (
+    <div className="space-y-2 w-full min-w-0 overflow-hidden">
+      {dictionaryCombo}
+      {!isIfcDict && classBrowser}
+
+      {loading && (
         <div className="flex items-center gap-2 px-3 py-6 text-xs text-zinc-400">
           <Loader2 className="h-3.5 w-3.5 animate-spin" />
           <span>Loading {isIfcDict ? bsddDictionary.name : selectedClass?.name} data…</span>
         </div>
-      </div>
-    );
-  }
+      )}
 
-  // Error state
-  if (error) {
-    return (
-      <div className="w-full min-w-0 overflow-hidden">
-        {pickers}
+      {!loading && error && (
         <div className="px-3 py-4 text-xs text-red-500/70">
           <p>Could not load bSDD data: {error}</p>
         </div>
-      </div>
-    );
-  }
+      )}
 
-  // Non-IFC dictionary with no class picked yet — prompt the user to search.
-  if (!isIfcDict && !selectedClass) {
-    return (
-      <div className="w-full min-w-0 overflow-hidden">
-        {pickers}
-        <div className="flex flex-col items-center justify-center text-center px-4 py-8 text-xs text-zinc-400 gap-2">
-          <Search className="h-6 w-6 text-zinc-300 dark:text-zinc-600" />
-          <p>
-            Search <span className="font-medium">{bsddDictionary.name}</span> for a class to add
-            its properties to <span className="font-mono font-medium">{entityType}</span>.
-          </p>
-          <button
-            type="button"
-            onClick={() => setBsddDictionary(IFC_DICTIONARY)}
-            className="mt-1 text-sky-500 hover:text-sky-600 underline underline-offset-2"
-          >
-            Back to {IFC_DICTIONARY.name}
-          </button>
-        </div>
-      </div>
-    );
-  }
-
-  // No data
-  if (!classInfo || groupedProps.size === 0) {
-    return (
-      <div className="w-full min-w-0 overflow-hidden">
-        {pickers}
-        <div className="flex flex-col items-center justify-center text-center px-4 py-8 text-xs text-zinc-400 gap-2">
+      {propertyEmpty && (
+        <div className="flex flex-col items-center justify-center text-center px-4 py-6 text-xs text-zinc-400 gap-2">
           <BookOpen className="h-6 w-6 text-zinc-300 dark:text-zinc-600" />
           <p>
             {isIfcDict ? (
@@ -602,8 +650,7 @@ export function BsddCard({
               </>
             ) : (
               <>
-                No properties defined on{' '}
-                <span className="font-medium">{selectedClass?.name}</span>
+                No properties defined on <span className="font-medium">{selectedClass?.name}</span>
               </>
             )}
           </p>
@@ -617,13 +664,9 @@ export function BsddCard({
             </button>
           )}
         </div>
-      </div>
-    );
-  }
+      )}
 
-  return (
-    <div className="space-y-2 w-full min-w-0 overflow-hidden">
-      {pickers}
+      {showProperties && classInfo && (<>
       {/* Header with class description */}
       {classInfo.definition && (
         <div className="px-1 pb-1 text-[11px] text-zinc-500 dark:text-zinc-400 leading-relaxed">
@@ -796,6 +839,7 @@ export function BsddCard({
           View on bSDD
         </a>
       </div>
+      </>)}
     </div>
   );
 }

--- a/apps/viewer/src/components/viewer/properties/BsddCard.tsx
+++ b/apps/viewer/src/components/viewer/properties/BsddCard.tsx
@@ -11,18 +11,28 @@
  */
 
 import { useState, useEffect, useMemo, useCallback } from 'react';
-import { BookOpen, Plus, Check, Loader2, ExternalLink, ChevronDown, ChevronRight, ArrowRight } from 'lucide-react';
+import { BookOpen, Plus, Check, Loader2, ExternalLink, ChevronDown, ChevronRight, ArrowRight, Library } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Badge } from '@/components/ui/badge';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { useViewerStore } from '@/store';
 import { toast } from '@/components/ui/toast';
 import { QuantityType } from '@ifc-lite/data';
 import {
-  fetchClassInfo,
+  fetchClassInfoForDictionary,
+  discoverDictionaries,
   bsddDataTypeLabel,
+  IFC_DICTIONARY,
   type BsddClassInfo,
   type BsddClassProperty,
+  type BsddDictionary,
 } from '@/services/bsdd';
 import { toPropertyValueType, defaultValue } from './bsddInlineValue.js';
 
@@ -95,7 +105,12 @@ export function BsddCard({
   const [error, setError] = useState<string | null>(null);
   const [expandedPsets, setExpandedPsets] = useState<Set<string>>(new Set());
   const [addedKeys, setAddedKeys] = useState<Set<string>>(new Set());
+  // Dictionaries that hold classes related to this IFC type (IFC first), used
+  // to populate the source-dictionary picker (issue #1219).
+  const [dictionaries, setDictionaries] = useState<BsddDictionary[]>([IFC_DICTIONARY]);
 
+  const bsddDictionary = useViewerStore((s) => s.bsddDictionary);
+  const setBsddDictionary = useViewerStore((s) => s.setBsddDictionary);
   const setProperty = useViewerStore((s) => s.setProperty);
   const createPropertySet = useViewerStore((s) => s.createPropertySet);
   const setQuantity = useViewerStore((s) => s.setQuantity);
@@ -106,7 +121,31 @@ export function BsddCard({
   const setPropertiesActiveTab = useViewerStore((s) => s.setPropertiesActiveTab);
   const setPendingPropertyFocus = useViewerStore((s) => s.setPendingPropertyFocus);
 
-  // Fetch class info from bSDD when entity type changes
+  // Discover which dictionaries have classes related to this IFC type, so the
+  // picker can offer non-IFC bSDDs (Uniclass, ETIM, a company's own, …). Always
+  // keeps IFC as the first option even if discovery fails (issue #1219).
+  useEffect(() => {
+    let cancelled = false;
+    setDictionaries([IFC_DICTIONARY]);
+    if (!entityType) return;
+
+    discoverDictionaries(entityType).then(
+      (dicts) => {
+        if (cancelled) return;
+        setDictionaries(dicts.length > 0 ? dicts : [IFC_DICTIONARY]);
+      },
+      () => {
+        if (!cancelled) setDictionaries([IFC_DICTIONARY]);
+      },
+    );
+
+    return () => {
+      cancelled = true;
+    };
+  }, [entityType]);
+
+  // Fetch class info from the selected dictionary when the entity type or the
+  // chosen dictionary changes.
   useEffect(() => {
     let cancelled = false;
     setClassInfo(null);
@@ -116,7 +155,7 @@ export function BsddCard({
     if (!entityType) return;
 
     setLoading(true);
-    fetchClassInfo(entityType).then(
+    fetchClassInfoForDictionary(entityType, bsddDictionary.uri).then(
       (info) => {
         if (cancelled) return;
         setLoading(false);
@@ -136,7 +175,7 @@ export function BsddCard({
     return () => {
       cancelled = true;
     };
-  }, [entityType]);
+  }, [entityType, bsddDictionary.uri]);
 
   // `addedKeys` tracks what was added to THIS element, so it must reset when the
   // selection moves to a different element — even one of the same IfcType, which
@@ -371,12 +410,56 @@ export function BsddCard({
     [addedKeys],
   );
 
+  const isIfcDict = bsddDictionary.uri === IFC_DICTIONARY.uri;
+
+  // The picker offers every discovered dictionary, plus the currently-selected
+  // one if it isn't related to *this* entity type (so the dropdown still shows
+  // the active choice rather than silently snapping to IFC).
+  const dictionaryOptions = useMemo(() => {
+    const opts = [...dictionaries];
+    if (!opts.some((d) => d.uri === bsddDictionary.uri)) {
+      opts.push(bsddDictionary);
+    }
+    return opts;
+  }, [dictionaries, bsddDictionary]);
+
+  const handleDictChange = useCallback(
+    (uri: string) => {
+      const next = dictionaryOptions.find((d) => d.uri === uri);
+      if (next) setBsddDictionary(next);
+    },
+    [dictionaryOptions, setBsddDictionary],
+  );
+
+  // Source-dictionary picker — always rendered above the body so users can
+  // switch bSDDs in any state (loading / error / empty / populated). Issue #1219.
+  const dictionarySelector = (
+    <div className="flex items-center gap-1.5 px-1 pb-2">
+      <Library className="h-3.5 w-3.5 text-sky-500 shrink-0" />
+      <Select value={bsddDictionary.uri} onValueChange={handleDictChange}>
+        <SelectTrigger className="h-7 text-xs flex-1 min-w-0" aria-label="bSDD source dictionary">
+          <SelectValue placeholder="Select dictionary" />
+        </SelectTrigger>
+        <SelectContent>
+          {dictionaryOptions.map((d) => (
+            <SelectItem key={d.uri} value={d.uri} className="text-xs">
+              {d.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+
   // Loading state
   if (loading) {
     return (
-      <div className="flex items-center gap-2 px-3 py-6 text-xs text-zinc-400">
-        <Loader2 className="h-3.5 w-3.5 animate-spin" />
-        <span>Loading bSDD data for {entityType}...</span>
+      <div className="w-full min-w-0 overflow-hidden">
+        {dictionarySelector}
+        <div className="flex items-center gap-2 px-3 py-6 text-xs text-zinc-400">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          <span>Loading {bsddDictionary.name} data for {entityType}...</span>
+        </div>
       </div>
     );
   }
@@ -384,8 +467,11 @@ export function BsddCard({
   // Error state
   if (error) {
     return (
-      <div className="px-3 py-4 text-xs text-red-500/70">
-        <p>Could not load bSDD data: {error}</p>
+      <div className="w-full min-w-0 overflow-hidden">
+        {dictionarySelector}
+        <div className="px-3 py-4 text-xs text-red-500/70">
+          <p>Could not load bSDD data: {error}</p>
+        </div>
       </div>
     );
   }
@@ -393,15 +479,31 @@ export function BsddCard({
   // No data
   if (!classInfo || groupedProps.size === 0) {
     return (
-      <div className="flex flex-col items-center justify-center text-center px-4 py-8 text-xs text-zinc-400 gap-2">
-        <BookOpen className="h-6 w-6 text-zinc-300 dark:text-zinc-600" />
-        <p>No bSDD data available for <span className="font-mono font-medium">{entityType}</span></p>
+      <div className="w-full min-w-0 overflow-hidden">
+        {dictionarySelector}
+        <div className="flex flex-col items-center justify-center text-center px-4 py-8 text-xs text-zinc-400 gap-2">
+          <BookOpen className="h-6 w-6 text-zinc-300 dark:text-zinc-600" />
+          <p>
+            No <span className="font-medium">{bsddDictionary.name}</span> properties for{' '}
+            <span className="font-mono font-medium">{entityType}</span>
+          </p>
+          {!isIfcDict && (
+            <button
+              type="button"
+              onClick={() => setBsddDictionary(IFC_DICTIONARY)}
+              className="mt-1 text-sky-500 hover:text-sky-600 underline underline-offset-2"
+            >
+              Back to {IFC_DICTIONARY.name}
+            </button>
+          )}
+        </div>
       </div>
     );
   }
 
   return (
     <div className="space-y-2 w-full min-w-0 overflow-hidden">
+      {dictionarySelector}
       {/* Header with class description */}
       {classInfo.definition && (
         <div className="px-1 pb-1 text-[11px] text-zinc-500 dark:text-zinc-400 leading-relaxed">
@@ -553,10 +655,19 @@ export function BsddCard({
         );
       })}
 
-      {/* Footer link */}
+      {/* Footer link — browse the active class on bSDD. For IFC we can build
+          the URL from the entity name; other dictionaries reuse the resolved
+          class URI (identifier → search host). */}
       <div className="flex items-center justify-center pt-1 pb-1">
         <a
-          href={`https://search.bsdd.buildingsmart.org/uri/buildingsmart/ifc/4.3/class/${entityType}`}
+          href={
+            isIfcDict
+              ? `https://search.bsdd.buildingsmart.org/uri/buildingsmart/ifc/4.3/class/${entityType}`
+              : classInfo.uri.replace(
+                  'identifier.buildingsmart.org',
+                  'search.bsdd.buildingsmart.org',
+                )
+          }
           target="_blank"
           rel="noopener noreferrer"
           className="flex items-center gap-1 text-[10px] text-sky-500/70 hover:text-sky-600 transition-colors"

--- a/apps/viewer/src/services/bsdd.test.ts
+++ b/apps/viewer/src/services/bsdd.test.ts
@@ -6,9 +6,10 @@ import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
-  discoverDictionaries,
-  fetchClassInfoForDictionary,
+  fetchAllDictionaries,
+  searchDictionaryClasses,
   searchRelatedClasses,
+  fetchClassByUri,
   IFC_DICTIONARY,
 } from './bsdd.js';
 
@@ -45,33 +46,23 @@ afterEach(() => {
   globalThis.fetch = realFetch;
 });
 
-function searchRoute(ifcType: string, classes: Array<Record<string, unknown>>): Route {
-  return {
-    match: (url) => url.includes('/Class/Search/v1') && url.includes(`RelatedIfcEntities=${ifcType}`),
-    body: { classes },
-  };
-}
-
-function classRoute(classUri: string, classProperties: Array<Record<string, unknown>>): Route {
-  const needle = encodeURIComponent(classUri);
-  return {
-    match: (url) => url.includes('/Class/v1?') && url.includes(needle),
-    body: { uri: classUri, name: classUri, classProperties },
-  };
-}
-
 describe('searchRelatedClasses', () => {
-  it('maps the dictionaryName field from the API', async () => {
+  it('maps the dictionaryName + reference code from the API', async () => {
     routes = [
-      searchRoute('IfcWallS', [
-        {
-          uri: 'https://x/uri/myco/d/1/class/W',
-          name: 'Wall',
-          referenceCode: 'W',
-          dictionaryUri: 'https://x/uri/myco/d/1',
-          dictionaryName: 'MyCo Dictionary',
+      {
+        match: (url) => url.includes('/Class/Search/v1') && url.includes('RelatedIfcEntities=IfcWallS'),
+        body: {
+          classes: [
+            {
+              uri: 'https://x/uri/myco/d/1/class/W',
+              name: 'Wall',
+              referenceCode: 'W',
+              dictionaryUri: 'https://x/uri/myco/d/1',
+              dictionaryName: 'MyCo Dictionary',
+            },
+          ],
         },
-      ]),
+      },
     ];
     const results = await searchRelatedClasses('IfcWallS');
     assert.strictEqual(results.length, 1);
@@ -80,85 +71,85 @@ describe('searchRelatedClasses', () => {
   });
 });
 
-describe('discoverDictionaries', () => {
-  it('lists IFC first, drops the IFC dict from related results, dedups + sorts the rest', async () => {
-    const myco = 'https://x/uri/myco/d/1';
-    const uni = 'https://x/uri/nbs/uniclass2015/1';
+describe('searchDictionaryClasses', () => {
+  it('free-text searches within a single dictionary and maps results', async () => {
+    const dict = 'https://x/uri/etim/etim/10.1';
     routes = [
-      searchRoute('IfcWallD', [
-        // IFC dict entry must be filtered out (IFC is the implicit default)
-        { uri: `${IFC_DICTIONARY.uri}/class/IfcWallD`, dictionaryUri: IFC_DICTIONARY.uri, dictionaryName: 'IFC' },
-        { uri: `${uni}/class/EF_25`, dictionaryUri: uni, dictionaryName: 'Uniclass 2015' },
-        // MyCo appears twice — must dedup to a single option
-        { uri: `${myco}/class/A`, dictionaryUri: myco, dictionaryName: 'MyCo Dictionary' },
-        { uri: `${myco}/class/B`, dictionaryUri: myco, dictionaryName: 'MyCo Dictionary' },
-      ]),
+      {
+        // Must scope to the dictionary and carry the query text
+        match: (url) =>
+          url.includes('/Class/Search/v1') &&
+          url.includes(`DictionaryUris=${encodeURIComponent(dict)}`) &&
+          url.includes('SearchText=cable'),
+        body: {
+          classes: [
+            {
+              uri: `${dict}/class/EC000019`,
+              referenceCode: 'EC000019',
+              name: 'Coaxial cable',
+              dictionaryUri: dict,
+              dictionaryName: 'ETIM 10.1',
+            },
+          ],
+        },
+      },
     ];
-
-    const dicts = await discoverDictionaries('IfcWallD');
-    assert.deepStrictEqual(
-      dicts.map((d) => d.name),
-      [IFC_DICTIONARY.name, 'MyCo Dictionary', 'Uniclass 2015'],
-    );
-    assert.strictEqual(dicts[0].uri, IFC_DICTIONARY.uri);
+    const res = await searchDictionaryClasses(dict, 'cable');
+    assert.strictEqual(res.length, 1);
+    assert.strictEqual(res[0].code, 'EC000019');
+    assert.strictEqual(res[0].name, 'Coaxial cable');
   });
 
-  it('always returns at least the IFC dictionary', async () => {
-    routes = [searchRoute('IfcWallE', [])];
-    const dicts = await discoverDictionaries('IfcWallE');
-    assert.deepStrictEqual(dicts, [IFC_DICTIONARY]);
+  it('returns [] on API failure', async () => {
+    routes = []; // every request 404s
+    const res = await searchDictionaryClasses('https://x/uri/none/1', 'q');
+    assert.deepStrictEqual(res, []);
   });
 });
 
-describe('fetchClassInfoForDictionary', () => {
-  it('merges properties across a dictionary\'s related classes, deduped by pset:name', async () => {
-    const myco = 'https://x/uri/myco/dM/1';
-    const classA = `${myco}/class/A`;
-    const classB = `${myco}/class/B`;
+describe('fetchAllDictionaries', () => {
+  it('pins IFC first, drops a duplicate IFC entry, and sorts the rest by name+version', async () => {
     routes = [
-      searchRoute('IfcWallM', [
-        { uri: classA, dictionaryUri: myco, dictionaryName: 'MyCo' },
-        { uri: classB, dictionaryUri: myco, dictionaryName: 'MyCo' },
-      ]),
-      classRoute(classA, [
-        { name: 'P1', propertySet: 'Pset_X', dataType: 'String' },
-        { name: 'P2', propertySet: 'Pset_X', dataType: 'Real' },
-      ]),
-      classRoute(classB, [
-        // P1/Pset_X duplicates classA — must collapse to one
-        { name: 'P1', propertySet: 'Pset_X', dataType: 'String' },
-        { name: 'P3', propertySet: 'Pset_Y', dataType: 'Boolean' },
-      ]),
+      {
+        match: (url) => url.includes('/Dictionary/v1'),
+        body: {
+          dictionaries: [
+            // duplicate of the pinned IFC dictionary — must be dropped
+            { uri: IFC_DICTIONARY.uri, name: 'IFC', version: '4.3' },
+            { uri: 'https://x/uri/nbs/uniclass2015/1', name: 'Uniclass 2015' },
+            { uri: 'https://x/uri/etim/etim/10.1', name: 'ETIM', version: '10.1' },
+          ],
+        },
+      },
     ];
-
-    const info = await fetchClassInfoForDictionary('IfcWallM', myco);
-    assert.ok(info, 'expected merged class info');
+    const dicts = await fetchAllDictionaries();
+    assert.strictEqual(dicts[0].uri, IFC_DICTIONARY.uri);
     assert.deepStrictEqual(
-      info!.classProperties.map((p) => `${p.propertySet}:${p.name}`),
-      ['Pset_X:P1', 'Pset_X:P2', 'Pset_Y:P3'],
+      dicts.map((d) => d.name),
+      [IFC_DICTIONARY.name, 'ETIM 10.1', 'Uniclass 2015'],
     );
-    // Non-IFC properties must not be flagged as IFC-standard.
-    assert.ok(info!.classProperties.every((p) => p.isIfcStandard === false));
   });
+});
 
-  it('returns null when the dictionary has no related class for the type', async () => {
-    routes = [searchRoute('IfcWallN', [])];
-    const info = await fetchClassInfoForDictionary('IfcWallN', 'https://x/uri/empty/d/1');
-    assert.strictEqual(info, null);
-  });
-
-  it('delegates to the IFC name path when the IFC dictionary is selected', async () => {
-    const ifcUri = `${IFC_DICTIONARY.uri}/class/IfcWallI`;
+describe('fetchClassByUri', () => {
+  it('maps a non-IFC class\'s properties (not flagged IFC-standard)', async () => {
+    const uri = 'https://x/uri/etim/etim/10.1/class/EC000770';
     routes = [
-      classRoute(ifcUri, [
-        { name: 'IsExternal', propertySet: 'Pset_WallCommon', dataType: 'Boolean' },
-      ]),
+      {
+        match: (url) => url.includes('/Class/v1?') && url.includes(encodeURIComponent(uri)),
+        body: {
+          uri,
+          name: 'Separation plate',
+          classProperties: [
+            { name: 'Material', propertySet: 'Material', dataType: 'String' },
+            { name: 'Height', propertySet: 'Measurements', dataType: 'Real' },
+          ],
+        },
+      },
     ];
-    const info = await fetchClassInfoForDictionary('IfcWallI', IFC_DICTIONARY.uri);
-    assert.ok(info, 'expected IFC class info');
-    assert.strictEqual(info!.classProperties.length, 1);
-    assert.strictEqual(info!.classProperties[0].name, 'IsExternal');
-    // IFC-path properties are flagged as standard.
-    assert.strictEqual(info!.classProperties[0].isIfcStandard, true);
+    const info = await fetchClassByUri(uri);
+    assert.ok(info, 'expected class info');
+    assert.strictEqual(info!.classProperties.length, 2);
+    assert.ok(info!.classProperties.every((p) => p.isIfcStandard === false));
   });
 });

--- a/apps/viewer/src/services/bsdd.test.ts
+++ b/apps/viewer/src/services/bsdd.test.ts
@@ -1,0 +1,164 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  discoverDictionaries,
+  fetchClassInfoForDictionary,
+  searchRelatedClasses,
+  IFC_DICTIONARY,
+} from './bsdd.js';
+
+// ---------------------------------------------------------------------------
+// Minimal fetch stub. The bSDD service only reads `res.ok` and `res.json()`,
+// so a route table keyed on URL substrings is enough to drive it.
+// ---------------------------------------------------------------------------
+
+interface Route {
+  match: (url: string) => boolean;
+  body: Record<string, unknown>;
+}
+
+let routes: Route[] = [];
+const realFetch = globalThis.fetch;
+
+function installFetch() {
+  globalThis.fetch = (async (input: unknown) => {
+    const url = String(input);
+    const route = routes.find((r) => r.match(url));
+    if (!route) {
+      return { ok: false, status: 404, statusText: 'Not Found', json: async () => ({}) } as Response;
+    }
+    return { ok: true, status: 200, statusText: 'OK', json: async () => route.body } as Response;
+  }) as typeof fetch;
+}
+
+beforeEach(() => {
+  routes = [];
+  installFetch();
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function searchRoute(ifcType: string, classes: Array<Record<string, unknown>>): Route {
+  return {
+    match: (url) => url.includes('/Class/Search/v1') && url.includes(`RelatedIfcEntities=${ifcType}`),
+    body: { classes },
+  };
+}
+
+function classRoute(classUri: string, classProperties: Array<Record<string, unknown>>): Route {
+  const needle = encodeURIComponent(classUri);
+  return {
+    match: (url) => url.includes('/Class/v1?') && url.includes(needle),
+    body: { uri: classUri, name: classUri, classProperties },
+  };
+}
+
+describe('searchRelatedClasses', () => {
+  it('maps the dictionaryName field from the API', async () => {
+    routes = [
+      searchRoute('IfcWallS', [
+        {
+          uri: 'https://x/uri/myco/d/1/class/W',
+          name: 'Wall',
+          referenceCode: 'W',
+          dictionaryUri: 'https://x/uri/myco/d/1',
+          dictionaryName: 'MyCo Dictionary',
+        },
+      ]),
+    ];
+    const results = await searchRelatedClasses('IfcWallS');
+    assert.strictEqual(results.length, 1);
+    assert.strictEqual(results[0].dictionaryName, 'MyCo Dictionary');
+    assert.strictEqual(results[0].code, 'W');
+  });
+});
+
+describe('discoverDictionaries', () => {
+  it('lists IFC first, drops the IFC dict from related results, dedups + sorts the rest', async () => {
+    const myco = 'https://x/uri/myco/d/1';
+    const uni = 'https://x/uri/nbs/uniclass2015/1';
+    routes = [
+      searchRoute('IfcWallD', [
+        // IFC dict entry must be filtered out (IFC is the implicit default)
+        { uri: `${IFC_DICTIONARY.uri}/class/IfcWallD`, dictionaryUri: IFC_DICTIONARY.uri, dictionaryName: 'IFC' },
+        { uri: `${uni}/class/EF_25`, dictionaryUri: uni, dictionaryName: 'Uniclass 2015' },
+        // MyCo appears twice — must dedup to a single option
+        { uri: `${myco}/class/A`, dictionaryUri: myco, dictionaryName: 'MyCo Dictionary' },
+        { uri: `${myco}/class/B`, dictionaryUri: myco, dictionaryName: 'MyCo Dictionary' },
+      ]),
+    ];
+
+    const dicts = await discoverDictionaries('IfcWallD');
+    assert.deepStrictEqual(
+      dicts.map((d) => d.name),
+      [IFC_DICTIONARY.name, 'MyCo Dictionary', 'Uniclass 2015'],
+    );
+    assert.strictEqual(dicts[0].uri, IFC_DICTIONARY.uri);
+  });
+
+  it('always returns at least the IFC dictionary', async () => {
+    routes = [searchRoute('IfcWallE', [])];
+    const dicts = await discoverDictionaries('IfcWallE');
+    assert.deepStrictEqual(dicts, [IFC_DICTIONARY]);
+  });
+});
+
+describe('fetchClassInfoForDictionary', () => {
+  it('merges properties across a dictionary\'s related classes, deduped by pset:name', async () => {
+    const myco = 'https://x/uri/myco/dM/1';
+    const classA = `${myco}/class/A`;
+    const classB = `${myco}/class/B`;
+    routes = [
+      searchRoute('IfcWallM', [
+        { uri: classA, dictionaryUri: myco, dictionaryName: 'MyCo' },
+        { uri: classB, dictionaryUri: myco, dictionaryName: 'MyCo' },
+      ]),
+      classRoute(classA, [
+        { name: 'P1', propertySet: 'Pset_X', dataType: 'String' },
+        { name: 'P2', propertySet: 'Pset_X', dataType: 'Real' },
+      ]),
+      classRoute(classB, [
+        // P1/Pset_X duplicates classA — must collapse to one
+        { name: 'P1', propertySet: 'Pset_X', dataType: 'String' },
+        { name: 'P3', propertySet: 'Pset_Y', dataType: 'Boolean' },
+      ]),
+    ];
+
+    const info = await fetchClassInfoForDictionary('IfcWallM', myco);
+    assert.ok(info, 'expected merged class info');
+    assert.deepStrictEqual(
+      info!.classProperties.map((p) => `${p.propertySet}:${p.name}`),
+      ['Pset_X:P1', 'Pset_X:P2', 'Pset_Y:P3'],
+    );
+    // Non-IFC properties must not be flagged as IFC-standard.
+    assert.ok(info!.classProperties.every((p) => p.isIfcStandard === false));
+  });
+
+  it('returns null when the dictionary has no related class for the type', async () => {
+    routes = [searchRoute('IfcWallN', [])];
+    const info = await fetchClassInfoForDictionary('IfcWallN', 'https://x/uri/empty/d/1');
+    assert.strictEqual(info, null);
+  });
+
+  it('delegates to the IFC name path when the IFC dictionary is selected', async () => {
+    const ifcUri = `${IFC_DICTIONARY.uri}/class/IfcWallI`;
+    routes = [
+      classRoute(ifcUri, [
+        { name: 'IsExternal', propertySet: 'Pset_WallCommon', dataType: 'Boolean' },
+      ]),
+    ];
+    const info = await fetchClassInfoForDictionary('IfcWallI', IFC_DICTIONARY.uri);
+    assert.ok(info, 'expected IFC class info');
+    assert.strictEqual(info!.classProperties.length, 1);
+    assert.strictEqual(info!.classProperties[0].name, 'IsExternal');
+    // IFC-path properties are flagged as standard.
+    assert.strictEqual(info!.classProperties[0].isIfcStandard, true);
+  });
+});

--- a/apps/viewer/src/services/bsdd.test.ts
+++ b/apps/viewer/src/services/bsdd.test.ts
@@ -7,6 +7,7 @@ import assert from 'node:assert/strict';
 
 import {
   fetchAllDictionaries,
+  listDictionaryClasses,
   searchDictionaryClasses,
   searchRelatedClasses,
   fetchClassByUri,
@@ -104,6 +105,40 @@ describe('searchDictionaryClasses', () => {
     routes = []; // every request 404s
     const res = await searchDictionaryClasses('https://x/uri/none/1', 'q');
     assert.deepStrictEqual(res, []);
+  });
+});
+
+describe('listDictionaryClasses', () => {
+  it('paginates a dictionary\'s classes and reports the total', async () => {
+    const dict = 'https://x/uri/etim/etim/10.1';
+    routes = [
+      {
+        match: (url) =>
+          url.includes('/Dictionary/v1/Classes') &&
+          url.includes(`Uri=${encodeURIComponent(dict)}`) &&
+          url.includes('Offset=50'),
+        body: {
+          // the list endpoint omits dictionaryUri per class — service folds it in
+          classes: [
+            { uri: `${dict}/class/EC000051`, code: 'EC000051', name: 'Cable tray' },
+          ],
+          classesTotalCount: 5799,
+          classesOffset: 50,
+        },
+      },
+    ];
+    const page = await listDictionaryClasses(dict, 50, 50);
+    assert.strictEqual(page.total, 5799);
+    assert.strictEqual(page.offset, 50);
+    assert.strictEqual(page.classes.length, 1);
+    assert.strictEqual(page.classes[0].code, 'EC000051');
+    assert.strictEqual(page.classes[0].dictionaryUri, dict);
+  });
+
+  it('returns an empty page on API failure', async () => {
+    routes = [];
+    const page = await listDictionaryClasses('https://x/uri/none/1', 0, 50);
+    assert.deepStrictEqual(page, { classes: [], total: 0, offset: 0 });
   });
 });
 

--- a/apps/viewer/src/services/bsdd.ts
+++ b/apps/viewer/src/services/bsdd.ts
@@ -19,6 +19,17 @@ const BSDD_API = '/api/bsdd';
 const IFC_DICTIONARY_URI =
   'https://identifier.buildingsmart.org/uri/buildingsmart/ifc/4.3';
 
+/**
+ * The buildingSMART IFC 4.3 dictionary — the default source the bSDD card
+ * reads property templates (Pset_* / Qto_*) and entity attributes from.
+ * Other dictionaries (Uniclass, ETIM, a company's own published bSDD, …)
+ * are discovered per entity type via {@link discoverDictionaries}.
+ */
+export const IFC_DICTIONARY: BsddDictionary = {
+  uri: IFC_DICTIONARY_URI,
+  name: 'IFC 4.3',
+};
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -65,6 +76,17 @@ export interface BsddSearchResult {
   name: string;
   definition: string | null;
   dictionaryUri: string;
+  /** Human-readable name of the dictionary this class belongs to */
+  dictionaryName: string;
+}
+
+/**
+ * A bSDD dictionary the user can read property definitions from.
+ * `uri` is the canonical dictionary identifier; `name` is for display.
+ */
+export interface BsddDictionary {
+  uri: string;
+  name: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -168,12 +190,12 @@ export async function fetchClassInfo(
   if (cached) return cached;
 
   try {
-    // Parameter names must be PascalCase per the bSDD OpenAPI spec
-    let raw: Record<string, unknown>;
+    // The IFC dictionary is keyed by class name, so we can address the class
+    // directly by URI. If that 404s (e.g. an unusual subtype name) fall back
+    // to a name search that resolves the canonical class URI.
+    let info: BsddClassInfo;
     try {
-      raw = await fetchJson<Record<string, unknown>>(
-        `${BSDD_API}/api/Class/v1?Uri=${encodeURIComponent(uri)}&IncludeClassProperties=true&IncludeClassRelations=true`,
-      );
+      info = await fetchClassDetail(uri, true);
     } catch {
       const fallbackUri = await resolveFallbackClassUri(ifcType);
       if (!fallbackUri || fallbackUri === uri) {
@@ -182,44 +204,7 @@ export async function fetchClassInfo(
       uri = fallbackUri;
       const fallbackCached = getCached(uri);
       if (fallbackCached) return fallbackCached;
-      raw = await fetchJson<Record<string, unknown>>(
-        `${BSDD_API}/api/Class/v1?Uri=${encodeURIComponent(uri)}&IncludeClassProperties=true&IncludeClassRelations=true`,
-      );
-    }
-
-    let info = mapClassResponse(raw, true);
-
-    // Fallback: if inline classProperties came back empty, try the
-    // dedicated paginated properties endpoint
-    if (info.classProperties.length === 0) {
-      const propsRaw = await fetchJson<Record<string, unknown>>(
-        `${BSDD_API}/api/Class/Properties/v1?ClassUri=${encodeURIComponent(uri)}`,
-      ).catch(() => null);
-
-      if (propsRaw) {
-        const propsList = propsRaw.classProperties as Array<Record<string, unknown>> | undefined;
-        if (propsList && propsList.length > 0) {
-          info = {
-            ...info,
-            classProperties: propsList.map((p) => ({
-              name: String(p.name ?? p.propertyCode ?? ''),
-              uri: String(p.propertyUri ?? p.uri ?? ''),
-              description: p.description ? String(p.description) : null,
-              dataType: p.dataType ? String(p.dataType) : null,
-              propertySet: p.propertySet ? String(p.propertySet) : null,
-              allowedValues: Array.isArray(p.allowedValues)
-                ? p.allowedValues.map((v: Record<string, unknown>) => ({
-                    uri: v.uri ? String(v.uri) : undefined,
-                    value: String(v.value ?? ''),
-                    description: v.description ? String(v.description) : undefined,
-                  }))
-                : null,
-              units: Array.isArray(p.units) ? (p.units as string[]) : null,
-              isIfcStandard: true,
-            })),
-          };
-        }
-      }
+      info = await fetchClassDetail(uri, true);
     }
 
     setCache(uri, info);
@@ -231,11 +216,72 @@ export async function fetchClassInfo(
 }
 
 /**
+ * Fetch a single class (with its properties) by full bSDD URI, regardless of
+ * which dictionary it belongs to. Throws on HTTP failure so callers can
+ * distinguish "missing" from "errored".
+ *
+ * `isIfcStandard` flags the resulting properties as coming from the IFC
+ * standard dictionary (drives the badge in the UI).
+ */
+async function fetchClassDetail(
+  uri: string,
+  isIfcStandard: boolean,
+): Promise<BsddClassInfo> {
+  // Parameter names must be PascalCase per the bSDD OpenAPI spec
+  const raw = await fetchJson<Record<string, unknown>>(
+    `${BSDD_API}/api/Class/v1?Uri=${encodeURIComponent(uri)}&IncludeClassProperties=true&IncludeClassRelations=true`,
+  );
+
+  let info = mapClassResponse(raw, isIfcStandard);
+
+  // Fallback: if inline classProperties came back empty, try the dedicated
+  // paginated properties endpoint. Network failures here are non-fatal — the
+  // primary call already succeeded, so keep the (property-less) result.
+  if (info.classProperties.length === 0) {
+    const propsRaw = await fetchJson<Record<string, unknown>>(
+      `${BSDD_API}/api/Class/Properties/v1?ClassUri=${encodeURIComponent(uri)}`,
+    ).catch(() => null);
+
+    if (propsRaw) {
+      const propsList = propsRaw.classProperties as Array<Record<string, unknown>> | undefined;
+      if (propsList && propsList.length > 0) {
+        info = {
+          ...info,
+          classProperties: propsList.map((p) => mapProperty(p, isIfcStandard)),
+        };
+      }
+    }
+  }
+
+  return info;
+}
+
+/**
+ * Fetch full class info (including properties) by full bSDD class URI.
+ * Used for non-IFC dictionaries (Uniclass, ETIM, a company's own bSDD, …)
+ * where classes are addressed by URI rather than by IFC type name.
+ */
+export async function fetchClassByUri(
+  classUri: string,
+  isIfcStandard = false,
+): Promise<BsddClassInfo | null> {
+  const cached = getCached(classUri);
+  if (cached) return cached;
+  try {
+    const info = await fetchClassDetail(classUri, isIfcStandard);
+    setCache(classUri, info);
+    return info;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Search bSDD for classes related to a given IFC entity type across all
  * dictionaries (not just the IFC dictionary).
  *
  * Uses `/api/Class/Search/v1` with a RelatedIfcEntities filter.
- * Returns lightweight results. Call `fetchClassInfo` on a specific result
+ * Returns lightweight results. Call `fetchClassByUri` on a specific result
  * to get full properties.
  */
 export async function searchRelatedClasses(
@@ -249,19 +295,136 @@ export async function searchRelatedClasses(
     );
     return (raw.classes ?? []).map((c) => ({
       uri: String(c.uri ?? ''),
-      code: String(c.code ?? c.name ?? ''),
+      code: String(c.code ?? c.referenceCode ?? c.name ?? ''),
       name: String(c.name ?? ''),
       definition: c.definition ? String(c.definition) : null,
       dictionaryUri: String(c.dictionaryUri ?? ''),
+      dictionaryName: String(c.dictionaryName ?? c.dictionaryUri ?? ''),
     }));
   } catch {
     return [];
   }
 }
 
+/**
+ * Discover which dictionaries hold classes related to an IFC entity type.
+ *
+ * The IFC dictionary is always offered first (it is the implicit default and
+ * the only one addressed by class name). The rest are derived from the
+ * RelatedIfcEntities search — these are the "other bSDDs" (Uniclass, ETIM, a
+ * company's own published dictionary, …) a user can switch the card to.
+ *
+ * Returned dictionaries are de-duplicated by URI and sorted by name, IFC first.
+ */
+export async function discoverDictionaries(
+  ifcType: string,
+): Promise<BsddDictionary[]> {
+  const related = await searchRelatedClasses(ifcType);
+  const byUri = new Map<string, BsddDictionary>();
+  for (const c of related) {
+    if (!c.dictionaryUri || c.dictionaryUri === IFC_DICTIONARY_URI) continue;
+    if (!byUri.has(c.dictionaryUri)) {
+      byUri.set(c.dictionaryUri, {
+        uri: c.dictionaryUri,
+        name: c.dictionaryName || c.dictionaryUri,
+      });
+    }
+  }
+  const others = Array.from(byUri.values()).sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+  return [IFC_DICTIONARY, ...others];
+}
+
+/**
+ * Fetch class info for an IFC entity type from a chosen dictionary.
+ *
+ * For the IFC dictionary this is the standard {@link fetchClassInfo} path.
+ * For any other dictionary, the entity type has no class-by-name URI, so we
+ * find the dictionary's class(es) that declare `RelatedIfcEntities = ifcType`,
+ * fetch each one's properties, and merge them into a single result (a
+ * dictionary may map several of its classes onto the same IFC entity).
+ *
+ * Returns null when the dictionary has no related class for this type, or
+ * when none of the related classes carry any properties.
+ */
+export async function fetchClassInfoForDictionary(
+  ifcType: string,
+  dictionaryUri: string,
+): Promise<BsddClassInfo | null> {
+  if (!dictionaryUri || dictionaryUri === IFC_DICTIONARY_URI) {
+    return fetchClassInfo(ifcType);
+  }
+
+  const cacheKey = `${dictionaryUri}::${ifcType}`;
+  const cached = getCached(cacheKey);
+  if (cached) return cached;
+
+  const related = await searchRelatedClasses(ifcType);
+  const inDict = related.filter((c) => c.dictionaryUri === dictionaryUri && c.uri);
+  if (inDict.length === 0) return null;
+
+  const details = await Promise.all(
+    inDict.map((c) => fetchClassByUri(c.uri, false)),
+  );
+
+  // Merge every related class's properties into one view, de-duplicating by
+  // "propertySet:name" so a property shared across the dictionary's classes
+  // is only offered once.
+  const seen = new Set<string>();
+  const merged: BsddClassProperty[] = [];
+  for (const detail of details) {
+    if (!detail) continue;
+    for (const prop of detail.classProperties) {
+      const key = `${prop.propertySet ?? ''}:${prop.name}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      merged.push(prop);
+    }
+  }
+
+  if (merged.length === 0) return null;
+
+  const primary = inDict[0];
+  const info: BsddClassInfo = {
+    uri: primary.uri,
+    code: primary.code,
+    name: primary.name,
+    definition: details.find((d) => d?.definition)?.definition ?? primary.definition,
+    parentClassUri: null,
+    classProperties: merged,
+    relatedIfcEntityNames: [ifcType],
+  };
+
+  setCache(cacheKey, info);
+  return info;
+}
+
 // ---------------------------------------------------------------------------
 // Response mapping
 // ---------------------------------------------------------------------------
+
+function mapProperty(
+  p: Record<string, unknown>,
+  isIfcStandard: boolean,
+): BsddClassProperty {
+  return {
+    name: String(p.name ?? p.propertyCode ?? ''),
+    uri: String(p.propertyUri ?? p.uri ?? ''),
+    description: p.description ? String(p.description) : null,
+    dataType: p.dataType ? String(p.dataType) : null,
+    propertySet: p.propertySet ? String(p.propertySet) : null,
+    allowedValues: Array.isArray(p.allowedValues)
+      ? p.allowedValues.map((v: Record<string, unknown>) => ({
+          uri: v.uri ? String(v.uri) : undefined,
+          value: String(v.value ?? ''),
+          description: v.description ? String(v.description) : undefined,
+        }))
+      : null,
+    units: Array.isArray(p.units) ? (p.units as string[]) : null,
+    isIfcStandard,
+  };
+}
 
 function mapClassResponse(
   raw: Record<string, unknown>,
@@ -278,22 +441,7 @@ function mapClassResponse(
       ? String((raw.parentClassReference as Record<string, unknown>).uri ?? '')
       : null,
     relatedIfcEntityNames: raw.relatedIfcEntityNames as string[] | null,
-    classProperties: (props ?? []).map((p) => ({
-      name: String(p.name ?? p.propertyCode ?? ''),
-      uri: String(p.propertyUri ?? p.uri ?? ''),
-      description: p.description ? String(p.description) : null,
-      dataType: p.dataType ? String(p.dataType) : null,
-      propertySet: p.propertySet ? String(p.propertySet) : null,
-      allowedValues: Array.isArray(p.allowedValues)
-        ? p.allowedValues.map((v: Record<string, unknown>) => ({
-            uri: v.uri ? String(v.uri) : undefined,
-            value: String(v.value ?? ''),
-            description: v.description ? String(v.description) : undefined,
-          }))
-        : null,
-      units: Array.isArray(p.units) ? (p.units as string[]) : null,
-      isIfcStandard,
-    })),
+    classProperties: (props ?? []).map((p) => mapProperty(p, isIfcStandard)),
   };
 }
 

--- a/apps/viewer/src/services/bsdd.ts
+++ b/apps/viewer/src/services/bsdd.ts
@@ -293,111 +293,78 @@ export async function searchRelatedClasses(
     }>(
       `${BSDD_API}/api/Class/Search/v1?SearchText=${encodeURIComponent(ifcType)}&RelatedIfcEntities=${encodeURIComponent(ifcType)}`,
     );
-    return (raw.classes ?? []).map((c) => ({
-      uri: String(c.uri ?? ''),
-      code: String(c.code ?? c.referenceCode ?? c.name ?? ''),
-      name: String(c.name ?? ''),
-      definition: c.definition ? String(c.definition) : null,
-      dictionaryUri: String(c.dictionaryUri ?? ''),
-      dictionaryName: String(c.dictionaryName ?? c.dictionaryUri ?? ''),
-    }));
+    return (raw.classes ?? []).map(mapSearchResult);
   } catch {
     return [];
   }
 }
 
-/**
- * Discover which dictionaries hold classes related to an IFC entity type.
- *
- * The IFC dictionary is always offered first (it is the implicit default and
- * the only one addressed by class name). The rest are derived from the
- * RelatedIfcEntities search — these are the "other bSDDs" (Uniclass, ETIM, a
- * company's own published dictionary, …) a user can switch the card to.
- *
- * Returned dictionaries are de-duplicated by URI and sorted by name, IFC first.
- */
-export async function discoverDictionaries(
-  ifcType: string,
-): Promise<BsddDictionary[]> {
-  const related = await searchRelatedClasses(ifcType);
-  const byUri = new Map<string, BsddDictionary>();
-  for (const c of related) {
-    if (!c.dictionaryUri || c.dictionaryUri === IFC_DICTIONARY_URI) continue;
-    if (!byUri.has(c.dictionaryUri)) {
-      byUri.set(c.dictionaryUri, {
-        uri: c.dictionaryUri,
-        name: c.dictionaryName || c.dictionaryUri,
-      });
-    }
-  }
-  const others = Array.from(byUri.values()).sort((a, b) =>
-    a.name.localeCompare(b.name),
-  );
-  return [IFC_DICTIONARY, ...others];
+function mapSearchResult(c: Record<string, unknown>): BsddSearchResult {
+  return {
+    uri: String(c.uri ?? ''),
+    code: String(c.code ?? c.referenceCode ?? c.name ?? ''),
+    name: String(c.name ?? ''),
+    definition: c.definition ? String(c.definition) : null,
+    dictionaryUri: String(c.dictionaryUri ?? ''),
+    dictionaryName: String(c.dictionaryName ?? c.dictionaryUri ?? ''),
+  };
 }
 
 /**
- * Fetch class info for an IFC entity type from a chosen dictionary.
+ * Search a single dictionary's classes by free text.
  *
- * For the IFC dictionary this is the standard {@link fetchClassInfo} path.
- * For any other dictionary, the entity type has no class-by-name URI, so we
- * find the dictionary's class(es) that declare `RelatedIfcEntities = ifcType`,
- * fetch each one's properties, and merge them into a single result (a
- * dictionary may map several of its classes onto the same IFC entity).
- *
- * Returns null when the dictionary has no related class for this type, or
- * when none of the related classes carry any properties.
+ * Backs the bSDD card's class picker for non-IFC dictionaries: rather than
+ * guessing a class from the IFC entity type (which dead-ends on property-less
+ * classification entries), the user searches the dictionary directly and picks
+ * the class whose properties they want. An empty query returns the
+ * dictionary's first page of classes (issue #1219).
  */
-export async function fetchClassInfoForDictionary(
-  ifcType: string,
+export async function searchDictionaryClasses(
   dictionaryUri: string,
-): Promise<BsddClassInfo | null> {
-  if (!dictionaryUri || dictionaryUri === IFC_DICTIONARY_URI) {
-    return fetchClassInfo(ifcType);
+  query: string,
+): Promise<BsddSearchResult[]> {
+  try {
+    const raw = await fetchJson<{ classes?: Array<Record<string, unknown>> }>(
+      `${BSDD_API}/api/Class/Search/v1?SearchText=${encodeURIComponent(query)}&DictionaryUris=${encodeURIComponent(dictionaryUri)}`,
+    );
+    return (raw.classes ?? []).map(mapSearchResult);
+  } catch {
+    return [];
   }
+}
 
-  const cacheKey = `${dictionaryUri}::${ifcType}`;
-  const cached = getCached(cacheKey);
-  if (cached) return cached;
+// Session cache for the dictionary catalogue — it changes rarely and a full
+// fetch is ~400 entries, so we keep it for the lifetime of the page.
+let dictionaryCatalogue: BsddDictionary[] | null = null;
 
-  const related = await searchRelatedClasses(ifcType);
-  const inDict = related.filter((c) => c.dictionaryUri === dictionaryUri && c.uri);
-  if (inDict.length === 0) return null;
-
-  const details = await Promise.all(
-    inDict.map((c) => fetchClassByUri(c.uri, false)),
-  );
-
-  // Merge every related class's properties into one view, de-duplicating by
-  // "propertySet:name" so a property shared across the dictionary's classes
-  // is only offered once.
-  const seen = new Set<string>();
-  const merged: BsddClassProperty[] = [];
-  for (const detail of details) {
-    if (!detail) continue;
-    for (const prop of detail.classProperties) {
-      const key = `${prop.propertySet ?? ''}:${prop.name}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-      merged.push(prop);
+/**
+ * Fetch the full catalogue of bSDD dictionaries for the source-dictionary
+ * picker. IFC 4.3 is pinned first; the rest follow sorted by display name
+ * (name + version, so multiple versions of one dictionary stay distinct).
+ * Falls back to just the IFC dictionary if the catalogue can't be loaded.
+ */
+export async function fetchAllDictionaries(): Promise<BsddDictionary[]> {
+  if (dictionaryCatalogue) return dictionaryCatalogue;
+  try {
+    const raw = await fetchJson<{ dictionaries?: Array<Record<string, unknown>> }>(
+      `${BSDD_API}/api/Dictionary/v1?Limit=1000`,
+    );
+    const seen = new Set<string>([IFC_DICTIONARY_URI]);
+    const others: BsddDictionary[] = [];
+    for (const d of raw.dictionaries ?? []) {
+      const uri = String(d.uri ?? '');
+      if (!uri || seen.has(uri)) continue;
+      seen.add(uri);
+      const name = String(d.name ?? uri);
+      const version = d.version ? String(d.version) : '';
+      others.push({ uri, name: version ? `${name} ${version}` : name });
     }
+    others.sort((a, b) => a.name.localeCompare(b.name));
+    dictionaryCatalogue = [IFC_DICTIONARY, ...others];
+    return dictionaryCatalogue;
+  } catch {
+    return [IFC_DICTIONARY];
   }
-
-  if (merged.length === 0) return null;
-
-  const primary = inDict[0];
-  const info: BsddClassInfo = {
-    uri: primary.uri,
-    code: primary.code,
-    name: primary.name,
-    definition: details.find((d) => d?.definition)?.definition ?? primary.definition,
-    parentClassUri: null,
-    classProperties: merged,
-    relatedIfcEntityNames: [ifcType],
-  };
-
-  setCache(cacheKey, info);
-  return info;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/viewer/src/services/bsdd.ts
+++ b/apps/viewer/src/services/bsdd.ts
@@ -310,14 +310,56 @@ function mapSearchResult(c: Record<string, unknown>): BsddSearchResult {
   };
 }
 
+/** One page of a dictionary's class list. */
+export interface BsddClassPage {
+  classes: BsddSearchResult[];
+  /** Total number of classes in the dictionary (for the whole list). */
+  total: number;
+  /** Offset this page started at. */
+  offset: number;
+}
+
+/**
+ * List a dictionary's classes, paginated, for browsing (issue #1219).
+ *
+ * Uses `/api/Dictionary/v1/Classes`, which — unlike the free-text search
+ * endpoint — accepts `Offset`/`Limit` and reports `classesTotalCount`. This
+ * lets the bSDD card show a scrollable list the user pages through (a single
+ * dictionary can hold thousands of classes, so we never fetch them all at
+ * once). For text filtering use {@link searchDictionaryClasses} instead.
+ */
+export async function listDictionaryClasses(
+  dictionaryUri: string,
+  offset: number,
+  limit: number,
+): Promise<BsddClassPage> {
+  try {
+    const raw = await fetchJson<{
+      classes?: Array<Record<string, unknown>>;
+      classesTotalCount?: number;
+      classesOffset?: number;
+    }>(
+      `${BSDD_API}/api/Dictionary/v1/Classes?Uri=${encodeURIComponent(dictionaryUri)}&Offset=${offset}&Limit=${limit}`,
+    );
+    return {
+      // The list endpoint omits dictionaryUri on each class; fold it back in.
+      classes: (raw.classes ?? []).map((c) => mapSearchResult({ dictionaryUri, ...c })),
+      total: Number(raw.classesTotalCount ?? 0),
+      offset: Number(raw.classesOffset ?? offset),
+    };
+  } catch {
+    return { classes: [], total: 0, offset };
+  }
+}
+
 /**
  * Search a single dictionary's classes by free text.
  *
- * Backs the bSDD card's class picker for non-IFC dictionaries: rather than
- * guessing a class from the IFC entity type (which dead-ends on property-less
- * classification entries), the user searches the dictionary directly and picks
- * the class whose properties they want. An empty query returns the
- * dictionary's first page of classes (issue #1219).
+ * Backs the bSDD card's class filter for non-IFC dictionaries: the user types
+ * to narrow the browsable list to matching classes. The free-text search
+ * endpoint does not honour `Offset`/`Limit`, so this returns the API's single
+ * (large) result page; browsing the full unfiltered list is paginated via
+ * {@link listDictionaryClasses} (issue #1219).
  */
 export async function searchDictionaryClasses(
   dictionaryUri: string,

--- a/apps/viewer/src/store/constants.ts
+++ b/apps/viewer/src/store/constants.ts
@@ -7,6 +7,7 @@
  */
 
 import type { TypeVisibility } from './types.js';
+import { IFC_DICTIONARY, type BsddDictionary } from '../services/bsdd.js';
 
 // ============================================================================
 // Camera Defaults
@@ -151,6 +152,34 @@ export function getGeomWorkerOverride(): number | undefined {
   return undefined;
 }
 
+/**
+ * localStorage key for the bSDD source-dictionary preference (issue #1219).
+ * Stores a JSON `{ uri, name }` so the friendly dictionary name survives a
+ * reload without re-querying the bSDD API. The chosen dictionary is the one
+ * the Properties → bSDD card reads property definitions from; default IFC 4.3.
+ */
+export const BSDD_DICTIONARY_STORAGE_KEY = 'ifc-lite-bsdd-dictionary';
+
+/**
+ * Resolve the persisted bSDD source dictionary, defaulting to IFC 4.3.
+ * A malformed or partial stored value falls back to the IFC default rather
+ * than throwing — the preference is non-critical UI state.
+ */
+function getInitialBsddDictionary(): BsddDictionary {
+  if (typeof window === 'undefined') return IFC_DICTIONARY;
+  try {
+    const raw = localStorage.getItem(BSDD_DICTIONARY_STORAGE_KEY);
+    if (!raw) return IFC_DICTIONARY;
+    const parsed = JSON.parse(raw) as Partial<BsddDictionary>;
+    if (parsed && typeof parsed.uri === 'string' && parsed.uri) {
+      return { uri: parsed.uri, name: parsed.name || parsed.uri };
+    }
+  } catch {
+    /* SSR / blocked storage / malformed JSON — use the IFC default */
+  }
+  return IFC_DICTIONARY;
+}
+
 export const UI_DEFAULTS = {
   /** Default active tool */
   ACTIVE_TOOL: 'select',
@@ -185,6 +214,12 @@ export const UI_DEFAULTS = {
    * reloads. Default `false` keeps existing per-layer rendering.
    */
   MERGE_LAYERS: getInitialMergeLayers(),
+  /**
+   * Issue #1219: the bSDD source dictionary the Properties → bSDD card reads
+   * property definitions from. Persisted so a user who works against their own
+   * (or a non-IFC) dictionary keeps that choice between sessions.
+   */
+  BSDD_DICTIONARY: getInitialBsddDictionary(),
 } as const;
 
 // ============================================================================

--- a/apps/viewer/src/store/slices/uiSlice.ts
+++ b/apps/viewer/src/store/slices/uiSlice.ts
@@ -7,7 +7,8 @@
  */
 
 import type { StateCreator } from 'zustand';
-import { MERGE_LAYERS_STORAGE_KEY, UI_DEFAULTS } from '../constants.js';
+import { BSDD_DICTIONARY_STORAGE_KEY, MERGE_LAYERS_STORAGE_KEY, UI_DEFAULTS } from '../constants.js';
+import type { BsddDictionary } from '../../services/bsdd.js';
 import type { ContactShadingQuality, SeparationLinesQuality } from '@ifc-lite/renderer';
 import type { FederatedModel } from '../types.js';
 import type { GeometryResult } from '@ifc-lite/geometry';
@@ -85,6 +86,10 @@ export interface UISlice {
   /** One-shot "scroll to + highlight + edit this property" request, armed by
    *  the bSDD add flow and consumed by the Properties panel. Null when idle. */
   pendingPropertyFocus: PropertyFocusTarget | null;
+  /** The bSDD source dictionary the Properties → bSDD card reads property
+   *  definitions from. Lets users work against a non-IFC / their own bSDD.
+   *  Persisted to localStorage; default IFC 4.3 (issue #1219). */
+  bsddDictionary: BsddDictionary;
   theme: ThemeMode;
   isMobile: boolean;
   hoverTooltipsEnabled: boolean;
@@ -117,6 +122,8 @@ export interface UISlice {
   setPropertiesActiveTab: (tab: 'properties' | 'quantities' | 'bsdd' | 'raw-step') => void;
   /** Arm (or clear, with null) the one-shot property-focus request. */
   setPendingPropertyFocus: (focus: PropertyFocusTarget | null) => void;
+  /** Choose the bSDD source dictionary; persisted to localStorage. */
+  setBsddDictionary: (dict: BsddDictionary) => void;
   setTheme: (theme: ThemeMode) => void;
   toggleTheme: () => void;
   /** Shift+click secret: toggle colorful mode on/off */
@@ -165,6 +172,7 @@ export const createUISlice: StateCreator<UISlice & UICrossSliceState, [], [], UI
   editEnabled: false,
   propertiesActiveTab: 'properties',
   pendingPropertyFocus: null,
+  bsddDictionary: UI_DEFAULTS.BSDD_DICTIONARY,
   theme: UI_DEFAULTS.THEME,
   isMobile: false,
   hoverTooltipsEnabled: UI_DEFAULTS.HOVER_TOOLTIPS_ENABLED,
@@ -229,6 +237,18 @@ export const createUISlice: StateCreator<UISlice & UICrossSliceState, [], [], UI
   setPropertiesActiveTab: (propertiesActiveTab) => set({ propertiesActiveTab }),
 
   setPendingPropertyFocus: (pendingPropertyFocus) => set({ pendingPropertyFocus }),
+
+  setBsddDictionary: (bsddDictionary) => {
+    // Persist eagerly so the choice (and its display name) survives a reload
+    // via `getInitialBsddDictionary` (constants.ts). Wrap in try/catch —
+    // Safari private mode / locked storage throws.
+    try {
+      localStorage.setItem(BSDD_DICTIONARY_STORAGE_KEY, JSON.stringify(bsddDictionary));
+    } catch {
+      /* storage unavailable — accept the in-memory choice silently */
+    }
+    set({ bsddDictionary });
+  },
 
   setTheme: (theme) => {
     applyThemeClasses(theme);


### PR DESCRIPTION
Closes #1219.

## Problem
The Properties → bSDD card was hardwired to the buildingSMART **IFC 4.3** dictionary. Users working against another bSDD — Uniclass, ETIM, NL-SfB, or their own published dictionary — had no way to surface its property definitions.

## What this does
Two pickers at the top of the bSDD card:

1. **Dictionary picker** — a searchable field over the **entire** bSDD catalogue (`fetchAllDictionaries`, ~400 dictionaries, one cached call). IFC 4.3 pinned first; the rest sorted by name+version. Browsable by scrolling or filter-by-typing.
2. **Class browser** (shown for a non-IFC dictionary) — a **scrollable, paginated list** of that dictionary's classes that you browse without having to know what to search for. It loads the next page as you scroll (infinite scroll), and a filter box narrows it. Picking a class loads its property sets into the existing one-click **add-to-element** flow.

IFC behaviour is unchanged — still the default, resolved by entity-type name. The chosen dictionary **persists to `localStorage`**.

## API design (pagination)
- **Browse** uses `GET /api/Dictionary/v1/Classes?Uri=&Offset=&Limit=`, which honours `Offset`/`Limit` and returns `classesTotalCount` — so a 5,799-class dictionary like ETIM is paged 50 at a time, never fetched whole.
- **Filter** uses `GET /api/Class/Search/v1?SearchText=&DictionaryUris=` (this endpoint ignores `Offset`/`Limit`, so it returns its single result page).
- A monotonic request token discards any in-flight page whose dictionary/filter changed before it resolved.

## Changes
- `services/bsdd.ts` — `BsddDictionary` type + `IFC_DICTIONARY`, `dictionaryName` on results, `fetchClassByUri`, `fetchAllDictionaries`, `listDictionaryClasses` (paginated), `searchDictionaryClasses`; shared `mapProperty`/`mapSearchResult`/`fetchClassDetail`.
- `store/constants.ts` + `store/slices/uiSlice.ts` — persisted `bsddDictionary` state + setter (default IFC 4.3).
- `components/viewer/properties/BsddCard.tsx` — the dictionary picker + paginated class browser + class-aware empty states.
- `services/bsdd.test.ts` — unit tests.

## Verification
- **7 service unit tests** pass (related-class mapping, in-dictionary search + failure, **paginated list + total + failure**, dictionary catalogue pin/dedup/sort, non-IFC class property mapping).
- Viewer `tsc --noEmit`: **0 errors** (against built workspace deps).
- **360/360** bSDD + store + uiSlice tests pass.
- **Live walkthrough** (building-architecture.ifc → IfcWall → bSDD tab): IFC shows 25 psets; switching to ETIM 10.1 browses *"Showing 50 of 5799 · scroll for more"*, pages to 100 on scroll, filters to 18 on "cable tray", and a picked class renders its property groups.

> Note: the bSDD API rate-limits (HTTP 429) under bursts; the viewer service currently treats any non-OK response as "no data", so heavy use can transiently show "No properties". Pre-existing behaviour (affects the IFC path too) — flagged for a possible follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now select and browse bSDD dictionaries beyond IFC using a searchable dictionary picker.
  * Added a paginated, scrollable class browser for exploring non-IFC dictionary classes.
  * Selected dictionary preference is persisted locally for consistent experience across sessions.

* **Tests**
  * Added comprehensive test suite for bSDD service functions and API interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->