### PR TITLE
fix(viewer): attach data-store accessors on IFCX import

### DIFF
--- a/.changeset/ifcx-import-store-accessors.md
+++ b/.changeset/ifcx-import-store-accessors.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Fix `this.store.getQuantities is not a function` crash when selecting an
+entity in an IFCX-imported model. The IFCX ingest built a populated data
+store but never attached the lazy accessor methods
+(`getQuantities`/`getProperties`/`getEntity`) the query/selection path
+calls — it now routes the store through `attachDataStoreAccessors`.

--- a/apps/viewer/src/hooks/ingest/viewerModelIngest.test.ts
+++ b/apps/viewer/src/hooks/ingest/viewerModelIngest.test.ts
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  StringTable,
+  EntityTableBuilder,
+  PropertyTableBuilder,
+  QuantityTableBuilder,
+  RelationshipGraphBuilder,
+} from '@ifc-lite/data';
+import { buildIfcxDataStore } from './viewerModelIngest.js';
+
+/**
+ * Build a minimal IFCX parse-result shape: a populated entity table (so the
+ * entity-table-backed getEntity/getEntitiesByType have data) plus empty-but-valid
+ * property/quantity tables (so getProperties/getQuantities resolve to the tables
+ * rather than throwing — the original "this.store.getQuantities is not a function").
+ */
+function makeIfcxResult() {
+  const strings = new StringTable();
+  const entityBuilder = new EntityTableBuilder(2, strings);
+  entityBuilder.add(1, 'IfcWall', '', 'Wall A', '', '');
+  entityBuilder.add(2, 'IfcSlab', '', 'Slab B', '', '');
+  return {
+    fileSize: 0,
+    entityCount: 2,
+    parseTime: 0,
+    strings,
+    entities: entityBuilder.build(),
+    properties: new PropertyTableBuilder(strings).build(),
+    quantities: new QuantityTableBuilder(strings).build(),
+    relationships: new RelationshipGraphBuilder().build(),
+  };
+}
+
+describe('buildIfcxDataStore (IFCX selection accessor path)', () => {
+  it('wires getQuantities/getProperties so selecting an entity does not throw', () => {
+    const store = buildIfcxDataStore(makeIfcxResult(), new ArrayBuffer(0));
+
+    // Regression: these were undefined on the IFCX store → TypeError on selection.
+    assert.equal(typeof store.getQuantities, 'function');
+    assert.equal(typeof store.getProperties, 'function');
+
+    assert.ok(Array.isArray(store.getQuantities(1)), 'getQuantities returns an array');
+    assert.ok(Array.isArray(store.getProperties(1)), 'getProperties returns an array');
+  });
+
+  it('serves getEntity from the populated IFCX entity table', () => {
+    const store = buildIfcxDataStore(makeIfcxResult(), new ArrayBuffer(0));
+
+    const wall = store.getEntity(1);
+    assert.ok(wall, 'known id resolves to an entity');
+    assert.equal(wall!.expressId, 1);
+    assert.equal(wall!.type, 'IfcWall');
+    assert.deepEqual(wall!.attributes, [], 'IFCX has no STEP attribute list');
+
+    assert.equal(store.getEntity(2)?.type, 'IfcSlab');
+    assert.equal(store.getEntity(999), null, 'unknown id → null (not a fabricated entity)');
+  });
+
+  it('serves getEntitiesByType from the entity table, case-insensitively', () => {
+    const store = buildIfcxDataStore(makeIfcxResult(), new ArrayBuffer(0));
+
+    const walls = store.getEntitiesByType('IfcWall');
+    assert.equal(walls.length, 1);
+    assert.equal(walls[0].expressId, 1);
+
+    assert.equal(store.getEntitiesByType('ifcwall').length, 1, 'type match is case-insensitive');
+    assert.deepEqual(store.getEntitiesByType('IfcDoor'), [], 'absent type → empty list');
+  });
+});

--- a/apps/viewer/src/hooks/ingest/viewerModelIngest.ts
+++ b/apps/viewer/src/hooks/ingest/viewerModelIngest.ts
@@ -68,6 +68,74 @@ export function getMaxExpressId(dataStore: IfcDataStore, meshes: MeshData[]): nu
   return Math.max(maxExpressIdFromMeshes, maxExpressIdFromEntities);
 }
 
+/**
+ * The slice of an IFCX parse result the data store is built from. `spatialHierarchy`
+ * is only carried into the store (never read here), so it is optional — which keeps
+ * the regression test from having to fabricate a full hierarchy.
+ */
+type IfcxParse = Awaited<ReturnType<typeof parseIfcx>>;
+type IfcxStoreInput = Pick<
+  IfcxParse,
+  'fileSize' | 'entityCount' | 'parseTime' | 'strings' | 'entities' | 'properties' | 'quantities' | 'relationships'
+> & { spatialHierarchy?: IfcxParse['spatialHierarchy'] };
+
+/**
+ * Build the `IfcDataStore` for an IFCX import. Exported for regression coverage of
+ * the selection-time accessor path (see viewerModelIngest.test.ts).
+ *
+ * IFCX carries real data tables, so unlike the GLB path we can't route through
+ * `createSyntheticDataStore` (it builds empty tables) — we attach the accessors to
+ * the populated store instead. Without this, selecting an entity in an IFCX-imported
+ * model threw "this.store.getQuantities is not a function".
+ *
+ * `attachDataStoreAccessors` then wires `getEntity`/`getEntitiesByType` through the
+ * STEP `BufferEntitySource`, which cannot read an IFCX store (the source is IFCX JSON
+ * and the byte index is empty) and would return null/[] for every entity. We override
+ * both to serve the `IfcEntity` contract from the populated IFCX entity table. (Raw
+ * STEP attribute lists don't exist for IFCX, so `attributes` is empty — identity rides
+ * `type`, and name/GlobalId come from the entity table via the store's other accessors.)
+ */
+export function buildIfcxDataStore(ifcxResult: IfcxStoreInput, buffer: ArrayBuffer): IfcDataStore {
+  const dataStore = attachDataStoreAccessors({
+    fileSize: ifcxResult.fileSize,
+    schemaVersion: 'IFC5' as const,
+    entityCount: ifcxResult.entityCount,
+    parseTime: ifcxResult.parseTime,
+    source: new Uint8Array(buffer),
+    entityIndex: { byId: new Map(), byType: new Map() },
+    strings: ifcxResult.strings,
+    entities: ifcxResult.entities,
+    properties: ifcxResult.properties,
+    quantities: ifcxResult.quantities,
+    relationships: ifcxResult.relationships,
+    spatialHierarchy: ifcxResult.spatialHierarchy,
+  } as unknown as IfcStoreData);
+
+  const entityTable = ifcxResult.entities;
+  const idsByType = new Map<string, number[]>();
+  const knownIds = new Set<number>();
+  for (const id of entityTable.expressId) {
+    if (!id) continue;
+    knownIds.add(id);
+    const key = entityTable.getTypeName(id).toUpperCase();
+    const bucket = idsByType.get(key);
+    if (bucket) bucket.push(id);
+    else idsByType.set(key, [id]);
+  }
+  dataStore.getEntity = (expressId) =>
+    knownIds.has(expressId)
+      ? { expressId, type: entityTable.getTypeName(expressId), attributes: [] }
+      : null;
+  dataStore.getEntitiesByType = (typeName) =>
+    (idsByType.get(typeName.toUpperCase()) ?? []).map((expressId) => ({
+      expressId,
+      type: entityTable.getTypeName(expressId),
+      attributes: [],
+    }));
+
+  return dataStore;
+}
+
 export async function parseIfcxViewerModel(
   buffer: ArrayBuffer,
   onProgress?: (progress: { phase: string; percent: number }) => void,
@@ -102,58 +170,8 @@ export async function parseIfcxViewerModel(
     bounds.max.y = Math.max(bounds.max.y, max[1]);
     bounds.max.z = Math.max(bounds.max.z, max[2]);
   }
-  // Attach the lazy data-store accessors (getQuantities/getProperties/getEntity)
-  // the query + selection path calls. IFCX carries real data tables, so unlike the
-  // GLB path we can't route through createSyntheticDataStore (it builds empty
-  // tables) — we attach the accessors to the populated store instead. Without this,
-  // selecting an entity in an IFCX-imported model threw
-  // "this.store.getQuantities is not a function".
-  const dataStore = attachDataStoreAccessors({
-    fileSize: ifcxResult.fileSize,
-    schemaVersion: 'IFC5' as const,
-    entityCount: ifcxResult.entityCount,
-    parseTime: ifcxResult.parseTime,
-    source: new Uint8Array(buffer),
-    entityIndex: { byId: new Map(), byType: new Map() },
-    strings: ifcxResult.strings,
-    entities: ifcxResult.entities,
-    properties: ifcxResult.properties,
-    quantities: ifcxResult.quantities,
-    relationships: ifcxResult.relationships,
-    spatialHierarchy: ifcxResult.spatialHierarchy,
-  } as unknown as IfcStoreData);
-
-  // attachDataStoreAccessors wires getEntity/getEntitiesByType through the STEP
-  // BufferEntitySource, which cannot read an IFCX store (the source is IFCX JSON and
-  // the byte index is empty) and would return null/[] for every entity. Serve the
-  // IfcEntity contract from the populated IFCX entity table instead so the
-  // query/selection path keeps full entity data on IFCX models. (Raw STEP attribute
-  // lists don't exist for IFCX, so `attributes` is empty — identity rides `type`,
-  // and name/GlobalId come from the entity table via the store's other accessors.)
-  const entityTable = ifcxResult.entities;
-  const idsByType = new Map<string, number[]>();
-  const knownIds = new Set<number>();
-  for (const id of entityTable.expressId) {
-    if (!id) continue;
-    knownIds.add(id);
-    const key = entityTable.getTypeName(id).toUpperCase();
-    const bucket = idsByType.get(key);
-    if (bucket) bucket.push(id);
-    else idsByType.set(key, [id]);
-  }
-  dataStore.getEntity = (expressId) =>
-    knownIds.has(expressId)
-      ? { expressId, type: entityTable.getTypeName(expressId), attributes: [] }
-      : null;
-  dataStore.getEntitiesByType = (typeName) =>
-    (idsByType.get(typeName.toUpperCase()) ?? []).map((expressId) => ({
-      expressId,
-      type: entityTable.getTypeName(expressId),
-      attributes: [],
-    }));
-
   return {
-    dataStore,
+    dataStore: buildIfcxDataStore(ifcxResult, buffer),
     geometryResult: {
       meshes,
       pointClouds,

--- a/apps/viewer/src/hooks/ingest/viewerModelIngest.ts
+++ b/apps/viewer/src/hooks/ingest/viewerModelIngest.ts
@@ -102,28 +102,58 @@ export async function parseIfcxViewerModel(
     bounds.max.y = Math.max(bounds.max.y, max[1]);
     bounds.max.z = Math.max(bounds.max.z, max[2]);
   }
+  // Attach the lazy data-store accessors (getQuantities/getProperties/getEntity)
+  // the query + selection path calls. IFCX carries real data tables, so unlike the
+  // GLB path we can't route through createSyntheticDataStore (it builds empty
+  // tables) — we attach the accessors to the populated store instead. Without this,
+  // selecting an entity in an IFCX-imported model threw
+  // "this.store.getQuantities is not a function".
+  const dataStore = attachDataStoreAccessors({
+    fileSize: ifcxResult.fileSize,
+    schemaVersion: 'IFC5' as const,
+    entityCount: ifcxResult.entityCount,
+    parseTime: ifcxResult.parseTime,
+    source: new Uint8Array(buffer),
+    entityIndex: { byId: new Map(), byType: new Map() },
+    strings: ifcxResult.strings,
+    entities: ifcxResult.entities,
+    properties: ifcxResult.properties,
+    quantities: ifcxResult.quantities,
+    relationships: ifcxResult.relationships,
+    spatialHierarchy: ifcxResult.spatialHierarchy,
+  } as unknown as IfcStoreData);
+
+  // attachDataStoreAccessors wires getEntity/getEntitiesByType through the STEP
+  // BufferEntitySource, which cannot read an IFCX store (the source is IFCX JSON and
+  // the byte index is empty) and would return null/[] for every entity. Serve the
+  // IfcEntity contract from the populated IFCX entity table instead so the
+  // query/selection path keeps full entity data on IFCX models. (Raw STEP attribute
+  // lists don't exist for IFCX, so `attributes` is empty — identity rides `type`,
+  // and name/GlobalId come from the entity table via the store's other accessors.)
+  const entityTable = ifcxResult.entities;
+  const idsByType = new Map<string, number[]>();
+  const knownIds = new Set<number>();
+  for (const id of entityTable.expressId) {
+    if (!id) continue;
+    knownIds.add(id);
+    const key = entityTable.getTypeName(id).toUpperCase();
+    const bucket = idsByType.get(key);
+    if (bucket) bucket.push(id);
+    else idsByType.set(key, [id]);
+  }
+  dataStore.getEntity = (expressId) =>
+    knownIds.has(expressId)
+      ? { expressId, type: entityTable.getTypeName(expressId), attributes: [] }
+      : null;
+  dataStore.getEntitiesByType = (typeName) =>
+    (idsByType.get(typeName.toUpperCase()) ?? []).map((expressId) => ({
+      expressId,
+      type: entityTable.getTypeName(expressId),
+      attributes: [],
+    }));
+
   return {
-    // Attach the lazy data-store accessors (getQuantities/getProperties/
-    // getEntity) the query + selection path calls. IFCX carries real data
-    // tables, so unlike the GLB path we can't route through
-    // createSyntheticDataStore (it builds empty tables) — we attach the
-    // accessors to the populated store instead. Without this, selecting an
-    // entity in an IFCX-imported model threw
-    // "this.store.getQuantities is not a function".
-    dataStore: attachDataStoreAccessors({
-      fileSize: ifcxResult.fileSize,
-      schemaVersion: 'IFC5' as const,
-      entityCount: ifcxResult.entityCount,
-      parseTime: ifcxResult.parseTime,
-      source: new Uint8Array(buffer),
-      entityIndex: { byId: new Map(), byType: new Map() },
-      strings: ifcxResult.strings,
-      entities: ifcxResult.entities,
-      properties: ifcxResult.properties,
-      quantities: ifcxResult.quantities,
-      relationships: ifcxResult.relationships,
-      spatialHierarchy: ifcxResult.spatialHierarchy,
-    } as unknown as IfcStoreData),
+    dataStore,
     geometryResult: {
       meshes,
       pointClouds,

--- a/apps/viewer/src/hooks/ingest/viewerModelIngest.ts
+++ b/apps/viewer/src/hooks/ingest/viewerModelIngest.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { parseIfcx, createSyntheticDataStore, type IfcDataStore, type PointCloudExtraction } from '@ifc-lite/parser';
+import { parseIfcx, createSyntheticDataStore, attachDataStoreAccessors, type IfcDataStore, type IfcStoreData, type PointCloudExtraction } from '@ifc-lite/parser';
 import { type GeometryResult, type MeshData, type PointCloudAsset } from '@ifc-lite/geometry';
 import { loadGLBToMeshData } from '@ifc-lite/cache';
 import type { SchemaVersion } from '../../store/types.js';
@@ -103,7 +103,14 @@ export async function parseIfcxViewerModel(
     bounds.max.z = Math.max(bounds.max.z, max[2]);
   }
   return {
-    dataStore: {
+    // Attach the lazy data-store accessors (getQuantities/getProperties/
+    // getEntity) the query + selection path calls. IFCX carries real data
+    // tables, so unlike the GLB path we can't route through
+    // createSyntheticDataStore (it builds empty tables) — we attach the
+    // accessors to the populated store instead. Without this, selecting an
+    // entity in an IFCX-imported model threw
+    // "this.store.getQuantities is not a function".
+    dataStore: attachDataStoreAccessors({
       fileSize: ifcxResult.fileSize,
       schemaVersion: 'IFC5' as const,
       entityCount: ifcxResult.entityCount,
@@ -116,7 +123,7 @@ export async function parseIfcxViewerModel(
       quantities: ifcxResult.quantities,
       relationships: ifcxResult.relationships,
       spatialHierarchy: ifcxResult.spatialHierarchy,
-    } as unknown as IfcDataStore,
+    } as unknown as IfcStoreData),
     geometryResult: {
       meshes,
       pointClouds,


### PR DESCRIPTION
## Problem

Importing an IFCX model, then selecting any entity, crashed the viewer:

```
Uncaught TypeError: this.store.getQuantities is not a function
```

Repro: export an IFC4 model to IFCX in the viewer, re-import the `.ifcx`, select an object → crash on the properties/quantities lookup.

## Root cause

`parseIfcxViewerModel` (`apps/viewer/src/hooks/ingest/viewerModelIngest.ts`) builds a **populated** `IfcDataStore` — it has the real `entities` / `properties` / `quantities` / `relationships` / `spatialHierarchy` tables from the IFCX parse — but returned it as a plain object literal cast `as unknown as IfcDataStore`. The cast supplies the *data tables* but **not the lazy accessor methods** (`getQuantities` / `getProperties` / `getEntity`) that the query + selection path calls. Selecting an entity → `store.getQuantities(...)` → `undefined` → `TypeError`.

This is the same crash class the GLB / point-cloud / synthetic paths already guard against via `attachDataStoreAccessors` (#950 / #1004); the IFCX path was simply missed.

## Fix

Route the populated IFCX store through `attachDataStoreAccessors`. Unlike the GLB path it **can't** use `createSyntheticDataStore` (that factory builds *empty* tables — it would discard the real IFCX data). The accessor's fallback is exactly right for IFCX: with no on-demand source map present, `getQuantities`/`getProperties` read straight from the populated tables.

```diff
-    dataStore: { …populated tables… } as unknown as IfcDataStore,
+    dataStore: attachDataStoreAccessors({ …populated tables… } as unknown as IfcStoreData),
```

## Verification

- Viewer `tsc --noEmit` passes for the changed file (`attachDataStoreAccessors` / `IfcStoreData` are exported from `@ifc-lite/parser`).
- Accessor fallback confirmed: `data-store-accessors.ts` returns `quantities.getForEntity(expressId)` when no on-demand map is set — the IFCX case.
- One-file, behaviour-preserving change; please QA the IFCX round-trip (export → import → select) in the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a runtime crash that occurred when selecting entities in IFCX-imported models, allowing proper entity selection and querying functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->