### PR TITLE
perf(geometry): skip tiny detail cuts in preview tessellation tiers (#1286)

### DIFF
--- a/.changeset/skip-small-cuts-preview.md
+++ b/.changeset/skip-small-cuts-preview.md
@@ -1,0 +1,15 @@
+---
+"@ifc-lite/wasm": minor
+---
+
+Skip tiny detail cuts in the preview tessellation tiers (#1286).
+
+In the `Lowest`/`Low` tessellation tiers, an `IfcBooleanResult` DIFFERENCE whose
+cutter's max dimension is below 10% of the host's (a small steel cope/notch, a
+minor detail recess) is now skipped and the host renders un-cut. On
+boolean-heavy Tekla steel models the exact `subtract` per cut dominates load
+time and almost every cut is such a small local notch, so dropping them in the
+preview tiers recovers Manifold-class load times (170_KM geometry ~7.6 s →
+~1.1 s, ~6.9×) with no parallelism and full determinism. `Medium` (the default)
+and finer keep every cut — byte-identical to before. The threshold is tunable
+natively via `IFC_LITE_FAST_CUT_RATIO`.

--- a/rust/geometry/src/processors/boolean.rs
+++ b/rust/geometry/src/processors/boolean.rs
@@ -1092,6 +1092,15 @@ impl BooleanClippingProcessor {
                 self.record_failure(BoolOp::Difference, BoolFailureReason::EmptyOperand);
                 return Ok(mesh);
             }
+            // Preview-mode (Lowest/Low) small-cut skip: a cutter far smaller than
+            // its host (a steel cope/notch, a small detail recess) costs a full
+            // exact subtract — the dominant load-time cost on boolean-heavy steel —
+            // for a barely-visible change. In the preview tiers we drop it and
+            // render the host un-cut, recovering Manifold-class load times.
+            // Medium/High/Highest keep EVERY cut (byte-identical to before).
+            if quality_skips_small_cuts(quality) && cutter_below_skip_ratio(&mesh, &second_mesh) {
+                return Ok(mesh);
+            }
             let clipper = ClippingProcessor::new();
             let result = clipper.subtract_mesh(&mesh, &second_mesh);
             self.drain_clipper_failures(&clipper);
@@ -1133,6 +1142,44 @@ impl BooleanClippingProcessor {
         );
         Ok(mesh)
     }
+}
+
+/// Whether this tessellation tier drops sub-threshold boolean cuts (preview
+/// tiers only). `Medium` (the default) and finer keep every cut, so their
+/// geometry is byte-identical to before this optimization.
+fn quality_skips_small_cuts(quality: TessellationQuality) -> bool {
+    matches!(quality, TessellationQuality::Lowest | TessellationQuality::Low)
+}
+
+/// Skip ratio for preview-mode small-cut dropping: cutter max-dimension as a
+/// fraction of host max-dimension. Default 0.10 (≈ Manifold-era load times on
+/// the steel corpus with no visible change to members). Native callers can tune
+/// it via `IFC_LITE_FAST_CUT_RATIO`; in wasm (no env) the default applies.
+fn fast_cut_skip_ratio() -> f64 {
+    use std::sync::OnceLock;
+    static R: OnceLock<f64> = OnceLock::new();
+    *R.get_or_init(|| {
+        std::env::var("IFC_LITE_FAST_CUT_RATIO")
+            .ok()
+            .and_then(|v| v.parse::<f64>().ok())
+            .filter(|v| v.is_finite() && *v > 0.0)
+            .unwrap_or(0.10)
+    })
+}
+
+/// True when `cutter`'s largest bounding-box dimension is below
+/// [`fast_cut_skip_ratio`] of `host`'s — i.e. a small local cut worth skipping in
+/// the preview tiers. Degenerate (zero-extent) hosts never skip.
+fn cutter_below_skip_ratio(host: &Mesh, cutter: &Mesh) -> bool {
+    let max_dim = |m: &Mesh| -> f64 {
+        let (mn, mx) = m.bounds();
+        (((mx.x - mn.x) as f64).max((mx.y - mn.y) as f64)).max((mx.z - mn.z) as f64)
+    };
+    let h = max_dim(host);
+    if h <= 0.0 {
+        return false;
+    }
+    max_dim(cutter) / h < fast_cut_skip_ratio()
 }
 
 /// Decide whether `plane` (point + outward normal) is coincident with one


### PR DESCRIPTION
## What

In the preview tessellation tiers (`Lowest`/`Low`), skip an `IfcBooleanResult`
DIFFERENCE whose cutter max-dimension is below **10%** of the host's (a small
steel cope/notch, a minor detail recess) and render the host un-cut. `Medium`
(the default) and finer keep **every** cut — byte-identical to before.

## Why (#1286)

Profiling the "wasm slow" regression on the Tekla KM steel corpus (native
`process_geometry`, per-phase `ProcessingStats`):

- The exact per-cut `subtract` is **~93%** of the geometry phase (skipping the
  cuts drops 170_KM geometry 7.6 s → 0.5 s). It is **not** mesh count / dedup:
  content-dedup (#1177) is already on (170_KM 35 s → 6 s without/with), and the
  combined-mesh path at Manifold-era mesh counts is still ~4× slower.
- Almost every cut is a tiny local cope/notch: the cutter's max dimension is
  **<10% of the host's on 98%** of cuts in 130_KM and **67%** in 170_KM, yet each
  still pays a full exact boolean.

So dropping the sub-threshold cuts in the preview tiers recovers Manifold-class
load times:

| File | geometry (all cuts) | geometry (skip <10%, Low) | ratio |
|---|---|---|---|
| 170_KM | 7.6 s | **1.1 s** | ~6.9× |

No parallelism, full determinism (deterministic size test). Verified visually in
`apps/viewer` at Low — members render correctly, small notches drop.

## Notes

- The change is Rust geometry compiled into `@ifc-lite/wasm` → changeset bumps
  that package (`minor`).
- Threshold is tunable natively via `IFC_LITE_FAST_CUT_RATIO`; the 10% default
  applies in wasm (no env in the browser).
- Gated to `Lowest`/`Low` only, so production (Medium+) geometry is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optimized preview rendering in Lowest and Low quality tiers: skips very small cuts (below 10% of host size) for faster display.
  * Cut threshold configurable via `IFC_LITE_FAST_CUT_RATIO` environment variable (default: 10%).
  * Medium and higher quality tiers preserve all detail as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->