### PR TITLE
fix(renderer): catch popErrorScope rejection on device loss

### DIFF
--- a/.changeset/renderer-poperrorscope-device-loss.md
+++ b/.changeset/renderer-poperrorscope-device-loss.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/renderer": patch
+---
+
+Stop a lost-device `popErrorScope` rejection from surfacing as an unhandled `DOMException`.
+
+During the first few frames the renderer wraps the render pass in `pushErrorScope('validation')` and reads it back with `device.popErrorScope()`. That promise rejects (`OperationError: Instance dropped in popErrorScope`) when the GPU device is lost while the scope is still pending — something seen in the wild on Windows/Edge when the adapter resets. The `.then()` had no rejection handler, so the rejection escaped the surrounding synchronous `try/catch` and became an unhandled rejection reported as a top-level error. It is now caught and treated like any other device loss: the context is invalidated so it reconfigures on the next frame, with a throttled warning instead of a crash.

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -2400,6 +2400,18 @@ export class Renderer {
                         this.device._lastUncapturedError = `VALIDATION: ${msg}`;
                         this.device._uncapturedErrorCount++;
                     }
+                }).catch((error: unknown) => {
+                    // popErrorScope() rejects (e.g. "Instance dropped in popErrorScope")
+                    // when the GPU device is lost while the scope is still pending. This
+                    // escapes the surrounding synchronous try/catch and would otherwise
+                    // surface as an unhandled rejection. Treat it like any other device
+                    // loss: invalidate the context so it reconfigures next frame.
+                    this.device.invalidateContext();
+                    const now = performance.now();
+                    if (now - this.lastRenderErrorTime > this.RENDER_ERROR_THROTTLE_MS) {
+                        this.lastRenderErrorTime = now;
+                        console.warn('[WebGPU] popErrorScope rejected (device likely lost):', error);
+                    }
                 });
             }
         } catch (error) {


### PR DESCRIPTION
## Problem

PostHog error tracking reported an unhandled `DOMException`:

> `OperationError: Instance dropped in popErrorScope`

Seen in production on `https://www.ifclite.com/` (Microsoft Edge 149 / Windows 10), unhandled, in the render loop. Closes #1312.

## Root cause

During the first few frames the renderer wraps the render pass in `pushErrorScope('validation')` and reads it back with `device.popErrorScope()` (`packages/renderer/src/index.ts`). That promise **rejects** with `OperationError: Instance dropped in popErrorScope` when the GPU device is lost while the scope is still pending — which happens in the wild on Windows/Edge when the adapter resets.

The `.then()` had no rejection handler. Because the rejection is asynchronous, it escapes the surrounding synchronous `try/catch` and became an unhandled promise rejection, reported as a top-level error.

## Fix

Add a `.catch()` that treats the rejection like any other device loss already handled by the synchronous catch right below it: invalidate the context so it reconfigures on the next frame, and emit a throttled warning instead of crashing.

## Notes

- Single occurrence so far, but the rejection is genuinely benign (device loss is recoverable), so the right behavior is to swallow it gracefully rather than let it surface as an error.
- Changeset included (`@ifc-lite/renderer` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)