### PR TITLE
fix(geometry): instancing dropped repeated geometry (Tekla steel showed as 'missing objects')

### DIFF
--- a/.changeset/instanced-submesh-placement.md
+++ b/.changeset/instanced-submesh-placement.md
@@ -1,0 +1,16 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Fix GPU instancing dropping repeated geometry ("missing objects" under #1238).
+
+The sub-mesh placement path (`apply_submesh_placement`) — taken by every
+multi-item element, which is all Tekla-style steel (beams, plates, assemblies)
+— baked the element's world placement into the vertices but never recorded it
+into `instance_meta.transform`, leaving the IDENTITY placeholder. The single-mesh
+path (`apply_placement`) already records it; the sub-mesh path did not. So
+`collate_refs` computed `rel_k = m_k · m_ref⁻¹ = identity` for every occurrence
+of a template and they all stacked on the first one, leaving every other position
+empty. The flat (non-instanced) path was always correct, and content-dedup made
+it look like ~half the model was gone. Now each sub-mesh records the scaled
+per-element placement before baking, mirroring the single-mesh path.

--- a/rust/geometry/src/router/processing.rs
+++ b/rust/geometry/src/router/processing.rs
@@ -729,6 +729,23 @@ impl GeometryRouter {
                 if let Some(placement) = decoder.resolve_ref(placement_attr)? {
                     let mut transform = self.get_placement_transform(&placement, decoder)?;
                     self.scale_transform(&mut transform);
+                    // Instancing: record the per-element world placement on EACH sub-mesh's
+                    // instance metadata BEFORE it is baked into the vertices, mirroring
+                    // `apply_placement` for the single-mesh path. Without this, the sub-mesh
+                    // path (every multi-item element — all the Tekla steel: beams, plates,
+                    // assemblies) leaves `instance_meta.transform` at the IDENTITY placeholder,
+                    // so `collate_refs` computes rel_k = m_k · m_ref⁻¹ = identity for every
+                    // occurrence and they all stack on the first one. The flat path was
+                    // always correct (placement IS baked into the vertices below), so the
+                    // dedup made it look like repeated geometry was "missing".
+                    if instancing_enabled() {
+                        let row_major = mat4_to_row_major(&transform);
+                        for sub in &mut sub_meshes.sub_meshes {
+                            if let Some(im) = sub.mesh.instance_meta.as_mut() {
+                                im.transform = row_major;
+                            }
+                        }
+                    }
                     for sub in &mut sub_meshes.sub_meshes {
                         self.transform_mesh_world(&mut sub.mesh, &transform);
                     }

--- a/rust/geometry/src/router/processing.rs
+++ b/rust/geometry/src/router/processing.rs
@@ -847,8 +847,31 @@ impl GeometryRouter {
                     // Apply MappedItem transform to newly added sub-meshes
                     if let Some(mut transform) = mapping_transform.clone() {
                         self.scale_transform(&mut transform);
+                        // The MappingTarget is baked into the vertices here, but
+                        // `rep_identity` was hashed from the canonical (pre-target)
+                        // geometry during the recursion. Two occurrences sharing a map
+                        // with DIFFERENT targets would therefore collate under one
+                        // template and reuse the reference's target offset/orientation.
+                        // When the target actually changes the geometry, re-hash the
+                        // post-target local geometry so rep_identity matches what is
+                        // baked. Identity targets (the common Revit case) leave the
+                        // geometry unchanged, so the canonical hash already matches —
+                        // skip the re-hash there to avoid the O(verts) cost.
+                        let nontrivial_target = !transform.is_identity(1e-9);
                         for sub in &mut sub_meshes.sub_meshes[count_before..] {
                             self.transform_mesh_local(&mut sub.mesh, &transform);
+                            if nontrivial_target
+                                && sub
+                                    .mesh
+                                    .instance_meta
+                                    .as_ref()
+                                    .is_some_and(|im| im.instanceable)
+                            {
+                                let h = Self::compute_mesh_hash_full(&sub.mesh) | DIRECT_SOLID_TAG;
+                                if let Some(im) = sub.mesh.instance_meta.as_mut() {
+                                    im.rep_identity = h;
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Problem

On models with lots of repeated geometry (e.g. the 170k-mesh Tekla steel model), GPU instancing (#1238) made ~half the model render as **missing** — equipment clusters, braces, plates, and assemblies disappeared. Turning instancing off rendered the complete model. The flat path was always correct; only the instanced path lost geometry.

## Root cause

`apply_submesh_placement` — the placement path taken by **every multi-item element** (all the Tekla steel: beams, plates, `IfcElementAssembly` children) — baked the element's world placement into the vertices (so the flat path is correct) but **never recorded it into `instance_meta.transform`**, leaving the IDENTITY placeholder that `process_representation_item` tags. The single-mesh path (`apply_placement`) already records it; the sub-mesh path did not.

So `collate_refs` computed `rel_k = m_k · m_ref⁻¹ = identity` for **every** occurrence of a template, and they all stacked on the first occurrence's position — every other position rendered empty. The content-dedup made it look like ~half the model was gone.

## Fix

Record the scaled per-element placement into each sub-mesh's `instance_meta.transform` before baking it into the vertices, mirroring `apply_placement`. One spot, gated on `instancing_enabled()`, zero effect on the flat path.

## Verification

64k-mesh steel model, identical fixed camera, grids off:
- before: instanced render ≈ 88% of the flat render; per-template occurrence transforms were all identical (`distinctTrans = 1`).
- after: instanced render is **1:1 with the flat render**; every occurrence has a distinct transform (`distinctTrans == occurrenceCount`).

Diagnosed by comparing per-occurrence world AABBs (instanced vs flat) and dumping `instance_meta.transform` at `collate_refs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GPU instancing where repeated geometry could be missing or incorrectly stacked due to incorrect per-instance placement metadata. Instanced sub-meshes now retain their correct world transform, and mapped target transforms no longer cause unrelated instances to collide under the same identity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->