### PR TITLE
fix(lens): By-Material groups by individual materials, not the layer-set name (#1366)

### DIFF
--- a/.changeset/fix-1366-by-material-individual.md
+++ b/.changeset/fix-1366-by-material-individual.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/lens": minor
+---
+
+"Color/select by Material" now groups by individual materials instead of the layer-set / usage name. A multi-layer element (e.g. a wall of gypsum board + insulation) now belongs to each of its materials' groups, so selecting "gypsum board" isolates every wall containing it — including multi-layer walls — and the legend lists the real materials rather than the Revit family/type string. Material rule criteria (`materialName`) match the same way. Adds an optional `LensDataProvider.getMaterialNames(globalId)` accessor; providers without it fall back to the previous single `getMaterialName` value. (#1366)

--- a/apps/viewer/src/lib/lens-material-names.test.ts
+++ b/apps/viewer/src/lib/lens-material-names.test.ts
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { lensMaterialNames } from './lens-material-names.js';
+
+describe('lensMaterialNames (#1366)', () => {
+  it('returns each layer material of a multi-layer set, not the layer-set name', () => {
+    const info = {
+      type: 'MaterialLayerSet' as const,
+      name: 'Basic Wall: Ext - Gyp/Ins', // layer-set / Revit type name — must NOT become a bucket
+      layers: [
+        { materialName: 'Gypsum Board', name: 'Finish' },
+        { materialName: 'Insulation', name: 'Thermal' },
+      ],
+    };
+    assert.deepEqual(lensMaterialNames(info), ['Gypsum Board', 'Insulation']);
+  });
+
+  it('de-duplicates repeated materials (gyp / ins / gyp -> two distinct)', () => {
+    const info = {
+      type: 'MaterialLayerSet' as const,
+      name: 'Wall Type X',
+      layers: [
+        { materialName: 'Gypsum Board' },
+        { materialName: 'Insulation' },
+        { materialName: 'Gypsum Board' },
+      ],
+    };
+    assert.deepEqual(lensMaterialNames(info), ['Gypsum Board', 'Insulation']);
+  });
+
+  it('falls back to the top-level name for a single plain material', () => {
+    const info = { type: 'Material' as const, name: 'Steel S355' };
+    assert.deepEqual(lensMaterialNames(info), ['Steel S355']);
+  });
+
+  it('collects constituent and profile materials', () => {
+    assert.deepEqual(
+      lensMaterialNames({ type: 'MaterialConstituentSet' as const, name: 'set', constituents: [{ materialName: 'Concrete' }, { materialName: 'Rebar' }] }),
+      ['Concrete', 'Rebar'],
+    );
+    assert.deepEqual(
+      lensMaterialNames({ type: 'MaterialProfileSet' as const, name: 'set', profiles: [{ materialName: 'Steel' }] }),
+      ['Steel'],
+    );
+  });
+
+  it('returns [] for no material info', () => {
+    assert.deepEqual(lensMaterialNames(null), []);
+    assert.deepEqual(lensMaterialNames(undefined), []);
+  });
+});

--- a/apps/viewer/src/lib/lens-material-names.ts
+++ b/apps/viewer/src/lib/lens-material-names.ts
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { MaterialInfo } from '@ifc-lite/parser';
+
+/**
+ * Collect the distinct *individual* material names for an element from its
+ * resolved {@link MaterialInfo} — each layer / constituent / profile / list
+ * material. Deliberately excludes the layer-set / usage name (`info.name`,
+ * which for Revit exports is the family+type, not a material) UNLESS the
+ * element has no sub-structure, in which case the top-level name IS the single
+ * material. Order-preserving and de-duplicated, so a wall layered
+ * gypsumboard / insulation / gypsumboard yields `["gypsumboard", "insulation"]`
+ * and the element can be grouped/selected under each material. (#1366)
+ */
+export function lensMaterialNames(info: MaterialInfo | null | undefined): string[] {
+  if (!info) return [];
+  const seen = new Set<string>();
+  const add = (s?: string) => {
+    const t = s?.trim();
+    if (t) seen.add(t);
+  };
+  for (const l of info.layers ?? []) add(l.materialName);
+  for (const c of info.constituents ?? []) add(c.materialName);
+  for (const p of info.profiles ?? []) add(p.materialName);
+  for (const m of info.materials ?? []) add(m.name);
+  // No sub-structure → the element carries a single plain material.
+  if (seen.size === 0) add(info.name);
+  return [...seen];
+}

--- a/apps/viewer/src/lib/lens/adapter.ts
+++ b/apps/viewer/src/lib/lens/adapter.ts
@@ -22,6 +22,7 @@ import {
   extractMaterialsOnDemand,
 } from '@ifc-lite/parser';
 import { resolveEntityPredefinedType } from '@/lib/entity-predefined-type';
+import { lensMaterialNames } from '@/lib/lens-material-names';
 import { toGlobalIdFromModels } from '@/store/globalId';
 import type { FederatedModel } from '@/store/types';
 
@@ -292,6 +293,13 @@ export function createLensDataProvider(
       if (info.profiles?.length) return info.profiles[0].materialName;
       if (info.materials?.length) return info.materials[0]?.name;
       return undefined;
+    },
+
+    getMaterialNames(globalId: number): string[] {
+      const resolved = resolveGlobalId(globalId, entries);
+      if (!resolved) return [];
+      const store = resolved.entry.ifcDataStore;
+      return lensMaterialNames(extractMaterialsOnDemand(store, resolved.expressId));
     },
 
     getModelId(globalId: number): string | undefined {

--- a/packages/lens/src/discovery.ts
+++ b/packages/lens/src/discovery.ts
@@ -131,9 +131,18 @@ export function discoverDataSources(
       }
     }
 
-    if (materials && provider.getMaterialName) {
-      const mat = provider.getMaterialName(globalId);
-      if (mat) materials.add(mat);
+    if (materials) {
+      // Prefer individual material names so the rule dropdown offers real
+      // materials (e.g. "Gypsum", "Insulation") rather than the layer-set /
+      // family-type string. Fall back to the single name. (#1366)
+      if (provider.getMaterialNames) {
+        for (const n of provider.getMaterialNames(globalId)) {
+          if (n) materials.add(n);
+        }
+      } else if (provider.getMaterialName) {
+        const mat = provider.getMaterialName(globalId);
+        if (mat) materials.add(mat);
+      }
     }
   }
 

--- a/packages/lens/src/engine.test.ts
+++ b/packages/lens/src/engine.test.ts
@@ -267,6 +267,53 @@ describe('evaluateAutoColorLens', () => {
     expect(result.executionTime).toBeGreaterThanOrEqual(0);
   });
 
+  it('should group a multi-material element under EVERY one of its materials (#1366)', () => {
+    // 4 walls with Gypsum, plus Insulation on three of them; one is single-mat.
+    const materials = new Map<number, string[]>([
+      [1, ['Gypsum']],
+      [2, ['Gypsum', 'Insulation']],
+      [3, ['Gypsum', 'Insulation']],
+      [4, ['Insulation']],
+    ]);
+    const provider: LensDataProvider = {
+      getEntityCount: () => materials.size,
+      forEachEntity: (cb) => { for (const id of materials.keys()) cb(id, 'm1'); },
+      getEntityType: () => 'IfcWall',
+      getPropertyValue: () => undefined,
+      getPropertySets: () => [],
+      getMaterialNames: (id) => materials.get(id) ?? [],
+    };
+
+    const result = evaluateAutoColorLens({ source: 'material' }, provider);
+
+    const byName = new Map(result.legend.map(e => [e.name, e]));
+    expect(new Set(byName.keys())).toEqual(new Set(['Gypsum', 'Insulation']));
+    // Gypsum: walls 1,2,3 — Insulation: walls 2,3,4. Multi-material walls
+    // appear in BOTH buckets (previously they bucketed by the layer-set name).
+    expect(new Set(result.ruleEntityIds.get(byName.get('Gypsum')!.id))).toEqual(new Set([1, 2, 3]));
+    expect(new Set(result.ruleEntityIds.get(byName.get('Insulation')!.id))).toEqual(new Set([2, 3, 4]));
+    expect(byName.get('Gypsum')!.count).toBe(3);
+    expect(byName.get('Insulation')!.count).toBe(3);
+    // Every element still renders in exactly one colour.
+    for (const id of materials.keys()) {
+      expect(result.colorMap.has(id)).toBe(true);
+    }
+  });
+
+  it('falls back to single getMaterialName when getMaterialNames is absent', () => {
+    const provider: LensDataProvider = {
+      getEntityCount: () => 1,
+      forEachEntity: (cb) => cb(1, 'm1'),
+      getEntityType: () => 'IfcWall',
+      getPropertyValue: () => undefined,
+      getPropertySets: () => [],
+      getMaterialName: () => 'Concrete',
+    };
+    const result = evaluateAutoColorLens({ source: 'material' }, provider);
+    expect(result.legend.map(e => e.name)).toEqual(['Concrete']);
+    expect(result.ruleEntityIds.get(result.legend[0].id)).toEqual([1]);
+  });
+
   it('should auto-color by property when provider supports getPropertyValue', () => {
     const entities = [
       { id: 1, type: 'IfcWall' },

--- a/packages/lens/src/engine.ts
+++ b/packages/lens/src/engine.ts
@@ -139,20 +139,24 @@ export function evaluateAutoColorLens(
   const ghostIds: number[] = [];
 
   provider.forEachEntity((globalId) => {
-    const raw = extractAutoColorValue(autoColor, globalId, provider);
-    const value = raw != null ? String(raw).trim() : '';
+    // Most sources yield a single value; `material` can yield several — an
+    // element built from a layer / constituent set belongs to EVERY one of its
+    // materials, so it may join multiple value groups (#1366).
+    const values = extractAutoColorValues(autoColor, globalId, provider);
 
-    if (value === '') {
+    if (values.length === 0) {
       ghostIds.push(globalId);
       return;
     }
 
-    let group = valueGroups.get(value);
-    if (!group) {
-      group = [];
-      valueGroups.set(value, group);
+    for (const value of values) {
+      let group = valueGroups.get(value);
+      if (!group) {
+        group = [];
+        valueGroups.set(value, group);
+      }
+      group.push(globalId);
     }
-    group.push(globalId);
   });
 
   // Phase 2: Sort distinct values by entity count (descending) for best color allocation
@@ -173,7 +177,10 @@ export function evaluateAutoColorLens(
     const rgba = hexToRgba(color, 1);
 
     for (const id of entityIds) {
-      colorMap.set(id, rgba);
+      // An element may belong to several value groups (e.g. multi-material).
+      // It renders in a single colour, so the first group wins — groups are
+      // sorted by count desc, so that is the element's largest material group.
+      if (!colorMap.has(id)) colorMap.set(id, rgba);
     }
 
     ruleCounts.set(ruleId, entityIds.length);
@@ -197,6 +204,37 @@ export function evaluateAutoColorLens(
     legend,
     executionTime: performance.now() - startTime,
   };
+}
+
+/**
+ * Extract every distinct value an entity should be grouped under. Only
+ * `material` is multi-valued — an element with a layer / constituent set
+ * belongs to each of its individual materials; all other sources collapse to
+ * a single value. Values are trimmed and de-duplicated; empties are dropped.
+ * Falls back to the single-valued {@link extractAutoColorValue} when the
+ * multi-material accessor is unavailable. (#1366)
+ */
+function extractAutoColorValues(
+  spec: AutoColorSpec,
+  globalId: number,
+  provider: LensDataProvider,
+): string[] {
+  if (spec.source === 'material' && provider.getMaterialNames) {
+    const names = provider.getMaterialNames(globalId);
+    if (names && names.length > 0) {
+      const seen = new Set<string>();
+      for (const n of names) {
+        const t = (n ?? '').trim();
+        if (t) seen.add(t);
+      }
+      if (seen.size > 0) return [...seen];
+    }
+    // else fall through to the single-valued accessor
+  }
+
+  const raw = extractAutoColorValue(spec, globalId, provider);
+  const value = raw != null ? String(raw).trim() : '';
+  return value === '' ? [] : [value];
 }
 
 /**

--- a/packages/lens/src/matching.test.ts
+++ b/packages/lens/src/matching.test.ts
@@ -423,3 +423,37 @@ describe('matchesCriteria — model', () => {
     expect(matchesCriteria(c, 1, createModelProvider(false))).toBe(false);
   });
 });
+
+describe('matchesCriteria — material (#1366)', () => {
+  // A layered wall: layer-set name from getMaterialName, individual materials
+  // from getMaterialNames.
+  const provider: LensDataProvider = {
+    getEntityCount: () => 1,
+    forEachEntity: (cb) => cb(1, 'm1'),
+    getEntityType: () => 'IfcWall',
+    getPropertyValue: () => undefined,
+    getPropertySets: () => [],
+    getMaterialName: () => 'Basic Wall: Ext - Gyp/Ins',
+    getMaterialNames: () => ['Gypsum Board', 'Insulation'],
+  };
+  const rule = (materialName: string): LensCriteria => ({ type: 'material', materialName });
+
+  it('matches an individual constituent material', () => {
+    expect(matchesCriteria(rule('gypsum'), 1, provider)).toBe(true);
+    expect(matchesCriteria(rule('insulation'), 1, provider)).toBe(true);
+  });
+
+  it('still matches the layer-set / single name (no regression for dropdown rules)', () => {
+    expect(matchesCriteria(rule('Basic Wall'), 1, provider)).toBe(true);
+  });
+
+  it('does not match an unrelated material', () => {
+    expect(matchesCriteria(rule('steel'), 1, provider)).toBe(false);
+  });
+
+  it('matches via getMaterialName when getMaterialNames is absent', () => {
+    const single: LensDataProvider = { ...provider, getMaterialNames: undefined };
+    expect(matchesCriteria(rule('Gyp/Ins'), 1, single)).toBe(true);
+    expect(matchesCriteria(rule('brick'), 1, single)).toBe(false);
+  });
+});

--- a/packages/lens/src/matching.ts
+++ b/packages/lens/src/matching.ts
@@ -96,23 +96,18 @@ function matchesMaterial(
 
   const pattern = criteria.materialName.toLowerCase();
 
-  // Prefer the individual-material accessor: a multi-layer element should
-  // match on any of its constituent materials (e.g. "gypsumboard" matches a
-  // wall whose layer set also contains insulation), not just the layer-set
-  // name that getMaterialName returns. (#1366)
-  if (provider.getMaterialNames) {
-    const names = provider.getMaterialNames(globalId);
-    if (names && names.length > 0) {
-      return names.some((n) => n.toLowerCase().includes(pattern));
-    }
-  }
-
-  // Fall back to the single material-name accessor when available.
-  if (provider.getMaterialName) {
-    const matName = provider.getMaterialName(globalId);
-    if (matName) {
-      return matName.toLowerCase().includes(pattern);
-    }
+  // Match against BOTH the individual constituent materials AND the single /
+  // layer-set name. A multi-layer element should match on any of its materials
+  // ("gypsumboard" matches a wall whose layer set also has insulation), and a
+  // rule built from the discovery dropdown — which may surface either an
+  // individual name or the layer-set name (e.g. "Basic Wall: Ext - Gyp/Ins") —
+  // must still match. Checking only one accessor regressed the other. (#1366)
+  if (provider.getMaterialNames || provider.getMaterialName) {
+    const names = provider.getMaterialNames?.(globalId);
+    if (names && names.some((n) => n.toLowerCase().includes(pattern))) return true;
+    const matName = provider.getMaterialName?.(globalId);
+    if (matName && matName.toLowerCase().includes(pattern)) return true;
+    // A dedicated material accessor exists; don't fall through to the pset scan.
     return false;
   }
 

--- a/packages/lens/src/matching.ts
+++ b/packages/lens/src/matching.ts
@@ -96,7 +96,18 @@ function matchesMaterial(
 
   const pattern = criteria.materialName.toLowerCase();
 
-  // Prefer dedicated material accessor if available
+  // Prefer the individual-material accessor: a multi-layer element should
+  // match on any of its constituent materials (e.g. "gypsumboard" matches a
+  // wall whose layer set also contains insulation), not just the layer-set
+  // name that getMaterialName returns. (#1366)
+  if (provider.getMaterialNames) {
+    const names = provider.getMaterialNames(globalId);
+    if (names && names.length > 0) {
+      return names.some((n) => n.toLowerCase().includes(pattern));
+    }
+  }
+
+  // Fall back to the single material-name accessor when available.
   if (provider.getMaterialName) {
     const matName = provider.getMaterialName(globalId);
     if (matName) {

--- a/packages/lens/src/types.ts
+++ b/packages/lens/src/types.ts
@@ -87,6 +87,15 @@ export interface LensDataProvider {
   getMaterialName?(globalId: number): string | undefined;
 
   /**
+   * Get every distinct *individual* material name for an entity — each layer /
+   * constituent / profile material of a multi-material element, or the single
+   * material for a simple one. Unlike {@link getMaterialName} this does NOT
+   * return the layer-set / usage name, so "color/select by material" groups by
+   * the real materials and a multi-layer element belongs to each of them. (#1366)
+   */
+  getMaterialNames?(globalId: number): string[];
+
+  /**
    * Get quantity sets for an entity (used for discovery).
    * Returns quantity set names and their quantity names.
    */


### PR DESCRIPTION
## Problem

The "By Material" lens (and material rule criteria) grouped elements by the **layer-set / usage name** — for Revit exports that's the family + type string, not a material. A wall of *gypsum board + insulation* showed up under one opaque label, and you couldn't select all elements containing a given material: selecting "gypsum board" missed multi-layer walls (#1366).

## Root cause

`LensDataProvider.getMaterialName()` returns a single value — `MaterialInfo.name` (the layer-set name) or the first layer — and `evaluateAutoColorLens` puts each element in exactly one bucket.

## Fix

Make material grouping multi-valued and key off the **individual constituent materials**:

- **engine**: new `extractAutoColorValues` — `material` returns every distinct material an element has, so the element joins each material's group. `colorMap` de-dupes (an element still renders one colour — its largest group wins); `ruleEntityIds` / legend counts include it in every material bucket (so isolation works). All other sources are unchanged (single value).
- **matching**: `matchesMaterial` checks each individual material, so a `materialName contains "gypsum"` rule matches multi-layer walls.
- **provider**: new optional `getMaterialNames(globalId)`; absent → falls back to the old single `getMaterialName`.
- **viewer**: implements it via a pure `lensMaterialNames(MaterialInfo)` collector — gathers layer/constituent/profile/list material names, **excludes** the layer-set name, and for a single plain material falls back to the top-level name. De-duplicated, so gyp/ins/gyp → `["gyp", "ins"]`.

Result: "gypsum board" now selects all 4 walls containing it; "insulation" selects all 8; the legend lists real materials.

## Scope

Multi-select of legend values (shift/ctrl to combine materials) is a separate UI enhancement and is **not** in this PR — the core data-correctness bug (per-material grouping + isolation) is fixed here.

## Tests

- `lensMaterialNames` collector: layer-set name excluded, dedup, single-material fallback, constituents/profiles — 5/5.
- engine: multi-material element lands in **both** buckets with correct counts; single-`getMaterialName` fallback path — `@ifc-lite/lens` 84/84.
- `turbo typecheck` clean (lens, viewer). Minor changeset for `@ifc-lite/lens` (additive optional accessor); no top-level export change so api-surface is unchanged.

Fixes #1366