### PR TITLE
perf(geometry): right-size worker pool (narrow small-file band to <=24MB)

### DIFF
--- a/.changeset/right-size-worker-pool.md
+++ b/.changeset/right-size-worker-pool.md
@@ -1,0 +1,21 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Right-size the geometry worker pool: narrow the small-file fast path from 8-64 MB
+to <= 24 MB.
+
+A 10-core browser worker-count sweep found the 8-64 MB `cores - 2` band (#1258)
+over-provisioned workers for decode- and heavy-tail-bound models in the 24-64 MB
+range. Because each worker is a separate WASM instance that re-decodes the file
+into its own heap and rebuilds the entity index, 8 workers ran 20-30% SLOWER than
+4 at up to ~5x the peak WASM memory (e.g. ~882 MB vs ~161 MB on a 54 MB model).
+Measured improvements at the new auto-selected count: a 34 MB heavy-tail model
+7.2s -> 5.7s (-21%), a 54 MB decode-bound model 14.4s -> 11.7s (-19%) at roughly
+half the peak memory. Genuinely small compute-bound steel (a 20 MB model with
+~26k boolean jobs) still benefits from `cores - 2` (17.0s vs 22.9s at 4 workers),
+so the fast path is kept for <= 24 MB where the per-worker re-decode/memory cost
+is low; > 24 MB now falls through to the existing per-core bandwidth cap (4 on a
+10-core host). The > 512 MB bandwidth caps and the memory-budget cap are
+unchanged. A fully workload-aware count (using the real prepass job/CSG density
+instead of the file-size proxy) is a follow-up.

--- a/packages/geometry/src/worker-count.test.ts
+++ b/packages/geometry/src/worker-count.test.ts
@@ -144,11 +144,36 @@ describe('computeWorkerCount', () => {
     // steel) — not the sustained bandwidth-bound big-file regime the per-core
     // caps guard. On a 10-core active-cooled machine it gets cores-2 = 8 workers
     // (was capped at 4, leaving 6 cores idle on CSG-bound geometry). Memory is
-    // a non-issue at 20 MB so the memoryCap doesn't bind.
+    // a non-issue at 20 MB so the memoryCap doesn't bind. (Within the narrowed
+    // <= SMALL_FILE_MB (24) fast-path band; per-worker re-decode cost is low here.)
     const r = computeWorkerCount({
       fileSizeMB: 20, cores: 10, deviceMemoryGB: 16, totalJobs: 25_000,
     });
     expect(r.count).toBe(8);
+    expect(r.reason).toBe('cores');
+  });
+
+  it('medium heavy-tail file (34 MB, 10 cores) → per-core cap (4), not the small-file bump', () => {
+    // Above SMALL_FILE_MB (24): a 10-core browser worker-count sweep showed the
+    // old 8-64 MB cores-2 band ran SLOWER than 4 workers on decode-/heavy-tail-
+    // bound models (34 MB: 7.2s@8 → 5.7s@4; 54 MB: 14.4s@8 → ~11s@4) at ~2x peak
+    // memory, because each worker re-decodes the file into its own WASM heap. So
+    // 24-64 MB now falls through to the per-core bandwidth cap (4 on 10-core).
+    const r = computeWorkerCount({
+      fileSizeMB: 34, cores: 10, deviceMemoryGB: 16, totalJobs: 6_000,
+    });
+    expect(r.count).toBe(4);
+    expect(r.reason).toBe('cores');
+  });
+
+  it('larger decode-bound file (54 MB, 10 cores) → per-core cap (4), not cores-2', () => {
+    // Guard against re-widening the small-file band over 24 MB: 54 MB is a classic
+    // decode-bound model (few big elements) where 8 workers thrash memory (882 MB
+    // peak) and run slower than 4. Must stay 4 on a 10-core host.
+    const r = computeWorkerCount({
+      fileSizeMB: 54, cores: 10, deviceMemoryGB: 16, totalJobs: 5_632,
+    });
+    expect(r.count).toBe(4);
     expect(r.reason).toBe('cores');
   });
 

--- a/packages/geometry/src/worker-count.ts
+++ b/packages/geometry/src/worker-count.ts
@@ -104,7 +104,18 @@ export function computeWorkerCount(inputs: WorkerCountInputs): WorkerCountResult
   // for idle workers on a model with little parallel work — while the 8–64 MB
   // band, where there's enough geometry to amortize the workers, still scales.
   // (#1258 review P2.)
-  const SMALL_FILE_MB = 64;
+  //
+  // Narrowed from 64 to 24 MB after a 10-core browser worker-count sweep: the
+  // original 8-64 MB band OVER-PROVISIONED decode- and heavy-tail-bound models in
+  // the 24-64 MB range. Each worker is a separate WASM instance that re-decodes
+  // the file into its own heap and rebuilds the entity index, so cores-2 = 8
+  // workers ran 20-30% SLOWER than 4 at ~5x the peak memory (e.g. 882 MB vs
+  // 161 MB on a 54 MB model; a 34 MB heavy-tail model went 7.2s -> 5.7s at 4).
+  // Genuinely small compute-bound steel (170_KM: 20 MB / ~26k boolean jobs) still
+  // measurably benefits from cores-2 (17.0s vs 22.9s at 4 workers), so the fast
+  // path is kept for <= 24 MB where the per-worker re-decode/memory cost is low.
+  // Above 24 MB falls through to the per-core bandwidth cap below (4 on 10-core).
+  const SMALL_FILE_MB = 24;
   const MIN_PARALLEL_MB = 8;
   if (fileSizeMB >= MIN_PARALLEL_MB && fileSizeMB <= SMALL_FILE_MB && cores >= 10) {
     coresCap = Math.min(maxWorkers, cores - 2);


### PR DESCRIPTION
## What

Narrows the geometry worker pool's small-file fast path from **8-64 MB** to **<= 24 MB**, fixing worker over-provisioning that made medium models load 20-30% slower at up to ~5x the peak WASM memory.

## Why (browser worker-count sweep, 10-core, real Chrome)

The 8-64 MB `cores - 2` band (#1258) was added on the assumption that small geometry-heavy files are compute-bound and scale with cores. A sweep across the workload spectrum shows that's only true for *genuinely small, compute-dense* files. Each worker is a **separate WASM instance that re-decodes the file into its own heap and rebuilds the entity index**, so for decode-/heavy-tail-bound models the per-worker cost dominates and more workers run *slower*:

| model | size | workload | wc=1 | wc=4 | wc=8 (old default) | peak WASM @8 |
|---|---|---|---|---|---|---|
| 20 MB | compute-bound steel (~26k boolean jobs, 1319 jobs/MB) | — | 22.9s | **17.0s** | 655 MB |
| 34 MB | heavy-tail | — | **5.7s** | 7.2s | ~600 MB |
| 54 MB | decode-bound (105 jobs/MB) | 10.0s / 161 MB | 11.3s | 14.4s / **882 MB** | |
| 11 MB | CSG-bound | 27.1s | 15.3s | 15.2s | 237 MB |

The discriminator is **per-element work density**, not file size: a 20 MB steel model (1319 jobs/MB) genuinely wants 8 workers, while a 54 MB decode-bound model (105 jobs/MB) wants far fewer — same band, opposite optimum. File size can't tell them apart perfectly, but **per-worker re-decode/memory cost grows with file size**, so keeping the `cores - 2` fast path only for `<= 24 MB` (where 170_KM-class steel lives and per-worker cost is low) captures the win without regressing it; `> 24 MB` falls through to the existing per-core bandwidth cap (4 on a 10-core host).

## Result (auto-selected count, real heuristic, validated live)

| model | before | after | Δ |
|---|---|---|---|
| 34 MB heavy-tail | wc=8, 7.2s | **wc=4, 5.7s** | **-21%** |
| 54 MB decode-bound | wc=8, 14.4s / 882 MB | **wc=4, 11.7s / 477 MB** | **-19%, -46% memory** |
| 20 MB compute-bound steel | wc=8, 17.0s | wc=8, 17.2s | neutral (win preserved) |
| 11 MB CSG | wc=8, 15.2s | wc=8, 15.1s | neutral |

Two solid wins, **zero regressions**, plus roughly half the peak WASM memory on the medium decode-bound case (which also reduces OOM/watchdog pressure on the huge models the pool serves).

## Scope / safety

- One constant: `SMALL_FILE_MB` 64 -> 24, with the rationale documented inline.
- The `> 512 MB` bandwidth caps (3-4 workers, measured on a 722 MB model) and the memory-budget cap are **untouched**.
- Tests: the existing 20 MB -> 8 case stays (it is the 170_KM-class steel guard); added 34 MB -> 4 and 54 MB -> 4 guards so the band can't silently re-widen. `pnpm --filter @ifc-lite/geometry test` green (110 tests).

## Follow-up

A fully **workload-aware** worker count (using the real prepass job/CSG density instead of the file-size proxy `MB * 100`) would handle the 24-64 MB compute-dense case too, but requires decoupling the active-dispatch count from the pre-spawn-for-compile-overlap count. Tracked as a follow-up.