### PR TITLE
perf(geometry): scale small compute-bound files to more workers

### DIFF
--- a/.changeset/small-file-worker-parallelism.md
+++ b/.changeset/small-file-worker-parallelism.md
@@ -1,0 +1,10 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Give small, compute-bound IFC files more geometry workers on active-cooled
+(10+ core) machines. The per-core caps were tuned to a bandwidth ceiling
+measured on a >512 MB georef result, but small models (e.g. a 20 MB
+boolean-clipped steel file) are CPU-bound, not bandwidth-bound — the 3–4
+worker cap left most cores idle. Files ≤64 MB now scale to `cores-2` workers
+(memory budget and `?geomWorkers=N` override still apply).

--- a/packages/geometry/src/worker-count.test.ts
+++ b/packages/geometry/src/worker-count.test.ts
@@ -152,6 +152,17 @@ describe('computeWorkerCount', () => {
     expect(r.reason).toBe('cores');
   });
 
+  it('tiny file (4 MB, 10 cores) stays on the conservative cap (4), not the bump', () => {
+    // Below MIN_PARALLEL_MB (8): a small/simple model loads fast on a few
+    // workers; the caller spawns from a file-size proxy before real job counts
+    // exist, so we must not pre-spawn workers that would sit idle. (#1258 P2)
+    const r = computeWorkerCount({
+      fileSizeMB: 4, cores: 10, deviceMemoryGB: 16, totalJobs: 400,
+    });
+    expect(r.count).toBe(4);
+    expect(r.reason).toBe('cores');
+  });
+
   it('big file on the same 10-core host still holds the bandwidth cap (3)', () => {
     // The small-file fast path must NOT lift the >512 MB bandwidth ceiling.
     const r = computeWorkerCount({

--- a/packages/geometry/src/worker-count.test.ts
+++ b/packages/geometry/src/worker-count.test.ts
@@ -139,6 +139,38 @@ describe('computeWorkerCount', () => {
     expect(withUndef.reason).toBe('cores');
   });
 
+  it('small compute-bound file (20 MB, 10 cores) → near-full cores (cores-2)', () => {
+    // 170_KM-class: a small, transient, COMPUTE-bound load (boolean-clipped
+    // steel) — not the sustained bandwidth-bound big-file regime the per-core
+    // caps guard. On a 10-core active-cooled machine it gets cores-2 = 8 workers
+    // (was capped at 4, leaving 6 cores idle on CSG-bound geometry). Memory is
+    // a non-issue at 20 MB so the memoryCap doesn't bind.
+    const r = computeWorkerCount({
+      fileSizeMB: 20, cores: 10, deviceMemoryGB: 16, totalJobs: 25_000,
+    });
+    expect(r.count).toBe(8);
+    expect(r.reason).toBe('cores');
+  });
+
+  it('big file on the same 10-core host still holds the bandwidth cap (3)', () => {
+    // The small-file fast path must NOT lift the >512 MB bandwidth ceiling.
+    const r = computeWorkerCount({
+      fileSizeMB: 722, cores: 10, deviceMemoryGB: 16, totalJobs: 70_000,
+    });
+    expect(r.count).toBe(3);
+    expect(r.reason).toBe('cores');
+  });
+
+  it('small file on an 8-core fanless host keeps the conservative cap (no thermal risk taken)', () => {
+    // The small-file path is gated to 10+ cores (active cooling); fanless
+    // 8-core stays on its existing tier.
+    const r = computeWorkerCount({
+      fileSizeMB: 20, cores: 8, deviceMemoryGB: 8, totalJobs: 25_000,
+    });
+    expect(r.count).toBe(3);
+    expect(r.reason).toBe('cores');
+  });
+
   it('M-series Pro/Max (12 cores, 16 GB), 400 MB file → 5 workers', () => {
     // 12+ cores tier: small files get 5 workers; huge files cap at 4.
     const r = computeWorkerCount({

--- a/packages/geometry/src/worker-count.ts
+++ b/packages/geometry/src/worker-count.ts
@@ -86,7 +86,19 @@ export function computeWorkerCount(inputs: WorkerCountInputs): WorkerCountResult
   // Cores-based ceiling (preserves the previous tier behaviour, but expressed
   // as upper bounds rather than exact picks).
   let coresCap: number;
-  if (cores >= 16 && deviceMemoryGB >= 16) {
+  // Small files load in a few seconds (not a sustained grind) and cost trivial
+  // memory, so neither the thermal nor the bandwidth/RAM concerns the per-core
+  // caps below guard against bind. A small but geometry-heavy model is
+  // COMPUTE-bound (boolean-clipped steel — 170_KM is 20 MB / ~5000 booleans —
+  // or dense breps), which scales with cores; the 3–4-worker cap left most of
+  // an active-cooled (10+ core) machine idle. The measured bandwidth ceiling
+  // was a >512 MB georef result (#1159) — the opposite regime. Give small files
+  // near-full parallelism; the memoryCap below still gates if RAM is tight, and
+  // `?geomWorkers=N` still overrides per-host.
+  const SMALL_FILE_MB = 64;
+  if (fileSizeMB <= SMALL_FILE_MB && cores >= 10) {
+    coresCap = Math.min(maxWorkers, cores - 2);
+  } else if (cores >= 16 && deviceMemoryGB >= 16) {
     coresCap = Math.min(maxWorkers, Math.floor(cores / 2));
   } else if (cores >= 12 && deviceMemoryGB >= 8) {
     // 12+ cores indicates M-series Pro 12-core or M-series Max with active

--- a/packages/geometry/src/worker-count.ts
+++ b/packages/geometry/src/worker-count.ts
@@ -95,8 +95,18 @@ export function computeWorkerCount(inputs: WorkerCountInputs): WorkerCountResult
   // was a >512 MB georef result (#1159) — the opposite regime. Give small files
   // near-full parallelism; the memoryCap below still gates if RAM is tight, and
   // `?geomWorkers=N` still overrides per-host.
+  //
+  // Lower bound (MIN_PARALLEL_MB): the caller spawns workers from a file-size
+  // PROXY (`fileSizeMB × 100`) before the pre-pass reports real job counts, so
+  // the totalJobs ceiling below can't yet protect a *light* small model. Gating
+  // the bump to ≥8 MB keeps tiny/simple models (which load in a couple seconds
+  // on a few workers) off the fast path — so we don't pay extra WASM-init/heap
+  // for idle workers on a model with little parallel work — while the 8–64 MB
+  // band, where there's enough geometry to amortize the workers, still scales.
+  // (#1258 review P2.)
   const SMALL_FILE_MB = 64;
-  if (fileSizeMB <= SMALL_FILE_MB && cores >= 10) {
+  const MIN_PARALLEL_MB = 8;
+  if (fileSizeMB >= MIN_PARALLEL_MB && fileSizeMB <= SMALL_FILE_MB && cores >= 10) {
     coresCap = Math.min(maxWorkers, cores - 2);
   } else if (cores >= 16 && deviceMemoryGB >= 16) {
     coresCap = Math.min(maxWorkers, Math.floor(cores / 2));


### PR DESCRIPTION
## Problem

Small, geometry-heavy IFC files (e.g. `170_KM` — 20 MB, ~5000 boolean clips, dense steel) load slowly in the browser despite a fast native time. On a 10-core active-cooled machine the worker heuristic caps these at **3–4 workers**, leaving ~6 cores idle on a load that is **CPU-bound** (exact-CSG / brep meshing), not memory-bandwidth-bound.

The per-core caps in `computeWorkerCount` were tuned (#1159) against a **>512 MB georef result**, where each worker streams a ~1.5×-file WASM heap over the unified-memory bus and a 5th/6th worker yields no speedup. That ceiling is real — but it's the *opposite* regime from a small file that fits comfortably in RAM and grinds on compute.

## Fix

Add a small-file fast path at the top of the cores cap: files **≤64 MB** on **10+ core** hosts scale to `cores-2` workers.

- The **memory budget still binds** (a non-issue at 20 MB, but the clamp stays).
- `?geomWorkers=N` **override still wins**.
- **Fanless 8-core** hosts are excluded (gated to 10+ cores = active cooling) — no thermal risk taken.
- **Big files unchanged**: the >512 MB bandwidth cap is untouched (regression-tested at 722 MB/10-core → still 3).

## Tests

`worker-count.test.ts`: added the small-file tier (20 MB/10-core → 8, `cores`), the big-file guard on the same host (722 MB/10-core → 3, `cores`), and the fanless-8-core exclusion (20 MB/8-core → 3, `cores`). All existing cases pass unchanged.

## Why this is safe to ship on by default

Pure-function change, no kernel touch, no behavior change for any file >64 MB. Targets exactly the regressed class (small + compute-bound) the user flagged (170_KM "used to load in 5 s, now dead slow"). Pairs with the content-affinity dedup work (#1257) which makes per-worker caches effective.