### PR TITLE
fix(ids): three IDS-validator false positives (#1441, #1442, #1444)

### DIFF
--- a/.changeset/ids-validator-false-positives.md
+++ b/.changeset/ids-validator-false-positives.md
@@ -1,0 +1,36 @@
+---
+"@ifc-lite/ids": patch
+---
+
+Fix three IDS-validator false positives that flagged valid IDS documents and (in
+one case) blocked model validation entirely.
+
+**Type-entity property applicability (#1441).** A standard occurrence pset is
+equally applicable to its companion type entity — IFC lets the same pset attach
+to either the occurrence or its type. The audit's applicability cross-check only
+matched occurrence subtypes, so an IDS that targets type entities (e.g.
+`IfcActuatorType`) with an element pset (e.g. `Pset_ManufacturerTypeInformation`,
+declared applicable only to `IfcElement`) was wrongly reported as
+`E_IFC_PROP_NOT_IN_PSET`. Because that is an `error`, it disabled the Run
+Validation button. The check now expands a pset's applicable occurrence classes
+with their companion type entities (via the authoritative `typeEntity` link, with
+a schema-validated `<Occurrence>Type` naming fallback for IFC2X3, whose rows omit
+the link).
+
+**Quantity sets in IFC4/IFC2X3 (#1442).** The upstream schema data only
+enumerates `Qto_*` quantity sets for IFC4X3, so IFC2X3/IFC4 carry no quantity-set
+rows at all and a standard set such as `Qto_SpaceBaseQuantities` tripped the
+reserved-prefix warning (`W_IFC_PSET_RESERVED_PREFIX`). The reserved-prefix check
+now only fires for a `Qto_*` name when the schema version actually has
+quantity-set coverage to check against — without that data we cannot tell an
+authoring typo from a real standard set, so suppressing the warning is the honest
+choice. `Pset_*` coverage is complete, so bogus `Pset_*` names still warn in every
+version, and bogus `Qto_*` names still warn in IFC4X3.
+
+**Empty requirements on a prohibited spec (#1444).** A prohibited specification
+(`<applicability maxOccurs="0">`) asserts that no entity matches and the IDS spec
+requires its requirements to be empty, yet the audit warned "specification has no
+<requirements>". The warning is now suppressed when the applicability declares an
+explicit numeric `maxOccurs` (prohibited `0` or a bounded count), where the
+cardinality itself is the assertion. Default-cardinality specs with no
+requirements still warn.

--- a/packages/ids/src/audit/audit.fixtures.test.ts
+++ b/packages/ids/src/audit/audit.fixtures.test.ts
@@ -160,7 +160,18 @@ const ISSUES: FixtureExpectation[] = [
     expectAny: ['E_RESTRICTION_EMPTY', 'E_XSD_REQUIRED_ATTR'],
   },
   { file: 'Issue 30 - should return error.ids', status: 'error' },
-  { file: 'Issue 39 - IfcTypeObjects allowed.ids', status: 'warning' },
+  // Issue 39 selects `IfcActuatorType` (a type entity with no occurrence
+  // form in IFC2X3) and requires `Pset_ManufacturerTypeInformation`, which
+  // the schema declares applicable to `IfcElement`. The pset attaches
+  // validly to the companion type, so post-#1441 this IDS is clean — no
+  // false `E_IFC_PROP_NOT_IN_PSET`. `expectNot` pins that specific code,
+  // since the `valid` status alone is the lowest rank and cannot catch a
+  // regression on its own.
+  {
+    file: 'Issue 39 - IfcTypeObjects allowed.ids',
+    status: 'valid',
+    expectNot: ['E_IFC_PROP_NOT_IN_PSET'],
+  },
   // Issue 41 ships a clean spec — the issue was about whether IDS-Audit
   // matched it, not invalid content. We accept it.
   { file: 'Issue 41 - Schema match.ids', status: 'valid' },

--- a/packages/ids/src/audit/audit.test.ts
+++ b/packages/ids/src/audit/audit.test.ts
@@ -183,6 +183,93 @@ describe('auditIDSDocument — IFC schema cross-checks', () => {
     expect(codes(r.issues)).toContain('E_IFC_PROP_NOT_IN_PSET');
   });
 
+  // #1441 — an occurrence pset (`Pset_ManufacturerTypeInformation` is only
+  // declared applicable to `IfcElement`) attaches just as validly to the
+  // corresponding *type* entity. A spec whose applicability is a type
+  // entity must not be flagged inapplicable; standard validators allow it.
+  it('accepts an occurrence pset on a companion type entity (IFC4)', async () => {
+    const xml = wrap(`<specification name="Manufacturer info on type" ifcVersion="IFC4">
+      <applicability>
+        <entity><name><simpleValue>IFCACTUATORTYPE</simpleValue></name></entity>
+      </applicability>
+      <requirements>
+        <property dataType="IFCLABEL">
+          <propertySet><simpleValue>Pset_ManufacturerTypeInformation</simpleValue></propertySet>
+          <baseName><simpleValue>ModelLabel</simpleValue></baseName>
+        </property>
+      </requirements>
+    </specification>`);
+    const r = await auditIDSDocument(xml);
+    expect(codes(r.issues)).not.toContain('E_IFC_PROP_NOT_IN_PSET');
+  });
+
+  // Same as above but via an enumeration of type entities — the exact
+  // shape that produced the reported "{IFCACTUATORTYPE, ...} in IFC4"
+  // false positive. None of the type entities should trip the check.
+  it('accepts an occurrence pset on an enumeration of type entities (IFC4)', async () => {
+    const xml = wrap(`<specification name="Manufacturer info on types" ifcVersion="IFC4">
+      <applicability>
+        <entity><name>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="IFCACTUATORTYPE"/>
+            <xs:enumeration value="IFCPUMPTYPE"/>
+            <xs:enumeration value="IFCWINDOWTYPE"/>
+          </xs:restriction>
+        </name></entity>
+      </applicability>
+      <requirements>
+        <property dataType="IFCLABEL">
+          <propertySet><simpleValue>Pset_ManufacturerTypeInformation</simpleValue></propertySet>
+          <baseName><simpleValue>Manufacturer</simpleValue></baseName>
+        </property>
+      </requirements>
+    </specification>`);
+    const r = await auditIDSDocument(xml);
+    expect(codes(r.issues)).not.toContain('E_IFC_PROP_NOT_IN_PSET');
+  });
+
+  // IFC2X3 entity rows omit the `typeEntity` link, so the fix relies on the
+  // schema-validated `<Occurrence>Type` naming fallback. `IfcActuator` has
+  // no occurrence form in IFC2X3 (upstream IDS-Audit-tool Issue 39), yet
+  // `IfcActuatorType` must still resolve `Pset_ManufacturerTypeInformation`
+  // (applicable to `IfcElement`) via the `IfcElement` → `IfcElementType`
+  // companion.
+  it('accepts an occurrence pset on a companion type entity (IFC2X3)', async () => {
+    const xml = wrap(`<specification name="Manufacturer info on type" ifcVersion="IFC2X3">
+      <applicability>
+        <entity><name><simpleValue>IFCACTUATORTYPE</simpleValue></name></entity>
+      </applicability>
+      <requirements>
+        <property dataType="IFCLABEL">
+          <propertySet><simpleValue>Pset_ManufacturerTypeInformation</simpleValue></propertySet>
+          <baseName><simpleValue>ModelLabel</simpleValue></baseName>
+        </property>
+      </requirements>
+    </specification>`);
+    const r = await auditIDSDocument(xml);
+    expect(codes(r.issues)).not.toContain('E_IFC_PROP_NOT_IN_PSET');
+  });
+
+  // The companion-type relaxation must stay tight: a pset that genuinely
+  // applies to a different element family is still flagged on an unrelated
+  // type entity. `Pset_WallCommon` (IfcWall) does not apply to
+  // `IfcActuatorType`.
+  it('still flags an unrelated pset on a type entity', async () => {
+    const xml = wrap(`<specification name="Wall pset on actuator type" ifcVersion="IFC4">
+      <applicability>
+        <entity><name><simpleValue>IFCACTUATORTYPE</simpleValue></name></entity>
+      </applicability>
+      <requirements>
+        <property>
+          <propertySet><simpleValue>Pset_WallCommon</simpleValue></propertySet>
+          <baseName><simpleValue>IsExternal</simpleValue></baseName>
+        </property>
+      </requirements>
+    </specification>`);
+    const r = await auditIDSDocument(xml);
+    expect(codes(r.issues)).toContain('E_IFC_PROP_NOT_IN_PSET');
+  });
+
   // #1062 — standard enumerated properties (PEnum_*) serialize as
   // IfcLabel, so IFCLABEL is the canonical IDS dataType for them and
   // must not be flagged (mirrors upstream IdsLib's HasDataTypes).
@@ -266,6 +353,129 @@ describe('auditIDSDocument — IFC schema cross-checks', () => {
     </specification>`);
     const r = await auditIDSDocument(xml);
     expect(codes(r.issues)).not.toContain('W_IFC_PSET_RESERVED_PREFIX');
+  });
+
+  // #1442 — `Qto_SpaceBaseQuantities` is a standard IFC4 quantity set, but
+  // the upstream schema data only enumerates `Qto_*` sets under IFC4X3, so
+  // IFC4 has no quantity-set rows at all. Without that data we cannot assert
+  // the name is unknown, so the reserved-prefix warning must be suppressed
+  // rather than emitted as a false positive.
+  it('does not warn on a standard IFC4 quantity set (Qto_SpaceBaseQuantities)', async () => {
+    const xml = wrap(`<specification name="Space quantities" ifcVersion="IFC4">
+      <applicability>
+        <entity><name><simpleValue>IFCSPACE</simpleValue></name></entity>
+      </applicability>
+      <requirements>
+        <property dataType="IFCAREAMEASURE">
+          <propertySet><simpleValue>Qto_SpaceBaseQuantities</simpleValue></propertySet>
+          <baseName><simpleValue>NetFloorArea</simpleValue></baseName>
+        </property>
+      </requirements>
+    </specification>`);
+    const r = await auditIDSDocument(xml);
+    expect(codes(r.issues)).not.toContain('W_IFC_PSET_RESERVED_PREFIX');
+    expect(codes(r.issues)).not.toContain('E_IFC_PROP_NOT_IN_PSET');
+  });
+
+  // The suppression is scoped to versions that lack quantity-set coverage. In
+  // IFC4X3 (full `Qto_*` data) a genuinely-unknown quantity set still warns —
+  // we have not blanket-disabled the reserved-prefix check.
+  it('still warns on an unknown Qto_* set in IFC4X3 (full Qto coverage)', async () => {
+    const xml = wrap(`<specification name="Bogus qto" ifcVersion="IFC4X3">
+      <applicability>
+        <entity><name><simpleValue>IFCSPACE</simpleValue></name></entity>
+      </applicability>
+      <requirements>
+        <property>
+          <propertySet><simpleValue>Qto_NotPublishedByBSI</simpleValue></propertySet>
+          <baseName><simpleValue>SomeQuantity</simpleValue></baseName>
+        </property>
+      </requirements>
+    </specification>`);
+    const r = await auditIDSDocument(xml);
+    expect(codes(r.issues)).toContain('W_IFC_PSET_RESERVED_PREFIX');
+  });
+
+  // A real IFC4X3 quantity set is recognised (not flagged) — confirms the
+  // IFC4X3 path still resolves standard sets.
+  it('does not warn on a real IFC4X3 quantity set', async () => {
+    const xml = wrap(`<specification name="Space quantities" ifcVersion="IFC4X3">
+      <applicability>
+        <entity><name><simpleValue>IFCSPACE</simpleValue></name></entity>
+      </applicability>
+      <requirements>
+        <property>
+          <propertySet><simpleValue>Qto_SpaceBaseQuantities</simpleValue></propertySet>
+          <baseName><simpleValue>NetFloorArea</simpleValue></baseName>
+        </property>
+      </requirements>
+    </specification>`);
+    const r = await auditIDSDocument(xml);
+    expect(codes(r.issues)).not.toContain('W_IFC_PSET_RESERVED_PREFIX');
+  });
+
+  // A bogus `Pset_*` name still warns in IFC4 — Pset coverage is complete, so
+  // the suppression is narrowly limited to quantity sets.
+  it('still warns on an unknown Pset_* set in IFC4 (full Pset coverage)', async () => {
+    const xml = wrap(`<specification name="Bogus pset" ifcVersion="IFC4">
+      <applicability>
+        <entity><name><simpleValue>IFCWALL</simpleValue></name></entity>
+      </applicability>
+      <requirements>
+        <property>
+          <propertySet><simpleValue>Pset_TotallyMadeUp</simpleValue></propertySet>
+          <baseName><simpleValue>SomeProperty</simpleValue></baseName>
+        </property>
+      </requirements>
+    </specification>`);
+    const r = await auditIDSDocument(xml);
+    expect(codes(r.issues)).toContain('W_IFC_PSET_RESERVED_PREFIX');
+  });
+
+  // #1444 — a prohibited specification (`<applicability maxOccurs="0">`)
+  // asserts that no entity matches; the IDS spec requires its requirements
+  // to be empty. The "no requirements" warning must not fire for it.
+  it('does not warn about empty requirements on a prohibited spec (#1444)', async () => {
+    const xml = wrap(`<specification name="COBie.Space.RoomTag" ifcVersion="IFC4">
+      <applicability minOccurs="0" maxOccurs="0">
+        <entity><name><simpleValue>IFCSPACE</simpleValue></name></entity>
+        <attribute>
+          <name><simpleValue>Description</simpleValue></name>
+          <value>
+            <xs:restriction base="xs:string">
+              <xs:enumeration value="n/a" />
+              <xs:enumeration value="TBC" />
+            </xs:restriction>
+          </value>
+        </attribute>
+      </applicability>
+      <requirements />
+    </specification>`);
+    const r = await auditIDSDocument(xml);
+    const noReq = r.issues.find(
+      (i) =>
+        i.code === 'E_XSD_STRUCTURE' &&
+        i.message.includes('no <requirements>')
+    );
+    expect(noReq).toBeUndefined();
+  });
+
+  // The warning still fires for a default-cardinality spec that genuinely
+  // does nothing (no requirements, no explicit maxOccurs).
+  it('still warns about empty requirements on a default-cardinality spec', async () => {
+    const xml = wrap(`<specification name="Does nothing" ifcVersion="IFC4">
+      <applicability>
+        <entity><name><simpleValue>IFCSPACE</simpleValue></name></entity>
+      </applicability>
+      <requirements />
+    </specification>`);
+    const r = await auditIDSDocument(xml);
+    const noReq = r.issues.find(
+      (i) =>
+        i.code === 'E_XSD_STRUCTURE' &&
+        i.message.includes('no <requirements>')
+    );
+    expect(noReq).toBeDefined();
   });
 
   it('flags a partOf relation that is not valid for the IFC version', async () => {

--- a/packages/ids/src/audit/ifc-schema/index.ts
+++ b/packages/ids/src/audit/ifc-schema/index.ts
@@ -24,6 +24,7 @@ import {
   findPropertySet,
   getInheritanceChain,
   getPartOfRelations,
+  getPropertySets,
   isEntitySubtypeOf,
   RESERVED_PSET_PREFIXES,
   type IfcEntityInfo,
@@ -386,7 +387,7 @@ async function auditPropertyFacet(
   // buildingSMART-published sets. Mirrors `IdsProperty.cs` upstream.
   const isReserved = RESERVED_PSET_PREFIXES.some((p) => psetName.startsWith(p));
   if (!pset) {
-    if (isReserved) {
+    if (isReserved && (await canVerifyReservedSet(version, psetName))) {
       issues.push({
         severity: 'warning',
         code: 'W_IFC_PSET_RESERVED_PREFIX',
@@ -411,9 +412,22 @@ async function auditPropertyFacet(
       version
     );
     if (candidates.length > 0) {
+      // Type/occurrence duality: a pset declared applicable to an
+      // occurrence class (e.g. `IfcElement`) is equally applicable to that
+      // class's companion *type* entity (`IfcElementType`) — IFC lets the
+      // same pset attach to either the occurrence or its type, and a type
+      // pset propagates to its occurrences. The standard validators honour
+      // this. Without it, an IDS that targets type entities (e.g.
+      // `IfcActuatorType`) with a standard element pset (e.g.
+      // `Pset_ManufacturerTypeInformation`, whose `applicableEntities` is
+      // just `IfcElement`) is wrongly flagged as inapplicable. (#1441)
+      const applicable = await expandWithCompanionTypes(
+        version,
+        pset.applicableEntities
+      );
       const anyMatches = (
         await Promise.all(
-          candidates.map((c) => psetApplies(version, c, pset.applicableEntities))
+          candidates.map((c) => psetApplies(version, c, applicable))
         )
       ).some(Boolean);
       if (!anyMatches) {
@@ -613,6 +627,77 @@ async function psetApplies(
     if (await isEntitySubtypeOf(version, entityName, candidate)) return true;
   }
   return false;
+}
+
+/**
+ * Expand a pset's `applicableEntities` (always occurrence classes in the
+ * buildingSMART data) with each class's companion *type* entity, so the
+ * applicability check accepts an IDS that targets type entities.
+ *
+ * Standard psets list only the occurrence class — e.g.
+ * `Pset_ManufacturerTypeInformation` → `["IfcElement"]` — yet IFC permits
+ * attaching the same pset to the corresponding type (`IfcElementType` and
+ * its subtypes), and many IDS specs do exactly that. Classes without a
+ * type twin (e.g. `IfcSite`, `IfcMaterial`) contribute nothing. (#1441)
+ *
+ * IFC4+ entity rows carry an authoritative `typeEntity` link. IFC2X3 rows
+ * omit it, so we fall back to the `<Occurrence>Type` naming convention —
+ * but only when that type entity actually exists in the schema version,
+ * so we never invent a non-existent class.
+ */
+async function expandWithCompanionTypes(
+  version: IfcSchemaVersion,
+  applicable: readonly string[]
+): Promise<string[]> {
+  const expanded = new Set<string>(applicable);
+  for (const name of applicable) {
+    const entity = await findEntity(version, name);
+    if (!entity) continue;
+    if (entity.typeEntity) {
+      expanded.add(entity.typeEntity);
+      continue;
+    }
+    const namedType = `${name}Type`;
+    if (await findEntity(version, namedType)) expanded.add(namedType);
+  }
+  return [...expanded];
+}
+
+/** Memoised "does this schema version have any `Qto_*` set?" lookup. */
+const quantitySetCoverage = new Map<IfcSchemaVersion, boolean>();
+
+async function versionHasQuantitySets(
+  version: IfcSchemaVersion
+): Promise<boolean> {
+  const cached = quantitySetCoverage.get(version);
+  if (cached !== undefined) return cached;
+  const sets = await getPropertySets(version);
+  const has = sets.some((p) => p.name.startsWith('Qto_'));
+  quantitySetCoverage.set(version, has);
+  return has;
+}
+
+/**
+ * Whether the reserved-prefix warning can be trusted for `name` in this
+ * version — i.e. whether our schema tables are complete enough to assert
+ * "this reserved name is not a known standard set".
+ *
+ * `Pset_*` coverage is complete across all versions. Quantity sets (`Qto_*`)
+ * are not: the upstream IDS-Audit-tool data only enumerates them for IFC4X3,
+ * so IFC2X3/IFC4 carry no `Qto_*` rows at all. Without that data we cannot
+ * tell an authoring typo from a real standard set we simply do not have
+ * (e.g. `Qto_SpaceBaseQuantities`, which is standard in IFC4), so suppressing
+ * the warning is the honest choice rather than emitting a false positive.
+ * Verifying `Qto_*` against an incomplete table caused #1442. We deliberately
+ * do not backfill a synthesised per-version quantity-set list, since entity
+ * existence alone cannot prove a set belongs to an earlier schema version.
+ */
+async function canVerifyReservedSet(
+  version: IfcSchemaVersion,
+  name: string
+): Promise<boolean> {
+  if (!name.startsWith('Qto_')) return true;
+  return versionHasQuantitySets(version);
 }
 
 /**

--- a/packages/ids/src/audit/xsd/index.ts
+++ b/packages/ids/src/audit/xsd/index.ts
@@ -168,9 +168,18 @@ function auditSpecification(
   spec.applicability.facets.forEach((facet, fi) => {
     auditFacet(facet, `${path}.applicability.facets[${fi}]`, issues);
   });
-  if (spec.requirements.length === 0) {
+  if (spec.requirements.length === 0 && typeof spec.maxOccurs !== 'number') {
     // The XSD allows zero requirements but conventional authoring tools
     // surface this as a warning — a spec with no requirements does nothing.
+    //
+    // Exception: when the applicability declares an explicit numeric
+    // `maxOccurs`, the cardinality itself IS the assertion, so empty
+    // requirements are intentional and correct — not a no-op. The common
+    // case is a *prohibited* spec (`maxOccurs="0"`): it passes only when
+    // no entity matches the applicability, and the IDS spec forbids
+    // attaching requirements to it at all (a bounded `maxOccurs="N"` is a
+    // count assertion in the same vein). Flagging those is a false
+    // positive. (#1444)
     issues.push({
       severity: 'warning',
       code: 'E_XSD_STRUCTURE',


### PR DESCRIPTION
Three IDS-validator false positives reported by @VitalijTetervov, all in the IDS audit (the static lint that runs before model validation). #1441 was an `error`, so it disabled the **Run Validation** button entirely; #1442 and #1444 were noisy `warning`s on valid documents.

## #1441 — type-entity property applicability
A standard occurrence pset is equally applicable to its companion type entity — IFC lets the same pset attach to either the occurrence or its type, and a type pset propagates to its occurrences. The applicability cross-check only matched occurrence subtypes, so an IDS that targets type entities (e.g. `IfcActuatorType`) with an element pset (e.g. `Pset_ManufacturerTypeInformation`, declared applicable only to `IfcElement`) was wrongly reported as `E_IFC_PROP_NOT_IN_PSET` → Run Validation blocked.

Fix: expand a pset's applicable occurrence classes with their companion type entities before the subtype check, using the authoritative `typeEntity` link (IFC4+), with a schema-validated `<Occurrence>Type` naming fallback for IFC2X3 (whose rows omit the link). This matches upstream's own "IfcTypeObjects allowed" fixture (IDS-Audit-tool Issue 39).

## #1442 — quantity sets not recognised in IFC4
The vendored upstream schema data (`SchemaInfo.Properties.g.cs`) enumerates `Qto_*` quantity sets **only** under its IFC4X3 block — IFC2X3/IFC4 carry no quantity-set rows at all — so `Qto_SpaceBaseQuantities` and friends were "unknown" and tripped `W_IFC_PSET_RESERVED_PREFIX`.

Fix (audit-level, no generated-data changes): the reserved-prefix warning now only fires for a `Qto_*` name when the schema version actually has quantity-set coverage to check against. Without that data we can't distinguish an authoring typo from a real standard set, so suppressing is the honest choice. `Pset_*` coverage is complete, so bogus `Pset_*` names still warn in every version, and bogus `Qto_*` names still warn in IFC4X3.

> An earlier revision backfilled quantity sets into IFC4/IFC2X3 from the IFC4X3 definitions, filtered by applicable-entity existence. Per reviewer feedback (entity existence can't prove a set belongs to an earlier schema version — an IFC4X3 set applicable to `IfcProduct` would leak into IFC4), that approach was dropped in favour of the coverage-aware suppression above. No data is fabricated.

## #1444 — empty requirements on a prohibited spec
A prohibited specification (`<applicability maxOccurs="0">`) asserts that no entity matches, and the IDS spec **requires** its requirements to be empty — yet the audit warned "specification has no `<requirements>`". Fix: suppress that warning when the applicability declares an explicit numeric `maxOccurs` (prohibited `0` or a bounded count), where the cardinality itself is the assertion. Default-cardinality specs with no requirements still warn.

## Tests
- New unit tests for each case (type applicability for IFC4 simpleValue + enumeration + IFC2X3; `Qto_SpaceBaseQuantities` suppression in IFC4 + still-warns in IFC4X3 + real IFC4X3 set recognised + bogus `Pset_*` still warns; prohibited-spec empty-requirements + default-cardinality still warns).
- Tightened the upstream `Issue 39 - IfcTypeObjects allowed.ids` fixture from `warning` to `valid` (it is now genuinely clean).
- `@ifc-lite/ids` 280 tests pass; package typechecks clean. No `@ifc-lite/data` changes.

Changeset included (patch bump for `@ifc-lite/ids`).

Closes #1441
Closes #1442
Closes #1444

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced false validation warnings for valid IDS documents.
  * Improved handling of type-related applicability so valid type-focused checks are no longer flagged incorrectly.
  * Suppressed some reserved-name warnings for quantity sets when the schema can’t reliably confirm coverage.
  * Avoided “missing requirements” warnings when a specification clearly sets an explicit maximum cardinality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->