### PR TITLE
feat(renderer): axis-aligned clip box (section/crop box) — #1329

### DIFF
--- a/.changeset/clip-box.md
+++ b/.changeset/clip-box.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/renderer": minor
+---
+
+Add `RenderOptions.clipBox` — an axis-aligned, world-space clip box (section / crop box). The fragment shader discards geometry outside the six box planes, so consumers can crop to a real geometry cut instead of bounding-box element isolation. Independent of `sectionPlane`; both can be active. (#1329)

--- a/packages/renderer/src/clip-box.test.ts
+++ b/packages/renderer/src/clip-box.test.ts
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Tests for the clip-box uniform packing. `packClipBox` is the single source of
+ * truth shared by `pipeline.updateUniforms` and the renderer's per-mesh /
+ * instanced template loops, so the min/max lanes, the zeroed padding + w lanes,
+ * and the returned flags bit must stay exactly as `main.wgsl` reads them.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { packClipBox, CLIPBOX_ENABLED_BIT } from './clip-box.js';
+import type { ClipBox } from './types.js';
+
+describe('packClipBox', () => {
+  const box: ClipBox = { min: [-1, -2, -3], max: [4, 5, 6], enabled: true };
+
+  it('writes min.xyz / max.xyz at the offset and returns the enabled bit', () => {
+    const out = new Float32Array(56);
+    const bit = packClipBox(box, out, 48);
+    assert.strictEqual(bit, CLIPBOX_ENABLED_BIT);
+    assert.deepStrictEqual([...out.slice(48, 51)], [-1, -2, -3]);
+    assert.deepStrictEqual([...out.slice(52, 55)], [4, 5, 6]);
+  });
+
+  it('zeroes the w padding lanes (51 and 55)', () => {
+    const out = new Float32Array(56).fill(9);
+    packClipBox(box, out, 48);
+    assert.strictEqual(out[51], 0);
+    assert.strictEqual(out[55], 0);
+  });
+
+  it('returns 0 and zeroes the region when disabled', () => {
+    const out = new Float32Array(56).fill(7);
+    const bit = packClipBox({ ...box, enabled: false }, out, 48);
+    assert.strictEqual(bit, 0);
+    for (let i = 48; i < 56; i++) assert.strictEqual(out[i], 0, `lane ${i}`);
+  });
+
+  it('returns 0 and zeroes the region when null/undefined', () => {
+    const out = new Float32Array(56).fill(7);
+    assert.strictEqual(packClipBox(null, out, 48), 0);
+    assert.strictEqual(packClipBox(undefined, out, 48), 0);
+    for (let i = 48; i < 56; i++) assert.strictEqual(out[i], 0, `lane ${i}`);
+  });
+
+  it('honours an arbitrary float offset', () => {
+    const out = new Float32Array(16);
+    packClipBox(box, out, 4);
+    assert.deepStrictEqual([...out.slice(4, 7)], [-1, -2, -3]);
+    assert.deepStrictEqual([...out.slice(8, 11)], [4, 5, 6]);
+    // lanes before the offset stay untouched
+    assert.deepStrictEqual([...out.slice(0, 4)], [0, 0, 0, 0]);
+  });
+});

--- a/packages/renderer/src/clip-box.ts
+++ b/packages/renderer/src/clip-box.ts
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Clip box (section / crop box) uniform packing. The box is an axis-aligned
+ * world-space AABB written into the shared per-draw uniform as two vec4 lanes
+ * (min.xyz + pad, max.xyz + pad); `main.wgsl` discards fragments outside it when
+ * the enabled flag bit is set. Kept as a tiny pure helper so the three write
+ * sites (pipeline.updateUniforms + the renderer's per-mesh and instanced
+ * template loops) stay in sync and the packing is unit-testable.
+ */
+import type { ClipBox } from './types.js';
+
+/** flags.y bit marking the clip box active. Must match `main.wgsl` (`& 4u`). */
+export const CLIPBOX_ENABLED_BIT = 4;
+
+/**
+ * Write `box` into `out` at float lanes [`minFloatOffset` .. +3] (min.xyz + pad)
+ * and [`minFloatOffset + 4` .. +3] (max.xyz + pad). Returns the flags.y bit to OR
+ * in: {@link CLIPBOX_ENABLED_BIT} when the box is active, else 0. A disabled or
+ * absent box zeroes the region so stale data from a previous draw can't clip.
+ */
+export function packClipBox(
+  box: ClipBox | null | undefined,
+  out: Float32Array,
+  minFloatOffset: number,
+): number {
+  const maxOff = minFloatOffset + 4;
+  if (box?.enabled) {
+    out[minFloatOffset] = box.min[0];
+    out[minFloatOffset + 1] = box.min[1];
+    out[minFloatOffset + 2] = box.min[2];
+    out[minFloatOffset + 3] = 0;
+    out[maxOff] = box.max[0];
+    out[maxOff + 1] = box.max[1];
+    out[maxOff + 2] = box.max[2];
+    out[maxOff + 3] = 0;
+    return CLIPBOX_ENABLED_BIT;
+  }
+  out[minFloatOffset] = 0;
+  out[minFloatOffset + 1] = 0;
+  out[minFloatOffset + 2] = 0;
+  out[minFloatOffset + 3] = 0;
+  out[maxOff] = 0;
+  out[maxOff + 1] = 0;
+  out[maxOff + 2] = 0;
+  out[maxOff + 3] = 0;
+  return 0;
+}

--- a/packages/renderer/src/constants.ts
+++ b/packages/renderer/src/constants.ts
@@ -85,9 +85,11 @@ export const CAMERA_CONSTANTS = {
 // ============================================================================
 
 export const PIPELINE_CONSTANTS = {
-  // Buffer layout (bytes) - must match WGSL shader expectations
+  // Buffer layout (bytes) - must match WGSL shader expectations.
+  // 56 floats: viewProj(16)+model(16)+baseColor(4)+metallicRoughness/pad(4)+
+  // sectionPlane(4)+flags(4)+clipBoxMin(4)+clipBoxMax(4) = 224 bytes.
   /** Total uniform buffer size */
-  UNIFORM_BUFFER_SIZE: 192,
+  UNIFORM_BUFFER_SIZE: 224,
   /** Byte offset for flags in uniform buffer */
   FLAGS_BYTE_OFFSET: 176,
 

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -2106,7 +2106,8 @@ export class Renderer {
                         tplFlags[0] = 0;
                         tplFlags[1] =
                             (sectionPlaneData?.enabled ? 1 : 0) |
-                            (options.sectionPlane?.flipped ? 2 : 0);
+                            (options.sectionPlane?.flipped ? 2 : 0) |
+                            tplClipBit;
                         tplFlags[2] = edgeEnabledU32;
                         tplFlags[3] = edgeIntensityMilliU32;
 
@@ -2162,7 +2163,8 @@ export class Renderer {
                     tplFlags[0] = 1; // isSelected
                     tplFlags[1] =
                         (sectionPlaneData?.enabled ? 1 : 0) |
-                        (options.sectionPlane?.flipped ? 2 : 0);
+                        (options.sectionPlane?.flipped ? 2 : 0) |
+                        tplClipBit;
                     tplFlags[2] = edgeEnabledU32;
                     tplFlags[3] = edgeIntensityMilliU32;
 

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -95,6 +95,7 @@ import type {
     SeparationLinesQuality,
 } from './types.js';
 import { SectionPlaneRenderer } from './section-plane.js';
+import { packClipBox } from './clip-box.js';
 import { Section2DOverlayRenderer, type CutPolygon2D, type DrawingLine2D } from './section-2d-overlay.js';
 import {
   SymbolicFillPipeline,
@@ -234,8 +235,9 @@ export class Renderer {
     private _loggedSectionBounds: boolean = false;
 
     // Pooled per-frame buffers to avoid GC pressure from per-batch Float32Array allocations
-    // A single 192-byte uniform buffer (48 floats) is reused for all batches/meshes within a frame
-    private readonly uniformScratch = new Float32Array(48);
+    // A single 224-byte uniform buffer (56 floats) is reused for all batches/meshes within a frame
+    // (48 floats viewProj…flags + 8 floats clipBoxMin/clipBoxMax)
+    private readonly uniformScratch = new Float32Array(56);
     private readonly uniformScratchU32 = new Uint32Array(this.uniformScratch.buffer, 176, 4);
 
     constructor(canvas: HTMLCanvasElement) {
@@ -1497,12 +1499,16 @@ export class Renderer {
                         meshBuf[40] = 0; meshBuf[41] = 0; meshBuf[42] = 0; meshBuf[43] = 0;
                     }
 
+                    // Clip box (offset 48-55: min.xyz + pad, max.xyz + pad) → enable bit
+                    const clipBit = packClipBox(options.clipBox, meshBuf, 48);
+
                     // Flags (offset 44-47 as u32)
-                    // flags.y packs: bit 0 = sectionEnabled, bit 1 = flipped
+                    // flags.y packs: bit 0 = sectionEnabled, bit 1 = flipped, bit 2 = clipBoxEnabled
                     meshFlags[0] = isSelected ? 1 : 0;
                     meshFlags[1] =
                         (sectionPlaneData?.enabled ? 1 : 0) |
-                        (options.sectionPlane?.flipped ? 2 : 0);
+                        (options.sectionPlane?.flipped ? 2 : 0) |
+                        clipBit;
                     meshFlags[2] = edgeEnabledU32;
                     meshFlags[3] = edgeIntensityMilliU32;
 
@@ -1780,16 +1786,19 @@ export class Renderer {
                 } else {
                     tpl[40] = 0; tpl[41] = 0; tpl[42] = 0; tpl[43] = 0;
                 }
+                // Clip box (offset 48-55: min.xyz + pad, max.xyz + pad) → enable bit
+                const tplClipBit = packClipBox(options.clipBox, tpl, 48);
                 // flags layout (main shader):
                 //   x = isSelected (0/1)
-                //   y = sectionEnabled bitfield:
-                //       bit 0 = enabled, bit 1 = flipped
+                //   y = section/clip bitfield:
+                //       bit 0 = sectionEnabled, bit 1 = flipped, bit 2 = clipBoxEnabled
                 //   z = edgeEnabled (0/1)
                 //   w = edgeIntensityMilli
                 tplFlags[0] = 0;
                 tplFlags[1] =
                     (sectionPlaneData?.enabled ? 1 : 0) |
-                    (options.sectionPlane?.flipped ? 2 : 0);
+                    (options.sectionPlane?.flipped ? 2 : 0) |
+                    tplClipBit;
                 tplFlags[2] = edgeEnabledU32;
                 tplFlags[3] = edgeIntensityMilliU32;
 

--- a/packages/renderer/src/pipeline.ts
+++ b/packages/renderer/src/pipeline.ts
@@ -559,7 +559,7 @@ export class RenderPipeline {
     }
 
     /**
-     * Write a raw 48-float (192-byte) uniform block into the SHARED uniform
+     * Write a raw 56-float (224-byte) uniform block into the SHARED uniform
      * buffer, whose bind group is `getBindGroup()`. Used by the GPU-instancing
      * pass, which reuses the frame's viewProj + section + flags from the
      * renderer's prebuilt template (model + baseColor are unused — vs_instanced

--- a/packages/renderer/src/pipeline.ts
+++ b/packages/renderer/src/pipeline.ts
@@ -9,6 +9,7 @@
 import { WebGPUDevice } from './device.js';
 import { mainShaderSource } from './shaders/main.wgsl.js';
 import { texturedShaderSource } from './shaders/textured.wgsl.js';
+import { packClipBox } from './clip-box.js';
 import {
     ENVIRONMENT_UNIFORM_SIZE,
     packEnvironmentUniforms,
@@ -103,12 +104,13 @@ export class RenderPipeline {
             this.multisampleTextureView = this.multisampleTexture.createView();
         }
 
-        // Create uniform buffer for camera matrices, PBR material, and section plane
+        // Create uniform buffer for camera matrices, PBR material, section plane + clip box
         // Layout: viewProj (64 bytes) + model (64 bytes) + baseColor (16 bytes) + metallicRoughness (8 bytes) +
-        //         sectionPlane (16 bytes: vec3 normal + float position) + flags (16 bytes: u32 isSelected + u32 sectionEnabled + padding) = 192 bytes
+        //         sectionPlane (16 bytes: vec3 normal + float distance) + flags (16 bytes) +
+        //         clipBoxMin (16 bytes) + clipBoxMax (16 bytes) = 224 bytes
         // WebGPU requires uniform buffers to be aligned to 16 bytes
         this.uniformBuffer = this.device.createBuffer({
-            size: 192, // 12 * 16 bytes = properly aligned
+            size: 224, // 14 * 16 bytes = properly aligned
             usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
         });
 
@@ -499,12 +501,13 @@ export class RenderPipeline {
         color?: [number, number, number, number],
         material?: { metallic?: number; roughness?: number },
         sectionPlane?: { normal: [number, number, number]; distance: number; enabled: boolean; flipped?: boolean },
-        isSelected?: boolean
+        isSelected?: boolean,
+        clipBox?: { min: [number, number, number]; max: [number, number, number]; enabled: boolean }
     ): void {
         // Create buffer with proper alignment:
-        // viewProj (16 floats) + model (16 floats) + baseColor (4 floats) + metallicRoughness (2 floats) + padding (2 floats)
-        // + sectionPlane (4 floats) + flags (4 u32) = 48 floats = 192 bytes
-        const buffer = new Float32Array(48);
+        // viewProj (16) + model (16) + baseColor (4) + metallicRoughness (2) + padding (2)
+        // + sectionPlane (4) + flags (4 u32) + clipBoxMin (4) + clipBoxMax (4) = 56 floats = 224 bytes
+        const buffer = new Float32Array(56);
         const flagBuffer = new Uint32Array(buffer.buffer, 176, 4); // flags at byte 176
 
         // viewProj: mat4x4<f32> at offset 0 (16 floats)
@@ -537,12 +540,17 @@ export class RenderPipeline {
             buffer[43] = sectionPlane.distance;
         }
 
+        // clipBoxMin / clipBoxMax: vec4<f32> at float offsets 48 / 52 (xyz + pad);
+        // returns the flags.y clip-enabled bit (or 0).
+        const clipBit = packClipBox(clipBox, buffer, 48);
+
         // flags: vec4<u32> at offset 44 (4 u32 - using flagBuffer view)
-        // flags.y packs: bit 0 = sectionEnabled, bit 1 = sectionFlipped.
+        // flags.y packs: bit 0 = sectionEnabled, bit 1 = sectionFlipped, bit 2 = clipBoxEnabled.
         flagBuffer[0] = isSelected ? 1 : 0;
         flagBuffer[1] =
             (sectionPlane?.enabled ? 1 : 0) |
-            (sectionPlane?.flipped ? 2 : 0);
+            (sectionPlane?.flipped ? 2 : 0) |
+            clipBit;
         flagBuffer[2] = 0;                             // reserved (edgeEnabled written by Renderer)
         flagBuffer[3] = 0;                             // reserved (edgeIntensity written by Renderer)
 
@@ -768,7 +776,7 @@ export class RenderPipeline {
     }
 
     getUniformBufferSize(): number {
-        return 192; // 48 floats * 4 bytes
+        return 224; // 56 floats * 4 bytes (incl. section plane + clip box)
     }
 
     private destroyed = false;

--- a/packages/renderer/src/shaders/main.wgsl.ts
+++ b/packages/renderer/src/shaders/main.wgsl.ts
@@ -15,7 +15,9 @@ export const mainShaderSource = `
           metallicRoughness: vec2<f32>, // x = metallic, y = roughness
           _padding1: vec2<f32>,
           sectionPlane: vec4<f32>,      // xyz = plane normal, w = plane distance
-          flags: vec4<u32>,             // x = isSelected, y = sectionEnabled, z = edgeEnabled, w = edgeIntensityMilli
+          flags: vec4<u32>,             // x = isSelected, y = section/clip bits, z = edgeEnabled, w = edgeIntensityMilli
+          clipBoxMin: vec4<f32>,        // xyz = clip-box min corner (world), w = pad
+          clipBoxMax: vec4<f32>,        // xyz = clip-box max corner (world), w = pad
         }
         @binding(0) @group(0) var<uniform> uniforms: Uniforms;
 
@@ -219,6 +221,14 @@ export const mainShaderSource = `
             let side = select(1.0, -1.0, flipped);
             let distToPlane = (dot(input.worldPos, planeNormal) - planeDistance) * side;
             if (distToPlane > 0.0) {
+              discard;
+            }
+          }
+          // Clip box (section / crop box): discard fragments OUTSIDE the AABB.
+          // flags.y bit 2 = clip-box enabled.
+          if ((uniforms.flags.y & 4u) != 0u) {
+            let p = input.worldPos;
+            if (any(p < uniforms.clipBoxMin.xyz) || any(p > uniforms.clipBoxMax.xyz)) {
               discard;
             }
           }

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -135,6 +135,23 @@ export interface SectionPlane {
   distance?: number;
 }
 
+/**
+ * Axis-aligned clip box (section / crop box): geometry is kept only where it
+ * lies INSIDE all six box planes; fragments outside the box are discarded by the
+ * shader (real geometry cut, unlike bounding-box element isolation). Coordinates
+ * are in the same world space the shader sees as `input.worldPos` — i.e. the
+ * viewer space the camera/section planes use. Independent of `sectionPlane`; both
+ * can be active at once.
+ */
+export interface ClipBox {
+  /** Box min corner [x, y, z] in world space. */
+  min: [number, number, number];
+  /** Box max corner [x, y, z] in world space. */
+  max: [number, number, number];
+  /** When false (or omitted), the box has no effect. */
+  enabled: boolean;
+}
+
 export type ContactShadingQuality = 'off' | 'low' | 'high';
 export type SeparationLinesQuality = 'off' | 'low' | 'high';
 
@@ -217,6 +234,9 @@ export interface RenderOptions {
   selectedModelIndex?: number;    // Model index for multi-model selection (must match mesh.modelIndex)
   // Section plane clipping
   sectionPlane?: SectionPlane;
+  // Section / crop box: clip geometry to an axis-aligned world-space box (all six
+  // sides). Independent of `sectionPlane`. Discarded fragments are also unpickable.
+  clipBox?: ClipBox;
   // Terrain clipping: discard fragments below this Y value in viewer space.
   // Used by Cesium overlay to prevent model from showing below terrain.
   terrainClipY?: number;

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -235,7 +235,8 @@ export interface RenderOptions {
   // Section plane clipping
   sectionPlane?: SectionPlane;
   // Section / crop box: clip geometry to an axis-aligned world-space box (all six
-  // sides). Independent of `sectionPlane`. Discarded fragments are also unpickable.
+  // sides). Independent of `sectionPlane`. Rendering only: the GPU picker does not
+  // clip on the box (same as `sectionPlane`), so consumers filter box picks themselves.
   clipBox?: ClipBox;
   // Terrain clipping: discard fragments below this Y value in viewer space.
   // Used by Cesium overlay to prevent model from showing below terrain.

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -3238,6 +3238,7 @@
     "BatchedMesh: interface",
     "Bounds3: interface",
     "Camera: class",
+    "ClipBox: interface",
     "ContactShadingQuality: type",
     "CutPolygon2D: interface",
     "DEFAULT_CAP_STYLE: const",


### PR DESCRIPTION
Closes #1329.

## What

Adds `RenderOptions.clipBox` — an axis-aligned, world-space clip box (section / crop box). The fragment shader discards anything outside the six box planes, so consumers can crop to a **real geometry cut** instead of bounding-box element isolation.

## How

- `types.ts` — `ClipBox { min, max, enabled }` + `RenderOptions.clipBox`.
- `shaders/main.wgsl.ts` — `Uniforms` gains `clipBoxMin` / `clipBoxMax` (two vec4 lanes); fragment discards when `worldPos` is outside the AABB. `flags.y` bit 2 = clip-box enabled.
- Per-draw uniform grew 192 → 224 bytes (`pipeline.ts` / `constants.ts`); the per-mesh, batched and instanced paths in `index.ts` all pack the box.
- Packing extracted to `clip-box.ts` (`packClipBox`) — one source of truth for all three write sites — with unit tests (`clip-box.test.ts`).

Independent of `sectionPlane`: both can be active at once.

## Scope (Phase 1)

- **Picking parity** is left to the consumer for now — the GPU picker doesn't clip on `sectionPlane` either, so downstream filters section/box picks itself. Happy to add a GPU-side box clip to the picker if preferred.
- **Caps** on the cut faces (hatched fills, like the section plane) are a deliberate follow-up (Phase 2).

## Verification

- `pnpm --filter @ifc-lite/renderer build` clean; **141 renderer tests pass** (incl. the new `packClipBox` tests).
- Wired into a downstream viewer (`RenderOptions.clipBox` from a selection's bounds + per-side margin) and confirmed the cut renders correctly on real models.

This PR is engine-only by design — the `apps/viewer` crop-box UI is intentionally left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clip-box clipping: Added `RenderOptions.clipBox` to define an axis-aligned, world-space bounding box for cropping. When enabled, fragments outside `min`/`max` are discarded (and unpickable) using a new clip-box stage that works independently of section-plane clipping.

* **Tests**
  * Added unit tests covering clip-box uniform packing, including correct min/max encoding (with padding cleared), proper handling of enabled/disabled/null inputs, and support for arbitrary float offsets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->