### PR TITLE
perf(export): share one entity index across geometry and attribute passes

### DIFF
--- a/rust/export/src/gltf.rs
+++ b/rust/export/src/gltf.rs
@@ -12,9 +12,11 @@
 //! zero (local-frame feature off) the output is byte-equivalent to the old TS path.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
+use ifc_lite_core::EntityIndex;
 use ifc_lite_geometry::{collate_refs, InstanceMeshRef, InstanceMeta, InstanceTemplate};
-use ifc_lite_processing::{process_geometry, MeshData};
+use ifc_lite_processing::{process_geometry, process_geometry_with_index, MeshData, ProcessingResult};
 use serde::Serialize;
 use serde_json::{json, Value};
 
@@ -926,7 +928,22 @@ fn assemble_glb(
 
 /// Like [`export_glb`] but also returns coverage stats. Meshes the model from bytes.
 pub fn export_glb_with_stats(content: &[u8], opts: &GltfOptions) -> (Vec<u8>, GltfStats) {
-    let result = process_geometry(content);
+    export_glb_from_result(process_geometry(content), opts)
+}
+
+/// Like [`export_glb_with_stats`] but reuses a pre-built entity index — for a caller
+/// that also runs the attribute pass ([`crate::stream_export_model_with_index`]) over
+/// the same bytes, `build_entity_index` once and share it across both. `index` MUST be
+/// built from the same `content`; output is byte-identical to `export_glb_with_stats`.
+pub fn export_glb_with_stats_with_index(
+    content: &[u8],
+    opts: &GltfOptions,
+    index: Arc<EntityIndex>,
+) -> (Vec<u8>, GltfStats) {
+    export_glb_from_result(process_geometry_with_index(content, index), opts)
+}
+
+fn export_glb_from_result(result: ProcessingResult, opts: &GltfOptions) -> (Vec<u8>, GltfStats) {
     // `process_geometry` emits the producer-native IFC **Z-up** frame (the Z-up→Y-up
     // swap normally happens at the wasm FFI, which this path never crosses). glTF
     // mandates +Y-up, so convert each visible mesh to Y-up — positions/normals
@@ -1099,6 +1116,19 @@ mod tests {
         assert_eq!(&glb[json_end + 4..json_end + 8], b"BIN\0", "BIN tag");
         let bin = glb[json_end + 8..json_end + 8 + bin_len].to_vec();
         (json, bin)
+    }
+
+    #[test]
+    fn with_index_glb_is_byte_identical() {
+        // The shared-index path must emit byte-for-byte the same GLB as the
+        // self-indexing path — it only injects an index equal to the one
+        // `export_glb_with_stats` builds internally. Guards the two from drifting.
+        let bytes = fixture("ara3d/duplex.ifc");
+        let opts = GltfOptions::default();
+        let (plain, _) = export_glb_with_stats(&bytes, &opts);
+        let idx = Arc::new(crate::build_entity_index(&bytes));
+        let (shared, _) = export_glb_with_stats_with_index(&bytes, &opts, idx);
+        assert_eq!(plain, shared, "shared-index GLB must equal self-indexed GLB");
     }
 
     #[test]

--- a/rust/export/src/lib.rs
+++ b/rust/export/src/lib.rs
@@ -30,16 +30,23 @@ mod shades;
 mod step;
 
 pub use csv::{export_csv, CsvMode, CsvOptions};
-pub use gltf::{export_glb, export_glb_from_meshes, export_glb_with_stats, GltfOptions, GltfStats};
+pub use gltf::{
+    export_glb, export_glb_from_meshes, export_glb_with_stats, export_glb_with_stats_with_index,
+    GltfOptions, GltfStats,
+};
 pub use hbjson::Model;
+// Re-exported so a caller can `build_entity_index` once and share it across the
+// geometry (`export_glb_with_stats_with_index`) and attribute
+// (`stream_export_model_with_index`) passes.
+pub use ifc_lite_core::{build_entity_index, EntityIndex};
 pub use ifc5::{export_ifc5, Ifc5Options};
 pub use json::{export_json, JsonOptions};
 pub use jsonld::{export_jsonld, JsonLdOptions};
 pub use kmz::{export_kmz, ifc_angle_to_kml_heading, KmzOptions};
 pub use merged::{export_merged, export_merged_with_stats, MergedOptions, MergedStats};
 pub use model::{
-    build_export_model, stream_export_model, EntityRow, ExportModel, PropValue, PropertySet,
-    QuantitySet, QuantityValue,
+    build_export_model, stream_export_model, stream_export_model_with_index, EntityRow,
+    ExportModel, PropValue, PropertySet, QuantitySet, QuantityValue,
 };
 pub use obj::{export_obj, export_obj_with_stats, ObjOptions, ObjStats};
 #[cfg(feature = "parquet-bos")]

--- a/rust/export/src/model.rs
+++ b/rust/export/src/model.rs
@@ -9,9 +9,11 @@
 //! directly-attached `IfcRelDefinesByProperties` property/quantity sets.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use ifc_lite_core::{
-    build_entity_index, AttributeValue, DecodedEntity, EntityDecoder, EntityScanner, IfcType,
+    build_entity_index, AttributeValue, DecodedEntity, EntityDecoder, EntityIndex, EntityScanner,
+    IfcType,
 };
 
 /// A single property value (`IfcPropertySingleValue` and friends).
@@ -217,15 +219,28 @@ pub fn build_export_model(content: &[u8]) -> ExportModel {
 /// plus the property side-map (both O(products)), so a model with tens of millions
 /// of entities extracts in a few GB instead of exhausting memory. Output is the
 /// caller's responsibility to stream onwards (e.g. to S3/Parquet) and drop.
-pub fn stream_export_model(content: &[u8], mut f: impl FnMut(EntityRow)) {
+pub fn stream_export_model(content: &[u8], f: impl FnMut(EntityRow)) {
+    let entity_index = Arc::new(build_entity_index(content));
+    stream_export_model_with_index(content, &entity_index, f);
+}
+
+/// Like [`stream_export_model`] but reuses a pre-built entity index. A caller also
+/// running the geometry pass ([`crate::export_glb_with_stats_with_index`]) over the
+/// same bytes builds the index once with [`build_entity_index`] and shares it across
+/// both, skipping the duplicate scan. `entity_index` MUST be built from the same
+/// `content`; output is identical to `stream_export_model`.
+pub fn stream_export_model_with_index(
+    content: &[u8],
+    entity_index: &Arc<EntityIndex>,
+    mut f: impl FnMut(EntityRow),
+) {
     // Property resolution memoizes the shared `IfcPropertySet`/leaf entities for
     // speed. Cap that cache so it can't grow without bound across millions of
     // products; clearing only forces a re-decode of a shared set, never affects
     // correctness.
     const PSET_CACHE_CAP: usize = 1 << 18; // 262_144 entries
 
-    let entity_index = build_entity_index(content);
-    let mut decoder = EntityDecoder::with_index(content, entity_index);
+    let mut decoder = EntityDecoder::with_arc_index(content, entity_index.clone());
 
     // Pass 1 — object → attached property/quantity definitions (IfcRelDefinesByProperties).
     // IfcRelDefinesByProperties: [GlobalId, OwnerHistory, Name, Description,
@@ -375,6 +390,26 @@ mod tests {
         stream_export_model(&bytes, |r| streamed.push(r));
         assert!(!streamed.is_empty(), "expected products");
         assert_eq!(collected, streamed, "stream and collect must agree row-for-row");
+    }
+
+    #[test]
+    fn stream_with_index_matches_plain() {
+        // The injected-index path shares one index across passes; it must yield
+        // identical rows to the self-indexing path. Guards the two from drifting.
+        let rel = "ara3d/duplex.ifc";
+        let path = format!("{}/../../tests/models/{}", env!("CARGO_MANIFEST_DIR"), rel);
+        if !std::path::Path::new(&path).exists() {
+            eprintln!("skipping {rel}: fixture absent — run `pnpm fixtures`");
+            return;
+        }
+        let bytes = fixture(rel);
+        let mut plain = Vec::new();
+        stream_export_model(&bytes, |r| plain.push(r));
+        let idx = Arc::new(build_entity_index(&bytes));
+        let mut shared = Vec::new();
+        stream_export_model_with_index(&bytes, &idx, |r| shared.push(r));
+        assert!(!plain.is_empty(), "expected products");
+        assert_eq!(plain, shared, "injected-index rows must match self-indexed rows");
     }
 
     #[test]

--- a/rust/processing/src/lib.rs
+++ b/rust/processing/src/lib.rs
@@ -23,7 +23,7 @@ pub use georeferencing::{extract_georeferencing, Georeferencing};
 pub use ifc_lite_geometry::TessellationQuality;
 pub use processor::{
     convert_mesh_to_site_local, process_geometry, process_geometry_filtered,
-    process_geometry_filtered_with_quality,
+    process_geometry_filtered_with_quality, process_geometry_with_index,
     process_geometry_streaming, process_geometry_streaming_filtered,
     process_geometry_streaming_filtered_with_options, process_geometry_streaming_with_options,
     process_geometry_streaming_with_options_and_bootstrap,

--- a/rust/processing/src/processor/mod.rs
+++ b/rust/processing/src/processor/mod.rs
@@ -114,7 +114,9 @@ pub struct ProcessingResult {
 }
 
 /// Controls the tradeoff between first-frame latency and richer upfront metadata.
-#[derive(Debug, Clone, Copy)]
+// Not `Copy`: `entity_index` holds an `Arc`. Every construction either moves the
+// struct into a process call once or `..Default::default()`s it, so `Clone` suffices.
+#[derive(Debug, Clone)]
 pub struct StreamingOptions {
     /// Batch size used for the very first emitted chunk.
     pub initial_batch_size: usize,
@@ -137,6 +139,14 @@ pub struct StreamingOptions {
     /// (`symbolic.rs`) deliberately ignores the level — symbols are
     /// resolution-independent line work.
     pub tessellation_quality: TessellationQuality,
+    /// Pre-built entity index to reuse instead of scanning `content` again. A caller
+    /// that runs both the geometry pass and a second pass over the same bytes (e.g. a
+    /// server emitting GLB *and* extracting properties) can `build_entity_index`
+    /// once and inject it here, skipping the duplicate SIMD scan. `None` builds it
+    /// internally, exactly as before. The index MUST come from
+    /// `build_entity_index(content)` for the *same* `content`, or decoding will read
+    /// the wrong byte ranges.
+    pub entity_index: Option<Arc<EntityIndex>>,
 }
 
 impl Default for StreamingOptions {
@@ -150,6 +160,7 @@ impl Default for StreamingOptions {
             emit_quick_metadata_bootstrap: false,
             retain_emitted_meshes: true,
             tessellation_quality: TessellationQuality::default(),
+            entity_index: None,
         }
     }
 }
@@ -279,6 +290,31 @@ where
     T: AsRef<[u8]> + ?Sized,
 {
     process_geometry_filtered(content.as_ref(), OpeningFilterMode::Default)
+}
+
+/// Like [`process_geometry`] but reuses a pre-built entity index instead of scanning
+/// `content` for one. For a caller that also runs a second pass over the same bytes
+/// (e.g. pairing GLB export with attribute extraction): build the index once with
+/// `ifc_lite_core::build_entity_index` and share it across both, skipping the
+/// duplicate scan. `index` MUST be built from the same `content`. Output is identical
+/// to `process_geometry(content)`.
+pub fn process_geometry_with_index<T>(content: &T, index: Arc<EntityIndex>) -> ProcessingResult
+where
+    T: AsRef<[u8]> + ?Sized,
+{
+    process_geometry_streaming_filtered_with_options(
+        content.as_ref(),
+        OpeningFilterMode::Default,
+        StreamingOptions {
+            initial_batch_size: usize::MAX,
+            throughput_batch_size: usize::MAX,
+            entity_index: Some(index),
+            ..StreamingOptions::default()
+        },
+        |_, _, _| {},
+        |_| {},
+        |_| {},
+    )
 }
 
 /// Process IFC content with parallel geometry extraction and emit batches as they complete.
@@ -412,8 +448,12 @@ pub fn process_geometry_streaming_filtered_with_options(
         "Starting IFC geometry processing"
     );
 
-    // Build entity index (fast SIMD-accelerated single pass)
-    let entity_index = Arc::new(build_entity_index(content));
+    // Build the entity index (fast SIMD-accelerated single pass), unless a caller
+    // injected one built from the same `content` to share across passes.
+    let entity_index = options
+        .entity_index
+        .clone()
+        .unwrap_or_else(|| Arc::new(build_entity_index(content)));
     let mut decoder = EntityDecoder::with_arc_index(content, entity_index.clone());
     tracing::debug!("Built entity index");
 


### PR DESCRIPTION
## What

A caller that runs both the GLB geometry pass and the attribute-extraction pass over the same bytes built the entity index twice — once in each pass. This adds an optional injectable index so it can be built once and shared.

- **processing:** `StreamingOptions.entity_index` (optional) + `process_geometry_with_index`
- **export:** `export_glb_with_stats_with_index`, `stream_export_model_with_index`, and re-exported `build_entity_index` / `EntityIndex`

The existing no-index entry points are unchanged — they build the index internally exactly as before. `stream_export_model` is now a thin wrapper over the indexed variant (mirroring how `build_export_model` wraps `stream_export_model`).

## Correctness

Output is byte-identical whether the index is injected or built internally, guarded by two new tests:
- `gltf::with_index_glb_is_byte_identical` — same GLB bytes
- `model::stream_with_index_matches_plain` — same rows

Full export + processing + core suites green; clippy clean.

## Performance

Measured end-to-end (geometry GLB + attribute extraction) on large models:
- ~1 GB / 14 M-entity file: 26.0 s → 24.0 s (saves ~1.9 s, ~7%)
- 536 MB file: 8.4 s → 7.6 s (~10%)

The gain is eliminating one of the two duplicate SIMD index scans; it scales with entity count, so it is a no-op on small models and meaningful on large ones.

## Notes

`StreamingOptions` drops `Copy` (it now holds an `Arc`); it keeps `Clone`. Every construction either moves it into a process call once or uses `..Default::default()`, so no call site relied on `Copy`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added indexed export support for GLB generation and shared prebuilt geometry index reuse across export passes.
  * Added indexed streaming for model extraction using a prebuilt IFC entity index.
  * Introduced `process_geometry_with_index` and an option to inject a shared entity index into geometry processing.

* **Bug Fixes**
  * Ensured indexed and non-indexed export results remain consistent (byte-identical GLB output and matching streamed rows).

* **Tests**
  * Added parity tests covering byte-identical GLB generation and identical streamed entity rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

The changes are limited to adding indexed variants while preserving existing entry points as wrappers.

The implementation is covered by parity tests for byte-identical GLB output and matching streamed rows, and no review comments remain.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the index-parity export checks and captured Before and After logs, and found that no Rust command could execute, so the validation result is inconclusive.
- Compared the before/after parity artifacts for process\_geometry\_with\_index and StreamingOptions.entity\_index, confirmed the After state injects Arc::new(build\_entity\_index(bytes)) and that compile behavior includes the expected E0277 failure for assert\_copy::\<StreamingOptions\>(), indicating Copy was dropped.

<a href="https://app.greptile.com/trex/runs/12813610/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["perf(export): share one entity index acr..."](https://github.com/ltplus-ag/ifc-lite/commit/9d7a2883e762975d8ec34592d2962b0196b1a8f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40895660)</sub>

<!-- /greptile_comment -->