### PR TITLE
fix(clash): suppress false positives + show the real contact interface (#1362, #1402)

### DIFF
--- a/.changeset/clash-contact-geometry.md
+++ b/.changeset/clash-contact-geometry.md
@@ -1,0 +1,6 @@
+---
+"@ifc-lite/clash": minor
+"@ifc-lite/renderer": patch
+---
+
+Show the focused clash's REAL contact interface instead of an AABB box (#1402). New `@ifc-lite/clash/contact`: `contactClusters(meshA, meshB)` returns the contact patches — the shared-face polygon for coplanar/flush overlaps (surface), the intersection line for crossings (line), or a point — classified by area/length, via a Moller triangle-triangle test plus shared-face clustering (coplanar pairs Sutherland-Hodgman clipped on their common plane and unioned into a boundary polygon; cross pairs unioned along the intersection line). Computed on demand for the single focused pair. The renderer gains `setClashContactLines()` to draw the contact polygon outlines / intersection lines; the viewer prefers this over the box.

--- a/.changeset/clash-false-positive-fix.md
+++ b/.changeset/clash-false-positive-fix.md
@@ -2,4 +2,4 @@
 "@ifc-lite/clash": patch
 ---
 
-Fix clash false positives and overstated contact regions (#1362, #1402). The coplanar-overlap fallback now confirms a real shared volume (point-in-solid probe) before reporting a hard clash, so skewed or abutting members that only touch at a face are no longer flagged. Hard verdicts now report a tight contact AABB (clamped to the element overlap) instead of the full whole-element AABB overlap. The TS reference engine and the Rust/WASM kernel stay byte-compatible.
+Fix clash false positives and overstated contact regions (#1362, #1402). The coplanar-overlap fallback now confirms a real shared volume (point-in-solid probe) before reporting a hard clash, so skewed or abutting members that only touch at a face are no longer flagged. Hard verdicts now report a tight contact AABB (clamped to the element overlap) instead of the full whole-element AABB overlap. The focused-clash region box draws this tight contact region (on by default, marking the penetration; toggle in clash settings), replacing the former whole-element box. The TS reference engine and the Rust/WASM kernel stay byte-compatible.

--- a/.changeset/clash-false-positive-fix.md
+++ b/.changeset/clash-false-positive-fix.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/clash": patch
+---
+
+Fix clash false positives and overstated contact regions (#1362, #1402). The coplanar-overlap fallback now confirms a real shared volume (point-in-solid probe) before reporting a hard clash, so skewed or abutting members that only touch at a face are no longer flagged. Hard verdicts now report a tight contact AABB (clamped to the element overlap) instead of the full whole-element AABB overlap. The TS reference engine and the Rust/WASM kernel stay byte-compatible.

--- a/apps/viewer/src/components/viewer/ClashSettingsDialog.tsx
+++ b/apps/viewer/src/components/viewer/ClashSettingsDialog.tsx
@@ -211,7 +211,7 @@ export function ClashSettingsDialog({ trigger }: ClashSettingsDialogProps) {
               <Switch checked={reportTouch} onCheckedChange={setReportTouch} />
             </SettingRow>
 
-            <SettingRow label="Show clash region box" hint="Draw a wireframe box around the focused clash's contact region. Off by default so it does not hide the actual penetration.">
+            <SettingRow label="Show clash region box" hint="Draw a tight wireframe box around the focused clash's contact region to mark the penetration. On by default; turn off to hide it.">
               <Switch checked={showRegionBox} onCheckedChange={setShowRegionBox} />
             </SettingRow>
 

--- a/apps/viewer/src/components/viewer/ClashSettingsDialog.tsx
+++ b/apps/viewer/src/components/viewer/ClashSettingsDialog.tsx
@@ -61,6 +61,7 @@ export function ClashSettingsDialog({ trigger }: ClashSettingsDialogProps) {
   const clearance = useViewerStore((s) => s.clashClearance);
   const clusterEpsilon = useViewerStore((s) => s.clashClusterEpsilon);
   const reportTouch = useViewerStore((s) => s.clashReportTouch);
+  const showRegionBox = useViewerStore((s) => s.showClashRegionBox);
   const groupBy = useViewerStore((s) => s.clashGroupBy);
   const presets = useViewerStore((s) => s.clashPresets);
   const classes = useViewerStore((s) => s.discoveredLensData?.classes ?? null);
@@ -70,6 +71,7 @@ export function ClashSettingsDialog({ trigger }: ClashSettingsDialogProps) {
   const setClearance = useViewerStore((s) => s.setClashClearance);
   const setClusterEpsilon = useViewerStore((s) => s.setClashClusterEpsilon);
   const setReportTouch = useViewerStore((s) => s.setClashReportTouch);
+  const setShowRegionBox = useViewerStore((s) => s.setShowClashRegionBox);
   const setGroupBy = useViewerStore((s) => s.setClashGroupBy);
   const resetSettings = useViewerStore((s) => s.resetClashSettings);
   const createPreset = useViewerStore((s) => s.createClashPreset);
@@ -207,6 +209,10 @@ export function ClashSettingsDialog({ trigger }: ClashSettingsDialogProps) {
 
             <SettingRow label="Report grazing contacts" hint="Include touch-classified results (surfaces that just graze) in detection.">
               <Switch checked={reportTouch} onCheckedChange={setReportTouch} />
+            </SettingRow>
+
+            <SettingRow label="Show clash region box" hint="Draw a wireframe box around the focused clash's contact region. Off by default so it does not hide the actual penetration.">
+              <Switch checked={showRegionBox} onCheckedChange={setShowRegionBox} />
             </SettingRow>
 
             <SettingRow label="Default grouping" hint="How the results list is organized in the panel.">

--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -491,9 +491,10 @@ export function Viewport({
   // Clash overlap-region wireframe box (#1277): push the focused clash's bounds
   // to the renderer as a distinct-colour box. Cleared (null) on teardown.
   const clashOverlapBox = useViewerStore((s) => s.clashOverlapBox);
-  // Off by default (#1402): the region box obscured the penetration and, drawn on
-  // the section-exempt overlay, looked uncut by the section plane. Only push it to
-  // the renderer when the user opts in via the clash settings.
+  // On by default (#1402): the box now uses the tight contact bounds (#1362 Bug B),
+  // so it marks the actual penetration instead of the old whole-element AABB that
+  // obscured everything. Pushed to the renderer whenever a clash is focused; the
+  // clash settings toggle hides it.
   const showClashRegionBox = useViewerStore((s) => s.showClashRegionBox);
   useEffect(() => {
     const renderer = rendererRef.current;

--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -503,7 +503,10 @@ export function Viewport({
         ? { ...clashOverlapBox, color: CLASH_COLOR_OVERLAP }
         : null,
     );
-  }, [clashOverlapBox, showClashRegionBox]);
+    // isInitialized: if a box is already set before the renderer mounts, this
+    // effect bails early; depend on it so the box is (re)sent once the renderer
+    // is ready.
+  }, [clashOverlapBox, showClashRegionBox, isInitialized]);
   const activeToolRef = useRef<string>(activeTool);
   const pendingMeasurePointRef = useLatestRef(pendingMeasurePoint);
   const activeMeasurementRef = useLatestRef(activeMeasurement);

--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -491,13 +491,19 @@ export function Viewport({
   // Clash overlap-region wireframe box (#1277): push the focused clash's bounds
   // to the renderer as a distinct-colour box. Cleared (null) on teardown.
   const clashOverlapBox = useViewerStore((s) => s.clashOverlapBox);
+  // Off by default (#1402): the region box obscured the penetration and, drawn on
+  // the section-exempt overlay, looked uncut by the section plane. Only push it to
+  // the renderer when the user opts in via the clash settings.
+  const showClashRegionBox = useViewerStore((s) => s.showClashRegionBox);
   useEffect(() => {
     const renderer = rendererRef.current;
     if (!renderer) return;
     renderer.setClashOverlapBox(
-      clashOverlapBox ? { ...clashOverlapBox, color: CLASH_COLOR_OVERLAP } : null,
+      showClashRegionBox && clashOverlapBox
+        ? { ...clashOverlapBox, color: CLASH_COLOR_OVERLAP }
+        : null,
     );
-  }, [clashOverlapBox]);
+  }, [clashOverlapBox, showClashRegionBox]);
   const activeToolRef = useRef<string>(activeTool);
   const pendingMeasurePointRef = useLatestRef(pendingMeasurePoint);
   const activeMeasurementRef = useLatestRef(activeMeasurement);

--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -488,26 +488,30 @@ export function Viewport({
   // animation loop reads the latest without re-subscribing.
   const clashHighlightColors = useViewerStore((s) => s.clashHighlightColors);
   const clashHighlightColorsRef = useLatestRef(clashHighlightColors);
-  // Clash overlap-region wireframe box (#1277): push the focused clash's bounds
-  // to the renderer as a distinct-colour box. Cleared (null) on teardown.
+  // Focused-clash indicator (#1277/#1402): prefer the real CONTACT geometry
+  // (shared-face polygon outlines / intersection lines) when available, and fall
+  // back to the AABB box otherwise. Both draw on the same overlay line buffer, so
+  // a single effect drives exactly one of them (no buffer race). Cleared on
+  // teardown. On by default; the clash settings toggle hides it.
   const clashOverlapBox = useViewerStore((s) => s.clashOverlapBox);
-  // On by default (#1402): the box now uses the tight contact bounds (#1362 Bug B),
-  // so it marks the actual penetration instead of the old whole-element AABB that
-  // obscured everything. Pushed to the renderer whenever a clash is focused; the
-  // clash settings toggle hides it.
+  const clashContactLines = useViewerStore((s) => s.clashContactLines);
   const showClashRegionBox = useViewerStore((s) => s.showClashRegionBox);
   useEffect(() => {
     const renderer = rendererRef.current;
     if (!renderer) return;
-    renderer.setClashOverlapBox(
-      showClashRegionBox && clashOverlapBox
-        ? { ...clashOverlapBox, color: CLASH_COLOR_OVERLAP }
-        : null,
-    );
-    // isInitialized: if a box is already set before the renderer mounts, this
-    // effect bails early; depend on it so the box is (re)sent once the renderer
-    // is ready.
-  }, [clashOverlapBox, showClashRegionBox, isInitialized]);
+    if (showClashRegionBox && clashContactLines && clashContactLines.vertices.length > 0) {
+      renderer.setClashContactLines({
+        vertices: new Float32Array(clashContactLines.vertices),
+        color: clashContactLines.color,
+      });
+    } else if (showClashRegionBox && clashOverlapBox) {
+      renderer.setClashOverlapBox({ ...clashOverlapBox, color: CLASH_COLOR_OVERLAP });
+    } else {
+      renderer.setClashContactLines(null);
+    }
+    // isInitialized: if a clash is focused before the renderer mounts, this effect
+    // bails early; depend on it so the indicator is (re)sent once it is ready.
+  }, [clashOverlapBox, clashContactLines, showClashRegionBox, isInitialized]);
   const activeToolRef = useRef<string>(activeTool);
   const pendingMeasurePointRef = useLatestRef(pendingMeasurePoint);
   const activeMeasurementRef = useLatestRef(activeMeasurement);

--- a/apps/viewer/src/hooks/useClash.ts
+++ b/apps/viewer/src/hooks/useClash.ts
@@ -10,7 +10,7 @@
  * renderer's selection channel and the federation registry.
  */
 
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import { useViewerStore } from '@/store';
 import {
   createClashEngine,
@@ -28,15 +28,49 @@ import {
 } from '@ifc-lite/clash';
 import { elementsFromStep } from '@ifc-lite/clash/step';
 import { createBCFFromClashResult } from '@ifc-lite/clash/bcf';
+import { contactClusters, type SharedFaceCluster, type Vec3 } from '@ifc-lite/clash/contact';
 import { writeBCF } from '@ifc-lite/bcf';
 import { getGlobalRenderer } from '@/hooks/useBCF';
-import { buildClashPairColors, CLASH_COLOR_A } from '@/lib/clash/clash-colors';
+import { buildClashPairColors, CLASH_COLOR_A, CLASH_COLOR_OVERLAP } from '@/lib/clash/clash-colors';
 import { posthog } from '@/lib/analytics';
 import { downloadBlob } from '@/lib/export/download';
 
 interface SelectionRef {
   modelId: string;
   expressId: number;
+}
+
+/**
+ * Flatten contact clusters into a world-frame line-list (x,y,z per endpoint, two
+ * per segment) for the focused-clash overlay. Prefer the shared-FACE polygon
+ * outlines when any surface contact exists (flush/coincident members); otherwise
+ * the intersection LINES (angled crossings); otherwise small crosses at POINT
+ * contacts. This is the real contact interface, not an AABB box (#1402).
+ */
+function contactLineList(clusters: readonly SharedFaceCluster[]): number[] {
+  const surfaces = clusters.filter((c) => c.kind === 'surface' && c.boundary.length >= 3);
+  const lines = clusters.filter((c) => c.kind === 'line' && c.boundary.length >= 2);
+  const points = clusters.filter((c) => c.kind === 'point');
+  const out: number[] = [];
+  const seg = (p: Vec3, q: Vec3) => out.push(p[0], p[1], p[2], q[0], q[1], q[2]);
+  // Shared-face polygon outlines (the contact patches) and intersection lines
+  // (penetration boundary) together describe the contact; render both so a thin
+  // patch still reads. Points only matter when there is no surface or line.
+  for (const c of surfaces) {
+    const b = c.boundary;
+    for (let i = 0; i < b.length; i += 1) seg(b[i], b[(i + 1) % b.length]);
+  }
+  for (const c of lines) seg(c.boundary[0], c.boundary[1]);
+  if (surfaces.length === 0 && lines.length === 0) {
+    const s = 0.05;
+    for (const c of points) {
+      const [x, y, z] = c.centroid;
+      seg([x - s, y, z], [x + s, y, z]);
+      seg([x, y - s, z], [x, y + s, z]);
+      seg([x, y, z - s], [x, y, z + s]);
+    }
+  }
+  return out;
 }
 
 /**
@@ -114,6 +148,10 @@ export function useClash() {
   const setPanelVisible = useViewerStore((s) => s.setClashPanelVisible);
   const clear = useViewerStore((s) => s.clearClash);
 
+  // Geometry of the last-gathered clash elements, keyed by federated ref, so a
+  // focused clash can compute its real contact interface for that one pair.
+  const elementsByRef = useRef(new Map<number, ClashElement>());
+
   /** Build clash elements + merged exclusions from every loaded model. */
   const gatherElements = useCallback((): { elements: ClashElement[]; exclusions: ExclusionSet } => {
     const state = useViewerStore.getState();
@@ -147,6 +185,8 @@ export function useClash() {
           state.setClashError('No model geometry is loaded. Load an IFC model first.');
           return;
         }
+        // Keep per-ref geometry so focusClash can build the contact interface.
+        elementsByRef.current = new Map(elements.map((e) => [e.ref, e]));
         const engine = createClashEngine({ backend: 'ts' });
         const res = await engine.run(elements, rules, {
           exclusions,
@@ -307,9 +347,33 @@ export function useClash() {
       const colors = buildClashPairColors(a ? clash.a.ref : null, b ? clash.b.ref : null);
       state.setClashHighlightColors(colors); // record for framing + teardown
       state.setPendingColorUpdates(colors);  // actually paint A amber / B cyan
-      // Mark the overlap REGION (clash.bounds AABB, world frame) as a distinct
-      // third-colour wireframe box (#1277).
-      state.setClashOverlapBox(clash.bounds ? { min: clash.bounds.min, max: clash.bounds.max } : null);
+      // Mark the contact as a distinct third colour (#1277/#1402). Prefer the
+      // REAL contact interface (shared-face polygon / intersection line) computed
+      // for this one pair; fall back to the AABB box if it can't be built.
+      let contactDrawn = false;
+      const elA = elementsByRef.current.get(clash.a.ref);
+      const elB = elementsByRef.current.get(clash.b.ref);
+      if (elA && elB) {
+        try {
+          const clusters = contactClusters(
+            { id: elA.key, positions: elA.positions, indices: elA.indices },
+            { id: elB.key, positions: elB.positions, indices: elB.indices },
+            { epsilon: Math.max(state.clashTolerance, 0.002) },
+          );
+          const vertices = contactLineList(clusters);
+          if (vertices.length >= 6) {
+            state.setClashContactLines({ vertices, color: CLASH_COLOR_OVERLAP });
+            state.setClashOverlapBox(null);
+            contactDrawn = true;
+          }
+        } catch {
+          // Contact geometry failed (degenerate mesh); fall back to the box.
+        }
+      }
+      if (!contactDrawn) {
+        state.setClashContactLines(null);
+        state.setClashOverlapBox(clash.bounds ? { min: clash.bounds.min, max: clash.bounds.max } : null);
+      }
       applyFocusMode(globalIds, mode);
       state.setClashSelectedId(clash.id);
       // frameSelection also frames the clash ids (see Viewport), so the camera
@@ -335,7 +399,7 @@ export function useClash() {
       const one = new Map<number, [number, number, number, number]>([[el.ref, CLASH_COLOR_A]]);
       state.setClashHighlightColors(one);
       state.setPendingColorUpdates(one);
-      state.setClashOverlapBox(null);
+      state.setClashOverlapBox(null); state.setClashContactLines(null);
       applyFocusMode([el.ref], mode);
       requestAnimationFrame(() => state.cameraCallbacks.frameSelection?.());
     },
@@ -368,7 +432,7 @@ export function useClash() {
     // pair colours (restoring an active lens) and rely on the selection outline.
     state.setClashHighlightColors(null);
     state.setPendingColorUpdates(state.lensAppliedColors ?? new Map());
-    state.setClashOverlapBox(null);
+    state.setClashOverlapBox(null); state.setClashContactLines(null);
   }, [refOf]);
 
   const clearHighlight = useCallback((): void => {
@@ -380,7 +444,7 @@ export function useClash() {
     // Restore the colour-override channel to whatever owned it (an active lens),
     // or clear it — don't leave the clash A/B colours painted. (#1277 review)
     state.setPendingColorUpdates(state.lensAppliedColors ?? new Map());
-    state.setClashOverlapBox(null);
+    state.setClashOverlapBox(null); state.setClashContactLines(null);
     setSelectedId(null);
   }, [setSelectedId]);
 
@@ -505,7 +569,7 @@ export function useClash() {
     state.clearGhost();
     // Drop the clash colour-override (restoring an active lens) + overlap box.
     state.setPendingColorUpdates(state.lensAppliedColors ?? new Map());
-    state.setClashOverlapBox(null);
+    state.setClashOverlapBox(null); state.setClashContactLines(null);
     clear();
   }, [clear]);
 

--- a/apps/viewer/src/store/homeView.ts
+++ b/apps/viewer/src/store/homeView.ts
@@ -11,6 +11,14 @@ export function resetVisibilityForHomeFromStore(): void {
   state.clearHierarchyBasketSelection();
   state.clearEntitySelection();
   state.clearBasket();
+  // Also drop any focused-clash state so "Show all" / reset filters clears the
+  // clash A/B colouring, the contact overlay (lines + box), and the selected row
+  // (#1402). The colour-override channel is restored to an active lens, or emptied.
+  state.setClashHighlightColors(null);
+  state.setClashOverlapBox(null);
+  state.setClashContactLines(null);
+  state.setClashSelectedId(null);
+  state.setPendingColorUpdates(state.lensAppliedColors ?? new Map());
   useViewerStore.setState({ activeBasketViewId: null });
 }
 

--- a/apps/viewer/src/store/slices/clashSlice.ts
+++ b/apps/viewer/src/store/slices/clashSlice.ts
@@ -77,11 +77,11 @@ export interface ClashSlice {
    */
   clashOverlapBox: { min: [number, number, number]; max: [number, number, number] } | null;
   /**
-   * Whether the focused clash's region box is drawn in the 3D view. Off by
-   * default (#1402): the wireframe box obscured the actual penetration and, being
-   * on the section-exempt overlay, appeared uncut by the section plane. The two
-   * glowing elements plus the contact marker convey the clash; the box is an
-   * opt-in extra.
+   * Whether the focused clash's region box is drawn in the 3D view. On by
+   * default (#1402): with the tight contact bounds (#1362 Bug B) the box marks
+   * the actual penetration region instead of the old whole-element AABB that
+   * obscured everything. It draws on the always-visible overlay so it shows
+   * through the (often isolated) clashing solids; toggle it off in clash settings.
    */
   showClashRegionBox: boolean;
 
@@ -186,7 +186,7 @@ export const createClashSlice: StateCreator<ClashSlice, [], [], ClashSlice> = (s
         clashClusterEpsilon: DEFAULT_CLASH_SETTINGS.clusterEpsilon,
         clashReportTouch: DEFAULT_CLASH_SETTINGS.reportTouch,
         clashGroupBy: DEFAULT_CLASH_SETTINGS.groupBy,
-        showClashRegionBox: false,
+        showClashRegionBox: true,
       });
       persistSettings();
     },

--- a/apps/viewer/src/store/slices/clashSlice.ts
+++ b/apps/viewer/src/store/slices/clashSlice.ts
@@ -76,6 +76,14 @@ export interface ClashSlice {
    * (#1277)
    */
   clashOverlapBox: { min: [number, number, number]; max: [number, number, number] } | null;
+  /**
+   * Whether the focused clash's region box is drawn in the 3D view. Off by
+   * default (#1402): the wireframe box obscured the actual penetration and, being
+   * on the section-exempt overlay, appeared uncut by the section plane. The two
+   * glowing elements plus the contact marker convey the clash; the box is an
+   * opt-in extra.
+   */
+  showClashRegionBox: boolean;
 
   setClashPanelVisible: (visible: boolean) => void;
   toggleClashPanel: () => void;
@@ -94,6 +102,7 @@ export interface ClashSlice {
   setClashSelectedId: (id: string | null) => void;
   setClashHighlightColors: (colors: Map<number, [number, number, number, number]> | null) => void;
   setClashOverlapBox: (box: { min: [number, number, number]; max: [number, number, number] } | null) => void;
+  setShowClashRegionBox: (show: boolean) => void;
   // Preset CRUD (persisted). create/update/import return a SaveResult so the UI
   // can surface quota / cap failures; the rest are best-effort.
   createClashPreset: (input: NewClashPreset) => SaveResult;
@@ -144,6 +153,7 @@ export const createClashSlice: StateCreator<ClashSlice, [], [], ClashSlice> = (s
     clashSelectedId: null,
     clashHighlightColors: null,
     clashOverlapBox: null,
+    showClashRegionBox: false,
 
     setClashPanelVisible: (clashPanelVisible) => set({ clashPanelVisible }),
     toggleClashPanel: () => set((s) => ({ clashPanelVisible: !s.clashPanelVisible })),
@@ -183,6 +193,7 @@ export const createClashSlice: StateCreator<ClashSlice, [], [], ClashSlice> = (s
     setClashSelectedId: (clashSelectedId) => set({ clashSelectedId }),
     setClashHighlightColors: (clashHighlightColors) => set({ clashHighlightColors }),
     setClashOverlapBox: (clashOverlapBox) => set({ clashOverlapBox }),
+    setShowClashRegionBox: (showClashRegionBox) => set({ showClashRegionBox }),
 
     createClashPreset: (input) => {
       const name = validatePresetName(input.name);

--- a/apps/viewer/src/store/slices/clashSlice.ts
+++ b/apps/viewer/src/store/slices/clashSlice.ts
@@ -153,7 +153,7 @@ export const createClashSlice: StateCreator<ClashSlice, [], [], ClashSlice> = (s
     clashSelectedId: null,
     clashHighlightColors: null,
     clashOverlapBox: null,
-    showClashRegionBox: false,
+    showClashRegionBox: true,
 
     setClashPanelVisible: (clashPanelVisible) => set({ clashPanelVisible }),
     toggleClashPanel: () => set((s) => ({ clashPanelVisible: !s.clashPanelVisible })),

--- a/apps/viewer/src/store/slices/clashSlice.ts
+++ b/apps/viewer/src/store/slices/clashSlice.ts
@@ -186,6 +186,7 @@ export const createClashSlice: StateCreator<ClashSlice, [], [], ClashSlice> = (s
         clashClusterEpsilon: DEFAULT_CLASH_SETTINGS.clusterEpsilon,
         clashReportTouch: DEFAULT_CLASH_SETTINGS.reportTouch,
         clashGroupBy: DEFAULT_CLASH_SETTINGS.groupBy,
+        showClashRegionBox: false,
       });
       persistSettings();
     },

--- a/apps/viewer/src/store/slices/clashSlice.ts
+++ b/apps/viewer/src/store/slices/clashSlice.ts
@@ -77,6 +77,13 @@ export interface ClashSlice {
    */
   clashOverlapBox: { min: [number, number, number]; max: [number, number, number] } | null;
   /**
+   * The focused clash's CONTACT geometry as a flat world-frame line-list (the
+   * real shared-face polygon outlines / intersection lines). Preferred over the
+   * AABB `clashOverlapBox` when present. `null` when no clash is focused or the
+   * contact could not be computed (then the box is used). (#1402)
+   */
+  clashContactLines: { vertices: number[]; color: [number, number, number, number] } | null;
+  /**
    * Whether the focused clash's region box is drawn in the 3D view. On by
    * default (#1402): with the tight contact bounds (#1362 Bug B) the box marks
    * the actual penetration region instead of the old whole-element AABB that
@@ -102,6 +109,7 @@ export interface ClashSlice {
   setClashSelectedId: (id: string | null) => void;
   setClashHighlightColors: (colors: Map<number, [number, number, number, number]> | null) => void;
   setClashOverlapBox: (box: { min: [number, number, number]; max: [number, number, number] } | null) => void;
+  setClashContactLines: (lines: { vertices: number[]; color: [number, number, number, number] } | null) => void;
   setShowClashRegionBox: (show: boolean) => void;
   // Preset CRUD (persisted). create/update/import return a SaveResult so the UI
   // can surface quota / cap failures; the rest are best-effort.
@@ -153,6 +161,7 @@ export const createClashSlice: StateCreator<ClashSlice, [], [], ClashSlice> = (s
     clashSelectedId: null,
     clashHighlightColors: null,
     clashOverlapBox: null,
+    clashContactLines: null,
     showClashRegionBox: true,
 
     setClashPanelVisible: (clashPanelVisible) => set({ clashPanelVisible }),
@@ -194,6 +203,7 @@ export const createClashSlice: StateCreator<ClashSlice, [], [], ClashSlice> = (s
     setClashSelectedId: (clashSelectedId) => set({ clashSelectedId }),
     setClashHighlightColors: (clashHighlightColors) => set({ clashHighlightColors }),
     setClashOverlapBox: (clashOverlapBox) => set({ clashOverlapBox }),
+    setClashContactLines: (clashContactLines) => set({ clashContactLines }),
     setShowClashRegionBox: (showClashRegionBox) => set({ showClashRegionBox }),
 
     createClashPreset: (input) => {
@@ -280,6 +290,7 @@ export const createClashSlice: StateCreator<ClashSlice, [], [], ClashSlice> = (s
         clashSelectedId: null,
         clashHighlightColors: null,
         clashOverlapBox: null,
+    clashContactLines: null,
       }),
   };
 };

--- a/packages/clash/package.json
+++ b/packages/clash/package.json
@@ -23,6 +23,10 @@
       "import": "./dist/bcf-bridge.js",
       "types": "./dist/bcf-bridge.d.ts"
     },
+    "./contact": {
+      "import": "./dist/contact/index.js",
+      "types": "./dist/contact/index.d.ts"
+    },
     "./wasm": {
       "import": "./dist/engine-wasm/index.js",
       "types": "./dist/engine-wasm/index.d.ts"

--- a/packages/clash/src/contact/aabb.ts
+++ b/packages/clash/src/contact/aabb.ts
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { AABB, Vec3 } from "./types.js";
+
+/** An empty AABB (inverted bounds); union with any AABB yields that AABB. */
+export const EMPTY_AABB: AABB = {
+  min: [Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY],
+  max: [Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY],
+};
+
+/** True when two AABBs overlap (closed intervals). */
+export function intersects(a: AABB, b: AABB): boolean {
+  return (
+    a.min[0] <= b.max[0] &&
+    a.max[0] >= b.min[0] &&
+    a.min[1] <= b.max[1] &&
+    a.max[1] >= b.min[1] &&
+    a.min[2] <= b.max[2] &&
+    a.max[2] >= b.min[2]
+  );
+}
+
+/** Smallest AABB containing both inputs. */
+export function unionAabb(a: AABB, b: AABB): AABB {
+  return {
+    min: [Math.min(a.min[0], b.min[0]), Math.min(a.min[1], b.min[1]), Math.min(a.min[2], b.min[2])],
+    max: [Math.max(a.max[0], b.max[0]), Math.max(a.max[1], b.max[1]), Math.max(a.max[2], b.max[2])],
+  };
+}
+
+/** Geometric centre of an AABB. */
+export function center(a: AABB): Vec3 {
+  return [(a.min[0] + a.max[0]) / 2, (a.min[1] + a.max[1]) / 2, (a.min[2] + a.max[2]) / 2];
+}
+
+/** Size (extent) of an AABB along each axis. */
+export function size(a: AABB): Vec3 {
+  return [a.max[0] - a.min[0], a.max[1] - a.min[1], a.max[2] - a.min[2]];
+}
+
+/** True when the AABB contains the point (closed intervals). */
+export function contains(a: AABB, p: Vec3): boolean {
+  return (
+    p[0] >= a.min[0] &&
+    p[0] <= a.max[0] &&
+    p[1] >= a.min[1] &&
+    p[1] <= a.max[1] &&
+    p[2] >= a.min[2] &&
+    p[2] <= a.max[2]
+  );
+}
+
+/** Inflate the AABB by `eps` on every face. Negative values deflate. */
+export function inflate(a: AABB, eps: number): AABB {
+  return {
+    min: [a.min[0] - eps, a.min[1] - eps, a.min[2] - eps],
+    max: [a.max[0] + eps, a.max[1] + eps, a.max[2] + eps],
+  };
+}
+
+/** Build an AABB from a flat positions buffer (xyz, xyz, …). */
+export function aabbFromPositions(positions: ArrayLike<number>): AABB {
+  if (positions.length === 0 || positions.length % 3 !== 0) {
+    return EMPTY_AABB;
+  }
+  let minX = Number.POSITIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let minZ = Number.POSITIVE_INFINITY;
+  let maxX = Number.NEGATIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+  let maxZ = Number.NEGATIVE_INFINITY;
+  for (let i = 0; i < positions.length; i += 3) {
+    const x = positions[i] as number;
+    const y = positions[i + 1] as number;
+    const z = positions[i + 2] as number;
+    if (x < minX) minX = x;
+    if (y < minY) minY = y;
+    if (z < minZ) minZ = z;
+    if (x > maxX) maxX = x;
+    if (y > maxY) maxY = y;
+    if (z > maxZ) maxZ = z;
+  }
+  return { min: [minX, minY, minZ], max: [maxX, maxY, maxZ] };
+}
+
+/** Longest axis of the AABB: 0=x, 1=y, 2=z. */
+export function longestAxis(a: AABB): 0 | 1 | 2 {
+  const [dx, dy, dz] = size(a);
+  if (dx >= dy && dx >= dz) return 0;
+  if (dy >= dz) return 1;
+  return 2;
+}

--- a/packages/clash/src/contact/bvh.ts
+++ b/packages/clash/src/contact/bvh.ts
@@ -1,0 +1,211 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { EMPTY_AABB, center, intersects, longestAxis, unionAabb } from "./aabb.js";
+import type { AABB, MeshBounds } from "./types.js";
+
+/**
+ * Median-split BVH with two query primitives:
+ *   - queryAABB(q): items overlapping `q`
+ *   - queryPairs(eps?): all unordered pairs whose (optionally inflated) AABBs overlap
+ *
+ * Build cost: O(n log n). queryPairs descends both subtrees simultaneously,
+ * pruning on AABB intersection — true O(n log n) self-pair enumeration rather
+ * than O(n^2) per-element queries.
+ */
+
+export interface BvhNode {
+  readonly bounds: AABB;
+  readonly left?: BvhNode;
+  readonly right?: BvhNode;
+  /** Indices into the original `items` array; present only on leaves. */
+  readonly items?: readonly number[];
+}
+
+export interface BvhOptions {
+  /** Maximum items per leaf; lower = deeper tree, higher = faster build. */
+  readonly leafSize?: number;
+}
+
+export class Bvh {
+  readonly root: BvhNode | null;
+  readonly items: readonly MeshBounds[];
+
+  private constructor(root: BvhNode | null, items: readonly MeshBounds[]) {
+    this.root = root;
+    this.items = items;
+  }
+
+  /** Build a BVH from a list of bounded items. Median-split along the longest axis. */
+  static build(items: readonly MeshBounds[], opts: BvhOptions = {}): Bvh {
+    if (items.length === 0) return new Bvh(null, items);
+    const leafSize = Math.max(1, opts.leafSize ?? 4);
+    const indices = items.map((_, i) => i);
+    const root = buildNode(items, indices, leafSize);
+    return new Bvh(root, items);
+  }
+
+  /** Return ids of items whose AABB intersects `q`. Order is depth-first, stable. */
+  queryAABB(q: AABB): string[] {
+    if (!this.root) return [];
+    const out: string[] = [];
+    queryAabbNode(this.root, q, this.items, out);
+    return out;
+  }
+
+  /**
+   * Return all unordered pairs `(idA, idB)` with idA < idB (lex) whose AABBs
+   * (optionally inflated by `epsilon` on all sides) overlap. Pair order is
+   * deterministic given input order.
+   */
+  queryPairs(epsilon = 0): IdPair[] {
+    if (!this.root) return [];
+    const out: IdPair[] = [];
+    selfPair(this.root, this.items, epsilon, out);
+    // Stable canonicalisation — the emission loops already guarantee no dupes,
+    // but we sort both within each pair and across the pair array so the
+    // output is insensitive to tree construction order (just input order).
+    for (let i = 0; i < out.length; i++) {
+      const p = out[i] as [string, string];
+      if (p[0] > p[1]) out[i] = [p[1], p[0]];
+    }
+    out.sort((a, b) =>
+      a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : a[1] < b[1] ? -1 : a[1] > b[1] ? 1 : 0,
+    );
+    return out;
+  }
+}
+
+type IdPair = readonly [string, string];
+
+function buildNode(items: readonly MeshBounds[], indices: number[], leafSize: number): BvhNode {
+  if (indices.length === 0) {
+    return { bounds: EMPTY_AABB, items: [] };
+  }
+  const bounds = indices.reduce<AABB>(
+    (acc, idx) => unionAabb(acc, (items[idx] as MeshBounds).aabb),
+    EMPTY_AABB,
+  );
+  if (indices.length <= leafSize) {
+    return { bounds, items: indices.slice() };
+  }
+  const axis = longestAxis(bounds);
+  // Sort indices by centre along longest axis, then split at median.
+  indices.sort((ia, ib) => {
+    const ca = center((items[ia] as MeshBounds).aabb)[axis];
+    const cb = center((items[ib] as MeshBounds).aabb)[axis];
+    return ca - cb;
+  });
+  const mid = indices.length >> 1;
+  const leftIdx = indices.slice(0, mid);
+  const rightIdx = indices.slice(mid);
+  return {
+    bounds,
+    left: buildNode(items, leftIdx, leafSize),
+    right: buildNode(items, rightIdx, leafSize),
+  };
+}
+
+function queryAabbNode(node: BvhNode, q: AABB, items: readonly MeshBounds[], out: string[]): void {
+  if (!intersects(node.bounds, q)) return;
+  if (node.items) {
+    for (const i of node.items) {
+      const it = items[i] as MeshBounds;
+      if (intersects(it.aabb, q)) out.push(it.id);
+    }
+    return;
+  }
+  if (node.left) queryAabbNode(node.left, q, items, out);
+  if (node.right) queryAabbNode(node.right, q, items, out);
+}
+
+/** Dual-traversal self-pair emission. */
+function selfPair(node: BvhNode, items: readonly MeshBounds[], eps: number, out: IdPair[]): void {
+  if (node.items) {
+    emitLeafPairs(node.items, items, eps, out);
+    return;
+  }
+  if (node.left) selfPair(node.left, items, eps, out);
+  if (node.right) selfPair(node.right, items, eps, out);
+  if (node.left && node.right) crossPair(node.left, node.right, items, eps, out);
+}
+
+function crossPair(
+  a: BvhNode,
+  b: BvhNode,
+  items: readonly MeshBounds[],
+  eps: number,
+  out: IdPair[],
+): void {
+  if (!boundsOverlapInflated(a.bounds, b.bounds, eps)) return;
+  if (a.items && b.items) {
+    emitLeafCross(a.items, b.items, items, eps, out);
+    return;
+  }
+  // Descend the larger side first to keep recursion depth bounded.
+  if (a.items) {
+    if (b.left) crossPair(a, b.left, items, eps, out);
+    if (b.right) crossPair(a, b.right, items, eps, out);
+    return;
+  }
+  if (b.items) {
+    if (a.left) crossPair(a.left, b, items, eps, out);
+    if (a.right) crossPair(a.right, b, items, eps, out);
+    return;
+  }
+  if (a.left) {
+    if (b.left) crossPair(a.left, b.left, items, eps, out);
+    if (b.right) crossPair(a.left, b.right, items, eps, out);
+  }
+  if (a.right) {
+    if (b.left) crossPair(a.right, b.left, items, eps, out);
+    if (b.right) crossPair(a.right, b.right, items, eps, out);
+  }
+}
+
+function emitLeafPairs(
+  leaf: readonly number[],
+  items: readonly MeshBounds[],
+  eps: number,
+  out: IdPair[],
+): void {
+  for (let i = 0; i < leaf.length; i++) {
+    const ia = leaf[i] as number;
+    const a = items[ia] as MeshBounds;
+    for (let j = i + 1; j < leaf.length; j++) {
+      const ib = leaf[j] as number;
+      const b = items[ib] as MeshBounds;
+      if (boundsOverlapInflated(a.aabb, b.aabb, eps)) out.push([a.id, b.id]);
+    }
+  }
+}
+
+function emitLeafCross(
+  aLeaf: readonly number[],
+  bLeaf: readonly number[],
+  items: readonly MeshBounds[],
+  eps: number,
+  out: IdPair[],
+): void {
+  for (const ia of aLeaf) {
+    const a = items[ia] as MeshBounds;
+    for (const ib of bLeaf) {
+      const b = items[ib] as MeshBounds;
+      if (a.id === b.id) continue;
+      if (boundsOverlapInflated(a.aabb, b.aabb, eps)) out.push([a.id, b.id]);
+    }
+  }
+}
+
+function boundsOverlapInflated(a: AABB, b: AABB, eps: number): boolean {
+  if (eps === 0) return intersects(a, b);
+  return (
+    a.min[0] - eps <= b.max[0] + eps &&
+    a.max[0] + eps >= b.min[0] - eps &&
+    a.min[1] - eps <= b.max[1] + eps &&
+    a.max[1] + eps >= b.min[1] - eps &&
+    a.min[2] - eps <= b.max[2] + eps &&
+    a.max[2] + eps >= b.min[2] - eps
+  );
+}

--- a/packages/clash/src/contact/contact.test.ts
+++ b/packages/clash/src/contact/contact.test.ts
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { contactClusters, type Mesh } from './index.js';
+
+/** Axis-aligned box [min..max] as a triangulated mesh (12 triangles). */
+function box(id: string, min: [number, number, number], max: [number, number, number]): Mesh {
+  const [x0, y0, z0] = min;
+  const [x1, y1, z1] = max;
+  const v = [
+    [x0, y0, z0], [x1, y0, z0], [x1, y1, z0], [x0, y1, z0],
+    [x0, y0, z1], [x1, y0, z1], [x1, y1, z1], [x0, y1, z1],
+  ];
+  const faces = [
+    [0, 1, 2], [0, 2, 3], [4, 6, 5], [4, 7, 6], [0, 5, 1], [0, 4, 5],
+    [1, 6, 2], [1, 5, 6], [2, 6, 7], [2, 7, 3], [3, 7, 4], [3, 4, 0],
+  ];
+  return { id, positions: new Float64Array(v.flat()), indices: new Uint32Array(faces.flat()) };
+}
+
+describe('contactClusters (contact interface geometry)', () => {
+  it('reports the shared faces of two overlapping boxes as surface clusters', () => {
+    // A [0,1]^3 and B shifted +0.5 in x overlap in x[0.5,1]; the coincident
+    // y/z faces over that range are the contact patches.
+    const a = box('A', [0, 0, 0], [1, 1, 1]);
+    const b = box('B', [0.5, 0, 0], [1.5, 1, 1]);
+    const clusters = contactClusters(a, b);
+    const surfaces = clusters.filter((c) => c.kind === 'surface');
+    expect(surfaces.length).toBeGreaterThanOrEqual(1);
+    // Each coincident face over x[0.5,1] is a 0.5 x 1 patch (area 0.5).
+    const totalArea = surfaces.reduce((s, c) => s + c.area_m2, 0);
+    expect(totalArea).toBeGreaterThan(0.4);
+    // Surface clusters carry a real boundary polygon (>= a triangle), not a point.
+    for (const c of surfaces) expect(c.boundary.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('returns no contact for clearly separated boxes', () => {
+    const a = box('A', [0, 0, 0], [1, 1, 1]);
+    const b = box('B', [5, 5, 5], [6, 6, 6]);
+    expect(contactClusters(a, b)).toEqual([]);
+  });
+
+  it('reports a line contact for two perpendicular bars that cross', () => {
+    const a = box('A', [-5, -0.5, -0.5], [5, 0.5, 0.5]); // along X
+    const b = box('B', [-0.5, -5, -0.5], [0.5, 5, 0.5]); // along Y
+    const clusters = contactClusters(a, b);
+    // The crossing yields line contacts along the shared edges (and possibly
+    // coincident top/bottom faces); at minimum some contact is reported.
+    expect(clusters.length).toBeGreaterThan(0);
+    const lines = clusters.filter((c) => c.kind === 'line');
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/clash/src/contact/index.ts
+++ b/packages/clash/src/contact/index.ts
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Contact-interface geometry for a single pair of meshes.
+ *
+ * Where the AABB clash box is a crude proxy, this returns the REAL contact
+ * patch: the shared-face polygon for coplanar/flush overlaps (surface), the
+ * intersection line for crossings (line), or a point — classified by area and
+ * length. It is built from a Moller triangle-triangle test (which reports the
+ * intersection segment for crossings and the coplanar case) followed by
+ * shared-face clustering: coplanar triangle pairs are Sutherland-Hodgman clipped
+ * on their common plane and unioned into a boundary polygon; cross pairs union
+ * their segments along the intersection line.
+ *
+ * Intended for on-demand use on the FOCUSED clash (one pair), not the bulk
+ * detection sweep — clustering every clash would be far too expensive.
+ */
+
+import { narrowPhase, type NarrowPhaseOptions } from './narrow-phase.js';
+import {
+  clusterSharedFaces,
+  type SharedFaceCluster,
+  type SharedFaceOptions,
+} from './shared-faces.js';
+import type { Mesh, Vec3 } from './types.js';
+
+export type { Mesh, Vec3, AABB } from './types.js';
+export type { SharedFaceCluster, SharedFaceOptions } from './shared-faces.js';
+export type { TrianglePair, NarrowPhaseOptions } from './narrow-phase.js';
+export { narrowPhase, clusterSharedFaces };
+
+export interface ContactOptions extends NarrowPhaseOptions, SharedFaceOptions {}
+
+/**
+ * Compute the contact interface(s) between two world-space meshes: the real
+ * shared-face polygon (surface), intersection line, or point — not an AABB.
+ * Returns an empty array when the triangles neither cross nor share a plane.
+ */
+export function contactClusters(a: Mesh, b: Mesh, opts: ContactOptions = {}): SharedFaceCluster[] {
+  const pairs = narrowPhase(a, b, opts);
+  if (pairs.length === 0) return [];
+  return clusterSharedFaces(pairs, opts);
+}

--- a/packages/clash/src/contact/mesh-bvh.ts
+++ b/packages/clash/src/contact/mesh-bvh.ts
@@ -1,0 +1,114 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Bvh } from "./bvh.js";
+import { triangleAabb, triangleAt, triangleCount } from "./triangle.js";
+import type { Mesh, MeshBounds } from "./types.js";
+
+/**
+ * A BVH over a mesh's triangles. Item ids are stringified triangle indices.
+ * Cross-traversal between two MeshBvh yields candidate triangle-pair indices.
+ */
+export interface MeshBvh {
+  readonly mesh: Mesh;
+  readonly bvh: Bvh;
+}
+
+export function buildMeshBvh(mesh: Mesh, leafSize = 8): MeshBvh {
+  const n = triangleCount(mesh);
+  const items: MeshBounds[] = new Array(n);
+  for (let i = 0; i < n; i++) {
+    items[i] = { id: String(i), aabb: triangleAabb(triangleAt(mesh, i)) };
+  }
+  return { mesh, bvh: Bvh.build(items, { leafSize }) };
+}
+
+/**
+ * Cross-query two MeshBvh instances. Returns candidate triangle-index pairs
+ * `(iA, iB)` where iA is in `a.mesh` and iB is in `b.mesh`, whose AABBs
+ * (inflated by `epsilon`) overlap.
+ *
+ * Pairs are not canonicalised — both meshes are distinct inputs, so order
+ * is preserved (A first, B second).
+ */
+export function queryMeshCross(
+  a: MeshBvh,
+  b: MeshBvh,
+  epsilon = 0,
+): Array<readonly [number, number]> {
+  if (!a.bvh.root || !b.bvh.root) return [];
+  const out: Array<readonly [number, number]> = [];
+  crossNode(a.bvh, b.bvh, a.bvh.root, b.bvh.root, epsilon, out);
+  // Dedup — BVHs partition the triangle set, so no true duplicates, but
+  // belt-and-braces:
+  const seen = new Set<string>();
+  const deduped: Array<readonly [number, number]> = [];
+  for (const p of out) {
+    const key = `${p[0]}|${p[1]}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(p);
+  }
+  return deduped;
+}
+
+function crossNode(
+  aTree: Bvh,
+  bTree: Bvh,
+  aNode: NonNullable<Bvh["root"]>,
+  bNode: NonNullable<Bvh["root"]>,
+  eps: number,
+  out: Array<readonly [number, number]>,
+): void {
+  if (!boundsOverlap(aNode.bounds, bNode.bounds, eps)) return;
+  const aLeaf = aNode.items;
+  const bLeaf = bNode.items;
+  if (aLeaf && bLeaf) {
+    for (const ia of aLeaf) {
+      const aItem = aTree.items[ia];
+      if (!aItem) continue;
+      for (const ib of bLeaf) {
+        const bItem = bTree.items[ib];
+        if (!bItem) continue;
+        if (boundsOverlap(aItem.aabb, bItem.aabb, eps)) {
+          out.push([Number(aItem.id), Number(bItem.id)]);
+        }
+      }
+    }
+    return;
+  }
+  if (aLeaf) {
+    if (bNode.left) crossNode(aTree, bTree, aNode, bNode.left, eps, out);
+    if (bNode.right) crossNode(aTree, bTree, aNode, bNode.right, eps, out);
+    return;
+  }
+  if (bLeaf) {
+    if (aNode.left) crossNode(aTree, bTree, aNode.left, bNode, eps, out);
+    if (aNode.right) crossNode(aTree, bTree, aNode.right, bNode, eps, out);
+    return;
+  }
+  if (aNode.left) {
+    if (bNode.left) crossNode(aTree, bTree, aNode.left, bNode.left, eps, out);
+    if (bNode.right) crossNode(aTree, bTree, aNode.left, bNode.right, eps, out);
+  }
+  if (aNode.right) {
+    if (bNode.left) crossNode(aTree, bTree, aNode.right, bNode.left, eps, out);
+    if (bNode.right) crossNode(aTree, bTree, aNode.right, bNode.right, eps, out);
+  }
+}
+
+function boundsOverlap(
+  a: { min: readonly [number, number, number]; max: readonly [number, number, number] },
+  b: { min: readonly [number, number, number]; max: readonly [number, number, number] },
+  eps: number,
+): boolean {
+  return (
+    a.min[0] - eps <= b.max[0] + eps &&
+    a.max[0] + eps >= b.min[0] - eps &&
+    a.min[1] - eps <= b.max[1] + eps &&
+    a.max[1] + eps >= b.min[1] - eps &&
+    a.min[2] - eps <= b.max[2] + eps &&
+    a.max[2] + eps >= b.min[2] - eps
+  );
+}

--- a/packages/clash/src/contact/narrow-phase.ts
+++ b/packages/clash/src/contact/narrow-phase.ts
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { buildMeshBvh, queryMeshCross } from "./mesh-bvh.js";
+import { triTriIntersect } from "./tri-tri.js";
+import type { Triangle } from "./triangle.js";
+import { triangleAt, triangleCount } from "./triangle.js";
+import type { Mesh, Vec3 } from "./types.js";
+
+export type TrianglePair =
+  | {
+      readonly triA: number;
+      readonly triB: number;
+      readonly a: Triangle;
+      readonly b: Triangle;
+      readonly kind: "coplanar";
+    }
+  | {
+      readonly triA: number;
+      readonly triB: number;
+      readonly a: Triangle;
+      readonly b: Triangle;
+      readonly kind: "cross";
+      /** 3D endpoints of the intersection segment on the common line. */
+      readonly p0: Vec3;
+      readonly p1: Vec3;
+    };
+
+export interface NarrowPhaseOptions {
+  /** AABB inflation (world units). Default 0.002 (2 mm). */
+  readonly epsilon?: number;
+  /** Plane-distance tolerance for coplanarity and Möller sign tests. */
+  readonly planeEps?: number;
+  /** BVH leaf size for per-mesh triangle BVHs. Default 8. */
+  readonly leafSize?: number;
+}
+
+/**
+ * For two meshes A and B, return every triangle pair whose triangles
+ * either strictly cross or are coplanar (and whose AABBs are within
+ * `epsilon` of each other).
+ *
+ * Coplanar pairs are emitted without further 2D-overlap testing —
+ * shared-face clustering (downstream) does that more robustly across
+ * a whole cluster of coplanar hits.
+ */
+export function narrowPhase(a: Mesh, b: Mesh, opts: NarrowPhaseOptions = {}): TrianglePair[] {
+  const epsilon = opts.epsilon ?? 0.002;
+  const planeEps = opts.planeEps ?? 1e-6;
+  const leafSize = opts.leafSize ?? 8;
+
+  if (triangleCount(a) === 0 || triangleCount(b) === 0) return [];
+
+  const bvhA = buildMeshBvh(a, leafSize);
+  const bvhB = buildMeshBvh(b, leafSize);
+  const candidates = queryMeshCross(bvhA, bvhB, epsilon);
+
+  const out: TrianglePair[] = [];
+  for (const [iA, iB] of candidates) {
+    const triA = triangleAt(a, iA);
+    const triB = triangleAt(b, iB);
+    const res = triTriIntersect(triA, triB, planeEps);
+    if (res.kind === "none") continue;
+    if (res.kind === "coplanar") {
+      out.push({ triA: iA, triB: iB, a: triA, b: triB, kind: "coplanar" });
+    } else {
+      out.push({
+        triA: iA,
+        triB: iB,
+        a: triA,
+        b: triB,
+        kind: "cross",
+        p0: res.p0,
+        p1: res.p1,
+      });
+    }
+  }
+
+  return out;
+}

--- a/packages/clash/src/contact/plane.ts
+++ b/packages/clash/src/contact/plane.ts
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Plane utilities. A plane is stored as a unit normal + signed offset:
+ *   normal · x = offset
+ * `canonicalPlane` produces a direction-independent key so that the pair
+ * (normal, -normal, offset, -offset) hashes identically.
+ */
+
+import type { Vec3 } from "./types.js";
+import { dot3, length3 } from "./vec3.js";
+
+export interface Plane {
+  readonly normal: Vec3;
+  readonly offset: number;
+}
+
+export interface PlaneBasis {
+  readonly origin: Vec3;
+  readonly u: Vec3;
+  readonly v: Vec3;
+  readonly normal: Vec3;
+}
+
+/** Build a plane from a normal (not required to be unit) and a point on it. */
+export function planeFromNormalPoint(normal: Vec3, point: Vec3): Plane {
+  const ln = length3(normal);
+  if (ln === 0) return { normal: [0, 0, 1], offset: 0 };
+  const n: Vec3 = [normal[0] / ln, normal[1] / ln, normal[2] / ln];
+  return { normal: n, offset: dot3(n, point) };
+}
+
+/**
+ * Direction-independent quantised plane key.
+ *
+ * The normal is reflected so its first nonzero component is positive,
+ * then rounded to `angleSnap` radians in spherical form. The offset is
+ * signed accordingly and rounded to `distSnap` world units.
+ */
+export function planeKey(plane: Plane, angleSnap = 1e-3, distSnap = 1e-3): string {
+  const n = plane.normal;
+  const ln = length3(n);
+  if (ln === 0) return "0|0|0|0";
+  // Canonicalise direction: first nonzero coordinate must be positive.
+  let sign = 1;
+  if (Math.abs(n[0]) > 1e-9) sign = n[0] > 0 ? 1 : -1;
+  else if (Math.abs(n[1]) > 1e-9) sign = n[1] > 0 ? 1 : -1;
+  else sign = n[2] > 0 ? 1 : -1;
+  const cx = (n[0] / ln) * sign;
+  const cy = (n[1] / ln) * sign;
+  const cz = (n[2] / ln) * sign;
+  const off = plane.offset * sign;
+  return [
+    Math.round(cx / angleSnap),
+    Math.round(cy / angleSnap),
+    Math.round(cz / angleSnap),
+    Math.round(off / distSnap),
+  ].join("|");
+}
+
+/**
+ * Build an orthonormal basis `{u, v}` in the plane so 3D plane points can
+ * be projected to 2D and back. `origin` is chosen as the foot of the normal
+ * from the world origin.
+ */
+export function planeBasis(plane: Plane): PlaneBasis {
+  const n = plane.normal;
+  // origin = offset * n (foot of normal from world origin if |n|=1)
+  const origin: Vec3 = [n[0] * plane.offset, n[1] * plane.offset, n[2] * plane.offset];
+  // pick a helper not parallel to n
+  const helper: Vec3 = Math.abs(n[0]) < 0.9 ? [1, 0, 0] : [0, 1, 0];
+  const u0: Vec3 = [
+    helper[1] * n[2] - helper[2] * n[1],
+    helper[2] * n[0] - helper[0] * n[2],
+    helper[0] * n[1] - helper[1] * n[0],
+  ];
+  const uLen = length3(u0);
+  const u: Vec3 = uLen === 0 ? [1, 0, 0] : [u0[0] / uLen, u0[1] / uLen, u0[2] / uLen];
+  const v: Vec3 = [n[1] * u[2] - n[2] * u[1], n[2] * u[0] - n[0] * u[2], n[0] * u[1] - n[1] * u[0]];
+  return { origin, u, v, normal: n };
+}
+
+/** Project a 3D point onto the plane's 2D basis. */
+export function projectTo2D(basis: PlaneBasis, p: Vec3): readonly [number, number] {
+  const dx = p[0] - basis.origin[0];
+  const dy = p[1] - basis.origin[1];
+  const dz = p[2] - basis.origin[2];
+  return [
+    dx * basis.u[0] + dy * basis.u[1] + dz * basis.u[2],
+    dx * basis.v[0] + dy * basis.v[1] + dz * basis.v[2],
+  ];
+}
+
+/** Lift a 2D basis point back to 3D. */
+export function liftTo3D(basis: PlaneBasis, p: readonly [number, number]): Vec3 {
+  return [
+    basis.origin[0] + basis.u[0] * p[0] + basis.v[0] * p[1],
+    basis.origin[1] + basis.u[1] * p[0] + basis.v[1] * p[1],
+    basis.origin[2] + basis.u[2] * p[0] + basis.v[2] * p[1],
+  ];
+}

--- a/packages/clash/src/contact/polygon-clip.ts
+++ b/packages/clash/src/contact/polygon-clip.ts
@@ -1,0 +1,168 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * 2D polygon utilities: Sutherland–Hodgman clip of a subject polygon by
+ * a convex clip polygon, shoelace area, perimeter, centroid.
+ *
+ * Both polygons are arrays of `[x, y]` pairs. CCW winding gives positive
+ * area (standard convention).
+ */
+
+export type Point2 = readonly [number, number];
+export type Polygon2 = readonly Point2[];
+
+/** Shoelace-formula signed area (positive when CCW). */
+export function polygonSignedArea(poly: Polygon2): number {
+  const n = poly.length;
+  if (n < 3) return 0;
+  let sum = 0;
+  for (let i = 0; i < n; i++) {
+    const a = poly[i] as Point2;
+    const b = poly[(i + 1) % n] as Point2;
+    sum += a[0] * b[1] - b[0] * a[1];
+  }
+  return sum / 2;
+}
+
+export const polygonArea = (poly: Polygon2): number => Math.abs(polygonSignedArea(poly));
+
+export function polygonPerimeter(poly: Polygon2): number {
+  const n = poly.length;
+  if (n < 2) return 0;
+  let sum = 0;
+  for (let i = 0; i < n; i++) {
+    const a = poly[i] as Point2;
+    const b = poly[(i + 1) % n] as Point2;
+    const dx = b[0] - a[0];
+    const dy = b[1] - a[1];
+    sum += Math.sqrt(dx * dx + dy * dy);
+  }
+  return sum;
+}
+
+/** Area-weighted centroid. Falls back to vertex mean for degenerate input. */
+export function polygonCentroid(poly: Polygon2): Point2 {
+  const n = poly.length;
+  if (n === 0) return [0, 0];
+  if (n === 1) {
+    const p0 = poly[0] as Point2;
+    return [p0[0], p0[1]];
+  }
+  const a2 = polygonSignedArea(poly) * 2;
+  if (Math.abs(a2) < 1e-18) {
+    let mx = 0;
+    let my = 0;
+    for (const p of poly) {
+      mx += p[0];
+      my += p[1];
+    }
+    return [mx / n, my / n];
+  }
+  let cx = 0;
+  let cy = 0;
+  for (let i = 0; i < n; i++) {
+    const a = poly[i] as Point2;
+    const b = poly[(i + 1) % n] as Point2;
+    const cross = a[0] * b[1] - b[0] * a[1];
+    cx += (a[0] + b[0]) * cross;
+    cy += (a[1] + b[1]) * cross;
+  }
+  return [cx / (3 * a2), cy / (3 * a2)];
+}
+
+/**
+ * Sutherland–Hodgman polygon clip. `subject` may be any simple polygon;
+ * `clip` must be **convex** (CCW). Returns the intersection polygon, which
+ * can be empty (no overlap) or degenerate (collinear/point contact).
+ */
+export function sutherlandHodgman(subject: Polygon2, clip: Polygon2): Polygon2 {
+  if (subject.length === 0 || clip.length < 3) return [];
+  // Enforce CCW clip — if the clip is CW we flip it.
+  const clipCCW = polygonSignedArea(clip) >= 0 ? clip : [...clip].reverse();
+  let output: Point2[] = subject.map((p) => [p[0], p[1]] as Point2);
+
+  for (let i = 0; i < clipCCW.length; i++) {
+    if (output.length === 0) break;
+    const a = clipCCW[i] as Point2;
+    const b = clipCCW[(i + 1) % clipCCW.length] as Point2;
+    const input = output;
+    output = [];
+    for (let j = 0; j < input.length; j++) {
+      const current = input[j] as Point2;
+      const prev = input[(j - 1 + input.length) % input.length] as Point2;
+      const curIn = isLeftOrOn(a, b, current);
+      const prevIn = isLeftOrOn(a, b, prev);
+      if (curIn) {
+        if (!prevIn) {
+          const ip = segmentIntersection(prev, current, a, b);
+          if (ip) output.push(ip);
+        }
+        output.push(current);
+      } else if (prevIn) {
+        const ip = segmentIntersection(prev, current, a, b);
+        if (ip) output.push(ip);
+      }
+    }
+  }
+  return output;
+}
+
+/** True when point `p` is to the left of, or on, directed edge `a → b`. */
+function isLeftOrOn(a: Point2, b: Point2, p: Point2): boolean {
+  const cross = (b[0] - a[0]) * (p[1] - a[1]) - (b[1] - a[1]) * (p[0] - a[0]);
+  return cross >= 0;
+}
+
+/** Intersection of segment `p1→p2` with infinite line through `a→b`. */
+function segmentIntersection(p1: Point2, p2: Point2, a: Point2, b: Point2): Point2 | null {
+  const r0 = p2[0] - p1[0];
+  const r1 = p2[1] - p1[1];
+  const s0 = b[0] - a[0];
+  const s1 = b[1] - a[1];
+  const denom = r0 * s1 - r1 * s0;
+  if (Math.abs(denom) < 1e-15) return null; // parallel
+  const qp0 = a[0] - p1[0];
+  const qp1 = a[1] - p1[1];
+  const t = (qp0 * s1 - qp1 * s0) / denom;
+  return [p1[0] + t * r0, p1[1] + t * r1];
+}
+
+/**
+ * Convex polygon from (unordered) points: sort by angle around centroid
+ * and return CCW. For use as a Sutherland-Hodgman clip.
+ */
+export function convexHull2(points: Polygon2): Polygon2 {
+  if (points.length < 3) return points.map((p) => [p[0], p[1]] as Point2);
+  // Andrew's monotone chain
+  const pts = [...points].sort((a, b) => (a[0] === b[0] ? a[1] - b[1] : a[0] - b[0]));
+  const lower: Point2[] = [];
+  for (const p of pts) {
+    while (lower.length >= 2) {
+      const a = lower[lower.length - 2] as Point2;
+      const b = lower[lower.length - 1] as Point2;
+      if (cross2(a, b, p) <= 0) lower.pop();
+      else break;
+    }
+    lower.push(p as Point2);
+  }
+  const upper: Point2[] = [];
+  for (let i = pts.length - 1; i >= 0; i--) {
+    const p = pts[i] as Point2;
+    while (upper.length >= 2) {
+      const a = upper[upper.length - 2] as Point2;
+      const b = upper[upper.length - 1] as Point2;
+      if (cross2(a, b, p) <= 0) upper.pop();
+      else break;
+    }
+    upper.push(p);
+  }
+  lower.pop();
+  upper.pop();
+  return [...lower, ...upper];
+}
+
+function cross2(o: Point2, a: Point2, b: Point2): number {
+  return (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0]);
+}

--- a/packages/clash/src/contact/shared-faces.ts
+++ b/packages/clash/src/contact/shared-faces.ts
@@ -1,0 +1,334 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Shared-face clustering.
+ *
+ * Inputs: TrianglePair[] emitted by narrowPhase() for a single pair of
+ * elements. Output: one or more SharedFaceCluster objects, each representing
+ * a distinct contact between the two elements, classified as
+ * surface / line / point.
+ *
+ * Coplanar pairs cluster by plane key. For each cluster we Sutherland-Hodgman
+ * every (A,B) triangle pair on the shared plane, sum polygon areas, build a
+ * 3D boundary polygon as the convex hull of the union of clip vertices.
+ *
+ * Cross pairs cluster by intersection-line key (direction + point on line).
+ * Length is the union length of the per-pair 3D segments projected onto
+ * the line direction.
+ *
+ * Remaining incidental contacts fall into either classification by
+ * magnitude against the thresholds.
+ */
+
+import type { TrianglePair } from "./narrow-phase.js";
+import type { Plane } from "./plane.js";
+import { liftTo3D, planeBasis, planeFromNormalPoint, planeKey, projectTo2D } from "./plane.js";
+import type { Point2 } from "./polygon-clip.js";
+import { convexHull2, polygonArea, polygonCentroid, sutherlandHodgman } from "./polygon-clip.js";
+import { triangleNormalRaw } from "./triangle.js";
+import type { Vec3 } from "./types.js";
+import { cross3, dot3, length3, normalize3 } from "./vec3.js";
+
+export interface SharedFaceCluster {
+  readonly kind: "surface" | "line" | "point";
+  /** Anchoring plane (for surface) or line (for line/point, where direction is the line dir). */
+  readonly plane?: Plane;
+  /** World-space centroid of the contact. */
+  readonly centroid: Vec3;
+  /** Outward normal (surface) or line direction (line/point). */
+  readonly normal: Vec3;
+  /** Shared-face area in m² (surface only — 0 otherwise). */
+  readonly area_m2: number;
+  /** Shared-line length in m (line only — 0 otherwise). */
+  readonly length_m: number;
+  /** Narrowest dimension of the contact patch in m. Distinguishes a broad
+   *  face (layered wall) from a thin bearing strip / cap. Length for a line
+   *  cluster is carried by `length_m`, so its `spanMin` is 0. */
+  readonly spanMin: number;
+  /** Widest dimension (diameter) of the contact patch in m. */
+  readonly spanMax: number;
+  /** Boundary polygon (3D) for surface contacts. Segment endpoints for line contacts. Empty for point. */
+  readonly boundary: readonly Vec3[];
+  /** Contributing triangle pairs. */
+  readonly pairs: readonly TrianglePair[];
+}
+
+export interface SharedFaceOptions {
+  /** Absolute tolerance for plane coincidence (unit: model-native length). Default 1e-3. */
+  readonly planeDistSnap?: number;
+  /** Angular snap for plane normal hashing (unitless, ~1 − cos). Default 1e-3. */
+  readonly planeAngleSnap?: number;
+  /** Area (m²) threshold: ≥ surface. Default 0.01. */
+  readonly surfaceAreaM2?: number;
+  /** Area (m²) below which a contact may still be line or point. Default 0.001. */
+  readonly pointAreaM2?: number;
+  /** Length (m) threshold: ≥ line. Default 0.05. */
+  readonly lineLengthM?: number;
+  /** Snap used when hashing intersection-line direction + base point. Default 1e-3. */
+  readonly lineSnap?: number;
+}
+
+export function clusterSharedFaces(
+  pairs: readonly TrianglePair[],
+  opts: SharedFaceOptions = {},
+): SharedFaceCluster[] {
+  const planeDistSnap = opts.planeDistSnap ?? 1e-3;
+  const planeAngleSnap = opts.planeAngleSnap ?? 1e-3;
+  const lineSnap = opts.lineSnap ?? 1e-3;
+  const surfaceAreaM2 = opts.surfaceAreaM2 ?? 0.01;
+  const pointAreaM2 = opts.pointAreaM2 ?? 0.001;
+  const lineLengthM = opts.lineLengthM ?? 0.05;
+
+  if (pairs.length === 0) return [];
+
+  // 1. Split into coplanar clusters and cross clusters.
+  const coplanarBuckets = new Map<string, { plane: Plane; pairs: TrianglePair[] }>();
+  const crossBuckets = new Map<string, { dir: Vec3; point: Vec3; pairs: TrianglePair[] }>();
+
+  for (const p of pairs) {
+    if (p.kind === "coplanar") {
+      const n = triangleNormalRaw(p.a);
+      const ln = length3(n);
+      if (ln === 0) continue;
+      const plane = planeFromNormalPoint(n, p.a.v0);
+      const key = planeKey(plane, planeAngleSnap, planeDistSnap);
+      const entry = coplanarBuckets.get(key) ?? { plane, pairs: [] };
+      entry.pairs.push(p);
+      coplanarBuckets.set(key, entry);
+    } else if (p.kind === "cross") {
+      const seg: Vec3 = [p.p1[0] - p.p0[0], p.p1[1] - p.p0[1], p.p1[2] - p.p0[2]];
+      const len = length3(seg);
+      if (len < 1e-12) continue;
+      const dir = normalize3(seg);
+      // Canonicalise direction so parallel + anti-parallel hash identically.
+      const canon = canonicaliseDir(dir);
+      const base = closestPointOnLineFromOrigin(p.p0, canon);
+      const key = `${quant(canon[0], lineSnap)}|${quant(canon[1], lineSnap)}|${quant(canon[2], lineSnap)}|${quant(base[0], lineSnap)}|${quant(base[1], lineSnap)}|${quant(base[2], lineSnap)}`;
+      const entry = crossBuckets.get(key) ?? { dir: canon, point: base, pairs: [] };
+      entry.pairs.push(p);
+      crossBuckets.set(key, entry);
+    }
+  }
+
+  const out: SharedFaceCluster[] = [];
+  for (const { plane, pairs: bucketPairs } of coplanarBuckets.values()) {
+    out.push(
+      classify(buildSurfaceCluster(plane, bucketPairs), surfaceAreaM2, pointAreaM2, lineLengthM),
+    );
+  }
+  for (const { dir, pairs: bucketPairs } of crossBuckets.values()) {
+    out.push(classify(buildLineCluster(dir, bucketPairs), surfaceAreaM2, pointAreaM2, lineLengthM));
+  }
+  return out;
+}
+
+// -------- surface / coplanar clusters --------
+
+function buildSurfaceCluster(
+  plane: Plane,
+  bucketPairs: TrianglePair[],
+): Omit<SharedFaceCluster, "kind"> {
+  const basis = planeBasis(plane);
+  let totalArea = 0;
+  const boundaryPts: Point2[] = [];
+
+  for (const p of bucketPairs) {
+    const pa = [projectTo2D(basis, p.a.v0), projectTo2D(basis, p.a.v1), projectTo2D(basis, p.a.v2)];
+    const pb = [projectTo2D(basis, p.b.v0), projectTo2D(basis, p.b.v1), projectTo2D(basis, p.b.v2)];
+    // Clip A against B; union of these clip polygons approximates the
+    // true shared face. For typical IFC meshes (tiled, non-overlapping)
+    // summed clip area ≤ true contact area ≤ the total area of A-triangles
+    // whose pair is in the bucket. We take the clipped sum.
+    const clipped = sutherlandHodgman(pa, pb);
+    if (clipped.length >= 3) {
+      totalArea += polygonArea(clipped);
+      boundaryPts.push(...clipped);
+    }
+  }
+
+  const boundary2d = boundaryPts.length >= 3 ? convexHull2(boundaryPts) : boundaryPts;
+  const centroid2d: Point2 =
+    boundary2d.length >= 3
+      ? polygonCentroid(boundary2d)
+      : boundary2d.length === 0
+        ? [0, 0]
+        : averagePoint2(boundary2d);
+  const centroid = liftTo3D(basis, centroid2d);
+  const boundary = boundary2d.map((p) => liftTo3D(basis, p));
+  const spans = polygonSpans(boundary2d);
+
+  return {
+    plane,
+    centroid,
+    normal: plane.normal,
+    area_m2: totalArea,
+    length_m: 0,
+    spanMin: spans.min,
+    spanMax: spans.max,
+    boundary,
+    pairs: bucketPairs,
+  };
+}
+
+/**
+ * Narrowest and widest dimensions of a convex 2D polygon (metres). `max` is
+ * the diameter (largest vertex-pair distance); `min` is the rotating-calipers
+ * width — the smallest gap between two parallel supporting lines. Degenerate
+ * (< 3 pts) polygons have width 0.
+ */
+function polygonSpans(pts: readonly Point2[]): { min: number; max: number } {
+  const n = pts.length;
+  if (n === 0) return { min: 0, max: 0 };
+  let max = 0;
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      const a = pts[i] as Point2;
+      const b = pts[j] as Point2;
+      const d = Math.hypot(a[0] - b[0], a[1] - b[1]);
+      if (d > max) max = d;
+    }
+  }
+  if (n < 3) return { min: 0, max };
+  let min = Number.POSITIVE_INFINITY;
+  for (let i = 0; i < n; i++) {
+    const a = pts[i] as Point2;
+    const b = pts[(i + 1) % n] as Point2;
+    const ex = b[0] - a[0];
+    const ey = b[1] - a[1];
+    const elen = Math.hypot(ex, ey);
+    if (elen < 1e-12) continue;
+    const nx = -ey / elen;
+    const ny = ex / elen;
+    let lo = Number.POSITIVE_INFINITY;
+    let hi = Number.NEGATIVE_INFINITY;
+    for (const p of pts) {
+      const d = (p[0] - a[0]) * nx + (p[1] - a[1]) * ny;
+      if (d < lo) lo = d;
+      if (d > hi) hi = d;
+    }
+    const width = hi - lo;
+    if (width < min) min = width;
+  }
+  return { min: Number.isFinite(min) ? min : 0, max };
+}
+
+// -------- line / cross clusters --------
+
+function buildLineCluster(dir: Vec3, bucketPairs: TrianglePair[]): Omit<SharedFaceCluster, "kind"> {
+  // Project every segment onto the line direction to get 1D intervals,
+  // union them, sum to get length.
+  const intervals: Array<[number, number]> = [];
+  let refPoint: Vec3 | null = null;
+
+  for (const p of bucketPairs) {
+    if (p.kind !== "cross") continue;
+    if (!refPoint) refPoint = p.p0;
+    const t0 = projectOnto(p.p0, refPoint, dir);
+    const t1 = projectOnto(p.p1, refPoint, dir);
+    intervals.push([Math.min(t0, t1), Math.max(t0, t1)]);
+  }
+  if (!refPoint || intervals.length === 0) {
+    return {
+      centroid: [0, 0, 0],
+      normal: dir,
+      area_m2: 0,
+      length_m: 0,
+      spanMin: 0,
+      spanMax: 0,
+      boundary: [],
+      pairs: bucketPairs,
+    };
+  }
+
+  intervals.sort((a, b) => a[0] - b[0]);
+  const merged: Array<[number, number]> = [];
+  for (const iv of intervals) {
+    if (merged.length === 0) {
+      merged.push([iv[0], iv[1]]);
+      continue;
+    }
+    const last = merged[merged.length - 1] as [number, number];
+    if (iv[0] <= last[1]) last[1] = Math.max(last[1], iv[1]);
+    else merged.push([iv[0], iv[1]]);
+  }
+  const length = merged.reduce((s, iv) => s + (iv[1] - iv[0]), 0);
+
+  // Pick the union's overall min/max as the line's centroid basis.
+  const tMin = (merged[0] as [number, number])[0];
+  const tMax = (merged[merged.length - 1] as [number, number])[1];
+  const centroidT = (tMin + tMax) / 2;
+  const centroid: Vec3 = [
+    refPoint[0] + dir[0] * centroidT,
+    refPoint[1] + dir[1] * centroidT,
+    refPoint[2] + dir[2] * centroidT,
+  ];
+  const boundary: Vec3[] = [
+    [refPoint[0] + dir[0] * tMin, refPoint[1] + dir[1] * tMin, refPoint[2] + dir[2] * tMin],
+    [refPoint[0] + dir[0] * tMax, refPoint[1] + dir[1] * tMax, refPoint[2] + dir[2] * tMax],
+  ];
+
+  return {
+    centroid,
+    normal: dir,
+    area_m2: 0,
+    length_m: length,
+    spanMin: 0,
+    spanMax: length,
+    boundary,
+    pairs: bucketPairs,
+  };
+}
+
+// -------- helpers --------
+
+function classify(
+  base: Omit<SharedFaceCluster, "kind">,
+  surfaceAreaM2: number,
+  pointAreaM2: number,
+  lineLengthM: number,
+): SharedFaceCluster {
+  if (base.area_m2 >= surfaceAreaM2) return { ...base, kind: "surface" };
+  if (base.length_m >= lineLengthM) return { ...base, kind: "line" };
+  if (base.area_m2 >= pointAreaM2) return { ...base, kind: "line" };
+  return { ...base, kind: "point" };
+}
+
+function canonicaliseDir(v: Vec3): Vec3 {
+  // Flip so the first significant component is positive.
+  if (Math.abs(v[0]) > 1e-9) return v[0] > 0 ? v : [-v[0], -v[1], -v[2]];
+  if (Math.abs(v[1]) > 1e-9) return v[1] > 0 ? v : [-v[0], -v[1], -v[2]];
+  return v[2] > 0 ? v : [-v[0], -v[1], -v[2]];
+}
+
+function closestPointOnLineFromOrigin(point: Vec3, dir: Vec3): Vec3 {
+  const t = dot3(point, dir);
+  return [point[0] - dir[0] * t, point[1] - dir[1] * t, point[2] - dir[2] * t];
+}
+
+function projectOnto(point: Vec3, refPoint: Vec3, dir: Vec3): number {
+  return (
+    (point[0] - refPoint[0]) * dir[0] +
+    (point[1] - refPoint[1]) * dir[1] +
+    (point[2] - refPoint[2]) * dir[2]
+  );
+}
+
+function quant(x: number, snap: number): number {
+  return Math.round(x / snap);
+}
+
+function averagePoint2(pts: readonly Point2[]): Point2 {
+  if (pts.length === 0) return [0, 0];
+  let x = 0;
+  let y = 0;
+  for (const p of pts) {
+    x += p[0];
+    y += p[1];
+  }
+  return [x / pts.length, y / pts.length];
+}
+
+// keep symbol imports that downstream modules may re-export
+void cross3;

--- a/packages/clash/src/contact/tri-tri.ts
+++ b/packages/clash/src/contact/tri-tri.ts
@@ -1,0 +1,202 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Triangle-triangle overlap tests based on Tomas Möller,
+ * "A Fast Triangle-Triangle Intersection Test" (1997),
+ * extended to report both strict crossings (with a 3D intersection segment)
+ * and the coplanar-overlap case, which is the signal shared-face detection
+ * downstream actually cares about.
+ */
+
+import type { Triangle } from "./triangle.js";
+import { isDegenerate, triangleNormalRaw } from "./triangle.js";
+import type { Vec3 } from "./types.js";
+import { cross3, dot3, length3, lerp3, sub3 } from "./vec3.js";
+
+export type TriTriResult =
+  | { readonly kind: "none" }
+  | { readonly kind: "cross"; readonly p0: Vec3; readonly p1: Vec3 }
+  | { readonly kind: "coplanar" };
+
+/**
+ * Full Möller test.
+ *
+ * `planeEps` is the absolute tolerance on signed plane distance — distances
+ * with |d| / |N| ≤ planeEps are treated as zero (on-plane). Defaults to 1e-6
+ * in model-native units.
+ */
+export function triTriIntersect(a: Triangle, b: Triangle, planeEps = 1e-6): TriTriResult {
+  if (isDegenerate(a) || isDegenerate(b)) return { kind: "none" };
+
+  // Plane of B
+  const N2 = triangleNormalRaw(b);
+  const ln2 = length3(N2);
+  const d2 = -dot3(N2, b.v0);
+  const dA0 = (dot3(N2, a.v0) + d2) / ln2;
+  const dA1 = (dot3(N2, a.v1) + d2) / ln2;
+  const dA2 = (dot3(N2, a.v2) + d2) / ln2;
+  const sA0 = signOf(dA0, planeEps);
+  const sA1 = signOf(dA1, planeEps);
+  const sA2 = signOf(dA2, planeEps);
+  if (sA0 === sA1 && sA1 === sA2 && sA0 !== 0) return { kind: "none" };
+
+  // Plane of A
+  const N1 = triangleNormalRaw(a);
+  const ln1 = length3(N1);
+  const d1 = -dot3(N1, a.v0);
+  const dB0 = (dot3(N1, b.v0) + d1) / ln1;
+  const dB1 = (dot3(N1, b.v1) + d1) / ln1;
+  const dB2 = (dot3(N1, b.v2) + d1) / ln1;
+  const sB0 = signOf(dB0, planeEps);
+  const sB1 = signOf(dB1, planeEps);
+  const sB2 = signOf(dB2, planeEps);
+  if (sB0 === sB1 && sB1 === sB2 && sB0 !== 0) return { kind: "none" };
+
+  // All-zero on either side → coplanar
+  if (sA0 === 0 && sA1 === 0 && sA2 === 0) return { kind: "coplanar" };
+  if (sB0 === 0 && sB1 === 0 && sB2 === 0) return { kind: "coplanar" };
+
+  // Chord endpoints: 3D points where each triangle's edges cross the opposite plane.
+  const chordA = triChord(a, dA0, dA1, dA2);
+  const chordB = triChord(b, dB0, dB1, dB2);
+  if (!chordA || !chordB) return { kind: "none" };
+
+  // Overlap along the common intersection line.
+  const D = cross3(N1, N2);
+  const dAxis = dominantAxis(D);
+  const ta0 = chordA[0][dAxis] as number;
+  const ta1 = chordA[1][dAxis] as number;
+  const tb0 = chordB[0][dAxis] as number;
+  const tb1 = chordB[1][dAxis] as number;
+  const aMin = Math.min(ta0, ta1);
+  const aMax = Math.max(ta0, ta1);
+  const bMin = Math.min(tb0, tb1);
+  const bMax = Math.max(tb0, tb1);
+  const oMin = Math.max(aMin, bMin);
+  const oMax = Math.min(aMax, bMax);
+  if (oMax < oMin - planeEps) return { kind: "none" };
+
+  // Reconstruct 3D endpoints of the overlap on the intersection line by
+  // picking the chord whose parameter interval matches the overlap.
+  const p0 = pointAtLineParam(chordA, chordB, dAxis, oMin);
+  const p1 = pointAtLineParam(chordA, chordB, dAxis, oMax);
+  return { kind: "cross", p0, p1 };
+}
+
+/**
+ * True when triangles lie in the same plane within `planeEps`.
+ * Both triangles must be non-degenerate.
+ */
+export function trianglesCoplanar(a: Triangle, b: Triangle, planeEps = 1e-6): boolean {
+  if (isDegenerate(a) || isDegenerate(b)) return false;
+  const N2 = triangleNormalRaw(b);
+  const d2 = -dot3(N2, b.v0);
+  const n2Len = length3(N2);
+  if (n2Len === 0) return false;
+  if (Math.abs(dot3(N2, a.v0) + d2) / n2Len > planeEps) return false;
+  if (Math.abs(dot3(N2, a.v1) + d2) / n2Len > planeEps) return false;
+  if (Math.abs(dot3(N2, a.v2) + d2) / n2Len > planeEps) return false;
+
+  const N1 = triangleNormalRaw(a);
+  const d1 = -dot3(N1, a.v0);
+  const n1Len = length3(N1);
+  if (n1Len === 0) return false;
+  if (Math.abs(dot3(N1, b.v0) + d1) / n1Len > planeEps) return false;
+  if (Math.abs(dot3(N1, b.v1) + d1) / n1Len > planeEps) return false;
+  if (Math.abs(dot3(N1, b.v2) + d1) / n1Len > planeEps) return false;
+
+  return true;
+}
+
+/** Signed distance (unit-normalised) from point `p` to triangle's plane. */
+export function signedDistanceToPlane(t: Triangle, p: Vec3): number {
+  const n = triangleNormalRaw(t);
+  const ln = length3(n);
+  if (ln === 0) return 0;
+  const d = -dot3(n, t.v0);
+  return (dot3(n, p) + d) / ln;
+}
+
+function signOf(x: number, eps: number): -1 | 0 | 1 {
+  if (x > eps) return 1;
+  if (x < -eps) return -1;
+  return 0;
+}
+
+function dominantAxis(v: Vec3): 0 | 1 | 2 {
+  const ax = Math.abs(v[0]);
+  const ay = Math.abs(v[1]);
+  const az = Math.abs(v[2]);
+  if (ax >= ay && ax >= az) return 0;
+  if (ay >= az) return 1;
+  return 2;
+}
+
+/** Intersection point of segment `p→q` with a plane, given signed distances `dp,dq` (opposite signs). */
+function edgePlane(p: Vec3, q: Vec3, dp: number, dq: number): Vec3 {
+  const t = dp / (dp - dq);
+  return lerp3(p, q, t);
+}
+
+/** Two 3D points where triangle's edges cross the opposite plane. */
+function triChord(tri: Triangle, d0: number, d1: number, d2: number): readonly [Vec3, Vec3] | null {
+  const pts: Vec3[] = [];
+  // Count crossings by edge
+  if ((d0 > 0 && d1 < 0) || (d0 < 0 && d1 > 0)) pts.push(edgePlane(tri.v0, tri.v1, d0, d1));
+  if ((d1 > 0 && d2 < 0) || (d1 < 0 && d2 > 0)) pts.push(edgePlane(tri.v1, tri.v2, d1, d2));
+  if ((d2 > 0 && d0 < 0) || (d2 < 0 && d0 > 0)) pts.push(edgePlane(tri.v2, tri.v0, d2, d0));
+  // On-plane vertices contribute themselves once
+  if (d0 === 0) pts.push(tri.v0);
+  if (d1 === 0) pts.push(tri.v1);
+  if (d2 === 0) pts.push(tri.v2);
+  if (pts.length < 2) return null;
+  const first = pts[0] as Vec3;
+  const last = pts[pts.length - 1] as Vec3;
+  return [first, last];
+}
+
+/**
+ * Given two chord segments on the same line, parametrised by their
+ * dominant-axis coordinate, return the 3D point whose dominant-axis
+ * coordinate is `t`. We look up the chord whose interval contains `t`
+ * (or the closer one) and lerp along it in 3D.
+ */
+function pointAtLineParam(
+  chordA: readonly [Vec3, Vec3],
+  chordB: readonly [Vec3, Vec3],
+  axis: 0 | 1 | 2,
+  t: number,
+): Vec3 {
+  // Prefer chord A unless B clearly contains t better.
+  const ta0 = chordA[0][axis] as number;
+  const ta1 = chordA[1][axis] as number;
+  const tb0 = chordB[0][axis] as number;
+  const tb1 = chordB[1][axis] as number;
+  const aMin = Math.min(ta0, ta1);
+  const aMax = Math.max(ta0, ta1);
+  const bMin = Math.min(tb0, tb1);
+  const bMax = Math.max(tb0, tb1);
+  const aContains = t >= aMin - 1e-12 && t <= aMax + 1e-12;
+  const bContains = t >= bMin - 1e-12 && t <= bMax + 1e-12;
+  if (aContains) return lerpChord(chordA, axis, t);
+  if (bContains) return lerpChord(chordB, axis, t);
+  // numerical fallback — pick whichever is closer
+  const distA = Math.min(Math.abs(t - aMin), Math.abs(t - aMax));
+  const distB = Math.min(Math.abs(t - bMin), Math.abs(t - bMax));
+  return distA <= distB ? lerpChord(chordA, axis, t) : lerpChord(chordB, axis, t);
+}
+
+function lerpChord(chord: readonly [Vec3, Vec3], axis: 0 | 1 | 2, t: number): Vec3 {
+  const a = chord[0][axis] as number;
+  const b = chord[1][axis] as number;
+  const denom = b - a;
+  if (Math.abs(denom) < 1e-15) return chord[0];
+  const u = (t - a) / denom;
+  return lerp3(chord[0], chord[1], u);
+}
+
+// Keep import of sub3 so bundlers don't eagerly tree-shake indirect users;
+// triangleNormalRaw uses it transitively.
+void sub3;

--- a/packages/clash/src/contact/triangle.ts
+++ b/packages/clash/src/contact/triangle.ts
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { AABB, Mesh, Vec3 } from "./types.js";
+import { cross3, length3, sub3 } from "./vec3.js";
+
+/** Triangle as three world-space vertices. */
+export interface Triangle {
+  readonly v0: Vec3;
+  readonly v1: Vec3;
+  readonly v2: Vec3;
+}
+
+/** Read the `triIndex`-th triangle from a mesh. */
+export function triangleAt(mesh: Mesh, triIndex: number): Triangle {
+  const base = triIndex * 3;
+  const i0 = mesh.indices[base] as number;
+  const i1 = mesh.indices[base + 1] as number;
+  const i2 = mesh.indices[base + 2] as number;
+  return {
+    v0: readVertex(mesh.positions, i0),
+    v1: readVertex(mesh.positions, i1),
+    v2: readVertex(mesh.positions, i2),
+  };
+}
+
+function readVertex(positions: ArrayLike<number>, index: number): Vec3 {
+  const b = index * 3;
+  return [positions[b] as number, positions[b + 1] as number, positions[b + 2] as number];
+}
+
+/** Total triangle count in a mesh. */
+export function triangleCount(mesh: Mesh): number {
+  return mesh.indices.length / 3;
+}
+
+/** Unnormalised triangle normal = (v1-v0) × (v2-v0). Useful as a plane direction. */
+export function triangleNormalRaw(t: Triangle): Vec3 {
+  return cross3(sub3(t.v1, t.v0), sub3(t.v2, t.v0));
+}
+
+/** Triangle area (geometric). */
+export function triangleArea(t: Triangle): number {
+  return length3(triangleNormalRaw(t)) / 2;
+}
+
+/** Triangle centroid. */
+export function triangleCentroid(t: Triangle): Vec3 {
+  return [
+    (t.v0[0] + t.v1[0] + t.v2[0]) / 3,
+    (t.v0[1] + t.v1[1] + t.v2[1]) / 3,
+    (t.v0[2] + t.v1[2] + t.v2[2]) / 3,
+  ];
+}
+
+/** Tight AABB of a triangle. */
+export function triangleAabb(t: Triangle): AABB {
+  return {
+    min: [
+      Math.min(t.v0[0], t.v1[0], t.v2[0]),
+      Math.min(t.v0[1], t.v1[1], t.v2[1]),
+      Math.min(t.v0[2], t.v1[2], t.v2[2]),
+    ],
+    max: [
+      Math.max(t.v0[0], t.v1[0], t.v2[0]),
+      Math.max(t.v0[1], t.v1[1], t.v2[1]),
+      Math.max(t.v0[2], t.v1[2], t.v2[2]),
+    ],
+  };
+}
+
+/** True when the triangle is degenerate (zero area within tolerance). */
+export function isDegenerate(t: Triangle, eps = 1e-12): boolean {
+  return length3(triangleNormalRaw(t)) <= eps;
+}

--- a/packages/clash/src/contact/types.ts
+++ b/packages/clash/src/contact/types.ts
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Core geometric and identity types for connection detection.
+ *
+ * IDs are opaque strings. In an ifc-lite integration they'd be
+ * federation-aware GlobalIds, but this package treats them as
+ * strings so it stays independent of the viewer.
+ */
+
+export type Vec3 = readonly [number, number, number];
+
+/** Axis-aligned bounding box in world coordinates. */
+export interface AABB {
+  readonly min: Vec3;
+  readonly max: Vec3;
+}
+
+/** An entity's bounds, keyed by an opaque id. */
+export interface MeshBounds {
+  readonly id: string;
+  readonly aabb: AABB;
+}
+
+/** Triangulated mesh in world coordinates (Z-up, matching IFC). */
+export interface Mesh {
+  readonly id: string;
+  /** Flat array of positions, length = 3 * vertexCount. */
+  readonly positions: Float32Array | Float64Array;
+  /** Flat array of triangle indices, length = 3 * triangleCount. */
+  readonly indices: Uint32Array;
+}
+
+/** Unordered pair of ids, canonicalised to (min, max) lexicographically. */
+export type IdPair = readonly [string, string];
+
+/** Classification types emitted by the shared-face pipeline. */
+export type ConnectionType = "point" | "line" | "surface";
+
+/** Reference type for an element's buildup origin. */
+export type ReferenceType = "outer_face" | "center" | "upper_face";

--- a/packages/clash/src/contact/vec3.ts
+++ b/packages/clash/src/contact/vec3.ts
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { Vec3 } from "./types.js";
+
+export const sub3 = (a: Vec3, b: Vec3): Vec3 => [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+export const add3 = (a: Vec3, b: Vec3): Vec3 => [a[0] + b[0], a[1] + b[1], a[2] + b[2]];
+export const scale3 = (a: Vec3, s: number): Vec3 => [a[0] * s, a[1] * s, a[2] * s];
+export const dot3 = (a: Vec3, b: Vec3): number => a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+export const cross3 = (a: Vec3, b: Vec3): Vec3 => [
+  a[1] * b[2] - a[2] * b[1],
+  a[2] * b[0] - a[0] * b[2],
+  a[0] * b[1] - a[1] * b[0],
+];
+export const length3 = (a: Vec3): number => Math.sqrt(dot3(a, a));
+export const normalize3 = (a: Vec3): Vec3 => {
+  const n = length3(a);
+  if (n === 0) return [0, 0, 0];
+  return [a[0] / n, a[1] / n, a[2] / n];
+};
+export const lerp3 = (a: Vec3, b: Vec3, t: number): Vec3 => [
+  a[0] + (b[0] - a[0]) * t,
+  a[1] + (b[1] - a[1]) * t,
+  a[2] + (b[2] - a[2]) * t,
+];
+
+/** True when vectors are numerically equal within absolute tolerance. */
+export const near3 = (a: Vec3, b: Vec3, eps = 1e-9): boolean =>
+  Math.abs(a[0] - b[0]) <= eps && Math.abs(a[1] - b[1]) <= eps && Math.abs(a[2] - b[2]) <= eps;
+
+/**
+ * Anti-parallel within angular tolerance: `normalize(a) · normalize(b) < -cos(angleDeg)`.
+ * Both vectors must be non-zero; a zero-length input returns false.
+ */
+export function antiParallel(a: Vec3, b: Vec3, angleDeg = 1): boolean {
+  const la = length3(a);
+  const lb = length3(b);
+  if (la === 0 || lb === 0) return false;
+  const cosA = Math.cos((angleDeg * Math.PI) / 180);
+  const d = (a[0] * b[0] + a[1] * b[1] + a[2] * b[2]) / (la * lb);
+  return d <= -cosA;
+}
+
+/** Parallel (same direction) within angular tolerance. */
+export function parallel(a: Vec3, b: Vec3, angleDeg = 1): boolean {
+  const la = length3(a);
+  const lb = length3(b);
+  if (la === 0 || lb === 0) return false;
+  const cosA = Math.cos((angleDeg * Math.PI) / 180);
+  const d = (a[0] * b[0] + a[1] * b[1] + a[2] * b[2]) / (la * lb);
+  return d >= cosA;
+}

--- a/packages/clash/src/differential.test.ts
+++ b/packages/clash/src/differential.test.ts
@@ -143,6 +143,14 @@ function assertParity(a: ClashResult, b: ClashResult): void {
     for (let i = 0; i < 3; i += 1) {
       expect(Math.abs(y.point[i] - x.point[i])).toBeLessThan(EPS);
     }
+    // Tight-contact bounds must agree across backends too (#1402 Bug B), not just
+    // count/status/point — otherwise a bounds regression in one kernel slips by.
+    if (x.bounds && y.bounds) {
+      for (let i = 0; i < 3; i += 1) {
+        expect(Math.abs(y.bounds.min[i] - x.bounds.min[i])).toBeLessThan(EPS);
+        expect(Math.abs(y.bounds.max[i] - x.bounds.max[i])).toBeLessThan(EPS);
+      }
+    }
   }
 }
 
@@ -239,6 +247,18 @@ describe('differential: WASM kernel === TS kernel', () => {
     const els = [
       boxHxyz('A', 'IfcWall', [0, 0, 0], [5, 0.5, 0.5]),
       boxHxyz('B', 'IfcDuctSegment', [0, 0, 0], [0.5, 5, 0.5]),
+    ];
+    const n = await bothAgree(els, [{ id: 'r', name: 'r', a: 'IfcWall', b: 'IfcDuct*', mode: 'hard' }]);
+    expect(n).toBe(1);
+  });
+
+  it('agrees on unequal-length aligned overlap (overlap-centre probe) (#1362)', async () => {
+    // Long bar x[-5,5] and short bar x[4.9,5.9] sharing y/z extents: the centroid
+    // midpoint falls outside the short bar, so both kernels must rely on the
+    // AABB-overlap-centre probe and agree it is a hard clash.
+    const els = [
+      boxHxyz('A', 'IfcWall', [0, 0, 0], [5, 0.5, 0.5]),
+      boxHxyz('B', 'IfcDuctSegment', [5.4, 0, 0], [0.5, 0.5, 0.5]),
     ];
     const n = await bothAgree(els, [{ id: 'r', name: 'r', a: 'IfcWall', b: 'IfcDuct*', mode: 'hard' }]);
     expect(n).toBe(1);

--- a/packages/clash/src/differential.test.ts
+++ b/packages/clash/src/differential.test.ts
@@ -52,6 +52,53 @@ function box(key: string, tag: string, center: Vec3, size = 1): ClashElement {
   };
 }
 
+const BOX_CORNER_ORDER: ReadonlyArray<readonly [number, number, number]> = [
+  [-1, -1, -1], [1, -1, -1], [1, 1, -1], [-1, 1, -1],
+  [-1, -1, 1], [1, -1, 1], [1, 1, 1], [-1, 1, 1],
+];
+const BOX_IDX = new Uint32Array([
+  0, 1, 2, 0, 2, 3, 4, 6, 5, 4, 7, 6, 0, 4, 5, 0, 5, 1,
+  1, 5, 6, 1, 6, 2, 2, 6, 7, 2, 7, 3, 3, 7, 4, 3, 4, 0,
+]);
+
+/** Box element with per-axis half-extents (world positions, no transform). */
+function boxHxyz(key: string, tag: string, center: Vec3, half: Vec3): ClashElement {
+  const v: number[] = [];
+  let min: Vec3 = [Infinity, Infinity, Infinity];
+  let max: Vec3 = [-Infinity, -Infinity, -Infinity];
+  for (const [sx, sy, sz] of BOX_CORNER_ORDER) {
+    const p: Vec3 = [center[0] + sx * half[0], center[1] + sy * half[1], center[2] + sz * half[2]];
+    v.push(...p);
+    for (let a = 0; a < 3; a += 1) { if (p[a] < min[a]) min[a] = p[a]; if (p[a] > max[a]) max[a] = p[a]; }
+  }
+  return { key, ref: refCounter++, model: 'm', tag, positions: new Float32Array(v), indices: BOX_IDX, bounds: { min, max } };
+}
+
+const PRISM_IDX = new Uint32Array([
+  0, 1, 2, 3, 4, 5, 0, 1, 4, 0, 4, 3, 1, 2, 5, 1, 5, 4, 2, 0, 3, 2, 3, 5,
+]);
+
+/** Closed triangular prism: footprint (XY) extruded between z0 and z1. */
+function triPrism(
+  key: string,
+  tag: string,
+  footprint: [[number, number], [number, number], [number, number]],
+  z0: number,
+  z1: number,
+): ClashElement {
+  const [p0, p1, p2] = footprint;
+  const v = [
+    p0[0], p0[1], z0, p1[0], p1[1], z0, p2[0], p2[1], z0,
+    p0[0], p0[1], z1, p1[0], p1[1], z1, p2[0], p2[1], z1,
+  ];
+  let min: Vec3 = [Infinity, Infinity, Infinity];
+  let max: Vec3 = [-Infinity, -Infinity, -Infinity];
+  for (let i = 0; i < v.length; i += 3) {
+    for (let a = 0; a < 3; a += 1) { const c = v[i + a]; if (c < min[a]) min[a] = c; if (c > max[a]) max[a] = c; }
+  }
+  return { key, ref: refCounter++, model: 'm', tag, positions: new Float32Array(v), indices: PRISM_IDX, bounds: { min, max } };
+}
+
 function applyMat4Pt(m: Mat4, x: number, y: number, z: number): Vec3 {
   return [
     m[0] * x + m[4] * y + m[8] * z + m[12],
@@ -168,6 +215,33 @@ describe('differential: WASM kernel === TS kernel', () => {
     const els = [box('A', 'IfcWall', [0, 0, 0], 1), box('B', 'IfcDuctSegment', [20, 0, 0], 1)];
     const n = await bothAgree(els, [{ id: 'r', name: 'r', a: 'IfcWall', b: 'IfcDuct*', mode: 'hard' }]);
     expect(n).toBe(0);
+  });
+
+  it('agrees that skewed members sharing only a face are not a hard clash (#1362 Bug A)', async () => {
+    const els = [
+      triPrism('A', 'IfcWall', [[0, 0], [2, 0], [0, 2]], 0, 1),
+      triPrism('B', 'IfcDuctSegment', [[2, 0], [0, 2], [5, 5]], 0, 1),
+    ];
+    const n = await bothAgree(els, [{ id: 'r', name: 'r', a: 'IfcWall', b: 'IfcDuct*', mode: 'hard' }]);
+    expect(n).toBe(0);
+  });
+
+  it('agrees that members that interpenetrate are a hard clash (#1362 recall)', async () => {
+    const els = [
+      triPrism('A', 'IfcWall', [[0, 0], [2, 0], [0, 2]], 0, 1),
+      boxHxyz('B', 'IfcDuctSegment', [1, 1, 0.5], [0.5, 0.5, 0.5]),
+    ];
+    const n = await bothAgree(els, [{ id: 'r', name: 'r', a: 'IfcWall', b: 'IfcDuct*', mode: 'hard' }]);
+    expect(n).toBe(1);
+  });
+
+  it('agrees on a genuine crossing (tight-contact path) (#1402 Bug B)', async () => {
+    const els = [
+      boxHxyz('A', 'IfcWall', [0, 0, 0], [5, 0.5, 0.5]),
+      boxHxyz('B', 'IfcDuctSegment', [0, 0, 0], [0.5, 5, 0.5]),
+    ];
+    const n = await bothAgree(els, [{ id: 'r', name: 'r', a: 'IfcWall', b: 'IfcDuct*', mode: 'hard' }]);
+    expect(n).toBe(1);
   });
 
   it('agrees on transformed elements (f32-quantized world coords)', async () => {

--- a/packages/clash/src/differential.test.ts
+++ b/packages/clash/src/differential.test.ts
@@ -145,6 +145,9 @@ function assertParity(a: ClashResult, b: ClashResult): void {
     }
     // Tight-contact bounds must agree across backends too (#1402 Bug B), not just
     // count/status/point — otherwise a bounds regression in one kernel slips by.
+    // Both kernels must also agree on whether bounds exist at all, so a one-sided
+    // bounds regression cannot hide behind a presence check.
+    expect(Boolean(y.bounds), `clash ${x.id} bounds presence must match`).toBe(Boolean(x.bounds));
     if (x.bounds && y.bounds) {
       for (let i = 0; i < 3; i += 1) {
         expect(Math.abs(y.bounds.min[i] - x.bounds.min[i])).toBeLessThan(EPS);

--- a/packages/clash/src/engine-ts/engine.test.ts
+++ b/packages/clash/src/engine-ts/engine.test.ts
@@ -47,6 +47,53 @@ function boxElement(key: string, tag: string, center: Vec3, size = 1): ClashElem
   };
 }
 
+/** Box corners in the canonical order, given a centre and per-axis half-extents. */
+function boxCorners(cx: number, cy: number, cz: number, hx: number, hy: number, hz: number): Vec3[] {
+  return [
+    [cx - hx, cy - hy, cz - hz],
+    [cx + hx, cy - hy, cz - hz],
+    [cx + hx, cy + hy, cz - hz],
+    [cx - hx, cy + hy, cz - hz],
+    [cx - hx, cy - hy, cz + hz],
+    [cx + hx, cy - hy, cz + hz],
+    [cx + hx, cy + hy, cz + hz],
+    [cx - hx, cy + hy, cz + hz],
+  ];
+}
+
+const BOX_INDICES = new Uint32Array([
+  0, 1, 2, 0, 2, 3, 4, 6, 5, 4, 7, 6, 0, 4, 5, 0, 5, 1,
+  1, 5, 6, 1, 6, 2, 2, 6, 7, 2, 7, 3, 3, 7, 4, 3, 4, 0,
+]);
+
+/** Box element with independent per-axis half-extents (for crossing bars). */
+function boxElementHxyz(key: string, tag: string, center: Vec3, half: Vec3): ClashElement {
+  const corners = boxCorners(center[0], center[1], center[2], half[0], half[1], half[2]);
+  const positions = new Float32Array(corners.flat());
+  return { key, ref: nextRef++, model: 'm', tag, bounds: fromPositions(positions), positions, indices: BOX_INDICES };
+}
+
+const PRISM_INDICES = new Uint32Array([
+  0, 1, 2, 3, 4, 5, 0, 1, 4, 0, 4, 3, 1, 2, 5, 1, 5, 4, 2, 0, 3, 2, 3, 5,
+]);
+
+/** Closed triangular prism: `footprint` (XY) extruded between z0 and z1. */
+function triPrismElement(
+  key: string,
+  tag: string,
+  footprint: [Vec3, Vec3, Vec3] | [[number, number], [number, number], [number, number]],
+  z0: number,
+  z1: number,
+): ClashElement {
+  const [p0, p1, p2] = footprint as [[number, number], [number, number], [number, number]];
+  const v = [
+    p0[0], p0[1], z0, p1[0], p1[1], z0, p2[0], p2[1], z0,
+    p0[0], p0[1], z1, p1[0], p1[1], z1, p2[0], p2[1], z1,
+  ];
+  const positions = new Float32Array(v);
+  return { key, ref: nextRef++, model: 'm', tag, bounds: fromPositions(positions), positions, indices: PRISM_INDICES };
+}
+
 const engine = createClashEngine({ backend: 'ts' });
 const hard = (over: Partial<ClashRule> = {}): ClashRule => ({
   id: 'r',
@@ -158,5 +205,51 @@ describe('TsClashEngine', () => {
     const controller = new AbortController();
     controller.abort();
     await expect(engine.run(elements, [hard()], { signal: controller.signal })).rejects.toThrow();
+  });
+});
+
+describe('TsClashEngine: false-positive + bounds regressions (#1362 / #1402)', () => {
+  const wallDuct = (over: Partial<ClashRule> = {}): ClashRule => ({
+    id: 'r', name: 'r', a: 'IfcWall', b: 'IfcDuct', mode: 'hard', ...over,
+  });
+
+  it('does not report a hard clash for skewed members that only share a face (Bug A)', async () => {
+    // Two wedges meeting flush at a slanted face: their axis-aligned bounds overlap
+    // fully, but the solids share NO volume. The old AABB-penetration proxy fired a
+    // false hard clash here.
+    const elements = [
+      triPrismElement('A', 'IfcWall', [[0, 0], [2, 0], [0, 2]], 0, 1),
+      triPrismElement('B', 'IfcDuct', [[2, 0], [0, 2], [5, 5]], 0, 1),
+    ];
+    const result = await engine.run(elements, [wallDuct()]);
+    expect(result.summary.total).toBe(0);
+  });
+
+  it('still reports a hard clash when members genuinely interpenetrate (Bug A recall)', async () => {
+    // Same wedge A, but a box that straddles the slanted face -> real shared volume.
+    const elements = [
+      triPrismElement('A', 'IfcWall', [[0, 0], [2, 0], [0, 2]], 0, 1),
+      boxElementHxyz('B', 'IfcDuct', [1, 1, 0.5], [0.5, 0.5, 0.5]),
+    ];
+    const result = await engine.run(elements, [wallDuct()]);
+    expect(result.summary.total).toBe(1);
+    expect(result.clashes[0].status).toBe('hard');
+  });
+
+  it('reports a tight contact box for a genuine crossing, not the element overlap (Bug B)', async () => {
+    // Perpendicular bars: A runs along X, B along Y, crossing near the origin.
+    const a = boxElementHxyz('A', 'IfcWall', [0, 0, 0], [5, 0.5, 0.5]);
+    const b = boxElementHxyz('B', 'IfcDuct', [0, 0, 0], [0.5, 5, 0.5]);
+    const result = await engine.run([a, b], [wallDuct()]);
+    expect(result.summary.total).toBe(1);
+    const { bounds } = result.clashes[0];
+    // Element-AABB overlap z-extent is 1.0 (both bars span z[-0.5,0.5]); the tight
+    // contact box must be strictly thinner in z.
+    expect(bounds.max[2] - bounds.min[2]).toBeLessThan(1.0);
+    // And it must stay within element A's bounds (the overlap is a subset of both).
+    for (let i = 0; i < 3; i += 1) {
+      expect(bounds.min[i]).toBeGreaterThanOrEqual(a.bounds.min[i] - 1e-6);
+      expect(bounds.max[i]).toBeLessThanOrEqual(a.bounds.max[i] + 1e-6);
+    }
   });
 });

--- a/packages/clash/src/engine-ts/engine.test.ts
+++ b/packages/clash/src/engine-ts/engine.test.ts
@@ -263,9 +263,9 @@ describe('TsClashEngine: false-positive + bounds regressions (#1362 / #1402)', (
     const result = await engine.run([a, b], [wallDuct()]);
     expect(result.summary.total).toBe(1);
     const { bounds } = result.clashes[0];
-    // Element-AABB overlap z-extent is 1.0 (both bars span z[-0.5,0.5]); the tight
-    // contact box must be strictly thinner in z.
-    expect(bounds.max[2] - bounds.min[2]).toBeLessThan(1.0);
+    // Tight along the long bar: A spans x[-5,5] (10 m), but the contact is only the
+    // local crossing (~B's 1 m width), so the box must NOT span A's full length.
+    expect(bounds.max[0] - bounds.min[0]).toBeLessThan(2.0);
     // And it must stay within the element-OVERLAP AABB on every axis, not just
     // element A: A is the long X bar, so an A-only check would still pass if the
     // box expanded across A's whole 10 m X span. The overlap is x[-0.5,0.5] (B's

--- a/packages/clash/src/engine-ts/engine.test.ts
+++ b/packages/clash/src/engine-ts/engine.test.ts
@@ -236,6 +236,18 @@ describe('TsClashEngine: false-positive + bounds regressions (#1362 / #1402)', (
     expect(result.clashes[0].status).toBe('hard');
   });
 
+  it('still reports a hard clash for unequal-length aligned members that overlap (Bug A recall #1455)', async () => {
+    // A long bar x[-5,5] and a short bar x[4.9,5.9] sharing y/z extents overlap by
+    // 0.1 m. The vertex-centroid midpoint (~x=2.7) lies outside the short bar, so a
+    // single centroid probe would drop this real clash; the overlap-centre probe
+    // keeps it.
+    const a = boxElementHxyz('A', 'IfcWall', [0, 0, 0], [5, 0.5, 0.5]);
+    const b = boxElementHxyz('B', 'IfcDuct', [5.4, 0, 0], [0.5, 0.5, 0.5]);
+    const result = await engine.run([a, b], [wallDuct()]);
+    expect(result.summary.total).toBe(1);
+    expect(result.clashes[0].status).toBe('hard');
+  });
+
   it('reports a tight contact box for a genuine crossing, not the element overlap (Bug B)', async () => {
     // Perpendicular bars: A runs along X, B along Y, crossing near the origin.
     const a = boxElementHxyz('A', 'IfcWall', [0, 0, 0], [5, 0.5, 0.5]);

--- a/packages/clash/src/engine-ts/engine.test.ts
+++ b/packages/clash/src/engine-ts/engine.test.ts
@@ -258,10 +258,15 @@ describe('TsClashEngine: false-positive + bounds regressions (#1362 / #1402)', (
     // Element-AABB overlap z-extent is 1.0 (both bars span z[-0.5,0.5]); the tight
     // contact box must be strictly thinner in z.
     expect(bounds.max[2] - bounds.min[2]).toBeLessThan(1.0);
-    // And it must stay within element A's bounds (the overlap is a subset of both).
+    // And it must stay within the element-OVERLAP AABB on every axis, not just
+    // element A: A is the long X bar, so an A-only check would still pass if the
+    // box expanded across A's whole 10 m X span. The overlap is x[-0.5,0.5] (B's
+    // width) on X, y[-0.5,0.5] (A's width) on Y, z[-0.5,0.5] on Z.
     for (let i = 0; i < 3; i += 1) {
-      expect(bounds.min[i]).toBeGreaterThanOrEqual(a.bounds.min[i] - 1e-6);
-      expect(bounds.max[i]).toBeLessThanOrEqual(a.bounds.max[i] + 1e-6);
+      const overlapMin = Math.max(a.bounds.min[i], b.bounds.min[i]);
+      const overlapMax = Math.min(a.bounds.max[i], b.bounds.max[i]);
+      expect(bounds.min[i]).toBeGreaterThanOrEqual(overlapMin - 1e-6);
+      expect(bounds.max[i]).toBeLessThanOrEqual(overlapMax + 1e-6);
     }
   });
 });

--- a/packages/clash/src/engine-ts/engine.test.ts
+++ b/packages/clash/src/engine-ts/engine.test.ts
@@ -115,6 +115,14 @@ describe('TsClashEngine', () => {
     expect(result.clashes[0].status).toBe('hard');
     expect(result.clashes[0].distance).toBeLessThan(0);
     expect(result.summary.byRule.r).toBe(1);
+    // The coplanar/flush overlap must report the real (non-degenerate) overlap
+    // region so it renders as a visible penetration box (#1402), not a zero-size
+    // box. Overlap of the two unit cubes offset 0.5 in x is 0.5 x 1 x 1.
+    const b = result.clashes[0].bounds;
+    expect(b.max[0] - b.min[0]).toBeGreaterThan(0.4);
+    expect(b.max[0] - b.min[0]).toBeLessThan(0.6);
+    expect(b.max[1] - b.min[1]).toBeGreaterThan(0.5);
+    expect(b.max[2] - b.min[2]).toBeGreaterThan(0.5);
   });
 
   it('reports no clash for separated elements in hard mode', async () => {

--- a/packages/clash/src/engine-ts/narrow.ts
+++ b/packages/clash/src/engine-ts/narrow.ts
@@ -120,7 +120,19 @@ export function testPair(
   let tN = 0;
   if (contactN > 0) { for (let i = 0; i < 3; i += 1) { if (cMin[i] < tMin[i]) tMin[i] = cMin[i]; if (cMax[i] > tMax[i]) tMax[i] = cMax[i]; } tN += 1; }
   if (ncN > 0) { for (let i = 0; i < 3; i += 1) { if (ncMin[i] < tMin[i]) tMin[i] = ncMin[i]; if (ncMax[i] > tMax[i]) tMax[i] = ncMax[i]; } tN += 1; }
-  const contactBounds = tN > 0 ? overlapBounds({ min: tMin, max: tMax }, overlap) : overlap;
+  // Clamp the contact AABB to the element overlap per-axis. (overlapBounds would
+  // degenerate a disjoint axis to a midpoint that can land OUTSIDE the overlap,
+  // breaking the "clamped to overlap" contract for the box.)
+  let contactBounds = overlap;
+  if (tN > 0) {
+    const cMinClamped: Vec3 = [0, 0, 0];
+    const cMaxClamped: Vec3 = [0, 0, 0];
+    for (let i = 0; i < 3; i += 1) {
+      cMinClamped[i] = Math.min(Math.max(tMin[i], overlap.min[i]), overlap.max[i]);
+      cMaxClamped[i] = Math.min(Math.max(tMax[i], overlap.min[i]), overlap.max[i]);
+    }
+    contactBounds = { min: cMinClamped, max: cMaxClamped };
+  }
 
   if (intersects) {
     const point: Vec3 = contactN > 0

--- a/packages/clash/src/engine-ts/narrow.ts
+++ b/packages/clash/src/engine-ts/narrow.ts
@@ -131,14 +131,21 @@ export function testPair(
   // all coplanar). AABB penetration ALONE is not enough: two skewed/abutting
   // members that merely share a face have overlapping AABBs yet no shared volume,
   // and the old proxy promoted that touch to a false hard clash (#1362). Confirm
-  // a real volume overlap first: the midpoint of the two vertex centroids lies in
-  // the shared interior for a genuine overlap, but on/outside the interface for a
-  // bare face touch — require it inside BOTH solids before reporting hard.
+  // a real shared volume first by probing for an interior point inside BOTH
+  // solids. Two probes are needed: the vertex-centroid midpoint sits inside a
+  // skewed straddling overlap, while the AABB-overlap centre covers an
+  // unequal-length aligned overlap (whose centroid midpoint can fall outside the
+  // shorter member). A bare face touch has no interior point common to both, so
+  // neither probe qualifies. Accept the pair if EITHER probe is inside both.
   if (minDist <= tolerance) {
     const gap = signedGap(elA.bounds, elB.bounds);
     if (gap < -tolerance) {
-      const probe = mid(triA.vertexCentroid(), triB.vertexCentroid());
-      if (triA.containsPoint(probe) && triB.containsPoint(probe)) {
+      const probeCentroid = mid(triA.vertexCentroid(), triB.vertexCentroid());
+      const probeOverlap = center(overlap);
+      if (
+        (triA.containsPoint(probeCentroid) && triB.containsPoint(probeCentroid)) ||
+        (triA.containsPoint(probeOverlap) && triB.containsPoint(probeOverlap))
+      ) {
         // Tight contact bounds (Bug B): the nearest-surface contact, not the
         // whole-element AABB overlap (meters wide for long/curved members).
         return {

--- a/packages/clash/src/engine-ts/narrow.ts
+++ b/packages/clash/src/engine-ts/narrow.ts
@@ -54,6 +54,13 @@ export function testPair(
   // than the whole-element AABB overlap (#1362 / #1402).
   const cMin: Vec3 = [Infinity, Infinity, Infinity];
   const cMax: Vec3 = [-Infinity, -Infinity, -Infinity];
+  // Near-contact AABB for coplanar/flush overlaps (no triangle crossing): the
+  // local region where surfaces actually touch, so the hard box is the contact
+  // patch (e.g. a wall corner) rather than the whole-element AABB intersection,
+  // which for angled members spans nearly the full member length (#1362/#1402).
+  const ncMin: Vec3 = [Infinity, Infinity, Infinity];
+  const ncMax: Vec3 = [-Infinity, -Infinity, -Infinity];
+  let ncN = 0;
   let minDist = Infinity;
   let closestA: Vec3 = elA.bounds.min as Vec3;
   let closestB: Vec3 = elB.bounds.min as Vec3;
@@ -76,13 +83,25 @@ export function testPair(
           if (c[i] < cMin[i]) cMin[i] = c[i];
           if (c[i] > cMax[i]) cMax[i] = c[i];
         }
-      } else if (!intersects) {
-        // Distance only matters while we still might be a clearance/touch case.
+      } else {
+        // Not a crossing: measure the gap (drives clearance/touch) and, when the
+        // pair is touching (within tolerance), accumulate it into the contact
+        // region. We do this even after a crossing was found, because coincident
+        // faces of flush members register as touches (not crossings) and carry
+        // most of the real contact area.
         const d = triTriDistance(s0, s1, s2, l0, l1, l2);
         if (d.dist < minDist) {
           minDist = d.dist;
           closestA = d.pA;
           closestB = d.pB;
+        }
+        if (d.dist <= tolerance) {
+          const cp = mid(d.pA, d.pB);
+          ncN += 1;
+          for (let i = 0; i < 3; i += 1) {
+            if (cp[i] < ncMin[i]) ncMin[i] = cp[i];
+            if (cp[i] > ncMax[i]) ncMax[i] = cp[i];
+          }
         }
       }
     }
@@ -90,17 +109,26 @@ export function testPair(
 
   const overlap = overlapBounds(elA.bounds, elB.bounds);
 
+  // Tight contact region: the union of the genuine triangle crossings (cMin/cMax)
+  // and the coplanar/flush touching pairs within tolerance (ncMin/ncMax), clamped
+  // to the element overlap. Crossings alone miss coincident faces (which register
+  // as touches, not crossings) so flush members reported only a partial, mis-
+  // placed patch; near-contacts alone miss angled crossings. Falls back to the
+  // overlap when neither was captured (#1362 / #1402).
+  const tMin: Vec3 = [Infinity, Infinity, Infinity];
+  const tMax: Vec3 = [-Infinity, -Infinity, -Infinity];
+  let tN = 0;
+  if (contactN > 0) { for (let i = 0; i < 3; i += 1) { if (cMin[i] < tMin[i]) tMin[i] = cMin[i]; if (cMax[i] > tMax[i]) tMax[i] = cMax[i]; } tN += 1; }
+  if (ncN > 0) { for (let i = 0; i < 3; i += 1) { if (ncMin[i] < tMin[i]) tMin[i] = ncMin[i]; if (ncMax[i] > tMax[i]) tMax[i] = ncMax[i]; } tN += 1; }
+  const contactBounds = tN > 0 ? overlapBounds({ min: tMin, max: tMax }, overlap) : overlap;
+
   if (intersects) {
     const point: Vec3 = contactN > 0
       ? [contactSumX / contactN, contactSumY / contactN, contactSumZ / contactN]
       : center(overlap);
-    // Tight contact AABB (Bug B): the box around the actual triangle crossings,
-    // clamped to the element overlap so it can never exceed it. Falls back to the
-    // overlap when (defensively) no contact point was recorded.
-    const bounds = contactN > 0 ? overlapBounds({ min: cMin, max: cMax }, overlap) : overlap;
     // Phase-0 penetration estimate from AABB overlap; exact depth lands in Rust.
     const penetration = Math.max(0, -signedGap(elA.bounds, elB.bounds));
-    return { status: 'hard', distance: -penetration, point, bounds };
+    return { status: 'hard', distance: -penetration, point, bounds: contactBounds };
   }
 
   // Fully-enclosed solid: no surface crossing, but one element's AABB is wholly
@@ -146,16 +174,15 @@ export function testPair(
         (triA.containsPoint(probeCentroid) && triB.containsPoint(probeCentroid)) ||
         (triA.containsPoint(probeOverlap) && triB.containsPoint(probeOverlap))
       ) {
-        // The shared volume of a coplanar/flush overlap IS the element-AABB
-        // intersection, and it is tight here: skewed false-touches were already
-        // suppressed above, so only genuine overlaps reach this point. (For a
-        // flush overlap the two nearest-surface points are near-coincident, so
-        // boxing them would yield a degenerate, invisible region box — #1402.)
+        // Report the tight contact region (the touching patch where the surfaces
+        // actually coincide), clamped to the element overlap — not the whole-
+        // element AABB intersection, which for angled members spans nearly the
+        // full member length and sits away from the real contact (#1362/#1402).
         return {
           status: 'hard',
           distance: gap,
           point: mid(closestA, closestB),
-          bounds: overlap,
+          bounds: contactBounds,
         };
       }
       // Only a face touch (no shared volume): fall through to the touch handling

--- a/packages/clash/src/engine-ts/narrow.ts
+++ b/packages/clash/src/engine-ts/narrow.ts
@@ -49,6 +49,11 @@ export function testPair(
   let contactSumY = 0;
   let contactSumZ = 0;
   let contactN = 0;
+  // Tight contact AABB: min/max of the per-pair contact points (the crossing
+  // representatives), so a hard verdict reports the local contact region rather
+  // than the whole-element AABB overlap (#1362 / #1402).
+  const cMin: Vec3 = [Infinity, Infinity, Infinity];
+  const cMax: Vec3 = [-Infinity, -Infinity, -Infinity];
   let minDist = Infinity;
   let closestA: Vec3 = elA.bounds.min as Vec3;
   let closestB: Vec3 = elB.bounds.min as Vec3;
@@ -67,6 +72,10 @@ export function testPair(
         contactSumY += c[1];
         contactSumZ += c[2];
         contactN += 1;
+        for (let i = 0; i < 3; i += 1) {
+          if (c[i] < cMin[i]) cMin[i] = c[i];
+          if (c[i] > cMax[i]) cMax[i] = c[i];
+        }
       } else if (!intersects) {
         // Distance only matters while we still might be a clearance/touch case.
         const d = triTriDistance(s0, s1, s2, l0, l1, l2);
@@ -85,9 +94,13 @@ export function testPair(
     const point: Vec3 = contactN > 0
       ? [contactSumX / contactN, contactSumY / contactN, contactSumZ / contactN]
       : center(overlap);
+    // Tight contact AABB (Bug B): the box around the actual triangle crossings,
+    // clamped to the element overlap so it can never exceed it. Falls back to the
+    // overlap when (defensively) no contact point was recorded.
+    const bounds = contactN > 0 ? overlapBounds({ min: cMin, max: cMax }, overlap) : overlap;
     // Phase-0 penetration estimate from AABB overlap; exact depth lands in Rust.
     const penetration = Math.max(0, -signedGap(elA.bounds, elB.bounds));
-    return { status: 'hard', distance: -penetration, point, bounds: overlap };
+    return { status: 'hard', distance: -penetration, point, bounds };
   }
 
   // Fully-enclosed solid: no surface crossing, but one element's AABB is wholly
@@ -113,13 +126,30 @@ export function testPair(
     return null;
   }
 
-  // Surfaces coincide/touch with no genuine crossing, but the volumes overlap
+  // Surfaces coincide/touch with no genuine crossing, but the AABBs penetrate
   // beyond tolerance (e.g. axis-aligned boxes, whose surface intersections are
-  // all coplanar) -> hard, via AABB penetration depth.
+  // all coplanar). AABB penetration ALONE is not enough: two skewed/abutting
+  // members that merely share a face have overlapping AABBs yet no shared volume,
+  // and the old proxy promoted that touch to a false hard clash (#1362). Confirm
+  // a real volume overlap first: the midpoint of the two vertex centroids lies in
+  // the shared interior for a genuine overlap, but on/outside the interface for a
+  // bare face touch — require it inside BOTH solids before reporting hard.
   if (minDist <= tolerance) {
     const gap = signedGap(elA.bounds, elB.bounds);
     if (gap < -tolerance) {
-      return { status: 'hard', distance: gap, point: center(overlap), bounds: overlap };
+      const probe = mid(triA.vertexCentroid(), triB.vertexCentroid());
+      if (triA.containsPoint(probe) && triB.containsPoint(probe)) {
+        // Tight contact bounds (Bug B): the nearest-surface contact, not the
+        // whole-element AABB overlap (meters wide for long/curved members).
+        return {
+          status: 'hard',
+          distance: gap,
+          point: mid(closestA, closestB),
+          bounds: boundsOfPoints(closestA, closestB),
+        };
+      }
+      // Only a face touch (no shared volume): fall through to the touch handling
+      // below, which suppresses it unless reportTouch is set.
     }
   }
 

--- a/packages/clash/src/engine-ts/narrow.ts
+++ b/packages/clash/src/engine-ts/narrow.ts
@@ -146,13 +146,16 @@ export function testPair(
         (triA.containsPoint(probeCentroid) && triB.containsPoint(probeCentroid)) ||
         (triA.containsPoint(probeOverlap) && triB.containsPoint(probeOverlap))
       ) {
-        // Tight contact bounds (Bug B): the nearest-surface contact, not the
-        // whole-element AABB overlap (meters wide for long/curved members).
+        // The shared volume of a coplanar/flush overlap IS the element-AABB
+        // intersection, and it is tight here: skewed false-touches were already
+        // suppressed above, so only genuine overlaps reach this point. (For a
+        // flush overlap the two nearest-surface points are near-coincident, so
+        // boxing them would yield a degenerate, invisible region box — #1402.)
         return {
           status: 'hard',
           distance: gap,
           point: mid(closestA, closestB),
-          bounds: boundsOfPoints(closestA, closestB),
+          bounds: overlap,
         };
       }
       // Only a face touch (no shared volume): fall through to the touch handling

--- a/packages/clash/src/engine-ts/tri-mesh.ts
+++ b/packages/clash/src/engine-ts/tri-mesh.ts
@@ -97,6 +97,30 @@ export class TriMesh {
   }
 
   /**
+   * Mean of every vertex (world-space, transform applied), summed in index
+   * order. A rigid-invariant interior probe for the volumetric-overlap check in
+   * the narrow phase: for a convex solid it is the centroid, and the midpoint of
+   * two solids' vertex centroids lands in their shared volume for a genuine
+   * overlap (but on/outside the interface for a bare face touch). Iterated in
+   * index order and summed in `f64` so it is bit-identical to the Rust
+   * `vertex_centroid`. Only called in the rare coplanar-overlap branch.
+   */
+  vertexCentroid(): Vec3 {
+    const n = Math.floor(this.positions.length / 3);
+    if (n === 0) return [0, 0, 0];
+    let sx = 0;
+    let sy = 0;
+    let sz = 0;
+    for (let i = 0; i < n; i += 1) {
+      const [x, y, z] = this.vertex(i);
+      sx += x;
+      sy += y;
+      sz += z;
+    }
+    return [sx / n, sy / n, sz / n];
+  }
+
+  /**
    * True when `p` is inside this closed mesh. Casts a fixed-direction ray and
    * counts forward crossings against every triangle (Möller–Trumbore,
    * double-sided so winding doesn't matter); an odd count means inside.

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -2878,6 +2878,27 @@ export class Renderer {
     }
 
     /**
+     * Draw the focused clash's CONTACT geometry as 3D line segments — the real
+     * shared-face polygon outlines / intersection lines, not the AABB box.
+     * `vertices` is a flat line-list (x,y,z per endpoint, 2 endpoints per
+     * segment) in world frame. Pass `null` to clear. Shares the clash-box line
+     * buffer, so only one of this / setClashOverlapBox is shown at a time.
+     */
+    setClashContactLines(
+        lines: { vertices: Float32Array; color: [number, number, number, number] } | null,
+    ): void {
+        if (!this.section2DOverlayRenderer) return;
+        if (!lines || lines.vertices.length === 0) {
+            this.section2DOverlayRenderer.clearClashBoxLines3D();
+            this.requestRender();
+            return;
+        }
+        this.section2DOverlayRenderer.setClashBoxLineColor(lines.color);
+        this.section2DOverlayRenderer.uploadClashBoxLines3D(lines.vertices);
+        this.requestRender();
+    }
+
+    /**
      * Upload filled IfcAnnotation regions for the symbolic overlay
      * (issue #653). Pass an empty array to clear.
      */

--- a/rust/clash/src/narrow.rs
+++ b/rust/clash/src/narrow.rs
@@ -59,6 +59,11 @@ pub fn test_pair(
     let mut intersects = false;
     let mut contact_sum: [f64; 3] = [0.0, 0.0, 0.0];
     let mut contact_n: u32 = 0;
+    // Tight contact AABB: min/max of the per-pair contact points (the crossing
+    // representatives), so a hard verdict reports the local contact region rather
+    // than the whole-element AABB overlap (#1362 / #1402).
+    let mut c_min: Vec3 = [f64::INFINITY; 3];
+    let mut c_max: Vec3 = [f64::NEG_INFINITY; 3];
     let mut min_dist = f64::INFINITY;
     let mut closest_a: Vec3 = aabb_a.min;
     let mut closest_b: Vec3 = aabb_b.min;
@@ -79,6 +84,14 @@ pub fn test_pair(
                 contact_sum[1] += c[1];
                 contact_sum[2] += c[2];
                 contact_n += 1;
+                for i in 0..3 {
+                    if c[i] < c_min[i] {
+                        c_min[i] = c[i];
+                    }
+                    if c[i] > c_max[i] {
+                        c_max[i] = c[i];
+                    }
+                }
             } else if !intersects {
                 // Distance only matters while we might still be clearance/touch.
                 let (dist, p_a, p_b) = tri_tri_distance(s0, s1, s2, l0, l1, l2);
@@ -100,13 +113,21 @@ pub fn test_pair(
         } else {
             overlap.center()
         };
+        // Tight contact AABB (Bug B): the box around the actual triangle crossings,
+        // clamped to the element overlap so it can never exceed it. Falls back to
+        // the overlap when (defensively) no contact point was recorded.
+        let bounds = if contact_n > 0 {
+            overlap_bounds(&Aabb::new(c_min, c_max), &overlap)
+        } else {
+            overlap
+        };
         // Phase-0 penetration estimate from AABB overlap.
         let penetration = (-signed_gap(aabb_a, aabb_b)).max(0.0);
         return Some(NarrowResult {
             status: ClashStatus::Hard,
             distance: -penetration,
             point,
-            bounds: overlap,
+            bounds,
         });
     }
 
@@ -138,17 +159,30 @@ pub fn test_pair(
         return None;
     }
 
-    // Surfaces coincide/touch with no genuine crossing, but the volumes overlap
-    // beyond tolerance (coplanar surfaces, e.g. axis-aligned boxes) -> hard.
+    // Surfaces coincide/touch with no genuine crossing, but the AABBs penetrate
+    // beyond tolerance (coplanar surfaces, e.g. axis-aligned boxes). AABB
+    // penetration ALONE is not enough: two skewed/abutting members that merely
+    // share a face have overlapping AABBs yet no shared volume, and the old proxy
+    // promoted that touch to a false hard clash (#1362). Confirm a real volume
+    // overlap first: the midpoint of the two vertex centroids lies in the shared
+    // interior for a genuine overlap, but on/outside the interface for a bare face
+    // touch -> require it inside BOTH solids before reporting hard.
     if min_dist <= tolerance {
         let gap = signed_gap(aabb_a, aabb_b);
         if gap < -tolerance {
-            return Some(NarrowResult {
-                status: ClashStatus::Hard,
-                distance: gap,
-                point: overlap.center(),
-                bounds: overlap,
-            });
+            let probe = mid(tri_a.vertex_centroid(), tri_b.vertex_centroid());
+            if tri_a.contains_point(probe) && tri_b.contains_point(probe) {
+                // Tight contact bounds (Bug B): the nearest-surface contact, not
+                // the whole-element AABB overlap (meters wide for long members).
+                return Some(NarrowResult {
+                    status: ClashStatus::Hard,
+                    distance: gap,
+                    point: mid(closest_a, closest_b),
+                    bounds: bounds_of_points(closest_a, closest_b),
+                });
+            }
+            // Only a face touch (no shared volume): fall through to the touch
+            // handling below, which suppresses it unless report_touch is set.
         }
     }
 

--- a/rust/clash/src/narrow.rs
+++ b/rust/clash/src/narrow.rs
@@ -161,7 +161,16 @@ pub fn test_pair(
         t_n += 1;
     }
     let contact_bounds = if t_n > 0 {
-        overlap_bounds(&Aabb::new(t_min, t_max), &overlap)
+        // Clamp the contact AABB to the element overlap per-axis. (overlap_bounds
+        // would degenerate a disjoint axis to a midpoint that can land OUTSIDE the
+        // overlap, breaking the "clamped to overlap" contract for the box.)
+        let mut min: Vec3 = [0.0; 3];
+        let mut max: Vec3 = [0.0; 3];
+        for i in 0..3 {
+            min[i] = t_min[i].max(overlap.min[i]).min(overlap.max[i]);
+            max[i] = t_max[i].max(overlap.min[i]).min(overlap.max[i]);
+        }
+        Aabb::new(min, max)
     } else {
         overlap
     };

--- a/rust/clash/src/narrow.rs
+++ b/rust/clash/src/narrow.rs
@@ -64,6 +64,13 @@ pub fn test_pair(
     // than the whole-element AABB overlap (#1362 / #1402).
     let mut c_min: Vec3 = [f64::INFINITY; 3];
     let mut c_max: Vec3 = [f64::NEG_INFINITY; 3];
+    // Near-contact AABB for coplanar/flush overlaps (no triangle crossing): the
+    // local touching region, so the hard box is the contact patch (e.g. a wall
+    // corner) not the whole-element AABB intersection, which for angled members
+    // spans nearly the full member length (#1362 / #1402).
+    let mut nc_min: Vec3 = [f64::INFINITY; 3];
+    let mut nc_max: Vec3 = [f64::NEG_INFINITY; 3];
+    let mut nc_n: u32 = 0;
     let mut min_dist = f64::INFINITY;
     let mut closest_a: Vec3 = aabb_a.min;
     let mut closest_b: Vec3 = aabb_b.min;
@@ -92,19 +99,72 @@ pub fn test_pair(
                         c_max[i] = c[i];
                     }
                 }
-            } else if !intersects {
-                // Distance only matters while we might still be clearance/touch.
+            } else {
+                // Not a crossing: measure the gap (drives clearance/touch) and,
+                // when touching (within tolerance), accumulate the pair into the
+                // contact region. Done even after a crossing is found, since
+                // coincident faces of flush members register as touches (not
+                // crossings) yet carry most of the real contact area.
                 let (dist, p_a, p_b) = tri_tri_distance(s0, s1, s2, l0, l1, l2);
                 if dist < min_dist {
                     min_dist = dist;
                     closest_a = p_a;
                     closest_b = p_b;
                 }
+                if dist <= tolerance {
+                    let cp = mid(p_a, p_b);
+                    nc_n += 1;
+                    for i in 0..3 {
+                        if cp[i] < nc_min[i] {
+                            nc_min[i] = cp[i];
+                        }
+                        if cp[i] > nc_max[i] {
+                            nc_max[i] = cp[i];
+                        }
+                    }
+                }
             }
         }
     }
 
     let overlap = overlap_bounds(aabb_a, aabb_b);
+
+    // Tight contact region: the union of the genuine triangle crossings
+    // (c_min/c_max) and the coplanar/flush touching pairs within tolerance
+    // (nc_min/nc_max), clamped to the element overlap. Crossings alone miss
+    // coincident faces (which register as touches, not crossings) so flush members
+    // reported only a partial, mis-placed patch; near-contacts alone miss angled
+    // crossings. Falls back to the overlap when neither was captured (#1362/#1402).
+    let mut t_min: Vec3 = [f64::INFINITY; 3];
+    let mut t_max: Vec3 = [f64::NEG_INFINITY; 3];
+    let mut t_n: u32 = 0;
+    if contact_n > 0 {
+        for i in 0..3 {
+            if c_min[i] < t_min[i] {
+                t_min[i] = c_min[i];
+            }
+            if c_max[i] > t_max[i] {
+                t_max[i] = c_max[i];
+            }
+        }
+        t_n += 1;
+    }
+    if nc_n > 0 {
+        for i in 0..3 {
+            if nc_min[i] < t_min[i] {
+                t_min[i] = nc_min[i];
+            }
+            if nc_max[i] > t_max[i] {
+                t_max[i] = nc_max[i];
+            }
+        }
+        t_n += 1;
+    }
+    let contact_bounds = if t_n > 0 {
+        overlap_bounds(&Aabb::new(t_min, t_max), &overlap)
+    } else {
+        overlap
+    };
 
     if intersects {
         let point: Vec3 = if contact_n > 0 {
@@ -113,21 +173,13 @@ pub fn test_pair(
         } else {
             overlap.center()
         };
-        // Tight contact AABB (Bug B): the box around the actual triangle crossings,
-        // clamped to the element overlap so it can never exceed it. Falls back to
-        // the overlap when (defensively) no contact point was recorded.
-        let bounds = if contact_n > 0 {
-            overlap_bounds(&Aabb::new(c_min, c_max), &overlap)
-        } else {
-            overlap
-        };
         // Phase-0 penetration estimate from AABB overlap.
         let penetration = (-signed_gap(aabb_a, aabb_b)).max(0.0);
         return Some(NarrowResult {
             status: ClashStatus::Hard,
             distance: -penetration,
             point,
-            bounds,
+            bounds: contact_bounds,
         });
     }
 
@@ -178,16 +230,16 @@ pub fn test_pair(
             if (tri_a.contains_point(probe_centroid) && tri_b.contains_point(probe_centroid))
                 || (tri_a.contains_point(probe_overlap) && tri_b.contains_point(probe_overlap))
             {
-                // The shared volume of a coplanar/flush overlap IS the element-AABB
-                // intersection, and it is tight here: skewed false-touches were
-                // suppressed above, so only genuine overlaps reach this point. (For a
-                // flush overlap the nearest-surface points are near-coincident, so
-                // boxing them would yield a degenerate, invisible region box — #1402.)
+                // Report the tight contact region (the touching patch where the
+                // surfaces actually coincide), clamped to the element overlap — not
+                // the whole-element AABB intersection, which for angled members
+                // spans nearly the full member length and sits away from the real
+                // contact (#1362/#1402).
                 return Some(NarrowResult {
                     status: ClashStatus::Hard,
                     distance: gap,
                     point: mid(closest_a, closest_b),
-                    bounds: overlap,
+                    bounds: contact_bounds,
                 });
             }
             // Only a face touch (no shared volume): fall through to the touch

--- a/rust/clash/src/narrow.rs
+++ b/rust/clash/src/narrow.rs
@@ -178,13 +178,16 @@ pub fn test_pair(
             if (tri_a.contains_point(probe_centroid) && tri_b.contains_point(probe_centroid))
                 || (tri_a.contains_point(probe_overlap) && tri_b.contains_point(probe_overlap))
             {
-                // Tight contact bounds (Bug B): the nearest-surface contact, not
-                // the whole-element AABB overlap (meters wide for long members).
+                // The shared volume of a coplanar/flush overlap IS the element-AABB
+                // intersection, and it is tight here: skewed false-touches were
+                // suppressed above, so only genuine overlaps reach this point. (For a
+                // flush overlap the nearest-surface points are near-coincident, so
+                // boxing them would yield a degenerate, invisible region box — #1402.)
                 return Some(NarrowResult {
                     status: ClashStatus::Hard,
                     distance: gap,
                     point: mid(closest_a, closest_b),
-                    bounds: bounds_of_points(closest_a, closest_b),
+                    bounds: overlap,
                 });
             }
             // Only a face touch (no shared volume): fall through to the touch

--- a/rust/clash/src/narrow.rs
+++ b/rust/clash/src/narrow.rs
@@ -163,15 +163,21 @@ pub fn test_pair(
     // beyond tolerance (coplanar surfaces, e.g. axis-aligned boxes). AABB
     // penetration ALONE is not enough: two skewed/abutting members that merely
     // share a face have overlapping AABBs yet no shared volume, and the old proxy
-    // promoted that touch to a false hard clash (#1362). Confirm a real volume
-    // overlap first: the midpoint of the two vertex centroids lies in the shared
-    // interior for a genuine overlap, but on/outside the interface for a bare face
-    // touch -> require it inside BOTH solids before reporting hard.
+    // promoted that touch to a false hard clash (#1362). Confirm a real shared
+    // volume first by probing for an interior point inside BOTH solids. Two probes
+    // are needed: the vertex-centroid midpoint sits inside a skewed straddling
+    // overlap, while the AABB-overlap centre covers an unequal-length aligned
+    // overlap (whose centroid midpoint can fall outside the shorter member). A
+    // bare face touch has no interior point common to both, so neither probe
+    // qualifies. Accept the pair if EITHER probe is inside both.
     if min_dist <= tolerance {
         let gap = signed_gap(aabb_a, aabb_b);
         if gap < -tolerance {
-            let probe = mid(tri_a.vertex_centroid(), tri_b.vertex_centroid());
-            if tri_a.contains_point(probe) && tri_b.contains_point(probe) {
+            let probe_centroid = mid(tri_a.vertex_centroid(), tri_b.vertex_centroid());
+            let probe_overlap = overlap.center();
+            if (tri_a.contains_point(probe_centroid) && tri_b.contains_point(probe_centroid))
+                || (tri_a.contains_point(probe_overlap) && tri_b.contains_point(probe_overlap))
+            {
                 // Tight contact bounds (Bug B): the nearest-surface contact, not
                 // the whole-element AABB overlap (meters wide for long members).
                 return Some(NarrowResult {

--- a/rust/clash/src/tests.rs
+++ b/rust/clash/src/tests.rs
@@ -124,6 +124,94 @@ fn session_of_sized(cubes: &[(f32, f32, f32, f32)]) -> ClashSession {
     session
 }
 
+/// Axis-aligned box with independent per-axis half-extents, centred at
+/// `(cx, cy, cz)`. Same packing/winding as `unit_cube`. Used for the
+/// perpendicular-bar crossing fixture (#1362 / #1402 Bug B).
+fn box_hxyz(cx: f32, cy: f32, cz: f32, hx: f32, hy: f32, hz: f32) -> (Vec<f32>, Vec<u32>, Vec<f32>) {
+    let corners = [
+        [cx - hx, cy - hy, cz - hz],
+        [cx + hx, cy - hy, cz - hz],
+        [cx + hx, cy + hy, cz - hz],
+        [cx - hx, cy + hy, cz - hz],
+        [cx - hx, cy - hy, cz + hz],
+        [cx + hx, cy - hy, cz + hz],
+        [cx + hx, cy + hy, cz + hz],
+        [cx - hx, cy + hy, cz + hz],
+    ];
+    let mut positions = Vec::with_capacity(24);
+    for c in &corners {
+        positions.extend_from_slice(c);
+    }
+    let indices: Vec<u32> = vec![
+        0, 1, 2, 0, 2, 3, 4, 6, 5, 4, 7, 6, 0, 5, 1, 0, 4, 5, 3, 2, 6, 3, 6, 7, 0, 3, 7, 0, 7, 4,
+        1, 5, 6, 1, 6, 2,
+    ];
+    let aabb = vec![cx - hx, cy - hy, cz - hz, cx + hx, cy + hy, cz + hz];
+    (positions, indices, aabb)
+}
+
+/// A closed triangular prism: the `footprint` triangle (XY) extruded between
+/// `z0` and `z1`. Exact-coordinate fixtures (no trig) so the slanted contact face
+/// is bit-identically coplanar in `f32` and `f64`, exercising the coplanar-touch
+/// fallback without the SAT degeneracy a rotated box would introduce (#1362 Bug A).
+fn tri_prism(footprint: [[f32; 2]; 3], z0: f32, z1: f32) -> (Vec<f32>, Vec<u32>, Vec<f32>) {
+    let [p0, p1, p2] = footprint;
+    // 0..2 bottom, 3..5 top.
+    let v: [[f32; 3]; 6] = [
+        [p0[0], p0[1], z0],
+        [p1[0], p1[1], z0],
+        [p2[0], p2[1], z0],
+        [p0[0], p0[1], z1],
+        [p1[0], p1[1], z1],
+        [p2[0], p2[1], z1],
+    ];
+    let mut positions = Vec::with_capacity(18);
+    let mut min = [f32::INFINITY; 3];
+    let mut max = [f32::NEG_INFINITY; 3];
+    for p in &v {
+        positions.extend_from_slice(p);
+        for axis in 0..3 {
+            if p[axis] < min[axis] {
+                min[axis] = p[axis];
+            }
+            if p[axis] > max[axis] {
+                max[axis] = p[axis];
+            }
+        }
+    }
+    // bottom, top, then a quad (2 tris) per footprint edge.
+    let indices: Vec<u32> = vec![
+        0, 1, 2, // bottom
+        3, 4, 5, // top
+        0, 1, 4, 0, 4, 3, // edge p0-p1
+        1, 2, 5, 1, 5, 4, // edge p1-p2 (the shared slanted face when reused)
+        2, 0, 3, 2, 3, 5, // edge p2-p0
+    ];
+    let aabb = vec![min[0], min[1], min[2], max[0], max[1], max[2]];
+    (positions, indices, aabb)
+}
+
+/// Build a session from already-built `(positions, indices, aabb)` parts.
+fn session_of_parts(parts: &[(Vec<f32>, Vec<u32>, Vec<f32>)]) -> ClashSession {
+    let mut positions: Vec<f32> = Vec::new();
+    let mut pos_ranges: Vec<u32> = Vec::new();
+    let mut indices: Vec<u32> = Vec::new();
+    let mut idx_ranges: Vec<u32> = Vec::new();
+    let mut aabbs: Vec<f32> = Vec::new();
+    for (p, idx, ab) in parts {
+        pos_ranges.push(positions.len() as u32);
+        pos_ranges.push(p.len() as u32);
+        idx_ranges.push(indices.len() as u32);
+        idx_ranges.push(idx.len() as u32);
+        positions.extend_from_slice(p);
+        indices.extend_from_slice(idx);
+        aabbs.extend_from_slice(ab);
+    }
+    let mut session = ClashSession::new();
+    session.ingest(&positions, &pos_ranges, &indices, &idx_ranges, &aabbs);
+    session
+}
+
 /// A closed, CONCAVE L-shaped prism: footprint
 /// `(0,0)-(2,0)-(2,1)-(1,1)-(1,2)-(0,2)` extruded z=0..1. The square
 /// `[1,2]×[1,2]` is the notch — inside the AABB but OUTSIDE the solid.
@@ -248,6 +336,76 @@ fn contains_point_concave_notch_is_outside() {
     assert!(mesh.contains_point([0.5, 0.5, 0.5]), "point in the L arm is inside the solid");
     assert!(!mesh.contains_point([1.5, 1.5, 0.5]), "point in the concave notch is OUTSIDE the solid");
     assert!(!mesh.contains_point([5.0, 5.0, 5.0]), "far point is outside");
+}
+
+#[test]
+fn skewed_face_touch_no_false_hard() {
+    // Bug A (#1362): two members that only SHARE A SLANTED FACE (no shared volume)
+    // still have fully-overlapping axis-aligned bounds because of the skew. The old
+    // AABB-penetration proxy promoted that bare touch to a false hard clash; the
+    // volumetric confirmation must suppress it.
+    // A = lower-left wedge (x+y<=2); B = upper-right wedge sharing the hypotenuse.
+    let a = tri_prism([[0.0, 0.0], [2.0, 0.0], [0.0, 2.0]], 0.0, 1.0);
+    let b = tri_prism([[2.0, 0.0], [0.0, 2.0], [5.0, 5.0]], 0.0, 1.0);
+    // Sanity: their AABBs overlap fully in A's footprint, so the broad phase pairs
+    // them even though the solids only touch along the slanted face.
+    let oa = &a.2;
+    let ob = &b.2;
+    let overlaps = oa[0] <= ob[3] && oa[3] >= ob[0] && oa[1] <= ob[4] && oa[4] >= ob[1];
+    assert!(overlaps, "fixture invalid: AABBs must overlap to reach the narrow phase");
+
+    let session = session_of_parts(&[a, b]);
+    let result = session.run_rule(&[0, 1], &[], HARD, 0.001, 0.0, false);
+    assert_eq!(
+        result.records.len(),
+        0,
+        "a bare slanted-face touch with overlapping AABBs must NOT be a hard clash"
+    );
+}
+
+#[test]
+fn skewed_genuine_overlap_still_hard() {
+    // Recall guard for Bug A: the SAME wedge A, but a box that genuinely straddles
+    // the slanted face -> the fix must still report the hard clash (it suppresses
+    // bare touches, not real overlaps).
+    let a = tri_prism([[0.0, 0.0], [2.0, 0.0], [0.0, 2.0]], 0.0, 1.0);
+    let b = box_hxyz(1.0, 1.0, 0.5, 0.5, 0.5, 0.5); // [0.5,1.5]^2 x [0,1], straddles x+y=2
+    let session = session_of_parts(&[a, b]);
+    let result = session.run_rule(&[0, 1], &[], HARD, 0.001, 0.0, false);
+    assert_eq!(result.records.len(), 1, "a genuine straddling overlap is a hard clash");
+    assert_eq!(result.records[0].status, ClashStatus::Hard);
+}
+
+#[test]
+fn crossing_hard_bounds_are_tight() {
+    // Bug B (#1362 / #1402): two perpendicular bars genuinely cross. The reported
+    // contact bounds must be the LOCAL crossing region, not the whole-element AABB
+    // overlap. Bar A runs along X, bar B along Y; they cross near the origin.
+    let a = box_hxyz(0.0, 0.0, 0.0, 5.0, 0.5, 0.5); // x[-5,5]
+    let b = box_hxyz(0.0, 0.0, 0.0, 0.5, 5.0, 0.5); // y[-5,5]
+    let a_aabb = a.2.clone();
+    let session = session_of_parts(&[a, b]);
+    let result = session.run_rule(&[0, 1], &[], HARD, 0.001, 0.0, false);
+    assert_eq!(result.records.len(), 1, "crossing bars are a hard clash");
+    let rec = &result.records[0];
+    assert_eq!(rec.status, ClashStatus::Hard);
+
+    // Element-AABB overlap (what the old code returned as `bounds`).
+    let overlap_z = 1.0_f64; // z[-0.5,0.5] for both bars
+    let bounds_z = rec.bounds[5] - rec.bounds[2];
+    assert!(
+        bounds_z < overlap_z,
+        "contact bounds must be tighter in z than the element overlap ({bounds_z} vs {overlap_z})"
+    );
+
+    // The tight bounds must stay inside the (smaller) element's AABB, never wider.
+    for axis in 0..3 {
+        assert!(
+            rec.bounds[axis] >= a_aabb[axis] as f64 - 1e-6
+                && rec.bounds[axis + 3] <= a_aabb[axis + 3] as f64 + 1e-6,
+            "contact bounds escape element A on axis {axis}"
+        );
+    }
 }
 
 // --- Triangle math unit tests -------------------------------------------------

--- a/rust/clash/src/tests.rs
+++ b/rust/clash/src/tests.rs
@@ -377,6 +377,20 @@ fn skewed_genuine_overlap_still_hard() {
 }
 
 #[test]
+fn aligned_unequal_overlap_still_hard() {
+    // Bug A recall (PR #1455 review): two AXIS-ALIGNED members of unequal length
+    // that genuinely overlap by a small amount, sharing y/z extents. The vertex-
+    // centroid midpoint (~x=2.7) lies outside the shorter member, so a single
+    // centroid probe would drop the clash; the AABB-overlap-centre probe keeps it.
+    let a = box_hxyz(0.0, 0.0, 0.0, 5.0, 0.5, 0.5); // x[-5,5]
+    let b = box_hxyz(5.4, 0.0, 0.0, 0.5, 0.5, 0.5); // x[4.9,5.9], overlaps x[4.9,5]
+    let session = session_of_parts(&[a, b]);
+    let result = session.run_rule(&[0, 1], &[], HARD, 0.001, 0.0, false);
+    assert_eq!(result.records.len(), 1, "a genuine aligned overlap is a hard clash");
+    assert_eq!(result.records[0].status, ClashStatus::Hard);
+}
+
+#[test]
 fn crossing_hard_bounds_are_tight() {
     // Bug B (#1362 / #1402): two perpendicular bars genuinely cross. The reported
     // contact bounds must be the LOCAL crossing region, not the whole-element AABB

--- a/rust/clash/src/tests.rs
+++ b/rust/clash/src/tests.rs
@@ -415,12 +415,12 @@ fn crossing_hard_bounds_are_tight() {
     let rec = &result.records[0];
     assert_eq!(rec.status, ClashStatus::Hard);
 
-    // Element-AABB overlap (what the old code returned as `bounds`).
-    let overlap_z = 1.0_f64; // z[-0.5,0.5] for both bars
-    let bounds_z = rec.bounds[5] - rec.bounds[2];
+    // Tight along the long bar: A spans x[-5,5] (10 m), but the contact is only
+    // the local crossing (~B's 1 m width), so the box must NOT span the whole bar.
+    let bounds_x = rec.bounds[3] - rec.bounds[0];
     assert!(
-        bounds_z < overlap_z,
-        "contact bounds must be tighter in z than the element overlap ({bounds_z} vs {overlap_z})"
+        bounds_x < 2.0,
+        "contact bounds must be local along the long bar, not its full length (got {bounds_x})"
     );
 
     // The tight bounds must stay inside the element-OVERLAP AABB on every axis,

--- a/rust/clash/src/tests.rs
+++ b/rust/clash/src/tests.rs
@@ -243,6 +243,16 @@ fn overlapping_cubes_hard() {
     let rec = &result.records[0];
     assert_eq!(rec.status, ClashStatus::Hard);
     assert!(rec.distance < 0.0, "penetration distance must be negative, got {}", rec.distance);
+    // The coplanar/flush overlap must report the real (non-degenerate) overlap
+    // region so it renders as a visible penetration box (#1402), not the zero-size
+    // box of two near-coincident surface points. Overlap here is 0.5 x 1 x 1.
+    let dx = rec.bounds[3] - rec.bounds[0];
+    let dy = rec.bounds[4] - rec.bounds[1];
+    let dz = rec.bounds[5] - rec.bounds[2];
+    assert!(
+        dx > 0.4 && dx < 0.6 && dy > 0.5 && dz > 0.5,
+        "coplanar hard clash must report a visible overlap region, got {dx}x{dy}x{dz}"
+    );
 }
 
 #[test]

--- a/rust/clash/src/tests.rs
+++ b/rust/clash/src/tests.rs
@@ -398,6 +398,7 @@ fn crossing_hard_bounds_are_tight() {
     let a = box_hxyz(0.0, 0.0, 0.0, 5.0, 0.5, 0.5); // x[-5,5]
     let b = box_hxyz(0.0, 0.0, 0.0, 0.5, 5.0, 0.5); // y[-5,5]
     let a_aabb = a.2.clone();
+    let b_aabb = b.2.clone();
     let session = session_of_parts(&[a, b]);
     let result = session.run_rule(&[0, 1], &[], HARD, 0.001, 0.0, false);
     assert_eq!(result.records.len(), 1, "crossing bars are a hard clash");
@@ -412,12 +413,16 @@ fn crossing_hard_bounds_are_tight() {
         "contact bounds must be tighter in z than the element overlap ({bounds_z} vs {overlap_z})"
     );
 
-    // The tight bounds must stay inside the (smaller) element's AABB, never wider.
+    // The tight bounds must stay inside the element-OVERLAP AABB on every axis,
+    // not just element A: A is the long X bar, so an X regression returning most
+    // of A's 10 m span would still satisfy an A-only check. The overlap is
+    // x[-0.5,0.5] (B's width) on X.
     for axis in 0..3 {
+        let overlap_min = a_aabb[axis].max(b_aabb[axis]) as f64;
+        let overlap_max = a_aabb[axis + 3].min(b_aabb[axis + 3]) as f64;
         assert!(
-            rec.bounds[axis] >= a_aabb[axis] as f64 - 1e-6
-                && rec.bounds[axis + 3] <= a_aabb[axis + 3] as f64 + 1e-6,
-            "contact bounds escape element A on axis {axis}"
+            rec.bounds[axis] >= overlap_min - 1e-6 && rec.bounds[axis + 3] <= overlap_max + 1e-6,
+            "contact bounds escape the element-overlap AABB on axis {axis}"
         );
     }
 }

--- a/rust/clash/src/tri_mesh.rs
+++ b/rust/clash/src/tri_mesh.rs
@@ -111,6 +111,27 @@ impl TriMesh {
         self.bvh.query_aabb(bounds)
     }
 
+    /// Mean of every vertex, summed in index order. A rigid-invariant interior
+    /// probe for the volumetric-overlap check in the narrow phase: the midpoint
+    /// of two solids' vertex centroids lands in their shared volume for a genuine
+    /// overlap (but on/outside the interface for a bare face touch). Iterated in
+    /// index order and summed in `f64`, bit-identical to the TS `vertexCentroid`.
+    pub fn vertex_centroid(&self) -> Vec3 {
+        let n = self.positions.len() / 3;
+        if n == 0 {
+            return [0.0, 0.0, 0.0];
+        }
+        let mut s = [0.0f64; 3];
+        for i in 0..n {
+            let v = self.vertex(i as u32);
+            s[0] += v[0];
+            s[1] += v[1];
+            s[2] += v[2];
+        }
+        let nf = n as f64;
+        [s[0] / nf, s[1] / nf, s[2] / nf]
+    }
+
     /// True when `p` is inside this closed mesh. Casts a fixed-direction ray and
     /// counts forward crossings against every triangle (Möller–Trumbore,
     /// double-sided so winding doesn't matter); an odd count means inside.

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -157,6 +157,19 @@
     "createBCFFromClashResult: function",
     "mapBcfToClashes: function"
   ],
+  "@ifc-lite/clash/contact": [
+    "AABB: interface",
+    "ContactOptions: interface",
+    "Mesh: interface",
+    "NarrowPhaseOptions: interface",
+    "SharedFaceCluster: interface",
+    "SharedFaceOptions: interface",
+    "TrianglePair: type",
+    "Vec3: type",
+    "clusterSharedFaces: function",
+    "contactClusters: function",
+    "narrowPhase: function"
+  ],
   "@ifc-lite/clash/ifcx": [
     "IfcxAdapterOptions: interface",
     "IfcxAdapterResult: interface",


### PR DESCRIPTION
## Summary

Fixes single-model clash false positives (#1362) and overhauls the focused-clash visualization to show the **real contact interface** instead of an AABB box (#1402), verified live on localhost.

## #1362 — false positives + contact region (TS + Rust kernels, kept byte-compatible)
- **Suppress false hard clashes:** the coplanar/touch fallback now requires a real shared volume via a point-in-solid probe (vertex-centroid midpoint OR AABB-overlap centre inside both solids), so skewed/abutting members that only share a face are no longer flagged. Goldens preserved; new guards `skewed_face_touch_no_false_hard`, `skewed_genuine_overlap_still_hard`, `aligned_unequal_overlap_still_hard`.
- **Contact region:** hard verdicts report the union of genuine triangle crossings and coplanar near-contacts (within tolerance), clamped to the element overlap — not the whole-element AABB (which for angled members spanned nearly the full length and floated off the elements).

## #1402 — real contact-interface geometry (replaces the AABB box)
- New `@ifc-lite/clash/contact`: `contactClusters(meshA, meshB)` returns the actual contact patches — **shared-face polygon** (coplanar/flush), **intersection line** (crossings), or **point** — classified by area/length, via a Möller triangle-triangle test plus shared-face clustering (Sutherland-Hodgman clip on the common plane; cross-segment union on the line). Computed lazily for the single focused pair, not the bulk sweep.
- Renderer gains `setClashContactLines()`; the viewer draws the contact polygon outlines / intersection lines on the focused clash and falls back to the box only if no contact can be built.
- Region indicator on by default (toggle in clash settings).
- **Show all / reset filters** now also clears the focused-clash colouring, contact overlay, and selected row (was left painted).

## Verification
- `cargo test -p ifc-lite-clash` 20/20 (goldens + new guards + visibility/contact assertions).
- `@ifc-lite/clash` vitest 123/123 incl. TS↔WASM differential parity and new contact tests.
- Driven on localhost with a real model: false touches gone, the indicator lies on the actual wall junction (shared-face strip + cross-edges), and Show all clears it.

Changesets included for `@ifc-lite/clash` and `@ifc-lite/renderer`. Conventional commits, no co-author trailer.

Closes #1362
Closes #1402

🤖 Generated with [Claude Code](https://claude.com/claude-code)