### PR TITLE
feat(renderer): themeable overlay/section-cut line colour (#1359)

### DIFF
--- a/.changeset/themeable-overlay-line-color.md
+++ b/.changeset/themeable-overlay-line-color.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/renderer": minor
+---
+
+renderer: add `Renderer.setOverlayLineColor(rgba)` so the 3D overlay lines (annotation / alignment / grid) and the section-cut outline are themeable. The line shader previously hardcoded black, leaving these lines invisible on dark backgrounds; the colour now comes from a uniform and defaults to opaque black (no behaviour change unless set). Complements `SymbolicTextInput.color`, which already themes the matching labels.

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -177,6 +177,9 @@ export class Renderer {
     private canvas: HTMLCanvasElement;
     private sectionPlaneRenderer: SectionPlaneRenderer | null = null;
     private section2DOverlayRenderer: Section2DOverlayRenderer | null = null;
+    // Overlay/section-cut line colour, kept on the Renderer so it survives a
+    // pre-init call and a section2DOverlayRenderer re-creation (re-applied below).
+    private overlayLineColor: readonly [number, number, number, number] = [0, 0, 0, 1];
     // IfcAnnotation overlay pipelines (issue #653). Created on `init()` once
     // the device exists; nulled until then.
     private symbolicFillPipeline: SymbolicFillPipeline | null = null;
@@ -293,6 +296,8 @@ export class Renderer {
             this.device.getFormat(),
             this.pipeline.getSampleCount()
         );
+        // Re-apply any colour set before this (re)creation so it isn't lost.
+        this.section2DOverlayRenderer.setOverlayLineColor(this.overlayLineColor);
         // IfcAnnotation overlay pipelines (issue #653). Share the device +
         // presentation format AND the MSAA sample count + objectId attachment
         // shape with the rest of the renderer so they composite into the same
@@ -2682,22 +2687,25 @@ export class Renderer {
     }
 
     /**
-     * Upload pre-lifted 3D line-list vertices for the standalone annotation
-     * overlay. Each segment is `[x1, y1, z1, x2, y2, z2]` in world space.
-     * The overlay is drawn regardless of whether a section plane is active.
-     * Pass an empty Float32Array to clear.
-     */
-    /**
      * Set the colour of the overlay lines (annotation / alignment / grid) and the
      * section-cut outline (RGBA, 0..1). Defaults to opaque black; theme it to keep
      * lines legible on a dark canvas. The matching label colour is per-text via
      * `SymbolicTextInput.color` on `uploadAnnotationTexts3D`.
      */
     setOverlayLineColor(color: readonly [number, number, number, number]): void {
+        // Persist on the Renderer so a pre-init call (and any later overlay
+        // re-creation) keeps the colour — init() re-applies this.overlayLineColor.
+        this.overlayLineColor = color;
         this.section2DOverlayRenderer?.setOverlayLineColor(color);
         this.requestRender();
     }
 
+    /**
+     * Upload pre-lifted 3D line-list vertices for the standalone annotation
+     * overlay. Each segment is `[x1, y1, z1, x2, y2, z2]` in world space.
+     * The overlay is drawn regardless of whether a section plane is active.
+     * Pass an empty Float32Array to clear.
+     */
     uploadAnnotationLines3D(vertices: Float32Array): void {
         if (!this.section2DOverlayRenderer) return;
         this.section2DOverlayRenderer.uploadAnnotationLines3D(vertices);

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -2687,6 +2687,17 @@ export class Renderer {
      * The overlay is drawn regardless of whether a section plane is active.
      * Pass an empty Float32Array to clear.
      */
+    /**
+     * Set the colour of the overlay lines (annotation / alignment / grid) and the
+     * section-cut outline (RGBA, 0..1). Defaults to opaque black; theme it to keep
+     * lines legible on a dark canvas. The matching label colour is per-text via
+     * `SymbolicTextInput.color` on `uploadAnnotationTexts3D`.
+     */
+    setOverlayLineColor(color: readonly [number, number, number, number]): void {
+        this.section2DOverlayRenderer?.setOverlayLineColor(color);
+        this.requestRender();
+    }
+
     uploadAnnotationLines3D(vertices: Float32Array): void {
         if (!this.section2DOverlayRenderer) return;
         this.section2DOverlayRenderer.uploadAnnotationLines3D(vertices);

--- a/packages/renderer/src/section-2d-overlay.ts
+++ b/packages/renderer/src/section-2d-overlay.ts
@@ -116,6 +116,12 @@ export class Section2DOverlayRenderer {
   private sampleCount: number;
   private initialized = false;
 
+  // Colour for the standalone 3D overlay lines (annotation / alignment / grid)
+  // and the section-cut outline, which share the line pipeline. Defaults to
+  // opaque black for backwards compatibility; a consumer can theme it (e.g. light
+  // lines on a dark canvas) via setOverlayLineColor().
+  private overlayLineColor: readonly [number, number, number, number] = [0, 0, 0, 1];
+
   // Cached geometry buffers
   private fillVertexBuffer: GPUBuffer | null = null;
   private fillIndexBuffer: GPUBuffer | null = null;
@@ -296,9 +302,18 @@ export class Section2DOverlayRenderer {
     // Shader for lines (uniform color)
     const lineShader = this.device.createShaderModule({
       code: `
+        // Mirrors the fill shader's uniform layout so both pipelines can share
+        // one buffer; the line shader only reads viewProj, planeOffset and the
+        // appended lineColor (byte offset 144). capFillColor/… are unused here but
+        // declared for correct field offsets.
         struct Uniforms {
           viewProj: mat4x4<f32>,
           planeOffset: vec4<f32>,
+          capFillColor: vec4<f32>,
+          capStrokeColor: vec4<f32>,
+          params: vec4<f32>,
+          params2: vec4<f32>,
+          lineColor: vec4<f32>,
         }
         @binding(0) @group(0) var<uniform> uniforms: Uniforms;
 
@@ -334,7 +349,7 @@ export class Section2DOverlayRenderer {
         @fragment
         fn fs_main(input: VertexOutput) -> FragOutLine {
           var out: FragOutLine;
-          out.color    = vec4<f32>(0.0, 0.0, 0.0, 1.0);  // Black lines
+          out.color    = uniforms.lineColor;  // consumer-themeable (defaults black)
           out.objectId = vec4<f32>(0.0, 0.0, 0.0, 0.0);
           return out;
         }
@@ -455,11 +470,12 @@ export class Section2DOverlayRenderer {
     //   capStrokeColor — vec4          16 B
     //   params         — vec4          16 B   x=patternId, y=spacingPx, z=angleRad, w=widthPx
     //   params2        — vec4          16 B   x=secondaryAngleRad
-    // Total: 144 B. The extended layout lets the fill fragment shader
-    // apply the user's cap style (screen-space hatch + colour) directly
-    // over the exact polygon silhouette the 2D section cutter produced.
+    //   lineColor      — vec4          16 B   overlay/section-cut line colour
+    // Total: 160 B. The fill fragment shader reads up to params2 (144 B); the
+    // line shader reads viewProj/planeOffset + the appended lineColor (offset
+    // 144 B), so the two pipelines share this one buffer without aliasing.
     this.uniformBuffer = this.device.createBuffer({
-      size: 144,
+      size: 160,
       usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
     });
 
@@ -700,6 +716,16 @@ export class Section2DOverlayRenderer {
   }
 
   /**
+   * Set the colour of the overlay lines (annotation / alignment / grid) and the
+   * section-cut outline, which share the line pipeline. RGBA components are in
+   * 0..1. Defaults to opaque black; set e.g. a light colour to keep the lines
+   * legible on a dark canvas. Takes effect on the next draw.
+   */
+  setOverlayLineColor(color: readonly [number, number, number, number]): void {
+    this.overlayLineColor = color;
+  }
+
+  /**
    * Upload a flat Float32Array of 3D line-list vertices for the standalone
    * annotation overlay. Each segment is `[x1, y1, z1, x2, y2, z2]` in world
    * space. The buffer is independent of the section cut's line buffer and
@@ -790,9 +816,10 @@ export class Section2DOverlayRenderer {
     // Reuse the existing fill uniform buffer slot 0 (viewProj + planeOffset).
     // The line shader only reads those two fields, so the fill/cap-style
     // tail of the uniforms is harmless leftover data.
-    const uniforms = new Float32Array(20);
+    const uniforms = new Float32Array(40);
     uniforms.set(viewProj, 0);
     // planeOffset = 0 — vertices are already in world space.
+    uniforms.set(this.overlayLineColor, 36); // lineColor (byte offset 144)
     this.device.queue.writeBuffer(this.uniformBuffer, 0, uniforms);
 
     pass.setPipeline(this.linePipeline);
@@ -810,9 +837,10 @@ export class Section2DOverlayRenderer {
     if (!this.linePipeline || !this.uniformBuffer || !this.bindGroup) return;
     if (!this.alignmentLineVertexBuffer || this.alignmentLineVertexCount === 0) return;
 
-    const uniforms = new Float32Array(20);
+    const uniforms = new Float32Array(40);
     uniforms.set(viewProj, 0);
     // planeOffset = 0 — vertices are already in world space.
+    uniforms.set(this.overlayLineColor, 36); // lineColor (byte offset 144)
     this.device.queue.writeBuffer(this.uniformBuffer, 0, uniforms);
 
     pass.setPipeline(this.linePipeline);
@@ -867,9 +895,10 @@ export class Section2DOverlayRenderer {
     if (!this.linePipeline || !this.uniformBuffer || !this.bindGroup) return;
     if (!this.gridLineVertexBuffer || this.gridLineVertexCount === 0) return;
 
-    const uniforms = new Float32Array(20);
+    const uniforms = new Float32Array(40);
     uniforms.set(viewProj, 0);
     // planeOffset = 0 — vertices are already in world space.
+    uniforms.set(this.overlayLineColor, 36); // lineColor (byte offset 144)
     this.device.queue.writeBuffer(this.uniformBuffer, 0, uniforms);
 
     pass.setPipeline(this.linePipeline);
@@ -920,8 +949,10 @@ export class Section2DOverlayRenderer {
     //   24..27 capStrokeColor
     //   28..31 params  (patternId, spacingPx, angleRad, widthPx)
     //   32..35 params2 (secondaryAngleRad, _, _, _)
-    const uniforms = new Float32Array(36);
+    //   36..39 lineColor (section-cut outline colour)
+    const uniforms = new Float32Array(40);
     uniforms.set(viewProj, 0);
+    uniforms.set(this.overlayLineColor, 36); // section-cut outline colour
     uniforms[16] = offset[0];
     uniforms[17] = offset[1];
     uniforms[18] = offset[2];


### PR DESCRIPTION
## Summary

Fixes #1359. The 3D overlay lines (annotation / alignment / grid) and the section-cut outline shared a line shader that **hardcoded** `out.color = vec4<f32>(0.0, 0.0, 0.0, 1.0)`. On a dark canvas these lines were essentially invisible, and a consumer could theme the matching **labels** (`SymbolicTextInput.color`) but not the **lines**.

## Change

- Add a `lineColor` uniform to the line shader and drive `out.color` from it.
- New API: `Renderer.setOverlayLineColor(rgba)` (delegates to `Section2DOverlayRenderer.setOverlayLineColor`). RGBA in 0..1.
- **Default is opaque black**, so existing behaviour is unchanged unless a consumer sets it.

### Buffer layout note

The line and fill pipelines share one uniform buffer. `lineColor` is appended at **byte offset 144** (after the fill pipeline's `params2`), so it never aliases the fill cap-style fields — the section-cut outline keeps its own colour independent of `capFillColor`. Buffer grows 144 → 160 B; the line shader mirrors the fill struct's field offsets and reads `viewProj` / `planeOffset` / `lineColor`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for customizing overlay line color via `Renderer.setOverlayLineColor(rgba)`.
  * 3D annotation, alignment, grid, and section-cut outline line overlays now use the configured RGBA color.
  * If not set, the renderer keeps the prior look by defaulting to opaque black.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->