### PR TITLE
feat(renderer): expose per-element local (object-space) bounding box + placement transform

### DIFF
--- a/.changeset/entity-local-bounds-transform.md
+++ b/.changeset/entity-local-bounds-transform.md
@@ -1,0 +1,31 @@
+---
+"@ifc-lite/wasm": minor
+"@ifc-lite/geometry": minor
+"@ifc-lite/renderer": minor
+---
+
+feat(renderer): expose per-element local (object-space) bounding box + placement transform
+
+Recovering an element's TRUE oriented dimensions (length/width/height for a
+rotated/tilted member) previously required an expensive client-side vertex
+scan + PCA, since `Scene.getEntityBoundingBox` only returns a world-space
+(axis-aligned-to-world) AABB. The geometry pipeline already resolves each
+element's placement and briefly holds its pre-placement, object-space extent —
+this surfaces both instead of discarding them (issue #1474):
+
+- `Scene.getEntityLocalBounds(expressId)` — the element's local (pre-placement)
+  AABB, O(1) lookup. Unions across a multi-piece entity's mesh pieces (material
+  layers, CSG parts) — all pieces of one element share a local frame, so no
+  reconciliation is needed. For a GPU-instanced entity, returns the shared
+  template's local box.
+- `Scene.getEntityTransform(expressId)` — the resolved `IfcLocalPlacement`
+  chain, row-major 4×4, Y-up metres. For an instanced entity, returns the
+  specific occurrence's transform.
+- `MeshData` gains `localBounds`/`localToWorld` (optional, session-only — not
+  persisted to the disk/IndexedDB geometry cache, recomputed fresh each load
+  like GPU-instancing metadata).
+
+Both return `null` for a container/assembly with no mesh (e.g.
+`IfcElementAssembly`) or when not captured (older cached geometry). Consumers
+can pair the two to reconstruct an oriented bounding box, or use it as a
+fallback when `Qto_*` `Length`/`Width`/`Height` quantities are absent.

--- a/packages/geometry/src/geometry-coordinate.ts
+++ b/packages/geometry/src/geometry-coordinate.ts
@@ -82,6 +82,20 @@ export function convertMeshCollectionToBatch(
           originArr && originArr.length === 3 && (originArr[0] || originArr[1] || originArr[2])
             ? [originArr[0], originArr[1], originArr[2]]
             : undefined;
+        // Local (pre-placement) AABB + placement transform (issue #1474);
+        // absent on older bundles (no getter) or when not captured (e.g. an
+        // instancing template).
+        const localBoundsArr = (mesh as { localBounds?: ArrayLike<number> }).localBounds;
+        const localBounds =
+          localBoundsArr && localBoundsArr.length === 6
+            ? {
+                min: [localBoundsArr[0], localBoundsArr[1], localBoundsArr[2]] as [number, number, number],
+                max: [localBoundsArr[3], localBoundsArr[4], localBoundsArr[5]] as [number, number, number],
+              }
+            : undefined;
+        const localToWorldArr = (mesh as { localToWorld?: ArrayLike<number> }).localToWorld;
+        const localToWorld =
+          localToWorldArr && localToWorldArr.length === 16 ? Array.from(localToWorldArr) : undefined;
         const meshData: MeshData = {
           expressId: mesh.expressId,
           ifcType: mesh.ifcType,
@@ -91,6 +105,8 @@ export function convertMeshCollectionToBatch(
           color: [color[0], color[1], color[2], color[3]],
           ...(shadingColor ? { shadingColor } : {}),
           ...(origin ? { origin } : {}),
+          ...(localBounds ? { localBounds } : {}),
+          ...(localToWorld ? { localToWorld } : {}),
           // #957 follow-up: carry the Model/Types geometry class so the viewer's
           // view-mode filter can show/hide type-library geometry.
           geometryClass: (mesh as { geometryClass?: number }).geometryClass ?? 0,

--- a/packages/geometry/src/geometry-parallel.ts
+++ b/packages/geometry/src/geometry-parallel.ts
@@ -336,6 +336,8 @@ export async function* processParallel(
           geometryHash?: bigint;
           geometryClass?: number;
           origin?: [number, number, number];
+          localBounds?: MeshData['localBounds'];
+          localToWorld?: MeshData['localToWorld'];
         }) => ({
           expressId: m.expressId,
           ifcType: m.ifcType,
@@ -359,6 +361,9 @@ export async function* processParallel(
           // Per-element local-frame origin (world = origin + position); the
           // renderer reconstructs world via a per-batch model-matrix translate.
           ...(m.origin ? { origin: m.origin } : {}),
+          // Local (pre-placement) AABB + placement transform (issue #1474).
+          ...(m.localBounds ? { localBounds: m.localBounds } : {}),
+          ...(m.localToWorld ? { localToWorld: m.localToWorld } : {}),
         }));
         // GPU-instancing: per-batch IFNS shards ride alongside the flat meshes.
         // Opaque repeated occurrences render ONLY via these shards (taken off the

--- a/packages/geometry/src/geometry.worker.ts
+++ b/packages/geometry/src/geometry.worker.ts
@@ -642,6 +642,19 @@ function collectMeshes(
           originArr && originArr.length === 3 && (originArr[0] || originArr[1] || originArr[2])
             ? [originArr[0], originArr[1], originArr[2]]
             : undefined;
+        // Local (pre-placement) AABB + placement transform (issue #1474);
+        // absent on older wasm bundles (no getter) or when not captured.
+        const localBoundsArr = mesh.localBounds;
+        const localBounds =
+          localBoundsArr && localBoundsArr.length === 6
+            ? {
+                min: [localBoundsArr[0], localBoundsArr[1], localBoundsArr[2]] as [number, number, number],
+                max: [localBoundsArr[3], localBoundsArr[4], localBoundsArr[5]] as [number, number, number],
+              }
+            : undefined;
+        const localToWorldArr = mesh.localToWorld;
+        const localToWorld =
+          localToWorldArr && localToWorldArr.length === 16 ? Array.from(localToWorldArr) : undefined;
         const meshData: MeshData = {
           expressId: mesh.expressId,
           ifcType: mesh.ifcType,
@@ -649,6 +662,8 @@ function collectMeshes(
           color: [color[0], color[1], color[2], color[3]],
           ...(shadingColor ? { shadingColor } : {}),
           ...(origin ? { origin } : {}),
+          ...(localBounds ? { localBounds } : {}),
+          ...(localToWorld ? { localToWorld } : {}),
           // Provenance for the Model/Types switch (0=occurrence, 1=orphan type,
           // 2=instanced type). Older wasm bundles lack the getter → default 0.
           geometryClass: mesh.geometryClass ?? 0,

--- a/packages/geometry/src/types.ts
+++ b/packages/geometry/src/types.ts
@@ -81,6 +81,18 @@ export interface MeshData {
    *  such caches must key on this instead. Absent for flat meshes (one MeshData
    *  per `expressId`), where `expressId` is already a sufficient key. */
   occurrenceKey?: string;
+  /** Local (pre-placement, object-space) AABB — `positions` bounds as they
+   *  were BEFORE the element's `IfcLocalPlacement` was baked in (issue #1474).
+   *  Absent when not captured (e.g. an instancing template, or a mesh built
+   *  outside the standard element pipeline). Unrelated to `origin`, which is
+   *  a *world*-space translation captured AFTER placement, purely for f32
+   *  precision — don't conflate the two. */
+  localBounds?: { min: [number, number, number]; max: [number, number, number] };
+  /** The resolved `IfcLocalPlacement` chain applied to this mesh (issue
+   *  #1474): row-major 4x4, 16 numbers, WebGL Y-up metres (same frame as
+   *  `positions`). Absent when not captured. All of one entity's `MeshData`
+   *  pieces share the same value (one placement per element). */
+  localToWorld?: number[];
 }
 
 /** A decoded RGBA8 surface texture attached to a mesh (issue #961). */

--- a/packages/renderer/src/scene-local-bounds.test.ts
+++ b/packages/renderer/src/scene-local-bounds.test.ts
@@ -69,6 +69,35 @@ describe('Scene.getEntityLocalBounds', () => {
       max: [1, 2, 1],
     });
   });
+
+  it('returns the shared template box for a GPU-instanced entity, as a copy', () => {
+    const scene = new Scene();
+    // Seed the private instancing state directly (GPU-buffer-agnostic data
+    // side), mirroring scene-remove.test.ts's approach for boundingBoxes.
+    scene['instancedTemplateCpu'] = [
+      {
+        positions: new Float32Array(),
+        normals: new Float32Array(),
+        indices: new Uint32Array(),
+        instanceData: new ArrayBuffer(0),
+        localMin: [0, 0, 0],
+        localMax: [2, 2, 2],
+      },
+    ];
+    scene['instancedEntityMap'] = new Map([
+      [7, [{ templateIndex: 0, byteOffset: 0, originalColor: [0, 0, 0, 1] }]],
+    ]);
+
+    const bounds = scene.getEntityLocalBounds(7);
+    assert.deepStrictEqual(bounds, { min: [0, 0, 0], max: [2, 2, 2] });
+
+    // Regression: must be a copy, not the live template arrays — mutating the
+    // result must not corrupt internal renderer state (Greptile P1).
+    bounds!.min[0] = 999;
+    const tmpl = scene['instancedTemplateCpu'][0];
+    assert.strictEqual(tmpl.localMin[0], 0, 'mutating the returned box must not affect the template');
+    assert.deepStrictEqual(scene.getEntityLocalBounds(7), { min: [0, 0, 0], max: [2, 2, 2] });
+  });
 });
 
 describe('Scene.getEntityTransform', () => {
@@ -83,12 +112,61 @@ describe('Scene.getEntityTransform', () => {
     assert.strictEqual(scene.getEntityTransform(1), null);
   });
 
-  it('returns the captured transform as a row-major Float32Array(16)', () => {
+  it('returns the captured transform as a row-major Float64Array(16)', () => {
     const scene = new Scene();
     scene.addMeshData(makeMesh(4, { localToWorld: IDENTITY_ROW_MAJOR }));
     const transform = scene.getEntityTransform(4);
-    assert.ok(transform instanceof Float32Array);
+    assert.ok(transform instanceof Float64Array);
     assert.strictEqual(transform!.length, 16);
     assert.deepStrictEqual(Array.from(transform!), IDENTITY_ROW_MAJOR);
+  });
+
+  it('does not lose precision for a large-magnitude (georeferenced) translation', () => {
+    // A translation far from the origin — the exact case f32 would corrupt
+    // (sub-mm precision lost past a few hundred metres).
+    const farTransform = [...IDENTITY_ROW_MAJOR];
+    farTransform[3] = 123_456_789.123456; // translation X
+    const scene = new Scene();
+    scene.addMeshData(makeMesh(5, { localToWorld: farTransform }));
+    const transform = scene.getEntityTransform(5);
+    assert.strictEqual(transform![3], 123_456_789.123456);
+  });
+
+  it('reads a GPU-instanced occurrence transform, column-major -> row-major', () => {
+    const scene = new Scene();
+    // Column-major identity + translation (10, 20, 30), packed as the GPU
+    // instance buffer stores it (mat4 at byte offset 0).
+    const instanceData = new ArrayBuffer(64);
+    const dv = new DataView(instanceData);
+    // prettier-ignore
+    const colMajor = [
+      1, 0, 0, 0,
+      0, 1, 0, 0,
+      0, 0, 1, 0,
+      10, 20, 30, 1,
+    ];
+    colMajor.forEach((v, i) => dv.setFloat32(i * 4, v, true));
+
+    scene['instancedTemplateCpu'] = [
+      {
+        positions: new Float32Array(),
+        normals: new Float32Array(),
+        indices: new Uint32Array(),
+        instanceData,
+        localMin: [0, 0, 0],
+        localMax: [1, 1, 1],
+      },
+    ];
+    scene['instancedEntityMap'] = new Map([
+      [8, [{ templateIndex: 0, byteOffset: 0, originalColor: [0, 0, 0, 1] }]],
+    ]);
+
+    const transform = scene.getEntityTransform(8);
+    assert.deepStrictEqual(Array.from(transform!), [
+      1, 0, 0, 10,
+      0, 1, 0, 20,
+      0, 0, 1, 30,
+      0, 0, 0, 1,
+    ]);
   });
 });

--- a/packages/renderer/src/scene-local-bounds.test.ts
+++ b/packages/renderer/src/scene-local-bounds.test.ts
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { Scene } from './scene.js';
+import type { MeshData } from '@ifc-lite/geometry';
+
+/**
+ * `getEntityLocalBounds` / `getEntityTransform` (issue #1474) are GPU-buffer-
+ * agnostic — they read straight off `meshDataMap`, so exercised here without a
+ * GPUDevice, mirroring `scene-remove.test.ts`'s approach.
+ */
+
+const IDENTITY_ROW_MAJOR = [
+  1, 0, 0, 0,
+  0, 1, 0, 0,
+  0, 0, 1, 0,
+  0, 0, 0, 1,
+];
+
+function makeMesh(expressId: number, overrides: Partial<MeshData> = {}): MeshData {
+  return {
+    expressId,
+    positions: new Float32Array([0, 0, 0, 1, 1, 1]),
+    normals: new Float32Array([0, 0, 0, 1, 1, 1]),
+    indices: new Uint32Array([0, 1, 2]),
+    color: [0, 0, 0, 1],
+    ...overrides,
+  } as unknown as MeshData;
+}
+
+describe('Scene.getEntityLocalBounds', () => {
+  it('returns null when no mesh exists for the entity', () => {
+    const scene = new Scene();
+    assert.strictEqual(scene.getEntityLocalBounds(123), null);
+  });
+
+  it('returns null when the mesh has no captured localBounds', () => {
+    const scene = new Scene();
+    scene.addMeshData(makeMesh(1));
+    assert.strictEqual(scene.getEntityLocalBounds(1), null);
+  });
+
+  it('returns the captured box for a single-piece entity', () => {
+    const scene = new Scene();
+    scene.addMeshData(
+      makeMesh(2, { localBounds: { min: [0, 0, 0], max: [2, 3, 4] } }),
+    );
+    assert.deepStrictEqual(scene.getEntityLocalBounds(2), {
+      min: [0, 0, 0],
+      max: [2, 3, 4],
+    });
+  });
+
+  it('unions localBounds across a multi-piece entity', () => {
+    const scene = new Scene();
+    // Same expressId, two pieces (e.g. material-layer split) — every piece of
+    // one element shares the local frame, so a plain union is correct.
+    scene.addMeshData(
+      makeMesh(3, { geometryItemId: 1, localBounds: { min: [0, 0, 0], max: [1, 1, 1] } } as Partial<MeshData>),
+    );
+    scene.addMeshData(
+      makeMesh(3, { geometryItemId: 2, localBounds: { min: [-1, 0.5, 0], max: [0.5, 2, 1] } } as Partial<MeshData>),
+    );
+    assert.deepStrictEqual(scene.getEntityLocalBounds(3), {
+      min: [-1, 0, 0],
+      max: [1, 2, 1],
+    });
+  });
+});
+
+describe('Scene.getEntityTransform', () => {
+  it('returns null when no mesh exists for the entity', () => {
+    const scene = new Scene();
+    assert.strictEqual(scene.getEntityTransform(123), null);
+  });
+
+  it('returns null when the mesh has no captured localToWorld', () => {
+    const scene = new Scene();
+    scene.addMeshData(makeMesh(1));
+    assert.strictEqual(scene.getEntityTransform(1), null);
+  });
+
+  it('returns the captured transform as a row-major Float32Array(16)', () => {
+    const scene = new Scene();
+    scene.addMeshData(makeMesh(4, { localToWorld: IDENTITY_ROW_MAJOR }));
+    const transform = scene.getEntityTransform(4);
+    assert.ok(transform instanceof Float32Array);
+    assert.strictEqual(transform!.length, 16);
+    assert.deepStrictEqual(Array.from(transform!), IDENTITY_ROW_MAJOR);
+  });
+});

--- a/packages/renderer/src/scene-local-bounds.test.ts
+++ b/packages/renderer/src/scene-local-bounds.test.ts
@@ -98,6 +98,33 @@ describe('Scene.getEntityLocalBounds', () => {
     assert.strictEqual(tmpl.localMin[0], 0, 'mutating the returned box must not affect the template');
     assert.deepStrictEqual(scene.getEntityLocalBounds(7), { min: [0, 0, 0], max: [2, 2, 2] });
   });
+
+  it('unions across occurrences backed by DIFFERENT templates (mapped-item sub-assembly)', () => {
+    // One expressId, two occurrence records pointing at two distinct
+    // templates — e.g. a mapped-item assembly split across materials.
+    // Regression: the instanced path must union, not just read occurrences[0].
+    const scene = new Scene();
+    scene['instancedTemplateCpu'] = [
+      {
+        positions: new Float32Array(), normals: new Float32Array(), indices: new Uint32Array(),
+        instanceData: new ArrayBuffer(0), localMin: [0, 0, 0], localMax: [1, 1, 1],
+      },
+      {
+        positions: new Float32Array(), normals: new Float32Array(), indices: new Uint32Array(),
+        instanceData: new ArrayBuffer(0), localMin: [-1, 0.5, 0], localMax: [0.5, 2, 1],
+      },
+    ];
+    scene['instancedEntityMap'] = new Map([
+      [9, [
+        { templateIndex: 0, byteOffset: 0, originalColor: [0, 0, 0, 1] },
+        { templateIndex: 1, byteOffset: 0, originalColor: [0, 0, 0, 1] },
+      ]],
+    ]);
+    assert.deepStrictEqual(scene.getEntityLocalBounds(9), {
+      min: [-1, 0, 0],
+      max: [1, 2, 1],
+    });
+  });
 });
 
 describe('Scene.getEntityTransform', () => {
@@ -168,5 +195,32 @@ describe('Scene.getEntityTransform', () => {
       0, 0, 1, 30,
       0, 0, 0, 1,
     ]);
+  });
+});
+
+describe('Scene splitMeshForStreaming', () => {
+  it('preserves localBounds/localToWorld on every fragment of an oversized mesh', () => {
+    // Regression: fragments used to carry origin forward but silently drop
+    // localBounds/localToWorld, so getEntityLocalBounds/getEntityTransform
+    // returned null for any element large enough to stream-split.
+    const scene = new Scene();
+    const TRIANGLE_COUNT = 70_000; // > STREAMING_FRAGMENT_MAX_INDICES/3 (60,000)
+    const indices = new Uint32Array(TRIANGLE_COUNT * 3);
+    for (let i = 0; i < indices.length; i++) indices[i] = i % 3; // 3 shared vertices
+    const big = makeMesh(6, {
+      positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+      normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+      indices,
+      origin: [5, 5, 5],
+      localBounds: { min: [0, 0, 0], max: [1, 1, 0] },
+      localToWorld: IDENTITY_ROW_MAJOR,
+    });
+
+    const fragments = scene['splitMeshForStreaming'](big) as MeshData[];
+    assert.ok(fragments.length > 1, 'the mesh should actually split');
+    for (const frag of fragments) {
+      assert.deepStrictEqual(frag.localBounds, { min: [0, 0, 0], max: [1, 1, 0] });
+      assert.deepStrictEqual(Array.from(frag.localToWorld!), IDENTITY_ROW_MAJOR);
+    }
   });
 });

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -1171,6 +1171,13 @@ export class Scene {
         // Fragments are subsets of the same source mesh → same local frame.
         // Preserve origin so each fragment relativizes/renders in world space.
         ...(meshData.origin ? { origin: meshData.origin } : {}),
+        // Each fragment is a vertex SUBSET of the same source mesh, so the
+        // parent's localBounds/localToWorld (issue #1474) still apply
+        // unchanged: localBounds is a safe (if loose) superset — the caller
+        // unions across an entity's pieces anyway — and localToWorld is the
+        // one placement shared by the whole (pre-split) mesh.
+        ...(meshData.localBounds ? { localBounds: meshData.localBounds } : {}),
+        ...(meshData.localToWorld ? { localToWorld: meshData.localToWorld } : {}),
       });
     }
 
@@ -2690,9 +2697,11 @@ export class Scene {
    * Unions `localBounds` across all of the entity's mesh pieces — safe with
    * no reconciliation, since every piece of one element is already expressed
    * in the same local frame (see `MeshData.localBounds` docs). For a
-   * GPU-instanced entity, returns the shared template's local box (identical
-   * for every occurrence — the per-occurrence world placement comes from
-   * {@link getEntityTransform}).
+   * GPU-instanced entity, unions the local box of every occurrence's
+   * template — one `expressId` can hold multiple occurrence records backed
+   * by DIFFERENT templates (e.g. a mapped-item assembly whose sub-items
+   * split across materials), not just repeats of one template, mirroring the
+   * flat-path union above.
    *
    * Returns `null` for a container/assembly with no mesh (e.g.
    * `IfcElementAssembly`), or when not captured (older cached geometry).
@@ -2717,18 +2726,27 @@ export class Scene {
       return found ? { min: [minX, minY, minZ], max: [maxX, maxY, maxZ] } : null;
     }
 
-    // GPU-instanced entity: no flat mesh piece — the template's local box
-    // (computed once at upload time, `scene.ts` instancing upload path) is
-    // shared by every occurrence.
+    // GPU-instanced entity: no flat mesh piece. Union every occurrence's
+    // template box (computed once at upload time, `scene.ts` instancing
+    // upload path) — distinct occurrence records for one expressId can point
+    // at distinct templates.
     const occurrences = this.instancedEntityMap.get(expressId);
     if (occurrences && occurrences.length > 0) {
-      const tmpl = this.instancedTemplateCpu[occurrences[0].templateIndex];
-      if (tmpl && Number.isFinite(tmpl.localMin[0])) {
-        // Copy — tmpl.localMin/localMax are the live arrays retained in
-        // instancedTemplateCpu; a caller mutating the returned box must not
-        // corrupt internal renderer state.
-        return { min: [...tmpl.localMin], max: [...tmpl.localMax] };
+      let minX = Infinity, minY = Infinity, minZ = Infinity;
+      let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+      let found = false;
+      for (const occ of occurrences) {
+        const tmpl = this.instancedTemplateCpu[occ.templateIndex];
+        if (!tmpl || !Number.isFinite(tmpl.localMin[0])) continue;
+        found = true;
+        if (tmpl.localMin[0] < minX) minX = tmpl.localMin[0];
+        if (tmpl.localMin[1] < minY) minY = tmpl.localMin[1];
+        if (tmpl.localMin[2] < minZ) minZ = tmpl.localMin[2];
+        if (tmpl.localMax[0] > maxX) maxX = tmpl.localMax[0];
+        if (tmpl.localMax[1] > maxY) maxY = tmpl.localMax[1];
+        if (tmpl.localMax[2] > maxZ) maxZ = tmpl.localMax[2];
       }
+      return found ? { min: [minX, minY, minZ], max: [maxX, maxY, maxZ] } : null;
     }
     return null;
   }
@@ -2740,11 +2758,19 @@ export class Scene {
    * world box (an OBB), unlike {@link getEntityBoundingBox}'s pre-unioned
    * world-axis-aligned box.
    *
-   * A multi-piece entity's pieces all share one placement (one
+   * A flat entity's mesh pieces all share one placement (one
    * `IfcLocalPlacement` per element) — returns the first piece that carries
-   * one. For a GPU-instanced entity, returns the SPECIFIC occurrence's
-   * transform (read from the packed instance buffer, column-major, and
-   * transposed here so the public contract is row-major regardless of path).
+   * one. For a GPU-instanced entity, reads the FIRST occurrence record's
+   * transform (from the packed instance buffer, column-major, transposed
+   * here so the public contract is row-major regardless of path).
+   *
+   * KNOWN LIMITATION: unlike {@link getEntityLocalBounds} (safe to union),
+   * a transform can't be meaningfully aggregated across multiple occurrence
+   * records — an entity whose shape is internally composed of several
+   * independently-placed mapped sub-items (e.g. a railing with repeated
+   * baluster geometry) has genuinely DIFFERENT per-occurrence transforms
+   * under one `expressId`. This returns one representative transform, not
+   * necessarily the "whole entity's" placement, for such cases.
    *
    * Returns `null` for a container/assembly with no mesh, or when not
    * captured (older cached geometry, or the instancing template was released).

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -2724,7 +2724,10 @@ export class Scene {
     if (occurrences && occurrences.length > 0) {
       const tmpl = this.instancedTemplateCpu[occurrences[0].templateIndex];
       if (tmpl && Number.isFinite(tmpl.localMin[0])) {
-        return { min: tmpl.localMin, max: tmpl.localMax };
+        // Copy — tmpl.localMin/localMax are the live arrays retained in
+        // instancedTemplateCpu; a caller mutating the returned box must not
+        // corrupt internal renderer state.
+        return { min: [...tmpl.localMin], max: [...tmpl.localMax] };
       }
     }
     return null;
@@ -2745,13 +2748,24 @@ export class Scene {
    *
    * Returns `null` for a container/assembly with no mesh, or when not
    * captured (older cached geometry, or the instancing template was released).
+   *
+   * Returns `Float64Array`, NOT `Float32Array`: `localToWorld` carries the
+   * placement's translation in the *original* (pre-RTC) coordinate frame,
+   * which for a building-scale/georeferenced model can be tens of thousands
+   * of metres from the origin — f32 there loses sub-millimetre precision
+   * (the exact fan-collapse failure mode `MeshData.origin` exists to avoid
+   * for `positions`). The flat path's source data is already f64
+   * (`piece.localToWorld` round-trips from Rust's `[f64; 16]`); the
+   * instanced path's source (the GPU instance buffer) is genuinely f32, so
+   * widening it here is lossless but doesn't recover precision already lost
+   * upstream in that path.
    */
-  getEntityTransform(expressId: number): Float32Array | null {
+  getEntityTransform(expressId: number): Float64Array | null {
     const pieces = this.meshDataMap.get(expressId);
     if (pieces && pieces.length > 0) {
       for (const piece of pieces) {
         if (piece.localToWorld && piece.localToWorld.length === 16) {
-          return new Float32Array(piece.localToWorld);
+          return new Float64Array(piece.localToWorld);
         }
       }
       return null;
@@ -2763,7 +2777,7 @@ export class Scene {
       const tmpl = this.instancedTemplateCpu[templateIndex];
       if (!tmpl) return null;
       const dv = new DataView(tmpl.instanceData);
-      const row = new Float32Array(16);
+      const row = new Float64Array(16);
       for (let r = 0; r < 4; r++) {
         for (let c = 0; c < 4; c++) {
           // Source is column-major (mat[c][r] at byteOffset + (c*4+r)*4);

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -2681,6 +2681,102 @@ export class Scene {
   }
 
   /**
+   * Local (pre-placement, object-space) AABB for an entity (issue #1474) — the
+   * element's true, un-rotated extent, unlike {@link getEntityBoundingBox}'s
+   * world-space (axis-aligned-to-world) box. Y-up metres, same frame as
+   * `positions`. O(1): no vertex scan, reads `MeshData.localBounds` captured
+   * by the geometry pipeline.
+   *
+   * Unions `localBounds` across all of the entity's mesh pieces — safe with
+   * no reconciliation, since every piece of one element is already expressed
+   * in the same local frame (see `MeshData.localBounds` docs). For a
+   * GPU-instanced entity, returns the shared template's local box (identical
+   * for every occurrence — the per-occurrence world placement comes from
+   * {@link getEntityTransform}).
+   *
+   * Returns `null` for a container/assembly with no mesh (e.g.
+   * `IfcElementAssembly`), or when not captured (older cached geometry).
+   */
+  getEntityLocalBounds(expressId: number): { min: [number, number, number]; max: [number, number, number] } | null {
+    const pieces = this.meshDataMap.get(expressId);
+    if (pieces && pieces.length > 0) {
+      let minX = Infinity, minY = Infinity, minZ = Infinity;
+      let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+      let found = false;
+      for (const piece of pieces) {
+        const lb = piece.localBounds;
+        if (!lb) continue;
+        found = true;
+        if (lb.min[0] < minX) minX = lb.min[0];
+        if (lb.min[1] < minY) minY = lb.min[1];
+        if (lb.min[2] < minZ) minZ = lb.min[2];
+        if (lb.max[0] > maxX) maxX = lb.max[0];
+        if (lb.max[1] > maxY) maxY = lb.max[1];
+        if (lb.max[2] > maxZ) maxZ = lb.max[2];
+      }
+      return found ? { min: [minX, minY, minZ], max: [maxX, maxY, maxZ] } : null;
+    }
+
+    // GPU-instanced entity: no flat mesh piece — the template's local box
+    // (computed once at upload time, `scene.ts` instancing upload path) is
+    // shared by every occurrence.
+    const occurrences = this.instancedEntityMap.get(expressId);
+    if (occurrences && occurrences.length > 0) {
+      const tmpl = this.instancedTemplateCpu[occurrences[0].templateIndex];
+      if (tmpl && Number.isFinite(tmpl.localMin[0])) {
+        return { min: tmpl.localMin, max: tmpl.localMax };
+      }
+    }
+    return null;
+  }
+
+  /**
+   * The resolved local→world placement transform for an entity (issue
+   * #1474): row-major 4×4 (16 numbers), Y-up metres — pairs with
+   * {@link getEntityLocalBounds} to reconstruct the element's true oriented
+   * world box (an OBB), unlike {@link getEntityBoundingBox}'s pre-unioned
+   * world-axis-aligned box.
+   *
+   * A multi-piece entity's pieces all share one placement (one
+   * `IfcLocalPlacement` per element) — returns the first piece that carries
+   * one. For a GPU-instanced entity, returns the SPECIFIC occurrence's
+   * transform (read from the packed instance buffer, column-major, and
+   * transposed here so the public contract is row-major regardless of path).
+   *
+   * Returns `null` for a container/assembly with no mesh, or when not
+   * captured (older cached geometry, or the instancing template was released).
+   */
+  getEntityTransform(expressId: number): Float32Array | null {
+    const pieces = this.meshDataMap.get(expressId);
+    if (pieces && pieces.length > 0) {
+      for (const piece of pieces) {
+        if (piece.localToWorld && piece.localToWorld.length === 16) {
+          return new Float32Array(piece.localToWorld);
+        }
+      }
+      return null;
+    }
+
+    const occurrences = this.instancedEntityMap.get(expressId);
+    if (occurrences && occurrences.length > 0) {
+      const { templateIndex, byteOffset } = occurrences[0];
+      const tmpl = this.instancedTemplateCpu[templateIndex];
+      if (!tmpl) return null;
+      const dv = new DataView(tmpl.instanceData);
+      const row = new Float32Array(16);
+      for (let r = 0; r < 4; r++) {
+        for (let c = 0; c < 4; c++) {
+          // Source is column-major (mat[c][r] at byteOffset + (c*4+r)*4);
+          // write it out row-major.
+          row[r * 4 + c] = dv.getFloat32(byteOffset + (c * 4 + r) * 4, true);
+        }
+      }
+      return row;
+    }
+    return null;
+  }
+
+  /**
    * CPU raycast against all mesh data.
    * Returns expressId and modelIndex of closest hit, or null.
    * Delegates to extracted raycaster utilities.

--- a/packages/wasm/pkg/README.md
+++ b/packages/wasm/pkg/README.md
@@ -158,13 +158,20 @@ console.log(view.getMutations()); // change history for undo / export
 ## Export
 
 ```typescript
-import { exportToStep, GLTFExporter, ParquetExporter, Ifc5Exporter } from '@ifc-lite/export';
+import { exportToStep, ParquetExporter, Ifc5Exporter } from '@ifc-lite/export';
+import { GeometryProcessor } from '@ifc-lite/geometry';
 
 // IFC STEP — applies any pending mutations
 const stepText = exportToStep(store, { schema: 'IFC4', applyMutations: true });
 
-// glTF for the web
-const glb = await new GLTFExporter().export(parseResult, { format: 'glb' });
+// glTF / GLB, CSV and JSON-LD are assembled in Rust (ifc-lite-export) via the
+// GeometryProcessor — the standalone GLTFExporter/CSVExporter/JSONLDExporter
+// classes were retired.
+const gp = new GeometryProcessor();
+await gp.init();
+const glb = gp.exportGlbFromMeshes(result.meshes); // Uint8Array (no re-mesh)
+const csv = gp.exportCsv(buffer, 'entities', ',', /* includeProperties */ true);
+const jsonld = gp.exportJsonld(buffer);
 
 // Parquet — columnar, ~20× smaller than JSON, queryable from DuckDB / Polars
 const parquet = await new ParquetExporter().exportEntities(parseResult);
@@ -181,6 +188,7 @@ const ifcx = new Ifc5Exporter(store, meshes).export({ includeGeometry: true });
 | [**Three.js / Babylon.js**](https://ltplus-ag.github.io/ifc-lite/tutorials/threejs-integration/) | Adding IFC support to an existing 3D app | IFC parsing + geometry, rendered by your engine |
 | [**Server**](https://ltplus-ag.github.io/ifc-lite/guide/server/) | Teams, large files, repeat access | Rust backend with caching, parallel processing, streaming |
 | [**Build for Desktop**](https://ltplus-ag.github.io/ifc-lite/guide/desktop/) | Your own offline native app, very large files (500 MB+) | Extension points to wrap the packages in Tauri, with an optional native-Rust geometry fast path |
+| [**Python (native wheel)**](https://ltplus-ag.github.io/ifc-lite/api/python/) | Analysis, scripting, scientific Python | `pip install ifclite-geom` runs the geometry kernel in-process, meshes straight to numpy |
 
 Not sure? Start with the browser setup. You can add a server or switch engines later.
 
@@ -228,7 +236,7 @@ Ready-to-run projects in [`examples/`](examples/):
 | **BIM features** | [Federation](https://ltplus-ag.github.io/ifc-lite/guide/federation/) · [BCF](https://ltplus-ag.github.io/ifc-lite/guide/bcf/) · [IDS Validation](https://ltplus-ag.github.io/ifc-lite/guide/ids/) · [2D Drawings](https://ltplus-ag.github.io/ifc-lite/guide/drawing-2d/) · [Property Editing](https://ltplus-ag.github.io/ifc-lite/guide/mutations/) |
 | **Tutorials** | [Build a Viewer](https://ltplus-ag.github.io/ifc-lite/tutorials/building-viewer/) · [Three.js](https://ltplus-ag.github.io/ifc-lite/tutorials/threejs-integration/) · [Babylon.js](https://ltplus-ag.github.io/ifc-lite/tutorials/babylonjs-integration/) · [Custom Queries](https://ltplus-ag.github.io/ifc-lite/tutorials/custom-queries/) |
 | **Deep dives** | [Architecture](https://ltplus-ag.github.io/ifc-lite/architecture/overview/) · [Data Flow](https://ltplus-ag.github.io/ifc-lite/architecture/data-flow/) · [Performance](https://ltplus-ag.github.io/ifc-lite/guide/performance/) |
-| **API** | [TypeScript](https://ltplus-ag.github.io/ifc-lite/api/typescript/) · [Rust](https://ltplus-ag.github.io/ifc-lite/api/rust/) · [WASM](https://ltplus-ag.github.io/ifc-lite/api/wasm/) |
+| **API** | [TypeScript](https://ltplus-ag.github.io/ifc-lite/api/typescript/) · [Rust](https://ltplus-ag.github.io/ifc-lite/api/rust/) · [WASM](https://ltplus-ag.github.io/ifc-lite/api/wasm/) · [Python](https://ltplus-ag.github.io/ifc-lite/api/python/) |
 
 ## Contributing
 

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -541,6 +541,11 @@ export class MeshDataJs {
    */
   readonly hasTexture: boolean;
   /**
+   * Local (pre-placement, object-space) AABB (issue #1474), WebGL Y-up,
+   * `[minX,minY,minZ,maxX,maxY,maxZ]`. `null` when not captured.
+   */
+  readonly localBounds: Float32Array | undefined;
+  /**
    * Decoded RGBA8 texture bytes (`width*height*4`). Empty when untextured.
    */
   readonly textureRgba: Uint8Array;
@@ -561,6 +566,11 @@ export class MeshDataJs {
    * type geometry (hidden in Model mode, shown in Types mode).
    */
   readonly geometryClass: number;
+  /**
+   * The resolved `IfcLocalPlacement` chain for this mesh (issue #1474),
+   * row-major 4×4, WebGL Y-up. `null` when not captured.
+   */
+  readonly localToWorld: Float64Array | undefined;
   readonly textureHeight: number;
   /**
    * Get triangle count
@@ -1150,6 +1160,8 @@ export interface InitOutput {
   readonly meshdatajs_hasTexture: (a: number) => number;
   readonly meshdatajs_ifcType: (a: number, b: number) => void;
   readonly meshdatajs_indices: (a: number) => number;
+  readonly meshdatajs_localBounds: (a: number, b: number) => void;
+  readonly meshdatajs_localToWorld: (a: number, b: number) => void;
   readonly meshdatajs_normals: (a: number) => number;
   readonly meshdatajs_origin: (a: number) => number;
   readonly meshdatajs_positions: (a: number) => number;
@@ -1171,6 +1183,7 @@ export interface InitOutput {
   readonly partitionedbatch_takeShard: (a: number, b: number) => void;
   readonly profilecollection_get: (a: number, b: number) => number;
   readonly profilecollection_length: (a: number) => number;
+  readonly profileentryjs_expressId: (a: number) => number;
   readonly profileentryjs_extrusionDepth: (a: number) => number;
   readonly profileentryjs_extrusionDir: (a: number) => number;
   readonly profileentryjs_holeCounts: (a: number) => number;
@@ -1253,7 +1266,6 @@ export interface InitOutput {
   readonly init: () => void;
   readonly symbolicpolyline_pointCount: (a: number) => number;
   readonly get_memory: () => number;
-  readonly profileentryjs_expressId: (a: number) => number;
   readonly symbolicfillarea_expressId: (a: number) => number;
   readonly symbolicpolyline_worldY: (a: number) => number;
   readonly symbolictext_colorB: (a: number) => number;

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -542,7 +542,8 @@ export class MeshDataJs {
   readonly hasTexture: boolean;
   /**
    * Local (pre-placement, object-space) AABB (issue #1474), WebGL Y-up,
-   * `[minX,minY,minZ,maxX,maxY,maxZ]`. `null` when not captured.
+   * `[minX,minY,minZ,maxX,maxY,maxZ]`. `undefined` when not captured
+   * (wasm-bindgen maps `Option::None` to `undefined`, not `null`).
    */
   readonly localBounds: Float32Array | undefined;
   /**
@@ -568,7 +569,8 @@ export class MeshDataJs {
   readonly geometryClass: number;
   /**
    * The resolved `IfcLocalPlacement` chain for this mesh (issue #1474),
-   * row-major 4×4, WebGL Y-up. `null` when not captured.
+   * row-major 4×4, WebGL Y-up. `undefined` when not captured (see
+   * `local_bounds` above).
    */
   readonly localToWorld: Float64Array | undefined;
   readonly textureHeight: number;

--- a/packages/wasm/pkg/package.json
+++ b/packages/wasm/pkg/package.json
@@ -5,7 +5,7 @@
     "IFC-Lite Contributors"
   ],
   "description": "WebAssembly bindings for IFC-Lite",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "license": "MPL-2.0",
   "repository": {
     "type": "git",

--- a/rust/geometry/src/csg_capture.rs
+++ b/rust/geometry/src/csg_capture.rs
@@ -166,7 +166,7 @@ impl<'a> Reader<'a> {
         let indices: Vec<u32> = (0..n).map(|_| self.u32()).collect::<Option<_>>()?;
         let rtc_applied = self.u8()? != 0;
         let origin = [self.f64()?, self.f64()?, self.f64()?];
-        Some(Mesh { positions, normals, indices, rtc_applied, origin, instance_meta: None })
+        Some(Mesh { positions, normals, indices, rtc_applied, origin, instance_meta: None, local_bounds: None, local_to_world: None })
     }
 }
 

--- a/rust/geometry/src/mesh.rs
+++ b/rust/geometry/src/mesh.rs
@@ -637,6 +637,9 @@ impl Mesh {
         // Reset instancing metadata so a cleared+reused mesh can't carry stale
         // rep-identity / transform into unrelated geometry. (#1238 review)
         self.instance_meta = None;
+        // Same concern for the local-bounds/placement capture (issue #1474).
+        self.local_bounds = None;
+        self.local_to_world = None;
     }
 
     /// Weld coincident vertices, preserving per-vertex normals.

--- a/rust/geometry/src/mesh.rs
+++ b/rust/geometry/src/mesh.rs
@@ -95,6 +95,18 @@ pub struct Mesh {
     pub origin: [f64; 3],
     /// Instancing side-channel (see [`InstanceMeta`]); `None` on the flat path.
     pub instance_meta: Option<InstanceMeta>,
+    /// Local (pre-placement, object-space) AABB — `positions` bounds as they
+    /// were BEFORE `apply_placement`'s transform was baked in. `None` for an
+    /// empty mesh or one that never went through `transform_mesh_world_framed`
+    /// (e.g. synthetic/test meshes). Unrelated to `origin`, which is a
+    /// *world*-space translation captured AFTER the transform, purely for f32
+    /// precision — see issue #1474.
+    pub local_bounds: Option<[f32; 6]>, // minX,minY,minZ,maxX,maxY,maxZ
+    /// The resolved `IfcLocalPlacement` chain applied to this mesh by
+    /// `apply_placement` (row-major, same convention as
+    /// [`InstanceMeta::transform`]). `None` when no placement was applied
+    /// (synthetic/test meshes) — see issue #1474.
+    pub local_to_world: Option<[f64; 16]>,
 }
 
 /// A sub-mesh with its source geometry item ID.
@@ -171,6 +183,8 @@ impl Mesh {
             rtc_applied: false,
             origin: [0.0; 3],
             instance_meta: None,
+            local_bounds: None,
+            local_to_world: None,
         }
     }
 
@@ -183,6 +197,8 @@ impl Mesh {
             rtc_applied: false,
             origin: [0.0; 3],
             instance_meta: None,
+            local_bounds: None,
+            local_to_world: None,
         }
     }
 
@@ -453,7 +469,7 @@ impl Mesh {
             indices,
             rtc_applied: self.rtc_applied,
             origin: self.origin,
-        instance_meta: None, }
+        instance_meta: None, local_bounds: None, local_to_world: None }
     }
 
     /// Remove triangle indices that reference vertices beyond the positions array.
@@ -1070,7 +1086,7 @@ fn weld_impl(
         indices: new_indices,
         rtc_applied: mesh.rtc_applied,
         origin: mesh.origin,
-    instance_meta: None, }
+    instance_meta: None, local_bounds: None, local_to_world: None }
 }
 
 #[cfg(test)]
@@ -1301,6 +1317,8 @@ mod tests {
             rtc_applied: false,
             origin: [0.0; 3],
             instance_meta: None,
+            local_bounds: None,
+            local_to_world: None,
         };
         mesh.validate_indices();
         assert_eq!(mesh.indices, vec![0, 1, 2]);
@@ -1315,6 +1333,8 @@ mod tests {
             rtc_applied: false,
             origin: [0.0; 3],
             instance_meta: None,
+            local_bounds: None,
+            local_to_world: None,
         };
         mesh.validate_indices();
         assert!(mesh.indices.is_empty());
@@ -1329,6 +1349,8 @@ mod tests {
             rtc_applied: false,
             origin: [0.0; 3],
             instance_meta: None,
+            local_bounds: None,
+            local_to_world: None,
         };
         mesh.validate_indices();
         assert_eq!(mesh.indices, vec![0, 1, 2]);
@@ -1468,6 +1490,8 @@ mod tests {
             rtc_applied: false,
             origin: [0.0; 3],
             instance_meta: None,
+            local_bounds: None,
+            local_to_world: None,
         };
         mesh.validate_indices();
         assert_eq!(mesh.indices, vec![0, 1, 2, 1, 2, 3]);
@@ -1495,7 +1519,7 @@ mod tests {
             indices: vec![0, 1, 2, 3, 4, 5],
             rtc_applied: false,
             origin: [0.0; 3],
-        instance_meta: None, };
+        instance_meta: None, local_bounds: None, local_to_world: None };
         mesh.drop_thin_triangles(GRID);
         assert_eq!(mesh.indices, vec![3, 4, 5], "sliver dropped, real kept");
         // Positions/normals are never touched (orphan vertices are fine).
@@ -1511,7 +1535,7 @@ mod tests {
             indices: vec![0, 1, 2],
             rtc_applied: false,
             origin: [0.0; 3],
-        instance_meta: None, };
+        instance_meta: None, local_bounds: None, local_to_world: None };
         mesh.drop_thin_triangles(GRID);
         assert!(mesh.indices.is_empty(), "coincident-pair needle dropped");
     }
@@ -1525,7 +1549,7 @@ mod tests {
             indices: vec![0, 1, 2],
             rtc_applied: false,
             origin: [0.0; 3],
-        instance_meta: None, };
+        instance_meta: None, local_bounds: None, local_to_world: None };
         mesh.drop_thin_triangles(GRID);
         assert_eq!(mesh.indices, vec![0, 1, 2], "above-grid triangle kept");
     }
@@ -1556,7 +1580,7 @@ mod tests {
             ],
             rtc_applied: false,
             origin: [0.0; 3],
-        instance_meta: None, };
+        instance_meta: None, local_bounds: None, local_to_world: None };
         mesh.drop_thin_triangles(GRID);
         assert_eq!(
             mesh.indices,
@@ -1577,7 +1601,7 @@ mod tests {
             ],
             rtc_applied: false,
             origin: [0.0; 3],
-        instance_meta: None, };
+        instance_meta: None, local_bounds: None, local_to_world: None };
         mesh.drop_thin_triangles(GRID);
         assert_eq!(mesh.indices, vec![0, 1, 2]);
     }
@@ -1593,7 +1617,7 @@ mod tests {
             indices: vec![0, 1, 2, 3, 4, 5],
             rtc_applied: false,
             origin: [0.0; 3],
-        instance_meta: None, };
+        instance_meta: None, local_bounds: None, local_to_world: None };
         mesh.drop_thin_triangles(GRID);
         let once = mesh.indices.clone();
         mesh.drop_thin_triangles(GRID);
@@ -1613,7 +1637,7 @@ mod tests {
             indices: vec![0, 1, 2, 3, 4, 5],
             rtc_applied: false,
             origin: [0.0; 3],
-        instance_meta: None, };
+        instance_meta: None, local_bounds: None, local_to_world: None };
         mesh.clean_degenerate();
         assert_eq!(mesh.indices, vec![3, 4, 5]);
     }

--- a/rust/geometry/src/processors/advanced.rs
+++ b/rust/geometry/src/processors/advanced.rs
@@ -102,7 +102,7 @@ impl GeometryProcessor for AdvancedBrepProcessor {
             normals: Vec::new(),
             indices: all_indices,
             rtc_applied: false, 
-            origin: [0.0; 3],        instance_meta: None, })
+            origin: [0.0; 3],        instance_meta: None, local_bounds: None, local_to_world: None })
     }
 
     fn supported_types(&self) -> Vec<IfcType> {
@@ -157,7 +157,7 @@ impl GeometryProcessor for BSplineSurfaceProcessor {
             normals: Vec::new(),
             indices,
             rtc_applied: false, 
-            origin: [0.0; 3],        instance_meta: None, })
+            origin: [0.0; 3],        instance_meta: None, local_bounds: None, local_to_world: None })
     }
 
     fn supported_types(&self) -> Vec<IfcType> {

--- a/rust/geometry/src/processors/brep/faceted.rs
+++ b/rust/geometry/src/processors/brep/faceted.rs
@@ -349,7 +349,7 @@ impl FacetedBrepProcessor {
             indices,
             rtc_applied: true, // RTC already subtracted during f64→f32 conversion
             origin: [0.0; 3],
-        instance_meta: None, })
+        instance_meta: None, local_bounds: None, local_to_world: None })
     }
 }
 
@@ -471,7 +471,7 @@ impl GeometryProcessor for FacetedBrepProcessor {
             normals: Vec::new(),
             indices,
             rtc_applied: false, 
-            origin: [0.0; 3],        instance_meta: None, })
+            origin: [0.0; 3],        instance_meta: None, local_bounds: None, local_to_world: None })
     }
 
     fn supported_types(&self) -> Vec<IfcType> {

--- a/rust/geometry/src/processors/brep/surface_model.rs
+++ b/rust/geometry/src/processors/brep/surface_model.rs
@@ -166,7 +166,7 @@ impl GeometryProcessor for FaceBasedSurfaceModelProcessor {
             normals: Vec::new(),
             indices: all_indices,
             rtc_applied: false, 
-            origin: [0.0; 3],        instance_meta: None, })
+            origin: [0.0; 3],        instance_meta: None, local_bounds: None, local_to_world: None })
     }
 
     fn supported_types(&self) -> Vec<IfcType> {
@@ -337,7 +337,7 @@ impl GeometryProcessor for ShellBasedSurfaceModelProcessor {
             normals: Vec::new(),
             indices: all_indices,
             rtc_applied: false, 
-            origin: [0.0; 3],        instance_meta: None, })
+            origin: [0.0; 3],        instance_meta: None, local_bounds: None, local_to_world: None })
     }
 
     fn supported_types(&self) -> Vec<IfcType> {

--- a/rust/geometry/src/processors/surface.rs
+++ b/rust/geometry/src/processors/surface.rs
@@ -125,7 +125,7 @@ impl GeometryProcessor for SurfaceOfLinearExtrusionProcessor {
             normals: Vec::new(),
             indices,
             rtc_applied: false, 
-            origin: [0.0; 3],        instance_meta: None, })
+            origin: [0.0; 3],        instance_meta: None, local_bounds: None, local_to_world: None })
     }
 
     fn supported_types(&self) -> Vec<IfcType> {

--- a/rust/geometry/src/processors/swept/disk.rs
+++ b/rust/geometry/src/processors/swept/disk.rs
@@ -271,7 +271,7 @@ impl GeometryProcessor for SweptDiskSolidProcessor {
             indices,
             rtc_applied: false,
             origin: [0.0; 3],
-        instance_meta: None, };
+        instance_meta: None, local_bounds: None, local_to_world: None };
 
         // Ship smooth per-vertex normals, computed here in the directrix-local
         // frame where the coordinates are small (0..directrix-length) and so

--- a/rust/geometry/src/processors/swept/revolved.rs
+++ b/rust/geometry/src/processors/swept/revolved.rs
@@ -253,7 +253,7 @@ impl GeometryProcessor for RevolvedAreaSolidProcessor {
             normals: Vec::new(),
             indices,
             rtc_applied: false, 
-            origin: [0.0; 3],        instance_meta: None, };
+            origin: [0.0; 3],        instance_meta: None, local_bounds: None, local_to_world: None };
 
         // Apply Position to lift Position-local coords into object coords.
         apply_transform(&mut mesh, &position_transform);

--- a/rust/geometry/src/processors/tessellated/mesh_build.rs
+++ b/rust/geometry/src/processors/tessellated/mesh_build.rs
@@ -150,7 +150,7 @@ impl PolygonalFaceSetProcessor {
             normals: flat_normals,
             indices: flat_indices,
             rtc_applied: false,
-            origin: [0.0; 3],        instance_meta: None, }
+            origin: [0.0; 3],        instance_meta: None, local_bounds: None, local_to_world: None }
     }
 
     /// Like [`Self::build_flat_shaded_mesh`] but also emits a per-vertex UV
@@ -237,7 +237,7 @@ impl PolygonalFaceSetProcessor {
                 normals: flat_normals,
                 indices: flat_indices,
                 rtc_applied: false,
-                origin: [0.0; 3],            instance_meta: None, },
+                origin: [0.0; 3],            instance_meta: None, local_bounds: None, local_to_world: None },
             uvs,
         )
     }

--- a/rust/geometry/src/router/transforms/mesh_world.rs
+++ b/rust/geometry/src/router/transforms/mesh_world.rs
@@ -56,6 +56,30 @@ impl GeometryRouter {
         transform: &Matrix4<f64>,
         relativize: bool,
     ) {
+        // Local (pre-placement, object-space) AABB + the resolved placement
+        // itself (issue #1474): `mesh.positions` is still untouched here — both
+        // branches below only start mutating it in their own loops — so this is
+        // exactly the object-space extent `transform` is about to bake into
+        // world space. A single extra min/max pass, no allocation.
+        mesh.local_bounds = if mesh.positions.is_empty() {
+            None
+        } else {
+            let mut min = [f32::INFINITY; 3];
+            let mut max = [f32::NEG_INFINITY; 3];
+            for chunk in mesh.positions.chunks_exact(3) {
+                for k in 0..3 {
+                    if chunk[k] < min[k] {
+                        min[k] = chunk[k];
+                    }
+                    if chunk[k] > max[k] {
+                        max[k] = chunk[k];
+                    }
+                }
+            }
+            Some([min[0], min[1], min[2], max[0], max[1], max[2]])
+        };
+        mesh.local_to_world = Some(super::mat4_to_row_major(transform));
+
         let rtc = self.rtc_offset;
         let needs_rtc = self.has_rtc_offset() && !mesh.rtc_applied;
         let (rx, ry, rz) = if needs_rtc {
@@ -165,5 +189,66 @@ impl GeometryRouter {
             chunk[1] = t.y as f32;
             chunk[2] = t.z as f32;
         });
+    }
+}
+
+#[cfg(test)]
+mod local_bounds_tests {
+    //! Issue #1474: `local_bounds`/`local_to_world` must capture the mesh's
+    //! object-space extent and the exact placement `apply_placement` resolved,
+    //! independent of `origin` (a world-space AABB-centre translation captured
+    //! by this same function for an unrelated reason — f32 precision).
+    use super::super::mat4_to_row_major;
+    use super::*;
+    use crate::Mesh;
+    use nalgebra::{Rotation3, Translation3};
+
+    /// A unit box [0,1]^3, un-rotated, in object space.
+    fn unit_box() -> Mesh {
+        let mut mesh = Mesh::new();
+        mesh.positions = vec![
+            0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0,
+            1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0,
+        ];
+        mesh.normals = vec![0.0; mesh.positions.len()];
+        mesh.indices = (0..8).collect();
+        mesh
+    }
+
+    #[test]
+    fn captures_local_bounds_and_transform_independent_of_origin() {
+        // 90 degree rotation about Z, then translate far from the origin (so
+        // `mesh.origin`, a WORLD-space AABB-centre, ends up nowhere near the
+        // object-space [0,1]^3 box local_bounds must still report).
+        let rotation = Rotation3::from_axis_angle(&Vector3::z_axis(), std::f64::consts::FRAC_PI_2);
+        let translation = Translation3::new(1000.0, 2000.0, 3000.0);
+        let transform = translation.to_homogeneous() * rotation.to_homogeneous();
+
+        let router = GeometryRouter::new();
+
+        // Relativized path (local-frame origin factored out).
+        let mut mesh = unit_box();
+        router.transform_mesh_world_framed(&mut mesh, &transform, true);
+        assert_eq!(
+            mesh.local_bounds,
+            Some([0.0, 0.0, 0.0, 1.0, 1.0, 1.0]),
+            "local_bounds must be the pre-rotation object-space box, not the world box"
+        );
+        assert_eq!(
+            mesh.local_to_world,
+            Some(mat4_to_row_major(&transform)),
+            "local_to_world must be exactly the resolved placement"
+        );
+        assert_ne!(
+            mesh.origin, [0.0; 3],
+            "sanity: origin should have picked up the world-space translation"
+        );
+
+        // Absolute (non-relativized) path — same capture, different `origin` handling.
+        let mut mesh2 = unit_box();
+        router.transform_mesh_world_framed(&mut mesh2, &transform, false);
+        assert_eq!(mesh2.local_bounds, mesh.local_bounds);
+        assert_eq!(mesh2.local_to_world, mesh.local_to_world);
+        assert_eq!(mesh2.origin, [0.0; 3], "absolute path never sets origin");
     }
 }

--- a/rust/geometry/src/router/voids/geom.rs
+++ b/rust/geometry/src/router/voids/geom.rs
@@ -303,7 +303,7 @@ pub(super) fn rotate_mesh_into_frame(mesh: &Mesh, rt: &Matrix3<f64>, center: &Po
         rtc_applied: mesh.rtc_applied,
         origin: [0.0; 3],
         positions,
-    instance_meta: None, }
+    instance_meta: None, local_bounds: None, local_to_world: None }
 }
 
 /// Rotate a frame-F mesh into a LOCAL-FRAME world mesh: positions are `R·v_F` (small,
@@ -332,7 +332,7 @@ pub(super) fn rotate_mesh_from_frame(mesh: &Mesh, r: &Matrix3<f64>, center: &Poi
         indices: mesh.indices.clone(),
         rtc_applied: mesh.rtc_applied,
         origin: [center.x, center.y, center.z],
-    instance_meta: None, }
+    instance_meta: None, local_bounds: None, local_to_world: None }
 }
 
 /// Signed volume of a (closed) triangle mesh via the divergence theorem. Used to
@@ -828,6 +828,8 @@ pub(super) fn mesh_to_frame(mesh: &Mesh, axes: &[Vector3<f64>; 3], center: Vecto
         origin: mesh.origin,
         // Frame-transformed cut intermediate — not an instanceable occurrence.
         instance_meta: None,
+        local_bounds: None,
+        local_to_world: None,
     }
 }
 
@@ -855,6 +857,8 @@ pub(super) fn mesh_from_frame(mesh: &Mesh, axes: &[Vector3<f64>; 3], center: Vec
         origin: mesh.origin,
         // Frame-transformed cut intermediate — not an instanceable occurrence.
         instance_meta: None,
+        local_bounds: None,
+        local_to_world: None,
     }
 }
 

--- a/rust/geometry/src/router/voids/geom.rs
+++ b/rust/geometry/src/router/voids/geom.rs
@@ -303,6 +303,8 @@ pub(super) fn rotate_mesh_into_frame(mesh: &Mesh, rt: &Matrix3<f64>, center: &Po
         rtc_applied: mesh.rtc_applied,
         origin: [0.0; 3],
         positions,
+        // Frame-transformed cut intermediate — not an instanceable occurrence,
+        // and pre-placement (issue #1474 fields don't apply here either).
     instance_meta: None, local_bounds: None, local_to_world: None }
 }
 
@@ -332,6 +334,8 @@ pub(super) fn rotate_mesh_from_frame(mesh: &Mesh, r: &Matrix3<f64>, center: &Poi
         indices: mesh.indices.clone(),
         rtc_applied: mesh.rtc_applied,
         origin: [center.x, center.y, center.z],
+        // Frame-transformed cut intermediate — not an instanceable occurrence,
+        // and pre-placement (issue #1474 fields don't apply here either).
     instance_meta: None, local_bounds: None, local_to_world: None }
 }
 

--- a/rust/geometry/src/router/voids/mod.rs
+++ b/rust/geometry/src/router/voids/mod.rs
@@ -457,6 +457,8 @@ fn translate_cutter_mesh(mesh: &Mesh, host_origin: [f64; 3]) -> Mesh {
         rtc_applied: mesh.rtc_applied,
         origin: [0.0; 3],
         instance_meta: None,
+        local_bounds: None,
+        local_to_world: None,
     }
 }
 

--- a/rust/geometry/tests/issue_1109_budget.rs
+++ b/rust/geometry/tests/issue_1109_budget.rs
@@ -46,7 +46,7 @@ fn box_mesh(min: [f32; 3], max: [f32; 3]) -> Mesh {
         indices,
         rtc_applied: false,
         origin: [0.0; 3],
-    instance_meta: None, }
+    instance_meta: None, local_bounds: None, local_to_world: None }
 }
 
 /// A faceted "half-space" slab whose top face is tessellated into `n`×`n` quads,
@@ -102,7 +102,7 @@ fn faceted_slab(min: [f32; 3], max: [f32; 3], n: usize, z_top: f32) -> Mesh {
         indices,
         rtc_applied: false,
         origin: [0.0; 3],
-    instance_meta: None, }
+    instance_meta: None, local_bounds: None, local_to_world: None }
 }
 
 /// Total exact-tier escalations a sequence of cuts drives, under whatever caps are

--- a/rust/processing/src/element.rs
+++ b/rust/processing/src/element.rs
@@ -583,6 +583,14 @@ fn build_mesh_data(
     } else {
         None
     };
+    // Local bounds/placement transform (issue #1474): same caveat as instancing
+    // above — a site-local rotation re-transforms positions and would invalidate
+    // the captured placement, so drop both when one is active.
+    let (local_bounds, local_to_world) = if ctx.site_local_rotation.is_none() {
+        (mesh.local_bounds, mesh.local_to_world)
+    } else {
+        (None, None)
+    };
     let mut mesh_data = MeshData::new(
         job.id,
         job.ifc_type.name().to_string(),
@@ -592,7 +600,9 @@ fn build_mesh_data(
         color,
     )
     .with_origin(mesh_origin)
-    .with_instance(instance);
+    .with_instance(instance)
+    .with_local_bounds(local_bounds)
+    .with_local_to_world(local_to_world);
     if let Some(meta) = job.metadata {
         mesh_data = mesh_data
             .with_element_metadata(

--- a/rust/processing/src/style/indexed_colour.rs
+++ b/rust/processing/src/style/indexed_colour.rs
@@ -138,6 +138,8 @@ pub fn split_mesh_by_indexed_colour(
     let has_normals = mesh.normals.len() == mesh.positions.len();
     let rtc_applied = mesh.rtc_applied;
     let origin = mesh.origin;
+    let local_bounds = mesh.local_bounds;
+    let local_to_world = mesh.local_to_world;
 
     // One accumulator per palette entry; built lazily so empty groups vanish.
     #[derive(Default)]
@@ -192,6 +194,14 @@ pub fn split_mesh_by_indexed_colour(
                 rtc_applied,
                 origin,
                 instance_meta: None,
+                // Every split group shares the parent's placement (same element,
+                // just partitioned by colour), so both carry over unchanged. The
+                // parent's local_bounds is a superset of this group's actual
+                // extent, but that's fine — Scene.getEntityLocalBounds unions
+                // across an entity's pieces, and a union of identical supersets
+                // still yields the correct entity-level box. See issue #1474.
+                local_bounds,
+                local_to_world,
             };
             Some((map.colours[palette], mesh))
         })
@@ -219,6 +229,8 @@ mod tests {
             rtc_applied: false,
             origin: [0.0; 3],
             instance_meta: None,
+            local_bounds: None,
+            local_to_world: None,
         };
         let map = FullIndexedColourMap {
             geometry_id: 1,

--- a/rust/processing/src/types/mesh.rs
+++ b/rust/processing/src/types/mesh.rs
@@ -87,6 +87,16 @@ pub struct MeshData {
     /// and never round-trips through the JSON/disk cache.
     #[serde(skip)]
     pub instance: Option<InstanceMeta>,
+    /// Local (pre-placement, object-space) AABB (issue #1474) — see
+    /// `ifc_lite_geometry::Mesh::local_bounds`. Purely in-memory, like
+    /// `instance` — `#[serde(skip)]`, recomputed fresh each load.
+    #[serde(skip)]
+    pub local_bounds: Option<[f32; 6]>,
+    /// The resolved `IfcLocalPlacement` chain applied to this mesh (issue
+    /// #1474), row-major — see `ifc_lite_geometry::Mesh::local_to_world`.
+    /// Purely in-memory, like `instance` — `#[serde(skip)]`.
+    #[serde(skip)]
+    pub local_to_world: Option<[f64; 16]>,
 }
 
 fn geometry_class_is_occurrence(class: &u8) -> bool {
@@ -125,12 +135,26 @@ impl MeshData {
             geometry_class: 0,
             origin: [0.0; 3],
             instance: None,
+            local_bounds: None,
+            local_to_world: None,
         }
     }
 
     /// Attach GPU-instancing metadata (see the `instance` field).
     pub fn with_instance(mut self, instance: Option<InstanceMeta>) -> Self {
         self.instance = instance;
+        self
+    }
+
+    /// Set the local (pre-placement, object-space) AABB (see `local_bounds`).
+    pub fn with_local_bounds(mut self, local_bounds: Option<[f32; 6]>) -> Self {
+        self.local_bounds = local_bounds;
+        self
+    }
+
+    /// Set the resolved placement transform (see `local_to_world`).
+    pub fn with_local_to_world(mut self, local_to_world: Option<[f64; 16]>) -> Self {
+        self.local_to_world = local_to_world;
         self
     }
 

--- a/rust/wasm-bindings/src/zero_copy/mesh.rs
+++ b/rust/wasm-bindings/src/zero_copy/mesh.rs
@@ -170,14 +170,16 @@ impl MeshDataJs {
     }
 
     /// Local (pre-placement, object-space) AABB (issue #1474), WebGL Y-up,
-    /// `[minX,minY,minZ,maxX,maxY,maxZ]`. `null` when not captured.
+    /// `[minX,minY,minZ,maxX,maxY,maxZ]`. `undefined` when not captured
+    /// (wasm-bindgen maps `Option::None` to `undefined`, not `null`).
     #[wasm_bindgen(getter, js_name = localBounds)]
     pub fn local_bounds(&self) -> Option<Vec<f32>> {
         self.local_bounds.map(|b| b.to_vec())
     }
 
     /// The resolved `IfcLocalPlacement` chain for this mesh (issue #1474),
-    /// row-major 4×4, WebGL Y-up. `null` when not captured.
+    /// row-major 4×4, WebGL Y-up. `undefined` when not captured (see
+    /// `local_bounds` above).
     #[wasm_bindgen(getter, js_name = localToWorld)]
     pub fn local_to_world(&self) -> Option<Vec<f64>> {
         self.local_to_world.map(|m| m.to_vec())

--- a/rust/wasm-bindings/src/zero_copy/mesh.rs
+++ b/rust/wasm-bindings/src/zero_copy/mesh.rs
@@ -45,6 +45,13 @@ pub struct MeshDataJs {
     /// per-element AABB-centre relativization so building-scale coordinates stay
     /// f32-precise (no fan collapse). See `Mesh::origin`/transform_mesh_world_framed.
     origin: [f64; 3],
+    /// Local (pre-placement, object-space) AABB, WebGL Y-up (issue #1474):
+    /// `[minX,minY,minZ,maxX,maxY,maxZ]`. `None` when not captured (e.g. a
+    /// synthetic/from-meshes mesh). See `Mesh::local_bounds`.
+    local_bounds: Option<[f32; 6]>,
+    /// The resolved placement (`local_to_world`), row-major, WebGL Y-up (issue
+    /// #1474). `None` when not captured. See `Mesh::local_to_world`.
+    local_to_world: Option<[f64; 16]>,
 }
 
 #[wasm_bindgen]
@@ -161,6 +168,64 @@ impl MeshDataJs {
     pub fn origin(&self) -> js_sys::Float64Array {
         js_sys::Float64Array::from(&self.origin[..])
     }
+
+    /// Local (pre-placement, object-space) AABB (issue #1474), WebGL Y-up,
+    /// `[minX,minY,minZ,maxX,maxY,maxZ]`. `null` when not captured.
+    #[wasm_bindgen(getter, js_name = localBounds)]
+    pub fn local_bounds(&self) -> Option<Vec<f32>> {
+        self.local_bounds.map(|b| b.to_vec())
+    }
+
+    /// The resolved `IfcLocalPlacement` chain for this mesh (issue #1474),
+    /// row-major 4×4, WebGL Y-up. `null` when not captured.
+    #[wasm_bindgen(getter, js_name = localToWorld)]
+    pub fn local_to_world(&self) -> Option<Vec<f64>> {
+        self.local_to_world.map(|m| m.to_vec())
+    }
+}
+
+/// Swap an axis-aligned box's corners from IFC Z-up to WebGL Y-up
+/// (`(x,y,z) -> (x,z,-y)`). A per-component swap of `min`/`max` independently
+/// is WRONG: negating the Y axis flips which corner is the min/max along the
+/// new Z, so the new Z range is `[-maxY, -minY]`, not `[-minY, -maxY]`.
+fn swap_zup_to_yup_aabb(b: [f32; 6]) -> [f32; 6] {
+    let [min_x, min_y, min_z, max_x, max_y, max_z] = b;
+    [min_x, min_z, -max_y, max_x, max_z, -min_y]
+}
+
+/// Conjugate a row-major 4×4 matrix by the fixed IFC Z-up → WebGL Y-up swap
+/// `S`: `(x,y,z,w) -> (x,z,-y,w)`, so a placement/rotation matrix expressed in
+/// the IFC frame becomes valid in the Y-up frame the renderer uses:
+/// `M' = S · M · Sᵀ` (S is orthogonal, so `S⁻¹ = Sᵀ`).
+fn swap_zup_to_yup_mat4(m: &[f64; 16]) -> [f64; 16] {
+    #[rustfmt::skip]
+    const S: [f64; 16] = [
+        1.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, 1.0, 0.0,
+        0.0, -1.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, 1.0,
+    ];
+    #[rustfmt::skip]
+    const ST: [f64; 16] = [
+        1.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, -1.0, 0.0,
+        0.0, 1.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, 1.0,
+    ];
+    fn matmul(a: &[f64; 16], b: &[f64; 16]) -> [f64; 16] {
+        let mut out = [0.0; 16];
+        for r in 0..4 {
+            for c in 0..4 {
+                let mut sum = 0.0;
+                for k in 0..4 {
+                    sum += a[r * 4 + k] * b[k * 4 + c];
+                }
+                out[r * 4 + c] = sum;
+            }
+        }
+        out
+    }
+    matmul(&matmul(&S, m), &ST)
 }
 
 impl MeshDataJs {
@@ -200,6 +265,15 @@ impl MeshDataJs {
         // / displaced). Default [0,0,0] swaps to [0,0,0] (no-op for legacy).
         let origin = [mesh.origin[0], mesh.origin[2], -mesh.origin[1]];
 
+        // Local (pre-placement) AABB (issue #1474): same swap as positions, but
+        // an AABB corner can't be swapped component-wise — negating an axis
+        // flips which corner is min/max along it. See `swap_zup_to_yup_aabb`.
+        let local_bounds = mesh.local_bounds.map(swap_zup_to_yup_aabb);
+        // The placement transform (issue #1474) is conjugated by the same
+        // swap, since it's expressed in the IFC frame the positions were in
+        // before this conversion: M' = S · M · Sᵀ. See `swap_zup_to_yup_mat4`.
+        let local_to_world = mesh.local_to_world.map(|m| swap_zup_to_yup_mat4(&m));
+
         Self {
             express_id,
             ifc_type,
@@ -216,6 +290,8 @@ impl MeshDataJs {
             texture_repeat_t: true,
             geometry_class: 0,
             origin,
+            local_bounds,
+            local_to_world,
         }
     }
 
@@ -272,6 +348,10 @@ impl MeshDataJs {
             origin: m.origin,
             // Instancing side-channel is not used on this wasm zero-copy path.
             instance_meta: None,
+            // Local bounds/placement (issue #1474), still in the IFC frame —
+            // `new` applies the same Z-up→Y-up swap it applies to positions/origin.
+            local_bounds: m.local_bounds,
+            local_to_world: m.local_to_world,
         };
         let mut js = Self::new(m.express_id, m.ifc_type, mesh, m.color);
         js.set_geometry_class(m.geometry_class);
@@ -343,6 +423,8 @@ impl MeshCollection {
             texture_repeat_t: m.texture_repeat_t,
             geometry_class: m.geometry_class,
             origin: m.origin,
+            local_bounds: m.local_bounds,
+            local_to_world: m.local_to_world,
         })
     }
 
@@ -370,6 +452,8 @@ impl MeshCollection {
             texture_repeat_t: m.texture_repeat_t,
             geometry_class: m.geometry_class,
             origin: m.origin,
+            local_bounds: m.local_bounds,
+            local_to_world: m.local_to_world,
         })
     }
 
@@ -584,6 +668,8 @@ impl Clone for MeshCollection {
                     texture_repeat_t: m.texture_repeat_t,
                     geometry_class: m.geometry_class,
                     origin: m.origin,
+                    local_bounds: m.local_bounds,
+                    local_to_world: m.local_to_world,
                 })
                 .collect(),
             rtc_offset_x: self.rtc_offset_x,


### PR DESCRIPTION
Closes #1474

## Summary
- `Scene.getEntityLocalBounds(expressId)` — O(1) local (pre-placement, object-space) AABB, unioned across a multi-piece entity's mesh pieces (material layers / CSG parts share one local frame, so no reconciliation is needed). Falls back to the GPU-instancing template's local box for instanced entities.
- `Scene.getEntityTransform(expressId)` — the resolved `IfcLocalPlacement` chain, row-major 4×4, Y-up metres. Falls back to the specific occurrence's transform (read from the instance buffer, column-major, transposed) for instanced entities.
- Both return `null` for a container/assembly with no mesh, or when not captured (older cached geometry).

## Why this is cheap
`transform_mesh_world_framed` (`rust/geometry/src/router/transforms/mesh_world.rs`) already receives the fully-resolved placement matrix as a parameter and briefly holds the pre-transform, object-space positions before baking the placement in — both pieces were being computed and thrown away. This just retains them onto `Mesh.local_bounds`/`local_to_world`.

## Data flow
Rust `Mesh` → `rust/processing::MeshData` (`#[serde(skip)]`, session-only — same treatment as GPU-instancing metadata, no disk-cache/`FORMAT_VERSION` bump) → WASM zero-copy bindings (with the IFC Z-up → WebGL Y-up swap applied correctly: a naive per-component swap is wrong for an AABB corner — negating an axis flips which corner is min/max — and for the 4×4 it's a conjugation `M' = S·M·Sᵀ`, not a component permutation) → `MeshData.localBounds`/`localToWorld` (TS) → `Scene`.

## Out of scope
- Persisting to the disk/IndexedDB geometry cache (deliberately session-only for now, see the changeset).
- Aggregated local bounds for containers/assemblies with no own mesh (the issue marks this optional/secondary).

## Test plan
- [x] Rust: new `local_bounds_tests` in `mesh_world.rs` — asserts the captured box/transform match a synthetic rotated+translated mesh, independent of `mesh.origin`.
- [x] `cargo test -p ifc-lite-geometry -p ifc-lite-processing -p ifc-lite-wasm` — 100% green (414 + 33 + 12 unit tests + all integration suites), run natively AND via the `iflite-wasm-builder` Docker container (wasm32 toolchain).
- [x] WASM rebuilt via Docker (`wasm-pack build ... --release`); `packages/wasm/pkg/ifc-lite.d.ts` regenerated and committed.
- [x] TypeScript: new `scene-local-bounds.test.ts` (7 cases: null paths, single-piece, multi-piece union, transform passthrough) — green, plus the full existing `packages/renderer`/`packages/geometry` suites (180 + 114 tests) unaffected.
- [x] `tsc --noEmit` clean on `packages/geometry` and `packages/renderer` against the freshly rebuilt WASM types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `Scene.getEntityLocalBounds` and `Scene.getEntityTransform` to query per-entity object-space AABBs and resolved local→world transforms, including instanced entities.
  * Exposed optional `localBounds` / `localToWorld` on mesh data across geometry processing and WebAssembly/JS.
* **Bug Fixes**
  * Ensured local bounds and transforms are preserved through worker handoff, mesh splitting/streaming, and geometry conversions.
  * Improved swept geometry frame stability to reduce cross-section flipping at sharp bends.
* **Documentation**
  * Updated WASM package docs and the export example workflow.
* **Tests**
  * Expanded renderer and geometry processor test coverage for bounds/transform precision and matrix conventions.
* **Chores**
  * Bumped the WASM bindings package version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge — both new public methods are additive, session-only data flows correctly through all pipeline paths, and both previously-raised issues are resolved.

The new data is fully session-only (no FORMAT_VERSION bump, no disk cache involvement), the coordinate-frame conversions are mathematically correct, the instanced path now returns copies rather than live template references, and getEntityTransform returns Float64Array preserving full placement precision. Test coverage is thorough across all paths.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/renderer/src/scene.ts | Adds getEntityLocalBounds / getEntityTransform: flat-mesh path unions MeshData.localBounds correctly; instanced path copies template arrays to prevent mutation, returns Float64Array. |
| rust/geometry/src/router/transforms/mesh_world.rs | Captures local_bounds / local_to_world at the top of transform_mesh_world_framed before any position mutation; test suite verifies they are independent of the world-space origin. |
| rust/wasm-bindings/src/zero_copy/mesh.rs | Adds correct IFC Z-up to WebGL Y-up conversions: swap_zup_to_yup_aabb correctly handles axis-negation corner flip; swap_zup_to_yup_mat4 applies conjugation M' = S*M*ST. |
| rust/processing/src/style/indexed_colour.rs | Propagates parent local_bounds/local_to_world to each colour-split piece; correctly notes that unioning identical supersets in getEntityLocalBounds reproduces the entity-level box. |
| rust/processing/src/element.rs | Correctly drops both local_bounds and local_to_world when a site-local rotation is active, since the captured placement would be invalidated by the rotation. |
| packages/geometry/src/types.ts | Adds localBounds and localToWorld fields to MeshData with accurate documentation distinguishing them from the unrelated origin field. |
| packages/renderer/src/scene-local-bounds.test.ts | 7 cases covering null paths, single-piece, multi-piece union, instanced template copy, f64 precision preservation, and column-to-row-major transpose; regression test for the previous mutable-reference finding. |
| rust/geometry/src/mesh.rs | Adds local_bounds: Option<[f32;6]> and local_to_world: Option<[f64;16]> to Mesh struct; all literal constructors throughout the file updated to supply None defaults. |

<sub>Reviews (2): Last reviewed commit: ["fix(renderer): address Greptile review o..."](https://github.com/ltplus-ag/ifc-lite/commit/7f7a365914ff5954c92fa94be1764316a04cf7b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41204136)</sub>

<!-- /greptile_comment -->