### PR TITLE
fix(viewer): sort grouped list by the sorted column, not always by count

### DIFF
--- a/apps/viewer/src/components/viewer/lists/ListResultsTable.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListResultsTable.tsx
@@ -118,7 +118,8 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange 
     items: DisplayItem[]; groupCount: number; totals: Totals; groupKeys: string[];
   }>(() => {
     if (isGrouped) {
-      const view = buildGroupedView(sortedRows, columns, { columnId: groupByColumnId, sumColumnIds }, expandedGroups);
+      const sort = sortCol === null ? null : { colIdx: sortCol, dir: sortDir };
+      const view = buildGroupedView(sortedRows, columns, { columnId: groupByColumnId, sumColumnIds }, expandedGroups, sort);
       return {
         items: view.items, groupCount: view.groupCount, totals: view.totals,
         groupKeys: view.items.filter((i) => i.kind === 'group').map((i) => (i as { key: string }).key),
@@ -130,7 +131,7 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange 
       totals: flatTotals(sortedRows, columns, sumColumnIds),
       groupKeys: [],
     };
-  }, [isGrouped, sortedRows, columns, groupByColumnId, sumColumnIds, expandedGroups]);
+  }, [isGrouped, sortedRows, columns, groupByColumnId, sumColumnIds, expandedGroups, sortCol, sortDir]);
 
   const columnWidths = useMemo(
     () => columns.map((c, i) => widthOverrides[c.id] ?? autoColumnWidth(c.label ?? c.propertyName, result.rows, i)),
@@ -204,6 +205,7 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange 
       columns,
       rows: sortedRows,
       grouping,
+      sort: sortCol === null ? null : { colIdx: sortCol, dir: sortDir },
       numericCols,
       columnWidths,
       generatedAt: new Date().toLocaleString(),
@@ -216,7 +218,7 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange 
       row_count: sortedRows.length,
       column_count: columns.length,
     });
-  }, [listName, columns, sortedRows, grouping, numericCols, columnWidths]);
+  }, [listName, columns, sortedRows, grouping, sortCol, sortDir, numericCols, columnWidths]);
 
   // Flat, ordered list of the selectable rows (group headers excluded) and a
   // lookup from a row to its position, so Shift+click range-select works over

--- a/apps/viewer/src/components/viewer/lists/list-table-utils.test.ts
+++ b/apps/viewer/src/components/viewer/lists/list-table-utils.test.ts
@@ -69,6 +69,15 @@ describe('buildGroupedView group ordering (#1498)', () => {
     assert.deepStrictEqual(groupOrder(desc), ['B', 'C', 'A']);
   });
 
+  it('breaks summed-column ties in the sort direction', () => {
+    // Sums: X=5, Y=5 (tie), Z=9 — ties resolve by label following the arrow.
+    const tie = rows(['X', 5], ['Y', 5], ['Z', 9]);
+    const asc = groupOrder(buildGroupedView(tie, columns, GROUP_BY_CAT, NO_EXPAND, { colIdx: 1, dir: 'asc' }));
+    assert.deepStrictEqual(asc, ['X', 'Y', 'Z']);
+    const desc = groupOrder(buildGroupedView(tie, columns, GROUP_BY_CAT, NO_EXPAND, { colIdx: 1, dir: 'desc' }));
+    assert.deepStrictEqual(desc, ['Z', 'Y', 'X']);
+  });
+
   it('numeric group columns sort numerically, not lexically', () => {
     const numCols: ColumnDefinition[] = [{ id: 'n', source: 'attribute', propertyName: 'N' }];
     const numRows: ListRow[] = [2, 10, 1].map((n, i) => ({ entityId: i + 1, modelId: 'm', values: [n] }));

--- a/apps/viewer/src/components/viewer/lists/list-table-utils.test.ts
+++ b/apps/viewer/src/components/viewer/lists/list-table-utils.test.ts
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import type { ColumnDefinition, ListRow } from '@ifc-lite/lists';
+import { buildGroupedView, compareCells, type GroupSort } from './list-table-utils';
+
+const columns: ColumnDefinition[] = [
+  { id: 'cat', source: 'attribute', propertyName: 'Category' },
+  { id: 'qty', source: 'quantity', propertyName: 'Qty' },
+];
+
+/** Build a row list from [category, qty] tuples. */
+function rows(...tuples: [string, number][]): ListRow[] {
+  return tuples.map(([cat, qty], i) => ({ entityId: i + 1, modelId: 'm', values: [cat, qty] }));
+}
+
+/** The visible group labels, in order, from a grouped view. */
+function groupOrder(view: { items: { kind: string }[] }): string[] {
+  return view.items
+    .filter((i): i is { kind: 'group'; label: string } => i.kind === 'group')
+    .map((g) => g.label);
+}
+
+const GROUP_BY_CAT = { columnId: 'cat', sumColumnIds: ['qty'] };
+const NO_EXPAND = new Set<string>();
+
+describe('buildGroupedView group ordering (#1498)', () => {
+  // Three categories whose group sizes deliberately disagree with their
+  // alphabetical order, so a count-sort and a value-sort are distinguishable.
+  //   C: 3 rows, A: 2 rows, B: 1 row
+  const sample = rows(
+    ['C', 10], ['C', 20], ['C', 5],
+    ['A', 7], ['A', 3],
+    ['B', 100],
+  );
+
+  it('defaults to count-descending when no sort is active', () => {
+    const view = buildGroupedView(sample, columns, GROUP_BY_CAT, NO_EXPAND, null);
+    assert.deepStrictEqual(groupOrder(view), ['C', 'A', 'B']);
+  });
+
+  it('sorting ascending on the group column orders groups by value, not count', () => {
+    const sort: GroupSort = { colIdx: 0, dir: 'asc' };
+    const view = buildGroupedView(sample, columns, GROUP_BY_CAT, NO_EXPAND, sort);
+    assert.deepStrictEqual(groupOrder(view), ['A', 'B', 'C']);
+  });
+
+  it('sorting descending on the group column reverses the group order', () => {
+    const sort: GroupSort = { colIdx: 0, dir: 'desc' };
+    const view = buildGroupedView(sample, columns, GROUP_BY_CAT, NO_EXPAND, sort);
+    assert.deepStrictEqual(groupOrder(view), ['C', 'B', 'A']);
+  });
+
+  it('asc and desc on the group column produce different orders (the reported bug)', () => {
+    const asc = groupOrder(buildGroupedView(sample, columns, GROUP_BY_CAT, NO_EXPAND, { colIdx: 0, dir: 'asc' }));
+    const desc = groupOrder(buildGroupedView(sample, columns, GROUP_BY_CAT, NO_EXPAND, { colIdx: 0, dir: 'desc' }));
+    assert.notDeepStrictEqual(asc, desc);
+    assert.deepStrictEqual(asc, [...desc].reverse());
+  });
+
+  it('sorting on a summed column orders groups by their aggregate sum', () => {
+    // Sums: C=35, A=10, B=100.
+    const asc = buildGroupedView(sample, columns, GROUP_BY_CAT, NO_EXPAND, { colIdx: 1, dir: 'asc' });
+    assert.deepStrictEqual(groupOrder(asc), ['A', 'C', 'B']);
+    const desc = buildGroupedView(sample, columns, GROUP_BY_CAT, NO_EXPAND, { colIdx: 1, dir: 'desc' });
+    assert.deepStrictEqual(groupOrder(desc), ['B', 'C', 'A']);
+  });
+
+  it('numeric group columns sort numerically, not lexically', () => {
+    const numCols: ColumnDefinition[] = [{ id: 'n', source: 'attribute', propertyName: 'N' }];
+    const numRows: ListRow[] = [2, 10, 1].map((n, i) => ({ entityId: i + 1, modelId: 'm', values: [n] }));
+    const view = buildGroupedView(numRows, numCols, { columnId: 'n', sumColumnIds: [] }, NO_EXPAND, { colIdx: 0, dir: 'asc' });
+    assert.deepStrictEqual(groupOrder(view), ['1', '2', '10']);
+  });
+
+  it('empty group values sort first ascending under a single (none) bucket', () => {
+    const withBlank = rows(['B', 1], ['A', 1]);
+    withBlank.push({ entityId: 99, modelId: 'm', values: ['', 1] });
+    const view = buildGroupedView(withBlank, columns, GROUP_BY_CAT, NO_EXPAND, { colIdx: 0, dir: 'asc' });
+    assert.deepStrictEqual(groupOrder(view), ['(none)', 'A', 'B']);
+  });
+
+  it('falls back to count-descending for a sort on a non-group, non-summed column', () => {
+    // colIdx 1 is not summed here, so groups keep the default order.
+    const noSum = { columnId: 'cat', sumColumnIds: [] };
+    const view = buildGroupedView(sample, columns, noSum, NO_EXPAND, { colIdx: 1, dir: 'asc' });
+    assert.deepStrictEqual(groupOrder(view), ['C', 'A', 'B']);
+  });
+});
+
+describe('compareCells', () => {
+  it('orders numbers numerically and nulls first', () => {
+    assert.ok(compareCells(2, 10) < 0);
+    assert.ok(compareCells(null, 0) < 0);
+    assert.strictEqual(compareCells(null, null), 0);
+  });
+});

--- a/apps/viewer/src/components/viewer/lists/list-table-utils.ts
+++ b/apps/viewer/src/components/viewer/lists/list-table-utils.ts
@@ -9,6 +9,11 @@
  */
 
 import type { CellValue, ColumnDefinition, ListRow, ListGrouping } from '@ifc-lite/lists';
+import { compareCells, orderGroups, type GroupSort, type OrderableGroup } from '@/lib/lists/group-sort';
+
+// Re-exported so existing consumers keep importing the list-table barrel.
+export { compareCells, orderGroups };
+export type { GroupSort, OrderableGroup };
 
 export function formatCellValue(value: CellValue): string {
   if (value === null || value === undefined) return '';
@@ -18,14 +23,6 @@ export function formatCellValue(value: CellValue): string {
     return value.toFixed(4).replace(/\.?0+$/, '');
   }
   return String(value);
-}
-
-export function compareCells(a: CellValue, b: CellValue): number {
-  if (a === null && b === null) return 0;
-  if (a === null) return -1;
-  if (b === null) return 1;
-  if (typeof a === 'number' && typeof b === 'number') return a - b;
-  return String(a).localeCompare(String(b));
 }
 
 /** A column is numeric (summable) when every sampled non-empty value is a
@@ -65,49 +62,13 @@ export type DisplayItem =
 export interface Totals { count: number; sums: Record<string, number> }
 export interface GroupedView { items: DisplayItem[]; groupCount: number; totals: Totals }
 
-/** Active header sort — a column index into the result columns and a
- *  direction. `null` means no explicit sort (grouped view falls back to its
- *  count-descending default). */
-export type GroupSort = { colIdx: number; dir: 'asc' | 'desc' } | null;
-
 function sumIndices(columns: ColumnDefinition[], sumColumnIds: string[]) {
   return sumColumnIds
     .map((id) => ({ id, idx: columns.findIndex((c) => c.id === id) }))
     .filter((s) => s.idx >= 0);
 }
 
-interface GroupBucket { key: string; label: string; raw: CellValue; count: number; sums: Record<string, number>; rows: ListRow[] }
-
-/** Minimal shape `orderGroups` needs — the group header's raw value (for the
- *  group-by column), row count, and per-column subtotals. */
-export interface OrderableGroup { label: string; raw: CellValue; count: number; sums: Record<string, number> }
-
-/** Order the group headers to match the active header sort so that toggling
- *  a column's sort actually reorders the groups (not just the rows inside
- *  them). The group header only carries a value for the group-by column and
- *  the summed columns, so those drive the order; anything else (or no sort)
- *  falls back to the count-descending default. Shared with the export path so
- *  the exported sections keep the on-screen order. */
-export function orderGroups<T extends OrderableGroup>(
-  groups: T[],
-  sort: GroupSort,
-  groupIdx: number,
-  sums: { id: string; idx: number }[],
-): T[] {
-  const byCount = (a: T, b: T) => b.count - a.count || a.label.localeCompare(b.label);
-  if (!sort) return groups.sort(byCount);
-
-  const dir = sort.dir === 'desc' ? -1 : 1;
-  if (sort.colIdx === groupIdx) {
-    return groups.sort((a, b) => compareCells(a.raw, b.raw) * dir || a.label.localeCompare(b.label));
-  }
-  const summed = sums.find((s) => s.idx === sort.colIdx);
-  if (summed) {
-    return groups.sort((a, b) => (a.sums[summed.id] - b.sums[summed.id]) * dir || a.label.localeCompare(b.label));
-  }
-  // A non-group, non-summed column has no group-level value to order by.
-  return groups.sort(byCount);
-}
+interface GroupBucket extends OrderableGroup { key: string; rows: ListRow[] }
 
 /** Bucket already-filtered/sorted rows by the group-by column, accumulate
  *  per-group + grand count/sums, and flatten into a virtualizable list

--- a/apps/viewer/src/components/viewer/lists/list-table-utils.ts
+++ b/apps/viewer/src/components/viewer/lists/list-table-utils.ts
@@ -9,7 +9,7 @@
  */
 
 import type { CellValue, ColumnDefinition, ListRow, ListGrouping } from '@ifc-lite/lists';
-import { compareCells, orderGroups, type GroupSort, type OrderableGroup } from '@/lib/lists/group-sort';
+import { buildGroupBuckets, compareCells, orderGroups, type GroupSort, type OrderableGroup } from '@/lib/lists/group-sort';
 
 // Re-exported so existing consumers keep importing the list-table barrel.
 export { compareCells, orderGroups };
@@ -68,8 +68,6 @@ function sumIndices(columns: ColumnDefinition[], sumColumnIds: string[]) {
     .filter((s) => s.idx >= 0);
 }
 
-interface GroupBucket extends OrderableGroup { key: string; rows: ListRow[] }
-
 /** Bucket already-filtered/sorted rows by the group-by column, accumulate
  *  per-group + grand count/sums, and flatten into a virtualizable list
  *  (group header followed by its rows when the group is expanded). */
@@ -82,25 +80,18 @@ export function buildGroupedView(
 ): GroupedView {
   const groupIdx = columns.findIndex((c) => c.id === grouping.columnId);
   const sums = sumIndices(columns, grouping.sumColumnIds);
-  const zero = (): Record<string, number> => Object.fromEntries(sums.map((s) => [s.id, 0]));
 
-  const totals: Totals = { count: rows.length, sums: zero() };
-  const byKey = new Map<string, GroupBucket>();
+  const byKey = buildGroupBuckets(
+    rows,
+    (r) => (groupIdx >= 0 ? r.values[groupIdx] : null),
+    sums,
+    (r, idx) => r.values[idx],
+    formatCellValue,
+  );
 
-  for (const row of rows) {
-    const cell = groupIdx >= 0 ? row.values[groupIdx] : null;
-    const isNone = cell === null || cell === undefined || cell === '';
-    const raw: CellValue = isNone ? null : cell;
-    const label = isNone ? '(none)' : formatCellValue(cell);
-    let g = byKey.get(label);
-    if (!g) { g = { key: label, label, raw, count: 0, sums: zero(), rows: [] }; byKey.set(label, g); }
-    g.count++;
-    g.rows.push(row);
-    for (const s of sums) {
-      const v = row.values[s.idx];
-      if (typeof v === 'number' && Number.isFinite(v)) { g.sums[s.id] += v; totals.sums[s.id] += v; }
-    }
-  }
+  // Grand totals are the sum of the per-group subtotals.
+  const totals: Totals = { count: rows.length, sums: Object.fromEntries(sums.map((s) => [s.id, 0])) };
+  for (const g of byKey.values()) for (const s of sums) totals.sums[s.id] += g.sums[s.id];
 
   const groups = orderGroups(Array.from(byKey.values()), sort, groupIdx, sums);
   const items: DisplayItem[] = [];

--- a/apps/viewer/src/components/viewer/lists/list-table-utils.ts
+++ b/apps/viewer/src/components/viewer/lists/list-table-utils.ts
@@ -65,10 +65,48 @@ export type DisplayItem =
 export interface Totals { count: number; sums: Record<string, number> }
 export interface GroupedView { items: DisplayItem[]; groupCount: number; totals: Totals }
 
+/** Active header sort — a column index into the result columns and a
+ *  direction. `null` means no explicit sort (grouped view falls back to its
+ *  count-descending default). */
+export type GroupSort = { colIdx: number; dir: 'asc' | 'desc' } | null;
+
 function sumIndices(columns: ColumnDefinition[], sumColumnIds: string[]) {
   return sumColumnIds
     .map((id) => ({ id, idx: columns.findIndex((c) => c.id === id) }))
     .filter((s) => s.idx >= 0);
+}
+
+interface GroupBucket { key: string; label: string; raw: CellValue; count: number; sums: Record<string, number>; rows: ListRow[] }
+
+/** Minimal shape `orderGroups` needs — the group header's raw value (for the
+ *  group-by column), row count, and per-column subtotals. */
+export interface OrderableGroup { label: string; raw: CellValue; count: number; sums: Record<string, number> }
+
+/** Order the group headers to match the active header sort so that toggling
+ *  a column's sort actually reorders the groups (not just the rows inside
+ *  them). The group header only carries a value for the group-by column and
+ *  the summed columns, so those drive the order; anything else (or no sort)
+ *  falls back to the count-descending default. Shared with the export path so
+ *  the exported sections keep the on-screen order. */
+export function orderGroups<T extends OrderableGroup>(
+  groups: T[],
+  sort: GroupSort,
+  groupIdx: number,
+  sums: { id: string; idx: number }[],
+): T[] {
+  const byCount = (a: T, b: T) => b.count - a.count || a.label.localeCompare(b.label);
+  if (!sort) return groups.sort(byCount);
+
+  const dir = sort.dir === 'desc' ? -1 : 1;
+  if (sort.colIdx === groupIdx) {
+    return groups.sort((a, b) => compareCells(a.raw, b.raw) * dir || a.label.localeCompare(b.label));
+  }
+  const summed = sums.find((s) => s.idx === sort.colIdx);
+  if (summed) {
+    return groups.sort((a, b) => (a.sums[summed.id] - b.sums[summed.id]) * dir || a.label.localeCompare(b.label));
+  }
+  // A non-group, non-summed column has no group-level value to order by.
+  return groups.sort(byCount);
 }
 
 /** Bucket already-filtered/sorted rows by the group-by column, accumulate
@@ -79,19 +117,22 @@ export function buildGroupedView(
   columns: ColumnDefinition[],
   grouping: ListGrouping,
   expanded: Set<string>,
+  sort: GroupSort = null,
 ): GroupedView {
   const groupIdx = columns.findIndex((c) => c.id === grouping.columnId);
   const sums = sumIndices(columns, grouping.sumColumnIds);
   const zero = (): Record<string, number> => Object.fromEntries(sums.map((s) => [s.id, 0]));
 
   const totals: Totals = { count: rows.length, sums: zero() };
-  const byKey = new Map<string, { key: string; label: string; count: number; sums: Record<string, number>; rows: ListRow[] }>();
+  const byKey = new Map<string, GroupBucket>();
 
   for (const row of rows) {
-    const raw = groupIdx >= 0 ? row.values[groupIdx] : null;
-    const label = raw === null || raw === undefined || raw === '' ? '(none)' : formatCellValue(raw);
+    const cell = groupIdx >= 0 ? row.values[groupIdx] : null;
+    const isNone = cell === null || cell === undefined || cell === '';
+    const raw: CellValue = isNone ? null : cell;
+    const label = isNone ? '(none)' : formatCellValue(cell);
     let g = byKey.get(label);
-    if (!g) { g = { key: label, label, count: 0, sums: zero(), rows: [] }; byKey.set(label, g); }
+    if (!g) { g = { key: label, label, raw, count: 0, sums: zero(), rows: [] }; byKey.set(label, g); }
     g.count++;
     g.rows.push(row);
     for (const s of sums) {
@@ -100,7 +141,7 @@ export function buildGroupedView(
     }
   }
 
-  const groups = Array.from(byKey.values()).sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+  const groups = orderGroups(Array.from(byKey.values()), sort, groupIdx, sums);
   const items: DisplayItem[] = [];
   for (const g of groups) {
     items.push({ kind: 'group', key: g.key, label: g.label, count: g.count, sums: g.sums });

--- a/apps/viewer/src/lib/lists/export/model.test.ts
+++ b/apps/viewer/src/lib/lists/export/model.test.ts
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import type { ColumnDefinition, ListRow } from '@ifc-lite/lists';
+import { buildExportModel } from './model';
+
+const columns: ColumnDefinition[] = [
+  { id: 'cat', source: 'attribute', propertyName: 'Category' },
+  { id: 'qty', source: 'quantity', propertyName: 'Qty' },
+];
+
+function rows(...tuples: [string, number][]): ListRow[] {
+  return tuples.map(([cat, qty], i) => ({ entityId: i + 1, modelId: 'm', values: [cat, qty] }));
+}
+
+// C: 3 rows, A: 2 rows, B: 1 row — count order disagrees with value order.
+const sample = rows(['C', 10], ['C', 20], ['C', 5], ['A', 7], ['A', 3], ['B', 100]);
+const base = {
+  title: 'List',
+  columns,
+  numericCols: [false, true],
+  columnWidths: [120, 120],
+  generatedAt: 'now',
+  grouping: { columnId: 'cat', sumColumnIds: ['qty'] },
+};
+
+describe('buildExportModel grouped-section order honours the on-screen sort (#1498)', () => {
+  it('defaults to count-descending with no sort', () => {
+    const m = buildExportModel({ ...base, rows: sample });
+    assert.deepStrictEqual(m.groups?.map((g) => g.label), ['C', 'A', 'B']);
+  });
+
+  it('follows an ascending group-column sort', () => {
+    const m = buildExportModel({ ...base, rows: sample, sort: { colIdx: 0, dir: 'asc' } });
+    assert.deepStrictEqual(m.groups?.map((g) => g.label), ['A', 'B', 'C']);
+  });
+
+  it('follows a descending group-column sort', () => {
+    const m = buildExportModel({ ...base, rows: sample, sort: { colIdx: 0, dir: 'desc' } });
+    assert.deepStrictEqual(m.groups?.map((g) => g.label), ['C', 'B', 'A']);
+  });
+
+  it('follows a summed-column sort by aggregate', () => {
+    // Sums: A=10, C=35, B=100.
+    const m = buildExportModel({ ...base, rows: sample, sort: { colIdx: 1, dir: 'asc' } });
+    assert.deepStrictEqual(m.groups?.map((g) => g.label), ['A', 'C', 'B']);
+  });
+});

--- a/apps/viewer/src/lib/lists/export/model.ts
+++ b/apps/viewer/src/lib/lists/export/model.ts
@@ -10,7 +10,7 @@
  */
 
 import type { CellValue, ColumnDefinition, ListRow, ListGrouping } from '@ifc-lite/lists';
-import { orderGroups, type GroupSort } from '@/components/viewer/lists/list-table-utils';
+import { orderGroups, type GroupSort } from '@/lib/lists/group-sort';
 
 export interface ExportColumn {
   id: string;

--- a/apps/viewer/src/lib/lists/export/model.ts
+++ b/apps/viewer/src/lib/lists/export/model.ts
@@ -10,7 +10,7 @@
  */
 
 import type { CellValue, ColumnDefinition, ListRow, ListGrouping } from '@ifc-lite/lists';
-import { orderGroups, type GroupSort } from '@/lib/lists/group-sort';
+import { buildGroupBuckets, orderGroups, type GroupSort } from '@/lib/lists/group-sort';
 
 export interface ExportColumn {
   id: string;
@@ -97,20 +97,17 @@ export function buildExportModel(input: BuildModelInput): ExportModel {
   let groups: ExportGroup[] | null = null;
   if (groupColumnId) {
     const groupIdx = columns.findIndex((c) => c.id === groupColumnId);
-    // `raw` rides alongside for value-based ordering; writers ignore it.
-    const byKey = new Map<string, ExportGroup & { raw: CellValue }>();
-    for (const r of rows) {
-      const cell = r.values[groupIdx];
-      const isNone = cell === null || cell === undefined || cell === '';
-      const raw: CellValue = isNone ? null : cell;
-      const label = isNone ? '(none)' : displayCell(cell);
-      let g = byKey.get(label);
-      if (!g) { g = { label, raw, count: 0, sums: zeroSums(), rows: [] }; byKey.set(label, g); }
-      g.count++;
-      g.rows.push(r.values);
-      addSums(g.sums, r.values);
-    }
-    groups = orderGroups(Array.from(byKey.values()), sort ?? null, groupIdx, sumIdx);
+    // Bucket + subtotal via the shared helper so the sections match the table
+    // exactly, then order and project each member row to its display values.
+    const byKey = buildGroupBuckets(
+      rows,
+      (r) => r.values[groupIdx],
+      sumIdx,
+      (r, idx) => r.values[idx],
+      displayCell,
+    );
+    groups = orderGroups(Array.from(byKey.values()), sort ?? null, groupIdx, sumIdx)
+      .map((g) => ({ label: g.label, count: g.count, sums: g.sums, rows: g.rows.map((r) => r.values) }));
   }
 
   return { title, generatedAt, columns: exportCols, groups, rows: flatRows, groupColumnId, sumColumnIds, totals };

--- a/apps/viewer/src/lib/lists/export/model.ts
+++ b/apps/viewer/src/lib/lists/export/model.ts
@@ -10,6 +10,7 @@
  */
 
 import type { CellValue, ColumnDefinition, ListRow, ListGrouping } from '@ifc-lite/lists';
+import { orderGroups, type GroupSort } from '@/components/viewer/lists/list-table-utils';
 
 export interface ExportColumn {
   id: string;
@@ -46,6 +47,8 @@ export interface BuildModelInput {
   /** Rows already filtered + sorted exactly as shown on screen. */
   rows: ListRow[];
   grouping?: ListGrouping;
+  /** Active header sort, so grouped sections export in the on-screen order. */
+  sort?: GroupSort;
   numericCols: boolean[];
   columnWidths: number[];
   generatedAt: string;
@@ -63,7 +66,7 @@ export function displayCell(value: CellValue): string {
 }
 
 export function buildExportModel(input: BuildModelInput): ExportModel {
-  const { columns, rows, grouping, numericCols, columnWidths, title, generatedAt } = input;
+  const { columns, rows, grouping, sort, numericCols, columnWidths, title, generatedAt } = input;
   const sumColumnIds = grouping?.sumColumnIds ?? [];
   const exportCols: ExportColumn[] = columns.map((c, i) => ({
     id: c.id,
@@ -94,17 +97,20 @@ export function buildExportModel(input: BuildModelInput): ExportModel {
   let groups: ExportGroup[] | null = null;
   if (groupColumnId) {
     const groupIdx = columns.findIndex((c) => c.id === groupColumnId);
-    const byKey = new Map<string, ExportGroup>();
+    // `raw` rides alongside for value-based ordering; writers ignore it.
+    const byKey = new Map<string, ExportGroup & { raw: CellValue }>();
     for (const r of rows) {
-      const raw = r.values[groupIdx];
-      const label = raw === null || raw === undefined || raw === '' ? '(none)' : displayCell(raw);
+      const cell = r.values[groupIdx];
+      const isNone = cell === null || cell === undefined || cell === '';
+      const raw: CellValue = isNone ? null : cell;
+      const label = isNone ? '(none)' : displayCell(cell);
       let g = byKey.get(label);
-      if (!g) { g = { label, count: 0, sums: zeroSums(), rows: [] }; byKey.set(label, g); }
+      if (!g) { g = { label, raw, count: 0, sums: zeroSums(), rows: [] }; byKey.set(label, g); }
       g.count++;
       g.rows.push(r.values);
       addSums(g.sums, r.values);
     }
-    groups = Array.from(byKey.values()).sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+    groups = orderGroups(Array.from(byKey.values()), sort ?? null, groupIdx, sumIdx);
   }
 
   return { title, generatedAt, columns: exportCols, groups, rows: flatRows, groupColumnId, sumColumnIds, totals };

--- a/apps/viewer/src/lib/lists/group-sort.ts
+++ b/apps/viewer/src/lib/lists/group-sort.ts
@@ -29,6 +29,42 @@ export type GroupSort = { colIdx: number; dir: 'asc' | 'desc' } | null;
  *  group-by column), row count, and per-column subtotals. */
 export interface OrderableGroup { label: string; raw: CellValue; count: number; sums: Record<string, number> }
 
+/** A bucketed group plus the member rows that fed it (row type is the
+ *  caller's — `ListRow` for the table, `ListRow` projected to values by the
+ *  export). */
+export type GroupBucket<R> = OrderableGroup & { key: string; rows: R[] };
+
+/** Bucket rows by a group cell, deriving `(none)` / raw / label and the
+ *  per-group subtotals identically for every caller, so the table view and the
+ *  export can never diverge on grouping (the divergence that caused #1498). The
+ *  returned Map keeps first-seen insertion order; callers apply their own
+ *  ordering with `orderGroups`. */
+export function buildGroupBuckets<R>(
+  rows: R[],
+  getGroupCell: (row: R) => CellValue,
+  sums: { id: string; idx: number }[],
+  getSumValue: (row: R, idx: number) => CellValue,
+  formatLabel: (cell: CellValue) => string,
+): Map<string, GroupBucket<R>> {
+  const zero = (): Record<string, number> => Object.fromEntries(sums.map((s) => [s.id, 0]));
+  const byKey = new Map<string, GroupBucket<R>>();
+  for (const row of rows) {
+    const cell = getGroupCell(row);
+    const isNone = cell === null || cell === undefined || cell === '';
+    const raw: CellValue = isNone ? null : cell;
+    const label = isNone ? '(none)' : formatLabel(cell);
+    let g = byKey.get(label);
+    if (!g) { g = { key: label, label, raw, count: 0, sums: zero(), rows: [] }; byKey.set(label, g); }
+    g.count++;
+    g.rows.push(row);
+    for (const s of sums) {
+      const v = getSumValue(row, s.idx);
+      if (typeof v === 'number' && Number.isFinite(v)) g.sums[s.id] += v;
+    }
+  }
+  return byKey;
+}
+
 /** Order the group headers to match the active header sort so that toggling
  *  a column's sort actually reorders the groups (not just the rows inside
  *  them). The group header only carries a value for the group-by column and

--- a/apps/viewer/src/lib/lists/group-sort.ts
+++ b/apps/viewer/src/lib/lists/group-sort.ts
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Pure, framework-agnostic sorting for the Lists feature — the cell
+ * comparator plus the group-header ordering. Lives in `lib/` so both the
+ * table component and the export model can share one implementation (and stay
+ * in agreement) without a component → lib layer inversion.
+ */
+
+import type { CellValue } from '@ifc-lite/lists';
+
+/** Null-first, numbers-numeric, everything-else locale-compared. */
+export function compareCells(a: CellValue, b: CellValue): number {
+  if (a === null && b === null) return 0;
+  if (a === null) return -1;
+  if (b === null) return 1;
+  if (typeof a === 'number' && typeof b === 'number') return a - b;
+  return String(a).localeCompare(String(b));
+}
+
+/** Active header sort — a column index into the result columns and a
+ *  direction. `null` means no explicit sort (grouped view falls back to its
+ *  count-descending default). */
+export type GroupSort = { colIdx: number; dir: 'asc' | 'desc' } | null;
+
+/** Minimal shape `orderGroups` needs — the group header's raw value (for the
+ *  group-by column), row count, and per-column subtotals. */
+export interface OrderableGroup { label: string; raw: CellValue; count: number; sums: Record<string, number> }
+
+/** Order the group headers to match the active header sort so that toggling
+ *  a column's sort actually reorders the groups (not just the rows inside
+ *  them). The group header only carries a value for the group-by column and
+ *  the summed columns, so those drive the order; anything else (or no sort)
+ *  falls back to the count-descending default. The label tie-breaker rides
+ *  the same direction as the primary key, so ties stay consistent with the
+ *  arrow. */
+export function orderGroups<T extends OrderableGroup>(
+  groups: T[],
+  sort: GroupSort,
+  groupIdx: number,
+  sums: { id: string; idx: number }[],
+): T[] {
+  const byCount = (a: T, b: T) => b.count - a.count || a.label.localeCompare(b.label);
+  if (!sort) return groups.sort(byCount);
+
+  const dir = sort.dir === 'desc' ? -1 : 1;
+  if (sort.colIdx === groupIdx) {
+    return groups.sort((a, b) => (compareCells(a.raw, b.raw) || a.label.localeCompare(b.label)) * dir);
+  }
+  const summed = sums.find((s) => s.idx === sort.colIdx);
+  if (summed) {
+    return groups.sort((a, b) => ((a.sums[summed.id] - b.sums[summed.id]) || a.label.localeCompare(b.label)) * dir);
+  }
+  // A non-group, non-summed column has no group-level value to order by.
+  return groups.sort(byCount);
+}


### PR DESCRIPTION
Closes #1498.

## The bug

In the Lists results table, when the results are **grouped** by a column, the group headers were always ordered by row count descending. The active header sort only reordered rows *inside* each group, so toggling Sort ascending/descending on the grouped column just flipped the arrow icon while the visible group order stayed identical (both directions showed the count-descending order 91, 34, 32, 31…), exactly as reported.

Root cause was a hard-coded `sort((a, b) => b.count - a.count …)` on the group headers in `buildGroupedView` (and a second copy in the export model builder) that never looked at the active sort.

## The fix

Thread the active header sort into `buildGroupedView` via a small `orderGroups` helper:

- Sorting the **group-by column** now orders groups by their value (numeric columns compare numerically), honouring direction.
- Sorting a **summed column** orders groups by their subtotal, honouring direction.
- The **count-descending default** is kept when no sort is active, or when the sort is on a column that has no group-level value (a per-row column that is neither the group key nor a summed aggregate) — ordering groups by such a column is ill-defined, so a stable default is preferable to jumping around.

The CSV/XLSX/PDF export path now reuses the same `orderGroups` helper, so exported grouped sections stay in the on-screen order (previously they would have diverged after sorting). This also removes the duplicated group-ordering logic.

## Tests

- `list-table-utils.test.ts` — group ordering for asc/desc on the group column (the reported bug: asc and desc now differ and are reverses of each other), summed-column ordering, numeric-vs-lexical, the `(none)` bucket, and the count-descending fallback.
- `model.test.ts` — the export model produces grouped sections in the same order as the on-screen table.

All green; full viewer `tsc --noEmit` clean. Scope is `apps/viewer` only (no published-package change, so no changeset).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Grouped list views now respect the current sort order, including sorting by group values and aggregated totals.
  * Exported grouped results now match the active table sort, or use the default grouping order when no sort is applied.

* **Bug Fixes**
  * Fixed grouped rows and exports showing inconsistent group ordering when sorting changed.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->