### PR TITLE
fix(viewer): Site hides terrain; annotation lines selectable + hideable (#1480)

### DIFF
--- a/.changeset/annotation-terrain-visibility.md
+++ b/.changeset/annotation-terrain-visibility.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/renderer": patch
+---
+
+Add an optional `ownerId` to `DrawingLine2D` so the IfcAnnotation / IfcGridAxis symbolic overlay can carry the express id of the entity that authored each segment. The section-cut and drawing-2d cutters leave it undefined; it lets the viewer drop an annotation's curves when the owning entity is hidden, without a mesh. Supports the terrain/annotation visibility fixes in #1480.

--- a/apps/viewer/src/components/viewer/GLBExportDialog.tsx
+++ b/apps/viewer/src/components/viewer/GLBExportDialog.tsx
@@ -40,6 +40,7 @@ import {
   AlertTitle,
 } from '@/components/ui/alert';
 import { useViewerStore } from '@/store';
+import { buildHiddenIfcTypes } from '@/store/typeVisibilityFilter';
 import { posthog } from '@/lib/analytics';
 import { toast } from '@/components/ui/toast';
 import { GeometryProcessor, isNoRenderGeometryError, type MeshData } from '@ifc-lite/geometry';
@@ -48,25 +49,6 @@ import { downloadBlob, sanitizeFilename } from '@/lib/export/download';
 import { withInstancedMeshes } from '../../utils/instancedExport.js';
 
 type ColorSource = 'rendering' | 'shading';
-
-/**
- * Translate the viewer's `typeVisibility` toggles into the set of IFC class
- * names the GLB exporter should drop on a visible-only export. Mirrors the
- * gating in `basketVisibleSet.ts` and `ViewportContainer.tsx` so the export
- * matches what the user sees in the viewport.
- */
-function buildHiddenIfcTypes(
-  typeVisibility: { spaces: boolean; spatialZones: boolean; openings: boolean; virtualElements: boolean; site: boolean; ifcAnnotations: boolean },
-): Set<string> {
-  const out = new Set<string>();
-  if (!typeVisibility.spaces) out.add('IfcSpace');
-  if (!typeVisibility.spatialZones) out.add('IfcSpatialZone');
-  if (!typeVisibility.openings) out.add('IfcOpeningElement');
-  if (!typeVisibility.virtualElements) out.add('IfcVirtualElement');
-  if (!typeVisibility.site) out.add('IfcSite');
-  if (!typeVisibility.ifcAnnotations) out.add('IfcAnnotation');
-  return out;
-}
 
 interface GLBExportDialogProps {
   trigger?: React.ReactNode;

--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -277,14 +277,21 @@ export function ViewportContainer() {
         if (!assets || assets.length === 0) continue;
         const modelIndex = modelIdToIndex.get(modelId) ?? 0;
         for (const asset of assets) {
+          // Scan-based terrain is stamped `IfcGeographicElement`; honour the
+          // same type-visibility gate as the mesh path so the Site toggle hides
+          // it too (issue #1480).
+          if (!isTypeVisible(asset.ifcType, typeVisibility)) continue;
           collected.push(asset.modelIndex === modelIndex ? asset : { ...asset, modelIndex });
         }
       }
     } else if (geometryResult?.pointClouds) {
-      collected.push(...geometryResult.pointClouds);
+      for (const asset of geometryResult.pointClouds) {
+        if (!isTypeVisible(asset.ifcType, typeVisibility)) continue;
+        collected.push(asset);
+      }
     }
     return collected;
-  }, [storeModels, geometryResult, modelIdToIndex]);
+  }, [storeModels, geometryResult, modelIdToIndex, typeVisibility]);
 
   // Extract georeferencing info merged with any live mutations (for Cesium overlay).
   // Reacts to: model load, Cesium toggle, and every georef field edit.

--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -28,6 +28,7 @@ import { useSolarSweep } from '@/hooks/useSolarSweep';
 import { getViewerStoreApi, useViewerStore } from '@/store';
 import { toGlobalIdFromModels } from '@/store/globalId';
 import { collectIfcBuildingStoreyElementsWithIfcSpace } from '@/store/basketVisibleSet';
+import { isTypeVisible } from '@/store/typeVisibilityFilter';
 import type { AggregationRelationships } from '@/utils/aggregation';
 import { useIfc } from '@/hooks/useIfc';
 import { useWebGPU } from '@/hooks/useWebGPU';
@@ -795,19 +796,12 @@ export function ViewportContainer() {
         continue;
       }
 
-      if (needsFilter) {
-        if (ifcType === 'IfcSpace' && !typeVisibility.spaces) continue;
-        if (ifcType === 'IfcSpatialZone' && !typeVisibility.spatialZones) continue;
-        if (ifcType === 'IfcOpeningElement' && !typeVisibility.openings) continue;
-        if (ifcType === 'IfcVirtualElement' && !typeVisibility.virtualElements) continue;
-        if (ifcType === 'IfcSite' && !typeVisibility.site) continue;
-        // IfcAnnotation can carry real 3D solid geometry (e.g. Bonsai
-        // plan-view "DRAWING" boxes) on top of the 2D symbolic curve overlay.
-        // The `ifcAnnotations` toggle drives the curve overlay (Viewport.tsx);
-        // honour it here too so the toggle also hides those 3D meshes instead
-        // of leaving them rendered as stray cubes (issue #1354).
-        if (ifcType === 'IfcAnnotation' && !typeVisibility.ifcAnnotations) continue;
-      }
+      // Type-visibility gate — shared mapping in `typeVisibilityFilter.ts`
+      // keeps the viewport, Cesium, basket and GLB export in lockstep. The
+      // `site` toggle also hides `IfcGeographicElement` terrain (issue #1480);
+      // `ifcAnnotations` also hides annotation 3D solid geometry / "Model Text"
+      // breps on top of the 2D curve overlay (issues #1354, #1480).
+      if (needsFilter && !isTypeVisible(ifcType, typeVisibility)) continue;
 
       // Mesh alpha flows through unchanged. The previous code re-multiplied
       // IfcSpace / IfcOpeningElement alpha down to <= 0.3 here, which stomped

--- a/apps/viewer/src/components/viewer/hierarchy/useHierarchyTree.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/useHierarchyTree.ts
@@ -71,6 +71,41 @@ function buildGeometricIdSet(
   return ids;
 }
 
+/**
+ * Global IDs of `IfcAnnotation` entities. Their 2D curves (plot boundaries,
+ * "Model Lines", leaders) render through the symbolic overlay, not the mesh
+ * pipeline, so they never enter `buildGeometricIdSet` and were absent from the
+ * "By Class" tree — the user could see them in 3D but not select or hide them
+ * (issue #1480). Folding them into the tree's inclusion set makes each an
+ * ordinary, hideable row; the overlay honours that hide (see
+ * `useSymbolicAnnotations`). Text annotations that carry a real brep mesh are
+ * already in the geometric set, so the union is idempotent for them.
+ */
+function collectAnnotationEntityIds(
+  models: Map<string, FederatedModel>,
+  legacyStore: IfcDataStore | null | undefined,
+): Set<number> {
+  const ids = new Set<number>();
+  const addFrom = (store: IfcDataStore | null | undefined, toGlobal: (localId: number) => number) => {
+    const getByType = (store as { getEntitiesByType?: (t: string) => Array<{ expressId: number }> } | null | undefined)?.getEntitiesByType;
+    if (typeof getByType !== 'function') return;
+    for (const ent of getByType.call(store, 'IfcAnnotation')) {
+      ids.add(toGlobal(ent.expressId));
+    }
+  };
+  if (models.size > 0) {
+    const state = useViewerStore.getState();
+    for (const [modelId, model] of models) {
+      addFrom(model.ifcDataStore, (localId) =>
+        modelId === 'legacy' || !models.has(modelId) ? localId : state.toGlobalId(modelId, localId),
+      );
+    }
+  } else {
+    addFrom(legacyStore, (localId) => localId);
+  }
+  return ids;
+}
+
 export function useHierarchyTree({ models, ifcDataStore, isMultiModel, geometryResult }: UseHierarchyTreeParams) {
   const [searchQuery, setSearchQuery] = useState('');
   const [expandedNodes, setExpandedNodes] = useState<Set<string>>(new Set());
@@ -197,6 +232,22 @@ export function useHierarchyTree({ models, ifcDataStore, isMultiModel, geometryR
     [models, hasGeometrySource ? meshCount : 0]
   );
 
+  // `IfcAnnotation` entities are a fixed set per loaded model (independent of
+  // streaming mesh count), so this is keyed on model identity only. Unioned
+  // into the "By Class" inclusion set so curve-only annotations appear as
+  // selectable / hideable rows (issue #1480).
+  const annotationEntityIds = useMemo(
+    () => hasGeometrySource ? collectAnnotationEntityIds(models, ifcDataStore) : new Set<number>(),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- static per model; toGlobalId reads live store
+    [models, ifcDataStore, hasGeometrySource]
+  );
+  const classTreeIds = useMemo(() => {
+    if (annotationEntityIds.size === 0) return geometricIds;
+    const merged = new Set(geometricIds);
+    for (const id of annotationEntityIds) merged.add(id);
+    return merged;
+  }, [geometricIds, annotationEntityIds]);
+
   const toGlobalIdsForModel = useCallback((modelId: string, expressIds: number[]): number[] => {
     if (modelId === 'legacy') return expressIds;
     const state = useViewerStore.getState();
@@ -240,7 +291,7 @@ export function useHierarchyTree({ models, ifcDataStore, isMultiModel, geometryR
   const treeData = useMemo(
     (): TreeNode[] => {
       if (groupingMode === 'type') {
-        return buildTypeTree(models, ifcDataStore, expandedNodes, isMultiModel, geometricIds, authoredProducts);
+        return buildTypeTree(models, ifcDataStore, expandedNodes, isMultiModel, classTreeIds, authoredProducts);
       }
       if (groupingMode === 'ifc-type') {
         return buildIfcTypeTree(models, ifcDataStore, expandedNodes, isMultiModel, geometricIds);
@@ -250,7 +301,7 @@ export function useHierarchyTree({ models, ifcDataStore, isMultiModel, geometryR
       }
       return buildTreeData(models, ifcDataStore, expandedNodes, isMultiModel, unifiedStoreys, sortMode);
     },
-    [models, ifcDataStore, expandedNodes, isMultiModel, unifiedStoreys, sortMode, groupingMode, geometricIds, authoredProducts]
+    [models, ifcDataStore, expandedNodes, isMultiModel, unifiedStoreys, sortMode, groupingMode, geometricIds, classTreeIds, authoredProducts]
   );
 
   // Filter nodes based on search

--- a/apps/viewer/src/components/viewer/hierarchy/useHierarchyTree.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/useHierarchyTree.ts
@@ -97,8 +97,11 @@ function collectAnnotationEntityIds(
   if (models.size > 0) {
     const state = useViewerStore.getState();
     for (const [modelId, model] of models) {
+      // modelId comes straight from `models`, so it is always resolvable —
+      // only the legacy sentinel needs the raw local id (matches the id the
+      // tree builder assigns via `resolveTreeGlobalId`).
       addFrom(model.ifcDataStore, (localId) =>
-        modelId === 'legacy' || !models.has(modelId) ? localId : state.toGlobalId(modelId, localId),
+        modelId === 'legacy' ? localId : state.toGlobalId(modelId, localId),
       );
     }
   } else {

--- a/apps/viewer/src/components/viewer/hierarchy/useHierarchyTree.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/useHierarchyTree.ts
@@ -87,9 +87,10 @@ function collectAnnotationEntityIds(
 ): Set<number> {
   const ids = new Set<number>();
   const addFrom = (store: IfcDataStore | null | undefined, toGlobal: (localId: number) => number) => {
-    const getByType = (store as { getEntitiesByType?: (t: string) => Array<{ expressId: number }> } | null | undefined)?.getEntitiesByType;
-    if (typeof getByType !== 'function') return;
-    for (const ent of getByType.call(store, 'IfcAnnotation')) {
+    // `getEntitiesByType` is a lazy accessor; guard for the rare
+    // cache-restored store whose accessors have not been reattached yet.
+    if (typeof store?.getEntitiesByType !== 'function') return;
+    for (const ent of store.getEntitiesByType('IfcAnnotation')) {
       ids.add(toGlobal(ent.expressId));
     }
   };

--- a/apps/viewer/src/hooks/useSymbolicAnnotations.test.ts
+++ b/apps/viewer/src/hooks/useSymbolicAnnotations.test.ts
@@ -121,4 +121,46 @@ describe('liftTo3DLineList', () => {
     liftTo3DLineList([], 1, out);
     assert.equal(out.length, 0);
   });
+
+  it('drops segments whose owner is hidden (issue #1480)', () => {
+    const lines: DrawingLine2D[] = [
+      { line: { start: { x: 1, y: 2 }, end: { x: 3, y: 4 } }, category: 'annotation', ownerId: 100 },
+      { line: { start: { x: 5, y: 6 }, end: { x: 7, y: 8 } }, category: 'annotation', ownerId: 200 },
+    ];
+    const out: number[] = [];
+    liftTo3DLineList(lines, 0, out, (id) => id === 100);
+    // Only owner 200's segment survives.
+    assert.deepEqual(out, [5, 0, 6, 7, 0, 8]);
+  });
+
+  it('keeps every segment when the predicate is absent', () => {
+    const lines: DrawingLine2D[] = [
+      { line: { start: { x: 1, y: 2 }, end: { x: 3, y: 4 } }, category: 'annotation', ownerId: 100 },
+    ];
+    const out: number[] = [];
+    liftTo3DLineList(lines, 0, out);
+    assert.equal(out.length, 6);
+  });
+});
+
+describe('owner tagging', () => {
+  it('polylineToSegments stamps every segment (incl. the closing one) with ownerId', () => {
+    const points = new Float32Array([0, 0, 1, 0, 1, 1]);
+    const out: DrawingLine2D[] = [];
+    polylineToSegments(points, 3, true, out, 4242);
+    assert.equal(out.length, 3);
+    assert.ok(out.every((s) => s.ownerId === 4242));
+  });
+
+  it('circleToSegments stamps every segment with ownerId', () => {
+    const out: DrawingLine2D[] = [];
+    circleToSegments(0, 0, 1, 0, Math.PI / 2, false, out, 7);
+    assert.ok(out.every((s) => s.ownerId === 7));
+  });
+
+  it('defaults ownerId to 0 when not supplied (back-compat)', () => {
+    const out: DrawingLine2D[] = [];
+    polylineToSegments(new Float32Array([0, 0, 1, 1]), 2, false, out);
+    assert.equal(out[0].ownerId, 0);
+  });
 });

--- a/apps/viewer/src/hooks/useSymbolicAnnotations.ts
+++ b/apps/viewer/src/hooks/useSymbolicAnnotations.ts
@@ -50,6 +50,8 @@ export interface AnnotationText2D {
   height: number;
   content: string;
   alignment: string;
+  /** Express ID of the owning IfcAnnotation / IfcGridAxis entity (per-entity hide). */
+  ownerId: number;
   /**
    * For multi-line text literals (e.g. CJK descriptions with `\X\0A`
    * newlines), one IfcTextLiteralWithExtent expands into one AnnotationText2D
@@ -84,6 +86,8 @@ export interface AnnotationFill2D {
   points: Float32Array;
   holesOffsets: Uint32Array;
   color: [number, number, number, number];
+  /** Express ID of the owning IfcAnnotation / IfcGridAxis entity (per-entity hide). */
+  ownerId: number;
   hatching?: {
     spacing: number;
     angle: number;
@@ -131,6 +135,7 @@ export function polylineToSegments(
   pointCount: number,
   isClosed: boolean,
   out: DrawingLine2D[],
+  ownerId = 0,
 ): void {
   for (let j = 0; j < pointCount - 1; j++) {
     out.push({
@@ -139,6 +144,7 @@ export function polylineToSegments(
         end:   { x: points[(j + 1) * 2], y: points[(j + 1) * 2 + 1] },
       },
       category: 'annotation',
+      ownerId,
     });
   }
   if (isClosed && pointCount > 2) {
@@ -148,6 +154,7 @@ export function polylineToSegments(
         end:   { x: points[0], y: points[1] },
       },
       category: 'annotation',
+      ownerId,
     });
   }
 }
@@ -164,6 +171,7 @@ export function circleToSegments(
   endAngle: number,
   isFullCircle: boolean,
   out: DrawingLine2D[],
+  ownerId = 0,
 ): void {
   const numSegments = isFullCircle ? CIRCLE_SEGMENTS_FULL : CIRCLE_SEGMENTS_ARC;
   for (let j = 0; j < numSegments; j++) {
@@ -177,6 +185,7 @@ export function circleToSegments(
         end:   { x: centerX + radius * Math.cos(a2), y: centerY + radius * Math.sin(a2) },
       },
       category: 'annotation',
+      ownerId,
     });
   }
 }
@@ -336,7 +345,7 @@ async function parseAnnotations(
         const looseTarget = poly.ifcType === 'IfcGridAxis' ? result.gridLoose : result.loose;
         const out = bucket ? bucket.lines : looseTarget;
         // poly.points is consumed synchronously here (not stored), so no copy needed.
-        polylineToSegments(poly.points, poly.pointCount, poly.isClosed, out);
+        polylineToSegments(poly.points, poly.pointCount, poly.isClosed, out, poly.expressId);
       } finally {
         poly.free();
       }
@@ -358,6 +367,7 @@ async function parseAnnotations(
           circle.endAngle,
           circle.isFullCircle,
           out,
+          circle.expressId,
         );
       } finally {
         circle.free();
@@ -422,6 +432,7 @@ async function parseAnnotations(
           billboard: true,
           color: textColor,
           targetPx,
+          ownerId: text.expressId,
         };
         (bucket ? bucket.texts : looseTextTarget).push(t2d);
       }
@@ -446,6 +457,7 @@ async function parseAnnotations(
           points,
           holesOffsets,
           color: [fill.fillR, fill.fillG, fill.fillB, fill.fillA],
+          ownerId: fill.expressId,
           hatching: fill.hasHatching
             ? {
                 spacing: fill.hatchSpacing,
@@ -485,8 +497,10 @@ export function liftTo3DLineList(
   lines: DrawingLine2D[],
   y: number,
   out: number[],
+  isHidden?: (ownerId: number) => boolean,
 ): void {
   for (const line of lines) {
+    if (isHidden && line.ownerId !== undefined && isHidden(line.ownerId)) continue;
     out.push(line.line.start.x, y, line.line.start.y);
     out.push(line.line.end.x,   y, line.line.end.y);
   }
@@ -549,29 +563,40 @@ function ensureParseFor(stores: IfcDataStore[]): void {
   }
 }
 
+/** One active model's data store plus the identity needed to map a parsed
+ *  primitive's LOCAL express id to the federated global id the visibility
+ *  sets are keyed by. `idOffset` is 0 for the legacy single-model path. */
+interface ActiveStore {
+  store: IfcDataStore;
+  modelId: string;
+  idOffset: number;
+}
+
 /** Read the active store set from the viewer store. Federation-aware. */
-function useActiveStores(): IfcDataStore[] {
+function useActiveStores(): ActiveStore[] {
   const { models, ifcDataStore } = useViewerStore(
     useShallow((s) => ({ models: s.models, ifcDataStore: s.ifcDataStore })),
   );
   return useMemo(() => {
-    const out: IfcDataStore[] = [];
+    const out: ActiveStore[] = [];
     if (models.size > 0) {
-      for (const [, m] of models) if (m.ifcDataStore) out.push(m.ifcDataStore);
+      for (const [modelId, m] of models) {
+        if (m.ifcDataStore) out.push({ store: m.ifcDataStore, modelId, idOffset: m.idOffset ?? 0 });
+      }
     } else if (ifcDataStore) {
-      out.push(ifcDataStore);
+      out.push({ store: ifcDataStore, modelId: 'legacy', idOffset: 0 });
     }
     return out;
   }, [models, ifcDataStore]);
 }
 
 /** Trigger parse for the active stores when `enabled`, tick on completion. */
-function useAnnotationParseTrigger(enabled: boolean, stores: IfcDataStore[]): number {
+function useAnnotationParseTrigger(enabled: boolean, stores: ActiveStore[]): number {
   const [version, setVersion] = useState(0);
 
   useEffect(() => {
     if (!enabled) return undefined;
-    ensureParseFor(stores);
+    ensureParseFor(stores.map((s) => s.store));
     const listener: CacheListener = () => setVersion((v) => v + 1);
     CACHE_LISTENERS.add(listener);
     return () => {
@@ -580,6 +605,50 @@ function useAnnotationParseTrigger(enabled: boolean, stores: IfcDataStore[]): nu
   }, [enabled, stores]);
 
   return version;
+}
+
+/**
+ * The per-entity hidden sets that gate the annotation overlay. An annotation's
+ * curves/text/fills are dropped when the owning entity has been hidden through
+ * the hierarchy panel, a lens, or a federated per-model hide — mirroring how
+ * hiding a meshed element (e.g. the "Model Text" brep) removes it. Isolation
+ * filters (storey solo, class filter) are intentionally NOT applied: annotation
+ * buckets lift to every storey by design (see
+ * `feedback_3d_annotation_overlay_no_section_filter`), and `byStorey` omits
+ * annotations, so honouring storey isolation here would wrongly blank them.
+ */
+interface HiddenOwnerSets {
+  global: ReadonlySet<number>;
+  lens: ReadonlySet<number>;
+  byModel: ReadonlyMap<string, Set<number>>;
+}
+
+const EMPTY_NUM_SET: ReadonlySet<number> = new Set<number>();
+
+function useHiddenOwnerSets(): HiddenOwnerSets {
+  return useViewerStore(
+    useShallow((s) => ({
+      global: s.hiddenEntities,
+      lens: s.lensHiddenIds,
+      byModel: s.hiddenEntitiesByModel,
+    })),
+  );
+}
+
+/** Build a per-store predicate: is this annotation owner (LOCAL express id)
+ *  currently hidden? Cheap fast-path when nothing is hidden. */
+function makeHiddenOwnerPredicate(
+  entry: ActiveStore,
+  sets: HiddenOwnerSets,
+): ((ownerId: number) => boolean) | undefined {
+  const perModel = sets.byModel.get(entry.modelId) ?? EMPTY_NUM_SET;
+  if (sets.global.size === 0 && sets.lens.size === 0 && perModel.size === 0) return undefined;
+  const offset = entry.idOffset;
+  return (ownerId: number): boolean => {
+    if (perModel.has(ownerId)) return true;
+    const globalId = ownerId + offset;
+    return sets.global.has(globalId) || sets.lens.has(globalId);
+  };
 }
 
 /** Resolve the world-space Y for a storey bucket.
@@ -628,6 +697,7 @@ export function useSymbolicAnnotations(params: {
   const { enabled, gridEnabled, gridSectionClip, fallbackY = 0 } = params;
   const effectiveGridEnabled = gridEnabled ?? enabled;
   const stores = useActiveStores();
+  const hiddenSets = useHiddenOwnerSets();
   // Trigger parse if EITHER subset is enabled — the parse pass is shared.
   const version = useAnnotationParseTrigger(enabled || effectiveGridEnabled, stores);
   const clipEnabled = !!gridSectionClip && gridSectionClip.enabled && gridSectionClip.axis === 'down';
@@ -640,8 +710,8 @@ export function useSymbolicAnnotations(params: {
 
     const verts: number[] = [];
     let storeIdx = 0;
-    for (const store of stores) {
-      const key = sourceKey(store);
+    for (const entry of stores) {
+      const key = sourceKey(entry.store);
       if (!key) { storeIdx++; continue; }
       const cached = PARSE_CACHE.get(key);
       if (!cached) {
@@ -649,6 +719,9 @@ export function useSymbolicAnnotations(params: {
         storeIdx++;
         continue;
       }
+      // Per-entity hide: an annotation/grid owner hidden via the hierarchy,
+      // a lens, or a federated per-model hide drops its overlay primitives.
+      const isHidden = makeHiddenOwnerPredicate(entry, hiddenSets);
       if (debugEnabled()) {
         console.log(
           `[annotations] store ${storeIdx}: annotation buckets=${cached.byStorey.size}+${cached.loose.length}loose, grid buckets=${cached.gridByStorey.size}+${cached.gridLoose.length}loose (annot=${enabled}, grid=${effectiveGridEnabled}, clip=${clipEnabled})`,
@@ -657,9 +730,9 @@ export function useSymbolicAnnotations(params: {
 
       if (enabled) {
         for (const bucket of cached.byStorey.values()) {
-          liftTo3DLineList(bucket.lines, resolveBucketY(bucket.storeyElevation, fallbackY), verts);
+          liftTo3DLineList(bucket.lines, resolveBucketY(bucket.storeyElevation, fallbackY), verts, isHidden);
         }
-        liftTo3DLineList(cached.loose, fallbackY, verts);
+        liftTo3DLineList(cached.loose, fallbackY, verts, isHidden);
       }
 
       if (effectiveGridEnabled) {
@@ -674,16 +747,16 @@ export function useSymbolicAnnotations(params: {
           for (const bucket of cached.gridByStorey.values()) {
             const y = resolveBucketY(bucket.storeyElevation, fallbackY);
             if (y < lo || y > hi) continue;
-            liftTo3DLineList(bucket.lines, y, verts);
+            liftTo3DLineList(bucket.lines, y, verts, isHidden);
           }
           if (fallbackY >= lo && fallbackY <= hi) {
-            liftTo3DLineList(cached.gridLoose, fallbackY, verts);
+            liftTo3DLineList(cached.gridLoose, fallbackY, verts, isHidden);
           }
         } else {
           for (const bucket of cached.gridByStorey.values()) {
-            liftTo3DLineList(bucket.lines, resolveBucketY(bucket.storeyElevation, fallbackY), verts);
+            liftTo3DLineList(bucket.lines, resolveBucketY(bucket.storeyElevation, fallbackY), verts, isHidden);
           }
-          liftTo3DLineList(cached.gridLoose, fallbackY, verts);
+          liftTo3DLineList(cached.gridLoose, fallbackY, verts, isHidden);
         }
       }
       storeIdx++;
@@ -692,7 +765,7 @@ export function useSymbolicAnnotations(params: {
     if (debugEnabled()) console.log(`[annotations] total 3D line vertices: ${verts.length / 3} from ${stores.length} stores`);
     if (verts.length === 0) return EMPTY_F32;
     return new Float32Array(verts);
-  }, [enabled, effectiveGridEnabled, clipEnabled, clipPos, clipDepth, stores, version, fallbackY]);
+  }, [enabled, effectiveGridEnabled, clipEnabled, clipPos, clipDepth, stores, hiddenSets, version, fallbackY]);
 }
 
 /**
@@ -848,8 +921,8 @@ export function useSymbolicAnnotationsForDrawing(params: {
         }
       : (f: AnnotationFill2D) => fills.push(f);
 
-    for (const store of stores) {
-      const key = sourceKey(store);
+    for (const entry of stores) {
+      const key = sourceKey(entry.store);
       if (!key) continue;
       const cached = PARSE_CACHE.get(key);
       if (!cached) continue;
@@ -908,6 +981,7 @@ export function useSymbolicAnnotationsRichData(params: {
   const { enabled, gridEnabled, gridSectionClip, fallbackY = 0 } = params;
   const effectiveGridEnabled = gridEnabled ?? enabled;
   const stores = useActiveStores();
+  const hiddenSets = useHiddenOwnerSets();
   const version = useAnnotationParseTrigger(enabled || effectiveGridEnabled, stores);
   const clipEnabled = !!gridSectionClip && gridSectionClip.enabled && gridSectionClip.axis === 'down';
   const clipPos = clipEnabled ? gridSectionClip!.posWorld : 0;
@@ -920,13 +994,17 @@ export function useSymbolicAnnotationsRichData(params: {
     const texts: AnnotationText3D[] = [];
     const fills: AnnotationFill3D[] = [];
 
-    for (const store of stores) {
-      const key = sourceKey(store);
+    for (const entry of stores) {
+      const key = sourceKey(entry.store);
       if (!key) continue;
       const cached = PARSE_CACHE.get(key);
       if (!cached) continue;
 
+      // Per-entity hide: drop text/fills whose owning annotation is hidden.
+      const isHidden = makeHiddenOwnerPredicate(entry, hiddenSets);
+
       const pushText = (t: AnnotationText2D, y: number) => {
+        if (isHidden && isHidden(t.ownerId)) return;
         // lineYOffset stacks multi-line text downward in world-Y. Glyph
         // upAxis is world-Y (see SymbolicTextPipeline), so subtracting
         // here puts line 1 below line 0 on screen for any side/oblique
@@ -944,6 +1022,7 @@ export function useSymbolicAnnotationsRichData(params: {
         });
       };
       const pushFill = (f: AnnotationFill2D, y: number) => {
+        if (isHidden && isHidden(f.ownerId)) return;
         fills.push({
           points: f.points,
           holesOffsets: f.holesOffsets,
@@ -993,5 +1072,5 @@ export function useSymbolicAnnotationsRichData(params: {
       texts: texts.length ? texts : EMPTY_TEXTS,
       fills: fills.length ? fills : EMPTY_FILLS,
     };
-  }, [enabled, effectiveGridEnabled, clipEnabled, clipPos, clipDepth, stores, version, fallbackY]);
+  }, [enabled, effectiveGridEnabled, clipEnabled, clipPos, clipDepth, stores, hiddenSets, version, fallbackY]);
 }

--- a/apps/viewer/src/store/basketVisibleSet.ts
+++ b/apps/viewer/src/store/basketVisibleSet.ts
@@ -15,6 +15,7 @@ import type { EntityRef } from './types.js';
 import { entityRefToString, stringToEntityRef } from './types.js';
 import { useViewerStore } from './index.js';
 import { toGlobalIdFromModels } from './globalId.js';
+import { isTypeVisible } from './typeVisibilityFilter.js';
 import { collectAggregatedDescendants, type AggregationRelationships } from '../utils/aggregation.js';
 
 type ViewerStateSnapshot = ReturnType<typeof useViewerStore.getState>;
@@ -81,9 +82,11 @@ function visibilityFingerprint(state: ViewerStateSnapshot): string {
     digestModelEntityMap(state.isolatedEntitiesByModel),
     digestNumberSet(state.selectedStoreys),
     tv.spaces ? 1 : 0,
+    tv.spatialZones ? 1 : 0,
     tv.openings ? 1 : 0,
     tv.virtualElements ? 1 : 0,
     tv.site ? 1 : 0,
+    tv.ifcAnnotations ? 1 : 0,
     state.models.size,
     modelParts.join(';'),
     state.geometryResult?.meshes?.length ?? 0,
@@ -108,15 +111,10 @@ function dedupeRefs(refs: EntityRef[]): EntityRef[] {
 }
 
 function matchesTypeVisibility(ifcType: string | undefined, typeVisibility: ViewerStateSnapshot['typeVisibility']): boolean {
-  if (ifcType === 'IfcSpace' && !typeVisibility.spaces) return false;
-  if (ifcType === 'IfcSpatialZone' && !typeVisibility.spatialZones) return false;
-  if (ifcType === 'IfcOpeningElement' && !typeVisibility.openings) return false;
-  if (ifcType === 'IfcVirtualElement' && !typeVisibility.virtualElements) return false;
-  if (ifcType === 'IfcSite' && !typeVisibility.site) return false;
-  // IfcAnnotation 3D mesh geometry (e.g. Bonsai plan-view boxes) tracks the
-  // same toggle that hides the 2D symbolic curve overlay (issue #1354).
-  if (ifcType === 'IfcAnnotation' && !typeVisibility.ifcAnnotations) return false;
-  return true;
+  // Shared mapping (`typeVisibilityFilter.ts`) so the basket's visible set,
+  // the viewport mesh filter and the GLB export never drift. `site` also hides
+  // `IfcGeographicElement` terrain (issue #1480).
+  return isTypeVisible(ifcType, typeVisibility);
 }
 
 function getDataStoreForModel(state: ViewerStateSnapshot, modelId: string): IfcDataStore | null {

--- a/apps/viewer/src/store/typeVisibilityFilter.test.ts
+++ b/apps/viewer/src/store/typeVisibilityFilter.test.ts
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Unit tests for the shared IFC-class → type-visibility mapping.
+ * Locks in issue #1480: the `site` toggle governs `IfcGeographicElement`
+ * terrain, not just `IfcSite`.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { isTypeVisible, buildHiddenIfcTypes } from './typeVisibilityFilter.js';
+
+const ALL_ON = {
+  spaces: true,
+  spatialZones: true,
+  openings: true,
+  virtualElements: true,
+  site: true,
+  ifcAnnotations: true,
+};
+
+describe('isTypeVisible', () => {
+  it('shows every mapped class when all toggles are on', () => {
+    for (const t of ['IfcSite', 'IfcGeographicElement', 'IfcSpace', 'IfcOpeningElement', 'IfcAnnotation']) {
+      assert.equal(isTypeVisible(t, ALL_ON), true, t);
+    }
+  });
+
+  it('hides IfcGeographicElement (terrain) when site is off (issue #1480)', () => {
+    const tv = { ...ALL_ON, site: false };
+    assert.equal(isTypeVisible('IfcGeographicElement', tv), false);
+    assert.equal(isTypeVisible('IfcSite', tv), false);
+  });
+
+  it('leaves unmapped classes (walls, slabs) always visible', () => {
+    const allOff = { spaces: false, spatialZones: false, openings: false, virtualElements: false, site: false, ifcAnnotations: false };
+    assert.equal(isTypeVisible('IfcWall', allOff), true);
+    assert.equal(isTypeVisible('IfcBuildingElementProxy', allOff), true);
+  });
+
+  it('treats an undefined ifcType as visible', () => {
+    assert.equal(isTypeVisible(undefined, { ...ALL_ON, site: false }), true);
+  });
+
+  it('gates each class on exactly its own toggle', () => {
+    assert.equal(isTypeVisible('IfcSpace', { ...ALL_ON, spaces: false }), false);
+    assert.equal(isTypeVisible('IfcSpace', { ...ALL_ON, site: false }), true);
+    assert.equal(isTypeVisible('IfcAnnotation', { ...ALL_ON, ifcAnnotations: false }), false);
+  });
+});
+
+describe('buildHiddenIfcTypes', () => {
+  it('is empty when nothing is toggled off', () => {
+    assert.equal(buildHiddenIfcTypes(ALL_ON).size, 0);
+  });
+
+  it('drops both IfcSite and IfcGeographicElement when site is off', () => {
+    const hidden = buildHiddenIfcTypes({ ...ALL_ON, site: false });
+    assert.ok(hidden.has('IfcSite'));
+    assert.ok(hidden.has('IfcGeographicElement'));
+    assert.equal(hidden.size, 2);
+  });
+
+  it('drops IfcAnnotation when annotations are off', () => {
+    const hidden = buildHiddenIfcTypes({ ...ALL_ON, ifcAnnotations: false });
+    assert.deepEqual([...hidden], ['IfcAnnotation']);
+  });
+});

--- a/apps/viewer/src/store/typeVisibilityFilter.ts
+++ b/apps/viewer/src/store/typeVisibilityFilter.ts
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Single source of truth for the IFC-class → `typeVisibility` toggle mapping.
+ *
+ * The same mapping was previously copy-pasted into three places
+ * (`ViewportContainer.tsx` mesh filter, `basketVisibleSet.ts` visible-set
+ * resolution, and `GLBExportDialog.tsx` export gating). Keeping it in one
+ * table means a new class → toggle association is added once and every
+ * consumer (viewport, Cesium, basket, export) stays in lockstep.
+ */
+
+import type { TypeVisibility } from './types.js';
+
+/** Which `typeVisibility` boolean gates each IFC class. */
+type TypeVisibilityKey = keyof Pick<
+  TypeVisibility,
+  'spaces' | 'spatialZones' | 'openings' | 'virtualElements' | 'site' | 'ifcAnnotations'
+>;
+
+/**
+ * IFC class → toggle key. When the mapped toggle is `false` the class is
+ * hidden from the viewport / export.
+ *
+ * `IfcGeographicElement` (terrain, `.TERRAIN.` etc.) rides the `site` toggle:
+ * the Site row is labelled "Terrain & context" and users reasonably expect
+ * modelled terrain to disappear with it (issue #1480). It renders as a normal
+ * product mesh, so — like `IfcSite` — it is otherwise unaffected by any
+ * type-visibility control.
+ */
+const IFC_TYPE_TO_VISIBILITY_KEY: Readonly<Record<string, TypeVisibilityKey>> = {
+  IfcSpace: 'spaces',
+  IfcSpatialZone: 'spatialZones',
+  IfcOpeningElement: 'openings',
+  IfcVirtualElement: 'virtualElements',
+  IfcSite: 'site',
+  IfcGeographicElement: 'site',
+  // IfcAnnotation can carry real 3D solid geometry (Bonsai plan-view boxes,
+  // Revit "Model Text" breps) on top of the 2D symbolic curve overlay; the
+  // `ifcAnnotations` toggle hides both (issues #1354, #1480).
+  IfcAnnotation: 'ifcAnnotations',
+};
+
+/**
+ * True when a mesh of `ifcType` should be visible under the current
+ * `typeVisibility` toggles. Classes with no mapped toggle are always visible.
+ */
+export function isTypeVisible(
+  ifcType: string | undefined,
+  typeVisibility: Pick<TypeVisibility, TypeVisibilityKey>,
+): boolean {
+  if (!ifcType) return true;
+  const key = IFC_TYPE_TO_VISIBILITY_KEY[ifcType];
+  if (key === undefined) return true;
+  return typeVisibility[key];
+}
+
+/**
+ * Build the set of IFC class names that are currently hidden by the toggles —
+ * used by the GLB exporter to drop them on a visible-only export so the file
+ * matches the viewport.
+ */
+export function buildHiddenIfcTypes(
+  typeVisibility: Pick<TypeVisibility, TypeVisibilityKey>,
+): Set<string> {
+  const out = new Set<string>();
+  for (const [ifcType, key] of Object.entries(IFC_TYPE_TO_VISIBILITY_KEY)) {
+    if (!typeVisibility[key]) out.add(ifcType);
+  }
+  return out;
+}

--- a/packages/renderer/src/section-2d-overlay.ts
+++ b/packages/renderer/src/section-2d-overlay.ts
@@ -69,6 +69,13 @@ export interface DrawingLine2D {
     end: { x: number; y: number };
   };
   category: string;
+  /**
+   * Express ID of the entity that authored this segment. Optional — only the
+   * IfcAnnotation / IfcGridAxis symbolic overlay sets it (so per-entity hide
+   * can drop an annotation's curves without a mesh). The section-cut and
+   * drawing-2d cutters leave it undefined.
+   */
+  ownerId?: number;
 }
 
 // Fill colors by IFC type (architectural convention).


### PR DESCRIPTION
Fixes #1480.

Three visibility gaps, all reproduced in the viewer with the reporter's model and re-verified after the fix.

## 1. Site visibility didn't include terrain (`IfcGeographicElement`)
The Site row is labelled **"Terrain & context"**, but the filter hid only `IfcSite`. Terrain modelled as `IfcGeographicElement` renders as a normal product mesh, so it stayed on screen no matter the toggle.

The IFC-class → `typeVisibility` mapping was copy-pasted in three places (`ViewportContainer` mesh filter, `basketVisibleSet`, `GLBExportDialog`). Consolidated into one `store/typeVisibilityFilter.ts` and mapped `IfcGeographicElement` onto `site`. Viewport, Cesium, basket and GLB export now share one table.

## 2. Hiding an annotation left its lines drawn
`IfcAnnotation` curves (plot boundaries, "Model Lines") render through the symbolic overlay, which only honoured the global **Annotations** toggle. Hiding an annotation via the panel removed its brep text but left the curves. Now every overlay primitive carries its owner express id, and the overlay drops primitives whose owner is hidden (hierarchy hide, lens, per-model hide).

Isolation / storey-solo are intentionally **not** applied to the overlay: annotation buckets lift to every storey by design, and `byStorey` omits annotations, so honouring storey isolation there would wrongly blank them.

## 3. Curve-only annotations were missing from "By Class"
They have no mesh, so they never entered the tree's geometry set — only the brep-text annotation showed. `IfcAnnotation` entities are now folded into the By-Class inclusion set, so each is an ordinary selectable / hideable row. Hiding the class hides the curves via (2).

Also fixed the basket visibility fingerprint, which omitted `spatialZones` / `ifcAnnotations`, leaving its cache stale when those toggled.

## Verification
Browser-driven against the reporter's model (WebGPU):
- Site off → terrain surfaces disappear; other geometry stays.
- By Class → `IfcAnnotation` count went 1 → the full set (text + curve annotations).
- Hiding the annotations removed the boundary/model-line overlay while the grid stayed; un-hiding restored them.

## Tests
- `store/typeVisibilityFilter.test.ts` — mapping incl. `IfcGeographicElement` under `site`.
- `hooks/useSymbolicAnnotations.test.ts` — owner tagging + hidden-owner lift filter.
- Existing `basketVisibleSet` / `treeDataBuilder` suites stay green; viewer `tsc` clean.

Changeset: `@ifc-lite/renderer` patch (adds optional `DrawingLine2D.ownerId`).