### PR TITLE
feat(mutations,export): retype an entity's IFC class (reassign class)

### DIFF
--- a/.changeset/entity-retype-reassign-class.md
+++ b/.changeset/entity-retype-reassign-class.md
@@ -1,0 +1,22 @@
+---
+"@ifc-lite/mutations": minor
+"@ifc-lite/export": minor
+---
+
+Add entity retype (reassign class) to the mutation overlay.
+
+`StoreEditor.setEntityType(expressId, newType, { predefinedType? })` and
+`MutablePropertyView.setEntityType(...)` change an entity's IFC class in place,
+and a new `BulkAction { type: 'SET_ENTITY_TYPE', entityType, predefinedType? }`
+applies it to a selection. `StepExporter` materializes the retype on export.
+
+The entity keeps its expressId, so geometry, placement, representation and every
+`IfcRel*` reference (all keyed by `#id`) carry over unchanged. Attributes are
+re-laid-out by name against the target class's declared layout — dropping
+attributes the target lacks (e.g. IFC2X3 `CompositionType`) and validating
+`PredefinedType` against the target enum (an unknown override falls back to
+`USERDEFINED` + `ObjectType`). This mirrors IfcOpenShell's
+`ifcopenshell.util.schema.reassign_class`. Intended for compatible
+reassignments such as the building-element subtypes that share the IfcElement
+layout (`IfcBuildingElementProxy` ↔ `IfcColumn`/`IfcBeam`/`IfcMember`/
+`IfcPlate`/`IfcWall`).

--- a/.changeset/entity-retype-reassign-class.md
+++ b/.changeset/entity-retype-reassign-class.md
@@ -1,9 +1,16 @@
 ---
 "@ifc-lite/mutations": minor
 "@ifc-lite/export": minor
+"@ifc-lite/data": minor
+"@ifc-lite/cache": patch
 ---
 
 Add entity retype (reassign class) to the mutation overlay.
+
+`EntityTable` gains an additive `setTypeOverride(expressId, typeName | null)` so
+a host (the viewer) can reflect a pending retype live in `getTypeName` /
+`getTypeEnum` without rebuilding the table; the original columnar type is left
+intact.
 
 `StoreEditor.setEntityType(expressId, newType, { predefinedType? })` and
 `MutablePropertyView.setEntityType(...)` change an entity's IFC class in place,

--- a/apps/viewer/src/components/viewer/PropertiesPanel.tsx
+++ b/apps/viewer/src/components/viewer/PropertiesPanel.tsx
@@ -1907,6 +1907,19 @@ function EntityDataSection({
     return query.entity(entityRef.expressId);
   }, [query, entityRef.expressId]);
 
+  // Overlay-aware display class: a pending retype (setEntityType) reassigns the
+  // class in place, so the header reflects the new class immediately — before
+  // the model is re-exported / reloaded. Re-evaluates on `mutationVersion`.
+  const headerMutationViews = useViewerStore((s) => s.mutationViews);
+  const headerMutationVersion = useViewerStore((s) => s.mutationVersion);
+  const displayType = useMemo(() => {
+    let mid = entityRef.modelId;
+    if (mid === 'legacy') mid = '__legacy__';
+    const pending = headerMutationViews.get(mid)?.getEntityTypeMutation?.(entityRef.expressId)?.newType;
+    return pending ?? entityNode?.type ?? '';
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [headerMutationViews, headerMutationVersion, entityRef.modelId, entityRef.expressId, entityNode]);
+
   // Get properties and quantities
   const properties: PropertySet[] = useMemo(() => {
     if (!entityNode) return [];
@@ -1958,9 +1971,9 @@ function EntityDataSection({
           <Layers className="h-4 w-4 text-emerald-600" />
           <div className="flex-1 min-w-0">
             <h3 className="font-bold text-sm truncate text-zinc-900 dark:text-zinc-100">
-              {entityNode.name || `${entityNode.type} #${entityRef.expressId}`}
+              {entityNode.name || `${displayType} #${entityRef.expressId}`}
             </h3>
-            <p className="text-xs font-mono text-zinc-500">{entityNode.type}</p>
+            <p className="text-xs font-mono text-zinc-500">{displayType}</p>
           </div>
           {elevationInfo !== null && (
             <span className="text-[10px] font-mono bg-emerald-100 dark:bg-emerald-950 px-1.5 py-0.5 border border-emerald-200 dark:border-emerald-800 text-emerald-600 dark:text-emerald-400">

--- a/apps/viewer/src/components/viewer/PropertyEditor.tsx
+++ b/apps/viewer/src/components/viewer/PropertyEditor.tsx
@@ -73,6 +73,18 @@ import {
   type QtoDefinition,
 } from '@/lib/ifc4-qto-definitions';
 
+// ── Edit-deck button styling ────────────────────────────────────────────────
+// Data-enrichment actions (Property / Quantity / Classification / Material)
+// live as quiet icon keys inside one segmented control — discoverable via
+// tooltip, compact enough to leave room for the headline action.
+const EDIT_TOOL_CLS =
+  'h-7 w-8 rounded-none border-0 bg-transparent text-zinc-500 shadow-none transition-colors hover:bg-indigo-500/10 hover:text-indigo-600 focus-visible:bg-indigo-500/10 dark:text-zinc-400 dark:hover:bg-indigo-400/15 dark:hover:text-indigo-300';
+
+// The structural "Reassign class" action is elevated as a distinct accent
+// affordance — it transforms the element rather than adding data to it.
+const RECLASS_TOOL_CLS =
+  'h-7 min-w-0 gap-1.5 rounded-md px-2.5 text-[11px] font-semibold text-indigo-700 ring-1 ring-inset ring-indigo-300/70 bg-indigo-500/10 shadow-none transition-colors hover:bg-indigo-500/20 hover:text-indigo-800 dark:text-indigo-300 dark:ring-indigo-700/60 dark:bg-indigo-500/10 dark:hover:text-indigo-200';
+
 interface PropertyEditorProps {
   modelId: string;
   entityId: number;
@@ -492,9 +504,8 @@ export function NewPropertyDialog({ modelId, entityId, entityType, existingPsets
   return (
     <Dialog open={open} onOpenChange={(o) => { setOpen(o); if (!o) resetForm(); }}>
       <DialogTrigger asChild>
-        <Button variant="outline" size="sm" title="Property" className="panel-action-button h-7 min-w-0">
-          <Plus className="h-3 w-3 shrink-0 panel-compact-icon" />
-          <span className="panel-compact-text">Property</span>
+        <Button variant="ghost" size="icon" title="Add property" className={EDIT_TOOL_CLS}>
+          <Plus className="h-3.5 w-3.5" />
         </Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-lg">
@@ -750,9 +761,8 @@ export function AddClassificationDialog({ modelId, entityId, entityType }: AddCl
       if (!o) { setSystem(''); setCustomSystem(''); setIdentification(''); setName(''); }
     }}>
       <DialogTrigger asChild>
-        <Button variant="outline" size="sm" title="Classification" className="panel-action-button h-7 min-w-0">
-          <Tag className="h-3 w-3 shrink-0 panel-compact-icon" />
-          <span className="panel-compact-text">Classification</span>
+        <Button variant="ghost" size="icon" title="Add classification" className={EDIT_TOOL_CLS}>
+          <Tag className="h-3.5 w-3.5" />
         </Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-md">
@@ -895,9 +905,8 @@ export function AddMaterialDialog({ modelId, entityId, entityType }: AddMaterial
       if (!o) { setMaterialName(''); setCategory(''); setDescription(''); }
     }}>
       <DialogTrigger asChild>
-        <Button variant="outline" size="sm" title="Material" className="panel-action-button h-7 min-w-0">
-          <Layers className="h-3 w-3 shrink-0 panel-compact-icon" />
-          <span className="panel-compact-text">Material</span>
+        <Button variant="ghost" size="icon" title="Add material" className={EDIT_TOOL_CLS}>
+          <Layers className="h-3.5 w-3.5" />
         </Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-md">
@@ -1081,9 +1090,8 @@ export function AddQuantityDialog({ modelId, entityId, entityType, existingQtos 
   return (
     <Dialog open={open} onOpenChange={(o) => { setOpen(o); if (!o) resetForm(); }}>
       <DialogTrigger asChild>
-        <Button variant="outline" size="sm" title="Quantity" className="panel-action-button h-7 min-w-0">
-          <Ruler className="h-3 w-3 shrink-0 panel-compact-icon" />
-          <span className="panel-compact-text">Quantity</span>
+        <Button variant="ghost" size="icon" title="Add quantity" className={EDIT_TOOL_CLS}>
+          <Ruler className="h-3.5 w-3.5" />
         </Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-lg">
@@ -1320,9 +1328,9 @@ export function ReassignClassDialog({ modelId, entityId, entityType, schemaVersi
   return (
     <Dialog open={open} onOpenChange={(o) => { setOpen(o); if (!o) reset(); }}>
       <DialogTrigger asChild>
-        <Button variant="outline" size="sm" title="Reassign IFC class" className="panel-action-button h-7 min-w-0">
-          <Replace className="h-3 w-3 shrink-0 panel-compact-icon" />
-          <span className="panel-compact-text">Reclass</span>
+        <Button variant="ghost" size="sm" title="Reassign IFC class" className={RECLASS_TOOL_CLS}>
+          <Replace className="h-3.5 w-3.5 shrink-0" />
+          <span>Reassign</span>
         </Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-lg">
@@ -1478,42 +1486,51 @@ export function EditToolbar({ modelId, entityId, entityType, existingPsets, exis
   // entities, spaces, or materials.
   const canReassign = isReassignableElement(resolveReassignSchema(schemaVersion), entityType);
   return (
-    <div className="panel-container flex flex-col gap-2 mb-3 pb-2 border-b border-purple-200 dark:border-purple-800 bg-purple-50/30 dark:bg-purple-950/20 -mx-3 -mt-3 px-3 pt-3">
+    <div className="panel-container relative -mx-3 -mt-3 mb-3 flex flex-col gap-2 border-b border-zinc-200 bg-gradient-to-b from-zinc-50/80 to-transparent px-3 pb-2.5 pt-3 dark:border-zinc-800 dark:from-zinc-900/50">
+      {/* live-edit accent hairline */}
+      <span
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-indigo-400/50 to-transparent"
+      />
       <div className="flex items-center justify-between gap-2">
-      <div className="flex items-center gap-1.5 flex-wrap">
-        <NewPropertyDialog
-          modelId={modelId}
-          entityId={entityId}
-          entityType={entityType}
-          existingPsets={existingPsets}
-          schemaVersion={schemaVersion}
-        />
-        <AddQuantityDialog
-          modelId={modelId}
-          entityId={entityId}
-          entityType={entityType}
-          existingQtos={existingQtos ?? []}
-        />
-        <AddClassificationDialog
-          modelId={modelId}
-          entityId={entityId}
-          entityType={entityType}
-        />
-        <AddMaterialDialog
-          modelId={modelId}
-          entityId={entityId}
-          entityType={entityType}
-        />
-        {canReassign && (
-          <ReassignClassDialog
-            modelId={modelId}
-            entityId={entityId}
-            entityType={entityType}
-            schemaVersion={schemaVersion}
-          />
-        )}
-      </div>
-      <UndoRedoButtons modelId={modelId} />
+        <div className="flex flex-wrap items-center gap-2">
+          {/* Data-enrichment cluster — one segmented control of icon keys */}
+          <div className="inline-flex items-center overflow-hidden rounded-md bg-white shadow-sm ring-1 ring-zinc-200 divide-x divide-zinc-200 dark:bg-zinc-800/50 dark:ring-zinc-700 dark:divide-zinc-700">
+            <NewPropertyDialog
+              modelId={modelId}
+              entityId={entityId}
+              entityType={entityType}
+              existingPsets={existingPsets}
+              schemaVersion={schemaVersion}
+            />
+            <AddQuantityDialog
+              modelId={modelId}
+              entityId={entityId}
+              entityType={entityType}
+              existingQtos={existingQtos ?? []}
+            />
+            <AddClassificationDialog
+              modelId={modelId}
+              entityId={entityId}
+              entityType={entityType}
+            />
+            <AddMaterialDialog
+              modelId={modelId}
+              entityId={entityId}
+              entityType={entityType}
+            />
+          </div>
+          {/* Structural transform — elevated accent action */}
+          {canReassign && (
+            <ReassignClassDialog
+              modelId={modelId}
+              entityId={entityId}
+              entityType={entityType}
+              schemaVersion={schemaVersion}
+            />
+          )}
+        </div>
+        <UndoRedoButtons modelId={modelId} />
       </div>
       {canReassign && <ReassignBadge modelId={modelId} entityId={entityId} entityType={entityType} />}
     </div>

--- a/apps/viewer/src/components/viewer/PropertyEditor.tsx
+++ b/apps/viewer/src/components/viewer/PropertyEditor.tsx
@@ -20,6 +20,8 @@ import {
   Tag,
   Layers,
   Ruler,
+  Replace,
+  ArrowRight,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -43,6 +45,16 @@ import {
 import { Switch } from '@/components/ui/switch';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Badge } from '@/components/ui/badge';
+import { ComboInput } from '@/components/ui/combo-input';
+import { cn } from '@/lib/utils';
+import {
+  resolveReassignSchema,
+  getReassignTargets,
+  getPredefinedTypes,
+  isKnownReassignTarget,
+  isReassignableElement,
+  COMMON_REASSIGN_TARGETS,
+} from '@/lib/ifc-class-reassign';
 import { useViewerStore } from '@/store';
 import { PropertyValueType, QuantityType } from '@ifc-lite/data';
 import type { PropertyValue } from '@ifc-lite/mutations';
@@ -1242,6 +1254,208 @@ export function AddQuantityDialog({ modelId, entityId, entityType, existingQtos 
 }
 
 // ============================================================================
+// Reassign IFC Class (retype)
+// ============================================================================
+
+interface ReassignClassDialogProps {
+  modelId: string;
+  entityId: number;
+  /** The element's current IFC class, e.g. "IfcBuildingElementProxy". */
+  entityType: string;
+  schemaVersion?: string;
+}
+
+/**
+ * Reassign an entity's IFC class in place ("retype"). The expressId is
+ * unchanged, so geometry / placement / representation and every IfcRel*
+ * reference carry over; the new class materializes on STEP export. Mirrors
+ * IfcOpenShell's `reassign_class`. Best for the building-element subtypes
+ * (Proxy ↔ Column / Beam / Member / Plate / Wall) that share the IfcElement
+ * attribute layout.
+ */
+export function ReassignClassDialog({ modelId, entityId, entityType, schemaVersion }: ReassignClassDialogProps) {
+  const setEntityType = useViewerStore((s) => s.setEntityType);
+  const bumpMutationVersion = useViewerStore((s) => s.bumpMutationVersion);
+
+  const [open, setOpen] = useState(false);
+  const [target, setTarget] = useState('');
+  const [predefinedType, setPredefinedType] = useState('');
+
+  const schema = useMemo(() => resolveReassignSchema(schemaVersion), [schemaVersion]);
+  const targets = useMemo(() => getReassignTargets(schema), [schema]);
+  const predefinedOptions = useMemo(
+    () => (target.trim() ? getPredefinedTypes(schema, target.trim()) : []),
+    [schema, target],
+  );
+  const quickTargets = useMemo(
+    () => COMMON_REASSIGN_TARGETS.filter((t) => t.toUpperCase() !== entityType.toUpperCase()),
+    [entityType],
+  );
+
+  const trimmedTarget = target.trim();
+  const targetChanged = trimmedTarget.length > 0 && trimmedTarget.toUpperCase() !== entityType.toUpperCase();
+  const knownTarget = trimmedTarget.length > 0 && isKnownReassignTarget(schema, trimmedTarget);
+  const validKeyword = /^[Ii][Ff][Cc][A-Za-z][A-Za-z0-9_]*$/.test(trimmedTarget);
+  // Allow apply when the class changes, or when only setting a predefined type
+  // on the same class (the retype API carries that too).
+  const canApply = validKeyword && (targetChanged || (trimmedTarget.length > 0 && predefinedType.length > 0));
+
+  const reset = useCallback(() => { setTarget(''); setPredefinedType(''); }, []);
+
+  // Drop a predefined type that the newly-chosen class doesn't define.
+  useEffect(() => {
+    if (predefinedType && !predefinedOptions.includes(predefinedType)) setPredefinedType('');
+  }, [predefinedOptions, predefinedType]);
+
+  const handleApply = useCallback(() => {
+    if (!canApply) return;
+    let normalizedModelId = modelId;
+    if (modelId === 'legacy') normalizedModelId = '__legacy__';
+    setEntityType(normalizedModelId, entityId, trimmedTarget, predefinedType || null);
+    bumpMutationVersion();
+    reset();
+    setOpen(false);
+  }, [canApply, modelId, entityId, trimmedTarget, predefinedType, setEntityType, bumpMutationVersion, reset]);
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { setOpen(o); if (!o) reset(); }}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm" title="Reassign IFC class" className="panel-action-button h-7 min-w-0">
+          <Replace className="h-3 w-3 shrink-0 panel-compact-icon" />
+          <span className="panel-compact-text">Reclass</span>
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Replace className="h-4 w-4" />
+            Reassign IFC Class
+          </DialogTitle>
+          <DialogDescription>
+            Change this element&apos;s IFC class in place. It keeps its identity, geometry and
+            relationships — only the class (and an optional predefined type) change on export.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-4">
+          {/* current → target */}
+          <div className="flex items-center gap-2 rounded-md border border-indigo-200/70 bg-indigo-50/40 px-3 py-2.5 dark:border-indigo-900/60 dark:bg-indigo-950/20">
+            <code className="flex-1 truncate font-mono text-[11px] text-zinc-500 dark:text-zinc-400" title={entityType}>{entityType}</code>
+            <ArrowRight className="h-3.5 w-3.5 shrink-0 text-indigo-400" />
+            <code
+              className={cn(
+                'flex-1 truncate text-right font-mono text-[11px] font-medium',
+                targetChanged ? 'text-indigo-600 dark:text-indigo-300' : 'text-zinc-400 dark:text-zinc-600',
+              )}
+              title={trimmedTarget || undefined}
+            >
+              {trimmedTarget || '—'}
+            </code>
+          </div>
+
+          {/* quick picks */}
+          {quickTargets.length > 0 && (
+            <div className="space-y-1.5">
+              <Label className="text-[11px] font-medium uppercase tracking-wide text-zinc-400">Common</Label>
+              <div className="flex flex-wrap gap-1.5">
+                {quickTargets.map((t) => (
+                  <button
+                    key={t}
+                    type="button"
+                    onClick={() => setTarget(t)}
+                    className={cn(
+                      'rounded-full border px-2.5 py-1 font-mono text-[11px] transition-colors',
+                      trimmedTarget === t
+                        ? 'border-indigo-400 bg-indigo-500/10 text-indigo-700 dark:text-indigo-300'
+                        : 'border-zinc-200 text-zinc-600 hover:border-indigo-300 hover:bg-indigo-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-indigo-950/30',
+                    )}
+                  >
+                    {t.replace(/^Ifc/, '')}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* searchable full list */}
+          <div className="space-y-1.5">
+            <Label className="text-sm font-medium">Target class</Label>
+            <ComboInput value={target} onChange={setTarget} options={targets} placeholder="Search element classes…" />
+            {trimmedTarget.length > 0 && !knownTarget && (
+              <p className="text-[11px] text-amber-600 dark:text-amber-400">
+                Not a standard {schema} element — it will export as a vendor/custom class.
+              </p>
+            )}
+          </div>
+
+          {/* predefined type */}
+          {predefinedOptions.length > 0 && (
+            <div className="space-y-1.5">
+              <Label className="text-sm font-medium">
+                Predefined type <span className="font-normal text-zinc-400">(optional)</span>
+              </Label>
+              <Select value={predefinedType || '__none__'} onValueChange={(v) => setPredefinedType(v === '__none__' ? '' : v)}>
+                <SelectTrigger className="font-mono text-sm"><SelectValue placeholder="— none —" /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__none__">— none —</SelectItem>
+                  {predefinedOptions.map((p) => (<SelectItem key={p} value={p}>{p}</SelectItem>))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          <p className="text-[11px] leading-relaxed text-zinc-400 dark:text-zinc-500">
+            Applies to the exported IFC and this panel. The model tree, colors and type filters refresh on reload.
+          </p>
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" size="sm" onClick={() => { reset(); setOpen(false); }}>Cancel</Button>
+          <Button size="sm" onClick={handleApply} disabled={!canApply}>
+            <Check className="mr-1 h-3.5 w-3.5" /> Reassign
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * Inline chip surfacing a pending reassignment for the selected element. Reads
+ * the overlay (re-rendering on `mutationVersion`) so a retype is visible in the
+ * panel immediately, before the model is re-exported / reloaded.
+ */
+export function ReassignBadge({ modelId, entityId, entityType }: { modelId: string; entityId: number; entityType: string }) {
+  const mutationVersion = useViewerStore((s) => s.mutationVersion);
+  const mutationViews = useViewerStore((s) => s.mutationViews);
+  const pending = useMemo(() => {
+    let mid = modelId;
+    if (mid === 'legacy') mid = '__legacy__';
+    const view = mutationViews.get(mid);
+    const m = view?.getEntityTypeMutation?.(entityId) ?? null;
+    if (!m) return null;
+    // A no-op (same class, no predefined type) isn't worth surfacing.
+    if (m.newType.toUpperCase() === entityType.toUpperCase() && !m.predefinedType) return null;
+    return m;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [modelId, entityId, entityType, mutationViews, mutationVersion]);
+
+  if (!pending) return null;
+  return (
+    <div className="flex items-center gap-1.5 rounded-md border border-indigo-200/70 bg-indigo-50/50 px-2 py-1 text-[11px] dark:border-indigo-900/60 dark:bg-indigo-950/25">
+      <Replace className="h-3 w-3 shrink-0 text-indigo-500" />
+      <span className="text-zinc-500 dark:text-zinc-400">Reassigned</span>
+      <ArrowRight className="h-3 w-3 shrink-0 text-indigo-400" />
+      <code className="font-mono font-medium text-indigo-600 dark:text-indigo-300">{pending.newType}</code>
+      {pending.predefinedType && (
+        <code className="font-mono text-indigo-500/80 dark:text-indigo-300/70">· {pending.predefinedType}</code>
+      )}
+      <span className="ml-auto text-zinc-400 dark:text-zinc-500">on export</span>
+    </div>
+  );
+}
+
+// ============================================================================
 // Edit Toolbar (combines all add actions)
 // ============================================================================
 
@@ -1259,8 +1473,12 @@ interface EditToolbarProps {
  * Schema-aware: filters available property/quantity sets based on entity type.
  */
 export function EditToolbar({ modelId, entityId, entityType, existingPsets, existingQtos, schemaVersion }: EditToolbarProps) {
+  // Reassign is only meaningful for occurrence building elements — not type
+  // entities, spaces, or materials.
+  const canReassign = isReassignableElement(resolveReassignSchema(schemaVersion), entityType);
   return (
-    <div className="panel-container flex items-center justify-between gap-2 mb-3 pb-2 border-b border-purple-200 dark:border-purple-800 bg-purple-50/30 dark:bg-purple-950/20 -mx-3 -mt-3 px-3 pt-3">
+    <div className="panel-container flex flex-col gap-2 mb-3 pb-2 border-b border-purple-200 dark:border-purple-800 bg-purple-50/30 dark:bg-purple-950/20 -mx-3 -mt-3 px-3 pt-3">
+      <div className="flex items-center justify-between gap-2">
       <div className="flex items-center gap-1.5 flex-wrap">
         <NewPropertyDialog
           modelId={modelId}
@@ -1285,8 +1503,18 @@ export function EditToolbar({ modelId, entityId, entityType, existingPsets, exis
           entityId={entityId}
           entityType={entityType}
         />
+        {canReassign && (
+          <ReassignClassDialog
+            modelId={modelId}
+            entityId={entityId}
+            entityType={entityType}
+            schemaVersion={schemaVersion}
+          />
+        )}
       </div>
       <UndoRedoButtons modelId={modelId} />
+      </div>
+      {canReassign && <ReassignBadge modelId={modelId} entityId={entityId} entityType={entityType} />}
     </div>
   );
 }

--- a/apps/viewer/src/components/viewer/PropertyEditor.tsx
+++ b/apps/viewer/src/components/viewer/PropertyEditor.tsx
@@ -1405,7 +1405,8 @@ export function ReassignClassDialog({ modelId, entityId, entityType, schemaVersi
           )}
 
           <p className="text-[11px] leading-relaxed text-zinc-400 dark:text-zinc-500">
-            Applies to the exported IFC and this panel. The model tree, colors and type filters refresh on reload.
+            Updates immediately here, in the model tree and lists, and is written to the
+            exported IFC. Class-based 3D colors refresh on reload.
           </p>
         </div>
 

--- a/apps/viewer/src/index.css
+++ b/apps/viewer/src/index.css
@@ -309,13 +309,6 @@ body {
   .panel-compact-text {
     display: none;
   }
-
-  .panel-action-button {
-    width: 1.75rem;
-    padding-left: 0;
-    padding-right: 0;
-    justify-content: center;
-  }
 }
 
 @container (max-width: 240px) {

--- a/apps/viewer/src/lib/ifc-class-reassign.ts
+++ b/apps/viewer/src/lib/ifc-class-reassign.ts
@@ -1,0 +1,124 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Schema data for the "Reassign IFC class" (retype) control.
+ *
+ * Sources the candidate target classes and their `PredefinedType` enum
+ * domains from the bundled IFC schema (`@ifc-lite/data`). The universe is
+ * restricted to non-abstract `IfcElement` subtypes — the building elements a
+ * user actually reassigns between (the MCAD-proxy case from issue #1231) —
+ * rather than every product in the schema.
+ */
+
+import {
+  ENTITIES_IFC2X3,
+  ENTITIES_IFC4,
+  ENTITIES_IFC4X3,
+  type IfcEntityInfo,
+} from '@ifc-lite/data';
+
+export type ReassignSchema = 'IFC2X3' | 'IFC4' | 'IFC4X3';
+
+const SCHEMA_LISTS: Record<ReassignSchema, readonly IfcEntityInfo[]> = {
+  IFC2X3: ENTITIES_IFC2X3,
+  IFC4: ENTITIES_IFC4,
+  IFC4X3: ENTITIES_IFC4X3,
+};
+
+/**
+ * Curated quick-pick targets — the building-element subtypes that share the
+ * `IfcElement` attribute layout, so a reassignment is a clean keyword swap.
+ * These surface as one-click chips; the rest live in the searchable list.
+ */
+export const COMMON_REASSIGN_TARGETS: readonly string[] = [
+  'IfcColumn',
+  'IfcBeam',
+  'IfcMember',
+  'IfcPlate',
+  'IfcWall',
+  'IfcSlab',
+  'IfcCovering',
+  'IfcRailing',
+  'IfcFooting',
+  'IfcBuildingElementProxy',
+];
+
+/** Map a loaded model's schema string (any spelling) to a bundled schema. */
+export function resolveReassignSchema(version?: string | null): ReassignSchema {
+  const up = (version ?? '').toUpperCase();
+  if (up.includes('2X3')) return 'IFC2X3';
+  if (up.includes('4X3')) return 'IFC4X3';
+  return 'IFC4';
+}
+
+const indexCache = new Map<ReassignSchema, Map<string, IfcEntityInfo>>();
+
+function indexFor(schema: ReassignSchema): Map<string, IfcEntityInfo> {
+  let idx = indexCache.get(schema);
+  if (!idx) {
+    idx = new Map();
+    for (const e of SCHEMA_LISTS[schema]) idx.set(e.name.toUpperCase(), e);
+    indexCache.set(schema, idx);
+  }
+  return idx;
+}
+
+function isSubtypeOf(
+  info: IfcEntityInfo,
+  ancestorUpper: string,
+  byUpper: Map<string, IfcEntityInfo>,
+): boolean {
+  let cursor: IfcEntityInfo | undefined = info;
+  const seen = new Set<string>();
+  while (cursor && !seen.has(cursor.name)) {
+    if (cursor.name.toUpperCase() === ancestorUpper) return true;
+    seen.add(cursor.name);
+    cursor = cursor.parent ? byUpper.get(cursor.parent.toUpperCase()) : undefined;
+  }
+  return false;
+}
+
+const targetsCache = new Map<ReassignSchema, string[]>();
+
+/** All non-abstract `IfcElement` subtypes for a schema, sorted A→Z. */
+export function getReassignTargets(schema: ReassignSchema): string[] {
+  let cached = targetsCache.get(schema);
+  if (cached) return cached;
+  const byUpper = indexFor(schema);
+  const out: string[] = [];
+  for (const e of SCHEMA_LISTS[schema]) {
+    if (e.abstract) continue;
+    if (!isSubtypeOf(e, 'IFCELEMENT', byUpper)) continue;
+    out.push(e.name);
+  }
+  out.sort((a, b) => a.localeCompare(b));
+  cached = out;
+  targetsCache.set(schema, cached);
+  return cached;
+}
+
+/** Is `className` a known, instantiable element class in this schema? */
+export function isKnownReassignTarget(schema: ReassignSchema, className: string): boolean {
+  const info = indexFor(schema).get(className.trim().toUpperCase());
+  return !!info && !info.abstract;
+}
+
+/**
+ * Is `className` an instantiable `IfcElement` subtype — i.e. a building
+ * element that may be reassigned? Used to gate the UI control so it only
+ * appears for occurrence elements (not type entities, spaces, or materials).
+ */
+export function isReassignableElement(schema: ReassignSchema, className: string): boolean {
+  const byUpper = indexFor(schema);
+  const info = byUpper.get(className.trim().toUpperCase());
+  if (!info || info.abstract) return false;
+  return isSubtypeOf(info, 'IFCELEMENT', byUpper);
+}
+
+/** The `PredefinedType` enum domain for a class, or `[]` if it has none. */
+export function getPredefinedTypes(schema: ReassignSchema, className: string): string[] {
+  const info = indexFor(schema).get(className.trim().toUpperCase());
+  return info ? [...info.predefinedTypes] : [];
+}

--- a/apps/viewer/src/store/slices/mutationSlice.ts
+++ b/apps/viewer/src/store/slices/mutationSlice.ts
@@ -1377,9 +1377,11 @@ export const createMutationSlice: StateCreator<
     let mutation: Mutation | null = null;
     try {
       mutation = view.setEntityType(entityId, newType, predefinedType ?? null);
-    } catch {
+    } catch (err) {
       // Invalid class keyword — surface nothing rather than crash the store.
-      // The dialog validates before calling, so this only guards stray callers.
+      // The dialog validates before calling, so this only guards stray callers;
+      // log it so a programmatic bad value isn't swallowed silently.
+      console.warn(`setEntityType(#${entityId} → "${newType}") rejected:`, err);
       return null;
     }
 

--- a/apps/viewer/src/store/slices/mutationSlice.ts
+++ b/apps/viewer/src/store/slices/mutationSlice.ts
@@ -337,6 +337,19 @@ export interface MutationSlice {
     oldValue?: string
   ) => Mutation | null;
 
+  /**
+   * Reassign an entity's IFC class in place ("retype"). The expressId is
+   * unchanged, so geometry / placement / representation and every IfcRel*
+   * reference carry over; the exporter re-lays-out attributes against the
+   * target class. Materializes on STEP export. Returns the recorded mutation.
+   */
+  setEntityType: (
+    modelId: string,
+    entityId: number,
+    newType: string,
+    predefinedType?: string | null
+  ) => Mutation | null;
+
   // Actions - Store-Level Mutations (raw STEP entity edits)
   /**
    * Edit a positional STEP argument by zero-based index. Used by the Raw
@@ -1324,6 +1337,42 @@ export const createMutationSlice: StateCreator<
       const newUndoStacks = new Map(state.undoStacks);
       const stack = newUndoStacks.get(modelId) || [];
       newUndoStacks.set(modelId, [...stack, mutation]);
+
+      const newRedoStacks = new Map(state.redoStacks);
+      newRedoStacks.set(modelId, []);
+
+      const newDirty = new Set(state.dirtyModels);
+      newDirty.add(modelId);
+
+      return {
+        undoStacks: newUndoStacks,
+        redoStacks: newRedoStacks,
+        dirtyModels: newDirty,
+        mutationVersion: state.mutationVersion + 1,
+      };
+    });
+
+    return mutation;
+  },
+
+  // Entity retype (reassign class)
+  setEntityType: (modelId, entityId, newType, predefinedType) => {
+    const view = get().mutationViews.get(modelId);
+    if (!view) return null;
+
+    let mutation: Mutation | null = null;
+    try {
+      mutation = view.setEntityType(entityId, newType, predefinedType ?? null);
+    } catch {
+      // Invalid class keyword — surface nothing rather than crash the store.
+      // The dialog validates before calling, so this only guards stray callers.
+      return null;
+    }
+
+    set((state) => {
+      const newUndoStacks = new Map(state.undoStacks);
+      const stack = newUndoStacks.get(modelId) || [];
+      newUndoStacks.set(modelId, [...stack, mutation!]);
 
       const newRedoStacks = new Map(state.redoStacks);
       newRedoStacks.set(modelId, []);
@@ -2572,6 +2621,16 @@ export const createMutationSlice: StateCreator<
         const globalId = cross.toGlobalId(modelId, mutation.entityId);
         cross.showEntity(globalId);
       }
+    } else if (mutation.type === 'UPDATE_ENTITY_TYPE') {
+      // `oldValue` is the class right before this retype: restore it when an
+      // earlier retype is still on the stack, otherwise drop the intent to
+      // revert the entity to its original class entirely.
+      const prevType = mutation.oldValue;
+      if (prevType != null && prevType !== '') {
+        view.setEntityType(mutation.entityId, String(prevType), undefined, undefined, true);
+      } else {
+        view.removeTypeMutation(mutation.entityId);
+      }
     }
 
     set((s) => {
@@ -2738,6 +2797,11 @@ export const createMutationSlice: StateCreator<
       if (cross.toGlobalId && cross.hideEntity) {
         const globalId = cross.toGlobalId(modelId, mutation.entityId);
         cross.hideEntity(globalId);
+      }
+    } else if (mutation.type === 'UPDATE_ENTITY_TYPE') {
+      const newType = mutation.entityType ?? (typeof mutation.newValue === 'string' ? mutation.newValue : undefined);
+      if (newType) {
+        view.setEntityType(mutation.entityId, newType, mutation.predefinedType ?? undefined, undefined, true);
       }
     }
 

--- a/apps/viewer/src/store/slices/mutationSlice.ts
+++ b/apps/viewer/src/store/slices/mutationSlice.ts
@@ -712,6 +712,20 @@ function generateChangeSetId(): string {
  * (the data store comes from `models`, the view from PropertiesPanel's
  * lazy-init effect). Returns null if either is missing.
  */
+/**
+ * Push the overlay's effective class for an entity into the model's
+ * EntityTable as an additive display override, so a UI retype reflects
+ * immediately in the inspector, hover, and the (mutationVersion-rebuilt)
+ * hierarchy tree. Reads the current overlay, so it also clears the override
+ * on undo (removeTypeMutation → null) and re-applies it on redo.
+ */
+function syncTypeOverride(get: () => ViewerState, modelId: string, entityId: number): void {
+  const view = get().mutationViews.get(modelId);
+  const newType = view?.getEntityTypeMutation?.(entityId)?.newType ?? null;
+  const dataStore = get().models.get(modelId)?.ifcDataStore ?? get().ifcDataStore;
+  dataStore?.entities?.setTypeOverride?.(entityId, newType);
+}
+
 function getOrCreateStoreEditor(
   get: () => ViewerState,
   // Editors are cached in-place on the (non-reactive) `storeEditors`
@@ -1368,6 +1382,9 @@ export const createMutationSlice: StateCreator<
       // The dialog validates before calling, so this only guards stray callers.
       return null;
     }
+
+    // Reflect the new class live (inspector, hover, tree on rebuild).
+    syncTypeOverride(get, modelId, entityId);
 
     set((state) => {
       const newUndoStacks = new Map(state.undoStacks);
@@ -2631,6 +2648,7 @@ export const createMutationSlice: StateCreator<
       } else {
         view.removeTypeMutation(mutation.entityId);
       }
+      syncTypeOverride(get, modelId, mutation.entityId);
     }
 
     set((s) => {
@@ -2803,6 +2821,7 @@ export const createMutationSlice: StateCreator<
       if (newType) {
         view.setEntityType(mutation.entityId, newType, mutation.predefinedType ?? undefined, undefined, true);
       }
+      syncTypeOverride(get, modelId, mutation.entityId);
     }
 
     set((s) => {

--- a/apps/viewer/src/utils/serverDataModel.ts
+++ b/apps/viewer/src/utils/serverDataModel.ts
@@ -327,6 +327,9 @@ function buildEntityTable(
 
   const indexOfId = (id: number): number => idToIndex.get(id) ?? -1;
 
+  // Additive display-class overrides (UI retype). See entity-table.ts.
+  const typeOverrides = new Map<number, string>();
+
   const entities: EntityTable = {
     count: entityCount,
     expressId,
@@ -357,6 +360,8 @@ function buildEntityTable(
       return i >= 0 ? strings.get(objectTypeArr[i]) : '';
     },
     getTypeName: (id) => {
+      const override = typeOverrides.get(id);
+      if (override !== undefined) return override;
       const i = indexOfId(id);
       return i >= 0 ? IfcTypeEnumToString(typeEnumArr[i]) : 'Unknown';
     },
@@ -371,8 +376,14 @@ function buildEntityTable(
       return indices.map(idx => expressId[idx]);
     },
     getTypeEnum: (id) => {
+      const override = typeOverrides.get(id);
+      if (override !== undefined) return IfcTypeEnumFromString(override);
       const i = indexOfId(id);
       return i >= 0 ? typeEnumArr[i] as IfcTypeEnum : IfcTypeEnum.Unknown;
+    },
+    setTypeOverride: (id, typeName) => {
+      if (typeName === null) typeOverrides.delete(id);
+      else typeOverrides.set(id, typeName);
     },
     getExpressIdByGlobalId: (gid) => {
       return globalIdToExpressId.get(gid) ?? -1;

--- a/packages/cache/src/sections/entities.ts
+++ b/packages/cache/src/sections/entities.ts
@@ -7,7 +7,7 @@
  */
 
 import type { EntityTable, StringTable } from '@ifc-lite/data';
-import { IfcTypeEnum, IfcTypeEnumToString } from '@ifc-lite/data';
+import { IfcTypeEnum, IfcTypeEnumToString, IfcTypeEnumFromString } from '@ifc-lite/data';
 import { BufferWriter, BufferReader } from '../utils/buffer-utils.js';
 
 /**
@@ -121,6 +121,9 @@ export function readEntities(reader: BufferReader, strings: StringTable): Entity
     }
   }
 
+  // Additive display-class overrides (UI retype). See entity-table.ts.
+  const typeOverrides = new Map<number, string>();
+
   return {
     count,
     expressId,
@@ -152,6 +155,8 @@ export function readEntities(reader: BufferReader, strings: StringTable): Entity
       return idx >= 0 ? strings.get(objectType[idx]) : '';
     },
     getTypeName: (id) => {
+      const override = typeOverrides.get(id);
+      if (override !== undefined) return override;
       const idx = indexOfId(id);
       return idx >= 0 ? IfcTypeEnumToString(typeEnum[idx]) : 'Unknown';
     },
@@ -169,8 +174,14 @@ export function readEntities(reader: BufferReader, strings: StringTable): Entity
       return ids;
     },
     getTypeEnum: (id) => {
+      const override = typeOverrides.get(id);
+      if (override !== undefined) return IfcTypeEnumFromString(override);
       const idx = indexOfId(id);
       return idx >= 0 ? typeEnum[idx] as IfcTypeEnum : IfcTypeEnum.Unknown;
+    },
+    setTypeOverride: (id, typeName) => {
+      if (typeName === null) typeOverrides.delete(id);
+      else typeOverrides.set(id, typeName);
     },
     getExpressIdByGlobalId: (gid) => {
       return globalIdToExpressId.get(gid) ?? -1;

--- a/packages/data/src/entity-table.ts
+++ b/packages/data/src/entity-table.ts
@@ -51,6 +51,14 @@ export interface EntityTable {
   /** Get IfcTypeEnum for an expressId using internal index. Returns IfcTypeEnum.Unknown if not found. */
   getTypeEnum(expressId: number): IfcTypeEnum;
 
+  /**
+   * Override the displayed class for an entity (additive — the original
+   * columnar type is left intact). `getTypeName`/`getTypeEnum` return the
+   * override when set, so a UI retype reflects immediately. Pass `null` to
+   * clear. Note: this does NOT re-bucket `getByType`/`typeIndices`.
+   */
+  setTypeOverride(expressId: number, typeName: string | null): void;
+
   /** Get expressId by IFC GlobalId string (22-char GUID). Returns -1 if not found. */
   getExpressIdByGlobalId(globalId: string): number;
 
@@ -250,6 +258,11 @@ export function entityTableFromColumns(
 
   const indexOfId = (id: number): number => idToIndex.get(id) ?? -1;
 
+  // Additive display-class overrides (UI retype). Keyed by expressId → new
+  // class name. Left empty unless the host sets one; the original columnar
+  // type is never modified.
+  const typeOverrides = new Map<number, string>();
+
   // GlobalId → expressId for BCF integration. Only populated for entities
   // that actually have a non-empty GlobalId string.
   const globalIdToExpressId = new Map<string, number>();
@@ -292,6 +305,8 @@ export function entityTableFromColumns(
       return idx >= 0 ? strings.get(objectType[idx]) : '';
     },
     getTypeName: (id) => {
+      const override = typeOverrides.get(id);
+      if (override !== undefined) return override;
       const idx = indexOfId(id);
       if (idx < 0) return 'Unknown';
       const enumName = IfcTypeEnumToString(typeEnum[idx]);
@@ -313,8 +328,15 @@ export function entityTableFromColumns(
     },
 
     getTypeEnum: (id) => {
+      const override = typeOverrides.get(id);
+      if (override !== undefined) return IfcTypeEnumFromString(override);
       const idx = indexOfId(id);
       return idx >= 0 ? typeEnum[idx] as IfcTypeEnum : IfcTypeEnum.Unknown;
+    },
+
+    setTypeOverride: (id, typeName) => {
+      if (typeName === null) typeOverrides.delete(id);
+      else typeOverrides.set(id, typeName);
     },
 
     getExpressIdByGlobalId: (gid) => globalIdToExpressId.get(gid) ?? -1,

--- a/packages/export/src/retype.test.ts
+++ b/packages/export/src/retype.test.ts
@@ -49,9 +49,11 @@ function buildMockDataStore(
   } as unknown as IfcDataStore;
 }
 
-/** Pull the single `#id=...;` line for an entity out of exported content. */
+/** Pull the single `#id=...;` record for an entity out of exported content.
+ *  Matches up to the STEP record terminator (`;`) rather than a line boundary,
+ *  so the slice is correct regardless of how the file is wrapped. */
 function lineFor(content: string, id: number): string {
-  const m = content.match(new RegExp(`#${id}=[^\\n]*`));
+  const m = content.match(new RegExp(`#${id}=[^;]*;`));
   return m ? m[0] : '';
 }
 
@@ -161,6 +163,24 @@ describe('StepExporter retype materialization', () => {
 
     expect(content).toContain(`#${created.expressId}=IFCMEMBER('newGUID00000000000000',$,'Created',$,$,$,$,$,.MULLION.);`);
     expect(content).not.toContain('IFCBUILDINGELEMENTPROXY');
+  });
+
+  it('applies a same-class PredefinedType override on a created entity', () => {
+    const store = buildMockDataStore([
+      [1, 'IfcProject', "#1=IFCPROJECT('projGUID0000000000000',$,'P',$,$,$,$,$,$);"],
+    ]);
+    const view = new MutablePropertyView(null, 'm1');
+    view.setExpressIdWatermark(1);
+    const created = view.createEntity('IfcColumn', [
+      'colGUID000000000000000', '$', 'Col', '$', '$', '$', '$', '$', '$',
+    ]);
+    // Same class, but set PredefinedType via the retype API.
+    view.setEntityType(created.expressId, 'IfcColumn', 'PILASTER');
+
+    const exporter = new StepExporter(store, view);
+    const content = decode(exporter.export({ schema: 'IFC4', applyMutations: true }).content);
+
+    expect(content).toContain(`#${created.expressId}=IFCCOLUMN('colGUID000000000000000',$,'Col',$,$,$,$,$,.PILASTER.);`);
   });
 
   it('combines a retype with a name attribute edit on the same entity', () => {

--- a/packages/export/src/retype.test.ts
+++ b/packages/export/src/retype.test.ts
@@ -1,0 +1,179 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+import type { IfcDataStore } from '@ifc-lite/parser';
+import { MutablePropertyView } from '@ifc-lite/mutations';
+import { StepExporter } from './step-exporter.js';
+import { retypeStepLine } from './retype.js';
+
+const decode = (bytes: Uint8Array) => new TextDecoder().decode(bytes);
+
+type MockEntityRef = { expressId: number; type: string; byteOffset: number; byteLength: number; lineNumber: number };
+
+function buildMockDataStore(
+  entries: Array<[number, string, string]>,
+  schemaVersion: 'IFC2X3' | 'IFC4' | 'IFC4X3' = 'IFC4',
+): IfcDataStore {
+  const encoder = new TextEncoder();
+  const parts: Uint8Array[] = [];
+  const byId = new Map<number, MockEntityRef>();
+  const byType = new Map<string, number[]>();
+  let offset = 0;
+
+  for (const [id, type, text] of entries) {
+    const encoded = encoder.encode(text);
+    const upper = type.toUpperCase();
+    byId.set(id, { expressId: id, type: upper, byteOffset: offset, byteLength: encoded.byteLength, lineNumber: 0 });
+    if (!byType.has(upper)) byType.set(upper, []);
+    byType.get(upper)!.push(id);
+    parts.push(encoded);
+    offset += encoded.byteLength;
+  }
+
+  const source = new Uint8Array(offset);
+  let position = 0;
+  for (const part of parts) {
+    source.set(part, position);
+    position += part.byteLength;
+  }
+
+  return {
+    fileSize: offset,
+    schemaVersion,
+    entityCount: entries.length,
+    parseTime: 0,
+    source,
+    entityIndex: { byId, byType },
+  } as unknown as IfcDataStore;
+}
+
+/** Pull the single `#id=...;` line for an entity out of exported content. */
+function lineFor(content: string, id: number): string {
+  const m = content.match(new RegExp(`#${id}=[^\\n]*`));
+  return m ? m[0] : '';
+}
+
+describe('retypeStepLine (unit)', () => {
+  it('swaps the keyword for an identical IFC4 layout, preserving args byte-for-byte', () => {
+    const line = "#42=IFCBUILDINGELEMENTPROXY('guid',$,'Proxy',$,$,#10,#20,'tag',.NOTDEFINED.);";
+    const out = retypeStepLine(line, 'IfcBuildingElementProxy', 'IfcColumn', null, 'IFC4');
+    expect(out).toBe("#42=IFCCOLUMN('guid',$,'Proxy',$,$,#10,#20,'tag',.NOTDEFINED.);");
+  });
+
+  it('drops an out-of-domain carried PredefinedType', () => {
+    // .ELEMENT. is valid for a proxy but not for IfcColumn → drop to $.
+    const line = "#42=IFCBUILDINGELEMENTPROXY('guid',$,'P',$,$,#10,#20,'tag',.ELEMENT.);";
+    const out = retypeStepLine(line, 'IfcBuildingElementProxy', 'IfcColumn', null, 'IFC4');
+    expect(out).toBe("#42=IFCCOLUMN('guid',$,'P',$,$,#10,#20,'tag',$);");
+  });
+
+  it('sets a valid PredefinedType override', () => {
+    const line = "#42=IFCBUILDINGELEMENTPROXY('guid',$,'P',$,$,#10,#20,'tag',$);";
+    const out = retypeStepLine(line, 'IfcBuildingElementProxy', 'IfcColumn', 'PILASTER', 'IFC4');
+    expect(out).toBe("#42=IFCCOLUMN('guid',$,'P',$,$,#10,#20,'tag',.PILASTER.);");
+  });
+
+  it('falls back to USERDEFINED + ObjectType for an unknown PredefinedType override', () => {
+    const line = "#42=IFCBUILDINGELEMENTPROXY('guid',$,'P',$,$,#10,#20,'tag',$);";
+    const out = retypeStepLine(line, 'IfcBuildingElementProxy', 'IfcColumn', 'MY_SPECIAL_KIND', 'IFC4');
+    // ObjectType is attribute index 4; PredefinedType index 8.
+    expect(out).toBe("#42=IFCCOLUMN('guid',$,'P',$,'MY_SPECIAL_KIND',#10,#20,'tag',.USERDEFINED.);");
+  });
+
+  it('drops the trailing IFC2X3 CompositionType when the target has no 9th attribute', () => {
+    // IFC2X3 proxy has CompositionType; IfcColumn has only 8 attributes.
+    const line = "#42=IFCBUILDINGELEMENTPROXY('guid',$,'P',$,$,#10,#20,'tag',.ELEMENT.);";
+    const out = retypeStepLine(line, 'IfcBuildingElementProxy', 'IfcColumn', null, 'IFC2X3');
+    expect(out).toBe("#42=IFCCOLUMN('guid',$,'P',$,$,#10,#20,'tag');");
+  });
+
+  it('keyword-only swaps when the target class is unknown to the schema', () => {
+    const line = "#42=IFCBUILDINGELEMENTPROXY('guid',$,'P',$,$,#10,#20,'tag',$);";
+    const out = retypeStepLine(line, 'IfcBuildingElementProxy', 'IfcVendorExtensionThing', null, 'IFC4');
+    expect(out).toBe("#42=IFCVENDOREXTENSIONTHING('guid',$,'P',$,$,#10,#20,'tag',$);");
+  });
+});
+
+describe('StepExporter retype materialization', () => {
+  it('retypes an existing proxy to IfcColumn, keeping geometry + IfcRel references on the same id', () => {
+    const store = buildMockDataStore([
+      [10, 'IfcLocalPlacement', '#10=IFCLOCALPLACEMENT($,#11);'],
+      [11, 'IfcAxis2Placement3D', '#11=IFCAXIS2PLACEMENT3D(#12,$,$);'],
+      [12, 'IfcCartesianPoint', '#12=IFCCARTESIANPOINT((0.,0.,0.));'],
+      [20, 'IfcProductDefinitionShape', '#20=IFCPRODUCTDEFINITIONSHAPE($,$,(#21));'],
+      [21, 'IfcShapeRepresentation', "#21=IFCSHAPEREPRESENTATION(#22,'Body','SweptSolid',(#23));"],
+      [22, 'IfcGeometricRepresentationContext', '#22=IFCGEOMETRICREPRESENTATIONCONTEXT($,$,3,$,$,$);'],
+      [23, 'IfcExtrudedAreaSolid', '#23=IFCEXTRUDEDAREASOLID(#24,$,#25,1.);'],
+      [24, 'IfcRectangleProfileDef', '#24=IFCRECTANGLEPROFILEDEF(.AREA.,$,$,0.3,0.3);'],
+      [25, 'IfcDirection', '#25=IFCDIRECTION((0.,0.,1.));'],
+      [42, 'IfcBuildingElementProxy', "#42=IFCBUILDINGELEMENTPROXY('1abcGUID000000000000PR',$,'SW-Part',$,$,#10,#20,'PART-42',.NOTDEFINED.);"],
+      [50, 'IfcRelContainedInSpatialStructure', "#50=IFCRELCONTAINEDINSPATIALSTRUCTURE('relGUID00000000000000',$,$,$,(#42),#60);"],
+    ]);
+
+    const view = new MutablePropertyView(null, 'm1');
+    view.setEntityType(42, 'IfcColumn');
+
+    const exporter = new StepExporter(store, view);
+    const content = decode(exporter.export({ schema: 'IFC4', applyMutations: true }).content);
+
+    // The proxy is now a column…
+    expect(content).toContain("#42=IFCCOLUMN('1abcGUID000000000000PR',$,'SW-Part',$,$,#10,#20,'PART-42',.NOTDEFINED.);");
+    expect(content).not.toContain('IFCBUILDINGELEMENTPROXY');
+    // …with its geometry + placement + the containment relationship all still
+    // pointing at #42 (refs are by #id, so they carry over untouched).
+    expect(lineFor(content, 42)).toContain('#10');
+    expect(lineFor(content, 42)).toContain('#20');
+    expect(content).toContain('(#42),#60');
+    expect(content).toContain('#23=IFCEXTRUDEDAREASOLID(#24,$,#25,1.);');
+  });
+
+  it('retypes with a PredefinedType override', () => {
+    const store = buildMockDataStore([
+      [42, 'IfcBuildingElementProxy', "#42=IFCBUILDINGELEMENTPROXY('g',$,'P',$,$,$,$,$,.NOTDEFINED.);"],
+    ]);
+    const view = new MutablePropertyView(null, 'm1');
+    view.setExpressIdWatermark(42);
+    view.setEntityType(42, 'IfcBeam', 'JOIST');
+
+    const exporter = new StepExporter(store, view);
+    const content = decode(exporter.export({ schema: 'IFC4', applyMutations: true }).content);
+
+    expect(content).toContain("#42=IFCBEAM('g',$,'P',$,$,$,$,$,.JOIST.);");
+  });
+
+  it('retypes a freshly-created overlay entity', () => {
+    const store = buildMockDataStore([
+      [1, 'IfcProject', "#1=IFCPROJECT('projGUID0000000000000',$,'P',$,$,$,$,$,$);"],
+    ]);
+    const view = new MutablePropertyView(null, 'm1');
+    view.setExpressIdWatermark(1);
+    // Per the NewEntity convention, label strings are passed RAW (serializeStepValue
+    // quotes them); `$`/`.ENUM.`/`#N` tokens pass through.
+    const created = view.createEntity('IfcBuildingElementProxy', [
+      'newGUID00000000000000', '$', 'Created', '$', '$', '$', '$', '$', '.NOTDEFINED.',
+    ]);
+    view.setEntityType(created.expressId, 'IfcMember', 'MULLION');
+
+    const exporter = new StepExporter(store, view);
+    const content = decode(exporter.export({ schema: 'IFC4', applyMutations: true }).content);
+
+    expect(content).toContain(`#${created.expressId}=IFCMEMBER('newGUID00000000000000',$,'Created',$,$,$,$,$,.MULLION.);`);
+    expect(content).not.toContain('IFCBUILDINGELEMENTPROXY');
+  });
+
+  it('combines a retype with a name attribute edit on the same entity', () => {
+    const store = buildMockDataStore([
+      [42, 'IfcBuildingElementProxy', "#42=IFCBUILDINGELEMENTPROXY('g',$,'OldName',$,$,$,$,$,.NOTDEFINED.);"],
+    ]);
+    const view = new MutablePropertyView(null, 'm1');
+    view.setEntityType(42, 'IfcColumn');
+    view.setAttribute(42, 'Name', 'NewName');
+
+    const exporter = new StepExporter(store, view);
+    const content = decode(exporter.export({ schema: 'IFC4', applyMutations: true }).content);
+
+    expect(content).toContain("#42=IFCCOLUMN('g',$,'NewName',$,$,$,$,$,.NOTDEFINED.);");
+  });
+});

--- a/packages/export/src/retype.ts
+++ b/packages/export/src/retype.ts
@@ -1,0 +1,188 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Entity retype (reassign class) materialization for STEP export.
+ *
+ * Mirrors IfcOpenShell's `ifcopenshell.util.schema.reassign_class`: an entity
+ * keeps its expressId (so geometry / placement / representation and every
+ * `IfcRel*` reference — all keyed by `#id` — carry over unchanged) while its
+ * class keyword and attribute layout are swapped to the target class.
+ *
+ * Attributes are re-laid-out BY NAME against the target class's declared
+ * attribute list:
+ *   - attributes the target class doesn't declare are dropped
+ *     (e.g. IFC2X3 `IfcBuildingElementProxy.CompositionType` when retyping to
+ *      `IfcColumn`, which has no 9th attribute);
+ *   - attributes the target declares but the source lacks become `$`;
+ *   - the `PredefinedType` enum is validated against the target class's
+ *     domain — an out-of-domain carried value is dropped, and an explicit
+ *     out-of-domain override falls back to `USERDEFINED` + `ObjectType`.
+ *
+ * For the common building-element subtypes (Proxy ↔ Column / Beam / Member /
+ * Plate / Wall) the IFC4 attribute layout is identical, so the re-layout is an
+ * identity and only the keyword (and optionally PredefinedType) changes — the
+ * raw argument tokens are preserved byte-for-byte.
+ */
+
+import { ENTITIES_IFC2X3, ENTITIES_IFC4, ENTITIES_IFC4X3 } from '@ifc-lite/data';
+import { escapeStepString, splitTopLevelArgs } from './step-serialization.js';
+import type { IfcSchemaVersion } from './schema-converter.js';
+
+interface RetypeEntityInfo {
+  readonly attributes: readonly string[];
+  readonly predefinedTypes: readonly string[];
+}
+
+function buildSchemaMap(
+  list: ReadonlyArray<{ name: string; attributes: readonly string[]; predefinedTypes: readonly string[] }>,
+): Map<string, RetypeEntityInfo> {
+  const map = new Map<string, RetypeEntityInfo>();
+  for (const entity of list) {
+    map.set(entity.name.toUpperCase(), {
+      attributes: entity.attributes,
+      predefinedTypes: entity.predefinedTypes,
+    });
+  }
+  return map;
+}
+
+const SCHEMA_MAPS: Record<IfcSchemaVersion, Map<string, RetypeEntityInfo>> = {
+  IFC2X3: buildSchemaMap(ENTITIES_IFC2X3),
+  IFC4: buildSchemaMap(ENTITIES_IFC4),
+  IFC4X3: buildSchemaMap(ENTITIES_IFC4X3),
+  // IFC5 isn't STEP; never reached for retype, but keep the lookup total.
+  IFC5: buildSchemaMap(ENTITIES_IFC4X3),
+};
+
+/**
+ * Look up a class's attribute layout + PredefinedType domain for a schema.
+ * Falls back to the IFC4 registry for vendor extensions absent from the
+ * requested schema's bundle, then to `null` for genuinely unknown classes.
+ */
+function lookupEntityInfo(schema: IfcSchemaVersion, name: string): RetypeEntityInfo | null {
+  const upper = name.toUpperCase();
+  return SCHEMA_MAPS[schema]?.get(upper) ?? SCHEMA_MAPS.IFC4.get(upper) ?? null;
+}
+
+/** Strip the dot-wrapping from a STEP enum token: `.ELEMENT.` → `ELEMENT`. */
+function enumValue(token: string): string | null {
+  const t = token.trim();
+  if (t.length >= 2 && t.startsWith('.') && t.endsWith('.')) {
+    return t.slice(1, -1);
+  }
+  return null;
+}
+
+/** Normalize a caller-supplied predefined type to a bare enum symbol. */
+function normalizePredefined(value: string): string {
+  return (enumValue(value) ?? value).trim().toUpperCase();
+}
+
+export interface RetypeArgsResult {
+  tokens: string[];
+  /** True when the layout was resolved from schema; false ⇒ keyword-only swap. */
+  resolved: boolean;
+}
+
+/**
+ * Re-lay-out an entity's STEP argument tokens for a new class.
+ *
+ * `argTokens` are already-serialized STEP fragments (as produced by
+ * {@link splitTopLevelArgs}). Returns a fresh token array in the target
+ * class's attribute order. When source or target layout can't be resolved
+ * from the schema (vendor extension, malformed), `resolved` is false and the
+ * caller should fall back to a keyword-only swap.
+ */
+export function retypeArgTokens(
+  argTokens: string[],
+  sourceType: string,
+  newType: string,
+  predefinedType: string | null | undefined,
+  schema: IfcSchemaVersion,
+): RetypeArgsResult {
+  const sourceInfo = lookupEntityInfo(schema, sourceType);
+  const targetInfo = lookupEntityInfo(schema, newType);
+
+  // Without both layouts we can't map by name. Fall back to keyword-only swap,
+  // preserving the original argument list verbatim.
+  if (!sourceInfo || !targetInfo) {
+    return { tokens: argTokens.slice(), resolved: false };
+  }
+
+  // Map source attribute NAME → its serialized token.
+  const byName = new Map<string, string>();
+  const span = Math.min(sourceInfo.attributes.length, argTokens.length);
+  for (let i = 0; i < span; i++) {
+    byName.set(sourceInfo.attributes[i], argTokens[i]);
+  }
+
+  const tokens = targetInfo.attributes.map((name) => byName.get(name) ?? '$');
+
+  const predefinedIdx = targetInfo.attributes.indexOf('PredefinedType');
+  if (predefinedIdx >= 0) {
+    if (predefinedType != null && predefinedType !== '') {
+      const sym = normalizePredefined(predefinedType);
+      if (targetInfo.predefinedTypes.includes(sym)) {
+        tokens[predefinedIdx] = `.${sym}.`;
+      } else {
+        // Unknown enum value → USERDEFINED + carry the literal on ObjectType /
+        // ElementType, mirroring IfcOpenShell's reassign_class fallback.
+        tokens[predefinedIdx] = '.USERDEFINED.';
+        const labelIdx = targetInfo.attributes.indexOf('ObjectType') >= 0
+          ? targetInfo.attributes.indexOf('ObjectType')
+          : targetInfo.attributes.indexOf('ElementType');
+        if (labelIdx >= 0) {
+          tokens[labelIdx] = `'${escapeStepString(predefinedType)}'`;
+        }
+      }
+    } else {
+      // No override: sanitize a carried-over enum that isn't valid for the
+      // target class. PredefinedType is optional, so dropping to `$` is valid.
+      const carried = enumValue(tokens[predefinedIdx]);
+      if (carried !== null && !targetInfo.predefinedTypes.includes(carried)) {
+        tokens[predefinedIdx] = '$';
+      }
+    }
+  }
+
+  return { tokens, resolved: true };
+}
+
+/**
+ * Rewrite a raw STEP entity line to a new IFC class.
+ *
+ * `entityText` is a single STEP record (`#123=IFCFOO(...);`, possibly with a
+ * trailing newline). Returns the rewritten line, or the original unchanged if
+ * it can't be parsed.
+ */
+export function retypeStepLine(
+  entityText: string,
+  sourceType: string,
+  newType: string,
+  predefinedType: string | null | undefined,
+  schema: IfcSchemaVersion,
+): string {
+  const eq = entityText.indexOf('=');
+  const openParen = entityText.indexOf('(');
+  const closeParen = entityText.lastIndexOf(');');
+  const newUpper = newType.toUpperCase();
+
+  if (eq < 0 || openParen < eq || closeParen < openParen) {
+    return entityText;
+  }
+
+  const idPrefix = entityText.slice(0, eq + 1); // "#123="
+  const argTokens = splitTopLevelArgs(entityText.slice(openParen + 1, closeParen));
+  const { tokens, resolved } = retypeArgTokens(argTokens, sourceType, newType, predefinedType, schema);
+
+  if (!resolved) {
+    // Keyword-only swap: keep the original argument list verbatim.
+    return `${idPrefix}${newUpper}${entityText.slice(openParen)}`;
+  }
+
+  // `entityText.slice(closeParen)` keeps the closing `);` plus any trailing
+  // bytes (newline) intact.
+  return `${idPrefix}${newUpper}(${tokens.join(',')}${entityText.slice(closeParen)}`;
+}

--- a/packages/export/src/retype.ts
+++ b/packages/export/src/retype.ts
@@ -156,6 +156,14 @@ export function retypeArgTokens(
  * `entityText` is a single STEP record (`#123=IFCFOO(...);`, possibly with a
  * trailing newline). Returns the rewritten line, or the original unchanged if
  * it can't be parsed.
+ *
+ * `schema` is the schema the raw text is in (the source schema). When the
+ * exporter is ALSO converting to a different output schema, the retype runs
+ * first in the source schema and the converter runs after. A narrow edge
+ * follows from that ordering: if the target class gains a `PredefinedType`
+ * slot only in the OUTPUT schema (e.g. IFC2X3 `IfcColumn` → IFC4 `IfcColumn`),
+ * an explicit override has no slot to land in and is dropped. Retyping within
+ * a single schema (the common case) is unaffected.
  */
 export function retypeStepLine(
   entityText: string,

--- a/packages/export/src/step-exporter.ts
+++ b/packages/export/src/step-exporter.ts
@@ -595,6 +595,12 @@ export class StepExporter {
         // below resolve against the TARGET class's attribute names. The
         // expressId is unchanged, so geometry / placement / representation and
         // every IfcRel* reference (keyed by #id) carry over untouched.
+        //
+        // This materializes inside the source-iteration loop, which `deltaOnly`
+        // skips — so, like in-place attribute/positional edits to existing
+        // entities, an existing-entity retype is only emitted by a full export
+        // (the common `applyMutations` path). Retyped OVERLAY-created entities
+        // are emitted under `deltaOnly` via the new-entities pass below.
         const typeMutation = overlayActive && typeof this.mutationView!.getEntityTypeMutation === 'function'
           ? this.mutationView!.getEntityTypeMutation(expressId)
           : null;
@@ -721,15 +727,17 @@ export class StepExporter {
         if (allowedEntityIds !== null && !allowedEntityIds.has(entity.expressId)) {
           continue;
         }
-        // If retyped to a class with a different attribute layout, re-lay-out
-        // the authored attributes by name (identity for compatible layouts).
+        // A retyped overlay entity is re-laid-out by name against the target
+        // class (identity for compatible layouts). Run this whenever a retype
+        // intent exists — even a same-class retype, which carries a
+        // PredefinedType override (e.g. setEntityType(id, 'IfcColumn', 'PILASTER')).
         const typeMut = getTypeMut ? getTypeMut(entity.expressId) : null;
         let argsText: string;
-        if (typeMut && typeMut.oldType && typeMut.oldType.toUpperCase() !== upperType) {
+        if (typeMut) {
           const srcTokens = entity.attributes.map(serializeStepValue);
           const { tokens } = retypeArgTokens(
             srcTokens,
-            typeMut.oldType,
+            typeMut.oldType ?? entity.type,
             entity.type,
             typeMut.predefinedType ?? null,
             sourceSchema,

--- a/packages/export/src/step-exporter.ts
+++ b/packages/export/src/step-exporter.ts
@@ -716,29 +716,32 @@ export class StepExporter {
         ? this.mutationView.getEntityTypeMutation.bind(this.mutationView)
         : null;
       for (const entity of this.mutationView.getNewEntities()) {
-        // STEP requires UPPERCASE entity type tokens. `NewEntity.type` is
-        // stored in canonical PascalCase per the public API contract; the
-        // upper-case happens here at the file-format boundary. A retyped
-        // overlay entity already carries its new type on `entity.type`.
-        const upperType = entity.type.toUpperCase();
+        // A retyped overlay entity keeps its AUTHORED type on `entity.type`
+        // (the overlay typeMutation is the source of truth for the effective
+        // class). Resolve the effective class, then re-lay-out the authored
+        // attributes from the authored layout up to it.
+        const typeMut = getTypeMut ? getTypeMut(entity.expressId) : null;
+        const effectiveType = typeMut?.newType ?? entity.type;
+        // STEP requires UPPERCASE entity type tokens; the upper-case happens
+        // here at the file-format boundary.
+        const upperType = effectiveType.toUpperCase();
         if (options.includeGeometry === false && this.isGeometryEntity(upperType)) {
           continue;
         }
         if (allowedEntityIds !== null && !allowedEntityIds.has(entity.expressId)) {
           continue;
         }
-        // A retyped overlay entity is re-laid-out by name against the target
-        // class (identity for compatible layouts). Run this whenever a retype
-        // intent exists — even a same-class retype, which carries a
-        // PredefinedType override (e.g. setEntityType(id, 'IfcColumn', 'PILASTER')).
-        const typeMut = getTypeMut ? getTypeMut(entity.expressId) : null;
+        // Re-lay-out by name against the effective class (identity for
+        // compatible layouts). Runs whenever a retype intent exists — even a
+        // same-class retype, which carries a PredefinedType override
+        // (e.g. setEntityType(id, 'IfcColumn', 'PILASTER')).
         let argsText: string;
         if (typeMut) {
           const srcTokens = entity.attributes.map(serializeStepValue);
           const { tokens } = retypeArgTokens(
             srcTokens,
-            typeMut.oldType ?? entity.type,
             entity.type,
+            effectiveType,
             typeMut.predefinedType ?? null,
             sourceSchema,
           );

--- a/packages/export/src/step-exporter.ts
+++ b/packages/export/src/step-exporter.ts
@@ -26,6 +26,7 @@ import { safeUtf8Decode } from '@ifc-lite/data';
 import { generateIfcGuid } from '@ifc-lite/encoding';
 import { collectReferencedEntityIds, getVisibleEntityIds, collectStyleEntities } from './reference-collector.js';
 import { convertStepLine, needsConversion, type IfcSchemaVersion } from './schema-converter.js';
+import { retypeStepLine, retypeArgTokens } from './retype.js';
 import { getCompleteEntityIndex, getMaxExpressId } from './entity-iteration.js';
 import {
   escapeStepString,
@@ -588,9 +589,34 @@ export class StepExporter {
           entityRef.byteOffset,
           entityRef.byteOffset + entityRef.byteLength
         );
-        let nextEntityText = modifiedAttributes.has(expressId)
-          ? this.applyAttributeMutations(entityText, entityType, modifiedAttributes.get(expressId)!)
-          : entityText;
+        let nextEntityText = entityText;
+
+        // Entity retype (reassign class) runs FIRST so attribute mutations
+        // below resolve against the TARGET class's attribute names. The
+        // expressId is unchanged, so geometry / placement / representation and
+        // every IfcRel* reference (keyed by #id) carry over untouched.
+        const typeMutation = overlayActive && typeof this.mutationView!.getEntityTypeMutation === 'function'
+          ? this.mutationView!.getEntityTypeMutation(expressId)
+          : null;
+        let workingType = entityType;
+        if (typeMutation) {
+          nextEntityText = retypeStepLine(
+            nextEntityText,
+            entityRef.type,
+            typeMutation.newType,
+            typeMutation.predefinedType ?? null,
+            sourceSchema,
+          );
+          workingType = typeMutation.newType.toUpperCase();
+          if (!modifiedEntities.has(expressId)) {
+            modifiedEntities.add(expressId);
+            modifiedEntityCount++;
+          }
+        }
+
+        if (modifiedAttributes.has(expressId)) {
+          nextEntityText = this.applyAttributeMutations(nextEntityText, workingType, modifiedAttributes.get(expressId)!);
+        }
 
         const positional = overlayActive && typeof this.mutationView!.getPositionalMutationsForEntity === 'function'
           ? this.mutationView!.getPositionalMutationsForEntity(expressId)
@@ -680,10 +706,14 @@ export class StepExporter {
       && (options.applyMutations !== false)
       && typeof this.mutationView.getNewEntities === 'function'
     ) {
+      const getTypeMut = typeof this.mutationView.getEntityTypeMutation === 'function'
+        ? this.mutationView.getEntityTypeMutation.bind(this.mutationView)
+        : null;
       for (const entity of this.mutationView.getNewEntities()) {
         // STEP requires UPPERCASE entity type tokens. `NewEntity.type` is
         // stored in canonical PascalCase per the public API contract; the
-        // upper-case happens here at the file-format boundary.
+        // upper-case happens here at the file-format boundary. A retyped
+        // overlay entity already carries its new type on `entity.type`.
         const upperType = entity.type.toUpperCase();
         if (options.includeGeometry === false && this.isGeometryEntity(upperType)) {
           continue;
@@ -691,7 +721,24 @@ export class StepExporter {
         if (allowedEntityIds !== null && !allowedEntityIds.has(entity.expressId)) {
           continue;
         }
-        const line = `#${entity.expressId}=${upperType}(${serializeStepArgs(entity.attributes)});`;
+        // If retyped to a class with a different attribute layout, re-lay-out
+        // the authored attributes by name (identity for compatible layouts).
+        const typeMut = getTypeMut ? getTypeMut(entity.expressId) : null;
+        let argsText: string;
+        if (typeMut && typeMut.oldType && typeMut.oldType.toUpperCase() !== upperType) {
+          const srcTokens = entity.attributes.map(serializeStepValue);
+          const { tokens } = retypeArgTokens(
+            srcTokens,
+            typeMut.oldType,
+            entity.type,
+            typeMut.predefinedType ?? null,
+            sourceSchema,
+          );
+          argsText = tokens.join(',');
+        } else {
+          argsText = serializeStepArgs(entity.attributes);
+        }
+        const line = `#${entity.expressId}=${upperType}(${argsText});`;
         if (converting) {
           const converted = convertStepLine(line, sourceSchema, schema);
           if (converted !== null) {

--- a/packages/mutations/src/bulk-query-engine.ts
+++ b/packages/mutations/src/bulk-query-engine.ts
@@ -84,6 +84,13 @@ export type BulkAction =
       type: 'SET_ATTRIBUTE';
       attribute: 'name' | 'description' | 'objectType';
       value: string;
+    }
+  | {
+      type: 'SET_ENTITY_TYPE';
+      /** Target IFC class (PascalCase, e.g. "IfcColumn"). */
+      entityType: string;
+      /** Optional PredefinedType to set on the target class. */
+      predefinedType?: string | null;
     };
 
 /**
@@ -328,6 +335,13 @@ export class BulkQueryEngine {
         // Attribute mutations would need to be implemented
         // For now, we'll skip these
         return null;
+
+      case 'SET_ENTITY_TYPE':
+        return this.mutationView.setEntityType(
+          entityId,
+          action.entityType,
+          action.predefinedType ?? null,
+        );
 
       default:
         return null;

--- a/packages/mutations/src/mutable-property-view.ts
+++ b/packages/mutations/src/mutable-property-view.ts
@@ -912,21 +912,23 @@ export class MutablePropertyView {
       );
     }
 
-    // A new overlay entity is retyped in place — there's no source line to
-    // rewrite, so the recorded NewEntity.type is the single source of truth.
-    // Its `attributes` array never changes (only `type` does), so the ORIGINAL
-    // pre-retype type must stick across repeated retypes — otherwise the second
-    // retype would re-lay-out the export from the already-mutated layout.
+    // The overlay typeMutation is the single source of truth for the effective
+    // class — we deliberately do NOT mutate `NewEntity.type` in place. Its
+    // `attributes` stay in the AUTHORED layout, and the exporter re-lays-out
+    // from that original type up to the effective type. Keeping the record as
+    // the only writer makes `removeTypeMutation` a clean revert (no in-place
+    // state to roll back), which undo relies on.
     const newEntity = this.newEntities.get(entityId);
     const existing = this.typeMutations.get(entityId);
-    const resolvedOld = existing?.oldType ?? oldType ?? newEntity?.type;
-    if (newEntity) {
-      newEntity.type = trimmed;
-    }
+    // `baseType` is the ORIGINAL class before any retype (sticky; for display
+    // and the new-entity source layout). `prevEffective` is the class right
+    // before THIS retype (for granular undo).
+    const baseType = existing?.oldType ?? oldType ?? newEntity?.type;
+    const prevEffective = existing?.newType ?? baseType;
 
     this.typeMutations.set(entityId, {
       newType: trimmed,
-      oldType: resolvedOld,
+      oldType: baseType,
       predefinedType: predefinedType ?? null,
     });
 
@@ -939,7 +941,7 @@ export class MutablePropertyView {
       entityType: trimmed,
       predefinedType: predefinedType ?? null,
       newValue: trimmed,
-      oldValue: resolvedOld ?? null,
+      oldValue: prevEffective ?? null,
     };
 
     if (!skipHistory) {
@@ -959,9 +961,10 @@ export class MutablePropertyView {
   }
 
   /**
-   * Drop a retype intent. Used by undo to roll a setEntityType back to "no
-   * override". Restoring a retyped NewEntity's original type is the caller's
-   * responsibility (the original type is carried on the mutation's oldValue).
+   * Drop a retype intent, reverting the entity to its original class. Because
+   * `setEntityType` never mutates `NewEntity.type` in place, this is a complete
+   * revert for both source-buffer and overlay-created entities — nothing else
+   * to roll back.
    */
   removeTypeMutation(entityId: number): void {
     this.typeMutations.delete(entityId);

--- a/packages/mutations/src/mutable-property-view.ts
+++ b/packages/mutations/src/mutable-property-view.ts
@@ -14,7 +14,7 @@
 
 import type { PropertyTable, PropertySet, Property, QuantitySet, Quantity } from '@ifc-lite/data';
 import { PropertyValueType, QuantityType } from '@ifc-lite/data';
-import type { IfcAttributeValue, PropertyValue, PropertyMutation, QuantityMutation, AttributeMutation, Mutation, NewEntity } from './types.js';
+import type { IfcAttributeValue, PropertyValue, PropertyMutation, QuantityMutation, AttributeMutation, EntityTypeMutation, Mutation, NewEntity } from './types.js';
 import { propertyKey, quantityKey, attributeKey, generateMutationId } from './types.js';
 
 /**
@@ -53,6 +53,7 @@ export class MutablePropertyView {
   private newQsets: Map<number, Map<string, QuantitySet>> = new Map(); // entityId -> qsetName -> QuantitySet
   private attributeMutations: Map<string, AttributeMutation> = new Map(); // `${entityId}:attr:${attrName}`
   private positionalAttrMutations: Map<number, Map<number, IfcAttributeValue>> = new Map(); // entityId -> argIndex -> value
+  private typeMutations: Map<number, EntityTypeMutation> = new Map(); // entityId -> retype intent
   private newEntities: Map<number, NewEntity> = new Map();
   private tombstones: Set<number> = new Set();
   /**
@@ -866,6 +867,95 @@ export class MutablePropertyView {
   }
 
   // ---------------------------------------------------------------------------
+  // Entity-type mutations (retype / reassign class)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Change an entity's IFC class in place ("retype" / reassign class).
+   *
+   * The entity keeps its expressId, so its geometry, placement, representation
+   * and every `IfcRel*` reference (all keyed by `#id`) carry over unchanged.
+   * At export the exporter re-lays-out the entity's attributes BY NAME against
+   * the target class's declared attribute list — attributes the target class
+   * doesn't have are dropped, missing ones become `$`. This mirrors
+   * IfcOpenShell's `ifcopenshell.util.schema.reassign_class`.
+   *
+   * Intended for compatible reassignments — e.g. the building-element subtypes
+   * (`IfcBuildingElementProxy` → `IfcColumn` / `IfcBeam` / `IfcMember` /
+   * `IfcPlate` / `IfcWall`) that share the IfcElement attribute layout. For
+   * such retypes only the class keyword changes (and an optional PredefinedType).
+   *
+   * @param newType Target IFC class (canonical PascalCase, e.g. "IfcColumn").
+   * @param predefinedType Optional PredefinedType for the target class. Unknown
+   *   values fall back to USERDEFINED + ObjectType at export.
+   */
+  setEntityType(
+    entityId: number,
+    newType: string,
+    predefinedType?: string | null,
+    oldType?: string,
+    skipHistory: boolean = false,
+  ): Mutation {
+    if (!newType || typeof newType !== 'string') {
+      throw new Error('setEntityType: newType is required');
+    }
+    const trimmed = newType.trim();
+    if (trimmed.length === 0) {
+      throw new Error('setEntityType: newType cannot be empty');
+    }
+
+    // A new overlay entity is retyped in place — there's no source line to
+    // rewrite, so the recorded NewEntity.type is the single source of truth.
+    const newEntity = this.newEntities.get(entityId);
+    const resolvedOld = oldType ?? newEntity?.type;
+    if (newEntity) {
+      newEntity.type = trimmed;
+    }
+
+    this.typeMutations.set(entityId, {
+      newType: trimmed,
+      oldType: resolvedOld,
+      predefinedType: predefinedType ?? null,
+    });
+
+    const mutation: Mutation = {
+      id: generateMutationId(),
+      type: 'UPDATE_ENTITY_TYPE',
+      timestamp: Date.now(),
+      modelId: this.modelId,
+      entityId,
+      entityType: trimmed,
+      predefinedType: predefinedType ?? null,
+      newValue: trimmed,
+      oldValue: resolvedOld ?? null,
+    };
+
+    if (!skipHistory) {
+      this.mutationHistory.push(mutation);
+    }
+    return mutation;
+  }
+
+  /** Get the retype intent for an entity, or null if it hasn't been retyped. */
+  getEntityTypeMutation(entityId: number): EntityTypeMutation | null {
+    return this.typeMutations.get(entityId) ?? null;
+  }
+
+  /** All retype intents, keyed by expressId. */
+  getTypeMutations(): Map<number, EntityTypeMutation> {
+    return this.typeMutations;
+  }
+
+  /**
+   * Drop a retype intent. Used by undo to roll a setEntityType back to "no
+   * override". Restoring a retyped NewEntity's original type is the caller's
+   * responsibility (the original type is carried on the mutation's oldValue).
+   */
+  removeTypeMutation(entityId: number): void {
+    this.typeMutations.delete(entityId);
+  }
+
+  // ---------------------------------------------------------------------------
   // Entity-level mutations (create / delete)
   // ---------------------------------------------------------------------------
 
@@ -1117,6 +1207,7 @@ export class MutablePropertyView {
     this.newPsets.clear();
     this.newQsets.clear();
     this.positionalAttrMutations.clear();
+    this.typeMutations.clear();
     this.newEntities.clear();
     this.tombstones.clear();
     this.entityAliases.clear();
@@ -1187,6 +1278,18 @@ export class MutablePropertyView {
             mutation.entityId,
             index,
             mutation.newValue as IfcAttributeValue,
+          );
+          break;
+        }
+
+        case 'UPDATE_ENTITY_TYPE': {
+          const newType = mutation.entityType ?? (typeof mutation.newValue === 'string' ? mutation.newValue : undefined);
+          if (!newType) break;
+          this.setEntityType(
+            mutation.entityId,
+            newType,
+            mutation.predefinedType ?? null,
+            mutation.oldValue == null ? undefined : String(mutation.oldValue),
           );
           break;
         }

--- a/packages/mutations/src/mutable-property-view.ts
+++ b/packages/mutations/src/mutable-property-view.ts
@@ -903,11 +903,23 @@ export class MutablePropertyView {
     if (trimmed.length === 0) {
       throw new Error('setEntityType: newType cannot be empty');
     }
+    // Validate at the shared boundary — `BulkQueryEngine` calls this directly,
+    // bypassing `StoreEditor`'s regex/normalizer checks. Without this, a bulk
+    // action could record `Column` and later export `#id=COLUMN(...)`.
+    if (!/^[Ii][Ff][Cc][A-Za-z][A-Za-z0-9_]*$/.test(trimmed)) {
+      throw new Error(
+        `setEntityType: "${newType}" is not a recognizable IFC entity name (expected e.g. "IfcColumn")`,
+      );
+    }
 
     // A new overlay entity is retyped in place — there's no source line to
     // rewrite, so the recorded NewEntity.type is the single source of truth.
+    // Its `attributes` array never changes (only `type` does), so the ORIGINAL
+    // pre-retype type must stick across repeated retypes — otherwise the second
+    // retype would re-lay-out the export from the already-mutated layout.
     const newEntity = this.newEntities.get(entityId);
-    const resolvedOld = oldType ?? newEntity?.type;
+    const existing = this.typeMutations.get(entityId);
+    const resolvedOld = existing?.oldType ?? oldType ?? newEntity?.type;
     if (newEntity) {
       newEntity.type = trimmed;
     }
@@ -941,9 +953,9 @@ export class MutablePropertyView {
     return this.typeMutations.get(entityId) ?? null;
   }
 
-  /** All retype intents, keyed by expressId. */
+  /** All retype intents, keyed by expressId. Returns a defensive copy. */
   getTypeMutations(): Map<number, EntityTypeMutation> {
-    return this.typeMutations;
+    return new Map(this.typeMutations);
   }
 
   /**

--- a/packages/mutations/src/store-editor.ts
+++ b/packages/mutations/src/store-editor.ts
@@ -196,6 +196,64 @@ export class StoreEditor {
     this.view.setAttribute(expressId, attrName, value);
   }
 
+  /**
+   * Change an entity's IFC class in place ("retype" / reassign class).
+   *
+   * The entity keeps its expressId, so its geometry, placement, representation
+   * and every `IfcRel*` reference (all keyed by `#id`) carry over unchanged.
+   * The STEP exporter re-lays-out the entity's attributes BY NAME against the
+   * target class's declared layout — mirroring IfcOpenShell's
+   * `reassign_class`. Best suited to compatible reassignments such as the
+   * building-element subtypes (`IfcBuildingElementProxy` ↔ `IfcColumn` /
+   * `IfcBeam` / `IfcMember` / `IfcPlate` / `IfcWall`) which share the
+   * IfcElement attribute layout.
+   *
+   * Returns false if the id is not known to the store or the overlay.
+   *
+   * @param newType Target IFC class. PascalCase (`IfcColumn`) or the all-caps
+   *   STEP form (`IFCCOLUMN`) — both normalize to canonical PascalCase.
+   * @param options.predefinedType Optional PredefinedType for the target class.
+   */
+  setEntityType(
+    expressId: number,
+    newType: string,
+    options?: { predefinedType?: string | null },
+  ): boolean {
+    if (typeof newType !== 'string') {
+      throw new TypeError(`StoreEditor.setEntityType: newType must be a string, got ${typeof newType}`);
+    }
+    const trimmed = newType.trim();
+    if (trimmed.length === 0) {
+      throw new Error('StoreEditor.setEntityType: newType cannot be empty');
+    }
+    if (!/^[Ii][Ff][Cc][A-Za-z][A-Za-z0-9_]*$/.test(trimmed)) {
+      throw new Error(
+        `StoreEditor.setEntityType: newType "${newType}" is not a recognizable IFC entity name (expected e.g. "IfcColumn")`,
+      );
+    }
+
+    // Resolve to canonical PascalCase and reject typos when a schema-aware
+    // normaliser is wired (same contract as addEntity).
+    let canonical = trimmed;
+    if (configuredNormalizer) {
+      const resolved = configuredNormalizer(trimmed);
+      if (!resolved) {
+        throw new Error(
+          `StoreEditor.setEntityType: newType "${newType}" is not in the IFC schema registry (typo? vendor extension?)`,
+        );
+      }
+      canonical = resolved;
+    }
+
+    const newEntity = this.view.getNewEntity(expressId);
+    if (newEntity === null && !this.store.entityIndex.byId.has(expressId)) {
+      return false;
+    }
+    const oldType = newEntity?.type ?? this.store.entityIndex.byId.get(expressId)?.type;
+    this.view.setEntityType(expressId, canonical, options?.predefinedType ?? null, oldType);
+    return true;
+  }
+
   /** Look up the overlay record for a freshly-added entity. */
   getNewEntity(expressId: number): NewEntity | null {
     return this.view.getNewEntity(expressId);

--- a/packages/mutations/src/types.ts
+++ b/packages/mutations/src/types.ts
@@ -40,6 +40,7 @@ export type MutationType =
   | 'DELETE_QUANTITY'
   | 'UPDATE_ATTRIBUTE'
   | 'UPDATE_POSITIONAL_ATTRIBUTE'
+  | 'UPDATE_ENTITY_TYPE'
   | 'CREATE_ENTITY'
   | 'DELETE_ENTITY';
 
@@ -77,6 +78,16 @@ export interface Mutation {
   // Attribute specific fields
   /** Attribute name (IFC entity attributes like Name, Description, ObjectType, Tag, etc.) */
   attributeName?: string;
+
+  // Entity-type (retype) specific fields
+  /** New IFC class keyword for UPDATE_ENTITY_TYPE (canonical PascalCase, e.g. "IfcColumn"). */
+  entityType?: string;
+  /**
+   * Optional PredefinedType to set on the retyped entity. Validated against the
+   * target class's enum domain at export; an unknown value falls back to
+   * USERDEFINED + ObjectType (mirrors IfcOpenShell's reassign_class).
+   */
+  predefinedType?: string | null;
 }
 
 /**
@@ -133,6 +144,24 @@ export interface AttributeMutation {
   value: string;
   /** Previous value (for undo) */
   oldValue?: string;
+}
+
+/**
+ * Entity-type (retype) mutation for overlay tracking.
+ *
+ * Records an intent to change an entity's IFC class in place, materialized by
+ * the STEP exporter. The entity keeps its expressId, so geometry / placement /
+ * representation and every `IfcRel*` reference (all keyed by `#id`) carry over
+ * unchanged. Attribute values are re-laid-out by NAME against the target
+ * class's declared attribute list at export.
+ */
+export interface EntityTypeMutation {
+  /** Target IFC class (canonical PascalCase, e.g. "IfcColumn"). */
+  newType: string;
+  /** Source IFC class at the time of the edit (for undo / display). */
+  oldType?: string;
+  /** Optional PredefinedType to apply to the target class. */
+  predefinedType?: string | null;
 }
 
 /**

--- a/packages/mutations/test/retype.test.ts
+++ b/packages/mutations/test/retype.test.ts
@@ -1,0 +1,150 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  MutablePropertyView,
+  StoreEditor,
+  BulkQueryEngine,
+  setEntityTypeNormalizer,
+  type BulkAction,
+  type MutationEntityRef,
+  type MutationStoreShape,
+} from '../src/index.js';
+
+function makeStore(maxId: number, type = 'IFCBUILDINGELEMENTPROXY'): MutationStoreShape {
+  const byId = new Map<number, MutationEntityRef>();
+  for (let id = 1; id <= maxId; id++) {
+    byId.set(id, { expressId: id, type, byteOffset: 0, byteLength: 1, lineNumber: id });
+  }
+  return { entityIndex: { byId } };
+}
+
+afterEach(() => {
+  // The normaliser is module-global — reset so tests don't leak into each other.
+  setEntityTypeNormalizer(null);
+});
+
+describe('StoreEditor.setEntityType', () => {
+  it('records a retype intent for an existing entity', () => {
+    const store = makeStore(10);
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(store, view);
+
+    const ok = editor.setEntityType(5, 'IfcColumn');
+
+    expect(ok).toBe(true);
+    const mut = view.getEntityTypeMutation(5);
+    expect(mut).not.toBeNull();
+    expect(mut!.newType).toBe('IfcColumn');
+    expect(mut!.oldType).toBe('IFCBUILDINGELEMENTPROXY');
+    expect(mut!.predefinedType).toBeNull();
+  });
+
+  it('carries an optional PredefinedType', () => {
+    const store = makeStore(3);
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(store, view);
+
+    editor.setEntityType(2, 'IfcColumn', { predefinedType: 'PILASTER' });
+
+    expect(view.getEntityTypeMutation(2)!.predefinedType).toBe('PILASTER');
+  });
+
+  it('returns false for an unknown expressId', () => {
+    const store = makeStore(3);
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(store, view);
+
+    expect(editor.setEntityType(999, 'IfcColumn')).toBe(false);
+    expect(view.getEntityTypeMutation(999)).toBeNull();
+  });
+
+  it('rejects an empty or non-IFC type', () => {
+    const store = makeStore(3);
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(store, view);
+
+    expect(() => editor.setEntityType(1, '')).toThrow(/cannot be empty/);
+    expect(() => editor.setEntityType(1, 'Column')).toThrow(/not a recognizable IFC entity name/);
+  });
+
+  it('normalizes via the configured registry resolver', () => {
+    setEntityTypeNormalizer((t) => (t.toUpperCase() === 'IFCCOLUMN' ? 'IfcColumn' : ''));
+    const store = makeStore(3);
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(store, view);
+
+    editor.setEntityType(1, 'IFCCOLUMN');
+    expect(view.getEntityTypeMutation(1)!.newType).toBe('IfcColumn');
+
+    // A name the resolver doesn't know is rejected.
+    expect(() => editor.setEntityType(2, 'IfcNotAThing')).toThrow(/not in the IFC schema registry/);
+  });
+});
+
+describe('MutablePropertyView.setEntityType', () => {
+  it('counts as a change and surfaces in the mutation history', () => {
+    const view = new MutablePropertyView(null, 'm1');
+    view.setEntityType(7, 'IfcBeam', null, 'IfcBuildingElementProxy');
+
+    expect(view.hasChanges(7)).toBe(true);
+    expect(view.getModifiedEntityCount()).toBe(1);
+    const history = view.getMutationsForEntity(7);
+    expect(history).toHaveLength(1);
+    expect(history[0].type).toBe('UPDATE_ENTITY_TYPE');
+    expect(history[0].entityType).toBe('IfcBeam');
+  });
+
+  it('retypes a freshly-created overlay entity in place', () => {
+    const view = new MutablePropertyView(null, 'm1');
+    view.setExpressIdWatermark(10);
+    const created = view.createEntity('IfcBuildingElementProxy', ['guid', '$', "'P'", '$', '$', '#1', '$', '$', '$']);
+
+    view.setEntityType(created.expressId, 'IfcColumn');
+
+    // The stored NewEntity reflects the new type directly.
+    expect(view.getNewEntity(created.expressId)!.type).toBe('IfcColumn');
+    expect(view.getEntityTypeMutation(created.expressId)!.oldType).toBe('IfcBuildingElementProxy');
+  });
+
+  it('clear() drops retype intents', () => {
+    const view = new MutablePropertyView(null, 'm1');
+    view.setEntityType(3, 'IfcColumn');
+    view.clear();
+    expect(view.getEntityTypeMutation(3)).toBeNull();
+    expect(view.hasChanges()).toBe(false);
+  });
+
+  it('replays through exportMutations → importMutations', () => {
+    const a = new MutablePropertyView(null, 'm1');
+    a.setEntityType(4, 'IfcMember', 'MULLION', 'IfcBuildingElementProxy');
+    const json = a.exportMutations();
+
+    const b = new MutablePropertyView(null, 'm1');
+    b.importMutations(json);
+
+    const mut = b.getEntityTypeMutation(4);
+    expect(mut).not.toBeNull();
+    expect(mut!.newType).toBe('IfcMember');
+    expect(mut!.predefinedType).toBe('MULLION');
+  });
+});
+
+describe('BulkAction SET_ENTITY_TYPE', () => {
+  it('applies a retype to a selected entity', () => {
+    const view = new MutablePropertyView(null, 'm1');
+    // Minimal EntityTable stub — the engine only needs count + expressId here.
+    const entities = { count: 1, expressId: [42] } as unknown as ConstructorParameters<typeof BulkQueryEngine>[0];
+    const engine = new BulkQueryEngine(entities, view);
+
+    const action: BulkAction = { type: 'SET_ENTITY_TYPE', entityType: 'IfcColumn', predefinedType: 'COLUMN' };
+    const result = engine.execute({ select: { expressIds: [42] }, action });
+
+    expect(result.affectedEntityCount).toBe(1);
+    const mut = view.getEntityTypeMutation(42);
+    expect(mut!.newType).toBe('IfcColumn');
+    expect(mut!.predefinedType).toBe('COLUMN');
+  });
+});

--- a/packages/mutations/test/retype.test.ts
+++ b/packages/mutations/test/retype.test.ts
@@ -97,15 +97,18 @@ describe('MutablePropertyView.setEntityType', () => {
     expect(history[0].entityType).toBe('IfcBeam');
   });
 
-  it('retypes a freshly-created overlay entity in place', () => {
+  it('retypes a freshly-created overlay entity via the overlay (authored type preserved)', () => {
     const view = new MutablePropertyView(null, 'm1');
     view.setExpressIdWatermark(10);
     const created = view.createEntity('IfcBuildingElementProxy', ['guid', '$', "'P'", '$', '$', '#1', '$', '$', '$']);
 
     view.setEntityType(created.expressId, 'IfcColumn');
 
-    // The stored NewEntity reflects the new type directly.
-    expect(view.getNewEntity(created.expressId)!.type).toBe('IfcColumn');
+    // The NewEntity keeps its AUTHORED type (attributes stay in that layout);
+    // the overlay typeMutation carries the effective class. This keeps undo a
+    // clean revert and lets the exporter re-lay-out from the authored layout.
+    expect(view.getNewEntity(created.expressId)!.type).toBe('IfcBuildingElementProxy');
+    expect(view.getEntityTypeMutation(created.expressId)!.newType).toBe('IfcColumn');
     expect(view.getEntityTypeMutation(created.expressId)!.oldType).toBe('IfcBuildingElementProxy');
   });
 

--- a/packages/mutations/test/retype.test.ts
+++ b/packages/mutations/test/retype.test.ts
@@ -109,6 +109,37 @@ describe('MutablePropertyView.setEntityType', () => {
     expect(view.getEntityTypeMutation(created.expressId)!.oldType).toBe('IfcBuildingElementProxy');
   });
 
+  it('rejects an invalid type keyword at the view boundary (bulk path safety)', () => {
+    const view = new MutablePropertyView(null, 'm1');
+    expect(() => view.setEntityType(1, 'Column')).toThrow(/not a recognizable IFC entity name/);
+    expect(() => view.setEntityType(1, '')).toThrow(/is required/);
+    expect(() => view.setEntityType(1, '   ')).toThrow(/cannot be empty/);
+    expect(view.getEntityTypeMutation(1)).toBeNull();
+  });
+
+  it('preserves the original type across repeated retypes (sticky oldType)', () => {
+    const view = new MutablePropertyView(null, 'm1');
+    view.setExpressIdWatermark(10);
+    const created = view.createEntity('IfcBuildingElementProxy', ['g', '$', "'P'", '$', '$', '$', '$', '$', '$']);
+
+    view.setEntityType(created.expressId, 'IfcColumn');
+    view.setEntityType(created.expressId, 'IfcBeam');
+
+    const mut = view.getEntityTypeMutation(created.expressId)!;
+    expect(mut.newType).toBe('IfcBeam');
+    // oldType must remain the ORIGINAL authored class, not the intermediate one,
+    // so export re-lays-out from the attributes' true layout.
+    expect(mut.oldType).toBe('IfcBuildingElementProxy');
+  });
+
+  it('getTypeMutations returns a defensive copy', () => {
+    const view = new MutablePropertyView(null, 'm1');
+    view.setEntityType(3, 'IfcColumn');
+    const copy = view.getTypeMutations();
+    copy.delete(3);
+    expect(view.getEntityTypeMutation(3)).not.toBeNull();
+  });
+
   it('clear() drops retype intents', () => {
     const view = new MutablePropertyView(null, 'm1');
     view.setEntityType(3, 'IfcColumn');
@@ -146,5 +177,18 @@ describe('BulkAction SET_ENTITY_TYPE', () => {
     const mut = view.getEntityTypeMutation(42);
     expect(mut!.newType).toBe('IfcColumn');
     expect(mut!.predefinedType).toBe('COLUMN');
+  });
+
+  it('surfaces an invalid type keyword as an error instead of recording it', () => {
+    const view = new MutablePropertyView(null, 'm1');
+    const entities = { count: 1, expressId: [42] } as unknown as ConstructorParameters<typeof BulkQueryEngine>[0];
+    const engine = new BulkQueryEngine(entities, view);
+
+    const action: BulkAction = { type: 'SET_ENTITY_TYPE', entityType: 'Column' };
+    const result = engine.execute({ select: { expressIds: [42] }, action });
+
+    expect(result.success).toBe(false);
+    expect(result.affectedEntityCount).toBe(0);
+    expect(view.getEntityTypeMutation(42)).toBeNull();
   });
 });

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -1992,6 +1992,7 @@
     "CsvParseOptions: interface",
     "CsvRow: interface",
     "DataMapping: interface",
+    "EntityTypeMutation: interface",
     "EntityTypeNormalizer: type",
     "FilterOperator: type",
     "IfcAttributeValue: type",


### PR DESCRIPTION
Closes #1231.

Lets consumers of `@ifc-lite/mutations` **change the IFC class of selected entities** — retype them in place — materialized into valid STEP at export. Real-world driver: MCAD exporters (SolidWorks etc.) collapse everything to `IfcBuildingElementProxy`; users want to reassign the correct class (`IfcColumn`, `IfcBeam`, `IfcMember`, `IfcPlate`, …) per hand-picked element.

## How it works — mirrors IfcOpenShell

I read the actual `ifcopenshell.util.schema.reassign_class` / `ifcopenshell.api.root.reassign_class` source. The model it uses:

1. **Same id preserved** — IfcOS removes + recreates with `id=info["id"]`. ifc-lite's overlay keeps the same expressId naturally, so geometry / placement / representation and every `IfcRel*` reference (all keyed by `#id`) carry over unchanged — no relinking needed.
2. **Attributes copied BY NAME against the *target* class declaration** — attributes the target doesn't declare are dropped; missing ones become `$`.
3. **`PredefinedType` enum is validated** against the target class's domain; an out-of-domain value is dropped, and an unknown explicit override falls back to `USERDEFINED` + `ObjectType`.

This is strictly more correct than a naive keyword swap, which would emit invalid IFC in IFC2X3 (where `IfcBuildingElementProxy` carries a trailing `CompositionType` that `IfcColumn`/`IfcBeam`/… don't have). In IFC4/IFC4X3 the building-element subtypes share an identical 9-attribute layout, so the re-layout is an identity and only the class keyword (plus optional PredefinedType) changes — the argument tokens are preserved byte-for-byte.

## API (answers the issue's 3 questions)

1. **API** — both forms requested:
   - `StoreEditor.setEntityType(expressId, newType, { predefinedType? })` → `boolean`
   - `MutablePropertyView.setEntityType(entityId, newType, predefinedType?)`
   - `BulkAction { type: 'SET_ENTITY_TYPE', entityType, predefinedType? }`
   - Emitted by `StepExporter.export({ applyMutations: true })`.
2. **Attribute-layout compatibility** — schema-driven name-based re-layout against the target class (IFC2X3/IFC4/IFC4X3 layouts handled per-schema); enum validation for `PredefinedType`. Unknown target class → graceful keyword-only swap.
3. **Geometry / `IfcRel*`** — stay on the same expressId, carry over unchanged. ✔️ (covered by a full round-trip test asserting `#42`'s geometry, placement, and `IfcRelContainedInSpatialStructure` references survive a Proxy→Column retype).

## Tests
- `packages/mutations/test/retype.test.ts` (10): StoreEditor/view API, validation, normalizer, bulk action, `clear()`, export→import replay.
- `packages/export/src/retype.test.ts` (10): unit `retypeStepLine` (identical-layout swap, dropped out-of-domain enum, valid override, USERDEFINED fallback, IFC2X3 drop-trailing, unknown-class keyword swap) + full `StepExporter` round-trips (refs preserved, PredefinedType override, new-entity retype, retype + attribute edit combined).

Full suites green (mutations 30, export 123); full `pnpm build` (all 36 packages) and `check:api-surface` pass.

## Notes / follow-ups
- Scoped to `@ifc-lite/mutations` + `@ifc-lite/export` exactly as the issue requests. The SDK `bim.store.*` facade could expose `setEntityType` for ergonomics in a follow-up (the SDK already wires the registry normalizer, so canonical-name resolution works there).
- `BulkAction`'s pre-existing `SET_ATTRIBUTE` handler is a no-op stub; left as-is (out of scope).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “retype” (IFC class reassign) support to change an entity’s class in-place while preserving expressId, relationships, and geometry/placement.
  * Added UI to pick a target IFC class and optional `PredefinedType`, including an export reassignment badge.
  * Extended mutation and bulk-edit APIs to set the entity type (with optional `predefinedType`) and reflect it in the viewer.
  * Added per-entity display-class type overrides for consistent UI/export presentation.
* **Improvements**
  * STEP export now applies retyping first, then re-lays out attributes to match the target class layout.
  * `PredefinedType` is validated/sanitized against the target domain with safe fallbacks for unknown values.
* **Tests**
  * Added unit and end-to-end coverage for retype/materialization and mutation behavior, including undo/redo and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->