### PR TITLE
fix(export): legacy-aware product filter — no orphan GLB nodes (#1496)

### DIFF
--- a/rust/core/src/lib.rs
+++ b/rust/core/src/lib.rs
@@ -91,7 +91,7 @@ pub use legacy_entities::{
 pub use model_bounds::{scan_model_bounds, scan_placement_bounds, ModelBounds};
 pub use parser::{parse_entity, EntityScanner, Token};
 pub use schema_gen::{AttributeValue, DecodedEntity, GeometryCategory, IfcSchema, ProfileCategory};
-pub use schema_helpers::{has_geometry_by_name, is_simple_geometry_type};
+pub use schema_helpers::{has_geometry_by_name, is_simple_geometry_type, legacy_aware_ifc_type};
 pub use step_encoding::{decode_ifc_string, encode_ifc_string};
 pub use streaming::{parse_stream, ParseEvent, StreamConfig};
 pub use units::{

--- a/rust/core/src/schema_helpers.rs
+++ b/rust/core/src/schema_helpers.rs
@@ -145,11 +145,23 @@ pub fn is_simple_geometry_type(type_name: &str) -> bool {
     cached(cache, upper.as_ref(), || compute_is_simple(upper.as_ref()))
 }
 
-fn compute_is_simple(upper: &str) -> bool {
-    let t = match get_legacy_entity_info(upper) {
+/// Resolve a STEP keyword to its `IfcType`, **legacy-aware**: a removed/renamed
+/// entity (`IFCPROXY`, `IFCSOLIDSTRATUM`, …) maps to its modern base type via the
+/// hand-maintained legacy table, exactly as `has_geometry_by_name` does. Any pass
+/// that *classifies* or *labels* an entity must use this rather than a bare
+/// `IfcType::from_str`; otherwise it disagrees with the geometry pass (which meshes
+/// legacy entities), leaving a rendered node with no attribute row — the
+/// geometry/attribute product-set divergence (#1496).
+pub fn legacy_aware_ifc_type(type_name: &str) -> IfcType {
+    let upper = normalise_uppercase(type_name);
+    match get_legacy_entity_info(upper.as_ref()) {
         Some(info) => info.base_type,
-        None => IfcType::from_str(upper),
-    };
+        None => IfcType::from_str(upper.as_ref()),
+    }
+}
+
+fn compute_is_simple(upper: &str) -> bool {
+    let t = legacy_aware_ifc_type(upper);
 
     // Anything not in the modern schema defaults to "simple" priority,
     // matching the original blacklist's "anything else is simple" behaviour.

--- a/rust/export/src/gltf.rs
+++ b/rust/export/src/gltf.rs
@@ -2955,6 +2955,53 @@ mod tests {
         }
     }
 
+    /// #1496 regression — the join contract: every meshed GLB node's `expressId`
+    /// must resolve to an export-model row, so a viewer can always look up
+    /// attributes on pick. The whole legacy-entity class (`IfcProxy`,
+    /// `IfcSolidStratum`, and the common IFC2x3 `*StandardCase`/`*ElementedCase`
+    /// entities) used to render *without* a row: the geometry pass meshes them via
+    /// the legacy table, but the attribute pass tested a bare `from_str`
+    /// (→ `Unknown`) against `IfcProduct`. Both now use `legacy_aware_ifc_type`.
+    /// These fixtures cover the proxy + geoscience cases; the mechanism generalises
+    /// to every legacy product. (Type-only geometry — `IfcBoilerType` in the
+    /// tessellation-with-*-texture fixtures — is a separate, harder case tracked as
+    /// a follow-up and intentionally NOT covered here.)
+    #[test]
+    fn glb_nodes_have_export_rows_for_legacy_products() {
+        for rel in [
+            "ifcopenshell/1030-sphere.ifc",
+            "ifcopenshell/1032-curve.ifc",
+            "issues/860_solid_stratum.ifc",
+        ] {
+            let Some(content) = fixture_opt(rel) else { continue };
+            let opts = GltfOptions {
+                include_metadata: true,
+                ..GltfOptions::default()
+            };
+            let (glb, _stats) = export_glb_with_stats(&content, &opts);
+            let (json, _bin) = parse_glb(&glb);
+            let rows: std::collections::HashSet<u32> = crate::model::build_export_model(&content)
+                .entities
+                .iter()
+                .map(|e| e.express_id)
+                .collect();
+            let mut checked = 0;
+            for n in json["nodes"].as_array().unwrap() {
+                let Some(extras) = n.get("extras") else { continue };
+                let Some(eid) = extras.get("expressId").and_then(|v| v.as_u64()) else {
+                    continue;
+                };
+                checked += 1;
+                assert!(
+                    rows.contains(&(eid as u32)),
+                    "{rel}: GLB node expressId {eid} (ifcType {:?}) has no export-model row (#1496)",
+                    extras.get("ifcType")
+                );
+            }
+            assert!(checked > 0, "{rel}: expected at least one meshed element node");
+        }
+    }
+
     #[test]
     fn occurrence_matrix_reconstructs_rotated_instance_under_national_grid_rtc() {
         // Decisive synthetic test for the RTC/rotation frame (review finding C1+M1):

--- a/rust/export/src/gltf.rs
+++ b/rust/export/src/gltf.rs
@@ -2968,12 +2968,14 @@ mod tests {
     /// a follow-up and intentionally NOT covered here.)
     #[test]
     fn glb_nodes_have_export_rows_for_legacy_products() {
+        let mut found = 0;
         for rel in [
             "ifcopenshell/1030-sphere.ifc",
             "ifcopenshell/1032-curve.ifc",
             "issues/860_solid_stratum.ifc",
         ] {
             let Some(content) = fixture_opt(rel) else { continue };
+            found += 1;
             let opts = GltfOptions {
                 include_metadata: true,
                 ..GltfOptions::default()
@@ -2999,6 +3001,16 @@ mod tests {
                 );
             }
             assert!(checked > 0, "{rel}: expected at least one meshed element node");
+        }
+        // Per the fixture_opt house rule the test is green when the corpus isn't
+        // fetched — but say so, so a silent zero-coverage run (Greptile #1511) is
+        // visible rather than masquerading as a real pass. CI fetches the corpus,
+        // so `found` is 3 there and the join contract is actually exercised.
+        if found == 0 {
+            eprintln!(
+                "skipping glb_nodes_have_export_rows: no legacy fixtures fetched \
+                 (run `pnpm fixtures`)"
+            );
         }
     }
 

--- a/rust/export/src/model.rs
+++ b/rust/export/src/model.rs
@@ -274,19 +274,23 @@ pub fn stream_export_model_with_index(
     // Pass 2 — emit a row per IfcProduct occurrence, resolving its property/quantity sets.
     let mut scanner = EntityScanner::new(content);
     while let Some((id, type_name, start, end)) = scanner.next_entity() {
-        // Filter on the STEP keyword *before* decoding. `parse_entity` resolves the
-        // type via this same `IfcType::from_str`, so this is identical to decoding
-        // and testing `ifc_type.is_subtype_of(IfcProduct)` — but it skips parsing
-        // the millions of non-product geometry primitives entirely.
-        if !IfcType::from_str(type_name).is_subtype_of(IfcType::IfcProduct) {
+        // Filter on the STEP keyword *before* decoding, skipping the millions of
+        // non-product geometry primitives. `legacy_aware_ifc_type` (not a bare
+        // `from_str`) resolves removed/renamed keywords (IFCPROXY, IFCSOLIDSTRATUM,
+        // …) to their modern base type, matching what the geometry pass meshes —
+        // otherwise those products render as GLB nodes with no attribute row (#1496).
+        let ty = ifc_lite_core::legacy_aware_ifc_type(type_name);
+        if !ty.is_subtype_of(IfcType::IfcProduct) {
             continue;
         }
         let entity = match decoder.decode_at_uncached(start, end) {
             Ok(e) => e,
             Err(_) => continue,
         };
-        // PascalCase canonical name (IfcWall), not the STEP keyword (IFCWALL).
-        let ifc_type = entity.ifc_type.name().to_string();
+        // PascalCase canonical name (IfcWall), not the STEP keyword (IFCWALL);
+        // the legacy-resolved type, so a proxy is "IfcBuildingElementProxy", not
+        // "Unknown", and equals the node's `ifcType` extra.
+        let ifc_type = ty.name().to_string();
         let global_id = opt_string(entity.get(0));
         let name = opt_string(entity.get(2));
         let description = opt_string(entity.get(3));

--- a/rust/processing/src/processor/mod.rs
+++ b/rust/processing/src/processor/mod.rs
@@ -661,7 +661,10 @@ pub fn process_geometry_streaming_filtered_with_options(
         }
 
         if ifc_lite_core::has_geometry_by_name(type_name) {
-            let ifc_type = IfcType::from_str(type_name);
+            // Legacy-aware so a remapped entity (IfcProxy, IfcSolidStratum, …)
+            // labels its node with the real base type, not "Unknown", and matches
+            // the attribute pass's row type (#1496).
+            let ifc_type = ifc_lite_core::legacy_aware_ifc_type(type_name);
             if quick_metadata_enabled {
                 quick_element_summaries.insert(
                     id,


### PR DESCRIPTION
Closes #1496 (the proxy + geoscience cases; type-only geometry tracked as a follow-up, see below).

## The bug

The geometry pass and the attribute pass disagreed on what counts as a product:
- **Geometry** meshes an entity when `has_geometry_by_name()` is true, which consults the hand-maintained `legacy_entities` table.
- **Attributes** (`stream_export_model`) emitted a row only when `IfcType::from_str(keyword).is_subtype_of(IfcProduct)` held — a bare `from_str`, no legacy resolution.

For every removed/renamed keyword — `IfcProxy`, `IfcSolidStratum`, and the **common IFC2x3 `*StandardCase` / `*ElementedCase`** entities — `from_str` returns `Unknown`, so the element **rendered as a GLB node but had no `EntityRow`**. A viewer picking it finds no attributes (the join-contract gap, and `ifcType` shows "Unknown").

## The fix

Extract the legacy-aware resolution `compute_is_simple` already used into a shared core helper `legacy_aware_ifc_type()`, and use it in **both** passes:
- attribute filter + row label (`rust/export/src/model.rs`) — the entity now gets a row, labelled with its real base type;
- geometry node label (`rust/processing/src/processor/mod.rs`) — the node's `ifcType` extra matches that base type.

## Why it's safe

Probed every legacy key: **all resolve to `Unknown` via `from_str` today**, so the helper only upgrades `Unknown → base type` and never relabels a resolvable entity. Output is **byte-identical for any model without legacy entities** (the determinism goldens are unaffected). For IFC2x3 models that do use `*StandardCase` entities, this is the intended correction (they now carry attributes + a real type instead of orphaning as "Unknown").

> Heads-up for review: if any insta snapshot pins a legacy entity's old `"Unknown"` label, accept the update — it reflects the fix.

## Tests

- New `gltf::glb_nodes_have_export_rows_for_legacy_products` asserts **every meshed node `expressId` has an export-model row** on `1030-sphere`/`1032-curve` (IfcProxy) and `860_solid_stratum` (IfcSolidStratum). Passes.
- `#957` type-only geometry test still green; core/processing/export unit suites green locally (fixture-gated tests skip where the corpus isn't fetched — CI runs them with `pnpm fixtures`).
- clippy clean on the three crates.

## Out of scope (follow-up)

Type-only geometry — `IfcBoilerType` in the `tessellation-with-*-texture` fixtures — is meshed by #957 Route B with the **type's** expressId. The attribute pass is `IfcProduct`-only, so it still skips these. Fixing that needs runtime orphan bookkeeping (which type-products were actually meshed), not a keyword remap — a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)