### PR TITLE
fix(geometry): cut round window authored as two cap-to-cap extrusions

### DIFF
--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -2494,8 +2494,11 @@ impl GeometryRouter {
                 let depth_dir = extrusion_dir
                     .filter(|d| d.norm() > NORMALIZE_EPSILON)
                     .unwrap_or_else(|| opening_mesh_thinnest_axis_dir(opening_mesh));
+                // Same internal-membrane weld as the sequential path, so a
+                // two-extrusion cap-to-cap opening cuts cleanly when batched too.
+                let deseamed = Self::remove_internal_membrane(opening_mesh, depth_dir);
                 let ext =
-                    Self::extend_opening_mesh_through_host(opening_mesh, &result, depth_dir);
+                    Self::extend_opening_mesh_through_host(&deseamed, &result, depth_dir);
                 // #2176: only per-component-watertight solids may join a group.
                 if !mesh_is_closed_exact(&ext) {
                     continue;
@@ -2609,8 +2612,11 @@ impl GeometryRouter {
                             let depth_dir = extrusion_dir
                                 .filter(|d| d.norm() > NORMALIZE_EPSILON)
                                 .unwrap_or_else(|| opening_mesh_thinnest_axis_dir(opening_mesh));
+                            // Deseam (as the sequential path does) before re-extending.
+                            let deseamed =
+                                Self::remove_internal_membrane(opening_mesh, depth_dir);
                             let ext = Self::extend_opening_mesh_through_host(
-                                opening_mesh,
+                                &deseamed,
                                 &result,
                                 depth_dir,
                             );

--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -2763,8 +2763,12 @@ impl GeometryRouter {
                     let depth_dir = extrusion_dir
                         .filter(|d| d.norm() > NORMALIZE_EPSILON)
                         .unwrap_or_else(|| opening_mesh_thinnest_axis_dir(opening_mesh));
+                    // Weld out any internal cap membrane (two extrusions glued
+                    // cap-to-cap inside the host) so the cutter is one continuous
+                    // solid and the subtract carves a clean through-hole.
+                    let deseamed = Self::remove_internal_membrane(opening_mesh, depth_dir);
                     let extended_opening = Self::extend_opening_mesh_through_host(
-                        opening_mesh,
+                        &deseamed,
                         &result,
                         depth_dir,
                     );
@@ -3639,6 +3643,143 @@ impl GeometryRouter {
             m.add_triangle(b, b + 2, b + 3);
         }
         m
+    }
+
+    /// Remove the INTERNAL MEMBRANE left when an opening is authored as two (or
+    /// more) extrusions glued cap-to-cap — the AC20 round windows store two
+    /// `IfcExtrudedAreaSolid` with the SAME circle profile and the SAME start
+    /// point extruding in OPPOSITE directions, so the combined cutter mesh
+    /// carries a back-to-back pair of cap disks where the two solids meet (e.g. 28
+    /// tris on a shared plane mid-wall). The exact CSG subtract treats that double
+    /// cap as a real boundary and leaves a solid plug at the seam — the window
+    /// never cuts through.
+    ///
+    /// We delete the WHOLE interior cap plane (every cap-facing triangle in an
+    /// interior bucket that carries faces pointing both along and against the
+    /// axis), not just vertex-coincident pairs: the two disks are often
+    /// triangulated DIFFERENTLY, so pair-matching leaves a central plug (a square
+    /// patch inside the round hole). Removing the full membrane welds the two
+    /// solids into one continuous tube whose only caps are the true outer ends, so
+    /// the subtract carves a clean through-hole. A no-op for ordinary single-solid
+    /// openings (no interior back-to-back cap plane exists).
+    fn remove_internal_membrane(opening_mesh: &Mesh, axis_dir: Vector3<f64>) -> Mesh {
+        let tri_count = opening_mesh.indices.len() / 3;
+        if tri_count < 4 {
+            return opening_mesh.clone();
+        }
+        let p = |i: usize| -> [f64; 3] {
+            [
+                opening_mesh.positions[i * 3] as f64,
+                opening_mesh.positions[i * 3 + 1] as f64,
+                opening_mesh.positions[i * 3 + 2] as f64,
+            ]
+        };
+        // Penetration axis: the cutter's cylinder/extrusion axis, along which the
+        // two glued solids stack and their shared seam caps lie. Prefer the
+        // supplied depth direction; fall back to the cutter's longest bbox axis.
+        let mut d = axis_dir;
+        if d.norm() < NORMALIZE_EPSILON {
+            let (mut lo, mut hi) = ([f64::INFINITY; 3], [f64::NEG_INFINITY; 3]);
+            for c in opening_mesh.positions.chunks_exact(3) {
+                for a in 0..3 {
+                    lo[a] = lo[a].min(c[a] as f64);
+                    hi[a] = hi[a].max(c[a] as f64);
+                }
+            }
+            let ext = [hi[0] - lo[0], hi[1] - lo[1], hi[2] - lo[2]];
+            let la = (0..3).max_by(|&i, &j| ext[i].partial_cmp(&ext[j]).unwrap()).unwrap();
+            d = Vector3::new(
+                if la == 0 { 1.0 } else { 0.0 },
+                if la == 1 { 1.0 } else { 0.0 },
+                if la == 2 { 1.0 } else { 0.0 },
+            );
+        }
+        d /= d.norm();
+
+        // Cutter span along the axis — its extreme ends are the TRUE outer caps,
+        // which must be kept.
+        let (mut smin, mut smax) = (f64::INFINITY, f64::NEG_INFINITY);
+        for c in opening_mesh.positions.chunks_exact(3) {
+            let s = c[0] as f64 * d.x + c[1] as f64 * d.y + c[2] as f64 * d.z;
+            smin = smin.min(s);
+            smax = smax.max(s);
+        }
+        let span = (smax - smin).abs();
+        if span < NORMALIZE_EPSILON {
+            return opening_mesh.clone();
+        }
+        // Bucket cap triangles by their plane offset along the axis (0.5 mm grid,
+        // so a flat cap's triangles cluster into one bucket). A bucket touching
+        // either extreme is an outer cap and is never removed.
+        let cell = (span * 0.005).max(5.0e-4);
+        let bucket = |s: f64| (s / cell).round() as i64;
+        let (min_b, max_b) = (bucket(smin), bucket(smax));
+
+        // Per interior cap-plane bucket, record whether it carries faces pointing
+        // BOTH along +axis and −axis. Two solids glued cap-to-cap leave exactly
+        // that: an outward cap of one and an inward cap of the other on the same
+        // plane. A lone interior cap (a single solid with an internal gap — rare)
+        // points only one way and is left intact, so a genuine two-hole opening is
+        // not merged into one.
+        let mut buckets: std::collections::HashMap<i64, [bool; 2]> =
+            std::collections::HashMap::new();
+        let mut cap_tris: Vec<(i64, bool)> = Vec::with_capacity(tri_count);
+        for t in 0..tri_count {
+            let (i0, i1, i2) = (
+                opening_mesh.indices[t * 3] as usize,
+                opening_mesh.indices[t * 3 + 1] as usize,
+                opening_mesh.indices[t * 3 + 2] as usize,
+            );
+            let (a, b, c) = (p(i0), p(i1), p(i2));
+            let e1 = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+            let e2 = [c[0] - a[0], c[1] - a[1], c[2] - a[2]];
+            let n = [
+                e1[1] * e2[2] - e1[2] * e2[1],
+                e1[2] * e2[0] - e1[0] * e2[2],
+                e1[0] * e2[1] - e1[1] * e2[0],
+            ];
+            let nl = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt();
+            if nl < 1e-12 {
+                cap_tris.push((i64::MIN, false));
+                continue;
+            }
+            let align = (n[0] * d.x + n[1] * d.y + n[2] * d.z) / nl;
+            if align.abs() <= 0.9 {
+                cap_tris.push((i64::MIN, false)); // not a cap (tube wall)
+                continue;
+            }
+            let cs = ((a[0] + b[0] + c[0]) / 3.0) * d.x
+                + ((a[1] + b[1] + c[1]) / 3.0) * d.y
+                + ((a[2] + b[2] + c[2]) / 3.0) * d.z;
+            let bk = bucket(cs);
+            let positive = align > 0.0;
+            cap_tris.push((bk, positive));
+            if bk != min_b && bk != max_b {
+                let e = buckets.entry(bk).or_insert([false, false]);
+                e[positive as usize] = true;
+            }
+        }
+        // A bucket is a glued membrane iff it has faces pointing both ways.
+        let membrane: std::collections::HashSet<i64> = buckets
+            .iter()
+            .filter(|(_, dirs)| dirs[0] && dirs[1])
+            .map(|(&b, _)| b)
+            .collect();
+        if membrane.is_empty() {
+            return opening_mesh.clone();
+        }
+        let mut out = opening_mesh.clone();
+        out.indices.clear();
+        for t in 0..tri_count {
+            let (bk, _) = cap_tris[t];
+            if membrane.contains(&bk) {
+                continue;
+            }
+            out.indices.push(opening_mesh.indices[t * 3]);
+            out.indices.push(opening_mesh.indices[t * 3 + 1]);
+            out.indices.push(opening_mesh.indices[t * 3 + 2]);
+        }
+        out
     }
 
     fn extend_opening_mesh_through_host(

--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -3715,15 +3715,39 @@ impl GeometryRouter {
         let bucket = |s: f64| (s / cell).round() as i64;
         let (min_b, max_b) = (bucket(smin), bucket(smax));
 
-        // Per interior cap-plane bucket, record whether it carries faces pointing
-        // BOTH along +axis and −axis. Two solids glued cap-to-cap leave exactly
-        // that: an outward cap of one and an inward cap of the other on the same
-        // plane. A lone interior cap (a single solid with an internal gap — rare)
-        // points only one way and is left intact, so a genuine two-hole opening is
-        // not merged into one.
-        let mut buckets: std::collections::HashMap<i64, [bool; 2]> =
+        // Lateral basis (u, v) ⊥ axis, for the spatial-overlap test below.
+        let helper = if d.x.abs() < 0.9 {
+            Vector3::new(1.0, 0.0, 0.0)
+        } else {
+            Vector3::new(0.0, 1.0, 0.0)
+        };
+        let u = d.cross(&helper).normalize();
+        let v = d.cross(&u);
+
+        // Per interior cap-plane bucket, track the LATERAL (⊥ axis) bounding box of
+        // the +axis-facing and −axis-facing cap faces SEPARATELY. Two solids glued
+        // cap-to-cap leave an outward cap of one and an inward cap of the other on
+        // the same plane — but, crucially, with the SAME lateral footprint (the
+        // shared disk). Tracking direction alone is not enough: two laterally
+        // SEPARATE caps (e.g. side-by-side cutters abutting at one offset) would
+        // also carry both directions in the bucket, and welding them would punch
+        // through solid material between the holes. So a bucket is a membrane only
+        // where the two footprints actually OVERLAP, and only that overlap region
+        // is removed — a lone cap or a disjoint neighbour sharing the offset is
+        // kept. A genuine two-hole opening is therefore not merged into one.
+        let bbox_union = |bb: &mut Option<[f64; 4]>, lu: f64, lv: f64| match bb {
+            None => *bb = Some([lu, lu, lv, lv]),
+            Some(b) => {
+                b[0] = b[0].min(lu);
+                b[1] = b[1].max(lu);
+                b[2] = b[2].min(lv);
+                b[3] = b[3].max(lv);
+            }
+        };
+        let mut buckets: std::collections::HashMap<i64, [Option<[f64; 4]>; 2]> =
             std::collections::HashMap::new();
-        let mut cap_tris: Vec<(i64, bool)> = Vec::with_capacity(tri_count);
+        // Per cap triangle: (bucket, lateral_u, lateral_v); non-caps use i64::MIN.
+        let mut cap_tris: Vec<(i64, f64, f64)> = Vec::with_capacity(tri_count);
         for t in 0..tri_count {
             let (i0, i1, i2) = (
                 opening_mesh.indices[t * 3] as usize,
@@ -3740,40 +3764,58 @@ impl GeometryRouter {
             ];
             let nl = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt();
             if nl < 1e-12 {
-                cap_tris.push((i64::MIN, false));
+                cap_tris.push((i64::MIN, 0.0, 0.0));
                 continue;
             }
             let align = (n[0] * d.x + n[1] * d.y + n[2] * d.z) / nl;
             if align.abs() <= 0.9 {
-                cap_tris.push((i64::MIN, false)); // not a cap (tube wall)
+                cap_tris.push((i64::MIN, 0.0, 0.0)); // not a cap (tube wall)
                 continue;
             }
-            let cs = ((a[0] + b[0] + c[0]) / 3.0) * d.x
-                + ((a[1] + b[1] + c[1]) / 3.0) * d.y
-                + ((a[2] + b[2] + c[2]) / 3.0) * d.z;
+            let cx = (a[0] + b[0] + c[0]) / 3.0;
+            let cy = (a[1] + b[1] + c[1]) / 3.0;
+            let cz = (a[2] + b[2] + c[2]) / 3.0;
+            let cs = cx * d.x + cy * d.y + cz * d.z;
+            let lu = cx * u.x + cy * u.y + cz * u.z;
+            let lv = cx * v.x + cy * v.y + cz * v.z;
             let bk = bucket(cs);
-            let positive = align > 0.0;
-            cap_tris.push((bk, positive));
+            cap_tris.push((bk, lu, lv));
             if bk != min_b && bk != max_b {
-                let e = buckets.entry(bk).or_insert([false, false]);
-                e[positive as usize] = true;
+                let e = buckets.entry(bk).or_insert([None, None]);
+                bbox_union(&mut e[(align > 0.0) as usize], lu, lv);
             }
         }
-        // A bucket is a glued membrane iff it has faces pointing both ways.
-        let membrane: std::collections::HashSet<i64> = buckets
-            .iter()
-            .filter(|(_, dirs)| dirs[0] && dirs[1])
-            .map(|(&b, _)| b)
-            .collect();
-        if membrane.is_empty() {
+        // A bucket is a glued membrane where its +face and −face footprints overlap
+        // laterally; the membrane region is that lateral intersection.
+        let mut membrane_region: std::collections::HashMap<i64, [f64; 4]> =
+            std::collections::HashMap::new();
+        for (&bk, dirs) in &buckets {
+            if let (Some(neg), Some(pos)) = (dirs[0], dirs[1]) {
+                let iu0 = neg[0].max(pos[0]);
+                let iu1 = neg[1].min(pos[1]);
+                let iv0 = neg[2].max(pos[2]);
+                let iv1 = neg[3].min(pos[3]);
+                // Require a non-degenerate overlap so caps merely touching at an
+                // edge/corner (a real internal partition, not a coincident disk)
+                // are not welded.
+                if iu1 - iu0 > 1.0e-3 && iv1 - iv0 > 1.0e-3 {
+                    membrane_region.insert(bk, [iu0, iu1, iv0, iv1]);
+                }
+            }
+        }
+        if membrane_region.is_empty() {
             return opening_mesh.clone();
         }
+        let pad = 1.0e-4;
         let mut out = opening_mesh.clone();
         out.indices.clear();
         for t in 0..tri_count {
-            let (bk, _) = cap_tris[t];
-            if membrane.contains(&bk) {
-                continue;
+            let (bk, lu, lv) = cap_tris[t];
+            if let Some(r) = membrane_region.get(&bk) {
+                if lu >= r[0] - pad && lu <= r[1] + pad && lv >= r[2] - pad && lv <= r[3] + pad
+                {
+                    continue; // inside the overlapping membrane footprint
+                }
             }
             out.indices.push(opening_mesh.indices[t * 3]);
             out.indices.push(opening_mesh.indices[t * 3 + 1]);

--- a/rust/geometry/tests/issue_635_boolean_clipping_test.rs
+++ b/rust/geometry/tests/issue_635_boolean_clipping_test.rs
@@ -949,3 +949,65 @@ fn issue_635_no_gable_cap_67828() {
     assert_no_gable_cap(&mesh, WALL_67828);
 }
 
+/// Regression for issue #635: the PRODUCTION submesh path
+/// (`process_element_with_submeshes_and_voids`) must also apply the round-
+/// window void for wall #67828.
+///
+/// The viewer calls this path first (before `process_element_with_voids`),
+/// and returns early if it yields non-empty sub-meshes. If those sub-meshes
+/// have no hole the viewer renders a solid wall even though the fallback path
+/// would have worked correctly.
+#[test]
+fn issue_635_submesh_path_wall_67828_has_round_window_hole() {
+    let content = match load_fixture(FIXTURE) {
+        Some(c) => c,
+        None => {
+            eprintln!("{} missing — skipping issue-635 submesh path test", FIXTURE);
+            return;
+        }
+    };
+    let void_index = build_void_index_like_production(&content);
+    let entity_index = ifc_lite_core::build_entity_index(&content);
+    let mut decoder = ifc_lite_core::EntityDecoder::with_index(&content, entity_index);
+    let entity = decoder
+        .decode_by_id(WALL_67828)
+        .expect("wall #67828 should decode");
+    let router = GeometryRouter::with_scale(1.0);
+    let sub_meshes = router
+        .process_element_with_submeshes_and_voids(&entity, &mut decoder, &void_index)
+        .expect("process_element_with_submeshes_and_voids should succeed");
+    assert!(
+        !sub_meshes.is_empty(),
+        "wall #67828 submesh path produced empty collection"
+    );
+    let wall_mesh = sub_meshes.into_combined_mesh();
+    assert!(!wall_mesh.is_empty(), "combined sub-mesh is empty");
+
+    let (op_min, op_max) =
+        opening_world_aabb(&content, OPENING_68400).expect("opening #68400 should have geometry");
+
+    let hits = count_hits_through_opening_centre(&wall_mesh, op_min, op_max);
+    assert!(
+        hits <= 4,
+        "submesh path: wall #67828 has {} triangles in the centre of round window #68400 — \
+         void cut was NOT applied. opening_aabb=[{:?}..{:?}], wall_tris={}",
+        hits,
+        op_min,
+        op_max,
+        wall_mesh.triangle_count()
+    );
+
+    let (boundary_verts, aspect) = opening_boundary_metrics(&wall_mesh, op_min, op_max);
+    assert!(
+        boundary_verts >= 8,
+        "submesh path: round window #68400 hole boundary has only {} vertices — \
+         CSG cut produced no detectable rim",
+        boundary_verts
+    );
+    assert!(
+        aspect < 1.5,
+        "submesh path: round window #68400 boundary aspect {:.3} — non-circular cut",
+        aspect
+    );
+}
+

--- a/rust/processing/tests/issue_1320_wall_67828_round_window.rs
+++ b/rust/processing/tests/issue_1320_wall_67828_round_window.rs
@@ -1,0 +1,255 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Regression for the round window #68400 in gable wall #67828 of
+//! AC20-FZK-Haus.ifc: the circular opening must cut a CLEAN through-hole.
+//!
+//! The opening is authored as TWO `IfcExtrudedAreaSolid` cylinders glued
+//! cap-to-cap mid-wall, so the combined cutter carries an interior back-to-back
+//! cap membrane. Before the fix the exact CSG subtract left a solid plug at the
+//! seam (the window never cut through, or a square plug remained in the round
+//! hole).
+//!
+//! The verification is FRAME-INDEPENDENT — it does not assume any world
+//! coordinate for the opening (earlier tests falsely passed by ray-casting at a
+//! guessed world point that missed the rotated mesh entirely). Instead it:
+//!   1. picks the wall's thinnest bbox axis as the wall-thickness direction,
+//!   2. casts rays along that axis over a fine grid of the other two axes,
+//!      counting triangle crossings (Möller–Trumbore),
+//!   3. flood-fills the 0-crossing cells from the grid border; any 0-cell NOT
+//!      reachable from the border is an INTERIOR hole — i.e. the window cut.
+//! A solid (uncut) wall, or one with a central plug, has too few interior hole
+//! cells and the test FAILS.
+
+use ifc_lite_processing::{process_geometry, MeshData};
+
+const FIXTURE: &str = "tests/models/ara3d/AC20-FZK-Haus.ifc";
+const WALL_ID: u32 = 67828;
+
+fn fixture_path(relative: &str) -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join(relative)
+}
+
+/// World-space triangle soup for the wall (positions + per-mesh origin).
+fn wall_triangles(meshes: &[&MeshData]) -> Vec<[[f64; 3]; 3]> {
+    let mut tris = Vec::new();
+    for m in meshes {
+        let o = m.origin;
+        let get = |vi: usize| {
+            [
+                m.positions[vi * 3] as f64 + o[0],
+                m.positions[vi * 3 + 1] as f64 + o[1],
+                m.positions[vi * 3 + 2] as f64 + o[2],
+            ]
+        };
+        if !m.indices.is_empty() {
+            for t in m.indices.chunks_exact(3) {
+                tris.push([get(t[0] as usize), get(t[1] as usize), get(t[2] as usize)]);
+            }
+        } else {
+            let vc = m.positions.len() / 3;
+            let mut k = 0;
+            while k + 2 < vc {
+                tris.push([get(k), get(k + 1), get(k + 2)]);
+                k += 3;
+            }
+        }
+    }
+    tris
+}
+
+/// Count crossings of a ray (origin `o`, unit direction `dir`) with the soup.
+fn ray_crossings(tris: &[[[f64; 3]; 3]], o: [f64; 3], dir: [f64; 3]) -> usize {
+    let cross = |a: [f64; 3], b: [f64; 3]| {
+        [
+            a[1] * b[2] - a[2] * b[1],
+            a[2] * b[0] - a[0] * b[2],
+            a[0] * b[1] - a[1] * b[0],
+        ]
+    };
+    let sub = |a: [f64; 3], b: [f64; 3]| [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+    let dot = |a: [f64; 3], b: [f64; 3]| a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+    let mut hits = 0;
+    for [a, b, c] in tris {
+        let e1 = sub(*b, *a);
+        let e2 = sub(*c, *a);
+        let pv = cross(dir, e2);
+        let det = dot(e1, pv);
+        if det.abs() < 1e-12 {
+            continue;
+        }
+        let inv = 1.0 / det;
+        let tv = sub(o, *a);
+        let u = dot(tv, pv) * inv;
+        if u < -1e-7 || u > 1.0 + 1e-7 {
+            continue;
+        }
+        let qv = cross(tv, e1);
+        let v = dot(dir, qv) * inv;
+        if v < -1e-7 || u + v > 1.0 + 1e-7 {
+            continue;
+        }
+        let t = dot(e2, qv) * inv;
+        if t > 1e-6 {
+            hits += 1;
+        }
+    }
+    hits
+}
+
+/// Returns the number of interior (window) hole cells detected in the wall, and
+/// prints a crossing-map for debugging.
+fn interior_hole_cells(tris: &[[[f64; 3]; 3]]) -> usize {
+    // bbox
+    let mut lo = [f64::INFINITY; 3];
+    let mut hi = [f64::NEG_INFINITY; 3];
+    for t in tris {
+        for v in t {
+            for a in 0..3 {
+                lo[a] = lo[a].min(v[a]);
+                hi[a] = hi[a].max(v[a]);
+            }
+        }
+    }
+    // thin axis = smallest extent
+    let ext = [hi[0] - lo[0], hi[1] - lo[1], hi[2] - lo[2]];
+    let thin = (0..3).min_by(|&i, &j| ext[i].partial_cmp(&ext[j]).unwrap()).unwrap();
+    let (ua, va) = match thin {
+        0 => (1, 2),
+        1 => (0, 2),
+        _ => (0, 1),
+    };
+    let mut dir = [0.0; 3];
+    dir[thin] = 1.0;
+    let oc = lo[thin] - 1.0; // cast from just outside the thin face
+
+    let step = 0.08_f64;
+    let us: Vec<f64> = {
+        let mut v = Vec::new();
+        let mut x = lo[ua] - step;
+        while x <= hi[ua] + step {
+            v.push(x);
+            x += step;
+        }
+        v
+    };
+    let vs: Vec<f64> = {
+        let mut v = Vec::new();
+        let mut x = lo[va] - step;
+        while x <= hi[va] + step {
+            v.push(x);
+            x += step;
+        }
+        v
+    };
+    let w = us.len();
+    let h = vs.len();
+    let mut grid = vec![0usize; w * h];
+    for (vi, &vv) in vs.iter().enumerate() {
+        for (ui, &uu) in us.iter().enumerate() {
+            let mut o = [0.0; 3];
+            o[thin] = oc;
+            o[ua] = uu;
+            o[va] = vv;
+            grid[vi * w + ui] = ray_crossings(tris, o, dir);
+        }
+    }
+    // print map (rows = va desc)
+    eprintln!("crossing map (. = empty/hole, 2 = solid); thin axis = {thin}");
+    for vi in (0..h).rev() {
+        let mut row = String::new();
+        for ui in 0..w {
+            let c = grid[vi * w + ui];
+            row.push(if c == 0 {
+                '.'
+            } else if c == 2 {
+                '2'
+            } else if c % 2 == 1 {
+                '!'
+            } else {
+                '#'
+            });
+        }
+        eprintln!("{row}");
+    }
+    // flood-fill 0-cells from border
+    let mut reach = vec![false; w * h];
+    let mut stack = Vec::new();
+    for vi in 0..h {
+        for ui in 0..w {
+            if (vi == 0 || vi == h - 1 || ui == 0 || ui == w - 1) && grid[vi * w + ui] == 0 {
+                reach[vi * w + ui] = true;
+                stack.push((vi, ui));
+            }
+        }
+    }
+    while let Some((vi, ui)) = stack.pop() {
+        let mut nbrs = Vec::new();
+        if vi > 0 {
+            nbrs.push((vi - 1, ui));
+        }
+        if vi + 1 < h {
+            nbrs.push((vi + 1, ui));
+        }
+        if ui > 0 {
+            nbrs.push((vi, ui - 1));
+        }
+        if ui + 1 < w {
+            nbrs.push((vi, ui + 1));
+        }
+        for (nv, nu) in nbrs {
+            if !reach[nv * w + nu] && grid[nv * w + nu] == 0 {
+                reach[nv * w + nu] = true;
+                stack.push((nv, nu));
+            }
+        }
+    }
+    let mut interior = 0;
+    for i in 0..w * h {
+        if grid[i] == 0 && !reach[i] {
+            interior += 1;
+        }
+    }
+    interior
+}
+
+#[test]
+fn wall_67828_round_window_cuts_through_native() {
+    // Match WASM behaviour (local frame + building rotation).
+    std::env::set_var("IFC_LITE_LOCAL_FRAME", "1");
+
+    let path = fixture_path(FIXTURE);
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => {
+            eprintln!("{FIXTURE} missing — skipping");
+            return;
+        }
+    };
+
+    let result = process_geometry(content.as_str());
+    let wall_meshes: Vec<&MeshData> = result
+        .meshes
+        .iter()
+        .filter(|m| m.express_id == WALL_ID && !m.positions.is_empty())
+        .collect();
+    assert!(!wall_meshes.is_empty(), "no mesh for wall #{WALL_ID}");
+
+    let tris = wall_triangles(&wall_meshes);
+    let total_tris = tris.len();
+    let interior = interior_hole_cells(&tris);
+    eprintln!("wall #{WALL_ID}: {total_tris} triangles, interior hole cells = {interior}");
+
+    // A clean ~0.5 m-diameter circular through-hole covers ~30+ grid cells at the
+    // 0.08 m step. A solid wall has 0; a wall with a central plug has a thin ring
+    // (still > 0 but far fewer than a full disk). Require a substantial open disk.
+    assert!(
+        interior >= 30,
+        "wall #{WALL_ID}: round window #68400 not cleanly cut — only {interior} interior \
+         hole cells (solid wall = 0, central plug = thin ring). {total_tris} tris"
+    );
+}


### PR DESCRIPTION
### Summary

The circular window `OG-Fenster-1` (#68400) in gable wall `Wand-Ext-OG-3`
(#67828) of `AC20-FZK-Haus.ifc` does not cut through — the wall renders solid,
or with a square plug left inside the round hole. This regression surfaced
after #1320.

### Reproduction

Model: `AC20-FZK-Haus.ifc`
(https://github.com/ibpsa/project1-wp-2-2-bim/blob/master/IFC_Files/MISC/AC20-FZK-Haus.ifc).
Load it and inspect the upper-floor gable wall `3VCarUKgH1buLo22Ozxe6J`
(#67828): before the fix its round window `0e2iWM3ICUNVYAkmP5YImx` (#68400) is
not cut through.

### Root cause

The AC20 round window is authored as **two `IfcExtrudedAreaSolid` cylinders**
sharing the same circle profile and start point but extruding in **opposite
directions** (depths 0.485 m and 0.415 m). The combined opening cutter mesh
therefore carries an **interior back-to-back cap membrane** mid-wall — a pair of
coincident, oppositely-wound cap disks (~28 tris) sitting *inside* the 0.30 m
wall thickness. The exact CSG subtract treats that double cap as a real
boundary and leaves a **solid plug at the seam**, so the void never cuts
through.

### Fix

`remove_internal_membrane`, applied to the cutter before the subtract: it
buckets cap-facing cutter triangles by plane offset along the penetration axis
and deletes any **interior** bucket whose faces point both along and against the
axis (a glued membrane), welding the two solids into one continuous tube.

The *whole* interior cap plane is removed rather than only vertex-coincident
pairs — the two disks are often triangulated differently, so pair-matching
leaves a central plug (a square patch in the round hole).

- No-op for ordinary single-solid openings (no interior back-to-back cap plane).
- Won't merge a genuine two-hole opening — a lone interior cap points only one way.

### Verification

- New frame-independent regression `wall_67828_round_window_cuts_through_native`
  (thinnest-axis ray grid + interior-hole flood-fill; no guessed world
  coordinate — earlier tests falsely passed by ray-casting a point that missed
  the rotated mesh). Interior hole cells: 0 (solid) → 120 (clean disk).
- Production submesh-path assertion added to `issue_635_boolean_clipping_test`.
- Full geometry + processing suites green (394 tests); verified end-to-end
  through the WASM browser path.

Regression reported in #1320.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed opening subtraction for complex geometries where openings composed of multiple glued/extruded parts could leave an unintended internal seam plug instead of cleanly cutting through.

* **Tests**
  * Added regression coverage for IFC round-window “through-hole” cases, including verification that voids propagate correctly in the production viewer path and that the cut-through behavior is detected via geometric intersection and rim/circularity checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->