### PR TITLE
ci: cut Depot spend (Docker cache to GHCR + free-runner WASM fast path)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,8 +42,8 @@ jobs:
     # Cap a stuck "Build and push" so it can't run to GitHub's 6h default.
     # A *cold* build — cargo-chef cooking the whole workspace after a
     # deps-cache miss — is the long pole, and a cold build that gets cancelled
-    # never warms the gha cache, so the cap must let one complete. 120 covers
-    # a cold build; warm builds finish in minutes.
+    # never warms the registry cache, so the cap must let one complete. 120
+    # covers a cold build; warm builds finish in minutes.
     timeout-minutes: 120
     permissions:
       contents: read
@@ -97,16 +97,27 @@ jobs:
           labels: |
             ${{ steps.meta.outputs.labels }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-          cache-from: type=gha
+          # Cache lives in GHCR (a `:buildcache` tag on the same package), NOT
+          # in the GitHub Actions cache. On a Depot runner `type=gha` is
+          # intercepted by Depot's cache backend and billed per-GB — with
+          # mode=max writing the multi-GB cargo-chef layer set on ~1/3 of main
+          # pushes, that was the single largest contributor to Depot's uncapped
+          # cache bill. `type=registry` writes straight to GHCR instead, which
+          # is free + unlimited for public packages, so the cache cost drops to
+          # $0 while warm builds stay fast. Trade: pushing the cache to GHCR
+          # adds ~1-3 min of network per build vs Depot's local cache.
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
           # mode=max keeps the cargo-chef "cooked deps" stage in the cache —
           # that layer is what makes warm builds finish in minutes instead of
           # recompiling the whole workspace, so dropping to mode=min would
-          # *raise* compute minutes.
-          cache-to: type=gha,mode=max
+          # *raise* compute minutes. image-manifest+oci-mediatypes make the
+          # cache blob a GHCR-compatible OCI manifest (required for the registry
+          # backend to push to ghcr.io).
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true
           # Build arm64 only for actual releases (distribution images). On the
           # frequent push-to-main builds (~1/3 of commits touch rust/** and
           # trigger this workflow) we build amd64 only — the arm64 leg runs
-          # under slow QEMU emulation and doubled both build time AND the gha
-          # cache that drives Depot's per-GB storage bill. The `latest`/sha
-          # main images stay amd64; multi-arch manifests ship on release.
+          # under slow QEMU emulation and roughly doubled build time (and, when
+          # the cache was on Depot, the cache bill too). The `latest`/sha main
+          # images stay amd64; multi-arch manifests ship on release.
           platforms: ${{ github.event_name == 'release' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}

--- a/.github/workflows/test-templates.yml
+++ b/.github/workflows/test-templates.yml
@@ -17,7 +17,13 @@ permissions:
 jobs:
   test-templates:
     name: Scaffold & verify (${{ matrix.template }})
-    runs-on: depot-ubuntu-24.04-4
+    # Free GitHub-hosted runner. This job scaffolds a template, runs
+    # `npm install` + tsc + a vite/tsc build against PUBLISHED packages —
+    # no Rust/WASM compile and no cargo cache to preserve, so it never
+    # needed Depot's paid cores. A 6-way matrix on `depot-ubuntu-24.04-4`
+    # was billing 6 x 2x the base rate for pure JS work; `ubuntu-latest` is
+    # free + unlimited on a public repo. See scripts/README-vercel-cost.md.
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,11 @@ jobs:
       rust: ${{ steps.filter.outputs.rust }}
       frontend: ${{ steps.filter.outputs.frontend }}
       geometry: ${{ steps.filter.outputs.geometry }}
+      # `true` when the WASM source is byte-identical to the published release
+      # tag, so `build` can fetch the prebuilt bundle and run on a FREE runner
+      # instead of compiling wasm32 on a paid Depot runner. See the `build`
+      # job and scripts/ci-wasm-prebuilt-eligible.sh.
+      wasm_prebuilt: ${{ steps.wasm.outputs.eligible }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -77,6 +82,15 @@ jobs:
               - 'Cargo.lock'
               - '.github/workflows/test.yml'
 
+      # Decide whether `build` can skip the from-source wasm32 compile. The
+      # probe emits `true` only when the WASM source is byte-identical to the
+      # `@ifc-lite/wasm@<version>` release tag that produced the published
+      # bundle; any doubt emits `false` → build from source on Depot (unchanged
+      # behaviour). It can never green-light a stale bundle.
+      - name: Resolve prebuilt-WASM eligibility
+        id: wasm
+        run: echo "eligible=$(bash scripts/ci-wasm-prebuilt-eligible.sh)" >> "$GITHUB_OUTPUT"
+
   # Shared install + WASM + workspace build. Uploads built dist/ for the
   # downstream JS jobs; Rust jobs do their own checkout + cargo cache
   # restore (Swatinem) and don't need this artifact.
@@ -84,7 +98,15 @@ jobs:
     name: Build packages + WASM
     needs: changes
     if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.frontend == 'true'
-    runs-on: depot-ubuntu-24.04-4
+    # Runner is chosen by whether we can skip the wasm32 compile. When the WASM
+    # source is byte-identical to the published release tag (the common case on
+    # frontend-only PRs), we fetch the prebuilt @ifc-lite/wasm bundle and run on
+    # a FREE ubuntu-latest runner — no Rust toolchain, no wasm-pack, no Swatinem
+    # rust-cache write to Depot. When Rust changed we compile from source on the
+    # paid Depot runner (needs the cores + the uncapped cargo cache), exactly as
+    # before. This is the CI twin of the scripts/vercel-install.sh fast path and
+    # attacks the single largest Depot line — the wasm32 compile on ~2/3 of PRs.
+    runs-on: ${{ needs.changes.outputs.wasm_prebuilt == 'true' && 'ubuntu-latest' || 'depot-ubuntu-24.04-4' }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -111,14 +133,35 @@ jobs:
       # Rust + wasm-pack for the wasm32 build (pure-Rust CSG kernel — no
       # C++ toolchain needed since M9). Single-sourced in
       # .github/actions/setup-wasm-build so the four wasm-building
-      # workflows stay in lock-step.
+      # workflows stay in lock-step. Skipped on the prebuilt fast path — that's
+      # where the Depot minutes AND the `ci-build` Swatinem rust-cache write to
+      # Depot both disappear.
       - name: Setup WASM build toolchain
+        if: needs.changes.outputs.wasm_prebuilt != 'true'
         uses: ./.github/actions/setup-wasm-build
         with:
           cache-prefix: ci-build
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      # Fast path: drop the published bundle into packages/wasm/pkg/ so the
+      # from-source `Build WASM` step below soft-skips (wasm-pack absent +
+      # runtime present → exit 0) and downstream consumers get a working
+      # runtime. Only runs when `changes` proved the source matches the release
+      # tag, so this is the exact binary a source build would produce. Retried
+      # because it's the one new hard-fail path (no Rust toolchain to fall back
+      # to on this runner); a transient npm blip shouldn't block the PR.
+      - name: Fetch prebuilt WASM
+        if: needs.changes.outputs.wasm_prebuilt == 'true'
+        run: |
+          for attempt in 1 2 3; do
+            if node scripts/fetch-prebuilt-wasm.mjs; then exit 0; fi
+            echo "::warning::prebuilt WASM fetch attempt ${attempt} failed; retrying…"
+            sleep $((attempt * 5))
+          done
+          echo "::error::Could not fetch the prebuilt @ifc-lite/wasm bundle after 3 attempts."
+          exit 1
 
       # Cache the fetched fixture tree keyed on the manifest hash. ~994 MiB.
       # Cache hit = no network. Cache miss (manifest changed) = one cold pull
@@ -146,7 +189,11 @@ jobs:
       # (pkg/ifc-lite.d.ts) is committed for the wasm-free typecheck lane
       # (#952). This step catches Rust → wasm breakage before downstream
       # consumers see it.
+      # Skipped on the prebuilt fast path (the bundle was just fetched above);
+      # the type-sync gate below is skipped there too, since a frontend-only PR
+      # can't have changed the committed .d.ts.
       - name: Build WASM
+        if: needs.changes.outputs.wasm_prebuilt != 'true'
         run: bash scripts/build-wasm.sh
 
       # Guard the wasm-free typecheck lane (#952): the committed
@@ -158,6 +205,7 @@ jobs:
       # churn on every wasm-pack run (see AGENTS.md) and are intentionally
       # excluded.
       - name: Verify committed wasm types are in sync
+        if: needs.changes.outputs.wasm_prebuilt != 'true'
         run: |
           if ! git diff --quiet -- packages/wasm/pkg/ifc-lite.d.ts; then
             echo "::error file=packages/wasm/pkg/ifc-lite.d.ts::Committed wasm types are out of sync with the Rust source. Run 'bash scripts/build-wasm.sh' and commit the regenerated packages/wasm/pkg/ifc-lite.d.ts."

--- a/scripts/README-vercel-cost.md
+++ b/scripts/README-vercel-cost.md
@@ -42,6 +42,7 @@ Snapshot that triggered this work (June 2026):
 | Job | Runner | Rationale |
 |---|---|---|
 | `changes`, `lint`, `typecheck`, `node-tests`, `test` gate | `ubuntu-latest` (free) | Not compile-bound; free + unlimited on a public repo |
+| `test-templates` (6-way matrix) | `ubuntu-latest` (free) | Scaffolds + builds templates against published pkgs; no Rust/WASM compile, no cargo cache — never needed Depot |
 | `desktop-override-audit` | `ubuntu-latest` (free) | Only `[ -f ]` file checks |
 | `build` (WASM) | `depot-ubuntu-24.04-4` | Compiles the WASM bundle; needs cores + cache |
 | `desktop-frontend-build` | `depot-ubuntu-24.04-4` | Compiles WASM from source |
@@ -68,6 +69,19 @@ Change: build **amd64 only on push-to-main** (`latest`/sha images), and
 **multi-arch only on `release: published`** (distribution images). `mode=max` is
 intentionally kept — it caches the cargo-chef "cooked deps" layer that makes
 warm builds finish in minutes; `mode=min` would *raise* compute minutes.
+
+**Cache backend moved off Depot (the bigger lever).** The build cache was
+`cache-to: type=gha,mode=max`. On a Depot runner `type=gha` is intercepted by
+Depot's cache backend and **billed per-GB** — and mode=max writes the whole
+multi-GB cargo-chef layer set on every rust-touching main push, so this was the
+single largest contributor to Depot's uncapped cache (it reached 173 GB). Now
+it's `type=registry,ref=…/ifc-lite-server:buildcache` — the cache lives as a
+`:buildcache` tag on the same GHCR package, which is **free + unlimited for
+public packages**. Warm builds stay fast; the cache line drops to $0. Cost:
+~1-3 min of extra network per build to push the cache to GHCR (vs Depot's local
+cache). The docker job itself stays on Depot for compute; a further option is to
+move it to a free `ubuntu-latest` runner (registry cache keeps warm builds
+reasonable, but cold cargo-chef builds get slow — accept the timeout risk first).
 
 Future option if arm64-on-main is ever wanted again: use Depot's **native arm64
 runners** (`depot-ubuntu-24.04-arm-*`, AWS Graviton, no QEMU) via a build matrix

--- a/scripts/README-vercel-cost.md
+++ b/scripts/README-vercel-cost.md
@@ -44,17 +44,46 @@ Snapshot that triggered this work (June 2026):
 | `changes`, `lint`, `typecheck`, `node-tests`, `test` gate | `ubuntu-latest` (free) | Not compile-bound; free + unlimited on a public repo |
 | `test-templates` (6-way matrix) | `ubuntu-latest` (free) | Scaffolds + builds templates against published pkgs; no Rust/WASM compile, no cargo cache — never needed Depot |
 | `desktop-override-audit` | `ubuntu-latest` (free) | Only `[ -f ]` file checks |
-| `build` (WASM) | `depot-ubuntu-24.04-4` | Compiles the WASM bundle; needs cores + cache |
+| `build` (WASM) | **`ubuntu-latest` (free) OR `depot-ubuntu-24.04-4`** | Frontend-only PRs fetch the prebuilt bundle and run free; Rust PRs compile from source on Depot. See §1a |
 | `desktop-frontend-build` | `depot-ubuntu-24.04-4` | Compiles WASM from source |
 | `rust-tests` | `depot-ubuntu-24.04-4` (was `-8`) | Kept on Depot for the cargo cache; right-sized for cost |
 | ~~`manifold-tests`~~ | — | DELETED at M9 (Manifold C++ kernel removed; pure-Rust kernel runs in `rust-tests`) |
 
 `release.yml`, `docs.yml`, `sdk-canary.yml` already use free `ubuntu-latest`.
 
+### 1a. Prebuilt-WASM fast path in CI (the biggest compute lever)
+
+The `build` job compiles `rust → wasm32` on **every** PR, but the WASM only
+changes on the ~1/3 of PRs that touch Rust. On the other ~2/3 (viewer/frontend
+work) the compile is wasted — and it's the single largest Depot compute line,
+plus its `ci-build` Swatinem rust-cache is a top Depot storage entry.
+
+The `changes` job now runs `scripts/ci-wasm-prebuilt-eligible.sh`, the CI twin
+of the `scripts/vercel-install.sh` fast path. It emits `wasm_prebuilt=true` only
+when the WASM source (`rust/** + Cargo.{toml,lock} + rust-toolchain.toml +
+scripts/build-wasm.sh`) is **byte-identical to the `@ifc-lite/wasm@<version>`
+release tag** that produced the published bundle. When true, `build`:
+- runs on **free `ubuntu-latest`** instead of paid Depot (`runs-on` is a
+  conditional expression on the output),
+- **skips** the Rust toolchain, the wasm32 compile, and the `ci-build`
+  rust-cache write to Depot,
+- **fetches** the published bundle via `scripts/fetch-prebuilt-wasm.mjs` (the
+  from-source `Build WASM` step then soft-skips: wasm-pack absent + runtime
+  present → exit 0).
+
+**Correctness:** any doubt (version unreadable, tag unreachable, Rust changed)
+emits `false` → compile from source on Depot, exactly as before. Because the
+guard is a byte-identical diff against the exact release tag, the fetched binary
+is what a source build would produce — a stale bundle can never be tested. The
+one new hard-fail path (prebuilt fetch fails on a runner with no Rust fallback)
+is retried 3× so a transient npm blip doesn't block the PR.
+
 ### Depot — do this in the dashboard (one-time)
-- **Cache → Retention: 7 days** (default is 14 days, *no size cap* — that's how it
-  reached 173 GB). Combined with the docker arm64 change below this is the main
-  cache-cost lever.
+- **Cache → Retention: 7 days** — already set. Note this alone doesn't shrink a
+  253 GB cache that's re-written faster than 7 days; the code-side levers (docker
+  cache → GHCR in §2, the WASM fast path above) are what stop *feeding* it. The
+  Cache Explorer shows the bulk is docker `buildkit-blob-*` (moved to GHCR by §2)
+  + the `ci-build`/`ci-rust` rust-caches.
 
 ---
 

--- a/scripts/ci-wasm-prebuilt-eligible.sh
+++ b/scripts/ci-wasm-prebuilt-eligible.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# CI prebuilt-WASM eligibility probe (see scripts/README-vercel-cost.md §1a).
+#
+# Emits a single token on STDOUT — `true` or `false` — for the test.yml
+# `changes` job to expose as an output. All diagnostics go to STDERR so the
+# captured value is a clean boolean.
+#
+#   true  → the published @ifc-lite/wasm bundle is byte-for-byte reproducible
+#           from this checkout (the WASM source is identical to the release tag
+#           that built it), so `build` can fetch the prebuilt bundle and run on
+#           a FREE runner instead of compiling wasm32 on a paid Depot runner.
+#   false → ANY uncertainty (version unreadable, tag unreachable, Rust source
+#           differs). `build` then compiles from source on Depot, exactly as
+#           before. The fast path can NEVER cause a stale bundle to be tested.
+#
+# This is the CI twin of the fast path in scripts/vercel-install.sh — keep the
+# WASM_SRC_PATHS list and the "any doubt → build from source" guarantee in
+# lock-step with that script.
+set -uo pipefail
+
+log() { echo "$@" >&2; }
+
+WASM_VERSION="$(node -p "require('./packages/wasm/package.json').version" 2>/dev/null || true)"
+if [ -z "${WASM_VERSION:-}" ]; then
+  log "🛠  wasm version unreadable — build from source."
+  echo false
+  exit 0
+fi
+
+WASM_TAG="@ifc-lite/wasm@${WASM_VERSION}"
+# Conservative superset: any Rust workspace change invalidates the fast path,
+# even one that can't reach the wasm-bindings crate. Correctness over savings.
+# MUST match WASM_SRC_PATHS in scripts/vercel-install.sh.
+WASM_SRC_PATHS=(rust Cargo.lock Cargo.toml rust-toolchain.toml scripts/build-wasm.sh)
+
+_tag_present() { git rev-parse -q --verify "refs/tags/${WASM_TAG}^{commit}" >/dev/null 2>&1; }
+
+if ! _tag_present; then
+  # actions/checkout is a shallow clone without tags — fetch just this one
+  # release tag from origin (anonymous read; ifc-lite is public) so we can diff
+  # against it. Best-effort: a blocked fetch simply leaves the tag absent and we
+  # fall through to the from-source build below.
+  log "ℹ️  Fetching release tag ${WASM_TAG} from origin (shallow)…"
+  git fetch --depth=1 origin "+refs/tags/${WASM_TAG}:refs/tags/${WASM_TAG}" >&2 2>&1 || true
+fi
+
+if ! _tag_present; then
+  log "🛠  Release tag ${WASM_TAG} not reachable in this clone — build from source."
+  echo false
+  exit 0
+fi
+
+if git diff --quiet "refs/tags/${WASM_TAG}" HEAD -- "${WASM_SRC_PATHS[@]}"; then
+  log "🅰  WASM source identical to ${WASM_TAG} — prebuilt npm bundle is valid."
+  echo true
+  exit 0
+fi
+
+log "🛠  Rust sources changed since ${WASM_TAG} — build from source."
+git diff --name-only "refs/tags/${WASM_TAG}" HEAD -- "${WASM_SRC_PATHS[@]}" \
+  | sed 's/^/     changed: /' | head -20 >&2 || true
+echo false
+exit 0


### PR DESCRIPTION
Cuts the ~\$255/mo Depot bill, which the dashboard breaks down as ~\$200 GitHub-Actions runner minutes (50,607 billable min) + ~\$46 cache storage (253 GB). Cache Explorer shows the 253 GB is dominated by Docker `buildkit-blob-*` entries + the `ci-rust`/`ci-build` Swatinem rust-caches. See `scripts/README-vercel-cost.md`.

## Changes

**1. Docker build cache: `type=gha` -> `type=registry` on GHCR** (`docker.yml`)
On a Depot runner `type=gha` is intercepted by Depot's cache backend and billed per-GB; with `mode=max` it writes the multi-GB cargo-chef layer set on ~1/3 of main pushes — the single largest cache contributor. It now lives as a `:buildcache` tag on the same GHCR package (free + unlimited for public packages). Warm builds stay fast; the job stays on Depot for compute. Trade: ~1-3 min extra network/build to push the cache.

**2. Free-runner WASM fast path** (`test.yml` + new `scripts/ci-wasm-prebuilt-eligible.sh`)
`build` compiled `rust -> wasm32` on every PR, but WASM only changes on the ~1/3 that touch Rust. The `changes` job now emits `wasm_prebuilt=true` only when the WASM source is byte-identical to the `@ifc-lite/wasm@<version>` release tag that produced the published bundle (the CI twin of the `scripts/vercel-install.sh` fast path). When true, `build`:
- runs on **free `ubuntu-latest`** instead of paid `depot-ubuntu-24.04-4`,
- **skips** the Rust toolchain + wasm32 compile + the `ci-build` rust-cache write to Depot,
- **fetches** the published bundle via `scripts/fetch-prebuilt-wasm.mjs` (the from-source `Build WASM` step then soft-skips), and skips the `.d.ts` type-sync gate (a frontend-only PR can't have changed the committed types).

Correctness: any doubt (version unreadable, tag unreachable, Rust changed) emits `false` -> compile from source on Depot, exactly as before. Because the guard is a byte-identical diff against the exact release tag, the fetched binary is what a source build would produce — a stale bundle can never be tested. The one new hard-fail path (prebuilt fetch on a runner with no Rust fallback) is retried 3x.

**3. `test-templates` -> `ubuntu-latest`** (`test-templates.yml`)
Scaffolds + builds templates against published packages — no Rust/WASM compile, no cargo cache — so the 6-way matrix never needed Depot's paid cores.

## Estimated impact
Compute drops on the ~2/3 of PRs that don't touch Rust (`build` goes free); storage loses the Docker `buildkit-blob-*` entries (to free GHCR). Roughly ~\$255 -> ~\$130-160/mo.

## Validation caveat
The WASM fast path **needs one green CI run on a real frontend-only PR** (where `main` isn't ahead of the release tag on Rust) to confirm the prebuilt path fires — look for `WASM source identical` in the `changes` log and `build` scheduled on `ubuntu-latest`. Every other path is unchanged from current behavior.

## Not in this PR (dashboard-only)
- Depot Cache Storage Policy is "No limit" (retention already 7 days)
- Vercel: confirm landing is off the 30-core Turbo machine + ignored-build-steps are live
- Railway: idle 24/7 Superset + two dormant services (collab-server, ifc-lite-api)

CI-only; no published-package src touched (no changeset needed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a faster CI path that can reuse a published WASM bundle when the source matches, reducing build time on paid runners.
  * Updated Docker build caching to use a registry-backed cache for improved reuse across builds.

* **Bug Fixes**
  * Tightened CI checks so source-based WASM builds and type-synchronization steps only run when needed.

* **Chores**
  * Switched one test job to free GitHub-hosted runners and updated workflow notes and cost guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Confidence Score: 4/5</h3>

The changes are CI-only and preserve conservative fallbacks for the WASM source-build path.

The workflow logic is scoped to runner/cache selection and guarded prebuilt reuse, with fallback behavior retained when source identity cannot be proven.

The prebuilt-WASM path should be observed on a real frontend-only PR to confirm the intended runner selection and fetch path in GitHub Actions.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The Docker cache configuration in CI was updated to use registry-based caching instead of the GHCR cache, updating the cache-from and cache-to directives accordingly while preserving the existing runs-on and platforms expression.
- In the wasm fast-path flow, the after-state now includes head workflow checks with a script, conditional build runner, fetch step, and a retry loop.
- The wasm fast-path after-state also shows conservative false outputs due to current Rust differences, including a forced source-difference checkout and an unreadable version, with stdout reported as false and diagnostics on stderr.
- A feasible true scenario is demonstrated using a tag-identical WASM source and a committed source difference from that tag, with stdout reported as true (and a subsequent stdout false due to Cargo.toml diagnostics).
- The templates-runner workflow was updated to run on ubuntu-latest while preserving the six templates and their scaffold/build steps.

<a href="https://app.greptile.com/trex/runs/12886928/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: skip from-source WASM compile on non..."](https://github.com/ltplus-ag/ifc-lite/commit/0732e21b7a52e359eb3d1f0a5109ac27fbee5496) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41038405)</sub>

<!-- /greptile_comment -->