### PR TITLE
fix(geometry): resolve degree units on space-after-equals exports (#1367)

### DIFF
--- a/.changeset/fix-1367-degree-trim-full-circle.md
+++ b/.changeset/fix-1367-degree-trim-full-circle.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Fix arched (degree-trimmed arc) openings rendering as full circles on Revit/EDM exports (#1367). These exporters write entity records with a space after the `=` (`#1593796= IFCPROJECT(`) and place `IFCPROJECT` plus the unit chain near the file tail. The streaming meta resolver's `find_ifcproject_id` searched for the literal `=IFCPROJECT(` (no space), so it found no project and the unit assignment silently defaulted (length → metres on a millimetre model, plane-angle → radians on a degree model). With the angle treated as radians, an `IfcTrimmedCurve` arc trimmed at `65.91°`/`114.08°` swept ~48 radians (~7.6 full turns), so an arched window opening cut a full-circle "void sphere" through the wall. The project scan now tolerates whitespace around `=`, and the plane-angle resolver reports an unresolved partial-index chain as "retry on a full index" (mirroring the length resolver) instead of masking it as the radian default, so a degree unit whose `IFCMEASUREWITHUNIT` lands past the streaming gate still resolves.

--- a/.changeset/fix-1367-degree-trim-full-circle.md
+++ b/.changeset/fix-1367-degree-trim-full-circle.md
@@ -1,5 +1,5 @@
 ---
-"@ifc-lite/geometry": patch
+"@ifc-lite/wasm": patch
 ---
 
 Fix arched (degree-trimmed arc) openings rendering as full circles on Revit/EDM exports (#1367). These exporters write entity records with a space after the `=` (`#1593796= IFCPROJECT(`) and place `IFCPROJECT` plus the unit chain near the file tail. The streaming meta resolver's `find_ifcproject_id` searched for the literal `=IFCPROJECT(` (no space), so it found no project and the unit assignment silently defaulted (length → metres on a millimetre model, plane-angle → radians on a degree model). With the angle treated as radians, an `IfcTrimmedCurve` arc trimmed at `65.91°`/`114.08°` swept ~48 radians (~7.6 full turns), so an arched window opening cut a full-circle "void sphere" through the wall. The project scan now tolerates whitespace around `=`, and the plane-angle resolver reports an unresolved partial-index chain as "retry on a full index" (mirroring the length resolver) instead of masking it as the radian default, so a degree unit whose `IFCMEASUREWITHUNIT` lands past the streaming gate still resolves.

--- a/rust/core/src/lib.rs
+++ b/rust/core/src/lib.rs
@@ -96,5 +96,5 @@ pub use step_encoding::{decode_ifc_string, encode_ifc_string};
 pub use streaming::{parse_stream, ParseEvent, StreamConfig};
 pub use units::{
     extract_length_unit_scale, extract_plane_angle_to_radians, get_si_prefix_multiplier,
-    try_extract_length_unit_scale,
+    try_extract_length_unit_scale, try_extract_plane_angle_to_radians,
 };

--- a/rust/core/src/units.rs
+++ b/rust/core/src/units.rs
@@ -363,6 +363,100 @@ pub fn try_extract_length_unit_scale(decoder: &mut EntityDecoder, project_id: u3
     }
 }
 
+/// Partial-index-safe sibling of [`extract_plane_angle_to_radians`].
+///
+/// The streaming meta gate resolves units against a PARTIAL entity index (only
+/// the file head scanned so far). [`extract_plane_angle_to_radians`] returns
+/// `Ok(1.0)` BOTH for a genuine radian/missing-unit file AND when a PLANEANGLEUNIT
+/// is declared but its conversion chain (`IFCMEASUREWITHUNIT`) is not yet indexed
+/// — the caller cannot tell "really radians" from "couldn't resolve yet". This
+/// variant returns `None` for the latter so `resolve_unit_scales` can retry
+/// against a full index, mirroring [`try_extract_length_unit_scale`]. Without it
+/// a Revit/EDM export whose DEGREE unit is early but whose `IFCMEASUREWITHUNIT`
+/// is at the file tail silently defaulted to radians → degree-trimmed arcs
+/// rendered as full circles (issue #1367).
+pub fn try_extract_plane_angle_to_radians(
+    decoder: &mut EntityDecoder,
+    project_id: u32,
+) -> Option<f64> {
+    // Project must decode; if not, the chain is incomplete on this index.
+    let project = decoder.decode_by_id(project_id).ok()?;
+    if project.ifc_type.as_str() != "IFCPROJECT" {
+        return Some(1.0); // Not a project — matches extract_plane_angle_to_radians.
+    }
+
+    let units_ref = match project.get(8).and_then(|a| a.as_entity_ref()) {
+        Some(r) => r,
+        None => return Some(1.0),
+    };
+    // Assignment not in the index ⇒ incomplete chain; signal a full-index retry.
+    let unit_assignment = decoder.decode_by_id(units_ref).ok()?;
+    if unit_assignment.ifc_type.as_str() != "IFCUNITASSIGNMENT" {
+        return Some(1.0);
+    }
+    let units_list = match unit_assignment.get(0).and_then(|a| a.as_list()) {
+        Some(list) => list,
+        None => return Some(1.0),
+    };
+
+    let mut saw_undecodable = false;
+    for unit_attr in units_list {
+        let unit_ref = match unit_attr.as_entity_ref() {
+            Some(r) => r,
+            None => continue,
+        };
+        let unit_entity = match decoder.decode_by_id(unit_ref) {
+            Ok(e) => e,
+            // A unit referenced by the assignment is missing from this index;
+            // it might be the plane-angle unit, so we cannot resolve confidently.
+            Err(_) => {
+                saw_undecodable = true;
+                continue;
+            }
+        };
+
+        match unit_entity.ifc_type.as_str() {
+            "IFCSIUNIT" => {
+                if unit_entity.get(1).and_then(|a| a.as_enum()) != Some("PLANEANGLEUNIT") {
+                    continue;
+                }
+                // SI plane-angle unit is .RADIAN.; honour exotic SI prefixes.
+                let prefix_scale = match unit_entity.get(2) {
+                    Some(p) if !p.is_null() => {
+                        p.as_enum().map(get_si_prefix_multiplier).unwrap_or(1.0)
+                    }
+                    _ => 1.0,
+                };
+                return Some(prefix_scale);
+            }
+            "IFCCONVERSIONBASEDUNIT" => {
+                if unit_entity.get(1).and_then(|a| a.as_enum()) != Some("PLANEANGLEUNIT") {
+                    continue;
+                }
+                // Resolve the conversion factor (IFCMEASUREWITHUNIT). A missing
+                // ref or one not yet indexed means we cannot resolve confidently
+                // — `None` makes `resolve_unit_scales` retry on a full index.
+                let conv_ref = unit_entity.get_ref(3)?;
+                let measure = decoder.decode_by_id(conv_ref).ok()?;
+                let value = measure.get(0).and_then(|a| a.as_float()).unwrap_or(0.0);
+                if value > 0.0 && value.is_finite() {
+                    return Some(value);
+                }
+                return None;
+            }
+            _ => {}
+        }
+    }
+
+    // No plane-angle unit found. If everything decoded, the file genuinely uses
+    // the radian default; otherwise it may be among the undecodable refs — retry.
+    if saw_undecodable {
+        None
+    } else {
+        Some(1.0)
+    }
+}
+
 /// Extract the multiplier that converts file plane-angle units to radians.
 ///
 /// Follows the chain: IFCPROJECT → IFCUNITASSIGNMENT → IFCSIUNIT / IFCCONVERSIONBASEDUNIT.
@@ -726,6 +820,111 @@ END-ISO-10303-21;
             "expected 1.0 default for missing PLANEANGLEUNIT, got {}",
             scale
         );
+    }
+
+    #[test]
+    fn test_try_extract_plane_angle_degree_full_index() {
+        let ifc_content = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('Test'),'2;1');
+FILE_NAME('test.ifc','2024-01-01',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('guid',$,'Test',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#4,$);
+#3=IFCUNITASSIGNMENT((#5,#10));
+#4=IFCAXIS2PLACEMENT3D(#7,$,$);
+#5=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#7=IFCCARTESIANPOINT((0.,0.,0.));
+#8=IFCSIUNIT(*,.PLANEANGLEUNIT.,$,.RADIAN.);
+#9=IFCMEASUREWITHUNIT(IFCRATIOMEASURE(0.0174532925199433),#8);
+#10=IFCCONVERSIONBASEDUNIT(#11,.PLANEANGLEUNIT.,'DEGREE',#9);
+#11=IFCDIMENSIONALEXPONENTS(0,0,0,0,0,0,0);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+        let mut decoder = EntityDecoder::new(ifc_content);
+        let scale = try_extract_plane_angle_to_radians(&mut decoder, 1).unwrap();
+        assert!((scale - 0.0174532925199433).abs() < 1e-9, "got {}", scale);
+    }
+
+    #[test]
+    fn test_try_extract_plane_angle_incomplete_chain_returns_none() {
+        // The DEGREE conversion unit is present but its IFCMEASUREWITHUNIT (#9)
+        // is omitted from the index — the partial-index situation that masked
+        // issue #1367. Must report None (retry) rather than the radian default.
+        let ifc_content = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('Test'),'2;1');
+FILE_NAME('test.ifc','2024-01-01',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('guid',$,'Test',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#4,$);
+#3=IFCUNITASSIGNMENT((#5,#10));
+#4=IFCAXIS2PLACEMENT3D(#7,$,$);
+#5=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#7=IFCCARTESIANPOINT((0.,0.,0.));
+#8=IFCSIUNIT(*,.PLANEANGLEUNIT.,$,.RADIAN.);
+#9=IFCMEASUREWITHUNIT(IFCRATIOMEASURE(0.0174532925199433),#8);
+#10=IFCCONVERSIONBASEDUNIT(#11,.PLANEANGLEUNIT.,'DEGREE',#9);
+#11=IFCDIMENSIONALEXPONENTS(0,0,0,0,0,0,0);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+        // Build an index that omits the conversion measure (#9), mimicking a
+        // partial streaming index where the tail measure is not yet scanned.
+        let full = crate::decoder::build_entity_index(&ifc_content);
+        let partial: crate::decoder::EntityIndex =
+            full.iter().filter(|(&id, _)| id != 9).map(|(&k, &v)| (k, v)).collect();
+        let mut decoder = EntityDecoder::with_index(ifc_content, partial);
+        assert_eq!(try_extract_plane_angle_to_radians(&mut decoder, 1), None);
+    }
+
+    #[test]
+    fn test_try_extract_plane_angle_radian_and_missing() {
+        // Genuine RADIAN file resolves to Some(1.0) (NOT None) on a full index.
+        let radian = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('Test'),'2;1');
+FILE_NAME('t.ifc','2024-01-01',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('guid',$,'Test',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#4,$);
+#3=IFCUNITASSIGNMENT((#5,#6));
+#4=IFCAXIS2PLACEMENT3D(#7,$,$);
+#5=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#6=IFCSIUNIT(*,.PLANEANGLEUNIT.,$,.RADIAN.);
+#7=IFCCARTESIANPOINT((0.,0.,0.));
+ENDSEC;
+END-ISO-10303-21;
+"#;
+        let mut decoder = EntityDecoder::new(radian);
+        assert_eq!(try_extract_plane_angle_to_radians(&mut decoder, 1), Some(1.0));
+
+        // No PLANEANGLEUNIT declared at all → radian default, fully resolved.
+        let missing = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('Test'),'2;1');
+FILE_NAME('t.ifc','2024-01-01',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('guid',$,'Test',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#4,$);
+#3=IFCUNITASSIGNMENT((#5));
+#4=IFCAXIS2PLACEMENT3D(#6,$,$);
+#5=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#6=IFCCARTESIANPOINT((0.,0.,0.));
+ENDSEC;
+END-ISO-10303-21;
+"#;
+        let mut decoder = EntityDecoder::new(missing);
+        assert_eq!(try_extract_plane_angle_to_radians(&mut decoder, 1), Some(1.0));
     }
 
     #[test]

--- a/rust/processing/src/prepass.rs
+++ b/rust/processing/src/prepass.rs
@@ -314,9 +314,12 @@ pub fn resolve_unit_scales(
         return UnitScales::default();
     };
 
-    // Fast path: resolve on the caller's decoder/index.
+    // Fast path: resolve on the caller's decoder/index. BOTH resolvers return
+    // `None` (not a masked default) when their chain is incomplete on a partial
+    // index, so an unresolved either-scale forces the full-index retry below
+    // rather than silently shipping radians/metres (issue #1367).
     let length = ifc_lite_core::try_extract_length_unit_scale(decoder, pid);
-    let angle = ifc_lite_core::extract_plane_angle_to_radians(decoder, pid).ok();
+    let angle = ifc_lite_core::try_extract_plane_angle_to_radians(decoder, pid);
 
     if let (Some(length_unit_scale), Some(plane_angle_to_radians)) = (length, angle) {
         return UnitScales {
@@ -347,23 +350,42 @@ pub fn resolve_unit_scales(
 /// no full entity scan. Returns `None` when the file has no project.
 pub fn find_ifcproject_id(content: &[u8]) -> Option<u32> {
     let mut from = 0usize;
-    while let Some(rel) = memchr::memmem::find(&content[from..], b"=IFCPROJECT(") {
-        let eq = from + rel;
-        // Backtrack over the express id digits to the '#'.
-        let mut i = eq;
-        while i > 0 && content[i - 1].is_ascii_digit() {
+    // Search for the keyword+paren only; the `=` and `#<id>` are reconstructed by
+    // backtracking. Exporters vary the whitespace around `=` — Revit/EDM emits
+    // `#1593796= IFCPROJECT(` with a SPACE, so the old `=IFCPROJECT(` literal
+    // never matched and the whole unit chain silently defaulted (length → metres
+    // on a mm model, plane-angle → radians on a degree model, making arched
+    // openings render as full circles — issue #1367). `IFCPROJECT(` cannot
+    // collide with `IFCPROJECTEDCRS(` because the `(` must immediately follow.
+    while let Some(rel) = memchr::memmem::find(&content[from..], b"IFCPROJECT(") {
+        let kw = from + rel;
+        // Backtrack over optional whitespace, then require '='.
+        let mut i = kw;
+        while i > 0 && content[i - 1].is_ascii_whitespace() {
             i -= 1;
         }
-        if i > 0 && content[i - 1] == b'#' && i < eq {
-            let mut id: u32 = 0;
-            for &b in &content[i..eq] {
-                id = id.wrapping_mul(10).wrapping_add((b - b'0') as u32);
+        if i > 0 && content[i - 1] == b'=' {
+            i -= 1; // step over '='
+            // Optional whitespace between the express id and '='.
+            while i > 0 && content[i - 1].is_ascii_whitespace() {
+                i -= 1;
             }
-            return Some(id);
+            // Backtrack over the express id digits to the '#'.
+            let digits_end = i;
+            while i > 0 && content[i - 1].is_ascii_digit() {
+                i -= 1;
+            }
+            if i > 0 && content[i - 1] == b'#' && i < digits_end {
+                let mut id: u32 = 0;
+                for &b in &content[i..digits_end] {
+                    id = id.wrapping_mul(10).wrapping_add((b - b'0') as u32);
+                }
+                return Some(id);
+            }
         }
-        // `=IFCPROJECT(` without a leading `#<digits>` (e.g. inside a string)
+        // `IFCPROJECT(` not preceded by `#<digits>=` (e.g. inside a string)
         // — keep searching.
-        from = eq + 1;
+        from = kw + 1;
     }
     None
 }
@@ -571,6 +593,7 @@ fn refs_from_list(entity: &DecodedEntity, index: usize) -> Option<Vec<u32>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ifc_lite_core::{EntityIndex, EntityScanner};
 
     #[test]
     fn find_ifcproject_id_late_in_file() {
@@ -588,6 +611,68 @@ mod tests {
     fn find_ifcproject_id_skips_string_decoys() {
         let ifc = b"DATA;\n#5=IFCWALL('decoy =IFCPROJECT( in a name',$);\n#7=IFCPROJECT('g',$);\n";
         assert_eq!(find_ifcproject_id(ifc), Some(7));
+    }
+
+    #[test]
+    fn find_ifcproject_id_handles_whitespace_around_equals() {
+        // Revit/EDM exporters write `#id= IFCPROJECT(` with a space after `=`;
+        // the old `=IFCPROJECT(` literal never matched → the whole unit chain
+        // defaulted to metres + radians (issue #1367, arched openings → circles).
+        let space_after = b"DATA;\n#1=IFCWALL('x',$);\n#1593796= IFCPROJECT('g',$,'P',$,$,$,$,$,$);\n";
+        assert_eq!(find_ifcproject_id(space_after), Some(1593796));
+
+        let space_both = b"DATA;\n#42 = IFCPROJECT('g',$);\n";
+        assert_eq!(find_ifcproject_id(space_both), Some(42));
+
+        // IFCPROJECTEDCRS must not be mistaken for IFCPROJECT.
+        let crs_only = b"DATA;\n#9= IFCPROJECTEDCRS('EPSG:32632',$,'WGS84',$,'UTM','32N',$);\n";
+        assert_eq!(find_ifcproject_id(crs_only), None);
+    }
+
+    /// Mimics the Revit/EDM ordering of Architecture.ifc (issue #1367): the
+    /// DEGREE plane-angle unit sits near the file head but its conversion
+    /// `IFCMEASUREWITHUNIT` is at the very tail. With a PARTIAL index that has the
+    /// project + assignment + degree unit but NOT the measure, the plane-angle
+    /// resolver must report "incomplete" so `resolve_unit_scales` retries against
+    /// a full index instead of silently shipping radians.
+    #[test]
+    fn resolve_unit_scales_recovers_degrees_when_measure_past_partial_index() {
+        const IFC: &[u8] = br#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('u.ifc','2026-06-26T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#10= IFCPROJECT('g',$,'P',$,$,$,$,$,#11);
+#11= IFCUNITASSIGNMENT((#12,#13));
+#12= IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);
+#13= IFCCONVERSIONBASEDUNIT(#14,.PLANEANGLEUNIT.,'DEGREE',#15);
+#14= IFCDIMENSIONALEXPONENTS(0,0,0,0,0,0,0);
+#16= IFCSIUNIT(*,.PLANEANGLEUNIT.,$,.RADIAN.);
+#15= IFCMEASUREWITHUNIT(IFCRATIOMEASURE(0.0174532925199433),#16);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+        // Build a PARTIAL index that omits the tail measure (#15) and exponents
+        // (#14), exactly the streaming-gate situation that masked the bug.
+        let mut partial = EntityIndex::default();
+        let mut scanner = EntityScanner::new(&IFC);
+        while let Some((id, _t, start, end)) = scanner.next_entity() {
+            if id == 15 || id == 14 {
+                continue; // forward-referenced past the gate
+            }
+            partial.insert(id, (start, end));
+        }
+        let mut decoder = EntityDecoder::with_index(IFC, partial);
+        let scales = resolve_unit_scales(IFC, Some(10), &mut decoder);
+        assert_eq!(scales.project_id, Some(10));
+        assert!((scales.length_unit_scale - 0.001).abs() < 1e-12);
+        assert!(
+            (scales.plane_angle_to_radians - 0.0174532925199433).abs() < 1e-12,
+            "expected degrees via full-index retry, got {}",
+            scales.plane_angle_to_radians
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Issue #1367: an arched-top window opening (`3i\$CjSRq9AeRthz5za_woI` in the reporter's `Architecture.ifc`, a Revit/EDM IFC2X3 export) cuts a full-circle "void sphere" through the wall instead of a clean arched rectangle.

| reported (broken) | expected |
|---|---|
| full-circle void with radial fans | arched rectangular opening |

## Root cause

Not a CSG/void bug — a **unit-resolution** bug. The opening's profile is a 1500×760 rectangle with an `IfcTrimmedCurve` arc on top, trimmed at `65.91°`/`114.08°`. The file declares its plane-angle unit as `DEGREE`.

This exporter writes entity records with a **space after `=`** (`#1593796= IFCPROJECT(`) and places `IFCPROJECT` plus the unit chain near the file tail. The streaming meta resolver's `find_ifcproject_id` did a raw byte search for the literal `=IFCPROJECT(` (no space), so it found **no project** → `resolve_unit_scales` returned its default `(1.0, 1.0)` → the degree trim params were treated as **radians**. A `65.91 → 114.08` rad arc sweeps ~48 radians (~7.6 full turns), tracing the whole circle (r=1837.8 mm) → the rendered sphere.

## Fix

- **`find_ifcproject_id`**: search for `IFCPROJECT(` and backtrack over optional whitespace around `=` to the `#<id>`. Handles `#id=IFCPROJECT(`, `#id= IFCPROJECT(`, `#id = IFCPROJECT(`; still rejects in-string decoys; cannot collide with `IFCPROJECTEDCRS` (the `(` must follow immediately).
- **`try_extract_plane_angle_to_radians`** (new, `Option`-returning): mirrors the existing `try_extract_length_unit_scale`. The old angle resolver returned `Ok(1.0)` for *both* a genuine radian file and an unresolvable-on-partial-index chain, so `resolve_unit_scales` skipped its full-index retry. Now an incomplete chain returns `None` → forces the retry. This protects exports where `IFCPROJECT` + the unit assignment sit before the streaming gate but the `IFCMEASUREWITHUNIT` is at the file tail (as it literally is here, line 2,039,675).

The prior session's off-target `symbolic.rs` change (2D annotation path, misdiagnosis, ineffective for this trim form) was reverted.

## Verification

End-to-end against the real file through the production path (`resolve_unit_scales` → seed → `ProfileProcessor::process`):

| | opening profile bbox |
|---|---|
| buggy (radians) | 3675 × 3675 mm — the full-circle void |
| **fixed (degrees)** | **1500 × 920 mm** — the correct arched rectangle |

- 7 new regression tests (whitespace around `=`, `IFCPROJECTEDCRS` non-collision, partial-index degree recovery, `try_extract_plane_angle_*` variants).
- Green: **85 core + 29 processing** lib tests, clippy clean on touched crates, `ifc-lite-wasm` compiles for `wasm32-unknown-unknown`.

Closes #1367.