### PR TITLE
perf(wasm): validate + enable threaded-WASM CSG (off-by-default second bundle)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,18 @@ packages/wasm/pkg/ifc-lite_bg.wasm
 packages/wasm/pkg/ifc-lite_bg.wasm.d.ts
 packages/wasm/pkg/ifc-lite.js
 
+# Threaded WASM bundle (build-wasm.sh BUILD_THREADED=1) — build artifact, like pkg/.
+packages/wasm/pkg-threaded/
+
+# csg-thread-bench: rung-2 measurement artifacts (wasm-pack output, copied IFC
+# fixtures, generated corpus blobs). Source (Cargo.toml, src/, web/index.html,
+# web/serve.mjs) IS committed; these regenerate via the crate header instructions.
+rust/csg-thread-bench/web/pkg-plain/
+rust/csg-thread-bench/web/pkg-threaded/
+rust/csg-thread-bench/web/models/
+rust/csg-thread-bench/web/corpus/
+rust/csg-thread-bench/Cargo.lock
+
 # Tauri/Claude temp files
 tmpclaude*
 nul

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,6 +864,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1624,6 +1633,7 @@ dependencies = [
  "thiserror 2.0.18",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-bindgen-rayon",
  "wasm-bindgen-test",
  "web-sys",
 ]
@@ -2346,6 +2356,7 @@ checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
+ "wasm_sync",
 ]
 
 [[package]]
@@ -3143,6 +3154,18 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-rayon"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a16c60a56c81e4dc3b9c43d76ba5633e1c0278211d59a9cb07d61b6cd1c6583"
+dependencies = [
+ "crossbeam-channel",
+ "js-sys",
+ "rayon",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/docs/architecture/csg-threading-design.md
+++ b/docs/architecture/csg-threading-design.md
@@ -1,3 +1,9 @@
+<!--
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+-->
+
 # Threaded-WASM CSG — design & evidence
 
 Status: **validated by measurement, not yet wired into production.** This is the

--- a/docs/architecture/csg-threading-design.md
+++ b/docs/architecture/csg-threading-design.md
@@ -1,0 +1,131 @@
+# Threaded-WASM CSG — design & evidence
+
+Status: **validated by measurement, not yet wired into production.** This is the
+successor to the deleted `single-controller-rayon-design.md` (§12 of which
+recorded a 4× *regression* and shelved WASM threading). That verdict is **stale**:
+it was measured in May 2026 on the BSP/decode-dominated pipeline, a month before
+the pure-Rust exact CSG kernel (#1024) inverted the workload. Re-measured on the
+current kernel, threading is a **net win**.
+
+## TL;DR
+
+- The pure-Rust exact CSG kernel is **compute-bound** (predicate-dominated, the
+  rational tier is cold) with **tiny, cache-resident per-element working sets**
+  (0.4–2.2 MB even on a 177 MB model). That is exactly the shape WASM threads win
+  on — the opposite of the decode path §12 measured.
+- **Atomics tax ≈ 0%** on this kernel (the spike's ~7% tax was on memory-heavy
+  decode; the kernel barely touches memory).
+- A threaded WASM build (shared memory + `wasm-bindgen-rayon`) scales the CSG step
+  **~2.9–4.2×** at 8 threads, and a **naive whole-pipeline** threaded build still
+  nets **~1.6–1.9×** end-to-end — no regression — because CSG now dominates.
+- The right architecture threads **only the CSG-heavy element loop**; decode and
+  parse stay as they are. Two bundles ship (threaded + plain) because Safari does
+  not support `credentialless` cross-origin isolation.
+
+## Measured evidence (10-core Apple Silicon, 4P+6E)
+
+### Rung 1 — native, CSG isolated (decode excluded)
+Across 6 real models: **95–99% efficiency at 2 cores, 83–96% at 4**, plateauing
+~4.3–5.5× at 8–10 (P/E asymmetry, not bandwidth — working sets are cache-resident).
+Harness: `rust/processing/examples/csg_scaling_bench.rs` (`--features csg-capture`).
+
+### Rung 2 — threaded WASM, CSG corpus replay (real captured cuts)
+Decision number = current single-thread WASM ÷ threaded-parallel WASM:
+
+| model | jobs | plain serial | 4 threads | 8 threads |
+|---|---|---|---|---|
+| ISSUE_068 | 970 | 13,683 ms | 4,805 (2.85×) | 3,266 (**4.19×**) |
+| dental_clinic | 245 | 7,728 ms | 2,637 (2.93×) | 1,850 (**4.18×**) |
+| advanced_model | 103 (heavy-tail) | 26,273 ms | 11,017 (2.39×) | 8,994 (**2.92×**) |
+
+Atomics tax: plain-serial 13,683 vs threaded-serial 13,638 ms → **~0%**. Output
+fingerprint byte-identical across every thread count. WASM retains ~76–92% of
+native's multicore scaling (dlmalloc single-lock contention is real but modest;
+worst on many-small-job models). Harness: `rust/csg-thread-bench/` + `web/`.
+
+### End-to-end — threaded WASM, full pipeline (parse+prepass+decode+CSG)
+Naive whole-batch threading (`process_geometry`'s existing `par_iter`):
+
+| model | plain serial | threaded 8T | speedup |
+|---|---|---|---|
+| ISSUE_068 | 17,108 ms | 9,020 ms | **1.90×** |
+| advanced_model | 29,008 ms | 18,100 ms | **1.60×** |
+
+The gap between the pure-CSG ceiling (4.19×) and end-to-end (1.90×) is the
+**serial parse + serial prepass + memory-bound decode** that does not thread.
+That gap is the optimization target, not a blocker.
+
+## Architecture
+
+Two viable shapes:
+
+1. **Naive (proven +1.6–1.9×):** build the geometry path as a threaded bundle and
+   call `initThreadPool(navigator.hardwareConcurrency)` once. The existing
+   `par_iter` over elements (`processor.rs:1554`, `gpu_meshes.rs:882`) becomes
+   parallel with **zero algorithm changes**. Decode threads too and pays a small
+   penalty, but CSG dominance keeps the net positive on geometry-heavy models.
+
+2. **Surgical (recovers toward the 4× ceiling):** one shared-memory geometry
+   instance; keep parse + prepass + decode serial (or in their current form) and
+   parallelize **only** the CSG-heavy boolean step across elements. This avoids
+   the decode-thread penalty §12 hit and Amdahl-limits on a much smaller serial
+   fraction. Recommended target after the naive bundle proves out in the viewer.
+
+Either way it stays **one Rust source** — no second kernel, no drift (unlike
+re-adding Manifold). Within-element `subtract()` is *not* parallelizable (single
+`&mut Interner`); the granularity is across elements, which is genuinely
+independent.
+
+### Build: two bundles
+- **Plain** (today's flags): the fallback for non-isolated contexts and Safari.
+- **Threaded**: the spike flags (validated, `spike/path-b-respike` / `8fcaff96`):
+  ```
+  target-feature=+simd128,+atomics,+bulk-memory,+mutable-globals
+  link-arg=--shared-memory --import-memory
+  link-arg=--export=__wasm_init_tls,__tls_size,__tls_align,__tls_base
+  + build-std=["std","panic_abort"] (already in .cargo/config.toml)
+  + wasm-bindgen-rayon 1.3.0
+  ```
+  Select at runtime via `wasm-feature-detect` (threads support) **and**
+  `self.crossOriginIsolated`.
+
+### Required patch (raw-serve / wasm-bindgen-rayon)
+`wasm-bindgen-rayon`'s `workerHelpers.js` does `import('../../..')` — a package
+**directory**, which only resolves under a bundler. On a raw static server the
+helper worker dies silently and the main thread awaits `ready` forever (presents
+as an `initThreadPool` hang). The build must rewrite it to the explicit module
+file, e.g. `import('../../../<out-name>.js')`, as a post-build step. (The viewer
+is bundled by Vite, which resolves the directory import; the patch is required for
+unbundled serving and worth applying defensively.)
+
+### Cross-origin isolation
+Already in place in production (`vercel.json`: COOP `same-origin` + COEP
+`credentialless`), and SAB is already used for the file buffer. **Safari does not
+support `credentialless`** → it is not cross-origin isolated → it must run the
+plain bundle. That is the core reason two bundles ship.
+
+## Projected production win
+
+Amdahl on a void-heavy model (CSG ≈ 85–90% of load, ~4× on CSG at 8 threads,
+serial parse/prepass/decode unthreaded): **~2.5–3× cold-load**. The measured
+naive whole-pipeline 1.9× is the floor; the surgical split plus trimming the
+~14 s serial prepass (separately tracked) approaches the projection. On
+steel/faceted-brep-heavy models where *meshing* dominates rather than CSG, the
+win is smaller — pair with the rect-fast path (do less CSG) and the brep-mesher
+lever.
+
+## Risks / costs
+- Two bundles double WASM build + CI artifact surface; the plain fallback path
+  must stay tested (Safari, non-isolated embeds).
+- `-Zbuild-std` pins a nightly (already the repo's toolchain); a bump can break
+  the std rebuild — pin deliberately.
+- dlmalloc single global lock caps scaling ~10–25% below native; a sharded
+  allocator is unreliable on `wasm32-unknown-unknown` (mimalloc-rust is dicey) —
+  accept the cap for now.
+- Memory: one shared instance must hold the largest model's working set within
+  the 4 GB wasm32 address space (max-memory already 4 GB).
+
+## Repro
+Native: `cargo run --release -p ifc-lite-processing --example csg_scaling_bench --features csg-capture -- <model.ifc>`
+WASM: build `rust/csg-thread-bench` plain + threaded (see crate header), serve
+`web/` with COOP/COEP (`node serve.mjs`), open `index.html?pkg=threaded&mode=…`.

--- a/rust/csg-thread-bench/Cargo.toml
+++ b/rust/csg-thread-bench/Cargo.toml
@@ -1,0 +1,43 @@
+# Rung-2 measurement crate: a threaded-vs-plain WASM build of JUST the pure-Rust
+# CSG kernel, replaying a real captured void-cut corpus in the browser. Detached
+# from the main workspace (own [workspace]) so the threaded RUSTFLAGS (atomics)
+# and the wasm-bindgen-rayon dep never perturb the production tree. NOT shipped.
+[package]
+name = "csg-thread-bench"
+version = "0.0.0"
+edition = "2021"
+publish = false
+license = "MPL-2.0"
+description = "rung-2 threaded-wasm CSG scaling measurement (not shipped)"
+
+# Detach from the parent workspace.
+[workspace]
+
+[lib]
+crate-type = ["cdylib"]
+
+# Disable wasm-opt: the homebrew binary mis-handles simd128/atomics (same reason
+# the production build-wasm.sh disables it). LLVM -O3 from the release profile is
+# the optimization.
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false
+
+[features]
+# Threaded build: pull wasm-bindgen-rayon + enable the par_iter replay path.
+# Built with the atomics/shared-memory RUSTFLAGS. The plain build omits this.
+threads = ["dep:wasm-bindgen-rayon"]
+
+[dependencies]
+ifc-lite-geometry = { path = "../geometry", default-features = false, features = ["csg_capture"] }
+ifc-lite-processing = { path = "../processing" }
+wasm-bindgen = "=0.2.106"
+rayon = "1.10"
+wasm-bindgen-rayon = { version = "1.3.0", optional = true }
+
+[profile.release]
+opt-level = 3
+lto = true
+codegen-units = 1
+panic = "abort"
+strip = true
+overflow-checks = false

--- a/rust/csg-thread-bench/build.sh
+++ b/rust/csg-thread-bench/build.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Build the rung-2 CSG bench into web/pkg-plain and web/pkg-threaded, then
+# serve with `node web/serve.mjs` and open
+#   http://localhost:8099/?pkg=threaded&mode=csg&model=<fixture>&parallel=1&threads=8
+#
+# The threaded bundle pulls wasm-bindgen-rayon, whose generated worker helper
+# does a *directory* dynamic import (`import('../../..')`). A bare static file
+# server (web/serve.mjs) cannot resolve a directory specifier, so the worker
+# silently fails to boot and the threaded run hangs before `initThreadPool`
+# resolves. The production pipeline avoids this in scripts/build-wasm.sh by
+# rewriting the helper after wasm-pack; we apply the SAME rewrite here so the
+# bench is runnable straight after a build with no manual patching. (#1255 P2)
+set -euo pipefail
+cd "$(dirname "$0")"
+
+OUT_PLAIN=web/pkg-plain
+OUT_THREADED=web/pkg-threaded
+
+echo "==> building plain bundle -> $OUT_PLAIN"
+wasm-pack build --release --target web --out-dir "$OUT_PLAIN" --out-name csgbench
+
+echo "==> building threaded bundle -> $OUT_THREADED"
+RUSTFLAGS='-C target-feature=+atomics,+bulk-memory,+mutable-globals' \
+  rustup run nightly \
+  wasm-pack build --release --target web --out-dir "$OUT_THREADED" \
+  --out-name csgbench -- --features threads -Z build-std=std,panic_abort
+
+# Rewrite the wasm-bindgen-rayon worker helper's directory import to a concrete,
+# server-resolvable module path so the worker boots under web/serve.mjs.
+helper=$(find "$OUT_THREADED/snippets" -name '*.js' -path '*wasm-bindgen-rayon*' 2>/dev/null | head -1 || true)
+if [[ -n "${helper:-}" ]]; then
+  # `import('../../..')` / `import('../../../')` -> `import('../../../csgbench.js')`
+  perl -0pi -e "s{import\(\s*['\"](\.\./\.\./\.\.)/?['\"]\s*\)}{import('\$1/csgbench.js')}g" "$helper"
+  echo "==> patched worker helper: $helper"
+else
+  echo "WARN: wasm-bindgen-rayon worker helper not found; threaded bench may hang" >&2
+fi
+
+echo "==> done. serve: node web/serve.mjs"

--- a/rust/csg-thread-bench/src/lib.rs
+++ b/rust/csg-thread-bench/src/lib.rs
@@ -1,0 +1,90 @@
+//! Rung-2: does the pure-Rust exact CSG kernel scale with cores in a THREADED
+//! WASM bundle (shared memory + atomics), net of the imported-memory per-load
+//! tax and dlmalloc single-lock contention that are invisible on native?
+//!
+//! Two binaries are built from this one crate:
+//!   - PLAIN  (no `threads` feature, no atomics): the current single-thread shape.
+//!   - THREADED (`--features threads`, atomics/shared-memory RUSTFLAGS): a real
+//!     rayon thread pool via wasm-bindgen-rayon.
+//!
+//! The browser harness loads a REAL captured void-cut corpus (serialized
+//! natively) and times `replay()`. Comparing plain-serial vs threaded-serial
+//! isolates the atomics tax; threaded-serial vs threaded-parallel(N) gives the
+//! scaling; plain-serial vs threaded-parallel(N) is the decision number.
+
+use ifc_lite_geometry::csg::ClippingProcessor;
+use ifc_lite_geometry::csg_capture::{deserialize, CapturedCsgJob};
+use ifc_lite_geometry::mesh::Mesh;
+use std::sync::OnceLock;
+use wasm_bindgen::prelude::*;
+
+#[cfg(feature = "threads")]
+pub use wasm_bindgen_rayon::init_thread_pool;
+
+#[cfg(feature = "threads")]
+use rayon::prelude::*;
+
+static CORPUS: OnceLock<Vec<CapturedCsgJob>> = OnceLock::new();
+
+/// Replay one captured cut through the production CSG path. Returns the output
+/// triangle-index count — a deterministic, order-independent work fingerprint.
+fn replay_one(job: &CapturedCsgJob) -> usize {
+    let csg = ClippingProcessor::new();
+    match job {
+        CapturedCsgJob::Single { host, cutter } => {
+            csg.subtract_mesh(host, cutter).map(|m| m.indices.len()).unwrap_or(0)
+        }
+        CapturedCsgJob::Many { host, cutters } => {
+            let refs: Vec<&Mesh> = cutters.iter().collect();
+            csg.subtract_mesh_many(host, &refs).map(|m| m.indices.len()).unwrap_or(0)
+        }
+    }
+}
+
+/// Load the captured corpus blob. Returns the job count.
+#[wasm_bindgen]
+pub fn load_corpus(blob: &[u8]) -> usize {
+    let jobs = deserialize(blob);
+    let n = jobs.len();
+    let _ = CORPUS.set(jobs);
+    n
+}
+
+/// Replay the whole corpus once. `parallel=true` uses the rayon pool (threaded
+/// build only); otherwise a plain serial fold. JS times the call. Returns the
+/// work fingerprint so the harness can verify byte-identical output across runs.
+#[wasm_bindgen]
+pub fn replay(parallel: bool) -> f64 {
+    let jobs = CORPUS.get().expect("corpus not loaded");
+    let fp: usize = if parallel {
+        #[cfg(feature = "threads")]
+        {
+            jobs.par_iter().map(replay_one).sum()
+        }
+        #[cfg(not(feature = "threads"))]
+        {
+            jobs.iter().map(replay_one).sum()
+        }
+    } else {
+        jobs.iter().map(replay_one).sum()
+    };
+    fp as f64
+}
+
+/// True if this binary was built with the threaded feature.
+#[wasm_bindgen]
+pub fn is_threaded() -> bool {
+    cfg!(feature = "threads")
+}
+
+/// Run the FULL native pipeline (parse + prepass + decode + extrude + CSG) on
+/// raw IFC bytes. process_geometry's internal element loop is a rayon par_iter,
+/// so under the threaded build + an initialized pool it parallelizes
+/// decode+CSG together (the §12 "thread the whole batch" shape). Comparing this
+/// to the pure-CSG `replay` quantifies the serial parse/prepass + decode drag.
+/// Returns the mesh count as a fingerprint; JS times the call.
+#[wasm_bindgen]
+pub fn run_pipeline(bytes: &[u8]) -> f64 {
+    let result = ifc_lite_processing::process_geometry(bytes);
+    result.meshes.len() as f64
+}

--- a/rust/csg-thread-bench/src/lib.rs
+++ b/rust/csg-thread-bench/src/lib.rs
@@ -48,10 +48,15 @@ fn replay_one(job: &CapturedCsgJob) -> usize {
 /// Load the captured corpus blob. Returns the job count.
 #[wasm_bindgen]
 pub fn load_corpus(blob: &[u8]) -> usize {
-    let jobs = deserialize(blob);
-    let n = jobs.len();
-    let _ = CORPUS.set(jobs);
-    n
+    match deserialize(blob) {
+        Ok(jobs) => {
+            let n = jobs.len();
+            let _ = CORPUS.set(jobs);
+            n
+        }
+        // Controlled failure (returns 0) instead of trapping on a bad blob.
+        Err(_) => 0,
+    }
 }
 
 /// Replay the whole corpus once. `parallel=true` uses the rayon pool (threaded

--- a/rust/csg-thread-bench/src/lib.rs
+++ b/rust/csg-thread-bench/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Rung-2: does the pure-Rust exact CSG kernel scale with cores in a THREADED
 //! WASM bundle (shared memory + atomics), net of the imported-memory per-load
 //! tax and dlmalloc single-lock contention that are invisible on native?

--- a/rust/csg-thread-bench/src/lib.rs
+++ b/rust/csg-thread-bench/src/lib.rs
@@ -51,8 +51,14 @@ pub fn load_corpus(blob: &[u8]) -> usize {
     match deserialize(blob) {
         Ok(jobs) => {
             let n = jobs.len();
-            let _ = CORPUS.set(jobs);
-            n
+            // OnceLock: first load wins. If the corpus is already initialized
+            // (a second call in the same wasm instance), keep the existing one
+            // and report ITS length — so the returned count never disagrees
+            // with what `replay` actually iterates.
+            match CORPUS.set(jobs) {
+                Ok(()) => n,
+                Err(_) => CORPUS.get().map_or(0, Vec::len),
+            }
         }
         // Controlled failure (returns 0) instead of trapping on a bad blob.
         Err(_) => 0,

--- a/rust/csg-thread-bench/web/index.html
+++ b/rust/csg-thread-bench/web/index.html
@@ -28,7 +28,10 @@ async function main() {
   await mod.default();
   log(`is_threaded=${mod.is_threaded()}`);
 
-  // Threaded build needs the pool initialized before ANY par_iter.
+  // Threaded build needs the pool initialized before ANY par_iter. The
+  // generated wasm-bindgen-rayon worker helper does a directory import a static
+  // server can't resolve; build.sh rewrites it to a concrete path, so build the
+  // threaded bundle via that script (not raw wasm-pack) or this step hangs.
   if (pkg === 'threaded') {
     const t0 = performance.now();
     await mod.initThreadPool(threads);

--- a/rust/csg-thread-bench/web/index.html
+++ b/rust/csg-thread-bench/web/index.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>CSG rung-2 bench</title></head>
+<body>
+<pre id="status">starting…</pre>
+<script type="module">
+const q = new URLSearchParams(location.search);
+const pkg = q.get('pkg') || 'plain';            // plain | threaded
+const mode = q.get('mode') || 'csg';            // csg (replay corpus) | pipeline (full process_geometry)
+const model = q.get('model') || 'ISSUE_068_ARK_NUS_skolebygg';
+const parallel = q.get('parallel') === '1';
+const threads = parseInt(q.get('threads') || '1', 10);
+const iters = parseInt(q.get('iters') || (mode === 'pipeline' ? '2' : '5'), 10);
+const statusEl = document.getElementById('status');
+const log = (m) => { statusEl.textContent += '\n' + m; console.log(m); };
+
+async function main() {
+  log(`pkg=${pkg} mode=${mode} model=${model} parallel=${parallel} threads=${threads} iters=${iters}`);
+  log(`crossOriginIsolated=${self.crossOriginIsolated}`);
+  const mod = await import(`./pkg-${pkg}/csgbench.js`);
+  await mod.default();
+  log(`is_threaded=${mod.is_threaded()}`);
+
+  // Threaded build needs the pool initialized before ANY par_iter.
+  if (pkg === 'threaded') {
+    const t0 = performance.now();
+    await mod.initThreadPool(threads);
+    log(`initThreadPool(${threads}) ok @ ${Math.round(performance.now() - t0)}ms`);
+  }
+
+  let run, njobs, label;
+  if (mode === 'pipeline') {
+    const buf = await (await fetch(`./models/${model}.ifc`)).arrayBuffer();
+    const bytes = new Uint8Array(buf);
+    log(`fetched ${model}.ifc (${(buf.byteLength/1e6).toFixed(1)} MB)`);
+    run = () => mod.run_pipeline(bytes);
+    label = 'full pipeline (parse+prepass+decode+CSG)';
+  } else {
+    const buf = await (await fetch(`./corpus/${model}.bin`)).arrayBuffer();
+    njobs = mod.load_corpus(new Uint8Array(buf));
+    log(`loaded ${njobs} jobs (${(buf.byteLength/1e6).toFixed(1)} MB)`);
+    run = () => mod.replay(parallel);
+    label = 'CSG corpus replay';
+  }
+
+  const fp0 = run();                              // warmup (untimed)
+  let best = Infinity, fp = fp0, ok = true;
+  for (let i = 0; i < iters; i++) {
+    const t = performance.now();
+    const f = run();
+    const dt = performance.now() - t;
+    if (f !== fp0) ok = false;
+    if (dt < best) best = dt;
+    fp = f;
+  }
+  const result = { pkg, mode, model, parallel, threads, njobs, minMs: +best.toFixed(1), fp, parity: ok };
+  window.__RESULT__ = result;
+  log(`(${label})`);
+  log('RESULT ' + JSON.stringify(result));
+  log('RESULT_DONE');
+}
+window.__READY = main().catch((e) => { window.__RESULT__ = { error: String(e) }; log('ERROR ' + e + '\n' + (e.stack||'')); log('RESULT_DONE'); });
+</script>
+</body>
+</html>

--- a/rust/csg-thread-bench/web/index.html
+++ b/rust/csg-thread-bench/web/index.html
@@ -1,3 +1,8 @@
+<!--
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+-->
 <!doctype html>
 <html>
 <head><meta charset="utf-8"><title>CSG rung-2 bench</title></head>
@@ -5,9 +10,11 @@
 <pre id="status">starting…</pre>
 <script type="module">
 const q = new URLSearchParams(location.search);
-const pkg = q.get('pkg') || 'plain';            // plain | threaded
-const mode = q.get('mode') || 'csg';            // csg (replay corpus) | pipeline (full process_geometry)
-const model = q.get('model') || 'ISSUE_068_ARK_NUS_skolebygg';
+// Whitelist pkg/mode (they index a dynamic import path) and sanitize the model
+// to a bare fixture basename — prevents `../`-style path traversal via the query.
+const pkg = q.get('pkg') === 'threaded' ? 'threaded' : 'plain';
+const mode = q.get('mode') === 'pipeline' ? 'pipeline' : 'csg';
+const model = (q.get('model') || 'ISSUE_068_ARK_NUS_skolebygg').replace(/[^A-Za-z0-9_-]/g, '');
 const parallel = q.get('parallel') === '1';
 const threads = parseInt(q.get('threads') || '1', 10);
 const iters = parseInt(q.get('iters') || (mode === 'pipeline' ? '2' : '5'), 10);

--- a/rust/csg-thread-bench/web/serve.mjs
+++ b/rust/csg-thread-bench/web/serve.mjs
@@ -1,11 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 // Minimal static server with COOP/COEP so the page is crossOriginIsolated
 // (required for SharedArrayBuffer + wasm threads). Mirrors the production
 // vercel.json header pair, but uses require-corp (all assets are same-origin).
 import { createServer } from 'node:http';
 import { readFile } from 'node:fs/promises';
-import { extname, join, normalize } from 'node:path';
+import { extname, normalize, resolve, sep } from 'node:path';
 
-const ROOT = new URL('.', import.meta.url).pathname;
+const ROOT = resolve(new URL('.', import.meta.url).pathname);
 const PORT = Number(process.env.PORT || 8099);
 const TYPES = {
   '.html': 'text/html; charset=utf-8',
@@ -22,9 +26,17 @@ createServer(async (req, res) => {
   res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
   res.setHeader('Cross-Origin-Resource-Policy', 'same-origin');
   try {
-    const urlPath = decodeURIComponent(new URL(req.url, `http://localhost`).pathname);
-    const rel = normalize(urlPath === '/' ? '/index.html' : urlPath).replace(/^(\.\.[/\\])+/, '');
-    const file = join(ROOT, rel);
+    const urlPath = decodeURIComponent(new URL(req.url, 'http://localhost').pathname);
+    // Strip leading slashes so the path resolves RELATIVE to ROOT, then confirm
+    // the resolved file stays inside ROOT — defeats `..`/absolute path traversal
+    // (e.g. `/../../etc/passwd`).
+    const rel = normalize(urlPath === '/' ? 'index.html' : urlPath).replace(/^[/\\]+/, '');
+    const file = resolve(ROOT, rel);
+    if (file !== ROOT && !file.startsWith(ROOT + sep)) {
+      res.statusCode = 403;
+      res.end('forbidden');
+      return;
+    }
     const body = await readFile(file);
     res.setHeader('Content-Type', TYPES[extname(file)] || 'application/octet-stream');
     res.end(body);

--- a/rust/csg-thread-bench/web/serve.mjs
+++ b/rust/csg-thread-bench/web/serve.mjs
@@ -1,0 +1,35 @@
+// Minimal static server with COOP/COEP so the page is crossOriginIsolated
+// (required for SharedArrayBuffer + wasm threads). Mirrors the production
+// vercel.json header pair, but uses require-corp (all assets are same-origin).
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { extname, join, normalize } from 'node:path';
+
+const ROOT = new URL('.', import.meta.url).pathname;
+const PORT = Number(process.env.PORT || 8099);
+const TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.wasm': 'application/wasm',
+  '.bin': 'application/octet-stream',
+  '.json': 'application/json',
+};
+
+createServer(async (req, res) => {
+  // COOP/COEP on EVERY response → crossOriginIsolated === true.
+  res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+  res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
+  res.setHeader('Cross-Origin-Resource-Policy', 'same-origin');
+  try {
+    const urlPath = decodeURIComponent(new URL(req.url, `http://localhost`).pathname);
+    const rel = normalize(urlPath === '/' ? '/index.html' : urlPath).replace(/^(\.\.[/\\])+/, '');
+    const file = join(ROOT, rel);
+    const body = await readFile(file);
+    res.setHeader('Content-Type', TYPES[extname(file)] || 'application/octet-stream');
+    res.end(body);
+  } catch (e) {
+    res.statusCode = 404;
+    res.end('not found: ' + e.message);
+  }
+}).listen(PORT, () => console.log(`serving ${ROOT} on http://localhost:${PORT} (COOP/COEP on)`));

--- a/rust/geometry/Cargo.toml
+++ b/rust/geometry/Cargo.toml
@@ -18,6 +18,10 @@ readme = "../../README.md"
 # (docs/architecture/geometry-pipeline.md).
 default = []
 debug_geometry = []
+# Measurement-only: record the (host, cutters) of every kernel subtract into a
+# global buffer so a bench can replay the real CSG corpus under varying thread
+# counts. Zero cost when absent. See src/csg_capture.rs.
+csg_capture = []
 
 [dependencies]
 

--- a/rust/geometry/src/csg_capture.rs
+++ b/rust/geometry/src/csg_capture.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! CSG corpus capture — measurement-only, behind the off-by-default
 //! `csg_capture` feature (zero cost in production: the hooks compile to
 //! nothing when the feature is absent).
@@ -16,6 +20,7 @@
 //! a threaded wasm build to measure the wasm-specific taxes.
 
 use crate::mesh::Mesh;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 
 /// One real CSG invocation captured from the pipeline. Holds owned copies of
@@ -31,15 +36,42 @@ pub enum CapturedCsgJob {
 
 static CAPTURED: Mutex<Vec<CapturedCsgJob>> = Mutex::new(Vec::new());
 
-/// Record a single-pair subtract. Called from the kernel boundary.
+/// Recording is OFF unless a capture run explicitly enables it. CRITICAL for
+/// measurement validity: the kernel `subtract`/`subtract_many` hooks ALSO fire
+/// when a bench replays the captured corpus — without this gate, every replayed
+/// cut would lock `CAPTURED` and clone its meshes, serializing rayon threads on
+/// one Mutex and distorting the very scaling numbers the bench measures. So the
+/// capture run wraps the pipeline in `set_enabled(true)`; replay leaves it off.
+static CAPTURE_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Turn recording on/off. Call `set_enabled(true)` only around the pipeline pass
+/// that should populate the corpus, then `set_enabled(false)` before replaying.
+pub fn set_enabled(on: bool) {
+    CAPTURE_ENABLED.store(on, Ordering::Relaxed);
+}
+
+#[inline]
+fn enabled() -> bool {
+    CAPTURE_ENABLED.load(Ordering::Relaxed)
+}
+
+/// Record a single-pair subtract. Called from the kernel boundary. No-op (one
+/// relaxed atomic load) unless a capture run is active.
 pub fn record_single(host: &Mesh, cutter: &Mesh) {
+    if !enabled() {
+        return;
+    }
     if let Ok(mut v) = CAPTURED.lock() {
         v.push(CapturedCsgJob::Single { host: host.clone(), cutter: cutter.clone() });
     }
 }
 
-/// Record a batched subtract. Called from the kernel boundary.
+/// Record a batched subtract. Called from the kernel boundary. No-op unless a
+/// capture run is active.
 pub fn record_many(host: &Mesh, cutters: &[&Mesh]) {
+    if !enabled() {
+        return;
+    }
     if let Ok(mut v) = CAPTURED.lock() {
         v.push(CapturedCsgJob::Many {
             host: host.clone(),

--- a/rust/geometry/src/csg_capture.rs
+++ b/rust/geometry/src/csg_capture.rs
@@ -175,20 +175,29 @@ impl<'a> Reader<'a> {
 pub fn deserialize(blob: &[u8]) -> Result<Vec<CapturedCsgJob>, &'static str> {
     let mut r = Reader { b: blob, p: 0 };
     let n = r.u32().ok_or("truncated blob: missing job count")? as usize;
-    // Cap the pre-allocation: a malformed count must not request gigabytes.
-    let mut jobs = Vec::with_capacity(n.min(blob.len()));
+    // Don't pre-size from the untrusted count (nor from blob.len(), which over-
+    // allocates ~30x since the smallest job is dozens of bytes) — just grow.
+    let mut jobs = Vec::new();
     for _ in 0..n {
         let tag = r.u8().ok_or("truncated blob: missing tag")?;
         let host = r.mesh().ok_or("truncated blob: bad host mesh")?;
-        if tag == 0 {
-            let cutter = r.mesh().ok_or("truncated blob: bad cutter mesh")?;
-            jobs.push(CapturedCsgJob::Single { host, cutter });
-        } else {
-            let nc = r.u32().ok_or("truncated blob: missing cutter count")? as usize;
-            let cutters: Vec<Mesh> =
-                (0..nc).map(|_| r.mesh()).collect::<Option<_>>().ok_or("truncated blob: bad cutter mesh")?;
-            jobs.push(CapturedCsgJob::Many { host, cutters });
+        match tag {
+            0 => {
+                let cutter = r.mesh().ok_or("truncated blob: bad cutter mesh")?;
+                jobs.push(CapturedCsgJob::Single { host, cutter });
+            }
+            1 => {
+                let nc = r.u32().ok_or("truncated blob: missing cutter count")? as usize;
+                let cutters: Vec<Mesh> =
+                    (0..nc).map(|_| r.mesh()).collect::<Option<_>>().ok_or("truncated blob: bad cutter mesh")?;
+                jobs.push(CapturedCsgJob::Many { host, cutters });
+            }
+            _ => return Err("invalid job tag"),
         }
+    }
+    // A well-formed blob is fully consumed; leftover bytes mean corruption.
+    if r.p != blob.len() {
+        return Err("trailing bytes after last job");
     }
     Ok(jobs)
 }

--- a/rust/geometry/src/csg_capture.rs
+++ b/rust/geometry/src/csg_capture.rs
@@ -1,0 +1,161 @@
+//! CSG corpus capture — measurement-only, behind the off-by-default
+//! `csg_capture` feature (zero cost in production: the hooks compile to
+//! nothing when the feature is absent).
+//!
+//! Every real void cut funnels through exactly one of
+//! [`crate::kernel::mesh_bridge::subtract`] / `subtract_many`, so recording at
+//! that boundary captures the complete, dedup-by-construction CSG work corpus
+//! the pipeline actually performed on a model. The replay harness
+//! (`rust/processing/examples/csg_scaling_bench.rs`) drives the native pipeline
+//! once to populate this, then re-runs the captured jobs under scoped rayon
+//! pools to measure whether across-element exact CSG scales with cores.
+//!
+//! This exists to settle "rung 1" of the in-WASM shared-memory threading
+//! question (see `project_wasm_csg_speed_is_worker_throttle` memory): does the
+//! pure-Rust exact kernel scale with cores at all on native, before paying for
+//! a threaded wasm build to measure the wasm-specific taxes.
+
+use crate::mesh::Mesh;
+use std::sync::Mutex;
+
+/// One real CSG invocation captured from the pipeline. Holds owned copies of
+/// the exact inputs the kernel received, so the replay is faithful.
+#[derive(Clone)]
+pub enum CapturedCsgJob {
+    /// A single `host − cutter` (a single-opening element, or one step of a
+    /// sequential per-cutter fallback).
+    Single { host: Mesh, cutter: Mesh },
+    /// A batched `host − (∪ cutters)` (the disjoint-opening fast group).
+    Many { host: Mesh, cutters: Vec<Mesh> },
+}
+
+static CAPTURED: Mutex<Vec<CapturedCsgJob>> = Mutex::new(Vec::new());
+
+/// Record a single-pair subtract. Called from the kernel boundary.
+pub fn record_single(host: &Mesh, cutter: &Mesh) {
+    if let Ok(mut v) = CAPTURED.lock() {
+        v.push(CapturedCsgJob::Single { host: host.clone(), cutter: cutter.clone() });
+    }
+}
+
+/// Record a batched subtract. Called from the kernel boundary.
+pub fn record_many(host: &Mesh, cutters: &[&Mesh]) {
+    if let Ok(mut v) = CAPTURED.lock() {
+        v.push(CapturedCsgJob::Many {
+            host: host.clone(),
+            cutters: cutters.iter().map(|m| (*m).clone()).collect(),
+        });
+    }
+}
+
+/// Take everything captured so far, clearing the buffer.
+pub fn drain() -> Vec<CapturedCsgJob> {
+    CAPTURED.lock().map(|mut v| std::mem::take(&mut *v)).unwrap_or_default()
+}
+
+// --- Manual little-endian (de)serialization (Mesh has no serde) ---------------
+// Shared by the native dumper and the wasm replay harness so the format can't
+// drift. Format: u32 job_count, then per job: u8 tag (0=Single,1=Many),
+// mesh(host), [mesh(cutter) | u32 n + n×mesh(cutter)]. mesh = u32 pos_len +
+// f32×, u32 norm_len + f32×, u32 idx_len + u32×, u8 rtc_applied, f64×3 origin.
+
+fn push_mesh(out: &mut Vec<u8>, m: &Mesh) {
+    out.extend_from_slice(&(m.positions.len() as u32).to_le_bytes());
+    for v in &m.positions {
+        out.extend_from_slice(&v.to_le_bytes());
+    }
+    out.extend_from_slice(&(m.normals.len() as u32).to_le_bytes());
+    for v in &m.normals {
+        out.extend_from_slice(&v.to_le_bytes());
+    }
+    out.extend_from_slice(&(m.indices.len() as u32).to_le_bytes());
+    for v in &m.indices {
+        out.extend_from_slice(&v.to_le_bytes());
+    }
+    out.push(m.rtc_applied as u8);
+    for v in &m.origin {
+        out.extend_from_slice(&v.to_le_bytes());
+    }
+}
+
+/// Serialize a captured corpus to a self-describing little-endian blob.
+pub fn serialize(jobs: &[CapturedCsgJob]) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(&(jobs.len() as u32).to_le_bytes());
+    for j in jobs {
+        match j {
+            CapturedCsgJob::Single { host, cutter } => {
+                out.push(0);
+                push_mesh(&mut out, host);
+                push_mesh(&mut out, cutter);
+            }
+            CapturedCsgJob::Many { host, cutters } => {
+                out.push(1);
+                push_mesh(&mut out, host);
+                out.extend_from_slice(&(cutters.len() as u32).to_le_bytes());
+                for c in cutters {
+                    push_mesh(&mut out, c);
+                }
+            }
+        }
+    }
+    out
+}
+
+struct Reader<'a> {
+    b: &'a [u8],
+    p: usize,
+}
+impl<'a> Reader<'a> {
+    fn u32(&mut self) -> u32 {
+        let v = u32::from_le_bytes(self.b[self.p..self.p + 4].try_into().unwrap());
+        self.p += 4;
+        v
+    }
+    fn f32(&mut self) -> f32 {
+        let v = f32::from_le_bytes(self.b[self.p..self.p + 4].try_into().unwrap());
+        self.p += 4;
+        v
+    }
+    fn f64(&mut self) -> f64 {
+        let v = f64::from_le_bytes(self.b[self.p..self.p + 8].try_into().unwrap());
+        self.p += 8;
+        v
+    }
+    fn u8(&mut self) -> u8 {
+        let v = self.b[self.p];
+        self.p += 1;
+        v
+    }
+    fn mesh(&mut self) -> Mesh {
+        let n = self.u32() as usize;
+        let positions: Vec<f32> = (0..n).map(|_| self.f32()).collect();
+        let n = self.u32() as usize;
+        let normals: Vec<f32> = (0..n).map(|_| self.f32()).collect();
+        let n = self.u32() as usize;
+        let indices: Vec<u32> = (0..n).map(|_| self.u32()).collect();
+        let rtc_applied = self.u8() != 0;
+        let origin = [self.f64(), self.f64(), self.f64()];
+        Mesh { positions, normals, indices, rtc_applied, origin }
+    }
+}
+
+/// Deserialize a blob produced by [`serialize`].
+pub fn deserialize(blob: &[u8]) -> Vec<CapturedCsgJob> {
+    let mut r = Reader { b: blob, p: 0 };
+    let n = r.u32() as usize;
+    let mut jobs = Vec::with_capacity(n);
+    for _ in 0..n {
+        let tag = r.u8();
+        let host = r.mesh();
+        if tag == 0 {
+            let cutter = r.mesh();
+            jobs.push(CapturedCsgJob::Single { host, cutter });
+        } else {
+            let nc = r.u32() as usize;
+            let cutters: Vec<Mesh> = (0..nc).map(|_| r.mesh()).collect();
+            jobs.push(CapturedCsgJob::Many { host, cutters });
+        }
+    }
+    jobs
+}

--- a/rust/geometry/src/csg_capture.rs
+++ b/rust/geometry/src/csg_capture.rs
@@ -139,55 +139,56 @@ struct Reader<'a> {
     p: usize,
 }
 impl<'a> Reader<'a> {
-    fn u32(&mut self) -> u32 {
-        let v = u32::from_le_bytes(self.b[self.p..self.p + 4].try_into().unwrap());
-        self.p += 4;
-        v
+    /// Bounds-checked slice advance; `None` on underflow (truncated blob).
+    fn take(&mut self, n: usize) -> Option<&'a [u8]> {
+        let s = self.b.get(self.p..self.p.checked_add(n)?)?;
+        self.p += n;
+        Some(s)
     }
-    fn f32(&mut self) -> f32 {
-        let v = f32::from_le_bytes(self.b[self.p..self.p + 4].try_into().unwrap());
-        self.p += 4;
-        v
+    fn u32(&mut self) -> Option<u32> {
+        Some(u32::from_le_bytes(self.take(4)?.try_into().ok()?))
     }
-    fn f64(&mut self) -> f64 {
-        let v = f64::from_le_bytes(self.b[self.p..self.p + 8].try_into().unwrap());
-        self.p += 8;
-        v
+    fn f32(&mut self) -> Option<f32> {
+        Some(f32::from_le_bytes(self.take(4)?.try_into().ok()?))
     }
-    fn u8(&mut self) -> u8 {
-        let v = self.b[self.p];
-        self.p += 1;
-        v
+    fn f64(&mut self) -> Option<f64> {
+        Some(f64::from_le_bytes(self.take(8)?.try_into().ok()?))
     }
-    fn mesh(&mut self) -> Mesh {
-        let n = self.u32() as usize;
-        let positions: Vec<f32> = (0..n).map(|_| self.f32()).collect();
-        let n = self.u32() as usize;
-        let normals: Vec<f32> = (0..n).map(|_| self.f32()).collect();
-        let n = self.u32() as usize;
-        let indices: Vec<u32> = (0..n).map(|_| self.u32()).collect();
-        let rtc_applied = self.u8() != 0;
-        let origin = [self.f64(), self.f64(), self.f64()];
-        Mesh { positions, normals, indices, rtc_applied, origin }
+    fn u8(&mut self) -> Option<u8> {
+        Some(self.take(1)?[0])
+    }
+    fn mesh(&mut self) -> Option<Mesh> {
+        let n = self.u32()? as usize;
+        let positions: Vec<f32> = (0..n).map(|_| self.f32()).collect::<Option<_>>()?;
+        let n = self.u32()? as usize;
+        let normals: Vec<f32> = (0..n).map(|_| self.f32()).collect::<Option<_>>()?;
+        let n = self.u32()? as usize;
+        let indices: Vec<u32> = (0..n).map(|_| self.u32()).collect::<Option<_>>()?;
+        let rtc_applied = self.u8()? != 0;
+        let origin = [self.f64()?, self.f64()?, self.f64()?];
+        Some(Mesh { positions, normals, indices, rtc_applied, origin })
     }
 }
 
-/// Deserialize a blob produced by [`serialize`].
-pub fn deserialize(blob: &[u8]) -> Vec<CapturedCsgJob> {
+/// Deserialize a blob produced by [`serialize`]. Returns `Err` on a truncated or
+/// malformed blob instead of panicking — the wasm bench path must not trap.
+pub fn deserialize(blob: &[u8]) -> Result<Vec<CapturedCsgJob>, &'static str> {
     let mut r = Reader { b: blob, p: 0 };
-    let n = r.u32() as usize;
-    let mut jobs = Vec::with_capacity(n);
+    let n = r.u32().ok_or("truncated blob: missing job count")? as usize;
+    // Cap the pre-allocation: a malformed count must not request gigabytes.
+    let mut jobs = Vec::with_capacity(n.min(blob.len()));
     for _ in 0..n {
-        let tag = r.u8();
-        let host = r.mesh();
+        let tag = r.u8().ok_or("truncated blob: missing tag")?;
+        let host = r.mesh().ok_or("truncated blob: bad host mesh")?;
         if tag == 0 {
-            let cutter = r.mesh();
+            let cutter = r.mesh().ok_or("truncated blob: bad cutter mesh")?;
             jobs.push(CapturedCsgJob::Single { host, cutter });
         } else {
-            let nc = r.u32() as usize;
-            let cutters: Vec<Mesh> = (0..nc).map(|_| r.mesh()).collect();
+            let nc = r.u32().ok_or("truncated blob: missing cutter count")? as usize;
+            let cutters: Vec<Mesh> =
+                (0..nc).map(|_| r.mesh()).collect::<Option<_>>().ok_or("truncated blob: bad cutter mesh")?;
             jobs.push(CapturedCsgJob::Many { host, cutters });
         }
     }
-    jobs
+    Ok(jobs)
 }

--- a/rust/geometry/src/kernel/mesh_bridge.rs
+++ b/rust/geometry/src/kernel/mesh_bridge.rs
@@ -344,6 +344,8 @@ fn exact_on_plane_weld(v: [f64; 3], t0: [f64; 3], t1: [f64; 3], t2: [f64; 3]) ->
 
 /// `host − cutter` as a `Mesh`.
 pub fn subtract(host: &Mesh, cutter: &Mesh) -> Mesh {
+    #[cfg(feature = "csg_capture")]
+    crate::csg_capture::record_single(host, cutter);
     let h = orient_outward(mesh_to_tris(host));
     let mut c = mesh_to_tris(cutter);
     promote_cutter_verts_onto_host_faces(&mut c, &h);
@@ -365,6 +367,8 @@ pub fn subtract(host: &Mesh, cutter: &Mesh) -> Mesh {
 /// constraint — see [`difference_all`]); the caller must fall back to
 /// sequential per-cutter subtraction.
 pub fn subtract_many(host: &Mesh, cutters: &[&Mesh]) -> Option<Mesh> {
+    #[cfg(feature = "csg_capture")]
+    crate::csg_capture::record_many(host, cutters);
     let h = orient_outward(mesh_to_tris(host));
     let comp_tris: Vec<Vec<Tri>> = cutters
         .iter()

--- a/rust/geometry/src/lib.rs
+++ b/rust/geometry/src/lib.rs
@@ -74,6 +74,9 @@ pub mod bool2d;
 /// min-angle refinement. Backs the quality triangulators in `triangulation`.
 mod cdt;
 pub mod csg;
+/// Measurement-only CSG corpus capture (off-by-default `csg_capture` feature).
+#[cfg(feature = "csg_capture")]
+pub mod csg_capture;
 /// Deterministic near-coplanar facet weld for faceted-BREP host meshes.
 /// Corrects f32 import jitter (~0.09°) so authored-coplanar roof slope facets
 /// are EXACTLY coplanar before the exact-kernel opening cut (issue #1007).

--- a/rust/processing/Cargo.toml
+++ b/rust/processing/Cargo.toml
@@ -14,6 +14,16 @@ keywords = ["ifc", "bim", "geometry", "pipeline", "aec"]
 categories = ["parsing", "algorithms"]
 readme = "../../README.md"
 
+[features]
+# Measurement-only: enable the geometry crate's CSG corpus capture so the
+# `csg_scaling_bench` example can replay real void-cut jobs. See
+# rust/processing/examples/csg_scaling_bench.rs.
+csg-capture = ["ifc-lite-geometry/csg_capture"]
+
+[[example]]
+name = "csg_scaling_bench"
+required-features = ["csg-capture"]
+
 [dependencies]
 ifc-lite-core = { version = "4.1.0", path = "../core" }
 # CSG runs on the pure-Rust exact kernel inside ifc-lite-geometry on every

--- a/rust/processing/examples/csg_scaling_bench.rs
+++ b/rust/processing/examples/csg_scaling_bench.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Rung-1 native CSG core-scaling microbench.
 //!
 //! Question it answers: does across-element exact CSG (void cutting) scale with
@@ -77,7 +81,9 @@ fn main() {
     // --- Phase 1: capture the real CSG corpus (untimed) ---
     println!("\n[capture] driving native pipeline once to record real void-cut jobs…");
     let cap_t = Instant::now();
+    ifc_lite_geometry::csg_capture::set_enabled(true);
     let _ = process_geometry(&content);
+    ifc_lite_geometry::csg_capture::set_enabled(false);
     let cap_ms = cap_t.elapsed().as_millis();
     let jobs = drain();
 

--- a/rust/processing/examples/csg_scaling_bench.rs
+++ b/rust/processing/examples/csg_scaling_bench.rs
@@ -1,0 +1,174 @@
+//! Rung-1 native CSG core-scaling microbench.
+//!
+//! Question it answers: does across-element exact CSG (void cutting) scale with
+//! CPU cores on native? This isolates the CSG subtract from decode/parse/extrude
+//! — the §12 single-controller post-mortem found the pipeline DECODE-dominated,
+//! but it measured the cheap BSP kernel a month before the pure-Rust exact
+//! kernel landed. If this rung shows the exact kernel scales, the wasm-threaded
+//! build (rung 2) is worth measuring; if it doesn't even scale natively, stop.
+//!
+//! Method (no synthetic data — the corpus is REAL):
+//!   1. Drive the native pipeline once on a real IFC model. The `csg_capture`
+//!      feature records the (host, cutters) of every kernel subtract.
+//!   2. Drain that corpus. Decode/parse/extrude are now OUT of the timed path.
+//!   3. Replay the corpus through the production CSG path (`ClippingProcessor`)
+//!      under scoped rayon pools of 1, 2, 4, 8, … threads.
+//!   4. Report wall time, speedup, efficiency, and verify byte-identical output
+//!      work across thread counts (the kernel is order-independent).
+//!
+//! Run:
+//!   cargo run --release -p ifc-lite-processing \
+//!     --example csg_scaling_bench --features csg-capture \
+//!     -- tests/models/ara3d/C20-Institute-Var-2.ifc
+//!   (or set CSG_BENCH_FIXTURE / CSG_BENCH_ITERS)
+
+use ifc_lite_geometry::csg::ClippingProcessor;
+use ifc_lite_geometry::csg_capture::{drain, CapturedCsgJob};
+use ifc_lite_geometry::mesh::Mesh;
+use ifc_lite_processing::process_geometry;
+use rayon::prelude::*;
+use std::time::Instant;
+
+/// Replay ONE captured job through the production CSG path. Returns the output
+/// triangle-index count — a deterministic fingerprint of the work performed.
+fn replay(job: &CapturedCsgJob) -> usize {
+    let csg = ClippingProcessor::new();
+    match job {
+        CapturedCsgJob::Single { host, cutter } => {
+            csg.subtract_mesh(host, cutter).map(|m| m.indices.len()).unwrap_or(0)
+        }
+        CapturedCsgJob::Many { host, cutters } => {
+            let refs: Vec<&Mesh> = cutters.iter().collect();
+            csg.subtract_mesh_many(host, &refs).map(|m| m.indices.len()).unwrap_or(0)
+        }
+    }
+}
+
+fn run_pool(jobs: &[CapturedCsgJob], threads: usize) -> (u128, usize) {
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(threads)
+        .build()
+        .expect("build rayon pool");
+    let t = Instant::now();
+    let fingerprint = pool.install(|| jobs.par_iter().map(replay).sum::<usize>());
+    (t.elapsed().as_micros(), fingerprint)
+}
+
+fn main() {
+    let fixture = std::env::args()
+        .nth(1)
+        .or_else(|| std::env::var("CSG_BENCH_FIXTURE").ok())
+        .unwrap_or_else(|| "tests/models/ara3d/C20-Institute-Var-2.ifc".to_string());
+    let iters: usize = std::env::var("CSG_BENCH_ITERS").ok().and_then(|s| s.parse().ok()).unwrap_or(4);
+
+    let content = match std::fs::read_to_string(&fixture) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("skip: cannot read fixture {fixture}: {e}");
+            eprintln!("      (run `pnpm fixtures` or pass a path / CSG_BENCH_FIXTURE)");
+            return;
+        }
+    };
+
+    let max_threads = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(8);
+    println!("fixture: {fixture} ({:.1} MB)", content.len() as f64 / 1e6);
+    println!("host cores (available_parallelism): {max_threads}");
+
+    // --- Phase 1: capture the real CSG corpus (untimed) ---
+    println!("\n[capture] driving native pipeline once to record real void-cut jobs…");
+    let cap_t = Instant::now();
+    let _ = process_geometry(&content);
+    let cap_ms = cap_t.elapsed().as_millis();
+    let jobs = drain();
+
+    if jobs.is_empty() {
+        eprintln!("skip: 0 CSG jobs captured — this model has no void cuts. Try a model with openings.");
+        return;
+    }
+
+    // Corpus stats.
+    let (mut n_single, mut n_many, mut n_cutters, mut host_tris, mut cutter_tris) = (0usize, 0usize, 0usize, 0usize, 0usize);
+    for j in &jobs {
+        match j {
+            CapturedCsgJob::Single { host, cutter } => {
+                n_single += 1;
+                n_cutters += 1;
+                host_tris += host.indices.len() / 3;
+                cutter_tris += cutter.indices.len() / 3;
+            }
+            CapturedCsgJob::Many { host, cutters } => {
+                n_many += 1;
+                n_cutters += cutters.len();
+                host_tris += host.indices.len() / 3;
+                cutter_tris += cutters.iter().map(|c| c.indices.len() / 3).sum::<usize>();
+            }
+        }
+    }
+    let working_set_mb = jobs.iter().map(|j| match j {
+        CapturedCsgJob::Single { host, cutter } => mesh_bytes(host) + mesh_bytes(cutter),
+        CapturedCsgJob::Many { host, cutters } => mesh_bytes(host) + cutters.iter().map(mesh_bytes).sum::<usize>(),
+    }).sum::<usize>() as f64 / 1e6;
+
+    println!("[capture] full pipeline ran in {cap_ms} ms (incl. parse+decode+extrude+CSG)");
+
+    // Optional: dump the real corpus to a blob for the in-browser (rung 2) replay.
+    if let Ok(path) = std::env::var("CSG_BENCH_DUMP") {
+        let blob = ifc_lite_geometry::csg_capture::serialize(&jobs);
+        match std::fs::write(&path, &blob) {
+            Ok(()) => println!("[dump] wrote {} jobs -> {path} ({:.1} MB)", jobs.len(), blob.len() as f64 / 1e6),
+            Err(e) => eprintln!("[dump] failed to write {path}: {e}"),
+        }
+    }
+    println!("\n=== CSG corpus (the timed working set, decode EXCLUDED) ===");
+    println!("  jobs:            {} ({} batched 'many', {} single)", jobs.len(), n_many, n_single);
+    println!("  total cutters:   {n_cutters}");
+    println!("  host triangles:  {host_tris}");
+    println!("  cutter triangles:{cutter_tris}");
+    println!("  input working set: {working_set_mb:.1} MB  (L2/L3 cache caveat: a small set understates the memory cost wasm's imported-memory tax would expose)");
+
+    // --- Phase 2: warm up + serial baseline ---
+    println!("\n[warmup] one untimed serial pass…");
+    let (_, baseline_fp) = run_pool(&jobs, 1);
+
+    // --- Phase 3: thread sweep ---
+    let mut thread_counts: Vec<usize> = vec![1, 2, 4, 8, max_threads];
+    thread_counts.retain(|&n| n <= max_threads);
+    thread_counts.sort_unstable();
+    thread_counts.dedup();
+
+    println!("\n=== scaling sweep ({iters} timed iters each, reporting MIN wall) ===");
+    println!("{:>8} | {:>11} | {:>8} | {:>10} | {}", "threads", "min ms", "speedup", "efficiency", "parity");
+
+    let mut serial_ms: Option<f64> = None;
+    for &n in &thread_counts {
+        // one untimed warmup at this thread count
+        let _ = run_pool(&jobs, n);
+        let mut best = u128::MAX;
+        let mut ok = true;
+        for _ in 0..iters {
+            let (us, fp) = run_pool(&jobs, n);
+            if fp != baseline_fp {
+                ok = false;
+            }
+            best = best.min(us);
+        }
+        let ms = best as f64 / 1000.0;
+        if n == 1 {
+            serial_ms = Some(ms);
+        }
+        let speedup = serial_ms.map(|s| s / ms).unwrap_or(1.0);
+        let eff = speedup / n as f64 * 100.0;
+        println!(
+            "{:>8} | {:>11.1} | {:>7.2}x | {:>9.0}% | {}",
+            n, ms, speedup, eff, if ok { "ok" } else { "MISMATCH!" }
+        );
+    }
+
+    println!("\nReading: efficiency near 100% at high thread counts ⇒ exact CSG is core-scalable ⇒");
+    println!("rung 2 (wasm-threaded build) is worth measuring. Efficiency collapsing toward 1/N ⇒");
+    println!("the work is memory/bandwidth-bound even on native ⇒ wasm threading will not help. Gate: >=2x at max threads.");
+}
+
+fn mesh_bytes(m: &Mesh) -> usize {
+    m.positions.len() * 4 + m.normals.len() * 4 + m.indices.len() * 4
+}

--- a/rust/wasm-bindings/Cargo.toml
+++ b/rust/wasm-bindings/Cargo.toml
@@ -19,8 +19,15 @@ crate-type = ["cdylib", "rlib"]
 [features]
 default = ["console_error_panic_hook"]
 debug_geometry = ["ifc-lite-geometry/debug_geometry"]
+# Threaded WASM bundle: in-instance rayon pool via wasm-bindgen-rayon. Built
+# separately with atomics/shared-memory flags (build-wasm.sh BUILD_THREADED=1).
+# Off by default — the default bundle stays single-threaded.
+threads = ["dep:wasm-bindgen-rayon"]
 
 [dependencies]
+# Optional: only compiled for the threaded bundle (--features threads). Needs
+# the atomics/shared-memory target-features to build, so it must stay optional.
+wasm-bindgen-rayon = { version = "1.3.0", optional = true }
 console_error_panic_hook = { version = "0.1", optional = true }
 futures-util = "0.3"
 # gloo-timers removed — sync processing for speed

--- a/rust/wasm-bindings/src/lib.rs
+++ b/rust/wasm-bindings/src/lib.rs
@@ -51,6 +51,14 @@ use wasm_bindgen::prelude::*;
 #[cfg(feature = "console_error_panic_hook")]
 pub use console_error_panic_hook::set_once as set_panic_hook;
 
+// Threaded build (off by default): exposes `initThreadPool(n)` to JS and makes
+// the geometry crate's `par_iter` element loops parallel in WASM. Built as a
+// SEPARATE bundle (atomics/shared-memory flags) via `build-wasm.sh BUILD_THREADED=1`;
+// requires cross-origin isolation at runtime. See
+// docs/architecture/csg-threading-design.md.
+#[cfg(feature = "threads")]
+pub use wasm_bindgen_rayon::init_thread_pool;
+
 mod api;
 mod utils;
 mod zero_copy;

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -169,6 +169,8 @@ if [ "${BUILD_THREADED:-}" = "1" ]; then
       echo "🧵 ✅ threaded bundle imports shared memory"
     else
       echo "🧵 ❌ threaded bundle does NOT import shared memory — build flags wrong"
+      echo "   Refusing to ship a non-functional threaded bundle."
+      exit 1
     fi
   fi
   ls -lh "$THREADED_WASM" | awk '{print "   Threaded WASM: " $5 " (no budget — not the default bundle)"}'

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -120,5 +120,59 @@ else
   echo "   ⚠️  Over $TARGET_LABEL target ($(($WASM_SIZE / 1024))KB)"
 fi
 
+# --- Optional second bundle: threaded (atomics + shared memory) -------------
+# Off by default. Enable with `BUILD_THREADED=1 ./scripts/build-wasm.sh`.
+# This is a SEPARATE bundle selected at runtime via wasm-feature-detect +
+# crossOriginIsolated (Safari lacks credentialless threads → it loads the
+# single-thread bundle above). See docs/architecture/csg-threading-design.md.
+if [ "${BUILD_THREADED:-}" = "1" ]; then
+  THREADED_OUT="../../packages/wasm/pkg-threaded"
+  echo ""
+  echo "🧵 Building threaded bundle → $THREADED_OUT (atomics/shared-memory + wasm-bindgen-rayon)"
+
+  # The exact flag set validated on spike/path-b-respike (8fcaff96). RUSTFLAGS
+  # fully replaces .cargo/config.toml's target rustflags, so the base flags
+  # (max-memory, stack-size, simd128) are repeated here. build-std stays in
+  # .cargo/config.toml [unstable] and rebuilds std WITH atomics.
+  RUSTFLAGS="-C link-arg=--max-memory=4294967296 -C link-arg=-zstack-size=8388608 -C target-feature=+simd128,+atomics,+bulk-memory,+mutable-globals -C link-arg=--shared-memory -C link-arg=--import-memory -C link-arg=--export=__wasm_init_tls -C link-arg=--export=__tls_size -C link-arg=--export=__tls_align -C link-arg=--export=__tls_base" \
+  rustup run nightly-2025-11-15 "$WASM_PACK" build rust/wasm-bindings \
+    --target web \
+    --out-dir "$THREADED_OUT" \
+    --out-name ifc-lite \
+    --release \
+    -- --features threads
+
+  # Patch wasm-bindgen-rayon's worker bootstrap: it does `import('../../..')`
+  # (the package DIRECTORY), which only resolves under a bundler. Vite resolves
+  # it, but on a raw static server the helper worker dies silently and
+  # initThreadPool hangs forever. Point at the explicit module file so the
+  # bundle also works unbundled. (Harmless under Vite.)
+  THREADED_REL="$(echo "$THREADED_OUT" | sed 's|^../../||')"
+  WH="$(ls "$THREADED_REL"/snippets/wasm-bindgen-rayon-*/src/workerHelpers.js 2>/dev/null || true)"
+  if [ -n "$WH" ] && [ -f "$WH" ]; then
+    perl -0pi -e "s#await import\('\.\./\.\./\.\.'\)#await import('../../../ifc-lite.js')#" "$WH"
+    echo "🧵 patched wasm-bindgen-rayon directory import in $WH"
+  else
+    echo "⚠️  threaded build: workerHelpers.js not found to patch (check $THREADED_REL/snippets)"
+  fi
+
+  # Strip platform-variant trampoline indices from the threaded .d.ts too.
+  THREADED_DTS="$THREADED_REL/ifc-lite.d.ts"
+  if [ -f "$THREADED_DTS" ]; then
+    grep -v '__wasm_bindgen_func_elem_' "$THREADED_DTS" > "$THREADED_DTS.tmp" && mv "$THREADED_DTS.tmp" "$THREADED_DTS"
+  fi
+
+  # Verify it really imports shared memory (the litmus test).
+  THREADED_WASM="$THREADED_REL/ifc-lite_bg.wasm"
+  if command -v wasm-objdump >/dev/null 2>&1; then
+    if wasm-objdump -j Import -x "$THREADED_WASM" 2>/dev/null | grep -qi 'memory.*shared'; then
+      echo "🧵 ✅ threaded bundle imports shared memory"
+    else
+      echo "🧵 ❌ threaded bundle does NOT import shared memory — build flags wrong"
+    fi
+  fi
+  ls -lh "$THREADED_WASM" | awk '{print "   Threaded WASM: " $5 " (no budget — not the default bundle)"}'
+fi
+
 echo ""
 echo "✨ Build complete!"


### PR DESCRIPTION
## Summary

Threading the pure-Rust exact CSG kernel in a **shared-memory WASM bundle** is a real win — and this re-opens a lever the shelved single-controller design (`single-controller-rayon-design.md` §12) wrote off. That verdict found a **4× regression** and was correct *for its time*: it was measured in May 2026 on the BSP/decode-dominated pipeline, a month before the pure-Rust exact kernel (#1024) inverted the workload. CSG is now dominant, compute-bound, and cache-resident — the shape WASM threads win on.

Validated by direct measurement (10-core Apple Silicon), not theory:

| Layer | Result |
|---|---|
| **Rung 1** — native CSG core-scaling | 95–99% @2 cores, 83–96% @4 across 6 real models |
| **Rung 2** — threaded-WASM CSG (real captured corpus) | **2.9–4.2× @8 threads** vs current single-thread; output byte-identical |
| Atomics tax | **~0%** (plain-serial 13,683 vs threaded-serial 13,638 ms — the kernel barely touches memory) |
| **End-to-end** — full pipeline threaded (naive whole-batch) | ISSUE_068 **1.90×**, advanced_model **1.60×** — positive, no regression |

The gap between end-to-end (1.9×) and the pure-CSG ceiling (4.19×) is the serial parse/prepass + memory-bound decode — the surgical "thread only the CSG element loop, keep decode serial" recovers toward the ceiling (Amdahl ≈ 2.5–3× cold-load on void-heavy models). Full write-up + repro in `docs/architecture/csg-threading-design.md`.

## What's in this PR (all off-by-default; **no default-runtime behavior change**)

- **`rust/wasm-bindings`** — `threads` feature (optional `wasm-bindgen-rayon`, re-exports `initThreadPool`). The default single-thread bundle is untouched.
- **`scripts/build-wasm.sh`** — `BUILD_THREADED=1` builds a second `packages/wasm/pkg-threaded` bundle (the validated spike flags), patches `wasm-bindgen-rayon`'s directory-import bug (only resolves under a bundler), and verifies the shared-memory import. Verified: the full `IfcAPI` compiles threaded and imports shared memory.
- **`rust/geometry`** — `csg_capture` feature + corpus (de)serialization (measurement only; compiles to nothing when absent).
- **`rust/processing`** — `csg-capture` feature + `csg_scaling_bench` example (native rung-1 bench).
- **`rust/csg-thread-bench`** — detached measurement crate + browser harness (rung-2 replay). Build artifacts (wasm output, copied IFC fixtures, corpus blobs) are gitignored.

## Not included / follow-ups
- The viewer runtime bundle-select (`wasm-feature-detect` + `crossOriginIsolated`; Safari → plain bundle) and the surgical CSG-only single-controller — separate PRs.
- No changeset: this is Rust/build/docs only with no `@ifc-lite/*` TS-package behavior change. Happy to add one if the release gate wants it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a browser-based CSG benchmarking runner supporting pipeline execution or captured-corpus replay, with an optional threaded mode that initializes the WASM thread pool when available.
  * Added a native CSG scaling microbench to measure multi-core scaling.
* **Documentation**
  * Published a validated Threaded-WASM CSG design/evidence document with benchmark results and deployment guidance.
* **Chores**
  * Introduced measurement-only CSG capture/replay to support repeatable benchmarks, expanded WASM threading build support, added a safer benchmark web server (COOP/COEP + path traversal protection), and updated `.gitignore` for new benchmark/bundle outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->