### PR TITLE
fix(viewer): count material-layer slices as placed geometry (#1353 follow-up)

### DIFF
--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -43,7 +43,7 @@ import { createBlankIfcFile } from '@/utils/createBlankIfc';
 import type { MeshData, CoordinateInfo, GeometryResult, PointCloudAsset } from '@ifc-lite/geometry';
 import { type IfcDataStore, type MapConversion } from '@ifc-lite/parser';
 import { getEffectiveGeoreference } from '@/lib/geo/effective-georef';
-import { isMeshVisibleInViewMode } from '@/lib/type-view-visibility';
+import { isMeshVisibleInViewMode, meshClassIsPlaced } from '@/lib/type-view-visibility';
 
 const ZERO_VEC3 = { x: 0, y: 0, z: 0 };
 const DEFAULT_COORDINATE_INFO: CoordinateInfo = {
@@ -679,7 +679,7 @@ export function ViewportContainer() {
     }
     if (!sawOccurrenceRef.current) {
       for (let i = occGeoScanLenRef.current; i < meshes.length; i++) {
-        if ((meshes[i].geometryClass ?? 0) === 0) { sawOccurrenceRef.current = true; break; }
+        if (meshClassIsPlaced(meshes[i].geometryClass ?? 0)) { sawOccurrenceRef.current = true; break; }
       }
     }
     occGeoScanLenRef.current = meshes.length;

--- a/apps/viewer/src/lib/type-view-visibility.test.ts
+++ b/apps/viewer/src/lib/type-view-visibility.test.ts
@@ -5,7 +5,19 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 
-import { isMeshVisibleInViewMode } from './type-view-visibility.js';
+import { isMeshVisibleInViewMode, meshClassIsPlaced } from './type-view-visibility.js';
+
+describe('meshClassIsPlaced (#1353 layer-slice follow-up)', () => {
+  it('counts occurrences (0) AND material-layer slices (3) as placed geometry', () => {
+    assert.equal(meshClassIsPlaced(0), true);
+    assert.equal(meshClassIsPlaced(3), true);
+  });
+  it('does NOT count type-library geometry (orphan 1 / instanced 2) as placed', () => {
+    // else a pure type-library file would wrongly think it has occurrences.
+    assert.equal(meshClassIsPlaced(1), false);
+    assert.equal(meshClassIsPlaced(2), false);
+  });
+});
 
 describe('isMeshVisibleInViewMode (#1353)', () => {
   describe('Model view of a real model (has occurrences)', () => {

--- a/apps/viewer/src/lib/type-view-visibility.ts
+++ b/apps/viewer/src/lib/type-view-visibility.ts
@@ -24,6 +24,16 @@
  */
 export type TypeViewMode = 'model' | 'types';
 
+/**
+ * Does this mesh's geometry_class count as PLACED (real-model) geometry?
+ * Class 0 (occurrence) AND class 3 (material-layer slice) are both placed —
+ * a model whose layered walls/slabs are emitted as slices still "has
+ * occurrences", so orphan type-library geometry must hide in Model view. (#1353)
+ */
+export function meshClassIsPlaced(geometryClass: number): boolean {
+  return geometryClass === 0 || geometryClass === 3;
+}
+
 export function isMeshVisibleInViewMode(
   geometryClass: number,
   viewMode: TypeViewMode,


### PR DESCRIPTION
Follow-up to #1379 (Codex review). The `hasOccurrenceGeometry` scan only recognised `geometry_class === 0`, but **class 3 (material-layer slices)** is also placed real-model geometry. A model whose layered walls/slabs are emitted as slices *plus* an orphan `IfcXxxType` would leave `hasOccurrenceGeometry=false`, so the orphan type-library geometry would wrongly reappear in **Model** view — the exact regression #1353 fixed, in a different geometry shape.

Fix: extract `meshClassIsPlaced(geometryClass)` (class 0 **or** 3) and use it for the occurrence scan. Pure type-library files (only class 1/2) still correctly report no occurrences, so the annex-E no-blank-screen behaviour is preserved.

Tests: `meshClassIsPlaced` (0/3 placed, 1/2 not) + existing `isMeshVisibleInViewMode` suite — 10/10. `turbo typecheck` clean.

Relates to #1353