### PR TITLE
fix(viewer): fold per-element origin into GLB-import camera-fit bounds

### DIFF
--- a/apps/viewer/src/utils/localParsingUtils.test.ts
+++ b/apps/viewer/src/utils/localParsingUtils.test.ts
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { MeshData } from '@ifc-lite/geometry';
+import { calculateMeshBounds } from './localParsingUtils.js';
+
+function mesh(origin?: [number, number, number]): MeshData {
+  return {
+    expressId: 1,
+    positions: new Float32Array([-15, -15, -15, 2, 1, 14]),
+    normals: new Float32Array(6),
+    indices: new Uint32Array([0, 1, 2]),
+    color: [1, 1, 1, 1],
+    ...(origin ? { origin } : {}),
+  };
+}
+
+describe('calculateMeshBounds — per-element origin folding', () => {
+  // Regression for the Codex P1 on #1446: a translated GLB re-imports as local
+  // positions + a (possibly georeferenced ~1e6 m) origin. The bounds feed
+  // coordinateInfo.shiftedBounds, which useGeometryStreaming uses as a camera-fit
+  // fallback — so they must be WORLD-space or the camera frames the scene origin.
+  it('folds a large georeferenced origin into world-space bounds', () => {
+    const { bounds } = calculateMeshBounds([mesh([501018.5, 53, -6083869.3])]);
+    // Local x∈[-15,2] → world x∈[~501003, ~501020]; local z∈[-15,14] → world z≈-6.08e6.
+    assert.ok(bounds.min.x > 500000 && bounds.max.x > 500000, 'x folded to world');
+    assert.ok(bounds.min.z < -6_000_000 && bounds.max.z < -6_000_000, 'z folded to world');
+  });
+
+  it('leaves non-local-frame meshes (no origin) at local bounds — no regression', () => {
+    const { bounds } = calculateMeshBounds([mesh(undefined)]);
+    assert.deepEqual(bounds.min, { x: -15, y: -15, z: -15 });
+    assert.deepEqual(bounds.max, { x: 2, y: 1, z: 14 });
+  });
+
+  it('still drops corrupted/unshifted local vertices beyond the 10 km guard', () => {
+    const m: MeshData = {
+      expressId: 2,
+      // first vertex is a corrupt 1e7 local stray; the others are sane.
+      positions: new Float32Array([1e7, 0, 0, 1, 0, 0, 0, 2, 0]),
+      normals: new Float32Array(9),
+      indices: new Uint32Array([0, 1, 2]),
+      color: [1, 1, 1, 1],
+      origin: [100, 0, 0],
+    };
+    const { bounds } = calculateMeshBounds([m]);
+    // The 1e7 stray is filtered; remaining locals [1,0,0]/[0,2,0] fold the +100 origin.
+    assert.equal(bounds.min.x, 100);
+    assert.equal(bounds.max.x, 101);
+    assert.equal(bounds.max.y, 2);
+  });
+});

--- a/apps/viewer/src/utils/localParsingUtils.ts
+++ b/apps/viewer/src/utils/localParsingUtils.ts
@@ -75,22 +75,35 @@ export function createEmptyBounds(): Bounds3D {
 export function updateBoundsFromPositions(
   bounds: Bounds3D,
   positions: Float32Array | number[],
-  maxCoord: number = MAX_VALID_COORD
+  maxCoord: number = MAX_VALID_COORD,
+  origin?: [number, number, number] | null,
 ): void {
+  // `origin` is the element's local-frame origin (world = origin + position).
+  // When present (per-element local frame, or a translated GLB import) the
+  // corruption filter still applies to the *local* coordinate — small by
+  // construction — but the bound is taken in WORLD space, so a legitimately
+  // large georeferenced offset (~1e6 m) doesn't fold the camera onto the scene
+  // origin (the `coordinateInfo.shiftedBounds` fallback in useGeometryStreaming
+  // uses these bounds when no robust box is selected). Absent origin →
+  // world == local, byte-identical to the legacy non-local-frame behaviour.
+  const ox = origin ? origin[0] : 0;
+  const oy = origin ? origin[1] : 0;
+  const oz = origin ? origin[2] : 0;
   for (let i = 0; i < positions.length; i += 3) {
     const x = positions[i];
     const y = positions[i + 1];
     const z = positions[i + 2];
-    // Filter out corrupted/unshifted vertices (> threshold from origin)
+    // Filter out corrupted/unshifted vertices (> threshold from the LOCAL origin).
     const isValid = Number.isFinite(x) && Number.isFinite(y) && Number.isFinite(z) &&
       Math.abs(x) < maxCoord && Math.abs(y) < maxCoord && Math.abs(z) < maxCoord;
     if (isValid) {
-      bounds.min.x = Math.min(bounds.min.x, x);
-      bounds.min.y = Math.min(bounds.min.y, y);
-      bounds.min.z = Math.min(bounds.min.z, z);
-      bounds.max.x = Math.max(bounds.max.x, x);
-      bounds.max.y = Math.max(bounds.max.y, y);
-      bounds.max.z = Math.max(bounds.max.z, z);
+      const wx = x + ox, wy = y + oy, wz = z + oz;
+      bounds.min.x = Math.min(bounds.min.x, wx);
+      bounds.min.y = Math.min(bounds.min.y, wy);
+      bounds.min.z = Math.min(bounds.min.z, wz);
+      bounds.max.x = Math.max(bounds.max.x, wx);
+      bounds.max.y = Math.max(bounds.max.y, wy);
+      bounds.max.z = Math.max(bounds.max.z, wz);
     }
   }
 }
@@ -107,7 +120,9 @@ export function calculateMeshBounds(meshes: MeshData[]): { bounds: Bounds3D; sta
   let totalTriangles = 0;
 
   for (const mesh of meshes) {
-    updateBoundsFromPositions(bounds, mesh.positions);
+    // Fold the per-element local-frame origin so the bounds are world-space
+    // (a translated GLB import keeps positions local + origin on the placement).
+    updateBoundsFromPositions(bounds, mesh.positions, MAX_VALID_COORD, mesh.origin ?? null);
     totalVertices += mesh.positions.length / 3;
     totalTriangles += mesh.indices.length / 3;
   }


### PR DESCRIPTION
## What

Follow-up to #1446 (merged) addressing the Codex **P1** review comment on that PR.

A translated GLB re-imports as small local positions + a (possibly georeferenced `~1e6 m`) `MeshData.origin` (#1446). `parseGlbViewerModel` derives `coordinateInfo` via `calculateMeshBounds`, which scanned `positions` only — so for a **compact georeferenced GLB** (root translation, no outlier tail) `coordinateInfo.shiftedBounds` centered near zero while the renderer draws the meshes at `origin + position`. `useGeometryStreaming` uses those bounds as a camera-fit fallback **before** `computeBounds` (which already folds origin), so the camera / section ranges framed the scene origin instead of the model.

## Fix

`updateBoundsFromPositions` now takes the per-mesh `origin`: the corruption filter still applies to the **local** coordinate (small by construction), but the emitted bound is world-space, so a legitimate georeferenced offset is kept rather than dropped by the 10 km guard. `calculateMeshBounds` passes `mesh.origin`. Absent origin → `world == local`, byte-identical to before (no-origin IFC/IFCX/native paths unchanged).

## Tests

New `localParsingUtils.test.ts` (3): folds a large georeferenced origin to world bounds; leaves non-local-frame meshes at local bounds (no regression); still drops corrupted/unshifted local strays beyond the 10 km guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)