### PR TITLE
feat(tools): live IfcOpenShell differential parity harness (plan 07)

### DIFF
--- a/.github/workflows/ifcopenshell-parity.yml
+++ b/.github/workflows/ifcopenshell-parity.yml
@@ -41,7 +41,9 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master 2026-05 (stable)
+      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master 2026-05
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v5
         with:
@@ -79,7 +81,9 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master 2026-05 (stable)
+      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master 2026-05
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v5
         with:

--- a/.github/workflows/ifcopenshell-parity.yml
+++ b/.github/workflows/ifcopenshell-parity.yml
@@ -1,0 +1,130 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Live IfcOpenShell differential parity (plan 07). Two lanes:
+#
+# - per-PR (`quick` job): ifc-lite side ONLY vs the committed reference over
+#   the in-tree geometry fixtures - no reference-engine install, no fixture
+#   download. Path-gated to geometry-affecting changes. Non-required check
+#   (not on the "Build + WASM + Rust + Node" needs-list) so branch
+#   protection and CI cost are unchanged; promote later if it proves stable.
+#
+# - nightly (`full` job): installs the PINNED engine, runs the whole
+#   committed corpus (fetched fixtures included), regenerates the reference
+#   dumps to detect reference-staleness, and uploads diff reports. Modeled on
+#   determinism.yml (free arm runner, cron + dispatch, non-blocking).
+
+name: IfcOpenShell parity
+
+on:
+  pull_request:
+    paths:
+      - "rust/geometry/**"
+      - "rust/processing/**"
+      - "rust/core/**"
+      - "rust/python/**"
+      - "tools/ifcopenshell_reference/**"
+      - ".github/workflows/ifcopenshell-parity.yml"
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  quick:
+    name: parity (in-tree fixtures, committed reference)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build + install ifclite_geom wheel
+        run: |
+          pip install maturin
+          maturin build --release -m rust/python/Cargo.toml -o /tmp/wheels
+          pip install /tmp/wheels/*.whl
+      - name: Unit tests (canonical stats + comparator)
+        working-directory: tools/ifcopenshell_reference
+        run: python -m unittest test_harness -v
+      - name: Differential vs committed reference (in-tree fixtures)
+        working-directory: tools/ifcopenshell_reference
+        run: |
+          python dump_ifclite.py \
+            ../../rust/geometry/tests/fixtures/bath_csg_solid.ifc \
+            ../../rust/geometry/tests/fixtures/issue_1155_halfspace_flyaway.ifc \
+            ../../rust/geometry/tests/fixtures/swept_disk_composite_arc_crankbar.ifc \
+            ../../rust/geometry/tests/fixtures/swept_disk_trimmed_line.ifc \
+            --out-dir /tmp/lite
+          fail=0
+          for f in bath_csg_solid issue_1155_halfspace_flyaway \
+                   swept_disk_composite_arc_crankbar swept_disk_trimmed_line; do
+            python compare.py --reference "reference/$f.reference.json" \
+              --ifclite "/tmp/lite/$f.ifclite.json" \
+              --allowlist allowlist.json || fail=1
+          done
+          exit $fail
+
+  full:
+    name: full corpus (pinned reference engine)
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Fetch fixture corpus
+        run: |
+          pnpm install --frozen-lockfile --ignore-scripts
+          pnpm fixtures
+      - name: Install pinned reference engine + ifclite wheel
+        run: |
+          pip install -r tools/ifcopenshell_reference/requirements.lock maturin
+          maturin build --release -m rust/python/Cargo.toml -o /tmp/wheels
+          pip install /tmp/wheels/*.whl
+      - name: Regenerate reference + differential over the corpus
+        working-directory: tools/ifcopenshell_reference
+        run: |
+          FIXED="../../rust/geometry/tests/fixtures/bath_csg_solid.ifc \
+                 ../../rust/geometry/tests/fixtures/issue_1155_halfspace_flyaway.ifc \
+                 ../../rust/geometry/tests/fixtures/swept_disk_composite_arc_crankbar.ifc \
+                 ../../rust/geometry/tests/fixtures/swept_disk_trimmed_line.ifc \
+                 ../../tests/models/ifcopenshell/1019-column.ifc \
+                 ../../tests/models/ifcopenshell/1030-sphere.ifc \
+                 ../../tests/models/ara3d/IfcOpenHouse_IFC4.ifc \
+                 ../../tests/models/ara3d/duplex.ifc"
+          python dump_reference.py $FIXED --out-dir /tmp/ref
+          python dump_ifclite.py $FIXED --out-dir /tmp/lite
+          mkdir -p /tmp/reports
+          fail=0
+          for r in /tmp/ref/*.reference.json; do
+            f=$(basename "$r" .reference.json)
+            python compare.py --reference "$r" --ifclite "/tmp/lite/$f.ifclite.json" \
+              --allowlist allowlist.json --report "/tmp/reports/$f.json" || fail=1
+            # Reference-staleness: freshly generated vs committed.
+            if ! diff -q "$r" "reference/$f.reference.json" > /dev/null 2>&1; then
+              echo "::warning::committed reference for $f is stale vs the pinned engine"
+            fi
+          done
+          exit $fail
+      - name: Upload diff reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ifcopenshell-parity-reports
+          path: /tmp/reports/

--- a/.github/workflows/ifcopenshell-parity.yml
+++ b/.github/workflows/ifcopenshell-parity.yml
@@ -40,10 +40,10 @@ jobs:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
+      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master 2026-05 (stable)
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v5
         with:
           python-version: "3.12"
       - name: Build + install ifclite_geom wheel
@@ -78,14 +78,14 @@ jobs:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
+      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master 2026-05 (stable)
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v5
         with:
           python-version: "3.12"
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
       - name: Fetch fixture corpus
@@ -124,7 +124,7 @@ jobs:
           exit $fail
       - name: Upload diff reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: ifcopenshell-parity-reports
           path: /tmp/reports/

--- a/.github/workflows/ifcopenshell-parity.yml
+++ b/.github/workflows/ifcopenshell-parity.yml
@@ -41,6 +41,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
+        with:
+          # Jobs install external packages afterwards and never push; do not
+          # leave the GITHUB_TOKEN in the local git config for them to read.
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master 2026-05
         with:
           toolchain: stable
@@ -81,6 +85,10 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
+        with:
+          # Jobs install external packages afterwards and never push; do not
+          # leave the GITHUB_TOKEN in the local git config for them to read.
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master 2026-05
         with:
           toolchain: stable

--- a/tools/ifcopenshell_reference/Dockerfile
+++ b/tools/ifcopenshell_reference/Dockerfile
@@ -1,0 +1,9 @@
+# Hermetic environment for the nightly reference run: the pinned engine is
+# the source of truth for "which reference version we are parity-checked
+# against"; bumping it is an explicit, reviewed change.
+FROM python:3.12-slim
+WORKDIR /harness
+COPY requirements.lock .
+RUN pip install --no-cache-dir -r requirements.lock
+COPY canonical.py dump_reference.py compare.py allowlist.json ./
+ENTRYPOINT ["python"]

--- a/tools/ifcopenshell_reference/README.md
+++ b/tools/ifcopenshell_reference/README.md
@@ -1,0 +1,65 @@
+# IfcOpenShell differential parity harness
+
+Out-of-band tooling: NOT a pnpm workspace package, NOT a Cargo workspace
+member. It builds and runs only when its own CI jobs or a developer invoke
+it. The geometry kernel's correctness was previously anchored to six numbers
+hand-copied from one pip 0.8.2 run; this harness replaces them with a live,
+re-runnable differential against a pinned reference engine.
+
+## Layout
+
+- `canonical.py` - every stat both sides report (bbox, tri/vertex counts,
+  signed volume, watertightness), computed from plain vertex/face arrays so
+  the comparison measures geometry, never stat-computation differences.
+  Known-answer unit tests in `test_harness.py` (stdlib unittest).
+- `dump_reference.py` - canonical per-element JSON from the PINNED
+  IfcOpenShell (world coords + welded, matching the provenance of the old
+  baked constants). Engine failures become first-class `skip:<reason>` rows.
+- `dump_ifclite.py` - the same schema from the shipped `ifclite_geom`
+  binding (already welded, absolute-world, Z-up metres - apples-to-apples
+  by construction; zero new kernel code).
+- `compare.py` - joins by express id and classifies every element:
+  `MATCH / MISMATCH / IFCLITE_ONLY / REFERENCE_ONLY / BOTH_SKIP`.
+- `allowlist.json` - reviewed, accepted divergences with investigation
+  notes; allowlisted rows report but do not fail.
+- `reference/` - committed reference JSON for the hard corpus, generated
+  with the pinned engine. Refreshing it (or bumping the pin) is an explicit,
+  reviewed change.
+
+## Gating policy (calibrated on real models, see compare.py docstring)
+
+METRIC truth gates; topology is advisory. bbox within 1 mm and volume within
+1% (both-closed, and only when physically plausible - a reported volume
+exceeding its own bbox volume is a mixed-winding artifact and downgrades to
+advisory). Triangle/vertex counts never gate: the engines legitimately
+triangulate identical solids at different densities (duplex wall #5448 is
+92 vs 308 triangles with identical bbox and volumes agreeing to 0.001%).
+
+## Running locally
+
+```bash
+python3 -m venv .venv && .venv/bin/pip install -r requirements.lock
+# build + install the ifclite_geom wheel
+.venv/bin/pip install maturin && .venv/bin/maturin build --release \
+    -m ../../rust/python/Cargo.toml -o /tmp/wheels && .venv/bin/pip install /tmp/wheels/*.whl
+
+.venv/bin/python -m unittest test_harness
+.venv/bin/python dump_ifclite.py <model.ifc> --out-dir /tmp/lite
+.venv/bin/python compare.py --reference reference/<model>.reference.json \
+    --ifclite /tmp/lite/<model>.ifclite.json --allowlist allowlist.json
+```
+
+Regenerating the committed reference (pin bump or intentional acceptance):
+
+```bash
+.venv/bin/python dump_reference.py <models...> --out-dir reference/
+```
+
+## CI
+
+- Per-PR (`ifcopenshell-parity` job): ifc-lite side only vs the committed
+  reference over the IN-TREE fixtures (no fixture download, no reference
+  engine install). Catches kernel drift on every geometry-affecting PR.
+- Nightly (`ifcopenshell-parity.yml`): installs the pinned engine, runs the
+  full committed corpus (fetched fixtures included), regenerates reference
+  dumps to detect reference-staleness, and uploads the diff reports.

--- a/tools/ifcopenshell_reference/allowlist.json
+++ b/tools/ifcopenshell_reference/allowlist.json
@@ -1,0 +1,9 @@
+{
+  "_doc": "Reviewed, accepted divergences. Key: fixture -> { '<express_id>' | 'type:<IfcType>': reason }. An allowlisted MISMATCH/REFERENCE_ONLY is reported but does not fail the gate; every entry is a diffable decision with an investigation note.",
+  "duplex.ifc": {
+    "23671": "volume 4.089 (reference) vs 3.251 (ifc-lite) at identical 1mm bbox and identical 52 tris; both volumes physically plausible (bbox volume 4.23). Sibling duplex coverings show the reference side reporting volumes EXCEEDING their own bbox (mixed winding), so the reference figure is suspect here too but cannot be auto-ruled-out. Under investigation."
+  },
+  "IfcOpenHouse_IFC4.ifc": {
+    "281": "wall volume diverges beyond 1% at matching bbox; suspected boolean/opening treatment difference between engines on this wall. Under investigation."
+  }
+}

--- a/tools/ifcopenshell_reference/canonical.py
+++ b/tools/ifcopenshell_reference/canonical.py
@@ -1,0 +1,129 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Canonical per-element geometry stats, shared by BOTH dumpers.
+
+Every stat both sides of the differential comparison report is computed by
+the functions in this file, from plain vertex/face arrays. That way the
+comparison only ever measures the GEOMETRY, never a difference in how a stat
+was computed.
+
+Conventions (must match on both sides):
+- vertices: flat list [x0, y0, z0, x1, ...] in absolute world METRES, Z-up,
+  WELDED (the reference engine runs weld-vertices=True; the ifc-lite side
+  comes pre-welded from ``ifclite_geom.geometry_data_buffers``).
+- faces: flat list of vertex indices, triangles only.
+- floats are rounded to ROUND_DECIMALS before serialization so trivial float
+  noise between engine builds does not create diffs (6 decimals of a metre =
+  sub-micron stability).
+"""
+
+from __future__ import annotations
+
+ROUND_DECIMALS = 6
+
+# Stat schema version for the emitted JSON documents.
+SCHEMA_VERSION = 1
+
+
+def _r(v: float) -> float:
+    rounded = round(v, ROUND_DECIMALS)
+    # Avoid -0.0 vs 0.0 diffs between engines.
+    return 0.0 if rounded == 0 else rounded
+
+
+def bbox(vertices: list[float]) -> dict:
+    """Axis-aligned bounding box {min: [x,y,z], max: [x,y,z]} of a flat
+    vertex list, rounded. Raises ValueError on an empty list."""
+    if not vertices:
+        raise ValueError("bbox of empty vertex list")
+    xs = vertices[0::3]
+    ys = vertices[1::3]
+    zs = vertices[2::3]
+    return {
+        "min": [_r(min(xs)), _r(min(ys)), _r(min(zs))],
+        "max": [_r(max(xs)), _r(max(ys)), _r(max(zs))],
+    }
+
+
+def tri_count(faces: list[int]) -> int:
+    return len(faces) // 3
+
+
+def vertex_count(vertices: list[float]) -> int:
+    return len(vertices) // 3
+
+
+def signed_volume(vertices: list[float], faces: list[int]) -> float:
+    """Signed volume via the divergence theorem (sum of signed tetrahedra
+    against the origin). Only meaningful for closed meshes; the comparator
+    takes abs() and applies a relative tolerance, and skips it when either
+    side marks the mesh open."""
+    total = 0.0
+    for i in range(0, len(faces) - 2, 3):
+        a, b, c = faces[i] * 3, faces[i + 1] * 3, faces[i + 2] * 3
+        ax, ay, az = vertices[a], vertices[a + 1], vertices[a + 2]
+        bx, by, bz = vertices[b], vertices[b + 1], vertices[b + 2]
+        cx, cy, cz = vertices[c], vertices[c + 1], vertices[c + 2]
+        total += (
+            ax * (by * cz - bz * cy)
+            - ay * (bx * cz - bz * cx)
+            + az * (bx * cy - by * cx)
+        )
+    return total / 6.0
+
+
+def is_closed(faces: list[int]) -> bool:
+    """True when every edge is shared by exactly two triangles (watertight),
+    counting undirected edges."""
+    from collections import Counter
+
+    edges: Counter = Counter()
+    for i in range(0, len(faces) - 2, 3):
+        tri = (faces[i], faces[i + 1], faces[i + 2])
+        for e in ((tri[0], tri[1]), (tri[1], tri[2]), (tri[2], tri[0])):
+            edges[tuple(sorted(e))] += 1
+    return bool(edges) and all(n == 2 for n in edges.values())
+
+
+def element_record(express_id: int, ifc_type: str, vertices: list[float], faces: list[int]) -> dict:
+    """The canonical per-element record both dumpers emit for an element the
+    engine processed successfully."""
+    closed = is_closed(faces)
+    return {
+        "express_id": express_id,
+        "ifc_type": ifc_type,
+        "status": "ok",
+        "bbox": bbox(vertices),
+        "vertex_count": vertex_count(vertices),
+        "tri_count": tri_count(faces),
+        "volume": _r(abs(signed_volume(vertices, faces))) if closed else None,
+        "closed": closed,
+    }
+
+
+def skip_record(express_id: int, ifc_type: str, reason: str) -> dict:
+    """First-class 'the engine could not process this element' outcome."""
+    return {
+        "express_id": express_id,
+        "ifc_type": ifc_type,
+        "status": f"skip:{reason}",
+        "bbox": None,
+        "vertex_count": 0,
+        "tri_count": 0,
+        "volume": None,
+        "closed": False,
+    }
+
+
+def document(fixture: str, sha256: str, engine: str, settings: dict, elements: list[dict]) -> dict:
+    """One JSON document per fixture, elements sorted by express id."""
+    return {
+        "version": SCHEMA_VERSION,
+        "fixture": fixture,
+        "sha256": sha256,
+        "engine": engine,
+        "settings": settings,
+        "elements": sorted(elements, key=lambda e: e["express_id"]),
+    }

--- a/tools/ifcopenshell_reference/compare.py
+++ b/tools/ifcopenshell_reference/compare.py
@@ -101,7 +101,19 @@ def classify(ref: dict | None, lite: dict | None) -> tuple[str, list[str], list[
     elif (ref.get("closed") and ref.get("volume") and not ref_vol_ok) or (
         lite.get("closed") and lite.get("volume") and not lite_vol_ok
     ):
+        # A reported volume exceeding its own bbox volume is a mixed-winding
+        # artifact - that side's figure is not evidence of anything.
         advisory.append("volume-unverifiable")
+    elif ref_vol_ok != lite_vol_ok:
+        # Exactly one side has usable volume evidence (closed vs open).
+        # GATING here would turn the calibrated welding-topology asymmetry
+        # (duplex: 200+ healthy elements where ifc-lite's edge-pairing reports
+        # open while the reference is closed) permanently red, so it stays
+        # advisory - but it is the harness's known blind spot: an interior
+        # regression that keeps the bbox and only breaks the volume-less side
+        # is not gated at the stats level. The nightly report surfaces these
+        # rows for review; topology-level comparison is the planned later phase.
+        advisory.append("volume-one-sided")
     return ("MISMATCH" if failing else "MATCH"), failing, advisory
 
 

--- a/tools/ifcopenshell_reference/compare.py
+++ b/tools/ifcopenshell_reference/compare.py
@@ -28,9 +28,11 @@ gates, topology is advisory.
                    cut faces by design. A dropped feature shows up in bbox or
                    volume; triangle counts alone would keep the gate
                    permanently red over healthy divergence.
-    vertex_count   ADVISORY: welding topology differs legitimately (duplex
-                   #6426: identical bbox + tri_count, 56 vs 48 welded verts);
-                   `closed` likewise (edge-pairing follows the welding).
+    vertex_count   NOT EVALUATED: carried in the dumps for human diffing
+                   only - welding topology differs legitimately (duplex #6426:
+                   identical bbox + tri_count, 56 vs 48 welded verts), so
+                   classify() neither gates nor flags it; `closed` likewise
+                   feeds only the volume-usability checks above.
 
 An allowlisted MISMATCH/REFERENCE_ONLY is reported but does not fail, so
 every accepted divergence is a reviewed, diffable decision. Exit code is

--- a/tools/ifcopenshell_reference/compare.py
+++ b/tools/ifcopenshell_reference/compare.py
@@ -1,0 +1,193 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Join a reference dump against an ifc-lite dump and classify every element.
+
+Usage:
+    python compare.py --reference ref.json --ifclite lite.json \
+        [--allowlist allowlist.json] [--report out.json]
+
+Classes:
+    MATCH           both ok, all gated stats within tolerance
+    MISMATCH        both ok, a gated stat out of tolerance      -> fails
+    IFCLITE_ONLY    ifc-lite produced geometry, reference skipped
+    REFERENCE_ONLY  reference produced geometry, ifc-lite skipped -> fails
+    BOTH_SKIP       agreement on no-geometry
+
+Gating policy (calibrated against the previously hand-baked constants in
+door_window_calibration_regression.rs AND a full duplex run): METRIC truth
+gates, topology is advisory.
+    bbox min/max   GATED, within 1 mm per axis
+    volume         GATED, relative 1%, only when BOTH sides are closed
+    tri_count      ADVISORY (flagged in the report beyond a 50%/16-triangle
+                   band, never failing): the engines legitimately triangulate
+                   identical solids at different densities - duplex wall #5448
+                   is 92 vs 308 triangles with the SAME 1 mm bbox and volumes
+                   agreeing to 0.001%, and exact-CSG retriangulation densifies
+                   cut faces by design. A dropped feature shows up in bbox or
+                   volume; triangle counts alone would keep the gate
+                   permanently red over healthy divergence.
+    vertex_count   ADVISORY: welding topology differs legitimately (duplex
+                   #6426: identical bbox + tri_count, 56 vs 48 welded verts);
+                   `closed` likewise (edge-pairing follows the welding).
+
+An allowlisted MISMATCH/REFERENCE_ONLY is reported but does not fail, so
+every accepted divergence is a reviewed, diffable decision. Exit code is
+non-zero iff a non-allowlisted MISMATCH or REFERENCE_ONLY exists.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+BBOX_TOL_M = 0.001
+VOLUME_REL_TOL = 0.01
+TRI_REL_TOL = 0.5
+TRI_ABS_SLACK = 16
+
+
+def load(path: Path) -> dict:
+    doc = json.loads(path.read_text())
+    return {e["express_id"]: e for e in doc["elements"]}, doc
+
+
+def bbox_close(a: dict, b: dict) -> bool:
+    return all(
+        abs(a[k][i] - b[k][i]) <= BBOX_TOL_M for k in ("min", "max") for i in range(3)
+    )
+
+
+def classify(ref: dict | None, lite: dict | None) -> tuple[str, list[str], list[str]]:
+    """Return (class, failing stats, advisory stats)."""
+    ref_ok = ref is not None and ref["status"] == "ok"
+    lite_ok = lite is not None and lite["status"] == "ok"
+    if not ref_ok and not lite_ok:
+        return "BOTH_SKIP", [], []
+    if ref_ok and not lite_ok:
+        return "REFERENCE_ONLY", [], []
+    if lite_ok and not ref_ok:
+        return "IFCLITE_ONLY", [], []
+
+    failing: list[str] = []
+    advisory: list[str] = []
+    if not bbox_close(ref["bbox"], lite["bbox"]):
+        failing.append("bbox")
+    tri_delta = abs(ref["tri_count"] - lite["tri_count"])
+    tri_band = max(TRI_ABS_SLACK, int(ref["tri_count"] * TRI_REL_TOL))
+    if tri_delta > tri_band:
+        advisory.append("tri_count")
+    # A mesh's true volume cannot exceed its bbox volume; a side that reports
+    # more has mixed triangle winding poisoning the signed-tetra sum (seen on
+    # duplex IfcCoverings: reference 6.34 m3 inside a 0.18 m3 bbox while
+    # ifc-lite matched the analytic slab volume). Such a side's volume is
+    # unusable evidence, so the gate is skipped and flagged advisory.
+    def usable_volume(e: dict) -> bool:
+        if not (e.get("closed") and e.get("volume")):
+            return False
+        ext = [e["bbox"]["max"][i] - e["bbox"]["min"][i] for i in range(3)]
+        bbox_vol = ext[0] * ext[1] * ext[2]
+        return bbox_vol > 0 and e["volume"] <= bbox_vol * 1.001
+
+    ref_vol_ok = usable_volume(ref)
+    lite_vol_ok = usable_volume(lite)
+    if ref_vol_ok and lite_vol_ok:
+        rv, lv = ref["volume"], lite["volume"]
+        if rv > 0 and abs(rv - lv) / rv > VOLUME_REL_TOL:
+            failing.append("volume")
+    elif (ref.get("closed") and ref.get("volume") and not ref_vol_ok) or (
+        lite.get("closed") and lite.get("volume") and not lite_vol_ok
+    ):
+        advisory.append("volume-unverifiable")
+    return ("MISMATCH" if failing else "MATCH"), failing, advisory
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--reference", type=Path, required=True)
+    ap.add_argument("--ifclite", type=Path, required=True)
+    ap.add_argument("--allowlist", type=Path)
+    ap.add_argument("--report", type=Path)
+    ap.add_argument("--top", type=int, default=10, help="mismatches to print")
+    args = ap.parse_args()
+
+    ref_by_id, ref_doc = load(args.reference)
+    lite_by_id, lite_doc = load(args.ifclite)
+    if ref_doc["sha256"] != lite_doc["sha256"]:
+        print(
+            f"FATAL: dumps are from different fixture bytes "
+            f"({ref_doc['sha256'][:12]} vs {lite_doc['sha256'][:12]})"
+        )
+        return 2
+
+    # Allowlist: {"<fixture>": {"<express_id>": "reason", "type:<IfcType>": "reason"}}
+    allow: dict = {}
+    if args.allowlist and args.allowlist.exists():
+        allow = json.loads(args.allowlist.read_text()).get(ref_doc["fixture"], {})
+
+    def allowed(eid: int, ifc_type: str) -> str | None:
+        return allow.get(str(eid)) or allow.get(f"type:{ifc_type}")
+
+    counts: dict[str, int] = {}
+    failures: list[dict] = []
+    allowed_divergences: list[dict] = []
+    rows: list[dict] = []
+    for eid in sorted(set(ref_by_id) | set(lite_by_id)):
+        ref, lite = ref_by_id.get(eid), lite_by_id.get(eid)
+        cls, failing, advisory = classify(ref, lite)
+        counts[cls] = counts.get(cls, 0) + 1
+        if advisory:
+            counts["advisory"] = counts.get("advisory", 0) + 1
+        ifc_type = (ref or lite)["ifc_type"]
+        row = {
+            "express_id": eid,
+            "ifc_type": ifc_type,
+            "class": cls,
+            "failing": failing,
+            "advisory": advisory,
+        }
+        rows.append(row)
+        if cls in ("MISMATCH", "REFERENCE_ONLY"):
+            reason = allowed(eid, ifc_type)
+            if reason:
+                allowed_divergences.append({**row, "allowlisted": reason})
+            else:
+                failures.append(row)
+
+    print(f"fixture: {ref_doc['fixture']} ({ref_doc['engine']} vs {lite_doc['engine']})")
+    for cls in ("MATCH", "MISMATCH", "IFCLITE_ONLY", "REFERENCE_ONLY", "BOTH_SKIP"):
+        if counts.get(cls):
+            print(f"  {cls:<15} {counts[cls]}")
+    if counts.get("advisory"):
+        print(f"  advisory        {counts['advisory']} (tri_count density; see report)")
+    if allowed_divergences:
+        print(f"  allowlisted     {len(allowed_divergences)}")
+    for f in failures[: args.top]:
+        print(f"  FAIL #{f['express_id']} {f['ifc_type']}: {', '.join(f['failing']) or f['class']}")
+    if len(failures) > args.top:
+        print(f"  ... and {len(failures) - args.top} more failures")
+
+    if args.report:
+        args.report.write_text(
+            json.dumps(
+                {
+                    "fixture": ref_doc["fixture"],
+                    "counts": counts,
+                    "failures": failures,
+                    "allowlisted": allowed_divergences,
+                    "elements": rows,
+                },
+                indent=1,
+                sort_keys=True,
+            )
+            + "\n"
+        )
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/ifcopenshell_reference/dump_ifclite.py
+++ b/tools/ifcopenshell_reference/dump_ifclite.py
@@ -1,0 +1,74 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Dump canonical per-element geometry stats from ifc-lite.
+
+Usage:
+    python dump_ifclite.py <model.ifc> [...] --out-dir out/
+
+Uses the shipped ``ifclite_geom`` Python binding, whose
+``geometry_data_buffers`` already returns per-STEP-id WELDED, absolute-world,
+Z-up metres - apples-to-apples with the reference engine's world-coords +
+weld-vertices settings by construction, requiring zero new kernel code. All
+stats come from the SAME canonical.py functions as the reference side.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import struct
+import sys
+from pathlib import Path
+
+import ifclite_geom
+
+import canonical
+
+
+def dump_model(path: Path) -> dict:
+    data = path.read_bytes()
+    doc = ifclite_geom.geometry_data_buffers(data)
+    elements = []
+    for step_id, el in doc["elements"].items():
+        express_id = int(step_id)
+        ifc_type = str(el.get("ifc_type", ""))
+        vbytes = el["vertices"]
+        fbytes = el["faces"]
+        verts = list(struct.unpack(f"<{len(vbytes) // 8}d", vbytes))
+        faces = list(struct.unpack(f"<{len(fbytes) // 4}I", fbytes))
+        if not verts or not faces:
+            elements.append(canonical.skip_record(express_id, ifc_type, "empty-geometry"))
+            continue
+        elements.append(canonical.element_record(express_id, ifc_type, verts, faces))
+
+    sha = hashlib.sha256(data).hexdigest()
+    return canonical.document(
+        fixture=path.name,
+        sha256=sha,
+        engine=f"ifclite_geom {getattr(ifclite_geom, '__version__', 'unknown')}",
+        settings={"welded": True, "world_coords": True, "frame": "z-up-metres"},
+        elements=elements,
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("models", nargs="+", type=Path)
+    ap.add_argument("--out-dir", type=Path, required=True)
+    args = ap.parse_args()
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    for path in args.models:
+        doc = dump_model(path)
+        out = args.out_dir / (path.stem + ".ifclite.json")
+        out.write_text(json.dumps(doc, indent=1, sort_keys=True) + "\n")
+        ok = sum(1 for e in doc["elements"] if e["status"] == "ok")
+        print(f"{path.name}: {ok} ok, {len(doc['elements']) - ok} skipped -> {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/ifcopenshell_reference/dump_reference.py
+++ b/tools/ifcopenshell_reference/dump_reference.py
@@ -1,0 +1,85 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Dump canonical per-element geometry stats from the PINNED reference engine.
+
+Usage:
+    python dump_reference.py <model.ifc> [<model2.ifc> ...] --out-dir reference/
+
+Geometry settings match the provenance of the previously hand-transcribed
+constants (rust/geometry/tests/door_window_calibration_regression.rs):
+world coordinates ON and vertex welding ON, so bboxes/counts are directly
+comparable. Elements the engine cannot process become first-class
+``skip:<reason>`` records, not silent absences.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import ifcopenshell
+import ifcopenshell.geom
+
+import canonical
+
+
+def dump_model(path: Path) -> dict:
+    settings = ifcopenshell.geom.settings()
+    settings.set(settings.USE_WORLD_COORDS, True)
+    settings.set(settings.WELD_VERTICES, True)
+
+    model = ifcopenshell.open(str(path))
+    elements = []
+    for product in model.by_type("IfcProduct"):
+        if not getattr(product, "Representation", None):
+            continue
+        try:
+            shape = ifcopenshell.geom.create_shape(settings, product)
+            verts = list(shape.geometry.verts)
+            faces = list(shape.geometry.faces)
+            if not verts or not faces:
+                elements.append(
+                    canonical.skip_record(product.id(), product.is_a(), "empty-geometry")
+                )
+                continue
+            elements.append(
+                canonical.element_record(product.id(), product.is_a(), verts, faces)
+            )
+        except Exception as exc:  # noqa: BLE001 - the failure IS the datum
+            reason = type(exc).__name__
+            elements.append(canonical.skip_record(product.id(), product.is_a(), reason))
+
+    sha = hashlib.sha256(path.read_bytes()).hexdigest()
+    return canonical.document(
+        fixture=path.name,
+        sha256=sha,
+        engine=f"ifcopenshell {ifcopenshell.version}",
+        settings={"use_world_coords": True, "weld_vertices": True},
+        elements=elements,
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("models", nargs="+", type=Path)
+    ap.add_argument("--out-dir", type=Path, required=True)
+    args = ap.parse_args()
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    for path in args.models:
+        doc = dump_model(path)
+        out = args.out_dir / (path.stem + ".reference.json")
+        out.write_text(json.dumps(doc, indent=1, sort_keys=True) + "\n")
+        ok = sum(1 for e in doc["elements"] if e["status"] == "ok")
+        skipped = len(doc["elements"]) - ok
+        print(f"{path.name}: {ok} ok, {skipped} skipped -> {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/ifcopenshell_reference/reference/1019-column.reference.json
+++ b/tools/ifcopenshell_reference/reference/1019-column.reference.json
@@ -1,0 +1,33 @@
+{
+ "elements": [
+  {
+   "bbox": {
+    "max": [
+     2.261907,
+     -21.030785,
+     4.0
+    ],
+    "min": [
+     1.55316,
+     -21.740059,
+     -0.599998
+    ]
+   },
+   "closed": true,
+   "express_id": 126,
+   "ifc_type": "IfcColumn",
+   "status": "ok",
+   "tri_count": 60,
+   "vertex_count": 32,
+   "volume": 1.616351
+  }
+ ],
+ "engine": "ifcopenshell 0.8.2",
+ "fixture": "1019-column.ifc",
+ "settings": {
+  "use_world_coords": true,
+  "weld_vertices": true
+ },
+ "sha256": "c5ee15218372a75a061070dbee5242eb8aa5dd0cefc5b765d048722ea5e996ee",
+ "version": 1
+}

--- a/tools/ifcopenshell_reference/reference/1030-sphere.reference.json
+++ b/tools/ifcopenshell_reference/reference/1030-sphere.reference.json
@@ -1,0 +1,22 @@
+{
+ "elements": [
+  {
+   "bbox": null,
+   "closed": false,
+   "express_id": 27,
+   "ifc_type": "IfcProxy",
+   "status": "skip:RuntimeError",
+   "tri_count": 0,
+   "vertex_count": 0,
+   "volume": null
+  }
+ ],
+ "engine": "ifcopenshell 0.8.2",
+ "fixture": "1030-sphere.ifc",
+ "settings": {
+  "use_world_coords": true,
+  "weld_vertices": true
+ },
+ "sha256": "0e1233abe55e091da29b4c7abad7895cda31df11a73e64a15d42bb5d2e02a2ab",
+ "version": 1
+}

--- a/tools/ifcopenshell_reference/reference/IfcOpenHouse_IFC4.reference.json
+++ b/tools/ifcopenshell_reference/reference/IfcOpenHouse_IFC4.reference.json
@@ -1,0 +1,831 @@
+{
+ "elements": [
+  {
+   "bbox": {
+    "max": [
+     10.0,
+     10.0,
+     -0.1609
+    ],
+    "min": [
+     -10.0,
+     -10.0,
+     -8.13
+    ]
+   },
+   "closed": false,
+   "express_id": 24,
+   "ifc_type": "IfcSite",
+   "status": "ok",
+   "tri_count": 570,
+   "vertex_count": 299,
+   "volume": null
+  },
+  {
+   "bbox": {
+    "max": [
+     5.0,
+     0.18,
+     3.0
+    ],
+    "min": [
+     -5.0,
+     -0.18,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 40,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 48,
+   "vertex_count": 24,
+   "volume": 6.56064
+  },
+  {
+   "bbox": {
+    "max": [
+     5.05,
+     5.23,
+     0.0
+    ],
+    "min": [
+     -5.05,
+     -0.23,
+     -2.0
+    ]
+   },
+   "closed": true,
+   "express_id": 72,
+   "ifc_type": "IfcFooting",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 110.292
+  },
+  {
+   "bbox": {
+    "max": [
+     0.5,
+     1.815,
+     2.0
+    ],
+    "min": [
+     -5.5,
+     -1.815,
+     0.4
+    ]
+   },
+   "closed": true,
+   "express_id": 119,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 34.848
+  },
+  {
+   "bbox": {
+    "max": [
+     3.93,
+     1.5,
+     2.0
+    ],
+    "min": [
+     2.07,
+     -1.5,
+     0.4
+    ]
+   },
+   "closed": true,
+   "express_id": 141,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 8.928
+  },
+  {
+   "bbox": {
+    "max": [
+     5.1,
+     2.5,
+     5.78
+    ],
+    "min": [
+     -5.1,
+     -0.4,
+     2.52
+    ]
+   },
+   "closed": true,
+   "express_id": 189,
+   "ifc_type": "IfcSlab",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 10.648802
+  },
+  {
+   "bbox": {
+    "max": [
+     5.1,
+     5.4,
+     5.78
+    ],
+    "min": [
+     -5.1,
+     2.5,
+     2.52
+    ]
+   },
+   "closed": true,
+   "express_id": 190,
+   "ifc_type": "IfcSlab",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 10.648802
+  },
+  {
+   "bbox": {
+    "max": [
+     5.0,
+     5.18,
+     3.0
+    ],
+    "min": [
+     -5.0,
+     4.82,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 221,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 10.8
+  },
+  {
+   "bbox": {
+    "max": [
+     5.0,
+     5.0,
+     5.5
+    ],
+    "min": [
+     4.64,
+     0.0,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 268,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 32,
+   "vertex_count": 18,
+   "volume": 6.858
+  },
+  {
+   "bbox": {
+    "max": [
+     -4.64,
+     5.0,
+     5.5
+    ],
+    "min": [
+     -5.0,
+     0.0,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 281,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 32,
+   "vertex_count": 18,
+   "volume": 6.60456
+  },
+  {
+   "bbox": {
+    "max": [
+     0.5,
+     1.815,
+     2.0
+    ],
+    "min": [
+     -5.5,
+     -1.815,
+     0.4
+    ]
+   },
+   "closed": true,
+   "express_id": 311,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 34.848
+  },
+  {
+   "bbox": {
+    "max": [
+     5.55,
+     2.2,
+     0.0
+    ],
+    "min": [
+     5.05,
+     1.0,
+     -0.4
+    ]
+   },
+   "closed": true,
+   "express_id": 2357,
+   "ifc_type": "IfcStairFlight",
+   "status": "ok",
+   "tri_count": 20,
+   "vertex_count": 12,
+   "volume": 0.18
+  },
+  {
+   "bbox": {
+    "max": [
+     5.32,
+     2.1,
+     2.2
+    ],
+    "min": [
+     4.32,
+     1.1,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 2380,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 2.2
+  },
+  {
+   "bbox": {
+    "max": [
+     4.84,
+     2.1,
+     2.2
+    ],
+    "min": [
+     4.76,
+     1.1,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 2441,
+   "ifc_type": "IfcDoor",
+   "status": "ok",
+   "tri_count": 48,
+   "vertex_count": 32,
+   "volume": 0.088232
+  },
+  {
+   "bbox": {
+    "max": [
+     -3.04,
+     0.045,
+     0.49
+    ],
+    "min": [
+     -4.9,
+     -0.045,
+     0.4
+    ]
+   },
+   "closed": true,
+   "express_id": 2543,
+   "ifc_type": "IfcMember",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.015066
+  },
+  {
+   "bbox": {
+    "max": [
+     -3.04,
+     0.045,
+     2.0
+    ],
+    "min": [
+     -4.9,
+     -0.045,
+     1.91
+    ]
+   },
+   "closed": true,
+   "express_id": 2549,
+   "ifc_type": "IfcMember",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.015066
+  },
+  {
+   "bbox": {
+    "max": [
+     -4.81,
+     0.045,
+     1.91
+    ],
+    "min": [
+     -4.9,
+     -0.045,
+     0.49
+    ]
+   },
+   "closed": true,
+   "express_id": 2560,
+   "ifc_type": "IfcMember",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.011502
+  },
+  {
+   "bbox": {
+    "max": [
+     -3.04,
+     0.045,
+     1.91
+    ],
+    "min": [
+     -3.13,
+     -0.045,
+     0.49
+    ]
+   },
+   "closed": true,
+   "express_id": 2566,
+   "ifc_type": "IfcMember",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.011502
+  },
+  {
+   "bbox": {
+    "max": [
+     -3.13,
+     0.005,
+     1.91
+    ],
+    "min": [
+     -4.81,
+     -0.005,
+     0.49
+    ]
+   },
+   "closed": true,
+   "express_id": 2587,
+   "ifc_type": "IfcPlate",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.023856
+  },
+  {
+   "bbox": {
+    "max": [
+     -1.27,
+     0.045,
+     0.49
+    ],
+    "min": [
+     -3.13,
+     -0.045,
+     0.4
+    ]
+   },
+   "closed": true,
+   "express_id": 2621,
+   "ifc_type": "IfcMember",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.015066
+  },
+  {
+   "bbox": {
+    "max": [
+     -1.27,
+     0.045,
+     2.0
+    ],
+    "min": [
+     -3.13,
+     -0.045,
+     1.91
+    ]
+   },
+   "closed": true,
+   "express_id": 2627,
+   "ifc_type": "IfcMember",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.015066
+  },
+  {
+   "bbox": {
+    "max": [
+     -3.04,
+     0.045,
+     1.91
+    ],
+    "min": [
+     -3.13,
+     -0.045,
+     0.49
+    ]
+   },
+   "closed": true,
+   "express_id": 2633,
+   "ifc_type": "IfcMember",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.011502
+  },
+  {
+   "bbox": {
+    "max": [
+     -1.27,
+     0.045,
+     1.91
+    ],
+    "min": [
+     -1.36,
+     -0.045,
+     0.49
+    ]
+   },
+   "closed": true,
+   "express_id": 2639,
+   "ifc_type": "IfcMember",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.011502
+  },
+  {
+   "bbox": {
+    "max": [
+     -1.36,
+     0.005,
+     1.91
+    ],
+    "min": [
+     -3.04,
+     -0.005,
+     0.49
+    ]
+   },
+   "closed": true,
+   "express_id": 2660,
+   "ifc_type": "IfcPlate",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.023856
+  },
+  {
+   "bbox": {
+    "max": [
+     0.5,
+     0.045,
+     0.49
+    ],
+    "min": [
+     -1.36,
+     -0.045,
+     0.4
+    ]
+   },
+   "closed": true,
+   "express_id": 2694,
+   "ifc_type": "IfcMember",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.015066
+  },
+  {
+   "bbox": {
+    "max": [
+     0.5,
+     0.045,
+     2.0
+    ],
+    "min": [
+     -1.36,
+     -0.045,
+     1.91
+    ]
+   },
+   "closed": true,
+   "express_id": 2700,
+   "ifc_type": "IfcMember",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.015066
+  },
+  {
+   "bbox": {
+    "max": [
+     -1.27,
+     0.045,
+     1.91
+    ],
+    "min": [
+     -1.36,
+     -0.045,
+     0.49
+    ]
+   },
+   "closed": true,
+   "express_id": 2706,
+   "ifc_type": "IfcMember",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.011502
+  },
+  {
+   "bbox": {
+    "max": [
+     0.5,
+     0.045,
+     1.91
+    ],
+    "min": [
+     0.41,
+     -0.045,
+     0.49
+    ]
+   },
+   "closed": true,
+   "express_id": 2712,
+   "ifc_type": "IfcMember",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.011502
+  },
+  {
+   "bbox": {
+    "max": [
+     0.41,
+     0.005,
+     1.91
+    ],
+    "min": [
+     -1.27,
+     -0.005,
+     0.49
+    ]
+   },
+   "closed": true,
+   "express_id": 2733,
+   "ifc_type": "IfcPlate",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.023856
+  },
+  {
+   "bbox": {
+    "max": [
+     3.93,
+     0.045,
+     0.49
+    ],
+    "min": [
+     2.07,
+     -0.045,
+     0.4
+    ]
+   },
+   "closed": true,
+   "express_id": 2767,
+   "ifc_type": "IfcMember",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.015066
+  },
+  {
+   "bbox": {
+    "max": [
+     3.93,
+     0.045,
+     2.0
+    ],
+    "min": [
+     2.07,
+     -0.045,
+     1.91
+    ]
+   },
+   "closed": true,
+   "express_id": 2773,
+   "ifc_type": "IfcMember",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.015066
+  },
+  {
+   "bbox": {
+    "max": [
+     2.16,
+     0.045,
+     1.91
+    ],
+    "min": [
+     2.07,
+     -0.045,
+     0.49
+    ]
+   },
+   "closed": true,
+   "express_id": 2779,
+   "ifc_type": "IfcMember",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.011502
+  },
+  {
+   "bbox": {
+    "max": [
+     3.93,
+     0.045,
+     1.91
+    ],
+    "min": [
+     3.84,
+     -0.045,
+     0.49
+    ]
+   },
+   "closed": true,
+   "express_id": 2785,
+   "ifc_type": "IfcMember",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.011502
+  },
+  {
+   "bbox": {
+    "max": [
+     3.84,
+     0.005,
+     1.91
+    ],
+    "min": [
+     2.16,
+     -0.005,
+     0.49
+    ]
+   },
+   "closed": true,
+   "express_id": 2806,
+   "ifc_type": "IfcPlate",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.023856
+  },
+  {
+   "bbox": {
+    "max": [
+     -4.81,
+     1.815,
+     0.49
+    ],
+    "min": [
+     -4.9,
+     -0.045,
+     0.4
+    ]
+   },
+   "closed": true,
+   "express_id": 2840,
+   "ifc_type": "IfcMember",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.015066
+  },
+  {
+   "bbox": {
+    "max": [
+     -4.81,
+     1.815,
+     2.0
+    ],
+    "min": [
+     -4.9,
+     -0.045,
+     1.91
+    ]
+   },
+   "closed": true,
+   "express_id": 2846,
+   "ifc_type": "IfcMember",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.015066
+  },
+  {
+   "bbox": {
+    "max": [
+     -4.81,
+     0.045,
+     1.91
+    ],
+    "min": [
+     -4.9,
+     -0.045,
+     0.49
+    ]
+   },
+   "closed": true,
+   "express_id": 2852,
+   "ifc_type": "IfcMember",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.011502
+  },
+  {
+   "bbox": {
+    "max": [
+     -4.81,
+     1.815,
+     1.91
+    ],
+    "min": [
+     -4.9,
+     1.725,
+     0.49
+    ]
+   },
+   "closed": true,
+   "express_id": 2858,
+   "ifc_type": "IfcMember",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.011502
+  },
+  {
+   "bbox": {
+    "max": [
+     -4.85,
+     1.725,
+     1.91
+    ],
+    "min": [
+     -4.86,
+     0.045,
+     0.49
+    ]
+   },
+   "closed": true,
+   "express_id": 2879,
+   "ifc_type": "IfcPlate",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.023856
+  }
+ ],
+ "engine": "ifcopenshell 0.8.2",
+ "fixture": "IfcOpenHouse_IFC4.ifc",
+ "settings": {
+  "use_world_coords": true,
+  "weld_vertices": true
+ },
+ "sha256": "71c9466bf02306be58d45b77d738541a0e7410767960b5eed1cf85737dfa34c9",
+ "version": 1
+}

--- a/tools/ifcopenshell_reference/reference/bath_csg_solid.reference.json
+++ b/tools/ifcopenshell_reference/reference/bath_csg_solid.reference.json
@@ -1,0 +1,33 @@
+{
+ "elements": [
+  {
+   "bbox": {
+    "max": [
+     2.0,
+     0.8,
+     0.8
+    ],
+    "min": [
+     0.0,
+     0.0,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 225,
+   "ifc_type": "IfcSanitaryTerminal",
+   "status": "ok",
+   "tri_count": 220,
+   "vertex_count": 112,
+   "volume": 0.548286
+  }
+ ],
+ "engine": "ifcopenshell 0.8.2",
+ "fixture": "bath_csg_solid.ifc",
+ "settings": {
+  "use_world_coords": true,
+  "weld_vertices": true
+ },
+ "sha256": "950424788ef247ebde29026d3a103cd59bb971eee697175bfdd4277f61a4d2e3",
+ "version": 1
+}

--- a/tools/ifcopenshell_reference/reference/duplex.reference.json
+++ b/tools/ifcopenshell_reference/reference/duplex.reference.json
@@ -1,0 +1,6018 @@
+{
+ "elements": [
+  {
+   "bbox": {
+    "max": [
+     6.2,
+     -12.6,
+     2.6
+    ],
+    "min": [
+     0.417,
+     -17.383,
+     0.019
+    ]
+   },
+   "closed": true,
+   "express_id": 67,
+   "ifc_type": "IfcSpace",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 71.39069
+  },
+  {
+   "bbox": {
+    "max": [
+     6.226,
+     -10.37,
+     2.6
+    ],
+    "min": [
+     0.417,
+     -12.6,
+     0.013
+    ]
+   },
+   "closed": true,
+   "express_id": 212,
+   "ifc_type": "IfcSpace",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 33.512179
+  },
+  {
+   "bbox": {
+    "max": [
+     6.226,
+     -8.075,
+     2.6
+    ],
+    "min": [
+     4.77,
+     -10.246,
+     0.013
+    ]
+   },
+   "closed": true,
+   "express_id": 355,
+   "ifc_type": "IfcSpace",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 8.177445
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -8.075,
+     2.6
+    ],
+    "min": [
+     6.2,
+     -17.383,
+     0.019
+    ]
+   },
+   "closed": true,
+   "express_id": 514,
+   "ifc_type": "IfcSpace",
+   "status": "ok",
+   "tri_count": 60,
+   "vertex_count": 32,
+   "volume": 40.241254
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -6.25,
+     6.0
+    ],
+    "min": [
+     6.418,
+     -11.55,
+     3.119
+    ]
+   },
+   "closed": true,
+   "express_id": 819,
+   "ifc_type": "IfcSpace",
+   "status": "ok",
+   "tri_count": 60,
+   "vertex_count": 32,
+   "volume": 114.950038
+  },
+  {
+   "bbox": {
+    "max": [
+     6.294,
+     -7.845384,
+     5.7
+    ],
+    "min": [
+     4.77,
+     -10.95,
+     3.113
+    ]
+   },
+   "closed": true,
+   "express_id": 1059,
+   "ifc_type": "IfcSpace",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 12.240221
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -11.134,
+     5.7
+    ],
+    "min": [
+     4.675,
+     -17.383,
+     3.119
+    ]
+   },
+   "closed": true,
+   "express_id": 1218,
+   "ifc_type": "IfcSpace",
+   "status": "ok",
+   "tri_count": 36,
+   "vertex_count": 20,
+   "volume": 56.893582
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -0.417,
+     5.7
+    ],
+    "min": [
+     4.675,
+     -6.666,
+     3.119
+    ]
+   },
+   "closed": true,
+   "express_id": 1442,
+   "ifc_type": "IfcSpace",
+   "status": "ok",
+   "tri_count": 32,
+   "vertex_count": 18,
+   "volume": 56.893582
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -0.417,
+     2.6
+    ],
+    "min": [
+     2.6,
+     -5.2,
+     0.019
+    ]
+   },
+   "closed": true,
+   "express_id": 1627,
+   "ifc_type": "IfcSpace",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 71.39069
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -5.2,
+     2.6
+    ],
+    "min": [
+     2.574,
+     -7.43,
+     0.013
+    ]
+   },
+   "closed": true,
+   "express_id": 1782,
+   "ifc_type": "IfcSpace",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 33.512179
+  },
+  {
+   "bbox": {
+    "max": [
+     4.03,
+     -7.554,
+     2.6
+    ],
+    "min": [
+     2.574,
+     -9.725,
+     0.013
+    ]
+   },
+   "closed": true,
+   "express_id": 1928,
+   "ifc_type": "IfcSpace",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 8.177445
+  },
+  {
+   "bbox": {
+    "max": [
+     2.6,
+     -0.417,
+     2.6
+    ],
+    "min": [
+     0.417,
+     -9.725,
+     0.019
+    ]
+   },
+   "closed": true,
+   "express_id": 2108,
+   "ifc_type": "IfcSpace",
+   "status": "ok",
+   "tri_count": 60,
+   "vertex_count": 32,
+   "volume": 40.241254
+  },
+  {
+   "bbox": {
+    "max": [
+     2.382,
+     -6.25,
+     6.0
+    ],
+    "min": [
+     0.417,
+     -11.55,
+     3.119
+    ]
+   },
+   "closed": true,
+   "express_id": 2412,
+   "ifc_type": "IfcSpace",
+   "status": "ok",
+   "tri_count": 60,
+   "vertex_count": 32,
+   "volume": 71.776646
+  },
+  {
+   "bbox": {
+    "max": [
+     4.03,
+     -6.85,
+     5.7
+    ],
+    "min": [
+     2.506,
+     -9.970051,
+     3.113
+    ]
+   },
+   "closed": true,
+   "express_id": 2637,
+   "ifc_type": "IfcSpace",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 12.301076
+  },
+  {
+   "bbox": {
+    "max": [
+     4.125,
+     -0.417,
+     5.7
+    ],
+    "min": [
+     0.417,
+     -6.666,
+     3.119
+    ]
+   },
+   "closed": true,
+   "express_id": 2789,
+   "ifc_type": "IfcSpace",
+   "status": "ok",
+   "tri_count": 36,
+   "vertex_count": 20,
+   "volume": 56.893582
+  },
+  {
+   "bbox": {
+    "max": [
+     4.125,
+     -11.134,
+     5.7
+    ],
+    "min": [
+     0.417,
+     -17.383,
+     3.119
+    ]
+   },
+   "closed": true,
+   "express_id": 3013,
+   "ifc_type": "IfcSpace",
+   "status": "ok",
+   "tri_count": 32,
+   "vertex_count": 18,
+   "volume": 56.893582
+  },
+  {
+   "bbox": {
+    "max": [
+     6.294,
+     -6.79,
+     5.7
+    ],
+    "min": [
+     4.77,
+     -7.721384,
+     3.113
+    ]
+   },
+   "closed": true,
+   "express_id": 3197,
+   "ifc_type": "IfcSpace",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 3.672064
+  },
+  {
+   "bbox": {
+    "max": [
+     4.03,
+     -10.094051,
+     5.7
+    ],
+    "min": [
+     2.506,
+     -11.01,
+     3.113
+    ]
+   },
+   "closed": true,
+   "express_id": 3325,
+   "ifc_type": "IfcSpace",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 3.611209
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -8.075,
+     5.7
+    ],
+    "min": [
+     7.3686,
+     -11.825,
+     0.019
+    ]
+   },
+   "closed": true,
+   "express_id": 3456,
+   "ifc_type": "IfcSpace",
+   "status": "ok",
+   "tri_count": 32,
+   "vertex_count": 18,
+   "volume": 20.796062
+  },
+  {
+   "bbox": {
+    "max": [
+     1.4314,
+     -5.975,
+     5.7
+    ],
+    "min": [
+     0.417,
+     -9.725,
+     0.019
+    ]
+   },
+   "closed": true,
+   "express_id": 3586,
+   "ifc_type": "IfcSpace",
+   "status": "ok",
+   "tri_count": 28,
+   "vertex_count": 16,
+   "volume": 20.796062
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -0.417,
+     9.0
+    ],
+    "min": [
+     0.417,
+     -17.383,
+     6.0
+    ]
+   },
+   "closed": true,
+   "express_id": 3707,
+   "ifc_type": "IfcSpace",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 405.453468
+  },
+  {
+   "bbox": {
+    "max": [
+     8.8,
+     0.0,
+     3.1
+    ],
+    "min": [
+     0.0,
+     -0.417,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 3797,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 48,
+   "vertex_count": 24,
+   "volume": 5.676137
+  },
+  {
+   "bbox": {
+    "max": [
+     8.8,
+     -0.417,
+     3.1
+    ],
+    "min": [
+     8.383,
+     -17.8,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 3999,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 48,
+   "vertex_count": 24,
+   "volume": 20.735242
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -17.383,
+     3.1
+    ],
+    "min": [
+     0.0,
+     -17.8,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 4043,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 48,
+   "vertex_count": 24,
+   "volume": 5.137081
+  },
+  {
+   "bbox": {
+    "max": [
+     0.417,
+     -0.417,
+     3.1
+    ],
+    "min": [
+     0.0,
+     -17.383,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 4087,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 48,
+   "vertex_count": 24,
+   "volume": 20.196186
+  },
+  {
+   "bbox": {
+    "max": [
+     2.6,
+     -0.417,
+     2.795
+    ],
+    "min": [
+     2.476,
+     -4.0,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 4131,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 1.241796
+  },
+  {
+   "bbox": {
+    "max": [
+     2.574,
+     -6.805,
+     2.795
+    ],
+    "min": [
+     2.45,
+     -9.725,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 4219,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 28,
+   "vertex_count": 16,
+   "volume": 0.820014
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -7.582,
+     2.795
+    ],
+    "min": [
+     4.182,
+     -8.075,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 4287,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 5.788705
+  },
+  {
+   "bbox": {
+    "max": [
+     4.618,
+     -9.725,
+     2.795
+    ],
+    "min": [
+     0.417,
+     -10.218,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 4399,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 5.788705
+  },
+  {
+   "bbox": {
+    "max": [
+     4.675,
+     -7.8,
+     2.795
+    ],
+    "min": [
+     4.125,
+     -10.0,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 4465,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 44,
+   "vertex_count": 24,
+   "volume": 2.856211
+  },
+  {
+   "bbox": {
+    "max": [
+     6.35,
+     -8.075,
+     2.795
+    ],
+    "min": [
+     6.226,
+     -10.995,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 4508,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 28,
+   "vertex_count": 16,
+   "volume": 0.820014
+  },
+  {
+   "bbox": {
+    "max": [
+     6.226,
+     -10.246,
+     2.795
+    ],
+    "min": [
+     4.77,
+     -10.37,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 4553,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.50462
+  },
+  {
+   "bbox": {
+    "max": [
+     6.324,
+     -13.8,
+     2.795
+    ],
+    "min": [
+     6.2,
+     -17.383,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 4598,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 1.241796
+  },
+  {
+   "bbox": {
+    "max": [
+     8.8,
+     0.0,
+     0.0
+    ],
+    "min": [
+     0.0,
+     -0.417,
+     -1.25
+    ]
+   },
+   "closed": true,
+   "express_id": 4643,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 4.587
+  },
+  {
+   "bbox": {
+    "max": [
+     8.8,
+     -0.417,
+     0.0
+    ],
+    "min": [
+     8.383,
+     -17.8,
+     -1.25
+    ]
+   },
+   "closed": true,
+   "express_id": 4818,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 9.060889
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -17.383,
+     0.0
+    ],
+    "min": [
+     0.0,
+     -17.8,
+     -1.25
+    ]
+   },
+   "closed": true,
+   "express_id": 4868,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 4.369639
+  },
+  {
+   "bbox": {
+    "max": [
+     0.417,
+     -0.417,
+     0.0
+    ],
+    "min": [
+     0.0,
+     -17.383,
+     -1.25
+    ]
+   },
+   "closed": true,
+   "express_id": 4918,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 8.843527
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -7.5825,
+     0.0
+    ],
+    "min": [
+     4.1825,
+     -8.0175,
+     -1.25
+    ]
+   },
+   "closed": true,
+   "express_id": 4968,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 2.284022
+  },
+  {
+   "bbox": {
+    "max": [
+     4.6175,
+     -9.7825,
+     0.0
+    ],
+    "min": [
+     0.417,
+     -10.2175,
+     -1.25
+    ]
+   },
+   "closed": true,
+   "express_id": 5057,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 2.284022
+  },
+  {
+   "bbox": {
+    "max": [
+     4.6175,
+     -8.0175,
+     -0.127
+    ],
+    "min": [
+     4.1825,
+     -9.7825,
+     -1.25
+    ]
+   },
+   "closed": true,
+   "express_id": 5106,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.862211
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -0.417,
+     0.0
+    ],
+    "min": [
+     0.417,
+     -9.725,
+     -0.127
+    ]
+   },
+   "closed": true,
+   "express_id": 5165,
+   "ifc_type": "IfcSlab",
+   "status": "ok",
+   "tri_count": 20,
+   "vertex_count": 12,
+   "volume": 8.227051
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -8.075,
+     0.0
+    ],
+    "min": [
+     0.417,
+     -17.383,
+     -0.127
+    ]
+   },
+   "closed": true,
+   "express_id": 5267,
+   "ifc_type": "IfcSlab",
+   "status": "ok",
+   "tri_count": 20,
+   "vertex_count": 12,
+   "volume": 8.243116
+  },
+  {
+   "bbox": {
+    "max": [
+     4.675,
+     -0.417,
+     6.0
+    ],
+    "min": [
+     4.125,
+     -17.383,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 5399,
+   "ifc_type": "IfcWall",
+   "status": "ok",
+   "tri_count": 76,
+   "vertex_count": 40,
+   "volume": 122.873944
+  },
+  {
+   "bbox": {
+    "max": [
+     8.8,
+     0.0,
+     6.0
+    ],
+    "min": [
+     0.0,
+     -0.417,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 5448,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 92,
+   "vertex_count": 40,
+   "volume": 6.545998
+  },
+  {
+   "bbox": {
+    "max": [
+     8.8,
+     0.0,
+     6.0
+    ],
+    "min": [
+     8.383,
+     -17.8,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 5498,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 112,
+   "vertex_count": 48,
+   "volume": 16.741648
+  },
+  {
+   "bbox": {
+    "max": [
+     8.8,
+     -17.383,
+     6.0
+    ],
+    "min": [
+     0.0,
+     -17.8,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 5548,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 92,
+   "vertex_count": 40,
+   "volume": 6.545998
+  },
+  {
+   "bbox": {
+    "max": [
+     0.417,
+     0.0,
+     6.0
+    ],
+    "min": [
+     0.0,
+     -17.8,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 5598,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 112,
+   "vertex_count": 48,
+   "volume": 16.741648
+  },
+  {
+   "bbox": {
+    "max": [
+     2.506,
+     -6.126,
+     6.0
+    ],
+    "min": [
+     0.417,
+     -6.25,
+     2.612
+    ]
+   },
+   "closed": true,
+   "express_id": 5642,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 32,
+   "vertex_count": 16,
+   "volume": 0.659914
+  },
+  {
+   "bbox": {
+    "max": [
+     2.506,
+     -6.25,
+     6.0
+    ],
+    "min": [
+     2.382,
+     -11.674,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 5687,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 28,
+   "vertex_count": 16,
+   "volume": 1.73277
+  },
+  {
+   "bbox": {
+    "max": [
+     2.382,
+     -11.55,
+     6.0
+    ],
+    "min": [
+     0.417,
+     -11.674,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 5731,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 28,
+   "vertex_count": 16,
+   "volume": 0.488914
+  },
+  {
+   "bbox": {
+    "max": [
+     4.125,
+     -6.666,
+     6.0
+    ],
+    "min": [
+     2.506,
+     -6.85,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 5775,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.863898
+  },
+  {
+   "bbox": {
+    "max": [
+     4.125,
+     -11.01,
+     6.0
+    ],
+    "min": [
+     2.506,
+     -11.134,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 5859,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.582192
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -11.55,
+     6.0
+    ],
+    "min": [
+     6.294,
+     -11.674,
+     2.612
+    ]
+   },
+   "closed": true,
+   "express_id": 5903,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 32,
+   "vertex_count": 16,
+   "volume": 0.659914
+  },
+  {
+   "bbox": {
+    "max": [
+     6.418,
+     -6.126,
+     6.0
+    ],
+    "min": [
+     6.294,
+     -11.55,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 5948,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 28,
+   "vertex_count": 16,
+   "volume": 1.73277
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -6.126,
+     6.0
+    ],
+    "min": [
+     6.418,
+     -6.25,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 5992,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 28,
+   "vertex_count": 16,
+   "volume": 0.488914
+  },
+  {
+   "bbox": {
+    "max": [
+     6.294,
+     -6.666,
+     6.0
+    ],
+    "min": [
+     4.675,
+     -6.79,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 6036,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.582192
+  },
+  {
+   "bbox": {
+    "max": [
+     6.294,
+     -10.95,
+     6.0
+    ],
+    "min": [
+     4.675,
+     -11.134,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 6080,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.863898
+  },
+  {
+   "bbox": {
+    "max": [
+     4.125,
+     -0.417,
+     3.1
+    ],
+    "min": [
+     0.417,
+     -17.383,
+     2.795
+    ]
+   },
+   "closed": true,
+   "express_id": 6132,
+   "ifc_type": "IfcSlab",
+   "status": "ok",
+   "tri_count": 28,
+   "vertex_count": 16,
+   "volume": 18.06485
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -0.417,
+     3.1
+    ],
+    "min": [
+     4.675,
+     -17.383,
+     2.795
+    ]
+   },
+   "closed": true,
+   "express_id": 6247,
+   "ifc_type": "IfcSlab",
+   "status": "ok",
+   "tri_count": 28,
+   "vertex_count": 16,
+   "volume": 18.096793
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     0.0,
+     2.52
+    ],
+    "min": [
+     3.548,
+     -0.417,
+     0.1
+    ]
+   },
+   "closed": true,
+   "express_id": 6293,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 4.879192
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     0.0,
+     2.52
+    ],
+    "min": [
+     3.548,
+     -0.417,
+     0.1
+    ]
+   },
+   "closed": true,
+   "express_id": 6426,
+   "ifc_type": "IfcWindow",
+   "status": "ok",
+   "tri_count": 108,
+   "vertex_count": 56,
+   "volume": 0.337282
+  },
+  {
+   "bbox": {
+    "max": [
+     5.252,
+     -17.383,
+     2.52
+    ],
+    "min": [
+     0.417,
+     -17.8,
+     0.1
+    ]
+   },
+   "closed": true,
+   "express_id": 6517,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 4.879192
+  },
+  {
+   "bbox": {
+    "max": [
+     5.252,
+     -17.383,
+     2.52
+    ],
+    "min": [
+     0.417,
+     -17.8,
+     0.1
+    ]
+   },
+   "closed": true,
+   "express_id": 6531,
+   "ifc_type": "IfcWindow",
+   "status": "ok",
+   "tri_count": 108,
+   "vertex_count": 56,
+   "volume": 0.337282
+  },
+  {
+   "bbox": {
+    "max": [
+     8.8,
+     -15.553,
+     2.01
+    ],
+    "min": [
+     8.383,
+     -16.803,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 6569,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 1.047713
+  },
+  {
+   "bbox": {
+    "max": [
+     8.825,
+     -15.477,
+     2.086
+    ],
+    "min": [
+     8.358,
+     -16.879,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 6652,
+   "ifc_type": "IfcDoor",
+   "status": "ok",
+   "tri_count": 68,
+   "vertex_count": 40,
+   "volume": 0.148741
+  },
+  {
+   "bbox": {
+    "max": [
+     0.417,
+     -0.997,
+     2.01
+    ],
+    "min": [
+     0.0,
+     -2.247,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 6743,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 1.047712
+  },
+  {
+   "bbox": {
+    "max": [
+     0.442,
+     -0.921,
+     2.086
+    ],
+    "min": [
+     -0.025,
+     -2.323,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 6757,
+   "ifc_type": "IfcDoor",
+   "status": "ok",
+   "tri_count": 68,
+   "vertex_count": 40,
+   "volume": 0.148741
+  },
+  {
+   "bbox": {
+    "max": [
+     8.8,
+     -5.195,
+     2.3
+    ],
+    "min": [
+     8.383,
+     -5.945,
+     0.1
+    ]
+   },
+   "closed": true,
+   "express_id": 6794,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.68805
+  },
+  {
+   "bbox": {
+    "max": [
+     8.8,
+     -5.195,
+     2.3
+    ],
+    "min": [
+     8.383,
+     -5.945,
+     0.1
+    ]
+   },
+   "closed": true,
+   "express_id": 6921,
+   "ifc_type": "IfcWindow",
+   "status": "ok",
+   "tri_count": 108,
+   "vertex_count": 56,
+   "volume": 0.098674
+  },
+  {
+   "bbox": {
+    "max": [
+     0.417,
+     -11.855,
+     2.3
+    ],
+    "min": [
+     0.0,
+     -12.605,
+     0.1
+    ]
+   },
+   "closed": true,
+   "express_id": 7011,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.68805
+  },
+  {
+   "bbox": {
+    "max": [
+     0.417,
+     -11.855,
+     2.3
+    ],
+    "min": [
+     0.0,
+     -12.605,
+     0.1
+    ]
+   },
+   "closed": true,
+   "express_id": 7025,
+   "ifc_type": "IfcWindow",
+   "status": "ok",
+   "tri_count": 108,
+   "vertex_count": 56,
+   "volume": 0.098674
+  },
+  {
+   "bbox": {
+    "max": [
+     4.125,
+     0.0,
+     5.61
+    ],
+    "min": [
+     1.325,
+     -0.417,
+     3.2
+    ]
+   },
+   "closed": true,
+   "express_id": 7063,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 2.813916
+  },
+  {
+   "bbox": {
+    "max": [
+     4.125,
+     0.0,
+     5.61
+    ],
+    "min": [
+     1.325,
+     -0.417,
+     3.2
+    ]
+   },
+   "closed": true,
+   "express_id": 7190,
+   "ifc_type": "IfcWindow",
+   "status": "ok",
+   "tri_count": 108,
+   "vertex_count": 56,
+   "volume": 0.221797
+  },
+  {
+   "bbox": {
+    "max": [
+     1.236,
+     0.0,
+     3.959
+    ],
+    "min": [
+     0.417,
+     -0.417,
+     3.2
+    ]
+   },
+   "closed": true,
+   "express_id": 7280,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.259216
+  },
+  {
+   "bbox": {
+    "max": [
+     1.236,
+     0.0,
+     3.959
+    ],
+    "min": [
+     0.417,
+     -0.417,
+     3.2
+    ]
+   },
+   "closed": true,
+   "express_id": 7407,
+   "ifc_type": "IfcWindow",
+   "status": "ok",
+   "tri_count": 108,
+   "vertex_count": 56,
+   "volume": 0.048727
+  },
+  {
+   "bbox": {
+    "max": [
+     1.236,
+     0.0,
+     4.7845
+    ],
+    "min": [
+     0.417,
+     -0.417,
+     4.0255
+    ]
+   },
+   "closed": true,
+   "express_id": 7497,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.259216
+  },
+  {
+   "bbox": {
+    "max": [
+     1.236,
+     0.0,
+     4.7845
+    ],
+    "min": [
+     0.417,
+     -0.417,
+     4.0255
+    ]
+   },
+   "closed": true,
+   "express_id": 7639,
+   "ifc_type": "IfcWindow",
+   "status": "ok",
+   "tri_count": 108,
+   "vertex_count": 56,
+   "volume": 0.048861
+  },
+  {
+   "bbox": {
+    "max": [
+     1.236,
+     0.0,
+     5.61
+    ],
+    "min": [
+     0.417,
+     -0.417,
+     4.851
+    ]
+   },
+   "closed": true,
+   "express_id": 7729,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.259216
+  },
+  {
+   "bbox": {
+    "max": [
+     1.236,
+     0.0,
+     5.61
+    ],
+    "min": [
+     0.417,
+     -0.417,
+     4.851
+    ]
+   },
+   "closed": true,
+   "express_id": 7743,
+   "ifc_type": "IfcWindow",
+   "status": "ok",
+   "tri_count": 108,
+   "vertex_count": 56,
+   "volume": 0.048727
+  },
+  {
+   "bbox": {
+    "max": [
+     7.475,
+     -17.383,
+     5.61
+    ],
+    "min": [
+     4.675,
+     -17.8,
+     3.2
+    ]
+   },
+   "closed": true,
+   "express_id": 7781,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 2.813916
+  },
+  {
+   "bbox": {
+    "max": [
+     7.475,
+     -17.383,
+     5.61
+    ],
+    "min": [
+     4.675,
+     -17.8,
+     3.2
+    ]
+   },
+   "closed": true,
+   "express_id": 7795,
+   "ifc_type": "IfcWindow",
+   "status": "ok",
+   "tri_count": 108,
+   "vertex_count": 56,
+   "volume": 0.221797
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -17.383,
+     3.959
+    ],
+    "min": [
+     7.564,
+     -17.8,
+     3.2
+    ]
+   },
+   "closed": true,
+   "express_id": 7833,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.259216
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -17.383,
+     3.959
+    ],
+    "min": [
+     7.564,
+     -17.8,
+     3.2
+    ]
+   },
+   "closed": true,
+   "express_id": 7847,
+   "ifc_type": "IfcWindow",
+   "status": "ok",
+   "tri_count": 108,
+   "vertex_count": 56,
+   "volume": 0.048727
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -17.383,
+     4.7845
+    ],
+    "min": [
+     7.564,
+     -17.8,
+     4.0255
+    ]
+   },
+   "closed": true,
+   "express_id": 7885,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.259216
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -17.383,
+     4.7845
+    ],
+    "min": [
+     7.564,
+     -17.8,
+     4.0255
+    ]
+   },
+   "closed": true,
+   "express_id": 7899,
+   "ifc_type": "IfcWindow",
+   "status": "ok",
+   "tri_count": 108,
+   "vertex_count": 56,
+   "volume": 0.048861
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -17.383,
+     5.61
+    ],
+    "min": [
+     7.564,
+     -17.8,
+     4.851
+    ]
+   },
+   "closed": true,
+   "express_id": 7937,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.259216
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -17.383,
+     5.61
+    ],
+    "min": [
+     7.564,
+     -17.8,
+     4.851
+    ]
+   },
+   "closed": true,
+   "express_id": 7951,
+   "ifc_type": "IfcWindow",
+   "status": "ok",
+   "tri_count": 108,
+   "vertex_count": 56,
+   "volume": 0.048727
+  },
+  {
+   "bbox": {
+    "max": [
+     6.35,
+     -9.291,
+     2.032
+    ],
+    "min": [
+     6.226,
+     -10.053,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 7989,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.192
+  },
+  {
+   "bbox": {
+    "max": [
+     6.375,
+     -9.215,
+     2.108
+    ],
+    "min": [
+     6.201,
+     -10.129,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 8066,
+   "ifc_type": "IfcDoor",
+   "status": "ok",
+   "tri_count": 68,
+   "vertex_count": 40,
+   "volume": 0.097884
+  },
+  {
+   "bbox": {
+    "max": [
+     2.574,
+     -7.749,
+     2.032
+    ],
+    "min": [
+     2.45,
+     -8.511,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 8155,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.192
+  },
+  {
+   "bbox": {
+    "max": [
+     2.599,
+     -7.673,
+     2.108
+    ],
+    "min": [
+     2.425,
+     -8.587,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 8169,
+   "ifc_type": "IfcDoor",
+   "status": "ok",
+   "tri_count": 68,
+   "vertex_count": 40,
+   "volume": 0.097884
+  },
+  {
+   "bbox": {
+    "max": [
+     2.3473,
+     -6.126,
+     5.132
+    ],
+    "min": [
+     1.4833,
+     -6.25,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 8206,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.2177
+  },
+  {
+   "bbox": {
+    "max": [
+     2.4233,
+     -6.101,
+     5.208
+    ],
+    "min": [
+     1.4073,
+     -6.275,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 8283,
+   "ifc_type": "IfcDoor",
+   "status": "ok",
+   "tri_count": 68,
+   "vertex_count": 40,
+   "volume": 0.108842
+  },
+  {
+   "bbox": {
+    "max": [
+     7.3213,
+     -11.55,
+     5.132
+    ],
+    "min": [
+     6.4573,
+     -11.674,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 8372,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.2177
+  },
+  {
+   "bbox": {
+    "max": [
+     7.3973,
+     -11.525,
+     5.208
+    ],
+    "min": [
+     6.3813,
+     -11.699,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 8386,
+   "ifc_type": "IfcDoor",
+   "status": "ok",
+   "tri_count": 68,
+   "vertex_count": 40,
+   "volume": 0.108842
+  },
+  {
+   "bbox": {
+    "max": [
+     8.333,
+     -8.0525,
+     3.05
+    ],
+    "min": [
+     7.4186,
+     -11.824927,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 8970,
+   "ifc_type": "IfcStairFlight",
+   "status": "ok",
+   "tri_count": 1152,
+   "vertex_count": 638,
+   "volume": 0.208445
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -8.075,
+     3.1
+    ],
+    "min": [
+     8.333,
+     -11.825,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 9002,
+   "ifc_type": "IfcMember",
+   "status": "ok",
+   "tri_count": 20,
+   "vertex_count": 12,
+   "volume": 0.092621
+  },
+  {
+   "bbox": {
+    "max": [
+     7.4186,
+     -8.075,
+     3.1
+    ],
+    "min": [
+     7.3686,
+     -11.825,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 9020,
+   "ifc_type": "IfcMember",
+   "status": "ok",
+   "tri_count": 20,
+   "vertex_count": 12,
+   "volume": 0.092621
+  },
+  {
+   "bbox": {
+    "max": [
+     8.378,
+     -8.075,
+     4.0
+    ],
+    "min": [
+     8.338,
+     -11.825,
+     1.043144
+    ]
+   },
+   "closed": false,
+   "express_id": 9326,
+   "ifc_type": "IfcRailing",
+   "status": "ok",
+   "tri_count": 72,
+   "vertex_count": 48,
+   "volume": null
+  },
+  {
+   "bbox": {
+    "max": [
+     7.4136,
+     -8.02,
+     4.2
+    ],
+    "min": [
+     7.3236,
+     -11.825,
+     0.248454
+    ]
+   },
+   "closed": false,
+   "express_id": 12184,
+   "ifc_type": "IfcRailing",
+   "status": "ok",
+   "tri_count": 1138,
+   "vertex_count": 708,
+   "volume": null
+  },
+  {
+   "bbox": {
+    "max": [
+     3.314,
+     -11.134,
+     5.1
+    ],
+    "min": [
+     2.514,
+     -11.6794,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 12574,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 164,
+   "vertex_count": 92,
+   "volume": 0.152899
+  },
+  {
+   "bbox": {
+    "max": [
+     2.913688,
+     -11.6794,
+     1.98095
+    ],
+    "min": [
+     2.151788,
+     -12.18035,
+     0.180637
+    ]
+   },
+   "closed": true,
+   "express_id": 12583,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.687132
+  },
+  {
+   "bbox": {
+    "max": [
+     4.114,
+     -11.134,
+     5.1
+    ],
+    "min": [
+     3.314,
+     -11.6794,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 12976,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 164,
+   "vertex_count": 92,
+   "volume": 0.152899
+  },
+  {
+   "bbox": {
+    "max": [
+     4.513688,
+     -10.63305,
+     1.98095
+    ],
+    "min": [
+     3.751788,
+     -11.134,
+     0.180637
+    ]
+   },
+   "closed": true,
+   "express_id": 12985,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.687132
+  },
+  {
+   "bbox": {
+    "max": [
+     5.483,
+     -11.134,
+     5.1
+    ],
+    "min": [
+     4.683,
+     -11.6794,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 13331,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 164,
+   "vertex_count": 92,
+   "volume": 0.152899
+  },
+  {
+   "bbox": {
+    "max": [
+     5.082688,
+     -11.6794,
+     1.98095
+    ],
+    "min": [
+     4.320788,
+     -12.18035,
+     0.180637
+    ]
+   },
+   "closed": true,
+   "express_id": 13340,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.687132
+  },
+  {
+   "bbox": {
+    "max": [
+     6.283,
+     -11.134,
+     5.1
+    ],
+    "min": [
+     5.483,
+     -11.6794,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 13685,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 164,
+   "vertex_count": 92,
+   "volume": 0.152899
+  },
+  {
+   "bbox": {
+    "max": [
+     6.682688,
+     -10.63305,
+     1.98095
+    ],
+    "min": [
+     5.920788,
+     -11.134,
+     0.180637
+    ]
+   },
+   "closed": true,
+   "express_id": 13694,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.687132
+  },
+  {
+   "bbox": {
+    "max": [
+     6.286,
+     -6.1206,
+     5.1
+    ],
+    "min": [
+     5.486,
+     -6.666,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 14040,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 164,
+   "vertex_count": 92,
+   "volume": 0.152899
+  },
+  {
+   "bbox": {
+    "max": [
+     6.685688,
+     -6.1206,
+     1.98095
+    ],
+    "min": [
+     5.923788,
+     -6.62155,
+     0.180637
+    ]
+   },
+   "closed": true,
+   "express_id": 14049,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.687132
+  },
+  {
+   "bbox": {
+    "max": [
+     5.486,
+     -6.1206,
+     5.1
+    ],
+    "min": [
+     4.686,
+     -6.666,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 14394,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 164,
+   "vertex_count": 92,
+   "volume": 0.152899
+  },
+  {
+   "bbox": {
+    "max": [
+     5.085688,
+     -6.16505,
+     1.98095
+    ],
+    "min": [
+     4.323788,
+     -6.666,
+     0.180637
+    ]
+   },
+   "closed": true,
+   "express_id": 14403,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.687132
+  },
+  {
+   "bbox": {
+    "max": [
+     4.117,
+     -6.1206,
+     5.1
+    ],
+    "min": [
+     3.317,
+     -6.666,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 14749,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 164,
+   "vertex_count": 92,
+   "volume": 0.152899
+  },
+  {
+   "bbox": {
+    "max": [
+     4.516688,
+     -6.1206,
+     1.98095
+    ],
+    "min": [
+     3.754788,
+     -6.62155,
+     0.180637
+    ]
+   },
+   "closed": true,
+   "express_id": 14758,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.687132
+  },
+  {
+   "bbox": {
+    "max": [
+     3.317,
+     -6.1206,
+     5.1
+    ],
+    "min": [
+     2.517,
+     -6.666,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 15103,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 164,
+   "vertex_count": 92,
+   "volume": 0.152899
+  },
+  {
+   "bbox": {
+    "max": [
+     2.916688,
+     -6.16505,
+     1.98095
+    ],
+    "min": [
+     2.154788,
+     -6.666,
+     0.180637
+    ]
+   },
+   "closed": true,
+   "express_id": 15112,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.687132
+  },
+  {
+   "bbox": {
+    "max": [
+     6.334,
+     -6.8046,
+     0.86
+    ],
+    "min": [
+     5.334,
+     -7.43,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 15463,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 152,
+   "vertex_count": 94,
+   "volume": 10.871246
+  },
+  {
+   "bbox": {
+    "max": [
+     7.334,
+     -6.805,
+     0.86
+    ],
+    "min": [
+     6.334,
+     -7.4304,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 15856,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 152,
+   "vertex_count": 94,
+   "volume": 13.135874
+  },
+  {
+   "bbox": {
+    "max": [
+     2.282,
+     -11.55,
+     5.132
+    ],
+    "min": [
+     1.418,
+     -11.674,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 15885,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.2177
+  },
+  {
+   "bbox": {
+    "max": [
+     2.358,
+     -11.525,
+     5.208
+    ],
+    "min": [
+     1.342,
+     -11.699,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 15962,
+   "ifc_type": "IfcDoor",
+   "status": "ok",
+   "tri_count": 68,
+   "vertex_count": 40,
+   "volume": 0.108842
+  },
+  {
+   "bbox": {
+    "max": [
+     7.342,
+     -6.126,
+     5.132
+    ],
+    "min": [
+     6.478,
+     -6.25,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 15999,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.2177
+  },
+  {
+   "bbox": {
+    "max": [
+     7.418,
+     -6.101,
+     5.208
+    ],
+    "min": [
+     6.402,
+     -6.275,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 16013,
+   "ifc_type": "IfcDoor",
+   "status": "ok",
+   "tri_count": 68,
+   "vertex_count": 40,
+   "volume": 0.108842
+  },
+  {
+   "bbox": {
+    "max": [
+     2.506,
+     -9.006051,
+     5.132
+    ],
+    "min": [
+     2.382,
+     -9.870051,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 16050,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.2177
+  },
+  {
+   "bbox": {
+    "max": [
+     2.531,
+     -8.930051,
+     5.208
+    ],
+    "min": [
+     2.357,
+     -9.946051,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 16064,
+   "ifc_type": "IfcDoor",
+   "status": "ok",
+   "tri_count": 68,
+   "vertex_count": 40,
+   "volume": 0.108842
+  },
+  {
+   "bbox": {
+    "max": [
+     6.418,
+     -7.945384,
+     5.132
+    ],
+    "min": [
+     6.294,
+     -8.809384,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 16101,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.2177
+  },
+  {
+   "bbox": {
+    "max": [
+     6.443,
+     -7.869384,
+     5.208
+    ],
+    "min": [
+     6.269,
+     -8.885384,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 16115,
+   "ifc_type": "IfcDoor",
+   "status": "ok",
+   "tri_count": 68,
+   "vertex_count": 40,
+   "volume": 0.108842
+  },
+  {
+   "bbox": {
+    "max": [
+     5.334,
+     -6.8046,
+     0.86
+    ],
+    "min": [
+     4.334,
+     -7.43,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 16149,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 152,
+   "vertex_count": 94,
+   "volume": 10.879133
+  },
+  {
+   "bbox": {
+    "max": [
+     3.574,
+     -6.8046,
+     0.86
+    ],
+    "min": [
+     2.574,
+     -7.43,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 16175,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 152,
+   "vertex_count": 94,
+   "volume": 10.893013
+  },
+  {
+   "bbox": {
+    "max": [
+     7.3339,
+     -6.805,
+     1.0016
+    ],
+    "min": [
+     4.3339,
+     -7.43,
+     0.86
+    ]
+   },
+   "closed": true,
+   "express_id": 16261,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 20,
+   "vertex_count": 12,
+   "volume": 0.080806
+  },
+  {
+   "bbox": {
+    "max": [
+     6.636075,
+     -7.5173,
+     0.9
+    ],
+    "min": [
+     6.229875,
+     -7.9207,
+     0.86
+    ]
+   },
+   "closed": true,
+   "express_id": 16306,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 124,
+   "vertex_count": 64,
+   "volume": 0.006463
+  },
+  {
+   "bbox": {
+    "max": [
+     3.574,
+     -6.805,
+     1.0016
+    ],
+    "min": [
+     2.574,
+     -7.43,
+     0.86
+    ]
+   },
+   "closed": true,
+   "express_id": 16411,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 24,
+   "vertex_count": 16,
+   "volume": 0.026935
+  },
+  {
+   "bbox": {
+    "max": [
+     3.574,
+     -5.2,
+     0.86
+    ],
+    "min": [
+     2.574,
+     -5.8254,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 16485,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 152,
+   "vertex_count": 94,
+   "volume": 8.232624
+  },
+  {
+   "bbox": {
+    "max": [
+     6.586,
+     -5.188,
+     1.0016
+    ],
+    "min": [
+     2.562,
+     -5.813,
+     0.86
+    ]
+   },
+   "closed": true,
+   "express_id": 16531,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 24,
+   "vertex_count": 16,
+   "volume": 0.108388
+  },
+  {
+   "bbox": {
+    "max": [
+     4.574,
+     -5.2,
+     0.86
+    ],
+    "min": [
+     3.574,
+     -5.8254,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 16563,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 152,
+   "vertex_count": 94,
+   "volume": 8.224738
+  },
+  {
+   "bbox": {
+    "max": [
+     5.574,
+     -5.2,
+     0.86
+    ],
+    "min": [
+     4.574,
+     -5.8254,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 16589,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 152,
+   "vertex_count": 94,
+   "volume": 8.216852
+  },
+  {
+   "bbox": {
+    "max": [
+     6.574,
+     -5.2,
+     0.86
+    ],
+    "min": [
+     5.574,
+     -5.8254,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 16615,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 152,
+   "vertex_count": 94,
+   "volume": 8.208965
+  },
+  {
+   "bbox": {
+    "max": [
+     3.466,
+     -10.37,
+     0.86
+    ],
+    "min": [
+     2.466,
+     -10.9954,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 16641,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 152,
+   "vertex_count": 94,
+   "volume": 16.082265
+  },
+  {
+   "bbox": {
+    "max": [
+     2.466,
+     -10.37,
+     0.86
+    ],
+    "min": [
+     1.466,
+     -10.9954,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 16667,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 152,
+   "vertex_count": 94,
+   "volume": 16.96371
+  },
+  {
+   "bbox": {
+    "max": [
+     4.466,
+     -10.37,
+     0.86
+    ],
+    "min": [
+     3.466,
+     -10.9954,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 16693,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 152,
+   "vertex_count": 94,
+   "volume": 16.074379
+  },
+  {
+   "bbox": {
+    "max": [
+     6.226,
+     -10.37,
+     0.86
+    ],
+    "min": [
+     5.226,
+     -10.9954,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 16719,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 152,
+   "vertex_count": 94,
+   "volume": 16.060499
+  },
+  {
+   "bbox": {
+    "max": [
+     4.4661,
+     -10.37,
+     1.0016
+    ],
+    "min": [
+     1.4661,
+     -10.995,
+     0.86
+    ]
+   },
+   "closed": true,
+   "express_id": 16802,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 152,
+   "vertex_count": 76,
+   "volume": 0.074343
+  },
+  {
+   "bbox": {
+    "max": [
+     3.1692,
+     -10.4573,
+     0.9
+    ],
+    "min": [
+     2.763,
+     -10.8607,
+     0.86
+    ]
+   },
+   "closed": true,
+   "express_id": 16847,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 124,
+   "vertex_count": 64,
+   "volume": 0.006463
+  },
+  {
+   "bbox": {
+    "max": [
+     6.226,
+     -10.37,
+     1.0016
+    ],
+    "min": [
+     5.226,
+     -10.995,
+     0.86
+    ]
+   },
+   "closed": true,
+   "express_id": 16884,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 24,
+   "vertex_count": 16,
+   "volume": 0.026935
+  },
+  {
+   "bbox": {
+    "max": [
+     6.226,
+     -11.9746,
+     0.86
+    ],
+    "min": [
+     5.226,
+     -12.6,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 16914,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 152,
+   "vertex_count": 94,
+   "volume": 18.720887
+  },
+  {
+   "bbox": {
+    "max": [
+     6.238,
+     -11.987,
+     1.0016
+    ],
+    "min": [
+     2.214,
+     -12.612,
+     0.86
+    ]
+   },
+   "closed": true,
+   "express_id": 16940,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 24,
+   "vertex_count": 16,
+   "volume": 0.108388
+  },
+  {
+   "bbox": {
+    "max": [
+     5.226,
+     -11.9746,
+     0.86
+    ],
+    "min": [
+     4.226,
+     -12.6,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 16971,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 152,
+   "vertex_count": 94,
+   "volume": 18.728774
+  },
+  {
+   "bbox": {
+    "max": [
+     4.226,
+     -11.9746,
+     0.86
+    ],
+    "min": [
+     3.226,
+     -12.6,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 16997,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 152,
+   "vertex_count": 94,
+   "volume": 18.73666
+  },
+  {
+   "bbox": {
+    "max": [
+     3.226,
+     -11.9746,
+     0.86
+    ],
+    "min": [
+     2.226,
+     -12.6,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 17023,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 152,
+   "vertex_count": 94,
+   "volume": 18.744546
+  },
+  {
+   "bbox": {
+    "max": [
+     8.3132,
+     -1.385,
+     0.8128
+    ],
+    "min": [
+     7.6528,
+     -3.215,
+     0.0
+    ]
+   },
+   "closed": false,
+   "express_id": 17341,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 120,
+   "vertex_count": 76,
+   "volume": null
+  },
+  {
+   "bbox": {
+    "max": [
+     7.198,
+     -3.2698,
+     0.8128
+    ],
+    "min": [
+     5.368,
+     -3.9302,
+     0.0
+    ]
+   },
+   "closed": false,
+   "express_id": 17409,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 120,
+   "vertex_count": 76,
+   "volume": null
+  },
+  {
+   "bbox": {
+    "max": [
+     7.988,
+     -3.295,
+     0.61
+    ],
+    "min": [
+     7.378,
+     -3.905,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 17532,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 112,
+   "vertex_count": 64,
+   "volume": 0.039888
+  },
+  {
+   "bbox": {
+    "max": [
+     8.288,
+     -0.612,
+     0.61
+    ],
+    "min": [
+     7.678,
+     -1.222,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 17602,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 112,
+   "vertex_count": 64,
+   "volume": 0.039888
+  },
+  {
+   "bbox": {
+    "max": [
+     7.198,
+     -1.7595,
+     0.457
+    ],
+    "min": [
+     5.368,
+     -2.6745,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 17716,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 112,
+   "vertex_count": 64,
+   "volume": 0.069012
+  },
+  {
+   "bbox": {
+    "max": [
+     1.231099,
+     -14.440383,
+     0.8128
+    ],
+    "min": [
+     0.570699,
+     -16.270383,
+     0.0
+    ]
+   },
+   "closed": false,
+   "express_id": 17786,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 120,
+   "vertex_count": 76,
+   "volume": null
+  },
+  {
+   "bbox": {
+    "max": [
+     3.515899,
+     -13.725183,
+     0.8128
+    ],
+    "min": [
+     1.685899,
+     -14.385583,
+     0.0
+    ]
+   },
+   "closed": false,
+   "express_id": 17815,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 120,
+   "vertex_count": 76,
+   "volume": null
+  },
+  {
+   "bbox": {
+    "max": [
+     1.505899,
+     -13.750383,
+     0.61
+    ],
+    "min": [
+     0.895899,
+     -14.360383,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 17844,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 112,
+   "vertex_count": 64,
+   "volume": 0.039888
+  },
+  {
+   "bbox": {
+    "max": [
+     1.205899,
+     -16.433383,
+     0.61
+    ],
+    "min": [
+     0.595899,
+     -17.043383,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 17873,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 112,
+   "vertex_count": 64,
+   "volume": 0.039888
+  },
+  {
+   "bbox": {
+    "max": [
+     3.515899,
+     -14.980883,
+     0.457
+    ],
+    "min": [
+     1.685899,
+     -15.895883,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 17902,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 112,
+   "vertex_count": 64,
+   "volume": 0.069012
+  },
+  {
+   "bbox": {
+    "max": [
+     2.45,
+     -3.0595,
+     3.735
+    ],
+    "min": [
+     0.443,
+     -4.5845,
+     3.1
+    ]
+   },
+   "closed": false,
+   "express_id": 19275,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 540,
+   "vertex_count": 372,
+   "volume": null
+  },
+  {
+   "bbox": {
+    "max": [
+     7.683,
+     -0.4045,
+     3.735
+    ],
+    "min": [
+     5.702,
+     -2.4365,
+     3.1
+    ]
+   },
+   "closed": false,
+   "express_id": 20657,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 536,
+   "vertex_count": 368,
+   "volume": null
+  },
+  {
+   "bbox": {
+    "max": [
+     3.298,
+     -15.351,
+     3.735
+    ],
+    "min": [
+     1.317,
+     -17.383,
+     3.1
+    ]
+   },
+   "closed": false,
+   "express_id": 20726,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 536,
+   "vertex_count": 368,
+   "volume": null
+  },
+  {
+   "bbox": {
+    "max": [
+     8.357,
+     -13.258,
+     3.735
+    ],
+    "min": [
+     6.35,
+     -14.783,
+     3.1
+    ]
+   },
+   "closed": false,
+   "express_id": 20755,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 540,
+   "vertex_count": 372,
+   "volume": null
+  },
+  {
+   "bbox": {
+    "max": [
+     4.125,
+     -0.417,
+     3.119
+    ],
+    "min": [
+     0.417,
+     -6.666,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 20792,
+   "ifc_type": "IfcSlab",
+   "status": "ok",
+   "tri_count": 20,
+   "vertex_count": 12,
+   "volume": 0.418821
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -0.417,
+     3.119
+    ],
+    "min": [
+     4.675,
+     -6.666,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 20903,
+   "ifc_type": "IfcSlab",
+   "status": "ok",
+   "tri_count": 20,
+   "vertex_count": 12,
+   "volume": 0.418821
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -11.118,
+     3.119
+    ],
+    "min": [
+     4.675,
+     -17.383,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 20958,
+   "ifc_type": "IfcSlab",
+   "status": "ok",
+   "tri_count": 20,
+   "vertex_count": 12,
+   "volume": 0.419314
+  },
+  {
+   "bbox": {
+    "max": [
+     4.125,
+     -11.134,
+     3.119
+    ],
+    "min": [
+     0.417,
+     -17.383,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 21013,
+   "ifc_type": "IfcSlab",
+   "status": "ok",
+   "tri_count": 20,
+   "vertex_count": 12,
+   "volume": 0.418821
+  },
+  {
+   "bbox": {
+    "max": [
+     2.506,
+     -6.126,
+     3.119
+    ],
+    "min": [
+     0.417,
+     -11.674,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 21080,
+   "ifc_type": "IfcSlab",
+   "status": "ok",
+   "tri_count": 68,
+   "vertex_count": 36,
+   "volume": 0.137006
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -6.126,
+     3.119
+    ],
+    "min": [
+     6.294,
+     -11.674,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 21147,
+   "ifc_type": "IfcSlab",
+   "status": "ok",
+   "tri_count": 68,
+   "vertex_count": 36,
+   "volume": 0.137006
+  },
+  {
+   "bbox": {
+    "max": [
+     4.03,
+     -6.85,
+     3.113
+    ],
+    "min": [
+     2.506,
+     -11.01,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 21195,
+   "ifc_type": "IfcSlab",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.082418
+  },
+  {
+   "bbox": {
+    "max": [
+     6.294,
+     -6.79,
+     3.113
+    ],
+    "min": [
+     4.77,
+     -10.95,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 21336,
+   "ifc_type": "IfcSlab",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.082418
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -8.075,
+     0.019
+    ],
+    "min": [
+     0.417,
+     -17.383,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 21401,
+   "ifc_type": "IfcSlab",
+   "status": "ok",
+   "tri_count": 60,
+   "vertex_count": 32,
+   "volume": 0.895848
+  },
+  {
+   "bbox": {
+    "max": [
+     6.226,
+     -10.37,
+     0.013
+    ],
+    "min": [
+     0.417,
+     -12.6,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 21449,
+   "ifc_type": "IfcSlab",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.168403
+  },
+  {
+   "bbox": {
+    "max": [
+     6.226,
+     -8.075,
+     0.013
+    ],
+    "min": [
+     4.77,
+     -10.246,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 21497,
+   "ifc_type": "IfcSlab",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.041093
+  },
+  {
+   "bbox": {
+    "max": [
+     4.03,
+     -7.554,
+     0.013
+    ],
+    "min": [
+     2.574,
+     -9.725,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 21545,
+   "ifc_type": "IfcSlab",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.041093
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -0.417,
+     0.019
+    ],
+    "min": [
+     0.417,
+     -9.725,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 21610,
+   "ifc_type": "IfcSlab",
+   "status": "ok",
+   "tri_count": 60,
+   "vertex_count": 32,
+   "volume": 0.895852
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -5.2,
+     0.013
+    ],
+    "min": [
+     2.574,
+     -7.43,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 21658,
+   "ifc_type": "IfcSlab",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.168403
+  },
+  {
+   "bbox": {
+    "max": [
+     3.447969,
+     0.0,
+     2.42
+    ],
+    "min": [
+     2.634969,
+     -0.417,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 21705,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.820431
+  },
+  {
+   "bbox": {
+    "max": [
+     3.523969,
+     0.025,
+     2.496
+    ],
+    "min": [
+     2.558969,
+     -0.442,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 21821,
+   "ifc_type": "IfcDoor",
+   "status": "ok",
+   "tri_count": 100,
+   "vertex_count": 56,
+   "volume": 0.062142
+  },
+  {
+   "bbox": {
+    "max": [
+     6.165,
+     -17.383,
+     2.42
+    ],
+    "min": [
+     5.352,
+     -17.8,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 21915,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.820431
+  },
+  {
+   "bbox": {
+    "max": [
+     6.241,
+     -17.358,
+     2.496
+    ],
+    "min": [
+     5.276,
+     -17.825,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 21929,
+   "ifc_type": "IfcDoor",
+   "status": "ok",
+   "tri_count": 100,
+   "vertex_count": 56,
+   "volume": 0.062142
+  },
+  {
+   "bbox": {
+    "max": [
+     0.417,
+     -14.583,
+     5.61
+    ],
+    "min": [
+     0.0,
+     -17.383,
+     3.2
+    ]
+   },
+   "closed": true,
+   "express_id": 21966,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 2.813916
+  },
+  {
+   "bbox": {
+    "max": [
+     0.417,
+     -14.583,
+     5.61
+    ],
+    "min": [
+     0.0,
+     -17.383,
+     3.2
+    ]
+   },
+   "closed": true,
+   "express_id": 21980,
+   "ifc_type": "IfcWindow",
+   "status": "ok",
+   "tri_count": 108,
+   "vertex_count": 56,
+   "volume": 0.221797
+  },
+  {
+   "bbox": {
+    "max": [
+     0.417,
+     -13.664,
+     5.61
+    ],
+    "min": [
+     0.0,
+     -14.483,
+     4.851
+    ]
+   },
+   "closed": true,
+   "express_id": 22018,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.259216
+  },
+  {
+   "bbox": {
+    "max": [
+     0.417,
+     -13.664,
+     5.61
+    ],
+    "min": [
+     0.0,
+     -14.483,
+     4.851
+    ]
+   },
+   "closed": true,
+   "express_id": 22032,
+   "ifc_type": "IfcWindow",
+   "status": "ok",
+   "tri_count": 108,
+   "vertex_count": 56,
+   "volume": 0.048727
+  },
+  {
+   "bbox": {
+    "max": [
+     0.417,
+     -13.664,
+     3.959
+    ],
+    "min": [
+     0.0,
+     -14.483,
+     3.2
+    ]
+   },
+   "closed": true,
+   "express_id": 22070,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.259216
+  },
+  {
+   "bbox": {
+    "max": [
+     0.417,
+     -13.664,
+     3.959
+    ],
+    "min": [
+     0.0,
+     -14.483,
+     3.2
+    ]
+   },
+   "closed": true,
+   "express_id": 22084,
+   "ifc_type": "IfcWindow",
+   "status": "ok",
+   "tri_count": 108,
+   "vertex_count": 56,
+   "volume": 0.048727
+  },
+  {
+   "bbox": {
+    "max": [
+     0.417,
+     -13.664,
+     4.7845
+    ],
+    "min": [
+     0.0,
+     -14.483,
+     4.0255
+    ]
+   },
+   "closed": true,
+   "express_id": 22122,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.259216
+  },
+  {
+   "bbox": {
+    "max": [
+     0.417,
+     -13.664,
+     4.7845
+    ],
+    "min": [
+     0.0,
+     -14.483,
+     4.0255
+    ]
+   },
+   "closed": true,
+   "express_id": 22136,
+   "ifc_type": "IfcWindow",
+   "status": "ok",
+   "tri_count": 108,
+   "vertex_count": 56,
+   "volume": 0.048861
+  },
+  {
+   "bbox": {
+    "max": [
+     8.8,
+     -0.417,
+     5.61
+    ],
+    "min": [
+     8.383,
+     -3.217,
+     3.2
+    ]
+   },
+   "closed": true,
+   "express_id": 22174,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 2.813916
+  },
+  {
+   "bbox": {
+    "max": [
+     8.8,
+     -0.417,
+     5.61
+    ],
+    "min": [
+     8.383,
+     -3.217,
+     3.2
+    ]
+   },
+   "closed": true,
+   "express_id": 22188,
+   "ifc_type": "IfcWindow",
+   "status": "ok",
+   "tri_count": 108,
+   "vertex_count": 56,
+   "volume": 0.221797
+  },
+  {
+   "bbox": {
+    "max": [
+     8.8,
+     -3.317,
+     5.61
+    ],
+    "min": [
+     8.383,
+     -4.136,
+     4.851
+    ]
+   },
+   "closed": true,
+   "express_id": 22226,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.259216
+  },
+  {
+   "bbox": {
+    "max": [
+     8.8,
+     -3.317,
+     5.61
+    ],
+    "min": [
+     8.383,
+     -4.136,
+     4.851
+    ]
+   },
+   "closed": true,
+   "express_id": 22240,
+   "ifc_type": "IfcWindow",
+   "status": "ok",
+   "tri_count": 108,
+   "vertex_count": 56,
+   "volume": 0.048727
+  },
+  {
+   "bbox": {
+    "max": [
+     8.8,
+     -3.317,
+     4.7845
+    ],
+    "min": [
+     8.383,
+     -4.136,
+     4.0255
+    ]
+   },
+   "closed": true,
+   "express_id": 22278,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.259216
+  },
+  {
+   "bbox": {
+    "max": [
+     8.8,
+     -3.317,
+     4.7845
+    ],
+    "min": [
+     8.383,
+     -4.136,
+     4.0255
+    ]
+   },
+   "closed": true,
+   "express_id": 22292,
+   "ifc_type": "IfcWindow",
+   "status": "ok",
+   "tri_count": 108,
+   "vertex_count": 56,
+   "volume": 0.048861
+  },
+  {
+   "bbox": {
+    "max": [
+     8.8,
+     -3.317,
+     3.959
+    ],
+    "min": [
+     8.383,
+     -4.136,
+     3.2
+    ]
+   },
+   "closed": true,
+   "express_id": 22330,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.259216
+  },
+  {
+   "bbox": {
+    "max": [
+     8.8,
+     -3.317,
+     3.959
+    ],
+    "min": [
+     8.383,
+     -4.136,
+     3.2
+    ]
+   },
+   "closed": true,
+   "express_id": 22344,
+   "ifc_type": "IfcWindow",
+   "status": "ok",
+   "tri_count": 108,
+   "vertex_count": 56,
+   "volume": 0.048727
+  },
+  {
+   "bbox": {
+    "max": [
+     8.8,
+     -11.774,
+     5.4
+    ],
+    "min": [
+     8.383,
+     -12.524,
+     3.2
+    ]
+   },
+   "closed": true,
+   "express_id": 22382,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.68805
+  },
+  {
+   "bbox": {
+    "max": [
+     8.8,
+     -11.774,
+     5.4
+    ],
+    "min": [
+     8.383,
+     -12.524,
+     3.2
+    ]
+   },
+   "closed": true,
+   "express_id": 22396,
+   "ifc_type": "IfcWindow",
+   "status": "ok",
+   "tri_count": 108,
+   "vertex_count": 56,
+   "volume": 0.098674
+  },
+  {
+   "bbox": {
+    "max": [
+     0.417,
+     -5.276,
+     5.4
+    ],
+    "min": [
+     0.0,
+     -6.026,
+     3.2
+    ]
+   },
+   "closed": true,
+   "express_id": 22434,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.68805
+  },
+  {
+   "bbox": {
+    "max": [
+     0.417,
+     -5.276,
+     5.4
+    ],
+    "min": [
+     0.0,
+     -6.026,
+     3.2
+    ]
+   },
+   "closed": true,
+   "express_id": 22448,
+   "ifc_type": "IfcWindow",
+   "status": "ok",
+   "tri_count": 108,
+   "vertex_count": 56,
+   "volume": 0.098674
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -0.417,
+     6.457
+    ],
+    "min": [
+     0.417,
+     -17.383,
+     6.0
+    ]
+   },
+   "closed": true,
+   "express_id": 22492,
+   "ifc_type": "IfcSlab",
+   "status": "ok",
+   "tri_count": 52,
+   "vertex_count": 24,
+   "volume": 60.747198
+  },
+  {
+   "bbox": {
+    "max": [
+     1.89055,
+     -10.12445,
+     7.981
+    ],
+    "min": [
+     0.86145,
+     -11.20555,
+     4.933
+    ]
+   },
+   "closed": true,
+   "express_id": 22506,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 3.391083
+  },
+  {
+   "bbox": {
+    "max": [
+     7.92355,
+     -6.59445,
+     7.981
+    ],
+    "min": [
+     6.89445,
+     -7.67555,
+     4.933
+    ]
+   },
+   "closed": true,
+   "express_id": 22520,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 3.391083
+  },
+  {
+   "bbox": {
+    "max": [
+     1.89055,
+     -10.12445,
+     6.457
+    ],
+    "min": [
+     0.86145,
+     -11.20555,
+     6.0
+    ]
+   },
+   "closed": true,
+   "express_id": 22533,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.50844
+  },
+  {
+   "bbox": {
+    "max": [
+     7.92355,
+     -6.59445,
+     6.457
+    ],
+    "min": [
+     6.89445,
+     -7.67555,
+     6.0
+    ]
+   },
+   "closed": true,
+   "express_id": 22546,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.50844
+  },
+  {
+   "bbox": {
+    "max": [
+     8.8,
+     0.0,
+     6.609
+    ],
+    "min": [
+     0.0,
+     -0.417,
+     6.0
+    ]
+   },
+   "closed": true,
+   "express_id": 22663,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 2.234786
+  },
+  {
+   "bbox": {
+    "max": [
+     8.8,
+     -0.417,
+     6.609
+    ],
+    "min": [
+     8.383,
+     -17.8,
+     6.0
+    ]
+   },
+   "closed": true,
+   "express_id": 22708,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 4.414465
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -17.383,
+     6.609
+    ],
+    "min": [
+     0.0,
+     -17.8,
+     6.0
+    ]
+   },
+   "closed": true,
+   "express_id": 22753,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 2.128888
+  },
+  {
+   "bbox": {
+    "max": [
+     0.417,
+     -0.417,
+     6.609
+    ],
+    "min": [
+     0.0,
+     -17.383,
+     6.0
+    ]
+   },
+   "closed": true,
+   "express_id": 22798,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 4.308567
+  },
+  {
+   "bbox": {
+    "max": [
+     1.962269,
+     -10.052731,
+     6.6348
+    ],
+    "min": [
+     0.789731,
+     -11.277269,
+     6.457
+    ]
+   },
+   "closed": true,
+   "express_id": 23162,
+   "ifc_type": "IfcWindow",
+   "status": "ok",
+   "tri_count": 140,
+   "vertex_count": 72,
+   "volume": 6.545904
+  },
+  {
+   "bbox": {
+    "max": [
+     7.995269,
+     -6.522731,
+     6.6348
+    ],
+    "min": [
+     6.822731,
+     -7.747269,
+     6.457
+    ]
+   },
+   "closed": true,
+   "express_id": 23251,
+   "ifc_type": "IfcWindow",
+   "status": "ok",
+   "tri_count": 140,
+   "vertex_count": 72,
+   "volume": 4.401741
+  },
+  {
+   "bbox": {
+    "max": [
+     9.0415,
+     0.2415,
+     -1.25
+    ],
+    "min": [
+     8.1415,
+     -18.0415,
+     -1.55
+    ]
+   },
+   "closed": true,
+   "express_id": 23286,
+   "ifc_type": "IfcFooting",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 4.93641
+  },
+  {
+   "bbox": {
+    "max": [
+     8.1415,
+     -17.1415,
+     -1.25
+    ],
+    "min": [
+     -0.2415,
+     -18.0415,
+     -1.55
+    ]
+   },
+   "closed": true,
+   "express_id": 23369,
+   "ifc_type": "IfcFooting",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 2.26341
+  },
+  {
+   "bbox": {
+    "max": [
+     0.6585,
+     0.2415,
+     -1.25
+    ],
+    "min": [
+     -0.2415,
+     -17.1415,
+     -1.55
+    ]
+   },
+   "closed": true,
+   "express_id": 23408,
+   "ifc_type": "IfcFooting",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 4.69341
+  },
+  {
+   "bbox": {
+    "max": [
+     8.1415,
+     0.2415,
+     -1.25
+    ],
+    "min": [
+     0.6585,
+     -0.6585,
+     -1.55
+    ]
+   },
+   "closed": true,
+   "express_id": 23446,
+   "ifc_type": "IfcFooting",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 2.02041
+  },
+  {
+   "bbox": {
+    "max": [
+     8.1415,
+     -7.35,
+     -1.25
+    ],
+    "min": [
+     3.95,
+     -8.25,
+     -1.55
+    ]
+   },
+   "closed": true,
+   "express_id": 23485,
+   "ifc_type": "IfcFooting",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 1.131705
+  },
+  {
+   "bbox": {
+    "max": [
+     4.85,
+     -8.25,
+     -1.25
+    ],
+    "min": [
+     3.95,
+     -10.45,
+     -1.55
+    ]
+   },
+   "closed": true,
+   "express_id": 23524,
+   "ifc_type": "IfcFooting",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.594
+  },
+  {
+   "bbox": {
+    "max": [
+     3.95,
+     -9.55,
+     -1.25
+    ],
+    "min": [
+     0.6585,
+     -10.45,
+     -1.55
+    ]
+   },
+   "closed": true,
+   "express_id": 23562,
+   "ifc_type": "IfcFooting",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.888705
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -0.417,
+     2.657
+    ],
+    "min": [
+     0.417,
+     -9.725,
+     2.6
+    ]
+   },
+   "closed": true,
+   "express_id": 23671,
+   "ifc_type": "IfcCovering",
+   "status": "ok",
+   "tri_count": 52,
+   "vertex_count": 28,
+   "volume": 4.08931
+  },
+  {
+   "bbox": {
+    "max": [
+     4.125,
+     -7.677,
+     2.657
+    ],
+    "min": [
+     2.574,
+     -9.725,
+     2.6
+    ]
+   },
+   "closed": true,
+   "express_id": 23768,
+   "ifc_type": "IfcCovering",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 6.339687
+  },
+  {
+   "bbox": {
+    "max": [
+     4.125,
+     -7.677,
+     2.657
+    ],
+    "min": [
+     2.574,
+     -9.725,
+     2.6
+    ]
+   },
+   "closed": true,
+   "express_id": 23826,
+   "ifc_type": "IfcCovering",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 6.339687
+  },
+  {
+   "bbox": {
+    "max": [
+     6.226,
+     -8.075,
+     2.657
+    ],
+    "min": [
+     4.675,
+     -10.246,
+     2.6
+    ]
+   },
+   "closed": true,
+   "express_id": 23884,
+   "ifc_type": "IfcCovering",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 6.89005
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -8.075,
+     2.657
+    ],
+    "min": [
+     0.417,
+     -17.383,
+     2.6
+    ]
+   },
+   "closed": true,
+   "express_id": 23992,
+   "ifc_type": "IfcCovering",
+   "status": "ok",
+   "tri_count": 52,
+   "vertex_count": 28,
+   "volume": 7.947491
+  },
+  {
+   "bbox": {
+    "max": [
+     4.125,
+     -0.417,
+     5.757
+    ],
+    "min": [
+     0.417,
+     -6.666,
+     5.7
+    ]
+   },
+   "closed": true,
+   "express_id": 24060,
+   "ifc_type": "IfcCovering",
+   "status": "ok",
+   "tri_count": 20,
+   "vertex_count": 12,
+   "volume": 85.221391
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -0.417,
+     5.757
+    ],
+    "min": [
+     4.675,
+     -6.666,
+     5.7
+    ]
+   },
+   "closed": true,
+   "express_id": 24128,
+   "ifc_type": "IfcCovering",
+   "status": "ok",
+   "tri_count": 20,
+   "vertex_count": 12,
+   "volume": 1.587713
+  },
+  {
+   "bbox": {
+    "max": [
+     6.294,
+     -6.79,
+     5.757
+    ],
+    "min": [
+     4.675,
+     -10.95,
+     5.7
+    ]
+   },
+   "closed": true,
+   "express_id": 24186,
+   "ifc_type": "IfcCovering",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 27.133808
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -6.25,
+     5.757
+    ],
+    "min": [
+     6.418,
+     -11.55,
+     5.7
+    ]
+   },
+   "closed": true,
+   "express_id": 24268,
+   "ifc_type": "IfcCovering",
+   "status": "ok",
+   "tri_count": 32,
+   "vertex_count": 16,
+   "volume": 38.262527
+  },
+  {
+   "bbox": {
+    "max": [
+     4.125,
+     -6.85,
+     5.757
+    ],
+    "min": [
+     2.506,
+     -11.01,
+     5.7
+    ]
+   },
+   "closed": true,
+   "express_id": 24326,
+   "ifc_type": "IfcCovering",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 26.794623
+  },
+  {
+   "bbox": {
+    "max": [
+     2.382,
+     -6.25,
+     5.757
+    ],
+    "min": [
+     0.417,
+     -11.55,
+     5.7
+    ]
+   },
+   "closed": true,
+   "express_id": 24408,
+   "ifc_type": "IfcCovering",
+   "status": "ok",
+   "tri_count": 32,
+   "vertex_count": 16,
+   "volume": 36.944123
+  },
+  {
+   "bbox": {
+    "max": [
+     4.125,
+     -11.134,
+     5.757
+    ],
+    "min": [
+     0.417,
+     -17.383,
+     5.7
+    ]
+   },
+   "closed": true,
+   "express_id": 24476,
+   "ifc_type": "IfcCovering",
+   "status": "ok",
+   "tri_count": 20,
+   "vertex_count": 12,
+   "volume": 2.172401
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -11.134,
+     5.757
+    ],
+    "min": [
+     4.675,
+     -17.383,
+     5.7
+    ]
+   },
+   "closed": true,
+   "express_id": 24544,
+   "ifc_type": "IfcCovering",
+   "status": "ok",
+   "tri_count": 20,
+   "vertex_count": 12,
+   "volume": 87.742572
+  },
+  {
+   "bbox": {
+    "max": [
+     8.383,
+     -7.43,
+     2.795
+    ],
+    "min": [
+     4.03,
+     -7.582,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 24596,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 1.849329
+  },
+  {
+   "bbox": {
+    "max": [
+     4.182,
+     -7.582,
+     3.1
+    ],
+    "min": [
+     4.03,
+     -9.725,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 24680,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 1.009782
+  },
+  {
+   "bbox": {
+    "max": [
+     4.03,
+     -7.43,
+     2.795
+    ],
+    "min": [
+     2.574,
+     -7.554,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 24723,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.50462
+  },
+  {
+   "bbox": {
+    "max": [
+     4.77,
+     -8.075,
+     2.795
+    ],
+    "min": [
+     4.618,
+     -10.37,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 24768,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.975008
+  },
+  {
+   "bbox": {
+    "max": [
+     4.618,
+     -10.218,
+     2.795
+    ],
+    "min": [
+     0.417,
+     -10.37,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 24813,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 1.784753
+  },
+  {
+   "bbox": {
+    "max": [
+     6.226,
+     -10.37,
+     2.0
+    ],
+    "min": [
+     5.226,
+     -10.71445,
+     1.4
+    ]
+   },
+   "closed": false,
+   "express_id": 26941,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 732,
+   "vertex_count": 384,
+   "volume": null
+  },
+  {
+   "bbox": {
+    "max": [
+     4.466,
+     -10.37,
+     2.0
+    ],
+    "min": [
+     3.466,
+     -10.71445,
+     1.4
+    ]
+   },
+   "closed": false,
+   "express_id": 29098,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 732,
+   "vertex_count": 384,
+   "volume": null
+  },
+  {
+   "bbox": {
+    "max": [
+     3.466,
+     -10.37,
+     2.0
+    ],
+    "min": [
+     2.466,
+     -10.71445,
+     1.4
+    ]
+   },
+   "closed": false,
+   "express_id": 29127,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 732,
+   "vertex_count": 384,
+   "volume": null
+  },
+  {
+   "bbox": {
+    "max": [
+     2.466,
+     -10.37,
+     2.0
+    ],
+    "min": [
+     1.466,
+     -10.71445,
+     1.4
+    ]
+   },
+   "closed": false,
+   "express_id": 31241,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 732,
+   "vertex_count": 384,
+   "volume": null
+  },
+  {
+   "bbox": {
+    "max": [
+     3.574,
+     -7.08555,
+     2.0
+    ],
+    "min": [
+     2.574,
+     -7.43,
+     1.4
+    ]
+   },
+   "closed": false,
+   "express_id": 31313,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 732,
+   "vertex_count": 384,
+   "volume": null
+  },
+  {
+   "bbox": {
+    "max": [
+     5.334,
+     -7.08555,
+     2.0
+    ],
+    "min": [
+     4.334,
+     -7.43,
+     1.4
+    ]
+   },
+   "closed": false,
+   "express_id": 31342,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 732,
+   "vertex_count": 384,
+   "volume": null
+  },
+  {
+   "bbox": {
+    "max": [
+     6.334,
+     -7.08555,
+     2.0
+    ],
+    "min": [
+     5.334,
+     -7.43,
+     1.4
+    ]
+   },
+   "closed": false,
+   "express_id": 31371,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 732,
+   "vertex_count": 384,
+   "volume": null
+  },
+  {
+   "bbox": {
+    "max": [
+     7.334,
+     -7.08555,
+     2.0
+    ],
+    "min": [
+     6.334,
+     -7.43,
+     1.4
+    ]
+   },
+   "closed": false,
+   "express_id": 31400,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 732,
+   "vertex_count": 384,
+   "volume": null
+  },
+  {
+   "bbox": {
+    "max": [
+     4.77,
+     -6.79,
+     5.695
+    ],
+    "min": [
+     4.618,
+     -10.95,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 31431,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 1.64087
+  },
+  {
+   "bbox": {
+    "max": [
+     4.182,
+     -6.85,
+     5.695
+    ],
+    "min": [
+     4.03,
+     -11.01,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 31476,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 1.64087
+  },
+  {
+   "bbox": {
+    "max": [
+     1.3814,
+     -5.975073,
+     3.05
+    ],
+    "min": [
+     0.467,
+     -9.7475,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 32063,
+   "ifc_type": "IfcStairFlight",
+   "status": "ok",
+   "tri_count": 1152,
+   "vertex_count": 638,
+   "volume": 0.208445
+  },
+  {
+   "bbox": {
+    "max": [
+     1.4314,
+     -5.975,
+     3.1
+    ],
+    "min": [
+     1.3814,
+     -9.725,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 32096,
+   "ifc_type": "IfcMember",
+   "status": "ok",
+   "tri_count": 20,
+   "vertex_count": 12,
+   "volume": 0.092621
+  },
+  {
+   "bbox": {
+    "max": [
+     0.467,
+     -5.975,
+     3.1
+    ],
+    "min": [
+     0.417,
+     -9.725,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 32115,
+   "ifc_type": "IfcMember",
+   "status": "ok",
+   "tri_count": 20,
+   "vertex_count": 12,
+   "volume": 0.092621
+  },
+  {
+   "bbox": {
+    "max": [
+     0.462,
+     -5.975,
+     4.0
+    ],
+    "min": [
+     0.422,
+     -9.725,
+     1.043144
+    ]
+   },
+   "closed": false,
+   "express_id": 32346,
+   "ifc_type": "IfcRailing",
+   "status": "ok",
+   "tri_count": 72,
+   "vertex_count": 48,
+   "volume": null
+  },
+  {
+   "bbox": {
+    "max": [
+     1.4764,
+     -5.975,
+     4.2
+    ],
+    "min": [
+     1.3864,
+     -9.78,
+     0.248454
+    ]
+   },
+   "closed": false,
+   "express_id": 35163,
+   "ifc_type": "IfcRailing",
+   "status": "ok",
+   "tri_count": 1138,
+   "vertex_count": 708,
+   "volume": null
+  },
+  {
+   "bbox": {
+    "max": [
+     4.03,
+     -9.970051,
+     6.0
+    ],
+    "min": [
+     2.506,
+     -10.094051,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 35199,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 28,
+   "vertex_count": 16,
+   "volume": 0.356031
+  },
+  {
+   "bbox": {
+    "max": [
+     3.288,
+     -9.970051,
+     5.132
+    ],
+    "min": [
+     2.526,
+     -10.094051,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 35241,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.192
+  },
+  {
+   "bbox": {
+    "max": [
+     3.364,
+     -9.945051,
+     5.208
+    ],
+    "min": [
+     2.45,
+     -10.119051,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 35318,
+   "ifc_type": "IfcDoor",
+   "status": "ok",
+   "tri_count": 68,
+   "vertex_count": 40,
+   "volume": 0.097884
+  },
+  {
+   "bbox": {
+    "max": [
+     6.294,
+     -7.721384,
+     6.0
+    ],
+    "min": [
+     4.77,
+     -7.845384,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 35357,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 28,
+   "vertex_count": 16,
+   "volume": 0.356031
+  },
+  {
+   "bbox": {
+    "max": [
+     6.293375,
+     -7.721384,
+     5.132
+    ],
+    "min": [
+     5.531375,
+     -7.845384,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 35399,
+   "ifc_type": "IfcOpeningElement",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.192
+  },
+  {
+   "bbox": {
+    "max": [
+     6.369375,
+     -7.696384,
+     5.208
+    ],
+    "min": [
+     5.455375,
+     -7.870384,
+     3.1
+    ]
+   },
+   "closed": true,
+   "express_id": 35413,
+   "ifc_type": "IfcDoor",
+   "status": "ok",
+   "tri_count": 68,
+   "vertex_count": 40,
+   "volume": 0.097884
+  },
+  {
+   "bbox": {
+    "max": [
+     1.5554,
+     -6.25,
+     3.1
+    ],
+    "min": [
+     1.4314,
+     -9.725,
+     2.612
+    ]
+   },
+   "closed": true,
+   "express_id": 35452,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.210279
+  },
+  {
+   "bbox": {
+    "max": [
+     7.3686,
+     -8.075,
+     3.1
+    ],
+    "min": [
+     7.2446,
+     -11.55,
+     2.612
+    ]
+   },
+   "closed": true,
+   "express_id": 35497,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.210279
+  },
+  {
+   "bbox": {
+    "max": [
+     4.03,
+     -9.320051,
+     3.933
+    ],
+    "min": [
+     3.5546,
+     -9.970051,
+     3.113
+    ]
+   },
+   "closed": true,
+   "express_id": 35783,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 116,
+   "vertex_count": 70,
+   "volume": 2.471245
+  },
+  {
+   "bbox": {
+    "max": [
+     4.03,
+     -8.670051,
+     3.933
+    ],
+    "min": [
+     3.5546,
+     -9.320051,
+     3.113
+    ]
+   },
+   "closed": true,
+   "express_id": 35854,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 116,
+   "vertex_count": 70,
+   "volume": 2.466783
+  },
+  {
+   "bbox": {
+    "max": [
+     5.2454,
+     -8.495384,
+     3.933
+    ],
+    "min": [
+     4.77,
+     -9.145384,
+     3.113
+    ]
+   },
+   "closed": true,
+   "express_id": 36125,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 116,
+   "vertex_count": 70,
+   "volume": 3.579727
+  },
+  {
+   "bbox": {
+    "max": [
+     5.2454,
+     -7.845384,
+     3.933
+    ],
+    "min": [
+     4.77,
+     -8.495384,
+     3.113
+    ]
+   },
+   "closed": true,
+   "express_id": 36151,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 116,
+   "vertex_count": 70,
+   "volume": 3.742572
+  },
+  {
+   "bbox": {
+    "max": [
+     5.2454,
+     -8.9325,
+     0.82
+    ],
+    "min": [
+     4.77,
+     -9.3825,
+     0.0
+    ]
+   },
+   "closed": true,
+   "express_id": 36423,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 116,
+   "vertex_count": 70,
+   "volume": 3.163308
+  },
+  {
+   "bbox": {
+    "max": [
+     1.087,
+     -4.612,
+     3.729
+    ],
+    "min": [
+     0.477,
+     -5.222,
+     3.119
+    ]
+   },
+   "closed": true,
+   "express_id": 36497,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 112,
+   "vertex_count": 64,
+   "volume": 0.039888
+  },
+  {
+   "bbox": {
+    "max": [
+     5.599,
+     -0.512,
+     3.729
+    ],
+    "min": [
+     4.989,
+     -1.122,
+     3.119
+    ]
+   },
+   "closed": true,
+   "express_id": 36526,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 112,
+   "vertex_count": 64,
+   "volume": 0.039888
+  },
+  {
+   "bbox": {
+    "max": [
+     4.035,
+     -16.669,
+     3.729
+    ],
+    "min": [
+     3.425,
+     -17.279,
+     3.119
+    ]
+   },
+   "closed": true,
+   "express_id": 36555,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 112,
+   "vertex_count": 64,
+   "volume": 0.039888
+  },
+  {
+   "bbox": {
+    "max": [
+     8.328,
+     -12.589,
+     3.729
+    ],
+    "min": [
+     7.718,
+     -13.199,
+     3.119
+    ]
+   },
+   "closed": true,
+   "express_id": 36584,
+   "ifc_type": "IfcFurnishingElement",
+   "status": "ok",
+   "tri_count": 112,
+   "vertex_count": 64,
+   "volume": 0.039888
+  },
+  {
+   "bbox": {
+    "max": [
+     4.5015,
+     -10.0,
+     3.1
+    ],
+    "min": [
+     4.2985,
+     -17.4213,
+     2.797
+    ]
+   },
+   "closed": true,
+   "express_id": 36686,
+   "ifc_type": "IfcBeam",
+   "status": "ok",
+   "tri_count": 156,
+   "vertex_count": 80,
+   "volume": 0.057478
+  },
+  {
+   "bbox": {
+    "max": [
+     6.4485,
+     -17.434,
+     3.1
+    ],
+    "min": [
+     0.266613,
+     -17.612,
+     2.693
+    ]
+   },
+   "closed": true,
+   "express_id": 36892,
+   "ifc_type": "IfcBeam",
+   "status": "ok",
+   "tri_count": 156,
+   "vertex_count": 80,
+   "volume": 0.047942
+  },
+  {
+   "bbox": {
+    "max": [
+     0.355613,
+     -13.40172,
+     6.0
+    ],
+    "min": [
+     0.177613,
+     -17.523,
+     5.593
+    ]
+   },
+   "closed": true,
+   "express_id": 37065,
+   "ifc_type": "IfcBeam",
+   "status": "ok",
+   "tri_count": 156,
+   "vertex_count": 80,
+   "volume": 0.031962
+  },
+  {
+   "bbox": {
+    "max": [
+     8.528954,
+     -17.439767,
+     6.0
+    ],
+    "min": [
+     4.428954,
+     -17.617767,
+     5.593
+    ]
+   },
+   "closed": true,
+   "express_id": 37195,
+   "ifc_type": "IfcBeam",
+   "status": "ok",
+   "tri_count": 156,
+   "vertex_count": 80,
+   "volume": 0.031797
+  },
+  {
+   "bbox": {
+    "max": [
+     4.5015,
+     -0.3787,
+     3.1
+    ],
+    "min": [
+     4.2985,
+     -7.8,
+     2.797
+    ]
+   },
+   "closed": true,
+   "express_id": 37325,
+   "ifc_type": "IfcBeam",
+   "status": "ok",
+   "tri_count": 156,
+   "vertex_count": 80,
+   "volume": 0.057478
+  },
+  {
+   "bbox": {
+    "max": [
+     8.533387,
+     -0.188,
+     3.1
+    ],
+    "min": [
+     2.3515,
+     -0.366,
+     2.693
+    ]
+   },
+   "closed": true,
+   "express_id": 37456,
+   "ifc_type": "IfcBeam",
+   "status": "ok",
+   "tri_count": 156,
+   "vertex_count": 80,
+   "volume": 0.047942
+  },
+  {
+   "bbox": {
+    "max": [
+     8.622387,
+     -0.277,
+     6.0
+    ],
+    "min": [
+     8.444387,
+     -4.39828,
+     5.593
+    ]
+   },
+   "closed": true,
+   "express_id": 37586,
+   "ifc_type": "IfcBeam",
+   "status": "ok",
+   "tri_count": 156,
+   "vertex_count": 80,
+   "volume": 0.031962
+  },
+  {
+   "bbox": {
+    "max": [
+     4.371046,
+     -0.182233,
+     6.0
+    ],
+    "min": [
+     0.271046,
+     -0.360233,
+     5.593
+    ]
+   },
+   "closed": true,
+   "express_id": 37716,
+   "ifc_type": "IfcBeam",
+   "status": "ok",
+   "tri_count": 156,
+   "vertex_count": 80,
+   "volume": 0.031797
+  },
+  {
+   "bbox": {
+    "max": [
+     8.4,
+     4.382734,
+     0.013
+    ],
+    "min": [
+     2.6,
+     0.0,
+     -0.137
+    ]
+   },
+   "closed": true,
+   "express_id": 37777,
+   "ifc_type": "IfcSlab",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 3.812979
+  },
+  {
+   "bbox": {
+    "max": [
+     6.2,
+     -17.8,
+     0.013
+    ],
+    "min": [
+     0.4,
+     -22.182734,
+     -0.137
+    ]
+   },
+   "closed": true,
+   "express_id": 37864,
+   "ifc_type": "IfcSlab",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 3.812979
+  },
+  {
+   "bbox": {
+    "max": [
+     7.92355,
+     -6.54045,
+     6.0
+    ],
+    "min": [
+     6.84045,
+     -6.59445,
+     5.712
+    ]
+   },
+   "closed": true,
+   "express_id": 37913,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.016844
+  },
+  {
+   "bbox": {
+    "max": [
+     6.89445,
+     -6.59445,
+     6.0
+    ],
+    "min": [
+     6.84045,
+     -7.72955,
+     5.712
+    ]
+   },
+   "closed": true,
+   "express_id": 37970,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.017653
+  },
+  {
+   "bbox": {
+    "max": [
+     7.97755,
+     -7.67555,
+     6.0
+    ],
+    "min": [
+     6.89445,
+     -7.72955,
+     5.712
+    ]
+   },
+   "closed": true,
+   "express_id": 38015,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.016844
+  },
+  {
+   "bbox": {
+    "max": [
+     7.97755,
+     -6.54045,
+     6.0
+    ],
+    "min": [
+     7.92355,
+     -7.67555,
+     5.712
+    ]
+   },
+   "closed": true,
+   "express_id": 38060,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.017653
+  },
+  {
+   "bbox": {
+    "max": [
+     1.89055,
+     -10.07045,
+     6.0
+    ],
+    "min": [
+     0.80745,
+     -10.12445,
+     5.712
+    ]
+   },
+   "closed": true,
+   "express_id": 38105,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.016844
+  },
+  {
+   "bbox": {
+    "max": [
+     0.86145,
+     -10.12445,
+     6.0
+    ],
+    "min": [
+     0.80745,
+     -11.25955,
+     5.712
+    ]
+   },
+   "closed": true,
+   "express_id": 38150,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.017653
+  },
+  {
+   "bbox": {
+    "max": [
+     1.94455,
+     -11.20555,
+     6.0
+    ],
+    "min": [
+     0.86145,
+     -11.25955,
+     5.712
+    ]
+   },
+   "closed": true,
+   "express_id": 38195,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.016844
+  },
+  {
+   "bbox": {
+    "max": [
+     1.94455,
+     -10.07045,
+     6.0
+    ],
+    "min": [
+     1.89055,
+     -11.20555,
+     5.712
+    ]
+   },
+   "closed": true,
+   "express_id": 38240,
+   "ifc_type": "IfcWallStandardCase",
+   "status": "ok",
+   "tri_count": 12,
+   "vertex_count": 8,
+   "volume": 0.017653
+  }
+ ],
+ "engine": "ifcopenshell 0.8.2",
+ "fixture": "duplex.ifc",
+ "settings": {
+  "use_world_coords": true,
+  "weld_vertices": true
+ },
+ "sha256": "b347a2c8aa8fff6db896a4417a9c50c22ac0ccd7c5cfc22b99b8d29336c606ed",
+ "version": 1
+}

--- a/tools/ifcopenshell_reference/reference/issue_1155_halfspace_flyaway.reference.json
+++ b/tools/ifcopenshell_reference/reference/issue_1155_halfspace_flyaway.reference.json
@@ -1,0 +1,33 @@
+{
+ "elements": [
+  {
+   "bbox": {
+    "max": [
+     12125.0,
+     64600.0,
+     11240.0
+    ],
+    "min": [
+     11875.0,
+     64350.0,
+     -700.0
+    ]
+   },
+   "closed": true,
+   "express_id": 113218,
+   "ifc_type": "IfcColumn",
+   "status": "ok",
+   "tri_count": 2944,
+   "vertex_count": 1472,
+   "volume": 79302453.423546
+  }
+ ],
+ "engine": "ifcopenshell 0.8.2",
+ "fixture": "issue_1155_halfspace_flyaway.ifc",
+ "settings": {
+  "use_world_coords": true,
+  "weld_vertices": true
+ },
+ "sha256": "29b00edd100732871c063ec7bb738360a66956acdf0796eff177c72cc28dcb91",
+ "version": 1
+}

--- a/tools/ifcopenshell_reference/reference/swept_disk_composite_arc_crankbar.reference.json
+++ b/tools/ifcopenshell_reference/reference/swept_disk_composite_arc_crankbar.reference.json
@@ -1,0 +1,33 @@
+{
+ "elements": [
+  {
+   "bbox": {
+    "max": [
+     4.860002,
+     0.018365,
+     0.0185
+    ],
+    "min": [
+     0.0,
+     -0.018365,
+     -0.0655
+    ]
+   },
+   "closed": true,
+   "express_id": 79,
+   "ifc_type": "IfcReinforcingBar",
+   "status": "ok",
+   "tri_count": 516,
+   "vertex_count": 260,
+   "volume": 0.005177
+  }
+ ],
+ "engine": "ifcopenshell 0.8.2",
+ "fixture": "swept_disk_composite_arc_crankbar.ifc",
+ "settings": {
+  "use_world_coords": true,
+  "weld_vertices": true
+ },
+ "sha256": "7653f051eef21dc23e6749770246d2e71ebf45647700ff271ff7d00ddec2fad4",
+ "version": 1
+}

--- a/tools/ifcopenshell_reference/reference/swept_disk_trimmed_line.reference.json
+++ b/tools/ifcopenshell_reference/reference/swept_disk_trimmed_line.reference.json
@@ -1,0 +1,33 @@
+{
+ "elements": [
+  {
+   "bbox": {
+    "max": [
+     2.75,
+     0.014394,
+     0.0145
+    ],
+    "min": [
+     0.0,
+     -0.014394,
+     -0.0145
+    ]
+   },
+   "closed": true,
+   "express_id": 50,
+   "ifc_type": "IfcReinforcingBar",
+   "status": "ok",
+   "tri_count": 100,
+   "vertex_count": 52,
+   "volume": 0.001799
+  }
+ ],
+ "engine": "ifcopenshell 0.8.2",
+ "fixture": "swept_disk_trimmed_line.ifc",
+ "settings": {
+  "use_world_coords": true,
+  "weld_vertices": true
+ },
+ "sha256": "287ccd9d9cfb73623c74168d79162a590dfbe53b4fd8d3f484995b6c1272f9fb",
+ "version": 1
+}

--- a/tools/ifcopenshell_reference/requirements.lock
+++ b/tools/ifcopenshell_reference/requirements.lock
@@ -1,0 +1,3 @@
+ifcopenshell==0.8.2
+numpy==2.0.2
+shapely==2.0.7

--- a/tools/ifcopenshell_reference/test_harness.py
+++ b/tools/ifcopenshell_reference/test_harness.py
@@ -1,0 +1,106 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Known-answer tests for the shared stat functions and the comparator.
+
+Run: python -m unittest test_harness  (stdlib only, no engine required)
+"""
+
+import unittest
+
+import canonical
+import compare
+
+
+def unit_cube() -> tuple[list[float], list[int]]:
+    # 8 vertices, 12 triangles, consistently outward-wound unit cube.
+    v = [
+        0, 0, 0,  1, 0, 0,  1, 1, 0,  0, 1, 0,
+        0, 0, 1,  1, 0, 1,  1, 1, 1,  0, 1, 1,
+    ]
+    f = [
+        0, 2, 1, 0, 3, 2,  # bottom (z=0, wound to face -z)
+        4, 5, 6, 4, 6, 7,  # top
+        0, 1, 5, 0, 5, 4,  # y=0
+        1, 2, 6, 1, 6, 5,  # x=1
+        2, 3, 7, 2, 7, 6,  # y=1
+        3, 0, 4, 3, 4, 7,  # x=0
+    ]
+    return [float(x) for x in v], f
+
+
+class CanonicalKnownAnswers(unittest.TestCase):
+    def test_unit_cube_stats(self):
+        v, f = unit_cube()
+        self.assertEqual(canonical.vertex_count(v), 8)
+        self.assertEqual(canonical.tri_count(f), 12)
+        self.assertEqual(canonical.bbox(v), {"min": [0.0, 0.0, 0.0], "max": [1.0, 1.0, 1.0]})
+        self.assertTrue(canonical.is_closed(f))
+        self.assertAlmostEqual(abs(canonical.signed_volume(v, f)), 1.0, places=9)
+
+    def test_open_mesh_not_closed(self):
+        v, f = unit_cube()
+        self.assertFalse(canonical.is_closed(f[:-6]))  # drop two triangles
+
+    def test_element_record_shape(self):
+        v, f = unit_cube()
+        rec = canonical.element_record(42, "IfcWall", v, f)
+        self.assertEqual(rec["status"], "ok")
+        self.assertEqual(rec["volume"], 1.0)
+        self.assertEqual(rec["tri_count"], 12)
+
+    def test_rounding_kills_negative_zero(self):
+        self.assertEqual(canonical.bbox([-0.0000001, 0, 0, 0, 0, 0])["min"][0], 0.0)
+
+
+class ComparatorClassification(unittest.TestCase):
+    def ok(self, **over):
+        base = {
+            "express_id": 1, "ifc_type": "IfcWall", "status": "ok",
+            "bbox": {"min": [0, 0, 0], "max": [1, 1, 1]},
+            "vertex_count": 8, "tri_count": 12, "volume": 1.0, "closed": True,
+        }
+        base.update(over)
+        return base
+
+    def test_match(self):
+        cls, failing, advisory = compare.classify(self.ok(), self.ok())
+        self.assertEqual((cls, failing, advisory), ("MATCH", [], []))
+
+    def test_bbox_gates(self):
+        other = self.ok(bbox={"min": [0, 0, 0], "max": [1, 1, 1.01]})
+        cls, failing, _ = compare.classify(self.ok(), other)
+        self.assertEqual(cls, "MISMATCH")
+        self.assertIn("bbox", failing)
+
+    def test_volume_gates_when_both_closed_and_plausible(self):
+        cls, failing, _ = compare.classify(self.ok(), self.ok(volume=0.8))
+        self.assertEqual(cls, "MISMATCH")
+        self.assertIn("volume", failing)
+
+    def test_implausible_volume_is_advisory_not_gating(self):
+        # volume exceeding the bbox volume = mixed-winding artifact, not evidence
+        cls, failing, advisory = compare.classify(self.ok(volume=35.0), self.ok())
+        self.assertEqual(cls, "MATCH")
+        self.assertEqual(failing, [])
+        self.assertIn("volume-unverifiable", advisory)
+
+    def test_tri_density_is_advisory(self):
+        cls, failing, advisory = compare.classify(self.ok(tri_count=92), self.ok(tri_count=308))
+        self.assertEqual(cls, "MATCH")
+        self.assertIn("tri_count", advisory)
+
+    def test_reference_only_fails(self):
+        skipped = canonical.skip_record(1, "IfcWall", "RuntimeError")
+        cls, _, _ = compare.classify(self.ok(), skipped)
+        self.assertEqual(cls, "REFERENCE_ONLY")
+
+    def test_ifclite_only_and_both_skip(self):
+        skipped = canonical.skip_record(1, "IfcWall", "x")
+        self.assertEqual(compare.classify(skipped, self.ok())[0], "IFCLITE_ONLY")
+        self.assertEqual(compare.classify(skipped, skipped)[0], "BOTH_SKIP")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The maturity assessment's highest-priority item. **Not to be merged by the agent - review at your leisure.**

## What it replaces
The only external correctness oracle was six hand-transcribed numbers from one pip 0.8.2 run (door_window_calibration_regression.rs). Kernel drift vs a trusted reference engine was invisible until a human re-derived constants.

## What it is
`tools/ifcopenshell_reference/` - out-of-band Python tooling (not a pnpm/Cargo workspace member):
- **one `canonical.py`** computes every stat both sides report, so the comparison measures geometry, never stat-computation differences (known-answer unit-cube tests, 11 passing)
- **`dump_reference.py`** - pinned `ifcopenshell==0.8.2` (the baked constants' exact provenance; `requirements.lock` + Dockerfile), world-coords + welded; engine failures are first-class `skip:<reason>` rows
- **`dump_ifclite.py`** - the shipped `ifclite_geom` binding (welded, absolute-world, Z-up metres by construction; zero new kernel code)
- **`compare.py`** - classifies every element MATCH/MISMATCH/IFCLITE_ONLY/REFERENCE_ONLY/BOTH_SKIP with a **calibrated** gate: metric truth gates (bbox 1 mm, volume 1% when both closed AND physically plausible - a reference 'volume' exceeding its own bbox volume is a mixed-winding artifact, auto-downgraded); triangle/vertex counts are advisory (identical solids, different tessellation densities: duplex wall #5448 = 92 vs 308 tris, volumes agree to 0.001%)
- **`allowlist.json`** - the 2 genuine divergences found (duplex covering #23671, OpenHouse wall #281 volumes), each with an investigation note; allowlisted rows report but never silently pass

## Validation
- Reproduces the baked window **#6426 constants exactly** on both sides (bbox min/extent + 108 triangles) - the live counterpart to the hand-copied numbers
- Committed corpus (8 fixtures, 120 KB): **330 elements - 327 MATCH**, 1 IFCLITE_ONLY (the reference cannot mesh `1030-sphere`; ifc-lite can), 2 allowlisted real divergences

## CI (cost-conscious per the house stance)
- **Per-PR**: ifc-lite vs the committed reference over IN-TREE fixtures only - no engine install, no fixture download; path-gated to geometry changes and deliberately NOT on the required-check needs-list
- **Nightly**: pinned engine, full corpus, reference-staleness warnings, report artifacts (modeled on determinism.yml)

## Follow-ups noted
advanced_model (35 MB, door #561323) joins the corpus via the nightly-generated set; the baked constants in door_window_calibration_regression.rs can then be re-pointed at the committed reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “IfcOpenShell parity” CI workflow with scheduled, pull-request, and manual runs, including automated geometry reference comparisons and diff report artifacts.
  * Added a local parity harness to generate geometry dumps and compare outputs.
  * Added new/updated geometry reference snapshots for multiple fixtures.
* **Bug Fixes**
  * Improved comparison gating rules and allowlisted divergence handling so reviewed differences don’t fail the full gate.
* **Documentation**
  * Added documentation for running and maintaining the parity harness, plus an allowlist guide.
* **Tests**
  * Added a unit test harness validating canonicalization and comparison behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->