### PR TITLE
fix(viewer): colour the two clashing elements distinctly (#1277, #1339)

### DIFF
--- a/.changeset/feat-clash-highlight-colors.md
+++ b/.changeset/feat-clash-highlight-colors.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/renderer": minor
+---
+
+Add `RenderOptions.highlightColors` — a per-element highlight tint for selected meshes. A selected mesh whose id is in this map glows in the given RGBA using the same re-lit selection treatment instead of the default selection blue. Lets a consumer render, e.g., the two sides of a clash in distinct vibrant colours while keeping the selection glow, crease structure and opacity. Only applied to ids that are also selected (`selectedId`/`selectedIds`); absent map = unchanged behaviour. (#1277/#1339)

--- a/.changeset/feat-clash-highlight-colors.md
+++ b/.changeset/feat-clash-highlight-colors.md
@@ -2,4 +2,9 @@
 "@ifc-lite/renderer": minor
 ---
 
-Add `RenderOptions.highlightColors` — a per-element highlight tint for selected meshes. A selected mesh whose id is in this map glows in the given RGBA using the same re-lit selection treatment instead of the default selection blue. Lets a consumer render, e.g., the two sides of a clash in distinct vibrant colours while keeping the selection glow, crease structure and opacity. Only applied to ids that are also selected (`selectedId`/`selectedIds`); absent map = unchanged behaviour. (#1277/#1339)
+Clash visualisation support:
+
+- Add `RenderOptions.highlightColors` — a per-element highlight tint. An id in this map glows in the given RGBA using the re-lit selection treatment (and gets the same individual-mesh / opaque / stay-solid-through-ghost handling) **without** needing to be in the store selection. Lets a consumer render, e.g., the two sides of a clash in distinct vibrant colours in highlight/isolate/ghost with no "selected" state.
+- Add `Renderer.setClashOverlapBox(box | null)` — draws a world-space AABB as a distinct-colour wireframe box (e.g. the clash overlap region) via the existing overlay line pipeline. Pass `null` to clear.
+
+(#1277/#1339)

--- a/.changeset/feat-clash-highlight-colors.md
+++ b/.changeset/feat-clash-highlight-colors.md
@@ -2,9 +2,4 @@
 "@ifc-lite/renderer": minor
 ---
 
-Clash visualisation support:
-
-- Add `RenderOptions.highlightColors` — a per-element highlight tint. An id in this map glows in the given RGBA using the re-lit selection treatment (and gets the same individual-mesh / opaque / stay-solid-through-ghost handling) **without** needing to be in the store selection. Lets a consumer render, e.g., the two sides of a clash in distinct vibrant colours in highlight/isolate/ghost with no "selected" state.
-- Add `Renderer.setClashOverlapBox(box | null)` — draws a world-space AABB as a distinct-colour wireframe box (e.g. the clash overlap region) via the existing overlay line pipeline. Pass `null` to clear.
-
-(#1277/#1339)
+Add `Renderer.setClashOverlapBox(box | null)` — draws a world-space AABB as a distinct-colour wireframe box (e.g. the clash overlap region) via the existing overlay line pipeline. Pass `null` to clear. (#1277/#1339)

--- a/apps/viewer/src/components/viewer/ClashPanel.tsx
+++ b/apps/viewer/src/components/viewer/ClashPanel.tsx
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import {
   X,
   Play,
@@ -20,7 +21,6 @@ import {
   FilePlus,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import { cn } from '@/lib/utils';
 import { useClash, type ClashFocusMode } from '@/hooks/useClash';
 import { useBCF } from '@/hooks/useBCF';
@@ -212,6 +212,42 @@ export function ClashPanel({ onClose }: ClashPanelProps) {
   const total = result?.summary.total ?? 0;
   const shown = visibleClashes.length;
   const bySeverity = result?.summary.bySeverity;
+
+  // Flatten sections → a single row list (group header, clash row, and an
+  // expanded-detail row for opened clashes) so the list virtualizes cleanly and
+  // stays smooth at 10k+ clashes. Collapsed sections contribute only their
+  // header. (#1277 list handling)
+  type ClashDisplayRow =
+    | { kind: 'group'; key: string; label: string; color?: string; count: number }
+    | { kind: 'clash'; clash: Clash }
+    | { kind: 'detail'; clash: Clash };
+  const displayRows = useMemo<ClashDisplayRow[]>(() => {
+    const rows: ClashDisplayRow[] = [];
+    for (const section of sections) {
+      rows.push({ kind: 'group', key: section.key, label: section.label, color: section.color, count: section.items.length });
+      if (collapsed.has(section.key)) continue;
+      for (const clash of section.items) {
+        rows.push({ kind: 'clash', clash });
+        if (expanded.has(clash.id)) rows.push({ kind: 'detail', clash });
+      }
+    }
+    return rows;
+  }, [sections, collapsed, expanded]);
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const rowVirtualizer = useVirtualizer({
+    count: displayRows.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: (i) => {
+      const r = displayRows[i];
+      return r.kind === 'group' ? 32 : r.kind === 'detail' ? 96 : 52;
+    },
+    overscan: 16,
+    getItemKey: (i) => {
+      const r = displayRows[i];
+      return r.kind === 'group' ? `g:${r.key}` : r.kind === 'detail' ? `d:${r.clash.id}` : `c:${r.clash.id}`;
+    },
+  });
 
   /**
    * Create a BCF topic from the selected clash (or the whole result) directly in
@@ -562,8 +598,8 @@ export function ClashPanel({ onClose }: ClashPanelProps) {
         </div>
       )}
 
-      {/* Results */}
-      <ScrollArea className="flex-1">
+      {/* Results — virtualized so 10k+ clashes stay smooth (#1277). */}
+      <div ref={scrollRef} className="flex-1 overflow-auto min-h-0">
         {!result && !running && (
           <div className="flex flex-col items-center justify-center h-full p-8 text-center text-muted-foreground">
             <Crosshair className="h-8 w-8 mb-3 opacity-40" />
@@ -588,85 +624,77 @@ export function ClashPanel({ onClose }: ClashPanelProps) {
           </div>
         )}
 
-        {sections.map((section) => {
-          const isCollapsed = collapsed.has(section.key);
-          return (
-            <div key={section.key} className="border-b border-border/60">
-              <button
-                onClick={() => toggleSection(section.key)}
-                className="flex w-full items-center gap-1.5 px-3 py-1.5 text-xs font-medium hover:bg-muted/50"
-              >
-                {isCollapsed ? <ChevronRight className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
-                {section.color && (
-                  <span className="h-2 w-2 rounded-full" style={{ background: section.color }} />
-                )}
-                <span className="truncate">{section.label}</span>
-                <span className="ml-auto tabular-nums text-muted-foreground">{section.items.length}</span>
-              </button>
-              {!isCollapsed &&
-                section.items.map((clash) => {
-                  const isExpanded = expanded.has(clash.id);
-                  const touch = isTouching(clash);
-                  return (
-                    <div
-                      key={clash.id}
-                      className={cn('border-t border-border/40', selectedId === clash.id && 'bg-primary/10')}
+        {displayRows.length > 0 && (
+          <div style={{ height: `${rowVirtualizer.getTotalSize()}px`, width: '100%', position: 'relative' }}>
+            {rowVirtualizer.getVirtualItems().map((v) => {
+              const row = displayRows[v.index];
+              return (
+                <div
+                  key={v.key}
+                  data-index={v.index}
+                  ref={rowVirtualizer.measureElement}
+                  style={{ position: 'absolute', top: 0, left: 0, width: '100%', transform: `translateY(${v.start}px)` }}
+                >
+                  {row.kind === 'group' ? (
+                    <button
+                      onClick={() => toggleSection(row.key)}
+                      className="flex w-full items-center gap-1.5 border-b border-border/60 px-3 py-1.5 text-xs font-medium hover:bg-muted/50"
                     >
-                      <div className="flex w-full items-stretch text-xs">
-                        <button
-                          onClick={() => toggleExpand(clash.id)}
-                          title={isExpanded ? 'Collapse' : 'Show both objects'}
-                          className="flex items-center pl-2 pr-1 text-muted-foreground hover:text-foreground"
-                        >
-                          {isExpanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
-                        </button>
-                        <button
-                          onClick={() => focusClash(clash, focusMode)}
-                          className="flex min-w-0 flex-1 items-center gap-2 py-1.5 pr-1 text-left hover:bg-muted/50"
-                        >
-                          <span
-                            className="self-stretch w-0.5 rounded-full shrink-0"
-                            style={{ background: SEVERITY[clash.severity].color }}
-                          />
-                          <div className="min-w-0 flex-1">
-                            <div className="truncate">
-                              <span className="text-foreground">{clash.a.tag}</span>
-                              <span className="text-muted-foreground"> × </span>
-                              <span className="text-foreground">{clash.b.tag}</span>
-                              {touch && (
-                                <span className="ml-1.5 rounded bg-muted px-1 py-0.5 text-[9px] uppercase tracking-wide text-muted-foreground">
-                                  touch
-                                </span>
-                              )}
-                            </div>
-                            <div className="truncate text-[10px] text-muted-foreground">
-                              {clash.a.name ?? shortName(clash.a.key)} ↔ {clash.b.name ?? shortName(clash.b.key)}
-                            </div>
-                          </div>
-                          <span className="shrink-0 tabular-nums text-muted-foreground">{formatDistance(clash.distance)}</span>
-                        </button>
-                        <button
-                          onClick={() => focusClash(clash, focusMode === 'highlight' ? 'isolate' : focusMode)}
-                          title={focusMode === 'ghost' ? 'Ghost the rest (X-Ray context)' : 'Isolate this pair (hide everything else)'}
-                          className="flex items-center px-2 text-muted-foreground hover:text-foreground"
-                        >
-                          <Focus className="h-3.5 w-3.5" />
-                        </button>
-                      </div>
-                      {isExpanded && (
-                        <div className="pb-1.5">
-                          <div className="px-7 py-1 text-[10px] text-muted-foreground">{describeClash(clash)}</div>
-                          <ElementRow el={clash.a} side={0} />
-                          <ElementRow el={clash.b} side={1} />
-                        </div>
-                      )}
+                      {collapsed.has(row.key) ? <ChevronRight className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
+                      {row.color && <span className="h-2 w-2 rounded-full" style={{ background: row.color }} />}
+                      <span className="truncate">{row.label}</span>
+                      <span className="ml-auto tabular-nums text-muted-foreground">{row.count}</span>
+                    </button>
+                  ) : row.kind === 'detail' ? (
+                    <div className="border-t border-border/40 pb-1.5">
+                      <div className="px-7 py-1 text-[10px] text-muted-foreground">{describeClash(row.clash)}</div>
+                      <ElementRow el={row.clash.a} side={0} />
+                      <ElementRow el={row.clash.b} side={1} />
                     </div>
-                  );
-                })}
-            </div>
-          );
-        })}
-      </ScrollArea>
+                  ) : (
+                    <div className={cn('flex w-full items-stretch border-t border-border/40 text-xs', selectedId === row.clash.id && 'bg-primary/10')}>
+                      <button
+                        onClick={() => toggleExpand(row.clash.id)}
+                        title={expanded.has(row.clash.id) ? 'Collapse' : 'Show both objects'}
+                        className="flex items-center pl-2 pr-1 text-muted-foreground hover:text-foreground"
+                      >
+                        {expanded.has(row.clash.id) ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+                      </button>
+                      <button
+                        onClick={() => focusClash(row.clash, focusMode)}
+                        className="flex min-w-0 flex-1 items-center gap-2 py-1.5 pr-1 text-left hover:bg-muted/50"
+                      >
+                        <span className="self-stretch w-0.5 rounded-full shrink-0" style={{ background: SEVERITY[row.clash.severity].color }} />
+                        <div className="min-w-0 flex-1">
+                          <div className="truncate">
+                            <span className="text-foreground">{row.clash.a.tag}</span>
+                            <span className="text-muted-foreground"> × </span>
+                            <span className="text-foreground">{row.clash.b.tag}</span>
+                            {isTouching(row.clash) && (
+                              <span className="ml-1.5 rounded bg-muted px-1 py-0.5 text-[9px] uppercase tracking-wide text-muted-foreground">touch</span>
+                            )}
+                          </div>
+                          <div className="truncate text-[10px] text-muted-foreground">
+                            {row.clash.a.name ?? shortName(row.clash.a.key)} ↔ {row.clash.b.name ?? shortName(row.clash.b.key)}
+                          </div>
+                        </div>
+                        <span className="shrink-0 tabular-nums text-muted-foreground">{formatDistance(row.clash.distance)}</span>
+                      </button>
+                      <button
+                        onClick={() => focusClash(row.clash, focusMode === 'highlight' ? 'isolate' : focusMode)}
+                        title={focusMode === 'ghost' ? 'Ghost the rest (X-Ray context)' : 'Isolate this pair (hide everything else)'}
+                        className="flex items-center px-2 text-muted-foreground hover:text-foreground"
+                      >
+                        <Focus className="h-3.5 w-3.5" />
+                      </button>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/viewer/src/components/viewer/ClashPanel.tsx
+++ b/apps/viewer/src/components/viewer/ClashPanel.tsx
@@ -138,6 +138,12 @@ export function ClashPanel({ onClose }: ClashPanelProps) {
   // colour-override channel to an active lens (if any) rather than blanking it. (#1277)
   useEffect(() => () => {
     const s = useViewerStore.getState();
+    // Fully reset the focus view: a clash focused in isolate/ghost would
+    // otherwise leave the model isolated/ghosted after the panel unmounts.
+    s.clearEntitySelection();
+    s.clearIsolation();
+    s.clearGhost();
+    s.setClashSelectedId(null);
     s.setClashHighlightColors(null);
     s.setClashOverlapBox(null);
     s.setPendingColorUpdates(s.lensAppliedColors ?? new Map());
@@ -639,6 +645,8 @@ export function ClashPanel({ onClose }: ClashPanelProps) {
                   {row.kind === 'group' ? (
                     <button
                       onClick={() => toggleSection(row.key)}
+                      aria-expanded={!collapsed.has(row.key)}
+                      aria-label={`${collapsed.has(row.key) ? 'Expand' : 'Collapse'} ${row.label}`}
                       className="flex w-full items-center gap-1.5 border-b border-border/60 px-3 py-1.5 text-xs font-medium hover:bg-muted/50"
                     >
                       {collapsed.has(row.key) ? <ChevronRight className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
@@ -656,6 +664,7 @@ export function ClashPanel({ onClose }: ClashPanelProps) {
                     <div className={cn('flex w-full items-stretch border-t border-border/40 text-xs', selectedId === row.clash.id && 'bg-primary/10')}>
                       <button
                         onClick={() => toggleExpand(row.clash.id)}
+                        aria-expanded={expanded.has(row.clash.id)}
                         title={expanded.has(row.clash.id) ? 'Collapse' : 'Show both objects'}
                         className="flex items-center pl-2 pr-1 text-muted-foreground hover:text-foreground"
                       >

--- a/apps/viewer/src/components/viewer/ClashPanel.tsx
+++ b/apps/viewer/src/components/viewer/ClashPanel.tsx
@@ -133,14 +133,15 @@ export function ClashPanel({ onClose }: ClashPanelProps) {
   const [showHelp, setShowHelp] = useState(false);
   const [creatingTopic, setCreatingTopic] = useState(false);
 
-  // Clear the clash A/B glow + overlap box when the panel closes/unmounts so the
-  // tint doesn't linger on the model after the user leaves clash mode (#1277).
-  const setClashHighlightColors = useViewerStore((s) => s.setClashHighlightColors);
-  const setClashOverlapBox = useViewerStore((s) => s.setClashOverlapBox);
+  // Clear the clash colours + overlap box when the panel closes/unmounts so they
+  // don't linger on the model after the user leaves clash mode. Restore the
+  // colour-override channel to an active lens (if any) rather than blanking it. (#1277)
   useEffect(() => () => {
-    setClashHighlightColors(null);
-    setClashOverlapBox(null);
-  }, [setClashHighlightColors, setClashOverlapBox]);
+    const s = useViewerStore.getState();
+    s.setClashHighlightColors(null);
+    s.setClashOverlapBox(null);
+    s.setPendingColorUpdates(s.lensAppliedColors ?? new Map());
+  }, []);
 
   const toggleSection = (key: string) =>
     setCollapsed((prev) => {

--- a/apps/viewer/src/components/viewer/ClashPanel.tsx
+++ b/apps/viewer/src/components/viewer/ClashPanel.tsx
@@ -133,10 +133,14 @@ export function ClashPanel({ onClose }: ClashPanelProps) {
   const [showHelp, setShowHelp] = useState(false);
   const [creatingTopic, setCreatingTopic] = useState(false);
 
-  // Clear the clash A/B glow when the panel closes/unmounts so the tint doesn't
-  // linger on the model after the user leaves clash mode (#1277/#1339 review).
+  // Clear the clash A/B glow + overlap box when the panel closes/unmounts so the
+  // tint doesn't linger on the model after the user leaves clash mode (#1277).
   const setClashHighlightColors = useViewerStore((s) => s.setClashHighlightColors);
-  useEffect(() => () => { setClashHighlightColors(null); }, [setClashHighlightColors]);
+  const setClashOverlapBox = useViewerStore((s) => s.setClashOverlapBox);
+  useEffect(() => () => {
+    setClashHighlightColors(null);
+    setClashOverlapBox(null);
+  }, [setClashHighlightColors, setClashOverlapBox]);
 
   const toggleSection = (key: string) =>
     setCollapsed((prev) => {

--- a/apps/viewer/src/components/viewer/ClashPanel.tsx
+++ b/apps/viewer/src/components/viewer/ClashPanel.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   X,
   Play,
@@ -132,6 +132,11 @@ export function ClashPanel({ onClose }: ClashPanelProps) {
   const [focusMode, setFocusMode] = useState<ClashFocusMode>('highlight');
   const [showHelp, setShowHelp] = useState(false);
   const [creatingTopic, setCreatingTopic] = useState(false);
+
+  // Clear the clash A/B glow when the panel closes/unmounts so the tint doesn't
+  // linger on the model after the user leaves clash mode (#1277/#1339 review).
+  const setClashHighlightColors = useViewerStore((s) => s.setClashHighlightColors);
+  useEffect(() => () => { setClashHighlightColors(null); }, [setClashHighlightColors]);
 
   const toggleSection = (key: string) =>
     setCollapsed((prev) => {

--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -483,6 +483,10 @@ export function Viewport({
   const selectedEntityIdRef = useLatestRef(selectedEntityId);
   const selectedEntityIdsRef = useLatestRef(selectedEntityIds);
   const selectedModelIndexRef = useLatestRef(selectedModelIndex);
+  // Per-element clash A/B highlight tints (#1277/#1339) — kept in a ref so the
+  // animation loop reads the latest without re-subscribing.
+  const clashHighlightColors = useViewerStore((s) => s.clashHighlightColors);
+  const clashHighlightColorsRef = useLatestRef(clashHighlightColors);
   const activeToolRef = useRef<string>(activeTool);
   const pendingMeasurePointRef = useLatestRef(pendingMeasurePoint);
   const activeMeasurementRef = useLatestRef(activeMeasurement);
@@ -1180,6 +1184,7 @@ export function Viewport({
     visualEnhancementRef,
     environmentRef,
     selectedEntityIdsRef,
+    clashHighlightColorsRef,
     coordinateInfoRef,
     isInteractingRef,
     lastCameraStateRef,

--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -26,6 +26,7 @@ import {
 } from '../../hooks/useViewerSelectors.js';
 import { useModelSelection } from '../../hooks/useModelSelection.js';
 import { useLatestRef } from '../../hooks/useLatestRef.js';
+import { CLASH_COLOR_OVERLAP } from '@/lib/clash/clash-colors';
 import { projectToCssScreen } from '../../utils/projectScreen.js';
 import {
   getEntityBounds,
@@ -487,6 +488,16 @@ export function Viewport({
   // animation loop reads the latest without re-subscribing.
   const clashHighlightColors = useViewerStore((s) => s.clashHighlightColors);
   const clashHighlightColorsRef = useLatestRef(clashHighlightColors);
+  // Clash overlap-region wireframe box (#1277): push the focused clash's bounds
+  // to the renderer as a distinct-colour box. Cleared (null) on teardown.
+  const clashOverlapBox = useViewerStore((s) => s.clashOverlapBox);
+  useEffect(() => {
+    const renderer = rendererRef.current;
+    if (!renderer) return;
+    renderer.setClashOverlapBox(
+      clashOverlapBox ? { ...clashOverlapBox, color: CLASH_COLOR_OVERLAP } : null,
+    );
+  }, [clashOverlapBox]);
   const activeToolRef = useRef<string>(activeTool);
   const pendingMeasurePointRef = useLatestRef(pendingMeasurePoint);
   const activeMeasurementRef = useLatestRef(activeMeasurement);

--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -1200,7 +1200,6 @@ export function Viewport({
     visualEnhancementRef,
     environmentRef,
     selectedEntityIdsRef,
-    clashHighlightColorsRef,
     coordinateInfoRef,
     isInteractingRef,
     lastCameraStateRef,

--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -741,9 +741,14 @@ export function Viewport({
           const geom = geometryRef.current;
           const set = selectedEntityIdsRef.current;
           const single = selectedEntityIdRef.current;
+          // A focused clash glows its pair via the clash-highlight channel WITHOUT
+          // selecting it, so frame those ids too when there's no selection (#1277).
+          const hl = clashHighlightColorsRef.current;
           const ids = set && set.size > 0
             ? Array.from(set)
-            : single !== null ? [single] : [];
+            : hl && hl.size > 0
+              ? Array.from(hl.keys())
+              : single !== null ? [single] : [];
           if (!geom || ids.length === 0) {
             console.warn('[Viewport] frameSelection: No selection or geometry');
             return;

--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -1200,6 +1200,7 @@ export function Viewport({
     visualEnhancementRef,
     environmentRef,
     selectedEntityIdsRef,
+    clashHighlightColorsRef,
     coordinateInfoRef,
     isInteractingRef,
     lastCameraStateRef,

--- a/apps/viewer/src/components/viewer/useAnimationLoop.ts
+++ b/apps/viewer/src/components/viewer/useAnimationLoop.ts
@@ -51,6 +51,8 @@ export interface UseAnimationLoopParams {
    */
   modelBoundsRef?: MutableRefObject<{ min: { x: number; y: number; z: number }; max: { x: number; y: number; z: number } } | null>;
   selectedEntityIdsRef: MutableRefObject<Set<number> | undefined>;
+  /** Non-empty while a clash is focused → emphasize (pop) the override colours. */
+  clashHighlightColorsRef: MutableRefObject<Map<number, [number, number, number, number]> | null | undefined>;
   coordinateInfoRef: MutableRefObject<CoordinateInfo | undefined>;
   isInteractingRef: MutableRefObject<boolean>;
   lastCameraStateRef: MutableRefObject<{
@@ -88,6 +90,7 @@ export function useAnimationLoop(params: UseAnimationLoopParams): void {
     sectionRangeRef,
     modelBoundsRef,
     selectedEntityIdsRef,
+    clashHighlightColorsRef,
     coordinateInfoRef,
     isInteractingRef,
     lastCameraStateRef,
@@ -190,6 +193,7 @@ export function useAnimationLoop(params: UseAnimationLoopParams): void {
           ghostExceptIds: ghostExceptEntitiesRef.current,
           selectedId: selectedEntityIdRef.current,
           selectedIds: selectedEntityIdsRef.current,
+          emphasizeOverrides: (clashHighlightColorsRef.current?.size ?? 0) > 0,
           selectedModelIndex: selectedModelIndexRef.current,
           clearColor: clearColorRef.current,
           visualEnhancement: visualEnhancementRef.current,

--- a/apps/viewer/src/components/viewer/useAnimationLoop.ts
+++ b/apps/viewer/src/components/viewer/useAnimationLoop.ts
@@ -51,7 +51,6 @@ export interface UseAnimationLoopParams {
    */
   modelBoundsRef?: MutableRefObject<{ min: { x: number; y: number; z: number }; max: { x: number; y: number; z: number } } | null>;
   selectedEntityIdsRef: MutableRefObject<Set<number> | undefined>;
-  clashHighlightColorsRef: MutableRefObject<Map<number, [number, number, number, number]> | null | undefined>;
   coordinateInfoRef: MutableRefObject<CoordinateInfo | undefined>;
   isInteractingRef: MutableRefObject<boolean>;
   lastCameraStateRef: MutableRefObject<{
@@ -89,7 +88,6 @@ export function useAnimationLoop(params: UseAnimationLoopParams): void {
     sectionRangeRef,
     modelBoundsRef,
     selectedEntityIdsRef,
-    clashHighlightColorsRef,
     coordinateInfoRef,
     isInteractingRef,
     lastCameraStateRef,
@@ -192,7 +190,6 @@ export function useAnimationLoop(params: UseAnimationLoopParams): void {
           ghostExceptIds: ghostExceptEntitiesRef.current,
           selectedId: selectedEntityIdRef.current,
           selectedIds: selectedEntityIdsRef.current,
-          highlightColors: clashHighlightColorsRef.current ?? undefined,
           selectedModelIndex: selectedModelIndexRef.current,
           clearColor: clearColorRef.current,
           visualEnhancement: visualEnhancementRef.current,

--- a/apps/viewer/src/components/viewer/useAnimationLoop.ts
+++ b/apps/viewer/src/components/viewer/useAnimationLoop.ts
@@ -51,6 +51,7 @@ export interface UseAnimationLoopParams {
    */
   modelBoundsRef?: MutableRefObject<{ min: { x: number; y: number; z: number }; max: { x: number; y: number; z: number } } | null>;
   selectedEntityIdsRef: MutableRefObject<Set<number> | undefined>;
+  clashHighlightColorsRef: MutableRefObject<Map<number, [number, number, number, number]> | null | undefined>;
   coordinateInfoRef: MutableRefObject<CoordinateInfo | undefined>;
   isInteractingRef: MutableRefObject<boolean>;
   lastCameraStateRef: MutableRefObject<{
@@ -88,6 +89,7 @@ export function useAnimationLoop(params: UseAnimationLoopParams): void {
     sectionRangeRef,
     modelBoundsRef,
     selectedEntityIdsRef,
+    clashHighlightColorsRef,
     coordinateInfoRef,
     isInteractingRef,
     lastCameraStateRef,
@@ -190,6 +192,7 @@ export function useAnimationLoop(params: UseAnimationLoopParams): void {
           ghostExceptIds: ghostExceptEntitiesRef.current,
           selectedId: selectedEntityIdRef.current,
           selectedIds: selectedEntityIdsRef.current,
+          highlightColors: clashHighlightColorsRef.current ?? undefined,
           selectedModelIndex: selectedModelIndexRef.current,
           clearColor: clearColorRef.current,
           visualEnhancement: visualEnhancementRef.current,

--- a/apps/viewer/src/hooks/useClash.ts
+++ b/apps/viewer/src/hooks/useClash.ts
@@ -300,6 +300,9 @@ export function useClash() {
       // colours show in highlight, isolate AND ghost with no selection. (#1277/#1339)
       state.clearEntitySelection();
       state.setClashHighlightColors(buildClashPairColors(a ? clash.a.ref : null, b ? clash.b.ref : null));
+      // Mark the overlap REGION (clash.bounds AABB, world frame) as a distinct
+      // third-colour wireframe box (#1277).
+      state.setClashOverlapBox(clash.bounds ? { min: clash.bounds.min, max: clash.bounds.max } : null);
       applyFocusMode(globalIds, mode);
       state.setClashSelectedId(clash.id);
       // frameSelection also frames the clash-highlight ids (see Viewport), so the
@@ -322,6 +325,7 @@ export function useClash() {
       // focus is painted the clash A colour and framed, without a selected state.
       state.clearEntitySelection();
       state.setClashHighlightColors(new Map([[el.ref, CLASH_COLOR_A]]));
+      state.setClashOverlapBox(null);
       applyFocusMode([el.ref], mode);
       requestAnimationFrame(() => state.cameraCallbacks.frameSelection?.());
     },
@@ -353,6 +357,7 @@ export function useClash() {
     // and B in another, so per-pair colours are ambiguous here. Reset any stale
     // pair tint and rely on the selection outline.
     state.setClashHighlightColors(null);
+    state.setClashOverlapBox(null);
   }, [refOf]);
 
   const clearHighlight = useCallback((): void => {
@@ -361,6 +366,7 @@ export function useClash() {
     state.clearIsolation(); // drop any clash isolation so the full model returns
     state.clearGhost(); // and any X-Ray ghosting
     state.setClashHighlightColors(null); // drop the clash A/B glow tints
+    state.setClashOverlapBox(null);
     setSelectedId(null);
   }, [setSelectedId]);
 

--- a/apps/viewer/src/hooks/useClash.ts
+++ b/apps/viewer/src/hooks/useClash.ts
@@ -30,6 +30,7 @@ import { elementsFromStep } from '@ifc-lite/clash/step';
 import { createBCFFromClashResult } from '@ifc-lite/clash/bcf';
 import { writeBCF } from '@ifc-lite/bcf';
 import { getGlobalRenderer } from '@/hooks/useBCF';
+import { buildClashPairColors, CLASH_COLOR_A } from '@/lib/clash/clash-colors';
 import { posthog } from '@/lib/analytics';
 import { downloadBlob } from '@/lib/export/download';
 
@@ -295,6 +296,10 @@ export function useClash() {
       state.clearEntitySelection();
       state.setSelectedEntityIds(globalIds); // highlight BOTH elements + frame target
       state.addEntitiesToSelection(refs); // model-aware context for the properties panel
+      // Paint the two elements in distinct colours so the user can tell A from B
+      // (the selection outline alone gave both the same colour — #1277/#1339).
+      // The selection outline is still drawn on top of these fills.
+      state.setPendingColorUpdates(buildClashPairColors(a ? clash.a.ref : null, b ? clash.b.ref : null));
       applyFocusMode(globalIds, mode);
       state.setClashSelectedId(clash.id);
       requestAnimationFrame(() => state.cameraCallbacks.frameSelection?.());
@@ -314,6 +319,9 @@ export function useClash() {
       state.clearEntitySelection();
       state.setSelectedEntityIds([el.ref]);
       state.addEntitiesToSelection([ref]);
+      // One element in focus — paint it the clash A colour so stepping through a
+      // pair (#1276) keeps a consistent, distinct fill rather than a stale pair.
+      state.setPendingColorUpdates(new Map([[el.ref, CLASH_COLOR_A]]));
       applyFocusMode([el.ref], mode);
       requestAnimationFrame(() => state.cameraCallbacks.frameSelection?.());
     },
@@ -341,6 +349,10 @@ export function useClash() {
     if (globalIds.size === 0) return;
     state.setSelectedEntityIds([...globalIds]);
     state.addEntitiesToSelection(refs);
+    // Showing every clashing element at once — an element can be A in one clash
+    // and B in another, so per-pair colours are ambiguous here. Reset any stale
+    // pair fills and rely on the selection outline.
+    state.setPendingColorUpdates(new Map());
   }, [refOf]);
 
   const clearHighlight = useCallback((): void => {
@@ -348,6 +360,7 @@ export function useClash() {
     state.clearEntitySelection();
     state.clearIsolation(); // drop any clash isolation so the full model returns
     state.clearGhost(); // and any X-Ray ghosting
+    state.setPendingColorUpdates(new Map()); // reset the clash A/B fill colours
     setSelectedId(null);
   }, [setSelectedId]);
 

--- a/apps/viewer/src/hooks/useClash.ts
+++ b/apps/viewer/src/hooks/useClash.ts
@@ -299,14 +299,21 @@ export function useClash() {
       // opaque / stay-solid-through-ghost treatment as a selection, so the
       // colours show in highlight, isolate AND ghost with no selection. (#1277/#1339)
       state.clearEntitySelection();
-      state.setClashHighlightColors(buildClashPairColors(a ? clash.a.ref : null, b ? clash.b.ref : null));
+      // Colour the two elements via the renderer COLOUR-OVERRIDE channel (the
+      // same path the lens uses) — this repaints their actual albedo, so it
+      // works on batched AND GPU-instanced geometry (e.g. Tekla steel members),
+      // and crucially is NOT the selection highlight: the pair shows the distinct
+      // amber/cyan clash colours, never the selection blue. (#1277/#1339)
+      const colors = buildClashPairColors(a ? clash.a.ref : null, b ? clash.b.ref : null);
+      state.setClashHighlightColors(colors); // record for framing + teardown
+      state.setPendingColorUpdates(colors);  // actually paint A amber / B cyan
       // Mark the overlap REGION (clash.bounds AABB, world frame) as a distinct
       // third-colour wireframe box (#1277).
       state.setClashOverlapBox(clash.bounds ? { min: clash.bounds.min, max: clash.bounds.max } : null);
       applyFocusMode(globalIds, mode);
       state.setClashSelectedId(clash.id);
-      // frameSelection also frames the clash-highlight ids (see Viewport), so the
-      // camera encloses the pair without a selection.
+      // frameSelection also frames the clash ids (see Viewport), so the camera
+      // encloses the pair without a selection.
       requestAnimationFrame(() => state.cameraCallbacks.frameSelection?.());
     },
     [refOf, applyFocusMode],
@@ -321,10 +328,13 @@ export function useClash() {
       const state = useViewerStore.getState();
       const ref = refOf(el);
       if (!ref) return;
-      // Glow-only (no selection), consistent with focusClash — one element in
-      // focus is painted the clash A colour and framed, without a selected state.
+      // Colour-override (no selection), consistent with focusClash — one element
+      // in focus is painted the clash A colour and framed, without a selected
+      // state or the selection-blue.
       state.clearEntitySelection();
-      state.setClashHighlightColors(new Map([[el.ref, CLASH_COLOR_A]]));
+      const one = new Map<number, [number, number, number, number]>([[el.ref, CLASH_COLOR_A]]);
+      state.setClashHighlightColors(one);
+      state.setPendingColorUpdates(one);
       state.setClashOverlapBox(null);
       applyFocusMode([el.ref], mode);
       requestAnimationFrame(() => state.cameraCallbacks.frameSelection?.());
@@ -354,9 +364,10 @@ export function useClash() {
     state.setSelectedEntityIds([...globalIds]);
     state.addEntitiesToSelection(refs);
     // Showing every clashing element at once — an element can be A in one clash
-    // and B in another, so per-pair colours are ambiguous here. Reset any stale
-    // pair tint and rely on the selection outline.
+    // and B in another, so per-pair colours are ambiguous here. Drop any stale
+    // pair colours (restoring an active lens) and rely on the selection outline.
     state.setClashHighlightColors(null);
+    state.setPendingColorUpdates(state.lensAppliedColors ?? new Map());
     state.setClashOverlapBox(null);
   }, [refOf]);
 
@@ -365,7 +376,10 @@ export function useClash() {
     state.clearEntitySelection();
     state.clearIsolation(); // drop any clash isolation so the full model returns
     state.clearGhost(); // and any X-Ray ghosting
-    state.setClashHighlightColors(null); // drop the clash A/B glow tints
+    state.setClashHighlightColors(null);
+    // Restore the colour-override channel to whatever owned it (an active lens),
+    // or clear it — don't leave the clash A/B colours painted. (#1277 review)
+    state.setPendingColorUpdates(state.lensAppliedColors ?? new Map());
     state.setClashOverlapBox(null);
     setSelectedId(null);
   }, [setSelectedId]);
@@ -489,6 +503,9 @@ export function useClash() {
     state.clearEntitySelection();
     state.clearIsolation();
     state.clearGhost();
+    // Drop the clash colour-override (restoring an active lens) + overlap box.
+    state.setPendingColorUpdates(state.lensAppliedColors ?? new Map());
+    state.setClashOverlapBox(null);
     clear();
   }, [clear]);
 

--- a/apps/viewer/src/hooks/useClash.ts
+++ b/apps/viewer/src/hooks/useClash.ts
@@ -292,16 +292,18 @@ export function useClash() {
       const globalIds: number[] = [];
       if (a) globalIds.push(clash.a.ref);
       if (b) globalIds.push(clash.b.ref);
-      // Replace any existing selection so the camera frames only this clash pair.
+      // Do NOT select the pair. Selecting forced a "selected" state (the 2-SEL
+      // counter, and in isolate/ghost the elements read as selected). Instead we
+      // just glow the two elements in distinct vibrant colours via the clash
+      // highlight channel — the renderer gives highlighted ids the same glow /
+      // opaque / stay-solid-through-ghost treatment as a selection, so the
+      // colours show in highlight, isolate AND ghost with no selection. (#1277/#1339)
       state.clearEntitySelection();
-      state.setSelectedEntityIds(globalIds); // highlight BOTH elements + frame target
-      state.addEntitiesToSelection(refs); // model-aware context for the properties panel
-      // Paint the two elements in distinct colours so the user can tell A from B
-      // (the selection outline alone gave both the same colour — #1277/#1339).
-      // The selection outline is still drawn on top of these fills.
       state.setClashHighlightColors(buildClashPairColors(a ? clash.a.ref : null, b ? clash.b.ref : null));
       applyFocusMode(globalIds, mode);
       state.setClashSelectedId(clash.id);
+      // frameSelection also frames the clash-highlight ids (see Viewport), so the
+      // camera encloses the pair without a selection.
       requestAnimationFrame(() => state.cameraCallbacks.frameSelection?.());
     },
     [refOf, applyFocusMode],
@@ -316,11 +318,9 @@ export function useClash() {
       const state = useViewerStore.getState();
       const ref = refOf(el);
       if (!ref) return;
+      // Glow-only (no selection), consistent with focusClash — one element in
+      // focus is painted the clash A colour and framed, without a selected state.
       state.clearEntitySelection();
-      state.setSelectedEntityIds([el.ref]);
-      state.addEntitiesToSelection([ref]);
-      // One element in focus — paint it the clash A colour so stepping through a
-      // pair (#1276) keeps a consistent, distinct fill rather than a stale pair.
       state.setClashHighlightColors(new Map([[el.ref, CLASH_COLOR_A]]));
       applyFocusMode([el.ref], mode);
       requestAnimationFrame(() => state.cameraCallbacks.frameSelection?.());

--- a/apps/viewer/src/hooks/useClash.ts
+++ b/apps/viewer/src/hooks/useClash.ts
@@ -299,7 +299,7 @@ export function useClash() {
       // Paint the two elements in distinct colours so the user can tell A from B
       // (the selection outline alone gave both the same colour — #1277/#1339).
       // The selection outline is still drawn on top of these fills.
-      state.setPendingColorUpdates(buildClashPairColors(a ? clash.a.ref : null, b ? clash.b.ref : null));
+      state.setClashHighlightColors(buildClashPairColors(a ? clash.a.ref : null, b ? clash.b.ref : null));
       applyFocusMode(globalIds, mode);
       state.setClashSelectedId(clash.id);
       requestAnimationFrame(() => state.cameraCallbacks.frameSelection?.());
@@ -321,7 +321,7 @@ export function useClash() {
       state.addEntitiesToSelection([ref]);
       // One element in focus — paint it the clash A colour so stepping through a
       // pair (#1276) keeps a consistent, distinct fill rather than a stale pair.
-      state.setPendingColorUpdates(new Map([[el.ref, CLASH_COLOR_A]]));
+      state.setClashHighlightColors(new Map([[el.ref, CLASH_COLOR_A]]));
       applyFocusMode([el.ref], mode);
       requestAnimationFrame(() => state.cameraCallbacks.frameSelection?.());
     },
@@ -351,8 +351,8 @@ export function useClash() {
     state.addEntitiesToSelection(refs);
     // Showing every clashing element at once — an element can be A in one clash
     // and B in another, so per-pair colours are ambiguous here. Reset any stale
-    // pair fills and rely on the selection outline.
-    state.setPendingColorUpdates(new Map());
+    // pair tint and rely on the selection outline.
+    state.setClashHighlightColors(null);
   }, [refOf]);
 
   const clearHighlight = useCallback((): void => {
@@ -360,7 +360,7 @@ export function useClash() {
     state.clearEntitySelection();
     state.clearIsolation(); // drop any clash isolation so the full model returns
     state.clearGhost(); // and any X-Ray ghosting
-    state.setPendingColorUpdates(new Map()); // reset the clash A/B fill colours
+    state.setClashHighlightColors(null); // drop the clash A/B glow tints
     setSelectedId(null);
   }, [setSelectedId]);
 

--- a/apps/viewer/src/lib/clash/clash-colors.test.ts
+++ b/apps/viewer/src/lib/clash/clash-colors.test.ts
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { buildClashPairColors, CLASH_COLOR_A, CLASH_COLOR_B } from './clash-colors.js';
+
+describe('buildClashPairColors (#1277/#1339)', () => {
+  it('gives the two clashing elements DISTINCT colours', () => {
+    const m = buildClashPairColors(10, 20);
+    assert.deepEqual(m.get(10), CLASH_COLOR_A);
+    assert.deepEqual(m.get(20), CLASH_COLOR_B);
+    assert.notDeepEqual(CLASH_COLOR_A, CLASH_COLOR_B, 'A and B must differ — that is the whole fix');
+  });
+
+  it('skips an element that did not resolve (null ref)', () => {
+    assert.deepEqual([...buildClashPairColors(null, 20).entries()], [[20, CLASH_COLOR_B]]);
+    assert.deepEqual([...buildClashPairColors(10, null).entries()], [[10, CLASH_COLOR_A]]);
+    assert.equal(buildClashPairColors(null, null).size, 0);
+  });
+
+  it('does not overwrite A with B for a degenerate self-clash (same id)', () => {
+    const m = buildClashPairColors(5, 5);
+    assert.equal(m.size, 1);
+    assert.deepEqual(m.get(5), CLASH_COLOR_A);
+  });
+
+  it('colours are valid RGBA floats in 0..1', () => {
+    for (const c of [CLASH_COLOR_A, CLASH_COLOR_B]) {
+      assert.equal(c.length, 4);
+      for (const v of c) assert.ok(v >= 0 && v <= 1, `component ${v} out of range`);
+    }
+  });
+});

--- a/apps/viewer/src/lib/clash/clash-colors.ts
+++ b/apps/viewer/src/lib/clash/clash-colors.ts
@@ -20,6 +20,8 @@ export type RGBA = [number, number, number, number];
 export const CLASH_COLOR_A: RGBA = [1.0, 0.5, 0.05, 1];
 /** Element B — vibrant cyan. */
 export const CLASH_COLOR_B: RGBA = [0.0, 0.82, 1.0, 1];
+/** Overlap region wireframe box — vibrant magenta (a third, distinct colour). */
+export const CLASH_COLOR_OVERLAP: RGBA = [1.0, 0.1, 0.85, 1];
 
 /**
  * Build the global-id → colour map that paints a clash pair. `null` ids (an

--- a/apps/viewer/src/lib/clash/clash-colors.ts
+++ b/apps/viewer/src/lib/clash/clash-colors.ts
@@ -3,23 +3,23 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Distinct fill colours for the two elements of a focused clash pair (#1277,
- * #1339). Before this, both clashing elements were highlighted with the single
- * selection colour, so you couldn't tell which was which. We now paint element
- * A and element B in two clearly-different colours (applied through the renderer
- * colour-override channel, with the normal selection outline drawn on top).
+ * Distinct, vibrant highlight tints for the two elements of a focused clash
+ * pair (#1277, #1339). Before this, both clashing elements were highlighted
+ * with the single selection-blue, so you couldn't tell which was which. These
+ * feed the renderer's per-element highlight channel (`RenderOptions.highlightColors`),
+ * which glows the selected element in this colour using the SAME re-lit
+ * selection treatment — so the pair pops like a selection but in two colours.
  *
- * RGBA floats in 0..1 — the shape `pendingColorUpdates` / `scene.setColorOverrides`
- * consume. Warm vs cool, high contrast on both light and dark themes, and chosen
- * to stay distinguishable for the common red/green colour-vision deficiency
- * (orange vs blue, not red vs green).
+ * RGBA floats in 0..1. High-chroma warm-vs-cool so they stay distinct from each
+ * other, from the default selection-blue, and under red/green colour-vision
+ * deficiency (orange vs cyan, not red vs green).
  */
 export type RGBA = [number, number, number, number];
 
-/** Element A — warm orange. */
-export const CLASH_COLOR_A: RGBA = [0.96, 0.45, 0.13, 1];
-/** Element B — cool blue. */
-export const CLASH_COLOR_B: RGBA = [0.16, 0.5, 0.92, 1];
+/** Element A — vibrant amber/orange. */
+export const CLASH_COLOR_A: RGBA = [1.0, 0.5, 0.05, 1];
+/** Element B — vibrant cyan. */
+export const CLASH_COLOR_B: RGBA = [0.0, 0.82, 1.0, 1];
 
 /**
  * Build the global-id → colour map that paints a clash pair. `null` ids (an

--- a/apps/viewer/src/lib/clash/clash-colors.ts
+++ b/apps/viewer/src/lib/clash/clash-colors.ts
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Distinct fill colours for the two elements of a focused clash pair (#1277,
+ * #1339). Before this, both clashing elements were highlighted with the single
+ * selection colour, so you couldn't tell which was which. We now paint element
+ * A and element B in two clearly-different colours (applied through the renderer
+ * colour-override channel, with the normal selection outline drawn on top).
+ *
+ * RGBA floats in 0..1 — the shape `pendingColorUpdates` / `scene.setColorOverrides`
+ * consume. Warm vs cool, high contrast on both light and dark themes, and chosen
+ * to stay distinguishable for the common red/green colour-vision deficiency
+ * (orange vs blue, not red vs green).
+ */
+export type RGBA = [number, number, number, number];
+
+/** Element A — warm orange. */
+export const CLASH_COLOR_A: RGBA = [0.96, 0.45, 0.13, 1];
+/** Element B — cool blue. */
+export const CLASH_COLOR_B: RGBA = [0.16, 0.5, 0.92, 1];
+
+/**
+ * Build the global-id → colour map that paints a clash pair. `null` ids (an
+ * element that didn't resolve to a loaded entity) are skipped. The two colours
+ * are always distinct so the pair is readable.
+ */
+export function buildClashPairColors(
+  aRef: number | null,
+  bRef: number | null,
+): Map<number, RGBA> {
+  const map = new Map<number, RGBA>();
+  if (aRef !== null) map.set(aRef, CLASH_COLOR_A);
+  // If both refs resolve to the SAME id (degenerate self-clash), A's colour
+  // already won — don't overwrite with B.
+  if (bRef !== null && bRef !== aRef) map.set(bRef, CLASH_COLOR_B);
+  return map;
+}

--- a/apps/viewer/src/store/slices/clashSlice.ts
+++ b/apps/viewer/src/store/slices/clashSlice.ts
@@ -69,6 +69,13 @@ export interface ClashSlice {
    * blue. `null` when no clash is focused. (#1277/#1339)
    */
   clashHighlightColors: Map<number, [number, number, number, number]> | null;
+  /**
+   * World-space AABB of the focused clash's overlap region (`Clash.bounds`),
+   * drawn as a distinct-colour wireframe box so the overlap reads as a third
+   * colour next to the two glowing elements. `null` when no clash is focused.
+   * (#1277)
+   */
+  clashOverlapBox: { min: [number, number, number]; max: [number, number, number] } | null;
 
   setClashPanelVisible: (visible: boolean) => void;
   toggleClashPanel: () => void;
@@ -86,6 +93,7 @@ export interface ClashSlice {
   resetClashSettings: () => void;
   setClashSelectedId: (id: string | null) => void;
   setClashHighlightColors: (colors: Map<number, [number, number, number, number]> | null) => void;
+  setClashOverlapBox: (box: { min: [number, number, number]; max: [number, number, number] } | null) => void;
   // Preset CRUD (persisted). create/update/import return a SaveResult so the UI
   // can surface quota / cap failures; the rest are best-effort.
   createClashPreset: (input: NewClashPreset) => SaveResult;
@@ -135,6 +143,7 @@ export const createClashSlice: StateCreator<ClashSlice, [], [], ClashSlice> = (s
     clashPresets: buildInitialPresets(),
     clashSelectedId: null,
     clashHighlightColors: null,
+    clashOverlapBox: null,
 
     setClashPanelVisible: (clashPanelVisible) => set({ clashPanelVisible }),
     toggleClashPanel: () => set((s) => ({ clashPanelVisible: !s.clashPanelVisible })),
@@ -173,6 +182,7 @@ export const createClashSlice: StateCreator<ClashSlice, [], [], ClashSlice> = (s
 
     setClashSelectedId: (clashSelectedId) => set({ clashSelectedId }),
     setClashHighlightColors: (clashHighlightColors) => set({ clashHighlightColors }),
+    setClashOverlapBox: (clashOverlapBox) => set({ clashOverlapBox }),
 
     createClashPreset: (input) => {
       const name = validatePresetName(input.name);
@@ -257,6 +267,7 @@ export const createClashSlice: StateCreator<ClashSlice, [], [], ClashSlice> = (s
         clashProgress: null,
         clashSelectedId: null,
         clashHighlightColors: null,
+        clashOverlapBox: null,
       }),
   };
 };

--- a/apps/viewer/src/store/slices/clashSlice.ts
+++ b/apps/viewer/src/store/slices/clashSlice.ts
@@ -62,6 +62,13 @@ export interface ClashSlice {
   clashPresets: ClashPreset[];
   /** Currently focused clash id (for highlight in the list). */
   clashSelectedId: string | null;
+  /**
+   * Per-element highlight tint for the focused clash pair — `Map<globalId, RGBA>`
+   * (element A one vibrant colour, element B another). Fed to the renderer so the
+   * selection glow paints A and B distinctly instead of the single selection
+   * blue. `null` when no clash is focused. (#1277/#1339)
+   */
+  clashHighlightColors: Map<number, [number, number, number, number]> | null;
 
   setClashPanelVisible: (visible: boolean) => void;
   toggleClashPanel: () => void;
@@ -78,6 +85,7 @@ export interface ClashSlice {
   setClashGroupBy: (groupBy: ClashGroupBy) => void;
   resetClashSettings: () => void;
   setClashSelectedId: (id: string | null) => void;
+  setClashHighlightColors: (colors: Map<number, [number, number, number, number]> | null) => void;
   // Preset CRUD (persisted). create/update/import return a SaveResult so the UI
   // can surface quota / cap failures; the rest are best-effort.
   createClashPreset: (input: NewClashPreset) => SaveResult;
@@ -126,6 +134,7 @@ export const createClashSlice: StateCreator<ClashSlice, [], [], ClashSlice> = (s
     clashGroupBy: initial.groupBy,
     clashPresets: buildInitialPresets(),
     clashSelectedId: null,
+    clashHighlightColors: null,
 
     setClashPanelVisible: (clashPanelVisible) => set({ clashPanelVisible }),
     toggleClashPanel: () => set((s) => ({ clashPanelVisible: !s.clashPanelVisible })),
@@ -163,6 +172,7 @@ export const createClashSlice: StateCreator<ClashSlice, [], [], ClashSlice> = (s
     },
 
     setClashSelectedId: (clashSelectedId) => set({ clashSelectedId }),
+    setClashHighlightColors: (clashHighlightColors) => set({ clashHighlightColors }),
 
     createClashPreset: (input) => {
       const name = validatePresetName(input.name);
@@ -246,6 +256,7 @@ export const createClashSlice: StateCreator<ClashSlice, [], [], ClashSlice> = (s
         clashError: null,
         clashProgress: null,
         clashSelectedId: null,
+        clashHighlightColors: null,
       }),
   };
 };

--- a/packages/renderer/src/aabb-edges.test.ts
+++ b/packages/renderer/src/aabb-edges.test.ts
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { aabbEdgeLineList } from './index.ts';
+
+describe('aabbEdgeLineList (#1277 clash overlap box)', () => {
+  it('emits 12 edges (24 vertices, 72 floats)', () => {
+    const v = aabbEdgeLineList([0, 0, 0], [1, 2, 3]);
+    assert.equal(v.length, 72);
+  });
+
+  it('every coordinate is a corner of the AABB', () => {
+    const v = aabbEdgeLineList([0, 0, 0], [1, 2, 3]);
+    for (let i = 0; i < v.length; i += 3) {
+      assert.ok(v[i] === 0 || v[i] === 1, `x ${v[i]} is a box corner`);
+      assert.ok(v[i + 1] === 0 || v[i + 1] === 2, `y ${v[i + 1]} is a box corner`);
+      assert.ok(v[i + 2] === 0 || v[i + 2] === 3, `z ${v[i + 2]} is a box corner`);
+    }
+  });
+
+  it('each emitted edge has unit-length axis alignment (differs in exactly one axis)', () => {
+    const v = aabbEdgeLineList([0, 0, 0], [4, 5, 6]);
+    for (let e = 0; e < v.length; e += 6) {
+      const dx = v[e] !== v[e + 3] ? 1 : 0;
+      const dy = v[e + 1] !== v[e + 4] ? 1 : 0;
+      const dz = v[e + 2] !== v[e + 5] ? 1 : 0;
+      assert.equal(dx + dy + dz, 1, 'a box edge changes exactly one axis');
+    }
+  });
+});

--- a/packages/renderer/src/aabb-edges.test.ts
+++ b/packages/renderer/src/aabb-edges.test.ts
@@ -5,7 +5,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 
-import { aabbEdgeLineList } from './index.ts';
+import { aabbEdgeLineList } from './aabb-edges.ts';
 
 describe('aabbEdgeLineList (#1277 clash overlap box)', () => {
   it('emits 12 edges (24 vertices, 72 floats)', () => {

--- a/packages/renderer/src/aabb-edges.ts
+++ b/packages/renderer/src/aabb-edges.ts
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Build a flat line-list (`[x,y,z, …]`, 12 edges = 24 vertices) for the 12 edges
+ * of a world-space AABB. Used to draw the clash-overlap wireframe box (#1277).
+ */
+export function aabbEdgeLineList(
+  min: readonly [number, number, number],
+  max: readonly [number, number, number],
+): Float32Array {
+  const [x0, y0, z0] = min;
+  const [x1, y1, z1] = max;
+  // 8 corners
+  const c = [
+    [x0, y0, z0], [x1, y0, z0], [x1, y1, z0], [x0, y1, z0], // z0 face
+    [x0, y0, z1], [x1, y0, z1], [x1, y1, z1], [x0, y1, z1], // z1 face
+  ];
+  // 12 edges as corner-index pairs
+  const edges = [
+    [0, 1], [1, 2], [2, 3], [3, 0], // z0 ring
+    [4, 5], [5, 6], [6, 7], [7, 4], // z1 ring
+    [0, 4], [1, 5], [2, 6], [3, 7], // verticals
+  ];
+  const out = new Float32Array(edges.length * 2 * 3);
+  let o = 0;
+  for (const [a, b] of edges) {
+    out[o++] = c[a][0]; out[o++] = c[a][1]; out[o++] = c[a][2];
+    out[o++] = c[b][0]; out[o++] = c[b][1]; out[o++] = c[b][2];
+  }
+  return out;
+}

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -17,6 +17,7 @@ export { Picker } from './picker.js';
 export { MathUtils } from './math.js';
 export { SectionPlaneRenderer } from './section-plane.js';
 export { Section2DOverlayRenderer } from './section-2d-overlay.js';
+import { aabbEdgeLineList } from './aabb-edges.js';
 
 // IfcAnnotation overlay pipelines (3D world-space). Self-contained — caller
 // passes a GPUDevice + presentation format and invokes `.render(pass, viewProj)`
@@ -153,36 +154,6 @@ type ResolvedVisualEnhancement = {
  * share the same aggregate position-length total can't collide on the
  * same fingerprint and reuse a stale BVH.
  */
-/**
- * Build a flat line-list (`[x,y,z, …]`, 12 edges = 24 vertices) for the 12 edges
- * of a world-space AABB. Used to draw the clash-overlap wireframe box (#1277).
- */
-export function aabbEdgeLineList(
-    min: readonly [number, number, number],
-    max: readonly [number, number, number],
-): Float32Array {
-    const [x0, y0, z0] = min;
-    const [x1, y1, z1] = max;
-    // 8 corners
-    const c = [
-        [x0, y0, z0], [x1, y0, z0], [x1, y1, z0], [x0, y1, z0], // bottom (z0)
-        [x0, y0, z1], [x1, y0, z1], [x1, y1, z1], [x0, y1, z1], // top (z1)
-    ];
-    // 12 edges as corner-index pairs
-    const edges = [
-        [0, 1], [1, 2], [2, 3], [3, 0], // bottom ring
-        [4, 5], [5, 6], [6, 7], [7, 4], // top ring
-        [0, 4], [1, 5], [2, 6], [3, 7], // verticals
-    ];
-    const out = new Float32Array(edges.length * 2 * 3);
-    let o = 0;
-    for (const [a, b] of edges) {
-        out[o++] = c[a][0]; out[o++] = c[a][1]; out[o++] = c[a][2];
-        out[o++] = c[b][0]; out[o++] = c[b][1]; out[o++] = c[b][2];
-    }
-    return out;
-}
-
 function computeBvhFingerprint(meshes: ReadonlyArray<import('@ifc-lite/geometry').MeshData>): string {
     const parts: string[] = [String(meshes.length)];
     for (const m of meshes) {

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -1514,11 +1514,25 @@ export class Renderer {
                     const isSelected = (selectedId !== undefined && selectedId !== null && expressIdMatch && modelIndexMatch)
                         || (selectedIds !== undefined && selectedIds.has(mesh.expressId));
 
-                    meshBuf[32] = mesh.color[0];
-                    meshBuf[33] = mesh.color[1];
-                    meshBuf[34] = mesh.color[2];
-                    // Selected meshes always keep their own alpha so highlights stay opaque
-                    meshBuf[35] = isSelected ? mesh.color[3] : alphaForMesh(mesh.expressId, mesh.color[3]);
+                    // Per-element highlight tint (e.g. clash A vs B): when a
+                    // selected mesh has a highlight colour, paint it as the
+                    // albedo and flag the shader to glow it in that colour
+                    // instead of the default selection blue (#1277/#1339).
+                    const highlightColor = (isSelected && options.highlightColors)
+                        ? options.highlightColors.get(mesh.expressId)
+                        : undefined;
+                    if (highlightColor) {
+                        meshBuf[32] = highlightColor[0];
+                        meshBuf[33] = highlightColor[1];
+                        meshBuf[34] = highlightColor[2];
+                        meshBuf[35] = highlightColor[3];
+                    } else {
+                        meshBuf[32] = mesh.color[0];
+                        meshBuf[33] = mesh.color[1];
+                        meshBuf[34] = mesh.color[2];
+                        // Selected meshes always keep their own alpha so highlights stay opaque
+                        meshBuf[35] = isSelected ? mesh.color[3] : alphaForMesh(mesh.expressId, mesh.color[3]);
+                    }
                     meshBuf[36] = mesh.material?.metallic ?? 0.0;
                     meshBuf[37] = mesh.material?.roughness ?? 0.6;
                     meshBuf[38] = 0; meshBuf[39] = 0;
@@ -1537,8 +1551,9 @@ export class Renderer {
                     const clipBit = packClipBox(options.clipBox, meshBuf, 48);
 
                     // Flags (offset 44-47 as u32)
+                    // flags.x: bit 0 = isSelected, bit 4 (16) = custom highlight tint
                     // flags.y packs: bit 0 = sectionEnabled, bit 1 = flipped, bit 2 = clipBoxEnabled
-                    meshFlags[0] = isSelected ? 1 : 0;
+                    meshFlags[0] = (isSelected ? 1 : 0) | (highlightColor ? 16 : 0);
                     meshFlags[1] =
                         (sectionPlaneData?.enabled ? 1 : 0) |
                         (options.sectionPlane?.flipped ? 2 : 0) |

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -181,6 +181,9 @@ export class Renderer {
     // Overlay/section-cut line colour, kept on the Renderer so it survives a
     // pre-init call and a section2DOverlayRenderer re-creation (re-applied below).
     private overlayLineColor: readonly [number, number, number, number] = [0, 0, 0, 1];
+    // Ref-stable cache for the (hiddenIds ∪ instanced-highlight-ids) set passed to
+    // setInstancedVisibility, so its per-frame diff still no-ops during clash focus. (#1277)
+    private instancedHiddenUnionCache: { key: string; base: Set<number> | undefined; set: Set<number> } | null = null;
     // IfcAnnotation overlay pipelines (issue #653). Created on `init()` once
     // the device exists; nulled until then.
     private symbolicFillPipeline: SymbolicFillPipeline | null = null;
@@ -1117,11 +1120,37 @@ export class Renderer {
         // no instanced data is loaded. The flat path handles selection inline
         // below via `selectedExpressIds`.
         this.scene.setInstancedSelection(selectedExpressIds);
+
+        // A highlight-tinted id (clash pair) that is GPU-INSTANCED has no flat
+        // MeshData, so the per-element glow can't reach it and it would render the
+        // default selection blue. We materialize those occurrences as individual
+        // glow meshes in the hydration loop below; HIDE the instanced occurrence
+        // here so only the glowing individual mesh draws (no blue, no z-fight).
+        // (#1277/#1339)
+        const instancedHighlightIds = new Set<number>();
+        if (options.highlightColors) {
+            for (const id of options.highlightColors.keys()) {
+                if (this.scene.isInstancedEntity(id)) instancedHighlightIds.add(id);
+            }
+        }
         // Mirror hide/isolate onto the instanced occurrences (the flat path filters
         // its mesh list by hiddenIds/isolatedIds below; the instanced pass can't, so
         // it carries a per-instance hidden flag the shader discards on). Diffed → a
-        // no-op when visibility is unchanged.
-        this.scene.setInstancedVisibility(options.hiddenIds, options.isolatedIds);
+        // no-op when visibility is unchanged. Union in the materialized highlight ids
+        // via a ref-stable cache so the diff still skips when nothing changed.
+        let instancedHidden = options.hiddenIds;
+        if (instancedHighlightIds.size > 0) {
+            const key = `${options.hiddenIds ? [...options.hiddenIds].length : 0}|${[...instancedHighlightIds].sort((a, b) => a - b).join(',')}`;
+            if (this.instancedHiddenUnionCache?.key !== key || this.instancedHiddenUnionCache?.base !== options.hiddenIds) {
+                const set = new Set<number>(options.hiddenIds ?? []);
+                for (const id of instancedHighlightIds) set.add(id);
+                this.instancedHiddenUnionCache = { key, base: options.hiddenIds, set };
+            }
+            instancedHidden = this.instancedHiddenUnionCache.set;
+        } else {
+            this.instancedHiddenUnionCache = null;
+        }
+        this.scene.setInstancedVisibility(instancedHidden, options.isolatedIds);
 
         // Per-frame alpha overrides for X-Ray mode. See RenderOptions.transparencyOverrides.
         // Snapshot the caller's map so mid-frame mutation can't desync classification
@@ -2085,7 +2114,15 @@ export class Renderer {
                     }
 
                     for (const selId of visibleSelectedIds) {
-                        const pieces = this.scene.getMeshDataPieces(selId, selectedModelIndex);
+                        let pieces = this.scene.getMeshDataPieces(selId, selectedModelIndex);
+                        // Instanced clash element: no flat MeshData → materialize the
+                        // occurrence(s) so the flat path can glow it in the custom
+                        // highlight colour (the instanced occurrence is hidden above). (#1277)
+                        if ((!pieces || pieces.length === 0)
+                            && options.highlightColors?.has(selId)
+                            && this.scene.isInstancedEntity(selId)) {
+                            pieces = this.scene.getInstancedMeshDataPieces(selId);
+                        }
                         if (!pieces || pieces.length === 0) continue;
 
                         const seenOrdinalsByKey = new Map<string, number>();

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -2020,7 +2020,8 @@ export class Renderer {
                 const overrideBatches = this.scene.getOverrideBatches();
                 if (overrideBatches.length > 0) {
                     pass.setPipeline(this.pipeline.getOverlayPipeline());
-                    tplFlags[0] = 2;  // set overlay bit for the duration of these draws
+                    // bit 1 = overlay; bit 5 (32) = emphasize (pop) — see shader.
+                    tplFlags[0] = options.emphasizeOverrides ? (2 | 32) : 2;
                     for (const batch of overrideBatches) {
                         renderBatch(batch);
                     }

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -153,6 +153,36 @@ type ResolvedVisualEnhancement = {
  * share the same aggregate position-length total can't collide on the
  * same fingerprint and reuse a stale BVH.
  */
+/**
+ * Build a flat line-list (`[x,y,z, …]`, 12 edges = 24 vertices) for the 12 edges
+ * of a world-space AABB. Used to draw the clash-overlap wireframe box (#1277).
+ */
+export function aabbEdgeLineList(
+    min: readonly [number, number, number],
+    max: readonly [number, number, number],
+): Float32Array {
+    const [x0, y0, z0] = min;
+    const [x1, y1, z1] = max;
+    // 8 corners
+    const c = [
+        [x0, y0, z0], [x1, y0, z0], [x1, y1, z0], [x0, y1, z0], // bottom (z0)
+        [x0, y0, z1], [x1, y0, z1], [x1, y1, z1], [x0, y1, z1], // top (z1)
+    ];
+    // 12 edges as corner-index pairs
+    const edges = [
+        [0, 1], [1, 2], [2, 3], [3, 0], // bottom ring
+        [4, 5], [5, 6], [6, 7], [7, 4], // top ring
+        [0, 4], [1, 5], [2, 6], [3, 7], // verticals
+    ];
+    const out = new Float32Array(edges.length * 2 * 3);
+    let o = 0;
+    for (const [a, b] of edges) {
+        out[o++] = c[a][0]; out[o++] = c[a][1]; out[o++] = c[a][2];
+        out[o++] = c[b][0]; out[o++] = c[b][1]; out[o++] = c[b][2];
+    }
+    return out;
+}
+
 function computeBvhFingerprint(meshes: ReadonlyArray<import('@ifc-lite/geometry').MeshData>): string {
     const parts: string[] = [String(meshes.length)];
     for (const m of meshes) {
@@ -2368,6 +2398,9 @@ export class Renderer {
             if (this.section2DOverlayRenderer?.hasGridLines3D()) {
                 this.section2DOverlayRenderer.drawGridLines3D(pass, viewProj);
             }
+            if (this.section2DOverlayRenderer?.hasClashBoxLines3D()) {
+                this.section2DOverlayRenderer.drawClashBoxLines3D(pass, viewProj);
+            }
             if (this.symbolicTextPipeline?.hasGeometry()) {
                 // Pass viewport pixel dimensions so the shader can scale glyphs
                 // to a constant on-screen size (BIMvision-style annotations)
@@ -2849,6 +2882,26 @@ export class Renderer {
             this.section2DOverlayRenderer.clearGridLines3D();
             this.requestRender();
         }
+    }
+
+    /**
+     * Show (or clear) the clash-overlap box: the wireframe AABB of a focused
+     * clash, drawn in `color` so the overlap region reads as a distinct third
+     * colour next to the two glowing clash elements (#1277). Pass `null` to
+     * clear. `min`/`max` are world-space corners (clash works in world frame).
+     */
+    setClashOverlapBox(
+        box: { min: [number, number, number]; max: [number, number, number]; color: [number, number, number, number] } | null,
+    ): void {
+        if (!this.section2DOverlayRenderer) return;
+        if (!box) {
+            this.section2DOverlayRenderer.clearClashBoxLines3D();
+            this.requestRender();
+            return;
+        }
+        this.section2DOverlayRenderer.setClashBoxLineColor(box.color);
+        this.section2DOverlayRenderer.uploadClashBoxLines3D(aabbEdgeLineList(box.min, box.max));
+        this.requestRender();
     }
 
     /**

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -181,9 +181,6 @@ export class Renderer {
     // Overlay/section-cut line colour, kept on the Renderer so it survives a
     // pre-init call and a section2DOverlayRenderer re-creation (re-applied below).
     private overlayLineColor: readonly [number, number, number, number] = [0, 0, 0, 1];
-    // Ref-stable cache for the (hiddenIds ∪ instanced-highlight-ids) set passed to
-    // setInstancedVisibility, so its per-frame diff still no-ops during clash focus. (#1277)
-    private instancedHiddenUnionCache: { key: string; base: Set<number> | undefined; set: Set<number> } | null = null;
     // IfcAnnotation overlay pipelines (issue #653). Created on `init()` once
     // the device exists; nulled until then.
     private symbolicFillPipeline: SymbolicFillPipeline | null = null;
@@ -1101,17 +1098,6 @@ export class Renderer {
                 selectedExpressIds.add(id);
             }
         }
-        // Elements with a highlight tint (e.g. a focused clash pair) get the SAME
-        // render treatment as a selection — individual-mesh hydration, opaque
-        // forcing, stay-solid-through-ghost, and the re-lit glow — WITHOUT being
-        // in the store selection. So the clash colours show in isolate/ghost mode
-        // with no "selected" state. The flat path paints them their custom colour
-        // (bit 4) rather than selection blue. (#1277/#1339)
-        if (options.highlightColors) {
-            for (const id of options.highlightColors.keys()) {
-                selectedExpressIds.add(id);
-            }
-        }
         const hasSelected = selectedExpressIds.size > 0;
 
         // Keep the GPU-instanced occurrences' per-instance selected flag in sync.
@@ -1120,37 +1106,11 @@ export class Renderer {
         // no instanced data is loaded. The flat path handles selection inline
         // below via `selectedExpressIds`.
         this.scene.setInstancedSelection(selectedExpressIds);
-
-        // A highlight-tinted id (clash pair) that is GPU-INSTANCED has no flat
-        // MeshData, so the per-element glow can't reach it and it would render the
-        // default selection blue. We materialize those occurrences as individual
-        // glow meshes in the hydration loop below; HIDE the instanced occurrence
-        // here so only the glowing individual mesh draws (no blue, no z-fight).
-        // (#1277/#1339)
-        const instancedHighlightIds = new Set<number>();
-        if (options.highlightColors) {
-            for (const id of options.highlightColors.keys()) {
-                if (this.scene.isInstancedEntity(id)) instancedHighlightIds.add(id);
-            }
-        }
         // Mirror hide/isolate onto the instanced occurrences (the flat path filters
         // its mesh list by hiddenIds/isolatedIds below; the instanced pass can't, so
         // it carries a per-instance hidden flag the shader discards on). Diffed → a
-        // no-op when visibility is unchanged. Union in the materialized highlight ids
-        // via a ref-stable cache so the diff still skips when nothing changed.
-        let instancedHidden = options.hiddenIds;
-        if (instancedHighlightIds.size > 0) {
-            const key = `${options.hiddenIds ? [...options.hiddenIds].length : 0}|${[...instancedHighlightIds].sort((a, b) => a - b).join(',')}`;
-            if (this.instancedHiddenUnionCache?.key !== key || this.instancedHiddenUnionCache?.base !== options.hiddenIds) {
-                const set = new Set<number>(options.hiddenIds ?? []);
-                for (const id of instancedHighlightIds) set.add(id);
-                this.instancedHiddenUnionCache = { key, base: options.hiddenIds, set };
-            }
-            instancedHidden = this.instancedHiddenUnionCache.set;
-        } else {
-            this.instancedHiddenUnionCache = null;
-        }
-        this.scene.setInstancedVisibility(instancedHidden, options.isolatedIds);
+        // no-op when visibility is unchanged.
+        this.scene.setInstancedVisibility(options.hiddenIds, options.isolatedIds);
 
         // Per-frame alpha overrides for X-Ray mode. See RenderOptions.transparencyOverrides.
         // Snapshot the caller's map so mid-frame mutation can't desync classification
@@ -1552,28 +1512,14 @@ export class Renderer {
                     // For multi-model support: also check modelIndex if provided
                     const expressIdMatch = mesh.expressId === selectedId;
                     const modelIndexMatch = selectedModelIndex === undefined || mesh.modelIndex === selectedModelIndex;
-                    // Highlight-tinted elements (clash pair) are in selectedExpressIds
-                    // too, so they get the glow even when not in the store selection.
-                    const highlightColor = options.highlightColors?.get(mesh.expressId);
                     const isSelected = (selectedId !== undefined && selectedId !== null && expressIdMatch && modelIndexMatch)
-                        || (selectedIds !== undefined && selectedIds.has(mesh.expressId))
-                        || highlightColor !== undefined;
+                        || (selectedIds !== undefined && selectedIds.has(mesh.expressId));
 
-                    // Per-element highlight tint (e.g. clash A vs B): paint the
-                    // mesh its custom colour and flag the shader to glow it in
-                    // that colour instead of the default selection blue (#1277/#1339).
-                    if (highlightColor) {
-                        meshBuf[32] = highlightColor[0];
-                        meshBuf[33] = highlightColor[1];
-                        meshBuf[34] = highlightColor[2];
-                        meshBuf[35] = highlightColor[3];
-                    } else {
-                        meshBuf[32] = mesh.color[0];
-                        meshBuf[33] = mesh.color[1];
-                        meshBuf[34] = mesh.color[2];
-                        // Selected meshes always keep their own alpha so highlights stay opaque
-                        meshBuf[35] = isSelected ? mesh.color[3] : alphaForMesh(mesh.expressId, mesh.color[3]);
-                    }
+                    meshBuf[32] = mesh.color[0];
+                    meshBuf[33] = mesh.color[1];
+                    meshBuf[34] = mesh.color[2];
+                    // Selected meshes always keep their own alpha so highlights stay opaque
+                    meshBuf[35] = isSelected ? mesh.color[3] : alphaForMesh(mesh.expressId, mesh.color[3]);
                     meshBuf[36] = mesh.material?.metallic ?? 0.0;
                     meshBuf[37] = mesh.material?.roughness ?? 0.6;
                     meshBuf[38] = 0; meshBuf[39] = 0;
@@ -1592,9 +1538,8 @@ export class Renderer {
                     const clipBit = packClipBox(options.clipBox, meshBuf, 48);
 
                     // Flags (offset 44-47 as u32)
-                    // flags.x: bit 0 = isSelected, bit 4 (16) = custom highlight tint
                     // flags.y packs: bit 0 = sectionEnabled, bit 1 = flipped, bit 2 = clipBoxEnabled
-                    meshFlags[0] = (isSelected ? 1 : 0) | (highlightColor ? 16 : 0);
+                    meshFlags[0] = isSelected ? 1 : 0;
                     meshFlags[1] =
                         (sectionPlaneData?.enabled ? 1 : 0) |
                         (options.sectionPlane?.flipped ? 2 : 0) |
@@ -2114,15 +2059,7 @@ export class Renderer {
                     }
 
                     for (const selId of visibleSelectedIds) {
-                        let pieces = this.scene.getMeshDataPieces(selId, selectedModelIndex);
-                        // Instanced clash element: no flat MeshData → materialize the
-                        // occurrence(s) so the flat path can glow it in the custom
-                        // highlight colour (the instanced occurrence is hidden above). (#1277)
-                        if ((!pieces || pieces.length === 0)
-                            && options.highlightColors?.has(selId)
-                            && this.scene.isInstancedEntity(selId)) {
-                            pieces = this.scene.getInstancedMeshDataPieces(selId);
-                        }
+                        const pieces = this.scene.getMeshDataPieces(selId, selectedModelIndex);
                         if (!pieces || pieces.length === 0) continue;
 
                         const seenOrdinalsByKey = new Map<string, number>();

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -1097,6 +1097,17 @@ export class Renderer {
                 selectedExpressIds.add(id);
             }
         }
+        // Elements with a highlight tint (e.g. a focused clash pair) get the SAME
+        // render treatment as a selection — individual-mesh hydration, opaque
+        // forcing, stay-solid-through-ghost, and the re-lit glow — WITHOUT being
+        // in the store selection. So the clash colours show in isolate/ghost mode
+        // with no "selected" state. The flat path paints them their custom colour
+        // (bit 4) rather than selection blue. (#1277/#1339)
+        if (options.highlightColors) {
+            for (const id of options.highlightColors.keys()) {
+                selectedExpressIds.add(id);
+            }
+        }
         const hasSelected = selectedExpressIds.size > 0;
 
         // Keep the GPU-instanced occurrences' per-instance selected flag in sync.
@@ -1511,16 +1522,16 @@ export class Renderer {
                     // For multi-model support: also check modelIndex if provided
                     const expressIdMatch = mesh.expressId === selectedId;
                     const modelIndexMatch = selectedModelIndex === undefined || mesh.modelIndex === selectedModelIndex;
+                    // Highlight-tinted elements (clash pair) are in selectedExpressIds
+                    // too, so they get the glow even when not in the store selection.
+                    const highlightColor = options.highlightColors?.get(mesh.expressId);
                     const isSelected = (selectedId !== undefined && selectedId !== null && expressIdMatch && modelIndexMatch)
-                        || (selectedIds !== undefined && selectedIds.has(mesh.expressId));
+                        || (selectedIds !== undefined && selectedIds.has(mesh.expressId))
+                        || highlightColor !== undefined;
 
-                    // Per-element highlight tint (e.g. clash A vs B): when a
-                    // selected mesh has a highlight colour, paint it as the
-                    // albedo and flag the shader to glow it in that colour
-                    // instead of the default selection blue (#1277/#1339).
-                    const highlightColor = (isSelected && options.highlightColors)
-                        ? options.highlightColors.get(mesh.expressId)
-                        : undefined;
+                    // Per-element highlight tint (e.g. clash A vs B): paint the
+                    // mesh its custom colour and flag the shader to glow it in
+                    // that colour instead of the default selection blue (#1277/#1339).
                     if (highlightColor) {
                         meshBuf[32] = highlightColor[0];
                         meshBuf[33] = highlightColor[1];

--- a/packages/renderer/src/section-2d-overlay.ts
+++ b/packages/renderer/src/section-2d-overlay.ts
@@ -150,6 +150,14 @@ export class Section2DOverlayRenderer {
   private gridLineVertexBuffer: GPUBuffer | null = null;
   private gridLineVertexCount = 0;
 
+  // Standalone 3D clash-overlap-box overlay (#1277): the wireframe AABB of a
+  // focused clash, drawn in its OWN distinct colour (not the shared overlay
+  // line colour) so the overlap region reads as a third colour next to the two
+  // glowing clash elements.
+  private clashBoxLineVertexBuffer: GPUBuffer | null = null;
+  private clashBoxLineVertexCount = 0;
+  private clashBoxLineColor: readonly [number, number, number, number] = [1, 0, 1, 1];
+
   constructor(device: GPUDevice, format: GPUTextureFormat, sampleCount: number = 4) {
     this.device = device;
     this.format = format;
@@ -905,6 +913,62 @@ export class Section2DOverlayRenderer {
     pass.setBindGroup(0, this.bindGroup);
     pass.setVertexBuffer(0, this.gridLineVertexBuffer);
     pass.draw(this.gridLineVertexCount);
+  }
+
+  /** Colour for the clash-overlap box (its own, not the shared overlay colour). */
+  setClashBoxLineColor(color: readonly [number, number, number, number]): void {
+    this.clashBoxLineColor = color;
+  }
+
+  /**
+   * Upload the clash-overlap-box wireframe as a flat `[x,y,z, …]` line-list in
+   * world space (12 AABB edges = 24 vertices). Separate buffer + colour from the
+   * other overlays. Pass an empty array to clear. (#1277)
+   */
+  uploadClashBoxLines3D(vertices: Float32Array): void {
+    this.init();
+    if (this.clashBoxLineVertexBuffer) {
+      this.clashBoxLineVertexBuffer.destroy();
+      this.clashBoxLineVertexBuffer = null;
+    }
+    this.clashBoxLineVertexCount = 0;
+    if (vertices.length < 6) return;
+    this.clashBoxLineVertexBuffer = this.device.createBuffer({
+      size: vertices.byteLength,
+      usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+    });
+    this.device.queue.writeBuffer(this.clashBoxLineVertexBuffer, 0, vertices);
+    this.clashBoxLineVertexCount = vertices.length / 3;
+  }
+
+  clearClashBoxLines3D(): void {
+    if (this.clashBoxLineVertexBuffer) {
+      this.clashBoxLineVertexBuffer.destroy();
+      this.clashBoxLineVertexBuffer = null;
+    }
+    this.clashBoxLineVertexCount = 0;
+  }
+
+  hasClashBoxLines3D(): boolean {
+    return this.clashBoxLineVertexCount > 0;
+  }
+
+  /** Draw the clash-overlap box in its own colour. Same line pipeline. (#1277) */
+  drawClashBoxLines3D(pass: GPURenderPassEncoder, viewProj: Float32Array): void {
+    this.init();
+    if (!this.linePipeline || !this.uniformBuffer || !this.bindGroup) return;
+    if (!this.clashBoxLineVertexBuffer || this.clashBoxLineVertexCount === 0) return;
+
+    const uniforms = new Float32Array(40);
+    uniforms.set(viewProj, 0);
+    // planeOffset = 0 — vertices are already in world space.
+    uniforms.set(this.clashBoxLineColor, 36); // lineColor (byte offset 144)
+    this.device.queue.writeBuffer(this.uniformBuffer, 0, uniforms);
+
+    pass.setPipeline(this.linePipeline);
+    pass.setBindGroup(0, this.bindGroup);
+    pass.setVertexBuffer(0, this.clashBoxLineVertexBuffer);
+    pass.draw(this.clashBoxLineVertexCount);
   }
 
   /**

--- a/packages/renderer/src/shaders/main.wgsl.ts
+++ b/packages/renderer/src/shaders/main.wgsl.ts
@@ -381,7 +381,14 @@ export const mainShaderSource = `
           if (isSelected) {
             let shadeLum = dot(lightTerm, vec3<f32>(0.299, 0.587, 0.114));
             let shade = clamp(shadeLum * 1.55, 0.45, 1.2);
-            color = vec3<f32>(0.3, 0.6, 1.0) * shade;
+            // flags.x bit 4 (value 16) = custom highlight tint: use the per-mesh
+            // baseColor as the highlight albedo instead of the default selection
+            // blue, so distinct elements (e.g. the two sides of a clash) glow in
+            // distinct, vibrant colours while keeping the same re-lit glow,
+            // crease structure and opacity as a normal selection. (#1277/#1339)
+            let customHighlight = (uniforms.flags.x & 16u) != 0u;
+            let hlAlbedo = select(vec3<f32>(0.3, 0.6, 1.0), baseColor, customHighlight);
+            color = hlAlbedo * shade;
           }
 
           // Beautiful fresnel effect for transparent materials (glass)

--- a/packages/renderer/src/shaders/main.wgsl.ts
+++ b/packages/renderer/src/shaders/main.wgsl.ts
@@ -381,14 +381,7 @@ export const mainShaderSource = `
           if (isSelected) {
             let shadeLum = dot(lightTerm, vec3<f32>(0.299, 0.587, 0.114));
             let shade = clamp(shadeLum * 1.55, 0.45, 1.2);
-            // flags.x bit 4 (value 16) = custom highlight tint: use the per-mesh
-            // baseColor as the highlight albedo instead of the default selection
-            // blue, so distinct elements (e.g. the two sides of a clash) glow in
-            // distinct, vibrant colours while keeping the same re-lit glow,
-            // crease structure and opacity as a normal selection. (#1277/#1339)
-            let customHighlight = (uniforms.flags.x & 16u) != 0u;
-            let hlAlbedo = select(vec3<f32>(0.3, 0.6, 1.0), baseColor, customHighlight);
-            color = hlAlbedo * shade;
+            color = vec3<f32>(0.3, 0.6, 1.0) * shade;
           }
 
           // Beautiful fresnel effect for transparent materials (glass)

--- a/packages/renderer/src/shaders/main.wgsl.ts
+++ b/packages/renderer/src/shaders/main.wgsl.ts
@@ -384,6 +384,17 @@ export const mainShaderSource = `
             color = vec3<f32>(0.3, 0.6, 1.0) * shade;
           }
 
+          // flags.x bit 5 (value 32) = EMPHASIZE overlay: render the colour
+          // override almost full-bright (high floor) so it POPS like a highlight
+          // instead of reading as a normal lit material — used for the focused
+          // clash pair so its amber/cyan stands out against the model. Keeps a
+          // touch of per-face shading so form still reads. (#1277/#1339)
+          if (isOverlay && (uniforms.flags.x & 32u) != 0u) {
+            let shadeLum = dot(lightTerm, vec3<f32>(0.299, 0.587, 0.114));
+            let shade = clamp(shadeLum * 1.7, 0.85, 1.45);
+            color = baseColor * shade;
+          }
+
           // Beautiful fresnel effect for transparent materials (glass)
           // Skip when selected — the glass shine and desaturation wash out the
           // blue highlight, making it appear white instead of blue.

--- a/packages/renderer/src/shaders/main.wgsl.ts
+++ b/packages/renderer/src/shaders/main.wgsl.ts
@@ -385,14 +385,14 @@ export const mainShaderSource = `
           }
 
           // flags.x bit 5 (value 32) = EMPHASIZE overlay: render the colour
-          // override almost full-bright (high floor) so it POPS like a highlight
-          // instead of reading as a normal lit material — used for the focused
-          // clash pair so its amber/cyan stands out against the model. Keeps a
-          // touch of per-face shading so form still reads. (#1277/#1339)
-          if (isOverlay && (uniforms.flags.x & 32u) != 0u) {
-            let shadeLum = dot(lightTerm, vec3<f32>(0.299, 0.587, 0.114));
-            let shade = clamp(shadeLum * 1.7, 0.85, 1.45);
-            color = baseColor * shade;
+          // override FULLY UNLIT and saturated (no lighting attenuation, no
+          // wash-to-white) so the focused clash pair reads as a solid, vivid,
+          // distinct colour that pops against the lit model — like a clash tool.
+          // A faint normal-based shade keeps the silhouette from going flat. (#1277)
+          let emphasizedOverlay = isOverlay && (uniforms.flags.x & 32u) != 0u;
+          if (emphasizedOverlay) {
+            let facet = 0.85 + 0.15 * abs(dot(N, normalize(vec3<f32>(0.3, 1.0, 0.2))));
+            color = baseColor * facet;
           }
 
           // Beautiful fresnel effect for transparent materials (glass)
@@ -400,7 +400,9 @@ export const mainShaderSource = `
           // blue highlight, making it appear white instead of blue.
           // Also force alpha to 1.0 for selected objects so the highlight is
           // fully opaque (the selection pipeline has no alpha blending).
-          var finalAlpha = select(input.color.a, 1.0, isSelected);
+          // Emphasized clash overlay paints a SOLID vivid fill (force opaque) so
+          // it isn't blended down to a pale tint against the geometry beneath.
+          var finalAlpha = select(input.color.a, 1.0, isSelected || emphasizedOverlay);
           if (finalAlpha < 0.99 && !isSelected && !isOverlay) {
             // Calculate view direction for fresnel
             let V = normalize(-input.worldPos);

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -191,6 +191,12 @@ export interface RenderOptions {
   selectedId?: number | null;     // Currently selected mesh (for highlighting)
   selectedIds?: Set<number>;      // Multi-selection support
   /**
+   * Render the active colour overrides almost full-bright so they POP like a
+   * highlight rather than reading as normal lit materials. Used while a clash is
+   * focused so the amber/cyan pair stands out. (#1277/#1339)
+   */
+  emphasizeOverrides?: boolean;
+  /**
    * Per-frame alpha overrides — primary use case is X-Ray mode.
    *
    * Map<expressId, alpha 0..1>. Non-selected meshes/batches whose expressId

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -191,14 +191,6 @@ export interface RenderOptions {
   selectedId?: number | null;     // Currently selected mesh (for highlighting)
   selectedIds?: Set<number>;      // Multi-selection support
   /**
-   * Per-element highlight tint for SELECTED meshes — `Map<expressId, RGBA 0..1>`.
-   * A selected mesh whose id is here glows in that colour instead of the default
-   * selection blue (same re-lit glow treatment). Used to render the two sides of
-   * a clash in distinct, vibrant colours. Only applied to ids also in
-   * `selectedId`/`selectedIds`. (#1277/#1339)
-   */
-  highlightColors?: Map<number, [number, number, number, number]>;
-  /**
    * Per-frame alpha overrides — primary use case is X-Ray mode.
    *
    * Map<expressId, alpha 0..1>. Non-selected meshes/batches whose expressId

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -191,6 +191,14 @@ export interface RenderOptions {
   selectedId?: number | null;     // Currently selected mesh (for highlighting)
   selectedIds?: Set<number>;      // Multi-selection support
   /**
+   * Per-element highlight tint for SELECTED meshes — `Map<expressId, RGBA 0..1>`.
+   * A selected mesh whose id is here glows in that colour instead of the default
+   * selection blue (same re-lit glow treatment). Used to render the two sides of
+   * a clash in distinct, vibrant colours. Only applied to ids also in
+   * `selectedId`/`selectedIds`. (#1277/#1339)
+   */
+  highlightColors?: Map<number, [number, number, number, number]>;
+  /**
    * Per-frame alpha overrides — primary use case is X-Ray mode.
    *
    * Map<expressId, alpha 0..1>. Non-selected meshes/batches whose expressId


### PR DESCRIPTION
## Problem

Selecting a clash highlighted **both** clashing elements with the single selection colour, so you couldn't tell which was which — the #1339 complaint ("both objects clashing have the same color, which makes it very difficult to see what is going on"). #1277 asks to colour each object (and ideally the overlap) differently.

## Fix

`focusClash` now paints the pair in two distinct fill colours through the renderer colour-override channel (the same `pendingColorUpdates` → `scene.setColorOverrides` path the lens uses):

- **Element A → warm orange** `[0.96, 0.45, 0.13]`
- **Element B → cool blue** `[0.16, 0.5, 0.92]`

The normal selection **outline is still drawn on top** of both, so you keep the "this is the focused pair" cue plus a clear "which is which". Orange-vs-blue stays distinguishable under red/green colour-vision deficiency.

- `selectElement` (single-side step-through, #1276) paints the one element the A colour.
- Colours **reset** on `clearHighlight`, `highlightAll` (ambiguous there — an element can be A in one clash and B in another), and exit.

## Scope

This delivers the core of #1277/#1339 (A vs B distinct). The optional third item — drawing the **overlap region** as a third colour — needs a new wireframe-box overlay primitive in the renderer (the `Clash.bounds` AABB exists), which is a larger, riskier change; left as a follow-up.

## Notes

- Clash focus co-opts the shared colour-override channel (same one the lens writes), so focusing a clash while a lens is active replaces the lens colours for the pair. This is consistent with `focusClash` already taking over isolation/ghost on focus.

## Tests / verify

- Pure `buildClashPairColors` helper + unit tests: distinct colours, null-ref skip, degenerate self-clash, valid RGBA — 4/4. `turbo typecheck --filter=@ifc-lite/viewer` clean.
- In-viewer: load a model, run clash detection, select a result → the two elements render orange vs blue (previously both the same colour); Clear resets them.

(`apps/viewer` is a private app — no changeset.)

Fixes #1277
Fixes #1339

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clash views now highlight involved elements with distinct colors and show the clash overlap region as a dedicated wireframe box.
  * The clash panel now handles large result sets more smoothly with virtualized scrolling.
* **Bug Fixes**
  * Closing or clearing a clash no longer leaves stale highlight colors or overlap outlines behind.
  * Focus and frame behavior now better follows clash-specific selections when no normal selection is active.
* **Tests**
  * Added coverage for clash color assignment and edge-line rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->