### PR TITLE
fix(release): retry changeset version on transient GitHub API failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "docs:serve": "python3 -m mkdocs serve",
     "docs:build": "python3 -m mkdocs build",
     "changeset": "changeset",
-    "version": "changeset version && node scripts/sync-versions.js",
+    "version": "node scripts/changeset-version-retry.mjs && node scripts/sync-versions.js",
     "release": "pnpm build && pnpm test:esm && pnpm release:npm && pnpm release:crates",
     "release:npm": "changeset publish",
     "release:crates": "node scripts/release-crates.mjs",

--- a/scripts/changeset-version-retry.mjs
+++ b/scripts/changeset-version-retry.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+/**
+ * Runs `changeset version` with retry/backoff to survive transient GitHub
+ * API failures during changelog generation.
+ *
+ * `@changesets/changelog-github` fetches PR + author metadata from
+ * https://api.github.com/graphql to build each changelog entry. That call
+ * occasionally dies mid-flight with errors like:
+ *
+ *   Failed to parse data from GitHub
+ *   Invalid response body while trying to fetch
+ *   https://api.github.com/graphql: Premature close
+ *
+ * which aborts the whole `changeset version` step and fails the Release
+ * workflow (e.g. run 28263520541). The failure is purely a network blip on
+ * GitHub's side — nothing in our repo is wrong.
+ *
+ * `changeset version` is transactional: when changelog generation throws it
+ * "escapes applying the changesets, and no files are affected", so re-running
+ * is safe. Each attempt is a fresh child process, which also resets the
+ * `@changesets/get-github-info` GraphQL DataLoader (it caches rejected
+ * promises for the process lifetime, so retrying in-process would just
+ * replay the cached failure). Spawning anew is what lets a retry actually
+ * reach the network again.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+const MAX_ATTEMPTS = 4;
+const BASE_DELAY_MS = 2000; // 2s, 4s, 8s — matches the repo's git retry policy
+
+/** Block for `ms` milliseconds without pulling in async/timers. */
+function sleepSync(ms) {
+  const shared = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(shared, 0, 0, ms);
+}
+
+// Resolve the changeset CLI from node_modules so this does not depend on
+// node_modules/.bin being on PATH.
+const changesetBin = require.resolve('@changesets/cli/bin.js');
+
+for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+  const result = spawnSync(process.execPath, [changesetBin, 'version'], {
+    stdio: 'inherit',
+  });
+
+  if (result.status === 0) {
+    process.exit(0);
+  }
+
+  // spawn itself failed (binary missing, etc.) — not a retryable network blip.
+  if (result.error) {
+    console.error(`changeset version could not be spawned: ${result.error.message}`);
+    process.exit(1);
+  }
+
+  if (attempt < MAX_ATTEMPTS) {
+    const delay = BASE_DELAY_MS * 2 ** (attempt - 1);
+    console.error(
+      `changeset version failed (exit ${result.status}) on attempt ${attempt}/${MAX_ATTEMPTS}; ` +
+        `retrying in ${delay / 1000}s (likely a transient GitHub API error during changelog generation).`,
+    );
+    sleepSync(delay);
+  } else {
+    console.error(
+      `changeset version failed after ${MAX_ATTEMPTS} attempts (exit ${result.status}).`,
+    );
+    process.exit(result.status ?? 1);
+  }
+}


### PR DESCRIPTION
The Release workflow failed (run 28263520541) during `changeset version`:

  Failed to parse data from GitHub
  Invalid response body while trying to fetch
  https://api.github.com/graphql: Premature close

`@changesets/changelog-github` fetches PR/author metadata from GitHub's
GraphQL API to build changelog entries; a transient network blip there
aborts the whole version step and fails the release. Nothing in the repo
is wrong — it's purely GitHub-side flakiness.

`changeset version` is transactional (it escapes cleanly without touching
files on failure), and each retry is a fresh process that resets the
get-github-info GraphQL DataLoader cache, so retrying actually re-hits the
network. Wrap it in scripts/changeset-version-retry.mjs with 4 attempts and
2s/4s/8s backoff (matching the repo's git retry policy).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017yN9ZUXKQQ3CNLJrDrua39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the versioning workflow to be more reliable when running release commands.
  * Added automatic retrying for temporary versioning failures, helping reduce interrupted releases.
  * Kept version synchronization in place after version updates complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->