### PR TITLE
fix(geometry): harden rotated-wall local-frame cut + correct release target (#1167 follow-up)

### DIFF
--- a/.changeset/wasm-rotated-wall-void-fix.md
+++ b/.changeset/wasm-rotated-wall-void-fix.md
@@ -1,0 +1,12 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Bump the wasm package for the rotated-wall void-overcut fix (#1167). The fix is
+Rust geometry code compiled into `@ifc-lite/wasm`, but its original changeset
+bumped only `@ifc-lite/geometry` — so the package that actually carries the
+compiled fix never got a release. This patch bumps `@ifc-lite/wasm` (and
+cascade-patches `@ifc-lite/geometry`, which depends on it) so consumers pinning
+the wasm package receive the corrected geometry. Also includes the #1259/#1270
+review follow-ups: per-opening frame gating in the local-frame cut, faithful
+per-cutter depth direction, and a both-bounds finiteness check.

--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -755,8 +755,9 @@ fn project_aabb_in_frame(
             hi[k] = hi[k].max(v);
         }
     }
-    lo.iter()
-        .all(|v| v.is_finite())
+    // Validate BOTH bounds: a +inf projection lands only in `hi`, so checking
+    // `lo` alone could return a non-finite AABB into the cutter path (#1259).
+    (lo.iter().all(|v| v.is_finite()) && hi.iter().all(|v| v.is_finite()))
         .then(|| (Point3::new(lo[0], lo[1], lo[2]), Point3::new(hi[0], hi[1], hi[2])))
 }
 
@@ -2080,18 +2081,43 @@ impl GeometryRouter {
                 OpeningType::Rectangular(..) => return None,
             };
             let (lmn, lmx) = project_aabb_in_frame(cutter, &axes, center)?;
-            match op {
-                // A clean tilted box becomes an axis-aligned rectangular cut in
-                // the frame — the watertight `rect_fast` path.
-                OpeningType::DiagonalRectangular(..) => {
-                    local_openings.push(OpeningType::Rectangular(lmn, lmx, Some(z)));
+            let in_frame =
+                |v: Vector3<f64>| Vector3::new(v.dot(&axes[0]), v.dot(&axes[1]), v.dot(&axes[2]));
+            // The cutter's own penetration (depth) axis expressed in the wall
+            // frame. Drives both the alignment test and — for the exact fallback
+            // — the cap-extension direction, which MUST stay faithful to THIS
+            // cutter: hardcoding the wall normal would push a misaligned
+            // opening's flush/short cap along the wrong axis and carve the wrong
+            // prism (#1270 review).
+            let frame_depth = match op {
+                OpeningType::DiagonalRectangular(_, f) => Some(in_frame(f.depth)),
+                OpeningType::NonRectangular(_, _, _, d) => d.map(in_frame),
+                OpeningType::Rectangular(..) => None,
+            };
+            // Whether THIS opening's own oriented box is axis-aligned in the
+            // wall frame. The frame is seeded from the FIRST rotated opening
+            // (#1167); a second opening tilted differently *in plane* is NOT
+            // axis-aligned here, so projecting its frame AABB would over-cut it
+            // (#1259 review). Only a clean box whose full frame aligns with the
+            // wall frame may take the fast rectangular cut; everything else —
+            // brep/curved voids and frame-misaligned boxes alike — keeps its
+            // exact (un-rotated, centred) mesh for the subtract.
+            let frame_aligned = match op {
+                OpeningType::DiagonalRectangular(_, f) => {
+                    is_axis_aligned_direction(&in_frame(f.depth))
+                        && is_axis_aligned_direction(&in_frame(f.cross_a))
+                        && is_axis_aligned_direction(&in_frame(f.cross_b))
                 }
-                // Curved / brep openings keep their (now un-rotated, centred)
-                // mesh for the exact subtract.
-                _ => {
-                    let mesh_local = mesh_to_frame(cutter, &axes, center);
-                    local_openings.push(OpeningType::NonRectangular(mesh_local, lmn, lmx, Some(z)));
-                }
+                _ => false,
+            };
+            if frame_aligned {
+                local_openings.push(OpeningType::Rectangular(lmn, lmx, Some(z)));
+            } else {
+                let mesh_local = mesh_to_frame(cutter, &axes, center);
+                // Keep this cutter's true depth in the frame; fall back to the
+                // wall normal (+Z) only when the opening carried no direction.
+                let dir = frame_depth.unwrap_or(z);
+                local_openings.push(OpeningType::NonRectangular(mesh_local, lmn, lmx, Some(dir)));
             }
         }
         let local_ctx = VoidContext {

--- a/rust/geometry/tests/issue_1167_rotated_wall_opening.rs
+++ b/rust/geometry/tests/issue_1167_rotated_wall_opening.rs
@@ -80,7 +80,17 @@ fn defects(m: &Mesh) -> (i64, usize) {
             (b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0]),
         ];
         let area = 0.5 * (cr[0] * cr[0] + cr[1] * cr[1] + cr[2] * cr[2]).sqrt();
-        if area > 1e-9 && maxe * maxe / (2.0 * area) > 50.0 {
+        let degenerate = if area > 1e-9 {
+            // Sliver: tall aspect ratio relative to its (non-zero) area.
+            maxe * maxe / (2.0 * area) > 50.0
+        } else {
+            // Exactly collapsed (collinear / zero-area): a degenerate triangle
+            // that can self-cancel in the edge map and otherwise hide a
+            // fragmented cut (#1259 review). A true point (maxe ~ 0) carries no
+            // surface, so flag only collapsed slivers with real extent.
+            maxe > 1.0e-6
+        };
+        if degenerate {
             needles += 1;
         }
     }


### PR DESCRIPTION
Follow-up to #1259 addressing the post-merge review findings from **CodeRabbit** and **Codex (ChatGPT)**. Each was verified against the merged code before fixing.

| # | Finding | Source | Fix |
|---|---|---|---|
| **A** | Changeset bumped `@ifc-lite/geometry`, but the compiled Rust fix ships in **`@ifc-lite/wasm`** (geometry *depends on* wasm, not vice-versa), so consumers pinning `@ifc-lite/wasm` would never get the fix. | Codex P1 | Changeset now targets `@ifc-lite/wasm`; `@ifc-lite/geometry` cascade-patches via its workspace dep. Caught before release (changeset was still pending). |
| **B** | Local-frame cut seeds the frame from the *first* rotated opening, then treated **every** `DiagonalRectangular` as axis-aligned in that frame — a differently in-plane-oriented opening would be over-cut. | CodeRabbit (Major) + Codex P2 | Gate per-opening: only a box whose **own** frame aligns with the wall frame takes the fast rectangular cut; anything else keeps its exact (un-rotated, centred) mesh for the subtract. |
| **C** | `project_aabb_in_frame` validated only `lo` finiteness — a `+inf` projection lands in `hi` and could slip through. | CodeRabbit (Minor) | Validate **both** bounds. |
| **D** | Regression test's `area > 1e-9` guard skipped exactly-collapsed triangles, which can self-cancel in the edge map and let `defects()` report `(0,0)` for a fragmented cut. | CodeRabbit (Minor) | Count collapsed zero-area triangles (with real extent) as defects. |

## Verification
- **`ifc-lite-geometry` suite: 507 / 0 / 14.**
- #1167 real-wall regression + multi-angle guards still green — the per-opening gating (B) does not change the common case (all wall openings share the wall frame), and the strengthened defect test (D) still passes (the cuts are genuinely clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed validation checks for rotated wall openings to prevent invalid geometry calculations.
  * Improved axis-aligned boundary validation for enhanced accuracy in geometric computations.
  * Enhanced handling of complex wall openings that don't align with standard reference frames.
  * Refined degenerate geometry and triangle detection logic to improve overall mesh quality.

* **Chores**
  * Released patch for WebAssembly module with geometry improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->