### PR TITLE
fix(viewer): allow editing/renaming a saved auto-color lens (#1365)

### DIFF
--- a/apps/viewer/src/components/viewer/LensPanel.tsx
+++ b/apps/viewer/src/components/viewer/LensPanel.tsx
@@ -1036,7 +1036,7 @@ function LensCard({
           </span>
         </div>
         <div className="flex items-center gap-1">
-          {onEdit && (
+          {onEdit && !lens.builtin && (
             <button
               onClick={(e) => { e.stopPropagation(); onEdit(lens); }}
               className="opacity-0 group-hover:opacity-100 text-zinc-400 hover:text-zinc-700 dark:text-zinc-500 dark:hover:text-zinc-200 p-0.5"

--- a/apps/viewer/src/components/viewer/LensPanel.tsx
+++ b/apps/viewer/src/components/viewer/LensPanel.tsx
@@ -26,6 +26,7 @@ import { downloadFile } from '@/lib/export/download';
 import { useViewerStore } from '@/store';
 import { useLens } from '@/hooks/useLens';
 import { createLensDataProvider } from '@/lib/lens';
+import { buildAutoColorLensToSave } from './lens-editor-utils';
 import type { Lens, LensRule, LensCriteria, AutoColorSpec, AutoColorLegendEntry, DiscoveredLensData } from '@/store/slices/lensSlice';
 import {
   LENS_PALETTE, ENTITY_ATTRIBUTE_NAMES, AUTO_COLOR_SOURCES,
@@ -798,7 +799,7 @@ function AutoColorEditor({
   discovered,
   onRequestDiscovery,
 }: {
-  initial: { name: string; autoColor: AutoColorSpec };
+  initial: { id?: string; name: string; autoColor: AutoColorSpec };
   onSave: (lens: Lens) => void;
   onCancel: () => void;
   discovered: DiscoveredLensData | null;
@@ -850,12 +851,11 @@ function AutoColorEditor({
     if (needsPset) autoColor.psetName = psetName.trim();
     if (needsPropertyName) autoColor.propertyName = propertyName.trim();
 
-    onSave({
-      id: `lens-auto-${Date.now()}`,
-      name: name.trim(),
-      rules: [],
-      autoColor,
-    });
+    onSave(buildAutoColorLensToSave(
+      initial,
+      { name: name.trim(), autoColor },
+      () => `lens-auto-${Date.now()}`,
+    ));
   };
 
   const canSave = name.trim().length > 0
@@ -1036,7 +1036,7 @@ function LensCard({
           </span>
         </div>
         <div className="flex items-center gap-1">
-          {onEdit && !isAutoColor && (
+          {onEdit && (
             <button
               onClick={(e) => { e.stopPropagation(); onEdit(lens); }}
               className="opacity-0 group-hover:opacity-100 text-zinc-400 hover:text-zinc-700 dark:text-zinc-500 dark:hover:text-zinc-200 p-0.5"
@@ -1354,14 +1354,25 @@ export function LensPanel({ onClose }: LensPanelProps) {
       <div className="flex-1 overflow-auto p-3 space-y-2">
         {savedLenses.map(lens => (
           editingLens?.id === lens.id ? (
-            <LensEditor
-              key={lens.id}
-              initial={editingLens}
-              onSave={handleSaveLens}
-              onCancel={() => setEditingLens(null)}
-              discovered={discoveredLensData}
-              onRequestDiscovery={handleRequestDiscovery}
-            />
+            editingLens.autoColor ? (
+              <AutoColorEditor
+                key={lens.id}
+                initial={{ id: editingLens.id, name: editingLens.name, autoColor: editingLens.autoColor }}
+                onSave={handleSaveLens}
+                onCancel={() => setEditingLens(null)}
+                discovered={discoveredLensData}
+                onRequestDiscovery={handleRequestDiscovery}
+              />
+            ) : (
+              <LensEditor
+                key={lens.id}
+                initial={editingLens}
+                onSave={handleSaveLens}
+                onCancel={() => setEditingLens(null)}
+                discovered={discoveredLensData}
+                onRequestDiscovery={handleRequestDiscovery}
+              />
+            )
           ) : (
             <LensCard
               key={lens.id}

--- a/apps/viewer/src/components/viewer/lens-editor-utils.test.ts
+++ b/apps/viewer/src/components/viewer/lens-editor-utils.test.ts
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { buildAutoColorLensToSave } from './lens-editor-utils.js';
+
+describe('buildAutoColorLensToSave (#1365)', () => {
+  it('preserves the existing id when editing a saved lens (so rename updates in place)', () => {
+    let generated = false;
+    const lens = buildAutoColorLensToSave(
+      { id: 'lens-auto-123' },
+      { name: 'Renamed lens', autoColor: { source: 'ifcType' } },
+      () => { generated = true; return 'lens-auto-SHOULD-NOT-BE-USED'; },
+    );
+
+    assert.equal(lens.id, 'lens-auto-123', 'editing must keep the original id');
+    assert.equal(generated, false, 'must not generate a new id when editing');
+    assert.equal(lens.name, 'Renamed lens');
+    assert.deepEqual(lens.autoColor, { source: 'ifcType' });
+    assert.deepEqual(lens.rules, []);
+  });
+
+  it('mints a fresh id only when creating a new lens (no initial id)', () => {
+    const lens = buildAutoColorLensToSave(
+      {},
+      { name: 'Color by IFC Class', autoColor: { source: 'property', psetName: 'Pset_X', propertyName: 'P' } },
+      () => 'lens-auto-FRESH',
+    );
+
+    assert.equal(lens.id, 'lens-auto-FRESH');
+    assert.equal(lens.name, 'Color by IFC Class');
+    assert.deepEqual(lens.autoColor, { source: 'property', psetName: 'Pset_X', propertyName: 'P' });
+  });
+});

--- a/apps/viewer/src/components/viewer/lens-editor-utils.ts
+++ b/apps/viewer/src/components/viewer/lens-editor-utils.ts
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { Lens, AutoColorSpec } from '@/store/slices/lensSlice';
+
+/**
+ * Build the {@link Lens} to persist from an auto-color editor session.
+ *
+ * When editing an existing lens (`initial.id` present) the id MUST be
+ * preserved so the save updates that lens in place. Only a brand-new lens
+ * (no `initial.id`) gets a freshly generated id. Regenerating the id on
+ * every save turned edits into duplicate lenses and made renaming a saved
+ * auto-color lens impossible (#1365).
+ */
+export function buildAutoColorLensToSave(
+  initial: { id?: string },
+  values: { name: string; autoColor: AutoColorSpec },
+  generateId: () => string,
+): Lens {
+  return {
+    id: initial.id ?? generateId(),
+    name: values.name,
+    rules: [],
+    autoColor: values.autoColor,
+  };
+}


### PR DESCRIPTION
## Problem

After creating an **Auto color** lens and saving it, it could not be edited — to change even just the name you had to delete and recreate it (#1365).

## Root cause

Three things combined:
1. The pencil **edit button was hidden** for auto-color lenses (`onEdit && !isAutoColor`).
2. Even if triggered, editing routed to the **rule editor** (`LensEditor`), which has no notion of `autoColor`.
3. `AutoColorEditor.handleSave()` always minted a **new id** (`lens-auto-${Date.now()}`), so a save while editing was treated as a *create* (duplicate) rather than an *update* — `handleSaveLens` decides create-vs-update by whether the id already exists.

## Fix

- Show the edit button for auto-color lenses.
- Route auto-color edits to `AutoColorEditor`, pre-filled with the existing lens (`id`, name, spec).
- Preserve the lens id on save via a small pure helper `buildAutoColorLensToSave(initial, values, generateId)` — existing id is kept when editing; a fresh id is generated only for a brand-new lens.

## Tests

- New `lens-editor-utils.test.ts` pins the id-preservation invariant: editing keeps the original id (and never calls the id generator); creating mints a fresh one. **Fails on the old logic, passes on the fix.**
- `turbo typecheck --filter=@ifc-lite/viewer` clean (29/29).

(`apps/viewer` is a private app — no changeset required.)

Fixes #1365

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved auto-color lens editing, including better handling of existing saved items and newly created ones.
  * The edit button now appears for all lenses when editing is available.
* **Bug Fixes**
  * Auto-color lens edits now preserve an existing lens ID when updating, or generate a new one when creating a fresh lens.
  * Editing now opens the correct editor for auto-color and rule-based lenses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->