### PR TITLE
fix(viewer): light the Cesium GLB (normals + PBR) so walls don't look mis-cut

### DIFF
--- a/apps/viewer/src/components/viewer/CesiumOverlay.tsx
+++ b/apps/viewer/src/components/viewer/CesiumOverlay.tsx
@@ -560,6 +560,24 @@ export function CesiumOverlay({
             upAxis: Cesium.Axis.Z,
             forwardAxis: Cesium.Axis.X,
           });
+          // Ambient floor. The overlay composits transparently with the
+          // atmosphere/skybox off, so the scene's ONLY light is the directional
+          // sun — without an environment map the model's shadowed faces get no
+          // ambient and read muddy. Give the model a flat image-based-lighting
+          // ambient via a constant spherical-harmonic term: every surface stays
+          // readable while the sun still shapes the lit faces. (#1380)
+          try {
+            const ibl = (model as unknown as {
+              imageBasedLighting?: { sphericalHarmonicCoefficients: unknown };
+            }).imageBasedLighting;
+            if (ibl) {
+              const a = new Cesium.Cartesian3(0.72, 0.72, 0.75); // neutral daylight ambient
+              const z = Cesium.Cartesian3.ZERO;
+              ibl.sphericalHarmonicCoefficients = [a, z, z, z, z, z, z, z, z];
+            }
+          } catch (e) {
+            console.warn('[CesiumOverlay] could not set model ambient IBL:', e);
+          }
         } finally {
           URL.revokeObjectURL(glbUrl);
         }

--- a/apps/viewer/src/components/viewer/CesiumOverlay.tsx
+++ b/apps/viewer/src/components/viewer/CesiumOverlay.tsx
@@ -31,6 +31,7 @@ import {
 } from '@/lib/geo/cesium-placement';
 import { getEffectiveHorizontalScale, resolveMapUnitToMetreScale } from '@/lib/geo/geo-scale';
 import { egm96Undulation } from '@/lib/geo/egm96-undulation';
+import { buildMergedGLB } from '@/lib/geo/cesium-glb';
 import { applySolarScene, SunPathDome } from '@/lib/geo/cesium-sun';
 import { sunPosition, sunTimes } from '@ifc-lite/solar';
 
@@ -50,133 +51,7 @@ function loadCesium() {
   return cesiumPromise;
 }
 
-/**
- * Build a minimal GLB with all geometry merged into a SINGLE mesh.
- * This is MUCH faster than GLTFExporter (which creates one glTF node per IFC mesh).
- * For a 42K mesh model: GLTFExporter takes seconds, this takes ~100ms.
- */
-function buildMergedGLB(meshes: import('@ifc-lite/geometry').MeshData[]): Uint8Array {
-  // Pass 1: calculate total sizes
-  let totalVerts = 0;
-  let totalIdxs = 0;
-  for (const m of meshes) {
-    if (!m.positions?.length || !m.indices?.length) continue;
-    totalVerts += m.positions.length / 3;
-    totalIdxs += m.indices.length;
-  }
 
-  // Allocate merged buffers
-  const positions = new Float32Array(totalVerts * 3);
-  const colors = new Uint8Array(totalVerts * 4);
-  const indices = new Uint32Array(totalIdxs);
-
-  // Pass 2: merge
-  let vertOff = 0;
-  let idxOff = 0;
-  for (const m of meshes) {
-    if (!m.positions?.length || !m.indices?.length) continue;
-    const nv = m.positions.length / 3;
-    // Positions are in the element's local frame (world = origin + position);
-    // fold the per-mesh origin while merging so the GLB is world-space. No-op
-    // when origin is absent/[0,0,0].
-    const ox = m.origin?.[0] ?? 0, oy = m.origin?.[1] ?? 0, oz = m.origin?.[2] ?? 0;
-    if (ox !== 0 || oy !== 0 || oz !== 0) {
-      for (let i = 0; i < nv; i++) {
-        const s = (vertOff + i) * 3, t = i * 3;
-        positions[s] = m.positions[t] + ox;
-        positions[s + 1] = m.positions[t + 1] + oy;
-        positions[s + 2] = m.positions[t + 2] + oz;
-      }
-    } else {
-      positions.set(m.positions, vertOff * 3);
-    }
-    // Vertex colors from mesh color
-    const r = Math.round((m.color?.[0] ?? 0.7) * 255);
-    const g = Math.round((m.color?.[1] ?? 0.7) * 255);
-    const b = Math.round((m.color?.[2] ?? 0.7) * 255);
-    const a = Math.round((m.color?.[3] ?? 1.0) * 255);
-    for (let i = 0; i < nv; i++) {
-      const ci = (vertOff + i) * 4;
-      colors[ci] = r; colors[ci + 1] = g; colors[ci + 2] = b; colors[ci + 3] = a;
-    }
-    for (let i = 0; i < m.indices.length; i++) {
-      indices[idxOff + i] = m.indices[i] + vertOff;
-    }
-    vertOff += nv;
-    idxOff += m.indices.length;
-  }
-
-  // Compute bounds
-  let minX = Infinity, minY = Infinity, minZ = Infinity;
-  let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
-  for (let i = 0; i < positions.length; i += 3) {
-    const x = positions[i], y = positions[i + 1], z = positions[i + 2];
-    if (x < minX) minX = x; if (x > maxX) maxX = x;
-    if (y < minY) minY = y; if (y > maxY) maxY = y;
-    if (z < minZ) minZ = z; if (z > maxZ) maxZ = z;
-  }
-
-  // Build minimal glTF JSON
-  const posByteLen = positions.byteLength;
-  const colByteLen = colors.byteLength;
-  const idxByteLen = indices.byteLength;
-  const totalBinLen = posByteLen + colByteLen + idxByteLen;
-
-  const gltf = {
-    asset: { version: '2.0', generator: 'IFC-Lite-Cesium' },
-    scene: 0,
-    scenes: [{ nodes: [0] }],
-    nodes: [{ mesh: 0 }],
-    meshes: [{ primitives: [{ attributes: { POSITION: 0, COLOR_0: 1 }, indices: 2 }] }],
-    accessors: [
-      { bufferView: 0, componentType: 5126, count: totalVerts, type: 'VEC3', min: [minX, minY, minZ], max: [maxX, maxY, maxZ] },
-      { bufferView: 1, componentType: 5121, count: totalVerts, type: 'VEC4', normalized: true },
-      { bufferView: 2, componentType: 5125, count: totalIdxs, type: 'SCALAR' },
-    ],
-    bufferViews: [
-      { buffer: 0, byteOffset: 0, byteLength: posByteLen, target: 34962 },
-      { buffer: 0, byteOffset: posByteLen, byteLength: colByteLen, target: 34962 },
-      { buffer: 0, byteOffset: posByteLen + colByteLen, byteLength: idxByteLen, target: 34963 },
-    ],
-    buffers: [{ byteLength: totalBinLen }],
-    extensionsUsed: ['KHR_materials_unlit'],
-  };
-
-  const jsonStr = JSON.stringify(gltf);
-  const jsonBuf = new TextEncoder().encode(jsonStr);
-  // Pad JSON to 4-byte alignment
-  const jsonPad = (4 - (jsonBuf.length % 4)) % 4;
-  const jsonChunkLen = jsonBuf.length + jsonPad;
-  // Pad binary to 4-byte alignment
-  const binPad = (4 - (totalBinLen % 4)) % 4;
-  const binChunkLen = totalBinLen + binPad;
-
-  // GLB: 12-byte header + 8-byte JSON chunk header + JSON + 8-byte BIN chunk header + BIN
-  const glbLen = 12 + 8 + jsonChunkLen + 8 + binChunkLen;
-  const glb = new ArrayBuffer(glbLen);
-  const view = new DataView(glb);
-  let off = 0;
-
-  // GLB header
-  view.setUint32(off, 0x46546C67, true); off += 4; // magic "glTF"
-  view.setUint32(off, 2, true); off += 4;           // version
-  view.setUint32(off, glbLen, true); off += 4;       // total length
-
-  // JSON chunk
-  view.setUint32(off, jsonChunkLen, true); off += 4;
-  view.setUint32(off, 0x4E4F534A, true); off += 4;   // "JSON"
-  new Uint8Array(glb, off, jsonBuf.length).set(jsonBuf); off += jsonBuf.length;
-  for (let i = 0; i < jsonPad; i++) view.setUint8(off++, 0x20); // space padding
-
-  // BIN chunk
-  view.setUint32(off, binChunkLen, true); off += 4;
-  view.setUint32(off, 0x004E4942, true); off += 4;   // "BIN\0"
-  new Uint8Array(glb, off, posByteLen).set(new Uint8Array(positions.buffer)); off += posByteLen;
-  new Uint8Array(glb, off, colByteLen).set(colors); off += colByteLen;
-  new Uint8Array(glb, off, idxByteLen).set(new Uint8Array(indices.buffer)); off += idxByteLen;
-
-  return new Uint8Array(glb);
-}
 
 /**
  * Build a Cesium model matrix for placing the IFC model in ECEF.

--- a/apps/viewer/src/lib/geo/cesium-glb.test.ts
+++ b/apps/viewer/src/lib/geo/cesium-glb.test.ts
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { buildMergedGLB } from './cesium-glb.js';
+
+function makeMesh(over: Partial<{ positions: number[]; normals: number[]; indices: number[]; color: number[]; origin: number[] }> = {}) {
+  return {
+    expressId: 1,
+    ifcType: 'IfcWall',
+    positions: new Float32Array(over.positions ?? [0, 0, 0, 1, 0, 0, 0, 1, 0]),
+    normals: new Float32Array(over.normals ?? [0, 0, 1, 0, 0, 1, 0, 0, 1]),
+    indices: new Uint32Array(over.indices ?? [0, 1, 2]),
+    color: (over.color ?? [0.5, 0.5, 0.5, 1]) as [number, number, number, number],
+    origin: (over.origin ?? [0, 0, 0]) as [number, number, number],
+  } as unknown as import('@ifc-lite/geometry').MeshData;
+}
+
+/** Parse the GLB container → { json, binLength }. */
+function parseGlb(glb: Uint8Array) {
+  const dv = new DataView(glb.buffer, glb.byteOffset, glb.byteLength);
+  assert.equal(dv.getUint32(0, true), 0x46546c67, 'GLB magic');
+  assert.equal(dv.getUint32(4, true), 2, 'GLB version');
+  assert.equal(dv.getUint32(8, true), glb.byteLength, 'GLB total length matches buffer');
+  const jsonLen = dv.getUint32(12, true);
+  assert.equal(dv.getUint32(16, true), 0x4e4f534a, 'JSON chunk tag');
+  const jsonBytes = glb.subarray(20, 20 + jsonLen);
+  const json = JSON.parse(new TextDecoder().decode(jsonBytes));
+  const binHeaderOff = 20 + jsonLen;
+  const binLen = dv.getUint32(binHeaderOff, true);
+  assert.equal(dv.getUint32(binHeaderOff + 4, true), 0x004e4942, 'BIN chunk tag');
+  return { json, binLen };
+}
+
+describe('buildMergedGLB (#1355 Cesium shading)', () => {
+  it('emits a NORMAL attribute so Cesium can light the model', () => {
+    const { json } = parseGlb(buildMergedGLB([makeMesh()]));
+    const attrs = json.meshes[0].primitives[0].attributes;
+    assert.ok('NORMAL' in attrs, 'primitive must declare a NORMAL attribute');
+    assert.ok('POSITION' in attrs && 'COLOR_0' in attrs);
+  });
+
+  it('uses a LIT PBR material (no KHR_materials_unlit)', () => {
+    const { json } = parseGlb(buildMergedGLB([makeMesh()]));
+    assert.ok(!(json.extensionsUsed ?? []).includes('KHR_materials_unlit'), 'must not be unlit');
+    assert.ok(Array.isArray(json.materials) && json.materials.length === 1, 'has a material');
+    assert.equal(json.meshes[0].primitives[0].material, 0, 'primitive references the material');
+    assert.equal(json.materials[0].doubleSided, true, 'double-sided (IFC winding not reliably outward)');
+  });
+
+  it('accessor/bufferView byte math is self-consistent (4 views, sizes sum to BIN)', () => {
+    const { json, binLen } = parseGlb(buildMergedGLB([makeMesh(), makeMesh()]));
+    assert.equal(json.accessors.length, 4); // POSITION, NORMAL, COLOR_0, indices
+    assert.equal(json.bufferViews.length, 4);
+    const sum = json.bufferViews.reduce((acc: number, bv: { byteLength: number }) => acc + bv.byteLength, 0);
+    assert.equal(json.buffers[0].byteLength, sum, 'buffer length = sum of bufferViews');
+    assert.ok(binLen >= sum, 'BIN chunk holds the buffer (plus alignment pad)');
+    // 2 triangles, 3 verts each
+    assert.equal(json.accessors[0].count, 6); // POSITION vert count
+    assert.equal(json.accessors[1].count, 6); // NORMAL vert count
+    assert.equal(json.accessors[3].count, 6); // index count
+  });
+
+  it('folds per-mesh origin into world-space positions', () => {
+    const glb = buildMergedGLB([makeMesh({ origin: [10, 20, 30] })]);
+    const { json } = parseGlb(glb);
+    // POSITION accessor min should reflect the +[10,20,30] shift of vertex (0,0,0)
+    assert.deepEqual(json.accessors[0].min, [10, 20, 30]);
+  });
+});

--- a/apps/viewer/src/lib/geo/cesium-glb.ts
+++ b/apps/viewer/src/lib/geo/cesium-glb.ts
@@ -1,0 +1,163 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { MeshData } from '@ifc-lite/geometry';
+
+/**
+ * Build a minimal GLB with all geometry merged into a SINGLE mesh, for the
+ * Cesium 3D-map overlay. MUCH faster than the per-node GLTFExporter (42K-mesh
+ * model: GLTFExporter takes seconds, this ~100ms). It consumes the SAME canonical
+ * `MeshData` the WebGPU viewer renders (void cuts / rect-fast / local-frame
+ * already baked in by the Rust geometry engine) — no separate extraction.
+ *
+ * Packs POSITION + NORMAL + COLOR_0 and a lit double-sided PBR material so
+ * Cesium shades the model with its sun: recessed faces (window/door reveals)
+ * read as 3D instead of flat strips that look like wrong cuts (#1355 follow-up).
+ */
+export function buildMergedGLB(meshes: MeshData[]): Uint8Array {
+  // Pass 1: calculate total sizes
+  let totalVerts = 0;
+  let totalIdxs = 0;
+  for (const m of meshes) {
+    if (!m.positions?.length || !m.indices?.length) continue;
+    totalVerts += m.positions.length / 3;
+    totalIdxs += m.indices.length;
+  }
+
+  // Allocate merged buffers
+  const positions = new Float32Array(totalVerts * 3);
+  const normals = new Float32Array(totalVerts * 3);
+  const colors = new Uint8Array(totalVerts * 4);
+  const indices = new Uint32Array(totalIdxs);
+
+  // Pass 2: merge
+  let vertOff = 0;
+  let idxOff = 0;
+  for (const m of meshes) {
+    if (!m.positions?.length || !m.indices?.length) continue;
+    const nv = m.positions.length / 3;
+    // Positions are in the element's local frame (world = origin + position);
+    // fold the per-mesh origin while merging so the GLB is world-space. No-op
+    // when origin is absent/[0,0,0].
+    const ox = m.origin?.[0] ?? 0, oy = m.origin?.[1] ?? 0, oz = m.origin?.[2] ?? 0;
+    if (ox !== 0 || oy !== 0 || oz !== 0) {
+      for (let i = 0; i < nv; i++) {
+        const s = (vertOff + i) * 3, t = i * 3;
+        positions[s] = m.positions[t] + ox;
+        positions[s + 1] = m.positions[t + 1] + oy;
+        positions[s + 2] = m.positions[t + 2] + oz;
+      }
+    } else {
+      positions.set(m.positions, vertOff * 3);
+    }
+    // Normals (directions — not origin-shifted) so Cesium can light the model
+    // and recessed faces (window/door reveals) read as 3D instead of flat
+    // strips. Fall back to +Z for any mesh missing per-vertex normals.
+    if (m.normals?.length === nv * 3) {
+      normals.set(m.normals, vertOff * 3);
+    } else {
+      for (let i = 0; i < nv; i++) {
+        const s = (vertOff + i) * 3;
+        normals[s] = 0; normals[s + 1] = 0; normals[s + 2] = 1;
+      }
+    }
+    // Vertex colors from mesh color
+    const r = Math.round((m.color?.[0] ?? 0.7) * 255);
+    const g = Math.round((m.color?.[1] ?? 0.7) * 255);
+    const b = Math.round((m.color?.[2] ?? 0.7) * 255);
+    const a = Math.round((m.color?.[3] ?? 1.0) * 255);
+    for (let i = 0; i < nv; i++) {
+      const ci = (vertOff + i) * 4;
+      colors[ci] = r; colors[ci + 1] = g; colors[ci + 2] = b; colors[ci + 3] = a;
+    }
+    for (let i = 0; i < m.indices.length; i++) {
+      indices[idxOff + i] = m.indices[i] + vertOff;
+    }
+    vertOff += nv;
+    idxOff += m.indices.length;
+  }
+
+  // Compute bounds
+  let minX = Infinity, minY = Infinity, minZ = Infinity;
+  let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+  for (let i = 0; i < positions.length; i += 3) {
+    const x = positions[i], y = positions[i + 1], z = positions[i + 2];
+    if (x < minX) minX = x; if (x > maxX) maxX = x;
+    if (y < minY) minY = y; if (y > maxY) maxY = y;
+    if (z < minZ) minZ = z; if (z > maxZ) maxZ = z;
+  }
+  if (totalVerts === 0) { minX = minY = minZ = 0; maxX = maxY = maxZ = 0; }
+
+  // Build minimal glTF JSON. BIN layout: positions, normals, colors, indices.
+  const posByteLen = positions.byteLength;
+  const nrmByteLen = normals.byteLength;
+  const colByteLen = colors.byteLength;
+  const idxByteLen = indices.byteLength;
+  const totalBinLen = posByteLen + nrmByteLen + colByteLen + idxByteLen;
+
+  const gltf = {
+    asset: { version: '2.0', generator: 'IFC-Lite-Cesium' },
+    scene: 0,
+    scenes: [{ nodes: [0] }],
+    nodes: [{ mesh: 0 }],
+    // Lit PBR material (NOT unlit): Cesium shades it with its sun via the
+    // per-vertex normals so recessed reveals/cuts read in 3D. Vertex colours
+    // (COLOR_0) multiply the white baseColorFactor, so element colours show.
+    // Double-sided because IFC winding isn't reliably outward (see AGENTS.md).
+    materials: [{
+      pbrMetallicRoughness: { baseColorFactor: [1, 1, 1, 1], metallicFactor: 0, roughnessFactor: 0.9 },
+      doubleSided: true,
+    }],
+    meshes: [{ primitives: [{ attributes: { POSITION: 0, NORMAL: 1, COLOR_0: 2 }, indices: 3, material: 0 }] }],
+    accessors: [
+      { bufferView: 0, componentType: 5126, count: totalVerts, type: 'VEC3', min: [minX, minY, minZ], max: [maxX, maxY, maxZ] },
+      { bufferView: 1, componentType: 5126, count: totalVerts, type: 'VEC3' },
+      { bufferView: 2, componentType: 5121, count: totalVerts, type: 'VEC4', normalized: true },
+      { bufferView: 3, componentType: 5125, count: totalIdxs, type: 'SCALAR' },
+    ],
+    bufferViews: [
+      { buffer: 0, byteOffset: 0, byteLength: posByteLen, target: 34962 },
+      { buffer: 0, byteOffset: posByteLen, byteLength: nrmByteLen, target: 34962 },
+      { buffer: 0, byteOffset: posByteLen + nrmByteLen, byteLength: colByteLen, target: 34962 },
+      { buffer: 0, byteOffset: posByteLen + nrmByteLen + colByteLen, byteLength: idxByteLen, target: 34963 },
+    ],
+    buffers: [{ byteLength: totalBinLen }],
+  };
+
+  const jsonStr = JSON.stringify(gltf);
+  const jsonBuf = new TextEncoder().encode(jsonStr);
+  // Pad JSON to 4-byte alignment
+  const jsonPad = (4 - (jsonBuf.length % 4)) % 4;
+  const jsonChunkLen = jsonBuf.length + jsonPad;
+  // Pad binary to 4-byte alignment
+  const binPad = (4 - (totalBinLen % 4)) % 4;
+  const binChunkLen = totalBinLen + binPad;
+
+  // GLB: 12-byte header + 8-byte JSON chunk header + JSON + 8-byte BIN chunk header + BIN
+  const glbLen = 12 + 8 + jsonChunkLen + 8 + binChunkLen;
+  const glb = new ArrayBuffer(glbLen);
+  const view = new DataView(glb);
+  let off = 0;
+
+  // GLB header
+  view.setUint32(off, 0x46546C67, true); off += 4; // magic "glTF"
+  view.setUint32(off, 2, true); off += 4;           // version
+  view.setUint32(off, glbLen, true); off += 4;       // total length
+
+  // JSON chunk
+  view.setUint32(off, jsonChunkLen, true); off += 4;
+  view.setUint32(off, 0x4E4F534A, true); off += 4;   // "JSON"
+  new Uint8Array(glb, off, jsonBuf.length).set(jsonBuf); off += jsonBuf.length;
+  for (let i = 0; i < jsonPad; i++) view.setUint8(off++, 0x20); // space padding
+
+  // BIN chunk
+  view.setUint32(off, binChunkLen, true); off += 4;
+  view.setUint32(off, 0x004E4942, true); off += 4;   // "BIN\0"
+  new Uint8Array(glb, off, posByteLen).set(new Uint8Array(positions.buffer)); off += posByteLen;
+  new Uint8Array(glb, off, nrmByteLen).set(new Uint8Array(normals.buffer)); off += nrmByteLen;
+  new Uint8Array(glb, off, colByteLen).set(colors); off += colByteLen;
+  new Uint8Array(glb, off, idxByteLen).set(new Uint8Array(indices.buffer)); off += idxByteLen;
+
+  return new Uint8Array(glb);
+}


### PR DESCRIPTION
## What you saw

On the Cesium 3D map the building's outer walls look like they have **wrong cuts** — flat white strips where window/door reveals should be.

## Why (analysis)

The geometry is **not** wrong. The Cesium overlay's `buildMergedGLB` reuses the *exact same* canonical Rust `MeshData` the WebGPU viewer renders — void cuts, rect-fast and local-frame already baked in. (Geometry is already single-source canonical Rust: viewer, `GLTFExporter`, and this Cesium GLB all consume `process_geometry` output. No re-extraction, no divergence.)

The bug was purely in the GLB **representation**: `buildMergedGLB` packed only `POSITION` + `COLOR_0` and tagged the material `KHR_materials_unlit`. Unlit + no normals → Cesium can't shade the model, so the (correct) recessed reveals/cuts render as flat strips that read as mis-cut walls.

## Fix

- Emit a **NORMAL** attribute (per-vertex directions; +Z fallback for any mesh missing normals).
- Replace the unlit material with a **lit, double-sided PBR** material — `baseColorFactor` white so the `COLOR_0` vertex colours still show, now shaded by Cesium's sun. Double-sided because IFC winding isn't reliably outward (per AGENTS.md).
- Extract `buildMergedGLB` out of the `CesiumOverlay` component into a pure, testable module `apps/viewer/src/lib/geo/cesium-glb.ts`.

Result: the model on the map shades like the viewer — reveals read as 3D recesses, not flat cuts.

## Consolidation question (answered)

No geometry re-consolidation needed — the glTF/GLB geometry is already canonical Rust. The only drift was this TS-side packer dropping normals + being unlit; that's what this fixes. (A larger optional follow-up would unify `buildMergedGLB` with `GLTFExporter` in `packages/export`, but they intentionally differ: single merged mesh + vertex colours for Cesium perf vs per-node materials for archive export.)

## Tests / verify

- `cesium-glb.test.ts`: parses the emitted GLB and asserts NORMAL present, lit PBR material (not unlit, double-sided, primitive references it), self-consistent accessor/bufferView byte math, and origin folded into world positions. 4/4. `turbo typecheck` clean.
- In-viewer: load a georeferenced model, enable the Cesium 3D context → the building is shaded (reveals read in 3D) instead of flat strips.

(`apps/viewer` is private — no changeset.)