### PR TITLE
fix(geometry): don't flag watertight roof/gable cutters as malformed (#1440 regression)

### DIFF
--- a/.changeset/roof-cutter-not-malformed.md
+++ b/.changeset/roof-cutter-not-malformed.md
@@ -1,0 +1,19 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Fix walls being sliced flat at a height (gable/roof top removed, windows left
+floating) after #1440. The malformed-void-cutter detector (`opening_obb_if_malformed`)
+flagged ANY cutter with a vertex >4 m beyond its near vertex cluster as "garbage".
+A legitimate roof/gable cut — a watertight prism authored to reach far up (e.g.
+~900 m) to clip a wall down to the roofline — trips that test on its structural
+top vertices, so the real cut was skipped and replaced by a horizontal slab,
+slicing every roof-capped wall flat.
+
+Gate the detector on a closed-manifold check: a cutter that welds (by position)
+to a closed 2-manifold is a VALID SOLID and is never reshaped, so roof/gable
+prisms and clean opening boxes are spared. Only genuinely broken cutters
+(self-intersecting / fin-laden tessellated voids, which leave boundary or
+non-manifold edges) still get the #1440 repair. The spike/flap regression
+(`multi_body_void_spike`) and the full geometry suite stay green; output matches
+the pre-#1440 (correct) result byte-for-byte on the reported model.

--- a/rust/geometry/src/router/voids/mod.rs
+++ b/rust/geometry/src/router/voids/mod.rs
@@ -242,6 +242,38 @@ fn make_obb_mesh(corners: &[Point3<f64>; 8]) -> Mesh {
     m
 }
 
+/// True if `m` welds (by position) to a CLOSED 2-manifold: every edge is shared
+/// by exactly two triangles — the topological signature of a valid solid. A
+/// clean opening box AND a watertight roof/gable prism (a tall cutter reaching
+/// hundreds of metres up to clip a wall to the roofline) both pass; only a
+/// self-intersecting / fin-laden GARBAGE cutter (the #1007 family) leaves
+/// boundary or non-manifold edges and fails. Conservative: a cutter with too
+/// few faces to bound a solid (e.g. a stray point cloud) is NOT closed, so it
+/// stays eligible for the malformed-cutter repair.
+fn cutter_is_closed_manifold(m: &Mesh) -> bool {
+    // A closed solid needs >= 4 triangles (a tetrahedron).
+    if m.indices.len() < 12 {
+        return false;
+    }
+    // Weld duplicated per-face vertices back together so shared edges are
+    // detectable; 10 µm is far below any real opening feature.
+    let w = m.welded_by_position(1.0e-5);
+    if w.indices.len() < 12 {
+        return false;
+    }
+    let mut edge_uses: FxHashMap<(u32, u32), u32> = FxHashMap::default();
+    for t in w.indices.chunks_exact(3) {
+        if t[0] == t[1] || t[1] == t[2] || t[0] == t[2] {
+            return false; // a degenerate triangle survived welding
+        }
+        for &(a, b) in &[(t[0], t[1]), (t[1], t[2]), (t[2], t[0])] {
+            let key = if a < b { (a, b) } else { (b, a) };
+            *edge_uses.entry(key).or_insert(0) += 1;
+        }
+    }
+    edge_uses.values().all(|&c| c == 2)
+}
+
 /// Compute the clean oriented box of a cutter's REAL opening iff the cutter is
 /// MALFORMED (a far-flung garbage-vertex cluster). `None` for a well-formed
 /// cutter — clean hosts are never reshaped.
@@ -254,6 +286,14 @@ fn make_obb_mesh(corners: &[Point3<f64>; 8]) -> Mesh {
 /// not malformed -> `None`. Principal axes via covariance eigendecomposition
 /// (for a box the eigenvectors align with the edges).
 fn opening_obb_if_malformed(m: &Mesh) -> Option<OpeningBox> {
+    // A cutter that welds to a closed solid is well-formed by construction — its
+    // far vertices are STRUCTURAL (a watertight roof prism, not stray garbage),
+    // so the far-cluster heuristic below must never reshape it. This is what
+    // separates a legitimate gable/roof cut (whose top can sit ~900 m up) from
+    // the self-intersecting tessellated voids the repair targets.
+    if cutter_is_closed_manifold(m) {
+        return None;
+    }
     let all: Vec<Vector3<f64>> = m
         .positions
         .chunks_exact(3)
@@ -1835,6 +1875,26 @@ mod flap_clip_tests {
     fn opening_obb_skips_wellformed_cutter() {
         let cutter = box_cutter_mesh([1.0, 0.1, 1.2], &[]);
         assert!(opening_obb_if_malformed(&cutter).is_none());
+    }
+
+    /// A watertight TALL cutter — a roof/gable void authored as a closed prism
+    /// reaching far up (here ~900 m) to clip a wall down to the roofline — is a
+    /// VALID SOLID, so its far (top) vertices are STRUCTURAL, not garbage. The
+    /// closed-manifold gate must spare it: flagging it malformed re-cut every
+    /// roof-capped wall as a flat horizontal slab, slicing the gable off (the
+    /// #1440 false-positive). `aabb_box` welds to a closed box, mirroring the
+    /// `IfcClosedShell` roof cutters that triggered the regression.
+    #[test]
+    fn watertight_tall_roof_cutter_is_not_flagged_malformed() {
+        let tall = aabb_box([0.6, 0.15, 450.0]);
+        assert!(
+            cutter_is_closed_manifold(&tall),
+            "a closed box prism must read as a valid solid"
+        );
+        assert!(
+            opening_obb_if_malformed(&tall).is_none(),
+            "a watertight tall cutter must never be reshaped as 'malformed'"
+        );
     }
 
     fn signed_volume(m: &Mesh) -> f64 {


### PR DESCRIPTION
## Problem

After #1440 ("repair spike + flap from malformed void cutters"), walls with a roof/gable cut render **sliced flat at a height** — the gable top is gone and windows float above the cut. This hits **every pitched-roof / gabled wall** on `main`.

Root cause: `opening_obb_if_malformed` flags a cutter as "garbage" whenever any vertex sits **>4 m beyond the near vertex cluster**. A legitimate roof cut is a watertight prism authored to reach far up (hundreds of metres) to clip a wall down to the roofline; its **structural top vertices** trip that test. The real cut is then skipped and `recut_malformed_openings` subtracts a horizontal slab instead, slicing the wall flat.

## Fix

Gate the detector on a **closed-manifold check**: a cutter that welds (by position) to a closed 2-manifold is a valid solid (roof/gable prisms, clean opening boxes) and is never reshaped. Only genuinely broken cutters (self-intersecting / fin-laden tessellated voids — the #1007 family #1440 targets, which leave boundary / non-manifold edges) still get the spike/flap repair.

## Validation

Reproduced natively on the reported model (3 roof-capped walls). After the fix, every wall matches the **pre-#1440 (correct)** result exactly:

| Wall | base z-max | broken (#1440) | fixed | pre-#1440 truth |
|------|-----------|----------------|-------|-----------------|
| A | 4.000 | 0.727 (stub) | 3.928 | 3.928 |
| B | 5.000 | sliced | 3.928 | 3.928 |
| C | 5.000 | sliced | 3.364 | 3.364 |

- `multi_body_void_spike` (#1440's own spike/flap regression) **still passes** — the real garbage cutter is not a closed manifold, so the #1440 fix is preserved.
- Full geometry suite green (413 unit + all integration tests; snapshots unchanged); new unit test `watertight_tall_roof_cutter_is_not_flagged_malformed` guards the false positive; clippy-clean.