### PR TITLE
fix(viewer): guard Node.removeChild/insertBefore against external DOM mutation

### DIFF
--- a/apps/viewer/src/harden-dom-mutations.ts
+++ b/apps/viewer/src/harden-dom-mutations.ts
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Harden `Node.prototype.removeChild` / `insertBefore` against external DOM
+ * mutation so the React reconciler can't crash the whole app.
+ *
+ * When a browser translation extension (Google Translate, the built-in
+ * Edge/Chrome translator, …), a password manager, or any other agent rewrites
+ * the DOM React owns, React's commit phase later tries to remove or move a node
+ * relative to a parent that no longer holds it. The native call then throws an
+ * UNCAUGHT `DOMException`:
+ *
+ *   NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be
+ *   removed is not a child of this node.
+ *   NotFoundError: Failed to execute 'insertBefore' on 'Node': The node before
+ *   which the new node is to be inserted is not a child of this node.
+ *
+ * Because the throw happens deep inside the reconciler (no app frame on the
+ * stack — see PostHog issues #1229/#1230 removeChild, #1232 insertBefore, all
+ * minified React-internal frames), it tears down the React tree and surfaces as
+ * a hard crash to the user. It is not a bug in our components; we can't stop the
+ * extension from editing the DOM, but we can make these two operations no-ops
+ * when the node/parent relationship has already been broken, which is exactly
+ * what the React team recommends (facebook/react#11538). React then proceeds as
+ * if the (already-detached) work succeeded.
+ *
+ * Imported for its side effect from main.tsx BEFORE react-dom initializes, so
+ * the reconciler only ever sees the guarded methods. Runs in dev and prod —
+ * the crash is observed in production.
+ */
+
+if (typeof Node !== 'undefined' && Node.prototype) {
+  const originalRemoveChild = Node.prototype.removeChild;
+  Node.prototype.removeChild = function removeChild<T extends Node>(this: Node, child: T): T {
+    if (child.parentNode !== this) {
+      // An external agent already detached/moved `child`; React thinks it still
+      // lives here. Pretend the removal happened instead of throwing.
+      if (import.meta.env.DEV && typeof console !== 'undefined') {
+        console.warn('[harden-dom] suppressed removeChild on a node with a different parent', child);
+      }
+      return child;
+    }
+    return originalRemoveChild.call(this, child) as T;
+  };
+
+  const originalInsertBefore = Node.prototype.insertBefore;
+  Node.prototype.insertBefore = function insertBefore<T extends Node>(
+    this: Node,
+    node: T,
+    child: Node | null,
+  ): T {
+    if (child && child.parentNode !== this) {
+      // The reference node was re-parented out from under us; inserting before
+      // it would throw. Fall back to a plain append so React's insert still
+      // lands in the parent it expects.
+      if (import.meta.env.DEV && typeof console !== 'undefined') {
+        console.warn('[harden-dom] suppressed insertBefore with a reference node from a different parent', child);
+      }
+      return originalInsertBefore.call(this, node, null) as T;
+    }
+    return originalInsertBefore.call(this, node, child) as T;
+  };
+}

--- a/apps/viewer/src/main.tsx
+++ b/apps/viewer/src/main.tsx
@@ -11,6 +11,10 @@
 // geometry/dataStore props don't blow its recursive prop-diff to a RangeError/OOM
 // (the load "stops halfway" stall). See disable-react-dev-perf-track.ts.
 import './disable-react-dev-perf-track';
+// Must run before react-dom: guards Node.removeChild/insertBefore so a browser
+// translation extension mutating the DOM can't crash the reconciler. See
+// harden-dom-mutations.ts (PostHog issues #1229/#1230/#1232).
+import './harden-dom-mutations';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { App } from './App';


### PR DESCRIPTION
## Problem

PostHog error tracking auto-filed three issues, all uncaught `DOMException`s on `https://www.ifclite.com/` (Chrome/Edge 149 on Windows):

- **#1229 / #1230** — `NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.`
- **#1232** — `NotFoundError: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.`

The stack traces are **entirely React-internal** (minified reconciler frames `Mo`/`eV`/`To`/`i2`, no app frame). That signature is the well-known React crash that happens when an external agent — a browser **translation extension** (Google Translate, the built-in Edge/Chrome translator), a password manager, etc. — rewrites the DOM React owns. React's commit phase then calls `removeChild`/`insertBefore` against a node whose parent has changed underneath it, the native call throws, and the whole React tree tears down → hard crash for the user.

It is not a bug in our components; we can't stop the extension from editing the DOM.

## Fix

Add `apps/viewer/src/harden-dom-mutations.ts`, a side-effect module imported from `main.tsx` **before react-dom initializes** (same pattern as the existing `disable-react-dev-perf-track.ts`). It wraps `Node.prototype.removeChild` and `Node.prototype.insertBefore` to make the broken-parent case a no-op (`removeChild`) / append fallback (`insertBefore`) instead of throwing — the mitigation [the React team recommends](https://github.com/facebook/react/issues/11538). React then proceeds as if the already-detached work succeeded.

- Runs in dev **and** prod (the crash is observed in production).
- The `console.warn` diagnostics are dev-only (`import.meta.env.DEV`), so prod is silent and Vite dead-code-eliminates them.
- No behavior change when the DOM is intact — the guard only triggers on the parent-mismatch path that would otherwise throw.

## Verification

- Viewer `tsc --noEmit` clean on the changed files.

Fixes #1229, #1230, #1232.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by adding resilience to DOM mutation operations that could cause crashes in edge cases where node relationships become misaligned.
  * Added fallback handling to prevent the app from crashing when external processes or race conditions interfere with expected DOM operations.
  * Development mode now includes diagnostic warnings when such conditions are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->