### PR TITLE
fix(viewer): stop stale-deploy WASM 404s via Vercel Skew Protection

### DIFF
--- a/apps/viewer/index.html
+++ b/apps/viewer/index.html
@@ -14,7 +14,28 @@
       if (theme === 'colorful') document.documentElement.classList.add('colorful');
     })();
   </script>
-  
+
+  <script>
+    // Vercel Skew Protection: pin this browser session to the deployment that
+    // served it. Lazily-fetched, content-hashed assets — notably the geometry
+    // WASM, only fetched when a model is opened — otherwise 404 after a new
+    // production deploy ships fresh hashes ("Failed to execute 'compile' on
+    // 'WebAssembly': HTTP status code is not ok"). The __vdpl cookie makes
+    // Vercel's edge route all subsequent same-origin requests to the matching
+    // deployment. The token below is replaced with the live VERCEL_DEPLOYMENT_ID
+    // at deploy time by scripts/vercel-build.sh, and ONLY when the project's
+    // Skew Protection toggle is on; otherwise it stays as the literal token and
+    // the `dpl_` guard makes this a no-op (localhost, previews, toggle off).
+    (function () {
+      try {
+        var id = '__VDPL_DEPLOYMENT_ID__';
+        if (id.indexOf('dpl_') === 0 && document.cookie.indexOf('__vdpl=') === -1) {
+          document.cookie = '__vdpl=' + id + '; path=/; SameSite=Strict; Secure';
+        }
+      } catch (e) { /* cookies disabled — skew protection simply won't apply */ }
+    })();
+  </script>
+
   <!-- Legacy ICO favicon (for older browsers) -->
   <link rel="icon" type="image/x-icon" href="/favicon.ico">
   <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">

--- a/apps/viewer/index.html
+++ b/apps/viewer/index.html
@@ -17,22 +17,34 @@
 
   <script>
     // Vercel Skew Protection: pin this browser session to the deployment that
-    // served it. Lazily-fetched, content-hashed assets — notably the geometry
-    // WASM, only fetched when a model is opened — otherwise 404 after a new
-    // production deploy ships fresh hashes ("Failed to execute 'compile' on
+    // served THIS document, so lazily-fetched content-hashed assets — notably
+    // the geometry WASM, only fetched when a model is opened — don't 404 after a
+    // newer deploy ships fresh hashes ("Failed to execute 'compile' on
     // 'WebAssembly': HTTP status code is not ok"). The __vdpl cookie makes
-    // Vercel's edge route all subsequent same-origin requests to the matching
-    // deployment. The token below is replaced with the live VERCEL_DEPLOYMENT_ID
-    // at deploy time by scripts/vercel-build.sh, and ONLY when the project's
-    // Skew Protection toggle is on; otherwise it stays as the literal token and
-    // the `dpl_` guard makes this a no-op (localhost, previews, toggle off).
+    // Vercel's edge route subsequent same-origin requests to the matching
+    // deployment. The token is replaced with the live VERCEL_DEPLOYMENT_ID at
+    // deploy time by scripts/vercel-build.sh, and ONLY when the project's Skew
+    // Protection toggle is on; otherwise it stays as the literal token and the
+    // `dpl_` guard below makes this a no-op (localhost, previews, toggle off).
     (function () {
       try {
         var id = '__VDPL_DEPLOYMENT_ID__';
-        if (id.indexOf('dpl_') === 0 && document.cookie.indexOf('__vdpl=') === -1) {
+        if (id.indexOf('dpl_') !== 0) return;
+        // Always reconcile the cookie to THIS page's deployment. Setting it only
+        // when absent would leave a stale __vdpl from an earlier deployment in
+        // place — e.g. a SameSite=Strict cross-site navigation doesn't send the
+        // cookie, so Vercel serves the current deployment while the browser
+        // still holds the old pin — and the next same-origin WASM fetch would
+        // route to the wrong (possibly deleted) deployment and 404.
+        var m = document.cookie.match(/(?:^|;\s*)__vdpl=([^;]*)/);
+        if (!m || m[1] !== id) {
           document.cookie = '__vdpl=' + id + '; path=/; SameSite=Strict; Secure';
         }
-      } catch (e) { /* cookies disabled — skew protection simply won't apply */ }
+      } catch (e) {
+        // House rule: don't swallow — a silently disabled skew fix is hard to
+        // diagnose against the very WASM 404 it is meant to prevent.
+        if (typeof console !== 'undefined') console.warn('[skew-protection] could not set __vdpl cookie', e);
+      }
     })();
   </script>
 

--- a/scripts/vercel-build.sh
+++ b/scripts/vercel-build.sh
@@ -76,4 +76,36 @@ echo "   PATH=$PATH"
 # apps/viewer and apps/viewer-embed.
 FILTER="${1:-@ifc-lite/viewer...}"
 echo "   filter:    $FILTER"
-exec npx turbo build --filter="$FILTER"
+
+npx turbo build --filter="$FILTER"
+build_status=$?
+
+# --- Vercel Skew Protection -------------------------------------------------
+# Pin each browser session to the deployment that served it so lazily-fetched,
+# content-hashed assets (notably the geometry WASM, fetched only when a model is
+# opened) don't 404 after a newer deploy ships fresh hashes — the cause of the
+# production "Failed to execute 'compile' on 'WebAssembly': HTTP status code is
+# not ok" error. apps/viewer/index.html ships a __VDPL_DEPLOYMENT_ID__ token; we
+# substitute the live deployment id here.
+#
+# This runs AFTER turbo (not as a turbo task) on purpose: the value is correct
+# even on a FULL TURBO cache hit, because the cached dist/index.html still holds
+# the literal token and we replace it outside turbo's cache. It only fires when
+# the project's Skew Protection toggle is on (VERCEL_SKEW_PROTECTION_ENABLED=1);
+# otherwise the token is left untouched and the in-page guard is a no-op.
+if [ "$build_status" -eq 0 ] && [ "${VERCEL_SKEW_PROTECTION_ENABLED:-}" = "1" ] && [ -n "${VERCEL_DEPLOYMENT_ID:-}" ]; then
+  injected=0
+  for html in apps/*/dist/index.html; do
+    [ -f "$html" ] || continue
+    if grep -q "__VDPL_DEPLOYMENT_ID__" "$html"; then
+      sed -i.bak "s/__VDPL_DEPLOYMENT_ID__/${VERCEL_DEPLOYMENT_ID}/g" "$html" && rm -f "$html.bak"
+      echo "🔒 Skew Protection: injected $VERCEL_DEPLOYMENT_ID into $html"
+      injected=1
+    fi
+  done
+  [ "$injected" -eq 0 ] && echo "ℹ️  Skew Protection enabled but no __VDPL_DEPLOYMENT_ID__ token found to inject."
+else
+  echo "ℹ️  Skew Protection: __VDPL_DEPLOYMENT_ID__ left unreplaced (toggle off or no deployment id)."
+fi
+
+exit $build_status


### PR DESCRIPTION
## Problem

Production (`www.ifclite.com`) throws, per PostHog error tracking:

> `TypeError: Failed to execute 'compile' on 'WebAssembly': HTTP status code is not ok`

6 occurrences across 5 distinct users (Chrome/Edge on Windows), first seen Jun 18, **still firing today** — confirmed prod, not preview, not resolved.

## Root cause — stale-deployment skew

The build content-hashes every wasm (`ifc-lite_bg-<hash>.wasm`, etc.) and wasm-bindgen fetches it **lazily, only when a model is opened**. Sequence:

1. A user loads deployment **N** (HTML + worker chunks in memory; wasm not fetched yet).
2. A newer deployment **N+1** ships; the `www` alias now serves N+1's hashes, and N's hashed files no longer exist on the alias.
3. The user opens an IFC → the in-memory N runtime fetches `…-<oldhash>.wasm` → **404** → `WebAssembly` compile throws *"HTTP status code is not ok."*

The intermittent, deploy-timed, low-but-multi-user pattern fits this exactly. (A genuinely missing asset would hit 100% of users; an SPA-rewrite-to-`index.html` would instead throw *"bad magic word"* — so it's a real 404 for old hashes.)

## Fix — Vercel Skew Protection (turbo-safe, for a static Vite SPA)

Vercel auto-wires skew protection for Next.js but not for static Vite SPAs, so we wire the `__vdpl` cookie ourselves. Once set, the edge routes a session's asset/worker/**wasm** requests to the deployment that served it, so the lazy wasm never 404s mid-session.

- **`apps/viewer/index.html`** — guarded inline `<head>` snippet sets the `__vdpl` cookie to a `__VDPL_DEPLOYMENT_ID__` token. The `id.indexOf('dpl_') === 0` guard makes it a **no-op** until the token is replaced (localhost, previews, toggle off).
- **`scripts/vercel-build.sh`** — after `turbo build`, substitutes the live `VERCEL_DEPLOYMENT_ID` into `dist/index.html`, **only when `VERCEL_SKEW_PROTECTION_ENABLED=1`**. Runs *outside* turbo on purpose: correct even on a FULL TURBO cache hit (the cached HTML keeps the literal token; we replace it post-cache). Dropped the `exec` and preserve turbo's exit code.

`__vdpl` is a **session cookie**: within a session the user stays pinned to a coherent deployment; new sessions get latest. If a pinned deployment has been deleted, Vercel falls back to current (graceful).

## ⚠️ Required to activate (this PR is inert until then)

1. Enable **Settings → Advanced → Skew Protection** on the Vercel project (Pro+). That sets `VERCEL_SKEW_PROTECTION_ENABLED=1` and exposes `VERCEL_DEPLOYMENT_ID` at build, which triggers the injection.
2. Sanity-check deployment **retention** — skew protection relies on the older deployment still existing.

## Testing

- In-page guard: no-ops on the unreplaced token; sets `__vdpl=dpl_…` for a real id.
- `vercel-build.sh` injection dry-run: token count `1 → 0`, live id substituted.
- Inline scripts confirmed preserved through Vite's HTML build (token reaches `dist`).
- `bash -n scripts/vercel-build.sh` clean.

No changeset (viewer-app only, no published-package src). `apps/viewer-embed` not touched — can follow up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added “Vercel Skew Protection” to the viewer page to verify deployment consistency using a secure cookie, with safe fallback behavior if browser restrictions prevent updates.
  * Updated the build pipeline to automatically inject the live deployment identifier into built HTML files when protection is enabled, while preserving the original build result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->