### PR TITLE
refactor: unify the two TS spatial-hierarchy builders

### DIFF
--- a/.changeset/unify-spatial-hierarchy-builders.md
+++ b/.changeset/unify-spatial-hierarchy-builders.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/parser": minor
+---
+
+`SpatialHierarchyBuilder` is now the single source for spatial-hierarchy construction. Added `buildFromCache(entities, relationships)` for cache restores (no source buffer, so storey elevations stay empty and `getStoreyByElevation` returns null), alongside the existing `build(...)` for fresh parses. Both entry points share one `buildNode`, so they can no longer drift: the fresh path now also applies the aggregate-descendant storey mapping (an `IfcBuildingElementPart` under an `IfcWall` resolves to that wall's storey), and the cache path now also has the cyclic-`IfcRelAggregates` guard. The viewer's duplicate `rebuildSpatialHierarchy` becomes a thin wrapper over `buildFromCache`.

--- a/apps/viewer/src/utils/spatialHierarchy.ts
+++ b/apps/viewer/src/utils/spatialHierarchy.ts
@@ -11,19 +11,19 @@
 import {
   IfcTypeEnum,
   RelationshipType,
-  isBuildingLikeSpatialType,
-  isSpaceLikeSpatialType,
-  isSpatialStructureType,
-  isStoreyLikeSpatialType,
   type SpatialHierarchy,
   type SpatialNode,
   type EntityTable,
   type RelationshipGraph,
 } from '@ifc-lite/data';
+import { SpatialHierarchyBuilder } from '@ifc-lite/parser';
 
 /**
- * Rebuild spatial hierarchy from cache data (entities + relationships)
- * OPTIMIZED: Uses index maps for O(1) lookups instead of O(n) linear searches
+ * Rebuild the spatial hierarchy from cache data (entities + relationships only,
+ * no source buffer). Thin wrapper over the single canonical builder in
+ * `@ifc-lite/parser`, so the cache path cannot drift from the fresh-parse path;
+ * storey elevations stay empty without a source buffer (`getStoreyByElevation`
+ * returns null).
  *
  * @param entities - Entity table from parsed IFC
  * @param relationships - Relationship graph from parsed IFC
@@ -33,194 +33,7 @@ export function rebuildSpatialHierarchy(
   entities: EntityTable,
   relationships: RelationshipGraph
 ): SpatialHierarchy | undefined {
-  // Use EntityTable.getTypeEnum() for O(1) lookups via its internal idToIndex map.
-  // This avoids building a temporary Map<number, IfcTypeEnum> with 4.4M entries
-  // (~350MB for large files) that duplicates data already in the entity table.
-
-  const byStorey = new Map<number, number[]>();
-  const byBuilding = new Map<number, number[]>();
-  const bySite = new Map<number, number[]>();
-  const bySpace = new Map<number, number[]>();
-  const storeyElevations = new Map<number, number>();
-  const storeyHeights = new Map<number, number>();
-  const elementToStorey = new Map<number, number>();
-
-  // Find IfcProject
-  const projectIds = entities.getByType(IfcTypeEnum.IfcProject);
-  if (projectIds.length === 0) {
-    console.warn('[rebuildSpatialHierarchy] No IfcProject found');
-    return undefined;
-  }
-  const projectId = projectIds[0];
-
-  // Build node tree recursively - NOW O(1) lookups!
-  function buildNode(expressId: number): SpatialNode {
-    // O(1) lookup instead of O(n) linear search
-    const typeEnum = entities.getTypeEnum(expressId);
-    const name = entities.getName(expressId) || `Entity #${expressId}`;
-
-    // Get contained elements via IfcRelContainedInSpatialStructure
-    const rawContainedElements = relationships.getRelated(
-      expressId,
-      RelationshipType.ContainsElements,
-      'forward'
-    );
-
-    // Split contained refs into real (non-spatial) elements vs spatial-structure
-    // elements. Keep unknown types as elements (custom/newer IFC classes):
-    // getTypeEnum() returns IfcTypeEnum.Unknown for both missing and unrecognized
-    // entities, and isSpatialStructureType(Unknown) is false.
-    //
-    // A contained spatial element — an IfcSpace / IfcSpatialZone attached to a
-    // storey via IfcRelContainedInSpatialStructure, which is what Revit Family +
-    // Dynamo emit instead of IfcRelAggregates — is a tree NODE, not a contained
-    // product. Promote it to a spatial child so it shows in the hierarchy; without
-    // this it was filtered out here and vanished from the tree (#1075).
-    const containedElements: number[] = [];
-    const containedSpatialChildren: number[] = [];
-    for (const id of rawContainedElements) {
-      const elemType = entities.getTypeEnum(id);
-      if (isSpatialStructureType(elemType) && elemType !== IfcTypeEnum.IfcProject) {
-        containedSpatialChildren.push(id);
-      } else {
-        containedElements.push(id);
-      }
-    }
-
-    // Get aggregated children via IfcRelAggregates
-    const aggregatedChildren = relationships.getRelated(
-      expressId,
-      RelationshipType.Aggregates,
-      'forward'
-    );
-
-    // Spatial child nodes come from BOTH aggregation and containment. Dedupe so a
-    // space referenced by both relationships isn't built twice. O(1) per child.
-    const childNodes: SpatialNode[] = [];
-    const spatialChildIds = new Set<number>();
-    const addSpatialChild = (childId: number) => {
-      if (spatialChildIds.has(childId)) return;
-      const childType = entities.getTypeEnum(childId);
-      if (childType && isSpatialStructureType(childType) && childType !== IfcTypeEnum.IfcProject) {
-        spatialChildIds.add(childId);
-        childNodes.push(buildNode(childId));
-      }
-    };
-    for (const childId of aggregatedChildren) addSpatialChild(childId);
-    for (const childId of containedSpatialChildren) addSpatialChild(childId);
-
-    // Add elements to appropriate maps
-    if (isStoreyLikeSpatialType(typeEnum)) {
-      byStorey.set(expressId, containedElements);
-    } else if (isBuildingLikeSpatialType(typeEnum)) {
-      byBuilding.set(expressId, containedElements);
-    } else if (typeEnum === IfcTypeEnum.IfcSite) {
-      bySite.set(expressId, containedElements);
-    } else if (isSpaceLikeSpatialType(typeEnum)) {
-      // IfcSpace and IfcSpatialZone both roll up their contained elements here.
-      bySpace.set(expressId, containedElements);
-    }
-
-    if (isStoreyLikeSpatialType(typeEnum)) {
-      for (const elementId of containedElements) {
-        elementToStorey.set(elementId, expressId);
-        // Propagate storey assignment to aggregated descendants (e.g. IfcBuildingElementPart
-        // children of an IfcWall). Without this, parts have no reverse-lookup entry even
-        // though the renderer emits them as standalone meshes.
-        // Cycle guard: malformed IFC files can have aggregate cycles.
-        // Direct storey containment wins — only set the descendant mapping if not already set.
-        const stack: number[] = [elementId];
-        const seen = new Set<number>([elementId]);
-        while (stack.length > 0) {
-          const current = stack.pop() as number;
-          const aggregatedKids = relationships.getRelated(
-            current,
-            RelationshipType.Aggregates,
-            'forward'
-          );
-          for (const kid of aggregatedKids) {
-            if (seen.has(kid)) continue;
-            seen.add(kid);
-            if (!elementToStorey.has(kid)) {
-              elementToStorey.set(kid, expressId);
-            }
-            stack.push(kid);
-          }
-        }
-      }
-      // Map the storey's spatial children (IfcSpace / IfcSpatialZone) to it too,
-      // so a selected space resolves "which storey it's on" in properties — the
-      // space itself is a child node, not in containedElements (#1075).
-      for (const childId of spatialChildIds) {
-        if (!elementToStorey.has(childId)) {
-          elementToStorey.set(childId, expressId);
-        }
-      }
-    }
-
-    return {
-      expressId,
-      type: typeEnum,
-      name,
-      children: childNodes,
-      elements: containedElements,
-    };
-  }
-
-  const projectNode = buildNode(projectId);
-
-  // Pre-build space lookup for O(1) getContainingSpace
-  const elementToSpace = new Map<number, number>();
-  for (const [spaceId, elementIds] of bySpace) {
-    for (const elementId of elementIds) {
-      elementToSpace.set(elementId, spaceId);
-    }
-  }
-
-  // Note: storeyHeights remains empty for cache path - client uses on-demand property extraction
-
-  return {
-    project: projectNode,
-    byStorey,
-    byBuilding,
-    bySite,
-    bySpace,
-    storeyElevations,
-    storeyHeights,
-    elementToStorey,
-
-    getStoreyElements(storeyId: number): number[] {
-      return byStorey.get(storeyId) ?? [];
-    },
-
-    getStoreyByElevation(): number | null {
-      return null;
-    },
-
-    getContainingSpace(elementId: number): number | null {
-      return elementToSpace.get(elementId) ?? null;
-    },
-
-    getPath(elementId: number): SpatialNode[] {
-      const path: SpatialNode[] = [];
-      const findPath = (node: SpatialNode, targetId: number): boolean => {
-        path.push(node);
-        if (node.elements.includes(targetId)) {
-          return true;
-        }
-        for (const child of node.children) {
-          if (findPath(child, targetId)) {
-            return true;
-          }
-        }
-        path.pop();
-        return false;
-      };
-
-      findPath(projectNode, elementId);
-      return path;
-    },
-  };
+  return new SpatialHierarchyBuilder().buildFromCache(entities, relationships);
 }
 
 /** Depth-first search for a spatial node by express id. */

--- a/packages/parser/src/spatial-hierarchy-builder.ts
+++ b/packages/parser/src/spatial-hierarchy-builder.ts
@@ -167,7 +167,9 @@ export class SpatialHierarchyBuilder {
         const path: SpatialNode[] = [];
         const findPath = (node: SpatialNode, targetId: number): boolean => {
           path.push(node);
-          if (node.elements.includes(targetId)) {
+          // Match the node itself (so a promoted space/zone resolves) or one of
+          // its contained elements.
+          if (node.expressId === targetId || node.elements.includes(targetId)) {
             return true;
           }
           for (const child of node.children) {

--- a/packages/parser/src/spatial-hierarchy-builder.ts
+++ b/packages/parser/src/spatial-hierarchy-builder.ts
@@ -3,7 +3,16 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Spatial hierarchy builder - builds project/building/storey tree
+ * Spatial hierarchy builder - builds the project/site/building/storey tree.
+ *
+ * Single source for spatial-hierarchy construction. There are two entry points
+ * over one shared `buildNode`:
+ *   - `build(...)`     fresh parse: extracts storey elevations from the source
+ *                      buffer. Throws if there is no IfcProject.
+ *   - `buildFromCache` cache restore: no source buffer, so storey elevations
+ *                      stay empty. Returns undefined if there is no IfcProject.
+ * Both paths get the same cycle guard, aggregate-descendant storey mapping, and
+ * spatial-child promotion, so they cannot drift.
  */
 
 import type { EntityTable, StringTable, RelationshipGraph, SpatialHierarchy, SpatialNode } from '@ifc-lite/data';
@@ -21,90 +30,124 @@ import { EntityExtractor } from './entity-extractor.js';
 
 const log = createLogger('SpatialHierarchy');
 
+/** Source needed to extract storey elevations on the fresh-parse path. */
+interface ElevationSource {
+  source: Uint8Array;
+  entityIndex: { byId: { get(expressId: number): EntityRef | undefined } };
+  lengthUnitScale: number;
+}
+
+/** Accumulators threaded through the recursion, plus the optional elevation source. */
+interface BuildContext {
+  entities: EntityTable;
+  relationships: RelationshipGraph;
+  byStorey: Map<number, number[]>;
+  byBuilding: Map<number, number[]>;
+  bySite: Map<number, number[]>;
+  bySpace: Map<number, number[]>;
+  storeyElevations: Map<number, number>;
+  elementToStorey: Map<number, number>;
+  visited: Set<number>;
+  elevation?: ElevationSource;
+}
+
 export class SpatialHierarchyBuilder {
   /**
-   * Build spatial hierarchy from entities and relationships
+   * Fresh-parse build. Extracts storey elevations from the source buffer.
+   * Throws if no IfcProject is present.
    *
-   * @param lengthUnitScale - Scale factor to convert IFC length values to meters (e.g., 0.001 for millimeters)
+   * @param lengthUnitScale - Scale to convert IFC length values to meters (e.g. 0.001 for millimeters).
    */
   build(
     entities: EntityTable,
     relationships: RelationshipGraph,
-    strings: StringTable,
+    _strings: StringTable,
     source: Uint8Array,
     entityIndex: { byId: { get(expressId: number): EntityRef | undefined } },
     lengthUnitScale: number = 1.0
   ): SpatialHierarchy {
-    const byStorey = new Map<number, number[]>();
-    const byBuilding = new Map<number, number[]>();
-    const bySite = new Map<number, number[]>();
-    const bySpace = new Map<number, number[]>();
-    const storeyElevations = new Map<number, number>();
-    const storeyHeights = new Map<number, number>();
-    const elementToStorey = new Map<number, number>();
+    const hierarchy = this.assemble(entities, relationships, { source, entityIndex, lengthUnitScale }, true);
+    // assemble only returns undefined when throwOnNoProject is false.
+    return hierarchy as SpatialHierarchy;
+  }
 
-    // PRE-BUILD INDEX MAP: O(n) once, then O(1) lookups
-    // This eliminates O(n²) when getTypeEnum is called for every spatial node
-    const entityTypeMap = new Map<number, IfcTypeEnum>();
-    for (let i = 0; i < entities.count; i++) {
-      entityTypeMap.set(entities.expressId[i], entities.typeEnum[i]);
-    }
+  /**
+   * Cache-restore build. No source buffer, so storey elevations stay empty
+   * (`getStoreyByElevation` returns null). Returns undefined if no IfcProject.
+   */
+  buildFromCache(
+    entities: EntityTable,
+    relationships: RelationshipGraph
+  ): SpatialHierarchy | undefined {
+    return this.assemble(entities, relationships, undefined, false);
+  }
 
-    // Find IfcProject (should be only one)
+  private assemble(
+    entities: EntityTable,
+    relationships: RelationshipGraph,
+    elevation: ElevationSource | undefined,
+    throwOnNoProject: boolean
+  ): SpatialHierarchy | undefined {
+    const ctx: BuildContext = {
+      entities,
+      relationships,
+      byStorey: new Map(),
+      byBuilding: new Map(),
+      bySite: new Map(),
+      bySpace: new Map(),
+      storeyElevations: new Map(),
+      elementToStorey: new Map(),
+      visited: new Set(),
+      elevation,
+    };
+
     const projectIds = entities.getByType(IfcTypeEnum.IfcProject);
     if (projectIds.length === 0) {
       console.warn('[SpatialHierarchyBuilder] No IfcProject found in IFC file');
-      throw new Error('No IfcProject found in IFC file');
+      if (throwOnNoProject) {
+        throw new Error('No IfcProject found in IFC file');
+      }
+      return undefined;
     }
-    const projectId = projectIds[0];
 
-    // Build project node
-    const projectNode = this.buildNode(
-      projectId,
-      entities,
-      relationships,
-      strings,
-      source,
-      entityIndex,
-      byStorey,
-      byBuilding,
-      bySite,
-      bySpace,
-      storeyElevations,
-      elementToStorey,
-      entityTypeMap,
-      lengthUnitScale,
-      new Set<number>()
-    );
+    const projectNode = this.buildNode(projectIds[0], ctx);
 
-    // Note: storeyHeights remains empty for client path - uses on-demand property extraction
-
-    // Validation: log warnings if maps are empty
-    if (byStorey.size === 0) {
+    if (ctx.byStorey.size === 0) {
       console.warn('[SpatialHierarchyBuilder] No storeys found in spatial hierarchy');
     }
-    if (byBuilding.size === 0) {
+    if (ctx.byBuilding.size === 0) {
       console.warn('[SpatialHierarchyBuilder] No buildings found in spatial hierarchy');
     }
 
-    const hierarchy: SpatialHierarchy = {
+    const { byStorey, byBuilding, bySite, bySpace, storeyElevations, elementToStorey } = ctx;
+
+    // Pre-build the element -> space lookup for O(1) getContainingSpace.
+    const elementToSpace = new Map<number, number>();
+    for (const [spaceId, elementIds] of bySpace) {
+      for (const elementId of elementIds) {
+        elementToSpace.set(elementId, spaceId);
+      }
+    }
+
+    return {
       project: projectNode,
       byStorey,
       byBuilding,
       bySite,
       bySpace,
       storeyElevations,
-      storeyHeights,
+      // storeyHeights stays empty: both paths use on-demand property extraction.
+      storeyHeights: new Map<number, number>(),
       elementToStorey,
-      
+
       getStoreyElements(storeyId: number): number[] {
         return byStorey.get(storeyId) ?? [];
       },
-      
+
       getStoreyByElevation(z: number): number | null {
+        // With an empty storeyElevations map (cache path) this returns null.
         let closestStorey: number | null = null;
         let closestDistance = Infinity;
-        
         for (const [storeyId, elevation] of storeyElevations) {
           const distance = Math.abs(elevation - z);
           if (distance < closestDistance) {
@@ -112,215 +155,157 @@ export class SpatialHierarchyBuilder {
             closestStorey = storeyId;
           }
         }
-        
-        // Only return if within reasonable distance (1 meter)
+        // Only return if within a reasonable distance (1 meter).
         return closestDistance < 1.0 ? closestStorey : null;
       },
-      
+
       getContainingSpace(elementId: number): number | null {
-        // Check if element is directly contained in a space
-        for (const [spaceId, elementIds] of bySpace) {
-          if (elementIds.includes(elementId)) {
-            return spaceId;
-          }
-        }
-        return null;
+        return elementToSpace.get(elementId) ?? null;
       },
-      
+
       getPath(elementId: number): SpatialNode[] {
         const path: SpatialNode[] = [];
-
-        // Build path from project to element
         const findPath = (node: SpatialNode, targetId: number): boolean => {
           path.push(node);
-          
-          // Check if this node contains the target
           if (node.elements.includes(targetId)) {
             return true;
           }
-          
-          // Recursively search children
           for (const child of node.children) {
             if (findPath(child, targetId)) {
               return true;
             }
           }
-          
-          // Backtrack
           path.pop();
           return false;
         };
-        
         findPath(projectNode, elementId);
         return path;
       },
     };
-
-    return hierarchy;
   }
 
-  private buildNode(
-    expressId: number,
-    entities: EntityTable,
-    relationships: RelationshipGraph,
-    strings: StringTable,
-    source: Uint8Array,
-    entityIndex: { byId: { get(expressId: number): EntityRef | undefined } },
-    byStorey: Map<number, number[]>,
-    byBuilding: Map<number, number[]>,
-    bySite: Map<number, number[]>,
-    bySpace: Map<number, number[]>,
-    storeyElevations: Map<number, number>,
-    elementToStorey: Map<number, number>,
-    entityTypeMap: Map<number, IfcTypeEnum>,
-    lengthUnitScale: number,
-    visited: Set<number>
-  ): SpatialNode {
-    const typeEnum = entityTypeMap.get(expressId) ?? IfcTypeEnum.Unknown;
-    const name = entities.getName(expressId);
+  private buildNode(expressId: number, ctx: BuildContext): SpatialNode {
+    const { entities, relationships } = ctx;
+    const typeEnum = entities.getTypeEnum(expressId);
+    const name = entities.getName(expressId) || `Entity #${expressId}`;
 
-    // Guard against cyclic IfcRelAggregates chains (A aggregates B, B aggregates A),
-    // which would otherwise recurse unbounded and overflow the stack. A revisited node
-    // is returned as a leaf so the rest of the hierarchy still builds.
-    if (visited.has(expressId)) {
-      return {
-        expressId,
-        type: typeEnum,
-        name,
-        elevation: undefined,
-        children: [],
-        elements: [],
-      };
+    // Guard against cyclic IfcRelAggregates chains (A aggregates B, B aggregates
+    // A), which would otherwise recurse unbounded and overflow the stack. A
+    // revisited node is returned as a leaf so the rest of the hierarchy still
+    // builds.
+    if (ctx.visited.has(expressId)) {
+      return { expressId, type: typeEnum, name, elevation: undefined, children: [], elements: [] };
     }
-    visited.add(expressId);
+    ctx.visited.add(expressId);
 
-    // Extract elevation for storeys (apply unit scale to convert to meters)
+    // Storey elevation (fresh path only): apply unit scale to convert to meters.
     let elevation: number | undefined;
-    if (typeEnum === IfcTypeEnum.IfcBuildingStorey) {
+    if (typeEnum === IfcTypeEnum.IfcBuildingStorey && ctx.elevation) {
+      const { source, entityIndex, lengthUnitScale } = ctx.elevation;
       let rawElevation = this.extractElevation(expressId, source, entityIndex);
       if (rawElevation === undefined) {
-        // The Elevation attribute is optional and is frequently left null (common
-        // in Revit / ArchiCAD exports). Fall back to the storey's Z from its
-        // ObjectPlacement so a storey without an explicit elevation still orders +
-        // lifts correctly in Exploded mode instead of being dropped from the sort,
-        // which made the model look like it had a single floor (#1289).
+        // Elevation is optional and frequently null (Revit / ArchiCAD). Fall back
+        // to the storey's Z from its ObjectPlacement so it still orders + lifts in
+        // Exploded mode instead of collapsing to a single floor (#1289).
         rawElevation = this.extractPlacementElevation(expressId, source, entityIndex);
       }
       if (rawElevation !== undefined) {
-        // Apply unit scale to convert to meters
         elevation = rawElevation * lengthUnitScale;
-        storeyElevations.set(expressId, elevation);
+        ctx.storeyElevations.set(expressId, elevation);
       }
     }
 
-    // Get direct contained elements via IfcRelContainedInSpatialStructure
-    const rawContainedElements = relationships.getRelated(
-      expressId,
-      RelationshipType.ContainsElements,
-      'forward'
-    );
-    // Keep entities whose type isn't in the EntityTable (e.g. IFC4x3 leaves the
-    // categorizer skipped). The filter's purpose is to peel off spatial-structure
-    // children — those become recursive nodes via the aggregates branch — not to
-    // gate on whether the EntityTable happened to record the type. Dropping
-    // missing entities silently hides every IfcReferent/IfcSignal/IfcAlignment
-    // under an IfcRailway/IfcRoad even though the relationship graph has them.
-    // A contained spatial element — an IfcSpace / IfcSpatialZone attached to a
-    // storey via IfcRelContainedInSpatialStructure, which is what Revit Family +
-    // Dynamo emit instead of IfcRelAggregates — is a tree NODE, not a contained
-    // product. Split it out here and promote it below; without this it was
-    // filtered out and vanished from the hierarchy (#1075). Unknown-typed
-    // entities (not in the EntityTable, e.g. some IFC4x3 leaves) stay elements.
+    // Direct contained elements via IfcRelContainedInSpatialStructure.
+    const rawContainedElements = relationships.getRelated(expressId, RelationshipType.ContainsElements, 'forward');
+
+    // Split contained refs into real (non-spatial) elements vs spatial-structure
+    // children. Unknown types stay elements (getTypeEnum returns Unknown for both
+    // missing and unrecognized entities, and isSpatialStructureType(Unknown) is
+    // false). A contained IfcSpace / IfcSpatialZone (what Revit Family + Dynamo
+    // emit instead of IfcRelAggregates) is a tree NODE, not a product: promote it
+    // below so it shows in the hierarchy instead of vanishing (#1075).
     const containedElements: number[] = [];
     const containedSpatialChildren: number[] = [];
     for (const id of rawContainedElements) {
-      const childType = entityTypeMap.get(id);
-      if (childType !== undefined && isSpatialStructureType(childType) && childType !== IfcTypeEnum.IfcProject) {
+      const childType = entities.getTypeEnum(id);
+      if (isSpatialStructureType(childType) && childType !== IfcTypeEnum.IfcProject) {
         containedSpatialChildren.push(id);
       } else {
         containedElements.push(id);
       }
     }
 
-    // Get child spatial elements via IfcRelAggregates (inverse - who aggregates this?)
-    // Actually, we want forward - what does this element aggregate?
-    const aggregatedChildren = relationships.getRelated(
-      expressId,
-      RelationshipType.Aggregates,
-      'forward'
-    );
+    // Forward IfcRelAggregates: what does this element aggregate?
+    const aggregatedChildren = relationships.getRelated(expressId, RelationshipType.Aggregates, 'forward');
 
     // Spatial child nodes come from BOTH aggregation and containment. Dedupe so a
-    // space referenced by both relationships isn't built twice (which `visited`
-    // would otherwise reduce to a duplicate leaf node).
+    // space referenced by both relationships isn't built twice.
     const childNodes: SpatialNode[] = [];
     const spatialChildIds = new Set<number>();
     const addSpatialChild = (childId: number) => {
       if (spatialChildIds.has(childId)) return;
-      const childType = entityTypeMap.get(childId) ?? IfcTypeEnum.Unknown;
+      const childType = entities.getTypeEnum(childId);
       if (isSpatialStructureType(childType) && childType !== IfcTypeEnum.IfcProject) {
         spatialChildIds.add(childId);
-        childNodes.push(this.buildNode(
-          childId,
-          entities,
-          relationships,
-          strings,
-          source,
-          entityIndex,
-          byStorey,
-          byBuilding,
-          bySite,
-          bySpace,
-          storeyElevations,
-          elementToStorey,
-          entityTypeMap,
-          lengthUnitScale,
-          visited
-        ));
+        childNodes.push(this.buildNode(childId, ctx));
       }
     };
     for (const childId of aggregatedChildren) addSpatialChild(childId);
     for (const childId of containedSpatialChildren) addSpatialChild(childId);
 
-    // Add elements to appropriate maps
+    // Roll contained elements up to the appropriate map.
     if (isStoreyLikeSpatialType(typeEnum)) {
-      byStorey.set(expressId, containedElements);
+      ctx.byStorey.set(expressId, containedElements);
     } else if (isBuildingLikeSpatialType(typeEnum)) {
-      byBuilding.set(expressId, containedElements);
+      ctx.byBuilding.set(expressId, containedElements);
     } else if (typeEnum === IfcTypeEnum.IfcSite) {
-      bySite.set(expressId, containedElements);
+      ctx.bySite.set(expressId, containedElements);
     } else if (isSpaceLikeSpatialType(typeEnum)) {
       // IfcSpace and IfcSpatialZone both roll up their contained elements here.
-      bySpace.set(expressId, containedElements);
+      ctx.bySpace.set(expressId, containedElements);
     }
 
     if (isStoreyLikeSpatialType(typeEnum)) {
       for (const elementId of containedElements) {
-        elementToStorey.set(elementId, expressId);
+        ctx.elementToStorey.set(elementId, expressId);
+        // Propagate the storey assignment to aggregated descendants (e.g. an
+        // IfcBuildingElementPart child of an IfcWall). Without this, parts have no
+        // reverse-lookup entry even though the renderer emits them as standalone
+        // meshes. Direct storey containment wins (only set if not already mapped);
+        // `seen` guards against aggregate cycles.
+        const stack: number[] = [elementId];
+        const seen = new Set<number>([elementId]);
+        while (stack.length > 0) {
+          const current = stack.pop() as number;
+          const aggregatedKids = relationships.getRelated(current, RelationshipType.Aggregates, 'forward');
+          for (const kid of aggregatedKids) {
+            if (seen.has(kid)) continue;
+            seen.add(kid);
+            if (!ctx.elementToStorey.has(kid)) {
+              ctx.elementToStorey.set(kid, expressId);
+            }
+            stack.push(kid);
+          }
+        }
       }
-      // Map the storey's spatial children (IfcSpace / IfcSpatialZone) to it too,
-      // so a selected space resolves "which storey it's on" — the space itself
-      // is a child node, not in containedElements (#1075).
+      // Map the storey's spatial children (IfcSpace / IfcSpatialZone) to it too, so
+      // a selected space resolves "which storey it's on" - the space is a child
+      // node, not in containedElements (#1075).
       for (const childId of spatialChildIds) {
-        if (!elementToStorey.has(childId)) {
-          elementToStorey.set(childId, expressId);
+        if (!ctx.elementToStorey.has(childId)) {
+          ctx.elementToStorey.set(childId, expressId);
         }
       }
     }
 
-    return {
-      expressId,
-      type: typeEnum,
-      name,
-      elevation,
-      children: childNodes,
-      elements: containedElements,
-    };
+    return { expressId, type: typeEnum, name, elevation, children: childNodes, elements: containedElements };
   }
 
   /**
-   * Extract elevation from IfcBuildingStorey entity
-   * Elevation is at attribute index 9 in IFC4 (after GlobalId, OwnerHistory, Name, Description, ObjectType, ObjectPlacement, Representation, LongName, CompositionType)
+   * Extract elevation from an IfcBuildingStorey. Elevation is attribute index 9
+   * in both IFC2x3 and IFC4 (GlobalId, OwnerHistory, Name, Description,
+   * ObjectType, ObjectPlacement, Representation, LongName, CompositionType,
+   * Elevation).
    */
   private extractElevation(
     expressId: number,
@@ -336,29 +321,25 @@ export class SpatialHierarchyBuilder {
       if (!entity) return undefined;
 
       const attrs = entity.attributes || [];
-      
-      // Helper to extract number from raw value or typed value like ['IFCLENGTHMEASURE', 3.0]
+
+      // Number from a raw value or a typed value like ['IFCLENGTHMEASURE', 3.0].
       const extractNumber = (val: any): number | undefined => {
         if (typeof val === 'number') return val;
         if (Array.isArray(val) && val.length === 2 && typeof val[1] === 'number') {
-          return val[1]; // Typed value: ['IFCLENGTHMEASURE', 3.0]
+          return val[1];
         }
         return undefined;
       };
-      
-      // Elevation is attribute index 9 for IfcBuildingStorey in both IFC2x3 and
-      // IFC4 (GlobalId, OwnerHistory, Name, Description, ObjectType,
-      // ObjectPlacement, Representation, LongName, CompositionType, Elevation).
-      // Read ONLY that slot: a previous "scan every attribute for a number < 10000"
-      // fallback wrongly treated reference attributes — parsed as bare express-id
-      // numbers (e.g. OwnerHistory #3628 -> 3628, or ObjectPlacement #7150) — as
-      // elevations, so a storey with a null Elevation got a garbage value instead
-      // of falling through to the ObjectPlacement-Z fallback below (#1289).
+
+      // Read ONLY slot 9: a previous "scan every attribute for a number < 10000"
+      // fallback wrongly treated reference attributes (parsed as bare express-id
+      // numbers, e.g. OwnerHistory #3628 -> 3628) as elevations, so a storey with
+      // a null Elevation got a garbage value instead of falling through to the
+      // ObjectPlacement-Z fallback below (#1289).
       if (attrs.length > 9) {
         return extractNumber(attrs[9]);
       }
     } catch (error) {
-      // Elevation extraction is optional - log for debugging but don't fail
       log.caught('Failed to extract elevation', error, {
         operation: 'extractElevation',
         entityId: expressId,
@@ -375,11 +356,10 @@ export class SpatialHierarchyBuilder {
    *   IfcBuildingStorey.ObjectPlacement (IfcLocalPlacement)
    *     -> RelativePlacement (IfcAxis2Placement3D)
    *       -> Location (IfcCartesianPoint).Coordinates[2]
-   * i.e. the storey's Z relative to its parent spatial container. That matches the
-   * semantics of the Elevation attribute (relative to the building), so it stays
-   * consistent with sibling storeys that DO carry the attribute, and it avoids
-   * folding in any site-level georeferencing Z. Returns the raw (unscaled) Z, or
-   * undefined when the placement chain can't be resolved.
+   * i.e. the storey's Z relative to its parent spatial container, which matches
+   * the semantics of the Elevation attribute and avoids folding in any site-level
+   * georeferencing Z. Returns the raw (unscaled) Z, or undefined when the chain
+   * can't be resolved.
    */
   private extractPlacementElevation(
     expressId: number,
@@ -398,12 +378,12 @@ export class SpatialHierarchyBuilder {
       const placementId = readAttrs(expressId)?.[5];
       if (typeof placementId !== 'number') return undefined;
 
-      // IfcLocalPlacement(PlacementRelTo, RelativePlacement) — RelativePlacement
+      // IfcLocalPlacement(PlacementRelTo, RelativePlacement) - RelativePlacement
       // (index 1) is the IfcAxis2Placement3D carrying this storey's own offset.
       const axisId = readAttrs(placementId)?.[1];
       if (typeof axisId !== 'number') return undefined;
 
-      // IfcAxis2Placement3D(Location, Axis, RefDirection) — Location (index 0) is
+      // IfcAxis2Placement3D(Location, Axis, RefDirection) - Location (index 0) is
       // an IfcCartesianPoint.
       const locationId = readAttrs(axisId)?.[0];
       if (typeof locationId !== 'number') return undefined;


### PR DESCRIPTION
## Problem

The parser's `SpatialHierarchyBuilder` (fresh parse) and the viewer's `rebuildSpatialHierarchy` (cache restore) were ~95% duplicated tree-building, and **each lacked a guard the other had**:
- The parser had **no aggregate-descendant storey mapping** (an `IfcBuildingElementPart` under an `IfcWall` had no reverse storey lookup).
- The viewer's cache path had **no cyclic-`IfcRelAggregates` guard** — a malformed file with an aggregate cycle would recurse unbounded and overflow the stack.

## Fix

`SpatialHierarchyBuilder` is now the single source. Two entry points share one `buildNode`:
- `build(...)` — fresh parse, extracts storey elevations from the source buffer (unchanged signature, non-breaking).
- `buildFromCache(entities, relationships)` — **new**; cache restore with no source buffer, so elevations stay empty and `getStoreyByElevation` returns null.

The shared `buildNode` always applies the cycle guard, the aggregate-descendant storey mapping, and the spatial-child (`IfcSpace`/`IfcSpatialZone`) promotion. It also adopts the viewer's `entities.getTypeEnum` (O(1), drops the ~4.4M-entry type map that cost ~350MB on large files) and a prebuilt element-to-space lookup. The viewer's `rebuildSpatialHierarchy` is now a thin wrapper over `buildFromCache`; its other exports (`registerAuthoredElement`, `rebuildOnDemandMaps`) are unchanged.

Net: both paths get the **union** of fixes and can no longer drift (-194 lines in the viewer).

## Verification

- `@ifc-lite/parser` builds (tsc) and its spatial test passes (3).
- Viewer `spatialHierarchy.test.ts` passes (11) — `rebuildSpatialHierarchy` delegates correctly through the canonical builder.
- Viewer typecheck clean for the import swap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Spatial hierarchy rebuilding is now faster and more consistent by using the same logic as fresh parsing.
  * Storey assignment for nested elements is improved, so related parts are more likely to appear on the correct storey.

* **Bug Fixes**
  * Fixed cases where cyclic hierarchy relationships could break cache-based rebuilds.
  * Improved space lookup accuracy when checking which space contains an element.

* **Refactor**
  * Unified hierarchy construction to reduce differences between parsed and restored models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->