### PR TITLE
debug: trace 170_KM instanced-render regression [INST-DBG, do not merge]

### DIFF
--- a/apps/viewer/src/components/viewer/useGeometryStreaming.ts
+++ b/apps/viewer/src/components/viewer/useGeometryStreaming.ts
@@ -615,6 +615,8 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
     if (!device) return;
 
     if (pendingInstancedShards.length > 0) {
+      // [INST-DBG] TEMP: count shards received / decoded ok / failed this drain.
+      let dbgOk = 0, dbgFail = 0;
       for (const bytes of pendingInstancedShards) {
         // CRITICAL: never let a shard decode/upload throw OUT of this effect.
         // addInstancedShard creates GPU buffers (mappedAtCreation); on a degraded
@@ -625,11 +627,14 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
         // still renders.
         try {
           const shard = decodeInstancedShard(new Uint8Array(bytes));
-          if (shard) scene.addInstancedShard(device, shard);
+          if (shard) { scene.addInstancedShard(device, shard); dbgOk += 1; }
         } catch (err) {
+          dbgFail += 1;
           console.warn('[useGeometryStreaming] instanced shard upload failed (device lost?), skipping:', err);
         }
       }
+      // eslint-disable-next-line no-console
+      console.log(`[INST-DBG] drain: received=${pendingInstancedShards.length} decodedOk=${dbgOk} failed=${dbgFail}`);
       renderer.requestRender();
     }
     clearInstancedShards();

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -1836,6 +1836,13 @@ export class Renderer {
                 // IFC Z-up→WebGL Y-up swap, so the uniform's model is unused here;
                 // we reuse the frame's viewProj + section + flags from `tpl`.
                 const instancedTemplates = this.scene.getInstancedTemplates();
+                // [INST-DBG] one-shot: does the opaque instanced draw actually run?
+                if (!(this as unknown as { _instDbg?: boolean })._instDbg) {
+                    (this as unknown as { _instDbg?: boolean })._instDbg = true;
+                    let n = 0; for (const it of instancedTemplates) n += it.instanceCount;
+                    // eslint-disable-next-line no-console
+                    console.log(`[INST-DBG] RENDER: getInstancedTemplates=${instancedTemplates.length} totalInstanceCount=${n} instancedVisible=${(this.scene as unknown as { instancedVisible?: boolean }).instancedVisible} hasTransparentInst=${this.scene.hasTransparentInstances?.()}`);
+                }
                 if (instancedTemplates.length > 0) {
                     // Opaque instanced pass. flags.x bit 2 marks "instanced pass" so the
                     // shader routes per-instance opacity: opaque (or selected) occurrences

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -1911,6 +1911,26 @@ export class Scene {
   addInstancedShard(device: GPUDevice, shard: DecodedInstancedShard): void {
     this.instancedDevice = device; // cached for per-instance selection/overlay writeBuffer
     const prepared = prepareInstancedRender(shard);
+    // [INST-DBG] TEMP diagnostic (170_KM instanced-render regression). Logs per
+    // shard: decoded vs prepared counts + the FIRST instance's world translation
+    // (col-major mat4 → floats 12,13,14). Sane ≈ model world coords; NaN/0/huge
+    // ⇒ produce/compose bug; prepared=0 ⇒ all transparent/dropped.
+    {
+      let totalInst = 0;
+      for (const p of prepared) totalInst += p.instanceCount;
+      let sample = 'n/a';
+      const first = prepared.find((p) => p.instanceCount > 0);
+      if (first) {
+        const dv = new DataView(first.instanceBuffer);
+        const tx = dv.getFloat32(48, true), ty = dv.getFloat32(52, true), tz = dv.getFloat32(56, true);
+        const o = shard.templates[first.templateIndex]?.origin;
+        sample = `worldT=[${tx.toFixed(1)},${ty.toFixed(1)},${tz.toFixed(1)}] tmplOrigin=[${o ? o.map((v) => v.toFixed(0)).join(',') : '?'}]`;
+      }
+      // eslint-disable-next-line no-console
+      console.log(
+        `[INST-DBG] addInstancedShard: shardTemplates=${shard.templates.length} shardInstances=${shard.instances.length} prepared=${prepared.length} totalInst=${totalInst} sharedFrameOrigin=${this.sharedFrameOrigin ? '[' + this.sharedFrameOrigin.map((v) => v.toFixed(0)).join(',') + ']' : 'null'} ${sample}`,
+      );
+    }
     for (const t of prepared) {
       const vcount = Math.floor(t.positions.length / 3);
       if (vcount === 0 || t.indices.length === 0 || t.instanceCount === 0) continue;


### PR DESCRIPTION
Temporary instrumentation to isolate why GPU-instanced occurrences (#1238) vanish on the 170_KM national-grid model. Adds [INST-DBG] console logs at the shard decode/upload chokepoint. Draft — for a preview build only; will be reverted once the root cause is found.