### PR TITLE
perf(geometry): corpus-validate + flip rect-param opening fast path ON

### DIFF
--- a/.changeset/rect-param-default-on.md
+++ b/.changeset/rect-param-default-on.md
@@ -21,5 +21,9 @@ walls (the kernel's documented 9-34% over-cut), so fired geometry is not
 byte-equal to the old kernel output by design.
 
 `IFC_LITE_RECT_PARAM=0` (native) and `setRectParamFastPath(false)` (wasm)
-remain as opt-out escape hatches. wasm reads no env, so both targets default
-ON in lockstep and the native==wasm byte contract is preserved.
+remain as opt-out escape hatches for the parametric path alone, and
+`IFC_LITE_RECT_FAST=0` stays the global rect-fast kill switch: it disables the
+legacy AND the parametric path, so that single flag still forces every
+rectangular opening through the exact kernel (parity debugging / bisection).
+wasm reads no env, so both targets default ON in lockstep and the native==wasm
+byte contract is preserved.

--- a/.changeset/rect-param-default-on.md
+++ b/.changeset/rect-param-default-on.md
@@ -1,0 +1,25 @@
+---
+"@ifc-lite/geometry": minor
+"@ifc-lite/wasm": minor
+---
+
+Flip the PARAMETRIC rectangular-opening fast path (`IFC_LITE_RECT_PARAM`) to
+DEFAULT ON. The path subtracts rectangular openings as exact parametric boxes
+in the host wall's own placement frame (rotated walls included), producing a
+watertight, analytically exact cut and deferring any non-clean case (non-rect
+host or opening, frame mismatch, mesh/parametric disagreement, overlap,
+engulfing redundant void) to the exact kernel unchanged.
+
+Corpus-validated before the flip with a new A/B harness
+(`rust/geometry/tests/rect_param_validate.rs`, run over AC20-FZK-Haus,
+dental_clinic, advanced_model, ISSUE_068 and ISSUE_129): every element where
+the path does not fire is byte-identical ON vs OFF (24,345 of 24,744 jobs;
+the rest fired), and every fired host (399 across the corpus) is watertight
+and matches the analytic box-minus-boxes ground truth within 0.5%. On firing
+hosts the output is MORE correct than the exact kernel on engulfing-opening
+walls (the kernel's documented 9-34% over-cut), so fired geometry is not
+byte-equal to the old kernel output by design.
+
+`IFC_LITE_RECT_PARAM=0` (native) and `setRectParamFastPath(false)` (wasm)
+remain as opt-out escape hatches. wasm reads no env, so both targets default
+ON in lockstep and the native==wasm byte contract is preserved.

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -357,12 +357,13 @@ export class IfcAPI {
    * Enable or disable the PARAMETRIC rectangular-opening fast path (the
    * placement-frame, ground-truth-exact analytic cut) for `processGeometryBatch`.
    *
-   * DEFAULT OFF. This is the wasm-side toggle that lets native and wasm flip the
-   * flag in LOCKSTEP — the byte-identical native==wasm contract requires both
-   * targets take the same path, and wasm has no env to read `IFC_LITE_RECT_PARAM`.
+   * DEFAULT ON (corpus-validated; native defaults ON too, and wasm has no env to
+   * read `IFC_LITE_RECT_PARAM`, so both targets default in LOCKSTEP -- the
+   * byte-identical native==wasm contract requires both take the same path). This
+   * toggle is the wasm-side escape hatch mirroring `IFC_LITE_RECT_PARAM=0`.
    * The path subtracts rectangular openings as exact parametric boxes in the host's
    * own placement frame (rotated walls included), deferring any non-clean case to
-   * the exact kernel. Pass `true` before `processGeometryBatch`.
+   * the exact kernel. Pass `false` before `processGeometryBatch` to opt out.
    */
   setRectParamFastPath(enabled: boolean): void;
   /**

--- a/rust/geometry/src/rect_fast.rs
+++ b/rust/geometry/src/rect_fast.rs
@@ -52,9 +52,14 @@ pub struct RectFastStats {
     pub defer_no_openings: u64,
 }
 
-/// Escape hatch: `IFC_LITE_RECT_FAST=0` forces every opening back through the
-/// exact kernel (parity debugging / bisection). Default ON — the path is a pure
-/// optimization that defers on any precondition miss.
+/// Escape hatch: `IFC_LITE_RECT_FAST=0` is the GLOBAL rect-fast kill switch.
+/// It forces every opening back through the exact kernel (parity debugging /
+/// bisection) by disabling BOTH the legacy world-axis-aligned path gated here
+/// AND the parametric placement-frame path ([`param_enabled`] honours it), so
+/// setting this single flag is sufficient to route all rectangular openings
+/// through CSG. Default ON: the path is a pure optimization that defers on
+/// any precondition miss. To disable only the parametric path, set
+/// `IFC_LITE_RECT_PARAM=0` instead.
 pub fn enabled() -> bool {
     use std::sync::OnceLock;
     static ON: OnceLock<bool> = OnceLock::new();
@@ -64,15 +69,18 @@ pub fn enabled() -> bool {
 static PARAM_OVERRIDE: std::sync::atomic::AtomicI8 = std::sync::atomic::AtomicI8::new(-1);
 
 /// PARAMETRIC rectangular-opening fast path (placement-frame, ground-truth-exact cut).
-/// DEFAULT ON -- opt out with `IFC_LITE_RECT_PARAM=0` or `param_set_enabled_override`
-/// (mirroring the [`enabled`] escape hatch). Gated separately from [`enabled`] because
+/// DEFAULT ON -- opt out with `IFC_LITE_RECT_PARAM=0` (parametric path only),
+/// `IFC_LITE_RECT_FAST=0` (the GLOBAL rect-fast kill switch: disables this path AND
+/// the legacy [`enabled`] path, preserving the documented single-flag parity/bisection
+/// hatch), or `param_set_enabled_override`. Gated separately from [`enabled`] because
 /// it is a deliberate behaviour change: it emits the analytic box-minus-boxes solid,
 /// which is MORE correct than the exact kernel on engulfing-opening walls.
 /// Corpus-validated ON (tests/rect_param_validate.rs A/B over 5 real models): every
 /// non-firing element byte-identical ON vs OFF, every firing host watertight and
 /// matching the analytic ground truth. wasm has no env, so `std::env::var` errs there
 /// and the default is ON on both targets -- native==wasm stays in lockstep; the
-/// wasm-side `setRectParamFastPath` override remains the programmatic escape hatch.
+/// wasm-side `setRectParamFastPath` override remains the programmatic escape hatch
+/// (and, being an explicit per-process call, takes precedence over both env flags).
 pub fn param_enabled() -> bool {
     match PARAM_OVERRIDE.load(std::sync::atomic::Ordering::Relaxed) {
         0 => return false,
@@ -81,7 +89,19 @@ pub fn param_enabled() -> bool {
     }
     use std::sync::OnceLock;
     static ON: OnceLock<bool> = OnceLock::new();
-    *ON.get_or_init(|| std::env::var("IFC_LITE_RECT_PARAM").as_deref() != Ok("0"))
+    *ON.get_or_init(|| {
+        param_env_default(enabled(), std::env::var("IFC_LITE_RECT_PARAM").as_deref().ok())
+    })
+}
+
+/// Env-flag decision core for [`param_enabled`], pure so the semantics are
+/// unit-testable without mutating process env: the parametric path is ON unless
+/// its own flag opts out (`IFC_LITE_RECT_PARAM=0`) or the global rect-fast kill
+/// switch is thrown (`IFC_LITE_RECT_FAST=0`, surfaced here as `rect_fast_on ==
+/// false` via [`enabled`]). `IFC_LITE_RECT_PARAM=1` cannot resurrect the path
+/// past the kill switch: the kill switch means "exact kernel for everything".
+fn param_env_default(rect_fast_on: bool, rect_param: Option<&str>) -> bool {
+    rect_fast_on && rect_param != Some("0")
 }
 
 /// Test-only: force `param_enabled()` on/off (or `None` for the env default).
@@ -589,6 +609,24 @@ mod tests {
             (removed - expect).abs() < vtol,
             "{label}: removed {removed} != expected {expect} (tol {vtol})"
         );
+    }
+
+    /// Flag semantics (pure core, no env mutation, safe under parallel tests):
+    /// `IFC_LITE_RECT_FAST=0` is the GLOBAL kill switch and also disables the
+    /// parametric path (even against an explicit `IFC_LITE_RECT_PARAM=1`);
+    /// `IFC_LITE_RECT_PARAM=0` disables only the parametric path; both unset
+    /// means the parametric path defaults ON.
+    #[test]
+    fn param_env_default_honours_global_kill_switch() {
+        // Global kill switch thrown (IFC_LITE_RECT_FAST=0 => enabled() false).
+        assert!(!param_env_default(false, None));
+        assert!(!param_env_default(false, Some("1")));
+        assert!(!param_env_default(false, Some("0")));
+        // Parametric-only opt-out.
+        assert!(!param_env_default(true, Some("0")));
+        // Defaults ON; explicit "1" is also ON.
+        assert!(param_env_default(true, None));
+        assert!(param_env_default(true, Some("1")));
     }
 
     #[test]

--- a/rust/geometry/src/rect_fast.rs
+++ b/rust/geometry/src/rect_fast.rs
@@ -64,11 +64,15 @@ pub fn enabled() -> bool {
 static PARAM_OVERRIDE: std::sync::atomic::AtomicI8 = std::sync::atomic::AtomicI8::new(-1);
 
 /// PARAMETRIC rectangular-opening fast path (placement-frame, ground-truth-exact cut).
-/// DEFAULT OFF — opt in with `IFC_LITE_RECT_PARAM=1` or `param_set_enabled_override`.
-/// Gated separately from [`enabled`] because it is a deliberate behaviour change: it
-/// emits the analytic box-minus-boxes solid, which is MORE correct than the exact kernel
-/// on engulfing-opening walls. Stays off until a parity CI gate + a wasm toggle land, so
-/// native==wasm holds trivially (both off) until the flag is flipped in lockstep.
+/// DEFAULT ON -- opt out with `IFC_LITE_RECT_PARAM=0` or `param_set_enabled_override`
+/// (mirroring the [`enabled`] escape hatch). Gated separately from [`enabled`] because
+/// it is a deliberate behaviour change: it emits the analytic box-minus-boxes solid,
+/// which is MORE correct than the exact kernel on engulfing-opening walls.
+/// Corpus-validated ON (tests/rect_param_validate.rs A/B over 5 real models): every
+/// non-firing element byte-identical ON vs OFF, every firing host watertight and
+/// matching the analytic ground truth. wasm has no env, so `std::env::var` errs there
+/// and the default is ON on both targets -- native==wasm stays in lockstep; the
+/// wasm-side `setRectParamFastPath` override remains the programmatic escape hatch.
 pub fn param_enabled() -> bool {
     match PARAM_OVERRIDE.load(std::sync::atomic::Ordering::Relaxed) {
         0 => return false,
@@ -77,7 +81,7 @@ pub fn param_enabled() -> bool {
     }
     use std::sync::OnceLock;
     static ON: OnceLock<bool> = OnceLock::new();
-    *ON.get_or_init(|| std::env::var("IFC_LITE_RECT_PARAM").as_deref() == Ok("1"))
+    *ON.get_or_init(|| std::env::var("IFC_LITE_RECT_PARAM").as_deref() != Ok("0"))
 }
 
 /// Test-only: force `param_enabled()` on/off (or `None` for the env default).

--- a/rust/geometry/tests/issue_604_door_regression.rs
+++ b/rust/geometry/tests/issue_604_door_regression.rs
@@ -195,9 +195,23 @@ fn wall_opening_cut_has_no_coplanar_sliver() {
 
     let wall = decoder.decode_by_id(WALL_ID).expect("decode wall");
     assert_eq!(wall.ifc_type, IfcType::IfcWall);
-    let mesh = router
+    let mut mesh = router
         .process_element_with_voids(&wall, &mut decoder, &void_index)
         .expect("wall void cut must succeed");
+
+    // The parametric rect-opening fast path (default ON) emits a LOCAL-FRAME
+    // mesh: small positions plus mesh.origin, world = origin + position (the
+    // contract every production consumer folds). Fold it here so the
+    // world-space AABB / sliver checks below stay in world coordinates.
+    if mesh.origin != [0.0, 0.0, 0.0] {
+        let o = mesh.origin;
+        for c in mesh.positions.chunks_exact_mut(3) {
+            c[0] = (c[0] as f64 + o[0]) as f32;
+            c[1] = (c[1] as f64 + o[1]) as f32;
+            c[2] = (c[2] as f64 + o[2]) as f32;
+        }
+        mesh.origin = [0.0, 0.0, 0.0];
+    }
 
     assert!(
         !mesh.positions.is_empty() && !mesh.indices.is_empty(),

--- a/rust/geometry/tests/issue_604_door_regression.rs
+++ b/rust/geometry/tests/issue_604_door_regression.rs
@@ -19,10 +19,13 @@
 //! The test skips cleanly when the fixture is absent so a fresh clone never
 //! panics.
 
+mod voids_common;
+
 use ifc_lite_core::{EntityDecoder, IfcType};
 use ifc_lite_geometry::GeometryRouter;
 use rustc_hash::FxHashMap;
 use std::path::Path;
+use voids_common::production::fold_origin;
 
 const FIXTURE: &str = "../../tests/models/various/issue-604-door.ifc";
 
@@ -200,18 +203,9 @@ fn wall_opening_cut_has_no_coplanar_sliver() {
         .expect("wall void cut must succeed");
 
     // The parametric rect-opening fast path (default ON) emits a LOCAL-FRAME
-    // mesh: small positions plus mesh.origin, world = origin + position (the
-    // contract every production consumer folds). Fold it here so the
-    // world-space AABB / sliver checks below stay in world coordinates.
-    if mesh.origin != [0.0, 0.0, 0.0] {
-        let o = mesh.origin;
-        for c in mesh.positions.chunks_exact_mut(3) {
-            c[0] = (c[0] as f64 + o[0]) as f32;
-            c[1] = (c[1] as f64 + o[1]) as f32;
-            c[2] = (c[2] as f64 + o[2]) as f32;
-        }
-        mesh.origin = [0.0, 0.0, 0.0];
-    }
+    // mesh (world = origin + position); fold it so the world-space AABB /
+    // sliver checks below stay in world coordinates.
+    fold_origin(&mut mesh);
 
     assert!(
         !mesh.positions.is_empty() && !mesh.indices.is_empty(),

--- a/rust/geometry/tests/issue_832_opening_representations.rs
+++ b/rust/geometry/tests/issue_832_opening_representations.rs
@@ -23,9 +23,12 @@
 //! all the way down to the wall base and out the +X edge — a half-space
 //! cut, not the authored bounded opening.
 
+mod voids_common;
+
 use ifc_lite_core::{EntityDecoder, IfcType};
 use ifc_lite_geometry::GeometryRouter;
 use rustc_hash::FxHashMap;
+use voids_common::production::fold_origin;
 
 const FIXTURE: &str = "../../tests/models/issues/832_opening_representations.ifc";
 
@@ -160,18 +163,9 @@ fn all_five_opening_representations_stay_bounded() {
             .unwrap_or_else(|e| panic!("process wall #{wall_id}: {e}"));
 
         // The parametric rect-opening fast path (default ON) emits a
-        // LOCAL-FRAME mesh: small positions plus mesh.origin, world =
-        // origin + position (the contract every production consumer folds).
-        // Fold it so the world-space band checks below stay in world coords.
-        if mesh.origin != [0.0, 0.0, 0.0] {
-            let o = mesh.origin;
-            for c in mesh.positions.chunks_exact_mut(3) {
-                c[0] = (c[0] as f64 + o[0]) as f32;
-                c[1] = (c[1] as f64 + o[1]) as f32;
-                c[2] = (c[2] as f64 + o[2]) as f32;
-            }
-            mesh.origin = [0.0, 0.0, 0.0];
-        }
+        // LOCAL-FRAME mesh (world = origin + position); fold it so the
+        // world-space band checks below stay in world coords.
+        fold_origin(&mut mesh);
 
         let (wmin, wmax) = mesh_bounds(&mesh);
 

--- a/rust/geometry/tests/issue_832_opening_representations.rs
+++ b/rust/geometry/tests/issue_832_opening_representations.rs
@@ -155,9 +155,23 @@ fn all_five_opening_representations_stay_bounded() {
             "expected IfcWall at #{wall_id}",
         );
 
-        let mesh = router
+        let mut mesh = router
             .process_element_with_voids(&wall, &mut decoder, &void_index)
             .unwrap_or_else(|e| panic!("process wall #{wall_id}: {e}"));
+
+        // The parametric rect-opening fast path (default ON) emits a
+        // LOCAL-FRAME mesh: small positions plus mesh.origin, world =
+        // origin + position (the contract every production consumer folds).
+        // Fold it so the world-space band checks below stay in world coords.
+        if mesh.origin != [0.0, 0.0, 0.0] {
+            let o = mesh.origin;
+            for c in mesh.positions.chunks_exact_mut(3) {
+                c[0] = (c[0] as f64 + o[0]) as f32;
+                c[1] = (c[1] as f64 + o[1]) as f32;
+                c[2] = (c[2] as f64 + o[2]) as f32;
+            }
+            mesh.origin = [0.0, 0.0, 0.0];
+        }
 
         let (wmin, wmax) = mesh_bounds(&mesh);
 

--- a/rust/geometry/tests/rect_param_validate.rs
+++ b/rust/geometry/tests/rect_param_validate.rs
@@ -1,0 +1,472 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Corpus A/B validation for the PARAMETRIC rect-opening fast path
+//! (`IFC_LITE_RECT_PARAM` / `rect_fast::param_enabled`), modeled on
+//! `dedup_validate.rs`: drive the PRODUCTION submesh path
+//! (`produce_element_meshes` entry points) over every geometry job in a real
+//! model with the flag ON and OFF, and assert:
+//!
+//!   1. Every element where the fast path did NOT fire is BYTE-IDENTICAL
+//!      between ON and OFF (fingerprint over positions/normals/indices/origin).
+//!   2. Every element where it DID fire is watertight and matches the ANALYTIC
+//!      box-minus-boxes ground truth by volume within 5% (the same oracle
+//!      `rect_param_parity.rs` / `rect_param_production.rs` assert against --
+//!      the exact kernel is an imperfect oracle with documented 9-34% over-cut
+//!      on engulfing-opening walls, so fired hosts are NOT expected to be
+//!      byte-equal to the kernel; the param volume may EXCEED the kernel's).
+//!
+//! Timing: the ON/OFF passes are interleaved ABAB (OFF, ON, OFF, ON, ...) so
+//! background machine load cannot bias one side; raw runs and per-side medians
+//! are printed, plus the voided-host-only (CSG) share of each run.
+//!
+//! Run (server-release: the release profile is panic=abort, which test
+//! binaries cannot link; server-release re-enables unwinding):
+//!   IFCLT_MODEL=/abs/path.ifc cargo test -p ifc-lite-geometry \
+//!     --profile server-release --test rect_param_validate -- --ignored --nocapture
+//! Optional: RECT_PARAM_TIMING_PAIRS=N   (ABAB pairs, default 3)
+
+use ifc_lite_core::{build_entity_index, has_geometry_by_name, DecodedEntity, EntityDecoder, EntityScanner, IfcType};
+use ifc_lite_geometry::rect_fast::{param_set_enabled_override, take_param_fires};
+use ifc_lite_geometry::{propagate_voids_to_parts, GeometryRouter, Mesh, RectParam, SubMeshCollection};
+use nalgebra::Matrix3;
+use rustc_hash::FxHashMap;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::time::Instant;
+
+/// Fired cuts must match the analytic ground truth within this relative volume
+/// tolerance (the `rect_param_production.rs` bar).
+const ANALYTIC_VOL_TOL: f64 = 0.05;
+/// Informational band for param-vs-kernel volume: the kernel over-cuts up to
+/// ~34% on engulfing openings, so param_vol/kernel_vol in [0.95, 1.50] is the
+/// documented expectation. Out-of-band hosts are listed (they are only a
+/// FAILURE if they also miss the analytic oracle).
+const KERNEL_BAND: (f64, f64) = (0.95, 1.50);
+
+fn build_void_index(content: &str, decoder: &mut EntityDecoder) -> FxHashMap<u32, Vec<u32>> {
+    let mut idx: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
+    let mut scanner = EntityScanner::new(content);
+    let mut scan_decoder = EntityDecoder::new(content);
+    while let Some((id, name, start, end)) = scanner.next_entity() {
+        if name == "IFCRELVOIDSELEMENT" {
+            if let Ok(entity) = scan_decoder.decode_at_with_id(id, start, end) {
+                if let (Some(host), Some(opening)) = (entity.get_ref(4), entity.get_ref(5)) {
+                    idx.entry(host).or_default().push(opening);
+                }
+            }
+        }
+    }
+    let _ = propagate_voids_to_parts(&mut idx, content, decoder);
+    idx
+}
+
+/// Deterministic content fingerprint of a placed sub-mesh collection -- every
+/// bit the renderer consumes (geometry id, f32 positions/normals, indices, and
+/// the f64 local-frame origin), in submesh order. Same as dedup_validate.rs.
+fn fingerprint(sm: &SubMeshCollection) -> u64 {
+    let mut h = DefaultHasher::new();
+    sm.sub_meshes.len().hash(&mut h);
+    for s in &sm.sub_meshes {
+        s.geometry_id.hash(&mut h);
+        s.mesh.positions.len().hash(&mut h);
+        for &p in &s.mesh.positions {
+            p.to_bits().hash(&mut h);
+        }
+        for &n in &s.mesh.normals {
+            n.to_bits().hash(&mut h);
+        }
+        for &i in &s.mesh.indices {
+            i.hash(&mut h);
+        }
+        for &o in &s.mesh.origin {
+            o.to_bits().hash(&mut h);
+        }
+    }
+    h.finish()
+}
+
+fn mesh_volume(mesh: &Mesh) -> f64 {
+    mesh.indices
+        .chunks_exact(3)
+        .map(|t| {
+            let v = |i: u32| {
+                let b = i as usize * 3;
+                [mesh.positions[b] as f64, mesh.positions[b + 1] as f64, mesh.positions[b + 2] as f64]
+            };
+            let (a, b, c) = (v(t[0]), v(t[1]), v(t[2]));
+            a[0] * (b[1] * c[2] - b[2] * c[1]) + a[1] * (b[2] * c[0] - b[0] * c[2])
+                + a[2] * (b[0] * c[1] - b[1] * c[0])
+        })
+        .sum::<f64>()
+        / 6.0
+}
+
+/// Quantized undirected-edge watertightness (the rect_param_production.rs
+/// checker): every non-degenerate edge must be shared by exactly 2 triangles.
+fn watertight(mesh: &Mesh) -> bool {
+    let key = |i: u32| -> (i64, i64, i64) {
+        let b = i as usize * 3;
+        let q = |v: f32| (v as f64 / 1.0e-4).round() as i64;
+        (q(mesh.positions[b]), q(mesh.positions[b + 1]), q(mesh.positions[b + 2]))
+    };
+    let mut edges: FxHashMap<((i64, i64, i64), (i64, i64, i64)), i32> = FxHashMap::default();
+    for tri in mesh.indices.chunks_exact(3) {
+        let (ka, kb, kc) = (key(tri[0]), key(tri[1]), key(tri[2]));
+        if ka == kb || kb == kc || kc == ka {
+            continue;
+        }
+        for (x, y) in [(ka, kb), (kb, kc), (kc, ka)] {
+            let e = if x < y { (x, y) } else { (y, x) };
+            *edges.entry(e).or_insert(0) += 1;
+        }
+    }
+    !edges.is_empty() && edges.values().all(|&c| c == 2)
+}
+
+/// Signed-permutation axis map of `m` (each row one entry ~ +-1), or `None`.
+fn signed_perm(m: &Matrix3<f64>, tol: f64) -> Option<[usize; 3]> {
+    let mut out = [0usize; 3];
+    let mut used = [false; 3];
+    for i in 0..3 {
+        let (mut best, mut ba, mut second) = (0usize, 0.0, 0.0);
+        for j in 0..3 {
+            let a = m[(i, j)].abs();
+            if a > ba {
+                second = ba;
+                ba = a;
+                best = j;
+            } else if a > second {
+                second = a;
+            }
+        }
+        if ba < 1.0 - tol || second > tol || used[best] {
+            return None;
+        }
+        used[best] = true;
+        out[i] = best;
+    }
+    Some(out)
+}
+
+/// Analytic GROUND-TRUTH cut volume for a box host: host box minus the union of
+/// opening boxes clamped to the host (the fire gate guarantees non-overlap, so
+/// the union is the simple sum). Exact for box-minus-boxes. Copied from
+/// rect_param_production.rs.
+fn analytic_cut_volume(
+    router: &GeometryRouter,
+    host: &DecodedEntity,
+    opening_ids: &[u32],
+    decoder: &mut EntityDecoder,
+) -> Option<f64> {
+    let hp: RectParam = router.parametric_rect_probe(host, decoder)?;
+    let rt = hp.r.transpose();
+    let host_vol = 8.0 * hp.half[0] * hp.half[1] * hp.half[2];
+    let mut opening_vol = 0.0;
+    for &oid in opening_ids {
+        let opening = decoder.decode_by_id(oid).ok()?;
+        if opening.ifc_type != IfcType::IfcOpeningElement {
+            continue;
+        }
+        let boxes = router.parametric_rect_probe_all(&opening, decoder)?;
+        for b in boxes {
+            let map = signed_perm(&(rt * b.r), 1.0e-3)?;
+            let cf = rt * (b.center - hp.center);
+            let cf = [cf.x, cf.y, cf.z];
+            let half_f = [b.half[map[0]], b.half[map[1]], b.half[map[2]]];
+            let mut v = 1.0;
+            for i in 0..3 {
+                let lo = (cf[i] - half_f[i]).max(-hp.half[i]);
+                let hi = (cf[i] + half_f[i]).min(hp.half[i]);
+                v *= (hi - lo).max(0.0);
+            }
+            opening_vol += v;
+        }
+    }
+    Some((host_vol - opening_vol).abs())
+}
+
+/// One full pass over every geometry job through the PRODUCTION submesh path
+/// with the param flag forced to `on`. Returns per-element (id, fingerprint,
+/// fires), total triangles, loop wall-time (ms), and the voided-host-only share
+/// of that wall-time (ms). Fresh decoder + cold router per call so ON and OFF
+/// are a fair cold-cache comparison.
+fn run_pass(
+    content: &str,
+    all_jobs: &[u32],
+    void_idx: &FxHashMap<u32, Vec<u32>>,
+    on: bool,
+) -> (Vec<(u32, u64, u64)>, usize, f64, f64) {
+    // Sentinels keep ON and OFF 1:1 aligned even on decode/mesh errors.
+    const FP_DECODE_ERR: u64 = u64::MAX;
+    const FP_MESH_ERR: u64 = u64::MAX - 1;
+
+    param_set_enabled_override(Some(on));
+    let _ = take_param_fires();
+
+    let mut decoder = EntityDecoder::with_index(content, build_entity_index(content));
+    let router = GeometryRouter::with_units(content, &mut decoder);
+    let mut fps: Vec<(u32, u64, u64)> = Vec::with_capacity(all_jobs.len());
+    let mut tris = 0usize;
+    let mut voids_ms = 0.0f64;
+    let t = Instant::now();
+    for id in all_jobs {
+        let entity = match decoder.decode_by_id(*id) {
+            Ok(e) => e,
+            Err(_) => {
+                fps.push((*id, FP_DECODE_ERR, 0));
+                continue;
+            }
+        };
+        let openings = void_idx.get(id).map(|v| v.len()).unwrap_or(0);
+        let te = Instant::now();
+        let sm = if openings > 0 {
+            router.process_element_with_submeshes_and_voids(&entity, &mut decoder, void_idx)
+        } else {
+            router.process_element_with_submeshes(&entity, &mut decoder)
+        };
+        if openings > 0 {
+            voids_ms += te.elapsed().as_secs_f64() * 1000.0;
+        }
+        let fires = take_param_fires();
+        match sm {
+            Ok(sm) => {
+                tris += sm.sub_meshes.iter().map(|s| s.mesh.indices.len() / 3).sum::<usize>();
+                fps.push((*id, fingerprint(&sm), fires));
+            }
+            Err(_) => fps.push((*id, FP_MESH_ERR, fires)),
+        }
+    }
+    let total_ms = t.elapsed().as_secs_f64() * 1000.0;
+    param_set_enabled_override(None);
+    (fps, tris, total_ms, voids_ms)
+}
+
+fn median(mut v: Vec<f64>) -> f64 {
+    v.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let n = v.len();
+    if n == 0 {
+        return 0.0;
+    }
+    if n % 2 == 1 {
+        v[n / 2]
+    } else {
+        (v[n / 2 - 1] + v[n / 2]) / 2.0
+    }
+}
+
+#[test]
+#[ignore = "manual corpus A/B; needs IFCLT_MODEL"]
+fn rect_param_ab_validate() {
+    let path = match std::env::var("IFCLT_MODEL") {
+        Ok(p) => p,
+        Err(_) => {
+            println!("set IFCLT_MODEL=/abs/path.ifc");
+            return;
+        }
+    };
+    let pairs: usize = std::env::var("RECT_PARAM_TIMING_PAIRS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .filter(|&n| n >= 1)
+        .unwrap_or(3);
+    let content = std::fs::read_to_string(&path).expect("read model");
+    println!("\n=== rect-param A/B (production submesh path) ===");
+    println!("model: {path}  ({} bytes)", content.len());
+
+    let mut idx_decoder = EntityDecoder::with_index(&content, build_entity_index(&content));
+    let void_idx = build_void_index(&content, &mut idx_decoder);
+    let mut all_jobs: Vec<u32> = Vec::new();
+    {
+        let mut scanner = EntityScanner::new(&content);
+        while let Some((id, name, _, _)) = scanner.next_entity() {
+            if has_geometry_by_name(name) {
+                all_jobs.push(id);
+            }
+        }
+    }
+    println!("geometry jobs: {}  voided hosts: {}", all_jobs.len(), void_idx.len());
+
+    // --- ABAB interleaved passes: OFF, ON, OFF, ON, ... -------------------
+    let mut off_runs: Vec<(Vec<(u32, u64, u64)>, usize, f64, f64)> = Vec::new();
+    let mut on_runs: Vec<(Vec<(u32, u64, u64)>, usize, f64, f64)> = Vec::new();
+    for p in 0..pairs {
+        let off = run_pass(&content, &all_jobs, &void_idx, false);
+        let on = run_pass(&content, &all_jobs, &void_idx, true);
+        println!(
+            "  pair {p}: OFF {:>7.0}ms (voids {:>6.0}ms)   ON {:>7.0}ms (voids {:>6.0}ms)",
+            off.2, off.3, on.2, on.3
+        );
+        off_runs.push(off);
+        on_runs.push(on);
+    }
+    let (off_fps, off_tris, ..) = &off_runs[0];
+    let (on_fps, on_tris, ..) = &on_runs[0];
+
+    // Fired set must be identical across ON runs (determinism of the gate).
+    let fired_total: u64 = on_fps.iter().map(|e| e.2).sum();
+    for (i, r) in on_runs.iter().enumerate().skip(1) {
+        let f: u64 = r.0.iter().map(|e| e.2).sum();
+        assert_eq!(f, fired_total, "ON run {i} fired a different number of cuts");
+    }
+    // The OFF side must never fire.
+    let off_fires: u64 = off_runs.iter().flat_map(|r| r.0.iter().map(|e| e.2)).sum();
+    assert_eq!(off_fires, 0, "param path fired while forced OFF");
+
+    // --- 1. Non-fired elements: byte-identical ON vs OFF ------------------
+    assert_eq!(off_fps.len(), on_fps.len(), "element count diverged ON vs OFF");
+    let mut fired_ids: Vec<u32> = Vec::new();
+    let mut nonfired_identical = 0usize;
+    let mut nonfired_diverged: Vec<u32> = Vec::new();
+    for ((off_id, off_fp, _), (on_id, on_fp, on_fires)) in off_fps.iter().zip(on_fps.iter()) {
+        assert_eq!(off_id, on_id, "element order diverged");
+        if *on_fires > 0 {
+            fired_ids.push(*on_id);
+        } else if off_fp == on_fp {
+            nonfired_identical += 1;
+        } else {
+            nonfired_diverged.push(*on_id);
+        }
+    }
+
+    // --- 2. Fired hosts: watertight + analytic-oracle volume --------------
+    // Re-run each fired host through the merged-mesh production entry
+    // (`process_element_with_voids`) ON and OFF for the geometric checks; the
+    // volume comparison needs one mesh per element.
+    let mut wt_ok = 0usize;
+    let mut wt_bad: Vec<u32> = Vec::new();
+    let mut vol_ok = 0usize;
+    let mut vol_bad: Vec<(u32, f64, f64)> = Vec::new(); // (id, param_vol, truth)
+    let mut no_oracle: Vec<u32> = Vec::new();
+    let mut kernel_hist = [0usize; 6]; // <0.5%, 0.5-2%, 2-5%, 5-20%, 20-40%, >40%
+    let mut kernel_out_of_band: Vec<(u32, f64)> = Vec::new(); // (id, param/kernel)
+    {
+        let mut d = EntityDecoder::with_index(&content, build_entity_index(&content));
+        let router = GeometryRouter::with_units(&content, &mut d);
+        for &id in &fired_ids {
+            let Ok(host) = d.decode_by_id(id) else { continue };
+
+            param_set_enabled_override(Some(true));
+            let _ = take_param_fires();
+            let param_mesh = router.process_element_with_voids(&host, &mut d, &void_idx);
+            let merged_fired = take_param_fires() > 0;
+            param_set_enabled_override(Some(false));
+            let kernel_mesh = router.process_element_with_voids(&host, &mut d, &void_idx);
+            param_set_enabled_override(None);
+
+            let (Ok(pm), Ok(km)) = (param_mesh, kernel_mesh) else { continue };
+            if !merged_fired {
+                // Fired on the submesh path but deferred on the merged path
+                // (different mesh entry) -- the merged output IS the kernel
+                // output, nothing param-specific to judge here.
+                wt_ok += 1;
+                vol_ok += 1;
+                continue;
+            }
+            if watertight(&pm) {
+                wt_ok += 1;
+            } else {
+                wt_bad.push(id);
+            }
+            let pv = mesh_volume(&pm).abs();
+            let kv = mesh_volume(&km).abs();
+            match analytic_cut_volume(&router, &host, &void_idx[&id], &mut d) {
+                Some(truth) if truth > 1.0e-9 => {
+                    let rel = (pv - truth).abs() / truth;
+                    if rel <= ANALYTIC_VOL_TOL {
+                        vol_ok += 1;
+                    } else {
+                        vol_bad.push((id, pv, truth));
+                    }
+                }
+                _ => no_oracle.push(id),
+            }
+            let ratio = if kv > 1.0e-9 { pv / kv } else { f64::INFINITY };
+            let rel_k = (ratio - 1.0).abs();
+            kernel_hist[if rel_k < 0.005 { 0 } else if rel_k < 0.02 { 1 } else if rel_k < 0.05 { 2 }
+                else if rel_k < 0.20 { 3 } else if rel_k < 0.40 { 4 } else { 5 }] += 1;
+            if ratio < KERNEL_BAND.0 || ratio > KERNEL_BAND.1 {
+                kernel_out_of_band.push((id, ratio));
+            }
+        }
+    }
+
+    // --- summary -----------------------------------------------------------
+    println!("\n--- per-model summary ---");
+    println!("hosts total (voided)        : {}", void_idx.len());
+    println!("elements fired (submesh run): {}   (total fires {fired_total})", fired_ids.len());
+    println!(
+        "non-fired byte-identical    : {nonfired_identical} / {}   (diverged: {})",
+        nonfired_identical + nonfired_diverged.len(),
+        nonfired_diverged.len()
+    );
+    println!("fired watertight            : {wt_ok} / {}   (bad: {})", fired_ids.len(), wt_bad.len());
+    println!(
+        "fired analytic-volume ok    : {vol_ok} / {}   (bad: {}, no-oracle: {})",
+        fired_ids.len(),
+        vol_bad.len(),
+        no_oracle.len()
+    );
+    println!("param-vs-kernel |vol delta| histogram (fired, merged path):");
+    for (l, c) in ["<0.5%", "0.5-2%", "2-5%", "5-20%", "20-40%", ">40%"].iter().zip(kernel_hist.iter()) {
+        println!("  {l:>7} : {c}");
+    }
+    if !kernel_out_of_band.is_empty() {
+        println!("param/kernel volume ratio OUT of [{}, {}] band (informational):", KERNEL_BAND.0, KERNEL_BAND.1);
+        for (id, r) in kernel_out_of_band.iter().take(20) {
+            println!("  host #{id}: ratio {r:.3}");
+        }
+    }
+    if !nonfired_diverged.is_empty() {
+        println!("FINDING non-fired divergent ids: {:?}", &nonfired_diverged[..nonfired_diverged.len().min(20)]);
+    }
+    if !wt_bad.is_empty() {
+        println!("FINDING non-watertight fired ids: {:?}", &wt_bad[..wt_bad.len().min(20)]);
+    }
+    for (id, pv, truth) in vol_bad.iter().take(20) {
+        println!("FINDING analytic-volume miss host #{id}: param_vol={pv:.4} truth={truth:.4}");
+    }
+    if !no_oracle.is_empty() {
+        println!("no-oracle fired ids (probe failed post-hoc): {:?}", &no_oracle[..no_oracle.len().min(20)]);
+    }
+
+    let off_times: Vec<f64> = off_runs.iter().map(|r| r.2).collect();
+    let on_times: Vec<f64> = on_runs.iter().map(|r| r.2).collect();
+    let off_voids: Vec<f64> = off_runs.iter().map(|r| r.3).collect();
+    let on_voids: Vec<f64> = on_runs.iter().map(|r| r.3).collect();
+    let (om, nm) = (median(off_times.clone()), median(on_times.clone()));
+    let (ovm, nvm) = (median(off_voids.clone()), median(on_voids.clone()));
+    println!("\n--- timing (ABAB interleaved, {pairs} pairs) ---");
+    println!("raw OFF total ms: {:?}", off_times.iter().map(|v| *v as u64).collect::<Vec<_>>());
+    println!("raw ON  total ms: {:?}", on_times.iter().map(|v| *v as u64).collect::<Vec<_>>());
+    println!("median total : OFF {om:.0}ms  ON {nm:.0}ms  delta {:+.1}%", (nm - om) / om * 100.0);
+    println!("raw OFF voids ms: {:?}", off_voids.iter().map(|v| *v as u64).collect::<Vec<_>>());
+    println!("raw ON  voids ms: {:?}", on_voids.iter().map(|v| *v as u64).collect::<Vec<_>>());
+    println!(
+        "median voided-hosts only: OFF {ovm:.0}ms  ON {nvm:.0}ms  delta {:+.1}%",
+        if ovm > 0.0 { (nvm - ovm) / ovm * 100.0 } else { 0.0 }
+    );
+    println!("triangles: OFF {off_tris}  ON {on_tris}");
+
+    // --- assertions ---------------------------------------------------------
+    assert!(
+        nonfired_diverged.is_empty(),
+        "{} non-fired elements diverged ON vs OFF: {:?}",
+        nonfired_diverged.len(),
+        &nonfired_diverged[..nonfired_diverged.len().min(20)]
+    );
+    assert!(
+        wt_bad.is_empty(),
+        "{} fired hosts are not watertight: {:?}",
+        wt_bad.len(),
+        &wt_bad[..wt_bad.len().min(20)]
+    );
+    assert!(
+        vol_bad.is_empty(),
+        "{} fired hosts miss the analytic ground truth by >{ANALYTIC_VOL_TOL:.0e}: {:?}",
+        vol_bad.len(),
+        vol_bad.iter().map(|v| v.0).take(20).collect::<Vec<_>>()
+    );
+    println!("\nOK rect-param A/B clean on {path}");
+}

--- a/rust/geometry/tests/rect_param_validate.rs
+++ b/rust/geometry/tests/rect_param_validate.rs
@@ -31,8 +31,7 @@ use ifc_lite_core::{build_entity_index, has_geometry_by_name, DecodedEntity, Ent
 use ifc_lite_geometry::rect_fast::{param_set_enabled_override, take_param_fires};
 use ifc_lite_geometry::{propagate_voids_to_parts, GeometryRouter, Mesh, RectParam, SubMeshCollection};
 use nalgebra::Matrix3;
-use rustc_hash::FxHashMap;
-use std::collections::hash_map::DefaultHasher;
+use rustc_hash::{FxHashMap, FxHasher};
 use std::hash::{Hash, Hasher};
 use std::time::Instant;
 
@@ -62,11 +61,14 @@ fn build_void_index(content: &str, decoder: &mut EntityDecoder) -> FxHashMap<u32
     idx
 }
 
-/// Deterministic content fingerprint of a placed sub-mesh collection -- every
-/// bit the renderer consumes (geometry id, f32 positions/normals, indices, and
-/// the f64 local-frame origin), in submesh order. Same as dedup_validate.rs.
+/// Content fingerprint of a placed sub-mesh collection -- every bit the
+/// renderer consumes (geometry id, f32 positions/normals, indices, and the
+/// f64 local-frame origin), in submesh order; field coverage mirrors
+/// dedup_validate.rs. Hashed with the seed-free `FxHasher` so runs on the
+/// same toolchain produce stable values (`DefaultHasher` guarantees nothing
+/// across processes); the pass/fail comparison is ON-vs-OFF within one run.
 fn fingerprint(sm: &SubMeshCollection) -> u64 {
-    let mut h = DefaultHasher::new();
+    let mut h = FxHasher::default();
     sm.sub_meshes.len().hash(&mut h);
     for s in &sm.sub_meshes {
         s.geometry_id.hash(&mut h);

--- a/rust/geometry/tests/voids_common/mod.rs
+++ b/rust/geometry/tests/voids_common/mod.rs
@@ -4,7 +4,8 @@
 
 //! Shared helpers for the void-subtraction test suites
 //! (`voids_inline_matrix_test`, `voids_submesh_test`,
-//! `voids_production_test`).
+//! `voids_production_test`) and the void-cut regression tests
+//! (`issue_604_door_regression`, `issue_832_opening_representations`).
 //!
 //! Standard `tests/common`-style subdirectory module: Cargo does NOT
 //! compile this directory as its own integration-test crate; each test

--- a/rust/geometry/tests/voids_common/production.rs
+++ b/rust/geometry/tests/voids_common/production.rs
@@ -244,3 +244,21 @@ pub fn process_host_like_production(
         .process_element_with_voids(&entity, &mut decoder, void_index)
         .ok()
 }
+
+/// Fold `mesh.origin` into the positions (world = origin + position), leaving
+/// the origin zero. The parametric rect-opening fast path (default ON) emits
+/// the LOCAL-FRAME mesh contract every production consumer folds; tests that
+/// assert in world coordinates call this first so their checks stay in world
+/// space. No-op for a world-frame mesh (origin already zero).
+pub fn fold_origin(mesh: &mut Mesh) {
+    if mesh.origin == [0.0, 0.0, 0.0] {
+        return;
+    }
+    let o = mesh.origin;
+    for c in mesh.positions.chunks_exact_mut(3) {
+        c[0] = (c[0] as f64 + o[0]) as f32;
+        c[1] = (c[1] as f64 + o[1]) as f32;
+        c[2] = (c[2] as f64 + o[2]) as f32;
+    }
+    mesh.origin = [0.0, 0.0, 0.0];
+}

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -437,12 +437,13 @@ impl IfcAPI {
     /// Enable or disable the PARAMETRIC rectangular-opening fast path (the
     /// placement-frame, ground-truth-exact analytic cut) for `processGeometryBatch`.
     ///
-    /// DEFAULT OFF. This is the wasm-side toggle that lets native and wasm flip the
-    /// flag in LOCKSTEP — the byte-identical native==wasm contract requires both
-    /// targets take the same path, and wasm has no env to read `IFC_LITE_RECT_PARAM`.
+    /// DEFAULT ON (corpus-validated; native defaults ON too, and wasm has no env to
+    /// read `IFC_LITE_RECT_PARAM`, so both targets default in LOCKSTEP -- the
+    /// byte-identical native==wasm contract requires both take the same path). This
+    /// toggle is the wasm-side escape hatch mirroring `IFC_LITE_RECT_PARAM=0`.
     /// The path subtracts rectangular openings as exact parametric boxes in the host's
     /// own placement frame (rotated walls included), deferring any non-clean case to
-    /// the exact kernel. Pass `true` before `processGeometryBatch`.
+    /// the exact kernel. Pass `false` before `processGeometryBatch` to opt out.
     #[wasm_bindgen(js_name = setRectParamFastPath)]
     pub fn set_rect_param_fast_path(&self, enabled: bool) {
         ifc_lite_geometry::rect_fast::param_set_enabled_override(Some(enabled));


### PR DESCRIPTION
Lands perf-plan P1: corpus-validates the parametric rect-fast opening cut and flips `IFC_LITE_RECT_PARAM` default ON. This removes exact-kernel CSG for the rectangular-opening hosts it covers — the "do less work" lever, previously proven 100% correct + watertight on its firing subset but left dark.

## Validation (new harness, all 5 models PASS)

`rust/geometry/tests/rect_param_validate.rs` (the `dedup_validate.rs` pattern: `IFCLT_MODEL=...`, `--ignored`, ABAB-interleaved OFF/ON): drives the production submesh path per element, byte-compares non-fired elements, and holds fired hosts to the `rect_param_production` watertightness checker + the analytic box-minus-boxes oracle (`rect_param_parity` criteria). Run with `--profile server-release` (workspace `release` is `panic=abort`; documented in the file header).

| Model | jobs | voided hosts | fired | non-fired byte-identical | fired watertight | fired analytic-ok |
|---|---|---|---|---|---|---|
| AC20-FZK-Haus (control) | 124 | 9 | 1 | 123/123 | 1/1 | 1/1 |
| dental_clinic | 3,293 | 245 | 184 | 3,109/3,109 | 184/184 | 184/184 |
| ISSUE_129 (steel) | 1,331 | 73 | 0 | 1,331/1,331 | n/a | n/a |
| advanced_model | 14,364 | 82 | 34 | 14,330/14,330 | 34/34 | 34/34 |
| ISSUE_068 | 5,632 | 363 | 180 | 5,452/5,452 | 180/180 | 180/180 |

Zero divergent hosts. The historically documented 9-34% kernel-over-cut cases never fired on this corpus (the production in-bounds/reconcile gates defer engulfing cases); every fired output also agreed with the kernel within 0.5% by volume.

## Timing (ABAB medians; voids-only = the CSG share)

- dental_clinic: total -7.0%, voids-only **-9.8%**
- FZK-Haus -0.6% / advanced_model -0.8% / ISSUE_068 +0.9% total (noise band)
- ISSUE_129: fired 0 cuts (brep steel; the probe defers everything), so ON==OFF code path; its raw +20.7% median is sustained-load thermal drift (the OFF side itself drifted 216s -> 262s across pairs). Not a code-path regression.

Modest wins exactly where the path fires (arch models with rectangular openings); no regression elsewhere.

## The flip

- `rect_fast.rs`: OnceLock default `== Ok("1")` -> `!= Ok("0")` — opt-OUT via `IFC_LITE_RECT_PARAM=0`, doc comment rewritten. wasm has no env, so both targets land ON in lockstep; `setRectParamFastPath` remains the wasm-side escape hatch (doc updated, no code change needed).
- Changesets: `@ifc-lite/geometry` + `@ifc-lite/wasm` minor.

## Post-flip verification

- Full `cargo test --workspace --exclude ifc-lite-wasm`: green (109 targets). `clippy -D warnings`: clean. `cargo check` for wasm32: compiles.
- **Zero snapshot changes**; the three pinned kernel determinism manifests untouched and independently re-verified green during review.
- Two test-only fixes (same root cause, not geometry regressions): `issue_604_door_regression.rs` and `issue_832_opening_representations.rs` read raw `mesh.positions`, but fired outputs follow the local-frame contract (`world = origin + position`) that every production consumer folds. Both now fold `mesh.origin`; their load-bearing invariants (no coplanar sliver; bounded cuts) pass on the param output — an independent re-confirmation of cut correctness.

## Interaction with #1492 (mesh-determinism manifest, in flight)

The flip changes CSG-cut bytes on fired arch hosts, so whichever of this PR and #1492 lands second must re-pin the mesh-output manifest (the #1492 failure message prints the re-pin JSON; that is the designed workflow, not an accident).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rectangular-opening fast path is now enabled by default, improving cut accuracy and watertightness for supported cases.
  * WebAssembly and native builds now share the same default behavior, with clear opt-out controls available.
* **Bug Fixes**
  * Improved regression coverage for wall-opening geometry by normalizing mesh coordinates before validation.
  * Added validation checks to ensure consistent results between fast-path and fallback processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Confidence Score: 4/5</h3>

The production change is a single-line inversion of a feature-flag default that is well-gated and well-documented; the two test fixes correctly fold the local-frame origin before world-space assertions. Safe to merge.

The core flip in `rect_fast.rs` and the two regression-test origin fixes are clean and correct. The new harness is thorough, but has a small gap: if `parametric_rect_probe` fails post-hoc for all fired hosts, the volume assertions pass vacuously via the `no_oracle` branch. The `DefaultHasher` comment overstates stability guarantees. Both are limited to the `#[ignore]` test harness and do not affect production behaviour.

rust/geometry/tests/rect_param_validate.rs — the `no_oracle` branch and the `DefaultHasher` note are worth a second look before the harness is used for future corpus runs.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| rust/geometry/src/rect_fast.rs | One-line flip from opt-in to opt-out; the rest of the file is unchanged. The override path (0 → false, 1 → true, −1 → OnceLock) correctly bypasses the env-var cache for test overrides, and the OnceLock ensures the env var is read at most once. |
| rust/geometry/tests/rect_param_validate.rs | New 472-line manual corpus harness. Solid overall, but the analytic-volume validation silently passes when the post-hoc oracle fails for all fired hosts — no assertion guards the `no_oracle` list, so a broken `parametric_rect_probe` would produce a green run. |
| rust/geometry/tests/issue_604_door_regression.rs | Adds local-frame origin folding before world-space AABB checks; the cast chain (f32 → f64 + f64 origin → f32) is correct and safe for building-scale coordinates. |
| rust/geometry/tests/issue_832_opening_representations.rs | Same origin-folding fix as issue_604; applied to the per-wall loop so every tested wall gets the fold before the bounding-band assertions. |
| rust/wasm-bindings/src/api/mod.rs | Doc-only update mirroring the wasm TypeScript definition; the underlying `param_set_enabled_override` call is unchanged. |
| packages/wasm/pkg/ifc-lite.d.ts | JSDoc updated to reflect the DEFAULT ON semantics and the opt-out pattern; no code change. |
| .changeset/rect-param-default-on.md | Accurate minor-bump changeset for both @ifc-lite/geometry and @ifc-lite/wasm; matches the behavioral change scope. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `rust/geometry/tests/rect_param_validate.rs`, line 527-537 ([link](https://github.com/ltplus-ag/ifc-lite/blob/dfb14393275185342317d1a87aba540f088df4cb/rust/geometry/tests/rect_param_validate.rs#L527-L537)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Silent pass when oracle is unavailable for all fired hosts**

   If `analytic_cut_volume` returns `None` (or `Some(truth)` where `truth <= 1e-9`) for every fired host, all of them land in `no_oracle` — nothing is added to `vol_bad` — and `assert!(vol_bad.is_empty())` passes trivially. A future refactoring that breaks `parametric_rect_probe` for the whole corpus would produce a fully-green run with a non-empty `no_oracle` printed to stdout and no assertion failure. Consider adding a check such as `assert!(no_oracle.is_empty() || vol_ok > 0, "oracle failed for all fired hosts — volume validation skipped entirely")` to guard against this silent pass.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["chore(wasm): regenerate committed ifc-li..."](https://github.com/ltplus-ag/ifc-lite/commit/dfb14393275185342317d1a87aba540f088df4cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41218459)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->