### PR TITLE
fix(geometry): instanced occurrence transforms — post-RTC frame (georef GLB collapse)

### DIFF
--- a/.changeset/glb-instancing-2x-rtc.md
+++ b/.changeset/glb-instancing-2x-rtc.md
@@ -1,0 +1,29 @@
+---
+"@ifc-lite/wasm": patch
+"@ifc-lite/geometry": patch
+---
+
+Fix GLB export collapse on georeferenced models with rotated instanced occurrences.
+
+The GPU-instancing collator built each occurrence's relative transform as
+`rel = m_k · m_ref⁻¹` on the **pre-RTC** (absolute, georeferenced-magnitude)
+placements stored in `InstanceMeta.transform`, while the baked template `origin`
+is **post-RTC** (small). For an occurrence rotated relative to its template,
+`rel.translation = T_k − R_rel·T_ref` — and when the rotation flips an axis the
+two ~1e6 m terms *add* instead of cancel, reaching **2× the georeference**. The
+renderer then applies that to the small template origin, so those occurrences fly
+out to twice the site offset. On a georeferenced model (e.g. EPSG:4326 rebar) this
+dragged the GLB exporter's scene-center to ~6e6 m and re-snapped every f32 vertex
+to a ~0.5 m grid, collapsing the whole model on export / re-import.
+
+`collate_refs` now takes the applied RTC and reduces both composed transforms to
+the post-RTC frame before forming the relative transform, so the offset cancels
+exactly regardless of rotation and the relative translation stays at building
+scale (consistent with the small template origin the renderer applies it to). The
+`processGeometryBatchInstanced` shard path passes the real RTC; the from-bytes
+glTF exporter passes `[0,0,0]` because it already conjugates by RTC per occurrence
+downstream. Non-georeferenced models (RTC `[0,0,0]`) are unchanged.
+
+Verified end to end: instanced occurrences for a georeferenced model now stay at
+building scale (was ~1.2e7 m), the viewer GLB export is precise (±9 m, was ±6e6 m
+collapsed), and the export → re-import round-trip is geometrically intact.

--- a/rust/export/src/gltf.rs
+++ b/rust/export/src/gltf.rs
@@ -645,7 +645,12 @@ fn assemble_glb(
             color: m.color,
         })
         .collect();
-    let collated = collate_refs(&refs, 2);
+    // rtc [0,0,0]: this path keeps the RAW pre-RTC relative transforms and applies
+    // its own `T(-rtc)·rel·T(rtc)` conjugation per occurrence in
+    // `occurrence_node_matrix` (it has the Z-up model rtc there). Passing the rtc
+    // here too would conjugate twice. The wasm GPU-shard path, which consumes the
+    // relative transform directly (no downstream conjugation), passes the real rtc.
+    let collated = collate_refs(&refs, 2, [0.0, 0.0, 0.0]);
 
     // Partition into instanced templates (non-rigid, exact-bit) and a flat remainder.
     // Only EXACT-bit groups are instanced: the template's local geometry IS each

--- a/rust/geometry/src/instancing/collate.rs
+++ b/rust/geometry/src/instancing/collate.rs
@@ -109,10 +109,30 @@ impl<'a> InstanceMeshRef<'a> {
     }
 }
 
+/// Subtract the model RTC offset from a composed (pre-RTC) world transform's
+/// translation column, giving the post-RTC placement that matches the post-RTC
+/// per-mesh `origin` the renderer applies the relative transform to.
+fn to_post_rtc(mut m: Matrix4<f64>, rtc: [f64; 3]) -> Matrix4<f64> {
+    m[(0, 3)] -= rtc[0];
+    m[(1, 3)] -= rtc[1];
+    m[(2, 3)] -= rtc[2];
+    m
+}
+
 /// Group instanceable meshes by representation identity into templates +
 /// per-instance transforms. `min_group` is the smallest occurrence count worth
 /// instancing (groups below it are emitted flat); use 2 to instance any repeat.
-pub fn collate_refs(meshes: &[InstanceMeshRef], min_group: usize) -> Collated {
+///
+/// `rtc` is the model RTC offset (`InstanceMeta.transform` is documented pre-RTC
+/// at georeferenced magnitude, while each mesh's baked `origin` is post-RTC and
+/// small). The per-occurrence relative transform is computed in the post-RTC
+/// frame: on raw absolute placements `rel = m_k · m_ref⁻¹` lets a *rotated*
+/// occurrence's translation reach `T_k − R_rel·T_ref ≈ 2× rtc` (the two ~1e6 m
+/// terms add instead of cancel), which then places the occurrence at twice the
+/// georeference and collapses f32 GLB exports. Reducing both transforms by `rtc`
+/// first keeps `rel.translation` at building scale and consistent with the small
+/// template origin.
+pub fn collate_refs(meshes: &[InstanceMeshRef], min_group: usize, rtc: [f64; 3]) -> Collated {
     // First-seen order keeps output deterministic regardless of hash iteration.
     let mut order: Vec<u128> = Vec::new();
     let mut groups: FxHashMap<u128, Vec<usize>> = FxHashMap::default();
@@ -153,7 +173,9 @@ pub fn collate_refs(meshes: &[InstanceMeshRef], min_group: usize) -> Collated {
         }
         let t_idx = members[0];
         let template = &meshes[t_idx];
-        let m_ref = compose_world(template.instance_meta.unwrap());
+        // Compose in the post-RTC frame so the georeferenced offset cancels
+        // exactly regardless of each occurrence's rotation (see fn docs).
+        let m_ref = to_post_rtc(compose_world(template.instance_meta.unwrap()), rtc);
         let Some(m_ref_inv) = m_ref.try_inverse() else {
             out.flat_indices.extend_from_slice(members);
             continue;
@@ -183,7 +205,7 @@ pub fn collate_refs(meshes: &[InstanceMeshRef], min_group: usize) -> Collated {
                 shapes_match = false;
                 break;
             }
-            let m_k = compose_world(mesh.instance_meta.unwrap());
+            let m_k = to_post_rtc(compose_world(mesh.instance_meta.unwrap()), rtc);
             let rel = m_k * m_ref_inv;
             occurrences.push(InstanceOccurrence {
                 mesh_index: i,
@@ -205,9 +227,9 @@ pub fn collate_refs(meshes: &[InstanceMeshRef], min_group: usize) -> Collated {
 }
 
 /// `collate_refs` over geometry `Mesh` values (thin wrapper, no geometry clone).
-pub fn collate_instances(meshes: &[Mesh], min_group: usize) -> Collated {
+pub fn collate_instances(meshes: &[Mesh], min_group: usize, rtc: [f64; 3]) -> Collated {
     let refs: Vec<InstanceMeshRef> = meshes.iter().map(InstanceMeshRef::from_mesh).collect();
-    collate_refs(&refs, min_group)
+    collate_refs(&refs, min_group, rtc)
 }
 
 /// Maximum per-vertex world-space error (in mesh units) when each occurrence is

--- a/rust/geometry/src/instancing/tests.rs
+++ b/rust/geometry/src/instancing/tests.rs
@@ -5,7 +5,7 @@
 use super::collate::mat4_to_row_major_f32;
 use super::{
     collate_and_encode, collate_instances, decode_instanced, encode_instanced, verify_recomposition,
-    InstanceMeshRef,
+    Collated, InstanceMeshRef,
 };
 use crate::mesh::{InstanceMeta, Mesh};
 use nalgebra::Matrix4;
@@ -73,7 +73,7 @@ fn collates_repeated_representation_and_recomposes_within_a_micrometre() {
         })
         .collect();
 
-    let collated = collate_instances(&meshes, 2);
+    let collated = collate_instances(&meshes, 2, [0.0, 0.0, 0.0]);
     assert_eq!(collated.templates.len(), 1, "one shared template");
     assert_eq!(collated.flat_indices.len(), 0, "nothing left flat");
     let tmpl = &collated.templates[0];
@@ -126,7 +126,7 @@ fn composes_placement_and_mapping_transform() {
         })
         .collect();
 
-    let collated = collate_instances(&meshes, 2);
+    let collated = collate_instances(&meshes, 2, [0.0, 0.0, 0.0]);
     assert_eq!(collated.templates.len(), 1);
     assert_eq!(collated.templates[0].occurrences.len(), 2);
     let err = verify_recomposition(&meshes, &collated);
@@ -165,7 +165,7 @@ fn rigid_canonical_transform_recomposes() {
             },
         ),
     ];
-    let collated = collate_instances(&meshes, 2);
+    let collated = collate_instances(&meshes, 2, [0.0, 0.0, 0.0]);
     assert_eq!(collated.templates.len(), 1, "one rigid template");
     assert_eq!(collated.templates[0].occurrences.len(), 2);
     let err = verify_recomposition(&meshes, &collated);
@@ -193,7 +193,7 @@ fn instanced_wire_format_roundtrips_and_expands_to_flat() {
         )
     };
     let meshes = vec![mk(&m0, 50), mk(&m1, 50), mk(&m2, 60)];
-    let collated = collate_instances(&meshes, 2);
+    let collated = collate_instances(&meshes, 2, [0.0, 0.0, 0.0]);
 
     let bytes = encode_instanced(&meshes, &collated, |i| i as u32, |_| [0.25, 0.5, 0.75, 1.0]);
     let dec = decode_instanced(&bytes).expect("decodes");
@@ -257,7 +257,7 @@ fn dump_instanced_fixture() {
         )
     };
     let meshes = vec![mk(&m0, 50), mk(&m1, 50), mk(&m2, 60)];
-    let collated = collate_instances(&meshes, 2);
+    let collated = collate_instances(&meshes, 2, [0.0, 0.0, 0.0]);
     let bytes = encode_instanced(&meshes, &collated, |i| (1000 + i) as u32, |i| {
         [i as f32 * 0.1, 0.2, 0.3, 1.0]
     });
@@ -289,9 +289,55 @@ fn collate_count_guard_drops_mismatched_group_to_flat() {
         mesh_from(baked(&CANON, &p), meta(777)),
         mesh_from(baked(&canon_b, &p), meta(777)), // same rep, different counts
     ];
-    let collated = collate_instances(&meshes, 2);
+    let collated = collate_instances(&meshes, 2, [0.0, 0.0, 0.0]);
     assert_eq!(collated.templates.len(), 0, "count mismatch must NOT form a template");
     assert_eq!(collated.flat_indices.len(), 2, "both fall to flat");
+}
+
+#[test]
+fn collate_reduces_georeferenced_rotated_occurrence_to_post_rtc_frame() {
+    // Regression for the GLB-export collapse: a rotated occurrence at a
+    // georeferenced placement. Computing `rel = m_k · m_ref⁻¹` on the raw
+    // pre-RTC (absolute, ~1e6 m) transforms makes the relative translation reach
+    // `T_k − R_rel·T_ref ≈ 2× rtc` when the rotation flips the sign — the
+    // occurrence then lands at twice the georeference and collapses the f32 GLB.
+    // Passing the applied rtc reduces both transforms to the post-RTC frame so
+    // `rel` stays building-scale (consistent with the small baked origin).
+    let rtc = [1_000_000.0_f64, 2_000_000.0, 0.0];
+    let t_template = Matrix4::new_translation(&nalgebra::Vector3::new(rtc[0], rtc[1], rtc[2]));
+    // Same placement, rotated 180° about Z — the worst case (sign flip).
+    let t_occ = t_template * Matrix4::from_euler_angles(0.0, 0.0, std::f64::consts::PI);
+    let mk = |m: &Matrix4<f64>| {
+        mesh_from(
+            baked(&CANON, m),
+            InstanceMeta {
+                transform: mat_rm(m),
+                local_transform: None,
+                canonical_transform: None,
+                rep_identity: 99,
+                instanceable: true,
+            },
+        )
+    };
+    let meshes = vec![mk(&t_template), mk(&t_occ)];
+    // occurrence transform translation magnitude (row-major mat4 → [3],[7],[11]).
+    let occ_trans = |c: &Collated| -> f64 {
+        let occ = &c.templates[0].occurrences;
+        occ.iter()
+            .map(|o| o.transform[3].abs().max(o.transform[7].abs()).max(o.transform[11].abs()) as f64)
+            .fold(0.0, f64::max)
+    };
+
+    // Without the rtc reduction (legacy behaviour) the rotated occurrence blows
+    // up to ~2× the georef offset.
+    let raw = collate_instances(&meshes, 2, [0.0, 0.0, 0.0]);
+    assert_eq!(raw.templates.len(), 1, "the two congruent meshes instance");
+    assert!(occ_trans(&raw) > 1_000_000.0, "legacy: rotated occurrence reaches ~2× rtc");
+
+    // With the applied rtc the relative transform stays building-scale.
+    let fixed = collate_instances(&meshes, 2, rtc);
+    assert_eq!(fixed.templates.len(), 1, "still instances after the reduction");
+    assert!(occ_trans(&fixed) < 10.0, "fixed: rel translation is building-scale, got {}", occ_trans(&fixed));
 }
 
 #[test]
@@ -316,7 +362,7 @@ fn collate_and_encode_matches_mesh_path() {
     let meshes = vec![mk(&m0, 50), mk(&m1, 50), mk(&m2, 60)];
     let col = |i: usize| [i as f32 * 0.1, 0.2, 0.3, 1.0];
 
-    let collated = collate_instances(&meshes, 2);
+    let collated = collate_instances(&meshes, 2, [0.0, 0.0, 0.0]);
     let bytes_mesh = encode_instanced(&meshes, &collated, |i| i as u32, col);
 
     let refs: Vec<InstanceMeshRef> = meshes
@@ -329,7 +375,7 @@ fn collate_and_encode_matches_mesh_path() {
             r
         })
         .collect();
-    let bytes_ref = collate_and_encode(&refs, 2);
+    let bytes_ref = collate_and_encode(&refs, 2, [0.0, 0.0, 0.0]);
 
     assert_eq!(bytes_mesh, bytes_ref, "ref one-shot must match the Mesh path byte-for-byte");
     // And it must still decode + expand.
@@ -358,7 +404,7 @@ fn singletons_and_non_instanceable_go_flat() {
         mesh_from(baked(&CANON, &p), meta(1, true)), // singleton rep 1
         mesh_from(baked(&CANON, &p), meta(2, false)), // not instanceable
     ];
-    let collated = collate_instances(&meshes, 2);
+    let collated = collate_instances(&meshes, 2, [0.0, 0.0, 0.0]);
     // BOTH meshes must be represented. The instanceable singleton has no repeat
     // so it goes flat; the non-instanceable mesh must STILL be drawn (emitted as
     // a flat singleton), not dropped — dropping it silently loses geometry on

--- a/rust/geometry/src/instancing/wire.rs
+++ b/rust/geometry/src/instancing/wire.rs
@@ -197,8 +197,8 @@ pub fn encode_instanced(
 /// One-shot producer: collate the mesh views into templates + instances and
 /// encode them as an instanced shard. The caller (e.g. the native helper) builds
 /// `InstanceMeshRef`s borrowing its own mesh storage — no geometry is cloned.
-pub fn collate_and_encode(meshes: &[InstanceMeshRef], min_group: usize) -> Vec<u8> {
-    let collated = collate_refs(meshes, min_group);
+pub fn collate_and_encode(meshes: &[InstanceMeshRef], min_group: usize, rtc: [f64; 3]) -> Vec<u8> {
+    let collated = collate_refs(meshes, min_group, rtc);
     encode_refs(meshes, &collated)
 }
 

--- a/rust/processing/tests/instancing_real_geometry.rs
+++ b/rust/processing/tests/instancing_real_geometry.rs
@@ -62,7 +62,8 @@ fn assert_roundtrip(name: &str) {
         .collect();
 
     // min_group = 2: any repeat instances; singletons + non-instanceable stay flat.
-    let shard = collate_and_encode(&refs, 2);
+    // rtc [0,0,0]: this fixture is modelled at the origin (no georeferenced offset).
+    let shard = collate_and_encode(&refs, 2, [0.0, 0.0, 0.0]);
     let decoded = decode_instanced(&shard).expect("decode IFNS shard");
 
     // (a) NO geometry lost — exactly one occurrence per non-empty input mesh.

--- a/rust/wasm-bindings/src/api/gpu_meshes/batch.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/batch.rs
@@ -529,7 +529,11 @@ impl IfcAPI {
             })
             .collect();
         // min_group = 2: instance any repeat; singletons + non-instanceable flat.
-        ifc_lite_geometry::collate_and_encode(&refs, 2)
+        // Pass the applied RTC so per-occurrence transforms are reduced to the
+        // post-RTC frame (matches the small baked origins; without it a rotated
+        // occurrence lands at 2× the georef offset and collapses GLB exports).
+        let rtc = if needs_shift { [rtc_x, rtc_y, rtc_z] } else { [0.0, 0.0, 0.0] };
+        ifc_lite_geometry::collate_and_encode(&refs, 2, rtc)
     }
 
     /// Produce a batch ONCE and PARTITION it (the instanced-ONLY path): opaque
@@ -648,8 +652,11 @@ impl IfcAPI {
         // min_group == the routing threshold so collate_refs never re-flattens a group
         // that already passed the count gate; only its own try_inverse / shape-mismatch
         // safety net can still drop a (rare, degenerate) group to a singleton template.
+        // Reduce occurrence transforms to the post-RTC frame (see the other call
+        // site) so rotated occurrences don't fly out to 2× the georef offset.
+        let rtc = if needs_shift { [rtc_x, rtc_y, rtc_z] } else { [0.0, 0.0, 0.0] };
         let shard =
-            ifc_lite_geometry::collate_and_encode(&refs, INSTANCE_MIN_OCCURRENCES as usize);
+            ifc_lite_geometry::collate_and_encode(&refs, INSTANCE_MIN_OCCURRENCES as usize, rtc);
         PartitionedBatch {
             meshes: Some(mesh_collection),
             shard,


### PR DESCRIPTION
## What

Fixes the GLB **export** collapse on georeferenced models that have rotated instanced occurrences (e.g. `rebar.ifc`, EPSG:4326). The follow-on to #1446 (re-import) and #1443 (instancing): #1446 made re-import precision-safe and #1443 added the from-bytes instanced exporter, but the **GPU-instancing collator** still emitted occurrence transforms in the wrong frame, so the viewer's "Export GLB" (which folds GPU-instanced occurrences in) produced a collapsed file.

## Root cause

`collate_refs` built each occurrence's relative transform `rel = m_k · m_ref⁻¹` on the **pre-RTC** absolute placements in `InstanceMeta.transform` (documented "pre-RTC", at georeferenced magnitude), while the baked template `origin` is **post-RTC** and small. For an occurrence rotated relative to its template:

```
rel.translation = T_k − R_rel·T_ref
```

When `R_rel` flips an axis the two `~1e6 m` terms **add** instead of cancel, reaching **2× the georeference**. Applied to the small template origin, those occurrences fly out to twice the site offset. On a georeferenced model this dragged the GLB exporter's scene-center to `~6e6 m`, re-snapping every f32 vertex to a `~0.5 m` grid and collapsing the whole model.

Deterministically reproduced on `rebar.ifc`: **258 / 2521** occurrences (all rotated copies) landed at exactly 2× `wasmRtcOffset`.

## Fix

`collate_refs` now takes the applied RTC and reduces both composed transforms to the post-RTC frame before forming `rel`, so the georeferenced offset cancels exactly regardless of rotation and the relative translation stays at building scale (consistent with the small template origin the renderer applies it to).

- `processGeometryBatchInstanced` (the GPU shard path, consumed directly by the renderer) passes the **real RTC** (gated on `needs_shift`).
- The from-bytes glTF exporter (#1443) passes **`[0,0,0]`** — it already applies a `T(-rtc)·rel·T(rtc)` conjugation per occurrence in `occurrence_node_matrix`, so reducing here too would conjugate twice.
- Non-georeferenced models (RTC `[0,0,0]`) are byte-identical to before.

## Verification

- Geometry instancing suite **9/9**, incl. a new regression test (a 180°-rotated occurrence at a georeferenced placement stays building-scale with the RTC applied, blows up to ~2× RTC without it). Existing recomposition tests unchanged.
- End-to-end on `rebar.ifc` (rebuilt wasm, real pipeline): instanced occurrences now span **±15 m** (was 1.2e7 m); the viewer GLB export is **±9 m precise** (was ±6e6 m collapsed); export → re-import is geometrically intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GLB export issues where georeferenced models with rotated repeated elements could collapse or shift incorrectly.
  * Improved handling so repeated geometry stays at the correct scale and imports back with intact shape and placement.
  * Reduced the chance of incorrect transforms during instanced export workflows, especially for models with large coordinate offsets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->