### PR TITLE
fix(viewer): SPA fallback rewrite so deep links don't hit Vercel NOT_FOUND

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -20,6 +20,10 @@
     {
       "source": "/mcp/:path*",
       "destination": "/index.html"
+    },
+    {
+      "source": "/((?!.*\\.).*)",
+      "destination": "/index.html"
     }
   ],
   "headers": [


### PR DESCRIPTION
## Problem (reproduced on production)

Any path that isn't `/`, `/mcp[/...]`, or an existing static file returns Vercel's raw **`NOT_FOUND`** page — there's no SPA fallback. Confirmed via the Vercel MCP against the live production deployment:

```
GET https://ifc-lite-…-ltplus.vercel.app/this/path/does/not/exist
→ 404  x-vercel-error: NOT_FOUND   (iad1::… — same shape as the reported fra1:: 404)
```

So a client-side navigation, a refresh on a deep link, or a shared URL 404s instead of loading the app. (Verified the #1251 Skew Protection is *active* in production — the live HTML carries a substituted `dpl_…` pin — so this full-page `NOT_FOUND` is a routing 404, distinct from the stale-WASM asset issue.)

## Fix

Add an SPA catch-all rewrite to `index.html`, **scoped with a negative lookahead that excludes dotted paths** (`/assets/*.js`, `*.wasm`, `*.css`, `favicon.ico`, `manifest.json`, …):

```json
{ "source": "/((?!.*\\.).*)", "destination": "/index.html" }
```

Why excluded, not a blanket `/(.*)`: a blanket catch-all would serve **HTML for a stale/deleted content-hashed asset**, breaking `WebAssembly.compile` ("HTTP status code is not ok") and defeating the Skew Protection (#1251) that pins a session to its deployment. Excluding extensions keeps asset 404s clean while giving navigation paths the SPA.

- Rewrites run **after** the filesystem check, so existing assets are served directly and unaffected.
- The `/api/*` and `/mcp*` rules are listed first, so they still match first.
- Mirrors the catch-all `apps/viewer-embed/vercel.json` already ships.

The Vercel preview on this PR will validate the regex compiles and that deep links now load the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to improve single-page application routing behavior, ensuring proper handling of navigation requests across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->