### PR TITLE
fix(renderer): snap every GPU-instanced occurrence, not just the first (#1405)

### DIFF
--- a/.changeset/fix-1405-snap-instanced-occurrence.md
+++ b/.changeset/fix-1405-snap-instanced-occurrence.md
@@ -1,0 +1,6 @@
+---
+"@ifc-lite/geometry": minor
+"@ifc-lite/renderer": patch
+---
+
+Fix measure-snap missing all-but-one occurrence of GPU-instanced geometry (#1405). `Scene.getInstancedMeshDataPieces` materializes one `MeshData` per instanced occurrence, all stamped with the same `expressId` but holding distinct world-space positions. `SnapDetector` cached the deduped vertices/edges/valence keyed on `expressId` alone, so the first occurrence's geometry was served for every later one (whose true world positions are elsewhere) and snap fell back to a free-point face hit — vertex/edge snapping lit up on only a single instance while raycast (which is cache-free) kept working on all of them. Materialized occurrences now carry a stable per-occurrence `occurrenceKey` (new optional field on `MeshData`), and the snap geometry cache keys on `occurrenceKey ?? expressId`, so snap works on every occurrence and the cache no longer collides instanced pieces with a flat mesh of the same `expressId`.

--- a/packages/geometry/src/types.ts
+++ b/packages/geometry/src/types.ts
@@ -72,6 +72,15 @@ export interface MeshData {
    *  caches predating local frame). The renderer reconstructs world via a
    *  per-batch model-matrix translate. */
   origin?: [number, number, number];
+  /** Stable key for CPU caches that must distinguish *occurrences* sharing one
+   *  `expressId`. GPU-instanced occurrences are materialized on demand as one
+   *  MeshData per occurrence, all stamped with the same `expressId` but holding
+   *  different world-space `positions` (issue #1405). Caches keyed on `expressId`
+   *  alone (e.g. the measure-snap geometry cache) would collide across them and
+   *  serve the first occurrence's geometry for every later one. When present,
+   *  such caches must key on this instead. Absent for flat meshes (one MeshData
+   *  per `expressId`), where `expressId` is already a sufficient key. */
+  occurrenceKey?: string;
 }
 
 /** A decoded RGBA8 surface texture attached to a mesh (issue #961). */

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -2220,7 +2220,13 @@ export class Scene {
         }
       }
       const color: [number, number, number, number] = [...o.originalColor];
-      out.push({ expressId, positions, normals, indices: tpl.indices, color });
+      // Per-occurrence key so CPU caches that would otherwise key on `expressId`
+      // alone (measure-snap geometry cache) don't collide across occurrences of
+      // this instanced entity, which share `expressId` but hold distinct
+      // world-space positions (issue #1405). templateIndex+byteOffset uniquely
+      // and stably identifies an occurrence within the instance buffers.
+      const occurrenceKey = `${expressId}:inst:${o.templateIndex}:${o.byteOffset}`;
+      out.push({ expressId, positions, normals, indices: tpl.indices, color, occurrenceKey });
     }
     return out.length > 0 ? out : undefined;
   }

--- a/packages/renderer/src/snap-detector-instanced.test.ts
+++ b/packages/renderer/src/snap-detector-instanced.test.ts
@@ -1,0 +1,151 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import type { MeshData } from '@ifc-lite/geometry';
+import type { Intersection } from './raycaster.js';
+import { SnapDetector, SnapType } from './snap-detector.js';
+
+/**
+ * Regression test for issue #1405: measure-snap missed all-but-one occurrence of
+ * GPU-instanced geometry.
+ *
+ * `Scene.getInstancedMeshDataPieces` materializes one MeshData per occurrence, all
+ * sharing the same `expressId` but holding distinct world-space positions. The
+ * snap-geometry cache used to key on `expressId` alone, so the first occurrence's
+ * deduped vertices/edges were served for every later occurrence — whose true world
+ * positions are elsewhere — and snap silently fell back to a free-point face hit.
+ * The fix keys the cache on the per-occurrence `occurrenceKey` when present.
+ */
+
+// Unit cube [0,1]^3, 8 verts / 12 tris. Adjacent faces meet at 90°, so all 12 cube
+// edges survive the cache's coplanar-diagonal filter and are real snap edges.
+const CUBE_INDICES = new Uint32Array([
+  0, 1, 2, 0, 2, 3, // bottom z=0
+  4, 6, 5, 4, 7, 6, // top    z=1
+  0, 5, 1, 0, 4, 5, // front  y=0
+  3, 2, 6, 3, 6, 7, // back   y=1
+  0, 3, 7, 0, 7, 4, // left   x=0
+  1, 5, 6, 1, 6, 2, // right  x=1
+]);
+
+function makeCube(expressId: number, offsetX: number, occurrenceKey?: string): MeshData {
+  const base = [
+    [0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0],
+    [0, 0, 1], [1, 0, 1], [1, 1, 1], [0, 1, 1],
+  ];
+  const positions = new Float32Array(base.length * 3);
+  for (let i = 0; i < base.length; i++) {
+    positions[i * 3] = base[i][0] + offsetX;
+    positions[i * 3 + 1] = base[i][1];
+    positions[i * 3 + 2] = base[i][2];
+  }
+  return {
+    expressId,
+    positions,
+    normals: new Float32Array(positions.length), // cache derives normals from positions
+    indices: CUBE_INDICES,
+    color: [0.5, 0.5, 0.5, 1],
+    occurrenceKey,
+  };
+}
+
+// A raycast hit landing exactly on `corner` of the mesh at meshes[meshIndex].
+function hitAtCorner(meshIndex: number, expressId: number, corner: [number, number, number]): Intersection {
+  return {
+    point: { x: corner[0], y: corner[1], z: corner[2] },
+    normal: { x: -1, y: 0, z: 0 },
+    distance: 100,
+    meshIndex,
+    triangleIndex: 0,
+    expressId,
+    barycentricCoord: { u: 1, v: 0, w: 0 },
+  };
+}
+
+const CAMERA = { position: { x: 0, y: 0, z: 100 }, fov: 50 };
+const SCREEN_H = 800;
+
+test('snap finds a vertex on EVERY instanced occurrence, not just the first (#1405)', () => {
+  // Two occurrences of one instanced entity: same expressId, distinct world placement.
+  const occA = makeCube(100, 0, '100:inst:0:0');
+  const occB = makeCube(100, 10, '100:inst:0:64');
+  const meshes = [occA, occB];
+  const detector = new SnapDetector();
+
+  // Hit occurrence A's corner first — this populates the cache.
+  const snapA = detector.detectSnapTarget(
+    { origin: CAMERA.position, direction: { x: 0, y: 0, z: -1 } },
+    meshes,
+    hitAtCorner(0, 100, [0, 0, 0]),
+    CAMERA,
+    SCREEN_H,
+  );
+  assert.ok(snapA, 'occurrence A should produce a snap target');
+  assert.equal(snapA!.type, SnapType.VERTEX, 'occurrence A should snap to a vertex');
+
+  // Now hit occurrence B's corresponding corner (offset +10 in x). Pre-fix this
+  // returned occurrence A's cached geometry (≥9 units away → no vertex/edge), so it
+  // fell back to a FACE hit. The fix must snap to B's own corner.
+  const snapB = detector.detectSnapTarget(
+    { origin: CAMERA.position, direction: { x: 0, y: 0, z: -1 } },
+    meshes,
+    hitAtCorner(1, 100, [10, 0, 0]),
+    CAMERA,
+    SCREEN_H,
+  );
+  assert.ok(snapB, 'occurrence B should produce a snap target');
+  assert.equal(snapB!.type, SnapType.VERTEX, 'occurrence B should snap to a vertex, not free-point face');
+  assert.ok(
+    Math.abs(snapB!.position.x - 10) < 1e-4,
+    `occurrence B snap must use B's own world geometry (x≈10), got x=${snapB!.position.x}`,
+  );
+});
+
+test('snap is independent of which occurrence populates the cache first (#1405)', () => {
+  const occA = makeCube(100, 0, '100:inst:0:0');
+  const occB = makeCube(100, 10, '100:inst:0:64');
+  const meshes = [occA, occB];
+  const detector = new SnapDetector();
+
+  // Reverse order: hit B first, then A.
+  const snapB = detector.detectSnapTarget(
+    { origin: CAMERA.position, direction: { x: 0, y: 0, z: -1 } },
+    meshes,
+    hitAtCorner(1, 100, [10, 0, 0]),
+    CAMERA,
+    SCREEN_H,
+  );
+  const snapA = detector.detectSnapTarget(
+    { origin: CAMERA.position, direction: { x: 0, y: 0, z: -1 } },
+    meshes,
+    hitAtCorner(0, 100, [0, 0, 0]),
+    CAMERA,
+    SCREEN_H,
+  );
+
+  assert.equal(snapB!.type, SnapType.VERTEX);
+  assert.ok(Math.abs(snapB!.position.x - 10) < 1e-4, `B snap x≈10, got ${snapB!.position.x}`);
+  assert.equal(snapA!.type, SnapType.VERTEX);
+  assert.ok(Math.abs(snapA!.position.x - 0) < 1e-4, `A snap x≈0, got ${snapA!.position.x}`);
+});
+
+test('flat meshes (no occurrenceKey) still snap, keyed by expressId', () => {
+  // Distinct flat meshes with distinct expressIds: the expressId fallback must hold.
+  const a = makeCube(1, 0);
+  const b = makeCube(2, 10);
+  const meshes = [a, b];
+  const detector = new SnapDetector();
+
+  const snap = detector.detectSnapTarget(
+    { origin: CAMERA.position, direction: { x: 0, y: 0, z: -1 } },
+    meshes,
+    hitAtCorner(1, 2, [10, 0, 0]),
+    CAMERA,
+    SCREEN_H,
+  );
+  assert.equal(snap!.type, SnapType.VERTEX);
+  assert.ok(Math.abs(snap!.position.x - 10) < 1e-4, `flat-mesh snap x≈10, got ${snap!.position.x}`);
+});

--- a/packages/renderer/src/snap-detector.ts
+++ b/packages/renderer/src/snap-detector.ts
@@ -89,7 +89,14 @@ export class SnapDetector {
   // Invalidated via clearCache(), which is called by Renderer.destroy() and
   // RaycastEngine.clearCaches(). Callers must invoke clearCaches() when models
   // are loaded/unloaded to prevent stale entries from accumulating.
-  private geometryCache = new Map<number, MeshGeometryCache>();
+  //
+  // Keyed by `mesh.occurrenceKey ?? mesh.expressId`: flat meshes (one per
+  // expressId) key on the numeric id, but GPU-instanced occurrences share one
+  // expressId across many world-space placements, so they must key on their
+  // per-occurrence string key (issue #1405) — keying on expressId alone served
+  // the first occurrence's edges/vertices for every later one, so snap lit up
+  // on a single instance.
+  private geometryCache = new Map<string | number, MeshGeometryCache>();
 
   /**
    * Detect best snap target near cursor
@@ -535,13 +542,16 @@ export class SnapDetector {
    * Get or compute geometry cache for a mesh
    */
   private getGeometryCache(mesh: MeshData): MeshGeometryCache {
-    const cached = this.geometryCache.get(mesh.expressId);
+    // Instanced occurrences share an expressId but hold distinct world-space
+    // positions, so key on the per-occurrence key when present (issue #1405).
+    const key = mesh.occurrenceKey ?? mesh.expressId;
+    const cached = this.geometryCache.get(key);
     if (cached) {
       return cached;
     }
 
     const cache = buildGeometryCache(mesh);
-    this.geometryCache.set(mesh.expressId, cache);
+    this.geometryCache.set(key, cache);
     return cache;
   }
 

--- a/packages/renderer/src/snap-detector.ts
+++ b/packages/renderer/src/snap-detector.ts
@@ -87,8 +87,14 @@ export class SnapDetector {
 
   // Cache for processed mesh geometry (vertices and edges).
   // Invalidated via clearCache(), which is called by Renderer.destroy() and
-  // RaycastEngine.clearCaches(). Callers must invoke clearCaches() when models
-  // are loaded/unloaded to prevent stale entries from accumulating.
+  // RaycastEngine.clearCaches(). The cache holds WORLD-space geometry, and both
+  // keys below stay stable across an in-place geometry edit (a flat mesh's
+  // positions or an instanced occurrence's matrix being mutated by
+  // translateMeshesForEntity / translateInstancedEntity). So callers must invoke
+  // clearCaches() not only on model load/unload but also after any in-place
+  // mutation (gizmo move, numeric move, exploded view) — otherwise snap keeps
+  // serving the pre-edit geometry. This is identical for flat and instanced
+  // meshes; instancing adds no new staleness window.
   //
   // Keyed by `mesh.occurrenceKey ?? mesh.expressId`: flat meshes (one per
   // expressId) key on the numeric id, but GPU-instanced occurrences share one


### PR DESCRIPTION
Fixes #1405.

## Problem
On a group of identical GPU-instanced elements (e.g. a row of bolts), vertex/edge snap hints appeared on **only one** occurrence. Free-point raycast measuring and selection worked on all of them; only the snap targets were missing on the rest.

## Root cause (issue hypothesis (a), confirmed)
`Scene.getInstancedMeshDataPieces` materializes **one `MeshData` per occurrence**, all stamped with the **same `expressId`** but holding distinct world-space `positions` (the per-occurrence matrix is baked in). `SnapDetector` cached the deduped vertices / edges / vertex-valence keyed on `mesh.expressId` alone:

```ts
const cached = this.geometryCache.get(mesh.expressId);
```

So whichever occurrence populated the cache first "owned" the snap geometry for that `expressId`; every later occurrence got the first one's world-space vertices/edges back — nowhere near the hovered point — so `findVertices`/`findEdges` matched nothing and snap fell back to a free-point face hit. Raycast is cache-free, which is why it kept working on all occurrences. The symptom is diagnostic of case (a): the bolts are one instanced entity expanding to multiple occurrences sharing an `expressId`.

## Fix (candidate #1)
- **`@ifc-lite/geometry`**: add an optional `occurrenceKey?: string` to `MeshData` — a stable per-occurrence key for CPU caches that must distinguish occurrences sharing an `expressId`. Additive; absent for flat meshes.
- **`scene.ts`**: `getInstancedMeshDataPieces` stamps `occurrenceKey = \`${expressId}:inst:${templateIndex}:${byteOffset}\`` on each materialized piece (intrinsic to the occurrence, stable across rays).
- **`snap-detector.ts`**: the geometry cache keys on `mesh.occurrenceKey ?? mesh.expressId` (Map widened to `string | number`). This also closes the secondary collision noted in the issue (instanced piece vs flat mesh of the same `expressId`).

Chose candidate #1 over #2 (template-local cache + per-occurrence transform): #2 has the flatter memory profile for huge instanced populations but needs `SnapDetector` to receive the template identity + matrix it doesn't currently get. #1 is the minimal, low-risk fix; the cache stays bounded (lazy, built only for raycast-hit occurrences, cleared on model load/unload via `clearCache()`).

## Tests
New `snap-detector-instanced.test.ts` (3 cases): snap lands on every occurrence, independence from cache-population order, and a flat-mesh control. Reverting the cache-key change makes the two #1405 cases fail (control still passes), so it's a genuine regression guard.

- New test: 3/3 pass.
- Full renderer suite: 169/169 pass.
- `tsc --noEmit` on `@ifc-lite/renderer` (against rebuilt geometry types): clean.

## Acceptance criteria
- [x] Snap (vertex/edge/face-center) lights up on every occurrence of an instanced element.
- [x] Part-to-part / part-edge distance measuring works between any two instances.
- [x] No raycast/snap perf regression (cache is keyed, not disabled; same per-lookup cost).
- [x] Regression test in `@ifc-lite/renderer` covering snap on a multi-occurrence instanced entity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snapping behavior for instanced geometry so each occurrence is handled correctly, instead of reusing a mismatched cached result.
  * Snapping now consistently targets the correct world-space point across multiple instances, even when cache data is loaded from another occurrence first.
  * Snapping continues to work as expected for non-instanced meshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->