### PR TITLE
test(diff): lock in attribute-level change detection (issue #1361)

### DIFF
--- a/packages/diff/src/diff.test.ts
+++ b/packages/diff/src/diff.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { diffModels } from './diff.js';
+import { buildDataFingerprint } from './fingerprint.js';
 import type { EntityFingerprint } from './types.js';
 
 /** Terse fingerprint builder for tests. */
@@ -111,6 +112,77 @@ describe('diffModels — type & geometry edge cases', () => {
     expect(
       diffModels([fp('e')], [fp('e')], { scope: 'geometry' }).byKey.get('e')?.state,
     ).toBe('unchanged');
+  });
+});
+
+describe('diffModels — issue #1361 (attribute changes Bonsai ignores)', () => {
+  // A user reported ifc-lite's compare flagging changes that buildingSMART's
+  // `ifcdiff` (Bonsai) did not. Investigating their two revisions showed the
+  // newer export genuinely *dropped* `PredefinedType` from nearly every element
+  // (e.g. `.POST.`/`.ELEMENT.`/`.USERDEFINED.` → `$`) and reclassified five
+  // `IfcBuildingElementProxy` to `IfcGeographicElement`. Those are real source
+  // changes — Bonsai's default diff is attribute-blind, ifc-lite is not. These
+  // tests lock in that ifc-lite reports the real deltas (and only the real
+  // deltas), so a future "match Bonsai / reduce noise" change can't silently
+  // drop genuine change detection.
+
+  // Build the data hash the viewer would, for one entity's relevant fields.
+  const hashOf = (input: Parameters<typeof buildDataFingerprint>[0]) =>
+    buildDataFingerprint(input);
+
+  it('flags a PredefinedType drop (real value → unset) as a data change', () => {
+    const base = [
+      fp('e1', {
+        ifcType: 'IfcMember',
+        dataHash: hashOf({ ifcType: 'IfcMember', name: 'member', predefinedType: 'POST' }),
+      }),
+    ];
+    const head = [
+      fp('e1', {
+        ifcType: 'IfcMember',
+        // Re-exported without a PredefinedType — semantically NOTDEFINED.
+        dataHash: hashOf({ ifcType: 'IfcMember', name: 'member' }),
+      }),
+    ];
+    const d = diffModels(base, head, { scope: 'data' }).byKey.get('e1');
+    expect(d?.state).toBe('modified');
+    expect(d?.changeKinds).toEqual(['data']);
+  });
+
+  it('flags a proxy → geographic reclassification (with its type assignment) as a data change', () => {
+    const base = [
+      fp('e2', {
+        ifcType: 'IfcBuildingElementProxy',
+        dataHash: hashOf({
+          ifcType: 'IfcBuildingElementProxy',
+          name: 'feature',
+          typeAssignments: [{ name: 'feature', type: 'IfcBuildingElementProxyType' }],
+        }),
+      }),
+    ];
+    const head = [
+      fp('e2', {
+        ifcType: 'IfcGeographicElement',
+        dataHash: hashOf({
+          ifcType: 'IfcGeographicElement',
+          name: 'feature',
+          typeAssignments: [{ name: 'feature', type: 'IfcGeographicElementType' }],
+        }),
+      }),
+    ];
+    const d = diffModels(base, head, { scope: 'data' }).byKey.get('e2');
+    expect(d?.state).toBe('modified');
+    expect(d?.changeKinds).toEqual(['data']);
+  });
+
+  it('does not flag an element whose attributes are genuinely unchanged', () => {
+    const sameInput = { ifcType: 'IfcBuildingElementProxy', name: 'proxy' };
+    const d = diffModels(
+      [fp('road', { ifcType: 'IfcBuildingElementProxy', dataHash: hashOf(sameInput) })],
+      [fp('road', { ifcType: 'IfcBuildingElementProxy', dataHash: hashOf(sameInput) })],
+      { scope: 'data' },
+    ).byKey.get('road');
+    expect(d?.state).toBe('unchanged');
   });
 });
 

--- a/packages/diff/src/fingerprint.test.ts
+++ b/packages/diff/src/fingerprint.test.ts
@@ -79,6 +79,19 @@ describe('buildDataFingerprint', () => {
     expect(buildDataFingerprint(base)).not.toBe(buildDataFingerprint({ ...base, name: 'W2' }));
   });
 
+  it('includes PredefinedType — value vs unset differ (issue #1361)', () => {
+    // A re-export that drops `.POST.` → `$` is a real change a coordinator may
+    // want to see; the fingerprint must reflect it. (Bonsai's default diff is
+    // attribute-blind and would not, which is the reported discrepancy.)
+    const withType: DataFingerprintInput = { ifcType: 'IfcMember', name: 'member', predefinedType: 'POST' };
+    const unset: DataFingerprintInput = { ifcType: 'IfcMember', name: 'member' };
+    expect(buildDataFingerprint(withType)).not.toBe(buildDataFingerprint(unset));
+    // An unset PredefinedType hashes identically to an explicit-empty one.
+    expect(buildDataFingerprint(unset)).toBe(
+      buildDataFingerprint({ ...unset, predefinedType: '' }),
+    );
+  });
+
   it('treats absent optional collections as empty (stable)', () => {
     expect(buildDataFingerprint({ ifcType: 'IfcWall' })).toBe(
       buildDataFingerprint({


### PR DESCRIPTION
## Summary

Investigates #1361 ("model not showing properly & version comparison wrong"). After reproducing with the reporter's two revisions, **ifc-lite is behaving correctly** — there is no functional bug. This PR adds regression tests that pin the correct behavior so it can't silently regress.

## What the two revisions actually contain

Matching every element by `GlobalId`:

- The newer export **genuinely dropped `PredefinedType`** from nearly every element: `.POST.` → `$` (IfcMember), `.ELEMENT.` → `$` and `.USERDEFINED.` → `$` (IfcBuildingElementProxy), `.USERDEFINED.` → `$` (IfcElementAssembly). Verified directly against the raw STEP.
- Five `IfcBuildingElementProxy` were **reclassified to `IfcGeographicElement`** (river / bridge / terrain), each with its type entity flipped `IfcBuildingElementProxyType` → `IfcGeographicElementType`.
- One element added, two deleted.

These are **real source-level changes**, so ifc-lite's data diff is right to report them. ifc-lite's data fingerprint includes `PredefinedType` and the type assignment; buildingSMART's `ifcdiff` (Bonsai) is attribute-blind by default and so doesn't surface them. That difference in what each tool compares is the entire discrepancy the reporter saw.

## "Model not showing all"

Ran the geometry pipeline headlessly on both files: every element meshes in **both** revisions (25 meshes in v1, 24 in v2 including all 5 geographic elements / the bridge). Nothing is dropped from geometry. The compare panel also already surfaces the per-field delta (e.g. `PredefinedType: ELEMENT → ∅`) when a changed element is selected.

## Change

Regression tests only (no runtime change):

- `fingerprint.test.ts` — `PredefinedType` is part of the data fingerprint; a value vs. unset differ, and unset hashes identically to explicit-empty.
- `diff.test.ts` — a `PredefinedType` drop and a proxy→geographic reclassification each classify as `modified` (`data`); a genuinely-unchanged element stays `unchanged`.

Fixtures are fully neutral (no source identifiers).

## Test plan

- [x] `vitest run` for `@ifc-lite/diff` — 20 passed.

Closes #1361.