### PR TITLE
perf(export): shared-index + fail-fast size for the streaming glTF path (#1516)

### DIFF
--- a/rust/export/src/error.rs
+++ b/rust/export/src/error.rs
@@ -16,6 +16,17 @@ pub enum ExportError {
     /// valid but empty file, which downstream tools accept silently, so this is
     /// surfaced as an error rather than an artifact.
     NoRenderGeometry,
+    /// The projected single-GLB output exceeds the glTF 32-bit (4 GiB) container
+    /// / buffer limit — the model is too large for one GLB and must be exported
+    /// as a multi-buffer glTF instead. Carries the projected total container size
+    /// in bytes (from pass 1), so a caller can log it or size a buffer split
+    /// without re-meshing. Replaces the historical 4 GiB `panic!` on the checked
+    /// export paths (issue #1516).
+    TooLarge {
+        /// Projected total GLB container size in bytes (may be a lower bound once
+        /// oversize; see [`crate::GlbSizeProjection::total_bytes`]).
+        bytes: u64,
+    },
 }
 
 impl ExportError {
@@ -24,6 +35,7 @@ impl ExportError {
     pub fn code(&self) -> &'static str {
         match self {
             ExportError::NoRenderGeometry => "NO_RENDER_GEOMETRY",
+            ExportError::TooLarge { .. } => "TOO_LARGE",
         }
     }
 }
@@ -34,6 +46,12 @@ impl fmt::Display for ExportError {
             ExportError::NoRenderGeometry => write!(
                 f,
                 "{}: export produced no render geometry (empty model or all meshes filtered out)",
+                self.code()
+            ),
+            ExportError::TooLarge { bytes } => write!(
+                f,
+                "{}: projected GLB is {bytes} bytes, over the glTF 32-bit (4 GiB) limit; \
+                 export as a multi-buffer glTF instead",
                 self.code()
             ),
         }

--- a/rust/export/src/gltf.rs
+++ b/rust/export/src/gltf.rs
@@ -1309,18 +1309,25 @@ pub fn try_export_glb(content: &[u8], opts: &GltfOptions) -> Result<Vec<u8>, Exp
 
 /// Fail-closed [`export_glb_with_stats`]; see [`try_export_glb`].
 ///
-/// Beyond the [`ExportError::NoRenderGeometry`] guard, a large input that would
-/// exceed the glTF 4 GiB single-GLB limit returns [`ExportError::TooLarge`]
-/// instead of PANICKING (as `export_glb_with_stats` does) — the checked bounded
-/// path fails fast after pass 1, so a caller can fall back to
-/// [`export_gltf_streaming`] without catching a panic (#1516).
+/// Beyond the [`ExportError::NoRenderGeometry`] guard, an input at/above the
+/// streaming threshold that would exceed the glTF 4 GiB single-GLB limit returns
+/// [`ExportError::TooLarge`] instead of PANICKING (as `export_glb_with_stats`
+/// does) — the checked bounded path fails fast after pass 1, so a caller can fall
+/// back to [`export_gltf_streaming`] without catching a panic (#1516).
+///
+/// A SUB-THRESHOLD input (default < 64 MB) keeps the in-memory instanced
+/// assembler, which retains the historical 4 GiB `pack_glb` assert. That bound is
+/// only reachable if such a small file meshed to over 4 GiB of GLB (a ~64x
+/// expansion — not observed in practice); a caller that must be panic-proof even
+/// then can force the checked bounded path with
+/// `IFC_LITE_GLB_STREAM_THRESHOLD_MB=1`.
 pub fn try_export_glb_with_stats(
     content: &[u8],
     opts: &GltfOptions,
 ) -> Result<(Vec<u8>, GltfStats), ExportError> {
     // Mirror `export_glb_with_stats`'s routing, but the large-model branch is the
     // CHECKED bounded assembler (typed TooLarge, no panic). Small models keep the
-    // in-memory instanced path (a sub-threshold input cannot exceed 4 GiB).
+    // in-memory instanced path (see the doc note on its residual 4 GiB assert).
     let (glb, stats) = if content.len() >= glb_stream_threshold_bytes() {
         try_export_glb_streaming_bounded(content, opts)?
     } else {
@@ -1692,6 +1699,17 @@ fn glb_stream_threshold_bytes() -> usize {
     mb.saturating_mul(1024 * 1024)
 }
 
+/// GLB container size in bytes: the 12-byte file header + the JSON chunk (8-byte
+/// chunk header + 4-aligned payload) + the BIN chunk (8-byte chunk header +
+/// 4-aligned payload). Computed in u64 so an oversize model never truncates on
+/// wasm32 (32-bit `usize`) — the projected size has to stay a reliable > 4 GiB
+/// signal (#1516). Matches the layout `write_bounded_glb`/`pack_glb` emit.
+fn glb_container_size(json_len: u64, bin_total: u64) -> u64 {
+    let json_pad = (4 - (json_len % 4)) % 4;
+    let bin_pad = (4 - (bin_total % 4)) % 4;
+    12 + 8 + (json_len + json_pad) + 8 + (bin_total + bin_pad)
+}
+
 /// Projected size of the single-GLB export for a model, computed from pass 1
 /// only (no output allocation) — issue #1516. A caller uses it to pick single
 /// GLB vs multi-buffer glTF ([`export_gltf_streaming`]) WITHOUT the historical
@@ -1776,7 +1794,7 @@ fn export_glb_streaming_bounded_impl(
         plan.bin_total,
     );
     assert!(
-        plan.total <= u32::MAX as usize,
+        plan.total <= u32::MAX as u64,
         "GLB total size is {} bytes, over the glTF 32-bit container limit (4 GiB)",
         plan.total,
     );
@@ -1811,8 +1829,8 @@ fn try_export_glb_streaming_bounded_impl(
     index: Option<Arc<EntityIndex>>,
 ) -> Result<(Vec<u8>, GltfStats), ExportError> {
     let plan = plan_bounded_glb(content, opts, index.clone());
-    if plan.bin_total > u32::MAX as u64 || plan.total > u32::MAX as usize {
-        return Err(ExportError::TooLarge { bytes: plan.total as u64 });
+    if plan.bin_total > u32::MAX as u64 || plan.total > u32::MAX as u64 {
+        return Err(ExportError::TooLarge { bytes: plan.total });
     }
     Ok(write_bounded_glb(content, opts, index, plan))
 }
@@ -1841,9 +1859,9 @@ fn project_glb_size_impl(
 ) -> GlbSizeProjection {
     let plan = plan_bounded_glb(content, opts, index);
     GlbSizeProjection {
-        total_bytes: plan.total as u64,
+        total_bytes: plan.total,
         bin_bytes: plan.bin_total,
-        fits_single_glb: plan.bin_total <= u32::MAX as u64 && plan.total <= u32::MAX as usize,
+        fits_single_glb: plan.bin_total <= u32::MAX as u64 && plan.total <= u32::MAX as u64,
         stats: plan.stats,
     }
 }
@@ -1862,8 +1880,9 @@ struct BoundedGlbPlan {
     norm_len: u64,
     /// BIN payload size (pos + norm + idx), exact (u64).
     bin_total: u64,
-    /// Projected GLB container size (headers + padded JSON + padded BIN).
-    total: usize,
+    /// Projected GLB container size (headers + padded JSON + padded BIN). u64 so
+    /// an oversize model does not truncate on wasm32 (32-bit `usize`).
+    total: u64,
     stats: GltfStats,
 }
 
@@ -2278,15 +2297,10 @@ fn plan_bounded_glb(
     };
     let json = serde_json::to_vec(&gltf).expect("glTF JSON serializes");
 
-    // Projected container size (chunk headers + padded JSON + padded BIN). On a
-    // 64-bit host `bin_total as usize` never truncates, so `total` is exact when
-    // the model fits; once oversize it is dominated by the BIN payload and
-    // reliably exceeds the 4 GiB limit — enough for the caller to fail fast.
-    let json_pad = (4 - (json.len() % 4)) % 4;
-    let bin_pad = ((4 - (bin_total % 4)) % 4) as usize;
-    let padded_json = json.len() + json_pad;
-    let padded_bin = bin_total as usize + bin_pad;
-    let total = 12 + 8 + padded_json + 8 + padded_bin;
+    // Projected container size in u64 (see `glb_container_size`): this crate also
+    // compiles to wasm32 (32-bit `usize`), so an oversize model must NOT truncate
+    // here — the size has to stay a reliable > 4 GiB fail-fast signal.
+    let total = glb_container_size(json.len() as u64, bin_total);
 
     BoundedGlbPlan { metas, json, pos_len, norm_len, bin_total, total, stats }
 }
@@ -2312,6 +2326,9 @@ fn write_bounded_glb(
     let BoundedGlbPlan { metas, json, pos_len, norm_len, bin_total, total, stats } = plan;
 
     // ── Preallocate the exact GLB container, then pass 2 writes into it ─────
+    // Safe to narrow to usize here: the caller validated `total`/`bin_total` fit
+    // the 4 GiB glTF limit, so every value below is < u32::MAX on any target.
+    let total = total as usize;
     let json_pad = (4 - (json.len() % 4)) % 4;
     let bin_pad = ((4 - (bin_total % 4)) % 4) as usize;
     let padded_json = json.len() + json_pad;
@@ -2618,6 +2635,21 @@ mod tests {
     }
 
     // ── #1516: streaming shared-index + fail-fast size ────────────────────
+
+    /// The container-size math is u64 end-to-end so an oversize model does NOT
+    /// truncate on wasm32 (32-bit `usize`) — the regression the projection guards.
+    #[test]
+    fn glb_container_size_does_not_truncate() {
+        // 12 header + 8 json-chunk hdr + padded json + 8 bin-chunk hdr + padded bin.
+        // json 10 -> pad to 12; bin 20 already aligned.
+        assert_eq!(glb_container_size(10, 20), 12 + 8 + 12 + 8 + 20);
+        // A > 4 GiB BIN payload must stay > u32::MAX (not wrap to a small usize).
+        let big = 5_000_000_000u64; // > u32::MAX (4_294_967_295)
+        let total = glb_container_size(100, big);
+        assert_eq!(total, 12 + 8 + 100 + 8 + big, "no truncation, exact u64 sum");
+        assert!(total > u32::MAX as u64, "oversize total must exceed 4 GiB, got {total}");
+    }
+
 
     /// The shared-index BOUNDED GLB path must emit byte-for-byte the same GLB as
     /// the self-indexing one — the injected index equals the one the bounded

--- a/rust/export/src/gltf.rs
+++ b/rust/export/src/gltf.rs
@@ -67,6 +67,7 @@ impl Default for GltfOptions {
 }
 
 /// Coverage stats for a GLB export.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct GltfStats {
     pub meshes: usize,
     pub vertices: usize,
@@ -1307,11 +1308,24 @@ pub fn try_export_glb(content: &[u8], opts: &GltfOptions) -> Result<Vec<u8>, Exp
 }
 
 /// Fail-closed [`export_glb_with_stats`]; see [`try_export_glb`].
+///
+/// Beyond the [`ExportError::NoRenderGeometry`] guard, a large input that would
+/// exceed the glTF 4 GiB single-GLB limit returns [`ExportError::TooLarge`]
+/// instead of PANICKING (as `export_glb_with_stats` does) — the checked bounded
+/// path fails fast after pass 1, so a caller can fall back to
+/// [`export_gltf_streaming`] without catching a panic (#1516).
 pub fn try_export_glb_with_stats(
     content: &[u8],
     opts: &GltfOptions,
 ) -> Result<(Vec<u8>, GltfStats), ExportError> {
-    let (glb, stats) = export_glb_with_stats(content, opts);
+    // Mirror `export_glb_with_stats`'s routing, but the large-model branch is the
+    // CHECKED bounded assembler (typed TooLarge, no panic). Small models keep the
+    // in-memory instanced path (a sub-threshold input cannot exceed 4 GiB).
+    let (glb, stats) = if content.len() >= glb_stream_threshold_bytes() {
+        try_export_glb_streaming_bounded(content, opts)?
+    } else {
+        export_glb_from_result(process_geometry(content), opts)
+    };
     if stats.meshes == 0 {
         return Err(ExportError::NoRenderGeometry);
     }
@@ -1406,6 +1420,33 @@ pub fn export_gltf_streaming(
     content: &[u8],
     opts: &GltfOptions,
     chunk_cap: usize,
+    sink: impl FnMut(GltfBuffer),
+) -> Vec<u8> {
+    export_gltf_streaming_impl(content, opts, None, chunk_cap, sink)
+}
+
+/// Like [`export_gltf_streaming`] but reuses a pre-built entity index instead of
+/// scanning `content` again on EACH of its two passes. A caller that already
+/// built the index — e.g. to share with the attribute pass
+/// ([`crate::stream_export_model_with_index`]) — passes it here to remove the
+/// redundant SIMD scans on the large models this path targets (#1516). `index`
+/// MUST come from [`build_entity_index`](crate::build_entity_index) over the same
+/// `content`; output is byte-identical to [`export_gltf_streaming`].
+pub fn export_gltf_streaming_with_index(
+    content: &[u8],
+    opts: &GltfOptions,
+    index: Arc<EntityIndex>,
+    chunk_cap: usize,
+    sink: impl FnMut(GltfBuffer),
+) -> Vec<u8> {
+    export_gltf_streaming_impl(content, opts, Some(index), chunk_cap, sink)
+}
+
+fn export_gltf_streaming_impl(
+    content: &[u8],
+    opts: &GltfOptions,
+    index: Option<Arc<EntityIndex>>,
+    chunk_cap: usize,
     mut sink: impl FnMut(GltfBuffer),
 ) -> Vec<u8> {
     // Bounded memory: drive the streaming geometry API with `retain_emitted_meshes: false`
@@ -1417,8 +1458,13 @@ pub fn export_gltf_streaming(
     // Instancing/content-dedup is skipped (it needs every mesh co-resident); the dense
     // models that actually need bounded memory have little instancing, and world geometry
     // is identical either way (instancing is only a dedup of repeated placements).
-    let stream_opts =
-        || StreamingOptions { retain_emitted_meshes: false, ..StreamingOptions::default() };
+    // A shared `index` (when present) is injected into BOTH passes' StreamingOptions so
+    // neither re-scans `content` for its entity index (#1516).
+    let stream_opts = || StreamingOptions {
+        retain_emitted_meshes: false,
+        entity_index: index.clone(),
+        ..StreamingOptions::default()
+    };
 
     let mut wmin = [f64::INFINITY; 3];
     let mut wmax = [f64::NEG_INFINITY; 3];
@@ -1646,16 +1692,42 @@ fn glb_stream_threshold_bytes() -> usize {
     mb.saturating_mul(1024 * 1024)
 }
 
+/// Projected size of the single-GLB export for a model, computed from pass 1
+/// only (no output allocation) — issue #1516. A caller uses it to pick single
+/// GLB vs multi-buffer glTF ([`export_gltf_streaming`]) WITHOUT the historical
+/// "attempt the GLB, catch the 4 GiB panic, re-run as multi-buffer" dance.
+#[derive(Debug, Clone, Copy)]
+pub struct GlbSizeProjection {
+    /// Projected total GLB container size in bytes (padded JSON + padded BIN +
+    /// chunk headers). Exact when it fits; a lower bound once oversize (the
+    /// truncated buffer numbers in the discarded JSON make it marginally short).
+    pub total_bytes: u64,
+    /// Projected BIN payload (positions + normals + indices), the value checked
+    /// against the glTF 4 GiB per-buffer limit. Always exact (u64, no truncation).
+    pub bin_bytes: u64,
+    /// `false` when the projected GLB would exceed the glTF 32-bit (4 GiB) limit
+    /// — route to [`export_gltf_streaming`] (multi-buffer) instead.
+    pub fits_single_glb: bool,
+    /// Coverage of the projected export (post content-dedup mesh/vertex/tri counts).
+    pub stats: GltfStats,
+}
+
 /// Bounded-memory single-**GLB** export: two passes over the deterministic mesh
 /// stream (`retain_emitted_meshes: false`, peak input = one batch).
 ///
-/// Pass 1 records per-mesh METADATA only (counts, local bbox, colour, ids,
-/// content-hash) plus the world AABB; the complete glTF JSON is then built and
-/// the final GLB `Vec` is preallocated at its exact container size. Pass 2
-/// re-streams the same meshes and bakes their bytes straight into the output at
-/// precomputed offsets. Peak memory = the final artifact + one batch + metadata
-/// — never the whole model's `MeshData`, never a growing three-run scratch, and
-/// never a second full copy from a final concatenation.
+/// Pass 1 ([`plan_bounded_glb`]) records per-mesh METADATA only (counts, local
+/// bbox, colour, ids, content-hash) plus the world AABB; the complete glTF JSON
+/// is then built and the final GLB `Vec` is preallocated at its exact container
+/// size. Pass 2 ([`write_bounded_glb`]) re-streams the same meshes and bakes
+/// their bytes straight into the output at precomputed offsets. Peak memory = the
+/// final artifact + one batch + metadata — never the whole model's `MeshData`,
+/// never a growing three-run scratch, and never a second full copy from a final
+/// concatenation.
+///
+/// **Oversize** (projected GLB over the glTF 4 GiB limit) PANICS with the
+/// historical messages (a worker classifier matches on them). Prefer
+/// [`try_export_glb_streaming_bounded`] to get [`ExportError::TooLarge`] instead,
+/// or [`project_glb_size`] to decide up front.
 ///
 /// Tradeoffs vs the in-memory assembler (`build_gltf`):
 /// - rep-identity instancing is SKIPPED (it needs every occurrence co-resident);
@@ -1670,8 +1742,148 @@ fn glb_stream_threshold_bytes() -> usize {
 /// byte stream on both paths, but only the in-memory fold lets that 0 into the
 /// accessor min/max hint; clean meshes are byte-identical.
 pub fn export_glb_streaming_bounded(content: &[u8], opts: &GltfOptions) -> (Vec<u8>, GltfStats) {
-    let stream_opts =
-        || StreamingOptions { retain_emitted_meshes: false, ..StreamingOptions::default() };
+    export_glb_streaming_bounded_impl(content, opts, None)
+}
+
+/// Like [`export_glb_streaming_bounded`] but reuses a pre-built entity index
+/// instead of scanning `content` again on EACH of the two passes — for a caller
+/// that already built it (e.g. to share with [`crate::stream_export_model_with_index`]),
+/// removing the redundant SIMD scans on the large models this path targets
+/// (#1516). `index` MUST come from [`build_entity_index`](crate::build_entity_index)
+/// over the same `content`; output is byte-identical.
+pub fn export_glb_streaming_bounded_with_index(
+    content: &[u8],
+    opts: &GltfOptions,
+    index: Arc<EntityIndex>,
+) -> (Vec<u8>, GltfStats) {
+    export_glb_streaming_bounded_impl(content, opts, Some(index))
+}
+
+fn export_glb_streaming_bounded_impl(
+    content: &[u8],
+    opts: &GltfOptions,
+    index: Option<Arc<EntityIndex>>,
+) -> (Vec<u8>, GltfStats) {
+    let plan = plan_bounded_glb(content, opts, index.clone());
+    // Back-compat: an oversize model PANICS with the historical messages (the
+    // worker's OutputTooLarge classifier matches on them). `try_export_glb*` /
+    // `try_export_glb_streaming_bounded` are the fail-closed alternatives that
+    // return `ExportError::TooLarge` instead.
+    assert!(
+        plan.bin_total <= u32::MAX as u64,
+        "GLB binary buffer is {} bytes, over the glTF 32-bit buffer limit \
+         (4 GiB); the model is too large for a single GLB",
+        plan.bin_total,
+    );
+    assert!(
+        plan.total <= u32::MAX as usize,
+        "GLB total size is {} bytes, over the glTF 32-bit container limit (4 GiB)",
+        plan.total,
+    );
+    write_bounded_glb(content, opts, index, plan)
+}
+
+/// Fail-closed [`export_glb_streaming_bounded`]: an oversize projected GLB
+/// returns [`ExportError::TooLarge`] (carrying the projected byte size) after
+/// pass 1 — no output allocation, no panic (#1516). An empty visible set is a
+/// valid (zero-mesh) GLB here; use [`try_export_glb_with_stats`] for the
+/// [`ExportError::NoRenderGeometry`] guard as well.
+pub fn try_export_glb_streaming_bounded(
+    content: &[u8],
+    opts: &GltfOptions,
+) -> Result<(Vec<u8>, GltfStats), ExportError> {
+    try_export_glb_streaming_bounded_impl(content, opts, None)
+}
+
+/// Shared-index [`try_export_glb_streaming_bounded`] (see
+/// [`export_glb_streaming_bounded_with_index`]).
+pub fn try_export_glb_streaming_bounded_with_index(
+    content: &[u8],
+    opts: &GltfOptions,
+    index: Arc<EntityIndex>,
+) -> Result<(Vec<u8>, GltfStats), ExportError> {
+    try_export_glb_streaming_bounded_impl(content, opts, Some(index))
+}
+
+fn try_export_glb_streaming_bounded_impl(
+    content: &[u8],
+    opts: &GltfOptions,
+    index: Option<Arc<EntityIndex>>,
+) -> Result<(Vec<u8>, GltfStats), ExportError> {
+    let plan = plan_bounded_glb(content, opts, index.clone());
+    if plan.bin_total > u32::MAX as u64 || plan.total > u32::MAX as usize {
+        return Err(ExportError::TooLarge { bytes: plan.total as u64 });
+    }
+    Ok(write_bounded_glb(content, opts, index, plan))
+}
+
+/// Project the single-GLB size for `content` from pass 1 only — the world AABB +
+/// per-mesh byte sizes the bounded assembler already computes — WITHOUT meshing
+/// twice or allocating the output (#1516). Lets a caller pick single GLB vs
+/// multi-buffer glTF up front. Meshes the model once (the price of an exact size).
+pub fn project_glb_size(content: &[u8], opts: &GltfOptions) -> GlbSizeProjection {
+    project_glb_size_impl(content, opts, None)
+}
+
+/// Shared-index [`project_glb_size`] (see [`export_glb_streaming_bounded_with_index`]).
+pub fn project_glb_size_with_index(
+    content: &[u8],
+    opts: &GltfOptions,
+    index: Arc<EntityIndex>,
+) -> GlbSizeProjection {
+    project_glb_size_impl(content, opts, Some(index))
+}
+
+fn project_glb_size_impl(
+    content: &[u8],
+    opts: &GltfOptions,
+    index: Option<Arc<EntityIndex>>,
+) -> GlbSizeProjection {
+    let plan = plan_bounded_glb(content, opts, index);
+    GlbSizeProjection {
+        total_bytes: plan.total as u64,
+        bin_bytes: plan.bin_total,
+        fits_single_glb: plan.bin_total <= u32::MAX as u64 && plan.total <= u32::MAX as usize,
+        stats: plan.stats,
+    }
+}
+
+/// Everything pass 2 ([`write_bounded_glb`]) needs from pass 1: the finished glTF
+/// JSON, the per-mesh write plan (`metas`, each carrying its byte offsets), the
+/// three run lengths, and the projected sizes — WITHOUT the vertex bytes (those
+/// re-stream on pass 2). Holding this between passes is what lets the caller
+/// fail fast on an oversize model before any output is allocated.
+struct BoundedGlbPlan {
+    metas: Vec<StreamedMeshMeta>,
+    json: Vec<u8>,
+    /// Positions / normals run lengths; the index run is `bin_total - pos - norm`
+    /// (its base offset is `pos_len + norm_len`, so `idx_len` need not be carried).
+    pos_len: u64,
+    norm_len: u64,
+    /// BIN payload size (pos + norm + idx), exact (u64).
+    bin_total: u64,
+    /// Projected GLB container size (headers + padded JSON + padded BIN).
+    total: usize,
+    stats: GltfStats,
+}
+
+/// Pass 1 of the bounded assembler: mesh the model once to gather per-mesh
+/// metadata + the world AABB, build the complete glTF JSON, and compute the exact
+/// output sizes — returning a [`BoundedGlbPlan`] the caller either writes
+/// ([`write_bounded_glb`]) or inspects for size ([`project_glb_size`]). Does NOT
+/// assert the 4 GiB limits; the caller decides (panic vs typed error).
+fn plan_bounded_glb(
+    content: &[u8],
+    opts: &GltfOptions,
+    index: Option<Arc<EntityIndex>>,
+) -> BoundedGlbPlan {
+    // A shared `index` (when present) is injected into BOTH passes' StreamingOptions
+    // so neither re-scans `content` for its entity index (#1516).
+    let stream_opts = || StreamingOptions {
+        retain_emitted_meshes: false,
+        entity_index: index.clone(),
+        ..StreamingOptions::default()
+    };
 
     // ── Pass 1: metadata + world AABB ────────────────────────────────────────
     let mut metas: Vec<StreamedMeshMeta> = Vec::new();
@@ -1982,13 +2194,12 @@ pub fn export_glb_streaming_bounded(content: &[u8], opts: &GltfOptions) -> (Vec<
     stats.materials = materials.len();
 
     let bin_total = pos_len + norm_len + idx_len;
-    // Same message as Chunker::flush so the worker's `OutputTooLarge` classifier
-    // matches regardless of which assembler tripped.
-    assert!(
-        bin_total <= u32::MAX as u64,
-        "GLB binary buffer is {bin_total} bytes, over the glTF 32-bit buffer limit \
-         (4 GiB); the model is too large for a single GLB",
-    );
+    // NOTE: the 4 GiB buffer/container limits are NOT asserted here — the caller
+    // decides (panic in `export_glb_streaming_bounded_impl` vs typed
+    // `ExportError::TooLarge` in the `try_*`/`project_*` paths). The `bin_total as
+    // u32` casts below therefore truncate on an oversize model, but that JSON is
+    // only ever emitted when the size fits (an oversize plan is discarded), so
+    // every path that actually produces bytes stays correct.
     let (buffers, buffer_views) = if bin_total == 0 && stats.meshes == 0 {
         (vec![Buffer { byte_length: 0, uri: None }], Vec::new())
     } else {
@@ -2067,17 +2278,44 @@ pub fn export_glb_streaming_bounded(content: &[u8], opts: &GltfOptions) -> (Vec<
     };
     let json = serde_json::to_vec(&gltf).expect("glTF JSON serializes");
 
-    // ── Preallocate the exact GLB container, then pass 2 writes into it ─────
+    // Projected container size (chunk headers + padded JSON + padded BIN). On a
+    // 64-bit host `bin_total as usize` never truncates, so `total` is exact when
+    // the model fits; once oversize it is dominated by the BIN payload and
+    // reliably exceeds the 4 GiB limit — enough for the caller to fail fast.
     let json_pad = (4 - (json.len() % 4)) % 4;
     let bin_pad = ((4 - (bin_total % 4)) % 4) as usize;
     let padded_json = json.len() + json_pad;
     let padded_bin = bin_total as usize + bin_pad;
     let total = 12 + 8 + padded_json + 8 + padded_bin;
-    // Same message as pack_glb (the authoritative container guard).
-    assert!(
-        total <= u32::MAX as usize,
-        "GLB total size is {total} bytes, over the glTF 32-bit container limit (4 GiB)",
-    );
+
+    BoundedGlbPlan { metas, json, pos_len, norm_len, bin_total, total, stats }
+}
+
+/// Pass 2 of the bounded assembler: preallocate the exact GLB container from
+/// `plan`, write the header + JSON, then re-stream the (deterministic) meshes and
+/// bake their bytes straight into the BIN region at the precomputed offsets.
+/// Callers MUST have already validated `plan.total`/`plan.bin_total` fit the glTF
+/// 4 GiB limits (panic or typed error) — this assumes they do.
+fn write_bounded_glb(
+    content: &[u8],
+    opts: &GltfOptions,
+    index: Option<Arc<EntityIndex>>,
+    plan: BoundedGlbPlan,
+) -> (Vec<u8>, GltfStats) {
+    // Re-stream with the same (optionally shared) index so pass 2 never re-scans
+    // for its entity index either (#1516).
+    let stream_opts = || StreamingOptions {
+        retain_emitted_meshes: false,
+        entity_index: index.clone(),
+        ..StreamingOptions::default()
+    };
+    let BoundedGlbPlan { metas, json, pos_len, norm_len, bin_total, total, stats } = plan;
+
+    // ── Preallocate the exact GLB container, then pass 2 writes into it ─────
+    let json_pad = (4 - (json.len() % 4)) % 4;
+    let bin_pad = ((4 - (bin_total % 4)) % 4) as usize;
+    let padded_json = json.len() + json_pad;
+    let padded_bin = bin_total as usize + bin_pad;
     let mut out = Vec::with_capacity(total);
     out.extend_from_slice(b"glTF");
     out.extend_from_slice(&2u32.to_le_bytes());
@@ -2377,6 +2615,90 @@ mod tests {
         let idx = Arc::new(crate::build_entity_index(&bytes));
         let (shared, _) = export_glb_with_stats_with_index(&bytes, &opts, idx);
         assert_eq!(plain, shared, "shared-index GLB must equal self-indexed GLB");
+    }
+
+    // ── #1516: streaming shared-index + fail-fast size ────────────────────
+
+    /// The shared-index BOUNDED GLB path must emit byte-for-byte the same GLB as
+    /// the self-indexing one — the injected index equals the one the bounded
+    /// assembler builds internally, so only the redundant scan is removed.
+    #[test]
+    fn bounded_glb_with_index_is_byte_identical() {
+        let bytes = fixture("ara3d/duplex.ifc");
+        for quantize in [false, true] {
+            let opts = GltfOptions { quantize, ..GltfOptions::default() };
+            let (plain, ps) = export_glb_streaming_bounded(&bytes, &opts);
+            let idx = Arc::new(crate::build_entity_index(&bytes));
+            let (shared, ss) = export_glb_streaming_bounded_with_index(&bytes, &opts, idx);
+            assert_eq!(plain, shared, "shared-index bounded GLB must match (quantize={quantize})");
+            assert_eq!(ps, ss, "stats must match");
+        }
+    }
+
+    /// The shared-index MULTI-BUFFER path must produce an identical `.gltf` JSON
+    /// and identical external buffers as the self-indexing one.
+    #[test]
+    fn gltf_streaming_with_index_is_byte_identical() {
+        let bytes = fixture("ara3d/duplex.ifc");
+        let opts = GltfOptions::default();
+        let cap = 256 * 1024;
+
+        let mut plain_bufs: Vec<Vec<u8>> = Vec::new();
+        let plain_json = export_gltf_streaming(&bytes, &opts, cap, |b| plain_bufs.push(b.bytes));
+
+        let idx = Arc::new(crate::build_entity_index(&bytes));
+        let mut shared_bufs: Vec<Vec<u8>> = Vec::new();
+        let shared_json =
+            export_gltf_streaming_with_index(&bytes, &opts, idx, cap, |b| shared_bufs.push(b.bytes));
+
+        assert_eq!(plain_json, shared_json, "shared-index .gltf JSON must match");
+        assert_eq!(plain_bufs, shared_bufs, "shared-index buffers must match");
+    }
+
+    /// `project_glb_size` (pass 1 only) must return the EXACT byte size of the GLB
+    /// the bounded assembler actually produces, plus matching coverage stats and
+    /// `fits_single_glb = true` for a normal model — so a caller can pick single
+    /// GLB vs multi-buffer without meshing to completion twice.
+    #[test]
+    fn project_glb_size_matches_bounded_output() {
+        let bytes = fixture("ara3d/duplex.ifc");
+        for quantize in [false, true] {
+            let opts = GltfOptions { quantize, ..GltfOptions::default() };
+            let proj = project_glb_size(&bytes, &opts);
+            let (glb, stats) = export_glb_streaming_bounded(&bytes, &opts);
+            assert_eq!(
+                proj.total_bytes as usize,
+                glb.len(),
+                "projected size must equal the real GLB length (quantize={quantize})"
+            );
+            assert!(proj.fits_single_glb, "duplex fits a single GLB");
+            assert_eq!(proj.stats, stats, "projected stats must match the export");
+            // Shared-index projection must agree with the self-indexed one.
+            let idx = Arc::new(crate::build_entity_index(&bytes));
+            let proj_idx = project_glb_size_with_index(&bytes, &opts, idx);
+            assert_eq!(proj_idx.total_bytes, proj.total_bytes);
+            assert_eq!(proj_idx.bin_bytes, proj.bin_bytes);
+        }
+    }
+
+    /// The checked bounded export returns the SAME bytes as the panicking one for
+    /// a model that fits (the common case), so `try_*` is a drop-in that only
+    /// changes the oversize behaviour (typed error vs panic).
+    #[test]
+    fn try_export_bounded_matches_export_for_fitting_model() {
+        let bytes = fixture("ara3d/duplex.ifc");
+        let opts = GltfOptions::default();
+        let (want, wstats) = export_glb_streaming_bounded(&bytes, &opts);
+        let (got, gstats) = try_export_glb_streaming_bounded(&bytes, &opts)
+            .expect("duplex fits — must not be TooLarge");
+        assert_eq!(want, got, "checked bounded GLB must equal the panicking one");
+        assert_eq!(wstats, gstats);
+
+        // The top-level fail-closed API agrees with the in-memory export for a
+        // small model and still guards the empty case.
+        let (glb, _) = try_export_glb_with_stats(&bytes, &opts).expect("has geometry");
+        let (want2, _) = export_glb_with_stats(&bytes, &opts);
+        assert_eq!(glb, want2, "try_export_glb_with_stats must match export_glb_with_stats");
     }
 
     // ── KHR_mesh_quantization ────────────────────────────────────────────
@@ -3324,6 +3646,16 @@ END-ISO-10303-21;\n";
         assert_eq!(stats.meshes, 0);
         let (json, _) = parse_glb(&glb);
         assert!(json["meshes"].as_array().is_none_or(|m| m.is_empty()));
+    }
+
+    /// The #1516 TooLarge variant carries the projected size and a stable code the
+    /// wasm/TS boundary can match on (mirroring NO_RENDER_GEOMETRY).
+    #[test]
+    fn too_large_error_code_and_message() {
+        let err = ExportError::TooLarge { bytes: 5_000_000_000 };
+        assert_eq!(err.code(), "TOO_LARGE");
+        assert!(err.to_string().contains("5000000000"), "message carries the byte size");
+        assert!(err.to_string().starts_with("TOO_LARGE"), "code prefixes the message");
     }
 
     #[test]

--- a/rust/export/src/lib.rs
+++ b/rust/export/src/lib.rs
@@ -33,10 +33,12 @@ mod step;
 pub use csv::{export_csv, CsvMode, CsvOptions};
 pub use error::ExportError;
 pub use gltf::{
-    export_glb, export_glb_from_meshes, export_glb_with_stats, export_glb_with_stats_with_index,
-    export_gltf_streaming, export_glb_streaming_bounded, try_export_glb,
-    try_export_glb_with_stats, GltfBuffer, GltfOptions,
-    GltfStats,
+    export_glb, export_glb_from_meshes, export_glb_streaming_bounded,
+    export_glb_streaming_bounded_with_index, export_glb_with_stats,
+    export_glb_with_stats_with_index, export_gltf_streaming, export_gltf_streaming_with_index,
+    project_glb_size, project_glb_size_with_index, try_export_glb, try_export_glb_streaming_bounded,
+    try_export_glb_streaming_bounded_with_index, try_export_glb_with_stats, GlbSizeProjection,
+    GltfBuffer, GltfOptions, GltfStats,
 };
 pub use hbjson::Model;
 // Re-exported so a caller can `build_entity_index` once and share it across the


### PR DESCRIPTION
Closes #1516. Two improvements to the multi-buffer / bounded streaming glTF export. **Perf/robustness, not correctness** — output is byte-identical for every model that fits.

## 1. Shared entity index
The streaming paths rebuilt their own entity index on **each** pass — twice for `export_glb_streaming_bounded`, twice for `export_gltf_streaming` — and a caller that also indexes for an attribute pass rebuilds it a third time.

- `export_glb_streaming_bounded_with_index(content, opts, Arc<EntityIndex>)`
- `export_gltf_streaming_with_index(content, opts, Arc<EntityIndex>, chunk_cap, sink)`

Both thread the shared index into **every** pass's `StreamingOptions.entity_index` (matching #1472), so a caller that also runs `stream_export_model_with_index` builds the index **once**. Byte-identical output.

## 2. Fail-fast total size after pass 1
The bounded assembler is split into `plan_bounded_glb` (pass 1: metadata + world AABB + glTF JSON + exact sizes) and `write_bounded_glb` (pass 2: bake bytes). On top of the split:

- **`project_glb_size[_with_index]` → `GlbSizeProjection`** — projected GLB container size (+ BIN size, `fits_single_glb`, coverage) from pass 1 only, no output allocation. Pick single-GLB vs multi-buffer without meshing to completion twice.
- **`ExportError::TooLarge { bytes }`** + **`try_export_glb_streaming_bounded[_with_index]`** — typed oversize error after pass 1 instead of the historical 4 GiB `panic!`. `try_export_glb_with_stats` now routes large inputs through the checked path (wasm/CLI fails closed with a typed error rather than a panic/trap). `export_glb_streaming_bounded` keeps the panic (exact historical messages) for back-compat.

## DRY / correctness
- Both streaming paths share one index-injecting `StreamingOptions` closure; the bounded panic/checked/project entrypoints share `plan_bounded_glb` + `write_bounded_glb`.
- Container size is computed in **u64 end-to-end** (`glb_container_size`) so an oversize model does not truncate on **wasm32** (32-bit `usize`); narrowed to `usize` only after the size is validated to fit.
- `GltfStats` gains `Copy/Clone/Debug/Default/PartialEq`.

## Tests
- Shared-index bounded GLB and multi-buffer output are **byte-identical** (f32 and quantized).
- `project_glb_size` total **equals the real GLB length exactly**; `glb_container_size` does not truncate for a synthetic >4 GiB BIN.
- Checked bounded matches the panicking one for a fitting model; `TooLarge` carries a stable `TOO_LARGE` code.

Full `ifc-lite-export` suite green; existing gltf tests unchanged (byte-identity). Builds clean for `wasm32-unknown-unknown`. Rust-only crate change.