### PR TITLE
fix(geometry): cap cutters per CSG arrangement (geometry-stream stall fix)

### DIFF
--- a/.changeset/csg-cutter-chunk.md
+++ b/.changeset/csg-cutter-chunk.md
@@ -1,5 +1,6 @@
 ---
 "@ifc-lite/geometry": patch
+"@ifc-lite/cache": patch
 ---
 
 Cap the number of void cutters packed into a single CSG arrangement, fixing a
@@ -22,3 +23,10 @@ equivalence tests and a new 20-cutter chunked-equivalence test all pass, and the
 full geometry suite is unchanged). For hosts with <= 16 cutters this is exactly
 the prior single arrangement. Verified end to end: the previously-stalling model
 now loads completely and renders correctly.
+
+Bumps the geometry cache `FORMAT_VERSION` (10 → 11). For a host with > 16 void
+cutters the chunked cut is solid-equivalent but not byte-identical (and on
+pre-fix builds those hosts often fell back to an AABB box), so the mesh hash
+changes. The bump invalidates pre-fix caches so restored models re-mesh with the
+correct tessellation, and the compare/diff feature does not flag those hosts from
+a stale-cache hash mismatch.

--- a/.changeset/csg-cutter-chunk.md
+++ b/.changeset/csg-cutter-chunk.md
@@ -1,0 +1,24 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Cap the number of void cutters packed into a single CSG arrangement, fixing a
+geometry-stream stall on models with elements that carry many openings.
+
+`subtract_mesh_many` previously subtracted every disjoint cutter of a host in ONE
+N-ary conforming arrangement. That arrangement's cost is super-linear in the
+cutters packed into it, so an element with ~90 openings cost ~12 s in a single
+arrangement (vs ~0.4 s chunked, 30x). On WASM that single element alone exceeded
+the 40 s geometry-stream watchdog: an 86 MB model that loaded in ~15 s natively
+stalled and failed to load in the browser. Because the per-element escalation
+budget bounds escalations, not the base arrangement size, it did not catch this.
+
+Void cutters here are order-free (set difference: `host − {all} ≡ host − {chunk₁}
+− {chunk₂} − …`), so the cutters are now processed in chunks of 16, bounding the
+per-arrangement cost so no single element can stall the stream. It is
+solid-equivalent (the batch path's contract is volume parity + watertightness,
+not byte-identical tessellation; the existing `subtract_many_*_matches_sequential`
+equivalence tests and a new 20-cutter chunked-equivalence test all pass, and the
+full geometry suite is unchanged). For hosts with <= 16 cutters this is exactly
+the prior single arrangement. Verified end to end: the previously-stalling model
+now loads completely and renders correctly.

--- a/packages/cache/src/types.ts
+++ b/packages/cache/src/types.ts
@@ -50,7 +50,18 @@ export const MAGIC = 0x4C434649; // "IFCL" in little-endian
  * only and silently drop all instanced occurrences — the bump invalidates those so
  * the model re-meshes (and re-writes a complete v10 cache with the shards).
  */
-export const FORMAT_VERSION = 10;
+/**
+ * v10→v11: CSG void-cutting caps cutters at 16 per N-ary arrangement and subtracts
+ * dense opening groups in chunks (#1432). For a host with >16 disjoint void cutters
+ * this is solid-equivalent but NOT byte-identical: the per-chunk consolidate yields
+ * a different tessellation and mesh hash than the old single arrangement. On
+ * pre-#1432 builds those hosts often exceeded the escalation budget and fell back to
+ * an AABB-box, so the chunked cut is also more correct. A v10 cache holds the old
+ * (boxed or differently-fragmented) mesh + hash, so without a bump a restored model
+ * would render stale geometry and the compare/diff feature would flag those hosts as
+ * changed. The bump invalidates pre-#1432 caches so they re-mesh.
+ */
+export const FORMAT_VERSION = 11;
 
 /** Section types in the binary format */
 export enum SectionType {

--- a/rust/geometry/src/csg/mod.rs
+++ b/rust/geometry/src/csg/mod.rs
@@ -515,22 +515,37 @@ impl ClippingProcessor {
         if live.is_empty() {
             return Ok(host_mesh.clone()); // silent: sequential path takes over
         }
-        crate::kernel::budget::begin();
-        let raw = crate::kernel::mesh_bridge::subtract_many(host_mesh, &live);
-        if crate::kernel::budget::tripped() {
-            // Escalation budget exceeded on the batched arrangement (#1109).
-            // Reject silently so the per-opening sequential path takes over —
-            // each opening gets its own budget + #635 AABB fallback, so the few
-            // hard cutters degrade while the rest cut exactly. Deterministic.
-            return Ok(host_mesh.clone());
+        // Cap the cutters packed into ONE conforming arrangement. Void cutters
+        // here are order-free (set difference: host − {all} ≡ host − {chunk₁} −
+        // {chunk₂} − …), and the N-ary arrangement cost is SUPER-LINEAR in the
+        // cutters in a single arrangement. A Revit IfcBuildingElementPart with
+        // ~90 openings cost ~12 s in one arrangement vs ~0.4 s chunked at 16 (30×),
+        // and on wasm that single element alone blew the geometry-stream watchdog —
+        // an 86 MB model that loaded in ~15 s natively STALLED at 40 s in the
+        // browser. Chunking bounds the per-arrangement cost so no single element
+        // can stall the stream. It is solid-equivalent (the batch path's contract
+        // is volume parity + watertightness, not byte-identical tessellation); for
+        // live.len() <= MAX_CUTTERS_PER_ARRANGEMENT it IS the prior single
+        // arrangement. On any chunk's budget trip / unrecovered constraint, reject
+        // the WHOLE group (return host un-cut) so the per-opening sequential path
+        // (own budget + #635 AABB fallback) takes over — identical to before.
+        const MAX_CUTTERS_PER_ARRANGEMENT: usize = 16;
+        let mut result = host_mesh.clone();
+        for chunk in live.chunks(MAX_CUTTERS_PER_ARRANGEMENT) {
+            crate::kernel::budget::begin();
+            let raw = crate::kernel::mesh_bridge::subtract_many(&result, chunk);
+            if crate::kernel::budget::tripped() {
+                // Escalation budget exceeded (#1109): reject the group silently so
+                // the per-opening sequential path takes over (deterministic).
+                return Ok(host_mesh.clone());
+            }
+            let Some(raw) = raw else {
+                // Unrecovered constraint in this chunk's arrangement — reject the
+                // group so the sequential per-opening path takes over.
+                return Ok(host_mesh.clone());
+            };
+            result = Self::consolidate_coplanar(raw);
         }
-        let Some(raw) = raw else {
-            // Unrecovered constraint in the N-ary arrangement — reject the
-            // group (silently, see above) so the sequential per-opening path
-            // (few constraints per arrangement) takes over.
-            return Ok(host_mesh.clone());
-        };
-        let result = Self::consolidate_coplanar(raw);
         if !result.is_empty() && !self.validate_mesh(&result) {
             self.record_failure(BoolOp::Difference, BoolFailureReason::KernelOutputInvalid);
             return Ok(host_mesh.clone());
@@ -875,6 +890,62 @@ fn add_triangle_to_mesh(mesh: &mut Mesh, triangle: &Triangle) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// >MAX_CUTTERS_PER_ARRANGEMENT disjoint cutters force the chunked path in
+    /// `subtract_mesh_many`; the result must match the sequential subtract chain.
+    /// Set difference is order-independent (host − {all} ≡ host − {chunk₁} −
+    /// {chunk₂} − …), so chunking is solid-equivalent. Guards the chunk boundary
+    /// (the perf fix for the 86 MB model that stalled the geometry stream on a
+    /// ~90-opening host packed into one arrangement).
+    #[test]
+    fn subtract_mesh_many_chunks_match_sequential() {
+        fn vol(m: &Mesh) -> f64 {
+            let p = |i: u32| {
+                let k = i as usize * 3;
+                [
+                    m.positions[k] as f64,
+                    m.positions[k + 1] as f64,
+                    m.positions[k + 2] as f64,
+                ]
+            };
+            let mut v = 0.0;
+            for t in m.indices.chunks_exact(3) {
+                let (a, b, c) = (p(t[0]), p(t[1]), p(t[2]));
+                v += a[0] * (b[1] * c[2] - c[1] * b[2])
+                    - a[1] * (b[0] * c[2] - c[0] * b[2])
+                    + a[2] * (b[0] * c[1] - c[0] * b[1]);
+            }
+            (v / 6.0).abs()
+        }
+        let csg = ClippingProcessor::new();
+        // Long wall + 20 disjoint through-openings (>16 ⇒ 2 chunks at the cap).
+        let wall = aabb_to_mesh(Point3::new(0., 0., 0.), Point3::new(40., 3., 0.2));
+        let cutters: Vec<Mesh> = (0..20)
+            .map(|i| {
+                let x = 1.0 + i as f64 * 2.0; // 2 m spacing ⇒ pairwise disjoint
+                aabb_to_mesh(Point3::new(x, 1., -0.5), Point3::new(x + 1.0, 2., 0.7))
+            })
+            .collect();
+        let refs: Vec<&Mesh> = cutters.iter().collect();
+        let batched = csg
+            .subtract_mesh_many(&wall, &refs)
+            .expect("chunked subtract must conform");
+        let mut seq = wall.clone();
+        for c in &cutters {
+            seq = csg.subtract_mesh(&seq, c).expect("sequential subtract");
+        }
+        let (vb, vs) = (vol(&batched), vol(&seq));
+        assert!(
+            (vb - vs).abs() < 1e-4,
+            "chunked volume {vb} != sequential {vs} on 20 disjoint cutters"
+        );
+        // Sanity: ~20 holes (~0.2 m³ each) actually removed from the ~24 m³ wall.
+        assert!(
+            vb < vol(&wall) - 3.0,
+            "expected ~20 holes removed; wall {} -> {vb}",
+            vol(&wall)
+        );
+    }
 
     #[test]
     fn test_plane_signed_distance() {

--- a/rust/geometry/src/csg/mod.rs
+++ b/rust/geometry/src/csg/mod.rs
@@ -891,12 +891,12 @@ fn add_triangle_to_mesh(mesh: &mut Mesh, triangle: &Triangle) {
 mod tests {
     use super::*;
 
-    /// >MAX_CUTTERS_PER_ARRANGEMENT disjoint cutters force the chunked path in
+    /// More cutters than MAX_CUTTERS_PER_ARRANGEMENT force the chunked path in
     /// `subtract_mesh_many`; the result must match the sequential subtract chain.
-    /// Set difference is order-independent (host − {all} ≡ host − {chunk₁} −
-    /// {chunk₂} − …), so chunking is solid-equivalent. Guards the chunk boundary
-    /// (the perf fix for the 86 MB model that stalled the geometry stream on a
-    /// ~90-opening host packed into one arrangement).
+    /// Set difference is order-independent (`host - {all}` equals
+    /// `host - {chunk1} - {chunk2} - ...`), so chunking is solid-equivalent. Guards
+    /// the chunk boundary (the perf fix for the 86 MB model that stalled the
+    /// geometry stream on a ~90-opening host packed into one arrangement).
     #[test]
     fn subtract_mesh_many_chunks_match_sequential() {
         fn vol(m: &Mesh) -> f64 {

--- a/rust/geometry/src/csg/mod.rs
+++ b/rust/geometry/src/csg/mod.rs
@@ -502,8 +502,6 @@ impl ClippingProcessor {
     /// genuinely invalid kernel OUTPUT records, exactly like
     /// [`Self::subtract_mesh`].
     pub fn subtract_mesh_many(&self, host_mesh: &Mesh, cutters: &[&Mesh]) -> Result<Mesh> {
-        let total: usize = cutters.iter().map(|c| c.triangle_count()).sum();
-        record_csg_op(0, host_mesh.triangle_count(), total);
         if host_mesh.is_empty() {
             return Ok(Mesh::new());
         }
@@ -532,6 +530,13 @@ impl ClippingProcessor {
         const MAX_CUTTERS_PER_ARRANGEMENT: usize = 16;
         let mut result = host_mesh.clone();
         for chunk in live.chunks(MAX_CUTTERS_PER_ARRANGEMENT) {
+            // Census: record THIS kernel invocation's real operand sizes (the
+            // current host + this chunk's cutters). Chunking runs the kernel once
+            // per chunk, so report K real ops, not one synthetic op carrying the
+            // whole group's cutter total. For live.len() <= cap this is one record
+            // identical to the prior single arrangement.
+            let chunk_tris: usize = chunk.iter().map(|c| c.triangle_count()).sum();
+            record_csg_op(0, result.triangle_count(), chunk_tris);
             crate::kernel::budget::begin();
             let raw = crate::kernel::mesh_bridge::subtract_many(&result, chunk);
             if crate::kernel::budget::tripped() {
@@ -544,11 +549,17 @@ impl ClippingProcessor {
                 // group so the sequential per-opening path takes over.
                 return Ok(host_mesh.clone());
             };
-            result = Self::consolidate_coplanar(raw);
-        }
-        if !result.is_empty() && !self.validate_mesh(&result) {
-            self.record_failure(BoolOp::Difference, BoolFailureReason::KernelOutputInvalid);
-            return Ok(host_mesh.clone());
+            let next = Self::consolidate_coplanar(raw);
+            // Validate each intermediate BEFORE it becomes the next chunk's host:
+            // a non-watertight / invalid intermediate would silently corrupt every
+            // subsequent subtraction. On failure reject the whole group so the
+            // per-opening sequential path takes over — same guard as the
+            // un-chunked path, just applied per chunk.
+            if !next.is_empty() && !self.validate_mesh(&next) {
+                self.record_failure(BoolOp::Difference, BoolFailureReason::KernelOutputInvalid);
+                return Ok(host_mesh.clone());
+            }
+            result = next;
         }
         Ok(result)
     }


### PR DESCRIPTION
## Problem

An 86 MB IFC (1.0M entities, ~610 void hosts) **stalled at the 40 s geometry-stream watchdog and failed to load** in the browser — it rendered most geometry then one worker got stuck. The log showed `IfcBuildingElementPart` hosts carrying dozens of `NonRectangular` openings (one with ~90) failing with `OperandTooLarge`.

## Root cause (measured)

`subtract_mesh_many` subtracts every disjoint cutter of a host in **one N-ary conforming arrangement**, whose cost is **super-linear in the cutters packed into it**. Native per-job profiling of the model:

- The dominant job: a host with only 3,292 host-triangles but **~90 cutters (2,548 cutter-triangles)** cost **12.3 s in one arrangement** (parallel-contended). On WASM that single element alone exceeds the 40 s watchdog.
- Natively the full pipeline loads in ~15 s (the per-element escalation budget bails it to AABB), but the budget bounds *escalations*, not the *base arrangement size* — so it doesn't prevent the WASM stall.

## Fix

Void cutters here are order-free — set difference is associative/commutative: `host − {all} ≡ host − {chunk₁} − {chunk₂} − …`. So `subtract_mesh_many` now processes cutters in **chunks of 16**, bounding per-arrangement cost so no single element can stall the stream.

- **Solid-equivalent.** The batch path's contract is volume parity + watertightness, not byte-identical tessellation (same as the existing disjoint-batch). For `<= 16` cutters it is exactly the prior single arrangement.
- **No worse on failure.** On any chunk's budget trip / unrecovered constraint, the whole group still falls through to the per-opening sequential path (own budget + #635 AABB fallback), exactly as before.

## Measured impact

- The ~90-cutter killer job: **12.3 s → 0.4 s (30x)**; total CSG corpus **−38%**.
- **The previously-stalling 86 MB model now loads completely (~35 s, no stall) and renders correctly** (8 storeys, 54K elements, verified in-browser).

## Tests

- Full `ifc-lite-geometry` suite green (550 tests, 0 failures), **no snapshot changes**.
- Existing `subtract_many_disjoint_openings_matches_sequential` / `subtract_many_two_pocket_group_matches_sequential` equivalence tests pass.
- New `subtract_mesh_many_chunks_match_sequential`: 20 disjoint cutters (>cap ⇒ chunked) match the sequential subtract chain by volume.

## Follow-up (not in this PR)

The model now loads at ~35 s — still close to the watchdog. The remaining cost is dense single-host cuts (20-30k-triangle hosts, 1 cutter each); a host-triangle spatial cull to the cutter region would cut those further. Tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CSG void-cutter subtraction for models with many openings: disjoint cutters are now processed in capped batches to avoid stalls and failed geometry renders.
  * Results remain solid-equivalent (watertight and volume-consistent); behavior matches the prior approach for smaller cutter counts.
* **Tests**
  * Added coverage to confirm chunked subtraction matches sequential results for larger cutter sets.
* **Chores**
  * Updated the geometry cache format to ensure restored models re-mesh with the correct tessellation after this change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->