### PR TITLE
fix(geometry): cut multi-body openings per body when bodies are spatially separate (#1367)

### DIFF
--- a/.changeset/fix-1367-multibody-opening-bridges.md
+++ b/.changeset/fix-1367-multibody-opening-bridges.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Fix wall openings rendering filled when a single `IfcOpeningElement` carries a row of separate void bodies (#1367). The void router merged every body of such a high-vertex opening into one cutter and subtracted them in a single arrangement, which left diagonal "bridge" triangles spanning some of the holes. An opening is now split into one cutter per body when its bodies form 2 or more disjoint spatial clusters, so each window is cut on its own. Bodies that touch or overlap (one void split into adjacent parts, e.g. inner/outer wall-leaf halves of a window) still subtract merged, so the gable-wall watertightness path is unchanged.

--- a/rust/geometry/src/csg_capture.rs
+++ b/rust/geometry/src/csg_capture.rs
@@ -166,7 +166,7 @@ impl<'a> Reader<'a> {
         let indices: Vec<u32> = (0..n).map(|_| self.u32()).collect::<Option<_>>()?;
         let rtc_applied = self.u8()? != 0;
         let origin = [self.f64()?, self.f64()?, self.f64()?];
-        Some(Mesh { positions, normals, indices, rtc_applied, origin })
+        Some(Mesh { positions, normals, indices, rtc_applied, origin, instance_meta: None })
     }
 }
 

--- a/rust/geometry/src/router/voids.rs
+++ b/rust/geometry/src/router/voids.rs
@@ -142,6 +142,58 @@ fn opening_mesh_thinnest_axis_dir(opening_mesh: &Mesh) -> Vector3<f64> {
     )
 }
 
+/// Count the disjoint spatial clusters formed by a set of per-item void AABBs.
+///
+/// Two AABBs join the same cluster when they overlap or touch on every axis
+/// (within `TOUCH_EPS`, so adjacent wall-leaf halves of one window count as one
+/// cluster); AABBs separated by a real gap on any axis stay in different
+/// clusters. Used by `classify_openings` to tell a row of SEPARATE window voids
+/// (many clusters → subtract per item) from one void split into touching parts
+/// (one cluster → keep merged). See the call site for the #1367 / FZK-Haus
+/// rationale. O(n²) union-find; `n` is the void-body count of a single opening
+/// (tiny in practice).
+fn spatial_cluster_count(
+    bounds: &[(Point3<f64>, Point3<f64>, Option<Vector3<f64>>)],
+) -> usize {
+    const TOUCH_EPS: f64 = 1.0e-3; // 1 mm: adjacent faces count as connected
+    let n = bounds.len();
+    if n <= 1 {
+        return n;
+    }
+    let mut parent: Vec<usize> = (0..n).collect();
+    fn find(p: &mut [usize], x: usize) -> usize {
+        let mut r = x;
+        while p[r] != r {
+            r = p[r];
+        }
+        let mut c = x;
+        while p[c] != r {
+            let nxt = p[c];
+            p[c] = r;
+            c = nxt;
+        }
+        r
+    }
+    let overlaps = |a: &(Point3<f64>, Point3<f64>, Option<Vector3<f64>>),
+                    b: &(Point3<f64>, Point3<f64>, Option<Vector3<f64>>)| {
+        a.0.x <= b.1.x + TOUCH_EPS
+            && b.0.x <= a.1.x + TOUCH_EPS
+            && a.0.y <= b.1.y + TOUCH_EPS
+            && b.0.y <= a.1.y + TOUCH_EPS
+            && a.0.z <= b.1.z + TOUCH_EPS
+            && b.0.z <= a.1.z + TOUCH_EPS
+    };
+    for i in 0..n {
+        for j in (i + 1)..n {
+            if overlaps(&bounds[i], &bounds[j]) {
+                let (ri, rj) = (find(&mut parent, i), find(&mut parent, j));
+                parent[ri] = rj;
+            }
+        }
+    }
+    (0..n).filter(|&i| find(&mut parent, i) == i).count()
+}
+
 /// Closed-surface check on exact f32 bit coords: every directed edge paired,
 /// no degenerate edges. The #2176 lesson — only per-component-watertight solid
 /// cutters may join a batched group; an open component poisons the whole
@@ -3157,9 +3209,32 @@ impl GeometryRouter {
                 });
             };
 
-            if vertex_count > 100 {
-                // High-vertex-count openings (circular / arched / faceted
-                // sweeps) won't fit through the BSP CSG safety thresholds,
+            // Probe per-item geometry up front. An opening that holds several
+            // SPATIALLY SEPARATE void solids — a whole row of windows authored
+            // under one IfcOpeningElement (issue #1367) — must be classified and
+            // subtracted PER ITEM even when its bodies SUM past the high-vertex
+            // guard below: merging them into one cutter and subtracting in a
+            // single arrangement leaves diagonal bridges over some of the holes
+            // (3 of 12 box void bodies on a limestone wall's front face),
+            // whereas one cutter per body cuts every hole cleanly.
+            //
+            // Bodies that TOUCH/OVERLAP are one logical void split into parts
+            // (e.g. the inner+outer wall-leaf halves of a single FZK-Haus
+            // window) and MUST stay merged — splitting them regresses the
+            // gable-wall consolidation watertightness guard into hairline
+            // cracks. So the trigger is ">=2 disjoint spatial clusters", not
+            // merely ">1 body". The merged high-vertex path also stays for a
+            // genuine SINGLE complex sweep (circular / arched / faceted) and for
+            // the rare opening whose per-item bounds can't be recovered.
+            let item_bounds_with_dir = self
+                .get_opening_item_bounds_with_direction(&opening_entity, decoder)
+                .unwrap_or_default();
+            let separable_bodies =
+                item_bounds_with_dir.len() > 1 && spatial_cluster_count(&item_bounds_with_dir) > 1;
+
+            if vertex_count > 100 && !separable_bodies {
+                // High-vertex-count single-body openings (circular / arched /
+                // faceted sweeps) won't fit through the CSG safety thresholds,
                 // so always carry the per-item AABB + extrusion direction
                 // as a fallback (issue #635).
                 let (fallback_min, fallback_max, fallback_dir) =
@@ -3176,12 +3251,7 @@ impl GeometryRouter {
                     fallback_max,
                     fallback_dir,
                 ));
-            } else {
-                let item_bounds_with_dir = self
-                    .get_opening_item_bounds_with_direction(&opening_entity, decoder)
-                    .unwrap_or_default();
-
-                if !item_bounds_with_dir.is_empty() {
+            } else if !item_bounds_with_dir.is_empty() {
                     // Per-item geometry-driven classification (origin/main).
                     // The earlier "is_floor_opening" host-aware heuristic
                     // (preserved here only via diagnostics) routed every
@@ -3314,7 +3384,6 @@ impl GeometryRouter {
                     );
                     openings.push(OpeningType::Rectangular(min_f64, max_f64, None));
                 }
-            }
         }
 
         // Stash the per-host diagnostic before returning. `host.ifc_type`
@@ -4618,6 +4687,50 @@ impl GeometryRouter {
 mod reveal_tests {
     use super::*;
     use crate::Mesh;
+
+    /// AABB tuple in the shape `get_opening_item_bounds_with_direction` returns.
+    fn aabb(
+        min: (f64, f64, f64),
+        max: (f64, f64, f64),
+    ) -> (Point3<f64>, Point3<f64>, Option<Vector3<f64>>) {
+        (
+            Point3::new(min.0, min.1, min.2),
+            Point3::new(max.0, max.1, max.2),
+            None,
+        )
+    }
+
+    #[test]
+    fn spatial_clusters_separate_window_row_split_per_body() {
+        // Issue #1367: a row of window voids under one IfcOpeningElement, each
+        // separated by a solid pillar -> one cluster per body (subtract per item).
+        let boxes: Vec<_> = (0..4)
+            .map(|i| {
+                let x0 = i as f64 * 2.0;
+                aabb((x0, 0.0, 0.0), (x0 + 1.0, 0.3, 1.9))
+            })
+            .collect();
+        assert_eq!(spatial_cluster_count(&boxes), 4);
+    }
+
+    #[test]
+    fn spatial_clusters_touching_wall_leaf_halves_stay_merged() {
+        // FZK-Haus: one window void split into adjacent inner/outer wall-leaf
+        // halves (same X/Z footprint, abutting in Y) -> a single cluster (keep
+        // merged, so the gable watertightness guard is not regressed).
+        let inner = aabb((0.0, 0.0, 0.0), (1.0, 0.485, 0.9));
+        let outer = aabb((0.0, 0.485, 0.0), (1.0, 0.9, 0.9));
+        assert_eq!(spatial_cluster_count(&[inner, outer]), 1);
+    }
+
+    #[test]
+    fn spatial_clusters_single_or_empty() {
+        assert_eq!(spatial_cluster_count(&[]), 0);
+        assert_eq!(
+            spatial_cluster_count(&[aabb((0.0, 0.0, 0.0), (1.0, 1.0, 1.0))]),
+            1
+        );
+    }
 
     /// Build a simple box mesh (12 triangles) for testing.
     #[allow(dead_code)]

--- a/rust/geometry/tests/issue_1367_multibody_opening.rs
+++ b/rust/geometry/tests/issue_1367_multibody_opening.rs
@@ -1,0 +1,169 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! End-to-end coverage for issue #1367 — a SINGLE `IfcOpeningElement` whose body
+//! holds a ROW of spatially-separate void solids (a window strip authored as one
+//! opening with many bodies) must cut EVERY hole.
+//!
+//! The reported defect: the void router merged all bodies of a high-vertex
+//! opening into one cutter and subtracted them in a single arrangement, which on
+//! the reporter's faceted-brep window bodies left diagonal "bridge" triangles
+//! spanning 3 of 12 holes. `classify_openings` now splits an opening into per-
+//! body cutters when its bodies form >= 2 disjoint spatial clusters, so each
+//! window is cut on its own — while a void merely SPLIT into touching parts (one
+//! window's inner/outer wall-leaf halves) still subtracts merged (see the
+//! `spatial_cluster_count` unit tests and the FZK-Haus gable watertightness
+//! tests for the two routing directions).
+//!
+//! This fixture is synthetic (no third-party model data): one straight wall and
+//! one opening carrying `N_WINDOWS` separate box voids, sized so the opening's
+//! combined mesh clears the `vertex_count > 100` high-vertex guard — i.e. it
+//! exercises the per-body-cluster split path and asserts the wall ends up with
+//! all `N_WINDOWS` holes (no body lost, the wall not emptied or over-cut).
+//! Faithfully reproducing the *bridge* needs the reporter's faceted-brep
+//! geometry, which can't be checked in; clean box voids cut cleanly either way.
+
+use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner};
+use ifc_lite_geometry::{propagate_voids_to_parts, GeometryRouter, Mesh};
+use rustc_hash::FxHashMap;
+
+const WALL_ID: u32 = 50;
+const N_WINDOWS: usize = 12;
+const WALL_FRONT_Y: f64 = 0.05; // wall is 0.1 m thick, centred on Y=0
+const WIN_PITCH: f64 = 0.7; // centre-to-centre spacing (0.2 m solid pillars)
+const WIN_X0: f64 = -3.85; // centre of the first window
+
+fn window_center_x(i: usize) -> f64 {
+    WIN_X0 + i as f64 * WIN_PITCH
+}
+
+/// Author the synthetic model: a 10 m × 0.1 m × 3 m wall and one opening whose
+/// body is `N_WINDOWS` separate 0.5 m boxes (z ∈ [1, 2]) punched through it.
+fn build_ifc() -> String {
+    let mut s = String::new();
+    s.push_str(
+        "ISO-10303-21;\n\
+         HEADER;\n\
+         FILE_DESCRIPTION(('issue-1367 multibody opening'),'2;1');\n\
+         FILE_NAME('mb.ifc','2026-06-26T00:00:00',(''),(''),'ifc-lite','ifc-lite','');\n\
+         FILE_SCHEMA(('IFC2X3'));\n\
+         ENDSEC;\n\
+         DATA;\n\
+         #2=IFCOWNERHISTORY($,$,$,.NOCHANGE.,$,$,$,0);\n\
+         #5=IFCCARTESIANPOINT((0.,0.,0.));\n\
+         #6=IFCDIRECTION((0.,0.,1.));\n\
+         #7=IFCDIRECTION((1.,0.,0.));\n\
+         #8=IFCAXIS2PLACEMENT3D(#5,#6,#7);\n\
+         #10=IFCUNITASSIGNMENT((#11));\n\
+         #11=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);\n\
+         #20=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#8,$);\n\
+         #1=IFCPROJECT('0proj0000000000000001',#2,'P',$,$,$,$,(#20),#10);\n\
+         #30=IFCLOCALPLACEMENT($,#8);\n\
+         #40=IFCCARTESIANPOINT((0.,0.));\n\
+         #41=IFCDIRECTION((1.,0.));\n\
+         #42=IFCAXIS2PLACEMENT2D(#40,#41);\n\
+         #43=IFCRECTANGLEPROFILEDEF(.AREA.,'',#42,10.,0.1);\n\
+         #44=IFCEXTRUDEDAREASOLID(#43,#8,#6,3.);\n\
+         #45=IFCSHAPEREPRESENTATION(#20,'Body','SweptSolid',(#44));\n\
+         #46=IFCPRODUCTDEFINITIONSHAPE($,$,(#45));\n\
+         #50=IFCWALLSTANDARDCASE('wall00000000000001',#2,'wall',$,$,#30,#46,'t1');\n",
+    );
+
+    // The opening's body: N separate boxes, each its own extrusion.
+    let mut next = 200u32;
+    let mut item_refs = Vec::with_capacity(N_WINDOWS);
+    for i in 0..N_WINDOWS {
+        let x = window_center_x(i);
+        let (pt, ax, prof, solid) = (next, next + 1, next + 2, next + 3);
+        next += 4;
+        s.push_str(&format!("#{pt}=IFCCARTESIANPOINT(({x:.4},0.,1.));\n"));
+        s.push_str(&format!("#{ax}=IFCAXIS2PLACEMENT3D(#{pt},#6,#7);\n"));
+        // 0.5 m (X) × 0.3 m (Y, > wall thickness) box, extruded 1 m up from z=1.
+        s.push_str(&format!("#{prof}=IFCRECTANGLEPROFILEDEF(.AREA.,'',#42,0.5,0.3);\n"));
+        s.push_str(&format!("#{solid}=IFCEXTRUDEDAREASOLID(#{prof},#{ax},#6,1.);\n"));
+        item_refs.push(format!("#{solid}"));
+    }
+    let items = item_refs.join(",");
+    let (rep, pds, opening, rel) = (next, next + 1, next + 2, next + 3);
+    s.push_str(&format!("#{rep}=IFCSHAPEREPRESENTATION(#20,'Body','SweptSolid',({items}));\n"));
+    s.push_str(&format!("#{pds}=IFCPRODUCTDEFINITIONSHAPE($,$,(#{rep}));\n"));
+    s.push_str(&format!(
+        "#{opening}=IFCOPENINGELEMENT('opening00000000001',#2,'op',$,$,#30,#{pds},'t2');\n"
+    ));
+    s.push_str(&format!(
+        "#{rel}=IFCRELVOIDSELEMENT('void000000000000001',#2,$,$,#50,#{opening});\n"
+    ));
+    s.push_str("ENDSEC;\nEND-ISO-10303-21;\n");
+    s
+}
+
+fn build_void_index(content: &str) -> FxHashMap<u32, Vec<u32>> {
+    let mut void_index: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
+    let mut scanner = EntityScanner::new(content);
+    let mut decoder = EntityDecoder::new(content);
+    while let Some((id, type_name, start, end)) = scanner.next_entity() {
+        if type_name == "IFCRELVOIDSELEMENT" {
+            if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
+                if let (Some(h), Some(o)) = (entity.get_ref(4), entity.get_ref(5)) {
+                    void_index.entry(h).or_default().push(o);
+                }
+            }
+        }
+    }
+    let _ = propagate_voids_to_parts(&mut void_index, content, &mut decoder);
+    void_index
+}
+
+/// Is `(x, z)` covered by any wall triangle lying on the front face (Y≈0.05)?
+fn front_face_covers(mesh: &Mesh, x: f64, z: f64) -> bool {
+    let p = |i: u32| {
+        let b = i as usize * 3;
+        [mesh.positions[b] as f64, mesh.positions[b + 1] as f64, mesh.positions[b + 2] as f64]
+    };
+    for t in mesh.indices.chunks_exact(3) {
+        let (a, b, c) = (p(t[0]), p(t[1]), p(t[2]));
+        if (a[1] - WALL_FRONT_Y).abs() > 1e-3
+            || (b[1] - WALL_FRONT_Y).abs() > 1e-3
+            || (c[1] - WALL_FRONT_Y).abs() > 1e-3
+        {
+            continue;
+        }
+        // Point-in-triangle in the (X, Z) plane.
+        let s = |u: [f64; 3], v: [f64; 3]| (u[0] - x) * (v[2] - z) - (v[0] - x) * (u[2] - z);
+        let (d1, d2, d3) = (s(a, b), s(b, c), s(c, a));
+        let neg = d1 < 0.0 || d2 < 0.0 || d3 < 0.0;
+        let pos = d1 > 0.0 || d2 > 0.0 || d3 > 0.0;
+        if !(neg && pos) {
+            return true;
+        }
+    }
+    false
+}
+
+#[test]
+fn multibody_separated_opening_cuts_every_hole() {
+    let ifc = build_ifc();
+    let entity_index = build_entity_index(&ifc);
+    let mut decoder = EntityDecoder::with_index(&ifc, entity_index);
+    let router = GeometryRouter::with_units(&ifc, &mut decoder);
+    let void_index = build_void_index(&ifc);
+    assert_eq!(void_index.get(&WALL_ID).map(Vec::len), Some(1), "wall must have one opening");
+
+    let wall = decoder.decode_by_id(WALL_ID).expect("decode wall");
+    let mesh = router
+        .process_element_with_voids(&wall, &mut decoder, &void_index)
+        .expect("cut wall");
+    assert!(!mesh.indices.is_empty(), "cut wall must not be empty");
+
+    // Every window centre (z = 1.5) must be a HOLE on the front face — no
+    // triangle may bridge it. A merge-and-subtract regression refills some.
+    let filled: Vec<usize> = (0..N_WINDOWS)
+        .filter(|&i| front_face_covers(&mesh, window_center_x(i), 1.5))
+        .collect();
+    assert!(
+        filled.is_empty(),
+        "windows still bridged on the front face (indices {filled:?}) — the \
+         multi-body opening was merged into one cutter instead of split per body"
+    );
+}


### PR DESCRIPTION
Part of #1367 (the multi-body-opening half). The arched-window full-circle cut is the remaining part of #1367, fixed separately.

## Symptom

A wall whose single `IfcOpeningElement` carries a row of separate void
bodies (a window strip authored as one opening with many bodies) renders
with several openings *filled* instead of cut: diagonal triangles bridge
across the holes. web-ifc shows the same model with clean rectangular
openings.

## Root cause

`classify_openings` (rust/geometry/src/router/voids.rs) routed any opening
whose combined mesh exceeds 100 vertices through a single merged cutter:

```rust
if vertex_count > 100 {
    // one NonRectangular cutter = ALL bodies merged
}
```

That guard is meant for a genuine single complex sweep (circular / arched /
faceted). But a multi-body opening whose bodies merely *sum* past 100
vertices also fell into it, so all the separate void boxes were merged into
one cutter and subtracted in a single exact-arrangement pass. For a row of
disjoint boxes that arrangement leaves "bridge" triangles over some holes.

Subtracting the bodies one at a time cuts every hole cleanly (verified by
replaying the captured kernel job: merged single-subtract bridges 3 of 12
holes; sequential per-body subtract bridges 0).

## Fix

Split an opening into one cutter per body only when its bodies are
*spatially separate* (form 2 or more disjoint clusters), via a new
`spatial_cluster_count` (AABB union-find, 1 mm touch tolerance). Bodies that
touch or overlap are one logical void split into parts (e.g. the inner/outer
wall-leaf halves of a single window) and stay on the merged path, because
splitting THOSE regresses the FZK-Haus gable-wall consolidation
watertightness guard into hairline cracks (caught by the existing
`csg_quality_regression` tests). A genuine single complex sweep also stays
merged. Openings with no spatial separation are byte-identical.

## Verification

- Reporter's model: all 12 windows on the affected wall now cut cleanly
  (front-face hole-coverage check: 3 bridged -> 0 bridged).
- FZK-Haus gable wall watertightness tests stay green (0 open edges).
- New unit tests for the cluster discriminator (separate row vs touching
  leaf halves) and a synthetic end-to-end multi-body-opening fixture.
- Full `cargo test --workspace --exclude ifc-lite-wasm` and
  `cargo clippy ... -D warnings` green; no snapshot changes.

## Note

Also includes a one-line repair to the off-by-default `csg_capture` dev
feature (a missing `Mesh.instance_meta` field) so the CSG corpus replay
example compiles again. It is feature-gated and has no effect on the
default build.