### PR TITLE
test(parity): shared unit-scale golden + site-local rotation goldens

### DIFF
--- a/packages/parser/src/unit-scale.parity.test.ts
+++ b/packages/parser/src/unit-scale.parity.test.ts
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { extractLengthUnitScale } from './unit-extractor.js';
+import type { EntityIndex, EntityRef } from './types.js';
+
+// The Rust extractor (rust/core/src/units.rs) and this TS extractor are pinned
+// to ONE shared vector file so the two cannot drift. The fixture lives in the
+// core crate; skip gracefully if this package is tested outside the monorepo.
+const fixturePath = fileURLToPath(
+  new URL('../../../rust/core/tests/fixtures/unit_scale_vectors.json', import.meta.url),
+);
+
+interface Vector {
+  name: string;
+  /** Minimal but complete ISO-10303-21 file containing the unit chain. */
+  ifc: string;
+  /** Multiplier that converts file length units to metres. */
+  lengthUnitScale: number;
+}
+
+/** Build source bytes + EntityIndex over a complete IFC STEP file string. */
+function indexIfc(content: string): { source: Uint8Array; entityIndex: EntityIndex } {
+  const source = new TextEncoder().encode(content);
+  const byId = new Map<number, EntityRef>();
+  const byType = new Map<string, number[]>();
+  const re = /^#(\d+)=([A-Z0-9_]+)\(/;
+  let offset = 0;
+  let lineNumber = 0;
+  for (const line of content.split('\n')) {
+    lineNumber += 1;
+    const m = re.exec(line);
+    if (m) {
+      const expressId = Number(m[1]);
+      const type = m[2];
+      const ref: EntityRef = {
+        expressId,
+        type,
+        byteOffset: offset,
+        byteLength: line.length,
+        lineNumber,
+      };
+      byId.set(expressId, ref);
+      const list = byType.get(type) ?? [];
+      list.push(expressId);
+      byType.set(type, list);
+    }
+    offset += line.length + 1; // +1 for '\n' (fixtures are pure ASCII)
+  }
+  return { source, entityIndex: { byId, byType } };
+}
+
+describe.skipIf(!existsSync(fixturePath))('extractLengthUnitScale shared parity vectors', () => {
+  const cases = (JSON.parse(readFileSync(fixturePath, 'utf8')) as { cases: Vector[] }).cases;
+
+  it('fixture has cases', () => {
+    expect(cases.length).toBeGreaterThan(0);
+  });
+
+  for (const c of cases) {
+    it(`matches the Rust extractor: ${c.name}`, () => {
+      const { source, entityIndex } = indexIfc(c.ifc);
+      expect(extractLengthUnitScale(source, entityIndex)).toBeCloseTo(c.lengthUnitScale, 12);
+    });
+  }
+});

--- a/packages/parser/src/unit-scale.parity.test.ts
+++ b/packages/parser/src/unit-scale.parity.test.ts
@@ -55,7 +55,12 @@ function indexIfc(content: string): { source: Uint8Array; entityIndex: EntityInd
 }
 
 describe.skipIf(!existsSync(fixturePath))('extractLengthUnitScale shared parity vectors', () => {
-  const cases = (JSON.parse(readFileSync(fixturePath, 'utf8')) as { cases: Vector[] }).cases;
+  // Guarded read: with skipIf active (fixture absent outside the monorepo)
+  // the describe body still executes at collection time, so an unguarded
+  // readFileSync would hard-fail instead of skipping.
+  const cases = existsSync(fixturePath)
+    ? (JSON.parse(readFileSync(fixturePath, 'utf8')) as { cases: Vector[] }).cases
+    : [];
 
   it('fixture has cases', () => {
     expect(cases.length).toBeGreaterThan(0);

--- a/rust/core/tests/fixtures/unit_scale_vectors.json
+++ b/rust/core/tests/fixtures/unit_scale_vectors.json
@@ -1,0 +1,45 @@
+{
+  "_comment": "Shared length-unit-scale test vectors for the Rust extractor (rust/core/src/units.rs extract_length_unit_scale) and the TS extractor (packages/parser/src/unit-extractor.ts extractLengthUnitScale). Each case is a minimal but complete ISO-10303-21 file; lengthUnitScale is the multiplier that converts file length units to metres. Both extractors must agree on every case. All fixtures are synthetic.",
+  "cases": [
+    {
+      "name": "si_millimetre",
+      "ifc": "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('t.ifc','2026-01-01T00:00:00',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n#1=IFCPROJECT('0001projectaaaaaaaaaaa',$,'P',$,$,$,$,$,#2);\n#2=IFCUNITASSIGNMENT((#3));\n#3=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);\nENDSEC;\nEND-ISO-10303-21;\n",
+      "lengthUnitScale": 0.001
+    },
+    {
+      "name": "si_metre_no_prefix",
+      "ifc": "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('t.ifc','2026-01-01T00:00:00',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n#1=IFCPROJECT('0001projectaaaaaaaaaaa',$,'P',$,$,$,$,$,#2);\n#2=IFCUNITASSIGNMENT((#3));\n#3=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);\nENDSEC;\nEND-ISO-10303-21;\n",
+      "lengthUnitScale": 1.0
+    },
+    {
+      "name": "si_centimetre",
+      "ifc": "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('t.ifc','2026-01-01T00:00:00',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n#1=IFCPROJECT('0001projectaaaaaaaaaaa',$,'P',$,$,$,$,$,#2);\n#2=IFCUNITASSIGNMENT((#3));\n#3=IFCSIUNIT(*,.LENGTHUNIT.,.CENTI.,.METRE.);\nENDSEC;\nEND-ISO-10303-21;\n",
+      "lengthUnitScale": 0.01
+    },
+    {
+      "name": "conversion_foot_by_name",
+      "ifc": "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('t.ifc','2026-01-01T00:00:00',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n#1=IFCPROJECT('0001projectaaaaaaaaaaa',$,'P',$,$,$,$,$,#2);\n#2=IFCUNITASSIGNMENT((#3));\n#3=IFCCONVERSIONBASEDUNIT(#4,.LENGTHUNIT.,'FOOT',#5);\n#4=IFCDIMENSIONALEXPONENTS(1,0,0,0,0,0,0);\n#5=IFCMEASUREWITHUNIT(IFCLENGTHMEASURE(0.3048),#6);\n#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);\nENDSEC;\nEND-ISO-10303-21;\n",
+      "lengthUnitScale": 0.3048
+    },
+    {
+      "name": "conversion_inch_by_name",
+      "ifc": "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('t.ifc','2026-01-01T00:00:00',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n#1=IFCPROJECT('0001projectaaaaaaaaaaa',$,'P',$,$,$,$,$,#2);\n#2=IFCUNITASSIGNMENT((#3));\n#3=IFCCONVERSIONBASEDUNIT(#4,.LENGTHUNIT.,'INCH',#5);\n#4=IFCDIMENSIONALEXPONENTS(1,0,0,0,0,0,0);\n#5=IFCMEASUREWITHUNIT(IFCLENGTHMEASURE(0.0254),#6);\n#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);\nENDSEC;\nEND-ISO-10303-21;\n",
+      "lengthUnitScale": 0.0254
+    },
+    {
+      "name": "late_project_after_units",
+      "ifc": "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('t.ifc','2026-01-01T00:00:00',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n#10=IFCCARTESIANPOINT((0.,0.,0.));\n#11=IFCSIUNIT(*,.AREAUNIT.,$,.SQUARE_METRE.);\n#12=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);\n#13=IFCUNITASSIGNMENT((#11,#12));\n#20=IFCWALL('0002wallbbbbbbbbbbbbbb',$,'W',$,$,$,$,$,$);\n#100=IFCPROJECT('0001projectaaaaaaaaaaa',$,'P',$,$,$,$,$,#13);\nENDSEC;\nEND-ISO-10303-21;\n",
+      "lengthUnitScale": 0.001
+    },
+    {
+      "name": "no_length_unit_defaults_to_metres",
+      "ifc": "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('t.ifc','2026-01-01T00:00:00',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n#1=IFCPROJECT('0001projectaaaaaaaaaaa',$,'P',$,$,$,$,$,#2);\n#2=IFCUNITASSIGNMENT((#3));\n#3=IFCSIUNIT(*,.AREAUNIT.,$,.SQUARE_METRE.);\nENDSEC;\nEND-ISO-10303-21;\n",
+      "lengthUnitScale": 1.0
+    },
+    {
+      "name": "conversion_custom_via_measure_with_milli_component",
+      "ifc": "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('t.ifc','2026-01-01T00:00:00',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n#1=IFCPROJECT('0001projectaaaaaaaaaaa',$,'P',$,$,$,$,$,#2);\n#2=IFCUNITASSIGNMENT((#3));\n#3=IFCCONVERSIONBASEDUNIT(#4,.LENGTHUNIT.,'CUSTOM_UNIT',#5);\n#4=IFCDIMENSIONALEXPONENTS(1,0,0,0,0,0,0);\n#5=IFCMEASUREWITHUNIT(IFCLENGTHMEASURE(25.4),#6);\n#6=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);\nENDSEC;\nEND-ISO-10303-21;\n",
+      "lengthUnitScale": 0.0254
+    }
+  ]
+}

--- a/rust/core/tests/unit_scale_parity.rs
+++ b/rust/core/tests/unit_scale_parity.rs
@@ -1,0 +1,60 @@
+//! Pins the Rust length-unit-scale extractor to the shared cross-language test
+//! vectors in `tests/fixtures/unit_scale_vectors.json`. The TypeScript extractor
+//! in `@ifc-lite/parser` (`packages/parser/src/unit-scale.parity.test.ts`) is
+//! held to the same fixture, so the two cannot drift.
+
+use ifc_lite_core::{
+    extract_length_unit_scale, try_extract_length_unit_scale, EntityDecoder, EntityScanner,
+};
+
+/// Locate the first IFCPROJECT id the way the real pipeline does: from the
+/// entity scan (ordering-independent, so the late-project case works).
+fn find_project_id(ifc: &str) -> Option<u32> {
+    let mut scanner = EntityScanner::new(ifc);
+    while let Some((id, type_name, _start, _end)) = scanner.next_entity() {
+        if type_name == "IFCPROJECT" {
+            return Some(id);
+        }
+    }
+    None
+}
+
+#[test]
+fn rust_unit_scale_matches_shared_vectors() {
+    let raw = include_str!("fixtures/unit_scale_vectors.json");
+    let doc: serde_json::Value = serde_json::from_str(raw).expect("fixture is valid JSON");
+    let cases = doc["cases"].as_array().expect("cases is an array");
+    assert!(!cases.is_empty(), "fixture has at least one case");
+
+    for case in cases {
+        let name = case["name"].as_str().unwrap_or("<unnamed>");
+        let ifc = case["ifc"].as_str().expect("ifc is a string");
+        let expected = case["lengthUnitScale"]
+            .as_f64()
+            .expect("lengthUnitScale is a number");
+
+        let project_id = find_project_id(ifc)
+            .unwrap_or_else(|| panic!("case `{name}`: fixture must contain an IFCPROJECT"));
+
+        let mut decoder = EntityDecoder::new(ifc);
+        let got = extract_length_unit_scale(&mut decoder, project_id)
+            .unwrap_or_else(|e| panic!("case `{name}`: extraction failed: {e:?}"));
+
+        // Relative tolerance: every expected scale is a positive constant.
+        let tol = expected.abs() * 1e-12;
+        assert!(
+            (got - expected).abs() <= tol,
+            "case `{name}`: got {got}, want {expected}"
+        );
+
+        // The streaming pre-pass sibling must never CONTRADICT the full
+        // extractor: on a complete index it either resolves to the same scale
+        // or defers (None, e.g. for conversion-based length units).
+        if let Some(pre) = try_extract_length_unit_scale(&mut decoder, project_id) {
+            assert!(
+                (pre - expected).abs() <= tol,
+                "case `{name}`: try_extract_length_unit_scale got {pre}, want {expected}"
+            );
+        }
+    }
+}

--- a/rust/core/tests/unit_scale_parity.rs
+++ b/rust/core/tests/unit_scale_parity.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Pins the Rust length-unit-scale extractor to the shared cross-language test
 //! vectors in `tests/fixtures/unit_scale_vectors.json`. The TypeScript extractor
 //! in `@ifc-lite/parser` (`packages/parser/src/unit-scale.parity.test.ts`) is

--- a/rust/processing/tests/site_rotation.rs
+++ b/rust/processing/tests/site_rotation.rs
@@ -1,0 +1,283 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Golden tests for the site-local coordinate-space tier: the three-tier
+//! selection in `processor/mod.rs` plus the inverse rotation applied by
+//! `processor/site_local.rs::convert_mesh_to_site_local`.
+//!
+//! The identity path is already covered by `geometry_data_export_test.rs`;
+//! this pins the previously untested NON-identity rotation path: an IfcSite
+//! placed with a 30 degree yaw about Z and a non-zero translation must yield
+//! meshes expressed in the site-local frame (positions and normals inverse
+//! rotated, the site translation carried as the RTC offset), with unit-length
+//! normals. Uses INLINE minimal IFC (one 4 x 1 x 2 extruded box placed
+//! relative to the site) so the test runs in CI without external fixtures.
+
+use ifc_lite_processing::{process_geometry, MeshData, ProcessingResult};
+
+/// Box dimensions in the element's local frame (metres).
+const BOX: [f64; 3] = [4.0, 1.0, 2.0];
+/// Site placement translation for the non-identity fixtures (metres).
+const SITE_T: [f64; 3] = [10.0, 20.0, 0.0];
+/// f32 mesh positions folded back to f64: ~1 ulp at coordinate magnitude 4.
+const EPS: f64 = 1e-5;
+
+/// Minimal IFC4 model: one IfcBuildingElementProxy, a 4 x 1 x 2 box extruded
+/// from the origin, placed RELATIVE to the IfcSite placement (#34), metre
+/// units. `site_placement` supplies the #30..#33 placement entities so each
+/// test can vary the site location/rotation without duplicating the body.
+fn model(site_placement: &str) -> String {
+    format!(
+        r##"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-01-01T00:00:00',(''),(''),'test','test','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#2=IFCUNITASSIGNMENT((#1));
+#3=IFCCARTESIANPOINT((0.,0.,0.));
+#4=IFCAXIS2PLACEMENT3D(#3,$,$);
+#5=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-06,#4,$);
+#6=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body','Model',*,*,*,*,#5,$,.MODEL_VIEW.,$);
+#7=IFCPROJECT('11tEAnIV5BixApwp1YzpwS',$,'t',$,$,$,$,(#5),#2);
+{site_placement}
+#34=IFCLOCALPLACEMENT($,#33);
+#35=IFCSITE('1s1tEAnIV5BixApwp1Yzp0',$,'site',$,$,#34,$,$,.ELEMENT.,$,$,$,$,$);
+#8=IFCCARTESIANPOINT((0.,0.));
+#9=IFCCARTESIANPOINT((4.,0.));
+#10=IFCCARTESIANPOINT((4.,1.));
+#11=IFCCARTESIANPOINT((0.,1.));
+#12=IFCPOLYLINE((#8,#9,#10,#11,#8));
+#13=IFCARBITRARYCLOSEDPROFILEDEF(.AREA.,$,#12);
+#14=IFCCARTESIANPOINT((0.,0.,0.));
+#15=IFCAXIS2PLACEMENT3D(#14,$,$);
+#16=IFCDIRECTION((0.,0.,1.));
+#17=IFCEXTRUDEDAREASOLID(#13,#15,#16,2.);
+#18=IFCSHAPEREPRESENTATION(#6,'Body','SweptSolid',(#17));
+#19=IFCPRODUCTDEFINITIONSHAPE($,$,(#18));
+#20=IFCCARTESIANPOINT((0.,0.,0.));
+#21=IFCAXIS2PLACEMENT3D(#20,$,$);
+#22=IFCLOCALPLACEMENT(#34,#21);
+#23=IFCBUILDINGELEMENTPROXY('36FTsOKg956eWgO6DwnT8U',$,'box',$,$,#22,#19,$,$);
+ENDSEC;
+END-ISO-10303-21;
+"##
+    )
+}
+
+/// Site rotated 30 degrees about Z (RefDirection = (cos30, sin30, 0)) AND
+/// translated: exercises BOTH conditions of the site_local tier.
+const ROTATED_SITE_PLACEMENT: &str = r##"#30=IFCCARTESIANPOINT((10.,20.,0.));
+#31=IFCDIRECTION((0.,0.,1.));
+#32=IFCDIRECTION((0.866025403784439,0.5,0.));
+#33=IFCAXIS2PLACEMENT3D(#30,#31,#32);"##;
+
+/// Site translated but NOT rotated: site_local tier with the identity
+/// fast-out inside `apply_inverse_rotation_in_place`.
+const TRANSLATED_SITE_PLACEMENT: &str = r##"#30=IFCCARTESIANPOINT((10.,20.,0.));
+#33=IFCAXIS2PLACEMENT3D(#30,$,$);"##;
+
+/// Fully identity site placement: must NOT trigger the site_local tier.
+const IDENTITY_SITE_PLACEMENT: &str = r##"#30=IFCCARTESIANPOINT((0.,0.,0.));
+#33=IFCAXIS2PLACEMENT3D(#30,$,$);"##;
+
+/// The proxy's occurrence meshes (express id #23, geometry_class 0).
+fn proxy_meshes(result: &ProcessingResult) -> Vec<&MeshData> {
+    let meshes: Vec<&MeshData> = result
+        .meshes
+        .iter()
+        .filter(|m| m.express_id == 23 && m.geometry_class == 0)
+        .collect();
+    assert!(!meshes.is_empty(), "expected meshes for the proxy (#23)");
+    meshes
+}
+
+/// Vertices in the serialized frame: `origin + position` (both already in the
+/// declared mesh coordinate space).
+fn frame_vertices(meshes: &[&MeshData]) -> Vec<[f64; 3]> {
+    let mut out = Vec::new();
+    for m in meshes {
+        for p in m.positions.chunks_exact(3) {
+            out.push([
+                p[0] as f64 + m.origin[0],
+                p[1] as f64 + m.origin[1],
+                p[2] as f64 + m.origin[2],
+            ]);
+        }
+    }
+    assert!(!out.is_empty(), "proxy meshes have vertices");
+    out
+}
+
+fn bbox(v: &[[f64; 3]]) -> ([f64; 3], [f64; 3]) {
+    let mut mn = [f64::INFINITY; 3];
+    let mut mx = [f64::NEG_INFINITY; 3];
+    for p in v {
+        for i in 0..3 {
+            mn[i] = mn[i].min(p[i]);
+            mx[i] = mx[i].max(p[i]);
+        }
+    }
+    (mn, mx)
+}
+
+fn approx(got: [f64; 3], want: [f64; 3], what: &str) {
+    for i in 0..3 {
+        assert!(
+            (got[i] - want[i]).abs() < EPS,
+            "{what}: axis {i} got {} want {}",
+            got[i],
+            want[i]
+        );
+    }
+}
+
+/// Every normal must be unit length; in the site-local frame the box faces
+/// are axis-aligned, so each normal must also be a signed basis vector. A
+/// missed inverse rotation leaves normals yawed 30 degrees and fails here.
+fn assert_normals_unit_and_axis_aligned(meshes: &[&MeshData]) {
+    for m in meshes {
+        for n in m.normals.chunks_exact(3) {
+            let (x, y, z) = (n[0] as f64, n[1] as f64, n[2] as f64);
+            let len = (x * x + y * y + z * z).sqrt();
+            assert!(
+                (len - 1.0).abs() < 1e-3,
+                "normal not unit length: ({x}, {y}, {z})"
+            );
+            let ax = [x.abs(), y.abs(), z.abs()];
+            let max = ax[0].max(ax[1]).max(ax[2]);
+            let off_axis: f64 = ax.iter().sum::<f64>() - max;
+            assert!(
+                max > 0.999 && off_axis < 1e-3,
+                "normal not axis-aligned in the site-local frame: ({x}, {y}, {z})"
+            );
+        }
+    }
+}
+
+/// Assert every mesh vertex coincides with one of the 8 `expected` corners.
+fn assert_vertices_match_corners(verts: &[[f64; 3]], expected: &[[f64; 3]], what: &str) {
+    for v in verts {
+        let matched = expected.iter().any(|e| {
+            (v[0] - e[0]).abs() < EPS && (v[1] - e[1]).abs() < EPS && (v[2] - e[2]).abs() < EPS
+        });
+        assert!(
+            matched,
+            "{what}: vertex ({}, {}, {}) matches no expected box corner",
+            v[0], v[1], v[2]
+        );
+    }
+}
+
+#[test]
+fn rotated_site_meshes_are_inverse_rotated_into_site_local_frame() {
+    let ifc = model(ROTATED_SITE_PLACEMENT);
+    let result = process_geometry(&ifc);
+
+    // Tier selection: non-identity site translation picks site_local.
+    assert_eq!(
+        result.mesh_coordinate_space.as_deref(),
+        Some("site_local"),
+        "non-identity site translation must select the site_local tier"
+    );
+    approx(
+        result.metadata.coordinate_info.origin_shift,
+        SITE_T,
+        "origin_shift (RTC) must be the site translation",
+    );
+
+    // The resolved site transform must carry the ACTUAL 30 degree yaw; if the
+    // fixture's RefDirection failed to parse this would silently degrade to
+    // identity and the assertions below would prove nothing.
+    let c = 30f64.to_radians().cos();
+    let s = 30f64.to_radians().sin();
+    let st = result.site_transform.as_ref().expect("site transform resolved");
+    assert_eq!(st.len(), 16, "column-major 4x4");
+    for (idx, want) in [(0, c), (1, s), (4, -s), (5, c), (10, 1.0)] {
+        assert!(
+            (st[idx] - want).abs() < 1e-9,
+            "site_transform[{idx}] got {} want {want}",
+            st[idx]
+        );
+    }
+    approx([st[12], st[13], st[14]], SITE_T, "site_transform translation");
+
+    // Compute the expected site-local corners BY HAND: place each local box
+    // corner into the world (w = t + R * l), then inverse-rotate it back
+    // around the site origin (R_transpose * (w - t)). This is the frame the
+    // pipeline claims to serialize; nothing below assumes the rotation
+    // cancels, the arithmetic performs it.
+    let mut expected = Vec::with_capacity(8);
+    for xi in [0.0, BOX[0]] {
+        for yi in [0.0, BOX[1]] {
+            for zi in [0.0, BOX[2]] {
+                let (lx, ly, lz) = (xi, yi, zi);
+                // Forward: world = t + R * l (yaw about Z).
+                let wx = SITE_T[0] + c * lx - s * ly;
+                let wy = SITE_T[1] + s * lx + c * ly;
+                let wz = SITE_T[2] + lz;
+                // Inverse: site_local = R_transpose * (world - t).
+                let dx = wx - SITE_T[0];
+                let dy = wy - SITE_T[1];
+                let dz = wz - SITE_T[2];
+                expected.push([c * dx + s * dy, -s * dx + c * dy, dz]);
+            }
+        }
+    }
+
+    let meshes = proxy_meshes(&result);
+    let verts = frame_vertices(&meshes);
+    let (mn, mx) = bbox(&verts);
+    approx(mn, [0.0, 0.0, 0.0], "site-local AABB min");
+    approx(mx, BOX, "site-local AABB max");
+    assert_vertices_match_corners(&verts, &expected, "rotated site");
+    assert_normals_unit_and_axis_aligned(&meshes);
+}
+
+#[test]
+fn translated_only_site_still_selects_site_local_and_keeps_axes() {
+    let ifc = model(TRANSLATED_SITE_PLACEMENT);
+    let result = process_geometry(&ifc);
+
+    assert_eq!(result.mesh_coordinate_space.as_deref(), Some("site_local"));
+    approx(
+        result.metadata.coordinate_info.origin_shift,
+        SITE_T,
+        "origin_shift (RTC) must be the site translation",
+    );
+
+    let meshes = proxy_meshes(&result);
+    let verts = frame_vertices(&meshes);
+    let (mn, mx) = bbox(&verts);
+    approx(mn, [0.0, 0.0, 0.0], "translated-site AABB min");
+    approx(mx, BOX, "translated-site AABB max");
+    assert_normals_unit_and_axis_aligned(&meshes);
+}
+
+#[test]
+fn identity_site_passes_through_unchanged() {
+    let ifc = model(IDENTITY_SITE_PLACEMENT);
+    let result = process_geometry(&ifc);
+
+    // No site translation and no large coordinates: raw_ifc, zero RTC.
+    assert_eq!(
+        result.mesh_coordinate_space.as_deref(),
+        Some("raw_ifc"),
+        "identity site must not trigger the site_local tier"
+    );
+    approx(
+        result.metadata.coordinate_info.origin_shift,
+        [0.0, 0.0, 0.0],
+        "identity site keeps a zero origin shift",
+    );
+
+    let meshes = proxy_meshes(&result);
+    let verts = frame_vertices(&meshes);
+    let (mn, mx) = bbox(&verts);
+    approx(mn, [0.0, 0.0, 0.0], "identity AABB min");
+    approx(mx, BOX, "identity AABB max");
+    assert_normals_unit_and_axis_aligned(&meshes);
+}

--- a/rust/processing/tests/site_rotation.rs
+++ b/rust/processing/tests/site_rotation.rs
@@ -139,8 +139,10 @@ fn approx(got: [f64; 3], want: [f64; 3], what: &str) {
 /// are axis-aligned, so each normal must also be a signed basis vector. A
 /// missed inverse rotation leaves normals yawed 30 degrees and fails here.
 fn assert_normals_unit_and_axis_aligned(meshes: &[&MeshData]) {
+    let mut checked = 0usize;
     for m in meshes {
         for n in m.normals.chunks_exact(3) {
+            checked += 1;
             let (x, y, z) = (n[0] as f64, n[1] as f64, n[2] as f64);
             let len = (x * x + y * y + z * z).sqrt();
             assert!(
@@ -156,6 +158,7 @@ fn assert_normals_unit_and_axis_aligned(meshes: &[&MeshData]) {
             );
         }
     }
+    assert!(checked > 0, "no normals emitted; the axis-alignment check must not pass vacuously");
 }
 
 /// Assert every mesh vertex coincides with one of the 8 `expected` corners.


### PR DESCRIPTION
Lands reliability Item C (drift-parity tests): converts two "documented as intentional, unproven" sync surfaces into test-enforced contracts. Test-only; zero production-code changes (+458 lines).

## 1. Shared Rust<->TS length-unit-scale golden

The geometry length-unit scale is genuinely computed twice: Rust `extract_length_unit_scale` (`rust/core/src/units.rs`, drives geometry scaling via the prepass) and TS `extractLengthUnitScale` (`packages/parser/src/unit-extractor.ts`, used by the columnar parser, authoring, MCP, export). Both are now pinned to ONE fixture, `rust/core/tests/fixtures/unit_scale_vectors.json` (the `ifc_string_parity` pattern), so they cannot drift:

- `rust/core/tests/unit_scale_parity.rs` — also guards that the streaming pre-pass sibling `try_extract_length_unit_scale` never contradicts the full extractor (it may defer on conversion-based units).
- `packages/parser/src/unit-scale.parity.test.ts` — same vectors via relative path, `describe.skipIf` outside the monorepo.

8 vectors: SI MILLI/base/CENTI, conversion-based FOOT/INCH by name, a custom conversion unit resolved through `IfcMeasureWithUnit` with a MILLI component (the most drift-prone path), late-`IfcProject` ordering, and default-when-missing. **All 8 agree Rust vs TS today** — the PR pins that, it did not have to fix anything.

Scoping note: `plane_angle_to_radians` is intentionally NOT in the golden — no TS counterpart exists (TS consumes the Rust prepass value). The TS georef resolvers compute a different quantity (`IfcProjectedCRS.MapUnit` scale) and are out of scope here.

## 2. Rust site-local rotation golden (previously untested path)

No TS code re-derives the site transform (all consumers read Rust mesh output; the `buildingRotation` scalar is Rust-computed and camera-only), so this is a Rust-only golden rather than a fake cross-language test. The non-identity rotation path in `processor/site_local.rs::convert_mesh_to_site_local` had **zero test coverage** — every existing fixture uses identity rotation.

`rust/processing/tests/site_rotation.rs` (inline synthetic IFC, no external fixtures):
- 30-degree yaw + (10,20,0) translation: asserts the `site_local` tier is selected, `origin_shift` = site translation, `site_transform` carries the actual cos30/sin30 entries (guards against the fixture silently degrading to identity), every vertex (`origin + position`) matches hand-computed inverse-rotated corners (eps 1e-5), and normals are unit-length AND axis-aligned in the site frame (catches a missed normal rotation independently).
- Translated-only site (identity-rotation fast-out) and fully-identity site (`raw_ifc` passthrough) as controls.

Test strength was verified by mutation: stubbing `convert_mesh_to_site_local` to a no-op fails the rotated case and only that case.

## Verification

- `cargo test -p ifc-lite-core --test unit_scale_parity` — 1 passed
- `cargo test -p ifc-lite-processing --test site_rotation` — 3 passed
- `pnpm --filter @ifc-lite/parser test unit-scale.parity` — 9 passed (full parser suite: 210 tests green)
- All re-run independently after implementation review.

No changeset: test-only (no published-package source changes).

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The PR is test-only and the added fixtures/tests match the existing Rust and TypeScript code paths reviewed.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran the unit-scale parity checks and observed an initial failure due to missing parity files and unbuilt workspace dependencies.
- After running pnpm install --frozen-lockfile and building @ifc-lite/data/@ifc-lite/encoding, the unit-scale parity checks passed with Rust exit 0 and TS parity reporting 1 file / 9 tests.
- I reviewed the site-rotation golden pre-run state, which showed the base worktree command, base commit, TEST\_FILE\_PRESENT: no, and an exit code 1 caused by a nightly cargo component issue before cargo could report the absent integration test target.
- After the head run, the site-rotation golden tests completed successfully: running 3 tests, all three tests ok, final test result: ok, and EXIT\_CODE: 0.
- Source inspection reveals the changed test file is tied to process\_geometry and includes the rotated, translated-only, identity, transform, vertex, and normal assertions.

<a href="https://app.greptile.com/trex/runs/12970012/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/parser/src/unit-scale.parity.test.ts | Adds Vitest parity coverage for the TypeScript length-unit extractor against the shared Rust fixture; no issues found. |
| rust/core/tests/fixtures/unit_scale_vectors.json | Adds shared synthetic unit-scale golden vectors covering SI, conversion-based, ordering, and default cases; no issues found. |
| rust/core/tests/unit_scale_parity.rs | Adds Rust parity coverage for full and streaming-safe length-unit scale extractors against the shared fixture; no issues found. |
| rust/processing/tests/site_rotation.rs | Adds Rust golden tests for site-local coordinate-space selection, inverse rotation, translation, and identity controls; no issues found. |

<sub>Reviews (1): Last reviewed commit: ["test(parity): shared unit-scale golden +..."](https://github.com/ltplus-ag/ifc-lite/commit/150dbf1c7cbe790db32187c6fe9a90b748713f70) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41201640)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of IFC length-unit scaling and site-based geometry handling, including rotated site placements.
* **Tests**
  * Added cross-language parity checks to verify length-unit results match shared reference cases.
  * Added golden geometry coverage for site-local coordinate selection, origin shifting, vertex placement, and normal orientation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->