### PR TITLE
feat(server): admission control, memory observability, disconnect cancellation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,26 @@ Project-specific gotchas and guardrails — the things that bite you *here* and 
 
 **House rules (enforced, but easy to violate):** no `as any` / `@ts-ignore` (fix the types or add a `.d.ts`); no silent `catch {}` (log or rethrow); split modules over ~400 non-generated lines; new packages/features ship tests; package-specific deps go in the consuming package, never root.
 
+## Fable 5 orchestration
+- Default Fable 5 to **high** effort for this repo. Escalate above high only for tightly scoped final judgment calls (architecture, risky API/semver decisions, geometry-kernel reasoning, security-sensitive review) after cheaper investigation has narrowed the problem.
+- Use Fable 5 as orchestrator, spec writer, and final reviewer — not as the default engine for token-heavy repo sweeps. Delegate mechanical implementation, broad code search, log triage, fixture inspection, and first-pass test repair to cheaper/specialized agents, then bring back a concise summary, exact files changed, commands run, and open risks.
+- This mirrors Theo's pattern: keep Fable on high, use Claude/other agents as wrappers for work routing, and offload token-hungry filesystem work to Codex. The ifc-lite-specific difference: Codex must still obey this AGENTS.md, use the canonical load/geometry/export paths above, and prove changes with local commands before Fable trusts the result.
+- When delegating from Claude/Fable, set subagent models explicitly. Use `model: fable` only for design/review/taste-sensitive work; use `model: sonnet` or `model: opus` for implementation depending on risk. Avoid Haiku for code changes or review in this repo unless the task is truly trivial and read-only.
+
+### Local Codex handoff
+- Codex is installed on Louis's machine; verify with `command -v codex && codex --version`. Use it as the preferred fallback for implementation, investigation, and adversarial review when Claude/Fable would burn context on filesystem work.
+- For a self-contained implementation/investigation, run Codex directly from the repo root with an explicit sandbox: `codex exec --sandbox workspace-write "<task prompt>"`. Use read-only mode for research/review: `codex exec "<task prompt>"`. Use `--json` or `-o <file>` when Fable needs a compact machine-readable summary instead of a long transcript.
+- Good direct handoff shape:
+  `codex exec --sandbox workspace-write "In this ifc-lite repo, follow AGENTS.md. Goal: <goal>. Relevant files: <files>. Constraints: no as any, no ts-ignore, no silent catch, preserve IFC EXPRESS names, no second load path. Make the smallest safe patch. Run <verification command>. Return: files changed, commands run, result, risks."`
+- If Claude Code has the OpenAI Codex plugin installed, prefer the slash commands for in-Claude orchestration: `/codex:rescue --background <task>` for delegated fixes/investigation, `/codex:review --background` for normal read-only review, `/codex:adversarial-review --background <focus>` for challenge review, then `/codex:status` and `/codex:result` to pull back the final summary. Do not enable the plugin review gate unless actively monitored; it can loop and drain usage.
+- Codex review paths are read-only critique. Treat Codex implementation output as a patch proposal until Fable/Claude inspects `git diff` and local verification passes.
+- Use `codex exec resume --last "<follow-up>"` only when continuing the immediately previous Codex thread for this repo; otherwise start fresh so stale context does not bleed across unrelated tasks.
+
+### Handoff hygiene
+- Handoff prompts must be self-contained: include the user goal, relevant AGENTS.md constraints, files/commands already inspected, acceptance criteria, and the exact verification command expected. Ask the delegate to avoid public API churn, respect IFC EXPRESS names, and report uncertainty instead of inventing aliases or fallbacks.
+- Keep Fable's context clean. Do not paste long logs, generated files, or fixture dumps back into Fable; summarize the failure signature and link/path the artifact. If a delegate fails, return the smallest repro, command, stderr excerpt, and suspected owner area.
+- Final Fable pass before shipping: review `git diff`, confirm generated artifacts/changesets/API surface rules, run the narrowest relevant tests, and explicitly list anything not verified.
+
 ## IFC schema fidelity
 - User-facing APIs/exports/scripts use exact IFC EXPRESS names — PascalCase attributes (`GlobalId`, `Name`, `ObjectType`), full relationship names (`IfcRelAggregates`, not `Aggregates`). Never invent aliases.
 - STEP type names are stored UPPERCASE; render via `store.entities.getTypeName(id)` to get `IfcPascalCase`.

--- a/apps/server/OPERATIONS.md
+++ b/apps/server/OPERATIONS.md
@@ -1,0 +1,62 @@
+# Server operations: admission control and memory
+
+The parse endpoints buffer the whole upload (default cap 500 MB) and spawn
+blocking decode/mesh work whose peak working set is a multiple of the file
+size. Admission control bounds how much of that runs at once so concurrent
+large uploads return `503 Retry-After` instead of OOM-killing the (single)
+replica.
+
+## Knobs (environment variables)
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `IFC_MAX_CONCURRENT_PARSES` | `WORKER_THREADS` (= cores) | Parse jobs running at once (CPU gate) |
+| `IFC_MEM_BUDGET_MB` | 70% of the cgroup memory limit, else 0 | Total admitted upload bytes at once; `0` disables the byte gate |
+| `IFC_ADMISSION_QUEUE_DEPTH` | `2 * WORKER_THREADS` | Requests allowed to wait for a slot before immediate 503 |
+| `IFC_ADMISSION_QUEUE_TIMEOUT_SECS` | `5` | Longest a queued request waits before 503 |
+| `IFC_MEM_SHED_PCT` | `85` | RSS percentage of the budget above which new work is shed |
+| `IFC_METRICS_ENABLED` | off | Expose `GET /api/v1/metrics` (Prometheus text; behind the bearer token when one is set) |
+
+Each admitted parse reserves the full `MAX_FILE_SIZE_MB` against the byte
+budget (multipart rarely declares a length up front), so the budget divided by
+the max file size is the number of large parses that can run concurrently.
+
+## Sizing rule
+
+Budget roughly `file_size x (1x upload buffer + 3-6x decode/mesh working set)`
+for geometry-heavy models; the multiplier is workload-dependent, re-measure on
+your corpus. Concretely for a single-replica box:
+
+- set `IFC_MEM_BUDGET_MB` to about 70% of instance RAM (the cgroup default
+  does this for you inside containers),
+- keep `IFC_MAX_CONCURRENT_PARSES` at the core count,
+- lower `MAX_FILE_SIZE_MB` below 500 unless the box has multiple GB of
+  headroom per concurrent slot,
+- front the deployment with an edge rate limiter when it is internet-facing
+  and unauthenticated (see the startup warning).
+
+## Probes
+
+- `GET /api/v1/health` - liveness. Static, never load-gated. Railway's
+  `healthcheckPath` points here; do NOT repoint it at readiness or the box
+  restart-loops exactly when it is busiest.
+- `GET /api/v1/ready` - readiness. Returns 503 while the RSS breaker is
+  shedding, so an external balancer can drain the instance.
+- `GET /api/v1/metrics` - admission gauges/counters + resident memory
+  (`ifc_server_resident_bytes`, `ifc_server_admission_in_flight`,
+  `ifc_server_admission_queued`, `ifc_server_admission_rejected_total{reason}`,
+  `ifc_server_mem_budget_bytes`), when `IFC_METRICS_ENABLED=1`.
+
+## Behavior notes
+
+- RSS sampling reads `/proc/self/statm` every 500 ms (Linux; the breaker is
+  inert on other platforms - the semaphores still bound admissions there). The
+  allocator was deliberately NOT swapped to jemalloc: the release matrix
+  includes a musl target where that is a known build risk; the RSS source
+  lives behind `admission::resident_bytes_now()` if that decision is revisited.
+- SSE disconnects cancel the parse at the next batch boundary
+  (`StreamingOptions::cancel`), freeing the core and the admission slot early.
+  Synchronous (non-streaming) parses run to completion; their admission slot
+  is held the whole time so a replacement is not admitted on top of a zombie.
+- Per-client rate limiting (429) is not built in; the admission gate is
+  per-process. Front with an edge limiter for per-IP fairness.

--- a/apps/server/src/admission.rs
+++ b/apps/server/src/admission.rs
@@ -1,0 +1,394 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Request admission control: bounded parse concurrency + a byte-weighted
+//! memory budget + a coarse RSS circuit breaker.
+//!
+//! Every parse handler acquires an [`AdmissionGuard`] BEFORE buffering the
+//! upload. Without this, N concurrent large uploads each buffer the full file
+//! and spawn blocking decode/mesh work whose working set is a multiple of the
+//! file size; nothing bounds N, so the container is OOM-killed (a full outage
+//! on the single-replica deployment). The byte-weighted semaphore is the
+//! load-bearing bound: total admitted upload bytes can never exceed the
+//! configured budget. The CPU semaphore keeps the blocking pool from
+//! thrashing, and the RSS breaker sheds load before the kernel does.
+//!
+//! Explicit semaphores were chosen over `tower::limit::GlobalConcurrencyLimit`:
+//! the tower layer makes over-limit requests wait unboundedly with no 503/
+//! `Retry-After`, wraps cheap GET routes too, and cannot express a byte budget.
+
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+use crate::error::ApiError;
+
+/// Tuning knobs, derived from [`crate::config::Config`] at startup.
+#[derive(Debug, Clone)]
+pub struct AdmissionCfg {
+    /// Parse jobs allowed to run at once (CPU gate).
+    pub max_concurrent_parses: usize,
+    /// Total upload bytes allowed to be admitted at once. `0` disables the
+    /// memory gate (the CPU gate still applies).
+    pub mem_budget_bytes: u64,
+    /// Requests allowed to WAIT for a permit before immediate rejection.
+    pub queue_depth: usize,
+    /// Longest a queued request waits for a permit before rejection.
+    pub queue_timeout: std::time::Duration,
+    /// RSS high-water percentage of `mem_budget_bytes` above which new parse
+    /// jobs are shed outright (the circuit breaker). Inert when the budget or
+    /// the sampled RSS is 0.
+    pub shed_pct: u8,
+}
+
+/// One memory-budget permit spans this many upload bytes, so the semaphore's
+/// permit count stays far below `Semaphore::MAX_PERMITS` even for multi-GB
+/// budgets.
+const BYTES_PER_PERMIT: u64 = 1024 * 1024;
+
+/// Shared admission state (one per process, in `AppState`).
+pub struct Admission {
+    cpu: Arc<Semaphore>,
+    /// `None` when the memory gate is disabled (`mem_budget_bytes == 0`).
+    mem: Option<Arc<Semaphore>>,
+    queued: AtomicUsize,
+    in_flight: AtomicUsize,
+    rejected_overload: AtomicU64,
+    rejected_queue_full: AtomicU64,
+    rejected_shed: AtomicU64,
+    /// Resident set size sampled by the background loop (bytes). Tests write
+    /// this directly; production writes come from [`spawn_rss_sampler`].
+    resident_bytes: AtomicU64,
+    cfg: AdmissionCfg,
+}
+
+/// RAII permit pair; drops release the slots.
+#[derive(Debug)]
+pub struct AdmissionGuard {
+    _cpu: OwnedSemaphorePermit,
+    _mem: Option<OwnedSemaphorePermit>,
+    admission: Arc<Admission>,
+}
+
+impl std::fmt::Debug for Admission {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Admission")
+            .field("cfg", &self.cfg)
+            .field("in_flight", &self.in_flight.load(Ordering::Relaxed))
+            .field("queued", &self.queued.load(Ordering::Relaxed))
+            .finish()
+    }
+}
+
+impl Drop for AdmissionGuard {
+    fn drop(&mut self) {
+        self.admission.in_flight.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+impl Admission {
+    pub fn new(cfg: AdmissionCfg) -> Self {
+        let mem = (cfg.mem_budget_bytes > 0).then(|| {
+            let permits = (cfg.mem_budget_bytes / BYTES_PER_PERMIT).max(1) as usize;
+            Arc::new(Semaphore::new(permits))
+        });
+        Self {
+            cpu: Arc::new(Semaphore::new(cfg.max_concurrent_parses.max(1))),
+            mem,
+            queued: AtomicUsize::new(0),
+            in_flight: AtomicUsize::new(0),
+            rejected_overload: AtomicU64::new(0),
+            rejected_queue_full: AtomicU64::new(0),
+            rejected_shed: AtomicU64::new(0),
+            resident_bytes: AtomicU64::new(0),
+            cfg,
+        }
+    }
+
+    /// Admit one parse job that will buffer up to `reserve_bytes` of upload.
+    ///
+    /// Multipart rarely declares a length up front, so callers reserve the
+    /// configured max file size — a conservative reservation that guarantees
+    /// the byte bound holds (tighter packing is a follow-up once the actual
+    /// size is known post-extract).
+    pub async fn acquire(
+        self: &Arc<Self>,
+        reserve_bytes: u64,
+    ) -> Result<AdmissionGuard, ApiError> {
+        // 1. RSS circuit breaker: shed before the kernel OOM-killer does.
+        if self.cfg.mem_budget_bytes > 0 && self.cfg.shed_pct > 0 {
+            let rss = self.resident_bytes.load(Ordering::Relaxed);
+            let watermark = self.cfg.mem_budget_bytes / 100 * self.cfg.shed_pct as u64;
+            if rss > 0 && rss >= watermark {
+                self.rejected_shed.fetch_add(1, Ordering::Relaxed);
+                return Err(ApiError::Overloaded {
+                    retry_after_secs: self.cfg.queue_timeout.as_secs().max(1) * 2,
+                });
+            }
+        }
+
+        struct QueuedCount<'a>(&'a AtomicUsize);
+        impl Drop for QueuedCount<'_> {
+            fn drop(&mut self) {
+                self.0.fetch_sub(1, Ordering::Relaxed);
+            }
+        }
+
+        // 2. CPU slot: non-blocking first - a free slot admits regardless of
+        // queue configuration. Only WAITERS are subject to the bounded queue:
+        // reject outright when enough requests are already waiting, otherwise
+        // wait for a slot up to the queue timeout.
+        let cpu = match Arc::clone(&self.cpu).try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(_) => {
+                if self.queued.load(Ordering::Relaxed) >= self.cfg.queue_depth {
+                    self.rejected_queue_full.fetch_add(1, Ordering::Relaxed);
+                    return Err(ApiError::Overloaded {
+                        retry_after_secs: self.cfg.queue_timeout.as_secs().max(1),
+                    });
+                }
+                self.queued.fetch_add(1, Ordering::Relaxed);
+                let _queued = QueuedCount(&self.queued);
+                match tokio::time::timeout(
+                    self.cfg.queue_timeout,
+                    Arc::clone(&self.cpu).acquire_owned(),
+                )
+                .await
+                {
+                    Ok(Ok(permit)) => permit,
+                    _ => {
+                        self.rejected_overload.fetch_add(1, Ordering::Relaxed);
+                        return Err(ApiError::Overloaded {
+                            retry_after_secs: self.cfg.queue_timeout.as_secs().max(1),
+                        });
+                    }
+                }
+            }
+        };
+
+        // 4. Byte-weighted memory permits (bounded wait). A request larger
+        // than the whole budget is clamped to it, so the largest allowed
+        // upload can always run - alone.
+        let mem = if let Some(mem) = &self.mem {
+            let budget_permits = (self.cfg.mem_budget_bytes / BYTES_PER_PERMIT).max(1);
+            let want = reserve_bytes.div_ceil(BYTES_PER_PERMIT).max(1).min(budget_permits) as u32;
+            match tokio::time::timeout(
+                self.cfg.queue_timeout,
+                Arc::clone(mem).acquire_many_owned(want),
+            )
+            .await
+            {
+                Ok(Ok(permit)) => Some(permit),
+                _ => {
+                    self.rejected_overload.fetch_add(1, Ordering::Relaxed);
+                    return Err(ApiError::Overloaded {
+                        retry_after_secs: self.cfg.queue_timeout.as_secs().max(1),
+                    });
+                }
+            }
+        } else {
+            None
+        };
+
+        self.in_flight.fetch_add(1, Ordering::Relaxed);
+        Ok(AdmissionGuard { _cpu: cpu, _mem: mem, admission: Arc::clone(self) })
+    }
+
+    /// Current sampled resident set size in bytes (0 = unknown/not sampled).
+    pub fn resident_bytes(&self) -> u64 {
+        self.resident_bytes.load(Ordering::Relaxed)
+    }
+
+    /// True when the RSS breaker would currently shed new work (readiness).
+    pub fn is_shedding(&self) -> bool {
+        if self.cfg.mem_budget_bytes == 0 || self.cfg.shed_pct == 0 {
+            return false;
+        }
+        let rss = self.resident_bytes.load(Ordering::Relaxed);
+        rss > 0 && rss >= self.cfg.mem_budget_bytes / 100 * self.cfg.shed_pct as u64
+    }
+
+    /// Prometheus text exposition of the admission gauges/counters.
+    pub fn metrics_text(&self) -> String {
+        format!(
+            "# TYPE ifc_server_resident_bytes gauge\n\
+             ifc_server_resident_bytes {}\n\
+             # TYPE ifc_server_mem_budget_bytes gauge\n\
+             ifc_server_mem_budget_bytes {}\n\
+             # TYPE ifc_server_admission_in_flight gauge\n\
+             ifc_server_admission_in_flight {}\n\
+             # TYPE ifc_server_admission_queued gauge\n\
+             ifc_server_admission_queued {}\n\
+             # TYPE ifc_server_admission_rejected_total counter\n\
+             ifc_server_admission_rejected_total{{reason=\"overloaded\"}} {}\n\
+             ifc_server_admission_rejected_total{{reason=\"queue_full\"}} {}\n\
+             ifc_server_admission_rejected_total{{reason=\"rss_shed\"}} {}\n",
+            self.resident_bytes.load(Ordering::Relaxed),
+            self.cfg.mem_budget_bytes,
+            self.in_flight.load(Ordering::Relaxed),
+            self.queued.load(Ordering::Relaxed),
+            self.rejected_overload.load(Ordering::Relaxed),
+            self.rejected_queue_full.load(Ordering::Relaxed),
+            self.rejected_shed.load(Ordering::Relaxed),
+        )
+    }
+
+    /// Test/simulation hook: set the sampled RSS directly.
+    pub fn set_resident_bytes(&self, bytes: u64) {
+        self.resident_bytes.store(bytes, Ordering::Relaxed);
+    }
+}
+
+/// Resident set size of this process in bytes, or 0 when unknown.
+///
+/// Linux (`/proc/self/statm`) covers every production target (Docker,
+/// Railway, the three release binaries). Other platforms return 0, which
+/// leaves the RSS breaker inert on dev machines - the admission semaphores
+/// still bound memory there. Kept behind this helper so the source can be
+/// swapped (e.g. for jemalloc stats) without touching call sites; the
+/// allocator swap itself was deliberately skipped because the release matrix
+/// includes a musl target where jemalloc is a known build risk.
+pub fn resident_bytes_now() -> u64 {
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(statm) = std::fs::read_to_string("/proc/self/statm") {
+            // Field 1 (0-based) is resident pages.
+            if let Some(pages) = statm
+                .split_whitespace()
+                .nth(1)
+                .and_then(|v| v.parse::<u64>().ok())
+            {
+                // Page size is 4096 on every target we ship; sysconf would need libc.
+                return pages * 4096;
+            }
+        }
+        0
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        0
+    }
+}
+
+/// Container memory limit from cgroups (v2 then v1), if readable. Seeds the
+/// default memory budget so it self-tunes to the instance size.
+pub fn cgroup_memory_limit_bytes() -> Option<u64> {
+    for path in [
+        "/sys/fs/cgroup/memory.max",
+        "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+    ] {
+        if let Ok(raw) = std::fs::read_to_string(path) {
+            let raw = raw.trim();
+            if raw == "max" {
+                return None;
+            }
+            if let Ok(v) = raw.parse::<u64>() {
+                // cgroup v1 reports a huge sentinel when unlimited.
+                if v > 0 && v < (1 << 60) {
+                    return Some(v);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Background sampler: refreshes the shared RSS gauge every 500 ms so the
+/// admission breaker reads a cheap atomic, never the filesystem, per request.
+pub fn spawn_rss_sampler(admission: Arc<Admission>) {
+    tokio::spawn(async move {
+        let mut tick = tokio::time::interval(std::time::Duration::from_millis(500));
+        loop {
+            tick.tick().await;
+            admission.set_resident_bytes(resident_bytes_now());
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(max_parses: usize, budget_mb: u64, queue_depth: usize) -> AdmissionCfg {
+        AdmissionCfg {
+            max_concurrent_parses: max_parses,
+            mem_budget_bytes: budget_mb * 1024 * 1024,
+            queue_depth,
+            queue_timeout: std::time::Duration::from_millis(50),
+            shed_pct: 85,
+        }
+    }
+
+    #[tokio::test]
+    async fn admits_within_limits_and_releases_on_drop() {
+        let a = Arc::new(Admission::new(cfg(1, 100, 2)));
+        let g = a.acquire(10 * 1024 * 1024).await.expect("first admit");
+        drop(g);
+        let _g2 = a.acquire(10 * 1024 * 1024).await.expect("slot released");
+    }
+
+    #[tokio::test]
+    async fn rejects_with_overloaded_when_cpu_saturated() {
+        let a = Arc::new(Admission::new(cfg(1, 0, 4)));
+        let _held = a.acquire(1).await.expect("first admit");
+        let err = a.acquire(1).await.expect_err("second must time out");
+        assert!(matches!(err, ApiError::Overloaded { .. }));
+    }
+
+    #[tokio::test]
+    async fn byte_budget_bounds_total_admitted_bytes() {
+        // 100 MB budget: two 40 MB jobs fit, the third must be rejected.
+        let a = Arc::new(Admission::new(cfg(8, 100, 4)));
+        let _g1 = a.acquire(40 * 1024 * 1024).await.expect("40MB #1");
+        let _g2 = a.acquire(40 * 1024 * 1024).await.expect("40MB #2");
+        let err = a.acquire(40 * 1024 * 1024).await.expect_err("over budget");
+        assert!(matches!(err, ApiError::Overloaded { .. }));
+    }
+
+    #[tokio::test]
+    async fn oversized_request_is_clamped_to_run_alone() {
+        let a = Arc::new(Admission::new(cfg(8, 100, 4)));
+        let g = a.acquire(500 * 1024 * 1024).await.expect("clamped to budget");
+        // While the clamped job holds the whole budget, nothing else fits.
+        let err = a.acquire(1024 * 1024).await.expect_err("budget exhausted");
+        assert!(matches!(err, ApiError::Overloaded { .. }));
+        drop(g);
+        let _g2 = a.acquire(1024 * 1024).await.expect("budget released");
+    }
+
+    #[tokio::test]
+    async fn queue_depth_rejects_immediately_when_full() {
+        let a = Arc::new(Admission::new(cfg(1, 0, 0)));
+        let _held = a.acquire(1).await.expect("first admit");
+        // queue_depth 0: the next request is rejected without waiting.
+        let start = std::time::Instant::now();
+        let err = a.acquire(1).await.expect_err("queue full");
+        assert!(matches!(err, ApiError::Overloaded { .. }));
+        assert!(start.elapsed() < std::time::Duration::from_millis(40), "no wait");
+    }
+
+    #[tokio::test]
+    async fn rss_breaker_sheds_above_watermark() {
+        let a = Arc::new(Admission::new(cfg(4, 100, 4)));
+        a.set_resident_bytes(90 * 1024 * 1024); // above 85% of 100 MB
+        let err = a.acquire(1).await.expect_err("shed");
+        assert!(matches!(err, ApiError::Overloaded { .. }));
+        assert!(a.is_shedding());
+        a.set_resident_bytes(10 * 1024 * 1024);
+        assert!(!a.is_shedding());
+        let _g = a.acquire(1).await.expect("admits again below watermark");
+    }
+
+    #[tokio::test]
+    async fn metrics_text_exposes_gauges_and_counters() {
+        let a = Arc::new(Admission::new(cfg(2, 100, 2)));
+        a.set_resident_bytes(1234);
+        let _g = a.acquire(1).await.unwrap();
+        let text = a.metrics_text();
+        assert!(text.contains("ifc_server_resident_bytes 1234"));
+        assert!(text.contains("ifc_server_admission_in_flight 1"));
+        assert!(text.contains("reason=\"rss_shed\"} 0"));
+    }
+}

--- a/apps/server/src/admission.rs
+++ b/apps/server/src/admission.rs
@@ -143,13 +143,26 @@ impl Admission {
         let cpu = match Arc::clone(&self.cpu).try_acquire_owned() {
             Ok(permit) => permit,
             Err(_) => {
-                if self.queued.load(Ordering::Relaxed) >= self.cfg.queue_depth {
-                    self.rejected_queue_full.fetch_add(1, Ordering::Relaxed);
-                    return Err(ApiError::Overloaded {
-                        retry_after_secs: self.cfg.queue_timeout.as_secs().max(1),
-                    });
+                // Reserve the queue slot atomically (CAS): a load-then-add
+                // would let concurrent waiters race past the depth check.
+                let mut cur = self.queued.load(Ordering::Relaxed);
+                loop {
+                    if cur >= self.cfg.queue_depth {
+                        self.rejected_queue_full.fetch_add(1, Ordering::Relaxed);
+                        return Err(ApiError::Overloaded {
+                            retry_after_secs: self.cfg.queue_timeout.as_secs().max(1),
+                        });
+                    }
+                    match self.queued.compare_exchange_weak(
+                        cur,
+                        cur + 1,
+                        Ordering::Relaxed,
+                        Ordering::Relaxed,
+                    ) {
+                        Ok(_) => break,
+                        Err(actual) => cur = actual,
+                    }
                 }
-                self.queued.fetch_add(1, Ordering::Relaxed);
                 let _queued = QueuedCount(&self.queued);
                 match tokio::time::timeout(
                     self.cfg.queue_timeout,
@@ -171,6 +184,12 @@ impl Admission {
         // 4. Byte-weighted memory permits (bounded wait). A request larger
         // than the whole budget is clamped to it, so the largest allowed
         // upload can always run - alone.
+        //
+        // Ordering is deliberate: CPU first, THEN memory. Memory-first would
+        // let up to queue_depth waiters pin budget BYTES while queueing for a
+        // CPU slot - the scarcer resource held longest. CPU-first bounds the
+        // number of memory waiters to max_concurrent_parses, and a CPU permit
+        // held briefly while memory times out costs only that waiter's slot.
         let mem = if let Some(mem) = &self.mem {
             let budget_permits = (self.cfg.mem_budget_bytes / BYTES_PER_PERMIT).max(1);
             let want = reserve_bytes.div_ceil(BYTES_PER_PERMIT).max(1).min(budget_permits) as u32;

--- a/apps/server/src/config.rs
+++ b/apps/server/src/config.rs
@@ -28,6 +28,25 @@ pub struct Config {
     pub cache_max_age_days: u64,
     /// Allowed CORS origins (comma-separated, or "*" for all in development).
     pub cors_origins: Vec<String>,
+    /// Parse jobs allowed to run at once (`IFC_MAX_CONCURRENT_PARSES`,
+    /// default = `worker_threads`). The admission CPU gate.
+    pub max_concurrent_parses: usize,
+    /// Total upload bytes (in MB) allowed to be admitted at once
+    /// (`IFC_MEM_BUDGET_MB`). Default: auto-detected from the cgroup memory
+    /// limit (70% of it) when readable, else 0 = memory gate disabled.
+    pub mem_budget_mb: usize,
+    /// Requests allowed to wait for an admission permit before immediate
+    /// rejection (`IFC_ADMISSION_QUEUE_DEPTH`, default = 2 * worker_threads).
+    pub admission_queue_depth: usize,
+    /// Longest a queued request waits for a permit, seconds
+    /// (`IFC_ADMISSION_QUEUE_TIMEOUT_SECS`, default 5).
+    pub admission_queue_timeout_secs: u64,
+    /// RSS high-water percentage of the memory budget above which new parse
+    /// jobs are shed (`IFC_MEM_SHED_PCT`, default 85).
+    pub mem_shed_pct: u8,
+    /// Expose `GET /api/v1/metrics` (`IFC_METRICS_ENABLED`, default false).
+    /// Protected by the bearer token when one is configured.
+    pub metrics_enabled: bool,
     /// Optional bearer token for the compute/parse routes.
     ///
     /// Read from `IFC_SERVER_API_TOKEN` (falling back to `API_TOKEN`). When set,
@@ -51,6 +70,12 @@ impl std::fmt::Debug for Config {
             .field("max_batch_size", &self.max_batch_size)
             .field("cache_max_age_days", &self.cache_max_age_days)
             .field("cors_origins", &self.cors_origins)
+            .field("max_concurrent_parses", &self.max_concurrent_parses)
+            .field("mem_budget_mb", &self.mem_budget_mb)
+            .field("admission_queue_depth", &self.admission_queue_depth)
+            .field("admission_queue_timeout_secs", &self.admission_queue_timeout_secs)
+            .field("mem_shed_pct", &self.mem_shed_pct)
+            .field("metrics_enabled", &self.metrics_enabled)
             // Redacted: never print the bearer token.
             .field("api_token", &self.api_token.as_ref().map(|_| "<redacted>"))
             .finish()
@@ -60,6 +85,10 @@ impl std::fmt::Debug for Config {
 impl Config {
     /// Load configuration from environment variables.
     pub fn from_env() -> Self {
+        let worker_threads: usize = std::env::var("WORKER_THREADS")
+            .unwrap_or_else(|_| num_cpus::get().to_string())
+            .parse()
+            .unwrap_or_else(|_| num_cpus::get());
         Self {
             port: std::env::var("PORT")
                 .unwrap_or_else(|_| "8080".into())
@@ -87,10 +116,38 @@ impl Config {
                 .unwrap_or_else(|_| "300".into())
                 .parse()
                 .unwrap_or(300),
-            worker_threads: std::env::var("WORKER_THREADS")
-                .unwrap_or_else(|_| num_cpus::get().to_string())
-                .parse()
-                .unwrap_or_else(|_| num_cpus::get()),
+            worker_threads,
+            max_concurrent_parses: std::env::var("IFC_MAX_CONCURRENT_PARSES")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(worker_threads)
+                .max(1),
+            mem_budget_mb: std::env::var("IFC_MEM_BUDGET_MB")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or_else(|| {
+                    // Self-tune to the container: 70% of the cgroup limit,
+                    // leaving headroom for the allocator and the OS. 0 when
+                    // no limit is readable (memory gate disabled).
+                    crate::admission::cgroup_memory_limit_bytes()
+                        .map(|b| (b / (1024 * 1024) * 70 / 100) as usize)
+                        .unwrap_or(0)
+                }),
+            admission_queue_depth: std::env::var("IFC_ADMISSION_QUEUE_DEPTH")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(worker_threads * 2),
+            admission_queue_timeout_secs: std::env::var("IFC_ADMISSION_QUEUE_TIMEOUT_SECS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(5),
+            mem_shed_pct: std::env::var("IFC_MEM_SHED_PCT")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(85),
+            metrics_enabled: std::env::var("IFC_METRICS_ENABLED")
+                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                .unwrap_or(false),
             initial_batch_size: std::env::var("INITIAL_BATCH_SIZE")
                 .unwrap_or_else(|_| "100".into())
                 .parse()

--- a/apps/server/src/config.rs
+++ b/apps/server/src/config.rs
@@ -143,8 +143,9 @@ impl Config {
                 .unwrap_or(5),
             mem_shed_pct: std::env::var("IFC_MEM_SHED_PCT")
                 .ok()
-                .and_then(|v| v.parse().ok())
-                .unwrap_or(85),
+                .and_then(|v| v.parse::<u8>().ok())
+                .unwrap_or(85)
+                .min(100),
             metrics_enabled: std::env::var("IFC_METRICS_ENABLED")
                 .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
                 .unwrap_or(false),

--- a/apps/server/src/error.rs
+++ b/apps/server/src/error.rs
@@ -44,6 +44,9 @@ pub enum ApiError {
 
     #[error("Parquet serialization error: {0}")]
     Parquet(String),
+
+    #[error("Server overloaded, retry after {retry_after_secs}s")]
+    Overloaded { retry_after_secs: u64 },
 }
 
 /// Error response body.
@@ -66,6 +69,12 @@ impl IntoResponse for ApiError {
             ApiError::Internal(_) => (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL_ERROR"),
             ApiError::Join(_) => (StatusCode::INTERNAL_SERVER_ERROR, "TASK_ERROR"),
             ApiError::Parquet(_) => (StatusCode::INTERNAL_SERVER_ERROR, "PARQUET_ERROR"),
+            ApiError::Overloaded { .. } => (StatusCode::SERVICE_UNAVAILABLE, "OVERLOADED"),
+        };
+
+        let retry_after = match &self {
+            ApiError::Overloaded { retry_after_secs } => Some(*retry_after_secs),
+            _ => None,
         };
 
         let body = ErrorResponse {
@@ -73,7 +82,13 @@ impl IntoResponse for ApiError {
             code: code.to_string(),
         };
 
-        (status, Json(body)).into_response()
+        let mut response = (status, Json(body)).into_response();
+        if let Some(secs) = retry_after {
+            if let Ok(v) = axum::http::HeaderValue::from_str(&secs.to_string()) {
+                response.headers_mut().insert(axum::http::header::RETRY_AFTER, v);
+            }
+        }
+        response
     }
 }
 

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -36,6 +36,7 @@ use tower_http::{
     timeout::TimeoutLayer, trace::TraceLayer,
 };
 
+mod admission;
 mod config;
 mod error;
 mod middleware;
@@ -80,6 +81,7 @@ fn build_cors_layer(config: &Config) -> CorsLayer {
 pub struct AppState {
     pub cache: Arc<DiskCache>,
     pub config: Arc<Config>,
+    pub admission: Arc<admission::Admission>,
 }
 
 /// Build the application router with all routes and middleware.
@@ -97,8 +99,12 @@ fn build_router(state: AppState) -> Router {
     let open_routes = Router::new()
         // Root endpoint - API information
         .route("/", get(routes::health::info))
-        // Health check
-        .route("/api/v1/health", get(routes::health::check));
+        // Health check (liveness: static, never load-gated - Railway's
+        // healthcheck points here and must not restart the box under load)
+        .route("/api/v1/health", get(routes::health::check))
+        // Readiness: 503 while the RSS breaker is shedding, so an external
+        // balancer can drain the instance without a restart loop.
+        .route("/api/v1/ready", get(routes::health::ready));
 
     // Protected routes: the compute-heavy parse endpoints and cache reads. When
     // `config.api_token` is set these require an `Authorization: Bearer <token>`
@@ -135,6 +141,9 @@ fn build_router(state: AppState) -> Router {
             "/api/v1/cache/geometry/{hash}",
             get(routes::parse::get_cached_geometry),
         )
+        // Prometheus text metrics (admission gauges + resident memory);
+        // registered only when enabled, protected by the same bearer layer.
+        .route("/api/v1/metrics", get(routes::metrics::metrics))
         // Optional bearer-token auth (off unless `api_token` is configured).
         .layer(axum::middleware::from_fn_with_state(
             config.clone(),
@@ -201,9 +210,27 @@ async fn main() {
     // Initialize cache
     let cache = Arc::new(DiskCache::new(&config.cache_dir).await);
 
+    let admission = Arc::new(admission::Admission::new(admission::AdmissionCfg {
+        max_concurrent_parses: config.max_concurrent_parses,
+        mem_budget_bytes: config.mem_budget_mb as u64 * 1024 * 1024,
+        queue_depth: config.admission_queue_depth,
+        queue_timeout: Duration::from_secs(config.admission_queue_timeout_secs),
+        shed_pct: config.mem_shed_pct,
+    }));
+    admission::spawn_rss_sampler(Arc::clone(&admission));
+    tracing::info!(
+        max_concurrent_parses = config.max_concurrent_parses,
+        mem_budget_mb = config.mem_budget_mb,
+        queue_depth = config.admission_queue_depth,
+        queue_timeout_secs = config.admission_queue_timeout_secs,
+        shed_pct = config.mem_shed_pct,
+        "Admission control active (mem budget 0 = byte gate disabled)"
+    );
+
     let state = AppState {
         cache,
         config: Arc::new(config.clone()),
+        admission,
     };
 
     // Build router

--- a/apps/server/src/parity_tests.rs
+++ b/apps/server/src/parity_tests.rs
@@ -108,7 +108,70 @@ async fn test_state(label: &str) -> AppState {
     AppState {
         cache,
         config: Arc::new(Config::from_env()),
+        admission: test_admission(8),
     }
+}
+
+/// Admission sized for tests: `n` CPU slots, no byte budget, tiny queue wait.
+fn test_admission(n: usize) -> Arc<crate::admission::Admission> {
+    Arc::new(crate::admission::Admission::new(crate::admission::AdmissionCfg {
+        max_concurrent_parses: n,
+        mem_budget_bytes: 0,
+        queue_depth: 2 * n,
+        queue_timeout: std::time::Duration::from_millis(100),
+        shed_pct: 85,
+    }))
+}
+
+#[tokio::test]
+async fn saturated_admission_returns_503_with_retry_after() {
+    let mut state = test_state("admission-503").await;
+    state.admission = test_admission(1);
+    // Hold the single CPU slot so the route-level request must be rejected -
+    // deterministic, no timing race.
+    let _held = state
+        .admission
+        .acquire(1)
+        .await
+        .expect("first admit takes the only slot");
+
+    let response = post_fixture(&state, "/api/v1/parse/metadata").await;
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let retry_after = response
+        .headers()
+        .get(header::RETRY_AFTER)
+        .expect("503 carries Retry-After");
+    assert!(retry_after.to_str().unwrap().parse::<u64>().unwrap() >= 1);
+}
+
+#[tokio::test]
+async fn admission_slot_release_readmits() {
+    let mut state = test_state("admission-readmit").await;
+    state.admission = test_admission(1);
+    let held = state.admission.acquire(1).await.expect("take the slot");
+    drop(held);
+    let response = post_fixture(&state, "/api/v1/parse/metadata").await;
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn ready_endpoint_reflects_shedding() {
+    let mut state = test_state("readiness").await;
+    state.admission = Arc::new(crate::admission::Admission::new(crate::admission::AdmissionCfg {
+        max_concurrent_parses: 2,
+        mem_budget_bytes: 100 * 1024 * 1024,
+        queue_depth: 4,
+        queue_timeout: std::time::Duration::from_millis(100),
+        shed_pct: 85,
+    }));
+    let ok = get(&state, "/api/v1/ready").await;
+    assert_eq!(ok.status(), StatusCode::OK);
+    state.admission.set_resident_bytes(95 * 1024 * 1024);
+    let shed = get(&state, "/api/v1/ready").await;
+    assert_eq!(shed.status(), StatusCode::SERVICE_UNAVAILABLE);
+    // Liveness stays static and open regardless of load.
+    let health = get(&state, "/api/v1/health").await;
+    assert_eq!(health.status(), StatusCode::OK);
 }
 
 /// POST the fixture as multipart to `uri`, returning the response.
@@ -258,6 +321,7 @@ async fn streaming_complete_event_carries_symbolic_data() {
         1000,
         ifc_lite_processing::OpeningFilterMode::Default,
         ifc_lite_processing::TessellationQuality::default(),
+        None,
     )
         .collect()
         .await;
@@ -290,6 +354,7 @@ async fn streaming_zero_batch_sizes_still_complete() {
             0,
             ifc_lite_processing::OpeningFilterMode::Default,
             ifc_lite_processing::TessellationQuality::default(),
+            None,
         )
         .collect::<Vec<_>>(),
     )

--- a/apps/server/src/parity_tests.rs
+++ b/apps/server/src/parity_tests.rs
@@ -155,6 +155,27 @@ async fn admission_slot_release_readmits() {
 }
 
 #[tokio::test]
+async fn metrics_endpoint_gated_by_config() {
+    // Disabled (default): 404.
+    let state = test_state("metrics-disabled").await;
+    let off = get(&state, "/api/v1/metrics").await;
+    assert_eq!(off.status(), StatusCode::NOT_FOUND);
+
+    // Enabled: 200 with the Prometheus text body.
+    let mut state = test_state("metrics-enabled").await;
+    let mut config = (*state.config).clone();
+    config.metrics_enabled = true;
+    state.config = Arc::new(config);
+    state.admission.set_resident_bytes(4321);
+    let on = get(&state, "/api/v1/metrics").await;
+    assert_eq!(on.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(on.into_body(), usize::MAX).await.unwrap();
+    let text = String::from_utf8(body.to_vec()).unwrap();
+    assert!(text.contains("ifc_server_resident_bytes 4321"));
+    assert!(text.contains("ifc_server_admission_in_flight"));
+}
+
+#[tokio::test]
 async fn ready_endpoint_reflects_shedding() {
     let mut state = test_state("readiness").await;
     state.admission = Arc::new(crate::admission::Admission::new(crate::admission::AdmissionCfg {

--- a/apps/server/src/routes/health.rs
+++ b/apps/server/src/routes/health.rs
@@ -41,6 +41,35 @@ pub async fn check() -> Json<HealthResponse> {
     })
 }
 
+/// GET /api/v1/ready - readiness probe: 503 while the admission RSS
+/// breaker is shedding new work, so an external load balancer can drain the
+/// instance. Deliberately separate from `/api/v1/health` (liveness), which
+/// Railway's healthcheck consumes - gating THAT on load would restart-loop
+/// the box exactly when it is busiest.
+pub async fn ready(
+    axum::extract::State(state): axum::extract::State<crate::AppState>,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+    if state.admission.is_shedding() {
+        (
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            axum::Json(HealthResponse {
+                status: "shedding",
+                version: env!("CARGO_PKG_VERSION"),
+                service: "ifc-lite-server",
+            }),
+        )
+            .into_response()
+    } else {
+        axum::Json(HealthResponse {
+            status: "ready",
+            version: env!("CARGO_PKG_VERSION"),
+            service: "ifc-lite-server",
+        })
+        .into_response()
+    }
+}
+
 /// GET / - API information endpoint.
 pub async fn info() -> Json<ApiInfoResponse> {
     Json(ApiInfoResponse {

--- a/apps/server/src/routes/metrics.rs
+++ b/apps/server/src/routes/metrics.rs
@@ -1,0 +1,26 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! `GET /api/v1/metrics` - Prometheus text exposition of the admission
+//! gauges/counters and resident memory. Hand-rolled text (no exporter
+//! dependency); the route only responds when `IFC_METRICS_ENABLED` is set,
+//! and it sits behind the bearer-token layer like every compute route.
+
+use axum::extract::State;
+use axum::http::{header, StatusCode};
+use axum::response::{IntoResponse, Response};
+
+use crate::AppState;
+
+pub async fn metrics(State(state): State<AppState>) -> Response {
+    if !state.config.metrics_enabled {
+        return (StatusCode::NOT_FOUND, "metrics disabled").into_response();
+    }
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "text/plain; version=0.0.4")],
+        state.admission.metrics_text(),
+    )
+        .into_response()
+}

--- a/apps/server/src/routes/mod.rs
+++ b/apps/server/src/routes/mod.rs
@@ -6,4 +6,5 @@
 
 pub mod cache;
 pub mod health;
+pub mod metrics;
 pub mod parse;

--- a/apps/server/src/routes/parse/json.rs
+++ b/apps/server/src/routes/parse/json.rs
@@ -28,6 +28,14 @@ pub async fn parse_full(
     mut multipart: Multipart,
 ) -> Result<Json<ParseResponse>, ApiError> {
     // Extract file from multipart
+    // Admission gate (bounded concurrency + byte budget): acquired BEFORE the
+    // upload is buffered, reserving the max upload size since multipart rarely
+    // declares a length up front. Held for the request's whole lifetime so a
+    // disconnected-but-still-running job keeps its memory slot.
+    let _admission = state
+        .admission
+        .acquire(state.config.max_file_size_mb as u64 * 1024 * 1024)
+        .await?;
     let data = extract_file(&mut multipart, state.config.max_file_size_mb).await?;
 
     // Generate cache key (include opening filter so different modes get different cache entries)
@@ -96,6 +104,14 @@ pub async fn parse_stream(
     let tessellation_quality = query.resolved_tessellation_quality()?;
 
     // Extract file
+    // Admission gate (bounded concurrency + byte budget): acquired BEFORE the
+    // upload is buffered, reserving the max upload size since multipart rarely
+    // declares a length up front. Held for the request's whole lifetime so a
+    // disconnected-but-still-running job keeps its memory slot.
+    let admission_guard = state
+        .admission
+        .acquire(state.config.max_file_size_mb as u64 * 1024 * 1024)
+        .await?;
     let data = extract_file(&mut multipart, state.config.max_file_size_mb).await?;
 
     let content = data;
@@ -109,6 +125,7 @@ pub async fn parse_stream(
         max_batch_size,
         query.opening_filter,
         tessellation_quality,
+        Some(admission_guard),
     )
     .map(|event: StreamEvent| {
             let json = serde_json::to_string(&event).unwrap_or_else(|e| {
@@ -131,6 +148,14 @@ pub async fn parse_metadata(
     mut multipart: Multipart,
 ) -> Result<Json<MetadataResponse>, ApiError> {
     // Extract file
+    // Admission gate (bounded concurrency + byte budget): acquired BEFORE the
+    // upload is buffered, reserving the max upload size since multipart rarely
+    // declares a length up front. Held for the request's whole lifetime so a
+    // disconnected-but-still-running job keeps its memory slot.
+    let _admission = state
+        .admission
+        .acquire(state.config.max_file_size_mb as u64 * 1024 * 1024)
+        .await?;
     let data = extract_file(&mut multipart, state.config.max_file_size_mb).await?;
 
     let file_size = data.len();

--- a/apps/server/src/routes/parse/json.rs
+++ b/apps/server/src/routes/parse/json.rs
@@ -32,7 +32,7 @@ pub async fn parse_full(
     // upload is buffered, reserving the max upload size since multipart rarely
     // declares a length up front. Held for the request's whole lifetime so a
     // disconnected-but-still-running job keeps its memory slot.
-    let _admission = state
+    let admission_guard = state
         .admission
         .acquire(state.config.max_file_size_mb as u64 * 1024 * 1024)
         .await?;
@@ -59,11 +59,15 @@ pub async fn parse_full(
     // geometry with the 2D symbolic-data extraction (issue #843) so
     // callers can render IfcGrid axes and IfcAnnotation polylines from
     // the same response without re-uploading the file.
-    let (result, symbolic_data) = tokio::task::spawn_blocking(move || {
+    // The guard moves INTO the blocking task and comes back with the result:
+    // if the TimeoutLayer (or a disconnect) cancels this handler future, the
+    // detached blocking work keeps running - and keeps its admission slot -
+    // until it actually exits, so a replacement cannot be admitted on top.
+    let ((result, symbolic_data), _admission) = tokio::task::spawn_blocking(move || {
         let result =
             process_geometry_filtered_with_quality(&content, opening_filter, tessellation_quality);
         let symbolic = ifc_lite_processing::extract_symbolic_data(&content);
-        (result, symbolic)
+        ((result, symbolic), admission_guard)
     })
     .await?;
 
@@ -152,7 +156,7 @@ pub async fn parse_metadata(
     // upload is buffered, reserving the max upload size since multipart rarely
     // declares a length up front. Held for the request's whole lifetime so a
     // disconnected-but-still-running job keeps its memory slot.
-    let _admission = state
+    let admission_guard = state
         .admission
         .acquire(state.config.max_file_size_mb as u64 * 1024 * 1024)
         .await?;
@@ -176,14 +180,18 @@ pub async fn parse_metadata(
 
         let schema_version = detect_schema_version(&content);
 
-        MetadataResponse {
-            entity_count,
-            geometry_count,
-            schema_version: schema_version.to_string(),
-            file_size,
-        }
+        (
+            MetadataResponse {
+                entity_count,
+                geometry_count,
+                schema_version: schema_version.to_string(),
+                file_size,
+            },
+            admission_guard,
+        )
     })
     .await?;
+    let (result, _admission) = result;
 
     Ok(Json(result))
 }

--- a/apps/server/src/routes/parse/parquet.rs
+++ b/apps/server/src/routes/parse/parquet.rs
@@ -65,7 +65,7 @@ pub async fn parse_parquet(
     // upload is buffered, reserving the max upload size since multipart rarely
     // declares a length up front. Held for the request's whole lifetime so a
     // disconnected-but-still-running job keeps its memory slot.
-    let _admission = state
+    let admission_guard = state
         .admission
         .acquire(state.config.max_file_size_mb as u64 * 1024 * 1024)
         .await?;
@@ -119,10 +119,15 @@ pub async fn parse_parquet(
     // that's independent of tokio's blocking thread pool
     let serialize_start = tokio::time::Instant::now();
     let opening_filter = query.opening_filter;
+    // Guard rides the blocking task (see parse_full): a cancelled handler
+    // future must not release the admission slot while the work runs on.
     let (
-        (geometry_result, geometry_parquet),
-        (data_model_stats, data_model_parquet),
-        symbolic_data,
+        (
+            (geometry_result, geometry_parquet),
+            (data_model_stats, data_model_parquet),
+            symbolic_data,
+        ),
+        _admission,
     ) = tokio::task::spawn_blocking(move || {
             // First: extract geometry, data model, and the 2D symbol stream
             // (IfcAnnotation + IfcGrid) all in parallel. Symbolic extraction is
@@ -153,9 +158,12 @@ pub async fn parse_parquet(
             );
 
             (
-                (geometry_result, geo_parquet),
-                (dm_stats, dm_parquet),
-                symbolic_data,
+                (
+                    (geometry_result, geo_parquet),
+                    (dm_stats, dm_parquet),
+                    symbolic_data,
+                ),
+                admission_guard,
             )
         })
         .await?;
@@ -293,7 +301,7 @@ pub async fn parse_parquet_optimized(
     // upload is buffered, reserving the max upload size since multipart rarely
     // declares a length up front. Held for the request's whole lifetime so a
     // disconnected-but-still-running job keeps its memory slot.
-    let _admission = state
+    let admission_guard = state
         .admission
         .acquire(state.config.max_file_size_mb as u64 * 1024 * 1024)
         .await?;
@@ -316,10 +324,14 @@ pub async fn parse_parquet_optimized(
     // Process on blocking thread pool (CPU-intensive). Extract the 2D symbol
     // stream (IfcAnnotation + IfcGrid) alongside geometry for endpoint parity
     // (issue #900) — it's cached and served via the symbolic fetch endpoint.
-    let (result, symbolic_data) = tokio::task::spawn_blocking(move || {
-        rayon::join(
-            || process_geometry_filtered_with_quality(&content, opening_filter, tessellation_quality),
-            || extract_symbolic_data(&content),
+    // Guard rides the blocking task (see parse_full).
+    let ((result, symbolic_data), _admission) = tokio::task::spawn_blocking(move || {
+        (
+            rayon::join(
+                || process_geometry_filtered_with_quality(&content, opening_filter, tessellation_quality),
+                || extract_symbolic_data(&content),
+            ),
+            admission_guard,
         )
     })
     .await?;

--- a/apps/server/src/routes/parse/parquet.rs
+++ b/apps/server/src/routes/parse/parquet.rs
@@ -61,6 +61,14 @@ pub async fn parse_parquet(
     mut multipart: Multipart,
 ) -> Result<Response, ApiError> {
     // Extract file from multipart
+    // Admission gate (bounded concurrency + byte budget): acquired BEFORE the
+    // upload is buffered, reserving the max upload size since multipart rarely
+    // declares a length up front. Held for the request's whole lifetime so a
+    // disconnected-but-still-running job keeps its memory slot.
+    let _admission = state
+        .admission
+        .acquire(state.config.max_file_size_mb as u64 * 1024 * 1024)
+        .await?;
     let data = extract_file(&mut multipart, state.config.max_file_size_mb).await?;
 
     // Generate cache key (include opening filter so different modes get different cache entries)
@@ -281,6 +289,14 @@ pub async fn parse_parquet_optimized(
     mut multipart: Multipart,
 ) -> Result<Response, ApiError> {
     // Extract file from multipart
+    // Admission gate (bounded concurrency + byte budget): acquired BEFORE the
+    // upload is buffered, reserving the max upload size since multipart rarely
+    // declares a length up front. Held for the request's whole lifetime so a
+    // disconnected-but-still-running job keeps its memory slot.
+    let _admission = state
+        .admission
+        .acquire(state.config.max_file_size_mb as u64 * 1024 * 1024)
+        .await?;
     let data = extract_file(&mut multipart, state.config.max_file_size_mb).await?;
 
     // Generate cache key (include opening filter so different modes get different cache entries)

--- a/apps/server/src/routes/parse/parquet_stream.rs
+++ b/apps/server/src/routes/parse/parquet_stream.rs
@@ -81,6 +81,14 @@ pub async fn parse_parquet_stream(
     use std::sync::{Arc, Mutex};
 
     // Extract file
+    // Admission gate (bounded concurrency + byte budget): acquired BEFORE the
+    // upload is buffered, reserving the max upload size since multipart rarely
+    // declares a length up front. Held for the request's whole lifetime so a
+    // disconnected-but-still-running job keeps its memory slot.
+    let admission_guard = state
+        .admission
+        .acquire(state.config.max_file_size_mb as u64 * 1024 * 1024)
+        .await?;
     let data = extract_file(&mut multipart, state.config.max_file_size_mb).await?;
 
     // Generate cache key before processing (include opening filter + quality)
@@ -150,6 +158,13 @@ pub async fn parse_parquet_stream(
             )),
         ]));
 
+        // The cached replay still holds the (potentially large) blob in the
+        // stream; keep the admission permit until the client drains it.
+        let fast_stream =
+            fast_stream.map(move |e| {
+                let _hold = &admission_guard;
+                e
+            });
         return Ok(Sse::new(fast_stream)
             .keep_alive(KeepAlive::default())
             .into_response());
@@ -180,6 +195,7 @@ pub async fn parse_parquet_stream(
         max_batch_size,
         query.opening_filter,
         tessellation_quality,
+        Some(admission_guard),
     )
     .map(move |event: StreamEvent| {
         let sse_event = match event {

--- a/apps/server/src/routes/parse/parquet_stream.rs
+++ b/apps/server/src/routes/parse/parquet_stream.rs
@@ -158,13 +158,11 @@ pub async fn parse_parquet_stream(
             )),
         ]));
 
-        // The cached replay still holds the (potentially large) blob in the
-        // stream; keep the admission permit until the client drains it.
-        let fast_stream =
-            fast_stream.map(move |e| {
-                let _hold = &admission_guard;
-                e
-            });
+        // Cached replay: no parse work runs, so holding the admission guard
+        // (and its CPU slot) while a slow client drains the SSE would starve
+        // real parses for nothing. The replay blob is already materialized
+        // and is bounded by cache content, far below a parse working set.
+        drop(admission_guard);
         return Ok(Sse::new(fast_stream)
             .keep_alive(KeepAlive::default())
             .into_response());

--- a/apps/server/src/routes/parse/parquet_stream.rs
+++ b/apps/server/src/routes/parse/parquet_stream.rs
@@ -346,7 +346,22 @@ pub async fn parse_parquet_stream(
     let content_for_cache = content.clone();
     let cache_key_for_dm = cache_key.clone();
     let cache_for_dm = cache.clone();
+    let admission_for_dm = state.admission.clone();
     tokio::spawn(async move {
+        // The data-model extraction re-parses the whole upload, so it must
+        // pass admission like any parse job. It is a cache-fill optimization:
+        // when the server is saturated, skipping it (the next request rebuilds
+        // it inline) beats bypassing the gate.
+        let _dm_admission = match admission_for_dm
+            .acquire(content_for_cache.len() as u64)
+            .await
+        {
+            Ok(guard) => guard,
+            Err(_) => {
+                tracing::debug!("Skipping data-model cache fill: admission saturated");
+                return;
+            }
+        };
         // Run data model extraction in blocking task
         let dm_result =
             tokio::task::spawn_blocking(move || extract_data_model(&content_for_cache)).await;

--- a/apps/server/src/services/streaming.rs
+++ b/apps/server/src/services/streaming.rs
@@ -88,13 +88,18 @@ pub fn process_streaming(
     let cancel = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let cancel_for_task = std::sync::Arc::clone(&cancel);
 
+    // The admission permit must be held until BOTH sides are done: the
+    // blocking producer (on disconnect the stream drops first, but the task
+    // keeps its memory/CPU until the cooperative cancel takes effect) AND the
+    // response stream (the unbounded channel can hold every emitted batch
+    // after a fast producer exits, so dropping the permit at task exit would
+    // let a replacement parse be admitted on top of the undrained buffers).
+    // An Arc'd guard held by both releases on whichever finishes last.
+    let admission = admission.map(std::sync::Arc::new);
+    let admission_for_task = admission.clone();
+
     let handle = tokio::task::spawn_blocking(move || {
-        // The admission permit must outlive the BLOCKING TASK, not just the
-        // response stream: on disconnect the stream drops first, but the task
-        // keeps its memory/CPU until the cooperative cancel takes effect at
-        // the next chunk boundary. Holding the guard here means a replacement
-        // is never admitted on top of a still-running job.
-        let _admission = admission;
+        let _admission = admission_for_task;
         let cache_key = DiskCache::generate_key(&content);
 
         let mut started = false;
@@ -186,6 +191,7 @@ pub fn process_streaming(
     });
 
     Box::pin(stream! {
+        let _admission = admission;
         while let Some(event) = rx.recv().await {
             yield event;
         }

--- a/apps/server/src/services/streaming.rs
+++ b/apps/server/src/services/streaming.rs
@@ -152,9 +152,12 @@ pub fn process_streaming(
             |_| {},
         );
 
-        if cancel_for_task.load(std::sync::atomic::Ordering::Relaxed) {
+        if cancel_for_task.load(std::sync::atomic::Ordering::Relaxed) || tx.is_closed() {
             // Client gone: the partial result must not be presented as a
-            // completed parse - skip Complete AND the symbolic extraction.
+            // completed parse - skip Complete AND the symbolic extraction
+            // (which re-scans the file). The is_closed check also covers a
+            // disconnect after the LAST batch, where the callback can no
+            // longer observe it.
             tracing::info!("SSE client disconnected; streaming parse stopped early");
             return;
         }

--- a/apps/server/src/services/streaming.rs
+++ b/apps/server/src/services/streaming.rs
@@ -72,6 +72,7 @@ pub fn process_streaming(
     max_batch_size: usize,
     opening_filter: OpeningFilterMode,
     tessellation_quality: TessellationQuality,
+    admission: Option<crate::admission::AdmissionGuard>,
 ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send>> {
     // Zero is a caller bug, not a reason to stall the stream.
     let initial_batch_size = initial_batch_size.max(1);
@@ -79,7 +80,21 @@ pub fn process_streaming(
 
     let (tx, mut rx) = mpsc::unbounded_channel::<StreamEvent>();
 
+    // Disconnect-aware cancellation: when the SSE client hangs up, the
+    // receiver drops, the batch callback notices via `tx.is_closed()`, and the
+    // streaming core stops between chunks instead of meshing the rest of the
+    // model for nobody (a full-size parse used to keep burning a core and its
+    // memory slot to completion).
+    let cancel = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let cancel_for_task = std::sync::Arc::clone(&cancel);
+
     let handle = tokio::task::spawn_blocking(move || {
+        // The admission permit must outlive the BLOCKING TASK, not just the
+        // response stream: on disconnect the stream drops first, but the task
+        // keeps its memory/CPU until the cooperative cancel takes effect at
+        // the next chunk boundary. Holding the guard here means a replacement
+        // is never admitted on top of a still-running job.
+        let _admission = admission;
         let cache_key = DiskCache::generate_key(&content);
 
         let mut started = false;
@@ -96,9 +111,14 @@ pub fn process_streaming(
                 // Batches are forwarded as they are emitted — retaining them
                 // in the ProcessingResult would double peak memory.
                 retain_emitted_meshes: false,
+                cancel: Some(std::sync::Arc::clone(&cancel_for_task)),
                 ..StreamingOptions::default()
             },
             |meshes, processed, total| {
+                if tx.is_closed() {
+                    cancel_for_task.store(true, std::sync::atomic::Ordering::Relaxed);
+                    return;
+                }
                 if !started {
                     started = true;
                     let _ = tx.send(StreamEvent::Start {
@@ -131,6 +151,13 @@ pub fn process_streaming(
             |_| {},
             |_| {},
         );
+
+        if cancel_for_task.load(std::sync::atomic::Ordering::Relaxed) {
+            // Client gone: the partial result must not be presented as a
+            // completed parse - skip Complete AND the symbolic extraction.
+            tracing::info!("SSE client disconnected; streaming parse stopped early");
+            return;
+        }
 
         if !started {
             // Zero-geometry model: the batch callback never ran. Emit Start

--- a/rust/processing/src/processor/mod.rs
+++ b/rust/processing/src/processor/mod.rs
@@ -147,6 +147,12 @@ pub struct StreamingOptions {
     /// `build_entity_index(content)` for the *same* `content`, or decoding will read
     /// the wrong byte ranges.
     pub entity_index: Option<Arc<EntityIndex>>,
+    /// Cooperative cancellation: when the flag flips true, the streaming core
+    /// stops between job chunks (no further meshing or batch emission). The
+    /// returned `ProcessingResult` is then PARTIAL - the caller set the flag,
+    /// so it must not present the result as a completed parse. Used by the
+    /// server to stop burning a core when an SSE client disconnects.
+    pub cancel: Option<Arc<std::sync::atomic::AtomicBool>>,
 }
 
 impl Default for StreamingOptions {
@@ -161,6 +167,7 @@ impl Default for StreamingOptions {
             retain_emitted_meshes: true,
             tessellation_quality: TessellationQuality::default(),
             entity_index: None,
+            cancel: None,
         }
     }
 }
@@ -1079,6 +1086,16 @@ pub fn process_geometry_streaming_filtered_with_options(
     let item_dedup_cache = GeometryRouter::new_dedup_cache();
 
     while chunk_start < total_jobs {
+        // Cooperative cancellation between chunks: the caller flipped the flag
+        // (e.g. its client disconnected), so stop meshing and emitting. The
+        // result below is partial by contract; see StreamingOptions::cancel.
+        if options
+            .cancel
+            .as_ref()
+            .is_some_and(|c| c.load(std::sync::atomic::Ordering::Relaxed))
+        {
+            break;
+        }
         let chunk_end = (chunk_start + current_chunk_size).min(total_jobs);
         let jobs_chunk = &mut entity_jobs[chunk_start..chunk_end];
 


### PR DESCRIPTION
Executes the P0 server-reliability plan: the parse endpoints buffered 500 MB uploads and spawned unbounded blocking work with no concurrency cap and no memory signal, so a handful of concurrent large parses could OOM-kill the single replica - reported "healthy" right up to the kill.

## Admission gate (`apps/server/src/admission.rs`)

Acquired by every parse handler **before** the upload is buffered:

- **CPU semaphore** (`IFC_MAX_CONCURRENT_PARSES`, default = cores). Free slots admit immediately; waiters are bounded by `IFC_ADMISSION_QUEUE_DEPTH` (default 2x cores) and `IFC_ADMISSION_QUEUE_TIMEOUT_SECS` (default 5), then **503 + Retry-After**.
- **Byte-weighted memory semaphore** (`IFC_MEM_BUDGET_MB`, default 70% of the cgroup limit when readable, else disabled). Each admitted parse reserves the max upload size, so total admitted bytes can never exceed the budget; an oversized request clamps to the whole budget so the largest allowed file can always run alone.
- **RSS circuit breaker** (`IFC_MEM_SHED_PCT`, default 85): sheds new work before the kernel OOM-killer does, fed by a 500 ms `/proc/self/statm` sampler behind a swappable `resident_bytes_now()` helper.

Design notes carried from the plan: explicit semaphores instead of `tower::limit` (the tower layer waits unboundedly with no 503/Retry-After, wraps cheap GET routes, and cannot express a byte budget). **Deviation, documented in code + OPERATIONS.md:** the jemalloc allocator swap was skipped because the release matrix includes a musl target where it is a known build risk; the RSS source is a one-line swap if revisited.

## Observability

- `GET /api/v1/metrics` (Prometheus text, `IFC_METRICS_ENABLED` + bearer layer): resident bytes, budget, in-flight, queued, rejected-by-reason counters. Hand-rolled text, no new exporter dependency.
- `GET /api/v1/ready`: 503 while the breaker is shedding, so a balancer can drain the instance. `GET /api/v1/health` stays static - Railway's healthcheck points at it and must not restart the box under load.

## Disconnect cancellation

`StreamingOptions::cancel` (additive field, `rust/processing`) stops the streaming core **between job chunks**; the SSE producer flips it when `tx.is_closed()`, so an abandoned stream stops burning a core instead of meshing the rest of the model for nobody, and skips the Complete/symbolic tail. The admission permit is owned by the blocking task itself (not the response stream), so a replacement is never admitted on top of a still-running job. Successful-parse output is untouched (early break only fires when the caller cancelled).

## Ops guide

`apps/server/OPERATIONS.md`: knob table, sizing rule (`file_size x (1x buffer + 3-6x working set)`), probe semantics, and the explicit warning not to repoint Railway's healthcheck at readiness.

## Deferred (per the plan's own scoping)

- Per-client rate limiting (`tower_governor`, plan Phase 3 "optional defense-in-depth"): needs proxy IP-extraction decisions; the in-process gate is the load-bearing part. The 429 variant lands with it so no dead enum variants ship now.
- Mid-parse cancellation for the synchronous endpoints (plan Phase 5b): the SSE paths cancel at chunk boundaries already; synchronous parses hold their admission slot to completion by design.

## Verification

- 8 admission unit tests (budget bound, oversized clamp, queue-depth immediate reject, RSS shed + recovery, release-on-drop, metrics text) - one of which caught and fixed a real design bug (the queue-depth fast-reject fired before trying a free slot)
- 3 route-level integration tests: saturated admission returns 503 + Retry-After (deterministic, no timing race), slot release readmits, `/ready` flips on simulated RSS while `/health` stays 200
- `cargo test -p ifc-lite-server` 31/31; workspace clippy + tests green; wasm target compiles (the `StreamingOptions` field is additive)
- Geometry output untouched: no kernel/export code in the diff; determinism snapshots and the manifest are unaffected
