### PR TITLE
perf(georef): memoize on-demand georef extraction (fixes large-model load stall, #1404 follow-up)

### DIFF
--- a/.changeset/georef-ondemand-memoize.md
+++ b/.changeset/georef-ondemand-memoize.md
@@ -1,0 +1,17 @@
+---
+"@ifc-lite/parser": patch
+---
+
+perf(georef): memoize `extractGeoreferencingOnDemand` per store
+
+On models without an `IfcMapConversion`, the on-demand georeferencing extractor
+scans and decodes every `IfcPropertySet` from the source buffer to find
+`ePset_MapConversion` / `ePset_ProjectedCRS`. On property-set-heavy models that
+is tens of thousands of entity decodes per call, and the viewer invokes it on
+the render path (once per streamed geometry batch), so the cost compounded to
+O(batches x propertySets) and could stall large-model loads by an order of
+magnitude. The result is a pure function of the immutable source + entityIndex
+(georef edits are layered on top later in `getEffectiveGeoreference`), so the
+extraction is now memoized per store via a `WeakMap`, collapsing it to a single
+scan per model. Not-yet-loaded stores (missing source/entityIndex) are not
+cached, so a store that fills in later still recomputes.

--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -372,7 +372,10 @@ export function ViewportContainer() {
     ifcDataStore,
     georefMutations,
     mutationVersion,
-    mergedGeometryResult,
+    // Only the (stable) coordinateInfo is read here, not the whole result —
+    // depending on `mergedGeometryResult` re-runs this on every streamed
+    // geometry batch, re-triggering the property-set georef scan each time.
+    mergedGeometryResult?.coordinateInfo,
     cesiumPlacementDraft,
     cesiumPlacementDraftModelId,
     anchorModelIdOverride,
@@ -411,7 +414,10 @@ export function ViewportContainer() {
       return false;
     }
     setCesiumAvailable(hasGeoref());
-  }, [storeModels, ifcDataStore, georefMutations, mutationVersion, setCesiumAvailable, mergedGeometryResult]);
+    // Depend on the stable coordinateInfo, not the whole mergedGeometryResult:
+    // the latter gets a new reference each streamed batch, which would re-run
+    // this georef property-set scan ~once per batch on large models.
+  }, [storeModels, ifcDataStore, georefMutations, mutationVersion, setCesiumAvailable, mergedGeometryResult?.coordinateInfo]);
 
   // Sync the active Cesium source model ID so terrain actions are scoped correctly
   useEffect(() => {

--- a/packages/parser/src/on-demand-extractors.ts
+++ b/packages/parser/src/on-demand-extractors.ts
@@ -710,8 +710,31 @@ export function extractGroupMembersOnDemand(
 /**
  * Extract georeferencing info from on-demand store (source buffer + entityIndex).
  * Bridges to the entity-based georef extractor by resolving entities lazily.
+ *
+ * Memoized per store. On models without an IfcMapConversion (e.g. IFC2x3 files
+ * that carry CRS in ePSet_MapConversion / ePSet_ProjectedCRS) the underlying
+ * scan decodes EVERY IfcPropertySet from the source buffer to match by name —
+ * tens of thousands of decodes on property-heavy models. The viewer calls this
+ * on the load/render path (ViewportContainer's Cesium-availability check), which
+ * re-runs on every streamed geometry batch, so without caching the cost is
+ * O(batches x propertySets) and can turn a multi-second load into minutes.
+ * Caching collapses it to a single scan per store. Safe because the result is a
+ * pure function of the immutable source + entityIndex; georef *edits* are layered
+ * on top later in getEffectiveGeoreference(), not here.
  */
+const georefOnDemandCache = new WeakMap<IfcDataStore, GeoreferenceInfo | null>();
+
 export function extractGeoreferencingOnDemand(store: IfcDataStore): GeoreferenceInfo | null {
+    // Don't cache a not-yet-loaded store — it may gain source/entityIndex later.
+    if (!store.source?.length || !store.entityIndex) return null;
+    const cached = georefOnDemandCache.get(store);
+    if (cached !== undefined) return cached;
+    const result = computeGeoreferencingOnDemand(store);
+    georefOnDemandCache.set(store, result);
+    return result;
+}
+
+function computeGeoreferencingOnDemand(store: IfcDataStore): GeoreferenceInfo | null {
     if (!store.source?.length || !store.entityIndex) return null;
 
     const extractor = new EntityExtractor(store.source);

--- a/packages/parser/src/on-demand-extractors.ts
+++ b/packages/parser/src/on-demand-extractors.ts
@@ -722,16 +722,28 @@ export function extractGroupMembersOnDemand(
  * pure function of the immutable source + entityIndex; georef *edits* are layered
  * on top later in getEffectiveGeoreference(), not here.
  */
-const georefOnDemandCache = new WeakMap<IfcDataStore, GeoreferenceInfo | null>();
+/**
+ * Memoize an O(entities) on-demand extraction per store. On-demand extractors
+ * derive purely from the immutable source + entityIndex, but the viewer calls
+ * them on render/stream hot paths where they can re-run once per geometry batch
+ * (regression #1404). Caching by store collapses that to one scan per model.
+ * Use this for any new `extract*OnDemand` so the whole family stays O(1)-per-call
+ * regardless of how often the render layer invokes it.
+ */
+const onDemandCaches = new WeakMap<IfcDataStore, Map<string, unknown>>();
+function oncePerStore<T>(store: IfcDataStore, key: string, compute: () => T): T {
+    let byKey = onDemandCaches.get(store);
+    if (!byKey) { byKey = new Map(); onDemandCaches.set(store, byKey); }
+    if (byKey.has(key)) return byKey.get(key) as T;
+    const value = compute();
+    byKey.set(key, value);
+    return value;
+}
 
 export function extractGeoreferencingOnDemand(store: IfcDataStore): GeoreferenceInfo | null {
     // Don't cache a not-yet-loaded store — it may gain source/entityIndex later.
     if (!store.source?.length || !store.entityIndex) return null;
-    const cached = georefOnDemandCache.get(store);
-    if (cached !== undefined) return cached;
-    const result = computeGeoreferencingOnDemand(store);
-    georefOnDemandCache.set(store, result);
-    return result;
+    return oncePerStore(store, 'georef', () => computeGeoreferencingOnDemand(store));
 }
 
 function computeGeoreferencingOnDemand(store: IfcDataStore): GeoreferenceInfo | null {

--- a/packages/parser/test/on-demand-georef-epset.test.ts
+++ b/packages/parser/test/on-demand-georef-epset.test.ts
@@ -2,10 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { StepTokenizer } from '../src/tokenizer.js';
 import { ColumnarParser } from '../src/columnar-parser.js';
 import { extractGeoreferencingOnDemand } from '../src/on-demand-extractors.js';
+import { EntityExtractor } from '../src/entity-extractor.js';
 
 /**
  * The on-demand georef path (used by the viewer's properties panel) only
@@ -106,5 +107,36 @@ describe('extractGeoreferencingOnDemand — IFC2x3 ePset fallback', () => {
     // the identical reference. Reference equality therefore proves memoization.
     expect(first).not.toBeNull();
     expect(second).toBe(first);
+  });
+
+  // Work-count regression guard (deterministic, machine-independent — counts
+  // work done, not wall-clock). The georef scan decodes one entity per property
+  // set on models without an IfcMapConversion; memoization must drop that to
+  // zero on subsequent calls so the viewer's per-batch invocations are free.
+  it('scans property sets once: zero entity decodes on the memoized second call', async () => {
+    const PSET_COUNT = 400;
+    let ifc = `#30=IFCSITE('06pHC0eJnCHlVXWW2sVoPO',$,'Site',$,$,$,$,$,.ELEMENT.,(51,26,47,208626),(5,27,36,650968),$,$,$);\n`;
+    // Many non-georef property sets force the scan to run to completion (the
+    // worst case: no ePset_MapConversion exists, so it never early-returns).
+    for (let i = 0; i < PSET_COUNT; i += 1) {
+      ifc += `#${1000 + i}=IFCPROPERTYSET('pset${i}aaaaaaaaaaaaaaaaaaaa',$,'Pset_Generic_${i}',$,());\n`;
+    }
+    const store = await storeFromIfc(ifc);
+
+    const decode = vi.spyOn(EntityExtractor.prototype, 'extractEntity');
+    decode.mockClear();
+    extractGeoreferencingOnDemand(store);
+    const firstCallDecodes = decode.mock.calls.length;
+    decode.mockClear();
+    extractGeoreferencingOnDemand(store);
+    const secondCallDecodes = decode.mock.calls.length;
+    decode.mockRestore();
+
+    // First call actually scanned the property sets...
+    expect(firstCallDecodes).toBeGreaterThanOrEqual(PSET_COUNT);
+    // ...the second call did NO work — the regression (#1404) re-scanned on
+    // every geometry batch, which on a real model is tens of thousands of
+    // decodes per batch.
+    expect(secondCallDecodes).toBe(0);
   });
 });

--- a/packages/parser/test/on-demand-georef-epset.test.ts
+++ b/packages/parser/test/on-demand-georef-epset.test.ts
@@ -88,4 +88,23 @@ describe('extractGeoreferencingOnDemand — IFC2x3 ePset fallback', () => {
     expect(georef?.source).toBe('siteLocation');
     expect(georef?.projectedCRS?.name).toBe('EPSG:4326');
   });
+
+  it('memoizes per store so repeated calls do not re-scan property sets', async () => {
+    // The on-demand scan decodes every IfcPropertySet to find ePset_MapConversion
+    // on models without an IfcMapConversion. The viewer calls this on the render
+    // path once per streamed geometry batch, so without caching a property-heavy
+    // model re-scans tens of thousands of psets per batch (regression #1404).
+    const ifc = `#30=IFCSITE('06pHC0eJnCHlVXWW2sVoPO',$,'Site',$,$,$,$,$,.ELEMENT.,(51,26,47,208626),(5,27,36,650968),$,$,$);
+#1357=IFCPROPERTYSINGLEVALUE('Name',$,IFCLABEL('EPSG:28992'),$);
+#1358=IFCPROPERTYSET('27AKTMp8j58fBEhvkJkcNJ',$,'ePset_ProjectedCRS',$,(#1357));
+#1360=IFCPROPERTYSINGLEVALUE('TargetCRS',$,IFCLABEL('EPSG:28992'),$);
+#1367=IFCPROPERTYSET('2If4Y3Lpv6dgTDkC5x_dnr',$,'ePset_MapConversion',$,(#1360));`;
+    const store = await storeFromIfc(ifc);
+    const first = extractGeoreferencingOnDemand(store);
+    const second = extractGeoreferencingOnDemand(store);
+    // A cache miss recomputes a fresh GeoreferenceInfo object; the cache returns
+    // the identical reference. Reference equality therefore proves memoization.
+    expect(first).not.toBeNull();
+    expect(second).toBe(first);
+  });
 });


### PR DESCRIPTION
## Problem

Large, property-set-heavy models regressed badly on load (a ~170 MB tower model went from ~8 s to ~110 s in the viewer; reproduced cross-browser). Bisected to **#1404** (`f746659`, "read IFC2X3 ePset_MapConversion CRS + enable Cesium fallback"); the prior commit `8c56b98` (#1412) was fine.

### Root cause

`extractGeoreferencingOnDemand` (`@ifc-lite/parser`) now scans **every `IfcPropertySet`**, decoding each from the source buffer, to find `ePset_MapConversion` / `ePset_ProjectedCRS` when a model has no `IfcMapConversion`. On a model with tens of thousands of property sets that is tens of thousands of entity decodes per call.

`ViewportContainer` calls it on the render path (the Cesium-availability check + the georef memo) with `mergedGeometryResult` in the deps — a new object reference on **every streamed geometry batch**. So the scan ran ~once per batch: **O(batches × propertySets)** on the main thread, starving the parser and geometry workers. It is invisible to headless/native benchmarks (the kernel streams the same model in ~5 s) because nothing there calls the viewer georef path, and it hits even non-georeferenced models (no ePset → the scan never early-returns).

## Fix

1. **`@ifc-lite/parser`** — memoize `extractGeoreferencingOnDemand` per store via a `WeakMap` (same pattern as the existing material-pset cache). The result is a pure function of the immutable `source` + `entityIndex`; georef *edits* are layered on later in `getEffectiveGeoreference`, so caching the base extraction is safe. Not-yet-loaded stores (missing `source`/`entityIndex`) are not cached, so a store that fills in later still recomputes. Collapses the cost to a single scan per model.
2. **viewer** — the Cesium-availability effect and the georef memo now depend on the stable `mergedGeometryResult.coordinateInfo` (the only value they read) instead of the whole result, so they stop re-firing on every geometry batch. Matches the intent that georef is needed once the model is loaded, not while it streams.

Either change alone removes the blow-up; together they also eliminate the wasted per-batch re-renders.

## Tests

- Added a memoization test to `on-demand-georef-epset.test.ts` (repeated calls return the identical reference → proves no re-scan).
- Existing ePset / legacy-fallback georef tests are unchanged and still assert correct CRS extraction.

> Note: validated by inspection + the added unit test; the full suite runs in CI (the parser test exercises the cache, and the viewer change is a dependency-array narrowing that reads the same value).

A `.changeset` (`@ifc-lite/parser` patch) is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Georeferencing extraction is now memoized per loaded model, preventing repeated scans/decodes for EPSG/CRS-related property sets.
  * The viewer recalculates Cesium georeferencing and availability only when coordinate information changes, reducing unnecessary work during streamed geometry batches.
* **Tests**
  * Added regression tests to verify georeferencing reuse on repeated calls and that subsequent requests avoid additional entity decoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->