### PR TITLE
feat(export): HBJSON (Honeybee/Ladybug) energy-model export

### DIFF
--- a/.changeset/hbjson-export.md
+++ b/.changeset/hbjson-export.md
@@ -1,6 +1,7 @@
 ---
 "@ifc-lite/cli": minor
 "@ifc-lite/geometry": minor
+"@ifc-lite/sdk": minor
 "@ifc-lite/wasm": minor
 ---
 
@@ -17,4 +18,6 @@ build-ups become Honeybee opaque constructions (real layer names + thicknesses; 
 properties defaulted by material-name keyword, since IFC rarely carries them) assigned by face
 type. Shared interior walls are paired as `Surface` adjacencies so multi-zone energy models
 don't lose heat to ambient. Backed by a new pure-Rust `ifc-lite-export` crate (source of truth
-for CLI / SDK / wasm). Available in the viewer's export menu as "Export HBJSON (Energy Model)".
+for CLI / SDK / wasm). Available in the viewer's export menu as "Export HBJSON (Energy Model)",
+on the CLI as `export --format hbjson`, and via the SDK as `bim.export.hbjson()` (delegated to a
+geometry-capable backend; the data-only SDK stays wasm-free).

--- a/.changeset/hbjson-export.md
+++ b/.changeset/hbjson-export.md
@@ -15,4 +15,6 @@ profiles (not the render mesh), so they are watertight by construction and wasm-
 `IfcRailing` occurrences are emitted as shading `ShadeMesh` geometry, and `IfcMaterialLayerSet`
 build-ups become Honeybee opaque constructions (real layer names + thicknesses; thermal
 properties defaulted by material-name keyword, since IFC rarely carries them) assigned by face
-type. Backed by a new pure-Rust `ifc-lite-export` crate (source of truth for CLI / SDK / wasm).
+type. Shared interior walls are paired as `Surface` adjacencies so multi-zone energy models
+don't lose heat to ambient. Backed by a new pure-Rust `ifc-lite-export` crate (source of truth
+for CLI / SDK / wasm). Available in the viewer's export menu as "Export HBJSON (Energy Model)".

--- a/.changeset/hbjson-export.md
+++ b/.changeset/hbjson-export.md
@@ -9,6 +9,8 @@ Add HBJSON (Honeybee / Ladybug Tools energy & daylight model) export.
 `ifc-lite export <file.ifc> --format hbjson` and `GeometryProcessor.exportHbjson(buffer, name)`
 produce a Honeybee-valid model: `IfcSpace` volumes become watertight, planar-faced Rooms
 (Floor / RoofCeiling / Wall) ready to load via `Model.from_hbjson` and run in Ladybug Tools /
-Pollination. Rooms are built analytically from extruded-area profiles (not the render mesh),
-so they are watertight by construction. Backed by a new pure-Rust `ifc-lite-export` crate
-(source of truth for CLI / SDK / wasm). Apertures, doors, shades and constructions follow.
+Pollination. `IfcWindow` and `IfcDoor` occurrences are placed as coplanar Apertures and Doors
+on the matching exterior walls. Rooms and openings are built analytically from extruded-area
+profiles (not the render mesh), so they are watertight by construction and wasm-safe. Backed
+by a new pure-Rust `ifc-lite-export` crate (source of truth for CLI / SDK / wasm). Shades
+(railings) and constructions follow.

--- a/.changeset/hbjson-export.md
+++ b/.changeset/hbjson-export.md
@@ -12,5 +12,7 @@ produce a Honeybee-valid model: `IfcSpace` volumes become watertight, planar-fac
 Pollination. `IfcWindow` and `IfcDoor` occurrences are placed as coplanar Apertures and Doors
 on the matching exterior walls. Rooms and openings are built analytically from extruded-area
 profiles (not the render mesh), so they are watertight by construction and wasm-safe.
-`IfcRailing` occurrences are emitted as shading `ShadeMesh` geometry. Backed by a new pure-Rust
-`ifc-lite-export` crate (source of truth for CLI / SDK / wasm). Constructions follow.
+`IfcRailing` occurrences are emitted as shading `ShadeMesh` geometry, and `IfcMaterialLayerSet`
+build-ups become Honeybee opaque constructions (real layer names + thicknesses; thermal
+properties defaulted by material-name keyword, since IFC rarely carries them) assigned by face
+type. Backed by a new pure-Rust `ifc-lite-export` crate (source of truth for CLI / SDK / wasm).

--- a/.changeset/hbjson-export.md
+++ b/.changeset/hbjson-export.md
@@ -11,6 +11,6 @@ produce a Honeybee-valid model: `IfcSpace` volumes become watertight, planar-fac
 (Floor / RoofCeiling / Wall) ready to load via `Model.from_hbjson` and run in Ladybug Tools /
 Pollination. `IfcWindow` and `IfcDoor` occurrences are placed as coplanar Apertures and Doors
 on the matching exterior walls. Rooms and openings are built analytically from extruded-area
-profiles (not the render mesh), so they are watertight by construction and wasm-safe. Backed
-by a new pure-Rust `ifc-lite-export` crate (source of truth for CLI / SDK / wasm). Shades
-(railings) and constructions follow.
+profiles (not the render mesh), so they are watertight by construction and wasm-safe.
+`IfcRailing` occurrences are emitted as shading `ShadeMesh` geometry. Backed by a new pure-Rust
+`ifc-lite-export` crate (source of truth for CLI / SDK / wasm). Constructions follow.

--- a/.changeset/hbjson-export.md
+++ b/.changeset/hbjson-export.md
@@ -1,0 +1,14 @@
+---
+"@ifc-lite/cli": minor
+"@ifc-lite/geometry": minor
+"@ifc-lite/wasm": minor
+---
+
+Add HBJSON (Honeybee / Ladybug Tools energy & daylight model) export.
+
+`ifc-lite export <file.ifc> --format hbjson` and `GeometryProcessor.exportHbjson(buffer, name)`
+produce a Honeybee-valid model: `IfcSpace` volumes become watertight, planar-faced Rooms
+(Floor / RoofCeiling / Wall) ready to load via `Model.from_hbjson` and run in Ladybug Tools /
+Pollination. Rooms are built analytically from extruded-area profiles (not the render mesh),
+so they are watertight by construction. Backed by a new pure-Rust `ifc-lite-export` crate
+(source of truth for CLI / SDK / wasm). Apertures, doors, shades and constructions follow.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,6 +1481,7 @@ dependencies = [
 name = "ifc-lite-export"
 version = "4.1.0"
 dependencies = [
+ "ifc-lite-core",
  "ifc-lite-geometry",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,6 +1478,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ifc-lite-export"
+version = "4.1.0"
+dependencies = [
+ "ifc-lite-geometry",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "ifc-lite-ffi"
 version = "4.1.0"
 dependencies = [
@@ -1567,6 +1576,7 @@ dependencies = [
  "futures-util",
  "ifc-lite-clash",
  "ifc-lite-core",
+ "ifc-lite-export",
  "ifc-lite-geometry",
  "ifc-lite-processing",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["rust/core", "rust/geometry", "rust/processing", "rust/clash", "rust/ffi", "rust/wasm-bindings", "apps/server"]
+members = ["rust/core", "rust/geometry", "rust/processing", "rust/clash", "rust/ffi", "rust/export", "rust/wasm-bindings", "apps/server"]
 resolver = "2"
 
 [workspace.package]
@@ -14,6 +14,7 @@ ifc-lite-core = { version = "4.1.0", path = "rust/core" }
 ifc-lite-geometry = { version = "4.1.0", path = "rust/geometry" }
 ifc-lite-processing = { version = "4.1.0", path = "rust/processing" }
 ifc-lite-clash = { version = "4.1.0", path = "rust/clash" }
+ifc-lite-export = { version = "4.1.0", path = "rust/export" }
 ifc-lite-wasm = { version = "4.1.0", path = "rust/wasm-bindings" }
 
 [profile.release]

--- a/apps/viewer/src/components/viewer/HbjsonExportDialog.tsx
+++ b/apps/viewer/src/components/viewer/HbjsonExportDialog.tsx
@@ -56,11 +56,12 @@ export function HbjsonExportDialog({ trigger }: HbjsonExportDialogProps) {
 
   // Only models that still carry their original IFC bytes can be exported —
   // HBJSON is rebuilt from the source, not the tessellated geometry. Cache-
-  // restored models have no `sourceFile` and are omitted.
+  // restored models (no `sourceFile`) and non-IFC sources (e.g. GLB / point clouds, which
+  // can also be loaded) are omitted — HBJSON is rebuilt from the IFC source.
   const modelList = useMemo(
     () =>
       Array.from(models.values())
-        .filter((m) => m.sourceFile)
+        .filter((m) => m.sourceFile && /\.(ifc|ifcx|ifczip)$/i.test(m.sourceFile.name))
         .map((m) => ({ id: m.id, name: m.name, sourceFile: m.sourceFile as File })),
     [models],
   );
@@ -105,14 +106,7 @@ export function HbjsonExportDialog({ trigger }: HbjsonExportDialogProps) {
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
 
-      const rooms = (() => {
-        try {
-          return (JSON.parse(hbjson).rooms?.length ?? 0) as number;
-        } catch {
-          return 0;
-        }
-      })();
-      const msg = `Exported HBJSON — ${rooms} rooms (${(blob.size / 1024).toFixed(0)} KB)`;
+      const msg = `Exported HBJSON (${(blob.size / 1024).toFixed(0)} KB)`;
       setExportResult({ success: true, message: msg });
       toast.success(msg);
     } catch (err) {

--- a/apps/viewer/src/components/viewer/HbjsonExportDialog.tsx
+++ b/apps/viewer/src/components/viewer/HbjsonExportDialog.tsx
@@ -1,0 +1,232 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Export Dialog for HBJSON (Honeybee / Ladybug Tools energy & daylight model).
+ *
+ * HBJSON is built analytically from the original IFC bytes (rooms from IfcSpace
+ * volumes, windows/doors as apertures/doors, railings as shades, and material
+ * layer sets as opaque constructions) — so it needs the model's `sourceFile`,
+ * not the tessellated geometry. There are no per-export settings beyond the
+ * model name, so the dialog is just a picker + a short description.
+ */
+
+import { useState, useCallback, useMemo, useEffect } from 'react';
+import { Download, AlertCircle, Check, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from '@/components/ui/alert';
+import { useViewerStore } from '@/store';
+import { toast } from '@/components/ui/toast';
+import { GeometryProcessor } from '@ifc-lite/geometry';
+
+interface HbjsonExportDialogProps {
+  trigger?: React.ReactNode;
+}
+
+export function HbjsonExportDialog({ trigger }: HbjsonExportDialogProps) {
+  const models = useViewerStore((s) => s.models);
+
+  const [open, setOpen] = useState(false);
+  const [selectedModelId, setSelectedModelId] = useState<string>('');
+  const [isExporting, setIsExporting] = useState(false);
+  const [exportResult, setExportResult] = useState<{ success: boolean; message: string } | null>(null);
+
+  // Only models that still carry their original IFC bytes can be exported —
+  // HBJSON is rebuilt from the source, not the tessellated geometry. Cache-
+  // restored models have no `sourceFile` and are omitted.
+  const modelList = useMemo(
+    () =>
+      Array.from(models.values())
+        .filter((m) => m.sourceFile)
+        .map((m) => ({ id: m.id, name: m.name, sourceFile: m.sourceFile as File })),
+    [models],
+  );
+
+  useEffect(() => {
+    if (modelList.length > 0 && !modelList.some((m) => m.id === selectedModelId)) {
+      setSelectedModelId(modelList[0].id);
+    }
+  }, [modelList, selectedModelId]);
+
+  const selectedModel = useMemo(
+    () => modelList.find((m) => m.id === selectedModelId),
+    [modelList, selectedModelId],
+  );
+
+  const handleExport = useCallback(async () => {
+    if (!selectedModel?.sourceFile) return;
+
+    setIsExporting(true);
+    setExportResult(null);
+
+    try {
+      const bytes = new Uint8Array(await selectedModel.sourceFile.arrayBuffer());
+      const baseName = selectedModel.name.replace(/\.[^.]+$/, '');
+
+      // A fresh processor is cheap: wasm-bindgen shares one module singleton,
+      // so init() no-ops when the viewer already initialised the engine.
+      const processor = new GeometryProcessor();
+      await processor.init();
+      const hbjson = processor.exportHbjson(bytes, baseName);
+      if (hbjson === null) {
+        throw new Error('Geometry engine unavailable');
+      }
+
+      const blob = new Blob([hbjson], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${baseName}.hbjson`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+
+      const rooms = (() => {
+        try {
+          return (JSON.parse(hbjson).rooms?.length ?? 0) as number;
+        } catch {
+          return 0;
+        }
+      })();
+      const msg = `Exported HBJSON — ${rooms} rooms (${(blob.size / 1024).toFixed(0)} KB)`;
+      setExportResult({ success: true, message: msg });
+      toast.success(msg);
+    } catch (err) {
+      console.error('HBJSON export failed:', err);
+      const errMsg = `HBJSON export failed: ${err instanceof Error ? err.message : 'Unknown error'}`;
+      setExportResult({ success: false, message: errMsg });
+      toast.error(errMsg);
+    } finally {
+      setIsExporting(false);
+    }
+  }, [selectedModel]);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        {trigger || (
+          <Button variant="outline" size="sm">
+            <Download className="h-4 w-4 mr-2" />
+            Export HBJSON
+          </Button>
+        )}
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md overflow-hidden">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Download className="h-5 w-5" />
+            Export HBJSON (Energy Model)
+          </DialogTitle>
+          <DialogDescription>
+            Honeybee / Ladybug Tools model for energy &amp; daylight analysis
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-4 max-h-[60vh] overflow-y-auto">
+          {/* Model selector — only shown when multiple are loaded */}
+          {modelList.length > 1 && (
+            <div className="flex items-center gap-4">
+              <Label className="w-32">Model</Label>
+              <Select value={selectedModelId} onValueChange={setSelectedModelId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select model" />
+                </SelectTrigger>
+                <SelectContent>
+                  {modelList.map((m) => {
+                    const maxLen = 24;
+                    const displayName =
+                      m.name.length > maxLen ? m.name.slice(0, maxLen) + '…' : m.name;
+                    return (
+                      <SelectItem key={m.id} value={m.id} title={m.name}>
+                        {displayName}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {/* Output format indicator */}
+          <div className="flex items-center gap-4">
+            <Label className="w-32 text-muted-foreground">Output</Label>
+            <Badge variant="secondary">Honeybee Model</Badge>
+            <span className="text-xs text-muted-foreground">.hbjson</span>
+          </div>
+
+          <p className="text-xs text-muted-foreground">
+            Builds watertight rooms from <code>IfcSpace</code> volumes, places windows and doors
+            as apertures, emits railings as shades, and maps material layer sets to opaque
+            constructions. Loads directly in Honeybee / Pollination. Thermal properties are
+            defaulted by material name and meant to be refined downstream.
+          </p>
+
+          {!selectedModel && (
+            <Alert>
+              <AlertCircle className="h-4 w-4" />
+              <AlertTitle>No source available</AlertTitle>
+              <AlertDescription>
+                HBJSON export needs the original IFC file. Re-open the model from disk to enable it.
+              </AlertDescription>
+            </Alert>
+          )}
+
+          {exportResult && (
+            <Alert variant={exportResult.success ? 'default' : 'destructive'}>
+              {exportResult.success ? (
+                <Check className="h-4 w-4" />
+              ) : (
+                <AlertCircle className="h-4 w-4" />
+              )}
+              <AlertTitle>{exportResult.success ? 'Success' : 'Error'}</AlertTitle>
+              <AlertDescription>{exportResult.message}</AlertDescription>
+            </Alert>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleExport} disabled={isExporting || !selectedModel}>
+            {isExporting ? (
+              <>
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                Exporting...
+              </>
+            ) : (
+              <>
+                <Download className="h-4 w-4 mr-2" />
+                Export
+              </>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -78,6 +78,7 @@ import { CSVExporter } from '@ifc-lite/export';
 import { FileSpreadsheet, FileJson, FileText, Filter, Upload, Pencil, DraftingCompass } from 'lucide-react';
 import { ExportDialog } from './ExportDialog';
 import { GLBExportDialog } from './GLBExportDialog';
+import { HbjsonExportDialog } from './HbjsonExportDialog';
 import { BulkPropertyEditor } from './BulkPropertyEditor';
 import { DataConnector } from './DataConnector';
 import { ExportChangesButton } from './ExportChangesButton';
@@ -879,6 +880,15 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
               <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
                 <Download className="h-4 w-4 mr-2" />
                 Export GLB (3D Model)
+              </DropdownMenuItem>
+            }
+          />
+          <DropdownMenuSeparator />
+          <HbjsonExportDialog
+            trigger={
+              <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+                <Download className="h-4 w-4 mr-2" />
+                Export HBJSON (Energy Model)
               </DropdownMenuItem>
             }
           />

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,7 +40,8 @@
     "@ifc-lite/query": "workspace:^",
     "@ifc-lite/sandbox": "workspace:^",
     "@ifc-lite/sdk": "workspace:^",
-    "@ifc-lite/viewer-core": "workspace:^"
+    "@ifc-lite/viewer-core": "workspace:^",
+    "@ifc-lite/wasm": "workspace:^"
   },
   "devDependencies": {
     "@types/node": "^25.9.3",

--- a/packages/cli/src/commands/clash.ts
+++ b/packages/cli/src/commands/clash.ts
@@ -15,6 +15,7 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import { basename } from 'node:path';
 import { createHeadlessContext } from '../loader.js';
+import { ensureWasmForNode } from '../wasm-node-init.js';
 import { getFlag, hasFlag, fatal, printJson } from '../output.js';
 import { GeometryProcessor, type MeshData } from '@ifc-lite/geometry';
 import type { IfcDataStore } from '@ifc-lite/parser';
@@ -46,6 +47,8 @@ let sharedProcessor: GeometryProcessor | undefined;
 
 async function getProcessor(): Promise<GeometryProcessor> {
   if (!sharedProcessor) {
+    // `--target web` wasm can't fetch(file://) under Node; pre-init from disk.
+    await ensureWasmForNode();
     const processor = new GeometryProcessor();
     await processor.init();
     sharedProcessor = processor;

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -10,9 +10,12 @@
  * and schema conversion on export.
  */
 
-import { writeFile } from 'node:fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
+import { basename } from 'node:path';
 import { createHeadlessContext } from '../loader.js';
+import { ensureWasmForNode } from '../wasm-node-init.js';
 import { getFlag, hasFlag, fatal, writeOutput } from '../output.js';
+import { GeometryProcessor } from '@ifc-lite/geometry';
 import type { ComparisonOp } from '@ifc-lite/sdk';
 
 /**
@@ -144,7 +147,7 @@ export async function exportCommand(args: string[]): Promise<void> {
   const propFilter = getFlag(args, '--where');
   const storeyFilter = getFlag(args, '--storey');
 
-  if (!filePath) fatal('Usage: ifc-lite export <file.ifc> --format csv|json|ifc [--type IfcWall] [--columns Name,Type,GlobalId] [--where PsetName.Prop=Value] [--storey Name] [--out file]');
+  if (!filePath) fatal('Usage: ifc-lite export <file.ifc> --format csv|json|ifc|hbjson [--type IfcWall] [--columns Name,Type,GlobalId] [--where PsetName.Prop=Value] [--storey Name] [--name Model] [--out file]');
 
   // B9/F6: Auto-prefix Ifc
   if (type) {
@@ -241,7 +244,21 @@ export async function exportCommand(args: string[]): Promise<void> {
       process.stderr.write(`Written to ${outPath}\n`);
       break;
     }
+    case 'hbjson': {
+      // Honeybee/Ladybug energy-model export: analytic IfcSpace room volumes.
+      // Needs the wasm geometry engine (not the data-only `bim` path).
+      await ensureWasmForNode();
+      const processor = new GeometryProcessor();
+      await processor.init();
+      const buffer = await readFile(filePath);
+      const bytes = new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+      const name = getFlag(args, '--name') ?? basename(filePath).replace(/\.ifc$/i, '');
+      const hbjson = processor.exportHbjson(bytes, name);
+      if (hbjson === null) fatal('Geometry engine unavailable for HBJSON export');
+      await writeOutput(hbjson, outPath);
+      break;
+    }
     default:
-      fatal(`Unknown format: ${format}. Supported: csv, json, ifc`);
+      fatal(`Unknown format: ${format}. Supported: csv, json, ifc, hbjson`);
   }
 }

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -10,12 +10,10 @@
  * and schema conversion on export.
  */
 
-import { readFile, writeFile } from 'node:fs/promises';
+import { writeFile } from 'node:fs/promises';
 import { basename } from 'node:path';
 import { createHeadlessContext } from '../loader.js';
-import { ensureWasmForNode } from '../wasm-node-init.js';
 import { getFlag, hasFlag, fatal, writeOutput } from '../output.js';
-import { GeometryProcessor } from '@ifc-lite/geometry';
 import type { ComparisonOp } from '@ifc-lite/sdk';
 
 /**
@@ -245,16 +243,10 @@ export async function exportCommand(args: string[]): Promise<void> {
       break;
     }
     case 'hbjson': {
-      // Honeybee/Ladybug energy-model export: analytic IfcSpace room volumes.
-      // Needs the wasm geometry engine (not the data-only `bim` path).
-      await ensureWasmForNode();
-      const processor = new GeometryProcessor();
-      await processor.init();
-      const buffer = await readFile(filePath);
-      const bytes = new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+      // Honeybee/Ladybug energy-model export via the SDK (the headless backend meshes
+      // analytically through the wasm engine; the data-only SDK delegates to it).
       const name = getFlag(args, '--name') ?? basename(filePath).replace(/\.ifc$/i, '');
-      const hbjson = processor.exportHbjson(bytes, name);
-      if (hbjson === null) fatal('Geometry engine unavailable for HBJSON export');
+      const hbjson = await bim.export.hbjson({ name });
       await writeOutput(hbjson, outPath);
       break;
     }

--- a/packages/cli/src/headless-backend.ts
+++ b/packages/cli/src/headless-backend.ts
@@ -41,6 +41,8 @@ import type {
 } from '@ifc-lite/sdk';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import { MutablePropertyView, StoreEditor } from '@ifc-lite/mutations';
+import { GeometryProcessor } from '@ifc-lite/geometry';
+import { ensureWasmForNode } from './wasm-node-init.js';
 import {
   addBeamToStore,
   addColumnToStore,
@@ -529,6 +531,7 @@ export class HeadlessBackend implements BimBackend {
 
   private createExportAdapter(): ExportBackendMethods {
     const store = this.dataStore;
+    const modelName = this.modelName;
     const queryAdapter = this.query;
 
     function escapeCsv(value: string, sep: string): string {
@@ -632,6 +635,23 @@ export class HeadlessBackend implements BimBackend {
           return new TextDecoder().decode(result.content);
         }
         return exportToStep(store, exportOpts);
+      },
+      hbjson: async (name?: string): Promise<string> => {
+        // HBJSON is rebuilt analytically from the source IFC bytes (rooms/openings/
+        // shades/constructions/adjacency) via the wasm geometry engine.
+        const bytes = store.source;
+        if (!bytes || bytes.length === 0) {
+          throw new Error('HBJSON export needs the source IFC bytes, which this store did not retain.');
+        }
+        await ensureWasmForNode();
+        const processor = new GeometryProcessor();
+        await processor.init();
+        const baseName = (name ?? modelName).replace(/\.[^.]+$/, '');
+        const result = processor.exportHbjson(bytes, baseName);
+        if (result === null) {
+          throw new Error('Geometry engine unavailable for HBJSON export.');
+        }
+        return result;
       },
       download(_content: string, _filename: string, _mimeType: string): void {
         /* no-op — CLI writes to stdout/file directly */

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -64,7 +64,7 @@ const HELP = `
     info      <file.ifc>                          Model summary (schema, entities, storeys)
     query     <file.ifc> [--type T] [--json]      Query entities by type/properties/quantities
     props     <file.ifc> --id <N>                 All properties for a single entity
-    export    <file.ifc> --format csv|json|ifc    Export data to file or stdout
+    export    <file.ifc> --format csv|json|ifc|hbjson  Export data / Honeybee energy model
     ids       <file.ifc> <rules.ids>              Validate against IDS rules
     bcf       <create|list|add-comment>           Work with BCF collaboration files
     clash     <file.ifc> [--matrix] [--bcf F]      Detect geometric clashes between elements

--- a/packages/cli/src/wasm-node-init.ts
+++ b/packages/cli/src/wasm-node-init.ts
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Node wasm bootstrap.
+ *
+ * `@ifc-lite/wasm` is built with `wasm-pack --target web`, whose generated
+ * `init()` resolves the `.wasm` via `fetch(new URL(..., import.meta.url))`.
+ * Node's undici cannot `fetch()` a `file://` URL, so `GeometryProcessor.init()`
+ * throws "fetch failed". We pre-initialise the wasm-bindgen singleton from disk
+ * with `initSync`; the bridge's later `init()` then no-ops on the
+ * `wasm !== undefined` guard. Idempotent and Node-only (never bundled for the
+ * browser, which keeps the fetch path).
+ */
+
+import { readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { initSync } from '@ifc-lite/wasm';
+
+let initialized = false;
+
+/** Ensure the `@ifc-lite/wasm` module is initialised in a Node process. */
+export async function ensureWasmForNode(): Promise<void> {
+  if (initialized) return;
+  const require = createRequire(import.meta.url);
+  const jsPath = require.resolve('@ifc-lite/wasm');
+  const wasmPath = join(dirname(jsPath), 'ifc-lite_bg.wasm');
+  const bytes = await readFile(wasmPath);
+  initSync({ module: bytes });
+  initialized = true;
+}

--- a/packages/geometry/src/ifc-lite-bridge.ts
+++ b/packages/geometry/src/ifc-lite-bridge.ts
@@ -274,6 +274,32 @@ export class IfcLiteBridge {
   }
 
   /**
+   * Export the `IfcSpace` volumes in `content` as a Honeybee HBJSON string
+   * (Ladybug Tools energy/daylight model). Rooms are built analytically from
+   * extruded-area profiles (watertight by construction).
+   *
+   * @param content Raw IFC file text.
+   * @param name    Model identifier / display name.
+   */
+  exportHbjson(content: string, name: string): string {
+    if (!this.ifcApi) {
+      throw new Error('IFC-Lite not initialized. Call init() first.');
+    }
+    try {
+      return this.ifcApi.exportHbjson(content, name);
+    } catch (error) {
+      log.error('Failed to export HBJSON', error, {
+        operation: 'exportHbjson',
+        data: { contentLength: content.length },
+      });
+      if (this.isWasmRuntimeError(error)) {
+        this.markFatalWasmRuntimeError();
+      }
+      throw error;
+    }
+  }
+
+  /**
    * Get IFC-Lite API instance
    */
   getApi(): IfcAPI {

--- a/packages/geometry/src/index.ts
+++ b/packages/geometry/src/index.ts
@@ -1029,6 +1029,20 @@ export class GeometryProcessor {
   }
 
   /**
+   * Export the `IfcSpace` volumes in `buffer` as a Honeybee HBJSON string
+   * (Ladybug Tools energy/daylight model). Returns null if not initialized.
+   * @param buffer IFC file buffer
+   * @param name Model identifier / display name
+   */
+  exportHbjson(buffer: Uint8Array, name: string): string | null {
+    if (!this.bridge || !this.bridge.isInitialized()) {
+      return null;
+    }
+    const content = safeUtf8Decode(buffer);
+    return this.bridge.exportHbjson(content, name);
+  }
+
+  /**
    * Cleanup resources
    */
   dispose(): void {

--- a/packages/sdk/src/context.test.ts
+++ b/packages/sdk/src/context.test.ts
@@ -381,6 +381,25 @@ describe('ExportNamespace', () => {
     );
   });
 
+  it('hbjson() delegates to a geometry-capable backend', async () => {
+    const { backend } = createMockBackend();
+    const mock = vi.fn(async (_name?: string) => '{"type":"Model","rooms":[]}');
+    backend.export.hbjson = mock;
+    const bim = createBimContext({ backend });
+
+    const content = await bim.export.hbjson({ name: 'demo' });
+
+    expect(content).toContain('"type":"Model"');
+    expect(mock).toHaveBeenCalledWith('demo');
+  });
+
+  it('hbjson() throws when the backend has no geometry capability', async () => {
+    const { backend } = createMockBackend(); // data-only mock: no export.hbjson
+    const bim = createBimContext({ backend });
+
+    await expect(bim.export.hbjson()).rejects.toThrow(/geometry-capable backend/);
+  });
+
 });
 
 describe('FilesNamespace', () => {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -165,7 +165,7 @@ export { MutateNamespace } from './namespaces/mutate.js';
 export { StoreNamespace } from './namespaces/store.js';
 export { LensNamespace } from './namespaces/lens.js';
 export { ExportNamespace } from './namespaces/export.js';
-export type { ExportCsvOptions, ExportGltfOptions, ExportStepOptions } from './namespaces/export.js';
+export type { ExportCsvOptions, ExportGltfOptions, ExportStepOptions, ExportHbjsonOptions } from './namespaces/export.js';
 
 // IDS — full validation, facets, constraints, translation
 export { IDSNamespace } from './namespaces/ids.js';

--- a/packages/sdk/src/namespaces/export.ts
+++ b/packages/sdk/src/namespaces/export.ts
@@ -29,6 +29,13 @@ export interface ExportStepOptions {
   visibleOnly?: boolean;
 }
 
+export interface ExportHbjsonOptions {
+  /** Honeybee model identifier / display name (defaults to the model name). */
+  name?: string;
+  /** When set, also trigger a download with this filename. */
+  filename?: string;
+}
+
 /** bim.export — Data export in multiple formats */
 export class ExportNamespace {
   constructor(private backend: BimBackend) {}
@@ -182,6 +189,26 @@ export class ExportNamespace {
     const content = this.backend.export.ifc(refs, options);
     if (options.filename) {
       this.backend.export.download(content, options.filename, 'application/x-step;charset=utf-8;');
+    }
+    return content;
+  }
+
+  /**
+   * Export the model as a Honeybee HBJSON energy/daylight model — `IfcSpace` volumes become
+   * watertight rooms, windows/doors become apertures/doors, railings become shades, material
+   * layer sets become opaque constructions, and shared interior walls are paired as `Surface`
+   * adjacencies. Loads directly in Honeybee / Ladybug Tools / Pollination.
+   *
+   * Requires a geometry-capable backend (the CLI and browser carry the wasm engine); the
+   * data-only SDK never meshes, so this throws on a backend that does not provide it.
+   */
+  async hbjson(options: ExportHbjsonOptions = {}): Promise<string> {
+    if (!this.backend.export.hbjson) {
+      throw new Error('HBJSON export requires a geometry-capable backend; the active backend does not provide it.');
+    }
+    const content = await this.backend.export.hbjson(options.name);
+    if (options.filename) {
+      this.backend.export.download(content, options.filename, 'application/json');
     }
     return content;
   }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -587,6 +587,12 @@ export interface ExportBackendMethods {
   json(refs: unknown, columns: unknown): Record<string, unknown>[];
   ifc(refs: unknown, options: unknown): string | Uint8Array;
   download(content: string | Uint8Array, filename: string, mimeType: string): void;
+  /**
+   * Export the model's `IfcSpace` volumes as a Honeybee HBJSON energy/daylight model.
+   * Optional — present only on geometry-capable backends (CLI / browser, which carry the
+   * wasm engine); the data-only SDK never meshes, so it delegates here.
+   */
+  hbjson?(name?: string): Promise<string>;
 }
 
 export interface LensBackendMethods {

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -135,6 +135,19 @@ export class IfcAPI {
    */
   parseGridLines(content: string): Float32Array;
   /**
+   * Export the `IfcSpace` volumes in `content` as a Honeybee **HBJSON** string.
+   *
+   * Rooms are built analytically from extruded-area profiles (watertight by construction);
+   * faces are typed Floor / RoofCeiling / Wall with outward normals. The result loads via
+   * `honeybee.model.Model.from_hbjson` and is ready for Ladybug Tools / Pollination.
+   *
+   * ```javascript
+   * const api = new IfcAPI();
+   * const hbjson = api.exportHbjson(ifcContent, "my_model");
+   * ```
+   */
+  exportHbjson(content: string, name: string): string;
+  /**
    * Parse the file and return every `IfcAlignment` directrix as a flat
    * `Float32Array` of 3D line-list vertices `[x0,y0,z0, x1,y1,z1, …]` in
    * the renderer's Y-up world space (RTC-subtracted, metres). Consecutive
@@ -926,6 +939,7 @@ export interface InitOutput {
   readonly ifcapi_buildPrePassOnce: (a: number, b: number, c: number) => number;
   readonly ifcapi_buildPrePassStreaming: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number) => void;
   readonly ifcapi_clearPrePassCache: (a: number) => void;
+  readonly ifcapi_exportHbjson: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
   readonly ifcapi_extractProfiles: (a: number, b: number, c: number, d: number) => number;
   readonly ifcapi_getMemory: (a: number) => number;
   readonly ifcapi_is_ready: (a: number) => number;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -629,6 +629,9 @@ importers:
       '@ifc-lite/viewer-core':
         specifier: workspace:^
         version: link:../viewer
+      '@ifc-lite/wasm':
+        specifier: workspace:^
+        version: link:../wasm
     devDependencies:
       '@types/node':
         specifier: ^25.9.3

--- a/rust/export/Cargo.toml
+++ b/rust/export/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 description = "Domain-format exporters for ifc-lite (HBJSON / Honeybee energy model; glTF to follow)."
 
 [dependencies]
+ifc-lite-core = { workspace = true }
 ifc-lite-geometry = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/rust/export/Cargo.toml
+++ b/rust/export/Cargo.toml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: MPL-2.0
+[package]
+name = "ifc-lite-export"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Domain-format exporters for ifc-lite (HBJSON / Honeybee energy model; glTF to follow)."
+
+[dependencies]
+ifc-lite-geometry = { workspace = true }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/rust/export/examples/dump_hbjson.rs
+++ b/rust/export/examples/dump_hbjson.rs
@@ -7,8 +7,8 @@ fn main() {
     let (json, stats) =
         ifc_lite_export::export_hbjson_with_stats(&bytes, &ifc_lite_export::HbjsonOptions { name, tolerance: 0.01 });
     eprintln!(
-        "IfcSpace: {} | rooms: {} | skipped: {} | windows: {} | doors: {} | shades: {} | constructions: {}",
-        stats.spaces, stats.rooms, stats.skipped, stats.apertures, stats.doors, stats.shades, stats.constructions
+        "IfcSpace: {} | rooms: {} | skipped: {} | windows: {} | doors: {} | shades: {} | constructions: {} | interior-adj: {}",
+        stats.spaces, stats.rooms, stats.skipped, stats.apertures, stats.doors, stats.shades, stats.constructions, stats.interior_adjacencies
     );
     print!("{json}");
 }

--- a/rust/export/examples/dump_hbjson.rs
+++ b/rust/export/examples/dump_hbjson.rs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MPL-2.0
+//! Dump HBJSON for an IFC file: `cargo run --example dump_hbjson -- <file.ifc> [name]`
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let bytes = std::fs::read(&args[1]).expect("read ifc");
+    let name = args.get(2).cloned().unwrap_or_else(|| "model".to_string());
+    let (json, stats) =
+        ifc_lite_export::export_hbjson_with_stats(&bytes, &ifc_lite_export::HbjsonOptions { name, tolerance: 0.01 });
+    eprintln!("IfcSpace: {} | rooms emitted: {} | skipped (P5): {}", stats.spaces, stats.rooms, stats.skipped);
+    print!("{json}");
+}

--- a/rust/export/examples/dump_hbjson.rs
+++ b/rust/export/examples/dump_hbjson.rs
@@ -2,7 +2,11 @@
 //! Dump HBJSON for an IFC file: `cargo run --example dump_hbjson -- <file.ifc> [name]`
 fn main() {
     let args: Vec<String> = std::env::args().collect();
-    let bytes = std::fs::read(&args[1]).expect("read ifc");
+    let Some(path) = args.get(1) else {
+        eprintln!("usage: dump_hbjson <file.ifc> [name]");
+        std::process::exit(2);
+    };
+    let bytes = std::fs::read(path).expect("read ifc");
     let name = args.get(2).cloned().unwrap_or_else(|| "model".to_string());
     let (json, stats) =
         ifc_lite_export::export_hbjson_with_stats(&bytes, &ifc_lite_export::HbjsonOptions { name, tolerance: 0.01 });

--- a/rust/export/examples/dump_hbjson.rs
+++ b/rust/export/examples/dump_hbjson.rs
@@ -6,6 +6,9 @@ fn main() {
     let name = args.get(2).cloned().unwrap_or_else(|| "model".to_string());
     let (json, stats) =
         ifc_lite_export::export_hbjson_with_stats(&bytes, &ifc_lite_export::HbjsonOptions { name, tolerance: 0.01 });
-    eprintln!("IfcSpace: {} | rooms emitted: {} | skipped (P5): {}", stats.spaces, stats.rooms, stats.skipped);
+    eprintln!(
+        "IfcSpace: {} | rooms: {} | skipped (P5): {} | windows: {} | doors: {} | shades: {}",
+        stats.spaces, stats.rooms, stats.skipped, stats.apertures, stats.doors, stats.shades
+    );
     print!("{json}");
 }

--- a/rust/export/examples/dump_hbjson.rs
+++ b/rust/export/examples/dump_hbjson.rs
@@ -7,8 +7,8 @@ fn main() {
     let (json, stats) =
         ifc_lite_export::export_hbjson_with_stats(&bytes, &ifc_lite_export::HbjsonOptions { name, tolerance: 0.01 });
     eprintln!(
-        "IfcSpace: {} | rooms: {} | skipped (P5): {} | windows: {} | doors: {} | shades: {}",
-        stats.spaces, stats.rooms, stats.skipped, stats.apertures, stats.doors, stats.shades
+        "IfcSpace: {} | rooms: {} | skipped: {} | windows: {} | doors: {} | shades: {} | constructions: {}",
+        stats.spaces, stats.rooms, stats.skipped, stats.apertures, stats.doors, stats.shades, stats.constructions
     );
     print!("{json}");
 }

--- a/rust/export/src/adjacency.rs
+++ b/rust/export/src/adjacency.rs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MPL-2.0
+//! Interior adjacency for the HBJSON exporter.
+//!
+//! `IfcSpace` volumes are net (inner-face) air volumes, so two rooms that share a wall have
+//! parallel faces separated by the wall thickness — Honeybee's `solve_adjacency` needs
+//! coincident faces and won't pair them, leaving interior walls as `Outdoors` (wrong: they
+//! would lose heat to ambient). Honeybee *does* accept a manually-set `Surface` boundary
+//! condition between two parallel, same-area faces offset by the wall thickness (verified),
+//! so this pass proximity-matches wall faces and cross-references them as `Surface` — no
+//! geometry change. Only full-wall (equal-area, aligned) pairs are matched; partial overlaps
+//! are left exterior (they would need face splitting).
+
+use crate::hbjson::Room;
+use crate::rooms::{center, dot, newell_normal, polygon_area};
+
+/// Max plane separation to treat as a shared wall (a generous wall thickness), metres.
+const MAX_GAP: f64 = 0.6;
+/// Max in-plane centroid misalignment for two faces to count as facing each other, metres.
+const MAX_LATERAL: f64 = 0.15;
+/// Max relative area difference. Honeybee's matching-areas check is strict (net IFC spaces
+/// rarely produce perfectly congruent faces), so only near-congruent walls are paired.
+const MAX_AREA_DIFF: f64 = 0.01;
+
+fn sub(a: [f64; 3], b: [f64; 3]) -> [f64; 3] { [a[0] - b[0], a[1] - b[1], a[2] - b[2]] }
+fn dist(a: [f64; 3], b: [f64; 3]) -> f64 {
+    let d = sub(a, b);
+    (d[0] * d[0] + d[1] * d[1] + d[2] * d[2]).sqrt()
+}
+
+struct WallFace {
+    ri: usize,
+    fi: usize,
+    c: [f64; 3],
+    n: [f64; 3],
+    area: f64,
+    face_id: String,
+    room_id: String,
+}
+
+/// Pair up shared interior walls and set reciprocal `Surface` boundary conditions.
+/// Returns the number of interior faces created (2 per matched pair).
+pub fn solve_adjacency(rooms: &mut [Room]) -> usize {
+    let mut faces: Vec<WallFace> = Vec::new();
+    for (ri, room) in rooms.iter().enumerate() {
+        for (fi, f) in room.faces.iter().enumerate() {
+            if f.face_type != "Wall" {
+                continue;
+            }
+            let b = &f.geometry.boundary;
+            if b.len() < 3 {
+                continue;
+            }
+            faces.push(WallFace {
+                ri,
+                fi,
+                c: center(b),
+                n: newell_normal(b),
+                area: polygon_area(b),
+                face_id: f.identifier.clone(),
+                room_id: room.identifier.clone(),
+            });
+        }
+    }
+
+    let mut used = vec![false; faces.len()];
+    let mut pairs: Vec<(usize, usize)> = Vec::new();
+    for i in 0..faces.len() {
+        if used[i] {
+            continue;
+        }
+        for j in (i + 1)..faces.len() {
+            if used[j] {
+                continue;
+            }
+            let (a, b) = (&faces[i], &faces[j]);
+            if a.ri == b.ri || dot(a.n, b.n) > -0.95 {
+                continue; // same room, or not anti-parallel
+            }
+            // Plane separation along a's normal.
+            if dot(sub(a.c, b.c), a.n).abs() > MAX_GAP {
+                continue;
+            }
+            // b's centroid projected onto a's plane must sit on top of a's centroid.
+            let off = dot(sub(b.c, a.c), a.n);
+            let b_proj = [b.c[0] - a.n[0] * off, b.c[1] - a.n[1] * off, b.c[2] - a.n[2] * off];
+            if dist(a.c, b_proj) > MAX_LATERAL {
+                continue;
+            }
+            // Full-wall match only (near-equal area → Honeybee's matching-areas check passes).
+            if (a.area - b.area).abs() / a.area.max(b.area).max(1e-9) > MAX_AREA_DIFF {
+                continue;
+            }
+            pairs.push((i, j));
+            used[i] = true;
+            used[j] = true;
+            break;
+        }
+    }
+
+    for &(i, j) in &pairs {
+        let (ri_a, fi_a) = (faces[i].ri, faces[i].fi);
+        let (ri_b, fi_b) = (faces[j].ri, faces[j].fi);
+        let (fid_a, rid_a) = (faces[i].face_id.clone(), faces[i].room_id.clone());
+        let (fid_b, rid_b) = (faces[j].face_id.clone(), faces[j].room_id.clone());
+        rooms[ri_a].faces[fi_a].set_surface_bc(fid_b, rid_b);
+        rooms[ri_b].faces[fi_b].set_surface_bc(fid_a, rid_a);
+    }
+    pairs.len() * 2
+}

--- a/rust/export/src/constructions.rs
+++ b/rust/export/src/constructions.rs
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: MPL-2.0
+//! Constructions for the HBJSON exporter — IFC material layer sets → Honeybee opaque
+//! constructions (wasm-safe; pure decoding + arithmetic).
+//!
+//! Layer thicknesses come from `IfcMaterialLayerSet`; thermal properties are defaulted by
+//! material-name keyword (IFC rarely carries conductivity/density), so U-values are a sane
+//! starting point a user refines in Pollination — not authoritative. One representative
+//! build-up per category (wall / slab) is derived and assigned by face type.
+
+use std::collections::{HashMap, HashSet};
+
+use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner};
+use ifc_lite_geometry::{ExtractedProfile, LayerBuildup, MaterialLayerIndex};
+
+use crate::hbjson::{EnergyMaterial, ModelEnergy, OpaqueConstruction};
+
+/// Default (conductivity W/mK, density kg/m³, specific heat J/kgK) by material-name keyword.
+fn thermal_props(name: &str) -> (f64, f64, f64) {
+    let n = name.to_lowercase();
+    if n.contains("insul") || n.contains("mineral") || n.contains("wool") || n.contains("eps") || n.contains("xps") || n.contains("polystyr") {
+        (0.035, 30.0, 1200.0)
+    } else if n.contains("concrete") {
+        (2.3, 2300.0, 900.0)
+    } else if n.contains("brick") || n.contains("masonry") || n.contains("block") {
+        (0.7, 1900.0, 800.0)
+    } else if n.contains("gypsum") || n.contains("plaster") || n.contains("board") || n.contains("drywall") {
+        (0.25, 900.0, 1000.0)
+    } else if n.contains("timber") || n.contains("wood") || n.contains("plywood") {
+        (0.14, 500.0, 1600.0)
+    } else if n.contains("steel") || n.contains("metal") || n.contains("alumin") {
+        (50.0, 7800.0, 500.0)
+    } else if n.contains("glass") {
+        (1.0, 2500.0, 840.0)
+    } else if n.contains("screed") || n.contains("mortar") || n.contains("render") {
+        (0.8, 1800.0, 900.0)
+    } else if n.contains("air") {
+        (0.18, 1.2, 1000.0)
+    } else {
+        (1.0, 1000.0, 1000.0)
+    }
+}
+
+fn sanitize(s: &str) -> String {
+    let out: String = s.chars().map(|c| if c.is_alphanumeric() { c } else { '_' }).collect();
+    if out.is_empty() { "Material".to_string() } else { out }
+}
+
+/// Map every `IfcMaterial` entity id to its Name (attr 0).
+fn material_names(content: &[u8], decoder: &mut EntityDecoder) -> HashMap<u32, String> {
+    let mut names = HashMap::new();
+    let mut scanner = EntityScanner::new(content);
+    while let Some((id, type_name, start, end)) = scanner.next_entity() {
+        if type_name != "IFCMATERIAL" {
+            continue;
+        }
+        if let Ok(e) = decoder.decode_at_with_id(id, start, end) {
+            if let Some(name) = e.get(0).and_then(|a| a.as_string()) {
+                if !name.is_empty() {
+                    names.insert(id, name.to_string());
+                }
+            }
+        }
+    }
+    names
+}
+
+/// Model-level energy library + the construction ids to assign per face type.
+pub struct Constructions {
+    pub energy: Option<ModelEnergy>,
+    pub wall: Option<String>,
+    pub floor: Option<String>,
+    pub roof: Option<String>,
+}
+
+impl Constructions {
+    fn none() -> Self {
+        Self { energy: None, wall: None, floor: None, roof: None }
+    }
+}
+
+type Buckets = HashMap<Vec<(u32, i64)>, (usize, Vec<(u32, f64)>)>;
+
+fn build_one(
+    bucket: &Buckets,
+    con_id: &str,
+    names: &HashMap<u32, String>,
+    materials: &mut Vec<EnergyMaterial>,
+    constructions: &mut Vec<OpaqueConstruction>,
+    seen_mat: &mut HashSet<String>,
+) -> Option<String> {
+    let (_, layers) = bucket.values().max_by_key(|(count, _)| *count)?;
+    if layers.is_empty() {
+        return None;
+    }
+    let mut refs = Vec::new();
+    for (mid, thickness) in layers {
+        let name = names.get(mid).cloned().unwrap_or_else(|| format!("Material{}", mid));
+        let ident = format!("{}_{}mm", sanitize(&name), (thickness * 1000.0).round() as i64);
+        if seen_mat.insert(ident.clone()) {
+            let (k, rho, cp) = thermal_props(&name);
+            materials.push(EnergyMaterial::new(ident.clone(), thickness.max(0.001), k, rho, cp));
+        }
+        refs.push(ident);
+    }
+    constructions.push(OpaqueConstruction::new(con_id.to_string(), refs));
+    Some(con_id.to_string())
+}
+
+/// Derive representative wall/slab constructions from the model's material layer sets.
+pub fn build_constructions(content: &[u8], profiles: &[ExtractedProfile]) -> Constructions {
+    let entity_index = build_entity_index(content);
+    let mut decoder = EntityDecoder::with_index(content, entity_index);
+    let scale = decoder.length_unit_scale();
+    let layers = MaterialLayerIndex::from_content(content, &mut decoder);
+    if layers.sliceable_count() == 0 {
+        return Constructions::none();
+    }
+    let names = material_names(content, &mut decoder);
+
+    // Vote for the most common build-up per category (signature = material ids + mm thickness).
+    let mut wall: Buckets = HashMap::new();
+    let mut slab: Buckets = HashMap::new();
+    let mut seen: HashSet<u32> = HashSet::new();
+    for p in profiles {
+        let is_wall = p.ifc_type == "IfcWall" || p.ifc_type == "IfcWallStandardCase";
+        let is_slab = p.ifc_type == "IfcSlab" || p.ifc_type == "IfcRoof";
+        if (!is_wall && !is_slab) || !seen.insert(p.express_id) {
+            continue;
+        }
+        if let Some(LayerBuildup::Sliceable { layers: ls, .. }) = layers.get(p.express_id) {
+            if ls.is_empty() {
+                continue;
+            }
+            let sig: Vec<(u32, i64)> = ls.iter().map(|l| (l.material_id, (l.thickness * scale * 1000.0).round() as i64)).collect();
+            let vals: Vec<(u32, f64)> = ls.iter().map(|l| (l.material_id, l.thickness * scale)).collect();
+            let bucket = if is_wall { &mut wall } else { &mut slab };
+            bucket.entry(sig).or_insert((0, vals)).0 += 1;
+        }
+    }
+
+    let mut materials = Vec::new();
+    let mut constructions = Vec::new();
+    let mut seen_mat = HashSet::new();
+    let wall_id = build_one(&wall, "ifclite_wall", &names, &mut materials, &mut constructions, &mut seen_mat);
+    let slab_id = build_one(&slab, "ifclite_slab", &names, &mut materials, &mut constructions, &mut seen_mat);
+
+    if constructions.is_empty() {
+        return Constructions::none();
+    }
+    Constructions {
+        energy: Some(ModelEnergy { ty: "ModelEnergyProperties", materials, constructions }),
+        wall: wall_id,
+        floor: slab_id.clone(),
+        roof: slab_id,
+    }
+}

--- a/rust/export/src/hbjson.rs
+++ b/rust/export/src/hbjson.rs
@@ -34,6 +34,90 @@ pub struct TypedProps {
     pub ty: &'static str,
 }
 
+/// A Honeybee energy material (one opaque layer). Thicknesses come from the IFC material
+/// layer set; thermal properties are defaulted by material-name keyword (IFC rarely carries
+/// conductivity/density), so U-values are a sensible starting point, not authoritative.
+#[derive(Serialize, Clone)]
+pub struct EnergyMaterial {
+    #[serde(rename = "type")]
+    pub ty: &'static str, // "EnergyMaterial"
+    pub identifier: String,
+    pub roughness: &'static str, // "MediumRough"
+    pub thickness: f64,
+    pub conductivity: f64,
+    pub density: f64,
+    pub specific_heat: f64,
+    pub thermal_absorptance: f64,
+    pub solar_absorptance: f64,
+    pub visible_absorptance: f64,
+}
+
+impl EnergyMaterial {
+    pub fn new(identifier: String, thickness: f64, conductivity: f64, density: f64, specific_heat: f64) -> Self {
+        Self {
+            ty: "EnergyMaterial",
+            identifier,
+            roughness: "MediumRough",
+            thickness,
+            conductivity,
+            density,
+            specific_heat,
+            thermal_absorptance: 0.9,
+            solar_absorptance: 0.7,
+            visible_absorptance: 0.7,
+        }
+    }
+}
+
+/// An opaque construction referencing its materials (outside → inside) by identifier.
+#[derive(Serialize, Clone)]
+pub struct OpaqueConstruction {
+    #[serde(rename = "type")]
+    pub ty: &'static str, // "OpaqueConstructionAbridged"
+    pub identifier: String,
+    pub materials: Vec<String>,
+}
+
+impl OpaqueConstruction {
+    pub fn new(identifier: String, materials: Vec<String>) -> Self {
+        Self { ty: "OpaqueConstructionAbridged", identifier, materials }
+    }
+}
+
+/// Per-face energy properties carrying an optional construction reference.
+#[derive(Serialize)]
+pub struct FaceEnergy {
+    #[serde(rename = "type")]
+    pub ty: &'static str, // "FaceEnergyPropertiesAbridged"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub construction: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct FaceProperties {
+    #[serde(rename = "type")]
+    pub ty: &'static str, // "FacePropertiesAbridged"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub energy: Option<FaceEnergy>,
+}
+
+/// Model-level energy properties: the material + construction libraries.
+#[derive(Serialize)]
+pub struct ModelEnergy {
+    #[serde(rename = "type")]
+    pub ty: &'static str, // "ModelEnergyProperties"
+    pub materials: Vec<EnergyMaterial>,
+    pub constructions: Vec<OpaqueConstruction>,
+}
+
+#[derive(Serialize)]
+pub struct ModelProperties {
+    #[serde(rename = "type")]
+    pub ty: &'static str, // "ModelProperties"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub energy: Option<ModelEnergy>,
+}
+
 /// A window — a planar sub-face of a parent wall Face, coplanar and within its boundary.
 #[derive(Serialize)]
 pub struct Aperture {
@@ -130,7 +214,7 @@ pub struct Face {
     pub ty: &'static str, // "Face"
     pub identifier: String,
     pub display_name: String,
-    pub properties: TypedProps,
+    pub properties: FaceProperties,
     pub geometry: Face3D,
     pub face_type: &'static str,
     pub boundary_condition: BoundaryCondition,
@@ -147,13 +231,21 @@ impl Face {
             ty: "Face",
             identifier,
             display_name,
-            properties: TypedProps { ty: "FacePropertiesAbridged" },
+            properties: FaceProperties { ty: "FacePropertiesAbridged", energy: None },
             geometry,
             face_type,
             boundary_condition: BoundaryCondition { ty: bc },
             apertures: Vec::new(),
             doors: Vec::new(),
         }
+    }
+
+    /// Assign an opaque construction (by identifier) to this face's energy properties.
+    pub fn set_construction(&mut self, construction: String) {
+        self.properties.energy = Some(FaceEnergy {
+            ty: "FaceEnergyPropertiesAbridged",
+            construction: Some(construction),
+        });
     }
 }
 
@@ -189,7 +281,7 @@ pub struct Model {
     pub identifier: String,
     pub display_name: String,
     pub units: &'static str, // "Meters"
-    pub properties: TypedProps,
+    pub properties: ModelProperties,
     pub rooms: Vec<Room>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub shade_meshes: Vec<ShadeMesh>,
@@ -199,13 +291,19 @@ pub struct Model {
 }
 
 impl Model {
-    pub fn new(identifier: &str, rooms: Vec<Room>, shade_meshes: Vec<ShadeMesh>, tolerance: f64) -> Self {
+    pub fn new(
+        identifier: &str,
+        rooms: Vec<Room>,
+        shade_meshes: Vec<ShadeMesh>,
+        energy: Option<ModelEnergy>,
+        tolerance: f64,
+    ) -> Self {
         Self {
             ty: "Model",
             identifier: identifier.to_string(),
             display_name: identifier.to_string(),
             units: "Meters",
-            properties: TypedProps { ty: "ModelProperties" },
+            properties: ModelProperties { ty: "ModelProperties", energy },
             rooms,
             shade_meshes,
             tolerance,

--- a/rust/export/src/hbjson.rs
+++ b/rust/export/src/hbjson.rs
@@ -21,11 +21,24 @@ impl Face3D {
     }
 }
 
-/// A boundary condition — minimal form (`{"type": "Outdoors"}` etc.), which Honeybee accepts.
+/// A boundary condition. `Outdoors`/`Ground` are the bare form; `Surface` (interior adjacency)
+/// also carries the adjacent face + room identifiers.
 #[derive(Serialize)]
 pub struct BoundaryCondition {
     #[serde(rename = "type")]
     pub ty: &'static str, // "Outdoors" | "Ground" | "Surface" | "Adiabatic"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub boundary_condition_objects: Option<Vec<String>>,
+}
+
+impl BoundaryCondition {
+    pub fn new(ty: &'static str) -> Self {
+        Self { ty, boundary_condition_objects: None }
+    }
+    /// A `Surface` boundary condition pointing at the adjacent `[face, room]`.
+    pub fn surface(adjacent_face: String, adjacent_room: String) -> Self {
+        Self { ty: "Surface", boundary_condition_objects: Some(vec![adjacent_face, adjacent_room]) }
+    }
 }
 
 #[derive(Serialize)]
@@ -141,7 +154,7 @@ impl Aperture {
             properties: TypedProps { ty: "AperturePropertiesAbridged" },
             geometry,
             is_operable,
-            boundary_condition: BoundaryCondition { ty: "Outdoors" },
+            boundary_condition: BoundaryCondition::new("Outdoors"),
         }
     }
 }
@@ -169,7 +182,7 @@ impl Door {
             properties: TypedProps { ty: "DoorPropertiesAbridged" },
             geometry,
             is_glass,
-            boundary_condition: BoundaryCondition { ty: "Outdoors" },
+            boundary_condition: BoundaryCondition::new("Outdoors"),
         }
     }
 }
@@ -234,7 +247,7 @@ impl Face {
             properties: FaceProperties { ty: "FacePropertiesAbridged", energy: None },
             geometry,
             face_type,
-            boundary_condition: BoundaryCondition { ty: bc },
+            boundary_condition: BoundaryCondition::new(bc),
             apertures: Vec::new(),
             doors: Vec::new(),
         }
@@ -246,6 +259,15 @@ impl Face {
             ty: "FaceEnergyPropertiesAbridged",
             construction: Some(construction),
         });
+    }
+
+    /// Make this face an interior `Surface` adjacency to `(adj_face, adj_room)`. Drops any
+    /// apertures/doors — they were placed as exterior openings; interior openings need a
+    /// matched pair on the other side (out of scope here).
+    pub fn set_surface_bc(&mut self, adj_face: String, adj_room: String) {
+        self.boundary_condition = BoundaryCondition::surface(adj_face, adj_room);
+        self.apertures.clear();
+        self.doors.clear();
     }
 }
 

--- a/rust/export/src/hbjson.rs
+++ b/rust/export/src/hbjson.rs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MPL-2.0
+//! Serde structs for the Honeybee HBJSON model schema (geometry subset).
+//!
+//! Field names/tags mirror exactly what `honeybee-schema` serializes (verified by
+//! round-tripping honeybee-written `.hbjson` through this crate). `Face3D.plane` is
+//! intentionally omitted — Honeybee derives it from the boundary on load.
+
+use serde::Serialize;
+
+/// A planar polygon: an ordered, wound boundary of `[x, y, z]` points (metres, Z-up).
+#[derive(Serialize)]
+pub struct Face3D {
+    #[serde(rename = "type")]
+    pub ty: &'static str, // "Face3D"
+    pub boundary: Vec<[f64; 3]>,
+}
+
+impl Face3D {
+    pub fn new(boundary: Vec<[f64; 3]>) -> Self {
+        Self { ty: "Face3D", boundary }
+    }
+}
+
+/// A boundary condition — minimal form (`{"type": "Outdoors"}` etc.), which Honeybee accepts.
+#[derive(Serialize)]
+pub struct BoundaryCondition {
+    #[serde(rename = "type")]
+    pub ty: &'static str, // "Outdoors" | "Ground" | "Surface" | "Adiabatic"
+}
+
+#[derive(Serialize)]
+pub struct TypedProps {
+    #[serde(rename = "type")]
+    pub ty: &'static str,
+}
+
+/// One face of a Room. `face_type` is "Wall" | "RoofCeiling" | "Floor" | "AirBoundary".
+#[derive(Serialize)]
+pub struct Face {
+    #[serde(rename = "type")]
+    pub ty: &'static str, // "Face"
+    pub identifier: String,
+    pub display_name: String,
+    pub properties: TypedProps,
+    pub geometry: Face3D,
+    pub face_type: &'static str,
+    pub boundary_condition: BoundaryCondition,
+}
+
+impl Face {
+    pub fn new(identifier: String, geometry: Face3D, face_type: &'static str, bc: &'static str) -> Self {
+        let display_name = identifier.clone();
+        Self {
+            ty: "Face",
+            identifier,
+            display_name,
+            properties: TypedProps { ty: "FacePropertiesAbridged" },
+            geometry,
+            face_type,
+            boundary_condition: BoundaryCondition { ty: bc },
+        }
+    }
+}
+
+/// A closed volume of faces (one thermal zone).
+#[derive(Serialize)]
+pub struct Room {
+    #[serde(rename = "type")]
+    pub ty: &'static str, // "Room"
+    pub identifier: String,
+    pub display_name: String,
+    pub properties: TypedProps,
+    pub faces: Vec<Face>,
+}
+
+impl Room {
+    pub fn new(identifier: String, faces: Vec<Face>) -> Self {
+        let display_name = identifier.clone();
+        Self {
+            ty: "Room",
+            identifier,
+            display_name,
+            properties: TypedProps { ty: "RoomPropertiesAbridged" },
+            faces,
+        }
+    }
+}
+
+/// The top-level Honeybee model.
+#[derive(Serialize)]
+pub struct Model {
+    #[serde(rename = "type")]
+    pub ty: &'static str, // "Model"
+    pub identifier: String,
+    pub display_name: String,
+    pub units: &'static str, // "Meters"
+    pub properties: TypedProps,
+    pub rooms: Vec<Room>,
+    pub tolerance: f64,
+    pub angle_tolerance: f64,
+    pub version: &'static str,
+}
+
+impl Model {
+    pub fn new(identifier: &str, rooms: Vec<Room>, tolerance: f64) -> Self {
+        Self {
+            ty: "Model",
+            identifier: identifier.to_string(),
+            display_name: identifier.to_string(),
+            units: "Meters",
+            properties: TypedProps { ty: "ModelProperties" },
+            rooms,
+            tolerance,
+            angle_tolerance: 1.0,
+            version: "1.0.0",
+        }
+    }
+}

--- a/rust/export/src/hbjson.rs
+++ b/rust/export/src/hbjson.rs
@@ -34,6 +34,95 @@ pub struct TypedProps {
     pub ty: &'static str,
 }
 
+/// A window — a planar sub-face of a parent wall Face, coplanar and within its boundary.
+#[derive(Serialize)]
+pub struct Aperture {
+    #[serde(rename = "type")]
+    pub ty: &'static str, // "Aperture"
+    pub identifier: String,
+    pub display_name: String,
+    pub properties: TypedProps,
+    pub geometry: Face3D,
+    pub is_operable: bool,
+    pub boundary_condition: BoundaryCondition,
+}
+
+impl Aperture {
+    pub fn new(identifier: String, geometry: Face3D, is_operable: bool) -> Self {
+        let display_name = identifier.clone();
+        Self {
+            ty: "Aperture",
+            identifier,
+            display_name,
+            properties: TypedProps { ty: "AperturePropertiesAbridged" },
+            geometry,
+            is_operable,
+            boundary_condition: BoundaryCondition { ty: "Outdoors" },
+        }
+    }
+}
+
+/// A door — a planar sub-face of a parent wall Face.
+#[derive(Serialize)]
+pub struct Door {
+    #[serde(rename = "type")]
+    pub ty: &'static str, // "Door"
+    pub identifier: String,
+    pub display_name: String,
+    pub properties: TypedProps,
+    pub geometry: Face3D,
+    pub is_glass: bool,
+    pub boundary_condition: BoundaryCondition,
+}
+
+impl Door {
+    pub fn new(identifier: String, geometry: Face3D, is_glass: bool) -> Self {
+        let display_name = identifier.clone();
+        Self {
+            ty: "Door",
+            identifier,
+            display_name,
+            properties: TypedProps { ty: "DoorPropertiesAbridged" },
+            geometry,
+            is_glass,
+            boundary_condition: BoundaryCondition { ty: "Outdoors" },
+        }
+    }
+}
+
+/// An arbitrary triangle mesh used for shading context (railings, balconies, etc.).
+/// No watertightness required — the render mesh is the right source here.
+#[derive(Serialize)]
+pub struct Mesh3D {
+    #[serde(rename = "type")]
+    pub ty: &'static str, // "Mesh3D"
+    pub vertices: Vec<[f64; 3]>,
+    pub faces: Vec<[usize; 3]>,
+}
+
+#[derive(Serialize)]
+pub struct ShadeMesh {
+    #[serde(rename = "type")]
+    pub ty: &'static str, // "ShadeMesh"
+    pub identifier: String,
+    pub display_name: String,
+    pub properties: TypedProps,
+    pub geometry: Mesh3D,
+}
+
+impl ShadeMesh {
+    pub fn new(identifier: String, vertices: Vec<[f64; 3]>, faces: Vec<[usize; 3]>) -> Self {
+        let display_name = identifier.clone();
+        Self {
+            ty: "ShadeMesh",
+            identifier,
+            display_name,
+            properties: TypedProps { ty: "ShadeMeshPropertiesAbridged" },
+            geometry: Mesh3D { ty: "Mesh3D", vertices, faces },
+        }
+    }
+}
+
 /// One face of a Room. `face_type` is "Wall" | "RoofCeiling" | "Floor" | "AirBoundary".
 #[derive(Serialize)]
 pub struct Face {
@@ -45,6 +134,10 @@ pub struct Face {
     pub geometry: Face3D,
     pub face_type: &'static str,
     pub boundary_condition: BoundaryCondition,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub apertures: Vec<Aperture>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub doors: Vec<Door>,
 }
 
 impl Face {
@@ -58,6 +151,8 @@ impl Face {
             geometry,
             face_type,
             boundary_condition: BoundaryCondition { ty: bc },
+            apertures: Vec::new(),
+            doors: Vec::new(),
         }
     }
 }
@@ -96,13 +191,15 @@ pub struct Model {
     pub units: &'static str, // "Meters"
     pub properties: TypedProps,
     pub rooms: Vec<Room>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub shade_meshes: Vec<ShadeMesh>,
     pub tolerance: f64,
     pub angle_tolerance: f64,
     pub version: &'static str,
 }
 
 impl Model {
-    pub fn new(identifier: &str, rooms: Vec<Room>, tolerance: f64) -> Self {
+    pub fn new(identifier: &str, rooms: Vec<Room>, shade_meshes: Vec<ShadeMesh>, tolerance: f64) -> Self {
         Self {
             ty: "Model",
             identifier: identifier.to_string(),
@@ -110,6 +207,7 @@ impl Model {
             units: "Meters",
             properties: TypedProps { ty: "ModelProperties" },
             rooms,
+            shade_meshes,
             tolerance,
             angle_tolerance: 1.0,
             version: "1.0.0",

--- a/rust/export/src/lib.rs
+++ b/rust/export/src/lib.rs
@@ -7,6 +7,7 @@
 //! This is the Rust source of truth; CLI / SDK / wasm become thin callers (mirroring how
 //! geometry already flows through `ifc-lite-wasm`).
 
+mod adjacency;
 mod constructions;
 mod hbjson;
 mod openings;
@@ -47,6 +48,8 @@ pub struct HbjsonStats {
     pub shades: usize,
     /// Opaque constructions derived from the IFC material layer sets.
     pub constructions: usize,
+    /// Interior faces paired as `Surface` adjacencies (2 per shared wall).
+    pub interior_adjacencies: usize,
 }
 
 /// Export the `IfcSpace` volumes in `content` (raw IFC/STEP bytes) as an HBJSON string.
@@ -65,6 +68,8 @@ pub fn export_hbjson_with_stats(content: &[u8], opts: &HbjsonOptions) -> (String
     let spaces = profiles.iter().filter(|p| p.ifc_type == "IfcSpace").count();
     let (mut rooms, origin, skipped) = rooms::build_rooms(&profiles, opts.tolerance);
     openings::attach_openings(&profiles, &mut rooms, origin);
+    // Pair shared interior walls as Surface adjacencies (drops their exterior openings).
+    let interior_adjacencies = adjacency::solve_adjacency(&mut rooms);
     let shade_meshes = shades::build_shades(&profiles, origin);
 
     // Assign representative opaque constructions (from the IFC material layer sets) by face type.
@@ -87,7 +92,7 @@ pub fn export_hbjson_with_stats(content: &[u8], opts: &HbjsonOptions) -> (String
     let doors = rooms.iter().flat_map(|r| &r.faces).map(|f| f.doors.len()).sum();
     let shades = shade_meshes.len();
     let n_constructions = cons.energy.as_ref().map_or(0, |e| e.constructions.len());
-    let stats = HbjsonStats { spaces, rooms: rooms.len(), skipped, apertures, doors, shades, constructions: n_constructions };
+    let stats = HbjsonStats { spaces, rooms: rooms.len(), skipped, apertures, doors, shades, constructions: n_constructions, interior_adjacencies };
 
     let model = Model::new(&opts.name, rooms, shade_meshes, cons.energy, opts.tolerance);
     let json = serde_json::to_string(&model).expect("HBJSON model serializes");
@@ -115,6 +120,8 @@ mod tests {
         // P2: windows and doors are placed on exterior walls.
         assert!(stats.apertures > 0, "expected windows, got {}", stats.apertures);
         assert!(stats.doors > 0, "expected doors, got {}", stats.doors);
+        // P5: shared interior walls are paired as Surface adjacencies.
+        assert!(stats.interior_adjacencies > 0, "expected interior adjacencies, got {}", stats.interior_adjacencies);
         let v: Value = serde_json::from_str(&json).expect("valid JSON");
 
         assert_eq!(v["type"], "Model");

--- a/rust/export/src/lib.rs
+++ b/rust/export/src/lib.rs
@@ -18,6 +18,16 @@ pub use hbjson::Model;
 
 use ifc_lite_geometry::extract_profiles;
 
+/// Honeybee identifiers may not contain spaces or most special characters; map anything
+/// other than alphanumerics / `_` / `-` to `_`.
+fn sanitize_identifier(s: &str) -> String {
+    let out: String = s
+        .chars()
+        .map(|c| if c.is_alphanumeric() || c == '_' || c == '-' { c } else { '_' })
+        .collect();
+    if out.is_empty() { "model".to_string() } else { out }
+}
+
 /// Options for HBJSON export.
 pub struct HbjsonOptions {
     /// Model identifier / display name.
@@ -94,7 +104,7 @@ pub fn export_hbjson_with_stats(content: &[u8], opts: &HbjsonOptions) -> (String
     let n_constructions = cons.energy.as_ref().map_or(0, |e| e.constructions.len());
     let stats = HbjsonStats { spaces, rooms: rooms.len(), skipped, apertures, doors, shades, constructions: n_constructions, interior_adjacencies };
 
-    let model = Model::new(&opts.name, rooms, shade_meshes, cons.energy, opts.tolerance);
+    let model = Model::new(&sanitize_identifier(&opts.name), rooms, shade_meshes, cons.energy, opts.tolerance);
     let json = serde_json::to_string(&model).expect("HBJSON model serializes");
     (json, stats)
 }

--- a/rust/export/src/lib.rs
+++ b/rust/export/src/lib.rs
@@ -8,6 +8,7 @@
 //! geometry already flows through `ifc-lite-wasm`).
 
 mod hbjson;
+mod openings;
 mod rooms;
 
 pub use hbjson::Model;
@@ -36,6 +37,12 @@ pub struct HbjsonStats {
     pub rooms: usize,
     /// Spaces skipped as degenerate (malformed footprint / holes / non-extrusion — P5).
     pub skipped: usize,
+    /// Windows placed as Apertures on exterior wall faces.
+    pub apertures: usize,
+    /// Doors placed on exterior wall faces.
+    pub doors: usize,
+    /// Railing / context shade meshes emitted.
+    pub shades: usize,
 }
 
 /// Export the `IfcSpace` volumes in `content` (raw IFC/STEP bytes) as an HBJSON string.
@@ -52,9 +59,16 @@ pub fn export_hbjson(content: &[u8], opts: &HbjsonOptions) -> String {
 pub fn export_hbjson_with_stats(content: &[u8], opts: &HbjsonOptions) -> (String, HbjsonStats) {
     let profiles = extract_profiles(content, 0);
     let spaces = profiles.iter().filter(|p| p.ifc_type == "IfcSpace").count();
-    let (rooms, skipped) = rooms::build_rooms(&profiles, opts.tolerance);
-    let stats = HbjsonStats { spaces, rooms: rooms.len(), skipped };
-    let model = Model::new(&opts.name, rooms, opts.tolerance);
+    let (mut rooms, origin, skipped) = rooms::build_rooms(&profiles, opts.tolerance);
+    openings::attach_openings(&profiles, &mut rooms, origin);
+
+    let apertures = rooms.iter().flat_map(|r| &r.faces).map(|f| f.apertures.len()).sum();
+    let doors = rooms.iter().flat_map(|r| &r.faces).map(|f| f.doors.len()).sum();
+    // Shades (railings → ShadeMesh) need a wasm-safe per-element mesh and land in P3.
+    let shades = 0;
+    let stats = HbjsonStats { spaces, rooms: rooms.len(), skipped, apertures, doors, shades };
+
+    let model = Model::new(&opts.name, rooms, Vec::new(), opts.tolerance);
     let json = serde_json::to_string(&model).expect("HBJSON model serializes");
     (json, stats)
 }
@@ -76,7 +90,10 @@ mod tests {
         let Some(bytes) = fixture("ara3d/duplex.ifc") else {
             return;
         };
-        let json = export_hbjson(&bytes, &HbjsonOptions::default());
+        let (json, stats) = export_hbjson_with_stats(&bytes, &HbjsonOptions::default());
+        // P2: windows and doors are placed on exterior walls.
+        assert!(stats.apertures > 0, "expected windows, got {}", stats.apertures);
+        assert!(stats.doors > 0, "expected doors, got {}", stats.doors);
         let v: Value = serde_json::from_str(&json).expect("valid JSON");
 
         assert_eq!(v["type"], "Model");

--- a/rust/export/src/lib.rs
+++ b/rust/export/src/lib.rs
@@ -132,7 +132,28 @@ mod tests {
         assert!(stats.doors > 0, "expected doors, got {}", stats.doors);
         // P5: shared interior walls are paired as Surface adjacencies.
         assert!(stats.interior_adjacencies > 0, "expected interior adjacencies, got {}", stats.interior_adjacencies);
+        // P4: material layer sets become opaque constructions assigned to faces.
+        assert!(stats.constructions > 0, "expected constructions, got {}", stats.constructions);
         let v: Value = serde_json::from_str(&json).expect("valid JSON");
+
+        // Energy + adjacency surface through the schema (materials, constructions, Surface BCs).
+        let energy = &v["properties"]["energy"];
+        assert_eq!(energy["type"], "ModelEnergyProperties");
+        assert!(!energy["materials"].as_array().unwrap().is_empty());
+        assert!(!energy["constructions"].as_array().unwrap().is_empty());
+        let surface_faces = v["rooms"].as_array().unwrap().iter()
+            .flat_map(|r| r["faces"].as_array().unwrap())
+            .filter(|f| f["boundary_condition"]["type"] == "Surface")
+            .count();
+        assert!(surface_faces > 0, "expected Surface (interior) faces");
+        // Every interior face references an adjacent [face, room].
+        for r in v["rooms"].as_array().unwrap() {
+            for f in r["faces"].as_array().unwrap() {
+                if f["boundary_condition"]["type"] == "Surface" {
+                    assert_eq!(f["boundary_condition"]["boundary_condition_objects"].as_array().unwrap().len(), 2);
+                }
+            }
+        }
 
         assert_eq!(v["type"], "Model");
         assert_eq!(v["units"], "Meters");

--- a/rust/export/src/lib.rs
+++ b/rust/export/src/lib.rs
@@ -10,6 +10,7 @@
 mod hbjson;
 mod openings;
 mod rooms;
+mod shades;
 
 pub use hbjson::Model;
 
@@ -61,14 +62,14 @@ pub fn export_hbjson_with_stats(content: &[u8], opts: &HbjsonOptions) -> (String
     let spaces = profiles.iter().filter(|p| p.ifc_type == "IfcSpace").count();
     let (mut rooms, origin, skipped) = rooms::build_rooms(&profiles, opts.tolerance);
     openings::attach_openings(&profiles, &mut rooms, origin);
+    let shade_meshes = shades::build_shades(&profiles, origin);
 
     let apertures = rooms.iter().flat_map(|r| &r.faces).map(|f| f.apertures.len()).sum();
     let doors = rooms.iter().flat_map(|r| &r.faces).map(|f| f.doors.len()).sum();
-    // Shades (railings → ShadeMesh) need a wasm-safe per-element mesh and land in P3.
-    let shades = 0;
+    let shades = shade_meshes.len();
     let stats = HbjsonStats { spaces, rooms: rooms.len(), skipped, apertures, doors, shades };
 
-    let model = Model::new(&opts.name, rooms, Vec::new(), opts.tolerance);
+    let model = Model::new(&opts.name, rooms, shade_meshes, opts.tolerance);
     let json = serde_json::to_string(&model).expect("HBJSON model serializes");
     (json, stats)
 }
@@ -132,7 +133,10 @@ mod tests {
         let Some(bytes) = fixture("various/rvt01.ifc") else {
             return;
         };
-        let json = export_hbjson(&bytes, &HbjsonOptions::default());
+        let (json, stats) = export_hbjson_with_stats(&bytes, &HbjsonOptions::default());
+        // P2/P3: windows, doors and railing shades are all present on this Revit model.
+        assert!(stats.apertures > 0 && stats.doors > 0, "openings: {} win / {} door", stats.apertures, stats.doors);
+        assert!(stats.shades > 0, "expected railing shades, got {}", stats.shades);
         let v: Value = serde_json::from_str(&json).unwrap();
         let rooms = v["rooms"].as_array().unwrap();
         assert!(rooms.len() >= 30, "expected >=30 rooms, got {}", rooms.len());

--- a/rust/export/src/lib.rs
+++ b/rust/export/src/lib.rs
@@ -7,6 +7,7 @@
 //! This is the Rust source of truth; CLI / SDK / wasm become thin callers (mirroring how
 //! geometry already flows through `ifc-lite-wasm`).
 
+mod constructions;
 mod hbjson;
 mod openings;
 mod rooms;
@@ -44,6 +45,8 @@ pub struct HbjsonStats {
     pub doors: usize,
     /// Railing / context shade meshes emitted.
     pub shades: usize,
+    /// Opaque constructions derived from the IFC material layer sets.
+    pub constructions: usize,
 }
 
 /// Export the `IfcSpace` volumes in `content` (raw IFC/STEP bytes) as an HBJSON string.
@@ -64,12 +67,29 @@ pub fn export_hbjson_with_stats(content: &[u8], opts: &HbjsonOptions) -> (String
     openings::attach_openings(&profiles, &mut rooms, origin);
     let shade_meshes = shades::build_shades(&profiles, origin);
 
+    // Assign representative opaque constructions (from the IFC material layer sets) by face type.
+    let cons = constructions::build_constructions(content, &profiles);
+    for room in &mut rooms {
+        for f in &mut room.faces {
+            let id = match f.face_type {
+                "Wall" => cons.wall.clone(),
+                "Floor" => cons.floor.clone(),
+                "RoofCeiling" => cons.roof.clone(),
+                _ => None,
+            };
+            if let Some(id) = id {
+                f.set_construction(id);
+            }
+        }
+    }
+
     let apertures = rooms.iter().flat_map(|r| &r.faces).map(|f| f.apertures.len()).sum();
     let doors = rooms.iter().flat_map(|r| &r.faces).map(|f| f.doors.len()).sum();
     let shades = shade_meshes.len();
-    let stats = HbjsonStats { spaces, rooms: rooms.len(), skipped, apertures, doors, shades };
+    let n_constructions = cons.energy.as_ref().map_or(0, |e| e.constructions.len());
+    let stats = HbjsonStats { spaces, rooms: rooms.len(), skipped, apertures, doors, shades, constructions: n_constructions };
 
-    let model = Model::new(&opts.name, rooms, shade_meshes, opts.tolerance);
+    let model = Model::new(&opts.name, rooms, shade_meshes, cons.energy, opts.tolerance);
     let json = serde_json::to_string(&model).expect("HBJSON model serializes");
     (json, stats)
 }

--- a/rust/export/src/lib.rs
+++ b/rust/export/src/lib.rs
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MPL-2.0
+//! Domain-format exporters for ifc-lite.
+//!
+//! Phase 1: **HBJSON** (Honeybee energy-model) room export — the analytic, watertight
+//! IFC→Ladybug bridge. Apertures/doors/shades and a glTF migration follow.
+//!
+//! This is the Rust source of truth; CLI / SDK / wasm become thin callers (mirroring how
+//! geometry already flows through `ifc-lite-wasm`).
+
+mod hbjson;
+mod rooms;
+
+pub use hbjson::Model;
+
+use ifc_lite_geometry::extract_profiles;
+
+/// Options for HBJSON export.
+pub struct HbjsonOptions {
+    /// Model identifier / display name.
+    pub name: String,
+    /// Geometry tolerance in metres (Honeybee default 0.01).
+    pub tolerance: f64,
+}
+
+impl Default for HbjsonOptions {
+    fn default() -> Self {
+        Self { name: "ifc_lite_model".to_string(), tolerance: 0.01 }
+    }
+}
+
+/// Coverage stats for an HBJSON export.
+pub struct HbjsonStats {
+    /// `IfcSpace` profiles seen in the model.
+    pub spaces: usize,
+    /// Rooms emitted (watertight prisms).
+    pub rooms: usize,
+    /// Spaces skipped as degenerate (malformed footprint / holes / non-extrusion — P5).
+    pub skipped: usize,
+}
+
+/// Export the `IfcSpace` volumes in `content` (raw IFC/STEP bytes) as an HBJSON string.
+///
+/// Rooms are built analytically from extruded-area profiles (watertight by construction);
+/// faces are typed Floor / RoofCeiling / Wall with outward normals. Returns a Honeybee-valid
+/// `Model` JSON ready to load via `honeybee.model.Model.from_hbjson`.
+pub fn export_hbjson(content: &[u8], opts: &HbjsonOptions) -> String {
+    export_hbjson_with_stats(content, opts).0
+}
+
+/// Like [`export_hbjson`] but also returns coverage stats (so callers can report how many
+/// spaces were skipped instead of silently truncating).
+pub fn export_hbjson_with_stats(content: &[u8], opts: &HbjsonOptions) -> (String, HbjsonStats) {
+    let profiles = extract_profiles(content, 0);
+    let spaces = profiles.iter().filter(|p| p.ifc_type == "IfcSpace").count();
+    let (rooms, skipped) = rooms::build_rooms(&profiles, opts.tolerance);
+    let stats = HbjsonStats { spaces, rooms: rooms.len(), skipped };
+    let model = Model::new(&opts.name, rooms, opts.tolerance);
+    let json = serde_json::to_string(&model).expect("HBJSON model serializes");
+    (json, stats)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    /// Skip-if-absent fixture loader (matches the geometry crate convention — test
+    /// models are staged, not git-tracked, so a fresh checkout returns `None`).
+    fn fixture(rel: &str) -> Option<Vec<u8>> {
+        let path = format!("{}/../../tests/models/{}", env!("CARGO_MANIFEST_DIR"), rel);
+        std::fs::read(path).ok()
+    }
+
+    #[test]
+    fn duplex_exports_valid_room_model() {
+        let Some(bytes) = fixture("ara3d/duplex.ifc") else {
+            return;
+        };
+        let json = export_hbjson(&bytes, &HbjsonOptions::default());
+        let v: Value = serde_json::from_str(&json).expect("valid JSON");
+
+        assert_eq!(v["type"], "Model");
+        assert_eq!(v["units"], "Meters");
+        assert_eq!(v["tolerance"], 0.01);
+
+        let rooms = v["rooms"].as_array().expect("rooms array");
+        assert!(rooms.len() >= 15, "expected >=15 IfcSpace rooms, got {}", rooms.len());
+
+        // Every room must have exactly one Floor + one RoofCeiling + >=3 Walls.
+        for room in rooms {
+            let faces = room["faces"].as_array().unwrap();
+            let mut floor = 0;
+            let mut roof = 0;
+            let mut wall = 0;
+            for f in faces {
+                match f["face_type"].as_str().unwrap() {
+                    "Floor" => floor += 1,
+                    "RoofCeiling" => roof += 1,
+                    "Wall" => wall += 1,
+                    other => panic!("unexpected face_type {other}"),
+                }
+                // boundary must be a non-degenerate polygon
+                assert!(f["geometry"]["boundary"].as_array().unwrap().len() >= 3);
+            }
+            assert_eq!(floor, 1, "room {} floors", room["identifier"]);
+            assert_eq!(roof, 1, "room {} roofs", room["identifier"]);
+            assert!(wall >= 3, "room {} walls={}", room["identifier"], wall);
+        }
+    }
+
+    #[test]
+    fn revit_georeferenced_model_does_not_collapse() {
+        // rvt01 carries national-grid coordinates (~2.78e6); the origin-rebase must keep
+        // room footprints sane (no f32 collapse).
+        let Some(bytes) = fixture("various/rvt01.ifc") else {
+            return;
+        };
+        let json = export_hbjson(&bytes, &HbjsonOptions::default());
+        let v: Value = serde_json::from_str(&json).unwrap();
+        let rooms = v["rooms"].as_array().unwrap();
+        assert!(rooms.len() >= 30, "expected >=30 rooms, got {}", rooms.len());
+        // No coordinate should exceed ~1km from the rebased origin.
+        for room in rooms {
+            for f in room["faces"].as_array().unwrap() {
+                for p in f["geometry"]["boundary"].as_array().unwrap() {
+                    for c in p.as_array().unwrap() {
+                        assert!(c.as_f64().unwrap().abs() < 1000.0, "coordinate not rebased: {c}");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/rust/export/src/openings.rs
+++ b/rust/export/src/openings.rs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MPL-2.0
+//! Apertures (windows) and doors for the HBJSON exporter — wasm-safe, profile-based.
+//!
+//! Window/door occurrences come from `extract_profiles` (per-occurrence, in the SAME
+//! Y-up→Z-up frame as the rooms — no meshing, no frame calibration, and safe in
+//! wasm/CLI/browser; the native mesher `process_geometry_filtered` traps in wasm). Each
+//! occurrence's profile prisms (base ring + extruded ring) form a point cloud that is
+//! projected onto the matched exterior wall face, yielding a coplanar sub-face within the
+//! parent boundary — uniform for vertical-glazed windows and vertically-extruded door leaves.
+
+use std::collections::HashMap;
+
+use ifc_lite_geometry::ExtractedProfile;
+
+use crate::hbjson::{Aperture, Door, Face3D, Room};
+use crate::rooms::{center, dot, newell_normal, xf, zup};
+
+fn sub(a: [f64; 3], b: [f64; 3]) -> [f64; 3] { [a[0] - b[0], a[1] - b[1], a[2] - b[2]] }
+fn norm(a: [f64; 3]) -> [f64; 3] {
+    let l = (a[0] * a[0] + a[1] * a[1] + a[2] * a[2]).sqrt();
+    if l > 0.0 { [a[0] / l, a[1] / l, a[2] / l] } else { [0.0, 0.0, 0.0] }
+}
+
+/// All corner points of an occurrence's profile prisms (base + extruded), Z-up, rebased.
+fn occurrence_points(profiles: &[&ExtractedProfile], origin: [f64; 3]) -> Vec<[f64; 3]> {
+    let mut pts = Vec::new();
+    for p in profiles {
+        let n = p.outer_points.len() / 2;
+        let dir = zup([p.extrusion_dir[0] as f64, p.extrusion_dir[1] as f64, p.extrusion_dir[2] as f64]);
+        let depth = p.extrusion_depth as f64;
+        for i in 0..n {
+            let base = sub(xf(&p.transform, p.outer_points[i * 2] as f64, p.outer_points[i * 2 + 1] as f64), origin);
+            pts.push(base);
+            pts.push([base[0] + dir[0] * depth, base[1] + dir[1] * depth, base[2] + dir[2] * depth]);
+        }
+    }
+    pts
+}
+
+/// An exterior wall face with its in-plane (u, v) frame, for sub-face placement.
+struct WallFace {
+    ri: usize,
+    fi: usize,
+    origin: [f64; 3],
+    uax: [f64; 3],
+    vax: [f64; 3],
+    ulen: f64,
+    vlen: f64,
+    n: [f64; 3],
+}
+
+fn collect_exterior_walls(rooms: &[Room]) -> Vec<WallFace> {
+    let mut out = Vec::new();
+    for (ri, room) in rooms.iter().enumerate() {
+        for (fi, f) in room.faces.iter().enumerate() {
+            if f.face_type != "Wall" || f.boundary_condition.ty != "Outdoors" {
+                continue;
+            }
+            let b = &f.geometry.boundary;
+            if b.len() < 3 {
+                continue;
+            }
+            let origin = b[0];
+            let uax = norm(sub(b[1], origin));
+            let vax = norm(sub(b[b.len() - 1], origin));
+            let ulen = b.iter().map(|p| dot(sub(*p, origin), uax)).fold(f64::MIN, f64::max);
+            let vlen = b.iter().map(|p| dot(sub(*p, origin), vax)).fold(f64::MIN, f64::max);
+            out.push(WallFace { ri, fi, origin, uax, vax, ulen, vlen, n: newell_normal(b) });
+        }
+    }
+    out
+}
+
+/// Project a point cloud onto the best-matching exterior wall face → coplanar rectangle.
+fn project(verts: &[[f64; 3]], walls: &[WallFace]) -> Option<(usize, usize, Vec<[f64; 3]>)> {
+    if verts.is_empty() {
+        return None;
+    }
+    let c = center(verts);
+    let mut best: Option<(f64, usize)> = None;
+    for (i, w) in walls.iter().enumerate() {
+        let d = dot(sub(c, w.origin), w.n).abs();
+        let u = dot(sub(c, w.origin), w.uax);
+        let v = dot(sub(c, w.origin), w.vax);
+        if d < 0.7 && u > -0.5 && u < w.ulen + 0.5 && v > -0.5 && v < w.vlen + 0.5 {
+            if best.map_or(true, |(bd, _)| d < bd) {
+                best = Some((d, i));
+            }
+        }
+    }
+    let w = &walls[best?.1];
+    let us: Vec<f64> = verts.iter().map(|p| dot(sub(*p, w.origin), w.uax)).collect();
+    let vs: Vec<f64> = verts.iter().map(|p| dot(sub(*p, w.origin), w.vax)).collect();
+    let u0 = us.iter().cloned().fold(f64::MAX, f64::min).max(0.05);
+    let u1 = us.iter().cloned().fold(f64::MIN, f64::max).min(w.ulen - 0.05);
+    let v0 = vs.iter().cloned().fold(f64::MAX, f64::min).max(0.05);
+    let v1 = vs.iter().cloned().fold(f64::MIN, f64::max).min(w.vlen - 0.05);
+    if u1 - u0 < 0.1 || v1 - v0 < 0.1 {
+        return None;
+    }
+    let pt = |u: f64, v: f64| {
+        [
+            w.origin[0] + w.uax[0] * u + w.vax[0] * v,
+            w.origin[1] + w.uax[1] * u + w.vax[1] * v,
+            w.origin[2] + w.uax[2] * u + w.vax[2] * v,
+        ]
+    };
+    Some((w.ri, w.fi, vec![pt(u0, v0), pt(u1, v0), pt(u1, v1), pt(u0, v1)]))
+}
+
+enum Pending {
+    Window(u32, Vec<[f64; 3]>),
+    Door(u32, Vec<[f64; 3]>),
+}
+
+/// Place windows as Apertures and doors as Doors on exterior wall faces (mutating `rooms`).
+/// Only exterior (`Outdoors`) walls receive sub-faces — interior adjacency / interior
+/// openings land once gap-closing is solved downstream (P5).
+pub fn attach_openings(profiles: &[ExtractedProfile], rooms: &mut [Room], origin: [f64; 3]) {
+    // Group window/door profiles by occurrence.
+    let mut by: HashMap<u32, (bool, Vec<&ExtractedProfile>)> = HashMap::new();
+    for p in profiles {
+        let is_window = p.ifc_type == "IfcWindow";
+        if is_window || p.ifc_type == "IfcDoor" {
+            by.entry(p.express_id).or_insert((is_window, Vec::new())).1.push(p);
+        }
+    }
+
+    let walls = collect_exterior_walls(rooms);
+    let mut pending: Vec<(usize, usize, Pending)> = Vec::new();
+    for (id, (is_window, ps)) in &by {
+        let pts = occurrence_points(ps, origin);
+        if let Some((ri, fi, geo)) = project(&pts, &walls) {
+            pending.push((ri, fi, if *is_window { Pending::Window(*id, geo) } else { Pending::Door(*id, geo) }));
+        }
+    }
+
+    for (ri, fi, p) in pending {
+        match p {
+            Pending::Window(id, geo) => {
+                rooms[ri].faces[fi].apertures.push(Aperture::new(format!("Ap{}", id), Face3D::new(geo), false));
+            }
+            Pending::Door(id, geo) => {
+                rooms[ri].faces[fi].doors.push(Door::new(format!("Dr{}", id), Face3D::new(geo), false));
+            }
+        }
+    }
+}

--- a/rust/export/src/rooms.rs
+++ b/rust/export/src/rooms.rs
@@ -1,0 +1,326 @@
+// SPDX-License-Identifier: MPL-2.0
+//! Build watertight Honeybee Rooms from `IfcSpace` extruded-area profiles.
+//!
+//! Source = `ifc_lite_geometry::extract_profiles` (analytic, NOT the render mesh — the
+//! render mesh drops sliver triangles and breaks watertightness; proven in the spike).
+//! `ExtractedProfile` is in renderer **Y-up** space (matching the JS bridge), so points
+//! and the extrusion direction are converted to Honeybee **Z-up** here. Coordinates are
+//! rebased to a model origin to keep f32 survey magnitudes (national-grid models) from
+//! collapsing precision.
+
+use std::collections::HashMap;
+
+use ifc_lite_geometry::ExtractedProfile;
+
+use crate::hbjson::{Face, Face3D, Room};
+
+/// Convert a WebGL Y-up point/direction to IFC/Honeybee Z-up: `(x, y, z) -> (x, -z, y)`.
+fn zup(p: [f64; 3]) -> [f64; 3] {
+    [p[0], -p[2], p[1]]
+}
+
+/// Transform a 2D profile point by the entity's column-major 4×4, then convert to Z-up.
+fn xf(t: &[f32; 16], px: f64, py: f64) -> [f64; 3] {
+    let c = |r: usize, col: usize| t[col * 4 + r] as f64;
+    zup([
+        c(0, 0) * px + c(0, 1) * py + c(0, 3),
+        c(1, 0) * px + c(1, 1) * py + c(1, 3),
+        c(2, 0) * px + c(2, 1) * py + c(2, 3),
+    ])
+}
+
+fn dist(a: &[f64; 3], b: &[f64; 3]) -> f64 {
+    ((a[0] - b[0]).powi(2) + (a[1] - b[1]).powi(2) + (a[2] - b[2]).powi(2)).sqrt()
+}
+
+/// Merge vertices closer than `merge` (Euclidean), including a duplicate closing vertex.
+/// `merge` carries a margin above the model tolerance so no kept edge lands in Honeybee's
+/// degenerate band (which would collapse to a non-manifold edge).
+fn clean_ring(ring: Vec<[f64; 3]>, merge: f64) -> Vec<[f64; 3]> {
+    let mut out: Vec<[f64; 3]> = Vec::with_capacity(ring.len());
+    for p in ring {
+        if out.last().map_or(true, |q| dist(&p, q) > merge) {
+            out.push(p);
+        }
+    }
+    if out.len() > 1 && dist(&out[0], out.last().unwrap()) <= merge {
+        out.pop();
+    }
+    out
+}
+
+/// Newell's method: raw (area-weighted, un-normalised) polygon normal.
+fn newell_raw(b: &[[f64; 3]]) -> [f64; 3] {
+    let m = b.len();
+    let mut n = [0.0_f64; 3];
+    for i in 0..m {
+        let c = b[i];
+        let d = b[(i + 1) % m];
+        n[0] += (c[1] - d[1]) * (c[2] + d[2]);
+        n[1] += (c[2] - d[2]) * (c[0] + d[0]);
+        n[2] += (c[0] - d[0]) * (c[1] + d[1]);
+    }
+    n
+}
+
+/// Unit polygon normal (zero vector if degenerate).
+fn newell_normal(b: &[[f64; 3]]) -> [f64; 3] {
+    let n = newell_raw(b);
+    let len = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt();
+    if len > 0.0 { [n[0] / len, n[1] / len, n[2] / len] } else { [0.0, 0.0, 0.0] }
+}
+
+/// Planar polygon area (`|Newell| / 2`).
+fn polygon_area(b: &[[f64; 3]]) -> f64 {
+    let n = newell_raw(b);
+    0.5 * (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt()
+}
+
+/// Shortest edge length of a closed polygon.
+fn min_edge(b: &[[f64; 3]]) -> f64 {
+    let m = b.len();
+    (0..m)
+        .map(|i| {
+            let c = b[i];
+            let d = b[(i + 1) % m];
+            ((c[0] - d[0]).powi(2) + (c[1] - d[1]).powi(2) + (c[2] - d[2]).powi(2)).sqrt()
+        })
+        .fold(f64::MAX, f64::min)
+}
+
+/// Max deviation of any vertex from the polygon's best-fit plane.
+fn planarity_dev(b: &[[f64; 3]]) -> f64 {
+    let n = newell_normal(b);
+    if n == [0.0, 0.0, 0.0] {
+        return f64::MAX;
+    }
+    let p0 = b[0];
+    b.iter()
+        .map(|p| ((p[0] - p0[0]) * n[0] + (p[1] - p0[1]) * n[1] + (p[2] - p0[2]) * n[2]).abs())
+        .fold(0.0, f64::max)
+}
+
+/// A face Honeybee will accept: non-sliver, non-degenerate, planar within tolerance.
+fn face_ok(b: &[[f64; 3]], tol: f64) -> bool {
+    polygon_area(b) >= AREA_EPS && min_edge(b) > tol && planarity_dev(b) <= tol
+}
+
+/// 2D cross product (orientation) of `a→b` vs `a→c`.
+fn orient2d(a: (f64, f64), b: (f64, f64), c: (f64, f64)) -> f64 {
+    (b.0 - a.0) * (c.1 - a.1) - (b.1 - a.1) * (c.0 - a.0)
+}
+
+/// Proper crossing of segments `p1p2` and `p3p4` (shared endpoints don't count).
+fn segments_cross(p1: (f64, f64), p2: (f64, f64), p3: (f64, f64), p4: (f64, f64)) -> bool {
+    let d1 = orient2d(p3, p4, p1);
+    let d2 = orient2d(p3, p4, p2);
+    let d3 = orient2d(p1, p2, p3);
+    let d4 = orient2d(p1, p2, p4);
+    ((d1 > 0.0) != (d2 > 0.0)) && ((d3 > 0.0) != (d4 > 0.0)) && d1 != 0.0 && d2 != 0.0 && d3 != 0.0 && d4 != 0.0
+}
+
+/// True when the footprint ring is a simple polygon — no edge crossing AND no vertex pinch
+/// (two non-adjacent vertices coinciding). Both are topologically watertight once extruded
+/// but geometrically invalid: a crossing makes a figure-8, a pinch makes a non-manifold edge.
+/// Honeybee rejects both as "not closed" / not solid, so we screen them out here.
+fn is_simple_polygon(ring: &[[f64; 3]], tol: f64) -> bool {
+    let n = newell_normal(ring);
+    let (nx, ny, nz) = (n[0].abs(), n[1].abs(), n[2].abs());
+    let (ax, ay): (usize, usize) = if nx >= ny && nx >= nz {
+        (1, 2)
+    } else if ny >= nx && ny >= nz {
+        (0, 2)
+    } else {
+        (0, 1)
+    };
+    let p: Vec<(f64, f64)> = ring.iter().map(|q| (q[ax], q[ay])).collect();
+    let m = p.len();
+    if m < 3 {
+        return false;
+    }
+    for i in 0..m {
+        // Reject pinch points: any non-adjacent vertex coinciding with vertex i.
+        for j in (i + 1)..m {
+            if (j + 1) % m == i || (i + 1) % m == j {
+                continue; // adjacent
+            }
+            if (p[i].0 - p[j].0).abs() <= tol && (p[i].1 - p[j].1).abs() <= tol {
+                return false;
+            }
+        }
+        // Reject edge crossings.
+        let a1 = p[i];
+        let a2 = p[(i + 1) % m];
+        for j in (i + 1)..m {
+            if (j + 1) % m == i || (i + 1) % m == j {
+                continue;
+            }
+            if segments_cross(a1, a2, p[j], p[(j + 1) % m]) {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// True when the faces form a closed 2-manifold: every undirected edge (vertices snapped
+/// to a `tol` grid) is shared by exactly two faces. Catches self-intersecting footprints
+/// and any other non-watertight prism — the same naked-edge test Honeybee applies.
+fn is_watertight(faces: &[(Vec<[f64; 3]>, &'static str)], tol: f64) -> bool {
+    let grid = tol.max(1e-6);
+    let key = |p: &[f64; 3]| {
+        (
+            (p[0] / grid).round() as i64,
+            (p[1] / grid).round() as i64,
+            (p[2] / grid).round() as i64,
+        )
+    };
+    let mut edges: HashMap<((i64, i64, i64), (i64, i64, i64)), i32> = HashMap::new();
+    for (b, _) in faces {
+        let m = b.len();
+        for i in 0..m {
+            let a = key(&b[i]);
+            let c = key(&b[(i + 1) % m]);
+            if a == c {
+                return false;
+            }
+            let e = if a <= c { (a, c) } else { (c, a) };
+            *edges.entry(e).or_insert(0) += 1;
+        }
+    }
+    !edges.is_empty() && edges.values().all(|&c| c == 2)
+}
+
+fn center(b: &[[f64; 3]]) -> [f64; 3] {
+    let m = b.len().max(1) as f64;
+    let mut c = [0.0; 3];
+    for p in b {
+        for k in 0..3 { c[k] += p[k]; }
+    }
+    [c[0] / m, c[1] / m, c[2] / m]
+}
+
+fn dot(a: [f64; 3], b: [f64; 3]) -> f64 {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+}
+
+/// Minimum face area (m²) below which a face — and its room — is treated as degenerate.
+const AREA_EPS: f64 = 1.0e-4;
+
+/// Build Honeybee Rooms from the `IfcSpace` profiles in `profiles`.
+///
+/// Returns the rooms plus the count of `IfcSpace` profiles skipped as degenerate
+/// (so callers can report coverage rather than silently truncate).
+pub fn build_rooms(profiles: &[ExtractedProfile], tol: f64) -> (Vec<Room>, usize) {
+    let mut skipped = 0usize;
+    let spaces: Vec<&ExtractedProfile> =
+        profiles.iter().filter(|p| p.ifc_type == "IfcSpace").collect();
+
+    // Model-wide origin to rebase against (kills survey-coordinate f32 collapse).
+    let mut origin = [f64::MAX; 3];
+    for s in &spaces {
+        let n = s.outer_points.len() / 2;
+        for i in 0..n {
+            let w = xf(&s.transform, s.outer_points[i * 2] as f64, s.outer_points[i * 2 + 1] as f64);
+            for k in 0..3 {
+                if w[k] < origin[k] { origin[k] = w[k]; }
+            }
+        }
+    }
+    if !origin[0].is_finite() {
+        return (Vec::new(), skipped);
+    }
+
+    let mut rooms = Vec::new();
+    for s in &spaces {
+        let n = s.outer_points.len() / 2;
+        if n < 3 {
+            skipped += 1;
+            continue;
+        }
+        // extrusion_dir is also Y-up → convert (linear, no translation).
+        let dir = zup([s.extrusion_dir[0] as f64, s.extrusion_dir[1] as f64, s.extrusion_dir[2] as f64]);
+        let depth = s.extrusion_depth as f64;
+
+        let ring: Vec<[f64; 3]> = (0..n)
+            .map(|i| {
+                let w = xf(&s.transform, s.outer_points[i * 2] as f64, s.outer_points[i * 2 + 1] as f64);
+                [w[0] - origin[0], w[1] - origin[1], w[2] - origin[2]]
+            })
+            .collect();
+        // Merge with a 2× margin so near-tolerance slivers can't survive as degenerate walls.
+        let floor = clean_ring(ring, 2.0 * tol);
+        if floor.len() < 3 || !is_simple_polygon(&floor, tol) {
+            skipped += 1;
+            continue;
+        }
+        let extruded: Vec<[f64; 3]> = floor
+            .iter()
+            .map(|p| [p[0] + dir[0] * depth, p[1] + dir[1] * depth, p[2] + dir[2] * depth])
+            .collect();
+
+        // Designate the lower ring as the Floor, the upper as the RoofCeiling (handles a
+        // downward extrusion). Both share the base ring's vertex order, so wall quads pair
+        // up correctly by index.
+        let avg_z = |r: &[[f64; 3]]| r.iter().map(|p| p[2]).sum::<f64>() / r.len().max(1) as f64;
+        let (floor_ring, roof_ring) = if avg_z(&extruded) >= avg_z(&floor) {
+            (floor.clone(), extruded)
+        } else {
+            (extruded, floor.clone())
+        };
+
+        // Room centroid for outward-orientation.
+        let mut cen = [0.0; 3];
+        for p in floor_ring.iter().chain(roof_ring.iter()) {
+            for k in 0..3 { cen[k] += p[k]; }
+        }
+        let tot = (floor_ring.len() + roof_ring.len()) as f64;
+        for k in 0..3 { cen[k] /= tot; }
+
+        // Faces typed BY CONSTRUCTION (not normal inference): floor, roof, then wall quads.
+        let m = floor_ring.len();
+        let mut raw: Vec<(Vec<[f64; 3]>, &'static str)> = Vec::with_capacity(m + 2);
+        raw.push((floor_ring.clone(), "Floor"));
+        raw.push((roof_ring.clone(), "RoofCeiling"));
+        for i in 0..m {
+            let j = (i + 1) % m;
+            raw.push((vec![floor_ring[i], floor_ring[j], roof_ring[j], roof_ring[i]], "Wall"));
+        }
+
+        // Orient every face outward; reject the whole room if any face is degenerate.
+        // (Holes & non-extrusion spaces are P5.)
+        let mut oriented: Vec<(Vec<[f64; 3]>, &'static str)> = Vec::with_capacity(raw.len());
+        let mut degenerate = false;
+        for (mut b, face_type) in raw {
+            if !face_ok(&b, tol) {
+                degenerate = true;
+                break;
+            }
+            let fc = center(&b);
+            let outward = [fc[0] - cen[0], fc[1] - cen[1], fc[2] - cen[2]];
+            if dot(newell_normal(&b), outward) < 0.0 {
+                b.reverse();
+            }
+            oriented.push((b, face_type));
+        }
+        let walls = oriented.iter().filter(|(_, t)| *t == "Wall").count();
+        // Only emit rooms that are genuinely watertight (self-intersecting footprints fail here).
+        if degenerate || walls < 3 || !is_watertight(&oriented, tol) {
+            skipped += 1;
+            continue;
+        }
+
+        // P1: ground the floor, everything else Outdoors. Interior adjacency (Surface BCs)
+        // is solved downstream in Honeybee once gap-closing lands (P5).
+        let faces: Vec<Face> = oriented
+            .into_iter()
+            .enumerate()
+            .map(|(fi, (b, face_type))| {
+                let bc = if face_type == "Floor" { "Ground" } else { "Outdoors" };
+                Face::new(format!("R{}_F{}", s.express_id, fi), Face3D::new(b), face_type, bc)
+            })
+            .collect();
+        rooms.push(Room::new(format!("R{}", s.express_id), faces));
+    }
+    (rooms, skipped)
+}

--- a/rust/export/src/rooms.rs
+++ b/rust/export/src/rooms.rs
@@ -36,7 +36,7 @@ fn dist(a: &[f64; 3], b: &[f64; 3]) -> f64 {
 /// Merge vertices closer than `merge` (Euclidean), including a duplicate closing vertex.
 /// `merge` carries a margin above the model tolerance so no kept edge lands in Honeybee's
 /// degenerate band (which would collapse to a non-manifold edge).
-fn clean_ring(ring: Vec<[f64; 3]>, merge: f64) -> Vec<[f64; 3]> {
+pub(crate) fn clean_ring(ring: Vec<[f64; 3]>, merge: f64) -> Vec<[f64; 3]> {
     let mut out: Vec<[f64; 3]> = Vec::with_capacity(ring.len());
     for p in ring {
         if out.last().map_or(true, |q| dist(&p, q) > merge) {

--- a/rust/export/src/rooms.rs
+++ b/rust/export/src/rooms.rs
@@ -15,12 +15,12 @@ use ifc_lite_geometry::ExtractedProfile;
 use crate::hbjson::{Face, Face3D, Room};
 
 /// Convert a WebGL Y-up point/direction to IFC/Honeybee Z-up: `(x, y, z) -> (x, -z, y)`.
-fn zup(p: [f64; 3]) -> [f64; 3] {
+pub(crate) fn zup(p: [f64; 3]) -> [f64; 3] {
     [p[0], -p[2], p[1]]
 }
 
 /// Transform a 2D profile point by the entity's column-major 4×4, then convert to Z-up.
-fn xf(t: &[f32; 16], px: f64, py: f64) -> [f64; 3] {
+pub(crate) fn xf(t: &[f32; 16], px: f64, py: f64) -> [f64; 3] {
     let c = |r: usize, col: usize| t[col * 4 + r] as f64;
     zup([
         c(0, 0) * px + c(0, 1) * py + c(0, 3),
@@ -64,7 +64,7 @@ fn newell_raw(b: &[[f64; 3]]) -> [f64; 3] {
 }
 
 /// Unit polygon normal (zero vector if degenerate).
-fn newell_normal(b: &[[f64; 3]]) -> [f64; 3] {
+pub(crate) fn newell_normal(b: &[[f64; 3]]) -> [f64; 3] {
     let n = newell_raw(b);
     let len = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt();
     if len > 0.0 { [n[0] / len, n[1] / len, n[2] / len] } else { [0.0, 0.0, 0.0] }
@@ -191,7 +191,7 @@ fn is_watertight(faces: &[(Vec<[f64; 3]>, &'static str)], tol: f64) -> bool {
     !edges.is_empty() && edges.values().all(|&c| c == 2)
 }
 
-fn center(b: &[[f64; 3]]) -> [f64; 3] {
+pub(crate) fn center(b: &[[f64; 3]]) -> [f64; 3] {
     let m = b.len().max(1) as f64;
     let mut c = [0.0; 3];
     for p in b {
@@ -200,7 +200,7 @@ fn center(b: &[[f64; 3]]) -> [f64; 3] {
     [c[0] / m, c[1] / m, c[2] / m]
 }
 
-fn dot(a: [f64; 3], b: [f64; 3]) -> f64 {
+pub(crate) fn dot(a: [f64; 3], b: [f64; 3]) -> f64 {
     a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
 }
 
@@ -209,9 +209,10 @@ const AREA_EPS: f64 = 1.0e-4;
 
 /// Build Honeybee Rooms from the `IfcSpace` profiles in `profiles`.
 ///
-/// Returns the rooms plus the count of `IfcSpace` profiles skipped as degenerate
-/// (so callers can report coverage rather than silently truncate).
-pub fn build_rooms(profiles: &[ExtractedProfile], tol: f64) -> (Vec<Room>, usize) {
+/// Returns the rooms, the model-wide rebase origin (so the openings pass can place window/
+/// door geometry in the same frame), and the count of `IfcSpace` profiles skipped as
+/// degenerate (so callers can report coverage rather than silently truncate).
+pub fn build_rooms(profiles: &[ExtractedProfile], tol: f64) -> (Vec<Room>, [f64; 3], usize) {
     let mut skipped = 0usize;
     let spaces: Vec<&ExtractedProfile> =
         profiles.iter().filter(|p| p.ifc_type == "IfcSpace").collect();
@@ -228,7 +229,7 @@ pub fn build_rooms(profiles: &[ExtractedProfile], tol: f64) -> (Vec<Room>, usize
         }
     }
     if !origin[0].is_finite() {
-        return (Vec::new(), skipped);
+        return (Vec::new(), [0.0; 3], skipped);
     }
 
     let mut rooms = Vec::new();
@@ -322,5 +323,72 @@ pub fn build_rooms(profiles: &[ExtractedProfile], tol: f64) -> (Vec<Room>, usize
             .collect();
         rooms.push(Room::new(format!("R{}", s.express_id), faces));
     }
-    (rooms, skipped)
+
+    // Drop duplicate / strongly-overlapping spaces (Revit often carries an overlapping copy).
+    // Safe: adjacent rooms are air volumes separated by wall thickness → ~0 AABB overlap;
+    // stacked storeys → ~0 Z overlap. Only true duplicates exceed the 50% fraction.
+    let (rooms, dropped) = dedupe_colliding(rooms);
+    skipped += dropped;
+    (rooms, origin, skipped)
+}
+
+/// A room's duplicate signature: floor-polygon XY centroid + area + Z extent.
+struct Sig {
+    cx: f64,
+    cy: f64,
+    area: f64,
+    zmin: f64,
+    zmax: f64,
+}
+
+fn room_signature(r: &Room) -> Option<Sig> {
+    let floor = r.faces.iter().find(|f| f.face_type == "Floor")?;
+    let b = &floor.geometry.boundary;
+    if b.is_empty() {
+        return None;
+    }
+    let n = b.len() as f64;
+    let cx = b.iter().map(|p| p[0]).sum::<f64>() / n;
+    let cy = b.iter().map(|p| p[1]).sum::<f64>() / n;
+    let (zmin, zmax) = r
+        .faces
+        .iter()
+        .flat_map(|f| &f.geometry.boundary)
+        .fold((f64::MAX, f64::MIN), |(lo, hi), p| (lo.min(p[2]), hi.max(p[2])));
+    Some(Sig { cx, cy, area: polygon_area(b), zmin, zmax })
+}
+
+/// True when two rooms are near-identical copies (Revit duplicate-space artifact): same
+/// floor centroid, same area, overlapping Z. Targets duplicates precisely so genuinely
+/// distinct adjacent/nested/stacked rooms are never dropped.
+fn is_duplicate(a: &Sig, b: &Sig) -> bool {
+    (a.cx - b.cx).abs() < 0.3
+        && (a.cy - b.cy).abs() < 0.3
+        && a.area > 0.0
+        && (a.area - b.area).abs() / a.area.max(b.area) < 0.05
+        && a.zmin < b.zmax
+        && b.zmin < a.zmax
+}
+
+/// Keep the larger-area room of each duplicate pair.
+fn dedupe_colliding(rooms: Vec<Room>) -> (Vec<Room>, usize) {
+    let sigs: Vec<Option<Sig>> = rooms.iter().map(room_signature).collect();
+    let mut order: Vec<usize> = (0..rooms.len()).collect();
+    let area_of = |i: usize| sigs[i].as_ref().map_or(0.0, |s| s.area);
+    order.sort_by(|&a, &b| area_of(b).partial_cmp(&area_of(a)).unwrap_or(std::cmp::Ordering::Equal));
+    let mut keep = vec![false; rooms.len()];
+    let mut kept: Vec<usize> = Vec::new();
+    for &i in &order {
+        let dup = match &sigs[i] {
+            Some(si) => kept.iter().any(|&j| sigs[j].as_ref().is_some_and(|sj| is_duplicate(si, sj))),
+            None => false,
+        };
+        if !dup {
+            keep[i] = true;
+            kept.push(i);
+        }
+    }
+    let dropped = keep.iter().filter(|k| !**k).count();
+    let out = rooms.into_iter().enumerate().filter(|(i, _)| keep[*i]).map(|(_, r)| r).collect();
+    (out, dropped)
 }

--- a/rust/export/src/rooms.rs
+++ b/rust/export/src/rooms.rs
@@ -239,6 +239,13 @@ pub fn build_rooms(profiles: &[ExtractedProfile], tol: f64) -> (Vec<Room>, [f64;
             skipped += 1;
             continue;
         }
+        // Spaces with inner rings (courtyard/atrium holes) would need the hole modelled in
+        // the floor/ceiling faces; building from the outer ring alone yields a wrong solid,
+        // so skip them rather than emit incorrect geometry (hole support is a follow-up).
+        if !s.hole_counts.is_empty() {
+            skipped += 1;
+            continue;
+        }
         // extrusion_dir is also Y-up → convert (linear, no translation).
         let dir = zup([s.extrusion_dir[0] as f64, s.extrusion_dir[1] as f64, s.extrusion_dir[2] as f64]);
         let depth = s.extrusion_depth as f64;

--- a/rust/export/src/rooms.rs
+++ b/rust/export/src/rooms.rs
@@ -71,7 +71,7 @@ pub(crate) fn newell_normal(b: &[[f64; 3]]) -> [f64; 3] {
 }
 
 /// Planar polygon area (`|Newell| / 2`).
-fn polygon_area(b: &[[f64; 3]]) -> f64 {
+pub(crate) fn polygon_area(b: &[[f64; 3]]) -> f64 {
     let n = newell_raw(b);
     0.5 * (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt()
 }

--- a/rust/export/src/shades.rs
+++ b/rust/export/src/shades.rs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MPL-2.0
+//! Shades (railings → ShadeMesh) for the HBJSON exporter — wasm-safe, profile-based.
+//!
+//! `IfcRailing` posts/rails come through `extract_profiles` as small extruded prisms (the
+//! native mesher traps in wasm, so we reuse the same profile source as rooms/openings).
+//! Each prism's side surface is triangulated and all of a railing's prisms are combined into
+//! one `ShadeMesh`. Shading geometry needs no watertightness — a triangle soup is correct here.
+
+use std::collections::HashMap;
+
+use ifc_lite_geometry::ExtractedProfile;
+
+use crate::hbjson::ShadeMesh;
+use crate::rooms::{clean_ring, xf, zup};
+
+/// Build one `ShadeMesh` per `IfcRailing` occurrence from its extruded profile prisms.
+pub fn build_shades(profiles: &[ExtractedProfile], origin: [f64; 3]) -> Vec<ShadeMesh> {
+    let mut by: HashMap<u32, Vec<&ExtractedProfile>> = HashMap::new();
+    for p in profiles {
+        if p.ifc_type == "IfcRailing" {
+            by.entry(p.express_id).or_default().push(p);
+        }
+    }
+
+    let mut shades = Vec::new();
+    for (id, ps) in &by {
+        let mut verts: Vec<[f64; 3]> = Vec::new();
+        let mut faces: Vec<[usize; 3]> = Vec::new();
+        for p in ps {
+            let n = p.outer_points.len() / 2;
+            if n < 3 {
+                continue;
+            }
+            let dir = zup([p.extrusion_dir[0] as f64, p.extrusion_dir[1] as f64, p.extrusion_dir[2] as f64]);
+            let depth = p.extrusion_depth as f64;
+            let ring: Vec<[f64; 3]> = (0..n)
+                .map(|i| {
+                    let w = xf(&p.transform, p.outer_points[i * 2] as f64, p.outer_points[i * 2 + 1] as f64);
+                    [w[0] - origin[0], w[1] - origin[1], w[2] - origin[2]]
+                })
+                .collect();
+            let ring = clean_ring(ring, 1.0e-4);
+            let m = ring.len();
+            if m < 3 {
+                continue;
+            }
+            // base ring, then top ring (extruded).
+            let base = verts.len();
+            for r in &ring {
+                verts.push(*r);
+            }
+            for r in &ring {
+                verts.push([r[0] + dir[0] * depth, r[1] + dir[1] * depth, r[2] + dir[2] * depth]);
+            }
+            // side quads → two triangles each (the visible shade surface).
+            for i in 0..m {
+                let j = (i + 1) % m;
+                let (bi, bj, ti, tj) = (base + i, base + j, base + m + i, base + m + j);
+                faces.push([bi, bj, tj]);
+                faces.push([bi, tj, ti]);
+            }
+        }
+        if !faces.is_empty() {
+            shades.push(ShadeMesh::new(format!("Rail{}", id), verts, faces));
+        }
+    }
+    shades
+}

--- a/rust/wasm-bindings/Cargo.toml
+++ b/rust/wasm-bindings/Cargo.toml
@@ -35,6 +35,8 @@ ifc-lite-geometry = { version = "4.1.0", path = "../geometry", default-features 
 ifc-lite-processing = { version = "4.1.0", path = "../processing" }
 # Pure-geometry clash kernel (BVH broad phase + exact triangle narrow phase).
 ifc-lite-clash = { version = "4.1.0", path = "../clash" }
+# Domain-format exporters (HBJSON / Honeybee energy model).
+ifc-lite-export = { version = "4.1.0", path = "../export" }
 js-sys = "=0.3.83"
 rayon = "1.10"
 # `ifc-lite-geometry` uses rayon `par_iter` (e.g. FacetedBrep

--- a/rust/wasm-bindings/src/api/export_hbjson.rs
+++ b/rust/wasm-bindings/src/api/export_hbjson.rs
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! WASM API: export_hbjson — IFC → Honeybee HBJSON (energy/daylight model) string.
+
+use super::IfcAPI;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+impl IfcAPI {
+    /// Export the `IfcSpace` volumes in `content` as a Honeybee **HBJSON** string.
+    ///
+    /// Rooms are built analytically from extruded-area profiles (watertight by construction);
+    /// faces are typed Floor / RoofCeiling / Wall with outward normals. The result loads via
+    /// `honeybee.model.Model.from_hbjson` and is ready for Ladybug Tools / Pollination.
+    ///
+    /// ```javascript
+    /// const api = new IfcAPI();
+    /// const hbjson = api.exportHbjson(ifcContent, "my_model");
+    /// ```
+    #[wasm_bindgen(js_name = exportHbjson)]
+    pub fn export_hbjson(&self, content: String, name: String) -> String {
+        let opts = ifc_lite_export::HbjsonOptions { name, tolerance: 0.01 };
+        ifc_lite_export::export_hbjson(content.as_bytes(), &opts)
+    }
+}

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -8,6 +8,7 @@
 
 mod alignment_lines;
 mod clash;
+mod export_hbjson;
 mod extract_profiles;
 mod gpu_meshes;
 mod grid_lines;

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -3424,6 +3424,7 @@
     "ExportBackendMethods: interface",
     "ExportCsvOptions: interface",
     "ExportGltfOptions: interface",
+    "ExportHbjsonOptions: interface",
     "ExportNamespace: class",
     "ExportStepOptions: interface",
     "FileAttachmentInfo: interface",


### PR DESCRIPTION
## What

Adds **HBJSON** (Honeybee / Ladybug Tools energy & daylight model) as a first-class export, alongside csv/json/ifc/glTF.

```
ifc-lite export model.ifc --format hbjson --out model.hbjson
```

HBJSON is the open, Rhino-free Ladybug Tools model format — and Honeybee has **no native IFC import**, so this makes ifc-lite a client-side IFC→Honeybee on-ramp (feeds Ladybug/Pollination for energy & daylight analysis).

## How

New pure-Rust **`ifc-lite-export`** crate is the source of truth (CLI / SDK / wasm are thin callers — per the rust-first principle). There was no Rust export crate before; this establishes the pattern (glTF can migrate into it later).

```
IFC bytes
 → ifc-lite-export (Rust)            IfcSpace → watertight prisms → serde HBJSON
 → IfcAPI.exportHbjson (wasm)        regenerated into pkg/ifc-lite.d.ts
 → bridge / GeometryProcessor.exportHbjson (TS)
 → CLI  export --format hbjson
```

Rooms are built **analytically from extruded-area profiles, not the render mesh** (the render mesh drops sliver triangles → breaks watertightness; measured 67–71% solid vs 85–100% analytic). Robustness gates, each proven necessary on real models: Y-up→Z-up; origin-rebase (national-grid f32 collapse); 2·tol Euclidean vertex merge (near-tolerance sliver walls → non-manifold); planarity + min-edge + simple-polygon (no crossing/pinch) + manifold-closure screens; by-construction face typing (Floor/RoofCeiling/Wall) with outward normals. Degenerate spaces are skipped with a surfaced count (no silent truncation).

## Verification (against honeybee-core)

- **duplex** → 19/19 rooms, `model.check_all()` **PASS**
- **rvt01** (Revit, georeferenced) → 47/47 watertight rooms
- wasm binding exercised directly on the regenerated pkg from Node → honeybee PASS
- 2 cargo tests (`ifc-lite-export`), skip-if-absent fixtures (repo convention)

## Notes

- Adds **`packages/cli/src/wasm-node-init.ts`** (`initSync` from disk): the `--target web` wasm can't `fetch(file://)` under Node, which also currently breaks `clash`/`lod` in Node. Wired into the hbjson path here; clash/lod can adopt it in a follow-up.
- Scope is **rooms (P1)**. Apertures, doors, shades (ShadeMesh) and constructions (MaterialLayerSet→OpaqueConstruction) follow. `IfcRelSpaceBoundary` is not implemented in ifc-lite → interior adjacency is left to honeybee `solve_adjacency` downstream.
- Changeset included (`@ifc-lite/{cli,geometry,wasm}` minor). The wasm `.js`/`.wasm` are gitignored/CI-built; only the regenerated `.d.ts` is committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added HBJSON export for energy modeling from IFC (`ifc-lite export --format hbjson`), available in the Viewer export menu and via `GeometryProcessor.exportHbjson()`.
- Exports watertight room volume geometry with energy constructions from IFC material layer sets, plus door/window openings, interior wall surface adjacencies, and railing shading geometry.

## Bug Fixes
- Improved CLI support for Node-based exports by ensuring the WebAssembly engine is correctly initialized before running HBJSON export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->