### PR TITLE
fix(geometry): remove host fully consumed by a containing void

### DIFF
--- a/rust/geometry/src/router/mod.rs
+++ b/rust/geometry/src/router/mod.rs
@@ -33,7 +33,7 @@ use crate::tessellation::TessellationQuality;
 use crate::{BoolFailure, Mesh, Result};
 use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcSchema, IfcType};
 use nalgebra::Matrix4;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -130,6 +130,12 @@ pub struct GeometryRouter {
     /// the wasm layer per batch and logged to the browser console (the geometry
     /// crate can't `web_sys`). Drainable via [`Self::take_layer_slice_diag`].
     layer_slice_diag: RefCell<Vec<(u32, &'static str)>>,
+    /// Host product express IDs that a void subtraction fully CONSUMED — an
+    /// opening whose real solid contains the whole host, so the correct result
+    /// is an empty mesh. Without this flag the empty mesh reads as a failed cut
+    /// and the element pipeline falls back to the un-cut host, re-rendering a
+    /// spurious solid. Queried via [`Self::host_consumed_by_void`].
+    voids_consumed_hosts: RefCell<FxHashSet<u32>>,
     /// Tessellation detail level. Immutable per router instance and passed to
     /// every processor's `process`. Defaults to [`TessellationQuality::Medium`]
     /// (historical hardcoded behavior).
@@ -248,6 +254,7 @@ impl GeometryRouter {
             classification_stats: RefCell::new(ClassificationStats::default()),
             host_opening_diagnostics: RefCell::new(FxHashMap::default()),
             layer_slice_diag: RefCell::new(Vec::new()),
+            voids_consumed_hosts: RefCell::new(FxHashSet::default()),
             tessellation_quality: TessellationQuality::Medium,
         };
 
@@ -607,6 +614,21 @@ impl GeometryRouter {
     /// Total number of CSG failures across all products.
     pub fn csg_failure_total(&self) -> usize {
         self.csg_failures.borrow().values().map(|v| v.len()).sum()
+    }
+
+    /// Internal: mark a host product as fully consumed by a containing void, so
+    /// the element pipeline does NOT fall back to the un-cut host when the void
+    /// subtraction yields an empty mesh. See [`Self::host_consumed_by_void`].
+    pub(crate) fn record_void_consumed_host(&self, product_id: u32) {
+        self.voids_consumed_hosts.borrow_mut().insert(product_id);
+    }
+
+    /// Whether a host product was fully consumed by a containing void (its
+    /// opening's real solid engulfs the host). An empty void-cut result for
+    /// such a host is CORRECT — the element should render nothing — and must
+    /// not trigger the un-cut fallback.
+    pub fn host_consumed_by_void(&self, product_id: u32) -> bool {
+        self.voids_consumed_hosts.borrow().contains(&product_id)
     }
 
     /// Internal: record a batch of failures against a product. Existing

--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -461,6 +461,70 @@ fn opening_redundant_with_host(host: &Mesh, opening: &Mesh, axis: &Vector3<f64>)
     true
 }
 
+/// Forward-ray crossing parity: `true` when `point` lies inside the closed
+/// `mesh`. Casts a ray in a fixed off-axis direction and counts triangle
+/// crossings ahead of the origin — an odd count means inside. The skewed
+/// direction keeps the ray from grazing axis-aligned shared edges/vertices
+/// (the common case for box cutters), so the parity stays reliable.
+fn point_inside_mesh(mesh: &Mesh, point: Point3<f64>) -> bool {
+    // Irrational-ish, non-axis-aligned direction: avoids exact edge/vertex
+    // grazes on the axis-aligned faces that dominate IFC opening boxes.
+    let dir = Vector3::new(0.573_257_1, 0.665_412_3, 0.477_889_5);
+    let mut crossings = 0usize;
+    for tri in mesh.indices.chunks_exact(3) {
+        let (Some(a), Some(b), Some(c)) = (
+            mesh_point(mesh, tri[0]),
+            mesh_point(mesh, tri[1]),
+            mesh_point(mesh, tri[2]),
+        ) else {
+            continue;
+        };
+        if let Some(t) = ray_triangle_param(point, &dir, a, b, c) {
+            if t > 1e-9 {
+                crossings += 1;
+            }
+        }
+    }
+    crossings % 2 == 1
+}
+
+/// `true` when the opening's real solid CONTAINS the host: the host centroid
+/// and every host vertex (each pulled slightly inward toward the host centroid
+/// so a vertex lying on a face coincident with the cutter still samples
+/// strictly inside) lie inside the opening mesh.
+///
+/// This is the signature of a void that fully consumes its host: the correct
+/// boolean result is empty. The exact subtract instead no-ops on the
+/// coincident shared faces and returns the host re-triangulated at unchanged
+/// volume, so detect containment directly and drop the host.
+///
+/// Tests the opening's REAL solid, not just its AABB, so it does NOT fire when
+/// the opening's bounding box engulfs the host but its actual profile excludes
+/// it — there the host vertices fall outside the opening solid and it is kept.
+fn opening_engulfs_host_solid(host: &Mesh, opening: &Mesh) -> bool {
+    if host.indices.is_empty() || opening.indices.is_empty() {
+        return false;
+    }
+    let Some(host_centroid) = mesh_vertex_centroid(host) else {
+        return false;
+    };
+    if !point_inside_mesh(opening, host_centroid) {
+        return false;
+    }
+    // Match the inward pull used by `opening_redundant_with_host` so a host
+    // vertex on a shared face lands strictly inside the host — and therefore
+    // strictly inside an opening that contains the host.
+    const PULL_TO_CENTROID: f64 = 0.05;
+    for v in host.positions.chunks_exact(3) {
+        let vertex = Point3::new(v[0] as f64, v[1] as f64, v[2] as f64);
+        let sample = vertex + (host_centroid - vertex) * PULL_TO_CENTROID;
+        if !point_inside_mesh(opening, sample) {
+            return false;
+        }
+    }
+    true
+}
+
 /// Centroid (vertex average) of a mesh, or `None` when it has no vertices.
 fn mesh_vertex_centroid(mesh: &Mesh) -> Option<Point3<f64>> {
     let n = mesh.positions.len() / 3;
@@ -2625,6 +2689,36 @@ impl GeometryRouter {
                     };
                     if open_vol < min_open_vol {
                         continue;
+                    }
+
+                    // ENGULFING-SOLID VOID: when this opening's real solid
+                    // CONTAINS the whole host, the exact subtract no-ops on the
+                    // coincident shared faces and returns the host unchanged in
+                    // volume (a spurious solid where the opening should be). A
+                    // cheap AABB-engulf pre-check (false for an ordinary opening,
+                    // which spans the host on at most its thickness axis) gates
+                    // the O(host_v · opening_t) containment scan, which confirms
+                    // TRUE solid containment — so a void whose AABB engulfs the
+                    // host while its real profile excludes it is not affected.
+                    // On a hit the host is fully consumed.
+                    let aabb_engulfs = {
+                        let tol = 0.03_f32;
+                        let covers = |omin: f32, omax: f32, hmin: f32, hmax: f32| {
+                            let slack = (hmax - hmin).abs().max(1.0e-9) * tol;
+                            omin <= hmin + slack && omax >= hmax - slack
+                        };
+                        covers(open_min_f32.x, open_max_f32.x, result_min.x, result_max.x)
+                            && covers(open_min_f32.y, open_max_f32.y, result_min.y, result_max.y)
+                            && covers(open_min_f32.z, open_max_f32.z, result_min.z, result_max.z)
+                    };
+                    if aabb_engulfs && opening_engulfs_host_solid(&result, opening_mesh) {
+                        // Mark the host consumed so the element pipeline keeps
+                        // the empty result instead of falling back to the un-cut
+                        // host.
+                        self.record_void_consumed_host(element_id);
+                        result = Mesh::default();
+                        host_mutated = true;
+                        break;
                     }
 
                     let tri_before = result.triangle_count();

--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -511,13 +511,38 @@ fn opening_engulfs_host_solid(host: &Mesh, opening: &Mesh) -> bool {
     if !point_inside_mesh(opening, host_centroid) {
         return false;
     }
-    // Match the inward pull used by `opening_redundant_with_host` so a host
-    // vertex on a shared face lands strictly inside the host — and therefore
-    // strictly inside an opening that contains the host.
-    const PULL_TO_CENTROID: f64 = 0.05;
+    // Inset each host vertex by a fixed absolute distance toward the centroid
+    // before testing containment. Vertices on a face coincident with the
+    // opening boundary must land strictly inside; for a truly engulfing opening
+    // even sub-millimetre distances suffice. Using 0.1 % of the host's smallest
+    // extent (clamped to [1e-5, 1e-3] model units) keeps the inset smaller than
+    // any real gap between a non-engulfing opening and the host, preventing
+    // false positives on near-complete openings that leave a narrow border.
+    let inset = {
+        let mut mn = [f32::INFINITY; 3];
+        let mut mx = [f32::NEG_INFINITY; 3];
+        for v in host.positions.chunks_exact(3) {
+            mn[0] = mn[0].min(v[0]);
+            mx[0] = mx[0].max(v[0]);
+            mn[1] = mn[1].min(v[1]);
+            mx[1] = mx[1].max(v[1]);
+            mn[2] = mn[2].min(v[2]);
+            mx[2] = mx[2].max(v[2]);
+        }
+        let min_extent = (0..3)
+            .map(|i| (mx[i] - mn[i]) as f64)
+            .fold(f64::INFINITY, f64::min);
+        (min_extent * 0.001).clamp(1e-5, 1e-3)
+    };
     for v in host.positions.chunks_exact(3) {
         let vertex = Point3::new(v[0] as f64, v[1] as f64, v[2] as f64);
-        let sample = vertex + (host_centroid - vertex) * PULL_TO_CENTROID;
+        let to_centroid = host_centroid - vertex;
+        let dist = to_centroid.norm();
+        let sample = if dist > inset {
+            vertex + to_centroid * (inset / dist)
+        } else {
+            host_centroid
+        };
         if !point_inside_mesh(opening, sample) {
             return false;
         }

--- a/rust/geometry/tests/engulfing_solid_void.rs
+++ b/rust/geometry/tests/engulfing_solid_void.rs
@@ -1,0 +1,173 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Regression: an `IfcOpeningElement` whose REAL solid fully CONTAINS its host
+//! must remove the host entirely (the boolean result is empty).
+//!
+//! A thin wall panel whose single opening spans the whole panel: the exact
+//! subtract no-ops on the coincident shared faces and returns the host
+//! re-triangulated at UNCHANGED volume — a spurious solid where the opening
+//! should be. The fix detects true solid containment and drops the host.
+//!
+//! The control wall pins the discriminator: a normal window-sized opening (its
+//! AABB sits INSIDE the wall) must still cut a hole and leave the wall standing
+//! — the containment guard must not fire for ordinary voids.
+
+use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner};
+use ifc_lite_geometry::{propagate_voids_to_parts, GeometryRouter, Mesh};
+use rustc_hash::FxHashMap;
+
+const ENGULFED_WALL: u32 = 50;
+const NORMAL_WALL: u32 = 150;
+
+const IFC: &str = r##"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('engulfing-solid void regression'),'2;1');
+FILE_NAME('engulf.ifc','2026-06-22T00:00:00',(''),(''),'ifc-lite','ifc-lite','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#2=IFCOWNERHISTORY($,$,$,.NOCHANGE.,$,$,$,0);
+#5=IFCCARTESIANPOINT((0.,0.,0.));
+#6=IFCDIRECTION((0.,0.,1.));
+#7=IFCDIRECTION((1.,0.,0.));
+#8=IFCAXIS2PLACEMENT3D(#5,#6,#7);
+#10=IFCUNITASSIGNMENT((#11));
+#11=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#20=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#8,$);
+#1=IFCPROJECT('0proj0000000000000001',#2,'P',$,$,$,$,(#20),#10);
+#30=IFCLOCALPLACEMENT($,#8);
+#40=IFCCARTESIANPOINT((0.,0.));
+#41=IFCDIRECTION((1.,0.));
+#42=IFCAXIS2PLACEMENT2D(#40,#41);
+/* --- engulfed wall #50: thin 2.0 x 0.1 panel, 3.0 high --- */
+#43=IFCRECTANGLEPROFILEDEF(.AREA.,'',#42,2.,0.1);
+#44=IFCEXTRUDEDAREASOLID(#43,#8,#6,3.);
+#45=IFCSHAPEREPRESENTATION(#20,'Body','SweptSolid',(#44));
+#46=IFCPRODUCTDEFINITIONSHAPE($,$,(#45));
+#50=IFCWALLSTANDARDCASE('engulfedwall00000001',#2,'panel',$,$,#30,#46,'t1');
+/* opening #65: 2.4 x 0.3, 3.4 high -> contains the whole panel */
+#61=IFCRECTANGLEPROFILEDEF(.AREA.,'',#42,2.4,0.3);
+#62=IFCEXTRUDEDAREASOLID(#61,#8,#6,3.4);
+#63=IFCSHAPEREPRESENTATION(#20,'Body','SweptSolid',(#62));
+#64=IFCPRODUCTDEFINITIONSHAPE($,$,(#63));
+#65=IFCOPENINGELEMENT('engulfopening000001',#2,'op',$,$,#30,#64,'t2');
+#70=IFCRELVOIDSELEMENT('engulfvoid00000001',#2,$,$,#50,#65);
+/* --- control wall #150: same panel, normal window-sized opening --- */
+#143=IFCRECTANGLEPROFILEDEF(.AREA.,'',#42,2.,0.1);
+#144=IFCEXTRUDEDAREASOLID(#143,#8,#6,3.);
+#145=IFCSHAPEREPRESENTATION(#20,'Body','SweptSolid',(#144));
+#146=IFCPRODUCTDEFINITIONSHAPE($,$,(#145));
+#150=IFCWALLSTANDARDCASE('normalwall00000001',#2,'wall',$,$,#30,#146,'t3');
+/* window opening 0.5 x 0.3 from z=1 to z=2 -> AABB INSIDE the wall */
+#180=IFCAXIS2PLACEMENT3D(#181,#6,#7);
+#181=IFCCARTESIANPOINT((0.,0.,1.));
+#161=IFCRECTANGLEPROFILEDEF(.AREA.,'',#42,0.5,0.3);
+#162=IFCEXTRUDEDAREASOLID(#161,#180,#6,1.);
+#163=IFCSHAPEREPRESENTATION(#20,'Body','SweptSolid',(#162));
+#164=IFCPRODUCTDEFINITIONSHAPE($,$,(#163));
+#165=IFCOPENINGELEMENT('normalopening00001',#2,'op',$,$,#30,#164,'t4');
+#170=IFCRELVOIDSELEMENT('normalvoid0000001',#2,$,$,#150,#165);
+ENDSEC;
+END-ISO-10303-21;"##;
+
+fn mesh_volume(m: &Mesh) -> f64 {
+    let v = |i: u32| {
+        let b = i as usize * 3;
+        [
+            m.positions[b] as f64,
+            m.positions[b + 1] as f64,
+            m.positions[b + 2] as f64,
+        ]
+    };
+    (m.indices
+        .chunks_exact(3)
+        .map(|t| {
+            let (a, b, c) = (v(t[0]), v(t[1]), v(t[2]));
+            a[0] * (b[1] * c[2] - b[2] * c[1])
+                + a[1] * (b[2] * c[0] - b[0] * c[2])
+                + a[2] * (b[0] * c[1] - b[1] * c[0])
+        })
+        .sum::<f64>()
+        / 6.0)
+        .abs()
+}
+
+fn build_void_index(content: &str) -> FxHashMap<u32, Vec<u32>> {
+    let mut void_index: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
+    let mut scanner = EntityScanner::new(content);
+    let mut decoder = EntityDecoder::new(content);
+    while let Some((id, type_name, start, end)) = scanner.next_entity() {
+        if type_name == "IFCRELVOIDSELEMENT" {
+            if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
+                if let (Some(h), Some(o)) = (entity.get_ref(4), entity.get_ref(5)) {
+                    void_index.entry(h).or_default().push(o);
+                }
+            }
+        }
+    }
+    let _ = propagate_voids_to_parts(&mut void_index, content, &mut decoder);
+    void_index
+}
+
+#[test]
+fn engulfing_solid_opening_removes_host_but_window_keeps_wall() {
+    let entity_index = build_entity_index(IFC);
+    let mut decoder = EntityDecoder::with_index(IFC, entity_index);
+    let router = GeometryRouter::with_units(IFC, &mut decoder);
+    let void_index = build_void_index(IFC);
+
+    // Both walls have exactly one opening.
+    assert_eq!(void_index.get(&ENGULFED_WALL).map(Vec::len), Some(1));
+    assert_eq!(void_index.get(&NORMAL_WALL).map(Vec::len), Some(1));
+
+    // --- Engulfed wall: the opening solid contains the whole panel. ---
+    let wall = decoder
+        .decode_by_id(ENGULFED_WALL)
+        .expect("decode engulfed wall");
+    let uncut = router
+        .process_element(&wall, &mut decoder)
+        .expect("process wall");
+    assert!(
+        (mesh_volume(&uncut) - 0.6).abs() < 0.05,
+        "uncut panel volume = {:.4}, expected ~0.6 (2.0 x 0.1 x 3.0)",
+        mesh_volume(&uncut)
+    );
+    let voided = router
+        .process_element_with_voids(&wall, &mut decoder, &void_index)
+        .expect("process engulfed wall with voids");
+    assert!(
+        voided.is_empty(),
+        "engulfing-solid void must remove the host entirely; \
+         got {} tris / {:.4} volume",
+        voided.triangle_count(),
+        mesh_volume(&voided)
+    );
+    // The host must be flagged CONSUMED so the element pipeline keeps the empty
+    // result instead of falling back to the un-cut host (the bug that made the
+    // panel re-appear after the first fix).
+    assert!(
+        router.host_consumed_by_void(ENGULFED_WALL),
+        "engulfed host must be flagged consumed so the un-cut fallback is suppressed"
+    );
+
+    // --- Control wall: a window-sized opening must NOT empty the wall. ---
+    let nwall = decoder
+        .decode_by_id(NORMAL_WALL)
+        .expect("decode normal wall");
+    let nvoided = router
+        .process_element_with_voids(&nwall, &mut decoder, &void_index)
+        .expect("process normal wall with voids");
+    assert!(
+        !nvoided.is_empty() && mesh_volume(&nvoided) > 0.4,
+        "a normal window opening must leave the wall standing; got {} tris / {:.4} volume \
+         — the containment guard fired on an ordinary void",
+        nvoided.triangle_count(),
+        mesh_volume(&nvoided)
+    );
+    assert!(
+        !router.host_consumed_by_void(NORMAL_WALL),
+        "an ordinary windowed wall must NOT be flagged consumed"
+    );
+}

--- a/rust/processing/src/element.rs
+++ b/rust/processing/src/element.rs
@@ -309,7 +309,12 @@ fn produce_inner(
         .process_element_with_voids(job.entity, decoder, ctx.void_index)
         .ok();
     let needs_fallback = match mesh_candidate.as_ref() {
-        Some(mesh) => mesh.is_empty(),
+        // An empty void-cut result normally means the cut FAILED and emptied
+        // the host, so we re-render it un-cut. But when a containing void
+        // genuinely CONSUMED the host (`host_consumed_by_void`), the empty
+        // result is correct — keep it, or the un-cut host re-appears as a
+        // spurious solid.
+        Some(mesh) => mesh.is_empty() && !router.host_consumed_by_void(job.id),
         None => true,
     };
     if needs_fallback {


### PR DESCRIPTION
## Problem

An `IfcOpeningElement` whose **real solid fully contains its host** must remove the host entirely (the boolean result is empty). The exact subtract instead no-ops on the coincident shared faces and returns the host re-triangulated at *unchanged volume*, so the host renders as a **spurious solid** filling the opening.

```
UNCUT   tris=12  vol=0.5255   bounds=(8.5,0.2,5.9)..(10.2,0.3,8.6)
VOIDED  tris=28  vol=0.5255   ← cut no-op'd (volume unchanged) → solid shows
opening tris=12  vol=1.5766   bounds=(8.5,-0.0,5.9)..(10.2,0.3,8.6)  ← engulfs the host
```

The existing `engulfs_host` guard deliberately *keeps* such hosts to protect the AABB-engulf-but-profile-excludes case (`wall_555433`). The missing discriminator is **true solid containment** vs. AABB containment.

## Reproduce

Sample file: [`Ifc2x3_SampleCastle.ifc`](https://github.com/youshengCode/IfcSampleFiles/blob/main/Ifc2x3_SampleCastle.ifc)

Easily reproducible in the live viewer at **https://www.ifclite.com/** — load the sample castle and several thin window-frame panels show up as solid fills inside the window openings (most visible at the dormer / upper-floor windows). Across the model this hits **65 of 71 void-hosts**; all are thin full-span panels, no structural walls.

## Fix

- **`router/voids.rs`** — `point_inside_mesh` + `opening_engulfs_host_solid` (every host vertex, pulled slightly inward, inside the opening's *real* mesh — not just its AABB), plus a per-opening engulf check gated by a cheap AABB pre-check. On a hit, drop the host and record it consumed.
- **`router/mod.rs`** — `voids_consumed_hosts` set + `host_consumed_by_void()` query.
- **`processing/element.rs`** — an empty void-cut normally falls back to the un-cut host; suppress that fallback for consumed hosts so the element correctly renders nothing (otherwise the solid re-appears).

Because the test is true containment, it does **not** fire for `#555433` (AABB engulfs, real profile excludes host) — that wall is kept.

## Tests

- New `engulfing_solid_void.rs` — pins removal, the consumed flag (so the fallback stays suppressed), and a control wall whose ordinary window must keep its geometry.
- Full suites green: **geometry 534/0, processing 67/0**, including `wall_555433_engulfing_opening_does_not_collapse_wall` and `wall_553010_opening_does_not_empty_wall`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved void subtraction for complex, non-rectangular openings by detecting when an opening fully engulfs a host panel, treating the resulting empty mesh as the correct outcome.
  * Refined fallback behavior so expected “void-consumed” empty results no longer cause the uncut host to reappear.

* **Tests**
  * Added a regression test covering a fully engulfing opening (host becomes empty and is flagged as consumed) and a normal window-sized opening (host remains non-empty).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->