### PR TITLE
feat(cli): global verbosity convention, export diagnostics, --profile (plan 06)

### DIFF
--- a/.changeset/cli-verbosity.md
+++ b/.changeset/cli-verbosity.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/cli": minor
+---
+
+CLI-wide verbosity convention: global `--verbose`, `--quiet`, `--debug`, and `--log-level <error|warn|info|debug>` flags (parsed and stripped before dispatch, so positional file paths are never confused with flag values). Human logs go to stderr only; stdout stays reserved for payloads and `--json`. Failures now print `Error [<command>]: <message>` with a remediation hint, and stack traces show under `--debug`/`--verbose` (the `DEBUG` env var still works). Parser diagnostics are no longer hard-silenced: they surface on stderr under `--verbose`. `export` gains `--diagnostics` (implied by `--verbose`), printing the same CSG/opening geometry report as `diagnose-geometry` from the export's own context.

--- a/packages/cli/src/commands/diagnose-geometry.ts
+++ b/packages/cli/src/commands/diagnose-geometry.ts
@@ -11,8 +11,9 @@
  * `ProcessingStats.geometry_diagnostics`. Use `--json` for the raw object.
  */
 import { readFile } from 'node:fs/promises';
-import { GeometryProcessor, type GeometryDiagnostics } from '@ifc-lite/geometry';
+import { GeometryProcessor } from '@ifc-lite/geometry';
 import { getFlag, hasFlag, fatal } from '../output.js';
+import { formatGeometryReport, NO_DIAGNOSTICS_LINE } from '../geometry-report.js';
 
 export async function diagnoseGeometryCommand(args: string[]): Promise<void> {
   const filePath = args.find((a) => !a.startsWith('-'));
@@ -43,53 +44,8 @@ export async function diagnoseGeometryCommand(args: string[]): Promise<void> {
   }
 
   if (!diag) {
-    console.log('No CSG / opening diagnostics recorded (no openings cut, no failures).');
+    console.log(NO_DIAGNOSTICS_LINE);
     return;
   }
-  printReport(diag);
-}
-
-function printReport(d: GeometryDiagnostics): void {
-  const lines: string[] = [];
-  lines.push('Geometry diagnostics');
-  lines.push('====================');
-  lines.push(
-    `CSG failures:        ${d.totalCsgFailures} across ${d.productsWithFailures} product(s)`,
-  );
-  lines.push(`Hosts with openings: ${d.hostsWithOpenings}`);
-  lines.push(
-    `Openings classified: ${d.classification.total} ` +
-      `(rectangular ${d.classification.rectangular}, diagonal ${d.classification.diagonal}, ` +
-      `non-rectangular ${d.classification.nonRectangular})`,
-  );
-  lines.push(`Silent rect no-ops:  ${d.silentNoOps}`);
-
-  if (d.failuresByReason.length > 0) {
-    lines.push('');
-    lines.push('Failures by reason:');
-    for (const r of d.failuresByReason) {
-      lines.push(`  ${r.count.toString().padStart(6)}  ${r.reason}`);
-    }
-  }
-
-  const rf = d.rectFast;
-  lines.push('');
-  lines.push(
-    `rect_fast: fired ${rf.fired}, openings cut ${rf.openingsCut} ` +
-      `(defer: host-not-box ${rf.deferHostNotBox}, not-through ${rf.deferNotThrough}, ` +
-      `off-face ${rf.deferOffFace}, near-edge ${rf.deferNearEdge}, no-openings ${rf.deferNoOpenings})`,
-  );
-
-  if (d.worstHosts.length > 0) {
-    lines.push('');
-    lines.push('Worst-failing hosts:');
-    for (const h of d.worstHosts) {
-      const label = h.firstFailureLabel ? ` [${h.firstFailureLabel}]` : '';
-      lines.push(
-        `  #${h.productId} ${h.ifcType}: ${h.csgFailures} failure(s), ${h.openings} opening(s)${label}`,
-      );
-    }
-  }
-
-  console.log(lines.join('\n'));
+  console.log(formatGeometryReport(diag));
 }

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -347,7 +347,12 @@ export async function exportCommand(args: string[]): Promise<void> {
           }
           logger.debug(`GLB meshes: ${countGlbMeshes(out as Uint8Array)}`);
           await writeFile(outPath, out as Uint8Array);
-          process.stderr.write(`Written to ${outPath}\n`);
+          logger.info(`Written to ${outPath}`);
+        }
+        if (profileFlag) {
+          process.stderr.write(
+            `profile: ${format} export ${(performance.now() - tWork).toFixed(0)}ms\n`,
+          );
         }
         // Opt-in geometry summary (--diagnostics, or implied by --verbose):
         // reuses the gp/bytes already in scope. This is a second geometry pass
@@ -370,11 +375,6 @@ export async function exportCommand(args: string[]): Promise<void> {
           }
         }
       } finally {
-        if (profileFlag) {
-          process.stderr.write(
-            `profile: ${format} export ${(performance.now() - tWork).toFixed(0)}ms\n`,
-          );
-        }
         gp.dispose();
       }
       break;

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -16,6 +16,8 @@ import { GeometryProcessor, isNoRenderGeometryError } from '@ifc-lite/geometry';
 import { countGlbMeshes } from '@ifc-lite/export';
 import { createHeadlessContext } from '../loader.js';
 import { getFlag, hasFlag, fatal, writeOutput } from '../output.js';
+import { logger } from '../logger.js';
+import { formatGeometryReport, NO_DIAGNOSTICS_LINE } from '../geometry-report.js';
 import type { ComparisonOp } from '@ifc-lite/sdk';
 import type { IfcDataStore } from '@ifc-lite/parser';
 
@@ -334,8 +336,21 @@ export async function exportCommand(args: string[]): Promise<void> {
                 : 'GLB export produced 0 meshes — the model has no exportable render geometry (or geometry production failed).',
             );
           }
+          logger.debug(`GLB meshes: ${countGlbMeshes(out as Uint8Array)}`);
           await writeFile(outPath, out as Uint8Array);
           process.stderr.write(`Written to ${outPath}\n`);
+        }
+        // Opt-in geometry summary (--diagnostics, or implied by --verbose):
+        // reuses the gp/bytes already in scope. This is a second geometry pass
+        // (the export bindings do not return diagnostics yet), so it only runs
+        // when asked for; the renderer is shared with diagnose-geometry.
+        if (hasFlag(args, '--diagnostics') || logger.level() === 'debug') {
+          if (format === 'ifcx') {
+            logger.info('No geometry diagnostics for ifcx export (no mesh pass).');
+          } else {
+            const diag = gp.diagnoseGeometry(bytes);
+            logger.info(diag ? formatGeometryReport(diag) : NO_DIAGNOSTICS_LINE);
+          }
         }
       } finally {
         gp.dispose();

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -288,7 +288,16 @@ export async function exportCommand(args: string[]): Promise<void> {
       if (filterActive && format === 'ifcx') {
         process.stderr.write('Note: --type/--storey/--where/--limit do not apply to IFCX; exporting the whole model.\n');
       }
+      // --profile: attribute wall-time between the per-invocation wasm
+      // bootstrap (GeometryProcessor init) and the export itself - the
+      // fixed-overhead split the throughput plan needs for tiny inputs.
+      const profileFlag = hasFlag(args, '--profile');
+      const tInit = performance.now();
       const { bytes, gp } = await rustExportContext(store, filePath);
+      if (profileFlag) {
+        process.stderr.write(`profile: wasm init ${(performance.now() - tInit).toFixed(0)}ms\n`);
+      }
+      const tWork = performance.now();
       try {
         if (format === 'ifcx') {
           const out = gp.exportIfcx(bytes);
@@ -348,11 +357,24 @@ export async function exportCommand(args: string[]): Promise<void> {
           if (format === 'ifcx') {
             logger.info('No geometry diagnostics for ifcx export (no mesh pass).');
           } else {
-            const diag = gp.diagnoseGeometry(bytes);
-            logger.info(diag ? formatGeometryReport(diag) : NO_DIAGNOSTICS_LINE);
+            // Best-effort: the export already succeeded; a diagnostics failure
+            // must not turn it into a command failure.
+            try {
+              const diag = gp.diagnoseGeometry(bytes);
+              logger.info(diag ? formatGeometryReport(diag) : NO_DIAGNOSTICS_LINE);
+            } catch (err) {
+              logger.warn(
+                `Geometry diagnostics failed: ${err instanceof Error ? err.message : String(err)}`,
+              );
+            }
           }
         }
       } finally {
+        if (profileFlag) {
+          process.stderr.write(
+            `profile: ${format} export ${(performance.now() - tWork).toFixed(0)}ms\n`,
+          );
+        }
         gp.dispose();
       }
       break;

--- a/packages/cli/src/commands/generate-spaces.ts
+++ b/packages/cli/src/commands/generate-spaces.ts
@@ -8,6 +8,7 @@
  */
 
 import { writeFile } from 'node:fs/promises';
+import { logger } from '../logger.js';
 import { createHeadlessContext } from '../loader.js';
 import { getFlag, getAllFlags, hasFlag, fatal, printJson } from '../output.js';
 import { MutablePropertyView, StoreEditor } from '@ifc-lite/mutations';
@@ -56,7 +57,7 @@ export async function generateSpacesCommand(args: string[]): Promise<void> {
   const dryRun = hasFlag(args, '--dry-run');
   const force = hasFlag(args, '--force');
   const json = hasFlag(args, '--json');
-  const debug = hasFlag(args, '--debug');
+  const debug = logger.level() === 'debug';
 
   const { store } = await createHeadlessContext(filePath!);
 

--- a/packages/cli/src/geometry-report.ts
+++ b/packages/cli/src/geometry-report.ts
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Human-readable renderer for the `GeometryDiagnostics` contract, shared by
+ * `diagnose-geometry` and `export --diagnostics` so both surfaces print the
+ * identical report.
+ */
+import type { GeometryDiagnostics } from '@ifc-lite/geometry';
+
+/** One-liner used when the geometry pass recorded nothing diagnostic-worthy. */
+export const NO_DIAGNOSTICS_LINE =
+  'No CSG / opening diagnostics recorded (no openings cut, no failures).';
+
+export function formatGeometryReport(d: GeometryDiagnostics): string {
+  const lines: string[] = [];
+  lines.push('Geometry diagnostics');
+  lines.push('====================');
+  lines.push(
+    `CSG failures:        ${d.totalCsgFailures} across ${d.productsWithFailures} product(s)`,
+  );
+  lines.push(`Hosts with openings: ${d.hostsWithOpenings}`);
+  lines.push(
+    `Openings classified: ${d.classification.total} ` +
+      `(rectangular ${d.classification.rectangular}, diagonal ${d.classification.diagonal}, ` +
+      `non-rectangular ${d.classification.nonRectangular})`,
+  );
+  lines.push(`Silent rect no-ops:  ${d.silentNoOps}`);
+
+  if (d.failuresByReason.length > 0) {
+    lines.push('');
+    lines.push('Failures by reason:');
+    for (const r of d.failuresByReason) {
+      lines.push(`  ${r.count.toString().padStart(6)}  ${r.reason}`);
+    }
+  }
+
+  const rf = d.rectFast;
+  lines.push('');
+  lines.push(
+    `rect_fast: fired ${rf.fired}, openings cut ${rf.openingsCut} ` +
+      `(defer: host-not-box ${rf.deferHostNotBox}, not-through ${rf.deferNotThrough}, ` +
+      `off-face ${rf.deferOffFace}, near-edge ${rf.deferNearEdge}, no-openings ${rf.deferNoOpenings})`,
+  );
+
+  if (d.worstHosts.length > 0) {
+    lines.push('');
+    lines.push('Worst-failing hosts:');
+    for (const h of d.worstHosts) {
+      const label = h.firstFailureLabel ? ` [${h.firstFailureLabel}]` : '';
+      lines.push(
+        `  #${h.productId} ${h.ifcType}: ${h.csgFailures} failure(s), ${h.openings} opening(s)${label}`,
+      );
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,6 +10,7 @@
  * from the command line. Designed for both humans and LLM terminals.
  */
 
+import { logger, parseVerbosity } from './logger.js';
 import { infoCommand } from './commands/info.js';
 import { queryCommand } from './commands/query.js';
 import { propsCommand } from './commands/props.js';
@@ -90,10 +91,14 @@ const HELP = `
     ext       validate <path>|init <dir>          Manage IFClite extensions (Phase 0 — validate, init)
 
   Options:
-    --help, -h       Show help
-    --version, -v    Show version
-    --json           Output as JSON (machine-readable)
-    --out <file>     Write output to file instead of stdout
+    --help, -h           Show help
+    --version, -v        Show version
+    --json               Output as JSON (machine-readable)
+    --out <file>         Write output to file instead of stdout
+    --verbose            Show parser + geometry diagnostics (stderr)
+    --quiet              Errors only
+    --debug              Verbose + stack traces on error
+    --log-level <level>  error|warn|info|debug (explicit wins over shorthands)
 
   Examples:
     ifc-lite info model.ifc
@@ -167,8 +172,18 @@ const HELP = `
   Learn more: https://ifclite.com
 `;
 
+/** Command being executed, captured for the top-level error handler. */
+let activeCommand = '';
+/** True when --debug was passed (stack traces on error). */
+let debugFlag = false;
+
 async function main(): Promise<void> {
-  const args = process.argv.slice(2);
+  // Global verbosity flags are parsed and STRIPPED before dispatch so a
+  // command's positional-argument scan never mistakes them for a file path.
+  const verbosity = parseVerbosity(process.argv.slice(2));
+  logger.configure({ level: verbosity.level });
+  debugFlag = verbosity.debug;
+  const args = verbosity.rest;
 
   if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
     process.stdout.write(HELP + '\n');
@@ -181,6 +196,7 @@ async function main(): Promise<void> {
   }
 
   const command = args[0];
+  activeCommand = command;
   const commandArgs = args.slice(1);
 
   switch (command) {
@@ -270,9 +286,16 @@ async function main(): Promise<void> {
 }
 
 main().catch((err: Error) => {
-  process.stderr.write(`Error: ${err.message}\n`);
-  if (process.env.DEBUG) {
+  const label = activeCommand ? `Error [${activeCommand}]` : 'Error';
+  process.stderr.write(`${label}: ${err.message}\n`);
+  // Stack traces with --debug/--verbose/--log-level debug, or the legacy
+  // DEBUG env var (kept for back-compat).
+  if (debugFlag || logger.level() === 'debug' || process.env.DEBUG) {
     process.stderr.write((err.stack ?? '') + '\n');
+  } else {
+    process.stderr.write(
+      `Hint: re-run with --debug for a stack trace, or \`ifc-lite ${activeCommand || '<command>'} --help\` for usage.\n`,
+    );
   }
   process.exit(1);
 });

--- a/packages/cli/src/loader.ts
+++ b/packages/cli/src/loader.ts
@@ -7,6 +7,7 @@
  */
 
 import { readFile } from 'node:fs/promises';
+import { logger } from './logger.js';
 import { basename } from 'node:path';
 import { IfcParser, type IfcDataStore } from '@ifc-lite/parser';
 import { createBimContext, type BimContext, type ViewerBackendMethods, type VisibilityBackendMethods } from '@ifc-lite/sdk';
@@ -35,11 +36,19 @@ export async function loadIfcFile(filePath: string): Promise<IfcDataStore> {
 
   const parser = new IfcParser();
 
-  // Suppress parser's internal console.log/warn during parsing
+  // Capture the parser's internal console.log/warn during parsing and route
+  // them to logger.debug: silent by default (stdout stays clean for payloads),
+  // visible on stderr under --verbose/--debug. The console capture is the
+  // belt-and-suspenders for raw console lines the parser emits outside its
+  // onDiagnostic channel.
   const origLog = console.log;
   const origWarn = console.warn;
-  console.log = () => {};
-  console.warn = () => {};
+  console.log = (...parts: unknown[]) => {
+    logger.debug(`parser: ${parts.map(String).join(' ')}`);
+  };
+  console.warn = (...parts: unknown[]) => {
+    logger.debug(`parser: ${parts.map(String).join(' ')}`);
+  };
   try {
     // Ensure we pass the exact slice — Node Buffers may be views into
     // a larger pooled ArrayBuffer, so buffer.buffer can include extra bytes.
@@ -47,7 +56,10 @@ export async function loadIfcFile(filePath: string): Promise<IfcDataStore> {
       buffer.byteOffset,
       buffer.byteOffset + buffer.byteLength,
     ) as ArrayBuffer;
-    const store = await parser.parseColumnar(arrayBuffer);
+    const store = await parser.parseColumnar(arrayBuffer, {
+      // The structured diagnostic channel, captured directly.
+      onDiagnostic: (m: string) => logger.debug(`parser: ${m}`),
+    });
     store.fileSize = buffer.byteLength;
     return store;
   } finally {

--- a/packages/cli/src/logger.test.ts
+++ b/packages/cli/src/logger.test.ts
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { logger, parseVerbosity } from './logger.js';
+
+describe('parseVerbosity', () => {
+  it('maps the shorthands and strips them from argv', () => {
+    expect(parseVerbosity(['--verbose', 'info', 'model.ifc'])).toEqual({
+      level: 'debug',
+      debug: false,
+      rest: ['info', 'model.ifc'],
+    });
+    expect(parseVerbosity(['--quiet', 'query', 'm.ifc']).level).toBe('error');
+    const dbg = parseVerbosity(['export', '--debug', 'm.ifc']);
+    expect(dbg.level).toBe('debug');
+    expect(dbg.debug).toBe(true);
+    expect(dbg.rest).toEqual(['export', 'm.ifc']);
+  });
+
+  it('strips --log-level AND its value so positional scans stay correct', () => {
+    const v = parseVerbosity(['info', '--log-level', 'warn', 'model.ifc']);
+    expect(v.level).toBe('warn');
+    expect(v.rest).toEqual(['info', 'model.ifc']);
+    // the classic trap: the value must never look like the file path
+    expect(v.rest.find((a) => !a.startsWith('-'))).toBe('info');
+  });
+
+  it('explicit --log-level wins over shorthands', () => {
+    expect(parseVerbosity(['--verbose', '--log-level', 'warn']).level).toBe('warn');
+    expect(parseVerbosity(['--log-level', 'debug', '--quiet']).level).toBe('debug');
+  });
+
+  it('warns and ignores an invalid --log-level value', () => {
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const v = parseVerbosity(['--log-level', 'loud', 'cmd']);
+    expect(v.level).toBe('info');
+    expect(v.rest).toEqual(['cmd']);
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('leaves command-local flags untouched', () => {
+    const v = parseVerbosity(['generate-spaces', 'm.ifc', '--json', '--out', 'x.json']);
+    expect(v.rest).toEqual(['generate-spaces', 'm.ifc', '--json', '--out', 'x.json']);
+  });
+});
+
+describe('logger', () => {
+  afterEach(() => {
+    logger.configure({ level: 'info' });
+    vi.restoreAllMocks();
+  });
+
+  it('writes to stderr only, gated by level', () => {
+    const err = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const out = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    logger.configure({ level: 'info' });
+    logger.debug('hidden');
+    expect(err).not.toHaveBeenCalled();
+    logger.info('shown');
+    expect(err).toHaveBeenCalledWith('shown\n');
+
+    logger.configure({ level: 'error' });
+    logger.info('quiet');
+    logger.warn('quiet');
+    expect(err).toHaveBeenCalledTimes(1);
+    logger.error('loud');
+    expect(err).toHaveBeenCalledWith('loud\n');
+
+    expect(out).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/logger.ts
+++ b/packages/cli/src/logger.ts
@@ -1,0 +1,109 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * CLI-wide leveled logger. Writes to STDERR only: stdout is reserved for
+ * command payloads and `--json` machine output (see output.ts), so human
+ * diagnostics must never pollute it.
+ *
+ * A module-level singleton configured once in index.ts. The CLI is a
+ * single-invocation, single-command process, so configure-once global state
+ * is the idiomatic shape here; threading a context through ~30 command
+ * signatures would be churn with no runtime benefit.
+ */
+
+export type LogLevel = 'error' | 'warn' | 'info' | 'debug';
+
+const LEVEL_ORDER: Record<LogLevel, number> = {
+  error: 0,
+  warn: 1,
+  info: 2,
+  debug: 3,
+};
+
+let currentLevel: LogLevel = 'info';
+
+export const logger = {
+  configure({ level }: { level: LogLevel }): void {
+    currentLevel = level;
+  },
+  level(): LogLevel {
+    return currentLevel;
+  },
+  error(msg: string): void {
+    write('error', msg);
+  },
+  warn(msg: string): void {
+    write('warn', msg);
+  },
+  info(msg: string): void {
+    write('info', msg);
+  },
+  debug(msg: string): void {
+    write('debug', msg);
+  },
+};
+
+function write(level: LogLevel, msg: string): void {
+  if (LEVEL_ORDER[level] > LEVEL_ORDER[currentLevel]) return;
+  process.stderr.write(`${msg}\n`);
+}
+
+/** The reserved global flags. Long-form only: `-v` is already `--version`,
+ * and short flags stay free for per-command use. */
+const GLOBAL_FLAGS = new Set(['--verbose', '--quiet', '--debug', '--log-level']);
+
+export interface Verbosity {
+  level: LogLevel;
+  /** True when `--debug` was passed (also unlocks stack traces on error). */
+  debug: boolean;
+  /** argv with the global flags AND the `--log-level` value stripped out. */
+  rest: string[];
+}
+
+/**
+ * Parse and STRIP the global verbosity flags from argv.
+ *
+ * Stripping is load-bearing: several commands pick their file path with
+ * `args.find(a => !a.startsWith('-'))`, so an unstripped `--log-level debug
+ * model.ifc` would make `debug` look like the positional file.
+ *
+ * Precedence: explicit `--log-level <level>` wins over the shorthands;
+ * `--verbose` and `--debug` map to `debug`; `--quiet` maps to `error`.
+ */
+export function parseVerbosity(args: string[]): Verbosity {
+  let level: LogLevel = 'info';
+  let explicit: LogLevel | null = null;
+  let debug = false;
+  const rest: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (!GLOBAL_FLAGS.has(arg)) {
+      rest.push(arg);
+      continue;
+    }
+    if (arg === '--verbose') {
+      level = 'debug';
+    } else if (arg === '--debug') {
+      level = 'debug';
+      debug = true;
+    } else if (arg === '--quiet') {
+      level = 'error';
+    } else if (arg === '--log-level') {
+      const value = args[i + 1];
+      if (value === 'error' || value === 'warn' || value === 'info' || value === 'debug') {
+        explicit = value;
+        i++; // strip the value too
+      } else {
+        process.stderr.write(
+          `Warning: --log-level expects error|warn|info|debug, got "${value ?? ''}"; ignoring\n`,
+        );
+        if (value !== undefined && !value.startsWith('-')) i++;
+      }
+    }
+  }
+
+  return { level: explicit ?? level, debug, rest };
+}

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -7,6 +7,7 @@
  */
 
 import { writeFile } from 'node:fs/promises';
+import { logger } from './logger.js';
 
 export type OutputFormat = 'json' | 'table' | 'csv';
 
@@ -17,7 +18,7 @@ export type OutputFormat = 'json' | 'table' | 'csv';
 export async function writeOutput(content: string | Uint8Array, outPath?: string): Promise<void> {
   if (outPath) {
     await writeFile(outPath, content);
-    process.stderr.write(`Written to ${outPath}\n`);
+    logger.info(`Written to ${outPath}`);
   } else {
     process.stdout.write(content);
     // Convenience newline for human-readable string output only; byte output


### PR DESCRIPTION
Executes the CLI diagnostics-convention plan. **Not to be merged by the agent - review at your leisure.**

## Problem
No global verbosity anywhere: failures printed a bare `Error: <msg>` (stack only via the `DEBUG` env var), the loader hard-silenced all parser output with no opt-out, and `export` gave no geometry signal beyond the zero-mesh guard - operators and LLM agents driving the CLI could not see why a parse was noisy or an export empty.

## Changes
- **Logger + parseVerbosity** (`packages/cli/src/logger.ts`): global `--verbose` / `--quiet` / `--debug` / `--log-level <level>`, parsed and **stripped** before dispatch (stripping is load-bearing: commands find their file path with `args.find(a => !a.startsWith('-'))`, so an unstripped `--log-level debug model.ifc` would load `debug`). Stderr-only; stdout stays reserved for payloads and `--json`. Long flags only (`-v` is `--version`).
- **Richer top-level catch**: `Error [<command>]: <message>` + a remediation hint; stack under `--debug`/`--verbose`/`--log-level debug` or the legacy `DEBUG` env var.
- **Parser diagnostics opt-in** (loader): captured console output AND the structured `onDiagnostic` channel route to `logger.debug` - silent by default, visible on stderr under `--verbose`. Verified: 36 parser lines verbose vs 0 default, stdout byte-identical (modulo the parse-time figure).
- **`export --diagnostics`** (implied by `--verbose`): prints the same CSG/opening report as `diagnose-geometry` via the extracted shared `formatGeometryReport` (diagnose-geometry output unchanged). Second geometry pass, only paid when asked; best-effort so a diagnostics failure never fails a successful export (adversarial-review finding, fixed).
- **`export --profile`**: wasm-init vs export wall-time split (plan 02's CLI deliverable, placed here to avoid cross-PR conflicts in export.ts). Sample: `wasm init 7ms / glb export 10ms` on a small fixture.

## Verification
- 115 CLI tests (6 new: shorthand mapping, strip-with-value, explicit-wins, invalid-value warning, local-flag passthrough, stderr-only level gating)
- E2E on the built CLI: flag-before-positional loads the model (not "debug"); error labeling + hint + stack gating; diagnostics + profile output on stderr; GLB still written
- `pnpm typecheck` 32/32; changeset included (@ifc-lite/cli minor)
- CodeRabbit adversarial pass: 1 finding, fixed