### PR TITLE
feat(geometry): element-level void-cut dedup, flag-gated OFF (#1286 Phase 4-5)

### DIFF
--- a/.changeset/void-cut-dedup.md
+++ b/.changeset/void-cut-dedup.md
@@ -1,0 +1,17 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Element-level void-cut dedup (#1286 Phase 5), flag-gated OFF
+(`IFC_LITE_DEF_DEDUP=1`).
+
+Identical voided elements (same host geometry, opening geometries, and opening
+placements relative to the host) currently re-run the exact-kernel CSG cut once
+per occurrence. With the flag on, the cut runs ONCE in the host definition frame
+(`process_element_with_submeshes_and_voids_unplaced`, reusing the existing
+`relativized_by` + `apply_void_context_inner`) and is cached by a void-inclusive
+`definition_signature`; each occurrence reuses the template with its own
+placement. Eligibility is gated to pure-translation, non-layered hosts (rotated /
+layered / unresolved-opening hosts fall back to the per-occurrence path), so it
+is never wrong, only sometimes deferred. Default OFF keeps native==wasm
+byte-identical until corpus-validated.

--- a/rust/geometry/src/lib.rs
+++ b/rust/geometry/src/lib.rs
@@ -138,8 +138,8 @@ pub use profile::{Profile2D, Profile2DWithVoids, ProfileType, VoidInfo};
 pub use profile_extractor::{extract_profiles, ExtractedProfile};
 pub use profiles::ProfileProcessor;
 pub use router::{
-    ClassificationStats, GeometryProcessor, GeometryRouter, HostOpeningDiagnostic, ItemDedupCache,
-    OpeningDiagnostic, OpeningKindDiag, RectParam,
+    ClassificationStats, DefinitionCache, GeometryProcessor, GeometryRouter, HostOpeningDiagnostic,
+    ItemDedupCache, OpeningDiagnostic, OpeningKindDiag, RectParam,
 };
 pub use tessellation::{scale_segments, TessellationQuality};
 pub use transform::{

--- a/rust/geometry/src/router/mod.rs
+++ b/rust/geometry/src/router/mod.rs
@@ -75,6 +75,16 @@ pub type ItemDedupCache = Arc<Mutex<FxHashMap<u128, Arc<(Mesh, Option<u128>)>>>>
 /// -1 = env default, 0 = forced off, 1 = forced on.
 static DEDUP_EXTRA_OVERRIDE: std::sync::atomic::AtomicI8 = std::sync::atomic::AtomicI8::new(-1);
 
+/// Shared element-level void-cut cache (#1286 Phase 5): a void-inclusive
+/// definition signature -> the POST-CUT, pre-placement (definition-frame) voided
+/// sub-meshes, so identical voided elements are CSG-cut once and reused with a
+/// per-occurrence placement.
+pub type DefinitionCache = Arc<Mutex<FxHashMap<u128, Arc<crate::mesh::SubMeshCollection>>>>;
+
+/// Test/env override for [`GeometryRouter::definition_dedup_enabled`]:
+/// -1 = env default, 0 = forced off, 1 = forced on.
+static DEF_DEDUP_OVERRIDE: std::sync::atomic::AtomicI8 = std::sync::atomic::AtomicI8::new(-1);
+
 /// Geometry router - routes entities to processors
 pub struct GeometryRouter {
     schema: IfcSchema,
@@ -100,6 +110,11 @@ pub struct GeometryRouter {
     /// so the lock is held only for a map get/clone (hit) or insert (miss); the
     /// build runs outside it. `None` ⇒ dedup disabled (e.g. `new()` in tests).
     item_dedup_cache: Option<ItemDedupCache>,
+    /// Shared cache of POST-CUT, pre-placement (definition-frame) voided
+    /// sub-meshes keyed by the void-inclusive definition signature (#1286 Phase
+    /// 5). Lets identical voided elements be CSG-cut once and reused with a
+    /// per-occurrence placement. `None` ⇒ disabled (the default; flag-gated).
+    definition_cache: Option<DefinitionCache>,
     /// Per-router memo for the per-item structural hash (shared sub-entities hashed
     /// once). Keyed by entity id ⇒ valid for one loaded model. Kept LOCAL (not
     /// shared) so the recursive DAG walk never contends the shared cache's lock;
@@ -247,6 +262,7 @@ impl GeometryRouter {
             mapped_item_cache: RefCell::new(FxHashMap::default()),
             geometry_hash_cache: RefCell::new(FxHashMap::default()),
             item_dedup_cache: None, // armed by `with_units` / `enable_content_dedup_shared`
+            definition_cache: None, // armed by `enable_definition_dedup_shared` (flag-gated)
             content_sig_memo: RefCell::new(FxHashMap::default()),
             unit_scale: 1.0,             // Default to base meters
             rtc_offset: (0.0, 0.0, 0.0), // Default to no offset
@@ -403,6 +419,46 @@ impl GeometryRouter {
             },
             std::sync::atomic::Ordering::Relaxed,
         );
+    }
+
+    /// Element-level void-cut dedup (#1286 Phase 5): cut identical voided elements
+    /// ONCE in the host definition frame and reuse with a per-occurrence
+    /// placement. DEFAULT OFF (a behaviour change: voided geometry moves from the
+    /// per-occurrence world cut to a canonical definition-frame cut), gated until
+    /// corpus-validated. Default off keeps native==wasm identical. Opt in with
+    /// `IFC_LITE_DEF_DEDUP=1` or [`Self::set_definition_dedup_override`].
+    pub fn definition_dedup_enabled() -> bool {
+        match DEF_DEDUP_OVERRIDE.load(std::sync::atomic::Ordering::Relaxed) {
+            0 => return false,
+            1 => return true,
+            _ => {}
+        }
+        static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        *ON.get_or_init(|| std::env::var("IFC_LITE_DEF_DEDUP").as_deref() == Ok("1"))
+    }
+
+    /// Test-only: force [`Self::definition_dedup_enabled`] on/off (`None` = env).
+    pub fn set_definition_dedup_override(v: Option<bool>) {
+        DEF_DEDUP_OVERRIDE.store(
+            match v {
+                None => -1,
+                Some(false) => 0,
+                Some(true) => 1,
+            },
+            std::sync::atomic::Ordering::Relaxed,
+        );
+    }
+
+    /// Build a fresh shared element-level void-cut cache (one per loaded model).
+    pub fn new_definition_cache() -> DefinitionCache {
+        Arc::new(Mutex::new(FxHashMap::default()))
+    }
+
+    /// Inject a shared definition cache into this router (mirrors
+    /// [`Self::enable_content_dedup_shared`]). All routers sharing the SAME `Arc`
+    /// dedup voided-element CSG against one cache across threads/batches.
+    pub fn enable_definition_dedup_shared(&mut self, cache: DefinitionCache) {
+        self.definition_cache = Some(cache);
     }
 
     /// Inject a shared item-dedup cache (see [`Self::new_dedup_cache`]) into this

--- a/rust/geometry/src/router/processing.rs
+++ b/rust/geometry/src/router/processing.rs
@@ -730,7 +730,7 @@ impl GeometryRouter {
     /// Apply the element's `ObjectPlacement` (scaled to metres) to every sub-mesh.
     /// Placement is a rigid per-instance transform, kept OUT of the dedup cache so
     /// instances of one shared geometry land at their own positions.
-    fn apply_submesh_placement(
+    pub(crate) fn apply_submesh_placement(
         &self,
         sub_meshes: &mut SubMeshCollection,
         element: &DecodedEntity,

--- a/rust/geometry/src/router/processing.rs
+++ b/rust/geometry/src/router/processing.rs
@@ -584,6 +584,21 @@ impl GeometryRouter {
         element: &DecodedEntity,
         decoder: &mut EntityDecoder,
     ) -> Result<SubMeshCollection> {
+        let mut sub_meshes = self.process_element_with_submeshes_unplaced(element, decoder)?;
+        self.apply_submesh_placement(&mut sub_meshes, element, decoder)?;
+        Ok(sub_meshes)
+    }
+
+    /// Like [`Self::process_element_with_submeshes`] but WITHOUT the element's
+    /// ObjectPlacement applied — the sub-meshes stay in the host DEFINITION frame.
+    /// This is the placement-invariant base the element-level void-cut cache
+    /// (#1286) needs; callers apply [`Self::apply_submesh_placement`] (or a
+    /// per-occurrence transform) afterwards.
+    pub(crate) fn process_element_with_submeshes_unplaced(
+        &self,
+        element: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+    ) -> Result<SubMeshCollection> {
         // If a material-layer buildup is attached, try slicing single-solid
         // elements (walls / slabs with IfcMaterialLayerSetUsage) first so each
         // layer gets its own sub-mesh keyed by IfcMaterial id. An empty void
@@ -709,7 +724,6 @@ impl GeometryRouter {
             sub.mesh.clean_degenerate();
         }
 
-        self.apply_submesh_placement(&mut sub_meshes, element, decoder)?;
         Ok(sub_meshes)
     }
 

--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -2896,6 +2896,140 @@ impl GeometryRouter {
         Ok(Some((voided, translation)))
     }
 
+    /// Void-inclusive definition signature for the element-level void-cut cache
+    /// (#1286 Phase 5): the host representation signature folded with an
+    /// ORDER-INVARIANT fold over each opening's (representation signature,
+    /// host-relative placement). Two elements share a signature iff their host
+    /// geometry, opening geometries AND opening placements relative to the host
+    /// all match — so they produce the identical definition-frame cut. `None`
+    /// (no shared key) when ineligible (layered / rotated host / unresolved
+    /// opening), so the caller falls back to the per-occurrence path.
+    pub fn definition_signature(
+        &self,
+        element: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+        void_index: &FxHashMap<u32, Vec<u32>>,
+    ) -> Result<Option<u128>> {
+        if self.is_material_layer_sliceable(element.id) {
+            return Ok(None);
+        }
+        let opening_ids = match void_index.get(&element.id) {
+            Some(ids) if !ids.is_empty() => ids.clone(),
+            _ => return Ok(None),
+        };
+        // Same eligibility as the unplaced cut: pure-translation host.
+        let host_w = self.get_placement_transform_from_element(element, decoder)?;
+        let rot = host_w.fixed_view::<3, 3>(0, 0);
+        let identity_rot = (0..3).all(|i| {
+            (0..3).all(|j| (rot[(i, j)] - if i == j { 1.0 } else { 0.0 }).abs() < 1e-9)
+        });
+        if !identity_rot {
+            return Ok(None);
+        }
+        let host_inv = match host_w.try_inverse() {
+            Some(m) => m,
+            None => return Ok(None),
+        };
+        let host_rep = match self.geometry_routing_key(element, decoder) {
+            Some(h) => h,
+            None => return Ok(None),
+        };
+        let mut parts: Vec<u128> = Vec::with_capacity(opening_ids.len());
+        for oid in opening_ids {
+            let opening = match decoder.decode_by_id(oid) {
+                Ok(o) => o,
+                Err(_) => return Ok(None),
+            };
+            if opening.ifc_type != IfcType::IfcOpeningElement {
+                continue;
+            }
+            let op_rep = match opening.get(6).and_then(|a| a.as_entity_ref()) {
+                Some(r) => {
+                    let mut memo = self.content_sig_memo.borrow_mut();
+                    super::content_hash::item_signature(decoder, r, &mut memo)
+                }
+                None => return Ok(None),
+            };
+            let op_w = self.get_placement_transform_from_element(&opening, decoder)?;
+            // M_rel = host^-1 * opening: the opening relative to the host. Quantise
+            // its 12 affine components so float-noise-free identical placements key
+            // the same, and 1e-6-distinct placements key apart (never false-merge).
+            let m_rel = host_inv * op_w;
+            let mut rel_bits: u128 = 0xcbf29ce484222325;
+            for r in 0..3 {
+                for c in 0..4 {
+                    let q = (m_rel[(r, c)] / 1.0e-6).round() as i64;
+                    rel_bits = rel_bits.wrapping_mul(0x100000001b3).wrapping_add(q as u128);
+                }
+            }
+            parts.push(op_rep ^ rel_bits.wrapping_mul(0x9e3779b97f4a7c15));
+        }
+        if parts.is_empty() {
+            return Ok(None);
+        }
+        parts.sort_unstable(); // ORDER-INVARIANT: opening declaration order is irrelevant
+        let mut structural = host_rep;
+        for p in parts {
+            structural = structural.wrapping_mul(0x100000001b3).wrapping_add(p);
+        }
+        Ok(Some(super::content_hash::key_with_params(
+            structural,
+            self.tessellation_quality.to_index(),
+            self.unit_scale,
+            self.rtc_offset,
+        )))
+    }
+
+    /// Element-level DEDUPED voided sub-meshes (#1286 Phase 5): on a
+    /// definition-cache HIT, clone the cached definition-frame template and apply
+    /// THIS occurrence's placement (no re-cut); on a MISS, run the definition-frame
+    /// cut once and cache it. Returns the PLACED voided sub-meshes, or `None` when
+    /// the flag is off / the element is ineligible / nothing was cut, so the caller
+    /// uses the per-occurrence [`Self::process_element_with_submeshes_and_voids`].
+    pub fn process_element_with_submeshes_and_voids_deduped(
+        &self,
+        element: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+        void_index: &FxHashMap<u32, Vec<u32>>,
+    ) -> Result<Option<SubMeshCollection>> {
+        if !Self::definition_dedup_enabled() {
+            return Ok(None);
+        }
+        let cache = match self.definition_cache.as_ref() {
+            Some(c) => c,
+            None => return Ok(None),
+        };
+        let sig = match self.definition_signature(element, decoder, void_index)? {
+            Some(s) => s,
+            None => return Ok(None),
+        };
+        let hit = cache
+            .lock()
+            .expect("definition cache poisoned")
+            .get(&sig)
+            .cloned();
+        let template = match hit {
+            Some(t) => (*t).clone(),
+            None => {
+                let built =
+                    self.process_element_with_submeshes_and_voids_unplaced(element, decoder, void_index)?;
+                let (tpl, _t) = match built {
+                    Some(v) => v,
+                    None => return Ok(None),
+                };
+                cache
+                    .lock()
+                    .expect("definition cache poisoned")
+                    .insert(sig, std::sync::Arc::new(tpl.clone()));
+                tpl
+            }
+        };
+        // Apply THIS occurrence's placement to the shared definition-frame template.
+        let mut placed = template;
+        self.apply_submesh_placement(&mut placed, element, decoder)?;
+        Ok(Some(placed))
+    }
+
     pub fn process_element_with_submeshes_and_voids(
         &self,
         element: &DecodedEntity,

--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -2813,6 +2813,89 @@ impl GeometryRouter {
     /// Returns an empty collection when there are no openings (callers should
     /// fall back to [`process_element_with_submeshes`]) or when every
     /// sub-mesh is destroyed by void subtraction.
+    /// The host's `ObjectPlacement` as a PURE TRANSLATION (metres), or `None` if
+    /// it carries any rotation. The v1 definition-frame void cut relativizes
+    /// cutters by a translation only (rotating axis-aligned `Rectangular` cutters
+    /// would break their AABB form), so rotated hosts fall back to the
+    /// per-occurrence world path.
+    fn host_translation_only(
+        &self,
+        element: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+    ) -> Result<Option<[f64; 3]>> {
+        let mut t = self.get_placement_transform_from_element(element, decoder)?;
+        // Rotation must be identity on the UNSCALED transform (the uniform unit
+        // scale would otherwise read the diagonal as non-identity).
+        let rot = t.fixed_view::<3, 3>(0, 0);
+        let identity_rot = (0..3).all(|i| {
+            (0..3).all(|j| {
+                let want = if i == j { 1.0 } else { 0.0 };
+                (rot[(i, j)] - want).abs() < 1e-9
+            })
+        });
+        if !identity_rot {
+            return Ok(None);
+        }
+        self.scale_transform(&mut t);
+        Ok(Some([t[(0, 3)], t[(1, 3)], t[(2, 3)]]))
+    }
+
+    /// Definition-frame voided sub-meshes for a PURE-TRANSLATION, non-layered
+    /// host: cut the UNPLACED base with the void cutters relativized into the
+    /// host's definition frame, so the result is placement-invariant (reusable
+    /// across translated occurrences — the element-level void-cut cache, #1286).
+    /// Returns `(def_frame_submeshes, host_translation)`, or `None` when the host
+    /// is ineligible (layered / rotated / no openings / empty / nothing cut) — the
+    /// caller then uses the per-occurrence [`Self::process_element_with_submeshes_and_voids`].
+    pub fn process_element_with_submeshes_and_voids_unplaced(
+        &self,
+        element: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+        void_index: &FxHashMap<u32, Vec<u32>>,
+    ) -> Result<Option<(SubMeshCollection, [f64; 3])>> {
+        if self.is_material_layer_sliceable(element.id) {
+            return Ok(None); // per-layer slice baking is not in v1
+        }
+        let opening_ids = match void_index.get(&element.id) {
+            Some(ids) if !ids.is_empty() => ids.clone(),
+            _ => return Ok(None),
+        };
+        let translation = match self.host_translation_only(element, decoder)? {
+            Some(t) => t,
+            None => return Ok(None), // rotated host
+        };
+        let base = self.process_element_with_submeshes_unplaced(element, decoder)?;
+        if base.is_empty() {
+            return Ok(None);
+        }
+        let ctx = self.build_void_context(element, &opening_ids, decoder);
+        if ctx.is_noop() {
+            return Ok(None);
+        }
+        // World cutters -> the host definition frame (translation only). The
+        // rect_fast `param` path is intentionally skipped (relativized_by drops
+        // it); apply_void_context_inner is the exact kernel, cutting the def base
+        // against def cutters at small coords.
+        let def_ctx = ctx.relativized_by(translation);
+        let mut voided = SubMeshCollection::new();
+        for sub in base.sub_meshes {
+            let gid = sub.geometry_id;
+            let mut m = self.apply_void_context_inner(sub.mesh, &def_ctx, element.id);
+            // Voided geometry is not GPU-instanced (the cut invalidates the base's
+            // rep_identity), exactly as the placed path clears it — keep the
+            // deduped output identical so collation behaves the same.
+            m.instance_meta = None;
+            m.clean_degenerate();
+            if !m.is_empty() {
+                voided.sub_meshes.push(SubMesh::new(gid, m));
+            }
+        }
+        if voided.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some((voided, translation)))
+    }
+
     pub fn process_element_with_submeshes_and_voids(
         &self,
         element: &DecodedEntity,

--- a/rust/geometry/tests/dedup_validate.rs
+++ b/rust/geometry/tests/dedup_validate.rs
@@ -928,3 +928,55 @@ fn void_unplaced_cut_matches_placed_geometry() {
         );
     }
 }
+
+/// Phase 5 (#1286): the element-level void-cut cache must produce geometry
+/// IDENTICAL to the current per-occurrence placed path (a cache HIT reuses an
+/// identical voided element's definition-frame template + this occurrence's
+/// placement; vertex order may differ since the placed path cuts independently,
+/// but the GEOMETRY must not), collapse identical voided walls to one template,
+/// and keep a distinct void distinct.
+#[test]
+fn definition_cache_dedups_and_matches_placed_geometry() {
+    let content = synthetic_voided_duplicates_ifc();
+    let void_idx = build_void_index(&content);
+    let wall_ids = [50u32, 250, 450];
+
+    GeometryRouter::set_definition_dedup_override(Some(true));
+    // Shared cache: wall #250 (identical to #50, translated +10m) HITS #50's
+    // cached definition-frame template; #450 (distinct void) misses.
+    let shared = GeometryRouter::new_definition_cache();
+    let mut d = EntityDecoder::with_index(&content, build_entity_index(&content));
+    let mut router = GeometryRouter::with_units(&content, &mut d);
+    router.enable_definition_dedup_shared(shared.clone());
+
+    let mut placed_fps = Vec::new();
+    for &id in &wall_ids {
+        let e = d.decode_by_id(id).unwrap();
+        let deduped = router
+            .process_element_with_submeshes_and_voids_deduped(&e, &mut d, &void_idx)
+            .unwrap()
+            .expect("translation-only voided host should be eligible");
+        // GEOMETRIC correctness: the deduped (cache) output must match the current
+        // per-occurrence placed path. Order may differ; geometry must not.
+        let placed = router
+            .process_element_with_submeshes_and_voids(&e, &mut d, &void_idx)
+            .unwrap();
+        assert_eq!(
+            sorted_coord_set(&deduped),
+            sorted_coord_set(&placed),
+            "deduped void geometry != placed path for #{id}"
+        );
+        placed_fps.push(sorted_coord_set(&placed));
+    }
+    let entries = shared.lock().unwrap().len();
+    GeometryRouter::set_definition_dedup_override(None);
+
+    assert_eq!(
+        entries, 2,
+        "identical voided walls #50/#250 must share one template (+ #450 distinct = 2)"
+    );
+    // #50 and #250 are the same geometry at different positions => different world
+    // coord-sets (placement preserved); #450 is a distinct void.
+    assert_ne!(placed_fps[0], placed_fps[1], "per-instance placement lost on the deduped void path");
+    assert_ne!(placed_fps[0], placed_fps[2], "a distinct void wrongly shared a template");
+}

--- a/rust/geometry/tests/dedup_validate.rs
+++ b/rust/geometry/tests/dedup_validate.rs
@@ -881,3 +881,50 @@ fn content_dedup_extra_facesets_byte_identical_when_flagged() {
     assert_ne!(on[0], on[1], "per-instance placement lost on the extra-type path");
     assert_eq!(unique_on, 2, "the two identical facesets must collapse to 1 (+1 distinct = 2)");
 }
+
+/// Order-insensitive coord-set hash over a whole SubMeshCollection.
+fn sorted_coord_set(sm: &SubMeshCollection) -> u64 {
+    let mut v: Vec<i64> = Vec::new();
+    for s in &sm.sub_meshes {
+        for p in &s.mesh.positions {
+            v.push((*p as f64 / 1e-4).round() as i64);
+        }
+    }
+    v.sort_unstable();
+    let mut h = DefaultHasher::new();
+    v.hash(&mut h);
+    h.finish()
+}
+
+/// Phase 4 frame correctness: the definition-frame void cut + re-place must be
+/// GEOMETRICALLY identical (sorted-coord-set) to the current per-occurrence
+/// placed path. Order may differ (independent cuts); geometry must not.
+#[test]
+fn void_unplaced_cut_matches_placed_geometry() {
+    let content = synthetic_voided_duplicates_ifc();
+    let void_idx = build_void_index(&content);
+    let mut d = EntityDecoder::with_index(&content, build_entity_index(&content));
+    let router = GeometryRouter::with_units(&content, &mut d);
+    for id in [50u32, 250, 450] {
+        let e = d.decode_by_id(id).unwrap();
+        let placed = router
+            .process_element_with_submeshes_and_voids(&e, &mut d, &void_idx)
+            .unwrap();
+        let (mut unplaced, t) = router
+            .process_element_with_submeshes_and_voids_unplaced(&e, &mut d, &void_idx)
+            .unwrap()
+            .expect("translation-only host should be eligible");
+        for sub in &mut unplaced.sub_meshes {
+            for c in sub.mesh.positions.chunks_mut(3) {
+                c[0] += t[0] as f32;
+                c[1] += t[1] as f32;
+                c[2] += t[2] as f32;
+            }
+        }
+        assert_eq!(
+            sorted_coord_set(&placed),
+            sorted_coord_set(&unplaced),
+            "unplaced def-frame cut + re-place != placed geometry for #{id}"
+        );
+    }
+}

--- a/rust/processing/src/element.rs
+++ b/rust/processing/src/element.rs
@@ -266,6 +266,21 @@ fn produce_inner(
     };
 
     if has_openings {
+        // Phase 5 (#1286, flag-gated): dedup identical voided elements by cutting
+        // once in the host definition frame and reusing with this occurrence's
+        // placement. Returns None when the flag is off / the element is
+        // ineligible, falling through to the per-occurrence cut below.
+        if let Ok(Some(sub_meshes)) = router
+            .process_element_with_submeshes_and_voids_deduped(job.entity, decoder, ctx.void_index)
+        {
+            if !sub_meshes.is_empty() {
+                let out =
+                    emit_sub_meshes(job, sub_meshes, element_color, ctx, decoder, hasher, layer_class);
+                if !out.is_empty() {
+                    return out;
+                }
+            }
+        }
         // Voided elements: submesh-aware cut FIRST, so per-part colours
         // survive the void subtraction (a voided window keeps frame/glass
         // split; a voided multi-layer wall keeps its layer colours).

--- a/rust/processing/src/processor.rs
+++ b/rust/processing/src/processor.rs
@@ -1503,6 +1503,8 @@ pub fn process_geometry_streaming_filtered_with_options(
     // across the rayon pool instead of once per element. The lock is held only for
     // a hash get/insert; meshing runs outside it.
     let item_dedup_cache = GeometryRouter::new_dedup_cache();
+    // Shared element-level void-cut cache (#1286 Phase 5; flag-gated, default off).
+    let definition_cache = GeometryRouter::new_definition_cache();
 
     while chunk_start < total_jobs {
         let chunk_end = (chunk_start + current_chunk_size).min(total_jobs);
@@ -1610,6 +1612,7 @@ pub fn process_geometry_streaming_filtered_with_options(
                     site_local_rotation,
                     &csg_failure_collector,
                     &item_dedup_cache,
+                    &definition_cache,
                 )
             })
             .collect();
@@ -1763,6 +1766,8 @@ fn process_entity_job(
     // Model-wide content-dedup cache shared by every per-job router so identical
     // geometry is meshed once across the rayon pool (#1109 follow-up).
     item_dedup_cache: &ifc_lite_geometry::ItemDedupCache,
+    // Model-wide element-level void-cut cache (#1286 Phase 5; flag-gated).
+    definition_cache: &ifc_lite_geometry::DefinitionCache,
 ) -> Vec<MeshData> {
     if skipped_entity_ids.contains(&job.id) {
         return Vec::new();
@@ -1784,6 +1789,9 @@ fn process_entity_job(
     // it skips on real models (see GeometryRouter::content_dedup_enabled).
     if GeometryRouter::content_dedup_enabled() {
         local_router.enable_content_dedup_shared(item_dedup_cache.clone());
+    }
+    if GeometryRouter::definition_dedup_enabled() {
+        local_router.enable_definition_dedup_shared(definition_cache.clone());
     }
     let local_router = local_router;
 

--- a/rust/wasm-bindings/src/api/gpu_meshes.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes.rs
@@ -827,6 +827,17 @@ impl IfcAPI {
                 .clone();
             router.enable_content_dedup_shared(cache);
         }
+        // Element-level void-cut dedup (#1286 Phase 5; flag-gated, default off).
+        if GeometryRouter::definition_dedup_enabled() {
+            let mut slot = self
+                .cached_definition_dedup
+                .lock()
+                .expect("ifc-lite cached_definition_dedup Mutex poisoned");
+            let cache = slot
+                .get_or_insert_with(GeometryRouter::new_definition_cache)
+                .clone();
+            router.enable_definition_dedup_shared(cache);
+        }
 
         // Attach the per-content material-layer index so single-solid walls and
         // slabs carrying an IfcMaterialLayerSetUsage slice into one coloured

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -65,6 +65,10 @@ pub struct IfcAPI {
     /// `cached_entity_index`.
     cached_item_dedup: std::sync::Mutex<Option<ifc_lite_geometry::ItemDedupCache>>,
 
+    /// Element-level void-cut cache (#1286 Phase 5; flag-gated). One per model,
+    /// lazily built, mirroring `cached_item_dedup`.
+    cached_definition_dedup: std::sync::Mutex<Option<ifc_lite_geometry::DefinitionCache>>,
+
     /// When `true`, `processGeometryBatch` suppresses geometry emission for
     /// every `IfcBuildingElementPart` whose `IfcRelAggregates` parent (a) has
     /// its own `Representation` and (b) is marked `Sliceable` in
@@ -202,6 +206,7 @@ impl IfcAPI {
             initialized: true,
             cached_entity_index: std::sync::Mutex::new(None),
             cached_item_dedup: std::sync::Mutex::new(None),
+            cached_definition_dedup: std::sync::Mutex::new(None),
             merge_layers: std::sync::atomic::AtomicBool::new(false),
             cached_parts_to_skip: std::sync::Mutex::new(None),
             cached_material_layer_index: std::sync::Mutex::new(None),


### PR DESCRIPTION
## What

#1286 Phase 4-5: the actual CSG win — dedup the **void cut** so identical voided elements are exact-kernel-cut once instead of once per occurrence. **Flag-gated OFF (`IFC_LITE_DEF_DEDUP=1`)**, so this is a no-op for production until corpus-validated.

Stacked on #1293 (the foundation + parity gate).

### Phase 4 — definition-frame void cut (the enabler)
`process_element_with_submeshes_and_voids_unplaced` cuts the UNPLACED base with cutters relativized into the host's **definition frame** (reusing the existing `VoidContext::relativized_by` + `apply_void_context_inner`), producing a placement-invariant, reusable result. Eligibility gated to **pure-translation, non-layered** hosts (`host_translation_only`); rotated/layered hosts return `None` and fall back to the per-occurrence path. `instance_meta` cleared (voided geometry isn't GPU-instanced, matching the placed path).

Proven geometrically identical to the placed path (sorted-coord-set) — only vertex order differs, since the placed path cuts independently.

### Phase 5 — the cache
`definition_signature` keys identical voided elements: host rep signature + an **order-invariant** fold over each opening's `(rep signature, host-relative placement)`. `process_element_with_submeshes_and_voids_deduped` cuts once on a miss, caches the definition-frame template, and on a hit clones it + applies this occurrence's placement. Wired into `produce_inner` (tried before the per-occurrence path) and armed in both batch paths (native rayon pool + wasm) alongside the item cache.

## Why it's safe to land off

- Default OFF => native==wasm byte-identical, zero production change.
- Never wrong, only deferred: any ineligible/unresolved case returns `None` -> existing per-occurrence path.
- Voided geometry isn't instanced either way (no collation interaction).

## Tests
`cargo test -p ifc-lite-geometry --test dedup_validate` (6 pass):
- `void_unplaced_cut_matches_placed_geometry` — def-frame cut + re-place == placed (sorted-coord-set).
- `definition_cache_dedups_and_matches_placed_geometry` — deduped == placed geometry, identical walls share one template (2 cache entries), distinct void stays distinct.

Full `wall_opening_cut_regression` (7) green with the fixture staged.

## Before flipping the flag
Live/corpus validation on 170_KM + a Revit arch + a georeferenced model (the def-frame cut is geometrically invariant near origin; confirm at national-grid scale + visually). Rotated-host coverage is a follow-up (v1 is translation-only). Refs #1286.
