### PR TITLE
feat(geometry): decouple small-cut skip from the tessellation tier; wire it into the viewer load

### DIFF
--- a/.changeset/skip-small-cuts-viewer.md
+++ b/.changeset/skip-small-cuts-viewer.md
@@ -1,0 +1,16 @@
+---
+"@ifc-lite/geometry": minor
+"@ifc-lite/wasm": minor
+---
+
+Decouple the small-cut skip (#1286) from the tessellation tier and use it for the
+viewer's on-screen load.
+
+`GeometryProcessor` gains a `skipSmallCuts` option (and the WASM `IfcAPI` a
+`setSkipSmallCuts` binding) that drops tiny `IfcBooleanResult` detail cuts (steel
+copes/notches) WITHOUT lowering the tessellation tier, so curved geometry keeps
+full density while the dominant boolean-heavy load cost is skipped. The viewer
+enables it for the streaming display load (boolean-heavy steel models reach
+Manifold-class first paint); exporters and drawings leave it off, so their
+geometry keeps every cut. Default off everywhere else, so all other output stays
+byte-identical.

--- a/apps/viewer/src/components/viewer/GeometryModeBanner.tsx
+++ b/apps/viewer/src/components/viewer/GeometryModeBanner.tsx
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Reload-to-apply banner for the "Fast / Exact geometry" load-time mode,
+ * mirroring {@link MergeLayersBanner}. The user flips the mode in the Visibility
+ * dropdown; when a model is already loaded the store sets
+ * `geometryModePendingReload` and we surface this non-modal banner above the
+ * canvas asking the user to reload (re-tessellating with the new mode).
+ *
+ * Anchored slightly below the merge-layers banner so the two don't overlap if
+ * both are pending at once.
+ */
+import { useCallback } from 'react';
+import { Zap, RefreshCw, X } from 'lucide-react';
+import { useViewerStore } from '@/store';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+export interface GeometryModeBannerProps {
+  /**
+   * Overrides the default `window.location.reload()` fallback with an in-place
+   * model reload (see ViewportContainer). Same contract as MergeLayersBanner.
+   */
+  onReload?: () => void;
+}
+
+export function GeometryModeBanner({ onReload }: GeometryModeBannerProps) {
+  const pending = useViewerStore((s) => s.geometryModePendingReload);
+  const mode = useViewerStore((s) => s.geometryMode);
+  const dismiss = useViewerStore((s) => s.clearGeometryModePendingReload);
+
+  const handleReload = useCallback(() => {
+    if (onReload) {
+      onReload();
+      return;
+    }
+    // Full-page reload is the only guaranteed path: the viewer doesn't retain
+    // the source File/handle once loading completes. The mode is persisted in
+    // localStorage so it's picked up on the next boot.
+    if (typeof window !== 'undefined') {
+      window.location.reload();
+    }
+  }, [onReload]);
+
+  if (!pending) return null;
+
+  return (
+    <div className="pointer-events-none absolute top-16 left-1/2 -translate-x-1/2 z-40 max-w-[min(640px,calc(100%-1.5rem))] w-fit">
+      <div
+        role="status"
+        aria-live="polite"
+        className={cn(
+          'pointer-events-auto flex items-center gap-3 border border-primary/40 bg-background/95 backdrop-blur',
+          'px-3 py-2 shadow-[0_8px_24px_-12px_rgba(0,0,0,0.45)] rounded-md',
+          'animate-in slide-in-from-top-2 fade-in-0 duration-200',
+        )}
+      >
+        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+          <Zap className="h-4 w-4" />
+        </div>
+        <div className="flex flex-col leading-tight min-w-0">
+          <span className="text-xs font-semibold text-foreground">
+            {mode === 'fast' ? 'Fast geometry enabled' : 'Exact geometry enabled'}
+          </span>
+          <span className="text-[11px] text-muted-foreground truncate">
+            Reload model to apply the new setting.
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5 ml-2">
+          <Button
+            size="sm"
+            variant="default"
+            className="h-7 px-2.5 gap-1.5 text-[11px] font-semibold uppercase tracking-wider"
+            onClick={handleReload}
+          >
+            <RefreshCw className="h-3.5 w-3.5" />
+            Reload
+          </Button>
+          <Button
+            size="icon-sm"
+            variant="ghost"
+            className="h-7 w-7"
+            onClick={dismiss}
+            aria-label="Dismiss reload reminder"
+          >
+            <X className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -29,6 +29,7 @@ import {
   Camera,
   Info,
   Layers2,
+  Zap,
   SquareX,
   BoxSelect,
   Building2,
@@ -378,6 +379,8 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
   // "what shows in the scene" controls.
   const mergeLayers = useViewerStore((state) => state.mergeLayers);
   const setMergeLayers = useViewerStore((state) => state.setMergeLayers);
+  const geometryMode = useViewerStore((state) => state.geometryMode);
+  const setGeometryMode = useViewerStore((state) => state.setGeometryMode);
   const resetViewerState = useViewerStore((state) => state.resetViewerState);
   const bcfPanelVisible = useViewerStore((state) => state.bcfPanelVisible);
   const setBcfPanelVisible = useViewerStore((state) => state.setBcfPanelVisible);
@@ -1564,6 +1567,29 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
               </span>
             </span>
             <Switch checked={mergeLayers} onCheckedChange={(next) => setMergeLayers(next === true)} />
+          </label>
+
+          {/* Fast vs Exact geometry — like merge-layers, a load-time geometry
+              input that only takes effect on the next model load ("· on reload").
+              Fast skips sub-10% detail cuts + auto-lowers density on heavy models
+              for quick first paint; Exact keeps every cut at full density for
+              display/measure/export fidelity. */}
+          <label className="group flex items-center justify-between gap-3 rounded-md px-2 py-1.5 cursor-pointer hover:bg-muted/50 transition-colors">
+            <span className={cn('flex items-center gap-2.5 min-w-0 transition-opacity', geometryMode !== 'fast' && 'opacity-50')}>
+              <Zap className="h-4 w-4 shrink-0 text-primary" />
+              <span className="grid gap-0.5 min-w-0">
+                <span className="text-sm leading-tight truncate">Fast geometry</span>
+                <span className="text-[10px] leading-tight text-muted-foreground truncate">
+                  {geometryMode === 'fast'
+                    ? 'Skip tiny cuts, auto-detail · on reload'
+                    : 'Exact: full cuts + density · on reload'}
+                </span>
+              </span>
+            </span>
+            <Switch
+              checked={geometryMode === 'fast'}
+              onCheckedChange={(next) => setGeometryMode(next === true ? 'fast' : 'exact')}
+            />
           </label>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -13,6 +13,7 @@ import {
 } from './dragOverlayState';
 import { ViewportOverlays } from './ViewportOverlays';
 import { MergeLayersBanner } from './MergeLayersBanner';
+import { GeometryModeBanner } from './GeometryModeBanner';
 import { LevelDisplayIndicator } from './LevelDisplayIndicator';
 import { ToolOverlays } from './ToolOverlays';
 import { AnnotationLayer } from './annotations/AnnotationLayer';
@@ -619,6 +620,28 @@ export function ViewportContainer() {
       // No retained File (e.g. blank/new model) — fall back to a full reload
       // (the toggle is persisted, so the user re-opens the file).
       console.warn('[merge-reload] no active sourceFile — falling back to window.location.reload()');
+      window.location.reload();
+    }
+  }, [loadFile]);
+
+  // Reload-to-apply for the Fast/Exact geometry mode, mirroring the merge-layers
+  // reload: re-load the active model in place so loadFile re-snapshots the mode
+  // and re-tessellates. Clears BOTH pending flags since one reload applies every
+  // load-time geometry setting.
+  const handleGeometryModeReload = useCallback(async () => {
+    const st = useViewerStore.getState();
+    const file = st.getActiveModel()?.sourceFile;
+    st.clearGeometryModePendingReload();
+    st.clearMergeLayersPendingReload();
+    if (file) {
+      try {
+        await loadFile(file);
+      } catch (err) {
+        console.error('[geom-mode-reload] loadFile threw:', err);
+      }
+    } else if (typeof window !== 'undefined') {
+      // No retained File — fall back to a full reload (the mode is persisted).
+      console.warn('[geom-mode-reload] no active sourceFile — falling back to window.location.reload()');
       window.location.reload();
     }
   }, [loadFile]);
@@ -1325,6 +1348,7 @@ export function ViewportContainer() {
           merge-layers toggle while a model is in scope. `onReload` re-loads the
           model in place (full page reload would drop it — no boot auto-restore). */}
       <MergeLayersBanner onReload={handleMergeLayersReload} />
+      <GeometryModeBanner onReload={handleGeometryModeReload} />
       <LevelDisplayIndicator />
       <ToolOverlays />
       <BasketPresentationDock />

--- a/apps/viewer/src/hooks/geometryCacheKey.test.ts
+++ b/apps/viewer/src/hooks/geometryCacheKey.test.ts
@@ -33,4 +33,24 @@ describe('buildGeometryCacheKey', () => {
     const key = buildGeometryCacheKey(99, 'a1b2c3', true, 5);
     assert.match(key, /^[A-Za-z0-9_-]+$/);
   });
+
+  it('omits the skip-small-cuts discriminator by default (preserves legacy full-cut entries)', () => {
+    const unset = buildGeometryCacheKey(2048, 'deadbeef', false, 5);
+    const off = buildGeometryCacheKey(2048, 'deadbeef', false, 5, false);
+    assert.strictEqual(unset, 'ifc-2048-deadbeef-v5');
+    assert.strictEqual(off, 'ifc-2048-deadbeef-v5');
+  });
+
+  it('appends a skip-small-cuts discriminator when on (#1286: skipped display cache must not collide with full-cut)', () => {
+    const skip = buildGeometryCacheKey(2048, 'deadbeef', false, 5, true);
+    const full = buildGeometryCacheKey(2048, 'deadbeef', false, 5, false);
+    assert.strictEqual(skip, 'ifc-2048-deadbeef-v5-sc');
+    assert.notStrictEqual(skip, full);
+  });
+
+  it('composes the merge-layers and skip-small-cuts discriminators and stays filename-safe', () => {
+    const key = buildGeometryCacheKey(4096, 'feed', true, 5, true);
+    assert.strictEqual(key, 'ifc-4096-feed-v5-ml-sc');
+    assert.match(key, /^[A-Za-z0-9_-]+$/);
+  });
 });

--- a/apps/viewer/src/hooks/geometryCacheKey.test.ts
+++ b/apps/viewer/src/hooks/geometryCacheKey.test.ts
@@ -53,4 +53,30 @@ describe('buildGeometryCacheKey', () => {
     assert.strictEqual(key, 'ifc-4096-feed-v5-ml-sc');
     assert.match(key, /^[A-Za-z0-9_-]+$/);
   });
+
+  it('omits the tessellation-tier discriminator at the medium default (preserves legacy entries)', () => {
+    const unset = buildGeometryCacheKey(2048, 'deadbeef', false, 5, false);
+    const medium = buildGeometryCacheKey(2048, 'deadbeef', false, 5, false, 'medium');
+    assert.strictEqual(unset, 'ifc-2048-deadbeef-v5');
+    assert.strictEqual(medium, 'ifc-2048-deadbeef-v5');
+  });
+
+  it('appends a tessellation-tier discriminator for a non-default tier (auto-low must not collide with medium)', () => {
+    const low = buildGeometryCacheKey(2048, 'deadbeef', false, 5, false, 'low');
+    const medium = buildGeometryCacheKey(2048, 'deadbeef', false, 5, false, 'medium');
+    assert.strictEqual(low, 'ifc-2048-deadbeef-v5-tlow');
+    assert.notStrictEqual(low, medium);
+  });
+
+  it('produces distinct keys per tier so different densities cache separately', () => {
+    const low = buildGeometryCacheKey(4096, 'feed', false, 5, false, 'low');
+    const lowest = buildGeometryCacheKey(4096, 'feed', false, 5, false, 'lowest');
+    assert.notStrictEqual(low, lowest);
+  });
+
+  it('composes all discriminators and stays filename-safe', () => {
+    const key = buildGeometryCacheKey(4096, 'feed', true, 5, true, 'lowest');
+    assert.strictEqual(key, 'ifc-4096-feed-v5-ml-sc-tlowest');
+    assert.match(key, /^[A-Za-z0-9_-]+$/);
+  });
 });

--- a/apps/viewer/src/hooks/geometryCacheKey.ts
+++ b/apps/viewer/src/hooks/geometryCacheKey.ts
@@ -21,10 +21,15 @@ import { FORMAT_VERSION } from '@ifc-lite/cache';
  *     (#1286), so its cached geometry differs from a full-cut build. It must
  *     discriminate the key or a skipped display cache would be served where a
  *     full-fidelity build is expected (and vice versa).
+ *   - `tessellationTier`: the load-time vertex-density tier (auto-low for heavy
+ *     models, or a `?geomTier=` override). A model meshed at `low` has different
+ *     bytes than at `medium`, so the tier must discriminate the key or a coarse
+ *     preview cache would be served where full density is expected (and vice
+ *     versa).
  *
- * The `mergeLayers` and `skipSmallCuts` discriminators are omitted at their
- * defaults (`false`) so pre-existing cache entries stay valid — only the opt-in
- * paths get a distinct key.
+ * The `mergeLayers`, `skipSmallCuts`, and `tessellationTier` discriminators are
+ * omitted at their defaults (`false` / `medium`) so pre-existing cache entries
+ * stay valid — only the opt-in / non-default paths get a distinct key.
  *
  * The desktop (Tauri) cache backend only accepts `[A-Za-z0-9_-]`, so the key
  * stays filename-safe and independent of the original filename.
@@ -34,7 +39,9 @@ export function buildGeometryCacheKey(
   fingerprint: string,
   mergeLayers: boolean,
   formatVersion: number | string = FORMAT_VERSION,
-  skipSmallCuts?: boolean
+  skipSmallCuts?: boolean,
+  tessellationTier?: string
 ): string {
-  return `ifc-${byteLength}-${fingerprint}-v${formatVersion}${mergeLayers ? '-ml' : ''}${skipSmallCuts ? '-sc' : ''}`;
+  const tier = tessellationTier && tessellationTier !== 'medium' ? `-t${tessellationTier}` : '';
+  return `ifc-${byteLength}-${fingerprint}-v${formatVersion}${mergeLayers ? '-ml' : ''}${skipSmallCuts ? '-sc' : ''}${tier}`;
 }

--- a/apps/viewer/src/hooks/geometryCacheKey.ts
+++ b/apps/viewer/src/hooks/geometryCacheKey.ts
@@ -17,10 +17,14 @@ import { FORMAT_VERSION } from '@ifc-lite/cache';
  *     flag — the toggle silently no-op'd until the model was re-imported
  *     (issue #1107). Including it makes a toggle+reload a cache miss that
  *     re-tessellates with the new flag.
+ *   - `skipSmallCuts`: the on-screen load skips tiny detail boolean cuts
+ *     (#1286), so its cached geometry differs from a full-cut build. It must
+ *     discriminate the key or a skipped display cache would be served where a
+ *     full-fidelity build is expected (and vice versa).
  *
- * The `mergeLayers` discriminator is omitted when false so pre-existing
- * cache entries (the default is off) stay valid — only the opt-in `true`
- * path gets a distinct key.
+ * The `mergeLayers` and `skipSmallCuts` discriminators are omitted at their
+ * defaults (`false`) so pre-existing cache entries stay valid — only the opt-in
+ * paths get a distinct key.
  *
  * The desktop (Tauri) cache backend only accepts `[A-Za-z0-9_-]`, so the key
  * stays filename-safe and independent of the original filename.
@@ -29,7 +33,8 @@ export function buildGeometryCacheKey(
   byteLength: number,
   fingerprint: string,
   mergeLayers: boolean,
-  formatVersion: number | string = FORMAT_VERSION
+  formatVersion: number | string = FORMAT_VERSION,
+  skipSmallCuts?: boolean
 ): string {
-  return `ifc-${byteLength}-${fingerprint}-v${formatVersion}${mergeLayers ? '-ml' : ''}`;
+  return `ifc-${byteLength}-${fingerprint}-v${formatVersion}${mergeLayers ? '-ml' : ''}${skipSmallCuts ? '-sc' : ''}`;
 }

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -676,17 +676,21 @@ export function useIfcLoader() {
       // Only for IFC4 STEP files (server doesn't support IFCX). Native
       // file handles (Tauri) don't have an HTTP-uploadable body, so skip
       // the server path and fall through to the WASM loader.
-      // Also skip it whenever the load needs local-only geometry tessellation
-      // the server can't reproduce: merge-layers (issue #1107), the small-cut
-      // skip, or a non-default tessellation tier. The server tessellates with
-      // none of these and its cache key ignores them, so routing through it
-      // would return geometry that disagrees with the cache key the client
-      // committed (it would serve full-cut/medium where `fast` was requested).
-      // The local WASM path honours all three. (In `fast` mode the local skip is
-      // also the faster path on boolean-heavy models, so little is lost.)
-      const needsLocalGeometryBuild =
-        mergeLayersAtLoad || skipSmallCutsAtLoad || loadTessellationTier !== undefined;
-      if (target.kind === 'primary' && format === 'ifc' && !needsLocalGeometryBuild && USE_SERVER && SERVER_URL && SERVER_URL !== '') {
+      // Skip it when merge-layers is on: the server tessellates without that
+      // flag and its cache key ignores it, so a toggle+reload would still return
+      // non-merged geometry (issue #1107). Merge-layers is opt-in, so the common
+      // load keeps the server fast path.
+      //
+      // The geometry-fidelity mode (skip-small-cuts / auto-low tier) is a
+      // LOCAL-WASM display optimization and does NOT gate the server here. The
+      // server produces canonical full-fidelity geometry and caches it under its
+      // OWN key (useIfcServer: streamResult.cache_key) — it never writes the
+      // local `-sc/-tlow` cacheKey, so there is no key/geometry mismatch. Gating
+      // the server on the default-on `fast` mode would disable the multi-core
+      // server fast-path for every primary IFC load (the cause of an "overall
+      // slower" regression on server-enabled deploys); fast mode still applies on
+      // every local-path load (IFCX, merge-layers, Tauri, or server-off).
+      if (target.kind === 'primary' && format === 'ifc' && !mergeLayersAtLoad && USE_SERVER && SERVER_URL && SERVER_URL !== '') {
         // Pass buffer directly - server uses File object for parsing, buffer is only for size checks
         const serverSuccess = await loadFromServer(file, buffer, () => loadSessionRef.current !== currentSession);
         if (serverSuccess) {

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -56,6 +56,20 @@ import { posthog } from '../lib/analytics.js';
 import { classifyLoadError, formatLoadError } from '../lib/load-errors.js';
 
 /**
+ * The on-screen streaming load skips tiny detail boolean cuts (steel
+ * copes/notches, minor recesses) for fast first paint on boolean-heavy models
+ * (#1286) — the per-cut exact subtract dominates load time there. This is
+ * decoupled from the tessellation tier: the load stays at Medium, so CURVES KEEP
+ * FULL DENSITY; only the sub-threshold cuts drop.
+ *
+ * Display only: exports (GLB/CSV/KMZ/HBJSON), drawings and annotations build
+ * their own GeometryProcessor with the skip OFF, so their geometry keeps every
+ * cut. The cache key folds this flag in (see buildGeometryCacheKey) so a skipped
+ * display cache is never served where a full-fidelity build is expected.
+ */
+const STREAMING_SKIP_SMALL_CUTS = true;
+
+/**
  * Where a {@link useIfcLoader.loadFile} call should land the model.
  *
  * `primary` is the historical single-model load: it resets all viewer state,
@@ -608,7 +622,13 @@ export function useIfcLoader() {
       // stays filename-safe and independent of the original filename. Pinned
       // to FORMAT_VERSION so a format bump invalidates stale entries (e.g. v5
       // added the geometryClass tag the Model/Types switch needs).
-      const cacheKey = buildGeometryCacheKey(buffer.byteLength, fingerprint, mergeLayersAtLoad);
+      const cacheKey = buildGeometryCacheKey(
+        buffer.byteLength,
+        fingerprint,
+        mergeLayersAtLoad,
+        undefined,
+        STREAMING_SKIP_SMALL_CUTS
+      );
       console.log(`[useIfc] loadFile "${file.name}" session=${currentSession} mergeLayers=${mergeLayersAtLoad} cacheKey=${cacheKey}`);
 
       // Cache + server are PRIMARY-ONLY: a federated add is WASM-only with no
@@ -672,6 +692,10 @@ export function useIfcLoader() {
       // key and the WASM tessellation always agree (issues #540, #1107).
       const geometryProcessor = new GeometryProcessor({
         quality: GeometryQuality.Balanced,
+        // Skip tiny detail boolean cuts on the on-screen load for fast first
+        // paint (#1286) while keeping Medium tessellation (full-density curves).
+        // Must match the flag folded into `cacheKey` above (issues #540, #1107).
+        skipSmallCuts: STREAMING_SKIP_SMALL_CUTS,
         preferNative: false,
         // Issue #540: snapshot at load time so the WASM bridge applies
         // the flag before the first parseMeshes* call.

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -56,18 +56,22 @@ import { posthog } from '../lib/analytics.js';
 import { classifyLoadError, formatLoadError } from '../lib/load-errors.js';
 
 /**
- * The on-screen streaming load skips tiny detail boolean cuts (steel
- * copes/notches, minor recesses) for fast first paint on boolean-heavy models
- * (#1286) — the per-cut exact subtract dominates load time there. This is
- * decoupled from the tessellation tier: the load stays at Medium, so CURVES KEEP
- * FULL DENSITY; only the sub-threshold cuts drop.
+ * The skip-tiny-cuts flag is no longer a hard constant: it is derived per-load
+ * from the user's geometry-fidelity mode (`fast` vs `exact`, see
+ * `resolveLoadTessellationTier` / store `geometryMode`). In `fast` mode the
+ * on-screen load skips sub-10% detail boolean cuts (steel copes/notches, minor
+ * recesses) for fast first paint on boolean-heavy models (#1286) and may auto-
+ * lower tessellation density on heavy models; in `exact` mode every cut runs at
+ * full density.
  *
- * Display only: exports (GLB/CSV/KMZ/HBJSON), drawings and annotations build
- * their own GeometryProcessor with the skip OFF, so their geometry keeps every
- * cut. The cache key folds this flag in (see buildGeometryCacheKey) so a skipped
- * display cache is never served where a full-fidelity build is expected.
+ * IMPORTANT: in `fast` mode this is NOT display-only — the cached
+ * `geometryResult.meshes` are what exports (GLB/IFC5/CSV) and in-viewer
+ * measure/section read, so they reflect the preview too. That is intentional and
+ * visible: the user picked `fast`. For full-fidelity exports/measurement they
+ * switch to `exact` and reload (same flow as Merge Layers). The cache key folds
+ * the derived flag + tier so a preview cache is never served where `exact` is
+ * expected, and vice versa.
  */
-const STREAMING_SKIP_SMALL_CUTS = true;
 
 /**
  * Where a {@link useIfcLoader.loadFile} call should land the model.
@@ -618,12 +622,18 @@ export function useIfcLoader() {
       // with the previous flag (issue #1107). Reused below for the
       // GeometryProcessor so the key and the actual tessellation agree.
       const mergeLayersAtLoad = useViewerStore.getState().mergeLayers;
-      // Auto-low tessellation density for heavy models (or a `?geomTier=`
-      // override). Decided here, before the cache key + GeometryProcessor, off
-      // file size — the only model-weight signal available pre-geometry — so the
-      // key stays deterministic at cache-check time and the actual tessellation
-      // matches what the key claims. `undefined` = engine default (medium).
-      const loadTessellationTier = resolveLoadTessellationTier(fileSizeMB);
+      // Snapshot the geometry-fidelity mode the same way: it is a load-time
+      // tessellation input, so it must discriminate the cache key and be reused
+      // for the GeometryProcessor. `fast` = skip sub-10% cuts + auto-low density
+      // for heavy models; `exact` = full cuts + full density.
+      const geometryModeAtLoad = useViewerStore.getState().geometryMode;
+      const skipSmallCutsAtLoad = geometryModeAtLoad === 'fast';
+      // Tessellation tier from the mode: a `?geomTier=` override wins, else
+      // auto-low for heavy models by file size in `fast` mode only (the only
+      // model-weight signal available pre-geometry, so the key stays
+      // deterministic at cache-check time). `undefined` = engine default
+      // (medium). `exact` never auto-lowers.
+      const loadTessellationTier = resolveLoadTessellationTier(fileSizeMB, geometryModeAtLoad);
       // Desktop Tauri cache commands only accept [A-Za-z0-9_-], so the key
       // stays filename-safe and independent of the original filename. Pinned
       // to FORMAT_VERSION so a format bump invalidates stale entries (e.g. v5
@@ -633,10 +643,10 @@ export function useIfcLoader() {
         fingerprint,
         mergeLayersAtLoad,
         undefined,
-        STREAMING_SKIP_SMALL_CUTS,
+        skipSmallCutsAtLoad,
         loadTessellationTier
       );
-      console.log(`[useIfc] loadFile "${file.name}" session=${currentSession} mergeLayers=${mergeLayersAtLoad} tier=${loadTessellationTier ?? 'medium'} cacheKey=${cacheKey}`);
+      console.log(`[useIfc] loadFile "${file.name}" session=${currentSession} mergeLayers=${mergeLayersAtLoad} geomMode=${geometryModeAtLoad} tier=${loadTessellationTier ?? 'medium'} cacheKey=${cacheKey}`);
 
       // Cache + server are PRIMARY-ONLY: a federated add is WASM-only with no
       // cache/server round-trip (matches the former parseStepBufferViewerModel).
@@ -666,12 +676,17 @@ export function useIfcLoader() {
       // Only for IFC4 STEP files (server doesn't support IFCX). Native
       // file handles (Tauri) don't have an HTTP-uploadable body, so skip
       // the server path and fall through to the WASM loader.
-      // Also skip it when merge-layers is on: the server tessellates without
-      // the flag and its cache key ignores it, so a toggle+reload would still
-      // return non-merged geometry. The local WASM path honours the flag, so
-      // route through it instead (issue #1107). Merge-layers is opt-in, so the
-      // common (flag-off) load keeps the server fast path.
-      if (target.kind === 'primary' && format === 'ifc' && !mergeLayersAtLoad && USE_SERVER && SERVER_URL && SERVER_URL !== '') {
+      // Also skip it whenever the load needs local-only geometry tessellation
+      // the server can't reproduce: merge-layers (issue #1107), the small-cut
+      // skip, or a non-default tessellation tier. The server tessellates with
+      // none of these and its cache key ignores them, so routing through it
+      // would return geometry that disagrees with the cache key the client
+      // committed (it would serve full-cut/medium where `fast` was requested).
+      // The local WASM path honours all three. (In `fast` mode the local skip is
+      // also the faster path on boolean-heavy models, so little is lost.)
+      const needsLocalGeometryBuild =
+        mergeLayersAtLoad || skipSmallCutsAtLoad || loadTessellationTier !== undefined;
+      if (target.kind === 'primary' && format === 'ifc' && !needsLocalGeometryBuild && USE_SERVER && SERVER_URL && SERVER_URL !== '') {
         // Pass buffer directly - server uses File object for parsing, buffer is only for size checks
         const serverSuccess = await loadFromServer(file, buffer, () => loadSessionRef.current !== currentSession);
         if (serverSuccess) {
@@ -704,10 +719,10 @@ export function useIfcLoader() {
         // Must match the tier folded into `cacheKey` above so the cached bytes
         // and the live tessellation agree (issues #540, #1107).
         tessellationQuality: loadTessellationTier,
-        // Skip tiny detail boolean cuts on the on-screen load for fast first
-        // paint (#1286) while keeping full-density curves at the chosen tier.
-        // Must match the flag folded into `cacheKey` above (issues #540, #1107).
-        skipSmallCuts: STREAMING_SKIP_SMALL_CUTS,
+        // Skip tiny detail boolean cuts in `fast` mode for quick first paint
+        // (#1286); `exact` mode keeps every cut. Must match the flag folded into
+        // `cacheKey` above so cached bytes and live tessellation agree (#540, #1107).
+        skipSmallCuts: skipSmallCutsAtLoad,
         preferNative: false,
         // Issue #540: snapshot at load time so the WASM bridge applies
         // the flag before the first parseMeshes* call.

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -14,7 +14,7 @@ import { useCallback, useRef } from 'react';
 import { flushSync } from 'react-dom';
 import { useShallow } from 'zustand/react/shallow';
 import { getViewerStoreApi, useViewerStore, type FederatedModel } from '@/store';
-import { getGeomWorkerOverride } from '../store/constants.js';
+import { getGeomWorkerOverride, resolveLoadTessellationTier } from '../store/constants.js';
 import { IfcParser, detectFormat, type IfcDataStore } from '@ifc-lite/parser';
 import { WorkerParser } from '@ifc-lite/parser/browser';
 import { memoryAccounting } from '../lib/perf/memoryAccounting.js';
@@ -618,6 +618,12 @@ export function useIfcLoader() {
       // with the previous flag (issue #1107). Reused below for the
       // GeometryProcessor so the key and the actual tessellation agree.
       const mergeLayersAtLoad = useViewerStore.getState().mergeLayers;
+      // Auto-low tessellation density for heavy models (or a `?geomTier=`
+      // override). Decided here, before the cache key + GeometryProcessor, off
+      // file size — the only model-weight signal available pre-geometry — so the
+      // key stays deterministic at cache-check time and the actual tessellation
+      // matches what the key claims. `undefined` = engine default (medium).
+      const loadTessellationTier = resolveLoadTessellationTier(fileSizeMB);
       // Desktop Tauri cache commands only accept [A-Za-z0-9_-], so the key
       // stays filename-safe and independent of the original filename. Pinned
       // to FORMAT_VERSION so a format bump invalidates stale entries (e.g. v5
@@ -627,9 +633,10 @@ export function useIfcLoader() {
         fingerprint,
         mergeLayersAtLoad,
         undefined,
-        STREAMING_SKIP_SMALL_CUTS
+        STREAMING_SKIP_SMALL_CUTS,
+        loadTessellationTier
       );
-      console.log(`[useIfc] loadFile "${file.name}" session=${currentSession} mergeLayers=${mergeLayersAtLoad} cacheKey=${cacheKey}`);
+      console.log(`[useIfc] loadFile "${file.name}" session=${currentSession} mergeLayers=${mergeLayersAtLoad} tier=${loadTessellationTier ?? 'medium'} cacheKey=${cacheKey}`);
 
       // Cache + server are PRIMARY-ONLY: a federated add is WASM-only with no
       // cache/server round-trip (matches the former parseStepBufferViewerModel).
@@ -692,8 +699,13 @@ export function useIfcLoader() {
       // key and the WASM tessellation always agree (issues #540, #1107).
       const geometryProcessor = new GeometryProcessor({
         quality: GeometryQuality.Balanced,
+        // Auto-low vertex density for heavy models (or `?geomTier=` override);
+        // `undefined` keeps the engine default (medium, full-density curves).
+        // Must match the tier folded into `cacheKey` above so the cached bytes
+        // and the live tessellation agree (issues #540, #1107).
+        tessellationQuality: loadTessellationTier,
         // Skip tiny detail boolean cuts on the on-screen load for fast first
-        // paint (#1286) while keeping Medium tessellation (full-density curves).
+        // paint (#1286) while keeping full-density curves at the chosen tier.
         // Must match the flag folded into `cacheKey` above (issues #540, #1107).
         skipSmallCuts: STREAMING_SKIP_SMALL_CUTS,
         preferNative: false,

--- a/apps/viewer/src/store/constants.test.ts
+++ b/apps/viewer/src/store/constants.test.ts
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { resolveLoadTessellationTier, AUTO_LOW_TIER_MB, AUTO_LOWEST_TIER_MB } from './constants.js';
+
+// In node:test there is no `window`, so getGeomTierOverride() returns undefined
+// and these assertions exercise the pure size + mode logic deterministically.
+describe('resolveLoadTessellationTier (geometry mode gating)', () => {
+  it('fast mode keeps medium (undefined) for small models', () => {
+    assert.strictEqual(resolveLoadTessellationTier(10, 'fast'), undefined);
+  });
+
+  it('fast mode auto-lows at/above the low threshold', () => {
+    assert.strictEqual(resolveLoadTessellationTier(AUTO_LOW_TIER_MB, 'fast'), 'low');
+    assert.strictEqual(resolveLoadTessellationTier(AUTO_LOWEST_TIER_MB - 1, 'fast'), 'low');
+  });
+
+  it('fast mode drops to lowest at/above the lowest threshold', () => {
+    assert.strictEqual(resolveLoadTessellationTier(AUTO_LOWEST_TIER_MB, 'fast'), 'lowest');
+    assert.strictEqual(resolveLoadTessellationTier(AUTO_LOWEST_TIER_MB + 500, 'fast'), 'lowest');
+  });
+
+  it('exact mode never auto-lows, even for very large models', () => {
+    assert.strictEqual(resolveLoadTessellationTier(10, 'exact'), undefined);
+    assert.strictEqual(resolveLoadTessellationTier(AUTO_LOW_TIER_MB, 'exact'), undefined);
+    assert.strictEqual(resolveLoadTessellationTier(AUTO_LOWEST_TIER_MB + 1000, 'exact'), undefined);
+  });
+
+  it('defaults to fast mode when omitted', () => {
+    assert.strictEqual(resolveLoadTessellationTier(AUTO_LOW_TIER_MB), 'low');
+  });
+});

--- a/apps/viewer/src/store/constants.ts
+++ b/apps/viewer/src/store/constants.ts
@@ -7,6 +7,7 @@
  */
 
 import type { TypeVisibility } from './types.js';
+import type { TessellationQuality } from '@ifc-lite/geometry';
 
 // ============================================================================
 // Camera Defaults
@@ -113,6 +114,22 @@ function getInitialMergeLayers(): boolean {
  * localStorage key for the geometry-worker-count A/B override.
  */
 export const GEOM_WORKERS_STORAGE_KEY = 'ifc-lite-geom-workers';
+export const GEOM_TIER_STORAGE_KEY = 'ifc-lite-geom-tier';
+
+// Auto-low tessellation density for heavy models. The on-screen load already
+// skips tiny detail boolean cuts on every load (#1286), which removes the
+// exact-tier escalations that dominate boolean-heavy steel; this is the
+// ORTHOGONAL triangle-count lever — dropping vertex density (low = 0.5x,
+// lowest = 0.25x) so a multi-million-triangle model uploads + fits in GPU
+// memory fast for first paint. The signal is file size, the only model-weight
+// proxy available before geometry runs (the pre-pass job count arrives after
+// the cache key is committed). Size correlates with triangle count at scale but
+// can't tell a dense-but-small model (e.g. 20 MB detailed steel, ~8M tris) from
+// a light one — those still load at medium density (the skip keeps them fast),
+// or can be forced low via `?geomTier=low`. Thresholds are deliberately high so
+// normal models keep full curve density; tune here.
+export const AUTO_LOW_TIER_MB = 50; // >= this → 'low'
+export const AUTO_LOWEST_TIER_MB = 150; // >= this → 'lowest'
 
 /**
  * Resolve an explicit geometry-worker count override for A/B tuning, or
@@ -148,6 +165,64 @@ export function getGeomWorkerOverride(): number | undefined {
   } catch {
     /* SSR / blocked storage — fall through to the heuristic */
   }
+  return undefined;
+}
+
+const TESSELLATION_TIERS: readonly TessellationQuality[] = [
+  'lowest',
+  'low',
+  'medium',
+  'high',
+  'highest',
+];
+
+/**
+ * Per-host manual override for the load-time tessellation tier, mirroring
+ * `getGeomWorkerOverride`. `?geomTier=low` (or lowest/medium/high/highest) sets
+ * it AND persists to localStorage so it survives the reload a re-measure needs
+ * (and a shared link carries it). `?geomTier=auto` clears the override. Useful
+ * for forcing low density on a dense-but-small model the size heuristic can't
+ * detect, or pinning full density on a large one.
+ */
+export function getGeomTierOverride(): TessellationQuality | undefined {
+  if (typeof window === 'undefined') return undefined;
+  try {
+    const param = new URLSearchParams(window.location.search).get('geomTier');
+    if (param != null) {
+      if (param === 'auto') {
+        localStorage.removeItem(GEOM_TIER_STORAGE_KEY);
+        return undefined;
+      }
+      if ((TESSELLATION_TIERS as readonly string[]).includes(param)) {
+        localStorage.setItem(GEOM_TIER_STORAGE_KEY, param);
+        return param as TessellationQuality;
+      }
+    }
+    const stored = localStorage.getItem(GEOM_TIER_STORAGE_KEY) ?? '';
+    if ((TESSELLATION_TIERS as readonly string[]).includes(stored)) {
+      return stored as TessellationQuality;
+    }
+  } catch {
+    /* SSR / blocked storage — fall through to the heuristic */
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the load-time tessellation tier for a model of `fileSizeMB`: a manual
+ * `?geomTier=` override wins, else auto-low for heavy models by size, else
+ * `undefined` (engine default = medium, full curve density). Returning
+ * `undefined` at the medium default keeps pre-existing cache entries valid (the
+ * tier discriminator is omitted from the cache key at medium — see
+ * `buildGeometryCacheKey`).
+ */
+export function resolveLoadTessellationTier(
+  fileSizeMB: number
+): TessellationQuality | undefined {
+  const override = getGeomTierOverride();
+  if (override) return override;
+  if (fileSizeMB >= AUTO_LOWEST_TIER_MB) return 'lowest';
+  if (fileSizeMB >= AUTO_LOW_TIER_MB) return 'low';
   return undefined;
 }
 

--- a/apps/viewer/src/store/constants.ts
+++ b/apps/viewer/src/store/constants.ts
@@ -131,6 +131,33 @@ export const GEOM_TIER_STORAGE_KEY = 'ifc-lite-geom-tier';
 export const AUTO_LOW_TIER_MB = 50; // >= this → 'low'
 export const AUTO_LOWEST_TIER_MB = 150; // >= this → 'lowest'
 
+/** localStorage key for the load-time geometry fidelity mode (mirrors merge-layers). */
+export const GEOMETRY_MODE_STORAGE_KEY = 'ifc-lite-geometry-mode';
+
+/**
+ * Load-time geometry fidelity mode — a user-facing, persistent switch that
+ * mirrors the merge-layers load-time input (sticky in localStorage, folded into
+ * the geometry cache key, reload-to-apply).
+ * - `fast` (default): skip tiny detail boolean cuts (#1286) + auto-low
+ *   tessellation density for heavy models, for fast first paint. PREVIEW
+ *   fidelity — sub-10% cutters (bolt holes, copes) are dropped and curves may be
+ *   coarser; display, measure AND export all read this same geometry, so it is a
+ *   deliberate, visible choice rather than a silent default.
+ * - `exact`: full boolean cuts + full curve density everywhere — display,
+ *   measure and export consistent. Slower on boolean-heavy / dense models.
+ */
+export type GeometryMode = 'fast' | 'exact';
+
+/** Resolve the initial geometry mode from localStorage; default `fast`. */
+function getInitialGeometryMode(): GeometryMode {
+  if (typeof window === 'undefined') return 'fast';
+  try {
+    return localStorage.getItem(GEOMETRY_MODE_STORAGE_KEY) === 'exact' ? 'exact' : 'fast';
+  } catch {
+    return 'fast';
+  }
+}
+
 /**
  * Resolve an explicit geometry-worker count override for A/B tuning, or
  * `undefined` to use the engine's cores/memory heuristic.
@@ -202,25 +229,31 @@ export function getGeomTierOverride(): TessellationQuality | undefined {
     if ((TESSELLATION_TIERS as readonly string[]).includes(stored)) {
       return stored as TessellationQuality;
     }
-  } catch {
-    /* SSR / blocked storage — fall through to the heuristic */
+  } catch (err) {
+    // Blocked/unavailable storage (Safari private mode, locked storage) or a
+    // bad URL — fall back to the heuristic, but don't swallow silently
+    // (AGENTS.md: no silent catch). A persisted ?geomTier override is lost here.
+    console.warn('[geom-tier] override read failed; using heuristic', err);
   }
   return undefined;
 }
 
 /**
- * Resolve the load-time tessellation tier for a model of `fileSizeMB`: a manual
- * `?geomTier=` override wins, else auto-low for heavy models by size, else
- * `undefined` (engine default = medium, full curve density). Returning
- * `undefined` at the medium default keeps pre-existing cache entries valid (the
- * tier discriminator is omitted from the cache key at medium — see
- * `buildGeometryCacheKey`).
+ * Resolve the load-time tessellation tier for a model of `fileSizeMB` under the
+ * given geometry `mode`: a manual `?geomTier=` override wins in any mode; else
+ * in `fast` mode auto-low for heavy models by size; else `undefined` (engine
+ * default = medium, full curve density). In `exact` mode auto-low never fires,
+ * so dense models keep full density. Returning `undefined` at the medium default
+ * keeps pre-existing cache entries valid (the tier discriminator is omitted from
+ * the cache key at medium — see `buildGeometryCacheKey`).
  */
 export function resolveLoadTessellationTier(
-  fileSizeMB: number
+  fileSizeMB: number,
+  mode: GeometryMode = 'fast'
 ): TessellationQuality | undefined {
   const override = getGeomTierOverride();
   if (override) return override;
+  if (mode !== 'fast') return undefined;
   if (fileSizeMB >= AUTO_LOWEST_TIER_MB) return 'lowest';
   if (fileSizeMB >= AUTO_LOW_TIER_MB) return 'low';
   return undefined;
@@ -260,6 +293,13 @@ export const UI_DEFAULTS = {
    * reloads. Default `false` keeps existing per-layer rendering.
    */
   MERGE_LAYERS: getInitialMergeLayers(),
+  /**
+   * Load-time geometry fidelity mode (see `GeometryMode`). Read from
+   * localStorage on boot so the user's choice survives reloads. Default `fast`
+   * (skip tiny cuts + auto-low density for heavy models) for quick first paint;
+   * `exact` for full display/measure/export fidelity.
+   */
+  GEOMETRY_MODE: getInitialGeometryMode(),
 } as const;
 
 // ============================================================================

--- a/apps/viewer/src/store/slices/uiSlice.ts
+++ b/apps/viewer/src/store/slices/uiSlice.ts
@@ -7,7 +7,7 @@
  */
 
 import type { StateCreator } from 'zustand';
-import { MERGE_LAYERS_STORAGE_KEY, UI_DEFAULTS } from '../constants.js';
+import { MERGE_LAYERS_STORAGE_KEY, GEOMETRY_MODE_STORAGE_KEY, UI_DEFAULTS, type GeometryMode } from '../constants.js';
 import type { ContactShadingQuality, SeparationLinesQuality } from '@ifc-lite/renderer';
 import type { FederatedModel } from '../types.js';
 import type { GeometryResult } from '@ifc-lite/geometry';
@@ -107,6 +107,15 @@ export interface UISlice {
   mergeLayers: boolean;
   /** True after the user flipped `mergeLayers` while a model was loaded. */
   mergeLayersPendingReload: boolean;
+  /**
+   * Load-time geometry fidelity mode (`fast` = skip tiny cuts + auto-low
+   * density; `exact` = full fidelity). Like `mergeLayers`, it is read on the
+   * next file load; flipping it while a model is in scope sets
+   * `geometryModePendingReload` so the UI can prompt a reload.
+   */
+  geometryMode: GeometryMode;
+  /** True after the user flipped `geometryMode` while a model was loaded. */
+  geometryModePendingReload: boolean;
 
   // Actions
   setLeftPanelCollapsed: (collapsed: boolean) => void;
@@ -137,6 +146,10 @@ export interface UISlice {
   setMergeLayers: (v: boolean) => void;
   /** Acknowledge the reload banner without performing a reload. */
   clearMergeLayersPendingReload: () => void;
+  /** Update the geometry fidelity mode and persist to localStorage. */
+  setGeometryMode: (v: GeometryMode) => void;
+  /** Acknowledge the geometry-mode reload banner without performing a reload. */
+  clearGeometryModePendingReload: () => void;
 }
 
 /** Apply the correct CSS classes on <html> for the given theme */
@@ -180,6 +193,8 @@ export const createUISlice: StateCreator<UISlice & UICrossSliceState, [], [], UI
   separationLinesRadius: UI_DEFAULTS.SEPARATION_LINES_RADIUS,
   mergeLayers: UI_DEFAULTS.MERGE_LAYERS,
   mergeLayersPendingReload: false,
+  geometryMode: UI_DEFAULTS.GEOMETRY_MODE,
+  geometryModePendingReload: false,
 
   // Actions
   setLeftPanelCollapsed: (leftPanelCollapsed) => set({ leftPanelCollapsed }),
@@ -287,4 +302,25 @@ export const createUISlice: StateCreator<UISlice & UICrossSliceState, [], [], UI
   },
 
   clearMergeLayersPendingReload: () => set({ mergeLayersPendingReload: false }),
+
+  setGeometryMode: (next) => {
+    const current = get();
+    if (current.geometryMode === next) return;
+    // Persist eagerly so the next page-load picks the same value up through
+    // `getInitialGeometryMode` (constants.ts). Wrap in try/catch — Safari
+    // private mode / locked storage throws.
+    try {
+      localStorage.setItem(GEOMETRY_MODE_STORAGE_KEY, next);
+    } catch (err) {
+      // Storage unavailable — accept the in-memory toggle, but don't swallow
+      // silently (AGENTS.md: no silent catch). The choice won't persist.
+      console.warn('[geometry-mode] persist failed; in-memory only', err);
+    }
+    // Only prompt a reload if a model is currently in scope; toggling on an
+    // empty viewer simply changes the next load with no visible effect.
+    const pending = hasLoadedModel(current);
+    set({ geometryMode: next, geometryModePendingReload: pending });
+  },
+
+  clearGeometryModePendingReload: () => set({ geometryModePendingReload: false }),
 });

--- a/packages/geometry/src/geometry-parallel.ts
+++ b/packages/geometry/src/geometry-parallel.ts
@@ -141,6 +141,13 @@ export interface ProcessParallelOptions {
    */
   tessellationQuality?: TessellationQuality | null;
   /**
+   * Issue #1286 — tier-independent small-cut skip. When true, each geometry
+   * worker's IfcAPI receives `setSkipSmallCuts(true)` before the first
+   * stream-chunk, dropping tiny `IfcBooleanResult` detail cuts while keeping the
+   * tessellation tier. `undefined`/`false` ⇒ every cut runs (default).
+   */
+  skipSmallCuts?: boolean;
+  /**
    * Explicit URL for the wasm-bindgen `.wasm` binary. When provided,
    * forwarded to the geometry workers' init messages so they call
    * `init(wasmUrl)` instead of relying on wasm-bindgen's default
@@ -500,6 +507,12 @@ export async function* processParallel(
     worker.postMessage({
       type: 'set-tessellation-quality',
       level: options?.tessellationQuality ?? null,
+    });
+    // Issue #1286: forward the small-cut skip the same way — always sent so a
+    // worker reused by a later export (which omits it) resets to false.
+    worker.postMessage({
+      type: 'set-skip-small-cuts',
+      enabled: options?.skipSmallCuts === true,
     });
   }
 

--- a/packages/geometry/src/geometry.worker.ts
+++ b/packages/geometry/src/geometry.worker.ts
@@ -169,6 +169,17 @@ export interface GeometryWorkerSetTessellationQualityMessage {
   level: TessellationQuality | null;
 }
 
+/**
+ * Forward the tier-independent small-cut skip (issue #1286) to this worker's
+ * IfcAPI. Sent AFTER `init` and BEFORE the first `stream-start`, mirroring
+ * `set-tessellation-quality`. `false` (the default) keeps every cut, so never
+ * sending the message changes nothing.
+ */
+export interface GeometryWorkerSetSkipSmallCutsMessage {
+  type: 'set-skip-small-cuts';
+  enabled: boolean;
+}
+
 export type GeometryWorkerRequest =
   | GeometryWorkerInitMessage
   | GeometryWorkerStreamStartMessage
@@ -180,6 +191,7 @@ export type GeometryWorkerRequest =
   | GeometryWorkerSetInstancingMessage
   | GeometryWorkerSetComputeGeometryHashesMessage
   | GeometryWorkerSetTessellationQualityMessage
+  | GeometryWorkerSetSkipSmallCutsMessage
   | GeometryWorkerPrePassMessage;
 
 export interface GeometryWorkerBatchMessage {
@@ -281,6 +293,8 @@ async function ensureInit(): Promise<IfcAPI> {
   applyComputeGeometryHashesToApi();
   tessellationQualityApplied = false;
   applyTessellationQualityToApi();
+  skipSmallCutsApplied = false;
+  applySkipSmallCutsToApi();
   entityIndexApplied = false;
   applyEntityIndexToApi();
   return api;
@@ -310,6 +324,7 @@ type IfcAPIWithMerge = IfcAPI & {
   setMergeLayers?: (enabled: boolean) => void;
   setComputeGeometryHashes?: (tolerance?: number | null) => void;
   setTessellationQuality?: (level?: string | null) => void;
+  setSkipSmallCuts?: (on: boolean) => void;
 };
 
 /**
@@ -361,6 +376,26 @@ function applyTessellationQualityToApi(): void {
     quality.setTessellationQuality(tessellationQuality);
   }
   tessellationQualityApplied = true;
+}
+
+/**
+ * Cached tier-independent small-cut skip for this worker (issue #1286), mirroring
+ * the merge-layers replay contract: the host posts the toggle before `init`, so
+ * remember it and re-apply once the IfcAPI exists. `false` (the default) keeps
+ * every cut. Always re-sent per run, so a worker reused by a later export resets
+ * to `false` and that export keeps full-fidelity geometry.
+ */
+let skipSmallCuts: boolean = false;
+let skipSmallCutsApplied: boolean = false;
+
+/** Push the cached small-cut skip onto the IfcAPI (once per API). */
+function applySkipSmallCutsToApi(): void {
+  if (!api || skipSmallCutsApplied) return;
+  const cutting = api as IfcAPIWithMerge;
+  if (typeof cutting.setSkipSmallCuts === 'function') {
+    cutting.setSkipSmallCuts(skipSmallCuts);
+  }
+  skipSmallCutsApplied = true;
 }
 
 /**
@@ -894,6 +929,8 @@ async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<vo
         applyComputeGeometryHashesToApi();
         tessellationQualityApplied = false;
         applyTessellationQualityToApi();
+        skipSmallCutsApplied = false;
+        applySkipSmallCutsToApi();
         entityIndexApplied = false;
         applyEntityIndexToApi();
       } else {
@@ -1002,6 +1039,14 @@ async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<vo
       tessellationQuality = e.data.level ?? null;
       tessellationQualityApplied = false;
       applyTessellationQualityToApi();
+      return;
+    }
+
+    if (e.data.type === 'set-skip-small-cuts') {
+      // Same cache-and-replay contract as set-merge-layers (issue #1286).
+      skipSmallCuts = e.data.enabled === true;
+      skipSmallCutsApplied = false;
+      applySkipSmallCutsToApi();
       return;
     }
 

--- a/packages/geometry/src/ifc-lite-bridge.ts
+++ b/packages/geometry/src/ifc-lite-bridge.ts
@@ -45,6 +45,7 @@ type IfcAPIWithMerge = IfcAPI & {
   setMergeLayers?: (enabled: boolean) => void;
   setComputeGeometryHashes?: (tolerance?: number | null) => void;
   setTessellationQuality?: (level?: string | null) => void;
+  setSkipSmallCuts?: (on: boolean) => void;
 };
 
 export class IfcLiteBridge {
@@ -76,6 +77,14 @@ export class IfcLiteBridge {
    * pattern.
    */
   private tessellationQuality: TessellationQuality | null = null;
+  /**
+   * Tier-independent small-cut skip (#1286). When true, the WASM mesh pass drops
+   * tiny `IfcBooleanResult` detail cuts (steel copes/notches) WITHOUT lowering
+   * the tessellation tier, so curves keep full density. Cached here and forwarded
+   * to the IfcAPI on `init` + every `setSkipSmallCuts` call, mirroring the
+   * `mergeLayers` replay pattern. Default false ⇒ every cut runs.
+   */
+  private skipSmallCuts: boolean = false;
 
   private isWasmRuntimeError(error: unknown): boolean {
     return error instanceof WebAssembly.RuntimeError;
@@ -139,6 +148,8 @@ export class IfcLiteBridge {
       this.applyComputeGeometryHashes();
       // …and for the tessellation-quality level (issue #976).
       this.applyTessellationQuality();
+      // …and for the tier-independent small-cut skip (issue #1286).
+      this.applySkipSmallCuts();
       this.initialized = true;
       log.info('WASM geometry engine initialized');
     } catch (error) {
@@ -642,5 +653,43 @@ export class IfcLiteBridge {
     log.debug(`tessellationQuality=${this.tessellationQuality ?? 'default'}`, {
       operation: 'setTessellationQuality',
     });
+  }
+
+  /**
+   * Toggle the tier-independent small-cut skip (issue #1286). Safe to call
+   * before `init()` — the value is cached and re-applied on the freshly
+   * constructed IfcAPI. Applies to meshes produced AFTER the call.
+   */
+  setSkipSmallCuts(on: boolean): void {
+    this.skipSmallCuts = on;
+    if (!this.ifcApi) return; // init() will apply on the new IfcAPI
+    this.applySkipSmallCuts();
+  }
+
+  /** Read back the active small-cut skip flag. */
+  getSkipSmallCuts(): boolean {
+    return this.skipSmallCuts;
+  }
+
+  /**
+   * Forward the cached small-cut skip flag to the underlying IfcAPI. Guards
+   * against an older WASM build that predates the binding so the flag degrades
+   * to a no-op (every cut runs) rather than throwing — same defensive shape as
+   * `applyTessellationQuality`.
+   */
+  private applySkipSmallCuts(): void {
+    if (!this.ifcApi) return;
+    const api = this.ifcApi as IfcAPIWithMerge;
+    if (typeof api.setSkipSmallCuts !== 'function') {
+      if (this.skipSmallCuts) {
+        log.warn('setSkipSmallCuts not present on WASM API — flag ignored until WASM is rebuilt', {
+          operation: 'setSkipSmallCuts',
+          data: { requested: this.skipSmallCuts },
+        });
+      }
+      return;
+    }
+    api.setSkipSmallCuts(this.skipSmallCuts);
+    log.debug(`skipSmallCuts=${this.skipSmallCuts}`, { operation: 'setSkipSmallCuts' });
   }
 }

--- a/packages/geometry/src/index.ts
+++ b/packages/geometry/src/index.ts
@@ -118,6 +118,16 @@ export interface GeometryProcessorOptions {
    * and worker-pool); the native desktop path does not consume it yet.
    */
   tessellationQuality?: TessellationQuality;
+  /**
+   * Tier-independent small-cut skip (issue #1286). When true, the WASM mesh pass
+   * drops `IfcBooleanResult` differences whose cutter is tiny relative to its
+   * host (steel copes/notches, minor detail recesses) WITHOUT lowering the
+   * tessellation tier — so curves keep full density while the dominant
+   * boolean-heavy load cost is skipped. Default false ⇒ every cut runs
+   * (byte-identical to before). The viewer enables it for the on-screen load;
+   * exporters/drawings leave it off so their geometry stays full fidelity.
+   */
+  skipSmallCuts?: boolean;
 }
 
 let activeWasmStreamingOperation: string | null = null;
@@ -209,6 +219,7 @@ export class GeometryProcessor {
   private mergeLayers: boolean;
   private enableInstancing: boolean;
   private tessellationQuality: TessellationQuality | null;
+  private skipSmallCuts: boolean;
 
   constructor(options: GeometryProcessorOptions = {}) {
     this.bufferBuilder = new BufferBuilder();
@@ -217,6 +228,7 @@ export class GeometryProcessor {
     this.mergeLayers = options.mergeLayers === true;
     this.enableInstancing = options.enableInstancing !== false;
     this.tessellationQuality = options.tessellationQuality ?? null;
+    this.skipSmallCuts = options.skipSmallCuts === true;
     // Note: options accepted for API compatibility
     void options.quality;
 
@@ -229,6 +241,8 @@ export class GeometryProcessor {
       this.bridge.setMergeLayers(this.mergeLayers);
       // Same eager cache-and-replay for the tessellation level (#976).
       this.bridge.setTessellationQuality(this.tessellationQuality);
+      // …and the tier-independent small-cut skip (#1286).
+      this.bridge.setSkipSmallCuts(this.skipSmallCuts);
     }
   }
 
@@ -782,6 +796,10 @@ export class GeometryProcessor {
       // Issue #976: forward the tessellation level so every pool worker's
       // IfcAPI tessellates at the same density as the main-thread paths.
       tessellationQuality: this.tessellationQuality,
+      // Issue #1286: forward the small-cut skip so every pool worker drops the
+      // same tiny detail cuts as the main-thread paths. Forwarded every run, so
+      // an export processor (default false) never inherits a prior load's skip.
+      skipSmallCuts: this.skipSmallCuts,
       wasmUrls,
       workerCountOverride,
     });

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -332,6 +332,17 @@ export class IfcAPI {
    */
   setMergeLayers(enabled: boolean): void;
   /**
+   * Toggle the tier-independent small-cut skip (#1286). When `true`,
+   * `processGeometryBatch` drops `IfcBooleanResult` differences whose cutter is
+   * tiny relative to its host (steel copes/notches) while keeping the
+   * tessellation tier — so curves stay full-density. The viewer enables this for
+   * the on-screen load; exports/drawings leave it off so their geometry keeps
+   * every cut. Default off ⇒ byte-identical to before.
+   *
+   * Set BEFORE processing — meshes already emitted are not regenerated.
+   */
+  setSkipSmallCuts(on: boolean): void;
+  /**
    * Clear the cached entity index (call between loads when reusing
    * the same `IfcAPI` instance — e.g. the parser worker keeps one
    * `IfcAPI` alive across multiple `parse` requests).
@@ -1099,6 +1110,7 @@ export interface InitOutput {
   readonly ifcapi_setEntityIndex: (a: number, b: number, c: number, d: number, e: number, f: number, g: number) => void;
   readonly ifcapi_setMergeLayers: (a: number, b: number) => void;
   readonly ifcapi_setRectParamFastPath: (a: number, b: number) => void;
+  readonly ifcapi_setSkipSmallCuts: (a: number, b: number) => void;
   readonly ifcapi_setTessellationQuality: (a: number, b: number, c: number, d: number) => void;
   readonly ifcapi_version: (a: number, b: number) => void;
   readonly meshOutline2d: (a: number, b: number, c: number, d: number, e: number, f: number) => number;

--- a/rust/geometry/src/lib.rs
+++ b/rust/geometry/src/lib.rs
@@ -129,7 +129,7 @@ pub use material_layer_index::{LayerAxis, LayerBuildup, LayerInfo, MaterialLayer
 pub use mesh::{CoordinateShift, InstanceMeta, Mesh, SubMesh, SubMeshCollection};
 pub use mesh_orient::orient_mesh_outward;
 pub use processors::{
-    set_skip_small_cuts, AdvancedBrepProcessor, BooleanClippingProcessor, ExtrudedAreaSolidProcessor,
+    AdvancedBrepProcessor, BooleanClippingProcessor, ExtrudedAreaSolidProcessor,
     ExtrudedAreaSolidTaperedProcessor, FaceBasedSurfaceModelProcessor, FacetedBrepProcessor,
     build_texture_index, MappedItemProcessor, MeshTexture, PolygonalFaceSetProcessor,
     ResolvedTextureMap, RevolvedAreaSolidProcessor, SurfaceOfLinearExtrusionProcessor,

--- a/rust/geometry/src/lib.rs
+++ b/rust/geometry/src/lib.rs
@@ -129,7 +129,7 @@ pub use material_layer_index::{LayerAxis, LayerBuildup, LayerInfo, MaterialLayer
 pub use mesh::{CoordinateShift, InstanceMeta, Mesh, SubMesh, SubMeshCollection};
 pub use mesh_orient::orient_mesh_outward;
 pub use processors::{
-    AdvancedBrepProcessor, BooleanClippingProcessor, ExtrudedAreaSolidProcessor,
+    set_skip_small_cuts, AdvancedBrepProcessor, BooleanClippingProcessor, ExtrudedAreaSolidProcessor,
     ExtrudedAreaSolidTaperedProcessor, FaceBasedSurfaceModelProcessor, FacetedBrepProcessor,
     build_texture_index, MappedItemProcessor, MeshTexture, PolygonalFaceSetProcessor,
     ResolvedTextureMap, RevolvedAreaSolidProcessor, SurfaceOfLinearExtrusionProcessor,

--- a/rust/geometry/src/processors/boolean/mod.rs
+++ b/rust/geometry/src/processors/boolean/mod.rs
@@ -727,13 +727,19 @@ impl BooleanClippingProcessor {
                 self.record_failure(BoolOp::Difference, BoolFailureReason::EmptyOperand);
                 return Ok(mesh);
             }
-            // Preview-mode (Lowest/Low) small-cut skip: a cutter far smaller than
-            // its host (a steel cope/notch, a small detail recess) costs a full
-            // exact subtract — the dominant load-time cost on boolean-heavy steel —
-            // for a barely-visible change. In the preview tiers we drop it and
-            // render the host un-cut, recovering Manifold-class load times.
-            // Medium/High/Highest keep EVERY cut (byte-identical to before).
-            if quality_skips_small_cuts(quality) && cutter_below_skip_ratio(&mesh, &second_mesh) {
+            // Small-cut skip: a cutter far smaller than its host (a steel
+            // cope/notch, a small detail recess) costs a full exact subtract —
+            // the dominant load-time cost on boolean-heavy steel — for a
+            // barely-visible change. Dropping it renders the host un-cut and
+            // recovers Manifold-class load times. Enabled either by a preview
+            // tessellation tier (Lowest/Low) OR by the explicit `skip_small_cuts`
+            // flag, which the viewer turns on WITHOUT dropping to a preview tier
+            // so curves stay full-density while the tiny cuts are skipped (#1286).
+            // With neither set (the default), EVERY cut runs — byte-identical to
+            // before this optimization, on any tier.
+            if (quality_skips_small_cuts(quality) || skip_small_cuts_enabled())
+                && cutter_below_skip_ratio(&mesh, &second_mesh)
+            {
                 return Ok(mesh);
             }
             let clipper = ClippingProcessor::new();
@@ -784,6 +790,29 @@ impl BooleanClippingProcessor {
 /// geometry is byte-identical to before this optimization.
 fn quality_skips_small_cuts(quality: TessellationQuality) -> bool {
     matches!(quality, TessellationQuality::Lowest | TessellationQuality::Low)
+}
+
+/// Explicit, tier-independent small-cut skip switch. The viewer enables it for
+/// the on-screen load so tiny detail cuts (steel copes/notches) are skipped for
+/// fast first paint WHILE the tessellation tier stays at `Medium` — curves keep
+/// full density (decoupling the cut-skip from the curve LOD, #1286).
+///
+/// A process-wide flag mirroring [`fast_cut_skip_ratio`]: in wasm each worker is
+/// its own module instance so this is effectively per-worker, and the JS bridge
+/// sets it before every batch (exports/drawings leave it at the `false` default,
+/// so their geometry keeps every cut). Native callers (the server, tests) never
+/// set it, so native output is byte-identical to before. `Relaxed` is sufficient
+/// — the flag is set once before a batch, then only read.
+static SKIP_SMALL_CUTS: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Enable/disable the tier-independent small-cut skip (see [`SKIP_SMALL_CUTS`]).
+pub fn set_skip_small_cuts(on: bool) {
+    SKIP_SMALL_CUTS.store(on, std::sync::atomic::Ordering::Relaxed);
+}
+
+#[inline]
+fn skip_small_cuts_enabled() -> bool {
+    SKIP_SMALL_CUTS.load(std::sync::atomic::Ordering::Relaxed)
 }
 
 /// Skip ratio for preview-mode small-cut dropping: cutter max-dimension as a

--- a/rust/geometry/src/processors/boolean/mod.rs
+++ b/rust/geometry/src/processors/boolean/mod.rs
@@ -53,13 +53,32 @@ pub struct BooleanClippingProcessor {
     /// and drained from any internal `ClippingProcessor` instances. Drainable
     /// via [`Self::take_failures`].
     failures: RefCell<Vec<BoolFailure>>,
+    /// Per-build small-cut skip (#1286). When set, a solid-solid DIFFERENCE
+    /// whose cutter is far smaller than its host is dropped (host rendered
+    /// un-cut) even at a full tessellation tier. Scoped to this processor
+    /// instance — injected by the [`crate::router::GeometryRouter`] that
+    /// constructs it — so concurrent native builds never bleed the flag into
+    /// each other (was a process-wide static). `false` ⇒ every cut runs,
+    /// byte-identical to before the optimization.
+    skip_small_cuts: bool,
 }
 
 impl BooleanClippingProcessor {
     pub fn new() -> Self {
+        Self::with_skip_small_cuts(false)
+    }
+
+    /// Construct with the per-build small-cut skip set (see
+    /// [`Self::skip_small_cuts`]). The router injects the build's value here;
+    /// nested boolean operands reuse the same `self`, and the only cross-
+    /// processor boolean construction sites (`CsgSolidProcessor`,
+    /// `MappedItemProcessor`) forward their own field so a whole CSG tree shares
+    /// one scoped value.
+    pub fn with_skip_small_cuts(skip_small_cuts: bool) -> Self {
         Self {
             schema: IfcSchema::new(),
             failures: RefCell::new(Vec::new()),
+            skip_small_cuts,
         }
     }
 
@@ -141,9 +160,8 @@ impl BooleanClippingProcessor {
             IfcType::IfcBlock => {
                 BlockProcessor::new().process(operand, decoder, &self.schema, quality)
             }
-            IfcType::IfcCsgSolid => {
-                CsgSolidProcessor::new().process(operand, decoder, &self.schema, quality)
-            }
+            IfcType::IfcCsgSolid => CsgSolidProcessor::with_skip_small_cuts(self.skip_small_cuts)
+                .process(operand, decoder, &self.schema, quality),
             IfcType::IfcBooleanResult | IfcType::IfcBooleanClippingResult => {
                 // Recursive case with depth tracking
                 self.process_with_depth(operand, decoder, &self.schema, depth + 1, quality)
@@ -732,12 +750,14 @@ impl BooleanClippingProcessor {
             // the dominant load-time cost on boolean-heavy steel — for a
             // barely-visible change. Dropping it renders the host un-cut and
             // recovers Manifold-class load times. Enabled either by a preview
-            // tessellation tier (Lowest/Low) OR by the explicit `skip_small_cuts`
-            // flag, which the viewer turns on WITHOUT dropping to a preview tier
+            // tessellation tier (Lowest/Low) OR by the per-build `skip_small_cuts`
+            // field, which the viewer turns on WITHOUT dropping to a preview tier
             // so curves stay full-density while the tiny cuts are skipped (#1286).
-            // With neither set (the default), EVERY cut runs — byte-identical to
+            // The field is scoped to this processor (injected by the router), so
+            // concurrent native builds never bleed it into one another. With
+            // neither set (the default), EVERY cut runs — byte-identical to
             // before this optimization, on any tier.
-            if (quality_skips_small_cuts(quality) || skip_small_cuts_enabled())
+            if (quality_skips_small_cuts(quality) || self.skip_small_cuts)
                 && cutter_below_skip_ratio(&mesh, &second_mesh)
             {
                 return Ok(mesh);
@@ -790,29 +810,6 @@ impl BooleanClippingProcessor {
 /// geometry is byte-identical to before this optimization.
 fn quality_skips_small_cuts(quality: TessellationQuality) -> bool {
     matches!(quality, TessellationQuality::Lowest | TessellationQuality::Low)
-}
-
-/// Explicit, tier-independent small-cut skip switch. The viewer enables it for
-/// the on-screen load so tiny detail cuts (steel copes/notches) are skipped for
-/// fast first paint WHILE the tessellation tier stays at `Medium` — curves keep
-/// full density (decoupling the cut-skip from the curve LOD, #1286).
-///
-/// A process-wide flag mirroring [`fast_cut_skip_ratio`]: in wasm each worker is
-/// its own module instance so this is effectively per-worker, and the JS bridge
-/// sets it before every batch (exports/drawings leave it at the `false` default,
-/// so their geometry keeps every cut). Native callers (the server, tests) never
-/// set it, so native output is byte-identical to before. `Relaxed` is sufficient
-/// — the flag is set once before a batch, then only read.
-static SKIP_SMALL_CUTS: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
-
-/// Enable/disable the tier-independent small-cut skip (see [`SKIP_SMALL_CUTS`]).
-pub fn set_skip_small_cuts(on: bool) {
-    SKIP_SMALL_CUTS.store(on, std::sync::atomic::Ordering::Relaxed);
-}
-
-#[inline]
-fn skip_small_cuts_enabled() -> bool {
-    SKIP_SMALL_CUTS.load(std::sync::atomic::Ordering::Relaxed)
 }
 
 /// Skip ratio for preview-mode small-cut dropping: cutter max-dimension as a

--- a/rust/geometry/src/processors/csg_primitive.rs
+++ b/rust/geometry/src/processors/csg_primitive.rs
@@ -96,11 +96,22 @@ impl GeometryProcessor for BlockProcessor {
 /// `IfcBooleanClippingResult` or an `IfcCsgPrimitive3D`. This processor
 /// resolves the reference and dispatches it to the matching leaf processor,
 /// so callers don't need to know that the geometry was wrapped.
-pub struct CsgSolidProcessor;
+pub struct CsgSolidProcessor {
+    /// Per-build small-cut skip, forwarded to the nested
+    /// [`BooleanClippingProcessor`] this wraps so a CSG tree shares one scoped
+    /// value (see `BooleanClippingProcessor::skip_small_cuts`).
+    skip_small_cuts: bool,
+}
 
 impl CsgSolidProcessor {
     pub fn new() -> Self {
-        Self
+        Self::with_skip_small_cuts(false)
+    }
+
+    /// Construct with the per-build small-cut skip forwarded to the boolean
+    /// processor at the root of the wrapped CSG tree.
+    pub fn with_skip_small_cuts(skip_small_cuts: bool) -> Self {
+        Self { skip_small_cuts }
     }
 }
 
@@ -132,7 +143,8 @@ impl GeometryProcessor for CsgSolidProcessor {
         // unbounded recursion.
         match root.ifc_type {
             IfcType::IfcBooleanResult | IfcType::IfcBooleanClippingResult => {
-                BooleanClippingProcessor::new().process(&root, decoder, schema, quality)
+                BooleanClippingProcessor::with_skip_small_cuts(self.skip_small_cuts)
+                    .process(&root, decoder, schema, quality)
             }
             IfcType::IfcBlock => BlockProcessor::new().process(&root, decoder, schema, quality),
             IfcType::IfcSphere => SphereProcessor::new().process(&root, decoder, schema, quality),

--- a/rust/geometry/src/processors/mapped.rs
+++ b/rust/geometry/src/processors/mapped.rs
@@ -17,11 +17,23 @@ use crate::router::GeometryProcessor;
 
 /// MappedItem processor (P0)
 /// Handles IfcMappedItem - geometry instancing
-pub struct MappedItemProcessor;
+pub struct MappedItemProcessor {
+    /// Per-build small-cut skip, forwarded to the transient
+    /// [`BooleanClippingProcessor`] this constructs for mapped boolean items so
+    /// the scoped value follows the CSG tree (see
+    /// `BooleanClippingProcessor::skip_small_cuts`).
+    skip_small_cuts: bool,
+}
 
 impl MappedItemProcessor {
     pub fn new() -> Self {
-        Self
+        Self::with_skip_small_cuts(false)
+    }
+
+    /// Construct with the per-build small-cut skip forwarded to the boolean
+    /// processor used for mapped boolean items.
+    pub fn with_skip_small_cuts(skip_small_cuts: bool) -> Self {
+        Self { skip_small_cuts }
     }
 }
 
@@ -95,7 +107,8 @@ impl GeometryProcessor for MappedItemProcessor {
                     // can surface failures from `IfcMappedItem` -> boolean
                     // chains in `take_csg_failures`. Without this drain the
                     // processor's failures vanish when it goes out of scope.
-                    let processor = BooleanClippingProcessor::new();
+                    let processor =
+                        BooleanClippingProcessor::with_skip_small_cuts(self.skip_small_cuts);
                     let mesh = processor.process(&item, decoder, schema, quality)?;
                     crate::diagnostics::push_pending_mapped_bool_failures(
                         processor.take_failures(),

--- a/rust/geometry/src/processors/mod.rs
+++ b/rust/geometry/src/processors/mod.rs
@@ -40,7 +40,7 @@ mod tests;
 // Re-export all processor types
 pub use advanced::{AdvancedBrepProcessor, BSplineSurfaceProcessor};
 pub use alignment::IfcAlignmentProcessor;
-pub use boolean::BooleanClippingProcessor;
+pub use boolean::{set_skip_small_cuts, BooleanClippingProcessor};
 pub use brep::{
     FaceBasedSurfaceModelProcessor, FacetedBrepProcessor, ShellBasedSurfaceModelProcessor,
 };

--- a/rust/geometry/src/processors/mod.rs
+++ b/rust/geometry/src/processors/mod.rs
@@ -40,7 +40,7 @@ mod tests;
 // Re-export all processor types
 pub use advanced::{AdvancedBrepProcessor, BSplineSurfaceProcessor};
 pub use alignment::IfcAlignmentProcessor;
-pub use boolean::{set_skip_small_cuts, BooleanClippingProcessor};
+pub use boolean::BooleanClippingProcessor;
 pub use brep::{
     FaceBasedSurfaceModelProcessor, FacetedBrepProcessor, ShellBasedSurfaceModelProcessor,
 };

--- a/rust/geometry/src/router/mod.rs
+++ b/rust/geometry/src/router/mod.rs
@@ -144,6 +144,13 @@ pub struct GeometryRouter {
     /// every processor's `process`. Defaults to [`TessellationQuality::Medium`]
     /// (historical hardcoded behavior).
     tessellation_quality: TessellationQuality,
+    /// Per-build small-cut skip (#1286). Injected into the boolean / CSG /
+    /// mapped processors at construction so a solid-solid DIFFERENCE with a tiny
+    /// cutter can be dropped without forcing a preview tessellation tier. Scoped
+    /// to this router (one per loaded build) so concurrent native builds never
+    /// bleed the flag into one another — it used to be a process-wide static.
+    /// `false` (default) ⇒ every cut runs, byte-identical to before.
+    skip_small_cuts: bool,
 }
 
 impl GeometryRouter {
@@ -167,6 +174,7 @@ impl GeometryRouter {
             layer_slice_diag: RefCell::new(Vec::new()),
             voids_consumed_hosts: RefCell::new(FxHashSet::default()),
             tessellation_quality: TessellationQuality::Medium,
+            skip_small_cuts: false,
         };
 
         // Register default P0 processors
@@ -381,6 +389,45 @@ impl GeometryRouter {
     #[inline]
     pub fn tessellation_quality(&self) -> TessellationQuality {
         self.tessellation_quality
+    }
+
+    /// Set the per-build small-cut skip (#1286) and re-register the boolean /
+    /// CSG / mapped processors so they carry it. Tier-independent: the viewer
+    /// turns this on to skip tiny steel copes/notches for fast first paint while
+    /// the tessellation tier stays at `Medium` (curves keep full density).
+    ///
+    /// Scoped to this router instance, so a concurrent native build with the
+    /// skip off is unaffected (this replaced a process-wide static that bled
+    /// across builds). `false` (default) keeps every cut, byte-identical to
+    /// before the optimization.
+    pub fn set_skip_small_cuts(&mut self, on: bool) {
+        if self.skip_small_cuts == on {
+            return;
+        }
+        self.skip_small_cuts = on;
+        self.register_skip_dependent_processors();
+    }
+
+    /// Get the current per-build small-cut skip flag.
+    #[inline]
+    pub fn skip_small_cuts(&self) -> bool {
+        self.skip_small_cuts
+    }
+
+    /// (Re)register the processors whose behavior depends on `skip_small_cuts`
+    /// so they pick up the current value. Called at construction and whenever
+    /// [`Self::set_skip_small_cuts`] flips the flag; `register` overwrites the
+    /// existing map entries keyed by IFC type.
+    fn register_skip_dependent_processors(&mut self) {
+        self.register(Box::new(MappedItemProcessor::with_skip_small_cuts(
+            self.skip_small_cuts,
+        )));
+        self.register(Box::new(BooleanClippingProcessor::with_skip_small_cuts(
+            self.skip_small_cuts,
+        )));
+        self.register(Box::new(CsgSolidProcessor::with_skip_small_cuts(
+            self.skip_small_cuts,
+        )));
     }
 
     /// Set the RTC offset for large coordinate handling

--- a/rust/wasm-bindings/src/api/gpu_meshes/batch.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/batch.rs
@@ -108,6 +108,13 @@ impl IfcAPI {
             .unwrap_or_else(|| self.get_or_resolve_plane_angle(&mut decoder));
         decoder.seed_unit_scales(unit_scale, plane_angle_to_radians);
 
+        // Apply the consumer-selected small-cut skip (#1286) for this batch.
+        // Independent of the tessellation tier so the viewer can skip tiny steel
+        // cuts while keeping full-density curves. Set every batch (default off)
+        // so an export's batch, which never enables it, keeps every cut even if a
+        // prior display batch in the same worker turned it on.
+        ifc_lite_geometry::set_skip_small_cuts(self.skip_small_cuts());
+
         // Create geometry router with unit scale and the consumer-selected
         // tessellation quality (issue #976) — Medium unless JS called
         // `setTessellationQuality`, so default output is byte-for-byte

--- a/rust/wasm-bindings/src/api/gpu_meshes/batch.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/batch.rs
@@ -108,19 +108,19 @@ impl IfcAPI {
             .unwrap_or_else(|| self.get_or_resolve_plane_angle(&mut decoder));
         decoder.seed_unit_scales(unit_scale, plane_angle_to_radians);
 
-        // Apply the consumer-selected small-cut skip (#1286) for this batch.
-        // Independent of the tessellation tier so the viewer can skip tiny steel
-        // cuts while keeping full-density curves. Set every batch (default off)
-        // so an export's batch, which never enables it, keeps every cut even if a
-        // prior display batch in the same worker turned it on.
-        ifc_lite_geometry::set_skip_small_cuts(self.skip_small_cuts());
-
         // Create geometry router with unit scale and the consumer-selected
         // tessellation quality (issue #976) — Medium unless JS called
         // `setTessellationQuality`, so default output is byte-for-byte
         // identical to the pre-quality pipeline.
         let mut router =
             GeometryRouter::with_scale_and_quality(unit_scale, self.tessellation_quality());
+
+        // Apply the consumer-selected small-cut skip (#1286) for this batch.
+        // Independent of the tessellation tier so the viewer can skip tiny steel
+        // cuts while keeping full-density curves. Scoped to this router (not a
+        // process-wide flag), so an export's router, which never enables it,
+        // keeps every cut regardless of a concurrent display build.
+        router.set_skip_small_cuts(self.skip_small_cuts());
 
         // Arm content-dedup against the per-worker shared cache so byte-identical
         // geometry (e.g. Tekla parts the exporter failed to share via

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -160,6 +160,13 @@ pub struct IfcAPI {
     /// which reproduces the historical hardcoded densities byte-for-byte.
     tessellation_quality: std::sync::atomic::AtomicU8,
 
+    /// Tier-independent small-cut skip switch (#1286). When set, `processGeometryBatch`
+    /// drops `IfcBooleanResult` differences whose cutter is tiny relative to its host
+    /// (steel copes/notches) WITHOUT lowering the tessellation tier, so curves keep
+    /// full density. Default off ⇒ every cut runs (byte-identical to before). Applied
+    /// to the geometry crate's flag at the top of each batch via `set_skip_small_cuts`.
+    skip_small_cuts: std::sync::atomic::AtomicBool,
+
     /// Lazily-resolved plane-angle → radians scale for the current content,
     /// seeded into every batch decoder via `EntityDecoder::seed_unit_scales`.
     /// `EntityDecoder::plane_angle_to_radians()` walks the whole DATA section
@@ -216,6 +223,7 @@ impl IfcAPI {
                 ifc_lite_geometry::DEFAULT_GEOM_HASH_TOLERANCE.to_bits(),
             ),
             tessellation_quality: std::sync::atomic::AtomicU8::new(TESSELLATION_QUALITY_MEDIUM),
+            skip_small_cuts: std::sync::atomic::AtomicBool::new(false),
             cached_plane_angle_to_radians: std::sync::Mutex::new(None),
             cached_geometry_styles: std::sync::Mutex::new(None),
         }
@@ -491,6 +499,20 @@ impl IfcAPI {
             .store(discriminant, std::sync::atomic::Ordering::Relaxed);
         Ok(())
     }
+
+    /// Toggle the tier-independent small-cut skip (#1286). When `true`,
+    /// `processGeometryBatch` drops `IfcBooleanResult` differences whose cutter is
+    /// tiny relative to its host (steel copes/notches) while keeping the
+    /// tessellation tier — so curves stay full-density. The viewer enables this for
+    /// the on-screen load; exports/drawings leave it off so their geometry keeps
+    /// every cut. Default off ⇒ byte-identical to before.
+    ///
+    /// Set BEFORE processing — meshes already emitted are not regenerated.
+    #[wasm_bindgen(js_name = setSkipSmallCuts)]
+    pub fn set_skip_small_cuts(&self, on: bool) {
+        self.skip_small_cuts
+            .store(on, std::sync::atomic::Ordering::Relaxed);
+    }
 }
 
 impl IfcAPI {
@@ -512,6 +534,13 @@ impl IfcAPI {
         {
             idx => TessellationQuality::from_index(idx),
         }
+    }
+
+    /// Active small-cut skip flag, applied to the geometry crate's switch at the
+    /// top of `processGeometryBatch`. JS controls it via [`Self::set_skip_small_cuts`].
+    pub(crate) fn skip_small_cuts(&self) -> bool {
+        self.skip_small_cuts
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Active geometry-hash tolerance (metres), or `None` when fingerprinting

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -164,7 +164,7 @@ pub struct IfcAPI {
     /// drops `IfcBooleanResult` differences whose cutter is tiny relative to its host
     /// (steel copes/notches) WITHOUT lowering the tessellation tier, so curves keep
     /// full density. Default off ⇒ every cut runs (byte-identical to before). Applied
-    /// to the geometry crate's flag at the top of each batch via `set_skip_small_cuts`.
+    /// to the per-batch `GeometryRouter` via `GeometryRouter::set_skip_small_cuts`.
     skip_small_cuts: std::sync::atomic::AtomicBool,
 
     /// Lazily-resolved plane-angle → radians scale for the current content,
@@ -536,8 +536,8 @@ impl IfcAPI {
         }
     }
 
-    /// Active small-cut skip flag, applied to the geometry crate's switch at the
-    /// top of `processGeometryBatch`. JS controls it via [`Self::set_skip_small_cuts`].
+    /// Active small-cut skip flag, applied to the per-batch `GeometryRouter` at
+    /// the top of `processGeometryBatch`. JS controls it via [`Self::set_skip_small_cuts`].
     pub(crate) fn skip_small_cuts(&self) -> bool {
         self.skip_small_cuts
             .load(std::sync::atomic::Ordering::Relaxed)


### PR DESCRIPTION
Stacked on #1295. Merge after it.

## What

#1295 ties the small-cut skip to the preview tessellation tiers (`Lowest`/`Low`), so using it means accepting coarser curves. This PR makes the skip an **explicit flag, independent of the tier**, and turns it on for the viewer's on-screen load at **Medium** — so the steel speedup lands **with full-density curves**.

- New `skipSmallCuts` option on `GeometryProcessor` + a `IfcAPI.setSkipSmallCuts` WASM binding.
- The #1286 gate becomes `(preview tier OR skip flag) && cutter-below-ratio` — **additive**, so the default (neither set) is byte-identical to before on every tier.
- The viewer's streaming load runs Medium + `skipSmallCuts: true`; exports / drawings / annotations build their own processor with the flag off, so their geometry keeps every cut.
- The flag is plumbed through the geometry pipeline (bridge / `GeometryProcessor` / worker pool) exactly like `tessellationQuality`, and re-sent each run so a reused worker resets to the default for a later export.
- The geometry cache key folds the flag (`-sc`) so a skipped display cache is never served where a full-fidelity build is expected.

## Why decouple

The tessellation tier bundles two independent things: curve density and (since #1295) whether tiny cuts are skipped. The viewer wants the second without the first. Decoupling is deterministic — an explicit, cache-keyed flag; native and WASM both honor it.

## Numbers (WASM, single-thread)

Same model corpus as #1295, comparing **Medium full-cut vs Medium + skip** (curves at full density in both):

| model | Medium full | Medium + skip | speedup | tri drop |
|---|---|---|---|---|
| boolean-heavy steel | 25.3s | 6.6s | ~3.8x | 15.8% |
| architectural | 10.7s | 10.7s | 1.00x | 0.0% |
| structural | 3.2s | 3.2s | 1.00x | 0.0% |

Steel reaches Manifold-class first paint with curves untouched; arch/structural are unchanged (their openings are larger than the ratio, and curves stay at Medium). It is lower than #1295's Low-tier number because steel connection geometry (bolts/holes/washers) stays at full density here, which is the point.

## Verification

- `skip-off` (default everywhere except the viewer load) is **byte-identical** — the full Rust geometry suite passes (wall-opening regression 7/7, snapshots match), and the WASM Medium-full tri count matches the pre-change baseline.
- Viewer typecheck clean; geometry package builds; cache-key unit test extended (8/8).

## Changeset

`@ifc-lite/geometry` + `@ifc-lite/wasm` minor (new public option + WASM binding).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option that speeds up on-screen loading for complex models by skipping tiny cut details during streaming.
  * Large models can now automatically use lighter tessellation levels, with a URL override for manual control.

* **Bug Fixes**
  * Geometry caches now account for the new load settings, preventing incorrect reuse across different quality modes.
  * Export and drawing outputs continue to preserve full detail by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->