### PR TITLE
fix(viewer): exploded mode leaves instanced + null-elevation storeys behind (#1289)

### DIFF
--- a/.changeset/exploded-mode-instanced-and-elevation.md
+++ b/.changeset/exploded-mode-instanced-and-elevation.md
@@ -1,0 +1,22 @@
+---
+"@ifc-lite/renderer": patch
+"@ifc-lite/parser": patch
+---
+
+Fix Exploded level-display mode leaving geometry behind (#1289).
+
+Two independent defects made Exploded mode look broken:
+
+- GPU-instanced occurrences (repeated geometry emitted via `IfcMappedItem`, e.g.
+  windows / mullions) were never lifted with their storey, because the per-entity
+  translate only touched the flat `meshDataMap` and not the instanced shard. They
+  stayed at their native elevation while the rest of the storey rose ("objects
+  left behind"). `Scene.translateInstancedEntity` now shifts each occurrence's
+  transform in both the CPU instance record and the GPU buffer, plus its cached
+  world AABB, so pick / measure / section / export stay correct. This also fixes
+  moving an instanced element with the gizmo.
+
+- A storey whose `Elevation` attribute is null (common in Revit / ArchiCAD
+  exports) was dropped from the elevation map, so Exploded mode had a single
+  floor to order ("only one floor"). The spatial-hierarchy builder now falls back
+  to the storey's `ObjectPlacement` Z when the attribute is missing.

--- a/packages/parser/src/spatial-hierarchy-builder.ts
+++ b/packages/parser/src/spatial-hierarchy-builder.ts
@@ -197,7 +197,15 @@ export class SpatialHierarchyBuilder {
     // Extract elevation for storeys (apply unit scale to convert to meters)
     let elevation: number | undefined;
     if (typeEnum === IfcTypeEnum.IfcBuildingStorey) {
-      const rawElevation = this.extractElevation(expressId, source, entityIndex);
+      let rawElevation = this.extractElevation(expressId, source, entityIndex);
+      if (rawElevation === undefined) {
+        // The Elevation attribute is optional and is frequently left null (common
+        // in Revit / ArchiCAD exports). Fall back to the storey's Z from its
+        // ObjectPlacement so a storey without an explicit elevation still orders +
+        // lifts correctly in Exploded mode instead of being dropped from the sort,
+        // which made the model look like it had a single floor (#1289).
+        rawElevation = this.extractPlacementElevation(expressId, source, entityIndex);
+      }
       if (rawElevation !== undefined) {
         // Apply unit scale to convert to meters
         elevation = rawElevation * lengthUnitScale;
@@ -361,6 +369,61 @@ export class SpatialHierarchyBuilder {
       // Elevation extraction is optional - log for debugging but don't fail
       log.caught('Failed to extract elevation', error, {
         operation: 'extractElevation',
+        entityId: expressId,
+        entityType: 'IfcBuildingStorey',
+      });
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Resolve a storey's elevation from its ObjectPlacement, used as a fallback when
+   * the Elevation attribute is null. Walks
+   *   IfcBuildingStorey.ObjectPlacement (IfcLocalPlacement)
+   *     -> RelativePlacement (IfcAxis2Placement3D)
+   *       -> Location (IfcCartesianPoint).Coordinates[2]
+   * i.e. the storey's Z relative to its parent spatial container. That matches the
+   * semantics of the Elevation attribute (relative to the building), so it stays
+   * consistent with sibling storeys that DO carry the attribute, and it avoids
+   * folding in any site-level georeferencing Z. Returns the raw (unscaled) Z, or
+   * undefined when the placement chain can't be resolved.
+   */
+  private extractPlacementElevation(
+    expressId: number,
+    source: Uint8Array,
+    entityIndex: { byId: { get(expressId: number): EntityRef | undefined } }
+  ): number | undefined {
+    try {
+      const extractor = new EntityExtractor(source);
+      const readAttrs = (id: number): unknown[] | undefined => {
+        const ref = entityIndex.byId.get(id);
+        if (!ref) return undefined;
+        return extractor.extractEntity(ref)?.attributes ?? undefined;
+      };
+
+      // IfcBuildingStorey.ObjectPlacement is attribute index 5.
+      const placementId = readAttrs(expressId)?.[5];
+      if (typeof placementId !== 'number') return undefined;
+
+      // IfcLocalPlacement(PlacementRelTo, RelativePlacement) — RelativePlacement
+      // (index 1) is the IfcAxis2Placement3D carrying this storey's own offset.
+      const axisId = readAttrs(placementId)?.[1];
+      if (typeof axisId !== 'number') return undefined;
+
+      // IfcAxis2Placement3D(Location, Axis, RefDirection) — Location (index 0) is
+      // an IfcCartesianPoint.
+      const locationId = readAttrs(axisId)?.[0];
+      if (typeof locationId !== 'number') return undefined;
+
+      // IfcCartesianPoint.Coordinates (index 0) is a list [x, y, z].
+      const coords = readAttrs(locationId)?.[0];
+      if (Array.isArray(coords) && coords.length >= 3 && typeof coords[2] === 'number') {
+        return coords[2];
+      }
+    } catch (error) {
+      log.caught('Failed to extract placement elevation', error, {
+        operation: 'extractPlacementElevation',
         entityId: expressId,
         entityType: 'IfcBuildingStorey',
       });

--- a/packages/parser/src/spatial-hierarchy-builder.ts
+++ b/packages/parser/src/spatial-hierarchy-builder.ts
@@ -346,24 +346,16 @@ export class SpatialHierarchyBuilder {
         return undefined;
       };
       
-      // Try index 9 first (correct index for IfcBuildingStorey.Elevation in IFC4)
+      // Elevation is attribute index 9 for IfcBuildingStorey in both IFC2x3 and
+      // IFC4 (GlobalId, OwnerHistory, Name, Description, ObjectType,
+      // ObjectPlacement, Representation, LongName, CompositionType, Elevation).
+      // Read ONLY that slot: a previous "scan every attribute for a number < 10000"
+      // fallback wrongly treated reference attributes — parsed as bare express-id
+      // numbers (e.g. OwnerHistory #3628 -> 3628, or ObjectPlacement #7150) — as
+      // elevations, so a storey with a null Elevation got a garbage value instead
+      // of falling through to the ObjectPlacement-Z fallback below (#1289).
       if (attrs.length > 9) {
-        const elev = extractNumber(attrs[9]);
-        if (elev !== undefined) return elev;
-      }
-      
-      // Try index 8 (in case of schema variations)
-      if (attrs.length > 8) {
-        const elev = extractNumber(attrs[8]);
-        if (elev !== undefined) return elev;
-      }
-
-      // Fallback: search for first numeric value that looks like an elevation
-      for (let i = 0; i < attrs.length; i++) {
-        const elev = extractNumber(attrs[i]);
-        if (elev !== undefined && Math.abs(elev) < 10000) {
-          return elev;
-        }
+        return extractNumber(attrs[9]);
       }
     } catch (error) {
       // Elevation extraction is optional - log for debugging but don't fail

--- a/packages/parser/test/storey-elevation-fallback.test.ts
+++ b/packages/parser/test/storey-elevation-fallback.test.ts
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+import { IfcParser } from '../src/index.js';
+
+/**
+ * #1289: a storey whose `Elevation` attribute is null (common in Revit /
+ * ArchiCAD exports) used to be dropped from `storeyElevations`, leaving Exploded
+ * mode with a single floor to order. The builder now falls back to the storey's
+ * ObjectPlacement Z, so every storey participates in the sort + lift.
+ *
+ * The fixture has two storeys: a ground floor that carries Elevation = 0, and a
+ * first floor with a NULL Elevation but a placement at Z = 3.5.
+ */
+
+/** Pad to the 22-char width of an IFC GlobalId (format is not validated here,
+ *  only the length / uniqueness matter for a clean parse). */
+const gid = (seed: string): string => seed.padEnd(22, '0').slice(0, 22);
+
+const IFC = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('test.ifc','2026-01-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCCARTESIANPOINT((0.,0.,0.));
+#2=IFCAXIS2PLACEMENT3D(#1,$,$);
+#3=IFCLOCALPLACEMENT($,#2);
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCLOCALPLACEMENT(#3,#5);
+#7=IFCCARTESIANPOINT((0.,0.,3.5));
+#8=IFCAXIS2PLACEMENT3D(#7,$,$);
+#9=IFCLOCALPLACEMENT(#3,#8);
+#10=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#11=IFCUNITASSIGNMENT((#10));
+#12=IFCPROJECT('${gid('Project')}',$,'Test',$,$,$,$,$,#11);
+#13=IFCSITE('${gid('Site')}',$,'Site',$,$,#3,$,$,.ELEMENT.,$,$,$,$,$);
+#14=IFCBUILDING('${gid('Building')}',$,'Building',$,$,#3,$,$,.ELEMENT.,$,$,$);
+#15=IFCBUILDINGSTOREY('${gid('StoreyGF')}',$,'Ground Floor',$,$,#6,$,$,.ELEMENT.,0.);
+#16=IFCBUILDINGSTOREY('${gid('StoreyF1')}',$,'First Floor',$,$,#9,$,$,$,$);
+#17=IFCRELAGGREGATES('${gid('RelP2S')}',$,$,$,#12,(#13));
+#18=IFCRELAGGREGATES('${gid('RelS2B')}',$,$,$,#13,(#14));
+#19=IFCRELAGGREGATES('${gid('RelB2St')}',$,$,$,#14,(#15,#16));
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+function toArrayBuffer(text: string): ArrayBuffer {
+  const bytes = new TextEncoder().encode(text);
+  const ab = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(ab).set(bytes);
+  return ab;
+}
+
+describe('storey elevation placement fallback (#1289)', () => {
+  it('derives a missing storey Elevation from its ObjectPlacement Z', async () => {
+    const parser = new IfcParser();
+    const store = await parser.parseColumnar(toArrayBuffer(IFC), { disableWorkerScan: true });
+
+    const elevations = store.spatialHierarchy?.storeyElevations;
+    expect(elevations, 'spatial hierarchy built').toBeDefined();
+
+    // Both storeys present: the attribute one (0) AND the placement-fallback one (3.5).
+    expect(elevations!.size).toBe(2);
+    const values = [...elevations!.values()].sort((a, b) => a - b);
+    expect(values[0]).toBeCloseTo(0, 6);
+    expect(values[1]).toBeCloseTo(3.5, 6);
+  });
+});

--- a/packages/renderer/src/scene-translate.test.ts
+++ b/packages/renderer/src/scene-translate.test.ts
@@ -175,4 +175,20 @@ describe('Scene.translateInstancedEntity', () => {
     assert.strictEqual(scene.translateInstancedEntity(404, [0, 5, 0]), false, 'unknown id');
     assert.strictEqual(scene.translateInstancedEntity(5, [0, 0, 0]), false, 'zero delta');
   });
+
+  it('keeps instanced bounds after a mixed flat+instanced move (no stranded null)', () => {
+    const scene = new Scene();
+    // Same expressId has BOTH an instanced occurrence and a flat mesh. The flat
+    // translate deletes the cached AABB; the instanced pass must rebuild it so a
+    // later bounds query is non-null (Codex review of #1289).
+    injectInstanced(scene, 7, [0, 0, 0]);
+    scene.addMeshData(mesh(7, [0, 0, 0, 1, 1, 1]));
+
+    assert.strictEqual(scene.translateMeshesForEntity(7, [0, 5, 0]), true);
+
+    const bounds = scene.getInstancedEntityBounds(7);
+    assert.ok(bounds, 'instanced bounds are not stranded to null');
+    assert.strictEqual(bounds!.min.y, 5, 'instanced bounds reflect the lift');
+    assert.strictEqual(bounds!.max.y, 6);
+  });
 });

--- a/packages/renderer/src/scene-translate.test.ts
+++ b/packages/renderer/src/scene-translate.test.ts
@@ -83,3 +83,96 @@ describe('Scene.translateMeshesForEntity', () => {
     assert.strictEqual(destroyed, true, 'evicted highlight GPU buffers were freed');
   });
 });
+
+/**
+ * GPU-instanced occurrences live in the per-template instance buffers, not
+ * meshDataMap, so the flat translate can't reach them. `translateInstancedEntity`
+ * lifts them with their storey in Exploded mode (#1289). The GPU writeBuffer is
+ * guarded by a cached device we don't supply, so the matrix math is exercised
+ * CPU-side via the instance record + the lazily-materialized occurrence MeshData.
+ */
+const INSTANCE_STRIDE = 88; // mirrors INSTANCE_STRIDE_BYTES
+
+interface InstancedTestState {
+  instancedEntityMap: Map<number, { templateIndex: number; byteOffset: number; originalColor: number[] }[]>;
+  instancedTemplateCpu: {
+    positions: Float32Array; normals: Float32Array; indices: Uint32Array;
+    instanceData: ArrayBuffer; localMin: number[]; localMax: number[];
+  }[];
+  instancedTemplates: unknown[];
+  boundingBoxes: Map<number, { min: { x: number; y: number; z: number }; max: { x: number; y: number; z: number } }>;
+}
+
+/** Inject one instanced template (a unit triangle) with one occurrence of
+ *  `expressId` at world translation `t`, plus its cached world AABB. */
+function injectInstanced(scene: Scene, expressId: number, t: [number, number, number]): DataView {
+  const instanceData = new ArrayBuffer(INSTANCE_STRIDE);
+  const dv = new DataView(instanceData);
+  // Identity upper-3x3 (col-major: m0, m5, m10, m15 = 1).
+  dv.setFloat32(0, 1, true); dv.setFloat32(20, 1, true); dv.setFloat32(40, 1, true); dv.setFloat32(60, 1, true);
+  // Translation column (m12, m13, m14) at +48/+52/+56.
+  dv.setFloat32(48, t[0], true); dv.setFloat32(52, t[1], true); dv.setFloat32(56, t[2], true);
+
+  const s = scene as unknown as InstancedTestState;
+  s.instancedTemplateCpu = [{
+    positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+    normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+    indices: new Uint32Array([0, 1, 2]),
+    instanceData,
+    localMin: [0, 0, 0], localMax: [1, 1, 0],
+  }];
+  s.instancedTemplates = []; // no GPU buffer => writeBuffer path skipped
+  s.instancedEntityMap = new Map([[expressId, [{ templateIndex: 0, byteOffset: 0, originalColor: [1, 1, 1, 1] }]]]);
+  s.boundingBoxes = new Map([[expressId, {
+    min: { x: t[0], y: t[1], z: t[2] }, max: { x: t[0] + 1, y: t[1] + 1, z: t[2] },
+  }]]);
+  return dv;
+}
+
+describe('Scene.translateInstancedEntity', () => {
+  it('lifts an instanced occurrence: instance matrix, AABB, and materialized geometry', () => {
+    const scene = new Scene();
+    const dv = injectInstanced(scene, 42, [0, 0, 0]);
+
+    assert.strictEqual(scene.translateInstancedEntity(42, [0, 5, 0]), true);
+
+    // Instance record translation column updated in place.
+    assert.strictEqual(dv.getFloat32(48, true), 0, 'x translation unchanged');
+    assert.strictEqual(dv.getFloat32(52, true), 5, 'y translation += 5');
+    assert.strictEqual(dv.getFloat32(56, true), 0, 'z translation unchanged');
+
+    // Cached world AABB shifted by the same delta (no recompute).
+    const bbox = (scene as unknown as InstancedTestState).boundingBoxes.get(42)!;
+    assert.strictEqual(bbox.min.y, 5);
+    assert.strictEqual(bbox.max.y, 6);
+
+    // Lazily-materialized occurrence geometry reflects the lift.
+    const pieces = scene.getInstancedMeshDataPieces(42)!;
+    assert.ok(pieces && pieces.length === 1);
+    assert.strictEqual(pieces[0].positions[1], 5, 'first vertex y lifted by 5');
+  });
+
+  it('the public translateMeshesForEntity moves an instanced-only entity', () => {
+    const scene = new Scene();
+    injectInstanced(scene, 7, [0, 0, 0]);
+    // No flat mesh for id 7 — the move must still succeed via the instanced path.
+    assert.strictEqual(scene.translateMeshesForEntity(7, [0, 4, 0]), true);
+    assert.strictEqual(scene.getInstancedMeshDataPieces(7)![0].positions[1], 4);
+  });
+
+  it('is reversible (Exploded -> Stacked subtracts the same delta)', () => {
+    const scene = new Scene();
+    const dv = injectInstanced(scene, 9, [2, 0, 0]);
+    scene.translateInstancedEntity(9, [0, 8, 0]);
+    scene.translateInstancedEntity(9, [0, -8, 0]);
+    assert.strictEqual(dv.getFloat32(48, true), 2, 'x restored');
+    assert.strictEqual(dv.getFloat32(52, true), 0, 'y restored to native');
+  });
+
+  it('returns false for a non-instanced id and for a zero delta', () => {
+    const scene = new Scene();
+    injectInstanced(scene, 5, [0, 0, 0]);
+    assert.strictEqual(scene.translateInstancedEntity(404, [0, 5, 0]), false, 'unknown id');
+    assert.strictEqual(scene.translateInstancedEntity(5, [0, 0, 0]), false, 'zero delta');
+  });
+});

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -795,6 +795,20 @@ export class Scene {
    * to a full reload if needed.
    */
   translateMeshesForEntity(expressId: number, delta: [number, number, number]): boolean {
+    // An entity can have flat meshes, GPU-instanced occurrences, or both. The
+    // instanced occurrences live in the per-template instance buffers, NOT in
+    // meshDataMap, so the flat path below can't reach them — without this they
+    // are "left behind" when a storey lifts in Exploded mode (#1289).
+    const instancedMoved = this.translateInstancedEntity(expressId, delta);
+    const flatMoved = this.translateFlatMeshesForEntity(expressId, delta);
+    return flatMoved || instancedMoved;
+  }
+
+  /**
+   * Translate every flat (non-instanced) mesh for `expressId` by `delta`. See
+   * {@link translateMeshesForEntity} for the full contract; this is the flat half.
+   */
+  private translateFlatMeshesForEntity(expressId: number, delta: [number, number, number]): boolean {
     const meshDataList = this.meshDataMap.get(expressId);
     if (!meshDataList || meshDataList.length === 0) return false;
     const [dx, dy, dz] = delta;
@@ -855,6 +869,64 @@ export class Scene {
     this.evictHighlightMeshes(expressId);
     for (const key of affectedKeys) {
       this.pendingBatchKeys.add(key);
+    }
+    return true;
+  }
+
+  /**
+   * Translate every GPU-instanced occurrence of `expressId` by `delta` in the
+   * renderer world frame. Instanced occurrences live in the per-template instance
+   * buffers (NOT meshDataMap), so the flat translate path can't reach them — this
+   * is what keeps repeated geometry (e.g. windows / mullions emitted via
+   * IfcMappedItem) lifting with its storey in Exploded mode (#1289).
+   *
+   * Mutates BOTH halves so every consumer stays consistent:
+   *   - the CPU instance record (so getInstancedMeshDataPieces / bounds / raycast
+   *     / measure / section / export see the new position), and
+   *   - the GPU instance buffer (so the occurrence renders at the new position).
+   * The cached world AABB is shifted by the same delta — every occurrence of the
+   * entity moves identically, so a recompute is unnecessary.
+   *
+   * Returns `true` when at least one occurrence moved. No-op (returns false) for
+   * a non-instanced id or a zero delta.
+   */
+  translateInstancedEntity(expressId: number, delta: [number, number, number]): boolean {
+    const occurrences = this.instancedEntityMap.get(expressId);
+    if (!occurrences || occurrences.length === 0) return false;
+    const [dx, dy, dz] = delta;
+    if (dx === 0 && dy === 0 && dz === 0) return false;
+
+    const device = this.instancedDevice;
+    let moved = false;
+    for (const occ of occurrences) {
+      const cpu = this.instancedTemplateCpu[occ.templateIndex];
+      if (!cpu) continue;
+      // Column-major mat4: the translation column is floats 12,13,14, i.e. bytes
+      // +48/+52/+56 of the occurrence's record (matches unionInstancedWorldAabb).
+      const dv = new DataView(cpu.instanceData);
+      const b = occ.byteOffset;
+      const tx = dv.getFloat32(b + 48, true) + dx;
+      const ty = dv.getFloat32(b + 52, true) + dy;
+      const tz = dv.getFloat32(b + 56, true) + dz;
+      dv.setFloat32(b + 48, tx, true);
+      dv.setFloat32(b + 52, ty, true);
+      dv.setFloat32(b + 56, tz, true);
+      // Push only the 12 translation bytes to the GPU buffer (in place). Guarded
+      // on the cached device so CPU-only tests still exercise the matrix math.
+      if (device) {
+        const gpu = this.instancedTemplates[occ.templateIndex]?.instanceBuffer;
+        if (gpu) device.queue.writeBuffer(gpu, b + 48, new Float32Array([tx, ty, tz]));
+      }
+      moved = true;
+    }
+    if (!moved) return false;
+
+    // Shift the cached world AABB by the same delta so pick / measure / section
+    // bounds stay correct without a recompute (all occurrences moved identically).
+    const bbox = this.boundingBoxes.get(expressId);
+    if (bbox) {
+      bbox.min.x += dx; bbox.min.y += dy; bbox.min.z += dz;
+      bbox.max.x += dx; bbox.max.y += dy; bbox.max.z += dz;
     }
     return true;
   }

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -799,8 +799,13 @@ export class Scene {
     // instanced occurrences live in the per-template instance buffers, NOT in
     // meshDataMap, so the flat path below can't reach them — without this they
     // are "left behind" when a storey lifts in Exploded mode (#1289).
-    const instancedMoved = this.translateInstancedEntity(expressId, delta);
+    //
+    // Flat runs FIRST because it deletes the entity's cached world AABB; the
+    // instanced pass runs last and rebuilds that AABB from the moved occurrence
+    // matrices, so a mixed flat+instanced entity never ends up with stranded
+    // (null) instanced bounds.
     const flatMoved = this.translateFlatMeshesForEntity(expressId, delta);
+    const instancedMoved = this.translateInstancedEntity(expressId, delta);
     return flatMoved || instancedMoved;
   }
 
@@ -921,14 +926,33 @@ export class Scene {
     }
     if (!moved) return false;
 
-    // Shift the cached world AABB by the same delta so pick / measure / section
-    // bounds stay correct without a recompute (all occurrences moved identically).
-    const bbox = this.boundingBoxes.get(expressId);
-    if (bbox) {
-      bbox.min.x += dx; bbox.min.y += dy; bbox.min.z += dz;
-      bbox.max.x += dx; bbox.max.y += dy; bbox.max.z += dz;
-    }
+    // Rebuild the cached world AABB from the moved occurrence matrices so pick /
+    // measure / section bounds stay correct. A simple in-place shift is unsafe for
+    // an entity that has BOTH flat meshes and instanced occurrences: the flat
+    // translate path deletes this same cache entry, which would strand the shift
+    // (a later getInstancedEntityBounds would return null). Recomputing fresh is
+    // robust regardless of the flat path and the upload-time bounds.
+    this.recomputeInstancedBounds(expressId);
     return true;
+  }
+
+  /** Recompute an instanced entity's cached world AABB by unioning the transformed
+   *  template AABB across its occurrences (using their CURRENT matrices). Used after
+   *  a translate so bounds reflect the moved geometry. No-op for a non-instanced id. */
+  private recomputeInstancedBounds(expressId: number): void {
+    const occurrences = this.instancedEntityMap.get(expressId);
+    if (!occurrences || occurrences.length === 0) return;
+    this.boundingBoxes.delete(expressId);
+    for (const occ of occurrences) {
+      const cpu = this.instancedTemplateCpu[occ.templateIndex];
+      if (!cpu) continue;
+      const dv = new DataView(cpu.instanceData);
+      this.unionInstancedWorldAabb(
+        expressId, dv, occ.byteOffset,
+        cpu.localMin[0], cpu.localMin[1], cpu.localMin[2],
+        cpu.localMax[0], cpu.localMax[1], cpu.localMax[2],
+      );
+    }
   }
 
   /** Drop the per-entity selection-highlight meshes for `expressId` (frozen


### PR DESCRIPTION
Fixes #1289.

Both symptoms in the issue trace to two independent defects in Exploded level-display mode. Verified against the two attached models (AC20-FZK-Haus, Project01_PC01).

## 1. "Objects left behind" (AC20-FZK-Haus) — render path
Exploded mode lifts a storey by pushing per-entity translations into `Scene.translateMeshesForEntities`, which only touched the flat `meshDataMap`. GPU-instanced occurrences (repeated geometry emitted via `IfcMappedItem` — FZK-Haus has 56 mapped items, and instancing fires at `min_group = 2`) live in separate per-template instance buffers, so they never moved and stayed at the original elevation while the rest of the storey rose.

`Scene.translateInstancedEntity` now shifts each occurrence's mat4 translation column in **both** the CPU instance record and the GPU instance buffer, plus the cached world AABB (so pick / measure / section / export stay consistent). It is wired into `translateMeshesForEntity`, so it also fixes gizmo moves of instanced elements.

## 2. "Only one floor" (Project01_PC01) — parser path
That model's `FirstFloor` storey has a null `Elevation` attribute but is placed at Z = 3.5 via its `ObjectPlacement`. The spatial-hierarchy builder dropped any storey without an explicit elevation from `storeyElevations`, leaving Exploded mode a single floor to order.

The builder now falls back to the storey's `ObjectPlacement` → `RelativePlacement` → `Location` Z when the `Elevation` attribute is missing. This matches the attribute's semantics (Z relative to the parent container), so it stays consistent with sibling storeys that do carry the attribute and avoids folding in site-level georeferencing Z.

## Tests
- `Scene.translateInstancedEntity`: lift, instanced-only entity via the public API, reversibility (Exploded → Stacked), and no-op cases. Full scene suite 29/29.
- `storey-elevation-fallback.test.ts`: synthetic IFC4 with one attribute-elevation storey and one null-elevation/placement-Z storey; asserts both land in `storeyElevations`.
- Changeset added (`@ifc-lite/renderer` + `@ifc-lite/parser`, patch).