### PR TITLE
feat(export): move KMZ export to Rust (Phase 3); keep BCF + 2D-SVG in TS

### DIFF
--- a/.changeset/rust-kmz-export.md
+++ b/.changeset/rust-kmz-export.md
@@ -1,0 +1,13 @@
+---
+"@ifc-lite/wasm": minor
+"@ifc-lite/geometry": minor
+"@ifc-lite/viewer": patch
+---
+
+Move the KMZ (Google Earth) exporter to Rust. The `ifc-lite-export` crate now
+assembles the KMZ archive (`doc.kml` + `model.glb`) and computes the IFC
+grid-north → KML heading, exposed via the wasm `exportKmz` binding and
+`GeometryProcessor.exportKmz`. The viewer's `buildKmz` is now a thin async caller
+(matching the OBJ/glTF/CSV pattern); the GLB it packages is already produced by the
+Rust GLB exporter. The archive uses a hand-rolled stored-ZIP writer so the wasm
+bundle pulls in no zip/deflate dependency.

--- a/apps/viewer/src/components/viewer/properties/LocationMap.tsx
+++ b/apps/viewer/src/components/viewer/properties/LocationMap.tsx
@@ -24,7 +24,7 @@ import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
 import type { CoordinateInfo, GeometryResult } from '@ifc-lite/geometry';
 import { exportGlbFromGeometry } from '@/lib/export/glb';
 import { reprojectToLatLon, reprojectFromLatLon, queryTerrainElevation, computeFootprintGeoJSON, type LatLon } from '@/lib/geo/reproject';
-import { buildKmz, ifcAngleToKmlHeading } from '@/lib/geo/kmz-exporter';
+import { buildKmz } from '@/lib/geo/kmz-exporter';
 
 // Lazy-load maplibre-gl to avoid bloating the initial bundle
 let maplibrePromise: Promise<typeof import('maplibre-gl')> | null = null;
@@ -453,11 +453,11 @@ export function LocationMap({
     if (!latLon || !geometryResult || !mapConversion) return;
     try {
       const glb = await exportGlbFromGeometry(geometryResult, { includeMetadata: true });
-      const heading = ifcAngleToKmlHeading(mapConversion.xAxisAbscissa, mapConversion.xAxisOrdinate);
-      const kmz = buildKmz({
+      const kmz = await buildKmz({
         latLon,
         altitude: mapConversion.orthogonalHeight,
-        heading,
+        xAxisAbscissa: mapConversion.xAxisAbscissa,
+        xAxisOrdinate: mapConversion.xAxisOrdinate,
         glb,
         name: 'IFC Model',
       });

--- a/apps/viewer/src/lib/geo/kmz-exporter.test.ts
+++ b/apps/viewer/src/lib/geo/kmz-exporter.test.ts
@@ -89,4 +89,25 @@ describe('buildKmz', () => {
     );
     assert.equal(calls.dispose, 1, 'dispose runs in finally even on failure');
   });
+
+  it('disposes even when init() throws (init is inside the try)', async () => {
+    let disposed = 0;
+    const gp: KmzProcessor = {
+      async init() {
+        throw new Error('wasm init failed');
+      },
+      exportKmz() {
+        throw new Error('should not reach exportKmz');
+      },
+      dispose() {
+        disposed++;
+      },
+    };
+
+    await assert.rejects(
+      () => buildKmz({ latLon: { lat: 0, lon: 0 }, altitude: 0, glb: GLB }, () => gp),
+      /wasm init failed/,
+    );
+    assert.equal(disposed, 1, 'dispose runs in finally when init throws');
+  });
 });

--- a/apps/viewer/src/lib/geo/kmz-exporter.test.ts
+++ b/apps/viewer/src/lib/geo/kmz-exporter.test.ts
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { buildKmz, type KmzProcessor } from './kmz-exporter.js';
+
+/** A stub `GeometryProcessor` slice that records how the helper drove it. */
+function makeStub(result: Uint8Array | null | (() => never)) {
+  const calls = {
+    init: 0,
+    dispose: 0,
+    args: [] as Array<{
+      glb: Uint8Array;
+      latitude: number;
+      longitude: number;
+      altitude: number;
+      xAxisAbscissa: number | undefined;
+      xAxisOrdinate: number | undefined;
+      name: string;
+    }>,
+  };
+  const gp: KmzProcessor = {
+    async init() {
+      calls.init++;
+    },
+    exportKmz(glb, latitude, longitude, altitude, xAxisAbscissa, xAxisOrdinate, name = 'IFC Model') {
+      calls.args.push({ glb, latitude, longitude, altitude, xAxisAbscissa, xAxisOrdinate, name });
+      if (typeof result === 'function') result();
+      return result as Uint8Array | null;
+    },
+    dispose() {
+      calls.dispose++;
+    },
+  };
+  return { gp, calls };
+}
+
+const GLB = new Uint8Array([0x67, 0x6c, 0x54, 0x46]); // "glTF"
+
+describe('buildKmz', () => {
+  it('forwards lat/lon/alt/axes/name to the Rust exporter and returns the bytes', async () => {
+    const kmz = new Uint8Array([0x50, 0x4b, 0x03, 0x04]); // "PK\x03\x04"
+    const { gp, calls } = makeStub(kmz);
+
+    const out = await buildKmz(
+      {
+        latLon: { lat: 47.5, lon: 8.5 },
+        altitude: 412,
+        xAxisAbscissa: 1,
+        xAxisOrdinate: 0,
+        glb: GLB,
+        name: 'Bldg A',
+      },
+      () => gp,
+    );
+
+    assert.deepEqual(out, kmz);
+    assert.equal(calls.init, 1);
+    assert.equal(calls.dispose, 1);
+    assert.deepEqual(calls.args[0], {
+      glb: GLB,
+      latitude: 47.5,
+      longitude: 8.5,
+      altitude: 412,
+      xAxisAbscissa: 1,
+      xAxisOrdinate: 0,
+      name: 'Bldg A',
+    });
+  });
+
+  it('defaults the name and passes undefined axes through (heading 0 in Rust)', async () => {
+    const { gp, calls } = makeStub(new Uint8Array([1]));
+
+    await buildKmz({ latLon: { lat: 0, lon: 0 }, altitude: 0, glb: GLB }, () => gp);
+
+    assert.equal(calls.args[0].name, 'IFC Model');
+    assert.equal(calls.args[0].xAxisAbscissa, undefined);
+    assert.equal(calls.args[0].xAxisOrdinate, undefined);
+  });
+
+  it('throws when the exporter returns no data, still disposing', async () => {
+    const { gp, calls } = makeStub(null);
+
+    await assert.rejects(
+      () => buildKmz({ latLon: { lat: 0, lon: 0 }, altitude: 0, glb: GLB }, () => gp),
+      /KMZ export returned no data/,
+    );
+    assert.equal(calls.dispose, 1, 'dispose runs in finally even on failure');
+  });
+});

--- a/apps/viewer/src/lib/geo/kmz-exporter.ts
+++ b/apps/viewer/src/lib/geo/kmz-exporter.ts
@@ -3,21 +3,19 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * KMZ Exporter — packages a GLB model with a KML file into a KMZ archive
- * so Google Earth can display the 3D model at its correct geolocation.
+ * KMZ Exporter — packages a GLB model + georeference into a KMZ archive so Google
+ * Earth can display the 3D model at its correct geolocation.
  *
- * KMZ is just a ZIP archive containing:
- *   doc.kml   — KML document with a <Model> positioned at lat/lon/alt
+ * KMZ is a ZIP archive containing:
+ *   doc.kml   — KML document with a <Model> positioned at lat/lon/alt + heading
  *   model.glb — the 3D model in glTF binary format
  *
- * The KML <Model> element uses:
- *   <Location>    — latitude, longitude, altitude from reprojected georef
- *   <Orientation> — heading derived from the angle-to-grid-north
- *   <Scale>       — uniform scale (1:1)
- *   <Link>        — relative path to the GLB inside the archive
+ * The KML assembly, the IFC grid-north → KML heading conversion, and the zip are all
+ * done in Rust (`ifc-lite-export`, via `GeometryProcessor.exportKmz`) — this is a thin
+ * async wrapper. The GLB is produced upstream by the Rust GLB exporter.
  */
 
-import { zipSync } from 'fflate';
+import { GeometryProcessor } from '@ifc-lite/geometry';
 import type { LatLon } from './reproject';
 
 export interface KmzOptions {
@@ -25,88 +23,42 @@ export interface KmzOptions {
   latLon: LatLon;
   /** Orthogonal height (elevation) in metres */
   altitude: number;
-  /** Heading in degrees clockwise from north (0 = north, 90 = east) */
-  heading: number;
+  /** `IfcMapConversion` X-axis grid-north components; omit for heading 0 (true north). */
+  xAxisAbscissa?: number;
+  xAxisOrdinate?: number;
   /** GLB model binary data */
   glb: Uint8Array;
   /** Display name for the placemark */
   name?: string;
 }
 
-/**
- * Convert the IFC angle-to-grid-north (counterclockwise from east) into
- * a KML heading (clockwise from north).
- *
- * IFC convention: atan2(XAxisOrdinate, XAxisAbscissa) gives the CCW angle
- * from the map east axis to the local X axis.
- *
- * KML convention: heading is CW from north (0=N, 90=E, 180=S, 270=W).
- */
-export function ifcAngleToKmlHeading(
-  xAxisAbscissa?: number,
-  xAxisOrdinate?: number,
-): number {
-  if (xAxisAbscissa === undefined || xAxisOrdinate === undefined) return 0;
-  const angleFromEastCcw = Math.atan2(xAxisOrdinate, xAxisAbscissa) * (180 / Math.PI);
-  // Convert: heading = 90 - angle (CCW from east → CW from north)
-  const heading = 90 - angleFromEastCcw;
-  // Normalize to [0, 360)
-  return ((heading % 360) + 360) % 360;
-}
-
-function buildKml(opts: KmzOptions): string {
-  const name = escapeXml(opts.name ?? 'IFC Model');
-  return `<?xml version="1.0" encoding="UTF-8"?>
-<kml xmlns="http://www.opengis.net/kml/2.2">
-  <Document>
-    <name>${name}</name>
-    <Placemark>
-      <name>${name}</name>
-      <Model id="model">
-        <altitudeMode>relativeToGround</altitudeMode>
-        <Location>
-          <longitude>${opts.latLon.lon}</longitude>
-          <latitude>${opts.latLon.lat}</latitude>
-          <altitude>${opts.altitude}</altitude>
-        </Location>
-        <Orientation>
-          <heading>${opts.heading}</heading>
-          <tilt>0</tilt>
-          <roll>0</roll>
-        </Orientation>
-        <Scale>
-          <x>1</x>
-          <y>1</y>
-          <z>1</z>
-        </Scale>
-        <Link>
-          <href>model.glb</href>
-        </Link>
-      </Model>
-    </Placemark>
-  </Document>
-</kml>`;
-}
-
-function escapeXml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&apos;');
-}
+/** The slice of `GeometryProcessor` this helper drives — a test seam (see kmz-exporter.test.ts). */
+export type KmzProcessor = Pick<GeometryProcessor, 'init' | 'exportKmz' | 'dispose'>;
 
 /**
- * Build a KMZ file (ZIP archive) containing doc.kml + model.glb.
- * Returns the KMZ as a Uint8Array ready for download.
+ * Build a KMZ archive (`doc.kml` + `model.glb`) via the Rust exporter.
+ *
+ * `createProcessor` defaults to the real wasm processor; tests inject a stub.
  */
-export function buildKmz(opts: KmzOptions): Uint8Array {
-  const kml = buildKml(opts);
-  const kmlBytes = new TextEncoder().encode(kml);
-
-  return zipSync({
-    'doc.kml': kmlBytes,
-    'model.glb': opts.glb,
-  });
+export async function buildKmz(
+  opts: KmzOptions,
+  createProcessor: () => KmzProcessor = () => new GeometryProcessor(),
+): Promise<Uint8Array> {
+  const gp = createProcessor();
+  await gp.init();
+  try {
+    const kmz = gp.exportKmz(
+      opts.glb,
+      opts.latLon.lat,
+      opts.latLon.lon,
+      opts.altitude,
+      opts.xAxisAbscissa,
+      opts.xAxisOrdinate,
+      opts.name ?? 'IFC Model',
+    );
+    if (kmz == null) throw new Error('KMZ export returned no data');
+    return kmz;
+  } finally {
+    gp.dispose();
+  }
 }

--- a/apps/viewer/src/lib/geo/kmz-exporter.ts
+++ b/apps/viewer/src/lib/geo/kmz-exporter.ts
@@ -45,8 +45,8 @@ export async function buildKmz(
   createProcessor: () => KmzProcessor = () => new GeometryProcessor(),
 ): Promise<Uint8Array> {
   const gp = createProcessor();
-  await gp.init();
   try {
+    await gp.init();
     const kmz = gp.exportKmz(
       opts.glb,
       opts.latLon.lat,

--- a/packages/geometry/src/ifc-lite-bridge.ts
+++ b/packages/geometry/src/ifc-lite-bridge.ts
@@ -443,6 +443,34 @@ export class IfcLiteBridge {
   }
 
   /**
+   * Package an already-produced GLB + georeference into a KMZ (`doc.kml` + `model.glb`
+   * zip) for Google Earth. `xAxisAbscissa`/`xAxisOrdinate` are the `IfcMapConversion`
+   * grid-north components (pass `undefined` for heading 0).
+   */
+  exportKmz(
+    glb: Uint8Array,
+    latitude: number,
+    longitude: number,
+    altitude: number,
+    xAxisAbscissa: number | undefined,
+    xAxisOrdinate: number | undefined,
+    name: string,
+  ): Uint8Array {
+    if (!this.ifcApi) {
+      throw new Error('IFC-Lite not initialized. Call init() first.');
+    }
+    try {
+      return this.ifcApi.exportKmz(glb, latitude, longitude, altitude, xAxisAbscissa, xAxisOrdinate, name);
+    } catch (error) {
+      log.error('Failed to exportKmz', error, { operation: 'exportKmz' });
+      if (this.isWasmRuntimeError(error)) {
+        this.markFatalWasmRuntimeError();
+      }
+      throw error;
+    }
+  }
+
+  /**
    * Export the `IfcSpace` volumes in `content` as a Honeybee HBJSON string
    * (Ladybug Tools energy/daylight model). Rooms are built analytically from
    * extruded-area profiles (watertight by construction).

--- a/packages/geometry/src/index.ts
+++ b/packages/geometry/src/index.ts
@@ -1161,6 +1161,24 @@ export class GeometryProcessor {
   }
 
   /**
+   * Package an already-produced GLB + georeference into a KMZ (Google Earth) archive.
+   * `xAxisAbscissa`/`xAxisOrdinate` are the `IfcMapConversion` grid-north components
+   * (pass `undefined` for heading 0). Returns null if not initialized.
+   */
+  exportKmz(
+    glb: Uint8Array,
+    latitude: number,
+    longitude: number,
+    altitude: number,
+    xAxisAbscissa: number | undefined,
+    xAxisOrdinate: number | undefined,
+    name = 'IFC Model',
+  ): Uint8Array | null {
+    if (!this.bridge?.isInitialized()) return null;
+    return this.bridge.exportKmz(glb, latitude, longitude, altitude, xAxisAbscissa, xAxisOrdinate, name);
+  }
+
+  /**
    * Export the `IfcSpace` volumes in `buffer` as a Honeybee HBJSON string
    * (Ladybug Tools energy/daylight model). Returns null if not initialized.
    * @param buffer IFC file buffer

--- a/packages/wasm/pkg/README.md
+++ b/packages/wasm/pkg/README.md
@@ -158,13 +158,20 @@ console.log(view.getMutations()); // change history for undo / export
 ## Export
 
 ```typescript
-import { exportToStep, GLTFExporter, ParquetExporter, Ifc5Exporter } from '@ifc-lite/export';
+import { exportToStep, ParquetExporter, Ifc5Exporter } from '@ifc-lite/export';
+import { GeometryProcessor } from '@ifc-lite/geometry';
 
 // IFC STEP — applies any pending mutations
 const stepText = exportToStep(store, { schema: 'IFC4', applyMutations: true });
 
-// glTF for the web
-const glb = await new GLTFExporter().export(parseResult, { format: 'glb' });
+// glTF / GLB, CSV and JSON-LD are assembled in Rust (ifc-lite-export) via the
+// GeometryProcessor — the standalone GLTFExporter/CSVExporter/JSONLDExporter
+// classes were retired.
+const gp = new GeometryProcessor();
+await gp.init();
+const glb = gp.exportGlbFromMeshes(result.meshes); // Uint8Array (no re-mesh)
+const csv = gp.exportCsv(buffer, 'entities', ',', /* includeProperties */ true);
+const jsonld = gp.exportJsonld(buffer);
 
 // Parquet — columnar, ~20× smaller than JSON, queryable from DuckDB / Polars
 const parquet = await new ParquetExporter().exportEntities(parseResult);

--- a/packages/wasm/pkg/README.md
+++ b/packages/wasm/pkg/README.md
@@ -158,20 +158,13 @@ console.log(view.getMutations()); // change history for undo / export
 ## Export
 
 ```typescript
-import { exportToStep, ParquetExporter, Ifc5Exporter } from '@ifc-lite/export';
-import { GeometryProcessor } from '@ifc-lite/geometry';
+import { exportToStep, GLTFExporter, ParquetExporter, Ifc5Exporter } from '@ifc-lite/export';
 
 // IFC STEP — applies any pending mutations
 const stepText = exportToStep(store, { schema: 'IFC4', applyMutations: true });
 
-// glTF / GLB, CSV and JSON-LD are assembled in Rust (ifc-lite-export) via the
-// GeometryProcessor — the standalone GLTFExporter/CSVExporter/JSONLDExporter
-// classes were retired.
-const gp = new GeometryProcessor();
-await gp.init();
-const glb = gp.exportGlbFromMeshes(result.meshes); // Uint8Array (no re-mesh)
-const csv = gp.exportCsv(buffer, 'entities', ',', /* includeProperties */ true);
-const jsonld = gp.exportJsonld(buffer);
+// glTF for the web
+const glb = await new GLTFExporter().export(parseResult, { format: 'glb' });
 
 // Parquet — columnar, ~20× smaller than JSON, queryable from DuckDB / Polars
 const parquet = await new ParquetExporter().exportEntities(parseResult);

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -92,6 +92,13 @@ export class IfcAPI {
    */
   exportGlb(content: string, include_metadata: boolean, hidden: Uint32Array, isolated: Uint32Array, hidden_types_csv: string): Uint8Array;
   /**
+   * Package an already-produced **GLB** + georeference into a **KMZ** (`Uint8Array`)
+   * for Google Earth: a ZIP of `doc.kml` (a `<Model>` placed at `latitude`/`longitude`/
+   * `altitude`) + `model.glb`. `x_axis_abscissa`/`x_axis_ordinate` are the
+   * `IfcMapConversion` grid-north components; pass both as `undefined` for heading 0.
+   */
+  exportKmz(glb: Uint8Array, latitude: number, longitude: number, altitude: number, x_axis_abscissa: number | null | undefined, x_axis_ordinate: number | null | undefined, name: string): Uint8Array;
+  /**
    * Assemble a **GLB** from already-produced meshes (the viewer's `MeshData`, flattened)
    * — no re-meshing. Per mesh `i`: `vertex_counts[i]` verts + `index_counts[i]` indices
    * taken in order from the concatenated `positions`/`normals`/`indices`; `colors` is
@@ -1011,6 +1018,7 @@ export interface InitOutput {
   readonly ifcapi_exportIfcx: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
   readonly ifcapi_exportJson: (a: number, b: number, c: number, d: number, e: number, f: number, g: number) => void;
   readonly ifcapi_exportJsonld: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number, k: number) => void;
+  readonly ifcapi_exportKmz: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number, k: number, l: number, m: number) => void;
   readonly ifcapi_exportMerged: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number) => void;
   readonly ifcapi_exportObj: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number) => void;
   readonly ifcapi_exportStep: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number) => void;

--- a/rust/export/src/kmz.rs
+++ b/rust/export/src/kmz.rs
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: MPL-2.0
+//! **KMZ** (Google Earth) exporter — a ZIP archive of `doc.kml` + `model.glb` so
+//! Google Earth can place a georeferenced 3D model at its real-world lat/lon/altitude.
+//!
+//! Ports `apps/viewer/src/lib/geo/kmz-exporter.ts`. The GLB is produced upstream by
+//! the Rust GLB exporter; this module computes the KML placement (incl. the IFC
+//! grid-north → KML heading conversion) and packs the archive.
+//!
+//! The archive uses the ZIP **stored** (uncompressed) method, written by hand so the
+//! default/wasm build pulls in no zip/deflate dependency (keeping the wasm bundle
+//! lean). KMZ readers accept stored entries; the trade-off is a larger file than a
+//! deflated archive, acceptable for this infrequent georef export.
+
+/// Options for KMZ export.
+pub struct KmzOptions {
+    /// WGS84 latitude of the model origin (degrees).
+    pub latitude: f64,
+    /// WGS84 longitude of the model origin (degrees).
+    pub longitude: f64,
+    /// Orthogonal height / elevation in metres.
+    pub altitude: f64,
+    /// `IfcMapConversion` `XAxisAbscissa` (grid-north X component). When either axis
+    /// component is absent the heading is `0` (local north == true north).
+    pub x_axis_abscissa: Option<f64>,
+    /// `IfcMapConversion` `XAxisOrdinate` (grid-north Y component).
+    pub x_axis_ordinate: Option<f64>,
+    /// Placemark display name (defaults to `IFC Model`).
+    pub name: Option<String>,
+}
+
+/// Convert the IFC angle-to-grid-north (counter-clockwise from map east, via the
+/// `IfcMapConversion` X-axis abscissa/ordinate) into a KML heading (clockwise from
+/// north: 0 = N, 90 = E, 180 = S, 270 = W). Returns `0` when either component is absent.
+pub fn ifc_angle_to_kml_heading(x_abscissa: Option<f64>, x_ordinate: Option<f64>) -> f64 {
+    match (x_abscissa, x_ordinate) {
+        (Some(x), Some(y)) => {
+            let angle_from_east_ccw = y.atan2(x).to_degrees();
+            // heading = 90 - angle (CCW-from-east → CW-from-north), normalized to [0, 360).
+            (90.0 - angle_from_east_ccw).rem_euclid(360.0)
+        }
+        _ => 0.0,
+    }
+}
+
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+fn build_kml(opts: &KmzOptions, heading: f64) -> String {
+    let name = xml_escape(opts.name.as_deref().unwrap_or("IFC Model"));
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Document>
+    <name>{name}</name>
+    <Placemark>
+      <name>{name}</name>
+      <Model id="model">
+        <altitudeMode>relativeToGround</altitudeMode>
+        <Location>
+          <longitude>{lon}</longitude>
+          <latitude>{lat}</latitude>
+          <altitude>{alt}</altitude>
+        </Location>
+        <Orientation>
+          <heading>{heading}</heading>
+          <tilt>0</tilt>
+          <roll>0</roll>
+        </Orientation>
+        <Scale>
+          <x>1</x>
+          <y>1</y>
+          <z>1</z>
+        </Scale>
+        <Link>
+          <href>model.glb</href>
+        </Link>
+      </Model>
+    </Placemark>
+  </Document>
+</kml>"#,
+        name = name,
+        lon = opts.longitude,
+        lat = opts.latitude,
+        alt = opts.altitude,
+        heading = heading,
+    )
+}
+
+/// Build a KMZ archive (`doc.kml` + `model.glb`) from a GLB byte slice + placement.
+pub fn export_kmz(glb: &[u8], opts: &KmzOptions) -> Vec<u8> {
+    let heading = ifc_angle_to_kml_heading(opts.x_axis_abscissa, opts.x_axis_ordinate);
+    let kml = build_kml(opts, heading);
+
+    let mut zip = StoredZip::new();
+    zip.add("doc.kml", kml.as_bytes());
+    zip.add("model.glb", glb);
+    zip.finish()
+}
+
+// ── Minimal stored-ZIP writer ──────────────────────────────────────────────────
+
+/// A bare-bones ZIP writer that stores entries uncompressed (method 0). Enough for
+/// KMZ; avoids a zip/deflate crate dependency in the default/wasm build.
+struct StoredZip {
+    out: Vec<u8>,
+    central: Vec<u8>,
+    count: u16,
+}
+
+// Fixed DOS timestamp (1980-01-01 00:00:00) so archives are byte-deterministic
+// (and because wall-clock time is unavailable on wasm).
+const DOS_TIME: u16 = 0;
+const DOS_DATE: u16 = 0x0021;
+
+impl StoredZip {
+    fn new() -> Self {
+        StoredZip { out: Vec::new(), central: Vec::new(), count: 0 }
+    }
+
+    fn add(&mut self, name: &str, data: &[u8]) {
+        let crc = crc32(data);
+        let offset = self.out.len() as u32;
+        let name_bytes = name.as_bytes();
+        let size = data.len() as u32;
+
+        // Local file header.
+        self.out.extend_from_slice(&0x0403_4b50u32.to_le_bytes());
+        self.out.extend_from_slice(&20u16.to_le_bytes()); // version needed
+        self.out.extend_from_slice(&0u16.to_le_bytes()); // flags
+        self.out.extend_from_slice(&0u16.to_le_bytes()); // method = stored
+        self.out.extend_from_slice(&DOS_TIME.to_le_bytes());
+        self.out.extend_from_slice(&DOS_DATE.to_le_bytes());
+        self.out.extend_from_slice(&crc.to_le_bytes());
+        self.out.extend_from_slice(&size.to_le_bytes()); // compressed size
+        self.out.extend_from_slice(&size.to_le_bytes()); // uncompressed size
+        self.out.extend_from_slice(&(name_bytes.len() as u16).to_le_bytes());
+        self.out.extend_from_slice(&0u16.to_le_bytes()); // extra length
+        self.out.extend_from_slice(name_bytes);
+        self.out.extend_from_slice(data);
+
+        // Central directory record.
+        self.central.extend_from_slice(&0x0201_4b50u32.to_le_bytes());
+        self.central.extend_from_slice(&20u16.to_le_bytes()); // version made by
+        self.central.extend_from_slice(&20u16.to_le_bytes()); // version needed
+        self.central.extend_from_slice(&0u16.to_le_bytes()); // flags
+        self.central.extend_from_slice(&0u16.to_le_bytes()); // method
+        self.central.extend_from_slice(&DOS_TIME.to_le_bytes());
+        self.central.extend_from_slice(&DOS_DATE.to_le_bytes());
+        self.central.extend_from_slice(&crc.to_le_bytes());
+        self.central.extend_from_slice(&size.to_le_bytes());
+        self.central.extend_from_slice(&size.to_le_bytes());
+        self.central.extend_from_slice(&(name_bytes.len() as u16).to_le_bytes());
+        self.central.extend_from_slice(&0u16.to_le_bytes()); // extra length
+        self.central.extend_from_slice(&0u16.to_le_bytes()); // comment length
+        self.central.extend_from_slice(&0u16.to_le_bytes()); // disk number start
+        self.central.extend_from_slice(&0u16.to_le_bytes()); // internal attrs
+        self.central.extend_from_slice(&0u32.to_le_bytes()); // external attrs
+        self.central.extend_from_slice(&offset.to_le_bytes());
+        self.central.extend_from_slice(name_bytes);
+
+        self.count += 1;
+    }
+
+    fn finish(mut self) -> Vec<u8> {
+        let cd_offset = self.out.len() as u32;
+        let cd_size = self.central.len() as u32;
+        self.out.extend_from_slice(&self.central);
+
+        // End of central directory record.
+        self.out.extend_from_slice(&0x0605_4b50u32.to_le_bytes());
+        self.out.extend_from_slice(&0u16.to_le_bytes()); // disk number
+        self.out.extend_from_slice(&0u16.to_le_bytes()); // cd start disk
+        self.out.extend_from_slice(&self.count.to_le_bytes()); // entries this disk
+        self.out.extend_from_slice(&self.count.to_le_bytes()); // total entries
+        self.out.extend_from_slice(&cd_size.to_le_bytes());
+        self.out.extend_from_slice(&cd_offset.to_le_bytes());
+        self.out.extend_from_slice(&0u16.to_le_bytes()); // comment length
+        self.out
+    }
+}
+
+/// CRC-32 (IEEE 802.3, polynomial 0xEDB88320) — the checksum ZIP entries require.
+fn crc32(data: &[u8]) -> u32 {
+    let mut crc = 0xFFFF_FFFFu32;
+    for &byte in data {
+        crc ^= byte as u32;
+        for _ in 0..8 {
+            let mask = (crc & 1).wrapping_neg();
+            crc = (crc >> 1) ^ (0xEDB8_8320 & mask);
+        }
+    }
+    !crc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn heading_matches_ifc_convention() {
+        // No axes → 0.
+        assert_eq!(ifc_angle_to_kml_heading(None, None), 0.0);
+        // X-axis along east (1,0): angle-from-east 0 → heading 90.
+        assert!((ifc_angle_to_kml_heading(Some(1.0), Some(0.0)) - 90.0).abs() < 1e-9);
+        // X-axis along north (0,1): angle-from-east 90 CCW → heading 0.
+        assert!((ifc_angle_to_kml_heading(Some(0.0), Some(1.0)) - 0.0).abs() < 1e-9);
+        // X-axis along west (-1,0): angle 180 → heading 90-180 = -90 → 270.
+        assert!((ifc_angle_to_kml_heading(Some(-1.0), Some(0.0)) - 270.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn kml_carries_placement() {
+        let opts = KmzOptions {
+            latitude: 47.5,
+            longitude: 8.5,
+            altitude: 412.0,
+            x_axis_abscissa: Some(1.0),
+            x_axis_ordinate: Some(0.0),
+            name: Some("Bldg <A>".to_string()),
+        };
+        let kml = build_kml(&opts, ifc_angle_to_kml_heading(opts.x_axis_abscissa, opts.x_axis_ordinate));
+        assert!(kml.contains("<latitude>47.5</latitude>"));
+        assert!(kml.contains("<longitude>8.5</longitude>"));
+        assert!(kml.contains("<altitude>412</altitude>"));
+        assert!(kml.contains("<heading>90</heading>"));
+        assert!(kml.contains("<href>model.glb</href>"));
+        assert!(kml.contains("Bldg &lt;A&gt;"), "name is XML-escaped");
+    }
+
+    #[test]
+    fn kmz_is_a_valid_stored_zip() {
+        let glb = b"glTF\x02\x00\x00\x00placeholder-binary";
+        let opts = KmzOptions {
+            latitude: 0.0,
+            longitude: 0.0,
+            altitude: 0.0,
+            x_axis_abscissa: None,
+            x_axis_ordinate: None,
+            name: None,
+        };
+        let kmz = export_kmz(glb, &opts);
+
+        // Starts with a local file header, ends with the EOCD signature.
+        assert_eq!(&kmz[0..4], &0x0403_4b50u32.to_le_bytes());
+        let eocd = &0x0605_4b50u32.to_le_bytes();
+        assert!(kmz.windows(4).any(|w| w == eocd), "has end-of-central-directory");
+
+        // Both entry names + the GLB bytes are present (stored, uncompressed).
+        assert!(kmz.windows(7).any(|w| w == b"doc.kml"));
+        assert!(kmz.windows(9).any(|w| w == b"model.glb"));
+        assert!(kmz.windows(glb.len()).any(|w| w == glb), "GLB stored verbatim");
+    }
+}

--- a/rust/export/src/kmz.rs
+++ b/rust/export/src/kmz.rs
@@ -33,6 +33,9 @@ pub struct KmzOptions {
 /// north: 0 = N, 90 = E, 180 = S, 270 = W). Returns `0` when either component is absent.
 pub fn ifc_angle_to_kml_heading(x_abscissa: Option<f64>, x_ordinate: Option<f64>) -> f64 {
     match (x_abscissa, x_ordinate) {
+        // A zero-length axis is degenerate (atan2(0,0) = 0 would otherwise map to 90);
+        // treat it like a missing axis → no rotation.
+        (Some(x), Some(y)) if x == 0.0 && y == 0.0 => 0.0,
         (Some(x), Some(y)) => {
             let angle_from_east_ccw = y.atan2(x).to_degrees();
             // heading = 90 - angle (CCW-from-east → CW-from-north), normalized to [0, 360).
@@ -205,6 +208,8 @@ mod tests {
     fn heading_matches_ifc_convention() {
         // No axes → 0.
         assert_eq!(ifc_angle_to_kml_heading(None, None), 0.0);
+        // Degenerate zero-length axis → 0 (not 90 from atan2(0,0)).
+        assert_eq!(ifc_angle_to_kml_heading(Some(0.0), Some(0.0)), 0.0);
         // X-axis along east (1,0): angle-from-east 0 → heading 90.
         assert!((ifc_angle_to_kml_heading(Some(1.0), Some(0.0)) - 90.0).abs() < 1e-9);
         // X-axis along north (0,1): angle-from-east 90 CCW → heading 0.

--- a/rust/export/src/lib.rs
+++ b/rust/export/src/lib.rs
@@ -16,6 +16,7 @@ mod hbjson;
 mod ifc5;
 mod json;
 mod jsonld;
+mod kmz;
 mod merged;
 mod model;
 mod obj;
@@ -33,6 +34,7 @@ pub use hbjson::Model;
 pub use ifc5::{export_ifc5, Ifc5Options};
 pub use json::{export_json, JsonOptions};
 pub use jsonld::{export_jsonld, JsonLdOptions};
+pub use kmz::{export_kmz, ifc_angle_to_kml_heading, KmzOptions};
 pub use merged::{export_merged, export_merged_with_stats, MergedOptions, MergedStats};
 pub use model::{
     build_export_model, EntityRow, ExportModel, PropValue, PropertySet, QuantitySet, QuantityValue,

--- a/rust/wasm-bindings/src/api/export_glb.rs
+++ b/rust/wasm-bindings/src/api/export_glb.rs
@@ -70,4 +70,30 @@ impl IfcAPI {
         )
         .0
     }
+
+    /// Package an already-produced **GLB** + georeference into a **KMZ** (`Uint8Array`)
+    /// for Google Earth: a ZIP of `doc.kml` (a `<Model>` placed at `latitude`/`longitude`/
+    /// `altitude`) + `model.glb`. `x_axis_abscissa`/`x_axis_ordinate` are the
+    /// `IfcMapConversion` grid-north components; pass both as `undefined` for heading 0.
+    #[wasm_bindgen(js_name = exportKmz)]
+    pub fn export_kmz(
+        &self,
+        glb: &[u8],
+        latitude: f64,
+        longitude: f64,
+        altitude: f64,
+        x_axis_abscissa: Option<f64>,
+        x_axis_ordinate: Option<f64>,
+        name: String,
+    ) -> Vec<u8> {
+        let opts = ifc_lite_export::KmzOptions {
+            latitude,
+            longitude,
+            altitude,
+            x_axis_abscissa,
+            x_axis_ordinate,
+            name: if name.is_empty() { None } else { Some(name) },
+        };
+        ifc_lite_export::export_kmz(glb, &opts)
+    }
 }

--- a/scripts/test-wasm-contract.mjs
+++ b/scripts/test-wasm-contract.mjs
@@ -497,6 +497,36 @@ test('should handle truncated IFC content gracefully', () => {
   }
 });
 
+// ===== export boundary (Rust ifc-lite-export) =====
+console.log('\n📋 export (exportGlb / exportKmz)');
+
+// A real GLB from the column fixture — also the input the KMZ packer consumes.
+const glbBytes = api.exportGlb(columnContent, false, new Uint32Array(), new Uint32Array(), '');
+
+test('exportGlb returns a binary glTF (GLB magic "glTF")', () => {
+  assert.ok(glbBytes instanceof Uint8Array, 'GLB should be a Uint8Array');
+  assert.ok(glbBytes.length > 20, 'GLB should be non-trivial');
+  assert.deepEqual(Array.from(glbBytes.slice(0, 4)), [0x67, 0x6c, 0x54, 0x46]); // "glTF"
+});
+
+test('exportKmz packs a stored-zip KMZ (PK header, doc.kml + model.glb, axis-derived heading)', () => {
+  const kmz = api.exportKmz(glbBytes, 47.5, 8.5, 412, 1, 0, 'Contract Bldg');
+  assert.ok(kmz instanceof Uint8Array, 'KMZ should be a Uint8Array');
+  assert.deepEqual(Array.from(kmz.slice(0, 4)), [0x50, 0x4b, 0x03, 0x04]); // "PK\x03\x04"
+  const text = Buffer.from(kmz).toString('latin1');
+  assert.ok(text.includes('doc.kml'), 'archive names doc.kml');
+  assert.ok(text.includes('model.glb'), 'archive names model.glb');
+  assert.ok(text.includes('<heading>90</heading>'), 'heading derived from grid axis (1,0) → 90');
+  assert.ok(text.includes('Contract Bldg'), 'placemark name present');
+});
+
+test('exportKmz accepts undefined optional grid axes at the JS boundary (heading 0)', () => {
+  // Exercises the Rust Option<f64> params as `undefined` (the shim detail Codex flagged).
+  const kmz = api.exportKmz(glbBytes, 0, 0, 0, undefined, undefined, '');
+  assert.ok(kmz instanceof Uint8Array);
+  assert.ok(Buffer.from(kmz).toString('latin1').includes('<heading>0</heading>'), 'undefined axes → heading 0');
+});
+
 // Summary
 console.log('\n' + '═'.repeat(50));
 console.log(`📊 Results: ${passed} passed, ${failed} failed`);


### PR DESCRIPTION
Phase 3 of the export-to-Rust migration. After analyzing the three remaining format exporters (BCF, 2D-SVG, KMZ), only **KMZ** is a clean fit — so this PR moves KMZ and documents *why* BCF and 2D-SVG stay in TypeScript.

## What moved: KMZ → Rust

`rust/export/src/kmz.rs` now assembles the KMZ archive (`doc.kml` + `model.glb`) and computes the IFC grid-north → KML heading from the `IfcMapConversion` X-axis components.

- **wasm**: `IfcAPI.exportKmz(glb, lat, lon, alt, xAxisAbscissa?, xAxisOrdinate?, name)`
- **TS**: `GeometryProcessor.exportKmz(...)`; viewer `buildKmz` is now a thin async caller (matching OBJ/glTF/CSV). The heading math + KML/zip assembly leave TS.
- The GLB it packages is already produced by the Rust GLB exporter — so KMZ consumes already-computed bytes, the ideal bytes→format shape.
- **Lean zip**: a hand-rolled **stored**-ZIP writer (+ CRC32) avoids pulling `flate2` into the already-oversized wasm bundle (it grew ~5 KB, not ~100 KB). KMZ readers accept stored entries; trade-off is a larger file, fine for this infrequent georef export.

## What stays in TypeScript (with rationale)

| Format | Why it stays |
|--------|--------------|
| **BCF** (~5,500 LOC) | The defining input is **canvas PNG snapshots + DOM overlays** — inherently browser-bound. The portable core (zip/XML/viewpoint, ~1,200 LOC) would add an FFI seam for a <20% zip speedup while snapshots can't leave TS. Net-negative ROI. |
| **2D-SVG** (~2K LOC serializer) | The expensive work — 2D **outline extraction — is *already* in Rust** (`projection_outline::mesh_outline_2d`). The SVG serializer is pure string-building but renderer-coupled (annotations, graphic overrides, viewport); moving it gains little and adds coupling at the call site. |

This is the "flip the clean wins, don't move what doesn't belong" call — moving BCF/SVG would add FFI surface for work that's either already in Rust or impossible in Rust.

## Verification

- cargo **34/34** for `ifc-lite-export` (incl. 3 new kmz tests: heading convention, KML placement, valid stored-zip structure)
- viewer kmz/glb/csv helper tests **10/10** (stub-driven, test-seam processor factory)
- `@ifc-lite/geometry` + `apps/viewer` typecheck clean; full `turbo build` green (incl. viewer vite build)
- Regenerated `packages/wasm/pkg/ifc-lite.d.ts` for the new `exportKmz` binding

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * KMZ (Google Earth) export functionality for 3D models with integrated georeference and placement data.

* **Tests**
  * Added test suite for KMZ export scenarios and edge cases.

* **Documentation**
  * Updated code examples to demonstrate current model export patterns and APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->