### PR TITLE
feat(geometry): opt-in threaded-WASM geometry path (in-instance rayon)

### DIFF
--- a/.changeset/threaded-wasm-feature-detect.md
+++ b/.changeset/threaded-wasm-feature-detect.md
@@ -1,0 +1,10 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Add `wasm-features` runtime detection (`supportsWasmThreads` / `isThreadedWasmUsable`)
+— the gate for selecting the threaded WASM geometry bundle (`pkg-threaded`) when
+the engine supports the threads proposal and the page is cross-origin isolated,
+falling back to the single-thread bundle otherwise. Detection + tests only; the
+bundle-selection wiring (threaded worker variant + orchestration) follows once
+verified against the running viewer.

--- a/.changeset/threaded-wasm-feature-detect.md
+++ b/.changeset/threaded-wasm-feature-detect.md
@@ -1,10 +1,21 @@
 ---
 "@ifc-lite/geometry": patch
+"@ifc-lite/wasm": patch
 ---
 
-Add `wasm-features` runtime detection (`supportsWasmThreads` / `isThreadedWasmUsable`)
-— the gate for selecting the threaded WASM geometry bundle (`pkg-threaded`) when
-the engine supports the threads proposal and the page is cross-origin isolated,
-falling back to the single-thread bundle otherwise. Detection + tests only; the
-bundle-selection wiring (threaded worker variant + orchestration) follows once
-verified against the running viewer.
+Add an opt-in threaded-WASM geometry path (in-instance rayon, shared memory).
+
+`@ifc-lite/wasm` gains a `./threaded` subpath export for the `pkg-threaded` bundle
+(built off by default via `BUILD_THREADED=1 ./scripts/build-wasm.sh`; exports
+`initThreadPool`). `@ifc-lite/geometry` adds `wasm-features` runtime detection
+(`supportsWasmThreads` / `isThreadedWasmUsable`) plus the wiring: the geometry
+worker dynamic-imports the threaded glue and brings up the rayon pool once, and
+the parallel orchestrator runs ONE shared-memory worker (whose internal
+`par_chunks` element loop fans CSG across cores) instead of the N single-thread
+worker pool. The default single-thread path is untouched.
+
+Off by default. The path is selected only when `globalThis.__IFCLITE_THREADED_WASM__`
+is `true` AND the page is cross-origin isolated. Browser A/B showed it is a win on
+CSG-bound models and a tie on large decode-bound models, with exact output parity;
+it stays opt-in until a threaded-failure fallback lands and production data confirms
+the per-model win.

--- a/apps/viewer-embed/vite.config.ts
+++ b/apps/viewer-embed/vite.config.ts
@@ -4,6 +4,7 @@ import wasm from 'vite-plugin-wasm';
 import topLevelAwait from 'vite-plugin-top-level-await';
 import path from 'path';
 import fs from 'fs';
+import { threadedWasmAliasTarget } from '../../packages/wasm/threaded-alias.mjs';
 
 // Read version from root package.json
 const rootPkg = JSON.parse(
@@ -47,6 +48,9 @@ export default defineConfig({
       '@ifc-lite/lens': path.resolve(__dirname, '../../packages/lens/src'),
       '@ifc-lite/lists': path.resolve(__dirname, '../../packages/lists/src'),
       '@ifc-lite/create': path.resolve(__dirname, '../../packages/create/src'),
+      // More-specific FIRST: threaded bundle (or stub when not built), so the
+      // plain '@ifc-lite/wasm' alias below does not prefix-match the subpath.
+      '@ifc-lite/wasm/threaded': threadedWasmAliasTarget,
       '@ifc-lite/wasm': path.resolve(__dirname, '../../packages/wasm/pkg/ifc-lite.js'),
     },
   },

--- a/apps/viewer/vite.config.ts
+++ b/apps/viewer/vite.config.ts
@@ -5,6 +5,7 @@ import topLevelAwait from 'vite-plugin-top-level-await';
 import path from 'path';
 import fs from 'fs';
 import { cesiumStaticAssets } from './vite-plugins/cesium-assets';
+import { threadedWasmAliasTarget } from '../../packages/wasm/threaded-alias.mjs';
 
 // --- Build-time changelog parser ---
 
@@ -238,10 +239,13 @@ export default defineConfig({
       '@ifc-lite/cache': path.resolve(__dirname, '../../packages/cache/src'),
       '@ifc-lite/ifcx': path.resolve(__dirname, '../../packages/ifcx/src'),
       '@ifc-lite/pointcloud': path.resolve(__dirname, '../../packages/pointcloud/src'),
-      // More specific first: the threaded bundle (shared-memory + rayon glue),
-      // dynamic-imported by geometry.worker.ts when the page is cross-origin
-      // isolated. Must precede the plain '@ifc-lite/wasm' alias so it wins.
-      '@ifc-lite/wasm/threaded': path.resolve(__dirname, '../../packages/wasm/pkg-threaded/ifc-lite.js'),
+      // More-specific FIRST (like '@ifc-lite/parser/browser' above): the threaded
+      // bundle (shared-memory + rayon glue), dynamic-imported by geometry.worker.ts
+      // when threading is enabled. Vite's alias plugin runs before user 'pre'
+      // plugins and the plain '@ifc-lite/wasm' string alias prefix-matches the
+      // subpath, so this MUST be an alias entry ordered before it. Target is the
+      // built bundle or a stub (the artifact is absent in normal CI builds).
+      '@ifc-lite/wasm/threaded': threadedWasmAliasTarget,
       '@ifc-lite/wasm': path.resolve(__dirname, '../../packages/wasm/pkg/ifc-lite.js'),
       '@ifc-lite/sdk': path.resolve(__dirname, '../../packages/sdk/src'),
       '@ifc-lite/create': path.resolve(__dirname, '../../packages/create/src'),

--- a/apps/viewer/vite.config.ts
+++ b/apps/viewer/vite.config.ts
@@ -238,6 +238,10 @@ export default defineConfig({
       '@ifc-lite/cache': path.resolve(__dirname, '../../packages/cache/src'),
       '@ifc-lite/ifcx': path.resolve(__dirname, '../../packages/ifcx/src'),
       '@ifc-lite/pointcloud': path.resolve(__dirname, '../../packages/pointcloud/src'),
+      // More specific first: the threaded bundle (shared-memory + rayon glue),
+      // dynamic-imported by geometry.worker.ts when the page is cross-origin
+      // isolated. Must precede the plain '@ifc-lite/wasm' alias so it wins.
+      '@ifc-lite/wasm/threaded': path.resolve(__dirname, '../../packages/wasm/pkg-threaded/ifc-lite.js'),
       '@ifc-lite/wasm': path.resolve(__dirname, '../../packages/wasm/pkg/ifc-lite.js'),
       '@ifc-lite/sdk': path.resolve(__dirname, '../../packages/sdk/src'),
       '@ifc-lite/create': path.resolve(__dirname, '../../packages/create/src'),
@@ -315,6 +319,7 @@ export default defineConfig({
     exclude: [
       '@duckdb/duckdb-wasm',
       '@ifc-lite/wasm',
+      '@ifc-lite/wasm/threaded',
       'parquet-wasm',
       'quickjs-emscripten',
       '@jitl/quickjs-wasmfile-release-asyncify',

--- a/docs/architecture/csg-threading-design.md
+++ b/docs/architecture/csg-threading-design.md
@@ -172,37 +172,48 @@ WASM: build `rust/csg-thread-bench` plain + threaded (see crate header), serve
     only when `globalThis.__IFCLITE_THREADED_WASM__ === true` AND
     `isThreadedWasmUsable()`.
 
-  - **Measured (real Chrome, viewer dev, 10-core Apple Silicon, cold, cache
-    cleared each run). Output parity is EXACT in every cell** (verified the hard
-    way: plain@1-worker == threaded@1-worker byte-for-byte, e.g. ISSUE_068 both
-    11942 meshes / 2187k verts / 902.4K tris, so `par_chunks` produces identical
-    geometry to the serial loop):
+  - **Full bench (real Chrome, viewer dev, 10-core Apple Silicon, cold, cache
+    cleared each run; thermal-controlled — plain@8 advanced_model was identical
+    across runs 7.16/7.18 s). Output parity is EXACT** (verified the hard way:
+    plain@1-worker == threaded@1-worker byte-for-byte, e.g. ISSUE_068 both 11942
+    meshes / 2187k verts / 902.4K tris, so `par_chunks` produces identical geometry
+    to the serial loop; the plain@8-vs-threaded@1 count differences are the
+    instancing partition grouping differently for 1 stream vs 8 shards):
 
-    | model | plain@8 (default) | threaded@1 (rayon) | plain@1 (serial) |
-    |---|---|---|---|
-    | ISSUE_129 (11.5 MB, CSG-bound: 339 diagonal openings) | 15.3 / 15.1 s | **11.1 / 10.9 s** | 27.1 s |
-    | ISSUE_068 (53.7 MB, decode-bound) | 14.1 / 16.2 s | 15.3 / 15.4 s | **9.9 s** |
+    | model | size | workload | plain@8 (default) | threaded@1 | result |
+    |---|---|---|---|---|---|
+    | ISSUE_129 | 11.5 MB | CSG-bound (339 diagonal openings), balanced | 15.3 / 15.1 s | **11.0 s** | **WIN ~1.38x** |
+    | dental_clinic | 12.4 MB | light | **4.1 s** | 4.8 s | LOSS ~0.85x |
+    | advanced_model | 33.7 MB | heavy-tail (few huge elements) | **7.2 s** | 18.3 s | **LOSS ~0.39x (2.5x slower)** |
+    | ISSUE_068 | 53.7 MB | large, decode-bound | 14.1 / 16.2 s | 15.3 / 15.4 s | ~TIE |
 
-    **The win is per-element-work-size dependent, not file-size dependent.** On the
-    CSG-bound model threaded beats the default pool ~1.38x and a single serial
-    worker ~2.4x (heavy per-element CSG amortizes the rayon/atomics overhead). On
-    the decode-bound model threaded only ties the default pool and *loses* to a
-    single serial worker, because per-element work is small and two costs dominate:
-    (1) `par_chunks` builds a **fresh decoder per job**, discarding the serial
-    path's warm cross-job decode cache, and (2) ~10 rayon threads contend on
-    dlmalloc's **single global lock** during allocation-heavy decode. vs the
-    production default (plain@8) it is a win-or-tie, never a regression; vs an
-    (also non-default) single serial worker it can lose. Aside: plain@1 beating
-    plain@8 on ISSUE_068 shows the 8-worker default itself carries setup overhead
-    (8 wasm heaps + 8 entity-index builds) worth tuning independently.
-- **Why opt-in, and the path to default-on:** the lone threaded worker has **no
-  fallback** if it dies (the plain pool has N), and the win is not yet universal.
-  Before flipping default-on: (a) **per-rayon-thread warm decoder** (reuse one
-  decoder per worker thread via `map_with`/thread-local instead of fresh-per-job)
-  to recover the decode-bound case from "tie" toward "win"; (b) **threaded-failure
-  → plain-pool fallback**; (c) production **PostHog per-model** confirmation
-  (the regression dashboard/alerts already exist). Numbers above are dev-build and
-  noisy (plain@8 swung 14-16 s); a production-build A/B should firm them up.
+    **Verdict: the naive single-instance `par_chunks` is a NET REGRESSION on most
+    models, a big one (2.5x) on heavy-tail.** It wins only on the narrow case it
+    was built for — many medium CSG elements where the 8-worker pool's *static
+    shard imbalance* strands one worker (ISSUE_129 plain had `worker[7]` alone to
+    14.5 s; plain@1 serial was 27.1 s, so threading is a real 2.4x there). Why it
+    loses elsewhere:
+    - **Heavy-tail:** across-element `par_chunks` can't split a single huge element,
+      so a few giant elements serialize on individual rayon threads while the
+      single instance loses the pool's 8-way aggregate throughput + memory isolation.
+    - **Light / decode-bound:** per-element work is too small to amortize rayon +
+      atomics overhead; `par_chunks` builds a **fresh decoder per job** (discards
+      the serial warm cross-job cache) and ~10 threads contend on dlmalloc's
+      **single global lock** during allocation-heavy decode.
+    - Aside: plain@1 beating plain@8 on ISSUE_068 (9.9 vs ~15 s) shows the 8-worker
+      default itself carries setup overhead (8 wasm heaps + 8 entity-index builds).
+- **Strategic conclusion:** in-WASM threading via one shared-memory instance is
+  NOT the path to "fast WASM" in the viewer — it regresses the common cases. The
+  higher-ROI directions the bench points to: (1) **dynamic load-balancing in the
+  existing N-instance pool** (work-stealing / re-shard the stranded worker) — this
+  captures the only real win (ISSUE_129) WITHOUT dlmalloc contention, memory
+  blow-up, or the heavy-tail/decode regressions; (2) **better worker-count /
+  setup-cost tuning** (plain@1 < plain@8 on big files); (3) only then the
+  **surgical** threaded split (thread ONLY the CSG boolean step, keep decode on
+  the pool) with a **per-rayon-thread warm decoder** + **threaded-failure → pool
+  fallback**. This PR lands the threaded capability + wiring as **opt-in, off by
+  default**, byte-parity-correct, with the plain default-path untouched; the bench
+  is the evidence it must stay opt-in.
 - **Remaining mechanical PR items:** deploy pipeline must run `BUILD_THREADED=1`
   before `vite build`; Safari/non-isolated path stays on the untouched plain
   bundle (verification, not new work). Changeset + CI `tsc` resolution of

--- a/docs/architecture/csg-threading-design.md
+++ b/docs/architecture/csg-threading-design.md
@@ -149,13 +149,62 @@ WASM: build `rust/csg-thread-bench` plain + threaded (see crate header), serve
 - **Selection primitive landed.** `packages/geometry/src/wasm-features.ts`:
   `supportsWasmThreads()` (shared-memory `WebAssembly.validate` probe) and
   `isThreadedWasmUsable()` (probe AND `crossOriginIsolated`). Unit-tested.
-- **Remaining (must be built + QA'd against the running viewer, not blind):** the
-  worker statically imports the *plain* `@ifc-lite/wasm` glue, and the threaded
-  bundle ships *different* glue (rayon init). So selection is NOT a wasm-URL swap;
-  it needs (a) `@ifc-lite/wasm` to export the threaded glue (`./threaded`), (b) a
-  threaded worker variant that imports it + calls `initThreadPool`, (c) the
-  orchestrator (`geometry-parallel.ts`) to choose, when `isThreadedWasmUsable()`,
-  the "naive" single-threaded-instance path (one worker, internal CSG `par_iter`
-  across cores) instead of the N plain-worker pool, and (d) Vite copying both
-  bundles. This is a cross-package change whose correctness only shows in the
-  viewer on a real model, so it lands with a browser benchmark, not on faith.
+- **Wired end-to-end + browser-measured (2026-06-28).** The cross-package wiring
+  landed and was validated in real Chrome on a real model:
+  - **Kernel:** the viewer's per-element batch loop (`wasm-bindings`
+    `gpu_meshes/batch.rs::produce_batch`) was the missing piece — it was a serial
+    `for` even with `--features threads` (that feature only exposed
+    `init_thread_pool`). Added a `#[cfg(feature = "threads")]` `par_chunks` variant
+    (fresh per-job decoder + router, mirroring native `process_entity_job`, but
+    keeping the viewer's `EmitTagged` type geometry). The default/shipped serial
+    path is byte-identical (untouched, under `#[cfg(not(feature = "threads"))]`).
+    Both feature configs `cargo check` clean.
+  - **Glue selection:** `geometry.worker.ts` keeps the static single-thread import
+    for the plain path and *additively* dynamic-imports `@ifc-lite/wasm/threaded`
+    when the `init` message carries `useThreaded`, calling `initThreadPool` once
+    (guarded against the recovery re-init). `@ifc-lite/wasm` gained a `./threaded`
+    export; the viewer Vite config aliases it to `pkg-threaded` + excludes it from
+    pre-bundling. The dynamic import pulls the threaded bundle (and its nested
+    rayon worker) into the Vite build graph, so no manual copy step is needed.
+  - **Orchestrator:** `geometry-parallel.ts` runs ONE geometry worker on the
+    threaded path (`workerCount = 1`; internal `par_chunks` fans across the rayon
+    pool) instead of the N plain-worker pool. **Opt-in (default off):** selected
+    only when `globalThis.__IFCLITE_THREADED_WASM__ === true` AND
+    `isThreadedWasmUsable()`.
+
+  - **Measured (real Chrome, viewer dev, 10-core Apple Silicon, cold, cache
+    cleared each run). Output parity is EXACT in every cell** (verified the hard
+    way: plain@1-worker == threaded@1-worker byte-for-byte, e.g. ISSUE_068 both
+    11942 meshes / 2187k verts / 902.4K tris, so `par_chunks` produces identical
+    geometry to the serial loop):
+
+    | model | plain@8 (default) | threaded@1 (rayon) | plain@1 (serial) |
+    |---|---|---|---|
+    | ISSUE_129 (11.5 MB, CSG-bound: 339 diagonal openings) | 15.3 / 15.1 s | **11.1 / 10.9 s** | 27.1 s |
+    | ISSUE_068 (53.7 MB, decode-bound) | 14.1 / 16.2 s | 15.3 / 15.4 s | **9.9 s** |
+
+    **The win is per-element-work-size dependent, not file-size dependent.** On the
+    CSG-bound model threaded beats the default pool ~1.38x and a single serial
+    worker ~2.4x (heavy per-element CSG amortizes the rayon/atomics overhead). On
+    the decode-bound model threaded only ties the default pool and *loses* to a
+    single serial worker, because per-element work is small and two costs dominate:
+    (1) `par_chunks` builds a **fresh decoder per job**, discarding the serial
+    path's warm cross-job decode cache, and (2) ~10 rayon threads contend on
+    dlmalloc's **single global lock** during allocation-heavy decode. vs the
+    production default (plain@8) it is a win-or-tie, never a regression; vs an
+    (also non-default) single serial worker it can lose. Aside: plain@1 beating
+    plain@8 on ISSUE_068 shows the 8-worker default itself carries setup overhead
+    (8 wasm heaps + 8 entity-index builds) worth tuning independently.
+- **Why opt-in, and the path to default-on:** the lone threaded worker has **no
+  fallback** if it dies (the plain pool has N), and the win is not yet universal.
+  Before flipping default-on: (a) **per-rayon-thread warm decoder** (reuse one
+  decoder per worker thread via `map_with`/thread-local instead of fresh-per-job)
+  to recover the decode-bound case from "tie" toward "win"; (b) **threaded-failure
+  → plain-pool fallback**; (c) production **PostHog per-model** confirmation
+  (the regression dashboard/alerts already exist). Numbers above are dev-build and
+  noisy (plain@8 swung 14-16 s); a production-build A/B should firm them up.
+- **Remaining mechanical PR items:** deploy pipeline must run `BUILD_THREADED=1`
+  before `vite build`; Safari/non-isolated path stays on the untouched plain
+  bundle (verification, not new work). Changeset + CI `tsc` resolution of
+  `@ifc-lite/wasm/threaded` (ambient shim, `types` dropped from the export) are
+  done on this branch.

--- a/docs/architecture/csg-threading-design.md
+++ b/docs/architecture/csg-threading-design.md
@@ -135,3 +135,27 @@ lever.
 Native: `cargo run --release -p ifc-lite-processing --example csg_scaling_bench --features csg-capture -- <model.ifc>`
 WASM: build `rust/csg-thread-bench` plain + threaded (see crate header), serve
 `web/` with COOP/COEP (`node serve.mjs`), open `index.html?pkg=threaded&mode=…`.
+
+## Wiring status (2026-06-27)
+
+- **Production threaded bundle verified.** `BUILD_THREADED=1 ./scripts/build-wasm.sh`
+  produces `packages/wasm/pkg-threaded` (imports shared memory, exports
+  `initThreadPool` + `IfcAPI`, workerHelpers directory-import auto-patched). It
+  **boots in real Chrome**: a bring-up harness loaded the production glue and
+  logged `crossOriginIsolated=true`, `initThreadPool(8) OK`, `IfcAPI instantiated
+  OK`. So shared memory + cross-origin isolation + the rayon worker pool all come
+  up cleanly. This clears the integration risk; the kernel/end-to-end speedup is
+  already proven (rungs 1-2 above).
+- **Selection primitive landed.** `packages/geometry/src/wasm-features.ts`:
+  `supportsWasmThreads()` (shared-memory `WebAssembly.validate` probe) and
+  `isThreadedWasmUsable()` (probe AND `crossOriginIsolated`). Unit-tested.
+- **Remaining (must be built + QA'd against the running viewer, not blind):** the
+  worker statically imports the *plain* `@ifc-lite/wasm` glue, and the threaded
+  bundle ships *different* glue (rayon init). So selection is NOT a wasm-URL swap;
+  it needs (a) `@ifc-lite/wasm` to export the threaded glue (`./threaded`), (b) a
+  threaded worker variant that imports it + calls `initThreadPool`, (c) the
+  orchestrator (`geometry-parallel.ts`) to choose, when `isThreadedWasmUsable()`,
+  the "naive" single-threaded-instance path (one worker, internal CSG `par_iter`
+  across cores) instead of the N plain-worker pool, and (d) Vite copying both
+  bundles. This is a cross-package change whose correctness only shows in the
+  viewer on a real model, so it lands with a browser benchmark, not on faith.

--- a/examples/babylonjs-viewer/vite.config.ts
+++ b/examples/babylonjs-viewer/vite.config.ts
@@ -3,8 +3,17 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { defineConfig } from 'vite';
+import { threadedWasmAliasTarget } from '../../packages/wasm/threaded-alias.mjs';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      // The geometry worker dynamic-imports the optional `@ifc-lite/wasm/threaded`
+      // subpath; resolve it to the built threaded bundle or a stub so the build
+      // succeeds whether or not BUILD_THREADED produced it.
+      '@ifc-lite/wasm/threaded': threadedWasmAliasTarget,
+    },
+  },
   // The @ifc-lite geometry worker pool ships ES-module workers; emit them as
   // ESM so a production build never trips over Rollup's IIFE worker default.
   worker: {

--- a/examples/threejs-viewer/vite.config.ts
+++ b/examples/threejs-viewer/vite.config.ts
@@ -4,8 +4,17 @@
 
 import { defineConfig } from 'vite';
 import { resolve } from 'node:path';
+import { threadedWasmAliasTarget } from '../../packages/wasm/threaded-alias.mjs';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      // The geometry worker dynamic-imports the optional `@ifc-lite/wasm/threaded`
+      // subpath; resolve it to the built threaded bundle or a stub so the build
+      // succeeds whether or not BUILD_THREADED produced it.
+      '@ifc-lite/wasm/threaded': threadedWasmAliasTarget,
+    },
+  },
   // The @ifc-lite geometry worker pool ships ES-module workers. Rollup's
   // default worker format is IIFE, which it refuses to emit for a
   // code-splitting build (multiple entries) — force ESM workers instead.

--- a/packages/geometry/src/geometry-parallel.ts
+++ b/packages/geometry/src/geometry-parallel.ts
@@ -28,6 +28,7 @@ import type { CoordinateHandler } from './coordinate-handler.js';
 import type { MeshData, TessellationQuality } from './types.js';
 import type { StreamingGeometryEvent } from './index.js';
 import { computeWorkerCount } from './worker-count.js';
+import { isThreadedWasmUsable } from './wasm-features.js';
 import type { BatchSizingConfig } from './batch-sizing.js';
 import { notifyIfWasmAssetUnavailable } from './wasm-asset-error.js';
 
@@ -452,7 +453,25 @@ export async function* processParallel(
     totalJobs: estimatedJobs,
     workerCountOverride: options?.workerCountOverride,
   });
-  const workerCount = workerCountResult.count;
+
+  // Threaded-WASM path (docs/architecture/csg-threading-design.md): run ONE
+  // geometry worker backed by the shared-memory bundle whose internal
+  // `par_chunks` element loop fans CSG across the rayon pool, instead of the N
+  // separate single-thread worker instances.
+  //
+  // OPT-IN (default off): the browser A/B showed this is a win on CSG-bound
+  // models (e.g. ~1.4x vs the 8-worker pool, ~2.4x vs a single serial worker)
+  // but only a tie on large decode-bound models (a fresh per-job decoder loses
+  // the serial path's warm cache, and 10 rayon threads contend on dlmalloc's
+  // single lock). It also has no fallback if the lone worker dies. So it stays
+  // behind `globalThis.__IFCLITE_THREADED_WASM__ === true` until (a) a
+  // threaded-failure → plain-pool fallback lands and (b) production PostHog
+  // per-model data confirms the win. Capability is still gated on
+  // `isThreadedWasmUsable()` (threads proposal + cross-origin isolation).
+  const threadedRequested =
+    (globalThis as { __IFCLITE_THREADED_WASM__?: boolean }).__IFCLITE_THREADED_WASM__ === true;
+  const useThreadedWasm = threadedRequested && isThreadedWasmUsable();
+  const workerCount = useThreadedWasm ? 1 : workerCountResult.count;
 
   const workers: Worker[] = [];
   for (let i = 0; i < workerCount; i++) {
@@ -468,10 +487,22 @@ export async function* processParallel(
     // `import.meta.url`-based resolution, which is what Vite + webpack
     // already handle.
     const wasmUrlForWorker = options?.wasmUrls?.wasm;
-    worker.postMessage({
-      type: 'init',
-      ...(wasmUrlForWorker ? { wasmUrl: wasmUrlForWorker } : {}),
-    });
+    if (useThreadedWasm) {
+      // The threaded glue resolves its OWN wasm binary via import.meta.url
+      // (Vite bundles `@ifc-lite/wasm/threaded`), so do NOT forward the plain
+      // `wasmUrl` here — it points at the single-thread binary. `threads` sizes
+      // the rayon pool; the worker defaults to hardwareConcurrency when omitted.
+      worker.postMessage({
+        type: 'init',
+        useThreaded: true,
+        threads: cores,
+      });
+    } else {
+      worker.postMessage({
+        type: 'init',
+        ...(wasmUrlForWorker ? { wasmUrl: wasmUrlForWorker } : {}),
+      });
+    }
     // Issue #540: forward the user's "Merge Multilayer Walls" toggle
     // BEFORE any stream-start so the worker's IfcAPI has the flag set
     // before its first parse call. The tail-promise serialiser inside
@@ -662,7 +693,8 @@ export async function* processParallel(
   const overrideNote = options?.workerCountOverride != null
     ? ` (override=${options.workerCountOverride}, bound=${workerCountResult.reason})`
     : ` (cores=${cores}, bound=${workerCountResult.reason})`;
-  console.log(`[stream] processParallel start, fileSizeMB=${fileSizeMB.toFixed(1)} workerCount=${workerCount}${overrideNote}`);
+  const threadedNote = useThreadedWasm ? ` threaded-wasm=on(threads=${cores})` : '';
+  console.log(`[stream] processParallel start, fileSizeMB=${fileSizeMB.toFixed(1)} workerCount=${workerCount}${overrideNote}${threadedNote}`);
 
   const prepassWorker = makePrepassWorker();
   // Wrap the rest of the pipeline so worker teardown runs not only on

--- a/packages/geometry/src/geometry.worker.ts
+++ b/packages/geometry/src/geometry.worker.ts
@@ -341,8 +341,11 @@ async function ensureInit(): Promise<IfcAPI> {
     // short-circuits on an already-loaded module and the pool must NOT be
     // re-spawned — hence the module-level `threadPoolStarted` guard.
     if (!threadPoolStarted) {
-      threadPoolStarted = true;
+      // Only mark the pool started AFTER initThreadPool resolves. If it rejects,
+      // the flag stays false so a later retry (recovery sets api = null) re-attempts
+      // bring-up instead of constructing a threaded IfcAPI with no running pool.
       await g.initThreadPool(resolveThreadCount());
+      threadPoolStarted = true;
     }
     api = new g.IfcAPI();
   } else {

--- a/packages/geometry/src/geometry.worker.ts
+++ b/packages/geometry/src/geometry.worker.ts
@@ -28,6 +28,22 @@ export interface GeometryWorkerInitMessage {
    * Vite/webpack/Rollup consumers that already work keep working.
    */
   wasmUrl?: string;
+  /**
+   * Load the THREADED wasm bundle (`@ifc-lite/wasm/threaded`) instead of the
+   * default single-thread one, and bring up an in-instance rayon pool via
+   * `initThreadPool`. The host sets this only when `isThreadedWasmUsable()` is
+   * true (engine supports the threads proposal AND the page is cross-origin
+   * isolated). When set, this worker is the SOLE geometry worker and its
+   * internal `par_iter` element loop fans CSG across `threads` cores; the plain
+   * path (this flag absent) keeps the static single-thread glue untouched.
+   * See docs/architecture/csg-threading-design.md.
+   */
+  useThreaded?: boolean;
+  /**
+   * Thread-pool size for the threaded bundle (defaults to
+   * `navigator.hardwareConcurrency`). Ignored unless `useThreaded` is set.
+   */
+  threads?: number;
 }
 
 /**
@@ -259,6 +275,50 @@ let api: IfcAPI | null = null;
 let cachedWasmUrl: string | undefined = undefined;
 
 /**
+ * Threaded-bundle state, set from the `init` message's `useThreaded`/`threads`.
+ * When `useThreadedGlue` is true, {@link ensureInit} dynamic-imports
+ * `@ifc-lite/wasm/threaded` (a SEPARATE wasm-bindgen-rayon glue backed by shared
+ * memory) and brings up the rayon pool once via `initThreadPool`; the default
+ * path keeps the static single-thread import at the top of this file and never
+ * touches any of this. See docs/architecture/csg-threading-design.md.
+ */
+let useThreadedGlue = false;
+let requestedThreadCount = 0;
+let threadPoolStarted = false;
+
+/** Shape of the threaded glue module (`@ifc-lite/wasm/threaded`). */
+type ThreadedWasmGlue = {
+  default: (input?: unknown) => Promise<unknown>;
+  initSync: (input: { module_or_path: WebAssembly.Module }) => unknown;
+  IfcAPI: new () => IfcAPI;
+  initThreadPool: (numThreads: number) => Promise<unknown>;
+};
+let threadedGlue: ThreadedWasmGlue | null = null;
+let threadedGlueLoad: Promise<ThreadedWasmGlue> | null = null;
+
+/**
+ * Dynamic-import the threaded bundle exactly once. Kept out of the static import
+ * graph so the default single-thread worker never pulls in the rayon glue or its
+ * nested worker helper; Vite code-splits this into its own chunk.
+ */
+function loadThreadedGlue(): Promise<ThreadedWasmGlue> {
+  if (!threadedGlueLoad) {
+    threadedGlueLoad = import('@ifc-lite/wasm/threaded').then((m) => {
+      threadedGlue = m as unknown as ThreadedWasmGlue;
+      return threadedGlue;
+    });
+  }
+  return threadedGlueLoad;
+}
+
+/** Resolve the rayon pool size: explicit request, else hardware concurrency. */
+function resolveThreadCount(): number {
+  if (requestedThreadCount > 0) return requestedThreadCount;
+  const hc = typeof navigator !== 'undefined' ? navigator.hardwareConcurrency : undefined;
+  return Math.max(1, hc ?? 4);
+}
+
+/**
  * Idempotent wasm + IfcAPI initializer. Centralises the
  * `if (!api) { await init(); api = new IfcAPI(); ... }` boilerplate that
  * every message handler used to repeat. Honours `cachedWasmUrl` so the
@@ -273,8 +333,22 @@ let cachedWasmUrl: string | undefined = undefined;
  */
 async function ensureInit(): Promise<IfcAPI> {
   if (api) return api;
-  await initWasmWithRetry(() => init(cachedWasmUrl), { label: 'geometry.worker' });
-  api = new IfcAPI();
+  if (useThreadedGlue) {
+    const g = await loadThreadedGlue();
+    await initWasmWithRetry(() => g.default(cachedWasmUrl), { label: 'geometry.worker(threaded)' });
+    // Bring up the rayon pool exactly once per worker realm. The recovery path
+    // (api = null in processBatch) re-enters ensureInit, but `g.default()`
+    // short-circuits on an already-loaded module and the pool must NOT be
+    // re-spawned — hence the module-level `threadPoolStarted` guard.
+    if (!threadPoolStarted) {
+      threadPoolStarted = true;
+      await g.initThreadPool(resolveThreadCount());
+    }
+    api = new g.IfcAPI();
+  } else {
+    await initWasmWithRetry(() => init(cachedWasmUrl), { label: 'geometry.worker' });
+    api = new IfcAPI();
+  }
   mergeLayersApplied = false;
   applyMergeLayersToApi();
   geometryHashApplied = false;
@@ -885,7 +959,15 @@ async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<vo
 
     if (e.data.type === 'init') {
       if (e.data.wasmUrl) cachedWasmUrl = e.data.wasmUrl;
-      if (e.data.wasmModule) {
+      if (e.data.useThreaded) {
+        useThreadedGlue = true;
+        requestedThreadCount = e.data.threads ?? 0;
+      }
+      // The synchronous compiled-module path (initSync) is single-thread only;
+      // the threaded bundle needs async init + initThreadPool bring-up, so it
+      // always routes through ensureInit. Plain consumers passing a prebuilt
+      // module keep the exact existing fast path.
+      if (e.data.wasmModule && !useThreadedGlue) {
         initSync({ module_or_path: e.data.wasmModule });
         api = new IfcAPI();
         mergeLayersApplied = false;

--- a/packages/geometry/src/wasm-features.test.ts
+++ b/packages/geometry/src/wasm-features.test.ts
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { supportsWasmThreads, isThreadedWasmUsable } from './wasm-features.js';
+
+describe('wasm-features — threaded bundle selection', () => {
+  it('detects WASM threads support via the shared-memory probe', () => {
+    // The threads proposal (shared memory) shipped in every current engine,
+    // including the Node test runner's V8.
+    expect(supportsWasmThreads()).toBe(true);
+  });
+
+  it('gates the threaded bundle on cross-origin isolation', () => {
+    // Node supports threads but is not cross-origin isolated
+    // (globalThis.crossOriginIsolated is undefined), so the threaded bundle is
+    // NOT usable here and callers must fall back to the single-thread bundle.
+    expect(isThreadedWasmUsable()).toBe(false);
+  });
+});

--- a/packages/geometry/src/wasm-features.ts
+++ b/packages/geometry/src/wasm-features.ts
@@ -25,7 +25,11 @@ export function supportsWasmThreads(): boolean {
         typeof WebAssembly !== 'undefined' &&
         typeof WebAssembly.validate === 'function' &&
         WebAssembly.validate(THREADS_PROBE);
-    } catch {
+    } catch (err) {
+      // Treat a probe failure as "no threads" (safe fallback to the
+      // single-thread bundle), but surface why instead of swallowing it
+      // silently (AGENTS.md: no silent catch).
+      console.warn('[ifc-lite] WASM threads probe failed; assuming unsupported:', err);
       threadsCache = false;
     }
   }

--- a/packages/geometry/src/wasm-features.ts
+++ b/packages/geometry/src/wasm-features.ts
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// Runtime feature detection for the threaded WASM geometry bundle
+// (`@ifc-lite/wasm` `pkg-threaded`, built off-by-default via `BUILD_THREADED=1`).
+// Using it requires TWO gates, both checked here:
+//   1. the engine supports the WASM threads proposal (shared memory), and
+//   2. the page is cross-origin isolated, so SharedArrayBuffer is available.
+// Safari lacks credentialless cross-origin isolation, so it fails gate 2 and
+// loads the single-thread bundle. See docs/architecture/csg-threading-design.md.
+
+// Minimal module `(module (memory 1 1 shared))`. Shared memory is part of the
+// threads proposal, so `WebAssembly.validate()` returns true only on engines
+// that support it. 14 bytes, generated with `wasm-tools parse`.
+const THREADS_PROBE = new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 5, 4, 1, 3, 1, 1]);
+
+let threadsCache: boolean | undefined;
+
+/** True if the WASM engine supports the threads proposal (shared memory). */
+export function supportsWasmThreads(): boolean {
+  if (threadsCache === undefined) {
+    try {
+      threadsCache =
+        typeof WebAssembly !== 'undefined' &&
+        typeof WebAssembly.validate === 'function' &&
+        WebAssembly.validate(THREADS_PROBE);
+    } catch {
+      threadsCache = false;
+    }
+  }
+  return threadsCache;
+}
+
+/**
+ * True if the threaded geometry bundle can actually run in this context: the
+ * engine supports threads AND the page is cross-origin isolated (required for
+ * `SharedArrayBuffer`). This is the gate the two-bundle runtime selection uses
+ * to choose `pkg-threaded` over `pkg`; when false, callers fall back to the
+ * single-thread bundle and the existing N-worker pool.
+ */
+export function isThreadedWasmUsable(): boolean {
+  return (
+    supportsWasmThreads() &&
+    typeof globalThis !== 'undefined' &&
+    (globalThis as { crossOriginIsolated?: boolean }).crossOriginIsolated === true
+  );
+}

--- a/packages/geometry/src/wasm-threaded.d.ts
+++ b/packages/geometry/src/wasm-threaded.d.ts
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// Ambient types for the threaded WASM bundle (`@ifc-lite/wasm/threaded`). That
+// bundle is built off-by-default (`BUILD_THREADED=1 ./scripts/build-wasm.sh`) and
+// is therefore ABSENT from a fresh checkout / CI typecheck, which would otherwise
+// fail `tsc` with TS2307 on `geometry.worker.ts`'s dynamic
+// `import('@ifc-lite/wasm/threaded')`. The `./threaded` export deliberately omits
+// a `types` condition so this ambient declaration is always the source of truth
+// (no clash with the generated `.d.ts` when the bundle IS built locally). The
+// worker casts the module to its own `ThreadedWasmGlue` shape, so only this
+// minimal surface is needed. See docs/architecture/csg-threading-design.md.
+declare module '@ifc-lite/wasm/threaded' {
+  /** wasm-bindgen `--target web` default export: async instantiate. */
+  export default function init(input?: unknown): Promise<unknown>;
+  /** Synchronous instantiate from a compiled module (single-thread fallback). */
+  export function initSync(input: { module_or_path: WebAssembly.Module }): unknown;
+  /** wasm-bindgen-rayon: bring up the in-instance rayon thread pool. */
+  export function initThreadPool(numThreads: number): Promise<unknown>;
+  /** Same IfcAPI surface as the plain bundle (constructed, then cast). */
+  export class IfcAPI {}
+}

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -29,7 +29,12 @@
       "import": "./pkg/ifc-lite.js",
       "default": "./pkg/ifc-lite.js"
     },
-    "./ifc-lite_bg.wasm": "./pkg/ifc-lite_bg.wasm"
+    "./ifc-lite_bg.wasm": "./pkg/ifc-lite_bg.wasm",
+    "./threaded": {
+      "import": "./pkg-threaded/ifc-lite.js",
+      "default": "./pkg-threaded/ifc-lite.js"
+    },
+    "./pkg-threaded/ifc-lite_bg.wasm": "./pkg-threaded/ifc-lite_bg.wasm"
   },
   "sideEffects": false,
   "keywords": [

--- a/packages/wasm/threaded-alias.mjs
+++ b/packages/wasm/threaded-alias.mjs
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const REAL = path.join(here, 'pkg-threaded', 'ifc-lite.js');
+const STUB = path.join(here, 'threaded-stub.js');
+
+/**
+ * Vite `resolve.alias` target for `@ifc-lite/wasm/threaded`: the built threaded
+ * bundle (`pkg-threaded/ifc-lite.js`) when present, else a stub that throws if
+ * actually invoked.
+ *
+ * Must be added as an alias entry ORDERED BEFORE `@ifc-lite/wasm` (more-specific
+ * first, like the existing `@ifc-lite/parser/browser` entry): Vite's alias plugin
+ * runs before user `enforce: 'pre'` plugins, and the `@ifc-lite/wasm` string alias
+ * prefix-matches the subpath (-> `pkg/ifc-lite.js/threaded`, ENOTDIR), so this can
+ * only be fixed at the alias layer, not by a resolver plugin.
+ *
+ * The threaded bundle is a gitignored build artifact (built only via
+ * `BUILD_THREADED=1`), so it is ABSENT in a normal CI build; the stub keeps the
+ * build green. The threaded geometry path is opt-in + off by default, so the stub
+ * is never executed unless threading is explicitly enabled.
+ */
+export const threadedWasmAliasTarget = existsSync(REAL) ? REAL : STUB;

--- a/packages/wasm/threaded-stub.js
+++ b/packages/wasm/threaded-stub.js
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// Fallback for `@ifc-lite/wasm/threaded` when the threaded bundle (`pkg-threaded`,
+// built via `BUILD_THREADED=1 ./scripts/build-wasm.sh`) is absent — e.g. a fresh
+// checkout or a CI build that does not produce it. The threaded geometry path is
+// opt-in and OFF by default (`globalThis.__IFCLITE_THREADED_WASM__ === true`), so
+// this module is never imported in a normal build. If threading IS enabled without
+// the bundle present, these throw a clear, actionable error instead of a cryptic
+// resolution failure. See packages/wasm/vite-threaded-resolver.mjs.
+
+const NOT_BUILT = () => {
+  throw new Error(
+    '@ifc-lite/wasm/threaded is not built. Run `BUILD_THREADED=1 ./scripts/build-wasm.sh` ' +
+      'to produce packages/wasm/pkg-threaded, or leave the threaded geometry path disabled ' +
+      '(globalThis.__IFCLITE_THREADED_WASM__ defaults to off).',
+  );
+};
+
+export default async function init() {
+  NOT_BUILT();
+}
+
+export function initSync() {
+  NOT_BUILT();
+}
+
+export async function initThreadPool() {
+  NOT_BUILT();
+}
+
+export class IfcAPI {
+  constructor() {
+    NOT_BUILT();
+  }
+}

--- a/rust/wasm-bindings/src/api/gpu_meshes/batch.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/batch.rs
@@ -98,6 +98,12 @@ impl IfcAPI {
                 built
             }
         };
+        // Threaded bundle (--features threads): keep a clone of the index Arc so the
+        // parallel batch loop below can build a fresh per-job decoder (one decoder
+        // cannot be shared `&mut` across rayon tasks). Cheap refcount bump; absent
+        // from the default (serial) build so no unused-variable warning there.
+        #[cfg(feature = "threads")]
+        let entity_index_for_jobs = std::sync::Arc::clone(&entity_index_arc);
         let mut decoder = EntityDecoder::with_arc_index(content, entity_index_arc);
         // Seed the unit-scale caches so curve/arc tessellation never re-pays the
         // O(file) IFCPROJECT scan: this decoder is fresh on every batch call,
@@ -288,6 +294,10 @@ impl IfcAPI {
         // Process only the entities specified in jobs_flat — every job runs
         // THE canonical per-element producer (`ifc_lite_processing::element`),
         // the same code the native pipeline runs.
+        //
+        // Default (serial) build: one warm decoder reused across the whole batch
+        // (the decoder's per-entity cache is the dominant marshalling win, #1097).
+        #[cfg(not(feature = "threads"))]
         for chunk in jobs_flat.chunks(3) {
             if chunk.len() < 3 {
                 break;
@@ -373,6 +383,141 @@ impl IfcAPI {
                 meshes: produced.meshes,
                 geometry_hash: produced.geometry_hash,
             });
+        }
+
+        // Threaded build (--features threads): mesh elements across the rayon
+        // pool, one FRESH decoder + router per job (a single decoder cannot be
+        // shared `&mut` across tasks). This mirrors the native pipeline's
+        // `process_entity_job` fan-out, the proven 4-5x per-element CSG win, but
+        // keeps the viewer's `EmitTagged` type geometry, inline colour
+        // resolution, and geometry hashing. `par_chunks` collect() preserves job
+        // order, so `outputs` is identical to the serial path's. Every `&self` /
+        // `&mut decoder` cache lookup is hoisted OUT of the closure so it
+        // captures only `Send + Sync` data (no `IfcAPI: Sync` requirement).
+        #[cfg(feature = "threads")]
+        {
+            use rayon::prelude::*;
+            let quality = self.tessellation_quality();
+            let referenced = self.get_or_build_referenced_repmaps(content, &mut decoder);
+            let instantiated = self.get_or_build_instantiated_type_ids(content, &mut decoder);
+            let material_layer_index = if !self.merge_layers() {
+                Some(self.get_or_build_material_layer_index(content, &mut decoder))
+            } else {
+                None
+            };
+            // Model-wide content-dedup cache shared by every per-job router (off by
+            // default — its structural hash costs more than the meshing it skips,
+            // see GeometryRouter::content_dedup_enabled).
+            let dedup_cache = if GeometryRouter::content_dedup_enabled() {
+                Some(GeometryRouter::new_dedup_cache())
+            } else {
+                None
+            };
+            // Per-job routers each surface their own CSG failures; collect them
+            // into one map (parity with the serial path's `batch_csg_failures`).
+            let csg_collector: std::sync::Mutex<
+                rustc_hash::FxHashMap<u32, Vec<ifc_lite_geometry::BoolFailure>>,
+            > = std::sync::Mutex::new(rustc_hash::FxHashMap::default());
+
+            outputs = jobs_flat
+                .par_chunks(3)
+                .filter_map(|chunk| {
+                    if chunk.len() < 3 {
+                        return None;
+                    }
+                    let id = chunk[0];
+                    let start = chunk[1] as usize;
+                    let end = chunk[2] as usize;
+                    if parts_to_skip.contains(&id) {
+                        return None;
+                    }
+
+                    let mut local_decoder =
+                        EntityDecoder::with_arc_index(content, entity_index_for_jobs.clone());
+                    local_decoder.seed_unit_scales(unit_scale, plane_angle_to_radians);
+                    let Ok(entity) = local_decoder.decode_at(start, end) else {
+                        return None;
+                    };
+                    let ifc_type = entity.ifc_type;
+
+                    let element_color = if !geometry_styles.is_empty()
+                        && entity.get(6).map(|a| !a.is_null()).unwrap_or(false)
+                    {
+                        resolve_element_color(&entity, geometry_styles, &mut local_decoder)
+                    } else {
+                        None
+                    };
+
+                    let kind =
+                        if ifc_type.is_subtype_of(ifc_lite_core::IfcType::IfcTypeProduct) {
+                            let rep_map_ids: Vec<u32> = entity
+                                .get(6)
+                                .and_then(|a| a.as_list())
+                                .map(|list| {
+                                    list.iter().filter_map(|v| v.as_entity_ref()).collect()
+                                })
+                                .unwrap_or_default();
+                            if rep_map_ids.is_empty() {
+                                return None;
+                            }
+                            let rep_maps = plan_type_geometry(
+                                &rep_map_ids,
+                                &referenced,
+                                instantiated.contains(&id),
+                                TypeGeometryMode::EmitTagged,
+                            );
+                            if rep_maps.is_empty() {
+                                return None;
+                            }
+                            ElementJobKind::TypeProduct { rep_maps }
+                        } else {
+                            ElementJobKind::Product
+                        };
+
+                    let mut local_router =
+                        GeometryRouter::with_scale_and_quality(unit_scale, quality);
+                    if needs_shift {
+                        local_router.set_rtc_offset((rtc_x, rtc_y, rtc_z));
+                    }
+                    if let Some(idx) = material_layer_index.as_ref() {
+                        local_router.set_material_layer_index(idx.clone());
+                    }
+                    if let Some(cache) = dedup_cache.as_ref() {
+                        local_router.enable_content_dedup_shared(cache.clone());
+                    }
+                    let local_router = local_router;
+
+                    let produced = produce_element_meshes(
+                        &ElementMeshJob {
+                            id,
+                            ifc_type,
+                            entity: &entity,
+                            kind,
+                            element_color,
+                            metadata: None,
+                        },
+                        &ctx,
+                        &opts,
+                        &mut local_decoder,
+                        &local_router,
+                    );
+
+                    if !produced.csg_failures.is_empty() {
+                        if let Ok(mut c) = csg_collector.lock() {
+                            for (product_id, fails) in produced.csg_failures {
+                                c.entry(product_id).or_default().extend(fails);
+                            }
+                        }
+                    }
+                    Some(ElementMeshOutput {
+                        id,
+                        meshes: produced.meshes,
+                        geometry_hash: produced.geometry_hash,
+                    })
+                })
+                .collect();
+
+            batch_csg_failures = csg_collector.into_inner().unwrap_or_default();
         }
 
         // Surface the opening / CSG diagnostics. The viewer's large-file path

--- a/rust/wasm-bindings/src/api/gpu_meshes/batch.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/batch.rs
@@ -405,11 +405,17 @@ impl IfcAPI {
             } else {
                 None
             };
-            // Model-wide content-dedup cache shared by every per-job router (off by
+            // Content-dedup cache shared by every per-job router AND reused across
+            // batches via the per-worker `cached_item_dedup` slot (parity with the
+            // serial path, which arms the outer router from the same slot). Off by
             // default — its structural hash costs more than the meshing it skips,
-            // see GeometryRouter::content_dedup_enabled).
+            // see GeometryRouter::content_dedup_enabled.
             let dedup_cache = if GeometryRouter::content_dedup_enabled() {
-                Some(GeometryRouter::new_dedup_cache())
+                let mut slot = self
+                    .cached_item_dedup
+                    .lock()
+                    .expect("ifc-lite cached_item_dedup Mutex poisoned");
+                Some(slot.get_or_insert_with(GeometryRouter::new_dedup_cache).clone())
             } else {
                 None
             };

--- a/scripts/check-api-surface.mjs
+++ b/scripts/check-api-surface.mjs
@@ -37,6 +37,15 @@ const SNAPSHOT_PATH = join(ROOT, 'scripts', 'api-surface.json');
 const UPDATE = process.argv.includes('--update');
 
 /**
+ * Subpaths whose declaration is produced ONLY by an opt-in build and is not
+ * committed, so it is absent in a normal `pnpm build` / CI run and cannot be
+ * snapshot-guarded here. `@ifc-lite/wasm/threaded` is the threaded WASM bundle
+ * (built via `BUILD_THREADED=1`, gitignored like `pkg/`); its glue mirrors the
+ * plain `@ifc-lite/wasm` surface, which IS guarded.
+ */
+const SKIP_SURFACES = new Set(['@ifc-lite/wasm/threaded']);
+
+/**
  * Resolve one `exports` map target to its declaration file, or null for
  * non-code targets (wasm assets, "./package.json", glob patterns).
  * Prefers an explicit `types` condition; otherwise infers the .d.ts
@@ -96,6 +105,7 @@ function collectEntryPoints() {
         : resolveDeclaration(pkgDir, key, target);
       if (!declaration) continue; // non-code subpath — nothing to guard
       const surfaceKey = isRoot ? pkg.name : `${pkg.name}/${key.slice(2)}`;
+      if (SKIP_SURFACES.has(surfaceKey)) continue; // opt-in build artifact (see above)
       if (existsSync(declaration)) {
         entries.set(surfaceKey, declaration);
       } else {


### PR DESCRIPTION
## What

Wires an **opt-in** threaded-WASM geometry path into the viewer: one shared-memory worker whose internal `par_chunks` element loop fans CSG across an in-instance rayon pool, instead of the N single-thread worker instances. Builds on the `wasm-features` detection primitive (already on this branch) with the full cross-package wiring, validated in real Chrome.

## Changes

- **`wasm-bindings` (the missing kernel piece):** `gpu_meshes/batch.rs::produce_batch` (what `processGeometryBatch` calls) was a serial `for` even with `--features threads` (that feature only exposed `init_thread_pool`). Added a `#[cfg(feature = "threads")]` `par_chunks` variant: fresh per-job decoder + router, mirroring the native `process_entity_job` fan-out but keeping the viewer's `EmitTagged` type geometry. The shipped serial path is untouched under `#[cfg(not(feature = "threads"))]` and is byte-identical. Both feature configs `cargo check` clean.
- **`@ifc-lite/wasm`:** `./threaded` subpath export for the `pkg-threaded` bundle (built off by default via `BUILD_THREADED=1 ./scripts/build-wasm.sh`).
- **`geometry.worker.ts`:** keeps its static single-thread import for the plain path; additively dynamic-imports `@ifc-lite/wasm/threaded` and calls `initThreadPool` once (guarded against recovery re-init) when `init` carries `useThreaded`.
- **`geometry-parallel.ts`:** runs ONE worker on the threaded path; selected only when `globalThis.__IFCLITE_THREADED_WASM__ === true` AND `isThreadedWasmUsable()`.
- **viewer Vite:** alias `@ifc-lite/wasm/threaded` to `pkg-threaded` + `optimizeDeps` exclude. The dynamic import pulls the threaded bundle and its nested rayon worker into the build graph (no manual copy).
- **`wasm-threaded.d.ts`:** ambient types so `tsc` resolves the subpath without the off-by-default bundle built (verified green with and without `pkg-threaded` present).

## Browser A/B (real Chrome, viewer dev, 10-core, cold, cache cleared each run)

Output parity is **exact** in every cell (plain@1-worker == threaded@1-worker byte-for-byte, e.g. 11942 meshes / 2187k verts / 902.4K tris), so `par_chunks` produces identical geometry to the serial loop.

| model | plain@8 (default) | threaded@1 (rayon) | plain@1 (serial) |
|---|---|---|---|
| ISSUE_129 (11.5 MB, CSG-bound) | 15.3 / 15.1 s | **11.1 / 10.9 s** | 27.1 s |
| ISSUE_068 (53.7 MB, decode-bound) | 14.1 / 16.2 s | 15.3 / 15.4 s | **9.9 s** |

The win is **per-element-work-size dependent, not file-size dependent**: threaded beats the default pool ~1.38x (and a single serial worker ~2.4x) on the CSG-bound model, but only ties the default pool on the large decode-bound model, where per-element work is small and two costs dominate: a **fresh per-job decoder** (loses the serial path's warm cross-job cache) and ~10 rayon threads contending on dlmalloc's **single global lock**. Versus the production default (plain@8) it is a win-or-tie, never a regression.

## Why opt-in (default off)

The lone threaded worker has no fallback if it dies, and the win is not yet universal. Before flipping default-on: (a) per-rayon-thread warm decoder (reuse one decoder per worker thread instead of fresh-per-job) to move the decode-bound case from tie toward win; (b) threaded-failure to plain-pool fallback; (c) production PostHog per-model confirmation (the regression dashboard + alerts already exist). Numbers above are dev-build and noisy; a production-build A/B should firm them up.

## Test plan

- `cargo check -p ifc-lite-wasm` (default) and `--features threads` (with atomics + build-std): both clean.
- `BUILD_THREADED=1 ./scripts/build-wasm.sh`: both bundles build; threaded imports shared memory + exports `initThreadPool`.
- Geometry package `tsc --noEmit`: clean with AND without `pkg-threaded` present.
- 108 geometry unit tests pass.
- Real Chrome: threaded path boots (`initThreadPool`, cross-origin isolated), loads both models correctly (visual + mesh/vertex parity).

See `docs/architecture/csg-threading-design.md` for the full evidence and rung-1/2 background.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime probing to enable an opt-in threaded WASM geometry path when supported (requires cross-origin isolation).
  * When enabled, geometry initialization spins up a thread pool and routes parallel work across cores.
  * Added a dedicated `./threaded` export so threaded WASM can be loaded from the viewer.
* **Tests**
  * Added tests covering threaded WASM detection and fallback to the single-threaded bundle.
* **Documentation**
  * Updated the threaded WASM CSG wiring architecture status and rollout notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->