### PR TITLE
docs: surface the ifclite-geom Python wheel in README + docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ const ifcx = new Ifc5Exporter(store, meshes).export({ includeGeometry: true });
 | [**Three.js / Babylon.js**](https://ltplus-ag.github.io/ifc-lite/tutorials/threejs-integration/) | Adding IFC support to an existing 3D app | IFC parsing + geometry, rendered by your engine |
 | [**Server**](https://ltplus-ag.github.io/ifc-lite/guide/server/) | Teams, large files, repeat access | Rust backend with caching, parallel processing, streaming |
 | [**Build for Desktop**](https://ltplus-ag.github.io/ifc-lite/guide/desktop/) | Your own offline native app, very large files (500 MB+) | Extension points to wrap the packages in Tauri, with an optional native-Rust geometry fast path |
+| [**Python (native wheel)**](https://ltplus-ag.github.io/ifc-lite/api/python/) | Analysis, scripting, scientific Python | `pip install ifclite-geom` runs the geometry kernel in-process, meshes straight to numpy |
 
 Not sure? Start with the browser setup. You can add a server or switch engines later.
 
@@ -235,7 +236,7 @@ Ready-to-run projects in [`examples/`](examples/):
 | **BIM features** | [Federation](https://ltplus-ag.github.io/ifc-lite/guide/federation/) · [BCF](https://ltplus-ag.github.io/ifc-lite/guide/bcf/) · [IDS Validation](https://ltplus-ag.github.io/ifc-lite/guide/ids/) · [2D Drawings](https://ltplus-ag.github.io/ifc-lite/guide/drawing-2d/) · [Property Editing](https://ltplus-ag.github.io/ifc-lite/guide/mutations/) |
 | **Tutorials** | [Build a Viewer](https://ltplus-ag.github.io/ifc-lite/tutorials/building-viewer/) · [Three.js](https://ltplus-ag.github.io/ifc-lite/tutorials/threejs-integration/) · [Babylon.js](https://ltplus-ag.github.io/ifc-lite/tutorials/babylonjs-integration/) · [Custom Queries](https://ltplus-ag.github.io/ifc-lite/tutorials/custom-queries/) |
 | **Deep dives** | [Architecture](https://ltplus-ag.github.io/ifc-lite/architecture/overview/) · [Data Flow](https://ltplus-ag.github.io/ifc-lite/architecture/data-flow/) · [Performance](https://ltplus-ag.github.io/ifc-lite/guide/performance/) |
-| **API** | [TypeScript](https://ltplus-ag.github.io/ifc-lite/api/typescript/) · [Rust](https://ltplus-ag.github.io/ifc-lite/api/rust/) · [WASM](https://ltplus-ag.github.io/ifc-lite/api/wasm/) |
+| **API** | [TypeScript](https://ltplus-ag.github.io/ifc-lite/api/typescript/) · [Rust](https://ltplus-ag.github.io/ifc-lite/api/rust/) · [WASM](https://ltplus-ag.github.io/ifc-lite/api/wasm/) · [Python](https://ltplus-ag.github.io/ifc-lite/api/python/) |
 
 ## Contributing
 

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -1,0 +1,118 @@
+# Python API Reference
+
+`ifclite-geom` is a native Python wheel that runs ifc-lite's Rust geometry
+kernel in-process. It turns an IFC file into per-entity triangle meshes with no
+Node, no WASM, and no subprocess.
+
+Meshes come back **welded**, **IFC Z-up**, in **absolute world metres**, keyed by
+IFC STEP id (occurrences only). This is the analysis-ready export, distinct from
+the render-oriented GLB the viewer uses.
+
+## Install
+
+```bash
+pip install ifclite-geom
+```
+
+Prebuilt wheels ship for CPython 3.9+ on Linux (x86_64, aarch64), macOS (Apple
+silicon and Intel), and Windows (x64). No Rust toolchain needed.
+
+## Quick start
+
+The module is `ifclite_geom` and exposes two functions. Both take the raw IFC
+file as `bytes` and return the same geometry; they differ only in output format.
+
+```python
+import ifclite_geom
+import numpy as np
+
+with open("model.ifc", "rb") as f:
+    ifc_bytes = f.read()
+
+data = ifclite_geom.geometry_data_buffers(ifc_bytes)
+
+print(data["element_count"], "elements")
+print("up axis:", data["up_axis"], "| units:", data["units"])
+print("rtc offset:", data["rtc_offset"])
+
+for step_id, el in data["elements"].items():
+    verts = np.frombuffer(el["vertices"], dtype=np.float64).reshape(-1, 3)
+    faces = np.frombuffer(el["faces"],    dtype=np.uint32 ).reshape(-1, 3)
+    print(step_id, el["ifc_type"], el["global_id"], verts.shape, faces.shape)
+```
+
+No numpy? Use the JSON variant, which returns the same data as arrays of numbers:
+
+```python
+import ifclite_geom, json
+
+doc = json.loads(ifclite_geom.geometry_data_json(ifc_bytes))
+first = next(iter(doc["elements"].values()))
+print(first["ifc_type"], first["vertices"][0])  # [x, y, z] in metres
+```
+
+## Functions
+
+### `geometry_data_buffers(ifc_bytes: bytes) -> dict`
+
+The fast path. Vertices and faces come back as raw little-endian byte buffers so
+you can hand them straight to `numpy.frombuffer` with zero parsing.
+
+```text
+{
+  "up_axis": "Z",            # always Z (IFC native)
+  "units": "m",              # always metres
+  "rtc_offset": [x, y, z],   # geo-reference offset already folded into vertices
+  "element_count": 1234,
+  "elements": {
+    <step_id:int>: {
+      "ifc_type":  "IfcWall",
+      "global_id": "3vB2...",          # may be None
+      "name":      "Basic Wall:...",   # may be None
+      "color":     [r, g, b, a],       # 0..1
+      "vertices":  <bytes>,            # f64 little-endian, xyz triplets
+      "faces":     <bytes>,            # u32 little-endian, triangle indices
+    },
+    ...
+  }
+}
+```
+
+Decode the buffers with:
+
+```python
+verts = np.frombuffer(el["vertices"], dtype=np.float64).reshape(-1, 3)  # (V, 3)
+faces = np.frombuffer(el["faces"],    dtype=np.uint32 ).reshape(-1, 3)  # (F, 3)
+```
+
+### `geometry_data_json(ifc_bytes: bytes) -> str`
+
+The same geometry as a readable `ifc-lite-geometry-data` JSON document (a string;
+call `json.loads` on it). Vertices are `[x, y, z]` arrays and faces are
+`[a, b, c]` index arrays, so no numpy is required. Each element also carries
+`global_id` and `name` when the source entity has them.
+
+## Notes
+
+- **One mesh per element.** Per-material submeshes of an element are merged into a
+  single indexed triangle soup, keyed by its IFC STEP id.
+- **Coordinates are absolute world metres.** The per-element local frame and the
+  model RTC offset are folded back into every vertex. For geo-referenced models
+  `rtc_offset` is non-zero; subtract it for f32-friendly local coordinates.
+- **Welded and indexed.** Coincident corners are merged (1 micron grid), so
+  closed-mesh consumers (volume, watertightness) work directly.
+- **Occurrences only.** Type-product / RepresentationMap geometry is not emitted.
+- **Errors** surface as `RuntimeError` (geometry pipeline failure) or
+  `ValueError` (JSON serialization failure).
+
+## Examples
+
+Runnable scripts live in the
+[`rust/python/examples/`](https://github.com/LTplus-AG/ifc-lite/tree/main/rust/python/examples)
+directory: a numpy quickstart, a JSON dump, and a Wavefront `.obj` exporter.
+
+## Source
+
+The binding is a thin PyO3 layer at
+[`rust/python`](https://github.com/LTplus-AG/ifc-lite/tree/main/rust/python),
+wrapping the same `process_geometry` pipeline used by the viewer and server.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -147,6 +147,7 @@ nav:
     - TypeScript API: api/typescript.md
     - Rust API: api/rust.md
     - WASM Bindings: api/wasm.md
+    - Python (PyPI): api/python.md
   - Tutorials:
     - Building a Viewer: tutorials/building-viewer.md
     - Three.js Integration: tutorials/threejs-integration.md


### PR DESCRIPTION
## Why

The native Python wheel (`ifclite-geom`) had no entry point from the project's main discovery surfaces: the root README and the hosted docs site only mention the npm packages and Rust crates. Anyone who finds the wheel on PyPI (or hears about it) has nowhere on the site to land. This is the "reach" follow-up to #1325 (the package-level README + examples + stub).

## What

- **`docs/api/python.md`** — a Python API Reference page (install, both functions, output schema, notes, links to examples + source), wired into the mkdocs nav under **API Reference** alongside TypeScript / Rust / WASM.
- **Root README, "Choose your setup"** — a `Python (native wheel)` row.
- **Root README, "Documentation" API row** — a `Python` link.

All links point at the hosted page `https://ltplus-ag.github.io/ifc-lite/api/python/`, matching the existing API entries.

## Notes

- Independent of #1325; can merge in either order. #1325 ships the package's own README/examples/stub and the `global_id`/`name` API addition.
- mkdocs nav adds one entry pointing at the new file; no other site config touched.

## Related

Pairs with #1325. Together they give a `pip` user a documentation URL to land on (the original request that prompted this).