### PR TITLE
feat(observability): structured geometry diagnostics + wasm PipelineDiagnostics

### DIFF
--- a/.changeset/pipeline-observability.md
+++ b/.changeset/pipeline-observability.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": minor
+---
+
+Add `IfcAPI.getPipelineDiagnostics()`: a structured, versioned per-load diagnostics object (schemaVersion + summed geometry wall time, mesh/triangle counts, degenerate-backstop drops, and CSG failure aggregates) accumulated across every `processGeometryBatch*` call and reset on load boundaries. Complements the existing `diagnoseGeometry` channel; always on (cheap counters, JS clock so it is wasm-safe). Native geometry diagnostics also gain structured `tracing` coverage behind a default-off `observability` cargo feature; default builds are byte-unchanged.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,6 +1536,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -29,7 +29,10 @@ ifc-lite-core = { path = "../../rust/core" }
 # triple (Manifold/BSP removed at M9; see
 # docs/architecture/pure-rust-csg-kernel.md).
 ifc-lite-geometry = { path = "../../rust/geometry", default-features = false }
-ifc-lite-processing = { path = "../../rust/processing" }
+# `observability` routes the geometry crate's production diagnostics through
+# tracing so they land in this server's existing subscriber (main.rs) as
+# structured events instead of raw stderr lines.
+ifc-lite-processing = { path = "../../rust/processing", features = ["observability"] }
 
 # Parallelism
 rayon = "1.10"

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -291,6 +291,15 @@ export class IfcAPI {
    */
   extractProfiles(content: string, model_index: number): ProfileCollection;
   /**
+   * Structured pipeline diagnostics accumulated across every
+   * `processGeometryBatch*` call since the last load reset
+   * (`clearPrePassCache` / `setEntityIndex`), as a JS object with a
+   * `schemaVersion` field — or `undefined` when no batch has run yet.
+   * Includes per-batch summed geometry wall time, mesh/triangle counts,
+   * the degenerate-backstop drop count, and the CSG failure aggregates.
+   */
+  getPipelineDiagnostics(): any;
+  /**
    * Get WASM memory for zero-copy access
    */
   getMemory(): any;
@@ -1110,6 +1119,7 @@ export interface InitOutput {
   readonly ifcapi_exportStep: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number) => void;
   readonly ifcapi_extractProfiles: (a: number, b: number, c: number, d: number) => number;
   readonly ifcapi_getMemory: (a: number) => number;
+  readonly ifcapi_getPipelineDiagnostics: (a: number) => number;
   readonly ifcapi_is_ready: (a: number) => number;
   readonly ifcapi_new: () => number;
   readonly ifcapi_parseAlignmentLines: (a: number, b: number, c: number) => number;

--- a/rust/geometry/Cargo.toml
+++ b/rust/geometry/Cargo.toml
@@ -22,6 +22,13 @@ debug_geometry = []
 # global buffer so a bench can replay the real CSG corpus under varying thread
 # counts. Zero cost when absent. See src/csg_capture.rs.
 csg_capture = []
+# Structured diagnostics: routes the production warn/debug messages through
+# `tracing` (structured fields, subscriber-controlled) instead of eprintln.
+# Default OFF so default builds carry no tracing code in this crate; the
+# native server enables it (via ifc-lite-processing/observability) so
+# geometry-crate diagnostics land in its existing tracing subscriber.
+# See src/diag.rs for the warn-vs-debug gating policy.
+observability = ["dep:tracing"]
 
 [dependencies]
 
@@ -62,6 +69,13 @@ smallvec = "1.13"
 
 # Error handling
 thiserror = "2.0"
+
+# Structured diagnostics, only behind the `observability` feature (dep:tracing
+# keeps it out of default builds entirely). Package-local on purpose: the
+# workspace root does not force tracing on every crate. ifc-lite-processing
+# already depends on tracing unconditionally, so enabling the feature adds no
+# new crate to consumers that use both.
+tracing = { version = "0.1", optional = true }
 
 # Pure-Rust CSG kernel (`kernel/`) — exact geometric predicates.
 # geometry-predicates: Shewchuk adaptive predicates + the public expansion

--- a/rust/geometry/src/diag.rs
+++ b/rust/geometry/src/diag.rs
@@ -1,0 +1,75 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Structured-diagnostics shims for the `observability` cargo feature.
+//!
+//! This crate's production diagnostics historically went to stderr via
+//! `eprintln!`. With the `observability` feature ON they become structured
+//! `tracing` events (fields instead of prose) that flow into whatever
+//! subscriber the host installed — the native server already runs a
+//! `tracing_subscriber::fmt` layer, so enabling the feature there is enough.
+//! With the feature OFF (the default), zero tracing code is compiled into
+//! this crate and behavior is byte-identical to before.
+//!
+//! Gating policy (documented decision):
+//!
+//! - WARN-level sites report genuine anomalies that operators currently see
+//!   on the server's stderr in default builds (failed layer slicing, degraded
+//!   fallbacks). Those messages must NOT silently disappear from default
+//!   builds, so [`diag_warn!`] keeps the legacy `eprintln!` as the
+//!   feature-OFF fallback and upgrades to `tracing::warn!` when ON.
+//!
+//! - DEBUG-level sites are high-volume trace/progress notes that were
+//!   already compile-time gated (`debug_assertions` or the `debug_geometry`
+//!   feature) or are pure success chatter. [`diag_debug!`] emits
+//!   `tracing::debug!` when ON; when OFF it expands to exactly the legacy
+//!   tokens the call site supplies (which may themselves carry the original
+//!   `#[cfg(...)]` gate, preserving today's behavior precisely).
+//!
+//! Both macros take the tracing form first and the legacy statements second,
+//! so the feature-OFF expansion reproduces the OLD output byte-for-byte:
+//!
+//! ```ignore
+//! diag_warn!(
+//!     { element_id = element.id, "material-layers: slicing errored" }
+//!     else {
+//!         eprintln!("[material-layers] #{}: sliceable but slicing errored", element.id);
+//!     }
+//! );
+//! ```
+
+/// Anomaly-level diagnostic: `tracing::warn!` when the `observability`
+/// feature is ON, the supplied legacy statements (normally the original
+/// `eprintln!`) when OFF. See the module docs for the gating policy.
+macro_rules! diag_warn {
+    ({ $($trace:tt)+ } else { $($legacy:tt)* }) => {{
+        #[cfg(feature = "observability")]
+        {
+            ::tracing::warn!($($trace)+);
+        }
+        #[cfg(not(feature = "observability"))]
+        {
+            $($legacy)*
+        }
+    }};
+}
+
+/// Trace/progress-level diagnostic: `tracing::debug!` when the
+/// `observability` feature is ON, the supplied legacy statements when OFF
+/// (pass an empty `else {}` to compile out entirely). See the module docs.
+macro_rules! diag_debug {
+    ({ $($trace:tt)+ } else { $($legacy:tt)* }) => {{
+        #[cfg(feature = "observability")]
+        {
+            ::tracing::debug!($($trace)+);
+        }
+        #[cfg(not(feature = "observability"))]
+        {
+            $($legacy)*
+        }
+    }};
+}
+
+pub(crate) use diag_debug;
+pub(crate) use diag_warn;

--- a/rust/geometry/src/lib.rs
+++ b/rust/geometry/src/lib.rs
@@ -81,6 +81,9 @@ pub mod csg_capture;
 /// Corrects f32 import jitter (~0.09°) so authored-coplanar roof slope facets
 /// are EXACTLY coplanar before the exact-kernel opening cut (issue #1007).
 pub mod facet_weld;
+/// Structured-diagnostics macro shims for the `observability` feature
+/// (tracing when ON, the legacy eprintln fallback when OFF).
+pub(crate) mod diag;
 pub mod diagnostics;
 pub mod error;
 pub mod congruence;

--- a/rust/geometry/src/processors/advanced.rs
+++ b/rust/geometry/src/processors/advanced.rs
@@ -56,7 +56,7 @@ impl GeometryProcessor for AdvancedBrepProcessor {
         let mut all_positions = Vec::new();
         let mut all_indices = Vec::new();
 
-        #[cfg(feature = "debug_geometry")]
+        #[cfg(any(feature = "debug_geometry", feature = "observability"))]
         let mut empty_faces: Vec<(u32, String)> = Vec::new();
 
         for face_ref in faces {
@@ -74,7 +74,7 @@ impl GeometryProcessor for AdvancedBrepProcessor {
                         all_indices.push(base_idx + idx);
                     }
                 } else {
-                    #[cfg(feature = "debug_geometry")]
+                    #[cfg(any(feature = "debug_geometry", feature = "observability"))]
                     {
                         let surface_kind = face
                             .get(1)
@@ -87,13 +87,23 @@ impl GeometryProcessor for AdvancedBrepProcessor {
             }
         }
 
-        #[cfg(feature = "debug_geometry")]
+        // Geometry loss on an advanced brep (faces that meshed to nothing) is
+        // a genuine anomaly: warn-level under observability. The legacy
+        // stderr line stays gated behind debug_geometry as before.
+        #[cfg(any(feature = "debug_geometry", feature = "observability"))]
         if !empty_faces.is_empty() {
-            eprintln!(
-                "[ifc-lite][advanced_brep] entity #{} produced {} empty face(s): {:?}",
-                entity.id,
-                empty_faces.len(),
-                empty_faces
+            crate::diag::diag_warn!(
+                { entity_id = entity.id, empty_faces = empty_faces.len(),
+                  faces = ?empty_faces, "advanced_brep: entity produced empty faces" }
+                else {
+                    #[cfg(feature = "debug_geometry")]
+                    eprintln!(
+                        "[ifc-lite][advanced_brep] entity #{} produced {} empty face(s): {:?}",
+                        entity.id,
+                        empty_faces.len(),
+                        empty_faces
+                    );
+                }
             );
         }
 

--- a/rust/geometry/src/processors/advanced_face/mod.rs
+++ b/rust/geometry/src/processors/advanced_face/mod.rs
@@ -80,26 +80,38 @@ pub(super) fn process_advanced_face(
         process_planar_face(face, decoder, quality)
     } else {
         // Unsupported surface type - return empty geometry
-        #[cfg(feature = "debug_geometry")]
-        eprintln!(
-            "[ifc-lite][advanced_face] face #{} unsupported surface {}",
-            face.id, surface_type
+        crate::diag::diag_debug!(
+            { face_id = face.id, surface = %surface_type,
+              "advanced_face: unsupported surface type, emitting empty geometry" }
+            else {
+                #[cfg(feature = "debug_geometry")]
+                eprintln!(
+                    "[ifc-lite][advanced_face] face #{} unsupported surface {}",
+                    face.id, surface_type
+                );
+            }
         );
         Ok((Vec::new(), Vec::new()))
     };
 
-    #[cfg(feature = "debug_geometry")]
-    {
-        if let Ok((ref pos, ref idx)) = result {
-            if pos.is_empty() || idx.is_empty() {
-                eprintln!(
-                    "[ifc-lite][advanced_face] face #{} surface={} produced 0 tris (verts={}, idx={})",
-                    face.id,
-                    surface_type,
-                    pos.len() / 3,
-                    idx.len() / 3,
-                );
-            }
+    #[cfg(any(feature = "debug_geometry", feature = "observability"))]
+    if let Ok((ref pos, ref idx)) = result {
+        if pos.is_empty() || idx.is_empty() {
+            crate::diag::diag_debug!(
+                { face_id = face.id, surface = %surface_type,
+                  verts = pos.len() / 3, indices = idx.len() / 3,
+                  "advanced_face: face produced zero triangles" }
+                else {
+                    #[cfg(feature = "debug_geometry")]
+                    eprintln!(
+                        "[ifc-lite][advanced_face] face #{} surface={} produced 0 tris (verts={}, idx={})",
+                        face.id,
+                        surface_type,
+                        pos.len() / 3,
+                        idx.len() / 3,
+                    );
+                }
+            );
         }
     }
 

--- a/rust/geometry/src/profile_extractor.rs
+++ b/rust/geometry/src/profile_extractor.rs
@@ -183,8 +183,14 @@ where
                     ) {
                         Ok(entry) => results.push(entry),
                         Err(_e) => {
-                            #[cfg(feature = "debug_geometry")]
-                            eprintln!("[profile_extractor] Skipping #{id} ({ifc_type_name}): {_e}");
+                            crate::diag::diag_debug!(
+                                { element_id = id, ifc_type = %ifc_type_name, error = %_e,
+                                  "profile_extractor: skipping element" }
+                                else {
+                                    #[cfg(feature = "debug_geometry")]
+                                    eprintln!("[profile_extractor] Skipping #{id} ({ifc_type_name}): {_e}");
+                                }
+                            );
                         }
                     }
                 } else if item.ifc_type == IfcType::IfcMappedItem {
@@ -238,8 +244,14 @@ fn extract_mapped_item_profiles(
     results: &mut Vec<ExtractedProfile>,
 ) {
     if depth > MAX_MAPPED_DEPTH {
-        #[cfg(feature = "debug_geometry")]
-        eprintln!("[profile_extractor] #{element_id} ({ifc_type}): max mapped item depth exceeded");
+        crate::diag::diag_debug!(
+            { element_id, ifc_type = %ifc_type, max_depth = MAX_MAPPED_DEPTH,
+              "profile_extractor: max mapped item depth exceeded" }
+            else {
+                #[cfg(feature = "debug_geometry")]
+                eprintln!("[profile_extractor] #{element_id} ({ifc_type}): max mapped item depth exceeded");
+            }
+        );
         return;
     }
 
@@ -297,8 +309,14 @@ fn extract_mapped_item_profiles(
             ) {
                 Ok(entry) => results.push(entry),
                 Err(_e) => {
-                    #[cfg(feature = "debug_geometry")]
-                    eprintln!("[profile_extractor] #{element_id} ({ifc_type}) mapped: {_e}");
+                    crate::diag::diag_debug!(
+                        { element_id, ifc_type = %ifc_type, error = %_e,
+                          "profile_extractor: skipping mapped item solid" }
+                        else {
+                            #[cfg(feature = "debug_geometry")]
+                            eprintln!("[profile_extractor] #{element_id} ({ifc_type}) mapped: {_e}");
+                        }
+                    );
                 }
             }
         } else if sub_item.ifc_type == IfcType::IfcMappedItem {
@@ -428,10 +446,17 @@ fn extract_extruded_solid(
     // Depth (attr 3) — required per IFC spec but default to 1.0 for robustness
     // with malformed files (logged under debug_geometry feature)
     let raw_depth = solid.get(3).and_then(|v| v.as_float());
-    #[cfg(feature = "debug_geometry")]
+    #[cfg(any(feature = "debug_geometry", feature = "observability"))]
     if raw_depth.is_none() {
-        eprintln!(
-            "[profile_extractor] #{element_id} ({ifc_type}): missing Depth, defaulting to 1.0"
+        crate::diag::diag_debug!(
+            { element_id, ifc_type = %ifc_type,
+              "profile_extractor: missing Depth, defaulting to 1.0" }
+            else {
+                #[cfg(feature = "debug_geometry")]
+                eprintln!(
+                    "[profile_extractor] #{element_id} ({ifc_type}): missing Depth, defaulting to 1.0"
+                );
+            }
         );
     }
     let depth = raw_depth.unwrap_or(1.0) * unit_scale;

--- a/rust/geometry/src/router/layers.rs
+++ b/rust/geometry/src/router/layers.rs
@@ -62,24 +62,43 @@ impl GeometryRouter {
             Ok(None) => return None,
             Err(_e) => {
                 // A sliceable wall whose base-mesh build errored falls back to a
-                // single solid. Record for the browser; eprintln for native.
+                // single solid. Record for the browser; warn for native.
                 self.push_layer_slice_diag(element.id, "skip:base-mesh-error");
-                eprintln!("[material-layers] #{}: sliceable but slicing errored", element.id);
+                crate::diag::diag_warn!(
+                    { element_id = element.id, reason = "base-mesh-error",
+                      "material-layers: sliceable element failed to slice, keeping single solid" }
+                    else {
+                        eprintln!("[material-layers] #{}: sliceable but slicing errored", element.id);
+                    }
+                );
                 return None;
             }
         };
         if collection.sub_meshes.len() < 2 {
-            eprintln!(
-                "[material-layers] #{}: sliceable but produced {} sub-mesh(es) (<2) — keeping single solid",
-                element.id,
-                collection.sub_meshes.len()
+            crate::diag::diag_warn!(
+                { element_id = element.id, sub_meshes = collection.sub_meshes.len(),
+                  reason = "fewer-than-two-sub-meshes",
+                  "material-layers: sliceable element produced too few sub-meshes, keeping single solid" }
+                else {
+                    eprintln!(
+                        "[material-layers] #{}: sliceable but produced {} sub-mesh(es) (<2) — keeping single solid",
+                        element.id,
+                        collection.sub_meshes.len()
+                    );
+                }
             );
             return None;
         }
-        eprintln!(
-            "[material-layers] #{}: sliced into {} layer sub-meshes",
-            element.id,
-            collection.sub_meshes.len()
+        crate::diag::diag_debug!(
+            { element_id = element.id, sub_meshes = collection.sub_meshes.len(),
+              "material-layers: sliced element into layer sub-meshes" }
+            else {
+                eprintln!(
+                    "[material-layers] #{}: sliced into {} layer sub-meshes",
+                    element.id,
+                    collection.sub_meshes.len()
+                );
+            }
         );
         // Mesh hygiene: slicing the base mesh by layer-interface planes can
         // introduce zero-area/collinear slivers at the cut, and this layered

--- a/rust/geometry/src/router/processing.rs
+++ b/rust/geometry/src/router/processing.rs
@@ -466,10 +466,16 @@ impl GeometryRouter {
                         depth + 1,
                         visited,
                     ) {
-                        #[cfg(debug_assertions)]
-                        eprintln!(
-                            "[ifc-lite] Skipping unsupported nested geometry #{} ({:?}): {}",
-                            nested_item.id, nested_item.ifc_type, _e
+                        crate::diag::diag_debug!(
+                            { item_id = nested_item.id, ifc_type = ?nested_item.ifc_type,
+                              error = %_e, "skipping unsupported nested geometry item" }
+                            else {
+                                #[cfg(debug_assertions)]
+                                eprintln!(
+                                    "[ifc-lite] Skipping unsupported nested geometry #{} ({:?}): {}",
+                                    nested_item.id, nested_item.ifc_type, _e
+                                );
+                            }
                         );
                         continue;
                     }
@@ -518,10 +524,16 @@ impl GeometryRouter {
                     }
                 }
                 Err(_e) => {
-                    #[cfg(debug_assertions)]
-                    eprintln!(
-                        "[ifc-lite] Skipping unsupported geometry #{} ({:?}): {}",
-                        item.id, item.ifc_type, _e
+                    crate::diag::diag_debug!(
+                        { item_id = item.id, ifc_type = ?item.ifc_type, error = %_e,
+                          "skipping unsupported geometry item" }
+                        else {
+                            #[cfg(debug_assertions)]
+                            eprintln!(
+                                "[ifc-lite] Skipping unsupported geometry #{} ({:?}): {}",
+                                item.id, item.ifc_type, _e
+                            );
+                        }
                     );
                 }
             }

--- a/rust/geometry/src/router/voids/mod.rs
+++ b/rust/geometry/src/router/voids/mod.rs
@@ -1668,13 +1668,21 @@ impl GeometryRouter {
                             // fires, so round windows (post profile
                             // simplification) can be confirmed to hit CSG and
                             // only genuinely-uncut voids land on the box cut.
-                            #[cfg(any(debug_assertions, test))]
-                            {
-                                eprintln!(
-                                    "[issue-635] AABB fallback used: opening={} tris (CSG produced no change)",
-                                    opening_mesh.triangle_count()
-                                );
-                            }
+                            // A genuine degraded mode, so warn-level under
+                            // observability; the legacy debug/test-only
+                            // eprintln is preserved otherwise.
+                            crate::diag::diag_warn!(
+                                { opening_tris = opening_mesh.triangle_count(),
+                                  reason = "csg-produced-no-change",
+                                  "voids: AABB fallback cut used for opening" }
+                                else {
+                                    #[cfg(any(debug_assertions, test))]
+                                    eprintln!(
+                                        "[issue-635] AABB fallback used: opening={} tris (CSG produced no change)",
+                                        opening_mesh.triangle_count()
+                                    );
+                                }
+                            );
                             // Deliberate degraded mode: this fallback removes
                             // the wall material inside the opening AABB but no
                             // longer emits reveal/recess quads (deleted with

--- a/rust/processing/Cargo.toml
+++ b/rust/processing/Cargo.toml
@@ -19,6 +19,12 @@ readme = "../../README.md"
 # `csg_scaling_bench` example can replay real void-cut jobs. See
 # rust/processing/examples/csg_scaling_bench.rs.
 csg-capture = ["ifc-lite-geometry/csg_capture"]
+# Structured diagnostics in the geometry crate: routes its production
+# warn/debug messages through `tracing` (this crate already depends on
+# tracing unconditionally, so the flag only affects ifc-lite-geometry).
+# Enabled by the native server; default OFF keeps wasm/default builds
+# byte-identical.
+observability = ["ifc-lite-geometry/observability"]
 
 [[example]]
 name = "csg_scaling_bench"

--- a/rust/processing/src/element.rs
+++ b/rust/processing/src/element.rs
@@ -176,6 +176,12 @@ pub struct ProducedElementMeshes {
     /// the same cuts) are discarded — only the path that produced the
     /// returned meshes contributes.
     pub csg_failures: FxHashMap<u32, Vec<BoolFailure>>,
+    /// Triangles dropped by the f32-collapse degenerate-triangle backstop
+    /// (`drop_degenerate_triangles` in `build_mesh_data`) across ALL of this
+    /// element's meshes. Zero when the backstop is disabled or nothing was
+    /// degenerate. Request-local (scoped per `produce_element_meshes` call)
+    /// so concurrent passes never cross-contaminate.
+    pub degenerate_triangles_dropped: u64,
 }
 
 /// THE canonical per-element mesh producer.
@@ -202,6 +208,14 @@ pub fn produce_element_meshes(
     // distributed cost. Unbounded under the server/offline-export profile.
     ifc_lite_geometry::kernel::budget::begin_element();
 
+    // Open this element's degenerate-backstop scope (same begin/drain shape as
+    // the kernel budget above): `build_mesh_data` adds to the thread-local as
+    // it drops collapsed triangles, and we drain it into the result below.
+    // Thread-local is correct on both pipelines: the native rayon loop runs
+    // one element entirely on one worker thread, and the wasm batch loop is
+    // serial.
+    DEGENERATE_DROPPED.with(|c| c.set(0));
+
     let mut hasher = match (&job.kind, opts.geometry_hash) {
         (ElementJobKind::Product, Some(cfg)) => {
             Some(GeometryHasher::new(cfg.tolerance, cfg.world_rtc))
@@ -217,11 +231,21 @@ pub fn produce_element_meshes(
 
     let geometry_hash = hasher.and_then(|h| if h.is_empty() { None } else { Some(h.finish()) });
 
+    let degenerate_triangles_dropped = DEGENERATE_DROPPED.with(|c| c.get());
+
     ProducedElementMeshes {
         meshes,
         geometry_hash,
         csg_failures,
+        degenerate_triangles_dropped,
     }
+}
+
+thread_local! {
+    /// Per-element degenerate-backstop drop tally. Reset at the top of
+    /// `produce_element_meshes`, incremented by `build_mesh_data`, drained
+    /// into [`ProducedElementMeshes::degenerate_triangles_dropped`].
+    static DEGENERATE_DROPPED: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
 }
 
 fn produce_inner(
@@ -572,7 +596,14 @@ fn build_mesh_data(
     // collapse is PREVENTED upstream and this drops nothing; it stays as the
     // defence-in-depth safety net for any element still too large for its frame.
     if !degenerate_backstop_disabled() {
+        let indices_before = mesh.indices.len();
         mesh.drop_degenerate_triangles();
+        let dropped = ((indices_before - mesh.indices.len()) / 3) as u64;
+        if dropped > 0 {
+            // Diagnostic tally only — the drop itself is unchanged. Drained
+            // per element by `produce_element_meshes` (see DEGENERATE_DROPPED).
+            DEGENERATE_DROPPED.with(|c| c.set(c.get() + dropped));
+        }
     }
     let mesh_origin = mesh.origin;
     // Instancing: capture before the fields are moved into MeshData. A site-local

--- a/rust/processing/src/lib.rs
+++ b/rust/processing/src/lib.rs
@@ -10,6 +10,7 @@
 pub mod element;
 pub mod geometry_export;
 mod georeferencing;
+pub mod pipeline_diagnostics;
 pub mod prepass;
 mod processor;
 pub mod style;
@@ -18,6 +19,9 @@ mod types;
 
 pub use geometry_export::{build_geometry_data_export, ExportedElement, GeometryDataExport};
 pub use georeferencing::{extract_georeferencing, Georeferencing};
+pub use pipeline_diagnostics::{
+    PipelineDiagnostics, PipelinePhaseTimings, PIPELINE_DIAGNOSTICS_SCHEMA_VERSION,
+};
 /// Re-exported so the server can name the quality level without a direct
 /// `ifc-lite-geometry` dependency edge for one enum.
 pub use ifc_lite_geometry::TessellationQuality;

--- a/rust/processing/src/pipeline_diagnostics.rs
+++ b/rust/processing/src/pipeline_diagnostics.rs
@@ -1,0 +1,284 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Structured per-load pipeline diagnostics — the cross-target contract.
+//!
+//! Lives in `ifc-lite-processing` (not the geometry crate) because this is
+//! where the per-phase numbers are actually collected: the phase timers
+//! (`ProcessingStats.{parse,entity_scan,lookup,preprocess,geometry}_time_ms`)
+//! are measured by `processor::process_geometry_*`, and the per-element
+//! production counters (degenerate-backstop drops, CSG failure drains) are
+//! owned by `element::produce_element_meshes`. The geometry crate only knows
+//! router-level CSG/opening data, which it already publishes as
+//! [`ifc_lite_geometry::GeometryDiagnostics`]; this struct composes those
+//! aggregates with the pipeline-level timings and counts.
+//!
+//! Serde contract: `camelCase` renames plus an explicit `schema_version`, the
+//! same pattern as `GeometryDiagnostics` (see its
+//! `serializes_camelcase_keys_matching_the_ts_contract` guard, mirrored
+//! below). The wasm getter (`IfcAPI::getPipelineDiagnostics`) crosses it to
+//! JS via `serde_wasm_bindgen::to_value`, exactly like `diagnoseGeometry`.
+//!
+//! Population:
+//! - wasm: accumulated on the NORMAL load path — every
+//!   `processGeometryBatch*` call folds one [`Self::record_batch`] in
+//!   (cheap counters plus two `js_sys::Date::now()` reads per batch, so it
+//!   is always on). `std::time::Instant` traps on wasm32, so the wasm side
+//!   fills only `phase_ms.geometry_ms` (summed batch wall time); the
+//!   scan/prepass phases run in JS workers outside the wasm module and are
+//!   reported as 0 there.
+//! - native: one-shot from the finished pass via
+//!   [`Self::from_processing_stats`], which maps the full `ProcessingStats`
+//!   phase timers.
+
+use crate::types::response::ProcessingStats;
+use ifc_lite_geometry::{GeometryDiagnostics, RectFastSummary};
+
+/// Version of the `PipelineDiagnostics` wire shape. Bump on any
+/// breaking key change so JS consumers can gate on it.
+pub const PIPELINE_DIAGNOSTICS_SCHEMA_VERSION: u32 = 1;
+
+/// Pipeline phase wall-times in milliseconds. Field names mirror the
+/// `ProcessingStats` timers they are sourced from. On wasm32 only
+/// `geometry_ms` is populated (see the module docs).
+#[derive(Debug, Clone, Copy, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PipelinePhaseTimings {
+    /// Entity scan + prepass span-stash/resolve.
+    pub entity_scan_ms: u64,
+    /// Lookup/style/property resolution.
+    pub lookup_ms: u64,
+    /// Geometry preprocessing (unit scales, RTC detection, site transforms).
+    pub preprocess_ms: u64,
+    /// Whole parse phase (scan + lookup + preprocess).
+    pub parse_ms: u64,
+    /// Per-element geometry extraction (meshing + CSG).
+    pub geometry_ms: u64,
+    /// End-to-end wall time of the pass.
+    pub total_ms: u64,
+}
+
+/// Aggregate structured diagnostics for one model load. Counter names are
+/// aligned with the existing [`GeometryDiagnostics`] contract
+/// (`total_csg_failures`, `hosts_with_openings`, `rect_fast`, ...) so a
+/// consumer reading both sees one vocabulary.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PipelineDiagnostics {
+    /// Wire-shape version ([`PIPELINE_DIAGNOSTICS_SCHEMA_VERSION`]).
+    pub schema_version: u32,
+    /// Geometry passes folded in: one per `processGeometryBatch*` call on
+    /// wasm, exactly 1 for the native single-pass pipeline.
+    pub batches: u64,
+    /// Element jobs submitted to the per-element producer.
+    pub element_count: u64,
+    /// Meshes emitted across all batches.
+    pub mesh_count: u64,
+    /// Triangles emitted across all batches.
+    pub triangle_count: u64,
+    /// Triangles removed by the f32-collapse degenerate-triangle backstop
+    /// (`element::build_mesh_data`). Non-zero means the backstop engaged.
+    pub backstop_count: u64,
+    /// Total CSG boolean failures (same meaning as
+    /// `GeometryDiagnostics::total_csg_failures`).
+    pub total_csg_failures: u64,
+    /// Distinct products with at least one CSG failure.
+    pub products_with_failures: u64,
+    /// Hosts that had openings processed.
+    pub hosts_with_openings: u64,
+    /// Hosts where rect cutters ran clean but the mesh came out unchanged.
+    pub silent_no_ops: u64,
+    /// rect_fast fast-path engagement, summed across batches.
+    pub rect_fast: RectFastSummary,
+    /// Phase wall-times (native: full; wasm: geometry only).
+    pub phase_ms: PipelinePhaseTimings,
+}
+
+impl Default for PipelineDiagnostics {
+    fn default() -> Self {
+        Self {
+            schema_version: PIPELINE_DIAGNOSTICS_SCHEMA_VERSION,
+            batches: 0,
+            element_count: 0,
+            mesh_count: 0,
+            triangle_count: 0,
+            backstop_count: 0,
+            total_csg_failures: 0,
+            products_with_failures: 0,
+            hosts_with_openings: 0,
+            silent_no_ops: 0,
+            rect_fast: RectFastSummary::default(),
+            phase_ms: PipelinePhaseTimings::default(),
+        }
+    }
+}
+
+impl PipelineDiagnostics {
+    /// Fold one geometry batch into the accumulator (the wasm
+    /// `processGeometryBatch*` path calls this once per batch).
+    /// `geometry_ms` is the batch's wall time; `diag` is the batch's drained
+    /// [`GeometryDiagnostics`]. Summing per-batch aggregates is exact because
+    /// each batch drains its own router (no double counting).
+    #[allow(clippy::too_many_arguments)]
+    pub fn record_batch(
+        &mut self,
+        element_count: u64,
+        mesh_count: u64,
+        triangle_count: u64,
+        backstop_count: u64,
+        geometry_ms: u64,
+        diag: &GeometryDiagnostics,
+    ) {
+        self.batches += 1;
+        self.element_count += element_count;
+        self.mesh_count += mesh_count;
+        self.triangle_count += triangle_count;
+        self.backstop_count += backstop_count;
+        self.total_csg_failures += diag.total_csg_failures;
+        self.products_with_failures += diag.products_with_failures;
+        self.hosts_with_openings += diag.hosts_with_openings;
+        self.silent_no_ops += diag.silent_no_ops;
+        self.rect_fast.fired += diag.rect_fast.fired;
+        self.rect_fast.openings_cut += diag.rect_fast.openings_cut;
+        self.rect_fast.defer_host_not_box += diag.rect_fast.defer_host_not_box;
+        self.rect_fast.defer_not_through += diag.rect_fast.defer_not_through;
+        self.rect_fast.defer_off_face += diag.rect_fast.defer_off_face;
+        self.rect_fast.defer_near_edge += diag.rect_fast.defer_near_edge;
+        self.rect_fast.defer_no_openings += diag.rect_fast.defer_no_openings;
+        self.phase_ms.geometry_ms += geometry_ms;
+        self.phase_ms.total_ms += geometry_ms;
+    }
+
+    /// Build the same contract from a finished native pass. The native
+    /// pipeline is single-pass, so `batches` is 1 and every phase timer is
+    /// available.
+    pub fn from_processing_stats(stats: &ProcessingStats, element_count: u64) -> Self {
+        let (hosts_with_openings, silent_no_ops, rect_fast) = match &stats.geometry_diagnostics {
+            Some(d) => (d.hosts_with_openings, d.silent_no_ops, d.rect_fast),
+            None => (0, 0, RectFastSummary::default()),
+        };
+        Self {
+            schema_version: PIPELINE_DIAGNOSTICS_SCHEMA_VERSION,
+            batches: 1,
+            element_count,
+            mesh_count: stats.total_meshes as u64,
+            triangle_count: stats.total_triangles as u64,
+            backstop_count: stats.degenerate_triangles_dropped,
+            total_csg_failures: stats.total_csg_failures,
+            products_with_failures: stats.products_with_failures,
+            hosts_with_openings,
+            silent_no_ops,
+            rect_fast,
+            phase_ms: PipelinePhaseTimings {
+                entity_scan_ms: stats.entity_scan_time_ms,
+                lookup_ms: stats.lookup_time_ms,
+                preprocess_ms: stats.preprocess_time_ms,
+                parse_ms: stats.parse_time_ms,
+                geometry_ms: stats.geometry_time_ms,
+                total_ms: stats.total_time_ms,
+            },
+        }
+    }
+
+    /// Whether anything has been recorded — the wasm getter returns
+    /// `undefined` before the first batch so consumers can gate on presence.
+    pub fn is_empty(&self) -> bool {
+        self.batches == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serializes_camelcase_keys_matching_the_ts_contract() {
+        // Guard the serde rename_all against drift from the TS-side consumer.
+        // The wasm getter uses the same renames via serde-wasm-bindgen, so
+        // this JSON key set is what crosses to JS. Mirrors the
+        // GeometryDiagnostics contract test in the geometry crate.
+        let mut d = PipelineDiagnostics::default();
+        d.record_batch(10, 12, 3000, 2, 42, &GeometryDiagnostics::default());
+        let v = serde_json::to_value(&d).expect("serializes");
+        for key in [
+            "schemaVersion",
+            "batches",
+            "elementCount",
+            "meshCount",
+            "triangleCount",
+            "backstopCount",
+            "totalCsgFailures",
+            "productsWithFailures",
+            "hostsWithOpenings",
+            "silentNoOps",
+            "rectFast",
+            "phaseMs",
+        ] {
+            assert!(v.get(key).is_some(), "missing top-level key {key}");
+        }
+        for key in [
+            "entityScanMs",
+            "lookupMs",
+            "preprocessMs",
+            "parseMs",
+            "geometryMs",
+            "totalMs",
+        ] {
+            assert!(v["phaseMs"].get(key).is_some(), "missing phaseMs key {key}");
+        }
+        assert!(v["rectFast"].get("deferHostNotBox").is_some());
+        assert_eq!(v["schemaVersion"], PIPELINE_DIAGNOSTICS_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn record_batch_accumulates_across_batches() {
+        let mut d = PipelineDiagnostics::default();
+        assert!(d.is_empty());
+        let diag = GeometryDiagnostics {
+            total_csg_failures: 2,
+            hosts_with_openings: 3,
+            ..Default::default()
+        };
+        d.record_batch(10, 12, 3000, 1, 40, &diag);
+        d.record_batch(5, 6, 1500, 0, 10, &GeometryDiagnostics::default());
+        assert!(!d.is_empty());
+        assert_eq!(d.batches, 2);
+        assert_eq!(d.element_count, 15);
+        assert_eq!(d.mesh_count, 18);
+        assert_eq!(d.triangle_count, 4500);
+        assert_eq!(d.backstop_count, 1);
+        assert_eq!(d.total_csg_failures, 2);
+        assert_eq!(d.hosts_with_openings, 3);
+        assert_eq!(d.phase_ms.geometry_ms, 50);
+    }
+
+    #[test]
+    fn from_processing_stats_maps_all_phase_timers() {
+        let stats = ProcessingStats {
+            total_meshes: 7,
+            total_triangles: 99,
+            parse_time_ms: 11,
+            entity_scan_time_ms: 5,
+            lookup_time_ms: 2,
+            preprocess_time_ms: 3,
+            geometry_time_ms: 40,
+            total_time_ms: 60,
+            degenerate_triangles_dropped: 4,
+            total_csg_failures: 1,
+            products_with_failures: 1,
+            ..Default::default()
+        };
+        let d = PipelineDiagnostics::from_processing_stats(&stats, 20);
+        assert_eq!(d.batches, 1);
+        assert_eq!(d.element_count, 20);
+        assert_eq!(d.mesh_count, 7);
+        assert_eq!(d.backstop_count, 4);
+        assert_eq!(d.phase_ms.parse_ms, 11);
+        assert_eq!(d.phase_ms.entity_scan_ms, 5);
+        assert_eq!(d.phase_ms.lookup_ms, 2);
+        assert_eq!(d.phase_ms.preprocess_ms, 3);
+        assert_eq!(d.phase_ms.geometry_ms, 40);
+        assert_eq!(d.phase_ms.total_ms, 60);
+    }
+}

--- a/rust/processing/src/processor/mod.rs
+++ b/rust/processing/src/processor/mod.rs
@@ -443,17 +443,41 @@ pub fn process_geometry_streaming_filtered_with_options(
     let parse_start = Clock::now();
     let entity_scan_start = Clock::now();
 
+    // Span taxonomy for the pipeline phases. Each phase span mirrors an
+    // existing ProcessingStats timer window (instrumentation only, no
+    // restructuring); `phase_ms` / count fields are recorded post-hoc from the
+    // measurements the pipeline already takes. Field names reuse the
+    // GeometryDiagnostics vocabulary (total_csg_failures, backstop_count, ...)
+    // so events and the wasm PipelineDiagnostics channel share one vocabulary.
+    let pipeline_span = tracing::info_span!(
+        "geometry_pipeline",
+        byte_size = content.len(),
+        element_count = tracing::field::Empty,
+        total_ms = tracing::field::Empty,
+    );
+    let _pipeline_guard = pipeline_span.clone().entered();
+
     tracing::info!(
         content_size = content.len(),
         "Starting IFC geometry processing"
     );
 
+    let scan_span = tracing::info_span!(
+        "scan_prepass",
+        total_entities = tracing::field::Empty,
+        geometry_entities = tracing::field::Empty,
+        phase_ms = tracing::field::Empty,
+    );
+    let scan_guard = scan_span.clone().entered();
+
     // Build the entity index (fast SIMD-accelerated single pass), unless a caller
     // injected one built from the same `content` to share across passes.
-    let entity_index = options
-        .entity_index
-        .clone()
-        .unwrap_or_else(|| Arc::new(build_entity_index(content)));
+    let entity_index = tracing::debug_span!("entity_index").in_scope(|| {
+        options
+            .entity_index
+            .clone()
+            .unwrap_or_else(|| Arc::new(build_entity_index(content)))
+    });
     let mut decoder = EntityDecoder::with_arc_index(content, entity_index.clone());
     tracing::debug!("Built entity index");
 
@@ -781,8 +805,13 @@ pub fn process_geometry_streaming_filtered_with_options(
     } = resolved;
 
     let entity_scan_time = entity_scan_start.elapsed();
+    scan_span.record("total_entities", total_entities as u64);
+    scan_span.record("geometry_entities", entity_jobs.len() as u64);
+    scan_span.record("phase_ms", entity_scan_time.as_millis() as u64);
+    drop(scan_guard);
 
     let lookup_start = Clock::now();
+    let lookup_span = tracing::debug_span!("lookup", phase_ms = tracing::field::Empty).entered();
     if options.include_properties {
         assign_space_zone_properties(
             &mut entity_jobs,
@@ -797,6 +826,8 @@ pub fn process_geometry_streaming_filtered_with_options(
         });
     }
     let lookup_time = lookup_start.elapsed();
+    lookup_span.record("phase_ms", lookup_time.as_millis() as u64);
+    drop(lookup_span);
 
     let (skipped_entity_ids, filtered_void_index) = apply_opening_filter(
         &entity_jobs,
@@ -919,12 +950,20 @@ pub fn process_geometry_streaming_filtered_with_options(
 
     // Preprocess complex geometry
     let preprocess_start = Clock::now();
+    let preprocess_span =
+        tracing::debug_span!("preprocess", phase_ms = tracing::field::Empty).entered();
     // Resolve BOTH unit scales once via the shared resolver (the scan recorded
     // IFCPROJECT's id, so this is an O(1) decode — no more full-file hunts:
     // the historic `with_units` + `plane_angle_to_radians` pair each re-walked
     // the whole DATA section). Seed the shared decoder so every later consumer
     // (opening filter, metadata phase, deferred-style replay) inherits them.
-    let unit_scales = crate::prepass::resolve_unit_scales(content, project_id, &mut decoder);
+    let unit_scales = tracing::debug_span!("unit_scale")
+        .in_scope(|| crate::prepass::resolve_unit_scales(content, project_id, &mut decoder));
+    tracing::debug!(
+        length_unit_scale = unit_scales.length_unit_scale,
+        plane_angle_to_radians = unit_scales.plane_angle_to_radians,
+        "Resolved unit scales"
+    );
     decoder.seed_unit_scales(
         unit_scales.length_unit_scale,
         unit_scales.plane_angle_to_radians,
@@ -986,6 +1025,8 @@ pub fn process_geometry_streaming_filtered_with_options(
     let has_rtc_offset = coord_space != RAW_IFC_MESH_COORDINATE_SPACE;
     router.set_rtc_offset(rtc_offset);
     let preprocess_time = preprocess_start.elapsed();
+    preprocess_span.record("phase_ms", preprocess_time.as_millis() as u64);
+    drop(preprocess_span);
 
     let parse_time = parse_start.elapsed();
     tracing::info!(
@@ -1070,6 +1111,11 @@ pub fn process_geometry_streaming_filtered_with_options(
     // pass instead of reading process-global counters.
     let rect_fast_collector: std::sync::Mutex<ifc_lite_geometry::RectFastStats> =
         std::sync::Mutex::new(ifc_lite_geometry::RectFastStats::default());
+    // Degenerate-backstop drop tally, summed from each element's
+    // `ProducedElementMeshes::degenerate_triangles_dropped` (request-local,
+    // like the other sinks). Non-zero means the f32-collapse safety net in
+    // `element::build_mesh_data` engaged for this model.
+    let backstop_collector = std::sync::atomic::AtomicU64::new(0);
 
     // Shared content-dedup cache for the whole model: every per-job router (built
     // fresh per element below) dedups against it, so byte-identical geometry the
@@ -1077,6 +1123,17 @@ pub fn process_geometry_streaming_filtered_with_options(
     // across the rayon pool instead of once per element. The lock is held only for
     // a hash get/insert; meshing runs outside it.
     let item_dedup_cache = GeometryRouter::new_dedup_cache();
+
+    let geometry_span = tracing::info_span!(
+        "geometry",
+        element_count = total_jobs,
+        mesh_count = tracing::field::Empty,
+        triangle_count = tracing::field::Empty,
+        backstop_count = tracing::field::Empty,
+        total_csg_failures = tracing::field::Empty,
+        phase_ms = tracing::field::Empty,
+    );
+    let geometry_guard = geometry_span.clone().entered();
 
     while chunk_start < total_jobs {
         let chunk_end = (chunk_start + current_chunk_size).min(total_jobs);
@@ -1186,6 +1243,7 @@ pub fn process_geometry_streaming_filtered_with_options(
                     &classification_collector,
                     &host_diag_collector,
                     &rect_fast_collector,
+                    &backstop_collector,
                     &item_dedup_cache,
                 )
             })
@@ -1247,6 +1305,13 @@ pub fn process_geometry_streaming_filtered_with_options(
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let total_csg_failures: usize = csg_failures.values().map(Vec::len).sum();
     let products_with_failures = csg_failures.len();
+    let backstop_dropped = backstop_collector.into_inner();
+    geometry_span.record("mesh_count", total_meshes as u64);
+    geometry_span.record("triangle_count", total_triangles as u64);
+    geometry_span.record("backstop_count", backstop_dropped);
+    geometry_span.record("total_csg_failures", total_csg_failures as u64);
+    geometry_span.record("phase_ms", geometry_time.as_millis() as u64);
+    drop(geometry_guard);
     if total_csg_failures > 0 {
         let mut by_reason: HashMap<&'static str, usize> = HashMap::new();
         for fails in csg_failures.values() {
@@ -1277,7 +1342,7 @@ pub fn process_geometry_streaming_filtered_with_options(
     // Every sink — `classification`, `host_diags`, `csg_failures` AND `rect_fast` —
     // is request-local: each was drained from this pass's own per-job routers and
     // merged here, so concurrent in-process geometry passes never cross-contaminate.
-    let geometry_diagnostics = {
+    let geometry_diagnostics = tracing::debug_span!("collate_diagnostics").in_scope(|| {
         // Matches the wasm path's WORST_HOSTS_LIMIT (top-N per-host detail cap).
         const WORST_HOSTS_LIMIT: usize = 16;
         let classification = classification_collector
@@ -1297,14 +1362,17 @@ pub fn process_geometry_streaming_filtered_with_options(
             WORST_HOSTS_LIMIT,
         );
         (!diag.is_empty()).then_some(diag)
-    };
+    });
 
     let total_time = total_start.elapsed();
+    pipeline_span.record("element_count", total_jobs as u64);
+    pipeline_span.record("total_ms", total_time.as_millis() as u64);
 
     tracing::info!(
         meshes = meshes.len(),
         vertices = total_vertices,
         triangles = total_triangles,
+        backstop_count = backstop_dropped,
         geometry_time_ms = geometry_time.as_millis(),
         total_time_ms = total_time.as_millis(),
         "Geometry processing complete"
@@ -1339,6 +1407,7 @@ pub fn process_geometry_streaming_filtered_with_options(
             from_cache: false,
             total_csg_failures: total_csg_failures as u64,
             products_with_failures: products_with_failures as u64,
+            degenerate_triangles_dropped: backstop_dropped,
             geometry_diagnostics,
         },
     }
@@ -1376,6 +1445,9 @@ fn process_entity_job(
     classification_collector: &std::sync::Mutex<ifc_lite_geometry::ClassificationStats>,
     host_diag_collector: &std::sync::Mutex<FxHashMap<u32, ifc_lite_geometry::HostOpeningDiagnostic>>,
     rect_fast_collector: &std::sync::Mutex<ifc_lite_geometry::RectFastStats>,
+    // Shared tally of degenerate-backstop triangle drops (see
+    // `element::build_mesh_data`); relaxed atomic, added to only when non-zero.
+    backstop_collector: &std::sync::atomic::AtomicU64,
     // Model-wide content-dedup cache shared by every per-job router so identical
     // geometry is meshed once across the rayon pool (#1109 follow-up).
     item_dedup_cache: &ifc_lite_geometry::ItemDedupCache,
@@ -1442,6 +1514,14 @@ fn process_entity_job(
         &mut local_decoder,
         &local_router,
     );
+
+    // Fold this element's degenerate-backstop drops into the pass tally.
+    if produced.degenerate_triangles_dropped > 0 {
+        backstop_collector.fetch_add(
+            produced.degenerate_triangles_dropped,
+            std::sync::atomic::Ordering::Relaxed,
+        );
+    }
 
     // Surface this element's CSG diagnostics in the shared collector. The
     // wasm path logs them in the browser console; without this the server

--- a/rust/processing/src/types/response.rs
+++ b/rust/processing/src/types/response.rs
@@ -136,6 +136,11 @@ pub struct ProcessingStats {
     /// Number of distinct products with at least one CSG failure.
     #[serde(default)]
     pub products_with_failures: u64,
+    /// Triangles removed by the f32-collapse degenerate-triangle backstop
+    /// across the whole pass (see `element::build_mesh_data`). Non-zero means
+    /// the backstop engaged for this model.
+    #[serde(default)]
+    pub degenerate_triangles_dropped: u64,
     /// Full CSG / opening diagnostics (opening classification, per-reason failure
     /// breakdown, per-host detail, silent rectangular no-ops, rect_fast engagement)
     /// aggregated across the native geometry pass — the same `GeometryDiagnostics`

--- a/rust/wasm-bindings/src/api/gpu_meshes/batch.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/batch.rs
@@ -58,6 +58,11 @@ impl IfcAPI {
         };
         use ifc_lite_processing::style::GeometryStyleInfo;
 
+        // Batch wall-clock for the PipelineDiagnostics channel. std::time::Instant
+        // traps on wasm32, so use the JS clock (two Date.now() reads per batch —
+        // negligible, always on).
+        let batch_started_ms = js_sys::Date::now();
+
         let content = data;
 
         // Geometry fingerprinting for the viewer's revision-diff feature.
@@ -292,6 +297,11 @@ impl IfcAPI {
             Vec<ifc_lite_geometry::BoolFailure>,
         > = rustc_hash::FxHashMap::default();
 
+        // PipelineDiagnostics tallies for this batch (elements actually run
+        // through the producer, degenerate-backstop drops).
+        let mut batch_elements: u64 = 0;
+        let mut batch_backstop: u64 = 0;
+
         // Process only the entities specified in jobs_flat — every job runs
         // THE canonical per-element producer (`ifc_lite_processing::element`),
         // the same code the native pipeline runs.
@@ -375,6 +385,8 @@ impl IfcAPI {
             for (product_id, fails) in produced.csg_failures {
                 batch_csg_failures.entry(product_id).or_default().extend(fails);
             }
+            batch_elements += 1;
+            batch_backstop += produced.degenerate_triangles_dropped;
             outputs.push(ElementMeshOutput {
                 id,
                 meshes: produced.meshes,
@@ -419,6 +431,25 @@ impl IfcAPI {
                 );
             }
         }
+
+        // Fold this batch into the per-worker PipelineDiagnostics accumulator
+        // (read by JS via getPipelineDiagnostics). Counts + two Date.now()
+        // reads — cheap enough to stay on the normal load path unconditionally.
+        let batch_meshes: u64 = outputs.iter().map(|o| o.meshes.len() as u64).sum();
+        let batch_triangles: u64 = outputs
+            .iter()
+            .flat_map(|o| o.meshes.iter())
+            .map(|m| (m.indices.len() / 3) as u64)
+            .sum();
+        let batch_ms = (js_sys::Date::now() - batch_started_ms).max(0.0) as u64;
+        self.record_pipeline_batch(
+            batch_elements,
+            batch_meshes,
+            batch_triangles,
+            batch_backstop,
+            batch_ms,
+            &csg_diag,
+        );
 
         (outputs, csg_diag)
     }

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -20,6 +20,7 @@ mod gpu_meshes;
 mod grid_lines;
 mod mesh_outline;
 mod parsing;
+mod pipeline_diagnostics;
 mod space_plate;
 pub(crate) mod styling;
 mod symbolic;
@@ -198,6 +199,15 @@ pub struct IfcAPI {
             )>,
         )>,
     >,
+
+    /// Per-load structured pipeline diagnostics (`PipelineDiagnostics`
+    /// contract, see `api::pipeline_diagnostics`): every
+    /// `processGeometryBatch*` call folds one batch record in — cheap
+    /// counters plus per-batch JS wall time, so it is always on. Read by JS
+    /// via `getPipelineDiagnostics`; reset by `clearPrePassCache` and
+    /// `setEntityIndex` (a new load on a reused IfcAPI), like the other
+    /// content-scoped state.
+    pipeline_diagnostics: std::sync::Mutex<ifc_lite_processing::PipelineDiagnostics>,
 }
 
 #[wasm_bindgen]
@@ -227,6 +237,9 @@ impl IfcAPI {
             skip_small_cuts: std::sync::atomic::AtomicBool::new(false),
             cached_plane_angle_to_radians: std::sync::Mutex::new(None),
             cached_geometry_styles: std::sync::Mutex::new(None),
+            pipeline_diagnostics: std::sync::Mutex::new(
+                ifc_lite_processing::PipelineDiagnostics::default(),
+            ),
         }
     }
 
@@ -308,6 +321,8 @@ impl IfcAPI {
             .lock()
             .expect("ifc-lite cached_item_dedup Mutex poisoned")
             .take();
+        // The pipeline diagnostics describe the previous load; start fresh.
+        self.reset_pipeline_diagnostics();
     }
 
     /// Populate `cached_entity_index` from pre-extracted column arrays.
@@ -396,6 +411,9 @@ impl IfcAPI {
             .lock()
             .expect("ifc-lite cached_item_dedup Mutex poisoned")
             .take();
+        // A new entity index means a new file — the pipeline diagnostics
+        // describe the previous load, so start fresh.
+        self.reset_pipeline_diagnostics();
     }
 
     /// Get WASM memory for zero-copy access

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -321,8 +321,13 @@ impl IfcAPI {
             .lock()
             .expect("ifc-lite cached_item_dedup Mutex poisoned")
             .take();
-        // The pipeline diagnostics describe the previous load; start fresh.
-        self.reset_pipeline_diagnostics();
+        // NB: do NOT reset pipeline_diagnostics here. clearPrePassCache runs in
+        // the JS load wrapper's `finally` AFTER the last processGeometryBatch
+        // (packages/geometry/src/index.ts), i.e. end-of-load cleanup; resetting
+        // here would erase the just-completed load's diagnostics before a host
+        // can read getPipelineDiagnostics(). Diagnostics are an accumulator, not
+        // a cache, so they reset only at load START (set_entity_index), unlike
+        // cached_item_dedup which is safe to drop on every clear.
     }
 
     /// Populate `cached_entity_index` from pre-extracted column arrays.

--- a/rust/wasm-bindings/src/api/pipeline_diagnostics.rs
+++ b/rust/wasm-bindings/src/api/pipeline_diagnostics.rs
@@ -1,0 +1,77 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! WASM API: getPipelineDiagnostics — structured per-load pipeline
+//! diagnostics (the `PipelineDiagnostics` contract from
+//! `ifc_lite_processing::pipeline_diagnostics`).
+//!
+//! Collected on the NORMAL load path: every `processGeometryBatch*` call
+//! folds one batch record into the per-worker accumulator (cheap counters
+//! plus two `js_sys::Date::now()` reads, so it is always on — no feature
+//! flag). `std::time::Instant` traps on wasm32, hence the JS clock; the
+//! scan/prepass phases run in JS workers outside this module and report 0
+//! here (native fills them from ProcessingStats). Crossed to JS via
+//! `serde_wasm_bindgen::to_value`, exactly like `diagnoseGeometry`.
+
+use super::IfcAPI;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+impl IfcAPI {
+    /// Structured pipeline diagnostics accumulated across every
+    /// `processGeometryBatch*` call since the last load reset
+    /// (`clearPrePassCache` / `setEntityIndex`), as a JS object with a
+    /// `schemaVersion` field — or `undefined` when no batch has run yet.
+    /// Includes per-batch summed geometry wall time, mesh/triangle counts,
+    /// the degenerate-backstop drop count, and the CSG failure aggregates.
+    #[wasm_bindgen(js_name = getPipelineDiagnostics)]
+    pub fn get_pipeline_diagnostics(&self) -> JsValue {
+        let diag = self
+            .pipeline_diagnostics
+            .lock()
+            .expect("ifc-lite pipeline_diagnostics Mutex poisoned");
+        if diag.is_empty() {
+            return JsValue::UNDEFINED;
+        }
+        serde_wasm_bindgen::to_value(&*diag).unwrap_or(JsValue::UNDEFINED)
+    }
+}
+
+impl IfcAPI {
+    /// Fold one produced batch into the per-worker accumulator. Called by
+    /// `produce_batch` at the end of every batch; not exposed to JS.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn record_pipeline_batch(
+        &self,
+        element_count: u64,
+        mesh_count: u64,
+        triangle_count: u64,
+        backstop_count: u64,
+        geometry_ms: u64,
+        diag: &ifc_lite_geometry::GeometryDiagnostics,
+    ) {
+        let mut acc = self
+            .pipeline_diagnostics
+            .lock()
+            .expect("ifc-lite pipeline_diagnostics Mutex poisoned");
+        acc.record_batch(
+            element_count,
+            mesh_count,
+            triangle_count,
+            backstop_count,
+            geometry_ms,
+            diag,
+        );
+    }
+
+    /// Reset the accumulator (a new load on a reused IfcAPI). Called from
+    /// `clearPrePassCache` and `setEntityIndex`.
+    pub(crate) fn reset_pipeline_diagnostics(&self) {
+        let mut acc = self
+            .pipeline_diagnostics
+            .lock()
+            .expect("ifc-lite pipeline_diagnostics Mutex poisoned");
+        *acc = ifc_lite_processing::PipelineDiagnostics::default();
+    }
+}

--- a/rust/wasm-bindings/tests/pipeline_diagnostics.rs
+++ b/rust/wasm-bindings/tests/pipeline_diagnostics.rs
@@ -133,7 +133,20 @@ fn get_pipeline_diagnostics_round_trips_a_normal_load() {
     assert_eq!(get_u64(&diag, "batches"), 2);
     assert_eq!(get_u64(&diag, "elementCount"), 2);
 
-    // A load reset empties the accumulator again.
+    // clearPrePassCache is end-of-load cleanup (it runs in the JS load
+    // wrapper's `finally`, after the last batch). Diagnostics MUST survive it
+    // so a host can read the completed load's numbers; only the caches drop.
     api.clear_pre_pass_cache();
-    assert!(api.get_pipeline_diagnostics().is_undefined());
+    let after_clear = api.get_pipeline_diagnostics();
+    assert!(!after_clear.is_undefined(), "diagnostics survive end-of-load clearPrePassCache");
+    assert_eq!(get_u64(&after_clear, "batches"), 2);
+
+    // set_entity_index is the load START boundary (a new file) — it resets the
+    // accumulator, so the next load begins fresh. A minimal one-entry index is
+    // enough to pass its non-empty guard and reach the reset.
+    api.set_entity_index(&[1u32], &[0u32], &[1u32]);
+    assert!(
+        api.get_pipeline_diagnostics().is_undefined(),
+        "a new entity index (new load) resets diagnostics"
+    );
 }

--- a/rust/wasm-bindings/tests/pipeline_diagnostics.rs
+++ b/rust/wasm-bindings/tests/pipeline_diagnostics.rs
@@ -1,0 +1,139 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! wasm round-trip smoke test for the `getPipelineDiagnostics` channel
+//! (run with `wasm-pack test --node rust/wasm-bindings --test pipeline_diagnostics`).
+//!
+//! Loads a tiny inline IFC through the NORMAL load path
+//! (`processGeometryBatch`) and asserts the getter returns a populated JS
+//! object with the expected `schemaVersion`, then that a load reset
+//! (`clearPrePassCache`) empties it again.
+
+#![cfg(target_arch = "wasm32")]
+
+use ifc_lite_wasm::IfcAPI;
+use wasm_bindgen::JsValue;
+use wasm_bindgen_test::wasm_bindgen_test;
+
+/// One wall carrying a bare IfcTriangulatedFaceSet body (same neutral fixture
+/// shape as rust/processing/tests/styling_default_colors.rs).
+const TINY_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('pipeline diagnostics smoke fixture'),'2;1');
+FILE_NAME('tiny.ifc','2026-07-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#15=IFCCARTESIANPOINTLIST3D(((0.,0.,0.),(1.,0.,0.),(0.,1.,0.),(0.,0.,1.)));
+#10=IFCWALL('1WallPipelineDiag0001',$,'Wall',$,$,#11,#12,$,$);
+#11=IFCLOCALPLACEMENT($,#5);
+#12=IFCPRODUCTDEFINITIONSHAPE($,$,(#13));
+#13=IFCSHAPEREPRESENTATION(#2,'Body','Tessellation',(#14));
+#14=IFCTRIANGULATEDFACESET(#15,$,.T.,((1,2,3),(1,2,4),(1,4,3),(2,3,4)),$);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+/// Scan the fixture for geometry-bearing entities and return the
+/// `(id, start, end)` triples `processGeometryBatch` expects.
+fn jobs_flat(content: &[u8]) -> Vec<u32> {
+    let mut scanner = ifc_lite_core::EntityScanner::new(content);
+    let mut jobs = Vec::new();
+    while let Some((id, type_name, start, end)) = scanner.next_entity() {
+        if ifc_lite_core::has_geometry_by_name(type_name) {
+            jobs.extend_from_slice(&[id, start as u32, end as u32]);
+        }
+    }
+    jobs
+}
+
+fn get_u64(obj: &JsValue, key: &str) -> u64 {
+    js_sys::Reflect::get(obj, &JsValue::from_str(key))
+        .unwrap_or(JsValue::UNDEFINED)
+        .as_f64()
+        .unwrap_or_else(|| panic!("key {key} missing or not a number")) as u64
+}
+
+#[wasm_bindgen_test]
+fn get_pipeline_diagnostics_round_trips_a_normal_load() {
+    let api = IfcAPI::new();
+
+    // Before any batch: undefined, so consumers can gate on presence.
+    assert!(api.get_pipeline_diagnostics().is_undefined());
+
+    let content = TINY_IFC.as_bytes();
+    let jobs = jobs_flat(content);
+    assert!(!jobs.is_empty(), "fixture must contain geometry jobs");
+
+    // The NORMAL load path: one processGeometryBatch call, no RTC shift,
+    // no voids/styles/materials.
+    let collection = api.process_geometry_batch(
+        content,
+        &jobs,
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        false,
+        &[],
+        &[],
+        &[],
+        &[],
+        &[],
+        None,
+        None,
+        None,
+        None,
+    );
+    drop(collection);
+
+    let diag = api.get_pipeline_diagnostics();
+    assert!(!diag.is_undefined(), "diagnostics must be populated after a batch");
+    assert_eq!(get_u64(&diag, "schemaVersion"), 1, "schemaVersion contract");
+    assert_eq!(get_u64(&diag, "batches"), 1);
+    assert_eq!(get_u64(&diag, "elementCount"), 1, "one wall job");
+    assert!(get_u64(&diag, "meshCount") >= 1, "the wall must mesh");
+    assert!(get_u64(&diag, "triangleCount") >= 4, "4-triangle tetrahedron body");
+    // Counters exist even when zero (serde contract, not presence-optional).
+    assert_eq!(get_u64(&diag, "totalCsgFailures"), 0);
+    assert_eq!(get_u64(&diag, "backstopCount"), 0);
+    let phase_ms = js_sys::Reflect::get(&diag, &JsValue::from_str("phaseMs")).unwrap();
+    assert!(!phase_ms.is_undefined(), "phaseMs object present");
+    // geometryMs is JS-clock measured; only assert it exists and is numeric.
+    let _ = get_u64(&phase_ms, "geometryMs");
+
+    // A second batch accumulates.
+    let collection = api.process_geometry_batch(
+        content,
+        &jobs,
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        false,
+        &[],
+        &[],
+        &[],
+        &[],
+        &[],
+        None,
+        None,
+        None,
+        None,
+    );
+    drop(collection);
+    let diag = api.get_pipeline_diagnostics();
+    assert_eq!(get_u64(&diag, "batches"), 2);
+    assert_eq!(get_u64(&diag, "elementCount"), 2);
+
+    // A load reset empties the accumulator again.
+    api.clear_pre_pass_cache();
+    assert!(api.get_pipeline_diagnostics().is_undefined());
+}


### PR DESCRIPTION
Lands reliability Item B: structured pipeline observability. Correct framing — the native server already runs a `tracing_subscriber` (`apps/server/src/main.rs:167`), so the 7 existing `tracing::` calls in `rust/processing` already emit there. This PR **broadens structured diagnostics to the geometry crate** and **adds a wasm diagnostics channel** (the genuinely new surface, where a `tracing` fmt layer is useless).

## Native: `observability` feature on the geometry crate

- New optional `observability` cargo feature on `rust/geometry` (`dep:tracing`, default OFF → default builds byte-unchanged, verified by build). The native server turns it on via `ifc-lite-processing/observability`.
- The ~15 production `eprintln!` diagnostics become structured events through two shims in `rust/geometry/src/diag.rs`:
  - `diag_warn!` — anomaly-level (failed layer slicing, degraded fallbacks). With the feature ON → `tracing::warn!` with fields; **with the feature OFF it keeps the legacy `eprintln!`** so operators do not lose these messages from default server builds.
  - `diag_debug!` — trace/progress chatter. `tracing::debug!` when ON; compiles out when OFF.
  - The feature-OFF expansion reproduces the old output byte-for-byte. Test/bench prints are left alone.
- Span taxonomy applied at the existing pipeline seams in `rust/processing` (scan/prepass → unit-scale → entity-index → per-element geometry → collation → export), field names aligned with the existing `GeometryDiagnostics` contract.

## wasm: `getPipelineDiagnostics()`

- New `PipelineDiagnostics` serde struct (`rust/processing/src/pipeline_diagnostics.rs`) with an explicit `schemaVersion` (camelCase renames), populated during a load: summed geometry wall time, mesh/triangle counts, degenerate-backstop drops, and the CSG failure aggregates.
- Exposed as `IfcAPI.getPipelineDiagnostics()` (`rust/wasm-bindings/src/api/pipeline_diagnostics.rs`), crossed via `serde_wasm_bindgen::to_value` exactly like `diagnoseGeometry`; returns `undefined` before the first batch.
- **Collected on the normal load path** (not behind a feature): `record_pipeline_batch` folds one record per `processGeometryBatch*` call (`gpu_meshes/batch.rs:445`), reset on load boundaries (`clearPrePassCache`, `setEntityIndex`). Cheap counters + `js_sys::Date::now()` — deliberately avoiding `std::time::Instant`, which traps on wasm32.

## Tests

- `pipeline_diagnostics.rs`: serde-key stability test (guards the camelCase + `schemaVersion` contract against TS drift) + a batch-accumulation test.
- wasm round-trip smoke (`rust/wasm-bindings/tests/pipeline_diagnostics.rs`, `wasm-pack test --node`): loads a tiny inline IFC through the real API and asserts the getter returns a populated object at the right schema version.

## Verification

- Default build byte-unchanged (feature off); `observability` build + `cargo test -p ifc-lite-geometry --features observability` green.
- Full `cargo test --workspace --exclude ifc-lite-wasm` green (the eprintln conversions preserve behavior); `clippy -D warnings` clean in both feature states.
- wasm round-trip green via `wasm-pack test --node`.

Changeset: `@ifc-lite/wasm` minor (new getter).
