### PR TITLE
fix(viewer): Export Changes exports all changed models, not just the first (#1534)

### DIFF
--- a/apps/viewer/src/components/viewer/ExportChangesButton.tsx
+++ b/apps/viewer/src/components/viewer/ExportChangesButton.tsx
@@ -91,6 +91,7 @@ export function ExportChangesButton({ className }: ExportChangesButtonProps) {
       if (files.length === 0) {
         if (skipped.length > 0) {
           setExportStatus('error');
+          setTimeout(() => setExportStatus('idle'), 3000);
           toast.error(`Export failed: ${skipped[0].reason}`);
         } else {
           toast.info('No changes to export');
@@ -139,7 +140,7 @@ export function ExportChangesButton({ className }: ExportChangesButtonProps) {
   const tooltip =
     modelCount > 1
       ? `Export changes in ${modelCount} models (${totalCount} changes)`
-      : `Export IFC with ${totalCount} property change${totalCount === 1 ? '' : 's'} applied`;
+      : `Export IFC with ${totalCount} change${totalCount === 1 ? '' : 's'} applied`;
 
   return (
     <Tooltip>

--- a/apps/viewer/src/components/viewer/ExportChangesButton.tsx
+++ b/apps/viewer/src/components/viewer/ExportChangesButton.tsx
@@ -3,175 +3,123 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Dedicated button for exporting IFC with property mutations applied.
- * Shows when there are pending changes and provides one-click export.
+ * Dedicated toolbar button for exporting IFC with pending changes applied.
+ * Shows when any loaded model has pending changes and exports ALL of them in
+ * one click: a single `.ifc` (or `.ifcx`) when one model changed, or a single
+ * zip bundling every changed model's file when several did (issue #1534 — this
+ * used to look at only the first federated model for both the badge and the
+ * export).
  */
 
-import { useState, useCallback, useMemo, useEffect } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { Download, Loader2, Check, AlertCircle } from 'lucide-react';
+import { zip, strToU8 } from 'fflate';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { useViewerStore, countGeneratedTasks } from '@/store';
-import { configureMutationView } from '@/utils/configureMutationView';
-import { StepExporter } from '@ifc-lite/export';
-import { MutablePropertyView } from '@ifc-lite/mutations';
-import type { IfcDataStore } from '@ifc-lite/parser';
+import { useViewerStore } from '@/store';
 import { toast } from '@/components/ui/toast';
-import { ensureModelExportReady } from '@/services/desktop-export';
-import { spliceScheduleIntoExport } from '@/sdk/adapters/export-schedule-splice';
-import { downloadFile, sanitizeFilename } from '@/lib/export/download';
+import { downloadFile } from '@/lib/export/download';
+import {
+  collectChangedModels,
+  totalChangeCount,
+  buildChangedArtifacts,
+  type ArtifactFile,
+} from '@/lib/export/model-changes';
+import { defaultBuildArtifactsDeps } from '@/lib/export/changed-model-export';
 
 interface ExportChangesButtonProps {
   /** Optional custom class name */
   className?: string;
 }
 
+/** YYYY-MM-DD for filenames. */
+function formatDate(): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/** Bundle produced files into a zip off the main thread (fflate async `zip`). */
+function zipArtifacts(files: ArtifactFile[]): Promise<Uint8Array> {
+  const entries: Record<string, Uint8Array> = {};
+  for (const f of files) {
+    entries[`${f.base}.${f.ext}`] = typeof f.content === 'string' ? strToU8(f.content) : f.content;
+  }
+  return new Promise((resolve, reject) => {
+    zip(entries, { level: 6 }, (err, data) => (err ? reject(err) : resolve(data)));
+  });
+}
 
 export function ExportChangesButton({ className }: ExportChangesButtonProps) {
+  // Subscribe to everything that can change the pending-changes count so the
+  // badge stays live. `mutationVersion` bumps on every property / quantity /
+  // attribute / georef mutation; schedule edits are watched explicitly.
   const models = useViewerStore((s) => s.models);
-  const getMutationView = useViewerStore((s) => s.getMutationView);
-  const registerMutationView = useViewerStore((s) => s.registerMutationView);
   const mutationVersion = useViewerStore((s) => s.mutationVersion);
-
-  // Legacy single-model support
+  const georefMutations = useViewerStore((s) => s.georefMutations);
+  const scheduleData = useViewerStore((s) => s.scheduleData);
+  const scheduleIsEdited = useViewerStore((s) => s.scheduleIsEdited);
+  const scheduleSourceModelId = useViewerStore((s) => s.scheduleSourceModelId);
   const legacyIfcDataStore = useViewerStore((s) => s.ifcDataStore);
-  const legacyGeometryResult = useViewerStore((s) => s.geometryResult);
 
   const [isExporting, setIsExporting] = useState(false);
   const [exportStatus, setExportStatus] = useState<'idle' | 'success' | 'error'>('idle');
 
-  // Get model info - supports both federated models and legacy single-model
-  const modelInfo = useMemo(() => {
-    // First check federated models
-    if (models.size > 0) {
-      const firstModel = models.values().next().value;
-      if (firstModel) {
-        return {
-          id: firstModel.id,
-          name: firstModel.name,
-          ifcDataStore: firstModel.ifcDataStore,
-          schemaVersion: firstModel.schemaVersion,
-        };
-      }
-    }
-    // Fall back to legacy single-model
-    if (legacyIfcDataStore && legacyGeometryResult) {
-      return {
-        id: '__legacy__',
-        name: 'model',
-        ifcDataStore: legacyIfcDataStore,
-        schemaVersion: legacyIfcDataStore.schemaVersion,
-      };
-    }
-    return null;
-  }, [models, legacyIfcDataStore, legacyGeometryResult]);
-
-  // Count mutations (includes georef mutations + pending generated schedule tasks)
-  const mutationCount = useMemo(() => {
-    if (!modelInfo) return 0;
-    const mutationView = getMutationView(modelInfo.id);
-    let count = mutationView?.getMutations().length || 0;
-    const state = useViewerStore.getState();
-    const gm = state.georefMutations?.get(modelInfo.id);
-    if (gm) {
-      if (gm.projectedCRS) count += Object.keys(gm.projectedCRS).length;
-      if (gm.mapConversion) count += Object.keys(gm.mapConversion).length;
-    }
-    // Generated schedule tasks are first-class pending edits — they get
-    // spliced into the STEP on export (see injectScheduleIntoStep), so
-    // they belong in the same badge that tells users "you have unsaved
-    // work." Attribution: only count when this is the schedule's source
-    // model, so the badge doesn't inflate on every federated model.
-    if (state.scheduleSourceModelId === modelInfo.id) {
-      count += countGeneratedTasks(state.scheduleData);
-    }
-    return count;
+  const changed = useMemo(
+    () => collectChangedModels(useViewerStore.getState()),
+    // getState() reads the live snapshot; these deps drive recomputation.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [modelInfo, getMutationView, mutationVersion]);
+    [models, mutationVersion, georefMutations, scheduleData, scheduleIsEdited, scheduleSourceModelId, legacyIfcDataStore],
+  );
 
-  // Ensure mutation view exists
-  useEffect(() => {
-    if (!modelInfo?.ifcDataStore) return;
-
-    let mutationView = getMutationView(modelInfo.id);
-    if (mutationView) return;
-
-    const dataStore = modelInfo.ifcDataStore;
-    mutationView = new MutablePropertyView(dataStore.properties || null, modelInfo.id);
-
-    configureMutationView(mutationView, dataStore as IfcDataStore);
-
-    registerMutationView(modelInfo.id, mutationView);
-  }, [modelInfo, getMutationView, registerMutationView]);
-
-  // Format date as YYYY-MM-DD
-  const formatDate = useCallback(() => {
-    const now = new Date();
-    const year = now.getFullYear();
-    const month = String(now.getMonth() + 1).padStart(2, '0');
-    const day = String(now.getDate()).padStart(2, '0');
-    return `${year}-${month}-${day}`;
-  }, []);
-
-  // Generate filename from model name + date
-  const generateFilename = useCallback(() => {
-    if (!modelInfo) return 'export.ifc';
-    // Remove extension if present
-    const baseName = sanitizeFilename(modelInfo.name.replace(/\.[^.]+$/, ''), { fallback: 'export' });
-    return `${baseName}_${formatDate()}.ifc`;
-  }, [modelInfo, formatDate]);
+  const totalCount = totalChangeCount(changed);
+  const modelCount = changed.models.length;
 
   const handleExport = useCallback(async () => {
-    if (!modelInfo) return;
-
     setIsExporting(true);
     setExportStatus('idle');
 
     try {
-      const mutationView = getMutationView(modelInfo.id);
-      const exportDataStore = await ensureModelExportReady(modelInfo.id);
-      if (!exportDataStore) {
-        throw new Error('Model data is unavailable for export');
+      const { files, skipped } = await buildChangedArtifacts(
+        useViewerStore.getState(),
+        defaultBuildArtifactsDeps,
+      );
+
+      if (files.length === 0) {
+        if (skipped.length > 0) {
+          setExportStatus('error');
+          toast.error(`Export failed: ${skipped[0].reason}`);
+        } else {
+          toast.info('No changes to export');
+        }
+        return;
       }
 
-      // Determine schema version
-      const schemaVersion = modelInfo.schemaVersion || 'IFC4';
-      const schema = schemaVersion.includes('2X3') ? 'IFC2X3'
-                   : schemaVersion.includes('4X3') ? 'IFC4X3'
-                   : 'IFC4';
-
-      const exporter = new StepExporter(exportDataStore, mutationView || undefined);
-      const state = useViewerStore.getState();
-      const georefMutations = state.georefMutations?.get(modelInfo.id) ?? undefined;
-      const result = exporter.export({
-        schema: schema as 'IFC2X3' | 'IFC4' | 'IFC4X3',
-        includeGeometry: true,
-        applyMutations: true,
-        deltaOnly: false,
-        georefMutations,
-        description: `Exported from ifc-lite with ${mutationCount} modifications`,
-        application: 'ifc-lite',
-      });
-
-      // Splice any pending schedule into the STEP via the shared
-      // helper. Same contract every export surface uses so bugs can't
-      // differ between the quick button, the dialog, and the SDK.
-      const spliced = spliceScheduleIntoExport(result, modelInfo.id, exportDataStore, {
-        scheduleData: state.scheduleData ?? null,
-        scheduleIsEdited: state.scheduleIsEdited === true,
-        scheduleSourceModelId: state.scheduleSourceModelId ?? null,
-      });
-
-      // Download the file
-      downloadFile(spliced.content, generateFilename(), 'text/plain');
+      const date = formatDate();
+      if (files.length === 1) {
+        const f = files[0];
+        downloadFile(f.content, `${f.base}_${date}.${f.ext}`, f.mime);
+      } else {
+        const zipped = await zipArtifacts(files);
+        downloadFile(zipped, `ifc-lite-changes_${date}.zip`, 'application/zip');
+      }
 
       setExportStatus('success');
-
-      // Reset status after 2 seconds
       setTimeout(() => setExportStatus('idle'), 2000);
 
-      toast.success(`Exported ${result.stats.entityCount} entities (${result.stats.modifiedEntityCount} modified)`);
+      const exportedChanges = files.reduce((n, f) => n + f.changeCount, 0);
+      if (skipped.length > 0) {
+        toast.info(
+          `Exported ${files.length} of ${files.length + skipped.length} models — ${skipped.length} skipped (${skipped[0].reason})`,
+        );
+      } else if (files.length === 1) {
+        toast.success(`Exported ${files[0].base}.${files[0].ext} (${exportedChanges} changes)`);
+      } else {
+        toast.success(`Exported ${files.length} models (${exportedChanges} changes)`);
+      }
     } catch (error) {
       console.error('[ExportChangesButton] Export failed:', error);
       setExportStatus('error');
@@ -180,12 +128,18 @@ export function ExportChangesButton({ className }: ExportChangesButtonProps) {
     } finally {
       setIsExporting(false);
     }
-  }, [modelInfo, getMutationView, mutationCount, generateFilename]);
+  }, []);
 
-  // Don't render if no model or no mutations
-  if (!modelInfo || mutationCount === 0) {
+  // Nothing to export — but keep rendering while an export is in flight so a
+  // mid-export clear (count -> 0) doesn't unmount the button and drop state.
+  if (totalCount === 0 && !isExporting) {
     return null;
   }
+
+  const tooltip =
+    modelCount > 1
+      ? `Export changes in ${modelCount} models (${totalCount} changes)`
+      : `Export IFC with ${totalCount} property change${totalCount === 1 ? '' : 's'} applied`;
 
   return (
     <Tooltip>
@@ -195,6 +149,7 @@ export function ExportChangesButton({ className }: ExportChangesButtonProps) {
           size="sm"
           onClick={handleExport}
           disabled={isExporting}
+          aria-busy={isExporting}
           // Amber = unsaved-changes affordance (matches the app convention used
           // by the Cesium placement editor / ExportDialog dirty marker). The
           // button only renders while changes exist, so it should read as a
@@ -212,13 +167,11 @@ export function ExportChangesButton({ className }: ExportChangesButtonProps) {
           )}
           Export Changes
           <Badge className="ml-2 text-xs bg-amber-500 text-white border-transparent hover:bg-amber-500">
-            {mutationCount}
+            {totalCount}
           </Badge>
         </Button>
       </TooltipTrigger>
-      <TooltipContent>
-        Export IFC with {mutationCount} property changes applied
-      </TooltipContent>
+      <TooltipContent>{tooltip}</TooltipContent>
     </Tooltip>
   );
 }

--- a/apps/viewer/src/lib/export/changed-model-export.integration.test.ts
+++ b/apps/viewer/src/lib/export/changed-model-export.integration.test.ts
@@ -1,0 +1,139 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * End-to-end verification of the #1534 fix through the REAL exporters: two
+ * separately-edited models must yield two files, each carrying its own change,
+ * and the multi-model case must bundle into one zip that round-trips back to
+ * both files. Drives the shipped `defaultBuildArtifactsDeps` (real StepExporter
+ * + real MutablePropertyView), not fakes — only the store-hydration dep is
+ * stubbed so no live viewer store is needed.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { zipSync, unzipSync, strToU8, strFromU8 } from 'fflate';
+import type { IfcDataStore } from '@ifc-lite/parser';
+import { MutablePropertyView } from '@ifc-lite/mutations';
+import type { FederatedModel, SchemaVersion } from '@/store/types';
+import { buildChangedArtifacts, type ChangesExportState, type ArtifactFile } from './model-changes.js';
+import { defaultBuildArtifactsDeps } from './changed-model-export.js';
+
+type Entry = [number, string, string];
+
+/** Minimal real IfcDataStore from STEP lines (mirrors the export package tests). */
+function buildDataStore(entries: Entry[]): IfcDataStore {
+  const encoder = new TextEncoder();
+  const parts: Uint8Array[] = [];
+  const byId = new Map<number, { expressId: number; type: string; byteOffset: number; byteLength: number; lineNumber: number }>();
+  const byType = new Map<string, number[]>();
+  let offset = 0;
+  for (const [id, type, text] of entries) {
+    const encoded = encoder.encode(text);
+    const upper = type.toUpperCase();
+    byId.set(id, { expressId: id, type: upper, byteOffset: offset, byteLength: encoded.byteLength, lineNumber: 0 });
+    if (!byType.has(upper)) byType.set(upper, []);
+    byType.get(upper)!.push(id);
+    parts.push(encoded);
+    offset += encoded.byteLength;
+  }
+  const source = new Uint8Array(offset);
+  let pos = 0;
+  for (const p of parts) {
+    source.set(p, pos);
+    pos += p.byteLength;
+  }
+  return {
+    fileSize: offset,
+    schemaVersion: 'IFC4',
+    entityCount: entries.length,
+    parseTime: 0,
+    source,
+    entityIndex: { byId, byType },
+  } as unknown as IfcDataStore;
+}
+
+function mkModel(id: string, name: string, ifcDataStore: IfcDataStore): FederatedModel {
+  return {
+    id,
+    name,
+    schemaVersion: 'IFC4' as SchemaVersion,
+    ifcDataStore,
+    geometryResult: null,
+    idOffset: 0,
+  } as unknown as FederatedModel;
+}
+
+function decode(content: string | Uint8Array): string {
+  return typeof content === 'string' ? content : new TextDecoder().decode(content);
+}
+
+/** Two models, each an IfcWall whose Name we edit to a distinct value. */
+function twoEditedModels(): { state: ChangesExportState; resolve: (id: string) => Promise<IfcDataStore | null> } {
+  const storeA = buildDataStore([[1, 'IFCWALL', "#1=IFCWALL('gidA',$,'Wall A',$,$,$,$,$);"]]);
+  const storeB = buildDataStore([[1, 'IFCWALL', "#1=IFCWALL('gidB',$,'Wall B',$,$,$,$,$);"]]);
+
+  const viewA = new MutablePropertyView(null, 'a');
+  viewA.setAttribute(1, 'Name', 'ALPHA-EDITED');
+  const viewB = new MutablePropertyView(null, 'b');
+  viewB.setAttribute(1, 'Name', 'BETA-EDITED');
+
+  const stores = new Map<string, IfcDataStore>([['a', storeA], ['b', storeB]]);
+  const state: ChangesExportState = {
+    models: new Map<string, FederatedModel>([
+      ['a', mkModel('a', 'alpha.ifc', storeA)],
+      ['b', mkModel('b', 'beta.ifc', storeB)],
+    ]),
+    ifcDataStore: null,
+    geometryResult: null,
+    mutationViews: new Map([['a', viewA], ['b', viewB]]),
+    georefMutations: new Map(),
+    scheduleData: null,
+    scheduleIsEdited: false,
+    scheduleSourceModelId: null,
+  };
+  return { state, resolve: async (id) => stores.get(id) ?? null };
+}
+
+function zipFiles(files: ArtifactFile[]): Uint8Array {
+  const entries: Record<string, Uint8Array> = {};
+  for (const f of files) entries[`${f.base}.${f.ext}`] = typeof f.content === 'string' ? strToU8(f.content) : f.content;
+  return zipSync(entries);
+}
+
+describe('changed-model export (real exporters, #1534)', () => {
+  it('produces one STEP file per edited model, each carrying its own edit', async () => {
+    const { state, resolve } = twoEditedModels();
+    const deps = { ...defaultBuildArtifactsDeps, resolveStepDataStore: resolve };
+
+    const { files, skipped } = await buildChangedArtifacts(state, deps);
+
+    assert.strictEqual(skipped.length, 0);
+    assert.strictEqual(files.length, 2, 'both edited models must export (issue #1534)');
+
+    const byId = new Map(files.map((f) => [f.modelId, decode(f.content)]));
+    const a = byId.get('a')!;
+    const b = byId.get('b')!;
+
+    // Each file is a real STEP file carrying ONLY its own edit.
+    assert.ok(a.includes('END-ISO-10303-21;'), 'model a is a complete STEP file');
+    assert.ok(a.includes('ALPHA-EDITED'), 'model a carries its edited Name');
+    assert.ok(!a.includes('BETA-EDITED'), 'model a is not contaminated by model b');
+    assert.ok(b.includes('BETA-EDITED'), 'model b carries its edited Name');
+    assert.ok(!b.includes('ALPHA-EDITED'), 'model b is not contaminated by model a');
+  });
+
+  it('bundles multiple models into a zip that round-trips to both files', async () => {
+    const { state, resolve } = twoEditedModels();
+    const deps = { ...defaultBuildArtifactsDeps, resolveStepDataStore: resolve };
+    const { files } = await buildChangedArtifacts(state, deps);
+
+    const zipped = zipFiles(files);
+    const unzipped = unzipSync(zipped);
+    const names = Object.keys(unzipped).sort();
+    assert.deepStrictEqual(names, ['alpha.ifc', 'beta.ifc']);
+    assert.ok(strFromU8(unzipped['alpha.ifc']).includes('ALPHA-EDITED'));
+    assert.ok(strFromU8(unzipped['beta.ifc']).includes('BETA-EDITED'));
+  });
+});

--- a/apps/viewer/src/lib/export/changed-model-export.ts
+++ b/apps/viewer/src/lib/export/changed-model-export.ts
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Real per-model export implementations for the Export Changes flow, plus the
+ * production `BuildArtifactsDeps` wiring. Kept out of `model-changes.ts` so that
+ * module (and its unit tests) stay free of the browser renderer and the store
+ * barrel — the pure `buildChangedArtifacts` takes these as injected deps.
+ *
+ * Both paths bake the model's pending edits (`applyMutations: true`,
+ * `includeGeometry: true`) so the output is a full, round-trippable model with
+ * changes applied — not a delta. The STEP path additionally splices any pending
+ * schedule, but ONLY when handed real schedule state (the caller passes `null`
+ * for every non-target model), which is the sole guard against injecting the
+ * single global schedule into every exported file.
+ */
+
+import { StepExporter, Ifc5Exporter } from '@ifc-lite/export';
+import type { IfcDataStore } from '@ifc-lite/parser';
+import type { MutablePropertyView } from '@ifc-lite/mutations';
+import { spliceScheduleIntoExport } from '@/sdk/adapters/export-schedule-splice';
+import { ensureModelExportReady } from '@/services/desktop-export';
+import type {
+  BuildArtifactsDeps,
+  ChangesExportArtifact,
+  IfcxExportInvocation,
+  StepExportInvocation,
+} from './model-changes.js';
+
+/**
+ * Export one model to STEP with its property/quantity/attribute/georef edits
+ * applied, then splice the pending schedule when `invocation.scheduleState` is
+ * non-null. Mirrors the single-model STEP branch of `ExportDialog`.
+ */
+export async function exportChangedModelToStep(
+  modelId: string,
+  dataStore: IfcDataStore,
+  view: MutablePropertyView | undefined,
+  invocation: StepExportInvocation,
+): Promise<ChangesExportArtifact> {
+  const exporter = new StepExporter(dataStore, view);
+  const result = await exporter.exportAsync({
+    schema: invocation.schema,
+    includeGeometry: true,
+    applyMutations: true,
+    visibleOnly: false,
+    georefMutations: invocation.georefMutations,
+    description: invocation.description,
+    application: 'ifc-lite',
+  });
+
+  let content: string | Uint8Array = result.content;
+  if (invocation.scheduleState) {
+    content = spliceScheduleIntoExport({ content }, modelId, dataStore, invocation.scheduleState).content;
+  }
+
+  return { content, ext: 'ifc', mime: 'text/plain' };
+}
+
+/**
+ * Export one IFC5 model to IFCX with edits applied. Mirrors the (non
+ * changes-only) IFC5 branch of `ExportDialog`, including materializing
+ * GPU-instanced occurrences for the primary model. `withInstancedMeshes` is
+ * dynamically imported so this module can be pulled into a Node test context
+ * without loading the browser renderer.
+ */
+export async function exportChangedModelToIfcx(
+  _modelId: string,
+  dataStore: IfcDataStore,
+  view: MutablePropertyView | undefined,
+  invocation: IfcxExportInvocation,
+): Promise<ChangesExportArtifact> {
+  const { withInstancedMeshes } = await import('../../utils/instancedExport.js');
+  const exportGeometry = invocation.geometryResult
+    ? withInstancedMeshes(invocation.geometryResult, invocation.idOffset === 0)
+    : invocation.geometryResult;
+
+  const exporter = new Ifc5Exporter(dataStore, exportGeometry, view, invocation.idOffset);
+  const result = exporter.export({
+    includeGeometry: true,
+    includeProperties: true,
+    applyMutations: true,
+    visibleOnly: false,
+    // A round-trip "export my edits" should not silently drop properties that
+    // lack an official IFC5 schema, so keep full fidelity here. (The Export
+    // dialog exposes this as a user toggle that defaults to on; the one-click
+    // changes button deliberately favors completeness.)
+    onlyKnownProperties: false,
+    author: 'ifc-lite',
+  });
+
+  return { content: result.content, ext: 'ifcx', mime: 'application/json' };
+}
+
+/** Production dependency set for `buildChangedArtifacts`. */
+export const defaultBuildArtifactsDeps: BuildArtifactsDeps = {
+  resolveStepDataStore: ensureModelExportReady,
+  exportStep: exportChangedModelToStep,
+  exportIfcx: exportChangedModelToIfcx,
+};

--- a/apps/viewer/src/lib/export/model-changes.test.ts
+++ b/apps/viewer/src/lib/export/model-changes.test.ts
@@ -1,0 +1,502 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import type { IfcDataStore, ScheduleExtraction } from '@ifc-lite/parser';
+import type { MutablePropertyView } from '@ifc-lite/mutations';
+import type { FederatedModel, SchemaVersion } from '@/store/types';
+import type { GeorefMutationData } from '@/store/slices/mutationSlice';
+import {
+  collectChangedModels,
+  totalChangeCount,
+  buildChangedArtifacts,
+  uniqueArtifactBase,
+  mapStepSchema,
+  LEGACY_MODEL_ID,
+  type ChangesExportState,
+  type BuildArtifactsDeps,
+  type ChangesExportArtifact,
+} from './model-changes.js';
+
+// ── test builders ────────────────────────────────────────────────────────────
+
+/** A mutation view whose only observable behavior is its modified-entity count. */
+function mkView(count: number): MutablePropertyView {
+  return { getModifiedEntityCount: () => count } as unknown as MutablePropertyView;
+}
+
+function mkModel(
+  id: string,
+  name: string,
+  schemaVersion: SchemaVersion = 'IFC4',
+  extra: Partial<FederatedModel> = {},
+): FederatedModel {
+  return {
+    id,
+    name,
+    schemaVersion,
+    ifcDataStore: {} as IfcDataStore,
+    geometryResult: null,
+    idOffset: 0,
+    ...extra,
+  } as unknown as FederatedModel;
+}
+
+function mkSchedule(taskExpressIds: number[]): ScheduleExtraction {
+  return { tasks: taskExpressIds.map((expressId) => ({ expressId })) } as unknown as ScheduleExtraction;
+}
+
+function mkState(partial: Partial<ChangesExportState>): ChangesExportState {
+  return {
+    models: new Map(),
+    ifcDataStore: null,
+    geometryResult: null,
+    mutationViews: new Map(),
+    georefMutations: new Map(),
+    scheduleData: null,
+    scheduleIsEdited: false,
+    scheduleSourceModelId: null,
+    ...partial,
+  };
+}
+
+/**
+ * Independent transcription of the store's `getModifiedEntityCount`
+ * (mutationSlice.ts). The equivalence test locks `collectChangedModels` to this
+ * formula so drift between the badge count and the store's count is CI-caught.
+ */
+function referenceModifiedEntityCount(state: ChangesExportState): number {
+  let count = 0;
+  for (const view of state.mutationViews.values()) count += view.getModifiedEntityCount();
+  for (const [modelId, gm] of state.georefMutations) {
+    const hasGeoref =
+      (gm.projectedCRS && Object.keys(gm.projectedCRS).length > 0) ||
+      (gm.mapConversion && Object.keys(gm.mapConversion).length > 0);
+    if (hasGeoref && !state.mutationViews.has(modelId)) count += 1;
+  }
+  const tasks = state.scheduleData?.tasks;
+  let hasGenerated = false;
+  if (tasks) {
+    for (const t of tasks) {
+      if (!t.expressId || t.expressId <= 0) {
+        count++;
+        hasGenerated = true;
+      }
+    }
+  }
+  if (state.scheduleIsEdited && !hasGenerated) count++;
+  return count;
+}
+
+// ── collectChangedModels ─────────────────────────────────────────────────────
+
+describe('collectChangedModels', () => {
+  it('returns every changed model, not just the first (issue #1534)', () => {
+    const models = new Map<string, FederatedModel>([
+      ['a', mkModel('a', 'alpha.ifc')],
+      ['b', mkModel('b', 'beta.ifc')],
+      ['c', mkModel('c', 'gamma.ifc')],
+      ['d', mkModel('d', 'delta.ifc')],
+    ]);
+    const mutationViews = new Map<string, MutablePropertyView>([
+      ['a', mkView(1)],
+      ['b', mkView(1)],
+      ['c', mkView(1)],
+      ['d', mkView(1)],
+    ]);
+    const state = mkState({ models, mutationViews });
+
+    const result = collectChangedModels(state);
+    assert.strictEqual(result.models.length, 4);
+    assert.strictEqual(totalChangeCount(result), 4);
+    assert.deepStrictEqual(result.models.map((m) => m.id), ['a', 'b', 'c', 'd']);
+  });
+
+  it('sums per-model counts equal to getModifiedEntityCount (anti-drift lock)', () => {
+    const models = new Map<string, FederatedModel>([
+      ['a', mkModel('a', 'a.ifc')],
+      ['b', mkModel('b', 'b.ifc')],
+      ['g', mkModel('g', 'g.ifc')], // georef-only
+    ]);
+    const mutationViews = new Map<string, MutablePropertyView>([
+      ['a', mkView(3)],
+      ['b', mkView(2)],
+    ]);
+    const georefMutations = new Map<string, GeorefMutationData>([
+      ['g', { projectedCRS: { Name: 'EPSG:2056' } as GeorefMutationData['projectedCRS'] }],
+    ]);
+    const state = mkState({
+      models,
+      mutationViews,
+      georefMutations,
+      scheduleData: mkSchedule([0, 0, 5]), // 2 generated tasks
+      scheduleSourceModelId: 'a',
+    });
+
+    const result = collectChangedModels(state);
+    assert.strictEqual(totalChangeCount(result), referenceModifiedEntityCount(state));
+  });
+
+  it('excludes register-only views (a selection registers a 0-count view)', () => {
+    const models = new Map<string, FederatedModel>([
+      ['a', mkModel('a', 'a.ifc')],
+      ['b', mkModel('b', 'b.ifc')],
+    ]);
+    const mutationViews = new Map<string, MutablePropertyView>([
+      ['a', mkView(2)],
+      ['b', mkView(0)], // inspected but never edited
+    ]);
+    const result = collectChangedModels(mkState({ models, mutationViews }));
+    assert.deepStrictEqual(result.models.map((m) => m.id), ['a']);
+  });
+
+  it('counts a georef-only model as +1, and 0 when it also has a view', () => {
+    const models = new Map<string, FederatedModel>([
+      ['g', mkModel('g', 'g.ifc')],
+      ['p', mkModel('p', 'p.ifc')],
+    ]);
+    const georefMutations = new Map<string, GeorefMutationData>([
+      ['g', { mapConversion: { Eastings: 100 } as GeorefMutationData['mapConversion'] }],
+      ['p', { mapConversion: { Eastings: 200 } as GeorefMutationData['mapConversion'] }],
+    ]);
+    // 'p' also has a property view -> its georef contributes 0 (store parity).
+    const mutationViews = new Map<string, MutablePropertyView>([['p', mkView(4)]]);
+    const result = collectChangedModels(mkState({ models, georefMutations, mutationViews }));
+
+    const g = result.models.find((m) => m.id === 'g');
+    const p = result.models.find((m) => m.id === 'p');
+    assert.strictEqual(g?.changeCount, 1);
+    assert.strictEqual(p?.changeCount, 4);
+  });
+
+  it('attributes the schedule to the declared source model only', () => {
+    const models = new Map<string, FederatedModel>([
+      ['a', mkModel('a', 'a.ifc')],
+      ['b', mkModel('b', 'b.ifc')],
+    ]);
+    const mutationViews = new Map<string, MutablePropertyView>([
+      ['a', mkView(1)],
+      ['b', mkView(1)],
+    ]);
+    const state = mkState({
+      models,
+      mutationViews,
+      scheduleData: mkSchedule([0, 0, 0]), // 3 generated
+      scheduleSourceModelId: 'b',
+    });
+    const result = collectChangedModels(state);
+    assert.strictEqual(result.scheduleTargetModelId, 'b');
+    assert.strictEqual(result.models.find((m) => m.id === 'a')?.changeCount, 1);
+    assert.strictEqual(result.models.find((m) => m.id === 'b')?.changeCount, 1 + 3);
+    assert.strictEqual(result.models.find((m) => m.id === 'b')?.isScheduleTarget, true);
+  });
+
+  it('resolves a deterministic schedule target when the source is null', () => {
+    const models = new Map<string, FederatedModel>([
+      ['x', mkModel('x', 'x.ifcx', 'IFC5')], // not splice-capable
+      ['y', mkModel('y', 'y.ifc', 'IFC4')], // first STEP-capable -> target
+      ['z', mkModel('z', 'z.ifc', 'IFC4')],
+    ]);
+    const state = mkState({
+      models,
+      scheduleData: mkSchedule([0]), // 1 generated task, no source
+      scheduleSourceModelId: null,
+    });
+    const result = collectChangedModels(state);
+    assert.strictEqual(result.scheduleTargetModelId, 'y');
+    // The target is included even with no property edits.
+    assert.strictEqual(result.models.find((m) => m.id === 'y')?.changeCount, 1);
+  });
+
+  it('does not attribute the schedule to a loaded IFC5 source (cannot splice IFCX)', () => {
+    const models = new Map<string, FederatedModel>([
+      ['x', mkModel('x', 'x.ifcx', 'IFC5')],
+      ['y', mkModel('y', 'y.ifc', 'IFC4')],
+    ]);
+    const mutationViews = new Map<string, MutablePropertyView>([['y', mkView(1)]]);
+    const state = mkState({
+      models,
+      mutationViews,
+      scheduleData: mkSchedule([0, 0]),
+      scheduleSourceModelId: 'x', // IFC5 -> not splice-capable
+    });
+    const result = collectChangedModels(state);
+    // No misattribution to the STEP sibling; schedule is neither counted nor
+    // (later) claimed as exported.
+    assert.strictEqual(result.scheduleTargetModelId, null);
+    assert.strictEqual(result.models.find((m) => m.id === 'y')?.changeCount, 1);
+    assert.strictEqual(totalChangeCount(result), 1);
+  });
+
+  it('drops schedule attribution when the source model was removed', () => {
+    const models = new Map<string, FederatedModel>([['a', mkModel('a', 'a.ifc')]]);
+    const mutationViews = new Map<string, MutablePropertyView>([['a', mkView(1)]]);
+    const state = mkState({
+      models,
+      mutationViews,
+      scheduleData: mkSchedule([0, 0, 0]),
+      scheduleSourceModelId: 'gone', // dangling id (model unloaded)
+    });
+    const result = collectChangedModels(state);
+    assert.strictEqual(result.scheduleTargetModelId, null);
+    assert.strictEqual(totalChangeCount(result), 1); // only a's property edit
+  });
+
+  it('does not attribute an untouched parsed schedule', () => {
+    const models = new Map<string, FederatedModel>([['a', mkModel('a', 'a.ifc')]]);
+    const mutationViews = new Map<string, MutablePropertyView>([['a', mkView(1)]]);
+    const state = mkState({
+      models,
+      mutationViews,
+      scheduleData: mkSchedule([5, 6, 7]), // all parsed (existing expressIds), not edited
+      scheduleIsEdited: false,
+      scheduleSourceModelId: null,
+    });
+    const result = collectChangedModels(state);
+    assert.strictEqual(result.scheduleTargetModelId, null);
+    assert.strictEqual(totalChangeCount(result), 1);
+  });
+
+  it('uses the legacy store only when the federation map is empty', () => {
+    const legacyDs = { schemaVersion: 'IFC4' } as IfcDataStore;
+    const mutationViews = new Map<string, MutablePropertyView>([[LEGACY_MODEL_ID, mkView(2)]]);
+
+    const legacyState = mkState({ models: new Map(), ifcDataStore: legacyDs, mutationViews });
+    const legacyResult = collectChangedModels(legacyState);
+    assert.deepStrictEqual(legacyResult.models.map((m) => m.id), [LEGACY_MODEL_ID]);
+
+    // A populated map + a lingering legacy store must NOT emit a phantom entry.
+    const models = new Map<string, FederatedModel>([['a', mkModel('a', 'a.ifc')]]);
+    const federatedState = mkState({
+      models,
+      ifcDataStore: legacyDs,
+      mutationViews: new Map<string, MutablePropertyView>([['a', mkView(1)]]),
+    });
+    const federatedResult = collectChangedModels(federatedState);
+    assert.deepStrictEqual(federatedResult.models.map((m) => m.id), ['a']);
+  });
+
+  it('keeps null-dataStore (native) models in the changed set for the badge', () => {
+    const models = new Map<string, FederatedModel>([
+      ['n', mkModel('n', 'native.ifc', 'IFC4', { ifcDataStore: null })],
+    ]);
+    const georefMutations = new Map<string, GeorefMutationData>([
+      ['n', { projectedCRS: { Name: 'EPSG:2056' } as GeorefMutationData['projectedCRS'] }],
+    ]);
+    const result = collectChangedModels(mkState({ models, georefMutations }));
+    assert.strictEqual(result.models.length, 1);
+    assert.strictEqual(result.models[0].ifcDataStore, null);
+    assert.strictEqual(result.models[0].changeCount, 1);
+  });
+});
+
+// ── pure helpers ─────────────────────────────────────────────────────────────
+
+describe('uniqueArtifactBase', () => {
+  it('dedupes same name+ext, leaves different ext alone', () => {
+    const used = new Set<string>();
+    assert.strictEqual(uniqueArtifactBase('model', 'ifc', used), 'model');
+    assert.strictEqual(uniqueArtifactBase('model', 'ifc', used), 'model-2');
+    assert.strictEqual(uniqueArtifactBase('model', 'ifc', used), 'model-3');
+    // same base, different extension is a distinct filename -> no suffix.
+    assert.strictEqual(uniqueArtifactBase('model', 'ifcx', used), 'model');
+  });
+});
+
+describe('mapStepSchema', () => {
+  it('maps schema versions to STEP tokens', () => {
+    assert.strictEqual(mapStepSchema('IFC2X3'), 'IFC2X3');
+    assert.strictEqual(mapStepSchema('IFC4'), 'IFC4');
+    assert.strictEqual(mapStepSchema('IFC4X3'), 'IFC4X3');
+    assert.strictEqual(mapStepSchema('IFC5'), 'IFC4'); // caller routes IFC5 elsewhere
+  });
+});
+
+// ── buildChangedArtifacts ────────────────────────────────────────────────────
+
+interface StepCall {
+  modelId: string;
+  hasSchedule: boolean;
+  scheduleSourceId: string | null;
+}
+
+function fakeDeps(overrides: Partial<BuildArtifactsDeps> = {}): {
+  deps: BuildArtifactsDeps;
+  stepCalls: StepCall[];
+  ifcxCalls: string[];
+} {
+  const stepCalls: StepCall[] = [];
+  const ifcxCalls: string[] = [];
+  const deps: BuildArtifactsDeps = {
+    resolveStepDataStore: async () => ({}) as IfcDataStore,
+    exportStep: async (modelId, _ds, _view, inv): Promise<ChangesExportArtifact> => {
+      stepCalls.push({
+        modelId,
+        hasSchedule: inv.scheduleState != null,
+        scheduleSourceId: inv.scheduleState?.scheduleSourceModelId ?? null,
+      });
+      return { content: `STEP:${modelId}`, ext: 'ifc', mime: 'text/plain' };
+    },
+    exportIfcx: async (modelId): Promise<ChangesExportArtifact> => {
+      ifcxCalls.push(modelId);
+      return { content: `IFCX:${modelId}`, ext: 'ifcx', mime: 'application/json' };
+    },
+    ...overrides,
+  };
+  return { deps, stepCalls, ifcxCalls };
+}
+
+describe('buildChangedArtifacts', () => {
+  it('produces one file per changed model', async () => {
+    const models = new Map<string, FederatedModel>([
+      ['a', mkModel('a', 'alpha.ifc')],
+      ['b', mkModel('b', 'beta.ifc')],
+    ]);
+    const mutationViews = new Map<string, MutablePropertyView>([
+      ['a', mkView(1)],
+      ['b', mkView(1)],
+    ]);
+    const { deps } = fakeDeps();
+    const { files, skipped } = await buildChangedArtifacts(mkState({ models, mutationViews }), deps);
+    assert.strictEqual(files.length, 2);
+    assert.strictEqual(skipped.length, 0);
+    assert.deepStrictEqual(files.map((f) => `${f.base}.${f.ext}`), ['alpha.ifc', 'beta.ifc']);
+  });
+
+  it('splices the schedule into exactly one model', async () => {
+    const models = new Map<string, FederatedModel>([
+      ['a', mkModel('a', 'a.ifc')],
+      ['b', mkModel('b', 'b.ifc')],
+      ['c', mkModel('c', 'c.ifc')],
+    ]);
+    const mutationViews = new Map<string, MutablePropertyView>([
+      ['a', mkView(1)],
+      ['b', mkView(1)],
+      ['c', mkView(1)],
+    ]);
+    const { deps, stepCalls } = fakeDeps();
+    const state = mkState({
+      models,
+      mutationViews,
+      scheduleData: mkSchedule([0, 0]),
+      scheduleSourceModelId: 'b',
+    });
+    const result = await buildChangedArtifacts(state, deps);
+    const withSchedule = stepCalls.filter((c) => c.hasSchedule);
+    assert.strictEqual(withSchedule.length, 1);
+    assert.strictEqual(withSchedule[0].modelId, 'b');
+    // The splice gate matches on scheduleSourceModelId === modelId, so the
+    // passed state's source must be rewritten to the resolved target id.
+    assert.strictEqual(withSchedule[0].scheduleSourceId, 'b');
+    assert.strictEqual(result.scheduleSpliced, true);
+  });
+
+  it('rewrites the schedule source to the target when the original source is null', async () => {
+    // Unattributed schedule (null source) must still splice into a real target,
+    // with the source rewritten so the STEP gate matches (not relying on the
+    // legacy null-source fallback).
+    const models = new Map<string, FederatedModel>([['only', mkModel('only', 'only.ifc')]]);
+    const { deps, stepCalls } = fakeDeps();
+    const state = mkState({
+      models,
+      scheduleData: mkSchedule([0]),
+      scheduleSourceModelId: null,
+    });
+    await buildChangedArtifacts(state, deps);
+    const withSchedule = stepCalls.filter((c) => c.hasSchedule);
+    assert.strictEqual(withSchedule.length, 1);
+    assert.strictEqual(withSchedule[0].modelId, 'only');
+    assert.strictEqual(withSchedule[0].scheduleSourceId, 'only');
+  });
+
+  it('does not splice the schedule into any model when no target is splice-capable', async () => {
+    // IFC5-only session with a pending schedule: nothing can receive the splice,
+    // so no STEP file carries it and no file falsely claims it.
+    const models = new Map<string, FederatedModel>([['x', mkModel('x', 'x.ifcx', 'IFC5')]]);
+    const mutationViews = new Map<string, MutablePropertyView>([['x', mkView(1)]]);
+    const { deps, stepCalls, ifcxCalls } = fakeDeps();
+    const state = mkState({
+      models,
+      mutationViews,
+      scheduleData: mkSchedule([0, 0]),
+      scheduleSourceModelId: 'x',
+    });
+    const result = await buildChangedArtifacts(state, deps);
+    assert.strictEqual(stepCalls.length, 0);
+    assert.deepStrictEqual(ifcxCalls, ['x']);
+    assert.strictEqual(result.scheduleSpliced, false);
+  });
+
+  it('dedupes colliding filenames across models', async () => {
+    const models = new Map<string, FederatedModel>([
+      ['a', mkModel('a', 'model.ifc')],
+      ['b', mkModel('b', 'model.ifc')],
+    ]);
+    const mutationViews = new Map<string, MutablePropertyView>([
+      ['a', mkView(1)],
+      ['b', mkView(1)],
+    ]);
+    const { deps } = fakeDeps();
+    const { files } = await buildChangedArtifacts(mkState({ models, mutationViews }), deps);
+    assert.deepStrictEqual(files.map((f) => `${f.base}.${f.ext}`), ['model.ifc', 'model-2.ifc']);
+  });
+
+  it('routes IFC5 models to the IFCX exporter (mixed batch keeps both)', async () => {
+    const models = new Map<string, FederatedModel>([
+      ['s', mkModel('s', 'step.ifc', 'IFC4')],
+      ['x', mkModel('x', 'usd.ifcx', 'IFC5')],
+    ]);
+    const mutationViews = new Map<string, MutablePropertyView>([
+      ['s', mkView(1)],
+      ['x', mkView(1)],
+    ]);
+    const { deps, ifcxCalls } = fakeDeps();
+    const { files } = await buildChangedArtifacts(mkState({ models, mutationViews }), deps);
+    assert.deepStrictEqual(ifcxCalls, ['x']);
+    const exts = files.map((f) => f.ext).sort();
+    assert.deepStrictEqual(exts, ['ifc', 'ifcx']);
+  });
+
+  it('skips a model that cannot be hydrated and still exports the rest', async () => {
+    const models = new Map<string, FederatedModel>([
+      ['a', mkModel('a', 'a.ifc')],
+      ['b', mkModel('b', 'b.ifc')],
+    ]);
+    const mutationViews = new Map<string, MutablePropertyView>([
+      ['a', mkView(1)],
+      ['b', mkView(1)],
+    ]);
+    const { deps } = fakeDeps({
+      resolveStepDataStore: async (id) => (id === 'a' ? null : ({} as IfcDataStore)),
+    });
+    const { files, skipped } = await buildChangedArtifacts(mkState({ models, mutationViews }), deps);
+    assert.strictEqual(files.length, 1);
+    assert.strictEqual(files[0].modelId, 'b');
+    assert.strictEqual(skipped.length, 1);
+    assert.strictEqual(skipped[0].name, 'a.ifc');
+  });
+
+  it('continues the batch when one export throws', async () => {
+    const models = new Map<string, FederatedModel>([
+      ['a', mkModel('a', 'a.ifc')],
+      ['b', mkModel('b', 'b.ifc')],
+    ]);
+    const mutationViews = new Map<string, MutablePropertyView>([
+      ['a', mkView(1)],
+      ['b', mkView(1)],
+    ]);
+    const { deps } = fakeDeps({
+      exportStep: async (modelId, _ds, _view, _inv): Promise<ChangesExportArtifact> => {
+        if (modelId === 'a') throw new Error('boom');
+        return { content: `STEP:${modelId}`, ext: 'ifc', mime: 'text/plain' };
+      },
+    });
+    const { files, skipped } = await buildChangedArtifacts(mkState({ models, mutationViews }), deps);
+    assert.strictEqual(files.length, 1);
+    assert.strictEqual(files[0].modelId, 'b');
+    assert.strictEqual(skipped.length, 1);
+    assert.strictEqual(skipped[0].reason, 'boom');
+  });
+});

--- a/apps/viewer/src/lib/export/model-changes.test.ts
+++ b/apps/viewer/src/lib/export/model-changes.test.ts
@@ -152,23 +152,28 @@ describe('collectChangedModels', () => {
     assert.deepStrictEqual(result.models.map((m) => m.id), ['a']);
   });
 
-  it('counts a georef-only model as +1, and 0 when it also has a view', () => {
+  it('counts georef edits additively so they are never dropped from export', () => {
     const models = new Map<string, FederatedModel>([
       ['g', mkModel('g', 'g.ifc')],
       ['p', mkModel('p', 'p.ifc')],
+      ['v', mkModel('v', 'v.ifc')],
     ]);
     const georefMutations = new Map<string, GeorefMutationData>([
       ['g', { mapConversion: { Eastings: 100 } as GeorefMutationData['mapConversion'] }],
       ['p', { mapConversion: { Eastings: 200 } as GeorefMutationData['mapConversion'] }],
+      // 'v' has a zero-count (inspection-only) view AND a georef edit — the
+      // georef must still count so the edit is exported (Codex #1538 finding).
+      ['v', { projectedCRS: { Name: 'EPSG:2056' } as GeorefMutationData['projectedCRS'] }],
     ]);
-    // 'p' also has a property view -> its georef contributes 0 (store parity).
-    const mutationViews = new Map<string, MutablePropertyView>([['p', mkView(4)]]);
+    const mutationViews = new Map<string, MutablePropertyView>([
+      ['p', mkView(4)], // property edits + georef -> counted additively
+      ['v', mkView(0)], // inspected-only view + georef
+    ]);
     const result = collectChangedModels(mkState({ models, georefMutations, mutationViews }));
 
-    const g = result.models.find((m) => m.id === 'g');
-    const p = result.models.find((m) => m.id === 'p');
-    assert.strictEqual(g?.changeCount, 1);
-    assert.strictEqual(p?.changeCount, 4);
+    assert.strictEqual(result.models.find((m) => m.id === 'g')?.changeCount, 1);
+    assert.strictEqual(result.models.find((m) => m.id === 'p')?.changeCount, 5);
+    assert.strictEqual(result.models.find((m) => m.id === 'v')?.changeCount, 1);
   });
 
   it('attributes the schedule to the declared source model only', () => {

--- a/apps/viewer/src/lib/export/model-changes.ts
+++ b/apps/viewer/src/lib/export/model-changes.ts
@@ -10,12 +10,15 @@
  * first federated model).
  *
  * `collectChangedModels` is pure over a store-shaped snapshot so it stays unit
- * testable. Its per-model `changeCount` mirrors the store's
- * `getModifiedEntityCount` contribution exactly (property/quantity/attribute
- * edits -> distinct modified entities, +1 per georef-only model, generated /
- * edited schedule tasks attributed to a single resolved target model), so
- * `sum(changeCount) === getModifiedEntityCount(state)` for any state whose
- * mutation-view and georef keys are loaded models — locked by a unit test.
+ * testable. Its per-model `changeCount` tracks the store's
+ * `getModifiedEntityCount` contribution (property/quantity/attribute edits ->
+ * distinct modified entities, +1 for georef edits, generated / edited schedule
+ * tasks attributed to a single resolved target model), so
+ * `sum(changeCount) === getModifiedEntityCount(state)` for the common states
+ * (locked by a unit test). The one intentional divergence: georef edits are
+ * counted even when the model also carries property edits, so a georef edit is
+ * never dropped from the export set — a slight, deliberate over-count vs the
+ * store in that rare both-edits case.
  */
 
 import type { IfcDataStore, ScheduleExtraction } from '@ifc-lite/parser';
@@ -179,10 +182,14 @@ export function collectChangedModels(state: ChangesExportState): ChangedModelsRe
     if (!m) continue; // stale id (model removed) — nothing to export
 
     const view = state.mutationViews.get(id);
-    // Mirror getModifiedEntityCount: view contributes distinct modified
-    // entities; a georef-only model (no view) contributes exactly +1.
+    // Distinct modified entities from the overlay, plus +1 when the model has
+    // georeferencing edits. Georef is counted even when a (possibly
+    // inspection-only) view exists, so a georef-only edit on an already-viewed
+    // model is never dropped from the export set. (getModifiedEntityCount counts
+    // georef only when the model has no view — this is a deliberate, more
+    // inclusive divergence in the rare property-and-georef case.)
     let changeCount = view ? view.getModifiedEntityCount() : 0;
-    if (!view && hasGeorefFields(state.georefMutations.get(id))) changeCount += 1;
+    if (hasGeorefFields(state.georefMutations.get(id))) changeCount += 1;
 
     const isScheduleTarget = id === scheduleTargetModelId;
     if (isScheduleTarget) changeCount += scheduleCount;

--- a/apps/viewer/src/lib/export/model-changes.ts
+++ b/apps/viewer/src/lib/export/model-changes.ts
@@ -1,0 +1,400 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Single source of truth for "which loaded models have pending changes, and
+ * how many". Both the toolbar Export Changes badge and its multi-model export
+ * loop read from here, so the count the user sees and the set of files they get
+ * can never disagree (issue #1534: the badge + export used to look at only the
+ * first federated model).
+ *
+ * `collectChangedModels` is pure over a store-shaped snapshot so it stays unit
+ * testable. Its per-model `changeCount` mirrors the store's
+ * `getModifiedEntityCount` contribution exactly (property/quantity/attribute
+ * edits -> distinct modified entities, +1 per georef-only model, generated /
+ * edited schedule tasks attributed to a single resolved target model), so
+ * `sum(changeCount) === getModifiedEntityCount(state)` for any state whose
+ * mutation-view and georef keys are loaded models — locked by a unit test.
+ */
+
+import type { IfcDataStore, ScheduleExtraction } from '@ifc-lite/parser';
+import type { MutablePropertyView } from '@ifc-lite/mutations';
+import type { GeometryResult } from '@ifc-lite/geometry';
+import type { FederatedModel, SchemaVersion } from '@/store/types';
+import type { GeorefMutationData } from '@/store/slices/mutationSlice';
+import type { ExportScheduleState } from '@/sdk/adapters/export-schedule-splice';
+// Import from the pure helpers module (not the slice) so this stays free of the
+// slice's runtime graph — keeps the module and its tests hermetic.
+import { countGeneratedTasks } from '@/store/slices/schedule-edit-helpers';
+import { sanitizeFilename } from './download.js';
+
+/** Synthetic id for the legacy single-model store (no federation map). */
+export const LEGACY_MODEL_ID = '__legacy__';
+
+/**
+ * The subset of the viewer store `collectChangedModels` /
+ * `buildChangedArtifacts` read. Declared structurally (not as the full
+ * `ViewerState`) so tests can build a minimal snapshot, and so the real store
+ * — whose Maps are mutable — is assignable via `ReadonlyMap`.
+ */
+export interface ChangesExportState {
+  /** Federated models keyed by id. Empty in legacy single-model mode. */
+  models: ReadonlyMap<string, FederatedModel>;
+  /** Legacy single-model data store (used only when `models` is empty). */
+  ifcDataStore: IfcDataStore | null;
+  /** Legacy single-model geometry (IFC5 legacy export needs it). */
+  geometryResult: GeometryResult | null;
+  /** Per-model overlay of pending edits. A model only has a view once edited. */
+  mutationViews: ReadonlyMap<string, MutablePropertyView>;
+  /** Per-model georeferencing edits. */
+  georefMutations: ReadonlyMap<string, GeorefMutationData>;
+  /** In-memory schedule (generated tasks / edits) pending export. */
+  scheduleData: ScheduleExtraction | null;
+  /** True when the parsed schedule has been edited since load. */
+  scheduleIsEdited: boolean;
+  /** Model the schedule is attributed to (null for untouched / unattributed). */
+  scheduleSourceModelId: string | null;
+}
+
+/** One loaded model with pending, exportable changes. */
+export interface ChangedModelEntry {
+  /** Federated model id, or {@link LEGACY_MODEL_ID}. */
+  id: string;
+  /** Raw model name (may carry a file extension); sanitize at the file layer. */
+  name: string;
+  schemaVersion: SchemaVersion;
+  /** null for native-metadata models — export layer decides exportability. */
+  ifcDataStore: IfcDataStore | null;
+  /** Distinct modified entities + this model's schedule contribution. */
+  changeCount: number;
+  /** True only for the one model the global schedule is attributed to. */
+  isScheduleTarget: boolean;
+}
+
+export interface ChangedModelsResult {
+  /** Only models whose `changeCount > 0`, in model insertion order. */
+  models: ChangedModelEntry[];
+  /** The single model the pending schedule is spliced into (null = none). */
+  scheduleTargetModelId: string | null;
+}
+
+interface ResolvedModel {
+  name: string;
+  schemaVersion: SchemaVersion;
+  ifcDataStore: IfcDataStore | null;
+}
+
+/**
+ * Candidate model ids, in a stable order. Legacy and federated are mutually
+ * exclusive: the legacy store is only consulted when the federation map is
+ * empty, so a populated map with a lingering `ifcDataStore` never emits a
+ * phantom legacy entry (mirrors the original ExportChangesButton fallback).
+ */
+function candidateModelIds(state: ChangesExportState): string[] {
+  if (state.models.size > 0) return Array.from(state.models.keys());
+  if (state.ifcDataStore) return [LEGACY_MODEL_ID];
+  return [];
+}
+
+function resolveModel(state: ChangesExportState, id: string): ResolvedModel | null {
+  if (id === LEGACY_MODEL_ID) {
+    if (!state.ifcDataStore) return null;
+    return {
+      name: 'model',
+      schemaVersion: state.ifcDataStore.schemaVersion as SchemaVersion,
+      ifcDataStore: state.ifcDataStore,
+    };
+  }
+  const m = state.models.get(id);
+  if (!m) return null;
+  return { name: m.name, schemaVersion: m.schemaVersion, ifcDataStore: m.ifcDataStore };
+}
+
+function hasGeorefFields(gm: GeorefMutationData | undefined): boolean {
+  if (!gm) return false;
+  const crs = gm.projectedCRS ? Object.keys(gm.projectedCRS).length : 0;
+  const map = gm.mapConversion ? Object.keys(gm.mapConversion).length : 0;
+  return crs > 0 || map > 0;
+}
+
+/** Number of pending schedule "changes" (matches `getModifiedEntityCount`). */
+function scheduleChangeCount(state: ChangesExportState): number {
+  const generated = countGeneratedTasks(state.scheduleData);
+  if (generated > 0) return generated;
+  // An edited-but-not-generated schedule surfaces a single +1 so the badge
+  // signals "pending export" without inflating per field (store parity).
+  return state.scheduleIsEdited === true ? 1 : 0;
+}
+
+/** A model the STEP schedule splice can actually write into. */
+function isSpliceCapable(m: ResolvedModel | null): boolean {
+  return m != null && m.schemaVersion !== 'IFC5' && m.ifcDataStore != null;
+}
+
+/**
+ * Resolve the one model the pending schedule is spliced into — and ONLY a model
+ * that can actually receive the splice. The schedule is spliced into STEP text
+ * (`injectScheduleIntoStep`), so the target must be a loaded, non-IFC5 model
+ * with a data store. Returning an unspliceable target would count the schedule
+ * in the badge yet drop it from every file (a silent, falsely-reported loss).
+ *
+ *   - no pending schedule -> null (an untouched parsed schedule is not a change)
+ *   - attributed source that is a loaded, splice-capable model -> that model
+ *   - attributed source that is removed / IFC5 / native -> null (do NOT
+ *     misattribute the schedule to an unrelated model; it's neither counted nor
+ *     claimed as exported)
+ *   - unattributed (null source) -> the first splice-capable candidate, else null
+ *
+ * `buildChangedArtifacts` rewrites the passed schedule state's source id to this
+ * resolved target so the STEP splice gate (`scheduleSourceModelId === modelId`)
+ * matches deterministically regardless of the original attribution.
+ */
+function resolveScheduleTarget(state: ChangesExportState, candidates: string[]): string | null {
+  if (scheduleChangeCount(state) === 0) return null;
+
+  const src = state.scheduleSourceModelId;
+  if (src != null) {
+    return candidates.includes(src) && isSpliceCapable(resolveModel(state, src)) ? src : null;
+  }
+
+  for (const id of candidates) {
+    if (isSpliceCapable(resolveModel(state, id))) return id;
+  }
+  return null;
+}
+
+/**
+ * Collect every loaded model with pending, exportable changes plus the resolved
+ * schedule target. Pure over {@link ChangesExportState}.
+ */
+export function collectChangedModels(state: ChangesExportState): ChangedModelsResult {
+  const candidates = candidateModelIds(state);
+  const scheduleTargetModelId = resolveScheduleTarget(state, candidates);
+  const scheduleCount = scheduleChangeCount(state);
+
+  const models: ChangedModelEntry[] = [];
+  for (const id of candidates) {
+    const m = resolveModel(state, id);
+    if (!m) continue; // stale id (model removed) — nothing to export
+
+    const view = state.mutationViews.get(id);
+    // Mirror getModifiedEntityCount: view contributes distinct modified
+    // entities; a georef-only model (no view) contributes exactly +1.
+    let changeCount = view ? view.getModifiedEntityCount() : 0;
+    if (!view && hasGeorefFields(state.georefMutations.get(id))) changeCount += 1;
+
+    const isScheduleTarget = id === scheduleTargetModelId;
+    if (isScheduleTarget) changeCount += scheduleCount;
+
+    if (changeCount > 0) {
+      models.push({
+        id,
+        name: m.name,
+        schemaVersion: m.schemaVersion,
+        ifcDataStore: m.ifcDataStore,
+        changeCount,
+        isScheduleTarget,
+      });
+    }
+  }
+
+  return { models, scheduleTargetModelId };
+}
+
+/** Total pending changes across all changed models — the badge number. */
+export function totalChangeCount(result: ChangedModelsResult): number {
+  let n = 0;
+  for (const m of result.models) n += m.changeCount;
+  return n;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Artifact builder
+//
+// Turns the changed-model set into a list of per-model export artifacts (one
+// `.ifc` per STEP model, one `.ifcx` per IFC5 model). Kept pure by taking the
+// heavy exporters as injected `deps` — the real wiring lives in
+// `changed-model-export.ts`, so this module (and its tests) never load the
+// browser renderer or the store barrel. The component turns `files` into a
+// single download or a zip, and reports `skipped`.
+// ────────────────────────────────────────────────────────────────────────────
+
+/** A produced export payload for one model, before final naming. */
+export interface ChangesExportArtifact {
+  content: string | Uint8Array;
+  ext: 'ifc' | 'ifcx';
+  mime: string;
+}
+
+/** STEP export request handed to the injected `exportStep` dep. */
+export interface StepExportInvocation {
+  schema: 'IFC2X3' | 'IFC4' | 'IFC4X3';
+  georefMutations?: GeorefMutationData;
+  /** Real schedule state ONLY for the schedule-target model; null otherwise. */
+  scheduleState: ExportScheduleState | null;
+  description: string;
+}
+
+/** IFC5 export request handed to the injected `exportIfcx` dep. */
+export interface IfcxExportInvocation {
+  geometryResult: GeometryResult | null;
+  idOffset: number;
+}
+
+export interface BuildArtifactsDeps {
+  /** Hydrate a model's exportable data store (native models may resolve null). */
+  resolveStepDataStore: (modelId: string) => Promise<IfcDataStore | null>;
+  exportStep: (
+    modelId: string,
+    dataStore: IfcDataStore,
+    view: MutablePropertyView | undefined,
+    invocation: StepExportInvocation,
+  ) => Promise<ChangesExportArtifact>;
+  exportIfcx: (
+    modelId: string,
+    dataStore: IfcDataStore,
+    view: MutablePropertyView | undefined,
+    invocation: IfcxExportInvocation,
+  ) => Promise<ChangesExportArtifact>;
+}
+
+/** A produced file (base name is deduped so `base.ext` is unique in the set). */
+export interface ArtifactFile {
+  base: string;
+  ext: 'ifc' | 'ifcx';
+  mime: string;
+  content: string | Uint8Array;
+  modelId: string;
+  changeCount: number;
+}
+
+export interface SkippedModel {
+  name: string;
+  reason: string;
+}
+
+export interface BuildArtifactsResult {
+  files: ArtifactFile[];
+  skipped: SkippedModel[];
+  scheduleTargetModelId: string | null;
+  /** True if the pending schedule was actually spliced into a produced STEP file. */
+  scheduleSpliced: boolean;
+}
+
+/** Map any schema string to the STEP schema token (matches the legacy button). */
+export function mapStepSchema(schemaVersion: string): 'IFC2X3' | 'IFC4' | 'IFC4X3' {
+  return schemaVersion.includes('2X3')
+    ? 'IFC2X3'
+    : schemaVersion.includes('4X3')
+      ? 'IFC4X3'
+      : 'IFC4';
+}
+
+function stripExtension(name: string): string {
+  return name.replace(/\.[^.]+$/, '');
+}
+
+/**
+ * Reserve a collision-free base for `base.ext`. fflate keys zip entries by
+ * name and silently clobbers duplicates, and federated models frequently share
+ * a name (and `sanitizeFilename` truncates to 60 chars), so two `model.ifc`
+ * inputs must become `model.ifc` + `model-2.ifc`. Same base, different ext
+ * (`model.ifc` + `model.ifcx`) do NOT collide.
+ */
+export function uniqueArtifactBase(base: string, ext: string, used: Set<string>): string {
+  if (!used.has(`${base}.${ext}`)) {
+    used.add(`${base}.${ext}`);
+    return base;
+  }
+  let i = 2;
+  while (used.has(`${base}-${i}.${ext}`)) i++;
+  used.add(`${base}-${i}.${ext}`);
+  return `${base}-${i}`;
+}
+
+/**
+ * Build every changed model's export artifact. Sequential (one `await` per
+ * model) so peak memory stays bounded and a single failure can't discard its
+ * siblings — each model is individually try/caught into `skipped`. The pending
+ * schedule's real state reaches only the resolved target model; every other
+ * model gets `null`, which makes double-injection structurally impossible.
+ */
+export async function buildChangedArtifacts(
+  state: ChangesExportState,
+  deps: BuildArtifactsDeps,
+): Promise<BuildArtifactsResult> {
+  const { models: changed, scheduleTargetModelId } = collectChangedModels(state);
+
+  const realScheduleState: ExportScheduleState = {
+    scheduleData: state.scheduleData ?? null,
+    scheduleIsEdited: state.scheduleIsEdited === true,
+    scheduleSourceModelId: state.scheduleSourceModelId ?? null,
+  };
+
+  const files: ArtifactFile[] = [];
+  const skipped: SkippedModel[] = [];
+  const usedNames = new Set<string>();
+  let scheduleSpliced = false;
+
+  for (const entry of changed) {
+    const view = state.mutationViews.get(entry.id);
+    // Rewrite the source id to the resolved target so the STEP splice gate
+    // (`scheduleSourceModelId === modelId`) matches deterministically — even
+    // when the original attribution was null (unattributed) or pointed at a
+    // now-removed model. `resolveScheduleTarget` guarantees the target is
+    // splice-capable, so this never routes the schedule to an IFC5/native file.
+    const scheduleArg = entry.id === scheduleTargetModelId
+      ? { ...realScheduleState, scheduleSourceModelId: entry.id }
+      : null;
+
+    try {
+      let artifact: ChangesExportArtifact;
+
+      if (entry.schemaVersion === 'IFC5') {
+        const model = state.models.get(entry.id);
+        const dataStore = model?.ifcDataStore ?? (entry.id === LEGACY_MODEL_ID ? state.ifcDataStore : null);
+        if (!dataStore) {
+          skipped.push({ name: entry.name, reason: 'No IFC data available for export' });
+          continue;
+        }
+        const geometryResult = model?.geometryResult ?? (entry.id === LEGACY_MODEL_ID ? state.geometryResult : null);
+        artifact = await deps.exportIfcx(entry.id, dataStore, view, {
+          geometryResult,
+          idOffset: model?.idOffset ?? 0,
+        });
+      } else {
+        const dataStore = await deps.resolveStepDataStore(entry.id);
+        if (!dataStore) {
+          skipped.push({ name: entry.name, reason: 'Model data is unavailable for export' });
+          continue;
+        }
+        artifact = await deps.exportStep(entry.id, dataStore, view, {
+          schema: mapStepSchema(entry.schemaVersion),
+          georefMutations: state.georefMutations.get(entry.id),
+          scheduleState: scheduleArg,
+          description: `Exported from ifc-lite with ${entry.changeCount} modifications`,
+        });
+        if (scheduleArg) scheduleSpliced = true;
+      }
+
+      const base = uniqueArtifactBase(
+        sanitizeFilename(stripExtension(entry.name), { fallback: 'export' }),
+        artifact.ext,
+        usedNames,
+      );
+      files.push({
+        base,
+        ext: artifact.ext,
+        mime: artifact.mime,
+        content: artifact.content,
+        modelId: entry.id,
+        changeCount: entry.changeCount,
+      });
+    } catch (err) {
+      skipped.push({ name: entry.name, reason: err instanceof Error ? err.message : 'Export failed' });
+    }
+  }
+
+  return { files, skipped, scheduleTargetModelId, scheduleSpliced };
+}

--- a/apps/viewer/src/store/slices/schedule-edit-helpers.ts
+++ b/apps/viewer/src/store/slices/schedule-edit-helpers.ts
@@ -177,3 +177,21 @@ export function resolveScheduleSourceModelId<M>(
   }
   return emptyFallback;
 }
+
+/**
+ * Count tasks that the user generated locally — tasks with no existing
+ * `expressId` in the host STEP file. These are the "pending schedule
+ * edits" equivalent of property mutations: they need to be serialized
+ * and spliced into the STEP on export.
+ *
+ * Matches the partitioning rule in `export-adapter.injectScheduleIntoStep`
+ * so the count, dirty flag, and export path agree on what counts.
+ */
+export function countGeneratedTasks(data: ScheduleExtraction | null | undefined): number {
+  if (!data || data.tasks.length === 0) return 0;
+  let n = 0;
+  for (const t of data.tasks) {
+    if (!t.expressId || t.expressId <= 0) n++;
+  }
+  return n;
+}

--- a/apps/viewer/src/store/slices/scheduleSlice.ts
+++ b/apps/viewer/src/store/slices/scheduleSlice.ts
@@ -1311,20 +1311,7 @@ export function computeActiveProductIds(
 
 export { taskStartEpoch, taskFinishEpoch, parseIsoDate };
 
-/**
- * Count tasks that the user generated locally — tasks with no existing
- * `expressId` in the host STEP file. These are the "pending schedule
- * edits" equivalent of property mutations: they need to be serialized
- * and spliced into the STEP on export.
- *
- * Matches the partitioning rule in `export-adapter.injectScheduleIntoStep`
- * so the count, dirty flag, and export path agree on what counts.
- */
-export function countGeneratedTasks(data: ScheduleExtraction | null | undefined): number {
-  if (!data || data.tasks.length === 0) return 0;
-  let n = 0;
-  for (const t of data.tasks) {
-    if (!t.expressId || t.expressId <= 0) n++;
-  }
-  return n;
-}
+// `countGeneratedTasks` lives with the other pure schedule helpers so lean
+// consumers (e.g. lib/export/model-changes) can import it without pulling the
+// slice's full runtime graph. Re-exported here to keep the store surface stable.
+export { countGeneratedTasks } from './schedule-edit-helpers.js';


### PR DESCRIPTION
Closes #1534.

## Problem
With several models loaded, editing a property in each one and clicking **Export Changes** only counted one change and exported a single model (the first). The report: *"The 'Export changes' only sees one change in one model and exports only one model. The first one."*

## Root cause
`ExportChangesButton` derived its model from `models.values().next().value` — the **first** federated model — and both the badge count and the export operated on that single model.

## Fix
Aggregate across **every** changed model, behind two small, unit-tested modules:

- **`lib/export/model-changes.ts`** (pure) — `collectChangedModels(state)` is the single source of truth for *what changed*: per-model modified-entity count + a georef-only `+1` + a single resolved schedule target. Its per-model `changeCount` mirrors the store's `getModifiedEntityCount()` exactly (locked by an equivalence test). `buildChangedArtifacts()` turns that into one artifact per model, sequentially and each individually `try/catch`ed.
- **`lib/export/changed-model-export.ts`** (IO) — the real per-model exporters (`StepExporter` for STEP schemas, `Ifc5Exporter` for IFC5), byte-for-byte parity with `ExportDialog`'s single-model branch. Injected as deps so the pure module and its tests never load the renderer or the store barrel.
- **`ExportChangesButton.tsx`** — badge = sum of all changed models' counts; the tooltip and toast report the multi-model case; keeps rendering during an in-flight export.

### Behavior
- **1 changed model** → a single bare `.ifc` / `.ifcx` download (unchanged from today).
- **N changed models** → **one** `ifc-lite-changes_<date>.zip` bundling each model's file (deduped entry names; fflate async `zip`), avoiding the browser multi-download prompt.
- **IFC5** models export as `.ifcx` (previously they collapsed to a mislabeled `.ifc`); a mixed batch puts both in the same zip.
- **Schedule** is spliced into exactly one *splice-capable* STEP model, with its source id rewritten to the resolved target so the splice gate always matches — never duplicated across files, never counted-but-silently-dropped.
- **Native / unhydratable** models are skipped with a reason instead of aborting the batch.

Also relocates the pure `countGeneratedTasks` helper to `schedule-edit-helpers` (re-exported from `scheduleSlice`, so `@/store` consumers are unchanged) to keep the new export module free of the store's runtime graph.

## Design + review
Approach was designed via an adversarial judge-panel and the diff was put through an adversarial find→verify review. That review caught a **major** self-introduced defect — a schedule attributed to a removed or IFC5 source model was counted in the badge yet silently dropped from every file — which is fixed here (`resolveScheduleTarget` now only ever targets a splice-capable model, and the splice source id is realigned to that target). Two findings were verified as **pre-existing and out of scope** for #1534 (noted below, not changed):
- `ExportDialog`'s "N entities modified" banner reads the all-models count while its single-model export writes one.
- `removeModel` leaves orphaned mutation views/georef entries (and a dangling schedule source) in the store; this fix tolerates that safely (a dangling schedule source resolves to no target, so it is neither counted nor claimed).
- The SDK `export.ifc` adapter is single-model **by contract** (throws on >1) — a separate feature gap.

`MergedExporter` was deliberately **not** used: it flattens N models into one re-based `.ifc` and can't do IFC5 — wrong semantics for "give me my edited models back."

## Testing
- New `model-changes.test.ts` (23 assertions): multi-model collection, the `getModifiedEntityCount` equivalence lock, register-only-view exclusion, georef-only counting, schedule attribution (declared source / null source / removed source / IFC5 source / untouched), legacy XOR federated, filename dedup, IFC5 routing, partial-success and throw continuation, and the schedule single-splice / source-rewrite guard.
- New `changed-model-export.integration.test.ts`: drives the **real** `StepExporter` + `MutablePropertyView` for two separately-edited models and asserts each `.ifc` carries only its own edit, then round-trips the zip back to both files.
- Full viewer suite green: **1275 passed, 0 failed, 2 skipped**; `tsc --noEmit` clean.

No changeset: changes are confined to `apps/viewer` (not a published `@ifc-lite/*` package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Export Changes now includes all edited models, not just one, and can download multiple exports together as a ZIP.
  * Export badges and tooltips now reflect the total number of changed models more accurately.

* **Bug Fixes**
  * Exporting no longer disappears mid-process when counts change.
  * Better handling for exports that partially fail or need to skip some models, with clearer success/error feedback.
  * Schedule-related edits are now handled more reliably during export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->