### PR TITLE
perf(server): incremental Parquet cache writer + shared buffers (plan 04, phases 1/3/4)

### DIFF
--- a/apps/server/src/parity_tests.rs
+++ b/apps/server/src/parity_tests.rs
@@ -337,7 +337,7 @@ async fn symbolic_endpoint_pending_for_unknown_key() {
 #[tokio::test]
 async fn streaming_complete_event_carries_symbolic_data() {
     let events: Vec<StreamEvent> = process_streaming(
-        FIXTURE.as_bytes().to_vec(),
+        bytes::Bytes::from_static(FIXTURE.as_bytes()),
         100,
         1000,
         ifc_lite_processing::OpeningFilterMode::Default,
@@ -370,7 +370,7 @@ async fn streaming_zero_batch_sizes_still_complete() {
     let events = tokio::time::timeout(
         std::time::Duration::from_secs(10),
         process_streaming(
-            FIXTURE.as_bytes().to_vec(),
+            bytes::Bytes::from_static(FIXTURE.as_bytes()),
             0,
             0,
             ifc_lite_processing::OpeningFilterMode::Default,

--- a/apps/server/src/routes/parse/mod.rs
+++ b/apps/server/src/routes/parse/mod.rs
@@ -56,7 +56,7 @@ impl ParseQuery {
 pub(crate) async fn extract_file(
     multipart: &mut Multipart,
     max_file_size_mb: usize,
-) -> Result<Vec<u8>, ApiError> {
+) -> Result<bytes::Bytes, ApiError> {
     let max_bytes = max_file_size_mb.saturating_mul(1024 * 1024);
 
     while let Some(field) = multipart.next_field().await? {
@@ -93,14 +93,16 @@ pub(crate) async fn extract_file(
                         format!("{:.1}x", original_size as f64 / decompressed.len() as f64),
                     "File decompressed successfully"
                 );
-                return Ok(decompressed);
+                return Ok(bytes::Bytes::from(decompressed));
             } else {
                 if bytes.len() > max_bytes {
                     return Err(ApiError::FileTooLarge {
                         max_mb: max_file_size_mb,
                     });
                 }
-                return Ok(bytes.to_vec());
+                // Already-buffered multipart Bytes: hand back the same
+                // allocation instead of a full `.to_vec()` copy.
+                return Ok(bytes);
             }
         }
     }

--- a/apps/server/src/routes/parse/parquet.rs
+++ b/apps/server/src/routes/parse/parquet.rs
@@ -222,7 +222,9 @@ pub async fn parse_parquet(
 
     let metadata_json = serde_json::to_string(&metadata_header)?;
 
-    // Cache the results for future requests
+    // Cache the results for future requests. `Bytes` makes the cache task's
+    // copy an O(1) refcount bump instead of duplicating the whole payload.
+    let combined_parquet = bytes::Bytes::from(combined_parquet);
     let parquet_cache_key = format!("{}-parquet-v4", cache_key_clone);
     let metadata_cache_key = format!("{}-parquet-metadata-v4", cache_key_clone);
     let combined_parquet_clone = combined_parquet.clone();

--- a/apps/server/src/routes/parse/parquet_stream.rs
+++ b/apps/server/src/routes/parse/parquet_stream.rs
@@ -216,19 +216,32 @@ pub async fn parse_parquet_stream(
                 ParquetStreamEvent::Progress { processed, total }
             }
             StreamEvent::Batch { meshes, batch_number } => {
-                // Feed the incremental cache writer, then let the meshes drop
-                // with this event (no whole-model retention).
-                if let Ok(mut slot) = cache_writer_for_stream.lock() {
-                    if let Some(writer) = slot.as_mut() {
-                        if let Err(e) = writer.append(&meshes) {
-                            tracing::error!(error = %e, "Streaming cache writer failed; skipping cache fill");
-                            *slot = None;
+                // Per-batch CPU work (client-blob serialization + cache-writer
+                // append) runs inside this stream map, i.e. on an async worker.
+                // On the multi-thread runtime, step off the async pool for it
+                // so other connections' polls are not starved. (Guarded by
+                // runtime flavor: block_in_place panics on current_thread,
+                // which the #[tokio::test] harness uses.)
+                let cpu_work = || {
+                    if let Ok(mut slot) = cache_writer_for_stream.lock() {
+                        if let Some(writer) = slot.as_mut() {
+                            if let Err(e) = writer.append(&meshes) {
+                                tracing::error!(error = %e, "Streaming cache writer failed; skipping cache fill");
+                                *slot = None;
+                            }
                         }
                     }
-                }
+                    serialize_to_parquet(&meshes)
+                };
+                let serialized = if tokio::runtime::Handle::current().runtime_flavor()
+                    == tokio::runtime::RuntimeFlavor::MultiThread
+                {
+                    tokio::task::block_in_place(cpu_work)
+                } else {
+                    cpu_work()
+                };
 
-                // Serialize batch to Parquet and base64 encode
-                match serialize_to_parquet(&meshes) {
+                match serialized {
                     Ok(parquet_bytes) => {
                         let base64_data = STANDARD.encode(&parquet_bytes);
                         ParquetStreamEvent::Batch {

--- a/apps/server/src/routes/parse/parquet_stream.rs
+++ b/apps/server/src/routes/parse/parquet_stream.rs
@@ -73,8 +73,7 @@ pub async fn parse_parquet_stream(
     Query(query): Query<ParseQuery>,
     mut multipart: Multipart,
 ) -> Result<axum::response::Response, ApiError> {
-    use crate::services::serialize_to_parquet;
-    use crate::types::MeshData;
+    use crate::services::{serialize_to_parquet, StreamingParquetCacheWriter};
     use axum::response::IntoResponse;
     use base64::{engine::general_purpose::STANDARD, Engine};
     use futures::StreamExt;
@@ -179,10 +178,20 @@ pub async fn parse_parquet_stream(
     let max_batch_size = state.config.max_batch_size;
     let cache = state.cache.clone();
 
-    // OPTIMIZATION: Accumulate meshes during streaming to avoid re-processing for cache
-    // This shared container collects all streamed meshes for caching
-    let accumulated_meshes: Arc<Mutex<Vec<MeshData>>> = Arc::new(Mutex::new(Vec::new()));
-    let accumulated_meshes_for_stream = accumulated_meshes.clone();
+    // Incremental cache writer: each batch's columns are appended as Parquet
+    // row groups (GLOBAL offsets) and the meshes dropped, replacing the old
+    // Arc<Mutex<Vec<MeshData>>> accumulator that held a FULL second copy of
+    // the model's geometry until Complete. `None` after a writer error (the
+    // cache fill is skipped; the client stream is unaffected).
+    let cache_writer: Arc<Mutex<Option<StreamingParquetCacheWriter>>> =
+        Arc::new(Mutex::new(match StreamingParquetCacheWriter::new() {
+            Ok(w) => Some(w),
+            Err(e) => {
+                tracing::error!(error = %e, "Failed to create streaming cache writer");
+                None
+            }
+        }));
+    let cache_writer_for_stream = cache_writer.clone();
     let cache_for_geometry = cache.clone();
     let cache_key_for_geometry = cache_key.clone();
 
@@ -207,9 +216,15 @@ pub async fn parse_parquet_stream(
                 ParquetStreamEvent::Progress { processed, total }
             }
             StreamEvent::Batch { meshes, batch_number } => {
-                // OPTIMIZATION: Accumulate meshes for caching (avoids re-processing)
-                if let Ok(mut acc) = accumulated_meshes_for_stream.lock() {
-                    acc.extend(meshes.iter().cloned());
+                // Feed the incremental cache writer, then let the meshes drop
+                // with this event (no whole-model retention).
+                if let Ok(mut slot) = cache_writer_for_stream.lock() {
+                    if let Some(writer) = slot.as_mut() {
+                        if let Err(e) = writer.append(&meshes) {
+                            tracing::error!(error = %e, "Streaming cache writer failed; skipping cache fill");
+                            *slot = None;
+                        }
+                    }
                 }
 
                 // Serialize batch to Parquet and base64 encode
@@ -243,45 +258,47 @@ pub async fn parse_parquet_stream(
                     });
                 }
 
-                // OPTIMIZATION: Use accumulated meshes instead of re-processing
-                // This eliminates duplicate geometry extraction (~1100ms savings for large files)
+                // Finish the incremental writer: the cache blob was built row
+                // group by row group as batches streamed, so nothing is
+                // re-serialized and no second copy of the geometry exists.
                 let cache = cache_for_geometry.clone();
                 let key = cache_key_for_geometry.clone();
                 let stats_clone = stats.clone();
                 let metadata_clone = metadata.clone();
-                let meshes_for_cache = accumulated_meshes.clone();
+                let writer_for_cache = cache_writer.clone();
                 let coord_space = mesh_coordinate_space.clone();
                 let site_tf = site_transform.clone();
                 let building_tf = building_transform.clone();
 
                 tokio::spawn(async move {
-                    // Take accumulated meshes (moves out of Arc<Mutex>)
-                    let all_meshes = {
-                        match meshes_for_cache.lock() {
-                            Ok(mut guard) => std::mem::take(&mut *guard),
+                    // Take the writer (moves out of Arc<Mutex>).
+                    let writer = {
+                        match writer_for_cache.lock() {
+                            Ok(mut guard) => guard.take(),
                             Err(_) => {
-                                tracing::error!("Failed to lock accumulated meshes for caching");
+                                tracing::error!("Failed to lock streaming cache writer");
                                 return;
                             }
                         }
                     };
-
-                    if all_meshes.is_empty() {
-                        tracing::warn!("No meshes accumulated for caching");
+                    let Some(writer) = writer else {
+                        tracing::warn!("Streaming cache writer unavailable; skipping cache fill");
+                        return;
+                    };
+                    if writer.mesh_count() == 0 {
+                        tracing::warn!("No meshes streamed; skipping cache fill");
                         return;
                     }
 
                     tracing::info!(
-                        mesh_count = all_meshes.len(),
-                        "Caching accumulated meshes from stream (no re-processing)"
+                        mesh_count = writer.mesh_count(),
+                        "Caching streamed geometry (incremental writer, no re-serialization)"
                     );
 
-                    // Serialize accumulated meshes to Parquet (no re-processing needed!)
-                    let serialize_result = tokio::task::spawn_blocking(move || {
-                        serialize_to_parquet(&all_meshes)
-                    }).await;
+                    let finish_result =
+                        tokio::task::spawn_blocking(move || writer.finish()).await;
 
-                    if let Ok(Ok(geometry_parquet)) = serialize_result {
+                    if let Ok(Ok(geometry_parquet)) = finish_result {
                         // Build combined format (same as non-streaming endpoint)
                         // Format: [geometry_len: u32][geometry_data][data_model_len: u32]
                         let mut combined_parquet = Vec::new();

--- a/apps/server/src/services/mod.rs
+++ b/apps/server/src/services/mod.rs
@@ -13,7 +13,7 @@ pub mod processor;
 pub mod streaming;
 
 pub use data_model::extract_data_model;
-pub use parquet::{serialize_to_parquet, ParquetError};
+pub use parquet::{serialize_to_parquet, ParquetError, StreamingParquetCacheWriter};
 pub use parquet_data_model::serialize_data_model_to_parquet;
 pub use parquet_optimized::{
     serialize_to_parquet_optimized_with_stats, OptimizedStats, VERTEX_MULTIPLIER,

--- a/apps/server/src/services/parquet.rs
+++ b/apps/server/src/services/parquet.rs
@@ -26,6 +26,8 @@ use thiserror::Error;
 /// Errors during Parquet serialization.
 #[derive(Debug, Error)]
 pub enum ParquetError {
+    #[error("Format overflow: {0}")]
+    Overflow(String),
     #[error("Arrow error: {0}")]
     Arrow(#[from] arrow::error::ArrowError),
     #[error("Parquet error: {0}")]
@@ -54,12 +56,21 @@ pub fn serialize_to_parquet(meshes: &[MeshData]) -> Result<Bytes, ParquetError> 
     let mesh_parquet = write_parquet_buffer(&mesh_batch)?;
     let vertex_parquet = write_parquet_buffer(&vertex_batch)?;
     let index_parquet = write_parquet_buffer(&index_batch)?;
-    Ok(frame_sections(&mesh_parquet, &vertex_parquet, &index_parquet))
+    frame_sections(&mesh_parquet, &vertex_parquet, &index_parquet)
 }
 
 /// Assemble the three Parquet buffers into the length-prefixed section layout
 /// shared by the whole-model serializer and the incremental cache writer.
-fn frame_sections(mesh: &[u8], vertex: &[u8], index: &[u8]) -> Bytes {
+/// Section lengths are u32 on the wire; fail loud instead of truncating a
+/// section over 4 GiB into a silently corrupt blob.
+fn frame_sections(mesh: &[u8], vertex: &[u8], index: &[u8]) -> Result<Bytes, ParquetError> {
+    for (name, len) in [("mesh", mesh.len()), ("vertex", vertex.len()), ("index", index.len())] {
+        if u32::try_from(len).is_err() {
+            return Err(ParquetError::Overflow(format!(
+                "{name} section is {len} bytes, over the u32 wire-format limit"
+            )));
+        }
+    }
     let mut output = Vec::with_capacity(12 + mesh.len() + vertex.len() + index.len());
     output.extend_from_slice(&(mesh.len() as u32).to_le_bytes());
     output.extend_from_slice(mesh);
@@ -67,7 +78,7 @@ fn frame_sections(mesh: &[u8], vertex: &[u8], index: &[u8]) -> Bytes {
     output.extend_from_slice(vertex);
     output.extend_from_slice(&(index.len() as u32).to_le_bytes());
     output.extend_from_slice(index);
-    Bytes::from(output)
+    Ok(Bytes::from(output))
 }
 
 /// Build the three Arrow tables (mesh metadata / vertices / indices) for a
@@ -365,8 +376,26 @@ impl StreamingParquetCacheWriter {
         self.idx_w.write(&index_batch)?;
         self.idx_w.flush()?;
         for mesh in meshes {
-            self.vertex_offset += (mesh.positions.len() / 3) as u32;
-            self.index_offset += mesh.indices.len() as u32;
+            // The mesh-table start columns are u32; a model that overflows
+            // them must fail the cache fill loudly, not wrap into offsets
+            // that decode as garbage.
+            let verts = u32::try_from(mesh.positions.len() / 3)
+                .ok()
+                .and_then(|v| self.vertex_offset.checked_add(v));
+            let idxs = u32::try_from(mesh.indices.len())
+                .ok()
+                .and_then(|v| self.index_offset.checked_add(v));
+            match (verts, idxs) {
+                (Some(v), Some(i)) => {
+                    self.vertex_offset = v;
+                    self.index_offset = i;
+                }
+                _ => {
+                    return Err(ParquetError::Overflow(
+                        "global vertex/index offsets exceed u32".to_string(),
+                    ));
+                }
+            }
         }
         self.mesh_count += meshes.len();
         Ok(())
@@ -383,7 +412,7 @@ impl StreamingParquetCacheWriter {
         let mesh = self.mesh_w.into_inner()?;
         let vertex = self.vert_w.into_inner()?;
         let index = self.idx_w.into_inner()?;
-        Ok(frame_sections(&mesh, &vertex, &index))
+        frame_sections(&mesh, &vertex, &index)
     }
 }
 

--- a/apps/server/src/services/parquet.rs
+++ b/apps/server/src/services/parquet.rs
@@ -47,6 +47,43 @@ pub enum ParquetError {
 // the parallel (positions, normals, colors, ...) column layout.
 #[allow(clippy::type_complexity)]
 pub fn serialize_to_parquet(meshes: &[MeshData]) -> Result<Bytes, ParquetError> {
+    let (mesh_batch, vertex_batch, index_batch) = build_mesh_tables(meshes, 0, 0)?;
+
+    // Write to a custom binary format with multiple Parquet sections
+    // Format: [mesh_parquet_len:u32][mesh_parquet][vertex_parquet_len:u32][vertex_parquet][index_parquet_len:u32][index_parquet]
+    let mesh_parquet = write_parquet_buffer(&mesh_batch)?;
+    let vertex_parquet = write_parquet_buffer(&vertex_batch)?;
+    let index_parquet = write_parquet_buffer(&index_batch)?;
+    Ok(frame_sections(&mesh_parquet, &vertex_parquet, &index_parquet))
+}
+
+/// Assemble the three Parquet buffers into the length-prefixed section layout
+/// shared by the whole-model serializer and the incremental cache writer.
+fn frame_sections(mesh: &[u8], vertex: &[u8], index: &[u8]) -> Bytes {
+    let mut output = Vec::with_capacity(12 + mesh.len() + vertex.len() + index.len());
+    output.extend_from_slice(&(mesh.len() as u32).to_le_bytes());
+    output.extend_from_slice(mesh);
+    output.extend_from_slice(&(vertex.len() as u32).to_le_bytes());
+    output.extend_from_slice(vertex);
+    output.extend_from_slice(&(index.len() as u32).to_le_bytes());
+    output.extend_from_slice(index);
+    Bytes::from(output)
+}
+
+/// Build the three Arrow tables (mesh metadata / vertices / indices) for a
+/// slice of meshes. `base_vertex_offset` / `base_index_offset` seed the
+/// mesh-table `vertex_start` / `index_start` columns so an incremental caller
+/// (the streaming cache writer) emits GLOBAL whole-model offsets while the
+/// per-batch client blobs keep batch-local ones (bases 0/0). The Z-up to Y-up
+/// transform lives here, in one place, for both paths.
+// The per-mesh column tuple type is explicit on purpose; aliasing it would hide
+// the parallel (positions, normals, colors, ...) column layout.
+#[allow(clippy::type_complexity)]
+fn build_mesh_tables(
+    meshes: &[MeshData],
+    base_vertex_offset: u32,
+    base_index_offset: u32,
+) -> Result<(RecordBatch, RecordBatch, RecordBatch), ParquetError> {
     // Calculate totals for pre-allocation
     let total_vertices: usize = meshes.iter().map(|m| m.positions.len() / 3).sum();
     let total_triangles: usize = meshes.iter().map(|m| m.indices.len() / 3).sum();
@@ -55,8 +92,8 @@ pub fn serialize_to_parquet(meshes: &[MeshData]) -> Result<Bytes, ParquetError> 
     // Phase 1: Compute cumulative offsets (must be sequential)
     let mut vertex_offsets = Vec::with_capacity(mesh_count);
     let mut index_offsets = Vec::with_capacity(mesh_count);
-    let mut vertex_offset: u32 = 0;
-    let mut index_offset: u32 = 0;
+    let mut vertex_offset: u32 = base_vertex_offset;
+    let mut index_offset: u32 = base_index_offset;
 
     for mesh in meshes {
         vertex_offsets.push(vertex_offset);
@@ -206,38 +243,9 @@ pub fn serialize_to_parquet(meshes: &[MeshData]) -> Result<Bytes, ParquetError> 
         idx_2.extend(i2);
     }
 
-    // Use separate schemas for each table type
-    let mesh_schema = Arc::new(Schema::new(vec![
-        Field::new("express_id", DataType::UInt32, false),
-        Field::new("ifc_type", DataType::Utf8, false),
-        Field::new("vertex_start", DataType::UInt32, false),
-        Field::new("vertex_count", DataType::UInt32, false),
-        Field::new("index_start", DataType::UInt32, false),
-        Field::new("index_count", DataType::UInt32, false),
-        Field::new("color_r", DataType::Float32, false),
-        Field::new("color_g", DataType::Float32, false),
-        Field::new("color_b", DataType::Float32, false),
-        Field::new("color_a", DataType::Float32, false),
-    ]));
-
-    let vertex_schema = Arc::new(Schema::new(vec![
-        Field::new("x", DataType::Float32, false),
-        Field::new("y", DataType::Float32, false),
-        Field::new("z", DataType::Float32, false),
-        Field::new("nx", DataType::Float32, false),
-        Field::new("ny", DataType::Float32, false),
-        Field::new("nz", DataType::Float32, false),
-    ]));
-
-    let index_schema = Arc::new(Schema::new(vec![
-        Field::new("i0", DataType::UInt32, false),
-        Field::new("i1", DataType::UInt32, false),
-        Field::new("i2", DataType::UInt32, false),
-    ]));
-
     // Create record batches
     let mesh_batch = RecordBatch::try_new(
-        mesh_schema.clone(),
+        mesh_schema(),
         vec![
             Arc::new(UInt32Array::from(express_ids)),
             Arc::new(StringArray::from(ifc_types)),
@@ -253,7 +261,7 @@ pub fn serialize_to_parquet(meshes: &[MeshData]) -> Result<Bytes, ParquetError> 
     )?;
 
     let vertex_batch = RecordBatch::try_new(
-        vertex_schema.clone(),
+        vertex_schema(),
         vec![
             Arc::new(Float32Array::from(pos_x)),
             Arc::new(Float32Array::from(pos_y)),
@@ -265,7 +273,7 @@ pub fn serialize_to_parquet(meshes: &[MeshData]) -> Result<Bytes, ParquetError> 
     )?;
 
     let index_batch = RecordBatch::try_new(
-        index_schema.clone(),
+        index_schema(),
         vec![
             Arc::new(UInt32Array::from(idx_0)),
             Arc::new(UInt32Array::from(idx_1)),
@@ -273,26 +281,110 @@ pub fn serialize_to_parquet(meshes: &[MeshData]) -> Result<Bytes, ParquetError> 
         ],
     )?;
 
-    // Write to a custom binary format with multiple Parquet sections
-    // Format: [mesh_parquet_len:u32][mesh_parquet][vertex_parquet_len:u32][vertex_parquet][index_parquet_len:u32][index_parquet]
-    let mut output = Vec::new();
+    Ok((mesh_batch, vertex_batch, index_batch))
+}
 
-    // Write mesh Parquet
-    let mesh_parquet = write_parquet_buffer(&mesh_batch)?;
-    output.extend_from_slice(&(mesh_parquet.len() as u32).to_le_bytes());
-    output.extend_from_slice(&mesh_parquet);
+fn mesh_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("express_id", DataType::UInt32, false),
+        Field::new("ifc_type", DataType::Utf8, false),
+        Field::new("vertex_start", DataType::UInt32, false),
+        Field::new("vertex_count", DataType::UInt32, false),
+        Field::new("index_start", DataType::UInt32, false),
+        Field::new("index_count", DataType::UInt32, false),
+        Field::new("color_r", DataType::Float32, false),
+        Field::new("color_g", DataType::Float32, false),
+        Field::new("color_b", DataType::Float32, false),
+        Field::new("color_a", DataType::Float32, false),
+    ]))
+}
 
-    // Write vertex Parquet
-    let vertex_parquet = write_parquet_buffer(&vertex_batch)?;
-    output.extend_from_slice(&(vertex_parquet.len() as u32).to_le_bytes());
-    output.extend_from_slice(&vertex_parquet);
+fn vertex_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("x", DataType::Float32, false),
+        Field::new("y", DataType::Float32, false),
+        Field::new("z", DataType::Float32, false),
+        Field::new("nx", DataType::Float32, false),
+        Field::new("ny", DataType::Float32, false),
+        Field::new("nz", DataType::Float32, false),
+    ]))
+}
 
-    // Write index Parquet
-    let index_parquet = write_parquet_buffer(&index_batch)?;
-    output.extend_from_slice(&(index_parquet.len() as u32).to_le_bytes());
-    output.extend_from_slice(&index_parquet);
+fn index_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("i0", DataType::UInt32, false),
+        Field::new("i1", DataType::UInt32, false),
+        Field::new("i2", DataType::UInt32, false),
+    ]))
+}
 
-    Ok(Bytes::from(output))
+/// Incremental whole-model cache writer for the streaming endpoint: each
+/// batch's columns are appended as one Parquet row group per table, so no
+/// `MeshData` has to be retained past the batch that produced it (previously
+/// the endpoint kept a FULL second copy of the model's meshes just to
+/// re-serialize them at Complete). The mesh-table `vertex_start`/`index_start`
+/// columns carry GLOBAL offsets (whole-model), matching what the one-shot
+/// `serialize_to_parquet` emits for the cached fast-path replay.
+pub struct StreamingParquetCacheWriter {
+    mesh_w: ArrowWriter<Vec<u8>>,
+    vert_w: ArrowWriter<Vec<u8>>,
+    idx_w: ArrowWriter<Vec<u8>>,
+    vertex_offset: u32,
+    index_offset: u32,
+    mesh_count: usize,
+}
+
+impl StreamingParquetCacheWriter {
+    pub fn new() -> Result<Self, ParquetError> {
+        fn writer(schema: Arc<Schema>) -> Result<ArrowWriter<Vec<u8>>, ParquetError> {
+            let props = writer_props(&schema);
+            Ok(ArrowWriter::try_new(Vec::new(), schema, Some(props))?)
+        }
+        Ok(Self {
+            mesh_w: writer(mesh_schema())?,
+            vert_w: writer(vertex_schema())?,
+            idx_w: writer(index_schema())?,
+            vertex_offset: 0,
+            index_offset: 0,
+            mesh_count: 0,
+        })
+    }
+
+    /// Append one batch as one row group per table, advancing the global
+    /// offsets. The meshes can be dropped by the caller afterwards.
+    pub fn append(&mut self, meshes: &[MeshData]) -> Result<(), ParquetError> {
+        if meshes.is_empty() {
+            return Ok(());
+        }
+        let (mesh_batch, vertex_batch, index_batch) =
+            build_mesh_tables(meshes, self.vertex_offset, self.index_offset)?;
+        self.mesh_w.write(&mesh_batch)?;
+        self.mesh_w.flush()?;
+        self.vert_w.write(&vertex_batch)?;
+        self.vert_w.flush()?;
+        self.idx_w.write(&index_batch)?;
+        self.idx_w.flush()?;
+        for mesh in meshes {
+            self.vertex_offset += (mesh.positions.len() / 3) as u32;
+            self.index_offset += mesh.indices.len() as u32;
+        }
+        self.mesh_count += meshes.len();
+        Ok(())
+    }
+
+    /// Total meshes appended so far.
+    pub fn mesh_count(&self) -> usize {
+        self.mesh_count
+    }
+
+    /// Close all three writers and assemble the `[len][mesh][len][vert][len][idx]`
+    /// section blob, identical in framing to `serialize_to_parquet`.
+    pub fn finish(self) -> Result<Bytes, ParquetError> {
+        let mesh = self.mesh_w.into_inner()?;
+        let vertex = self.vert_w.into_inner()?;
+        let index = self.idx_w.into_inner()?;
+        Ok(frame_sections(&mesh, &vertex, &index))
+    }
 }
 
 /// Write a RecordBatch to a Parquet buffer with LZ4 compression.
@@ -301,15 +393,23 @@ pub fn serialize_to_parquet(meshes: &[MeshData]) -> Result<Bytes, ParquetError> 
 fn write_parquet_buffer(batch: &RecordBatch) -> Result<Vec<u8>, ParquetError> {
     let mut buffer = Vec::new();
     let cursor = Cursor::new(&mut buffer);
+    let props = writer_props(&batch.schema());
+    let mut writer = ArrowWriter::try_new(cursor, batch.schema(), Some(props))?;
+    writer.write(batch)?;
+    writer.close()?;
 
-    // Build WriterProperties with dictionary disabled for numeric columns
+    Ok(buffer)
+}
+
+/// Writer properties shared by the one-shot and incremental writers: LZ4, and
+/// dictionary encoding disabled for numeric columns (high-entropy vertex data
+/// gains nothing from a dictionary while paying significant overhead).
+fn writer_props(schema: &Schema) -> WriterProperties {
     let mut props_builder = WriterProperties::builder()
         .set_compression(Compression::LZ4_RAW)
         .set_dictionary_enabled(true); // Default: enabled for strings
 
-    // Disable dictionary encoding for all numeric columns (floats and integers)
-    // This dramatically speeds up serialization for high-entropy data like vertex coordinates
-    for field in batch.schema().fields() {
+    for field in schema.fields() {
         let is_numeric = matches!(
             field.data_type(),
             DataType::Float32
@@ -326,13 +426,7 @@ fn write_parquet_buffer(batch: &RecordBatch) -> Result<Vec<u8>, ParquetError> {
         }
     }
 
-    let props = props_builder.build();
-
-    let mut writer = ArrowWriter::try_new(cursor, batch.schema(), Some(props))?;
-    writer.write(batch)?;
-    writer.close()?;
-
-    Ok(buffer)
+    props_builder.build()
 }
 
 #[cfg(test)]
@@ -372,6 +466,69 @@ mod tests {
             "Expected compact output, got {} bytes",
             data.len()
         );
+    }
+
+    /// Decode one framed section blob back into its three tables.
+    fn read_sections(blob: &[u8]) -> Vec<Vec<RecordBatch>> {
+        use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+        let mut out = Vec::new();
+        let mut off = 0usize;
+        for _ in 0..3 {
+            let len = u32::from_le_bytes(blob[off..off + 4].try_into().unwrap()) as usize;
+            off += 4;
+            let section = Bytes::copy_from_slice(&blob[off..off + len]);
+            off += len;
+            let reader = ParquetRecordBatchReaderBuilder::try_new(section)
+                .unwrap()
+                .build()
+                .unwrap();
+            out.push(reader.map(|b| b.unwrap()).collect::<Vec<_>>());
+        }
+        assert_eq!(off, blob.len(), "trailing bytes after the three sections");
+        out
+    }
+
+    /// Concatenate row groups per column into one comparable table.
+    fn concat_all(batches: &[RecordBatch]) -> RecordBatch {
+        let schema = batches[0].schema();
+        arrow::compute::concat_batches(&schema, batches).unwrap()
+    }
+
+    /// The incremental cache writer must produce a blob DECODE-equivalent to
+    /// the one-shot serializer for the same meshes: same schemas, same rows,
+    /// same GLOBAL vertex/index offsets - only the row-group layout differs.
+    #[test]
+    fn incremental_writer_matches_one_shot_serializer() {
+        let mesh = |id: u32, verts: usize| {
+            let mut positions = Vec::new();
+            for v in 0..verts {
+                positions.extend_from_slice(&[v as f32, id as f32, 0.5 * v as f32]);
+            }
+            let normals = vec![0.0; verts * 3];
+            let indices: Vec<u32> = (0..(verts as u32 / 3) * 3).collect();
+            MeshData::new(id, format!("IfcThing{id}"), positions, normals, indices, [0.1, 0.2, 0.3, 1.0])
+        };
+        let meshes: Vec<MeshData> = (1..=7).map(|i| mesh(i, 3 * i as usize)).collect();
+
+        let one_shot = serialize_to_parquet(&meshes).unwrap();
+
+        let mut writer = StreamingParquetCacheWriter::new().unwrap();
+        // Uneven batches on purpose: 2 + 4 + 1.
+        writer.append(&meshes[0..2]).unwrap();
+        writer.append(&meshes[2..6]).unwrap();
+        writer.append(&meshes[6..7]).unwrap();
+        assert_eq!(writer.mesh_count(), 7);
+        let incremental = writer.finish().unwrap();
+
+        let a = read_sections(&one_shot);
+        let b = read_sections(&incremental);
+        for (section_a, section_b) in a.iter().zip(b.iter()) {
+            let ta = concat_all(section_a);
+            let tb = concat_all(section_b);
+            assert_eq!(ta.schema(), tb.schema());
+            assert_eq!(ta.num_rows(), tb.num_rows());
+            assert_eq!(ta, tb, "decoded tables must be identical (incl. global offsets)");
+        }
     }
 
     /// Regression test for #586: meshes with positions but no normals

--- a/apps/server/src/services/streaming.rs
+++ b/apps/server/src/services/streaming.rs
@@ -67,7 +67,7 @@ pub(crate) fn detect_schema_version(content: &[u8]) -> &'static str {
 /// in the HEADER must not block otherwise valid models, so no `String`
 /// conversion happens anywhere on this path.
 pub fn process_streaming(
-    content: Vec<u8>,
+    content: bytes::Bytes,
     initial_batch_size: usize,
     max_batch_size: usize,
     opening_filter: OpeningFilterMode,


### PR DESCRIPTION
Executes the memory half of the parquet-streaming plan. **Per the current instruction this PR is NOT to be merged by the agent - review at your leisure.**

## Problem
The streaming endpoint kept a FULL second copy of the model's meshes (`Arc<Mutex<Vec<MeshData>>>`) solely to re-serialize a whole-model cache blob at Complete; the non-streaming endpoint deep-cloned its combined payload for the cache task; ingest copied the multipart buffer once more. Peak geometry memory per request was ~3x the model.

## Changes
- **`StreamingParquetCacheWriter`**: appends each batch's columns as one Parquet row group per table (mesh/vertex/index) with GLOBAL vertex/index offsets; meshes drop with the batch that produced them; Complete just closes the writers and frames the sections. Decode-equivalence to the one-shot serializer is unit-tested (same schemas/rows/offsets; only the row-group layout differs, which every Parquet reader handles). Writer failure disables the cache fill, never the client stream.
- Column building, schemas, and writer properties factored so the per-batch client blobs and the cache writer share one code path (one Z-up to Y-up transform).
- `parse_parquet` response + cache task share one `Bytes` (refcount); `extract_file` returns the multipart `Bytes` directly (no `to_vec`); the streaming endpoint's file-buffer clones became refcount bumps; `process_streaming` takes `Bytes`.
- Adversarial-review hardening: u32 overflow in section framing and global offsets fails loudly (`ParquetError::Overflow`) instead of truncating; the per-batch CPU work (including the PRE-EXISTING client-blob serialization) steps off the async pool via flavor-guarded `block_in_place`.

## Compatibility
Client-facing SSE contract and per-batch blobs are byte-unchanged. The cache blob is decode-identical under the same `-parquet-v4` key (row-group layout differs; contents, schemas and global offsets identical - unit-tested). No geometry code touched.

## Deferred (plan phase 2, separable by design)
Binary (non-base64) transport via content negotiation + server-client reader - a wire-format addition, tracked as the follow-up PR.

## Verification
`cargo test -p ifc-lite-server` 33/33 (incl. the new decode-equivalence test with uneven 2/4/1 batches); workspace clippy clean; CodeRabbit adversarial pass run pre-PR (2 findings, both fixed above).