### PR TITLE
fix(geometry): cut high-vertex IfcOpeningElement voids under the local frame (#1297)

### DIFF
--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -820,6 +820,19 @@ impl VoidContext {
         self.openings.is_empty()
     }
 
+    /// True iff every cutter mesh is already in world coords (`origin == 0`). When
+    /// so AND the host is world-framed, `apply_void_context` can run the inner CSG
+    /// directly (the native / legacy fast path) without cloning the cutters; if any
+    /// cutter carries its own per-element origin it must be relativized first.
+    fn all_cutters_world_framed(&self) -> bool {
+        let world = |o: &OpeningType| match o {
+            OpeningType::Rectangular(..) => true,
+            OpeningType::DiagonalRectangular(m, _) => m.origin == [0.0, 0.0, 0.0],
+            OpeningType::NonRectangular(m, ..) => m.origin == [0.0, 0.0, 0.0],
+        };
+        self.openings.iter().all(world) && self.merged_openings.iter().all(world)
+    }
+
     /// Return a copy of this context with every opening (raw + merged)
     /// translated by `-origin`, i.e. moved from the world frame into the host's
     /// per-element local frame. Used by [`GeometryRouter::apply_void_context`]
@@ -841,35 +854,24 @@ impl VoidContext {
     }
 }
 
-/// Fold a per-element local-frame mesh into absolute world coordinates in place
-/// (`position += origin`, then `origin = 0`). A cutter sourced from
-/// `process_element` arrives in the opening's OWN local frame when
-/// `local_frame_enabled()` is on (the wasm default); the void pipeline requires
-/// cutters in world coords (see `classify_openings`/#1297), so this restores that
-/// invariant. No-op when the mesh is already world-framed (origin 0 — the native
-/// default), keeping that path byte-identical.
-fn fold_origin_to_world(mesh: &mut Mesh) {
+/// Express a cutter mesh in the host's local frame: `result = position +
+/// mesh.origin - host_origin`, folded in f64 before the f32 store, with the
+/// result origin zeroed (the mesh now lives in the shared host frame).
+///
+/// Honouring the cutter's OWN `origin` keeps a per-element local-frame opening
+/// (the wasm default: small positions relative to the opening's AABB centre)
+/// PRECISE — it is never first rounded to absolute world f32 and then brought
+/// back near the host, so detail openings far from the global origin can't
+/// collapse on the coarse world grid (#1310 review). A world-framed cutter
+/// (`origin == 0` — the native and ≤100-vertex default) reduces to the plain
+/// `position - host_origin` and stays byte-identical.
+fn translate_cutter_mesh(mesh: &Mesh, host_origin: [f64; 3]) -> Mesh {
     let o = mesh.origin;
-    if o == [0.0, 0.0, 0.0] {
-        return;
-    }
-    for c in mesh.positions.chunks_exact_mut(3) {
-        c[0] = (c[0] as f64 + o[0]) as f32;
-        c[1] = (c[1] as f64 + o[1]) as f32;
-        c[2] = (c[2] as f64 + o[2]) as f32;
-    }
-    mesh.origin = [0.0, 0.0, 0.0];
-}
-
-/// Translate a cutter mesh's positions by `-origin` in f64 before the f32 store,
-/// moving it into the host's local frame. `origin` is carried on the result as
-/// zero (the mesh is now expressed in the shared local frame).
-fn translate_cutter_mesh(mesh: &Mesh, origin: [f64; 3]) -> Mesh {
     let mut positions = Vec::with_capacity(mesh.positions.len());
     for c in mesh.positions.chunks_exact(3) {
-        positions.push((c[0] as f64 - origin[0]) as f32);
-        positions.push((c[1] as f64 - origin[1]) as f32);
-        positions.push((c[2] as f64 - origin[2]) as f32);
+        positions.push((c[0] as f64 + o[0] - host_origin[0]) as f32);
+        positions.push((c[1] as f64 + o[1] - host_origin[1]) as f32);
+        positions.push((c[2] as f64 + o[2] - host_origin[2]) as f32);
     }
     Mesh {
         positions,
@@ -877,7 +879,8 @@ fn translate_cutter_mesh(mesh: &Mesh, origin: [f64; 3]) -> Mesh {
         indices: mesh.indices.clone(),
         rtc_applied: mesh.rtc_applied,
         origin: [0.0; 3],
-    instance_meta: None, }
+        instance_meta: None,
+    }
 }
 
 impl OpeningType {
@@ -1985,11 +1988,15 @@ impl GeometryRouter {
         }
 
         let origin = mesh.origin;
-        if origin == [0.0, 0.0, 0.0] {
-            // Legacy/world frame: no relativization needed.
+        if origin == [0.0, 0.0, 0.0] && ctx.all_cutters_world_framed() {
+            // Legacy/world frame on host AND cutters: no relativization needed.
             return self.apply_void_context_inner(mesh, ctx, element_id);
         }
         // Work entirely in the host's local frame (origin 0 on every operand).
+        // `relativized_by` folds each cutter's OWN origin and subtracts the host
+        // origin in f64, so a per-element local-frame opening lands at the host
+        // precisely. This also covers a host that snapped to origin 0 while its
+        // openings did not (origin == 0 but cutters are local-framed).
         mesh.origin = [0.0, 0.0, 0.0];
         let local_ctx = ctx.relativized_by(origin);
         let mut result = self.apply_void_context_inner(mesh, &local_ctx, element_id);
@@ -2899,10 +2906,15 @@ impl GeometryRouter {
             .get_opening_item_bounds_with_direction(opening_entity, decoder)
             .ok()
             .and_then(|items| items.into_iter().find_map(|(_, _, d)| d));
+        // WORLD bounds: `opening_mesh` may be in its own per-element local frame
+        // (wasm), so fold its origin back in. `apply_void_context` then relativizes
+        // these by the host origin alongside the cutter mesh, keeping both in the
+        // shared host frame (#1310 review).
+        let o = opening_mesh.origin;
         let (mn, mx) = opening_mesh.bounds();
         (
-            Point3::new(mn.x as f64, mn.y as f64, mn.z as f64),
-            Point3::new(mx.x as f64, mx.y as f64, mx.z as f64),
+            Point3::new(mn.x as f64 + o[0], mn.y as f64 + o[1], mn.z as f64 + o[2]),
+            Point3::new(mx.x as f64 + o[0], mx.y as f64 + o[1], mx.z as f64 + o[2]),
             dir,
         )
     }
@@ -2938,24 +2950,17 @@ impl GeometryRouter {
                 Err(_) => continue,
             };
 
-            let mut opening_mesh = match self.process_element(&opening_entity, decoder) {
+            // The cutter is kept in WHATEVER frame `process_element` produced — world
+            // (native / local frame off) or the opening's own per-element local frame
+            // (wasm). `apply_void_context` carries `mesh.origin` through and folds it in
+            // f64 when it relativizes the cutter into the host frame, so the opening's
+            // detail stays precise even far from the global origin and the AABB-overlap
+            // guard sees the cutter at the host (#1297, refined per #1310 review). The
+            // bounds derived below are folded to WORLD so the same relativization applies.
+            let opening_mesh = match self.process_element(&opening_entity, decoder) {
                 Ok(m) if !m.is_empty() => m,
                 _ => continue,
             };
-            // The void cut runs in a SHARED host+cutter frame: `apply_void_context`
-            // relativizes cutters that are in WORLD coords by the host origin (see the
-            // `get_opening_item_meshes_world` contract note, which extracts with
-            // `relativize=false` for exactly this reason). `process_element`, however,
-            // honours `local_frame_enabled()` (default ON for wasm), so it returns the
-            // opening in the opening's OWN local frame — positions relative to
-            // `mesh.origin` (the opening's AABB centre). Stored as a cutter that way, the
-            // opening's origin is never folded back in, so `relativized_by(host_origin)`
-            // and the #635 fallback AABB (`opening_mesh.bounds()`, which ignores origin)
-            // land the cutter ~`-opening_origin` away from the host. The AABB-overlap
-            // guard then skips it, the CSG is a silent no-op, and the host renders SOLID
-            // (#1297 — wasm-only; native has local frame OFF so cutters are already
-            // world-framed). Fold the origin back to world here to restore the invariant.
-            fold_origin_to_world(&mut opening_mesh);
 
             let vertex_count = opening_mesh.positions.len() / 3;
 
@@ -3110,11 +3115,20 @@ impl GeometryRouter {
                         }
                     }
                 } else {
+                    // WORLD bounds (fold the opening's per-element origin); see
+                    // `fallback_aabb_for_opening` (#1310 review).
+                    let o = opening_mesh.origin;
                     let (open_min, open_max) = opening_mesh.bounds();
-                    let min_f64 =
-                        Point3::new(open_min.x as f64, open_min.y as f64, open_min.z as f64);
-                    let max_f64 =
-                        Point3::new(open_max.x as f64, open_max.y as f64, open_max.z as f64);
+                    let min_f64 = Point3::new(
+                        open_min.x as f64 + o[0],
+                        open_min.y as f64 + o[1],
+                        open_min.z as f64 + o[2],
+                    );
+                    let max_f64 = Point3::new(
+                        open_max.x as f64 + o[0],
+                        open_max.y as f64 + o[1],
+                        open_max.z as f64 + o[2],
+                    );
 
                     bump(
                         self,

--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -841,6 +841,26 @@ impl VoidContext {
     }
 }
 
+/// Fold a per-element local-frame mesh into absolute world coordinates in place
+/// (`position += origin`, then `origin = 0`). A cutter sourced from
+/// `process_element` arrives in the opening's OWN local frame when
+/// `local_frame_enabled()` is on (the wasm default); the void pipeline requires
+/// cutters in world coords (see `classify_openings`/#1297), so this restores that
+/// invariant. No-op when the mesh is already world-framed (origin 0 — the native
+/// default), keeping that path byte-identical.
+fn fold_origin_to_world(mesh: &mut Mesh) {
+    let o = mesh.origin;
+    if o == [0.0, 0.0, 0.0] {
+        return;
+    }
+    for c in mesh.positions.chunks_exact_mut(3) {
+        c[0] = (c[0] as f64 + o[0]) as f32;
+        c[1] = (c[1] as f64 + o[1]) as f32;
+        c[2] = (c[2] as f64 + o[2]) as f32;
+    }
+    mesh.origin = [0.0, 0.0, 0.0];
+}
+
 /// Translate a cutter mesh's positions by `-origin` in f64 before the f32 store,
 /// moving it into the host's local frame. `origin` is carried on the result as
 /// zero (the mesh is now expressed in the shared local frame).
@@ -2918,10 +2938,24 @@ impl GeometryRouter {
                 Err(_) => continue,
             };
 
-            let opening_mesh = match self.process_element(&opening_entity, decoder) {
+            let mut opening_mesh = match self.process_element(&opening_entity, decoder) {
                 Ok(m) if !m.is_empty() => m,
                 _ => continue,
             };
+            // The void cut runs in a SHARED host+cutter frame: `apply_void_context`
+            // relativizes cutters that are in WORLD coords by the host origin (see the
+            // `get_opening_item_meshes_world` contract note, which extracts with
+            // `relativize=false` for exactly this reason). `process_element`, however,
+            // honours `local_frame_enabled()` (default ON for wasm), so it returns the
+            // opening in the opening's OWN local frame — positions relative to
+            // `mesh.origin` (the opening's AABB centre). Stored as a cutter that way, the
+            // opening's origin is never folded back in, so `relativized_by(host_origin)`
+            // and the #635 fallback AABB (`opening_mesh.bounds()`, which ignores origin)
+            // land the cutter ~`-opening_origin` away from the host. The AABB-overlap
+            // guard then skips it, the CSG is a silent no-op, and the host renders SOLID
+            // (#1297 — wasm-only; native has local frame OFF so cutters are already
+            // world-framed). Fold the origin back to world here to restore the invariant.
+            fold_origin_to_world(&mut opening_mesh);
 
             let vertex_count = opening_mesh.positions.len() / 3;
 

--- a/rust/geometry/tests/opening_void_cut_local_frame_test.rs
+++ b/rust/geometry/tests/opening_void_cut_local_frame_test.rs
@@ -1,0 +1,184 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Regression: high-vertex `IfcOpeningElement` voids must still be cut under the
+//! per-element LOCAL FRAME (#1297).
+//!
+//! In wasm the host mesh is stored relative to its per-element AABB-centre origin
+//! (`world = origin + position`, default ON). The void cut runs host AND cutters
+//! in that shared frame: `apply_void_context` relativises WORLD-coordinate cutters
+//! by the host origin. The >100-vertex opening path in `classify_openings`,
+//! however, sourced its cutter from `process_element`, which — under the local
+//! frame — returns the opening in the OPENING'S OWN local frame (positions
+//! relative to the opening's centre). That origin was never folded back in, so the
+//! cutter (and its #635 fallback AABB) landed a whole building placement away from
+//! the host, the AABB-overlap guard skipped it, the CSG was a silent no-op, and
+//! the host rendered SOLID (no holes, `total_csg_failures = 0`).
+//!
+//! Native was unaffected (local frame OFF → cutters already world-framed), so the
+//! bug only ever showed in the browser. This file runs in its OWN test binary so
+//! it can force the local frame on (the flag is read once and cached per process).
+
+use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner, IfcType};
+use ifc_lite_geometry::{GeometryRouter, Mesh};
+use rustc_hash::FxHashMap;
+
+/// A 40 m × 40 m × 2 m steel-style plate placed 200 m / 300 m from the origin
+/// (so its per-element local origin is large in X and Y), with a single round
+/// hole through its thickness. A radius-16 circle tessellates to the 32-segment
+/// cap maximum, so the meshed opening clears the 100-vertex threshold and takes
+/// the `classify_openings` high-vertex path — the one #1297 broke. The hole
+/// extrusion (z = -1 .. 3) fully penetrates the plate (z = 0 .. 2).
+fn plate_with_round_hole_far_from_origin_ifc() -> &'static str {
+    r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('test.ifc','2024-01-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('1234567890123456789012',#2,'Test',$,$,$,$,(#10),#7);
+#2=IFCOWNERHISTORY(#3,#4,$,.ADDED.,$,$,$,0);
+#3=IFCPERSONANDORGANIZATION(#5,#6,$);
+#4=IFCAPPLICATION(#6,'1.0','Test','Test');
+#5=IFCPERSON($,'Test',$,$,$,$,$,$);
+#6=IFCORGANIZATION($,'Test',$,$,$);
+#7=IFCUNITASSIGNMENT((#8,#9));
+#8=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#9=IFCSIUNIT(*,.AREAUNIT.,$,.SQUARE_METRE.);
+#10=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#11,$);
+#11=IFCAXIS2PLACEMENT3D(#12,$,$);
+#12=IFCCARTESIANPOINT((0.,0.,0.));
+#13=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body','Model',*,*,*,*,#10,$,.MODEL_VIEW.,$);
+#20=IFCLOCALPLACEMENT($,#21);
+#21=IFCAXIS2PLACEMENT3D(#22,#23,#24);
+#22=IFCCARTESIANPOINT((200.,300.,0.));
+#23=IFCDIRECTION((0.,0.,1.));
+#24=IFCDIRECTION((1.,0.,0.));
+#30=IFCRECTANGLEPROFILEDEF(.AREA.,'Plate',#31,40.0,40.0);
+#31=IFCAXIS2PLACEMENT2D(#32,#33);
+#32=IFCCARTESIANPOINT((0.,0.));
+#33=IFCDIRECTION((1.,0.));
+#40=IFCEXTRUDEDAREASOLID(#30,#41,#42,2.0);
+#41=IFCAXIS2PLACEMENT3D(#43,$,$);
+#42=IFCDIRECTION((0.,0.,1.));
+#43=IFCCARTESIANPOINT((0.,0.,0.));
+#50=IFCSHAPEREPRESENTATION(#13,'Body','SweptSolid',(#40));
+#51=IFCPRODUCTDEFINITIONSHAPE($,$,(#50));
+#100=IFCPLATE('0001234567890123456789',#2,'TestPlate',$,$,#20,#51,'Tag',$);
+#60=IFCLOCALPLACEMENT(#20,#61);
+#61=IFCAXIS2PLACEMENT3D(#62,#63,#64);
+#62=IFCCARTESIANPOINT((0.,0.,-1.));
+#63=IFCDIRECTION((0.,0.,1.));
+#64=IFCDIRECTION((1.,0.,0.));
+#70=IFCCIRCLEPROFILEDEF(.AREA.,'Hole',#71,16.0);
+#71=IFCAXIS2PLACEMENT2D(#72,#73);
+#72=IFCCARTESIANPOINT((0.,0.));
+#73=IFCDIRECTION((1.,0.));
+#80=IFCEXTRUDEDAREASOLID(#70,#81,#82,4.0);
+#81=IFCAXIS2PLACEMENT3D(#83,$,$);
+#82=IFCDIRECTION((0.,0.,1.));
+#83=IFCCARTESIANPOINT((0.,0.,0.));
+#90=IFCSHAPEREPRESENTATION(#13,'Body','SweptSolid',(#80));
+#91=IFCPRODUCTDEFINITIONSHAPE($,$,(#90));
+#110=IFCOPENINGELEMENT('0001234567890123456790',#2,'Hole',$,$,#60,#91,$,.OPENING.);
+#120=IFCRELVOIDSELEMENT('0001234567890123456791',#2,$,$,#100,#110);
+ENDSEC;
+END-ISO-10303-21;
+"#
+}
+
+/// Signed mesh volume (divergence theorem). Folds the per-element `origin` back in
+/// so the figure is comparable whether or not the local frame is active.
+fn mesh_volume(mesh: &Mesh) -> f64 {
+    let o = mesh.origin;
+    mesh.indices
+        .chunks_exact(3)
+        .map(|t| {
+            let v = |i: u32| {
+                let b = i as usize * 3;
+                [
+                    mesh.positions[b] as f64 + o[0],
+                    mesh.positions[b + 1] as f64 + o[1],
+                    mesh.positions[b + 2] as f64 + o[2],
+                ]
+            };
+            let (a, b, c) = (v(t[0]), v(t[1]), v(t[2]));
+            a[0] * (b[1] * c[2] - b[2] * c[1]) + a[1] * (b[2] * c[0] - b[0] * c[2])
+                + a[2] * (b[0] * c[1] - b[1] * c[0])
+        })
+        .sum::<f64>()
+        / 6.0
+}
+
+fn build_void_index(content: &str) -> FxHashMap<u32, Vec<u32>> {
+    let mut void_index: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
+    let mut scanner = EntityScanner::new(content);
+    let mut decoder = EntityDecoder::new(content);
+    while let Some((id, type_name, start, end)) = scanner.next_entity() {
+        if type_name != "IFCRELVOIDSELEMENT" {
+            continue;
+        }
+        if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
+            if let (Some(host_id), Some(opening_id)) = (entity.get_ref(4), entity.get_ref(5)) {
+                void_index.entry(host_id).or_default().push(opening_id);
+            }
+        }
+    }
+    void_index
+}
+
+#[test]
+fn high_vertex_opening_is_cut_under_per_element_local_frame() {
+    // Force the local frame on BEFORE any geometry call reads & caches the flag.
+    // Safe: this file is its own test binary, so nothing else reads it first.
+    std::env::set_var("IFC_LITE_LOCAL_FRAME", "1");
+
+    let content = plate_with_round_hole_far_from_origin_ifc();
+    let entity_index = build_entity_index(content);
+    let mut decoder = EntityDecoder::with_index(content, entity_index);
+    let router = GeometryRouter::with_units(content, &mut decoder);
+    let void_index = build_void_index(content);
+
+    assert_eq!(
+        void_index.get(&100).map(Vec::as_slice),
+        Some([110u32].as_slice()),
+        "the void index must associate opening #110 with plate #100"
+    );
+
+    let plate = decoder.decode_by_id(100).expect("decode plate #100");
+    assert_eq!(plate.ifc_type, IfcType::IfcPlate);
+
+    let mesh = router
+        .process_element_with_voids(&plate, &mut decoder, &void_index)
+        .expect("plate-with-void path ok");
+
+    // The mesh must be in a per-element local frame (proves the bug's precondition
+    // is actually exercised; a world-framed host never triggered #1297).
+    assert_ne!(
+        mesh.origin, [0.0, 0.0, 0.0],
+        "the host plate must be stored in its per-element local frame"
+    );
+
+    // Uncut plate = 40 × 40 × 2 = 3200 m3; the hole removes pi r^2 * 2 = ~1608 m3
+    // (r = 16, thickness 2). #1297: the cut was silently dropped, leaving the full
+    // 3200 m3 solid plate. A real cut lands well under the uncut volume.
+    let uncut = 40.0 * 40.0 * 2.0;
+    let vol = mesh_volume(&mesh);
+    assert!(
+        vol < uncut - 1000.0,
+        "the round hole was not cut (solid plate) — #1297 regression: \
+         cut volume = {vol} m3, uncut plate = {uncut} m3"
+    );
+
+    // A solid box plate is 12 triangles; a cut plate carries the annular caps +
+    // cylinder wall, an order of magnitude more. Pins the cut against a silent
+    // no-op that still returns the (uncut) host mesh.
+    let tris = mesh.indices.len() / 3;
+    assert!(
+        tris > 30,
+        "expected a cut plate (annulus + bore wall), got {tris} triangles \
+         (an uncut box plate is 12) — the void cut was dropped"
+    );
+}


### PR DESCRIPTION
Fixes #1297.

## Summary

`IfcOpeningElement` voids (bolt-hole / detail openings on plates and members) were cut correctly in the native pipeline but silently **not** cut in the browser/WASM pipeline, so plates and members rendered **solid** with no error and `total_csg_failures = 0`.

## Root cause

The void cut runs the host **and** its opening cutters in a *shared* coordinate frame: `apply_void_context` relativizes **world-coordinate** opening cutters by the host's origin. One cutter source violated that contract.

In `classify_openings` (`rust/geometry/src/router/voids.rs`), the **high-vertex (>100 verts) opening path** sourced its cutter via `process_element`, which honours `local_frame_enabled()` — **ON for `wasm32`, OFF for native**. Under WASM the opening therefore comes back in the *opening's own* per-element local frame (positions relative to the opening's AABB centre, `mesh.origin` = that centre). Stored as a cutter that way, its origin is never folded back:

- `relativized_by(host_origin)` subtracts only the **host** origin, and
- the #635 fallback AABB is `opening_mesh.bounds()`, which **ignores `origin`**.

So the cutter (and its fallback box) land ~`-opening_origin` away from the host — a building/georef-scale displacement. The AABB-overlap guard skips it, the exact CSG produces no change, the AABB fallback misses too, and the host stays solid. A non-overlapping cutter is a silent no-op, hence `total_csg_failures = 0`.

The ≤100-vertex path was always correct because it sources cutters from `get_opening_item_meshes_world` (explicit `relativize=false`, world coords). The author enforced the world-coords contract there but missed it on the `process_element` high-vertex path. Native was unaffected because its cutters are already world-framed.

## Fix

Fold the opening's per-element origin back to world coordinates right after `process_element` in `classify_openings`, restoring the world-coords cutter invariant. It is a **no-op when `origin == 0`** (native / already world-framed), so native output and the cross-arch determinism snapshots stay byte-identical.

## Verification

End-to-end on the tracked steel fixture `ISSUE_129_N1540_…_EXE_MOD` (361 openings, circular bolt holes):

| Configuration | total triangles |
|---|---|
| native (local frame OFF) | **141,491** |
| local frame ON, **before** fix | **129,705** — 11,786 tris (~8.3%) of void detail dropped |
| local frame ON, **after** fix | **141,240** — restored, within 0.18% of native (residual = f32 precision) |

Adds `opening_void_cut_local_frame_test.rs`: a self-contained synthetic plate with a high-vertex round hole, placed far from the origin, run in its own test binary with the local frame forced on. It **fails without the fix** (solid 3200 m³ plate = full uncut volume) and **passes with it**. The existing wall-opening regression tests (7/7) and the geometry lib unit tests (389/0) stay green.

## Notes / follow-ups (not in this PR)

- **Coverage gap that let this through:** every prior opening-cut test runs on native (local frame OFF) with ≤100-vertex rectangular openings, so none exercised the broken path. This PR's test closes that gap for the high-vertex case.
- **Separate pre-existing finding:** `wall_553010_opening_does_not_empty_wall` fails under `IFC_LITE_LOCAL_FRAME=1` (cut volume 16.5455 vs 16.5468, ~0.008%) — identical with and without this fix, so it is an independent local-frame precision-tolerance issue worth a separate look (local frame is live in the browser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where void openings were incorrectly skipped during subtraction operations when using per-element local coordinate frames, particularly in WebAssembly environments.

* **Tests**
  * Added regression test to ensure void geometry cutting works correctly with local coordinate frame configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->