### PR TITLE
feat(ids): isolate involved elements per specification (#1236)

### DIFF
--- a/apps/viewer/src/components/viewer/IDSPanel.tsx
+++ b/apps/viewer/src/components/viewer/IDSPanel.tsx
@@ -29,6 +29,8 @@ import {
   Focus,
   EyeOff,
   Eye,
+  Boxes,
+  Layers,
   FileText,
   Loader2,
   Building2,
@@ -460,6 +462,7 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
     error,
     activeSpecificationId,
     filterMode,
+    isolationScope,
 
     // Actions
     loadIDSFile,
@@ -469,9 +472,11 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
     setActiveSpecification,
     selectEntity,
     setFilterMode,
+    setIsolationScope,
     applyColors,
     isolateFailed,
     isolatePassed,
+    isolateInvolved,
     clearIsolation,
     exportReportJSON,
     exportReportHTML,
@@ -654,6 +659,12 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
   const renderResults = () => {
     if (!report) return null;
 
+    // In 'spec' scope the isolate/color actions target the active
+    // specification; disable them until one is selected.
+    const specScope = isolationScope === 'spec';
+    const noActiveSpec = specScope && !activeSpecificationId;
+    const scopeSuffix = specScope ? ' (this spec)' : ' (whole IDS)';
+
     return (
       <>
         {/* Audit summary stays visible above the validation report so
@@ -690,7 +701,9 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
             <PassRateBar passRate={report.summary.overallPassRate} />
           </div>
           <p className="text-xs text-muted-foreground mt-2 text-center">
-            💡 Click any entity to select and zoom to it in the 3D view
+            {specScope
+              ? '💡 Select a specification to isolate its elements — passed green, failed red'
+              : '💡 Click any entity to select and zoom to it in the 3D view'}
           </p>
         </div>
 
@@ -708,24 +721,47 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
             </SelectContent>
           </Select>
 
+          {/* Isolate scope: whole report vs. the active specification (#1236).
+              'Per Spec' isolates the selected specification's elements
+              (passed green, failed red). */}
+          <Select value={isolationScope} onValueChange={(v) => setIsolationScope(v as 'ids' | 'spec')}>
+            <SelectTrigger className="h-8 w-[112px]" aria-label="Isolate scope">
+              <Layers className="h-3 w-3 mr-1" />
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="ids">Whole IDS</SelectItem>
+              <SelectItem value="spec">Per Spec</SelectItem>
+            </SelectContent>
+          </Select>
+
           <div className="flex-1 min-w-2" />
 
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button variant="ghost" size="sm" className="h-8 w-8 p-0" onClick={isolateFailed}>
+              <Button variant="ghost" size="sm" className="h-8 w-8 p-0" onClick={isolateFailed} disabled={noActiveSpec}>
                 <EyeOff className="h-4 w-4" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Isolate Failed</TooltipContent>
+            <TooltipContent>Isolate failed{scopeSuffix}</TooltipContent>
           </Tooltip>
 
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button variant="ghost" size="sm" className="h-8 w-8 p-0" onClick={isolatePassed}>
+              <Button variant="ghost" size="sm" className="h-8 w-8 p-0" onClick={isolatePassed} disabled={noActiveSpec}>
                 <Eye className="h-4 w-4" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Isolate Passed</TooltipContent>
+            <TooltipContent>Isolate passed{scopeSuffix}</TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button variant="ghost" size="sm" className="h-8 w-8 p-0" onClick={() => isolateInvolved()} disabled={noActiveSpec}>
+                <Boxes className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Isolate involved{scopeSuffix} — passed green + failed red</TooltipContent>
           </Tooltip>
 
           <Tooltip>
@@ -734,7 +770,7 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
                 <Focus className="h-4 w-4" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Clear Isolation</TooltipContent>
+            <TooltipContent>Clear isolation</TooltipContent>
           </Tooltip>
 
           <Tooltip>

--- a/apps/viewer/src/components/viewer/IDSPanel.tsx
+++ b/apps/viewer/src/components/viewer/IDSPanel.tsx
@@ -463,6 +463,8 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
     activeSpecificationId,
     filterMode,
     isolationScope,
+    isolateMode,
+    isolationActive,
 
     // Actions
     loadIDSFile,
@@ -521,6 +523,29 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
   const handleEntityClick = useCallback((modelId: string, expressId: number) => {
     selectEntity(modelId, expressId);
   }, [selectEntity]);
+
+  // Active state for the isolate toggle buttons. A button is "active" only
+  // when ITS mode is applied AND isolation is still live, so an externally
+  // cleared isolation self-heals the button back to inactive.
+  const failedActive = isolationActive && isolateMode === 'failed';
+  const passedActive = isolationActive && isolateMode === 'passed';
+  const involvedActive = isolationActive && isolateMode === 'involved';
+
+  // Clicking the active isolate button toggles it off (undo).
+  const handleIsolateFailed = useCallback(() => {
+    if (failedActive) clearIsolation();
+    else isolateFailed();
+  }, [failedActive, clearIsolation, isolateFailed]);
+
+  const handleIsolatePassed = useCallback(() => {
+    if (passedActive) clearIsolation();
+    else isolatePassed();
+  }, [passedActive, clearIsolation, isolatePassed]);
+
+  const handleIsolateInvolved = useCallback(() => {
+    if (involvedActive) clearIsolation();
+    else isolateInvolved();
+  }, [involvedActive, clearIsolation, isolateInvolved]);
 
   // Render validation progress
   const renderProgress = () => {
@@ -739,38 +764,73 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
 
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button variant="ghost" size="sm" className="h-8 w-8 p-0" onClick={isolateFailed} disabled={noActiveSpec}>
+              <Button
+                variant={failedActive ? 'secondary' : 'ghost'}
+                size="sm"
+                className={cn('h-8 w-8 p-0', failedActive && 'text-red-600')}
+                aria-pressed={failedActive}
+                onClick={handleIsolateFailed}
+                disabled={noActiveSpec}
+              >
                 <EyeOff className="h-4 w-4" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Isolate failed{scopeSuffix}</TooltipContent>
+            <TooltipContent>
+              {failedActive ? 'Show all (undo isolate failed)' : `Isolate failed${scopeSuffix}`}
+            </TooltipContent>
           </Tooltip>
 
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button variant="ghost" size="sm" className="h-8 w-8 p-0" onClick={isolatePassed} disabled={noActiveSpec}>
+              <Button
+                variant={passedActive ? 'secondary' : 'ghost'}
+                size="sm"
+                className={cn('h-8 w-8 p-0', passedActive && 'text-green-600')}
+                aria-pressed={passedActive}
+                onClick={handleIsolatePassed}
+                disabled={noActiveSpec}
+              >
                 <Eye className="h-4 w-4" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Isolate passed{scopeSuffix}</TooltipContent>
+            <TooltipContent>
+              {passedActive ? 'Show all (undo isolate passed)' : `Isolate passed${scopeSuffix}`}
+            </TooltipContent>
           </Tooltip>
 
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button variant="ghost" size="sm" className="h-8 w-8 p-0" onClick={() => isolateInvolved()} disabled={noActiveSpec}>
+              <Button
+                variant={involvedActive ? 'secondary' : 'ghost'}
+                size="sm"
+                className="h-8 w-8 p-0"
+                aria-pressed={involvedActive}
+                onClick={handleIsolateInvolved}
+                disabled={noActiveSpec}
+              >
                 <Boxes className="h-4 w-4" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Isolate involved{scopeSuffix} — passed green + failed red</TooltipContent>
+            <TooltipContent>
+              {involvedActive
+                ? 'Show all (undo isolate involved)'
+                : `Isolate involved${scopeSuffix} — passed green + failed red`}
+            </TooltipContent>
           </Tooltip>
 
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button variant="ghost" size="sm" className="h-8 w-8 p-0" onClick={clearIsolation}>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 w-8 p-0"
+                onClick={clearIsolation}
+                disabled={!isolationActive}
+              >
                 <Focus className="h-4 w-4" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Clear isolation</TooltipContent>
+            <TooltipContent>Clear isolation (show all)</TooltipContent>
           </Tooltip>
 
           <Tooltip>

--- a/apps/viewer/src/hooks/ids/idsColorSystem.ts
+++ b/apps/viewer/src/hooks/ids/idsColorSystem.ts
@@ -33,6 +33,16 @@ export interface ColorModelInfo {
   idOffset?: number;
 }
 
+/** Optional scoping for {@link buildValidationColorUpdates}. */
+export interface ColorScopeOptions {
+  /**
+   * Restrict colors to a single specification's results. An entity may pass
+   * one specification and fail another, so per-spec coloring (instead of the
+   * whole-report verdict) is what makes the active spec's green/red correct.
+   */
+  specId?: string;
+}
+
 /**
  * Build a map of color overrides from validation results.
  *
@@ -46,6 +56,7 @@ export interface ColorModelInfo {
  * @param defaultPassedColor - Fallback passed color
  * @param geometryResult - Current geometry for capturing original colors (may be null)
  * @param originalColors - Mutable map to store original colors into (only populated if empty)
+ * @param scope - Optional scoping (e.g. restrict to a single specification)
  * @returns Map of globalId to color tuple for updateMeshColors
  */
 export function buildValidationColorUpdates(
@@ -55,7 +66,8 @@ export function buildValidationColorUpdates(
   defaultFailedColor: ColorTuple,
   defaultPassedColor: ColorTuple,
   geometryResult: GeometryResult | null | undefined,
-  originalColors: Map<number, ColorTuple>
+  originalColors: Map<number, ColorTuple>,
+  scope?: ColorScopeOptions
 ): Map<number, ColorTuple> {
   const colorUpdates = new Map<number, ColorTuple>();
 
@@ -63,9 +75,14 @@ export function buildValidationColorUpdates(
   const failedClr = displayOptions.failedColor ?? defaultFailedColor;
   const passedClr = displayOptions.passedColor ?? defaultPassedColor;
 
+  // When scoped to a spec, only that spec's results drive the colors.
+  const specResults = scope?.specId
+    ? report.specificationResults.filter((s) => s.specification.id === scope.specId)
+    : report.specificationResults;
+
   // Build a set of globalIds we'll be updating
   const globalIdsToUpdate = new Set<number>();
-  for (const specResult of report.specificationResults) {
+  for (const specResult of specResults) {
     for (const entityResult of specResult.entityResults) {
       const globalId = toGlobalIdFromModels(models, entityResult.modelId, entityResult.expressId);
       globalIdsToUpdate.add(globalId);
@@ -81,8 +98,8 @@ export function buildValidationColorUpdates(
     }
   }
 
-  // Process all entity results
-  for (const specResult of report.specificationResults) {
+  // Process all entity results (within scope)
+  for (const specResult of specResults) {
     for (const entityResult of specResult.entityResults) {
       const globalId = toGlobalIdFromModels(models, entityResult.modelId, entityResult.expressId);
 

--- a/apps/viewer/src/hooks/useIDS.ts
+++ b/apps/viewer/src/hooks/useIDS.ts
@@ -95,6 +95,10 @@ export interface UseIDSResult {
   filterMode: 'all' | 'failed' | 'passed';
   /** Isolation/color scope: whole report ('ids') or active spec only ('spec') */
   isolationScope: 'ids' | 'spec';
+  /** Which isolate action is currently applied by IDS (null = none) */
+  isolateMode: 'failed' | 'passed' | 'involved' | null;
+  /** True when any entity isolation is currently active in the 3D view */
+  isolationActive: boolean;
   /** Display options */
   displayOptions: {
     highlightFailed: boolean;
@@ -212,6 +216,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
   const activeEntityId = useViewerStore((s) => s.idsActiveEntityId);
   const filterMode = useViewerStore((s) => s.idsFilterMode);
   const isolationScope = useViewerStore((s) => s.idsIsolationScope);
+  const isolateMode = useViewerStore((s) => s.idsIsolateMode);
   const displayOptions = useViewerStore((s) => s.idsDisplayOptions);
 
   // IDS store actions
@@ -231,6 +236,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
   const setIdsLocale = useViewerStore((s) => s.setIdsLocale);
   const setIdsFilterMode = useViewerStore((s) => s.setIdsFilterMode);
   const setIdsIsolationScope = useViewerStore((s) => s.setIdsIsolationScope);
+  const setIdsIsolateMode = useViewerStore((s) => s.setIdsIsolateMode);
   const setIdsDisplayOptions = useViewerStore((s) => s.setIdsDisplayOptions);
   const idsFailedEntityIds = useViewerStore((s) => s.idsFailedEntityIds);
   const idsPassedEntityIds = useViewerStore((s) => s.idsPassedEntityIds);
@@ -245,6 +251,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
   const setSelectedEntityId = useViewerStore((s) => s.setSelectedEntityId);
   const setSelectedEntity = useViewerStore((s) => s.setSelectedEntity);
   const setIsolatedEntities = useViewerStore((s) => s.setIsolatedEntities);
+  const isolatedEntities = useViewerStore((s) => s.isolatedEntities);
   const toGlobalId = useViewerStore((s) => s.toGlobalId);
   const cameraCallbacks = useViewerStore((s) => s.cameraCallbacks);
   const geometryResult = useViewerStore((s) => s.geometryResult);
@@ -697,11 +704,15 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
       if (ids.size > 0) {
         setIsolatedEntities(ids);
         setSpecColors(activeSpecificationId);
+        setIdsIsolateMode('failed');
       }
       return;
     }
     const failedIds = keySetToGlobalIds(idsFailedEntityIds);
-    if (failedIds.size > 0) setIsolatedEntities(failedIds);
+    if (failedIds.size > 0) {
+      setIsolatedEntities(failedIds);
+      setIdsIsolateMode('failed');
+    }
   }, [
     isolationScope,
     activeSpecificationId,
@@ -711,6 +722,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
     idsFailedEntityIds,
     setIsolatedEntities,
     setSpecColors,
+    setIdsIsolateMode,
   ]);
 
   const isolatePassed = useCallback(() => {
@@ -720,11 +732,15 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
       if (ids.size > 0) {
         setIsolatedEntities(ids);
         setSpecColors(activeSpecificationId);
+        setIdsIsolateMode('passed');
       }
       return;
     }
     const passedIds = keySetToGlobalIds(idsPassedEntityIds);
-    if (passedIds.size > 0) setIsolatedEntities(passedIds);
+    if (passedIds.size > 0) {
+      setIsolatedEntities(passedIds);
+      setIdsIsolateMode('passed');
+    }
   }, [
     isolationScope,
     activeSpecificationId,
@@ -734,6 +750,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
     idsPassedEntityIds,
     setIsolatedEntities,
     setSpecColors,
+    setIdsIsolateMode,
   ]);
 
   const isolateInvolved = useCallback((specId?: string) => {
@@ -746,6 +763,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
       if (ids.size > 0) {
         setIsolatedEntities(ids);
         setSpecColors(targetSpec);
+        setIdsIsolateMode('involved');
       } else {
         // The spec has no applicable entities (not_applicable). There's
         // nothing to isolate, so drop any stale isolation/overlay left by a
@@ -753,6 +771,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
         // the panel points at this (empty) spec.
         setIsolatedEntities(null);
         restoreReportColors();
+        setIdsIsolateMode(null);
       }
       return;
     }
@@ -763,6 +782,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
     if (ids.size > 0) {
       setIsolatedEntities(ids);
       setPendingColorUpdates(buildColors(undefined, true));
+      setIdsIsolateMode('involved');
     }
   }, [
     isolationScope,
@@ -777,6 +797,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
     setSpecColors,
     restoreReportColors,
     setPendingColorUpdates,
+    setIdsIsolateMode,
     buildColors,
   ]);
 
@@ -785,7 +806,8 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
     // Returning to "show all" restores the default whole-report coloring,
     // replacing any per-spec green/red applied while isolated.
     restoreReportColors();
-  }, [setIsolatedEntities, restoreReportColors]);
+    setIdsIsolateMode(null);
+  }, [setIsolatedEntities, restoreReportColors, setIdsIsolateMode]);
 
   const setActiveSpecification = useCallback((specId: string | null) => {
     setIdsActiveSpecification(specId);
@@ -800,8 +822,10 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
   const setIsolationScope = useCallback((scope: 'ids' | 'spec') => {
     setIdsIsolationScope(scope);
     if (scope === 'spec') {
-      // Entering per-spec scope isolates the active spec (if one is selected).
+      // Entering per-spec scope isolates the active spec, or clears any stale
+      // whole-IDS isolation so the user starts from a clean "pick a spec" slate.
       if (activeSpecificationId) isolateInvolved(activeSpecificationId);
+      else clearIsolation();
     } else {
       // Back to whole-IDS scope: drop per-spec isolation and restore colors.
       clearIsolation();
@@ -1142,6 +1166,8 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
     activeEntityId,
     filterMode,
     isolationScope,
+    isolateMode,
+    isolationActive: isolatedEntities != null,
     displayOptions,
 
     // Document actions

--- a/apps/viewer/src/hooks/useIDS.ts
+++ b/apps/viewer/src/hooks/useIDS.ts
@@ -746,6 +746,13 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
       if (ids.size > 0) {
         setIsolatedEntities(ids);
         setSpecColors(targetSpec);
+      } else {
+        // The spec has no applicable entities (not_applicable). There's
+        // nothing to isolate, so drop any stale isolation/overlay left by a
+        // previously selected spec rather than leaving it on screen while
+        // the panel points at this (empty) spec.
+        setIsolatedEntities(null);
+        restoreReportColors();
       }
       return;
     }
@@ -768,6 +775,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
     idsPassedEntityIds,
     setIsolatedEntities,
     setSpecColors,
+    restoreReportColors,
     setPendingColorUpdates,
     buildColors,
   ]);

--- a/apps/viewer/src/hooks/useIDS.ts
+++ b/apps/viewer/src/hooks/useIDS.ts
@@ -93,6 +93,8 @@ export interface UseIDSResult {
   activeEntityId: { modelId: string; expressId: number } | null;
   /** Filter mode */
   filterMode: 'all' | 'failed' | 'passed';
+  /** Isolation/color scope: whole report ('ids') or active spec only ('spec') */
+  isolationScope: 'ids' | 'spec';
   /** Display options */
   displayOptions: {
     highlightFailed: boolean;
@@ -132,6 +134,8 @@ export interface UseIDSResult {
   setLocale: (locale: SupportedLocale) => void;
   /** Set filter mode */
   setFilterMode: (mode: 'all' | 'failed' | 'passed') => void;
+  /** Set the isolation/color scope (whole report vs active spec) */
+  setIsolationScope: (scope: 'ids' | 'spec') => void;
   /** Update display options */
   setDisplayOptions: (options: Partial<UseIDSResult['displayOptions']>) => void;
 
@@ -142,11 +146,17 @@ export interface UseIDSResult {
   clearColors: () => void;
 
   // Isolation actions
-  /** Isolate failed entities */
+  /** Isolate failed entities (whole report, or active spec when scope = 'spec') */
   isolateFailed: () => void;
-  /** Isolate passed entities */
+  /** Isolate passed entities (whole report, or active spec when scope = 'spec') */
   isolatePassed: () => void;
-  /** Clear isolation */
+  /**
+   * Isolate the involved entities (passed ∪ failed) and color them
+   * (passed green, failed red). Targets the given spec, else the active spec
+   * when scope = 'spec', else the whole report.
+   */
+  isolateInvolved: (specId?: string) => void;
+  /** Clear isolation (and restore whole-report colors) */
   clearIsolation: () => void;
 
   // Utility getters
@@ -201,6 +211,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
   const activeSpecificationId = useViewerStore((s) => s.idsActiveSpecificationId);
   const activeEntityId = useViewerStore((s) => s.idsActiveEntityId);
   const filterMode = useViewerStore((s) => s.idsFilterMode);
+  const isolationScope = useViewerStore((s) => s.idsIsolationScope);
   const displayOptions = useViewerStore((s) => s.idsDisplayOptions);
 
   // IDS store actions
@@ -219,9 +230,12 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
   const setIdsError = useViewerStore((s) => s.setIdsError);
   const setIdsLocale = useViewerStore((s) => s.setIdsLocale);
   const setIdsFilterMode = useViewerStore((s) => s.setIdsFilterMode);
+  const setIdsIsolationScope = useViewerStore((s) => s.setIdsIsolationScope);
   const setIdsDisplayOptions = useViewerStore((s) => s.setIdsDisplayOptions);
   const idsFailedEntityIds = useViewerStore((s) => s.idsFailedEntityIds);
   const idsPassedEntityIds = useViewerStore((s) => s.idsPassedEntityIds);
+  const getFailedEntitiesForSpec = useViewerStore((s) => s.getFailedEntitiesForSpec);
+  const getPassedEntitiesForSpec = useViewerStore((s) => s.getPassedEntitiesForSpec);
 
   // Viewer state
   const models = useViewerStore((s) => s.models);
@@ -514,10 +528,6 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
   // Selection Actions
   // ============================================================================
 
-  const setActiveSpecification = useCallback((specId: string | null) => {
-    setIdsActiveSpecification(specId);
-  }, [setIdsActiveSpecification]);
-
   const selectEntity = useCallback((modelId: string, expressId: number, zoomToEntity = true) => {
 
     // Update IDS state
@@ -582,23 +592,50 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
   // Color Actions
   // ============================================================================
 
+  // Build the color-override map for the whole report (or a single spec when
+  // `specId` is given). `bothHighlights` forces passed+failed coloring
+  // regardless of the user's display toggles — used when isolating a spec's
+  // involved elements so both green and red show.
+  const buildColors = useCallback(
+    (specId?: string, bothHighlights = false): Map<number, ColorTuple> => {
+      if (!report) return new Map<number, ColorTuple>();
+      const opts = bothHighlights
+        ? { ...displayOptions, highlightFailed: true, highlightPassed: true }
+        : displayOptions;
+      return buildValidationColorUpdates(
+        report,
+        models,
+        opts,
+        defaultFailedColor,
+        defaultPassedColor,
+        geometryResultRef.current,
+        originalColorsRef.current,
+        specId ? { specId } : undefined
+      );
+    },
+    [report, models, displayOptions, defaultFailedColor, defaultPassedColor]
+  );
+
   const applyColors = useCallback(() => {
-    if (!report) return;
-
-    const colorUpdates = buildValidationColorUpdates(
-      report,
-      models,
-      displayOptions,
-      defaultFailedColor,
-      defaultPassedColor,
-      geometryResultRef.current,
-      originalColorsRef.current
-    );
-
+    const colorUpdates = buildColors();
     if (colorUpdates.size > 0) {
       setPendingColorUpdates(colorUpdates);
     }
-  }, [report, models, displayOptions, defaultFailedColor, defaultPassedColor, setPendingColorUpdates]);
+  }, [buildColors, setPendingColorUpdates]);
+
+  // Replace the overlay with a single spec's colors (passed green + failed
+  // red). Per-spec coloring is what makes the active spec's verdict correct
+  // even for entities that pass in another specification.
+  const setSpecColors = useCallback((specId: string) => {
+    setPendingColorUpdates(buildColors(specId, true));
+  }, [buildColors, setPendingColorUpdates]);
+
+  // Restore the default whole-report coloring, replacing any per-spec colors.
+  // An empty map clears the overlay when there's nothing to highlight.
+  const restoreReportColors = useCallback(() => {
+    if (!report) return;
+    setPendingColorUpdates(buildColors());
+  }, [report, buildColors, setPendingColorUpdates]);
 
   const clearColors = useCallback(() => {
     // Empty map signals overlay clear immediately.
@@ -622,43 +659,146 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
   // Isolation Actions
   // ============================================================================
 
+  // Parse a cached "modelId:expressId" key into a renderer global id.
+  const keyToGlobalId = useCallback((key: string): number | undefined => {
+    const lastColonIndex = key.lastIndexOf(':');
+    const modelId = key.substring(0, lastColonIndex);
+    const expressId = parseInt(key.substring(lastColonIndex + 1), 10);
+    return toViewerGlobalId(modelId, expressId);
+  }, [toViewerGlobalId]);
+
+  // Resolve a list of entity refs to a set of renderer global ids.
+  const refsToGlobalIds = useCallback(
+    (refs: Array<{ modelId: string; expressId: number }>): Set<number> => {
+      const ids = new Set<number>();
+      for (const { modelId, expressId } of refs) {
+        const globalId = toViewerGlobalId(modelId, expressId);
+        if (globalId != null) ids.add(globalId);
+      }
+      return ids;
+    },
+    [toViewerGlobalId]
+  );
+
+  // Collect global ids from a cached "modelId:expressId" key set.
+  const keySetToGlobalIds = useCallback((keys: Set<string>): Set<number> => {
+    const ids = new Set<number>();
+    for (const key of keys) {
+      const globalId = keyToGlobalId(key);
+      if (globalId != null) ids.add(globalId);
+    }
+    return ids;
+  }, [keyToGlobalId]);
+
   const isolateFailed = useCallback(() => {
-    const failedIds = new Set<number>();
-
-    for (const key of idsFailedEntityIds) {
-      const lastColonIndex = key.lastIndexOf(':');
-      const modelId = key.substring(0, lastColonIndex);
-      const expressIdStr = key.substring(lastColonIndex + 1);
-      const expressId = parseInt(expressIdStr, 10);
-      const globalId = toViewerGlobalId(modelId, expressId);
-      if (globalId != null) failedIds.add(globalId);
+    if (isolationScope === 'spec') {
+      if (!activeSpecificationId) return;
+      const ids = refsToGlobalIds(getFailedEntitiesForSpec(activeSpecificationId));
+      if (ids.size > 0) {
+        setIsolatedEntities(ids);
+        setSpecColors(activeSpecificationId);
+      }
+      return;
     }
-
-    if (failedIds.size > 0) {
-      setIsolatedEntities(failedIds);
-    }
-  }, [idsFailedEntityIds, setIsolatedEntities, toViewerGlobalId]);
+    const failedIds = keySetToGlobalIds(idsFailedEntityIds);
+    if (failedIds.size > 0) setIsolatedEntities(failedIds);
+  }, [
+    isolationScope,
+    activeSpecificationId,
+    getFailedEntitiesForSpec,
+    refsToGlobalIds,
+    keySetToGlobalIds,
+    idsFailedEntityIds,
+    setIsolatedEntities,
+    setSpecColors,
+  ]);
 
   const isolatePassed = useCallback(() => {
-    const passedIds = new Set<number>();
-
-    for (const key of idsPassedEntityIds) {
-      const lastColonIndex = key.lastIndexOf(':');
-      const modelId = key.substring(0, lastColonIndex);
-      const expressIdStr = key.substring(lastColonIndex + 1);
-      const expressId = parseInt(expressIdStr, 10);
-      const globalId = toViewerGlobalId(modelId, expressId);
-      if (globalId != null) passedIds.add(globalId);
+    if (isolationScope === 'spec') {
+      if (!activeSpecificationId) return;
+      const ids = refsToGlobalIds(getPassedEntitiesForSpec(activeSpecificationId));
+      if (ids.size > 0) {
+        setIsolatedEntities(ids);
+        setSpecColors(activeSpecificationId);
+      }
+      return;
     }
+    const passedIds = keySetToGlobalIds(idsPassedEntityIds);
+    if (passedIds.size > 0) setIsolatedEntities(passedIds);
+  }, [
+    isolationScope,
+    activeSpecificationId,
+    getPassedEntitiesForSpec,
+    refsToGlobalIds,
+    keySetToGlobalIds,
+    idsPassedEntityIds,
+    setIsolatedEntities,
+    setSpecColors,
+  ]);
 
-    if (passedIds.size > 0) {
-      setIsolatedEntities(passedIds);
+  const isolateInvolved = useCallback((specId?: string) => {
+    const targetSpec = specId ?? (isolationScope === 'spec' ? activeSpecificationId : null);
+    if (targetSpec) {
+      const ids = refsToGlobalIds([
+        ...getFailedEntitiesForSpec(targetSpec),
+        ...getPassedEntitiesForSpec(targetSpec),
+      ]);
+      if (ids.size > 0) {
+        setIsolatedEntities(ids);
+        setSpecColors(targetSpec);
+      }
+      return;
     }
-  }, [idsPassedEntityIds, setIsolatedEntities, toViewerGlobalId]);
+    // Whole report: every applicable entity (passed ∪ failed), colored
+    // green/red regardless of the user's display toggles.
+    const ids = keySetToGlobalIds(idsFailedEntityIds);
+    for (const globalId of keySetToGlobalIds(idsPassedEntityIds)) ids.add(globalId);
+    if (ids.size > 0) {
+      setIsolatedEntities(ids);
+      setPendingColorUpdates(buildColors(undefined, true));
+    }
+  }, [
+    isolationScope,
+    activeSpecificationId,
+    getFailedEntitiesForSpec,
+    getPassedEntitiesForSpec,
+    refsToGlobalIds,
+    keySetToGlobalIds,
+    idsFailedEntityIds,
+    idsPassedEntityIds,
+    setIsolatedEntities,
+    setSpecColors,
+    setPendingColorUpdates,
+    buildColors,
+  ]);
 
   const clearIsolation = useCallback(() => {
     setIsolatedEntities(null);
-  }, [setIsolatedEntities]);
+    // Returning to "show all" restores the default whole-report coloring,
+    // replacing any per-spec green/red applied while isolated.
+    restoreReportColors();
+  }, [setIsolatedEntities, restoreReportColors]);
+
+  const setActiveSpecification = useCallback((specId: string | null) => {
+    setIdsActiveSpecification(specId);
+    // In per-spec scope, selecting a spec immediately isolates its involved
+    // elements (passed green, failed red); deselecting clears isolation.
+    if (isolationScope === 'spec') {
+      if (specId) isolateInvolved(specId);
+      else clearIsolation();
+    }
+  }, [setIdsActiveSpecification, isolationScope, isolateInvolved, clearIsolation]);
+
+  const setIsolationScope = useCallback((scope: 'ids' | 'spec') => {
+    setIdsIsolationScope(scope);
+    if (scope === 'spec') {
+      // Entering per-spec scope isolates the active spec (if one is selected).
+      if (activeSpecificationId) isolateInvolved(activeSpecificationId);
+    } else {
+      // Back to whole-IDS scope: drop per-spec isolation and restore colors.
+      clearIsolation();
+    }
+  }, [setIdsIsolationScope, activeSpecificationId, isolateInvolved, clearIsolation]);
 
   // ============================================================================
   // Utility Getters
@@ -993,6 +1133,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
     activeSpecificationId,
     activeEntityId,
     filterMode,
+    isolationScope,
     displayOptions,
 
     // Document actions
@@ -1014,6 +1155,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
     togglePanel,
     setLocale,
     setFilterMode: setFilterModeAction,
+    setIsolationScope,
     setDisplayOptions: setDisplayOptionsAction,
 
     // Color actions
@@ -1023,6 +1165,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
     // Isolation actions
     isolateFailed,
     isolatePassed,
+    isolateInvolved,
     clearIsolation,
 
     // Utility getters

--- a/apps/viewer/src/store/slices/idsSlice.ts
+++ b/apps/viewer/src/store/slices/idsSlice.ts
@@ -38,6 +38,13 @@ export interface IDSDisplayOptions {
 /** IDS filter mode */
 export type IDSFilterMode = 'all' | 'failed' | 'passed';
 
+/**
+ * Scope for the isolate/color controls.
+ * - 'ids': act on the whole validation report (every specification combined)
+ * - 'spec': act on the currently active specification only
+ */
+export type IDSIsolationScope = 'ids' | 'spec';
+
 export interface IDSSliceState {
   /** Loaded IDS document */
   idsDocument: IDSDocument | null;
@@ -70,6 +77,13 @@ export interface IDSSliceState {
   idsDisplayOptions: IDSDisplayOptions;
   /** Filter mode (show all, failed only, passed only) */
   idsFilterMode: IDSFilterMode;
+  /**
+   * Whether the isolate/color controls act on the whole report ('ids',
+   * default) or on the active specification only ('spec'). In 'spec' mode,
+   * selecting a specification isolates its involved elements (passed green,
+   * failed red) so they can be reviewed in context — per issue #1236.
+   */
+  idsIsolationScope: IDSIsolationScope;
   /** Cached set of failed entity IDs for efficient lookup */
   idsFailedEntityIds: Set<string>; // "modelId:expressId" format
   /** Cached set of passed entity IDs */
@@ -102,6 +116,7 @@ export interface IDSSlice extends IDSSliceState {
   setIdsLocale: (locale: SupportedLocale) => void;
   setIdsDisplayOptions: (options: Partial<IDSDisplayOptions>) => void;
   setIdsFilterMode: (mode: IDSFilterMode) => void;
+  setIdsIsolationScope: (scope: IDSIsolationScope) => void;
 
   // Utility getters
   getActiveSpecificationResult: () => IDSSpecificationResult | null;
@@ -184,6 +199,7 @@ export const createIdsSlice: StateCreator<IDSSlice, [], [], IDSSlice> = (set, ge
   idsLocale: getDefaultLocale(),
   idsDisplayOptions: DEFAULT_DISPLAY_OPTIONS,
   idsFilterMode: 'all',
+  idsIsolationScope: 'ids',
   idsFailedEntityIds: new Set(),
   idsPassedEntityIds: new Set(),
 
@@ -235,6 +251,7 @@ export const createIdsSlice: StateCreator<IDSSlice, [], [], IDSSlice> = (set, ge
       idsValidationReport: null,
       idsActiveSpecificationId: null,
       idsActiveEntityId: null,
+      idsIsolationScope: 'ids',
       idsFailedEntityIds: new Set(),
       idsPassedEntityIds: new Set(),
     }),
@@ -272,6 +289,8 @@ export const createIdsSlice: StateCreator<IDSSlice, [], [], IDSSlice> = (set, ge
     })),
 
   setIdsFilterMode: (idsFilterMode) => set({ idsFilterMode }),
+
+  setIdsIsolationScope: (idsIsolationScope) => set({ idsIsolationScope }),
 
   // Utility getters
   getActiveSpecificationResult: () => {

--- a/apps/viewer/src/store/slices/idsSlice.ts
+++ b/apps/viewer/src/store/slices/idsSlice.ts
@@ -45,6 +45,13 @@ export type IDSFilterMode = 'all' | 'failed' | 'passed';
  */
 export type IDSIsolationScope = 'ids' | 'spec';
 
+/**
+ * Which IDS isolate action is currently applied, so the panel can show the
+ * active button as pressed and toggle it off on a second click. `null` when
+ * IDS is not isolating.
+ */
+export type IDSIsolateMode = 'failed' | 'passed' | 'involved' | null;
+
 export interface IDSSliceState {
   /** Loaded IDS document */
   idsDocument: IDSDocument | null;
@@ -84,6 +91,8 @@ export interface IDSSliceState {
    * failed red) so they can be reviewed in context — per issue #1236.
    */
   idsIsolationScope: IDSIsolationScope;
+  /** Which isolate action is currently applied (drives toggle + active state) */
+  idsIsolateMode: IDSIsolateMode;
   /** Cached set of failed entity IDs for efficient lookup */
   idsFailedEntityIds: Set<string>; // "modelId:expressId" format
   /** Cached set of passed entity IDs */
@@ -117,6 +126,7 @@ export interface IDSSlice extends IDSSliceState {
   setIdsDisplayOptions: (options: Partial<IDSDisplayOptions>) => void;
   setIdsFilterMode: (mode: IDSFilterMode) => void;
   setIdsIsolationScope: (scope: IDSIsolationScope) => void;
+  setIdsIsolateMode: (mode: IDSIsolateMode) => void;
 
   // Utility getters
   getActiveSpecificationResult: () => IDSSpecificationResult | null;
@@ -200,6 +210,7 @@ export const createIdsSlice: StateCreator<IDSSlice, [], [], IDSSlice> = (set, ge
   idsDisplayOptions: DEFAULT_DISPLAY_OPTIONS,
   idsFilterMode: 'all',
   idsIsolationScope: 'ids',
+  idsIsolateMode: null,
   idsFailedEntityIds: new Set(),
   idsPassedEntityIds: new Set(),
 
@@ -241,6 +252,7 @@ export const createIdsSlice: StateCreator<IDSSlice, [], [], IDSSlice> = (set, ge
       idsValidationReport: report,
       idsFailedEntityIds: failed,
       idsPassedEntityIds: passed,
+      idsIsolateMode: null,
       idsError: null,
       idsProgress: null,
     });
@@ -252,6 +264,7 @@ export const createIdsSlice: StateCreator<IDSSlice, [], [], IDSSlice> = (set, ge
       idsActiveSpecificationId: null,
       idsActiveEntityId: null,
       idsIsolationScope: 'ids',
+      idsIsolateMode: null,
       idsFailedEntityIds: new Set(),
       idsPassedEntityIds: new Set(),
     }),
@@ -291,6 +304,8 @@ export const createIdsSlice: StateCreator<IDSSlice, [], [], IDSSlice> = (set, ge
   setIdsFilterMode: (idsFilterMode) => set({ idsFilterMode }),
 
   setIdsIsolationScope: (idsIsolationScope) => set({ idsIsolationScope }),
+
+  setIdsIsolateMode: (idsIsolateMode) => set({ idsIsolateMode }),
 
   // Utility getters
   getActiveSpecificationResult: () => {


### PR DESCRIPTION
Closes #1236.

## What
Adds a **Whole IDS / Per Spec** isolation scope to the IDS validation results panel, so you can isolate the elements involved in a single specification and review them in context — passed green, failed red.

The panel already had whole-report *Isolate Failed / Isolate Passed / Clear Isolation* + red/green coloring. This scopes those controls (and adds an *Isolate Involved* button) to the selected specification, which is what the issue asked for ("isolate the involved elements per specification … isolate by IDS or SPEC, there is room for another button/pulldown").

## How
Modeled on the recently-merged compare/diff overlay's scope-toggle pattern (`ComparePanel` + `useCompareOverlay`):

- **Scope pulldown** `Whole IDS` (default) / `Per Spec` in the actions bar. Default keeps existing behaviour unchanged.
- In **Per Spec** scope, selecting a specification auto-isolates its involved elements and colors them.
- The existing **Isolate Failed / Isolate Passed / Clear Isolation** controls become scope-aware (disabled until a spec is selected in Per Spec mode).
- New **Isolate Involved** button shows passed (green) and failed (red) together.
- **Per-spec coloring correctness:** an entity can pass one spec and fail another, so colors are computed from the *active spec's* verdict rather than the combined whole-report verdict. Clearing isolation / switching back to Whole IDS restores the default whole-report coloring.

## Files (all under `apps/viewer`)
- `store/slices/idsSlice.ts` — `idsIsolationScope` state + setter
- `hooks/ids/idsColorSystem.ts` — optional `{ specId }` scope on the color builder
- `hooks/useIDS.ts` — scope-aware isolate actions, `isolateInvolved`, `setIsolationScope`, per-spec coloring, auto-isolate on spec select
- `components/viewer/IDSPanel.tsx` — scope pulldown, Isolate Involved button, dynamic tooltips/disabled state, updated hint

## Testing
- `tsc --noEmit` for `apps/viewer`: clean for all changed files.
- Not yet verified in-browser — recommend a visual check of the green/red per-spec isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)