### PR TITLE
feat(viewer): refresh button to reload the open model from disk (#1345)

### DIFF
--- a/apps/viewer/src/components/viewer/CommandPalette.tsx
+++ b/apps/viewer/src/components/viewer/CommandPalette.tsx
@@ -92,7 +92,7 @@ import { SCRIPT_TEMPLATES } from '@/lib/scripts/templates';
 import { exportGlbFromGeometry } from '@/lib/export/glb';
 import { exportCsvFromBytes } from '@/lib/export/csv';
 import { downloadFile } from '@/lib/export/download';
-import { getRecentFiles, formatFileSize, getCachedFile } from '@/lib/recent-files';
+import { getRecentFiles, formatFileSize, getCachedFile, getCachedFileNames } from '@/lib/recent-files';
 import type { RecentFileEntry } from '@/lib/recent-files';
 import { closeActiveAnalysisExtension } from '@/services/analysis-extensions';
 import { describeRunCommandError } from '@/services/extensions/runtime-errors';
@@ -120,6 +120,13 @@ interface Command {
   shortcut?: string;
   detail?: string;            // subtle secondary text (e.g. file size)
   action: () => void;
+  /**
+   * Run the action synchronously inside the click handler instead of deferring
+   * to the next animation frame. Required for actions that open a file dialog:
+   * Chrome only honours `input.click()` / `showOpenFilePicker()` while transient
+   * user activation is live, which a `requestAnimationFrame` hop would discard.
+   */
+  immediate?: boolean;
 }
 
 interface FlatItem {
@@ -246,6 +253,9 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const navigatedByKeyboard = useRef(false);
+  // Names currently in the blob cache, refreshed each open. Lets recent-file
+  // clicks decide hit/miss without an async gap that would void user activation.
+  const cachedNamesRef = useRef<Set<string>>(new Set());
 
   const { execute } = useSandbox();
   const extensionCommands = useSlotContributions<CommandContribution>('commandPalette');
@@ -255,6 +265,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
     if (open) {
       setRecentIds(getRecentIds());
       setRecentFiles(getRecentFiles());
+      void getCachedFileNames().then((names) => { cachedNamesRef.current = new Set(names); });
       setQuery('');
       requestAnimationFrame(() => inputRef.current?.focus());
     }
@@ -265,11 +276,15 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
     const c: Command[] = [];
 
     // ── File ──
+    // `immediate` so the open action runs inside the click gesture: opening a
+    // file dialog needs live user activation, which a rAF hop would discard.
+    // The actual picker is driven by MainToolbar's handleOpenClick (via the
+    // `ifc-lite:open-files` event) so palette opens capture a live handle too.
     c.push(
       { id: 'file:open', label: 'Open File', keywords: 'ifc ifcx glb load model browse', category: 'File', icon: FolderOpen,
+        immediate: true,
         action: () => {
-          const input = document.getElementById('file-input-open') as HTMLInputElement | null;
-          if (input) input.click();
+          window.dispatchEvent(new CustomEvent('ifc-lite:open-files'));
         } },
     );
     for (const rf of recentFiles) {
@@ -279,17 +294,20 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
         keywords: `recent open ${formatFileSize(rf.size)}`,
         category: 'File', icon: Clock,
         detail: formatFileSize(rf.size),
+        immediate: true,
         action: () => {
-          // Try loading from IndexedDB blob cache → dispatches to MainToolbar's loadFile
-          getCachedFile(rf).then(file => {
-            if (file) {
-              window.dispatchEvent(new CustomEvent('ifc-lite:load-file', { detail: file }));
-            } else {
-              // Cache miss — fall back to file picker
-              const input = document.getElementById('file-input-open') as HTMLInputElement | null;
-              if (input) input.click();
-            }
-          });
+          // Cached (decided synchronously from the pre-loaded key set): load the
+          // blob — dispatching a load event needs no user activation.
+          if (cachedNamesRef.current.has(fileName)) {
+            void getCachedFile(rf).then(file => {
+              if (file) window.dispatchEvent(new CustomEvent('ifc-lite:load-file', { detail: file }));
+              else window.dispatchEvent(new CustomEvent('ifc-lite:open-files'));
+            });
+          } else {
+            // Not cached — re-pick. Synchronous within the gesture so the dialog
+            // actually opens on Chrome.
+            window.dispatchEvent(new CustomEvent('ifc-lite:open-files'));
+          }
         },
       });
     }
@@ -634,7 +652,13 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
   const runCommand = useCallback((cmd: Command) => {
     onOpenChange(false);
     recordUsage(cmd.id);
-    requestAnimationFrame(() => cmd.action());
+    // File-dialog actions must run while user activation is still live; deferring
+    // them to a frame later voids it and Chrome silently ignores the dialog.
+    if (cmd.immediate) {
+      cmd.action();
+    } else {
+      requestAnimationFrame(() => cmd.action());
+    }
   }, [onOpenChange]);
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {

--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -51,6 +51,7 @@ import {
   Redo2,
   Boxes,
   Shapes,
+  RefreshCw,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
@@ -69,7 +70,7 @@ import {
   DropdownMenuSubContent,
 } from '@/components/ui/dropdown-menu';
 import { Progress } from '@/components/ui/progress';
-import { useViewerStore, isIfcxDataStore } from '@/store';
+import { useViewerStore, isIfcxDataStore, type FederatedModel } from '@/store';
 import { goHomeFromStore, resetVisibilityForHomeFromStore } from '@/store/homeView';
 import { executeBasketIsolate } from '@/store/basket/basketCommands';
 import { useIfc } from '@/hooks/useIfc';
@@ -85,6 +86,11 @@ import { DataConnector } from './DataConnector';
 import { ExportChangesButton } from './ExportChangesButton';
 import { SearchInline } from './SearchInline';
 import { recordRecentFiles, cacheFileBlobs } from '@/lib/recent-files';
+import {
+  supportsFileSystemAccess,
+  openIfcFilesWithHandles,
+  readFreshFile,
+} from '@/services/file-system-access';
 import { ThemeSwitch } from './ThemeSwitch';
 import { ExtensionToolbarSlot } from '@/components/extensions/ExtensionToolbarSlot';
 import { toast } from '@/components/ui/toast';
@@ -498,6 +504,64 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
     e.target.value = '';
   }, [loadFilesSequentially, addIfcxOverlays, ifcDataStore]);
 
+  // Open via the File System Access API when available (Chromium) so we capture
+  // a live FileSystemFileHandle for each file — that handle is what lets the
+  // Refresh button re-read the same file from disk later (issue #1345). Browsers
+  // without the API fall back to the hidden <input type="file">.
+  const handleOpenClick = useCallback(async () => {
+    if (!supportsFileSystemAccess()) {
+      fileInputRef.current?.click();
+      return;
+    }
+    const opened = await openIfcFilesWithHandles();
+    if (!opened) return; // cancelled, unavailable, or picker failed
+
+    const files = opened.map(o => o.file);
+    recordRecentFiles(files.map(f => ({ name: f.name, size: f.size })));
+    cacheFileBlobs(files);
+
+    if (opened.length === 1) {
+      // Single model: keep the handle so Refresh can re-read it from disk.
+      void loadFile(opened[0].file, { kind: 'primary' }, { sourceHandle: opened[0].handle });
+    } else {
+      // Multiple files mirror handleFileSelect's branching (no per-model handle).
+      const allIfcx = files.every(f => f.name.endsWith('.ifcx'));
+      resetViewerState();
+      clearAllModels();
+      if (allIfcx) {
+        loadFederatedIfcx(files);
+      } else {
+        loadFilesSequentially(files);
+      }
+    }
+  }, [loadFile, loadFilesSequentially, loadFederatedIfcx, resetViewerState, clearAllModels]);
+
+  // Refresh re-reads the same file from disk and re-parses it. It is only
+  // possible for a single model opened via the File System Access API (which
+  // gave us a live handle); drag-drop, <input type="file">, cache-restored, and
+  // federated loads have no handle, so the button is not offered for them.
+  const refreshableModel = useMemo<FederatedModel | null>(() => {
+    if (loading || models.size !== 1) return null;
+    const only = models.values().next().value as FederatedModel | undefined;
+    return only?.sourceHandle ? only : null;
+  }, [models, loading]);
+
+  const handleRefresh = useCallback(async () => {
+    const model = refreshableModel;
+    if (!model?.sourceHandle) return;
+    const fresh = await readFreshFile(model.sourceHandle);
+    if (!fresh) {
+      toast.error(
+        `Couldn't re-read "${model.name}". It may have been moved or deleted, or access was denied.`,
+      );
+      return;
+    }
+    recordRecentFiles([{ name: fresh.name, size: fresh.size }]);
+    cacheFileBlobs([fresh]);
+    void loadFile(fresh, { kind: 'primary' }, { sourceHandle: model.sourceHandle });
+    toast.success(`Refreshed "${fresh.name}"`);
+  }, [refreshableModel, loadFile]);
+
   const hasSelection = selectedEntityId !== null;
   // Selection chip uses the multi-select size when present; falls back
   // to the single legacy `selectedEntityId` so the chip still says
@@ -788,7 +852,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
             onClick={(e) => {
               // Blur button to close tooltip before opening file dialog
               (e.currentTarget as HTMLButtonElement).blur();
-              fileInputRef.current?.click();
+              void handleOpenClick();
             }}
             disabled={loading}
           >
@@ -801,6 +865,25 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
         </TooltipTrigger>
         <TooltipContent>Open IFC File</TooltipContent>
       </Tooltip>
+
+      {refreshableModel && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onClick={(e) => {
+                (e.currentTarget as HTMLButtonElement).blur();
+                void handleRefresh();
+              }}
+              disabled={loading}
+            >
+              <RefreshCw className="h-4 w-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Refresh model from disk</TooltipContent>
+        </Tooltip>
+      )}
 
       {/* Add Model button - only shown when models are loaded */}
       {hasModelsLoaded && (

--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -618,6 +618,15 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
     }
   }, [loadFile, addModel, clearAllModels]);
 
+  // The command palette dispatches this (synchronously, inside the click) so the
+  // toolbar's handle-capturing open path runs while user activation is still
+  // live — required for the file dialog to actually open on Chrome.
+  useEffect(() => {
+    const handler = () => { void handleOpenClick(); };
+    window.addEventListener('ifc-lite:open-files', handler);
+    return () => window.removeEventListener('ifc-lite:open-files', handler);
+  }, [handleOpenClick]);
+
   const hasSelection = selectedEntityId !== null;
   // Selection chip uses the multi-select size when present; falls back
   // to the single legacy `selectedEntityId` so the chip still says

--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -288,6 +288,14 @@ function ActionButton({ icon: Icon, label, onClick, shortcut, disabled }: Action
 }
 // #endregion
 
+/** Extensions the viewer can ingest (IFC / IFCX / GLB / point clouds). */
+function isSupportedModelFile(f: File): boolean {
+  const n = f.name.toLowerCase();
+  return n.endsWith('.ifc') || n.endsWith('.ifcx') || n.endsWith('.glb')
+    || n.endsWith('.las') || n.endsWith('.laz') || n.endsWith('.ply') || n.endsWith('.pcd')
+    || n.endsWith('.e57') || n.endsWith('.pts') || n.endsWith('.xyz');
+}
+
 interface MainToolbarProps {
   onShowShortcuts?: () => void;
 }
@@ -434,11 +442,8 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
     const files = e.target.files;
     if (!files || files.length === 0) return;
 
-    // Filter to supported files (IFC, IFCX, GLB)
-    const supportedFiles = Array.from(files).filter(
-      f => f.name.endsWith('.ifc') || f.name.endsWith('.ifcx') || f.name.endsWith('.glb')
-        || f.name.toLowerCase().endsWith('.las') || f.name.toLowerCase().endsWith('.laz') || f.name.toLowerCase().endsWith('.ply') || f.name.toLowerCase().endsWith('.pcd') || f.name.toLowerCase().endsWith('.e57') || f.name.toLowerCase().endsWith('.pts') || f.name.toLowerCase().endsWith('.xyz')
-    );
+    // Filter to supported files (IFC, IFCX, GLB, point clouds)
+    const supportedFiles = Array.from(files).filter(isSupportedModelFile);
 
     if (supportedFiles.length === 0) return;
 
@@ -471,38 +476,53 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
     e.target.value = '';
   }, [loadFile, loadFilesSequentially, loadFederatedIfcx, resetViewerState, clearAllModels]);
 
-  const handleAddModelSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = e.target.files;
-    if (!files || files.length === 0) return;
-
-    // Filter to supported files (IFC, IFCX, GLB)
-    const supportedFiles = Array.from(files).filter(
-      f => f.name.endsWith('.ifc') || f.name.endsWith('.ifcx') || f.name.endsWith('.glb')
-        || f.name.toLowerCase().endsWith('.las') || f.name.toLowerCase().endsWith('.laz') || f.name.toLowerCase().endsWith('.ply') || f.name.toLowerCase().endsWith('.pcd') || f.name.toLowerCase().endsWith('.e57') || f.name.toLowerCase().endsWith('.pts') || f.name.toLowerCase().endsWith('.xyz')
-    );
-
+  // Shared Add-Model routing. `handles` is positionally aligned with
+  // `supportedFiles`, carrying a live FS Access handle per file (Chromium) so
+  // each added model stays part of a refreshable federation.
+  const addSupportedFiles = useCallback((
+    supportedFiles: File[],
+    handles?: (FileSystemFileHandle | undefined)[],
+  ) => {
     if (supportedFiles.length === 0) return;
-
-    // Check if adding IFCX files
     const newFilesAreIfcx = supportedFiles.every(f => f.name.endsWith('.ifcx'));
     const existingIsIfcx = isIfcxDataStore(ifcDataStore);
 
     if (newFilesAreIfcx && existingIsIfcx) {
       // Adding IFCX overlay(s) to existing IFCX model - re-compose with new layers
       console.log(`[MainToolbar] Adding ${supportedFiles.length} IFCX overlay(s) to existing IFCX model - re-composing`);
-      addIfcxOverlays(supportedFiles);
+      void addIfcxOverlays(supportedFiles);
     } else if (newFilesAreIfcx && !existingIsIfcx && ifcDataStore) {
       // User trying to add IFCX to IFC4 model - won't work
       console.warn('[MainToolbar] Cannot add IFCX files to non-IFCX model');
       alert(`IFCX overlay files cannot be added to IFC4 models.\n\nPlease load IFCX files separately.`);
     } else {
       // Standard case - add as independent models (IFC4, GLB, or mixed)
-      loadFilesSequentially(supportedFiles);
+      void loadFilesSequentially(supportedFiles, handles);
     }
+  }, [loadFilesSequentially, addIfcxOverlays, ifcDataStore]);
 
+  const handleAddModelSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files || files.length === 0) return;
+    // <input> yields no live handle, so models added this way aren't refreshable.
+    const supportedFiles = Array.from(files).filter(isSupportedModelFile);
+    addSupportedFiles(supportedFiles);
     // Reset input so same files can be selected again
     e.target.value = '';
-  }, [loadFilesSequentially, addIfcxOverlays, ifcDataStore]);
+  }, [addSupportedFiles]);
+
+  // Preferred Add-Model path: the picker captures a handle per file so the
+  // resulting federation can be refreshed. Falls back to the hidden <input>.
+  const handleAddModelClick = useCallback(async () => {
+    if (!supportsFileSystemAccess()) {
+      addModelInputRef.current?.click();
+      return;
+    }
+    const opened = await openIfcFilesWithHandles();
+    if (!opened) return;
+    const supported = opened.filter(o => isSupportedModelFile(o.file));
+    addSupportedFiles(supported.map(o => o.file), supported.map(o => o.handle));
+  }, [addSupportedFiles]);
 
   // Open via the File System Access API when available (Chromium) so we capture
   // a live FileSystemFileHandle for each file — that handle is what lets the
@@ -518,49 +538,85 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
 
     const files = opened.map(o => o.file);
     recordRecentFiles(files.map(f => ({ name: f.name, size: f.size })));
-    cacheFileBlobs(files);
+    void cacheFileBlobs(files);
 
     if (opened.length === 1) {
       // Single model: keep the handle so Refresh can re-read it from disk.
       void loadFile(opened[0].file, { kind: 'primary' }, { sourceHandle: opened[0].handle });
     } else {
-      // Multiple files mirror handleFileSelect's branching (no per-model handle).
+      // Multiple files mirror handleFileSelect's branching.
       const allIfcx = files.every(f => f.name.endsWith('.ifcx'));
       resetViewerState();
       clearAllModels();
       if (allIfcx) {
-        loadFederatedIfcx(files);
+        // IFCX layers compose into one shared store — no per-file handle.
+        void loadFederatedIfcx(files);
       } else {
-        loadFilesSequentially(files);
+        // Carry each file's handle so the whole federation stays refreshable.
+        void loadFilesSequentially(files, opened.map(o => o.handle));
       }
     }
   }, [loadFile, loadFilesSequentially, loadFederatedIfcx, resetViewerState, clearAllModels]);
 
-  // Refresh re-reads the same file from disk and re-parses it. It is only
-  // possible for a single model opened via the File System Access API (which
-  // gave us a live handle); drag-drop, <input type="file">, cache-restored, and
-  // federated loads have no handle, so the button is not offered for them.
-  const refreshableModel = useMemo<FederatedModel | null>(() => {
-    if (loading || models.size !== 1) return null;
-    const only = models.values().next().value as FederatedModel | undefined;
-    return only?.sourceHandle ? only : null;
+  // Refresh re-reads files from disk and re-parses them. Offered when EVERY
+  // loaded model has a live FS Access handle (a single model, or a federation
+  // fully opened via the picker/drag this session). Drag-drop on non-Chromium,
+  // <input type="file">, cache-restored, and IFCX-composed models have no
+  // handle, so a mixed session hides the button rather than risk dropping the
+  // handle-less models during the rebuild.
+  const canRefresh = useMemo(() => {
+    if (loading || models.size === 0) return false;
+    return Array.from(models.values()).every(m => m.sourceHandle);
   }, [models, loading]);
 
   const handleRefresh = useCallback(async () => {
-    const model = refreshableModel;
-    if (!model?.sourceHandle) return;
-    const fresh = await readFreshFile(model.sourceHandle);
-    if (!fresh) {
-      toast.error(
-        `Couldn't re-read "${model.name}". It may have been moved or deleted, or access was denied.`,
-      );
+    const targets = (Array.from(useViewerStore.getState().models.values()) as FederatedModel[])
+      .filter((m): m is FederatedModel & { sourceHandle: FileSystemFileHandle } => Boolean(m.sourceHandle))
+      .sort((a, b) => (a.loadedAt ?? 0) - (b.loadedAt ?? 0));
+    if (targets.length === 0) return;
+
+    // Re-read every handle BEFORE clearing anything, so a failed read never
+    // leaves the viewer empty.
+    const reads = await Promise.all(
+      targets.map(async (m) => ({ model: m, fresh: await readFreshFile(m.sourceHandle) })),
+    );
+    const ok = reads.filter((r) => r.fresh) as { model: typeof targets[number]; fresh: File }[];
+    const failedNames = reads.filter((r) => !r.fresh).map((r) => `"${r.model.name}"`);
+
+    if (ok.length === 0) {
+      toast.error(`Couldn't re-read ${failedNames.join(', ')}. Files may have moved, been deleted, or access was denied.`);
       return;
     }
-    recordRecentFiles([{ name: fresh.name, size: fresh.size }]);
-    cacheFileBlobs([fresh]);
-    void loadFile(fresh, { kind: 'primary' }, { sourceHandle: model.sourceHandle });
-    toast.success(`Refreshed "${fresh.name}"`);
-  }, [refreshableModel, loadFile]);
+
+    recordRecentFiles(ok.map((r) => ({ name: r.fresh.name, size: r.fresh.size })));
+    void cacheFileBlobs(ok.map((r) => r.fresh));
+
+    if (targets.length === 1) {
+      void loadFile(ok[0].fresh, { kind: 'primary' }, { sourceHandle: ok[0].model.sourceHandle });
+    } else {
+      // Rebuild the federation from fresh bytes, preserving id + order + state.
+      clearAllModels();
+      for (const r of ok) {
+        const reloadedId = await addModel(r.fresh, {
+          name: r.model.name,
+          modelId: r.model.id,
+          loadedAt: r.model.loadedAt,
+          visible: r.model.visible,
+          collapsed: r.model.collapsed,
+          sourceHandle: r.model.sourceHandle,
+        });
+        if (reloadedId && r.model.visible === false) {
+          useViewerStore.getState().setModelVisibility(r.model.id, false);
+        }
+      }
+    }
+
+    if (failedNames.length > 0) {
+      toast.error(`Refreshed ${ok.length}; couldn't re-read ${failedNames.join(', ')}.`);
+    } else {
+      toast.success(ok.length === 1 ? `Refreshed "${ok[0].fresh.name}"` : `Refreshed ${ok.length} models`);
+    }
+  }, [loadFile, addModel, clearAllModels]);
 
   const hasSelection = selectedEntityId !== null;
   // Selection chip uses the multi-select size when present; falls back
@@ -866,7 +922,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
         <TooltipContent>Open IFC File</TooltipContent>
       </Tooltip>
 
-      {refreshableModel && (
+      {canRefresh && (
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
@@ -881,7 +937,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
               <RefreshCw className="h-4 w-4" />
             </Button>
           </TooltipTrigger>
-          <TooltipContent>Refresh model from disk</TooltipContent>
+          <TooltipContent>{models.size > 1 ? 'Refresh models from disk' : 'Refresh model from disk'}</TooltipContent>
         </Tooltip>
       )}
 
@@ -894,7 +950,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
               size="icon-sm"
               onClick={(e) => {
                 (e.currentTarget as HTMLButtonElement).blur();
-                addModelInputRef.current?.click();
+                void handleAddModelClick();
               }}
               disabled={loading}
               className="text-[#9ece6a] hover:text-[#9ece6a] hover:bg-[#9ece6a]/10"

--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -296,6 +296,11 @@ function isSupportedModelFile(f: File): boolean {
     || n.endsWith('.e57') || n.endsWith('.pts') || n.endsWith('.xyz');
 }
 
+/** Case-insensitive IFCX check (filenames are accepted case-insensitively). */
+function isIfcxModelFile(f: File): boolean {
+  return f.name.toLowerCase().endsWith('.ifcx');
+}
+
 interface MainToolbarProps {
   onShowShortcuts?: () => void;
 }
@@ -484,7 +489,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
     handles?: (FileSystemFileHandle | undefined)[],
   ) => {
     if (supportedFiles.length === 0) return;
-    const newFilesAreIfcx = supportedFiles.every(f => f.name.endsWith('.ifcx'));
+    const newFilesAreIfcx = supportedFiles.every(isIfcxModelFile);
     const existingIsIfcx = isIfcxDataStore(ifcDataStore);
 
     if (newFilesAreIfcx && existingIsIfcx) {
@@ -533,8 +538,12 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
       fileInputRef.current?.click();
       return;
     }
-    const opened = await openIfcFilesWithHandles();
-    if (!opened) return; // cancelled, unavailable, or picker failed
+    const picked = await openIfcFilesWithHandles();
+    if (!picked) return; // cancelled, unavailable, or picker failed
+    // The picker keeps an "all files" option, so drop anything unsupported
+    // before it reaches the load pipeline (matches the <input> + Add Model paths).
+    const opened = picked.filter(o => isSupportedModelFile(o.file));
+    if (opened.length === 0) return;
 
     const files = opened.map(o => o.file);
     recordRecentFiles(files.map(f => ({ name: f.name, size: f.size })));
@@ -545,7 +554,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
       void loadFile(opened[0].file, { kind: 'primary' }, { sourceHandle: opened[0].handle });
     } else {
       // Multiple files mirror handleFileSelect's branching.
-      const allIfcx = files.every(f => f.name.endsWith('.ifcx'));
+      const allIfcx = files.every(isIfcxModelFile);
       resetViewerState();
       clearAllModels();
       if (allIfcx) {
@@ -592,7 +601,8 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
     void cacheFileBlobs(ok.map((r) => r.fresh));
 
     if (targets.length === 1) {
-      void loadFile(ok[0].fresh, { kind: 'primary' }, { sourceHandle: ok[0].model.sourceHandle });
+      // Await so the success toast only fires once the reload has completed.
+      await loadFile(ok[0].fresh, { kind: 'primary' }, { sourceHandle: ok[0].model.sourceHandle });
     } else {
       // Rebuild the federation from fresh bytes, preserving id + order + state.
       clearAllModels();
@@ -942,6 +952,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
                 void handleRefresh();
               }}
               disabled={loading}
+              aria-label={models.size > 1 ? 'Refresh models from disk' : 'Refresh model from disk'}
             >
               <RefreshCw className="h-4 w-4" />
             </Button>

--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -502,13 +502,20 @@ export function ViewportContainer() {
       return;
     }
 
-    recordRecentFiles(supportedFiles.map((file) => ({ name: file.name, size: file.size })));
-    void cacheFileBlobs(supportedFiles);
-    setRecentFiles(getRecentFiles().slice(0, 3));
-
     void handlesPromise.then((opened) => {
-      const handleByName = new Map((opened ?? []).map((o) => [o.file.name, o.handle]));
-      routeLoad(supportedFiles, supportedFiles.map((f) => handleByName.get(f.name)));
+      // Prefer the handle-paired files (Chromium): each file + handle comes from
+      // the same dropped item, so no filename matching is needed. Fall back to
+      // the plain dropped files when no handles were captured (Firefox/Safari).
+      const supportedOpened = (opened ?? []).filter((o) => isSupportedFile(o.file));
+      const useHandles = supportedOpened.length > 0;
+      const files = useHandles ? supportedOpened.map((o) => o.file) : supportedFiles;
+      const handles = useHandles ? supportedOpened.map((o) => o.handle) : undefined;
+
+      recordRecentFiles(files.map((file) => ({ name: file.name, size: file.size })));
+      void cacheFileBlobs(files);
+      setRecentFiles(getRecentFiles().slice(0, 3));
+
+      routeLoad(files, handles);
     });
   }, [routeLoad, applyDragEvent, isSupportedFile, webgpu.supported]);
 

--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -31,6 +31,11 @@ import type { AggregationRelationships } from '@/utils/aggregation';
 import { useIfc } from '@/hooks/useIfc';
 import { useWebGPU } from '@/hooks/useWebGPU';
 import { cacheFileBlobs, formatFileSize, getCachedFile, getRecentFiles, recordRecentFiles, type RecentFileEntry } from '@/lib/recent-files';
+import {
+  supportsFileSystemAccess,
+  openIfcFilesWithHandles,
+  handlesFromDataTransfer,
+} from '@/services/file-system-access';
 import { toast } from '@/components/ui/toast';
 import { describeUnsupportedFormat } from '@/hooks/ingest/pointCloudIngest';
 import { Upload, MousePointer, Layers, Info, Command, AlertTriangle, ChevronDown, ExternalLink, Plus, Clock3, Sparkles, ArrowUpRight, PackagePlus } from 'lucide-react';
@@ -440,6 +445,35 @@ export function ViewportContainer() {
     applyDragEvent('leave');
   }, [applyDragEvent]);
 
+  const isSupportedFile = useCallback((f: File) => {
+    const n = f.name.toLowerCase();
+    return n.endsWith('.ifc') || n.endsWith('.ifcx') || n.endsWith('.glb')
+      || n.endsWith('.las') || n.endsWith('.laz') || n.endsWith('.ply') || n.endsWith('.pcd')
+      || n.endsWith('.e57') || n.endsWith('.pts') || n.endsWith('.xyz');
+  }, []);
+
+  // Single routing point for every ingestion path (picker / drop / input). The
+  // optional `handles` array is positionally aligned with `files` and carries a
+  // live FS Access handle per file when one was captured (Chromium) so the model
+  // stays refreshable; entries are `undefined` otherwise.
+  const routeLoad = useCallback((
+    files: File[],
+    handles?: (FileSystemFileHandle | undefined)[],
+  ) => {
+    if (hasModelsLoaded) {
+      // Models already loaded - add new files sequentially (federate).
+      void loadFilesSequentially(files, handles);
+    } else if (files.length === 1) {
+      // Single file, no models loaded - primary single-model load.
+      void loadFile(files[0], { kind: 'primary' }, { sourceHandle: handles?.[0] });
+    } else {
+      // Multiple files, no models loaded - start a fresh federation.
+      resetViewerState();
+      clearAllModels();
+      void loadFilesSequentially(files, handles);
+    }
+  }, [loadFile, loadFilesSequentially, resetViewerState, clearAllModels, hasModelsLoaded]);
+
   const handleDrop = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
@@ -450,12 +484,13 @@ export function ViewportContainer() {
       return;
     }
 
+    // Capture live handles synchronously — the DataTransferItemList is neutered
+    // once this handler returns, so this must run before any await.
+    const handlesPromise = handlesFromDataTransfer(e.dataTransfer);
+
     // Filter to supported files (IFC, IFCX, GLB, point clouds)
     const allDropped = Array.from(e.dataTransfer.files);
-    const supportedFiles = allDropped.filter(
-      f => f.name.endsWith('.ifc') || f.name.endsWith('.ifcx') || f.name.endsWith('.glb')
-        || f.name.toLowerCase().endsWith('.las') || f.name.toLowerCase().endsWith('.laz') || f.name.toLowerCase().endsWith('.ply') || f.name.toLowerCase().endsWith('.pcd') || f.name.toLowerCase().endsWith('.e57') || f.name.toLowerCase().endsWith('.pts') || f.name.toLowerCase().endsWith('.xyz')
-    );
+    const supportedFiles = allDropped.filter(isSupportedFile);
 
     if (supportedFiles.length === 0) {
       // Tell the user *why* — common case is a Recap project / SketchUp
@@ -471,19 +506,11 @@ export function ViewportContainer() {
     void cacheFileBlobs(supportedFiles);
     setRecentFiles(getRecentFiles().slice(0, 3));
 
-    if (hasModelsLoaded) {
-      // Models already loaded - add new files sequentially
-      loadFilesSequentially(supportedFiles);
-    } else if (supportedFiles.length === 1) {
-      // Single file, no models loaded - use loadFile
-      loadFile(supportedFiles[0]);
-    } else {
-      // Multiple files, no models loaded - use federation
-      resetViewerState();
-      clearAllModels();
-      loadFilesSequentially(supportedFiles);
-    }
-  }, [loadFile, loadFilesSequentially, resetViewerState, clearAllModels, webgpu.supported, hasModelsLoaded]);
+    void handlesPromise.then((opened) => {
+      const handleByName = new Map((opened ?? []).map((o) => [o.file.name, o.handle]));
+      routeLoad(supportedFiles, supportedFiles.map((f) => handleByName.get(f.name)));
+    });
+  }, [routeLoad, applyDragEvent, isSupportedFile, webgpu.supported]);
 
   const handleFileSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     // Block file loading if WebGPU not supported
@@ -494,11 +521,9 @@ export function ViewportContainer() {
     const files = e.target.files;
     if (!files || files.length === 0) return;
 
-    // Filter to supported files (IFC, IFCX, GLB)
-    const supportedFiles = Array.from(files).filter(
-      f => f.name.endsWith('.ifc') || f.name.endsWith('.ifcx') || f.name.endsWith('.glb')
-        || f.name.toLowerCase().endsWith('.las') || f.name.toLowerCase().endsWith('.laz') || f.name.toLowerCase().endsWith('.ply') || f.name.toLowerCase().endsWith('.pcd') || f.name.toLowerCase().endsWith('.e57') || f.name.toLowerCase().endsWith('.pts') || f.name.toLowerCase().endsWith('.xyz')
-    );
+    // Filter to supported files (IFC, IFCX, GLB). The <input> path yields no
+    // live handle, so these models are not refreshable.
+    const supportedFiles = Array.from(files).filter(isSupportedFile);
 
     if (supportedFiles.length === 0) return;
 
@@ -506,20 +531,33 @@ export function ViewportContainer() {
     void cacheFileBlobs(supportedFiles);
     setRecentFiles(getRecentFiles().slice(0, 3));
 
-    if (supportedFiles.length === 1) {
-      // Single file - use loadFile (simpler single-model path)
-      loadFile(supportedFiles[0]);
-    } else {
-      // Multiple files selected - use federation from the start
-      // Clear everything and start fresh, then load sequentially
-      resetViewerState();
-      clearAllModels();
-      loadFilesSequentially(supportedFiles);
-    }
+    routeLoad(supportedFiles);
 
     // Reset input so same file can be selected again
     e.target.value = '';
-  }, [loadFile, loadFilesSequentially, resetViewerState, clearAllModels, webgpu.supported]);
+  }, [routeLoad, isSupportedFile, webgpu.supported]);
+
+  // Preferred open path: the File System Access picker (Chromium) captures a
+  // live handle per file so the model can be refreshed from disk. Falls back to
+  // the hidden <input type="file"> on browsers without the API.
+  const handleOpenClick = useCallback(async () => {
+    if (!webgpu.supported) return;
+    if (!supportsFileSystemAccess()) {
+      fileInputRef.current?.click();
+      return;
+    }
+    const opened = await openIfcFilesWithHandles();
+    if (!opened) return;
+    const supported = opened.filter((o) => isSupportedFile(o.file));
+    if (supported.length === 0) return;
+
+    const files = supported.map((o) => o.file);
+    recordRecentFiles(files.map((f) => ({ name: f.name, size: f.size })));
+    void cacheFileBlobs(files);
+    setRecentFiles(getRecentFiles().slice(0, 3));
+
+    routeLoad(files, supported.map((o) => o.handle));
+  }, [routeLoad, isSupportedFile, webgpu.supported]);
 
   const handleStartBlank = useCallback(async () => {
     if (!webgpu.supported) return;
@@ -1016,12 +1054,7 @@ export function ViewportContainer() {
             */}
             {/* Track 1 — open / drag */}
             <button
-              onClick={() => {
-                if (!webgpu.supported) {
-                  return;
-                }
-                fileInputRef.current?.click();
-              }}
+              onClick={() => { void handleOpenClick(); }}
               disabled={!webgpu.supported || webgpu.checking}
               className={`group w-full flex items-center justify-center gap-3 px-6 py-3 font-mono text-sm border transition-all ${
                 !webgpu.supported || webgpu.checking
@@ -1094,7 +1127,7 @@ export function ViewportContainer() {
                           await loadFile(cached);
                           return;
                         }
-                        fileInputRef.current?.click();
+                        void handleOpenClick();
                       }}
                       className="flex items-center justify-between gap-3 border border-zinc-200 bg-zinc-50 px-3 py-2 text-left transition-colors hover:border-primary hover:text-primary dark:border-[#3b4261] dark:bg-[#1f2335] dark:hover:border-primary"
                     >

--- a/apps/viewer/src/hooks/useIfcFederation.ts
+++ b/apps/viewer/src/hooks/useIfcFederation.ts
@@ -55,7 +55,11 @@ export interface IfcxDataStore extends IfcDataStore {
 export function useIfcFederation(
   // The ONE canonical loader. Federated adds route through it (target
   // 'federated') so model #1 and model #N share an identical pipeline.
-  loadFile: (file: File, target?: import('./useIfcLoader.js').LoadTarget) => Promise<void>,
+  loadFile: (
+    file: File,
+    target?: import('./useIfcLoader.js').LoadTarget,
+    options?: { sourceHandle?: FileSystemFileHandle },
+  ) => Promise<void>,
 ) {
   const {
     setLoading,
@@ -109,6 +113,8 @@ export function useIfcFederation(
       loadedAt?: number;
       visible?: boolean;
       collapsed?: boolean;
+      /** Live FS Access handle so this federated model stays refreshable. */
+      sourceHandle?: FileSystemFileHandle;
     }
   ): Promise<string | null> => {
     const modelId = options?.modelId ?? crypto.randomUUID();
@@ -158,7 +164,7 @@ export function useIfcFederation(
         collapsed: options?.collapsed,
         loadedAt: options?.loadedAt,
         sharedRtcOffset,
-      });
+      }, { sourceHandle: options?.sourceHandle });
 
       if (loadSessionRef.current !== currentSession) return null;
       const registered = useViewerStore.getState().models.has(modelId);
@@ -361,9 +367,12 @@ export function useIfcFederation(
    * Load multiple files sequentially (WASM parser isn't thread-safe)
    * Each file fully loads before the next one starts
    */
-  const loadFilesSequentially = useCallback(async (files: File[]): Promise<void> => {
-    for (const file of files) {
-      await addModel(file);
+  const loadFilesSequentially = useCallback(async (
+    files: File[],
+    handles?: (FileSystemFileHandle | undefined)[],
+  ): Promise<void> => {
+    for (let i = 0; i < files.length; i++) {
+      await addModel(files[i], { sourceHandle: handles?.[i] });
     }
   }, [addModel]);
 

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -335,6 +335,7 @@ export function useIfcLoader() {
             loadedAt: target.loadedAt ?? Date.now(),
             fileSize: buffer.byteLength,
             sourceFile: file,
+            sourceHandle: options?.sourceHandle,
             idOffset,
             maxExpressId,
             pointCloudHandleId: patch?.pointCloudHandleId,

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -186,6 +186,7 @@ export function useIfcLoader() {
   const loadFile = useCallback(async (
     file: File,
     target: LoadTarget = { kind: 'primary' },
+    options?: { sourceHandle?: FileSystemFileHandle },
   ) => {
     const { resetViewerState, clearAllModels } = useViewerStore.getState();
     // Only a primary (destructive, replace-everything) load bumps the session.
@@ -243,6 +244,7 @@ export function useIfcLoader() {
           loadedAt: Date.now(),
           fileSize,
           sourceFile: file,
+          sourceHandle: options?.sourceHandle,
           idOffset: 0,
           maxExpressId: 0,
           loadState: 'pending',

--- a/apps/viewer/src/lib/recent-files.ts
+++ b/apps/viewer/src/lib/recent-files.ts
@@ -116,6 +116,28 @@ export async function cacheFileBlobs(files: File[]): Promise<void> {
   } catch { /* IndexedDB unavailable — degrade gracefully */ }
 }
 
+/**
+ * List the names of files currently in the blob cache (keys only, no blobs).
+ * Cheap enough to call on every palette open so callers can decide cache
+ * hit/miss synchronously, without an `await` that would drop the user
+ * activation a file dialog needs.
+ */
+export async function getCachedFileNames(): Promise<string[]> {
+  try {
+    const db = await openDB();
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const req = tx.objectStore(STORE_NAME).getAllKeys();
+    const keys = await new Promise<IDBValidKey[]>((resolve, reject) => {
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+    db.close();
+    return keys.map(String);
+  } catch {
+    return [];
+  }
+}
+
 /** Retrieve a cached file blob and reconstruct a File object. */
 export async function getCachedFile(target: string | RecentFileEntry): Promise<File | null> {
   const name = typeof target === 'string' ? target : target.name;

--- a/apps/viewer/src/lib/recent-files.ts
+++ b/apps/viewer/src/lib/recent-files.ts
@@ -86,6 +86,12 @@ function openDB(): Promise<IDBDatabase> {
 /** Cache file blobs in IndexedDB for instant reload from palette. */
 export async function cacheFileBlobs(files: File[]): Promise<void> {
   try {
+    // Only stage up to the cache capacity. The store keeps at most
+    // MAX_CACHED_FILES entries, so reading every blob of a large multi-file drop
+    // into memory just to evict most of them afterwards is wasteful — keep the
+    // last-selected ones (the eviction below keeps newest by timestamp anyway).
+    const eligible = files.filter((f) => f.size <= MAX_CACHE_SIZE).slice(-MAX_CACHED_FILES);
+
     // Read every blob FIRST. An IndexedDB transaction auto-commits as soon as
     // control returns to the event loop with no pending request, so awaiting
     // file.arrayBuffer() *inside* the transaction would inactivate it and make
@@ -93,8 +99,7 @@ export async function cacheFileBlobs(files: File[]): Promise<void> {
     // nothing cached). Do all the async reads up front, then write in one
     // synchronous burst.
     const records: { name: string; blob: ArrayBuffer; size: number; type: string; timestamp: number }[] = [];
-    for (const file of files) {
-      if (file.size > MAX_CACHE_SIZE) continue; // skip oversized files
+    for (const file of eligible) {
       records.push({
         name: file.name,
         blob: await file.arrayBuffer(),

--- a/apps/viewer/src/lib/recent-files.ts
+++ b/apps/viewer/src/lib/recent-files.ts
@@ -86,14 +86,31 @@ function openDB(): Promise<IDBDatabase> {
 /** Cache file blobs in IndexedDB for instant reload from palette. */
 export async function cacheFileBlobs(files: File[]): Promise<void> {
   try {
+    // Read every blob FIRST. An IndexedDB transaction auto-commits as soon as
+    // control returns to the event loop with no pending request, so awaiting
+    // file.arrayBuffer() *inside* the transaction would inactivate it and make
+    // the next store.put() throw TransactionInactiveError (silently caught →
+    // nothing cached). Do all the async reads up front, then write in one
+    // synchronous burst.
+    const records: { name: string; blob: ArrayBuffer; size: number; type: string; timestamp: number }[] = [];
+    for (const file of files) {
+      if (file.size > MAX_CACHE_SIZE) continue; // skip oversized files
+      records.push({
+        name: file.name,
+        blob: await file.arrayBuffer(),
+        size: file.size,
+        type: file.type,
+        timestamp: Date.now(),
+      });
+    }
+    if (records.length === 0) return;
+
     const db = await openDB();
     const tx = db.transaction(STORE_NAME, 'readwrite');
     const store = tx.objectStore(STORE_NAME);
 
-    for (const file of files) {
-      if (file.size > MAX_CACHE_SIZE) continue; // skip oversized files
-      const blob = await file.arrayBuffer();
-      store.put({ name: file.name, blob, size: file.size, type: file.type, timestamp: Date.now() });
+    for (const record of records) {
+      store.put(record);
     }
 
     // Evict old entries beyond MAX_CACHED_FILES
@@ -113,7 +130,9 @@ export async function cacheFileBlobs(files: File[]): Promise<void> {
       tx.onerror = () => reject(tx.error);
     });
     db.close();
-  } catch { /* IndexedDB unavailable — degrade gracefully */ }
+  } catch (err) {
+    console.warn('[recent-files] failed to cache file blobs', err);
+  }
 }
 
 /**

--- a/apps/viewer/src/services/file-system-access.ts
+++ b/apps/viewer/src/services/file-system-access.ts
@@ -115,3 +115,45 @@ export async function readFreshFile(handle: FileSystemFileHandle): Promise<File 
     return null;
   }
 }
+
+/**
+ * Capture live handles for files dropped onto the page (Chromium). Returns one
+ * `{ file, handle }` per dropped file that exposes a file handle, or `null` when
+ * the API is unavailable so the caller can fall back to `dataTransfer.files`.
+ *
+ * MUST be invoked synchronously from the `drop` event handler: the
+ * `DataTransferItemList` is neutered the moment the handler returns to the event
+ * loop, so every `getAsFileSystemHandle()` call is kicked off before the first
+ * `await` and only then resolved together.
+ */
+export function handlesFromDataTransfer(dataTransfer: DataTransfer): Promise<OpenedFile[] | null> {
+  if (!supportsFileSystemAccess()) return Promise.resolve(null);
+  const items = Array.from(dataTransfer.items).filter((i) => i.kind === 'file');
+  if (items.length === 0) return Promise.resolve(null);
+  if (typeof items[0].getAsFileSystemHandle !== 'function') return Promise.resolve(null);
+
+  // Synchronous: start every handle request before awaiting anything.
+  const pending = items.map((item) => {
+    try {
+      return item.getAsFileSystemHandle?.() ?? Promise.resolve(null);
+    } catch {
+      return Promise.resolve(null);
+    }
+  });
+
+  return (async () => {
+    const handles = await Promise.all(pending);
+    const opened: OpenedFile[] = [];
+    for (const h of handles) {
+      if (h && h.kind === 'file') {
+        const fh = h as FileSystemFileHandle;
+        try {
+          opened.push({ file: await fh.getFile(), handle: fh });
+        } catch (err) {
+          console.warn(`[file-system-access] drag handle read failed for "${fh.name}"`, err);
+        }
+      }
+    }
+    return opened.length > 0 ? opened : null;
+  })();
+}

--- a/apps/viewer/src/services/file-system-access.ts
+++ b/apps/viewer/src/services/file-system-access.ts
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * File System Access API helpers (Chromium: Chrome / Edge).
+ *
+ * Opening a file via `showOpenFilePicker` yields a live `FileSystemFileHandle`.
+ * Unlike a `<input type="file">` File — a frozen snapshot of the bytes at pick
+ * time — a handle can be re-read on demand with `getFile()`, which returns a
+ * fresh File reflecting the current on-disk contents. That is what powers the
+ * "Refresh" action: re-read the same file the user is editing in their
+ * authoring tool, without re-picking it (issue #1345).
+ *
+ * Browsers without the API (Firefox / Safari) fall back to `<input type="file">`,
+ * where no handle exists and Refresh is simply not offered.
+ */
+
+/** Accept filter mirroring the `<input type="file">` accept list. */
+const IFC_ACCEPT_TYPES: FilePickerAcceptType[] = [
+  {
+    description: 'BIM models & point clouds',
+    accept: {
+      'application/octet-stream': [
+        '.ifc',
+        '.ifcx',
+        '.glb',
+        '.las',
+        '.laz',
+        '.ply',
+        '.pcd',
+        '.e57',
+        '.pts',
+        '.xyz',
+      ],
+    },
+  },
+];
+
+export interface OpenedFile {
+  file: File;
+  handle: FileSystemFileHandle;
+}
+
+/**
+ * Whether this browser exposes the File System Access open API. Requires a
+ * secure context (https / localhost) and a Chromium engine.
+ */
+export function supportsFileSystemAccess(): boolean {
+  return typeof window !== 'undefined' && typeof window.showOpenFilePicker === 'function';
+}
+
+/**
+ * Prompt the user to pick one or more BIM files, returning both the File and
+ * its live handle for each. Returns `null` when the user cancels, the API is
+ * unavailable, or the picker fails — so callers can fall back to
+ * `<input type="file">`.
+ */
+export async function openIfcFilesWithHandles(): Promise<OpenedFile[] | null> {
+  if (!supportsFileSystemAccess()) return null;
+
+  let handles: FileSystemFileHandle[];
+  try {
+    handles = await window.showOpenFilePicker!({
+      multiple: true,
+      excludeAcceptAllOption: false,
+      types: IFC_ACCEPT_TYPES,
+    });
+  } catch (err) {
+    // AbortError = the user dismissed the dialog; not worth surfacing.
+    if (err instanceof DOMException && err.name === 'AbortError') return null;
+    console.warn('[file-system-access] showOpenFilePicker failed, falling back', err);
+    return null;
+  }
+
+  const opened: OpenedFile[] = [];
+  for (const handle of handles) {
+    try {
+      opened.push({ file: await handle.getFile(), handle });
+    } catch (err) {
+      console.warn(`[file-system-access] could not read "${handle.name}"`, err);
+    }
+  }
+  return opened.length > 0 ? opened : null;
+}
+
+/**
+ * Ensure we still hold read permission for a handle, prompting if the grant
+ * lapsed. Resolves true when read access is granted. The request path must run
+ * inside a user gesture. When the engine lacks the permission probes (some
+ * Chromium builds expose `showOpenFilePicker` but not `queryPermission`), we
+ * optimistically return true and let `getFile()` surface the real error.
+ */
+async function ensureReadPermission(handle: FileSystemFileHandle): Promise<boolean> {
+  if (typeof handle.queryPermission !== 'function') return true;
+  const opts: FileSystemHandlePermissionDescriptor = { mode: 'read' };
+  if ((await handle.queryPermission(opts)) === 'granted') return true;
+  if (typeof handle.requestPermission === 'function') {
+    return (await handle.requestPermission(opts)) === 'granted';
+  }
+  return false;
+}
+
+/**
+ * Re-read a handle's current on-disk contents. Returns a fresh File, or `null`
+ * if permission was denied or the file is no longer reachable (moved/deleted).
+ * Must be called from a user gesture so the permission prompt can show.
+ */
+export async function readFreshFile(handle: FileSystemFileHandle): Promise<File | null> {
+  if (!(await ensureReadPermission(handle))) return null;
+  try {
+    return await handle.getFile();
+  } catch (err) {
+    console.warn(`[file-system-access] refresh read failed for "${handle.name}"`, err);
+    return null;
+  }
+}

--- a/apps/viewer/src/services/file-system-access.ts
+++ b/apps/viewer/src/services/file-system-access.ts
@@ -136,7 +136,8 @@ export function handlesFromDataTransfer(dataTransfer: DataTransfer): Promise<Ope
   const pending = items.map((item) => {
     try {
       return item.getAsFileSystemHandle?.() ?? Promise.resolve(null);
-    } catch {
+    } catch (err) {
+      console.warn('[file-system-access] getAsFileSystemHandle threw for a dropped item', err);
       return Promise.resolve(null);
     }
   });

--- a/apps/viewer/src/store/types.ts
+++ b/apps/viewer/src/store/types.ts
@@ -336,6 +336,15 @@ export interface FederatedModel {
   /** Original source handle used for explicit reload/reposition operations. */
   sourceFile?: ModelSourceFile;
   /**
+   * Live File System Access handle captured when the model was opened via
+   * `showOpenFilePicker` (Chromium only). Unlike `sourceFile` — a frozen
+   * snapshot of the bytes at pick time — this can be re-read with `getFile()`
+   * to pull the current on-disk contents, powering the "Refresh" action
+   * (issue #1345). Absent for drag-drop, `<input type="file">`, cache-restored,
+   * and federated loads. Held in memory only; never serialized to cache.
+   */
+  sourceHandle?: FileSystemFileHandle;
+  /**
    * ID offset for this model (from FederationRegistry)
    * All mesh expressIds are globalIds = originalExpressId + idOffset
    * Use this to convert back to original IDs for property lookup

--- a/apps/viewer/src/store/types.ts
+++ b/apps/viewer/src/store/types.ts
@@ -336,12 +336,15 @@ export interface FederatedModel {
   /** Original source handle used for explicit reload/reposition operations. */
   sourceFile?: ModelSourceFile;
   /**
-   * Live File System Access handle captured when the model was opened via
-   * `showOpenFilePicker` (Chromium only). Unlike `sourceFile` — a frozen
-   * snapshot of the bytes at pick time — this can be re-read with `getFile()`
-   * to pull the current on-disk contents, powering the "Refresh" action
-   * (issue #1345). Absent for drag-drop, `<input type="file">`, cache-restored,
-   * and federated loads. Held in memory only; never serialized to cache.
+   * Live File System Access handle captured when the model was opened on a
+   * Chromium browser, via the picker (`showOpenFilePicker`) or by drag-drop
+   * (`DataTransferItem.getAsFileSystemHandle`), through the toolbar, the
+   * empty-state open, the command palette, or Add Model. Unlike `sourceFile`
+   * (a frozen snapshot of the bytes at pick time), this can be re-read with
+   * `getFile()` to pull the current on-disk contents, powering the "Refresh"
+   * action (issue #1345). Absent for the `<input type="file">` fallback
+   * (Firefox/Safari/insecure context), cache-restored models, and IFCX-composed
+   * layers. Held in memory only; never serialized to cache.
    */
   sourceHandle?: FileSystemFileHandle;
   /**

--- a/apps/viewer/src/types/file-system-access.d.ts
+++ b/apps/viewer/src/types/file-system-access.d.ts
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * File System Access API surface that TypeScript's bundled `lib.dom` (TS 6.0.3)
+ * does not yet declare. `FileSystemHandle` / `FileSystemFileHandle.getFile()`
+ * already ship in lib.dom, but `Window.showOpenFilePicker`, its options, and the
+ * Chromium permission probes (`queryPermission` / `requestPermission`) are
+ * missing. These are global augmentations (no imports/exports → ambient scope),
+ * so they merge with the existing lib.dom interfaces.
+ *
+ * Used by `services/file-system-access.ts` to capture a live file handle on open
+ * and re-read it on demand (the "Refresh" action).
+ */
+
+interface FileSystemHandlePermissionDescriptor {
+  mode?: 'read' | 'readwrite';
+}
+
+interface FileSystemHandle {
+  /** Chromium-only: current permission state without prompting. */
+  queryPermission?(
+    descriptor?: FileSystemHandlePermissionDescriptor,
+  ): Promise<PermissionState>;
+  /** Chromium-only: prompt for permission (must run in a user gesture). */
+  requestPermission?(
+    descriptor?: FileSystemHandlePermissionDescriptor,
+  ): Promise<PermissionState>;
+}
+
+interface FilePickerAcceptType {
+  description?: string;
+  accept: Record<string, string | string[]>;
+}
+
+interface OpenFilePickerOptions {
+  multiple?: boolean;
+  excludeAcceptAllOption?: boolean;
+  types?: FilePickerAcceptType[];
+  id?: string;
+  startIn?:
+    | FileSystemHandle
+    | 'desktop'
+    | 'documents'
+    | 'downloads'
+    | 'music'
+    | 'pictures'
+    | 'videos';
+}
+
+interface Window {
+  showOpenFilePicker?(
+    options?: OpenFilePickerOptions,
+  ): Promise<FileSystemFileHandle[]>;
+}

--- a/apps/viewer/src/types/file-system-access.d.ts
+++ b/apps/viewer/src/types/file-system-access.d.ts
@@ -54,3 +54,8 @@ interface Window {
     options?: OpenFilePickerOptions,
   ): Promise<FileSystemFileHandle[]>;
 }
+
+interface DataTransferItem {
+  /** Chromium-only: live handle for a dropped file (call synchronously in `drop`). */
+  getAsFileSystemHandle?(): Promise<FileSystemHandle | null>;
+}


### PR DESCRIPTION
## Summary

Closes #1345. Adds a **Refresh** button to reload the open model without closing and re-opening the same file, so it can be monitored during design.

The existing Open flow uses `<input type="file">`, which hands back a File that is a *frozen snapshot* of the bytes at pick time. Re-reading it can never reflect on-disk edits. Only the **File System Access API** (`showOpenFilePicker` → `FileSystemFileHandle.getFile()`) returns a fresh snapshot of the current file. So the Open button now prefers that API when available (Chromium / secure context) to capture a live handle, and falls back to `<input type="file">` everywhere else.

## Changes (`apps/viewer`)

- **`services/file-system-access.ts`** (new) — `supportsFileSystemAccess()`, `openIfcFilesWithHandles()` (picks files + captures live handles; user-cancel handled), `readFreshFile(handle)` (permission-checked re-read of current on-disk bytes; surfaces moved/deleted/denied).
- **`types/file-system-access.d.ts`** (new) — minimal ambient declarations for the API surface missing from TS 6.0.3 `lib.dom` (`Window.showOpenFilePicker`, `OpenFilePickerOptions`, `queryPermission`/`requestPermission`). `FileSystemFileHandle.getFile()` already ships in lib.dom.
- **`store/types.ts`** — `FederatedModel.sourceHandle?: FileSystemFileHandle` (in-memory only, never serialized to cache; mirrors `sourceFile`).
- **`hooks/useIfcLoader.ts`** — `loadFile` accepts an optional `{ sourceHandle }` and persists it on the primary model record.
- **`components/viewer/MainToolbar.tsx`** — Open button prefers the FS Access API; new Refresh button (`RefreshCw`).

## Behaviour / scope

- Refresh is **only shown** when exactly one model is loaded **and** it has a live handle. Drag-drop, `<input type="file">`, recent-files-from-cache, and federated multi-model loads have no handle, so the button isn't offered (no dead/disabled control).
- Multi-file Open keeps the existing federated/sequential paths unchanged.
- Non-Chromium browsers (Firefox/Safari) and insecure contexts fall back to `<input type="file">` transparently — no Refresh button, no regression.

## Testing

- `tsc --noEmit` clean for all touched files (remaining errors are pre-existing un-built-package gaps in the worktree, unrelated to this change).
- Not yet smoke-tested in a running viewer (requires built wasm pkg + dev server).

## Follow-up (not in this PR)

- Drag-and-drop could also capture handles via Chromium `DataTransferItem.getAsFileSystemHandle()`, extending Refresh to dropped files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Refresh” action that reloads models from their original disk source when supported.
  * Improved Open, Add Model, and drag-and-drop to use file picker handles when available, enabling refresh-aware loading.
  * Enhanced recent files to make faster, cache-aware loading decisions.
* **Bug Fixes**
  * Updated command palette file-dialog activation to more reliably preserve browser interaction state.
  * Improved recent-file caching performance and resilience for more consistent loads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->