### PR TITLE
ci(python-wheels): cross-compile Intel-mac wheel on Apple-silicon runner

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -29,7 +29,10 @@ jobs:
           - { os: ubuntu-latest, target: x86_64 }
           - { os: ubuntu-latest, target: aarch64 }
           - { os: macos-14, target: aarch64 }
-          - { os: macos-13, target: x86_64 }
+          # Cross-compile the Intel-mac wheel on the Apple-silicon runner: the
+          # macos-13 (Intel) runners are being deprecated and queue indefinitely.
+          # abi3 means no Python lib is linked, so a cross target builds cleanly.
+          - { os: macos-14, target: x86_64 }
           - { os: windows-latest, target: x64 }
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4


### PR DESCRIPTION
The `macos-13` (Intel) runners are being deprecated and queue indefinitely, hard-blocking the `ifclite-geom` PyPI publish job (it needs all 5 wheels). Build the `x86_64-apple-darwin` wheel on the `macos-14` (Apple-silicon) runner via maturin cross-compile instead; abi3 links no Python lib so the cross target builds cleanly. No Rust code change — wheel contents are identical to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS build infrastructure to maintain compatibility with the latest supported runner versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->