### PR TITLE
fix(collab-server): merge persisted Y frames (data loss), uncollide room ids, unpoison audit log

### DIFF
--- a/.changeset/fix-collab-persistence-data-loss.md
+++ b/.changeset/fix-collab-persistence-data-loss.md
@@ -1,0 +1,22 @@
+---
+"@ifc-lite/collab-server": patch
+---
+
+fix(collab-server): merge persisted update frames instead of byte-concatenating them
+
+Room logs store one Yjs update per `append`. Every persistence backend
+(`Memory`, `File`, `Redis`, `S3`) returned the frames byte-concatenated, and
+`loadFromDisk` fed that blob to `Y.applyUpdate`, which decodes only the first
+update and silently ignores the rest — so every edit after the first frame was
+lost on room reload (up to `compactEvery` updates between compactions). `load`
+now combines frames with `Y.mergeUpdates`.
+
+Also:
+- `FilePersistence` room ids are encoded with `encodeURIComponent` (reversible,
+  collision-free, traversal-safe) instead of a lossy `[^a-zA-Z0-9._-] -> _`
+  replace that mapped distinct rooms (e.g. `a/b` and `a:b`) onto one log file.
+  Safe ids (UUIDs, room codes) are unchanged, so existing logs keep their names.
+- `JsonlFileAuditSink.append` no longer poisons its write chain: a single failed
+  append previously left the shared promise rejected, so every subsequent append
+  was skipped forever. Writes now run after the previous one settles regardless
+  of outcome, while callers still observe their own error.

--- a/packages/collab-server/src/audit-log.ts
+++ b/packages/collab-server/src/audit-log.ts
@@ -102,9 +102,18 @@ export class JsonlFileAuditSink implements AuditSink {
 
   append(entry: AuditEntry): Promise<void> {
     // Serialize all writes through one chain so size accounting and
-    // rotation observe a consistent state.
-    this.inflight = this.inflight.then(() => this.appendInner(entry));
-    return this.inflight;
+    // rotation observe a consistent state. Run after the previous write
+    // settles whether it resolved OR rejected: chaining a bare `.then()` onto
+    // a rejected `inflight` would skip the append callback, permanently
+    // poisoning every future write after one transient failure. The internal
+    // handle swallows rejections to keep the chain alive; the caller still
+    // sees its own error via the returned promise.
+    const run = this.inflight.then(
+      () => this.appendInner(entry),
+      () => this.appendInner(entry),
+    );
+    this.inflight = run.catch(() => {});
+    return run;
   }
 
   private async appendInner(entry: AuditEntry): Promise<void> {

--- a/packages/collab-server/src/persistence-redis.ts
+++ b/packages/collab-server/src/persistence-redis.ts
@@ -19,6 +19,7 @@
  */
 
 import type { Persistence } from './persistence.js';
+import { mergeUpdateFrames } from './persistence.js';
 
 /**
  * Minimal Redis-like surface. The two big Node clients (ioredis,
@@ -67,18 +68,17 @@ export class RedisPersistence implements Persistence {
       this.client.getBuffer(this.snapKey(roomId)),
       this.client.lrangeBuffer(this.logKey(roomId)),
     ]);
-    const parts: Buffer[] = [];
-    if (snap && snap.byteLength > 0) parts.push(snap);
-    for (const f of frames ?? []) parts.push(f);
-    if (parts.length === 0) return null;
-    const total = parts.reduce((n, p) => n + p.byteLength, 0);
-    const out = new Uint8Array(total);
-    let o = 0;
-    for (const p of parts) {
-      out.set(new Uint8Array(p.buffer, p.byteOffset, p.byteLength), o);
-      o += p.byteLength;
+    const parts: Uint8Array[] = [];
+    if (snap && snap.byteLength > 0) {
+      parts.push(new Uint8Array(snap.buffer, snap.byteOffset, snap.byteLength));
     }
-    return out;
+    for (const f of frames ?? []) {
+      parts.push(new Uint8Array(f.buffer, f.byteOffset, f.byteLength));
+    }
+    if (parts.length === 0) return null;
+    // Merge, not byte-concatenate: applyUpdate reads only the first frame of a
+    // naive concatenation and drops the rest (see mergeUpdateFrames).
+    return mergeUpdateFrames(parts);
   }
 
   async append(roomId: string, update: Uint8Array): Promise<void> {

--- a/packages/collab-server/src/persistence-s3.ts
+++ b/packages/collab-server/src/persistence-s3.ts
@@ -30,6 +30,7 @@
 import { randomBytes } from 'node:crypto';
 
 import type { Persistence } from './persistence.js';
+import { mergeUpdateFrames } from './persistence.js';
 
 /** Minimum S3 surface we need; AWS SDK satisfies it directly. */
 export interface S3LikeClient {
@@ -184,7 +185,9 @@ export class S3Persistence implements Persistence {
     }
     if (frames.length === 0) return null;
 
-    return concat(frames);
+    // Merge, not byte-concatenate: applyUpdate reads only the first frame of a
+    // naive concatenation and drops the rest (see mergeUpdateFrames).
+    return mergeUpdateFrames(frames);
   }
 
   async append(roomId: string, update: Uint8Array): Promise<void> {

--- a/packages/collab-server/src/persistence.ts
+++ b/packages/collab-server/src/persistence.ts
@@ -14,6 +14,20 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import * as Y from 'yjs';
+
+/**
+ * Merge an ordered list of persisted Yjs update frames into one update.
+ *
+ * A room log is a sequence of independent Y updates (one per `append`). They
+ * MUST be combined with `Y.mergeUpdates`, never byte-concatenated:
+ * `Y.applyUpdate` decodes only the first update in a naive concatenation and
+ * silently ignores the rest, so every edit after the first frame is lost on
+ * room reload (up to `compactEvery` updates between compactions).
+ */
+export function mergeUpdateFrames(frames: Uint8Array[]): Uint8Array {
+  return frames.length === 1 ? frames[0] : Y.mergeUpdates(frames);
+}
 
 export interface Persistence {
   /** Load any saved updates for `roomId` and return them as a single merged blob. */
@@ -32,7 +46,7 @@ export class MemoryPersistence implements Persistence {
   async load(roomId: string): Promise<Uint8Array | null> {
     const arr = this.logs.get(roomId);
     if (!arr || arr.length === 0) return null;
-    return concat(arr);
+    return mergeUpdateFrames(arr);
   }
 
   async append(roomId: string, update: Uint8Array): Promise<void> {
@@ -74,7 +88,12 @@ export class FilePersistence implements Persistence {
   }
 
   private logPath(roomId: string): string {
-    const safe = roomId.replace(/[^a-zA-Z0-9._-]/g, '_');
+    // Reversible, collision-free, and traversal-safe (encodes `/` and `\`),
+    // matching the S3 backend. A lossy `[^a-zA-Z0-9._-] -> _` replace would
+    // map distinct rooms (e.g. `a/b` and `a:b`) onto one log file and
+    // interleave their updates. Safe ids (UUIDs, room codes) are unchanged, so
+    // existing logs keep their names.
+    const safe = encodeURIComponent(roomId);
     return path.join(this.dataDir, `${safe}.log`);
   }
 
@@ -93,7 +112,7 @@ export class FilePersistence implements Persistence {
       offset += len;
     }
     if (frames.length === 0) return null;
-    return concat(frames);
+    return mergeUpdateFrames(frames);
   }
 
   async append(roomId: string, update: Uint8Array): Promise<void> {
@@ -119,15 +138,4 @@ export class FilePersistence implements Persistence {
       await fs.promises.unlink(file);
     }
   }
-}
-
-function concat(arr: Uint8Array[]): Uint8Array {
-  const total = arr.reduce((n, a) => n + a.byteLength, 0);
-  const out = new Uint8Array(total);
-  let o = 0;
-  for (const a of arr) {
-    out.set(a, o);
-    o += a.byteLength;
-  }
-  return out;
 }

--- a/packages/collab-server/src/persistence.ts
+++ b/packages/collab-server/src/persistence.ts
@@ -97,9 +97,27 @@ export class FilePersistence implements Persistence {
     return path.join(this.dataDir, `${safe}.log`);
   }
 
+  /**
+   * Pre-encoding log path (the old lossy `[^a-zA-Z0-9._-] -> _` sanitizer).
+   * Lossy — distinct rooms could collide — so it is used ONLY to find and
+   * migrate a room's existing log after upgrading to the encoded scheme, never
+   * for new writes. Equals `logPath` for ids the old sanitizer left unchanged
+   * (UUIDs, room codes), which is the no-migration-needed common case.
+   */
+  private legacyLogPath(roomId: string): string {
+    const safe = roomId.replace(/[^a-zA-Z0-9._-]/g, '_');
+    return path.join(this.dataDir, `${safe}.log`);
+  }
+
   async load(roomId: string): Promise<Uint8Array | null> {
-    const file = this.logPath(roomId);
-    if (!fs.existsSync(file)) return null;
+    let file = this.logPath(roomId);
+    if (!fs.existsSync(file)) {
+      // A room persisted before the encoded-filename change still lives under
+      // the old sanitized name; read it so history survives the upgrade.
+      const legacy = this.legacyLogPath(roomId);
+      if (legacy === file || !fs.existsSync(legacy)) return null;
+      file = legacy;
+    }
     const buf = await fs.promises.readFile(file);
     if (buf.byteLength === 0) return null;
     const frames: Uint8Array[] = [];
@@ -117,6 +135,14 @@ export class FilePersistence implements Persistence {
 
   async append(roomId: string, update: Uint8Array): Promise<void> {
     const file = this.logPath(roomId);
+    // One-time migration: adopt a pre-encoding log so appends extend the
+    // room's existing history instead of starting a second, empty file.
+    if (!fs.existsSync(file)) {
+      const legacy = this.legacyLogPath(roomId);
+      if (legacy !== file && fs.existsSync(legacy)) {
+        await fs.promises.rename(legacy, file);
+      }
+    }
     const header = Buffer.alloc(4);
     header.writeUInt32LE(update.byteLength, 0);
     const body = Buffer.concat([header, Buffer.from(update)]);
@@ -130,12 +156,19 @@ export class FilePersistence implements Persistence {
     header.writeUInt32LE(mergedState.byteLength, 0);
     await fs.promises.writeFile(tmp, Buffer.concat([header, Buffer.from(mergedState)]));
     await fs.promises.rename(tmp, file);
+    // The compacted snapshot supersedes any pre-encoding log; remove it so a
+    // future load can't fall back to stale state.
+    const legacy = this.legacyLogPath(roomId);
+    if (legacy !== file && fs.existsSync(legacy)) {
+      await fs.promises.unlink(legacy);
+    }
   }
 
   async drop(roomId: string): Promise<void> {
-    const file = this.logPath(roomId);
-    if (fs.existsSync(file)) {
-      await fs.promises.unlink(file);
+    for (const file of new Set([this.logPath(roomId), this.legacyLogPath(roomId)])) {
+      if (fs.existsSync(file)) {
+        await fs.promises.unlink(file);
+      }
     }
   }
 }

--- a/packages/collab-server/test/persistence-redis.test.ts
+++ b/packages/collab-server/test/persistence-redis.test.ts
@@ -3,10 +3,28 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { describe, expect, it } from 'vitest';
+import * as Y from 'yjs';
 import {
   RedisPersistence,
   type RedisLikeClient,
 } from '../src/persistence-redis.js';
+
+/** Real per-transaction update frames, mirroring the server's onDocUpdate. */
+function makeFrames(values: number[]): Uint8Array[] {
+  const doc = new Y.Doc();
+  const frames: Uint8Array[] = [];
+  doc.on('update', (u: Uint8Array) => frames.push(u));
+  const arr = doc.getArray<number>('log');
+  for (const v of values) doc.transact(() => arr.push([v]));
+  return frames;
+}
+
+/** Apply a loaded blob to a fresh doc and read back the array it encodes. */
+function replay(loaded: Uint8Array | null): number[] {
+  const doc = new Y.Doc();
+  if (loaded) Y.applyUpdate(doc, loaded);
+  return doc.getArray<number>('log').toArray();
+}
 
 /** Tiny in-memory fake matching the RedisLikeClient surface. */
 function fakeRedis(): { client: RedisLikeClient; store: Map<string, Buffer | Buffer[]> } {
@@ -51,10 +69,11 @@ describe('RedisPersistence', () => {
     const { client } = fakeRedis();
     const p = new RedisPersistence({ client });
     expect(await p.load('room')).toBeNull();
-    await p.append('room', new Uint8Array([1, 2]));
-    await p.append('room', new Uint8Array([3, 4]));
-    const all = await p.load('room');
-    expect(all).toEqual(new Uint8Array([1, 2, 3, 4]));
+    const frames = makeFrames([1, 2, 3]);
+    for (const f of frames) await p.append('room', f);
+    // Regression: byte-concatenating the frames and applying once would decode
+    // only the first update, dropping [2, 3]. Merged frames reconstruct all.
+    expect(replay(await p.load('room'))).toEqual([1, 2, 3]);
   });
 
   it('compact replaces snap and clears the log', async () => {

--- a/packages/collab-server/test/persistence-s3.test.ts
+++ b/packages/collab-server/test/persistence-s3.test.ts
@@ -3,11 +3,29 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { describe, expect, it } from 'vitest';
+import * as Y from 'yjs';
 import {
   S3Persistence,
   type S3Commands,
   type S3LikeClient,
 } from '../src/persistence-s3.js';
+
+/** Real per-transaction update frames, mirroring the server's onDocUpdate. */
+function makeFrames(values: number[]): Uint8Array[] {
+  const doc = new Y.Doc();
+  const frames: Uint8Array[] = [];
+  doc.on('update', (u: Uint8Array) => frames.push(u));
+  const arr = doc.getArray<number>('log');
+  for (const v of values) doc.transact(() => arr.push([v]));
+  return frames;
+}
+
+/** Apply a loaded blob to a fresh doc and read back the array it encodes. */
+function replay(loaded: Uint8Array | null): number[] {
+  const doc = new Y.Doc();
+  if (loaded) Y.applyUpdate(doc, loaded);
+  return doc.getArray<number>('log').toArray();
+}
 
 /**
  * Tiny in-memory shim that satisfies the S3LikeClient + S3Commands
@@ -92,10 +110,11 @@ describe('S3Persistence', () => {
     const { client, commands } = makeFakeS3();
     const p = new S3Persistence({ client, commands, bucket: 'b' });
     expect(await p.load('room')).toBeNull();
-    await p.append('room', new Uint8Array([1, 2, 3]));
-    await p.append('room', new Uint8Array([4, 5, 6]));
-    const all = await p.load('room');
-    expect(all).toEqual(new Uint8Array([1, 2, 3, 4, 5, 6]));
+    const frames = makeFrames([1, 2, 3]);
+    for (const f of frames) await p.append('room', f);
+    // Regression: byte-concatenating the frames and applying once would decode
+    // only the first update, dropping [2, 3]. Merged frames reconstruct all.
+    expect(replay(await p.load('room'))).toEqual([1, 2, 3]);
   });
 
   it('compact replaces snap and clears the log', async () => {
@@ -117,18 +136,11 @@ describe('S3Persistence', () => {
     const p = new S3Persistence({ client, commands, bucket: 'b' });
     // 7 frames > PAGE_SIZE (3) ⇒ spans 3 list pages. A single-page load
     // would silently drop the tail; assert every frame is replayed in order.
-    const frames = [
-      [1],
-      [2],
-      [3],
-      [4],
-      [5],
-      [6],
-      [7],
-    ];
-    for (const f of frames) await p.append('room', new Uint8Array(f));
-    const all = await p.load('room');
-    expect(all).toEqual(new Uint8Array([1, 2, 3, 4, 5, 6, 7]));
+    const values = [1, 2, 3, 4, 5, 6, 7];
+    for (const f of makeFrames(values)) await p.append('room', f);
+    // Reconstructing the doc proves every frame was listed across pages and
+    // merged: a dropped page (or a byte-concat load) would lose mutations.
+    expect(replay(await p.load('room'))).toEqual(values);
   });
 
   it('compact paginates removeLog so no log frames are orphaned', async () => {

--- a/packages/collab-server/test/persistence.test.ts
+++ b/packages/collab-server/test/persistence.test.ts
@@ -81,4 +81,32 @@ describe('FilePersistence', () => {
     expect(replay(await p.load('a/b'))).toEqual([10, 11]);
     expect(replay(await p.load('a:b'))).toEqual([20, 21]);
   });
+
+  it('reads and migrates a pre-encoding (legacy sanitized) room log', async () => {
+    const dir = tmpDir();
+    // A room id with a `/` written under the OLD sanitizer: `project/model`
+    // was stored as `project_model.log`.
+    const framed = (frames: Uint8Array[]): Buffer =>
+      Buffer.concat(
+        frames.flatMap((f) => {
+          const hdr = Buffer.alloc(4);
+          hdr.writeUInt32LE(f.byteLength, 0);
+          return [hdr, Buffer.from(f)];
+        }),
+      );
+    fs.writeFileSync(path.join(dir, 'project_model.log'), framed(makeFrames([7, 8])));
+
+    const p = new FilePersistence({ dataDir: dir });
+    // Read-fallback: history survives the upgrade even before any new write.
+    expect(replay(await p.load('project/model'))).toEqual([7, 8]);
+
+    // A new append migrates the legacy file to the encoded name and extends it.
+    for (const f of makeFrames([9])) await p.append('project/model', f);
+    expect(fs.existsSync(path.join(dir, 'project_model.log'))).toBe(false);
+    expect(fs.existsSync(path.join(dir, 'project%2Fmodel.log'))).toBe(true);
+    // The `9` frame is a fresh Y doc's update, so it only asserts the migrated
+    // file is still readable and non-empty (independent docs don't merge into
+    // one array); the key guarantees are the fallback read + the rename above.
+    expect(await p.load('project/model')).not.toBeNull();
+  });
 });

--- a/packages/collab-server/test/persistence.test.ts
+++ b/packages/collab-server/test/persistence.test.ts
@@ -1,0 +1,84 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as Y from 'yjs';
+import { FilePersistence, MemoryPersistence } from '../src/persistence.js';
+
+/** Real per-transaction update frames, mirroring the server's onDocUpdate. */
+function makeFrames(values: number[]): Uint8Array[] {
+  const doc = new Y.Doc();
+  const frames: Uint8Array[] = [];
+  doc.on('update', (u: Uint8Array) => frames.push(u));
+  const arr = doc.getArray<number>('log');
+  for (const v of values) doc.transact(() => arr.push([v]));
+  return frames;
+}
+
+/** Apply a loaded blob to a fresh doc and read back the array it encodes. */
+function replay(loaded: Uint8Array | null): number[] {
+  const doc = new Y.Doc();
+  if (loaded) Y.applyUpdate(doc, loaded);
+  return doc.getArray<number>('log').toArray();
+}
+
+const tmpDirs: string[] = [];
+function tmpDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'collab-persist-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('MemoryPersistence', () => {
+  it('load reconstructs the full state from all appended frames', async () => {
+    const p = new MemoryPersistence();
+    expect(await p.load('room')).toBeNull();
+    for (const f of makeFrames([1, 2, 3])) await p.append('room', f);
+    // Regression: a byte-concatenation applied via Y.applyUpdate decodes only
+    // the first frame, dropping every later edit (up to `compactEvery`).
+    expect(replay(await p.load('room'))).toEqual([1, 2, 3]);
+  });
+});
+
+describe('FilePersistence', () => {
+  it('load reconstructs the full state across many un-compacted frames', async () => {
+    const p = new FilePersistence({ dataDir: tmpDir() });
+    const values = Array.from({ length: 20 }, (_, i) => i);
+    for (const f of makeFrames(values)) await p.append('room', f);
+    expect(replay(await p.load('room'))).toEqual(values);
+  });
+
+  it('a compacted snapshot then further appends still load in full', async () => {
+    const dir = tmpDir();
+    const seed = new Y.Doc();
+    const seedArr = seed.getArray<number>('log');
+    seed.transact(() => seedArr.push([1, 2]));
+    const p = new FilePersistence({ dataDir: dir });
+    await p.compact('room', Y.encodeStateAsUpdate(seed));
+    // Post-compaction incremental edits continue on the same doc.
+    const frames: Uint8Array[] = [];
+    seed.on('update', (u: Uint8Array) => frames.push(u));
+    seed.transact(() => seedArr.push([3]));
+    seed.transact(() => seedArr.push([4]));
+    for (const f of frames) await p.append('room', f);
+    expect(replay(await p.load('room'))).toEqual([1, 2, 3, 4]);
+  });
+
+  it('does not collide distinct room ids that a lossy sanitizer would merge', async () => {
+    const dir = tmpDir();
+    const p = new FilePersistence({ dataDir: dir });
+    // `a/b` and `a:b` both map to `a_b` under a `[^a-zA-Z0-9._-] -> _` replace.
+    for (const f of makeFrames([10, 11])) await p.append('a/b', f);
+    for (const f of makeFrames([20, 21])) await p.append('a:b', f);
+    expect(replay(await p.load('a/b'))).toEqual([10, 11]);
+    expect(replay(await p.load('a:b'))).toEqual([20, 21]);
+  });
+});


### PR DESCRIPTION
Found via a full multi-agent code review of `main`; verified by reading the code and covered with regression tests.

## 1. CRITICAL: room reload silently drops all edits after the first frame
Every room stores one Yjs update per `append`. All four persistence backends (`Memory`, `File`, `Redis`, `S3`) returned the frames **byte-concatenated**, and `RoomManager.loadFromDisk` fed that blob to `Y.applyUpdate` — which decodes only the *first* update in a concatenation and silently ignores the rest. Between compactions (default `compactEvery: 1000`) up to ~999 updates accumulate, so a server restart / room eviction+reload loses every edit after the first frame. (The S3 backend even carried a comment acknowledging ">1000 un-compacted frames would silently drop the tail.")

Fix: a shared `mergeUpdateFrames` helper combines frames with `Y.mergeUpdates` (single-frame fast-path preserves the compacted-snapshot case), routed through all four backends.

## 2. FilePersistence room-id collision
`logPath` sanitized ids with a lossy `[^a-zA-Z0-9._-] -> _` replace, so distinct rooms (`a/b`, `a:b`, `a_b`) mapped to one `.log` file and interleaved their updates. Now uses `encodeURIComponent` (reversible, collision-free, path-traversal-safe), matching the S3 backend. Safe ids (UUIDs, room codes) are unchanged, so existing logs keep their names.

## 3. Audit-log write chain poisoned by one failure
`JsonlFileAuditSink.append` chained each write onto a shared `inflight` promise with a bare `.then()`. One transient append rejection left `inflight` rejected forever, so every subsequent append's callback was skipped — the audit log went permanently silent. Writes now run after the previous one settles regardless of outcome; callers still see their own error.

## Tests
- New `test/persistence.test.ts` for the untested File/Memory backends: multi-frame load reconstructs the full doc; compacted-snapshot-then-appends loads in full; distinct-but-colliding room ids stay isolated.
- Rewrote the `Redis`/`S3` round-trip + pagination tests to append **real** Y updates and assert doc reconstruction (they previously pinned byte concatenation with fake bytes — the anti-pattern that masked this bug).
- All 47 `@ifc-lite/collab-server` tests pass; full workspace typecheck clean.

Changeset: `@ifc-lite/collab-server` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)