### PR TITLE
chore: consolidate chat-proxy dev env, drop orphan apps/api

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "dev": "pnpm build && pnpm --filter viewer dev",
-    "dev:api": "zsh -lc 'set -a; source \"apps/api/.env.local\"; set +a; PORT=3001 tsx scripts/dev-chat-api.ts'",
+    "dev:api": "zsh -lc 'set -a; source \"api/.env.local\"; set +a; PORT=3001 tsx scripts/dev-chat-api.ts'",
     "dev:embed": "pnpm build && pnpm --filter @ifc-lite/viewer-embed dev",
     "build": "turbo build",
     "build:embed": "pnpm --filter @ifc-lite/viewer-embed build",


### PR DESCRIPTION
## What

Point the `dev:api` script at `api/.env.local` instead of `apps/api/.env.local`, co-locating the chat-proxy dev env with the function it configures (`api/chat.ts`).

```diff
- "dev:api": "... source \"apps/api/.env.local\" ... tsx scripts/dev-chat-api.ts'",
+ "dev:api": "... source \"api/.env.local\" ... tsx scripts/dev-chat-api.ts'",
```

## Why

While auditing whether `server/chat/` was misplaced, the actual cruft turned out to be `apps/api/`. It is **not** a workspace app — it's an untracked directory holding only:

- a gitignored `.env.local` (sourced by `dev:api`), and
- a stale `.vercel/` link to a **dead Vercel project** named `api` (`prj_PdYtORJuxe…`): `live:false`, `latestDeployment:null`, `domains:[]`, **0 deployments ever** (verified via the Vercel API).

Production `/api/chat` is served by the **root `ifc-lite` Vercel project**, which auto-deploys the load-bearing root `api/` folder as a single serverless function (every prod deploy reports `lambdaRuntimeStats:{"nodejs":1}`). So `apps/api/` only added confusion next to the real `api/`.

For context — `server/chat/` itself is **correctly placed and live**: it's the TypeScript free-tier LLM chat proxy (quota in Neon Postgres, CORS, SSE) behind `api/chat.ts` + `scripts/dev-chat-api.ts`, consumed same-origin by the viewer's `ChatPanel`. It does **not** belong in the Rust `apps/server/` crate despite the name overlap, and can't move from repo-root because Vercel's function detection is pinned there.

## Scope

This PR contains only the tracked one-liner. The rest is local/untracked cleanup (no repo footprint), already done on my machine:

- removed stray `output.json` (a 3 KB geometry-cache dump at repo root)
- removed `apps/api/.vercel/` and `api/.vercel/` (both stale links to the dead `api` project)

## After merge (local, gitignored secret)

```sh
mv apps/api/.env.local api/.env.local && rm -rf apps/api
```

## Follow-up (not code)

The dead `api` Vercel project (`prj_PdYtORJuxe…`) can be deleted from the dashboard — it serves nothing.

No changeset: root `package.json` script only, not a published `packages/*` surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration for the API service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->