### PR TITLE
fix: maturity quick wins (iflx determinism, NaN-safe sort, dead code, stale doc)

### DIFF
--- a/.changeset/iflx-deterministic-gzip-mtime.md
+++ b/.changeset/iflx-deterministic-gzip-mtime.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/extensions": patch
+---
+
+Pin the gzip MTIME header to 0 in `packBundle` so `.iflx` bytes are deterministic for the same input. Previously the header embedded wall-clock seconds, so re-packing identical content in a different second produced a different content-addressed bundle hash (and flaked the determinism test). Matches the fix already shipped in the flavor packer.

--- a/packages/extensions/src/bundle/iflx.test.ts
+++ b/packages/extensions/src/bundle/iflx.test.ts
@@ -48,6 +48,17 @@ describe('packBundle / unpackBundle', () => {
     expect(Buffer.from(a).toString('hex')).toBe(Buffer.from(b).toString('hex'));
   });
 
+  it('zeroes the gzip MTIME header so packed bytes are time-independent', async () => {
+    // Bytes 4..8 of a gzip stream are the 4-byte MTIME field. Without
+    // { mtime: 0 } fflate stamps wall-clock seconds there, so identical
+    // content packed in different seconds hashes differently. Assert the
+    // invariant directly instead of relying on two packs landing in the
+    // same second.
+    const original = await loadGood();
+    const packed = packBundle(original);
+    expect(Array.from(packed.subarray(4, 8))).toEqual([0, 0, 0, 0]);
+  });
+
   it('sets source kind to iflx after unpack', async () => {
     const original = await loadGood();
     const packed = packBundle(original);

--- a/packages/extensions/src/bundle/iflx.ts
+++ b/packages/extensions/src/bundle/iflx.ts
@@ -76,7 +76,11 @@ export function packBundle(bundle: Bundle, signature?: SignatureBlock): Uint8Arr
     ...(signature ? { signature } : {}),
   };
   const json = JSON.stringify(envelope);
-  return gzipSync(new TextEncoder().encode(json));
+  // Pin mtime to 0 so the gzip header doesn't embed wall-clock time:
+  // otherwise two packs of identical content straddling a second boundary
+  // differ in the 4-byte MTIME field, flaking the determinism test and
+  // breaking the content-addressed bundle hash the loader verifies.
+  return gzipSync(new TextEncoder().encode(json), { mtime: 0 });
 }
 
 /**

--- a/rust/geometry/src/congruence/engine.rs
+++ b/rust/geometry/src/congruence/engine.rs
@@ -129,7 +129,10 @@ pub(super) fn signature_keys(w: &Welded) -> Vec<u64> {
     cov /= w.verts.len() as f64;
     let eig = cov.symmetric_eigenvalues();
     let mut ev = [eig[0], eig[1], eig[2]];
-    ev.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    // total_cmp: a NaN/inf vertex coordinate yields a NaN eigenvalue, and
+    // partial_cmp().unwrap() would panic on it (NaN sorts deterministically
+    // to one end instead).
+    ev.sort_by(|a, b| a.total_cmp(b));
     // relative quantisation: eigenvalues scale with size^2; use a log-ish grid.
     let q = |x: f64| -> [i64; 2] {
         let s = (x.max(0.0)).sqrt(); // characteristic length
@@ -504,7 +507,7 @@ fn pca_frame(verts: &[Vector3<f64>]) -> Option<Matrix3<f64>> {
     let eig = nalgebra::SymmetricEigen::new(cov);
     // sort eigenvectors by eigenvalue
     let mut idx = [0usize, 1, 2];
-    idx.sort_by(|&a, &b| eig.eigenvalues[a].partial_cmp(&eig.eigenvalues[b]).unwrap());
+    idx.sort_by(|&a, &b| eig.eigenvalues[a].total_cmp(&eig.eigenvalues[b]));
     let mut f: Matrix3<f64> = Matrix3::zeros();
     for (k, &i) in idx.iter().enumerate() {
         let col: Vector3<f64> = eig.eigenvectors.column(i).into_owned();

--- a/rust/geometry/src/congruence/engine.rs
+++ b/rust/geometry/src/congruence/engine.rs
@@ -42,6 +42,13 @@ pub(super) fn build_welded(mesh: &Mesh) -> Option<Welded> {
     if nv < 4 || nv > MAX_VERTS || w.indices.is_empty() {
         return None;
     }
+    // Reject non-finite coordinates outright: a NaN/inf vertex poisons the
+    // centroid and covariance (NaN eigenvalues), and verify's max-deviation
+    // fold is NaN-blind (`NaN > max_dev` is false), so a malformed mesh could
+    // otherwise bucket AND pass verification with a NaN canonical transform.
+    if w.positions.iter().any(|v| !v.is_finite()) {
+        return None;
+    }
     let mut verts: Vec<Vector3<f64>> = Vec::with_capacity(nv);
     let mut c = Vector3::zeros();
     for i in 0..nv {

--- a/rust/geometry/src/congruence/tests.rs
+++ b/rust/geometry/src/congruence/tests.rs
@@ -227,3 +227,19 @@ fn translated_copy_merges() {
     }
     assert!(safe_merge(&a, &b), "a translated copy must merge");
 }
+
+#[test]
+fn nan_vertex_does_not_panic() {
+    // A NaN/inf coordinate propagates through the centroid into the covariance
+    // eigenvalues; the eigenvalue sorts in signature_keys and the PCA eigenframe
+    // must use total_cmp (partial_cmp().unwrap() panicked on NaN). The invariant
+    // here is "no unwind", not any particular bucketing outcome.
+    let mut m = tetra();
+    m.positions.extend_from_slice(&[f32::NAN, 0.5, 0.5]);
+    m.normals.extend_from_slice(&[0.0, 0.0, 0.0]);
+    m.indices.extend_from_slice(&[0, 1, 4]);
+    if let Some(w) = build_welded(&m) {
+        let _ = signature_keys(&w);
+        let _ = verify(&w, &w);
+    }
+}

--- a/rust/geometry/src/congruence/tests.rs
+++ b/rust/geometry/src/congruence/tests.rs
@@ -229,17 +229,23 @@ fn translated_copy_merges() {
 }
 
 #[test]
-fn nan_vertex_does_not_panic() {
-    // A NaN/inf coordinate propagates through the centroid into the covariance
-    // eigenvalues; the eigenvalue sorts in signature_keys and the PCA eigenframe
-    // must use total_cmp (partial_cmp().unwrap() panicked on NaN). The invariant
-    // here is "no unwind", not any particular bucketing outcome.
+fn non_finite_vertex_mesh_is_rejected() {
+    // A NaN/inf coordinate poisons the centroid/covariance (NaN eigenvalues;
+    // the pre-fix partial_cmp().unwrap() sorts panicked on them) and verify's
+    // max-deviation fold is NaN-blind, so a malformed mesh could bucket AND
+    // pass verification with a NaN canonical transform. build_welded is the
+    // single entry to the pipeline and must reject it outright; the total_cmp
+    // sorts stay as defense-in-depth for values arising later.
     let mut m = tetra();
     m.positions.extend_from_slice(&[f32::NAN, 0.5, 0.5]);
     m.normals.extend_from_slice(&[0.0, 0.0, 0.0]);
     m.indices.extend_from_slice(&[0, 1, 4]);
-    if let Some(w) = build_welded(&m) {
-        let _ = signature_keys(&w);
-        let _ = verify(&w, &w);
-    }
+    assert!(build_welded(&m).is_none(), "NaN-vertex mesh must be rejected");
+
+    let mut inf = tetra();
+    inf.positions[0] = f32::INFINITY;
+    assert!(build_welded(&inf).is_none(), "inf-vertex mesh must be rejected");
+
+    // Finite meshes are unaffected by the gate.
+    assert!(build_welded(&tetra()).is_some());
 }

--- a/rust/geometry/src/mesh.rs
+++ b/rust/geometry/src/mesh.rs
@@ -232,40 +232,6 @@ impl Mesh {
         self.normals.push(normal.z as f32);
     }
 
-    /// Add a vertex with normal, applying coordinate shift in f64 BEFORE f32 conversion
-    /// This preserves precision for large coordinates (georeferenced models)
-    ///
-    /// # Arguments
-    /// * `position` - Vertex position in world coordinates (f64)
-    /// * `normal` - Vertex normal
-    /// * `shift` - Coordinate shift to subtract (in f64) before converting to f32
-    ///
-    /// # Precision
-    /// For coordinates like 5,000,000m (Swiss UTM), direct f32 conversion loses ~1m precision.
-    /// By subtracting the centroid first (in f64), we convert small values (0-100m range)
-    /// which preserves sub-millimeter precision.
-    #[inline]
-    pub fn add_vertex_with_shift(
-        &mut self,
-        position: Point3<f64>,
-        normal: Vector3<f64>,
-        shift: &CoordinateShift,
-    ) {
-        // Subtract shift in f64 precision BEFORE converting to f32
-        // This is the key to preserving precision for large coordinates
-        let shifted_x = position.x - shift.x;
-        let shifted_y = position.y - shift.y;
-        let shifted_z = position.z - shift.z;
-
-        self.positions.push(shifted_x as f32);
-        self.positions.push(shifted_y as f32);
-        self.positions.push(shifted_z as f32);
-
-        self.normals.push(normal.x as f32);
-        self.normals.push(normal.y as f32);
-        self.normals.push(normal.z as f32);
-    }
-
     /// Apply coordinate shift to existing positions in-place
     /// Uses f64 intermediate for precision when subtracting large offsets
     #[inline]
@@ -1171,45 +1137,6 @@ mod tests {
         let zero_shift = CoordinateShift::default();
         assert!(!zero_shift.is_significant());
         assert!(zero_shift.is_zero());
-    }
-
-    #[test]
-    fn test_add_vertex_with_shift_preserves_precision() {
-        // Test case: Swiss UTM coordinates (typical large coordinate scenario)
-        // Without shifting: 5000000.123 as f32 = 5000000.0 (loses 0.123m precision!)
-        // With shifting: (5000000.123 - 5000000.0) as f32 = 0.123 (full precision preserved)
-
-        let mut mesh = Mesh::new();
-
-        // Large coordinates typical of Swiss UTM (EPSG:2056)
-        let p1 = Point3::new(2679012.123456, 1247892.654321, 432.111);
-        let p2 = Point3::new(2679012.223456, 1247892.754321, 432.211);
-
-        // Create shift from approximate centroid
-        let shift = CoordinateShift::new(2679012.0, 1247892.0, 432.0);
-
-        mesh.add_vertex_with_shift(p1, Vector3::z(), &shift);
-        mesh.add_vertex_with_shift(p2, Vector3::z(), &shift);
-
-        // Verify shifted positions have sub-millimeter precision
-        // p1 shifted: (0.123456, 0.654321, 0.111)
-        // p2 shifted: (0.223456, 0.754321, 0.211)
-        assert!((mesh.positions[0] - 0.123456).abs() < 0.0001); // X1
-        assert!((mesh.positions[1] - 0.654321).abs() < 0.0001); // Y1
-        assert!((mesh.positions[2] - 0.111).abs() < 0.0001); // Z1
-        assert!((mesh.positions[3] - 0.223456).abs() < 0.0001); // X2
-        assert!((mesh.positions[4] - 0.754321).abs() < 0.0001); // Y2
-        assert!((mesh.positions[5] - 0.211).abs() < 0.0001); // Z2
-
-        // Verify relative distances are preserved with high precision
-        let dx = mesh.positions[3] - mesh.positions[0];
-        let dy = mesh.positions[4] - mesh.positions[1];
-        let dz = mesh.positions[5] - mesh.positions[2];
-
-        // Expected: dx=0.1, dy=0.1, dz=0.1
-        assert!((dx - 0.1).abs() < 0.0001);
-        assert!((dy - 0.1).abs() < 0.0001);
-        assert!((dz - 0.1).abs() < 0.0001);
     }
 
     #[test]

--- a/rust/geometry/src/router/transforms/mod.rs
+++ b/rust/geometry/src/router/transforms/mod.rs
@@ -19,10 +19,11 @@ use nalgebra::Matrix4;
 /// When ON, `transform_mesh_world` stores positions relative to a per-element
 /// f64 `origin` (so f32 coords stay element-small and never collapse to
 /// degenerate fans at building/georef scale), and the void CSG runs in that same
-/// local frame. The renderer + WASM + cache must all consume `MeshData.origin`
-/// (world = origin + position) for this to render correctly — so it stays OFF by
-/// default until that whole stack ships, then flips on. `IFC_LITE_LOCAL_FRAME=1`
-/// enables it for native verification meanwhile. Read once and cached.
+/// local frame. The renderer, WASM boundary, and cache all consume
+/// `MeshData.origin` (world = origin + position), so the flag is ON by default
+/// for the wasm/viewer build (the precision-critical target). Native and server
+/// stay env-gated via `IFC_LITE_LOCAL_FRAME` to keep cross-arch determinism
+/// snapshots absolute-coord byte-identical. Read once and cached.
 pub(crate) fn local_frame_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| {


### PR DESCRIPTION
Four small, independent hardening fixes (each its own commit):

1. **.iflx gzip MTIME pinned to 0** (`packages/extensions/src/bundle/iflx.ts`): fflate stamps wall-clock seconds into the gzip header by default, so identical content packed in different seconds hashed differently. This flaked the byte-determinism test and made the content-addressed `bundleHash` (verified fail-closed on every load) non-reproducible. Mirrors the fix already shipped in the flavor packer; adds a direct MTIME-bytes regression assertion plus a changeset.
2. **NaN-safe eigenvalue sorts** (`rust/geometry/src/congruence/engine.rs:132,507`): `partial_cmp().unwrap()` panics on the NaN eigenvalues a NaN/inf vertex coordinate produces. Replaced with `total_cmp` (total order, never panics). Only affects the env-flag-gated instancing-analysis path; default-on geometry output untouched. New no-panic regression test.
3. **Delete dead `add_vertex_with_shift`** (`rust/geometry/src/mesh.rs`): superseded by the batch AABB-origin local frame in `mesh_world.rs`; its only caller was its own unit test. `CoordinateShift`/`apply_shift` remain (still live).
4. **Fix stale `local_frame_enabled` doc comment** (`rust/geometry/src/router/transforms/mod.rs`): the comment claimed the flag stays OFF by default until the consumer stack ships; the stack shipped (#1114) and the code returns `true` for wasm. Comment now matches the code (and drops the em dash).

## Verification
- `pnpm --filter @ifc-lite/extensions test`: 588/588 pass (incl. new MTIME assertion)
- `cargo test -p ifc-lite-geometry --lib` (congruence + mesh) and the new `nan_vertex_does_not_panic`: pass
- `cargo test -p ifc-lite-geometry --test exact_predicate_determinism --test geometry_correctness_harness`: pass (no snapshot churn)
- `cargo clippy -p ifc-lite-geometry --all-targets -- -D warnings`: clean

No geometry output, determinism snapshot, manifest, or cache FORMAT_VERSION change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made packed bundle output deterministic by pinning gzip `mtime` to eliminate time-dependent hash changes.
  * Improved robustness of geometry processing by rejecting meshes with non-finite vertex data and avoiding crashes during eigen computations.
* **Tests**
  * Added coverage to verify deterministic bundle gzip bytes.
  * Added unit tests to ensure non-finite vertex meshes are rejected.
* **Chores**
  * Updated documentation for local-frame vertex precision behavior to match renderer/WASM expectations.
  * Removed an obsolete mesh vertex helper in favor of the current coordinate-shift workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

All four changes are narrow, well-tested, and non-breaking; no geometry output, determinism snapshots, or public API is altered.

Each fix targets a specific, clearly-described defect with a corresponding regression test, and the changes are confined to either a TypeScript serialisation path or a Rust instancing-analysis sub-path that is off by default on non-wasm targets.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .changeset/iflx-deterministic-gzip-mtime.md | New changeset entry for the gzip MTIME determinism fix; accurately describes the patch. |
| packages/extensions/src/bundle/iflx.ts | Adds `{ mtime: 0 }` to `gzipSync` call to pin the gzip MTIME header, making packed bytes fully deterministic regardless of wall-clock time. |
| packages/extensions/src/bundle/iflx.test.ts | New test directly asserts bytes 4–7 of the gzip stream are zero, providing a regression guard for the MTIME fix independent of timing. |
| rust/geometry/src/congruence/engine.rs | Two `partial_cmp().unwrap()` calls on eigenvalue arrays replaced with `total_cmp`; NaN/inf vertex guard added early in `build_welded` with a thorough comment explaining the NaN-blind verification path. |
| rust/geometry/src/congruence/tests.rs | New `non_finite_vertex_mesh_is_rejected` test exercises NaN and inf inputs directly with `assert!(build_welded(...).is_none())`, also guards that finite meshes still pass. |
| rust/geometry/src/mesh.rs | Dead `add_vertex_with_shift` method and its sole unit test removed; `CoordinateShift`/`apply_shift` remain untouched. |
| rust/geometry/src/router/transforms/mod.rs | Doc comment for `local_frame_enabled` updated to match the current behaviour (ON by default for wasm, env-gated for native); no logic changed. |

<sub>Reviews (2): Last reviewed commit: ["fix(geometry): reject non-finite meshes ..."](https://github.com/ltplus-ag/ifc-lite/commit/3281b3bb80c821fe3862e74ea378c929194b0fe8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41192816)</sub>

<!-- /greptile_comment -->