### PR TITLE
fix(geometry): consistently outward-wind assembled element bodies (beam winding)

### DIFF
--- a/rust/geometry/src/lib.rs
+++ b/rust/geometry/src/lib.rs
@@ -92,6 +92,7 @@ pub mod instancing;
 pub mod kernel;
 pub mod material_layer_index;
 pub mod mesh;
+pub mod mesh_orient;
 pub mod processors;
 pub mod profile;
 pub mod profile_extractor;
@@ -126,6 +127,7 @@ pub use instancing::{
 };
 pub use material_layer_index::{LayerAxis, LayerBuildup, LayerInfo, MaterialLayerIndex};
 pub use mesh::{CoordinateShift, InstanceMeta, Mesh, SubMesh, SubMeshCollection};
+pub use mesh_orient::orient_mesh_outward;
 pub use processors::{
     AdvancedBrepProcessor, BooleanClippingProcessor, ExtrudedAreaSolidProcessor,
     ExtrudedAreaSolidTaperedProcessor, FaceBasedSurfaceModelProcessor, FacetedBrepProcessor,

--- a/rust/geometry/src/mesh_orient.rs
+++ b/rust/geometry/src/mesh_orient.rs
@@ -16,11 +16,13 @@
 //!
 //! [`orient_mesh_outward`] recovers face adjacency (the meshes are flat-shaded,
 //! so positions are welded by a fine grid), propagates a consistent orientation
-//! across shared edges per connected component, then flips each component so its
-//! signed volume is positive (outward). A non-manifold or non-orientable
-//! component is left untouched — re-orienting it is ambiguous and must not make
-//! things worse. The winding-invariant geometry hash and the summary snapshots
-//! are unaffected; only normals/quantities change, which is the point.
+//! across shared edges per connected component, then flips each CLOSED component
+//! so its signed volume is positive (outward). An OPEN component (a TIN /
+//! `SurfaceModel` sheet with boundary edges — no meaningful enclosed volume) or a
+//! non-manifold / non-orientable one is left untouched: re-orienting it is
+//! ambiguous and would reverse authored normals. The winding-invariant geometry
+//! hash and the summary snapshots are unaffected; only normals/quantities change,
+//! which is the point.
 
 use crate::Mesh;
 use rustc_hash::FxHashMap;
@@ -38,6 +40,14 @@ const WELD: f64 = 1.0e5;
 pub fn orient_mesh_outward(mesh: &mut Mesh) -> bool {
     let ntri = mesh.indices.len() / 3;
     if ntri < 2 {
+        return false;
+    }
+    // Bail cleanly on malformed buffers instead of panicking on an out-of-range
+    // index below.
+    let vertex_count = mesh.positions.len() / 3;
+    if mesh.positions.len() % 3 != 0
+        || mesh.indices.iter().any(|&idx| idx as usize >= vertex_count)
+    {
         return false;
     }
 
@@ -88,6 +98,12 @@ pub fn orient_mesh_outward(mesh: &mut Mesh) -> bool {
         let mut stack = vec![seed];
         visited[seed] = true;
         let mut orientable = true;
+        // Only a CLOSED manifold (every welded edge shared by exactly two tris) has
+        // a meaningful "outward". An OPEN component — an `IfcTriangulatedFaceSet`
+        // TIN (`Closed=.F.`), a `SurfaceModel` sheet — would be flipped by its
+        // (meaningless) signed volume, reversing the authored normals. Track any
+        // boundary/non-manifold edge and leave such a component untouched.
+        let mut closed = true;
 
         while let Some(t) = stack.pop() {
             comp.push(t);
@@ -104,9 +120,11 @@ pub fn orient_mesh_outward(mesh: &mut Mesh) -> bool {
                 }
                 let key = if a < b { (a, b) } else { (b, a) };
                 let inc = &edge_tris[&key];
+                if inc.len() != 2 {
+                    closed = false; // boundary (1) or non-manifold (>2) edge
+                }
                 if inc.len() > 2 {
-                    orientable = false; // non-manifold edge
-                    continue;
+                    continue; // ambiguous — don't propagate across a non-manifold edge
                 }
                 for &nb in inc {
                     if nb == t {
@@ -128,14 +146,14 @@ pub fn orient_mesh_outward(mesh: &mut Mesh) -> bool {
             }
         }
 
-        if !orientable {
+        if !orientable || !closed {
             for &t in &comp {
-                flip[t] = false; // leave this component's winding as authored
+                flip[t] = false; // open / non-orientable — leave winding as authored
             }
             continue;
         }
 
-        // Flip the whole component outward (positive signed volume).
+        // Flip the whole CLOSED component outward (positive signed volume).
         let mut vol6 = 0.0f64;
         for &t in &comp {
             let v = tv(t);
@@ -243,5 +261,40 @@ mod tests {
         let flipped = orient_mesh_outward(&mut m);
         assert!(flipped, "an inward-wound cube must be flipped outward");
         assert_eq!(bad_edges(&m), 0);
+    }
+
+    /// An OPEN sheet (a flat quad = two tris, with boundary edges) has no
+    /// meaningful enclosed volume. Even with one tri authored backwards, the
+    /// orienter must leave it byte-identical rather than flip it by a bogus
+    /// signed volume (which would reverse a TIN / SurfaceModel's authored normals).
+    #[test]
+    fn open_sheet_is_left_untouched() {
+        let p = [
+            [0.0f32, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0],
+        ];
+        let faces: [[usize; 3]; 2] = [[0, 1, 2], [0, 3, 2]]; // tri 1 deliberately reversed
+        let mut m = Mesh::new();
+        for f in &faces {
+            for &vi in f {
+                m.positions.extend_from_slice(&p[vi]);
+                m.normals.extend_from_slice(&[0.0, 0.0, 1.0]);
+            }
+            let base = m.indices.len() as u32;
+            m.indices.extend_from_slice(&[base, base + 1, base + 2]);
+        }
+        let before = m.indices.clone();
+        let flipped = orient_mesh_outward(&mut m);
+        assert!(!flipped, "an open sheet must not be re-oriented");
+        assert_eq!(m.indices, before, "open-sheet index buffer must be untouched");
+    }
+
+    /// Malformed buffers (an index past the vertex array) must bail cleanly, not
+    /// panic.
+    #[test]
+    fn malformed_indices_bail_without_panic() {
+        let mut m = cube(&[]);
+        m.indices[0] = 9999; // out of range
+        let flipped = orient_mesh_outward(&mut m);
+        assert!(!flipped, "malformed input must be a no-op");
     }
 }

--- a/rust/geometry/src/mesh_orient.rs
+++ b/rust/geometry/src/mesh_orient.rs
@@ -1,0 +1,247 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Make a mesh's per-triangle winding consistent and OUTWARD, per connected
+//! component.
+//!
+//! IFC faceted breps (whose face loops are not reliably outward) and merged
+//! multi-item bodies (an extrusion unioned with a boolean cut) can arrive with
+//! MIXED per-triangle winding: some faces wound outward, some inward. That
+//! corrupts signed volume (quantities) and the smooth normals
+//! [`crate::csg::calculate_normals`] accumulates from the winding (lighting). The
+//! kernel's whole-operand `orient_outward` only flips an ENTIRE mesh by its
+//! global signed volume, so it cannot repair a mesh that is internally
+//! inconsistent.
+//!
+//! [`orient_mesh_outward`] recovers face adjacency (the meshes are flat-shaded,
+//! so positions are welded by a fine grid), propagates a consistent orientation
+//! across shared edges per connected component, then flips each component so its
+//! signed volume is positive (outward). A non-manifold or non-orientable
+//! component is left untouched — re-orienting it is ambiguous and must not make
+//! things worse. The winding-invariant geometry hash and the summary snapshots
+//! are unaffected; only normals/quantities change, which is the point.
+
+use crate::Mesh;
+use rustc_hash::FxHashMap;
+
+/// Vertex weld grid (10 µm): fine enough not to merge distinct mm-scale features,
+/// coarse enough to weld the (usually bit-equal) coincident flat-shaded
+/// duplicates so shared edges are found. Under-welding only splits a body into
+/// more components (each still oriented); over-welding would fuse distinct
+/// vertices and is the dangerous direction, so the grid stays fine.
+const WELD: f64 = 1.0e5;
+
+/// Orient every connected component of `mesh` consistently and outward, in place.
+/// Returns `true` iff any triangle's winding was flipped (the caller must then
+/// recompute normals — the existing ones were baked with the old winding).
+pub fn orient_mesh_outward(mesh: &mut Mesh) -> bool {
+    let ntri = mesh.indices.len() / 3;
+    if ntri < 2 {
+        return false;
+    }
+
+    // Weld positions -> welded vertex id; record the welded vid of every corner.
+    let q = |v: f32| (v as f64 * WELD).round() as i64;
+    let mut vid_of: FxHashMap<(i64, i64, i64), u32> = FxHashMap::default();
+    let mut vpos: Vec<[f64; 3]> = Vec::new();
+    let mut corner: Vec<u32> = Vec::with_capacity(mesh.indices.len());
+    for &idx in &mesh.indices {
+        let b = idx as usize * 3;
+        let key = (
+            q(mesh.positions[b]),
+            q(mesh.positions[b + 1]),
+            q(mesh.positions[b + 2]),
+        );
+        let vid = *vid_of.entry(key).or_insert_with(|| {
+            let id = vpos.len() as u32;
+            vpos.push([key.0 as f64 / WELD, key.1 as f64 / WELD, key.2 as f64 / WELD]);
+            id
+        });
+        corner.push(vid);
+    }
+    let tv = |t: usize| [corner[3 * t], corner[3 * t + 1], corner[3 * t + 2]];
+
+    // Undirected welded edge -> incident triangles. >2 incident ⇒ non-manifold.
+    let mut edge_tris: FxHashMap<(u32, u32), Vec<usize>> = FxHashMap::default();
+    for t in 0..ntri {
+        let v = tv(t);
+        for &(a, b) in &[(v[0], v[1]), (v[1], v[2]), (v[2], v[0])] {
+            if a == b {
+                continue; // welded-degenerate edge
+            }
+            let key = if a < b { (a, b) } else { (b, a) };
+            edge_tris.entry(key).or_default().push(t);
+        }
+    }
+
+    let mut flip = vec![false; ntri];
+    let mut visited = vec![false; ntri];
+    let mut any_flip = false;
+
+    for seed in 0..ntri {
+        if visited[seed] {
+            continue;
+        }
+        // BFS the component, propagating a consistent orientation.
+        let mut comp: Vec<usize> = Vec::new();
+        let mut stack = vec![seed];
+        visited[seed] = true;
+        let mut orientable = true;
+
+        while let Some(t) = stack.pop() {
+            comp.push(t);
+            let v = tv(t);
+            // Effective directed edges of t given its current flip.
+            let dirs = if flip[t] {
+                [(v[0], v[2]), (v[2], v[1]), (v[1], v[0])]
+            } else {
+                [(v[0], v[1]), (v[1], v[2]), (v[2], v[0])]
+            };
+            for &(a, b) in &dirs {
+                if a == b {
+                    continue;
+                }
+                let key = if a < b { (a, b) } else { (b, a) };
+                let inc = &edge_tris[&key];
+                if inc.len() > 2 {
+                    orientable = false; // non-manifold edge
+                    continue;
+                }
+                for &nb in inc {
+                    if nb == t {
+                        continue;
+                    }
+                    // A consistent neighbour must traverse this edge as (b, a). Its
+                    // UNFLIPPED winding has (a, b) iff it must flip to do so.
+                    let nv = tv(nb);
+                    let need_flip =
+                        [(nv[0], nv[1]), (nv[1], nv[2]), (nv[2], nv[0])].contains(&(a, b));
+                    if !visited[nb] {
+                        visited[nb] = true;
+                        flip[nb] = need_flip;
+                        stack.push(nb);
+                    } else if flip[nb] != need_flip {
+                        orientable = false; // contradiction (non-orientable)
+                    }
+                }
+            }
+        }
+
+        if !orientable {
+            for &t in &comp {
+                flip[t] = false; // leave this component's winding as authored
+            }
+            continue;
+        }
+
+        // Flip the whole component outward (positive signed volume).
+        let mut vol6 = 0.0f64;
+        for &t in &comp {
+            let v = tv(t);
+            let (i0, i1, i2) = if flip[t] {
+                (v[0], v[2], v[1])
+            } else {
+                (v[0], v[1], v[2])
+            };
+            let (a, b, c) = (vpos[i0 as usize], vpos[i1 as usize], vpos[i2 as usize]);
+            vol6 += a[0] * (b[1] * c[2] - b[2] * c[1]) + a[1] * (b[2] * c[0] - b[0] * c[2])
+                + a[2] * (b[0] * c[1] - b[1] * c[0]);
+        }
+        if vol6 < 0.0 {
+            for &t in &comp {
+                flip[t] = !flip[t];
+            }
+        }
+    }
+
+    for t in 0..ntri {
+        if flip[t] {
+            mesh.indices.swap(3 * t + 1, 3 * t + 2);
+            any_flip = true;
+        }
+    }
+    any_flip
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a unit cube as a flat-shaded mesh (positions not index-shared), with
+    /// `bad` triangle indices given as flipped (inward) so the winding is mixed.
+    fn cube(flipped: &[usize]) -> Mesh {
+        // 12 triangles, outward-wound.
+        let c = [
+            [0.0f32, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0], [1.0, 0.0, 1.0], [1.0, 1.0, 1.0], [0.0, 1.0, 1.0],
+        ];
+        let faces: [[usize; 3]; 12] = [
+            [0, 2, 1], [0, 3, 2], // bottom z=0 (outward -z)
+            [4, 5, 6], [4, 6, 7], // top z=1 (outward +z)
+            [0, 1, 5], [0, 5, 4], // front y=0
+            [2, 3, 7], [2, 7, 6], // back y=1
+            [1, 2, 6], [1, 6, 5], // right x=1
+            [0, 4, 7], [0, 7, 3], // left x=0
+        ];
+        let mut m = Mesh::new();
+        for (t, f) in faces.iter().enumerate() {
+            let mut tri = *f;
+            if flipped.contains(&t) {
+                tri.swap(1, 2);
+            }
+            for &vi in &tri {
+                m.positions.extend_from_slice(&c[vi]);
+                m.normals.extend_from_slice(&[0.0, 0.0, 0.0]);
+            }
+            let base = (m.indices.len()) as u32;
+            m.indices.extend_from_slice(&[base, base + 1, base + 2]);
+        }
+        m
+    }
+
+    fn bad_edges(m: &Mesh) -> usize {
+        let q = |v: f32| (v as f64 * WELD).round() as i64;
+        let key = |i: u32| {
+            let b = i as usize * 3;
+            (q(m.positions[b]), q(m.positions[b + 1]), q(m.positions[b + 2]))
+        };
+        let mut dir: FxHashMap<((i64, i64, i64), (i64, i64, i64)), u32> = FxHashMap::default();
+        for t in m.indices.chunks_exact(3) {
+            let (a, b, c) = (key(t[0]), key(t[1]), key(t[2]));
+            for e in [(a, b), (b, c), (c, a)] {
+                *dir.entry(e).or_insert(0) += 1;
+            }
+        }
+        dir.values().filter(|&&c| c >= 2).count()
+    }
+
+    #[test]
+    fn fixes_mixed_winding_to_consistent_outward() {
+        let mut m = cube(&[3, 7, 10]); // three inward-flipped faces
+        assert!(bad_edges(&m) > 0, "fixture must start winding-inconsistent");
+        let flipped = orient_mesh_outward(&mut m);
+        assert!(flipped, "the mixed-winding cube must be re-oriented");
+        assert_eq!(bad_edges(&m), 0, "winding must be consistent after orient");
+    }
+
+    #[test]
+    fn already_outward_is_untouched() {
+        let mut m = cube(&[]);
+        let before = m.indices.clone();
+        let flipped = orient_mesh_outward(&mut m);
+        assert!(!flipped, "a clean outward cube must not be touched");
+        assert_eq!(m.indices, before, "index buffer must be byte-identical");
+    }
+
+    #[test]
+    fn fully_inward_cube_is_flipped_outward() {
+        // Every face inward: globally consistent but negative volume → flip all.
+        let all: Vec<usize> = (0..12).collect();
+        let mut m = cube(&all);
+        assert_eq!(bad_edges(&m), 0, "a fully-inward cube is still consistent");
+        let flipped = orient_mesh_outward(&mut m);
+        assert!(flipped, "an inward-wound cube must be flipped outward");
+        assert_eq!(bad_edges(&m), 0);
+    }
+}

--- a/rust/processing/src/element.rs
+++ b/rust/processing/src/element.rs
@@ -38,8 +38,8 @@ use crate::style::{FullIndexedColourMap, GeometryStyleInfo};
 use crate::types::mesh::{MeshData, MeshTextureData};
 use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcType};
 use ifc_lite_geometry::{
-    calculate_normals, BoolFailure, GeometryHasher, GeometryRouter, Mesh, ResolvedTextureMap,
-    SubMeshCollection,
+    calculate_normals, orient_mesh_outward, BoolFailure, GeometryHasher, GeometryRouter, Mesh,
+    ResolvedTextureMap, SubMeshCollection,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::BTreeMap;
@@ -323,6 +323,16 @@ fn produce_inner(
         return Vec::new();
     }
 
+    // Make the assembled body consistently outward-wound. A faceted brep (IFC
+    // face loops are not reliably outward) or a merged multi-item body (extrusion
+    // unioned with a boolean cut) can carry MIXED winding that corrupts signed
+    // volume and the smooth normals computed below. No-op for already-consistent
+    // bodies (every extrusion), so their index buffer + normals are untouched; a
+    // flip invalidates any baked normals, so recompute them.
+    if orient_mesh_outward(&mut mesh) {
+        calculate_normals(&mut mesh);
+    }
+
     // Multi-colour IfcIndexedColourMap → one mesh per palette group (#858),
     // resolved by walking the element's representation for the colour-mapped
     // face set. Only applies while the produced triangle count still matches
@@ -396,7 +406,9 @@ fn emit_sub_meshes(
         if sub_mesh.is_empty() {
             continue;
         }
-        if sub_mesh.normals.len() != sub_mesh.positions.len() {
+        // Consistently outward-wind each sub-body (see the single-mesh path); a
+        // flip invalidates baked normals, so recompute on flip or when absent.
+        if orient_mesh_outward(&mut sub_mesh) || sub_mesh.normals.len() != sub_mesh.positions.len() {
             calculate_normals(&mut sub_mesh);
         }
 

--- a/rust/processing/tests/beam_winding_consistency.rs
+++ b/rust/processing/tests/beam_winding_consistency.rs
@@ -1,0 +1,90 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Regression: assembled element bodies must be consistently outward-wound.
+//!
+//! `IfcBeam` bodies in this model are hollow tubes built from booleans /
+//! faceted breps, which arrived with MIXED per-triangle winding (some faces
+//! inward) — corrupting signed volume and the smooth normals used for lighting.
+//! `produce_element_meshes` now runs `orient_mesh_outward` on the assembled body,
+//! so every beam mesh comes out winding-consistent. A consistently-oriented mesh
+//! never has a DIRECTED welded edge traversed twice (the opposite direction
+//! carries the shared edge for the neighbour); two same-direction traversals mean
+//! two triangles cross that edge with the same winding.
+
+use ifc_lite_core::EntityScanner;
+use ifc_lite_processing::process_geometry;
+use std::collections::{HashMap, HashSet};
+
+const FIXTURE: &str = "../../tests/models/ara3d/ISSUE_021_Mini Project.ifc";
+
+fn read_fixture() -> Option<String> {
+    match std::fs::read_to_string(FIXTURE) {
+        Ok(s) => Some(s),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            eprintln!(
+                "skipping beam-winding regression: fixture missing at {FIXTURE} — \
+                 run `pnpm fixtures` (sha256 in tests/models/manifest.json)"
+            );
+            None
+        }
+        Err(e) => panic!("failed to read fixture {FIXTURE}: {e}"),
+    }
+}
+
+/// Directed welded edges seen >= 2 times (winding-inconsistent edges).
+fn inconsistent_edges(positions: &[f32], origin: [f64; 3], indices: &[u32]) -> usize {
+    let q = |v: f32, o: f64| ((v as f64 + o) * 1.0e5).round() as i64;
+    let key = |i: u32| {
+        let b = i as usize * 3;
+        (q(positions[b], origin[0]), q(positions[b + 1], origin[1]), q(positions[b + 2], origin[2]))
+    };
+    let mut dir: HashMap<((i64, i64, i64), (i64, i64, i64)), u32> = HashMap::new();
+    for t in indices.chunks_exact(3) {
+        let (a, b, c) = (key(t[0]), key(t[1]), key(t[2]));
+        for e in [(a, b), (b, c), (c, a)] {
+            *dir.entry(e).or_insert(0) += 1;
+        }
+    }
+    dir.values().filter(|&&c| c >= 2).count()
+}
+
+#[test]
+fn beam_meshes_are_winding_consistent() {
+    let Some(content) = read_fixture() else { return };
+
+    let mut beam_ids: HashSet<u32> = HashSet::new();
+    let mut scanner = EntityScanner::new(&content);
+    while let Some((id, t, _, _)) = scanner.next_entity() {
+        if t == "IFCBEAM" {
+            beam_ids.insert(id);
+        }
+    }
+    assert!(!beam_ids.is_empty(), "fixture must contain IfcBeam entities");
+
+    let result = process_geometry(&content);
+
+    let mut beams = 0usize;
+    let mut bad_beams = 0usize;
+    let mut bad_edges_total = 0usize;
+    let mut per_beam: HashMap<u32, usize> = HashMap::new();
+    for m in result.meshes.iter().filter(|m| beam_ids.contains(&m.express_id)) {
+        *per_beam.entry(m.express_id).or_insert(0) +=
+            inconsistent_edges(&m.positions, m.origin, &m.indices);
+    }
+    for (_, bad) in per_beam {
+        beams += 1;
+        if bad > 0 {
+            bad_beams += 1;
+            bad_edges_total += bad;
+        }
+    }
+
+    assert!(beams > 100, "expected the model's many beams, got {beams}");
+    assert_eq!(
+        bad_beams, 0,
+        "{bad_beams}/{beams} beam meshes are winding-inconsistent ({bad_edges_total} bad edges) — \
+         orient_mesh_outward should make every assembled body outward-consistent"
+    );
+}


### PR DESCRIPTION
## Summary

Some element bodies — `IfcBeam` hollow tubes built from booleans / faceted breps in `ISSUE_021_Mini Project.ifc`, and merged multi-item bodies generally — were emitted with **mixed per-triangle winding** (some faces inward). Shapes are correct (Hausdorff < 0.25 mm) and double-sided rendering hides it, but it corrupts **signed volume** (quantities) and the **smooth normals** the renderer accumulates from winding (lighting). Audit finding #4.

The kernel's whole-operand `orient_outward` only flips an *entire* mesh by its global signed volume, so it cannot repair a body that is internally inconsistent.

## Fix

New `ifc_lite_geometry::orient_mesh_outward`:
1. Weld positions (flat-shaded meshes don't share vertices) to recover face adjacency.
2. Per connected component, propagate a consistent orientation across shared edges (BFS).
3. Flip each component outward by its signed volume.
4. A non-manifold (edge shared by >2 faces) or non-orientable component is **left untouched** — re-orienting it is ambiguous and must not make things worse.

`produce_element_meshes` runs it on the assembled body (single-mesh path + each sub-mesh) before computing normals; a flip invalidates baked normals so they're recomputed. It is a **no-op for already-consistent bodies** (every extrusion), so their index buffer and normals are byte-identical.

## Why this is low-risk

- The **geometry hash is winding-invariant** (`geom_hash.rs`) and the correctness-harness snapshots store winding-invariant summaries (triangle count, area, bbox) — so re-orienting changes **no** snapshot. Only normals/quantities change, which is the point.
- The geometry correctness harness drives the kernel directly (not `element.rs`), so kernel manifests are untouched.

## Verification

- `ISSUE_021` through the full pipeline: **522/1949 winding-inconsistent → 0/1949** (new fixture-gated `beam_winding_consistency` test).
- Unit tests for the orienter (mixed-winding cube → consistent; clean cube → byte-identical no-op; fully-inward cube → flipped outward).
- Geometry lib 392/0, processing crate all green.

Rust-only (ships via the wasm rebuild); no published-package src touched, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mesh geometry now automatically applies outward-facing winding orientation for improved consistency.

* **Tests**
  * Added regression test to verify consistent mesh winding across assembled geometry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->