### PR TITLE
perf(geometry): drop per-occurrence rep_identity re-hash + flagged extra-type dedup (#1286 foundation)

### DIFF
--- a/.changeset/dedup-perocc-rehash.md
+++ b/.changeset/dedup-perocc-rehash.md
@@ -1,0 +1,17 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Geometry content-dedup: drop the per-occurrence `rep_identity` re-hash and add an
+opt-in extra-type gate.
+
+On a content-dedup cache hit the item mesh was cloned and its full 128-bit
+`compute_mesh_hash_full` was re-run for instancing `rep_identity` on every
+occurrence (tens of thousands of times on repeated steel). The cache now stores
+the `rep_identity` beside the mesh, so a hit stamps it as a `u128` copy instead of
+re-hashing. Byte-identical output.
+
+Also adds `IFC_LITE_DEDUP_EXTRA` (default OFF) which extends content-dedup to
+`IfcPolygonalFaceSet` / `IfcTriangulatedFaceSet` / `IfcShellBasedSurfaceModel` /
+`IfcFaceBasedSurfaceModel` (their structural signature is already complete);
+gated so low-reuse models never pay the hash for no payback.

--- a/.changeset/dedup-perocc-rehash.md
+++ b/.changeset/dedup-perocc-rehash.md
@@ -15,3 +15,8 @@ Also adds `IFC_LITE_DEDUP_EXTRA` (default OFF) which extends content-dedup to
 `IfcPolygonalFaceSet` / `IfcTriangulatedFaceSet` / `IfcShellBasedSurfaceModel` /
 `IfcFaceBasedSurfaceModel` (their structural signature is already complete);
 gated so low-reuse models never pay the hash for no payback.
+
+Note: the public Rust `ItemDedupCache` value type changes from `Arc<Mesh>` to
+`Arc<(Mesh, Option<u128>)>`. The alias is an opaque handle outside the workspace
+(keys come from private `item_dedup_key`); this is an intentional 0.x source
+break for any external Rust code that constructed map entries by hand.

--- a/rust/geometry/src/router/mod.rs
+++ b/rust/geometry/src/router/mod.rs
@@ -72,12 +72,19 @@ pub trait GeometryProcessor {
 }
 
 /// Shared content-dedup cache: maps a 128-bit structural item hash to the
-/// LOCAL (pre-placement, void-free, colour-free) item mesh. Build ONE per loaded
+/// LOCAL (pre-placement, void-free, colour-free) item mesh PLUS its precomputed
+/// instancing `rep_identity` (`Some` when instancing tagged it, else `None`).
+/// Storing the rep beside the mesh lets a cache hit stamp it without re-running
+/// the O(verts) `compute_mesh_hash_full` per occurrence. Build ONE per loaded
 /// model with [`GeometryRouter::new_dedup_cache`] and inject it into every
 /// per-element / per-batch router via
 /// [`GeometryRouter::enable_content_dedup_shared`] so byte-identical geometry is
 /// meshed once regardless of how the work is partitioned across threads/batches.
-pub type ItemDedupCache = Arc<Mutex<FxHashMap<u128, Arc<Mesh>>>>;
+pub type ItemDedupCache = Arc<Mutex<FxHashMap<u128, Arc<(Mesh, Option<u128>)>>>>;
+
+/// Test/env override for [`GeometryRouter::build_dedup_extra_enabled`]:
+/// -1 = env default, 0 = forced off, 1 = forced on.
+static DEDUP_EXTRA_OVERRIDE: std::sync::atomic::AtomicI8 = std::sync::atomic::AtomicI8::new(-1);
 
 /// Shared `IfcMappedItem` source cache: maps an `IfcRepresentationMap` express id
 /// to its SOURCE-coordinate (pre-`MappingTarget`, pre-placement, colour-free) item
@@ -384,6 +391,36 @@ impl GeometryRouter {
     /// meshes bake in this model's unit scale / tessellation quality.
     pub fn new_dedup_cache() -> ItemDedupCache {
         Arc::new(Mutex::new(FxHashMap::default()))
+    }
+
+    /// Whether content-dedup covers EXTRA item types beyond the proven default
+    /// set (faceset / surface-model families). `item_signature`'s generic byte
+    /// walk is already complete for them, so this is pure additive build savings
+    /// on models that repeat tessellated geometry — but it pays a hash on every
+    /// such item, so it stays OFF by default until corpus-validated (low-reuse
+    /// models would pay the hash for no payback, the #1177 trap). Opt in with
+    /// `IFC_LITE_DEDUP_EXTRA=1` or [`Self::set_build_dedup_extra_override`].
+    /// Default OFF keeps native==wasm identical.
+    pub fn build_dedup_extra_enabled() -> bool {
+        match DEDUP_EXTRA_OVERRIDE.load(std::sync::atomic::Ordering::Relaxed) {
+            0 => return false,
+            1 => return true,
+            _ => {}
+        }
+        static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        *ON.get_or_init(|| std::env::var("IFC_LITE_DEDUP_EXTRA").as_deref() == Ok("1"))
+    }
+
+    /// Test-only: force [`Self::build_dedup_extra_enabled`] on/off (`None` = env).
+    pub fn set_build_dedup_extra_override(v: Option<bool>) {
+        DEDUP_EXTRA_OVERRIDE.store(
+            match v {
+                None => -1,
+                Some(false) => 0,
+                Some(true) => 1,
+            },
+            std::sync::atomic::Ordering::Relaxed,
+        );
     }
 
     /// Inject a shared item-dedup cache (see [`Self::new_dedup_cache`]) into this

--- a/rust/geometry/src/router/processing.rs
+++ b/rust/geometry/src/router/processing.rs
@@ -632,8 +632,9 @@ impl GeometryRouter {
             return self.process_mapped_item_cached(item, decoder);
         }
 
-        // `None` ⇒ dedup disabled (no hash overhead). On a hit, return a clone of
-        // the cached item mesh; meshing is skipped entirely.
+        // `None` ⇒ dedup disabled (no hash overhead). On a hit, clone the cached
+        // item mesh and stamp its STORED rep_identity (no per-occurrence re-hash);
+        // meshing is skipped entirely.
         let dedup_key = self.item_dedup_key(item, decoder);
         if let (Some(key), Some(cache)) = (dedup_key, self.item_dedup_cache.as_ref()) {
             let hit = cache
@@ -641,12 +642,16 @@ impl GeometryRouter {
                 .unwrap_or_else(|e| e.into_inner())
                 .get(&key)
                 .cloned();
-            if let Some(mesh) = hit {
-                return Ok(self.tag_direct_instance((*mesh).clone()));
+            if let Some(entry) = hit {
+                let (mesh, rep) = (entry.0.clone(), entry.1);
+                return Ok(self.stamp_direct_instance(mesh, rep));
             }
         }
 
         let mesh = self.process_representation_item_uncached(item, decoder)?;
+        // Compute the instancing rep_identity ONCE for this unique shape so cache
+        // hits can reuse it instead of re-hashing the full mesh per occurrence.
+        let rep = self.direct_rep_identity(&mesh);
 
         // Cache the freshly-meshed item under its structural hash. Two exclusions:
         //  - empty meshes (unsupported/degenerate geometry);
@@ -661,7 +666,7 @@ impl GeometryRouter {
             if !mesh.positions.is_empty() && !crate::kernel::budget::tripped() {
                 // Clone into the Arc BEFORE locking: a mesh deep-copy inside the
                 // single-Mutex critical section serializes the pool on every miss.
-                let cached = Arc::new(mesh.clone());
+                let cached = Arc::new((mesh.clone(), rep));
                 cache
                     .lock()
                     .unwrap_or_else(|e| e.into_inner())
@@ -669,24 +674,32 @@ impl GeometryRouter {
             }
         }
 
-        Ok(self.tag_direct_instance(mesh))
+        Ok(self.stamp_direct_instance(mesh, rep))
     }
 
-    /// Instancing: tag a direct-solid item mesh with its local-geometry content
-    /// hash as `rep_identity`, so identical representations across the model
-    /// collate into a single template + per-occurrence transforms. The hash is of
-    /// the pre-placement local mesh (the same `compute_mesh_hash` the geometry
-    /// cache uses), so two occurrences differing only by `IfcObjectPlacement`
-    /// share an id. A high tag bit namespaces these apart from mapped-item ids
-    /// (RepresentationMap entity ids). No-op when the flag is off or the mesh
-    /// already carries metadata (mapped items) / is empty.
-    fn tag_direct_instance(&self, mut mesh: Mesh) -> Mesh {
+    /// Compute the direct-solid instancing `rep_identity` for a freshly-built,
+    /// pre-placement item mesh, or `None` when instancing is off / the mesh is
+    /// empty / it already carries metadata (mapped items). FULL 128-bit
+    /// (non-sampling) hash: rep_identity has no downstream meshes_equal guard at
+    /// the source and must be cross-worker consistent, so a sampled-hash collision
+    /// (#833 family) would silently group non-identical geometry; 128-bit makes
+    /// that ~2^-127. Computed ONCE per unique shape — cache hits reuse the stored
+    /// value via [`Self::stamp_direct_instance`] instead of re-hashing.
+    fn direct_rep_identity(&self, mesh: &Mesh) -> Option<u128> {
         if instancing_enabled() && mesh.instance_meta.is_none() && !mesh.positions.is_empty() {
-            // FULL 128-bit (non-sampling) hash: rep_identity has no downstream
-            // meshes_equal guard at the source and must be cross-worker consistent,
-            // so a sampled-hash collision (#833 family) would silently group
-            // non-identical geometry. The 128-bit content hash makes that ~2^-127.
-            let exact_rep = Self::compute_mesh_hash_full(&mesh) | DIRECT_SOLID_TAG;
+            Some(Self::compute_mesh_hash_full(mesh) | DIRECT_SOLID_TAG)
+        } else {
+            None
+        }
+    }
+
+    /// Stamp a direct-solid item mesh with a KNOWN `rep_identity` (no re-hash) so
+    /// identical representations collate into a single template + per-occurrence
+    /// transforms. `rep` comes from [`Self::direct_rep_identity`] on a fresh build
+    /// or from the dedup cache on a hit; `None` is a no-op (instancing off / empty
+    /// / already tagged).
+    fn stamp_direct_instance(&self, mut mesh: Mesh, rep: Option<u128>) -> Mesh {
+        if let Some(exact_rep) = rep {
             mesh.instance_meta = Some(InstanceMeta {
                 transform: IDENTITY_ROW_MAJOR,
                 local_transform: None,
@@ -718,13 +731,25 @@ impl GeometryRouter {
         // arch models improve too (advanced_model 3.1×, ISSUE_068 1.7×) with no
         // regression on the tested corpus. The IfcMappedItem instancing cache is a
         // separate path, always on.
-        if !matches!(
+        let base = matches!(
             item.ifc_type,
             IfcType::IfcFacetedBrep
                 | IfcType::IfcBooleanResult
                 | IfcType::IfcBooleanClippingResult
                 | IfcType::IfcExtrudedAreaSolid
-        ) {
+        );
+        // Additive, flagged OFF by default: faceset / surface-model families. Their
+        // generic byte signature (`sig_walk_bytes`) is already complete; gated so a
+        // low-reuse model never pays the hash for no payback (the #1177 trap).
+        let extra = Self::build_dedup_extra_enabled()
+            && matches!(
+                item.ifc_type,
+                IfcType::IfcPolygonalFaceSet
+                    | IfcType::IfcTriangulatedFaceSet
+                    | IfcType::IfcShellBasedSurfaceModel
+                    | IfcType::IfcFaceBasedSurfaceModel
+            );
+        if !(base || extra) {
             return None;
         }
         let structural = {

--- a/rust/geometry/tests/dedup_validate.rs
+++ b/rust/geometry/tests/dedup_validate.rs
@@ -638,3 +638,246 @@ fn dedup_byte_identical_and_faster() {
     assert_eq!(mismatches, 0, "content-dedup produced different geometry");
     println!("✓ dedup is byte-identical to the non-deduped path");
 }
+
+/// Two geometrically-IDENTICAL voided walls (same 2x0.3x3 swept section, same
+/// 0.5x0.5x1 opening at the same wall-relative offset) at DIFFERENT placements,
+/// plus a third wall with a DISTINCT (0.8x0.8) opening. Exercises the VOID path
+/// (`process_element_with_submeshes_and_voids`), which the calibration snapshot
+/// harness (`process_element` only) cannot see — the parity gate for the
+/// element-level void-cut dedup work (#1286).
+fn synthetic_voided_duplicates_ifc() -> String {
+    r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('voided.ifc','2025-01-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('proj',$,'P','',$,$,$,(#12),#7);
+#7=IFCUNITASSIGNMENT((#8));
+#8=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#12=IFCGEOMETRICREPRESENTATIONCONTEXT('3D','Model',3,1.E-6,#14,$);
+#14=IFCAXIS2PLACEMENT3D(#15,$,$);
+#15=IFCCARTESIANPOINT((0.,0.,0.));
+#40=IFCLOCALPLACEMENT($,#41);
+#41=IFCAXIS2PLACEMENT3D(#42,$,$);
+#42=IFCCARTESIANPOINT((0.,0.,0.));
+#50=IFCWALL('w1',$,'W1','',$,#40,#51,$,$);
+#51=IFCPRODUCTDEFINITIONSHAPE($,$,(#52));
+#52=IFCSHAPEREPRESENTATION(#12,'Body','SweptSolid',(#53));
+#53=IFCEXTRUDEDAREASOLID(#54,#57,#60,3.);
+#54=IFCRECTANGLEPROFILEDEF(.AREA.,$,#55,2.,0.3);
+#55=IFCAXIS2PLACEMENT2D(#56,$);
+#56=IFCCARTESIANPOINT((0.,0.));
+#57=IFCAXIS2PLACEMENT3D(#58,$,$);
+#58=IFCCARTESIANPOINT((0.,0.,0.));
+#60=IFCDIRECTION((0.,0.,1.));
+#140=IFCLOCALPLACEMENT($,#141);
+#141=IFCAXIS2PLACEMENT3D(#142,$,$);
+#142=IFCCARTESIANPOINT((0.,0.,1.));
+#150=IFCOPENINGELEMENT('o1',$,'O1','',$,#140,#151,$,$);
+#151=IFCPRODUCTDEFINITIONSHAPE($,$,(#152));
+#152=IFCSHAPEREPRESENTATION(#12,'Body','SweptSolid',(#153));
+#153=IFCEXTRUDEDAREASOLID(#154,#157,#160,1.);
+#154=IFCRECTANGLEPROFILEDEF(.AREA.,$,#155,0.5,0.5);
+#155=IFCAXIS2PLACEMENT2D(#156,$);
+#156=IFCCARTESIANPOINT((0.,0.));
+#157=IFCAXIS2PLACEMENT3D(#158,$,$);
+#158=IFCCARTESIANPOINT((0.,0.,0.));
+#160=IFCDIRECTION((0.,0.,1.));
+#201=IFCRELVOIDSELEMENT('rv1',$,$,$,#50,#150);
+#240=IFCLOCALPLACEMENT($,#241);
+#241=IFCAXIS2PLACEMENT3D(#242,$,$);
+#242=IFCCARTESIANPOINT((10.,0.,0.));
+#250=IFCWALL('w2',$,'W2','',$,#240,#251,$,$);
+#251=IFCPRODUCTDEFINITIONSHAPE($,$,(#252));
+#252=IFCSHAPEREPRESENTATION(#12,'Body','SweptSolid',(#253));
+#253=IFCEXTRUDEDAREASOLID(#254,#257,#260,3.);
+#254=IFCRECTANGLEPROFILEDEF(.AREA.,$,#255,2.,0.3);
+#255=IFCAXIS2PLACEMENT2D(#256,$);
+#256=IFCCARTESIANPOINT((0.,0.));
+#257=IFCAXIS2PLACEMENT3D(#258,$,$);
+#258=IFCCARTESIANPOINT((0.,0.,0.));
+#260=IFCDIRECTION((0.,0.,1.));
+#340=IFCLOCALPLACEMENT($,#341);
+#341=IFCAXIS2PLACEMENT3D(#342,$,$);
+#342=IFCCARTESIANPOINT((10.,0.,1.));
+#350=IFCOPENINGELEMENT('o2',$,'O2','',$,#340,#351,$,$);
+#351=IFCPRODUCTDEFINITIONSHAPE($,$,(#352));
+#352=IFCSHAPEREPRESENTATION(#12,'Body','SweptSolid',(#353));
+#353=IFCEXTRUDEDAREASOLID(#354,#357,#360,1.);
+#354=IFCRECTANGLEPROFILEDEF(.AREA.,$,#355,0.5,0.5);
+#355=IFCAXIS2PLACEMENT2D(#356,$);
+#356=IFCCARTESIANPOINT((0.,0.));
+#357=IFCAXIS2PLACEMENT3D(#358,$,$);
+#358=IFCCARTESIANPOINT((0.,0.,0.));
+#360=IFCDIRECTION((0.,0.,1.));
+#202=IFCRELVOIDSELEMENT('rv2',$,$,$,#250,#350);
+#440=IFCLOCALPLACEMENT($,#441);
+#441=IFCAXIS2PLACEMENT3D(#442,$,$);
+#442=IFCCARTESIANPOINT((0.,10.,0.));
+#450=IFCWALL('w3',$,'W3','',$,#440,#451,$,$);
+#451=IFCPRODUCTDEFINITIONSHAPE($,$,(#452));
+#452=IFCSHAPEREPRESENTATION(#12,'Body','SweptSolid',(#453));
+#453=IFCEXTRUDEDAREASOLID(#454,#457,#460,3.);
+#454=IFCRECTANGLEPROFILEDEF(.AREA.,$,#455,2.,0.3);
+#455=IFCAXIS2PLACEMENT2D(#456,$);
+#456=IFCCARTESIANPOINT((0.,0.));
+#457=IFCAXIS2PLACEMENT3D(#458,$,$);
+#458=IFCCARTESIANPOINT((0.,0.,0.));
+#460=IFCDIRECTION((0.,0.,1.));
+#540=IFCLOCALPLACEMENT($,#541);
+#541=IFCAXIS2PLACEMENT3D(#542,$,$);
+#542=IFCCARTESIANPOINT((0.,10.,1.));
+#550=IFCOPENINGELEMENT('o3',$,'O3','',$,#540,#551,$,$);
+#551=IFCPRODUCTDEFINITIONSHAPE($,$,(#552));
+#552=IFCSHAPEREPRESENTATION(#12,'Body','SweptSolid',(#553));
+#553=IFCEXTRUDEDAREASOLID(#554,#557,#560,1.);
+#554=IFCRECTANGLEPROFILEDEF(.AREA.,$,#555,0.8,0.8);
+#555=IFCAXIS2PLACEMENT2D(#556,$);
+#556=IFCCARTESIANPOINT((0.,0.));
+#557=IFCAXIS2PLACEMENT3D(#558,$,$);
+#558=IFCCARTESIANPOINT((0.,0.,0.));
+#560=IFCDIRECTION((0.,0.,1.));
+#203=IFCRELVOIDSELEMENT('rv3',$,$,$,#450,#550);
+ENDSEC;
+END-ISO-10303-21;
+"#
+    .to_string()
+}
+
+/// CI parity gate (#1286): content-dedup must be BYTE-IDENTICAL to the
+/// non-deduped path through the VOID submesh path, keep placement per-instance,
+/// and keep a distinct void distinct. Guards the element-level void-cut dedup.
+#[test]
+fn content_dedup_byte_identical_on_voided_duplicates() {
+    let content = synthetic_voided_duplicates_ifc();
+    let wall_ids = [50u32, 250, 450];
+    let void_idx = build_void_index(&content);
+    // every wall must actually carry a void, else the path under test is skipped.
+    for id in &wall_ids {
+        assert!(
+            void_idx.get(id).map(|v| !v.is_empty()).unwrap_or(false),
+            "wall #{id} has no void in the index"
+        );
+    }
+
+    let run_path = |dedup: bool| -> Vec<u64> {
+        let mut d = EntityDecoder::with_index(&content, build_entity_index(&content));
+        let mut router = GeometryRouter::with_units(&content, &mut d);
+        if !dedup {
+            router.disable_content_dedup();
+        }
+        wall_ids
+            .iter()
+            .map(|&id| {
+                let e = d.decode_by_id(id).expect("decode wall");
+                let sm = router
+                    .process_element_with_submeshes_and_voids(&e, &mut d, &void_idx)
+                    .expect("void mesh");
+                assert!(!sm.sub_meshes.is_empty(), "wall #{id} produced no voided geometry");
+                fingerprint(&sm)
+            })
+            .collect()
+    };
+
+    let on = run_path(true);
+    let off = run_path(false);
+
+    assert_eq!(
+        on, off,
+        "void-path content-dedup geometry differs from the freshly-built path"
+    );
+    // walls 1 and 2 are geometrically identical but at different placements:
+    // their WORLD fingerprints must differ (placement stays per-instance).
+    assert_ne!(on[0], on[1], "per-instance placement was lost on the void path");
+    // wall 3 has a distinct opening: it must not collapse into the duplicates.
+    assert_ne!(on[0], on[2], "a distinct void wrongly matched the duplicates");
+}
+
+/// Two identical IfcTriangulatedFaceSet proxies at different placements + one
+/// distinct, to validate the flagged EXTRA-type dedup (Phase 3 / #1286): with the
+/// flag ON the duplicates must collapse to one cached item and stay byte-identical
+/// to the freshly-built path.
+fn synthetic_faceset_duplicates_ifc() -> String {
+    r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('fs.ifc','2025-01-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('proj',$,'P','',$,$,$,(#12),#7);
+#7=IFCUNITASSIGNMENT((#8));
+#8=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#12=IFCGEOMETRICREPRESENTATIONCONTEXT('3D','Model',3,1.E-6,#14,$);
+#14=IFCAXIS2PLACEMENT3D(#15,$,$);
+#15=IFCCARTESIANPOINT((0.,0.,0.));
+#40=IFCLOCALPLACEMENT($,#41);
+#41=IFCAXIS2PLACEMENT3D(#42,$,$);
+#42=IFCCARTESIANPOINT((0.,0.,0.));
+#50=IFCBUILDINGELEMENTPROXY('a1',$,'A1','',$,#40,#51,$,$);
+#51=IFCPRODUCTDEFINITIONSHAPE($,$,(#52));
+#52=IFCSHAPEREPRESENTATION(#12,'Body','Tessellation',(#53));
+#53=IFCTRIANGULATEDFACESET(#54,$,$,((1,2,3),(1,3,4)),$);
+#54=IFCCARTESIANPOINTLIST3D(((0.,0.,0.),(1.,0.,0.),(1.,1.,0.),(0.,1.,0.)));
+#70=IFCLOCALPLACEMENT($,#71);
+#71=IFCAXIS2PLACEMENT3D(#72,$,$);
+#72=IFCCARTESIANPOINT((10.,0.,0.));
+#80=IFCBUILDINGELEMENTPROXY('a2',$,'A2','',$,#70,#81,$,$);
+#81=IFCPRODUCTDEFINITIONSHAPE($,$,(#82));
+#82=IFCSHAPEREPRESENTATION(#12,'Body','Tessellation',(#83));
+#83=IFCTRIANGULATEDFACESET(#84,$,$,((1,2,3),(1,3,4)),$);
+#84=IFCCARTESIANPOINTLIST3D(((0.,0.,0.),(1.,0.,0.),(1.,1.,0.),(0.,1.,0.)));
+#100=IFCLOCALPLACEMENT($,#101);
+#101=IFCAXIS2PLACEMENT3D(#102,$,$);
+#102=IFCCARTESIANPOINT((0.,10.,0.));
+#110=IFCBUILDINGELEMENTPROXY('b',$,'B','',$,#100,#111,$,$);
+#111=IFCPRODUCTDEFINITIONSHAPE($,$,(#112));
+#112=IFCSHAPEREPRESENTATION(#12,'Body','Tessellation',(#113));
+#113=IFCTRIANGULATEDFACESET(#114,$,$,((1,2,3),(1,3,4)),$);
+#114=IFCCARTESIANPOINTLIST3D(((0.,0.,0.),(2.,0.,0.),(2.,2.,0.),(0.,2.,0.)));
+ENDSEC;
+END-ISO-10303-21;
+"#
+    .to_string()
+}
+
+#[test]
+fn content_dedup_extra_facesets_byte_identical_when_flagged() {
+    let content = synthetic_faceset_duplicates_ifc();
+    let ids = [50u32, 80, 110];
+
+    // Flag ON: faceset items become dedup candidates.
+    GeometryRouter::set_build_dedup_extra_override(Some(true));
+    let mut d_on = EntityDecoder::with_index(&content, build_entity_index(&content));
+    let on_router = GeometryRouter::with_units(&content, &mut d_on);
+    let mut on = Vec::new();
+    for &id in &ids {
+        let e = d_on.decode_by_id(id).expect("decode element");
+        let sm = on_router
+            .process_element_with_submeshes(&e, &mut d_on)
+            .expect("mesh element");
+        assert!(!sm.sub_meshes.is_empty(), "element #{id} produced no geometry");
+        on.push(fingerprint(&sm));
+    }
+    let unique_on = on_router.dedup_unique_count();
+    GeometryRouter::set_build_dedup_extra_override(None); // reset global before asserts
+
+    // Ground truth: dedup fully disabled ⇒ every faceset rebuilt.
+    let mut d_off = EntityDecoder::with_index(&content, build_entity_index(&content));
+    let mut off_router = GeometryRouter::with_units(&content, &mut d_off);
+    off_router.disable_content_dedup();
+    let mut off = Vec::new();
+    for &id in &ids {
+        let e = d_off.decode_by_id(id).expect("decode element");
+        let sm = off_router
+            .process_element_with_submeshes(&e, &mut d_off)
+            .expect("mesh element");
+        off.push(fingerprint(&sm));
+    }
+
+    assert_eq!(on, off, "extra-type (faceset) dedup is not byte-identical to fresh build");
+    assert_ne!(on[0], on[1], "per-instance placement lost on the extra-type path");
+    assert_eq!(unique_on, 2, "the two identical facesets must collapse to 1 (+1 distinct = 2)");
+}

--- a/rust/geometry/tests/dedup_validate.rs
+++ b/rust/geometry/tests/dedup_validate.rs
@@ -843,13 +843,41 @@ END-ISO-10303-21;
     .to_string()
 }
 
+/// RAII scope for the process-global dedup-extra override
+/// (`GeometryRouter::set_build_dedup_extra_override`): serializes every test
+/// that forces the override (a static mutex held for the guard's lifetime, so
+/// two such tests can't interleave under the parallel test runner) and restores
+/// the env-default (`None`) on drop, INCLUDING on a panicking assert, so a
+/// failure can't leak the forced state into later tests. `None` is the correct
+/// restore value (not a saved snapshot): the only writers are guard scopes, so
+/// outside any scope the override is always at its env-default.
+struct DedupExtraOverrideGuard {
+    _lock: std::sync::MutexGuard<'static, ()>,
+}
+
+impl DedupExtraOverrideGuard {
+    fn set(v: bool) -> Self {
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let lock = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        GeometryRouter::set_build_dedup_extra_override(Some(v));
+        Self { _lock: lock }
+    }
+}
+
+impl Drop for DedupExtraOverrideGuard {
+    fn drop(&mut self) {
+        GeometryRouter::set_build_dedup_extra_override(None);
+    }
+}
+
 #[test]
 fn content_dedup_extra_facesets_byte_identical_when_flagged() {
     let content = synthetic_faceset_duplicates_ifc();
     let ids = [50u32, 80, 110];
 
-    // Flag ON: faceset items become dedup candidates.
-    GeometryRouter::set_build_dedup_extra_override(Some(true));
+    // Flag ON: faceset items become dedup candidates. Guard restores the
+    // env-default override on every exit path (assert panics included).
+    let _extra_on = DedupExtraOverrideGuard::set(true);
     let mut d_on = EntityDecoder::with_index(&content, build_entity_index(&content));
     let on_router = GeometryRouter::with_units(&content, &mut d_on);
     let mut on = Vec::new();
@@ -862,9 +890,9 @@ fn content_dedup_extra_facesets_byte_identical_when_flagged() {
         on.push(fingerprint(&sm));
     }
     let unique_on = on_router.dedup_unique_count();
-    GeometryRouter::set_build_dedup_extra_override(None); // reset global before asserts
 
-    // Ground truth: dedup fully disabled ⇒ every faceset rebuilt.
+    // Ground truth: dedup fully disabled ⇒ every faceset rebuilt (the override
+    // value is irrelevant on this path, so the guard can stay in scope).
     let mut d_off = EntityDecoder::with_index(&content, build_entity_index(&content));
     let mut off_router = GeometryRouter::with_units(&content, &mut d_off);
     off_router.disable_content_dedup();

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -77,12 +77,14 @@
 # +38: #1623 Phase 2 don't-bake — MappedInstancePlan type alias + output_instancing_plan field + enable_/getter + `mod instancing` decl.
 # +28: #858 palette guard — indexed_colour_split_ids field + enable_indexed_colour_split_guard setter + is_indexed_colour_split_source accessor (routes an indexed-colour mapped source to the flat per-palette split instead of a colour-collapsing instance placeholder).
 # +42: #1623 Phase 3 batch-local template mode — instancing_batch_local flag + instanced_sources_materialized tracker fields + set_/getter/mark_source_materialized_if_first methods (browser per-batch don't-bake).
-     746 rust/geometry/src/router/mod.rs
+# +1: #1293 dedup rep_identity: build_dedup_extra_enabled/set_build_dedup_extra_override gate + DEDUP_EXTRA_OVERRIDE static; net +1 after the ItemDedupCache doc consolidation.
+     747 rust/geometry/src/router/mod.rs
 # +65: #1623 Phase 2 don't-bake — the top-level mapped-item intercept (template retag + instance placeholder) + the public/impl process_element_with_submeshes split; the two eligibility/ensure helpers were extracted to router/instancing.rs (new, 92 lines) to hold the net down.
 # +7: #858 palette guard — exclude an indexed-colour single-solid source from the don't-bake decision (one .filter on the resolved solid id + explanatory comment) so its per-triangle palette survives the flat split.
 # +16: #1623 Phase 3 — thread the batch-local vs global template decision through the mapped-item intercept (is_template match arm + retag guard).
 # +3: hoist the item-dedup mesh clone out of the cache Mutex critical section (let-binding + 2-line rationale) so a dedup miss no longer serializes the worker pool on a deep-copy.
-    1165 rust/geometry/src/router/processing.rs
+# +18: #1293 dedup rep_identity: store rep beside the cached mesh, split tag_direct_instance into direct_rep_identity + stamp_direct_instance, and the flagged IFC_LITE_DEDUP_EXTRA type gate in item_dedup_key.
+    1183 rust/geometry/src/router/processing.rs
 # +26: is_rtc_votable_representation predicate + doc — Surface3D is meshable but must NOT cast RTC votes (#1526 pollution via absolute-coord surfaces).
      472 rust/geometry/src/router/rtc_offset.rs
 # +1: reveal-quads comment expanded to 2 lines (dead-symbol reference fix, no code change).


### PR DESCRIPTION
## What

Foundation for the #1286 redundant-geometry-production fix. Lands the two safe, byte-identical pieces + the parity gate the rest depends on.

The compute-level content-dedup is already shipped and on (it skips re-meshing structurally-identical items, 170_KM geometry 16.4s -> 2.8s). This PR removes the *residual* per-occurrence cost and widens coverage, without changing geometry output.

### Phase 1 — drop the per-occurrence `rep_identity` re-hash (byte-identical)
On a dedup cache **hit**, the item mesh was cloned and its full 128-bit `compute_mesh_hash_full` was re-run to set the instancing `rep_identity` — once **per occurrence** (tens of thousands of times on repeated steel). The cache now stores `rep_identity` beside the mesh (`Arc<Mesh>` -> `Arc<(Mesh, Option<u128>)>`), so a hit stamps it as a `u128` copy. `tag_direct_instance` split into `direct_rep_identity` (compute once) + `stamp_direct_instance` (stamp, no hash).

### Phase 3 — widen the dedup type-gate (opt-in, default OFF)
`IFC_LITE_DEDUP_EXTRA=1` extends content-dedup to `IfcPolygonalFaceSet` / `IfcTriangulatedFaceSet` / `IfcShellBasedSurfaceModel` / `IfcFaceBasedSurfaceModel` (their structural signature is already complete). Gated so low-reuse models never pay the hash for no payback (the #1177 trap). Default OFF keeps native==wasm identical.

### Phase 2 — the parity gate (the important one)
The snapshot harness only walks `process_element`, so submesh-path dedup false-merges were **untested** and would ship as silently-wrong geometry. Adds `dedup_validate` tests on synthetic fixtures:
- `content_dedup_byte_identical_on_voided_duplicates` — dedup ON==OFF byte-identical through the **void** path, placement per-instance, distinct voids stay distinct.
- `content_dedup_extra_facesets_byte_identical_when_flagged` — flagged faceset dedup collapses duplicates + byte-identical.

## Why now

This is the safe foundation under the bigger void-cut dedup (the actual CSG win). That part requires moving the void cut into the element's local frame (it's geometrically invariant but changes output representation, so snapshot regen) and lands as a separate flag-gated PR stacked on this one.

## Test
`cargo test -p ifc-lite-geometry --test dedup_validate` — 4 pass, byte-identical ON==OFF. Refs #1286.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `IFC_LITE_DEDUP_EXTRA` environment variable feature flag to extend content-deduplication to additional IFC surface model types (`IfcPolygonalFaceSet`, `IfcTriangulatedFaceSet`, `IfcShellBasedSurfaceModel`, `IfcFaceBasedSurfaceModel`).

* **Performance Improvements**
  * Optimized geometry content-deduplication caching to reuse precomputed mesh hashes instead of recalculating per occurrence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->