### PR TITLE
fix(viewer,renderer): point-cloud deviation correctness + large-file ingest OOM

### DIFF
--- a/apps/viewer/src/components/viewer/DeviationPanel.tsx
+++ b/apps/viewer/src/components/viewer/DeviationPanel.tsx
@@ -15,7 +15,7 @@
  * `pointCloudAssetCount > 0`.
  */
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useViewerStore } from '@/store';
 import { getGlobalRenderer } from '@/hooks/useBCF';
 import { cn } from '@/lib/utils';
@@ -85,6 +85,25 @@ export function DeviationPanel({ triangleCount }: DeviationPanelProps) {
       setRunning(false);
     }
   }, [halfRange, setHalfRange, setColorMode, setComputed]);
+
+  // Auto-compute when the user switches to the Deviation colour mode and a
+  // result isn't ready. Selecting the mode alone only points the splat shader
+  // at the per-point deviation buffer — which stays zero-initialised (→ every
+  // point at the ramp centre, i.e. flat grey/white) until the compute pass
+  // runs. Auto-running it makes "pick Deviation" actually show the heatmap.
+  // Guarded by a ref so a failed compute doesn't retry-loop (the manual
+  // button stays available); reset when leaving deviation mode.
+  const autoComputedRef = useRef(false);
+  useEffect(() => {
+    if (colorMode !== 'deviation') {
+      autoComputedRef.current = false;
+      return;
+    }
+    if (!computed && !running && !autoComputedRef.current && triangleCount > 0) {
+      autoComputedRef.current = true;
+      void handleCompute();
+    }
+  }, [colorMode, computed, running, triangleCount, handleCompute]);
 
   // Hide the panel entirely when there's no BIM to compare against.
   // Point-cloud-only sessions (just a LAS / IFCx scan) have nothing

--- a/apps/viewer/src/components/viewer/PointCloudPanel.tsx
+++ b/apps/viewer/src/components/viewer/PointCloudPanel.tsx
@@ -54,6 +54,7 @@ export function PointCloudPanel({ assetCount, triangleCount }: PointCloudPanelPr
   const setEdlStrength = useViewerStore((s) => s.setPointCloudEdlStrength);
   const fixedColor = useViewerStore((s) => s.pointCloudFixedColor);
   const setFixedColor = useViewerStore((s) => s.setPointCloudFixedColor);
+  const deviationComputed = useViewerStore((s) => s.pointCloudDeviationComputed);
 
   if (assetCount <= 0) return null;
 
@@ -91,6 +92,18 @@ export function PointCloudPanel({ assetCount, triangleCount }: PointCloudPanelPr
           );
         })}
         <PointCloudLegend colorMode={colorMode} />
+        {colorMode === 'deviation' && !deviationComputed && (
+          // Selecting the Deviation colour mode only tells the shader to
+          // read the per-point deviation buffer — it does NOT run the
+          // compare. Until "Compute deviation" runs, that buffer is all
+          // zeros, so every point maps to the ramp centre (grey). Nudge
+          // the user toward the compute button below.
+          <span className="text-[10px] text-amber-500 px-2 leading-tight">
+            {triangleCount > 0
+              ? 'Run “Compute deviation” below to populate the heatmap.'
+              : 'Load a BIM model to compare the scan against.'}
+          </span>
+        )}
         {colorMode === 'fixed' && (
           // Native colour input — keeps the panel dependency-free.
           // Hex round-trips through float[0..1]: parse `#rrggbb` to a

--- a/apps/viewer/src/components/viewer/ViewportOverlays.tsx
+++ b/apps/viewer/src/components/viewer/ViewportOverlays.tsx
@@ -274,9 +274,20 @@ function BasepointToggleButton() {
  */
 function PointCloudPanelMount() {
   const count = useViewerStore((s) => s.pointCloudAssetCount);
-  // Triangle total comes from the merged geometry result. The panel
-  // gates the BIM↔scan deviation compute button on triangleCount > 0
-  // so the user can't trigger an empty-BVH compute pass.
-  const triangleCount = useViewerStore((s) => s.geometryResult?.totalTriangles ?? 0);
+  // BIM↔scan deviation is a CROSS-MODEL operation: the point cloud is one
+  // federated model, the BIM mesh is another. `renderer.computeDeviations()`
+  // builds its BVH from EVERY mesh in the scene (`collectAllSceneMeshes`),
+  // so the compute button must appear whenever ANY loaded model contributes
+  // triangles — not just the active one. Gating on `s.geometryResult` (the
+  // ACTIVE model's result) hid the button whenever the point cloud was the
+  // active model (its synthetic geometryResult has totalTriangles === 0),
+  // which is exactly the common case — so deviation could never be computed
+  // and the colour mode showed every point at the ramp centre (grey). Sum
+  // across all loaded models to mirror the scene the BVH is actually built from.
+  const triangleCount = useViewerStore((s) => {
+    let total = 0;
+    for (const m of s.models.values()) total += m.geometryResult?.totalTriangles ?? 0;
+    return total;
+  });
   return <PointCloudPanel assetCount={count} triangleCount={triangleCount} />;
 }

--- a/apps/viewer/src/hooks/ingest/pointCloudIngest.ts
+++ b/apps/viewer/src/hooks/ingest/pointCloudIngest.ts
@@ -39,13 +39,13 @@ export type PointCloudFormat = 'las' | 'laz' | 'ply' | 'pcd' | 'e57' | 'pts' | '
  * entity table derives its enum (58) from the type name itself.
  */
 function emptyDataStore(
-  buffer: ArrayBuffer,
+  fileSize: number,
   expressId: number,
   fileName: string,
 ): IfcDataStore {
   return createSyntheticDataStore({
     schemaVersion: 'IFC4',
-    fileSize: buffer.byteLength,
+    fileSize,
     entityCount: 1,
     entities: [{
       expressId,
@@ -73,7 +73,10 @@ export interface PointCloudIngestOptions {
   format: PointCloudFormat;
   blob: Blob;
   fileName: string;
-  buffer: ArrayBuffer;
+  /** Source file size in bytes — used only for the synthetic data store.
+   *  Point clouds stream from `blob`; the whole file is never read into
+   *  memory here, so we take the size rather than an ArrayBuffer. */
+  fileSize: number;
   /** Renderer to push chunks into. Streaming starts immediately. */
   renderer: Renderer;
   /** Express ID assigned to this asset (for picking + federation). */
@@ -382,7 +385,7 @@ export function ingestPointCloud(opts: PointCloudIngestOptions): PointCloudInges
   };
 
   return {
-    dataStore: emptyDataStore(opts.buffer, expressId, opts.fileName),
+    dataStore: emptyDataStore(opts.fileSize, expressId, opts.fileName),
     geometryResult,
     schemaVersion: 'IFC4',
     rendererHandle: handle,

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -369,12 +369,25 @@ export function useIfcLoader() {
 
 
 
-      // Read file from disk. The browser path streams files ≥
-      // STREAM_SAB_THRESHOLD directly into a SharedArrayBuffer, which avoids
-      // a doubled-peak ArrayBuffer + SAB allocation when the geometry
-      // pipeline copies into its own SAB. (#600)
+      // Detect point clouds from a small head slice FIRST. Point clouds
+      // (E57/LAS/LAZ/PLY/PCD/PTS/XYZ) stream from the Blob in bounded windows
+      // and must NOT be read whole into a (Shared)ArrayBuffer — a multi-GB
+      // scan dies with "Array buffer allocation failed" on that single
+      // allocation, before the streaming decoder ever runs. Magic-byte /
+      // extension detection only needs the first few bytes. Only IFC / GLB /
+      // IFCX actually need the full buffer.
+      const headBuf = await file.slice(0, 4096).arrayBuffer();
+      const pointCloudFormat = detectPointCloudFormat(file.name, headBuf);
+
+      // The browser path streams files ≥ STREAM_SAB_THRESHOLD directly into a
+      // SharedArrayBuffer, avoiding a doubled-peak ArrayBuffer + SAB allocation
+      // when the geometry pipeline copies into its own SAB (#600). For point
+      // clouds we keep `acquired`/`buffer` as a cheap head stand-in — the PC
+      // ingest path uses the Blob + file.size, never this buffer.
       const fileReadStart = performance.now();
-      const acquired: AcquiredBuffer = await acquireFileBuffer(file);
+      const acquired: AcquiredBuffer = pointCloudFormat
+        ? { buffer: headBuf, view: new Uint8Array(headBuf), isShared: false }
+        : await acquireFileBuffer(file);
       // `buffer` retains its previous semantics (ArrayBuffer-shaped) for
       // every downstream consumer. When `acquired.isShared` is true the
       // backing store is a SharedArrayBuffer; downstream code only ever
@@ -383,10 +396,15 @@ export function useIfcLoader() {
       // type-system: the runtime is identical.
       const buffer = acquired.buffer as ArrayBuffer;
       const fileReadMs = performance.now() - fileReadStart;
-      console.log(`[useIfc] File: ${file.name}, size: ${fileSizeMB.toFixed(2)}MB, read in ${fileReadMs.toFixed(0)}ms${acquired.isShared ? ' (streamed→SAB)' : ''}`);
+      console.log(
+        `[useIfc] File: ${file.name}, size: ${fileSizeMB.toFixed(2)}MB` +
+          (pointCloudFormat
+            ? ` — point cloud, streaming from Blob (no whole-file read)`
+            : `, read in ${fileReadMs.toFixed(0)}ms${acquired.isShared ? ' (streamed→SAB)' : ''}`),
+      );
 
-      // Detect file format (IFCX/IFC5 vs IFC4 STEP vs GLB vs LAS/LAZ)
-      const pointCloudFormat = detectPointCloudFormat(file.name, buffer);
+      // IFCX/IFC5 vs IFC4 STEP vs GLB resolved from the full buffer; point
+      // cloud format was already resolved from the head slice above.
       const format = pointCloudFormat ?? detectFormat(buffer);
 
       // LAS / LAZ point clouds: stream chunks straight to the renderer.
@@ -407,7 +425,7 @@ export function useIfcLoader() {
           format,
           blob,
           fileName: file.name,
-          buffer,
+          fileSize: file.size,
           renderer,
           onProgress: setProgress,
           onAssetCountDelta: incCount,

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -417,6 +417,11 @@ export function useIfcLoader() {
           setLoading(false);
           return;
         }
+        // WebGPU init is async (Viewport calls `renderer.init()` on mount).
+        // Dropping a point cloud BEFORE an IFC — i.e. right after mount,
+        // before init resolves — used to throw "Renderer not initialized"
+        // from `beginPointCloudStream`. Wait for the device to be ready.
+        await renderer.whenReady();
         setProgress({ phase: `Streaming ${format.toUpperCase()}`, percent: 5 });
         setGeometryStreamingActive(false);
         const blob = file;

--- a/packages/pointcloud/src/formats/e57-decode.ts
+++ b/packages/pointcloud/src/formats/e57-decode.ts
@@ -16,23 +16,39 @@ import type { DecodedPointChunk, PointCloudBBox } from '../types.js';
 import { findField, type Data3DEntry, type PrototypeField } from './e57-xml.js';
 
 /**
- * Decode the binary section starting at `entry.binaryFileOffset` in the
- * logical-bytes view. NOTE: `binaryFileOffset` here must already point
- * at the first DataPacket (i.e. AFTER the 32-byte CompressedVector
- * section header) — `decodeE57` does this conversion via
- * `resolveCompressedVectorDataOffset`. Callers passing the raw XML
- * offset directly will see a "bytestreamCount ≠ prototype length"
- * mismatch.
- *
- * Supports Float (single/double), ScaledInteger (bit-packed integer
- * with scale/offset), and Integer for cartesianX/Y/Z + colorRed/
- * Green/Blue + intensity. Other prototype fields are honoured for
- * stride math but discarded.
+ * Resolved prototype field set for one scan: the cartesian axes (always
+ * present, validated) plus the optional colour / intensity /
+ * classification channels and the predicates that decide which output
+ * buffers to allocate. Shared by the whole-file (`decodeE57Scan`) and
+ * the streaming (`E57StreamingSource`) decoders so both agree on which
+ * channels a scan carries.
  */
-export function decodeE57Scan(logical: Uint8Array, entry: Data3DEntry): DecodedPointChunk {
-  const xField = findField(entry.prototype, 'cartesianX');
-  const yField = findField(entry.prototype, 'cartesianY');
-  const zField = findField(entry.prototype, 'cartesianZ');
+export interface ScanFieldSet {
+  xField: PrototypeField;
+  yField: PrototypeField;
+  zField: PrototypeField;
+  rField?: PrototypeField;
+  gField?: PrototypeField;
+  bField?: PrototypeField;
+  /** colorRed/Green/Blue all present → emit a colours buffer. */
+  hasRgb: boolean;
+  iField?: PrototypeField;
+  /** intensity present (any supported kind) → emit an intensities buffer. */
+  hasIntensity: boolean;
+  cField?: PrototypeField;
+  /** classification present as Integer/ScaledInteger → emit a class buffer. */
+  hasClassification: boolean;
+}
+
+/**
+ * Validate + resolve a scan's prototype into a `ScanFieldSet`. Throws on
+ * a missing or plain-Integer cartesian axis (only Float / ScaledInteger
+ * cartesian is supported — see the inline note below).
+ */
+export function resolveScanFields(prototype: PrototypeField[]): ScanFieldSet {
+  const xField = findField(prototype, 'cartesianX');
+  const yField = findField(prototype, 'cartesianY');
+  const zField = findField(prototype, 'cartesianZ');
   if (!xField || !yField || !zField) {
     throw new Error('E57: prototype missing cartesianX/Y/Z');
   }
@@ -47,11 +63,11 @@ export function decodeE57Scan(logical: Uint8Array, entry: Data3DEntry): DecodedP
       );
     }
   }
-  const rField = findField(entry.prototype, 'colorRed');
-  const gField = findField(entry.prototype, 'colorGreen');
-  const bField = findField(entry.prototype, 'colorBlue');
+  const rField = findField(prototype, 'colorRed');
+  const gField = findField(prototype, 'colorGreen');
+  const bField = findField(prototype, 'colorBlue');
   const hasRgb = !!(rField && gField && bField);
-  const iField = findField(entry.prototype, 'intensity');
+  const iField = findField(prototype, 'intensity');
   // Classification: not in the standard ASTM E2807 prototype, but
   // some exporters (CloudCompare, custom LIDAR pipelines) add a
   // `classification` Integer / ScaledInteger field. We honour it
@@ -59,24 +75,210 @@ export function decodeE57Scan(logical: Uint8Array, entry: Data3DEntry): DecodedP
   // works on those files. Stock Faro / Leica scans don't carry it
   // — that's why classification mode shows everything as class 0
   // (the spec maps that to "Created, never classified").
-  const cField = findField(entry.prototype, 'classification');
+  const cField = findField(prototype, 'classification');
+  return {
+    xField, yField, zField,
+    rField, gField, bField, hasRgb,
+    // Any supported intensity kind (Float / Integer / ScaledInteger).
+    iField,
+    hasIntensity: !!iField && (iField.kind === 'Float' || iField.kind === 'Integer' || iField.kind === 'ScaledInteger'),
+    cField,
+    hasClassification: !!cField && (cField.kind === 'Integer' || cField.kind === 'ScaledInteger'),
+  };
+}
+
+/** Lightweight 4-byte DataPacket header peek (type + total logical length). */
+export interface PacketHeaderPeek {
+  /** packetType: 1=data, 2=index, 3=empty. */
+  packetType: number;
+  /** Total packet length in logical bytes (header field + 1). */
+  packetLength: number;
+}
+
+/**
+ * Read a DataPacket's 4-byte header without decoding its payload. The
+ * streaming reader uses this to learn a packet's length up front so it
+ * can decide whether the packet fits in the current window before
+ * committing to decode it.
+ *
+ * Packet header (4 bytes):
+ *   byte 0:    packetType (1=data, 2=index, 3=empty)
+ *   byte 1:    packetFlags (bit 0 = compressorRestart)
+ *   bytes 2-3: packetLogicalLength - 1 (LE u16; total packet bytes minus 1)
+ */
+export function peekPacketHeader(view: DataView, offset: number): PacketHeaderPeek {
+  return {
+    packetType: view.getUint8(offset),
+    packetLength: view.getUint16(offset + 2, true) + 1,
+  };
+}
+
+/** Result of decoding a single DataPacket. */
+export interface DecodedPacket {
+  /** packetType: 1=data (positions populated), 2/3=skip (take=0). */
+  packetType: number;
+  /** Total packet length in logical bytes — advance the cursor by this. */
+  packetLength: number;
+  /** Records decoded into the channel buffers (0 for non-data packets). */
+  take: number;
+  /** take*3 cartesian floats (data packets only). */
+  positions?: Float32Array;
+  /** take*3 colour floats when the scan carries RGB. */
+  colors?: Float32Array;
+  /** take intensities when the scan carries intensity. */
+  intensities?: Uint16Array;
+  /** take classifications when the scan carries them. */
+  classifications?: Uint8Array;
+}
+
+/**
+ * Decode ONE DataPacket at `offset` in the logical-byte view `logical`.
+ *
+ * Non-data packets (index/empty) return `{ packetType, packetLength,
+ * take: 0 }` so the caller can skip them by `packetLength`. Data packets
+ * decode up to `maxRecords` consecutive records into freshly-allocated,
+ * tightly-sized channel buffers — the caller owns striding, pose, and
+ * concatenation.
+ *
+ * Callers must ensure `offset + 4 <= logical.length` (header readable)
+ * before calling; this function then bounds-checks the full packet
+ * against `logical.length` for data packets.
+ */
+export function decodeE57Packet(
+  logical: Uint8Array,
+  view: DataView,
+  offset: number,
+  fields: ScanFieldSet,
+  prototype: PrototypeField[],
+  maxRecords: number,
+): DecodedPacket {
+  const packetType = view.getUint8(offset);
+  const packetLength = view.getUint16(offset + 2, true) + 1;
+  if (packetType !== 1) {
+    // Skip non-data packets (index/empty); they may appear interleaved.
+    return { packetType, packetLength, take: 0 };
+  }
+  const packetEnd = offset + packetLength;
+  if (packetEnd > logical.length) {
+    throw new Error('E57: DataPacket runs past end of logical bytes');
+  }
+  // Data packet header beyond the common 4 bytes:
+  //   byte 4..5: bytestreamCount (u16 LE)
+  //   then `bytestreamCount` × u16 LE = bytestreamByteCount[]
+  //   then payload (concatenated bytestreams, in prototype order)
+  //
+  // CRCs in E57 live at the PAGE level (4 bytes per 1024-byte
+  // physical page, stripped by `stripPageCrc` before we get here).
+  // There is no per-packet trailing CRC — the bytestreams fill the
+  // packet exactly up to `packetEnd`. An earlier version of this
+  // code subtracted 4 bytes assuming a packet-level CRC, which
+  // false-positived the bounds checks below on real-world Faro /
+  // Trimble exports whose last bytestream ends within the final
+  // 4 bytes of the packet.
+  const payloadEnd = packetEnd;
+  if (offset + 6 > payloadEnd) {
+    throw new Error('E57: truncated DataPacket header');
+  }
+  const bytestreamCount = view.getUint16(offset + 4, true);
+  if (bytestreamCount !== prototype.length) {
+    throw new Error(
+      `E57: packet bytestreamCount (${bytestreamCount}) ≠ prototype length (${prototype.length})`,
+    );
+  }
+  const bytestreamLengths: number[] = [];
+  let cursor = offset + 6;
+  for (let i = 0; i < bytestreamCount; i++) {
+    if (cursor + 2 > payloadEnd) {
+      throw new Error('E57: truncated bytestream length table');
+    }
+    bytestreamLengths.push(view.getUint16(cursor, true));
+    cursor += 2;
+  }
+  const fieldOffsets = new Map<string, { start: number; length: number }>();
+  let streamCursor = cursor;
+  for (let i = 0; i < bytestreamCount; i++) {
+    // Each bytestream must fit inside the packet payload — a corrupt
+    // file could otherwise have us read into the next packet or
+    // even past `logical`.
+    if (streamCursor + bytestreamLengths[i] > payloadEnd) {
+      throw new Error(
+        `E57: bytestream ${prototype[i].name} (${bytestreamLengths[i]} bytes) `
+        + `runs past packet payload at offset ${streamCursor}`,
+      );
+    }
+    fieldOffsets.set(prototype[i].name, { start: streamCursor, length: bytestreamLengths[i] });
+    streamCursor += bytestreamLengths[i];
+  }
+
+  // Per-axis packet capacity varies by field kind: Float uses
+  // floor(length / byteSize), ScaledInteger uses floor(length * 8 /
+  // bitsPerRecord). Take the min so a mixed-encoding packet picks
+  // the shortest stream.
+  const { xField, yField, zField } = fields;
+  const xPos = fieldOffsets.get('cartesianX')!;
+  const yPos = fieldOffsets.get('cartesianY')!;
+  const zPos = fieldOffsets.get('cartesianZ')!;
+  const xCapacity = floatOrSiPointCapacity(xField, xPos.length);
+  const yCapacity = floatOrSiPointCapacity(yField, yPos.length);
+  const zCapacity = floatOrSiPointCapacity(zField, zPos.length);
+  const pointsInPacket = Math.min(xCapacity, yCapacity, zCapacity);
+  const take = Math.min(pointsInPacket, Math.max(0, maxRecords));
+
+  const positions = new Float32Array(take * 3);
+  const colors = fields.hasRgb ? new Float32Array(take * 3) : undefined;
+  const intensities = fields.hasIntensity ? new Uint16Array(take) : undefined;
+  const classifications = fields.hasClassification ? new Uint8Array(take) : undefined;
+
+  readCartesianStream(logical, view, xField, xPos.start, positions, 0, take, 0);
+  readCartesianStream(logical, view, yField, yPos.start, positions, 0, take, 1);
+  readCartesianStream(logical, view, zField, zPos.start, positions, 0, take, 2);
+
+  if (colors && fields.rField && fields.gField && fields.bField) {
+    writeColorChannel(view, fieldOffsets.get('colorRed')!.start, fields.rField, colors, 0, take, 0, logical);
+    writeColorChannel(view, fieldOffsets.get('colorGreen')!.start, fields.gField, colors, 0, take, 1, logical);
+    writeColorChannel(view, fieldOffsets.get('colorBlue')!.start, fields.bField, colors, 0, take, 2, logical);
+  }
+  if (intensities && fields.iField) {
+    readIntensityStream(logical, view, fields.iField, fieldOffsets.get('intensity')!.start, intensities, 0, take);
+  }
+  if (classifications && fields.cField) {
+    readClassificationStream(
+      logical, view, fields.cField,
+      fieldOffsets.get('classification')!.start,
+      classifications, 0, take,
+    );
+  }
+
+  return { packetType, packetLength, take, positions, colors, intensities, classifications };
+}
+
+/**
+ * Decode the binary section starting at `entry.binaryFileOffset` in the
+ * logical-bytes view. NOTE: `binaryFileOffset` here must already point
+ * at the first DataPacket (i.e. AFTER the 32-byte CompressedVector
+ * section header) — `decodeE57` does this conversion via
+ * `resolveCompressedVectorDataOffset`. Callers passing the raw XML
+ * offset directly will see a "bytestreamCount ≠ prototype length"
+ * mismatch.
+ *
+ * Supports Float (single/double), ScaledInteger (bit-packed integer
+ * with scale/offset), and Integer for cartesianX/Y/Z + colorRed/
+ * Green/Blue + intensity. Other prototype fields are honoured for
+ * stride math but discarded.
+ *
+ * Whole-file path: holds the entire scan in memory. The streaming
+ * `E57StreamingSource` shares the per-packet primitives above but reads
+ * the binary section incrementally so multi-GB files don't allocate the
+ * whole file at once.
+ */
+export function decodeE57Scan(logical: Uint8Array, entry: Data3DEntry): DecodedPointChunk {
+  const fields = resolveScanFields(entry.prototype);
 
   const positions = new Float32Array(entry.recordCount * 3);
-  const colors = hasRgb ? new Float32Array(entry.recordCount * 3) : undefined;
-  // Allocate intensity for any supported field kind. ScaledInteger
-  // and Integer (u8 / u16) are both common in real exports.
-  const intensities = iField && (iField.kind === 'Float' || iField.kind === 'Integer' || iField.kind === 'ScaledInteger')
-    ? new Uint16Array(entry.recordCount)
-    : undefined;
-  const classifications = cField && (cField.kind === 'Integer' || cField.kind === 'ScaledInteger')
-    ? new Uint8Array(entry.recordCount)
-    : undefined;
+  const colors = fields.hasRgb ? new Float32Array(entry.recordCount * 3) : undefined;
+  const intensities = fields.hasIntensity ? new Uint16Array(entry.recordCount) : undefined;
+  const classifications = fields.hasClassification ? new Uint8Array(entry.recordCount) : undefined;
 
-  // Walk DataPackets starting at binaryFileOffset.
-  // Packet header (4 bytes):
-  //   byte 0: packetType (1=data, 2=index, 3=empty)
-  //   byte 1: packetFlags (bit 0 = compressorRestart)
-  //   bytes 2..3: packetLogicalLength - 1 (LE u16; total packet bytes minus 1)
   let offset = entry.binaryFileOffset;
   const view = new DataView(logical.buffer, logical.byteOffset, logical.byteLength);
   let written = 0;
@@ -85,100 +287,19 @@ export function decodeE57Scan(logical: Uint8Array, entry: Data3DEntry): DecodedP
     if (offset + 4 > logical.length) {
       throw new Error('E57: truncated DataPacket header');
     }
-    const packetType = view.getUint8(offset);
-    const packetLogicalLength = view.getUint16(offset + 2, true) + 1;
-    if (packetType !== 1) {
-      // Skip non-data packets (index/empty); they may appear interleaved.
-      offset += packetLogicalLength;
+    const packet = decodeE57Packet(logical, view, offset, fields, entry.prototype, entry.recordCount - written);
+    if (packet.packetType !== 1) {
+      offset += packet.packetLength;
       continue;
     }
-    const packetEnd = offset + packetLogicalLength;
-    if (packetEnd > logical.length) {
-      throw new Error('E57: DataPacket runs past end of logical bytes');
+    if (packet.take > 0 && packet.positions) {
+      positions.set(packet.positions, written * 3);
+      if (colors && packet.colors) colors.set(packet.colors, written * 3);
+      if (intensities && packet.intensities) intensities.set(packet.intensities, written);
+      if (classifications && packet.classifications) classifications.set(packet.classifications, written);
+      written += packet.take;
     }
-    // Data packet header beyond the common 4 bytes:
-    //   byte 4..5: bytestreamCount (u16 LE)
-    //   then `bytestreamCount` × u16 LE = bytestreamByteCount[]
-    //   then payload (concatenated bytestreams, in prototype order)
-    //
-    // CRCs in E57 live at the PAGE level (4 bytes per 1024-byte
-    // physical page, stripped by `stripPageCrc` before we get here).
-    // There is no per-packet trailing CRC — the bytestreams fill the
-    // packet exactly up to `packetEnd`. An earlier version of this
-    // code subtracted 4 bytes assuming a packet-level CRC, which
-    // false-positived the bounds checks below on real-world Faro /
-    // Trimble exports whose last bytestream ends within the final
-    // 4 bytes of the packet.
-    const payloadEnd = packetEnd;
-    if (offset + 6 > payloadEnd) {
-      throw new Error('E57: truncated DataPacket header');
-    }
-    const bytestreamCount = view.getUint16(offset + 4, true);
-    if (bytestreamCount !== entry.prototype.length) {
-      throw new Error(
-        `E57: packet bytestreamCount (${bytestreamCount}) ≠ prototype length (${entry.prototype.length})`,
-      );
-    }
-    const bytestreamLengths: number[] = [];
-    let cursor = offset + 6;
-    for (let i = 0; i < bytestreamCount; i++) {
-      if (cursor + 2 > payloadEnd) {
-        throw new Error('E57: truncated bytestream length table');
-      }
-      bytestreamLengths.push(view.getUint16(cursor, true));
-      cursor += 2;
-    }
-    const fieldOffsets = new Map<string, { start: number; length: number }>();
-    let streamCursor = cursor;
-    for (let i = 0; i < bytestreamCount; i++) {
-      // Each bytestream must fit inside the packet payload — a corrupt
-      // file could otherwise have us read into the next packet or
-      // even past `logical`.
-      if (streamCursor + bytestreamLengths[i] > payloadEnd) {
-        throw new Error(
-          `E57: bytestream ${entry.prototype[i].name} (${bytestreamLengths[i]} bytes) `
-          + `runs past packet payload at offset ${streamCursor}`,
-        );
-      }
-      fieldOffsets.set(entry.prototype[i].name, { start: streamCursor, length: bytestreamLengths[i] });
-      streamCursor += bytestreamLengths[i];
-    }
-
-    // Per-axis packet capacity now varies by field kind: Float uses
-    // floor(length / byteSize), ScaledInteger uses floor(length * 8 /
-    // bitsPerRecord). Take the min so a mixed-encoding packet picks
-    // the shortest stream.
-    const xPos = fieldOffsets.get('cartesianX')!;
-    const yPos = fieldOffsets.get('cartesianY')!;
-    const zPos = fieldOffsets.get('cartesianZ')!;
-    const xCapacity = floatOrSiPointCapacity(xField, xPos.length);
-    const yCapacity = floatOrSiPointCapacity(yField, yPos.length);
-    const zCapacity = floatOrSiPointCapacity(zField, zPos.length);
-    const pointsInPacket = Math.min(xCapacity, yCapacity, zCapacity);
-    const take = Math.min(pointsInPacket, entry.recordCount - written);
-
-    readCartesianStream(logical, view, xField, xPos.start, positions, written, take, 0);
-    readCartesianStream(logical, view, yField, yPos.start, positions, written, take, 1);
-    readCartesianStream(logical, view, zField, zPos.start, positions, written, take, 2);
-
-    if (colors && rField && gField && bField) {
-      writeColorChannel(view, fieldOffsets.get('colorRed')!.start, rField, colors, written, take, 0, logical);
-      writeColorChannel(view, fieldOffsets.get('colorGreen')!.start, gField, colors, written, take, 1, logical);
-      writeColorChannel(view, fieldOffsets.get('colorBlue')!.start, bField, colors, written, take, 2, logical);
-    }
-    if (intensities && iField) {
-      readIntensityStream(logical, view, iField, fieldOffsets.get('intensity')!.start, intensities, written, take);
-    }
-    if (classifications && cField) {
-      readClassificationStream(
-        logical, view, cField,
-        fieldOffsets.get('classification')!.start,
-        classifications, written, take,
-      );
-    }
-
-    written += take;
-    offset = packetEnd;
+    offset += packet.packetLength;
   }
 
   if (written < entry.recordCount) {

--- a/packages/pointcloud/src/formats/e57-page.ts
+++ b/packages/pointcloud/src/formats/e57-page.ts
@@ -82,6 +82,19 @@ export function physicalToLogical(physical: number, pageSize: number): number {
 }
 
 /**
+ * Convert a logical (CRC-stripped) offset back to its physical (on-disk)
+ * offset — the inverse of `physicalToLogical`. Needed by the streaming
+ * reader to translate XML / section offsets into the byte ranges it must
+ * `Blob.slice()` from disk.
+ */
+export function logicalToPhysical(logical: number, pageSize: number): number {
+  const payloadPerPage = pageSize - 4;
+  const pages = Math.floor(logical / payloadPerPage);
+  const within = logical - pages * payloadPerPage;
+  return pages * pageSize + within;
+}
+
+/**
  * Read a CompressedVector binary-section header (E57 spec §6.4.2) and
  * return the LOGICAL byte offset where its DataPackets actually start.
  *

--- a/packages/pointcloud/src/streaming/e57-source.test.ts
+++ b/packages/pointcloud/src/streaming/e57-source.test.ts
@@ -1,0 +1,385 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { E57StreamingSource } from './e57-source.js';
+import { decodeE57 } from '../formats/e57.js';
+import { logicalToPhysical, physicalToLogical } from '../formats/e57-page.js';
+import type { DecodedPointChunk } from '../types.js';
+
+const enc = new TextEncoder();
+
+interface TestPoint {
+  x: number; y: number; z: number;
+  r?: number; g?: number; b?: number;
+}
+
+/**
+ * Build the logical byte stream for one or more DataPackets carrying
+ * `points`, split into groups of `pointsPerPacket`. cartesianX/Y/Z are
+ * Float single; colours (when present on the first point) are Integer u8.
+ */
+function buildDataPackets(points: TestPoint[], pointsPerPacket: number): Uint8Array {
+  const hasColor = points.length > 0 && points[0].r !== undefined;
+  const nStreams = hasColor ? 6 : 3;
+  const groups: Uint8Array[] = [];
+  for (let start = 0; start < points.length; start += pointsPerPacket) {
+    const group = points.slice(start, start + pointsPerPacket);
+    const k = group.length;
+    const lenF = k * 4;
+    const lenU8 = k * 1;
+    const lengths = hasColor ? [lenF, lenF, lenF, lenU8, lenU8, lenU8] : [lenF, lenF, lenF];
+    const totalPayload = lengths.reduce((a, b) => a + b, 0);
+    const headerBytes = 4 + 2 + nStreams * 2;
+    const packetSize = headerBytes + totalPayload;
+    const buf = new ArrayBuffer(packetSize);
+    const view = new DataView(buf);
+    view.setUint8(0, 1);                       // packetType = data
+    view.setUint8(1, 0);                       // flags
+    view.setUint16(2, packetSize - 1, true);   // packetLogicalLength - 1
+    view.setUint16(4, nStreams, true);         // bytestreamCount
+    for (let i = 0; i < nStreams; i++) view.setUint16(6 + i * 2, lengths[i], true);
+    let cursor = headerBytes;
+    for (let i = 0; i < k; i++) view.setFloat32(cursor + i * 4, group[i].x, true);
+    cursor += lenF;
+    for (let i = 0; i < k; i++) view.setFloat32(cursor + i * 4, group[i].y, true);
+    cursor += lenF;
+    for (let i = 0; i < k; i++) view.setFloat32(cursor + i * 4, group[i].z, true);
+    cursor += lenF;
+    if (hasColor) {
+      for (let i = 0; i < k; i++) view.setUint8(cursor + i, group[i].r ?? 0);
+      cursor += lenU8;
+      for (let i = 0; i < k; i++) view.setUint8(cursor + i, group[i].g ?? 0);
+      cursor += lenU8;
+      for (let i = 0; i < k; i++) view.setUint8(cursor + i, group[i].b ?? 0);
+    }
+    groups.push(new Uint8Array(buf));
+  }
+  const total = groups.reduce((a, g) => a + g.length, 0);
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const g of groups) { out.set(g, off); off += g.length; }
+  return out;
+}
+
+/** Inflate a logical byte stream into the physical (CRC-paged) form —
+ *  the exact inverse of `stripPageCrc`. CRC tails are left zeroed (the
+ *  decoder never validates them). */
+function inflateToPhysical(logical: Uint8Array, pageSize: number): Uint8Array {
+  const payloadPerPage = pageSize - 4;
+  const fullPages = Math.floor(logical.length / payloadPerPage);
+  const tail = logical.length - fullPages * payloadPerPage;
+  const physLen = fullPages * pageSize + (tail > 0 ? tail + 4 : 0);
+  const out = new Uint8Array(physLen);
+  for (let p = 0; p < fullPages; p++) {
+    out.set(logical.subarray(p * payloadPerPage, (p + 1) * payloadPerPage), p * pageSize);
+  }
+  if (tail > 0) out.set(logical.subarray(fullPages * payloadPerPage), fullPages * pageSize);
+  return out;
+}
+
+/** Build a complete, CRC-paged single-scan E57 file as a Blob. */
+function buildE57(
+  points: TestPoint[],
+  opts: { pageSize?: number; pointsPerPacket?: number; emptyData3D?: boolean } = {},
+): {
+  blob: Blob;
+  physical: Uint8Array;
+} {
+  const pageSize = opts.pageSize ?? 256;
+  const hasColor = points.length > 0 && points[0].r !== undefined;
+  const packets = buildDataPackets(points, opts.pointsPerPacket ?? 8);
+
+  // Logical layout: [header 48][pad to 64][section 32][data][xml].
+  const sectionLogicalOffset = 64;
+  const dataLogicalOffset = sectionLogicalOffset + 32;
+  const xmlLogicalOffset = dataLogicalOffset + packets.length;
+
+  const colorProto = hasColor
+    ? `<colorRed type="Integer" minimum="0" maximum="255"/>`
+      + `<colorGreen type="Integer" minimum="0" maximum="255"/>`
+      + `<colorBlue type="Integer" minimum="0" maximum="255"/>`
+    : '';
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>`
+    + `<e57Root type="Structure">`
+    + `<data3D type="Vector">`
+    + (opts.emptyData3D ? '' : `<vectorChild type="Structure">`
+      + `<guid type="String">{scan-1}</guid>`
+      + `<points type="CompressedVector" fileOffset="${logicalToPhysical(sectionLogicalOffset, pageSize)}" recordCount="${points.length}">`
+      + `<prototype type="Structure">`
+      + `<cartesianX type="Float" precision="single"/>`
+      + `<cartesianY type="Float" precision="single"/>`
+      + `<cartesianZ type="Float" precision="single"/>`
+      + colorProto
+      + `</prototype>`
+      + `</points>`
+      + `</vectorChild>`)
+    + `</data3D>`
+    + `</e57Root>`;
+  const xmlBytes = enc.encode(xml);
+
+  const logicalLen = xmlLogicalOffset + xmlBytes.length;
+  const logical = new Uint8Array(logicalLen);
+
+  // FileHeader (48 bytes).
+  logical.set(enc.encode('ASTM-E57'), 0);
+  const hv = new DataView(logical.buffer, 0, 48);
+  hv.setUint32(8, 1, true);   // major
+  hv.setUint32(12, 0, true);  // minor
+  hv.setBigUint64(16, BigInt(logicalLen), true);                              // fileLogicalSize (logical)
+  hv.setBigUint64(24, BigInt(logicalToPhysical(xmlLogicalOffset, pageSize)), true); // xmlPhysicalOffset
+  hv.setBigUint64(32, BigInt(xmlBytes.length), true);                         // xmlLogicalLength
+  hv.setBigUint64(40, BigInt(pageSize), true);                                // pageSize
+
+  // CompressedVector section header (32 bytes).
+  const sv = new DataView(logical.buffer, sectionLogicalOffset, 32);
+  sv.setUint8(0, 1); // sectionId = CompressedVector
+  sv.setBigUint64(8, BigInt(32 + packets.length), true);                      // sectionLogicalLength
+  sv.setBigUint64(16, BigInt(logicalToPhysical(dataLogicalOffset, pageSize)), true); // dataPhysicalOffset
+  sv.setBigUint64(24, 0n, true);                                              // indexPhysicalOffset
+
+  // Data + XML.
+  logical.set(packets, dataLogicalOffset);
+  logical.set(xmlBytes, xmlLogicalOffset);
+
+  const physical = inflateToPhysical(logical, pageSize);
+  return { blob: new Blob([physical]), physical };
+}
+
+/**
+ * Build a complete, CRC-paged MULTI-scan E57 file as a Blob. Each scan
+ * gets its own CompressedVector section header + data region, laid out
+ * back-to-back: [header 48 / pad 64] [sec0 32][data0] [sec1 32][data1] … [xml].
+ * All scans here are cartesian-only (no colour) to keep the layout simple.
+ */
+function buildMultiScanE57(
+  scans: TestPoint[][],
+  opts: { pageSize?: number; pointsPerPacket?: number } = {},
+): { blob: Blob; physical: Uint8Array } {
+  const pageSize = opts.pageSize ?? 256;
+  const ppp = opts.pointsPerPacket ?? 8;
+
+  let cursor = 64;
+  const layout = scans.map((pts) => {
+    const packets = buildDataPackets(pts, ppp);
+    const sectionLogicalOffset = cursor;
+    const dataLogicalOffset = cursor + 32;
+    cursor = dataLogicalOffset + packets.length;
+    return { pts, packets, sectionLogicalOffset, dataLogicalOffset };
+  });
+  const xmlLogicalOffset = cursor;
+
+  const children = layout.map((s, i) =>
+    `<vectorChild type="Structure">`
+    + `<guid type="String">{scan-${i + 1}}</guid>`
+    + `<points type="CompressedVector" fileOffset="${logicalToPhysical(s.sectionLogicalOffset, pageSize)}" recordCount="${s.pts.length}">`
+    + `<prototype type="Structure">`
+    + `<cartesianX type="Float" precision="single"/>`
+    + `<cartesianY type="Float" precision="single"/>`
+    + `<cartesianZ type="Float" precision="single"/>`
+    + `</prototype>`
+    + `</points>`
+    + `</vectorChild>`,
+  ).join('');
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>`
+    + `<e57Root type="Structure"><data3D type="Vector">${children}</data3D></e57Root>`;
+  const xmlBytes = enc.encode(xml);
+
+  const logicalLen = xmlLogicalOffset + xmlBytes.length;
+  const logical = new Uint8Array(logicalLen);
+
+  logical.set(enc.encode('ASTM-E57'), 0);
+  const hv = new DataView(logical.buffer, 0, 48);
+  hv.setUint32(8, 1, true);
+  hv.setUint32(12, 0, true);
+  hv.setBigUint64(16, BigInt(logicalLen), true);
+  hv.setBigUint64(24, BigInt(logicalToPhysical(xmlLogicalOffset, pageSize)), true);
+  hv.setBigUint64(32, BigInt(xmlBytes.length), true);
+  hv.setBigUint64(40, BigInt(pageSize), true);
+
+  for (const s of layout) {
+    const sv = new DataView(logical.buffer, s.sectionLogicalOffset, 32);
+    sv.setUint8(0, 1);
+    sv.setBigUint64(8, BigInt(32 + s.packets.length), true);
+    sv.setBigUint64(16, BigInt(logicalToPhysical(s.dataLogicalOffset, pageSize)), true);
+    sv.setBigUint64(24, 0n, true);
+    logical.set(s.packets, s.dataLogicalOffset);
+  }
+  logical.set(xmlBytes, xmlLogicalOffset);
+
+  const physical = inflateToPhysical(logical, pageSize);
+  return { blob: new Blob([physical]), physical };
+}
+
+async function drain(src: E57StreamingSource, maxPoints: number): Promise<DecodedPointChunk[]> {
+  await src.open();
+  const chunks: DecodedPointChunk[] = [];
+  let c: DecodedPointChunk | null;
+  // eslint-disable-next-line no-cond-assign
+  while ((c = await src.next(maxPoints)) !== null) chunks.push(c);
+  return chunks;
+}
+
+function mergePositions(chunks: DecodedPointChunk[]): number[] {
+  const out: number[] = [];
+  for (const c of chunks) for (let i = 0; i < c.pointCount * 3; i++) out.push(c.positions[i]);
+  return out;
+}
+
+function totalPoints(chunks: DecodedPointChunk[]): number {
+  return chunks.reduce((a, c) => a + c.pointCount, 0);
+}
+
+describe('logicalToPhysical', () => {
+  it('is the inverse of physicalToLogical across page boundaries', () => {
+    const pageSize = 256;
+    const payload = pageSize - 4;
+    for (const logical of [0, 1, 251, 252, 253, 503, 504, 1000, 5000]) {
+      expect(physicalToLogical(logicalToPhysical(logical, pageSize), pageSize)).toBe(logical);
+    }
+    // Logical 252 lands at the start of physical page 1's payload.
+    expect(logicalToPhysical(payload, pageSize)).toBe(pageSize);
+  });
+});
+
+describe('E57StreamingSource', () => {
+  const points: TestPoint[] = [];
+  for (let i = 0; i < 50; i++) {
+    points.push({ x: i * 0.5, y: i * 0.25 - 5, z: -i, r: i % 256, g: (i * 2) % 256, b: (i * 3) % 256 });
+  }
+
+  it('streams positions + colours identical to the whole-file decoder', async () => {
+    const { blob, physical } = buildE57(points, { pageSize: 256, pointsPerPacket: 8 });
+    const reference = decodeE57(physical);
+    expect(reference).not.toBeNull();
+    expect(reference!.pointCount).toBe(50);
+
+    const src = new E57StreamingSource(blob);
+    const chunks = await drain(src, 200_000);
+    expect(totalPoints(chunks)).toBe(50);
+    expect(mergePositions(chunks)).toEqual(Array.from(reference!.positions));
+
+    // Colours present and matching the reference decode.
+    const mergedColors: number[] = [];
+    for (const c of chunks) {
+      expect(c.colors).toBeDefined();
+      for (let i = 0; i < c.pointCount * 3; i++) mergedColors.push(c.colors![i]);
+    }
+    expect(mergedColors.length).toBe(150);
+    for (let i = 0; i < 150; i++) expect(mergedColors[i]).toBeCloseTo(reference!.colors![i], 5);
+  });
+
+  it('emits multiple chunks when maxPoints is below the point count', async () => {
+    const { blob } = buildE57(points, { pageSize: 256, pointsPerPacket: 8 });
+    const src = new E57StreamingSource(blob);
+    const chunks = await drain(src, 10);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(totalPoints(chunks)).toBe(50);
+    for (const c of chunks) expect(c.pointCount).toBeLessThanOrEqual(10 + 8); // ≤ maxPoints + one packet overshoot
+  });
+
+  it('reassembles a packet bigger than the read window (grow path)', async () => {
+    const { blob, physical } = buildE57(points, { pageSize: 256, pointsPerPacket: 8 });
+    const reference = decodeE57(physical);
+    // windowBytes below a single packet forces the "grow window to the
+    // packet length" path on every read.
+    const src = new E57StreamingSource(blob, { windowBytes: 70 });
+    const chunks = await drain(src, 200_000);
+    expect(totalPoints(chunks)).toBe(50);
+    expect(mergePositions(chunks)).toEqual(Array.from(reference!.positions));
+  });
+
+  it('handles a packet straddling a multi-packet window (re-read path)', async () => {
+    const { blob, physical } = buildE57(points, { pageSize: 256, pointsPerPacket: 8 });
+    const reference = decodeE57(physical);
+    // ~2 packets per window: each window decodes the packets it fully
+    // holds, then breaks on the straddling tail and re-reads from the
+    // advanced cursor — without growing the window.
+    const src = new E57StreamingSource(blob, { windowBytes: 250 });
+    const chunks = await drain(src, 200_000);
+    expect(totalPoints(chunks)).toBe(50);
+    expect(mergePositions(chunks)).toEqual(Array.from(reference!.positions));
+  });
+
+  it('applies stride downsampling natively', async () => {
+    const { blob } = buildE57(points, { pageSize: 256, pointsPerPacket: 8 });
+    const src = new E57StreamingSource(blob, { downsample: { stride: 5 } });
+    const info = await src.open();
+    expect(info.totalPointCount).toBe(Math.ceil(50 / 5)); // 10
+    const chunks: DecodedPointChunk[] = [];
+    let c: DecodedPointChunk | null;
+    // eslint-disable-next-line no-cond-assign
+    while ((c = await src.next(200_000)) !== null) chunks.push(c);
+    // 50 points strided by 5 → first kept index 0,5,10,…,45 = 10 points.
+    expect(totalPoints(chunks)).toBe(10);
+    const xs = mergePositions(chunks).filter((_, i) => i % 3 === 0);
+    expect(xs).toEqual([0, 2.5, 5, 7.5, 10, 12.5, 15, 17.5, 20, 22.5]);
+  });
+
+  it('strides multi-scan files on the merged global index, not per-scan', async () => {
+    // Two scans with disjoint x ranges so a per-scan phase reset (the
+    // pre-fix bug) is visible in the output: scan A x∈[0,28), scan B
+    // x∈[100,132). Merged global order is A (idx 0..27) then B (idx 28..59).
+    const scanA: TestPoint[] = [];
+    for (let i = 0; i < 28; i++) scanA.push({ x: i, y: 0, z: 0 });
+    const scanB: TestPoint[] = [];
+    for (let i = 0; i < 32; i++) scanB.push({ x: 100 + i, y: 0, z: 0 });
+
+    const { blob, physical } = buildMultiScanE57([scanA, scanB], { pageSize: 256, pointsPerPacket: 8 });
+
+    // Reference: whole-file decode (merged, scan order) then GLOBAL stride.
+    const reference = decodeE57(physical);
+    expect(reference).not.toBeNull();
+    expect(reference!.pointCount).toBe(60);
+    const stride = 5;
+    const refXs = Array.from(reference!.positions).filter((_, i) => i % 3 === 0);
+    const expectedXs = refXs.filter((_, p) => p % stride === 0);
+
+    const src = new E57StreamingSource(blob, { downsample: { stride } });
+    const info = await src.open();
+    // Reported count must equal what is actually emitted (ceil(60/5)=12).
+    expect(info.totalPointCount).toBe(Math.ceil(60 / stride));
+
+    const chunks = await drain(src, 200_000);
+    expect(totalPoints(chunks)).toBe(Math.ceil(60 / stride));
+    const gotXs = mergePositions(chunks).filter((_, i) => i % 3 === 0);
+    // Global indices 0,5,…,55 → scan A x=0,5,10,15,20,25; then the phase
+    // CARRIES across the boundary: next kept global index is 30 (not 28),
+    // i.e. scan B local 2,7,12,17,22,27 → x=102,107,112,117,122,127.
+    // A per-scan reset (the bug) would instead emit 13 pts ending
+    // 100,105,…,130. This asserts the file-global phase.
+    expect(gotXs).toEqual([0, 5, 10, 15, 20, 25, 102, 107, 112, 117, 122, 127]);
+    expect(gotXs).toEqual(expectedXs);
+  });
+
+  it('streams multi-scan files identically to the whole-file decoder (stride 1)', async () => {
+    const scanA: TestPoint[] = [];
+    for (let i = 0; i < 13; i++) scanA.push({ x: i, y: i + 1, z: i + 2 });
+    const scanB: TestPoint[] = [];
+    for (let i = 0; i < 19; i++) scanB.push({ x: 50 + i, y: 60 + i, z: 70 + i });
+    const { blob, physical } = buildMultiScanE57([scanA, scanB], { pageSize: 256, pointsPerPacket: 8 });
+    const reference = decodeE57(physical);
+    expect(reference!.pointCount).toBe(32);
+    const src = new E57StreamingSource(blob);
+    const chunks = await drain(src, 200_000);
+    expect(totalPoints(chunks)).toBe(32);
+    expect(mergePositions(chunks)).toEqual(Array.from(reference!.positions));
+  });
+
+  it('reports header metadata via open()', async () => {
+    const { blob } = buildE57(points, { pageSize: 256 });
+    const src = new E57StreamingSource(blob, { label: 'apt.e57' });
+    const info = await src.open();
+    expect(info.totalPointCount).toBe(50);
+    expect(info.hasColor).toBe(true);
+    expect(info.hasIntensity).toBe(false);
+    expect(info.label).toBe('apt.e57');
+  });
+
+  it('throws a clear error on a file with no Data3D scans', async () => {
+    const { blob } = buildE57([], { pageSize: 256, emptyData3D: true });
+    const src = new E57StreamingSource(blob);
+    await expect(src.open()).rejects.toThrow(/no Data3D scans/);
+  });
+});

--- a/packages/pointcloud/src/streaming/e57-source.ts
+++ b/packages/pointcloud/src/streaming/e57-source.ts
@@ -2,94 +2,506 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+/**
+ * E57 (ASTM E2807-11) streaming source.
+ *
+ * Unlike a naive "read the whole file, then decode" approach — which
+ * allocates the entire file (plus a CRC-stripped copy of it) in one
+ * `ArrayBuffer` and dies with "Array buffer allocation failed" on
+ * multi-GB scans — this source reads the binary CompressedVector
+ * section incrementally:
+ *
+ *   open():  read the 48-byte FileHeader + the (small) XML section, then
+ *            resolve every Data3D scan's binary data offset by reading
+ *            just its 32-byte CompressedVector section header.
+ *   next():  read a bounded LOGICAL window from the blob (page-CRC
+ *            stripped on the fly), walk the DataPackets inside it,
+ *            apply stride + per-scan pose, and emit a decoded chunk.
+ *
+ * Peak memory is therefore ~one window (≤ 16 MiB) plus one output chunk,
+ * not the whole file. The per-packet decode primitives are shared with
+ * the whole-file `decodeE57Scan` so both paths agree byte-for-byte.
+ */
+
 import type { DecodedPointChunk } from '../types.js';
-import { decodeE57 } from '../formats/e57.js';
+import {
+  computeBBox,
+  decodeE57Packet,
+  peekPacketHeader,
+  resolveScanFields,
+  type DecodedPacket,
+  type ScanFieldSet,
+} from '../formats/e57-decode.js';
+import { applyPoseInPlace } from '../formats/e57.js';
+import {
+  parseE57FileHeader,
+  physicalToLogical,
+  readU64LE,
+  stripPageCrc,
+} from '../formats/e57-page.js';
+import {
+  parseE57Xml,
+  type Data3DEntry,
+  type E57Pose,
+  type PrototypeField,
+} from '../formats/e57-xml.js';
+import { BlobByteSource } from './blob-source.js';
 import type {
   DownsampleHint,
   PointSourceInfo,
   StreamingPointSource,
 } from './types.js';
 
+/** 1 MiB — always ≥ any single packet (E57 packets are ≤ 64 KiB). */
+const MIN_WINDOW_BYTES = 1 << 20;
+/** 16 MiB — caps peak window memory per `next()`. */
+const MAX_WINDOW_BYTES = 16 << 20;
+
+/** Pre-resolved plan for one Data3D scan, built once in `open()`. */
+interface ScanPlan {
+  recordCount: number;
+  /** Logical offset of the first DataPacket (post CompressedVector header). */
+  dataLogicalOffset: number;
+  fields: ScanFieldSet;
+  prototype: PrototypeField[];
+  pose?: E57Pose;
+  /** Estimated logical bytes per record — used only for window sizing. */
+  bytesPerRecord: number;
+}
+
+/** A stride-selected, pose-applied slice of one decoded packet. */
+interface SelectedPart {
+  count: number;
+  positions: Float32Array;
+  colors?: Float32Array;
+  intensities?: Uint16Array;
+  classifications?: Uint8Array;
+}
+
 export class E57StreamingSource implements StreamingPointSource {
-  private blob: Blob;
+  private bytes: BlobByteSource;
   private downsample: DownsampleHint;
   private label?: string;
-  private chunk: DecodedPointChunk | null = null;
-  private served = false;
+  /** Test hook: force a fixed window size to exercise straddle/re-read. */
+  private windowBytesOverride?: number;
 
-  constructor(blob: Blob, options: { label?: string; downsample?: DownsampleHint } = {}) {
-    this.blob = blob;
+  private opened = false;
+  private pageSize = 1024;
+  private fileLogicalSize = 0;
+  private scans: ScanPlan[] = [];
+  private totalPointCount = 0;
+  private hasColor = false;
+  private hasIntensity = false;
+  private hasClassification = false;
+
+  // Streaming cursor.
+  private scanIdx = 0;
+  private logCursor = 0;
+  /** Records consumed of the CURRENT scan (resets at each scan boundary). */
+  private recordsWritten = 0;
+  /**
+   * Cumulative declared `recordCount` of every scan BEFORE the current one.
+   * `scanRecordBase + recordsWritten` is the record's index in the merged
+   * multi-scan cloud — the phase the stride must align to so downsampling
+   * matches the whole-file decoder (which strides the merged cloud globally)
+   * rather than restarting the stride phase inside each scan.
+   */
+  private scanRecordBase = 0;
+
+  constructor(
+    blob: Blob,
+    options: { label?: string; downsample?: DownsampleHint; windowBytes?: number } = {},
+  ) {
+    this.bytes = new BlobByteSource(blob);
     this.downsample = options.downsample ?? { stride: 1 };
     this.label = options.label;
+    this.windowBytesOverride = options.windowBytes;
   }
 
   async open(signal?: AbortSignal): Promise<PointSourceInfo> {
+    if (this.opened) return this.toInfo();
     abortIfAborted(signal);
-    const buf = await this.blob.arrayBuffer();
+
+    const headerBytes = await this.bytes.read(0, 64);
     abortIfAborted(signal);
-    const decoded = decodeE57(new Uint8Array(buf));
-    if (!decoded) {
+    const header = parseE57FileHeader(headerBytes);
+    if (header.pageSize <= 4) {
+      throw new Error(`E57: invalid pageSize ${header.pageSize}`);
+    }
+    this.pageSize = header.pageSize;
+    // Prefer the header's logical size; fall back to the blob size mapped
+    // through the page math when a producer leaves fileLogicalSize at 0.
+    this.fileLogicalSize = header.fileLogicalSize > 0
+      ? header.fileLogicalSize
+      : physicalToLogical(this.bytes.size, header.pageSize);
+
+    const xmlLogical = await readLogicalRange(
+      this.bytes, header.xmlLogicalOffset, header.xmlLogicalLength, header.pageSize,
+    );
+    abortIfAborted(signal);
+    const xmlText = new TextDecoder().decode(xmlLogical);
+    const entries = parseE57Xml(xmlText);
+    if (entries.length === 0) {
       throw new Error('E57: file contains no Data3D scans');
     }
-    this.chunk = applyStride(decoded, this.downsample.stride);
-    return {
-      totalPointCount: this.chunk.pointCount,
-      bbox: this.chunk.bbox,
-      hasColor: !!this.chunk.colors,
-      hasClassification: !!this.chunk.classifications,
-      hasIntensity: !!this.chunk.intensities,
-      label: this.label,
-    };
+
+    const scans: ScanPlan[] = [];
+    let total = 0;
+    for (const entry of entries) {
+      const dataLogicalOffset = await this.resolveDataOffset(entry, header.pageSize, signal);
+      const fields = resolveScanFields(entry.prototype);
+      scans.push({
+        recordCount: entry.recordCount,
+        dataLogicalOffset,
+        fields,
+        prototype: entry.prototype,
+        pose: entry.pose,
+        bytesPerRecord: estimateBytesPerRecord(entry.prototype),
+      });
+      total += entry.recordCount;
+    }
+
+    this.scans = scans;
+    this.totalPointCount = total;
+    this.hasColor = scans.some((s) => s.fields.hasRgb);
+    this.hasIntensity = scans.some((s) => s.fields.hasIntensity);
+    this.hasClassification = scans.some((s) => s.fields.hasClassification);
+    this.scanIdx = 0;
+    this.logCursor = scans[0].dataLogicalOffset;
+    this.recordsWritten = 0;
+    this.scanRecordBase = 0;
+    this.opened = true;
+    return this.toInfo();
   }
 
   async next(maxPoints: number, signal?: AbortSignal): Promise<DecodedPointChunk | null> {
     abortIfAborted(signal);
-    if (!this.chunk || this.served) return null;
-    void maxPoints;
-    this.served = true;
-    return this.chunk;
+    if (!this.opened) {
+      throw new Error('E57StreamingSource: open() must be awaited before next()');
+    }
+    if (!Number.isFinite(maxPoints) || maxPoints <= 0) {
+      // 0/negative would emit empty chunks without advancing the cursor,
+      // creating a non-terminating loop in the host.
+      throw new Error(`E57StreamingSource: maxPoints must be > 0 (got ${maxPoints})`);
+    }
+    const stride = Math.max(1, this.downsample.stride | 0);
+
+    const parts: SelectedPart[] = [];
+    let produced = 0;
+    let anyColor = false;
+    let anyIntensity = false;
+    let anyClassification = false;
+
+    while (produced < maxPoints) {
+      abortIfAborted(signal);
+
+      // Skip past any fully-consumed scans, re-seating the cursor on the
+      // next scan's data region.
+      while (
+        this.scanIdx < this.scans.length
+        && this.recordsWritten >= this.scans[this.scanIdx].recordCount
+      ) {
+        // Carry the finished scan's full declared record count into the
+        // file-global phase so the next scan keeps striding on the merged
+        // cloud's index line (…, k·stride, …) instead of re-aligning to 0.
+        this.scanRecordBase += this.scans[this.scanIdx].recordCount;
+        this.scanIdx++;
+        if (this.scanIdx < this.scans.length) {
+          this.logCursor = this.scans[this.scanIdx].dataLogicalOffset;
+          this.recordsWritten = 0;
+        }
+      }
+      if (this.scanIdx >= this.scans.length) break; // stream exhausted
+      const scan = this.scans[this.scanIdx];
+
+      const windowLen = this.computeWindowLen(scan, maxPoints - produced, stride);
+      if (windowLen <= 0) {
+        // No file bytes remain for this scan (over-reported recordCount).
+        this.recordsWritten = scan.recordCount;
+        continue;
+      }
+      let window = await readLogicalRange(this.bytes, this.logCursor, windowLen, this.pageSize);
+      abortIfAborted(signal);
+      if (window.length === 0) {
+        this.recordsWritten = scan.recordCount;
+        continue;
+      }
+      let view = new DataView(window.buffer, window.byteOffset, window.byteLength);
+
+      // Guarantee the first packet fits: if it straddles the window end
+      // and we're not at EOF, re-read a window sized to exactly that
+      // packet. (With the default ≥1 MiB window this never fires; it
+      // matters only for the tiny windows tests use.)
+      if (window.length >= 4) {
+        const peek0 = peekPacketHeader(view, 0);
+        const atEof = this.logCursor + window.length >= this.fileLogicalSize;
+        if (peek0.packetLength > window.length && !atEof) {
+          window = await readLogicalRange(this.bytes, this.logCursor, peek0.packetLength, this.pageSize);
+          abortIfAborted(signal);
+          view = new DataView(window.buffer, window.byteOffset, window.byteLength);
+        }
+      }
+
+      let local = 0;
+      let progressed = false;
+      while (produced < maxPoints && this.recordsWritten < scan.recordCount) {
+        if (local + 4 > window.length) break; // header needs more bytes
+        const peek = peekPacketHeader(view, local);
+        if (local + peek.packetLength > window.length) {
+          // Packet straddles the window end. We've already advanced
+          // logCursor past every packet consumed so far; break and let
+          // the outer loop re-read a fresh window starting at this packet.
+          break;
+        }
+        const packet = decodeE57Packet(
+          window, view, local, scan.fields, scan.prototype, scan.recordCount - this.recordsWritten,
+        );
+        if (packet.packetType !== 1) {
+          // Skip non-data packets (index/empty); may appear interleaved.
+          local += packet.packetLength;
+          this.logCursor += packet.packetLength;
+          progressed = true;
+          continue;
+        }
+        if (packet.take > 0 && packet.positions) {
+          // Phase the stride on the file-global record index so multi-scan
+          // downsampling matches the whole-file decoder, not per-scan.
+          const sel = selectStride(packet, this.scanRecordBase + this.recordsWritten, stride, scan.pose);
+          if (sel.count > 0) {
+            parts.push(sel);
+            produced += sel.count;
+            if (sel.colors) anyColor = true;
+            if (sel.intensities) anyIntensity = true;
+            if (sel.classifications) anyClassification = true;
+          }
+          this.recordsWritten += packet.take;
+        }
+        local += packet.packetLength;
+        this.logCursor += packet.packetLength;
+        progressed = true;
+      }
+
+      if (!progressed) {
+        // Nothing consumable in this window despite bytes remaining —
+        // only reachable when the file ends mid-packet (truncated or
+        // over-reported recordCount). Drop the scan's phantom tail, like
+        // the whole-file decoder trims its under-filled output.
+        this.recordsWritten = scan.recordCount;
+      }
+    }
+
+    if (produced === 0) return null;
+    return concatParts(parts, produced, anyColor, anyIntensity, anyClassification);
   }
 
   close(): void {
-    this.chunk = null;
-    this.served = false;
+    this.opened = false;
+    this.scans = [];
+    this.scanIdx = 0;
+    this.logCursor = 0;
+    this.recordsWritten = 0;
+    this.scanRecordBase = 0;
+  }
+
+  /**
+   * Resolve a scan's binary data offset by reading its 32-byte
+   * CompressedVector section header (E57 §6.4.2). The XML's `fileOffset`
+   * points at this section header, not the first DataPacket.
+   */
+  private async resolveDataOffset(
+    entry: Data3DEntry,
+    pageSize: number,
+    signal?: AbortSignal,
+  ): Promise<number> {
+    const sectionLogical = physicalToLogical(entry.binaryFileOffset, pageSize);
+    const headerBytes = await readLogicalRange(this.bytes, sectionLogical, 32, pageSize);
+    abortIfAborted(signal);
+    if (headerBytes.length < 32) {
+      throw new Error(
+        `E57: CompressedVector section header at logical ${sectionLogical} runs past end of file`,
+      );
+    }
+    const view = new DataView(headerBytes.buffer, headerBytes.byteOffset, headerBytes.byteLength);
+    const sectionId = view.getUint8(0);
+    if (sectionId !== 1) {
+      throw new Error(
+        `E57: expected CompressedVector section (id=1) at physical ${entry.binaryFileOffset}, got id=${sectionId}`,
+      );
+    }
+    const dataPhysicalOffset = readU64LE(view, 16);
+    return physicalToLogical(dataPhysicalOffset, pageSize);
+  }
+
+  /** Logical bytes to pull on the next read — bounded and EOF-clamped. */
+  private computeWindowLen(scan: ScanPlan, remainingPoints: number, stride: number): number {
+    const remainingFile = this.fileLogicalSize - this.logCursor;
+    if (remainingFile <= 0) return 0;
+    if (this.windowBytesOverride && this.windowBytesOverride > 0) {
+      return Math.min(this.windowBytesOverride, remainingFile);
+    }
+    // Aim for ~remainingPoints worth of source records, +15% slack for
+    // packet/bytestream-table overhead, clamped to [MIN, MAX].
+    const want = remainingPoints * stride * scan.bytesPerRecord * 1.15 + 4096;
+    const len = Math.min(MAX_WINDOW_BYTES, Math.max(MIN_WINDOW_BYTES, want));
+    return Math.min(len, remainingFile);
+  }
+
+  private toInfo(): PointSourceInfo {
+    const stride = Math.max(1, this.downsample.stride | 0);
+    return {
+      totalPointCount: stride === 1
+        ? this.totalPointCount
+        : Math.ceil(this.totalPointCount / stride),
+      // The source-wide bbox is aggregated by the host from each emitted
+      // chunk's bbox; we can't know it without decoding, so report a
+      // finite zero bbox as the fallback the host only uses if no chunk
+      // is ever emitted.
+      bbox: { min: [0, 0, 0], max: [0, 0, 0] },
+      hasColor: this.hasColor,
+      hasClassification: this.hasClassification,
+      hasIntensity: this.hasIntensity,
+      label: this.label,
+    };
   }
 }
 
-function applyStride(chunk: DecodedPointChunk, stride: number): DecodedPointChunk {
-  const s = Math.max(1, stride | 0);
-  if (s === 1) return chunk;
-  const newCount = Math.ceil(chunk.pointCount / s);
-  const positions = new Float32Array(newCount * 3);
-  const colors = chunk.colors ? new Float32Array(newCount * 3) : undefined;
-  const intensities = chunk.intensities ? new Uint16Array(newCount) : undefined;
-  const classifications = chunk.classifications ? new Uint8Array(newCount) : undefined;
+/**
+ * Read a LOGICAL byte range [logStart, logStart+logLength) from a
+ * CRC-paged E57 file. Reads the covering physical page span, strips the
+ * 4-byte per-page CRC tails, and returns the requested logical slice.
+ *
+ * Returns fewer bytes than requested (or empty) near EOF — callers treat
+ * a short read as "scan ends here".
+ */
+async function readLogicalRange(
+  src: BlobByteSource,
+  logStart: number,
+  logLength: number,
+  pageSize: number,
+): Promise<Uint8Array> {
+  if (logLength <= 0) return new Uint8Array(0);
+  const payloadPerPage = pageSize - 4;
+  const firstPage = Math.floor(logStart / payloadPerPage);
+  const logicalPageStart = firstPage * payloadPerPage;
+  const physicalStart = firstPage * pageSize;
+  const logEnd = logStart + logLength;
+  // Page containing the last byte we need (inclusive).
+  const lastPage = Math.floor((logEnd - 1) / payloadPerPage);
+  const physicalEnd = (lastPage + 1) * pageSize; // exclusive; read() clamps to size
+  const physical = await src.read(physicalStart, physicalEnd);
+  if (physical.length === 0) return new Uint8Array(0);
+  // `physical` starts on a page boundary, so stripPageCrc treats byte 0
+  // as a page start correctly. A clamped (EOF) tail is handled by
+  // stripPageCrc's partial-page logic.
+  const logical = stripPageCrc(physical, pageSize);
+  const rel = logStart - logicalPageStart;
+  if (rel >= logical.length) return new Uint8Array(0);
+  return logical.subarray(rel, Math.min(rel + logLength, logical.length));
+}
+
+/**
+ * Take every `stride`-th record from a decoded packet (phased by the
+ * file-global record index `base` — the record's position in the merged
+ * multi-scan cloud, so the kept set is {i : (base+j) ≡ 0 mod stride})
+ * and apply the scan's pose. Returns a fresh, tightly-sized slice — the
+ * packet's own buffers are reused verbatim when `stride === 1`.
+ */
+function selectStride(
+  packet: DecodedPacket,
+  base: number,
+  stride: number,
+  pose?: E57Pose,
+): SelectedPart {
+  const take = packet.take;
+  const pos = packet.positions!;
+  if (stride === 1) {
+    if (pose) applyPoseInPlace(pos, take, pose);
+    return {
+      count: take,
+      positions: pos,
+      colors: packet.colors,
+      intensities: packet.intensities,
+      classifications: packet.classifications,
+    };
+  }
+  // First in-packet index j whose global index (base+j) is stride-aligned.
+  const firstKept = (stride - (base % stride)) % stride;
+  let count = 0;
+  for (let j = firstKept; j < take; j += stride) count++;
+
+  const positions = new Float32Array(count * 3);
+  const colors = packet.colors ? new Float32Array(count * 3) : undefined;
+  const intensities = packet.intensities ? new Uint16Array(count) : undefined;
+  const classifications = packet.classifications ? new Uint8Array(count) : undefined;
   let dst = 0;
-  for (let i = 0; i < chunk.pointCount; i += s) {
-    positions[dst * 3] = chunk.positions[i * 3];
-    positions[dst * 3 + 1] = chunk.positions[i * 3 + 1];
-    positions[dst * 3 + 2] = chunk.positions[i * 3 + 2];
-    if (colors && chunk.colors) {
-      colors[dst * 3] = chunk.colors[i * 3];
-      colors[dst * 3 + 1] = chunk.colors[i * 3 + 1];
-      colors[dst * 3 + 2] = chunk.colors[i * 3 + 2];
+  for (let j = firstKept; j < take; j += stride) {
+    positions[dst * 3] = pos[j * 3];
+    positions[dst * 3 + 1] = pos[j * 3 + 1];
+    positions[dst * 3 + 2] = pos[j * 3 + 2];
+    if (colors && packet.colors) {
+      colors[dst * 3] = packet.colors[j * 3];
+      colors[dst * 3 + 1] = packet.colors[j * 3 + 1];
+      colors[dst * 3 + 2] = packet.colors[j * 3 + 2];
     }
-    if (intensities && chunk.intensities) {
-      intensities[dst] = chunk.intensities[i];
-    }
-    if (classifications && chunk.classifications) {
-      classifications[dst] = chunk.classifications[i];
-    }
+    if (intensities && packet.intensities) intensities[dst] = packet.intensities[j];
+    if (classifications && packet.classifications) classifications[dst] = packet.classifications[j];
     dst++;
+  }
+  if (pose) applyPoseInPlace(positions, count, pose);
+  return { count, positions, colors, intensities, classifications };
+}
+
+/**
+ * Concatenate per-packet selected parts into one chunk. Channels are
+ * unioned across parts (a multi-scan chunk where one scan lacks colour
+ * leaves that scan's slice at zeros), mirroring `decodeE57`'s merge.
+ */
+function concatParts(
+  parts: SelectedPart[],
+  total: number,
+  anyColor: boolean,
+  anyIntensity: boolean,
+  anyClassification: boolean,
+): DecodedPointChunk {
+  const positions = new Float32Array(total * 3);
+  const colors = anyColor ? new Float32Array(total * 3) : undefined;
+  const intensities = anyIntensity ? new Uint16Array(total) : undefined;
+  const classifications = anyClassification ? new Uint8Array(total) : undefined;
+  let off = 0;
+  for (const p of parts) {
+    positions.set(p.positions, off * 3);
+    if (colors && p.colors) colors.set(p.colors, off * 3);
+    if (intensities && p.intensities) intensities.set(p.intensities, off);
+    if (classifications && p.classifications) classifications.set(p.classifications, off);
+    off += p.count;
   }
   return {
     positions,
     colors,
     intensities,
     classifications,
-    pointCount: newCount,
-    bbox: chunk.bbox,
+    pointCount: total,
+    bbox: computeBBox(positions),
   };
+}
+
+/** Rough logical bytes per record — window-sizing heuristic only. */
+function estimateBytesPerRecord(prototype: PrototypeField[]): number {
+  let bytes = 0;
+  for (const f of prototype) {
+    if (f.kind === 'Float') {
+      bytes += f.precision === 'single' ? 4 : 8;
+    } else if (f.kind === 'Integer') {
+      const widest = Math.max(Math.abs(f.minimum ?? 0), Math.abs(f.maximum ?? 255));
+      bytes += widest > 255 ? 2 : 1;
+    } else {
+      // ScaledInteger: ceil(log2(span+1)) bits per record.
+      const span = Math.max(0, (f.maximum ?? 0) - (f.minimum ?? 0));
+      const bits = span <= 0 ? 1 : Math.ceil(Math.log2(span + 1));
+      bytes += bits / 8;
+    }
+  }
+  return Math.max(1, bytes);
 }
 
 function abortIfAborted(signal?: AbortSignal): void {

--- a/packages/renderer/src/deviation/deviation-pipeline.ts
+++ b/packages/renderer/src/deviation/deviation-pipeline.ts
@@ -52,7 +52,15 @@ export class DeviationPipeline {
   private bvhTriangleCount = 0;
   private bvhNodeCount = 0;
   private bvhBounds: TriangleBVHResult['bounds'] | null = null;
-  private paramsBuffer: GPUBuffer | null = null;
+  /**
+   * One uniform buffer per `dispatch()` call within a compute batch. They
+   * MUST be distinct: every chunk's dispatch is recorded into one encoder and
+   * submitted once, but `queue.writeBuffer` runs on the queue BEFORE that
+   * single submit — so a single shared buffer would hold only the LAST
+   * chunk's params when every pass executes. Freed by `releaseTransientParams`
+   * after `onSubmittedWorkDone()`.
+   */
+  private transientParamsBuffers: GPUBuffer[] = [];
 
   constructor(device: GPUDevice) {
     this.device = device;
@@ -142,19 +150,19 @@ export class DeviationPipeline {
     if (!this.bvhNodesBuffer || !this.trianglesBuffer) return false;
     if (input.pointCount === 0) return true;
 
-    // Reuse one instance-cached uniform buffer for the dispatch params.
-    // Created lazily once; overwritten per chunk via writeBuffer. All
-    // chunk dispatches are recorded into one encoder and submitted once,
-    // and writeBuffer is queued in submission order relative to the
-    // dispatches, so overwriting between chunks within the same submit is
-    // safe (each chunk's bind group reads the value as enqueued).
-    if (!this.paramsBuffer) {
-      this.paramsBuffer = this.device.createBuffer({
-        size: PARAMS_UNIFORM_BYTES,
-        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
-      });
-    }
-    const paramsBuffer = this.paramsBuffer;
+    // A FRESH uniform buffer per chunk. `queue.writeBuffer` is ordered on the
+    // queue ahead of the single `submit` that runs every chunk's compute pass,
+    // so reusing one cached buffer left every pass reading the LAST chunk's
+    // `pointCount` — the shorter final chunk — and every full chunk then
+    // early-returned its tail (`pi >= params.pointCount`), leaving those
+    // points' deviation at its zero init → rendered at the ramp centre
+    // (white) regardless of their true distance. Distinct buffers keep each
+    // pass's params intact; they're freed in `releaseTransientParams()`.
+    const paramsBuffer = this.device.createBuffer({
+      size: PARAMS_UNIFORM_BYTES,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+    this.transientParamsBuffers.push(paramsBuffer);
     const params = new Uint32Array(PARAMS_UNIFORM_BYTES / 4);
     const paramsF = new Float32Array(params.buffer);
     params[0] = input.pointCount;
@@ -196,9 +204,18 @@ export class DeviationPipeline {
     this.trianglesBuffer = null;
   }
 
+  /**
+   * Destroy the per-dispatch uniform buffers from the last compute batch.
+   * Call after `queue.onSubmittedWorkDone()` so the GPU is finished reading
+   * them. Safe to call repeatedly.
+   */
+  releaseTransientParams(): void {
+    for (const b of this.transientParamsBuffers) b.destroy();
+    this.transientParamsBuffers = [];
+  }
+
   destroy(): void {
     this.disposeBvh();
-    this.paramsBuffer?.destroy();
-    this.paramsBuffer = null;
+    this.releaseTransientParams();
   }
 }

--- a/packages/renderer/src/deviation/deviation-shader.wgsl.ts
+++ b/packages/renderer/src/deviation/deviation-shader.wgsl.ts
@@ -219,10 +219,19 @@ fn cs_main(@builtin(global_invocation_id) gid: vec3<u32>) {
   }
 
   // Signed distance: project (p - closestPoint) onto the closest
-  // triangle's normal. Positive ⇒ p is on the outward side.
+  // triangle's normal. Positive means p is on the outward side.
+  //
+  // sign() returns 0 when (p - closestPoint) is perpendicular to the
+  // normal -- i.e. the point is COPLANAR with the triangle but its closest
+  // feature is an edge/vertex (a point beside a wall, an open door swung
+  // into a wall's plane, a floor point laterally past the nearest floor
+  // tri). That multiplied a genuinely large dist by 0 and painted far
+  // points at the ramp centre (white). Treat the in-plane case as the
+  // outward side so the magnitude still flags them.
   let toPoint = p - bestPoint;
   let dist = sqrt(bestDistSq);
-  let s = sign(dot(toPoint, bestNormal));
+  let nd = dot(toPoint, bestNormal);
+  let s = select(-1.0, 1.0, nd >= 0.0);
   var signed: f32 = s * dist;
 
   // Optional clip: keeps the histogram + ramp focused on near-surface

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -190,6 +190,9 @@ export class Renderer {
         highQuality: true,
     };
     private pointCloudRenderer: PointCloudRenderer | null = null;
+    /** Set true at the end of `init()`; gates `whenReady()`. */
+    private ready = false;
+    private readyWaiters: Array<() => void> = [];
     private deviationPipeline: DeviationPipeline | null = null;
     /**
      * Cache of which mesh-set the BVH was built from. We rebuild on
@@ -341,6 +344,28 @@ export class Renderer {
                 },
             };
         });
+
+        this.markReady();
+    }
+
+    /**
+     * Resolves once `init()` has finished and the GPU device + point-cloud
+     * renderer are usable. Callers that may run before init completes — e.g.
+     * dropping a point cloud immediately after the viewport mounts, before
+     * the async WebGPU init resolves — should `await renderer.whenReady()`
+     * before `beginPointCloudStream`, which otherwise throws
+     * "Renderer not initialized".
+     */
+    whenReady(): Promise<void> {
+        if (this.ready) return Promise.resolve();
+        return new Promise<void>((resolve) => { this.readyWaiters.push(resolve); });
+    }
+
+    private markReady(): void {
+        this.ready = true;
+        const waiters = this.readyWaiters;
+        this.readyWaiters = [];
+        for (const w of waiters) w();
     }
 
     /**

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -578,6 +578,8 @@ export class Renderer {
         // Otherwise the caller's "compute done" callback fires before
         // the deviation buffers are actually populated.
         await this.device.getDevice().queue.onSubmittedWorkDone();
+        // The GPU is done reading each chunk's params uniform — free them.
+        this.deviationPipeline.releaseTransientParams();
         this.requestRender();
 
         // Suggest a default half-range = max(0.01m, max-extent / 1000).

--- a/packages/renderer/src/pointcloud/point-cloud-node.ts
+++ b/packages/renderer/src/pointcloud/point-cloud-node.ts
@@ -112,7 +112,15 @@ export function appendChunkToNode(
     device.limits.maxBufferSize,
     device.limits.maxStorageBufferBindingSize,
   );
-  const maxPerBuffer = Math.max(1, Math.floor((maxBytes * 0.95) / POINT_VERTEX_BYTES));
+  const bufferPointCap = Math.floor((maxBytes * 0.95) / POINT_VERTEX_BYTES);
+  // The deviation compute dispatches ceil(count / 64) workgroups over a whole
+  // chunk (its workgroup size is 64). That count must stay within
+  // maxComputeWorkgroupsPerDimension (65535), else WebGPU rejects the dispatch
+  // ("group size ... must be less or equal to 65535"). So a chunk is capped so
+  // both its GPU buffer AND a single per-point compute dispatch over it fit —
+  // ~4.19 M points (65535 × 64), tighter than the ~5.3 M buffer cap.
+  const dispatchPointCap = device.limits.maxComputeWorkgroupsPerDimension * 64;
+  const maxPerBuffer = Math.max(1, Math.min(bufferPointCap, dispatchPointCap));
   for (let start = 0; start < total; start += maxPerBuffer) {
     appendPointSubBuffer(device, node, chunk, start, Math.min(maxPerBuffer, total - start));
   }

--- a/packages/renderer/src/pointcloud/point-cloud-node.ts
+++ b/packages/renderer/src/pointcloud/point-cloud-node.ts
@@ -87,13 +87,45 @@ export function createNode(
 const DEBUG_VERTEX_CLASS_LOG_LIMIT = 3;
 let debugVertexClassLogs = 0;
 
-/** Convert a renderer-agnostic chunk into a GPU vertex buffer + metadata. */
+/**
+ * Append a chunk's points to a node as one or more GPU vertex buffers.
+ *
+ * A single GPU buffer can't exceed `maxBufferSize` (typically 256 MiB), and
+ * because this vertex buffer is also bound as STORAGE for the deviation
+ * compute, `maxStorageBufferBindingSize` (often 128 MiB) applies too. At
+ * 24 B/point that caps a buffer at ~5–11 M points — so a large chunk (e.g. a
+ * whole-file decode that doesn't sub-chunk, or a big inline cloud) is split
+ * into sub-buffers that each fit, instead of failing with
+ * "Buffer size N is greater than the maximum buffer size". The draw and
+ * deviation passes already iterate `node.chunks`, so the split is transparent.
+ */
 export function appendChunkToNode(
   device: GPUDevice,
   node: PointCloudNode,
   chunk: PointCloudChunkInput,
-): PointCloudGpuChunk {
-  const count = chunk.pointCount;
+): void {
+  const total = chunk.pointCount;
+  if (total <= 0) return;
+  // Honour BOTH the raw buffer cap and the storage-binding cap, with a 5%
+  // margin for safety against driver rounding.
+  const maxBytes = Math.min(
+    device.limits.maxBufferSize,
+    device.limits.maxStorageBufferBindingSize,
+  );
+  const maxPerBuffer = Math.max(1, Math.floor((maxBytes * 0.95) / POINT_VERTEX_BYTES));
+  for (let start = 0; start < total; start += maxPerBuffer) {
+    appendPointSubBuffer(device, node, chunk, start, Math.min(maxPerBuffer, total - start));
+  }
+}
+
+/** Pack `chunk`'s `[start, start+count)` points into one GPU vertex buffer. */
+function appendPointSubBuffer(
+  device: GPUDevice,
+  node: PointCloudNode,
+  chunk: PointCloudChunkInput,
+  start: number,
+  count: number,
+): void {
   const bytes = new ArrayBuffer(count * POINT_VERTEX_BYTES);
   const f32 = new Float32Array(bytes);
   const u8 = new Uint8Array(bytes);
@@ -104,27 +136,28 @@ export function appendChunkToNode(
   const intensities = chunk.intensities;
   const expressId = node.meta.expressId >>> 0;
 
-  for (let i = 0; i < count; i++) {
-    const fOff = i * 6;
-    f32[fOff] = positions[i * 3];
-    f32[fOff + 1] = positions[i * 3 + 1];
-    f32[fOff + 2] = positions[i * 3 + 2];
+  for (let j = 0; j < count; j++) {
+    const src = start + j;
+    const fOff = j * 6;
+    f32[fOff] = positions[src * 3];
+    f32[fOff + 1] = positions[src * 3 + 1];
+    f32[fOff + 2] = positions[src * 3 + 2];
 
-    const byteOff = i * POINT_VERTEX_BYTES + 12;
+    const byteOff = j * POINT_VERTEX_BYTES + 12;
     if (colors) {
-      u8[byteOff] = clamp01(colors[i * 3]) * 255;
-      u8[byteOff + 1] = clamp01(colors[i * 3 + 1]) * 255;
-      u8[byteOff + 2] = clamp01(colors[i * 3 + 2]) * 255;
+      u8[byteOff] = clamp01(colors[src * 3]) * 255;
+      u8[byteOff + 1] = clamp01(colors[src * 3 + 1]) * 255;
+      u8[byteOff + 2] = clamp01(colors[src * 3 + 2]) * 255;
     } else {
       u8[byteOff] = 200;
       u8[byteOff + 1] = 200;
       u8[byteOff + 2] = 200;
     }
-    u8[byteOff + 3] = classes ? classes[i] : 0;
+    u8[byteOff + 3] = classes ? classes[src] : 0;
 
     // intensity at offset +16, low 16 bits of a u32
-    u32[i * 6 + 4] = intensities ? intensities[i] & 0xffff : 0;
-    u32[i * 6 + 5] = expressId;
+    u32[j * 6 + 4] = intensities ? intensities[src] & 0xffff : 0;
+    u32[j * 6 + 5] = expressId;
   }
 
   // Sanity-check the packed buffer: read back the class byte for
@@ -135,8 +168,8 @@ export function appendChunkToNode(
   if (debugVertexClassLogs < DEBUG_VERTEX_CLASS_LOG_LIMIT && classes) {
     debugVertexClassLogs++;
     const sample: number[] = [];
-    for (let i = 0; i < Math.min(8, count); i++) {
-      sample.push(u8[i * POINT_VERTEX_BYTES + 15]);
+    for (let j = 0; j < Math.min(8, count); j++) {
+      sample.push(u8[j * POINT_VERTEX_BYTES + 15]);
     }
     console.log(
       `[pointcloud-debug] vertex-buffer chunk #${debugVertexClassLogs}: `
@@ -163,16 +196,14 @@ export function appendChunkToNode(
   // and some implementations skip the initial clear when STORAGE is set.
   device.queue.writeBuffer(deviationBuffer, 0, new Float32Array(count));
 
-  const gpuChunk: PointCloudGpuChunk = {
+  node.chunks.push({
     vertexBuffer,
     deviationBuffer,
     pointCount: count,
     bbox: chunk.bbox,
-  };
-  node.chunks.push(gpuChunk);
+  });
   node.pointCount += count;
   growBounds(node.bounds, chunk.bbox);
-  return gpuChunk;
 }
 
 /** One-shot upload — produces a node with a single GPU chunk. */


### PR DESCRIPTION
## Summary
Two independent fixes from a session debugging the BIM↔scan **deviation** heatmap on a real 3.7 GB E57 scan + IFC.

### 1. Ingest OOM — "Array buffer allocation failed" on multi-GB point clouds
`useIfcLoader` called `acquireFileBuffer(file)` (streams the **entire** file into a `(Shared)ArrayBuffer`) **before** detecting the file is a point cloud. A 3.7 GB E57 passed the 4 GB gate, then the single ~3.7 GB allocation failed — the streaming decoder never ran.

- Detect point-cloud format from a **4 KB head slice**; for point clouds, **skip the whole-file read** (they stream from the Blob in bounded windows). Only IFC/GLB/IFCX still read the full buffer.
- `ingestPointCloud` now takes `fileSize` instead of an `ArrayBuffer` (it only used it for the synthetic data store).
- Complements #1079 (which streams the E57 *decode*). Together a multi-GB E57 loads with peak memory ≈ one window.

### 2. BIM↔scan deviation correctness + reachability
The heatmap was unusable. Four issues:

| # | Bug | Fix |
|---|-----|-----|
| 1 | **Per-chunk params buffer shared** (`deviation-pipeline.ts`). One cached uniform buffer rewritten per chunk, but all passes run in one submit and `queue.writeBuffer` is ordered before it → every pass reads the **last (shortest) chunk's `pointCount`** → every full chunk early-returns its tail → **~24% of points stay zero (white)** regardless of true distance. | One params buffer **per dispatch**, freed after `onSubmittedWorkDone()`. |
| 2 | **Sign collapses to 0 for coplanar points** (`deviation-shader.wgsl.ts`). `sign(dot(p−closestPoint, normal))` = 0 when the nearest feature is an edge/vertex and the point is in the triangle's plane (open door in a wall plane, floor point past the nearest floor tri) → zeroes a large distance → white. | Never-zero sign so magnitude still flags far points. |
| 3 | **Compute button gated on the active model's triangles** (`ViewportOverlays.tsx`). Deviation is cross-model (scan vs every scene mesh); with the point cloud active, `totalTriangles` was 0 → button vanished. | Gate on triangles **summed across all models**. |
| 4 | **Selecting Deviation did nothing** until a separate compute click (`DeviationPanel.tsx`). | Auto-run compute on selection (guarded); pre-compute hint. |

## A note on the investigation
A multi-agent root-cause pass flagged a "BVH is Z-up, points are Y-up" coordinate-frame mismatch as the cause. That was a **false positive** — verified against `rust/wasm-bindings/src/zero_copy.rs:161`, the WASM mesher already converts mesh data to Y-up (same `x, z, −y` swap as the point cloud), and the BIM+scan render aligned with identity model matrices. **Not changed** — that "fix" would have broken a working alignment.

## Test plan
WebGPU compute — verified manually in the viewer (headless can't exercise it):
- [ ] Load a multi-GB E57 → no "Array buffer allocation failed".
- [ ] Load IFC + point cloud → pick **Deviation** → heatmap auto-computes; no white patches on far geometry; open doors / furniture flagged.
- [ ] `pnpm --filter @ifc-lite/renderer build` (typecheck) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deviation mode can now automatically start “Compute deviation” when needed, while keeping the manual button available.
  * Point cloud deviation guidance now appears with more specific context (e.g., when BIM data is missing).
* **Bug Fixes**
  * Deviation controls now reflect triangle availability across all loaded models.
  * Improved signed-distance handling for coplanar/edge cases.
  * More reliable deviation reruns via improved transient compute resource cleanup; renderer readiness is better synchronized.
* **Performance**
  * Point-cloud loading/ingest is more efficient by avoiding whole-file reads for detected point-cloud formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->