### PR TITLE
feat(export): configurable spatial merge matching in MergedExporter

### DIFF
--- a/.changeset/merge-spatial-matching-options.md
+++ b/.changeset/merge-spatial-matching-options.md
@@ -23,5 +23,12 @@ All three options are optional and, when omitted, preserve today's exact
 default behavior (name match, else single-instance fallback for site/building;
 name-then-elevation for storeys) — purely additive, no default behavior change.
 
+One edge-case hardening applies in every mode, including the default: when two
+sites (or buildings) in the same secondary model would match the same
+first-model target (e.g. identical names), only the first claims it and the
+second is kept as its own root instead of being silently collapsed onto the
+same target. This brings site/building matching to parity with the
+pre-existing storey behavior.
+
 The CLI `merge` command gains matching `--merge-sites` / `--merge-buildings` /
 `--merge-storeys` flags.

--- a/.changeset/merge-spatial-matching-options.md
+++ b/.changeset/merge-spatial-matching-options.md
@@ -1,0 +1,27 @@
+---
+"@ifc-lite/export": minor
+"@ifc-lite/cli": minor
+---
+
+feat(export): configurable spatial merge matching in `MergedExporter`
+
+`MergedExporter` unifies `IfcSite`/`IfcBuilding`/`IfcBuildingStorey` across
+merged models with a single fixed heuristic today. It now accepts explicit
+matching strategies, mirroring IfcOpenShell/BlenderBIM's "Merge Projects"
+recipe:
+
+- `mergeSites?: 'single' | 'by-name'` — `'single'` ignores Name and unifies
+  iff each model contributes exactly one `IfcSite`; `'by-name'` matches only
+  same-name (case-insensitive) sites, with no single-instance fallback.
+- `mergeBuildings?: 'single' | 'by-name'` — same strategy, for `IfcBuilding`.
+- `mergeStoreys?: 'by-name' | 'by-elevation' | 'by-name-then-elevation'` —
+  `'by-name'`/`'by-elevation'` match on exactly one criterion with no
+  fallback; `'by-name-then-elevation'` is the pre-existing combined heuristic
+  made explicit.
+
+All three options are optional and, when omitted, preserve today's exact
+default behavior (name match, else single-instance fallback for site/building;
+name-then-elevation for storeys) — purely additive, no default behavior change.
+
+The CLI `merge` command gains matching `--merge-sites` / `--merge-buildings` /
+`--merge-storeys` flags.

--- a/docs/api/typescript.md
+++ b/docs/api/typescript.md
@@ -624,6 +624,14 @@ interface MergeExportOptions {
   //   'normalize'      — rescale it into the first model's unit (one single-unit project)
   //   'assume-shared'  — force one project without rescaling
   unitReconciliation?: 'auto' | 'normalize' | 'assume-shared';
+  // Spatial matching strategy per container type (omitted = today's combined
+  // heuristic: name match, else single-instance fallback for sites/buildings;
+  // name-then-elevation for storeys):
+  //   'single':  unify iff each model contributes exactly one (Name ignored)
+  //   'by-name': Name match only (case-insensitive), no single-instance fallback
+  mergeSites?: 'single' | 'by-name';
+  mergeBuildings?: 'single' | 'by-name';
+  mergeStoreys?: 'by-name' | 'by-elevation' | 'by-name-then-elevation';
   visibleOnly?: boolean;
 }
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -473,7 +473,7 @@ ifc-lite merge a.ifc b.ifc --out merged.ifc --json
 ifc-lite merge metric.ifc imperial.ifc --unit-reconciliation normalize --out merged.ifc
 ```
 
-The merger unifies spatial hierarchy (storeys, buildings) by name and elevation, and offsets entity IDs to avoid collisions. Models that share the first file's length unit merge into a single IfcProject; a model with a different unit is federated (kept as its own project) unless `--unit-reconciliation normalize` rescales it into the first file's unit.
+The merger unifies spatial hierarchy (sites, buildings, storeys) by name and elevation, and offsets entity IDs to avoid collisions. Models that share the first file's length unit merge into a single IfcProject; a model with a different unit is federated (kept as its own project) unless `--unit-reconciliation normalize` rescales it into the first file's unit. The per-container matching strategy can be pinned down with `--merge-sites` / `--merge-buildings` / `--merge-storeys` (see [Spatial matching strategy](exporting.md#spatial-matching-strategy)).
 
 **Flags:**
 
@@ -481,6 +481,9 @@ The merger unifies spatial hierarchy (storeys, buildings) by name and elevation,
 |------|-------------|
 | `--schema <ver>` | Target schema (`IFC2X3`, `IFC4`, `IFC4X3`) |
 | `--unit-reconciliation <mode>` | Mixed-unit handling: `auto` (default, federate differing units), `normalize` (rescale into the first file's unit → one single-unit project), `assume-shared` (force one project without rescaling) |
+| `--merge-sites <mode>` | IfcSite matching across models: `single` (unify iff each model has exactly one site, Name ignored) or `by-name` (Name match only, no single-instance fallback). Omitted: Name match, else single-instance fallback |
+| `--merge-buildings <mode>` | Same modes as `--merge-sites`, applied to IfcBuilding |
+| `--merge-storeys <mode>` | IfcBuildingStorey matching: `by-name`, `by-elevation`, or `by-name-then-elevation` (default) |
 | `--out <file>` | Output file (required) |
 | `--json` | Output merge stats as JSON |
 

--- a/docs/guide/exporting.md
+++ b/docs/guide/exporting.md
@@ -417,6 +417,28 @@ result:
 | `'normalize'` | Rescales every length-valued datum of a differing-unit model into the first model's unit, then unifies it — the output is **one single-unit `IfcProject`** that opens correctly everywhere. `stats.normalizedModelCount` reports how many models were rescaled. |
 | `'assume-shared'` | Forces one project without rescaling. Use only when units are already normalised; mixing real units this way mis-scales geometry. |
 
+#### Spatial matching strategy
+
+By default, `IfcSite`/`IfcBuilding` are matched by Name (case-insensitive),
+falling back to unifying a lone instance in each model when no name matches;
+`IfcBuildingStorey` is matched by Name, falling back to Elevation (±0.5 model
+units). To pin down the exact strategy — mirroring IfcOpenShell/BlenderBIM's
+"Merge Projects" recipe — pass:
+
+```typescript
+const result = exporter.export({
+  schema: 'IFC4',
+  mergeSites: 'single',              // 'single' | 'by-name'
+  mergeBuildings: 'by-name',         // 'single' | 'by-name'
+  mergeStoreys: 'by-name-then-elevation', // 'by-name' | 'by-elevation' | 'by-name-then-elevation'
+});
+```
+
+`'single'` ignores Name and unifies iff each model contributes exactly one
+instance of that container type. `'by-name'` requires a Name match with no
+single-instance fallback. All three fields are optional; omitting one keeps
+the pre-existing combined heuristic for that container type.
+
 `'normalize'` rescales all `IfcCartesianPoint`/`IfcCartesianPointList` coordinates,
 scalar lengths (extrusion depths, profile dimensions, radii, thicknesses, storey
 elevations, `IfcVector.Magnitude`, CSG primitive sizes), `IfcLengthMeasure`

--- a/packages/cli/src/commands/merge.ts
+++ b/packages/cli/src/commands/merge.ts
@@ -6,7 +6,9 @@
  * ifc-lite merge <file1.ifc> <file2.ifc> [...] --out <merged.ifc>
  *
  * Merge multiple IFC files into a single file.
- * Spatial hierarchy (storeys, buildings) is unified by name/elevation.
+ * Spatial hierarchy (sites, buildings, storeys) is unified by name/elevation
+ * by default; --merge-sites/--merge-buildings/--merge-storeys override the
+ * matching strategy per container type.
  */
 
 import { writeFile } from 'node:fs/promises';
@@ -16,6 +18,12 @@ import { getFlag, hasFlag, fatal, printJson } from '../output.js';
 
 const UNIT_RECONCILIATION_MODES = ['auto', 'normalize', 'assume-shared'] as const;
 type UnitReconciliation = typeof UNIT_RECONCILIATION_MODES[number];
+
+const ROOT_CONTAINER_MODES = ['single', 'by-name'] as const;
+type RootContainerMode = typeof ROOT_CONTAINER_MODES[number];
+
+const STOREY_MODES = ['by-name', 'by-elevation', 'by-name-then-elevation'] as const;
+type StoreyMode = typeof STOREY_MODES[number];
 
 export async function mergeCommand(args: string[]): Promise<void> {
   const outPath = getFlag(args, '--out');
@@ -33,11 +41,30 @@ export async function mergeCommand(args: string[]): Promise<void> {
     fatal(`--unit-reconciliation must be one of: ${UNIT_RECONCILIATION_MODES.join(', ')}`);
   }
 
+  // How IfcSite/IfcBuilding/IfcBuildingStorey are matched across models
+  // (mirrors IfcOpenShell/BlenderBIM's "Merge Projects" recipe). Omitted keeps
+  // MergedExporter's pre-existing combined heuristic.
+  const mergeSitesFlag = getFlag(args, '--merge-sites') as RootContainerMode | undefined;
+  if (mergeSitesFlag !== undefined && !ROOT_CONTAINER_MODES.includes(mergeSitesFlag)) {
+    fatal(`--merge-sites must be one of: ${ROOT_CONTAINER_MODES.join(', ')}`);
+  }
+  const mergeBuildingsFlag = getFlag(args, '--merge-buildings') as RootContainerMode | undefined;
+  if (mergeBuildingsFlag !== undefined && !ROOT_CONTAINER_MODES.includes(mergeBuildingsFlag)) {
+    fatal(`--merge-buildings must be one of: ${ROOT_CONTAINER_MODES.join(', ')}`);
+  }
+  const mergeStoreysFlag = getFlag(args, '--merge-storeys') as StoreyMode | undefined;
+  if (mergeStoreysFlag !== undefined && !STOREY_MODES.includes(mergeStoreysFlag)) {
+    fatal(`--merge-storeys must be one of: ${STOREY_MODES.join(', ')}`);
+  }
+
   // Collect all positional args as input files
   const files: string[] = [];
   for (let i = 0; i < args.length; i++) {
     if (args[i].startsWith('-')) {
-      if (args[i] === '--out' || args[i] === '--schema' || args[i] === '--unit-reconciliation') i++; // skip value
+      if (
+        args[i] === '--out' || args[i] === '--schema' || args[i] === '--unit-reconciliation' ||
+        args[i] === '--merge-sites' || args[i] === '--merge-buildings' || args[i] === '--merge-storeys'
+      ) i++; // skip value
       continue;
     }
     files.push(args[i]);
@@ -64,6 +91,9 @@ export async function mergeCommand(args: string[]): Promise<void> {
   const result = exporter.export({
     schema: (schema ?? 'IFC4') as 'IFC2X3' | 'IFC4' | 'IFC4X3' | 'IFC5',
     unitReconciliation,
+    mergeSites: mergeSitesFlag,
+    mergeBuildings: mergeBuildingsFlag,
+    mergeStoreys: mergeStoreysFlag,
   });
 
   await writeFile(outPath, result.content, 'utf-8');

--- a/packages/cli/src/commands/merge.ts
+++ b/packages/cli/src/commands/merge.ts
@@ -43,14 +43,27 @@ export async function mergeCommand(args: string[]): Promise<void> {
 
   // How IfcSite/IfcBuilding/IfcBuildingStorey are matched across models
   // (mirrors IfcOpenShell/BlenderBIM's "Merge Projects" recipe). Omitted keeps
-  // MergedExporter's pre-existing combined heuristic.
+  // MergedExporter's pre-existing combined heuristic. getFlag() returns
+  // undefined both when a flag is absent AND when it's the last arg with no
+  // value, so check presence separately — otherwise `merge a.ifc b.ifc --out
+  // x.ifc --merge-sites` (trailing, valueless) would silently fall back to
+  // the default instead of erroring.
+  if (hasFlag(args, '--merge-sites') && getFlag(args, '--merge-sites') === undefined) {
+    fatal(`--merge-sites requires a value: one of ${ROOT_CONTAINER_MODES.join(', ')}`);
+  }
   const mergeSitesFlag = getFlag(args, '--merge-sites') as RootContainerMode | undefined;
   if (mergeSitesFlag !== undefined && !ROOT_CONTAINER_MODES.includes(mergeSitesFlag)) {
     fatal(`--merge-sites must be one of: ${ROOT_CONTAINER_MODES.join(', ')}`);
   }
+  if (hasFlag(args, '--merge-buildings') && getFlag(args, '--merge-buildings') === undefined) {
+    fatal(`--merge-buildings requires a value: one of ${ROOT_CONTAINER_MODES.join(', ')}`);
+  }
   const mergeBuildingsFlag = getFlag(args, '--merge-buildings') as RootContainerMode | undefined;
   if (mergeBuildingsFlag !== undefined && !ROOT_CONTAINER_MODES.includes(mergeBuildingsFlag)) {
     fatal(`--merge-buildings must be one of: ${ROOT_CONTAINER_MODES.join(', ')}`);
+  }
+  if (hasFlag(args, '--merge-storeys') && getFlag(args, '--merge-storeys') === undefined) {
+    fatal(`--merge-storeys requires a value: one of ${STOREY_MODES.join(', ')}`);
   }
   const mergeStoreysFlag = getFlag(args, '--merge-storeys') as StoreyMode | undefined;
   if (mergeStoreysFlag !== undefined && !STOREY_MODES.includes(mergeStoreysFlag)) {

--- a/packages/export/src/merged-exporter.test.ts
+++ b/packages/export/src/merged-exporter.test.ts
@@ -344,6 +344,25 @@ describe('MergedExporter', () => {
       expect(content.match(/=IFCBUILDING\(/g)?.length).toBe(1);
     });
 
+    it('mergeBuildings "by-name" keeps differing-name lone buildings separate (no single fallback)', () => {
+      const model1 = buildModel('m1', 'Arch', [
+        [1, 'IFCPROJECT', "#1=IFCPROJECT('g1',$,'P',$,$,$,$,$,$);"],
+        [2, 'IFCBUILDING', "#2=IFCBUILDING('g2',$,'Building A',$,$,$,$,$,$,$);"],
+      ]);
+      const model2 = buildModel('m2', 'Struct', [
+        [1, 'IFCPROJECT', "#1=IFCPROJECT('g3',$,'P2',$,$,$,$,$,$);"],
+        [2, 'IFCBUILDING', "#2=IFCBUILDING('g4',$,'Building B',$,$,$,$,$,$,$);"],
+      ]);
+
+      const exporter = new MergedExporter([model1, model2]);
+      const result = exporter.export({ schema: 'IFC4', projectStrategy: 'keep-first', mergeBuildings: 'by-name' });
+      const content = decode(result.content);
+
+      expect(content).toContain("IFCBUILDING('g2'");
+      expect(content).toContain("IFCBUILDING('g4'");
+      expect(content.match(/=IFCBUILDING\(/g)?.length).toBe(2);
+    });
+
     it('mergeStoreys "by-name" does not fall back to elevation', () => {
       const model1 = buildModel('m1', 'Arch', [
         [1, 'IFCPROJECT', "#1=IFCPROJECT('g1',$,'P',$,$,$,$,$,$);"],
@@ -382,9 +401,34 @@ describe('MergedExporter', () => {
       expect(content).toContain("IFCBUILDINGSTOREY('g4'");
     });
 
-    it('omitted mergeSites/mergeStoreys keeps the pre-existing combined heuristic', () => {
-      // Same fixture as the "single" test above, but with no mode override —
-      // must still unify via the name-else-single-fallback heuristic.
+    it('mergeStoreys "by-name-then-elevation" explicitly matches by name, then by elevation', () => {
+      // Same fixtures as the two strict-mode tests above, but combined under
+      // the explicit combined mode: 'Level 1'-style name match unifies the
+      // first pair, and the elevation fallback unifies a differently-named pair.
+      const model1 = buildModel('m1', 'Arch', [
+        [1, 'IFCPROJECT', "#1=IFCPROJECT('g1',$,'P',$,$,$,$,$,$);"],
+        [2, 'IFCBUILDINGSTOREY', "#2=IFCBUILDINGSTOREY('g2',$,'Ground Floor',$,$,$,$,$,.ELEMENT.,0.);"],
+        [3, 'IFCBUILDINGSTOREY', "#3=IFCBUILDINGSTOREY('g3',$,'EG',$,$,$,$,$,.ELEMENT.,3000.);"],
+      ]);
+      const model2 = buildModel('m2', 'Struct', [
+        [1, 'IFCPROJECT', "#1=IFCPROJECT('g4',$,'P2',$,$,$,$,$,$);"],
+        [2, 'IFCBUILDINGSTOREY', "#2=IFCBUILDINGSTOREY('g5',$,'Ground Floor',$,$,$,$,$,.ELEMENT.,0.);"], // name match
+        [3, 'IFCBUILDINGSTOREY', "#3=IFCBUILDINGSTOREY('g6',$,'Ground',$,$,$,$,$,.ELEMENT.,3000.);"], // elevation-fallback match
+      ]);
+
+      const exporter = new MergedExporter([model1, model2]);
+      const result = exporter.export({ schema: 'IFC4', projectStrategy: 'keep-first', mergeStoreys: 'by-name-then-elevation' });
+      const content = decode(result.content);
+
+      expect(content).not.toContain("IFCBUILDINGSTOREY('g5'");
+      expect(content).not.toContain("IFCBUILDINGSTOREY('g6'");
+      expect(content.match(/=IFCBUILDINGSTOREY\(/g)?.length).toBe(2);
+    });
+
+    it('omitted mergeSites keeps the pre-existing combined heuristic', () => {
+      // Storey/building default-heuristic coverage lives in the top-level
+      // 'should unify storeys with matching names' / 'by elevation' tests
+      // above, which already call export() with no mergeStoreys override.
       const model1 = buildModel('m1', 'Arch', [
         [1, 'IFCPROJECT', "#1=IFCPROJECT('g1',$,'P',$,$,$,$,$,$);"],
         [2, 'IFCSITE', "#2=IFCSITE('g2',$,'Site A',$,$,$,$,$,$,$);"],
@@ -400,6 +444,31 @@ describe('MergedExporter', () => {
 
       expect(content).not.toContain("IFCSITE('g4'");
       expect(content.match(/=IFCSITE\(/g)?.length).toBe(1);
+    });
+
+    it('does not drop a secondary model\'s second site when both name-match the same first-model target', () => {
+      // Regression guard: without matchedFirstSites, both of model2's
+      // identically-named sites would resolve to model1's single site,
+      // silently dropping the second site's spatial sub-tree.
+      const model1 = buildModel('m1', 'Arch', [
+        [1, 'IFCPROJECT', "#1=IFCPROJECT('g1',$,'P',$,$,$,$,$,$);"],
+        [2, 'IFCSITE', "#2=IFCSITE('g2',$,'Site',$,$,$,$,$,$,$);"],
+      ]);
+      const model2 = buildModel('m2', 'Struct', [
+        [1, 'IFCPROJECT', "#1=IFCPROJECT('g3',$,'P2',$,$,$,$,$,$);"],
+        [2, 'IFCSITE', "#2=IFCSITE('g4',$,'Site',$,$,$,$,$,$,$);"],
+        [3, 'IFCSITE', "#3=IFCSITE('g5',$,'Site',$,$,$,$,$,$,$);"],
+      ]);
+
+      const exporter = new MergedExporter([model1, model2]);
+      const result = exporter.export({ schema: 'IFC4', projectStrategy: 'keep-first', mergeSites: 'by-name' });
+      const content = decode(result.content);
+
+      // First 'Site' claims model1's target and is dropped; the second is
+      // kept as its own root instead of also being silently swallowed.
+      expect(content).not.toContain("IFCSITE('g4'");
+      expect(content).toContain("IFCSITE('g5'");
+      expect(content.match(/=IFCSITE\(/g)?.length).toBe(2);
     });
   });
 

--- a/packages/export/src/merged-exporter.test.ts
+++ b/packages/export/src/merged-exporter.test.ts
@@ -287,6 +287,122 @@ describe('MergedExporter', () => {
     expect(() => new MergedExporter([])).toThrow('at least one model');
   });
 
+  describe('configurable spatial merge matching (mergeSites/mergeBuildings/mergeStoreys)', () => {
+    it('mergeSites "single" unifies by count alone, ignoring differing names', () => {
+      const model1 = buildModel('m1', 'Arch', [
+        [1, 'IFCPROJECT', "#1=IFCPROJECT('g1',$,'P',$,$,$,$,$,$);"],
+        [2, 'IFCSITE', "#2=IFCSITE('g2',$,'Site A',$,$,$,$,$,$,$);"],
+      ]);
+      const model2 = buildModel('m2', 'Struct', [
+        [1, 'IFCPROJECT', "#1=IFCPROJECT('g3',$,'P2',$,$,$,$,$,$);"],
+        [2, 'IFCSITE', "#2=IFCSITE('g4',$,'Site B',$,$,$,$,$,$,$);"],
+      ]);
+
+      const exporter = new MergedExporter([model1, model2]);
+      const result = exporter.export({ schema: 'IFC4', projectStrategy: 'keep-first', mergeSites: 'single' });
+      const content = decode(result.content);
+
+      expect(content).not.toContain("IFCSITE('g4'");
+      expect(content.match(/=IFCSITE\(/g)?.length).toBe(1);
+    });
+
+    it('mergeSites "by-name" keeps differing-name lone sites separate (no single fallback)', () => {
+      const model1 = buildModel('m1', 'Arch', [
+        [1, 'IFCPROJECT', "#1=IFCPROJECT('g1',$,'P',$,$,$,$,$,$);"],
+        [2, 'IFCSITE', "#2=IFCSITE('g2',$,'Site A',$,$,$,$,$,$,$);"],
+      ]);
+      const model2 = buildModel('m2', 'Struct', [
+        [1, 'IFCPROJECT', "#1=IFCPROJECT('g3',$,'P2',$,$,$,$,$,$);"],
+        [2, 'IFCSITE', "#2=IFCSITE('g4',$,'Site B',$,$,$,$,$,$,$);"],
+      ]);
+
+      const exporter = new MergedExporter([model1, model2]);
+      const result = exporter.export({ schema: 'IFC4', projectStrategy: 'keep-first', mergeSites: 'by-name' });
+      const content = decode(result.content);
+
+      // Differing names, no single-instance fallback → both kept
+      expect(content).toContain("IFCSITE('g2'");
+      expect(content).toContain("IFCSITE('g4'");
+      expect(content.match(/=IFCSITE\(/g)?.length).toBe(2);
+    });
+
+    it('mergeBuildings "single" unifies by count alone, ignoring differing names', () => {
+      const model1 = buildModel('m1', 'Arch', [
+        [1, 'IFCPROJECT', "#1=IFCPROJECT('g1',$,'P',$,$,$,$,$,$);"],
+        [2, 'IFCBUILDING', "#2=IFCBUILDING('g2',$,'Building A',$,$,$,$,$,$,$);"],
+      ]);
+      const model2 = buildModel('m2', 'Struct', [
+        [1, 'IFCPROJECT', "#1=IFCPROJECT('g3',$,'P2',$,$,$,$,$,$);"],
+        [2, 'IFCBUILDING', "#2=IFCBUILDING('g4',$,'Building B',$,$,$,$,$,$,$);"],
+      ]);
+
+      const exporter = new MergedExporter([model1, model2]);
+      const result = exporter.export({ schema: 'IFC4', projectStrategy: 'keep-first', mergeBuildings: 'single' });
+      const content = decode(result.content);
+
+      expect(content).not.toContain("IFCBUILDING('g4'");
+      expect(content.match(/=IFCBUILDING\(/g)?.length).toBe(1);
+    });
+
+    it('mergeStoreys "by-name" does not fall back to elevation', () => {
+      const model1 = buildModel('m1', 'Arch', [
+        [1, 'IFCPROJECT', "#1=IFCPROJECT('g1',$,'P',$,$,$,$,$,$);"],
+        [2, 'IFCBUILDINGSTOREY', "#2=IFCBUILDINGSTOREY('g2',$,'EG',$,$,$,$,$,.ELEMENT.,0.);"],
+      ]);
+      const model2 = buildModel('m2', 'Struct', [
+        [1, 'IFCPROJECT', "#1=IFCPROJECT('g3',$,'P2',$,$,$,$,$,$);"],
+        // Same elevation, different name — would unify under the elevation fallback.
+        [2, 'IFCBUILDINGSTOREY', "#2=IFCBUILDINGSTOREY('g4',$,'Ground',$,$,$,$,$,.ELEMENT.,0.);"],
+      ]);
+
+      const exporter = new MergedExporter([model1, model2]);
+      const result = exporter.export({ schema: 'IFC4', projectStrategy: 'keep-first', mergeStoreys: 'by-name' });
+      const content = decode(result.content);
+
+      // Strict by-name: no elevation fallback → kept separate
+      expect(content).toContain("IFCBUILDINGSTOREY('g4'");
+    });
+
+    it('mergeStoreys "by-elevation" ignores matching names when elevation differs', () => {
+      const model1 = buildModel('m1', 'Arch', [
+        [1, 'IFCPROJECT', "#1=IFCPROJECT('g1',$,'P',$,$,$,$,$,$);"],
+        [2, 'IFCBUILDINGSTOREY', "#2=IFCBUILDINGSTOREY('g2',$,'Ground Floor',$,$,$,$,$,.ELEMENT.,0.);"],
+      ]);
+      const model2 = buildModel('m2', 'Struct', [
+        [1, 'IFCPROJECT', "#1=IFCPROJECT('g3',$,'P2',$,$,$,$,$,$);"],
+        // Same name, very different elevation — would unify under the name match.
+        [2, 'IFCBUILDINGSTOREY', "#2=IFCBUILDINGSTOREY('g4',$,'Ground Floor',$,$,$,$,$,.ELEMENT.,9000.);"],
+      ]);
+
+      const exporter = new MergedExporter([model1, model2]);
+      const result = exporter.export({ schema: 'IFC4', projectStrategy: 'keep-first', mergeStoreys: 'by-elevation' });
+      const content = decode(result.content);
+
+      // Strict by-elevation: name is ignored, elevation is out of tolerance → kept separate
+      expect(content).toContain("IFCBUILDINGSTOREY('g4'");
+    });
+
+    it('omitted mergeSites/mergeStoreys keeps the pre-existing combined heuristic', () => {
+      // Same fixture as the "single" test above, but with no mode override —
+      // must still unify via the name-else-single-fallback heuristic.
+      const model1 = buildModel('m1', 'Arch', [
+        [1, 'IFCPROJECT', "#1=IFCPROJECT('g1',$,'P',$,$,$,$,$,$);"],
+        [2, 'IFCSITE', "#2=IFCSITE('g2',$,'Site A',$,$,$,$,$,$,$);"],
+      ]);
+      const model2 = buildModel('m2', 'Struct', [
+        [1, 'IFCPROJECT', "#1=IFCPROJECT('g3',$,'P2',$,$,$,$,$,$);"],
+        [2, 'IFCSITE', "#2=IFCSITE('g4',$,'Site B',$,$,$,$,$,$,$);"],
+      ]);
+
+      const exporter = new MergedExporter([model1, model2]);
+      const result = exporter.export({ schema: 'IFC4', projectStrategy: 'keep-first' });
+      const content = decode(result.content);
+
+      expect(content).not.toContain("IFCSITE('g4'");
+      expect(content.match(/=IFCSITE\(/g)?.length).toBe(1);
+    });
+  });
+
   // Regression: github.com/LTplus-AG/ifc-lite/issues/1110
   // When the parser defers property atoms out of byId (deferPropertyAtomIndex
   // on huge files), the merge must still emit them — otherwise the kept

--- a/packages/export/src/merged-exporter.ts
+++ b/packages/export/src/merged-exporter.ts
@@ -1313,27 +1313,34 @@ export class MergedExporter {
     skipEntityIds: Set<number>,
     mergeModes: Pick<MergeSetup, 'mergeSites' | 'mergeBuildings' | 'mergeStoreys'>,
   ): void {
-    // Unify IfcSite
+    // Unify IfcSite. matchedFirstSites guards against two of this model's
+    // sites (e.g. duplicate/identically-named) both matching the same
+    // first-model target — only the first claims it, the second is kept as
+    // its own root instead of silently losing its spatial sub-tree.
     const sites = this.findEntitiesByType(dataStore, 'IFCSITE');
+    const matchedFirstSites = new Set<number>();
     for (const id of sites) {
       const match = this.matchRootContainer(
         id, dataStore, mergeModes.mergeSites, sites.length,
-        lookup.sitesByName, lookup.siteIds,
+        lookup.sitesByName, lookup.siteIds, matchedFirstSites,
       );
       if (match !== undefined) {
+        matchedFirstSites.add(match);
         sharedRemap.set(id, match + firstModelOffset);
         skipEntityIds.add(id);
       }
     }
 
-    // Unify IfcBuilding
+    // Unify IfcBuilding — same already-matched guard as sites.
     const buildings = this.findEntitiesByType(dataStore, 'IFCBUILDING');
+    const matchedFirstBuildings = new Set<number>();
     for (const id of buildings) {
       const match = this.matchRootContainer(
         id, dataStore, mergeModes.mergeBuildings, buildings.length,
-        lookup.buildingsByName, lookup.buildingIds,
+        lookup.buildingsByName, lookup.buildingIds, matchedFirstBuildings,
       );
       if (match !== undefined) {
+        matchedFirstBuildings.add(match);
         sharedRemap.set(id, match + firstModelOffset);
         skipEntityIds.add(id);
       }
@@ -1387,6 +1394,12 @@ export class MergedExporter {
    * - `'single'`: ignore name — unify iff both models contribute exactly one.
    * - `'by-name'`: name match only, no single-instance fallback.
    * - omitted: name match, else single-instance fallback (pre-existing heuristic).
+   *
+   * `matchedFirst` excludes first-model targets already claimed by an earlier
+   * entity in this same model's loop — without it, two of this model's sites
+   * (or buildings) sharing a name/being the sole instance would both resolve
+   * to the same target, and the second would be dropped (skipped + remapped)
+   * rather than kept as its own root.
    */
   private matchRootContainer(
     id: number,
@@ -1395,12 +1408,18 @@ export class MergedExporter {
     countInThisModel: number,
     firstModelByName: Map<string, number>,
     firstModelIds: number[],
+    matchedFirst: Set<number>,
   ): number | undefined {
-    const bySingle = () =>
-      countInThisModel === 1 && firstModelIds.length === 1 ? firstModelIds[0] : undefined;
+    const bySingle = () => {
+      if (countInThisModel !== 1 || firstModelIds.length !== 1) return undefined;
+      const candidate = firstModelIds[0];
+      return matchedFirst.has(candidate) ? undefined : candidate;
+    };
     const byName = () => {
       const name = this.extractEntityName(id, dataStore);
-      return name ? firstModelByName.get(name.toLowerCase()) : undefined;
+      if (!name) return undefined;
+      const candidate = firstModelByName.get(name.toLowerCase());
+      return candidate !== undefined && !matchedFirst.has(candidate) ? candidate : undefined;
     };
 
     if (mergeMode === 'single') return bySingle();

--- a/packages/export/src/merged-exporter.ts
+++ b/packages/export/src/merged-exporter.ts
@@ -134,6 +134,12 @@ interface MergeSetup {
    * unified into the primary project (rather than federated).
    */
   normalize: boolean;
+  /** Spatial matching strategy for IfcSite — see {@link MergeExportOptions.mergeSites}. */
+  mergeSites?: 'single' | 'by-name';
+  /** Spatial matching strategy for IfcBuilding — see {@link MergeExportOptions.mergeBuildings}. */
+  mergeBuildings?: 'single' | 'by-name';
+  /** Spatial matching strategy for IfcBuildingStorey — see {@link MergeExportOptions.mergeStoreys}. */
+  mergeStoreys?: 'by-name' | 'by-elevation' | 'by-name-then-elevation';
 }
 
 /**
@@ -313,6 +319,35 @@ export interface MergeExportOptions {
    *   normalised units; mixing real units under this mode mis-scales geometry.
    */
   unitReconciliation?: 'auto' | 'normalize' | 'assume-shared';
+
+  /**
+   * How IfcSite instances are matched across models for spatial unification
+   * (mirrors IfcOpenShell/BlenderBIM's "Merge Projects" recipe). Omitted
+   * (default) keeps today's combined heuristic: match by Name
+   * (case-insensitive), else unify when both models contribute exactly one
+   * site.
+   *
+   * - `'single'`: unify only when each model contributes exactly one
+   *   IfcSite — Name is ignored entirely.
+   * - `'by-name'`: unify only sites with a matching Name; a lone,
+   *   differently-named site in each model is kept as two separate roots.
+   */
+  mergeSites?: 'single' | 'by-name';
+
+  /** Same matching strategy as {@link mergeSites}, applied to IfcBuilding. */
+  mergeBuildings?: 'single' | 'by-name';
+
+  /**
+   * How IfcBuildingStorey instances are matched across models. Omitted
+   * (default) is `'by-name-then-elevation'` — today's behavior.
+   *
+   * - `'by-name'`: match only by Name (case-insensitive); no elevation
+   *   fallback.
+   * - `'by-elevation'`: match only by Elevation (±0.5 model-unit tolerance,
+   *   same as today), ignoring Name entirely.
+   * - `'by-name-then-elevation'`: try Name first, fall back to Elevation.
+   */
+  mergeStoreys?: 'by-name' | 'by-elevation' | 'by-name-then-elevation';
 
   /** Apply visibility filtering to each model before merging */
   visibleOnly?: boolean;
@@ -729,6 +764,9 @@ export class MergedExporter {
       primaryVolumeScale: this.resolveDerivedUnitScale(firstModel.dataStore, 'VOLUMEUNIT', primaryScale, 3),
       assumeShared: options.unitReconciliation === 'assume-shared',
       normalize: options.unitReconciliation === 'normalize',
+      mergeSites: options.mergeSites,
+      mergeBuildings: options.mergeBuildings,
+      mergeStoreys: options.mergeStoreys,
     };
   }
 
@@ -944,7 +982,7 @@ export class MergedExporter {
       // Unify spatial hierarchy: match Site, Building, Storey to first model.
       // Under normalize, this model's raw elevations are in its own unit, so the
       // elevation match is done in the primary unit (rawElevation * lengthFactor).
-      this.unifySpatialEntities(model.dataStore, setup.spatialLookup, setup.firstModelOffset, lengthFactor, sharedRemap, skipEntityIds);
+      this.unifySpatialEntities(model.dataStore, setup.spatialLookup, setup.firstModelOffset, lengthFactor, sharedRemap, skipEntityIds, setup);
 
       // Skip IfcRelAggregates that become fully redundant after unification.
       this.skipRedundantRelAggregates(model.dataStore, sharedRemap, skipEntityIds);
@@ -1257,9 +1295,14 @@ export class MergedExporter {
    * to the first model's equivalents. Matched entities are remapped and
    * their duplicate entity is skipped from output.
    *
-   * Matching strategy:
-   * - Sites/Buildings: by name (case-insensitive), or if only one in each model
-   * - Storeys: by name first, then by elevation (tolerance ±0.5 model units)
+   * Matching strategy per container type is driven by
+   * {@link MergeExportOptions.mergeSites} / `mergeBuildings` / `mergeStoreys`
+   * (all optional; omitted keeps the pre-existing combined heuristic):
+   * - Sites/Buildings: `'single'` (ignore name, unify iff exactly one in each
+   *   model), `'by-name'` (name only, no fallback), or omitted — name first,
+   *   else single-instance fallback.
+   * - Storeys: `'by-name'`, `'by-elevation'` (tolerance ±0.5 model units), or
+   *   `'by-name-then-elevation'` (default, also the omitted behavior).
    */
   private unifySpatialEntities(
     dataStore: IfcDataStore,
@@ -1268,17 +1311,15 @@ export class MergedExporter {
     elevationFactor: number,
     sharedRemap: Map<number, number>,
     skipEntityIds: Set<number>,
+    mergeModes: Pick<MergeSetup, 'mergeSites' | 'mergeBuildings' | 'mergeStoreys'>,
   ): void {
     // Unify IfcSite
     const sites = this.findEntitiesByType(dataStore, 'IFCSITE');
     for (const id of sites) {
-      const name = this.extractEntityName(id, dataStore);
-      let match: number | undefined;
-      if (name) match = lookup.sitesByName.get(name.toLowerCase());
-      // If single site in both models, unify regardless of name
-      if (match === undefined && sites.length === 1 && lookup.siteIds.length === 1) {
-        match = lookup.siteIds[0];
-      }
+      const match = this.matchRootContainer(
+        id, dataStore, mergeModes.mergeSites, sites.length,
+        lookup.sitesByName, lookup.siteIds,
+      );
       if (match !== undefined) {
         sharedRemap.set(id, match + firstModelOffset);
         skipEntityIds.add(id);
@@ -1288,36 +1329,36 @@ export class MergedExporter {
     // Unify IfcBuilding
     const buildings = this.findEntitiesByType(dataStore, 'IFCBUILDING');
     for (const id of buildings) {
-      const name = this.extractEntityName(id, dataStore);
-      let match: number | undefined;
-      if (name) match = lookup.buildingsByName.get(name.toLowerCase());
-      if (match === undefined && buildings.length === 1 && lookup.buildingIds.length === 1) {
-        match = lookup.buildingIds[0];
-      }
+      const match = this.matchRootContainer(
+        id, dataStore, mergeModes.mergeBuildings, buildings.length,
+        lookup.buildingsByName, lookup.buildingIds,
+      );
       if (match !== undefined) {
         sharedRemap.set(id, match + firstModelOffset);
         skipEntityIds.add(id);
       }
     }
 
-    // Unify IfcBuildingStorey — name match first, then elevation fallback
+    // Unify IfcBuildingStorey — mode-driven name/elevation matching
+    const storeyMode = mergeModes.mergeStoreys ?? 'by-name-then-elevation';
     const matchedFirstStoreys = new Set<number>();
     for (const id of this.findEntitiesByType(dataStore, 'IFCBUILDINGSTOREY')) {
       const name = this.extractEntityName(id, dataStore);
       let match: number | undefined;
 
-      // Try name match
-      if (name) {
+      // Name match (skipped entirely under 'by-elevation')
+      if (storeyMode !== 'by-elevation' && name) {
         const candidate = lookup.storeysByName.get(name.toLowerCase());
         if (candidate !== undefined && !matchedFirstStoreys.has(candidate)) {
           match = candidate;
         }
       }
 
-      // Fallback: match by elevation. The candidate's raw elevation is in this
-      // model's unit; scale it into the primary unit so the comparison (and the
-      // ±0.5 m tolerance) is unit-consistent under normalize (factor 1 otherwise).
-      if (match === undefined) {
+      // Elevation match (skipped entirely under 'by-name'). The candidate's raw
+      // elevation is in this model's unit; scale it into the primary unit so the
+      // comparison (and the ±0.5 m tolerance) is unit-consistent under normalize
+      // (factor 1 otherwise).
+      if (match === undefined && storeyMode !== 'by-name') {
         const rawElevation = this.extractStoreyElevation(id, dataStore);
         if (rawElevation !== undefined) {
           const elevation = rawElevation * elevationFactor;
@@ -1338,6 +1379,33 @@ export class MergedExporter {
         skipEntityIds.add(id);
       }
     }
+  }
+
+  /**
+   * Match one IfcSite/IfcBuilding instance against the first model's
+   * equivalents, per {@link mergeMode}:
+   * - `'single'`: ignore name — unify iff both models contribute exactly one.
+   * - `'by-name'`: name match only, no single-instance fallback.
+   * - omitted: name match, else single-instance fallback (pre-existing heuristic).
+   */
+  private matchRootContainer(
+    id: number,
+    dataStore: IfcDataStore,
+    mergeMode: 'single' | 'by-name' | undefined,
+    countInThisModel: number,
+    firstModelByName: Map<string, number>,
+    firstModelIds: number[],
+  ): number | undefined {
+    const bySingle = () =>
+      countInThisModel === 1 && firstModelIds.length === 1 ? firstModelIds[0] : undefined;
+    const byName = () => {
+      const name = this.extractEntityName(id, dataStore);
+      return name ? firstModelByName.get(name.toLowerCase()) : undefined;
+    };
+
+    if (mergeMode === 'single') return bySingle();
+    if (mergeMode === 'by-name') return byName();
+    return byName() ?? bySingle();
   }
 
   /**


### PR DESCRIPTION
Closes #1483

## Summary
- `MergedExporter` gains `mergeSites`/`mergeBuildings` (`'single' | 'by-name'`) and `mergeStoreys` (`'by-name' | 'by-elevation' | 'by-name-then-elevation'`) options, mirroring IfcOpenShell/BlenderBIM's "Merge Projects" recipe.
- All new options are optional; omitted keeps today's exact combined heuristic (name match, else single-instance fallback for site/building; name-then-elevation for storeys) — no default behavior change.
- CLI `merge` command gets matching `--merge-sites` / `--merge-buildings` / `--merge-storeys` flags.
- Docs (`docs/guide/exporting.md`) and changeset updated.

## Out of scope (tracked as follow-up in #1483)
- Viewer UI (`ExportDialog.tsx`) — radio groups for these options + a "delete empty containers" checkbox, to be wired once this engine change is available.
- "Delete empty containers" post-merge pruning — separate feature.

## Test plan
- [x] `pnpm --filter @ifc-lite/export vitest run src/merged-exporter.test.ts` — 42/42 passing (36 pre-existing + 6 new, covering `single`/`by-name`/`by-elevation` strict modes and the omitted-default fallback).
- [x] `pnpm --filter @ifc-lite/cli vitest run` — 109/109 passing (unaffected).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable spatial merge matching options for combining multi-model exports, letting you control how sites, buildings, and storeys are unified.
  * New CLI flags: `--merge-sites`, `--merge-buildings`, and `--merge-storeys`, with defaults preserving prior matching behavior when options are omitted.
  * Updated export docs and CLI help with the new options and matching strategy details.
* **Tests**
  * Added coverage for the new merge matching modes, including defaults and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge — additive-only change with no default behaviour modification and full test coverage of all new code paths.

Every new mode is gated behind optional options that default to the pre-existing heuristic, so no existing call site is affected. The matchedFirst guard that was called out in the previous review thread is correctly implemented for both sites and buildings, and the regression test directly validates the collision scenario. The CLI parsing handles the valueless-flag edge case explicitly. No logic errors or contract violations found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/export/src/merged-exporter.ts | Core engine change: adds matchRootContainer helper with 'single'/'by-name'/omitted modes and fixes the previously-missing matchedFirstSites/matchedFirstBuildings guard; storey matching gains explicit by-name/by-elevation/by-name-then-elevation switching. Logic is correct, default behavior preserved. |
| packages/export/src/merged-exporter.test.ts | Six new targeted tests cover 'single'/'by-name' for both sites and buildings, all three storey modes, the default-heuristic fallback, and the duplicate-name collision regression guard added this PR. |
| packages/cli/src/commands/merge.ts | Three new CLI flags with valueless-flag detection (hasFlag+getFlag guard), enum validation, and correct positional-arg skipping; wired through to the exporter options cleanly. |
| docs/guide/exporting.md | New 'Spatial matching strategy' section accurately documents the three options, their union semantics, and the omitted-default behaviour for all container types. |
| .changeset/merge-spatial-matching-options.md | Minor bump for both @ifc-lite/export and @ifc-lite/cli; descriptions match the implementation accurately. |

<sub>Reviews (2): Last reviewed commit: ["fix(export): address CodeRabbit/Greptile..."](https://github.com/ltplus-ag/ifc-lite/commit/598666d4e68ba32cc98ede97d8ab78fd26909474) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41167085)</sub>

<!-- /greptile_comment -->