### PR TITLE
fix(viewer): preserve case + dots in export filenames, and unify all exports (#1299)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,5 +49,9 @@ Project-specific gotchas and guardrails — the things that bite you *here* and 
 ## CLI
 - Discover the full SDK API with `ifc-lite schema` (JSON). `eval` runs SDK expressions (`ifc-lite eval model.ifc "bim.query().byType('IfcWall').count()"`); always pass `--json` for machine output. `HeadlessBackend` (`packages/cli/src/headless-backend.ts`) runs query/export/create/IDS/BCF without a renderer.
 
+## Browser exports (viewer)
+- One way to save a file: `apps/viewer/src/lib/export/download.ts`. Use `downloadBlob` / `downloadFile` / `downloadDataUrl` — never hand-roll an `<a download>` + `URL.createObjectURL` dance, and never write another filename regex. `downloadFile` already copies the wasm `Uint8Array<ArrayBufferLike>` into a `BlobPart`.
+- Run every user/model-derived filename through `sanitizeFilename` (preserves case + dots, strips only OS-unsafe chars — see #1299). It is *not* a slug; don't lowercase or hyphenate names for filenames. Slugs (extension IDs) are a separate concern.
+
 ## New source files
 - MPL-2.0 header on every new file — see [`./LICENSE_HEADER.md`](./LICENSE_HEADER.md).

--- a/apps/viewer/src/components/extensions/AuditLogPanel.tsx
+++ b/apps/viewer/src/components/extensions/AuditLogPanel.tsx
@@ -26,6 +26,7 @@ import type { AuditEvent, AuditEventKind } from '@ifc-lite/extensions';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { useExtensionHost } from '@/sdk/ExtensionHostProvider';
+import { downloadFile } from '@/lib/export/download';
 import { toast } from '@/components/ui/toast';
 import { HelpHint } from './HelpHint';
 
@@ -96,13 +97,7 @@ export function AuditLogPanel({ extensionId, onClose }: AuditLogPanelProps) {
 
   const handleExport = () => {
     const json = host.audit.exportJson();
-    const blob = new Blob([json], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `ifclite-audit-${new Date().toISOString().slice(0, 10)}.json`;
-    a.click();
-    URL.revokeObjectURL(url);
+    downloadFile(json, `ifclite-audit-${new Date().toISOString().slice(0, 10)}.json`, 'application/json');
     toast.success('Audit log exported.');
   };
 

--- a/apps/viewer/src/components/extensions/FlavorDialog.tsx
+++ b/apps/viewer/src/components/extensions/FlavorDialog.tsx
@@ -22,6 +22,7 @@ import type { Flavor, UnpackedFlavor } from '@ifc-lite/extensions';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { useExtensionHost } from '@/sdk/ExtensionHostProvider';
 import { toast } from '@/components/ui/toast';
+import { downloadFile } from '@/lib/export/download';
 import { FlavorMergeDialog } from './FlavorMergeDialog';
 import { FlavorListView } from './FlavorListView';
 import { FlavorImportPreview } from './FlavorImportPreview';
@@ -94,19 +95,9 @@ export function FlavorDialog({ open, onClose }: FlavorDialogProps) {
     setBusy(true);
     try {
       const bytes = await host.flavors.exportFlavor(id);
-      // Copy into a fresh ArrayBuffer so DOM Blob typings accept it —
-      // Uint8Array<ArrayBufferLike> isn't a BlobPart in strict
-      // TS lib.dom, and `.slice()` on the underlying buffer may
-      // return SharedArrayBuffer.
-      const buffer = new ArrayBuffer(bytes.byteLength);
-      new Uint8Array(buffer).set(bytes);
-      const blob = new Blob([buffer], { type: 'application/octet-stream' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `${id || 'flavor'}.iflv`;
-      a.click();
-      URL.revokeObjectURL(url);
+      // downloadFile copies the (possibly ArrayBufferLike / Shared) bytes into a
+      // fresh ArrayBuffer-backed view, so DOM Blob typings accept them.
+      downloadFile(bytes, `${id || 'flavor'}.iflv`, 'application/octet-stream');
       toast.success(toastText.flavorExported(`${id}.iflv`));
     } catch (err) {
       toast.error(toastText.failed('Export', err));

--- a/apps/viewer/src/components/extensions/PrivacyPanel.tsx
+++ b/apps/viewer/src/components/extensions/PrivacyPanel.tsx
@@ -29,6 +29,7 @@ import {
   type TranscriptTurn,
 } from '@ifc-lite/extensions';
 import { useViewerStore } from '@/store';
+import { downloadFile } from '@/lib/export/download';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { useExtensionHost } from '@/sdk/ExtensionHostProvider';
@@ -83,13 +84,7 @@ export function PrivacyPanel({ onClose }: PrivacyPanelProps) {
 
   const handleExportLog = () => {
     const json = host.actionLog.exportJson();
-    const blob = new Blob([json], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `ifclite-action-log-${new Date().toISOString().slice(0, 10)}.json`;
-    a.click();
-    URL.revokeObjectURL(url);
+    downloadFile(json, `ifclite-action-log-${new Date().toISOString().slice(0, 10)}.json`, 'application/json');
     toast.success('Action log exported.');
   };
 

--- a/apps/viewer/src/components/mcp/playground-dispatcher.ts
+++ b/apps/viewer/src/components/mcp/playground-dispatcher.ts
@@ -71,6 +71,7 @@ import type { CatalogTool } from './types';
 import type { ViewerController, ColorTuple } from './PlaygroundViewer';
 import { playgroundFiles } from './playground-files';
 import { playgroundUploads } from './playground-uploads';
+import { sanitizeFilename } from '../../lib/export/download';
 
 // ── loaded-model handle ────────────────────────────────────────────────────
 
@@ -1634,8 +1635,7 @@ function coerceFilename(
   if (!base) base = fallbackBase;
   // Drop any extension already on it (incl. multi-dot like .bcf.zip).
   base = base.replace(/\.(ifc|ifczip|bcfzip|bcf|zip|csv|json|tsv|xml|ids|gltf|glb|ifcx|pdf)$/i, '');
-  base = base.replace(/[^\w.\-]+/g, '_'); // sanitize for OS download
-  if (!base) base = fallbackBase;
+  base = sanitizeFilename(base, { fallback: fallbackBase }); // shared OS-safe sanitiser
   return `${base}.${ext}`;
 }
 

--- a/apps/viewer/src/components/mcp/playground-files.ts
+++ b/apps/viewer/src/components/mcp/playground-files.ts
@@ -14,6 +14,7 @@
  * happens when the user presses that button.
  */
 import { useEffect, useState } from 'react';
+import { downloadBlob } from '../../lib/export/download';
 
 export interface PlaygroundFile {
   /** Stable id used by tools to refer back to a written artifact. */
@@ -101,16 +102,8 @@ class FileStore {
   download(id: string): void {
     const file = this.files.find((f) => f.id === id);
     if (!file) return;
-    const url = URL.createObjectURL(file.blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = file.filename;
-    a.style.display = 'none';
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
-    // Revoke after a tick so the browser actually fetched the blob.
-    setTimeout(() => URL.revokeObjectURL(url), 1000);
+    // file.filename is already coerced (extension-forced, OS-safe) at creation.
+    downloadBlob(file.blob, file.filename);
   }
 
   subscribe(listener: () => void): () => void {

--- a/apps/viewer/src/components/viewer/BCFPanel.tsx
+++ b/apps/viewer/src/components/viewer/BCFPanel.tsx
@@ -40,6 +40,7 @@ import { BCFTopicList } from './bcf/BCFTopicList';
 import { BCFTopicDetail } from './bcf/BCFTopicDetail';
 import { BCFCreateTopicForm } from './bcf/BCFCreateTopicForm';
 import { openGenericFileDialog } from '@/services/file-dialog';
+import { downloadBlob, sanitizeFilename } from '@/lib/export/download';
 
 // ============================================================================
 // Main BCF Panel Component
@@ -190,16 +191,9 @@ export function BCFPanel({ onClose }: BCFPanelProps) {
     try {
       setBcfLoading(true);
       const blob = await writeBCF(bcfProject);
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
       // Use project name, or generate from model name, or date-based fallback
-      const fileName = bcfProject.name || getDefaultProjectName();
-      a.download = `${fileName}.bcfzip`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
+      const fileName = sanitizeFilename(bcfProject.name || getDefaultProjectName(), { fallback: 'issues' });
+      downloadBlob(blob, `${fileName}.bcfzip`);
       posthog.capture('bcf_exported', { topic_count: bcfProject.topics.size });
     } catch (error) {
       console.error('Failed to export BCF:', error);

--- a/apps/viewer/src/components/viewer/CommandPalette.tsx
+++ b/apps/viewer/src/components/viewer/CommandPalette.tsx
@@ -91,6 +91,7 @@ import { toast as paletteToast } from '@/components/ui/toast';
 import { SCRIPT_TEMPLATES } from '@/lib/scripts/templates';
 import { exportGlbFromGeometry } from '@/lib/export/glb';
 import { exportCsvFromBytes } from '@/lib/export/csv';
+import { downloadFile } from '@/lib/export/download';
 import { getRecentFiles, formatFileSize, getCachedFile } from '@/lib/recent-files';
 import type { RecentFileEntry } from '@/lib/recent-files';
 import { closeActiveAnalysisExtension } from '@/services/analysis-extensions';
@@ -195,18 +196,6 @@ function recordUsage(id: string) {
     r.unshift(id);
     localStorage.setItem(RECENT_KEY, JSON.stringify(r.slice(0, 30)));
   } catch { /* noop */ }
-}
-
-// ── Utilities ──────────────────────────────────────────────────────────
-
-function downloadBlob(data: BlobPart | Uint8Array, name: string, mime: string) {
-  // The Rust/wasm exporters return `Uint8Array<ArrayBufferLike>`, which TS 5.7
-  // no longer treats as a `BlobPart`. Copy into a fresh ArrayBuffer-backed view
-  // (same coercion as GLBExportDialog) so the Blob constructor accepts it.
-  const part: BlobPart = data instanceof Uint8Array ? new Uint8Array(data) : data;
-  const url = URL.createObjectURL(new Blob([part], { type: mime }));
-  Object.assign(document.createElement('a'), { href: url, download: name }).click();
-  URL.revokeObjectURL(url);
 }
 
 /** Toggle a sidebar workspace panel (#1208). The store's `toggleWorkspacePanel`
@@ -508,24 +497,24 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
       { id: 'export:glb', label: 'Export GLB', keywords: '3d model gltf download', category: 'Export', icon: Download,
         action: async () => {
           const gr = useViewerStore.getState().geometryResult; if (!gr) return;
-          try { downloadBlob(await exportGlbFromGeometry(gr, { includeMetadata: true }), 'model.glb', 'model/gltf-binary'); }
+          try { downloadFile(await exportGlbFromGeometry(gr, { includeMetadata: true }), 'model.glb', 'model/gltf-binary'); }
           catch (e) { console.error('GLB export failed:', e); }
         } },
       { id: 'export:csv-entities', label: 'Export CSV: Entities', keywords: 'spreadsheet properties download', category: 'Export', icon: FileSpreadsheet,
-        action: async () => { const d = useViewerStore.getState().ifcDataStore; if (!d?.source) return; try { downloadBlob(await exportCsvFromBytes(d.source, 'entities', { includeProperties: true }), 'entities.csv', 'text/csv'); } catch (e) { console.error(e); } } },
+        action: async () => { const d = useViewerStore.getState().ifcDataStore; if (!d?.source) return; try { downloadFile(await exportCsvFromBytes(d.source, 'entities', { includeProperties: true }), 'entities.csv', 'text/csv'); } catch (e) { console.error(e); } } },
       { id: 'export:csv-properties', label: 'Export CSV: Properties', keywords: 'pset spreadsheet download', category: 'Export', icon: FileSpreadsheet,
-        action: async () => { const d = useViewerStore.getState().ifcDataStore; if (!d?.source) return; try { downloadBlob(await exportCsvFromBytes(d.source, 'properties'), 'properties.csv', 'text/csv'); } catch (e) { console.error(e); } } },
+        action: async () => { const d = useViewerStore.getState().ifcDataStore; if (!d?.source) return; try { downloadFile(await exportCsvFromBytes(d.source, 'properties'), 'properties.csv', 'text/csv'); } catch (e) { console.error(e); } } },
       { id: 'export:csv-quantities', label: 'Export CSV: Quantities', keywords: 'qto spreadsheet download', category: 'Export', icon: FileSpreadsheet,
-        action: async () => { const d = useViewerStore.getState().ifcDataStore; if (!d?.source) return; try { downloadBlob(await exportCsvFromBytes(d.source, 'quantities'), 'quantities.csv', 'text/csv'); } catch (e) { console.error(e); } } },
+        action: async () => { const d = useViewerStore.getState().ifcDataStore; if (!d?.source) return; try { downloadFile(await exportCsvFromBytes(d.source, 'quantities'), 'quantities.csv', 'text/csv'); } catch (e) { console.error(e); } } },
       { id: 'export:csv-spatial', label: 'Export CSV: Spatial', keywords: 'hierarchy spreadsheet download', category: 'Export', icon: FileSpreadsheet,
-        action: async () => { const d = useViewerStore.getState().ifcDataStore; if (!d?.source) return; try { downloadBlob(await exportCsvFromBytes(d.source, 'spatial'), 'spatial-hierarchy.csv', 'text/csv'); } catch (e) { console.error(e); } } },
+        action: async () => { const d = useViewerStore.getState().ifcDataStore; if (!d?.source) return; try { downloadFile(await exportCsvFromBytes(d.source, 'spatial'), 'spatial-hierarchy.csv', 'text/csv'); } catch (e) { console.error(e); } } },
       { id: 'export:json', label: 'Export JSON', keywords: 'data entities all download', category: 'Export', icon: FileJson,
         action: () => {
           const d = useViewerStore.getState().ifcDataStore; if (!d) return;
           try {
             const out: Record<string, unknown>[] = [];
             for (let i = 0; i < d.entities.count; i++) { const id = d.entities.expressId[i]; out.push({ expressId: id, globalId: d.entities.getGlobalId(id), name: d.entities.getName(id), type: d.entities.getTypeName(id), properties: d.properties.getForEntity(id) }); }
-            downloadBlob(JSON.stringify({ entities: out }, null, 2), 'model-data.json', 'application/json');
+            downloadFile(JSON.stringify({ entities: out }, null, 2), 'model-data.json', 'application/json');
           } catch (e) { console.error(e); }
         } },
     );

--- a/apps/viewer/src/components/viewer/ExportChangesButton.tsx
+++ b/apps/viewer/src/components/viewer/ExportChangesButton.tsx
@@ -20,19 +20,13 @@ import type { IfcDataStore } from '@ifc-lite/parser';
 import { toast } from '@/components/ui/toast';
 import { ensureModelExportReady } from '@/services/desktop-export';
 import { spliceScheduleIntoExport } from '@/sdk/adapters/export-schedule-splice';
-import { downloadBlob, sanitizeFilename } from '@/lib/export/download';
+import { downloadFile, sanitizeFilename } from '@/lib/export/download';
 
 interface ExportChangesButtonProps {
   /** Optional custom class name */
   className?: string;
 }
 
-function toBlobPart(content: string | Uint8Array): BlobPart {
-  if (typeof content === 'string') return content;
-  const bytes = new Uint8Array(content.byteLength);
-  bytes.set(content);
-  return bytes;
-}
 
 export function ExportChangesButton({ className }: ExportChangesButtonProps) {
   const models = useViewerStore((s) => s.models);
@@ -170,7 +164,7 @@ export function ExportChangesButton({ className }: ExportChangesButtonProps) {
       });
 
       // Download the file
-      downloadBlob(new Blob([toBlobPart(spliced.content)], { type: 'text/plain' }), generateFilename());
+      downloadFile(spliced.content, generateFilename(), 'text/plain');
 
       setExportStatus('success');
 

--- a/apps/viewer/src/components/viewer/ExportChangesButton.tsx
+++ b/apps/viewer/src/components/viewer/ExportChangesButton.tsx
@@ -20,6 +20,7 @@ import type { IfcDataStore } from '@ifc-lite/parser';
 import { toast } from '@/components/ui/toast';
 import { ensureModelExportReady } from '@/services/desktop-export';
 import { spliceScheduleIntoExport } from '@/sdk/adapters/export-schedule-splice';
+import { downloadBlob, sanitizeFilename } from '@/lib/export/download';
 
 interface ExportChangesButtonProps {
   /** Optional custom class name */
@@ -123,7 +124,7 @@ export function ExportChangesButton({ className }: ExportChangesButtonProps) {
   const generateFilename = useCallback(() => {
     if (!modelInfo) return 'export.ifc';
     // Remove extension if present
-    const baseName = modelInfo.name.replace(/\.[^.]+$/, '');
+    const baseName = sanitizeFilename(modelInfo.name.replace(/\.[^.]+$/, ''), { fallback: 'export' });
     return `${baseName}_${formatDate()}.ifc`;
   }, [modelInfo, formatDate]);
 
@@ -169,15 +170,7 @@ export function ExportChangesButton({ className }: ExportChangesButtonProps) {
       });
 
       // Download the file
-      const blob = new Blob([toBlobPart(spliced.content)], { type: 'text/plain' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = generateFilename();
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
+      downloadBlob(new Blob([toBlobPart(spliced.content)], { type: 'text/plain' }), generateFilename());
 
       setExportStatus('success');
 

--- a/apps/viewer/src/components/viewer/ExportDialog.tsx
+++ b/apps/viewer/src/components/viewer/ExportDialog.tsx
@@ -60,6 +60,7 @@ import { withInstancedMeshes } from '../../utils/instancedExport.js';
 import { MutablePropertyView } from '@ifc-lite/mutations';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import { spliceScheduleIntoExport } from '@/sdk/adapters/export-schedule-splice';
+import { downloadBlob, sanitizeFilename } from '@/lib/export/download';
 
 type ExportScope = 'single' | 'merged';
 type SchemaVersion = 'IFC2X3' | 'IFC4' | 'IFC4X3' | 'IFC5';
@@ -385,15 +386,7 @@ export function ExportDialog({ trigger }: ExportDialogProps) {
 
         setExportProgress(null);
 
-        const blob = new Blob([toBlobPart(result.content)], { type: 'text/plain' });
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = 'merged_export.ifc';
-        document.body.appendChild(a);
-        a.click();
-        document.body.removeChild(a);
-        URL.revokeObjectURL(url);
+        downloadBlob(new Blob([toBlobPart(result.content)], { type: 'text/plain' }), 'merged_export.ifc');
 
         const msg = `Merged ${result.stats.modelCount} models, ${result.stats.totalEntityCount.toLocaleString()} entities`;
         setExportResult({ success: true, message: msg });
@@ -410,7 +403,7 @@ export function ExportDialog({ trigger }: ExportDialogProps) {
         throw new Error('Selected model has no parsed IFC data store available for export');
       }
       const mutationView = getMutationView(selectedModelId);
-      const baseName = selectedModel.name.replace(/\.[^.]+$/, '');
+      const baseName = sanitizeFilename(selectedModel.name.replace(/\.[^.]+$/, ''), { fallback: 'model' });
 
       // ── IFC5 → always IFCX ──────────────────────────────────────────
       if (isIfc5) {
@@ -464,16 +457,8 @@ export function ExportDialog({ trigger }: ExportDialogProps) {
           author: 'ifc-lite',
         });
 
-        const blob = new Blob([toBlobPart(result.content)], { type: 'application/json' });
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
         const suffix = changesOnly ? '_changes' : (visibleOnly ? '_visible' : '_export');
-        a.download = `${baseName}${suffix}.ifcx`;
-        document.body.appendChild(a);
-        a.click();
-        document.body.removeChild(a);
-        URL.revokeObjectURL(url);
+        downloadBlob(new Blob([toBlobPart(result.content)], { type: 'application/json' }), `${baseName}${suffix}.ifcx`);
 
         const ifcxMsg = `Exported IFCX: ${result.stats.nodeCount} nodes, ${result.stats.meshCount} meshes, ${result.stats.propertyCount} properties`;
         setExportResult({ success: true, message: ifcxMsg });
@@ -491,15 +476,7 @@ export function ExportDialog({ trigger }: ExportDialogProps) {
           exportedAt: new Date().toISOString(),
         };
 
-        const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = `${baseName}_changes.json`;
-        document.body.appendChild(a);
-        a.click();
-        document.body.removeChild(a);
-        URL.revokeObjectURL(url);
+        downloadBlob(new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' }), `${baseName}_changes.json`);
 
         const jsonMsg = `Exported ${mutations.length} changes as JSON`;
         setExportResult({ success: true, message: jsonMsg });
@@ -556,16 +533,8 @@ export function ExportDialog({ trigger }: ExportDialogProps) {
           scheduleSourceModelId: state.scheduleSourceModelId ?? null,
         });
 
-        const blob = new Blob([toBlobPart(spliced.content)], { type: 'text/plain' });
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
         const suffix = visibleOnly ? '_visible' : '_export';
-        a.download = `${baseName}${suffix}.ifc`;
-        document.body.appendChild(a);
-        a.click();
-        document.body.removeChild(a);
-        URL.revokeObjectURL(url);
+        downloadBlob(new Blob([toBlobPart(spliced.content)], { type: 'text/plain' }), `${baseName}${suffix}.ifc`);
 
         const stepMsg = `Exported ${result.stats.entityCount} entities (${result.stats.modifiedEntityCount} modified)`;
         setExportResult({ success: true, message: stepMsg });

--- a/apps/viewer/src/components/viewer/ExportDialog.tsx
+++ b/apps/viewer/src/components/viewer/ExportDialog.tsx
@@ -60,7 +60,7 @@ import { withInstancedMeshes } from '../../utils/instancedExport.js';
 import { MutablePropertyView } from '@ifc-lite/mutations';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import { spliceScheduleIntoExport } from '@/sdk/adapters/export-schedule-splice';
-import { downloadBlob, sanitizeFilename } from '@/lib/export/download';
+import { downloadFile, sanitizeFilename } from '@/lib/export/download';
 
 type ExportScope = 'single' | 'merged';
 type SchemaVersion = 'IFC2X3' | 'IFC4' | 'IFC4X3' | 'IFC5';
@@ -69,12 +69,6 @@ interface ExportDialogProps {
   trigger?: React.ReactNode;
 }
 
-function toBlobPart(content: string | Uint8Array): BlobPart {
-  if (typeof content === 'string') return content;
-  const bytes = new Uint8Array(content.byteLength);
-  bytes.set(content);
-  return bytes;
-}
 
 export function ExportDialog({ trigger }: ExportDialogProps) {
   const models = useViewerStore((s) => s.models);
@@ -386,7 +380,7 @@ export function ExportDialog({ trigger }: ExportDialogProps) {
 
         setExportProgress(null);
 
-        downloadBlob(new Blob([toBlobPart(result.content)], { type: 'text/plain' }), 'merged_export.ifc');
+        downloadFile(result.content, 'merged_export.ifc', 'text/plain');
 
         const msg = `Merged ${result.stats.modelCount} models, ${result.stats.totalEntityCount.toLocaleString()} entities`;
         setExportResult({ success: true, message: msg });
@@ -458,7 +452,7 @@ export function ExportDialog({ trigger }: ExportDialogProps) {
         });
 
         const suffix = changesOnly ? '_changes' : (visibleOnly ? '_visible' : '_export');
-        downloadBlob(new Blob([toBlobPart(result.content)], { type: 'application/json' }), `${baseName}${suffix}.ifcx`);
+        downloadFile(result.content, `${baseName}${suffix}.ifcx`, 'application/json');
 
         const ifcxMsg = `Exported IFCX: ${result.stats.nodeCount} nodes, ${result.stats.meshCount} meshes, ${result.stats.propertyCount} properties`;
         setExportResult({ success: true, message: ifcxMsg });
@@ -476,7 +470,7 @@ export function ExportDialog({ trigger }: ExportDialogProps) {
           exportedAt: new Date().toISOString(),
         };
 
-        downloadBlob(new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' }), `${baseName}_changes.json`);
+        downloadFile(JSON.stringify(data, null, 2), `${baseName}_changes.json`, 'application/json');
 
         const jsonMsg = `Exported ${mutations.length} changes as JSON`;
         setExportResult({ success: true, message: jsonMsg });
@@ -534,7 +528,7 @@ export function ExportDialog({ trigger }: ExportDialogProps) {
         });
 
         const suffix = visibleOnly ? '_visible' : '_export';
-        downloadBlob(new Blob([toBlobPart(spliced.content)], { type: 'text/plain' }), `${baseName}${suffix}.ifc`);
+        downloadFile(spliced.content, `${baseName}${suffix}.ifc`, 'text/plain');
 
         const stepMsg = `Exported ${result.stats.entityCount} entities (${result.stats.modifiedEntityCount} modified)`;
         setExportResult({ success: true, message: stepMsg });

--- a/apps/viewer/src/components/viewer/GLBExportDialog.tsx
+++ b/apps/viewer/src/components/viewer/GLBExportDialog.tsx
@@ -44,6 +44,7 @@ import { posthog } from '@/lib/analytics';
 import { toast } from '@/components/ui/toast';
 import { type MeshData } from '@ifc-lite/geometry';
 import { exportGlbFromGeometry } from '@/lib/export/glb';
+import { downloadBlob, sanitizeFilename } from '@/lib/export/download';
 import { withInstancedMeshes } from '../../utils/instancedExport.js';
 
 type ColorSource = 'rendering' | 'shading';
@@ -246,16 +247,9 @@ export function GLBExportDialog({ trigger }: GLBExportDialogProps) {
       const glb = await exportGlbFromGeometry(exportGeometry, { meshes, includeMetadata });
 
       const blob = new Blob([new Uint8Array(glb)], { type: 'model/gltf-binary' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      const baseName = selectedModel.name.replace(/\.[^.]+$/, '');
+      const baseName = sanitizeFilename(selectedModel.name.replace(/\.[^.]+$/, ''), { fallback: 'model' });
       const suffix = visibleOnly ? '_visible' : '';
-      a.download = `${baseName}${suffix}.glb`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
+      downloadBlob(blob, `${baseName}${suffix}.glb`);
 
       const msg = `Exported GLB (${(blob.size / 1024).toFixed(0)} KB)`;
       setExportResult({ success: true, message: msg });

--- a/apps/viewer/src/components/viewer/HbjsonExportDialog.tsx
+++ b/apps/viewer/src/components/viewer/HbjsonExportDialog.tsx
@@ -41,6 +41,7 @@ import {
 import { useViewerStore } from '@/store';
 import { toast } from '@/components/ui/toast';
 import { GeometryProcessor } from '@ifc-lite/geometry';
+import { downloadBlob, sanitizeFilename } from '@/lib/export/download';
 
 interface HbjsonExportDialogProps {
   trigger?: React.ReactNode;
@@ -97,14 +98,7 @@ export function HbjsonExportDialog({ trigger }: HbjsonExportDialogProps) {
       }
 
       const blob = new Blob([hbjson], { type: 'application/json' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `${baseName}.hbjson`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
+      downloadBlob(blob, `${sanitizeFilename(baseName, { fallback: 'model' })}.hbjson`);
 
       const msg = `Exported HBJSON (${(blob.size / 1024).toFixed(0)} KB)`;
       setExportResult({ success: true, message: msg });

--- a/apps/viewer/src/components/viewer/LensPanel.tsx
+++ b/apps/viewer/src/components/viewer/LensPanel.tsx
@@ -22,6 +22,7 @@ import { X, EyeOff, Palette, Check, Plus, Trash2, Pencil, Save, Download, Upload
 import { discoverDataSources } from '@ifc-lite/lens';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+import { downloadFile } from '@/lib/export/download';
 import { useViewerStore } from '@/store';
 import { useLens } from '@/hooks/useLens';
 import { createLensDataProvider } from '@/lib/lens';
@@ -1260,13 +1261,7 @@ export function LensPanel({ onClose }: LensPanelProps) {
 
   const handleExport = useCallback(() => {
     const data = exportLenses();
-    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'lenses.json';
-    a.click();
-    URL.revokeObjectURL(url);
+    downloadFile(JSON.stringify(data, null, 2), 'lenses.json', 'application/json');
   }, [exportLenses]);
 
   const handleImport = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {

--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -75,6 +75,7 @@ import { executeBasketIsolate } from '@/store/basket/basketCommands';
 import { useIfc } from '@/hooks/useIfc';
 import { cn } from '@/lib/utils';
 import { exportCsvFromBytes } from '@/lib/export/csv';
+import { downloadFile, downloadDataUrl } from '@/lib/export/download';
 import { FileSpreadsheet, FileJson, FileText, Filter, Upload, Pencil, DraftingCompass } from 'lucide-react';
 import { ExportDialog } from './ExportDialog';
 import { GLBExportDialog } from './GLBExportDialog';
@@ -713,11 +714,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
     const canvas = document.querySelector('canvas');
     if (!canvas) return;
     try {
-      const dataUrl = canvas.toDataURL('image/png');
-      const a = document.createElement('a');
-      a.href = dataUrl;
-      a.download = 'screenshot.png';
-      a.click();
+      downloadDataUrl(canvas.toDataURL('image/png'), 'screenshot.png');
       toast.success('Screenshot saved');
     } catch (err) {
       console.error('Screenshot failed:', err);
@@ -730,14 +727,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
     try {
       const csv = await exportCsvFromBytes(ifcDataStore.source, type, { includeProperties: type === 'entities' });
       const filename = type === 'spatial' ? 'spatial-hierarchy.csv' : `${type}.csv`;
-
-      const blob = new Blob([csv], { type: 'text/csv' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = filename;
-      a.click();
-      URL.revokeObjectURL(url);
+      downloadFile(csv, filename, 'text/csv');
       toast.success(`Exported ${type} CSV`);
     } catch (err) {
       console.error('CSV export failed:', err);
@@ -761,13 +751,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
       }
 
       const json = JSON.stringify({ entities }, null, 2);
-      const blob = new Blob([json], { type: 'application/json' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = 'model-data.json';
-      a.click();
-      URL.revokeObjectURL(url);
+      downloadFile(json, 'model-data.json', 'application/json');
       toast.success(`Exported ${entities.length} entities as JSON`);
     } catch (err) {
       console.error('JSON export failed:', err);

--- a/apps/viewer/src/components/viewer/MobileToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MobileToolbar.tsx
@@ -44,6 +44,7 @@ import { executeBasketIsolate } from '@/store/basket/basketCommands';
 import { useIfc } from '@/hooks/useIfc';
 import { cn } from '@/lib/utils';
 import { exportGlbFromGeometry } from '@/lib/export/glb';
+import { downloadBlob } from '@/lib/export/download';
 import { recordRecentFiles, cacheFileBlobs } from '@/lib/recent-files';
 import { toast } from '@/components/ui/toast';
 
@@ -135,12 +136,7 @@ export function MobileToolbar() {
     try {
       const glb = await exportGlbFromGeometry(geometryResult, { includeMetadata: true });
       const blob = new Blob([new Uint8Array(glb)], { type: 'model/gltf-binary' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = 'model.glb';
-      a.click();
-      URL.revokeObjectURL(url);
+      downloadBlob(blob, 'model.glb');
       toast.success(`Exported GLB (${(blob.size / 1024).toFixed(0)} KB)`);
     } catch (err) {
       toast.error(`Export failed: ${err instanceof Error ? err.message : 'Unknown error'}`);

--- a/apps/viewer/src/components/viewer/properties/LocationMap.tsx
+++ b/apps/viewer/src/components/viewer/properties/LocationMap.tsx
@@ -23,6 +23,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
 import type { CoordinateInfo, GeometryResult } from '@ifc-lite/geometry';
 import { exportGlbFromGeometry } from '@/lib/export/glb';
+import { downloadBlob } from '@/lib/export/download';
 import { reprojectToLatLon, reprojectFromLatLon, queryTerrainElevation, computeFootprintGeoJSON, type LatLon } from '@/lib/geo/reproject';
 import { buildKmz } from '@/lib/geo/kmz-exporter';
 
@@ -461,13 +462,7 @@ export function LocationMap({
         glb,
         name: 'IFC Model',
       });
-      const blob = new Blob([kmz as BlobPart], { type: 'application/vnd.google-earth.kmz' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = 'model.kmz';
-      a.click();
-      URL.revokeObjectURL(url);
+      downloadBlob(new Blob([kmz as BlobPart], { type: 'application/vnd.google-earth.kmz' }), 'model.kmz');
     } catch (err) {
       console.error('KMZ export failed:', err);
     }

--- a/apps/viewer/src/hooks/ids/idsExportService.ts
+++ b/apps/viewer/src/hooks/ids/idsExportService.ts
@@ -11,6 +11,7 @@
 
 import type { IDSValidationReport, SupportedLocale } from '@ifc-lite/ids';
 import { posthog } from '../../lib/analytics';
+import { downloadFile } from '../../lib/export/download';
 
 // ============================================================================
 // JSON Export
@@ -59,13 +60,7 @@ export function buildReportJSON(report: IDSValidationReport): Record<string, unk
  */
 export function downloadReportJSON(report: IDSValidationReport): void {
   const exportData = buildReportJSON(report);
-  const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: 'application/json' });
-  const url = URL.createObjectURL(blob);
-  const a = globalThis.document.createElement('a');
-  a.href = url;
-  a.download = `ids-report-${new Date().toISOString().split('T')[0]}.json`;
-  a.click();
-  URL.revokeObjectURL(url);
+  downloadFile(JSON.stringify(exportData, null, 2), `ids-report-${new Date().toISOString().split('T')[0]}.json`, 'application/json');
   posthog.capture('ids_report_exported', { format: 'json', total_specifications: report.summary.totalSpecifications });
 }
 
@@ -436,12 +431,6 @@ export function buildReportHTML(report: IDSValidationReport, locale: SupportedLo
  */
 export function downloadReportHTML(report: IDSValidationReport, locale: SupportedLocale): void {
   const html = buildReportHTML(report, locale);
-  const blob = new Blob([html], { type: 'text/html' });
-  const url = URL.createObjectURL(blob);
-  const a = globalThis.document.createElement('a');
-  a.href = url;
-  a.download = `ids-report-${new Date().toISOString().split('T')[0]}.html`;
-  a.click();
-  URL.revokeObjectURL(url);
+  downloadFile(html, `ids-report-${new Date().toISOString().split('T')[0]}.html`, 'text/html');
   posthog.capture('ids_report_exported', { format: 'html', locale, total_specifications: report.summary.totalSpecifications });
 }

--- a/apps/viewer/src/hooks/useClash.ts
+++ b/apps/viewer/src/hooks/useClash.ts
@@ -31,6 +31,7 @@ import { createBCFFromClashResult } from '@ifc-lite/clash/bcf';
 import { writeBCF } from '@ifc-lite/bcf';
 import { getGlobalRenderer } from '@/hooks/useBCF';
 import { posthog } from '@/lib/analytics';
+import { downloadBlob } from '@/lib/export/download';
 
 interface SelectionRef {
   modelId: string;
@@ -65,15 +66,6 @@ export interface ClashBcfConfig {
 
 /** Dark, neutral background for offscreen snapshot captures (Tokyo Night base). */
 const SNAPSHOT_CLEAR_COLOR: [number, number, number, number] = [0.04, 0.05, 0.1, 1];
-
-function downloadBlob(blob: Blob, filename: string): void {
-  const url = URL.createObjectURL(blob);
-  const anchor = document.createElement('a');
-  anchor.href = url;
-  anchor.download = filename;
-  anchor.click();
-  URL.revokeObjectURL(url);
-}
 
 /** Decode a `data:image/png;base64,...` URL into raw PNG bytes for the BCF zip. */
 function dataUrlToBytes(dataUrl: string): Uint8Array | undefined {

--- a/apps/viewer/src/hooks/useDrawingExport.ts
+++ b/apps/viewer/src/hooks/useDrawingExport.ts
@@ -4,6 +4,7 @@
 
 import { useCallback } from 'react';
 import { posthog } from '@/lib/analytics';
+import { downloadFile, sanitizeFilename } from '@/lib/export/download';
 import {
   GraphicOverrideEngine,
   renderFrame,
@@ -628,16 +629,10 @@ function useDrawingExport({
     // Use sheet export if enabled, otherwise raw drawing export
     const svg = (sheetEnabled && activeSheet) ? generateSheetSVG() : generateExportSVG();
     if (!svg) return;
-    const blob = new Blob([svg], { type: 'image/svg+xml' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    const filename = (sheetEnabled && activeSheet)
-      ? `${activeSheet.name.replace(/\s+/g, '-')}-${sectionPlane.axis}-${sectionPlane.position}.svg`
-      : `section-${sectionPlane.axis}-${sectionPlane.position}.svg`;
-    a.download = filename;
-    a.click();
-    URL.revokeObjectURL(url);
+    const stem = (sheetEnabled && activeSheet)
+      ? `${sanitizeFilename(activeSheet.name, { fallback: 'sheet' })}-${sectionPlane.axis}-${sectionPlane.position}`
+      : `section-${sectionPlane.axis}-${sectionPlane.position}`;
+    downloadFile(svg, `${stem}.svg`, 'image/svg+xml');
     posthog.capture('drawing_exported', { format: 'svg', axis: sectionPlane.axis, sheet_enabled: sheetEnabled });
   }, [generateExportSVG, generateSheetSVG, sheetEnabled, activeSheet, sectionPlane]);
 

--- a/apps/viewer/src/hooks/useIDS.ts
+++ b/apps/viewer/src/hooks/useIDS.ts
@@ -32,6 +32,7 @@ import {
 } from '@ifc-lite/ids';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import { createBCFFromIDSReport, writeBCF } from '@ifc-lite/bcf';
+import { downloadBlob } from '@/lib/export/download';
 import type { EntityBoundsInput, IDSBCFExportOptions } from '@ifc-lite/bcf';
 import type { IDSBCFExportSettings, IDSExportProgress } from '@/components/viewer/IDSExportDialog';
 import { getEntityBounds } from '@/utils/viewportUtils';
@@ -1114,12 +1115,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
     setBcfExportProgress({ phase: 'writing', current: 1, total: 2, message: 'Writing BCF file...' });
 
     const blob = await writeBCF(bcfProject);
-    const url = URL.createObjectURL(blob);
-    const a = globalThis.document.createElement('a');
-    a.href = url;
-    a.download = `ids-report-${new Date().toISOString().split('T')[0]}.bcfzip`;
-    a.click();
-    URL.revokeObjectURL(url);
+    downloadBlob(blob, `ids-report-${new Date().toISOString().split('T')[0]}.bcfzip`);
 
     // Phase 5: Load into BCF panel if requested
     if (loadIntoBcfPanel) {

--- a/apps/viewer/src/lib/clash/persistence.ts
+++ b/apps/viewer/src/lib/clash/persistence.ts
@@ -21,6 +21,7 @@ import {
   type ClashMode,
   type ClashSeverity,
 } from '@ifc-lite/clash';
+import { downloadFile } from '../export/download.js';
 
 /** A built-in or user-defined clash rule preset, with editor/runtime flags. */
 export type ClashPreset = ClashRulePreset & { enabled: boolean; builtin: boolean };
@@ -235,15 +236,8 @@ export function saveSettings(settings: ClashGlobalSettings): SaveResult {
 /** Download the user's presets (customs + modified built-ins) as a JSON file. */
 export function exportPresets(presets: ClashPreset[]): void {
   const custom = presets.filter((p) => !p.builtin || builtinDiffersFromDefault(p));
-  const blob = new Blob([JSON.stringify({ schemaVersion: SCHEMA_VERSION, presets: custom }, null, 2)], {
-    type: 'application/json',
-  });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = 'clash-rules.clash-presets.json';
-  a.click();
-  URL.revokeObjectURL(url);
+  const json = JSON.stringify({ schemaVersion: SCHEMA_VERSION, presets: custom }, null, 2);
+  downloadFile(json, 'clash-rules.clash-presets.json', 'application/json');
 }
 
 /** Parse an exported file into custom presets (ids regenerated, `builtin` stripped). */

--- a/apps/viewer/src/lib/compare/exportReport.ts
+++ b/apps/viewer/src/lib/compare/exportReport.ts
@@ -21,6 +21,7 @@ import type { FederatedModel } from '../../store/types.js';
 import type { CompareResult } from '../../store/slices/compareSlice.js';
 import type { CompareRef } from './buildFingerprints.js';
 import { summarizeGeometryChange, type Aabb } from './describeChange.js';
+import { downloadBlob, sanitizeFilename } from '../export/download.js';
 
 /** One row of the exported change report. */
 export interface CompareReportRow {
@@ -192,10 +193,6 @@ export function reportToJson(report: CompareReport): string {
   return JSON.stringify(report, null, 2);
 }
 
-function slug(s: string): string {
-  return (s || 'model').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 40) || 'model';
-}
-
 /** Build + download the change report as a CSV or JSON file. */
 export function downloadCompareReport(
   format: 'csv' | 'json',
@@ -203,13 +200,9 @@ export function downloadCompareReport(
   models: ReadonlyMap<string, FederatedModel>,
 ): void {
   const report = buildCompareReport(result, models);
-  const name = `compare-${slug(report.baseModel)}-vs-${slug(report.headModel)}`;
+  const modelName = (s: string) => sanitizeFilename(s, { fallback: 'model', maxLength: 40 });
+  const name = `compare-${modelName(report.baseModel)}-vs-${modelName(report.headModel)}`;
   const body = format === 'csv' ? reportToCsv(report) : reportToJson(report);
   const type = format === 'csv' ? 'text/csv;charset=utf-8;' : 'application/json;charset=utf-8;';
-  const url = URL.createObjectURL(new Blob([body], { type }));
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = `${name}.${format}`;
-  a.click();
-  setTimeout(() => URL.revokeObjectURL(url), 1500);
+  downloadBlob(new Blob([body], { type }), `${name}.${format}`);
 }

--- a/apps/viewer/src/lib/export/download.test.ts
+++ b/apps/viewer/src/lib/export/download.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { sanitizeFilename } from './index.js';
+import { sanitizeFilename } from './download.js';
 
 describe('sanitizeFilename', () => {
   it('preserves uppercase letters (issue #1299)', () => {
@@ -21,7 +21,7 @@ describe('sanitizeFilename', () => {
     assert.strictEqual(sanitizeFilename('A_B-C D'), 'A_B-C D');
   });
 
-  it('replaces path separators and reserved characters', () => {
+  it('replaces path separators and reserved characters with a hyphen', () => {
     assert.strictEqual(sanitizeFilename('a/b\\c'), 'a-b-c');
     assert.strictEqual(sanitizeFilename('a:b*c?d'), 'a-b-c-d');
   });
@@ -35,18 +35,20 @@ describe('sanitizeFilename', () => {
     assert.strictEqual(sanitizeFilename('---x---'), 'x');
   });
 
-  it('falls back to "list" for empty or all-stripped input', () => {
-    assert.strictEqual(sanitizeFilename(''), 'list');
-    assert.strictEqual(sanitizeFilename('   '), 'list');
-    assert.strictEqual(sanitizeFilename('***'), 'list');
-  });
-
-  it('caps the length at 60 characters', () => {
-    const long = 'X'.repeat(100);
-    assert.strictEqual(sanitizeFilename(long).length, 60);
-  });
-
   it('keeps non-ASCII letters', () => {
     assert.strictEqual(sanitizeFilename('Brücke Ö'), 'Brücke Ö');
+  });
+
+  it('uses the provided fallback for empty or fully-stripped input', () => {
+    assert.strictEqual(sanitizeFilename(''), 'file');
+    assert.strictEqual(sanitizeFilename('   '), 'file');
+    assert.strictEqual(sanitizeFilename('***'), 'file');
+    assert.strictEqual(sanitizeFilename('', { fallback: 'list' }), 'list');
+    assert.strictEqual(sanitizeFilename('***', { fallback: 'model' }), 'model');
+  });
+
+  it('caps the length at maxLength (default 60)', () => {
+    assert.strictEqual(sanitizeFilename('X'.repeat(100)).length, 60);
+    assert.strictEqual(sanitizeFilename('X'.repeat(100), { maxLength: 40 }).length, 40);
   });
 });

--- a/apps/viewer/src/lib/export/download.test.ts
+++ b/apps/viewer/src/lib/export/download.test.ts
@@ -35,6 +35,10 @@ describe('sanitizeFilename', () => {
     assert.strictEqual(sanitizeFilename('---x---'), 'x');
   });
 
+  it('keeps leading/trailing underscores (only space/dot/hyphen are trimmed)', () => {
+    assert.strictEqual(sanitizeFilename('_my_list_'), '_my_list_');
+  });
+
   it('keeps non-ASCII letters', () => {
     assert.strictEqual(sanitizeFilename('Brücke Ö'), 'Brücke Ö');
   });

--- a/apps/viewer/src/lib/export/download.ts
+++ b/apps/viewer/src/lib/export/download.ts
@@ -1,0 +1,97 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Canonical browser-export helpers: one filename sanitiser and one download
+ * trigger, so every "Save as ..." path in the app behaves identically. Prefer
+ * these over hand-rolling an `<a download>` blob dance or another bespoke
+ * filename regex — see issue #1299 for what drifting copies cost us (uppercase
+ * names lowercased, dotted classification codes hyphenated, dots underscored).
+ */
+
+export interface SanitizeFilenameOptions {
+  /** Returned (and used as the base) when sanitising yields an empty string. Default `'file'`. */
+  fallback?: string;
+  /** Maximum length of the returned name. Default 60. */
+  maxLength?: number;
+}
+
+/**
+ * Make a user- or model-supplied name safe to use as a download filename
+ * without mangling it. Case is preserved (so `DRAWINGS` stays `DRAWINGS`) and
+ * dots are kept (so a classification code like `000.000` survives intact); only
+ * characters that are genuinely unsafe in filenames (path separators, reserved
+ * characters, control characters) are replaced with `-`. Whitespace runs
+ * collapse to a single space and leading/trailing separators are trimmed.
+ *
+ * Pass only the stem — append the extension yourself (`${sanitizeFilename(x)}.csv`).
+ */
+export function sanitizeFilename(name: string, options: SanitizeFilenameOptions = {}): string {
+  const fallback = options.fallback ?? 'file';
+  const maxLength = options.maxLength ?? 60;
+  const cleaned = (name || fallback)
+    .replace(/\s+/g, ' ') // collapse all whitespace (tabs, newlines, runs) to one space
+    // Keep letters (any case/script), digits, dot, underscore, space and hyphen;
+    // replace anything else (path separators, reserved chars, controls) with '-'.
+    .replace(/[^\p{L}\p{N}._ -]+/gu, '-')
+    .replace(/^[\s.-]+|[\s.-]+$/g, '') // trim leading/trailing space, dot or hyphen
+    .slice(0, maxLength)
+    .replace(/[\s.-]+$/, ''); // re-trim in case slice() left a trailing separator
+  return cleaned || fallback;
+}
+
+/** True when we can actually trigger a download (browser context). */
+function canDownload(): boolean {
+  return typeof document !== 'undefined' && typeof URL !== 'undefined';
+}
+
+function clickDownloadAnchor(href: string, filename: string): void {
+  const a = document.createElement('a');
+  a.href = href;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+}
+
+/** Trigger a browser download of a `Blob`. No-op outside the browser. */
+export function downloadBlob(blob: Blob, filename: string): void {
+  if (!canDownload()) return;
+  const url = URL.createObjectURL(blob);
+  clickDownloadAnchor(url, filename);
+  // Defer revocation: revoking synchronously can cancel the download in some browsers.
+  setTimeout(() => URL.revokeObjectURL(url), 1500);
+}
+
+/**
+ * Trigger a browser download of string or binary content, wrapping it in a
+ * `Blob` first. Pass an explicit `mime` for text formats (e.g.
+ * `'text/csv;charset=utf-8;'`); the default suits arbitrary binary payloads.
+ *
+ * Accepts the `Uint8Array<ArrayBufferLike>` that the Rust/wasm exporters return:
+ * TS 5.7+ no longer treats that as a `BlobPart`, so we copy it into a fresh
+ * `ArrayBuffer`-backed view here instead of making every caller do it.
+ */
+export function downloadFile(
+  content: string | Uint8Array | ArrayBuffer | Blob,
+  filename: string,
+  mime = 'application/octet-stream',
+): void {
+  if (!canDownload()) return;
+  if (content instanceof Blob) {
+    downloadBlob(content, filename);
+    return;
+  }
+  const part: BlobPart = content instanceof Uint8Array ? new Uint8Array(content) : content;
+  downloadBlob(new Blob([part], { type: mime }), filename);
+}
+
+/**
+ * Trigger a browser download from a `data:` (or other directly-addressable)
+ * URL, e.g. a canvas `toDataURL()` screenshot. No-op outside the browser.
+ */
+export function downloadDataUrl(dataUrl: string, filename: string): void {
+  if (!canDownload()) return;
+  clickDownloadAnchor(dataUrl, filename);
+}

--- a/apps/viewer/src/lib/export/download.ts
+++ b/apps/viewer/src/lib/export/download.ts
@@ -26,6 +26,10 @@ export interface SanitizeFilenameOptions {
  * collapse to a single space and leading/trailing separators are trimmed.
  *
  * Pass only the stem — append the extension yourself (`${sanitizeFilename(x)}.csv`).
+ *
+ * Note: underscores are kept anywhere (including the ends — only space/dot/hyphen
+ * are trimmed off the ends). `fallback` is returned verbatim when the result is
+ * empty, so pass a clean token like `'list'` / `'model'`.
  */
 export function sanitizeFilename(name: string, options: SanitizeFilenameOptions = {}): string {
   const fallback = options.fallback ?? 'file';

--- a/apps/viewer/src/lib/lists/export/index.test.ts
+++ b/apps/viewer/src/lib/lists/export/index.test.ts
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { sanitizeFilename } from './index.js';
+
+describe('sanitizeFilename', () => {
+  it('preserves uppercase letters (issue #1299)', () => {
+    assert.strictEqual(sanitizeFilename('DRAWINGS'), 'DRAWINGS');
+    assert.strictEqual(sanitizeFilename('MyList'), 'MyList');
+  });
+
+  it('preserves dot-separated classification codes (issue #1299)', () => {
+    assert.strictEqual(sanitizeFilename('000.000'), '000.000');
+    assert.strictEqual(sanitizeFilename('DOC 000.000 REV-A'), 'DOC 000.000 REV-A');
+  });
+
+  it('keeps underscores, hyphens and spaces', () => {
+    assert.strictEqual(sanitizeFilename('A_B-C D'), 'A_B-C D');
+  });
+
+  it('replaces path separators and reserved characters', () => {
+    assert.strictEqual(sanitizeFilename('a/b\\c'), 'a-b-c');
+    assert.strictEqual(sanitizeFilename('a:b*c?d'), 'a-b-c-d');
+  });
+
+  it('collapses whitespace runs to a single space', () => {
+    assert.strictEqual(sanitizeFilename('a   b\t c'), 'a b c');
+  });
+
+  it('trims leading/trailing separators and dots', () => {
+    assert.strictEqual(sanitizeFilename('  .name.  '), 'name');
+    assert.strictEqual(sanitizeFilename('---x---'), 'x');
+  });
+
+  it('falls back to "list" for empty or all-stripped input', () => {
+    assert.strictEqual(sanitizeFilename(''), 'list');
+    assert.strictEqual(sanitizeFilename('   '), 'list');
+    assert.strictEqual(sanitizeFilename('***'), 'list');
+  });
+
+  it('caps the length at 60 characters', () => {
+    const long = 'X'.repeat(100);
+    assert.strictEqual(sanitizeFilename(long).length, 60);
+  });
+
+  it('keeps non-ASCII letters', () => {
+    assert.strictEqual(sanitizeFilename('Brücke Ö'), 'Brücke Ö');
+  });
+});

--- a/apps/viewer/src/lib/lists/export/index.ts
+++ b/apps/viewer/src/lib/lists/export/index.ts
@@ -19,8 +19,23 @@ export const EXPORT_LABELS: Record<ExportFormat, string> = {
   pdf: 'PDF (.pdf)',
 };
 
-function slug(s: string): string {
-  return (s || 'list').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 60) || 'list';
+/**
+ * Make a user-supplied list name safe to use as a download filename without
+ * mangling it. Case is preserved (so `DRAWINGS` stays `DRAWINGS`) and dots are
+ * kept (so a classification code like `000.000` survives intact). Only
+ * characters that are unsafe in filenames are replaced; whitespace runs collapse
+ * to a single space and leading/trailing separators are trimmed.
+ */
+export function sanitizeFilename(s: string): string {
+  const cleaned = (s || 'list')
+    .replace(/\s+/g, ' ') // collapse all whitespace (tabs, newlines, runs) to one space
+    // Keep letters (any case/script), digits, dot, underscore, space and hyphen;
+    // replace anything else (path separators, reserved chars, controls) with '-'.
+    .replace(/[^\p{L}\p{N}._ -]+/gu, '-')
+    .replace(/^[\s.-]+|[\s.-]+$/g, '') // trim leading/trailing space, dot or hyphen
+    .slice(0, 60)
+    .replace(/[\s.-]+$/, ''); // re-trim in case slice() left a trailing separator
+  return cleaned || 'list';
 }
 
 function download(blob: Blob, filename: string): void {
@@ -33,7 +48,7 @@ function download(blob: Blob, filename: string): void {
 }
 
 export async function exportList(format: ExportFormat, model: ExportModel): Promise<void> {
-  const name = slug(model.title);
+  const name = sanitizeFilename(model.title);
   if (format === 'csv') {
     download(new Blob([toCsv(model)], { type: 'text/csv;charset=utf-8;' }), `${name}.csv`);
   } else if (format === 'xlsx') {

--- a/apps/viewer/src/lib/lists/export/index.ts
+++ b/apps/viewer/src/lib/lists/export/index.ts
@@ -8,6 +8,7 @@
  * libs) are lazy-loaded so they never touch the initial bundle.
  */
 
+import { downloadBlob, sanitizeFilename } from '../../export/download';
 import { toCsv } from './csv';
 import type { ExportModel } from './model';
 
@@ -19,44 +20,16 @@ export const EXPORT_LABELS: Record<ExportFormat, string> = {
   pdf: 'PDF (.pdf)',
 };
 
-/**
- * Make a user-supplied list name safe to use as a download filename without
- * mangling it. Case is preserved (so `DRAWINGS` stays `DRAWINGS`) and dots are
- * kept (so a classification code like `000.000` survives intact). Only
- * characters that are unsafe in filenames are replaced; whitespace runs collapse
- * to a single space and leading/trailing separators are trimmed.
- */
-export function sanitizeFilename(s: string): string {
-  const cleaned = (s || 'list')
-    .replace(/\s+/g, ' ') // collapse all whitespace (tabs, newlines, runs) to one space
-    // Keep letters (any case/script), digits, dot, underscore, space and hyphen;
-    // replace anything else (path separators, reserved chars, controls) with '-'.
-    .replace(/[^\p{L}\p{N}._ -]+/gu, '-')
-    .replace(/^[\s.-]+|[\s.-]+$/g, '') // trim leading/trailing space, dot or hyphen
-    .slice(0, 60)
-    .replace(/[\s.-]+$/, ''); // re-trim in case slice() left a trailing separator
-  return cleaned || 'list';
-}
-
-function download(blob: Blob, filename: string): void {
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = filename;
-  a.click();
-  setTimeout(() => URL.revokeObjectURL(url), 1500);
-}
-
 export async function exportList(format: ExportFormat, model: ExportModel): Promise<void> {
-  const name = sanitizeFilename(model.title);
+  const name = sanitizeFilename(model.title, { fallback: 'list' });
   if (format === 'csv') {
-    download(new Blob([toCsv(model)], { type: 'text/csv;charset=utf-8;' }), `${name}.csv`);
+    downloadBlob(new Blob([toCsv(model)], { type: 'text/csv;charset=utf-8;' }), `${name}.csv`);
   } else if (format === 'xlsx') {
     const { toXlsx } = await import('./xlsx');
-    download(await toXlsx(model), `${name}.xlsx`);
+    downloadBlob(await toXlsx(model), `${name}.xlsx`);
   } else {
     const { toPdf } = await import('./pdf');
-    download(await toPdf(model), `${name}.pdf`);
+    downloadBlob(await toPdf(model), `${name}.pdf`);
   }
 }
 

--- a/apps/viewer/src/lib/lists/persistence.ts
+++ b/apps/viewer/src/lib/lists/persistence.ts
@@ -7,6 +7,7 @@
  */
 
 import type { ListDefinition } from '@ifc-lite/lists';
+import { downloadFile, sanitizeFilename } from '../export/download.js';
 
 const STORAGE_KEY = 'ifc-lite-lists';
 
@@ -30,13 +31,8 @@ export function saveListDefinitions(definitions: ListDefinition[]): void {
 
 export function exportListDefinition(definition: ListDefinition): void {
   const json = JSON.stringify(definition, null, 2);
-  const blob = new Blob([json], { type: 'application/json' });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = `${definition.name.replace(/[^a-zA-Z0-9-_]/g, '_')}.list.json`;
-  a.click();
-  URL.revokeObjectURL(url);
+  const name = sanitizeFilename(definition.name, { fallback: 'list' });
+  downloadFile(json, `${name}.list.json`, 'application/json');
 }
 
 export function importListDefinition(file: File): Promise<ListDefinition> {

--- a/apps/viewer/src/lib/search/result-export.test.ts
+++ b/apps/viewer/src/lib/search/result-export.test.ts
@@ -93,9 +93,7 @@ describe('__internal helpers', () => {
     assert.strictEqual(__internal.escapeCsvCell('a\nb'), '"a\nb"');
   });
 
-  it('sanitiseFilenameStem strips path-unsafe characters', () => {
-    assert.strictEqual(__internal.sanitiseFilenameStem('My Query.csv'), 'My_Query_csv');
-    assert.strictEqual(__internal.sanitiseFilenameStem('   '), 'query');
-    assert.strictEqual(__internal.sanitiseFilenameStem('weird/../path'), 'weird_path');
-  });
+  // Filename sanitisation now lives in lib/export/download.ts (sanitizeFilename),
+  // which preserves case and dots — see download.test.ts. downloadResult() routes
+  // its stem through it, so there is no module-local helper to test here anymore.
 });

--- a/apps/viewer/src/lib/search/result-export.ts
+++ b/apps/viewer/src/lib/search/result-export.ts
@@ -10,6 +10,8 @@
  * the same module but isolated from the formatters.
  */
 
+import { downloadFile, sanitizeFilename } from '../export/download.js';
+
 export interface ExportResult {
   columns: string[];
   rows: unknown[][];
@@ -75,36 +77,19 @@ export function formatJson(result: ExportResult): string {
   return JSON.stringify(out, null, 2);
 }
 
-/** Sanitise a stem for use as a download filename — strip path-unsafe
- *  characters, fall back to `query`. */
-function sanitiseFilenameStem(stem: string): string {
-  const cleaned = stem.replace(/[^a-zA-Z0-9_\-]+/g, '_').replace(/^_+|_+$/g, '');
-  return cleaned.length > 0 ? cleaned.slice(0, 60) : 'query';
-}
-
-/** Build the `Blob` + temporary `<a>` download flow for a result. The
- *  caller passes a "stem" that becomes the filename root (`stem.csv`).
- *  Browser-only — does nothing useful when `document` is missing. */
+/** Build the `Blob` + download flow for a result. The caller passes a "stem"
+ *  that becomes the filename root (`stem.csv`). Browser-only — does nothing
+ *  useful when `document` is missing. */
 export function downloadResult(
   result: ExportResult,
   format: 'csv' | 'json',
   filenameStem = 'ifc-query',
 ): void {
-  if (typeof document === 'undefined' || typeof URL === 'undefined') return;
-
   const content = format === 'csv' ? formatCsv(result) : formatJson(result);
   const mime = format === 'csv' ? 'text/csv;charset=utf-8' : 'application/json;charset=utf-8';
-  const blob = new Blob([content], { type: mime });
-  const url = URL.createObjectURL(blob);
-
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = `${sanitiseFilenameStem(filenameStem)}.${format}`;
-  document.body.appendChild(a);
-  a.click();
-  document.body.removeChild(a);
-  URL.revokeObjectURL(url);
+  const name = sanitizeFilename(filenameStem, { fallback: 'query' });
+  downloadFile(content, `${name}.${format}`, mime);
 }
 
 /** Exposed for tests. */
-export const __internal = { escapeCsvCell, cellToString, sanitiseFilenameStem };
+export const __internal = { escapeCsvCell, cellToString };

--- a/apps/viewer/src/sdk/adapters/export-adapter.ts
+++ b/apps/viewer/src/sdk/adapters/export-adapter.ts
@@ -10,6 +10,7 @@ import { getModelForRef, LEGACY_MODEL_ID } from './model-compat.js';
 import { applyAttributeMutationsToEntityData, getMutationViewForModel } from './mutation-view.js';
 import { serializeScheduleToStep, type ScheduleExtraction, type IfcDataStore } from '@ifc-lite/parser';
 import { spliceScheduleIntoExport } from './export-schedule-splice.js';
+import { downloadFile } from '../../lib/export/download.js';
 
 /** Options for CSV export */
 interface CsvOptions {
@@ -126,13 +127,6 @@ function escapeCsv(value: string, sep: string): string {
  * on the same LocalBackend, providing full export support for both
  * direct dispatch calls and SDK namespace usage.
  */
-function toBlobPart(content: string | Uint8Array): BlobPart {
-  if (typeof content === 'string') return content;
-  const bytes = new Uint8Array(content.byteLength);
-  bytes.set(content);
-  return bytes;
-}
-
 export function createExportAdapter(store: StoreApi): ExportBackendMethods {
   /** Resolve entity data via the query subsystem */
   function getEntityData(ref: EntityRef): EntityData | null {
@@ -797,16 +791,12 @@ function findFirstOwnerHistoryId(stepContent: string): number | null {
   return m ? parseInt(m[1], 10) : null;
 }
 
-/** Trigger a browser file download */
+/** Trigger a browser file download. Unlike the shared helper this throws
+ *  outside the browser, since the SDK's `export.download()` contract promises a
+ *  hard failure rather than a silent no-op when there is no DOM. */
 function triggerDownload(content: string | Uint8Array, filename: string, mimeType: string): void {
   if (typeof document === 'undefined') {
     throw new Error('download() requires a browser environment (document is unavailable)');
   }
-  const blob = new Blob([toBlobPart(content)], { type: mimeType });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = filename;
-  a.click();
-  URL.revokeObjectURL(url);
+  downloadFile(content, filename, mimeType);
 }


### PR DESCRIPTION
Closes #1299

## The bug (#1299)
Saving a list export lowercased the filename (`DRAWINGS` → `drawings`) and turned dotted classification codes into hyphens (`000.000` → `000-000`). Root cause: a `slug()` helper that lowercased and replaced every non-alphanumeric run.

## Why it kept happening
Filename handling was copy-pasted all over the viewer with no single owner:
- **5 different sanitisers** with conflicting rules — list export and compare report lowercased + hyphenated dots; search export and list-definition export preserved case but turned dots into `_`; the MCP playground preserved both.
- **~30 hand-rolled** `<a download>` + `URL.createObjectURL` blocks, including **4 near-identical local download helpers** (useClash, CommandPalette, export-adapter, plus the lists one).

So the same class of bug lived in several places, and there was no obvious "right way" for the next export.

## The fix — one canonical module
New `apps/viewer/src/lib/export/download.ts`:
- `sanitizeFilename(name, { fallback, maxLength })` — preserves case and dots (any script via `\p{L}`), replaces only genuinely OS-unsafe characters with `-`, collapses whitespace, trims separators, caps length, falls back when empty. It is **not** a slug.
- `downloadBlob` / `downloadFile` / `downloadDataUrl` — a single anchor-click download flow. `downloadFile` copies the wasm `Uint8Array<ArrayBufferLike>` into a `BlobPart`, so callers stop reinventing that TS 5.7 coercion.

Everything now routes through it:
- **Sanitisers consolidated:** list export (#1299), compare report (same lowercase+dot bug), search result export + list-definition export (dot→`_`), MCP `coerceFilename` (keeps its path-strip + extension-forcing).
- **Dynamic names sanitised** at GLB / HBJSON / IFC / IFCX / changes-JSON / BCF / drawing-SVG / export-changes.
- **Duplicate helpers + inline blocks removed** across useClash, CommandPalette, export-adapter (SDK keeps its deliberate throw-outside-browser contract), and the fixed-name sites (lenses, audit/action logs, IDS BCF/JSON/HTML, clash presets, KMZ, flavor, screenshots, toolbar CSV/JSON).

CesiumOverlay's `createObjectURL` is a model *load*, not a download — intentionally untouched.

## Verification
- New `download.test.ts` (9 cases: case/dot preservation, reserved-char stripping, whitespace, trim, fallback, length, non-ASCII). Search export test updated. Both green via `node:test`.
- `tsc --noEmit` across the whole viewer: **zero new errors** vs the pre-change baseline, after each of the three migration batches.
- Net **-116 lines**. `AGENTS.md` now documents the one way so this doesn't drift back.
- No changeset: `@ifc-lite/viewer` is the deployed app, not an npm-published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)