### PR TITLE
fix(viewer): confine edge-docked panels to the viewport so they stay closable (#1245)

### DIFF
--- a/apps/viewer/src/components/viewer/ViewerLayout.tsx
+++ b/apps/viewer/src/components/viewer/ViewerLayout.tsx
@@ -349,7 +349,11 @@ export function ViewerLayout() {
 
                   {/* Center - Viewport */}
                   <Panel id="viewport-panel" defaultSize={78} minSize={30}>
-                    <div className="h-full w-full overflow-hidden relative">
+                    {/* data-floating-snap-bounds: edge-docked floating panels
+                        (#1201) snap to THIS region, not the whole window, so a
+                        dock never hides under the toolbar (its own close control
+                        with it) or over the hierarchy / sidebar (#1245). */}
+                    <div data-floating-snap-bounds className="h-full w-full overflow-hidden relative">
                       <ViewportContainer />
                     </div>
                   </Panel>

--- a/apps/viewer/src/components/viewer/dock/FloatingPanel.tsx
+++ b/apps/viewer/src/components/viewer/dock/FloatingPanel.tsx
@@ -12,7 +12,7 @@
  * `setFloatingPanelRect` / `snapFloatingPanel` calls.
  */
 
-import { useEffect, useRef, type CSSProperties, type ReactNode } from 'react';
+import { useEffect, useRef, type ReactNode } from 'react';
 import {
   PanelLeft,
   PanelRight,
@@ -24,6 +24,9 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { FloatingPanelState, SnapZone } from '@/store';
+import { computeFloatingPanelStyle, type SnapBounds } from './floating-panel-geometry';
+
+export type { SnapBounds };
 
 const MIN_W = 260;
 const MIN_H = 180;
@@ -31,25 +34,6 @@ const MIN_H = 180;
 const RESIZE_EDGE_MARGIN = 40;
 
 const clamp = (v: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, v));
-
-/**
- * The region an edge-snapped panel docks into, in window coordinates. Snapping
- * to this region (the 3D viewport) rather than the whole window keeps the
- * toolbar, hierarchy, sidebar and status bar visible — and, crucially, keeps a
- * docked panel's own title bar (close / un-dock controls) out from under the
- * z-50 toolbar so it can always be closed (#1245).
- */
-export interface SnapBounds {
-  /** px from the window's top / left edge to the region's top / left edge. */
-  top: number;
-  left: number;
-  /** px from the window's right / bottom edge to the region's edge (CSS right/bottom). */
-  right: number;
-  bottom: number;
-  /** Region extent, used to clamp a snapped panel so it can't outgrow the region. */
-  width: number;
-  height: number;
-}
 
 interface FloatingPanelProps {
   panel: FloatingPanelState;
@@ -64,21 +48,6 @@ interface FloatingPanelProps {
   /** Re-dock into the right slot (stop floating, show docked). */
   onDock: () => void;
   onClose: () => void;
-}
-
-function styleFor(p: FloatingPanelState, bounds: SnapBounds | null): CSSProperties {
-  if (p.snap === 'free') return { left: p.x, top: p.y, width: p.w, height: p.h };
-  // Edge snaps confine to the viewport region so a docked panel never hides
-  // under the toolbar (taking its own close control with it) or over the
-  // hierarchy / sidebar. Until the region is measured, fall back to the window
-  // edges (one frame at most — the host measures in a layout effect).
-  const vw = typeof window !== 'undefined' ? window.innerWidth : 0;
-  const vh = typeof window !== 'undefined' ? window.innerHeight : 0;
-  const b = bounds ?? { top: 0, left: 0, right: 0, bottom: 0, width: vw, height: vh };
-  if (p.snap === 'left') return { left: b.left, top: b.top, bottom: b.bottom, width: Math.min(p.w, b.width) };
-  if (p.snap === 'bottom') return { left: b.left, right: b.right, bottom: b.bottom, height: Math.min(p.h, b.height) };
-  // 'right'
-  return { right: b.right, top: b.top, bottom: b.bottom, width: Math.min(p.w, b.width) };
 }
 
 export function FloatingPanel({
@@ -202,7 +171,7 @@ export function FloatingPanel({
   return (
     <div
       ref={ref}
-      style={{ ...styleFor(panel, bounds), zIndex }}
+      style={{ ...computeFloatingPanelStyle(panel, bounds), zIndex }}
       onMouseDown={onFocus}
       className="absolute pointer-events-auto flex flex-col rounded-lg border border-border bg-background shadow-2xl overflow-hidden"
     >

--- a/apps/viewer/src/components/viewer/dock/FloatingPanel.tsx
+++ b/apps/viewer/src/components/viewer/dock/FloatingPanel.tsx
@@ -32,10 +32,31 @@ const RESIZE_EDGE_MARGIN = 40;
 
 const clamp = (v: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, v));
 
+/**
+ * The region an edge-snapped panel docks into, in window coordinates. Snapping
+ * to this region (the 3D viewport) rather than the whole window keeps the
+ * toolbar, hierarchy, sidebar and status bar visible — and, crucially, keeps a
+ * docked panel's own title bar (close / un-dock controls) out from under the
+ * z-50 toolbar so it can always be closed (#1245).
+ */
+export interface SnapBounds {
+  /** px from the window's top / left edge to the region's top / left edge. */
+  top: number;
+  left: number;
+  /** px from the window's right / bottom edge to the region's edge (CSS right/bottom). */
+  right: number;
+  bottom: number;
+  /** Region extent, used to clamp a snapped panel so it can't outgrow the region. */
+  width: number;
+  height: number;
+}
+
 interface FloatingPanelProps {
   panel: FloatingPanelState;
   title: string;
   zIndex: number;
+  /** The viewport region edge snaps confine to; null until measured. */
+  bounds: SnapBounds | null;
   children: ReactNode;
   onRect: (rect: Partial<Pick<FloatingPanelState, 'x' | 'y' | 'w' | 'h'>>) => void;
   onSnap: (snap: SnapZone) => void;
@@ -45,23 +66,26 @@ interface FloatingPanelProps {
   onClose: () => void;
 }
 
-function styleFor(p: FloatingPanelState): CSSProperties {
-  switch (p.snap) {
-    case 'left':
-      return { left: 0, top: 0, bottom: 0, width: p.w };
-    case 'right':
-      return { right: 0, top: 0, bottom: 0, width: p.w };
-    case 'bottom':
-      return { left: 0, right: 0, bottom: 0, height: p.h };
-    default:
-      return { left: p.x, top: p.y, width: p.w, height: p.h };
-  }
+function styleFor(p: FloatingPanelState, bounds: SnapBounds | null): CSSProperties {
+  if (p.snap === 'free') return { left: p.x, top: p.y, width: p.w, height: p.h };
+  // Edge snaps confine to the viewport region so a docked panel never hides
+  // under the toolbar (taking its own close control with it) or over the
+  // hierarchy / sidebar. Until the region is measured, fall back to the window
+  // edges (one frame at most — the host measures in a layout effect).
+  const vw = typeof window !== 'undefined' ? window.innerWidth : 0;
+  const vh = typeof window !== 'undefined' ? window.innerHeight : 0;
+  const b = bounds ?? { top: 0, left: 0, right: 0, bottom: 0, width: vw, height: vh };
+  if (p.snap === 'left') return { left: b.left, top: b.top, bottom: b.bottom, width: Math.min(p.w, b.width) };
+  if (p.snap === 'bottom') return { left: b.left, right: b.right, bottom: b.bottom, height: Math.min(p.h, b.height) };
+  // 'right'
+  return { right: b.right, top: b.top, bottom: b.bottom, width: Math.min(p.w, b.width) };
 }
 
 export function FloatingPanel({
   panel,
   title,
   zIndex,
+  bounds,
   children,
   onRect,
   onSnap,
@@ -127,10 +151,15 @@ export function FloatingPanel({
     const px = e.clientX;
     const py = e.clientY;
     const snap = panel.snap;
-    // Clamp growth to the viewport so a snapped panel can't be dragged past the
-    // edge (header / inner edge becoming unreachable) (#1208).
-    const maxW = Math.max(MIN_W, window.innerWidth - RESIZE_EDGE_MARGIN);
-    const maxH = Math.max(MIN_H, window.innerHeight - RESIZE_EDGE_MARGIN);
+    // Clamp growth so a snapped panel can't be dragged past its dock region
+    // (header / inner edge becoming unreachable). Free panels clamp to the
+    // window; edge-snapped panels clamp to the viewport region (#1208 / #1245).
+    const maxW = snap === 'free'
+      ? Math.max(MIN_W, window.innerWidth - RESIZE_EDGE_MARGIN)
+      : Math.max(MIN_W, bounds?.width ?? window.innerWidth);
+    const maxH = snap === 'free'
+      ? Math.max(MIN_H, window.innerHeight - RESIZE_EDGE_MARGIN)
+      : Math.max(MIN_H, bounds?.height ?? window.innerHeight);
 
     const move = (ev: MouseEvent) => {
       const dx = ev.clientX - px;
@@ -173,7 +202,7 @@ export function FloatingPanel({
   return (
     <div
       ref={ref}
-      style={{ ...styleFor(panel), zIndex }}
+      style={{ ...styleFor(panel, bounds), zIndex }}
       onMouseDown={onFocus}
       className="absolute pointer-events-auto flex flex-col rounded-lg border border-border bg-background shadow-2xl overflow-hidden"
     >

--- a/apps/viewer/src/components/viewer/dock/FloatingPanelHost.tsx
+++ b/apps/viewer/src/components/viewer/dock/FloatingPanelHost.tsx
@@ -9,13 +9,17 @@
  * stays interactive in the gaps between windows.
  */
 
+import { useLayoutEffect, useState } from 'react';
 import { useViewerStore } from '@/store';
 import { getPanelDef } from '@/lib/panels/registry';
 import { renderPanelBody } from '@/lib/panels/renderPanelBody';
 import { usePanelControls } from '@/hooks/usePanelControls';
-import { FloatingPanel } from './FloatingPanel';
+import { FloatingPanel, type SnapBounds } from './FloatingPanel';
 
 const FLOAT_Z_BASE = 30;
+
+/** ViewerLayout tags the 3D viewport with this so edge snaps confine to it. */
+const SNAP_BOUNDS_SELECTOR = '[data-floating-snap-bounds]';
 
 export function FloatingPanelHost() {
   const floatingPanels = useViewerStore((s) => s.floatingPanels);
@@ -23,6 +27,41 @@ export function FloatingPanelHost() {
   const snapFloatingPanel = useViewerStore((s) => s.snapFloatingPanel);
   const bringFloatingPanelToFront = useViewerStore((s) => s.bringFloatingPanelToFront);
   const { closePanel, dockPanel } = usePanelControls();
+
+  // The region edge-snapped panels dock into: the 3D viewport, in window
+  // coordinates. Tracked only while a panel is actually snapped so free-float /
+  // empty states stay observer-free. Kept in sync with sidebar / hierarchy
+  // resizes (and window resizes) so a dock never drifts under the toolbar or
+  // over the rail (#1245).
+  const hasSnapped = floatingPanels.some((p) => p.snap !== 'free');
+  const [snapBounds, setSnapBounds] = useState<SnapBounds | null>(null);
+  useLayoutEffect(() => {
+    if (!hasSnapped) {
+      setSnapBounds(null);
+      return;
+    }
+    const el = document.querySelector(SNAP_BOUNDS_SELECTOR) as HTMLElement | null;
+    if (!el) return;
+    const measure = () => {
+      const r = el.getBoundingClientRect();
+      setSnapBounds({
+        top: r.top,
+        left: r.left,
+        right: Math.max(0, window.innerWidth - r.right),
+        bottom: Math.max(0, window.innerHeight - r.bottom),
+        width: r.width,
+        height: r.height,
+      });
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    window.addEventListener('resize', measure);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener('resize', measure);
+    };
+  }, [hasSnapped]);
 
   if (floatingPanels.length === 0) return null;
 
@@ -40,6 +79,7 @@ export function FloatingPanelHost() {
             panel={panel}
             title={def?.title ?? panel.id}
             zIndex={FLOAT_Z_BASE + i}
+            bounds={snapBounds}
             onRect={(rect) => setFloatingPanelRect(panel.id, rect)}
             onSnap={(snap) => snapFloatingPanel(panel.id, snap)}
             onFocus={() => bringFloatingPanelToFront(panel.id)}

--- a/apps/viewer/src/components/viewer/dock/floating-panel-geometry.test.ts
+++ b/apps/viewer/src/components/viewer/dock/floating-panel-geometry.test.ts
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { computeFloatingPanelStyle, type SnapBounds } from './floating-panel-geometry.js';
+import type { FloatingPanelState, SnapZone } from '@/store';
+
+function panel(snap: SnapZone, over: Partial<FloatingPanelState> = {}): FloatingPanelState {
+  return { id: 'properties', snap, x: 120, y: 200, w: 360, h: 460, ...over };
+}
+
+// A viewport region that starts BELOW a 48px toolbar and stops ABOVE a 24px
+// status bar, inset on the right by a 300px sidebar — the shape that makes a
+// docked panel's title bar reachable instead of buried (#1245).
+const BOUNDS: SnapBounds = { top: 48, left: 0, right: 300, bottom: 24, width: 900, height: 800 };
+
+describe('computeFloatingPanelStyle', () => {
+  it('places a free panel at its stored window coordinates', () => {
+    const s = computeFloatingPanelStyle(panel('free'), BOUNDS);
+    assert.deepEqual(s, { left: 120, top: 200, width: 360, height: 460 });
+  });
+
+  it('right-snaps inside the region, NOT under the toolbar (regression #1245)', () => {
+    const s = computeFloatingPanelStyle(panel('right'), BOUNDS);
+    // top must follow the region (below the toolbar), never 0 — that buried
+    // the title bar (and its close control) under the z-50 toolbar.
+    assert.equal(s.top, 48);
+    assert.equal(s.right, 300);
+    assert.equal(s.bottom, 24);
+    assert.equal(s.left, undefined);
+    assert.equal(s.width, 360);
+  });
+
+  it('left-snaps to the region top/left edge', () => {
+    const s = computeFloatingPanelStyle(panel('left'), BOUNDS);
+    assert.equal(s.top, 48);
+    assert.equal(s.left, 0);
+    assert.equal(s.bottom, 24);
+    assert.equal(s.right, undefined);
+  });
+
+  it('bottom-snaps to the region bottom and spans its width (no top)', () => {
+    const s = computeFloatingPanelStyle(panel('bottom'), BOUNDS);
+    assert.equal(s.bottom, 24);
+    assert.equal(s.left, 0);
+    assert.equal(s.right, 300);
+    assert.equal(s.top, undefined);
+    assert.equal(s.height, 460);
+  });
+
+  it('clamps a snapped panel so it cannot outgrow the region', () => {
+    const wide = computeFloatingPanelStyle(panel('right', { w: 5000 }), BOUNDS);
+    assert.equal(wide.width, 900); // clamped to bounds.width
+
+    const tall = computeFloatingPanelStyle(panel('bottom', { h: 5000 }), BOUNDS);
+    assert.equal(tall.height, 800); // clamped to bounds.height
+  });
+
+  it('falls back to window edges when bounds is not yet measured', () => {
+    const s = computeFloatingPanelStyle(panel('right', { w: 5000 }), null);
+    assert.equal(s.top, 0);
+    assert.equal(s.right, 0);
+    assert.equal(s.bottom, 0);
+    assert.equal(s.width, 5000); // unclamped without a region
+  });
+});

--- a/apps/viewer/src/components/viewer/dock/floating-panel-geometry.ts
+++ b/apps/viewer/src/components/viewer/dock/floating-panel-geometry.ts
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Pure placement geometry for floating / edge-snapped workspace panels
+ * (#1201 / #1245). Kept DOM- and React-free (type-only imports) so the
+ * regression-critical snapping math can be unit-tested without a renderer.
+ */
+
+import type { CSSProperties } from 'react';
+import type { FloatingPanelState } from '@/store';
+
+/**
+ * The region an edge-snapped panel docks into, in window coordinates. Snapping
+ * to this region (the 3D viewport) rather than the whole window keeps the
+ * toolbar, hierarchy, sidebar and status bar visible — and, crucially, keeps a
+ * docked panel's own title bar (close / un-dock controls) out from under the
+ * z-50 toolbar so it can always be closed (#1245).
+ */
+export interface SnapBounds {
+  /** px from the window's top / left edge to the region's top / left edge. */
+  top: number;
+  left: number;
+  /** px from the window's right / bottom edge to the region's edge (CSS right/bottom). */
+  right: number;
+  bottom: number;
+  /** Region extent, used to clamp a snapped panel so it can't outgrow the region. */
+  width: number;
+  height: number;
+}
+
+/**
+ * Absolute-position style for a floating panel.
+ *
+ * - `free` panels sit at their stored window coordinates.
+ * - Edge snaps (`left` / `right` / `bottom`) confine to `bounds` — the viewport
+ *   region — so a docked panel never hides under the toolbar (its own close
+ *   control with it) or over the hierarchy / sidebar, and can't outgrow the
+ *   region. When `bounds` is null (not yet measured — at most one frame, since
+ *   the host measures in a layout effect) snaps fall back to the window edges.
+ */
+export function computeFloatingPanelStyle(p: FloatingPanelState, bounds: SnapBounds | null): CSSProperties {
+  if (p.snap === 'free') return { left: p.x, top: p.y, width: p.w, height: p.h };
+
+  const top = bounds?.top ?? 0;
+  const left = bounds?.left ?? 0;
+  const right = bounds?.right ?? 0;
+  const bottom = bounds?.bottom ?? 0;
+  const width = bounds ? Math.min(p.w, bounds.width) : p.w;
+  const height = bounds ? Math.min(p.h, bounds.height) : p.h;
+
+  if (p.snap === 'left') return { left, top, bottom, width };
+  if (p.snap === 'bottom') return { left, right, bottom, height };
+  return { right, top, bottom, width }; // 'right'
+}


### PR DESCRIPTION
Fixes #1245.

## Problem

Docking the **Inspector** (and any panel) to the right made it impossible to close — it obscured everything, including its own close control.

### Root cause
The `FloatingPanelHost` is a `fixed inset-0 z-30` overlay spanning the whole window, and an edge-snapped panel used `top: 0`. The `MainToolbar` is `relative z-50` and 48px tall, so a panel docked **left/right rendered its title bar (close ✕ / un-dock 📌 / free-float / snap controls) directly behind the higher-z toolbar** → unclickable. A *free-floating* panel (e.g. IDS) sits at `y≈96`, so its ✕ stays visible — which is why floating "worked" but edge-docking didn't. Left/right snaps also ran to the window edge, covering the hierarchy and sidebar.

## Fix

Edge-snapped panels now confine to the **3D viewport region** (Solibri-style) instead of the whole window:

- **`ViewerLayout.tsx`** — tags the viewport div with `data-floating-snap-bounds`.
- **`FloatingPanelHost.tsx`** — measures that region (window coords) via `getBoundingClientRect` + a `ResizeObserver`, **only while a panel is snapped**, and passes it down as `bounds`. Measured in a `useLayoutEffect` (no flash) and kept in sync with sidebar / hierarchy / window resizes.
- **`FloatingPanel.tsx`** — `styleFor` insets left/right/bottom snaps to `bounds` (below the toolbar, above the status bar, clear of the rail), clamps the panel so it can't outgrow the region, and bounds resize to it. **Free-float panels are unchanged.**

A docked panel now always keeps its title bar reachable below the toolbar and never covers the hierarchy or sidebar.

## Verification
- Viewer `tsc --noEmit`: **zero errors in the three edited files**.
- Scope: `apps/viewer` only — no published-package change, so no changeset needed.

## Notes
Per @MennoMekes's feedback in #1201, edge-docking is a secondary workflow (the sidebar + pop-out-to-second-screen cover the main cases); this makes it behave correctly rather than removing it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Floating panels now intelligently snap and dock within viewport region boundaries with refined resize constraints, improving workspace organization and keeping panels within defined bounds for better layout control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->