### PR TITLE
fix(viewer): Hide removes a panel from the list instead of disabling it in place (#1263)

### DIFF
--- a/apps/viewer/src/components/viewer/sidebar/ActivityBar.tsx
+++ b/apps/viewer/src/components/viewer/sidebar/ActivityBar.tsx
@@ -21,7 +21,6 @@ import {
   PanelRightOpen,
   EllipsisVertical,
   RotateCcw,
-  EyeOff,
   Eye,
   SquareArrowOutUpRight,
   MonitorUp,
@@ -64,7 +63,10 @@ export function ActivityBar() {
   const [dragId, setDragId] = useState<WorkspacePanelId | null>(null);
   const [overId, setOverId] = useState<WorkspacePanelId | null>(null);
 
-  const visibleIds = order.filter((id) => customizing || !hidden.has(id) || id === 'properties');
+  // Hidden panels are removed from the rail in every mode (#1263), including
+  // customize. Restoring a hidden panel happens in the Customize popover's
+  // dedicated Hidden section, not by an inline greyed icon here.
+  const visibleIds = order.filter((id) => !hidden.has(id) || id === 'properties');
 
   const onIconClick = (id: WorkspacePanelId) => {
     const region = getPanelDef(id)?.region;
@@ -102,15 +104,15 @@ export function ActivityBar() {
           const loc = panelLocation(id);
           const active = loc === 'docked';
           const open = isOpen(id);
-          const isHidden = hidden.has(id);
           const showDivider = prevGroup !== null && def.group !== prevGroup;
           prevGroup = def.group;
 
-          // Accessible name — the Radix tooltip is NOT the button's name, and
+          // Accessible name: the Radix tooltip is NOT the button's name, and
           // tooltips don't fire on touch / for many SR users, so set it
-          // explicitly. In customize mode it describes the show/hide action.
+          // explicitly. In customize mode the action is "hide" (only shown
+          // panels render here now, #1263).
           const ariaLabel = customizing
-            ? `${def.title}, ${isHidden ? 'hidden' : 'shown'} — activate to ${isHidden ? 'show' : 'hide'}`
+            ? `${def.title}, activate to hide from the sidebar`
             : `${def.title}${loc === 'floating' ? ' (floating)' : loc === 'popped' ? ' (popped out)' : ''}`;
 
           return (
@@ -121,7 +123,7 @@ export function ActivityBar() {
                   <button
                     type="button"
                     aria-label={ariaLabel}
-                    aria-pressed={customizing ? !isHidden : active}
+                    aria-pressed={active}
                     draggable={customizing && id !== 'properties'}
                     onDragStart={() => customizing && setDragId(id)}
                     onDragEnd={() => {
@@ -138,7 +140,7 @@ export function ActivityBar() {
                       setDragId(null);
                       setOverId(null);
                     }}
-                    onClick={() => (customizing ? setPanelShownInSidebar(id, isHidden) : onIconClick(id))}
+                    onClick={() => (customizing ? setPanelShownInSidebar(id, false) : onIconClick(id))}
                     className={cn(
                       'relative h-9 w-9 inline-flex items-center justify-center rounded-md transition-colors',
                       active
@@ -147,7 +149,6 @@ export function ActivityBar() {
                       customizing && 'cursor-grab active:cursor-grabbing',
                       dragId === id && 'opacity-40',
                       overId === id && dragId && dragId !== id && 'ring-1 ring-primary/60',
-                      customizing && isHidden && 'opacity-40',
                     )}
                   >
                     {/* Active accent bar (VS Code idiom) */}
@@ -165,17 +166,13 @@ export function ActivityBar() {
                         aria-hidden
                       />
                     )}
-                    {/* Customize-mode eye marker on hidden panels. */}
-                    {customizing && isHidden && (
-                      <EyeOff className="absolute -right-0.5 -bottom-0.5 h-2.5 w-2.5 text-muted-foreground" aria-hidden />
-                    )}
                   </button>
                 </TooltipTrigger>
                 <TooltipContent side="left">
                   {def.title}
                   <span className="text-muted-foreground">
                     {customizing
-                      ? isHidden ? ' · hidden — click to show' : ' · click to hide'
+                      ? ' · click to hide'
                       : `${ALT_LABEL.get(id) ? ` · ${ALT_LABEL.get(id)}` : ''}${loc === 'floating' ? ' · floating' : loc === 'popped' ? ' · popped out' : ''}`}
                   </span>
                 </TooltipContent>

--- a/apps/viewer/src/components/viewer/sidebar/CustomizeSidebar.tsx
+++ b/apps/viewer/src/components/viewer/sidebar/CustomizeSidebar.tsx
@@ -3,21 +3,26 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Sidebar customizer popover (#1208).
+ * Sidebar customizer popover (#1208, #1263).
  *
- * Lets the user reorder the activity bar (drag a row, or the keyboard up/down
- * buttons) and choose which panels appear in it (the eye toggle), plus reset
- * to defaults. A self-contained NON-MODAL popover (role="group") anchored to
- * the activity-bar footer — closes on an outside click or Escape, moves focus
- * into itself on open and restores it on close. The same store actions back the
- * inline drag in the activity bar, so the two stay consistent.
+ * Lets the user reorder the activity bar (drag a row, or the up/down buttons)
+ * and choose which panels appear in it, plus reset to defaults. A self-contained
+ * NON-MODAL popover (role="group") anchored to the activity-bar footer: closes on
+ * an outside click or Escape, moves focus into itself on open and restores it on
+ * close. The same store actions back the inline drag in the activity bar, so the
+ * two stay consistent.
+ *
+ * Hiding REMOVES a panel from the Shown list rather than greying it in place
+ * (#1263): hidden panels move to a separate "Hidden" section whose only control
+ * is Show (restore). So "hide" cleans the rail down to the tools you use, and
+ * restoring is a distinct action, not an inline disabled state.
  */
 
 import { useEffect, useRef, useState } from 'react';
-import { GripVertical, Eye, EyeOff, RotateCcw, Lock, ChevronUp, ChevronDown } from 'lucide-react';
+import { GripVertical, Eye, EyeOff, RotateCcw, Lock, ChevronUp, ChevronDown, Plus } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useViewerStore } from '@/store';
-import { getPanelDef } from '@/lib/panels/registry';
+import { getPanelDef, type WorkspacePanelId } from '@/lib/panels/registry';
 
 export function CustomizeSidebar({ onClose }: { onClose: () => void }) {
   const order = useViewerStore((s) => s.sidebarOrder);
@@ -32,6 +37,10 @@ export function CustomizeSidebar({ onClose }: { onClose: () => void }) {
   const [dragId, setDragId] = useState<string | null>(null);
   const [overId, setOverId] = useState<string | null>(null);
 
+  // Shown panels keep their rail order; hidden ones live in their own section.
+  const shownIds = order.filter((id) => !hidden.has(id));
+  const hiddenList = order.filter((id) => hidden.has(id));
+
   // Move focus into the popover on open and restore it to the trigger on close.
   useEffect(() => {
     restoreFocusRef.current = (document.activeElement as HTMLElement) ?? null;
@@ -41,7 +50,7 @@ export function CustomizeSidebar({ onClose }: { onClose: () => void }) {
     };
   }, []);
 
-  // Close on outside click / Escape. The customize toggle button is excluded —
+  // Close on outside click / Escape. The customize toggle button is excluded,
   // otherwise its own click would close the popover here (mousedown) and then
   // immediately reopen it (the button's click handler), so it could never close.
   useEffect(() => {
@@ -94,12 +103,14 @@ export function CustomizeSidebar({ onClose }: { onClose: () => void }) {
       </div>
 
       <div className="max-h-[60vh] overflow-y-auto py-1">
-        {order.map((id, index) => {
+        {/* Shown: the panels in the rail, reorderable, each with a Hide control. */}
+        {shownIds.map((id, index) => {
           const def = getPanelDef(id);
           if (!def) return null;
           const Icon = def.Icon;
-          const isHidden = hidden.has(id);
           const locked = id === 'properties';
+          const prevShown = shownIds[index - 1];
+          const nextShown = shownIds[index + 1];
           return (
             <div
               key={id}
@@ -114,7 +125,7 @@ export function CustomizeSidebar({ onClose }: { onClose: () => void }) {
                 if (overId !== id) setOverId(id);
               }}
               onDrop={() => {
-                if (dragId && dragId !== id) reorder(dragId as never, order.indexOf(id));
+                if (dragId && dragId !== id) reorder(dragId as WorkspacePanelId, order.indexOf(id));
                 setDragId(null);
                 setOverId(null);
               }}
@@ -122,7 +133,6 @@ export function CustomizeSidebar({ onClose }: { onClose: () => void }) {
                 'group flex items-center gap-1.5 px-2 py-1.5 mx-1 rounded-md cursor-grab active:cursor-grabbing',
                 dragId === id && 'opacity-40',
                 overId === id && dragId && dragId !== id && 'ring-1 ring-primary/60',
-                isHidden && 'opacity-50',
               )}
             >
               <GripVertical className="h-3.5 w-3.5 text-muted-foreground/60 shrink-0" aria-hidden />
@@ -131,7 +141,7 @@ export function CustomizeSidebar({ onClose }: { onClose: () => void }) {
               <button
                 type="button"
                 disabled={index === 0}
-                onClick={() => reorder(id, index - 1)}
+                onClick={() => prevShown && reorder(id, order.indexOf(prevShown))}
                 aria-label={`Move ${def.title} up`}
                 className="h-6 w-5 inline-flex items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-25 disabled:pointer-events-none transition-colors"
               >
@@ -139,8 +149,8 @@ export function CustomizeSidebar({ onClose }: { onClose: () => void }) {
               </button>
               <button
                 type="button"
-                disabled={index === order.length - 1}
-                onClick={() => reorder(id, index + 1)}
+                disabled={index === shownIds.length - 1}
+                onClick={() => nextShown && reorder(id, order.indexOf(nextShown))}
                 aria-label={`Move ${def.title} down`}
                 className="h-6 w-5 inline-flex items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-25 disabled:pointer-events-none transition-colors"
               >
@@ -149,29 +159,54 @@ export function CustomizeSidebar({ onClose }: { onClose: () => void }) {
               <button
                 type="button"
                 disabled={locked}
-                onClick={() => setShown(id, isHidden)}
-                aria-label={locked ? `${def.title} is always shown` : `${isHidden ? 'Show' : 'Hide'} ${def.title}`}
-                title={locked ? 'Always shown' : isHidden ? 'Show in sidebar' : 'Hide from sidebar'}
+                onClick={() => setShown(id, false)}
+                aria-label={locked ? `${def.title} is always shown` : `Hide ${def.title}`}
+                title={locked ? 'Always shown' : 'Hide from sidebar'}
                 className={cn(
                   'h-6 w-6 inline-flex items-center justify-center rounded transition-colors',
                   locked ? 'opacity-30' : 'text-muted-foreground hover:bg-muted hover:text-foreground',
                 )}
               >
-                {locked ? (
-                  <Lock className="h-3.5 w-3.5" />
-                ) : isHidden ? (
-                  <EyeOff className="h-3.5 w-3.5" />
-                ) : (
-                  <Eye className="h-3.5 w-3.5" />
-                )}
+                {locked ? <Lock className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}
               </button>
             </div>
           );
         })}
+
+        {/* Hidden: removed from the rail; the only control is Show (restore). */}
+        {hiddenList.length > 0 && (
+          <>
+            <div className="mt-1 px-3 pt-2 pb-1 border-t border-border/60 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70">
+              Hidden
+            </div>
+            {hiddenList.map((id) => {
+              const def = getPanelDef(id);
+              if (!def) return null;
+              const Icon = def.Icon;
+              return (
+                <div key={id} className="flex items-center gap-1.5 px-2 py-1.5 mx-1 rounded-md text-muted-foreground">
+                  <span className="w-3.5 shrink-0" aria-hidden />
+                  <Icon className="h-4 w-4 shrink-0 opacity-60" aria-hidden />
+                  <span className="text-xs flex-1 truncate opacity-70">{def.title}</span>
+                  <button
+                    type="button"
+                    onClick={() => setShown(id, true)}
+                    aria-label={`Show ${def.title}`}
+                    title="Show in sidebar"
+                    className="h-6 inline-flex items-center gap-1 rounded px-1.5 text-[11px] text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+                  >
+                    <Plus className="h-3.5 w-3.5" />
+                    Show
+                  </button>
+                </div>
+              );
+            })}
+          </>
+        )}
       </div>
 
       <div className="px-3 py-1.5 border-t border-border text-[10px] text-muted-foreground select-none">
-        Drag or use ▲▼ to reorder · the eye shows / hides
+        Drag a row to reorder. Hide moves a panel to Hidden; Show brings it back.
       </div>
     </div>
   );


### PR DESCRIPTION
## #1263 Hide only disables a panel instead of removing it from the list

In Customize Panels, hiding a panel (e.g. Compare Models) greyed it out but kept it in the list, and the rail still showed it greyed while customizing. Expected: hiding should remove it from the visible list entirely, with restore as a separate control.

### Fix
- The **Customize popover** now splits into a **Shown** list (reorderable, each row has Hide) and a separate **Hidden** section that only appears when something is hidden, with a single **Show** (restore) control per row. So Hide removes a panel from the list, and restoring is a distinct action, not an inline disabled state.
- The **rail** drops hidden panels in every mode, including customize, so hiding an icon removes it immediately. Restore happens in the popover's Hidden section.

Pure viewer UI, no store/behavior changes (the existing `setPanelShownInSidebar` already drives the hidden set). Frontend-design pass, ASCII punctuation only.

### Verification
- `tsc --noEmit` clean, viewer unit tests pass (sidebar slice + registry), production `vite build` green.
- Playwright: opening Customize and hiding Compare moves it to a Hidden section with a Show button, removes its rail icon, and `sidebarHiddenIds` reflects it.

Closes #1263
