### PR TITLE
feat(export): normalize units in merged export into one single-unit project (#1475)

### DIFF
--- a/.changeset/merge-normalize-units.md
+++ b/.changeset/merge-normalize-units.md
@@ -1,0 +1,29 @@
+---
+"@ifc-lite/export": minor
+"@ifc-lite/cli": minor
+---
+
+feat(export): add `unitReconciliation: 'normalize'` merge mode
+
+`MergedExporter` can now rescale a model whose length unit differs from the first
+model's into the primary unit, so a mixed-unit merge produces one ordinary
+single-unit `IfcProject` with one `IfcUnitAssignment` (opens correctly everywhere,
+BIM Vision included) instead of a multi-project federation.
+
+- Every length-valued datum is rescaled: all `IfcCartesianPoint` /
+  `IfcCartesianPointList` coordinates, scalar lengths (extrusion depths, profile
+  dimensions, radii, thicknesses, `IfcVector.Magnitude`, CSG primitive sizes,
+  `IfcBuildingStorey.Elevation`, `IfcSite.RefElevation`), `IfcLengthMeasure`
+  property values, and `IfcQuantityLength`. Which attributes are length-valued is
+  derived from the IFC schema registry, not hand-rolled.
+- Areas and volumes are converted by their own declared `AREAUNIT`/`VOLUMEUNIT`
+  ratio (not the length factor squared/cubed), so a model with millimetre lengths
+  but square-/cubic-metre quantities (the common authoring-tool default) is not
+  corrupted.
+- Angles, direction ratios, counts, unit definitions and georeferencing offsets
+  are left untouched. `MergeExportResult.stats.normalizedModelCount` reports how
+  many models were rescaled, and advisories are surfaced for schemas the length
+  registry does not fully cover (IFC4X3) and for georeferenced models.
+
+The CLI `merge` command gains a `--unit-reconciliation <auto|normalize|assume-shared>`
+flag, and the viewer's merged export adds a "Mixed units" selector.

--- a/apps/viewer/src/components/viewer/ExportDialog.tsx
+++ b/apps/viewer/src/components/viewer/ExportDialog.tsx
@@ -95,6 +95,8 @@ export function ExportDialog({ trigger }: ExportDialogProps) {
   const [applyMutations, setApplyMutations] = useState(true);
   const [changesOnly, setChangesOnly] = useState(false);
   const [visibleOnly, setVisibleOnly] = useState(false);
+  // How a merged export reconciles models with different length units.
+  const [unitReconciliation, setUnitReconciliation] = useState<'auto' | 'normalize' | 'assume-shared'>('auto');
   const [onlyKnownProperties, setOnlyKnownProperties] = useState(true);
   const [isExporting, setIsExporting] = useState(false);
   const [exportResult, setExportResult] = useState<{ success: boolean; message: string } | null>(null);
@@ -366,6 +368,7 @@ export function ExportDialog({ trigger }: ExportDialogProps) {
         const result = await mergedExporter.exportAsync({
           schema,
           projectStrategy: 'keep-first',
+          unitReconciliation,
           visibleOnly,
           hiddenEntityIdsByModel: hiddenByModel,
           isolatedEntityIdsByModel: isolatedByModel,
@@ -386,7 +389,10 @@ export function ExportDialog({ trigger }: ExportDialogProps) {
 
         downloadFile(result.content, 'merged_export.ifc', 'text/plain');
 
-        const msg = `Merged ${result.stats.modelCount} models, ${result.stats.totalEntityCount.toLocaleString()} entities`;
+        const msg = `Merged ${result.stats.modelCount} models, ${result.stats.totalEntityCount.toLocaleString()} entities`
+          + (result.stats.normalizedModelCount > 0
+            ? ` (${result.stats.normalizedModelCount} rescaled into the first model's unit)`
+            : '');
         setExportResult({ success: true, message: msg });
         toast.success(msg);
         exportedFormat = 'ifc';
@@ -556,7 +562,7 @@ export function ExportDialog({ trigger }: ExportDialogProps) {
         });
       }
     }
-  }, [selectedModel, selectedModelId, schema, isIfc5, exportScope, includeGeometry, applyMutations, changesOnly, visibleOnly, onlyKnownProperties, getMutationView, getLocalHiddenIds, getLocalIsolatedIds, modifiedCount, models, extensionHost, outputInfo]);
+  }, [selectedModel, selectedModelId, schema, isIfc5, exportScope, includeGeometry, applyMutations, changesOnly, visibleOnly, unitReconciliation, onlyKnownProperties, getMutationView, getLocalHiddenIds, getLocalIsolatedIds, modifiedCount, models, extensionHost, outputInfo]);
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -591,6 +597,23 @@ export function ExportDialog({ trigger }: ExportDialogProps) {
                 <SelectContent>
                   <SelectItem value="single">Single Model</SelectItem>
                   <SelectItem value="merged">Merged (All Models)</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {/* Mixed-unit handling — only meaningful for a merged export */}
+          {!isIfc5 && !changesOnly && exportScope === 'merged' && modelList.length > 1 && (
+            <div className="flex items-center gap-4">
+              <Label className="w-32">Mixed units</Label>
+              <Select value={unitReconciliation} onValueChange={(v) => setUnitReconciliation(v as typeof unitReconciliation)}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="auto">Keep each unit (separate projects)</SelectItem>
+                  <SelectItem value="normalize">Normalize to first model</SelectItem>
+                  <SelectItem value="assume-shared">Assume shared unit</SelectItem>
                 </SelectContent>
               </Select>
             </div>

--- a/docs/api/typescript.md
+++ b/docs/api/typescript.md
@@ -600,20 +600,43 @@ interface StepExportResult {
 
 ### MergedExporter
 
-Merge multiple IFC models into a single STEP file with unified ID space.
+Merge multiple IFC models into a single STEP file with a unified ID space,
+spatial-hierarchy unification, and unit-aware reconciliation.
 
 ```typescript
 class MergedExporter {
-  export(
-    models: MergeModelInput[],
-    options?: MergeExportOptions
-  ): MergeExportResult;
+  constructor(models: MergeModelInput[]);
+  export(options: MergeExportOptions): MergeExportResult;          // synchronous
+  exportAsync(options: MergeExportOptions): Promise<MergeExportResult>; // progress + mutations
 }
 
 interface MergeModelInput {
+  id: string;
+  name: string;
   dataStore: IfcDataStore;
-  source: Uint8Array;
-  name?: string;
+  lengthUnitScale?: number;   // metres per unit; falls back to dataStore.lengthUnitScale
+}
+
+interface MergeExportOptions {
+  schema: 'IFC2X3' | 'IFC4' | 'IFC4X3' | 'IFC5';
+  // Mixed length units:
+  //   'auto' (default) — federate a differing-unit model as its own IfcProject
+  //   'normalize'      — rescale it into the first model's unit (one single-unit project)
+  //   'assume-shared'  — force one project without rescaling
+  unitReconciliation?: 'auto' | 'normalize' | 'assume-shared';
+  visibleOnly?: boolean;
+}
+
+interface MergeExportResult {
+  content: Uint8Array;
+  stats: {
+    modelCount: number;
+    totalEntityCount: number;
+    fileSize: number;
+    federatedModelCount: number;   // models kept as separate projects (auto)
+    normalizedModelCount: number;  // models rescaled into the first unit (normalize)
+    warnings: string[];
+  };
 }
 ```
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -468,15 +468,19 @@ ifc-lite merge file1.ifc file2.ifc file3.ifc --schema IFC4 --out merged.ifc
 
 # JSON output with stats
 ifc-lite merge a.ifc b.ifc --out merged.ifc --json
+
+# Mixed units: rescale every model into the first file's unit (one single-unit project)
+ifc-lite merge metric.ifc imperial.ifc --unit-reconciliation normalize --out merged.ifc
 ```
 
-The merger unifies spatial hierarchy (storeys, buildings) by name and elevation, offsets entity IDs to avoid collisions, and merges into a single IfcProject.
+The merger unifies spatial hierarchy (storeys, buildings) by name and elevation, and offsets entity IDs to avoid collisions. Models that share the first file's length unit merge into a single IfcProject; a model with a different unit is federated (kept as its own project) unless `--unit-reconciliation normalize` rescales it into the first file's unit.
 
 **Flags:**
 
 | Flag | Description |
 |------|-------------|
 | `--schema <ver>` | Target schema (`IFC2X3`, `IFC4`, `IFC4X3`) |
+| `--unit-reconciliation <mode>` | Mixed-unit handling: `auto` (default, federate differing units), `normalize` (rescale into the first file's unit → one single-unit project), `assume-shared` (force one project without rescaling) |
 | `--out <file>` | Output file (required) |
 | `--json` | Output merge stats as JSON |
 

--- a/docs/guide/exporting.md
+++ b/docs/guide/exporting.md
@@ -387,22 +387,44 @@ Supports all 202 `IfcProduct` subtypes from IFC4 and IFC4X3 schemas, including i
 
 ### Multi-Model Merged Export
 
-Merge multiple IFC models into a single file:
+Merge multiple IFC models into a single file. The models are passed to the
+constructor; `export()` (sync) or `exportAsync()` (progress-reporting) takes the
+options:
 
 ```typescript
 import { MergedExporter } from '@ifc-lite/export';
 
-const exporter = new MergedExporter();
-const result = await exporter.export([
-  { dataStore: store1, source: buffer1, name: 'Architecture' },
-  { dataStore: store2, source: buffer2, name: 'Structure' },
-], {
+const exporter = new MergedExporter([
+  { id: 'arch', name: 'Architecture', dataStore: store1 },
+  { id: 'struct', name: 'Structure', dataStore: store2 },
+]);
+const result = await exporter.exportAsync({
+  schema: 'IFC4',
+  unitReconciliation: 'normalize',
   visibleOnly: true,
-  hiddenEntityIds: hiddenSet,
-  isolatedEntityIds: isolatedSet,
 });
 await saveFile('merged.ifc', result.content);
 ```
+
+#### Mixed length units
+
+When the models use different length units, `unitReconciliation` controls the
+result:
+
+| Mode | Behaviour |
+|------|-----------|
+| `'auto'` (default) | Unit-aware: same-unit models are unified; a differing-unit model is **federated** as its own `IfcProject` so its raw coordinates stay correctly scaled. The output then holds more than one `IfcProject` (flagged in `stats.warnings`). |
+| `'normalize'` | Rescales every length-valued datum of a differing-unit model into the first model's unit, then unifies it — the output is **one single-unit `IfcProject`** that opens correctly everywhere. `stats.normalizedModelCount` reports how many models were rescaled. |
+| `'assume-shared'` | Forces one project without rescaling. Use only when units are already normalised; mixing real units this way mis-scales geometry. |
+
+`'normalize'` rescales all `IfcCartesianPoint`/`IfcCartesianPointList` coordinates,
+scalar lengths (extrusion depths, profile dimensions, radii, thicknesses, storey
+elevations, `IfcVector.Magnitude`, CSG primitive sizes), `IfcLengthMeasure`
+property values and `IfcQuantityLength`. Areas and volumes are converted by their
+own declared `AREAUNIT`/`VOLUMEUNIT` ratio. Angles, ratios, counts, unit
+definitions and georeferencing offsets are left untouched. Length attributes
+specific to IFC4X3 (alignment / linear referencing) may not be rescaled — a
+`stats.warnings` advisory flags this.
 
 ## GLB Import
 

--- a/packages/cli/src/commands/merge.ts
+++ b/packages/cli/src/commands/merge.ts
@@ -14,6 +14,9 @@ import { basename } from 'node:path';
 import { loadIfcFile } from '../loader.js';
 import { getFlag, hasFlag, fatal, printJson } from '../output.js';
 
+const UNIT_RECONCILIATION_MODES = ['auto', 'normalize', 'assume-shared'] as const;
+type UnitReconciliation = typeof UNIT_RECONCILIATION_MODES[number];
+
 export async function mergeCommand(args: string[]): Promise<void> {
   const outPath = getFlag(args, '--out');
   if (!outPath) fatal('--out is required: ifc-lite merge <file1.ifc> <file2.ifc> --out merged.ifc');
@@ -21,11 +24,20 @@ export async function mergeCommand(args: string[]): Promise<void> {
   const schema = getFlag(args, '--schema') as 'IFC2X3' | 'IFC4' | 'IFC4X3' | undefined;
   const jsonOutput = hasFlag(args, '--json');
 
+  // How to reconcile models whose length unit differs from the first file's.
+  // 'auto' (default) federates them as separate projects; 'normalize' rescales
+  // them into the first file's unit for one single-unit project; 'assume-shared'
+  // forces one project without rescaling.
+  const unitReconciliation = (getFlag(args, '--unit-reconciliation') ?? 'auto') as UnitReconciliation;
+  if (!UNIT_RECONCILIATION_MODES.includes(unitReconciliation)) {
+    fatal(`--unit-reconciliation must be one of: ${UNIT_RECONCILIATION_MODES.join(', ')}`);
+  }
+
   // Collect all positional args as input files
   const files: string[] = [];
   for (let i = 0; i < args.length; i++) {
     if (args[i].startsWith('-')) {
-      if (args[i] === '--out' || args[i] === '--schema') i++; // skip value
+      if (args[i] === '--out' || args[i] === '--schema' || args[i] === '--unit-reconciliation') i++; // skip value
       continue;
     }
     files.push(args[i]);
@@ -49,7 +61,10 @@ export async function mergeCommand(args: string[]): Promise<void> {
   // Dynamic import to avoid loading the exporter unless needed
   const { MergedExporter } = await import('@ifc-lite/export');
   const exporter = new MergedExporter(models);
-  const result = exporter.export({ schema: (schema ?? 'IFC4') as 'IFC2X3' | 'IFC4' | 'IFC4X3' | 'IFC5' });
+  const result = exporter.export({
+    schema: (schema ?? 'IFC4') as 'IFC2X3' | 'IFC4' | 'IFC4X3' | 'IFC5',
+    unitReconciliation,
+  });
 
   await writeFile(outPath, result.content, 'utf-8');
 
@@ -60,10 +75,14 @@ export async function mergeCommand(args: string[]): Promise<void> {
       totalEntityCount: result.stats.totalEntityCount,
       fileSize: result.stats.fileSize,
       federatedModelCount: result.stats.federatedModelCount,
+      normalizedModelCount: result.stats.normalizedModelCount,
       warnings: result.stats.warnings,
     });
   } else {
     process.stderr.write(`Merged ${result.stats.modelCount} models → ${outPath} (${result.stats.totalEntityCount} entities)\n`);
+    if (result.stats.normalizedModelCount > 0) {
+      process.stderr.write(`Normalized ${result.stats.normalizedModelCount} model(s) into the first file's unit\n`);
+    }
     for (const warning of result.stats.warnings) {
       process.stderr.write(`Warning: ${warning}\n`);
     }

--- a/packages/export/src/merged-exporter.test.ts
+++ b/packages/export/src/merged-exporter.test.ts
@@ -696,6 +696,219 @@ describe('MergedExporter', () => {
     });
   });
 
+  // Regression: github.com/LTplus-AG/ifc-lite/issues/1475
+  // `unitReconciliation: 'normalize'` rescales every length-valued datum of a
+  // differing-unit model into the primary model's unit, so the output is ONE
+  // IfcProject with ONE IfcUnitAssignment (correctly scaled) — not a federation.
+  describe('unit normalization (#1475)', () => {
+    // Primary = metres. Both models declare square-/cubic-metre area/volume units
+    // (the Revit convention: millimetre lengths but metre-derived area/volume).
+    const metreModel = (): MergeModelInput => {
+      const m = buildModel('primary', 'Primary-metre', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('primProj')}',$,'Primary',$,$,$,$,(#3),#2);`],
+        [2, 'IFCUNITASSIGNMENT', '#2=IFCUNITASSIGNMENT((#8,#9,#10));'],
+        [3, 'IFCGEOMETRICREPRESENTATIONCONTEXT', "#3=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#7,$);"],
+        [4, 'IFCSITE', `#4=IFCSITE('${guid('primSite')}',$,'Site',$,$,$,$,$,$,$);`],
+        [5, 'IFCWALL', `#5=IFCWALL('${guid('primWall')}',$,'PW',$,$,#6,$,$);`],
+        [6, 'IFCCARTESIANPOINT', '#6=IFCCARTESIANPOINT((1.5,0.,0.));'],
+        [7, 'IFCCARTESIANPOINT', '#7=IFCCARTESIANPOINT((0.,0.,0.));'],
+        [8, 'IFCSIUNIT', '#8=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);'],
+        [9, 'IFCSIUNIT', '#9=IFCSIUNIT(*,.AREAUNIT.,$,.SQUARE_METRE.);'],
+        [10, 'IFCSIUNIT', '#10=IFCSIUNIT(*,.VOLUMEUNIT.,$,.CUBIC_METRE.);'],
+        [11, 'IFCRELAGGREGATES', `#11=IFCRELAGGREGATES('${guid('primAgg')}',$,$,$,#1,(#4));`],
+      ]);
+      m.lengthUnitScale = 1.0;
+      return m;
+    };
+
+    // Secondary = millimetres. A column at x=3000 mm, a storey at 3000 mm, a
+    // 2500 mm extrusion depth, a 300 mm circle radius, a length quantity in mm and
+    // an AREA quantity already in m² (Revit) that must NOT be length-rescaled.
+    const mmModel = (): MergeModelInput => {
+      const m = buildModel('mm', 'Secondary-mm', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('mmProj')}',$,'Secondary',$,$,$,$,(#3),#2);`],
+        [2, 'IFCUNITASSIGNMENT', '#2=IFCUNITASSIGNMENT((#8,#9,#10));'],
+        [3, 'IFCGEOMETRICREPRESENTATIONCONTEXT', "#3=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#7,$);"],
+        [4, 'IFCSITE', `#4=IFCSITE('${guid('mmSite')}',$,'Site',$,$,$,$,$,$,$);`],
+        [5, 'IFCCOLUMN', `#5=IFCCOLUMN('${guid('mmCol')}',$,'MC',$,$,#6,$,$);`],
+        [6, 'IFCCARTESIANPOINT', '#6=IFCCARTESIANPOINT((3000.,0.,0.));'],
+        [7, 'IFCCARTESIANPOINT', '#7=IFCCARTESIANPOINT((0.,0.,0.));'],
+        [8, 'IFCSIUNIT', '#8=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);'],
+        [9, 'IFCSIUNIT', '#9=IFCSIUNIT(*,.AREAUNIT.,$,.SQUARE_METRE.);'],
+        [10, 'IFCSIUNIT', '#10=IFCSIUNIT(*,.VOLUMEUNIT.,$,.CUBIC_METRE.);'],
+        [11, 'IFCBUILDINGSTOREY', `#11=IFCBUILDINGSTOREY('${guid('mmStorey')}',$,'L1',$,$,$,$,$,.ELEMENT.,3000.);`],
+        [12, 'IFCEXTRUDEDAREASOLID', '#12=IFCEXTRUDEDAREASOLID(#13,#7,#14,2500.);'],
+        [13, 'IFCCIRCLEPROFILEDEF', '#13=IFCCIRCLEPROFILEDEF(.AREA.,$,$,300.);'],
+        [14, 'IFCDIRECTION', '#14=IFCDIRECTION((0.,0.,1.));'],
+        [15, 'IFCQUANTITYLENGTH', "#15=IFCQUANTITYLENGTH('Height',$,$,3000.,$);"],
+        [16, 'IFCQUANTITYAREA', "#16=IFCQUANTITYAREA('Area',$,$,12.5,$);"],
+        [17, 'IFCRELAGGREGATES', `#17=IFCRELAGGREGATES('${guid('mmAgg')}',$,$,$,#1,(#4));`],
+      ]);
+      m.lengthUnitScale = 0.001;
+      return m;
+    };
+
+    it('rescales coordinates and unifies into one single-unit project', () => {
+      const result = new MergedExporter([metreModel(), mmModel()])
+        .export({ schema: 'IFC4', unitReconciliation: 'normalize' });
+      const content = decode(result.content);
+
+      // mm coordinate 3000 → 3 metres; the primary metre coord is untouched.
+      expect(content).toContain('(3.,0.,0.)');
+      expect(content).not.toContain('(3000.,0.,0.)');
+      expect(content).toContain('(1.5,0.,0.)');
+
+      // Exactly one IfcProject and one IfcUnitAssignment — a clean single-unit file.
+      expect(content.match(/=IFCPROJECT\(/g)?.length).toBe(1);
+      expect(content.match(/=IFCUNITASSIGNMENT\(/g)?.length).toBe(1);
+      expect(content.match(/=IFCSITE\(/g)?.length).toBe(1);
+
+      expect(result.stats.federatedModelCount).toBe(0);
+      expect(result.stats.normalizedModelCount).toBe(1);
+      expect(result.stats.warnings).toEqual([]);
+      expect(findDanglingRefs(content)).toEqual([]);
+    });
+
+    it('rescales scalar lengths (elevation, depth, radius) and length quantities', () => {
+      const content = decode(new MergedExporter([metreModel(), mmModel()])
+        .export({ schema: 'IFC4', unitReconciliation: 'normalize' }).content);
+
+      // Storey elevation 3000 mm → 3 m.
+      expect(content).toMatch(/,\.ELEMENT\.,3\.\)/);
+      // Extrusion depth 2500 mm → 2.5 m; circle radius 300 mm → 0.3 m.
+      expect(content).toMatch(/IFCEXTRUDEDAREASOLID\(#\d+,#\d+,#\d+,2\.5\)/);
+      expect(content).toContain('IFCCIRCLEPROFILEDEF(.AREA.,$,$,0.3)');
+      // Length quantity 3000 mm → 3 m.
+      expect(content).toContain("IFCQUANTITYLENGTH('Height',$,$,3.,$)");
+      // Direction is never rescaled.
+      expect(content).toContain('IFCDIRECTION((0.,0.,1.))');
+      expect(findDanglingRefs(content)).toEqual([]);
+    });
+
+    it('does NOT length-rescale area quantities already in square metres (Revit)', () => {
+      const content = decode(new MergedExporter([metreModel(), mmModel()])
+        .export({ schema: 'IFC4', unitReconciliation: 'normalize' }).content);
+      // Area is declared in m² in both models → the area factor is 1, so 12.5 stays.
+      expect(content).toContain("IFCQUANTITYAREA('Area',$,$,12.5,$)");
+    });
+
+    it('converts a conversion-based square-foot area quantity into square metres', () => {
+      // Secondary declares AREAUNIT as an IfcConversionBasedUnit (square foot,
+      // 0.09290304 m²) via IfcMeasureWithUnit → the area factor is read from it.
+      const imperial = buildModel('imp', 'Imperial', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('impProj')}',$,'Imp',$,$,$,$,$,#2);`],
+        [2, 'IFCUNITASSIGNMENT', '#2=IFCUNITASSIGNMENT((#3,#5));'],
+        [3, 'IFCSIUNIT', '#3=IFCSIUNIT(*,.LENGTHUNIT.,$,.FOOT.);'],
+        [4, 'IFCSIUNIT', '#4=IFCSIUNIT(*,.AREAUNIT.,$,.SQUARE_METRE.);'],
+        [5, 'IFCCONVERSIONBASEDUNIT', "#5=IFCCONVERSIONBASEDUNIT(#9,.AREAUNIT.,'SQUARE FOOT',#6);"],
+        [6, 'IFCMEASUREWITHUNIT', '#6=IFCMEASUREWITHUNIT(IFCAREAMEASURE(0.09290304),#4);'],
+        [7, 'IFCELEMENTQUANTITY', `#7=IFCELEMENTQUANTITY('${guid('impQto')}',$,'Q',$,$,(#8));`],
+        [8, 'IFCQUANTITYAREA', "#8=IFCQUANTITYAREA('Area',$,$,10.,$);"],
+        [9, 'IFCDIMENSIONALEXPONENTS', '#9=IFCDIMENSIONALEXPONENTS(0,0,0,0,0,0,0);'],
+      ]);
+      imperial.lengthUnitScale = 0.3048;
+
+      const content = decode(new MergedExporter([metreModel(), imperial])
+        .export({ schema: 'IFC4', unitReconciliation: 'normalize' }).content);
+      // 10 ft² × 0.09290304 = 0.9290304 m².
+      expect(content).toContain("IFCQUANTITYAREA('Area',$,$,0.9290304,$)");
+      // The conversion factor itself (a unit definition) is untouched.
+      expect(content).toContain('IFCAREAMEASURE(0.09290304)');
+      expect(findDanglingRefs(content)).toEqual([]);
+    });
+
+    it('rescales in the other direction (metre model into a feet primary)', () => {
+      const feet = buildModel('feet', 'Feet', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('ftProj')}',$,'Feet',$,$,$,$,$,#2);`],
+        [2, 'IFCUNITASSIGNMENT', '#2=IFCUNITASSIGNMENT((#3));'],
+        [3, 'IFCSIUNIT', '#3=IFCSIUNIT(*,.LENGTHUNIT.,$,.FOOT.);'],
+        [4, 'IFCWALL', `#4=IFCWALL('${guid('ftWall')}',$,'FW',$,$,#5,$,$);`],
+        [5, 'IFCCARTESIANPOINT', '#5=IFCCARTESIANPOINT((5.,0.,0.));'],
+      ]);
+      feet.lengthUnitScale = 0.3048;
+      const metre = buildModel('m', 'Metre', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('mProj')}',$,'Metre',$,$,$,$,$,#2);`],
+        [2, 'IFCUNITASSIGNMENT', '#2=IFCUNITASSIGNMENT((#3));'],
+        [3, 'IFCSIUNIT', '#3=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);'],
+        [4, 'IFCCOLUMN', `#4=IFCCOLUMN('${guid('mCol')}',$,'MC',$,$,#5,$,$);`],
+        [5, 'IFCCARTESIANPOINT', '#5=IFCCARTESIANPOINT((3.048,0.,0.));'],
+      ]);
+      metre.lengthUnitScale = 1.0;
+
+      const content = decode(new MergedExporter([feet, metre])
+        .export({ schema: 'IFC4', unitReconciliation: 'normalize' }).content);
+      // 3.048 m ÷ 0.3048 m/ft = 10 ft.
+      expect(content).toContain('(10.,0.,0.)');
+      expect(content.match(/=IFCPROJECT\(/g)?.length).toBe(1);
+      expect(findDanglingRefs(content)).toEqual([]);
+    });
+
+    it('normalizes via exportAsync as well', async () => {
+      const result = await new MergedExporter([metreModel(), mmModel()])
+        .exportAsync({ schema: 'IFC4', unitReconciliation: 'normalize' });
+      const content = decode(result.content);
+      expect(content).toContain('(3.,0.,0.)');
+      expect(content.match(/=IFCPROJECT\(/g)?.length).toBe(1);
+      expect(result.stats.normalizedModelCount).toBe(1);
+      expect(findDanglingRefs(content)).toEqual([]);
+    });
+
+    it('leaves an already-shared-unit model untouched under normalize', () => {
+      const result = new MergedExporter([metreModel(), metreModel()])
+        .export({ schema: 'IFC4', unitReconciliation: 'normalize' });
+      const content = decode(result.content);
+      // Same unit → nothing rescaled, still unified to one project.
+      expect(result.stats.normalizedModelCount).toBe(0);
+      expect(content.match(/=IFCPROJECT\(/g)?.length).toBe(1);
+      expect(content).toContain('(1.5,0.,0.)');
+      expect(findDanglingRefs(content)).toEqual([]);
+    });
+
+    it('warns that IFC4X3-specific length attributes may be unscaled', () => {
+      const mm = mmModel();
+      (mm.dataStore as { schemaVersion: string }).schemaVersion = 'IFC4X3';
+      const result = new MergedExporter([metreModel(), mm])
+        .export({ schema: 'IFC4X3', unitReconciliation: 'normalize' });
+      expect(result.stats.normalizedModelCount).toBe(1);
+      expect(result.stats.warnings.some(w => w.includes('IFC4X3'))).toBe(true);
+    });
+
+    it('warns when a normalized model carries georeferencing', () => {
+      const mm = mmModel();
+      const store = mm.dataStore;
+      // Splice a minimal IfcMapConversion into the mock store so the caveat fires.
+      const map = "#18=IFCMAPCONVERSION(#3,#19,10.,20.,0.,$,$,$);";
+      const crs = "#19=IFCPROJECTEDCRS('EPSG:2056',$,$,$,$,$,$);";
+      const extra = new TextEncoder().encode(map + crs);
+      const merged = new Uint8Array(store.source!.length + extra.length);
+      merged.set(store.source!); merged.set(extra, store.source!.length);
+      let off = store.source!.length;
+      for (const [id, type, text] of [[18, 'IFCMAPCONVERSION', map], [19, 'IFCPROJECTEDCRS', crs]] as Array<[number, string, string]>) {
+        const len = new TextEncoder().encode(text).length;
+        store.entityIndex.byId.set(id, { expressId: id, type, byteOffset: off, byteLength: len, lineNumber: 0 } as never);
+        if (!store.entityIndex.byType.has(type)) store.entityIndex.byType.set(type, []);
+        store.entityIndex.byType.get(type)!.push(id);
+        off += len;
+      }
+      (store as { source: Uint8Array }).source = merged;
+
+      const result = new MergedExporter([metreModel(), mm])
+        .export({ schema: 'IFC4', unitReconciliation: 'normalize' });
+      expect(result.stats.warnings.some(w => w.includes('georeferencing'))).toBe(true);
+    });
+
+    it("contrast: 'auto' federates the mm model (two projects), 'normalize' unifies it", () => {
+      const auto = decode(new MergedExporter([metreModel(), mmModel()]).export({ schema: 'IFC4' }).content);
+      expect(auto.match(/=IFCPROJECT\(/g)?.length).toBe(2); // federated
+      expect(auto).toContain('(3000.,0.,0.)'); // raw mm coords preserved
+
+      const norm = decode(new MergedExporter([metreModel(), mmModel()])
+        .export({ schema: 'IFC4', unitReconciliation: 'normalize' }).content);
+      expect(norm.match(/=IFCPROJECT\(/g)?.length).toBe(1); // unified
+      expect(norm).not.toContain('(3000.,0.,0.)'); // rescaled
+    });
+  });
+
   // Federated export must round-trip pending edits (issue #1406): the merged
   // path historically read raw source bytes and dropped every mutation, so only
   // single-model export reflected edits. exportAsync now bakes each model's

--- a/packages/export/src/merged-exporter.ts
+++ b/packages/export/src/merged-exporter.ts
@@ -20,6 +20,7 @@ import { convertStepLine, needsConversion, type IfcSchemaVersion } from './schem
 import { assembleStepBytes } from './step-serialization.js';
 import { getCompleteEntityIndex, getMaxExpressId, type CompleteEntityIndex, type ExportEntityRef } from './entity-iteration.js';
 import { StepExporter } from './step-exporter.js';
+import { rescaleEntityLengths, computeNormalizeFactor } from './unit-normalize.js';
 
 /** Entity types forming shared infrastructure (deduplicated across models). */
 const SHARED_INFRASTRUCTURE_TYPES = new Set([
@@ -88,6 +89,16 @@ function isRelationshipType(typeUpper: string): boolean {
 /** Relative tolerance for comparing two length unit scale factors. */
 const UNIT_SCALE_TOLERANCE = 1e-6;
 
+/** SI prefix multipliers, for resolving prefixed area/volume units (rarely used). */
+const SI_PREFIX_MULTIPLIERS: Record<string, number> = {
+  ATTO: 1e-18, FEMTO: 1e-15, PICO: 1e-12, NANO: 1e-9, MICRO: 1e-6, MILLI: 1e-3,
+  CENTI: 1e-2, DECI: 1e-1, DECA: 1e1, HECTO: 1e2, KILO: 1e3, MEGA: 1e6,
+  GIGA: 1e9, TERA: 1e12, PETA: 1e15, EXA: 1e18,
+};
+
+/** Source schemas the IFC4 length registry does not fully cover (see #1475 review). */
+const NORMALIZE_UNCOVERED_SCHEMAS = new Set(['IFC4X3', 'IFC5']);
+
 /** Lookup tables for matching spatial entities from the first model. */
 interface SpatialLookup {
   sitesByName: Map<string, number>;
@@ -112,8 +123,48 @@ interface MergeSetup {
   spatialLookup: SpatialLookup;
   /** Length unit scale of the primary model — the unit other models merge into. */
   primaryScale: number;
+  /** Area unit scale (m² per unit) of the primary model — target for area values. */
+  primaryAreaScale: number;
+  /** Volume unit scale (m³ per unit) of the primary model — target for volume values. */
+  primaryVolumeScale: number;
   /** When true, every model is treated as sharing the primary unit. */
   assumeShared: boolean;
+  /**
+   * When true, a differing-unit model is rescaled into the primary unit and then
+   * unified into the primary project (rather than federated).
+   */
+  normalize: boolean;
+}
+
+/**
+ * How one model folds into the merge, decided from its units and the
+ * reconciliation mode. See {@link MergedExporter.resolveModelMode}.
+ *
+ * Length, area and volume carry *independent* factors: IFC declares
+ * `AREAUNIT`/`VOLUMEUNIT` separately from `LENGTHUNIT` (e.g. millimetre lengths
+ * with square-/cubic-metre areas), so an area is not simply the length factor
+ * squared.
+ */
+interface ModelMode {
+  /**
+   * True when the model is unified into the primary project (its project, units,
+   * contexts and matching spatial structure are deduplicated). False federates it.
+   */
+  compatible: boolean;
+  /** Factor applied to every length-valued datum before emit (`1` = no rescale). */
+  lengthFactor: number;
+  /** Factor applied to every area-valued datum before emit (`1` = no rescale). */
+  areaFactor: number;
+  /** Factor applied to every volume-valued datum before emit (`1` = no rescale). */
+  volumeFactor: number;
+  /**
+   * Unit space the model's emitted entities end up in — the primary scale when
+   * normalized/compatible, else the model's own scale. Recorded with each emitted
+   * GlobalId so later models reconcile against the right unit space.
+   */
+  effectiveScale: number;
+  /** True when this (non-primary) model was rescaled into the primary unit. */
+  normalized: boolean;
 }
 
 /** Per-model plan: how this model's entities are remapped, skipped, or restamped. */
@@ -196,6 +247,20 @@ function viewHasMutations(view: MutablePropertyView | undefined): boolean {
 }
 
 /**
+ * Drop models with no usable source (nothing to emit): a cache-restored or
+ * metadata-only store can reach the merge with an empty `.source`. The emit loop
+ * already skips them, but the primary model (`models[0]`) and the unit/offset
+ * setup must be computed over the SAME set — otherwise an empty model at index 0
+ * would poison the primary unit/scale that later models normalize against. When
+ * every model is empty the original list is kept so a valid (empty) file is still
+ * produced rather than throwing.
+ */
+function withUsableSource(models: MergeModelInput[]): MergeModelInput[] {
+  const usable = models.filter(m => m.dataStore.source && m.dataStore.source.length > 0);
+  return usable.length > 0 ? usable : models;
+}
+
+/**
  * Options for merged STEP export
  */
 export interface MergeExportOptions {
@@ -231,11 +296,23 @@ export interface MergeExportOptions {
    *   (a deliberate relaxation of the IfcSingleProjectInstance rule, flagged in
    *   `stats.warnings`) — the only way to preserve mixed units in one file
    *   without rewriting every length-valued attribute.
+   * - `'normalize'`: single-unit merge. A model with a *different* length unit
+   *   is *rescaled* — every length-valued datum (all `IfcCartesianPoint`
+   *   coordinates, extrusion depths, profile dimensions, radii, thicknesses,
+   *   storey elevations, placement offsets, `IfcLengthMeasure` property values,
+   *   `IfcQuantityLength`/`Area`/`Volume`, …) is converted from its own unit
+   *   into the first model's unit — and then unified into the single first
+   *   `IfcProject` (its `IfcUnitAssignment` and contexts deduplicated). The
+   *   output is one ordinary single-unit IFC that opens correctly everywhere
+   *   (BIM Vision included). Angles, ratios, counts and georeferencing offsets
+   *   are left as-is. Area/volume values assume the SI-derived unit
+   *   (square/cube of the length unit). See {@link ./unit-normalize.ts} for the
+   *   exact set of rescaled attributes.
    * - `'assume-shared'`: treat every model as sharing the first model's unit
    *   (the pre-1332 behaviour). Use only when the caller has already
    *   normalised units; mixing real units under this mode mis-scales geometry.
    */
-  unitReconciliation?: 'auto' | 'assume-shared';
+  unitReconciliation?: 'auto' | 'normalize' | 'assume-shared';
 
   /** Apply visibility filtering to each model before merging */
   visibleOnly?: boolean;
@@ -284,6 +361,12 @@ export interface MergeExportResult {
      */
     federatedModelCount: number;
     /**
+     * Number of models whose length-valued data was rescaled into the first
+     * model's unit under `unitReconciliation: 'normalize'`. 0 for the other
+     * modes (or when every model already shared the first model's unit).
+     */
+    normalizedModelCount: number;
+    /**
      * Human-readable advisories about the merge (empty on a clean single-unit
      * merge). Notably flags when federation produced more than one IfcProject,
      * which intentionally relaxes the IfcSingleProjectInstance schema rule.
@@ -315,14 +398,15 @@ export interface MergeExportResult {
  *    fresh deterministic GlobalId so the file has no duplicate-GlobalId errors
  *    and no relationship membership is lost.
  *
- * Conformance trade-off: when federation triggers, the file contains more than
- * one IfcProject, which intentionally relaxes the IfcSingleProjectInstance
- * EXPRESS rule (SIZEOF(IfcProject) <= 1). This is the only way to keep two
- * different length units in one STEP file without rewriting every length-valued
- * coordinate, and it is strictly better than the previous silent mis-scale.
- * `MergeExportResult.stats.warnings` flags it; pass
- * `unitReconciliation: 'assume-shared'` to force a single project when units
- * are already normalised.
+ * Conformance trade-off: when federation triggers (under the default `'auto'`),
+ * the file contains more than one IfcProject, which intentionally relaxes the
+ * IfcSingleProjectInstance EXPRESS rule (SIZEOF(IfcProject) <= 1). This preserves
+ * both units without rewriting coordinates, and is strictly better than a silent
+ * mis-scale. `MergeExportResult.stats.warnings` flags it. To instead get one
+ * ordinary single-unit IfcProject, pass `unitReconciliation: 'normalize'` — it
+ * rescales every length-valued datum of the differing-unit models into the first
+ * model's unit (see {@link ./unit-normalize.ts}). Use `'assume-shared'` only when
+ * the caller has already normalised units.
  *
  * Limitation: federation only unifies a model against the *first* model's unit
  * group. Two non-first models that share a unit different from the first are
@@ -351,7 +435,7 @@ export class MergedExporter {
         'Use exportAsync() for merged export with mutations.',
       );
     }
-    const models = this.models;
+    const models = withUsableSource(this.models);
     const setup = this.buildMergeSetup(options, models);
 
     const allEntityLines: string[] = [];
@@ -361,6 +445,8 @@ export class MergedExporter {
     const guidToFinalId = new Map<string, GuidRecord>();
     let isFirstModel = true;
     let federatedModelCount = 0;
+    let normalizedModelCount = 0;
+    const normalizeWarnings = new Set<string>();
 
     for (const model of models) {
       const offset = setup.modelOffsets.get(model.id)!;
@@ -372,17 +458,16 @@ export class MergedExporter {
       const completeIndex = getCompleteEntityIndex(model.dataStore);
       const includedEntityIds = this.computeIncludedEntityIds(model, options, completeIndex, source);
 
-      const modelScale = this.resolveUnitScale(model);
-      const compatible = isFirstModel || setup.assumeShared
-        || this.unitsCompatible(modelScale, setup.primaryScale);
-      if (!isFirstModel && !compatible) federatedModelCount++;
-      const plan = this.planModel(model, completeIndex, isFirstModel, compatible, setup, guidToFinalId);
+      const mode = this.resolveModelMode(model, isFirstModel, setup);
+      if (!isFirstModel && !mode.compatible) federatedModelCount++;
+      if (mode.normalized) { normalizedModelCount++; this.collectNormalizeCaveats(model, normalizeWarnings); }
+      const plan = this.planModel(model, completeIndex, isFirstModel, mode.compatible, mode.lengthFactor, setup, guidToFinalId);
 
       const sourceSchema = (model.dataStore.schemaVersion as IfcSchemaVersion) || 'IFC4';
       for (const [expressId, entityRef] of completeIndex) {
         if (includedEntityIds !== null && !includedEntityIds.has(expressId)) continue;
         if (plan.skipEntityIds.has(expressId)) continue;
-        const line = this.renderEntity(expressId, entityRef, source, offset, plan, sourceSchema, schema, guidToFinalId, modelScale);
+        const line = this.renderEntity(expressId, entityRef, source, offset, plan, sourceSchema, schema, guidToFinalId, mode);
         if (line !== null) allEntityLines.push(line);
       }
 
@@ -395,7 +480,7 @@ export class MergedExporter {
 
     return {
       content,
-      stats: this.buildStats(allEntityLines.length, content.byteLength, federatedModelCount),
+      stats: this.buildStats(allEntityLines.length, content.byteLength, federatedModelCount, normalizedModelCount, normalizeWarnings),
     };
   }
 
@@ -414,7 +499,7 @@ export class MergedExporter {
     // Bake each model's pending edits into its source bytes before merging, so
     // federated export round-trips mutations like single-model export. Models
     // without edits pass through unchanged (no export/parse cost).
-    const models = await this.bakeMutatedModels();
+    const models = withUsableSource(await this.bakeMutatedModels());
     const setup = this.buildMergeSetup(options, models);
 
     const allEntityLines: string[] = [];
@@ -429,6 +514,8 @@ export class MergedExporter {
     let isFirstModel = true;
     let entitiesProcessed = 0;
     let federatedModelCount = 0;
+    let normalizedModelCount = 0;
+    const normalizeWarnings = new Set<string>();
     const YIELD_INTERVAL = 2000;
 
     if (onProgress) onProgress({ phase: 'preparing', percent: 0, entitiesProcessed: 0, entitiesTotal: totalEntities });
@@ -451,11 +538,10 @@ export class MergedExporter {
       const completeIndex = getCompleteEntityIndex(model.dataStore);
       const includedEntityIds = this.computeIncludedEntityIds(model, options, completeIndex, source);
 
-      const modelScale = this.resolveUnitScale(model);
-      const compatible = isFirstModel || setup.assumeShared
-        || this.unitsCompatible(modelScale, setup.primaryScale);
-      if (!isFirstModel && !compatible) federatedModelCount++;
-      const plan = this.planModel(model, completeIndex, isFirstModel, compatible, setup, guidToFinalId);
+      const mode = this.resolveModelMode(model, isFirstModel, setup);
+      if (!isFirstModel && !mode.compatible) federatedModelCount++;
+      if (mode.normalized) { normalizedModelCount++; this.collectNormalizeCaveats(model, normalizeWarnings); }
+      const plan = this.planModel(model, completeIndex, isFirstModel, mode.compatible, mode.lengthFactor, setup, guidToFinalId);
       const sourceSchema = (model.dataStore.schemaVersion as IfcSchemaVersion) || 'IFC4';
 
       let entityCount = 0;
@@ -463,7 +549,7 @@ export class MergedExporter {
         if (includedEntityIds !== null && !includedEntityIds.has(expressId)) continue;
         if (plan.skipEntityIds.has(expressId)) continue;
 
-        const line = this.renderEntity(expressId, entityRef, source, offset, plan, sourceSchema, schema, guidToFinalId, modelScale);
+        const line = this.renderEntity(expressId, entityRef, source, offset, plan, sourceSchema, schema, guidToFinalId, mode);
         if (line !== null) allEntityLines.push(line);
 
         entityCount++;
@@ -501,7 +587,7 @@ export class MergedExporter {
 
     return {
       content,
-      stats: this.buildStats(allEntityLines.length, content.byteLength, federatedModelCount),
+      stats: this.buildStats(allEntityLines.length, content.byteLength, federatedModelCount, normalizedModelCount, normalizeWarnings),
     };
   }
 
@@ -552,7 +638,13 @@ export class MergedExporter {
   /**
    * Assemble the result stats, including any federation conformance warnings.
    */
-  private buildStats(totalEntityCount: number, fileSize: number, federatedModelCount: number): MergeExportResult['stats'] {
+  private buildStats(
+    totalEntityCount: number,
+    fileSize: number,
+    federatedModelCount: number,
+    normalizedModelCount: number,
+    normalizeWarnings: Set<string>,
+  ): MergeExportResult['stats'] {
     const warnings: string[] = [];
     if (federatedModelCount > 0) {
       warnings.push(
@@ -560,11 +652,36 @@ export class MergedExporter {
         `federated as separate IfcProject roots to keep their geometry correctly scaled. The output ` +
         `therefore contains ${federatedModelCount + 1} IfcProject instances, which intentionally relaxes ` +
         `the IfcSingleProjectInstance rule (SIZEOF(IfcProject) <= 1). Some single-project viewers may ` +
-        `only show the first project. Pass unitReconciliation:'assume-shared' to force one project when ` +
-        `units are already normalised.`,
+        `only show the first project. Pass unitReconciliation:'normalize' to rescale them into one ` +
+        `single-unit project, or 'assume-shared' when units are already normalised.`,
       );
     }
-    return { modelCount: this.models.length, totalEntityCount, fileSize, federatedModelCount, warnings };
+    warnings.push(...normalizeWarnings);
+    return { modelCount: this.models.length, totalEntityCount, fileSize, federatedModelCount, normalizedModelCount, warnings };
+  }
+
+  /**
+   * Record advisories for a model being normalized. The rescaler derives its
+   * length-attribute map from the IFC4 schema registry, so it may not cover
+   * length attributes introduced by newer schemas (IFC4X3 alignment / linear
+   * referencing), and it deliberately leaves georeferencing untouched.
+   */
+  private collectNormalizeCaveats(model: MergeModelInput, warnings: Set<string>): void {
+    const schema = (model.dataStore.schemaVersion ?? '').toUpperCase();
+    if (NORMALIZE_UNCOVERED_SCHEMAS.has(schema)) {
+      warnings.add(
+        `Model "${model.name}" (${schema}) was normalized using the IFC4 length-attribute schema; ` +
+        `length values on ${schema}-specific entities (e.g. alignment / linear-referencing segment ` +
+        `lengths and radii) may not have been rescaled. Verify infrastructure geometry.`,
+      );
+    }
+    if (this.findEntitiesByType(model.dataStore, 'IFCMAPCONVERSION').length > 0) {
+      warnings.add(
+        `Model "${model.name}" carries georeferencing (IfcMapConversion), which normalize leaves ` +
+        `untouched. If the model was georeferenced in its own unit, review the merged coordinate ` +
+        `operation.`,
+      );
+    }
   }
 
   /**
@@ -600,15 +717,128 @@ export class MergedExporter {
     }
 
     const firstModel = models[0];
+    const primaryScale = this.resolveUnitScale(firstModel);
     return {
       modelOffsets,
       firstModelOffset: modelOffsets.get(firstModel.id)!,
       firstModelInfraMap: this.findInfrastructureEntities(firstModel.dataStore),
       firstProjectIds: this.findEntitiesByType(firstModel.dataStore, 'IFCPROJECT'),
       spatialLookup: this.buildSpatialLookup(firstModel.dataStore),
-      primaryScale: this.resolveUnitScale(firstModel),
+      primaryScale,
+      primaryAreaScale: this.resolveDerivedUnitScale(firstModel.dataStore, 'AREAUNIT', primaryScale, 2),
+      primaryVolumeScale: this.resolveDerivedUnitScale(firstModel.dataStore, 'VOLUMEUNIT', primaryScale, 3),
       assumeShared: options.unitReconciliation === 'assume-shared',
+      normalize: options.unitReconciliation === 'normalize',
     };
+  }
+
+  /**
+   * Decide how one model folds into the merge from its length unit and the
+   * reconciliation mode.
+   *
+   * - The primary model, `assume-shared`, and any model that already shares the
+   *   primary unit are unified with no rescale.
+   * - Under `normalize`, a differing-unit model is unified *and* rescaled: every
+   *   length-valued datum is multiplied by `primaryScale`-relative factor so its
+   *   geometry stays correct under the single shared unit.
+   * - Otherwise (`auto`) a differing-unit model is federated (kept as its own
+   *   project + units), leaving its raw coordinates untouched.
+   *
+   * Area/volume reconciliation is gated on the length unit differing: a model that
+   * shares the primary's length unit is treated as fully compatible (factors 1).
+   * A model that pairs a matching length unit with a *divergent* area/volume unit
+   * (a non-conformant combination no mainstream exporter emits) is not rescaled.
+   */
+  private resolveModelMode(model: MergeModelInput, isFirstModel: boolean, setup: MergeSetup): ModelMode {
+    const modelScale = this.resolveUnitScale(model);
+    if (isFirstModel || setup.assumeShared || this.unitsCompatible(modelScale, setup.primaryScale)) {
+      return { compatible: true, lengthFactor: 1, areaFactor: 1, volumeFactor: 1, effectiveScale: modelScale, normalized: false };
+    }
+    if (setup.normalize) {
+      // Each dimension is converted by the ratio of its own declared unit, not by
+      // powers of the length factor — IFC declares area/volume units independently
+      // (Revit: millimetre lengths but square-/cubic-metre areas/volumes).
+      const modelArea = this.resolveDerivedUnitScale(model.dataStore, 'AREAUNIT', modelScale, 2);
+      const modelVolume = this.resolveDerivedUnitScale(model.dataStore, 'VOLUMEUNIT', modelScale, 3);
+      return {
+        compatible: true,
+        lengthFactor: computeNormalizeFactor(modelScale, setup.primaryScale),
+        areaFactor: computeNormalizeFactor(modelArea, setup.primaryAreaScale),
+        volumeFactor: computeNormalizeFactor(modelVolume, setup.primaryVolumeScale),
+        effectiveScale: setup.primaryScale,
+        normalized: true,
+      };
+    }
+    // auto: federate the differing-unit model, coordinates untouched.
+    return { compatible: false, lengthFactor: 1, areaFactor: 1, volumeFactor: 1, effectiveScale: modelScale, normalized: false };
+  }
+
+  /**
+   * Resolve a model's declared AREAUNIT / VOLUMEUNIT scale (SI m² / m³ per unit)
+   * by walking IfcProject → IfcUnitAssignment. Falls back to the length-derived
+   * unit (`lengthScale ** power`) when the model declares no explicit area/volume
+   * unit — the IFC default. A prefixed SI area/volume unit (rare) applies the
+   * prefix once (buildingSMART / IfcOpenShell convention).
+   */
+  private resolveDerivedUnitScale(
+    dataStore: IfcDataStore,
+    wantType: 'AREAUNIT' | 'VOLUMEUNIT',
+    lengthScale: number,
+    power: number,
+  ): number {
+    const fallback = Math.pow(lengthScale, power);
+    const projectIds = this.findEntitiesByType(dataStore, 'IFCPROJECT');
+    if (projectIds.length === 0) return fallback;
+
+    // IfcProject.UnitsInContext = attr 8 → IfcUnitAssignment.
+    const unitsAttr = this.extractStepAttribute(projectIds[0], dataStore, 8);
+    const assignMatch = unitsAttr?.match(/^#(\d+)$/);
+    if (!assignMatch) return fallback;
+
+    // IfcUnitAssignment.Units = attr 0 (a list of unit refs).
+    const listAttr = this.extractStepAttribute(parseInt(assignMatch[1], 10), dataStore, 0);
+    if (!listAttr) return fallback;
+
+    for (const m of listAttr.matchAll(/#(\d+)/g)) {
+      const uid = parseInt(m[1], 10);
+      const uref = dataStore.entityIndex.byId.get(uid);
+      const utype = (uref?.type ?? '').toUpperCase();
+
+      if (utype === 'IFCSIUNIT') {
+        // IfcSIUnit: [1] UnitType, [2] Prefix, [3] Name.
+        if (this.normalizeEnum(this.extractStepAttribute(uid, dataStore, 1)) !== wantType) continue;
+        const prefixRaw = this.extractStepAttribute(uid, dataStore, 2);
+        if (!prefixRaw || prefixRaw === '$' || prefixRaw === '*') return 1.0; // square/cubic metre
+        const mult = SI_PREFIX_MULTIPLIERS[this.normalizeEnum(prefixRaw)];
+        return mult !== undefined ? mult : 1.0;
+      }
+
+      if (utype === 'IFCCONVERSIONBASEDUNIT') {
+        // IfcConversionBasedUnit: [1] UnitType, [2] Name, [3] ConversionFactor.
+        if (this.normalizeEnum(this.extractStepAttribute(uid, dataStore, 1)) !== wantType) continue;
+        const convMatch = this.extractStepAttribute(uid, dataStore, 3)?.match(/^#(\d+)$/);
+        if (convMatch) {
+          // IfcMeasureWithUnit.ValueComponent = attr 0 (e.g. IFCAREAMEASURE(0.0929)).
+          const num = this.parseMeasureNumber(this.extractStepAttribute(parseInt(convMatch[1], 10), dataStore, 0));
+          if (num !== undefined && num > 0) return num;
+        }
+        return fallback;
+      }
+    }
+    return fallback;
+  }
+
+  /** Uppercase an enum token, stripping the STEP `.ENUM.` dots. `''` for nullish. */
+  private normalizeEnum(raw: string | null): string {
+    return (raw ?? '').replace(/\./g, '').trim().toUpperCase();
+  }
+
+  /** Extract the number from a bare real or a typed measure token (`IFCAREAMEASURE(0.09)`). */
+  private parseMeasureNumber(raw: string | null): number | undefined {
+    if (!raw) return undefined;
+    const typed = raw.match(/\(([^)]*)\)\s*$/);
+    const n = Number((typed ? typed[1] : raw).trim());
+    return Number.isFinite(n) ? n : undefined;
   }
 
   /**
@@ -659,10 +889,10 @@ export class MergedExporter {
    * Plan how a model's entities are remapped, skipped, or re-stamped, given
    * whether it shares the primary model's length unit (`compatible`).
    *
-   * Compatible (or `assume-shared`) models are unified into the primary project:
-   * their IfcProject, shared infrastructure, and matching spatial structure are
-   * deduplicated, and a rooted entity repeating an already-emitted GlobalId is
-   * unified to that one instance.
+   * Compatible models (same unit, `assume-shared`, or `normalize`d into the
+   * primary unit) are unified into the primary project: their IfcProject, shared
+   * infrastructure, and matching spatial structure are deduplicated, and a rooted
+   * entity repeating an already-emitted GlobalId is unified to that one instance.
    *
    * Incompatible (federated) models keep their own project, units, contexts and
    * spatial structure so their coordinates stay correctly scaled; a rooted
@@ -675,6 +905,7 @@ export class MergedExporter {
     completeIndex: CompleteEntityIndex,
     isFirstModel: boolean,
     compatible: boolean,
+    lengthFactor: number,
     setup: MergeSetup,
     guidToFinalId: Map<string, GuidRecord>,
   ): ModelMergePlan {
@@ -711,7 +942,9 @@ export class MergedExporter {
       }
 
       // Unify spatial hierarchy: match Site, Building, Storey to first model.
-      this.unifySpatialEntities(model.dataStore, setup.spatialLookup, setup.firstModelOffset, sharedRemap, skipEntityIds);
+      // Under normalize, this model's raw elevations are in its own unit, so the
+      // elevation match is done in the primary unit (rawElevation * lengthFactor).
+      this.unifySpatialEntities(model.dataStore, setup.spatialLookup, setup.firstModelOffset, lengthFactor, sharedRemap, skipEntityIds);
 
       // Skip IfcRelAggregates that become fully redundant after unification.
       this.skipRedundantRelAggregates(model.dataStore, sharedRemap, skipEntityIds);
@@ -764,7 +997,7 @@ export class MergedExporter {
     sourceSchema: IfcSchemaVersion,
     targetSchema: IfcSchemaVersion,
     guidToFinalId: Map<string, GuidRecord>,
-    modelScale: number,
+    mode: ModelMode,
   ): string | null {
     const entityText = safeUtf8Decode(source, entityRef.byteOffset, entityRef.byteOffset + entityRef.byteLength);
 
@@ -780,6 +1013,14 @@ export class MergedExporter {
     const mintedGuid = plan.guidRewrite.get(localId);
     if (mintedGuid !== undefined) {
       finalText = this.replaceGlobalId(finalText, mintedGuid);
+    }
+
+    // Normalize units: rescale every length/area/volume-valued datum into the
+    // primary unit. Done on the SOURCE-schema text (entityRef.type), before any
+    // schema conversion, so the schema-derived attribute indices line up. Touches
+    // only numeric literals, so id remaps and the GlobalId re-stamp above are safe.
+    if (mode.lengthFactor !== 1 || mode.areaFactor !== 1 || mode.volumeFactor !== 1) {
+      finalText = rescaleEntityLengths(finalText, entityRef.type.toUpperCase(), mode.lengthFactor, mode.areaFactor, mode.volumeFactor);
     }
 
     if (needsConversion(sourceSchema, targetSchema)) {
@@ -798,7 +1039,7 @@ export class MergedExporter {
       const emittedGuid = this.readLeadingGuid(finalText)
         ?? mintedGuid ?? plan.localGuids.get(localId);
       if (emittedGuid !== undefined) {
-        guidToFinalId.set(emittedGuid, { finalId: localId + offset, scale: modelScale });
+        guidToFinalId.set(emittedGuid, { finalId: localId + offset, scale: mode.effectiveScale });
       }
     }
 
@@ -1024,6 +1265,7 @@ export class MergedExporter {
     dataStore: IfcDataStore,
     lookup: SpatialLookup,
     firstModelOffset: number,
+    elevationFactor: number,
     sharedRemap: Map<number, number>,
     skipEntityIds: Set<number>,
   ): void {
@@ -1072,10 +1314,13 @@ export class MergedExporter {
         }
       }
 
-      // Fallback: match by elevation
+      // Fallback: match by elevation. The candidate's raw elevation is in this
+      // model's unit; scale it into the primary unit so the comparison (and the
+      // ±0.5 m tolerance) is unit-consistent under normalize (factor 1 otherwise).
       if (match === undefined) {
-        const elevation = this.extractStoreyElevation(id, dataStore);
-        if (elevation !== undefined) {
+        const rawElevation = this.extractStoreyElevation(id, dataStore);
+        if (rawElevation !== undefined) {
+          const elevation = rawElevation * elevationFactor;
           for (const entry of lookup.storeysByElevation) {
             if (matchedFirstStoreys.has(entry.expressId)) continue;
             const tolerance = Math.max(0.5, Math.abs(entry.elevation) * 0.01);

--- a/packages/export/src/unit-normalize.test.ts
+++ b/packages/export/src/unit-normalize.test.ts
@@ -1,0 +1,207 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import {
+  toStepRealScaled,
+  scaleNumberLiterals,
+  scaleTypedMeasures,
+  rescaleEntityLengths,
+  getEntityLengthPlan,
+  computeNormalizeFactor,
+} from './unit-normalize.js';
+
+describe('toStepRealScaled', () => {
+  it('always emits a decimal point', () => {
+    expect(toStepRealScaled(3)).toBe('3.');
+    expect(toStepRealScaled(2500 * 0.001)).toBe('2.5');
+  });
+
+  it('erases floating-point noise from the multiply', () => {
+    // 0.3048 * 100 = 30.479999999999997 in IEEE-754.
+    expect(toStepRealScaled(0.3048 * 100)).toBe('30.48');
+    expect(toStepRealScaled(1.1 * 3)).toBe('3.3');
+  });
+
+  it('emits valid STEP exponent form for tiny/huge magnitudes (uppercase E, mantissa dot)', () => {
+    expect(toStepRealScaled(5e-7)).toBe('5.E-7');
+    expect(toStepRealScaled(1.5e-8)).toBe('1.5E-8');
+    expect(toStepRealScaled(1e21)).toBe('1.E+21');
+  });
+
+  it('guards NaN/Infinity/-0', () => {
+    expect(toStepRealScaled(NaN)).toBe('0.');
+    expect(toStepRealScaled(Infinity)).toBe('0.');
+    expect(toStepRealScaled(-0)).toBe('0.');
+  });
+});
+
+describe('scaleNumberLiterals', () => {
+  it('scales every coordinate incl. the canonical trailing-dot form', () => {
+    expect(scaleNumberLiterals('(3000.,0.,-1.5)', 0.001)).toBe('(3.,0.,-0.0015)');
+  });
+
+  it('keeps exponent and leading-dot reals intact (scales mantissa only)', () => {
+    expect(scaleNumberLiterals('(1.E-5,.5,-2.5E2)', 1000)).toBe('(0.01,500.,-250000.)');
+  });
+
+  it('scales nested coordinate lists', () => {
+    expect(scaleNumberLiterals('((0.,0.),(1000.,2000.))', 0.001)).toBe('((0.,0.),(1.,2.))');
+  });
+
+  it('never touches #-references or quoted strings', () => {
+    expect(scaleNumberLiterals("#5,'Room (3000)',100.", 0.001)).toBe("#5,'Room (3000)',0.1");
+  });
+});
+
+describe('scaleTypedMeasures', () => {
+  it('scales each typed measure by its own dimension factor', () => {
+    // length ×0.001, area unchanged, volume unchanged (the Revit case).
+    expect(scaleTypedMeasures('IFCLENGTHMEASURE(100.),IFCAREAMEASURE(4.),IFCVOLUMEMEASURE(8.)', 0.001, 1, 1))
+      .toBe('IFCLENGTHMEASURE(0.1),IFCAREAMEASURE(4.),IFCVOLUMEMEASURE(8.)');
+  });
+
+  it('scales area/volume when the model uses length-derived units', () => {
+    expect(scaleTypedMeasures('IFCAREAMEASURE(4000000.),IFCVOLUMEMEASURE(8000000000.)', 0.001, 1e-6, 1e-9))
+      .toBe('IFCAREAMEASURE(4.),IFCVOLUMEMEASURE(8.)');
+  });
+
+  it('covers the positive/non-negative length aliases', () => {
+    expect(scaleTypedMeasures('IFCPOSITIVELENGTHMEASURE(5.),IFCNONNEGATIVELENGTHMEASURE(0.)', 0.001, 1, 1))
+      .toBe('IFCPOSITIVELENGTHMEASURE(0.005),IFCNONNEGATIVELENGTHMEASURE(0.)');
+  });
+
+  it('never scales measure-looking text inside a quoted string', () => {
+    expect(scaleTypedMeasures("IFCTEXT('e.g. IFCLENGTHMEASURE(100.)')", 0.001, 1, 1))
+      .toBe("IFCTEXT('e.g. IFCLENGTHMEASURE(100.)')");
+  });
+
+  it('scales every measure in a comma-separated list (boundary handling without lookbehind)', () => {
+    expect(scaleTypedMeasures('(IFCLENGTHMEASURE(1000.),IFCLENGTHMEASURE(2000.))', 0.001, 1, 1))
+      .toBe('(IFCLENGTHMEASURE(1.),IFCLENGTHMEASURE(2.))');
+  });
+});
+
+describe('getEntityLengthPlan (schema-derived)', () => {
+  it('finds coordinate lists', () => {
+    expect(getEntityLengthPlan('IFCCARTESIANPOINT').listIdx).toEqual([0]);
+    expect(getEntityLengthPlan('IFCCARTESIANPOINTLIST3D').listIdx).toEqual([0]);
+  });
+
+  it('finds scalar lengths and excludes angles on shape profiles', () => {
+    // I-shape: OverallWidth(3)..FlangeEdgeRadius(8) are lengths; FlangeSlope(9) is an angle.
+    expect(getEntityLengthPlan('IFCISHAPEPROFILEDEF').scalarIdx).toEqual([3, 4, 5, 6, 7, 8]);
+    expect(getEntityLengthPlan('IFCEXTRUDEDAREASOLID').scalarIdx).toEqual([3]);
+    expect(getEntityLengthPlan('IFCBUILDINGSTOREY').scalarIdx).toEqual([9]);
+    expect(getEntityLengthPlan('IFCSITE').scalarIdx).toEqual([11]);
+  });
+
+  it('classifies area/volume quantities and their unit guard', () => {
+    const area = getEntityLengthPlan('IFCQUANTITYAREA');
+    expect(area.areaIdx).toEqual([3]);
+    expect(area.unitGuardIdx).toEqual([2]);
+    const vol = getEntityLengthPlan('IFCQUANTITYVOLUME');
+    expect(vol.volumeIdx).toEqual([3]);
+    const len = getEntityLengthPlan('IFCQUANTITYLENGTH');
+    expect(len.scalarIdx).toEqual([3]);
+    expect(len.unitGuardIdx).toEqual([2]);
+  });
+
+  it('excludes unit-definition and georeferencing entities', () => {
+    expect(getEntityLengthPlan('IFCSIUNIT').empty).toBe(true);
+    expect(getEntityLengthPlan('IFCMEASUREWITHUNIT').empty).toBe(true);
+    expect(getEntityLengthPlan('IFCMAPCONVERSION').empty).toBe(true);
+  });
+
+  it('leaves directions and pure geometry-of-directions untouched', () => {
+    expect(getEntityLengthPlan('IFCDIRECTION').empty).toBe(true);
+    expect(getEntityLengthPlan('IFCAXIS2PLACEMENT3D').empty).toBe(true);
+  });
+});
+
+describe('rescaleEntityLengths (full entity lines)', () => {
+  it('scales cartesian point coordinates', () => {
+    expect(rescaleEntityLengths('#6=IFCCARTESIANPOINT((100.,200.,300.));', 'IFCCARTESIANPOINT', 0.001, 1, 1))
+      .toBe('#6=IFCCARTESIANPOINT((0.1,0.2,0.3));');
+  });
+
+  it('scales an extrusion depth without touching #-refs', () => {
+    expect(rescaleEntityLengths('#7=IFCEXTRUDEDAREASOLID(#1,#2,#3,2500.);', 'IFCEXTRUDEDAREASOLID', 0.001, 1, 1))
+      .toBe('#7=IFCEXTRUDEDAREASOLID(#1,#2,#3,2.5);');
+  });
+
+  it('scales a storey elevation at index 9', () => {
+    expect(rescaleEntityLengths("#8=IFCBUILDINGSTOREY('g',$,'L1',$,$,$,$,$,.ELEMENT.,3000.);", 'IFCBUILDINGSTOREY', 0.001, 1, 1))
+      .toBe("#8=IFCBUILDINGSTOREY('g',$,'L1',$,$,$,$,$,.ELEMENT.,3.);");
+  });
+
+  it('leaves a Revit area quantity alone (areaFactor 1) but scales a length-derived one', () => {
+    expect(rescaleEntityLengths("#9=IFCQUANTITYAREA('A',$,$,120.5,$);", 'IFCQUANTITYAREA', 0.001, 1, 1))
+      .toBe("#9=IFCQUANTITYAREA('A',$,$,120.5,$);");
+    expect(rescaleEntityLengths("#9=IFCQUANTITYAREA('A',$,$,5000000.,$);", 'IFCQUANTITYAREA', 0.001, 1e-6, 1e-9))
+      .toBe("#9=IFCQUANTITYAREA('A',$,$,5.,$);");
+  });
+
+  it('does not scale a quantity that carries its own explicit unit', () => {
+    expect(rescaleEntityLengths("#10=IFCQUANTITYLENGTH('L',$,#99,2500.,$);", 'IFCQUANTITYLENGTH', 0.001, 1, 1))
+      .toBe("#10=IFCQUANTITYLENGTH('L',$,#99,2500.,$);");
+  });
+
+  it('does not scale a property that carries its own explicit unit', () => {
+    expect(rescaleEntityLengths("#14=IFCPROPERTYSINGLEVALUE('T',$,IFCLENGTHMEASURE(50.),#77);", 'IFCPROPERTYSINGLEVALUE', 0.001, 1, 1))
+      .toBe("#14=IFCPROPERTYSINGLEVALUE('T',$,IFCLENGTHMEASURE(50.),#77);");
+  });
+
+  it('does not scale an IfcPropertyTableValue that declares its own DefiningUnit', () => {
+    // Attrs: Name,Description,DefiningValues,DefinedValues,Expression,DefiningUnit(5),DefinedUnit(6).
+    // DefiningUnit is a live ref → the table's values are already in its own unit.
+    const line = "#30=IFCPROPERTYTABLEVALUE('T',$,(IFCLENGTHMEASURE(10.)),(IFCLENGTHMEASURE(20.)),$,#88,$);";
+    expect(rescaleEntityLengths(line, 'IFCPROPERTYTABLEVALUE', 0.001, 1, 1)).toBe(line);
+  });
+
+  it('scales an IfcPropertyTableValue with no explicit unit', () => {
+    const line = "#31=IFCPROPERTYTABLEVALUE('T',$,(IFCLENGTHMEASURE(10.)),(IFCLENGTHMEASURE(20.)),$,$,$);";
+    expect(rescaleEntityLengths(line, 'IFCPROPERTYTABLEVALUE', 0.001, 1, 1))
+      .toBe("#31=IFCPROPERTYTABLEVALUE('T',$,(IFCLENGTHMEASURE(0.01)),(IFCLENGTHMEASURE(0.02)),$,$,$);");
+  });
+
+  it('scales a typed measure across a string with unbalanced parens', () => {
+    expect(rescaleEntityLengths("#13=IFCPROPERTYSINGLEVALUE('A )( B',$,IFCLENGTHMEASURE(5.),$);", 'IFCPROPERTYSINGLEVALUE', 0.001, 1, 1))
+      .toBe("#13=IFCPROPERTYSINGLEVALUE('A )( B',$,IFCLENGTHMEASURE(0.005),$);");
+  });
+
+  it('never rescales a direction, an angle, a count, or a name with digits', () => {
+    expect(rescaleEntityLengths('#11=IFCDIRECTION((0.,0.,1.));', 'IFCDIRECTION', 0.001, 1, 1))
+      .toBe('#11=IFCDIRECTION((0.,0.,1.));');
+    expect(rescaleEntityLengths("#12=IFCWALL('g',#1,'Room 3000',$,$,$,$,$);", 'IFCWALL', 0.001, 1, 1))
+      .toBe("#12=IFCWALL('g',#1,'Room 3000',$,$,$,$,$);");
+    // A revolve's Angle (index 3) is an IfcPlaneAngleMeasure — untouched.
+    expect(rescaleEntityLengths('#20=IFCREVOLVEDAREASOLID(#1,#2,#3,1.5708);', 'IFCREVOLVEDAREASOLID', 0.001, 1, 1))
+      .toBe('#20=IFCREVOLVEDAREASOLID(#1,#2,#3,1.5708);');
+  });
+
+  it('never corrupts a unit-definition entity', () => {
+    expect(rescaleEntityLengths('#15=IFCMEASUREWITHUNIT(IFCLENGTHMEASURE(0.3048),#5);', 'IFCMEASUREWITHUNIT', 0.001, 1, 1))
+      .toBe('#15=IFCMEASUREWITHUNIT(IFCLENGTHMEASURE(0.3048),#5);');
+  });
+
+  it('is a no-op when all factors are 1', () => {
+    const line = '#6=IFCCARTESIANPOINT((100.,200.,300.));';
+    expect(rescaleEntityLengths(line, 'IFCCARTESIANPOINT', 1, 1, 1)).toBe(line);
+  });
+});
+
+describe('computeNormalizeFactor', () => {
+  it('returns the ratio metres-per-unit', () => {
+    expect(computeNormalizeFactor(0.001, 1.0)).toBe(0.001); // mm into metres
+    expect(computeNormalizeFactor(1.0, 0.001)).toBe(1000); // metres into mm
+    expect(computeNormalizeFactor(0.3048, 1.0)).toBeCloseTo(0.3048, 10); // feet into metres
+  });
+
+  it('returns 1 for equal or invalid scales', () => {
+    expect(computeNormalizeFactor(1, 1)).toBe(1);
+    expect(computeNormalizeFactor(0, 1)).toBe(1);
+    expect(computeNormalizeFactor(1, NaN)).toBe(1);
+  });
+});

--- a/packages/export/src/unit-normalize.ts
+++ b/packages/export/src/unit-normalize.ts
@@ -1,0 +1,382 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Unit normalization for merged STEP export (issue #1475).
+ *
+ * When {@link MergedExporter} runs with `unitReconciliation: 'normalize'`, every
+ * non-primary model whose length unit differs from the primary model's has all
+ * of its length-valued data rescaled into the primary unit, so the models can be
+ * unified into ONE `IfcProject` with ONE `IfcUnitAssignment` (rather than
+ * federated as separate, mutually mis-scaled projects).
+ *
+ * This module is the pure, text-level rescaler. It knows WHICH numeric attributes
+ * of a STEP entity carry a length (and which carry an area/volume) by deriving the
+ * answer from the generated IFC schema registry (`@ifc-lite/parser`
+ * `getAllAttributesForEntity`) — the 0-based index into an entity's `allAttributes`
+ * is exactly its 0-based STEP attribute index, and each attribute is typed. This
+ * avoids a hand-maintained per-entity table and stays correct as the schema evolves.
+ *
+ * ## Factors
+ * The caller passes three *independent* factors (a length datum × `lengthFactor`,
+ * an area datum × `areaFactor`, a volume datum × `volumeFactor`). They are NOT
+ * `lengthFactor` powers: IFC declares `AREAUNIT`/`VOLUMEUNIT` independently of
+ * `LENGTHUNIT` (e.g. Revit exports millimetre lengths but square-/cubic-metre
+ * areas/volumes), so each dimension is converted by the ratio of its own declared
+ * unit. See {@link MergedExporter} for how the factors are derived.
+ *
+ * ## What is rescaled
+ * - **Coordinate lists** — every number in a `LIST OF IfcLengthMeasure` attribute
+ *   (`IfcCartesianPoint.Coordinates`, `IfcCartesianPointList2D/3D.CoordList`). × length.
+ * - **Scalar lengths** — any attribute typed `IfcLengthMeasure` /
+ *   `IfcPositiveLengthMeasure` / `IfcNonNegativeLengthMeasure` (extrusion depths,
+ *   profile dimensions, radii, wall thicknesses, `IfcVector.Magnitude`, CSG
+ *   primitive sizes, `IfcBuildingStorey.Elevation`, `IfcSite.RefElevation`,
+ *   `IfcQuantityLength.LengthValue`, …). × length.
+ * - **Areas / volumes** — `IfcQuantityArea.AreaValue` (× area),
+ *   `IfcQuantityVolume.VolumeValue` (× volume).
+ * - **Typed measures in property values** — `IFCLENGTHMEASURE(x)` /
+ *   `IFCPOSITIVELENGTHMEASURE(x)` / `IFCNONNEGATIVELENGTHMEASURE(x)` (× length),
+ *   `IFCAREAMEASURE(x)` (× area), `IFCVOLUMEMEASURE(x)` (× volume), wherever they
+ *   appear outside a quoted string.
+ *
+ * ## What is NOT rescaled
+ * - Unit-definition entities (`IfcSIUnit`, `IfcConversionBasedUnit`,
+ *   `IfcMeasureWithUnit`, `IfcUnitAssignment`, …): their numbers define units, not
+ *   data, and must survive verbatim.
+ * - Georeferencing (`IfcMapConversion`): its offsets are in the map/CRS unit,
+ *   independent of the project length unit.
+ * - A quantity or property that carries its own explicit unit reference (`Unit`,
+ *   or `DefiningUnit`/`DefinedUnit` on `IfcPropertyTableValue`): its value is
+ *   already in that unit, not the global one.
+ * - Angles, direction ratios, plain `IfcReal` ratios and counts — never typed as a
+ *   length/area/volume measure, so they are excluded automatically.
+ */
+
+import { getAllAttributesForEntity } from '@ifc-lite/parser';
+import { splitTopLevelStepArguments } from './step-serialization.js';
+
+/** IFC defined types whose values are lengths (STEP writes them as bare reals). */
+const LENGTH_MEASURE_TYPES = new Set([
+  'IfcLengthMeasure',
+  'IfcPositiveLengthMeasure',
+  'IfcNonNegativeLengthMeasure',
+]);
+
+/**
+ * Entity types whose numeric content must NEVER be rescaled: unit definitions
+ * (the numbers *are* the unit) and georeferencing (offsets live in the CRS unit).
+ * `IFCMAPCONVERSION` is matched by prefix to also catch schema variants.
+ */
+const RESCALE_EXCLUDED_TYPES = new Set([
+  'IFCUNITASSIGNMENT', 'IFCSIUNIT', 'IFCCONVERSIONBASEDUNIT', 'IFCCONTEXTDEPENDENTUNIT',
+  'IFCDERIVEDUNIT', 'IFCDERIVEDUNITELEMENT', 'IFCDIMENSIONALEXPONENTS', 'IFCMONETARYUNIT',
+  'IFCMEASUREWITHUNIT',
+]);
+
+function isRescaleExcluded(typeUpper: string): boolean {
+  return RESCALE_EXCLUDED_TYPES.has(typeUpper) || typeUpper.startsWith('IFCMAPCONVERSION');
+}
+
+/**
+ * Per-entity plan: which STEP attribute indices carry a length / area / volume,
+ * and where a self-describing unit override lives. Indices are 0-based STEP order.
+ */
+export interface EntityLengthPlan {
+  /** Attributes that are a LIST of lengths (coordinate arrays) → scale all numbers. */
+  listIdx: number[];
+  /** Scalar length attributes → scale by the length factor. */
+  scalarIdx: number[];
+  /** Scalar area attributes → scale by the area factor. */
+  areaIdx: number[];
+  /** Scalar volume attributes → scale by the volume factor. */
+  volumeIdx: number[];
+  /**
+   * Indices of unit-override attributes (`Unit` / `DefiningUnit` / `DefinedUnit`,
+   * typed IfcNamedUnit or the IfcUnit SELECT). When ANY of them is a live
+   * reference (not `$`), the entity's value(s) carry their own unit and must NOT
+   * be rescaled to the global unit.
+   */
+  unitGuardIdx: number[];
+  /** True when there is neither a value to scale nor a unit override to consider. */
+  empty: boolean;
+}
+
+const EMPTY_PLAN: EntityLengthPlan = {
+  listIdx: [], scalarIdx: [], areaIdx: [], volumeIdx: [], unitGuardIdx: [], empty: true,
+};
+
+/** Attribute names that hold a self-describing unit override for a value. */
+const UNIT_GUARD_NAMES = new Set(['Unit', 'DefiningUnit', 'DefinedUnit']);
+
+const planCache = new Map<string, EntityLengthPlan>();
+
+/**
+ * The base measure type of an attribute, and whether it is an aggregate. Handles
+ * both the compact `"IfcLengthMeasure[]"` encoding and the rare raw EXPRESS form
+ * (`"UNIQUE LIST [1:2] OF IfcLengthMeasure"`) the generated registry sometimes
+ * carries — the base is the last `Ifc…` token, and an aggregate is signalled by
+ * the flags, a `[]` suffix, or a `LIST`/`SET`/`ARRAY` keyword.
+ */
+function attrBaseType(type: string, flags: { isList: boolean; isArray: boolean; isSet: boolean }): { base: string; isList: boolean } {
+  const match = type.match(/Ifc[A-Za-z0-9]+/g);
+  const base = match ? match[match.length - 1] : type;
+  const isList = flags.isList || flags.isArray || flags.isSet
+    || /\[\]/.test(type) || /\b(?:LIST|SET|ARRAY|BAG)\b/i.test(type);
+  return { base, isList };
+}
+
+/**
+ * Derive (and cache) the length/area/volume attribute plan for an uppercase STEP
+ * type name from the generated schema registry. Excluded types (unit definitions,
+ * georeferencing) and unknown/abstract types return the empty plan.
+ */
+export function getEntityLengthPlan(typeUpper: string): EntityLengthPlan {
+  const cached = planCache.get(typeUpper);
+  if (cached !== undefined) return cached;
+  const plan = buildEntityLengthPlan(typeUpper);
+  planCache.set(typeUpper, plan);
+  return plan;
+}
+
+function buildEntityLengthPlan(typeUpper: string): EntityLengthPlan {
+  if (isRescaleExcluded(typeUpper)) return EMPTY_PLAN;
+
+  const attrs = getAllAttributesForEntity(typeUpper);
+  if (!attrs || attrs.length === 0) return EMPTY_PLAN;
+
+  const listIdx: number[] = [];
+  const scalarIdx: number[] = [];
+  const areaIdx: number[] = [];
+  const volumeIdx: number[] = [];
+  const unitGuardIdx: number[] = [];
+
+  attrs.forEach((a, i) => {
+    const { base, isList } = attrBaseType(a.type, a);
+    if (LENGTH_MEASURE_TYPES.has(base)) {
+      if (isList) listIdx.push(i);
+      else scalarIdx.push(i);
+    } else if (base === 'IfcAreaMeasure' && !isList) {
+      areaIdx.push(i);
+    } else if (base === 'IfcVolumeMeasure' && !isList) {
+      volumeIdx.push(i);
+    }
+    // A quantity's Unit is typed IfcNamedUnit; a property's Unit is the IfcUnit
+    // SELECT; an IfcPropertyTableValue uses DefiningUnit/DefinedUnit. Any of them,
+    // when set, means the value carries its own unit.
+    if (UNIT_GUARD_NAMES.has(a.name) && (base === 'IfcNamedUnit' || base === 'IfcUnit')) {
+      unitGuardIdx.push(i);
+    }
+  });
+
+  const empty = listIdx.length === 0 && scalarIdx.length === 0
+    && areaIdx.length === 0 && volumeIdx.length === 0 && unitGuardIdx.length === 0;
+  return empty ? EMPTY_PLAN : { listIdx, scalarIdx, areaIdx, volumeIdx, unitGuardIdx, empty };
+}
+
+/**
+ * Format a number as a valid ISO-10303-21 STEP REAL, after a unit multiply.
+ *
+ * Rounds to 12 significant digits first to erase floating-point noise from the
+ * multiply (e.g. `0.3048 * 100 = 30.479999999999997` → `30.48`) — 12 digits keeps
+ * sub-micron precision at building scale. Always emits a decimal point, and
+ * rewrites JavaScript's lowercase exponent (`1.5e-7`) into STEP's uppercase form
+ * with a mantissa dot (`1.5E-7`), so small/large magnitudes stay parseable.
+ */
+export function toStepRealScaled(v: number): string {
+  if (!Number.isFinite(v)) return '0.';
+  if (v === 0) return '0.'; // also normalizes -0
+  const s = parseFloat(v.toPrecision(12)).toString();
+  const e = s.indexOf('e');
+  if (e !== -1) {
+    let mantissa = s.slice(0, e);
+    const exp = s.slice(e + 1);
+    if (!mantissa.includes('.')) mantissa += '.';
+    return `${mantissa}E${exp}`;
+  }
+  return s.includes('.') ? s : s + '.';
+}
+
+/**
+ * Single token matcher used by {@link scaleNumberLiterals}: a full STEP string
+ * (kept verbatim, honouring the `''` escape), a `#`-reference (kept verbatim), or
+ * a REAL/INTEGER literal (rescaled). Ordering matters — strings and refs are
+ * matched first so their inner digits are never treated as numbers. The number
+ * alternative consumes an optional exponent as one token, so `1.E-5` / `-2.5E2`
+ * scale the mantissa without touching the exponent digits.
+ */
+const NUMBER_TOKEN_RE = /'(?:[^']|'')*'|#\d+|[+-]?(?:\d+\.\d*|\.\d+|\d+)(?:[eE][+-]?\d+)?/g;
+
+/**
+ * Multiply every bare numeric literal in `text` by `factor`, leaving quoted
+ * strings and `#`-references untouched. O(n) single pass — safe for the large
+ * coordinate lists of tessellated geometry.
+ */
+export function scaleNumberLiterals(text: string, factor: number): string {
+  return text.replace(NUMBER_TOKEN_RE, (tok) => {
+    const c = tok.charCodeAt(0);
+    if (c === 0x27 /* ' */ || c === 0x23 /* # */) return tok;
+    return toStepRealScaled(parseFloat(tok) * factor);
+  });
+}
+
+/**
+ * Scale the typed measures embedded in property/quantity values. Matches
+ * `IFC[POSITIVE|NONNEGATIVE]LENGTHMEASURE(x)` (× lengthFactor), `IFCAREAMEASURE(x)`
+ * (× areaFactor) and `IFCVOLUMEMEASURE(x)` (× volumeFactor), but never inside a
+ * quoted string (the string alternative is matched first and returned verbatim).
+ *
+ * A single non-word delimiter (`(`, `,`, whitespace, or start-of-input) is
+ * captured before the keyword and restored, so a keyword can never be matched as
+ * the suffix of a longer identifier — without a lookbehind, which some engines
+ * (older Safari) reject at construction time and would break importing this module.
+ */
+const TYPED_MEASURE_RE =
+  /('(?:[^']|'')*')|(^|[^A-Za-z0-9_])(IFC(?:POSITIVE|NONNEGATIVE)?LENGTHMEASURE|IFCAREAMEASURE|IFCVOLUMEMEASURE)\(([^)]*)\)/gi;
+
+export function scaleTypedMeasures(
+  text: string,
+  lengthFactor: number,
+  areaFactor: number,
+  volumeFactor: number,
+): string {
+  return text.replace(
+    TYPED_MEASURE_RE,
+    (full, str, delim, keyword, num) => {
+      if (str !== undefined) return full; // inside a quoted string
+      const kw = keyword.toUpperCase();
+      const factor = kw === 'IFCAREAMEASURE' ? areaFactor
+        : kw === 'IFCVOLUMEMEASURE' ? volumeFactor
+        : lengthFactor; // any *LENGTHMEASURE
+      return `${delim}${keyword}(${scaleMeasureNumber(num, factor)})`;
+    },
+  );
+}
+
+/** Scale the numeric content of one typed-measure token, preserving non-numeric ($) content. */
+function scaleMeasureNumber(num: string, factor: number): string {
+  const trimmed = num.trim();
+  const n = Number(trimmed);
+  if (trimmed === '' || !Number.isFinite(n)) return num;
+  return toStepRealScaled(n * factor);
+}
+
+/** Scale a single scalar attribute token by `factor` (skips `$`/`*`/non-bare-number). */
+function scaleScalarArg(arg: string, factor: number): string {
+  const trimmed = arg.trim();
+  if (trimmed === '' || trimmed === '$' || trimmed === '*') return arg;
+  const n = Number(trimmed);
+  // Only a bare real is a directly-typed length; a typed token (IFC…MEASURE(…))
+  // is left to the measure pass, so it is never scaled twice.
+  if (!Number.isFinite(n)) return arg;
+  return toStepRealScaled(n * factor);
+}
+
+/**
+ * Locate the outer STEP argument list of one entity line: the first `(` (nothing
+ * is quoted before the type name) and its matching `)`, honouring quoted strings
+ * (with the `''` escape) so a literal `)` inside a string never closes early.
+ * Returns `null` for a line without arguments.
+ */
+function findOuterArgs(line: string): { open: number; close: number } | null {
+  const open = line.indexOf('(');
+  if (open === -1) return null;
+  let depth = 0;
+  let inString = false;
+  for (let i = open; i < line.length; i++) {
+    const ch = line[i];
+    if (inString) {
+      if (ch === "'") {
+        if (line[i + 1] === "'") i++; // escaped quote
+        else inString = false;
+      }
+      continue;
+    }
+    if (ch === "'") { inString = true; continue; }
+    if (ch === '(') depth++;
+    else if (ch === ')') {
+      depth--;
+      if (depth === 0) return { open, close: i };
+    }
+  }
+  return null;
+}
+
+/**
+ * Rescale every length/area/volume-valued datum of one STEP entity line.
+ *
+ * `typeUpper` is the entity's uppercase STEP type (used for the schema-derived
+ * plan). The line is expected to be a single `#id=TYPE(...);` statement. Returns
+ * the input unchanged when all factors are `1`, the type is excluded (unit
+ * definition / georeferencing), or there is nothing to scale.
+ */
+export function rescaleEntityLengths(
+  line: string,
+  typeUpper: string,
+  lengthFactor: number,
+  areaFactor: number,
+  volumeFactor: number,
+): string {
+  if (lengthFactor === 1 && areaFactor === 1 && volumeFactor === 1) return line;
+  if (!Number.isFinite(lengthFactor) || !Number.isFinite(areaFactor) || !Number.isFinite(volumeFactor)) return line;
+  if (isRescaleExcluded(typeUpper)) return line;
+
+  const plan = getEntityLengthPlan(typeUpper);
+  const hasStructural = plan.listIdx.length > 0 || plan.scalarIdx.length > 0
+    || plan.areaIdx.length > 0 || plan.volumeIdx.length > 0;
+
+  // Fast path: nothing structural, no unit override to weigh, and no typed measure.
+  if (!hasStructural && plan.unitGuardIdx.length === 0 && !line.includes('MEASURE')) return line;
+
+  const bounds = findOuterArgs(line);
+  if (!bounds) return line;
+  let inner = line.slice(bounds.open + 1, bounds.close);
+
+  let skipValues = false;
+  if (hasStructural || plan.unitGuardIdx.length > 0) {
+    const args = splitTopLevelStepArguments(inner);
+
+    // A live unit-override reference means the value is already in its own unit.
+    skipValues = plan.unitGuardIdx.some((idx) => {
+      const u = args[idx]?.trim();
+      return u !== undefined && u !== '' && u !== '$' && u !== '*';
+    });
+
+    if (!skipValues && hasStructural) {
+      for (const idx of plan.listIdx) {
+        if (args[idx] !== undefined) args[idx] = scaleNumberLiterals(args[idx], lengthFactor);
+      }
+      for (const idx of plan.scalarIdx) {
+        if (args[idx] !== undefined) args[idx] = scaleScalarArg(args[idx], lengthFactor);
+      }
+      for (const idx of plan.areaIdx) {
+        if (args[idx] !== undefined) args[idx] = scaleScalarArg(args[idx], areaFactor);
+      }
+      for (const idx of plan.volumeIdx) {
+        if (args[idx] !== undefined) args[idx] = scaleScalarArg(args[idx], volumeFactor);
+      }
+      inner = args.join(',');
+    }
+  }
+
+  // Typed measures live in property/quantity value slots (an IfcValue SELECT is
+  // written with its explicit type). Skipped when the entity declares its own unit.
+  if (!skipValues && inner.includes('MEASURE')) {
+    inner = scaleTypedMeasures(inner, lengthFactor, areaFactor, volumeFactor);
+  }
+
+  return line.slice(0, bounds.open + 1) + inner + line.slice(bounds.close);
+}
+
+/**
+ * Factor that converts a value expressed in `modelScale` units into `primaryScale`
+ * units (both are SI-per-unit for the same dimension). Returns `1` when the units
+ * already match or either scale is non-positive/non-finite.
+ */
+export function computeNormalizeFactor(modelScale: number, primaryScale: number): number {
+  if (!Number.isFinite(modelScale) || !Number.isFinite(primaryScale)) return 1;
+  if (modelScale <= 0 || primaryScale <= 0) return 1;
+  if (modelScale === primaryScale) return 1;
+  return modelScale / primaryScale;
+}


### PR DESCRIPTION
Closes #1475.

## Problem

Merging models with different length units produced either a multi-project federation (`unitReconciliation: 'auto'`) that strict viewers (BIM Vision) reject and tolerant viewers render mis-scaled, or a mis-scaled single project (`'assume-shared'`). There was no way to get a **single, correctly-scaled, single-unit** IFC out of a mixed-unit merge.

## Change

Adds `unitReconciliation: 'normalize'` to `MergedExporter`. A model whose length unit differs from the first model's is **rescaled** into the primary unit and unified into the single primary `IfcProject` (one `IfcUnitAssignment`), so a mixed-unit merge produces an ordinary single-unit IFC that opens correctly everywhere.

### Which attributes are rescaled

Derived from the IFC schema registry (`getAllAttributesForEntity`), **not hand-rolled** — the 0-based `allAttributes` index is the STEP index, and each attribute is typed:

- **Coordinates** — every number in a `LIST OF IfcLengthMeasure` (`IfcCartesianPoint`, `IfcCartesianPointList2D/3D`).
- **Scalar lengths** — `IfcLengthMeasure` / `IfcPositiveLengthMeasure` / `IfcNonNegativeLengthMeasure` attributes: extrusion depths, all profile dimensions (angles auto-excluded), radii, wall thicknesses, `IfcVector.Magnitude`, CSG primitive sizes, `IfcBuildingStorey.Elevation`, `IfcSite.RefElevation`, `IfcQuantityLength`.
- **Length property values** — `IFCLENGTHMEASURE(x)` and friends in `IfcPropertySingleValue` etc.
- **Areas / volumes** — converted by their **own declared `AREAUNIT`/`VOLUMEUNIT` ratio** (not the length factor squared/cubed), so a millimetre-length / square-metre-area model (Revit's default) is **not** corrupted.

### What is left untouched

Angles, direction ratios, plain-real ratios, counts; unit-definition entities (`IfcSIUnit`, `IfcMeasureWithUnit`, …); georeferencing offsets (`IfcMapConversion`); and any quantity/property that carries its own explicit `Unit` (or `DefiningUnit`/`DefinedUnit`).

### Surfacing

- `MergeExportResult.stats.normalizedModelCount` reports how many models were rescaled.
- Advisories flag schemas the IFC4 length registry does not fully cover (IFC4X3 alignment / linear referencing) and georeferenced models.
- CLI: `ifc-lite merge ... --unit-reconciliation <auto|normalize|assume-shared>`.
- Viewer: a "Mixed units" selector in the merged export dialog.

## Testing

- `packages/export/src/unit-normalize.test.ts` — 33 unit tests for the pure rescaler (STEP number formatting incl. exponent/FP-noise edge cases, quote-safe typed-measure scan, schema-derived plans, unit guards).
- `packages/export/src/merged-exporter.test.ts` — 12 integration tests (single-unit unification, scalar/elevation/quantity rescaling, Revit m² preservation, imperial ft² conversion, reverse direction, `exportAsync`, IFC4X3/georef caveats, auto-vs-normalize contrast).
- Full package suite: 178 passed / 0 failed; type-clean.
- Verified end-to-end with the real parser: parse two mixed-unit files → normalize-merge → single `IfcProject`, coordinates + length quantities rescaled, m² area preserved, output re-parses cleanly.

## Review

Design and implementation were each put through an adversarial review pass. The blocker it caught (scaling area/volume by the length factor squared/cubed corrupts Revit's mm-length/m²-area default) is handled by reading each dimension's own declared unit; STEP-formatting, quote-safety, RegExp-lookbehind portability, and the `IfcPropertyTableValue`/empty-source edge cases are covered.

## Docs

`docs/guide/exporting.md`, `docs/guide/cli.md`, `docs/api/typescript.md` document the mode (and the two stale `MergedExporter` API snippets were corrected). Changeset included (minor: `@ifc-lite/export`, `@ifc-lite/cli`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a mixed-unit merge option that can rescale models into a single common unit during merged exports.
  * The viewer export dialog and CLI merge command now let you choose how mixed units are handled.

* **Bug Fixes**
  * Improved merged exports so lengths, areas, volumes, and related quantities stay consistent after normalization.
  * Added warnings for cases where normalization can’t fully apply, such as some schema or georeferenced models.

* **Documentation**
  * Updated export and CLI guides with the new mixed-unit merge workflow and option descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core rescaling logic is correct and well-tested across the important real-world cases (Revit mm/m² split, imperial ft², reverse direction, unit guards, schema conversion ordering).

The factor math, double-scaling prevention, and unit-guard logic all check out. The two findings are both narrow edge cases: a prefixed SI area/volume unit (e.g. IFCSIUNIT with AREAUNIT and MILLI prefix) would be mis-scaled by the prefix once rather than twice, and IFCCONVERSIONBASEDUNITWITHOFFSET (IFC4X3-only) is absent from the exclusion set but practically unreachable through the normal deduplication path.

The IFCSIUNIT prefix lines in resolveDerivedUnitScale (merged-exporter.ts ~811-813) and the RESCALE_EXCLUDED_TYPES set in unit-normalize.ts (lines 72-76) are the spots to revisit if IFC4X3 or prefixed SI area unit support is ever hardened.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/export/src/unit-normalize.ts | New pure rescaler module: schema-driven attribute plans, safe number tokenisation, typed-measure regex, and unit-factor computation. Core logic is sound; one minor edge case with prefixed SI area/volume units noted. |
| packages/export/src/merged-exporter.ts | Adds resolveModelMode, resolveDerivedUnitScale, withUsableSource, and collectNormalizeCaveats. Factor math and double-scaling prevention are correct; IFCCONVERSIONBASEDUNITWITHOFFSET (IFC4X3-only) is absent from RESCALE_EXCLUDED_TYPES but mitigated by deduplication/skip logic and the IFC4X3 advisory warning. |
| packages/export/src/merged-exporter.test.ts | 12 new integration tests covering single-unit unification, scalar/elevation/quantity rescaling, Revit m² preservation, imperial ft² conversion, reverse direction, exportAsync, IFC4X3/georef caveats, and auto-vs-normalize contrast. |
| packages/export/src/unit-normalize.test.ts | 33 unit tests for toStepRealScaled, scaleNumberLiterals, scaleTypedMeasures, getEntityLengthPlan, rescaleEntityLengths, and computeNormalizeFactor. Thorough coverage of edge cases. |
| packages/cli/src/commands/merge.ts | Adds --unit-reconciliation flag with validation, correctly skips the flag value token in the positional-arg loop, and surfaces normalizedModelCount in JSON/human output. |
| apps/viewer/src/components/viewer/ExportDialog.tsx | Adds unitReconciliation state, passes it to exportAsync, surfaces normalizedModelCount in the success message, and adds a conditional Mixed Units selector for merged exports. |

<sub>Reviews (1): Last reviewed commit: ["feat(export): normalize units in merged ..."](https://github.com/ltplus-ag/ifc-lite/commit/ac32563b425f28f671a66995d1f26de3133d0c73) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41068080)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->