### PR TITLE
fix(viewer): honour Show Annotations toggle for IfcAnnotation 3D meshes

### DIFF
--- a/apps/viewer/src/components/viewer/GLBExportDialog.tsx
+++ b/apps/viewer/src/components/viewer/GLBExportDialog.tsx
@@ -56,7 +56,7 @@ type ColorSource = 'rendering' | 'shading';
  * matches what the user sees in the viewport.
  */
 function buildHiddenIfcTypes(
-  typeVisibility: { spaces: boolean; spatialZones: boolean; openings: boolean; virtualElements: boolean; site: boolean },
+  typeVisibility: { spaces: boolean; spatialZones: boolean; openings: boolean; virtualElements: boolean; site: boolean; ifcAnnotations: boolean },
 ): Set<string> {
   const out = new Set<string>();
   if (!typeVisibility.spaces) out.add('IfcSpace');
@@ -64,6 +64,7 @@ function buildHiddenIfcTypes(
   if (!typeVisibility.openings) out.add('IfcOpeningElement');
   if (!typeVisibility.virtualElements) out.add('IfcVirtualElement');
   if (!typeVisibility.site) out.add('IfcSite');
+  if (!typeVisibility.ifcAnnotations) out.add('IfcAnnotation');
   return out;
 }
 

--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -699,6 +699,7 @@ export function ViewportContainer() {
       prevVis.openings !== typeVisibility.openings ||
       prevVis.virtualElements !== typeVisibility.virtualElements ||
       prevVis.site !== typeVisibility.site ||
+      prevVis.ifcAnnotations !== typeVisibility.ifcAnnotations ||
       filteredTypeModeRef.current !== effectiveViewMode;
     const sourceChanged = filteredSourceRef.current !== allMeshes;
     if (typeVisChanged || sourceChanged || allMeshes.length < filteredSourceLenRef.current) {
@@ -709,7 +710,7 @@ export function ViewportContainer() {
       filteredTypeModeRef.current = effectiveViewMode;
     }
 
-    const needsFilter = !typeVisibility.spaces || !typeVisibility.spatialZones || !typeVisibility.openings || !typeVisibility.virtualElements || !typeVisibility.site;
+    const needsFilter = !typeVisibility.spaces || !typeVisibility.spatialZones || !typeVisibility.openings || !typeVisibility.virtualElements || !typeVisibility.site || !typeVisibility.ifcAnnotations;
     const prevCacheLen = cache.length;
 
     // Only process NEW meshes since last run — O(batch_size) not O(total)
@@ -739,6 +740,12 @@ export function ViewportContainer() {
         if (ifcType === 'IfcOpeningElement' && !typeVisibility.openings) continue;
         if (ifcType === 'IfcVirtualElement' && !typeVisibility.virtualElements) continue;
         if (ifcType === 'IfcSite' && !typeVisibility.site) continue;
+        // IfcAnnotation can carry real 3D solid geometry (e.g. Bonsai
+        // plan-view "DRAWING" boxes) on top of the 2D symbolic curve overlay.
+        // The `ifcAnnotations` toggle drives the curve overlay (Viewport.tsx);
+        // honour it here too so the toggle also hides those 3D meshes instead
+        // of leaving them rendered as stray cubes (issue #1354).
+        if (ifcType === 'IfcAnnotation' && !typeVisibility.ifcAnnotations) continue;
       }
 
       // Mesh alpha flows through unchanged. The previous code re-multiplied

--- a/apps/viewer/src/store/basketVisibleSet.test.ts
+++ b/apps/viewer/src/store/basketVisibleSet.test.ts
@@ -255,6 +255,44 @@ describe('basketVisibleSet', () => {
     });
   });
 
+  describe('type visibility: IfcAnnotation (issue #1354)', () => {
+    const meshes = [
+      { expressId: 1, ifcType: 'IfcWall' },
+      { expressId: 2, ifcType: 'IfcAnnotation' },
+    ];
+
+    it('includes IfcAnnotation 3D meshes when the toggle is on', () => {
+      useViewerStore.setState({
+        selectedEntitiesSet: new Set(),
+        selectedEntity: null,
+        selectedEntityIds: new Set(),
+        hierarchyBasketSelection: new Set(),
+        geometryResult: { meshes } as any,
+        typeVisibility: { ...useViewerStore.getState().typeVisibility, ifcAnnotations: true },
+      });
+      invalidateVisibleBasketCache();
+
+      const refs = getVisibleBasketEntityRefsFromStore();
+      assert.ok(refs.some((r) => entityRefToString(r) === 'legacy:2'));
+    });
+
+    it('drops IfcAnnotation 3D meshes when the toggle is off', () => {
+      useViewerStore.setState({
+        selectedEntitiesSet: new Set(),
+        selectedEntity: null,
+        selectedEntityIds: new Set(),
+        hierarchyBasketSelection: new Set(),
+        geometryResult: { meshes } as any,
+        typeVisibility: { ...useViewerStore.getState().typeVisibility, ifcAnnotations: false },
+      });
+      invalidateVisibleBasketCache();
+
+      const refs = getVisibleBasketEntityRefsFromStore();
+      assert.ok(refs.some((r) => entityRefToString(r) === 'legacy:1'));
+      assert.ok(!refs.some((r) => entityRefToString(r) === 'legacy:2'));
+    });
+  });
+
   describe('federation: unresolved globalId in multi-model', () => {
     it('getBasketSelectionRefsFromStore returns array when models exist', () => {
       useViewerStore.setState({

--- a/apps/viewer/src/store/basketVisibleSet.test.ts
+++ b/apps/viewer/src/store/basketVisibleSet.test.ts
@@ -291,6 +291,26 @@ describe('basketVisibleSet', () => {
       assert.ok(refs.some((r) => entityRefToString(r) === 'legacy:1'));
       assert.ok(!refs.some((r) => entityRefToString(r) === 'legacy:2'));
     });
+
+    it('drops IfcAnnotation 3D meshes on the models (federated) path too', () => {
+      // The gate also runs through `state.models` in collectVisibleCandidates,
+      // not just the legacy `state.geometryResult` fallback. Lock both paths.
+      const model = { visible: true, idOffset: 0, geometryResult: { meshes } } as any;
+      useViewerStore.setState({
+        selectedEntitiesSet: new Set(),
+        selectedEntity: null,
+        selectedEntityIds: new Set(),
+        hierarchyBasketSelection: new Set(),
+        geometryResult: null,
+        models: new Map([['m1', model]]),
+        typeVisibility: { ...useViewerStore.getState().typeVisibility, ifcAnnotations: false },
+      });
+      invalidateVisibleBasketCache();
+
+      const refs = getVisibleBasketEntityRefsFromStore();
+      assert.ok(refs.some((r) => r.expressId === 1));
+      assert.ok(!refs.some((r) => r.expressId === 2));
+    });
   });
 
   describe('federation: unresolved globalId in multi-model', () => {

--- a/apps/viewer/src/store/basketVisibleSet.ts
+++ b/apps/viewer/src/store/basketVisibleSet.ts
@@ -113,6 +113,9 @@ function matchesTypeVisibility(ifcType: string | undefined, typeVisibility: View
   if (ifcType === 'IfcOpeningElement' && !typeVisibility.openings) return false;
   if (ifcType === 'IfcVirtualElement' && !typeVisibility.virtualElements) return false;
   if (ifcType === 'IfcSite' && !typeVisibility.site) return false;
+  // IfcAnnotation 3D mesh geometry (e.g. Bonsai plan-view boxes) tracks the
+  // same toggle that hides the 2D symbolic curve overlay (issue #1354).
+  if (ifcType === 'IfcAnnotation' && !typeVisibility.ifcAnnotations) return false;
   return true;
 }
 


### PR DESCRIPTION
## Problem

Closes #1354.

`IfcAnnotation` entities can carry **real 3D solid geometry** — e.g. the Bonsai plan-view "DRAWING" boxes in the issue render as grey cubes. The `Show Annotations` toggle (`typeVisibility.ifcAnnotations`) only drove the separate **2D symbolic curve overlay** (`useSymbolicAnnotations` in `Viewport.tsx`). The 3D meshes flow through the normal merged-geometry path, whose type filter handled `IfcSpace` / `IfcOpeningElement` / `IfcVirtualElement` / `IfcSite` but **never `IfcAnnotation`** — so the cubes always rendered and ignored the toggle.

## Fix

Gate `IfcAnnotation` meshes on `typeVisibility.ifcAnnotations` at the three existing type-visibility filter sites (the same three the other five toggles already live in):

- `ViewportContainer.tsx` — merged-geometry render filter (+ change-detection and `needsFilter` guards)
- `basketVisibleSet.ts` — `matchesTypeVisibility` (selection / list / isolation visible set)
- `GLBExportDialog.tsx` — `buildHiddenIfcTypes` (visible-only export parity)

Turning Annotations off now hides both the 2D overlay and the 3D cubes consistently. Default stays `true`, so users who want annotations see no change.

This does not tie anything to the section plane — it's a pure global type filter, consistent with the "annotations toggle is global" guidance.

## Scope note

This makes the toggle *effective*; the cubes still show by **default**. Flipping the default so Bonsai drawing annotations are hidden out-of-the-box is a separate decision (it would also hide legitimate annotations), left out of this PR.

## Tests

- New `basketVisibleSet` tests for #1354 (include-when-on / drop-when-off). Negative control confirmed the drop test fails without the gate.
- Full `basketVisibleSet` (16) and `visibilitySlice` (29) suites green.
- Viewer typecheck clean for touched files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the “visible only” export and viewport rendering to respect the **IfcAnnotation** type-visibility toggle.
  * Prevented annotation elements from appearing when **IfcAnnotations** is disabled, while keeping other visible entities intact.
  * Ensured geometry filtering and visibility results update correctly when type-visibility settings change.
* **Tests**
  * Added automated coverage to verify **IfcAnnotation** visibility is included/excluded appropriately, including the federated/models code path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->