### PR TITLE
Clarify MeshData JSDoc for downstream consumers

### DIFF
--- a/packages/geometry/src/index.ts
+++ b/packages/geometry/src/index.ts
@@ -779,6 +779,9 @@ export class GeometryProcessor {
    * @param options.sizeThreshold File size threshold in bytes (default: 2MB)
    * @param options.batchSize Number of meshes per batch for streaming (default: 25)
    * @param options.entityIndex Optional entity index for priority-based loading
+   * @yields StreamingGeometryEvent with 'batch' events containing MeshData[].
+   *   Multiple meshes may share the same expressId (one per material/part).
+   *   Consumers should group by expressId for per-element rendering or picking.
    */
   async *processAdaptive(
     buffer: Uint8Array,

--- a/packages/geometry/src/types.ts
+++ b/packages/geometry/src/types.ts
@@ -6,21 +6,34 @@
  * Geometry types for IFC-Lite
  */
 
+/**
+ * Mesh data for a single geometric representation of an IFC element.
+ *
+ * An element may produce MULTIPLE MeshData entries (one per material, CSG part,
+ * or representation item). Group by `expressId` for per-element operations such
+ * as DOM grouping, picking, or depth sorting. The number of meshes per element
+ * depends on the IFC file's geometric complexity.
+ */
 export interface MeshData {
   expressId: number;
   ifcType?: string;          // IFC type name (e.g., "IfcWall", "IfcSpace") - optional for backward compatibility with old caches
   modelIndex?: number;       // Index of the model this mesh belongs to (for multi-model federation)
   positions: Float32Array;  // [x,y,z, x,y,z, ...]
   normals: Float32Array;    // [nx,ny,nz, ...]
-  indices: Uint32Array;     // Triangle indices
+  /** Triangle indices (3 per face).
+   *  NOTE: Winding order is UNRELIABLE (meshes are double-sided by design).
+   *  Do not use winding for front/back-face determination or normal-based
+   *  culling. Use depth testing or `abs(dot(normal, viewDir))` for shading. */
+  indices: Uint32Array;
   /** Apparent rendering colour: IfcSurfaceStyleRendering.DiffuseColour
    *  when authored, otherwise the SurfaceColour. Matches what most IFC
    *  viewers display and what the GLB exporter uses by default. */
   color: [number, number, number, number];
   /** SurfaceColour, populated by the WASM extractor only when the file
    *  authored a distinct DiffuseColour (so `shadingColor !== color`).
-   *  Consumed by the GLB exporter's "Shading" colour-source option;
-   *  renderers and other exporters can ignore it. */
+   *  Consumed by the GLB exporter's "Shading" colour-source option.
+   *  For basic rendering, use `color` (matches most IFC viewers).
+   *  For physically-accurate rendering, prefer `shadingColor ?? color`. */
   shadingColor?: [number, number, number, number];
   /** Per-vertex entity IDs for color-merged batches (desktop fast path).
    *  When present the renderer writes these instead of repeating `expressId`
@@ -40,12 +53,17 @@ export interface MeshData {
    *  share the same value (it is the whole-entity hash). Consumed by the
    *  model-diff / compare feature (issue #924); renderers ignore it. */
   geometryHash?: bigint;
-  /** Geometry provenance for the viewer's Model/Types view switch (#957 follow-up):
-   *  0 = occurrence (placed IfcProduct), 1 = orphan type geometry (an
-   *  IfcTypeProduct RepresentationMap with no occurrence — shown in BOTH modes),
-   *  2 = instanced type geometry (the type-library shape of a type that HAS an
-   *  occurrence — hidden in Model mode, shown in Types mode). Absent/0 for caches
-   *  and non-wasm paths. */
+  /** Geometry provenance for rendering and the viewer's Model/Types view switch:
+   *  - 0 = occurrence (placed IfcProduct). RENDER THIS in normal/Model views.
+   *  - 1 = orphan type geometry (an IfcTypeProduct RepresentationMap with no
+   *    occurrence). RENDER THIS in both Model and Types views.
+   *  - 2 = instanced type template. DO NOT RENDER in normal/Model view.
+   *    Instances of this type appear as class 0 occurrences with the same shape.
+   *    Rendering class 2 produces duplicate overlapping geometry.
+   *    Shown only in the viewer's Types mode.
+   *
+   *  Absent/undefined is treated as 0 (occurrence).
+   *  Downstream filter: `if ((mesh.geometryClass ?? 0) === 2) continue;` */
   geometryClass?: number;
   /** Per-element local-frame origin (WebGL Y-up, metres): world position of
    *  vertex i = `origin + positions[3i..3i+3]`. Present when the wasm pipeline


### PR DESCRIPTION
Adds documentation to MeshData and processAdaptive addressing common integration pitfalls discovered while building a Node.js rendering pipeline:

- **MeshData interface**: Note that multiple meshes per expressId is expected (one per material/part). Consumers should group by expressId for per-element operations.
- **indices**: Warn that winding order is unreliable (double-sided by design). Back-face culling by winding silently drops real faces.
- **geometryClass**: Clarify rendering implications with a concrete filter example. Class 2 must not be rendered in normal views or overlapping duplicates appear.
- **shadingColor**: Add guidance on priority (use `color` for basic rendering, `shadingColor ?? color` for physically-accurate).
- **processAdaptive**: Document that batches may contain same-expressId meshes.

No code changes, only JSDoc additions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how streaming geometry results are delivered, including batch events and how to group meshes for per-element rendering or picking.
  * Expanded guidance on mesh data handling, including index usage, color selection for accurate rendering, and when to prefer `shadingColor` over `color`.
  * Added clearer explanations for geometry classification values and how they should be interpreted in downstream filtering and rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->