### PR TITLE
fix(release): resilient changelog so GitHub enrichment can't block releases

### DIFF
--- a/.changeset/changelog-resilient.cjs
+++ b/.changeset/changelog-resilient.cjs
@@ -1,0 +1,50 @@
+// Resilient changelog generator.
+//
+// The release pipeline uses @changesets/changelog-github to enrich each changelog
+// entry with PR / author links. That enrichment makes a GitHub GraphQL request
+// (via @changesets/get-github-info). When that request fails — e.g. undici
+// "Invalid response body ... Premature close" under Node 24, or a transient GitHub
+// API hiccup — changesets THROWS and the entire `changeset version` step (and thus
+// every package release) is blocked. Changelog enrichment is optional and must
+// never be able to block a release.
+//
+// This wraps the GitHub generator and, on ANY error, falls back to the plain
+// default changelog (the changeset summary). Normal runs are unchanged (rich
+// changelog with PR links); only a failed enrichment degrades to a plain entry.
+//
+// Loaded by @changesets/apply-release-plan, which resolves `config.changelog[0]`
+// from the `.changeset/` directory, so config references this as
+// `"./changelog-resilient.cjs"`. The export shape (CJS `__esModule` + `default`)
+// mirrors @changesets/changelog-github so the loader's default-unwrap works.
+
+const github = require("@changesets/changelog-github").default;
+const fallback = require("@changesets/cli/changelog").default;
+
+async function getReleaseLine(changeset, type, options) {
+  try {
+    return await github.getReleaseLine(changeset, type, options);
+  } catch (err) {
+    console.error(
+      "[changelog] GitHub enrichment failed (" +
+        (err && err.message) +
+        "); falling back to the plain changeset summary.",
+    );
+    return fallback.getReleaseLine(changeset, type, options);
+  }
+}
+
+async function getDependencyReleaseLine(changesets, dependenciesUpdated, options) {
+  try {
+    return await github.getDependencyReleaseLine(changesets, dependenciesUpdated, options);
+  } catch (err) {
+    console.error(
+      "[changelog] GitHub dependency enrichment failed (" +
+        (err && err.message) +
+        "); falling back to a plain dependency list.",
+    );
+    return fallback.getDependencyReleaseLine(changesets, dependenciesUpdated, options);
+  }
+}
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = { getReleaseLine, getDependencyReleaseLine };

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,8 +1,10 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.2/schema.json",
   "changelog": [
-    "@changesets/changelog-github",
-    { "repo": "LTplus-AG/ifc-lite" }
+    "./changelog-resilient.cjs",
+    {
+      "repo": "LTplus-AG/ifc-lite"
+    }
   ],
   "commit": false,
   "fixed": [],


### PR DESCRIPTION
## Problem

The **Release** workflow has been failing since the recent merges, blocking all package publishing. The failure is in `changeset version`:

```
🦋 error Failed to parse data from GitHub
🦋 error Invalid response body while trying to fetch https://api.github.com/graphql: Premature close
   at @changesets/get-github-info/.../changesets-get-github-info.cjs.js:185
```

`@changesets/changelog-github` enriches each changelog entry by querying GitHub's GraphQL API for the introducing commit's PR/author. That fetch threw an undici `Premature close` (the release job runs **Node 24**, per the `Unsupported engine: wanted 22.x` warning), and the throw propagated out of `changeset version` → the whole release is blocked. The query/token/endpoint are all fine (verified by hand); the enrichment is just a flaky, **optional** step that should never be able to block a release.

This is **not** caused by #1446's code — it's the latest commit whose Release run is visible failing; the #1438 Release run failed identically and #1443's was cancelled by the next push.

## Fix

A small wrapper (`.changeset/changelog-resilient.cjs`) around `@changesets/changelog-github`: on **any** enrichment error it falls back to the plain default changelog (`@changesets/cli/changelog`, the changeset summary). Config points `changelog` at it.

- Normal runs: unchanged — rich changelog with PR/author links.
- Enrichment fails (Premature close, rate-limit, transient API): degrade to a plain entry and **the release proceeds**.

## Verification

- Wrapper unit-tested in isolation: normal path returns the enriched line; forced-failure path (no token) catches and returns a valid plain summary line; dependency line likewise.
- **End-to-end**: ran `changeset version` with enrichment forced to fail — it **completed (exit 0)** and wrote valid `CHANGELOG.md` entries (vs. the current hard failure).
- Module loads via changesets' resolver (resolved from `.changeset/`); export shape mirrors `@changesets/changelog-github` (`__esModule` + `default`).

No published-package source changes, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)