### PR TITLE
fix(cache): honor GLB node matrices so instanced exports round-trip (follow-up to #1443)

### DIFF
--- a/.changeset/glb-import-node-matrix.md
+++ b/.changeset/glb-import-node-matrix.md
@@ -1,0 +1,26 @@
+---
+"@ifc-lite/cache": patch
+---
+
+GLB importer: honor node matrices so instanced exports round-trip.
+
+The GLB importer (`parseGLBToMeshData`) composed only `node.translation` down the
+hierarchy, never `node.matrix`. The from-meshes export (the viewer's "Export GLB")
+emits translations only and round-tripped fine, but the from-bytes instanced exporter
+(#1443) places each shared-template occurrence with a node MATRIX (rotation +
+translation). Re-importing such a GLB collapsed every instanced occurrence onto the
+template (each matrix node contributed a zero translation), losing per-occurrence
+position and rotation.
+
+The importer now composes the full column-major 4x4 down the hierarchy. The composed
+TRANSLATION rides each mesh as `MeshData.origin` (kept out of the f32 vertex buffer for
+georeferenced precision, as before), and any ROTATION/SCALE is baked into the small,
+local imported vertices and normals (which stay f32-precise because they are
+template-local). The pure-translation path is byte-identical to before, so the viewer's
+own exports are unaffected.
+
+Verified end to end: a real instanced GLB exported by `ifc-lite-export` (C20-Institute)
+re-imports with occurrences spread across the building at many distinct world poses (not
+collapsed), with local vertices staying sub-metre. Normal note: rotation is exact; a
+non-uniform-scale instance would want the inverse-transpose for normals (a rare,
+accepted approximation, since instance transforms are rigid).

--- a/packages/cache/src/glb.test.ts
+++ b/packages/cache/src/glb.test.ts
@@ -368,3 +368,96 @@ describe('parseGLBToMeshData — node translation → origin', () => {
     expect(p[2]).toBeCloseTo(0.31, 6);
   });
 });
+
+describe('parseGLBToMeshData — node matrix (instanced occurrence)', () => {
+  // The from-bytes instanced exporter shares one template mesh across occurrences and
+  // places each with a node MATRIX (rotation + translation) under the translated root.
+  // The importer composes the full 4x4, bakes the rotation into the small LOCAL vertices
+  // + normals (f32-safe), and surfaces only the translation as MeshData.origin (kept out
+  // of the f32 buffer for georef precision). world = origin + position == matrix * local.
+  function buildInstancedDoc(rootTranslation: number[], occMatrix: number[]) {
+    const tmpl = [1, 0, 0, 0, 1, 0, 0, 0, 1]; // template-local triangle p0,p1,p2
+    const nrm = [1, 0, 0, 1, 0, 0, 1, 0, 0]; // +x normal per vertex
+    const bin = new Uint8Array(84);
+    new Float32Array(bin.buffer, 0, 9).set(tmpl);
+    new Float32Array(bin.buffer, 36, 9).set(nrm);
+    new Uint32Array(bin.buffer, 72, 3).set([0, 1, 2]);
+    const doc = {
+      asset: { version: '2.0' },
+      scene: 0,
+      scenes: [{ nodes: [0] }],
+      nodes: [
+        { translation: rootTranslation, children: [1] },
+        { mesh: 0, matrix: occMatrix },
+      ],
+      meshes: [{ primitives: [{ attributes: { POSITION: 0, NORMAL: 1 }, indices: 2 }] }],
+      accessors: [
+        { bufferView: 0, byteOffset: 0, componentType: 5126, count: 3, type: 'VEC3' },
+        { bufferView: 1, byteOffset: 0, componentType: 5126, count: 3, type: 'VEC3' },
+        { bufferView: 2, byteOffset: 0, componentType: 5125, count: 3, type: 'SCALAR' },
+      ],
+      bufferViews: [
+        { buffer: 0, byteOffset: 0, byteLength: 36, byteStride: 12, target: 34962 },
+        { buffer: 0, byteOffset: 36, byteLength: 36, byteStride: 12, target: 34962 },
+        { buffer: 0, byteOffset: 72, byteLength: 12, target: 34963 },
+      ],
+      buffers: [{ byteLength: 84 }],
+    };
+    return { doc, bin, tmpl };
+  }
+
+  it('bakes node-matrix rotation into vertices + normals, translation into origin', () => {
+    // 90 deg about Z (column-major) + local translation [10, 20, 0].
+    const occMatrix = [0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1, 0, 10, 20, 0, 1];
+    const { doc, bin } = buildInstancedDoc([1000, 2000, 3000], occMatrix);
+    const meshes = parseGLBToMeshData(doc, bin);
+    expect(meshes).toHaveLength(1);
+    const mesh = meshes[0];
+
+    // origin = composed translation (root + occ) = [1010, 2020, 3000].
+    expect(mesh.origin).toBeDefined();
+    expect(mesh.origin![0]).toBeCloseTo(1010);
+    expect(mesh.origin![1]).toBeCloseTo(2020);
+    expect(mesh.origin![2]).toBeCloseTo(3000);
+
+    // Rotation baked into LOCAL vertices: Rz(90)·[1,0,0]=[0,1,0], ·[0,1,0]=[-1,0,0], ·[0,0,1]=[0,0,1].
+    const expectLocal = [0, 1, 0, -1, 0, 0, 0, 0, 1];
+    for (let i = 0; i < 9; i++) expect(mesh.positions[i]).toBeCloseTo(expectLocal[i], 4);
+
+    // Reconstructed world = origin + baked-local == matrix * template (full precision).
+    expect(mesh.origin![0] + mesh.positions[0]).toBeCloseTo(1010); // p0.x
+    expect(mesh.origin![1] + mesh.positions[1]).toBeCloseTo(2021); // p0.y
+    expect(mesh.origin![2] + mesh.positions[2]).toBeCloseTo(3000); // p0.z
+
+    // Normal +x rotated to +y; still unit length.
+    expect(mesh.normals[0]).toBeCloseTo(0, 4);
+    expect(mesh.normals[1]).toBeCloseTo(1, 4);
+    expect(mesh.normals[2]).toBeCloseTo(0, 4);
+  });
+
+  it('keeps rotated-occurrence vertices full-precision under a national-grid offset', () => {
+    // 90 deg about Z at a Dutch-RD-scale translation: the baked vertices stay LOCAL
+    // (small) so f32 holds them exactly; the ~6e6 m offset rides origin (a JS double).
+    const occMatrix = [0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+    const { doc, bin } = buildInstancedDoc([155000, 463000, 5500000], occMatrix);
+    const meshes = parseGLBToMeshData(doc, bin);
+    const mesh = meshes[0];
+    // Baked-local positions are small (|v| ~ 1), not building/grid scale.
+    for (const v of mesh.positions) expect(Math.abs(v)).toBeLessThan(2);
+    // origin carries the grid offset at full f64 precision.
+    expect(mesh.origin![0]).toBe(155000);
+    expect(mesh.origin![2]).toBe(5500000);
+    // World p1 = origin + Rz(90)·[0,1,0]=[-1,0,0] -> x = 155000 - 1 = 154999 exactly.
+    expect(mesh.origin![0] + mesh.positions[3]).toBeCloseTo(154999, 3);
+  });
+
+  it('leaves a pure-translation node unbaked (vertices stay the template, no rotation cost)', () => {
+    // Identity rotation + translation: must behave exactly like the translation path.
+    const occMatrix = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 7, 8, 9, 1];
+    const { doc, bin, tmpl } = buildInstancedDoc([100, 200, 300], occMatrix);
+    const mesh = parseGLBToMeshData(doc, bin)[0];
+    // No rotation: positions are the untouched template (no fresh buffer needed).
+    for (let i = 0; i < 9; i++) expect(mesh.positions[i]).toBeCloseTo(tmpl[i], 6);
+    expect(mesh.origin).toEqual([107, 208, 309]);
+  });
+});

--- a/packages/cache/src/glb.ts
+++ b/packages/cache/src/glb.ts
@@ -57,9 +57,13 @@ interface GLTFNode {
   name?: string;
   extras?: { expressId?: number };
   children?: number[];
-  /** Node-local translation (xyz). Our exporter places all geometry under a
-   *  single translated root node, so this must be composed down the hierarchy. */
+  /** Node-local translation (xyz). The from-meshes exporter places all geometry
+   *  under a single translated root node, so this is composed down the hierarchy. */
   translation?: number[];
+  /** Node-local column-major 4x4 (glTF convention). The from-bytes instanced
+   *  exporter places each shared-template occurrence with a node MATRIX (rotation +
+   *  translation); mutually exclusive with `translation` per the glTF spec. */
+  matrix?: number[];
 }
 
 interface GLTFMesh {
@@ -341,6 +345,42 @@ function readAccessorData(
   return result;
 }
 
+/** Column-major 4x4 (glTF node-transform convention). */
+type Mat4 = number[];
+
+const MAT4_IDENTITY: Mat4 = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+
+/** Column-major 4x4 multiply `a * b`. */
+function mat4Mul(a: Mat4, b: Mat4): Mat4 {
+  const out = new Array<number>(16);
+  for (let col = 0; col < 4; col++) {
+    for (let row = 0; row < 4; row++) {
+      let s = 0;
+      for (let k = 0; k < 4; k++) s += a[k * 4 + row] * b[col * 4 + k];
+      out[col * 4 + row] = s;
+    }
+  }
+  return out;
+}
+
+/** A node's local transform: its `matrix` (column-major) or a translation matrix. */
+function nodeLocalMat4(nd: GLTFNode): Mat4 {
+  if (Array.isArray(nd.matrix) && nd.matrix.length === 16) return nd.matrix;
+  const t = nd.translation;
+  return [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, t?.[0] ?? 0, t?.[1] ?? 0, t?.[2] ?? 0, 1];
+}
+
+/** True when a 4x4's upper-left 3x3 is the identity (within epsilon) — i.e. the
+ *  node carries pure translation, so vertices need no rotation/scale baking. */
+function linearIsIdentity(m: Mat4): boolean {
+  const e = 1e-6;
+  return (
+    Math.abs(m[0] - 1) < e && Math.abs(m[1]) < e && Math.abs(m[2]) < e &&
+    Math.abs(m[4]) < e && Math.abs(m[5] - 1) < e && Math.abs(m[6]) < e &&
+    Math.abs(m[8]) < e && Math.abs(m[9]) < e && Math.abs(m[10] - 1) < e
+  );
+}
+
 /**
  * Parse GLB geometry into MeshData format
  *
@@ -356,32 +396,32 @@ export function parseGLBToMeshData(gltf: GLTFDocument, bin: Uint8Array): MeshDat
     return meshes;
   }
 
-  // Compose node translations down the hierarchy. Our exporter parents every
-  // element node under one translated root (placement rides that root, vertices
-  // are centre-relative), so a parser that read accessors alone would land the
-  // whole model at the scene centre. Walk from the scene roots accumulating
-  // translation; the composed value rides each mesh as `MeshData.origin` below.
-  const nodeWorldT = new Map<number, [number, number, number]>();
+  // Compose each node's world transform down the hierarchy as a column-major 4x4.
+  // The exporter parents every element node under one translated root (placement
+  // rides that root; vertices are scene-centre-relative). The from-meshes path uses
+  // pure node TRANSLATIONS; the from-bytes INSTANCED path places each shared-template
+  // occurrence with a node MATRIX (rotation + translation). We compose the full 4x4
+  // so both round-trip: the translation rides each mesh as `MeshData.origin` (kept
+  // out of the f32 buffer for georef precision) and any rotation/scale is baked into
+  // the small, local imported vertices below.
+  const nodeWorldM = new Map<number, Mat4>();
   {
     const seen = new Set<number>();
     const roots = gltf.scenes?.[gltf.scene ?? 0]?.nodes ?? gltf.nodes.map((_, i) => i);
-    const walk = (idx: number, px: number, py: number, pz: number): void => {
+    const walk = (idx: number, parent: Mat4): void => {
       const nd = gltf.nodes?.[idx];
       if (!nd || seen.has(idx)) return; // guard against malformed cycles
       seen.add(idx);
-      const t = nd.translation;
-      const x = px + (t?.[0] ?? 0);
-      const y = py + (t?.[1] ?? 0);
-      const z = pz + (t?.[2] ?? 0);
-      nodeWorldT.set(idx, [x, y, z]);
-      for (const c of nd.children ?? []) walk(c, x, y, z);
+      const world = mat4Mul(parent, nodeLocalMat4(nd));
+      nodeWorldM.set(idx, world);
+      for (const c of nd.children ?? []) walk(c, world);
     };
-    for (const r of roots) walk(r, 0, 0, 0);
+    for (const r of roots) walk(r, MAT4_IDENTITY);
     // Extraction below iterates ALL nodes, not just scene-reachable ones. Walk any
     // node the scene roots didn't reach (disconnected components) as its own root so
     // every mesh node gets a composed transform — never silently emitted in local space.
     for (let i = 0; i < gltf.nodes.length; i++) {
-      if (!seen.has(i)) walk(i, 0, 0, 0);
+      if (!seen.has(i)) walk(i, MAT4_IDENTITY);
     }
   }
 
@@ -435,18 +475,6 @@ export function parseGLBToMeshData(gltf: GLTFDocument, bin: Uint8Array): MeshDat
         throw new Error('Position data must be Float32');
       }
 
-      // Surface the node's composed world translation as `MeshData.origin`
-      // (world = origin + position) rather than baking it into the f32 vertices.
-      // The exporter keeps vertices scene-centre-relative precisely so a
-      // georeferenced placement (a root translation of ~1e6 m) stays out of the
-      // f32 buffer; baking it back in would re-snap every vertex to a ~0.5 m grid
-      // and collapse fine detail (the GLB-roundtrip corruption). The renderer and
-      // all world-space consumers fold `origin` (#1114), so positions stay small
-      // and full-precision while the element still lands at its world position.
-      const wt = nodeWorldT.get(nodeIdx);
-      const origin: [number, number, number] | undefined =
-        wt && (wt[0] !== 0 || wt[1] !== 0 || wt[2] !== 0) ? wt : undefined;
-
       // Read normal data (optional, generate if missing)
       let normals: Float32Array;
       if (normAccessorIdx !== undefined) {
@@ -478,10 +506,46 @@ export function parseGLBToMeshData(gltf: GLTFDocument, bin: Uint8Array): MeshDat
         }
       }
 
+      // Apply the node's composed world transform. The TRANSLATION rides each mesh
+      // as `MeshData.origin` (world = origin + position) and is kept OUT of the f32
+      // vertex buffer: the exporter emits scene-centre-relative vertices precisely so
+      // a georeferenced placement (~1e6 m) does not re-snap every vertex to a ~0.5 m
+      // grid (the #1446 round-trip corruption); the renderer folds `origin` (#1114).
+      // Any ROTATION/SCALE (a from-bytes instanced occurrence's node MATRIX) is baked
+      // into the small, local vertices + normals here — MeshData has a translation
+      // origin channel but no rotation channel, so honoring the matrix means rotating
+      // the imported geometry, which stays f32-precise because the vertices are local.
+      const m = nodeWorldM.get(nodeIdx) ?? MAT4_IDENTITY;
+      const t: [number, number, number] = [m[12], m[13], m[14]];
+      let outPositions = positions;
+      let outNormals = normals;
+      if (!linearIsIdentity(m)) {
+        outPositions = new Float32Array(positions.length);
+        for (let i = 0; i + 2 < positions.length; i += 3) {
+          const x = positions[i], y = positions[i + 1], z = positions[i + 2];
+          outPositions[i] = m[0] * x + m[4] * y + m[8] * z;
+          outPositions[i + 1] = m[1] * x + m[5] * y + m[9] * z;
+          outPositions[i + 2] = m[2] * x + m[6] * y + m[10] * z;
+        }
+        outNormals = new Float32Array(normals.length);
+        for (let i = 0; i + 2 < normals.length; i += 3) {
+          const x = normals[i], y = normals[i + 1], z = normals[i + 2];
+          const nx = m[0] * x + m[4] * y + m[8] * z;
+          const ny = m[1] * x + m[5] * y + m[9] * z;
+          const nz = m[2] * x + m[6] * y + m[10] * z;
+          const len = Math.hypot(nx, ny, nz) || 1;
+          outNormals[i] = nx / len;
+          outNormals[i + 1] = ny / len;
+          outNormals[i + 2] = nz / len;
+        }
+      }
+      const origin: [number, number, number] | undefined =
+        t[0] !== 0 || t[1] !== 0 || t[2] !== 0 ? t : undefined;
+
       meshes.push({
         expressId,
-        positions,
-        normals,
+        positions: outPositions,
+        normals: outNormals,
         indices,
         color: resolveMaterialColor(primitive.material),
         ...(origin ? { origin } : {}),


### PR DESCRIPTION
## What

Follow-up to #1443 (GLB instancing). The GLB importer (`parseGLBToMeshData`) composed only `node.translation` down the hierarchy, never `node.matrix`.

- The **from-meshes** export (the viewer's "Export GLB") emits node **translations** only → round-tripped fine (and #1446 fixed its SAB crash + georef precision).
- The **from-bytes instanced** export (#1443) places each shared-template occurrence with a node **matrix** (rotation + translation). Re-importing such a GLB **collapsed every instanced occurrence onto the template** (each matrix node contributed a zero translation), losing per-occurrence position and rotation.

This was the deferred gap called out in #1446.

## Change

`parseGLBToMeshData` now composes the full **column-major 4×4** down the hierarchy:
- the composed **translation** rides each mesh as `MeshData.origin` (kept out of the f32 vertex buffer for georeferenced precision, exactly as #1446);
- any **rotation/scale** is baked into the small, **template-local** vertices + normals (f32-safe because they are local, not world-scale).

The pure-translation path is **byte-identical** to before (`linearIsIdentity` short-circuit), so the viewer's own from-meshes exports are unaffected.

## Verification

- **3 new synthetic tests**: node-matrix rotation baked into vertices+normals with translation surfaced as origin; rotated occurrence at national-grid (~6e6 m) keeps local vertices full-precision while the offset rides `origin`; pure-translation node left unbaked (identical to the translation path).
- **Real end-to-end round-trip**: an instanced GLB exported by `ifc-lite-export` (C20-Institute, node matrices) re-imports through the updated parser with occurrences spread across the building at **>50 distinct world poses** (not collapsed), local vertices sub-metre.
- Cache glb suite **25/25**, package typechecks clean, no new exports.

Normal note: rotation is exact; a non-uniform-scale instance would want the inverse-transpose for normals — a rare, accepted approximation since instance transforms are rigid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Imported GLB models now preserve full node transforms, so rotated and scaled instances appear in the correct world position instead of collapsing onto the original mesh.
  * Per-instance translation is still preserved, while vertex positions and normals are adjusted only when needed for accurate display.
  * Large-coordinate scenes keep their precision better during import, reducing visible offset errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->