### PR TITLE
docs: add error-handling and integration contract guide

### DIFF
--- a/docs/guide/error-handling.md
+++ b/docs/guide/error-handling.md
@@ -1,0 +1,104 @@
+# Error Handling and Integration Contract
+
+This page is the behavioral contract for integrating ifc-lite into another
+system: what you get when things fail, how to manage memory across the WASM
+boundary, what is guaranteed to be reproducible, and what stability to expect
+across versions. It complements the per-feature guides, which cover the happy
+path.
+
+## Parse and geometry errors
+
+The Rust crates return typed `Result`s (a `thiserror` `Error` enum with variants
+such as `ParseError`, `InvalidEntityRef`, `InvalidIfcType`). Failures propagate
+as `Err`, not panics.
+
+The STEP parser degrades safely on malformed input. It rejects a bad record with
+an `Err`, skips unparseable bytes and continues scanning to the next valid
+entity, and never panics, hangs, or overflows the stack on hostile bytes. This
+is covered by malformed-input regression tests and a coverage-guided fuzz target
+(`rust/core/fuzz/`); see the testing guide for how to run the fuzzer.
+
+At the WASM boundary, a hard failure surfaces as a thrown JavaScript error. Wrap
+calls that ingest untrusted files in `try/catch`.
+
+## The WASM cache is fail-fast (long-lived workers and servers)
+
+`IfcAPI` keeps per-load caches (entity index, parts-to-skip, material-layer
+index) behind mutexes that **fail fast**: if an earlier call panicked while
+holding a lock, the lock is poisoned and the next call panics rather than
+operating on inconsistent cache state. In a long-lived worker or a multi-tenant
+server, one malformed file can therefore leave that specific `IfcAPI` instance
+unusable.
+
+The recovery contract is simple: **on any thrown error, discard that `IfcAPI`
+instance and create a fresh one.** Do not keep using an instance that has thrown.
+
+```ts
+let api = new IfcAPI();
+try {
+  const result = api.processGeometryBatch(/* ... */);
+  // ... use result ...
+} catch (err) {
+  // The instance may be poisoned; do not reuse it.
+  api.free();
+  api = new IfcAPI();
+  throw err; // or handle and continue with the fresh instance
+}
+```
+
+## Memory management (WASM)
+
+Memory is managed manually across the WASM boundary. Every handle, mesh,
+collection, and the `IfcAPI` itself implements `free()` and `[Symbol.dispose]()`.
+Call `free()` (or use a `using` declaration) to release Rust-side memory,
+**including on error paths**, since a thrown call can still leave allocated
+objects.
+
+```ts
+function withMeshes(collection: MeshCollection) {
+  try {
+    for (let i = 0; i < collection.length; i++) {
+      const mesh = collection.get(i);
+      try {
+        upload(mesh);
+      } finally {
+        mesh.free();
+      }
+    }
+  } finally {
+    collection.free();
+  }
+}
+```
+
+Most consumers should not manage this by hand: use
+[`@ifc-lite/geometry`](geometry.md)'s `GeometryProcessor`, which wraps the
+pre-pass and job-batch flow and frees handles for you.
+
+## Determinism scope
+
+For a critical system that checksums or compares geometry, know exactly what is
+reproducible:
+
+- **The exact-arithmetic predicate / CSG kernel is byte-identical across
+  `x86_64`, `aarch64`, and `wasm32`.** Predicate signs are integer parity over
+  FMA-free IEEE-754 arithmetic (the kernel uses no fused multiply-add), pinned by
+  a cross-platform sign manifest. A scheduled workflow re-runs the predicate
+  battery and a mesh-stat parity check on arm64 against committed x86_64
+  snapshots, so a platform-dependent regression fails the build.
+- **Everything else is run-deterministic, not cross-platform-guaranteed.**
+  Tessellation density, styling and colour-map iteration order, and rounding in
+  non-exact paths can differ between architectures. If you store a geometry
+  checksum as a baseline, compute it on the same architecture you will compare
+  against.
+
+## Versioning and stability
+
+Packages (`@ifc-lite/*`) and the Rust crates are versioned with
+[changesets](https://github.com/changesets/changesets); a breaking change bumps
+the major version. Pin a version for reproducible builds.
+
+One caveat for integrators: the mesh and exported-data formats are **not yet
+semver-guaranteed to be byte-stable across minor versions**. If you persist
+serialized geometry or exports, re-validate them when you upgrade, rather than
+assuming the bytes are identical.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,6 +130,7 @@ nav:
     - 2D Drawings: guide/drawing-2d.md
     - Property Editing: guide/mutations.md
     - Performance: guide/performance.md
+    - Error Handling & Integration: guide/error-handling.md
   - Customization:
     - Extensions: guide/extensions.md
     - Authoring Extensions: guide/extension-authoring.md


### PR DESCRIPTION
Adds `docs/guide/error-handling.md` (linked under User Guide), the behavioral contract an integrator needs but can't derive from the per-feature guides:

- **Errors**: typed `Result`s from the Rust crates; the parser degrades safely on malformed input (Err per bad record, skips garbage, never panics) and surfaces thrown errors at the WASM boundary.
- **WASM cache fail-fast**: the `IfcAPI` caches fail fast on a poisoned mutex, so the recovery contract is "discard the instance and recreate on any thrown error." Includes the try/catch + recreate pattern.
- **Memory**: manual `free()` / `[Symbol.dispose]` discipline including on error paths, with the try/finally and `using` patterns, and a pointer to `GeometryProcessor` for consumers who don't want to manage it.
- **Determinism scope**: the exact predicate/CSG kernel is byte-identical across x86_64 / aarch64 / wasm (FMA-free, manifest-pinned, CI-verified); the rest is run-deterministic only. Checksum on the same arch.
- **Versioning**: changesets; mesh/output formats not yet semver-byte-stable across minors.

Grounded in the actual source (the mutex fail-fast comment, the wasm README memory contract, the cross-platform sign manifest). Docs only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new guide covering error handling, integration expectations, memory cleanup, and cross-platform determinism.
  * Clarified how to handle parser failures and recover from cache-related errors safely.
  * Documented versioning and stability guidance, including reproducibility notes and current format stability limits.
  * Updated the documentation navigation to surface the new guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->