### PR TITLE
fix(geometry): render IfcSurfaceCurveSweptAreaSolid duct elbows (#1485)

### DIFF
--- a/.changeset/duct-elbow-surface-curve-swept.md
+++ b/.changeset/duct-elbow-surface-curve-swept.md
@@ -1,0 +1,6 @@
+---
+"@ifc-lite/geometry": patch
+"@ifc-lite/wasm": patch
+---
+
+Render `IfcSurfaceCurveSweptAreaSolid` and `IfcFixedReferenceSweptAreaSolid` solids. Round HVAC duct elbows — a circular profile swept along a trimmed circular-arc directrix, how Revit exports IFC4.3 duct bends — had no geometry processor registered and were silently dropped from the model. They now mesh as swept tubes (a rotation-minimising frame carries the section along the directrix, exact for the circular cross-sections these fittings use). Fixes #1485.

--- a/rust/geometry/src/processors/mod.rs
+++ b/rust/geometry/src/processors/mod.rs
@@ -50,7 +50,9 @@ pub use extrusion_tapered::ExtrudedAreaSolidTaperedProcessor;
 pub use mapped::MappedItemProcessor;
 pub use sectioned::SectionedSolidHorizontalProcessor;
 pub use surface::SurfaceOfLinearExtrusionProcessor;
-pub use swept::{RevolvedAreaSolidProcessor, SweptDiskSolidProcessor};
+pub use swept::{
+    RevolvedAreaSolidProcessor, SurfaceCurveSweptAreaSolidProcessor, SweptDiskSolidProcessor,
+};
 pub use tessellated::{PolygonalFaceSetProcessor, TriangulatedFaceSetProcessor};
 pub use texture::{build_texture_index, MeshTexture, ResolvedTextureMap};
 

--- a/rust/geometry/src/processors/swept/disk.rs
+++ b/rust/geometry/src/processors/swept/disk.rs
@@ -23,7 +23,7 @@ use crate::router::GeometryProcessor;
 /// by rotating it from `tangents[i-1]` onto `tangents[i]` (the minimum rotation
 /// that aligns them). When consecutive tangents are parallel the frame stays
 /// untouched.
-fn build_tube_rmf(
+pub(crate) fn build_tube_rmf(
     curve_points: &[Point3<f64>],
 ) -> (Vec<Vector3<f64>>, Vec<Vector3<f64>>, Vec<Vector3<f64>>) {
     let n = curve_points.len();

--- a/rust/geometry/src/processors/swept/mod.rs
+++ b/rust/geometry/src/processors/swept/mod.rs
@@ -2,10 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-//! Swept geometry processors - SweptDiskSolid and RevolvedAreaSolid.
+//! Swept geometry processors - SweptDiskSolid, RevolvedAreaSolid and
+//! SurfaceCurveSweptAreaSolid.
 
 mod disk;
 mod revolved;
+mod surface_curve;
 
 pub use disk::SweptDiskSolidProcessor;
 pub use revolved::RevolvedAreaSolidProcessor;
+pub use surface_curve::SurfaceCurveSweptAreaSolidProcessor;

--- a/rust/geometry/src/processors/swept/surface_curve.rs
+++ b/rust/geometry/src/processors/swept/surface_curve.rs
@@ -1,0 +1,257 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! `IfcSurfaceCurveSweptAreaSolid` / `IfcFixedReferenceSweptAreaSolid` — a 2D
+//! `SweptArea` profile swept along a `Directrix` curve.
+
+use crate::{
+    profile::Profile2D, profiles::ProfileProcessor, Error, Mesh, Point3, Result,
+    TessellationQuality, Vector3,
+};
+use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcSchema, IfcType};
+use nalgebra::Matrix4;
+
+use super::super::helpers::parse_axis2_placement_3d;
+use super::disk::build_tube_rmf;
+use crate::router::GeometryProcessor;
+
+/// Processor for `IfcSurfaceCurveSweptAreaSolid` and `IfcFixedReferenceSweptAreaSolid`.
+///
+/// Sweeps the inherited `SweptArea` profile along the `Directrix` curve, then
+/// applies the solid's `Position`. This is the representation Revit emits for
+/// round HVAC duct elbows: an `IfcCircleProfileDef` swept along a trimmed
+/// circular-arc directrix. Before this processor existed the elbows produced no
+/// geometry at all because the router had no handler for the type — every
+/// duct-elbow body was silently dropped (issue #1485).
+///
+/// The cross-section is oriented along the sweep with a rotation-minimising
+/// frame (RMF), identical to `IfcSweptDiskSolid`. For a circular profile the RMF
+/// is orientation-independent, so the swept tube is geometrically exact. For a
+/// planar directrix (every duct elbow) the RMF also keeps a non-circular
+/// section's out-of-plane axis stable, matching the natural placement. The exact
+/// reference-surface / fixed-reference roll of a *non-circular* section swept
+/// along a *non-planar* directrix is not modelled (no such case is known in the
+/// wild); the shape is still produced, only its roll about the tangent may
+/// differ. Both entity types share the attribute layout for slots 0..=4 and only
+/// differ in slot 5 (a reference surface vs. a fixed direction), which this RMF
+/// path does not consult, so one processor handles both.
+pub struct SurfaceCurveSweptAreaSolidProcessor {
+    profile_processor: ProfileProcessor,
+}
+
+impl SurfaceCurveSweptAreaSolidProcessor {
+    pub fn new(schema: IfcSchema) -> Self {
+        Self {
+            profile_processor: ProfileProcessor::new(schema),
+        }
+    }
+}
+
+impl GeometryProcessor for SurfaceCurveSweptAreaSolidProcessor {
+    fn process(
+        &self,
+        entity: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+        _schema: &IfcSchema,
+        quality: TessellationQuality,
+    ) -> Result<Mesh> {
+        // Shared IfcSweptAreaSolid attributes plus the swept-curve extension:
+        //   0: SweptArea  (IfcProfileDef)         - 2D section in xy of Position
+        //   1: Position   (IfcAxis2Placement3D)   - places the whole solid (opt.)
+        //   2: Directrix  (IfcCurve)              - path swept along
+        //   3: StartParam (IfcParameterValue)     - optional
+        //   4: EndParam   (IfcParameterValue)     - optional
+        //   5: ReferenceSurface / FixedReference  - orientation (see type docs)
+
+        // --- SweptArea -> Profile2D ------------------------------------------------
+        let profile_attr = entity.get(0).ok_or_else(|| {
+            Error::geometry("SurfaceCurveSweptAreaSolid missing SweptArea".to_string())
+        })?;
+        let profile_entity = decoder
+            .resolve_ref(profile_attr)?
+            .ok_or_else(|| Error::geometry("Failed to resolve SweptArea".to_string()))?;
+        self.profile_processor.set_tessellation_quality(quality);
+        let profile = self
+            .profile_processor
+            .process(&profile_entity, decoder, quality)?;
+        if profile.outer.len() < 3 {
+            return Ok(Mesh::new());
+        }
+
+        // --- Directrix -> 3D sample points -----------------------------------------
+        let directrix_attr = entity.get(2).ok_or_else(|| {
+            Error::geometry("SurfaceCurveSweptAreaSolid missing Directrix".to_string())
+        })?;
+        let directrix = decoder
+            .resolve_ref(directrix_attr)?
+            .ok_or_else(|| Error::geometry("Failed to resolve Directrix".to_string()))?;
+
+        let start_param = entity.get_float(3);
+        let end_param = entity.get_float(4);
+        let has_trim = start_param.is_some() || end_param.is_some();
+
+        // Mirror IfcSweptDiskSolid's directrix sampling so composite / polyline /
+        // line directrixes honour the solid-level Start/EndParam. A trimmed conic
+        // (the duct-elbow case) carries its own Trim1/Trim2, so get_curve_points
+        // already returns just the swept arc and the redundant solid params are a
+        // no-op.
+        let curve_points =
+            if has_trim && directrix.ifc_type.is_subtype_of(IfcType::IfcCompositeCurve) {
+                self.profile_processor.get_composite_curve_points_trimmed(
+                    &directrix,
+                    decoder,
+                    start_param,
+                    end_param,
+                )?
+            } else if has_trim && directrix.ifc_type == IfcType::IfcPolyline {
+                self.profile_processor.get_polyline_points_trimmed(
+                    &directrix,
+                    decoder,
+                    start_param,
+                    end_param,
+                )?
+            } else if has_trim && directrix.ifc_type == IfcType::IfcLine {
+                self.profile_processor.get_line_points_3d(
+                    &directrix,
+                    decoder,
+                    start_param.unwrap_or(0.0),
+                    end_param.unwrap_or(1.0),
+                )?
+            } else {
+                self.profile_processor
+                    .get_curve_points(&directrix, decoder, quality)?
+            };
+
+        // Drop consecutive coincident samples — a zero-length step yields a NaN
+        // tangent in the RMF and shatters the tube.
+        let mut points: Vec<Point3<f64>> = Vec::with_capacity(curve_points.len());
+        for p in curve_points {
+            if points
+                .last()
+                .is_none_or(|last: &Point3<f64>| (p - *last).norm() > 1e-9)
+            {
+                points.push(p);
+            }
+        }
+        if points.len() < 2 {
+            return Ok(Mesh::new());
+        }
+
+        // --- Position: place the whole solid ---------------------------------------
+        let position: Matrix4<f64> = match entity.get(1) {
+            Some(pos_attr) if !pos_attr.is_null() => match decoder.resolve_ref(pos_attr)? {
+                Some(pos_entity) => parse_axis2_placement_3d(&pos_entity, decoder)?,
+                None => Matrix4::identity(),
+            },
+            _ => Matrix4::identity(),
+        };
+        for p in &mut points {
+            *p = position.transform_point(p);
+        }
+
+        // --- Sweep the profile along the placed directrix --------------------------
+        let (_, perp1s, perp2s) = build_tube_rmf(&points);
+        sweep_profile_along_frames(&profile, &points, &perp1s, &perp2s)
+    }
+
+    fn supported_types(&self) -> Vec<IfcType> {
+        vec![
+            IfcType::IfcSurfaceCurveSweptAreaSolid,
+            IfcType::IfcFixedReferenceSweptAreaSolid,
+        ]
+    }
+}
+
+impl Default for SurfaceCurveSweptAreaSolidProcessor {
+    fn default() -> Self {
+        Self::new(IfcSchema::new())
+    }
+}
+
+/// Sweep a 2D `profile` (outer boundary + holes) along the directrix samples
+/// `points`, placing the section into each per-sample frame `(perp1, perp2)`.
+/// Emits side walls for every loop plus triangulated end caps, then computes
+/// smooth per-vertex normals in the directrix-local frame (small coordinates,
+/// precise) exactly like `IfcSweptDiskSolid`.
+///
+/// Vertex layout is one contiguous "ring" per directrix sample, each ring
+/// ordered as `outer` points then every hole's points — the same order
+/// `Profile2D::triangulate` emits, so the cap triangle indices address ring
+/// slots directly.
+fn sweep_profile_along_frames(
+    profile: &Profile2D,
+    points: &[Point3<f64>],
+    perp1s: &[Vector3<f64>],
+    perp2s: &[Vector3<f64>],
+) -> Result<Mesh> {
+    let n = points.len();
+    if n < 2 || perp1s.len() != n || perp2s.len() != n {
+        return Ok(Mesh::new());
+    }
+
+    // Loop slices in triangulation order: outer first, then each hole.
+    let loops: Vec<&[nalgebra::Point2<f64>]> = std::iter::once(profile.outer.as_slice())
+        .chain(profile.holes.iter().map(|h| h.as_slice()))
+        .collect();
+    let ring_len: usize = loops.iter().map(|l| l.len()).sum();
+    if ring_len < 3 {
+        return Ok(Mesh::new());
+    }
+
+    let mut mesh = Mesh::with_capacity(n * ring_len, 0);
+
+    // Ring vertices, sample by sample. Placeholder normals are overwritten by
+    // calculate_normals below.
+    let placeholder = Vector3::new(0.0, 0.0, 1.0);
+    for i in 0..n {
+        let p = points[i];
+        let u = perp1s[i];
+        let v = perp2s[i];
+        for loop_pts in &loops {
+            for pt in loop_pts.iter() {
+                mesh.add_vertex(p + u * pt.x + v * pt.y, placeholder);
+            }
+        }
+    }
+
+    // Side walls: connect ring i to ring i+1 for each loop, wrapping the loop.
+    // `calculate_normals` uses (v1-v0)x(v2-v0); with a CCW outer loop the winding
+    // below yields +perp1 (radially outward) face normals. A CW hole loop flips
+    // the sign so its wall normal faces into the void.
+    for i in 0..n - 1 {
+        let base_i = (i * ring_len) as u32;
+        let base_next = ((i + 1) * ring_len) as u32;
+        let mut loop_start = 0u32;
+        for loop_pts in &loops {
+            let m = loop_pts.len() as u32;
+            if m >= 2 {
+                for j in 0..m {
+                    let jn = (j + 1) % m;
+                    let a = base_i + loop_start + j;
+                    let b = base_i + loop_start + jn;
+                    let c = base_next + loop_start + j;
+                    let d = base_next + loop_start + jn;
+                    mesh.add_triangle(a, d, c);
+                    mesh.add_triangle(a, b, d);
+                }
+            }
+            loop_start += m;
+        }
+    }
+
+    // End caps from the profile triangulation (handles holes). The start cap
+    // faces -tangent (reversed winding), the end cap faces +tangent.
+    if let Ok(tri) = profile.triangulate() {
+        let base_first = 0u32;
+        let base_last = ((n - 1) * ring_len) as u32;
+        for t in tri.indices.chunks_exact(3) {
+            let (i0, i1, i2) = (t[0] as u32, t[1] as u32, t[2] as u32);
+            mesh.add_triangle(base_first + i0, base_first + i2, base_first + i1);
+            mesh.add_triangle(base_last + i0, base_last + i1, base_last + i2);
+        }
+    }
+
+    crate::calculate_normals(&mut mesh);
+    Ok(mesh)
+}

--- a/rust/geometry/src/router/mod.rs
+++ b/rust/geometry/src/router/mod.rs
@@ -37,7 +37,7 @@ use crate::processors::{
     FaceBasedSurfaceModelProcessor, FacetedBrepProcessor, IfcAlignmentProcessor,
     MappedItemProcessor, PolygonalFaceSetProcessor, RevolvedAreaSolidProcessor,
     SectionedSolidHorizontalProcessor, ShellBasedSurfaceModelProcessor, SphereProcessor,
-    SweptDiskSolidProcessor, TriangulatedFaceSetProcessor,
+    SurfaceCurveSweptAreaSolidProcessor, SweptDiskSolidProcessor, TriangulatedFaceSetProcessor,
 };
 use crate::tessellation::TessellationQuality;
 use crate::{BoolFailure, Mesh, Result};
@@ -205,6 +205,9 @@ impl GeometryRouter {
         router.register(Box::new(BooleanClippingProcessor::new()));
         router.register(Box::new(SweptDiskSolidProcessor::new(schema_clone.clone())));
         router.register(Box::new(RevolvedAreaSolidProcessor::new(
+            schema_clone.clone(),
+        )));
+        router.register(Box::new(SurfaceCurveSweptAreaSolidProcessor::new(
             schema_clone.clone(),
         )));
         router.register(Box::new(SectionedSolidHorizontalProcessor::new(

--- a/rust/geometry/tests/fixtures/issue_1485_duct_elbow_surface_curve_swept.ifc
+++ b/rust/geometry/tests/fixtures/issue_1485_duct_elbow_surface_curve_swept.ifc
@@ -1,0 +1,67 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('issue_1485_duct_elbow_surface_curve_swept.ifc','2026-07-02T00:00:00',(''),(''),'ifc-lite neutral fixture','ifc-lite','');
+FILE_SCHEMA(('IFC4X3_ADD2'));
+ENDSEC;
+DATA;
+/* Units: millimetres, plane angle in DEGREES (Revit HVAC convention). The
+   trimmed-arc directrix parameters below are therefore read as degrees. */
+#1=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);
+#2=IFCSIUNIT(*,.PLANEANGLEUNIT.,$,.RADIAN.);
+#3=IFCDIMENSIONALEXPONENTS(0,0,0,0,0,0,0);
+#4=IFCMEASUREWITHUNIT(IFCPLANEANGLEMEASURE(0.017453292519943295),#2);
+#5=IFCCONVERSIONBASEDUNIT(#3,.PLANEANGLEUNIT.,'DEGREE',#4);
+#6=IFCUNITASSIGNMENT((#1,#5));
+/* Representation context */
+#10=IFCCARTESIANPOINT((0.,0.,0.));
+#11=IFCAXIS2PLACEMENT3D(#10,$,$);
+#12=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,0.01,#11,$);
+#13=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body','Model',*,*,*,*,#12,$,.MODEL_VIEW.,$);
+#20=IFCPROJECT('0P00000000000000000000',$,'Duct elbow fixture',$,$,$,$,(#12),#6);
+/* Identity placement shared by the spatial tree and the fitting */
+#30=IFCAXIS2PLACEMENT3D(#10,$,$);
+#31=IFCLOCALPLACEMENT($,#30);
+/* --- Round duct elbow, 90 degrees --------------------------------------------
+   SweptArea  : circle radius 50 mm, centred on origin (the duct bore).
+   Directrix  : circle radius 150 mm centred at (0,150) in the XY plane, trimmed
+                270deg -> 0deg (a 90deg quarter arc from (0,0) to (150,150)).
+   Reference  : surface of linear extrusion of the directrix along +Z.
+   The bend lies in the XY plane so the swept tube's Z extent is exactly the
+   duct diameter (2 x 50 = 100 mm) - a clean geometric correctness check. */
+#40=IFCCARTESIANPOINT((0.,0.));
+#41=IFCDIRECTION((1.,0.));
+#42=IFCAXIS2PLACEMENT2D(#40,#41);
+#43=IFCCIRCLEPROFILEDEF(.AREA.,'bore',#42,50.);
+#44=IFCCARTESIANPOINT((0.,150.));
+#45=IFCDIRECTION((1.,0.));
+#46=IFCAXIS2PLACEMENT2D(#44,#45);
+#47=IFCCIRCLE(#46,150.);
+#48=IFCTRIMMEDCURVE(#47,(IFCPARAMETERVALUE(270.)),(IFCPARAMETERVALUE(0.)),.T.,.PARAMETER.);
+#49=IFCARBITRARYOPENPROFILEDEF(.CURVE.,$,#48);
+#50=IFCCARTESIANPOINT((0.,0.,0.));
+#51=IFCAXIS2PLACEMENT3D(#50,$,$);
+#52=IFCDIRECTION((0.,0.,1.));
+#53=IFCSURFACEOFLINEAREXTRUSION(#49,#51,#52,1.);
+#54=IFCAXIS2PLACEMENT3D(#10,$,$);
+#55=IFCSURFACECURVESWEPTAREASOLID(#43,#54,#48,IFCPARAMETERVALUE(0.),IFCPARAMETERVALUE(90.),#53);
+#56=IFCSHAPEREPRESENTATION(#13,'Body','AdvancedSweptSolid',(#55));
+#57=IFCPRODUCTDEFINITIONSHAPE($,$,(#56));
+#58=IFCDUCTFITTING('0F00000000000000000000',$,'Round elbow',$,$,#31,#57,$,.BEND.);
+/* The same elbow as an IfcFixedReferenceSweptAreaSolid (shares the profile,
+   position and directrix). Slots 0..4 match IfcSurfaceCurveSweptAreaSolid; only
+   slot 5 differs (a FixedReference direction rather than a reference surface),
+   so a single processor handles both. */
+#70=IFCDIRECTION((0.,0.,1.));
+#71=IFCFIXEDREFERENCESWEPTAREASOLID(#43,#54,#48,IFCPARAMETERVALUE(0.),IFCPARAMETERVALUE(90.),#70);
+#72=IFCSHAPEREPRESENTATION(#13,'Body','AdvancedSweptSolid',(#71));
+#73=IFCPRODUCTDEFINITIONSHAPE($,$,(#72));
+#74=IFCDUCTFITTING('0G00000000000000000000',$,'Round elbow (fixed ref)',$,$,#31,#73,$,.BEND.);
+/* Minimal spatial tree so the fixture loads as a complete model */
+#60=IFCBUILDING('0B00000000000000000000',$,'Building',$,$,#31,$,$,.ELEMENT.,$,$,$);
+#61=IFCBUILDINGSTOREY('0S00000000000000000000',$,'Storey',$,$,#31,$,$,.ELEMENT.,0.);
+#62=IFCRELAGGREGATES('0R00000000000000000001',$,$,$,#20,(#60));
+#63=IFCRELAGGREGATES('0R00000000000000000002',$,$,$,#60,(#61));
+#64=IFCRELCONTAINEDINSPATIALSTRUCTURE('0R00000000000000000003',$,$,$,(#58,#74),#61);
+ENDSEC;
+END-ISO-10303-21;

--- a/rust/geometry/tests/issue_1485_duct_elbow_surface_curve_swept.rs
+++ b/rust/geometry/tests/issue_1485_duct_elbow_surface_curve_swept.rs
@@ -1,0 +1,235 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Regression test for issue #1485 — round HVAC duct elbows exported by Revit as
+//! `IfcSurfaceCurveSweptAreaSolid` (a circular `SweptArea` swept along a trimmed
+//! circular-arc `Directrix`) rendered as **nothing**: the geometry router had no
+//! processor registered for the type, so every elbow body was silently dropped.
+//!
+//! The fixture is a neutral, self-contained reproduction of the reported
+//! geometry chain (no data from the reporter's model): a 90-degree round elbow
+//! with a 50 mm bore radius swept along a 150 mm bend-radius arc that lies in the
+//! XY plane. Because the bend is planar, a correctly swept tube is exactly the
+//! bore diameter (100 mm) thick in Z, and its surface stays exactly one bore
+//! radius from the arc centre-line — both are checked below. A second fitting
+//! repeats the elbow as an `IfcFixedReferenceSweptAreaSolid` (same processor).
+
+use ifc_lite_core::{EntityDecoder, IfcType};
+use ifc_lite_geometry::{GeometryRouter, Mesh, ProfileProcessor, TessellationQuality};
+
+const FIXTURE: &str = "tests/fixtures/issue_1485_duct_elbow_surface_curve_swept.ifc";
+
+// Fixture parameters, in metres (the fixture authors them in millimetres).
+const BORE_R: f32 = 0.050; // SweptArea circle radius
+const BEND_R: f32 = 0.150; // directrix arc radius
+const CENTER: [f32; 3] = [0.0, 0.150, 0.0]; // directrix arc centre, in the z=0 plane
+
+fn read_fixture() -> String {
+    std::fs::read_to_string(FIXTURE).unwrap_or_else(|e| panic!("read fixture {FIXTURE}: {e}"))
+}
+
+fn bounds(mesh: &Mesh) -> ([f32; 3], [f32; 3]) {
+    let mut min = [f32::INFINITY; 3];
+    let mut max = [f32::NEG_INFINITY; 3];
+    for c in mesh.positions.chunks_exact(3) {
+        for a in 0..3 {
+            min[a] = min[a].min(c[a]);
+            max[a] = max[a].max(c[a]);
+        }
+    }
+    (min, max)
+}
+
+/// Distance from a point to the arc centre-line circle (radius `BEND_R`,
+/// centred at `CENTER`, lying in the z = CENTER.z plane).
+fn dist_to_centerline(p: &[f32]) -> f32 {
+    let dx = p[0] - CENTER[0];
+    let dy = p[1] - CENTER[1];
+    let dz = p[2] - CENTER[2];
+    let radial = (dx * dx + dy * dy).sqrt(); // distance from the circle's axis
+    ((radial - BEND_R).powi(2) + dz * dz).sqrt()
+}
+
+/// Nearest point on the centre-line circle to `p`. Returns `None` on the axis
+/// where the nearest point is undefined.
+fn nearest_centerline(p: &[f32]) -> Option<[f32; 3]> {
+    let dx = p[0] - CENTER[0];
+    let dy = p[1] - CENTER[1];
+    let radial = (dx * dx + dy * dy).sqrt();
+    if radial < 1e-5 {
+        return None;
+    }
+    Some([
+        CENTER[0] + dx / radial * BEND_R,
+        CENTER[1] + dy / radial * BEND_R,
+        CENTER[2],
+    ])
+}
+
+fn process_fitting(id: u32) -> Mesh {
+    let content = read_fixture();
+    let entity_index = ifc_lite_core::build_entity_index(&content);
+    let mut decoder = EntityDecoder::with_index(&content, entity_index);
+    let router = GeometryRouter::with_units(&content, &mut decoder);
+    let fitting = decoder
+        .decode_by_id(id)
+        .unwrap_or_else(|e| panic!("decode fitting #{id}: {e:?}"));
+    assert_eq!(fitting.ifc_type, IfcType::IfcDuctFitting);
+    router
+        .process_element(&fitting, &mut decoder)
+        .unwrap_or_else(|e| panic!("process fitting #{id}: {e:?}"))
+}
+
+/// The core regression: the swept elbow must produce a real, correctly shaped
+/// tube (pre-fix it produced an empty mesh).
+fn assert_elbow_is_a_tube(id: u32, label: &str) {
+    let mesh = process_fitting(id);
+
+    let tris = mesh.indices.len() / 3;
+    assert!(
+        tris > 200,
+        "{label} #{id}: only {tris} triangles — the swept elbow was dropped or degenerate \
+         (issue #1485 regression)"
+    );
+
+    let (min, max) = bounds(&mesh);
+    let span = [max[0] - min[0], max[1] - min[1], max[2] - min[2]];
+
+    // The bend is planar in XY, so the tube is exactly the bore diameter thick in
+    // Z. This pins the bore radius and proves the section did not twist out of
+    // plane.
+    let diameter = 2.0 * BORE_R;
+    assert!(
+        (span[2] - diameter).abs() < 0.003,
+        "{label} #{id}: Z span {:.4} m, expected the bore diameter {diameter:.3} m",
+        span[2]
+    );
+
+    // The in-plane extent must reflect the 150 mm bend arc plus the bore, not a
+    // collapsed section: roughly (BEND_R + BORE_R) .. so ~0.2 m each.
+    for axis in [0usize, 1] {
+        assert!(
+            span[axis] > 0.18 && span[axis] < 0.22,
+            "{label} #{id}: axis {axis} span {:.4} m, expected ~0.20 m (arc + bore)",
+            span[axis]
+        );
+    }
+
+    // Adversarial shape check: every vertex must sit within one bore radius of the
+    // arc centre-line (a genuine tube), and the wall must actually reach the bore
+    // radius. A wrong radius, an off-axis sweep, or a flattened/ballooned tube all
+    // break this.
+    let mut worst_outside = 0.0f32;
+    let mut reaches = 0.0f32;
+    for p in mesh.positions.chunks_exact(3) {
+        let d = dist_to_centerline(p);
+        worst_outside = worst_outside.max(d - BORE_R); // > 0 means outside the tube
+        reaches = reaches.max(d);
+    }
+    assert!(
+        worst_outside < 0.003,
+        "{label} #{id}: a vertex sits {:.4} m outside the {BORE_R:.3} m bore tube \
+         — the sweep radius/axis is wrong",
+        worst_outside
+    );
+    assert!(
+        (reaches - BORE_R).abs() < 0.003,
+        "{label} #{id}: tube wall reaches only {reaches:.4} m from the centre-line, \
+         expected the bore radius {BORE_R:.3} m",
+    );
+
+    // Normals must face outward (radially away from the arc centre-line). A
+    // flipped sweep winding renders the tube lit inside-out. Averaged smooth
+    // normals at the cap seams tilt, so require a strong majority rather than
+    // every vertex.
+    assert_eq!(mesh.normals.len(), mesh.positions.len(), "missing normals");
+    let (mut wall, mut outward) = (0u32, 0u32);
+    for i in 0..mesh.positions.len() / 3 {
+        let p = &mesh.positions[3 * i..3 * i + 3];
+        if (dist_to_centerline(p) - BORE_R).abs() > 0.006 {
+            continue; // cap interior, not a wall vertex
+        }
+        let Some(cl) = nearest_centerline(p) else {
+            continue;
+        };
+        let out = [p[0] - cl[0], p[1] - cl[1], p[2] - cl[2]];
+        let out_len = (out[0] * out[0] + out[1] * out[1] + out[2] * out[2]).sqrt();
+        if out_len < 1e-6 {
+            continue;
+        }
+        let n = &mesh.normals[3 * i..3 * i + 3];
+        let dot = (n[0] * out[0] + n[1] * out[1] + n[2] * out[2]) / out_len;
+        wall += 1;
+        if dot > 0.3 {
+            outward += 1;
+        }
+    }
+    assert!(
+        wall > 50,
+        "{label} #{id}: only {wall} wall vertices sampled"
+    );
+    assert!(
+        outward * 100 > wall * 90,
+        "{label} #{id}: normals not outward ({outward}/{wall}) — swept tube winding is inverted"
+    );
+}
+
+#[test]
+fn surface_curve_swept_elbow_renders_as_a_tube() {
+    assert_elbow_is_a_tube(58, "IfcSurfaceCurveSweptAreaSolid");
+}
+
+#[test]
+fn fixed_reference_swept_elbow_renders_as_a_tube() {
+    assert_elbow_is_a_tube(74, "IfcFixedReferenceSweptAreaSolid");
+}
+
+/// The directrix on its own must sample a planar 90-degree arc of the bend
+/// radius — the sampling foundation the sweep relies on.
+#[test]
+fn directrix_is_a_planar_quarter_arc() {
+    let content = read_fixture();
+    let entity_index = ifc_lite_core::build_entity_index(&content);
+    let mut decoder = EntityDecoder::with_index(&content, entity_index);
+    let directrix = decoder.decode_by_id(48).unwrap();
+    assert_eq!(directrix.ifc_type, IfcType::IfcTrimmedCurve);
+
+    let pp = ProfileProcessor::new(ifc_lite_core::IfcSchema::new());
+    let pts = pp
+        .get_curve_points(&directrix, &mut decoder, TessellationQuality::Medium)
+        .expect("sample directrix");
+    assert!(
+        pts.len() >= 5,
+        "expected a sampled arc, got {} pts",
+        pts.len()
+    );
+
+    // Planar (authored in the z = 0 plane, millimetres).
+    let worst_z = pts.iter().fold(0.0f64, |a, p| a.max(p.z.abs()));
+    assert!(
+        worst_z < 1.0,
+        "directrix left the z=0 plane: max |z| = {worst_z:.4} mm"
+    );
+
+    // Every sample is one bend radius (150 mm) from the arc centre (0,150).
+    for p in &pts {
+        let r = ((p.x - 0.0).powi(2) + (p.y - 150.0).powi(2)).sqrt();
+        assert!(
+            (r - 150.0).abs() < 1.0,
+            "directrix point {p:?} is {r:.3} mm from centre, expected 150 mm"
+        );
+    }
+
+    // Endpoints span a quarter turn: from (0,0) to (150,150).
+    let start = pts.first().unwrap();
+    let end = pts.last().unwrap();
+    assert!(
+        start.x.abs() < 1.0 && start.y.abs() < 1.0,
+        "arc start not at (0,0): {start:?}"
+    );
+    assert!(
+        (end.x - 150.0).abs() < 1.0 && (end.y - 150.0).abs() < 1.0,
+        "arc end not at (150,150): {end:?}"
+    );
+}


### PR DESCRIPTION
## Problem

Fixes #1485. Round HVAC duct elbows in an IFC4.3 RV model (Revit export) rendered as **nothing** in the viewer while showing correctly in other viewers.

Root cause: Revit exports round duct bends as `IfcSurfaceCurveSweptAreaSolid` — a circular `SweptArea` profile swept along a trimmed circular-arc `Directrix`. The geometry router **had no processor registered for the type** (it was recognised in `router/layers.rs` but never dispatched), so every elbow body was silently dropped. Verified against the reporter's file: elbow `#1538` produced **0 triangles**; a normal duct segment beside it produced 140.

## Fix

Add `SurfaceCurveSweptAreaSolidProcessor` (registered in the router, so every native + wasm/viewer path picks it up via the shared `GeometryRouter::new` registration):

- Extracts the `SweptArea` as a `Profile2D` (circle, and by construction any profile incl. holes).
- Samples the `Directrix` in 3D, reusing `IfcSweptDiskSolid`'s proven trim handling (composite / polyline / line honour the solid-level Start/EndParam; a trimmed conic carries its own trim).
- Applies the solid `Position`, then sweeps the section with the disk processor's rotation-minimising frame (factored to `pub(crate)`, shared, no behavioural change to `IfcSweptDiskSolid`). Outward-oriented walls + triangulated end caps + smooth normals.
- The **same** processor handles `IfcFixedReferenceSweptAreaSolid` (slots 0..4 are identical; slot 5 differs only in orientation control).

For the circular cross-sections these fittings use, the swept tube is geometrically **exact** (RMF orientation is rotationally invariant). Non-circular sections along a non-planar directrix keep a rotation-minimising roll rather than the exact reference-surface roll — documented, and shape-correct.

## Verification

- **Real file**: all 383 `IfcDuctFitting` elements now mesh (0 empty, was: elbows dropped); the 12 unique swept elbow geometries are instanced via `IfcMappedItem`, so they mesh 12× and cache.
- **Neutral fixture** (`tests/fixtures/issue_1485_duct_elbow_surface_curve_swept.ifc`): a self-contained 90° round elbow reproducing the reported geometry chain — no data from the reporter's model. It produces the identical 788-triangle mesh as the real elbow.
- **Adversarial assertions** in the committed test:
  - Z extent equals the bore diameter exactly (bend authored in XY → proves radius + no out-of-plane twist).
  - In-plane spans ≈ arc radius + bore (proves the sweep follows the 150 mm arc, not a collapsed section).
  - Every vertex lies within one bore radius of the arc centre-line, and the wall reaches the bore radius (proves it's a genuine tube of the right radius/axis).
  - Normals point outward (caught and fixed an inverted-winding bug during review).
  - Both `IfcSurfaceCurveSweptAreaSolid` and `IfcFixedReferenceSweptAreaSolid` variants.

`cargo test -p ifc-lite-geometry` is green (the only failures are pre-existing, environmental — the `wall_opening_cut_regression` tests need the downloaded `advanced_model.ifc` fixture). `cargo clippy -p ifc-lite-geometry --tests` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)