### PR TITLE
fix(viewer): hide unplaced IfcType library geometry in Model view (#1353)

### DIFF
--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -43,6 +43,7 @@ import { createBlankIfcFile } from '@/utils/createBlankIfc';
 import type { MeshData, CoordinateInfo, GeometryResult, PointCloudAsset } from '@ifc-lite/geometry';
 import { type IfcDataStore, type MapConversion } from '@ifc-lite/parser';
 import { getEffectiveGeoreference } from '@/lib/geo/effective-georef';
+import { isMeshVisibleInViewMode } from '@/lib/type-view-visibility';
 
 const ZERO_VEC3 = { x: 0, y: 0, z: 0 };
 const DEFAULT_COORDINATE_INFO: CoordinateInfo = {
@@ -656,6 +657,35 @@ export function ViewportContainer() {
     // that arrives in a later batch even when the meshes array is mutated in place.
   }, [mergedGeometryResult, geometryContentVersion]);
 
+  // Does the model carry any PLACED occurrence (class 0)? Used to decide whether
+  // orphan type-library geometry (class 1) is clutter to hide in Model view or
+  // the only geometry that must stay visible (pure type-library files). Same
+  // incremental-scan pattern as hasTypeGeometry. (#1353)
+  const occGeoSourceRef = useRef<MeshData[] | null>(null);
+  const occGeoScanLenRef = useRef(0);
+  const sawOccurrenceRef = useRef(false);
+  const hasOccurrenceGeometry = useMemo(() => {
+    const meshes = mergedGeometryResult?.meshes;
+    if (!meshes || meshes.length === 0) {
+      occGeoSourceRef.current = meshes ?? null;
+      occGeoScanLenRef.current = meshes?.length ?? 0;
+      sawOccurrenceRef.current = false;
+      return false;
+    }
+    if (occGeoSourceRef.current !== meshes || meshes.length < occGeoScanLenRef.current) {
+      occGeoSourceRef.current = meshes;
+      occGeoScanLenRef.current = 0;
+      sawOccurrenceRef.current = false;
+    }
+    if (!sawOccurrenceRef.current) {
+      for (let i = occGeoScanLenRef.current; i < meshes.length; i++) {
+        if ((meshes[i].geometryClass ?? 0) === 0) { sawOccurrenceRef.current = true; break; }
+      }
+    }
+    occGeoScanLenRef.current = meshes.length;
+    return sawOccurrenceRef.current;
+  }, [mergedGeometryResult, geometryContentVersion]);
+
   // Persisted view mode may be 'types' from a prior model; fall back to 'model'
   // when the current geometry has no type library so "Types" never renders an
   // empty scene (and the now-hidden switch can't be used to recover).
@@ -676,6 +706,7 @@ export function ViewportContainer() {
   const filteredSourceRef = useRef<MeshData[] | null>(null);
   const filteredTypeVisRef = useRef(typeVisibility);
   const filteredTypeModeRef = useRef(effectiveViewMode);
+  const filteredHasOccRef = useRef(hasOccurrenceGeometry);
   const filteredVersionRef = useRef(0);
 
   const filteredGeometry = useMemo(() => {
@@ -700,7 +731,10 @@ export function ViewportContainer() {
       prevVis.virtualElements !== typeVisibility.virtualElements ||
       prevVis.site !== typeVisibility.site ||
       prevVis.ifcAnnotations !== typeVisibility.ifcAnnotations ||
-      filteredTypeModeRef.current !== effectiveViewMode;
+      filteredTypeModeRef.current !== effectiveViewMode ||
+      // Occurrence-presence flipping (e.g. occurrences stream in after orphan
+      // types) changes whether class-1 orphans render in Model view (#1353).
+      filteredHasOccRef.current !== hasOccurrenceGeometry;
     const sourceChanged = filteredSourceRef.current !== allMeshes;
     if (typeVisChanged || sourceChanged || allMeshes.length < filteredSourceLenRef.current) {
       cache.length = 0;
@@ -708,6 +742,7 @@ export function ViewportContainer() {
       filteredSourceRef.current = allMeshes;
       filteredTypeVisRef.current = typeVisibility;
       filteredTypeModeRef.current = effectiveViewMode;
+      filteredHasOccRef.current = hasOccurrenceGeometry;
     }
 
     const needsFilter = !typeVisibility.spaces || !typeVisibility.spatialZones || !typeVisibility.openings || !typeVisibility.virtualElements || !typeVisibility.site || !typeVisibility.ifcAnnotations;
@@ -718,19 +753,14 @@ export function ViewportContainer() {
       const mesh = allMeshes[i];
       const ifcType = mesh.ifcType;
 
-      // Model/Types view switch (#957 follow-up). geometryClass: 0 = occurrence,
-      // 1 = orphan type (no occurrence — shown in BOTH modes since it's the only
-      // geometry), 2 = instanced type-library shape. In 'model' mode hide class 2
-      // (else the AC20 duplicate boxes at the MappingOrigin reappear); in 'types'
-      // mode hide occurrences (class 0) so only the type library shows.
+      // Model/Types view switch (#957, #1353). geometryClass: 0 = occurrence,
+      // 1 = orphan type, 2 = instanced type-library shape, 3 = material-layer
+      // slice (treated like an occurrence — it's part of the real build-up).
+      // An orphan type (class 1) renders in Model view ONLY when the model has
+      // no placed occurrences (pure type-library file); otherwise it's unplaced
+      // library clutter and belongs in the Types view. See helper for the table.
       const geometryClass = mesh.geometryClass ?? 0;
-      // Class 3 = a material-layer slice. It IS rendered in 3D (the renderer
-      // draws it backface-culled so the build-up shows without the thin slabs
-      // z-fighting into a hollow shell), so it's treated like an occurrence
-      // (class 0) for the Model/Types switch.
-      if (effectiveViewMode === 'types') {
-        if (geometryClass === 0 || geometryClass === 3) continue;
-      } else if (geometryClass === 2) {
+      if (!isMeshVisibleInViewMode(geometryClass, effectiveViewMode, hasOccurrenceGeometry)) {
         continue;
       }
 
@@ -768,7 +798,7 @@ export function ViewportContainer() {
     // Return the same array reference — downstream change detection uses
     // geometryVersion (which increments each batch) instead of array identity.
     return cache;
-  }, [mergedGeometryResult, typeVisibility, effectiveViewMode]);
+  }, [mergedGeometryResult, typeVisibility, effectiveViewMode, hasOccurrenceGeometry]);
 
   // Version counter that changes every batch — triggers useGeometryStreaming
   // without requiring a new geometry array reference.

--- a/apps/viewer/src/lib/type-view-visibility.test.ts
+++ b/apps/viewer/src/lib/type-view-visibility.test.ts
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { isMeshVisibleInViewMode } from './type-view-visibility.js';
+
+describe('isMeshVisibleInViewMode (#1353)', () => {
+  describe('Model view of a real model (has occurrences)', () => {
+    const vis = (c: number) => isMeshVisibleInViewMode(c, 'model', true);
+    it('shows occurrences and layer slices', () => {
+      assert.equal(vis(0), true);
+      assert.equal(vis(3), true);
+    });
+    it('hides instanced-type duplicates', () => {
+      assert.equal(vis(2), false);
+    });
+    it('hides ORPHAN type-library geometry (the #1353 fix)', () => {
+      // Bonsai-authored unplaced IfcXxxType defs must not clutter the Model view.
+      assert.equal(vis(1), false);
+    });
+  });
+
+  describe('Model view of a pure type-library file (no occurrences — annex-E)', () => {
+    const vis = (c: number) => isMeshVisibleInViewMode(c, 'model', false);
+    it('STILL shows orphan types so the view is not blank (no regression)', () => {
+      assert.equal(vis(1), true);
+    });
+    it('still hides instanced-type duplicates', () => {
+      assert.equal(vis(2), false);
+    });
+  });
+
+  describe('Types view', () => {
+    const vis = (c: number) => isMeshVisibleInViewMode(c, 'types', true);
+    it('shows orphan + instanced type geometry', () => {
+      assert.equal(vis(1), true);
+      assert.equal(vis(2), true);
+    });
+    it('hides occurrences and layer slices', () => {
+      assert.equal(vis(0), false);
+      assert.equal(vis(3), false);
+    });
+  });
+
+  it('the Model/Types switch now actually changes what renders for a Bonsai model', () => {
+    // An orphan type flips visibility between the two modes (it was stuck-on before).
+    assert.notEqual(
+      isMeshVisibleInViewMode(1, 'model', true),
+      isMeshVisibleInViewMode(1, 'types', true),
+    );
+  });
+});

--- a/apps/viewer/src/lib/type-view-visibility.ts
+++ b/apps/viewer/src/lib/type-view-visibility.ts
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Model/Types view-switch visibility rule (#957, #1353).
+ *
+ * geometry_class on each mesh:
+ *   0 = placed occurrence
+ *   1 = orphan type      — a type RepresentationMap that no occurrence instances
+ *   2 = instanced type   — the type-library copy of a shape an occurrence places
+ *   3 = material-layer slice (rendered like an occurrence)
+ *
+ * `Model` view = the real building: placed occurrences + layer slices.
+ * `Types`  view = the type library: orphan + instanced type geometry.
+ *
+ * The subtlety #1353 fixes: an *orphan* type (class 1) used to render in BOTH
+ * views, because for a pure type-library file (buildingSMART annex-E, zero
+ * occurrences) it is the only geometry and hiding it would blank the screen.
+ * But a real model authored in Bonsai can also carry unplaced `IfcXxxType`
+ * definitions with geometry; those are type-library content and should NOT
+ * clutter the Model view — they belong in the Types view. So an orphan type is
+ * shown in Model view ONLY when the model has no placed occurrences at all.
+ */
+export type TypeViewMode = 'model' | 'types';
+
+export function isMeshVisibleInViewMode(
+  geometryClass: number,
+  viewMode: TypeViewMode,
+  hasOccurrenceGeometry: boolean,
+): boolean {
+  if (viewMode === 'types') {
+    // Type library only: orphan (1) + instanced (2) type geometry.
+    return geometryClass === 1 || geometryClass === 2;
+  }
+  // Model view.
+  if (geometryClass === 2) return false; // instanced-type duplicates never show here
+  if (geometryClass === 1) {
+    // Orphan type-library geometry: hide it once the model has real placed
+    // geometry (it lives in the Types view); keep it only for pure type-library
+    // files so the Model view isn't empty.
+    return !hasOccurrenceGeometry;
+  }
+  // class 0 (occurrence) and class 3 (layer slice) are the real model.
+  return true;
+}


### PR DESCRIPTION
## Problem

Type objects created in Bonsai (`IfcWallType`, `IfcSignType`, …) that should be hidden by default render in the 3D scene, and toggling the **Model / Types** switch does nothing — "I don't see any change when I go from types to model, they are still visible" (#1353).

## Root cause (confirmed on the reporter's model)

I ran the reporter's Bonsai model (EVO Norrlandsvägen, IfcOpenShell/Bonsai 0.8.5) through the geometry pipeline:

```
total meshes: 1088
  class 0 (occurrence):  1074
  class 1 (orphan-type):   14   ← IfcSignType, IfcFootingType, IfcActuatorType, IfcBuiltElementType, IfcMechanicalFastenerType
```

Those 14 are **genuine orphan types**: they carry geometry via a `RepresentationMap`, but no occurrence instantiates that map and no `IfcRelDefinesByType` references them (verified — they appear nowhere else in the file). The `geometry_class` tagging is **correct**.

The bug is the **view-filter rule**: an orphan type (class 1) was rendered in *both* Model and Types views. That rule exists for buildingSMART **annex-E** files which are *purely* type geometry (zero occurrences) — there, hiding the orphan would blank the screen. But a real model can also carry unplaced type-library definitions, and those shouldn't clutter the Model view.

## Fix (viewer-only)

An orphan type renders in **Model** view **only when the model has no placed occurrences** (pure type-library file); when real occurrences exist it's treated as type-library content and shown in the **Types** view only. So the switch now actually toggles those objects.

- New pure helper `isMeshVisibleInViewMode(geometryClass, viewMode, hasOccurrenceGeometry)` with the full class × mode table; the inline filter in `ViewportContainer` now delegates to it.
- `ViewportContainer` gains a `hasOccurrenceGeometry` signal (same incremental-scan pattern as the existing `hasTypeGeometry`) and rebuilds the filtered set when occurrence-presence flips during streaming.

**No geometry-pipeline / wasm / cache-format change** — the classification was already right.

## Tests / verify

- `type-view-visibility.test.ts`: model vs types × occurrence-present vs pure-library, including the annex-E **no-regression** case (orphan still shows when there are no occurrences) and that the switch now flips an orphan's visibility. 8/8. `turbo typecheck --filter=@ifc-lite/viewer` clean.
- In-viewer: load a Bonsai model with unplaced `IfcXxxType` geometry → in **Model** view the type objects are gone; switch to **Types** → they appear. A pure annex-E type-library file still shows its geometry in Model view.

(`apps/viewer` is private — no changeset.)

Fixes #1353