### PR TITLE
refactor(geometry): fold round-window deseam into extend_opening_mesh_through_host

### DIFF
--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -2494,11 +2494,8 @@ impl GeometryRouter {
                 let depth_dir = extrusion_dir
                     .filter(|d| d.norm() > NORMALIZE_EPSILON)
                     .unwrap_or_else(|| opening_mesh_thinnest_axis_dir(opening_mesh));
-                // Same internal-membrane weld as the sequential path, so a
-                // two-extrusion cap-to-cap opening cuts cleanly when batched too.
-                let deseamed = Self::remove_internal_membrane(opening_mesh, depth_dir);
                 let ext =
-                    Self::extend_opening_mesh_through_host(&deseamed, &result, depth_dir);
+                    Self::extend_opening_mesh_through_host(opening_mesh, &result, depth_dir);
                 // #2176: only per-component-watertight solids may join a group.
                 if !mesh_is_closed_exact(&ext) {
                     continue;
@@ -2612,11 +2609,8 @@ impl GeometryRouter {
                             let depth_dir = extrusion_dir
                                 .filter(|d| d.norm() > NORMALIZE_EPSILON)
                                 .unwrap_or_else(|| opening_mesh_thinnest_axis_dir(opening_mesh));
-                            // Deseam (as the sequential path does) before re-extending.
-                            let deseamed =
-                                Self::remove_internal_membrane(opening_mesh, depth_dir);
                             let ext = Self::extend_opening_mesh_through_host(
-                                &deseamed,
+                                opening_mesh,
                                 &result,
                                 depth_dir,
                             );
@@ -2769,12 +2763,8 @@ impl GeometryRouter {
                     let depth_dir = extrusion_dir
                         .filter(|d| d.norm() > NORMALIZE_EPSILON)
                         .unwrap_or_else(|| opening_mesh_thinnest_axis_dir(opening_mesh));
-                    // Weld out any internal cap membrane (two extrusions glued
-                    // cap-to-cap inside the host) so the cutter is one continuous
-                    // solid and the subtract carves a clean through-hole.
-                    let deseamed = Self::remove_internal_membrane(opening_mesh, depth_dir);
                     let extended_opening = Self::extend_opening_mesh_through_host(
-                        &deseamed,
+                        opening_mesh,
                         &result,
                         depth_dir,
                     );
@@ -3835,6 +3825,15 @@ impl GeometryRouter {
         host_mesh: &Mesh,
         dir: Vector3<f64>,
     ) -> Mesh {
+        // Weld out any internal cap membrane FIRST: an opening authored as two (or
+        // more) extrusions glued cap-to-cap inside the host (e.g. the AC20 round
+        // windows) leaves a back-to-back cap pair mid-cutter that the exact subtract
+        // treats as a real boundary, leaving a solid plug at the seam. Deseaming here,
+        // inside the one helper every void path funnels through, means no current or
+        // future call site can forget it. No-op for ordinary single-solid openings.
+        let deseamed = Self::remove_internal_membrane(opening_mesh, dir);
+        let opening_mesh = &deseamed;
+
         let len = dir.norm();
         if len < NORMALIZE_EPSILON {
             return opening_mesh.clone();


### PR DESCRIPTION
Follow-up to #1330.

## Why

`remove_internal_membrane` (the two-extrusion round-window deseam) was called explicitly before each of the **3** `extend_opening_mesh_through_host` call sites. A future void path, or the currently-dead `voids_2d` fast path if it were revived, could route an opening cutter through `extend` without deseaming and silently regress the round-window cut. The fix relied on reviewer vigilance at every call site.

## What

Move the deseam to the top of `extend_opening_mesh_through_host`, the single helper every void subtract funnels through, so no call site can forget it. The 3 call sites now pass the raw `opening_mesh`.

Pure refactor, behaviour identical: `extend` already received the same `depth_dir` the explicit deseam used, and it stays a no-op for ordinary single-solid openings.

`remove_internal_membrane` is now called from exactly one place; `extend_opening_mesh_through_host` still has exactly its 3 callers.

## Verification

- Round window still cuts clean: **120 interior hole cells**, unchanged from #1330.
- `issue_635` **11/11**, plus `wall_opening_cut_regression`, `voids_production` / `voids_submesh`, `issue_964` / `issue_1167` / `issue_1007` / `issue_960`, `door_window_calibration`, `engulfing_solid_void`, `opening_void_cut_local_frame` all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized cleanup of opening geometry before extension, making subtract/trim operations more consistent.
  * Improved consistency across batched and sequential workflows so openings are processed the same way in all paths.
  * Reduced the chance of missed preprocessing steps that could cause uneven results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->