### PR TITLE
fix(export): self-contained GLB placement + Z-up→Y-up (fix misplaced/centre-collapsed GLB)

### DIFF
--- a/.changeset/glb-self-contained-placement.md
+++ b/.changeset/glb-self-contained-placement.md
@@ -1,0 +1,17 @@
+---
+"@ifc-lite/cache": patch
+---
+
+GLB export/import placement fixes.
+
+The GLB importer (`parseGLBToMeshData` / `loadGLBToMeshData`) now composes node-
+hierarchy translation into world vertex positions. The Rust exporter places all
+element geometry under a single translated root node (vertices stored relative to
+one scene centre for f32 precision); a parser that read accessors alone landed the
+whole model at that centre ("all centre aligned"). It now walks the scene roots,
+accumulates translation, and bakes it into each mesh node's vertices so re-imported
+GLBs — and any GLB with node transforms — land at their true world position.
+
+Paired with the Rust `ifc-lite-export` GLB/OBJ fixes (self-contained, scene-centre-
+baked geometry + IFC Z-up→WebGL Y-up conversion on the from-bytes path + double-
+sided materials).

--- a/packages/cache/src/glb.test.ts
+++ b/packages/cache/src/glb.test.ts
@@ -211,3 +211,50 @@ describe('parseGLBToMeshData / loadGLBToMeshData — material colour round-trip'
     expect(meshes[0].color).toEqual([0.8, 0.8, 0.8, 1.0]);
   });
 });
+
+describe('parseGLBToMeshData — node translation folding', () => {
+  // The exporter parents every element node under ONE translated root node (the
+  // placement rides that root; vertices are scene-centre-relative). A parser that
+  // ignored node transforms would land the whole model at the centre ("all centre
+  // aligned"). Verify the composed root translation is baked into world positions.
+  it('bakes a translated root node into child mesh world positions', () => {
+    const bin = new Uint8Array(84);
+    const fv = new Float32Array(bin.buffer);
+    fv.set([0, 0, 0, 1, 0, 0, 0, 1, 0], 0); // positions (centre-relative)
+    fv.set([0, 0, 1, 0, 0, 1, 0, 0, 1], 9); // normals
+    new Uint32Array(bin.buffer, 72, 3).set([0, 1, 2]); // indices
+
+    const meshes = parseGLBToMeshData(
+      {
+        asset: { version: '2.0' },
+        scene: 0,
+        scenes: [{ nodes: [0] }],
+        // node 0 = translated root parenting node 1; node 1 = the mesh.
+        nodes: [
+          { children: [1], translation: [10, 20, 30] },
+          { mesh: 0, extras: { expressId: 42 } },
+        ],
+        meshes: [{ primitives: [{ attributes: { POSITION: 0, NORMAL: 1 }, indices: 2 }] }],
+        accessors: [
+          { bufferView: 0, byteOffset: 0, componentType: 5126, count: 3, type: 'VEC3' },
+          { bufferView: 1, byteOffset: 0, componentType: 5126, count: 3, type: 'VEC3' },
+          { bufferView: 2, byteOffset: 0, componentType: 5125, count: 3, type: 'SCALAR' },
+        ],
+        bufferViews: [
+          { buffer: 0, byteOffset: 0, byteLength: 36, byteStride: 12, target: 34962 },
+          { buffer: 0, byteOffset: 36, byteLength: 36, byteStride: 12, target: 34962 },
+          { buffer: 0, byteOffset: 72, byteLength: 12, target: 34963 },
+        ],
+        buffers: [{ byteLength: 84 }],
+      },
+      bin,
+    );
+
+    expect(meshes).toHaveLength(1);
+    expect(meshes[0].expressId).toBe(42);
+    // Each vertex must be offset by the root translation [10, 20, 30].
+    expect(Array.from(meshes[0].positions)).toEqual([
+      10, 20, 30, 11, 20, 30, 10, 21, 30,
+    ]);
+  });
+});

--- a/packages/cache/src/glb.test.ts
+++ b/packages/cache/src/glb.test.ts
@@ -257,4 +257,44 @@ describe('parseGLBToMeshData — node translation folding', () => {
       10, 20, 30, 11, 20, 30, 10, 21, 30,
     ]);
   });
+
+  it('folds translation for a mesh node not reachable from the scene root', () => {
+    // node 0 is the scene root (no mesh); the mesh lives on node 1 which is NOT a
+    // child of node 0 (disconnected). Extraction must still fold node 1's own
+    // translation rather than emit local-space vertices.
+    const bin = new Uint8Array(84);
+    const fv = new Float32Array(bin.buffer);
+    fv.set([0, 0, 0, 1, 0, 0, 0, 1, 0], 0);
+    fv.set([0, 0, 1, 0, 0, 1, 0, 0, 1], 9);
+    new Uint32Array(bin.buffer, 72, 3).set([0, 1, 2]);
+
+    const meshes = parseGLBToMeshData(
+      {
+        asset: { version: '2.0' },
+        scene: 0,
+        scenes: [{ nodes: [0] }], // only node 0 is in the scene; node 1 is orphaned
+        nodes: [
+          { translation: [100, 0, 0] }, // root, no mesh, not a parent of node 1
+          { mesh: 0, translation: [5, 6, 7], extras: { expressId: 7 } },
+        ],
+        meshes: [{ primitives: [{ attributes: { POSITION: 0, NORMAL: 1 }, indices: 2 }] }],
+        accessors: [
+          { bufferView: 0, byteOffset: 0, componentType: 5126, count: 3, type: 'VEC3' },
+          { bufferView: 1, byteOffset: 0, componentType: 5126, count: 3, type: 'VEC3' },
+          { bufferView: 2, byteOffset: 0, componentType: 5125, count: 3, type: 'SCALAR' },
+        ],
+        bufferViews: [
+          { buffer: 0, byteOffset: 0, byteLength: 36, byteStride: 12, target: 34962 },
+          { buffer: 0, byteOffset: 36, byteLength: 36, byteStride: 12, target: 34962 },
+          { buffer: 0, byteOffset: 72, byteLength: 12, target: 34963 },
+        ],
+        buffers: [{ byteLength: 84 }],
+      },
+      bin,
+    );
+
+    expect(meshes).toHaveLength(1);
+    // node 1's own translation [5,6,7] is applied (NOT node 0's [100,0,0]).
+    expect(Array.from(meshes[0].positions)).toEqual([5, 6, 7, 6, 6, 7, 5, 7, 7]);
+  });
 });

--- a/packages/cache/src/glb.ts
+++ b/packages/cache/src/glb.ts
@@ -371,6 +371,12 @@ export function parseGLBToMeshData(gltf: GLTFDocument, bin: Uint8Array): MeshDat
       for (const c of nd.children ?? []) walk(c, x, y, z);
     };
     for (const r of roots) walk(r, 0, 0, 0);
+    // Extraction below iterates ALL nodes, not just scene-reachable ones. Walk any
+    // node the scene roots didn't reach (disconnected components) as its own root so
+    // every mesh node gets a composed transform — never silently emitted in local space.
+    for (let i = 0; i < gltf.nodes.length; i++) {
+      if (!seen.has(i)) walk(i, 0, 0, 0);
+    }
   }
 
   const DEFAULT_COLOR: [number, number, number, number] = [0.8, 0.8, 0.8, 1.0];

--- a/packages/cache/src/glb.ts
+++ b/packages/cache/src/glb.ts
@@ -56,6 +56,9 @@ interface GLTFNode {
   name?: string;
   extras?: { expressId?: number };
   children?: number[];
+  /** Node-local translation (xyz). Our exporter places all geometry under a
+   *  single translated root node, so this must be composed down the hierarchy. */
+  translation?: number[];
 }
 
 interface GLTFMesh {
@@ -347,6 +350,29 @@ export function parseGLBToMeshData(gltf: GLTFDocument, bin: Uint8Array): MeshDat
     return meshes;
   }
 
+  // Compose node translations down the hierarchy. Our exporter parents every
+  // element node under one translated root (placement rides that root, vertices
+  // are centre-relative), so a parser that read accessors alone would land the
+  // whole model at the scene centre. Walk from the scene roots accumulating
+  // translation, then bake it into each mesh node's vertices → absolute world.
+  const nodeWorldT = new Map<number, [number, number, number]>();
+  {
+    const seen = new Set<number>();
+    const roots = gltf.scenes?.[gltf.scene ?? 0]?.nodes ?? gltf.nodes.map((_, i) => i);
+    const walk = (idx: number, px: number, py: number, pz: number): void => {
+      const nd = gltf.nodes?.[idx];
+      if (!nd || seen.has(idx)) return; // guard against malformed cycles
+      seen.add(idx);
+      const t = nd.translation;
+      const x = px + (t?.[0] ?? 0);
+      const y = py + (t?.[1] ?? 0);
+      const z = pz + (t?.[2] ?? 0);
+      nodeWorldT.set(idx, [x, y, z]);
+      for (const c of nd.children ?? []) walk(c, x, y, z);
+    };
+    for (const r of roots) walk(r, 0, 0, 0);
+  }
+
   const DEFAULT_COLOR: [number, number, number, number] = [0.8, 0.8, 0.8, 1.0];
 
   const resolveMaterialColor = (
@@ -392,9 +418,23 @@ export function parseGLBToMeshData(gltf: GLTFDocument, bin: Uint8Array): MeshDat
       if (posAccessorIdx === undefined) continue;
 
       // Read position data
-      const positions = readAccessorData(gltf, bin, posAccessorIdx);
+      let positions = readAccessorData(gltf, bin, posAccessorIdx);
       if (!(positions instanceof Float32Array)) {
         throw new Error('Position data must be Float32');
+      }
+
+      // Fold the node's composed world translation into the vertices (a fresh
+      // buffer — readAccessorData may alias the shared bin). Yields absolute
+      // world positions so bounds/render need no per-node transform handling.
+      const wt = nodeWorldT.get(nodeIdx);
+      if (wt && (wt[0] !== 0 || wt[1] !== 0 || wt[2] !== 0)) {
+        const placed = new Float32Array(positions.length);
+        for (let i = 0; i < positions.length; i += 3) {
+          placed[i] = positions[i] + wt[0];
+          placed[i + 1] = positions[i + 1] + wt[1];
+          placed[i + 2] = positions[i + 2] + wt[2];
+        }
+        positions = placed;
       }
 
       // Read normal data (optional, generate if missing)

--- a/rust/export/src/frame.rs
+++ b/rust/export/src/frame.rs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MPL-2.0
+//! IFC Z-up → WebGL Y-up frame conversion for the **from-bytes** exporters.
+//!
+//! `ifc_lite_processing::process_geometry` emits geometry in the producer-native
+//! IFC **Z-up** frame. The Z-up→Y-up swap that every rendered/exported mesh
+//! normally undergoes happens at the wasm FFI (`MeshDataJs::new`) — which the
+//! from-bytes export path (CLI / MCP / SDK) never crosses. glTF 2.0 *mandates*
+//! +Y up, and the viewer / legacy GLTFExporter output is Y-up, so the from-bytes
+//! GLB/OBJ exporters must redo the identical conversion to match:
+//!
+//! - positions + normals: `(x, y, z) -> (x, z, -y)`
+//! - triangle winding reversed (mirrors `MeshDataJs::new`, keeps front faces)
+//! - per-element `origin` swapped the same way
+//!
+//! The from-meshes GLB path (the viewer's own `MeshData`) is already Y-up and
+//! must NOT be re-swapped — only this from-bytes path applies it.
+
+/// Convert a single IFC Z-up point/vector to WebGL Y-up: `(x, y, z) -> (x, z, -y)`.
+#[inline]
+pub(crate) fn yup_f32(p: [f32; 3]) -> [f32; 3] {
+    [p[0], p[2], -p[1]]
+}
+
+/// Same conversion for an f64 point (the per-element `origin`).
+#[inline]
+pub(crate) fn yup_f64(p: [f64; 3]) -> [f64; 3] {
+    [p[0], p[2], -p[1]]
+}
+
+/// One mesh's geometry converted from the IFC Z-up `process_geometry` frame into
+/// the WebGL Y-up frame (owned buffers), ready to feed the shared glTF assembler.
+pub(crate) struct YUpMesh {
+    pub positions: Vec<f32>,
+    pub normals: Vec<f32>,
+    pub indices: Vec<u32>,
+    pub origin: [f64; 3],
+}
+
+/// Convert Z-up `positions`/`normals`/`indices`/`origin` to Y-up owned buffers.
+pub(crate) fn to_yup(
+    positions: &[f32],
+    normals: &[f32],
+    indices: &[u32],
+    origin: [f64; 3],
+) -> YUpMesh {
+    let mut p = Vec::with_capacity(positions.len());
+    for c in positions.chunks_exact(3) {
+        p.extend_from_slice(&yup_f32([c[0], c[1], c[2]]));
+    }
+    let mut n = Vec::with_capacity(normals.len());
+    for c in normals.chunks_exact(3) {
+        n.extend_from_slice(&yup_f32([c[0], c[1], c[2]]));
+    }
+    // Reverse winding to compensate the handedness convention (identical to
+    // `MeshDataJs::new`): swap the 2nd/3rd index of every triangle.
+    let mut idx = indices.to_vec();
+    let tri_end = idx.len() - idx.len() % 3;
+    let mut i = 0;
+    while i < tri_end {
+        idx.swap(i + 1, i + 2);
+        i += 3;
+    }
+    YUpMesh { positions: p, normals: n, indices: idx, origin: yup_f64(origin) }
+}

--- a/rust/export/src/gltf.rs
+++ b/rust/export/src/gltf.rs
@@ -82,7 +82,10 @@ struct Scene {
 
 #[derive(Serialize)]
 struct Node {
-    mesh: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mesh: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    children: Option<Vec<u32>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     translation: Option<[f64; 3]>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -117,6 +120,11 @@ struct Material {
     extensions: Extensions,
     #[serde(rename = "alphaMode", skip_serializing_if = "Option::is_none")]
     alpha_mode: Option<&'static str>,
+    // IFC face winding isn't reliably outward (the viewer renders cull-none /
+    // double-sided), so single-sided glTF consumers would cull inward-wound or
+    // coplanar faces → "missing geometry". Match the viewer: always double-sided.
+    #[serde(rename = "doubleSided")]
+    double_sided: bool,
 }
 
 #[derive(Serialize)]
@@ -227,7 +235,46 @@ fn view_ok(v: &MeshView) -> bool {
 }
 
 /// Core glTF/GLB assembler over pre-filtered mesh views.
+///
+/// Placement model (the fix for "all centre aligned"): each view's vertices are
+/// LOCAL to its per-element `origin` (`world = origin + position`). We compute one
+/// model-wide `scene_center`, bake `world - scene_center` into the f32 vertex
+/// buffer, and ride the single large `scene_center` on ONE root-node translation
+/// that parents every element node. This keeps vertices small (f32-precise even at
+/// georef scale) AND self-contained: a consumer that ignores node transforms sees
+/// the whole model uniformly offset, never each element collapsed onto the origin
+/// (the failure mode of per-element `node.translation`).
 fn assemble_glb(views: &[MeshView], include_metadata: bool) -> (Vec<u8>, GltfStats) {
+    // Pre-filter once so both passes (centre, then bake) see exactly the same set.
+    let visible: Vec<&MeshView> = views.iter().filter(|v| view_ok(v)).collect();
+
+    // ── Pass 1: one model-wide WORLD AABB → scene centre ────────────────────
+    let mut wmin = [f64::INFINITY; 3];
+    let mut wmax = [f64::NEG_INFINITY; 3];
+    for v in &visible {
+        let o = v.origin;
+        for p in v.positions.chunks_exact(3) {
+            for k in 0..3 {
+                let w = p[k] as f64 + o[k];
+                if w < wmin[k] {
+                    wmin[k] = w;
+                }
+                if w > wmax[k] {
+                    wmax[k] = w;
+                }
+            }
+        }
+    }
+    let scene_center = if visible.is_empty() {
+        [0.0, 0.0, 0.0]
+    } else {
+        [
+            (wmin[0] + wmax[0]) * 0.5,
+            (wmin[1] + wmax[1]) * 0.5,
+            (wmin[2] + wmax[2]) * 0.5,
+        ]
+    };
+
     // Binary blobs, concatenated as [positions | normals | indices].
     let mut positions: Vec<u8> = Vec::new();
     let mut normals: Vec<u8> = Vec::new();
@@ -239,35 +286,34 @@ fn assemble_glb(views: &[MeshView], include_metadata: bool) -> (Vec<u8>, GltfSta
     let mut accessors: Vec<Accessor> = Vec::new();
     let mut meshes: Vec<Mesh> = Vec::new();
     let mut nodes: Vec<Node> = Vec::new();
-    let mut node_indices: Vec<u32> = Vec::new();
+    let mut element_node_indices: Vec<u32> = Vec::new();
 
     let mut stats = GltfStats { meshes: 0, vertices: 0, triangles: 0, materials: 0 };
 
-    for mesh in views {
-        if !view_ok(mesh) {
-            continue;
-        }
+    // ── Pass 2: bake centre-relative positions + assemble accessors/nodes ───
+    for mesh in &visible {
         let nverts = (mesh.positions.len() / 3) as u32;
-
-        // Bounds from LOCAL positions (accessor space; the node translation is applied after).
-        let mut min = [mesh.positions[0], mesh.positions[1], mesh.positions[2]];
-        let mut max = min;
-        for v in mesh.positions.chunks_exact(3) {
-            for k in 0..3 {
-                if v[k] < min[k] {
-                    min[k] = v[k];
-                }
-                if v[k] > max[k] {
-                    max[k] = v[k];
-                }
-            }
-        }
+        let o = mesh.origin;
 
         let pos_off = positions.len() as u32;
         let norm_off = normals.len() as u32;
         let idx_off = indices.len() as u32;
-        for &p in mesh.positions {
-            positions.extend_from_slice(&p.to_le_bytes());
+
+        // Bake each vertex into the scene-centre-relative frame (f32). Bounds are
+        // taken on the baked coords — accessor space is exactly the buffer bytes.
+        let mut min = [f32::INFINITY; 3];
+        let mut max = [f32::NEG_INFINITY; 3];
+        for p in mesh.positions.chunks_exact(3) {
+            for k in 0..3 {
+                let baked = ((p[k] as f64 + o[k]) - scene_center[k]) as f32;
+                positions.extend_from_slice(&baked.to_le_bytes());
+                if baked < min[k] {
+                    min[k] = baked;
+                }
+                if baked > max[k] {
+                    max[k] = baked;
+                }
+            }
         }
         for &n in mesh.normals {
             normals.extend_from_slice(&n.to_le_bytes());
@@ -319,6 +365,7 @@ fn assemble_glb(views: &[MeshView], include_metadata: bool) -> (Vec<u8>, GltfSta
                 },
                 extensions: Extensions { khr_materials_unlit: EmptyObj {} },
                 alpha_mode: if mesh.color[3] < 1.0 { Some("BLEND") } else { None },
+                double_sided: true,
             });
             idx
         });
@@ -332,26 +379,37 @@ fn assemble_glb(views: &[MeshView], include_metadata: bool) -> (Vec<u8>, GltfSta
             }],
         });
 
-        // RTC: large offset rides the node translation, positions stay local f32.
-        let translation = if mesh.origin != [0.0, 0.0, 0.0] {
-            Some(mesh.origin)
-        } else {
-            None
-        };
         let extras = if include_metadata {
             Some(json!({ "expressId": mesh.express_id, "ifcType": mesh.ifc_type }))
         } else {
             None
         };
         let node_idx = nodes.len() as u32;
-        nodes.push(Node { mesh: mesh_idx, translation, extras });
-        node_indices.push(node_idx);
+        nodes.push(Node { mesh: Some(mesh_idx), children: None, translation: None, extras });
+        element_node_indices.push(node_idx);
 
         stats.meshes += 1;
         stats.vertices += nverts as usize;
         stats.triangles += mesh.indices.len() / 3;
     }
     stats.materials = materials.len();
+
+    // Single root node carries the model-wide centre (omitted when ~zero) and
+    // parents every element node, so the scene has exactly one top-level node.
+    let center_nonzero =
+        scene_center.iter().any(|c| c.abs() > f64::EPSILON);
+    let scene_nodes = if element_node_indices.is_empty() {
+        Vec::new()
+    } else {
+        let root_idx = nodes.len() as u32;
+        nodes.push(Node {
+            mesh: None,
+            children: Some(element_node_indices),
+            translation: if center_nonzero { Some(scene_center) } else { None },
+            extras: None,
+        });
+        vec![root_idx]
+    };
 
     // Buffer views over the single concatenated binary buffer.
     let pos_len = positions.len() as u32;
@@ -400,7 +458,7 @@ fn assemble_glb(views: &[MeshView], include_metadata: bool) -> (Vec<u8>, GltfSta
     let gltf = Gltf {
         asset: Asset { version: "2.0", generator: "IFC-Lite", extras: asset_extras },
         scene: 0,
-        scenes: vec![Scene { nodes: node_indices }],
+        scenes: vec![Scene { nodes: scene_nodes }],
         nodes,
         meshes,
         materials: if materials.is_empty() { None } else { Some(materials) },
@@ -421,18 +479,29 @@ fn assemble_glb(views: &[MeshView], include_metadata: bool) -> (Vec<u8>, GltfSta
 /// Like [`export_glb`] but also returns coverage stats. Meshes the model from bytes.
 pub fn export_glb_with_stats(content: &[u8], opts: &GltfOptions) -> (Vec<u8>, GltfStats) {
     let result = process_geometry(content);
-    let views: Vec<MeshView> = result
-        .meshes
+    // `process_geometry` emits the producer-native IFC **Z-up** frame (the Z-up→Y-up
+    // swap normally happens at the wasm FFI, which this path never crosses). glTF
+    // mandates +Y-up, so convert each visible mesh to Y-up — positions/normals
+    // swapped, winding reversed, origin swapped — matching the viewer/legacy output.
+    // The from-meshes path (`export_glb_from_meshes`) skips this: its `MeshData` is
+    // already Y-up.
+    let visible: Vec<&MeshData> =
+        result.meshes.iter().filter(|m| mesh_visible(m, opts)).collect();
+    let yup: Vec<crate::frame::YUpMesh> = visible
         .iter()
-        .filter(|m| mesh_visible(m, opts))
-        .map(|m| MeshView {
+        .map(|m| crate::frame::to_yup(&m.positions, &m.normals, &m.indices, m.origin))
+        .collect();
+    let views: Vec<MeshView> = visible
+        .iter()
+        .zip(yup.iter())
+        .map(|(m, y)| MeshView {
             express_id: m.express_id,
             ifc_type: &m.ifc_type,
-            positions: &m.positions,
-            normals: &m.normals,
-            indices: &m.indices,
+            positions: &y.positions,
+            normals: &y.normals,
+            indices: &y.indices,
             color: m.color,
-            origin: m.origin,
+            origin: y.origin,
         })
         .collect();
     assemble_glb(&views, opts.include_metadata)
@@ -571,12 +640,37 @@ mod tests {
 
         let nodes = json["nodes"].as_array().unwrap();
         let meshes = json["meshes"].as_array().unwrap();
-        assert_eq!(nodes.len(), stats.meshes);
+        // One mesh-node per element + a single root node that parents them all.
+        assert_eq!(nodes.len(), stats.meshes + 1);
         assert_eq!(meshes.len(), stats.meshes);
 
-        // Materials present + KHR_materials_unlit declared.
+        // Scene has exactly one top-level node: the root. It carries the placement
+        // translation and lists every element node as a child; element nodes
+        // themselves carry NO translation (placement is baked relative to centre).
+        let scene_nodes = json["scenes"][0]["nodes"].as_array().unwrap();
+        assert_eq!(scene_nodes.len(), 1, "single root node");
+        let root_idx = scene_nodes[0].as_u64().unwrap() as usize;
+        let root = &nodes[root_idx];
+        assert!(root.get("mesh").is_none(), "root is a transform node, no mesh");
+        assert_eq!(
+            root["children"].as_array().unwrap().len(),
+            stats.meshes,
+            "root parents every element node"
+        );
+        for (i, n) in nodes.iter().enumerate() {
+            if i != root_idx {
+                assert!(n.get("translation").is_none(), "element nodes carry no translation");
+                assert!(n["mesh"].is_number(), "element nodes reference a mesh");
+            }
+        }
+
+        // Materials present + KHR_materials_unlit declared + double-sided.
         assert!(json["materials"].as_array().unwrap().len() >= 1);
         assert_eq!(json["extensionsUsed"][0], "KHR_materials_unlit");
+        assert!(
+            json["materials"].as_array().unwrap().iter().all(|m| m["doubleSided"] == true),
+            "materials double-sided (IFC winding isn't reliably outward)"
+        );
 
         // Every accessor must fit inside its bufferView (validator-critical).
         let bvs = json["bufferViews"].as_array().unwrap();
@@ -627,14 +721,57 @@ mod tests {
 
         let (json, bin) = parse_glb(&glb);
         assert_eq!(json["asset"]["generator"], "IFC-Lite");
-        assert_eq!(json["nodes"].as_array().unwrap().len(), 2);
-        // Mesh 1's RTC origin must ride a node translation (positions stay local).
-        let has_translation = json["nodes"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .any(|n| n["translation"] == serde_json::json!([1000.0, 2000.0, 3000.0]));
-        assert!(has_translation, "RTC origin emitted as node translation");
+        let nodes = json["nodes"].as_array().unwrap();
+        // 2 element nodes + 1 root.
+        assert_eq!(nodes.len(), 3);
+
+        // Exactly ONE node carries a translation — the single root. Per-element
+        // node.translation (the "all centre aligned" failure mode) is gone.
+        let translated: Vec<&Value> =
+            nodes.iter().filter(|n| n.get("translation").is_some()).collect();
+        assert_eq!(translated.len(), 1, "only the root node is translated");
+        let scene_nodes = json["scenes"][0]["nodes"].as_array().unwrap();
+        assert_eq!(scene_nodes.len(), 1);
+        let root = &nodes[scene_nodes[0].as_u64().unwrap() as usize];
+        let root_t = root["translation"].as_array().unwrap();
+        let center = [
+            root_t[0].as_f64().unwrap(),
+            root_t[1].as_f64().unwrap(),
+            root_t[2].as_f64().unwrap(),
+        ];
+
+        // SELF-CONTAINED placement: the two quads are ~3000 apart in mesh 1's farthest
+        // axis. Their baked (translation-dropped) accessor bounds must preserve that
+        // separation — i.e. dropping the root translation does NOT collapse them onto
+        // each other (which is exactly what per-element node.translation did wrong).
+        let accs = json["accessors"].as_array().unwrap();
+        let mut bmin = [f64::INFINITY; 3];
+        let mut bmax = [f64::NEG_INFINITY; 3];
+        for mesh in json["meshes"].as_array().unwrap() {
+            let pa = mesh["primitives"][0]["attributes"]["POSITION"].as_u64().unwrap() as usize;
+            for k in 0..3 {
+                let lo = accs[pa]["min"][k].as_f64().unwrap();
+                let hi = accs[pa]["max"][k].as_f64().unwrap();
+                if lo < bmin[k] { bmin[k] = lo; }
+                if hi > bmax[k] { bmax[k] = hi; }
+            }
+        }
+        assert!(
+            (bmax[2] - bmin[2]) > 2999.0,
+            "baked geometry retains the ~3000 element separation (no centre-collapse): got {}",
+            bmax[2] - bmin[2]
+        );
+
+        // World reconstruction: root.translation + baked bounds recover the true AABB
+        // (~[0,0,0]..[1001,2001,3000]).
+        for k in 0..3 {
+            let wmax = center[k] + bmax[k];
+            let wmin = center[k] + bmin[k];
+            assert!(wmin.abs() < 1.0, "world min ~0 on axis {k}: {wmin}");
+            let expect = [1001.0, 2001.0, 3000.0][k];
+            assert!((wmax - expect).abs() < 1.0, "world max ~{expect} on axis {k}: {wmax}");
+        }
+
         // Translucent material → BLEND.
         assert!(json["materials"].as_array().unwrap().iter().any(|m| m["alphaMode"] == "BLEND"));
         assert_eq!(bin.len(), json["buffers"][0]["byteLength"].as_u64().unwrap() as usize);

--- a/rust/export/src/lib.rs
+++ b/rust/export/src/lib.rs
@@ -10,6 +10,7 @@
 mod adjacency;
 mod constructions;
 mod csv;
+mod frame;
 mod geom;
 mod gltf;
 mod hbjson;

--- a/rust/export/src/obj.rs
+++ b/rust/export/src/obj.rs
@@ -16,6 +16,8 @@ use std::fmt::Write as _;
 
 use ifc_lite_processing::{process_geometry, MeshData};
 
+use crate::frame::{yup_f32, yup_f64};
+
 /// Options for OBJ export.
 pub struct ObjOptions {
     /// Emit per-vertex normals (`vn` + `f a//na`). Most DCC tools expect them.
@@ -84,32 +86,41 @@ pub fn export_obj_with_stats(content: &[u8], opts: &ObjOptions) -> (String, ObjS
         let _ = writeln!(out, "o {group}");
         let _ = writeln!(out, "g {group}");
 
-        // Vertices — fold the per-mesh f64 origin so georef-scale placements survive.
+        // Vertices — fold the per-mesh f64 origin so georef-scale placements survive,
+        // then convert the producer-native IFC Z-up world point to WebGL Y-up
+        // (`(x,y,z) -> (x,z,-y)`) so OBJ matches the header's declared frame and the
+        // GLB exporter (`process_geometry` itself is Z-up; the swap is normally done
+        // at the wasm FFI, which this path never crosses).
         let [ox, oy, oz] = mesh.origin;
         for i in 0..nverts {
-            let x = mesh.positions[i * 3] as f64 + ox;
-            let y = mesh.positions[i * 3 + 1] as f64 + oy;
-            let z = mesh.positions[i * 3 + 2] as f64 + oz;
+            let wx = mesh.positions[i * 3] as f64 + ox;
+            let wy = mesh.positions[i * 3 + 1] as f64 + oy;
+            let wz = mesh.positions[i * 3 + 2] as f64 + oz;
+            let [x, y, z] = yup_f64([wx, wy, wz]);
             let _ = writeln!(out, "v {x:.6} {y:.6} {z:.6}");
         }
         if has_normals {
             for i in 0..nverts {
-                let nx = mesh.normals[i * 3];
-                let ny = mesh.normals[i * 3 + 1];
-                let nz = mesh.normals[i * 3 + 2];
+                let [nx, ny, nz] = yup_f32([
+                    mesh.normals[i * 3],
+                    mesh.normals[i * 3 + 1],
+                    mesh.normals[i * 3 + 2],
+                ]);
                 let _ = writeln!(out, "vn {nx:.6} {ny:.6} {nz:.6}");
             }
         }
 
-        // Faces — OBJ indices are 1-based and global; offset by vert_base.
+        // Faces — OBJ indices are 1-based and global; offset by vert_base. Winding is
+        // reversed (2nd/3rd vertex swapped) to compensate the Z-up→Y-up handedness
+        // convention, matching the GLB exporter / `MeshDataJs::new`.
         for tri in mesh.indices.chunks_exact(3) {
             let a = vert_base + tri[0] as usize + 1;
             let b = vert_base + tri[1] as usize + 1;
             let c = vert_base + tri[2] as usize + 1;
             if has_normals {
-                let _ = writeln!(out, "f {a}//{a} {b}//{b} {c}//{c}");
+                let _ = writeln!(out, "f {a}//{a} {c}//{c} {b}//{b}");
             } else {
-                let _ = writeln!(out, "f {a} {b} {c}");
+                let _ = writeln!(out, "f {a} {c} {b}");
             }
             stats.triangles += 1;
         }


### PR DESCRIPTION
## Problem

Exported GLB geometry was **misplaced / "all centre aligned"** with some elements missing. Root cause is *not* the recent Rust exporter migration — it predates it.

The per-element **local frame** is hard-ON for the viewer (`local_frame_enabled()` → `true` for `wasm32`): every element's vertices are stored relative to its own AABB-centre, and the real placement rides a glTF **`node.translation`**. The GLB was therefore **not self-contained** — any consumer that flattens or ignores node transforms drew every element at its local frame, i.e. **collapsed onto the world origin**. The legacy TS `GLTFExporter` used the same `node.translation`, so the bug is long-standing.

Proven on `duplex.ifc` with the viewer's local-frame on: **486 / 486** element nodes carried a per-element translation; dropping them collapses the whole model to ±9 m around the origin.

A second, from-bytes-only defect: CLI/MCP/SDK `export_glb`/`export_obj` emitted raw **IFC Z-up** (they never cross the wasm FFI where the Y-up swap happens) → rotated 90°.

## Fix

- **GLB self-contained** (`gltf.rs`): bake `(origin + position) − scene_centre` into the f32 vertices and ride the single `scene_centre` on **one root node** that parents every element node. No per-element translation. Stays f32-precise (centre-relative) even at georef scale, and degrades gracefully — drop even the root and the building stays intact (uniform offset), never collapsed.
- **Z-up→Y-up** for the from-bytes path (`frame.rs`, applied in `gltf.rs` + `obj.rs`): replicates `MeshDataJs::new` exactly — swap `(x,y,z)→(x,z,-y)`, reverse winding, swap origin.
- **Double-sided materials**: IFC winding isn't reliably outward and the viewer renders cull-none; single-sided culling was a likely contributor to "missing" faces.
- **GLB importer** (`packages/cache/src/glb.ts`): composes node-hierarchy translation into world positions, so our own export→re-import (and any transformed GLB) lands correctly instead of at the centre.

Both export paths go through the shared assembler, so the viewer (from-meshes) and CLI/MCP/SDK (from-bytes) are fixed together. No TS API changes — takes effect on the next wasm rebuild.

## Verification

- `cargo test -p ifc-lite-export` → 34 passed (incl. existing georef `revit_georeferenced_model_does_not_collapse` + new root-node/no-collapse regression tests).
- `@ifc-lite/cache` GLB tests → 3 passed (incl. new node-translation-folding round-trip).
- Empirically on duplex with local-frame on: **1** root translation (was 486); dropping it preserves the **full building extent** (no collapse); building height is now the **Y** axis (foundation −1.55 → roof 9.0) confirming Z-up→Y-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Centralized GLB export placement transform for improved node hierarchy efficiency.
  * Enhanced coordinate system handling for WebGL compatibility.

* **Bug Fixes**
  * Fixed GLB importer to correctly position vertices at true world coordinates by baking node translations.
  * Updated all materials to support double-sided rendering.

* **Tests**
  * Added test coverage for node translation folding in GLB mesh data parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->