### PR TITLE
fix(geometry): stop curve-only entities from zeroing the RTC offset (#1526)

### DIFF
--- a/.changeset/rtc-curve-only-alignment-pollution.md
+++ b/.changeset/rtc-curve-only-alignment-pollution.md
@@ -1,0 +1,6 @@
+---
+"@ifc-lite/geometry": patch
+"@ifc-lite/wasm": patch
+---
+
+Fix shredded geometry in georeferenced IFC4.3 infrastructure models (e.g. Quadri/Trimble road exports). RTC-offset detection sampled a bogus `(0,0,0)` world position for origin-placed, curve-only entities such as `IfcAlignmentSegment` (their only representation is an axis curve, so no body vertex could be read). Those spurious origin votes outnumbered the handful of large-coordinate solids and dragged the detected re-basing offset to zero, so vertices at national-grid magnitudes (~166 km) were cast to f32 with ~16 mm quantization and small features (signals, kerbs) rendered mangled. Curve/axis-only elements now abstain from the RTC sample when they have no meshable body representation, letting the real solids anchor the offset; body elements at the origin still cast their "no shift" vote. Fixes #1526.

--- a/rust/geometry/src/router/mod.rs
+++ b/rust/geometry/src/router/mod.rs
@@ -166,6 +166,27 @@ pub struct GeometryRouter {
     skip_small_cuts: bool,
 }
 
+/// Whether an `IfcShapeRepresentation.RepresentationType` names a meshable
+/// body/surface (as opposed to a curve/axis/annotation). Shared by the void
+/// probe (opening extraction) and RTC-offset detection so both agree on what
+/// counts as real geometry.
+pub(super) fn is_body_representation(rep_type: &str) -> bool {
+    matches!(
+        rep_type,
+        "Body"
+            | "SweptSolid"
+            | "Brep"
+            | "CSG"
+            | "Clipping"
+            | "Tessellation"
+            | "MappedRepresentation"
+            | "SolidModel"
+            | "SurfaceModel"
+            | "AdvancedSweptSolid"
+            | "AdvancedBrep"
+    )
+}
+
 impl GeometryRouter {
     /// Create new router with default processors
     pub fn new() -> Self {

--- a/rust/geometry/src/router/rtc_offset.rs
+++ b/rust/geometry/src/router/rtc_offset.rs
@@ -87,9 +87,66 @@ impl GeometryRouter {
                     return Some((world.x, world.y, world.z));
                 }
             }
+            // Placement sits at the origin and we could not cheaply read a body
+            // vertex. If this element has NO meshable body/surface representation
+            // at all — only a curve/axis (e.g. an IfcAlignmentSegment carrying just
+            // its 'Axis'/'Segment' curve) — it carries no reliable world position
+            // and must NOT vote (0,0,0) into the RTC sample set. Infrastructure
+            // files pair a handful of large-coordinate solids with many
+            // origin-placed alignment segments, and those spurious origin votes
+            // would drag the median back to zero and suppress the re-basing the
+            // solids actually need. Report "no evidence" instead.
+            //
+            // A body element we simply could not sample cheaply (e.g. a swept
+            // solid near the origin, which the vertex probe does not walk) still
+            // votes (0,0,0): its geometry genuinely sits at the origin, and that
+            // "no shift" vote is what keeps origin-local building models with a
+            // far georef datum from falling through to the placement-bounds
+            // fallback (which would re-base them off-screen).
+            if !self.element_has_body_representation(entity, decoder) {
+                return None;
+            }
         }
 
         Some((tx, ty, tz))
+    }
+
+    /// True when the element carries at least one meshable body/surface shape
+    /// representation (as opposed to only curve/axis/footprint representations,
+    /// e.g. an IfcAlignmentSegment). Used to decide whether an origin-placed
+    /// element with no cheaply-samplable vertex may still cast a "no shift"
+    /// (0,0,0) vote during RTC detection.
+    fn element_has_body_representation(
+        &self,
+        entity: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+    ) -> bool {
+        let Some(rep_attr) = entity.get(6) else {
+            return false;
+        };
+        if rep_attr.is_null() {
+            return false;
+        }
+        let Ok(Some(rep)) = decoder.resolve_ref(rep_attr) else {
+            return false;
+        };
+        if rep.ifc_type != IfcType::IfcProductDefinitionShape {
+            return false;
+        }
+        let Some(reps_attr) = rep.get(2) else {
+            return false;
+        };
+        let Ok(reps) = decoder.resolve_ref_list(reps_attr) else {
+            return false;
+        };
+        reps.iter().any(|sr| {
+            sr.ifc_type == IfcType::IfcShapeRepresentation
+                && sr
+                    .get(2)
+                    .and_then(|a| a.as_string())
+                    .map(super::is_body_representation)
+                    .unwrap_or(false)
+        })
     }
 
     /// Read the first geometry vertex (f64) from an element's representation.
@@ -343,13 +400,21 @@ impl GeometryRouter {
         decoder: &mut EntityDecoder,
     ) -> Option<(f64, f64, f64)> {
         const MAX_SAMPLES: usize = 50;
+        // Cap on USABLE samples, not raw jobs: `take` follows `filter_map` so
+        // elements that abstain (origin-placed curve/axis-only reps such as
+        // IfcAlignmentSegment, which return None) do not consume the sample
+        // budget. Otherwise a file that emits 50+ alignment segments before its
+        // real large-coordinate solids would fill the window with abstentions,
+        // sample zero positions, and miss the re-basing the solids need.
+        // Matches `detect_rtc_offset_from_first_element`, which likewise counts
+        // pushed samples rather than scanned entities.
         let translations: Vec<(f64, f64, f64)> = jobs
             .iter()
-            .take(MAX_SAMPLES)
             .filter_map(|&(id, start, end, _)| {
                 let entity = decoder.decode_at_with_id(id, start, end).ok()?;
                 self.sample_element_translation(&entity, decoder)
             })
+            .take(MAX_SAMPLES)
             .collect();
 
         if translations.is_empty() {

--- a/rust/geometry/src/router/voids/geom.rs
+++ b/rust/geometry/src/router/voids/geom.rs
@@ -31,24 +31,6 @@ pub(super) fn rotate_and_normalize(
 }
 
 
-/// Whether the representation type is geometry we can process.
-pub(super) fn is_body_representation(rep_type: &str) -> bool {
-    matches!(
-        rep_type,
-        "Body"
-            | "SweptSolid"
-            | "Brep"
-            | "CSG"
-            | "Clipping"
-            | "Tessellation"
-            | "MappedRepresentation"
-            | "SolidModel"
-            | "SurfaceModel"
-            | "AdvancedSweptSolid"
-            | "AdvancedBrep"
-    )
-}
-
 /// Pick a unit-vector along the wall's thinnest AABB axis. Used as a
 /// last-ditch extrusion direction for the issue #635 AABB fallback when
 /// the opening doesn't carry an explicit `IfcDirection`.

--- a/rust/geometry/src/router/voids/probe.rs
+++ b/rust/geometry/src/router/voids/probe.rs
@@ -6,6 +6,7 @@
 
 use super::geom::*;
 use super::{GeometryRouter, RectParam, MAX_EXTRUSION_EXTRACT_DEPTH};
+use crate::router::is_body_representation;
 use crate::{Error, Mesh, Point3, Result, Vector3};
 use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcType};
 use nalgebra::{Matrix3, Matrix4};

--- a/rust/geometry/tests/rtc_jobs_ordering.rs
+++ b/rust/geometry/tests/rtc_jobs_ordering.rs
@@ -1,0 +1,127 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Guards `GeometryRouter::detect_rtc_offset_from_jobs` (issue #1526 follow-up):
+//! the sample budget must count USABLE samples, not raw jobs. Origin-placed
+//! curve/axis-only products (e.g. IfcAlignmentSegment) abstain from RTC
+//! sampling; if `take(MAX_SAMPLES)` ran before the abstention filter, a file
+//! that lists more than 50 such products ahead of its real large-coordinate
+//! solid would sample zero positions and fail to detect the re-basing offset.
+
+use ifc_lite_core::{build_entity_index, has_geometry_by_name, EntityDecoder, EntityScanner, IfcType};
+use ifc_lite_geometry::GeometryRouter;
+
+/// One origin-placed proxy whose only representation is an axis polyline — no
+/// meshable body, so RTC sampling abstains. Ids are offset by `base`.
+fn curve_only_proxy(base: u32, guid: &str) -> String {
+    format!(
+        "#{p0}=IFCCARTESIANPOINT((0.,0.,0.));\n\
+         #{p1}=IFCCARTESIANPOINT((5.,0.,0.));\n\
+         #{poly}=IFCPOLYLINE((#{p0},#{p1}));\n\
+         #{rep}=IFCSHAPEREPRESENTATION(#6,'Axis','Curve3D',(#{poly}));\n\
+         #{pds}=IFCPRODUCTDEFINITIONSHAPE($,$,(#{rep}));\n\
+         #{ax}=IFCAXIS2PLACEMENT3D(#{p0},$,$);\n\
+         #{plc}=IFCLOCALPLACEMENT($,#{ax});\n\
+         #{proxy}=IFCBUILDINGELEMENTPROXY('{guid}',$,'seg',$,$,#{plc},#{pds},$,$);\n",
+        p0 = base,
+        p1 = base + 1,
+        poly = base + 2,
+        rep = base + 3,
+        pds = base + 4,
+        ax = base + 5,
+        plc = base + 6,
+        proxy = base + 7,
+    )
+}
+
+/// Deterministic pseudo-GUID (22 chars) that varies by index — process_geometry
+/// is not involved here, but distinct GlobalIds keep the model well-formed.
+fn guid(i: u32) -> String {
+    let base = b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_$";
+    let mut s = String::from("1zzzzzzzzzzzzzzzzzzzz");
+    s.push(base[(i as usize) % base.len()] as char);
+    s.push(base[((i as usize) / base.len()) % base.len()] as char);
+    s
+}
+
+const SOLID_X: f64 = 200_000.0;
+const SOLID_Y: f64 = 6_000_000.0;
+const SOLID_Z: f64 = 100.0;
+
+/// 55 origin-placed curve-only proxies (> MAX_SAMPLES = 50) FOLLOWED BY a single
+/// large-coordinate tessellated solid.
+fn model() -> String {
+    let mut s = String::from(
+        "ISO-10303-21;\n\
+         HEADER;\n\
+         FILE_DESCRIPTION((''),'2;1');\n\
+         FILE_NAME('','2026-01-01T00:00:00',(''),(''),'t','t','');\n\
+         FILE_SCHEMA(('IFC4X3_ADD2'));\n\
+         ENDSEC;\n\
+         DATA;\n\
+         #1=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);\n\
+         #2=IFCUNITASSIGNMENT((#1));\n\
+         #3=IFCCARTESIANPOINT((0.,0.,0.));\n\
+         #4=IFCAXIS2PLACEMENT3D(#3,$,$);\n\
+         #5=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-05,#4,$);\n\
+         #6=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body','Model',*,*,*,*,#5,$,.MODEL_VIEW.,$);\n\
+         #7=IFCPROJECT('01tEAnIV5BixApwp1YzpwS',$,'t',$,$,$,$,(#5),#2);\n",
+    );
+
+    for i in 0..55u32 {
+        s.push_str(&curve_only_proxy(1000 + i * 10, &guid(i)));
+    }
+
+    // The lone large-coordinate solid, emitted AFTER all curve-only products.
+    s.push_str(&format!(
+        "#900=IFCCARTESIANPOINTLIST3D((({x},{y},{z}),({x1},{y},{z}),({x},{y1},{z}),({x},{y},{z1})));\n\
+         #901=IFCTRIANGULATEDFACESET(#900,$,$,((1,2,3),(1,2,4),(1,3,4),(2,3,4)),$);\n\
+         #902=IFCSHAPEREPRESENTATION(#6,'Body','Tessellation',(#901));\n\
+         #903=IFCPRODUCTDEFINITIONSHAPE($,$,(#902));\n\
+         #904=IFCAXIS2PLACEMENT3D(#3,$,$);\n\
+         #905=IFCLOCALPLACEMENT($,#904);\n\
+         #906=IFCBUILDINGELEMENTPROXY('11tEAnIV5BixApwp1YzpwS',$,'solid',$,$,#905,#903,$,$);\n",
+        x = SOLID_X,
+        y = SOLID_Y,
+        z = SOLID_Z,
+        x1 = SOLID_X + 1.0,
+        y1 = SOLID_Y + 1.0,
+        z1 = SOLID_Z + 1.0,
+    ));
+
+    s.push_str("ENDSEC;\nEND-ISO-10303-21;\n");
+    s
+}
+
+#[test]
+fn from_jobs_scans_past_abstaining_curve_only_entities() {
+    let content = model();
+    let entity_index = build_entity_index(&content);
+    let mut decoder = EntityDecoder::with_index(&content, entity_index);
+    let router = GeometryRouter::with_units(&content, &mut decoder);
+
+    // Collect geometry jobs in file order (curve proxies first, solid last).
+    // detect_rtc_offset_from_jobs ignores the IfcType slot, so a placeholder is
+    // fine; only (id, start, end) drive decoding.
+    let mut jobs: Vec<(u32, usize, usize, IfcType)> = Vec::new();
+    let mut scanner = EntityScanner::new(&content);
+    while let Some((id, type_name, start, end)) = scanner.next_entity() {
+        if has_geometry_by_name(type_name) {
+            jobs.push((id, start, end, IfcType::IfcBuildingElementProxy));
+        }
+    }
+    assert!(jobs.len() > 50, "need >50 jobs to exercise the budget, got {}", jobs.len());
+    // The solid is the LAST job, past the 50-sample window.
+    assert!(jobs.len() >= 56);
+
+    let offset = router
+        .detect_rtc_offset_from_jobs(&jobs, &mut decoder)
+        .expect("solid past the first 50 curve-only jobs must still yield a sample");
+
+    assert!(
+        (offset.0 - SOLID_X).abs() < 10.0 && (offset.1 - SOLID_Y).abs() < 10.0,
+        "RTC must anchor on the trailing solid, got {:?}",
+        offset
+    );
+}

--- a/rust/processing/tests/rtc_curve_only_pollution.rs
+++ b/rust/processing/tests/rtc_curve_only_pollution.rs
@@ -1,0 +1,129 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Regression for issue #1526 (IFC4X3 civil model from Quadri rendered with
+//! shredded geometry): RTC-offset detection must not be poisoned by
+//! origin-placed, curve-only entities (e.g. IfcAlignmentSegment axis curves).
+//!
+//! These infrastructure files bake large world coordinates directly into a
+//! handful of Brep/tessellated solids (identity placement) while carrying many
+//! origin-placed alignment segments whose only representation is an axis curve.
+//! The RTC sampler could not read a body vertex from those curves, so it used
+//! to fall back to the placement translation `(0,0,0)` and let those spurious
+//! origin votes dominate the median — dragging the detected offset to zero and
+//! leaving the real solids to render as f32 jitter 200 km from the origin.
+//!
+//! Uses INLINE minimal IFC so the test runs in CI without external fixtures.
+
+use ifc_lite_processing::process_geometry;
+
+/// Large world coordinates the solid is authored at (metres). Well past the
+/// 10 km RTC threshold, mirroring the national-grid magnitudes in #1526.
+const SOLID_X: f64 = 200_000.0;
+const SOLID_Y: f64 = 6_000_000.0;
+const SOLID_Z: f64 = 100.0;
+
+/// One origin-placed proxy whose ONLY representation is an axis polyline —
+/// the RTC vertex probe cannot read a solid vertex from it. Numbered from a
+/// caller-supplied base so several can coexist without id collisions.
+fn curve_only_proxy(base: u32, guid: &str) -> String {
+    let p0 = base;
+    let p1 = base + 1;
+    let poly = base + 2;
+    let rep = base + 3;
+    let pds = base + 4;
+    let pt = base + 5;
+    let ax = base + 6;
+    let plc = base + 7;
+    let proxy = base + 8;
+    format!(
+        "#{p0}=IFCCARTESIANPOINT((0.,0.,0.));\n\
+         #{p1}=IFCCARTESIANPOINT((5.,0.,0.));\n\
+         #{poly}=IFCPOLYLINE((#{p0},#{p1}));\n\
+         #{rep}=IFCSHAPEREPRESENTATION(#6,'Axis','Curve3D',(#{poly}));\n\
+         #{pds}=IFCPRODUCTDEFINITIONSHAPE($,$,(#{rep}));\n\
+         #{pt}=IFCCARTESIANPOINT((0.,0.,0.));\n\
+         #{ax}=IFCAXIS2PLACEMENT3D(#{pt},$,$);\n\
+         #{plc}=IFCLOCALPLACEMENT($,#{ax});\n\
+         #{proxy}=IFCBUILDINGELEMENTPROXY('{guid}',$,'seg',$,$,#{plc},#{pds},$,$);\n"
+    )
+}
+
+fn model() -> String {
+    // Header + shared context/units. One tessellated solid at large world
+    // coordinates (identity placement), then four origin-placed curve-only
+    // proxies so the origin votes are a strict majority of the samples.
+    let mut s = String::from(
+        "ISO-10303-21;\n\
+         HEADER;\n\
+         FILE_DESCRIPTION((''),'2;1');\n\
+         FILE_NAME('','2026-01-01T00:00:00',(''),(''),'t','t','');\n\
+         FILE_SCHEMA(('IFC4X3_ADD2'));\n\
+         ENDSEC;\n\
+         DATA;\n\
+         #1=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);\n\
+         #2=IFCUNITASSIGNMENT((#1));\n\
+         #3=IFCCARTESIANPOINT((0.,0.,0.));\n\
+         #4=IFCAXIS2PLACEMENT3D(#3,$,$);\n\
+         #5=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-05,#4,$);\n\
+         #6=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body','Model',*,*,*,*,#5,$,.MODEL_VIEW.,$);\n\
+         #7=IFCPROJECT('01tEAnIV5BixApwp1YzpwS',$,'t',$,$,$,$,(#5),#2);\n",
+    );
+
+    // Tessellated solid (a small tetra-ish faceset) at the large anchor.
+    s.push_str(&format!(
+        "#20=IFCCARTESIANPOINTLIST3D((({x},{y},{z}),({x1},{y},{z}),({x},{y1},{z}),({x},{y},{z1})));\n\
+         #21=IFCTRIANGULATEDFACESET(#20,$,$,((1,2,3),(1,2,4),(1,3,4),(2,3,4)),$);\n\
+         #22=IFCSHAPEREPRESENTATION(#6,'Body','Tessellation',(#21));\n\
+         #23=IFCPRODUCTDEFINITIONSHAPE($,$,(#22));\n\
+         #24=IFCCARTESIANPOINT((0.,0.,0.));\n\
+         #25=IFCAXIS2PLACEMENT3D(#24,$,$);\n\
+         #26=IFCLOCALPLACEMENT($,#25);\n\
+         #27=IFCBUILDINGELEMENTPROXY('11tEAnIV5BixApwp1YzpwS',$,'solid',$,$,#26,#23,$,$);\n",
+        x = SOLID_X,
+        y = SOLID_Y,
+        z = SOLID_Z,
+        x1 = SOLID_X + 1.0,
+        y1 = SOLID_Y + 1.0,
+        z1 = SOLID_Z + 1.0,
+    ));
+
+    for (i, guid) in [
+        "21tEAnIV5BixApwp1YzpwS",
+        "31tEAnIV5BixApwp1YzpwS",
+        "41tEAnIV5BixApwp1YzpwS",
+        "51tEAnIV5BixApwp1YzpwS",
+    ]
+    .iter()
+    .enumerate()
+    {
+        s.push_str(&curve_only_proxy(100 + (i as u32) * 20, guid));
+    }
+
+    s.push_str("ENDSEC;\nEND-ISO-10303-21;\n");
+    s
+}
+
+#[test]
+fn rtc_offset_survives_curve_only_origin_entities() {
+    let result = process_geometry(&model());
+    let shift = result.metadata.coordinate_info.origin_shift;
+
+    // The offset must anchor on the large-coordinate solid, NOT be dragged to
+    // (0,0,0) by the four origin-placed axis-curve proxies.
+    assert!(
+        result.metadata.coordinate_info.is_geo_referenced,
+        "model with 200 km solid must be flagged geo-referenced"
+    );
+    assert!(
+        (shift[0] - SOLID_X).abs() < 10.0,
+        "RTC X should anchor near the solid ({SOLID_X}), got {}",
+        shift[0]
+    );
+    assert!(
+        (shift[1] - SOLID_Y).abs() < 10.0,
+        "RTC Y should anchor near the solid ({SOLID_Y}), got {}",
+        shift[1]
+    );
+}


### PR DESCRIPTION
## Problem

Issue #1526: a georeferenced IFC4.3 civil model (Quadri/Trimble road export) renders with mangled geometry — signals, kerbs and pavements come out shredded, while other viewers show it correctly.

## Root cause

The model bakes national-grid world coordinates (~73 630 E, ~166 245 N) directly into brep/tessellated geometry with identity placements. That needs an RTC (relative-to-center) re-basing before vertices are cast to `f32`, or precision collapses.

RTC-offset detection samples each element's world position and takes the **median**. The file pairs ~8 large-coordinate solids with **16 `IfcAlignmentSegment`** entities. Alignment segments carry only an `'Axis'/'Segment'` curve representation, so the vertex probe returns nothing and the sampler fell through to the placement translation `(0,0,0)` — casting a spurious "I'm at the origin" vote. Those votes outnumbered the solids, so the median landed at `(0,0,0)` and **no re-basing happened**.

Result: vertices at ~166 km cast to `f32` land on a **15.6 mm** grid, shredding sub-metre features.

| | max stored `\|vertex\|` | f32 ULP (precision floor) |
|---|---|---|
| before | 166 309 m | **15.6 mm** |
| after | 74 m (RTC-relative) | **0.0076 mm** |

## Fix

In `sample_element_translation`, an origin-placed element whose vertex can't be probed now abstains from the RTC sample **iff it has no meshable body/surface representation** (curve/axis-only, like an alignment segment). Body elements sitting at the origin still cast their `(0,0,0)` "no shift" vote — that vote is what keeps origin-local building models with a far georef datum from falling through to the placement-bounds fallback (which would re-base them off-screen), so the existing streaming-prepass contract is preserved.

The change is in the sampler shared by the native processing path and the wasm streaming prepass, so server and browser make the identical needs-shift decision.

## Verification

- New inline-IFC regression test `rtc_curve_only_pollution` (large-coord solid + 4 origin-placed axis-curve proxies); fails on `main`, passes with the fix.
- Reproduced on the reported file: `origin_shift` goes `(0,0,0)` → `(73630, 166245, 451)`, `is_geo_referenced` false → true, and the largest stored f32 vertex magnitude drops from 166 km to 74 m.
- `ifc-lite-geometry` (416) + `ifc-lite-processing` suites green; clippy clean on the touched file. (The 3 `wall_opening_cut_regression` failures are pre-existing on `main` — they need external fixtures not staged in the repo.)

Fixes #1526.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved georeferenced IFC offset detection so curve-only, origin-placed elements no longer pull the scene origin toward `(0,0,0)`.
  - Large-coordinate solid geometry now correctly determines the re-basing offset, helping preserve small details and reduce visual artifacts.
- **Tests**
  - Added a regression test covering mixed solid and curve-only IFC content to verify the offset stays anchored to the correct geometry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->