### PR TITLE
fix(cache): GLB re-import — SharedArrayBuffer decode crash + georef precision

### DIFF
--- a/.changeset/glb-roundtrip-sab-precision.md
+++ b/.changeset/glb-roundtrip-sab-precision.md
@@ -1,0 +1,31 @@
+---
+"@ifc-lite/cache": patch
+---
+
+Fix GLB re-import: SharedArrayBuffer crash + georeferenced precision corruption.
+
+Two independent round-trip bugs in the GLB importer (`parseGLB` / `parseGLBToMeshData`):
+
+1. **SharedArrayBuffer decode crash.** The viewer streams large imports (>= 256 MB)
+   into a `SharedArrayBuffer` (`acquireFileBuffer`), and that buffer reaches the GLB
+   parser unchanged. `parseGLB` decoded the JSON chunk with `new TextDecoder().decode(view)`,
+   which browsers reject for any SharedArrayBuffer-backed view (a Spectre mitigation) with
+   "TextDecoder.decode: ... can't be a SharedArrayBuffer ...". Re-importing a large exported
+   GLB therefore threw before any geometry was read. The JSON chunk now goes through
+   `safeUtf8Decode` (already in `@ifc-lite/data`), which copies it into a private non-shared
+   buffer on the SAB path. Only the small JSON chunk is copied; the binary chunk stays
+   zero-copy (it was already copied via `.slice()`).
+
+2. **Georeferenced f32 re-snap.** The exporter keeps vertices relative to the model
+   scene-centre and carries the placement on a single root-node translation, precisely so a
+   georeferenced offset (a root translation of ~1e6 m) stays out of the f32 vertex buffer. The
+   importer was baking that translation back into the f32 vertices, which re-snaps every vertex
+   to a ~0.06-0.5 m grid at georef scale and collapses fine (rebar-scale) detail. It now surfaces
+   the composed root translation as `MeshData.origin` (world = origin + position) instead, which
+   the renderer and every world-space consumer already fold (the local-frame path). The
+   non-georeferenced case (zero translation) is unchanged.
+
+Note: the importer's node walk still reads only `node.translation`, not `node.matrix`. The
+viewer's own "Export GLB" (from-meshes) emits only translations, so it round-trips fully. The
+from-bytes instanced exporter emits per-occurrence node matrices; round-tripping those is a
+follow-up that lands with the instancing work.

--- a/packages/cache/src/glb.test.ts
+++ b/packages/cache/src/glb.test.ts
@@ -212,12 +212,35 @@ describe('parseGLBToMeshData / loadGLBToMeshData — material colour round-trip'
   });
 });
 
-describe('parseGLBToMeshData — node translation folding', () => {
+describe('parseGLB — SharedArrayBuffer-backed input', () => {
+  // The viewer streams large imports (>= 256 MB) into a SharedArrayBuffer
+  // (acquireFileBuffer). In a browser, `TextDecoder.decode` rejects any
+  // SAB-backed view (a Spectre mitigation) with "...can't be a SharedArrayBuffer
+  // ...", which crashed re-import of large exported GLBs. The JSON chunk now goes
+  // through safeUtf8Decode, which copies it into a private buffer on the SAB path.
+  //
+  // NOTE: Node's TextDecoder does NOT reproduce the browser's SAB rejection, so
+  // this is a path-coverage / documentation test (it exercises the SAB input and
+  // asserts correctness), not a guard that can fail on the pre-fix code in CI.
+  it('parses a GLB whose bytes are backed by a SharedArrayBuffer', () => {
+    const glb = buildGLB([[0.2, 0.4, 0.6, 1.0]]);
+    const sab = new SharedArrayBuffer(glb.byteLength);
+    const shared = new Uint8Array(sab);
+    shared.set(glb);
+    const meshes = loadGLBToMeshData(shared);
+    expect(meshes).toHaveLength(1);
+    expect(meshes[0].color[0]).toBeCloseTo(0.2);
+    expect(meshes[0].color[2]).toBeCloseTo(0.6);
+  });
+});
+
+describe('parseGLBToMeshData — node translation → origin', () => {
   // The exporter parents every element node under ONE translated root node (the
   // placement rides that root; vertices are scene-centre-relative). A parser that
-  // ignored node transforms would land the whole model at the centre ("all centre
-  // aligned"). Verify the composed root translation is baked into world positions.
-  it('bakes a translated root node into child mesh world positions', () => {
+  // ignored node transforms would land the whole model at the centre. We surface
+  // the composed root translation as `MeshData.origin` (world = origin + position)
+  // rather than baking it into the f32 vertices — see the georef-precision test.
+  it('surfaces a composed root translation as origin, leaving vertices local', () => {
     const bin = new Uint8Array(84);
     const fv = new Float32Array(bin.buffer);
     fv.set([0, 0, 0, 1, 0, 0, 0, 1, 0], 0); // positions (centre-relative)
@@ -252,16 +275,15 @@ describe('parseGLBToMeshData — node translation folding', () => {
 
     expect(meshes).toHaveLength(1);
     expect(meshes[0].expressId).toBe(42);
-    // Each vertex must be offset by the root translation [10, 20, 30].
-    expect(Array.from(meshes[0].positions)).toEqual([
-      10, 20, 30, 11, 20, 30, 10, 21, 30,
-    ]);
+    // Placement rides `origin`; vertices stay local (world = origin + position).
+    expect(meshes[0].origin).toEqual([10, 20, 30]);
+    expect(Array.from(meshes[0].positions)).toEqual([0, 0, 0, 1, 0, 0, 0, 1, 0]);
   });
 
-  it('folds translation for a mesh node not reachable from the scene root', () => {
+  it('uses a mesh node’s own translation as origin when unreachable from the scene root', () => {
     // node 0 is the scene root (no mesh); the mesh lives on node 1 which is NOT a
-    // child of node 0 (disconnected). Extraction must still fold node 1's own
-    // translation rather than emit local-space vertices.
+    // child of node 0 (disconnected). Extraction must still apply node 1's own
+    // translation rather than emit it as the scene root's.
     const bin = new Uint8Array(84);
     const fv = new Float32Array(bin.buffer);
     fv.set([0, 0, 0, 1, 0, 0, 0, 1, 0], 0);
@@ -295,6 +317,54 @@ describe('parseGLBToMeshData — node translation folding', () => {
 
     expect(meshes).toHaveLength(1);
     // node 1's own translation [5,6,7] is applied (NOT node 0's [100,0,0]).
-    expect(Array.from(meshes[0].positions)).toEqual([5, 6, 7, 6, 6, 7, 5, 7, 7]);
+    expect(meshes[0].origin).toEqual([5, 6, 7]);
+    expect(Array.from(meshes[0].positions)).toEqual([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+  });
+
+  it('keeps sub-metre detail for a georeferenced root translation (no f32 collapse)', () => {
+    // Regression for the GLB-roundtrip corruption: a georef root translation
+    // (~6e6 m) baked into f32 vertices re-snaps everything to a ~0.5 m grid. With
+    // the translation on `origin`, the centre-relative vertices keep full f32
+    // precision and the cm-scale spread survives the round-trip.
+    const bin = new Uint8Array(84);
+    const fv = new Float32Array(bin.buffer);
+    // Three vertices 0.04 m apart in X, 0.31 m offset in Z — the kind of detail a
+    // rebar cross-section carries.
+    fv.set([-0.02, 0, 0.31, 0.02, 0, 0.31, 0, 5, 0.31], 0);
+    fv.set([0, 0, 1, 0, 0, 1, 0, 0, 1], 9);
+    new Uint32Array(bin.buffer, 72, 3).set([0, 1, 2]);
+
+    const sceneCenter = [501018.54, 53, -6083869.35]; // EPSG:4326-scale, Y-up GLB frame
+    const meshes = parseGLBToMeshData(
+      {
+        asset: { version: '2.0' },
+        scene: 0,
+        scenes: [{ nodes: [1] }],
+        nodes: [
+          { mesh: 0, extras: { expressId: 7 } },
+          { children: [0], translation: sceneCenter },
+        ],
+        meshes: [{ primitives: [{ attributes: { POSITION: 0, NORMAL: 1 }, indices: 2 }] }],
+        accessors: [
+          { bufferView: 0, byteOffset: 0, componentType: 5126, count: 3, type: 'VEC3' },
+          { bufferView: 1, byteOffset: 0, componentType: 5126, count: 3, type: 'VEC3' },
+          { bufferView: 2, byteOffset: 0, componentType: 5125, count: 3, type: 'SCALAR' },
+        ],
+        bufferViews: [
+          { buffer: 0, byteOffset: 0, byteLength: 36, byteStride: 12, target: 34962 },
+          { buffer: 0, byteOffset: 36, byteLength: 36, byteStride: 12, target: 34962 },
+          { buffer: 0, byteOffset: 72, byteLength: 12, target: 34963 },
+        ],
+        buffers: [{ byteLength: 84 }],
+      },
+      bin,
+    );
+
+    expect(meshes).toHaveLength(1);
+    expect(meshes[0].origin).toEqual(sceneCenter);
+    const p = meshes[0].positions;
+    // Full precision retained: 0.04 m X-spread and 0.31 m Z-offset survive exactly.
+    expect(p[3] - p[0]).toBeCloseTo(0.04, 6);
+    expect(p[2]).toBeCloseTo(0.31, 6);
   });
 });

--- a/packages/cache/src/glb.ts
+++ b/packages/cache/src/glb.ts
@@ -10,6 +10,7 @@
  */
 
 import type { MeshData } from '@ifc-lite/geometry';
+import { safeUtf8Decode } from '@ifc-lite/data';
 
 // glTF 2.0 constants
 const GLB_MAGIC = 0x46546c67; // 'glTF'
@@ -155,8 +156,13 @@ export function parseGLB(data: Uint8Array): ParsedGLB {
     }
 
     if (chunkType === CHUNK_TYPE_JSON) {
-      const jsonBytes = data.subarray(offset, offset + chunkLength);
-      const jsonString = new TextDecoder().decode(jsonBytes);
+      // Decode SAB-safe: the viewer streams large imports (>= 256 MB) into a
+      // SharedArrayBuffer (acquireFileBuffer), and `TextDecoder.decode` rejects any
+      // SharedArrayBuffer-backed view (a Spectre mitigation) with "...can't be a
+      // SharedArrayBuffer...". safeUtf8Decode copies the JSON chunk into a private
+      // (non-shared) scratch buffer on the SAB path, so re-importing a large GLB no
+      // longer throws. Only the small JSON chunk is copied; BIN stays zero-copy.
+      const jsonString = safeUtf8Decode(data, offset, offset + chunkLength);
       json = JSON.parse(jsonString) as GLTFDocument;
     } else if (chunkType === CHUNK_TYPE_BIN) {
       bin = data.slice(offset, offset + chunkLength);
@@ -354,7 +360,7 @@ export function parseGLBToMeshData(gltf: GLTFDocument, bin: Uint8Array): MeshDat
   // element node under one translated root (placement rides that root, vertices
   // are centre-relative), so a parser that read accessors alone would land the
   // whole model at the scene centre. Walk from the scene roots accumulating
-  // translation, then bake it into each mesh node's vertices → absolute world.
+  // translation; the composed value rides each mesh as `MeshData.origin` below.
   const nodeWorldT = new Map<number, [number, number, number]>();
   {
     const seen = new Set<number>();
@@ -424,24 +430,22 @@ export function parseGLBToMeshData(gltf: GLTFDocument, bin: Uint8Array): MeshDat
       if (posAccessorIdx === undefined) continue;
 
       // Read position data
-      let positions = readAccessorData(gltf, bin, posAccessorIdx);
+      const positions = readAccessorData(gltf, bin, posAccessorIdx);
       if (!(positions instanceof Float32Array)) {
         throw new Error('Position data must be Float32');
       }
 
-      // Fold the node's composed world translation into the vertices (a fresh
-      // buffer — readAccessorData may alias the shared bin). Yields absolute
-      // world positions so bounds/render need no per-node transform handling.
+      // Surface the node's composed world translation as `MeshData.origin`
+      // (world = origin + position) rather than baking it into the f32 vertices.
+      // The exporter keeps vertices scene-centre-relative precisely so a
+      // georeferenced placement (a root translation of ~1e6 m) stays out of the
+      // f32 buffer; baking it back in would re-snap every vertex to a ~0.5 m grid
+      // and collapse fine detail (the GLB-roundtrip corruption). The renderer and
+      // all world-space consumers fold `origin` (#1114), so positions stay small
+      // and full-precision while the element still lands at its world position.
       const wt = nodeWorldT.get(nodeIdx);
-      if (wt && (wt[0] !== 0 || wt[1] !== 0 || wt[2] !== 0)) {
-        const placed = new Float32Array(positions.length);
-        for (let i = 0; i < positions.length; i += 3) {
-          placed[i] = positions[i] + wt[0];
-          placed[i + 1] = positions[i + 1] + wt[1];
-          placed[i + 2] = positions[i + 2] + wt[2];
-        }
-        positions = placed;
-      }
+      const origin: [number, number, number] | undefined =
+        wt && (wt[0] !== 0 || wt[1] !== 0 || wt[2] !== 0) ? wt : undefined;
 
       // Read normal data (optional, generate if missing)
       let normals: Float32Array;
@@ -480,6 +484,7 @@ export function parseGLBToMeshData(gltf: GLTFDocument, bin: Uint8Array): MeshDat
         normals,
         indices,
         color: resolveMaterialColor(primitive.material),
+        ...(origin ? { origin } : {}),
       });
     }
   }


### PR DESCRIPTION
## What

Fixes GLB **re-import** failing after exporting a large/georeferenced model (e.g. 170_KM.glb). Two independent round-trip bugs in `packages/cache/src/glb.ts`:

### 1. SharedArrayBuffer decode crash (the reported error)
> `GLB parsing failed: TextDecoder.decode: ... can't be a SharedArrayBuffer or an ArrayBufferView backed by a SharedArrayBuffer`

The viewer streams large imports (`>= 256 MB`, `acquireFileBuffer`) into a `SharedArrayBuffer`, which reaches `parseGLB` unchanged. The JSON chunk was decoded with `new TextDecoder().decode(view)` — browsers reject that for any SAB-backed view (Spectre mitigation), so re-importing a large exported GLB threw **before any geometry was read**. The JSON chunk now goes through `safeUtf8Decode` (already in `@ifc-lite/data`, already a cache dep), which copies it into a private non-shared buffer on the SAB path. Only the small JSON chunk is copied; BIN was already zero-copy via `.slice()`.

### 2. Georeferenced f32 re-snap (the next bug you'd hit)
The Rust exporter keeps vertices relative to the model scene-centre and carries the placement on a **single root-node translation**, precisely so a georeferenced offset (~1e6 m) stays out of the f32 vertex buffer. The importer was **baking that translation back into the f32 vertices**, re-snapping every vertex to a ~0.06–0.5 m grid at georef scale and collapsing rebar-scale (~0.04 m) detail. It now surfaces the composed root translation as `MeshData.origin` (`world = origin + position`), which the renderer/BVH/pick/section path already folds (#1114). The non-georef case (zero translation → `undefined` origin) is byte-identical to before.

## Scope / follow-up
The importer's node walk reads only `node.translation`, **not `node.matrix`**. The viewer's own "Export GLB" uses the from-meshes path (`instance: None`) which emits **translations only**, so it round-trips fully. The from-bytes instanced exporter (PR #1443) emits per-occurrence **node matrices**; round-tripping those (position + rotation) is a follow-up that should land alongside that PR — it needs a real instanced GLB to test and a rotation channel on `MeshData`.

## Provenance
This is the salvaged real fix from the local `glb-roundtrip-rebar` investigation (the `glb.ts` origin change + its georef regression test), plus the new SAB-safe decode. The throwaway `[DEBUG-FRAMES]`/`[DEBUG-SHARD]` `console.log` instrumentation from that branch is dropped.

## Tests
`packages/cache/src/glb.test.ts`: existing colour round-trip + the origin/georef-precision regression (sub-metre detail at ~6e6 m), plus a SharedArrayBuffer-input path-coverage test (Node's TextDecoder does not reproduce the browser SAB rejection, so it documents + exercises the path rather than guarding it). **Cache glb suite 22/22**, package typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GLB imports that could fail when files are backed by `SharedArrayBuffer`.
  * Improved handling of georeferenced models so vertex precision is preserved during import.
  * Kept mesh positions in local space and now expose scene translation separately, helping world-space viewers render large or geospatial scenes more accurately.
  * Updated import validation to better cover translation behavior and precision-related edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->