### PR TITLE
fix(viewer): self-heal blank page when a deploy-window asset 404s

### DIFF
--- a/apps/viewer/index.html
+++ b/apps/viewer/index.html
@@ -70,23 +70,44 @@
       var ERROR_DEBOUNCE_MS = 800;
       var healed = false;
 
-      function attempts() { try { return Number(sessionStorage.getItem(KEY)) || 0; } catch (e) { return 0; } }
-      function setAttempts(n) { try { sessionStorage.setItem(KEY, String(n)); } catch (e) {} }
+      function warn(msg) { if (typeof console !== 'undefined') console.warn('[boot-self-heal] ' + msg); }
+      // Current attempt count, or -1 when sessionStorage is unreadable (sandboxed
+      // frame / storage disabled) — the signal that we cannot bound retries.
+      function attempts() {
+        try { return Number(sessionStorage.getItem(KEY)) || 0; }
+        catch (e) { warn('sessionStorage unreadable: ' + e); return -1; }
+      }
+      // Persist n and confirm it survives a read-back; returns false when storage
+      // is unavailable, so callers can refuse to reload rather than loop forever.
+      function recordAttempts(n) {
+        try {
+          sessionStorage.setItem(KEY, String(n));
+          return (Number(sessionStorage.getItem(KEY)) || 0) === n;
+        } catch (e) { warn('sessionStorage unwritable: ' + e); return false; }
+      }
       function mounted() {
         var r = document.getElementById('root');
         return !!(r && r.childElementCount > 0);
       }
       function heal(reason) {
         if (healed) return;
-        if (mounted()) { setAttempts(0); return; } // app is actually up — nothing to do
+        if (mounted()) { recordAttempts(0); return; } // app is actually up — nothing to do
         var n = attempts();
+        // Storage blocked: we can't enforce MAX, so reloading would loop forever.
+        // Give up and let the broken page surface (a manual reload still works).
+        if (n < 0) { warn('cannot bound retries without storage; skipping auto-reload (' + reason + ')'); return; }
         if (n >= MAX) return;                       // avoid reload loops on a real outage
-        healed = true;
         // On a retry, a stale __vdpl pin to a deleted deployment would keep us
         // broken; drop it so the reload falls back to the current live deploy.
-        if (n >= 1) { try { document.cookie = '__vdpl=; path=/; Max-Age=0; SameSite=Strict; Secure'; } catch (e) {} }
-        setAttempts(n + 1);
-        if (typeof console !== 'undefined') console.warn('[boot-self-heal] app failed to boot (' + reason + '); reloading to recover');
+        if (n >= 1) {
+          try { document.cookie = '__vdpl=; path=/; Max-Age=0; SameSite=Strict; Secure'; }
+          catch (e) { warn('could not clear __vdpl pin: ' + e); }
+        }
+        // Record the attempt BEFORE reloading and confirm it stuck; if it didn't,
+        // bail rather than risk reloading forever.
+        if (!recordAttempts(n + 1)) { warn('retry count did not persist; skipping auto-reload to avoid a loop (' + reason + ')'); return; }
+        healed = true;
+        warn('app failed to boot (' + reason + '); reloading to recover');
         location.reload();
       }
 
@@ -110,11 +131,11 @@
       // Clear the guard once the app mounts, so a later deploy in the same
       // session can self-heal again (and a recovered reload resets the counter).
       function watchMount() {
-        if (mounted()) { setAttempts(0); return; }
+        if (mounted()) { recordAttempts(0); return; }
         var root = document.getElementById('root');
         if (!root || typeof MutationObserver === 'undefined') return;
         var mo = new MutationObserver(function () {
-          if (mounted()) { setAttempts(0); mo.disconnect(); }
+          if (mounted()) { recordAttempts(0); mo.disconnect(); }
         });
         mo.observe(root, { childList: true });
       }

--- a/apps/viewer/index.html
+++ b/apps/viewer/index.html
@@ -48,6 +48,84 @@
     })();
   </script>
 
+  <script>
+    // Boot self-heal — the safety net UNDER skew protection above.
+    //
+    // When a Vercel deploy is mid-rollout (or the __vdpl pin above points at a
+    // now-deleted deployment), the content-hashed ENTRY module can 404. Vercel
+    // serves 404s as `text/plain`, which the browser refuses to run as a module
+    // ("blocked because of a disallowed MIME type"). The entry never executes,
+    // React never mounts, and the page shows only the themed background with no
+    // content — recoverable only by a manual reload.
+    //
+    // This must live INLINE in the HTML: a listener inside the bundle can't fire
+    // if the bundle itself failed to load. We watch for (a) a load error on any
+    // entry/preload module asset, or (b) #root never gaining children, and then
+    // reload ONCE to fetch fresh HTML + matching assets. sessionStorage bounds
+    // the attempts so a genuinely-broken deploy can't loop.
+    (function () {
+      var KEY = 'ifc-lite:boot-reload';
+      var MAX = 2;            // at most 2 automatic reloads, then give up
+      var BACKSTOP_MS = 30000; // silent-hang backstop (entry JS is multi-MB)
+      var ERROR_DEBOUNCE_MS = 800;
+      var healed = false;
+
+      function attempts() { try { return Number(sessionStorage.getItem(KEY)) || 0; } catch (e) { return 0; } }
+      function setAttempts(n) { try { sessionStorage.setItem(KEY, String(n)); } catch (e) {} }
+      function mounted() {
+        var r = document.getElementById('root');
+        return !!(r && r.childElementCount > 0);
+      }
+      function heal(reason) {
+        if (healed) return;
+        if (mounted()) { setAttempts(0); return; } // app is actually up — nothing to do
+        var n = attempts();
+        if (n >= MAX) return;                       // avoid reload loops on a real outage
+        healed = true;
+        // On a retry, a stale __vdpl pin to a deleted deployment would keep us
+        // broken; drop it so the reload falls back to the current live deploy.
+        if (n >= 1) { try { document.cookie = '__vdpl=; path=/; Max-Age=0; SameSite=Strict; Secure'; } catch (e) {} }
+        setAttempts(n + 1);
+        if (typeof console !== 'undefined') console.warn('[boot-self-heal] app failed to boot (' + reason + '); reloading to recover');
+        location.reload();
+      }
+
+      // (a) Fast path: a content-hashed entry/preload module failed to load.
+      // Capture phase — resource load errors on script/link elements don't bubble.
+      window.addEventListener('error', function (e) {
+        var t = e && e.target;
+        if (!t || !t.tagName) return;
+        var url = t.src || t.href || '';
+        var isModuleAsset =
+          (t.tagName === 'SCRIPT' && /\/assets\/.*\.m?js(\?|$)/.test(url)) ||
+          (t.tagName === 'LINK' && t.rel === 'modulepreload');
+        if (isModuleAsset) setTimeout(function () { heal('module-load-error'); }, ERROR_DEBOUNCE_MS);
+      }, true);
+
+      // (b) Backstop: app never mounted (e.g. a block that fired no error event).
+      window.addEventListener('load', function () {
+        setTimeout(function () { heal('mount-timeout'); }, BACKSTOP_MS);
+      });
+
+      // Clear the guard once the app mounts, so a later deploy in the same
+      // session can self-heal again (and a recovered reload resets the counter).
+      function watchMount() {
+        if (mounted()) { setAttempts(0); return; }
+        var root = document.getElementById('root');
+        if (!root || typeof MutationObserver === 'undefined') return;
+        var mo = new MutationObserver(function () {
+          if (mounted()) { setAttempts(0); mo.disconnect(); }
+        });
+        mo.observe(root, { childList: true });
+      }
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', watchMount);
+      } else {
+        watchMount();
+      }
+    })();
+  </script>
+
   <!-- Legacy ICO favicon (for older browsers) -->
   <link rel="icon" type="image/x-icon" href="/favicon.ico">
   <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">

--- a/apps/viewer/src/main.tsx
+++ b/apps/viewer/src/main.tsx
@@ -32,6 +32,38 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 // itself so its overlay-path logic stays unit-testable.
 import './lib/placement-edit.boot';
 
+// Post-mount chunk recovery — complements the inline boot self-heal in
+// index.html. The boot watchdog handles the ENTRY failing to load; this handles
+// a LAZY chunk (exporters / ids / bcf / sandbox …) 404ing after a newer deploy
+// ships fresh hashes mid-session. Vite dispatches `vite:preloadError` for that;
+// reload once (sessionStorage-bounded) to pull the matching new chunks.
+window.addEventListener('vite:preloadError', (event) => {
+  const KEY = 'ifc-lite:chunk-reload';
+  let n = 0;
+  try {
+    n = Number(sessionStorage.getItem(KEY)) || 0;
+  } catch {
+    /* sessionStorage unavailable (private mode) — fall through, let it surface */
+  }
+  if (n >= 1) return; // already retried this session — let the error surface
+  try {
+    sessionStorage.setItem(KEY, String(n + 1));
+  } catch {
+    /* ignore */
+  }
+  // Stop Vite from re-throwing as an unhandled rejection; we own the recovery.
+  event.preventDefault();
+  window.location.reload();
+});
+
+// Reaching here means the entry executed and is about to mount, so any prior
+// boot/chunk reload succeeded — reset the chunk guard for a fresh budget.
+try {
+  sessionStorage.removeItem('ifc-lite:chunk-reload');
+} catch {
+  /* ignore */
+}
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <App />

--- a/apps/viewer/src/main.tsx
+++ b/apps/viewer/src/main.tsx
@@ -39,18 +39,26 @@ import './lib/placement-edit.boot';
 // reload once (sessionStorage-bounded) to pull the matching new chunks.
 window.addEventListener('vite:preloadError', (event) => {
   const KEY = 'ifc-lite:chunk-reload';
-  let n = 0;
+  // Bound the retry with sessionStorage. If storage is unavailable (private mode
+  // / sandboxed frame) we can't record the attempt, so we must NOT reload — that
+  // would loop forever on a permanently-missing chunk. In that case fall through
+  // and let Vite surface the error.
+  let attempt = 0;
   try {
-    n = Number(sessionStorage.getItem(KEY)) || 0;
-  } catch {
-    /* sessionStorage unavailable (private mode) — fall through, let it surface */
+    attempt = Number(sessionStorage.getItem(KEY)) || 0;
+  } catch (err) {
+    console.warn('[chunk-reload] sessionStorage unreadable; letting preload error surface', err);
+    return;
   }
-  if (n >= 1) return; // already retried this session — let the error surface
+  if (attempt >= 1) return; // already retried this session — let the error surface
+  let recorded = false;
   try {
-    sessionStorage.setItem(KEY, String(n + 1));
-  } catch {
-    /* ignore */
+    sessionStorage.setItem(KEY, String(attempt + 1));
+    recorded = (Number(sessionStorage.getItem(KEY)) || 0) > attempt;
+  } catch (err) {
+    console.warn('[chunk-reload] sessionStorage unwritable; letting preload error surface', err);
   }
+  if (!recorded) return; // couldn't bound the retry → don't suppress Vite's error or loop
   // Stop Vite from re-throwing as an unhandled rejection; we own the recovery.
   event.preventDefault();
   window.location.reload();
@@ -60,8 +68,9 @@ window.addEventListener('vite:preloadError', (event) => {
 // boot/chunk reload succeeded — reset the chunk guard for a fresh budget.
 try {
   sessionStorage.removeItem('ifc-lite:chunk-reload');
-} catch {
-  /* ignore */
+} catch (err) {
+  // Storage unavailable — nothing was persisted to clear; log per the no-silent-catch rule.
+  console.warn('[chunk-reload] could not clear retry guard', err);
 }
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/vercel.json
+++ b/vercel.json
@@ -50,6 +50,24 @@
       ]
     },
     {
+      "source": "/assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
       "source": "/api/(.*)",
       "headers": [
         {


### PR DESCRIPTION
## Problem

Loading `ifclite.com` while a Vercel deploy is mid-rollout (or when the `__vdpl` skew-protection cookie pins the session to a now-deleted deployment) makes the content-hashed **entry module** 404. Vercel serves 404s as `content-type: text/plain`, which the browser **refuses to execute as a module** ("blocked because of a disallowed MIME type"). The entry never runs → React never mounts → the page shows only the themed **background with no content**, recoverable only by a manual reload.

Confirmed against the live site: a missing `/assets/*.js` returns `404 text/plain` (`x-vercel-error: NOT_FOUND`) — exactly the reported MIME error. Skew Protection is already active (`dpl_…`) but has a cold-start/cross-context gap and no client-side safety net under it.

## Fix

- **`apps/viewer/index.html`** — inline **boot watchdog**. Must be inline: a listener inside the bundle can't fire if the bundle itself failed to load. Reloads **once** on an entry/preload module load-error or if `#root` never gains children. `sessionStorage`-bounded (max 2 attempts, drops a stale `__vdpl` pin on retry, resets on successful mount) so it can't loop.
- **`apps/viewer/src/main.tsx`** — `vite:preloadError` handler for **lazy** chunks (`exporters`/`ids`/`bcf`/`sandbox`) that 404 after a mid-session deploy. Complements the boot watchdog.
- **`vercel.json`** — `immutable` caching for `/assets/*` (content-hashed → byte-stable across deploys; was needlessly revalidating), plus explicit always-revalidate on the HTML entry so clients never run stale markup.

## Verification

Ran the inline watchdog under a mocked DOM — all scenarios green:

- **A** entry fails, `#root` empty → reloads once ✅ (the reported bug)
- **B** app mounted → no reload, guard cleared ✅
- **C** already retried max → gives up, no loop ✅
- **D** retry → drops stale `__vdpl` pin ✅

`vercel.json` valid, HTML tags balanced, inline JS syntax-checked. The failure path is hard to stage on a live preview (needs a mid-deploy race), hence the unit-level proof; the preview deploy confirms the watchdog ships in the built HTML and the app still boots normally.