### PR TITLE
fix(export): unit-aware federated merge + GlobalId reconciliation (#1332)

### DIFF
--- a/.changeset/fix-1332-unit-aware-merge.md
+++ b/.changeset/fix-1332-unit-aware-merge.md
@@ -1,0 +1,16 @@
+---
+"@ifc-lite/export": minor
+---
+
+Make `MergedExporter` unit-aware so federating models with different length units no longer mis-scales geometry, and reconcile shared GlobalIds instead of emitting duplicates (#1332).
+
+Previously the merge folded every model into the first model's `IfcProject` and deduplicated its `IfcUnitAssignment`, so a second model's raw coordinates were silently reinterpreted under the first model's unit (e.g. a metre model read as feet, ≈3.28x off). Models that reused the same `GlobalId` for `IfcSite`/`IfcBuilding`/`IfcBuildingStorey` or products also produced duplicate-entity errors in strict viewers.
+
+Now:
+
+- A model that shares the first model's length unit is unified as before (single project, spatial structure and infrastructure deduplicated).
+- A model with a different length unit is **federated**: it keeps its own `IfcProject`, `IfcUnitAssignment` and representation contexts, so its coordinates stay correctly scaled. The output then contains more than one `IfcProject` only when units actually differ — an intentional, flagged relaxation of the `IfcSingleProjectInstance` rule that is strictly better than the previous silent mis-scale.
+- GlobalIds are reconciled, not blindly duplicated: a non-relationship rooted entity repeating a GlobalId already emitted **in the same unit space** is unified to the one instance. Otherwise it is kept and re-stamped with a fresh deterministic GlobalId — this preserves objectified relationships (`IfcRel*`), whose membership can differ even when the GlobalId matches, and prevents a unit-compatible model from being unified onto a federated (different-unit) instance.
+- Resource entities whose Name is coincidentally a 22-character GlobalId-charset string (properties, quantities, materials, styles, …) are no longer mistaken for rooted entities, so their values and names are never dropped or overwritten.
+
+The model's unit scale is read from `dataStore.lengthUnitScale` automatically. New `MergeModelInput.lengthUnitScale` lets callers override it, and a new `MergeExportOptions.unitReconciliation: 'auto' | 'assume-shared'` option (default `'auto'`) can force the pre-1332 single-project behaviour when the caller has already normalised units. `MergeExportResult.stats` now also reports `federatedModelCount` and `warnings` (the latter flags the multi-`IfcProject` conformance trade-off); the CLI `merge` command prints these warnings.

--- a/packages/cli/src/commands/merge.ts
+++ b/packages/cli/src/commands/merge.ts
@@ -59,8 +59,13 @@ export async function mergeCommand(args: string[]): Promise<void> {
       modelCount: result.stats.modelCount,
       totalEntityCount: result.stats.totalEntityCount,
       fileSize: result.stats.fileSize,
+      federatedModelCount: result.stats.federatedModelCount,
+      warnings: result.stats.warnings,
     });
   } else {
     process.stderr.write(`Merged ${result.stats.modelCount} models → ${outPath} (${result.stats.totalEntityCount} entities)\n`);
+    for (const warning of result.stats.warnings) {
+      process.stderr.write(`Warning: ${warning}\n`);
+    }
   }
 }

--- a/packages/export/src/merged-exporter.test.ts
+++ b/packages/export/src/merged-exporter.test.ts
@@ -69,6 +69,14 @@ function buildModel(id: string, name: string, entries: Array<[number, string, st
 /** Decode Uint8Array content to string for test assertions */
 const decode = (bytes: Uint8Array) => new TextDecoder().decode(bytes);
 
+/**
+ * Build a valid 22-char IFC GlobalId from a short, charset-safe label.
+ * The merge's GlobalId reconciliation only activates on real 22-char ids, so
+ * mixed-unit / shared-GUID tests must use these (the short 'g1'/'g2' ids in the
+ * legacy tests are intentionally ignored by that logic).
+ */
+const guid = (label: string): string => (label + '0'.repeat(22)).slice(0, 22);
+
 /** Count `#N` references in the output that have no `#N=` definition. */
 function findDanglingRefs(content: string): number[] {
   const defined = new Set<number>();
@@ -373,5 +381,266 @@ describe('MergedExporter', () => {
     expect(decode(result.content)).toContain('DATA;');
     expect(decode(result.content)).toContain('ENDSEC;');
     expect(decode(result.content)).toContain('END-ISO-10303-21;');
+  });
+
+  // Regression: github.com/LTplus-AG/ifc-lite/issues/1332
+  // A model whose length unit differs from the first model's must NOT be folded
+  // into the first project's unit (which silently rescales its coordinates).
+  // Instead it is federated: it keeps its own IfcProject, IfcUnitAssignment and
+  // representation context, and its raw coordinates are copied verbatim.
+  describe('unit-aware federation (#1332)', () => {
+    // model1 = feet (lengthUnitScale 0.3048); model2 = metres (1.0). maxId(m1)=9.
+    const electrical = (): MergeModelInput => {
+      const m = buildModel('elec', 'Electrical', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('elecProj')}',$,'Elec',$,$,$,$,(#3),#2);`],
+        [2, 'IFCUNITASSIGNMENT', '#2=IFCUNITASSIGNMENT((#9));'],
+        [3, 'IFCGEOMETRICREPRESENTATIONCONTEXT', "#3=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#8,$);"],
+        [4, 'IFCSITE', `#4=IFCSITE('${guid('elecSite')}',$,'Site',$,$,$,$,$,$,$);`],
+        [5, 'IFCWALL', `#5=IFCWALL('${guid('elecWall')}',$,'W',$,$,#6,$,$);`],
+        [6, 'IFCCARTESIANPOINT', '#6=IFCCARTESIANPOINT((100.,200.,300.));'],
+        [7, 'IFCRELAGGREGATES', `#7=IFCRELAGGREGATES('${guid('elecAgg')}',$,$,$,#1,(#4));`],
+        [8, 'IFCCARTESIANPOINT', '#8=IFCCARTESIANPOINT((0.,0.,0.));'],
+        [9, 'IFCSIUNIT', '#9=IFCSIUNIT(*,.LENGTHUNIT.,$,.FOOT.);'],
+      ]);
+      m.lengthUnitScale = 0.3048;
+      return m;
+    };
+    const architecture = (): MergeModelInput => {
+      const m = buildModel('arch', 'Architecture', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('archProj')}',$,'Arch',$,$,$,$,(#3),#2);`],
+        [2, 'IFCUNITASSIGNMENT', '#2=IFCUNITASSIGNMENT((#9));'],
+        [3, 'IFCGEOMETRICREPRESENTATIONCONTEXT', "#3=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#8,$);"],
+        [4, 'IFCSITE', `#4=IFCSITE('${guid('archSite')}',$,'Site',$,$,$,$,$,$,$);`],
+        [5, 'IFCCOLUMN', `#5=IFCCOLUMN('${guid('archCol')}',$,'C',$,$,#6,$,$);`],
+        [6, 'IFCCARTESIANPOINT', '#6=IFCCARTESIANPOINT((1.5,2.5,3.5));'],
+        [7, 'IFCRELAGGREGATES', `#7=IFCRELAGGREGATES('${guid('archAgg')}',$,$,$,#1,(#4));`],
+        [8, 'IFCCARTESIANPOINT', '#8=IFCCARTESIANPOINT((0.,0.,0.));'],
+        [9, 'IFCSIUNIT', '#9=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);'],
+      ]);
+      m.lengthUnitScale = 1.0;
+      return m;
+    };
+
+    it('keeps the divergent-unit model as its own project + units (no remap, no dedup)', () => {
+      const result = new MergedExporter([electrical(), architecture()]).export({ schema: 'IFC4' });
+      const content = decode(result.content);
+
+      // First (feet) model unchanged.
+      expect(content).toContain(`#1=IFCPROJECT('${guid('elecProj')}'`);
+
+      // Second (metre) model federated: its project is KEPT (offset 9 → #10),
+      // NOT skipped and NOT remapped onto the first project.
+      expect(content).toContain(`#10=IFCPROJECT('${guid('archProj')}'`);
+      // Its own unit assignment and context survive (not deduplicated).
+      expect(content).toContain('#11=IFCUNITASSIGNMENT');
+      expect(content).toContain('#12=IFCGEOMETRICREPRESENTATIONCONTEXT');
+      // Output is a federation: exactly two IfcProject roots.
+      expect(content.match(/=IFCPROJECT\(/g)?.length).toBe(2);
+
+      // The metre aggregate points at the metre project (#10) and site (#13) —
+      // proof it was NOT reparented onto the feet project (#1).
+      expect(content).toMatch(
+        new RegExp(`#16=IFCRELAGGREGATES\\('${guid('archAgg')}',\\$,\\$,\\$,#10,\\(#13\\)\\)`),
+      );
+
+      // Coordinates copied verbatim — not rescaled into the foot unit.
+      expect(content).toContain('(1.5,2.5,3.5)');
+      expect(findDanglingRefs(content)).toEqual([]);
+    });
+
+    it('re-stamps shared GlobalIds across a unit boundary (no duplicate GUID errors)', () => {
+      // Both disciplines reuse the same Site GlobalId (the Duplex case).
+      const elec = buildModel('elec', 'Electrical', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('m1Proj')}',$,'Elec',$,$,$,$,$,#2);`],
+        [2, 'IFCUNITASSIGNMENT', '#2=IFCUNITASSIGNMENT((#4));'],
+        [3, 'IFCSITE', `#3=IFCSITE('${guid('sharedSite')}',$,'Site',$,$,$,$,$,$,$);`],
+        [4, 'IFCSIUNIT', '#4=IFCSIUNIT(*,.LENGTHUNIT.,$,.FOOT.);'],
+      ]);
+      elec.lengthUnitScale = 0.3048;
+      const arch = buildModel('arch', 'Architecture', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('m2Proj')}',$,'Arch',$,$,$,$,$,#2);`],
+        [2, 'IFCUNITASSIGNMENT', '#2=IFCUNITASSIGNMENT((#4));'],
+        [3, 'IFCSITE', `#3=IFCSITE('${guid('sharedSite')}',$,'Site',$,$,$,$,$,$,$);`],
+        [4, 'IFCSIUNIT', '#4=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);'],
+      ]);
+      arch.lengthUnitScale = 1.0;
+
+      const content = decode(new MergedExporter([elec, arch]).export({ schema: 'IFC4' }).content);
+
+      // The shared GlobalId must appear exactly once (kept on the first site).
+      expect(content.match(new RegExp(guid('sharedSite'), 'g'))?.length).toBe(1);
+      // Both sites are still present (federated, not unified) — the second got a
+      // fresh GlobalId so the file has no duplicate-GUID error.
+      expect(content.match(/=IFCSITE\(/g)?.length).toBe(2);
+      expect(content.match(/=IFCPROJECT\(/g)?.length).toBe(2);
+      expect(findDanglingRefs(content)).toEqual([]);
+    });
+
+    it('unifies (not duplicates) shared GlobalIds when models share a unit', () => {
+      // Same unit (both metres) + a shared wall GlobalId → genuinely the same
+      // entity, so it is unified to one instance and references are remapped.
+      const m1 = buildModel('m1', 'Arch', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('m1Proj')}',$,'Arch',$,$,$,$,$,$);`],
+        [2, 'IFCWALL', `#2=IFCWALL('${guid('sharedWall')}',$,'W',$,$,$,$,$);`],
+      ]);
+      const m2 = buildModel('m2', 'Struct', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('m2Proj')}',$,'Struct',$,$,$,$,$,$);`],
+        [2, 'IFCWALL', `#2=IFCWALL('${guid('sharedWall')}',$,'W',$,$,$,$,$);`],
+        [3, 'IFCRELDEFINESBYPROPERTIES', `#3=IFCRELDEFINESBYPROPERTIES('${guid('m2Rel')}',$,$,$,(#2),#4);`],
+        [4, 'IFCPROPERTYSET', `#4=IFCPROPERTYSET('${guid('m2Pset')}',$,'Pset',$,$);`],
+      ]);
+
+      const content = decode(new MergedExporter([m1, m2]).export({ schema: 'IFC4' }).content);
+
+      // The shared wall is emitted once; the project is unified (single root).
+      expect(content.match(new RegExp(guid('sharedWall'), 'g'))?.length).toBe(1);
+      expect(content.match(/=IFCPROJECT\(/g)?.length).toBe(1);
+      // m2's relationship is reparented onto the unified wall (#2), not m2's
+      // skipped copy (which would have been #4 after the offset of 2).
+      expect(content).toMatch(
+        new RegExp(`IFCRELDEFINESBYPROPERTIES\\('${guid('m2Rel')}',\\$,\\$,\\$,\\(#2\\),#6\\)`),
+      );
+      expect(findDanglingRefs(content)).toEqual([]);
+    });
+
+    it("'assume-shared' forces unification even when units differ", () => {
+      const elec = buildModel('elec', 'Electrical', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('m1Proj')}',$,'Elec',$,$,$,$,$,$);`],
+        [2, 'IFCSITE', `#2=IFCSITE('${guid('sharedSite')}',$,'Site',$,$,$,$,$,$,$);`],
+      ]);
+      elec.lengthUnitScale = 0.3048;
+      const arch = buildModel('arch', 'Architecture', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('m2Proj')}',$,'Arch',$,$,$,$,$,$);`],
+        [2, 'IFCSITE', `#2=IFCSITE('${guid('sharedSite')}',$,'Site',$,$,$,$,$,$,$);`],
+      ]);
+      arch.lengthUnitScale = 1.0;
+
+      const content = decode(
+        new MergedExporter([elec, arch]).export({ schema: 'IFC4', unitReconciliation: 'assume-shared' }).content,
+      );
+
+      // Forced single project + unified site despite the unit mismatch.
+      expect(content.match(/=IFCPROJECT\(/g)?.length).toBe(1);
+      expect(content.match(/=IFCSITE\(/g)?.length).toBe(1);
+      expect(findDanglingRefs(content)).toEqual([]);
+    });
+
+    it('federates via exportAsync as well', async () => {
+      const result = await new MergedExporter([electrical(), architecture()]).exportAsync({ schema: 'IFC4' });
+      const content = decode(result.content);
+      expect(content.match(/=IFCPROJECT\(/g)?.length).toBe(2);
+      expect(content).toContain('(1.5,2.5,3.5)');
+      expect(findDanglingRefs(content)).toEqual([]);
+    });
+
+    it('surfaces a conformance warning when federation triggers (and none otherwise)', () => {
+      const federated = new MergedExporter([electrical(), architecture()]).export({ schema: 'IFC4' });
+      expect(federated.stats.federatedModelCount).toBe(1);
+      expect(federated.stats.warnings.length).toBe(1);
+      expect(federated.stats.warnings[0]).toMatch(/IfcSingleProjectInstance/);
+
+      // Two same-unit models: no federation, no warning.
+      const a = buildModel('a', 'A', [[1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('aProj')}',$,'A',$,$,$,$,$,$);`]]);
+      const b = buildModel('b', 'B', [[1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('bProj')}',$,'B',$,$,$,$,$,$);`]]);
+      const clean = new MergedExporter([a, b]).export({ schema: 'IFC4' });
+      expect(clean.stats.federatedModelCount).toBe(0);
+      expect(clean.stats.warnings).toEqual([]);
+    });
+
+    // Regression (review of #1332): objectified relationships must NOT be
+    // dropped on a GlobalId match — same GlobalId does not imply same membership,
+    // so dropping one orphans its elements from the spatial tree.
+    it('keeps (re-stamps) a relationship with a shared GlobalId instead of dropping its members', () => {
+      const a = buildModel('a', 'Arch', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('projA')}',$,'A',$,$,$,$,$,$);`],
+        [2, 'IFCBUILDINGSTOREY', `#2=IFCBUILDINGSTOREY('${guid('sharedStorey')}',$,'L1',$,$,$,$,$,.ELEMENT.,0.);`],
+        [3, 'IFCWALL', `#3=IFCWALL('${guid('wallA')}',$,'WA',$,$,$,$,$);`],
+        [4, 'IFCRELCONTAINEDINSPATIALSTRUCTURE', `#4=IFCRELCONTAINEDINSPATIALSTRUCTURE('${guid('sharedRel')}',$,$,$,(#3),#2);`],
+      ]);
+      const b = buildModel('b', 'Struct', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('projB')}',$,'B',$,$,$,$,$,$);`],
+        [2, 'IFCBUILDINGSTOREY', `#2=IFCBUILDINGSTOREY('${guid('sharedStorey')}',$,'L1',$,$,$,$,$,.ELEMENT.,0.);`],
+        [3, 'IFCCOLUMN', `#3=IFCCOLUMN('${guid('colB')}',$,'CB',$,$,$,$,$);`],
+        [4, 'IFCRELCONTAINEDINSPATIALSTRUCTURE', `#4=IFCRELCONTAINEDINSPATIALSTRUCTURE('${guid('sharedRel')}',$,$,$,(#3),#2);`],
+      ]);
+
+      const content = decode(new MergedExporter([a, b]).export({ schema: 'IFC4' }).content);
+
+      // Storey is unified (one instance), but BOTH containment relationships survive.
+      expect(content.match(/=IFCBUILDINGSTOREY\(/g)?.length).toBe(1);
+      expect(content.match(/=IFCRELCONTAINEDINSPATIALSTRUCTURE\(/g)?.length).toBe(2);
+      // B's column is kept (#3 + offset 4 = #7) and contained in the unified storey #2.
+      expect(content).toContain(`#7=IFCCOLUMN('${guid('colB')}'`);
+      expect(content).toMatch(/IFCRELCONTAINEDINSPATIALSTRUCTURE\([^)]*,\(#7\),#2\)/);
+      // The shared relationship GlobalId survives once; B's copy was re-stamped.
+      expect(content.match(new RegExp(guid('sharedRel'), 'g'))?.length).toBe(1);
+      expect(findDanglingRefs(content)).toEqual([]);
+    });
+
+    // Regression (review of #1332): a non-rooted resource entity whose Name is
+    // coincidentally a 22-char GlobalId-charset string must NOT be treated as a
+    // GlobalId, or its value would be unified away / its Name overwritten.
+    it('does not mistake a 22-char property Name for a GlobalId', () => {
+      const propName = guid('ThermalRes'); // 22 chars, valid GlobalId charset
+      const a = buildModel('a', 'Arch', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('projA')}',$,'A',$,$,$,$,$,$);`],
+        [2, 'IFCWALL', `#2=IFCWALL('${guid('wallA')}',$,'WA',$,$,$,$,$);`],
+        [3, 'IFCPROPERTYSET', `#3=IFCPROPERTYSET('${guid('psetA')}',$,'Pset_X',$,(#4));`],
+        [4, 'IFCPROPERTYSINGLEVALUE', `#4=IFCPROPERTYSINGLEVALUE('${propName}',$,IFCTEXT('aVal'),$);`],
+        [5, 'IFCRELDEFINESBYPROPERTIES', `#5=IFCRELDEFINESBYPROPERTIES('${guid('relA')}',$,$,$,(#2),#3);`],
+      ]);
+      const b = buildModel('b', 'Struct', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('projB')}',$,'B',$,$,$,$,$,$);`],
+        [2, 'IFCWALL', `#2=IFCWALL('${guid('wallB')}',$,'WB',$,$,$,$,$);`],
+        [3, 'IFCPROPERTYSET', `#3=IFCPROPERTYSET('${guid('psetB')}',$,'Pset_X',$,(#4));`],
+        [4, 'IFCPROPERTYSINGLEVALUE', `#4=IFCPROPERTYSINGLEVALUE('${propName}',$,IFCTEXT('bVal'),$);`],
+        [5, 'IFCRELDEFINESBYPROPERTIES', `#5=IFCRELDEFINESBYPROPERTIES('${guid('relB')}',$,$,$,(#2),#3);`],
+      ]);
+
+      const content = decode(new MergedExporter([a, b]).export({ schema: 'IFC4' }).content);
+
+      // Both property atoms survive with their own distinct values and Name intact.
+      expect(content.match(/=IFCPROPERTYSINGLEVALUE\(/g)?.length).toBe(2);
+      expect(content).toContain("IFCTEXT('aVal')");
+      expect(content).toContain("IFCTEXT('bVal')");
+      expect(content.match(new RegExp(propName, 'g'))?.length).toBe(2);
+      expect(findDanglingRefs(content)).toEqual([]);
+    });
+
+    // Regression (review of #1332): in a 3+ model merge, a unit-compatible model
+    // must not be unified onto an entity emitted by a FEDERATED (different-unit)
+    // model just because the GlobalId matches — that would reintroduce the
+    // mis-scale transitively.
+    it('does not unify a compatible model onto a federated entity sharing a GlobalId', () => {
+      const sharedWall = guid('sharedWall');
+      const a = buildModel('a', 'PrimaryMetre', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('projA')}',$,'A',$,$,$,$,$,$);`],
+        [2, 'IFCWALL', `#2=IFCWALL('${guid('wallA')}',$,'WA',$,$,#3,$,$);`],
+        [3, 'IFCCARTESIANPOINT', '#3=IFCCARTESIANPOINT((9.,9.,9.));'],
+      ]);
+      a.lengthUnitScale = 1.0; // primary = metres
+      const b = buildModel('b', 'Feet', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('projB')}',$,'B',$,$,$,$,$,$);`],
+        [2, 'IFCWALL', `#2=IFCWALL('${sharedWall}',$,'BW-feet',$,$,#3,$,$);`],
+        [3, 'IFCCARTESIANPOINT', '#3=IFCCARTESIANPOINT((100.,100.,100.));'],
+      ]);
+      b.lengthUnitScale = 0.3048; // federated (feet)
+      const c = buildModel('c', 'Metre', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('projC')}',$,'C',$,$,$,$,$,$);`],
+        [2, 'IFCWALL', `#2=IFCWALL('${sharedWall}',$,'CW-metres',$,$,#3,$,$);`],
+        [3, 'IFCCARTESIANPOINT', '#3=IFCCARTESIANPOINT((2.,2.,2.));'],
+      ]);
+      c.lengthUnitScale = 1.0; // compatible with primary
+
+      const content = decode(new MergedExporter([a, b, c]).export({ schema: 'IFC4' }).content);
+
+      // C's metre wall must NOT be dropped/reparented onto B's feet wall.
+      expect(content).toContain("'CW-metres'");
+      expect(content).toContain('(2.,2.,2.)'); // C's coordinate is preserved, not orphaned to feet space
+      expect(content.match(/=IFCWALL\(/g)?.length).toBe(3); // all three walls survive
+      // The shared GlobalId is kept once (on B, first emitter); C's was re-stamped.
+      expect(content.match(new RegExp(sharedWall, 'g'))?.length).toBe(1);
+      expect(findDanglingRefs(content)).toEqual([]);
+    });
   });
 });

--- a/packages/export/src/merged-exporter.test.ts
+++ b/packages/export/src/merged-exporter.test.ts
@@ -642,5 +642,56 @@ describe('MergedExporter', () => {
       expect(content.match(new RegExp(sharedWall, 'g'))?.length).toBe(1);
       expect(findDanglingRefs(content)).toEqual([]);
     });
+
+    // Regression (CodeRabbit on PR): schema conversion can replace an
+    // unsupported rooted type with an IFCPROXY carrying a freshly-minted
+    // GlobalId. The emitted (not source) GlobalId must be registered, or a later
+    // model with the original GlobalId would be unified onto that proxy.
+    it('registers the emitted GlobalId after IFCPROXY conversion (no false unify)', () => {
+      const sharedGuid = guid('sharedAlign');
+      // IfcAlignmentHorizontal has no IFC2X3 representation → replaced by an
+      // IFCPROXY carrying a freshly-minted GlobalId (schema-converter.ts).
+      const m1 = buildModel('m1', 'A', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('p1')}',$,'A',$,$,$,$,$,$);`],
+        [2, 'IFCALIGNMENTHORIZONTAL', `#2=IFCALIGNMENTHORIZONTAL('${sharedGuid}',$,'AL',$,$,$);`],
+      ]);
+      const m2 = buildModel('m2', 'B', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('p2')}',$,'B',$,$,$,$,$,$);`],
+        [2, 'IFCALIGNMENTHORIZONTAL', `#2=IFCALIGNMENTHORIZONTAL('${sharedGuid}',$,'AL',$,$,$);`],
+      ]);
+
+      const content = decode(new MergedExporter([m1, m2]).export({ schema: 'IFC2X3' }).content);
+
+      // Both alignments survive as proxies; m2 was not dropped onto m1's proxy.
+      expect(content.match(/=IFCPROXY\(/g)?.length).toBe(2);
+      // The original GlobalId was replaced by the minted proxy ids on both.
+      expect(content).not.toContain(sharedGuid);
+      expect(findDanglingRefs(content)).toEqual([]);
+    });
+
+    // Regression (CodeRabbit on PR): the rooted-entity denylist must cover other
+    // non-rooted resource entities that lead with a string, e.g. IfcTextLiteral.
+    it('does not mistake a 22-char IfcTextLiteral Literal for a GlobalId', () => {
+      const literal = guid('SomeLiteralText'); // 22-char, GlobalId charset
+      const m1 = buildModel('m1', 'A', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('p1')}',$,'A',$,$,$,$,$,$);`],
+        [2, 'IFCTEXTLITERAL', `#2=IFCTEXTLITERAL('${literal}',#3,.LEFT.);`],
+        [3, 'IFCAXIS2PLACEMENT2D', '#3=IFCAXIS2PLACEMENT2D(#4,$);'],
+        [4, 'IFCCARTESIANPOINT', '#4=IFCCARTESIANPOINT((0.,0.));'],
+      ]);
+      const m2 = buildModel('m2', 'B', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('p2')}',$,'B',$,$,$,$,$,$);`],
+        [2, 'IFCTEXTLITERAL', `#2=IFCTEXTLITERAL('${literal}',#3,.LEFT.);`],
+        [3, 'IFCAXIS2PLACEMENT2D', '#3=IFCAXIS2PLACEMENT2D(#4,$);'],
+        [4, 'IFCCARTESIANPOINT', '#4=IFCCARTESIANPOINT((0.,0.));'],
+      ]);
+
+      const content = decode(new MergedExporter([m1, m2]).export({ schema: 'IFC4' }).content);
+
+      // Both text literals survive (not unified away); the literal is untouched.
+      expect(content.match(/=IFCTEXTLITERAL\(/g)?.length).toBe(2);
+      expect(content.match(new RegExp(literal, 'g'))?.length).toBe(2);
+      expect(findDanglingRefs(content)).toEqual([]);
+    });
   });
 });

--- a/packages/export/src/merged-exporter.ts
+++ b/packages/export/src/merged-exporter.ts
@@ -44,6 +44,14 @@ const GLOBAL_ID_RE = /^[0-9A-Za-z_$]{22}$/;
  * when that string happens to be 22 charset characters. (IfcRoot property
  * containers like IFCPROPERTYSET / IFCELEMENTQUANTITY are deliberately absent —
  * they ARE rooted and carry a real GlobalId at attribute 0.)
+ *
+ * This is a best-effort denylist, not an exhaustive IfcRoot classifier — the
+ * merge works off raw STEP text and has no schema table. It covers the resource
+ * families that realistically appear in federated models; an unlisted
+ * string-leading resource type is only ever a problem if two models share an
+ * identical 22-char charset Name for it AND it collides, which is negligible. A
+ * miss in the other direction (treating a real root as non-rooted) is safe — it
+ * just skips one GlobalId reconciliation.
  */
 const NON_ROOTED_STRING_TYPES = new Set([
   // IfcSimpleProperty / IfcComplexProperty (IfcPropertyAbstraction — not rooted)
@@ -53,14 +61,21 @@ const NON_ROOTED_STRING_TYPES = new Set([
   // IfcPhysicalQuantity (not rooted)
   'IFCQUANTITYLENGTH', 'IFCQUANTITYAREA', 'IFCQUANTITYVOLUME', 'IFCQUANTITYCOUNT',
   'IFCQUANTITYWEIGHT', 'IFCQUANTITYTIME', 'IFCQUANTITYNUMBER', 'IFCPHYSICALCOMPLEXQUANTITY',
-  // Materials, classification & library refs (IfcExternalInformation/Reference)
-  'IFCMATERIAL', 'IFCCLASSIFICATION', 'IFCCLASSIFICATIONREFERENCE',
+  // Materials & their constituents (IfcMaterialDefinition — not rooted; lead with a Name)
+  'IFCMATERIAL', 'IFCMATERIALPROFILE', 'IFCMATERIALPROFILESET',
+  'IFCMATERIALCONSTITUENT', 'IFCMATERIALCONSTITUENTSET',
+  // Classification, library & document refs (IfcExternalInformation/Reference)
+  'IFCCLASSIFICATION', 'IFCCLASSIFICATIONREFERENCE',
   'IFCLIBRARYINFORMATION', 'IFCLIBRARYREFERENCE', 'IFCEXTERNALREFERENCE',
+  'IFCDOCUMENTINFORMATION', 'IFCDOCUMENTREFERENCE',
+  // Constraints & approvals (lead with a Name/Identifier)
+  'IFCMETRIC', 'IFCOBJECTIVE', 'IFCAPPROVAL', 'IFCTABLE',
   // Actors (IfcPerson/IfcOrganization lead with an Identification string)
   'IFCPERSON', 'IFCORGANIZATION',
-  // Presentation layers & styles (lead with a Name string)
+  // Presentation layers, styles & text literals (lead with a Name/Literal string)
   'IFCPRESENTATIONLAYERASSIGNMENT', 'IFCPRESENTATIONLAYERWITHSTYLE',
   'IFCSURFACESTYLE', 'IFCCURVESTYLE', 'IFCTEXTSTYLE', 'IFCFILLAREASTYLE',
+  'IFCTEXTLITERAL', 'IFCTEXTLITERALWITHEXTENT',
 ]);
 
 /** True for IfcRelationship subtypes (objectified relationships). */
@@ -678,14 +693,38 @@ export class MergedExporter {
       finalText = converted;
     }
 
-    // Record the emitted GlobalId → final express id + unit scale. Emitted
-    // entities are not sharedRemap keys, so their final id is localId + offset.
-    const emittedGuid = mintedGuid ?? plan.localGuids.get(localId);
-    if (emittedGuid !== undefined) {
-      guidToFinalId.set(emittedGuid, { finalId: localId + offset, scale: modelScale });
+    // Record the emitted GlobalId → final express id + unit scale, for rooted
+    // entities only. Read it from the FINAL line, not the source: schema
+    // conversion can replace an unsupported rooted type with an IFCPROXY that
+    // carries a freshly-minted GlobalId, so the source guid would be stale.
+    // Emitted entities are not sharedRemap keys, so their final id is
+    // localId + offset.
+    if (plan.localGuids.has(localId)) {
+      const emittedGuid = this.readLeadingGuid(finalText)
+        ?? mintedGuid ?? plan.localGuids.get(localId);
+      if (emittedGuid !== undefined) {
+        guidToFinalId.set(emittedGuid, { finalId: localId + offset, scale: modelScale });
+      }
     }
 
     return finalText;
+  }
+
+  /**
+   * Read the GlobalId (first quoted attribute) from an already-rendered STEP
+   * line. Used to register the id that was actually emitted, after any id
+   * remap, GlobalId re-stamp, or schema conversion. Returns null if the first
+   * quoted token is not a 22-char GlobalId.
+   */
+  private readLeadingGuid(entityText: string): string | null {
+    const open = entityText.indexOf('(');
+    if (open === -1) return null;
+    const q1 = entityText.indexOf("'", open + 1);
+    if (q1 === -1) return null;
+    const q2 = entityText.indexOf("'", q1 + 1);
+    if (q2 === -1) return null;
+    const raw = entityText.slice(q1 + 1, q2);
+    return GLOBAL_ID_RE.test(raw) ? raw : null;
   }
 
   /**

--- a/packages/export/src/merged-exporter.ts
+++ b/packages/export/src/merged-exporter.ts
@@ -11,13 +11,13 @@
  */
 
 import type { IfcDataStore } from '@ifc-lite/parser';
-import { generateHeader } from '@ifc-lite/parser';
+import { generateHeader, deterministicGlobalId } from '@ifc-lite/parser';
 import { decodeIfcString } from '@ifc-lite/encoding';
 import { safeUtf8Decode } from '@ifc-lite/data';
 import { collectReferencedEntityIds, getVisibleEntityIds, collectStyleEntities } from './reference-collector.js';
 import { convertStepLine, needsConversion, type IfcSchemaVersion } from './schema-converter.js';
 import { assembleStepBytes } from './step-serialization.js';
-import { getCompleteEntityIndex, getMaxExpressId } from './entity-iteration.js';
+import { getCompleteEntityIndex, getMaxExpressId, type CompleteEntityIndex, type ExportEntityRef } from './entity-iteration.js';
 
 /** Entity types forming shared infrastructure (deduplicated across models). */
 const SHARED_INFRASTRUCTURE_TYPES = new Set([
@@ -25,6 +25,51 @@ const SHARED_INFRASTRUCTURE_TYPES = new Set([
   'IFCGEOMETRICREPRESENTATIONCONTEXT',
   'IFCGEOMETRICREPRESENTATIONSUBCONTEXT',
 ]);
+
+/**
+ * An IfcGloballyUniqueId is exactly 22 characters of the buildingSMART base64
+ * alphabet. We use this to recognise a rooted entity (IfcRoot subtype) by its
+ * first attribute. Geometry/list entities never carry a string there, but some
+ * non-rooted RESOURCE entities lead with a Name/Identifier string that can
+ * legitimately be 22 charset chars (e.g. a coded property key). Those are
+ * excluded by type ({@link NON_ROOTED_STRING_TYPES}) so their Name is never
+ * mistaken for a GlobalId — otherwise the GlobalId reconciliation could drop or
+ * rename them.
+ */
+const GLOBAL_ID_RE = /^[0-9A-Za-z_$]{22}$/;
+
+/**
+ * Non-IfcRoot entity types whose first attribute is (or can be) a quoted
+ * Name/Identifier string. They must NOT be treated as rooted by GlobalId, even
+ * when that string happens to be 22 charset characters. (IfcRoot property
+ * containers like IFCPROPERTYSET / IFCELEMENTQUANTITY are deliberately absent —
+ * they ARE rooted and carry a real GlobalId at attribute 0.)
+ */
+const NON_ROOTED_STRING_TYPES = new Set([
+  // IfcSimpleProperty / IfcComplexProperty (IfcPropertyAbstraction — not rooted)
+  'IFCPROPERTYSINGLEVALUE', 'IFCPROPERTYENUMERATEDVALUE', 'IFCPROPERTYLISTVALUE',
+  'IFCPROPERTYBOUNDEDVALUE', 'IFCPROPERTYTABLEVALUE', 'IFCPROPERTYREFERENCEVALUE',
+  'IFCCOMPLEXPROPERTY',
+  // IfcPhysicalQuantity (not rooted)
+  'IFCQUANTITYLENGTH', 'IFCQUANTITYAREA', 'IFCQUANTITYVOLUME', 'IFCQUANTITYCOUNT',
+  'IFCQUANTITYWEIGHT', 'IFCQUANTITYTIME', 'IFCQUANTITYNUMBER', 'IFCPHYSICALCOMPLEXQUANTITY',
+  // Materials, classification & library refs (IfcExternalInformation/Reference)
+  'IFCMATERIAL', 'IFCCLASSIFICATION', 'IFCCLASSIFICATIONREFERENCE',
+  'IFCLIBRARYINFORMATION', 'IFCLIBRARYREFERENCE', 'IFCEXTERNALREFERENCE',
+  // Actors (IfcPerson/IfcOrganization lead with an Identification string)
+  'IFCPERSON', 'IFCORGANIZATION',
+  // Presentation layers & styles (lead with a Name string)
+  'IFCPRESENTATIONLAYERASSIGNMENT', 'IFCPRESENTATIONLAYERWITHSTYLE',
+  'IFCSURFACESTYLE', 'IFCCURVESTYLE', 'IFCTEXTSTYLE', 'IFCFILLAREASTYLE',
+]);
+
+/** True for IfcRelationship subtypes (objectified relationships). */
+function isRelationshipType(typeUpper: string): boolean {
+  return typeUpper.startsWith('IFCREL');
+}
+
+/** Relative tolerance for comparing two length unit scale factors. */
+const UNIT_SCALE_TOLERANCE = 1e-6;
 
 /** Lookup tables for matching spatial entities from the first model. */
 interface SpatialLookup {
@@ -34,6 +79,47 @@ interface SpatialLookup {
   storeysByElevation: Array<{ expressId: number; elevation: number }>;
   siteIds: number[];
   buildingIds: number[];
+}
+
+/** Shared, model-independent state computed once per merge. */
+interface MergeSetup {
+  /** ID offset applied to each model's express ids, keyed by model id. */
+  modelOffsets: Map<string, number>;
+  /** Offset of the first (primary) model — always 0, but kept explicit. */
+  firstModelOffset: number;
+  /** Infrastructure entities (units, contexts) of the primary model. */
+  firstModelInfraMap: Map<string, number[]>;
+  /** IfcProject express ids of the primary model. */
+  firstProjectIds: number[];
+  /** Spatial lookup built from the primary model. */
+  spatialLookup: SpatialLookup;
+  /** Length unit scale of the primary model — the unit other models merge into. */
+  primaryScale: number;
+  /** When true, every model is treated as sharing the primary unit. */
+  assumeShared: boolean;
+}
+
+/** Per-model plan: how this model's entities are remapped, skipped, or restamped. */
+interface ModelMergePlan {
+  /** Local express id → final express id, for references that must be rewritten. */
+  sharedRemap: Map<number, number>;
+  /** Local express ids omitted from the output (unified or deduplicated). */
+  skipEntityIds: Set<number>;
+  /** Local express id → fresh GlobalId, for federated entities whose id collides. */
+  guidRewrite: Map<number, string>;
+  /** Local express id → original GlobalId (rooted entities only). */
+  localGuids: Map<number, string>;
+}
+
+/**
+ * Where an already-emitted GlobalId landed: its final express id and the unit
+ * scale of the model that emitted it. The scale lets a later model decide
+ * whether it can truly unify with that instance (same unit space) or must stay
+ * distinct (a federated, differently-scaled instance) — see {@link MergedExporter.planModel}.
+ */
+interface GuidRecord {
+  finalId: number;
+  scale: number;
 }
 
 /**
@@ -46,6 +132,17 @@ export interface MergeModelInput {
   name: string;
   /** Parsed IFC data store (must have source buffer) */
   dataStore: IfcDataStore;
+  /**
+   * Length unit scale of this model — the factor that converts the model's raw
+   * IFC length values into base SI metres (`1.0` metres, `0.001` millimetres,
+   * `0.3048` feet, …). Optional: when omitted the exporter reads
+   * `dataStore.lengthUnitScale`, falling back to `1.0`.
+   *
+   * The merge compares each model's scale to the first model's to decide
+   * whether it can be folded into the unified project (same unit) or must be
+   * federated as its own project (different unit). See {@link MergedExporter}.
+   */
+  lengthUnitScale?: number;
 }
 
 /**
@@ -70,6 +167,25 @@ export interface MergeExportOptions {
    * - 'keep-first': Keep the first model's IfcProject as the root
    */
   projectStrategy?: 'keep-first';
+
+  /**
+   * How to reconcile models whose length unit differs from the first model's.
+   *
+   * - `'auto'` (default): unit-aware merge. Models that share the first
+   *   model's length unit are unified into a single `IfcProject` (spatial
+   *   structure and infrastructure deduplicated). A model with a *different*
+   *   length unit is federated — it keeps its own `IfcProject`,
+   *   `IfcUnitAssignment` and representation contexts so its coordinates stay
+   *   correctly scaled, instead of being silently reinterpreted under the
+   *   first model's unit. The output then contains more than one `IfcProject`
+   *   (a deliberate relaxation of the IfcSingleProjectInstance rule, flagged in
+   *   `stats.warnings`) — the only way to preserve mixed units in one file
+   *   without rewriting every length-valued attribute.
+   * - `'assume-shared'`: treat every model as sharing the first model's unit
+   *   (the pre-1332 behaviour). Use only when the caller has already
+   *   normalised units; mixing real units under this mode mis-scales geometry.
+   */
+  unitReconciliation?: 'auto' | 'assume-shared';
 
   /** Apply visibility filtering to each model before merging */
   visibleOnly?: boolean;
@@ -112,6 +228,17 @@ export interface MergeExportResult {
     totalEntityCount: number;
     /** File size in bytes */
     fileSize: number;
+    /**
+     * Number of models federated as their own IfcProject because their length
+     * unit differed from the first model's. 0 means a single unified project.
+     */
+    federatedModelCount: number;
+    /**
+     * Human-readable advisories about the merge (empty on a clean single-unit
+     * merge). Notably flags when federation produced more than one IfcProject,
+     * which intentionally relaxes the IfcSingleProjectInstance schema rule.
+     */
+    warnings: string[];
   };
 }
 
@@ -119,14 +246,37 @@ export interface MergeExportResult {
  * Merges multiple IFC models into a single STEP file.
  *
  * Uses the same approach as IfcOpenShell's MergeProjects recipe, extended
- * with spatial hierarchy unification:
+ * with spatial hierarchy unification and unit-aware federation:
  * 1. First model's entities use their original IDs
  * 2. Subsequent models' IDs are offset to avoid collisions
- * 3. IfcProject is unified — all references remapped to the first model's project
- * 4. Spatial structure (Site, Building, Storey) is unified by name/elevation:
- *    matching entities are remapped to the first model's equivalents so that
- *    products from all models end up in the same unified tree
- * 5. Duplicate entities and shared infrastructure (units, contexts) are skipped
+ * 3. A model that shares the first model's length unit is *unified*: its
+ *    IfcProject is remapped to the first model's, spatial structure (Site,
+ *    Building, Storey) is unified by name/elevation, and shared infrastructure
+ *    (units, contexts) is deduplicated.
+ * 4. A model with a *different* length unit is *federated*: it keeps its own
+ *    IfcProject, IfcUnitAssignment and representation contexts, so its raw
+ *    coordinates remain correctly scaled rather than being reinterpreted under
+ *    the first model's unit (the mis-scale bug, issue #1332).
+ * 5. GlobalIds are reconciled, not blindly duplicated: a non-relationship
+ *    rooted entity that repeats a GlobalId already emitted *in the same unit
+ *    space* is unified (references remapped to the one instance). Otherwise —
+ *    a federated/different-unit instance, or an objectified relationship whose
+ *    payload (RelatedObjects) may differ — it is kept and re-stamped with a
+ *    fresh deterministic GlobalId so the file has no duplicate-GlobalId errors
+ *    and no relationship membership is lost.
+ *
+ * Conformance trade-off: when federation triggers, the file contains more than
+ * one IfcProject, which intentionally relaxes the IfcSingleProjectInstance
+ * EXPRESS rule (SIZEOF(IfcProject) <= 1). This is the only way to keep two
+ * different length units in one STEP file without rewriting every length-valued
+ * coordinate, and it is strictly better than the previous silent mis-scale.
+ * `MergeExportResult.stats.warnings` flags it; pass
+ * `unitReconciliation: 'assume-shared'` to force a single project when units
+ * are already normalised.
+ *
+ * Limitation: federation only unifies a model against the *first* model's unit
+ * group. Two non-first models that share a unit different from the first are
+ * each kept as independent projects (correct, just less deduplicated).
  */
 export class MergedExporter {
   private models: MergeModelInput[];
@@ -141,147 +291,39 @@ export class MergedExporter {
   export(options: MergeExportOptions): MergeExportResult {
     const onProgress = options.onProgress;
     const schema = (options.schema || 'IFC4') as IfcSchemaVersion;
-
-    // Generate header. Policy: a federated/merged file has no single source
-    // header to round-trip, so we deliberately emit an ifc-lite provenance
-    // header rather than picking one model's FILE_DESCRIPTION arbitrarily.
-    const header = generateHeader({
-      schema,
-      description: options.description || `Merged export of ${this.models.length} models from ifc-lite`,
-      author: options.author || '',
-      organization: options.organization || '',
-      application: options.application || 'ifc-lite',
-      filename: options.filename || 'merged.ifc',
-    });
+    const header = this.buildHeader(options, schema);
+    const setup = this.buildMergeSetup(options);
 
     const allEntityLines: string[] = [];
-
-    // Track ID offsets per model
-    let nextAvailableId = 1;
-    const modelOffsets = new Map<string, number>();
-
-    // First pass: determine ID offsets. Span the COMPLETE entity set (incl.
-    // deferred property atoms) so the next model's offset clears every id this
-    // model will emit — otherwise a deferred atom at a high id collides.
-    for (const model of this.models) {
-      modelOffsets.set(model.id, nextAvailableId - 1); // offset = nextAvailableId - 1 so IDs start at nextAvailableId
-      nextAvailableId += getMaxExpressId(getCompleteEntityIndex(model.dataStore));
-    }
-
-    // Collect first model's info for deduplication
-    const firstModel = this.models[0];
-    const firstModelOffset = modelOffsets.get(firstModel.id)!;
-    const firstModelInfraMap = this.findInfrastructureEntities(firstModel.dataStore);
-    const firstProjectIds = this.findEntitiesByType(firstModel.dataStore, 'IFCPROJECT');
-
-    // Build spatial lookup from first model for Site/Building/Storey unification
-    const spatialLookup = this.buildSpatialLookup(firstModel.dataStore);
-
-    // Process each model
+    // Tracks every GlobalId already emitted → its final express id + unit scale,
+    // so later models can unify against (shared unit) or stay unique from
+    // (federated / different unit) it.
+    const guidToFinalId = new Map<string, GuidRecord>();
     let isFirstModel = true;
+    let federatedModelCount = 0;
 
     for (const model of this.models) {
-      const offset = modelOffsets.get(model.id)!;
+      const offset = setup.modelOffsets.get(model.id)!;
       const source = model.dataStore.source;
       if (!source || source.length === 0) continue;
 
       // Complete view over byId + any deferred property atoms, so the closure
       // walk and the emit loop both reach every entity the source defines.
       const completeIndex = getCompleteEntityIndex(model.dataStore);
+      const includedEntityIds = this.computeIncludedEntityIds(model, options, completeIndex, source);
 
-      // Determine which entities to include
-      let includedEntityIds: Set<number> | null = null;
+      const modelScale = this.resolveUnitScale(model);
+      const compatible = isFirstModel || setup.assumeShared
+        || this.unitsCompatible(modelScale, setup.primaryScale);
+      if (!isFirstModel && !compatible) federatedModelCount++;
+      const plan = this.planModel(model, completeIndex, isFirstModel, compatible, setup, guidToFinalId);
 
-      if (options.visibleOnly) {
-        const hiddenIds = options.hiddenEntityIdsByModel?.get(model.id) ?? new Set<number>();
-        const isolatedIds = options.isolatedEntityIdsByModel?.get(model.id) ?? null;
-        const { roots, hiddenProductIds } = getVisibleEntityIds(model.dataStore, hiddenIds, isolatedIds);
-        includedEntityIds = collectReferencedEntityIds(
-          roots,
-          source,
-          completeIndex,
-          hiddenProductIds,
-        );
-        // Second pass: collect style entities that reference included geometry
-        collectStyleEntities(includedEntityIds, source, {
-          byId: completeIndex,
-          byType: model.dataStore.entityIndex.byType,
-        });
-      }
-
-      // Build remap table (references to remap) and skip set (entities to omit)
-      const sharedRemap = new Map<number, number>();
-      const skipEntityIds = new Set<number>();
-
-      if (!isFirstModel) {
-        // Remap this model's IfcProject references → first model's IfcProject.
-        const projectIds = this.findEntitiesByType(model.dataStore, 'IFCPROJECT');
-        if (firstProjectIds.length > 0) {
-          for (const pid of projectIds) {
-            sharedRemap.set(pid, firstProjectIds[0] + firstModelOffset);
-            skipEntityIds.add(pid);
-          }
-        }
-
-        // Remap and skip duplicate infrastructure (units, contexts)
-        const modelInfra = this.findInfrastructureEntities(model.dataStore);
-        for (const [type, firstIds] of firstModelInfraMap) {
-          const thisIds = modelInfra.get(type);
-          if (thisIds && firstIds.length > 0 && thisIds.length > 0) {
-            sharedRemap.set(thisIds[0], firstIds[0] + firstModelOffset);
-            skipEntityIds.add(thisIds[0]);
-          }
-        }
-
-        // Unify spatial hierarchy: match Site, Building, Storey to first model
-        this.unifySpatialEntities(
-          model.dataStore, spatialLookup, firstModelOffset,
-          sharedRemap, skipEntityIds,
-        );
-
-        // Skip IfcRelAggregates that become fully redundant after unification.
-        // e.g. Model2's Project→Site becomes FirstProject→FirstSite which
-        // already exists from Model1, causing duplicate tree nodes.
-        this.skipRedundantRelAggregates(
-          model.dataStore, sharedRemap, skipEntityIds,
-        );
-      }
-
-      // Emit entities for this model
+      const sourceSchema = (model.dataStore.schemaVersion as IfcSchemaVersion) || 'IFC4';
       for (const [expressId, entityRef] of completeIndex) {
-        // Skip entities outside the visible closure
-        if (includedEntityIds !== null && !includedEntityIds.has(expressId)) {
-          continue;
-        }
-
-        // Skip duplicate entities (project, infrastructure)
-        if (skipEntityIds.has(expressId)) {
-          continue;
-        }
-
-        // Get original entity text — safeUtf8Decode handles SAB-backed sources
-        const entityText = safeUtf8Decode(
-          source, entityRef.byteOffset, entityRef.byteOffset + entityRef.byteLength,
-        );
-
-        // Remap IDs if this is not the first model or if offset is non-zero
-        let finalText: string;
-        if (offset === 0 && sharedRemap.size === 0) {
-          finalText = entityText;
-        } else {
-          finalText = this.remapEntityText(entityText, offset, sharedRemap);
-        }
-
-        // Apply schema conversion if target differs from source
-        const sourceSchema = (model.dataStore.schemaVersion as IfcSchemaVersion) || 'IFC4';
-        if (needsConversion(sourceSchema, schema)) {
-          const converted = convertStepLine(finalText, sourceSchema, schema);
-          if (converted !== null) {
-            allEntityLines.push(converted);
-          }
-        } else {
-          allEntityLines.push(finalText);
-        }
+        if (includedEntityIds !== null && !includedEntityIds.has(expressId)) continue;
+        if (plan.skipEntityIds.has(expressId)) continue;
+        const line = this.renderEntity(expressId, entityRef, source, offset, plan, sourceSchema, schema, guidToFinalId, modelScale);
+        if (line !== null) allEntityLines.push(line);
       }
 
       isFirstModel = false;
@@ -293,11 +335,7 @@ export class MergedExporter {
 
     return {
       content,
-      stats: {
-        modelCount: this.models.length,
-        totalEntityCount: allEntityLines.length,
-        fileSize: content.byteLength,
-      },
+      stats: this.buildStats(allEntityLines.length, content.byteLength, federatedModelCount),
     };
   }
 
@@ -308,20 +346,14 @@ export class MergedExporter {
    */
   async exportAsync(options: MergeExportOptions): Promise<MergeExportResult> {
     const onProgress = options.onProgress;
-
     const schema = (options.schema || 'IFC4') as IfcSchemaVersion;
     // See export(): merged files emit an ifc-lite provenance header by policy
     // (no single source header to preserve across federated models).
-    const header = generateHeader({
-      schema,
-      description: options.description || `Merged export of ${this.models.length} models from ifc-lite`,
-      author: options.author || '',
-      organization: options.organization || '',
-      application: options.application || 'ifc-lite',
-      filename: options.filename || 'merged.ifc',
-    });
+    const header = this.buildHeader(options, schema);
+    const setup = this.buildMergeSetup(options);
 
     const allEntityLines: string[] = [];
+    const guidToFinalId = new Map<string, GuidRecord>();
 
     // First pass: count total entities for progress
     let totalEntities = 0;
@@ -329,28 +361,15 @@ export class MergedExporter {
       totalEntities += getCompleteEntityIndex(model.dataStore).size;
     }
 
-    let nextAvailableId = 1;
-    const modelOffsets = new Map<string, number>();
-
-    for (const model of this.models) {
-      modelOffsets.set(model.id, nextAvailableId - 1);
-      nextAvailableId += getMaxExpressId(getCompleteEntityIndex(model.dataStore));
-    }
-
-    const firstModel = this.models[0];
-    const firstModelOffset = modelOffsets.get(firstModel.id)!;
-    const firstModelInfraMap = this.findInfrastructureEntities(firstModel.dataStore);
-    const firstProjectIds = this.findEntitiesByType(firstModel.dataStore, 'IFCPROJECT');
-    const spatialLookup = this.buildSpatialLookup(firstModel.dataStore);
-
     let isFirstModel = true;
     let entitiesProcessed = 0;
+    let federatedModelCount = 0;
     const YIELD_INTERVAL = 2000;
 
     if (onProgress) onProgress({ phase: 'preparing', percent: 0, entitiesProcessed: 0, entitiesTotal: totalEntities });
 
     for (const model of this.models) {
-      const offset = modelOffsets.get(model.id)!;
+      const offset = setup.modelOffsets.get(model.id)!;
       const source = model.dataStore.source;
       if (!source || source.length === 0) continue;
 
@@ -365,69 +384,22 @@ export class MergedExporter {
       }
 
       const completeIndex = getCompleteEntityIndex(model.dataStore);
+      const includedEntityIds = this.computeIncludedEntityIds(model, options, completeIndex, source);
 
-      let includedEntityIds: Set<number> | null = null;
-      if (options.visibleOnly) {
-        const hiddenIds = options.hiddenEntityIdsByModel?.get(model.id) ?? new Set<number>();
-        const isolatedIds = options.isolatedEntityIdsByModel?.get(model.id) ?? null;
-        const { roots, hiddenProductIds } = getVisibleEntityIds(model.dataStore, hiddenIds, isolatedIds);
-        includedEntityIds = collectReferencedEntityIds(
-          roots, source, completeIndex, hiddenProductIds,
-        );
-        collectStyleEntities(includedEntityIds, source, {
-          byId: completeIndex,
-          byType: model.dataStore.entityIndex.byType,
-        });
-      }
-
-      const sharedRemap = new Map<number, number>();
-      const skipEntityIds = new Set<number>();
-
-      if (!isFirstModel) {
-        const projectIds = this.findEntitiesByType(model.dataStore, 'IFCPROJECT');
-        if (firstProjectIds.length > 0) {
-          for (const pid of projectIds) {
-            sharedRemap.set(pid, firstProjectIds[0] + firstModelOffset);
-            skipEntityIds.add(pid);
-          }
-        }
-
-        const modelInfra = this.findInfrastructureEntities(model.dataStore);
-        for (const [type, firstIds] of firstModelInfraMap) {
-          const thisIds = modelInfra.get(type);
-          if (thisIds && firstIds.length > 0 && thisIds.length > 0) {
-            sharedRemap.set(thisIds[0], firstIds[0] + firstModelOffset);
-            skipEntityIds.add(thisIds[0]);
-          }
-        }
-
-        this.unifySpatialEntities(model.dataStore, spatialLookup, firstModelOffset, sharedRemap, skipEntityIds);
-        this.skipRedundantRelAggregates(model.dataStore, sharedRemap, skipEntityIds);
-      }
+      const modelScale = this.resolveUnitScale(model);
+      const compatible = isFirstModel || setup.assumeShared
+        || this.unitsCompatible(modelScale, setup.primaryScale);
+      if (!isFirstModel && !compatible) federatedModelCount++;
+      const plan = this.planModel(model, completeIndex, isFirstModel, compatible, setup, guidToFinalId);
+      const sourceSchema = (model.dataStore.schemaVersion as IfcSchemaVersion) || 'IFC4';
 
       let entityCount = 0;
       for (const [expressId, entityRef] of completeIndex) {
         if (includedEntityIds !== null && !includedEntityIds.has(expressId)) continue;
-        if (skipEntityIds.has(expressId)) continue;
+        if (plan.skipEntityIds.has(expressId)) continue;
 
-        const entityText = safeUtf8Decode(
-          source, entityRef.byteOffset, entityRef.byteOffset + entityRef.byteLength,
-        );
-
-        let finalText: string;
-        if (offset === 0 && sharedRemap.size === 0) {
-          finalText = entityText;
-        } else {
-          finalText = this.remapEntityText(entityText, offset, sharedRemap);
-        }
-
-        const sourceSchema = (model.dataStore.schemaVersion as IfcSchemaVersion) || 'IFC4';
-        if (needsConversion(sourceSchema, schema)) {
-          const converted = convertStepLine(finalText, sourceSchema, schema);
-          if (converted !== null) allEntityLines.push(converted);
-        } else {
-          allEntityLines.push(finalText);
-        }
+        const line = this.renderEntity(expressId, entityRef, source, offset, plan, sourceSchema, schema, guidToFinalId, modelScale);
+        if (line !== null) allEntityLines.push(line);
 
         entityCount++;
         entitiesProcessed++;
@@ -464,12 +436,319 @@ export class MergedExporter {
 
     return {
       content,
-      stats: {
-        modelCount: this.models.length,
-        totalEntityCount: allEntityLines.length,
-        fileSize: content.byteLength,
-      },
+      stats: this.buildStats(allEntityLines.length, content.byteLength, federatedModelCount),
     };
+  }
+
+  /**
+   * Assemble the result stats, including any federation conformance warnings.
+   */
+  private buildStats(totalEntityCount: number, fileSize: number, federatedModelCount: number): MergeExportResult['stats'] {
+    const warnings: string[] = [];
+    if (federatedModelCount > 0) {
+      warnings.push(
+        `${federatedModelCount} model(s) had a length unit differing from the first model and were ` +
+        `federated as separate IfcProject roots to keep their geometry correctly scaled. The output ` +
+        `therefore contains ${federatedModelCount + 1} IfcProject instances, which intentionally relaxes ` +
+        `the IfcSingleProjectInstance rule (SIZEOF(IfcProject) <= 1). Some single-project viewers may ` +
+        `only show the first project. Pass unitReconciliation:'assume-shared' to force one project when ` +
+        `units are already normalised.`,
+      );
+    }
+    return { modelCount: this.models.length, totalEntityCount, fileSize, federatedModelCount, warnings };
+  }
+
+  /**
+   * Build the ifc-lite provenance header. Merged files have no single source
+   * header to round-trip, so we deliberately emit our own rather than picking
+   * one model's FILE_DESCRIPTION arbitrarily.
+   */
+  private buildHeader(options: MergeExportOptions, schema: IfcSchemaVersion): string {
+    return generateHeader({
+      schema,
+      description: options.description || `Merged export of ${this.models.length} models from ifc-lite`,
+      author: options.author || '',
+      organization: options.organization || '',
+      application: options.application || 'ifc-lite',
+      filename: options.filename || 'merged.ifc',
+    });
+  }
+
+  /**
+   * Compute the model-independent state shared by export()/exportAsync():
+   * per-model id offsets and the primary model's project/infra/spatial/unit info.
+   */
+  private buildMergeSetup(options: MergeExportOptions): MergeSetup {
+    // Determine ID offsets. Span the COMPLETE entity set (incl. deferred
+    // property atoms) so the next model's offset clears every id this model
+    // will emit — otherwise a deferred atom at a high id collides.
+    let nextAvailableId = 1;
+    const modelOffsets = new Map<string, number>();
+    for (const model of this.models) {
+      modelOffsets.set(model.id, nextAvailableId - 1); // start at nextAvailableId
+      nextAvailableId += getMaxExpressId(getCompleteEntityIndex(model.dataStore));
+    }
+
+    const firstModel = this.models[0];
+    return {
+      modelOffsets,
+      firstModelOffset: modelOffsets.get(firstModel.id)!,
+      firstModelInfraMap: this.findInfrastructureEntities(firstModel.dataStore),
+      firstProjectIds: this.findEntitiesByType(firstModel.dataStore, 'IFCPROJECT'),
+      spatialLookup: this.buildSpatialLookup(firstModel.dataStore),
+      primaryScale: this.resolveUnitScale(firstModel),
+      assumeShared: options.unitReconciliation === 'assume-shared',
+    };
+  }
+
+  /**
+   * Resolve a model's length unit scale (raw IFC length → metres). Prefers an
+   * explicit `lengthUnitScale` on the input, else the value the parser stamped
+   * on the data store, else metres.
+   */
+  private resolveUnitScale(model: MergeModelInput): number {
+    const explicit = model.lengthUnitScale;
+    if (typeof explicit === 'number' && explicit > 0) return explicit;
+    const fromStore = model.dataStore.lengthUnitScale;
+    if (typeof fromStore === 'number' && fromStore > 0) return fromStore;
+    return 1.0;
+  }
+
+  /** True when two length unit scales are equal within relative tolerance. */
+  private unitsCompatible(a: number, b: number): boolean {
+    if (a === b) return true;
+    const max = Math.max(Math.abs(a), Math.abs(b));
+    if (max === 0) return true;
+    return Math.abs(a - b) <= max * UNIT_SCALE_TOLERANCE;
+  }
+
+  /**
+   * Resolve the set of express ids to include for a model under visibility
+   * filtering, or `null` when no filtering is requested (include everything).
+   */
+  private computeIncludedEntityIds(
+    model: MergeModelInput,
+    options: MergeExportOptions,
+    completeIndex: CompleteEntityIndex,
+    source: Uint8Array,
+  ): Set<number> | null {
+    if (!options.visibleOnly) return null;
+    const hiddenIds = options.hiddenEntityIdsByModel?.get(model.id) ?? new Set<number>();
+    const isolatedIds = options.isolatedEntityIdsByModel?.get(model.id) ?? null;
+    const { roots, hiddenProductIds } = getVisibleEntityIds(model.dataStore, hiddenIds, isolatedIds);
+    const included = collectReferencedEntityIds(roots, source, completeIndex, hiddenProductIds);
+    // Second pass: collect style entities that reference included geometry.
+    collectStyleEntities(included, source, {
+      byId: completeIndex,
+      byType: model.dataStore.entityIndex.byType,
+    });
+    return included;
+  }
+
+  /**
+   * Plan how a model's entities are remapped, skipped, or re-stamped, given
+   * whether it shares the primary model's length unit (`compatible`).
+   *
+   * Compatible (or `assume-shared`) models are unified into the primary project:
+   * their IfcProject, shared infrastructure, and matching spatial structure are
+   * deduplicated, and a rooted entity repeating an already-emitted GlobalId is
+   * unified to that one instance.
+   *
+   * Incompatible (federated) models keep their own project, units, contexts and
+   * spatial structure so their coordinates stay correctly scaled; a rooted
+   * entity whose GlobalId collides with one already emitted is given a fresh
+   * deterministic GlobalId, since the two cannot be the same instance across
+   * different unit spaces.
+   */
+  private planModel(
+    model: MergeModelInput,
+    completeIndex: CompleteEntityIndex,
+    isFirstModel: boolean,
+    compatible: boolean,
+    setup: MergeSetup,
+    guidToFinalId: Map<string, GuidRecord>,
+  ): ModelMergePlan {
+    const source = model.dataStore.source!;
+    const sharedRemap = new Map<number, number>();
+    const skipEntityIds = new Set<number>();
+    const guidRewrite = new Map<number, string>();
+
+    // One cheap pass to read each rooted entity's GlobalId (first attribute).
+    const localGuids = new Map<number, string>();
+    for (const [id, ref] of completeIndex) {
+      const guid = this.extractGlobalIdFast(ref, source);
+      if (guid !== null) localGuids.set(id, guid);
+    }
+
+    if (!isFirstModel && compatible) {
+      // Remap this model's IfcProject references → first model's IfcProject.
+      const projectIds = this.findEntitiesByType(model.dataStore, 'IFCPROJECT');
+      if (setup.firstProjectIds.length > 0) {
+        for (const pid of projectIds) {
+          sharedRemap.set(pid, setup.firstProjectIds[0] + setup.firstModelOffset);
+          skipEntityIds.add(pid);
+        }
+      }
+
+      // Remap and skip duplicate infrastructure (units, contexts).
+      const modelInfra = this.findInfrastructureEntities(model.dataStore);
+      for (const [type, firstIds] of setup.firstModelInfraMap) {
+        const thisIds = modelInfra.get(type);
+        if (thisIds && firstIds.length > 0 && thisIds.length > 0) {
+          sharedRemap.set(thisIds[0], firstIds[0] + setup.firstModelOffset);
+          skipEntityIds.add(thisIds[0]);
+        }
+      }
+
+      // Unify spatial hierarchy: match Site, Building, Storey to first model.
+      this.unifySpatialEntities(model.dataStore, setup.spatialLookup, setup.firstModelOffset, sharedRemap, skipEntityIds);
+
+      // Skip IfcRelAggregates that become fully redundant after unification.
+      this.skipRedundantRelAggregates(model.dataStore, sharedRemap, skipEntityIds);
+    }
+
+    if (!isFirstModel) {
+      // GlobalId reconciliation against everything emitted by earlier models.
+      const pendingMinted = new Set<string>();
+      for (const [id, guid] of localGuids) {
+        if (skipEntityIds.has(id)) continue; // already unified/deduped above
+        const prior = guidToFinalId.get(guid);
+        if (prior === undefined) continue; // first occurrence — kept as-is
+
+        // Unify (drop + remap refs to the one instance) ONLY when this is a
+        // physical/spatial root AND both this model and the emitter share the
+        // primary unit. Two conditions force "keep + re-stamp" instead:
+        //   - Objectified relationships (IfcRel*): same GlobalId does not imply
+        //     the same membership (e.g. a storey-containment listing different
+        //     elements per discipline), so dropping one would orphan elements.
+        //   - The colliding instance was emitted in a different unit space
+        //     (a federated model), so unifying would reinterpret coordinates —
+        //     the very mis-scale this fix prevents, reached transitively.
+        const type = (completeIndex.get(id)?.type ?? '').toUpperCase();
+        const emitterIsPrimaryUnit = this.unitsCompatible(prior.scale, setup.primaryScale);
+        const canUnify = compatible && emitterIsPrimaryUnit && !isRelationshipType(type);
+        if (canUnify) {
+          sharedRemap.set(id, prior.finalId);
+          skipEntityIds.add(id);
+        } else {
+          guidRewrite.set(id, this.mintUniqueGuid(guid, model.id, guidToFinalId, pendingMinted));
+        }
+      }
+    }
+
+    return { sharedRemap, skipEntityIds, guidRewrite, localGuids };
+  }
+
+  /**
+   * Render one source entity into its final STEP line: apply id offset + shared
+   * remaps, re-stamp a federated GlobalId if needed, apply schema conversion,
+   * and register the emitted GlobalId so later models can reconcile against it.
+   * Returns `null` when schema conversion drops the entity.
+   */
+  private renderEntity(
+    localId: number,
+    entityRef: ExportEntityRef,
+    source: Uint8Array,
+    offset: number,
+    plan: ModelMergePlan,
+    sourceSchema: IfcSchemaVersion,
+    targetSchema: IfcSchemaVersion,
+    guidToFinalId: Map<string, GuidRecord>,
+    modelScale: number,
+  ): string | null {
+    const entityText = safeUtf8Decode(source, entityRef.byteOffset, entityRef.byteOffset + entityRef.byteLength);
+
+    // Remap ids. Fast path: the first model (offset 0, no remaps) is byte-identical.
+    let finalText: string;
+    if (offset === 0 && plan.sharedRemap.size === 0) {
+      finalText = entityText;
+    } else {
+      finalText = this.remapEntityText(entityText, offset, plan.sharedRemap);
+    }
+
+    // Re-stamp the GlobalId for a federated entity whose id collides.
+    const mintedGuid = plan.guidRewrite.get(localId);
+    if (mintedGuid !== undefined) {
+      finalText = this.replaceGlobalId(finalText, mintedGuid);
+    }
+
+    if (needsConversion(sourceSchema, targetSchema)) {
+      const converted = convertStepLine(finalText, sourceSchema, targetSchema);
+      if (converted === null) return null;
+      finalText = converted;
+    }
+
+    // Record the emitted GlobalId → final express id + unit scale. Emitted
+    // entities are not sharedRemap keys, so their final id is localId + offset.
+    const emittedGuid = mintedGuid ?? plan.localGuids.get(localId);
+    if (emittedGuid !== undefined) {
+      guidToFinalId.set(emittedGuid, { finalId: localId + offset, scale: modelScale });
+    }
+
+    return finalText;
+  }
+
+  /**
+   * Mint a fresh, deterministic, collision-free GlobalId for an entity whose id
+   * collides. Seeded from the original GlobalId and the model's stable id so the
+   * output is reproducible and does not churn when an unrelated earlier model
+   * changes size; checked against both already-emitted ids and the ids minted
+   * so far for this model.
+   */
+  private mintUniqueGuid(
+    original: string,
+    modelId: string,
+    guidToFinalId: Map<string, GuidRecord>,
+    pendingMinted: Set<string>,
+  ): string {
+    let candidate = deterministicGlobalId(`${original}#${modelId}`);
+    let n = 0;
+    while (guidToFinalId.has(candidate) || pendingMinted.has(candidate)) {
+      candidate = deterministicGlobalId(`${original}#${modelId}#${n++}`);
+    }
+    pendingMinted.add(candidate);
+    return candidate;
+  }
+
+  /**
+   * Read an entity's GlobalId (first attribute) by decoding only its head.
+   * Returns the 22-char id for a rooted entity, or `null` for any entity whose
+   * first attribute is not a GlobalId (geometry, lists, property atoms, …).
+   */
+  private extractGlobalIdFast(ref: ExportEntityRef, source: Uint8Array): string | null {
+    // Non-rooted resource entities (property/quantity/material/style/actor …)
+    // lead with a Name string that can itself be 22 charset chars; never treat
+    // those as a GlobalId or reconciliation would drop/rename them.
+    if (NON_ROOTED_STRING_TYPES.has((ref.type ?? '').toUpperCase())) return null;
+    // 128 bytes comfortably spans `#<id>=<LONGEST_TYPE_NAME>('<22-char id>'`,
+    // so the GlobalId is always fully inside the window.
+    const end = Math.min(ref.byteOffset + 128, ref.byteOffset + ref.byteLength);
+    const head = safeUtf8Decode(source, ref.byteOffset, end);
+    const open = head.indexOf('(');
+    if (open === -1) return null;
+    let i = open + 1;
+    while (i < head.length && (head[i] === ' ' || head[i] === '\t' || head[i] === '\n' || head[i] === '\r')) i++;
+    if (head[i] !== "'") return null;
+    // A GlobalId never contains a quote (charset excludes it), so the next
+    // quote closes it.
+    const close = head.indexOf("'", i + 1);
+    if (close === -1) return null;
+    const raw = head.slice(i + 1, close);
+    return GLOBAL_ID_RE.test(raw) ? raw : null;
+  }
+
+  /**
+   * Replace an entity's GlobalId (first quoted attribute) with `newGuid`.
+   * `newGuid` is a 22-char IFC id (no quote in its charset), so this is safe.
+   */
+  private replaceGlobalId(entityText: string, newGuid: string): string {
+    const open = entityText.indexOf('(');
+    if (open === -1) return entityText;
+    const q1 = entityText.indexOf("'", open + 1);
+    if (q1 === -1) return entityText;
+    const q2 = entityText.indexOf("'", q1 + 1);
+    if (q2 === -1) return entityText;
+    return entityText.slice(0, q1 + 1) + newGuid + entityText.slice(q2);
   }
 
   /**


### PR DESCRIPTION
Fixes #1332.

## Problem

`MergedExporter` produced an invalid / mis-scaled IFC when federated models did not share length units, and duplicate-entity errors when they described the same building across disciplines (shared `GlobalId`s).

Root cause: the merge folded **every** model into the first model's `IfcProject` and deduplicated its `IfcUnitAssignment`. In IFC2x3/IFC4 length units live only on `IfcProject.UnitsInContext`, so a second model's raw coordinates were then reinterpreted under the first model's unit — e.g. the buildingSMART Duplex Electrical (FOOT) + Architecture (METRE) pair ends up ~3.28x off. The merge also did no `GlobalId` reconciliation, so shared GUIDs surfaced as duplicate-entity errors in strict viewers (BIM Vision).

## Approach (auto-federate)

A single `IfcProject` can carry only one unit, so the only schema-faithful way to keep mixed units in one file without rewriting every coordinate is to keep divergent models as their own project:

- Each model's length unit scale is resolved from `MergeModelInput.lengthUnitScale ?? dataStore.lengthUnitScale ?? 1` (the parser already stamps this on every store, so **no call-site changes are required** for the fix to take effect).
- A model that **shares** the first model's unit is unified as before (project remap + spatial unification + infrastructure dedup).
- A model with a **different** unit is **federated**: it keeps its own `IfcProject`, `IfcUnitAssignment` and representation contexts, so its coordinates stay correctly scaled. Multi-`IfcProject` output happens only on a genuine unit mismatch.
- **GlobalId reconciliation, not blind dedup**: a non-relationship rooted entity repeating a GlobalId *in the same unit space* is unified to one instance; otherwise it is kept and re-stamped with a fresh deterministic GlobalId.

### Conformance trade-off (intentional, flagged)

When federation triggers, the file has more than one `IfcProject`, which relaxes the `IfcSingleProjectInstance` rule (`SIZEOF(IfcProject) <= 1`). This is strictly better than the previous silent mis-scale and is surfaced via `MergeExportResult.stats.warnings` (the CLI `merge` command prints it). Callers who have already normalised units can pass `unitReconciliation: 'assume-shared'` to force a single project.

## API additions (all additive / back-compatible)

- `MergeModelInput.lengthUnitScale?` — optional per-model override.
- `MergeExportOptions.unitReconciliation?: 'auto' | 'assume-shared'` (default `'auto'`).
- `MergeExportResult.stats.federatedModelCount` and `stats.warnings`.

## Adversarial review hardening

This branch was run through a multi-agent adversarial review; the confirmed findings are fixed here and locked in with regression tests:

1. **Relationship payloads no longer dropped.** `IfcRel*` entities sharing a GlobalId are re-stamped (kept), not unified-away — same GlobalId does not imply same membership, so dropping one orphaned its elements from the spatial tree.
2. **22-char Name false-positive fixed.** Non-rooted resource entities (properties, quantities, materials, styles, persons/orgs) whose Name is coincidentally a 22-char GlobalId-charset string are excluded by type, so their values/names are never dropped or overwritten.
3. **Transitive cross-unit unification fixed.** `guidToFinalId` now tracks the emitter's unit scale; a unit-compatible model can no longer be unified onto a federated (different-unit) instance in a 3+ model merge.
4. **Deterministic minted GlobalIds** are seeded from the stable model id (not the positional id offset), so they don't churn when an unrelated earlier model changes size.

## Tests

`packages/export/src/merged-exporter.test.ts`: 21 passing (12 pre-existing + 9 new), covering federation, unify-vs-restamp, relationship preservation, the 22-char-name case, the 3-model transitive case, and the conformance warning. Full `@ifc-lite/export` suite green (116 passed); `@ifc-lite/cli` typechecks.

## Known follow-up (out of scope)

`IfcGeometricRepresentationSubContext` dedup still matches positionally rather than by `(ContextType, ContextIdentifier)`. This is pre-existing (and now *narrowed*, since federated models skip dedup entirely); tracked for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Merge now handles models with different length units more safely, keeping them separate when needed instead of forcing a single unit space.
  * Merge output now includes additional federation-related counts and warnings.

* **Bug Fixes**
  * Improved handling of shared identifiers during merges to reduce duplicate conflicts and preserve relationships.
  * Fixed cases where certain 22-character names could be mistaken for identifiers.

* **CLI**
  * The merge command now shows warnings in both normal and JSON output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->