### PR TITLE
fix(server-client): send auth token on data-model + symbolic fetches

### DIFF
--- a/.changeset/fix-server-client-auth.md
+++ b/.changeset/fix-server-client-auth.md
@@ -1,0 +1,15 @@
+---
+"@ifc-lite/server-client": patch
+---
+
+fix(server-client): send the auth token on data-model and symbolic fetches
+
+`fetchDataModel` and `fetchSymbolic` were the only requests that omitted
+`authHeaders()`, so against a server started with `IFC_SERVER_API_TOKEN` the
+geometry parse succeeded but the follow-up data-model and symbolic fetches got
+401 and silently returned null — the model loaded with no properties and no
+annotations. Both now send the `Authorization` header like every other request.
+
+Also: the streaming parse cache-check now includes the parse query string
+(`parseQuery(options)`), matching the non-streaming path, so a cached result for
+a different tessellation quality is no longer returned as a hit.

--- a/packages/server-client/src/client.ts
+++ b/packages/server-client/src/client.ts
@@ -286,7 +286,7 @@ export class IfcServerClient {
 
     // Step 2: Check if already cached
     const cacheCheckStart = performance.now();
-    const cacheCheck = await fetch(`${this.baseUrl}/api/v1/cache/check/${hash}`, {
+    const cacheCheck = await fetch(`${this.baseUrl}/api/v1/cache/check/${hash}${parseQuery(options)}`, {
       method: 'GET',
       headers: this.authHeaders(),
       signal: AbortSignal.timeout(5000),
@@ -649,6 +649,7 @@ export class IfcServerClient {
       try {
         const response = await fetch(`${this.baseUrl}/api/v1/parse/data-model/${cacheKey}`, {
           method: 'GET',
+          headers: this.authHeaders(),
           signal: AbortSignal.timeout(30000),
         });
 
@@ -722,6 +723,7 @@ export class IfcServerClient {
       try {
         response = await fetch(`${this.baseUrl}/api/v1/parse/symbolic/${cacheKey}`, {
           method: 'GET',
+          headers: this.authHeaders(),
           signal: AbortSignal.timeout(30000),
         });
       } catch (error) {

--- a/packages/server-client/src/client.ts
+++ b/packages/server-client/src/client.ts
@@ -297,7 +297,10 @@ export class IfcServerClient {
       // CACHE HIT - fetch all geometry at once (much faster than re-parsing)
       console.log(`[client] Stream: Cache HIT (check: ${cacheCheckTime.toFixed(0)}ms) - fetching cached geometry`);
 
-      const cachedResult = await this.fetchCachedGeometry(hash);
+      // Pass options: `/cache/geometry/:hash` keys on the same parse query, so
+      // omitting them would fetch default `medium` geometry (or 404) even
+      // though the option-scoped cache-check above hit the requested variant.
+      const cachedResult = await this.fetchCachedGeometry(hash, options);
 
       // Send all meshes as a single batch to the callback
       const decodeStart = performance.now();


### PR DESCRIPTION
Found via a full multi-agent code review of `main`; verified by reading the code.

## Authenticated servers silently lose properties + annotations
`IfcServerClient` attaches `authHeaders()` (the `Authorization: Bearer <token>` set when `IFC_SERVER_API_TOKEN` is configured) to every request **except** `fetchDataModel` and `fetchSymbolic`. Against a secured server the geometry parse succeeds, but both follow-up fetches get 401 and collapse to `null` after retries — the model renders with no property data and no symbolic annotations, with no visible error. Both now send `authHeaders()` like every other endpoint.

## Streaming cache-check ignored parse options
The `parseParquetStream` cache-check hit `/api/v1/cache/check/${hash}` without the `parseQuery(options)` suffix that the non-streaming `parseParquet` path uses. A cached result for a *different* tessellation quality was therefore returned as a hit. The streaming check now includes `parseQuery(options)`, matching the non-streaming path (the server already keys distinct qualities separately).

Full workspace typecheck clean. Changeset: `@ifc-lite/server-client` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)