### PR TITLE
docs(python): README + examples + type stub for the ifclite-geom wheel

### DIFF
--- a/rust/python/Cargo.lock
+++ b/rust/python/Cargo.lock
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-python"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "ifc-lite-processing",
  "pyo3",

--- a/rust/python/Cargo.toml
+++ b/rust/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ifc-lite-python"
-version = "4.1.0"
+version = "4.2.0"
 edition = "2021"
 license = "MPL-2.0"
 repository = "https://github.com/LTplus-AG/ifc-lite"

--- a/rust/python/README.md
+++ b/rust/python/README.md
@@ -1,0 +1,125 @@
+# ifclite-geom
+
+Native [ifc-lite](https://github.com/LTplus-AG/ifc-lite) geometry tessellation for
+Python. It turns an IFC file into per-entity triangle meshes with no Node, no
+WASM, and no subprocess: the Rust geometry kernel runs directly inside the
+Python process.
+
+Meshes come back **welded**, **IFC Z-up**, in **absolute world metres**, keyed by
+IFC STEP id (occurrences only). This is the analysis-ready export, distinct from
+the render-oriented GLB the viewer uses.
+
+## Install
+
+```bash
+pip install ifclite-geom
+```
+
+Prebuilt wheels ship for CPython 3.9+ on Linux (x86_64, aarch64), macOS (Apple
+silicon and Intel), and Windows (x64). No Rust toolchain needed.
+
+## Quick start
+
+The module is `ifclite_geom` and exposes two functions. Both take the raw IFC
+file as `bytes` and return the same geometry; they differ only in the output
+format.
+
+```python
+import ifclite_geom
+import numpy as np
+
+with open("model.ifc", "rb") as f:
+    ifc_bytes = f.read()
+
+data = ifclite_geom.geometry_data_buffers(ifc_bytes)
+
+print(data["element_count"], "elements")
+print("up axis:", data["up_axis"], "| units:", data["units"])
+print("rtc offset:", data["rtc_offset"])
+
+for step_id, el in data["elements"].items():
+    verts = np.frombuffer(el["vertices"], dtype=np.float64).reshape(-1, 3)
+    faces = np.frombuffer(el["faces"],    dtype=np.uint32 ).reshape(-1, 3)
+    print(step_id, el["ifc_type"], el["global_id"], verts.shape, faces.shape)
+```
+
+Prefer no numpy dependency? Use the JSON variant, which returns the same data as
+arrays of numbers:
+
+```python
+import ifclite_geom, json
+
+doc = json.loads(ifclite_geom.geometry_data_json(ifc_bytes))
+first = next(iter(doc["elements"].values()))
+print(first["ifc_type"], first["vertices"][0])  # [x, y, z] in metres
+```
+
+## API
+
+### `geometry_data_buffers(ifc_bytes: bytes) -> dict`
+
+The fast path. Vertices and faces come back as raw little-endian byte buffers so
+you can hand them straight to `numpy.frombuffer` with zero parsing.
+
+```text
+{
+  "up_axis": "Z",            # always Z (IFC native)
+  "units": "m",              # always metres
+  "rtc_offset": [x, y, z],   # geo-reference offset already folded into vertices
+  "element_count": 1234,
+  "elements": {
+    <step_id:int>: {
+      "ifc_type":  "IfcWall",
+      "global_id": "3vB2...",   # may be None
+      "name":      "Basic Wall:...",  # may be None
+      "color":     [r, g, b, a],      # 0..1
+      "vertices":  <bytes>,           # f64 little-endian, xyz triplets
+      "faces":     <bytes>,           # u32 little-endian, triangle indices
+    },
+    ...
+  }
+}
+```
+
+Decode the buffers with:
+
+```python
+verts = np.frombuffer(el["vertices"], dtype=np.float64).reshape(-1, 3)  # (V, 3)
+faces = np.frombuffer(el["faces"],    dtype=np.uint32 ).reshape(-1, 3)  # (F, 3)
+```
+
+### `geometry_data_json(ifc_bytes: bytes) -> str`
+
+The same geometry as a readable `ifc-lite-geometry-data` JSON document (a
+string; call `json.loads` on it). Vertices are `[x, y, z]` arrays and faces are
+`[a, b, c]` index arrays, so no numpy is required. Each element also carries
+`global_id` and `name` when the source entity has them.
+
+## Notes
+
+- **One mesh per element.** Per-material submeshes of an element are merged into a
+  single indexed triangle soup, keyed by its IFC STEP id.
+- **Coordinates are absolute world metres.** The per-element local frame and the
+  model RTC offset are folded back into every vertex. For geo-referenced models
+  `rtc_offset` is non-zero; subtract it if you want f32-friendly local
+  coordinates.
+- **Welded and indexed.** Coincident corners are merged (1 micron grid), so
+  closed-mesh consumers (volume, watertightness checks) work directly.
+- **Occurrences only.** Type-product / RepresentationMap geometry is not
+  emitted, matching what occurrence-based tessellators produce.
+- **Errors** surface as `RuntimeError` (geometry pipeline failure) or
+  `ValueError` (JSON serialization failure).
+
+## Examples
+
+Runnable scripts live in [`examples/`](./examples):
+
+- [`quickstart_numpy.py`](./examples/quickstart_numpy.py) - load a file and
+  inspect meshes via numpy.
+- [`dump_json.py`](./examples/dump_json.py) - write the JSON document to disk.
+- [`export_obj.py`](./examples/export_obj.py) - write every element to a single
+  Wavefront `.obj` (numpy only, no extra deps).
+
+## License
+
+MPL-2.0. Part of the [ifc-lite](https://github.com/LTplus-AG/ifc-lite) project.

--- a/rust/python/examples/dump_json.py
+++ b/rust/python/examples/dump_json.py
@@ -1,3 +1,6 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 """Tessellate an IFC file and write the geometry-data JSON document to disk.
 
 No numpy needed: the JSON variant returns vertices/faces as plain arrays.

--- a/rust/python/examples/dump_json.py
+++ b/rust/python/examples/dump_json.py
@@ -1,0 +1,30 @@
+"""Tessellate an IFC file and write the geometry-data JSON document to disk.
+
+No numpy needed: the JSON variant returns vertices/faces as plain arrays.
+
+Usage:
+    pip install ifclite-geom
+    python dump_json.py path/to/model.ifc out.json
+"""
+
+import sys
+
+import ifclite_geom
+
+
+def main(in_path: str, out_path: str) -> None:
+    with open(in_path, "rb") as f:
+        ifc_bytes = f.read()
+
+    # geometry_data_json already returns a JSON string; write it straight out.
+    doc = ifclite_geom.geometry_data_json(ifc_bytes)
+    with open(out_path, "w", encoding="utf-8") as f:
+        f.write(doc)
+
+    print(f"wrote {out_path} ({len(doc)} bytes)")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        sys.exit("usage: python dump_json.py path/to/model.ifc out.json")
+    main(sys.argv[1], sys.argv[2])

--- a/rust/python/examples/export_obj.py
+++ b/rust/python/examples/export_obj.py
@@ -1,0 +1,45 @@
+"""Export every element of an IFC file to a single Wavefront .obj.
+
+Each IFC element becomes an `o <step_id>_<ifc_type>` group. Only numpy is
+required. The .obj keeps IFC Z-up world coordinates in metres.
+
+Usage:
+    pip install ifclite-geom numpy
+    python export_obj.py path/to/model.ifc out.obj
+"""
+
+import sys
+
+import numpy as np
+
+import ifclite_geom
+
+
+def main(in_path: str, out_path: str) -> None:
+    with open(in_path, "rb") as f:
+        ifc_bytes = f.read()
+
+    data = ifclite_geom.geometry_data_buffers(ifc_bytes)
+
+    vertex_offset = 1  # .obj indices are 1-based and run across the whole file
+    with open(out_path, "w", encoding="utf-8") as out:
+        out.write(f"# ifclite-geom export ({data['element_count']} elements, "
+                  f"{data['units']}, up={data['up_axis']})\n")
+        for step_id, el in data["elements"].items():
+            verts = np.frombuffer(el["vertices"], dtype=np.float64).reshape(-1, 3)
+            faces = np.frombuffer(el["faces"], dtype=np.uint32).reshape(-1, 3)
+
+            out.write(f"o {step_id}_{el['ifc_type']}\n")
+            for x, y, z in verts:
+                out.write(f"v {x:.6f} {y:.6f} {z:.6f}\n")
+            for a, b, c in faces + vertex_offset:
+                out.write(f"f {a} {b} {c}\n")
+            vertex_offset += len(verts)
+
+    print(f"wrote {out_path}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        sys.exit("usage: python export_obj.py path/to/model.ifc out.obj")
+    main(sys.argv[1], sys.argv[2])

--- a/rust/python/examples/export_obj.py
+++ b/rust/python/examples/export_obj.py
@@ -1,3 +1,6 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 """Export every element of an IFC file to a single Wavefront .obj.
 
 Each IFC element becomes an `o <step_id>_<ifc_type>` group. Only numpy is

--- a/rust/python/examples/quickstart_numpy.py
+++ b/rust/python/examples/quickstart_numpy.py
@@ -1,3 +1,6 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 """Load an IFC file and inspect its meshes with numpy.
 
 Usage:

--- a/rust/python/examples/quickstart_numpy.py
+++ b/rust/python/examples/quickstart_numpy.py
@@ -1,0 +1,42 @@
+"""Load an IFC file and inspect its meshes with numpy.
+
+Usage:
+    pip install ifclite-geom numpy
+    python quickstart_numpy.py path/to/model.ifc
+"""
+
+import sys
+
+import numpy as np
+
+import ifclite_geom
+
+
+def main(path: str) -> None:
+    with open(path, "rb") as f:
+        ifc_bytes = f.read()
+
+    data = ifclite_geom.geometry_data_buffers(ifc_bytes)
+
+    print(f"{data['element_count']} elements")
+    print(f"up axis: {data['up_axis']}  units: {data['units']}")
+    print(f"rtc offset: {data['rtc_offset']}")
+
+    total_tris = 0
+    for step_id, el in data["elements"].items():
+        verts = np.frombuffer(el["vertices"], dtype=np.float64).reshape(-1, 3)
+        faces = np.frombuffer(el["faces"], dtype=np.uint32).reshape(-1, 3)
+        total_tris += len(faces)
+        # Print a one-line summary for the first few elements.
+        if step_id in list(data["elements"])[:5]:
+            label = el["name"] or el["global_id"] or "-"
+            print(f"  #{step_id} {el['ifc_type']:<20} {label:<24} "
+                  f"{len(verts):>6} verts  {len(faces):>6} tris")
+
+    print(f"total triangles: {total_tris}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        sys.exit("usage: python quickstart_numpy.py path/to/model.ifc")
+    main(sys.argv[1])

--- a/rust/python/ifclite_geom.pyi
+++ b/rust/python/ifclite_geom.pyi
@@ -1,0 +1,46 @@
+# Type stubs for the ifclite-geom native extension.
+# Shipped next to the compiled module so editors and type checkers see the API.
+from typing import Any, Dict, List, Optional, TypedDict
+
+class ElementBuffers(TypedDict):
+    ifc_type: str
+    global_id: Optional[str]
+    name: Optional[str]
+    color: List[float]  # [r, g, b, a] in 0..1
+    vertices: bytes  # f64 little-endian, xyz triplets
+    faces: bytes  # u32 little-endian, triangle indices
+
+class GeometryBuffers(TypedDict):
+    up_axis: str  # always "Z"
+    units: str  # always "m"
+    rtc_offset: List[float]  # [x, y, z], already folded into vertices
+    element_count: int
+    elements: Dict[int, ElementBuffers]  # keyed by IFC STEP id
+
+def geometry_data_buffers(ifc_bytes: bytes) -> GeometryBuffers:
+    """Tessellate IFC bytes; return per-entity geometry with vertices/faces as
+    raw little-endian byte buffers (f64 xyz triplets, u32 triangle indices) for
+    ``numpy.frombuffer``.
+
+    Vertices are welded, IFC Z-up, absolute-world metres, keyed by IFC STEP id
+    (occurrences only). ``ifc_bytes`` is the raw IFC file content, e.g.
+    ``open(path, "rb").read()``.
+
+    Raises:
+        RuntimeError: the geometry pipeline failed.
+    """
+    ...
+
+def geometry_data_json(ifc_bytes: bytes) -> str:
+    """Tessellate IFC bytes; return the ``ifc-lite-geometry-data`` JSON document
+    as a string (call ``json.loads`` on it).
+
+    Same geometry as :func:`geometry_data_buffers`, but vertices/faces are JSON
+    arrays (no numpy needed) and each element also carries ``global_id`` and
+    ``name`` when present.
+
+    Raises:
+        RuntimeError: the geometry pipeline failed.
+        ValueError: JSON serialization failed.
+    """
+    ...

--- a/rust/python/ifclite_geom.pyi
+++ b/rust/python/ifclite_geom.pyi
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
 # Type stubs for the ifclite-geom native extension.
 # Shipped next to the compiled module so editors and type checkers see the API.
 from typing import Any, Dict, List, Optional, TypedDict

--- a/rust/python/pyproject.toml
+++ b/rust/python/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "maturin"
 [project]
 name = "ifclite-geom"
 description = "Native ifc-lite geometry-data export for Python (welded, IFC Z-up, world coords)."
+readme = "README.md"
 requires-python = ">=3.9"
 license = { text = "MPL-2.0" }
 authors = [{ name = "IFC-Lite Contributors" }]
@@ -17,10 +18,16 @@ classifiers = [
 dynamic = ["version"]
 
 [project.urls]
+Homepage = "https://github.com/LTplus-AG/ifc-lite"
 Repository = "https://github.com/LTplus-AG/ifc-lite"
+Documentation = "https://github.com/LTplus-AG/ifc-lite/tree/main/rust/python#readme"
 
 [tool.maturin]
 # The cdylib is `ifclite_geom`; build an abi3 wheel (one wheel per platform
 # works across CPython >= 3.9). Manifest-relative to this crate.
 module-name = "ifclite_geom"
 features = ["pyo3/extension-module"]
+# Ship the type stub next to the compiled module so editors / type checkers get
+# signatures and docstrings (the .so itself carries no static types). Pure-Rust
+# layout: the stub lands at the wheel root, adjacent to ifclite_geom.<abi>.so.
+include = [{ path = "ifclite_geom.pyi", format = "wheel" }]

--- a/rust/python/src/lib.rs
+++ b/rust/python/src/lib.rs
@@ -50,9 +50,14 @@ fn run_export(ifc_bytes: Vec<u8>) -> Result<GeometryDataExport, String> {
 /// little-endian byte buffers (f64 xyz triplets, u32 triangle indices) for
 /// `numpy.frombuffer`. Returns a dict:
 /// `{ up_axis:"Z", units:"m", rtc_offset:[x,y,z], element_count,
-///    elements: { step_id: { ifc_type, color:[r,g,b,a], vertices:bytes,
-///    faces:bytes } } }`. Vertices are welded, IFC Z-up, absolute-world metres.
+///    elements: { step_id: { ifc_type, global_id, name, color:[r,g,b,a],
+///    vertices:bytes, faces:bytes } } }`. `global_id` / `name` are `None` when
+///    the source entity has none. Vertices are welded, IFC Z-up, absolute-world
+///    metres, keyed by IFC STEP id (occurrences only).
+///
+/// `ifc_bytes` is the raw IFC file content (e.g. `open(path, "rb").read()`).
 #[pyfunction]
+#[pyo3(signature = (ifc_bytes))]
 fn geometry_data_buffers(py: Python<'_>, ifc_bytes: Vec<u8>) -> PyResult<Py<PyAny>> {
     let export = py
         .detach(|| run_export(ifc_bytes))
@@ -68,6 +73,10 @@ fn geometry_data_buffers(py: Python<'_>, ifc_bytes: Vec<u8>) -> PyResult<Py<PyAn
     for (id, el) in &export.elements {
         let d = PyDict::new(py);
         d.set_item("ifc_type", &el.ifc_type)?;
+        // Mirror the JSON path so both exports carry the same identity fields;
+        // `None` maps to Python `None` (key always present).
+        d.set_item("global_id", el.global_id.clone())?;
+        d.set_item("name", el.name.clone())?;
         d.set_item("color", el.color.to_vec())?;
         // Reinterpret the contiguous `[f64;3]` / `[u32;3]` vecs as little-endian
         // bytes (zero-copy; PyBytes copies into Python). Targets are all LE.
@@ -91,8 +100,14 @@ fn geometry_data_buffers(py: Python<'_>, ifc_bytes: Vec<u8>) -> PyResult<Py<PyAn
     Ok(out.into_any().unbind())
 }
 
-/// Tessellate IFC bytes; return the `ifc-lite-geometry-data` JSON document.
+/// Tessellate IFC bytes; return the `ifc-lite-geometry-data` JSON document as a
+/// string. Same geometry as [`geometry_data_buffers`], but vertices/faces are
+/// JSON arrays (no numpy needed) and each element also carries `global_id` and
+/// `name` when present.
+///
+/// `ifc_bytes` is the raw IFC file content (e.g. `open(path, "rb").read()`).
 #[pyfunction]
+#[pyo3(signature = (ifc_bytes))]
 fn geometry_data_json(py: Python<'_>, ifc_bytes: Vec<u8>) -> PyResult<String> {
     let export = py
         .detach(|| run_export(ifc_bytes))


### PR DESCRIPTION
## Why

The `ifclite-geom` PyO3 wheel (added in #1316, published as `ifclite-geom-v4.1.0`) shipped with **no usage docs**: a `pip install` user has nothing to point at to learn which functions exist or how to call them. This came up directly from someone testing the wheel.

## What

- **`rust/python/README.md`** — quickstart, full output schema for both functions, notes, examples index. Wired as the PyPI project page via `project.readme` so it renders on https://pypi.org/project/ifclite-geom.
- **`pyproject.toml`** — `readme`, `project.urls` Homepage + Documentation.
- **`examples/`** — runnable scripts: `quickstart_numpy.py`, `dump_json.py`, `export_obj.py` (numpy-only).
- **`ifclite_geom.pyi`** — type stub (TypedDict-shaped) so editors / type checkers get signatures + docstrings off the compiled module; bundled via `[tool.maturin] include`.
- **`src/lib.rs`** — fold `global_id` / `name` into the `geometry_data_buffers` dict so the fast path matches `geometry_data_json` (lets a consumer map triangles back to IFC entities); add `#[pyo3(signature = (ifc_bytes))]` so `help()` shows the arg.
- **Version 4.1.0 → 4.2.0** (`Cargo.toml` + `Cargo.lock`). Additive API; the README and the new fields only reach PyPI on the **next** `ifclite-geom-v*` tag.

## Verification

- `cargo check` on `rust/python` passes (run standalone; the crate is workspace-excluded). No new warnings from these edits.
- All example scripts + the stub pass `python -m py_compile`.
- The `python-wheels` CI builds wheels for this PR (paths trigger on `rust/python/**`).

## One thing to confirm at review

The type stub ships via `[tool.maturin] include = [{ path = "ifclite_geom.pyi", format = "wheel" }]`. Please eyeball a CI wheel artifact to confirm `ifclite_geom.pyi` lands at the wheel root, adjacent to `ifclite_geom.<abi>.so` (where type checkers look). If maturin places it elsewhere, we switch to a `python-source` layout. The README, examples, and the `global_id`/`name` change are independent of this.

## Release note

To publish: tag `ifclite-geom-v4.2.0` after merge (existing trusted-publishing workflow).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-element identity fields (global ID and name) to geometry data exports.
  * Added example scripts demonstrating JSON export, OBJ file generation, and NumPy integration.

* **Documentation**
  * Added comprehensive module documentation with API reference and usage examples.
  * Added type stubs for improved IDE support and code completion.

* **Chores**
  * Version bumped to 4.2.0 with updated package metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->