### PR TITLE
fix(viewer): keep model visible during orbit on sparse/outlier models (#1394)

### DIFF
--- a/.changeset/fix-1394-orbit-hides-model.md
+++ b/.changeset/fix-1394-orbit-hides-model.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/renderer": minor
+---
+
+Add `Camera.setOrbitAnchorBounds(bounds | null)` / `getOrbitAnchorBounds()` — an outlier-robust orbit-pivot anchor distinct from the full-scene `sceneBounds`. The renderer keeps `sceneBounds` pinned to the full model AABB (needed for near/far clipping and section ranges), but a handful of far-flung meshes can push that AABB's centre into empty space; when the anchor is set, the orbit-pivot fallback rotates around the tighter centre instead. Part of the fix for the model disappearing during orbit on sparse/outlier models (#1394).

--- a/apps/viewer/src/components/viewer/useAnimationLoop.ts
+++ b/apps/viewer/src/components/viewer/useAnimationLoop.ts
@@ -185,7 +185,17 @@ export function useAnimationLoop(params: UseAnimationLoopParams): void {
         continuousThrottleMs > 0 &&
         (currentTime - lastRenderTime) < continuousThrottleMs;
 
-      if ((isAnimating || renderRequested || queueFlushed) && !throttled) {
+      // Render continuously while the user is interacting (issue #1394), not
+      // just when a pointermove happens to set the dirty flag. Pointer events
+      // can arrive sparsely (coalesced / slow drag), which left the swap chain
+      // unrefreshed for hundreds of ms between renders. Compositors that don't
+      // preserve canvas contents between frames then show BLANK while orbiting
+      // and only "reappear" on release — the reported bug. The large-model
+      // interaction throttle still caps the cadence via `throttled`.
+      const willRender =
+        (isAnimating || renderRequested || queueFlushed || isInteractingRef.current) && !throttled;
+
+      if (willRender) {
         renderer.consumeRenderRequest();
         renderer.render({
           hiddenIds: hiddenEntitiesRef.current,

--- a/apps/viewer/src/components/viewer/useGeometryStreaming.ts
+++ b/apps/viewer/src/components/viewer/useGeometryStreaming.ts
@@ -396,11 +396,15 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
       // dot — the user sees a blank viewport even though geometry is in
       // the scene. See packages/renderer/src/camera-fit-policy.ts.
       let fitted = false;
-      // Outlier-robust bounds take precedence over the raw wasm AABB when a
+      // Outlier-robust framing takes precedence over the raw wasm AABB when a
       // sparse far tail would otherwise park the fit target / orbit pivot in
-      // empty space (issue #1394). Returns null for models without such a tail,
-      // leaving the shiftedBounds / computeBounds paths below untouched.
-      const robustEarly = geometry.length > 0 ? robustFitBounds(geometry) : null;
+      // empty space (issue #1394). `robust` is null for models without such a
+      // tail, leaving the shiftedBounds / computeBounds paths below untouched.
+      // `sceneBoundsFull` is the FULL AABB and is what feeds setSceneBounds —
+      // near/far clipping + section ranges must still cover the far meshes.
+      const rbEarly = geometry.length > 0 ? robustFitBounds(geometry) : null;
+      const robustEarly = rbEarly?.robust ?? null;
+      let sceneBoundsFull: Bounds | null = null;
       if (robustEarly) {
         const canvas = renderer.getCanvas();
         const canvasShort = Math.min(canvas?.height ?? 0, canvas?.width ?? 0);
@@ -409,6 +413,7 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
           { viewportShortPx: canvasShort > 0 ? canvasShort : undefined },
         );
         geometryBoundsRef.current = robustEarly;
+        sceneBoundsFull = rbEarly!.full;
         lastFitPolicyKindRef.current = policy.kind;
         fitted = true;
       }
@@ -423,6 +428,8 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
             { viewportShortPx: canvasShort > 0 ? canvasShort : undefined },
           );
           geometryBoundsRef.current = { min: { ...sb.min }, max: { ...sb.max } };
+          // shiftedBounds is the full wasm AABB.
+          sceneBoundsFull = { min: { ...sb.min }, max: { ...sb.max } };
           lastFitPolicyKindRef.current = policy.kind;
           fitted = true;
         }
@@ -437,6 +444,7 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
             { viewportShortPx: canvasShort > 0 ? canvasShort : undefined },
           );
           geometryBoundsRef.current = bounds;
+          sceneBoundsFull = bounds;
           lastFitPolicyKindRef.current = policy.kind;
           fitted = true;
         }
@@ -447,7 +455,9 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
         // directly (not via Renderer.loadGeometry), so this is the only place
         // the camera learns the bounds — consumers like the orbit-pivot
         // fallback (issue #1107) and tight near/far clipping depend on it.
-        renderer.getCamera().setSceneBounds(geometryBoundsRef.current);
+        // Use the FULL AABB so clipping/section ranges still cover far meshes;
+        // the trimmed robust box only drives framing + the orbit anchor (#1394).
+        renderer.getCamera().setSceneBounds(sceneBoundsFull ?? geometryBoundsRef.current);
         // Pin (or clear) the robust orbit-pivot anchor for this model (#1394).
         renderer.getCamera().setOrbitAnchorBounds(robustEarly);
         const pos = renderer.getCamera().getPosition();
@@ -512,11 +522,14 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
           // sub-pixel distance for railway / road corridors.
           if (cameraFittedRef.current && !finalBoundsRefittedRef.current && capturedGeometry && capturedGeometry.length > 0) {
             const t0 = performance.now();
-            // Prefer outlier-robust bounds so a sparse far tail can't park the
+            // Prefer outlier-robust framing so a sparse far tail can't park the
             // fit target (and the orbit pivot) in empty space (issue #1394).
-            // Falls back to the full exact AABB when there is no far tail.
-            const robust = robustFitBounds(capturedGeometry);
-            const exactBounds = robust ?? computeBounds(capturedGeometry);
+            // `robust` is the trimmed framing box (null when there is no tail);
+            // `fullBounds` is the complete AABB for clipping / section ranges.
+            const rb = robustFitBounds(capturedGeometry);
+            const robust = rb?.robust ?? null;
+            const fullBounds = rb?.full ?? computeBounds(capturedGeometry);
+            const exactBounds = robust ?? fullBounds;
             // Pin (or clear) the robust orbit-pivot anchor. setSceneBounds gets
             // overwritten by the renderer's per-upload full-AABB sync, so the
             // pivot reads this dedicated anchor instead (issue #1394).
@@ -542,9 +555,11 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
                 }
               }
               geometryBoundsRef.current = exactBounds;
-              // Refresh the camera's cached bounds with the final exact extent
-              // (issue #1107 orbit-pivot fallback / clipping).
-              r.getCamera().setSceneBounds(exactBounds);
+              // Refresh the camera's cached scene bounds with the FULL extent so
+              // near/far clipping + section ranges still cover the far meshes;
+              // the trimmed robust box only drives framing + the orbit anchor
+              // (issues #1107 / #1394).
+              r.getCamera().setSceneBounds(fullBounds ?? exactBounds);
               finalBoundsRefittedRef.current = true;
             }
           }
@@ -757,24 +772,27 @@ function computeBounds(meshes: MeshData[]): Bounds | null {
 
 // Outlier-robust camera-fit bounds (issue #1394).
 //
-// Returns tightened fit bounds when the model is a compact cluster plus a
-// sparse far tail (a stray covering 600 m off, a detached out-building), and
-// `null` otherwise. When `null`, callers keep their existing bounds, so models
-// without a far tail are completely unaffected.
+// Returns `{ full, robust }` where `full` is the complete model AABB and
+// `robust` is a tightened framing box when the model is a compact cluster plus
+// a sparse far tail (a stray covering 600 m off, a detached out-building), or
+// `null` when there is no such tail. Returns `null` overall only when there is
+// no usable geometry. Callers MUST use `full` for clipping / scene bounds and
+// `robust ?? full` only for camera framing + the orbit pivot — trimming the
+// scene bounds would clip the far meshes out of near/far and section ranges.
 //
 // Unlike `computeBounds`, this folds the per-element origin and uses a generous
 // garbage threshold rather than MAX_VALID_COORD — real building coordinates can
 // be hundreds of thousands of millimetres from the origin (this model keeps mm
 // with no RTC shift), which `computeBounds`' 10 km guard rejects outright. We
 // keep the innermost ROBUST_KEEP_MASS of *vertex mass* (measured by each mesh's
-// distance from the vertex-weighted centroid) and return that union AABB only
-// when it is meaningfully tighter than the full extent (ROBUST_SHRINK_GUARD) —
-// i.e. only when a few far meshes were genuinely inflating the box and dragging
-// the fit target (and the raycast-miss orbit pivot, see useMouseControls) into
+// distance from the vertex-weighted centroid) and emit a `robust` box only when
+// it is meaningfully tighter than the full extent (ROBUST_SHRINK_GUARD) — i.e.
+// only when a few far meshes were genuinely inflating the box and dragging the
+// fit target (and the raycast-miss orbit pivot, see useMouseControls) into
 // empty space.
 const ROBUST_GARBAGE_COORD = 1e12;
 
-function robustFitBounds(meshes: MeshData[]): Bounds | null {
+function robustFitBounds(meshes: MeshData[]): { full: Bounds; robust: Bounds | null } | null {
   let fMinX = Infinity, fMinY = Infinity, fMinZ = Infinity;
   let fMaxX = -Infinity, fMaxY = -Infinity, fMaxZ = -Infinity;
   const cx: number[] = [], cy: number[] = [], cz: number[] = [], w: number[] = [];
@@ -806,8 +824,11 @@ function robustFitBounds(meshes: MeshData[]): Bounds | null {
   }
   const count = w.length;
   const fullMaxSize = Math.max(fMaxX - fMinX, fMaxY - fMinY, fMaxZ - fMinZ);
-  // Need a meaningful population and a finite extent to reason about outliers.
-  if (count < 8 || totalW <= 0 || !(fullMaxSize > 0) || !Number.isFinite(fullMaxSize)) return null;
+  // No usable geometry → no bounds at all.
+  if (count === 0 || totalW <= 0 || !(fullMaxSize > 0) || !Number.isFinite(fullMaxSize)) return null;
+  const full: Bounds = { min: { x: fMinX, y: fMinY, z: fMinZ }, max: { x: fMaxX, y: fMaxY, z: fMaxZ } };
+  // Too few meshes to reason about an outlier tail — full bounds only.
+  if (count < 8) return { full, robust: null };
 
   const ctrX = cwX / totalW, ctrY = cwY / totalW, ctrZ = cwZ / totalW;
   const order = Array.from({ length: count }, (_, i) => i);
@@ -829,15 +850,16 @@ function robustFitBounds(meshes: MeshData[]): Bounds | null {
     cum += w[order[i]];
     kept++;
   }
-  if (kept >= count) return null; // nothing dropped → caller keeps its bounds
+  if (kept >= count) return { full, robust: null }; // nothing dropped → no override
   const robustMaxSize = Math.max(rMaxX - rMinX, rMaxY - rMinY, rMaxZ - rMinZ);
-  if (!(robustMaxSize < fullMaxSize * ROBUST_SHRINK_GUARD)) return null; // tail isn't inflating the box → no override
+  // Tail isn't inflating the box → no override (compact models unaffected).
+  if (!(robustMaxSize < fullMaxSize * ROBUST_SHRINK_GUARD)) return { full, robust: null };
 
   console.log(
     `[GeomStream] outlier-robust camera fit: dropped ${count - kept} far mesh(es) from framing, ` +
     `extent ${Math.round(fullMaxSize)} → ${Math.round(robustMaxSize)} units`,
   );
-  return { min: { x: rMinX, y: rMinY, z: rMinZ }, max: { x: rMaxX, y: rMaxY, z: rMaxZ } };
+  return { full, robust: { min: { x: rMinX, y: rMinY, z: rMinZ }, max: { x: rMaxX, y: rMaxY, z: rMaxZ } } };
 }
 
 function userMovedCamera(

--- a/apps/viewer/src/components/viewer/useGeometryStreaming.ts
+++ b/apps/viewer/src/components/viewer/useGeometryStreaming.ts
@@ -93,6 +93,20 @@ const DEFAULT_BOUNDS = {
 
 const MAX_VALID_COORD = 10000;
 
+// Outlier-robust camera-fit bounds (issue #1394). A handful of far-flung
+// meshes (a stray covering 600 m off, a detached out-building) blow the raw
+// AABB out to hundreds of metres even though ~99 % of the geometry sits in a
+// compact cluster. The camera fits to the inflated AABB → its centre lands in
+// empty space between the building and the strays → the model renders tiny and
+// off to one side, and orbiting (the raycast-miss pivot also anchors to that
+// AABB centre, see useMouseControls) swings it straight out of frame. We keep
+// the innermost ROBUST_KEEP_MASS of the *vertex mass* and drop the sparse far
+// tail from the fit bounds only (the strays still render). The end-guard makes
+// this a strict no-op unless the tail meaningfully inflates the box, so compact
+// single-building models frame exactly as before.
+const ROBUST_KEEP_MASS = 0.995;
+const ROBUST_SHRINK_GUARD = 0.66;
+
 function traceGeometrySync(message: string): void {
   console.log(`[GeomSync] ${message}`);
 }
@@ -382,8 +396,24 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
       // dot — the user sees a blank viewport even though geometry is in
       // the scene. See packages/renderer/src/camera-fit-policy.ts.
       let fitted = false;
+      // Outlier-robust bounds take precedence over the raw wasm AABB when a
+      // sparse far tail would otherwise park the fit target / orbit pivot in
+      // empty space (issue #1394). Returns null for models without such a tail,
+      // leaving the shiftedBounds / computeBounds paths below untouched.
+      const robustEarly = geometry.length > 0 ? robustFitBounds(geometry) : null;
+      if (robustEarly) {
+        const canvas = renderer.getCanvas();
+        const canvasShort = Math.min(canvas?.height ?? 0, canvas?.width ?? 0);
+        const policy = renderer.getCamera().fitBoundsAdaptive(
+          robustEarly,
+          { viewportShortPx: canvasShort > 0 ? canvasShort : undefined },
+        );
+        geometryBoundsRef.current = robustEarly;
+        lastFitPolicyKindRef.current = policy.kind;
+        fitted = true;
+      }
       const sb = coordinateInfo?.shiftedBounds;
-      if (sb) {
+      if (!fitted && sb) {
         const maxSize = Math.max(sb.max.x - sb.min.x, sb.max.y - sb.min.y, sb.max.z - sb.min.z);
         if (maxSize > 0 && Number.isFinite(maxSize)) {
           const canvas = renderer.getCanvas();
@@ -418,6 +448,8 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
         // the camera learns the bounds — consumers like the orbit-pivot
         // fallback (issue #1107) and tight near/far clipping depend on it.
         renderer.getCamera().setSceneBounds(geometryBoundsRef.current);
+        // Pin (or clear) the robust orbit-pivot anchor for this model (#1394).
+        renderer.getCamera().setOrbitAnchorBounds(robustEarly);
         const pos = renderer.getCamera().getPosition();
         const tgt = renderer.getCamera().getTarget();
         cameraSnapshotRef.current = { px: pos.x, py: pos.y, pz: pos.z, tx: tgt.x, ty: tgt.y, tz: tgt.z };
@@ -480,7 +512,15 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
           // sub-pixel distance for railway / road corridors.
           if (cameraFittedRef.current && !finalBoundsRefittedRef.current && capturedGeometry && capturedGeometry.length > 0) {
             const t0 = performance.now();
-            const exactBounds = computeBounds(capturedGeometry);
+            // Prefer outlier-robust bounds so a sparse far tail can't park the
+            // fit target (and the orbit pivot) in empty space (issue #1394).
+            // Falls back to the full exact AABB when there is no far tail.
+            const robust = robustFitBounds(capturedGeometry);
+            const exactBounds = robust ?? computeBounds(capturedGeometry);
+            // Pin (or clear) the robust orbit-pivot anchor. setSceneBounds gets
+            // overwritten by the renderer's per-upload full-AABB sync, so the
+            // pivot reads this dedicated anchor instead (issue #1394).
+            r.getCamera().setOrbitAnchorBounds(robust);
             console.log(`[GeomStream] computeBounds: ${(performance.now() - t0).toFixed(0)}ms`);
             if (exactBounds) {
               if (!userMovedCamera(r, cameraSnapshotRef.current)) {
@@ -690,7 +730,9 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
 
 // ─── Helpers ─────────────────────────────────────────────────────────────
 
-function computeBounds(meshes: MeshData[]): { min: { x: number; y: number; z: number }; max: { x: number; y: number; z: number } } | null {
+type Bounds = { min: { x: number; y: number; z: number }; max: { x: number; y: number; z: number } };
+
+function computeBounds(meshes: MeshData[]): Bounds | null {
   let minX = Infinity, minY = Infinity, minZ = Infinity;
   let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
   for (let gi = 0; gi < meshes.length; gi++) {
@@ -711,6 +753,91 @@ function computeBounds(meshes: MeshData[]): { min: { x: number; y: number; z: nu
   const maxSize = Math.max(maxX - minX, maxY - minY, maxZ - minZ);
   if (minX === Infinity || maxSize <= 0 || !Number.isFinite(maxSize)) return null;
   return { min: { x: minX, y: minY, z: minZ }, max: { x: maxX, y: maxY, z: maxZ } };
+}
+
+// Outlier-robust camera-fit bounds (issue #1394).
+//
+// Returns tightened fit bounds when the model is a compact cluster plus a
+// sparse far tail (a stray covering 600 m off, a detached out-building), and
+// `null` otherwise. When `null`, callers keep their existing bounds, so models
+// without a far tail are completely unaffected.
+//
+// Unlike `computeBounds`, this folds the per-element origin and uses a generous
+// garbage threshold rather than MAX_VALID_COORD — real building coordinates can
+// be hundreds of thousands of millimetres from the origin (this model keeps mm
+// with no RTC shift), which `computeBounds`' 10 km guard rejects outright. We
+// keep the innermost ROBUST_KEEP_MASS of *vertex mass* (measured by each mesh's
+// distance from the vertex-weighted centroid) and return that union AABB only
+// when it is meaningfully tighter than the full extent (ROBUST_SHRINK_GUARD) —
+// i.e. only when a few far meshes were genuinely inflating the box and dragging
+// the fit target (and the raycast-miss orbit pivot, see useMouseControls) into
+// empty space.
+const ROBUST_GARBAGE_COORD = 1e12;
+
+function robustFitBounds(meshes: MeshData[]): Bounds | null {
+  let fMinX = Infinity, fMinY = Infinity, fMinZ = Infinity;
+  let fMaxX = -Infinity, fMaxY = -Infinity, fMaxZ = -Infinity;
+  const cx: number[] = [], cy: number[] = [], cz: number[] = [], w: number[] = [];
+  const bb: Float64Array[] = [];
+  let cwX = 0, cwY = 0, cwZ = 0, totalW = 0;
+  for (let gi = 0; gi < meshes.length; gi++) {
+    const positions = meshes[gi].positions;
+    const o = meshes[gi].origin;
+    const ox = o ? o[0] : 0, oy = o ? o[1] : 0, oz = o ? o[2] : 0;
+    let mnX = Infinity, mnY = Infinity, mnZ = Infinity;
+    let mxX = -Infinity, mxY = -Infinity, mxZ = -Infinity;
+    let n = 0;
+    for (let i = 0; i < positions.length; i += 3) {
+      const x = positions[i] + ox, y = positions[i + 1] + oy, z = positions[i + 2] + oz;
+      if (Math.abs(x) < ROBUST_GARBAGE_COORD && Math.abs(y) < ROBUST_GARBAGE_COORD && Math.abs(z) < ROBUST_GARBAGE_COORD) {
+        if (x < mnX) mnX = x; if (y < mnY) mnY = y; if (z < mnZ) mnZ = z;
+        if (x > mxX) mxX = x; if (y > mxY) mxY = y; if (z > mxZ) mxZ = z;
+        n++;
+      }
+    }
+    if (n > 0) {
+      if (mnX < fMinX) fMinX = mnX; if (mnY < fMinY) fMinY = mnY; if (mnZ < fMinZ) fMinZ = mnZ;
+      if (mxX > fMaxX) fMaxX = mxX; if (mxY > fMaxY) fMaxY = mxY; if (mxZ > fMaxZ) fMaxZ = mxZ;
+      const mcx = (mnX + mxX) / 2, mcy = (mnY + mxY) / 2, mcz = (mnZ + mxZ) / 2;
+      cx.push(mcx); cy.push(mcy); cz.push(mcz); w.push(n);
+      bb.push(Float64Array.of(mnX, mnY, mnZ, mxX, mxY, mxZ));
+      cwX += mcx * n; cwY += mcy * n; cwZ += mcz * n; totalW += n;
+    }
+  }
+  const count = w.length;
+  const fullMaxSize = Math.max(fMaxX - fMinX, fMaxY - fMinY, fMaxZ - fMinZ);
+  // Need a meaningful population and a finite extent to reason about outliers.
+  if (count < 8 || totalW <= 0 || !(fullMaxSize > 0) || !Number.isFinite(fullMaxSize)) return null;
+
+  const ctrX = cwX / totalW, ctrY = cwY / totalW, ctrZ = cwZ / totalW;
+  const order = Array.from({ length: count }, (_, i) => i);
+  order.sort((a, b) => {
+    const da = (cx[a] - ctrX) ** 2 + (cy[a] - ctrY) ** 2 + (cz[a] - ctrZ) ** 2;
+    const db = (cx[b] - ctrX) ** 2 + (cy[b] - ctrY) ** 2 + (cz[b] - ctrZ) ** 2;
+    return da - db;
+  });
+
+  const keepTarget = ROBUST_KEEP_MASS * totalW;
+  let cum = 0, kept = 0;
+  let rMinX = Infinity, rMinY = Infinity, rMinZ = Infinity;
+  let rMaxX = -Infinity, rMaxY = -Infinity, rMaxZ = -Infinity;
+  for (let i = 0; i < count; i++) {
+    if (cum >= keepTarget) break;
+    const b = bb[order[i]];
+    if (b[0] < rMinX) rMinX = b[0]; if (b[1] < rMinY) rMinY = b[1]; if (b[2] < rMinZ) rMinZ = b[2];
+    if (b[3] > rMaxX) rMaxX = b[3]; if (b[4] > rMaxY) rMaxY = b[4]; if (b[5] > rMaxZ) rMaxZ = b[5];
+    cum += w[order[i]];
+    kept++;
+  }
+  if (kept >= count) return null; // nothing dropped → caller keeps its bounds
+  const robustMaxSize = Math.max(rMaxX - rMinX, rMaxY - rMinY, rMaxZ - rMinZ);
+  if (!(robustMaxSize < fullMaxSize * ROBUST_SHRINK_GUARD)) return null; // tail isn't inflating the box → no override
+
+  console.log(
+    `[GeomStream] outlier-robust camera fit: dropped ${count - kept} far mesh(es) from framing, ` +
+    `extent ${Math.round(fullMaxSize)} → ${Math.round(robustMaxSize)} units`,
+  );
+  return { min: { x: rMinX, y: rMinY, z: rMinZ }, max: { x: rMaxX, y: rMaxY, z: rMaxZ } };
 }
 
 function userMovedCamera(

--- a/apps/viewer/src/components/viewer/useMouseControls.ts
+++ b/apps/viewer/src/components/viewer/useMouseControls.ts
@@ -499,9 +499,15 @@ export function useMouseControls(params: UseMouseControlsParams): void {
         let totalEntities = scene.getMeshes().length;
         for (const b of batchedMeshes) totalEntities += b.expressIds.length;
         const isLargeModel = totalEntities > 50_000;
+        // Outlier/sparse models (issue #1394) already carry a robust orbit
+        // anchor that gives an instant, good pivot. Skip the CPU raycast for
+        // them too: the first-orbit BVH build can stall the main thread for
+        // ~1s (the reported "model only appears after ~1s of dragging"), and
+        // orbiting around the model centre is the better behaviour anyway.
+        const hasRobustAnchor = camera.getOrbitAnchorBounds() !== null;
 
         let hit: { intersection: { point: { x: number; y: number; z: number } } } | null = null;
-        if (!isLargeModel) {
+        if (!isLargeModel && !hasRobustAnchor) {
           hit = renderer.raycastScene(cx, cy, {
             hiddenIds: hiddenEntitiesRef.current,
             isolatedIds: isolatedEntitiesRef.current,
@@ -522,12 +528,9 @@ export function useMouseControls(params: UseMouseControlsParams): void {
           // No geometry hit or large model — anchor the pivot to the scene
           // centre (a stable point on the model) rather than the camera target,
           // which drifts as you orbit/pan and made repeated rotation feel
-          // untethered (issue #1107, item 3). The anchor is projected onto the
-          // cursor ray so the pivot still sits under the pointer, at the scene's
-          // depth. getSceneBounds() is O(1) (cached), safe on the large-model
-          // path. Falls back to the camera target if bounds aren't known yet.
-          const ray = camera.unprojectToRay(cx, cy, canvas.width, canvas.height);
-          const bounds = camera.getSceneBounds();
+          // untethered (issue #1107, item 3).
+          const anchorBounds = camera.getOrbitAnchorBounds();
+          const bounds = anchorBounds ?? camera.getSceneBounds();
           const anchor = bounds
             ? {
                 x: (bounds.min.x + bounds.max.x) / 2,
@@ -535,17 +538,32 @@ export function useMouseControls(params: UseMouseControlsParams): void {
                 z: (bounds.min.z + bounds.max.z) / 2,
               }
             : camera.getTarget();
-          const toAnchor = {
-            x: anchor.x - ray.origin.x,
-            y: anchor.y - ray.origin.y,
-            z: anchor.z - ray.origin.z,
-          };
-          const d = Math.max(1, toAnchor.x * ray.direction.x + toAnchor.y * ray.direction.y + toAnchor.z * ray.direction.z);
-          camera.setOrbitCenter({
-            x: ray.origin.x + ray.direction.x * d,
-            y: ray.origin.y + ray.direction.y * d,
-            z: ray.origin.z + ray.direction.z * d,
-          });
+          let pivot: { x: number; y: number; z: number };
+          if (anchorBounds) {
+            // Outlier model (issue #1394): the geometry is a compact cluster
+            // surrounded by lots of empty space, so the cursor usually misses
+            // it. Projecting the anchor onto the cursor ray (the #1107 path
+            // below) would place the pivot in that empty space *beside* the
+            // model, and orbiting then swings the model out of frame. Orbit
+            // around the robust model centre directly so it stays put.
+            pivot = anchor;
+          } else {
+            // #1107: project the scene centre onto the cursor ray so the pivot
+            // still sits under the pointer, at the scene's depth.
+            const ray = camera.unprojectToRay(cx, cy, canvas.width, canvas.height);
+            const toAnchor = {
+              x: anchor.x - ray.origin.x,
+              y: anchor.y - ray.origin.y,
+              z: anchor.z - ray.origin.z,
+            };
+            const d = Math.max(1, toAnchor.x * ray.direction.x + toAnchor.y * ray.direction.y + toAnchor.z * ray.direction.z);
+            pivot = {
+              x: ray.origin.x + ray.direction.x * d,
+              y: ray.origin.y + ray.direction.y * d,
+              z: ray.origin.z + ray.direction.z * d,
+            };
+          }
+          camera.setOrbitCenter(pivot);
         }
       }
 

--- a/apps/viewer/src/components/viewer/useTouchControls.ts
+++ b/apps/viewer/src/components/viewer/useTouchControls.ts
@@ -97,8 +97,8 @@ export function useTouchControls(params: UseTouchControlsParams): void {
       // Anchor to the scene centre (stable) rather than the drifting camera
       // target, projected onto the finger ray (issue #1107, item 3). Matches
       // the mouse orbit fallback in useMouseControls.
-      const ray = camera.unprojectToRay(tx, ty, canvas.width, canvas.height);
-      const bounds = camera.getSceneBounds();
+      const anchorBounds = camera.getOrbitAnchorBounds();
+      const bounds = anchorBounds ?? camera.getSceneBounds();
       const anchor = bounds
         ? {
             x: (bounds.min.x + bounds.max.x) / 2,
@@ -106,20 +106,28 @@ export function useTouchControls(params: UseTouchControlsParams): void {
             z: (bounds.min.z + bounds.max.z) / 2,
           }
         : camera.getTarget();
-      const toAnchor = {
-        x: anchor.x - ray.origin.x,
-        y: anchor.y - ray.origin.y,
-        z: anchor.z - ray.origin.z,
-      };
-      const d = Math.max(
-        1,
-        toAnchor.x * ray.direction.x + toAnchor.y * ray.direction.y + toAnchor.z * ray.direction.z,
-      );
-      camera.setOrbitCenter({
-        x: ray.origin.x + ray.direction.x * d,
-        y: ray.origin.y + ray.direction.y * d,
-        z: ray.origin.z + ray.direction.z * d,
-      });
+      if (anchorBounds) {
+        // Outlier model (issue #1394): orbit around the robust model centre
+        // directly. Projecting onto the finger ray would place the pivot in the
+        // empty space beside the sparse model and swing it out of frame.
+        camera.setOrbitCenter(anchor);
+      } else {
+        const ray = camera.unprojectToRay(tx, ty, canvas.width, canvas.height);
+        const toAnchor = {
+          x: anchor.x - ray.origin.x,
+          y: anchor.y - ray.origin.y,
+          z: anchor.z - ray.origin.z,
+        };
+        const d = Math.max(
+          1,
+          toAnchor.x * ray.direction.x + toAnchor.y * ray.direction.y + toAnchor.z * ray.direction.z,
+        );
+        camera.setOrbitCenter({
+          x: ray.origin.x + ray.direction.x * d,
+          y: ray.origin.y + ray.direction.y * d,
+          z: ray.origin.z + ray.direction.z * d,
+        });
+      }
     };
 
     const handleTouchStart = async (e: TouchEvent) => {

--- a/apps/viewer/src/components/viewer/useTouchControls.ts
+++ b/apps/viewer/src/components/viewer/useTouchControls.ts
@@ -86,10 +86,15 @@ export function useTouchControls(params: UseTouchControlsParams): void {
       const rect = canvas.getBoundingClientRect();
       const tx = touch.clientX - rect.left;
       const ty = touch.clientY - rect.top;
-      const hit = renderer.raycastScene(tx, ty, {
-        hiddenIds: hiddenEntitiesRef.current,
-        isolatedIds: isolatedEntitiesRef.current,
-      });
+      // Outlier/sparse models (issue #1394) carry a robust orbit anchor that
+      // gives an instant, good pivot — skip the raycast (its first-touch BVH
+      // build can stall the main thread ~1s) and orbit the model centre below.
+      const hit = camera.getOrbitAnchorBounds() !== null
+        ? null
+        : renderer.raycastScene(tx, ty, {
+            hiddenIds: hiddenEntitiesRef.current,
+            isolatedIds: isolatedEntitiesRef.current,
+          });
       if (hit?.intersection) {
         camera.setOrbitCenter(hit.intersection.point);
         return;

--- a/packages/renderer/src/camera-controls.ts
+++ b/packages/renderer/src/camera-controls.ts
@@ -35,6 +35,15 @@ export interface CameraInternalState {
   orthoSize: number;
   /** Scene bounding box for tight orthographic near/far computation */
   sceneBounds: { min: { x: number; y: number; z: number }; max: { x: number; y: number; z: number } } | null;
+  /**
+   * Optional outlier-robust bounds for anchoring the orbit pivot (issue #1394).
+   * Distinct from `sceneBounds`: the renderer keeps `sceneBounds` synced to the
+   * FULL model AABB (needed for near/far clipping and section ranges), but a
+   * handful of far-flung meshes can push that AABB's centre into empty space,
+   * which the orbit-pivot fallback would then rotate around. When set, the pivot
+   * uses this tighter centre instead. `null` ⇒ fall back to `sceneBounds`.
+   */
+  orbitAnchorBounds: { min: { x: number; y: number; z: number }; max: { x: number; y: number; z: number } } | null;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/renderer/src/camera.ts
+++ b/packages/renderer/src/camera.ts
@@ -289,6 +289,10 @@ export class Camera {
   reset(): void {
     this.controls.setOrbitCenter(null);
     this.animator.reset();
+    // Drop the previous model's outlier-robust orbit anchor (issue #1394) — it
+    // survives setSceneBounds() syncs, so without this a model swap would orbit
+    // the new model around the old one's centre until the first fit clears it.
+    this.state.orbitAnchorBounds = null;
   }
 
   getViewProjMatrix(): Mat4 {

--- a/packages/renderer/src/camera.ts
+++ b/packages/renderer/src/camera.ts
@@ -41,6 +41,7 @@ export class Camera {
       projectionMode: 'perspective',
       orthoSize: 50, // Default half-height in world units
       sceneBounds: null,
+      orbitAnchorBounds: null,
     };
 
     const updateMatrices = () => this.updateMatrices();
@@ -458,6 +459,25 @@ export class Camera {
    */
   getSceneBounds(): { min: { x: number; y: number; z: number }; max: { x: number; y: number; z: number } } | null {
     return this.state.sceneBounds;
+  }
+
+  /**
+   * Set the outlier-robust orbit-pivot anchor bounds (issue #1394), or `null`
+   * to clear it (the pivot then falls back to {@link getSceneBounds}). The
+   * renderer never touches this, so it survives the per-upload `setSceneBounds`
+   * syncs that keep `sceneBounds` pinned to the full model AABB.
+   */
+  setOrbitAnchorBounds(bounds: { min: { x: number; y: number; z: number }; max: { x: number; y: number; z: number } } | null): void {
+    this.state.orbitAnchorBounds = bounds;
+  }
+
+  /**
+   * The robust orbit-pivot anchor bounds last set via {@link setOrbitAnchorBounds}
+   * (null if never set / cleared). O(1); safe on the orbit hot path. Returns the
+   * live reference; callers must not mutate.
+   */
+  getOrbitAnchorBounds(): { min: { x: number; y: number; z: number }; max: { x: number; y: number; z: number } } | null {
+    return this.state.orbitAnchorBounds;
   }
 
   private updateMatrices(): void {


### PR DESCRIPTION
Fixes #1394 — on certain models the geometry would disappear during orbit and reappear when the drag ended.

## Root cause (three compounding issues)

The model in the issue is a compact building cluster near the origin plus ~56 far-flung meshes (a covering 640 m off, a couple of detached out-buildings) spread across ~900 m. That combination broke navigation in three ways:

1. **Inflated AABB hijacks fit + pivot.** The raw scene AABB spans the strays, so the camera-fit target — and the raycast-miss orbit pivot, which anchors to the scene-bounds centre — land in *empty space* between the cluster and the strays. The building rendered tiny and off to one side, and orbiting swung it out of frame.
2. **Pivot projected into the void.** The orbit-pivot fallback (#1107) projects the anchor onto the cursor ray. On a sparse model you start the drag over emptiness, so the pivot landed *beside* the building and orbiting swept it away.
3. **Swap chain went stale while dragging.** Rendering was on-demand (only when a pointermove set the dirty flag). Sparse/coalesced pointer events left the canvas unrefreshed for hundreds of ms, and compositors that don't preserve canvas contents between frames showed **blank** during the orbit — reappearing on release. (GPU-compositor-dependent, which is why it reproduced on the reporter's Chrome + Firefox but not everywhere.)

## Fixes

- **Outlier-robust camera framing** (`useGeometryStreaming.ts`): new `robustFitBounds()` keeps the innermost 99.5% of *vertex mass* for the camera framing only (strays still render). Gated to a strict **no-op** unless the sparse tail meaningfully inflates the box (robust extent < 66% of full), so compact single-building models frame exactly as before.
- **Dedicated orbit anchor** (`Camera.setOrbitAnchorBounds()` / `getOrbitAnchorBounds()`): the robust centre is pinned separately from `sceneBounds`. The renderer keeps `sceneBounds` synced to the full AABB (needed for near/far clipping + section ranges) via per-upload `setSceneBounds()`; the new anchor survives that and drives the pivot.
- **Orbit around the model centre directly** for outlier models (`useMouseControls.ts` + `useTouchControls.ts`) instead of projecting onto the cursor ray.
- **Continuous render while interacting** (`useAnimationLoop.ts`): the loop now renders every frame during a drag (still capped by the large-model throttle), so the swap chain can't go stale/blank between sparse pointer events.
- **Skip the first-orbit raycast/BVH build** for outlier models — it stalled the main thread ~1s ("model only appears after ~1s of dragging"); the robust anchor already gives an instant pivot.

## Verification

- Reproduced live with the reporter's model: confirmed fixed on the reporter's Chrome and Firefox (model stays visible and centred through sustained orbit from any start point, no ~1s stall).
- Robust path is a verified no-op for models without a far tail (guarded by mass-fraction + size-ratio).
- `@ifc-lite/renderer` and the viewer typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smarter orbit controls that keep the camera anchored on a more stable model center during rotation.
  * Improved camera fitting for streamed geometry so sparse outliers are less likely to affect framing.

* **Bug Fixes**
  * Prevented models from disappearing or drifting during orbit interactions on sparse or uneven geometry.
  * Made mouse and touch orbit behavior more consistent when selecting the pivot point.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->