### PR TITLE
fix(geometry): recover from stale-deploy WASM MIME error (#1363)

### DIFF
--- a/.changeset/wasm-version-skew-recovery.md
+++ b/.changeset/wasm-version-skew-recovery.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Detect and broadcast the "stale deployment" WASM-asset failure so hosts can recover from version skew. When a production deploy rotates the content-hashed `ifc-lite_bg-<hash>.wasm` under a still-open tab, the lazy fetch 404s (served as `text/plain`) and `WebAssembly.instantiateStreaming` throws `Response has unsupported MIME type 'text/plain' … expected 'application/wasm'` — the engine never initializes (#1363). A same-URL retry can't recover a rotated asset, so the geometry engine now classifies this case (`isWasmAssetUnavailableError`) and dispatches a `WASM_ASSET_UNAVAILABLE_EVENT` on `globalThis` at its init choke points (the main-thread `GeometryProcessor.init` and the worker-pool error handlers). The library never reloads the page itself; an opted-in host (the viewer) listens and reloads once onto the current deployment.

--- a/.changeset/wasm-version-skew-recovery.md
+++ b/.changeset/wasm-version-skew-recovery.md
@@ -1,5 +1,5 @@
 ---
-"@ifc-lite/geometry": patch
+"@ifc-lite/geometry": minor
 ---
 
 Detect and broadcast the "stale deployment" WASM-asset failure so hosts can recover from version skew. When a production deploy rotates the content-hashed `ifc-lite_bg-<hash>.wasm` under a still-open tab, the lazy fetch 404s (served as `text/plain`) and `WebAssembly.instantiateStreaming` throws `Response has unsupported MIME type 'text/plain' … expected 'application/wasm'` — the engine never initializes (#1363). A same-URL retry can't recover a rotated asset, so the geometry engine now classifies this case (`isWasmAssetUnavailableError`) and dispatches a `WASM_ASSET_UNAVAILABLE_EVENT` on `globalThis` at its init choke points (the main-thread `GeometryProcessor.init` and the worker-pool error handlers). The library never reloads the page itself; an opted-in host (the viewer) listens and reloads once onto the current deployment.

--- a/apps/viewer/src/lib/load-errors.test.ts
+++ b/apps/viewer/src/lib/load-errors.test.ts
@@ -27,6 +27,36 @@ describe('classifyLoadError', () => {
     assert.equal(classifyLoadError(new Error('NetworkError when attempting to fetch wasm')), 'wasm_engine_load');
   });
 
+  it('classifies the wrong-MIME engine binary as wasm_engine_load (issue #1363)', () => {
+    // A deploy rotated the hashed wasm under an open tab, so the 404 page
+    // (served as text/plain) stands in for it and the streaming loader rejects.
+    // Firefox phrasing (the exact message captured in PostHog):
+    assert.equal(
+      classifyLoadError(
+        new TypeError(
+          "WebAssembly: Response has unsupported MIME type 'text/plain; charset=utf-8' expected 'application/wasm'",
+        ),
+      ),
+      'wasm_engine_load',
+    );
+    // Chromium phrasing:
+    assert.equal(
+      classifyLoadError(
+        new TypeError("Incorrect response MIME type. Expected 'application/wasm'."),
+      ),
+      'wasm_engine_load',
+    );
+    // Wrapped by the geometry worker pool, it must still classify the same.
+    assert.equal(
+      classifyLoadError(
+        new Error(
+          "Geometry worker error: WebAssembly: Response has unsupported MIME type 'text/plain; charset=utf-8' expected 'application/wasm'",
+        ),
+      ),
+      'wasm_engine_load',
+    );
+  });
+
   it('classifies out-of-memory failures', () => {
     assert.equal(classifyLoadError(new Error('memory access out of bounds')), 'out_of_memory');
     assert.equal(classifyLoadError(new Error('Cannot enlarge memory arrays')), 'out_of_memory');

--- a/apps/viewer/src/lib/load-errors.ts
+++ b/apps/viewer/src/lib/load-errors.ts
@@ -51,15 +51,21 @@ function messageOf(err: unknown): string {
 /**
  * The geometry engine binary (`ifc-lite_bg.wasm`) failed to load. This is a
  * download/compile failure of the WASM module itself, not a problem with the
- * IFC file — the binary 404'd, was served with a non-OK status, or the fetch
- * was blocked (corporate proxy / antivirus / offline). wasm-bindgen's loader
- * cannot recover from a non-OK HTTP status, so it rethrows.
+ * IFC file — the binary 404'd, was served with a non-OK status, was served
+ * with the wrong MIME type, or the fetch was blocked (corporate proxy /
+ * antivirus / offline). wasm-bindgen's loader cannot recover from a non-OK
+ * HTTP status, so it rethrows.
  */
 function isWasmEngineLoadError(message: string): boolean {
   return (
     /HTTP status code is not ok/i.test(message) ||
     // `compile`/`compileStreaming`/`instantiate`/`instantiateStreaming` on `WebAssembly`.
     /'(compile|compileStreaming|instantiate|instantiateStreaming)' on 'WebAssembly'/i.test(message) ||
+    // Wrong MIME type for the engine binary — a deploy rotated the hashed wasm
+    // under an open tab, so the 404 page (text/plain) stands in for it. Firefox
+    // phrases this `Response has unsupported MIME type … expected 'application/wasm'`,
+    // Chromium `Incorrect response MIME type. Expected 'application/wasm'.` (#1363).
+    (/application\/wasm/i.test(message) && /mime|content[- ]?type|unsupported|incorrect|expected/i.test(message)) ||
     // Streaming-fetch failure for the engine binary specifically.
     (/wasm/i.test(message) && /failed to fetch|networkerror|load failed/i.test(message)) ||
     /ifc-lite_bg\.wasm/i.test(message)

--- a/apps/viewer/src/lib/wasm-version-skew.test.ts
+++ b/apps/viewer/src/lib/wasm-version-skew.test.ts
@@ -1,0 +1,89 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  recoverFromWasmVersionSkew,
+  installWasmVersionSkewRecovery,
+  __resetWasmVersionSkewForTests,
+  type VersionSkewDeps,
+} from './wasm-version-skew.js';
+
+const MIME_SKEW =
+  "WebAssembly: Response has unsupported MIME type 'text/plain; charset=utf-8' expected 'application/wasm'";
+
+/** A controllable clock + in-memory reload bookkeeping for the recovery deps. */
+class Harness {
+  reloads = 0;
+  private now: number;
+  private lastReloadAt: number | null = null;
+  readonly deps: VersionSkewDeps;
+
+  constructor(initialNow = 1_000_000) {
+    this.now = initialNow;
+    this.deps = {
+      now: () => this.now,
+      reload: () => {
+        this.reloads += 1;
+      },
+      hasRecentReload: (n) => this.lastReloadAt != null && n - this.lastReloadAt < 60_000,
+      rememberReload: (n) => {
+        this.lastReloadAt = n;
+      },
+    };
+  }
+
+  setNow(n: number): void {
+    this.now = n;
+  }
+}
+
+function makeDeps(initialNow = 1_000_000): Harness {
+  return new Harness(initialNow);
+}
+
+describe('recoverFromWasmVersionSkew', () => {
+  it('reloads once on a stale-deploy WASM MIME error (issue #1363)', () => {
+    const h = makeDeps();
+    assert.equal(recoverFromWasmVersionSkew(MIME_SKEW, h.deps), true);
+    assert.equal(h.reloads, 1);
+  });
+
+  it('does NOT reload for an unrelated error', () => {
+    const h = makeDeps();
+    assert.equal(recoverFromWasmVersionSkew('RangeError: invalid array length', h.deps), false);
+    assert.equal(h.reloads, 0);
+  });
+
+  it('debounces a second skew within the window (no reload loop)', () => {
+    const h = makeDeps(1_000_000);
+    assert.equal(recoverFromWasmVersionSkew(MIME_SKEW, h.deps), true);
+    h.setNow(1_030_000); // +30s, still inside the 60s window
+    assert.equal(recoverFromWasmVersionSkew(MIME_SKEW, h.deps), false);
+    assert.equal(h.reloads, 1);
+  });
+
+  it('recovers again after the debounce window elapses (later redeploy)', () => {
+    const h = makeDeps(1_000_000);
+    assert.equal(recoverFromWasmVersionSkew(MIME_SKEW, h.deps), true);
+    h.setNow(1_000_000 + 61_000); // past the window
+    assert.equal(recoverFromWasmVersionSkew(MIME_SKEW, h.deps), true);
+    assert.equal(h.reloads, 2);
+  });
+
+  it('accepts an Error object, not just a string', () => {
+    const h = makeDeps();
+    assert.equal(recoverFromWasmVersionSkew(new TypeError(MIME_SKEW), h.deps), true);
+    assert.equal(h.reloads, 1);
+  });
+});
+
+describe('installWasmVersionSkewRecovery', () => {
+  it('is a safe no-op without a DOM window', () => {
+    __resetWasmVersionSkewForTests();
+    // No `window` in the node:test runtime — must not throw.
+    assert.doesNotThrow(() => installWasmVersionSkewRecovery());
+  });
+});

--- a/apps/viewer/src/lib/wasm-version-skew.ts
+++ b/apps/viewer/src/lib/wasm-version-skew.ts
@@ -1,0 +1,121 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Recover from "deployment skew": a tab that has been open across a production
+ * deploy holds JS referencing a content-hashed `ifc-lite_bg-<hash>.wasm` that
+ * the new deploy rotated away. The lazy fetch 404s (served as `text/plain`), so
+ * `WebAssembly.instantiateStreaming` throws
+ * `unsupported MIME type 'text/plain' … expected 'application/wasm'` and the
+ * engine never initializes (issue #1363).
+ *
+ * The asset is gone for good, so a same-URL retry can't help — the only fix is
+ * to reload the document so the browser pulls the current deployment's HTML and
+ * its fresh asset URLs. The `@ifc-lite/geometry` engine broadcasts
+ * {@link WASM_ASSET_UNAVAILABLE_EVENT} when it hits this; we also watch the
+ * global error channels as a backstop for any wasm asset (parser, direct
+ * imports) that bubbles unhandled.
+ *
+ * The reload is debounced per tab so a genuinely broken deploy (where the new
+ * assets are also unreachable) can't spin in a reload loop.
+ */
+
+import {
+  isWasmAssetUnavailableError,
+  WASM_ASSET_UNAVAILABLE_EVENT,
+} from '@ifc-lite/geometry';
+
+/** sessionStorage key holding the epoch-ms of the last skew-triggered reload. */
+const RELOAD_TS_KEY = 'ifclite:wasm-skew-reload-ts';
+
+/**
+ * Minimum gap between skew reloads in one tab. A successful reload fixes the
+ * skew well within this window; a still-broken deploy is therefore allowed to
+ * surface its error instead of looping. After the window elapses, a genuinely
+ * new deploy later in a long session can recover again.
+ */
+const RELOAD_DEBOUNCE_MS = 60_000;
+
+function recentlyReloaded(now: number): boolean {
+  try {
+    const raw = sessionStorage.getItem(RELOAD_TS_KEY);
+    if (raw == null) return false;
+    const ts = Number(raw);
+    return Number.isFinite(ts) && now - ts < RELOAD_DEBOUNCE_MS;
+  } catch {
+    return false;
+  }
+}
+
+function markReloaded(now: number): void {
+  try {
+    sessionStorage.setItem(RELOAD_TS_KEY, String(now));
+  } catch {
+    /* sessionStorage blocked (private mode / disabled) — still reload once */
+  }
+}
+
+export interface VersionSkewDeps {
+  now: () => number;
+  reload: () => void;
+  hasRecentReload: (now: number) => boolean;
+  rememberReload: (now: number) => void;
+}
+
+const defaultDeps: VersionSkewDeps = {
+  now: () => Date.now(),
+  reload: () => window.location.reload(),
+  hasRecentReload: recentlyReloaded,
+  rememberReload: markReloaded,
+};
+
+/**
+ * If `err` carries the stale-deployment WASM signature, reload the page once
+ * (debounced per tab). Returns `true` when a reload was triggered. Exposed with
+ * injectable deps for unit testing; production callers omit `deps`.
+ */
+export function recoverFromWasmVersionSkew(
+  err: unknown,
+  deps: VersionSkewDeps = defaultDeps,
+): boolean {
+  if (!isWasmAssetUnavailableError(err)) return false;
+  const now = deps.now();
+  if (deps.hasRecentReload(now)) return false;
+  deps.rememberReload(now);
+  deps.reload();
+  return true;
+}
+
+let installed = false;
+
+/**
+ * Wire the event-driven + global-backstop recovery. Idempotent; call once at
+ * app boot. No-op outside a browser window (SSR / tests without a DOM).
+ */
+export function installWasmVersionSkewRecovery(): void {
+  if (installed || typeof window === 'undefined') return;
+  installed = true;
+
+  // Explicit signal from the geometry engine's init choke points. This covers
+  // the common case where the app caught + reported the failure rather than
+  // letting it bubble to the global handlers below.
+  window.addEventListener(WASM_ASSET_UNAVAILABLE_EVENT, (event) => {
+    const detail = (event as CustomEvent<{ message?: string }>).detail;
+    recoverFromWasmVersionSkew(detail?.message ?? '');
+  });
+
+  // Backstop for any wasm asset error that bubbles unhandled — parser wasm,
+  // direct `@ifc-lite/wasm` imports, third-party wasm, etc.
+  window.addEventListener('unhandledrejection', (event) => {
+    recoverFromWasmVersionSkew(event.reason);
+  });
+  window.addEventListener('error', (event) => {
+    recoverFromWasmVersionSkew(event.error ?? event.message);
+  });
+}
+
+/** Test-only: reset the install guard so the module can be re-wired. */
+export function __resetWasmVersionSkewForTests(): void {
+  installed = false;
+}

--- a/apps/viewer/src/main.tsx
+++ b/apps/viewer/src/main.tsx
@@ -31,6 +31,15 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 // side-effect import; keeps `@ifc-lite/parser` out of placement-edit
 // itself so its overlay-path logic stays unit-testable.
 import './lib/placement-edit.boot';
+import { installWasmVersionSkewRecovery } from './lib/wasm-version-skew';
+
+// WASM engine-binary recovery — the sibling of the chunk recovery below for the
+// `ifc-lite_bg.wasm` binary, which wasm-bindgen fetches inside a worker and so
+// is invisible to Vite's `vite:preloadError`. When a deploy rotates the hashed
+// wasm under an open tab the lazy fetch 404s (served as text/plain) and the
+// engine throws an `application/wasm` MIME error (#1363); reload once, debounced,
+// to pull the current deployment's assets.
+installWasmVersionSkewRecovery();
 
 // Post-mount chunk recovery — complements the inline boot self-heal in
 // index.html. The boot watchdog handles the ENTRY failing to load; this handles

--- a/packages/geometry/src/geometry-parallel.ts
+++ b/packages/geometry/src/geometry-parallel.ts
@@ -29,6 +29,7 @@ import type { MeshData, TessellationQuality } from './types.js';
 import type { StreamingGeometryEvent } from './index.js';
 import { computeWorkerCount } from './worker-count.js';
 import type { BatchSizingConfig } from './batch-sizing.js';
+import { notifyIfWasmAssetUnavailable } from './wasm-asset-error.js';
 
 /**
  * Plan content-affinity routing for one chunk: assign each job (by index) to a
@@ -406,6 +407,9 @@ export async function* processParallel(
         return;
       }
       if (msg.type === 'error') {
+        // A rotated/missing engine binary after a redeploy (#1363) surfaces
+        // here as the worker's wasm-init failure — let the host reload.
+        notifyIfWasmAssetUnavailable(msg.message);
         workerError = new Error(`Geometry worker error: ${msg.message}`);
         workersCompleted++;
         worker.terminate();
@@ -424,6 +428,7 @@ export async function* processParallel(
         (err?.message && String(err.message)) ||
         (err?.filename ? `at ${err.filename}:${err.lineno ?? 0}` : '') ||
         'worker terminated unexpectedly';
+      notifyIfWasmAssetUnavailable(detail);
       workerError = new Error(`Geometry worker failed: ${detail}`);
       workersCompleted++;
       worker.terminate();
@@ -861,6 +866,10 @@ export async function* processParallel(
       return;
     }
     if (data.type === 'error') {
+      // The streaming pre-pass is the first thing to touch the engine binary,
+      // so a stale-deploy 404 of the wasm (#1363) lands here — let the host
+      // reload onto the current deployment.
+      notifyIfWasmAssetUnavailable(data.message);
       prepassError = new Error(data.message);
       prepassDone = true;
       prepassWorker.terminate();
@@ -872,6 +881,7 @@ export async function* processParallel(
     // `buildPrePassStreaming`. We treat unknown messages as no-ops.
   };
   prepassWorker.onerror = (e) => {
+    notifyIfWasmAssetUnavailable(e.message);
     prepassError = new Error(`Pre-pass worker failed: ${e.message}`);
     prepassDone = true;
     prepassWorker.terminate();

--- a/packages/geometry/src/index.ts
+++ b/packages/geometry/src/index.ts
@@ -33,10 +33,11 @@ export { GeometryQuality } from './progressive-loader.js';
 export { computeWorkerCount, pickWorkerCount, type WorkerCountInputs, type WorkerCountResult } from './worker-count.js';
 export { getGeometryStreamWatchdogMs, type WatchdogInputs } from './watchdog.js';
 // Stale-deployment WASM-asset detection (#1363). The host app subscribes to
-// WASM_ASSET_UNAVAILABLE_EVENT to reload onto the current deployment.
+// WASM_ASSET_UNAVAILABLE_EVENT and uses `isWasmAssetUnavailableError` to reload
+// onto the current deployment. `notifyIfWasmAssetUnavailable` stays internal —
+// it is the engine-side dispatcher, imported directly where it fires.
 export {
   isWasmAssetUnavailableError,
-  notifyIfWasmAssetUnavailable,
   WASM_ASSET_UNAVAILABLE_EVENT,
 } from './wasm-asset-error.js';
 export {

--- a/packages/geometry/src/index.ts
+++ b/packages/geometry/src/index.ts
@@ -32,6 +32,13 @@ export { CoordinateHandler } from './coordinate-handler.js';
 export { GeometryQuality } from './progressive-loader.js';
 export { computeWorkerCount, pickWorkerCount, type WorkerCountInputs, type WorkerCountResult } from './worker-count.js';
 export { getGeometryStreamWatchdogMs, type WatchdogInputs } from './watchdog.js';
+// Stale-deployment WASM-asset detection (#1363). The host app subscribes to
+// WASM_ASSET_UNAVAILABLE_EVENT to reload onto the current deployment.
+export {
+  isWasmAssetUnavailableError,
+  notifyIfWasmAssetUnavailable,
+  WASM_ASSET_UNAVAILABLE_EVENT,
+} from './wasm-asset-error.js';
 export {
   // `isInstancedShard` / `INSTANCED_SHARD_MAGIC` / `INSTANCED_SHARD_VERSION`
   // are intentionally NOT re-exported — they have no consumer outside the
@@ -45,6 +52,7 @@ export {
 export * from './types.js';
 
 import { IfcLiteBridge } from './ifc-lite-bridge.js';
+import { notifyIfWasmAssetUnavailable } from './wasm-asset-error.js';
 import { BufferBuilder } from './buffer-builder.js';
 import { CoordinateHandler } from './coordinate-handler.js';
 import { GeometryQuality } from './progressive-loader.js';
@@ -237,7 +245,15 @@ export class GeometryProcessor {
     } else {
       // WASM path
       if (this.bridge) {
-        await this.bridge.init();
+        try {
+          await this.bridge.init();
+        } catch (err) {
+          // A rotated/missing engine binary after a redeploy (#1363) can't be
+          // recovered by retrying the same hashed URL — signal the host to
+          // reload onto the current deployment. No-op for any other failure.
+          notifyIfWasmAssetUnavailable(err);
+          throw err;
+        }
       }
     }
   }

--- a/packages/geometry/src/wasm-asset-error.test.ts
+++ b/packages/geometry/src/wasm-asset-error.test.ts
@@ -1,0 +1,107 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  isWasmAssetUnavailableError,
+  notifyIfWasmAssetUnavailable,
+  WASM_ASSET_UNAVAILABLE_EVENT,
+} from './wasm-asset-error.js';
+
+describe('isWasmAssetUnavailableError', () => {
+  it('flags the Firefox wrong-MIME engine binary (PostHog issue #1363)', () => {
+    // The exact message captured: a rotated hashed wasm 404s as text/plain.
+    expect(
+      isWasmAssetUnavailableError(
+        "WebAssembly: Response has unsupported MIME type 'text/plain; charset=utf-8' expected 'application/wasm'",
+      ),
+    ).toBe(true);
+  });
+
+  it('flags the Chromium wrong-MIME phrasing', () => {
+    expect(
+      isWasmAssetUnavailableError("Incorrect response MIME type. Expected 'application/wasm'."),
+    ).toBe(true);
+  });
+
+  it('flags a non-OK HTTP status on a WebAssembly compile (asset gone)', () => {
+    expect(
+      isWasmAssetUnavailableError(
+        "Failed to execute 'compile' on 'WebAssembly': HTTP status code is not ok",
+      ),
+    ).toBe(true);
+    expect(
+      isWasmAssetUnavailableError('WebAssembly compile failed: status 404'),
+    ).toBe(true);
+  });
+
+  it('flags a dynamic-import of a now-missing .wasm chunk', () => {
+    expect(
+      isWasmAssetUnavailableError(
+        'Failed to fetch dynamically imported module: https://app/assets/ifc-lite_bg-OLD.wasm',
+      ),
+    ).toBe(true);
+  });
+
+  it('sees through the worker-pool wrapper prefix', () => {
+    expect(
+      isWasmAssetUnavailableError(
+        "Geometry worker error: WebAssembly: Response has unsupported MIME type 'text/plain' expected 'application/wasm'",
+      ),
+    ).toBe(true);
+  });
+
+  it('accepts Error objects, not just strings', () => {
+    expect(
+      isWasmAssetUnavailableError(
+        new TypeError("Response has unsupported MIME type 'text/plain' expected 'application/wasm'"),
+      ),
+    ).toBe(true);
+  });
+
+  it('does NOT flag a genuine corrupt-module compile error (reload would loop)', () => {
+    expect(
+      isWasmAssetUnavailableError(
+        'CompileError: expected magic word 00 61 73 6d, found 3c 21 44 4f',
+      ),
+    ).toBe(false);
+  });
+
+  it('does NOT flag unrelated errors', () => {
+    expect(isWasmAssetUnavailableError('RangeError: invalid array length')).toBe(false);
+    expect(isWasmAssetUnavailableError('Geometry worker error: unreachable')).toBe(false);
+    expect(isWasmAssetUnavailableError('')).toBe(false);
+    expect(isWasmAssetUnavailableError(null)).toBe(false);
+    expect(isWasmAssetUnavailableError(undefined)).toBe(false);
+  });
+});
+
+describe('notifyIfWasmAssetUnavailable', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('dispatches the event on a version-skew error and returns true', () => {
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal('dispatchEvent', dispatchEvent);
+    // CustomEvent exists in the test (jsdom/happy-dom or Node ≥ 19) — assert it
+    // is used. If the runtime lacks it, the function still returns true.
+    const matched = notifyIfWasmAssetUnavailable(
+      "Response has unsupported MIME type 'text/plain' expected 'application/wasm'",
+    );
+    expect(matched).toBe(true);
+    if (typeof CustomEvent === 'function') {
+      expect(dispatchEvent).toHaveBeenCalledTimes(1);
+      const event = dispatchEvent.mock.calls[0][0] as CustomEvent;
+      expect(event.type).toBe(WASM_ASSET_UNAVAILABLE_EVENT);
+    }
+  });
+
+  it('does not dispatch (and returns false) for an unrelated error', () => {
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal('dispatchEvent', dispatchEvent);
+    expect(notifyIfWasmAssetUnavailable('some unrelated failure')).toBe(false);
+    expect(dispatchEvent).not.toHaveBeenCalled();
+  });
+});

--- a/packages/geometry/src/wasm-asset-error.ts
+++ b/packages/geometry/src/wasm-asset-error.ts
@@ -1,0 +1,133 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Detect and broadcast the "stale deployment" WASM-asset signature (#1363).
+ *
+ * A long-lived viewer tab holds JS that references a content-hashed
+ * `ifc-lite_bg-<hash>.wasm`. A later production deploy rotates that asset, so
+ * the tab's now-lazy fetch 404s. The static host serves the 404 body as
+ * `text/plain`, so `WebAssembly.instantiateStreaming` rejects with
+ *
+ *   TypeError: WebAssembly: Response has unsupported MIME type
+ *              'text/plain; charset=utf-8' expected 'application/wasm'
+ *
+ * and wasm-bindgen re-raises it (its built-in MIME fallback only triggers for
+ * an *ok* response — a 404 is `!ok`, so the original TypeError propagates).
+ *
+ * Unlike a transient blip (handled by {@link initWasmWithRetry} with a
+ * same-URL retry), a rotated asset is gone for good: refetching the same hashed
+ * URL can never recover it. The only remedy is reloading the document so the
+ * browser pulls the current deployment's HTML and its fresh asset URLs.
+ *
+ * Detection lives here as a pure, unit-testable predicate; the host app owns
+ * the reload policy and subscribes to {@link WASM_ASSET_UNAVAILABLE_EVENT}.
+ * This library never reloads the page on its own.
+ */
+
+/**
+ * Dispatched on `globalThis` when a WASM engine binary is unreachable because
+ * the deployment rotated assets under a still-open tab. `detail.message`
+ * carries the originating error text. Hosts that opt in (the viewer) reload
+ * once to pick up the current deployment.
+ */
+export const WASM_ASSET_UNAVAILABLE_EVENT = 'ifclite:wasm-asset-unavailable';
+
+function messageOf(err: unknown): string {
+  if (err == null) return '';
+  if (typeof err === 'string') return err;
+  if (typeof err === 'object' && 'message' in err) {
+    const m = (err as { message?: unknown }).message;
+    if (typeof m === 'string') return m;
+  }
+  return String(err);
+}
+
+/**
+ * True when an error looks like a content-hashed WASM binary that 404'd / was
+ * served with the wrong MIME type because the deployment rotated under a
+ * still-open tab. Matches the browser-specific phrasings:
+ *
+ *  - Firefox:  `Response has unsupported MIME type 'text/plain…' expected 'application/wasm'`
+ *  - Chromium: `Incorrect response MIME type. Expected 'application/wasm'.`
+ *  - status-first variants: a `WebAssembly` compile that failed because the
+ *    response was a non-OK HTTP status (the asset is simply gone).
+ *  - the dynamic-import sibling: `Failed to fetch dynamically imported
+ *    module … .wasm`.
+ *
+ * The message may be wrapped (e.g. `Geometry worker error: <original>`), so the
+ * match is a substring test rather than an exact compare. Genuine
+ * module-validation failures (`CompileError`, bad magic word) are intentionally
+ * NOT matched — those are real corruption, not version skew, and a reload would
+ * loop without fixing them.
+ */
+export function isWasmAssetUnavailableError(err: unknown): boolean {
+  const msg = messageOf(err);
+  if (!msg) return false;
+
+  // Never treat a genuine corrupt-module / validation failure as version skew.
+  if (/compileerror|magic (?:word|number)|invalid (?:wasm|module)|module is not a valid/i.test(msg)) {
+    return false;
+  }
+
+  // Wrong-MIME-for-wasm — the #1363 signature. Both the "expected
+  // application/wasm" and "unsupported/incorrect MIME type" phrasings mean the
+  // bytes were not the engine binary, i.e. a 404 / HTML / text page stood in
+  // its place.
+  if (/application\/wasm/i.test(msg) && /mime|content[- ]?type|unsupported|incorrect|expected/i.test(msg)) {
+    return true;
+  }
+
+  // A WebAssembly fetch/compile that failed on a non-OK HTTP response — the
+  // hashed asset is missing after a redeploy.
+  if (
+    /wasm|webassembly/i.test(msg) &&
+    /HTTP status code is not ok|status code (?:4\d\d|5\d\d)|status (?:4\d\d|5\d\d)/i.test(msg)
+  ) {
+    return true;
+  }
+
+  // The dynamic-import wrapper around a now-missing `.wasm` URL.
+  if (
+    /\.wasm/i.test(msg) &&
+    /dynamically imported module|importing a module script failed|error loading dynamically imported/i.test(msg)
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+interface DomDispatcher {
+  dispatchEvent: (event: Event) => boolean;
+}
+
+function domDispatcher(): DomDispatcher | null {
+  const g = globalThis as unknown as Partial<DomDispatcher> & { CustomEvent?: unknown };
+  return typeof g.dispatchEvent === 'function' && typeof g.CustomEvent === 'function'
+    ? (g as DomDispatcher)
+    : null;
+}
+
+/**
+ * If `err` is the version-skew signature, broadcast
+ * {@link WASM_ASSET_UNAVAILABLE_EVENT} on `globalThis` so an opted-in host can
+ * reload. Returns whether the error matched. No-op (returns the match result
+ * but dispatches nothing) in non-DOM hosts such as Node. The library never
+ * reloads the page itself.
+ */
+export function notifyIfWasmAssetUnavailable(err: unknown): boolean {
+  if (!isWasmAssetUnavailableError(err)) return false;
+  const target = domDispatcher();
+  if (target) {
+    try {
+      target.dispatchEvent(
+        new CustomEvent(WASM_ASSET_UNAVAILABLE_EVENT, { detail: { message: messageOf(err) } }),
+      );
+    } catch {
+      /* CustomEvent unavailable — best effort, nothing more to do */
+    }
+  }
+  return true;
+}

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -1603,6 +1603,7 @@
     "SymbolicRepresentationCollection: class (type-only)",
     "TessellationQuality: type",
     "Vec3: interface",
+    "WASM_ASSET_UNAVAILABLE_EVENT: const",
     "WatchdogInputs: interface",
     "WorkerCountInputs: interface",
     "WorkerCountResult: interface",
@@ -1611,6 +1612,7 @@
     "decodeInstancedShard: function",
     "getGeometryStreamWatchdogMs: function",
     "isTauri: function",
+    "isWasmAssetUnavailableError: function",
     "pickWorkerCount: function"
   ],
   "@ifc-lite/ids": [


### PR DESCRIPTION
## Problem (#1363)

PostHog auto-filed `TypeError: WebAssembly: Response has unsupported MIME type 'text/plain; charset=utf-8' expected 'application/wasm'` on `https://www.ifclite.com/` (Firefox).

**Root cause — deployment skew, confirmed against production:**
- The live geometry binary is served correctly: `GET /assets/ifc-lite_bg-<hash>.wasm` → `200, content-type: application/wasm`.
- A **missing** hashed wasm path → `404, content-type: text/plain; charset=utf-8` — exactly the error string.

So a tab left open across a deploy holds JS referencing an old `ifc-lite_bg-<oldhash>.wasm`. The redeploy rotates assets, the lazy fetch 404s as `text/plain`, and `WebAssembly.instantiateStreaming` throws the MIME `TypeError` (wasm-bindgen's built-in fallback only kicks in for an *ok* response, so a 404 re-throws). The viewer's existing `vite:preloadError` recovery can't see this — wasm-bindgen fetches the binary inside a worker, not via Vite's preload helper. A same-URL retry can't recover a rotated asset; only reloading onto fresh HTML can.

## Fix

A guarded, debounced **reload-once** recovery — the standard SPA remedy, and the automated version of the "Please reload the page" guidance `load-errors.ts` already shows for this failure family.

- **`@ifc-lite/geometry`** (`wasm-asset-error.ts`): pure `isWasmAssetUnavailableError()` classifier (Firefox + Chromium MIME phrasings, non-OK-status wasm compiles, dynamic-import of a missing `.wasm`; deliberately **not** genuine `CompileError`s). On a match it dispatches `WASM_ASSET_UNAVAILABLE_EVENT` on `globalThis` at the init choke points — main-thread `GeometryProcessor.init` and the worker-pool error handlers. The library never reloads the page itself; the host owns the policy.
- **viewer** (`wasm-version-skew.ts`): `installWasmVersionSkewRecovery()` reloads once on that event, plus a global `unhandledrejection`/`error` backstop. Reloads are debounced 60s per tab (sessionStorage), so a genuinely broken redeploy surfaces its error instead of looping; a later deploy in a long session can still recover.
- **viewer** (`load-errors.ts`): the wrong-MIME phrasing now classifies as `wasm_engine_load`, so #1363 is tagged in error tracking and gets the actionable user message instead of falling through to `unknown`.

## Tests

- `wasm-asset-error.test.ts` — classifier incl. Firefox/Chromium phrasings, worker-pool wrapper prefix, and the corrupt-module negative case (10).
- `wasm-version-skew.test.ts` — reload-once, debounce/no-loop, recovery after the window, DOM-less no-op (6).
- `load-errors.test.ts` — new #1363 MIME cases classify as `wasm_engine_load`.

All green locally. (Geometry/viewer `tsc` in the fresh worktree shows only pre-existing environmental noise from staged-artifact mismatch; zero errors reference the changed files.)

Closes #1363.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
