### PR TITLE
fix(benchmark): re-arm the stale Snowdon mesh guard + flag non-CI baselines

### DIFF
--- a/scripts/check-benchmark-regression.js
+++ b/scripts/check-benchmark-regression.js
@@ -73,6 +73,15 @@ function percentIncrease(current, baseline) {
   return ((current - baseline) / baseline) * 100;
 }
 
+// The CI job diffs like-for-like only when the baseline was itself recorded on
+// the CI runner. A locally recorded baseline (fast Apple-Silicon, real GPU, an
+// older metric era) makes every SwiftShader CI run look like a huge regression —
+// which is exactly the false alarm this check is meant to avoid. Flag a baseline
+// entry that carries no CI environment tag so the mismatch is visible, not silent.
+function looksCiRecorded(environment) {
+  return typeof environment === 'string' && /github-actions|swiftshader|ubuntu-latest|\bci\b/i.test(environment);
+}
+
 function formatMs(value) {
   if (typeof value !== 'number') return 'N/A';
   return `${value.toFixed(0)}ms`;
@@ -121,6 +130,7 @@ function compareResults() {
       baselineTimestamp: baselineEntry?.timestamp ?? null,
       baselineEnvironment: baselineEntry?.environment ?? null,
       missingBaseline: !baselineEntry?.metrics,
+      baselineLikelyLocal: !!baselineEntry?.metrics && !looksCiRecorded(baselineEntry?.environment),
       rows: [],
     };
 
@@ -160,6 +170,13 @@ function printConsoleReport(models) {
     }
     if (model.baselineEnvironment) {
       console.log(`  Baseline environment: ${model.baselineEnvironment}`);
+    }
+    if (model.baselineLikelyLocal) {
+      console.warn(
+        '  ⚠ Baseline is not CI-recorded (no CI environment tag) — deltas below may reflect a ' +
+          'machine/metric-era mismatch, not a code change. Refresh via the Benchmark workflow ' +
+          '(record_baseline); see tests/benchmark/README.md.'
+      );
     }
 
     for (const row of model.rows) {
@@ -205,6 +222,14 @@ function buildMarkdownReport(models, regressions) {
     if (baselineNote) {
       lines.push('');
       lines.push(`Baseline ${baselineNote}.`);
+    }
+    if (model.baselineLikelyLocal) {
+      lines.push('');
+      lines.push(
+        '> ⚠ This baseline is not CI-recorded (no CI environment tag), so the deltas below may reflect a ' +
+          'machine/metric-era mismatch rather than a code change. Refresh it via the Benchmark workflow ' +
+          '(`record_baseline`).'
+      );
     }
     lines.push('');
     lines.push('| Metric | Current | Baseline | Delta | Threshold | Status |');

--- a/tests/benchmark/viewer-benchmark.spec.ts
+++ b/tests/benchmark/viewer-benchmark.spec.ts
@@ -120,8 +120,13 @@ test.describe('Viewer Performance Benchmarks', () => {
   // Expected mesh counts for geometry correctness validation
   // These help detect if optimizations break geometry (e.g., CSG skipping too much)
   const expectedMeshCounts: Record<string, number> = {
+    // NB: totalMeshes is scraped from "[useIfc] Geometry streaming complete: N batches, M meshes"
+    // = mesh OCCURRENCES streamed (instanced occurrences counted). This is a different quantity
+    // from the deduped allMeshes.length that the "[ifc-lite] … → N meshes" summary and the PostHog
+    // `ifc_model_loaded.mesh_count` report. Keep every expected value below in the SAME occurrence
+    // unit as totalMeshes so this assertion stays apples-to-apples.
     'AC20-FZK-Haus.ifc': 317,  // Verified vs raw WASM pipeline 2026-06-10: incl. 32 type meshes (#957) + 7 IfcSpace (#1022). Was 230 pre-type-geometry/spaces.
-    '01_Snowdon_Towers_Sample_Structural(1).ifc': 1500,  // Structural elements
+    '01_Snowdon_Towers_Sample_Structural(1).ifc': 17380,  // Occurrence count, verified identical across CI SwiftShader + local A/B on 2026-07-02. Was a stale 1500 (deduped/legacy-metric value) that silently disabled this drop check for Snowdon.
     'O-S1-BWK-BIM architectural - BIM bouwkundig.ifc': 16400,  // Large architectural model
     'ISSUE_053_20181220Holter_Tower_10.ifc': 60000,  // Complex model (some walls may skip CSG due to MAX_OPENINGS)
   };


### PR DESCRIPTION
Follow-ups on top of the CI-recorded baseline (#1489, which already fixed the stale local-vs-SwiftShare baseline). **No `baseline.json` change here** — main's #1489 CI baseline is kept as-is.

## Context: the CI "regression" was never real
`baseline.json` used to hold **local Apple-Silicon** numbers compared against **headless SwiftShader** CI (~5x slower speed class + older metric era), so every perf-path PR tripped +50%. Confirmed a measurement artifact, not code:
- Local A/B of current `main` (wasm built from source, headed Chrome): FZK **400ms**, Snowdon **800ms** — baseline speed class.
- 5 unrelated branches all report Snowdon CI `totalWallClock` in a 3000-3600ms band regardless of diff.
- Production telemetry: within-Chrome weekly `ms_per_mesh` is flat.

#1489 fixed the baseline. This PR closes two residual gaps:

## 1. Re-arm the Snowdon geometry-loss guard (resolves greptile P1)
`totalMeshes` is scraped from `"[useIfc] Geometry streaming complete: N batches, M meshes"` = mesh **occurrences**. FZK's `expectedMeshCounts` (317) already matches that occurrence count, but Snowdon's was a stale **1500** (a deduped/legacy value), so the drop-guard was silently inert for Snowdon (17380 always cleared the 1500 floor). Updated to **17380** — verified identical across the #1489 CI baseline, a fresh CI record, and a local Apple-Silicon A/B (2026-07-02) — and documented the occurrence-vs-deduped distinction (PostHog `mesh_count` uses the deduped `allMeshes.length`, ~7151).

## 2. Guard against re-introducing a local baseline
`check-benchmark-regression.js` now warns when a compared model's baseline lacks a CI `environment` tag, so a locally-recorded baseline can't silently reintroduce the false alarm #1489 fixed.

## Related (out of repo)
PostHog per-model alert `pQ4wgqJi` was firing on a single bimodal-by-browser federated model (small 3-sample window). Its query was hardened separately (recent_loads≥5, ≥3 distinct persons/window, ≥3s delta, recent-p25≥baseline-median); validated to suppress the false positive while still able to fire on a real broad regression.

## Verification
- `node --check` + `benchmark:check` run clean; the non-CI-baseline warning does not fire (main's baseline carries CI env tags).
- `totalMeshes` is not one of the six timing thresholds the regression checker compares, so no baseline re-record is needed.
- No changeset — `tests/` + `scripts/` only, no published-package surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a warning when benchmark baselines appear to come from a local environment, helping highlight possible metric mismatches in reports and console output.
* **Tests**
  * Updated benchmark expectations for a geometry-correctness case to match the current streamed mesh count and clarified the metric being checked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->