### PR TITLE
feat(clash): X-Ray 'Ghost' context mode — see a clash pair in transparent context (#1275)

### DIFF
--- a/.changeset/renderer-ghost-except.md
+++ b/.changeset/renderer-ghost-except.md
@@ -1,0 +1,10 @@
+---
+"@ifc-lite/renderer": minor
+---
+
+Add `ghostExceptIds` / `ghostAlpha` to `RenderOptions` — an X-Ray *context* mode
+that fades every non-selected mesh NOT in the set to a translucent alpha, while
+the focused subset stays solid. It feeds the existing `transparencyOverrides`
+alpha path (explicit per-id entries still win, selected meshes stay opaque), so
+callers can ghost "the rest" of a model without building a Map over every
+element. Same id space as `isolatedIds`.

--- a/.changeset/viewer-clash-ghost.md
+++ b/.changeset/viewer-clash-ghost.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/viewer": minor
+---
+
+Clash review now has an **X-Ray "Ghost" context** mode (#1275). The "On select"
+control offers Highlight / Isolate / **Ghost**: Ghost keeps the clashing pair
+solid and fades the rest of the model to translucent context, so a clash can be
+judged in place without hiding its surroundings. Wires the renderer's
+`ghostExceptIds` through a new `ghostExceptEntities` visibility channel.

--- a/apps/viewer/src/components/viewer/ClashPanel.tsx
+++ b/apps/viewer/src/components/viewer/ClashPanel.tsx
@@ -22,7 +22,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { cn } from '@/lib/utils';
-import { useClash } from '@/hooks/useClash';
+import { useClash, type ClashFocusMode } from '@/hooks/useClash';
 import { useBCF } from '@/hooks/useBCF';
 import { useViewerStore } from '@/store';
 import { ClashBcfExportDialog } from '@/components/viewer/ClashBcfExportDialog';
@@ -128,7 +128,8 @@ export function ClashPanel({ onClose }: ClashPanelProps) {
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [sortBy, setSortBy] = useState<ClashSortBy>('severity');
   const [hideTouching, setHideTouching] = useState(false);
-  const [isolateOnSelect, setIsolateOnSelect] = useState(false);
+  /** How the rest of the model is shown when a clash is focused (#1275). */
+  const [focusMode, setFocusMode] = useState<ClashFocusMode>('highlight');
   const [showHelp, setShowHelp] = useState(false);
   const [creatingTopic, setCreatingTopic] = useState(false);
 
@@ -214,7 +215,7 @@ export function ClashPanel({ onClose }: ClashPanelProps) {
     setCreatingTopic(true);
     try {
       if (clash) {
-        focusClash(clash);
+        focusClash(clash, focusMode);
         // Wait for the camera move + a render before grabbing the snapshot.
         await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
       }
@@ -235,12 +236,23 @@ export function ClashPanel({ onClose }: ClashPanelProps) {
     } finally {
       setCreatingTopic(false);
     }
-  }, [result, creatingTopic, selectedId, focusClash, bcfProject, setBcfProject, total, bcfAuthor, addTopic, createViewpointFromState, addViewpoint, setBcfPanelVisible]);
+  }, [result, creatingTopic, selectedId, focusClash, focusMode, bcfProject, setBcfProject, total, bcfAuthor, addTopic, createViewpointFromState, addViewpoint, setBcfPanelVisible]);
+
+  /** Switch the focus mode and immediately re-apply it to the selected clash so
+   *  the change is visible without re-clicking the row (#1275). */
+  const changeFocusMode = useCallback(
+    (mode: ClashFocusMode): void => {
+      setFocusMode(mode);
+      const current = selectedId ? result?.clashes.find((c) => c.id === selectedId) : undefined;
+      if (current) focusClash(current, mode);
+    },
+    [selectedId, result, focusClash],
+  );
 
   /** One side (A or B) of a clash inside the expanded row (#1276). */
   const ElementRow = ({ el, side }: { el: ClashElementRef; side: 0 | 1 }) => (
     <button
-      onClick={() => selectElement(el, isolateOnSelect)}
+      onClick={() => selectElement(el, focusMode)}
       title={`${el.tag} · ${el.name ?? el.key}`}
       className="flex w-full items-center gap-2 py-1 pl-7 pr-3 text-left hover:bg-muted/50"
     >
@@ -507,15 +519,33 @@ export function ClashPanel({ onClose }: ClashPanelProps) {
               <input type="checkbox" checked={hideTouching} onChange={(e) => setHideTouching(e.target.checked)} className="accent-[#f7768e]" />
               Hide touching{touchingCount > 0 ? ` (${touchingCount})` : ''}
             </label>
-            <label className="inline-flex items-center gap-1.5 cursor-pointer" title="When selecting a clash, hide everything except the clashing objects">
-              <input type="checkbox" checked={isolateOnSelect} onChange={(e) => setIsolateOnSelect(e.target.checked)} className="accent-[#f7768e]" />
-              Isolate on select
-            </label>
+            <div className="inline-flex items-center gap-1" title="How the rest of the model is shown when you click a clash">
+              <span>On select:</span>
+              <div className="inline-flex rounded-md border border-border overflow-hidden">
+                {([
+                  ['highlight', 'Highlight', 'Keep the whole model visible'],
+                  ['isolate', 'Isolate', 'Hide everything except the clashing pair'],
+                  ['ghost', 'Ghost', 'Fade the rest to translucent context (X-Ray)'],
+                ] as [ClashFocusMode, string, string][]).map(([m, label, tip]) => (
+                  <button
+                    key={m}
+                    title={tip}
+                    onClick={() => changeFocusMode(m)}
+                    className={cn(
+                      'px-1.5 py-0.5 transition-colors',
+                      focusMode === m ? 'bg-primary text-primary-foreground' : 'hover:bg-muted',
+                    )}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+            </div>
             <div className="ml-auto flex items-center gap-1 shrink-0">
               <Button variant="ghost" size="sm" className="h-6 px-2 text-xs" title="Select every element involved in a clash" onClick={highlightAll}>
                 Highlight all
               </Button>
-              <Button variant="ghost" size="sm" className="h-6 px-2 text-xs" title="Clear selection and isolation" onClick={clearHighlight}>
+              <Button variant="ghost" size="sm" className="h-6 px-2 text-xs" title="Clear selection, isolation and ghosting" onClick={clearHighlight}>
                 Clear
               </Button>
             </div>
@@ -582,7 +612,7 @@ export function ClashPanel({ onClose }: ClashPanelProps) {
                           {isExpanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
                         </button>
                         <button
-                          onClick={() => focusClash(clash, isolateOnSelect)}
+                          onClick={() => focusClash(clash, focusMode)}
                           className="flex min-w-0 flex-1 items-center gap-2 py-1.5 pr-1 text-left hover:bg-muted/50"
                         >
                           <span
@@ -607,8 +637,8 @@ export function ClashPanel({ onClose }: ClashPanelProps) {
                           <span className="shrink-0 tabular-nums text-muted-foreground">{formatDistance(clash.distance)}</span>
                         </button>
                         <button
-                          onClick={() => focusClash(clash, true)}
-                          title="Isolate this pair (hide everything else)"
+                          onClick={() => focusClash(clash, focusMode === 'highlight' ? 'isolate' : focusMode)}
+                          title={focusMode === 'ghost' ? 'Ghost the rest (X-Ray context)' : 'Isolate this pair (hide everything else)'}
                           className="flex items-center px-2 text-muted-foreground hover:text-foreground"
                         >
                           <Focus className="h-3.5 w-3.5" />

--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -217,7 +217,7 @@ export function Viewport({
 
   // Visibility state - use computedIsolatedIds from parent (includes storey selection)
   // Fall back to store isolation if computedIsolatedIds is not provided
-  const { hiddenEntities, isolatedEntities: storeIsolatedEntities } = useVisibilityState();
+  const { hiddenEntities, isolatedEntities: storeIsolatedEntities, ghostExceptEntities } = useVisibilityState();
   const isolatedEntities = computedIsolatedIds ?? storeIsolatedEntities ?? null;
 
   // Tool state — `sectionPickMode` arms a face-pick on the next click for
@@ -479,6 +479,7 @@ export function Viewport({
   const coordinateInfoRef = useLatestRef(coordinateInfo);
   const hiddenEntitiesRef = useLatestRef(hiddenEntities);
   const isolatedEntitiesRef = useLatestRef(isolatedEntities);
+  const ghostExceptEntitiesRef = useLatestRef(ghostExceptEntities);
   const selectedEntityIdRef = useLatestRef(selectedEntityId);
   const selectedEntityIdsRef = useLatestRef(selectedEntityIds);
   const selectedModelIndexRef = useLatestRef(selectedModelIndex);
@@ -1169,6 +1170,7 @@ export function Viewport({
     terrainClipYRef,
     hiddenEntitiesRef,
     isolatedEntitiesRef,
+    ghostExceptEntitiesRef,
     selectedEntityIdRef,
     selectedModelIndexRef,
     clearColorRef,
@@ -1232,6 +1234,7 @@ export function Viewport({
     visualEnhancementRef,
     hiddenEntities,
     isolatedEntities,
+    ghostExceptEntities,
     selectedEntityId,
     selectedEntityIds,
     selectedModelIndex,

--- a/apps/viewer/src/components/viewer/useAnimationLoop.ts
+++ b/apps/viewer/src/components/viewer/useAnimationLoop.ts
@@ -34,6 +34,8 @@ export interface UseAnimationLoopParams {
   terrainClipYRef: MutableRefObject<number | null>;
   hiddenEntitiesRef: MutableRefObject<Set<number>>;
   isolatedEntitiesRef: MutableRefObject<Set<number> | null>;
+  /** X-Ray context: ghost every entity NOT in this set (null = no ghosting). */
+  ghostExceptEntitiesRef: MutableRefObject<Set<number> | null>;
   selectedEntityIdRef: MutableRefObject<number | null>;
   selectedModelIndexRef: MutableRefObject<number | undefined>;
   clearColorRef: MutableRefObject<[number, number, number, number]>;
@@ -76,6 +78,7 @@ export function useAnimationLoop(params: UseAnimationLoopParams): void {
     terrainClipYRef,
     hiddenEntitiesRef,
     isolatedEntitiesRef,
+    ghostExceptEntitiesRef,
     selectedEntityIdRef,
     selectedModelIndexRef,
     clearColorRef,
@@ -184,6 +187,7 @@ export function useAnimationLoop(params: UseAnimationLoopParams): void {
         renderer.render({
           hiddenIds: hiddenEntitiesRef.current,
           isolatedIds: isolatedEntitiesRef.current,
+          ghostExceptIds: ghostExceptEntitiesRef.current,
           selectedId: selectedEntityIdRef.current,
           selectedIds: selectedEntityIdsRef.current,
           selectedModelIndex: selectedModelIndexRef.current,

--- a/apps/viewer/src/components/viewer/useRenderUpdates.ts
+++ b/apps/viewer/src/components/viewer/useRenderUpdates.ts
@@ -30,6 +30,7 @@ export interface UseRenderUpdatesParams {
   // Visibility/selection state (reactive values, not refs)
   hiddenEntities: Set<number>;
   isolatedEntities: Set<number> | null;
+  ghostExceptEntities: Set<number> | null;
   selectedEntityId: number | null;
   selectedEntityIds: Set<number> | undefined;
   selectedModelIndex: number | undefined;
@@ -62,6 +63,7 @@ export function useRenderUpdates(params: UseRenderUpdatesParams): void {
     clearColorRef,
     hiddenEntities,
     isolatedEntities,
+    ghostExceptEntities,
     selectedEntityId,
     selectedEntityIds,
     selectedModelIndex,
@@ -145,7 +147,7 @@ export function useRenderUpdates(params: UseRenderUpdatesParams): void {
     if (!renderer || !isInitialized) return;
 
     renderer.requestRender();
-  }, [hiddenEntities, isolatedEntities, selectedEntityId, selectedEntityIds, selectedModelIndex, isInitialized, sectionPlane, activeTool, sectionRange, coordinateInfo?.buildingRotation]);
+  }, [hiddenEntities, isolatedEntities, ghostExceptEntities, selectedEntityId, selectedEntityIds, selectedModelIndex, isInitialized, sectionPlane, activeTool, sectionRange, coordinateInfo?.buildingRotation]);
 }
 
 export default useRenderUpdates;

--- a/apps/viewer/src/hooks/useClash.ts
+++ b/apps/viewer/src/hooks/useClash.ts
@@ -37,6 +37,14 @@ interface SelectionRef {
   expressId: number;
 }
 
+/**
+ * How the rest of the model is shown when a clash is focused (#1275):
+ * - `highlight`: everything stays visible, the pair is just selected/framed;
+ * - `isolate`:   everything else is hidden;
+ * - `ghost`:     everything else fades to translucent X-Ray context.
+ */
+export type ClashFocusMode = 'highlight' | 'isolate' | 'ghost';
+
 /** How clashes collapse into BCF topics. `storey` is omitted — Clash has no
  *  storey, so it degrades to `rule` (see grouping.ts) and would only confuse. */
 export type ClashBcfGroupBy = 'cluster' | 'rule' | 'typePair' | 'element';
@@ -258,13 +266,28 @@ export function useClash() {
   }, []);
 
   /**
-   * Select both elements of a clash, highlight them, and frame the camera. When
-   * `isolate` is set, also hide everything else so only the clashing pair is
-   * visible — the "isolate clashing objects" view (#1275). Otherwise any active
-   * isolation is cleared so the pair is highlighted in full context.
+   * Apply a focus mode to a set of global ids in the shared visibility channels:
+   * - `highlight`: clear isolation + ghosting (pair highlighted in full context);
+   * - `isolate`:   hide everything except the ids (#1275);
+   * - `ghost`:     keep the ids solid and fade the rest to translucent context
+   *                via the renderer's X-Ray path (#1275 "see them in context").
+   */
+  const applyFocusMode = useCallback((globalIds: number[], mode: ClashFocusMode): void => {
+    const state = useViewerStore.getState();
+    if (mode === 'isolate') state.setIsolatedEntities(new Set(globalIds));
+    else if (mode === 'ghost') state.setGhostExceptEntities(new Set(globalIds));
+    else {
+      state.clearIsolation();
+      state.clearGhost();
+    }
+  }, []);
+
+  /**
+   * Select both elements of a clash, highlight them, frame the camera, and apply
+   * the chosen focus `mode` (highlight / isolate / ghost) — #1275.
    */
   const focusClash = useCallback(
-    (clash: Clash, isolate = false): void => {
+    (clash: Clash, mode: ClashFocusMode = 'highlight'): void => {
       const state = useViewerStore.getState();
       const a = refOf(clash.a);
       const b = refOf(clash.b);
@@ -280,32 +303,29 @@ export function useClash() {
       state.clearEntitySelection();
       state.setSelectedEntityIds(globalIds); // highlight BOTH elements + frame target
       state.addEntitiesToSelection(refs); // model-aware context for the properties panel
-      if (isolate) state.setIsolatedEntities(new Set(globalIds));
-      else state.clearIsolation();
+      applyFocusMode(globalIds, mode);
       state.setClashSelectedId(clash.id);
       requestAnimationFrame(() => state.cameraCallbacks.frameSelection?.());
     },
-    [refOf],
+    [refOf, applyFocusMode],
   );
 
   /**
    * Focus a SINGLE element of a clash pair so the user can step through each side
-   * and read it in isolation (#1276). `isolate` hides everything else; otherwise
-   * the element is highlighted in context.
+   * and read it on its own (#1276), applying the chosen focus `mode`.
    */
   const selectElement = useCallback(
-    (el: ClashElementRef, isolate = false): void => {
+    (el: ClashElementRef, mode: ClashFocusMode = 'highlight'): void => {
       const state = useViewerStore.getState();
       const ref = refOf(el);
       if (!ref) return;
       state.clearEntitySelection();
       state.setSelectedEntityIds([el.ref]);
       state.addEntitiesToSelection([ref]);
-      if (isolate) state.setIsolatedEntities(new Set([el.ref]));
-      else state.clearIsolation();
+      applyFocusMode([el.ref], mode);
       requestAnimationFrame(() => state.cameraCallbacks.frameSelection?.());
     },
-    [refOf],
+    [refOf, applyFocusMode],
   );
 
   /** Highlight every element involved in any clash. */
@@ -335,6 +355,7 @@ export function useClash() {
     const state = useViewerStore.getState();
     state.clearEntitySelection();
     state.clearIsolation(); // drop any clash isolation so the full model returns
+    state.clearGhost(); // and any X-Ray ghosting
     setSelectedId(null);
   }, [setSelectedId]);
 
@@ -456,6 +477,7 @@ export function useClash() {
     const state = useViewerStore.getState();
     state.clearEntitySelection();
     state.clearIsolation();
+    state.clearGhost();
     clear();
   }, [clear]);
 

--- a/apps/viewer/src/hooks/useViewerSelectors.ts
+++ b/apps/viewer/src/hooks/useViewerSelectors.ts
@@ -37,10 +37,12 @@ export function useSelectionState() {
 export function useVisibilityState() {
   const hiddenEntities = useViewerStore((state) => state.hiddenEntities);
   const isolatedEntities = useViewerStore((state) => state.isolatedEntities);
+  const ghostExceptEntities = useViewerStore((state) => state.ghostExceptEntities);
 
   return {
     hiddenEntities,
     isolatedEntities,
+    ghostExceptEntities,
   };
 }
 

--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -265,6 +265,7 @@ const createViewerStore = () => create<ViewerState>()((...args) => ({
       // Visibility (legacy)
       hiddenEntities: new Set(),
       isolatedEntities: null,
+      ghostExceptEntities: null,
       classFilter: null,
       // Re-read persisted toggles on every file load so a new model never
       // reverts the user's visibility choices (e.g. "Show Annotations").

--- a/apps/viewer/src/store/slices/visibilitySlice.ts
+++ b/apps/viewer/src/store/slices/visibilitySlice.ts
@@ -24,6 +24,11 @@ export interface VisibilitySlice {
   // State (legacy - single model)
   hiddenEntities: Set<number>;
   isolatedEntities: Set<number> | null;
+  /** X-Ray context: when non-null, every entity NOT in this set renders ghosted
+   *  (translucent) so a focused subset (e.g. a clash pair) stands out while the
+   *  rest stays visible for context. `null` = no ghosting. Drives the renderer's
+   *  `ghostExceptIds`. */
+  ghostExceptEntities: Set<number> | null;
   /** Class-level filter (from Class tab type-group clicks) — independent of isolatedEntities */
   classFilter: { ids: Set<number>; label: string } | null;
   typeVisibility: TypeVisibility;
@@ -72,6 +77,10 @@ export interface VisibilitySlice {
   setHiddenEntities: (ids: Set<number>) => void;
   /** Set all isolated entities at once (for BCF viewpoint with defaultVisibility=false) */
   setIsolatedEntities: (ids: Set<number> | null) => void;
+  /** Ghost everything except these entities (X-Ray context). `null` clears it. */
+  setGhostExceptEntities: (ids: Set<number> | null) => void;
+  /** Clear X-Ray context ghosting. */
+  clearGhost: () => void;
 
   // Actions (multi-model)
   /** Hide entity in specific model */
@@ -98,6 +107,7 @@ export const createVisibilitySlice: StateCreator<VisibilitySlice, [], [], Visibi
   // Initial state (legacy)
   hiddenEntities: new Set(),
   isolatedEntities: null,
+  ghostExceptEntities: null,
   classFilter: null,
   // Read persisted toggles fresh so the user's choices survive reloads.
   typeVisibility: getPersistedTypeVisibility(),
@@ -199,16 +209,25 @@ export const createVisibilitySlice: StateCreator<VisibilitySlice, [], [], Visibi
 
   clearClassFilter: () => set({ classFilter: null }),
 
-  clearAllFilters: () => set({ isolatedEntities: null, classFilter: null }),
+  clearAllFilters: () => set({ isolatedEntities: null, classFilter: null, ghostExceptEntities: null }),
 
-  showAll: () => set({ hiddenEntities: new Set(), isolatedEntities: null, classFilter: null }),
+  showAll: () => set({ hiddenEntities: new Set(), isolatedEntities: null, classFilter: null, ghostExceptEntities: null }),
 
   setHiddenEntities: (ids) => set({ hiddenEntities: new Set(ids), isolatedEntities: null, classFilter: null }),
 
   setIsolatedEntities: (ids) => set({
     isolatedEntities: ids ? new Set(ids) : null,
     hiddenEntities: new Set(), // Clear hidden when setting isolation
+    ghostExceptEntities: null, // Isolation (hide) and ghosting are mutually exclusive
   }),
+
+  setGhostExceptEntities: (ids) => set({
+    ghostExceptEntities: ids ? new Set(ids) : null,
+    // Ghosting shows the rest translucent — clear isolation (which hides it).
+    isolatedEntities: null,
+  }),
+
+  clearGhost: () => set({ ghostExceptEntities: null }),
 
   isEntityVisible: (id) => {
     const state = get();

--- a/apps/viewer/src/store/slices/visibilitySlice.ts
+++ b/apps/viewer/src/store/slices/visibilitySlice.ts
@@ -213,7 +213,7 @@ export const createVisibilitySlice: StateCreator<VisibilitySlice, [], [], Visibi
 
   showAll: () => set({ hiddenEntities: new Set(), isolatedEntities: null, classFilter: null, ghostExceptEntities: null }),
 
-  setHiddenEntities: (ids) => set({ hiddenEntities: new Set(ids), isolatedEntities: null, classFilter: null }),
+  setHiddenEntities: (ids) => set({ hiddenEntities: new Set(ids), isolatedEntities: null, classFilter: null, ghostExceptEntities: null }),
 
   setIsolatedEntities: (ids) => set({
     isolatedEntities: ids ? new Set(ids) : null,

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -1100,8 +1100,17 @@ export class Renderer {
         // Snapshot the caller's map so mid-frame mutation can't desync classification
         // and uniform-write decisions for the same batch/mesh.
         const txOverridesSrc = options.transparencyOverrides;
-        const hasTxOverrides = txOverridesSrc != null && txOverridesSrc.size > 0;
-        const txOverrides = hasTxOverrides ? new Map(txOverridesSrc) : null;
+        const hasTxMap = txOverridesSrc != null && txOverridesSrc.size > 0;
+        const txOverrides = hasTxMap ? new Map(txOverridesSrc) : null;
+        // X-Ray *context* mode: every non-selected mesh NOT in ghostExceptIds
+        // fades to ghostAlpha. It feeds the same alpha-override machinery as
+        // transparencyOverrides (explicit per-id entries win), so it routes
+        // through the transparent pipeline with no extra call sites — and avoids
+        // building a Map over every element just to fade "the rest".
+        const ghostExceptIds = options.ghostExceptIds ?? null;
+        const ghostAlpha = options.ghostAlpha ?? 0.12;
+        const hasGhost = ghostExceptIds != null;
+        const hasTxOverrides = hasTxMap || hasGhost;
         const alphaForMesh = (expressId: number, fallback: number): number => {
             if (!hasTxOverrides) return fallback;
             // Selected meshes are exempt — the highlight pass renders them last,
@@ -1109,8 +1118,10 @@ export class Renderer {
             // consistent so a selected mesh never enters the transparent pipeline
             // because of its own override entry.
             if (hasSelected && selectedExpressIds.has(expressId)) return fallback;
-            const a = txOverrides!.get(expressId);
-            return a !== undefined ? a : fallback;
+            const a = txOverrides?.get(expressId);
+            if (a !== undefined) return a;
+            if (hasGhost && !ghostExceptIds!.has(expressId)) return ghostAlpha;
+            return fallback;
         };
         // Cache resolved batch alpha for the frame: classification needs it
         // (opaque vs transparent routing) and renderBatch needs it for the
@@ -1132,8 +1143,12 @@ export class Renderer {
                 // pass redraws them on top, but excluding here also means a
                 // batch made entirely of selected entities stays opaque.
                 if (hasSelected && selectedExpressIds.has(eid)) continue;
-                const a = txOverrides!.get(eid);
-                if (a !== undefined && a < minAlpha) minAlpha = a;
+                const a = txOverrides?.get(eid);
+                if (a !== undefined) {
+                    if (a < minAlpha) minAlpha = a;
+                } else if (hasGhost && !ghostExceptIds!.has(eid)) {
+                    if (ghostAlpha < minAlpha) minAlpha = ghostAlpha;
+                }
             }
             const resolved = minAlpha === Infinity ? fallback : minAlpha;
             batchAlphaCache!.set(batch, resolved);

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -207,6 +207,13 @@ export interface RenderOptions {
    * `null`/absent disables ghosting. Selected meshes (`selectedId`/`selectedIds`)
    * are always exempt, and explicit {@link transparencyOverrides} entries win
    * over the ghost alpha. Same id space as `isolatedIds` (federated global id).
+   *
+   * Mixed colour batches resolve to the minimum alpha among their non-selected
+   * entities (same as {@link transparencyOverrides}), so an excepted id that
+   * shares a batch with ghosted ids fades with the batch unless it is also in
+   * `selectedIds` — the selection highlight pass then repaints it opaque. To
+   * guarantee a focused entity stays fully solid, include it in `selectedIds`
+   * (the clash viewer co-selects the focused pair for exactly this reason).
    */
   ghostExceptIds?: Set<number> | null;
   /** Alpha (0..1) for ghosted meshes under {@link ghostExceptIds}. Default 0.12. */

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -199,6 +199,18 @@ export interface RenderOptions {
    * — keep them out of the map to avoid unnecessary work.
    */
   transparencyOverrides?: Map<number, number> | null;
+  /**
+   * X-Ray *context* mode: every non-selected mesh whose `expressId` is NOT in
+   * this set renders at {@link ghostAlpha}, so a focused subset (e.g. a clash
+   * pair) stays solid while the rest of the model fades to translucent context.
+   *
+   * `null`/absent disables ghosting. Selected meshes (`selectedId`/`selectedIds`)
+   * are always exempt, and explicit {@link transparencyOverrides} entries win
+   * over the ghost alpha. Same id space as `isolatedIds` (federated global id).
+   */
+  ghostExceptIds?: Set<number> | null;
+  /** Alpha (0..1) for ghosted meshes under {@link ghostExceptIds}. Default 0.12. */
+  ghostAlpha?: number;
   // Building rotation in radians (from IfcSite placement) - used to orient section planes
   buildingRotation?: number;
   selectedModelIndex?: number;    // Model index for multi-model selection (must match mesh.modelIndex)


### PR DESCRIPTION
Completes the deferred half of **#1275**: the merged clash work could *isolate* a clashing pair (hide the rest), but the issue also asked to *"see them in context with everything else turned transparent."* The renderer already had an X-Ray alpha path (`transparencyOverrides`) — it just wasn't wired into the viewer. This PR wires it.

## What changed
- **`@ifc-lite/renderer`** — new `RenderOptions.ghostExceptIds` + `ghostAlpha`. Every non-selected mesh whose id is *not* in the set fades to `ghostAlpha`, reusing the existing alpha-override machinery (explicit `transparencyOverrides` win; selected meshes stay opaque). No per-element `Map` needed — a Set-membership check per mesh, so it scales without enumerating "the rest".
- **`@ifc-lite/viewer`** — new `ghostExceptEntities` visibility channel, wired store → `Viewport` ref → animation-loop `render()` (mirrors `isolatedEntities`). Isolation and ghosting are mutually exclusive.
- **Clash panel** — the "On select" control is now **Highlight / Isolate / Ghost**. The mode applies on row click, per-element step-through, and the BCF-topic snapshot, and re-applies live when you switch it on a selected clash.

## Verification (in-browser, WebGPU, real Chrome)
- **Ghost**: clashing pair stays solid cyan while the rest of the house renders translucent. ✅
- **Isolate**: rest hidden. ✅
- **Highlight**: everything opaque. ✅
- 0 console errors, 60 FPS.
- `@ifc-lite/renderer` tests 131/131, `@ifc-lite/clash` 112/112, renderer + viewer `tsc` clean.

## Notes
- Ghosting routes faded meshes through the transparent pipeline (same cost model as the existing X-Ray mode) — it's an opt-in focus action, not always-on.
- The flat render path is covered; GPU-instanced *occurrences* don't carry per-instance alpha overrides (same existing limitation as `transparencyOverrides`), so ghosting applies to the flat path. Noted for a follow-up if instanced models need it.

Closes #1275

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Ghost" focus mode for clash review: keeps selected elements opaque while fading all other model geometry to translucent
  * Clash focus control now offers three modes—Highlight, Isolate, and Ghost—replacing the previous checkbox-based selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->