### PR TITLE
fix(query): scope whereProperty to the named property set

### DIFF
--- a/.changeset/fix-query-pset-scope.md
+++ b/.changeset/fix-query-pset-scope.md
@@ -1,0 +1,15 @@
+---
+"@ifc-lite/data": minor
+"@ifc-lite/query": patch
+"@ifc-lite/cache": patch
+---
+
+fix(query): scope `whereProperty` to the named property set
+
+`EntityQuery.whereProperty(psetName, propName, ...)` recorded the property-set
+name but never passed it to `findByProperty`, so a property matched in *any*
+property set — e.g. filtering `Pset_WallCommon.IsExternal` also returned doors
+whose `Pset_DoorCommon.IsExternal` matched. `findByProperty` gains an optional
+`psetName` argument (honored by the in-memory, cache-restored, and
+server-converted property tables), and `whereProperty` now passes it. An unknown
+pset name matches nothing.

--- a/apps/viewer/src/utils/serverDataModel.ts
+++ b/apps/viewer/src/utils/serverDataModel.ts
@@ -597,12 +597,20 @@ export function convertServerDataModel(
       }
       return null;
     },
-    findByProperty: (propName: string, _operator: string, value: PropertyValue): number[] => {
-      // Server-converted data: search all psets for matching property name + value
+    findByProperty: (
+      propName: string,
+      _operator: string,
+      value: PropertyValue,
+      psetName?: string,
+    ): number[] => {
+      // Server-converted data: search psets for matching property name + value.
+      // When a pset is named, restrict to it so a same-named property in
+      // another pset does not match.
       const matchingEntityIds: number[] = [];
       for (const [entityId, psets] of entityToPsets) {
         let found = false;
         for (const pset of psets) {
+          if (psetName !== undefined && pset.pset_name !== psetName) continue;
           for (const prop of pset.properties) {
             if (prop.property_name === propName && prop.property_value === value) {
               matchingEntityIds.push(entityId);

--- a/packages/cache/src/sections/properties.ts
+++ b/packages/cache/src/sections/properties.ts
@@ -163,14 +163,20 @@ export function readProperties(reader: BufferReader, strings: StringTable): Prop
       return null;
     },
 
-    findByProperty: (prop, operator, value) => {
+    findByProperty: (prop, operator, value, pset) => {
       const propIdx = strings.indexOf(prop);
       if (propIdx < 0) return [];
+
+      // When a property-set is named, only rows in that pset match; a same-named
+      // property in another pset must not. An unknown pset name matches nothing.
+      const psetIdx = pset === undefined ? -1 : strings.indexOf(pset);
+      if (pset !== undefined && psetIdx < 0) return [];
 
       const rowIndices = propIndex.get(propIdx) || [];
       const results: number[] = [];
 
       for (const idx of rowIndices) {
+        if (psetIdx >= 0 && psetName[idx] !== psetIdx) continue;
         const propValue = getPropertyValue(idx);
         if (compareValues(propValue, operator, value)) {
           results.push(entityId[idx]);

--- a/packages/data/src/data-store.ts
+++ b/packages/data/src/data-store.ts
@@ -38,7 +38,12 @@ interface RelationshipGraph {
 interface PropertyTable {
   getForEntity(expressId: number): PropertySet[];
   getPropertyValue(expressId: number, psetName: string, propName: string): PropertyValue | null;
-  findByProperty(propName: string, operator: string, value: PropertyValue): number[];
+  findByProperty(
+    propName: string,
+    operator: string,
+    value: PropertyValue,
+    psetName?: string,
+  ): number[];
 }
 
 interface QuantityTable {

--- a/packages/data/src/property-table.ts
+++ b/packages/data/src/property-table.ts
@@ -46,7 +46,17 @@ export interface PropertyTable {
   
   getForEntity(expressId: number): PropertySet[];
   getPropertyValue(expressId: number, psetName: string, propName: string): PropertyValue | null;
-  findByProperty(propName: string, operator: string, value: PropertyValue): number[];
+  /**
+   * Find entity ids whose property `propName` satisfies `operator`/`value`.
+   * When `psetName` is given, only matches within that property set (a
+   * same-named property in another pset does not match).
+   */
+  findByProperty(
+    propName: string,
+    operator: string,
+    value: PropertyValue,
+    psetName?: string,
+  ): number[];
 }
 
 export class PropertyTableBuilder {
@@ -230,12 +240,18 @@ export function propertyTableFromColumns(columns: PropertyTableColumns, strings:
       return null;
     },
 
-    findByProperty: (prop, operator, value) => {
+    findByProperty: (prop, operator, value, pset) => {
       const propIdx = strings.indexOf(prop);
       if (propIdx < 0) return [];
+      // When a property-set is named, only rows in that pset match; a property
+      // of the same name in a different pset must not. An unknown pset name
+      // matches nothing.
+      const psetIdx = pset === undefined ? -1 : strings.indexOf(pset);
+      if (pset !== undefined && psetIdx < 0) return [];
       const rowIndices = propIndex.get(propIdx) || [];
       const results: number[] = [];
       for (const idx of rowIndices) {
+        if (psetIdx >= 0 && psetName[idx] !== psetIdx) continue;
         const propValue = getPropertyValue(table, idx, strings);
         if (compareValues(propValue, operator, value)) {
           results.push(entityId[idx]);

--- a/packages/query/src/entity-query.ts
+++ b/packages/query/src/entity-query.ts
@@ -149,7 +149,12 @@ export class EntityQuery {
     let filteredIds = ids;
     
     for (const filter of this.propertyFilters) {
-      const matchingIds = this.store.properties.findByProperty(filter.prop, filter.op, filter.value);
+      const matchingIds = this.store.properties.findByProperty(
+        filter.prop,
+        filter.op,
+        filter.value,
+        filter.pset,
+      );
       const matchingSet = new Set(matchingIds);
       filteredIds = filteredIds.filter(id => matchingSet.has(id));
     }

--- a/packages/query/test/entity-query.test.ts
+++ b/packages/query/test/entity-query.test.ts
@@ -146,7 +146,7 @@ describe('EntityQuery', () => {
       // (Pset_DoorCommon). A query scoped to Pset_WallCommon must return only
       // the wall; ignoring the pset name would leak the door in.
       const store = makeStore();
-      const query = new EntityQuery(store as any, null);
+      const query = new EntityQuery(store, null);
       query.whereProperty('Pset_WallCommon', 'IsExternal', '=', true);
       const results = query.execute();
       expect(results.map(r => r.expressId)).toEqual([1]);
@@ -154,7 +154,7 @@ describe('EntityQuery', () => {
 
     it('returns nothing for an unknown property set even if the property exists', () => {
       const store = makeStore();
-      const query = new EntityQuery(store as any, null);
+      const query = new EntityQuery(store, null);
       query.whereProperty('Pset_NonExistent', 'IsExternal', '=', true);
       const results = query.execute();
       expect(results).toHaveLength(0);

--- a/packages/query/test/entity-query.test.ts
+++ b/packages/query/test/entity-query.test.ts
@@ -140,6 +140,25 @@ describe('EntityQuery', () => {
       expect(results).toHaveLength(1);
       expect(results[0].expressId).toBe(1);
     });
+
+    it('scopes to the named property set, not a same-named property elsewhere', () => {
+      // `IsExternal=true` holds for wall 1 (Pset_WallCommon) and door 3
+      // (Pset_DoorCommon). A query scoped to Pset_WallCommon must return only
+      // the wall; ignoring the pset name would leak the door in.
+      const store = makeStore();
+      const query = new EntityQuery(store as any, null);
+      query.whereProperty('Pset_WallCommon', 'IsExternal', '=', true);
+      const results = query.execute();
+      expect(results.map(r => r.expressId)).toEqual([1]);
+    });
+
+    it('returns nothing for an unknown property set even if the property exists', () => {
+      const store = makeStore();
+      const query = new EntityQuery(store as any, null);
+      query.whereProperty('Pset_NonExistent', 'IsExternal', '=', true);
+      const results = query.execute();
+      expect(results).toHaveLength(0);
+    });
   });
 
   // ── Limit & Offset ────────────────────────────────────────────

--- a/packages/query/test/mock-store.ts
+++ b/packages/query/test/mock-store.ts
@@ -17,6 +17,8 @@ import {
   RelationshipType,
   PropertyValueType,
   QuantityType,
+  type IfcStoreBase,
+  type IfcEntity,
 } from '@ifc-lite/data';
 
 export {
@@ -72,7 +74,7 @@ export interface MockStoreOptions {
  * The returned object is duck-typed to match IfcDataStore's shape as consumed
  * by EntityQuery, EntityNode, QueryResultEntity, and IfcQuery.
  */
-export function createMockStore(opts: MockStoreOptions = {}) {
+export function createMockStore(opts: MockStoreOptions = {}): IfcStoreBase {
   const strings = new StringTable();
   const entityBuilder = new EntityTableBuilder(
     Math.max((opts.entities?.length ?? 0) + 1, 16),
@@ -134,7 +136,7 @@ export function createMockStore(opts: MockStoreOptions = {}) {
     byType.get(upper)!.push(e.expressId);
   }
 
-  const entityMap = new Map<number, { expressId: number; type: string; attributes: unknown[] }>();
+  const entityMap = new Map<number, IfcEntity>();
   for (const e of opts.entities ?? []) {
     entityMap.set(e.expressId, {
       expressId: e.expressId,
@@ -149,7 +151,9 @@ export function createMockStore(opts: MockStoreOptions = {}) {
     });
   }
 
-  return {
+  // Assign to a variable (not a fresh literal return) so the wider mock shape
+  // is structurally accepted as IfcStoreBase without an excess-property error.
+  const store = {
     fileSize: 0,
     schemaVersion: 'IFC4' as const,
     entityCount: opts.entities?.length ?? 0,
@@ -167,7 +171,9 @@ export function createMockStore(opts: MockStoreOptions = {}) {
     getEntity: (expressId: number) => entityMap.get(expressId) ?? null,
     getEntitiesByType: (typeName: string) => {
       const ids = byType.get(typeName.toUpperCase()) ?? [];
-      return ids.map((id: number) => entityMap.get(id)).filter(Boolean);
+      return ids
+        .map((id: number) => entityMap.get(id))
+        .filter((e): e is IfcEntity => e !== undefined);
     },
     getProperties: (expressId: number) => properties.getForEntity(expressId),
     getQuantities: (expressId: number) => quantities.getForEntity(expressId),
@@ -181,4 +187,5 @@ export function createMockStore(opts: MockStoreOptions = {}) {
     onDemandMaterialMap: undefined,
     onDemandDocumentMap: undefined,
   };
+  return store;
 }


### PR DESCRIPTION
Found via a full multi-agent code review of `main`; verified by reading the code and pinned with a regression test.

## `whereProperty` ignored the property-set name
`EntityQuery.whereProperty(psetName, propName, operator, value)` stored `psetName` in the filter but `applyPropertyFilters` called `findByProperty(prop, op, value)` and never passed it — and `findByProperty` had no pset parameter. So a property matched in **any** property set: filtering `Pset_WallCommon.IsExternal = true` also returned doors whose `Pset_DoorCommon.IsExternal` matched, silently widening results.

## Fix
`findByProperty` gains an optional `psetName` argument, honored consistently across all three implementations that back a query store:
- `@ifc-lite/data` `PropertyTable` (fresh in-memory loads)
- `@ifc-lite/cache` restored store
- `serverDataModel` (server-converted models)

`whereProperty` now passes the pset name; an unknown pset matches nothing. The parameter is optional, so existing `findByProperty(prop, op, value)` callers are unaffected.

## Tests
- New `entity-query.test.ts` cases: a `Pset_WallCommon`-scoped filter returns only the wall (not the same-named door property), and an unknown pset returns nothing.
- All 112 `@ifc-lite/query` + 51 `@ifc-lite/data` + 25 `@ifc-lite/cache` tests pass; full workspace typecheck clean. No public export added, so the API-surface snapshot is unchanged.

Changesets: `@ifc-lite/data` minor (interface gained an optional param), `@ifc-lite/query` + `@ifc-lite/cache` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)