### PR TITLE
feat(viewer): storey sort order for the model browser (#1296)

### DIFF
--- a/apps/viewer/src/components/viewer/HierarchyPanel.tsx
+++ b/apps/viewer/src/components/viewer/HierarchyPanel.tsx
@@ -27,6 +27,7 @@ import { isSpatialContainer } from './hierarchy/types';
 import { useHierarchyTree } from './hierarchy/useHierarchyTree';
 import { HierarchyNode, SectionHeader } from './hierarchy/HierarchyNode';
 import { StoreyDisplayControls } from './hierarchy/StoreyDisplayControls';
+import { HierarchySortControl } from './hierarchy/HierarchySortControl';
 
 export function HierarchyPanel() {
   const {
@@ -106,6 +107,8 @@ export function HierarchyPanel() {
     setSearchQuery,
     groupingMode,
     setGroupingMode,
+    sortMode,
+    setSortMode,
     unifiedStoreys,
     filteredNodes: rawFilteredNodes,
     storeysNodes: rawStoreysNodes,
@@ -709,6 +712,9 @@ export function HierarchyPanel() {
             className="h-9 text-sm rounded-none border-2 border-zinc-200 dark:border-zinc-800 focus:border-primary focus:ring-0 bg-white dark:bg-zinc-950 text-zinc-900 dark:text-zinc-100 placeholder:text-zinc-400 dark:placeholder:text-zinc-600"
           />
           {groupingToggle}
+          {groupingMode === 'spatial' && (
+            <HierarchySortControl value={sortMode} onChange={setSortMode} />
+          )}
         </div>
 
         {/* Resizable content area */}
@@ -829,6 +835,9 @@ export function HierarchyPanel() {
           className="h-9 text-sm rounded-none border-2 border-zinc-200 dark:border-zinc-800 focus:border-primary focus:ring-0 bg-white dark:bg-zinc-950 text-zinc-900 dark:text-zinc-100 placeholder:text-zinc-400 dark:placeholder:text-zinc-600"
         />
         {groupingToggle}
+        {groupingMode === 'spatial' && (
+          <HierarchySortControl value={sortMode} onChange={setSortMode} />
+        )}
       </div>
 
       {/* Section Header */}

--- a/apps/viewer/src/components/viewer/hierarchy/HierarchySortControl.tsx
+++ b/apps/viewer/src/components/viewer/hierarchy/HierarchySortControl.tsx
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Sort-order selector for the spatial browser (issue #1296). The tree defaults
+ * to elevation order (the top-down building stack), which reads as arbitrary
+ * when storey names don't track height; this lets the user switch to an
+ * alphanumeric (natural-numeric) name sort, in either direction.
+ *
+ * Only meaningful in the spatial grouping mode — the Class / Type / Material
+ * trees are already name-sorted — so the panel renders it just for `spatial`.
+ */
+
+import { ChevronDown, ArrowDownWideNarrow, ArrowUpWideNarrow, ArrowDownAZ, ArrowUpAZ } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import type { HierarchySortMode } from './types';
+
+const SORT_OPTIONS: ReadonlyArray<{
+  value: HierarchySortMode;
+  /** Short word for the trigger; the icon carries the direction. */
+  short: string;
+  label: string;
+  Icon: typeof ArrowDownWideNarrow;
+}> = [
+  { value: 'elevation-desc', short: 'Elevation', label: 'Elevation, high to low', Icon: ArrowDownWideNarrow },
+  { value: 'elevation-asc', short: 'Elevation', label: 'Elevation, low to high', Icon: ArrowUpWideNarrow },
+  { value: 'name-asc', short: 'Name', label: 'Name, A to Z', Icon: ArrowDownAZ },
+  { value: 'name-desc', short: 'Name', label: 'Name, Z to A', Icon: ArrowUpAZ },
+];
+
+interface HierarchySortControlProps {
+  value: HierarchySortMode;
+  onChange: (mode: HierarchySortMode) => void;
+}
+
+export function HierarchySortControl({ value, onChange }: HierarchySortControlProps) {
+  const active = SORT_OPTIONS.find((o) => o.value === value) ?? SORT_OPTIONS[0];
+  const ActiveIcon = active.Icon;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-6 w-full justify-between gap-1 px-2 mt-1 text-[10px] rounded-none uppercase tracking-wider"
+          title="Sort storeys"
+        >
+          <span className="flex items-center gap-1 min-w-0">
+            <ActiveIcon className="h-3 w-3 shrink-0" />
+            <span className="truncate">Sort: {active.short}</span>
+          </span>
+          <ChevronDown className="h-3 w-3 shrink-0 opacity-60" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="min-w-[11rem]">
+        <DropdownMenuRadioGroup value={value} onValueChange={(v) => onChange(v as HierarchySortMode)}>
+          {SORT_OPTIONS.map(({ value: optValue, label, Icon }) => (
+            <DropdownMenuRadioItem key={optValue} value={optValue} className="text-xs gap-2">
+              <Icon className="h-3.5 w-3.5 shrink-0" />
+              {label}
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.test.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.test.ts
@@ -7,7 +7,8 @@ import assert from 'node:assert';
 import { IfcTypeEnum, RelationshipType, type SpatialHierarchy, type SpatialNode } from '@ifc-lite/data';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import { useViewerStore, type FederatedModel } from '@/store';
-import { buildTreeData, buildTypeTree, type AuthoredProduct } from './treeDataBuilder';
+import { buildTreeData, buildTypeTree, compareStoreyEntries, type AuthoredProduct } from './treeDataBuilder';
+import type { HierarchySortMode } from './types';
 
 function createSpatialNode(
   expressId: number,
@@ -299,5 +300,93 @@ describe('buildTreeData', () => {
     assert.strictEqual(railing.ifcType, 'IfcRailing');
     assert.strictEqual(flight.depth, stair.depth + 1, 'parts nest one level under the assembly');
     assert.strictEqual(flight.hasChildren, false, 'leaf parts are not expandable');
+  });
+});
+
+/** Three storeys whose names deliberately don't track elevation, so each sort
+ *  mode produces a distinct order. Storey express ids: 4 = "Level 10" @ 0m,
+ *  5 = "Level 2" @ 6m, 6 = "Level 1" @ 3m. Children are listed 4,5,6. */
+function createSortStoreyDataStore(): IfcDataStore {
+  const s10 = createSpatialNode(4, IfcTypeEnum.IfcBuildingStorey, 'Level 10');
+  s10.elevation = 0;
+  const s2 = createSpatialNode(5, IfcTypeEnum.IfcBuildingStorey, 'Level 2');
+  s2.elevation = 6;
+  const s1 = createSpatialNode(6, IfcTypeEnum.IfcBuildingStorey, 'Level 1');
+  s1.elevation = 3;
+  const buildingNode = createSpatialNode(3, IfcTypeEnum.IfcBuilding, 'MY_BUILDING', [s10, s2, s1]);
+  const siteNode = createSpatialNode(2, IfcTypeEnum.IfcSite, 'MY_SITE', [buildingNode]);
+  const projectNode = createSpatialNode(1, IfcTypeEnum.IfcProject, 'MY_PROJECT', [siteNode]);
+
+  const spatialHierarchy: SpatialHierarchy = {
+    project: projectNode,
+    byStorey: new Map([[4, []], [5, []], [6, []]]),
+    byBuilding: new Map(),
+    bySite: new Map(),
+    bySpace: new Map(),
+    storeyElevations: new Map([[4, 0], [5, 6], [6, 3]]),
+    storeyHeights: new Map(),
+    elementToStorey: new Map(),
+    getStoreyElements: () => [],
+    getStoreyByElevation: () => null,
+    getContainingSpace: () => null,
+    getPath: () => [],
+  };
+
+  return {
+    spatialHierarchy,
+    entities: {
+      count: 0,
+      getName: () => '',
+      getTypeName: () => 'Unknown',
+    },
+  } as unknown as IfcDataStore;
+}
+
+describe('storey sort order (#1296)', () => {
+  // Expand project/site/building so the storey children are emitted in sorted order.
+  const expanded = new Set(['root-1', 'root-1-2', 'root-1-2-3']);
+
+  function storeyOrder(sortMode: HierarchySortMode): number[] {
+    const nodes = buildTreeData(new Map(), createSortStoreyDataStore(), expanded, false, [], sortMode);
+    return nodes
+      .filter((n) => n.type === 'IfcBuildingStorey')
+      .map((n) => n.expressIds[0]);
+  }
+
+  it('defaults to elevation, highest first', () => {
+    // No explicit mode → previous behaviour preserved.
+    const nodes = buildTreeData(new Map(), createSortStoreyDataStore(), expanded, false, []);
+    const order = nodes.filter((n) => n.type === 'IfcBuildingStorey').map((n) => n.expressIds[0]);
+    assert.deepStrictEqual(order, [5, 6, 4]);
+  });
+
+  it('elevation-desc orders highest elevation first', () => {
+    assert.deepStrictEqual(storeyOrder('elevation-desc'), [5, 6, 4]);
+  });
+
+  it('elevation-asc orders lowest elevation first', () => {
+    assert.deepStrictEqual(storeyOrder('elevation-asc'), [4, 6, 5]);
+  });
+
+  it('name-asc sorts alphanumerically with natural numeric order (Level 2 before Level 10)', () => {
+    assert.deepStrictEqual(storeyOrder('name-asc'), [6, 5, 4]);
+  });
+
+  it('name-desc reverses the alphanumeric order', () => {
+    assert.deepStrictEqual(storeyOrder('name-desc'), [4, 5, 6]);
+  });
+});
+
+describe('compareStoreyEntries', () => {
+  it('treats missing elevation as 0', () => {
+    const a = { name: 'A' };
+    const b = { name: 'B', elevation: 5 };
+    // desc: b (5) before a (0) → positive when comparing (a, b)
+    assert.ok(compareStoreyEntries(a, b, 'elevation-desc') > 0);
+    assert.ok(compareStoreyEntries(a, b, 'elevation-asc') < 0);
+  });
+
+  it('name sort is case-insensitive', () => {
+    assert.strictEqual(compareStoreyEntries({ name: 'roof' }, { name: 'ROOF' }, 'name-asc'), 0);
   });
 });

--- a/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.test.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.test.ts
@@ -390,3 +390,98 @@ describe('compareStoreyEntries', () => {
     assert.strictEqual(compareStoreyEntries({ name: 'roof' }, { name: 'ROOF' }, 'name-asc'), 0);
   });
 });
+
+/** IFC4.3 facility with three IfcFacilityPart rows named "Part 10/2/1"
+ *  (express ids 4/5/6), listed 4,5,6 under an IfcFacility. */
+function createFacilityPartsDataStore(): IfcDataStore {
+  const p10 = createSpatialNode(4, IfcTypeEnum.IfcFacilityPart, 'Part 10');
+  const p2 = createSpatialNode(5, IfcTypeEnum.IfcFacilityPart, 'Part 2');
+  const p1 = createSpatialNode(6, IfcTypeEnum.IfcFacilityPart, 'Part 1');
+  const facilityNode = createSpatialNode(2, IfcTypeEnum.IfcFacility, 'FACILITY', [p10, p2, p1]);
+  const projectNode = createSpatialNode(1, IfcTypeEnum.IfcProject, 'PROJECT', [facilityNode]);
+
+  const spatialHierarchy: SpatialHierarchy = {
+    project: projectNode,
+    byStorey: new Map(),
+    byBuilding: new Map(),
+    bySite: new Map(),
+    bySpace: new Map(),
+    storeyElevations: new Map(),
+    storeyHeights: new Map(),
+    elementToStorey: new Map(),
+    getStoreyElements: () => [],
+    getStoreyByElevation: () => null,
+    getContainingSpace: () => null,
+    getPath: () => [],
+  };
+
+  return {
+    spatialHierarchy,
+    entities: { count: 0, getName: () => '', getTypeName: () => 'Unknown' },
+  } as unknown as IfcDataStore;
+}
+
+/** A building with mixed children: storey "Level B" (4), space "Atrium" (5),
+ *  storey "Level A" (6) — listed 4,5,6. The space is a non-level sibling. */
+function createMixedChildrenDataStore(): IfcDataStore {
+  const sB = createSpatialNode(4, IfcTypeEnum.IfcBuildingStorey, 'Level B');
+  sB.elevation = 0;
+  const space = createSpatialNode(5, IfcTypeEnum.IfcSpace, 'Atrium');
+  const sA = createSpatialNode(6, IfcTypeEnum.IfcBuildingStorey, 'Level A');
+  sA.elevation = 0;
+  const buildingNode = createSpatialNode(3, IfcTypeEnum.IfcBuilding, 'MY_BUILDING', [sB, space, sA]);
+  const siteNode = createSpatialNode(2, IfcTypeEnum.IfcSite, 'MY_SITE', [buildingNode]);
+  const projectNode = createSpatialNode(1, IfcTypeEnum.IfcProject, 'MY_PROJECT', [siteNode]);
+
+  const spatialHierarchy: SpatialHierarchy = {
+    project: projectNode,
+    byStorey: new Map([[4, []], [6, []]]),
+    byBuilding: new Map(),
+    bySite: new Map(),
+    bySpace: new Map([[5, []]]),
+    storeyElevations: new Map([[4, 0], [6, 0]]),
+    storeyHeights: new Map(),
+    elementToStorey: new Map(),
+    getStoreyElements: () => [],
+    getStoreyByElevation: () => null,
+    getContainingSpace: () => null,
+    getPath: () => [],
+  };
+
+  return {
+    spatialHierarchy,
+    entities: { count: 0, getName: () => '', getTypeName: () => 'Unknown' },
+  } as unknown as IfcDataStore;
+}
+
+describe('storey sort order — IFC4.3 parts and non-level siblings (#1296)', () => {
+  it('sorts IfcFacilityPart rows, not just IfcBuildingStorey', () => {
+    const nodes = buildTreeData(
+      new Map(),
+      createFacilityPartsDataStore(),
+      new Set(['root-1', 'root-1-2']),
+      false,
+      [],
+      'name-asc',
+    );
+    const order = nodes.filter((n) => n.type === 'IfcFacilityPart').map((n) => n.expressIds[0]);
+    // Part 1, Part 2, Part 10 (natural numeric) → ids 6, 5, 4
+    assert.deepStrictEqual(order, [6, 5, 4]);
+  });
+
+  it('keeps a non-level sibling (IfcSpace) in its original slot while sorting storeys', () => {
+    const nodes = buildTreeData(
+      new Map(),
+      createMixedChildrenDataStore(),
+      new Set(['root-1', 'root-1-2', 'root-1-2-3']),
+      false,
+      [],
+      'name-asc',
+    );
+    const order = nodes
+      .filter((n) => (n.type === 'IfcBuildingStorey' || n.type === 'IfcSpace') && n.id.startsWith('root-1-2-3-'))
+      .map((n) => n.expressIds[0]);
+    // Storeys A(6)/B(4) reorder by name; the space (5) stays in the middle slot.
+    assert.deepStrictEqual(order, [6, 5, 4]);
+  });
+});

--- a/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.ts
@@ -28,6 +28,22 @@ export function elevationKey(elevation: number): string {
   return (Math.round(elevation * 2) / 2).toFixed(2);
 }
 
+/** "Level" rows the browser sorts: building storeys plus their IFC4.3
+ *  facility-part equivalents (facility / bridge / road / railway parts). These
+ *  are the elevation-bearing leaf containers under a building or facility, so
+ *  they share the storey sort; other spatial children (Site, Building, Space)
+ *  keep their document order. `isStoreyLikeSpatialType` covers only
+ *  IfcBuildingStorey, hence the explicit part types here. */
+function isLevelLikeSpatialType(type: IfcTypeEnum): boolean {
+  return (
+    isStoreyLikeSpatialType(type) ||
+    type === IfcTypeEnum.IfcFacilityPart ||
+    type === IfcTypeEnum.IfcBridgePart ||
+    type === IfcTypeEnum.IfcRoadPart ||
+    type === IfcTypeEnum.IfcRailwayPart
+  );
+}
+
 /** Natural, case-insensitive name collation so "Level 2" sorts before "Level 10". */
 const storeyNameCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
 
@@ -338,13 +354,19 @@ function buildSpatialNodes(
   });
 
   if (isNodeExpanded) {
-    // Reorder storey-like children by the chosen browser sort mode (#1296).
-    // Only storey lists are reordered; other spatial children (Site, Building)
-    // keep their document order.
-    const containsStoreys = (spatialNode.children || []).some((child) => isStoreyLikeSpatialType(child.type));
-    const sortedChildren = containsStoreys
-      ? [...(spatialNode.children || [])].sort((a, b) => compareStoreyEntries(a, b, sortMode))
-      : spatialNode.children || [];
+    // Reorder the level-like children (storeys + facility parts) by the chosen
+    // browser sort mode (#1296), sorting only those rows IN PLACE so non-level
+    // siblings (Site, Building, Space) keep their document position.
+    const children = spatialNode.children || [];
+    const levelChildren = children.filter((child) => isLevelLikeSpatialType(child.type));
+    let sortedChildren = children;
+    if (levelChildren.length > 1) {
+      const sortedLevels = [...levelChildren].sort((a, b) => compareStoreyEntries(a, b, sortMode));
+      let li = 0;
+      sortedChildren = children.map((child) =>
+        isLevelLikeSpatialType(child.type) ? sortedLevels[li++] : child,
+      );
+    }
 
     for (const child of sortedChildren) {
       buildSpatialNodes(

--- a/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.ts
@@ -20,11 +20,35 @@ import {
   getAggregatedChildren,
   type AggregationRelationships,
 } from '@/utils/aggregation';
-import type { TreeNode, NodeType, StoreyData, UnifiedStorey } from './types';
+import type { TreeNode, NodeType, StoreyData, UnifiedStorey, HierarchySortMode } from './types';
+import { DEFAULT_HIERARCHY_SORT } from './types';
 
 /** Helper to create elevation key (with 0.5m tolerance for matching) */
 export function elevationKey(elevation: number): string {
   return (Math.round(elevation * 2) / 2).toFixed(2);
+}
+
+/** Natural, case-insensitive name collation so "Level 2" sorts before "Level 10". */
+const storeyNameCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
+
+/** Order two storey-like entries (unified storeys or spatial nodes) by the
+ *  browser sort mode chosen in the hierarchy panel (issue #1296). */
+export function compareStoreyEntries(
+  a: { name: string; elevation?: number },
+  b: { name: string; elevation?: number },
+  mode: HierarchySortMode,
+): number {
+  switch (mode) {
+    case 'elevation-asc':
+      return (a.elevation ?? 0) - (b.elevation ?? 0);
+    case 'name-asc':
+      return storeyNameCollator.compare(a.name, b.name);
+    case 'name-desc':
+      return storeyNameCollator.compare(b.name, a.name);
+    case 'elevation-desc':
+    default:
+      return (b.elevation ?? 0) - (a.elevation ?? 0);
+  }
 }
 
 /** Convert IfcTypeEnum to NodeType string */
@@ -122,7 +146,10 @@ function getSpatialNodeElements(
 }
 
 /** Build unified storey data for multi-model mode */
-export function buildUnifiedStoreys(models: Map<string, FederatedModel>): UnifiedStorey[] {
+export function buildUnifiedStoreys(
+  models: Map<string, FederatedModel>,
+  sortMode: HierarchySortMode = DEFAULT_HIERARCHY_SORT,
+): UnifiedStorey[] {
   if (models.size <= 1) return [];
 
   const storeysByElevation = new Map<string, UnifiedStorey>();
@@ -167,7 +194,7 @@ export function buildUnifiedStoreys(models: Map<string, FederatedModel>): Unifie
   }
 
   return Array.from(storeysByElevation.values())
-    .sort((a, b) => b.elevation - a.elevation);
+    .sort((a, b) => compareStoreyEntries(a, b, sortMode));
 }
 
 /** Get all element IDs for a unified storey (as global IDs) - optimized to avoid spread operator */
@@ -267,7 +294,8 @@ function buildSpatialNodes(
   idOffset: number,
   expandedNodes: Set<string>,
   nodes: TreeNode[],
-  descendantSpaceCache: Map<number, Set<number>>
+  descendantSpaceCache: Map<number, Set<number>>,
+  sortMode: HierarchySortMode
 ): void {
   const nodeId = `${parentNodeId}-${spatialNode.expressId}`;
   const nodeType = getNodeType(spatialNode.type);
@@ -310,10 +338,12 @@ function buildSpatialNodes(
   });
 
   if (isNodeExpanded) {
-    // Sort storeys by elevation descending
-    const shouldSortByElevation = (spatialNode.children || []).some((child) => isStoreyLikeSpatialType(child.type));
-    const sortedChildren = shouldSortByElevation
-      ? [...(spatialNode.children || [])].sort((a, b) => (b.elevation || 0) - (a.elevation || 0))
+    // Reorder storey-like children by the chosen browser sort mode (#1296).
+    // Only storey lists are reordered; other spatial children (Site, Building)
+    // keep their document order.
+    const containsStoreys = (spatialNode.children || []).some((child) => isStoreyLikeSpatialType(child.type));
+    const sortedChildren = containsStoreys
+      ? [...(spatialNode.children || [])].sort((a, b) => compareStoreyEntries(a, b, sortMode))
       : spatialNode.children || [];
 
     for (const child of sortedChildren) {
@@ -328,7 +358,8 @@ function buildSpatialNodes(
         idOffset,
         expandedNodes,
         nodes,
-        descendantSpaceCache
+        descendantSpaceCache,
+        sortMode
       );
     }
 
@@ -348,7 +379,8 @@ export function buildTreeData(
   ifcDataStore: IfcDataStore | null | undefined,
   expandedNodes: Set<string>,
   isMultiModel: boolean,
-  unifiedStoreys: UnifiedStorey[]
+  unifiedStoreys: UnifiedStorey[],
+  sortMode: HierarchySortMode = DEFAULT_HIERARCHY_SORT
 ): TreeNode[] {
   const nodes: TreeNode[] = [];
 
@@ -460,7 +492,8 @@ export function buildTreeData(
           model.idOffset ?? 0,
           expandedNodes,
           nodes,
-          descendantSpaceCache
+          descendantSpaceCache,
+          sortMode
         );
       }
     }
@@ -480,7 +513,8 @@ export function buildTreeData(
         model.idOffset ?? 0,
         expandedNodes,
         nodes,
-        descendantSpaceCache
+        descendantSpaceCache,
+        sortMode
       );
     }
   } else if (ifcDataStore?.spatialHierarchy?.project) {
@@ -497,7 +531,8 @@ export function buildTreeData(
       0,
       expandedNodes,
       nodes,
-      descendantSpaceCache
+      descendantSpaceCache,
+      sortMode
     );
   }
 

--- a/apps/viewer/src/components/viewer/hierarchy/types.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/types.ts
@@ -77,6 +77,26 @@ export interface UnifiedStorey {
   totalElements: number;
 }
 
+/**
+ * How the spatial browser orders storeys (and storey-like spatial parts).
+ * Elevation keeps the building-section mental model; name is alphanumeric with
+ * natural numeric ordering so "Level 2" sorts before "Level 10" (issue #1296).
+ */
+export type HierarchySortMode =
+  | 'elevation-desc'  // highest storey first (default — top-down building stack)
+  | 'elevation-asc'   // lowest storey first
+  | 'name-asc'        // A to Z
+  | 'name-desc';      // Z to A
+
+export const HIERARCHY_SORT_MODES: readonly HierarchySortMode[] = [
+  'elevation-desc',
+  'elevation-asc',
+  'name-asc',
+  'name-desc',
+];
+
+export const DEFAULT_HIERARCHY_SORT: HierarchySortMode = 'elevation-desc';
+
 // Spatial container types (all non-leaf spatial nodes) - these don't participate in storey filters.
 const SPATIAL_CONTAINER_TYPES: Set<NodeType> = new Set([
   'IfcProject',

--- a/apps/viewer/src/components/viewer/hierarchy/useHierarchyTree.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/useHierarchyTree.ts
@@ -6,7 +6,8 @@ import { useMemo, useState, useCallback, useEffect } from 'react';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import type { GeometryResult } from '@ifc-lite/geometry';
 import { useViewerStore, type FederatedModel } from '@/store';
-import type { TreeNode, UnifiedStorey } from './types';
+import type { TreeNode, UnifiedStorey, HierarchySortMode } from './types';
+import { HIERARCHY_SORT_MODES, DEFAULT_HIERARCHY_SORT } from './types';
 import {
   buildUnifiedStoreys,
   getUnifiedStoreyElements as getUnifiedStoreyElementsFn,
@@ -20,6 +21,18 @@ import {
 } from './treeDataBuilder';
 
 export type GroupingMode = 'spatial' | 'type' | 'ifc-type' | 'material';
+
+const SORT_STORAGE_KEY = 'hierarchy-sort';
+
+/** Read the persisted sort mode, falling back to the default for missing or
+ *  stale (e.g. renamed) localStorage values. */
+function readStoredSortMode(): HierarchySortMode {
+  if (typeof window === 'undefined') return DEFAULT_HIERARCHY_SORT;
+  const stored = localStorage.getItem(SORT_STORAGE_KEY);
+  return stored && (HIERARCHY_SORT_MODES as readonly string[]).includes(stored)
+    ? (stored as HierarchySortMode)
+    : DEFAULT_HIERARCHY_SORT;
+}
 
 interface UseHierarchyTreeParams {
   models: Map<string, FederatedModel>;
@@ -60,11 +73,12 @@ export function useHierarchyTree({ models, ifcDataStore, isMultiModel, geometryR
   const [groupingMode, setGroupingMode] = useState<GroupingMode>(() =>
     (typeof window !== 'undefined' && localStorage.getItem('hierarchy-grouping') as GroupingMode) || 'spatial'
   );
+  const [sortMode, setSortMode] = useState<HierarchySortMode>(readStoredSortMode);
 
   // Build unified storey data for multi-model mode (moved before useEffect that depends on it)
   const unifiedStoreys = useMemo(
-    (): UnifiedStorey[] => buildUnifiedStoreys(models),
-    [models]
+    (): UnifiedStorey[] => buildUnifiedStoreys(models, sortMode),
+    [models, sortMode]
   );
 
   // Auto-expand nodes on initial load based on model count
@@ -229,9 +243,9 @@ export function useHierarchyTree({ models, ifcDataStore, isMultiModel, geometryR
       if (groupingMode === 'material') {
         return buildMaterialTree(models, ifcDataStore, expandedNodes, isMultiModel, geometricIds);
       }
-      return buildTreeData(models, ifcDataStore, expandedNodes, isMultiModel, unifiedStoreys);
+      return buildTreeData(models, ifcDataStore, expandedNodes, isMultiModel, unifiedStoreys, sortMode);
     },
-    [models, ifcDataStore, expandedNodes, isMultiModel, unifiedStoreys, groupingMode, geometricIds, authoredProducts]
+    [models, ifcDataStore, expandedNodes, isMultiModel, unifiedStoreys, sortMode, groupingMode, geometricIds, authoredProducts]
   );
 
   // Filter nodes based on search
@@ -327,11 +341,21 @@ export function useHierarchyTree({ models, ifcDataStore, isMultiModel, geometryR
     }
   }, []);
 
+  // Persist storey sort-order preference (issue #1296)
+  const handleSetSortMode = useCallback((mode: HierarchySortMode) => {
+    setSortMode(mode);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(SORT_STORAGE_KEY, mode);
+    }
+  }, []);
+
   return {
     searchQuery,
     setSearchQuery,
     groupingMode,
     setGroupingMode: handleSetGroupingMode,
+    sortMode,
+    setSortMode: handleSetSortMode,
     unifiedStoreys,
     treeData,
     filteredNodes,

--- a/apps/viewer/src/components/viewer/hierarchy/useHierarchyTree.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/useHierarchyTree.ts
@@ -25,13 +25,18 @@ export type GroupingMode = 'spatial' | 'type' | 'ifc-type' | 'material';
 const SORT_STORAGE_KEY = 'hierarchy-sort';
 
 /** Read the persisted sort mode, falling back to the default for missing or
- *  stale (e.g. renamed) localStorage values. */
+ *  stale (e.g. renamed) localStorage values. Reads can throw (private mode,
+ *  opaque origin), so guard and fall back rather than break the panel mount. */
 function readStoredSortMode(): HierarchySortMode {
   if (typeof window === 'undefined') return DEFAULT_HIERARCHY_SORT;
-  const stored = localStorage.getItem(SORT_STORAGE_KEY);
-  return stored && (HIERARCHY_SORT_MODES as readonly string[]).includes(stored)
-    ? (stored as HierarchySortMode)
-    : DEFAULT_HIERARCHY_SORT;
+  try {
+    const stored = localStorage.getItem(SORT_STORAGE_KEY);
+    return stored && (HIERARCHY_SORT_MODES as readonly string[]).includes(stored)
+      ? (stored as HierarchySortMode)
+      : DEFAULT_HIERARCHY_SORT;
+  } catch {
+    return DEFAULT_HIERARCHY_SORT;
+  }
 }
 
 interface UseHierarchyTreeParams {
@@ -345,7 +350,11 @@ export function useHierarchyTree({ models, ifcDataStore, isMultiModel, geometryR
   const handleSetSortMode = useCallback((mode: HierarchySortMode) => {
     setSortMode(mode);
     if (typeof window !== 'undefined') {
-      localStorage.setItem(SORT_STORAGE_KEY, mode);
+      try {
+        localStorage.setItem(SORT_STORAGE_KEY, mode);
+      } catch {
+        // Private mode / quota — keep the in-memory choice, just don't persist.
+      }
     }
   }, []);
 


### PR DESCRIPTION
Closes #1296.

## Problem
The model browser sorted storeys only by elevation (highest first). When storey names do not track height, that order reads as arbitrary, and the issue asked for an alphanumeric option.

## Change
Adds a sort selector under the grouping toggle, shown only in the spatial view (the Class / Type / Material trees are already name-sorted). Four modes:

- Elevation, high to low (default, preserves prior behavior)
- Elevation, low to high
- Name, A to Z
- Name, Z to A

Name sorting uses natural numeric collation, so `Level 2` sorts before `Level 10` (not after). The choice persists in `localStorage` and applies uniformly to single-model storeys, federated unified storeys, and storey-like spatial parts (`IfcFacilityPart` etc.).

The Spacemouse navigation idea raised in the issue is a separate input-device feature and is intentionally out of scope here.

## Files
- `hierarchy/types.ts` - `HierarchySortMode` type + default
- `hierarchy/treeDataBuilder.ts` - `compareStoreyEntries` comparator threaded through `buildUnifiedStoreys` / `buildTreeData` / `buildSpatialNodes`
- `hierarchy/useHierarchyTree.ts` - sort state + `localStorage` persistence
- `hierarchy/HierarchySortControl.tsx` - new dropdown control
- `HierarchyPanel.tsx` - wires the control into both layouts
- `hierarchy/treeDataBuilder.test.ts` - 7 new tests

## Verification
- `tsc --noEmit`: clean on all touched files.
- Tests: 12/12 pass, including the natural-numeric `Level 2` before `Level 10` case and the unchanged default-order regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a storey sorting control to the hierarchy panel when using spatial grouping mode.
  * Users can now sort entries by elevation (high-to-low or low-to-high) or by name (A–Z or Z–A).
  * The selected sort preference is saved and automatically restored between sessions.

* **Tests**
  * Expanded test coverage for storey ordering across multiple sort modes and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->