### PR TITLE
feat(viewer): splittable dock, Hierarchy in the panel list, clearer level modes (#1264, #1265, #1266, #1267, #1269)

### DIFF
--- a/apps/viewer/src/components/viewer/HierarchyPanel.tsx
+++ b/apps/viewer/src/components/viewer/HierarchyPanel.tsx
@@ -472,7 +472,7 @@ export function HierarchyPanel() {
           setLevelDisplayMode('solo');
           // Mirror to the advanced filter: one storey rule = this storey (issue #1107).
           upsertSearchRule((r) => r.kind === 'storey' && r.op === 'in', Rule.storey([node.name], 'in'));
-          // Phrase it as Solo so the storey-row → Solo link is obvious (#1265).
+          // Phrase it as Solo so the storey-row to Solo link is obvious (#1265).
           toast.success(`Solo: showing only ${node.name}`);
         }
       }

--- a/apps/viewer/src/components/viewer/HierarchyPanel.tsx
+++ b/apps/viewer/src/components/viewer/HierarchyPanel.tsx
@@ -462,6 +462,8 @@ export function HierarchyPanel() {
           clearStoreySelection();
           // Clear the mirrored storey rule too (issue #1107).
           upsertSearchRule((r) => r.kind === 'storey', null);
+          // Make the "click again to leave Solo" behaviour discoverable (#1265).
+          toast.success('Showing all storeys');
         } else {
           // Select this storey (replaces any existing selection). Isolating a
           // single storey IS Solo, so reflect that in the level-display mode —
@@ -470,7 +472,8 @@ export function HierarchyPanel() {
           setLevelDisplayMode('solo');
           // Mirror to the advanced filter: one storey rule = this storey (issue #1107).
           upsertSearchRule((r) => r.kind === 'storey' && r.op === 'in', Rule.storey([node.name], 'in'));
-          toast.success(`Filter → storey ${node.name}`);
+          // Phrase it as Solo so the storey-row → Solo link is obvious (#1265).
+          toast.success(`Solo: showing only ${node.name}`);
         }
       }
     } else if (node.type === 'IfcSpace') {

--- a/apps/viewer/src/components/viewer/dock/FloatingPanel.tsx
+++ b/apps/viewer/src/components/viewer/dock/FloatingPanel.tsx
@@ -8,9 +8,9 @@
  * Chrome around an arbitrary panel: a drag-by-header title bar, float controls
  * and a resize affordance. The float controls are two distinct ideas, and the
  * labels keep them apart (#1264):
- *   - SNAP left / right / bottom / free — positions the *floating overlay*; it
+ *   - SNAP left / right / bottom / free: positions the *floating overlay*; it
  *     still sits ON TOP of the model (the 3D view stays full size behind it).
- *   - DOCK — re-docks the panel into the sidebar, which RESERVES space so the
+ *   - DOCK: re-docks the panel into the sidebar, which RESERVES space so the
  *     panel and the model sit side by side (and can be split, #1266).
  *
  * Geometry lives in the dock slice so it persists and survives re-render; this
@@ -189,18 +189,18 @@ export function FloatingPanel({
         <GripVertical className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
         <span className="text-xs font-medium truncate min-w-0 flex-1">{title}</span>
         <div className="flex items-center gap-0.5 shrink-0">
-          {/* Float positioning — overlay; the model stays full size behind it. */}
+          {/* Float positioning (overlay); the model stays full size behind it. */}
           {snapBtn('left', PanelLeft, 'Snap left (overlay)')}
           {snapBtn('bottom', PanelBottom, 'Snap bottom (overlay)')}
           {snapBtn('right', PanelRight, 'Snap right (overlay)')}
           {snapBtn('free', Square, 'Free float')}
           <span className="mx-0.5 h-4 w-px bg-border" aria-hidden />
-          {/* Dock — reserves space (panel + model side by side). */}
+          {/* Dock reserves space (panel + model side by side). */}
           <button
             type="button"
             data-no-drag
             title="Dock into sidebar (reserves space)"
-            aria-label="Dock into sidebar — reserves space beside the model"
+            aria-label="Dock into sidebar (reserves space beside the model)"
             onClick={onDock}
             className="h-6 w-6 inline-flex items-center justify-center rounded hover:bg-muted transition-colors"
           >

--- a/apps/viewer/src/components/viewer/dock/FloatingPanel.tsx
+++ b/apps/viewer/src/components/viewer/dock/FloatingPanel.tsx
@@ -5,11 +5,17 @@
 /**
  * A floating / edge-snapped workspace-panel window (issue #1201).
  *
- * Chrome around an arbitrary panel: a drag-by-header title bar, dock controls
- * (snap left / right / bottom / free-float, re-dock into the right slot, close)
- * and a resize affordance. Geometry lives in the dock slice so it persists and
- * survives re-render; this component only translates pointer gestures into
- * `setFloatingPanelRect` / `snapFloatingPanel` calls.
+ * Chrome around an arbitrary panel: a drag-by-header title bar, float controls
+ * and a resize affordance. The float controls are two distinct ideas, and the
+ * labels keep them apart (#1264):
+ *   - SNAP left / right / bottom / free — positions the *floating overlay*; it
+ *     still sits ON TOP of the model (the 3D view stays full size behind it).
+ *   - DOCK — re-docks the panel into the sidebar, which RESERVES space so the
+ *     panel and the model sit side by side (and can be split, #1266).
+ *
+ * Geometry lives in the dock slice so it persists and survives re-render; this
+ * component only translates pointer gestures into `setFloatingPanelRect` /
+ * `snapFloatingPanel` calls.
  */
 
 import { useEffect, useRef, type ReactNode } from 'react';
@@ -183,14 +189,18 @@ export function FloatingPanel({
         <GripVertical className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
         <span className="text-xs font-medium truncate min-w-0 flex-1">{title}</span>
         <div className="flex items-center gap-0.5 shrink-0">
-          {snapBtn('left', PanelLeft, 'Dock left')}
-          {snapBtn('bottom', PanelBottom, 'Dock bottom')}
-          {snapBtn('right', PanelRight, 'Dock right')}
+          {/* Float positioning — overlay; the model stays full size behind it. */}
+          {snapBtn('left', PanelLeft, 'Snap left (overlay)')}
+          {snapBtn('bottom', PanelBottom, 'Snap bottom (overlay)')}
+          {snapBtn('right', PanelRight, 'Snap right (overlay)')}
           {snapBtn('free', Square, 'Free float')}
+          <span className="mx-0.5 h-4 w-px bg-border" aria-hidden />
+          {/* Dock — reserves space (panel + model side by side). */}
           <button
             type="button"
             data-no-drag
-            title="Dock into right panel"
+            title="Dock into sidebar (reserves space)"
+            aria-label="Dock into sidebar — reserves space beside the model"
             onClick={onDock}
             className="h-6 w-6 inline-flex items-center justify-center rounded hover:bg-muted transition-colors"
           >

--- a/apps/viewer/src/components/viewer/hierarchy/StoreyDisplayControls.tsx
+++ b/apps/viewer/src/components/viewer/hierarchy/StoreyDisplayControls.tsx
@@ -3,15 +3,20 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Storey display controls — Stacked / Exploded / Solo, relocated from the
- * toolbar into the hierarchy's Building Storeys section so every "level"
- * concept lives where the user already thinks about storeys.
+ * Storey display controls — relocated from the toolbar into the hierarchy's
+ * Building Storeys section so every "level" concept lives where the user
+ * already thinks about storeys.
  *
- * The storey rows are the picker: Solo isolates the shared `activeStorey`
- * (set when a storey row is clicked), so there's no separate storey dropdown
- * and no lowest-storey cold-start surprise. The Floorplan button on the right
- * activates a top-down section view of the active storey — folding in the
- * old toolbar Quick-Floorplan dropdown so storey navigation + display sit
+ * Grouping (#1269): Stacked and Solo are the closely-related "which storeys
+ * are shown" pair (all vs one), so they sit together in a single segmented
+ * toggle. Exploded does something different — it lifts the storeys apart for
+ * a sectioned, drawing-like view — so it reads as a SEPARATE toggle button
+ * next to the pair rather than a third equal option.
+ *
+ * The storey rows below are the Solo picker: clicking a storey solos it and
+ * clicking it again returns to Stacked (#1265). The Floorplan button on the
+ * right activates a top-down section view of the active storey — folding in
+ * the old toolbar Quick-Floorplan dropdown so storey navigation + display sit
  * together.
  *
  * Self-gates: renders only with ≥ 2 storeys (single-storey models have no
@@ -19,16 +24,17 @@
  */
 
 import { Layers3, ChevronsUpDown, SquareStack, Building2 } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useViewerStore } from '@/store';
 import { applyLevelDisplayMode } from '@/store/levelDisplay';
 import { useFloorplanView } from '@/hooks/useFloorplanView';
 import { cn } from '@/lib/utils';
 import type { LevelDisplayMode } from '@/store/slices/levelDisplaySlice';
 
-const MODES: Array<{ key: LevelDisplayMode; label: string; Icon: typeof Layers3; hint: string }> = [
-  { key: 'stacked', label: 'Stacked', Icon: Layers3, hint: 'Every storey at its real elevation (default)' },
-  { key: 'exploded', label: 'Exploded', Icon: ChevronsUpDown, hint: 'Lift each storey apart vertically' },
-  { key: 'solo', label: 'Solo', Icon: SquareStack, hint: 'Show only the active storey' },
+/** The related "which storeys show" pair — a single Stacked⇄Solo toggle. */
+const SHOW_MODES: Array<{ key: Extract<LevelDisplayMode, 'stacked' | 'solo'>; label: string; Icon: typeof Layers3; hint: string }> = [
+  { key: 'stacked', label: 'Stacked', Icon: Layers3, hint: 'Show every storey at its real elevation (the default view)' },
+  { key: 'solo', label: 'Solo', Icon: SquareStack, hint: 'Show only one storey — click a storey below to pick it' },
 ];
 
 export function StoreyDisplayControls() {
@@ -55,49 +61,91 @@ export function StoreyDisplayControls() {
   // One unified transition: Solo isolates the active/top storey via the storey
   // filter; Stacked / Exploded clear that isolation. No second channel to
   // strand. (Solo's default storey is the top one, not the empty basement.)
-  const handleMode = (mode: LevelDisplayMode) => applyLevelDisplayMode(mode);
+  const isExploded = levelDisplayMode === 'exploded';
+  // Exploded is a separate on/off lens: turning it off returns to Stacked.
+  const toggleExploded = () => applyLevelDisplayMode(isExploded ? 'stacked' : 'exploded');
 
   return (
     <div className="border-b border-zinc-200 dark:border-zinc-800 bg-zinc-50/60 dark:bg-zinc-950/40 px-2 py-1.5">
-      <div className="flex items-center gap-1">
+      <div className="flex items-center gap-1.5">
         {showModes && (
-          <div className="inline-flex flex-1 rounded-md border border-zinc-200 dark:border-zinc-800 p-0.5">
-            {MODES.map(({ key, label, Icon, hint }) => (
-              <button
-                key={key}
-                type="button"
-                title={hint}
-                aria-pressed={levelDisplayMode === key}
-                onClick={() => handleMode(key)}
-                className={cn(
-                  'flex flex-1 items-center justify-center gap-1 rounded px-1.5 py-1 text-[11px] font-medium transition-colors',
-                  levelDisplayMode === key
-                    ? 'bg-primary text-primary-foreground'
-                    : 'text-muted-foreground hover:text-foreground hover:bg-muted/60',
-                )}
-              >
-                <Icon className="h-3.5 w-3.5 shrink-0" />
-                <span className="truncate">{label}</span>
-              </button>
-            ))}
-          </div>
+          <>
+            {/* Related pair: Stacked ⇄ Solo (which storeys are shown). */}
+            <div className="inline-flex flex-1 rounded-md border border-zinc-200 dark:border-zinc-800 p-0.5">
+              {SHOW_MODES.map(({ key, label, Icon, hint }) => {
+                // Solo is "active" whenever a storey is isolated; Stacked is the
+                // base view (also shown while Exploded, since Exploded lifts the
+                // full stack). This keeps the pair truthful next to Exploded.
+                const pressed = key === 'solo' ? levelDisplayMode === 'solo' : levelDisplayMode === 'stacked';
+                return (
+                  <Tooltip key={key}>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        aria-pressed={pressed}
+                        onClick={() => applyLevelDisplayMode(key)}
+                        className={cn(
+                          'flex flex-1 items-center justify-center gap-1 rounded px-1.5 py-1 text-[11px] font-medium transition-colors',
+                          pressed
+                            ? 'bg-primary text-primary-foreground'
+                            : 'text-muted-foreground hover:text-foreground hover:bg-muted/60',
+                        )}
+                      >
+                        <Icon className="h-3.5 w-3.5 shrink-0" />
+                        <span className="truncate">{label}</span>
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">{hint}</TooltipContent>
+                  </Tooltip>
+                );
+              })}
+            </div>
+
+            {/* Separate lens: Exploded lifts the storeys apart for a sectioned
+                view — distinct from "which storeys show", so it stands alone. */}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-pressed={isExploded}
+                  onClick={toggleExploded}
+                  className={cn(
+                    'inline-flex h-7 shrink-0 items-center justify-center gap-1 rounded-md border px-2 text-[11px] font-medium transition-colors',
+                    isExploded
+                      ? 'border-primary bg-primary text-primary-foreground'
+                      : 'border-zinc-200 dark:border-zinc-800 text-muted-foreground hover:bg-muted hover:text-foreground',
+                  )}
+                >
+                  <ChevronsUpDown className="h-3.5 w-3.5 shrink-0" />
+                  <span>Exploded</span>
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Lift each storey apart vertically for a sectioned, drawing-like view</TooltipContent>
+            </Tooltip>
+          </>
         )}
-        <button
-          type="button"
-          disabled={!floorplanTarget}
-          title={floorplanTarget ? `Floorplan: ${floorplanTarget.name}` : 'Pick a storey to floorplan it'}
-          aria-label="Floorplan the active storey"
-          onClick={() => floorplanTarget && activateFloorplan(floorplanTarget)}
-          className={cn(
-            'inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-zinc-200 dark:border-zinc-800 text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-40',
-            !showModes && 'ml-auto',
-          )}
-        >
-          <Building2 className="h-3.5 w-3.5" />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              disabled={!floorplanTarget}
+              aria-label="Floorplan the active storey"
+              onClick={() => floorplanTarget && activateFloorplan(floorplanTarget)}
+              className={cn(
+                'inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-zinc-200 dark:border-zinc-800 text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-40',
+                !showModes && 'ml-auto',
+              )}
+            >
+              <Building2 className="h-3.5 w-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {floorplanTarget ? `Top-down floorplan of ${floorplanTarget.name}` : 'Pick a storey to floorplan it'}
+          </TooltipContent>
+        </Tooltip>
       </div>
 
-      {showModes && levelDisplayMode === 'exploded' && (
+      {showModes && isExploded && (
         <div className="mt-1.5 flex items-center gap-2 text-[11px] text-muted-foreground">
           <span>Gap</span>
           <input
@@ -116,14 +164,19 @@ export function StoreyDisplayControls() {
         </div>
       )}
 
-      {showModes && levelDisplayMode === 'solo' && (
+      {/* Discoverability hint (#1265): the storey rows ARE the Solo picker. */}
+      {showModes && !isExploded && (
         <div className="mt-1 text-[10px] leading-tight text-muted-foreground">
-          {activeInfo ? (
-            <>
-              Showing <span className="font-medium text-foreground">{activeInfo.name}</span> · click a storey to switch
-            </>
+          {levelDisplayMode === 'solo' ? (
+            activeInfo ? (
+              <>
+                Showing only <span className="font-medium text-foreground">{activeInfo.name}</span> · click another storey to switch, or click it again for all
+              </>
+            ) : (
+              'Click a storey below to show only it'
+            )
           ) : (
-            'Click a storey to solo it'
+            'Click a storey below to show only that level'
           )}
         </div>
       )}

--- a/apps/viewer/src/components/viewer/hierarchy/StoreyDisplayControls.tsx
+++ b/apps/viewer/src/components/viewer/hierarchy/StoreyDisplayControls.tsx
@@ -3,19 +3,19 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Storey display controls — relocated from the toolbar into the hierarchy's
+ * Storey display controls, relocated from the toolbar into the hierarchy's
  * Building Storeys section so every "level" concept lives where the user
  * already thinks about storeys.
  *
  * Grouping (#1269): Stacked and Solo are the closely-related "which storeys
  * are shown" pair (all vs one), so they sit together in a single segmented
- * toggle. Exploded does something different — it lifts the storeys apart for
- * a sectioned, drawing-like view — so it reads as a SEPARATE toggle button
+ * toggle. Exploded does something different: it lifts the storeys apart for
+ * a sectioned, drawing-like view, so it reads as a SEPARATE toggle button
  * next to the pair rather than a third equal option.
  *
  * The storey rows below are the Solo picker: clicking a storey solos it and
  * clicking it again returns to Stacked (#1265). The Floorplan button on the
- * right activates a top-down section view of the active storey — folding in
+ * right activates a top-down section view of the active storey, folding in
  * the old toolbar Quick-Floorplan dropdown so storey navigation + display sit
  * together.
  *
@@ -31,10 +31,10 @@ import { useFloorplanView } from '@/hooks/useFloorplanView';
 import { cn } from '@/lib/utils';
 import type { LevelDisplayMode } from '@/store/slices/levelDisplaySlice';
 
-/** The related "which storeys show" pair — a single Stacked⇄Solo toggle. */
+/** The related "which storeys show" pair: a single Stacked / Solo toggle. */
 const SHOW_MODES: Array<{ key: Extract<LevelDisplayMode, 'stacked' | 'solo'>; label: string; Icon: typeof Layers3; hint: string }> = [
   { key: 'stacked', label: 'Stacked', Icon: Layers3, hint: 'Show every storey at its real elevation (the default view)' },
-  { key: 'solo', label: 'Solo', Icon: SquareStack, hint: 'Show only one storey — click a storey below to pick it' },
+  { key: 'solo', label: 'Solo', Icon: SquareStack, hint: 'Show only one storey, click a storey below to pick it' },
 ];
 
 export function StoreyDisplayControls() {
@@ -70,7 +70,7 @@ export function StoreyDisplayControls() {
       <div className="flex items-center gap-1.5">
         {showModes && (
           <>
-            {/* Related pair: Stacked ⇄ Solo (which storeys are shown). */}
+            {/* Related pair: Stacked / Solo (which storeys are shown). */}
             <div className="inline-flex flex-1 rounded-md border border-zinc-200 dark:border-zinc-800 p-0.5">
               {SHOW_MODES.map(({ key, label, Icon, hint }) => {
                 // Solo is "active" whenever a storey is isolated; Stacked is the
@@ -102,7 +102,7 @@ export function StoreyDisplayControls() {
             </div>
 
             {/* Separate lens: Exploded lifts the storeys apart for a sectioned
-                view — distinct from "which storeys show", so it stands alone. */}
+                view, distinct from "which storeys show", so it stands alone. */}
             <Tooltip>
               <TooltipTrigger asChild>
                 <button

--- a/apps/viewer/src/components/viewer/sidebar/ActivityBar.tsx
+++ b/apps/viewer/src/components/viewer/sidebar/ActivityBar.tsx
@@ -40,7 +40,7 @@ import { usePanelControls } from '@/hooks/usePanelControls';
 import { WORKSPACE_PANELS, getPanelDef, type WorkspacePanelId } from '@/lib/panels/registry';
 import { CustomizeSidebar } from './CustomizeSidebar';
 
-/** Alt+N hint per panel — by registry index (frozen since #1200): 1-9, then 0.
+/** Alt+N hint per panel, by registry index (frozen since #1200): 1-9, then 0.
  *  Only the first ten registry entries get a shortcut; later additions (e.g.
  *  Hierarchy, #1267) have none, so the map is limited to the first ten. */
 const ALT_LABEL = new Map<WorkspacePanelId, string>(
@@ -68,8 +68,8 @@ export function ActivityBar() {
 
   const onIconClick = (id: WorkspacePanelId) => {
     const region = getPanelDef(id)?.region;
-    // The left nav panel (Hierarchy, #1267) lives in its own slot — just toggle
-    // it; it never affects the right-pane sidebar mode.
+    // The left nav panel (Hierarchy, #1267) lives in its own slot, so just
+    // toggle it; it never affects the right-pane sidebar mode.
     if (region === 'left') {
       toggle(id);
       return;

--- a/apps/viewer/src/components/viewer/sidebar/ActivityBar.tsx
+++ b/apps/viewer/src/components/viewer/sidebar/ActivityBar.tsx
@@ -40,9 +40,11 @@ import { usePanelControls } from '@/hooks/usePanelControls';
 import { WORKSPACE_PANELS, getPanelDef, type WorkspacePanelId } from '@/lib/panels/registry';
 import { CustomizeSidebar } from './CustomizeSidebar';
 
-/** Alt+N hint per panel — by registry index (frozen since #1200): 1-9, then 0. */
+/** Alt+N hint per panel — by registry index (frozen since #1200): 1-9, then 0.
+ *  Only the first ten registry entries get a shortcut; later additions (e.g.
+ *  Hierarchy, #1267) have none, so the map is limited to the first ten. */
 const ALT_LABEL = new Map<WorkspacePanelId, string>(
-  WORKSPACE_PANELS.map((p, i) => [p.id, i < 9 ? `Alt+${i + 1}` : 'Alt+0']),
+  WORKSPACE_PANELS.slice(0, 10).map((p, i) => [p.id, i < 9 ? `Alt+${i + 1}` : 'Alt+0']),
 );
 
 export function ActivityBar() {
@@ -65,9 +67,16 @@ export function ActivityBar() {
   const visibleIds = order.filter((id) => customizing || !hidden.has(id) || id === 'properties');
 
   const onIconClick = (id: WorkspacePanelId) => {
+    const region = getPanelDef(id)?.region;
+    // The left nav panel (Hierarchy, #1267) lives in its own slot — just toggle
+    // it; it never affects the right-pane sidebar mode.
+    if (region === 'left') {
+      toggle(id);
+      return;
+    }
     // Bottom-region panels (Script / Schedule / Lists) open in the bottom strip
     // — their own region — without touching the right-pane sidebar mode.
-    if (getPanelDef(id)?.region === 'bottom') {
+    if (region === 'bottom') {
       toggle(id);
       return;
     }
@@ -167,7 +176,7 @@ export function ActivityBar() {
                   <span className="text-muted-foreground">
                     {customizing
                       ? isHidden ? ' · hidden — click to show' : ' · click to hide'
-                      : ` · ${ALT_LABEL.get(id) ?? ''}${loc === 'floating' ? ' · floating' : loc === 'popped' ? ' · popped out' : ''}`}
+                      : `${ALT_LABEL.get(id) ? ` · ${ALT_LABEL.get(id)}` : ''}${loc === 'floating' ? ' · floating' : loc === 'popped' ? ' · popped out' : ''}`}
                   </span>
                 </TooltipContent>
               </Tooltip>

--- a/apps/viewer/src/components/viewer/sidebar/SidebarPanelHost.tsx
+++ b/apps/viewer/src/components/viewer/sidebar/SidebarPanelHost.tsx
@@ -330,7 +330,9 @@ export function SidebarPanelHost() {
   // A docked analysis panel, optionally split with a second panel below.
   if (!secondaryActive) {
     return (
-      <div className="h-full flex flex-col panel-container">
+      // data-detach-root lets usePanelDetachDrag lift from the current docked
+      // bounds instead of falling back to default float geometry.
+      <div data-detach-root className="h-full flex flex-col panel-container">
         <PanelChromeBar detachId={shown} />
         <div className="flex-1 min-h-0 overflow-hidden">{renderPanelBody(shown, () => closePanel(shown))}</div>
       </div>

--- a/apps/viewer/src/components/viewer/sidebar/SidebarPanelHost.tsx
+++ b/apps/viewer/src/components/viewer/sidebar/SidebarPanelHost.tsx
@@ -3,32 +3,44 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * The docked sidebar's content pane (#1208).
+ * The docked sidebar's content pane (#1208, split added in #1266).
  *
- * Renders the single active workspace panel. Each panel ships its own header
- * (title + close), so the sidebar adds only a slim **grab bar**: a dot-grid
- * grip you drag to detach + a chevron that collapses the pane to the rail.
+ * Renders the active workspace panel, and — when the user splits it — a SECOND
+ * panel stacked beneath it with a draggable divider (Blender-style). Both halves
+ * reserve real layout space (the pane is a flex sibling of the viewport), so a
+ * split is "model | Information / IDS", never an overlay. Floating (#1201) stays
+ * a separate overlay channel.
  *
- * The drag is LIVE: on the first move the panel lifts straight out of the dock
- * into a floating window (#1201) positioned exactly where it was, then tracks
- * the cursor for the whole gesture (no disappear-until-drop). Release inside
- * the viewport → it stays floating where dropped; release past the window edge
- * (e.g. dragging onto another monitor) → it hands off to an OS / Picture-in-
- * Picture window. Pointer capture on <body> keeps the gesture alive after the
- * grab bar unmounts and while the cursor leaves the window.
+ * Each panel ships its own header (title + close), so the sidebar adds only a
+ * slim **grab bar**: a dot-grid grip you drag to detach, a Split control, and a
+ * chevron that collapses the pane to the rail.
+ *
+ * The detach drag is LIVE: on the first move the panel lifts straight out of the
+ * dock into a floating window (#1201) positioned exactly where it was, then
+ * tracks the cursor for the whole gesture. Release inside the viewport → it
+ * stays floating; release past the window edge → it hands off to an OS / PiP
+ * window.
  *
  * Render precedence preserves the pre-existing right-slot behavior:
  *   right-placed analysis extension → Add Element tool → active panel → Information.
  */
 
-import { useSyncExternalStore } from 'react';
-import { Grip, ChevronRight } from 'lucide-react';
+import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react';
+import { Grip, ChevronRight, Rows2, X, Check } from 'lucide-react';
 import { useViewerStore } from '@/store';
-import { type WorkspacePanelId } from '@/lib/panels/registry';
+import { WORKSPACE_PANELS, getPanelDef, type WorkspacePanelId } from '@/lib/panels/registry';
 import { renderPanelBody } from '@/lib/panels/renderPanelBody';
 import { usePanelControls } from '@/hooks/usePanelControls';
 import { usePanelDetachDrag } from '@/hooks/usePanelDetachDrag';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { ExtensionDockHost } from '@/components/extensions/ExtensionDockHost';
 import { AddElementPanel } from '../AddElementPanel';
 import {
@@ -38,39 +50,166 @@ import {
   subscribeAnalysisExtensions,
 } from '@/services/analysis-extensions';
 
-/** Slim grab bar: drag the grip to lift the panel into a live floating window
- *  (release past the window edge to pop out to another screen); the chevron
- *  collapses the pane to the rail. Title-less + close-less — the body owns those. */
+/** Right-pane panels eligible to share the docked split (#1266). */
+const SIDE_PANELS = WORKSPACE_PANELS.filter((p) => p.region === 'side');
+
+/** Dropdown that picks / switches / removes the lower split panel (#1266). */
+function SplitMenu({ primaryId }: { primaryId: WorkspacePanelId }) {
+  const secondary = useViewerStore((s) => s.sidebarSecondaryPanel);
+  const setSecondary = useViewerStore((s) => s.setSidebarSecondaryPanel);
+  const closeFloatingPanel = useViewerStore((s) => s.closeFloatingPanel);
+  const setPanelPoppedOut = useViewerStore((s) => s.setPanelPoppedOut);
+
+  // Picking a panel that's currently floating / popped pulls it back inline.
+  const pick = (id: WorkspacePanelId) => {
+    closeFloatingPanel(id);
+    setPanelPoppedOut(id, false);
+    setSecondary(id);
+  };
+
+  const options = SIDE_PANELS.filter((p) => p.id !== primaryId);
+
+  return (
+    <DropdownMenu>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              data-chrome-btn
+              data-no-drag
+              aria-label="Split panel"
+              className="h-5 w-5 inline-flex items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+            >
+              <Rows2 className="h-3.5 w-3.5" />
+            </button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Split — stack a second panel below</TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent align="end" className="w-48">
+        <DropdownMenuLabel className="text-[10px] uppercase tracking-wider text-muted-foreground">
+          {secondary ? 'Panel below' : 'Split — show below'}
+        </DropdownMenuLabel>
+        {options.map((p) => (
+          <DropdownMenuItem key={p.id} onSelect={() => pick(p.id)} className="gap-2">
+            <p.Icon className="h-4 w-4 text-muted-foreground" />
+            <span className="flex-1">{p.title}</span>
+            {secondary === p.id && <Check className="h-3.5 w-3.5 text-primary" />}
+          </DropdownMenuItem>
+        ))}
+        {secondary && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={() => setSecondary(null)} className="gap-2">
+              <X className="h-4 w-4 text-muted-foreground" />
+              Remove split
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+/** Slim grab bar for the TOP / single panel: drag the grip to lift the panel
+ *  into a live floating window, Split to stack a second panel below, chevron to
+ *  collapse the pane to the rail. Title-less + close-less — the body owns those. */
 function PanelChromeBar({ detachId }: { detachId: WorkspacePanelId }) {
   const setSidebarMode = useViewerStore((s) => s.setSidebarMode);
   const onPointerDown = usePanelDetachDrag(detachId);
 
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        {/* Pointer-only drag affordance — not a button (it has no keyboard
-            action and wraps the real collapse <button>). Keyboard users reach
-            panels via the activity bar / Alt+N (#1208). */}
-        <div
-          onPointerDown={onPointerDown}
-          className="flex items-center gap-1 h-6 shrink-0 px-1.5 border-b border-border/50 bg-muted/10 select-none touch-none cursor-grab active:cursor-grabbing"
-        >
+    <div
+      onPointerDown={onPointerDown}
+      className="flex items-center gap-1 h-6 shrink-0 px-1.5 border-b border-border/50 bg-muted/10 select-none touch-none cursor-grab active:cursor-grabbing"
+    >
+      <Tooltip>
+        <TooltipTrigger asChild>
           <Grip className="h-3.5 w-3.5 text-muted-foreground/50 shrink-0" />
-          <span className="flex-1" />
-          <button
-            type="button"
-            data-chrome-btn
-            aria-label="Collapse sidebar to icons"
-            title="Collapse to icons"
-            onClick={() => setSidebarMode('collapsed')}
-            className="h-5 w-5 inline-flex items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
-          >
-            <ChevronRight className="h-3.5 w-3.5" />
-          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Drag to float · drag onto another screen to pop out</TooltipContent>
+      </Tooltip>
+      <span className="flex-1" />
+      <SplitMenu primaryId={detachId} />
+      <button
+        type="button"
+        data-chrome-btn
+        data-no-drag
+        aria-label="Collapse sidebar to icons"
+        title="Collapse to icons"
+        onClick={() => setSidebarMode('collapsed')}
+        className="h-5 w-5 inline-flex items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+      >
+        <ChevronRight className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}
+
+/** Slim bar for the BOTTOM split panel: shows the panel name + a close-split
+ *  control (the body keeps its own header). */
+function SecondaryChromeBar({ id }: { id: WorkspacePanelId }) {
+  const setSecondary = useViewerStore((s) => s.setSidebarSecondaryPanel);
+  const title = getPanelDef(id)?.title ?? id;
+  return (
+    <div className="flex items-center gap-1 h-6 shrink-0 px-1.5 border-b border-border/50 bg-muted/10 select-none">
+      <Rows2 className="h-3 w-3 text-muted-foreground/50 shrink-0" aria-hidden />
+      <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground truncate flex-1">{title}</span>
+      <button
+        type="button"
+        aria-label="Remove split"
+        title="Remove split"
+        onClick={() => setSecondary(null)}
+        className="h-5 w-5 inline-flex items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}
+
+/** Two stacked panels + a draggable divider; both halves reserve space (#1266). */
+function SplitContainer({
+  containerRef,
+  ratio,
+  onDividerDown,
+  primary,
+  secondaryId,
+}: {
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  ratio: number;
+  onDividerDown: (e: React.MouseEvent) => void;
+  primary: React.ReactNode;
+  secondaryId: WorkspacePanelId;
+}) {
+  const setSecondary = useViewerStore((s) => s.setSidebarSecondaryPanel);
+  return (
+    <div ref={containerRef} className="h-full flex flex-col panel-container">
+      {/* Top half — flex-basis is the ratio; min-height stops it collapsing. */}
+      <div
+        data-detach-root
+        className="flex flex-col min-h-[120px] overflow-hidden"
+        style={{ flexBasis: `${ratio * 100}%`, flexGrow: 0, flexShrink: 1 }}
+      >
+        {primary}
+      </div>
+      {/* Divider */}
+      <div
+        onMouseDown={onDividerDown}
+        role="separator"
+        aria-orientation="horizontal"
+        aria-label="Resize split"
+        className="h-1.5 shrink-0 cursor-row-resize bg-border hover:bg-primary/50 active:bg-primary/70 transition-colors"
+      />
+      {/* Bottom half — fills the rest. */}
+      <div className="flex-1 min-h-[120px] flex flex-col overflow-hidden">
+        <SecondaryChromeBar id={secondaryId} />
+        <div className="flex-1 min-h-0 overflow-hidden">
+          {renderPanelBody(secondaryId, () => setSecondary(null))}
         </div>
-      </TooltipTrigger>
-      <TooltipContent side="bottom">Drag to float · drag onto another screen to pop out</TooltipContent>
-    </Tooltip>
+      </div>
+    </div>
   );
 }
 
@@ -78,7 +217,41 @@ export function SidebarPanelHost() {
   const activePanel = useViewerStore((s) => s.sidebarActivePanel);
   const activeTool = useViewerStore((s) => s.activeTool);
   const setActiveTool = useViewerStore((s) => s.setActiveTool);
+  const secondaryPanel = useViewerStore((s) => s.sidebarSecondaryPanel);
+  const splitRatio = useViewerStore((s) => s.sidebarSplitRatio);
+  const setSplitRatio = useViewerStore((s) => s.setSidebarSplitRatio);
   const { floatingIds, poppedIds, closePanel } = usePanelControls();
+
+  // Divider drag: translate pointer Y within the pane into the top-half ratio.
+  const containerRef = useRef<HTMLDivElement>(null);
+  const dragCleanupRef = useRef<(() => void) | null>(null);
+  useEffect(() => () => dragCleanupRef.current?.(), []);
+  const onDividerDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      const el = containerRef.current;
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      const move = (ev: MouseEvent) => {
+        if (rect.height <= 0) return;
+        setSplitRatio((ev.clientY - rect.top) / rect.height);
+      };
+      const teardown = () => {
+        document.removeEventListener('mousemove', move);
+        document.removeEventListener('mouseup', up);
+        document.body.style.cursor = '';
+        document.body.style.userSelect = '';
+        dragCleanupRef.current = null;
+      };
+      const up = () => teardown();
+      dragCleanupRef.current = teardown;
+      document.addEventListener('mousemove', move);
+      document.addEventListener('mouseup', up);
+      document.body.style.cursor = 'row-resize';
+      document.body.style.userSelect = 'none';
+    },
+    [setSplitRatio],
+  );
 
   const analysisState = useSyncExternalStore(
     subscribeAnalysisExtensions,
@@ -96,7 +269,16 @@ export function SidebarPanelHost() {
     shown = null;
   }
 
-  // Right-placed analysis extension / Add Element carry their own chrome.
+  // A split only renders when the secondary still resolves to an inline panel
+  // (not floated / popped, not collapsed to the same id as the primary).
+  const secondaryActive =
+    secondaryPanel !== null &&
+    secondaryPanel !== shown &&
+    !floatingIds.has(secondaryPanel) &&
+    !poppedIds.has(secondaryPanel);
+
+  // Right-placed analysis extension / Add Element carry their own chrome and
+  // never split.
   if (rightExtension) {
     return (
       <div data-detach-root className="h-full flex flex-col panel-container">
@@ -114,22 +296,56 @@ export function SidebarPanelHost() {
 
   // Information fallback (or empty when Information is detached).
   if (shown === null || shown === 'properties') {
-    return (
-      <div data-detach-root className="h-full flex flex-col panel-container">
-        {shown === 'properties' && <PanelChromeBar detachId="properties" />}
-        <div className="flex-1 min-h-0 overflow-hidden">
-          {shown === 'properties' && renderPanelBody('properties', () => {})}
+    // Empty (Information detached) or no split → render single.
+    if (shown === null || !secondaryActive) {
+      return (
+        <div data-detach-root className="h-full flex flex-col panel-container">
+          {shown === 'properties' && <PanelChromeBar detachId="properties" />}
+          <div className="flex-1 min-h-0 overflow-hidden">
+            {shown === 'properties' && renderPanelBody('properties', () => {})}
+          </div>
+          <ExtensionDockHost slot="dock.right" className="max-h-[40%] border-t" />
         </div>
-        <ExtensionDockHost slot="dock.right" className="max-h-[40%] border-t" />
-      </div>
+      );
+    }
+    // Information on top, a second panel below (the user's canonical example).
+    return (
+      <SplitContainer
+        containerRef={containerRef}
+        ratio={splitRatio}
+        onDividerDown={onDividerDown}
+        primary={
+          <>
+            <PanelChromeBar detachId="properties" />
+            <div className="flex-1 min-h-0 overflow-hidden">{renderPanelBody('properties', () => {})}</div>
+          </>
+        }
+        secondaryId={secondaryPanel as WorkspacePanelId}
+      />
     );
   }
 
-  // A docked analysis panel — grab bar + the panel's own body.
+  // A docked analysis panel — optionally split with a second panel below.
+  if (!secondaryActive) {
+    return (
+      <div className="h-full flex flex-col panel-container">
+        <PanelChromeBar detachId={shown} />
+        <div className="flex-1 min-h-0 overflow-hidden">{renderPanelBody(shown, () => closePanel(shown))}</div>
+      </div>
+    );
+  }
   return (
-    <div className="h-full flex flex-col panel-container">
-      <PanelChromeBar detachId={shown} />
-      <div className="flex-1 min-h-0 overflow-hidden">{renderPanelBody(shown, () => closePanel(shown))}</div>
-    </div>
+    <SplitContainer
+      containerRef={containerRef}
+      ratio={splitRatio}
+      onDividerDown={onDividerDown}
+      primary={
+        <>
+          <PanelChromeBar detachId={shown} />
+          <div className="flex-1 min-h-0 overflow-hidden">{renderPanelBody(shown, () => closePanel(shown))}</div>
+        </>
+      }
+      secondaryId={secondaryPanel as WorkspacePanelId}
+    />
   );
 }

--- a/apps/viewer/src/components/viewer/sidebar/SidebarPanelHost.tsx
+++ b/apps/viewer/src/components/viewer/sidebar/SidebarPanelHost.tsx
@@ -5,28 +5,30 @@
 /**
  * The docked sidebar's content pane (#1208, split added in #1266).
  *
- * Renders the active workspace panel, and — when the user splits it — a SECOND
+ * Renders the active workspace panel, and, when the user splits it, a SECOND
  * panel stacked beneath it with a draggable divider (Blender-style). Both halves
  * reserve real layout space (the pane is a flex sibling of the viewport), so a
  * split is "model | Information / IDS", never an overlay. Floating (#1201) stays
  * a separate overlay channel.
  *
  * Each panel ships its own header (title + close), so the sidebar adds only a
- * slim **grab bar**: a dot-grid grip you drag to detach, a Split control, and a
- * chevron that collapses the pane to the rail.
+ * slim grab bar on top: a dot-grid grip you drag to detach, a Split control, and
+ * a chevron that collapses the pane to the rail. The two stacked panels read as
+ * a matched pair joined by one resize handle (which also carries the
+ * remove-split action), so neither half repeats a title.
  *
  * The detach drag is LIVE: on the first move the panel lifts straight out of the
  * dock into a floating window (#1201) positioned exactly where it was, then
- * tracks the cursor for the whole gesture. Release inside the viewport → it
- * stays floating; release past the window edge → it hands off to an OS / PiP
- * window.
+ * tracks the cursor for the whole gesture. Release inside the viewport keeps it
+ * floating; release past the window edge hands it off to an OS / PiP window.
  *
  * Render precedence preserves the pre-existing right-slot behavior:
- *   right-placed analysis extension → Add Element tool → active panel → Information.
+ *   right-placed analysis extension, then Add Element tool, then active panel,
+ *   then Information.
  */
 
 import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react';
-import { Grip, ChevronRight, Rows2, X, Check } from 'lucide-react';
+import { Grip, ChevronRight, Rows2, X, Check, GripHorizontal } from 'lucide-react';
 import { useViewerStore } from '@/store';
 import { WORKSPACE_PANELS, getPanelDef, type WorkspacePanelId } from '@/lib/panels/registry';
 import { renderPanelBody } from '@/lib/panels/renderPanelBody';
@@ -79,17 +81,23 @@ function SplitMenu({ primaryId }: { primaryId: WorkspacePanelId }) {
               data-chrome-btn
               data-no-drag
               aria-label="Split panel"
-              className="h-5 w-5 inline-flex items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+              aria-pressed={!!secondary}
+              className={
+                'h-5 w-5 inline-flex items-center justify-center rounded transition-colors '
+                + (secondary
+                  ? 'text-primary bg-primary/10'
+                  : 'text-muted-foreground hover:bg-muted hover:text-foreground')
+              }
             >
               <Rows2 className="h-3.5 w-3.5" />
             </button>
           </DropdownMenuTrigger>
         </TooltipTrigger>
-        <TooltipContent side="bottom">Split — stack a second panel below</TooltipContent>
+        <TooltipContent side="bottom">Split: stack a second panel below</TooltipContent>
       </Tooltip>
-      <DropdownMenuContent align="end" className="w-48">
-        <DropdownMenuLabel className="text-[10px] uppercase tracking-wider text-muted-foreground">
-          {secondary ? 'Panel below' : 'Split — show below'}
+      <DropdownMenuContent align="end" className="w-52">
+        <DropdownMenuLabel className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          {secondary ? 'Panel below' : 'Split: show below'}
         </DropdownMenuLabel>
         {options.map((p) => (
           <DropdownMenuItem key={p.id} onSelect={() => pick(p.id)} className="gap-2">
@@ -112,9 +120,9 @@ function SplitMenu({ primaryId }: { primaryId: WorkspacePanelId }) {
   );
 }
 
-/** Slim grab bar for the TOP / single panel: drag the grip to lift the panel
- *  into a live floating window, Split to stack a second panel below, chevron to
- *  collapse the pane to the rail. Title-less + close-less — the body owns those. */
+/** Slim grab bar atop the docked panel: drag the grip to lift it into a live
+ *  floating window, Split to stack a second panel below, chevron to collapse the
+ *  pane to the rail. Title-less and close-less: the panel body owns those. */
 function PanelChromeBar({ detachId }: { detachId: WorkspacePanelId }) {
   const setSidebarMode = useViewerStore((s) => s.setSidebarMode);
   const onPointerDown = usePanelDetachDrag(detachId);
@@ -122,54 +130,55 @@ function PanelChromeBar({ detachId }: { detachId: WorkspacePanelId }) {
   return (
     <div
       onPointerDown={onPointerDown}
-      className="flex items-center gap-1 h-6 shrink-0 px-1.5 border-b border-border/50 bg-muted/10 select-none touch-none cursor-grab active:cursor-grabbing"
+      className="flex items-center gap-1 h-6 shrink-0 px-1.5 border-b border-border/60 bg-muted/20 select-none touch-none cursor-grab active:cursor-grabbing"
     >
       <Tooltip>
         <TooltipTrigger asChild>
-          <Grip className="h-3.5 w-3.5 text-muted-foreground/50 shrink-0" />
+          <Grip className="h-3.5 w-3.5 text-muted-foreground/60 shrink-0" />
         </TooltipTrigger>
-        <TooltipContent side="bottom">Drag to float · drag onto another screen to pop out</TooltipContent>
+        <TooltipContent side="bottom">Drag to float, or onto another screen to pop out</TooltipContent>
       </Tooltip>
       <span className="flex-1" />
       <SplitMenu primaryId={detachId} />
-      <button
-        type="button"
-        data-chrome-btn
-        data-no-drag
-        aria-label="Collapse sidebar to icons"
-        title="Collapse to icons"
-        onClick={() => setSidebarMode('collapsed')}
-        className="h-5 w-5 inline-flex items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
-      >
-        <ChevronRight className="h-3.5 w-3.5" />
-      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            data-chrome-btn
+            data-no-drag
+            aria-label="Collapse sidebar to icons"
+            onClick={() => setSidebarMode('collapsed')}
+            className="h-5 w-5 inline-flex items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+          >
+            <ChevronRight className="h-3.5 w-3.5" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Collapse to icons</TooltipContent>
+      </Tooltip>
     </div>
   );
 }
 
-/** Slim bar for the BOTTOM split panel: shows the panel name + a close-split
- *  control (the body keeps its own header). */
-function SecondaryChromeBar({ id }: { id: WorkspacePanelId }) {
-  const setSecondary = useViewerStore((s) => s.setSidebarSecondaryPanel);
-  const title = getPanelDef(id)?.title ?? id;
+/** The resize handle between the two split halves (#1266): a centered grip so
+ *  it reads as draggable. Removing the split lives on the lower panel's own
+ *  header close button (and the Split menu), so the divider stays clutter-free. */
+function SplitDivider({ onResizeStart }: { onResizeStart: (e: React.MouseEvent) => void }) {
   return (
-    <div className="flex items-center gap-1 h-6 shrink-0 px-1.5 border-b border-border/50 bg-muted/10 select-none">
-      <Rows2 className="h-3 w-3 text-muted-foreground/50 shrink-0" aria-hidden />
-      <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground truncate flex-1">{title}</span>
-      <button
-        type="button"
-        aria-label="Remove split"
-        title="Remove split"
-        onClick={() => setSecondary(null)}
-        className="h-5 w-5 inline-flex items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
-      >
-        <X className="h-3.5 w-3.5" />
-      </button>
+    <div
+      onMouseDown={onResizeStart}
+      role="separator"
+      aria-orientation="horizontal"
+      aria-label="Resize split"
+      className="group relative h-2.5 shrink-0 cursor-row-resize flex items-center justify-center border-y border-border/60 bg-muted/30 hover:bg-primary/10 transition-colors"
+    >
+      <GripHorizontal className="h-3 w-3 text-muted-foreground/50 group-hover:text-primary/70 transition-colors" />
     </div>
   );
 }
 
-/** Two stacked panels + a draggable divider; both halves reserve space (#1266). */
+/** Two stacked panels joined by one resize handle; both halves reserve space
+ *  (#1266). The body of each half owns its own header, so the split adds no
+ *  duplicate title chrome. */
 function SplitContainer({
   containerRef,
   ratio,
@@ -186,7 +195,7 @@ function SplitContainer({
   const setSecondary = useViewerStore((s) => s.setSidebarSecondaryPanel);
   return (
     <div ref={containerRef} className="h-full flex flex-col panel-container">
-      {/* Top half — flex-basis is the ratio; min-height stops it collapsing. */}
+      {/* Top half: flex-basis is the ratio; min-height stops it collapsing. */}
       <div
         data-detach-root
         className="flex flex-col min-h-[120px] overflow-hidden"
@@ -194,17 +203,10 @@ function SplitContainer({
       >
         {primary}
       </div>
-      {/* Divider */}
-      <div
-        onMouseDown={onDividerDown}
-        role="separator"
-        aria-orientation="horizontal"
-        aria-label="Resize split"
-        className="h-1.5 shrink-0 cursor-row-resize bg-border hover:bg-primary/50 active:bg-primary/70 transition-colors"
-      />
-      {/* Bottom half — fills the rest. */}
+      <SplitDivider onResizeStart={onDividerDown} />
+      {/* Bottom half fills the rest; the body's own header carries its title +
+          close (closing it clears the split). */}
       <div className="flex-1 min-h-[120px] flex flex-col overflow-hidden">
-        <SecondaryChromeBar id={secondaryId} />
         <div className="flex-1 min-h-0 overflow-hidden">
           {renderPanelBody(secondaryId, () => setSecondary(null))}
         </div>
@@ -296,7 +298,7 @@ export function SidebarPanelHost() {
 
   // Information fallback (or empty when Information is detached).
   if (shown === null || shown === 'properties') {
-    // Empty (Information detached) or no split → render single.
+    // Empty (Information detached) or no split: render single.
     if (shown === null || !secondaryActive) {
       return (
         <div data-detach-root className="h-full flex flex-col panel-container">
@@ -308,7 +310,7 @@ export function SidebarPanelHost() {
         </div>
       );
     }
-    // Information on top, a second panel below (the user's canonical example).
+    // Information on top, a second panel below (the canonical example).
     return (
       <SplitContainer
         containerRef={containerRef}
@@ -325,7 +327,7 @@ export function SidebarPanelHost() {
     );
   }
 
-  // A docked analysis panel — optionally split with a second panel below.
+  // A docked analysis panel, optionally split with a second panel below.
   if (!secondaryActive) {
     return (
       <div className="h-full flex flex-col panel-container">

--- a/apps/viewer/src/hooks/usePanelControls.ts
+++ b/apps/viewer/src/hooks/usePanelControls.ts
@@ -18,6 +18,7 @@ import { useViewerStore } from '@/store';
 import {
   isAnalysisPanel,
   isBottomPanel,
+  isLeftPanel,
   type WorkspacePanelId,
   type AnalysisPanelId,
 } from '@/lib/panels/registry';
@@ -69,6 +70,8 @@ export function usePanelControls(): PanelControls {
   const scriptVisible = useViewerStore((s) => s.scriptPanelVisible);
   const ganttVisible = useViewerStore((s) => s.ganttPanelVisible);
   const listVisible = useViewerStore((s) => s.listPanelVisible);
+  // The Hierarchy panel (left region, #1267) is "docked" while its slot is open.
+  const leftPanelCollapsed = useViewerStore((s) => s.leftPanelCollapsed);
 
   const floatingIds = useMemo(
     () => new Set<WorkspacePanelId>(floatingPanels.map((p) => p.id)),
@@ -87,12 +90,13 @@ export function usePanelControls(): PanelControls {
 
   const isDockedInHome = useCallback(
     (id: WorkspacePanelId): boolean => {
+      if (id === 'hierarchy') return !leftPanelCollapsed; // left slot open
       if (id === 'script') return scriptVisible;
       if (id === 'gantt') return ganttVisible;
       if (id === 'lists') return listVisible;
       return id === sideDocked; // side panels: the panel actually shown in the pane
     },
-    [sideDocked, scriptVisible, ganttVisible, listVisible],
+    [sideDocked, scriptVisible, ganttVisible, listVisible, leftPanelCollapsed],
   );
 
   const panelLocation = useCallback(
@@ -110,25 +114,49 @@ export function usePanelControls(): PanelControls {
   );
 
   const openInHome = useCallback((id: WorkspacePanelId) => {
+    // Hierarchy's home is the left slot — reveal it instead of routing through
+    // the right-pane / bottom-strip flags (#1267).
+    if (isLeftPanel(id)) {
+      useViewerStore.getState().setLeftPanelCollapsed(false);
+      return;
+    }
     useViewerStore.getState().openPanelInHome(id);
   }, []);
 
   const toggle = useCallback((id: WorkspacePanelId) => {
+    if (isLeftPanel(id)) {
+      const s = useViewerStore.getState();
+      s.setLeftPanelCollapsed(!s.leftPanelCollapsed);
+      return;
+    }
     if (isBottomPanel(id)) useViewerStore.getState().toggleBottomPanel(id);
     else useViewerStore.getState().toggleWorkspacePanel(id);
   }, []);
 
   const floatPanel = useCallback((id: WorkspacePanelId) => {
+    // The left nav panel stays docked on the left — never floats (#1267).
+    if (isLeftPanel(id)) {
+      useViewerStore.getState().setLeftPanelCollapsed(false);
+      return;
+    }
     closePanelWindow(id);
     useViewerStore.getState().floatPanel(id);
     useViewerStore.getState().setRightPanelCollapsed(false);
   }, []);
 
   const popOutPanel = useCallback((id: WorkspacePanelId) => {
+    if (isLeftPanel(id)) {
+      useViewerStore.getState().setLeftPanelCollapsed(false);
+      return;
+    }
     void openPanelWindow(id);
   }, []);
 
   const closePanel = useCallback((id: WorkspacePanelId) => {
+    if (isLeftPanel(id)) {
+      useViewerStore.getState().setLeftPanelCollapsed(true);
+      return;
+    }
     useViewerStore.getState().closeFloatingPanel(id);
     closePanelWindow(id);
     if (isAnalysisPanel(id)) setDockedVisible(id, false);

--- a/apps/viewer/src/hooks/usePanelControls.ts
+++ b/apps/viewer/src/hooks/usePanelControls.ts
@@ -72,6 +72,8 @@ export function usePanelControls(): PanelControls {
   const listVisible = useViewerStore((s) => s.listPanelVisible);
   // The Hierarchy panel (left region, #1267) is "docked" while its slot is open.
   const leftPanelCollapsed = useViewerStore((s) => s.leftPanelCollapsed);
+  // The lower half of a docked split (#1266) — also docked/visible.
+  const secondaryPanel = useViewerStore((s) => s.sidebarSecondaryPanel);
 
   const floatingIds = useMemo(
     () => new Set<WorkspacePanelId>(floatingPanels.map((p) => p.id)),
@@ -88,15 +90,25 @@ export function usePanelControls(): PanelControls {
     return null;
   }, [activePanel, floatingIds, poppedIds]);
 
+  // The panel actually rendered in the lower split half — mirrors
+  // SidebarPanelHost's `secondaryActive`: set, inline (not floated / popped), and
+  // distinct from the primary. So the rail reflects it as docked, not closed.
+  const secondaryDocked = useMemo<WorkspacePanelId | null>(() => {
+    if (!secondaryPanel || secondaryPanel === sideDocked) return null;
+    if (floatingIds.has(secondaryPanel) || poppedIds.has(secondaryPanel)) return null;
+    return secondaryPanel;
+  }, [secondaryPanel, sideDocked, floatingIds, poppedIds]);
+
   const isDockedInHome = useCallback(
     (id: WorkspacePanelId): boolean => {
       if (id === 'hierarchy') return !leftPanelCollapsed; // left slot open
       if (id === 'script') return scriptVisible;
       if (id === 'gantt') return ganttVisible;
       if (id === 'lists') return listVisible;
-      return id === sideDocked; // side panels: the panel actually shown in the pane
+      // A side panel is docked as the right-pane primary OR the split secondary.
+      return id === sideDocked || id === secondaryDocked;
     },
-    [sideDocked, scriptVisible, ganttVisible, listVisible, leftPanelCollapsed],
+    [sideDocked, secondaryDocked, scriptVisible, ganttVisible, listVisible, leftPanelCollapsed],
   );
 
   const panelLocation = useCallback(
@@ -129,6 +141,13 @@ export function usePanelControls(): PanelControls {
       s.setLeftPanelCollapsed(!s.leftPanelCollapsed);
       return;
     }
+    // If the panel is the lower split half it's already docked below — toggling
+    // its rail icon closes that half (clears the split) rather than promoting it
+    // to primary and collapsing the split out from under it (#1266).
+    if (useViewerStore.getState().sidebarSecondaryPanel === id) {
+      useViewerStore.getState().setSidebarSecondaryPanel(null);
+      return;
+    }
     if (isBottomPanel(id)) useViewerStore.getState().toggleBottomPanel(id);
     else useViewerStore.getState().toggleWorkspacePanel(id);
   }, []);
@@ -156,6 +175,10 @@ export function usePanelControls(): PanelControls {
     if (isLeftPanel(id)) {
       useViewerStore.getState().setLeftPanelCollapsed(true);
       return;
+    }
+    // If it was the lower split half, leave the split too (#1266).
+    if (useViewerStore.getState().sidebarSecondaryPanel === id) {
+      useViewerStore.getState().setSidebarSecondaryPanel(null);
     }
     useViewerStore.getState().closeFloatingPanel(id);
     closePanelWindow(id);

--- a/apps/viewer/src/hooks/usePanelControls.ts
+++ b/apps/viewer/src/hooks/usePanelControls.ts
@@ -72,7 +72,7 @@ export function usePanelControls(): PanelControls {
   const listVisible = useViewerStore((s) => s.listPanelVisible);
   // The Hierarchy panel (left region, #1267) is "docked" while its slot is open.
   const leftPanelCollapsed = useViewerStore((s) => s.leftPanelCollapsed);
-  // The lower half of a docked split (#1266) — also docked/visible.
+  // The lower half of a docked split (#1266), also docked/visible.
   const secondaryPanel = useViewerStore((s) => s.sidebarSecondaryPanel);
 
   const floatingIds = useMemo(
@@ -90,7 +90,7 @@ export function usePanelControls(): PanelControls {
     return null;
   }, [activePanel, floatingIds, poppedIds]);
 
-  // The panel actually rendered in the lower split half — mirrors
+  // The panel actually rendered in the lower split half, mirroring
   // SidebarPanelHost's `secondaryActive`: set, inline (not floated / popped), and
   // distinct from the primary. So the rail reflects it as docked, not closed.
   const secondaryDocked = useMemo<WorkspacePanelId | null>(() => {
@@ -126,7 +126,7 @@ export function usePanelControls(): PanelControls {
   );
 
   const openInHome = useCallback((id: WorkspacePanelId) => {
-    // Hierarchy's home is the left slot — reveal it instead of routing through
+    // Hierarchy's home is the left slot, so reveal it instead of routing through
     // the right-pane / bottom-strip flags (#1267).
     if (isLeftPanel(id)) {
       useViewerStore.getState().setLeftPanelCollapsed(false);
@@ -141,9 +141,9 @@ export function usePanelControls(): PanelControls {
       s.setLeftPanelCollapsed(!s.leftPanelCollapsed);
       return;
     }
-    // If the panel is the lower split half it's already docked below — toggling
-    // its rail icon closes that half (clears the split) rather than promoting it
-    // to primary and collapsing the split out from under it (#1266).
+    // If the panel is the lower split half it's already docked below, so
+    // toggling its rail icon closes that half (clears the split) rather than
+    // promoting it to primary and collapsing the split out from under it (#1266).
     if (useViewerStore.getState().sidebarSecondaryPanel === id) {
       useViewerStore.getState().setSidebarSecondaryPanel(null);
       return;
@@ -153,7 +153,7 @@ export function usePanelControls(): PanelControls {
   }, []);
 
   const floatPanel = useCallback((id: WorkspacePanelId) => {
-    // The left nav panel stays docked on the left — never floats (#1267).
+    // The left nav panel stays docked on the left; it never floats (#1267).
     if (isLeftPanel(id)) {
       useViewerStore.getState().setLeftPanelCollapsed(false);
       return;

--- a/apps/viewer/src/lib/panels/registry.test.ts
+++ b/apps/viewer/src/lib/panels/registry.test.ts
@@ -32,12 +32,26 @@ describe('workspacePanelForShortcutCode (Alt+digit routing #1200/#1208)', () => 
     assert.strictEqual(workspacePanelForShortcutCode('Numpad0'), WORKSPACE_PANELS[9].id);
   });
 
-  it('every digit maps to a distinct, valid panel id', () => {
+  it('the ten digit shortcuts map to the first ten registry panels, in order', () => {
     const codes = ['Digit1', 'Digit2', 'Digit3', 'Digit4', 'Digit5', 'Digit6', 'Digit7', 'Digit8', 'Digit9', 'Digit0'];
     const ids = codes.map((c) => workspacePanelForShortcutCode(c));
     assert.ok(ids.every((id) => id !== undefined && isWorkspacePanelId(id)));
     assert.strictEqual(new Set(ids).size, codes.length, 'no two digits collide');
-    assert.strictEqual(ids.length, WORKSPACE_PANELS.length, 'one digit per registry panel');
+    // Only the first ten registry entries get an Alt shortcut; later additions
+    // (e.g. Hierarchy, #1267) are reachable from the rail but have no digit.
+    assert.deepStrictEqual(ids, WORKSPACE_PANELS.slice(0, 10).map((p) => p.id));
+  });
+
+  it('registry panels past the tenth have no Alt+digit shortcut (#1267)', () => {
+    // Hierarchy is appended so the frozen Alt+1..0 mapping stays intact.
+    assert.ok(WORKSPACE_PANELS.length >= 11, 'expected Hierarchy appended to the registry');
+    const shortcutTargets = new Set(
+      ['Digit1', 'Digit2', 'Digit3', 'Digit4', 'Digit5', 'Digit6', 'Digit7', 'Digit8', 'Digit9', 'Digit0']
+        .map((c) => workspacePanelForShortcutCode(c)),
+    );
+    for (const def of WORKSPACE_PANELS.slice(10)) {
+      assert.ok(!shortcutTargets.has(def.id), `${def.id} should not be bound to a digit`);
+    }
   });
 
   it('bottom-strip panels are reachable by shortcut and flagged as bottom', () => {

--- a/apps/viewer/src/lib/panels/registry.ts
+++ b/apps/viewer/src/lib/panels/registry.ts
@@ -85,7 +85,7 @@ export const WORKSPACE_PANELS: readonly WorkspacePanelDef[] = [
   { id: 'script', title: 'Script editor', short: 'Script', Icon: Terminal, group: 'work', region: 'bottom', prefersWide: true },
   { id: 'gantt', title: 'Construction schedule', short: 'Schedule', Icon: CalendarRange, group: 'work', region: 'bottom', prefersWide: true },
   { id: 'lists', title: 'Entity lists', short: 'Lists', Icon: Table2, group: 'work', region: 'bottom', prefersWide: true },
-  // Left-slot nav panel (#1267) — APPENDED so the frozen Alt+1..0 mapping above
+  // Left-slot nav panel (#1267), APPENDED so the frozen Alt+1..0 mapping above
   // is untouched (it gets no Alt shortcut). Its default *display* position is the
   // top of the rail (see DEFAULT_ORDER in sidebarSlice); the activity bar toggles
   // its left slot via `leftPanelCollapsed` rather than the right-pane flags.
@@ -100,7 +100,7 @@ export function isBottomPanel(id: WorkspacePanelId): id is BottomPanelId {
   return id === 'script' || id === 'gantt' || id === 'lists';
 }
 
-/** The left-slot nav panel (Hierarchy, #1267) — toggled via `leftPanelCollapsed`,
+/** The left-slot nav panel (Hierarchy, #1267): toggled via `leftPanelCollapsed`,
  *  never floated / popped / docked into the right pane. */
 export function isLeftPanel(id: WorkspacePanelId): id is 'hierarchy' {
   return id === 'hierarchy';

--- a/apps/viewer/src/lib/panels/registry.ts
+++ b/apps/viewer/src/lib/panels/registry.ts
@@ -28,14 +28,17 @@ import {
   Terminal,
   CalendarRange,
   Table2,
+  ListTree,
   type LucideIcon,
 } from 'lucide-react';
 
 /** Every panel reachable from the unified sidebar rail. `properties` is the
  *  Information panel (the right pane's default fallback). Each panel opens in
  *  its home {@link WorkspacePanelDef.region} — `side` panels in the right pane,
- *  `bottom` panels (Script / Schedule / Lists) in the bottom strip. */
+ *  `bottom` panels (Script / Schedule / Lists) in the bottom strip, and the
+ *  `left` panel (Hierarchy) in the left navigation slot (#1267). */
 export type WorkspacePanelId =
+  | 'hierarchy'
   | 'properties'
   | 'compare'
   | 'bcf'
@@ -48,10 +51,11 @@ export type WorkspacePanelId =
   | 'lists';
 
 /** Activity-bar clustering — a divider is drawn whenever the group changes. */
-export type PanelGroup = 'inspect' | 'review' | 'author' | 'work';
+export type PanelGroup = 'navigate' | 'inspect' | 'review' | 'author' | 'work';
 
-/** Where a panel docks when opened from the rail. */
-export type PanelRegion = 'side' | 'bottom';
+/** Where a panel docks when opened from the rail. `left` is the dedicated
+ *  hierarchy navigation slot, toggled via `leftPanelCollapsed` (#1267). */
+export type PanelRegion = 'side' | 'bottom' | 'left';
 
 export interface WorkspacePanelDef {
   id: WorkspacePanelId;
@@ -81,6 +85,11 @@ export const WORKSPACE_PANELS: readonly WorkspacePanelDef[] = [
   { id: 'script', title: 'Script editor', short: 'Script', Icon: Terminal, group: 'work', region: 'bottom', prefersWide: true },
   { id: 'gantt', title: 'Construction schedule', short: 'Schedule', Icon: CalendarRange, group: 'work', region: 'bottom', prefersWide: true },
   { id: 'lists', title: 'Entity lists', short: 'Lists', Icon: Table2, group: 'work', region: 'bottom', prefersWide: true },
+  // Left-slot nav panel (#1267) — APPENDED so the frozen Alt+1..0 mapping above
+  // is untouched (it gets no Alt shortcut). Its default *display* position is the
+  // top of the rail (see DEFAULT_ORDER in sidebarSlice); the activity bar toggles
+  // its left slot via `leftPanelCollapsed` rather than the right-pane flags.
+  { id: 'hierarchy', title: 'Hierarchy', short: 'Tree', Icon: ListTree, group: 'navigate', region: 'left' },
 ];
 
 /** The bottom-strip panel ids, mapped to their store visibility flag + setter
@@ -89,6 +98,12 @@ export type BottomPanelId = Extract<WorkspacePanelId, 'script' | 'gantt' | 'list
 
 export function isBottomPanel(id: WorkspacePanelId): id is BottomPanelId {
   return id === 'script' || id === 'gantt' || id === 'lists';
+}
+
+/** The left-slot nav panel (Hierarchy, #1267) — toggled via `leftPanelCollapsed`,
+ *  never floated / popped / docked into the right pane. */
+export function isLeftPanel(id: WorkspacePanelId): id is 'hierarchy' {
+  return id === 'hierarchy';
 }
 
 const PANEL_BY_ID = new Map<WorkspacePanelId, WorkspacePanelDef>(WORKSPACE_PANELS.map((p) => [p.id, p]));

--- a/apps/viewer/src/lib/panels/renderPanelBody.tsx
+++ b/apps/viewer/src/lib/panels/renderPanelBody.tsx
@@ -13,6 +13,7 @@
 
 import type { ReactNode } from 'react';
 import type { WorkspacePanelId } from './registry';
+import { HierarchyPanel } from '@/components/viewer/HierarchyPanel';
 import { PropertiesPanel } from '@/components/viewer/PropertiesPanel';
 import { ComparePanel } from '@/components/viewer/ComparePanel';
 import { BCFPanel } from '@/components/viewer/BCFPanel';
@@ -31,6 +32,9 @@ import { ListPanel } from '@/components/viewer/lists/ListPanel';
  */
 export function renderPanelBody(id: WorkspacePanelId, onClose: () => void): ReactNode {
   switch (id) {
+    // Hierarchy's home is the left slot (#1267); it is never routed to the right
+    // pane / float / pop-out, but the case keeps the id → body map exhaustive.
+    case 'hierarchy': return <HierarchyPanel />;
     case 'properties': return <PropertiesPanel />;
     case 'compare': return <ComparePanel onClose={onClose} />;
     case 'bcf': return <BCFPanel onClose={onClose} />;

--- a/apps/viewer/src/lib/panels/renderPanelBody.tsx
+++ b/apps/viewer/src/lib/panels/renderPanelBody.tsx
@@ -33,7 +33,7 @@ import { ListPanel } from '@/components/viewer/lists/ListPanel';
 export function renderPanelBody(id: WorkspacePanelId, onClose: () => void): ReactNode {
   switch (id) {
     // Hierarchy's home is the left slot (#1267); it is never routed to the right
-    // pane / float / pop-out, but the case keeps the id → body map exhaustive.
+    // pane / float / pop-out, but the case keeps the id to body map exhaustive.
     case 'hierarchy': return <HierarchyPanel />;
     case 'properties': return <PropertiesPanel />;
     case 'compare': return <ComparePanel onClose={onClose} />;

--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -695,9 +695,9 @@ function registerSidebarExclusivity(store: ReturnType<typeof createViewerStore>)
 /**
  * Keep the Hierarchy left slot (#1267) in step with its rail visibility: hiding
  * the Hierarchy icon from the activity bar collapses its left slot, and showing
- * it again re-opens the slot — so "hide it" actually hides the panel, not just
- * its rail entry. One-way (hidden-set → collapse); collapsing via the left drag
- * handle keeps the rail icon so the panel can be re-opened from there.
+ * it again re-opens the slot, so "hide it" actually hides the panel, not just
+ * its rail entry. One-way (hidden-set drives collapse); collapsing via the left
+ * drag handle keeps the rail icon so the panel can be re-opened from there.
  */
 function registerHierarchyLeftSync(store: ReturnType<typeof createViewerStore>): void {
   store.subscribe((state, prev) => {

--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -692,18 +692,37 @@ function registerSidebarExclusivity(store: ReturnType<typeof createViewerStore>)
   });
 }
 
+/**
+ * Keep the Hierarchy left slot (#1267) in step with its rail visibility: hiding
+ * the Hierarchy icon from the activity bar collapses its left slot, and showing
+ * it again re-opens the slot — so "hide it" actually hides the panel, not just
+ * its rail entry. One-way (hidden-set → collapse); collapsing via the left drag
+ * handle keeps the rail icon so the panel can be re-opened from there.
+ */
+function registerHierarchyLeftSync(store: ReturnType<typeof createViewerStore>): void {
+  store.subscribe((state, prev) => {
+    const wasHidden = prev.sidebarHiddenIds.includes('hierarchy');
+    const isHidden = state.sidebarHiddenIds.includes('hierarchy');
+    if (isHidden !== wasHidden) state.setLeftPanelCollapsed(isHidden);
+  });
+}
+
 export function getViewerStoreApi() {
   const existing = globalStoreRegistry[STORE_SINGLETON_KEY];
   if (existing) return existing;
   const store = createViewerStore();
   globalStoreRegistry[STORE_SINGLETON_KEY] = store;
   registerSidebarExclusivity(store);
+  registerHierarchyLeftSync(store);
   // Initial reconcile: a persisted panel flag (e.g. scriptPanelVisible) can be
   // true at load before any change fires the subscription, so seed the docked
   // panel from the current flags rather than leaving it on the fallback.
   const init = store.getState();
   const initialActive = SIDEBAR_PANEL_FLAGS.find(([flag]) => init[flag])?.[1];
   if (initialActive) init.setSidebarActivePanel(initialActive);
+  // A persisted "Hierarchy hidden" never fired the subscription above, so seed
+  // the collapsed left slot from it on load (#1267).
+  if (init.sidebarHiddenIds.includes('hierarchy')) init.setLeftPanelCollapsed(true);
   return store;
 }
 

--- a/apps/viewer/src/store/slices/sidebarSlice.test.ts
+++ b/apps/viewer/src/store/slices/sidebarSlice.test.ts
@@ -115,6 +115,81 @@ describe('sidebarSlice (#1208)', () => {
     s.getState().resetSidebarLayout();
     assert.strictEqual(s.getState().sidebarMode, 'expanded');
     assert.deepStrictEqual(s.getState().sidebarHiddenIds, []);
-    assert.strictEqual(s.getState().sidebarOrder[0], WORKSPACE_PANELS[0].id);
+    // Hierarchy (#1267) is the default top of the rail, even though it's the
+    // last *registry* entry (so the Alt+1..0 mapping stays frozen).
+    assert.strictEqual(s.getState().sidebarOrder[0], 'hierarchy');
+  });
+});
+
+describe('sidebarSlice ordering (#1267)', () => {
+  it('defaults Hierarchy to the top of the rail order', () => {
+    const s = make();
+    assert.strictEqual(s.getState().sidebarOrder[0], 'hierarchy');
+  });
+
+  it('keeps every registry panel present after reordering Hierarchy', () => {
+    const s = make();
+    const before = [...s.getState().sidebarOrder].sort();
+    s.getState().reorderSidebarPanel('hierarchy', 5);
+    const after = [...s.getState().sidebarOrder].sort();
+    assert.deepStrictEqual(after, before);
+    assert.strictEqual(s.getState().sidebarOrder.length, WORKSPACE_PANELS.length);
+  });
+});
+
+describe('sidebarSlice docked split (#1266)', () => {
+  it('sets a side panel as the lower split half', () => {
+    const s = make();
+    s.getState().setSidebarActivePanel('ids');
+    s.getState().setSidebarSecondaryPanel('compare');
+    assert.strictEqual(s.getState().sidebarSecondaryPanel, 'compare');
+  });
+
+  it('rejects non-side panels as the split half (bottom / left)', () => {
+    const s = make();
+    s.getState().setSidebarActivePanel('ids');
+    s.getState().setSidebarSecondaryPanel('script'); // bottom strip
+    assert.strictEqual(s.getState().sidebarSecondaryPanel, null);
+    s.getState().setSidebarSecondaryPanel('hierarchy'); // left slot
+    assert.strictEqual(s.getState().sidebarSecondaryPanel, null);
+  });
+
+  it('refuses to split a panel against itself', () => {
+    const s = make();
+    s.getState().setSidebarActivePanel('ids');
+    s.getState().setSidebarSecondaryPanel('ids');
+    assert.strictEqual(s.getState().sidebarSecondaryPanel, null);
+  });
+
+  it('collapses the split when the secondary is promoted to primary', () => {
+    const s = make();
+    s.getState().setSidebarActivePanel('ids');
+    s.getState().setSidebarSecondaryPanel('compare');
+    assert.strictEqual(s.getState().sidebarSecondaryPanel, 'compare');
+    s.getState().setSidebarActivePanel('compare');
+    assert.strictEqual(s.getState().sidebarActivePanel, 'compare');
+    assert.strictEqual(s.getState().sidebarSecondaryPanel, null);
+  });
+
+  it('clamps the split ratio to [0.2, 0.8] and falls back on NaN', () => {
+    const s = make();
+    s.getState().setSidebarSplitRatio(0.05);
+    assert.strictEqual(s.getState().sidebarSplitRatio, 0.2);
+    s.getState().setSidebarSplitRatio(0.95);
+    assert.strictEqual(s.getState().sidebarSplitRatio, 0.8);
+    s.getState().setSidebarSplitRatio(0.42);
+    assert.strictEqual(s.getState().sidebarSplitRatio, 0.42);
+    s.getState().setSidebarSplitRatio(Number.NaN);
+    assert.strictEqual(s.getState().sidebarSplitRatio, 0.5);
+  });
+
+  it('resetSidebarLayout drops the split back to a single panel', () => {
+    const s = make();
+    s.getState().setSidebarActivePanel('ids');
+    s.getState().setSidebarSecondaryPanel('compare');
+    s.getState().setSidebarSplitRatio(0.7);
+    s.getState().resetSidebarLayout();
+    assert.strictEqual(s.getState().sidebarSecondaryPanel, null);
+    assert.strictEqual(s.getState().sidebarSplitRatio, 0.5);
   });
 });

--- a/apps/viewer/src/store/slices/sidebarSlice.test.ts
+++ b/apps/viewer/src/store/slices/sidebarSlice.test.ts
@@ -99,8 +99,10 @@ describe('sidebarSlice (#1208)', () => {
     });
     assert.ok(['expanded', 'collapsed'].includes(s.getState().sidebarMode));
     assert.ok(Number.isFinite(s.getState().sidebarWidthPct));
-    // order: bcf first, no dupes / unknowns, every registry panel present.
-    assert.strictEqual(s.getState().sidebarOrder[0], 'bcf');
+    // order: Hierarchy is migrated to the top (#1267), then the persisted bcf,
+    // no dupes / unknowns, every registry panel present.
+    assert.strictEqual(s.getState().sidebarOrder[0], 'hierarchy');
+    assert.strictEqual(s.getState().sidebarOrder[1], 'bcf');
     assert.strictEqual(new Set(s.getState().sidebarOrder).size, WORKSPACE_PANELS.length);
     // Information is never hidden; a valid id is.
     assert.ok(!s.getState().sidebarHiddenIds.includes('properties'));
@@ -134,6 +136,15 @@ describe('sidebarSlice ordering (#1267)', () => {
     const after = [...s.getState().sidebarOrder].sort();
     assert.deepStrictEqual(after, before);
     assert.strictEqual(s.getState().sidebarOrder.length, WORKSPACE_PANELS.length);
+  });
+
+  it('migrates a pre-#1267 saved order (no Hierarchy) by prepending it to the top', () => {
+    const s = make();
+    // An order persisted before Hierarchy existed in the registry.
+    s.getState().applySidebarLayout({ order: ['properties', 'compare', 'bcf'] });
+    assert.strictEqual(s.getState().sidebarOrder[0], 'hierarchy');
+    assert.strictEqual(s.getState().sidebarOrder[1], 'properties');
+    assert.strictEqual(new Set(s.getState().sidebarOrder).size, WORKSPACE_PANELS.length);
   });
 });
 

--- a/apps/viewer/src/store/slices/sidebarSlice.ts
+++ b/apps/viewer/src/store/slices/sidebarSlice.ts
@@ -24,9 +24,24 @@ import type { StateCreator } from 'zustand';
 import {
   WORKSPACE_PANELS,
   isWorkspacePanelId,
+  getPanelDef,
   SIDEBAR_DEFAULT_WIDTH_PCT,
   type WorkspacePanelId,
 } from '@/lib/panels/registry';
+
+/** Clamp the docked-split ratio so neither half can collapse to nothing. */
+const MIN_SPLIT_RATIO = 0.2;
+const MAX_SPLIT_RATIO = 0.8;
+function clampSplitRatio(r: number): number {
+  if (!Number.isFinite(r)) return 0.5;
+  return Math.max(MIN_SPLIT_RATIO, Math.min(MAX_SPLIT_RATIO, r));
+}
+
+/** Only right-pane (`side`) panels can share the docked split (#1266) — bottom
+ *  and left panels have their own regions. */
+function canShareSplit(id: WorkspacePanelId): boolean {
+  return getPanelDef(id)?.region === 'side';
+}
 
 /** Expanded = rail + content pane; collapsed = icon-only rail. The activity-bar
  *  rail is always visible — there is intentionally no "fully off" mode (the
@@ -45,7 +60,15 @@ const STORAGE_KEY = 'ifc-lite:sidebar-layout-v1';
 const MIN_WIDTH_PCT = 14;
 const MAX_WIDTH_PCT = 60;
 
-const DEFAULT_ORDER: WorkspacePanelId[] = WORKSPACE_PANELS.map((p) => p.id);
+// Display order in the rail. Hierarchy (#1267) is appended to WORKSPACE_PANELS
+// to keep the frozen Alt+1..0 mapping intact, but its natural home is the TOP
+// of the rail (it's the primary navigation surface), so float it to the front
+// here. The registry order still drives Alt+N; this only drives display.
+const DEFAULT_ORDER: WorkspacePanelId[] = (() => {
+  const ids = WORKSPACE_PANELS.map((p) => p.id);
+  const rest = ids.filter((id) => id !== 'hierarchy');
+  return ids.includes('hierarchy') ? ['hierarchy', ...rest] : rest;
+})();
 
 function clampWidth(pct: number): number {
   if (!Number.isFinite(pct)) return SIDEBAR_DEFAULT_WIDTH_PCT;
@@ -145,6 +168,13 @@ export interface SidebarSlice {
   /** The panel currently shown in the dock — runtime only; tracked from the
    *  per-panel visibility flags by the store subscription. */
   sidebarActivePanel: WorkspacePanelId;
+  /** The panel shown in the LOWER half of a split docked pane, or null when the
+   *  pane isn't split (#1266). Side panels only; runtime-only (a within-session
+   *  power feature, like the float layout's geometry). */
+  sidebarSecondaryPanel: WorkspacePanelId | null;
+  /** Fraction (0.2–0.8) of the docked pane's height given to the TOP panel when
+   *  split. Runtime-only. */
+  sidebarSplitRatio: number;
   /** Panels currently torn off into an OS / PiP window — runtime only
    *  (window handles can't persist, and pop-up blockers forbid auto-reopen). */
   poppedOutIds: WorkspacePanelId[];
@@ -164,6 +194,11 @@ export interface SidebarSlice {
   resetSidebarLayout: () => void;
   /** Set the active docked panel (called by the store's exclusivity subscription). */
   setSidebarActivePanel: (id: WorkspacePanelId) => void;
+  /** Set / clear the lower-half split panel (#1266). Ignores non-side panels and
+   *  a panel that already owns the top half. Un-floating is the caller's job. */
+  setSidebarSecondaryPanel: (id: WorkspacePanelId | null) => void;
+  /** Resize the docked split (fraction for the top panel, clamped 0.2–0.8). */
+  setSidebarSplitRatio: (ratio: number) => void;
   /** Track a panel popped out into / re-docked from an OS window. */
   setPanelPoppedOut: (id: WorkspacePanelId, on: boolean) => void;
 
@@ -194,6 +229,8 @@ export const createSidebarSlice: StateCreator<SidebarSlice, [], [], SidebarSlice
     sidebarHiddenIds: persisted.hiddenIds,
     sidebarCustomizing: false,
     sidebarActivePanel: 'properties',
+    sidebarSecondaryPanel: null,
+    sidebarSplitRatio: 0.5,
     poppedOutIds: [],
 
     setSidebarMode: (mode) => {
@@ -253,13 +290,28 @@ export const createSidebarSlice: StateCreator<SidebarSlice, [], [], SidebarSlice
         sidebarOrder: snap.order,
         sidebarHiddenIds: snap.hiddenIds,
         sidebarCustomizing: false,
+        // Drop any docked split back to a single panel (#1266).
+        sidebarSecondaryPanel: null,
+        sidebarSplitRatio: 0.5,
       });
       persist(snap);
     },
 
     setSidebarActivePanel: (id) => {
-      if (get().sidebarActivePanel !== id) set({ sidebarActivePanel: id });
+      const patch: Partial<SidebarSlice> = {};
+      if (get().sidebarActivePanel !== id) patch.sidebarActivePanel = id;
+      // The top half can't also be the bottom half — if the new primary is the
+      // split secondary, collapse the split (#1266).
+      if (get().sidebarSecondaryPanel === id) patch.sidebarSecondaryPanel = null;
+      if (Object.keys(patch).length > 0) set(patch);
     },
+
+    setSidebarSecondaryPanel: (id) => {
+      if (id !== null && (!canShareSplit(id) || id === get().sidebarActivePanel)) return;
+      set({ sidebarSecondaryPanel: id });
+    },
+
+    setSidebarSplitRatio: (ratio) => set({ sidebarSplitRatio: clampSplitRatio(ratio) }),
 
     setPanelPoppedOut: (id, on) => {
       const current = get().poppedOutIds;

--- a/apps/viewer/src/store/slices/sidebarSlice.ts
+++ b/apps/viewer/src/store/slices/sidebarSlice.ts
@@ -37,7 +37,7 @@ function clampSplitRatio(r: number): number {
   return Math.max(MIN_SPLIT_RATIO, Math.min(MAX_SPLIT_RATIO, r));
 }
 
-/** Only right-pane (`side`) panels can share the docked split (#1266) — bottom
+/** Only right-pane (`side`) panels can share the docked split (#1266); bottom
  *  and left panels have their own regions. */
 function canShareSplit(id: WorkspacePanelId): boolean {
   return getPanelDef(id)?.region === 'side';
@@ -178,8 +178,8 @@ export interface SidebarSlice {
    *  pane isn't split (#1266). Side panels only; runtime-only (a within-session
    *  power feature, like the float layout's geometry). */
   sidebarSecondaryPanel: WorkspacePanelId | null;
-  /** Fraction (0.2–0.8) of the docked pane's height given to the TOP panel when
-   *  split. Runtime-only. */
+  /** Fraction (0.2 to 0.8) of the docked pane's height given to the TOP panel
+   *  when split. Runtime-only. */
   sidebarSplitRatio: number;
   /** Panels currently torn off into an OS / PiP window — runtime only
    *  (window handles can't persist, and pop-up blockers forbid auto-reopen). */
@@ -203,7 +203,7 @@ export interface SidebarSlice {
   /** Set / clear the lower-half split panel (#1266). Ignores non-side panels and
    *  a panel that already owns the top half. Un-floating is the caller's job. */
   setSidebarSecondaryPanel: (id: WorkspacePanelId | null) => void;
-  /** Resize the docked split (fraction for the top panel, clamped 0.2–0.8). */
+  /** Resize the docked split (fraction for the top panel, clamped 0.2 to 0.8). */
   setSidebarSplitRatio: (ratio: number) => void;
   /** Track a panel popped out into / re-docked from an OS window. */
   setPanelPoppedOut: (id: WorkspacePanelId, on: boolean) => void;
@@ -306,7 +306,7 @@ export const createSidebarSlice: StateCreator<SidebarSlice, [], [], SidebarSlice
     setSidebarActivePanel: (id) => {
       const patch: Partial<SidebarSlice> = {};
       if (get().sidebarActivePanel !== id) patch.sidebarActivePanel = id;
-      // The top half can't also be the bottom half — if the new primary is the
+      // The top half can't also be the bottom half: if the new primary is the
       // split secondary, collapse the split (#1266).
       if (get().sidebarSecondaryPanel === id) patch.sidebarSecondaryPanel = null;
       if (Object.keys(patch).length > 0) set(patch);

--- a/apps/viewer/src/store/slices/sidebarSlice.ts
+++ b/apps/viewer/src/store/slices/sidebarSlice.ts
@@ -92,8 +92,14 @@ function normalizeOrder(order: unknown): WorkspacePanelId[] {
       }
     }
   }
+  // Surface registry panels the persisted list never knew about, in
+  // DEFAULT_ORDER order. Hierarchy (#1267) is special: its documented home is
+  // the TOP of the rail, so a first-time migration of an order saved BEFORE it
+  // existed prepends it instead of trailing it at the bottom.
   for (const id of DEFAULT_ORDER) {
-    if (!seen.has(id)) out.push(id);
+    if (seen.has(id)) continue;
+    if (id === 'hierarchy') out.unshift(id);
+    else out.push(id);
   }
   return out;
 }


### PR DESCRIPTION
Follow-up feedback on the unified sidebar (#1217) and level-display (#1095). Five issues filed after #1263, all in the viewer's sidebar / hierarchy area.

## #1264 + #1266 — Splittable right dock (reserves space)
- The right sidebar dock can split into **two stacked panels with a draggable divider**. Both halves reserve real layout space beside the model — never an overlay (that was the #1264 complaint).
- A **Split** control in the panel chrome picks / switches / removes the lower panel, and pulls a currently-floating panel back inline.
- Floating chrome relabeled to disambiguate: **Snap left/bottom/right = overlay positioning** (model stays full size behind), **Dock = reserves space**. Free-float stays a separate option.

## #1267 — Hierarchy in the customizable panel list
- Hierarchy is now an item in the rail (default **top**, reorderable + hideable like the others); its home stays the **left slot**. The rail icon toggles the left slot; hiding it collapses the slot. The frozen `Alt+1..0` mapping is untouched — Hierarchy is appended to the registry and gets no digit shortcut.

## #1269 — Regrouped level modes
- **[Stacked | Solo]** are one segmented pair ("which storeys show"); **Exploded** is a separate toggle (it lifts the floors apart for a sectioned view).

## #1265 — Clearer level-display behavior
- Mode tooltips, an inline hint that the storey rows are the Solo picker, Solo on/off toasts, and Exploded now toggles back to Stacked. (Solo's single-isolation-channel design is unchanged — the confusion is addressed with copy/affordances, not a second selection path.)

## Verification
- `tsc --noEmit` clean · **38 unit tests pass** (added split-slice + registry/ordering tests) · production `vite build` green.
- Browser smoke (Chrome DevTools): split create / divider / remove, Hierarchy rail toggle + left-slot collapse, regrouped Stacked/Solo/Exploded + Exploded toggle-back on a 2-storey model — no JS console errors.

No changeset: viewer-app-only change (precedent #1248 shipped without one; nothing published depends on `@ifc-lite/viewer`).

Closes #1264
Closes #1265
Closes #1266
Closes #1267
Closes #1269


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated left-sidebar Hierarchy panel for improved navigation.
  * Introduced docked sidebar split mode to stack secondary panels beneath the active one.
  * Reorganized storey display controls with a Stacked ⇄ Solo toggle pair and separate Exploded button.

* **Improvements**
  * Enhanced toast messages for storey selection feedback.
  * Clarified floating panel control labels to distinguish overlay vs. docking behavior.
  * Optimized keyboard shortcut hints to the first 10 panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->