### PR TITLE
feat(lists,lens): add PredefinedType as a List & Lens attribute (#1364)

### DIFF
--- a/.changeset/feat-1364-predefined-type-attribute.md
+++ b/.changeset/feat-1364-predefined-type-attribute.md
@@ -1,0 +1,6 @@
+---
+"@ifc-lite/lists": minor
+"@ifc-lite/lens": minor
+---
+
+Expose IFC `PredefinedType` as a selectable entity attribute in Lists and Lens. `ENTITY_ATTRIBUTES` (lists) and `ENTITY_ATTRIBUTE_NAMES` (lens) now include `PredefinedType`, so it can be used as a List column / condition and as a Lens "color by attribute" / rule criterion. The list engine resolves it through a new optional `ListDataProvider.getEntityPredefinedType(expressId)` accessor (implementers without it degrade gracefully). (#1364)

--- a/apps/viewer/src/lib/entity-predefined-type.test.ts
+++ b/apps/viewer/src/lib/entity-predefined-type.test.ts
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { pickPredefinedType } from './entity-predefined-type.js';
+
+describe('pickPredefinedType (#1364)', () => {
+  it('returns the PredefinedType enum token from schema-named attributes', () => {
+    const attrs = [
+      { name: 'Name', value: 'Floor:Generic 150mm' },
+      { name: 'ObjectType', value: 'Floor:Generic 150mm' },
+      { name: 'PredefinedType', value: 'FLOOR' }, // markers already stripped by the extractor
+    ];
+    assert.equal(pickPredefinedType(attrs), 'FLOOR');
+  });
+
+  it('returns USERDEFINED / NOTDEFINED tokens verbatim (they are valid buckets)', () => {
+    assert.equal(pickPredefinedType([{ name: 'PredefinedType', value: 'USERDEFINED' }]), 'USERDEFINED');
+    assert.equal(pickPredefinedType([{ name: 'PredefinedType', value: 'NOTDEFINED' }]), 'NOTDEFINED');
+  });
+
+  it('returns undefined when the slot is absent', () => {
+    assert.equal(pickPredefinedType([{ name: 'Name', value: 'Wall-01' }]), undefined);
+  });
+
+  it('returns undefined when the slot is present but empty', () => {
+    assert.equal(pickPredefinedType([{ name: 'PredefinedType', value: '' }]), undefined);
+    assert.equal(pickPredefinedType([{ name: 'PredefinedType', value: '   ' }]), undefined);
+  });
+});

--- a/apps/viewer/src/lib/entity-predefined-type.ts
+++ b/apps/viewer/src/lib/entity-predefined-type.ts
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { extractAllEntityAttributes, type IfcDataStore } from '@ifc-lite/parser';
+
+/**
+ * Pick the `PredefinedType` value out of the schema-named attribute pairs
+ * returned by {@link extractAllEntityAttributes}. The extractor already strips
+ * the STEP enum markers (`.FLOOR.` → `FLOOR`), so this returns the display
+ * token (e.g. `"FLOOR"`, `"FLOORING"`, `"USERDEFINED"`, `"NOTDEFINED"`).
+ * Returns `undefined` when the slot is absent or empty so callers can ghost /
+ * skip elements that carry no PredefinedType.
+ */
+export function pickPredefinedType(
+  attrs: ReadonlyArray<{ name: string; value: string | number | boolean }>,
+): string | undefined {
+  const entry = attrs.find((a) => a.name === 'PredefinedType');
+  if (!entry) return undefined;
+  const value = String(entry.value).trim();
+  return value.length > 0 ? value : undefined;
+}
+
+/**
+ * Resolve an entity's IFC `PredefinedType` (e.g. `IfcSlab.FLOOR`,
+ * `IfcCovering.FLOORING`) from the source buffer. Schema-driven, so it works
+ * for any product type whose attribute layout the registry knows. (#1364)
+ *
+ * Like `Tag` and the property / quantity auto-color sources, this re-parses
+ * the entity on demand — there is no columnar PredefinedType accessor — which
+ * is the same cost class as those existing per-entity attribute reads.
+ */
+export function resolveEntityPredefinedType(
+  store: IfcDataStore,
+  expressId: number,
+): string | undefined {
+  if (!(store.source?.length > 0) || !store.entityIndex) return undefined;
+  return pickPredefinedType(extractAllEntityAttributes(store, expressId));
+}

--- a/apps/viewer/src/lib/lens/adapter.ts
+++ b/apps/viewer/src/lib/lens/adapter.ts
@@ -21,6 +21,7 @@ import {
   extractClassificationsOnDemand,
   extractMaterialsOnDemand,
 } from '@ifc-lite/parser';
+import { resolveEntityPredefinedType } from '@/lib/entity-predefined-type';
 import { toGlobalIdFromModels } from '@/store/globalId';
 import type { FederatedModel } from '@/store/types';
 
@@ -190,6 +191,9 @@ export function createLensDataProvider(
           if (ot) return ot;
           break;
         }
+        case 'PredefinedType':
+          // No columnar accessor — resolve from the source buffer (#1364).
+          return resolveEntityPredefinedType(store, id);
         case 'Tag':
           // Tag is not stored in columnar — always on-demand
           break;

--- a/apps/viewer/src/lib/lists/adapter.ts
+++ b/apps/viewer/src/lib/lists/adapter.ts
@@ -22,6 +22,7 @@ import {
 import type { PropertySet, QuantitySet } from '@ifc-lite/data';
 import { ENTITY_ATTRIBUTES } from '@ifc-lite/lists';
 import type { ListDataProvider, ListClassificationRef, DiscoveredColumns } from '@ifc-lite/lists';
+import { resolveEntityPredefinedType } from '../entity-predefined-type.js';
 
 /** Collect every material-name string an element exposes — top-level
  *  material plus layer / constituent / profile names and list members. */
@@ -67,6 +68,17 @@ export function createListDataProvider(store: IfcDataStore): ListDataProvider {
     return empty;
   }
 
+  // PredefinedType re-parses the entity (no columnar accessor); cache it so
+  // a list column doesn't re-extract per row across re-renders.
+  const predefCache = new Map<number, string>();
+  function getPredefinedTypeFor(id: number): string {
+    const cached = predefCache.get(id);
+    if (cached !== undefined) return cached;
+    const value = resolveEntityPredefinedType(store, id) ?? '';
+    predefCache.set(id, value);
+    return value;
+  }
+
   // Complete column discovery is cached — the provider outlives a builder
   // open, and the scan touches every entity that declares a pset/qto.
   let columnsCache: DiscoveredColumns | null = null;
@@ -91,6 +103,7 @@ export function createListDataProvider(store: IfcDataStore): ListDataProvider {
     getEntityGlobalId: (id) => store.entities.getGlobalId(id),
     getEntityDescription: (id) => store.entities.getDescription(id) || getOnDemandAttrs(id).description,
     getEntityObjectType: (id) => store.entities.getObjectType(id) || getOnDemandAttrs(id).objectType,
+    getEntityPredefinedType: (id) => getPredefinedTypeFor(id),
     getEntityTag: (id) => getOnDemandAttrs(id).tag,
     getEntityTypeName: (id) => store.entities.getTypeName(id),
 

--- a/packages/lens/src/types.ts
+++ b/packages/lens/src/types.ts
@@ -259,7 +259,7 @@ export const LENS_CRITERIA_TYPES = [
 
 /** Common entity attribute names for the lens rule editor */
 export const ENTITY_ATTRIBUTE_NAMES = [
-  'Name', 'Description', 'ObjectType', 'Tag',
+  'Name', 'Description', 'ObjectType', 'PredefinedType', 'Tag',
 ] as const;
 
 /** Common IFC classes for lens rule editor UI */

--- a/packages/lists/src/engine.test.ts
+++ b/packages/lists/src/engine.test.ts
@@ -84,6 +84,12 @@ function createMockProvider(): ListDataProvider {
     [3, 'Level 0'],
   ]);
 
+  const predefinedTypes = new Map<number, string>([
+    [1, 'SOLIDWALL'],
+    // entity 2 intentionally has no PredefinedType
+    [3, 'FLOOR'],
+  ]);
+
   return {
     getEntitiesByType: (type) => typeIndex.get(type) ?? [],
     getEntityName: (id) => entities.get(id)?.name ?? '',
@@ -98,6 +104,7 @@ function createMockProvider(): ListDataProvider {
     getMaterialNames: (id) => materialNames.get(id) ?? [],
     getClassifications: (id) => classifications.get(id) ?? [],
     getStoreyName: (id) => storeyNames.get(id) ?? '',
+    getEntityPredefinedType: (id) => predefinedTypes.get(id) ?? '',
   };
 }
 
@@ -126,6 +133,30 @@ describe('executeList', () => {
     expect(result.rows[0].values[0]).toBe('Wall-01');
     expect(result.rows[1].values[0]).toBe('Wall-02');
     expect(result.rows[0].values[1]).toBe('IfcWall');
+  });
+
+  // #1364: PredefinedType is selectable as an entity attribute column.
+  it('resolves the PredefinedType attribute column', () => {
+    const provider = createMockProvider();
+    const def: ListDefinition = {
+      id: 'predef',
+      name: 'PredefinedType',
+      createdAt: 0,
+      updatedAt: 0,
+      entityTypes: [IfcTypeEnum.IfcWall, IfcTypeEnum.IfcSlab],
+      conditions: [],
+      columns: [
+        { id: 'name', source: 'attribute', propertyName: 'Name' },
+        { id: 'predef', source: 'attribute', propertyName: 'PredefinedType' },
+      ],
+    };
+
+    const result = executeList(def, provider);
+    const byName = new Map(result.rows.map(r => [r.values[0], r.values[1]]));
+    expect(byName.get('Wall-01')).toBe('SOLIDWALL');
+    expect(byName.get('Slab-01')).toBe('FLOOR');
+    // Element without a PredefinedType yields null, not a fabricated value.
+    expect(byName.get('Wall-02')).toBe(null);
   });
 
   it('extracts property values with IFC type resolution', () => {

--- a/packages/lists/src/engine.ts
+++ b/packages/lists/src/engine.ts
@@ -370,6 +370,8 @@ function getAttributeValue(entityId: number, attrName: string, provider: ListDat
       return provider.getEntityDescription(entityId) || null;
     case 'ObjectType':
       return provider.getEntityObjectType(entityId) || null;
+    case 'PredefinedType':
+      return provider.getEntityPredefinedType?.(entityId) || null;
     case 'Tag':
       return provider.getEntityTag(entityId) || null;
     default:

--- a/packages/lists/src/types.ts
+++ b/packages/lists/src/types.ts
@@ -71,6 +71,9 @@ export interface ListDataProvider {
   getClassifications?(expressId: number): ListClassificationRef[];
   /** Building-storey name the element belongs to, or '' when unplaced. */
   getStoreyName?(expressId: number): string;
+  /** IFC `PredefinedType` enum token (e.g. "FLOOR", "FLOORING"), or '' when
+   *  the element has none. Used by the `PredefinedType` attribute column. */
+  getEntityPredefinedType?(expressId: number): string;
   /**
    * Discover EVERY property set / property and quantity set / quantity in
    * the model — complete and independent of entity-type selection — so the
@@ -248,6 +251,7 @@ export const ENTITY_ATTRIBUTES = [
   'Class',
   'Description',
   'ObjectType',
+  'PredefinedType',
   'Tag',
 ] as const;
 


### PR DESCRIPTION
## Request

`PredefinedType` is an IFC attribute (e.g. `IfcSlab.PredefinedType = FLOOR`, `IfcCovering.PredefinedType = FLOORING`). Users want it available wherever an attribute can be chosen — List columns/conditions and Lens "color by" rules — e.g. to filter FLOORING down to floor tiles, or color elements by predefined type (#1364).

## Change

`PredefinedType` is now a first-class entity attribute:

- **`@ifc-lite/lists`**: added to `ENTITY_ATTRIBUTES`, so it appears in the List column picker and condition attribute selector. The engine resolves it via a new **optional** `ListDataProvider.getEntityPredefinedType(expressId)` (implementers without it degrade gracefully — no breaking change).
- **`@ifc-lite/lens`**: added to `ENTITY_ATTRIBUTE_NAMES`, so it appears in both the rule-criterion attribute dropdown and the auto-color "by attribute" dropdown. The lens engine already routes any attribute name through `getEntityAttribute`.
- **viewer**: a shared `resolveEntityPredefinedType(store, expressId)` helper resolves the enum token (`FLOOR`, `FLOORING`, …) from the source buffer via the schema-driven `extractAllEntityAttributes` (markers stripped). Wired into both the lens and lists data providers; the lists provider caches per entity.

## Notes

- Resolution is on-demand (re-parses the entity) — the **same cost class** as `Tag` and the existing `property`/`quantity` auto-color sources; only `ObjectType` has a columnar fast path. No new columnar storage / cache-format bump.
- `USERDEFINED` / `NOTDEFINED` are surfaced verbatim (valid buckets); absent/empty resolves to no value (ghosted / null cell).
- No public top-level export was added/removed/renamed, so `scripts/api-surface.json` is unchanged; a minor changeset bumps `@ifc-lite/lists` + `@ifc-lite/lens`.

## Tests

- `pickPredefinedType` pure helper (token extraction, absent/empty → undefined): 4/4.
- `@ifc-lite/lists` engine: new `PredefinedType` column test (`SOLIDWALL`/`FLOOR`, absent → null); 26/26.
- `@ifc-lite/lens` 82/82. `turbo typecheck` clean for lists, lens, viewer (29/29).

Closes #1364