### PR TITLE
fix(georef): read IFC2X3 ePset_MapConversion CRS + enable Cesium fallback

### DIFF
--- a/.changeset/fix-ifc2x3-epset-georef-cesium.md
+++ b/.changeset/fix-ifc2x3-epset-georef-cesium.md
@@ -1,0 +1,16 @@
+---
+"@ifc-lite/parser": patch
+"@ifc-lite/wasm": patch
+"@ifc-lite/server-bin": patch
+"@ifc-lite/server-client": patch
+---
+
+Fix IFC2X3 `ePset_MapConversion` / `ePset_ProjectedCRS` georeferencing so the authored EPSG code is read (not a fallback `EPSG:4326`), and route those models into the Cesium / federation pipeline.
+
+IFC2X3 has no native `IfcMapConversion`/`IfcProjectedCRS`, so tools like `ifc-georeferencer` store georeferencing in property sets per the buildingSMART guide. Three bugs dropped these models to the legacy `IfcSite` lat/long (`EPSG:4326`), so two files differing only by CRS (`EPSG:7415` RD+NAP vs `EPSG:28992` RD) both displayed the same wrong CRS:
+
+- The pset-name match was case-sensitive (`ePSet_`/`EPset_`) and missed the real-world `ePset_` casing — now matched case-insensitively in both the TS (`extractGeoreferencing`) and Rust (`GeoRefExtractor`) extractors.
+- The ePSet path never read `ePset_ProjectedCRS.Name` (nor `MapConversion.TargetCRS`), so the EPSG code was discarded — now surfaced, with typed `IFCLABEL(...)`/`IFCLENGTHMEASURE(...)` values unwrapped.
+- The viewer's on-demand extractor never loaded the property sets at all — now pulls in the georef ePSets + their values (only when no `IfcMapConversion` exists, deferred-atom safe).
+
+The viewer's Cesium/federation gate accepts the `ePSetMapConversion` source, and ePSet offsets are scaled by the project length unit (millimetres for these files) so the model reprojects to the correct location instead of ~1000× out of range. The offline reproject fallback for the compound `EPSG:7415` (datum reported as `RD`) now carries the Kadaster `+towgs84` shift.

--- a/apps/viewer/src/lib/geo/effective-georef.test.ts
+++ b/apps/viewer/src/lib/geo/effective-georef.test.ts
@@ -12,6 +12,7 @@ import {
   inferMapUnitScale,
   mergeMapConversion,
   mergeProjectedCRS,
+  resolveEpsetMapUnitScale,
   supportsStandardGeoreferencing,
 } from './effective-georef.js';
 import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
@@ -136,6 +137,27 @@ describe('effective georeferencing', () => {
       xAxisAbscissa: 0,
       xAxisOrdinate: 1,
       scale: 0.9999,
+    });
+  });
+
+  describe('resolveEpsetMapUnitScale (IFC2x3 ePset offsets use the project unit)', () => {
+    it('defaults an ePSet georef without MapUnit to the project length-unit scale', () => {
+      // mm project (lengthUnitScale = 0.001): RD offsets are authored in mm and
+      // must scale by 0.001 to metres, NOT pass through the "treat as metres"
+      // heuristic that would put the model 1000× out of range.
+      assert.strictEqual(resolveEpsetMapUnitScale('ePSetMapConversion', undefined, 0.001), 0.001);
+    });
+
+    it('keeps an explicit MapUnit scale on an ePSet georef (user edited MapUnit)', () => {
+      assert.strictEqual(resolveEpsetMapUnitScale('ePSetMapConversion', 1, 0.001), 1);
+    });
+
+    it('leaves native IfcMapConversion georef untouched', () => {
+      assert.strictEqual(resolveEpsetMapUnitScale('mapConversion', undefined, 0.001), undefined);
+    });
+
+    it('leaves siteLocation georef untouched', () => {
+      assert.strictEqual(resolveEpsetMapUnitScale('siteLocation', undefined, 0.001), undefined);
     });
   });
 
@@ -270,6 +292,21 @@ describe('effective georeferencing', () => {
         hasStandardGeoreferencing({
           source: 'mapConversion',
           projectedCRS: { id: 1, name: 'EPSG:28992' },
+          mapConversion,
+        }),
+        true,
+      );
+    });
+
+    it('accepts IFC2x3 ePSet_MapConversion georef (enables Cesium / federation)', () => {
+      // The buildingSMART IFC2x3 ePset fallback is a real projected placement
+      // (RD eastings/northings), unlike the lat/long-only siteLocation path —
+      // it must pass the same gate as native IfcMapConversion so the model
+      // reaches the Cesium overlay and federation alignment.
+      assert.strictEqual(
+        hasStandardGeoreferencing({
+          source: 'ePSetMapConversion',
+          projectedCRS: { id: 1, name: 'EPSG:7415' },
           mapConversion,
         }),
         true,

--- a/apps/viewer/src/lib/geo/effective-georef.ts
+++ b/apps/viewer/src/lib/geo/effective-georef.ts
@@ -113,6 +113,30 @@ export function mergeMapConversion(
   };
 }
 
+/**
+ * The buildingSMART IFC2x3 `ePset_MapConversion` convention stores
+ * Eastings/Northings in the project length unit — there is no MapUnit in the
+ * ePset. So an ePSet-sourced georef with no explicit MapUnit must scale its
+ * offsets by the project length-unit → metres factor.
+ *
+ * Without this, the "absent MapUnit ⇒ treat offsets as metres" heuristic in
+ * {@link resolveMapUnitToMetreScale} reads millimetre offsets as metres and
+ * flings the model ~1000× outside the CRS valid range (e.g. RD easting
+ * 160073528 mm read as 160073 km → reprojection returns null and Cesium can't
+ * place the model). Only applies when MapUnit hasn't been set/edited
+ * (mapUnitScale still undefined) — an explicit MapUnit always wins.
+ */
+export function resolveEpsetMapUnitScale(
+  source: GeoreferenceInfo['source'] | undefined,
+  mapUnitScale: number | undefined,
+  lengthUnitScale: number,
+): number | undefined {
+  if (source === 'ePSetMapConversion' && mapUnitScale === undefined) {
+    return lengthUnitScale;
+  }
+  return mapUnitScale;
+}
+
 export function getEffectiveGeoreference(
   dataStore: IfcDataStore | null | undefined,
   coordinateInfo?: CoordinateInfo,
@@ -126,6 +150,14 @@ export function getEffectiveGeoreference(
     mutations?.projectedCRS,
     lengthUnitScale,
   );
+  if (projectedCRS) {
+    // ePset_MapConversion offsets are in the project length unit (no MapUnit).
+    projectedCRS.mapUnitScale = resolveEpsetMapUnitScale(
+      original?.source,
+      projectedCRS.mapUnitScale,
+      lengthUnitScale,
+    );
+  }
   const mapConversion = mergeMapConversion(original?.mapConversion, mutations?.mapConversion);
 
   if (!projectedCRS && !mapConversion) return null;

--- a/apps/viewer/src/lib/geo/reproject.ts
+++ b/apps/viewer/src/lib/geo/reproject.ts
@@ -157,7 +157,12 @@ const DATUM_TOWGS84: Record<string, string> = {
   // Netherlands — Amersfoort (Bessel 1841). The bundled EPSG:28992 already
   // ships with the higher-precision Kadaster +towgs84, so this fires only
   // when a derived/compound CRS lacks it (e.g. some compound RD/NAP cases).
+  // The compound EPSG:7415 (RD + NAP height) reports its datum as "RD" rather
+  // than "Amersfoort", and its bundled proj4 carries no +towgs84 at all, so it
+  // needs the same shift under that key for the offline (no precision-grid)
+  // fallback to land in the Netherlands instead of ~117 m off.
   'amersfoort': '+towgs84=565.4171,50.3319,465.5524,1.9342,-1.6677,9.1019,4.0725',
+  'rd': '+towgs84=565.4171,50.3319,465.5524,1.9342,-1.6677,9.1019,4.0725',
   // Austria — MGI (Bessel 1841)
   'militar-geographische institut': '+towgs84=577.326,90.129,463.919,5.137,1.474,5.297,2.4232',
   'mgi': '+towgs84=577.326,90.129,463.919,5.137,1.474,5.297,2.4232',

--- a/packages/parser/src/georef-extractor.ts
+++ b/packages/parser/src/georef-extractor.ts
@@ -170,10 +170,11 @@ function readPsetSingleValues(
       if (typeof raw === 'number') {
         values[propName] = raw;
       } else if (typeof raw === 'string') {
-        const num = getNumber(raw);
-        // Prefer numeric coordinates (stored as strings in some writers) but
-        // keep EPSG labels like "EPSG:7415" as strings.
-        values[propName] = num !== undefined && /^[+-]?\d/.test(raw.trim()) ? num : raw;
+        // Keep the raw string verbatim. Coordinate fields are coerced on read
+        // via `asNumber` (some writers store Eastings/Scale as strings), while
+        // CRS metadata that merely looks numeric — `Name: "7415"`, `MapZone:
+        // "31N"` — must stay a string so `asString` doesn't discard it.
+        values[propName] = raw;
       }
     }
   }
@@ -205,7 +206,34 @@ function findPsetByName(
 }
 
 function asString(value: string | number | undefined): string | undefined {
-  return typeof value === 'string' && value.length > 0 ? value : undefined;
+  if (typeof value === 'string') return value.length > 0 ? value : undefined;
+  if (typeof value === 'number') return String(value);
+  return undefined;
+}
+
+function asNumber(value: string | number | undefined): number | undefined {
+  return typeof value === 'number' ? value : getNumber(value);
+}
+
+/**
+ * Map an IFC unit label (e.g. "MILLIMETRE", "FOOT") to its metre scale.
+ * Mirrors the viewer's `inferMapUnitScale` and the native `IfcProjectedCRS`
+ * path so direct parser/MCP consumers of `ProjectedCRS.mapUnitScale` see the
+ * same scale regardless of whether the CRS came from a native entity or an
+ * ePSet. Returns `undefined` for an absent/unknown unit (the ePSet convention
+ * then defers to the project length unit downstream).
+ */
+function inferMapUnitScaleFromLabel(mapUnit: string | undefined): number | undefined {
+  if (!mapUnit) return undefined;
+  const n = mapUnit.toUpperCase();
+  if (n.includes('US') && (n.includes('SURVEY') || n.includes('FTUS'))) return 0.3048006096;
+  if (n.includes('FOOT') || n.includes('FEET')) return 0.3048;
+  if (n.includes('MILLI')) return 0.001;
+  if (n.includes('CENTI')) return 0.01;
+  if (n.includes('DECI')) return 0.1;
+  if (n.includes('KILO')) return 1000;
+  if (n.includes('METRE') || n.includes('METER')) return 1;
+  return undefined;
 }
 
 /**
@@ -224,10 +252,10 @@ function extractEPSetMapConversion(
 
   const values = readPsetSingleValues(entities, pset);
 
-  const eastings = typeof values['Eastings'] === 'number' ? (values['Eastings'] as number) : 0;
-  const northings = typeof values['Northings'] === 'number' ? (values['Northings'] as number) : 0;
-  const orthogonalHeight = typeof values['OrthogonalHeight'] === 'number' ? (values['OrthogonalHeight'] as number) : 0;
-  if (eastings === 0 && northings === 0 && orthogonalHeight === 0) return null;
+  // Some writers store the offsets as strings, so coerce on read.
+  const eastings = asNumber(values['Eastings']) ?? 0;
+  const northings = asNumber(values['Northings']) ?? 0;
+  const orthogonalHeight = asNumber(values['OrthogonalHeight']) ?? 0;
 
   const mapConversion: MapConversion = {
     id: pset.expressId,
@@ -236,9 +264,9 @@ function extractEPSetMapConversion(
     eastings,
     northings,
     orthogonalHeight,
-    xAxisAbscissa: typeof values['XAxisAbscissa'] === 'number' ? (values['XAxisAbscissa'] as number) : undefined,
-    xAxisOrdinate: typeof values['XAxisOrdinate'] === 'number' ? (values['XAxisOrdinate'] as number) : undefined,
-    scale: typeof values['Scale'] === 'number' ? (values['Scale'] as number) : undefined,
+    xAxisAbscissa: asNumber(values['XAxisAbscissa']),
+    xAxisOrdinate: asNumber(values['XAxisOrdinate']),
+    scale: asNumber(values['Scale']),
   };
 
   // Resolve the CRS name from ePSet_ProjectedCRS.Name, falling back to the
@@ -249,8 +277,16 @@ function extractEPSetMapConversion(
   const crsValues = crsPset ? readPsetSingleValues(entities, crsPset) : {};
   const crsName = asString(crsValues['Name']) ?? asString(values['TargetCRS']);
 
+  // Reject only when there is nothing to georeference by: no CRS name AND the
+  // placement sits at the local origin. Mirrors `has_georef()` in rust/core
+  // (a CRS name OR any non-zero offset is sufficient) so a valid zero-origin
+  // placement at a real projected CRS is kept rather than dropping to the
+  // legacy IfcSite/EPSG:4326 fallback.
+  if (!crsName && eastings === 0 && northings === 0 && orthogonalHeight === 0) return null;
+
   let projectedCRS: ProjectedCRS | undefined;
   if (crsName || crsPset) {
+    const mapUnit = asString(crsValues['MapUnit']);
     projectedCRS = {
       id: crsPset?.expressId ?? pset.expressId,
       name: crsName ?? '',
@@ -259,7 +295,11 @@ function extractEPSetMapConversion(
       verticalDatum: asString(crsValues['VerticalDatum']),
       mapProjection: asString(crsValues['MapProjection']),
       mapZone: asString(crsValues['MapZone']),
-      mapUnit: asString(crsValues['MapUnit']),
+      mapUnit,
+      // An explicit ePSet MapUnit carries its own scale (parity with the native
+      // IfcProjectedCRS path). When absent, leave it undefined so consumers fall
+      // back to the project length unit per the buildingSMART convention.
+      mapUnitScale: inferMapUnitScaleFromLabel(mapUnit),
     };
   }
 

--- a/packages/parser/src/georef-extractor.ts
+++ b/packages/parser/src/georef-extractor.ts
@@ -132,65 +132,144 @@ export function extractGeoreferencing(
 }
 
 /**
- * IFC2x3 fallback: a property set named `ePSet_MapConversion` /
- * `EPset_MapConversion` carrying Eastings/Northings/OrthogonalHeight (+
- * optional XAxisAbscissa/XAxisOrdinate/Scale) as IfcPropertySingleValue
- * entries. Mirrors `GeoRefExtractor::parse_pset_map_conversion` in
- * rust/core/src/georef.rs.
+ * Unwrap an IfcValue `NominalValue`. The columnar/on-demand extractor delivers
+ * typed values as a `[TYPENAME, value]` tuple (e.g.
+ * `["IFCLENGTHMEASURE", 160073528]`, `["IFCLABEL", "EPSG:7415"]`), which
+ * `getNumber`/`getString` don't see through; raw scalars (used by the
+ * entity-map callers) pass through untouched.
+ */
+function unwrapNominalValue(value: unknown): unknown {
+  if (Array.isArray(value) && value.length >= 2 && typeof value[0] === 'string') {
+    return value[1];
+  }
+  return value;
+}
+
+/**
+ * Read an `IfcPropertySet`'s `IfcPropertySingleValue` children into a
+ * name → raw-value map, keeping the value as-is (string or number) so both
+ * numeric (Eastings) and string (TargetCRS, EPSG Name) properties survive.
+ */
+function readPsetSingleValues(
+  entities: Map<number, IfcEntity>,
+  pset: IfcEntity,
+): Record<string, string | number> {
+  const values: Record<string, string | number> = {};
+  // IfcPropertySet: GlobalId (0), OwnerHistory (1), Name (2), Description (3), HasProperties (4)
+  const props = pset.attributes[4];
+  if (Array.isArray(props)) {
+    for (const propRef of props) {
+      const propId = getReference(propRef);
+      if (!propId) continue;
+      const prop = entities.get(propId);
+      if (!prop) continue;
+      // IfcPropertySingleValue: Name (0), Description (1), NominalValue (2)
+      const propName = getString(prop.attributes[0]);
+      if (!propName) continue;
+      const raw = unwrapNominalValue(prop.attributes[2]);
+      if (typeof raw === 'number') {
+        values[propName] = raw;
+      } else if (typeof raw === 'string') {
+        const num = getNumber(raw);
+        // Prefer numeric coordinates (stored as strings in some writers) but
+        // keep EPSG labels like "EPSG:7415" as strings.
+        values[propName] = num !== undefined && /^[+-]?\d/.test(raw.trim()) ? num : raw;
+      }
+    }
+  }
+  return values;
+}
+
+/**
+ * Find the first `IfcPropertySet` whose Name matches `targetName`
+ * case-insensitively. buildingSMART's geo-referencing guide spells the
+ * IFC2x3 property sets `ePSet_…` (capital S), but real authoring tools (e.g.
+ * the `ifc-georeferencer` post-processor) write `ePset_…` (lowercase) — an
+ * exact match silently dropped those models to the legacy IfcSite/EPSG:4326
+ * fallback, so they displayed the wrong CRS.
+ */
+function findPsetByName(
+  entities: Map<number, IfcEntity>,
+  entitiesByType: Map<string, number[]>,
+  targetName: string,
+): IfcEntity | null {
+  const target = targetName.toLowerCase();
+  const psetIds = entitiesByType.get('IfcPropertySet') || [];
+  for (const psetId of psetIds) {
+    const pset = entities.get(psetId);
+    if (!pset) continue;
+    const name = getString(pset.attributes[2]);
+    if (name && name.toLowerCase() === target) return pset;
+  }
+  return null;
+}
+
+function asString(value: string | number | undefined): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+/**
+ * IFC2x3 fallback: a property set named `ePSet_MapConversion` (any casing)
+ * carrying Eastings/Northings/OrthogonalHeight (+ optional
+ * XAxisAbscissa/XAxisOrdinate/Scale/TargetCRS), optionally paired with an
+ * `ePSet_ProjectedCRS` set carrying the EPSG `Name`. Mirrors
+ * `GeoRefExtractor::extract_from_pset` in rust/core/src/georef.rs.
  */
 function extractEPSetMapConversion(
   entities: Map<number, IfcEntity>,
   entitiesByType: Map<string, number[]>,
 ): GeoreferenceInfo | null {
-  const psetIds = entitiesByType.get('IfcPropertySet') || [];
-  for (const psetId of psetIds) {
-    const pset = entities.get(psetId);
-    if (!pset) continue;
-    // IfcPropertySet: GlobalId (0), OwnerHistory (1), Name (2), Description (3), HasProperties (4)
-    const name = getString(pset.attributes[2]);
-    if (name !== 'ePSet_MapConversion' && name !== 'EPset_MapConversion') continue;
+  const pset = findPsetByName(entities, entitiesByType, 'ePSet_MapConversion');
+  if (!pset) return null;
 
-    const values: Record<string, number> = {};
-    const props = pset.attributes[4];
-    if (Array.isArray(props)) {
-      for (const propRef of props) {
-        const propId = getReference(propRef);
-        if (!propId) continue;
-        const prop = entities.get(propId);
-        if (!prop) continue;
-        // IfcPropertySingleValue: Name (0), Description (1), NominalValue (2)
-        const propName = getString(prop.attributes[0]);
-        const value = getNumber(prop.attributes[2]);
-        if (propName && value !== undefined) {
-          values[propName] = value;
-        }
-      }
-    }
+  const values = readPsetSingleValues(entities, pset);
 
-    const eastings = values['Eastings'] ?? 0;
-    const northings = values['Northings'] ?? 0;
-    const orthogonalHeight = values['OrthogonalHeight'] ?? 0;
-    if (eastings === 0 && northings === 0 && orthogonalHeight === 0) continue;
+  const eastings = typeof values['Eastings'] === 'number' ? (values['Eastings'] as number) : 0;
+  const northings = typeof values['Northings'] === 'number' ? (values['Northings'] as number) : 0;
+  const orthogonalHeight = typeof values['OrthogonalHeight'] === 'number' ? (values['OrthogonalHeight'] as number) : 0;
+  if (eastings === 0 && northings === 0 && orthogonalHeight === 0) return null;
 
-    const mapConversion: MapConversion = {
-      id: pset.expressId,
-      sourceCRS: 0,
-      targetCRS: 0,
-      eastings,
-      northings,
-      orthogonalHeight,
-      xAxisAbscissa: values['XAxisAbscissa'],
-      xAxisOrdinate: values['XAxisOrdinate'],
-      scale: values['Scale'],
-    };
-    return {
-      hasGeoreference: true,
-      source: 'ePSetMapConversion',
-      mapConversion,
-      transformMatrix: computeTransformMatrix(mapConversion),
+  const mapConversion: MapConversion = {
+    id: pset.expressId,
+    sourceCRS: 0,
+    targetCRS: 0,
+    eastings,
+    northings,
+    orthogonalHeight,
+    xAxisAbscissa: typeof values['XAxisAbscissa'] === 'number' ? (values['XAxisAbscissa'] as number) : undefined,
+    xAxisOrdinate: typeof values['XAxisOrdinate'] === 'number' ? (values['XAxisOrdinate'] as number) : undefined,
+    scale: typeof values['Scale'] === 'number' ? (values['Scale'] as number) : undefined,
+  };
+
+  // Resolve the CRS name from ePSet_ProjectedCRS.Name, falling back to the
+  // MapConversion's TargetCRS (the ifc-georeferencer tool writes both as the
+  // same EPSG label). Without this the EPSG code in the file was never
+  // surfaced on the IFC2x3 path.
+  const crsPset = findPsetByName(entities, entitiesByType, 'ePSet_ProjectedCRS');
+  const crsValues = crsPset ? readPsetSingleValues(entities, crsPset) : {};
+  const crsName = asString(crsValues['Name']) ?? asString(values['TargetCRS']);
+
+  let projectedCRS: ProjectedCRS | undefined;
+  if (crsName || crsPset) {
+    projectedCRS = {
+      id: crsPset?.expressId ?? pset.expressId,
+      name: crsName ?? '',
+      description: asString(crsValues['Description']),
+      geodeticDatum: asString(crsValues['GeodeticDatum']),
+      verticalDatum: asString(crsValues['VerticalDatum']),
+      mapProjection: asString(crsValues['MapProjection']),
+      mapZone: asString(crsValues['MapZone']),
+      mapUnit: asString(crsValues['MapUnit']),
     };
   }
-  return null;
+
+  return {
+    hasGeoreference: true,
+    source: 'ePSetMapConversion',
+    mapConversion,
+    projectedCRS,
+    transformMatrix: computeTransformMatrix(mapConversion),
+  };
 }
 
 function getAttributeValueByName(entity: IfcEntity, attributeName: string): unknown {

--- a/packages/parser/src/on-demand-extractors.ts
+++ b/packages/parser/src/on-demand-extractors.ts
@@ -757,6 +757,52 @@ export function extractGeoreferencingOnDemand(store: IfcDataStore): Georeference
         }
     }
 
+    // IFC2x3 fallback: models without IfcMapConversion store georeferencing in
+    // ePSet_MapConversion / ePSet_ProjectedCRS property sets. Those aren't
+    // loaded above, so the ePSet path in extractGeorefFromEntities had nothing
+    // to read and the model fell back to the legacy IfcSite EPSG:4326 (wrong
+    // CRS). Only scan property sets when no IfcMapConversion exists, and only
+    // pull in the georef ePSets + their values — not every pset in the model.
+    if (!typeMap.has('IfcMapConversion')) {
+        const psetIds = byType.get('IFCPROPERTYSET');
+        if (psetIds?.length) {
+            const georefPsetIds: number[] = [];
+            const childIds = new Set<number>();
+            for (const id of psetIds) {
+                const ref = byId.get(id);
+                if (!ref) continue;
+                const entity = extractor.extractEntity(ref);
+                if (!entity?.attributes) continue;
+                // IfcPropertySet: Name (2), HasProperties (4)
+                const name = typeof entity.attributes[2] === 'string'
+                    ? (entity.attributes[2] as string).toLowerCase()
+                    : '';
+                if (name !== 'epset_mapconversion' && name !== 'epset_projectedcrs') continue;
+                entityMap.set(id, entity);
+                georefPsetIds.push(id);
+                const props = entity.attributes[4];
+                if (Array.isArray(props)) {
+                    for (const propRef of props) {
+                        const propId = typeof propRef === 'number' ? propRef : null;
+                        if (propId === null || childIds.has(propId)) continue;
+                        // Property atoms may be deferred on huge files (not in
+                        // the primary byId index) — fall back like refFromStore.
+                        const childRef = byId.get(propId) ?? store.deferredEntityIndex?.get(propId);
+                        if (!childRef) continue;
+                        const child = extractor.extractEntity(childRef);
+                        if (child) {
+                            entityMap.set(propId, child);
+                            childIds.add(propId);
+                        }
+                    }
+                }
+            }
+            if (georefPsetIds.length) {
+                typeMap.set('IfcPropertySet', georefPsetIds);
+            }
+        }
+    }
+
     if (entityMap.size === 0) return null;
 
     // Cast to IfcEntity (they share the same shape)

--- a/packages/parser/test/georef-extractor.test.ts
+++ b/packages/parser/test/georef-extractor.test.ts
@@ -349,4 +349,54 @@ describe('Georeferencing Extractor', () => {
     expect(georef.hasGeoreference).toBe(false);
     expect(georef.source).toBeUndefined();
   });
+
+  // Real-world casing written by the `ifc-georeferencer` post-processor:
+  // `ePset_…` (lowercase s), which an exact match missed → models fell back
+  // to the legacy IfcSite EPSG:4326 and displayed the wrong CRS.
+  it('matches the ePset name case-insensitively (ifc-georeferencer casing)', () => {
+    for (const name of ['ePset_MapConversion', 'epset_mapconversion', 'EPSET_MAPCONVERSION']) {
+      const { entities, entitiesByType } = epsetEntities(name);
+      const georef = extractGeoreferencing(entities, entitiesByType);
+      expect(georef.source).toBe('ePSetMapConversion');
+      expect(georef.mapConversion?.eastings).toBeCloseTo(1000.5, 9);
+    }
+  });
+
+  it('surfaces the EPSG code from ePset_ProjectedCRS.Name', () => {
+    const { entities, entitiesByType } = epsetEntities('ePset_MapConversion');
+    // ePset_ProjectedCRS with a single Name property (EPSG:7415 = RD + NAP).
+    entities.set(10, {
+      expressId: 10,
+      type: 'IfcPropertySingleValue',
+      attributes: ['Name', null, 'EPSG:7415', null],
+    });
+    entities.set(11, {
+      expressId: 11,
+      type: 'IfcPropertySet',
+      attributes: ['0PSet00000000000000002', null, 'ePset_ProjectedCRS', null, ['#10']],
+    });
+    entitiesByType.set('IfcPropertySingleValue', [1, 2, 3, 10]);
+    entitiesByType.set('IfcPropertySet', [4, 11]);
+
+    const georef = extractGeoreferencing(entities, entitiesByType);
+    expect(georef.source).toBe('ePSetMapConversion');
+    expect(georef.projectedCRS?.name).toBe('EPSG:7415');
+  });
+
+  it('falls back to MapConversion.TargetCRS when no ePset_ProjectedCRS exists', () => {
+    const { entities, entitiesByType } = epsetEntities('ePset_MapConversion');
+    // Add a string TargetCRS property to the map-conversion pset.
+    entities.set(5, {
+      expressId: 5,
+      type: 'IfcPropertySingleValue',
+      attributes: ['TargetCRS', null, 'EPSG:28992', null],
+    });
+    const pset = entities.get(4)!;
+    pset.attributes[4] = ['#1', '#2', '#3', '#5'];
+    entitiesByType.set('IfcPropertySingleValue', [1, 2, 3, 5]);
+
+    const georef = extractGeoreferencing(entities, entitiesByType);
+    expect(georef.source).toBe('ePSetMapConversion');
+    expect(georef.projectedCRS?.name).toBe('EPSG:28992');
+  });
 });

--- a/packages/parser/test/georef-extractor.test.ts
+++ b/packages/parser/test/georef-extractor.test.ts
@@ -399,4 +399,85 @@ describe('Georeferencing Extractor', () => {
     expect(georef.source).toBe('ePSetMapConversion');
     expect(georef.projectedCRS?.name).toBe('EPSG:28992');
   });
+
+  // A bare-numeric EPSG `Name` ("7415") and a `MapZone` like "31N" must stay
+  // strings — over-eager numeric coercion used to drop them before the CRS was
+  // assembled, leaving the gate without a name.
+  it('preserves numeric-looking CRS metadata as strings', () => {
+    const { entities, entitiesByType } = epsetEntities('ePset_MapConversion');
+    entities.set(10, {
+      expressId: 10,
+      type: 'IfcPropertySingleValue',
+      attributes: ['Name', null, '7415', null],
+    });
+    entities.set(11, {
+      expressId: 11,
+      type: 'IfcPropertySingleValue',
+      attributes: ['MapZone', null, '31N', null],
+    });
+    entities.set(12, {
+      expressId: 12,
+      type: 'IfcPropertySet',
+      attributes: ['0PSet00000000000000002', null, 'ePset_ProjectedCRS', null, ['#10', '#11']],
+    });
+    entitiesByType.set('IfcPropertySingleValue', [1, 2, 3, 10, 11]);
+    entitiesByType.set('IfcPropertySet', [4, 12]);
+
+    const georef = extractGeoreferencing(entities, entitiesByType);
+    expect(georef.projectedCRS?.name).toBe('7415');
+    expect(georef.projectedCRS?.mapZone).toBe('31N');
+  });
+
+  // A model placed at the projected-CRS origin (offsets all 0) but carrying a
+  // real CRS name is a valid georeference and must not drop to EPSG:4326.
+  it('keeps a zero-origin ePSet georeference when a CRS name is present', () => {
+    const { entities, entitiesByType } = epsetEntities('ePset_MapConversion');
+    (entities.get(1)!.attributes as unknown[])[2] = 0;
+    (entities.get(2)!.attributes as unknown[])[2] = 0;
+    (entities.get(3)!.attributes as unknown[])[2] = 0;
+    entities.set(10, {
+      expressId: 10,
+      type: 'IfcPropertySingleValue',
+      attributes: ['Name', null, 'EPSG:28992', null],
+    });
+    entities.set(11, {
+      expressId: 11,
+      type: 'IfcPropertySet',
+      attributes: ['0PSet00000000000000002', null, 'ePset_ProjectedCRS', null, ['#10']],
+    });
+    entitiesByType.set('IfcPropertySingleValue', [1, 2, 3, 10]);
+    entitiesByType.set('IfcPropertySet', [4, 11]);
+
+    const georef = extractGeoreferencing(entities, entitiesByType);
+    expect(georef.source).toBe('ePSetMapConversion');
+    expect(georef.projectedCRS?.name).toBe('EPSG:28992');
+    expect(georef.mapConversion?.eastings).toBe(0);
+  });
+
+  // An explicit ePSet MapUnit label carries its own scale (parity with the
+  // native IfcProjectedCRS path); direct consumers must not assume metres.
+  it('infers mapUnitScale from an explicit ePSet MapUnit label', () => {
+    const { entities, entitiesByType } = epsetEntities('ePset_MapConversion');
+    entities.set(10, {
+      expressId: 10,
+      type: 'IfcPropertySingleValue',
+      attributes: ['Name', null, 'EPSG:2225', null],
+    });
+    entities.set(11, {
+      expressId: 11,
+      type: 'IfcPropertySingleValue',
+      attributes: ['MapUnit', null, 'FOOT', null],
+    });
+    entities.set(12, {
+      expressId: 12,
+      type: 'IfcPropertySet',
+      attributes: ['0PSet00000000000000002', null, 'ePset_ProjectedCRS', null, ['#10', '#11']],
+    });
+    entitiesByType.set('IfcPropertySingleValue', [1, 2, 3, 10, 11]);
+    entitiesByType.set('IfcPropertySet', [4, 12]);
+
+    const georef = extractGeoreferencing(entities, entitiesByType);
+    expect(georef.projectedCRS?.mapUnit).toBe('FOOT');
+    expect(georef.projectedCRS?.mapUnitScale).toBe(0.3048);
+  });
 });

--- a/packages/parser/test/on-demand-georef-epset.test.ts
+++ b/packages/parser/test/on-demand-georef-epset.test.ts
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { StepTokenizer } from '../src/tokenizer.js';
+import { ColumnarParser } from '../src/columnar-parser.js';
+import { extractGeoreferencingOnDemand } from '../src/on-demand-extractors.js';
+
+/**
+ * The on-demand georef path (used by the viewer's properties panel) only
+ * loaded IfcMapConversion/IfcProjectedCRS/IfcSite, so IFC2x3 models that carry
+ * georeferencing in `ePset_MapConversion` / `ePset_ProjectedCRS` property sets
+ * fell through to the legacy IfcSite EPSG:4326 fallback and displayed the wrong
+ * CRS. These fixtures mirror files written by the `ifc-georeferencer` tool
+ * (lowercase `ePset_`, typed IFCLABEL values).
+ */
+async function storeFromIfc(ifc: string) {
+  const source = new TextEncoder().encode(ifc);
+  const tokenizer = new StepTokenizer(source);
+  const entityRefs: Array<{
+    expressId: number;
+    type: string;
+    byteOffset: number;
+    byteLength: number;
+    lineNumber: number;
+  }> = [];
+  for (const ref of tokenizer.scanEntitiesFast()) {
+    entityRefs.push({
+      expressId: ref.expressId,
+      type: ref.type,
+      byteOffset: ref.offset,
+      byteLength: ref.length,
+      lineNumber: ref.line,
+    });
+  }
+  const parser = new ColumnarParser();
+  return parser.parseLite(source.buffer.slice(0), entityRefs, {});
+}
+
+describe('extractGeoreferencingOnDemand — IFC2x3 ePset fallback', () => {
+  it('surfaces the EPSG code from lowercase ePset_ProjectedCRS (RD + NAP compound)', async () => {
+    const ifc = `#6=IFCPROJECT('1mj5Hja8yfJfRTJSXP39EZ',$,'P',$,$,$,$,$,$);
+#30=IFCSITE('06pHC0eJnCHlVXWW2sVoPO',$,'Site',$,$,$,$,$,.ELEMENT.,(51,26,47,208626),(5,27,36,650968),$,$,$);
+#1357=IFCPROPERTYSINGLEVALUE('Name',$,IFCLABEL('EPSG:7415'),$);
+#1358=IFCPROPERTYSET('27AKTMp8j58fBEhvkJkcNJ',$,'ePset_ProjectedCRS',$,(#1357));
+#1359=IFCRELDEFINESBYPROPERTIES('3eMryiQHj84vNzfI1G88R1',$,$,$,(#30),#1358);
+#1360=IFCPROPERTYSINGLEVALUE('TargetCRS',$,IFCLABEL('EPSG:7415'),$);
+#1361=IFCPROPERTYSINGLEVALUE('Eastings',$,IFCLENGTHMEASURE(160073528.13858587),$);
+#1362=IFCPROPERTYSINGLEVALUE('Northings',$,IFCLENGTHMEASURE(384153306.2191765),$);
+#1363=IFCPROPERTYSINGLEVALUE('OrthogonalHeight',$,IFCLENGTHMEASURE(0.),$);
+#1364=IFCPROPERTYSINGLEVALUE('XAxisAbscissa',$,IFCREAL(0.6156614753256583),$);
+#1365=IFCPROPERTYSINGLEVALUE('XAxisOrdinate',$,IFCREAL(-0.788010753606722),$);
+#1366=IFCPROPERTYSINGLEVALUE('Scale',$,IFCREAL(1.),$);
+#1367=IFCPROPERTYSET('2If4Y3Lpv6dgTDkC5x_dnr',$,'ePset_MapConversion',$,(#1360,#1361,#1362,#1363,#1364,#1365,#1366));
+#1368=IFCRELDEFINESBYPROPERTIES('0AUnylrXbCLgALz5UN_kQ2',$,$,$,(#30),#1367);`;
+    const store = await storeFromIfc(ifc);
+    const georef = extractGeoreferencingOnDemand(store);
+
+    expect(georef?.hasGeoreference).toBe(true);
+    expect(georef?.source).toBe('ePSetMapConversion');
+    // The whole point: the file's EPSG code reaches the panel, not EPSG:4326.
+    expect(georef?.projectedCRS?.name).toBe('EPSG:7415');
+    expect(georef?.mapConversion?.eastings).toBeCloseTo(160073528.13858587, 3);
+  });
+
+  it('reads horizontal-only EPSG:28992 the same way', async () => {
+    const ifc = `#30=IFCSITE('06pHC0eJnCHlVXWW2sVoPO',$,'Site',$,$,$,$,$,.ELEMENT.,(51,26,47,208626),(5,27,36,650968),$,$,$);
+#1357=IFCPROPERTYSINGLEVALUE('Name',$,IFCLABEL('EPSG:28992'),$);
+#1358=IFCPROPERTYSET('27AKTMp8j58fBEhvkJkcNJ',$,'ePset_ProjectedCRS',$,(#1357));
+#1360=IFCPROPERTYSINGLEVALUE('TargetCRS',$,IFCLABEL('EPSG:28992'),$);
+#1361=IFCPROPERTYSINGLEVALUE('Eastings',$,IFCLENGTHMEASURE(160073528.13858587),$);
+#1362=IFCPROPERTYSINGLEVALUE('Northings',$,IFCLENGTHMEASURE(384153306.2191765),$);
+#1363=IFCPROPERTYSINGLEVALUE('OrthogonalHeight',$,IFCLENGTHMEASURE(0.),$);
+#1367=IFCPROPERTYSET('2If4Y3Lpv6dgTDkC5x_dnr',$,'ePset_MapConversion',$,(#1360,#1361,#1362,#1363));`;
+    const store = await storeFromIfc(ifc);
+    const georef = extractGeoreferencingOnDemand(store);
+
+    expect(georef?.source).toBe('ePSetMapConversion');
+    expect(georef?.projectedCRS?.name).toBe('EPSG:28992');
+  });
+
+  it('still uses the legacy IfcSite fallback when no ePsets exist', async () => {
+    const ifc = `#30=IFCSITE('06pHC0eJnCHlVXWW2sVoPO',$,'Site',$,$,$,$,$,.ELEMENT.,(51,26,47,208626),(5,27,36,650968),$,$,$);`;
+    const store = await storeFromIfc(ifc);
+    const georef = extractGeoreferencingOnDemand(store);
+
+    expect(georef?.source).toBe('siteLocation');
+    expect(georef?.projectedCRS?.name).toBe('EPSG:4326');
+  });
+});

--- a/rust/core/src/georef.rs
+++ b/rust/core/src/georef.rs
@@ -28,6 +28,38 @@ fn pset_value_string(prop: &DecodedEntity) -> Option<String> {
     }
 }
 
+/// Map an IFC unit label (e.g. "MILLIMETRE", "FOOT") to its metre scale.
+/// Mirrors the TS parser's `inferMapUnitScaleFromLabel` and the viewer's
+/// `inferMapUnitScale` so an ePSet_ProjectedCRS.MapUnit yields the same scale
+/// the native IfcProjectedCRS path resolves from the unit entity. Returns
+/// `None` for an absent/unknown unit (the ePSet convention then defers to the
+/// project length unit downstream).
+fn infer_map_unit_scale(label: &str) -> Option<f64> {
+    let n = label.to_uppercase();
+    if n.contains("US") && (n.contains("SURVEY") || n.contains("FTUS")) {
+        return Some(0.3048006096);
+    }
+    if n.contains("FOOT") || n.contains("FEET") {
+        return Some(0.3048);
+    }
+    if n.contains("MILLI") {
+        return Some(0.001);
+    }
+    if n.contains("CENTI") {
+        return Some(0.01);
+    }
+    if n.contains("DECI") {
+        return Some(0.1);
+    }
+    if n.contains("KILO") {
+        return Some(1000.0);
+    }
+    if n.contains("METRE") || n.contains("METER") {
+        return Some(1.0);
+    }
+    None
+}
+
 /// Where the georeferencing data was authored in the file.
 ///
 /// Single discriminator shared (string-for-string) with the TS parser's
@@ -496,8 +528,16 @@ impl GeoRefExtractor {
             let crs_entity = decoder.decode_by_id(crs_id)?;
             Self::parse_pset_projected_crs(decoder, &crs_entity, &mut georef);
         }
-        if georef.crs_name.is_none() {
-            georef.crs_name = target_crs;
+        // ePSet_ProjectedCRS.Name wins, but an empty/whitespace-only name must
+        // not block the TargetCRS fallback — the viewer gate requires a truthy
+        // CRS name, so leaving `crs_name = Some("")` would silently drop the
+        // model to the IfcSite/EPSG:4326 fallback. Treat blank as missing.
+        let crs_name_is_blank = georef
+            .crs_name
+            .as_ref()
+            .map_or(true, |name| name.trim().is_empty());
+        if crs_name_is_blank {
+            georef.crs_name = target_crs.filter(|name| !name.trim().is_empty());
         }
 
         georef.normalize_axis();
@@ -536,7 +576,13 @@ impl GeoRefExtractor {
                 "VerticalDatum" => georef.vertical_datum = value,
                 "MapProjection" => georef.map_projection = value,
                 "MapZone" => georef.map_zone = value,
-                "MapUnit" => georef.map_unit = value,
+                "MapUnit" => {
+                    // Parity with the native IfcProjectedCRS path: derive the
+                    // metre scale from the unit label so consumers don't default
+                    // explicit non-metre ePSet offsets to metres.
+                    georef.map_unit_scale = value.as_deref().and_then(infer_map_unit_scale);
+                    georef.map_unit = value;
+                }
                 _ => {}
             }
         }

--- a/rust/core/src/georef.rs
+++ b/rust/core/src/georef.rs
@@ -535,7 +535,7 @@ impl GeoRefExtractor {
         let crs_name_is_blank = georef
             .crs_name
             .as_ref()
-            .map_or(true, |name| name.trim().is_empty());
+            .is_none_or(|name| name.trim().is_empty());
         if crs_name_is_blank {
             georef.crs_name = target_crs.filter(|name| !name.trim().is_empty());
         }

--- a/rust/core/src/georef.rs
+++ b/rust/core/src/georef.rs
@@ -10,7 +10,23 @@
 use crate::decoder::EntityDecoder;
 use crate::error::Result;
 use crate::generated::IfcType;
-use crate::schema_gen::DecodedEntity;
+use crate::schema_gen::{AttributeValue, DecodedEntity};
+
+/// Read an `IfcPropertySingleValue.NominalValue` (index 2) as a string,
+/// unwrapping the typed-value wrapper `IFCLABEL('…')` / `IFCIDENTIFIER('…')`
+/// (parsed as a `List([type-name, value])`) that plain `get_string` doesn't
+/// see through. Property values in the IFC2x3 ePSets are always typed, so
+/// without this the CRS `Name`/`TargetCRS` labels came back empty.
+fn pset_value_string(prop: &DecodedEntity) -> Option<String> {
+    match prop.get(2)? {
+        AttributeValue::String(s) => Some(s.clone()),
+        AttributeValue::List(items) => match (items.first(), items.get(1)) {
+            (Some(AttributeValue::String(_)), Some(AttributeValue::String(v))) => Some(v.clone()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
 
 /// Where the georeferencing data was authored in the file.
 ///
@@ -378,30 +394,51 @@ impl GeoRefExtractor {
         decoder: &mut EntityDecoder,
         entity_types: &[(u32, IfcType)],
     ) -> Result<Option<GeoReference>> {
-        // Find IfcPropertySet with name ePSet_MapConversion
+        // Locate the ePSet_MapConversion (required) and ePSet_ProjectedCRS
+        // (optional) property sets. The match is case-insensitive: the
+        // buildingSMART geo-referencing guide spells these `ePSet_…` (capital
+        // S), but real authoring tools (e.g. the `ifc-georeferencer`
+        // post-processor) write `ePset_…` (lowercase), and an exact match
+        // silently dropped those models to the legacy IfcSite/EPSG:4326
+        // fallback so they displayed the wrong CRS. IfcPropertySet.Name is
+        // attribute 2 (attribute 0 is GlobalId); reading attribute 0 here
+        // never matched the ePSet at all (issue #900 review).
+        let mut map_conversion_pset: Option<u32> = None;
+        let mut projected_crs_pset: Option<u32> = None;
         for (id, ifc_type) in entity_types {
-            if *ifc_type == IfcType::IfcPropertySet {
-                let entity = decoder.decode_by_id(*id)?;
-                // IfcPropertySet.Name is attribute 2 (attribute 0 is GlobalId);
-                // reading attribute 0 here never matched the ePSet, so the
-                // IFC2x3 georeferencing fallback was dead (issue #900 review).
-                if let Some(name) = entity.get_string(2) {
-                    if name == "ePSet_MapConversion" || name == "EPset_MapConversion" {
-                        return Self::parse_pset_map_conversion(decoder, &entity);
-                    }
+            if *ifc_type != IfcType::IfcPropertySet {
+                continue;
+            }
+            let entity = decoder.decode_by_id(*id)?;
+            if let Some(name) = entity.get_string(2) {
+                let lower = name.to_ascii_lowercase();
+                if lower == "epset_mapconversion" && map_conversion_pset.is_none() {
+                    map_conversion_pset = Some(*id);
+                } else if lower == "epset_projectedcrs" && projected_crs_pset.is_none() {
+                    projected_crs_pset = Some(*id);
                 }
             }
         }
-        Ok(None)
+
+        let Some(mc_id) = map_conversion_pset else {
+            return Ok(None);
+        };
+        let mc_entity = decoder.decode_by_id(mc_id)?;
+        Self::parse_pset_map_conversion(decoder, &mc_entity, projected_crs_pset)
     }
 
-    /// Parse ePSet_MapConversion property set
+    /// Parse ePSet_MapConversion property set, plus the EPSG `Name` from an
+    /// optional ePSet_ProjectedCRS set (falling back to the MapConversion's
+    /// own `TargetCRS` label). Without the CRS name the EPSG code authored in
+    /// the file was never surfaced on the IFC2x3 path.
     fn parse_pset_map_conversion(
         decoder: &mut EntityDecoder,
         pset: &DecodedEntity,
+        projected_crs_pset: Option<u32>,
     ) -> Result<Option<GeoReference>> {
         let mut georef = GeoReference::new();
         georef.source = GeoRefSource::EPSetMapConversion;
+        let mut target_crs: Option<String> = None;
 
         // HasProperties is typically at index 4
         if let Some(props_list) = pset.get_list(4) {
@@ -442,11 +479,25 @@ impl GeoRefExtractor {
                                     georef.scale = v;
                                 }
                             }
+                            "TargetCRS" => {
+                                if let Some(v) = pset_value_string(&prop) {
+                                    target_crs = Some(v);
+                                }
+                            }
                             _ => {}
                         }
                     }
                 }
             }
+        }
+
+        // Pull the CRS name + datum fields from ePSet_ProjectedCRS if present.
+        if let Some(crs_id) = projected_crs_pset {
+            let crs_entity = decoder.decode_by_id(crs_id)?;
+            Self::parse_pset_projected_crs(decoder, &crs_entity, &mut georef);
+        }
+        if georef.crs_name.is_none() {
+            georef.crs_name = target_crs;
         }
 
         georef.normalize_axis();
@@ -455,6 +506,39 @@ impl GeoRefExtractor {
             Ok(Some(georef))
         } else {
             Ok(None)
+        }
+    }
+
+    /// Parse an ePSet_ProjectedCRS property set into the georef's CRS fields.
+    fn parse_pset_projected_crs(
+        decoder: &mut EntityDecoder,
+        pset: &DecodedEntity,
+        georef: &mut GeoReference,
+    ) {
+        let Some(props_list) = pset.get_list(4) else {
+            return;
+        };
+        for prop_attr in props_list {
+            let Some(prop_id) = prop_attr.as_entity_ref() else {
+                continue;
+            };
+            let Ok(prop) = decoder.decode_by_id(prop_id) else {
+                continue;
+            };
+            let Some(name) = prop.get_string(0) else {
+                continue;
+            };
+            let value = pset_value_string(&prop);
+            match name {
+                "Name" => georef.crs_name = value,
+                "Description" => georef.crs_description = value,
+                "GeodeticDatum" => georef.geodetic_datum = value,
+                "VerticalDatum" => georef.vertical_datum = value,
+                "MapProjection" => georef.map_projection = value,
+                "MapZone" => georef.map_zone = value,
+                "MapUnit" => georef.map_unit = value,
+                _ => {}
+            }
         }
     }
 

--- a/rust/processing/src/georeferencing.rs
+++ b/rust/processing/src/georeferencing.rs
@@ -301,6 +301,63 @@ END-ISO-10303-21;
         assert_eq!(geo.map_zone.as_deref(), Some("32N"));
     }
 
+    /// An empty `ePset_ProjectedCRS.Name` must not block the `TargetCRS`
+    /// fallback — otherwise `crs_name` stays "" and the viewer gate (which
+    /// requires a truthy name) silently drops the model to EPSG:4326.
+    const IFC2X3_EPSET_EMPTY_CRS_NAME_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ifc-georeferencer empty-crs-name fixture'),'2;1');
+FILE_NAME('georef-empty.ifc','2026-06-26T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#1=IFCPROPERTYSINGLEVALUE('TargetCRS',$,IFCLABEL('EPSG:28992'),$);
+#2=IFCPROPERTYSINGLEVALUE('Eastings',$,IFCLENGTHMEASURE(1000.5),$);
+#3=IFCPROPERTYSINGLEVALUE('Northings',$,IFCLENGTHMEASURE(2000.25),$);
+#4=IFCPROPERTYSINGLEVALUE('OrthogonalHeight',$,IFCLENGTHMEASURE(0.),$);
+#5=IFCPROPERTYSET('2If4Y3Lpv6dgTDkC5x_dnr',$,'ePset_MapConversion',$,(#1,#2,#3,#4));
+#6=IFCPROPERTYSINGLEVALUE('Name',$,IFCLABEL(''),$);
+#7=IFCPROPERTYSET('27AKTMp8j58fBEhvkJkcNJ',$,'ePset_ProjectedCRS',$,(#6));
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+    #[test]
+    fn empty_projected_crs_name_falls_back_to_target_crs() {
+        let geo = extract_georeferencing(IFC2X3_EPSET_EMPTY_CRS_NAME_IFC)
+            .expect("expected georeferencing from ePset_MapConversion");
+        assert_eq!(geo.crs_name.as_deref(), Some("EPSG:28992"));
+    }
+
+    /// An explicit ePSet `MapUnit` label resolves to the matching metre scale,
+    /// parity with the native IfcProjectedCRS path (which reads it from the
+    /// unit entity). Direct consumers must not default these offsets to metres.
+    const IFC2X3_EPSET_FOOT_MAPUNIT_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ifc-georeferencer foot-mapunit fixture'),'2;1');
+FILE_NAME('georef-foot.ifc','2026-06-26T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#2=IFCPROPERTYSINGLEVALUE('Eastings',$,IFCLENGTHMEASURE(1000.5),$);
+#3=IFCPROPERTYSINGLEVALUE('Northings',$,IFCLENGTHMEASURE(2000.25),$);
+#4=IFCPROPERTYSINGLEVALUE('OrthogonalHeight',$,IFCLENGTHMEASURE(0.),$);
+#5=IFCPROPERTYSET('2If4Y3Lpv6dgTDkC5x_dnr',$,'ePset_MapConversion',$,(#2,#3,#4));
+#6=IFCPROPERTYSINGLEVALUE('Name',$,IFCLABEL('EPSG:2225'),$);
+#8=IFCPROPERTYSINGLEVALUE('MapUnit',$,IFCLABEL('FOOT'),$);
+#7=IFCPROPERTYSET('27AKTMp8j58fBEhvkJkcNJ',$,'ePset_ProjectedCRS',$,(#6,#8));
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+    #[test]
+    fn epset_map_unit_label_resolves_scale() {
+        let geo = extract_georeferencing(IFC2X3_EPSET_FOOT_MAPUNIT_IFC).expect("georef");
+        assert_eq!(geo.crs_name.as_deref(), Some("EPSG:2225"));
+        assert_eq!(geo.map_unit.as_deref(), Some("FOOT"));
+        assert_eq!(geo.map_unit_scale, Some(0.3048));
+    }
+
     /// Two authored IfcMapConversions: the FIRST one wins, matching the TS
     /// parser's `mapConversionIds[0]` pick (the server used to serve the
     /// LAST one — alignment audit).

--- a/rust/processing/src/georeferencing.rs
+++ b/rust/processing/src/georeferencing.rs
@@ -215,6 +215,63 @@ END-ISO-10303-21;
         assert!((geo.orthogonal_height - 42.0).abs() < 1e-6);
     }
 
+    /// Real-world fixture mirroring the `ifc-georeferencer` post-processor:
+    /// lowercase `ePset_…` property-set names and a separate `ePset_ProjectedCRS`
+    /// carrying the EPSG `Name`. The exact-match + missing-CRS bug dropped these
+    /// to the legacy IfcSite EPSG:4326 and showed the wrong CRS.
+    const IFC2X3_EPSET_LOWERCASE_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ifc-georeferencer pset fixture'),'2;1');
+FILE_NAME('georef-lc.ifc','2026-06-26T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#1=IFCPROPERTYSINGLEVALUE('TargetCRS',$,IFCLABEL('EPSG:7415'),$);
+#2=IFCPROPERTYSINGLEVALUE('Eastings',$,IFCLENGTHMEASURE(160073528.13858587),$);
+#3=IFCPROPERTYSINGLEVALUE('Northings',$,IFCLENGTHMEASURE(384153306.2191765),$);
+#4=IFCPROPERTYSINGLEVALUE('OrthogonalHeight',$,IFCLENGTHMEASURE(0.),$);
+#5=IFCPROPERTYSET('2If4Y3Lpv6dgTDkC5x_dnr',$,'ePset_MapConversion',$,(#1,#2,#3,#4));
+#6=IFCPROPERTYSINGLEVALUE('Name',$,IFCLABEL('EPSG:7415'),$);
+#7=IFCPROPERTYSET('27AKTMp8j58fBEhvkJkcNJ',$,'ePset_ProjectedCRS',$,(#6));
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+    #[test]
+    fn extracts_ifc2x3_lowercase_epset_with_projected_crs_name() {
+        let geo = extract_georeferencing(IFC2X3_EPSET_LOWERCASE_IFC)
+            .expect("expected georeferencing from lowercase ePset_ sets");
+        assert_eq!(geo.source.as_deref(), Some("ePSetMapConversion"));
+        // CRS name surfaced from ePset_ProjectedCRS.Name (was previously lost).
+        assert_eq!(geo.crs_name.as_deref(), Some("EPSG:7415"));
+        assert!((geo.eastings - 160073528.13858587).abs() < 1e-3);
+    }
+
+    /// Without an ePset_ProjectedCRS set, the CRS name falls back to the
+    /// MapConversion's own `TargetCRS` label.
+    const IFC2X3_EPSET_TARGETCRS_ONLY_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ifc-georeferencer targetcrs-only fixture'),'2;1');
+FILE_NAME('georef-tc.ifc','2026-06-26T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#1=IFCPROPERTYSINGLEVALUE('TargetCRS',$,IFCLABEL('EPSG:28992'),$);
+#2=IFCPROPERTYSINGLEVALUE('Eastings',$,IFCLENGTHMEASURE(1000.5),$);
+#3=IFCPROPERTYSINGLEVALUE('Northings',$,IFCLENGTHMEASURE(2000.25),$);
+#4=IFCPROPERTYSINGLEVALUE('OrthogonalHeight',$,IFCLENGTHMEASURE(0.),$);
+#5=IFCPROPERTYSET('2If4Y3Lpv6dgTDkC5x_dnr',$,'ePset_MapConversion',$,(#1,#2,#3,#4));
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+    #[test]
+    fn falls_back_to_target_crs_when_no_projected_crs_pset() {
+        let geo = extract_georeferencing(IFC2X3_EPSET_TARGETCRS_ONLY_IFC)
+            .expect("expected georeferencing from ePset_MapConversion");
+        assert_eq!(geo.crs_name.as_deref(), Some("EPSG:28992"));
+    }
+
     /// Millimetre MapUnit: the conversion offsets are authored in mm and the
     /// served `map_unit_scale` must say 0.001 — the TS parser already did
     /// this; the server previously ignored MapUnit entirely (alignment


### PR DESCRIPTION
## Problem

Users load IFC2X3 files georeferenced by the `ifc-georeferencer` tool (e.g. `Massamodel S1.ifc` = `EPSG:7415` RD+NAP, `..._28992.ifc` = `EPSG:28992` RD) and **both display the same wrong EPSG** (`EPSG:4326`).

IFC2X3 has no native `IfcMapConversion`/`IfcProjectedCRS`, so georeferencing is stored in `ePset_MapConversion` / `ePset_ProjectedCRS` property sets per the [buildingSMART Geo-referencing guide](https://www.buildingsmart.org/wp-content/uploads/2020/02/User-Guide-for-Geo-referencing-in-IFC-v2.0.pdf). The "vertical datum" hunch was a red herring — both files failed identically.

## Root cause (three bugs)

1. **Case-sensitive pset-name match.** The guide spells these `ePSet_` (capital S), but real tools write `ePset_` (lowercase). Code matched only `ePSet_`/`EPset_` → fallback skipped → legacy `IfcSite` lat/long → hardcoded `EPSG:4326`.
2. **The ePSet path never read `ePset_ProjectedCRS.Name`** (nor `MapConversion.TargetCRS`), so the EPSG code was discarded even on a name match.
3. **The viewer's on-demand extractor never loaded the property sets at all** — it only fetched `IfcMapConversion`/`IfcProjectedCRS`/`IfcSite`, and typed `IFCLABEL(...)`/`IFCLENGTHMEASURE(...)` values weren't unwrapped.

## Fix

- Match the ePSet name **case-insensitively** and read `ePset_ProjectedCRS` (+ `TargetCRS` backstop), unwrapping typed values — in both the TS (`extractGeoreferencing`) and Rust (`GeoRefExtractor`) extractors, kept in parity.
- The viewer's `extractGeoreferencingOnDemand` now pulls in the georef ePSets + their children (only when no `IfcMapConversion` exists; deferred-atom safe).

### Cesium / federation pipeline

- The gate (`hasStandardGeoreferencing`, shared by Cesium + federation) already accepts any non-`siteLocation` source — so `ePSetMapConversion` flows once it has a CRS name. Locked in with a test.
- **Unit fix:** ePSet offsets are in the project length unit (millimetres here: `160073528 mm` = 160 km RD), but the absent-MapUnit heuristic treated them as metres → ~1000× out of range → reprojection returned null → Cesium couldn't place the model. Now scaled by the project length unit for the ePSet source (spec-correct per the guide).
- Compound `EPSG:7415` is already in `PRECISION_GRIDS` (RD horizontal grid). Hardened the **offline** fallback (datum reported as `RD`, no `+towgs84`) with the Kadaster shift.

## Verification

End-to-end through the real viewer pipeline on both downloaded files:

| File | CRS | gate | mapUnitScale | reprojects to |
|------|-----|------|------|------|
| `…S1.ifc` | **EPSG:7415** | ✓ | 0.001 (mm) | 51.447°N, 5.462°E (Eindhoven) |
| `…S1_28992.ifc` | **EPSG:28992** | ✓ | 0.001 (mm) | 51.447°N, 5.462°E |

Both land exactly at the `IfcSite` coordinates, in the Netherlands.

## Tests

- Parser: 19 georef tests (new on-demand ePset + casing + `ePset_ProjectedCRS.Name` cases).
- Rust: new lowercase-`ePset_` + `ePset_ProjectedCRS` + `TargetCRS`-fallback fixtures; all georef tests pass.
- Viewer geo suite: **99/99 pass** (new: ePSet gate acceptance + `resolveEpsetMapUnitScale`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved IFC2X3 georeferencing support so authored CRS/EPSG information is picked up more reliably, including cases where property set names use different casing.
  * Better handling of projected CRS details, map-unit scaling, and reprojection fallback data for improved viewer accuracy.
* **Bug Fixes**
  * Prevented georeferencing from defaulting to generic world coordinates when authored CRS data is available.
  * Fixed offset and datum-shift handling for more accurate map positioning in affected models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->