### PR TITLE
ci(docs): widen Pages deploy timeout so backend backlog doesn't fail the run

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -121,3 +121,13 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        with:
+          # A push burst to main (every rust/** change triggers this workflow)
+          # can leave several Pages deployments backlogged on GitHub's backend,
+          # which processes one per environment at a time. The action's default
+          # 10-minute poll window (timeout: 600000) is too tight for that
+          # backlog and turns a recoverable delay into a hard failure: a run
+          # timed out at deployment_queued while the very next push deployed
+          # fine. Give the backend more runway before aborting.
+          timeout: 1200000 # 20 minutes (default 600000 = 10 min)
+          error_count: 20 # tolerate more transient status-API blips (default 10)


### PR DESCRIPTION
## What failed

The **Deploy Documentation** run for `307e56f7` (fix(geometry): render IfcSurfaceCurveSweptAreaSolid duct elbows) failed at ~17:13 local time. The `build` job was fully green; the `deploy` job's `actions/deploy-pages` step polled `deployment_queued` for the full default 10-minute window and then aborted:

```
Current status: deployment_queued
...
##[error]Timeout reached, aborting!
Canceling Pages deployment...
```

## Root cause

A burst of 4 pushes to `main` in ~2 minutes (14:53-14:55 UTC) each fired a full Deploy Documentation run (the trigger paths include the broad `rust/**` glob). The runs serialize via `concurrency: {group: pages, cancel-in-progress: false}`, but each run that reaches the deploy job hands GitHub's Pages backend a fresh deployment, and the backend processes one deployment per environment at a time. One deployment got backlogged past the action's default `timeout: 600000` (10 min) and was aborted.

It's a transient backend backlog, not a broken config: the **very next push deployed fine on identical configuration**, and this is the only failure in 30+ consecutive successful docs runs. The in-repo lever is the deploy step's patience window, and a 10-minute default is too tight for this repo during merge bursts, turning a recoverable delay into a hard failure.

## Fix

Set the `deploy-pages` step to be more patient:

- `timeout: 1200000` (20 min, up from the 10-min default) so a backlogged backend gets more runway before aborting.
- `error_count: 20` (up from 10) to ride out more transient status-API blips.

If a deployment is ever *truly* stuck, the run still self-heals on the next push (as it did here). No behavior change for the normal case, where deploys complete in seconds.

## Notes / follow-up

- Only `docs.yml` deploys to Pages and uses the `pages` concurrency group, so there is no cross-workflow Pages contention.
- Churn observation (not changed here): the `rust/**` path trigger fires this workflow on nearly every merge to main, even when the human-authored MkDocs content is unchanged (Rustdoc is a best-effort `continue-on-error` addon). Narrowing that trigger would cut CI churn but would let Rustdoc go stale between `docs/**` changes, so it's left as a separate call.

CI-only change; no `@ifc-lite/*` package src touched, so no changeset needed.