### PR TITLE
feat(analytics): tag events with build commit for deploy attribution

### DIFF
--- a/apps/viewer/src/lib/analytics.ts
+++ b/apps/viewer/src/lib/analytics.ts
@@ -41,6 +41,15 @@ if (enabled) {
       // in ./analytics-scrub.ts.
       before_send: scrubEvent,
     });
+    // Register build attribution as super-properties so every event (incl.
+    // ifc_model_loaded) carries the deploy it was served from — this is what
+    // lets field perf regressions be pinned to a specific release. Guarded with
+    // typeof for the Node test runner, where the Vite `define` constants that
+    // back __APP_VERSION__/__BUILD_SHA__ are not injected.
+    posthogClient.register({
+      app_version: typeof __APP_VERSION__ === 'string' ? __APP_VERSION__ : 'dev',
+      app_build_sha: typeof __BUILD_SHA__ === 'string' ? __BUILD_SHA__ : 'dev',
+    });
     client = posthogClient;
   } catch (err) {
     console.warn('[analytics] PostHog init failed; analytics disabled', err);

--- a/apps/viewer/src/vite-env.d.ts
+++ b/apps/viewer/src/vite-env.d.ts
@@ -31,6 +31,7 @@ interface ImportMeta {
 
 // Build-time constants injected by Vite define
 declare const __APP_VERSION__: string;
+declare const __BUILD_SHA__: string;
 declare const __BUILD_DATE__: string;
 declare const __RELEASE_HISTORY__: Array<{
   name: string;

--- a/apps/viewer/vite.config.ts
+++ b/apps/viewer/vite.config.ts
@@ -208,6 +208,10 @@ const rootPkg = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, '../../package.json'), 'utf-8')
 );
 const appVersion = viewerPkg.version || rootPkg.version;
+// Git commit the bundle was built from, for attributing field perf/regressions
+// to a specific deploy. Vercel sets VERCEL_GIT_COMMIT_SHA, GitHub Actions sets
+// GITHUB_SHA; falls back to 'dev' for local builds.
+const buildSha = (process.env.VERCEL_GIT_COMMIT_SHA || process.env.GITHUB_SHA || 'dev').slice(0, 12);
 
 export default defineConfig({
   plugins: [
@@ -218,6 +222,7 @@ export default defineConfig({
   ],
   define: {
     __APP_VERSION__: JSON.stringify(appVersion),
+    __BUILD_SHA__: JSON.stringify(buildSha),
     __BUILD_DATE__: JSON.stringify(new Date().toISOString()),
     __RELEASE_HISTORY__: JSON.stringify(parseChangelogs()),
     __PACKAGE_VERSIONS__: JSON.stringify(collectPackageVersions()),


### PR DESCRIPTION
## Why

Field perf-regression detection (via the `ifc_model_loaded` PostHog event) can already group loads by a file fingerprint (`file_size_mb` + `mesh_count` + `total_triangles`), but it can't attribute a load-time step to a specific deploy. This adds the missing dimension.

## What

- `vite.config.ts`: inject `__BUILD_SHA__` (from `VERCEL_GIT_COMMIT_SHA` / `GITHUB_SHA`, `'dev'` locally, first 12 chars).
- `vite-env.d.ts`: declare it.
- `analytics.ts`: after PostHog init, `register({ app_version, app_build_sha })` as **super-properties** so every event (current and future, incl. `ifc_model_loaded`) carries the deploy it was served from. `typeof` guards keep it safe under the Node test runner where the Vite `define` constants aren't injected.

## Enables

```sql
-- regression = a new build's median jumps vs the prior build for the same file
SELECT properties.app_build_sha, count(),
       round(median(toFloat(properties.total_elapsed_ms))) AS med_ms
FROM events
WHERE event = 'ifc_model_loaded'
  AND round(toFloat(properties.file_size_mb)) = 169
GROUP BY properties.app_build_sha
ORDER BY min(timestamp)
```

No new per-capture code (super-property covers all events). `@ifc-lite/viewer` is private, so no changeset. Privacy: `app_version`/`app_build_sha` are non-sensitive and pass the existing event scrub denylist.