### PR TITLE
feat(export): cheap entity_count (scan, no index build) for downstream DoS guards (#1517)

### DIFF
--- a/rust/core/src/lib.rs
+++ b/rust/core/src/lib.rs
@@ -89,7 +89,7 @@ pub use legacy_entities::{
     get_legacy_entity_info, is_legacy_entity, map_legacy_to_base_type, LegacyEntityInfo,
 };
 pub use model_bounds::{scan_model_bounds, scan_placement_bounds, ModelBounds};
-pub use parser::{parse_entity, EntityScanner, Token};
+pub use parser::{entity_count, parse_entity, EntityScanner, Token};
 pub use schema_gen::{AttributeValue, DecodedEntity, GeometryCategory, IfcSchema, ProfileCategory};
 pub use schema_helpers::{has_geometry_by_name, is_simple_geometry_type, legacy_aware_ifc_type};
 pub use step_encoding::{decode_ifc_string, encode_ifc_string};

--- a/rust/core/src/parser/mod.rs
+++ b/rust/core/src/parser/mod.rs
@@ -14,5 +14,5 @@
 mod scanner;
 mod tokenizer;
 
-pub use scanner::EntityScanner;
+pub use scanner::{entity_count, EntityScanner};
 pub use tokenizer::{parse_entity, Token};

--- a/rust/core/src/parser/scanner.rs
+++ b/rust/core/src/parser/scanner.rs
@@ -272,6 +272,23 @@ impl<'a> EntityScanner<'a> {
         counts
     }
 
+    /// Count the entities remaining from the scanner's current position, without
+    /// allocating anything per entity.
+    ///
+    /// Unlike [`count_by_type`](Self::count_by_type) (which builds a per-keyword
+    /// map) or [`build_entity_index`](crate::build_entity_index) (which retains a
+    /// span per entity, ~20 B each), this walks the byte stream and increments a
+    /// single counter: `O(scan)` time, `O(1)` memory. It is the cheap primitive
+    /// for a downstream entity-count DoS guard on a file too large to index
+    /// (issue #1517). Advances the scanner to the end of the data section.
+    pub fn count(&mut self) -> usize {
+        let mut n = 0usize;
+        while self.next_entity().is_some() {
+            n += 1;
+        }
+        n
+    }
+
     /// Reset scanner to beginning (re-applies the HEADER skip).
     pub fn reset(&mut self) {
         self.position = data_section_start(self.bytes);
@@ -372,6 +389,22 @@ impl<'a> EntityScanner<'a> {
 
         false
     }
+}
+
+/// Count the entities in a STEP/IFC byte buffer in `O(scan)` time and `O(1)`
+/// memory — no entity index, no per-type map.
+///
+/// A thin wrapper over [`EntityScanner::count`]. This is the cheap primitive a
+/// downstream can use to reject a file with a pathologically large entity count
+/// that a byte-size cap would miss, WITHOUT paying the ~20 B/entity the full
+/// index costs (issue #1517). Header-aware and comment-/string-safe, exactly
+/// like the scanner (it IS the scanner), so the count matches what
+/// [`build_entity_index`](crate::build_entity_index) would find.
+pub fn entity_count<T>(content: &T) -> usize
+where
+    T: AsRef<[u8]> + ?Sized,
+{
+    EntityScanner::new(content).count()
 }
 
 /// Locate the byte offset of the first character after `DATA;` (skipping the
@@ -515,6 +548,39 @@ ENDSEC;\nEND-ISO-10303-21;\n";
         // Confirm we landed at the real DATA;, not the one in the description.
         let pos = scanner.position();
         assert!(pos == content.len() || pos > content.find("ENDSEC;").unwrap());
+    }
+
+    /// `count` / `entity_count` must agree with the number of entities the
+    /// scanner walks (and with the entity index), while allocating nothing per
+    /// entity. It shares `next_entity`, so it inherits the header-skip and the
+    /// quote/comment guards for free.
+    #[test]
+    fn test_entity_count_matches_scan() {
+        let content = "ISO-10303-21;\nHEADER;\n\
+FILE_DESCRIPTION(('has a #99 and DATA; inside'),'2;1');\n\
+FILE_NAME('26-IFC\\X2\\00B1\\X0\\2#.ifc','2026-04-29T18:21:27',$,$,'a','b',$);\n\
+FILE_SCHEMA(('IFC4'));\nENDSEC;\n\
+DATA;\n\
+#1=IFCPROJECT('guid',$,$,$,$,$,$,$,$);\n\
+/* a comment with #77= IFCWALL inside */\n\
+#2=IFCWALL('guid2',$,$,$,'name with ; semicolon',$,$,$);\n\
+#3=IFCDOOR('guid3',$,$,$,$,$,$,$);\n\
+ENDSEC;\nEND-ISO-10303-21;\n";
+
+        // Free function.
+        assert_eq!(entity_count(content), 3);
+        // Method, from a fresh scanner.
+        assert_eq!(EntityScanner::new(content).count(), 3);
+        // Agrees with the per-type tally (which walks the same entities).
+        let total: usize = EntityScanner::new(content).count_by_type().values().sum();
+        assert_eq!(total, 3);
+    }
+
+    /// An empty / header-only buffer counts zero, never panics.
+    #[test]
+    fn test_entity_count_empty() {
+        assert_eq!(entity_count(""), 0);
+        assert_eq!(entity_count("ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\nENDSEC;\n"), 0);
     }
 
     /// Escaped single quotes (`''`) keep the string open per ISO 10303-21.

--- a/rust/export/src/lib.rs
+++ b/rust/export/src/lib.rs
@@ -42,7 +42,12 @@ pub use hbjson::Model;
 // Re-exported so a caller can `build_entity_index` once and share it across the
 // geometry (`export_glb_with_stats_with_index`) and attribute
 // (`stream_export_model_with_index`) passes.
-pub use ifc_lite_core::{build_entity_index, EntityIndex};
+//
+// `entity_count` is the cheap `O(scan)`, `O(1)`-memory entity tally (issue
+// #1517): a downstream DoS guard can reject a file with a pathological entity
+// count WITHOUT forcing the full index (`build_entity_index(..).len()` would
+// allocate ~20 B/entity — undoing the bounded-memory work).
+pub use ifc_lite_core::{build_entity_index, entity_count, EntityIndex};
 pub use ifc5::{export_ifc5, Ifc5Options};
 pub use json::{export_json, JsonOptions};
 pub use jsonld::{export_jsonld, JsonLdOptions};
@@ -163,6 +168,21 @@ mod tests {
     fn fixture(rel: &str) -> Option<Vec<u8>> {
         let path = format!("{}/../../tests/models/{}", env!("CARGO_MANIFEST_DIR"), rel);
         std::fs::read(path).ok()
+    }
+
+    #[test]
+    fn entity_count_reexport_matches_index() {
+        // The re-exported cheap tally must equal the full index's entity count
+        // (both walk the same scanner) — so a downstream can gate on the count
+        // without paying for the index. Well-formed fixtures have unique ids, so
+        // the index map length equals the scanned entity count.
+        let Some(bytes) = fixture("ara3d/duplex.ifc") else {
+            return;
+        };
+        let counted = entity_count(&bytes);
+        let indexed = build_entity_index(&bytes).len();
+        assert!(counted > 0, "expected entities");
+        assert_eq!(counted, indexed, "cheap count must match the index length");
     }
 
     #[test]

--- a/rust/export/src/lib.rs
+++ b/rust/export/src/lib.rs
@@ -177,6 +177,9 @@ mod tests {
         // without paying for the index. Well-formed fixtures have unique ids, so
         // the index map length equals the scanned entity count.
         let Some(bytes) = fixture("ara3d/duplex.ifc") else {
+            eprintln!(
+                "skipping entity_count_reexport_matches_index: fixture absent — run `pnpm fixtures`"
+            );
             return;
         };
         let counted = entity_count(&bytes);


### PR DESCRIPTION
Closes #1517.

## Problem
A downstream consumer wants an **entity-count cap** to reject a file with a pathologically large entity count that a byte-size cap wouldn't catch. Post-#1472 the entity index is lazy, so `build_entity_index(..).len()` forces the full `FxHashMap` (~20 B/entity, ~1.5 GB at 74 M entities) — undoing the bounded-memory work.

## Change
- `EntityScanner::count(&mut self) -> usize` — `O(scan)` time, `O(1)` memory.
- Free `ifc_lite_core::entity_count(content) -> usize`.
- Re-exported from `ifc-lite-export` alongside `build_entity_index` / `EntityIndex`.

Because it *is* the scanner (`next_entity`), it inherits the HEADER skip and the quote-/comment-aware guards, so the count matches the entity set `build_entity_index` would find.

## Tests
- count agrees with the scanner and `count_by_type` across an in-header `#`, a `DATA;` inside a header string, a `/* … */` comment, and a `;` inside a quoted attribute; empty/header-only buffers count zero; the re-export equals `build_entity_index(..).len()` on a real fixture.

Rust-only crate API addition; no wasm/TS surface.