### PR TITLE
fix(ifcx,viewer): guard IFCX path cycles; neutralize list CSV formula injection

### DIFF
--- a/.changeset/fix-ifcx-path-cycle.md
+++ b/.changeset/fix-ifcx-path-cycle.md
@@ -1,0 +1,12 @@
+---
+"@ifc-lite/ifcx": patch
+---
+
+fix(ifcx): guard PathIndex hierarchical indexing against child cycles
+
+`PathIndex.indexHierarchicalPaths` recursed through a node's children with no
+ancestor tracking, so a malformed IFCX layer with a child cycle (`A -> B -> A`)
+recursed until the stack overflowed and crashed the load. The recursion now
+tracks the uuids on the current DFS branch and skips a child that is already an
+ancestor; a node reached by two distinct non-ancestral paths (a diamond) is
+still indexed under both.

--- a/apps/viewer/src/lib/lists/export/csv.ts
+++ b/apps/viewer/src/lib/lists/export/csv.ts
@@ -9,8 +9,9 @@ function esc(s: string, delim: string): string {
   // Neutralize spreadsheet formula injection (CWE-1236): a leading =, +, -, @,
   // TAB or CR makes a cell execute as a formula in Excel/LibreOffice/Sheets.
   // List cells derive from attacker-controllable IFC values, so prefix such
-  // cells with an apostrophe (matching the SDK export adapter).
-  if (/^[=+\-@\t\r]/.test(s)) s = `'${s}`;
+  // cells with an apostrophe. A leading UTF-8 BOM is treated as file metadata
+  // by spreadsheet importers, so a marker hidden behind one still executes.
+  if (/^\uFEFF?[=+\-@\t\r]/.test(s)) s = `'${s}`;
   return /["\r\n]/.test(s) || s.includes(delim) ? `"${s.replace(/"/g, '""')}"` : s;
 }
 

--- a/apps/viewer/src/lib/lists/export/csv.ts
+++ b/apps/viewer/src/lib/lists/export/csv.ts
@@ -6,6 +6,11 @@ import type { CellValue } from '@ifc-lite/lists';
 import { displayCell, type ExportModel } from './model';
 
 function esc(s: string, delim: string): string {
+  // Neutralize spreadsheet formula injection (CWE-1236): a leading =, +, -, @,
+  // TAB or CR makes a cell execute as a formula in Excel/LibreOffice/Sheets.
+  // List cells derive from attacker-controllable IFC values, so prefix such
+  // cells with an apostrophe (matching the SDK export adapter).
+  if (/^[=+\-@\t\r]/.test(s)) s = `'${s}`;
   return /["\r\n]/.test(s) || s.includes(delim) ? `"${s.replace(/"/g, '""')}"` : s;
 }
 

--- a/packages/ifcx/src/path-resolver.test.ts
+++ b/packages/ifcx/src/path-resolver.test.ts
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { PathIndex } from './path-resolver.js';
+import type { IfcxLayer } from './layer-stack.js';
+import type { IfcxNode } from './types.js';
+
+/** Build a minimal single-layer stack from `path -> children` definitions. */
+function layerWith(nodes: IfcxNode[]): IfcxLayer {
+  const nodesByPath = new Map<string, IfcxNode[]>();
+  for (const node of nodes) nodesByPath.set(node.path, [node]);
+  return {
+    id: 'layer-1',
+    name: 'test',
+    file: {
+      header: { id: 'h', ifcxVersion: '1', dataVersion: '1', author: 't', timestamp: '' },
+      imports: [],
+      schemas: {},
+      data: nodes,
+    },
+    buffer: new ArrayBuffer(0),
+    strength: 0,
+    enabled: true,
+    source: { type: 'buffer', name: 'test' },
+    nodesByPath,
+    loadedAt: 0,
+  };
+}
+
+describe('PathIndex.buildIndex cycle safety', () => {
+  it('terminates on a child cycle instead of overflowing the stack', () => {
+    // A -> B -> A: a malformed IFCX layer. Without an ancestor guard the
+    // hierarchical index recursion never returns.
+    const index = new PathIndex();
+    index.buildIndex([
+      layerWith([
+        { path: 'A', children: { toB: 'B' } },
+        { path: 'B', children: { toA: 'A' } },
+      ]),
+    ]);
+    // Both directions still resolve one hop; the cycle is simply not followed
+    // back onto an ancestor.
+    assert.equal(index.resolvePath('A/toB'), 'B');
+    assert.equal(index.resolvePath('B/toA'), 'A');
+  });
+
+  it('indexes a diamond (shared, non-ancestral child) under both parents', () => {
+    // A -> D and A -> C -> D: D is reached by two distinct paths and must be
+    // indexed under both (only true ancestry cycles are cut).
+    const index = new PathIndex();
+    index.buildIndex([
+      layerWith([
+        { path: 'A', children: { toD: 'D', toC: 'C' } },
+        { path: 'C', children: { toD: 'D' } },
+        { path: 'D', children: {} },
+      ]),
+    ]);
+    assert.equal(index.resolvePath('A/toD'), 'D');
+    assert.equal(index.resolvePath('A/toC/toD'), 'D');
+  });
+});

--- a/packages/ifcx/src/path-resolver.ts
+++ b/packages/ifcx/src/path-resolver.ts
@@ -114,12 +114,20 @@ export class PathIndex {
   private indexHierarchicalPaths(
     rootUuid: string,
     currentUuid: string,
-    pathSegments: string[]
+    pathSegments: string[],
+    // Uuids on the current DFS branch. A malformed IFCX layer can contain a
+    // child cycle (A -> B -> A); without this guard the recursion never
+    // terminates and overflows the stack. A node reached by two distinct
+    // (non-ancestral) paths is still indexed under both — only true ancestry
+    // cycles are cut.
+    ancestors: Set<string> = new Set([rootUuid])
   ): void {
     const children = this.childNameIndex.get(currentUuid);
     if (!children) return;
 
     for (const [childName, childUuid] of children) {
+      if (ancestors.has(childUuid)) continue;
+
       const newSegments = [...pathSegments, childName];
       const hierarchicalPath = `${rootUuid}/${newSegments.join('/')}`;
 
@@ -133,7 +141,9 @@ export class PathIndex {
       }
 
       // Recurse
-      this.indexHierarchicalPaths(rootUuid, childUuid, newSegments);
+      ancestors.add(childUuid);
+      this.indexHierarchicalPaths(rootUuid, childUuid, newSegments, ancestors);
+      ancestors.delete(childUuid);
     }
   }
 


### PR DESCRIPTION
Found via a full multi-agent code review of `main`; verified by reading the code and covered with tests.

## 1. IFCX path cycle → stack overflow (crash)
`PathIndex.indexHierarchicalPaths` recursed through each node's `children` with
no ancestor tracking. A malformed/adversarial IFCX layer with a child cycle
(`A -> B -> A`, reachable from external files or collaboration) recursed forever
and overflowed the stack on load. The recursion now carries the set of uuids on
the current DFS branch and skips a child that is already an ancestor. A node
reached by two distinct non-ancestral paths (a diamond) is still indexed under
both. `walkPath` was already bounded by the query segment list and is unchanged.

New `path-resolver.test.ts`: a cyclic layer terminates and still resolves one
hop each way; a diamond indexes the shared child under both parents.

## 2. List CSV export — spreadsheet formula injection (CWE-1236)
`apps/viewer/.../lists/export/csv.ts` quoted delimiters/quotes/newlines but did
not neutralize cells beginning with `=`, `+`, `-`, `@`, TAB or CR, which
Excel/LibreOffice/Sheets execute as formulas. List cells derive from
attacker-controllable IFC values. The `esc` helper now prefixes such cells with
an apostrophe, matching the neutralization the SDK export adapter
(`export-adapter.ts`) already performs.

All 16 `@ifc-lite/ifcx` tests pass; ifcx + viewer typecheck clean. Changeset:
`@ifc-lite/ifcx` patch (viewer is not a published package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)