### PR TITLE
fix: decode STEP string escapes in the rust parser

### DIFF
--- a/.changeset/rust-step-string-decode.md
+++ b/.changeset/rust-step-string-decode.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Decode STEP string escapes (`\X2\`, `\X4\`, `\X\`, `\S\`, `\P\`) in the Rust parser so entity names and property values surface as native UTF-8, matching the TypeScript `decodeIfcString`. Previously the Rust/CLI/server path left the escapes literal (a name stored as `Name\X2\00FC\X0\` came through unescaped), while the browser parser decoded them, so the two paths disagreed on non-ASCII text. The Rust and TS decoders are now pinned to one shared test-vector fixture so they cannot drift.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1482,6 +1482,7 @@ dependencies = [
  "memchr",
  "nom",
  "rustc-hash",
+ "serde_json",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",

--- a/packages/encoding/src/ifc-string.parity.test.ts
+++ b/packages/encoding/src/ifc-string.parity.test.ts
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { decodeIfcString } from './ifc-string.js';
+
+// The Rust step_encoding decoder and this TS decoder are pinned to ONE shared
+// vector file so the two cannot drift. The fixture lives in the core crate;
+// skip gracefully if this package is tested outside the monorepo layout.
+const fixturePath = fileURLToPath(
+  new URL('../../../rust/core/tests/fixtures/ifc_string_vectors.json', import.meta.url),
+);
+
+interface Vector {
+  name: string;
+  encoded: string;
+  decoded: string;
+}
+
+describe.skipIf(!existsSync(fixturePath))('decodeIfcString shared parity vectors', () => {
+  const cases = (JSON.parse(readFileSync(fixturePath, 'utf8')) as { cases: Vector[] }).cases;
+
+  it('fixture has cases', () => {
+    expect(cases.length).toBeGreaterThan(0);
+  });
+
+  for (const c of cases) {
+    it(`matches the Rust decoder: ${c.name}`, () => {
+      expect(decodeIfcString(c.encoded)).toBe(c.decoded);
+    });
+  }
+});

--- a/rust/core/Cargo.toml
+++ b/rust/core/Cargo.toml
@@ -44,6 +44,8 @@ thiserror = "2.0"
 [dev-dependencies]
 ifc-lite-geometry = { path = "../geometry" }
 tokio = { version = "1", features = ["macros", "rt"] }
+# Test-only: parse the shared decode parity fixture.
+serde_json = "1.0"
 
 [lints]
 workspace = true

--- a/rust/core/src/lib.rs
+++ b/rust/core/src/lib.rs
@@ -72,6 +72,7 @@ pub mod model_bounds;
 pub mod parser;
 pub mod schema_gen;
 pub(crate) mod schema_helpers;
+pub mod step_encoding;
 pub mod streaming;
 pub mod units;
 
@@ -91,6 +92,7 @@ pub use model_bounds::{scan_model_bounds, scan_placement_bounds, ModelBounds};
 pub use parser::{parse_entity, EntityScanner, Token};
 pub use schema_gen::{AttributeValue, DecodedEntity, GeometryCategory, IfcSchema, ProfileCategory};
 pub use schema_helpers::{has_geometry_by_name, is_simple_geometry_type};
+pub use step_encoding::{decode_ifc_string, encode_ifc_string};
 pub use streaming::{parse_stream, ParseEvent, StreamConfig};
 pub use units::{
     extract_length_unit_scale, extract_plane_angle_to_radians, get_si_prefix_multiplier,

--- a/rust/core/src/schema_gen.rs
+++ b/rust/core/src/schema_gen.rs
@@ -57,7 +57,13 @@ impl AttributeValue {
     pub fn from_token(token: &Token) -> Self {
         match token {
             Token::EntityRef(id) => AttributeValue::EntityRef(*id),
-            Token::String(s) => AttributeValue::String(String::from_utf8_lossy(s).into_owned()),
+            Token::String(s) => {
+                // Decode STEP escapes (\X2\, \X4\, \X\, \S\, \P\) so every
+                // consumer of a string attribute sees native UTF-8, matching
+                // the TS decodeIfcString. No-escape strings stay zero-cost.
+                let raw = String::from_utf8_lossy(s);
+                AttributeValue::String(crate::step_encoding::decode_ifc_string(&raw).into_owned())
+            }
             Token::Integer(i) => AttributeValue::Integer(*i),
             Token::Float(f) => AttributeValue::Float(*f),
             Token::Enum(e) => AttributeValue::Enum(String::from_utf8_lossy(e).into_owned()),

--- a/rust/core/src/step_encoding.rs
+++ b/rust/core/src/step_encoding.rs
@@ -1,0 +1,216 @@
+//! STEP string escape decoding/encoding (ISO 10303-21 / IFC).
+//!
+//! IFC string attribute values encode non-ASCII characters with backslash
+//! escape sequences. This module decodes them to native UTF-8 so the Rust
+//! crates, CLI, and server surface the same text the browser parser does via
+//! `decodeIfcString` in `@ifc-lite/encoding`. The two decoders are pinned to a
+//! shared test-vector fixture (`tests/fixtures/ifc_string_vectors.json`).
+//!
+//! Supported escapes:
+//! - `\X2\HHHH..\X0\` UTF-16 code units, 4 hex digits each (surrogate pairs ok)
+//! - `\X4\HHHHHHHH..\X0\` Unicode scalar values, 8 hex digits each
+//! - `\X\HH` single ISO-8859-1 byte
+//! - `\S\C` extended ASCII: code point of `C` plus 128
+//! - `\PC\` code-page directive, consumed and dropped
+//!
+//! Unknown or malformed escapes are passed through unchanged.
+
+use std::borrow::Cow;
+
+/// Decode IFC STEP string escapes to UTF-8.
+///
+/// Returns the input borrowed and untouched when it contains no backslash, so
+/// the common case (plain names, GUIDs, enums) is allocation-free.
+pub fn decode_ifc_string(s: &str) -> Cow<'_, str> {
+    if !s.as_bytes().contains(&b'\\') {
+        return Cow::Borrowed(s);
+    }
+
+    let bytes = s.as_bytes();
+    let n = bytes.len();
+    let mut out = String::with_capacity(n);
+    let mut i = 0;
+
+    while i < n {
+        if bytes[i] != b'\\' {
+            // Copy one whole UTF-8 character; `i` is always on a char boundary
+            // because every escape marker is ASCII.
+            let ch = s[i..].chars().next().unwrap();
+            out.push(ch);
+            i += ch.len_utf8();
+            continue;
+        }
+
+        // `\PC\` code-page directive: consume four bytes and drop.
+        if i + 3 < n && bytes[i + 1] == b'P' && bytes[i + 3] == b'\\' {
+            i += 4;
+            continue;
+        }
+
+        // `\S\C`: byte value is the code point of `C` plus 128.
+        if i + 3 < n && bytes[i + 1] == b'S' && bytes[i + 2] == b'\\' {
+            let code = bytes[i + 3] as u32 + 128;
+            out.push(char::from_u32(code).unwrap_or('\u{FFFD}'));
+            i += 4;
+            continue;
+        }
+
+        // `\X\HH`: a single ISO-8859-1 byte.
+        if i + 4 < n && bytes[i + 1] == b'X' && bytes[i + 2] == b'\\' {
+            if let (Some(hi), Some(lo)) = (hex_val(bytes[i + 3]), hex_val(bytes[i + 4])) {
+                let code = ((hi << 4) | lo) as u32;
+                out.push(char::from_u32(code).unwrap_or('\u{FFFD}'));
+                i += 5;
+                continue;
+            }
+        }
+
+        // `\X2\HHHH..\X0\`: UTF-16 code units (decoded as a unit, so surrogate
+        // pairs spanning two groups combine correctly).
+        if starts_with(bytes, i, b"\\X2\\") {
+            if let Some(end) = find(bytes, i + 4, b"\\X0\\") {
+                let hex = &s[i + 4..end];
+                if !hex.is_empty()
+                    && hex.len().is_multiple_of(4)
+                    && hex.bytes().all(|c| c.is_ascii_hexdigit())
+                {
+                    let units: Vec<u16> = (0..hex.len())
+                        .step_by(4)
+                        .map(|j| u16::from_str_radix(&hex[j..j + 4], 16).unwrap())
+                        .collect();
+                    out.push_str(&String::from_utf16_lossy(&units));
+                    i = end + 4;
+                    continue;
+                }
+            }
+        }
+
+        // `\X4\HHHHHHHH..\X0\`: Unicode scalar values.
+        if starts_with(bytes, i, b"\\X4\\") {
+            if let Some(end) = find(bytes, i + 4, b"\\X0\\") {
+                let hex = &s[i + 4..end];
+                if !hex.is_empty()
+                    && hex.len().is_multiple_of(8)
+                    && hex.bytes().all(|c| c.is_ascii_hexdigit())
+                {
+                    for j in (0..hex.len()).step_by(8) {
+                        let v = u32::from_str_radix(&hex[j..j + 8], 16).unwrap();
+                        out.push(char::from_u32(v).unwrap_or('\u{FFFD}'));
+                    }
+                    i = end + 4;
+                    continue;
+                }
+            }
+        }
+
+        // Unknown escape: keep the backslash and advance one byte.
+        out.push('\\');
+        i += 1;
+    }
+
+    Cow::Owned(out)
+}
+
+/// Encode a UTF-8 string back to IFC STEP escapes. Inverse of
+/// [`decode_ifc_string`] for the canonical (non-overlong) forms; kept for STEP
+/// writers and round-trip tests.
+///
+/// Printable ASCII is preserved; everything else (and backslash) is escaped as
+/// `\X\HH`, `\X2\HHHH\X0\`, or `\X4\HHHHHHHH\X0\` by code point.
+pub fn encode_ifc_string(s: &str) -> Cow<'_, str> {
+    if s.bytes().all(|b| (0x20..=0x7E).contains(&b) && b != b'\\') {
+        return Cow::Borrowed(s);
+    }
+
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        let cp = ch as u32;
+        if (0x20..=0x7E).contains(&cp) && ch != '\\' {
+            out.push(ch);
+        } else if cp <= 0xFF {
+            out.push_str(&format!("\\X\\{cp:02X}"));
+        } else if cp <= 0xFFFF {
+            out.push_str(&format!("\\X2\\{cp:04X}\\X0\\"));
+        } else {
+            out.push_str(&format!("\\X4\\{cp:08X}\\X0\\"));
+        }
+    }
+    Cow::Owned(out)
+}
+
+#[inline]
+fn hex_val(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+#[inline]
+fn starts_with(bytes: &[u8], at: usize, pat: &[u8]) -> bool {
+    bytes.len() >= at + pat.len() && &bytes[at..at + pat.len()] == pat
+}
+
+fn find(bytes: &[u8], from: usize, pat: &[u8]) -> Option<usize> {
+    if pat.is_empty() || from + pat.len() > bytes.len() {
+        return None;
+    }
+    bytes[from..]
+        .windows(pat.len())
+        .position(|w| w == pat)
+        .map(|p| from + p)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_backslash_is_borrowed_and_unchanged() {
+        assert!(matches!(decode_ifc_string("Hello World"), Cow::Borrowed(_)));
+        // A typical base64 IFC GUID contains no backslash.
+        assert_eq!(decode_ifc_string("3Bvg7$qHb0gP37$Qz2vN1k"), "3Bvg7$qHb0gP37$Qz2vN1k");
+    }
+
+    #[test]
+    fn decodes_x2_bmp() {
+        assert_eq!(decode_ifc_string(r"Br\X2\00FC\X0\cke"), "Br\u{FC}cke");
+    }
+
+    #[test]
+    fn decodes_x2_surrogate_pair() {
+        assert_eq!(decode_ifc_string(r"\X2\D83DDE00\X0\"), "\u{1F600}");
+    }
+
+    #[test]
+    fn decodes_x4_astral() {
+        assert_eq!(decode_ifc_string(r"\X4\0001F600\X0\"), "\u{1F600}");
+    }
+
+    #[test]
+    fn decodes_x_and_s() {
+        assert_eq!(decode_ifc_string(r"\X\E9"), "\u{E9}");
+        assert_eq!(decode_ifc_string(r"\S\a"), "\u{E1}");
+    }
+
+    #[test]
+    fn drops_code_page_directive() {
+        assert_eq!(decode_ifc_string(r"\PA\Hello"), "Hello");
+    }
+
+    #[test]
+    fn keeps_unknown_escape() {
+        assert_eq!(decode_ifc_string(r"a\Qb"), r"a\Qb");
+        // Malformed (no terminator) is passed through, not panicked on.
+        assert_eq!(decode_ifc_string(r"\X2\00FC"), r"\X2\00FC");
+    }
+
+    #[test]
+    fn round_trips_through_encode() {
+        for s in ["plain", "Br\u{FC}cke", "\u{1F600}", "a\u{E9}b"] {
+            assert_eq!(decode_ifc_string(&encode_ifc_string(s)), s);
+        }
+    }
+}

--- a/rust/core/tests/fixtures/ifc_string_vectors.json
+++ b/rust/core/tests/fixtures/ifc_string_vectors.json
@@ -1,0 +1,60 @@
+{
+  "_comment": "Shared decode test vectors for the Rust step_encoding and TS ifc-string decoders. Expected values use JSON unicode escapes so this file stays pure ASCII. Both decoders must agree on every case.",
+  "cases": [
+    {
+      "name": "plain_ascii",
+      "encoded": "Hello World",
+      "decoded": "Hello World"
+    },
+    {
+      "name": "guid_no_escape",
+      "encoded": "3Bvg7$qHb0gP37$Qz2vN1k",
+      "decoded": "3Bvg7$qHb0gP37$Qz2vN1k"
+    },
+    {
+      "name": "x2_bmp",
+      "encoded": "Br\\X2\\00FC\\X0\\cke",
+      "decoded": "Br\u00fccke"
+    },
+    {
+      "name": "x2_multi_unit",
+      "encoded": "\\X2\\00E400F6\\X0\\",
+      "decoded": "\u00e4\u00f6"
+    },
+    {
+      "name": "x2_surrogate_pair",
+      "encoded": "\\X2\\D83DDE00\\X0\\",
+      "decoded": "\ud83d\ude00"
+    },
+    {
+      "name": "x4_astral",
+      "encoded": "\\X4\\0001F600\\X0\\",
+      "decoded": "\ud83d\ude00"
+    },
+    {
+      "name": "x_single_byte_iso8859",
+      "encoded": "\\X\\E9",
+      "decoded": "\u00e9"
+    },
+    {
+      "name": "s_extended_ascii",
+      "encoded": "\\S\\a",
+      "decoded": "\u00e1"
+    },
+    {
+      "name": "p_directive_dropped",
+      "encoded": "\\PA\\Hello",
+      "decoded": "Hello"
+    },
+    {
+      "name": "unknown_escape_kept",
+      "encoded": "a\\Qb",
+      "decoded": "a\\Qb"
+    },
+    {
+      "name": "malformed_x2_no_terminator",
+      "encoded": "\\X2\\00FC",
+      "decoded": "\\X2\\00FC"
+    }
+  ]
+}

--- a/rust/core/tests/ifc_string_parity.rs
+++ b/rust/core/tests/ifc_string_parity.rs
@@ -1,0 +1,36 @@
+//! Pins the Rust STEP string decoder to the shared cross-language test vectors
+//! in `tests/fixtures/ifc_string_vectors.json`. The TypeScript decoder in
+//! `@ifc-lite/encoding` is held to the same fixture, so the two cannot drift.
+
+use ifc_lite_core::{decode_ifc_string, parse_entity, AttributeValue};
+
+/// The from_token funnel must apply the decoder, so a parsed string attribute
+/// surfaces as native UTF-8 (not a literal escape) to every consumer.
+#[test]
+fn parsed_string_attribute_is_decoded() {
+    let line = b"#1=IFCWALL('Br\\X2\\00FC\\X0\\cke',$,$);";
+    let (_id, _ty, tokens) = parse_entity(line).expect("entity parses");
+    match AttributeValue::from_token(&tokens[0]) {
+        AttributeValue::String(s) => assert_eq!(s, "Br\u{FC}cke"),
+        other => panic!("expected decoded String, got {other:?}"),
+    }
+}
+
+#[test]
+fn rust_decoder_matches_shared_vectors() {
+    let raw = include_str!("fixtures/ifc_string_vectors.json");
+    let doc: serde_json::Value = serde_json::from_str(raw).expect("fixture is valid JSON");
+    let cases = doc["cases"].as_array().expect("cases is an array");
+    assert!(!cases.is_empty(), "fixture has at least one case");
+
+    for case in cases {
+        let name = case["name"].as_str().unwrap_or("<unnamed>");
+        let encoded = case["encoded"].as_str().expect("encoded is a string");
+        let expected = case["decoded"].as_str().expect("decoded is a string");
+        assert_eq!(
+            decode_ifc_string(encoded),
+            expected,
+            "case `{name}`: decode({encoded:?})"
+        );
+    }
+}

--- a/rust/processing/src/processor.rs
+++ b/rust/processing/src/processor.rs
@@ -649,7 +649,10 @@ fn parse_step_string(token: &[u8]) -> Option<String> {
     if trimmed.len() < 2 || trimmed[0] != b'\'' || trimmed[trimmed.len() - 1] != b'\'' {
         return None;
     }
-    Some(String::from_utf8_lossy(&trimmed[1..trimmed.len() - 1]).replace("''", "'"))
+    let unescaped = String::from_utf8_lossy(&trimmed[1..trimmed.len() - 1]).replace("''", "'");
+    // Decode STEP unicode escapes so quick-metadata names match the from_token
+    // path and the TS parser (e.g. a name stored as Br\X2\00FC\X0\cke).
+    Some(ifc_lite_core::decode_ifc_string(&unescaped).into_owned())
 }
 
 fn parse_step_ref(token: &[u8]) -> Option<u32> {


### PR DESCRIPTION
## Problem

Entity names and property values that carry STEP unicode escapes (`\X2\HHHH\X0\`, `\X4\...`, `\X\HH`, `\S\C`, `\PC\`) came through the **Rust** parser (and therefore the CLI and server) literally, while the **TypeScript** parser (`@ifc-lite/encoding`) decoded them. The two paths disagreed on any non-ASCII text (accented names, non-Latin scripts), so a name stored as `Name\X2\00FC\X0\` showed up decoded in the browser but raw via the Rust crates.

## Fix

- New `ifc_lite_core::decode_ifc_string` / `encode_ifc_string` in `rust/core/src/step_encoding.rs`, a faithful port of the TS `decodeIfcString` semantics (UTF-16 `\X2\` with surrogate-pair handling, scalar `\X4\`, ISO-8859-1 `\X\`, extended-ASCII `\S\`, code-page `\P\` directives dropped, unknown escapes passed through).
- Routed both Rust string funnels through it:
  - `AttributeValue::from_token` (`schema_gen.rs`) covers every parsed string attribute.
  - `parse_step_string` (`processing`) covers the quick-metadata name path.
- **Zero-cost** for the common case: strings with no backslash are returned borrowed, unchanged (GUIDs, enums, plain ASCII names).

## No-drift guarantee

Both decoders are pinned to **one shared fixture** (`rust/core/tests/fixtures/ifc_string_vectors.json`, pure ASCII via `\u` escapes):
- Rust: `rust/core/tests/ifc_string_parity.rs`
- TS: `packages/encoding/src/ifc-string.parity.test.ts`

## Verification

- `cargo test -p ifc-lite-core`: decoder unit tests, the shared-vector parity test, and an end-to-end test that a parsed `IFCWALL` name surfaces decoded all pass.
- TS decoder run against the same fixture: all 11 vectors pass.
- STEP export (`rust/export/src/step.rs`) is unaffected: it rewrites raw source bytes and never reads the decoded `AttributeValue::String`, so escaped output is preserved.