### PR TITLE
fix(geometry): unbreak main — set instance_meta on voids.rs frame meshes

### DIFF
--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -707,6 +707,8 @@ fn mesh_to_frame(mesh: &Mesh, axes: &[Vector3<f64>; 3], center: Vector3<f64>) ->
         indices: mesh.indices.clone(),
         rtc_applied: mesh.rtc_applied,
         origin: mesh.origin,
+        // Frame-transformed cut intermediate — not an instanceable occurrence.
+        instance_meta: None,
     }
 }
 
@@ -732,6 +734,8 @@ fn mesh_from_frame(mesh: &Mesh, axes: &[Vector3<f64>; 3], center: Vector3<f64>) 
         indices: mesh.indices.clone(),
         rtc_applied: mesh.rtc_applied,
         origin: mesh.origin,
+        // Frame-transformed cut intermediate — not an instanceable occurrence.
+        instance_meta: None,
     }
 }
 


### PR DESCRIPTION
## Urgent: main is red

`error[E0063]: missing field instance_meta in initializer of Mesh` at `rust/geometry/src/router/voids.rs:704` and `:729` — the wasm build fails, blocking **all** downstream CI and the release PR (#1261).

## Cause

A **semantic merge conflict** (git auto-merged cleanly, but it doesn't compile):
- #1259 (rotated-wall, b125ae60) added `mesh_to_frame` / `mesh_from_frame` with `Mesh {…}` literals.
- #1238 (e753e96f) then added the `instance_meta` field to `Mesh`.

Neither PR's own CI could catch it — the conflict only exists once both are on main.

## Fix

Set `instance_meta: None` on both frame-transform meshes — a frame-transformed void-cut intermediate is never an instanceable occurrence. `cargo check -p ifc-lite-geometry` passes.

Merging admin ASAP to unblock main + the release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed metadata handling in geometry frame transformations to prevent unintended metadata propagation through intermediate processing stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->