### PR TITLE
fix(export): apply mutations in merged (federated) export (#1406)

### DIFF
--- a/.changeset/merged-export-mutations.md
+++ b/.changeset/merged-export-mutations.md
@@ -1,5 +1,6 @@
 ---
 "@ifc-lite/export": minor
+"@ifc-lite/mutations": minor
 "@ifc-lite/viewer": patch
 ---
 
@@ -14,3 +15,7 @@ Models without pending edits pass through unchanged (no export/parse cost). The 
 `MergedExporter.export()` throws if a model carries pending edits, since baking needs the
 async parser. The viewer's "Merged (All Models)" export now passes each model's mutation view
 (gated by the Apply Mutations toggle).
+
+`MutablePropertyView` gains `hasPendingChanges()`, which reports the current overlay footprint
+(what the exporter would bake) rather than the append-only mutation history; the merged
+exporter uses it to decide whether to re-bake a model.

--- a/.changeset/merged-export-mutations.md
+++ b/.changeset/merged-export-mutations.md
@@ -1,0 +1,16 @@
+---
+"@ifc-lite/export": minor
+"@ifc-lite/viewer": patch
+---
+
+Apply pending edits in merged (federated) export. `MergeModelInput` gains an optional
+`mutationView`; `MergedExporter.exportAsync` now bakes each model's edits (attribute /
+property / quantity / retype / positional mutations and overlay-created entities) into its
+source via `StepExporter` before merging, so federated export round-trips edits exactly like
+single-model export. Previously the merged path read raw source bytes and silently dropped
+every mutation — only single-model export reflected edits ([#1406](https://github.com/LTplus-AG/ifc-lite/issues/1406)).
+
+Models without pending edits pass through unchanged (no export/parse cost). The synchronous
+`MergedExporter.export()` throws if a model carries pending edits, since baking needs the
+async parser. The viewer's "Merged (All Models)" export now passes each model's mutation view
+(gated by the Apply Mutations toggle).

--- a/apps/viewer/src/components/viewer/ExportDialog.tsx
+++ b/apps/viewer/src/components/viewer/ExportDialog.tsx
@@ -344,6 +344,10 @@ export function ExportDialog({ trigger }: ExportDialogProps) {
             id: entry.model.id,
             name: entry.model.name,
             dataStore: entry.dataStore,
+            // Pass each model's pending edits so federated export round-trips
+            // mutations like single-model export. Gated by the Apply Mutations
+            // toggle; models without edits resolve to undefined (no bake cost).
+            mutationView: applyMutations ? (getMutationView(entry.model.id) ?? undefined) : undefined,
           });
         }
 

--- a/apps/viewer/src/components/viewer/ExportDialog.tsx
+++ b/apps/viewer/src/components/viewer/ExportDialog.tsx
@@ -680,7 +680,7 @@ export function ExportDialog({ trigger }: ExportDialogProps) {
             </div>
           )}
 
-          {exportScope === 'single' && (
+          {(exportScope === 'single' || exportScope === 'merged') && (
             <div className="flex items-center justify-between">
               <Label>Apply Property Changes</Label>
               <Switch checked={applyMutations} onCheckedChange={setApplyMutations} />

--- a/packages/export/src/merged-exporter.test.ts
+++ b/packages/export/src/merged-exporter.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect } from 'vitest';
 import { MergedExporter, type MergeModelInput } from './merged-exporter.js';
 import type { IfcDataStore } from '@ifc-lite/parser';
+import { MutablePropertyView as LiveMutablePropertyView } from '@ifc-lite/mutations';
 
 type MockEntityRef = { expressId: number; type: string; byteOffset: number; byteLength: number; lineNumber: number };
 
@@ -691,6 +692,57 @@ describe('MergedExporter', () => {
       // Both text literals survive (not unified away); the literal is untouched.
       expect(content.match(/=IFCTEXTLITERAL\(/g)?.length).toBe(2);
       expect(content.match(new RegExp(literal, 'g'))?.length).toBe(2);
+      expect(findDanglingRefs(content)).toEqual([]);
+    });
+  });
+
+  // Federated export must round-trip pending edits (issue #1406): the merged
+  // path historically read raw source bytes and dropped every mutation, so only
+  // single-model export reflected edits. exportAsync now bakes each model's
+  // mutation view before merging.
+  describe('mutations (round-trip of edits)', () => {
+    const wallA = guid('wallA');
+    const wallB = guid('wallB');
+
+    function editedModelA(): MergeModelInput {
+      const base = buildModel('m1', 'A', [
+        [1, 'IFCWALL', `#1=IFCWALL('${wallA}',$,'Original Wall A',$,$,$,$,$,$);`],
+      ]);
+      const view = new LiveMutablePropertyView(null, 'm1');
+      view.setAttribute(1, 'Name', 'Edited Wall A');
+      return { ...base, mutationView: view };
+    }
+
+    const modelB: () => MergeModelInput = () => buildModel('m2', 'B', [
+      [1, 'IFCWALL', `#1=IFCWALL('${wallB}',$,'Wall B',$,$,$,$,$,$);`],
+    ]);
+
+    it('applies a model’s attribute edit in merged (federated) export', async () => {
+      const result = await new MergedExporter([editedModelA(), modelB()]).exportAsync({ schema: 'IFC4' });
+      const content = decode(result.content);
+
+      expect(content).toContain("'Edited Wall A'");
+      expect(content).not.toContain("'Original Wall A'");
+      // The unedited second model is unaffected and still present.
+      expect(content).toContain("'Wall B'");
+      expect(findDanglingRefs(content)).toEqual([]);
+    });
+
+    it('sync export() throws rather than silently dropping pending edits', () => {
+      expect(() => new MergedExporter([editedModelA(), modelB()]).export({ schema: 'IFC4' }))
+        .toThrow(/exportAsync/);
+    });
+
+    it('a model whose view has no pending edits is not baked (no-op)', async () => {
+      const emptyView = new LiveMutablePropertyView(null, 'm2');
+      const a = buildModel('m1', 'A', [
+        [1, 'IFCWALL', `#1=IFCWALL('${wallA}',$,'Wall A',$,$,$,$,$,$);`],
+      ]);
+      const b: MergeModelInput = { ...modelB(), mutationView: emptyView };
+      const result = await new MergedExporter([a, b]).exportAsync({ schema: 'IFC4' });
+      const content = decode(result.content);
+      expect(content).toContain("'Wall A'");
+      expect(content).toContain("'Wall B'");
       expect(findDanglingRefs(content)).toEqual([]);
     });
   });

--- a/packages/export/src/merged-exporter.ts
+++ b/packages/export/src/merged-exporter.ts
@@ -11,13 +11,15 @@
  */
 
 import type { IfcDataStore } from '@ifc-lite/parser';
-import { generateHeader, deterministicGlobalId } from '@ifc-lite/parser';
+import { generateHeader, deterministicGlobalId, IfcParser } from '@ifc-lite/parser';
 import { decodeIfcString } from '@ifc-lite/encoding';
 import { safeUtf8Decode } from '@ifc-lite/data';
+import type { MutablePropertyView } from '@ifc-lite/mutations';
 import { collectReferencedEntityIds, getVisibleEntityIds, collectStyleEntities } from './reference-collector.js';
 import { convertStepLine, needsConversion, type IfcSchemaVersion } from './schema-converter.js';
 import { assembleStepBytes } from './step-serialization.js';
 import { getCompleteEntityIndex, getMaxExpressId, type CompleteEntityIndex, type ExportEntityRef } from './entity-iteration.js';
+import { StepExporter } from './step-exporter.js';
 
 /** Entity types forming shared infrastructure (deduplicated across models). */
 const SHARED_INFRASTRUCTURE_TYPES = new Set([
@@ -158,6 +160,28 @@ export interface MergeModelInput {
    * federated as its own project (different unit). See {@link MergedExporter}.
    */
   lengthUnitScale?: number;
+
+  /**
+   * Pending edits for this model — property / attribute / quantity / retype /
+   * positional mutations and overlay-created entities. When present and
+   * non-empty, {@link MergedExporter.exportAsync} bakes them into the model
+   * (via {@link StepExporter}) before merging, so federated export round-trips
+   * edits exactly like single-model export. Empty or absent views cost nothing.
+   *
+   * Only honoured by the async `exportAsync` path: baking re-parses the edited
+   * bytes, which needs the async parser. The synchronous {@link MergedExporter.export}
+   * throws if any model carries pending edits.
+   */
+  mutationView?: MutablePropertyView;
+}
+
+/** True when a mutation view carries any pending edit (mutations or overlay-created entities). */
+function viewHasMutations(view: MutablePropertyView | undefined): boolean {
+  if (!view) return false;
+  const muts = typeof view.getMutations === 'function' ? view.getMutations() : [];
+  if (muts.length > 0) return true;
+  const created = typeof view.getNewEntities === 'function' ? view.getNewEntities() : [];
+  return created.length > 0;
 }
 
 /**
@@ -307,7 +331,17 @@ export class MergedExporter {
     const onProgress = options.onProgress;
     const schema = (options.schema || 'IFC4') as IfcSchemaVersion;
     const header = this.buildHeader(options, schema);
-    const setup = this.buildMergeSetup(options);
+
+    // Baking edits into source bytes needs the async parser, so the sync path
+    // cannot honour them. Fail loudly rather than silently dropping the edits.
+    if (this.models.some(m => viewHasMutations(m.mutationView))) {
+      throw new Error(
+        'MergedExporter.export() cannot apply pending edits — baking needs the async parser. ' +
+        'Use exportAsync() for merged export with mutations.',
+      );
+    }
+    const models = this.models;
+    const setup = this.buildMergeSetup(options, models);
 
     const allEntityLines: string[] = [];
     // Tracks every GlobalId already emitted → its final express id + unit scale,
@@ -317,7 +351,7 @@ export class MergedExporter {
     let isFirstModel = true;
     let federatedModelCount = 0;
 
-    for (const model of this.models) {
+    for (const model of models) {
       const offset = setup.modelOffsets.get(model.id)!;
       const source = model.dataStore.source;
       if (!source || source.length === 0) continue;
@@ -365,14 +399,19 @@ export class MergedExporter {
     // See export(): merged files emit an ifc-lite provenance header by policy
     // (no single source header to preserve across federated models).
     const header = this.buildHeader(options, schema);
-    const setup = this.buildMergeSetup(options);
+
+    // Bake each model's pending edits into its source bytes before merging, so
+    // federated export round-trips mutations like single-model export. Models
+    // without edits pass through unchanged (no export/parse cost).
+    const models = await this.bakeMutatedModels();
+    const setup = this.buildMergeSetup(options, models);
 
     const allEntityLines: string[] = [];
     const guidToFinalId = new Map<string, GuidRecord>();
 
     // First pass: count total entities for progress
     let totalEntities = 0;
-    for (const model of this.models) {
+    for (const model of models) {
       totalEntities += getCompleteEntityIndex(model.dataStore).size;
     }
 
@@ -383,7 +422,7 @@ export class MergedExporter {
 
     if (onProgress) onProgress({ phase: 'preparing', percent: 0, entitiesProcessed: 0, entitiesTotal: totalEntities });
 
-    for (const model of this.models) {
+    for (const model of models) {
       const offset = setup.modelOffsets.get(model.id)!;
       const source = model.dataStore.source;
       if (!source || source.length === 0) continue;
@@ -456,6 +495,50 @@ export class MergedExporter {
   }
 
   /**
+   * Bake each model's pending edits into its source bytes before merging.
+   *
+   * A model with a non-empty {@link MergeModelInput.mutationView} is run through
+   * {@link StepExporter} in its own source schema (mutations applied, geometry +
+   * quantities kept), and the resulting bytes are re-parsed into a fresh data
+   * store. The merge pipeline then sees the edited entities as ordinary source,
+   * so unit-aware federation, GlobalId reconciliation and id offsetting are
+   * unaffected. Models without edits pass through untouched (no export/parse cost).
+   */
+  private async bakeMutatedModels(): Promise<MergeModelInput[]> {
+    const baked: MergeModelInput[] = [];
+    let parser: IfcParser | null = null;
+    for (const model of this.models) {
+      if (!viewHasMutations(model.mutationView)) {
+        baked.push(model);
+        continue;
+      }
+      const sourceSchema = (model.dataStore.schemaVersion as IfcSchemaVersion) || 'IFC4';
+      // Export in the SOURCE schema so no schema conversion happens here — the
+      // merge loop still converts to the requested target schema per entity.
+      const exported = new StepExporter(model.dataStore, model.mutationView).export({
+        schema: sourceSchema,
+        applyMutations: true,
+        includeGeometry: true,
+        includeQuantities: true,
+      });
+      parser = parser ?? new IfcParser();
+      // slice() yields an exact-length ArrayBuffer-backed copy for the parser.
+      const reparsed = await parser.parseColumnar(exported.content.slice().buffer, {
+        disableWorkerScan: true,
+      });
+      baked.push({
+        id: model.id,
+        name: model.name,
+        dataStore: reparsed,
+        // Keep the caller's explicit unit scale (else the original store's) so
+        // unit-aware federation is unaffected by the bake round-trip.
+        lengthUnitScale: model.lengthUnitScale ?? model.dataStore.lengthUnitScale,
+      });
+    }
+    return baked;
+  }
+
+  /**
    * Assemble the result stats, including any federation conformance warnings.
    */
   private buildStats(totalEntityCount: number, fileSize: number, federatedModelCount: number): MergeExportResult['stats'] {
@@ -493,18 +576,19 @@ export class MergedExporter {
    * Compute the model-independent state shared by export()/exportAsync():
    * per-model id offsets and the primary model's project/infra/spatial/unit info.
    */
-  private buildMergeSetup(options: MergeExportOptions): MergeSetup {
+  private buildMergeSetup(options: MergeExportOptions, models: MergeModelInput[]): MergeSetup {
     // Determine ID offsets. Span the COMPLETE entity set (incl. deferred
     // property atoms) so the next model's offset clears every id this model
-    // will emit — otherwise a deferred atom at a high id collides.
+    // will emit — otherwise a deferred atom at a high id collides. Computed over
+    // the (possibly baked) model list so mutation-created entities are covered.
     let nextAvailableId = 1;
     const modelOffsets = new Map<string, number>();
-    for (const model of this.models) {
+    for (const model of models) {
       modelOffsets.set(model.id, nextAvailableId - 1); // start at nextAvailableId
       nextAvailableId += getMaxExpressId(getCompleteEntityIndex(model.dataStore));
     }
 
-    const firstModel = this.models[0];
+    const firstModel = models[0];
     return {
       modelOffsets,
       firstModelOffset: modelOffsets.get(firstModel.id)!,

--- a/packages/export/src/merged-exporter.ts
+++ b/packages/export/src/merged-exporter.ts
@@ -175,9 +175,20 @@ export interface MergeModelInput {
   mutationView?: MutablePropertyView;
 }
 
-/** True when a mutation view carries any pending edit (mutations or overlay-created entities). */
+/**
+ * True when a mutation view carries pending edits the exporter would bake.
+ *
+ * Keys off the view's *current overlay footprint* (`hasPendingChanges`), not the
+ * append-only mutation history: the history never shrinks, so an
+ * edited-then-undone model would keep reporting changes and force a redundant
+ * re-bake. `hasPendingChanges` is a conservative over-approximation (the safe
+ * direction here — under-reporting would silently drop edits). Falls back to the
+ * legacy history/new-entity check for views that predate the method.
+ */
 function viewHasMutations(view: MutablePropertyView | undefined): boolean {
   if (!view) return false;
+  if (typeof view.hasPendingChanges === 'function') return view.hasPendingChanges();
+  // Legacy fallback (older MutablePropertyView without hasPendingChanges).
   const muts = typeof view.getMutations === 'function' ? view.getMutations() : [];
   if (muts.length > 0) return true;
   const created = typeof view.getNewEntities === 'function' ? view.getNewEntities() : [];

--- a/packages/mutations/src/mutable-property-view.ts
+++ b/packages/mutations/src/mutable-property-view.ts
@@ -1199,8 +1199,8 @@ export class MutablePropertyView {
 
   /**
    * True when the overlay currently carries anything the STEP exporter would
-   * bake (property/quantity overrides, attribute or positional edits, pset/qset
-   * creates or deletes, or overlay-created/tombstoned entities).
+   * bake (property/quantity overrides, attribute / positional / type edits,
+   * pset/qset creates or deletes, or overlay-created/tombstoned entities).
    *
    * Unlike {@link getMutations} / {@link hasChanges}, this reflects the *current
    * overlay footprint* — the same set {@link clear} resets and the exporter
@@ -1218,6 +1218,7 @@ export class MutablePropertyView {
       this.quantityMutations.size > 0 ||
       this.attributeMutations.size > 0 ||
       this.positionalAttrMutations.size > 0 ||
+      this.typeMutations.size > 0 ||
       this.newPsets.size > 0 ||
       this.newQsets.size > 0 ||
       this.deletedPsets.size > 0 ||

--- a/packages/mutations/src/mutable-property-view.ts
+++ b/packages/mutations/src/mutable-property-view.ts
@@ -1198,6 +1198,36 @@ export class MutablePropertyView {
   }
 
   /**
+   * True when the overlay currently carries anything the STEP exporter would
+   * bake (property/quantity overrides, attribute or positional edits, pset/qset
+   * creates or deletes, or overlay-created/tombstoned entities).
+   *
+   * Unlike {@link getMutations} / {@link hasChanges}, this reflects the *current
+   * overlay footprint* — the same set {@link clear} resets and the exporter
+   * reads — rather than the append-only mutation history, which never shrinks.
+   * It is deliberately a conservative over-approximation: undoing an edit resets
+   * the overlay entry's value (or leaves a no-op DELETE marker) instead of
+   * removing it, so a fully-reverted model can still report `true`. That is the
+   * safe direction for gating an export bake — over-reporting only costs a
+   * redundant (identical-output) re-bake, whereas under-reporting would silently
+   * drop edits.
+   */
+  hasPendingChanges(): boolean {
+    return (
+      this.propertyMutations.size > 0 ||
+      this.quantityMutations.size > 0 ||
+      this.attributeMutations.size > 0 ||
+      this.positionalAttrMutations.size > 0 ||
+      this.newPsets.size > 0 ||
+      this.newQsets.size > 0 ||
+      this.deletedPsets.size > 0 ||
+      this.deletedQsets.size > 0 ||
+      this.newEntities.size > 0 ||
+      this.tombstones.size > 0
+    );
+  }
+
+  /**
    * Get count of modified entities
    */
   getModifiedEntityCount(): number {

--- a/packages/mutations/test/mutable-property-view.test.ts
+++ b/packages/mutations/test/mutable-property-view.test.ts
@@ -216,4 +216,12 @@ describe('MutablePropertyView.hasPendingChanges', () => {
     expect(view.getMutations().length).toBeGreaterThan(0);
     expect(view.hasPendingChanges()).toBe(true);
   });
+
+  it('reports a type-only (retype) edit so merged export does not drop it', () => {
+    const view = new MutablePropertyView(null, 'model-1');
+    expect(view.hasPendingChanges()).toBe(false);
+
+    view.setEntityType(1, 'IfcColumn');
+    expect(view.hasPendingChanges()).toBe(true);
+  });
 });

--- a/packages/mutations/test/mutable-property-view.test.ts
+++ b/packages/mutations/test/mutable-property-view.test.ts
@@ -188,3 +188,32 @@ describe('BulkQueryEngine', () => {
     expect(view.getPropertyValue(2, 'Pset_Bulk', 'Zone')).toBe('North');
   });
 });
+
+describe('MutablePropertyView.hasPendingChanges', () => {
+  it('is false on a fresh view and true once an overlay edit is recorded', () => {
+    const view = new MutablePropertyView(null, 'model-1');
+    view.setOnDemandExtractor(() => []);
+    expect(view.hasPendingChanges()).toBe(false);
+
+    view.setProperty(1, 'Pset_Test', 'Foo', 'bar', PropertyValueType.Label);
+    expect(view.hasPendingChanges()).toBe(true);
+  });
+
+  it('returns to false after clear()', () => {
+    const view = new MutablePropertyView(null, 'model-1');
+    view.createPropertySet(1, 'Pset_New', [{ name: 'A', value: 'x', type: PropertyValueType.Label }]);
+    expect(view.hasPendingChanges()).toBe(true);
+
+    view.clear();
+    expect(view.hasPendingChanges()).toBe(false);
+  });
+
+  it('tracks the current overlay footprint, not append-only history', () => {
+    const view = new MutablePropertyView(null, 'model-1');
+    view.setOnDemandExtractor(() => []);
+    view.setProperty(1, 'Pset_Test', 'Foo', 'bar', PropertyValueType.Label);
+    // History only grows; the overlay footprint is what gates the export bake.
+    expect(view.getMutations().length).toBeGreaterThan(0);
+    expect(view.hasPendingChanges()).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #1406.

## Problem
Merged (federated) export silently dropped every pending edit. `MergedExporter` read raw
`dataStore.source` bytes and only remapped IDs — it had no per-model hook to receive a
model's mutation overlay. So edits round-tripped only via single-model `StepExporter`
export; the **Apply Mutations** toggle did nothing in Merged mode.

## Fix
Bake-then-merge, encapsulated in the package so the API stays clean:

- `MergeModelInput` gains optional `mutationView`.
- `MergedExporter.exportAsync` bakes each model that has pending edits through the existing,
  well-tested `StepExporter` (in the model's own source schema, mutations applied), re-parses
  the result, and feeds the baked store into the **unchanged** merge pipeline. So unit-aware
  federation, GlobalId reconciliation, spatial unification and id offsetting all keep working.
- Models without edits pass through untouched (no export/parse cost).
- Sync `export()` throws if any model carries pending edits (baking needs the async parser);
  no existing caller passed a view, so this is safe.
- Viewer: the Merged (All Models) branch passes each model's `getMutationView(id)`, gated by
  the Apply Mutations toggle.

This reuses 100% of `StepExporter`'s mutation logic rather than duplicating it; the only cost
is one export+reparse per *edited* model, on an already-heavy user-initiated operation.

## Tests
`packages/export/src/merged-exporter.test.ts`:
- attribute edit round-trips into merged output (edited value present, original gone, second
  model intact, no dangling refs);
- sync `export()` throws rather than dropping edits;
- a view with no pending edits is a no-op.

Full `@ifc-lite/export` suite green (121 passed). `@ifc-lite/export` and `@ifc-lite/viewer`
typecheck clean.

## Notes
- Georeferencing mutations in merged export are out of scope here (single-model only for now)
  and can follow up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Merged (All Models) STEP export now preserves round-tripping of per-model pending property edits when **Apply Property Changes** is enabled.
  * The **Apply Property Changes** toggle is now shown for both single-model and merged export flows.
* **Bug Fixes**
  * Merged exports no longer drop edited content from federated model views and prevent dangling references in the output.
  * Models without pending edits continue to export unchanged.
* **Behavior Changes**
  * Synchronous merged export now rejects models with pending edits and requires the async export flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->