### PR TITLE
feat(export): lit GLB materials option, default lit (#1321)

### DIFF
--- a/.changeset/glb-lit-materials.md
+++ b/.changeset/glb-lit-materials.md
@@ -1,0 +1,11 @@
+---
+"@ifc-lite/wasm": minor
+"@ifc-lite/geometry": minor
+---
+
+GLB export: add a `lit` option (default `true`) so exported models render with
+standard PBR lighting in external viewers instead of flat `KHR_materials_unlit`.
+`GeometryProcessor.exportGlb(.., lit?)` and `exportGlbFromMeshes(meshes, includeMetadata?, lit?)`
+now emit lit materials by default; pass `lit: false` for the previous flat,
+apparent-colour look. Normals were always written — only the unlit material
+extension suppressed shading. (#1321)

--- a/apps/viewer/src/components/viewer/GLBExportDialog.tsx
+++ b/apps/viewer/src/components/viewer/GLBExportDialog.tsx
@@ -94,6 +94,9 @@ export function GLBExportDialog({ trigger }: GLBExportDialogProps) {
   const [colorSource, setColorSource] = useState<ColorSource>('rendering');
   const [visibleOnly, setVisibleOnly] = useState(false);
   const [includeMetadata, setIncludeMetadata] = useState(true);
+  // Lit materials shade from normals in external viewers; unlit (#1321) renders
+  // the flat apparent base colour. Default lit — most users expect shading.
+  const [lit, setLit] = useState(true);
   const [isExporting, setIsExporting] = useState(false);
   const [exportResult, setExportResult] = useState<{ success: boolean; message: string } | null>(null);
 
@@ -244,7 +247,7 @@ export function GLBExportDialog({ trigger }: GLBExportDialogProps) {
             : m,
         );
 
-      const glb = await exportGlbFromGeometry(exportGeometry, { meshes, includeMetadata });
+      const glb = await exportGlbFromGeometry(exportGeometry, { meshes, includeMetadata, lit });
 
       const blob = new Blob([new Uint8Array(glb)], { type: 'model/gltf-binary' });
       const baseName = sanitizeFilename(selectedModel.name.replace(/\.[^.]+$/, ''), { fallback: 'model' });
@@ -259,6 +262,7 @@ export function GLBExportDialog({ trigger }: GLBExportDialogProps) {
         visible_only: visibleOnly,
         include_metadata: includeMetadata,
         color_source: colorSource,
+        lit,
         size_kb: Math.round(blob.size / 1024),
       });
     } catch (err) {
@@ -273,6 +277,7 @@ export function GLBExportDialog({ trigger }: GLBExportDialogProps) {
     selectedModel,
     selectedModelId,
     includeMetadata,
+    lit,
     colorSource,
     visibleOnly,
     typeVisibility,
@@ -379,6 +384,17 @@ export function GLBExportDialog({ trigger }: GLBExportDialogProps) {
               </p>
             </div>
             <Switch checked={includeMetadata} onCheckedChange={setIncludeMetadata} />
+          </div>
+
+          {/* Lit materials */}
+          <div className="flex items-center justify-between">
+            <div>
+              <Label>Lit Materials</Label>
+              <p className="text-xs text-muted-foreground">
+                Shade from normals in other viewers. Off = flat apparent colour (unlit)
+              </p>
+            </div>
+            <Switch checked={lit} onCheckedChange={setLit} />
           </div>
 
           {exportResult && (

--- a/apps/viewer/src/lib/export/glb.ts
+++ b/apps/viewer/src/lib/export/glb.ts
@@ -14,6 +14,12 @@ export interface GlbFromGeometryOptions {
   includeMetadata?: boolean;
   /** Pre-filtered meshes to emit (visibility/colour selection already applied). */
   meshes?: MeshData[];
+  /**
+   * Emit standard (lit) PBR materials so external viewers shade the model from
+   * its normals. `false` ⇒ flat `KHR_materials_unlit` (the historical look —
+   * apparent base colour only, no shading). Defaults to lit. (#1321)
+   */
+  lit?: boolean;
 }
 
 /** The slice of `GeometryProcessor` this helper drives — a test seam (see glb.test.ts). */
@@ -34,7 +40,7 @@ export async function exportGlbFromGeometry(
   const gp = createProcessor();
   await gp.init();
   try {
-    const glb = gp.exportGlbFromMeshes(meshes, opts.includeMetadata ?? false);
+    const glb = gp.exportGlbFromMeshes(meshes, opts.includeMetadata ?? false, opts.lit ?? true);
     if (!glb) throw new Error('GLB assembly returned no data');
     return glb;
   } finally {

--- a/packages/geometry/src/ifc-lite-bridge.ts
+++ b/packages/geometry/src/ifc-lite-bridge.ts
@@ -321,9 +321,10 @@ export class IfcLiteBridge {
     hidden: Uint32Array = new Uint32Array(),
     isolated: Uint32Array = new Uint32Array(),
     hiddenTypesCsv = '',
+    lit = true,
   ): Uint8Array {
     return this.runExport('exportGlb', content, (api) =>
-      api.exportGlb(content, includeMetadata, hidden, isolated, hiddenTypesCsv),
+      api.exportGlb(content, includeMetadata, hidden, isolated, hiddenTypesCsv, lit),
     );
   }
 
@@ -425,13 +426,14 @@ export class IfcLiteBridge {
     origins: Float64Array,
     expressIds: Uint32Array,
     includeMetadata: boolean,
+    lit = true,
   ): Uint8Array {
     if (!this.ifcApi) {
       throw new Error('IFC-Lite not initialized. Call init() first.');
     }
     try {
       return this.ifcApi.exportGlbFromMeshes(
-        positions, normals, indices, vertexCounts, indexCounts, colors, origins, expressIds, includeMetadata,
+        positions, normals, indices, vertexCounts, indexCounts, colors, origins, expressIds, includeMetadata, lit,
       );
     } catch (error) {
       log.error('Failed to exportGlbFromMeshes', error, { operation: 'exportGlbFromMeshes' });

--- a/packages/geometry/src/index.ts
+++ b/packages/geometry/src/index.ts
@@ -1078,9 +1078,10 @@ export class GeometryProcessor {
     hidden: Uint32Array = new Uint32Array(),
     isolated: Uint32Array = new Uint32Array(),
     hiddenTypesCsv = '',
+    lit = true,
   ): Uint8Array | null {
     if (!this.bridge?.isInitialized()) return null;
-    return this.bridge.exportGlb(safeUtf8Decode(buffer), includeMetadata, hidden, isolated, hiddenTypesCsv);
+    return this.bridge.exportGlb(safeUtf8Decode(buffer), includeMetadata, hidden, isolated, hiddenTypesCsv, lit);
   }
 
   exportCsv(
@@ -1149,9 +1150,11 @@ export class GeometryProcessor {
   /**
    * Assemble a GLB from already-produced meshes (no re-meshing) — the viewer path.
    * Flattens `MeshData[]` into the wasm binding's parallel arrays. The caller passes
-   * exactly the meshes it wants emitted (its own visibility filtering).
+   * exactly the meshes it wants emitted (its own visibility filtering). `lit` emits
+   * standard PBR materials that shade from normals; `false` ⇒ flat
+   * `KHR_materials_unlit` (the historical look — #1321).
    */
-  exportGlbFromMeshes(meshes: MeshData[], includeMetadata = false): Uint8Array | null {
+  exportGlbFromMeshes(meshes: MeshData[], includeMetadata = false, lit = true): Uint8Array | null {
     if (!this.bridge?.isInitialized()) return null;
     let totalV = 0;
     let totalI = 0;
@@ -1185,7 +1188,7 @@ export class GeometryProcessor {
       io += m.indices.length;
     }
     return this.bridge.exportGlbFromMeshes(
-      positions, normals, indices, vertexCounts, indexCounts, colors, origins, expressIds, includeMetadata,
+      positions, normals, indices, vertexCounts, indexCounts, colors, origins, expressIds, includeMetadata, lit,
     );
   }
 

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -89,10 +89,12 @@ export class IfcAPI {
    * comma-separated list of IFC type names whose class toggle is off (e.g.
    * `"IfcOpeningElement,IfcSpace"`). `include_metadata` attaches counts + per-node
    * `expressId`. Per-mesh RTC origin rides the node translation (precision-safe).
-   * `lit` emits standard PBR materials that shade from normals (`false` ⇒ flat
-   * `KHR_materials_unlit`, the historical look — #1321).
+   * `lit` emits standard PBR materials that shade from normals; omitted or
+   * `true` ⇒ lit (the default), `false` ⇒ flat `KHR_materials_unlit` (the
+   * historical look — #1321). Optional at the boundary so older 5-arg callers
+   * keep lit-by-default behaviour.
    */
-  exportGlb(content: string, include_metadata: boolean, hidden: Uint32Array, isolated: Uint32Array, hidden_types_csv: string, lit: boolean): Uint8Array;
+  exportGlb(content: string, include_metadata: boolean, hidden: Uint32Array, isolated: Uint32Array, hidden_types_csv: string, lit?: boolean | null): Uint8Array;
   /**
    * Package an already-produced **GLB** + georeference into a **KMZ** (`Uint8Array`)
    * for Google Earth: a ZIP of `doc.kml` (a `<Model>` placed at `latitude`/`longitude`/
@@ -107,7 +109,7 @@ export class IfcAPI {
    * RGBA per mesh, `origins` xyz per mesh, `express_ids` labels each mesh (indices are
    * per-mesh local). The caller passes exactly the meshes it wants emitted.
    */
-  exportGlbFromMeshes(positions: Float32Array, normals: Float32Array, indices: Uint32Array, vertex_counts: Uint32Array, index_counts: Uint32Array, colors: Float32Array, origins: Float64Array, express_ids: Uint32Array, include_metadata: boolean, lit: boolean): Uint8Array;
+  exportGlbFromMeshes(positions: Float32Array, normals: Float32Array, indices: Uint32Array, vertex_counts: Uint32Array, index_counts: Uint32Array, colors: Float32Array, origins: Float64Array, express_ids: Uint32Array, include_metadata: boolean, lit?: boolean | null): Uint8Array;
   /**
    * Export the render geometry in `content` as a Wavefront **OBJ** string.
    *

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -89,8 +89,10 @@ export class IfcAPI {
    * comma-separated list of IFC type names whose class toggle is off (e.g.
    * `"IfcOpeningElement,IfcSpace"`). `include_metadata` attaches counts + per-node
    * `expressId`. Per-mesh RTC origin rides the node translation (precision-safe).
+   * `lit` emits standard PBR materials that shade from normals (`false` ⇒ flat
+   * `KHR_materials_unlit`, the historical look — #1321).
    */
-  exportGlb(content: string, include_metadata: boolean, hidden: Uint32Array, isolated: Uint32Array, hidden_types_csv: string): Uint8Array;
+  exportGlb(content: string, include_metadata: boolean, hidden: Uint32Array, isolated: Uint32Array, hidden_types_csv: string, lit: boolean): Uint8Array;
   /**
    * Package an already-produced **GLB** + georeference into a **KMZ** (`Uint8Array`)
    * for Google Earth: a ZIP of `doc.kml` (a `<Model>` placed at `latitude`/`longitude`/
@@ -105,7 +107,7 @@ export class IfcAPI {
    * RGBA per mesh, `origins` xyz per mesh, `express_ids` labels each mesh (indices are
    * per-mesh local). The caller passes exactly the meshes it wants emitted.
    */
-  exportGlbFromMeshes(positions: Float32Array, normals: Float32Array, indices: Uint32Array, vertex_counts: Uint32Array, index_counts: Uint32Array, colors: Float32Array, origins: Float64Array, express_ids: Uint32Array, include_metadata: boolean): Uint8Array;
+  exportGlbFromMeshes(positions: Float32Array, normals: Float32Array, indices: Uint32Array, vertex_counts: Uint32Array, index_counts: Uint32Array, colors: Float32Array, origins: Float64Array, express_ids: Uint32Array, include_metadata: boolean, lit: boolean): Uint8Array;
   /**
    * Export the render geometry in `content` as a Wavefront **OBJ** string.
    *
@@ -1067,8 +1069,8 @@ export interface InitOutput {
   readonly ifcapi_buildPrePassStreaming: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number) => void;
   readonly ifcapi_clearPrePassCache: (a: number) => void;
   readonly ifcapi_exportCsv: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number) => void;
-  readonly ifcapi_exportGlb: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number, k: number) => void;
-  readonly ifcapi_exportGlbFromMeshes: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number, k: number, l: number, m: number, n: number, o: number, p: number, q: number, r: number, s: number) => void;
+  readonly ifcapi_exportGlb: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number, k: number, l: number) => void;
+  readonly ifcapi_exportGlbFromMeshes: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number, k: number, l: number, m: number, n: number, o: number, p: number, q: number, r: number, s: number, t: number) => void;
   readonly ifcapi_exportHbjson: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
   readonly ifcapi_exportIfcx: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
   readonly ifcapi_exportJson: (a: number, b: number, c: number, d: number, e: number, f: number, g: number) => void;

--- a/rust/export/src/gltf.rs
+++ b/rust/export/src/gltf.rs
@@ -27,6 +27,11 @@ pub struct GltfOptions {
     pub hidden: Vec<u32>,
     /// Exclude meshes whose IFC type is in this set (class-level visibility toggle).
     pub hidden_types: Vec<String>,
+    /// Emit standard (lit) PBR materials so external viewers shade the model from
+    /// its normals. When `false`, materials are tagged `KHR_materials_unlit` and
+    /// render flat with just the apparent base colour (the historical behaviour,
+    /// kept for colour-accurate exports). Default `true`. (#1321)
+    pub lit: bool,
 }
 
 impl Default for GltfOptions {
@@ -36,6 +41,7 @@ impl Default for GltfOptions {
             isolated: Vec::new(),
             hidden: Vec::new(),
             hidden_types: Vec::new(),
+            lit: true,
         }
     }
 }
@@ -117,7 +123,10 @@ struct Attributes {
 struct Material {
     #[serde(rename = "pbrMetallicRoughness")]
     pbr: Pbr,
-    extensions: Extensions,
+    // `Some` only for unlit exports (#1321); a lit material omits it entirely so
+    // the viewer applies standard PBR lighting from the mesh normals.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    extensions: Option<Extensions>,
     #[serde(rename = "alphaMode", skip_serializing_if = "Option::is_none")]
     alpha_mode: Option<&'static str>,
     // IFC face winding isn't reliably outward (the viewer renders cull-none /
@@ -244,7 +253,7 @@ fn view_ok(v: &MeshView) -> bool {
 /// georef scale) AND self-contained: a consumer that ignores node transforms sees
 /// the whole model uniformly offset, never each element collapsed onto the origin
 /// (the failure mode of per-element `node.translation`).
-fn assemble_glb(views: &[MeshView], include_metadata: bool) -> (Vec<u8>, GltfStats) {
+fn assemble_glb(views: &[MeshView], include_metadata: bool, lit: bool) -> (Vec<u8>, GltfStats) {
     // Pre-filter once so both passes (centre, then bake) see exactly the same set.
     let visible: Vec<&MeshView> = views.iter().filter(|v| view_ok(v)).collect();
 
@@ -363,7 +372,11 @@ fn assemble_glb(views: &[MeshView], include_metadata: bool) -> (Vec<u8>, GltfSta
                     metallic_factor: 0.0,
                     roughness_factor: 1.0,
                 },
-                extensions: Extensions { khr_materials_unlit: EmptyObj {} },
+                extensions: if lit {
+                    None
+                } else {
+                    Some(Extensions { khr_materials_unlit: EmptyObj {} })
+                },
                 alpha_mode: if mesh.color[3] < 1.0 { Some("BLEND") } else { None },
                 double_sided: true,
             });
@@ -465,7 +478,7 @@ fn assemble_glb(views: &[MeshView], include_metadata: bool) -> (Vec<u8>, GltfSta
         accessors,
         buffer_views,
         buffers: vec![Buffer { byte_length: bin.len() as u32 }],
-        extensions_used: if stats.materials > 0 {
+        extensions_used: if !lit && stats.materials > 0 {
             Some(vec!["KHR_materials_unlit"])
         } else {
             None
@@ -504,7 +517,7 @@ pub fn export_glb_with_stats(content: &[u8], opts: &GltfOptions) -> (Vec<u8>, Gl
             origin: y.origin,
         })
         .collect();
-    assemble_glb(&views, opts.include_metadata)
+    assemble_glb(&views, opts.include_metadata, opts.lit)
 }
 
 /// Assemble a GLB from already-produced meshes (the viewer's MeshData — **no re-meshing**).
@@ -523,6 +536,7 @@ pub fn export_glb_from_meshes(
     origins: &[f64],
     express_ids: &[u32],
     include_metadata: bool,
+    lit: bool,
 ) -> (Vec<u8>, GltfStats) {
     let n = vertex_counts.len();
     let mut views: Vec<MeshView> = Vec::with_capacity(n);
@@ -564,7 +578,7 @@ pub fn export_glb_from_meshes(
         vbase += vc;
         ibase += ic;
     }
-    assemble_glb(&views, include_metadata)
+    assemble_glb(&views, include_metadata, lit)
 }
 
 /// Pack a glTF JSON document and binary buffer into a GLB container (little-endian).
@@ -664,9 +678,17 @@ mod tests {
             }
         }
 
-        // Materials present + KHR_materials_unlit declared + double-sided.
+        // Materials present + LIT by default (#1321: no KHR_materials_unlit) +
+        // double-sided.
         assert!(json["materials"].as_array().unwrap().len() >= 1);
-        assert_eq!(json["extensionsUsed"][0], "KHR_materials_unlit");
+        assert!(
+            json.get("extensionsUsed").is_none(),
+            "lit by default: no extensionsUsed / unlit extension"
+        );
+        assert!(
+            json["materials"].as_array().unwrap().iter().all(|m| m.get("extensions").is_none()),
+            "lit materials carry no extensions"
+        );
         assert!(
             json["materials"].as_array().unwrap().iter().all(|m| m["doubleSided"] == true),
             "materials double-sided (IFC winding isn't reliably outward)"
@@ -713,7 +735,7 @@ mod tests {
 
         let (glb, stats) = export_glb_from_meshes(
             &positions, &normals, &indices, &vertex_counts, &index_counts, &colors, &origins,
-            &express_ids, true,
+            &express_ids, true, true,
         );
         assert_eq!(stats.meshes, 2);
         assert_eq!(stats.triangles, 4);
@@ -775,6 +797,42 @@ mod tests {
         // Translucent material → BLEND.
         assert!(json["materials"].as_array().unwrap().iter().any(|m| m["alphaMode"] == "BLEND"));
         assert_eq!(bin.len(), json["buffers"][0]["byteLength"].as_u64().unwrap() as usize);
+
+        // Lit (the call above passed lit = true): no unlit extension anywhere.
+        assert!(json.get("extensionsUsed").is_none(), "lit export omits extensionsUsed");
+        assert!(
+            json["materials"].as_array().unwrap().iter().all(|m| m.get("extensions").is_none()),
+            "lit materials carry no extensions"
+        );
+    }
+
+    #[test]
+    fn unlit_option_emits_khr_materials_unlit() {
+        // #1321: lit = false reproduces the historical flat material — every
+        // material tagged KHR_materials_unlit and the extension declared globally.
+        let positions: Vec<f32> = vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0];
+        let normals: Vec<f32> = std::iter::repeat([0.0f32, 0.0, 1.0]).take(4).flatten().collect();
+        let indices: Vec<u32> = vec![0, 1, 2, 0, 2, 3];
+        let (glb, _) = export_glb_from_meshes(
+            &positions,
+            &normals,
+            &indices,
+            &[4],
+            &[6],
+            &[0.5, 0.5, 0.5, 1.0],
+            &[0.0, 0.0, 0.0],
+            &[10],
+            false,
+            false, // lit = false ⇒ unlit
+        );
+        let (json, _) = parse_glb(&glb);
+        assert_eq!(json["extensionsUsed"][0], "KHR_materials_unlit");
+        assert!(
+            json["materials"].as_array().unwrap().iter().all(|m| m["extensions"]
+                ["KHR_materials_unlit"]
+                .is_object()),
+            "unlit materials carry the KHR_materials_unlit extension"
+        );
     }
 
     #[test]

--- a/rust/wasm-bindings/src/api/export_glb.rs
+++ b/rust/wasm-bindings/src/api/export_glb.rs
@@ -15,8 +15,10 @@ impl IfcAPI {
     /// comma-separated list of IFC type names whose class toggle is off (e.g.
     /// `"IfcOpeningElement,IfcSpace"`). `include_metadata` attaches counts + per-node
     /// `expressId`. Per-mesh RTC origin rides the node translation (precision-safe).
-    /// `lit` emits standard PBR materials that shade from normals (`false` ⇒ flat
-    /// `KHR_materials_unlit`, the historical look — #1321).
+    /// `lit` emits standard PBR materials that shade from normals; omitted or
+    /// `true` ⇒ lit (the default), `false` ⇒ flat `KHR_materials_unlit` (the
+    /// historical look — #1321). Optional at the boundary so older 5-arg callers
+    /// keep lit-by-default behaviour.
     #[wasm_bindgen(js_name = exportGlb)]
     #[allow(clippy::too_many_arguments)]
     pub fn export_glb(
@@ -26,7 +28,7 @@ impl IfcAPI {
         hidden: &[u32],
         isolated: &[u32],
         hidden_types_csv: String,
-        lit: bool,
+        lit: Option<bool>,
     ) -> Vec<u8> {
         let hidden_types = hidden_types_csv
             .split(',')
@@ -38,7 +40,7 @@ impl IfcAPI {
             hidden: hidden.to_vec(),
             isolated: isolated.to_vec(),
             hidden_types,
-            lit,
+            lit: lit.unwrap_or(true),
         };
         ifc_lite_export::export_glb(content.as_bytes(), &opts)
     }
@@ -61,7 +63,7 @@ impl IfcAPI {
         origins: &[f64],
         express_ids: &[u32],
         include_metadata: bool,
-        lit: bool,
+        lit: Option<bool>,
     ) -> Vec<u8> {
         ifc_lite_export::export_glb_from_meshes(
             positions,
@@ -73,7 +75,7 @@ impl IfcAPI {
             origins,
             express_ids,
             include_metadata,
-            lit,
+            lit.unwrap_or(true),
         )
         .0
     }

--- a/rust/wasm-bindings/src/api/export_glb.rs
+++ b/rust/wasm-bindings/src/api/export_glb.rs
@@ -15,7 +15,10 @@ impl IfcAPI {
     /// comma-separated list of IFC type names whose class toggle is off (e.g.
     /// `"IfcOpeningElement,IfcSpace"`). `include_metadata` attaches counts + per-node
     /// `expressId`. Per-mesh RTC origin rides the node translation (precision-safe).
+    /// `lit` emits standard PBR materials that shade from normals (`false` ⇒ flat
+    /// `KHR_materials_unlit`, the historical look — #1321).
     #[wasm_bindgen(js_name = exportGlb)]
+    #[allow(clippy::too_many_arguments)]
     pub fn export_glb(
         &self,
         content: String,
@@ -23,6 +26,7 @@ impl IfcAPI {
         hidden: &[u32],
         isolated: &[u32],
         hidden_types_csv: String,
+        lit: bool,
     ) -> Vec<u8> {
         let hidden_types = hidden_types_csv
             .split(',')
@@ -34,6 +38,7 @@ impl IfcAPI {
             hidden: hidden.to_vec(),
             isolated: isolated.to_vec(),
             hidden_types,
+            lit,
         };
         ifc_lite_export::export_glb(content.as_bytes(), &opts)
     }
@@ -56,6 +61,7 @@ impl IfcAPI {
         origins: &[f64],
         express_ids: &[u32],
         include_metadata: bool,
+        lit: bool,
     ) -> Vec<u8> {
         ifc_lite_export::export_glb_from_meshes(
             positions,
@@ -67,6 +73,7 @@ impl IfcAPI {
             origins,
             express_ids,
             include_metadata,
+            lit,
         )
         .0
     }


### PR DESCRIPTION
Closes #1321.

## Problem

Every GLB from `@ifc-lite/geometry` rendered **flat / unshaded** in external glTF viewers (Blender, three.js, Babylon, Windows 3D Viewer): no lighting, surfaces of similar colour merged together. The in-app WebGPU renderer was unaffected because it lights the scene itself and ignores the GLB material — so the flatness was export-only.

Cause: `assemble_glb()` tagged **every** material with `KHR_materials_unlit` (and declared it in `extensionsUsed`), telling viewers to paint the flat base colour and ignore lighting + normals. NORMAL accessors were already written, so the data for shading was present — only the unlit material suppressed it. Both export paths (`export_glb` from bytes, `export_glb_from_meshes` from `MeshData`) shared the assembler, neither exposed a lit/unlit choice.

## Change

Add a `lit` option threaded through the stack, **defaulting to lit** (the material is already `metallic 0 / roughness 1 / doubleSided`, so dropping the unlit extension yields a correct matte PBR material that shades from the existing normals):

- **rust/export/src/gltf.rs** — `GltfOptions.lit`; `assemble_glb(.., lit)` skips the unlit extension and omits it from `extensionsUsed` when `lit`; `Material.extensions` → `Option`; `export_glb_from_meshes(.., lit)`.
- **rust/wasm-bindings** — `lit` arg on `exportGlb` + `exportGlbFromMeshes` (pkg `ifc-lite.d.ts` regenerated).
- **@ifc-lite/geometry** — `exportGlb(.., lit = true)`, `exportGlbFromMeshes(meshes, includeMetadata?, lit = true)`.
- **apps/viewer** — "Lit Materials" toggle in the GLB export dialog (default on); unlit still reachable for a colour-accurate flat export.

## Tests

- `from_meshes_assembles_valid_glb` extended to assert the default lit material carries no `extensions` / no `extensionsUsed`.
- New `unlit_option_emits_khr_materials_unlit` proves `lit = false` still emits the extension.
- `pnpm --filter @ifc-lite/geometry build` + `pnpm --filter viewer typecheck` clean; wasm rebuilt via `scripts/build-wasm.sh`.
<img width="384" height="321" alt="image" src="https://github.com/user-attachments/assets/a7ce1bac-1cbd-4c6c-8ff6-b9659c5cae68" />

## Verify

Export a model → open the `.glb` in Blender / three.js editor / Windows 3D Viewer → surfaces show shading instead of a flat silhouette. Toggle "Lit Materials" off to compare against the previous unlit look.

Changeset: `@ifc-lite/wasm` + `@ifc-lite/geometry` minor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

**New Features**
- Added a **“Lit Materials”** option to the GLB export dialog. Exported models now use standard lit PBR materials by default for better appearance in external 3D viewers.

**Behavior Change**
- The default GLB material style is now **lit**. To match the previous flat/unlit look, disable **Lit Materials** during export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->