### PR TITLE
fix(renderer): keep colour-merged doors/windows pickable under isolation (#1358)

### DIFF
--- a/.changeset/fix-1358-pick-isolation-merged-filler.md
+++ b/.changeset/fix-1358-pick-isolation-merged-filler.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/renderer": patch
+---
+
+Fix picking of colour-merged fillers (IfcDoor / IfcWindow) under isolation. When a door or window is colour-fused into a batch keyed by its host wall or opening, its expressId lives only in the per-vertex `entityIds`, not in `batch.expressIds`. Picking now seeds its candidate set from the scene's authoritative mesh-data id set (`getAllMeshDataExpressIds()`), so an isolated door/window is hydrated and selectable instead of returning `null` from `pick()`. (#1358)

--- a/packages/renderer/src/picking-manager.test.ts
+++ b/packages/renderer/src/picking-manager.test.ts
@@ -60,4 +60,79 @@ describe('PickingManager', () => {
     assert.equal(pickerCalls, 0);
     assert.equal(meshCreations, 0);
   });
+
+  // Regression for #1358: a door/window colour-fused into a batch keyed by its
+  // host wall/opening must stay pickable under isolation. The filler's id lives
+  // only in the per-vertex entityIds (and thus in the scene's mesh-data id set),
+  // not in batch.expressIds — picking must hydrate it from the former.
+  it('hydrates and picks a colour-merged filler (door) isolated under a host batch', async () => {
+    const WALL = 200;
+    const DOOR = 201; // fused into the wall batch; absent from batch.expressIds
+
+    const camera = {
+      unprojectToRay: () => ({ origin: { x: 0, y: 0, z: 0 }, direction: { x: 0, y: 0, z: -1 } }),
+      getViewProjMatrix: () => ({ m: new Float32Array(16) }),
+    };
+
+    const createdMeshes: Array<{ expressId: number; modelIndex?: number }> = [];
+    let pickerMeshes: Array<{ expressId: number }> = [];
+
+    const scene = {
+      getMeshes: () => createdMeshes,
+      // Batch only carries the PRIMARY expressId (the wall) — the door is fused in.
+      getBatchedMeshes: () => [{ expressIds: [WALL] }],
+      isGeometryDataReleased: () => false,
+      // Authoritative pickable-id set DOES include the fused door (Scene.addMeshData
+      // registers a merged mesh under every per-vertex entityId).
+      getAllMeshDataExpressIds: () => [WALL, DOOR],
+      getMeshDataPieces: (expressId: number) =>
+        expressId === DOOR ? [{ expressId: DOOR }]
+        : expressId === WALL ? [{ expressId: WALL }]
+        : undefined,
+      getInstancedTemplates: () => undefined,
+      raycast: () => {
+        throw new Error('should not fall back to CPU raycast for a single isolated filler');
+      },
+    };
+
+    const picker = {
+      pick: async (
+        _x: number, _y: number, _w: number, _h: number,
+        meshes: Array<{ expressId: number }>,
+      ) => {
+        pickerMeshes = meshes;
+        const hit = meshes.find((m) => m.expressId === DOOR);
+        return hit ? { expressId: DOOR, modelIndex: 0 } : null;
+      },
+    };
+
+    const canvas = {
+      width: 100,
+      height: 100,
+      getBoundingClientRect: () => ({ width: 100, height: 100 }),
+    };
+
+    const manager = new PickingManager(
+      camera as never,
+      scene as never,
+      picker as never,
+      canvas as HTMLCanvasElement,
+      (piece) => {
+        createdMeshes.push({ expressId: piece.expressId, modelIndex: piece.modelIndex });
+      },
+    );
+
+    const result = await manager.pick(50, 50, { isolatedIds: new Set([DOOR]) });
+
+    // The door mesh was hydrated and passed to the GPU picker, which returned it.
+    assert.deepStrictEqual(result, { expressId: DOOR, modelIndex: 0 });
+    assert.ok(
+      createdMeshes.some((m) => m.expressId === DOOR),
+      'expected the isolated door piece to be hydrated for picking',
+    );
+    assert.ok(
+      pickerMeshes.every((m) => m.expressId === DOOR),
+      'expected only the isolated door to survive the isolation filter',
+    );
+  });
 });

--- a/packages/renderer/src/picking-manager.ts
+++ b/packages/renderer/src/picking-manager.ts
@@ -104,13 +104,15 @@ export class PickingManager {
                 };
             }
 
-            // Collect all expressIds from batched meshes
-            const expressIds = new Set<number>();
-            for (const batch of batchedMeshes) {
-                for (const expressId of batch.expressIds) {
-                    expressIds.add(expressId);
-                }
-            }
+            // Collect every pickable expressId. We use the scene's authoritative
+            // mesh-data id set rather than each batch's `expressIds`, because a batch
+            // only records the PRIMARY expressId of each merged piece. When a door or
+            // window is colour-fused into a batch keyed by its host wall / opening,
+            // the filler's id lives only in the per-vertex entityIds (registered in
+            // meshDataMap by Scene.addMeshData). Reading batch.expressIds alone would
+            // skip the filler, so under isolation its mesh is never hydrated and
+            // pick() returns null (#1358).
+            const expressIds = new Set<number>(this.scene.getAllMeshDataExpressIds());
 
             // Track how many individual mesh pieces already exist for each (expressId:modelIndex).
             // Multi-piece elements (windows/doors with submeshes) need all pieces for reliable picking.


### PR DESCRIPTION
## Problem

When the scene is isolated to only `IfcDoor` / `IfcWindow` elements, clicking the panel surface returns `null` from `pick()` even though the elements render and appear in the type facet (#1358).

## Root cause

Doors/windows are frequently **colour-fused** into a batch whose **primary** `expressId` belongs to the host wall or the `IfcOpeningElement`. `BatchedMesh.expressIds` records only that primary id per merged piece (`meshDataArray.map(m => m.expressId)`); the filler's id lives only in the per-vertex `entityIds`.

`PickingManager.pick()` seeded its candidate-id set from `batch.expressIds`, so an isolated door/window was never in the set → its individual pick mesh was never hydrated → the isolation filter dropped everything → `pick()` returned `null`.

(The CPU triangle raycaster already handled this correctly because it iterates `meshDataMap.keys()`, which `Scene.addMeshData` registers under *every* per-vertex entity. Only the GPU mesh-hydration path was affected.)

## Fix

Seed the picking candidate set from `Scene.getAllMeshDataExpressIds()` — the scene's authoritative pickable-id set, which already includes the per-vertex entity ids of colour-merged batches — instead of `batch.expressIds`. One line, no change to `batch.expressIds` semantics (so the visibility / colour-override / transparency routing that consume it are untouched).

## Tests

- New regression test in `picking-manager.test.ts`: a door fused into a wall-keyed batch (absent from `batch.expressIds`, present in the mesh-data id set) is hydrated and survives the isolation filter when isolated. **Verified it fails on the old code and passes on the fix.**
- Full renderer suite green: 163/163. `turbo typecheck --filter=@ifc-lite/renderer` clean.

Fixes #1358

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved picking for isolated colour-merged doors and windows so they can be selected correctly.
  * Fixed cases where isolated mesh pieces were not hydrated for picking when their IDs were only available through per-vertex data.
  * Made GPU picking more reliable under isolation, reducing reliance on fallback selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->