### PR TITLE
fix(ci): lowercase the Docker registry cache ref

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -87,6 +87,13 @@ jobs:
             # sha for push-to-main builds
             type=sha,prefix=,event=branch
 
+      # The registry cache exporter requires a fully lowercase repository name
+      # (OCI spec), but ${{ github.repository_owner }} preserves case
+      # (`LTplus-AG`). The image *tags* are fine because docker/metadata-action
+      # lowercases them; the raw cache ref below is not, so lowercase it here.
+      - name: Compute lowercase cache ref
+        run: echo "CACHE_IMAGE=${REGISTRY}/$(echo "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
       - name: Build and push
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
@@ -106,14 +113,14 @@ jobs:
           # is free + unlimited for public packages, so the cache cost drops to
           # $0 while warm builds stay fast. Trade: pushing the cache to GHCR
           # adds ~1-3 min of network per build vs Depot's local cache.
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-from: type=registry,ref=${{ env.CACHE_IMAGE }}:buildcache
           # mode=max keeps the cargo-chef "cooked deps" stage in the cache —
           # that layer is what makes warm builds finish in minutes instead of
           # recompiling the whole workspace, so dropping to mode=min would
           # *raise* compute minutes. image-manifest+oci-mediatypes make the
           # cache blob a GHCR-compatible OCI manifest (required for the registry
           # backend to push to ghcr.io).
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true
+          cache-to: type=registry,ref=${{ env.CACHE_IMAGE }}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true
           # Build arm64 only for actual releases (distribution images). On the
           # frequent push-to-main builds (~1/3 of commits touch rust/** and
           # trigger this workflow) we build amd64 only — the arm64 leg runs


### PR DESCRIPTION
Follow-up to #1477. The GHCR registry cache ref used the raw `${{ env.IMAGE_NAME }}` (`LTplus-AG/ifc-lite-server`), but the OCI registry cache exporter requires a lowercase repository name, so the first push-to-main Docker build failed at cache-config time:

```
failed to configure registry cache exporter: invalid reference format:
repository name (LTplus-AG/ifc-lite-server) must be lowercase
```

The image tags were fine (docker/metadata-action lowercases them) and the failure was before any build step, so no image was pushed and `:latest` is untouched.

Fix: compute a lowercased `CACHE_IMAGE` (`ghcr.io/ltplus-ag/ifc-lite-server`) and use it for both `cache-from` and `cache-to`.

Note: `docker.yml` only runs on push-to-main + release, so this can't be exercised by PR CI - it validates on the merge to main (which I'll monitor).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Docker build caching to make image builds more reliable and consistent.
  * Reduced the chance of build timeouts during cold starts by better handling registry cache usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge; the workflow-only change is narrowly scoped to correcting the GHCR cache reference casing.

The changed Docker workflow now uses a lowercased cache image for registry cache import/export while leaving image tagging behavior unchanged.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex captured the before artifact showing the command, working directory, exit status, real workflow lines, and mixed-case resolved cache refs.
- T-Rex captured the after artifact showing the command, working directory, exit status, real workflow lines, the evaluated CACHE\_IMAGE, and lowercase resolved cache refs.
- T-Rex captured the validator artifact containing the generated validation script used for both runs.

<a href="https://app.greptile.com/trex/runs/12890558/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): lowercase the Docker registry c..."](https://github.com/ltplus-ag/ifc-lite/commit/97cbbdb9188b2f77e83c3fde770dcfba8ec6d59a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41045351)</sub>

<!-- /greptile_comment -->