### PR TITLE
fix(export): remove the ~512MB exporter input cap; fail loud on empty GLB

### DIFF
--- a/.changeset/glb-export-reliability.md
+++ b/.changeset/glb-export-reliability.md
@@ -1,6 +1,6 @@
 ---
 "@ifc-lite/wasm": minor
-"@ifc-lite/geometry": patch
+"@ifc-lite/geometry": minor
 "@ifc-lite/export": patch
 "@ifc-lite/cli": patch
 "@ifc-lite/mcp": patch

--- a/.changeset/glb-export-reliability.md
+++ b/.changeset/glb-export-reliability.md
@@ -1,0 +1,30 @@
+---
+"@ifc-lite/wasm": minor
+"@ifc-lite/geometry": patch
+"@ifc-lite/export": patch
+"@ifc-lite/cli": patch
+"@ifc-lite/mcp": patch
+---
+
+Make the Rust-backed exporters reliable on large and degenerate inputs.
+
+Remove the ~512 MB input cap on GLB/glTF (and the sibling OBJ, CSV, JSON, JSON-LD,
+STEP, IFCX, HBJSON exporters). They decoded the entire input IFC byte buffer into a
+single JS string via `safeUtf8Decode` before crossing into WASM, where the binding
+immediately turned it back into bytes (`content.as_bytes()`). For an input over V8's
+`0x1fffffe8` (~512 MB) string ceiling that decode threw "Cannot create a string longer
+than 0x1fffffe8 characters", so files in the 0.5 GB+ range failed before any geometry
+ran. The boundary now passes the raw `Uint8Array`/`&[u8]` straight through (matching the
+existing `exportMerged` path), which removes the cap, drops a redundant full-buffer copy
+and a UTF-8 re-encode, and is byte-faithful for non-UTF-8 input.
+
+Fail loud on an empty GLB export. A malformed-but-parseable model (or a filter whose
+matched entities carry no triangulated geometry) produced a structurally valid GLB with
+zero meshes, which the CLI and MCP tools wrote to disk and reported as success. Both now
+reject a zero-mesh GLB with a clear error (new `countGlbMeshes` helper in
+`@ifc-lite/export`).
+
+Guard the GLB assembler against the glTF 32-bit buffer limit. The assembler cast every
+buffer offset and byteLength `as u32`; past 4 GiB those casts silently wrapped (release
+builds disable overflow checks) and emitted a corrupt GLB. It now sums the binary buffer
+length in `usize` and asserts the 4 GiB ceiling with a clear message instead of wrapping.

--- a/.changeset/glb-export-reliability.md
+++ b/.changeset/glb-export-reliability.md
@@ -1,7 +1,7 @@
 ---
 "@ifc-lite/wasm": minor
 "@ifc-lite/geometry": minor
-"@ifc-lite/export": patch
+"@ifc-lite/export": minor
 "@ifc-lite/cli": patch
 "@ifc-lite/mcp": patch
 ---
@@ -17,6 +17,12 @@ than 0x1fffffe8 characters", so files in the 0.5 GB+ range failed before any geo
 ran. The boundary now passes the raw `Uint8Array`/`&[u8]` straight through (matching the
 existing `exportMerged` path), which removes the cap, drops a redundant full-buffer copy
 and a UTF-8 re-encode, and is byte-faithful for non-UTF-8 input.
+
+Scope: this lifts the cap on the INPUT side for all exporters. GLB returns a
+`Uint8Array`, so its output also escapes the V8 ceiling; the string-returning
+exporters (OBJ/CSV/JSON/JSON-LD/STEP/IFCX/HBJSON) still cap their serialized OUTPUT
+at the same ~512 MB string limit. In-browser, the wasm32 linear-memory heap (not the
+string cap) is the practical ceiling for the very largest models.
 
 Fail loud on an empty GLB export. A malformed-but-parseable model (or a filter whose
 matched entities carry no triangulated geometry) produced a structurally valid GLB with

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -13,6 +13,7 @@
 import { writeFile, readFile } from 'node:fs/promises';
 import { basename } from 'node:path';
 import { GeometryProcessor } from '@ifc-lite/geometry';
+import { countGlbMeshes } from '@ifc-lite/export';
 import { createHeadlessContext } from '../loader.js';
 import { getFlag, hasFlag, fatal, writeOutput } from '../output.js';
 import type { ComparisonOp } from '@ifc-lite/sdk';
@@ -310,6 +311,16 @@ export async function exportCommand(args: string[]): Promise<void> {
           const out = gp.exportGlb(bytes, false, new Uint32Array(), isolated, '');
           if (out == null) fatal('GLB export failed (geometry pipeline not initialized)');
           if (!outPath) fatal('--out is required for GLB/glTF export (binary output)');
+          // Fail loud on an empty export: assemble_glb still emits a structurally
+          // valid GLB with zero meshes when nothing had render geometry, which would
+          // otherwise be written to disk and reported as success.
+          if (countGlbMeshes(out as Uint8Array) === 0) {
+            fatal(
+              filterActive
+                ? 'GLB export produced 0 meshes — the matched entities have no exportable render geometry. Check --type/--storey/--where/--limit.'
+                : 'GLB export produced 0 meshes — the model has no exportable render geometry (or geometry production failed).',
+            );
+          }
           await writeFile(outPath, out as Uint8Array);
           process.stderr.write(`Written to ${outPath}\n`);
         }

--- a/packages/export/src/glb.test.ts
+++ b/packages/export/src/glb.test.ts
@@ -50,6 +50,12 @@ describe('countGlbMeshes', () => {
     expect(countGlbMeshes(glb)).toBe(3);
   });
 
+  it('returns 0 without throwing on a malformed / non-GLB buffer', () => {
+    expect(countGlbMeshes(new Uint8Array(0))).toBe(0);
+    expect(countGlbMeshes(new Uint8Array([1, 2, 3]))).toBe(0);
+    expect(countGlbMeshes(new Uint8Array([0x67, 0x6c, 0x54, 0x46, 9, 9, 9, 9]))).toBe(0);
+  });
+
   it('parses round-trip with the shared parseGLB', () => {
     const glb = buildGlb({ asset: { version: '2.0' }, meshes: [{}] }, new Uint8Array([1, 2, 3, 4]));
     const { json, bin } = parseGLB(glb);

--- a/packages/export/src/glb.test.ts
+++ b/packages/export/src/glb.test.ts
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { countGlbMeshes, parseGLB } from './glb.js';
+
+/**
+ * Assemble a minimal GLB (12-byte header + JSON chunk + BIN chunk) the same way
+ * the Rust assembler does, so we can exercise the empty-export gate without the
+ * wasm pipeline.
+ */
+function buildGlb(json: unknown, bin: Uint8Array = new Uint8Array()): Uint8Array {
+  const jsonBytes = new TextEncoder().encode(JSON.stringify(json));
+  const pad4 = (n: number) => (4 - (n % 4)) % 4;
+  const jsonChunkLen = jsonBytes.length + pad4(jsonBytes.length);
+  const binChunkLen = bin.length + pad4(bin.length);
+  const total = 12 + 8 + jsonChunkLen + 8 + binChunkLen;
+  const out = new Uint8Array(total);
+  const dv = new DataView(out.buffer);
+  let o = 0;
+  dv.setUint32(o, 0x46546c67, true); o += 4; // magic 'glTF'
+  dv.setUint32(o, 2, true); o += 4; // version
+  dv.setUint32(o, total, true); o += 4; // total length
+  // JSON chunk
+  dv.setUint32(o, jsonChunkLen, true); o += 4;
+  dv.setUint32(o, 0x4e4f534a, true); o += 4; // 'JSON'
+  out.set(jsonBytes, o); o += jsonBytes.length;
+  for (let i = 0; i < pad4(jsonBytes.length); i++) out[o++] = 0x20; // space-pad JSON
+  // BIN chunk (may be zero-length, as it is for an empty export)
+  dv.setUint32(o, binChunkLen, true); o += 4;
+  dv.setUint32(o, 0x004e4942, true); o += 4; // 'BIN\0'
+  out.set(bin, o); o += bin.length;
+  return out;
+}
+
+describe('countGlbMeshes', () => {
+  it('returns 0 for an empty export (meshes: [])', () => {
+    const glb = buildGlb({ asset: { version: '2.0' }, meshes: [] });
+    expect(countGlbMeshes(glb)).toBe(0);
+  });
+
+  it('returns 0 when the meshes array is absent', () => {
+    const glb = buildGlb({ asset: { version: '2.0' } });
+    expect(countGlbMeshes(glb)).toBe(0);
+  });
+
+  it('counts the meshes that are present', () => {
+    const glb = buildGlb({ asset: { version: '2.0' }, meshes: [{}, {}, {}] });
+    expect(countGlbMeshes(glb)).toBe(3);
+  });
+
+  it('parses round-trip with the shared parseGLB', () => {
+    const glb = buildGlb({ asset: { version: '2.0' }, meshes: [{}] }, new Uint8Array([1, 2, 3, 4]));
+    const { json, bin } = parseGLB(glb);
+    expect(json.meshes).toHaveLength(1);
+    expect(bin.byteLength).toBe(4);
+  });
+});

--- a/packages/export/src/glb.ts
+++ b/packages/export/src/glb.ts
@@ -55,7 +55,15 @@ export function parseGLB(glb: Uint8Array): ParsedGlb {
  * the cost is bounded by the metadata size and dwarfed by the meshing it follows.
  */
 export function countGlbMeshes(glb: Uint8Array): number {
-  const { json } = parseGLB(glb);
+  let json: ParsedGlb['json'];
+  try {
+    ({ json } = parseGLB(glb));
+  } catch {
+    // A malformed / truncated / non-GLB buffer has no countable meshes. Return 0
+    // so callers treat it as an empty export (and fail loud) rather than crashing
+    // on the parse with an opaque stack trace.
+    return 0;
+  }
   return Array.isArray(json?.meshes) ? json.meshes.length : 0;
 }
 

--- a/packages/export/src/glb.ts
+++ b/packages/export/src/glb.ts
@@ -45,6 +45,20 @@ export function parseGLB(glb: Uint8Array): ParsedGlb {
   return { json, bin };
 }
 
+/**
+ * Count the meshes declared in an IFC-Lite-generated GLB. Zero means the export
+ * carries no render geometry — a structurally valid but empty GLB. The
+ * CLI / MCP exporters use this to fail loud instead of writing an empty file as
+ * "success" (e.g. malformed-but-parseable input, or a filter whose matched
+ * entities have no triangulated representation). Only the GLB JSON metadata chunk
+ * is parsed; the multi-GB binary mesh buffer (the separate BIN chunk) is not, so
+ * the cost is bounded by the metadata size and dwarfed by the meshing it follows.
+ */
+export function countGlbMeshes(glb: Uint8Array): number {
+  const { json } = parseGLB(glb);
+  return Array.isArray(json?.meshes) ? json.meshes.length : 0;
+}
+
 function componentTypeSize(componentType: number): number {
   // Only types we emit
   if (componentType === 5126) return 4; // FLOAT

--- a/packages/export/src/index.ts
+++ b/packages/export/src/index.ts
@@ -23,4 +23,4 @@ export { Ifc5Exporter, IFC5_KNOWN_PROP_NAMES, type Ifc5ExportOptions, type Ifc5E
 export type { Vec3, LodInput, Lod0Element, Lod0Json, Lod1MetaJson, GenerateLod1Result } from './lod-geometry-types.js';
 export { generateLod0 } from './lod0-generator.js';
 export { generateLod1, type GenerateLod1Options } from './lod1-generator.js';
-export { parseGLB, extractGlbMapping, parseGLBToMeshData } from './glb.js';
+export { parseGLB, extractGlbMapping, parseGLBToMeshData, countGlbMeshes } from './glb.js';

--- a/packages/geometry/src/ifc-lite-bridge.ts
+++ b/packages/geometry/src/ifc-lite-bridge.ts
@@ -301,7 +301,7 @@ export class IfcLiteBridge {
    * `hidden` / `isolated` are express-id visibility filters (empty `isolated` ⇒ all).
    */
   exportObj(
-    content: string,
+    content: Uint8Array,
     includeNormals = true,
     hidden: Uint32Array = new Uint32Array(),
     isolated: Uint32Array = new Uint32Array(),
@@ -316,7 +316,7 @@ export class IfcLiteBridge {
    * `hiddenTypesCsv` is a comma-separated IFC-type visibility filter.
    */
   exportGlb(
-    content: string,
+    content: Uint8Array,
     includeMetadata = false,
     hidden: Uint32Array = new Uint32Array(),
     isolated: Uint32Array = new Uint32Array(),
@@ -333,7 +333,7 @@ export class IfcLiteBridge {
    * empty `delimiter` ⇒ `,`; `includeProperties` adds flattened `Pset_Prop` columns.
    */
   exportCsv(
-    content: string,
+    content: Uint8Array,
     mode: 'entities' | 'properties' | 'quantities' | 'spatial' = 'entities',
     delimiter = ',',
     includeProperties = false,
@@ -345,7 +345,7 @@ export class IfcLiteBridge {
 
   /** Export structured JSON (array of entity objects with typed property values). */
   exportJson(
-    content: string,
+    content: Uint8Array,
     pretty = false,
     includeProperties = true,
     includeQuantities = true,
@@ -361,7 +361,7 @@ export class IfcLiteBridge {
    * empty `included` ⇒ whole model.
    */
   exportStep(
-    content: string,
+    content: Uint8Array,
     schema = '',
     included: Uint32Array = new Uint32Array(),
     mutationsJson = '',
@@ -388,7 +388,7 @@ export class IfcLiteBridge {
   }
 
   /** Export IFC5/IFCX (USD-style node graph). */
-  exportIfcx(content: string, onlyKnownProperties = true, pretty = false): string {
+  exportIfcx(content: Uint8Array, onlyKnownProperties = true, pretty = false): string {
     return this.runExport('exportIfcx', content, (api) =>
       api.exportIfcx(content, onlyKnownProperties, pretty),
     );
@@ -400,7 +400,7 @@ export class IfcLiteBridge {
    * OBJ/glTF/STEP exporters so `--type`/`--storey`/`--where`/`--limit` subsets apply.
    */
   exportJsonld(
-    content: string,
+    content: Uint8Array,
     context = '',
     includeProperties = true,
     includeQuantities = false,
@@ -477,7 +477,7 @@ export class IfcLiteBridge {
    * (Ladybug Tools energy/daylight model). Rooms are built analytically from
    * extruded-area profiles (watertight by construction).
    */
-  exportHbjson(content: string, name: string): string {
+  exportHbjson(content: Uint8Array, name: string): string {
     return this.runExport('exportHbjson', content, (api) => api.exportHbjson(content, name));
   }
 
@@ -485,7 +485,7 @@ export class IfcLiteBridge {
    * Shared wrapper for the domain-format exporters: init guard + structured error
    * logging + fatal-wasm-error marking, mirroring the other bridge entry points.
    */
-  private runExport<T>(op: string, content: string, run: (api: IfcAPI) => T): T {
+  private runExport<T>(op: string, content: Uint8Array, run: (api: IfcAPI) => T): T {
     if (!this.ifcApi) {
       throw new Error('IFC-Lite not initialized. Call init() first.');
     }

--- a/packages/geometry/src/index.ts
+++ b/packages/geometry/src/index.ts
@@ -1089,7 +1089,7 @@ export class GeometryProcessor {
     isolated: Uint32Array = new Uint32Array(),
   ): string | null {
     if (!this.bridge?.isInitialized()) return null;
-    return this.bridge.exportObj(safeUtf8Decode(buffer), includeNormals, hidden, isolated);
+    return this.bridge.exportObj(buffer, includeNormals, hidden, isolated);
   }
 
   exportGlb(
@@ -1101,7 +1101,7 @@ export class GeometryProcessor {
     lit = true,
   ): Uint8Array | null {
     if (!this.bridge?.isInitialized()) return null;
-    return this.bridge.exportGlb(safeUtf8Decode(buffer), includeMetadata, hidden, isolated, hiddenTypesCsv, lit);
+    return this.bridge.exportGlb(buffer, includeMetadata, hidden, isolated, hiddenTypesCsv, lit);
   }
 
   exportCsv(
@@ -1111,7 +1111,7 @@ export class GeometryProcessor {
     includeProperties = false,
   ): string | null {
     if (!this.bridge?.isInitialized()) return null;
-    return this.bridge.exportCsv(safeUtf8Decode(buffer), mode, delimiter, includeProperties);
+    return this.bridge.exportCsv(buffer, mode, delimiter, includeProperties);
   }
 
   exportJson(
@@ -1121,7 +1121,7 @@ export class GeometryProcessor {
     includeQuantities = true,
   ): string | null {
     if (!this.bridge?.isInitialized()) return null;
-    return this.bridge.exportJson(safeUtf8Decode(buffer), pretty, includeProperties, includeQuantities);
+    return this.bridge.exportJson(buffer, pretty, includeProperties, includeQuantities);
   }
 
   exportJsonld(
@@ -1133,7 +1133,7 @@ export class GeometryProcessor {
     included: Uint32Array = new Uint32Array(),
   ): string | null {
     if (!this.bridge?.isInitialized()) return null;
-    return this.bridge.exportJsonld(safeUtf8Decode(buffer), context, includeProperties, includeQuantities, pretty, included);
+    return this.bridge.exportJsonld(buffer, context, includeProperties, includeQuantities, pretty, included);
   }
 
   exportStep(
@@ -1143,12 +1143,12 @@ export class GeometryProcessor {
     mutationsJson = '',
   ): string | null {
     if (!this.bridge?.isInitialized()) return null;
-    return this.bridge.exportStep(safeUtf8Decode(buffer), schema, included, mutationsJson);
+    return this.bridge.exportStep(buffer, schema, included, mutationsJson);
   }
 
   exportIfcx(buffer: Uint8Array, onlyKnownProperties = true, pretty = false): string | null {
     if (!this.bridge?.isInitialized()) return null;
-    return this.bridge.exportIfcx(safeUtf8Decode(buffer), onlyKnownProperties, pretty);
+    return this.bridge.exportIfcx(buffer, onlyKnownProperties, pretty);
   }
 
   /** Merge several IFC models (raw byte buffers) into one STEP/IFC string. */
@@ -1240,8 +1240,7 @@ export class GeometryProcessor {
     if (!this.bridge || !this.bridge.isInitialized()) {
       return null;
     }
-    const content = safeUtf8Decode(buffer);
-    return this.bridge.exportHbjson(content, name);
+    return this.bridge.exportHbjson(buffer, name);
   }
 
   /**

--- a/packages/mcp/src/tools/export.ts
+++ b/packages/mcp/src/tools/export.ts
@@ -14,6 +14,7 @@
 import { writeFile, readFile } from 'node:fs/promises';
 import type { EntityRef } from '@ifc-lite/sdk';
 import { GeometryProcessor } from '@ifc-lite/geometry';
+import { countGlbMeshes } from '@ifc-lite/export';
 import type { Tool } from './types.js';
 import { okResult, resolveModel } from './util.js';
 import { ToolErrorCode, ToolExecutionError } from '../errors.js';
@@ -152,6 +153,16 @@ const exportGlb: Tool = {
       const glb = gp.exportGlb(bytes, false, new Uint32Array(), isolated, '');
       if (glb == null) {
         throw new ToolExecutionError({ code: ToolErrorCode.INTERNAL_ERROR, message: 'GLB export produced no output.' });
+      }
+      // A structurally valid GLB with zero meshes means nothing had render
+      // geometry — fail loud instead of writing an empty file as success.
+      if (countGlbMeshes(glb) === 0) {
+        throw new ToolExecutionError({
+          code: ToolErrorCode.INTERNAL_ERROR,
+          message: filterType
+            ? `GLB export produced 0 meshes — no ${filterType} elements have exportable render geometry.`
+            : 'GLB export produced 0 meshes — the model has no exportable render geometry.',
+        });
       }
       await writeFile(filePath, glb);
       return okResult(`Wrote ${glb.length.toLocaleString()} bytes to ${filePath}.`, { filePath, bytes: glb.length });

--- a/packages/mcp/src/tools/export.ts
+++ b/packages/mcp/src/tools/export.ts
@@ -146,6 +146,15 @@ const exportGlb: Tool = {
     const isolated = filterType
       ? new Uint32Array(m.bim.query().byType(filterType).toArray().map((e) => e.ref.expressId))
       : new Uint32Array();
+    // An empty isolation set means "export everything" to the Rust mesher, so a
+    // `type` filter that matched nothing would silently export the WHOLE model
+    // and report success. Fail loud instead, mirroring the CLI guard.
+    if (filterType && isolated.length === 0) {
+      throw new ToolExecutionError({
+        code: ToolErrorCode.INVALID_INPUT,
+        message: `No ${filterType} entities found - nothing to export.`,
+      });
+    }
     const bytes = await resolveIfcBytes(m);
     const gp = new GeometryProcessor();
     await gp.init();
@@ -193,6 +202,15 @@ const exportObj: Tool = {
     const isolated = filterType
       ? new Uint32Array(m.bim.query().byType(filterType).toArray().map((e) => e.ref.expressId))
       : new Uint32Array();
+    // An empty isolation set means "export everything" to the Rust mesher, so a
+    // `type` filter that matched nothing would silently export the WHOLE model
+    // and report success. Fail loud instead, mirroring the CLI guard.
+    if (filterType && isolated.length === 0) {
+      throw new ToolExecutionError({
+        code: ToolErrorCode.INVALID_INPUT,
+        message: `No ${filterType} entities found - nothing to export.`,
+      });
+    }
     const bytes = await resolveIfcBytes(m);
     const gp = new GeometryProcessor();
     await gp.init();

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -94,7 +94,7 @@ export class IfcAPI {
    * historical look — #1321). Optional at the boundary so older 5-arg callers
    * keep lit-by-default behaviour.
    */
-  exportGlb(content: string, include_metadata: boolean, hidden: Uint32Array, isolated: Uint32Array, hidden_types_csv: string, lit?: boolean | null): Uint8Array;
+  exportGlb(content: Uint8Array, include_metadata: boolean, hidden: Uint32Array, isolated: Uint32Array, hidden_types_csv: string, lit?: boolean | null): Uint8Array;
   /**
    * Package an already-produced **GLB** + georeference into a **KMZ** (`Uint8Array`)
    * for Google Earth: a ZIP of `doc.kml` (a `<Model>` placed at `latitude`/`longitude`/
@@ -120,7 +120,7 @@ export class IfcAPI {
    * const obj = api.exportObj(ifcContent, true, new Uint32Array(), new Uint32Array());
    * ```
    */
-  exportObj(content: string, include_normals: boolean, hidden: Uint32Array, isolated: Uint32Array): string;
+  exportObj(content: Uint8Array, include_normals: boolean, hidden: Uint32Array, isolated: Uint32Array): string;
   /**
    * Process geometry for a subset of pre-scanned entities → flat
    * MeshCollection. Takes raw bytes + pre-pass data from buildPrePassOnce.
@@ -211,22 +211,22 @@ export class IfcAPI {
    * `"spatial"`}. `delimiter` defaults to `,` when empty; `include_properties` adds
    * flattened `Pset_Prop` columns to the entities view.
    */
-  exportCsv(content: string, mode: string, delimiter: string, include_properties: boolean): string;
+  exportCsv(content: Uint8Array, mode: string, delimiter: string, include_properties: boolean): string;
   /**
    * Export **IFC5 / IFCX** (the USD-style node graph). `only_known_properties` keeps
    * only properties with an official IFC5 schema.
    */
-  exportIfcx(content: string, only_known_properties: boolean, pretty: boolean): string;
+  exportIfcx(content: Uint8Array, only_known_properties: boolean, pretty: boolean): string;
   /**
    * Export structured **JSON** (array of entity objects with typed property values).
    */
-  exportJson(content: string, pretty: boolean, include_properties: boolean, include_quantities: boolean): string;
+  exportJson(content: Uint8Array, pretty: boolean, include_properties: boolean, include_quantities: boolean): string;
   /**
    * Export **JSON-LD** (`@graph` of `ifc:` nodes). Empty `context` ⇒ buildingSMART
    * IFC4 OWL default. `included` is an express-id isolation filter mirroring the
    * OBJ/glTF/STEP exporters (empty ⇒ all entities).
    */
-  exportJsonld(content: string, context: string, include_properties: boolean, include_quantities: boolean, pretty: boolean, included: Uint32Array): string;
+  exportJsonld(content: Uint8Array, context: string, include_properties: boolean, include_quantities: boolean, pretty: boolean, included: Uint32Array): string;
   /**
    * Re-serialize the model in `content` to a STEP/IFC string.
    *
@@ -236,7 +236,7 @@ export class IfcAPI {
    * `mutations_json` carries `MutablePropertyView` edits (attribute updates +
    * property-set synthesis); empty ⇒ none. See `export_step_json` for the shape.
    */
-  exportStep(content: string, schema: string, included: Uint32Array, mutations_json: string): string;
+  exportStep(content: Uint8Array, schema: string, included: Uint32Array, mutations_json: string): string;
   /**
    * Merge several IFC models into one STEP/IFC string. `concatenated` is every model's
    * bytes laid end-to-end; `lengths[i]` is the byte length of model `i`. The first model
@@ -255,7 +255,7 @@ export class IfcAPI {
    * const hbjson = api.exportHbjson(ifcContent, "my_model");
    * ```
    */
-  exportHbjson(content: string, name: string): string;
+  exportHbjson(content: Uint8Array, name: string): string;
   /**
    * Parse the file and return every `IfcAlignment` directrix as a flat
    * `Float32Array` of 3D line-list vertices `[x0,y0,z0, x1,y1,z1, …]` in

--- a/rust/export/src/gltf.rs
+++ b/rust/export/src/gltf.rs
@@ -453,7 +453,22 @@ fn assemble_glb(views: &[MeshView], include_metadata: bool, lit: bool) -> (Vec<u
         });
     }
 
-    let mut bin = Vec::with_capacity((pos_len + norm_len + idx_len) as usize);
+    // glTF/GLB is a 32-bit container: every buffer offset, byteLength and chunk
+    // length is a u32. Past 4 GiB those `as u32` casts silently wrap (release sets
+    // overflow-checks = false) and emit a structurally corrupt GLB instead of
+    // erroring. Guard the concatenated binary buffer here — every buffer.byteLength
+    // and per-mesh accessor/bufferView offset is bounded by it (positions grows
+    // monotonically, so an over-limit run aborts before the GLB is packed). The
+    // container total (JSON chunk + framing on top) is guarded separately in
+    // pack_glb. (In wasm32 the 32-bit heap OOMs long before 4 GiB; this protects
+    // native consumers of the export crate.) Sum in usize to avoid the u32 wrap.
+    let bin_len = positions.len() + normals.len() + indices.len();
+    assert!(
+        bin_len <= u32::MAX as usize,
+        "GLB binary buffer is {bin_len} bytes, over the glTF 32-bit buffer limit \
+         (4 GiB); the model is too large for a single GLB",
+    );
+    let mut bin = Vec::with_capacity(bin_len);
     bin.extend_from_slice(&positions);
     bin.extend_from_slice(&normals);
     bin.extend_from_slice(&indices);
@@ -592,6 +607,15 @@ fn pack_glb(json_bytes: &[u8], bin: &[u8]) -> Vec<u8> {
     let padded_bin = bin.len() + bin_pad;
 
     let total = 12 + 8 + padded_json + 8 + padded_bin;
+    // The GLB container total and chunk lengths are u32 (little-endian). This is
+    // the authoritative 4 GiB guard: it covers the JSON chunk + 28 bytes of
+    // framing + padding on top of the binary buffer, which the assemble_glb check
+    // (binary buffer only) does not. Fail loud instead of wrapping into a corrupt
+    // container. (Reachable only for a ~4 GiB native export; wasm32 OOMs first.)
+    assert!(
+        total <= u32::MAX as usize,
+        "GLB total size is {total} bytes, over the glTF 32-bit container limit (4 GiB)",
+    );
     let mut out = Vec::with_capacity(total);
 
     // GLB header

--- a/rust/export/src/gltf.rs
+++ b/rust/export/src/gltf.rs
@@ -460,8 +460,9 @@ fn assemble_glb(views: &[MeshView], include_metadata: bool, lit: bool) -> (Vec<u
     // and per-mesh accessor/bufferView offset is bounded by it (positions grows
     // monotonically, so an over-limit run aborts before the GLB is packed). The
     // container total (JSON chunk + framing on top) is guarded separately in
-    // pack_glb. (In wasm32 the 32-bit heap OOMs long before 4 GiB; this protects
-    // native consumers of the export crate.) Sum in usize to avoid the u32 wrap.
+    // pack_glb. Summed in usize, which is 64-bit on the native consumers this
+    // guard actually protects; on wasm32 usize is 32-bit, but the linear-memory
+    // heap OOMs long before 4 GiB so the guard is effectively native-only there.
     let bin_len = positions.len() + normals.len() + indices.len();
     assert!(
         bin_len <= u32::MAX as usize,

--- a/rust/wasm-bindings/src/api/export_data.rs
+++ b/rust/wasm-bindings/src/api/export_data.rs
@@ -16,7 +16,7 @@ impl IfcAPI {
     #[wasm_bindgen(js_name = exportCsv)]
     pub fn export_csv(
         &self,
-        content: String,
+        content: &[u8],
         mode: String,
         delimiter: String,
         include_properties: bool,
@@ -31,20 +31,20 @@ impl IfcAPI {
             delimiter: if delimiter.is_empty() { ",".to_string() } else { delimiter },
             include_properties,
         };
-        ifc_lite_export::export_csv(content.as_bytes(), mode, &opts)
+        ifc_lite_export::export_csv(content, mode, &opts)
     }
 
     /// Export structured **JSON** (array of entity objects with typed property values).
     #[wasm_bindgen(js_name = exportJson)]
     pub fn export_json(
         &self,
-        content: String,
+        content: &[u8],
         pretty: bool,
         include_properties: bool,
         include_quantities: bool,
     ) -> String {
         let opts = JsonOptions { pretty, include_properties, include_quantities };
-        ifc_lite_export::export_json(content.as_bytes(), &opts)
+        ifc_lite_export::export_json(content, &opts)
     }
 
     /// Export **JSON-LD** (`@graph` of `ifc:` nodes). Empty `context` ⇒ buildingSMART
@@ -53,7 +53,7 @@ impl IfcAPI {
     #[wasm_bindgen(js_name = exportJsonld)]
     pub fn export_jsonld(
         &self,
-        content: String,
+        content: &[u8],
         context: String,
         include_properties: bool,
         include_quantities: bool,
@@ -70,7 +70,7 @@ impl IfcAPI {
         if !context.is_empty() {
             opts.context = context;
         }
-        ifc_lite_export::export_jsonld(content.as_bytes(), &opts)
+        ifc_lite_export::export_jsonld(content, &opts)
     }
 
     /// Export **IFC5 / IFCX** (the USD-style node graph). `only_known_properties` keeps
@@ -78,11 +78,11 @@ impl IfcAPI {
     #[wasm_bindgen(js_name = exportIfcx)]
     pub fn export_ifcx(
         &self,
-        content: String,
+        content: &[u8],
         only_known_properties: bool,
         pretty: bool,
     ) -> String {
         let opts = Ifc5Options { only_known_properties, pretty, ..Default::default() };
-        ifc_lite_export::export_ifc5(content.as_bytes(), &opts)
+        ifc_lite_export::export_ifc5(content, &opts)
     }
 }

--- a/rust/wasm-bindings/src/api/export_glb.rs
+++ b/rust/wasm-bindings/src/api/export_glb.rs
@@ -23,7 +23,7 @@ impl IfcAPI {
     #[allow(clippy::too_many_arguments)]
     pub fn export_glb(
         &self,
-        content: String,
+        content: &[u8],
         include_metadata: bool,
         hidden: &[u32],
         isolated: &[u32],
@@ -42,7 +42,7 @@ impl IfcAPI {
             hidden_types,
             lit: lit.unwrap_or(true),
         };
-        ifc_lite_export::export_glb(content.as_bytes(), &opts)
+        ifc_lite_export::export_glb(content, &opts)
     }
 
     /// Assemble a **GLB** from already-produced meshes (the viewer's `MeshData`, flattened)

--- a/rust/wasm-bindings/src/api/export_hbjson.rs
+++ b/rust/wasm-bindings/src/api/export_hbjson.rs
@@ -20,8 +20,8 @@ impl IfcAPI {
     /// const hbjson = api.exportHbjson(ifcContent, "my_model");
     /// ```
     #[wasm_bindgen(js_name = exportHbjson)]
-    pub fn export_hbjson(&self, content: String, name: String) -> String {
+    pub fn export_hbjson(&self, content: &[u8], name: String) -> String {
         let opts = ifc_lite_export::HbjsonOptions { name, tolerance: 0.01 };
-        ifc_lite_export::export_hbjson(content.as_bytes(), &opts)
+        ifc_lite_export::export_hbjson(content, &opts)
     }
 }

--- a/rust/wasm-bindings/src/api/export_obj.rs
+++ b/rust/wasm-bindings/src/api/export_obj.rs
@@ -20,7 +20,7 @@ impl IfcAPI {
     #[wasm_bindgen(js_name = exportObj)]
     pub fn export_obj(
         &self,
-        content: String,
+        content: &[u8],
         include_normals: bool,
         hidden: &[u32],
         isolated: &[u32],
@@ -30,6 +30,6 @@ impl IfcAPI {
             hidden: hidden.to_vec(),
             isolated: isolated.to_vec(),
         };
-        ifc_lite_export::export_obj(content.as_bytes(), &opts)
+        ifc_lite_export::export_obj(content, &opts)
     }
 }

--- a/rust/wasm-bindings/src/api/export_step.rs
+++ b/rust/wasm-bindings/src/api/export_step.rs
@@ -19,13 +19,13 @@ impl IfcAPI {
     #[wasm_bindgen(js_name = exportStep)]
     pub fn export_step(
         &self,
-        content: String,
+        content: &[u8],
         schema: String,
         included: &[u32],
         mutations_json: String,
     ) -> String {
         ifc_lite_export::export_step_json(
-            content.as_bytes(),
+            content,
             if schema.is_empty() { None } else { Some(schema) },
             if included.is_empty() { None } else { Some(included.to_vec()) },
             &mutations_json,

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -1220,6 +1220,7 @@
     "collectStyleEntities: function",
     "convertEntityType: function",
     "convertStepLine: function",
+    "countGlbMeshes: function",
     "describeConversion: function",
     "exportToStep: function",
     "extractGlbMapping: function",

--- a/scripts/test-wasm-contract.mjs
+++ b/scripts/test-wasm-contract.mjs
@@ -501,12 +501,20 @@ test('should handle truncated IFC content gracefully', () => {
 console.log('\n📋 export (exportGlb / exportKmz)');
 
 // A real GLB from the column fixture — also the input the KMZ packer consumes.
-const glbBytes = api.exportGlb(columnContent, false, new Uint32Array(), new Uint32Array(), '');
+const glbBytes = api.exportGlb(new TextEncoder().encode(columnContent), false, new Uint32Array(), new Uint32Array(), '');
 
-test('exportGlb returns a binary glTF (GLB magic "glTF")', () => {
+test('exportGlb returns a binary glTF (GLB magic "glTF") with real meshes', () => {
   assert.ok(glbBytes instanceof Uint8Array, 'GLB should be a Uint8Array');
   assert.ok(glbBytes.length > 20, 'GLB should be non-trivial');
   assert.deepEqual(Array.from(glbBytes.slice(0, 4)), [0x67, 0x6c, 0x54, 0x46]); // "glTF"
+  // Guard that the export actually carried geometry. The IFC source must cross
+  // the boundary as a Uint8Array; if it ever arrived empty (e.g. a string coerced
+  // to zero bytes), the GLB would still be structurally valid yet declare zero
+  // meshes — caught here.
+  const dv = new DataView(glbBytes.buffer, glbBytes.byteOffset, glbBytes.byteLength);
+  const jsonLen = dv.getUint32(12, true);
+  const gltf = JSON.parse(Buffer.from(glbBytes.buffer, glbBytes.byteOffset + 20, jsonLen).toString('utf-8'));
+  assert.ok(Array.isArray(gltf.meshes) && gltf.meshes.length > 0, 'GLB should declare meshes');
 });
 
 test('exportKmz packs a stored-zip KMZ (PK header, doc.kml + model.glb, axis-derived heading)', () => {


### PR DESCRIPTION
## Summary

Makes the Rust-backed exporters reliable on large and degenerate inputs. Three fixes:

1. **Input-size cap removed.** All 8 exporters (glb/obj/csv/json/jsonld/step/ifcx/hbjson) decoded the entire input IFC buffer into one JS string via `safeUtf8Decode` before crossing into WASM, where the binding immediately turned it back into bytes (`content.as_bytes()`). Past V8's `0x1fffffe8` (~512MB) string ceiling that decode threw `Cannot create a string longer than 0x1fffffe8 characters`, so files over ~0.5GB failed before any geometry ran. They now pass the raw `Uint8Array`/`&[u8]` straight through (matching the existing `exportMerged` path), which removes the cap, drops a redundant full-buffer copy and a UTF-8 re-encode, and is byte-faithful for non-UTF-8 IFC. Removing `safeUtf8Decode` is SAB-safe: wasm-bindgen copies the bytes into linear memory directly, so the `TextDecoder` SharedArrayBuffer restriction it guarded no longer applies.

2. **Empty GLB fails loud.** A malformed-but-parseable model, or a filter matching geometry-free entities, produced a structurally valid GLB with zero meshes that the CLI and MCP exporters wrote and reported as success. Both now reject a zero-mesh GLB via the new `countGlbMeshes` helper in `@ifc-lite/export`.

3. **4 GiB GLB guard.** The assembler cast every buffer offset and byteLength `as u32`; past 4 GiB those casts silently wrapped (release disables overflow checks) into a corrupt GLB. The size is now summed in `usize` and asserted at both the binary-buffer and container-total chokepoints. Latent today (the only callers are wasm32, which OOMs before 4 GiB), so this protects native consumers of the export crate.

`@ifc-lite/wasm`, `@ifc-lite/geometry` and `@ifc-lite/export` are bumped `minor`. The change is breaking only on the low-level surfaces: `IfcAPI.export*` (`@ifc-lite/wasm`) and the re-exported `IfcLiteBridge.export*` (`@ifc-lite/geometry`) parameter types changed `string` -> `Uint8Array`. The primary documented API `GeometryProcessor.export*` is unchanged (already `Uint8Array`) and the bridge is the only in-repo caller, so `minor` is a deliberate call over `major`; external callers of the low-level `IfcAPI` / `IfcLiteBridge` exporters must switch to passing bytes. `@ifc-lite/export` is `minor` for the additive `countGlbMeshes` export.

Scope honesty: this lifts the cap on the INPUT side for all exporters. GLB returns a `Uint8Array` so its output also escapes the V8 string ceiling, but the string-returning exporters (OBJ/CSV/JSON/JSON-LD/STEP/IFCX/HBJSON) still cap their serialized OUTPUT at the same ~512 MB limit. In-browser, the wasm32 linear-memory heap (not the string cap) is the practical ceiling for the very largest models, so a 571-838 MB file is unblocked at the decode boundary but not guaranteed to complete; that end-to-end path is not yet covered by a large-file test.

## Test

- `cargo test -p ifc-lite-export` (35 passed)
- `turbo build` across all packages (typecheck)
- `pnpm test:wasm-contract` (22 passed). The `exportGlb` contract case now passes bytes and asserts a non-empty mesh set, closing a gap where passing a string silently exported an empty GLB while the test stayed green.
- new `countGlbMeshes` unit test (4)
- `pnpm check:api-surface`
- End to end: the CLI exports `duplex.ifc` to a 2.1MB GLB through the new byte boundary; a geometry-free `--type IfcSite` export exits 1 with a clear message and writes no file.

## Follow-ups (not in this PR)

- GLB output has no instancing: repeated geometry is emitted fully expanded per element (the size-amplification suspect). Needs a measurement on a representative repetitive model before implementing shared accessors / `EXT_mesh_gpu_instancing`.
- Per-element CSG-failure diagnostics are dropped at the wasm batch boundary (`batch.rs`, `let _ = drain_and_log_csg_diagnostics(...)`) and survive only as `console.warn`; the native path already returns `total_csg_failures` / `products_with_failures`. Additive seam to surface them.
