### PR TITLE
fix(export): valid edited property sets — retain shared atoms + stamp OwnerHistory (#1413)

### DIFF
--- a/.changeset/shared-property-atom-skip.md
+++ b/.changeset/shared-property-atom-skip.md
@@ -11,3 +11,9 @@ any atom still referenced by a surviving property set / element quantity; the ed
 emits its replacement with the new value while shared atoms stay for the psets that keep their
 original. Fixes both single-model and merged export (the merged exporter bakes through
 `StepExporter`). ([#1413](https://github.com/LTplus-AG/ifc-lite/issues/1413))
+
+Also stamp generated `IfcPropertySet` / `IfcRelDefinesByProperties` / `IfcElementQuantity`
+entities (emitted when a property/quantity is edited) with an existing `IfcOwnerHistory`
+instead of `$`. OwnerHistory is optional in IFC4 but **mandatory** in IFC2X3, so the previous
+`$` produced an invalid IFC2X3 file that strict readers (e.g. BIM Vision) reject. The exporter
+now reuses the model's owner history (falling back to `$` only when the file has none).

--- a/.changeset/shared-property-atom-skip.md
+++ b/.changeset/shared-property-atom-skip.md
@@ -1,0 +1,13 @@
+---
+"@ifc-lite/export": patch
+---
+
+Stop dropping shared property atoms when a property is edited. Editing a property replaces its
+property set and skips that set's member atoms wholesale; because exporters deduplicate shared
+`Pset_*Common` atoms (e.g. one `IsExternal` `IfcPropertySingleValue` referenced by dozens of
+psets), this orphaned every other pset referencing the atom, leaving dangling `#id` references —
+an invalid IFC that strict readers (e.g. BIM Vision) refuse to open. `StepExporter` now retains
+any atom still referenced by a surviving property set / element quantity; the edited pset still
+emits its replacement with the new value while shared atoms stay for the psets that keep their
+original. Fixes both single-model and merged export (the merged exporter bakes through
+`StepExporter`). ([#1413](https://github.com/LTplus-AG/ifc-lite/issues/1413))

--- a/packages/export/src/owner-history.test.ts
+++ b/packages/export/src/owner-history.test.ts
@@ -10,6 +10,15 @@ import { StepExporter } from './step-exporter.js';
 
 const decode = (b: Uint8Array) => new TextDecoder().decode(b);
 
+/** Referenced `#N` tokens that have no `#N=` definition. */
+function danglingRefs(text: string): number[] {
+  const defined = new Set<number>();
+  for (const m of text.matchAll(/(^|\n)\s*#(\d+)\s*=/g)) defined.add(+m[2]);
+  const refs = new Set<number>();
+  for (const m of text.matchAll(/#(\d+)/g)) refs.add(+m[1]);
+  return [...refs].filter(id => !defined.has(id)).sort((a, b) => a - b);
+}
+
 // Minimal IFC2X3 model: a wall with Pset_WallCommon, all roots carrying the
 // shared owner history #5 (mandatory in IFC2X3).
 const IFC = `ISO-10303-21;
@@ -47,5 +56,49 @@ describe('StepExporter — generated psets carry OwnerHistory (IFC2X3)', () => {
     // No generated pset/rel left an empty ($) owner history.
     expect(out).not.toMatch(/=IFCPROPERTYSET\('.{22}',\$,/);
     expect(out).not.toMatch(/=IFCRELDEFINESBYPROPERTIES\('.{22}',\$,/);
+  });
+});
+
+// Two owner histories — #5 (first in the file) and #6 — modelling a federated /
+// merged export. The edited wall #10 carries the SECOND one (#6). A generated
+// pset must inherit the host element's OWN owner history (#6), not the file's
+// first owner history (#5); stamping #5 mis-attributes the pset to the wrong
+// source model. Both owner histories are emitted (IfcOwnerHistory is always kept
+// as infrastructure), so this is an attribution check, not a dangling-ref one.
+const IFC_MULTI_OH = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t.ifc','',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0proj00000000000000000',$,'P',$,$,$,$,$,$);
+#2=IFCORGANIZATION($,'Org',$,$,$);
+#3=IFCPERSONANDORGANIZATION($,#2,$);
+#4=IFCAPPLICATION(#2,'1','app','app');
+#5=IFCOWNERHISTORY(#3,#4,$,.ADDED.,$,$,$,0);
+#6=IFCOWNERHISTORY(#3,#4,$,.MODIFIED.,$,$,$,1);
+#10=IFCWALL('0wall10000000000000000',#6,'W',$,$,$,$,$,$);
+#20=IFCPROPERTYSINGLEVALUE('IsExternal',$,IFCBOOLEAN(.F.),$);
+#30=IFCPROPERTYSET('0psetB0000000000000000',#6,'Pset_WallCommon',$,(#20));
+#40=IFCRELDEFINESBYPROPERTIES('0relB00000000000000000',#6,$,$,(#10),#30);
+ENDSEC;
+END-ISO-10303-21;`;
+
+describe('StepExporter — generated psets inherit the host element owner history', () => {
+  it('stamps the edited element own owner history, not the file first one', async () => {
+    const store = await new IfcParser().parseColumnar(new TextEncoder().encode(IFC_MULTI_OH).buffer, { disableWorkerScan: true });
+    const view = new MutablePropertyView(null, 'm');
+    view.setOnDemandExtractor((id: number) => extractPropertiesOnDemand(store, id));
+    view.setProperty(10, 'Pset_WallCommon', 'IsExternal', true, PropertyValueType.Boolean);
+
+    const out = decode(new StepExporter(store, view).export({ schema: 'IFC4', applyMutations: true }).content);
+
+    // Wall #10 owns owner history #6 — the regenerated pset + rel must carry it,
+    // not the file's first owner history #5.
+    expect(out).toMatch(/=IFCPROPERTYSET\('.{22}',#6,'Pset_WallCommon'/);
+    expect(out).toMatch(/=IFCRELDEFINESBYPROPERTIES\('.{22}',#6,/);
+    expect(out).not.toMatch(/=IFCPROPERTYSET\('.{22}',#5,/);
+    expect(danglingRefs(out)).toEqual([]);
   });
 });

--- a/packages/export/src/owner-history.test.ts
+++ b/packages/export/src/owner-history.test.ts
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { IfcParser, extractPropertiesOnDemand } from '@ifc-lite/parser';
+import { MutablePropertyView } from '@ifc-lite/mutations';
+import { PropertyValueType } from '@ifc-lite/data';
+import { StepExporter } from './step-exporter.js';
+
+const decode = (b: Uint8Array) => new TextDecoder().decode(b);
+
+// Minimal IFC2X3 model: a wall with Pset_WallCommon, all roots carrying the
+// shared owner history #5 (mandatory in IFC2X3).
+const IFC = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t.ifc','',(''),(''),'','','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#1=IFCPERSON($,'','U',$,$,$,$,$);
+#2=IFCORGANIZATION($,'Org',$,$,$);
+#3=IFCPERSONANDORGANIZATION(#1,#2,$);
+#4=IFCAPPLICATION(#2,'1','app','app');
+#5=IFCOWNERHISTORY(#3,#4,$,.ADDED.,$,$,$,0);
+#10=IFCWALL('0wall00000000000000000',#5,'W',$,$,$,$,$);
+#20=IFCPROPERTYSINGLEVALUE('IsExternal',$,IFCBOOLEAN(.F.),$);
+#30=IFCPROPERTYSET('0pset00000000000000000',#5,'Pset_WallCommon',$,(#20));
+#40=IFCRELDEFINESBYPROPERTIES('0rel000000000000000000',#5,$,$,(#10),#30);
+ENDSEC;
+END-ISO-10303-21;`;
+
+describe('StepExporter — generated psets carry OwnerHistory (IFC2X3)', () => {
+  it('stamps generated IfcPropertySet/IfcRelDefinesByProperties with an existing owner history', async () => {
+    const store = await new IfcParser().parseColumnar(new TextEncoder().encode(IFC).buffer, { disableWorkerScan: true });
+    const view = new MutablePropertyView(null, 'm');
+    view.setOnDemandExtractor((id: number) => extractPropertiesOnDemand(store, id));
+    view.setProperty(10, 'Pset_WallCommon', 'IsExternal', true, PropertyValueType.Boolean);
+
+    const out = decode(new StepExporter(store, view).export({ schema: 'IFC2X3', applyMutations: true }).content);
+
+    // The regenerated pset + rel must reference the model's owner history (#5),
+    // not `$` — OwnerHistory is mandatory in IFC2X3.
+    expect(out).toMatch(/=IFCPROPERTYSET\('.{22}',#5,'Pset_WallCommon'/);
+    expect(out).toMatch(/=IFCRELDEFINESBYPROPERTIES\('.{22}',#5,/);
+    // No generated pset/rel left an empty ($) owner history.
+    expect(out).not.toMatch(/=IFCPROPERTYSET\('.{22}',\$,/);
+    expect(out).not.toMatch(/=IFCRELDEFINESBYPROPERTIES\('.{22}',\$,/);
+  });
+});

--- a/packages/export/src/shared-atom.test.ts
+++ b/packages/export/src/shared-atom.test.ts
@@ -19,6 +19,23 @@ function danglingRefs(text: string): number[] {
   return [...refs].filter(id => !defined.has(id)).sort((a, b) => a - b);
 }
 
+/** Resolve `Pset.<prop>` to the IFCLABEL value its atom carries in the export. */
+function propertyValue(text: string, psetName: string, propName: string): string | null {
+  const byId = new Map<number, string>();
+  for (const m of text.matchAll(/(^|\n)\s*#(\d+)\s*=([^\n]*)/g)) byId.set(+m[2], m[3]);
+  const psetLine = [...byId.values()].find(
+    l => new RegExp(`^IFCPROPERTYSET\\('.*?',[^,]*,'${psetName}'`).test(l),
+  );
+  if (!psetLine) return null;
+  const atomIds = [...psetLine.matchAll(/#(\d+)/g)].map(m => +m[1]);
+  for (const id of atomIds) {
+    const atom = byId.get(id);
+    const m = atom?.match(/^IFCPROPERTYSINGLEVALUE\('([^']*)',[^,]*,IFCLABEL\('([^']*)'\)/);
+    if (m && m[1] === propName) return m[2];
+  }
+  return null;
+}
+
 // A wall with two property sets that SHARE one IfcPropertySingleValue (#20),
 // mirroring how IFC exporters deduplicate Pset_*Common atoms (e.g. IsExternal).
 const IFC = `ISO-10303-21;
@@ -55,9 +72,11 @@ describe('StepExporter — shared property atoms (issue #1413)', () => {
     // No dangling refs — the shared atom #20 is retained for Pset_B.
     expect(danglingRefs(out)).toEqual([]);
     expect(out).toMatch(/(^|\n)\s*#20\s*=/);
-    // Pset_B is untouched and still references the original shared value.
-    expect(out).toContain("IFCLABEL('orig')");
-    // The edit is applied (new value present).
-    expect(out).toContain('edited');
+    // The edit lands on Pset_A.OnlyA specifically...
+    expect(propertyValue(out, 'Pset_A', 'OnlyA')).toBe('edited');
+    // ...while the untouched Pset_B keeps the original shared value, and the
+    // shared atom carries its original value (not the edit).
+    expect(propertyValue(out, 'Pset_B', 'Shared')).toBe('orig');
+    expect(propertyValue(out, 'Pset_A', 'Shared')).toBe('orig');
   });
 });

--- a/packages/export/src/shared-atom.test.ts
+++ b/packages/export/src/shared-atom.test.ts
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { IfcParser, extractPropertiesOnDemand } from '@ifc-lite/parser';
+import { MutablePropertyView } from '@ifc-lite/mutations';
+import { PropertyValueType } from '@ifc-lite/data';
+import { StepExporter } from './step-exporter.js';
+
+const decode = (b: Uint8Array) => new TextDecoder().decode(b);
+
+/** Referenced `#N` tokens that have no `#N=` definition. */
+function danglingRefs(text: string): number[] {
+  const defined = new Set<number>();
+  for (const m of text.matchAll(/(^|\n)\s*#(\d+)\s*=/g)) defined.add(+m[2]);
+  const refs = new Set<number>();
+  for (const m of text.matchAll(/#(\d+)/g)) refs.add(+m[1]);
+  return [...refs].filter(id => !defined.has(id)).sort((a, b) => a - b);
+}
+
+// A wall with two property sets that SHARE one IfcPropertySingleValue (#20),
+// mirroring how IFC exporters deduplicate Pset_*Common atoms (e.g. IsExternal).
+const IFC = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t.ifc','',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0proj00000000000000000',$,'P',$,$,$,$,$,$);
+#10=IFCWALL('0wall00000000000000000',$,'W',$,$,$,$,$,$);
+#20=IFCPROPERTYSINGLEVALUE('Shared',$,IFCLABEL('orig'),$);
+#21=IFCPROPERTYSINGLEVALUE('OnlyA',$,IFCLABEL('a'),$);
+#22=IFCPROPERTYSINGLEVALUE('OnlyB',$,IFCLABEL('b'),$);
+#30=IFCPROPERTYSET('0psetA0000000000000000',$,'Pset_A',$,(#20,#21));
+#31=IFCPROPERTYSET('0psetB0000000000000000',$,'Pset_B',$,(#20,#22));
+#40=IFCRELDEFINESBYPROPERTIES('0relA00000000000000000',$,$,$,(#10),#30);
+#41=IFCRELDEFINESBYPROPERTIES('0relB00000000000000000',$,$,$,(#10),#31);
+ENDSEC;
+END-ISO-10303-21;`;
+
+describe('StepExporter — shared property atoms (issue #1413)', () => {
+  it('keeps a shared atom when only one of its psets is edited', async () => {
+    const parser = new IfcParser();
+    const store = await parser.parseColumnar(new TextEncoder().encode(IFC).buffer, { disableWorkerScan: true });
+
+    const view = new MutablePropertyView(null, 'm');
+    view.setOnDemandExtractor((id: number) => extractPropertiesOnDemand(store, id));
+    // Edit a property in Pset_A only; #20 is shared with Pset_B.
+    view.setProperty(10, 'Pset_A', 'OnlyA', 'edited', PropertyValueType.Label);
+
+    const out = decode(new StepExporter(store, view).export({ schema: 'IFC4', applyMutations: true }).content);
+
+    // No dangling refs — the shared atom #20 is retained for Pset_B.
+    expect(danglingRefs(out)).toEqual([]);
+    expect(out).toMatch(/(^|\n)\s*#20\s*=/);
+    // Pset_B is untouched and still references the original shared value.
+    expect(out).toContain("IFCLABEL('orig')");
+    // The edit is applied (new value present).
+    expect(out).toContain('edited');
+  });
+});

--- a/packages/export/src/shared-atom.test.ts
+++ b/packages/export/src/shared-atom.test.ts
@@ -19,12 +19,16 @@ function danglingRefs(text: string): number[] {
   return [...refs].filter(id => !defined.has(id)).sort((a, b) => a - b);
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /** Resolve `Pset.<prop>` to the IFCLABEL value its atom carries in the export. */
 function propertyValue(text: string, psetName: string, propName: string): string | null {
   const byId = new Map<number, string>();
   for (const m of text.matchAll(/(^|\n)\s*#(\d+)\s*=([^\n]*)/g)) byId.set(+m[2], m[3]);
   const psetLine = [...byId.values()].find(
-    l => new RegExp(`^IFCPROPERTYSET\\('.*?',[^,]*,'${psetName}'`).test(l),
+    l => new RegExp(`^IFCPROPERTYSET\\('.*?',[^,]*,'${escapeRegExp(psetName)}'`).test(l),
   );
   if (!psetLine) return null;
   const atomIds = [...psetLine.matchAll(/#(\d+)/g)].map(m => +m[1]);

--- a/packages/export/src/step-exporter.ts
+++ b/packages/export/src/step-exporter.ts
@@ -540,6 +540,13 @@ export class StepExporter {
       );
     }
 
+    // A modified pset is replaced wholesale, which skips ALL of its member atoms.
+    // But IFC exporters deduplicate identical Pset_*Common atoms (e.g. one
+    // IsExternal IfcPropertySingleValue shared by dozens of psets), so skipping a
+    // shared atom would orphan every OTHER pset that still references it, leaving
+    // dangling refs and an invalid file. Keep any atom a surviving container needs.
+    this.retainSharedAtoms(skipPropertySetIds, allowedEntityIds);
+
     // Export original entities from source buffer, SKIPPING modified property sets
     if (!options.deltaOnly && this.dataStore.source) {
       const source = this.dataStore.source;
@@ -1268,6 +1275,38 @@ export class StepExporter {
   /**
    * Get IDs of properties in a property set
    */
+  /**
+   * Un-skip property/quantity atoms that a surviving (non-skipped, and — under
+   * visible-only export — still-included) IfcPropertySet / IfcElementQuantity
+   * still references.
+   *
+   * When a property is edited, the modified pset is replaced and its member atoms
+   * are added to `skipIds` wholesale. Because exporters deduplicate shared
+   * Pset_*Common atoms (e.g. a single IsExternal / IsLoadBearing value referenced
+   * by many psets), that wholesale skip can drop an atom another pset still needs.
+   * This pass restores any such atom: the edited pset still emits its replacement
+   * with the new value, while the shared atom stays for the psets that keep their
+   * original value.
+   */
+  private retainSharedAtoms(skipIds: Set<number>, allowedEntityIds: Set<number> | null): void {
+    if (skipIds.size === 0) return;
+    const byType = this.dataStore.entityIndex.byType;
+    const containerIds = [
+      ...(byType.get('IFCPROPERTYSET') ?? []),
+      ...(byType.get('IFCELEMENTQUANTITY') ?? []),
+    ];
+    for (const containerId of containerIds) {
+      // Skipped containers are being dropped/replaced — their atoms may go.
+      if (skipIds.has(containerId)) continue;
+      // Under visible-only export a container outside the closure is not emitted,
+      // so it cannot keep an atom alive.
+      if (allowedEntityIds !== null && !allowedEntityIds.has(containerId)) continue;
+      for (const atomId of this.getPropertyIdsInSet(containerId)) {
+        skipIds.delete(atomId);
+      }
+    }
+  }
+
   private getPropertyIdsInSet(psetId: number): number[] {
     const entityRef = this.dataStore.entityIndex.byId.get(psetId);
     if (!entityRef || !this.dataStore.source) return [];

--- a/packages/export/src/step-exporter.ts
+++ b/packages/export/src/step-exporter.ts
@@ -130,6 +130,8 @@ export class StepExporter {
   private mutationView: MutablePropertyView | null;
   private nextExpressId: number;
   private entityExtractor: EntityExtractor | null;
+  /** Lazily-resolved `#id` of an existing IfcOwnerHistory (or `$`). */
+  private ownerHistoryRefCache: string | undefined;
 
   constructor(dataStore: IfcDataStore, mutationView?: MutablePropertyView) {
     this.dataStore = dataStore;
@@ -823,6 +825,21 @@ export class StepExporter {
   }
 
   /**
+   * Resolve a STEP reference to an existing IfcOwnerHistory, used to stamp the
+   * IfcPropertySet / IfcRelDefinesByProperties / IfcElementQuantity entities we
+   * generate for mutations. OwnerHistory is optional in IFC4 but MANDATORY in
+   * IFC2X3 (IfcRoot.OwnerHistory), so emitting `$` yields an invalid IFC2X3 file
+   * that strict readers (e.g. BIM Vision) reject. Reuse any existing owner
+   * history in the model; fall back to `$` only when the file has none.
+   */
+  private resolveOwnerHistoryRef(): string {
+    if (this.ownerHistoryRefCache !== undefined) return this.ownerHistoryRefCache;
+    const ids = this.dataStore.entityIndex.byType.get('IFCOWNERHISTORY');
+    this.ownerHistoryRefCache = ids && ids.length > 0 ? `#${ids[0]}` : '$';
+    return this.ownerHistoryRefCache;
+  }
+
+  /**
    * Generate STEP entities for property sets
    */
   private generatePropertySetEntities(
@@ -859,8 +876,8 @@ export class StepExporter {
       const propRefs = propertyIds.map(id => `#${id}`).join(',');
       const globalId = this.generateGlobalId();
 
-      // #ID=IFCPROPERTYSET('GlobalId',$,'Name',$,(#props));
-      const psetLine = `#${psetId}=IFCPROPERTYSET('${globalId}',$,'${escapeStepString(pset.name)}',$,(${propRefs}));`;
+      // #ID=IFCPROPERTYSET('GlobalId',#ownerHistory,'Name',$,(#props));
+      const psetLine = `#${psetId}=IFCPROPERTYSET('${globalId}',${this.resolveOwnerHistoryRef()},'${escapeStepString(pset.name)}',$,(${propRefs}));`;
       lines.push(psetLine);
 
       if (typeOwnedPsetNames?.has(pset.name)) {
@@ -871,8 +888,8 @@ export class StepExporter {
         count++;
 
         const relGlobalId = this.generateGlobalId();
-        // #ID=IFCRELDEFINESBYPROPERTIES('GlobalId',$,$,$,(#entity),#pset);
-        const relLine = `#${relId}=IFCRELDEFINESBYPROPERTIES('${relGlobalId}',$,$,$,(#${entityId}),#${psetId});`;
+        // #ID=IFCRELDEFINESBYPROPERTIES('GlobalId',#ownerHistory,$,$,(#entity),#pset);
+        const relLine = `#${relId}=IFCRELDEFINESBYPROPERTIES('${relGlobalId}',${this.resolveOwnerHistoryRef()},$,$,(#${entityId}),#${psetId});`;
         lines.push(relLine);
       }
     }
@@ -912,8 +929,8 @@ export class StepExporter {
       const quantRefs = quantityIds.map(id => `#${id}`).join(',');
       const globalId = this.generateGlobalId();
 
-      // #ID=IFCELEMENTQUANTITY('GlobalId',$,'Name',$,$,(#quants));
-      const qsetLine = `#${qsetId}=IFCELEMENTQUANTITY('${globalId}',$,'${escapeStepString(qset.name)}',$,$,(${quantRefs}));`;
+      // #ID=IFCELEMENTQUANTITY('GlobalId',#ownerHistory,'Name',$,$,(#quants));
+      const qsetLine = `#${qsetId}=IFCELEMENTQUANTITY('${globalId}',${this.resolveOwnerHistoryRef()},'${escapeStepString(qset.name)}',$,$,(${quantRefs}));`;
       lines.push(qsetLine);
 
       // Create IfcRelDefinesByProperties to link qset to entity
@@ -921,7 +938,7 @@ export class StepExporter {
       count++;
 
       const relGlobalId = this.generateGlobalId();
-      const relLine = `#${relId}=IFCRELDEFINESBYPROPERTIES('${relGlobalId}',$,$,$,(#${entityId}),#${qsetId});`;
+      const relLine = `#${relId}=IFCRELDEFINESBYPROPERTIES('${relGlobalId}',${this.resolveOwnerHistoryRef()},$,$,(#${entityId}),#${qsetId});`;
       lines.push(relLine);
     }
 

--- a/packages/export/src/step-exporter.ts
+++ b/packages/export/src/step-exporter.ts
@@ -130,8 +130,11 @@ export class StepExporter {
   private mutationView: MutablePropertyView | null;
   private nextExpressId: number;
   private entityExtractor: EntityExtractor | null;
-  /** Lazily-resolved `#id` of an existing IfcOwnerHistory (or `$`). */
-  private ownerHistoryRefCache: string | undefined;
+  /** Lazily-resolved fallback `#id` of an IfcOwnerHistory that survives the
+   *  current export closure (or `$` when the file has none). */
+  private ownerHistoryFallbackRef: string | undefined;
+  /** Per-host cache of an element's own OwnerHistory ref (`#id` or null). */
+  private ownerHistoryByEntity = new Map<number, string | null>();
 
   constructor(dataStore: IfcDataStore, mutationView?: MutablePropertyView) {
     this.dataStore = dataStore;
@@ -662,6 +665,7 @@ export class StepExporter {
       const newEntities = this.generatePropertySetEntities(
         entityId,
         psets,
+        allowedEntityIds,
         typeOwnedPsetNamesByEntity.get(entityId)
       );
       entities.push(...newEntities.lines);
@@ -697,7 +701,7 @@ export class StepExporter {
 
     // Generate new quantity entities for mutations
     for (const { entityId, qsets } of newQuantitySets) {
-      const newEntities = this.generateQuantitySetEntities(entityId, qsets);
+      const newEntities = this.generateQuantitySetEntities(entityId, qsets, allowedEntityIds);
       entities.push(...newEntities.lines);
       newEntityCount += newEntities.count;
     }
@@ -825,18 +829,57 @@ export class StepExporter {
   }
 
   /**
-   * Resolve a STEP reference to an existing IfcOwnerHistory, used to stamp the
+   * Resolve a STEP reference to an existing IfcOwnerHistory for the
    * IfcPropertySet / IfcRelDefinesByProperties / IfcElementQuantity entities we
-   * generate for mutations. OwnerHistory is optional in IFC4 but MANDATORY in
-   * IFC2X3 (IfcRoot.OwnerHistory), so emitting `$` yields an invalid IFC2X3 file
-   * that strict readers (e.g. BIM Vision) reject. Reuse any existing owner
-   * history in the model; fall back to `$` only when the file has none.
+   * generate for `hostEntityId`'s mutations. OwnerHistory is optional in IFC4 but
+   * MANDATORY in IFC2X3 (IfcRoot.OwnerHistory), so emitting `$` yields an invalid
+   * IFC2X3 file that strict readers (e.g. BIM Vision) reject.
+   *
+   * Prefer the host element's OWN owner history: it is the semantically correct
+   * owner and — being reachable from an exported root — is guaranteed to survive a
+   * `visibleOnly` closure. Fall back to any owner history still inside the export
+   * (closure-aware) so we never reference one a `visibleOnly` / isolated export
+   * dropped, then to `$` only when the file has none.
    */
-  private resolveOwnerHistoryRef(): string {
-    if (this.ownerHistoryRefCache !== undefined) return this.ownerHistoryRefCache;
-    const ids = this.dataStore.entityIndex.byType.get('IFCOWNERHISTORY');
-    this.ownerHistoryRefCache = ids && ids.length > 0 ? `#${ids[0]}` : '$';
-    return this.ownerHistoryRefCache;
+  private resolveOwnerHistoryRef(hostEntityId: number, allowedEntityIds: Set<number> | null): string {
+    const own = this.getOwnerHistoryRefOfEntity(hostEntityId);
+    if (own !== null) {
+      const ownId = parseInt(own.slice(1), 10);
+      if (allowedEntityIds === null || allowedEntityIds.has(ownId)) return own;
+    }
+    if (this.ownerHistoryFallbackRef === undefined) {
+      const ids = this.dataStore.entityIndex.byType.get('IFCOWNERHISTORY') ?? [];
+      const surviving = allowedEntityIds === null
+        ? ids[0]
+        : ids.find((id: number) => allowedEntityIds.has(id));
+      this.ownerHistoryFallbackRef = surviving !== undefined ? `#${surviving}` : '$';
+    }
+    return this.ownerHistoryFallbackRef;
+  }
+
+  /**
+   * Read an element's own OwnerHistory reference (`#id`), or null when the
+   * element omits one (`$`) or cannot be parsed. OwnerHistory is the second
+   * attribute of every IfcRoot subtype, immediately after the GlobalId string.
+   */
+  private getOwnerHistoryRefOfEntity(entityId: number): string | null {
+    const cached = this.ownerHistoryByEntity.get(entityId);
+    if (cached !== undefined) return cached;
+    let result: string | null = null;
+    const entityRef = this.dataStore.entityIndex.byId.get(entityId);
+    if (entityRef && this.dataStore.source && entityRef.byteLength > 0) {
+      const entityText = safeUtf8Decode(
+        this.dataStore.source,
+        entityRef.byteOffset,
+        entityRef.byteOffset + entityRef.byteLength
+      );
+      // #ID=IFCWALL('GlobalId',#owner,...): GlobalId is a quoted STEP string
+      // (doubled '' escapes); OwnerHistory is the ref/`$` right after it.
+      const match = entityText.match(/=\s*IFC\w+\s*\(\s*'(?:[^']|'')*'\s*,\s*#(\d+)/i);
+      if (match) result = `#${match[1]}`;
+    }
+    this.ownerHistoryByEntity.set(entityId, result);
+    return result;
   }
 
   /**
@@ -845,6 +888,7 @@ export class StepExporter {
   private generatePropertySetEntities(
     entityId: number,
     psets: PropertySet[],
+    allowedEntityIds: Set<number> | null,
     typeOwnedPsetNames?: Set<string>
   ): { lines: string[]; count: number; generatedTypeOwnedPsetIds: Map<string, number> } {
     const lines: string[] = [];
@@ -877,7 +921,7 @@ export class StepExporter {
       const globalId = this.generateGlobalId();
 
       // #ID=IFCPROPERTYSET('GlobalId',#ownerHistory,'Name',$,(#props));
-      const psetLine = `#${psetId}=IFCPROPERTYSET('${globalId}',${this.resolveOwnerHistoryRef()},'${escapeStepString(pset.name)}',$,(${propRefs}));`;
+      const psetLine = `#${psetId}=IFCPROPERTYSET('${globalId}',${this.resolveOwnerHistoryRef(entityId, allowedEntityIds)},'${escapeStepString(pset.name)}',$,(${propRefs}));`;
       lines.push(psetLine);
 
       if (typeOwnedPsetNames?.has(pset.name)) {
@@ -889,7 +933,7 @@ export class StepExporter {
 
         const relGlobalId = this.generateGlobalId();
         // #ID=IFCRELDEFINESBYPROPERTIES('GlobalId',#ownerHistory,$,$,(#entity),#pset);
-        const relLine = `#${relId}=IFCRELDEFINESBYPROPERTIES('${relGlobalId}',${this.resolveOwnerHistoryRef()},$,$,(#${entityId}),#${psetId});`;
+        const relLine = `#${relId}=IFCRELDEFINESBYPROPERTIES('${relGlobalId}',${this.resolveOwnerHistoryRef(entityId, allowedEntityIds)},$,$,(#${entityId}),#${psetId});`;
         lines.push(relLine);
       }
     }
@@ -902,7 +946,8 @@ export class StepExporter {
    */
   private generateQuantitySetEntities(
     entityId: number,
-    qsets: QuantitySet[]
+    qsets: QuantitySet[],
+    allowedEntityIds: Set<number> | null
   ): { lines: string[]; count: number } {
     const lines: string[] = [];
     let count = 0;
@@ -930,7 +975,7 @@ export class StepExporter {
       const globalId = this.generateGlobalId();
 
       // #ID=IFCELEMENTQUANTITY('GlobalId',#ownerHistory,'Name',$,$,(#quants));
-      const qsetLine = `#${qsetId}=IFCELEMENTQUANTITY('${globalId}',${this.resolveOwnerHistoryRef()},'${escapeStepString(qset.name)}',$,$,(${quantRefs}));`;
+      const qsetLine = `#${qsetId}=IFCELEMENTQUANTITY('${globalId}',${this.resolveOwnerHistoryRef(entityId, allowedEntityIds)},'${escapeStepString(qset.name)}',$,$,(${quantRefs}));`;
       lines.push(qsetLine);
 
       // Create IfcRelDefinesByProperties to link qset to entity
@@ -938,7 +983,7 @@ export class StepExporter {
       count++;
 
       const relGlobalId = this.generateGlobalId();
-      const relLine = `#${relId}=IFCRELDEFINESBYPROPERTIES('${relGlobalId}',${this.resolveOwnerHistoryRef()},$,$,(#${entityId}),#${qsetId});`;
+      const relLine = `#${relId}=IFCRELDEFINESBYPROPERTIES('${relGlobalId}',${this.resolveOwnerHistoryRef(entityId, allowedEntityIds)},$,$,(#${entityId}),#${qsetId});`;
       lines.push(relLine);
     }
 


### PR DESCRIPTION
Closes #1413.

Two `StepExporter` correctness fixes that make an **edited** property/quantity set produce a
valid IFC file (both surfaced while validating federated export with edits via ifcopenshell).

## 1. Retain shared property atoms (#1413)
Editing a property replaces its property set and skipped **all** of that set's member atoms.
IFC exporters deduplicate shared `Pset_*Common` atoms (one `IsExternal` `IfcPropertySingleValue`
can be referenced by dozens of psets), so the wholesale skip orphaned every other pset
referencing the atom → dangling `#id` refs → invalid IFC that strict readers (BIM Vision)
refuse to open. `StepExporter` now retains any atom still referenced by a surviving property
set / element quantity; the edited pset still emits its replacement with the new value while
shared atoms stay for the psets that keep their original.

Reproduction: `IfcStair-Assembly.ifc` has 26 atoms shared across psets (`#60`=`IsExternal`
referenced by 28 psets); editing `Pset_SpaceCommon.IsExternal` on `#49` produced dangling
refs `[58, 60]` before, none after.

## 2. Stamp generated psets with OwnerHistory (valid IFC2X3)
Editing a property/quantity emits a replacement `IfcPropertySet` /
`IfcRelDefinesByProperties` / `IfcElementQuantity`. These hardcoded `$` for OwnerHistory,
which is optional in IFC4 but **mandatory in IFC2X3** — so an edited IFC2X3 model exported to
a file that strict readers reject ("Attribute not optional"). The exporter now reuses an
existing `IfcOwnerHistory` from the model (falling back to `$` only when the file has none).

Verified with ifcopenshell 0.8.5: a same-schema IFC2X3 merge with a `Pset_WallCommon` edit
went from 2 validation errors → **0**.

## Tests
`packages/export/src/shared-atom.test.ts` and `packages/export/src/owner-history.test.ts`.
Full `@ifc-lite/export` suite green (122 passed); typecheck clean. Both fixes apply to
single-model and merged export (the merged exporter bakes through `StepExporter`).

Independent of #1407 (merged-export mutations) — these are pre-existing `StepExporter` bugs
that also affect single-model export; #1407 surfaced them via federated export.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed exports that could produce invalid STEP files with dangling references after editing shared property values.
  * Preserved shared property values used by other property sets when only one set is changed.
  * Ensured newly generated property and quantity records reuse valid owner history information, improving IFC2X3/IFC4 export correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->