### PR TITLE
fix(viewer): sort elements inside storeys, not just storey rows (#1476)

### DIFF
--- a/apps/viewer/src/components/viewer/hierarchy/HierarchySortControl.tsx
+++ b/apps/viewer/src/components/viewer/hierarchy/HierarchySortControl.tsx
@@ -8,6 +8,11 @@
  * when storey names don't track height; this lets the user switch to an
  * alphanumeric (natural-numeric) name sort, in either direction.
  *
+ * A name sort applies at every spatial level — storey rows AND the elements
+ * inside each storey (issue #1476), so it stays useful even when a model has a
+ * single storey. Elevation modes reorder only the storey stack; elements keep
+ * their as-modeled document order (they carry no elevation).
+ *
  * Only meaningful in the spatial grouping mode — the Class / Type / Material
  * trees are already name-sorted — so the panel renders it just for `spatial`.
  */
@@ -52,7 +57,7 @@ export function HierarchySortControl({ value, onChange }: HierarchySortControlPr
           variant="outline"
           size="sm"
           className="h-6 w-full justify-between gap-1 px-2 mt-1 text-[10px] rounded-none uppercase tracking-wider"
-          title="Sort storeys"
+          title="Sort the spatial browser (storeys and their contents)"
         >
           <span className="flex items-center gap-1 min-w-0">
             <ActiveIcon className="h-3 w-3 shrink-0" />

--- a/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.test.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.test.ts
@@ -7,7 +7,7 @@ import assert from 'node:assert';
 import { IfcTypeEnum, RelationshipType, type SpatialHierarchy, type SpatialNode } from '@ifc-lite/data';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import { useViewerStore, type FederatedModel } from '@/store';
-import { buildTreeData, buildTypeTree, compareStoreyEntries, type AuthoredProduct } from './treeDataBuilder';
+import { buildTreeData, buildTypeTree, buildUnifiedStoreys, compareStoreyEntries, type AuthoredProduct } from './treeDataBuilder';
 import type { HierarchySortMode } from './types';
 
 function createSpatialNode(
@@ -453,6 +453,205 @@ function createMixedChildrenDataStore(): IfcDataStore {
     entities: { count: 0, getName: () => '', getTypeName: () => 'Unknown' },
   } as unknown as IfcDataStore;
 }
+
+/** One storey "GROUND" (#4) containing three named walls whose document order
+ *  (8, 7, 9) tracks neither name nor id, so each sort mode yields a distinct
+ *  order. Names: 7 = "Wall 10", 8 = "Wall 2", 9 = "Wall 1". */
+function createStoreyElementsDataStore(): IfcDataStore {
+  const storeyNode = createSpatialNode(4, IfcTypeEnum.IfcBuildingStorey, 'GROUND');
+  storeyNode.elevation = 0;
+  const buildingNode = createSpatialNode(3, IfcTypeEnum.IfcBuilding, 'MY_BUILDING', [storeyNode]);
+  const siteNode = createSpatialNode(2, IfcTypeEnum.IfcSite, 'MY_SITE', [buildingNode]);
+  const projectNode = createSpatialNode(1, IfcTypeEnum.IfcProject, 'MY_PROJECT', [siteNode]);
+
+  const spatialHierarchy: SpatialHierarchy = {
+    project: projectNode,
+    byStorey: new Map([[4, [8, 7, 9]]]), // document order: 8, 7, 9
+    byBuilding: new Map(),
+    bySite: new Map(),
+    bySpace: new Map(),
+    storeyElevations: new Map([[4, 0]]),
+    storeyHeights: new Map(),
+    elementToStorey: new Map([[7, 4], [8, 4], [9, 4]]),
+    getStoreyElements: () => [],
+    getStoreyByElevation: () => null,
+    getContainingSpace: () => null,
+    getPath: () => [],
+  };
+
+  const names: Record<number, string> = { 7: 'Wall 10', 8: 'Wall 2', 9: 'Wall 1' };
+  return {
+    spatialHierarchy,
+    entities: {
+      count: 0,
+      getName: (id: number) => names[id] ?? '',
+      getTypeName: () => 'IfcWall',
+    },
+  } as unknown as IfcDataStore;
+}
+
+/** A stair #10 aggregating THREE parts whose document order [11, 12, 13] tracks
+ *  neither name-asc nor name-desc, so both directions prove the recursion sorts
+ *  (a two-part fixture where asc happens to equal document order would leave the
+ *  asc assertion tautological). Names: 11 = "M-mid", 12 = "A-first", 13 = "Z-last". */
+function createSortAssemblyDataStore(): IfcDataStore {
+  const storeyNode = createSpatialNode(4, IfcTypeEnum.IfcBuildingStorey, 'GROUND');
+  const buildingNode = createSpatialNode(3, IfcTypeEnum.IfcBuilding, 'MY_BUILDING', [storeyNode]);
+  const siteNode = createSpatialNode(2, IfcTypeEnum.IfcSite, 'MY_SITE', [buildingNode]);
+  const projectNode = createSpatialNode(1, IfcTypeEnum.IfcProject, 'MY_PROJECT', [siteNode]);
+
+  const spatialHierarchy: SpatialHierarchy = {
+    project: projectNode,
+    byStorey: new Map([[4, [10]]]), // only the stair is contained; parts hang off it
+    byBuilding: new Map(),
+    bySite: new Map(),
+    bySpace: new Map(),
+    storeyElevations: new Map(),
+    storeyHeights: new Map(),
+    elementToStorey: new Map([[10, 4]]),
+    getStoreyElements: () => [],
+    getStoreyByElevation: () => null,
+    getContainingSpace: () => null,
+    getPath: () => [],
+  };
+
+  const names: Record<number, string> = { 10: 'Stair', 11: 'M-mid', 12: 'A-first', 13: 'Z-last' };
+  const types: Record<number, string> = {
+    10: 'IfcStair', 11: 'IfcRailing', 12: 'IfcStairFlight', 13: 'IfcRailing',
+  };
+
+  return {
+    spatialHierarchy,
+    entities: {
+      count: 0,
+      getName: (id: number) => names[id] ?? '',
+      getTypeName: (id: number) => types[id] ?? 'Unknown',
+    },
+    relationships: {
+      getRelated: (id: number, relType: RelationshipType, direction: 'forward' | 'inverse') =>
+        relType === RelationshipType.Aggregates && direction === 'forward' && id === 10
+          ? [11, 12, 13]
+          : [],
+    },
+  } as unknown as IfcDataStore;
+}
+
+/** One storey "GROUND" (#4) at elevation 0 holding the given element ids, used to
+ *  build a federated (multi-model) scenario. Names drive the in-storey sort. */
+function createSortStoreyModelDataStore(
+  elements: number[],
+  names: Record<number, string>,
+): IfcDataStore {
+  const storeyNode = createSpatialNode(4, IfcTypeEnum.IfcBuildingStorey, 'GROUND');
+  storeyNode.elevation = 0;
+  const buildingNode = createSpatialNode(3, IfcTypeEnum.IfcBuilding, 'MY_BUILDING', [storeyNode]);
+  const siteNode = createSpatialNode(2, IfcTypeEnum.IfcSite, 'MY_SITE', [buildingNode]);
+  const projectNode = createSpatialNode(1, IfcTypeEnum.IfcProject, 'MY_PROJECT', [siteNode]);
+
+  const spatialHierarchy: SpatialHierarchy = {
+    project: projectNode,
+    byStorey: new Map([[4, elements]]),
+    byBuilding: new Map(),
+    bySite: new Map(),
+    bySpace: new Map(),
+    storeyElevations: new Map([[4, 0]]),
+    storeyHeights: new Map(),
+    elementToStorey: new Map(elements.map((e) => [e, 4] as const)),
+    getStoreyElements: () => [],
+    getStoreyByElevation: () => null,
+    getContainingSpace: () => null,
+    getPath: () => [],
+  };
+
+  return {
+    spatialHierarchy,
+    entities: {
+      count: 0,
+      getName: (id: number) => names[id] ?? '',
+      getTypeName: () => 'IfcWall',
+    },
+  } as unknown as IfcDataStore;
+}
+
+describe('element sort within a storey (#1476)', () => {
+  // Storey (and its ancestors) expanded so the contained elements are emitted.
+  const expanded = new Set(['root-1', 'root-1-2', 'root-1-2-3', 'root-1-2-3-4']);
+
+  function elementOrder(sortMode?: HierarchySortMode): number[] {
+    const nodes = buildTreeData(new Map(), createStoreyElementsDataStore(), expanded, false, [], sortMode);
+    return nodes.filter((n) => n.type === 'element').map((n) => n.expressIds[0]);
+  }
+
+  it('keeps document order for elements in elevation mode (default behaviour)', () => {
+    assert.deepStrictEqual(elementOrder('elevation-desc'), [8, 7, 9]);
+    assert.deepStrictEqual(elementOrder('elevation-asc'), [8, 7, 9]);
+    // No explicit mode → default (elevation-desc) → document order preserved.
+    assert.deepStrictEqual(elementOrder(), [8, 7, 9]);
+  });
+
+  it('name-asc sorts elements inside the storey by name, natural-numeric', () => {
+    // Wall 1(9), Wall 2(8), Wall 10(7) — reaches inside the storey (#1476).
+    assert.deepStrictEqual(elementOrder('name-asc'), [9, 8, 7]);
+  });
+
+  it('name-desc reverses the in-storey element order', () => {
+    assert.deepStrictEqual(elementOrder('name-desc'), [7, 8, 9]);
+  });
+
+  it("sorts a decomposing assembly's parts by name when a name sort is active", () => {
+    useViewerStore.setState({ models: new Map() });
+    const ds = createSortAssemblyDataStore();
+    const stairExpanded = new Set([
+      'root-1', 'root-1-2', 'root-1-2-3', 'root-1-2-3-4', 'element-legacy-10',
+    ]);
+    const partOrder = (mode: HierarchySortMode): number[] =>
+      buildTreeData(new Map(), ds, stairExpanded, false, [], mode)
+        .filter((n) => n.type === 'element' && [11, 12, 13].includes(n.expressIds[0]))
+        .map((n) => n.expressIds[0]);
+    // Parts document order is [11 "M-mid", 12 "A-first", 13 "Z-last"] — chosen so
+    // BOTH sort directions differ from it, so neither assertion is tautological.
+    assert.deepStrictEqual(partOrder('name-asc'), [12, 11, 13], 'A-first, M-mid, Z-last');
+    assert.deepStrictEqual(partOrder('name-desc'), [13, 11, 12], 'Z-last, M-mid, A-first');
+    assert.deepStrictEqual(partOrder('elevation-desc'), [11, 12, 13], 'elevation keeps document order');
+  });
+
+  it('sorts elements inside a federated (multi-model) storey contribution (#1476)', () => {
+    // Exercises the multi-model unified-storey contribution loop (the third
+    // orderElementIdsByName call site), which the single-model tests never reach.
+    useViewerStore.setState({ models: new Map() });
+    const offA = useViewerStore.getState().registerModelOffset('sort-fed-A', 20);
+    const offB = useViewerStore.getState().registerModelOffset('sort-fed-B', 20);
+    const modelA: FederatedModel = {
+      ...createModel(offA),
+      id: 'sort-fed-A',
+      name: 'Model A',
+      ifcDataStore: createSortStoreyModelDataStore([8, 7, 9], { 7: 'Wall 10', 8: 'Wall 2', 9: 'Wall 1' }),
+      maxExpressId: 9,
+    };
+    const modelB: FederatedModel = {
+      ...createModel(offB),
+      id: 'sort-fed-B',
+      name: 'Model B',
+      ifcDataStore: createSortStoreyModelDataStore([5], { 5: 'Solo' }),
+      maxExpressId: 5,
+    };
+    const models = new Map<string, FederatedModel>([['sort-fed-A', modelA], ['sort-fed-B', modelB]]);
+    useViewerStore.setState({ models });
+
+    const unified = buildUnifiedStoreys(models, 'name-asc');
+    // Both storeys sit at elevation 0, so they merge into one unified storey.
+    assert.strictEqual(unified.length, 1, 'storeys at the same elevation unify');
+
+    const expanded = new Set([`unified-${unified[0].key}`, 'contrib-sort-fed-A-4']);
+    const nodes = buildTreeData(models, null, expanded, true, unified, 'name-asc');
+
+    const orderA = nodes
+      .filter((n) => n.type === 'element' && n.id.startsWith('element-sort-fed-A-'))
+      .map((n) => n.expressIds[0]);
+    // Model A doc order [8, 7, 9] → name-asc Wall 1(9), Wall 2(8), Wall 10(7).
+    assert.deepStrictEqual(orderA, [9, 8, 7], 'contribution elements sort by name inside a federated storey');
+  });
+});
 
 describe('storey sort order — IFC4.3 parts and non-level siblings (#1296)', () => {
   it('sorts IfcFacilityPart rows, not just IfcBuildingStorey', () => {

--- a/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.ts
@@ -67,6 +67,15 @@ export function compareStoreyEntries(
   }
 }
 
+/** The name a spatial element row renders with: its entity name, or a
+ *  "<Type> #<id>" fallback. Single source of truth so the displayed label
+ *  (emitElementSubtree) and the name-sort key (orderElementIdsByName) can't
+ *  drift apart. */
+function getElementDisplayName(id: number, dataStore: IfcDataStore): string {
+  const entities = dataStore.entities;
+  return entities?.getName(id) || `${entities?.getTypeName(id) || 'Unknown'} #${id}`;
+}
+
 /** Order the element rows within a spatial container by the active browser sort
  *  (issue #1476). A name sort orders elements by the same visible name the row
  *  renders (`getName || "<Type> #<id>"`), using the natural-numeric collator so
@@ -84,14 +93,11 @@ function orderElementIdsByName(
   if ((mode !== 'name-asc' && mode !== 'name-desc') || elementIds.length < 2) {
     return elementIds;
   }
-  const entities = dataStore.entities;
-  const displayName = (id: number): string =>
-    entities?.getName(id) || `${entities?.getTypeName(id) || 'Unknown'} #${id}`;
   const dir = mode === 'name-desc' ? -1 : 1;
   // Decorate-sort-undecorate: resolve each display name exactly once rather than
   // O(n log n) times inside the comparator.
   return elementIds
-    .map((id) => ({ id, name: displayName(id) }))
+    .map((id) => ({ id, name: getElementDisplayName(id, dataStore) }))
     .sort((a, b) => dir * storeyNameCollator.compare(a.name, b.name))
     .map((e) => e.id);
 }
@@ -286,7 +292,7 @@ function emitElementSubtree(
   const relationships = dataStore.relationships as AggregationRelationships | undefined;
   const globalId = resolveTreeGlobalId(modelId, elementId, models);
   const entityType = dataStore.entities?.getTypeName(elementId) || 'Unknown';
-  const entityName = dataStore.entities?.getName(elementId) || `${entityType} #${elementId}`;
+  const entityName = getElementDisplayName(elementId, dataStore);
 
   // Direct decomposition children, minus anything already on the path (cycle
   // guard), ordered by the active name sort so it reaches inside a decomposing

--- a/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.ts
@@ -67,6 +67,35 @@ export function compareStoreyEntries(
   }
 }
 
+/** Order the element rows within a spatial container by the active browser sort
+ *  (issue #1476). A name sort orders elements by the same visible name the row
+ *  renders (`getName || "<Type> #<id>"`), using the natural-numeric collator so
+ *  "W-2" sorts before "W-10"; this makes the sort reach INSIDE a storey, not just
+ *  the storey rows — the whole point of the reported bug (one storey means the
+ *  storey sort is a no-op). Elevation modes keep the as-modeled document order, since
+ *  individual elements carry no elevation. Returns the input array unchanged (not
+ *  a copy) when nothing to reorder, so callers must treat the result as readonly.
+ *  `Array.prototype.sort` is stable, so equal-named elements keep document order. */
+function orderElementIdsByName(
+  elementIds: number[],
+  dataStore: IfcDataStore,
+  mode: HierarchySortMode,
+): number[] {
+  if ((mode !== 'name-asc' && mode !== 'name-desc') || elementIds.length < 2) {
+    return elementIds;
+  }
+  const entities = dataStore.entities;
+  const displayName = (id: number): string =>
+    entities?.getName(id) || `${entities?.getTypeName(id) || 'Unknown'} #${id}`;
+  const dir = mode === 'name-desc' ? -1 : 1;
+  // Decorate-sort-undecorate: resolve each display name exactly once rather than
+  // O(n log n) times inside the comparator.
+  return elementIds
+    .map((id) => ({ id, name: displayName(id) }))
+    .sort((a, b) => dir * storeyNameCollator.compare(a.name, b.name))
+    .map((e) => e.id);
+}
+
 /** Convert IfcTypeEnum to NodeType string */
 export function getNodeType(ifcType: IfcTypeEnum): NodeType {
   switch (ifcType) {
@@ -252,15 +281,23 @@ function emitElementSubtree(
   expandedNodes: Set<string>,
   nodes: TreeNode[],
   ancestors: Set<number>,
+  sortMode: HierarchySortMode,
 ): void {
   const relationships = dataStore.relationships as AggregationRelationships | undefined;
   const globalId = resolveTreeGlobalId(modelId, elementId, models);
   const entityType = dataStore.entities?.getTypeName(elementId) || 'Unknown';
   const entityName = dataStore.entities?.getName(elementId) || `${entityType} #${elementId}`;
 
-  // Direct decomposition children, minus anything already on the path (cycle guard).
-  const childIds = getAggregatedChildren(relationships, elementId)
-    .filter((id) => id !== elementId && !ancestors.has(id));
+  // Direct decomposition children, minus anything already on the path (cycle
+  // guard), ordered by the active name sort so it reaches inside a decomposing
+  // assembly too, not just the storey rows (issue #1476).
+  const childIds = orderElementIdsByName(
+    getAggregatedChildren(relationships, elementId).filter(
+      (id) => id !== elementId && !ancestors.has(id),
+    ),
+    dataStore,
+    sortMode,
+  );
   const hasChildren = childIds.length > 0;
   const nodeId = `element-${modelId}-${elementId}`;
   const isExpanded = hasChildren && expandedNodes.has(nodeId);
@@ -293,7 +330,7 @@ function emitElementSubtree(
   if (isExpanded) {
     const nextAncestors = new Set(ancestors).add(elementId);
     for (const childId of childIds) {
-      emitElementSubtree(childId, modelId, models, dataStore, depth + 1, expandedNodes, nodes, nextAncestors);
+      emitElementSubtree(childId, modelId, models, dataStore, depth + 1, expandedNodes, nodes, nextAncestors, sortMode);
     }
   }
 }
@@ -386,10 +423,13 @@ function buildSpatialNodes(
     }
 
     // Add direct spatial children elements for expanded nodes — each may itself
-    // decompose into nested parts via IfcRelAggregates (issue #1133).
+    // decompose into nested parts via IfcRelAggregates (issue #1133). Order them
+    // by the active name sort so it reaches inside the storey/space, not just the
+    // storey rows (issue #1476).
     if (hasDirectElements) {
-      for (const elementId of elements) {
-        emitElementSubtree(elementId, modelId, models, dataStore, depth + 1, expandedNodes, nodes, new Set());
+      const orderedElements = orderElementIdsByName(elements, dataStore, sortMode);
+      for (const elementId of orderedElements) {
+        emitElementSubtree(elementId, modelId, models, dataStore, depth + 1, expandedNodes, nodes, new Set(), sortMode);
       }
     }
   }
@@ -456,10 +496,12 @@ export function buildTreeData(
           });
 
           // If contribution expanded, show elements (assemblies nest their
-          // IfcRelAggregates parts — issue #1133).
+          // IfcRelAggregates parts — issue #1133), ordered by the active name
+          // sort so it reaches inside the storey (issue #1476).
           if (contribExpanded && model?.ifcDataStore) {
-            for (const elementId of storey.elements) {
-              emitElementSubtree(elementId, storey.modelId, models, model.ifcDataStore, 2, expandedNodes, nodes, new Set());
+            const orderedElements = orderElementIdsByName(storey.elements, model.ifcDataStore, sortMode);
+            for (const elementId of orderedElements) {
+              emitElementSubtree(elementId, storey.modelId, models, model.ifcDataStore, 2, expandedNodes, nodes, new Set(), sortMode);
             }
           }
         }

--- a/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.ts
@@ -70,10 +70,13 @@ export function compareStoreyEntries(
 /** The name a spatial element row renders with: its entity name, or a
  *  "<Type> #<id>" fallback. Single source of truth so the displayed label
  *  (emitElementSubtree) and the name-sort key (orderElementIdsByName) can't
- *  drift apart. */
-function getElementDisplayName(id: number, dataStore: IfcDataStore): string {
+ *  drift apart. Callers that already resolved the type name pass it as
+ *  `typeName` so the fallback branch does not fetch it a second time. */
+function getElementDisplayName(id: number, dataStore: IfcDataStore, typeName?: string): string {
   const entities = dataStore.entities;
-  return entities?.getName(id) || `${entities?.getTypeName(id) || 'Unknown'} #${id}`;
+  const name = entities?.getName(id);
+  if (name) return name;
+  return `${typeName || entities?.getTypeName(id) || 'Unknown'} #${id}`;
 }
 
 /** Order the element rows within a spatial container by the active browser sort
@@ -292,7 +295,8 @@ function emitElementSubtree(
   const relationships = dataStore.relationships as AggregationRelationships | undefined;
   const globalId = resolveTreeGlobalId(modelId, elementId, models);
   const entityType = dataStore.entities?.getTypeName(elementId) || 'Unknown';
-  const entityName = getElementDisplayName(elementId, dataStore);
+  // Reuse entityType so an unnamed element resolves its type name only once.
+  const entityName = getElementDisplayName(elementId, dataStore, entityType);
 
   // Direct decomposition children, minus anything already on the path (cycle
   // guard), ordered by the active name sort so it reaches inside a decomposing


### PR DESCRIPTION
Closes #1476.

## Problem
The Project Browser "Sort" (added in #1296/#1309) only reordered **storey-like spatial rows**. Element rows *inside* a storey were always emitted in document order, so a model with a single storey saw no visible effect from the name sort — which is what the issue reporter hit.

## Fix
`treeDataBuilder.ts` gains an `orderElementIdsByName()` helper that orders element rows by their display name (`getName() || "<Type> #<id>"`) using the **same natural-numeric collator** as the storey sort, but only when a name mode is active. It is applied at all three element-emission sites:

1. `buildSpatialNodes` — a storey's / space's direct contents
2. `emitElementSubtree` — `IfcRelAggregates` assembly parts (recursively; `emitElementSubtree` gains a `sortMode` param)
3. `buildTreeData` — multi-model unified-storey contributions

Elevation modes (including the `elevation-desc` default) return the element list **unchanged** — individual elements carry no elevation — so existing behavior is byte-identical. The sort control tooltip/doc copy is updated to reflect that a name sort now reaches the storey contents too.

## Tests (`treeDataBuilder.test.ts`, 19/19 pass)
- Elevation modes keep document order; name-asc/name-desc sort in-storey elements with natural-numeric ordering (`Wall 1` < `Wall 2` < `Wall 10`)
- A 3-part assembly-recursion case whose document order differs from **both** sort directions (so neither assertion is tautological)
- A federated (multi-model) storey-contribution case exercising the third call site

## Notes
- Viewer `tsc --noEmit`: 0 errors
- `@ifc-lite/viewer` is a private app → no changeset needed
- Vetted by an adversarial multi-agent review (mutation-safety / completeness / behavior-parity + verify pass): no data-store mutation, stable sort, no correctness regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Name-based hierarchy sorting now orders both storeys and the elements inside each storey.
  * Expanded sorting behavior in the spatial browser, including direct elements, decomposition/aggregation parts, and unified multi-model storey contributions.
* **Bug Fixes**
  * Elevation-based sorting preserves original document order for contents while still reordering the storey stack.
  * Updated the hierarchy sort control tooltip to reflect how storeys and their contents are sorted.
* **Tests**
  * Added coverage for element ordering within a storey, assembly part ordering under name sort, and federated multi-model scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the focused scope and test coverage described for the hierarchy sorting changes.

The change is limited to hierarchy sort behavior, preserves elevation-mode ordering, and includes targeted coverage for direct contents, recursive assemblies, and multi-model storey contributions.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- A workspace package build was completed to resolve local dist imports for the viewer test harness.
- The viewer tests for trex\_hierarchy\_contract.test.ts across scenarios were run with concurrency set to 1 using the specified pnpm command.
- Before and after artifacts for the first scenario were captured to show the initial and final UI states of the Hierarchy Sort Tooltip.
- Before and after renderings of the HierarchySortControl were captured, showing the button titles 'Sort storeys' and 'Sort the spatial browser (storeys and their contents)'; verbose logs include the executed command context and the title strings read from the rendered button.

<a href="https://app.greptile.com/trex/runs/12898121/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["perf(viewer): resolve element type name ..."](https://github.com/ltplus-ag/ifc-lite/commit/53778db4c3e2b8a30a4403cba7320ed3551cf452) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41057573)</sub>

<!-- /greptile_comment -->