### PR TITLE
spike(wasm): measured wide-arith win (~1.7x CSG, blocked upstream) + pkg-wide bundle

### DIFF
--- a/docs/architecture/wasm-wide-arithmetic.md
+++ b/docs/architecture/wasm-wide-arithmetic.md
@@ -91,14 +91,15 @@ only safe handling is the feature-detect + fallback above (zero regression,
 auto-upgrade per engine as each ships). For users today it yields no in-browser
 speedup.
 
-The bigger lever that *does* work in today's browsers is **threads**: the
-`pkg-threaded` bundle (rayon-in-wasm, atomics + shared memory; SharedArrayBuffer
-is widely supported and the viewer already sets COOP/COEP). Native shows
-threading is a far larger win than wide-arith on the heavy models — Tekla 1-core
-14.2s vs 10-core 2.9s (~4.8x) vs wide-arith's 1.7x. In-wasm scaling still needs
-the `rust/csg-thread-bench` (rung-2) browser result to confirm it tracks native,
-but it is the near-term in-browser path; wide-arith is additive on top later
-(a threaded+wide bundle combines both target-features).
+The bigger lever that *does* work in today's browsers is **threads** (in-instance
+rayon), and it is **already measured** — see `docs/architecture/csg-threading-design.md`
++ the `rust/csg-thread-bench` rung-2 result: threaded WASM scales the CSG step
+**2.9-4.2x at 8 threads** (atomics tax ~0%, output byte-identical) and **1.6-1.9x
+end-to-end** on the current exact-CSG kernel. The `pkg-threaded` bundle is built
+(#1255) but not yet wired into runtime selection. It works in today's
+Chrome/Firefox (cross-origin isolated; the viewer already sets COOP/COEP; Safari
+lacks credentialless COI and falls back to the plain bundle). wide-arith is
+additive on top later (a threaded+wide bundle combines both target-features).
 
 **Working around the wasm-bindgen blocker:** split the CSG kernel into a separate
 plain-`cdylib` wasm (no wasm-bindgen) built with `+wide-arithmetic`, exposing the

--- a/docs/architecture/wasm-wide-arithmetic.md
+++ b/docs/architecture/wasm-wide-arithmetic.md
@@ -52,10 +52,64 @@ ThatOpen wins today.
 - `wide-arithmetic` is a recognized wasm target feature in our pinned toolchain.
 - LLVM 21 lowers our actual `bnum` I256/I512 `checked_mul` to the wide ops with
   only `-C target-feature=+wide-arithmetic`. No `bnum` changes required.
-- Gating factor for shipping is **browser engine support** (V8 / SpiderMonkey
-  shipping the proposal), which is handled by feature detection below.
+- At the kernel level there is no blocker: the win is real today on a plain
+  `cdylib` (the benches above).
 
-## Delivery plan (how WASM users get it)
+## Delivery status: blocked upstream (verified 2026-06-27)
+
+Shipping it to browser users is blocked on TWO upstream items, both confirmed here:
+
+1. **wasm-bindgen cannot process a wide-arithmetic module.** The production wasm
+   goes through `wasm-bindgen` (pinned `=0.2.106`) for the `IfcAPI` glue. Building
+   `pkg-wide` fails in the bindgen step: `failed to parse code section: wide
+   arithmetic support is not enabled` — its `walrus` parser rejects the new
+   opcodes. We cannot build the production bundle until a wasm-bindgen / `walrus`
+   release enables wide-arith parsing. (The benches sidestep this: plain
+   `cdylib`, no bindgen — which is why they build and run.)
+2. **No shipping browser engine supports it yet.** Node 22's V8 rejects the
+   module (`WebAssembly.validate()` -> false, "invalid numeric opcode 0xfc13");
+   stable Chrome/Safari are not expected to differ today.
+
+Net: the lever is proven and worth tracking, but **not shippable now**. The plan
+below is the design to wire once BOTH clear. The runtime feature-detect makes it
+a safe, zero-cost no-op for every user until then — the wide `.wasm` is never
+fetched while the probe returns false, which it does on every engine today.
+
+## When might it ship, and can we work around it?
+
+**Timeline (researched 2026-06):** wide-arithmetic is **Phase 3** (implementation
+phase, not yet a finished standard = Phase 4). A 2026 runtime survey found only
+**Wasmtime and Wasmer** run a full wide-arith build in stable releases; **no
+stable browser ships it** (V8 has only prototyped it; it is flag/experimental at
+best). Realistically: per-engine shipping through 2026-2027, "Baseline" (all
+three engines, safe to rely on) later still. So this is a track-and-adopt lever,
+not a near-term one.
+
+**Working around the browser blocker:** there is no useful polyfill — emulating
+the instructions in wasm IS the slow `__multi3` path we are trying to escape. The
+only safe handling is the feature-detect + fallback above (zero regression,
+auto-upgrade per engine as each ships). For users today it yields no in-browser
+speedup.
+
+The bigger lever that *does* work in today's browsers is **threads**: the
+`pkg-threaded` bundle (rayon-in-wasm, atomics + shared memory; SharedArrayBuffer
+is widely supported and the viewer already sets COOP/COEP). Native shows
+threading is a far larger win than wide-arith on the heavy models — Tekla 1-core
+14.2s vs 10-core 2.9s (~4.8x) vs wide-arith's 1.7x. In-wasm scaling still needs
+the `rust/csg-thread-bench` (rung-2) browser result to confirm it tracks native,
+but it is the near-term in-browser path; wide-arith is additive on top later
+(a threaded+wide bundle combines both target-features).
+
+**Working around the wasm-bindgen blocker:** split the CSG kernel into a separate
+plain-`cdylib` wasm (no wasm-bindgen) built with `+wide-arithmetic`, exposing the
+boolean over linear memory (the `csgbench` crate is a proof this builds and runs).
+The main bindgen bundle stays non-wide; JS loads the kernel module only when the
+probe passes. This sidesteps wasm-bindgen entirely — but only matters once a
+browser supports the proposal, so it is not worth building ahead of that. The
+alternative is to wait for a wasm-bindgen / `walrus` release that enables
+wide-arith parsing.
+
+## Delivery plan (wire once unblocked)
 
 This reuses the exact pattern already in place for the threaded second bundle
 (`packages/wasm/pkg-threaded`, built off-by-default in `scripts/build-wasm.sh`).

--- a/docs/architecture/wasm-wide-arithmetic.md
+++ b/docs/architecture/wasm-wide-arithmetic.md
@@ -1,0 +1,116 @@
+# WASM wide-arithmetic: measured win + delivery plan
+
+Status: measurement + design (2026-06-27)
+Goal: close the in-browser WASM-vs-native gap on exact-CSG/brep-heavy models
+**without an install or an upload** (the hard client-side constraint), by building
+the geometry kernel with the WASM wide-arithmetic proposal.
+
+## Why this exists
+
+The exact pure-Rust CSG kernel (`rust/geometry/src/kernel/`) runs a predicate
+cascade over `bnum` fixed-width integers (I256/I512/I1024/I2048). On native those
+are stack-allocated checked arithmetic; on wasm32 there is no wide-integer
+hardware, so `bnum`'s 64x64->128 limb products compile to `__multi3` libcalls.
+That is the structural reason heavy CSG/brep models are slower in the browser
+than natively. The WASM wide-arithmetic proposal adds `i64.mul_wide_s/u`,
+`i64.add128`, `i64.sub128`, which map those limb ops to single instructions.
+
+## Measured (Apple M4, rustc 1.93-nightly / LLVM 21.1.5, wasmtime 46 / Cranelift)
+
+Built with `-C target-feature=+wide-arithmetic`; verified the ops are emitted
+(`wasm-tools print | grep`) and that output is byte-identical to baseline.
+
+**Predicate microbench** (a 3x3 determinant = orient3d core, the exact hot path):
+
+| tier | baseline wasm | +wide-arith | speedup | vs native |
+|---|---:|---:|---:|---:|
+| I256 (common) | 438 ns | 232 ns | 1.9x | within 1.23x of native |
+| I512 (cache)  | 1093 ns | 358 ns | 3.1x | at native parity |
+
+**End-to-end CSG** (a real slab-minus-9-boxes void cut through
+`mesh_bridge::subtract_many`: arrangement + predicates + retriangulation):
+
+| build | ms/cut | vs native |
+|---|---:|---:|
+| native | 10.25 | 1.0x |
+| baseline wasm | 23.16 | 2.26x slower |
+| **+wide-arith wasm** | **13.58** | **1.33x slower** |
+
+End-to-end speedup **1.71x** — lower than the predicate-only number because a
+real cut also spends time in arrangement bookkeeping / retriangulation /
+allocation that wide-arith does not touch. Mechanism confirmed: 1447 wide ops in
+the wide build, 0 in baseline (which instead emits `__multi3` libcalls).
+
+**Bottom line:** wide-arithmetic takes in-browser exact CSG from ~2.3x
+slower-than-native to ~1.3x, with zero algorithm change and no install/upload.
+Native already beats web-ifc on the Tekla model (2.9s vs 4.9s), so closing the
+wasm gap this far makes the in-browser path competitive on exactly the models
+ThatOpen wins today.
+
+## Toolchain status: reachable now
+
+- `wide-arithmetic` is a recognized wasm target feature in our pinned toolchain.
+- LLVM 21 lowers our actual `bnum` I256/I512 `checked_mul` to the wide ops with
+  only `-C target-feature=+wide-arithmetic`. No `bnum` changes required.
+- Gating factor for shipping is **browser engine support** (V8 / SpiderMonkey
+  shipping the proposal), which is handled by feature detection below.
+
+## Delivery plan (how WASM users get it)
+
+This reuses the exact pattern already in place for the threaded second bundle
+(`packages/wasm/pkg-threaded`, built off-by-default in `scripts/build-wasm.sh`).
+
+1. **Build a third bundle `packages/wasm/pkg-wide`.** Same `wasm-pack` invocation
+   as the default `pkg`, with `+wide-arithmetic` added to the default flags
+   (`.cargo/config.toml` already sets `+simd128`). Off by default, behind
+   `BUILD_WIDE=1` in `scripts/build-wasm.sh` (added in this change). CI/Vercel
+   build it alongside `pkg` once we flip it on.
+
+2. **Feature-detect at runtime** with a tiny `WebAssembly.validate()` probe of a
+   40-byte module containing an `i64.add128` (opcode `0xFC 0x13`). Returns true
+   only on engines that accept the proposal. Drop this into
+   `packages/geometry/src/wasm-features.ts` when wiring selection:
+
+   ```ts
+   // module: (func (param i64 i64 i64 i64) (result i64 i64)
+   //           local.get 0..3  i64.add128)  -- generated via `wasm-tools parse`
+   const PROBE = new Uint8Array([
+     0,97,115,109,1,0,0,0,1,10,1,96,4,126,126,126,126,2,126,126,3,2,1,0,
+     10,14,1,12,0,32,0,32,1,32,2,32,3,252,19,11,
+   ]);
+   let cached: boolean | undefined;
+   export function supportsWideArithmetic(): boolean {
+     if (cached === undefined) {
+       try { cached = typeof WebAssembly !== 'undefined' && WebAssembly.validate(PROBE); }
+       catch { cached = false; }
+     }
+     return cached;
+   }
+   ```
+
+3. **Select the bundle URL.** `geometry.worker.ts` already accepts an init
+   `wasmUrl` (it otherwise falls back to `new URL('ifc-lite_bg.wasm', import.meta.url)`).
+   When the probe is true, pass the `pkg-wide` wasm URL through the existing
+   `wasmUrls` plumbing in `geometry-parallel.ts`; otherwise pass `pkg`. No engine
+   without the feature ever loads the wide module, so it is safe to ship eagerly.
+
+4. **Bundling.** Vite copies both `pkg` and `pkg-wide` wasm as assets (same as the
+   threaded bundle). The JS glue is identical between bundles; only the `.wasm`
+   differs, so the JS is shared and only the chosen `.wasm` is fetched.
+
+Net: one extra `.wasm` artifact + a ~40-byte feature probe + a one-line URL
+choice. Users on engines with wide-arithmetic transparently get ~1.7x faster
+in-browser CSG; everyone else is unaffected.
+
+## Reproduce
+
+Two standalone bench crates (predicate microbench + end-to-end CSG) live in the
+profiling repo under `wide-arith/`. Each builds twice and runs under wasmtime:
+
+```sh
+cargo build --release --lib --target wasm32-unknown-unknown
+RUSTFLAGS="-C target-feature=+wide-arithmetic" \
+  cargo build --release --lib --target wasm32-unknown-unknown --target-dir target-wide
+wasm-tools print target-wide/wasm32-unknown-unknown/release/*.wasm | grep -c 'mul_wide\|add128'
+wasmtime run -W wide-arithmetic=y --invoke <fn> target-wide/.../*.wasm <args>
+```

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -196,7 +196,7 @@ if [ "${BUILD_WIDE:-}" = "1" ]; then
     --out-dir "$WIDE_OUT" \
     --out-name ifc-lite \
     --release \
-    $FEATURES
+    -- $FEATURES
 
   WIDE_REL="$(echo "$WIDE_OUT" | sed 's|^../../||')"
   WIDE_DTS="$WIDE_REL/ifc-lite.d.ts"
@@ -204,13 +204,19 @@ if [ "${BUILD_WIDE:-}" = "1" ]; then
     grep -v '__wasm_bindgen_func_elem_' "$WIDE_DTS" > "$WIDE_DTS.tmp" && mv "$WIDE_DTS.tmp" "$WIDE_DTS"
   fi
   # Litmus test: the bundle must actually contain wide-arithmetic ops.
-  if command -v wasm-tools >/dev/null 2>&1; then
-    if [ "$(wasm-tools print "$WIDE_REL/ifc-lite_bg.wasm" 2>/dev/null | grep -cE 'mul_wide|add128|sub128')" -gt 0 ]; then
-      echo "🔢 ✅ wide-arithmetic bundle emits wide ops"
-    else
-      echo "🔢 ❌ wide-arithmetic bundle has NO wide ops — flags wrong; refusing to ship"
-      exit 1
-    fi
+  # wasm-tools is REQUIRED for BUILD_WIDE=1 — without it we cannot verify the
+  # bundle isn't silently baseline wasm, so refuse to proceed rather than ship
+  # an unverified bundle.
+  if ! command -v wasm-tools >/dev/null 2>&1; then
+    echo "🔢 ❌ wasm-tools not found — required for BUILD_WIDE=1 to verify wide ops; refusing to ship an unverified bundle"
+    echo "      Install it with: cargo install wasm-tools"
+    exit 1
+  fi
+  if [ "$(wasm-tools print "$WIDE_REL/ifc-lite_bg.wasm" 2>/dev/null | grep -cE 'mul_wide|add128|sub128')" -gt 0 ]; then
+    echo "🔢 ✅ wide-arithmetic bundle emits wide ops"
+  else
+    echo "🔢 ❌ wide-arithmetic bundle has NO wide ops — flags wrong; refusing to ship"
+    exit 1
   fi
   ls -lh "$WIDE_REL/ifc-lite_bg.wasm" | awk '{print "   Wide WASM: " $5 " (no budget — not the default bundle)"}'
 fi

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -176,5 +176,44 @@ if [ "${BUILD_THREADED:-}" = "1" ]; then
   ls -lh "$THREADED_WASM" | awk '{print "   Threaded WASM: " $5 " (no budget — not the default bundle)"}'
 fi
 
+# --- Optional third bundle: wide-arithmetic ---------------------------------
+# Off by default. Enable with `BUILD_WIDE=1 ./scripts/build-wasm.sh`.
+# Same single-thread bundle as `pkg`, plus the wasm wide-arithmetic proposal
+# (+wide-arithmetic), which maps the exact-CSG kernel's bnum 64x64->128 limb
+# products to i64.mul_wide / i64.add128 instead of __multi3 libcalls. Measured
+# ~1.7x on a real void cut (docs/architecture/wasm-wide-arithmetic.md). Selected
+# at runtime via a WebAssembly.validate() probe (packages/geometry/src/wasm-features.ts);
+# engines without the proposal load the `pkg` bundle and are unaffected.
+if [ "${BUILD_WIDE:-}" = "1" ]; then
+  WIDE_OUT="../../packages/wasm/pkg-wide"
+  echo ""
+  echo "🔢 Building wide-arithmetic bundle → $WIDE_OUT (+wide-arithmetic)"
+  # RUSTFLAGS fully replaces .cargo/config.toml's target rustflags, so repeat the
+  # base flags (max-memory, stack-size, simd128) and add +wide-arithmetic.
+  RUSTFLAGS="-C link-arg=--max-memory=4294967296 -C link-arg=-zstack-size=8388608 -C target-feature=+simd128,+wide-arithmetic" \
+  rustup run nightly-2025-11-15 "$WASM_PACK" build rust/wasm-bindings \
+    --target web \
+    --out-dir "$WIDE_OUT" \
+    --out-name ifc-lite \
+    --release \
+    $FEATURES
+
+  WIDE_REL="$(echo "$WIDE_OUT" | sed 's|^../../||')"
+  WIDE_DTS="$WIDE_REL/ifc-lite.d.ts"
+  if [ -f "$WIDE_DTS" ]; then
+    grep -v '__wasm_bindgen_func_elem_' "$WIDE_DTS" > "$WIDE_DTS.tmp" && mv "$WIDE_DTS.tmp" "$WIDE_DTS"
+  fi
+  # Litmus test: the bundle must actually contain wide-arithmetic ops.
+  if command -v wasm-tools >/dev/null 2>&1; then
+    if [ "$(wasm-tools print "$WIDE_REL/ifc-lite_bg.wasm" 2>/dev/null | grep -cE 'mul_wide|add128|sub128')" -gt 0 ]; then
+      echo "🔢 ✅ wide-arithmetic bundle emits wide ops"
+    else
+      echo "🔢 ❌ wide-arithmetic bundle has NO wide ops — flags wrong; refusing to ship"
+      exit 1
+    fi
+  fi
+  ls -lh "$WIDE_REL/ifc-lite_bg.wasm" | awk '{print "   Wide WASM: " $5 " (no budget — not the default bundle)"}'
+fi
+
 echo ""
 echo "✨ Build complete!"


### PR DESCRIPTION
> **Status: tracking spike — NOT shippable, no user-facing speedup today.** Draft until the two upstream blockers below clear.

## What

Measures the WASM **wide-arithmetic** proposal on ifc-lite's actual exact-CSG kernel and documents how to ship it *once it's possible*. This is the only no-install lever that attacks the root cause of the in-browser CSG/brep slowdown (no wide-integer hardware on wasm32 -> bnum's 64x64->128 limb products become `__multi3` libcalls).

**This PR ships docs + build tooling only** — the `BUILD_WIDE=1` bundle flag and the architecture doc. No published-package src, no runtime wiring, no changeset. Merging it gives users nothing; it exists to record the measurement and the delivery plan.

## Does this reach users? No — blocked on two upstream items (verified 2026-06-27)

1. **wasm-bindgen cannot parse a wide-arith module.** Production wasm goes through `wasm-bindgen =0.2.106` for the `IfcAPI` glue; building `pkg-wide` fails in the bindgen step (`failed to parse code section: wide arithmetic support is not enabled` — its `walrus` parser rejects the new opcodes). The benches sidestep this with a plain `cdylib` (no bindgen), which is why they build and run while the real bundle can't.
2. **No stable browser engine supports it.** Node 22 / V8 returns `WebAssembly.validate() -> false` ("invalid numeric opcode 0xfc13"); stable Chrome/Safari are the same. The proposal is Phase 3 (not a finished standard); only Wasmtime/Wasmer run it in stable. Realistic shipping: per-engine through 2026-2027, "Baseline" (safe to rely on everywhere) later.

The runtime gate (40-byte `WebAssembly.validate()` probe -> choose `pkg-wide` vs `pkg` URL) is a **zero-cost no-op** until both clear: the probe returns false on every engine today, so the wide `.wasm` is never fetched. It auto-upgrades per engine with zero regression.

## Measured (Apple M4, rustc 1.93 / LLVM 21, wasmtime 46)

`-C target-feature=+wide-arithmetic` makes LLVM emit `i64.mul_wide`/`add128`/`sub128` from our real `bnum` I256/I512 predicate math; output is byte-identical to baseline.

- **Predicate (orient3d det3):** I256 438->232 ns (1.9x), I512 1093->358 ns (3.1x) — to ~native parity.
- **End-to-end real void cut** (`subtract_many`, slab minus 9 boxes): **23.16 -> 13.58 ms/cut = 1.71x**; wasm goes from 2.26x slower-than-native to **1.33x**. Note this is one real cut, not full-model load time, and only on exact-CSG/brep-heavy work.

Native already beats web-ifc on the Tekla model (2.9s vs 4.9s), so closing the wasm gap this far makes the in-browser path competitive on exactly the models that look slow today.

## In this PR (docs + build tooling only)

- `docs/architecture/wasm-wide-arithmetic.md`: numbers, mechanism, upstream blocker status, and the delivery plan.
- `scripts/build-wasm.sh`: `BUILD_WIDE=1` builds a `packages/wasm/pkg-wide` bundle (mirrors `pkg-threaded`; refuses to ship if the wide ops aren't present).

## Delivery plan (follow-up, once BOTH blockers clear)

Reuses the threaded-bundle pattern exactly: build `pkg-wide` -> feature-detect at runtime with the `validate()` probe -> pass the `pkg-wide` URL through `geometry.worker.ts`'s existing `wasmUrl` plumbing. Engines without the proposal load `pkg` and are unaffected, so it can ship eagerly once buildable.

For reference, the bigger levers that work in **today's** browsers: threads (`pkg-threaded`, measured 1.6-1.9x end-to-end, built in #1255, not yet wired into runtime selection) and the tessellation tier (medium->low ~7.6x on heavy steel, no rebuild). wide-arith is additive on top of those later.

Repro crates live in the profiling repo under `wide-arith/`.
