### PR TITLE
fix(export): HBJSON review fixes — adjacency, determinism, robustness

### DIFF
--- a/rust/export/src/adjacency.rs
+++ b/rust/export/src/adjacency.rs
@@ -27,7 +27,7 @@ fn dist(a: [f64; 3], b: [f64; 3]) -> f64 {
     (d[0] * d[0] + d[1] * d[1] + d[2] * d[2]).sqrt()
 }
 
-struct WallFace {
+struct AdjFace {
     ri: usize,
     fi: usize,
     c: [f64; 3],
@@ -37,20 +37,21 @@ struct WallFace {
     room_id: String,
 }
 
-/// Pair up shared interior walls and set reciprocal `Surface` boundary conditions.
-/// Returns the number of interior faces created (2 per matched pair).
+/// Pair up shared interior faces (walls between side-by-side rooms AND floors/ceilings
+/// between stacked rooms) and set reciprocal `Surface` boundary conditions. Returns the
+/// number of interior faces created (2 per matched pair).
 pub fn solve_adjacency(rooms: &mut [Room]) -> usize {
-    let mut faces: Vec<WallFace> = Vec::new();
+    // Every planar face is a candidate: anti-parallel normals naturally pick wall↔wall
+    // (horizontal normals) and floor↔roof (vertical normals) pairs; same-storey floors
+    // (parallel down-normals) and exterior faces never match.
+    let mut faces: Vec<AdjFace> = Vec::new();
     for (ri, room) in rooms.iter().enumerate() {
         for (fi, f) in room.faces.iter().enumerate() {
-            if f.face_type != "Wall" {
-                continue;
-            }
             let b = &f.geometry.boundary;
             if b.len() < 3 {
                 continue;
             }
-            faces.push(WallFace {
+            faces.push(AdjFace {
                 ri,
                 fi,
                 c: center(b),
@@ -68,6 +69,9 @@ pub fn solve_adjacency(rooms: &mut [Room]) -> usize {
         if used[i] {
             continue;
         }
+        // Pick the BEST (closest) valid partner, not just the first — multiple anti-parallel
+        // same-area faces can fall inside MAX_GAP and first-match could pair the wrong rooms.
+        let mut best: Option<(f64, usize)> = None;
         for j in (i + 1)..faces.len() {
             if used[j] {
                 continue;
@@ -76,24 +80,29 @@ pub fn solve_adjacency(rooms: &mut [Room]) -> usize {
             if a.ri == b.ri || dot(a.n, b.n) > -0.95 {
                 continue; // same room, or not anti-parallel
             }
-            // Plane separation along a's normal.
-            if dot(sub(a.c, b.c), a.n).abs() > MAX_GAP {
+            let gap = dot(sub(a.c, b.c), a.n).abs();
+            if gap > MAX_GAP {
                 continue;
             }
             // b's centroid projected onto a's plane must sit on top of a's centroid.
             let off = dot(sub(b.c, a.c), a.n);
             let b_proj = [b.c[0] - a.n[0] * off, b.c[1] - a.n[1] * off, b.c[2] - a.n[2] * off];
-            if dist(a.c, b_proj) > MAX_LATERAL {
+            let lateral = dist(a.c, b_proj);
+            if lateral > MAX_LATERAL {
                 continue;
             }
-            // Full-wall match only (near-equal area → Honeybee's matching-areas check passes).
+            // Full-face match only (near-equal area → Honeybee's matching-areas check passes).
             if (a.area - b.area).abs() / a.area.max(b.area).max(1e-9) > MAX_AREA_DIFF {
                 continue;
             }
+            if best.map_or(true, |(bg, _)| gap < bg) {
+                best = Some((gap, j));
+            }
+        }
+        if let Some((_, j)) = best {
             pairs.push((i, j));
             used[i] = true;
             used[j] = true;
-            break;
         }
     }
 

--- a/rust/export/src/constructions.rs
+++ b/rust/export/src/constructions.rs
@@ -88,7 +88,10 @@ fn build_one(
     constructions: &mut Vec<OpaqueConstruction>,
     seen_mat: &mut HashSet<String>,
 ) -> Option<String> {
-    let (_, layers) = bucket.values().max_by_key(|(count, _)| *count)?;
+    // Most common build-up; tie-break by signature so the choice is deterministic across runs.
+    let (_, (_, layers)) = bucket
+        .iter()
+        .max_by(|x, y| x.1 .0.cmp(&y.1 .0).then_with(|| x.0.cmp(y.0)))?;
     if layers.is_empty() {
         return None;
     }

--- a/rust/export/src/openings.rs
+++ b/rust/export/src/openings.rs
@@ -127,8 +127,13 @@ pub fn attach_openings(profiles: &[ExtractedProfile], rooms: &mut [Room], origin
     }
 
     let walls = collect_exterior_walls(rooms);
+    // Stable id order — HashMap iteration is randomized, which would make the aperture/door
+    // order (and thus the HBJSON bytes) vary between runs.
+    let mut ids: Vec<u32> = by.keys().copied().collect();
+    ids.sort_unstable();
     let mut pending: Vec<(usize, usize, Pending)> = Vec::new();
-    for (id, (is_window, ps)) in &by {
+    for id in &ids {
+        let (is_window, ps) = &by[id];
         let pts = occurrence_points(ps, origin);
         if let Some((ri, fi, geo)) = project(&pts, &walls) {
             pending.push((ri, fi, if *is_window { Pending::Window(*id, geo) } else { Pending::Door(*id, geo) }));

--- a/rust/export/src/rooms.rs
+++ b/rust/export/src/rooms.rs
@@ -148,19 +148,42 @@ fn is_simple_polygon(ring: &[[f64; 3]], tol: f64) -> bool {
                 return false;
             }
         }
-        // Reject edge crossings.
+        // Reject edge crossings AND collinear partial overlaps (a polygon that doubles back
+        // along an edge is topologically watertight but geometrically self-overlapping).
         let a1 = p[i];
         let a2 = p[(i + 1) % m];
         for j in (i + 1)..m {
             if (j + 1) % m == i || (i + 1) % m == j {
                 continue;
             }
-            if segments_cross(a1, a2, p[j], p[(j + 1) % m]) {
+            let (b1, b2) = (p[j], p[(j + 1) % m]);
+            if segments_cross(a1, a2, b1, b2) || collinear_overlap(a1, a2, b1, b2, tol) {
                 return false;
             }
         }
     }
     true
+}
+
+/// True when edges `a1a2` and `b1b2` are collinear (within `tol`) and overlap by more than
+/// `tol` along their shared line — i.e. the polygon doubles back over itself.
+fn collinear_overlap(a1: (f64, f64), a2: (f64, f64), b1: (f64, f64), b2: (f64, f64), tol: f64) -> bool {
+    let dx = a2.0 - a1.0;
+    let dy = a2.1 - a1.1;
+    let len = (dx * dx + dy * dy).sqrt();
+    if len < 1e-9 {
+        return false;
+    }
+    let dev = tol * len; // |orient2d| ≤ dev ⇔ point within `tol` of the line a1a2
+    if orient2d(a1, a2, b1).abs() > dev || orient2d(a1, a2, b2).abs() > dev {
+        return false;
+    }
+    let t = |p: (f64, f64)| ((p.0 - a1.0) * dx + (p.1 - a1.1) * dy) / (len * len);
+    let (tb1, tb2) = (t(b1), t(b2));
+    let (blo, bhi) = if tb1 <= tb2 { (tb1, tb2) } else { (tb2, tb1) };
+    let lo = 0.0_f64.max(blo);
+    let hi = 1.0_f64.min(bhi);
+    (hi - lo) * len > tol
 }
 
 /// True when the faces form a closed 2-manifold: every undirected edge (vertices snapped

--- a/rust/export/src/shades.rs
+++ b/rust/export/src/shades.rs
@@ -22,8 +22,14 @@ pub fn build_shades(profiles: &[ExtractedProfile], origin: [f64; 3]) -> Vec<Shad
         }
     }
 
+    // Emit in a stable id order — HashMap iteration is randomized, which would make the
+    // exported HBJSON byte-unstable across runs (breaks caching / diffing).
+    let mut ids: Vec<u32> = by.keys().copied().collect();
+    ids.sort_unstable();
+
     let mut shades = Vec::new();
-    for (id, ps) in &by {
+    for id in &ids {
+        let ps = &by[id];
         let mut verts: Vec<[f64; 3]> = Vec::new();
         let mut faces: Vec<[usize; 3]> = Vec::new();
         for p in ps {


### PR DESCRIPTION
Follow-up to #1235 (merged). These are the CodeRabbit review findings that were pushed just after the squash-merge point, so they didn't make it into main — bringing them forward cleanly.

## Fixes (all in the `ifc-lite-export` crate)

- **Interior adjacency — stacked rooms.** `solve_adjacency` only paired wall faces, so a room stacked above another kept `Ground`/`Outdoors` boundary conditions instead of reciprocal interior `Surface` BCs. Now every planar face is a candidate — anti-parallel normals naturally pick wall↔wall (side-by-side) and floor↔roof (stacked) pairs; same-storey floors and exterior faces never match.
- **Adjacency — best candidate.** Pick the closest valid partner instead of the first inside the gap/lateral/area thresholds.
- **Determinism (byte-stable HBJSON).** Sort ids before emitting shade meshes and apertures/doors (HashMap iteration is randomized); deterministically tie-break the representative construction build-up (`max_by_key` over `HashMap::values()` was unstable on ties).
- **Robustness — collinear overlaps.** `is_simple_polygon` only caught strict crossings; a footprint doubling back along an edge is topologically watertight but geometrically self-overlapping — now rejected.

## Verification
- `cargo test -p ifc-lite-export` green.
- honeybee: duplex `check_all` PASS; rvt01 gains 2 interior faces from stacked floor/roof pairing, only source-data room overlaps remain.