### PR TITLE
fix(release): ship #1311's wasm change; stop publishing the viewer app to npm

### DIFF
--- a/.changeset/layer-wall-watertight-section.md
+++ b/.changeset/layer-wall-watertight-section.md
@@ -1,4 +1,5 @@
 ---
+"@ifc-lite/wasm": patch
 "@ifc-lite/drawing-2d": patch
 "@ifc-lite/renderer": patch
 ---

--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -2,6 +2,7 @@
   "name": "@ifc-lite/viewer",
   "version": "1.32.0",
   "description": "IFC-Lite viewer application",
+  "private": true,
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Problem

Two issues with the release of [#1311](https://github.com/LTplus-AG/ifc-lite/pull/1311), surfaced from #1327 (`chore: version packages`):

**1. The wasm runtime change would not ship.** #1311 changed `rust/geometry/src/router/layers.rs` + `rust/processing/src/element.rs`, which compile into **`@ifc-lite/wasm`** (it publishes `pkg/ifc-lite_bg.wasm`). But the source changeset listed only `@ifc-lite/drawing-2d` and `@ifc-lite/renderer`. The release runs `changeset publish`, which only publishes packages whose local version is not already on npm, so `@ifc-lite/wasm` would keep its old version and the old mesh generation would stay on npm. The hollow-wall fixes in the release notes would not actually reach consumers.

**2. `@ifc-lite/viewer` is being published to npm by accident.** `apps/viewer` is a Vite **app** deployed via Vercel (root `vercel.json`), not a library: no `main`/`module`/`exports`/`bin`/`types`/`files`, so `npm i @ifc-lite/viewer` gives nothing importable. It was never marked `private` (its sibling app `@ifc-lite/viewer-embed` is), so every release dumps a **~29 MB / 1115-file** tarball of the whole app tree (full `src/`, built `dist/` including the entire Cesium asset bundle, configs, even a stray `.turbo/turbo-build.log`) to npm, with zero consumers. The real consumable viewer library is **`@ifc-lite/viewer-core`** (`packages/viewer`).

## Fix

- Add **`@ifc-lite/wasm`** (`patch`) to the changeset so the new wasm republishes. `@ifc-lite/geometry` (the bridge) needs no bump: it builds with `tsc` and imports `@ifc-lite/wasm` as an external runtime dep (`workspace:^`) rather than bundling it, so consumers pick up the republished wasm transitively at install time.
- Mark **`@ifc-lite/viewer`** `private: true` (matching `viewer-embed`). The #1311 overlay change in `apps/viewer` ships via Vercel deployment from `main`, not via npm, so the viewer does not belong in the changeset. Existing npm 1.x versions are left in place (can be `npm deprecate`d separately if desired).

## Verification

Ran `changeset version` against this branch:

| package | main | bumped | npm now |
|---|---|---|---|
| `@ifc-lite/wasm` | 2.13.0 | **2.13.1** | 2.13.0 |
| `@ifc-lite/drawing-2d` | 1.18.3 | 1.18.4 | 1.18.3 |
| `@ifc-lite/renderer` | 1.29.1 | 1.29.2 | 1.29.1 |
| `@ifc-lite/viewer` | 1.32.0 | not versioned/published ✓ (private) | 1.32.0 |
| `@ifc-lite/geometry` | 2.10.0 | unchanged ✓ (externalizes wasm) | 2.10.0 |

All published bumps are clean single patches above current npm, so `changeset publish` will republish each. The release job's `pnpm build` rebuilds the wasm from #1311's rust source before publishing.

Once this lands on `main`, the changesets action regenerates #1327 to include `@ifc-lite/wasm` and exclude the viewer; that PR can then be merged to release. `verify-npm-publish.js` and `sync-versions.js` both skip private packages, so making the viewer private needs no other changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores / Maintenance**
  * Updated release metadata to treat the `@ifc-lite/wasm` update as a patch release.
  * Marked the viewer package as non-publishable to prevent it from being released externally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->