### PR TITLE
feat(viewer): select all elements in a compare group via section header

### DIFF
--- a/apps/viewer/src/components/viewer/ComparePanel.tsx
+++ b/apps/viewer/src/components/viewer/ComparePanel.tsx
@@ -146,6 +146,24 @@ export function ComparePanel({ onClose }: ComparePanelProps) {
     requestAnimationFrame(() => state.cameraCallbacks.frameSelection?.());
   };
 
+  // Select every element in a state bucket at once (section-header click).
+  // Iterates the full diff entries — not the display-capped `groups` rows — so
+  // the selection matches the header count, including "+N more not shown" rows.
+  const focusGroup = (groupState: DiffState) => {
+    if (!result) return;
+    const refs = result.diff.entries
+      .filter((e) => e.state === groupState)
+      .map(renderRef)
+      .filter((r): r is CompareRef => !!r);
+    if (refs.length === 0) return;
+    const state = useViewerStore.getState();
+    state.clearEntitySelection();
+    state.setSelectedEntityIds(refs.map((r) => r.globalId));
+    state.addEntitiesToSelection(refs.map((r) => ({ modelId: r.modelId, expressId: r.localId })));
+    state.setCompareSelectedKey(null); // bulk select → no single-row "what changed" detail
+    requestAnimationFrame(() => state.cameraCallbacks.frameSelection?.());
+  };
+
   const downloadReport = (format: 'csv' | 'json') => {
     if (!result) return;
     downloadCompareReport(format, result, models);
@@ -298,6 +316,7 @@ export function ComparePanel({ onClose }: ComparePanelProps) {
                 counts={counts}
                 selectedKey={selectedKey}
                 onFocus={focusEntry}
+                onFocusGroup={focusGroup}
               />
 
               {/* What-changed detail for the selected element */}

--- a/apps/viewer/src/components/viewer/compare/CompareResultsList.tsx
+++ b/apps/viewer/src/components/viewer/compare/CompareResultsList.tsx
@@ -7,7 +7,7 @@
  * to keep it under the module-size house rule (AGENTS.md).
  */
 
-import { Plus, Minus, PencilLine } from 'lucide-react';
+import { Plus, Minus, PencilLine, MousePointerClick } from 'lucide-react';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { cn } from '@/lib/utils';
 import { COMPARE_COLORS, type RGBA } from '@/lib/compare/overlay';
@@ -48,9 +48,11 @@ interface CompareResultsListProps {
   counts: CompareResult['diff']['counts'] | undefined;
   selectedKey: string | null;
   onFocus: (row: CompareRow) => void;
+  /** Select every element in a state bucket at once (section-header click). */
+  onFocusGroup: (state: DiffState) => void;
 }
 
-export function CompareResultsList({ result, groups, counts, selectedKey, onFocus }: CompareResultsListProps) {
+export function CompareResultsList({ result, groups, counts, selectedKey, onFocus, onFocusGroup }: CompareResultsListProps) {
   return (
     <ScrollArea className="flex-1 min-h-0">
       {!result ? (
@@ -64,11 +66,17 @@ export function CompareResultsList({ result, groups, counts, selectedKey, onFocu
             if (!bucket || bucket.rows.length === 0) return null;
             return (
               <div key={state}>
-                <div className="flex items-center gap-1.5 px-1 py-1 text-xs font-medium">
+                <button
+                  type="button"
+                  onClick={() => onFocusGroup(state)}
+                  title={`Select all ${label.toLowerCase()} in 3D`}
+                  className="group w-full flex items-center gap-1.5 px-1 py-1 text-xs font-medium rounded hover:bg-muted transition-colors"
+                >
                   <Icon className="h-3.5 w-3.5" style={{ color: rgbaCss(color) }} />
                   <span>{label}</span>
                   <span className="text-muted-foreground">({bucket.rows.length + bucket.truncated})</span>
-                </div>
+                  <MousePointerClick className="h-3 w-3 ml-auto opacity-0 group-hover:opacity-60 transition-opacity" />
+                </button>
                 <div className="space-y-0.5">
                   {bucket.rows.map((row) => (
                     <button


### PR DESCRIPTION
## What

In **Compare models**, clicking a section header (**Changed** / **Added** / **Deleted**) now selects and frames *every* element in that group in the 3D viewer at once — instead of clicking each row one by one.

Requested behavior: the header is the click target (the count + label), matching where users expect "select all this group" to live.

## How

- `ComparePanel.focusGroup(state)` mirrors the existing single-row `focusEntry`, batched across both selection channels: `clearEntitySelection → setSelectedEntityIds(globalIds) → addEntitiesToSelection(refs) → frameSelection`.
- It iterates the **full** `result.diff.entries` filtered by state — not the display-capped group rows (`MAX_ROWS_PER_GROUP = 1000`) — so the selection matches the header count, including the `+N more not shown` rows.
- Bulk select clears the single-row "what changed" detail (`setCompareSelectedKey(null)`), since there's no single entry to describe.
- `CompareResultsList` gains an `onFocusGroup` prop; its section header `<div>` becomes a `<button>` with a hover background and a `MousePointerClick` affordance icon that fades in on hover.
- Deleted-group elements highlight the base-model meshes via `renderRef`'s base-side fallback (same logic single-row already uses).

## Scope / notes

- Viewer-only (`apps/viewer`); no `@ifc-lite/*` package src touched → no changeset needed.
- Two files, +31/-4. Single-row click behavior is unchanged.
- Typecheck: `apps/viewer` `tsc --noEmit` is clean for both changed files.

## Test plan

- [ ] Run a comparison, click **Added (N)** → all added elements highlight + camera frames them.
- [ ] Same for **Changed** and **Deleted** (verify deleted highlights base-model meshes).
- [ ] A group with `+N more not shown` selects the full count, not just the visible 1000.
- [ ] Single-row click still selects + frames one element and shows its "what changed" detail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bulk selection for compare results: Section headers in the compare panel are now interactive buttons. Clicking a header selects all entries within that state category in the 3D view, replacing any previous selections. Enhanced with visual indicators on hover and pointer icons for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->